### PR TITLE
Fixing bug introduced in ImportFam merge, whereby TypeWithSchema wasn…

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateSamplesFam.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateSamplesFam.scala
@@ -1,7 +1,9 @@
 package org.broadinstitute.hail.driver
 
 import org.broadinstitute.hail.Utils._
-import org.broadinstitute.hail.io.annotators.{SampleFamAnnotator, SampleTSVAnnotator}
+import org.broadinstitute.hail.annotations.Annotation
+import org.broadinstitute.hail.expr.Parser
+import org.broadinstitute.hail.io.annotators.SampleFamAnnotator
 import org.kohsuke.args4j.{Option => Args4jOption}
 
 object AnnotateSamplesFam extends Command {
@@ -47,7 +49,7 @@ object AnnotateSamplesFam extends Command {
     val isQuantitative = options.isQuantitative
 
     val (m, signature) = SampleFamAnnotator(input, delimiter, isQuantitative, options.missing, state.hadoopConf)
-    val annotated = vds.annotateSamples(m, signature, AnnotateSamplesTSV.parseRoot(options.root))
+    val annotated = vds.annotateSamples(m, signature, Parser.parseAnnotationRoot(options.root, Annotation.SAMPLE_HEAD))
     state.copy(vds = annotated)
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/io/annotators/SampleFamAnnotator.scala
+++ b/src/main/scala/org/broadinstitute/hail/io/annotators/SampleFamAnnotator.scala
@@ -12,7 +12,7 @@ object SampleFamAnnotator {
   val numericRegex = """^-?(?:\d+|\d*\.\d+)(?:[eE]-?\d+)?$""".r
 
   def apply(filename: String, delimiter: String, isQuantitative: Boolean, missing: String,
-    hConf: hadoop.conf.Configuration): (Map[String, Annotation], TypeWithSchema) = {
+    hConf: hadoop.conf.Configuration): (Map[String, Annotation], Type) = {
     readLines(filename, hConf) { lines =>
       fatalIf(lines.isEmpty, "Empty .fam file")
 

--- a/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
@@ -394,7 +394,7 @@ class VariantSampleMatrix[T](val metadata: VariantMetadata,
         }.fold(true)(_ && _)
   }
 
-  def mapAnnotationsWithAggregate[U](zeroValue: U, newVAS: TypeWithSchema)(
+  def mapAnnotationsWithAggregate[U](zeroValue: U, newVAS: Type)(
     seqOp: (U, Variant, Int, T) => U,
     combOp: (U, U) => U,
     mapOp: (Annotation, U) => Annotation)


### PR DESCRIPTION
…'t reverted to Type.  Also, using now using Parser.parseAnnotationRoot to parse root.
