### PR TITLE
Various.

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/Utils.scala
+++ b/src/main/scala/org/broadinstitute/hail/Utils.scala
@@ -722,17 +722,15 @@ object Utils extends Logging {
   def hadoopStripCodec(s: String, conf: hadoop.conf.Configuration): String = {
     val path = new org.apache.hadoop.fs.Path(s)
 
-    val ext = Option(new CompressionCodecFactory(conf)
+    Option(new CompressionCodecFactory(conf)
       .getCodec(path))
-    val toStrip = ext.map(_.getDefaultExtension)
-    assert(toStrip.forall(s.endsWith))
-    val lengthToStrip = toStrip.map(_.length)
-      .getOrElse(0)
-
-    s.substring(0, s.length - lengthToStrip)
+      .map { case codec =>
+        val ext = codec.getDefaultExtension
+        assert(s.endsWith(ext))
+        s.dropRight(ext.length)
+      }.getOrElse(s)
   }
-
-
+  
   def writeObjectFile[T](filename: String,
     hConf: hadoop.conf.Configuration)(f: (ObjectOutputStream) => T): T = {
     val oos = new ObjectOutputStream(hadoopCreate(filename, hConf))

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateSamples.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateSamples.scala
@@ -1,36 +1,10 @@
 package org.broadinstitute.hail.driver
 
-import org.broadinstitute.hail.Utils._
-import org.kohsuke.args4j.{Option => Args4jOption}
-
-object AnnotateSamples extends Command {
-
-  def newOptions: Options = throw new UnsupportedOperationException
-
+object AnnotateSamples extends SuperCommand {
   def name = "annotatesamples"
 
   def description = "Annotate samples in current dataset"
 
-  override def runCommand(state: State, options: Options): State = throw new UnsupportedOperationException
-
-  override def lookup(args: Array[String]): (Command, Array[String]) = {
-    val errorString =
-      """parse error: expect one of the following:
-        |  annotatesamples expr <args>
-        |  annotatesamples tsv <args>
-      """.stripMargin
-    fatalIf(args.isEmpty, errorString)
-    args.head match {
-      case "expr" => (AnnotateSamplesExpr, args.tail)
-      case "tsv" => (AnnotateSamplesTSV, args.tail)
-      case _ => fatal(errorString)
-    }
-  }
-
-  override def run(state: State, args: Array[String]): State = {
-    val (c, newArgs) = lookup(args)
-    c.run(state, newArgs)
-  }
-
-  override def run(state: State, options: Options): State = throw new UnsupportedOperationException
+  register(AnnotateSamplesExpr)
+  register(AnnotateSamplesTSV)
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariants.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariants.scala
@@ -1,47 +1,14 @@
 package org.broadinstitute.hail.driver
 
-import org.broadinstitute.hail.Utils._
-import org.kohsuke.args4j.{Option => Args4jOption}
-
-
-object AnnotateVariants extends Command {
-
-  def newOptions: Options = throw new UnsupportedOperationException
-
+object AnnotateVariants extends SuperCommand {
   def name = "annotatevariants"
 
   def description = "Annotate variants in current dataset"
 
-  override def lookup(args: Array[String]): (Command, Array[String]) = {
-    val errorString =
-      """parse error: expect one of the following:
-        |  annotatevariants expr <args>
-        |  annotatevariants tsv <args>
-        |  annotatevariants vcf <args>
-        |  annotatevariants vds <args>
-        |  annotatevariants bed <args>
-        |  annotatevariants intervals <args>
-      """.stripMargin
-    fatalIf(args.isEmpty, errorString)
-    args.head match {
-      case "expr" => (AnnotateVariantsExpr, args.tail)
-      case "bed" => (AnnotateVariantsBed, args.tail)
-      case "tsv" => (AnnotateVariantsTSV, args.tail)
-      case "vcf" => (AnnotateVariantsVCF, args.tail)
-      case "vds" => (AnnotateVariantsVDS, args.tail)
-      case "intervals" => (AnnotateVariantsIList, args.tail)
-      case _ => fatal(errorString)
-    }
-  }
-
-  override def runCommand(state: State, options: Options): State = throw new UnsupportedOperationException
-
-  override def run(state: State, args: Array[String]): State = {
-    val (c, newArgs) = lookup(args)
-    c.run(state, newArgs)
-  }
-
-  override def run(state: State, options: Options): State = throw new UnsupportedOperationException
-
-
+  register(AnnotateVariantsBed)
+  register(AnnotateVariantsExpr)
+  register(AnnotateVariantsIList)
+  register(AnnotateVariantsTSV)
+  register(AnnotateVariantsVCF)
+  register(AnnotateVariantsVDS)
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsBed.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsBed.scala
@@ -1,12 +1,7 @@
 package org.broadinstitute.hail.driver
 
-import org.broadinstitute.hail.Utils._
-import org.broadinstitute.hail.annotations._
-import org.broadinstitute.hail.expr
 import org.broadinstitute.hail.io.annotators._
 import org.kohsuke.args4j.{Option => Args4jOption}
-
-import scala.collection.mutable
 
 object AnnotateVariantsBed extends Command {
 
@@ -22,22 +17,13 @@ object AnnotateVariantsBed extends Command {
 
   def newOptions = new Options
 
-  def name = "annotatevariants/bed"
+  def name = "annotatevariants bed"
 
-  override def hidden = true
-
-  def description = "Annotate variants in current dataset"
+  def description = "Annotate variants with UCSC BED file"
 
   def run(state: State, options: Options): State = {
-    val vds = state.vds
-
-    val cond = options.input
-
-    val conf = state.sc.hadoopConfiguration
-
-    val (iList, signature) = BedAnnotator(cond, conf)
-    val annotated = vds.annotateInvervals(iList, signature, AnnotateVariantsTSV.parseRoot(options.root))
-
-    state.copy(vds = annotated)
+    val (iList, signature) = BedAnnotator(options.input, state.hadoopConf)
+    state.copy(
+      vds = state.vds.annotateInvervals(iList, signature, AnnotateVariantsTSV.parseRoot(options.root)))
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsIList.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsIList.scala
@@ -17,22 +17,14 @@ object AnnotateVariantsIList extends Command {
 
   def newOptions = new Options
 
-  def name = "annotatevariants/intervals"
+  def name = "annotatevariants intervals"
 
-  override def hidden = true
-
-  def description = "Annotate variants in current dataset"
+  def description = "Annotate variants with interval list"
 
   def run(state: State, options: Options): State = {
     val vds = state.vds
-
-    val cond = options.input
-
-    val conf = state.sc.hadoopConfiguration
-
-    val (iList, signature) = IntervalListAnnotator(cond, conf)
+    val (iList, signature) = IntervalListAnnotator(options.input, state.hadoopConf)
     val annotated = vds.annotateInvervals(iList, signature, AnnotateVariantsTSV.parseRoot(options.root))
-
     state.copy(vds = annotated)
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsTSV.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsTSV.scala
@@ -1,12 +1,9 @@
 package org.broadinstitute.hail.driver
 
 import org.broadinstitute.hail.Utils._
-import org.broadinstitute.hail.annotations._
-import org.broadinstitute.hail.expr
+import org.broadinstitute.hail.expr._
 import org.broadinstitute.hail.io.annotators._
 import org.kohsuke.args4j.{Option => Args4jOption}
-
-import scala.collection.mutable
 
 object AnnotateVariantsTSV extends Command {
 
@@ -34,52 +31,30 @@ object AnnotateVariantsTSV extends Command {
 
   def newOptions = new Options
 
-  def name = "annotatevariants/tsv"
+  def name = "annotatevariants tsv"
 
-  override def hidden = true
-
-  def description = "Annotate variants in current dataset"
-
-  def parseTypeMap(s: String): Map[String, String] = {
-    s.split(",")
-      .map(_.trim())
-      .map(s => s.split(":").map(_.trim()))
-      .map {
-        case Array(f, t) => (f, t)
-        case arr => fatal("parse error in type declaration")
-      }
-      .toMap
-  }
+  def description = "Annotate variants with TSV file"
 
   def parseColumns(s: String): Array[String] = {
     val split = s.split(",").map(_.trim)
     fatalIf(split.length != 4 && split.length != 1,
-      "Cannot read chr, pos, ref, alt columns from '" + s +
-        "': enter 4 comma-separated column identifiers for separate chr/pos/ref/alt columns, " +
-        "or one identifier for chr:pos:ref:alt")
+      s"""Cannot read chr, pos, ref, alt columns from `$s':
+          |  enter four comma-separated column identifiers for separate chr/pos/ref/alt columns, or
+          |  one column identifier for a single chr:pos:ref:alt column.""".stripMargin)
     split
   }
 
   def parseRoot(s: String): List[String] = {
-    val split = s.split("""\.""").toList
-    fatalIf(split.isEmpty || split.head != "va", s"invalid root '$s': expect 'va.<path[.path2...]>'")
+    val split = s.split("\\.").toList
+    fatalIf(split.isEmpty || split.head != "va", s"Root must start with `va.', got `$s'")
     split.tail
   }
 
   def run(state: State, options: Options): State = {
     val vds = state.vds
-
-    val cond = options.condition
-
-    val stripped = hadoopStripCodec(cond, state.sc.hadoopConfiguration)
-
-
-    val conf = state.sc.hadoopConfiguration
-
-
-    val (rdd, signature) = VariantTSVAnnotator(vds.sparkContext, cond,
+    val (rdd, signature) = VariantTSVAnnotator(vds.sparkContext, options.condition,
       parseColumns(options.vCols),
-      parseTypeMap(options.types),
+      Parser.parseAnnotationTypes(options.types),
       options.missingIdentifier)
     val annotated = vds.annotateVariants(rdd, signature, parseRoot(options.root))
 

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsVCF.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsVCF.scala
@@ -27,21 +27,19 @@ object AnnotateVariantsVCF extends Command {
 
   def newOptions = new Options
 
-  def name = "annotatevariants/vcf"
+  def name = "annotatevariants vcf"
 
-  override def hidden = true
-
-  def description = "Annotate variants in current dataset"
+  def description = "Annotate variants with VCF file"
 
   def run(state: State, options: Options): State = {
     val vds = state.vds
 
     val filepath = options.input
 
-    fatalIf(!options.force && filepath.endsWith(".gz"), "Hail does not load '.gz' files by default, " +
-      "rename to '.bgz' if the file is block-gzipped or use argument '--force'.")
+    fatalIf(!options.force && filepath.endsWith(".gz"),
+      ".gz cannot be loaded in parallel, use .bgz or -f override")
 
-    val otherVds = LoadVCF(vds.sparkContext, filepath).filterSamples({case (s, sa) => false})
+    val otherVds = LoadVCF(vds.sparkContext, filepath, skipGenotypes = true)
     val otherVdsSplit = SplitMulti.run(state.copy(vds = otherVds)).vds
 
     val annotated = vds.annotateVariants(otherVdsSplit.variantsAndAnnotations, otherVdsSplit.vaSignature,

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsVDS.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsVDS.scala
@@ -19,20 +19,18 @@ object AnnotateVariantsVDS extends Command {
 
   def newOptions = new Options
 
-  def name = "annotatevariants/vds"
+  def name = "annotatevariants vds"
 
-  override def hidden = true
-
-  def description = "Annotate variants in current dataset"
+  def description = "Annotate variants with VDS file"
 
   def run(state: State, options: Options): State = {
     val vds = state.vds
 
     val filepath = options.input
 
-    val readOtherVds = Read.run(State(state.sc, state.sqlContext, null), Array("-i", filepath)).vds
+    val readOtherVds = Read.run(state, Array("-i", filepath)).vds
 
-    fatalIf(!readOtherVds.wasSplit, "cannot annotate from a multiallelic VDS, run 'splitmulti' on that VDS first.")
+    fatalIf(!readOtherVds.wasSplit, "cannot annotate from a multiallelic VDS, run `splitmulti' on that VDS first.")
 
     val (rdd, signature) =(readOtherVds.variantsAndAnnotations, readOtherVds.vaSignature)
     val annotated = vds.annotateVariants(readOtherVds.variantsAndAnnotations,

--- a/src/main/scala/org/broadinstitute/hail/driver/Command.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/Command.scala
@@ -1,12 +1,12 @@
 package org.broadinstitute.hail.driver
 
-import org.apache.spark.{SparkException, SparkContext}
+import org.apache.spark.SparkContext
 import org.apache.spark.sql.SQLContext
-import org.broadinstitute.hail.FatalException
 import org.broadinstitute.hail.variant.VariantDataset
-import org.kohsuke.args4j.{Option => Args4jOption, CmdLineException, CmdLineParser}
+import org.kohsuke.args4j.{Argument, CmdLineException, CmdLineParser, Option => Args4jOption}
 import scala.collection.JavaConverters._
 import org.broadinstitute.hail.Utils._
+import scala.collection.mutable
 
 case class State(sc: SparkContext,
   sqlContext: SQLContext,
@@ -15,7 +15,131 @@ case class State(sc: SparkContext,
   def hadoopConf = sc.hadoopConfiguration
 }
 
-// FIXME: HasArgs vs Command
+object ToplevelCommands {
+  val commands = mutable.Map.empty[String, Command]
+
+  def commandNames: Set[String] = commands.keys.toSet
+
+  def register(command: Command) {
+    commands += command.name -> command
+  }
+
+  def lookup(args: Array[String]): (Command, Array[String]) = {
+    assert(!args.isEmpty)
+
+    val commandName = args.head
+    commands.get(commandName) match {
+      case Some(c) => c.lookup(args.tail)
+      case None =>
+        fatal(s"no such command `$commandName'")
+    }
+  }
+
+  def printCommands() {
+    val visibleCommands = commands.values.filterNot(_.hidden)
+    val maxLen = visibleCommands.map(_.name.length).max
+    visibleCommands
+      .foreach(cmd => println("  " + cmd.name + (" " * (maxLen - cmd.name.length + 2))
+        + cmd.description))
+  }
+
+  register(AnnotateSamples)
+  register(AnnotateVariants)
+  register(Cache)
+  register(ImportAnnotations)
+  register(Count)
+  register(DownsampleVariants)
+  register(ExportPlink)
+  register(ExportGenotypes)
+  register(ExportSamples)
+  register(ExportVariants)
+  register(ExportVCF)
+  register(FilterGenotypes)
+  register(FamSummary)
+  register(FilterVariants)
+  register(FilterSamples)
+  register(GenDataset)
+  register(Grep)
+  register(GQByDP)
+  register(GQHist)
+  register(ImportVCF)
+  register(LinearRegressionCommand)
+  register(MendelErrorsCommand)
+  register(SplitMulti)
+  register(PCA)
+  register(Read)
+  register(RenameSamples)
+  register(Repartition)
+  register(SampleQC)
+  register(ShowAnnotations)
+  register(VariantQC)
+  register(VEP)
+  register(Write)
+}
+
+abstract class SuperCommand extends Command {
+
+  class Options extends BaseOptions {
+    @Argument(required = true, usage = "<subcommand> <arguments...>")
+    var arguments: java.util.ArrayList[String] = new java.util.ArrayList[String]()
+  }
+
+  def newOptions = new Options
+
+  val subcommands = mutable.Map.empty[String, Command]
+
+  def subcommandNames: Set[String] = subcommands.keys.toSet
+
+  def register(subcommand: Command) {
+    val split = subcommand.name.split(" ")
+    assert(name == split.init.mkString(" "))
+    subcommands += split.last -> subcommand
+  }
+
+  override def supportsMultiallelic = true
+
+  override def lookup(args: Array[String]): (Command, Array[String]) = {
+    if (args.isEmpty
+      || args.head(0) == '-')
+      return (this, args)
+
+    val subcommandName = args.head
+    subcommands.get(subcommandName) match {
+      case Some(sc) => sc.lookup(args.tail)
+      case None =>
+        fatal(s"$name: no such sub-command `$subcommandName'")
+    }
+  }
+
+  override def printUsage() {
+    super.printUsage()
+
+    println("")
+    println("Sub-commands:")
+    val visibleSubcommands = subcommands.values.filterNot(_.hidden)
+    val maxLen = visibleSubcommands.map(_.name.length).max
+    visibleSubcommands
+      .foreach(sc => println("  " + sc.name + (" " * (maxLen - sc.name.length + 2))
+        + sc.description))
+  }
+
+  override def parseArgs(args: Array[String]): Options = {
+    val options = newOptions
+    options.arguments = new java.util.ArrayList[String](args.toList.asJava)
+    options
+  }
+
+  def run(state: State, options: Options): State = {
+    val args = options.arguments.asScala.toArray
+
+    if (args.isEmpty)
+      fatal(s"no sub-command given.  See help (-h) output for list of sub-commands.")
+
+    val (sc, scArgs) = lookup(args)
+    sc.run(state, scArgs)
+  }
+}
+
 abstract class Command {
 
   class BaseOptions {
@@ -38,6 +162,15 @@ abstract class Command {
 
   def lookup(args: Array[String]): (Command, Array[String]) = (this, args)
 
+  def printUsage() {
+    println("usage: " + name + " [<args>]")
+    println("")
+    println(description)
+    println("")
+    println("Arguments:")
+    new CmdLineParser(newOptions).printUsage(System.out)
+  }
+
   def parseArgs(args: Array[String]): Options = {
     val options = newOptions
     val parser = new CmdLineParser(options)
@@ -45,17 +178,12 @@ abstract class Command {
     try {
       parser.parseArgument((args: Iterable[String]).asJavaCollection)
       if (options.printUsage) {
-        println("usage: " + name + " [<args>]")
-        println("")
-        println(description)
-        println("")
-        println("Arguments:")
-        new CmdLineParser(newOptions).printUsage(System.out)
+        printUsage()
         sys.exit(0)
       }
     } catch {
       case e: CmdLineException =>
-        fatal(s"$name: parse error: ${e.getMessage}")
+        fatal(s"parse error: ${e.getMessage}")
     }
 
     options
@@ -65,7 +193,7 @@ abstract class Command {
     if (!supportsMultiallelic
       && state.vds != null
       && !state.vds.wasSplit)
-      fatal(s"`$name' does not support multiallelics.\n  Run `splitmulti' first.")
+      fatal(s"does not support multiallelics.\n  Run `splitmulti' first.")
 
     run(state, options)
   }

--- a/src/main/scala/org/broadinstitute/hail/driver/DownsampleVariants.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/DownsampleVariants.scala
@@ -1,11 +1,6 @@
 package org.broadinstitute.hail.driver
 
-import org.broadinstitute.hail.Utils._
-import org.broadinstitute.hail.methods._
-import org.broadinstitute.hail.variant._
 import org.kohsuke.args4j.{Option => Args4jOption}
-
-import scala.io.Source
 
 object DownsampleVariants extends Command {
 

--- a/src/main/scala/org/broadinstitute/hail/driver/ImportAnnotations.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/ImportAnnotations.scala
@@ -1,15 +1,9 @@
 package org.broadinstitute.hail.driver
 
-import org.apache.hadoop.conf.Configuration
-import org.apache.spark.SparkEnv
-import org.apache.spark.sql.Row
-import org.apache.spark.sql.types.{StructField, StructType}
-import org.broadinstitute.hail.Utils._
 import org.broadinstitute.hail.annotations.Annotation
-import org.broadinstitute.hail.expr
+import org.broadinstitute.hail.expr._
 import org.broadinstitute.hail.io.annotators._
-import org.broadinstitute.hail.methods.LoadVCF
-import org.broadinstitute.hail.variant.{GenotypeStream, GenotypeStreamBuilder, Variant, VariantDataset, VariantMetadata}
+import org.broadinstitute.hail.variant._
 import org.kohsuke.args4j.{Option => Args4jOption}
 
 object ImportAnnotations extends Command {
@@ -25,7 +19,7 @@ object ImportAnnotations extends Command {
 
     @Args4jOption(required = false, name = "-m", aliases = Array("--missing"),
       usage = "Specify additional identifiers to be treated as missing")
-    var missingIdentifiers: String = "NA"
+    var missingIdentifier: String = "NA"
 
     @Args4jOption(required = false, name = "--vcolumns",
       usage = "Specify the column identifiers for chromosome, position, ref, and alt (in that order)")
@@ -36,29 +30,22 @@ object ImportAnnotations extends Command {
 
   def name = "importannotations"
 
-  def description = "Import a tsv file containing variants / annotations into a sample-free vds"
+  def description = "Import a TSV file containing variants / annotations into a sample-free VDS"
 
   def run(state: State, options: Options): State = {
-    val cond = options.input
+    val (rdd, signature) = VariantTSVAnnotator(state.sc,
+      options.input,
+      AnnotateVariantsTSV.parseColumns(options.vCols),
+      Parser.parseAnnotationTypes(options.types),
+      options.missingIdentifier)
 
-    val conf = state.sc.hadoopConfiguration
-    val serializer = SparkEnv.get.serializer.newInstance()
-
-    val vds = hadoopStripCodec(options.input, conf) match {
-      case tsv if tsv.endsWith(".tsv") =>
-        val (rdd, signature) = VariantTSVAnnotator(state.sc, cond, AnnotateVariantsTSV.parseColumns(options.vCols),
-          AnnotateVariantsTSV.parseTypeMap(options.types), options.missingIdentifiers)
-        new VariantDataset(
-          VariantMetadata(IndexedSeq.empty[(String, String)], Array.empty[String], Annotation.emptyIndexedSeq(0),
-            expr.TEmpty, signature, wasSplit = true),
-          Array.empty[Int],
-          rdd.map { case (v, va) => (v, va, new GenotypeStreamBuilder(v, true).result()) })
-      case _ =>
-        fatal(
-          """This module requires an input file in the following format:
-            |  .tsv (tab separated values with chr, pos, ref, and alt columns, or chr:pos:ref:alt column)""".stripMargin)
-    }
+    val vds = new VariantDataset(
+      VariantMetadata(IndexedSeq.empty, IndexedSeq.empty, Annotation.emptyIndexedSeq(0),
+        TEmpty, signature, wasSplit = true),
+      Array.empty[Int],
+      rdd.map { case (v, va) => (v, va, Iterable.empty) })
 
     state.copy(vds = vds)
   }
+
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/ImportVCF.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/ImportVCF.scala
@@ -26,6 +26,9 @@ object ImportVCF extends Command {
     @Args4jOption(name = "-n", aliases = Array("--npartition"), usage = "Number of partitions")
     var nPartitions: Int = 0
 
+    @Args4jOption(name = "--skip-genotypes", usage = "Don't load genotypes")
+    var skipGenotypes: Boolean = false
+
     @Args4jOption(name = "--store-gq", usage = "Store GQ instead of computing from PL")
     var storeGQ: Boolean = false
 
@@ -76,7 +79,8 @@ object ImportVCF extends Command {
       if (options.nPartitions != 0)
         Some(options.nPartitions)
       else
-        None))
+        None,
+      options.skipGenotypes))
   }
 
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/Main.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/Main.scala
@@ -49,6 +49,18 @@ object Main {
     var tmpDir: String = "/tmp"
   }
 
+  def handleFatal(e: Exception): Nothing = {
+    System.err.println(s"hail: fatal: ${e.getMessage}")
+    log.error(e.getMessage)
+    sys.exit(1)
+  }
+
+  def handleFatal(cmd: Command, e: Exception): Nothing = {
+    System.err.println(s"hail: fatal: ${cmd.name}: ${e.getMessage}")
+    log.error(e.getMessage)
+    sys.exit(1)
+  }
+
   def logAndPropagateException(cmd: Command, e: Exception): Nothing = {
     log.error(s"${cmd.name}: exception", e)
     if (HailConfiguration.stacktrace)
@@ -76,10 +88,8 @@ object Main {
     try {
       cmd.runCommand(s, cmdOpts.asInstanceOf[cmd.Options])
     } catch {
-      case f: FatalException =>
-        System.err.println(s"hail: ${cmd.name}: fatal: ${f.getMessage}")
-        log.error(f.getMessage)
-        sys.exit(1)
+      case e: FatalException =>
+        handleFatal(cmd, e)
 
       case e: SparkException =>
         handlePropagatedException(cmd, "org.broadinstitute.hail.FatalException", e)
@@ -153,46 +163,8 @@ object Main {
       }
     */
 
-    val commands = Array(
-      AnnotateSamples,
-      AnnotateVariants,
-      Cache,
-      ImportAnnotations,
-      Count,
-      DownsampleVariants,
-      ExportPlink,
-      ExportGenotypes,
-      ExportSamples,
-      ExportVariants,
-      ExportVCF,
-      FilterGenotypes,
-      FamSummary,
-      FilterVariants,
-      FilterSamples,
-      GenDataset,
-      Grep,
-      GQByDP,
-      GQHist,
-      ImportVCF,
-      LinearRegressionCommand,
-      MendelErrorsCommand,
-      SplitMulti,
-      PCA,
-      Read,
-      RenameSamples,
-      Repartition,
-      SampleQC,
-      ShowAnnotations,
-      VariantQC,
-      VEP,
-      Write
-    )
-
-    val nameCommand = commands
-      .map(c => (c.name, c))
-      .toMap
-
-    val splitArgs: Array[Array[String]] = splitBefore[String](args, (arg: String) => nameCommand.contains(arg))
+    val commandNames = ToplevelCommands.commandNames
+    val splitArgs: Array[Array[String]] = splitBefore[String](args, (arg: String) => commandNames.contains(arg))
 
     val globalArgs = splitArgs(0)
 
@@ -201,18 +173,14 @@ object Main {
     try {
       parser.parseArgument((globalArgs: Iterable[String]).asJavaCollection)
       if (options.printUsage) {
-        println("usage: hail [<global options>] <cmd1> [<cmd1 args>]")
-        println("            [<cmd2> [<cmd2 args>] ... <cmdN> [<cmdN args>]]")
+        println("usage: hail [global options] <cmd1> [cmd1 args]")
+        println("  [<cmd2> [cmd2 args] ... <cmdN> [cmdN args]]")
         println("")
-        println("global options:")
+        println("Global options:")
         new CmdLineParser(new Options).printUsage(System.out)
         println("")
-        println("commands:")
-        val visibleCommands = commands.filterNot(_.hidden)
-        val maxLen = visibleCommands.map(_.name.length).max
-        visibleCommands
-          .foreach(cmd => println("  " + cmd.name + (" " * (maxLen - cmd.name.length + 2))
-            + cmd.description))
+        println("Commands:")
+        ToplevelCommands.printCommands()
         sys.exit(0)
       }
     } catch {
@@ -248,16 +216,22 @@ object Main {
       fatal("no commands given")
 
     val invocations: Array[(Command, Command#Options, Array[String])] = splitArgs.tail
-      .map(args => {
-        val cmdName = args(0)
-        nameCommand.get(cmdName) match {
-          case Some(cmd) =>
-            val (cmdLookup, cmdArgs) = cmd.lookup(args.tail)
-            (cmdLookup, cmdLookup.parseArgs(cmdArgs): Command#Options, cmdArgs)
-          case None =>
-            fatal("unknown command `" + cmdName + "'")
+      .map { args =>
+        val (cmd, cmdArgs) =
+          try {
+            ToplevelCommands.lookup(args)
+          } catch {
+            case e: FatalException =>
+              handleFatal(e)
+          }
+
+        try {
+          (cmd, cmd.parseArgs(cmdArgs): Command#Options, args)
+        } catch {
+          case e: FatalException =>
+            handleFatal(cmd, e)
         }
-      })
+      }
 
     val conf = new SparkConf().setAppName("Hail")
     if (options.master != null)

--- a/src/main/scala/org/broadinstitute/hail/expr/AST.scala
+++ b/src/main/scala/org/broadinstitute/hail/expr/AST.scala
@@ -48,6 +48,10 @@ object DoubleNumericConversion extends NumericConversion[Double] {
   }
 }
 
+trait Parsable {
+  def parse(s: String): Annotation
+}
+
 sealed abstract class Type extends Serializable {
   def getAsOption[T](fields: String*)(implicit ct: ClassTag[T]): Option[T] = {
     getOption(fields: _*)
@@ -113,9 +117,6 @@ sealed abstract class Type extends Serializable {
   def typeCheck(a: Any): Boolean
 
   def schema: DataType
-
-  def parse(s: String): Annotation =
-    throw new UnsupportedOperationException(s"Cannot generate a parser for $toString")
 }
 
 case object TEmpty extends Type {
@@ -128,14 +129,14 @@ case object TEmpty extends Type {
     BooleanType
 }
 
-case object TBoolean extends Type {
+case object TBoolean extends Type with Parsable {
   override def toString = "Boolean"
 
   def typeCheck(a: Any): Boolean = a == null || a.isInstanceOf[Boolean]
 
   def schema = BooleanType
 
-  override def parse(s: String): Annotation = s.toBoolean
+  def parse(s: String): Annotation = s.toBoolean
 }
 
 case object TChar extends Type {
@@ -149,24 +150,24 @@ case object TChar extends Type {
 
 abstract class TNumeric extends Type
 
-case object TInt extends TNumeric {
+case object TInt extends TNumeric with Parsable {
   override def toString = "Int"
 
   def typeCheck(a: Any): Boolean = a == null || a.isInstanceOf[Int]
 
   def schema = IntegerType
 
-  override def parse(s: String): Annotation = s.toInt
+  def parse(s: String): Annotation = s.toInt
 }
 
-case object TLong extends TNumeric {
+case object TLong extends TNumeric with Parsable {
   override def toString = "Long"
 
   def typeCheck(a: Any): Boolean = a == null || a.isInstanceOf[Long]
 
   def schema = LongType
 
-  override def parse(s: String): Annotation = s.toLong
+  def parse(s: String): Annotation = s.toLong
 }
 
 case object TFloat extends TNumeric {
@@ -176,27 +177,27 @@ case object TFloat extends TNumeric {
 
   def schema = FloatType
 
-  override def parse(s: String): Annotation = s.toFloat
+  def parse(s: String): Annotation = s.toFloat
 }
 
-case object TDouble extends TNumeric {
+case object TDouble extends TNumeric with Parsable {
   override def toString = "Double"
 
   def typeCheck(a: Any): Boolean = a == null || a.isInstanceOf[Double]
 
   def schema = DoubleType
 
-  override def parse(s: String): Annotation = s.toDouble
+  def parse(s: String): Annotation = s.toDouble
 }
 
-case object TString extends Type {
+case object TString extends Type with Parsable {
   override def toString = "String"
 
   def typeCheck(a: Any): Boolean = a == null || a.isInstanceOf[String]
 
   def schema = StringType
 
-  override def parse(s: String): Annotation = s
+  def parse(s: String): Annotation = s
 }
 
 case class TArray(elementType: Type) extends Type {

--- a/src/main/scala/org/broadinstitute/hail/expr/Parser.scala
+++ b/src/main/scala/org/broadinstitute/hail/expr/Parser.scala
@@ -22,7 +22,7 @@ object Parser extends JavaTokenParsers {
   def parse[T](symTab: Map[String, (Int, Type)], expected: Type, a: ArrayBuffer[Any], code: String): () => T = {
     // println(s"code = $code")
     val t: AST = parseAll(expr, code) match {
-      case Success(result, _) => result.asInstanceOf[AST]
+      case Success(result, _) => result
       case NoSuccess(msg, next) => ParserUtils.error(next.pos, msg)
     }
 
@@ -33,6 +33,22 @@ object Parser extends JavaTokenParsers {
 
     val f: () => Any = t.eval(EvalContext(symTab, a))
     () => f().asInstanceOf[T]
+  }
+
+  def parseType(code: String): Type = {
+    // println(s"code = $code")
+    parseAll(type_expr, code) match {
+      case Success(result, _) => result
+      case NoSuccess(msg, next) => ParserUtils.error(next.pos, msg)
+    }
+  }
+
+  def parseAnnotationTypes(code: String): Map[String, Type] = {
+    // println(s"code = $code")
+    parseAll(struct_fields, code) match {
+      case Success(result, _) => result.toMap
+      case NoSuccess(msg, next) => ParserUtils.error(next.pos, msg)
+    }
   }
 
   def withPos[T](p: => Parser[T]): Parser[Positioned[T]] =
@@ -82,7 +98,7 @@ object Parser extends JavaTokenParsers {
 
   def let_expr: Parser[AST] =
     withPos("let") ~ rep1sep((identifier <~ "=") ~ expr, "and") ~ ("in" ~> expr) ^^ { case let ~ bindings ~ body =>
-        Let(let.pos, bindings.iterator.map { case id ~ v => (id, v) }.toArray, body)
+      Let(let.pos, bindings.iterator.map { case id ~ v => (id, v) }.toArray, body)
     }
 
   def or_expr: Parser[AST] =
@@ -133,22 +149,17 @@ object Parser extends JavaTokenParsers {
     }
 
   def named_arg: Parser[(String, AST)] =
-    tsvIdentifier ~ "=" ~ expr ^^ { case id ~ eq ~ expr => (id, expr) }
-
+    tsvIdentifier ~ "=" ~ expr ^^ { case id ~ _ ~ expr => (id, expr) }
 
   def annotationExpressions: Parser[Array[(Array[String], AST)]] =
-    annotationExpression ~ rep("," ~ annotationExpression) ^^ { case arg ~ lst =>
-      (arg :: lst.map { case _ ~ arg => arg }).toArray
-    }
+    rep1sep(annotationExpression, ",") ^^ { _.toArray }
 
   def annotationExpression: Parser[(Array[String], AST)] = annotationIdentifier ~ "=" ~ expr ^^ {
     case id ~ eq ~ expr => (id, expr)
   }
 
   def annotationIdentifier: Parser[Array[String]] =
-    """[sv]a""".r ~ rep("." ~ (tickIdentifier ||| ident)) ^^ {
-      case arg ~ lst => (arg :: lst.map { case _ ~ arg => arg }).toArray
-    }
+    rep1sep(identifier, ".") ^^ { _.toArray }
 
   def tsvIdentifier: Parser[String] = tickIdentifier | """[^\s\p{Cntrl}=,]+""".r
 
@@ -157,9 +168,7 @@ object Parser extends JavaTokenParsers {
   def identifier = tickIdentifier | ident
 
   def args: Parser[Array[AST]] =
-    repsep(expr, ",") ^^ {
-      _.toArray
-    }
+    repsep(expr, ",") ^^ { _.toArray }
 
   def dot_expr: Parser[AST] =
     unary_expr ~ rep((withPos(".") ~ identifier ~ "(" ~ args ~ ")")
@@ -201,4 +210,33 @@ object Parser extends JavaTokenParsers {
       guard(not("if" | "else")) ~> withPos(identifier) ^^ (r => SymRef(r.pos, r.x)) |
       "{" ~> expr <~ "}" |
       "(" ~> expr <~ ")"
+
+  def annotationSignature: Parser[TStruct] =
+    struct_fields ^^ { fields => TStruct(fields: _*) }
+
+  def struct_field: Parser[(String, Type)] =
+    (identifier <~ ":") ~ type_expr ^^ { case name ~ t =>
+      (name, t)
+    }
+
+  def struct_fields: Parser[Array[(String, Type)]] = rep1sep(struct_field, ",") ^^ { _.toArray }
+
+  def type_expr: Parser[Type] =
+    "Empty" ^^ { _ => TEmpty } |
+      "Boolean" ^^ { _ => TBoolean } |
+      "Char" ^^ { _ => TChar } |
+      "Int" ^^ { _ => TInt } |
+      "Long" ^^ { _ => TLong } |
+      "Float" ^^ { _ => TFloat } |
+      "Double" ^^ { _ => TDouble } |
+      "String" ^^ { _ => TString } |
+      "Sample" ^^ { _ => TSample } |
+      "AltAllele" ^^ { _ => TAltAllele } |
+      "Variant" ^^ { _ => TVariant } |
+      "Genotype" ^^ { _ => TGenotype } |
+      "String" ^^ { _ => TString } |
+      ("Array" ~ "[") ~> type_expr <~ "]" ^^ { elementType => TArray(elementType) } |
+      ("Struct" ~ "(") ~> struct_fields <~ ")" ^^ { fields =>
+        TStruct(fields: _*)
+      }
 }

--- a/src/main/scala/org/broadinstitute/hail/io/annotators/SampleTSVAnnotator.scala
+++ b/src/main/scala/org/broadinstitute/hail/io/annotators/SampleTSVAnnotator.scala
@@ -4,13 +4,13 @@ import org.apache.hadoop
 import org.apache.spark.sql.Row
 import org.broadinstitute.hail.Utils._
 import org.broadinstitute.hail.annotations._
-import org.broadinstitute.hail.expr
+import org.broadinstitute.hail.expr._
 
 import scala.collection.mutable
 
 object SampleTSVAnnotator extends TSVAnnotator {
-  def apply(filename: String, sampleCol: String, typeMap: Map[String, String], missing: String,
-    hConf: hadoop.conf.Configuration): (Map[String, Annotation], expr.Type) = {
+  def apply(filename: String, sampleCol: String, declaredSig: Map[String, Type], missing: String,
+    hConf: hadoop.conf.Configuration): (Map[String, Annotation], Type) = {
     readLines(filename, hConf) { lines =>
       fatalIf(lines.isEmpty, "empty TSV file")
 
@@ -19,28 +19,26 @@ object SampleTSVAnnotator extends TSVAnnotator {
 
       val sampleIndex = split.indexOf(sampleCol)
       fatalIf(sampleIndex < 0, s"Could not find designated sample column id '$sampleCol")
-      typeMap.foreach { case (id, t) =>
+      declaredSig.foreach { case (id, t) =>
         if (!split.contains(id))
           warn(s"""found "$id" in type map but not in TSV header """)
       }
 
-      val orderedSignatures: Array[(String, Option[expr.Type])] = split.map { s =>
-        if (s != sampleCol)
-          (s, Some(parseStringType(typeMap.getOrElse(s, "String"))))
-        else
+      val orderedSignatures: Array[(String, Option[Type])] = split.map { s =>
+        if (s != sampleCol) {
+          val t = declaredSig.getOrElse(s, TString)
+          if (!t.isInstanceOf[Parsable])
+            fatal(
+              s"Unsupported type $t in TSV annotation.  Supported types: Boolean, Int, Long, Float, Double and String.")
+          (s, Some(t))
+        } else
           (s, None)
       }
 
-      val signature = expr.TStruct(
+      val signature = TStruct(
         orderedSignatures.flatMap { case (key, o) =>
-          o match {
-            case Some(sig) => Some(key, sig)
-            case None => None
-          }
-        }
-          .zipWithIndex
-          .map { case ((key, t), i) => expr.Field(key, t, i) }
-      )
+          o.map(sig => (key, sig))
+        }: _*)
 
       val functions = buildParsers(missing, orderedSignatures)
 

--- a/src/main/scala/org/broadinstitute/hail/io/annotators/TSVAnnotator.scala
+++ b/src/main/scala/org/broadinstitute/hail/io/annotators/TSVAnnotator.scala
@@ -2,34 +2,14 @@ package org.broadinstitute.hail.io.annotators
 
 import org.broadinstitute.hail.Utils._
 import org.broadinstitute.hail.annotations._
-import org.broadinstitute.hail.expr
+import org.broadinstitute.hail.expr._
 
 import scala.collection.mutable
 
 trait TSVAnnotator {
-  def parseStringType(s: String): expr.Type = {
-    s match {
-      case "Float" => expr.TFloat
-      case "Double" => expr.TDouble
-      case "Int" => expr.TInt
-      case "Long" => expr.TLong
-      case "Boolean" => expr.TBoolean
-      case "String" => expr.TString
-      case _ => fatal(
-        s"""Unrecognized type "$s".  Hail supports parsing the following types in annotations:
-            |  - Float (4-byte floating point number)
-            |  - Double (8-byte floating point number)
-            |  - Int (4-byte integer)
-            |  - Long (8-byte integer)
-            |  - Boolean
-            |  - String
-            |
-             |  Note that the above types are case sensitive.""".stripMargin)
-    }
-  }
 
   def buildParsers(missing: String,
-    namesAndTypes: Array[(String, Option[expr.Type])]): Array[(mutable.ArrayBuilder[Annotation], String) => Unit] = {
+    namesAndTypes: Array[(String, Option[Type])]): Array[(mutable.ArrayBuilder[Annotation], String) => Unit] = {
     namesAndTypes.map {
       case (head, ot) =>
         ot match {
@@ -37,15 +17,15 @@ trait TSVAnnotator {
             if (s == missing) {
               ab += null: Annotation
               ()
-            }
-            else
+            } else {
               try {
-                ab += t.parse(s)
+                ab += t.asInstanceOf[Parsable].parse(s)
                 ()
               } catch {
                 case e: Exception =>
                   fatal(s"""${e.getClass.getName}: tried to convert "$s" to $t in column "$head" """)
               }
+            }
           }
           case None => (ab: mutable.ArrayBuilder[Annotation], s: String) => ()
         }

--- a/src/main/scala/org/broadinstitute/hail/vcf/HtsjdkRecordReader.scala
+++ b/src/main/scala/org/broadinstitute/hail/vcf/HtsjdkRecordReader.scala
@@ -28,7 +28,8 @@ class HtsjdkRecordReader(codec: htsjdk.variant.vcf.VCFCodec) extends Serializabl
   def readRecord(reportAcc: Accumulable[mutable.Map[Int, Int], Int],
     line: String,
     infoSignature: TStruct,
-    storeGQ: Boolean): (Variant, Annotation, Iterable[Genotype]) = {
+    storeGQ: Boolean,
+    skipGenotypes: Boolean): (Variant, Annotation, Iterable[Genotype]) = {
     val vc = codec.decode(line)
 
     val pass = vc.filtersWereApplied() && vc.getFilters.isEmpty
@@ -69,6 +70,9 @@ class HtsjdkRecordReader(codec: htsjdk.variant.vcf.VCFCodec) extends Serializabl
       filters,
       pass,
       info)
+
+    if (skipGenotypes)
+      return (v, va, Iterable.empty)
 
     val gb = new GenotypeBuilder(v)
 


### PR DESCRIPTION
```
Lots of local cleanups.
Use `' for quoting inside error messages.
Added SuperCommand, ToplevelCommands.  Use for annotatevariants and annotatesamples.
Try to make multiple instances of (essentially) same error message consistent.
Added option to LoadVCF, ImportVCF to skip genotypes.  Use in importannotations.
Fixed some bugs in FatalException handling.
Moved Type.parse to trait Parsable.
Added Parser.parseAnnotationTypes.
Added `type_expr' non-terminal to Parser.
Prefer `import ...expr._' to `import ...expr' and `expr.Foo'.
```
