### PR TITLE
ExportGenotypes no longer prints ref or missing calls by default (add…

### DIFF
--- a/docs/ExportTSV.md
+++ b/docs/ExportTSV.md
@@ -19,12 +19,16 @@ Command line arguments:
 2. `exportvariants` will print one line per variant in the VDS.  The accessible namespace includes:
    - `v` (variant)
    - `va` (variant annotations)
-3. `exportgenotypes` will print one line per unique (variant, sample) in the VDS.   **WARNING: This is an operation with an output length of M x N.  Use it wisely if you value your gigabytes.** The accessible namespace includes:
+3. `exportgenotypes` will print one line per unique (variant, sample) in the VDS<sup>*<sup>.  The accessible namespace includes:
    - `g` (genotype)
    - `s` (sample)
    - `sa` (sample annotations)
    - `v` (variant)
    - `va` (variant annotations). 
+   
+<sup>*<sup>The `exportgenotypes` module does not print hom-ref or missing genotypes by default, in order to restrict the size of the file produced.  There are command line arguments to turn on these print modes:
+ - `--print-ref`
+ - `--print-missing`
    
 ## Designating output with .columns files
 

--- a/docs/QC.md
+++ b/docs/QC.md
@@ -8,9 +8,8 @@ These modules compute a variety of statistics from the genotype data, collapsing
   
 Command line arguments:
  - `-o` -- writes computed statistics to the following path as a TSV file
- - `--store, -s` -- stores all computed statistics within hail in `annotations` objects, to be used with downstream [filter](Filtering.md) and [export](Exporting.md) modules.
  
-The sets of statistics, their types, and brief descriptions of how they are calculated are listed below.
+If no output file is specified, all computed statistics will be stored within hail in `annotations` objects, to be used with downstream [filter](Filtering.md) and [export](Exporting.md) modules.  These can be accessed with `va.qc.<identifier>` and `sa.qc.<identifier>` for variant and sample qc, respectively.  The statistics, their types, and brief descriptions of how they are calculated are listed below.
 
 **Note:** All standard deviations are calculated with zero degrees of freedom.
 

--- a/src/main/scala/org/broadinstitute/hail/driver/SampleQC.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/SampleQC.scala
@@ -319,12 +319,7 @@ object SampleQC extends Command {
 
     @Args4jOption(required = false, name = "-o", aliases = Array("--output"),
       usage = "Output file", forbids = Array("store"))
-    var output: String = ""
-
-    @Args4jOption(required = false, name = "-s", aliases = Array("--store"),
-      usage = "Store qc output in vds annotations", forbids = Array("output"))
-    var store: Boolean = false
-
+    var output: String = _
   }
 
   def newOptions = new Options
@@ -367,7 +362,7 @@ object SampleQC extends Command {
     val sampleIdsBc = state.sc.broadcast(vds.sampleIds)
 
     val r = results(vds)
-    if (options.store) {
+    if (output == null) {
       val rMap = r
         .mapValues(_.asMap)
         .collectAsMap()

--- a/src/main/scala/org/broadinstitute/hail/driver/VariantQC.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/VariantQC.scala
@@ -281,11 +281,7 @@ object VariantQC extends Command {
   class Options extends BaseOptions {
     @Args4jOption(required = false, name = "-o", aliases = Array("--output"),
       usage = "Output file", forbids = Array("store"))
-    var output: String = ""
-
-    @Args4jOption(required = false, name = "-s", aliases = Array("--store"),
-      usage = "Store qc output in vds annotations", forbids = Array("output"))
-    var store: Boolean = false
+    var output: String = _
   }
 
   def newOptions = new Options
@@ -305,7 +301,7 @@ object VariantQC extends Command {
 
     val output = options.output
 
-    if (options.store) {
+    if (output == null) {
       val r = results(vds)
         .persist(StorageLevel.MEMORY_AND_DISK)
 

--- a/src/test/scala/org/broadinstitute/hail/PipelineSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/PipelineSuite.scala
@@ -11,7 +11,7 @@ class PipelineSuite extends SparkSuite {
     s = Write.run(s, Array("-o", "/tmp/sample.vds"))
     s = Read.run(s, Array("-i", "/tmp/sample.vds"))
     s = SampleQC.run(s, Array("-o", "/tmp/sampleqc.tsv"))
-    s = VariantQC.run(s, Array("-s"))
+    s = VariantQC.run(s, Array.empty[String])
     s = GQByDP.run(s, Array("-o", "/tmp/gqbydp.tsv"))
     s = MendelErrorsCommand.run(s, Array("-f", "src/test/resources/sample.fam",
       "-o", "/tmp/mendel"))

--- a/src/test/scala/org/broadinstitute/hail/methods/ExportSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/ExportSuite.scala
@@ -14,7 +14,7 @@ class ExportSuite extends SparkSuite {
     state = SplitMulti.run(state, Array.empty[String])
 
     SampleQC.run(state, Array("-o", "/tmp/sampleQC.tsv"))
-    val postSampleQC = SampleQC.run(state, Array("--store"))
+    val postSampleQC = SampleQC.run(state, Array.empty[String])
 
     val sb = new StringBuilder()
     sb.tsvAppend(Array(1, 2, 3, 4, 5))
@@ -45,7 +45,7 @@ class ExportSuite extends SparkSuite {
     assert(sQcOutput == sExportOutput)
 
     VariantQC.run(state, Array("-o", "/tmp/variantQC.tsv"))
-    val postVariantQC = VariantQC.run(state, Array("--store"))
+    val postVariantQC = VariantQC.run(state, Array.empty[String])
 
     ExportVariants.run(postVariantQC, Array("-o", "/tmp/exportVariants.tsv", "-c",
       "Chrom=v.contig,Pos=v.start,Ref=v.ref,Alt=v.alt,callRate=va.qc.callRate,MAC=va.qc.MAC,MAF=va.qc.MAF," +

--- a/src/test/scala/org/broadinstitute/hail/methods/FilterSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/FilterSuite.scala
@@ -68,7 +68,7 @@ class FilterSuite extends SparkSuite {
     assert(FilterVariants.run(state, Array("--remove", "-c", """va.rsid == ".""""))
       .vds.nVariants == 258)
 
-    val stateWithSampleQC = SampleQC.run(state, Array("--store"))
+    val stateWithSampleQC = SampleQC.run(state, Array.empty[String])
 
     assert(FilterSamples.run(stateWithSampleQC, Array("--keep", "-c", "sa.qc.nCalled == 337"))
       .vds.nLocalSamples == 17)
@@ -79,7 +79,7 @@ class FilterSuite extends SparkSuite {
     assert(FilterSamples.run(stateWithSampleQC, Array("--keep", "-c", "if (\"^C1048\" ~ s.id) {sa.qc.rTiTv > 3.5 && sa.qc.nSingleton < 10000000} else sa.qc.rTiTv > 3"))
       .vds.nLocalSamples == 14)
 
-    val stateWithVariantQC = VariantQC.run(state, Array("--store"))
+    val stateWithVariantQC = VariantQC.run(state, Array.empty[String])
 
     assert(FilterVariants.run(stateWithVariantQC, Array("--keep", "-c", "va.qc.nCalled < 100"))
       .vds.nVariants == 36)

--- a/src/test/scala/org/broadinstitute/hail/methods/SampleQCSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/SampleQCSuite.scala
@@ -17,8 +17,8 @@ class SampleQCSuite extends SparkSuite {
     s = SplitMulti.run(s, Array.empty[String])
 
     // Get QC metrics
-    s = SampleQC.run(s, Array("-s"))
+    s = SampleQC.run(s, Array.empty[String])
     s = FilterSamples.run(s, Array("--remove", "-c","""s.id ~ "C1046::HG02024""""))
-    s = SampleQC.run(s, Array("-s"))
+    s = SampleQC.run(s, Array.empty[String])
   }
 }


### PR DESCRIPTION
…ed command line arguments to turn that functionality on)

Sample and Variant QC modules no longer require the --store option: if no file (-o) is specified, they will store by default.
