### PR TITLE
Added global functionality and command name rework

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,8 @@
+ - added `annotateglobal table` which reads a text file with a header and stores it as an `Array[Struct]`.  [see docs for details](docs/ImportAnnotations.md#GlobalTable)
+
+ - renamed all `tsv` modules to `table`.  We support arbitrary delimiters, so the name should be more general
+
+____
 
  - split `annotateglobal` into `annotateglobal expr` and `annotateglobal list`.  The latter can be used to load a text file as an `Array[String]` or `Set[String]` to the global annotations, which can then be used to do things like `filtervariants expr` on genes in a gene list.
  

--- a/docs/ImportAnnotations.md
+++ b/docs/ImportAnnotations.md
@@ -8,7 +8,7 @@ Hail includes modules for importing annotations from external files, for use in 
 Each of these modules has multiple run modes, which are specified with the first word after the command invocation.  Examples:
 
 ```
-<...> annotatesamples tsv <args>
+<...> annotatesamples table <args>
 ```
 
 ```
@@ -22,25 +22,25 @@ Each of these modules has multiple run modes, which are specified with the first
 ## Annotating Samples
 
 Hail currently supports annotating samples from:
- - [tsv files](#SampleTSV)
+ - [text tables](#SampleTable)
  - [programmatic commands](#SampleProg)
  - [Plink .fam files](#Fam)
 
 ____
 
-<a name="SampleTSV"></a>
-### Tab separated values (.tsv[.gz])
+<a name="SampleTable"></a>
+### Text tables
 
-This file format requires one column containing sample IDs, and each other column will be written to sample annotations.
+This module expects a text file with multiple delimited columns (default: tab-delimited).  One of these columns must contain sample IDs, and each other column will be written to sample annotations.
 
 **Command line arguments:**
 
-- `tsv` Invoke this functionality (`annotatesamples tsv <args>`)
-- `-i | --input <path-to-tsv>` specify the file path **(Required)**
-- `-r | --root <root>` specify the annotation path in which to place the fields read from the TSV, as a period-delimited path starting with `sa` **(Required)**
+- `table` Invoke this functionality (`annotatesamples table <args>`)
+- `-i | --input <path-to-file>` specify the file path **(Required)**
+- `-r | --root <root>` specify the annotation path in which to place the fields read from the file, as a period-delimited path starting with `sa` **(Required)**
 - `-s | --sampleheader <id>` specify the name of the column containing sample IDs **(Optional with default "Sample")**
 - `-t | --types <typestring>` specify data types of fields, in a comma-delimited string of `name: Type` elements.  **If a field is not found in this type map, it will be read and stored as a string** **(Optional)**
-- `-m | --missing <missings>` specify identifiers to be treated as missing, in a comma-separated list **(Optional with default "NA")**
+- `-m | --missing <missing-value>` specify identifiers to be treated as missing, in a comma-separated list **(Optional with default "NA")**
 
 ____
 
@@ -61,13 +61,13 @@ To annotate from this file, one must a) specify where to put it in sample annota
 
 ```
 $ hail [read / import / previous commands] \
-    annotatesamples tsv \
+    annotatesamples table \
         -i file:///user/me/samples.tsv \
         -t "Phenotype1: Double, Age: Int" \
         -r sa.phenotypes
 ```
 
-   This will read the tsv and produce annotations of the following schema:
+   This will read the file and produce annotations of the following schema:
 
 ```
 Sample annotations:
@@ -99,7 +99,7 @@ This file does not have non-string types, but it does have a sample column ident
 
 ```
 $ hail [read / import, previous commands] \
-    annotatesamples tsv \
+    annotatesamples table \
         -i file:///user/me/samples2.tsv \
         -s PT-ID \
         --missing "." \
@@ -112,7 +112,8 @@ ____
 <a name="SampleProg"></a>
 ### Programmatic Annotation
 
-Programmatic annotation means computing new annotations from the existing exposed data structures, which in this case are the sample (`s`), the sample annotations (`sa`), and the global annotation (`global`).
+Programmatic annotation means computing new annotations from the existing exposed data structures, which in this case are the sample (`s`), the sample annotations (`sa`), an
+d the global annotation (`global`).
 
 **Command line arguments:**
 
@@ -165,7 +166,7 @@ ____
 ## Annotating Variants
 
 Hail currently supports annotating variants from seven sources:
- - [TSV files](#VariantTSV)
+ - [Text tables](#VariantTable)
  - [interval list files](#IntervalList)
  - [UCSC bed files](#UCSCBed)
  - [VCFs (info field, filters, qual)](#VCF)
@@ -174,19 +175,19 @@ Hail currently supports annotating variants from seven sources:
 
 ____
 
-<a name="VariantTSV"></a>
-### Tab separated values (tsv[.gz])
+<a name="VariantTable"></a>
+### Text tables
 
-This file format requires either one column of the format "Chr:Pos:Ref:Alt", or four columns (one for each of these fields).  All other columns will be written to variant annotations.  Multiple files can be read in one command, but they must agree in their file format.
+This module expects text files with multiple delimited columns (default: tab-delimited).  Variants are keyed either by one column of the format "Chr:Pos:Ref:Alt", or four columns (one for each of these fields).  All other columns will be written to variant annotations as a struct.  Multiple files can be read in one command, but they must agree in their file format.
 
 **Command line arguments:**
 
-- `tsv` Invoke this functionality (`annotatevariants tsv <args>`)
+- `table` Invoke this functionality (`annotatevariants table <args>`)
 - `<files...>` specify the file or files to be read **(Required)**
-- `-r | --root <root>` specify the annotation path in which to place the fields read from the TSV, as a period-delimited path starting with `va` **(Required)**
+- `-r | --root <root>` specify the annotation path in which to place the fields read from the file, as a period-delimited path starting with `va` **(Required)**
 - `-v | --vcolumns <variantcols>` Either one column name (if Chr:Pos:Ref:Alt), or four comma-separated column identifiers **(Optional with default "Chromosome, Position, Ref, Alt")**
 - `-t | --types <typestring>` specify data types of fields, in a comma-delimited string of `name: Type` elements.  If a field is not found in this type map, it will be read and stored as a string **(Optional)**
-- `-m | --missing <missings>` specify identifiers to be treated as missing, in a comma-separated list **(Optional with default "NA")**
+- `-m | --missing <missing-value>` specify identifiers to be treated as missing, in a comma-separated list **(Optional with default "NA")**
 
 ____
 
@@ -205,7 +206,7 @@ This file contains one field to identify the variant and two data columns: one w
 
 ```
 $ hail [read / import / previous commands] \
-    annotatevariants tsv \
+    annotatevariants table \
         file:///user/me/consequences.tsv.gz \
         -t "DNAseSensitivity: Double" \
         -r va.varianteffects \
@@ -240,7 +241,7 @@ In this case, the variant is indicated by four columns, but the header does not 
 
 ```
 $ hail [read / import / previous commands] \
-    annotatevariants tsv \
+    annotatevariants table \
         file:///user/me/ExAC_Counts.tsv.gz \
         -t "AC: Int" \
         -r va.exac \
@@ -554,7 +555,7 @@ ____
 ## Annotating global variables
 
 Hail currently supports annotating the global annotation table from two sources:
- - [Text files](#GlobalList)
+ - Text files, both [lists](#GlobalList) and [tables](#GlobalTable)
  - [Programmatic commands](#GlobalProg)
 
 ____
@@ -562,7 +563,7 @@ ____
 <a name="GlobalList"></a>
 ### Text lists
 
-It is possible to add global annotations from text files.  A file is read into the global table at the specified path as either an array or a set of strings.
+This module imports a text file "as-is", as either an `Array[String]` (where order and duplicates are kept) or a `Set[String]` (containing only unique values, good for assessing membership with `contains`).  If read as an array, the 
 
 **Command line arguments:**
 
@@ -573,7 +574,9 @@ It is possible to add global annotations from text files.  A file is read into t
 
 ____
 
-**Example1**
+**Example**
+
+```
 $ cat /tmp/genes.txt
 SCN2A
 SONIC-HEDGEHOG
@@ -584,6 +587,97 @@ OSM
 TSC1
 TSC2
 
+$ hail 
+    read -i file.vds \ 
+    annotateglobal list -i /tmp/genes.txt -r global.genes \
+    printschema --global \
+    showglobals
+    
+          
+hail: info: running: read -i ../data/profile.vds/   
+hail: info: running: annotateglobal list -i /tmp/genes.txt -r global.genes
+hail: info: running: printschema --global    
+   Global annotation schema:
+   global: Struct {
+       genes: Array[String]
+   }
+hail: info: running: showglobals
+   Global annotations: `global' = {
+     "genes" : [ "SCN2A", "SONIC-HEDGEHOG", "PRNP", "ALDH4A1", "LEP", "OSM", "TSC1", "TSC2" ]
+   }
+```
+
+____
+
+<a name="GlobalTable"></a>
+### Text tables
+
+This module imports a text file with multiple columns as an `Array[Struct]`.  The usability of this module mimics the `annotatesamples table` module ([link here](#SampleTable))
+
+**Command line arguments:**
+
+- `table` Invoke this functionality (`annotateglobal table <args>`)
+- `-i | --input <path-to-file>` specify the file path **(Required)**
+- `-r | --root <root>` specify the annotation path in which to place the fields read from the file, as a period-delimited path starting with `global` **(Required)**
+- `-t | --types <typestring>` specify data types of fields, in a comma-delimited string of `name: Type` elements.  **If a field is not found in this type map, it will be read and stored as a string** **(Optional)**
+- `-m | --missing <missing-value>` specify identifiers to be treated as missing, in a comma-separated list **(Optional with default "NA")**
+ 
+**Example**
+
+```
+$ cat /tmp/file1.txt
+GENE    PLI     EXAC_LOF_COUNT
+Gene1   0.12312 2
+Gene2   0.99123 0
+Gene3   NA      NA
+Gene4   0.9123  10
+Gene5   0.0001  202
+
+$ hail read -i ../data/profile.vds/ \
+    annotateglobal table -i /tmp/file1.txt -r global.genes -t "PLI: Double, EXAC_LOF_COUNT: Int" \
+    printschema --global \
+    showglobals
+    
+    
+hail: info: running: read -i ../data/profile.vds/
+hail: info: running: annotateglobal table -i /tmp/file1.txt -r global.genes -t 'PLI: Double, EXAC_LOF_COUNT: Int'
+hail: info: running: printschema --global
+Global annotation schema:
+global: Struct {
+    genes: Array[Struct {
+        GENE: String,
+        PLI: Double,
+        EXAC_LOF_COUNT: Int
+    }]
+}
+
+hail: info: running: showglobals
+Global annotations: `global' = {
+  "genes" : [ {
+    "GENE" : "Gene1",
+    "PLI" : 0.12312,
+    "EXAC_LOF_COUNT" : 2
+  }, {
+    "GENE" : "Gene2",
+    "PLI" : 0.99123,
+    "EXAC_LOF_COUNT" : 0
+  }, {
+    "GENE" : "Gene3",
+    "PLI" : null,
+    "EXAC_LOF_COUNT" : null
+  }, {
+    "GENE" : "Gene4",
+    "PLI" : 0.9123,
+    "EXAC_LOF_COUNT" : 10
+  }, {
+    "GENE" : "Gene5",
+    "PLI" : 1.0E-4,
+    "EXAC_LOF_COUNT" : 202
+  } ]
+}
+```
+
+____
 
 <a name="GlobalProg"></a>
 ### Programmatic Annotation

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateGlobal.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateGlobal.scala
@@ -12,4 +12,5 @@ object AnnotateGlobal extends SuperCommand {
 
   register(AnnotateGlobalExpr)
   register(AnnotateGlobalList)
+  register(AnnotateGlobalTable)
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateGlobalTable.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateGlobalTable.scala
@@ -1,0 +1,56 @@
+package org.broadinstitute.hail.driver
+
+import org.broadinstitute.hail.annotations.Annotation
+import org.broadinstitute.hail.expr._
+import org.broadinstitute.hail.io.annotators.GlobalTableAnnotator
+import org.kohsuke.args4j.{Option => Args4jOption}
+
+object AnnotateGlobalTable extends Command {
+
+  class Options extends BaseOptions {
+    @Args4jOption(required = true, name = "-i", aliases = Array("--input"),
+      usage = "Path to file")
+    var input: String = _
+
+    @Args4jOption(required = false, name = "-t", aliases = Array("--types"),
+      usage = "Define types of fields in file")
+    var types: String = ""
+
+    @Args4jOption(required = true, name = "-r", aliases = Array("--root"),
+      usage = "Argument is a period-delimited path starting with `global'")
+    var root: String = _
+
+    @Args4jOption(required = false, name = "-m", aliases = Array("--missing"),
+      usage = "Specify identifier to be treated as missing")
+    var missing: String = "NA"
+
+    @Args4jOption(required = false, name = "-d", aliases = Array("--delimiter"),
+      usage = "Field delimiter regex")
+    var delimiter: String = "\\t"
+  }
+
+  def newOptions = new Options
+
+  def name = "annotateglobal table"
+
+  def description = "Annotate global table from a text file with multiple columns"
+
+  override def supportsMultiallelic = true
+
+  def run(state: State, options: Options): State = {
+    val vds = state.vds
+
+    val path = Parser.parseAnnotationRoot(options.root, Annotation.GLOBAL_HEAD)
+
+    val (result, signature) = GlobalTableAnnotator(options.input, state.hadoopConf,
+      Parser.parseAnnotationTypes(options.types), options.missing, options.delimiter)
+
+
+    val (newGlobalSig, inserter) = vds.insertGlobal(signature, path)
+
+    state.copy(vds = vds.copy(
+      globalAnnotation = inserter(vds.globalAnnotation, Some(result)),
+      globalSignature = newGlobalSig))
+  }
+}
+

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateSamples.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateSamples.scala
@@ -7,5 +7,5 @@ object AnnotateSamples extends SuperCommand {
 
   register(AnnotateSamplesExpr)
   register(AnnotateSamplesFam)
-  register(AnnotateSamplesTSV)
+  register(AnnotateSamplesTable)
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateSamplesTable.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateSamplesTable.scala
@@ -2,10 +2,10 @@ package org.broadinstitute.hail.driver
 
 import org.broadinstitute.hail.annotations.Annotation
 import org.broadinstitute.hail.expr._
-import org.broadinstitute.hail.io.annotators.SampleTSVAnnotator
+import org.broadinstitute.hail.io.annotators.SampleTableAnnotator
 import org.kohsuke.args4j.{Option => Args4jOption}
 
-object AnnotateSamplesTSV extends Command {
+object AnnotateSamplesTable extends Command {
 
   class Options extends BaseOptions {
     @Args4jOption(required = true, name = "-i", aliases = Array("--input"),
@@ -35,9 +35,9 @@ object AnnotateSamplesTSV extends Command {
 
   def newOptions = new Options
 
-  def name = "annotatesamples tsv"
+  def name = "annotatesamples table"
 
-  def description = "Annotate samples with TSV file"
+  def description = "Annotate samples with a text table"
 
   override def supportsMultiallelic = true
 
@@ -46,7 +46,7 @@ object AnnotateSamplesTSV extends Command {
 
     val input = options.input
 
-    val (m, signature) = SampleTSVAnnotator(input, options.sampleCol,
+    val (m, signature) = SampleTableAnnotator(input, options.sampleCol,
       Parser.parseAnnotationTypes(options.types),
       options.missing,
       state.hadoopConf, options.delimiter)

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariants.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariants.scala
@@ -13,7 +13,7 @@ object AnnotateVariants extends SuperCommand {
   register(AnnotateVariantsBed)
   register(AnnotateVariantsExpr)
   register(AnnotateVariantsIntervals)
-  register(AnnotateVariantsTSV)
+  register(AnnotateVariantsTable)
   register(AnnotateVariantsVCF)
   register(AnnotateVariantsVDS)
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsTable.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsTable.scala
@@ -8,7 +8,7 @@ import org.kohsuke.args4j.{Argument, Option => Args4jOption}
 
 import scala.collection.JavaConverters._
 
-object AnnotateVariantsTSV extends Command {
+object AnnotateVariantsTable extends Command {
 
   class Options extends BaseOptions {
     @Args4jOption(required = false, name = "-t", aliases = Array("--types"),
@@ -38,7 +38,7 @@ object AnnotateVariantsTSV extends Command {
 
   def newOptions = new Options
 
-  def name = "annotatevariants tsv"
+  def name = "annotatevariants table"
 
   def description = "Annotate variants with TSV file"
 
@@ -57,7 +57,7 @@ object AnnotateVariantsTSV extends Command {
     val files = hadoopGlobAll(options.arguments.asScala, state.hadoopConf)
 
     val vds = state.vds
-    val (rdd, signature) = VariantTSVAnnotator(vds.sparkContext, files,
+    val (rdd, signature) = VariantTableAnnotator(vds.sparkContext, files,
       parseColumns(options.vCols),
       Parser.parseAnnotationTypes(options.types),
       options.missingIdentifier, options.delimiter)

--- a/src/main/scala/org/broadinstitute/hail/driver/ImportAnnotations.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/ImportAnnotations.scala
@@ -44,9 +44,9 @@ object ImportAnnotations extends Command {
     if (files.isEmpty)
       fatal("Arguments referred to no files")
 
-    val (rdd, signature) = VariantTSVAnnotator(state.sc,
+    val (rdd, signature) = VariantTableAnnotator(state.sc,
       files,
-      AnnotateVariantsTSV.parseColumns(options.vCols),
+      AnnotateVariantsTable.parseColumns(options.vCols),
       Parser.parseAnnotationTypes(options.types),
       options.missingIdentifier, options.delimiter)
 

--- a/src/main/scala/org/broadinstitute/hail/io/annotators/SampleTableAnnotator.scala
+++ b/src/main/scala/org/broadinstitute/hail/io/annotators/SampleTableAnnotator.scala
@@ -1,0 +1,66 @@
+package org.broadinstitute.hail.io.annotators
+
+import org.apache.hadoop
+import org.apache.spark.sql.Row
+import org.broadinstitute.hail.Utils._
+import org.broadinstitute.hail.annotations._
+import org.broadinstitute.hail.expr._
+
+import scala.collection.mutable
+
+object SampleTableAnnotator extends TSVAnnotator {
+  def apply(filename: String, sampleCol: String, declaredSig: Map[String, Type], missing: String,
+    hConf: hadoop.conf.Configuration, delim: String): (Map[String, Annotation], Type) = {
+    readLines(filename, hConf) { lines =>
+      if (lines.isEmpty)
+        fatal("empty TSV file")
+
+      val delimiter = unescapeString(delim)
+
+      val header = lines.next().value
+      val split = header.split(delimiter)
+
+      val sampleIndex = split.indexOf(sampleCol)
+      if (sampleIndex < 0)
+        fatal(s"Could not find designated sample column id '$sampleCol")
+      declaredSig.foreach { case (id, t) =>
+        if (!split.contains(id))
+          warn(s"""found "$id" in type map but not in TSV header """)
+      }
+
+      val orderedSignatures: Array[(String, Option[Type])] = split.map { s =>
+        if (s != sampleCol) {
+          val t = declaredSig.getOrElse(s, TString)
+          if (!t.isInstanceOf[Parsable])
+            fatal(
+              s"Unsupported type $t in TSV annotation.  Supported types: Boolean, Int, Long, Float, Double and String.")
+          (s, Some(t))
+        } else
+          (s, None)
+      }
+
+      val signature = TStruct(
+        orderedSignatures.flatMap { case (key, o) =>
+          o.map(sig => (key, sig))
+        }: _*)
+
+      val functions = buildParsers(missing, orderedSignatures)
+
+      val ab = mutable.ArrayBuilder.make[Any]
+      val m = lines.map {
+        _.transform { l =>
+          val lineSplit = l.value.split(delimiter)
+          if (lineSplit.length != split.length)
+            fatal(s"expected ${split.length} fields, but got ${lineSplit.length}")
+          val sample = lineSplit(sampleIndex)
+          ab.clear()
+          lineSplit.iterator.zip(functions.iterator)
+            .foreach { case (field, fn) => fn(ab, field) }
+          (sample, Row.fromSeq(ab.result()))
+        }
+      }
+        .toMap
+      (m, signature)
+    }
+  }
+}

--- a/src/main/scala/org/broadinstitute/hail/io/annotators/VariantTableAnnotator.scala
+++ b/src/main/scala/org/broadinstitute/hail/io/annotators/VariantTableAnnotator.scala
@@ -10,7 +10,7 @@ import org.broadinstitute.hail.variant.Variant
 
 import scala.collection.mutable
 
-object VariantTSVAnnotator extends TSVAnnotator {
+object VariantTableAnnotator extends TSVAnnotator {
   def apply(sc: SparkContext, files: Array[String], vColumns: Array[String], declaredSig: Map[String, Type],
     missing: String, delim: String): (RDD[(Variant, Annotation)], Type) = {
 

--- a/src/test/scala/org/broadinstitute/hail/driver/example/CaseControlCountSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/driver/example/CaseControlCountSuite.scala
@@ -8,7 +8,7 @@ class CaseControlCountSuite extends SparkSuite {
   @Test def test() {
     var s = State(sc, sqlContext)
     s = ImportVCF.run(s, Array("src/test/resources/casecontrolcount.vcf"))
-    s = AnnotateSamples.run(s, Array("tsv",
+    s = AnnotateSamples.run(s, Array("table",
       "-i", "src/test/resources/casecontrolstatus.tsv",
       "--root", "sa",
       "--types", "case: Boolean"))

--- a/src/test/scala/org/broadinstitute/hail/methods/ImportAnnotationsSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/ImportAnnotationsSuite.scala
@@ -36,7 +36,7 @@ class ImportAnnotationsSuite extends SparkSuite {
     }
 
     val anno1 = AnnotateSamples.run(state,
-      Array("tsv", "-i", "src/test/resources/sampleAnnotations.tsv", "-s", "Sample", "-r", "sa.`my phenotype`", "-t", "qPhen:Int"))
+      Array("table", "-i", "src/test/resources/sampleAnnotations.tsv", "-s", "Sample", "-r", "sa.`my phenotype`", "-t", "qPhen:Int"))
 
     val q1 = anno1.vds.querySA("sa.`my phenotype`.Status")._2
     val q2 = anno1.vds.querySA("sa.`my phenotype`.qPhen")._2
@@ -126,7 +126,7 @@ class ImportAnnotationsSuite extends SparkSuite {
         .toMap
     }
     val anno1 = AnnotateVariants.run(state,
-      Array("tsv", "src/test/resources/variantAnnotations.tsv", "-t", "Rand1:Double,Rand2:Double", "-r", "va.stuff"))
+      Array("table", "src/test/resources/variantAnnotations.tsv", "-t", "Rand1:Double,Rand2:Double", "-r", "va.stuff"))
 
     val q1 = anno1.vds.queryVA("va.stuff")._2
     anno1.vds.rdd
@@ -138,10 +138,10 @@ class ImportAnnotationsSuite extends SparkSuite {
       }
 
     val anno1alternate = AnnotateVariants.run(state,
-      Array("tsv", "src/test/resources/variantAnnotations.alternateformat.tsv", "--vcolumns",
+      Array("table", "src/test/resources/variantAnnotations.alternateformat.tsv", "--vcolumns",
         "Chromosome:Position:Ref:Alt", "-t", "Rand1:Double,Rand2:Double", "-r", "va.stuff"))
 
-    val anno1glob = AnnotateVariants.run(state, Array("tsv", "src/test/resources/variantAnnotations.split.*.tsv",
+    val anno1glob = AnnotateVariants.run(state, Array("table", "src/test/resources/variantAnnotations.split.*.tsv",
       "-t", "Rand1:Double,Rand2:Double", "-r", "va.stuff"))
 
     assert(anno1alternate.vds.same(anno1.vds))
@@ -219,7 +219,7 @@ class ImportAnnotationsSuite extends SparkSuite {
     val state = SplitMulti.run(State(sc, sqlContext, vds), noArgs)
 
     val tsv1r = AnnotateVariants.run(state,
-      Array("tsv", "src/test/resources/variantAnnotations.tsv", "-t", "Rand1:Double,Rand2:Double", "-r", "va.stuff"))
+      Array("table", "src/test/resources/variantAnnotations.tsv", "-t", "Rand1:Double,Rand2:Double", "-r", "va.stuff"))
 
     val vcf1 = AnnotateVariants.run(state, Array("vcf", "src/test/resources/sampleInfoOnly.vcf", "--root", "va.other"))
 

--- a/src/test/scala/org/broadinstitute/hail/methods/LinearRegressionSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/LinearRegressionSuite.scala
@@ -17,12 +17,12 @@ class LinearRegressionSuite extends SparkSuite {
 
     s = SplitMulti.run(s)
 
-    s = AnnotateSamples.run(s, Array("tsv",
+    s = AnnotateSamples.run(s, Array("table",
       "-i", "src/test/resources/linearRegression.cov",
       "--root", "sa.cov",
       "--types", "Cov1: Double, Cov2: Double"))
 
-    s = AnnotateSamples.run(s, Array("tsv",
+    s = AnnotateSamples.run(s, Array("table",
       "-i", "src/test/resources/linearRegression.pheno",
       "--root", "sa.pheno",
       "--types", "Pheno: Double",
@@ -114,7 +114,7 @@ class LinearRegressionSuite extends SparkSuite {
 
     s = SplitMulti.run(s)
 
-    s = AnnotateSamples.run(s, Array("tsv",
+    s = AnnotateSamples.run(s, Array("table",
       "-i", "src/test/resources/linearRegression.pheno",
       "--root", "sa.pheno",
       "--types", "Pheno: Int",
@@ -184,7 +184,7 @@ class LinearRegressionSuite extends SparkSuite {
 
     s = SplitMulti.run(s)
 
-    s = AnnotateSamples.run(s, Array("tsv",
+    s = AnnotateSamples.run(s, Array("table",
       "-i", "src/test/resources/linearRegression.cov",
       "--root", "sa.cov",
       "--types", "Cov1: Double, Cov2: Double"))
@@ -204,11 +204,11 @@ class LinearRegressionSuite extends SparkSuite {
     val v9 = Variant("1", 9, "C", "T")   // x = (., 1, 1, 1, 1, 1)
     val v10 = Variant("1", 10, "C", "T") // x = (., 2, 2, 2, 2, 2)
 
-    val qMissing = s.vds.queryVA("va.linreg.nMissing")._2
-    val qBeta = s.vds.queryVA("va.linreg.beta")._2
-    val qSe = s.vds.queryVA("va.linreg.se")._2
-    val qTstat = s.vds.queryVA("va.linreg.tstat")._2
-    val qPval = s.vds.queryVA("va.linreg.pval")._2
+    val (_, qMissing) = s.vds.queryVA("va.linreg.nMissing")
+    val (_, qBeta) = s.vds.queryVA("va.linreg.beta")
+    val (_, qSe) = s.vds.queryVA("va.linreg.se")
+    val (_, qTstat) = s.vds.queryVA("va.linreg.tstat")
+    val (_, qPval) = s.vds.queryVA("va.linreg.pval")
 
     val annotationMap = s.vds.variantsAndAnnotations
       .collect()
@@ -266,7 +266,7 @@ class LinearRegressionSuite extends SparkSuite {
 
     s = SplitMulti.run(s)
 
-    s = AnnotateSamples.run(s, Array("tsv",
+    s = AnnotateSamples.run(s, Array("table",
       "-i", "src/test/resources/linearRegression.cov",
       "--root", "sa.cov",
       "--types", "Cov1: Double, Cov2: Double"))
@@ -350,12 +350,12 @@ class LinearRegressionSuite extends SparkSuite {
 
     s = SplitMulti.run(s)
 
-    s = AnnotateSamples.run(s, Array("tsv",
+    s = AnnotateSamples.run(s, Array("table",
       "-i", "src/test/resources/linearRegression.cov",
       "--root", "sa.cov",
       "--types", "Cov1: Double, Cov2: Double"))
 
-    s = AnnotateSamples.run(s, Array("tsv",
+    s = AnnotateSamples.run(s, Array("table",
       "-i", "src/test/resources/linearRegression.pheno",
       "--root", "sa.pheno",
       "--types", "Pheno: String",
@@ -375,12 +375,12 @@ class LinearRegressionSuite extends SparkSuite {
 
     s = SplitMulti.run(s)
 
-    s = AnnotateSamples.run(s, Array("tsv",
+    s = AnnotateSamples.run(s, Array("table",
       "-i", "src/test/resources/linearRegression.cov",
       "--root", "sa.cov",
       "--types", "Cov1: Double, Cov2: String"))
 
-    s = AnnotateSamples.run(s, Array("tsv",
+    s = AnnotateSamples.run(s, Array("table",
       "-i", "src/test/resources/linearRegression.pheno",
       "--root", "sa.pheno",
       "--types", "Pheno: Double",


### PR DESCRIPTION
- added `annotateglobal table`
- renamed all `tsv` commands to `table`
