### PR TITLE
tp_annorework_review2

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/annotations/Annotation.scala
+++ b/src/main/scala/org/broadinstitute/hail/annotations/Annotation.scala
@@ -8,8 +8,6 @@ object Annotation {
 
   def emptyIndexedSeq(n: Int): IndexedSeq[Annotation] = IndexedSeq.fill[Annotation](n)(null)
 
-  def emptySignature: Signature = EmptySignature()
-
   def printAnnotation(a: Any, nSpace: Int = 0): String = {
     val spaces = " " * nSpace
     a match {

--- a/src/main/scala/org/broadinstitute/hail/driver/ExportVCF.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/ExportVCF.scala
@@ -54,7 +54,7 @@ object ExportVCF extends Command {
       }
 
       val infoHeader: Option[Array[(String, VCFSignature)]] = vas
-        .getOption(List("info")) match {
+        .getOption("info") match {
         case Some(sigs: StructSignature) =>
           Some(sigs.m.toArray
             .sortBy { case (key, (i, s)) => i }
@@ -102,13 +102,13 @@ object ExportVCF extends Command {
     }
 
     val infoF: (StringBuilder, Annotation) => Unit = {
-      vas.getOption(List("info")) match {
+      vas.getOption("info") match {
         case Some(signatures: StructSignature) =>
           val keys = signatures.m.map { case (k, (i, v)) => (k, i, v.dType == expr.TBoolean) }
             .toArray
             .sortBy { case (key, index, isBoolean) => index }
             .map { case (key, index, isBoolean) => (key, isBoolean) }
-          val querier = vas.query(List("info"))
+          val querier = vas.query("info")
 
           (sb, ad) => {
             val infoRow = querier(ad).map(_.asInstanceOf[Row])

--- a/src/main/scala/org/broadinstitute/hail/methods/LoadVCF.scala
+++ b/src/main/scala/org/broadinstitute/hail/methods/LoadVCF.scala
@@ -189,7 +189,7 @@ object LoadVCF {
         }
     })
     VariantSampleMatrix(VariantMetadata(filters, sampleIds,
-      Annotation.emptyIndexedSeq(sampleIds.length), Annotation.emptySignature,
+      Annotation.emptyIndexedSeq(sampleIds.length), Signature.empty,
       variantAnnotationSignatures), genotypes)
   }
 

--- a/src/main/scala/org/broadinstitute/hail/variant/Genotype.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/Genotype.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.hail.variant
 import java.util
 import org.apache.commons.lang3.builder.HashCodeBuilder
 import org.apache.commons.math3.distribution.BinomialDistribution
+import org.apache.spark.sql.types._
 import org.broadinstitute.hail.ByteIterator
 import org.broadinstitute.hail.check.{Gen, Arbitrary}
 import scala.language.implicitConversions
@@ -199,6 +200,14 @@ object Genotype {
     fakeRef: Boolean = false): Genotype = {
     new Genotype(gt.getOrElse(-1), ad.map(_.toArray).orNull, dp.getOrElse(-1), gq.getOrElse(-1), pl.map(_.toArray).orNull, fakeRef)
   }
+
+  def schema: DataType = StructType(Array(
+    StructField("gt", IntegerType),
+    StructField("ad", ArrayType(IntegerType)),
+    StructField("dp", IntegerType),
+    StructField("gq", IntegerType),
+    StructField("pl", ArrayType(IntegerType)),
+    StructField("fakeRef", BooleanType)))
 
   final val flagMultiHasGTBit = 0x1
   final val flagMultiGTRefBit = 0x2

--- a/src/main/scala/org/broadinstitute/hail/variant/Variant.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/Variant.scala
@@ -18,7 +18,7 @@ object CopyState extends Enumeration {
 }
 
 object AltAllele {
-  def schema(): StructType = StructType(Array(
+  def schema: StructType = StructType(Array(
     StructField("ref", StringType, nullable = false),
     StructField("alt", StringType, nullable = false)))
 
@@ -135,12 +135,12 @@ object Variant {
 
   implicit def arbVariant: Arbitrary[Variant] = Arbitrary(gen)
 
-  def schema(): StructType =
+  def schema: StructType =
     StructType(Array(
       StructField("contig", StringType, nullable = false),
       StructField("start", IntegerType, nullable = false),
       StructField("ref", StringType, nullable = false),
-      StructField("altAlleles", ArrayType(AltAllele.schema(), containsNull = false),
+      StructField("altAlleles", ArrayType(AltAllele.schema, containsNull = false),
         nullable = false)))
 
   def fromRow(r: Row) =

--- a/src/main/scala/org/broadinstitute/hail/variant/VariantMetadata.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/VariantMetadata.scala
@@ -11,8 +11,8 @@ object VariantMetadata {
   def apply(sampleIds: Array[String]): VariantMetadata = new VariantMetadata(Array.empty[(String, String)],
     sampleIds,
     Annotation.emptyIndexedSeq(sampleIds.length),
-    Annotation.emptySignature,
-    Annotation.emptySignature)
+    Signature.empty,
+    Signature.empty)
 
   def apply(filters: IndexedSeq[(String, String)], sampleIds: Array[String],
     sa: IndexedSeq[Annotation], sas: Signature, vas: Signature): VariantMetadata = {

--- a/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
@@ -448,12 +448,10 @@ class VariantSampleMatrix[T](val metadata: VariantMetadata,
 class RichVDS(vds: VariantDataset) {
 
   def makeSchema(): StructType = {
-    val vaStruct = vds.vaSignature.getSchema
-
     val s = StructType(Array(
-      StructField("variant", Variant.schema(), nullable = false),
-      StructField("annotations", vds.vaSignature.getSchema, nullable = false),
-      StructField("gs", GenotypeStream.schema(), nullable = false)
+      StructField("variant", Variant.schema, nullable = false),
+      StructField("annotations", vds.vaSignature.schema, nullable = false),
+      StructField("gs", GenotypeStream.schema, nullable = false)
     ))
     s
   }

--- a/src/test/scala/org/broadinstitute/hail/methods/ImportVCFSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/ImportVCFSuite.scala
@@ -63,10 +63,10 @@ class ImportVCFSuite extends SparkSuite {
     var s = State(sc, sqlContext)
     s = ImportVCF.run(s, Array("src/test/resources/undeclaredinfo.vcf"))
 
-    assert(s.vds.vaSignature.getOption(List("info")).isDefined)
-    assert(s.vds.vaSignature.getOption(List("info", "undeclared")).isEmpty)
-    assert(s.vds.vaSignature.getOption(List("info", "undeclaredFlag")).isEmpty)
-    val infoQuerier = s.vds.vaSignature.query(List("info"))
+    assert(s.vds.vaSignature.getOption("info").isDefined)
+    assert(s.vds.vaSignature.getOption("info", "undeclared").isEmpty)
+    assert(s.vds.vaSignature.getOption("info", "undeclaredFlag").isEmpty)
+    val infoQuerier = s.vds.vaSignature.query("info")
 
     val anno = s.vds
       .rdd

--- a/src/test/scala/org/broadinstitute/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/variant/vsm/VSMSuite.scala
@@ -31,7 +31,7 @@ class VSMSuite extends SparkSuite {
         "inner" -> (0, StructSignature(Map(
           "thing1" -> (0, SimpleSignature(expr.TString))))),
         "thing2" -> (1, SimpleSignature(expr.TString)))),
-      Annotation.emptySignature)
+      Signature.empty)
     val mdata4 = new VariantMetadata(
       IndexedSeq.empty[(String, String)],
       Array("S1", "S2"),
@@ -41,7 +41,7 @@ class VSMSuite extends SparkSuite {
           "thing1" -> (0, SimpleSignature(expr.TString))))),
         "thing2" -> (1, SimpleSignature(expr.TString)),
       "dummy" -> (2, SimpleSignature(expr.TString)))),
-      Annotation.emptySignature)
+      Signature.empty)
 
     assert(mdata1 != mdata2)
     assert(mdata1 != mdata3)

--- a/src/test/scala/org/broadinstitute/hail/vcf/SplitSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/vcf/SplitSuite.scala
@@ -17,7 +17,7 @@ class SplitSuite extends SparkSuite {
       forAll(VariantSampleMatrix.gen[Genotype](sc, Genotype.gen _)) { (vds: VariantDataset) =>
         var s = State(sc, sqlContext, vds)
         s = SplitMulti.run(s, Array[String]())
-        val wasSplitQuerier = s.vds.vaSignature.query(List("wasSplit"))
+        val wasSplitQuerier = s.vds.vaSignature.query("wasSplit")
         s.vds.mapWithAll((v: Variant, va: Annotation, _: Int, g: Genotype) =>
           !g.fakeRef || wasSplitQuerier(va).asInstanceOf[Option[Boolean]].get)
           .collect()
@@ -49,7 +49,7 @@ class SplitSuite extends SparkSuite {
       .join(vds2.mapWithKeys((v, s, g) => ((v, s), g)))
       .foreach { case (k, (g1, g2)) => simpleAssert(g1 == g2) }
 
-    val wasSplitQuerier = vds1.vaSignature.query(List("wasSplit"))
+    val wasSplitQuerier = vds1.vaSignature.query("wasSplit")
 
     // test for wasSplit
     vds1.mapWithAll((v, va, s, g) => (v.start, wasSplitQuerier(va).asInstanceOf[Option[Boolean]].get))


### PR DESCRIPTION
Mostly minor.  Let me know if you have any questions.  If you merge this in to tp_annorework, I'll merge it in to master.

Moved Annotation.emptySignature to Signature.empty.
Use convenience functions in more places (looked over all instances of List).
Rename Annotation.getSchema to .schema.  Make schema virtual on Type.  (Prefer virtual functions to match).
Some renaming in Signature.
Removed () on some simple functions (.getSchema(), .empty(), etc).
