### PR TITLE
Reworked AnnotateSamplesTSV.parseRoot and AnnotateVariantsTSV.parseRo…

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/annotations/Annotation.scala
+++ b/src/main/scala/org/broadinstitute/hail/annotations/Annotation.scala
@@ -4,6 +4,10 @@ import org.apache.spark.sql.Row
 
 object Annotation {
 
+  final val SAMPLE_HEAD = "sa"
+
+  final val VARIANT_HEAD = "va"
+
   def empty: Annotation = null
 
   def emptyIndexedSeq(n: Int): IndexedSeq[Annotation] = IndexedSeq.fill[Annotation](n)(null)

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateSamplesTSV.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateSamplesTSV.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.hail.driver
 
 import org.broadinstitute.hail.Utils._
+import org.broadinstitute.hail.annotations.Annotation
 import org.broadinstitute.hail.expr._
 import org.broadinstitute.hail.io.annotators.SampleTSVAnnotator
 import org.kohsuke.args4j.{Option => Args4jOption}
@@ -37,12 +38,6 @@ object AnnotateSamplesTSV extends Command {
 
   override def supportsMultiallelic = true
 
-  def parseRoot(s: String): List[String] = {
-    val split = s.split("\\.").toList
-    fatalIf(split.isEmpty || split.head != "sa", s"Root must start with `sa.', got `$s'")
-    split.tail
-  }
-
   def run(state: State, options: Options): State = {
     val vds = state.vds
 
@@ -52,7 +47,8 @@ object AnnotateSamplesTSV extends Command {
       Parser.parseAnnotationTypes(options.types),
       options.missing,
       state.hadoopConf)
-    val annotated = vds.annotateSamples(m, signature, parseRoot(options.root))
+    val annotated = vds.annotateSamples(m, signature,
+      Parser.parseAnnotationRoot(options.root, Annotation.SAMPLE_HEAD))
     state.copy(vds = annotated)
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsBed.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsBed.scala
@@ -1,5 +1,7 @@
 package org.broadinstitute.hail.driver
 
+import org.broadinstitute.hail.annotations.Annotation
+import org.broadinstitute.hail.expr._
 import org.broadinstitute.hail.io.annotators._
 import org.kohsuke.args4j.{Option => Args4jOption}
 
@@ -24,6 +26,7 @@ object AnnotateVariantsBed extends Command {
   def run(state: State, options: Options): State = {
     val (iList, signature) = BedAnnotator(options.input, state.hadoopConf)
     state.copy(
-      vds = state.vds.annotateInvervals(iList, signature, AnnotateVariantsTSV.parseRoot(options.root)))
+      vds = state.vds.annotateInvervals(iList, signature,
+        Parser.parseAnnotationRoot(options.root, Annotation.VARIANT_HEAD)))
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsIList.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsIList.scala
@@ -1,6 +1,8 @@
 package org.broadinstitute.hail.driver
 
 import org.broadinstitute.hail.io.annotators._
+import org.broadinstitute.hail.annotations.Annotation
+import org.broadinstitute.hail.expr._
 import org.kohsuke.args4j.{Option => Args4jOption}
 
 object AnnotateVariantsIList extends Command {
@@ -24,7 +26,8 @@ object AnnotateVariantsIList extends Command {
   def run(state: State, options: Options): State = {
     val vds = state.vds
     val (iList, signature) = IntervalListAnnotator(options.input, state.hadoopConf)
-    val annotated = vds.annotateInvervals(iList, signature, AnnotateVariantsTSV.parseRoot(options.root))
+    val annotated = vds.annotateInvervals(iList, signature,
+      Parser.parseAnnotationRoot(options.root, Annotation.VARIANT_HEAD))
     state.copy(vds = annotated)
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsTSV.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsTSV.scala
@@ -1,9 +1,11 @@
 package org.broadinstitute.hail.driver
 
 import org.broadinstitute.hail.Utils._
+import org.broadinstitute.hail.annotations.Annotation
 import org.broadinstitute.hail.expr._
 import org.broadinstitute.hail.io.annotators._
 import org.kohsuke.args4j.{Argument, Option => Args4jOption}
+
 import scala.collection.JavaConverters._
 
 object AnnotateVariantsTSV extends Command {
@@ -45,12 +47,6 @@ object AnnotateVariantsTSV extends Command {
     split
   }
 
-  def parseRoot(s: String): List[String] = {
-    val split = s.split("\\.").toList
-    fatalIf(split.isEmpty || split.head != "va", s"Root must start with `va.', got `$s'")
-    split.tail
-  }
-
   def run(state: State, options: Options): State = {
 
     val files = hadoopGlobAll(options.arguments.asScala, state.hadoopConf)
@@ -60,7 +56,8 @@ object AnnotateVariantsTSV extends Command {
       parseColumns(options.vCols),
       Parser.parseAnnotationTypes(options.types),
       options.missingIdentifier)
-    val annotated = vds.annotateVariants(rdd, signature, parseRoot(options.root))
+    val annotated = vds.annotateVariants(rdd, signature,
+      Parser.parseAnnotationRoot(options.root, Annotation.VARIANT_HEAD))
 
     state.copy(vds = annotated)
   }

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsVCF.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsVCF.scala
@@ -1,7 +1,8 @@
 package org.broadinstitute.hail.driver
 
-import org.broadinstitute.hail.Utils._
 import org.broadinstitute.hail.methods.LoadVCF
+import org.broadinstitute.hail.expr._
+import org.broadinstitute.hail.annotations.Annotation
 import scala.collection.JavaConverters._
 import org.kohsuke.args4j.{Argument, Option => Args4jOption}
 
@@ -36,7 +37,7 @@ object AnnotateVariantsVCF extends Command with VCFImporter {
     val otherVdsSplit = SplitMulti.run(state.copy(vds = otherVds)).vds
 
     val annotated = vds.annotateVariants(otherVdsSplit.variantsAndAnnotations, otherVdsSplit.vaSignature,
-      AnnotateVariantsTSV.parseRoot(options.root))
+      Parser.parseAnnotationRoot(options.root, Annotation.VARIANT_HEAD))
     state.copy(vds = annotated)
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsVDS.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsVDS.scala
@@ -1,7 +1,8 @@
 package org.broadinstitute.hail.driver
 
 import org.broadinstitute.hail.Utils._
-import org.broadinstitute.hail.io.annotators._
+import org.broadinstitute.hail.annotations.Annotation
+import org.broadinstitute.hail.expr._
 import org.kohsuke.args4j.{Option => Args4jOption}
 
 object AnnotateVariantsVDS extends Command {
@@ -34,7 +35,7 @@ object AnnotateVariantsVDS extends Command {
 
     val (rdd, signature) =(readOtherVds.variantsAndAnnotations, readOtherVds.vaSignature)
     val annotated = vds.annotateVariants(readOtherVds.variantsAndAnnotations,
-      readOtherVds.vaSignature, AnnotateVariantsTSV.parseRoot(options.root))
+      readOtherVds.vaSignature, Parser.parseAnnotationRoot(options.root, Annotation.VARIANT_HEAD))
     state.copy(vds = annotated)
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
@@ -435,6 +435,7 @@ class VariantSampleMatrix[T](val metadata: VariantMetadata,
 
   def annotateSamples(annotations: Map[String, Annotation], signature: Type,
     path: List[String]): VariantSampleMatrix[T] = {
+
     val (newSignature, inserter) = insertSA(signature, path)
 
     val newAnnotations = sampleIds.zipWithIndex.map { case (id, i) =>

--- a/src/test/scala/org/broadinstitute/hail/methods/ImportAnnotationsSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/ImportAnnotationsSuite.scala
@@ -34,10 +34,10 @@ class ImportAnnotationsSuite extends SparkSuite {
     }
 
     val anno1 = AnnotateSamples.run(state,
-      Array("tsv", "-i", "src/test/resources/sampleAnnotations.tsv", "-s", "Sample", "-r", "sa.phenotype", "-t", "qPhen:Int"))
+      Array("tsv", "-i", "src/test/resources/sampleAnnotations.tsv", "-s", "Sample", "-r", "sa.`my phenotype`", "-t", "qPhen:Int"))
 
-    val q1 = anno1.vds.querySA("phenotype", "Status")
-    val q2 = anno1.vds.querySA("phenotype", "qPhen")
+    val q1 = anno1.vds.querySA("my phenotype", "Status")
+    val q2 = anno1.vds.querySA("my phenotype", "qPhen")
 
     anno1.vds.metadata.sampleIds.zip(anno1.vds.metadata.sampleAnnotations)
       .forall {


### PR DESCRIPTION
…ot to use the parser.  This allows us to use backticks in these identifiers as everywhere else
