### PR TITLE
Annotation rework review 1.  (Actually 2?)

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/Utils.scala
+++ b/src/main/scala/org/broadinstitute/hail/Utils.scala
@@ -15,8 +15,8 @@ import org.broadinstitute.hail.io.hadoop.{BytesOnlyWritable, ByteArrayOutputForm
 import org.broadinstitute.hail.check.Gen
 import org.broadinstitute.hail.io.compress.BGzipCodec
 import org.broadinstitute.hail.driver.HailConfiguration
+import org.broadinstitute.hail.utils.RichRow
 import org.broadinstitute.hail.variant.Variant
-import scala.collection.mutable.ListBuffer
 import scala.collection.{TraversableOnce, mutable}
 import scala.language.implicitConversions
 import breeze.linalg.{Vector => BVector, DenseVector => BDenseVector, SparseVector => BSparseVector}
@@ -926,4 +926,6 @@ object Utils extends Logging {
     def zero(initialValue: mutable.Map[K, Int]): mutable.Map[K, Int] =
       mutable.Map.empty[K, Int]
   }
+
+  implicit def toRichRow(r: Row): RichRow = new RichRow(r)
 }

--- a/src/main/scala/org/broadinstitute/hail/annotations/Signature.scala
+++ b/src/main/scala/org/broadinstitute/hail/annotations/Signature.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.hail.annotations
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 import org.broadinstitute.hail.expr
-import RichRow._
+import org.broadinstitute.hail.Utils._
 
 abstract class Signature {
   def dType: expr.Type
@@ -28,6 +28,8 @@ abstract class Signature {
       None
   }
 
+  def delete(fields: String*): (Signature, Deleter) = delete(fields.toList)
+
   def delete(path: List[String]): (Signature, Deleter) = {
     if (path.nonEmpty) {
       (this, a => a)
@@ -36,11 +38,12 @@ abstract class Signature {
       (null, null)
   }
 
-  def insert(path: List[String], signature: Signature): (Signature, Inserter) = {
+  def insert(signature: Signature, fields: String*): (Signature, Inserter) = insert(signature, fields.toList)
+
+  def insert(signature: Signature, path: List[String]): (Signature, Inserter) = {
     if (path.nonEmpty) {
-      StructSignature(Map.empty[String, (Int, Signature)]).insert(path, signature)
-    }
-    else
+      StructSignature(Map.empty).insert(signature, path)
+    } else
       (this, (a, toIns) => toIns.getOrElse(null))
   }
 
@@ -148,7 +151,7 @@ case class StructSignature(m: Map[String, (Int, Signature)]) extends Signature {
     }
   }
 
-  override def insert(p: List[String], signature: Signature): (Signature, Inserter) = {
+  override def insert(signature: Signature, p: List[String]): (Signature, Inserter) = {
     if (p.isEmpty)
       (signature, (a, toIns) => toIns.getOrElse(null))
     else if (p.length == 1) {
@@ -174,12 +177,11 @@ case class StructSignature(m: Map[String, (Int, Signature)]) extends Signature {
           val newStruct = StructSignature(m + ((key, (m.size, signature))))
           (newStruct, f)
       }
-    }
-    else {
+    } else {
       val key = p.head
       m.get(key) match {
         case Some((i, s)) =>
-          val (sig, ins) = s.insert(p.tail, signature)
+          val (sig, ins) = s.insert(signature, p.tail)
           val f: Inserter = (a, toIns) =>
             if (a == null)
               Row.fromSeq(Array.fill[Any](m.size)(null))
@@ -194,16 +196,16 @@ case class StructSignature(m: Map[String, (Int, Signature)]) extends Signature {
           val (sig, ins) = {
             if (p.length > 1)
               StructSignature(Map.empty[String, (Int, Signature)])
-                .insert(p.tail, signature)
+                .insert(signature, p.tail)
             else
-              signature.insert(p.tail, signature)
+              signature.insert(signature, p.tail)
           }
-          val f: Inserter = (a, toIns) => if (a == null) {
-            Row.fromSeq(Array.fill[Any](m.size)(null))
-              .append(ins(null, toIns))
-          }
-          else
-            a.asInstanceOf[Row].append(ins(null, toIns))
+          val f: Inserter = (a, toIns) =>
+            if (a == null) {
+              Row.fromSeq(Array.fill[Any](m.size)(null))
+                .append(ins(null, toIns))
+            } else
+              a.asInstanceOf[Row].append(ins(null, toIns))
           (StructSignature(m + ((key, (m.size, sig)))), f)
       }
     }
@@ -218,7 +220,7 @@ case class StructSignature(m: Map[String, (Int, Signature)]) extends Signature {
         }
         .map {
           case (key, (index, sig)) =>
-            StructField(key, sig.getSchema, true)
+            StructField(key, sig.getSchema, nullable = true)
         }
       )
     assert(s.length > 0)
@@ -234,8 +236,8 @@ case class StructSignature(m: Map[String, (Int, Signature)]) extends Signature {
         }
         .map {
           case (k, (i, v)) => v.printSchema(s"""$k""", nSpace + 2, path + "." + k)
-//          keep for future debugging:
-//          case (k, (i, v)) => v.printSchema(s"""[$i] $k""", nSpace + 2, path + "." + k)
+          //          keep for future debugging:
+          //          case (k, (i, v)) => v.printSchema(s"""[$i] $k""", nSpace + 2, path + "." + k)
         }
         .mkString("\n")
   }

--- a/src/main/scala/org/broadinstitute/hail/driver/Command.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/Command.scala
@@ -62,7 +62,7 @@ abstract class Command {
   def runCommand(state: State, options: Options): State = {
     if (!supportsMultiallelic
       && state.vds != null
-      && !state.vds.metadata.wasSplit)
+      && !state.vds.wasSplit)
       fatal(s"`$name' does not support multiallelics.\n  Run `splitmulti' first.")
 
     run(state, options)

--- a/src/main/scala/org/broadinstitute/hail/driver/ExportGenotypes.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/ExportGenotypes.scala
@@ -38,14 +38,14 @@ object ExportGenotypes extends Command {
     val sc = vds.sparkContext
     val cond = options.condition
     val output = options.output
-    val vas = vds.vaSignatures
-    val sas = vds.saSignatures
+    val vas = vds.vaSignature
+    val sas = vds.saSignature
 
     val symTab = Map(
       "v" ->(0, expr.TVariant),
-      "va" ->(1, vds.vaSignatures.dType),
+      "va" ->(1, vas.dType),
       "s" ->(2, expr.TSample),
-      "sa" ->(3, vds.saSignatures.dType),
+      "sa" ->(3, sas.dType),
       "g" ->(4, expr.TGenotype))
     val a = new Array[Any](5)
 

--- a/src/main/scala/org/broadinstitute/hail/driver/ExportSamples.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/ExportSamples.scala
@@ -29,13 +29,13 @@ object ExportSamples extends Command {
   def run(state: State, options: Options): State = {
     val vds = state.vds
     val hConf = vds.sparkContext.hadoopConfiguration
-    val sas = vds.saSignatures
+    val sas = vds.saSignature
     val cond = options.condition
     val output = options.output
 
     val symTab = Map(
       "s" ->(0, expr.TSample),
-      "sa" ->(1, vds.saSignatures.dType))
+      "sa" ->(1, sas.dType))
     val a = new Array[Any](2)
 
     val (header, fs) = if (cond.endsWith(".columns"))

--- a/src/main/scala/org/broadinstitute/hail/driver/ExportVariants.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/ExportVariants.scala
@@ -31,13 +31,13 @@ object ExportVariants extends Command {
 
   def run(state: State, options: Options): State = {
     val vds = state.vds
-    val vas = vds.metadata.vaSignatures
+    val vas = vds.vaSignature
     val cond = options.condition
     val output = options.output
 
     val symTab = Map(
       "v" ->(0, TVariant),
-      "va" ->(1, vds.metadata.vaSignatures.dType))
+      "va" ->(1, vas.dType))
     val a = new Array[Any](2)
 
     val (header, fs) = if (cond.endsWith(".columns"))

--- a/src/main/scala/org/broadinstitute/hail/driver/FilterGenotypes.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/FilterGenotypes.scala
@@ -30,6 +30,8 @@ object FilterGenotypes extends Command {
   def run(state: State, options: Options): State = {
     val sc = state.sc
     val vds = state.vds
+    val vas = vds.vaSignature
+    val sas = vds.saSignature
 
     if (!options.keep && !options.remove)
       fatal(name + ": one of `--keep' or `--remove' required")
@@ -38,9 +40,9 @@ object FilterGenotypes extends Command {
 
     val symTab = Map(
       "v" ->(0, expr.TVariant),
-      "va" ->(1, vds.vaSignatures.dType),
+      "va" ->(1, vas.dType),
       "s" ->(2, expr.TSample),
-      "sa" ->(3, vds.saSignatures.dType),
+      "sa" ->(3, sas.dType),
       "g" ->(4, expr.TGenotype))
     val a = new Array[Any](5)
 

--- a/src/main/scala/org/broadinstitute/hail/driver/FilterSamples.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/FilterSamples.scala
@@ -35,11 +35,11 @@ object FilterSamples extends Command {
     if (!options.keep && !options.remove)
       fatal(name + ": one of `--keep' or `--remove' required")
 
-    val indexOfSample: Map[String, Int] = vds.sampleIds.zipWithIndex.toMap
-
     val keep = options.keep
+    val sas = vds.saSignature
     val p = options.condition match {
       case f if f.endsWith(".sample_list") =>
+        val indexOfSample: Map[String, Int] = vds.sampleIds.zipWithIndex.toMap
         val samples = Source.fromInputStream(hadoopOpen(f, state.hadoopConf))
           .getLines()
           .filter(line => !line.isEmpty)
@@ -49,7 +49,7 @@ object FilterSamples extends Command {
       case c: String =>
         val symTab = Map(
           "s" -> (0, expr.TSample),
-          "sa" -> (1, vds.saSignatures.dType))
+          "sa" -> (1, sas.dType))
         val a = new Array[Any](2)
         val f: () => Any = expr.Parser.parse(symTab, a, c)
         val sampleIdsBc = state.sc.broadcast(state.vds.sampleIds)

--- a/src/main/scala/org/broadinstitute/hail/driver/FilterVariants.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/FilterVariants.scala
@@ -34,8 +34,8 @@ object FilterVariants extends Command {
     if (!options.keep && !options.remove)
       fatal(name + ": one of `--keep' or `--remove' required")
 
+    val vas = vds.vaSignature
     val cond = options.condition
-    val vas = vds.metadata.vaSignatures
     val keep = options.keep
     val p: (Variant, Annotation) => Boolean = cond match {
       case f if f.endsWith(".interval_list") =>
@@ -45,8 +45,7 @@ object FilterVariants extends Command {
       case c: String =>
         val symTab = Map(
           "v" -> (0, TVariant),
-          "va" -> (1, vds.metadata.vaSignatures.dType
-            ))
+          "va" -> (1, vas.dType))
         val a = new Array[Any](2)
         val f: () => Any = expr.Parser.parse[Any](symTab, a, options.condition)
         (v: Variant, va: Annotation) => {

--- a/src/main/scala/org/broadinstitute/hail/driver/RenameSamples.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/RenameSamples.scala
@@ -35,7 +35,7 @@ object RenameSamples extends Command {
 
     val vds = state.vds
     val newSamples = mutable.Set.empty[String]
-    val newSampleIds = vds.metadata.sampleIds
+    val newSampleIds = vds.sampleIds
       .map { case s =>
         val news = m.getOrElse(s, s)
         if (newSamples.contains(news))

--- a/src/main/scala/org/broadinstitute/hail/driver/ShowAnnotations.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/ShowAnnotations.scala
@@ -30,10 +30,10 @@ object ShowAnnotations extends Command {
     val sb = new StringBuilder()
     sb.append("Sample annotations:")
     sb.append("\n")
-    sb.append(vds.saSchema)
+    sb.append(vds.saSignature.printSchema("sa", 2, "sa"))
     sb.append("\n")
     sb.append("Variant annotations:")
-    sb.append(vds.vaSchema)
+    sb.append(vds.vaSignature.printSchema("va", 2, "va"))
     val result = sb.result()
 
     options.output match {

--- a/src/main/scala/org/broadinstitute/hail/utils/RichRow.scala
+++ b/src/main/scala/org/broadinstitute/hail/utils/RichRow.scala
@@ -1,14 +1,9 @@
-package org.broadinstitute.hail.annotations
+package org.broadinstitute.hail.utils
 
 import org.apache.spark.sql.Row
-
+import org.broadinstitute.hail.variant.{GenotypeStream, Variant}
 import scala.collection.mutable
 import scala.language.implicitConversions
-
-
-object RichRow {
-  implicit def fromRow(r: Row): RichRow = new RichRow(r)
-}
 
 class RichRow(r: Row) {
 
@@ -29,7 +24,7 @@ class RichRow(r: Row) {
     Option(r.get(i))
   }
 
-  def getOptionAs[T](i: Int): Option[T] = {
+  def getAsOption[T](i: Int): Option[T] = {
     if (r.isNullAt(i))
       None
     else
@@ -57,4 +52,7 @@ class RichRow(r: Row) {
     (i until r.size).foreach(ab += r.get(_))
     Row.fromSeq(ab.result())
   }
+
+  def getVariant(i: Int) = Variant.fromRow(r.getAs[Row](i))
+  def getGenotypeStream(v: Variant, i: Int) = GenotypeStream.fromRow(v, r.getAs[Row](i))
 }

--- a/src/main/scala/org/broadinstitute/hail/variant/VariantMetadata.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/VariantMetadata.scala
@@ -23,8 +23,8 @@ object VariantMetadata {
 case class VariantMetadata(filters: IndexedSeq[(String, String)],
   sampleIds: IndexedSeq[String],
   sampleAnnotations: IndexedSeq[Annotation],
-  saSignatures: Signature,
-  vaSignatures: Signature,
+  saSignature: Signature,
+  vaSignature: Signature,
   wasSplit: Boolean = false) {
 
   def nSamples: Int = sampleIds.length

--- a/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.hail.variant
 
 import java.nio.ByteBuffer
-import org.apache.spark.sql.catalyst.ScalaReflection.Schema
 import org.apache.spark.{SparkEnv, SparkContext}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Row, SQLContext}
@@ -10,8 +9,7 @@ import org.broadinstitute.hail.check.Gen
 import scala.language.implicitConversions
 import org.broadinstitute.hail.annotations._
 import scala.reflect.ClassTag
-import org.apache.spark.sql.types.{NullType, StructType, StructField, StringType}
-
+import org.apache.spark.sql.types.{StructType, StructField}
 
 object VariantSampleMatrix {
   def apply[T](metadata: VariantMetadata,
@@ -36,7 +34,8 @@ object VariantSampleMatrix {
     new VariantSampleMatrix[Genotype](metadata,
       localSamples,
       df.rdd.map(row => {
-        (Variant.fromRow(row.getAs[Row](0)), row.get(1), GenotypeStream.fromRow(row.getAs[Row](2)))
+        val v = row.getVariant(0)
+        (v, row.get(1), row.getGenotypeStream(v, 2))
       }))
   }
 
@@ -48,12 +47,12 @@ object VariantSampleMatrix {
 
   def genVariantValues[T](nSamples: Int, g: (Variant) => Gen[T]): Gen[(Variant, Iterable[T])] =
     for (v <- Variant.gen;
-         values <- genValues[T](nSamples, g(v)))
+      values <- genValues[T](nSamples, g(v)))
       yield (v, values)
 
   def genVariantValues[T](g: (Variant) => Gen[T]): Gen[(Variant, Iterable[T])] =
     for (v <- Variant.gen;
-         values <- genValues[T](g(v)))
+      values <- genValues[T](g(v)))
       yield (v, values)
 
   def genVariantGenotypes: Gen[(Variant, Iterable[Genotype])] =
@@ -78,7 +77,7 @@ object VariantSampleMatrix {
   def gen[T](sc: SparkContext, g: (Variant) => Gen[T])(implicit tct: ClassTag[T]): Gen[VariantSampleMatrix[T]] = {
     val samplesVariantsGen =
       for (sampleIds <- Gen.distinctBuildableOf[Array[String], String](Gen.identifier);
-           variants <- Gen.distinctBuildableOf[Array[Variant], Variant](Variant.gen))
+        variants <- Gen.distinctBuildableOf[Array[Variant], Variant](Variant.gen))
         yield (sampleIds, variants)
     samplesVariantsGen.flatMap { case (sampleIds, variants) => gen(sc, sampleIds, variants, g) }
   }
@@ -109,23 +108,27 @@ class VariantSampleMatrix[T](val metadata: VariantMetadata,
 
   def nLocalSamples: Int = localSamples.length
 
-  def vaSignatures: Signature = metadata.vaSignatures
+  def vaSignature: Signature = metadata.vaSignature
 
-  def saSignatures: Signature = metadata.saSignatures
+  def saSignature: Signature = metadata.saSignature
 
   def sampleAnnotations: IndexedSeq[Annotation] = metadata.sampleAnnotations
 
+  def wasSplit: Boolean = metadata.wasSplit
+
+  def filters: IndexedSeq[(String, String)] = metadata.filters
+
   def copy[U](localSamples: Array[Int] = localSamples,
     rdd: RDD[(Variant, Annotation, Iterable[U])] = rdd,
-    filters: IndexedSeq[(String, String)] = metadata.filters,
-    sampleIds: IndexedSeq[String] = metadata.sampleIds,
-    sampleAnnotations: IndexedSeq[Annotation] = metadata.sampleAnnotations,
-    saSignatures: Signature = metadata.saSignatures,
-    vaSignatures: Signature = metadata.vaSignatures,
-    wasSplit: Boolean = metadata.wasSplit)
+    filters: IndexedSeq[(String, String)] = filters,
+    sampleIds: IndexedSeq[String] = sampleIds,
+    sampleAnnotations: IndexedSeq[Annotation] = sampleAnnotations,
+    saSignature: Signature = saSignature,
+    vaSignature: Signature = vaSignature,
+    wasSplit: Boolean = wasSplit)
     (implicit tct: ClassTag[U]): VariantSampleMatrix[U] =
     new VariantSampleMatrix[U](
-      VariantMetadata(filters, sampleIds, sampleAnnotations, saSignatures, vaSignatures, wasSplit), localSamples, rdd)
+      VariantMetadata(filters, sampleIds, sampleAnnotations, saSignature, vaSignature, wasSplit), localSamples, rdd)
 
   def sparkContext: SparkContext = rdd.sparkContext
 
@@ -234,7 +237,7 @@ class VariantSampleMatrix[T](val metadata: VariantMetadata,
 
   // FIXME see if we can remove broadcasts elsewhere in the code
   def filterSamples(p: (Int, Annotation) => Boolean): VariantSampleMatrix[T] = {
-    val mask = localSamples.map((s) => p(s, metadata.sampleAnnotations(s)))
+    val mask = localSamples.map((s) => p(s, sampleAnnotations(s)))
     val maskBc = sparkContext.broadcast(mask)
     val localtct = tct
     copy[T](localSamples = localSamples.zipWithIndex
@@ -394,7 +397,7 @@ class VariantSampleMatrix[T](val metadata: VariantMetadata,
 
   def queryVA(path: List[String]): Querier = {
     try {
-      vaSignatures.query(path)
+      vaSignature.query(path)
     } catch {
       case e: AnnotationPathException => fatal(s"Invalid variant annotations query: ${path.::("va").mkString(".")}")
     }
@@ -404,7 +407,7 @@ class VariantSampleMatrix[T](val metadata: VariantMetadata,
 
   def querySA(path: List[String]): Querier = {
     try {
-      saSignatures.query(path)
+      saSignature.query(path)
     } catch {
       case e: AnnotationPathException => fatal(s"Invalid sample annotations query: ${path.::("sa").mkString(".")}")
     }
@@ -413,7 +416,7 @@ class VariantSampleMatrix[T](val metadata: VariantMetadata,
   def deleteVA(args: String*): (Signature, Deleter) = deleteVA(args.toList)
 
   def deleteVA(path: List[String]): (Signature, Deleter) = {
-    vaSignatures.delete(path) match {
+    vaSignature.delete(path) match {
       case (null, null) => (EmptySignature(), a => null)
       case x => x
     }
@@ -422,7 +425,7 @@ class VariantSampleMatrix[T](val metadata: VariantMetadata,
   def deleteSA(args: String*): (Signature, Deleter) = deleteSA(args.toList)
 
   def deleteSA(path: List[String]): (Signature, Deleter) = {
-    saSignatures.delete(path) match {
+    saSignature.delete(path) match {
       case (null, null) => (EmptySignature(), a => null)
       case x => x
     }
@@ -431,27 +434,13 @@ class VariantSampleMatrix[T](val metadata: VariantMetadata,
   def insertVA(sig: Signature, args: String*): (Signature, Inserter) = insertVA(sig, args.toList)
 
   def insertVA(sig: Signature, path: List[String]): (Signature, Inserter) = {
-    vaSignatures.insert(path, sig)
+    vaSignature.insert(sig, path)
   }
 
   def insertSA(sig: Signature, args: String*): (Signature, Inserter) = insertSA(sig, args.toList)
 
   def insertSA(sig: Signature, path: List[String]): (Signature, Inserter) = {
-    saSignatures.insert(path, sig)
-  }
-
-  def vaSchema: String = {
-    metadata.vaSignatures match {
-      case null => "va: empty schema"
-      case s => s.printSchema("va", 2, "va")
-    }
-  }
-
-  def saSchema: String = {
-    metadata.saSignatures match {
-      case null => "sa: empty schema"
-      case s => s.printSchema("sa", 2, "sa")
-    }
+    saSignature.insert(sig, path)
   }
 }
 
@@ -459,12 +448,12 @@ class VariantSampleMatrix[T](val metadata: VariantMetadata,
 class RichVDS(vds: VariantDataset) {
 
   def makeSchema(): StructType = {
-    val vaStruct = vds.metadata.vaSignatures.getSchema
+    val vaStruct = vds.vaSignature.getSchema
 
     val s = StructType(Array(
-      StructField("variant", Variant.schema(), false),
-      StructField("annotations", vds.metadata.vaSignatures.getSchema, false),
-      StructField("gs", GenotypeStream.schema(), false)
+      StructField("variant", Variant.schema(), nullable = false),
+      StructField("annotations", vds.vaSignature.getSchema, nullable = false),
+      StructField("gs", GenotypeStream.schema(), nullable = false)
     ))
     s
   }
@@ -484,7 +473,7 @@ class RichVDS(vds: VariantDataset) {
     val rowRDD = vds.rdd
       .map {
         case (v, va, gs) =>
-          Row.fromSeq(Array(Variant.toRow(v), va.asInstanceOf[Row], GenotypeStream.toRow(gs.toGenotypeStream(v, compress))))
+          Row.fromSeq(Array(v.toRow, va.asInstanceOf[Row], gs.toGenotypeStream(v, compress).toRow))
       }
     sqlContext.createDataFrame(rowRDD, makeSchema())
       .write.parquet(dirname + "/rdd.parquet")
@@ -493,10 +482,10 @@ class RichVDS(vds: VariantDataset) {
 
   def eraseSplit: VariantDataset = {
     val (newSignatures1, f1) = vds.deleteVA("wasSplit")
-    val vds1 = vds.copy(vaSignatures = newSignatures1)
+    val vds1 = vds.copy(vaSignature = newSignatures1)
     val (newSignatures2, f2) = vds1.deleteVA("aIndex")
     vds1.copy(wasSplit = false,
-      vaSignatures = newSignatures2,
+      vaSignature = newSignatures2,
       rdd = vds1.rdd.map {
         case (v, va, gs) =>
           (v, f2(f1(va)), gs.lazyMap(g => g.copy(fakeRef = false)))

--- a/src/test/scala/org/broadinstitute/hail/methods/ImportVCFSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/ImportVCFSuite.scala
@@ -63,10 +63,10 @@ class ImportVCFSuite extends SparkSuite {
     var s = State(sc, sqlContext)
     s = ImportVCF.run(s, Array("src/test/resources/undeclaredinfo.vcf"))
 
-    assert(s.vds.metadata.vaSignatures.getOption(List("info")).isDefined)
-    assert(s.vds.metadata.vaSignatures.getOption(List("info", "undeclared")).isEmpty)
-    assert(s.vds.metadata.vaSignatures.getOption(List("info", "undeclaredFlag")).isEmpty)
-    val infoQuerier = s.vds.metadata.vaSignatures.query(List("info"))
+    assert(s.vds.vaSignature.getOption(List("info")).isDefined)
+    assert(s.vds.vaSignature.getOption(List("info", "undeclared")).isEmpty)
+    assert(s.vds.vaSignature.getOption(List("info", "undeclaredFlag")).isEmpty)
+    val infoQuerier = s.vds.vaSignature.query(List("info"))
 
     val anno = s.vds
       .rdd

--- a/src/test/scala/org/broadinstitute/hail/vcf/SplitSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/vcf/SplitSuite.scala
@@ -17,7 +17,7 @@ class SplitSuite extends SparkSuite {
       forAll(VariantSampleMatrix.gen[Genotype](sc, Genotype.gen _)) { (vds: VariantDataset) =>
         var s = State(sc, sqlContext, vds)
         s = SplitMulti.run(s, Array[String]())
-        val wasSplitQuerier = s.vds.metadata.vaSignatures.query(List("wasSplit"))
+        val wasSplitQuerier = s.vds.vaSignature.query(List("wasSplit"))
         s.vds.mapWithAll((v: Variant, va: Annotation, _: Int, g: Genotype) =>
           !g.fakeRef || wasSplitQuerier(va).asInstanceOf[Option[Boolean]].get)
           .collect()
@@ -49,7 +49,7 @@ class SplitSuite extends SparkSuite {
       .join(vds2.mapWithKeys((v, s, g) => ((v, s), g)))
       .foreach { case (k, (g1, g2)) => simpleAssert(g1 == g2) }
 
-    val wasSplitQuerier = vds1.metadata.vaSignatures.query(List("wasSplit"))
+    val wasSplitQuerier = vds1.vaSignature.query(List("wasSplit"))
 
     // test for wasSplit
     vds1.mapWithAll((v, va, s, g) => (v.start, wasSplitQuerier(va).asInstanceOf[Option[Boolean]].get))


### PR DESCRIPTION
Rather than give you a million minor comments, I just made the changes I wanted to suggest.  The code is looking really great.  I will have at one more round of comments on the VCF code (ugh) and the annotation internals, both of which I'm still looking at.  All tests pass.  Feel free to fight back on any of these.

Here's a rough summary of the changes:

Moved RichRow to utils.
Use named args for booleans (nullable in StructField, mostly).
Renamed signatures signature in various places.
Use convience functions consistently throughout.
Annotation clients shouldn't ever see Rows: various changes, toRow -> toAnnotation, Annotation(...) -> Row.fromSeq(Array(...)), etc.
Removed TAbstractStruct/TVdsStruct.
toRow goes on class, not object.
Don't store out      Variant    in GenotypeStream (duplicate).
Put back RichRow.toVariant, .toGenotypeStream for consistency with other Row client code.
Put schema on AltAllele, too.
Signature argument first in insert for consistency between Signature and VSM operations and between convience and main functions.
Formatting: always
  } else
never
  }
  else
Some gratuitous renaming.  Some not so gratuitous renaming.
