### PR TITLE
Two fixes in AST/Parser

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/expr/AST.scala
+++ b/src/main/scala/org/broadinstitute/hail/expr/AST.scala
@@ -1070,8 +1070,14 @@ case class SymRef(posn: Position, symbol: String) extends AST(posn) {
 
 case class If(pos: Position, cond: AST, thenTree: AST, elseTree: AST)
   extends AST(pos, Array(cond, thenTree, elseTree)) {
-  override def typecheckThis(typeSymTab: SymbolTable): Type =
-    TBoolean
+  override def typecheckThis(typeSymTab: SymbolTable): Type = {
+    thenTree.typecheck(typeSymTab)
+    elseTree.typecheck(typeSymTab)
+    if (thenTree.`type` != elseTree.`type`)
+      parseError(s"expected same-type `then' and `else' clause, got `${thenTree.`type`}' and `${elseTree.`type`}'")
+    else
+      thenTree.`type`
+  }
 
   def eval(c: EvalContext): () => Any = {
     val f1 = cond.eval(c)

--- a/src/main/scala/org/broadinstitute/hail/expr/Parser.scala
+++ b/src/main/scala/org/broadinstitute/hail/expr/Parser.scala
@@ -150,7 +150,7 @@ object Parser extends JavaTokenParsers {
   }
 
   def primary_expr: Parser[AST] =
-    withPos("""-?\d+\.\d+[dD]?""".r) ^^ (r => Const(r.pos, r.x.toDouble, TDouble)) |
+    withPos("""-?\d*\.\d+[dD]?""".r) ^^ (r => Const(r.pos, r.x.toDouble, TDouble)) |
       withPos("""-?\d+(\.\d*)?[eE][+-]?\d+[dD]?""".r) ^^ (r => Const(r.pos, r.x.toDouble, TDouble)) |
       // FIXME L suffix
       withPos(wholeNumber) ^^ (r => Const(r.pos, r.x.toInt, TInt)) |

--- a/src/test/scala/org/broadinstitute/hail/methods/ExportSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/ExportSuite.scala
@@ -104,4 +104,14 @@ class ExportSuite extends SparkSuite {
       assert(lines.next == "I have some spaces and tabs\there\tmore weird stuff here")
     }
   }
+
+  @Test def testIf() {
+    var s = State(sc, sqlContext)
+    s = ImportVCF.run(s, Array("src/test/resources/sample.vcf"))
+    s = SplitMulti.run(s, Array.empty[String])
+    s = SampleQC.run(s, Array.empty[String])
+
+      // this should run without errors
+    s = ExportSamples.run(s, Array("-o", "/tmp/samples3.tsv", "-c", "computation = 5 * (if (sa.qc.callRate < .95) 0 else 1)"))
+  }
 }


### PR DESCRIPTION
1.  Allow floating-point literals to take the form ".99" instead of "0.99".
2.  Fix typing of "if" expressions to assert that both the then and else ASTs have the same type, then return that type (was TBoolean)
3.  Wrote a test for both these cases
