### PR TITLE
Added SKAT-O group test command

### DIFF
--- a/docs/commands/grouptest_skato.md
+++ b/docs/commands/grouptest_skato.md
@@ -1,0 +1,114 @@
+<div class="cmdhead"></div>
+
+<div class="description"></div>
+
+<div class="synopsis"></div>
+
+<div class="options"></div>
+ 
+<div class="cmdsubsection">
+
+### Requirements:
+
+SKAT-O is not implemented natively in Hail. Instead, we use the SKAT package in R to run SKAT-O as described [here](https://cran.r-project.org/web/packages/SKAT/vignettes/SKAT.pdf).
+
+1. [R installed ( > 2.13.0 )](https://www.r-project.org)
+2. The following R libraries installed:
+    * [jsonlite](https://cran.r-project.org/web/packages/jsonlite/index.html)
+    * [SKAT](https://cran.r-project.org/web/packages/SKAT/index.html)
+3. A configuration text file pointing to the path of the Rscript binary (`hail.skato.Rscript`) and the path of the Hail R script to run SKAT (`hail.skato.script`). Use the `--config` command line option to specify the path to this file.
+ 
+**Example configuration file:**
+ 
+```
+hail.skato.Rscript /usr/bin/Rscript
+hail.skato.script /path/to/hail/src/dist/scripts/skato.r
+```
+</div>
+
+<div class="cmdsubsection">
+
+### Output File:
+
+Results are written to the output file specified by `-o` or `--output` and have the following format:
+
+Column Number | Name | Description
+:-: | ---
+1 | groupName | Name of group. Multiple group keys specified by `-k | --group-keys` are comma-separated
+2 | pValue | P value from SKAT-O. Includes small-sample size adjustment if N < 2000 and non-quantitative phenotype
+3 | pValueNoAdj | P value without adjustment for small-sample size. `null` if N \ge 2000 or quantitative phenotype
+4 | nMarker | Number of markers in group before filtering for missing rate
+5 | nMarkerTest | Number of markers tested in group
+
+**Example:**
+
+```
+groupName       pValue  pValueNoAdj     nMarker nMarkerTest
+group_4 0.2932  0.2447  8       2
+group_0 0.6367  0.6292  8       2
+group_10        0.06804 0.08229 7       3
+group_3 0.7344  0.7679  8       1
+group_5 0.607   0.582   8       2
+```
+
+**Notes:**
+
+- If the number of markers tested is 0, SKAT-O returns a P-value of 1.0
+- Results are not sorted by groupName
+- An empty set or array as the group key will produce an empty string as the groupName
+
+</div>
+
+<div class="cmdsubsection">
+### Implementation Details:
+
+**All Hail variants and samples in the variant dataset at the time of calling `grouptest skato` are included in the SKAT-O test** 
+
+1. Hail groups variants together by the keys specified by the `-k | --group-keys` command line option.
+2. If there are duplicate variants, one is randomly chosen.
+3. The phenotype vector and covariate matrix are constructed from the command-line options `-y` and `-c | --covariates` respectively. 
+4. Genotype vectors are constructed using the value in `g.nNonRefAlleles`
+5. The following R commands are run:
+
+```
+# 1. Run Null Model
+## No covariates specified
+obj <- SKAT_Null_Model(Y ~ 1, ... )
+
+## Covariates specified (X)
+obj <- SKAT_Null_Model(Y ~ X, ... )
+
+# 2. Run SKAT once per group with genotype matrix (Z) and result of null model
+SKAT(Z, obj, ... )
+
+# Y is the phenotype vector (coded as 0/1 for dichotomous variable and NA for missing value)
+# ... are optional parameters such as impute.method, r.corr, etc.
+```
+
+**Caveats**
+
+Hail will not return the same answer as SKAT-O from PLINK files:
+
+ * when variants have a minor allele frequency (MAF) of 0.5. This is because SKAT-O cannot know which allele is the reference allele from .bim files. Therefore, in Hail, the genotype vector codes reference allele homozygotes as 0 while in SKAT-O from PLINK files, the genotype vector codes these as 2.
+ * when using the `--estimate-maf 2` option if variants have a MAF equal to 0.5 after filtering samples with missing phenotypes and/or covariates. (see above)
+ * when using the `--impute-method random` option.
+
+</div>
+
+<div class="cmdsubsection">
+
+### Examples:
+
+<h4 class="example">Gene burden test from VEP annotation with SKAT-O</h4>
+```
+hail importvcf /path/to/file.vcf \
+variantqc \
+vep --config /path/to/vep.properties \
+filtervariants expr --keep -c 'va.qc.AF < 0.01 && va.qc.AC > 0' \
+annotatesamples table -i /path/to/sampleAnnotations.txt -r sa.pheno \
+grouptest skato 
+    -k "let x = va.vep.transcript_consequences.map(csq => csq.gene_id).toSet in if (x.size == 0) NA: Set[String] else x" 
+    -y "sa.pheno.Phenotype" 
+    -c "sa.pheno.PC1,sa.pheno.PC2" -o /path/to/skatoOutput.tsv 
+```
+</div>

--- a/docs/commands/grouptest_skato.md
+++ b/docs/commands/grouptest_skato.md
@@ -62,13 +62,12 @@ group_5 0.607   0.582   8       2
 <div class="cmdsubsection">
 ### Implementation Details:
 
-**All Hail variants and samples in the variant dataset at the time of calling `grouptest skato` are included in the SKAT-O test** 
+**All Hail variants and samples in the variant dataset at the time of calling `grouptest skato` are included in the SKAT-O test. Duplicate variants are not removed!** 
 
 1. Hail groups variants together by the keys specified by the `-k | --group-keys` command line option.
-2. If there are duplicate variants, one is randomly chosen.
-3. The phenotype vector and covariate matrix are constructed from the command-line options `-y` and `-c | --covariates` respectively. 
-4. Genotype vectors are constructed using the value in `g.nNonRefAlleles`
-5. The following R commands are run:
+2. The phenotype vector and covariate matrix are constructed from the command-line options `-y` and `-c | --covariates` respectively. 
+3. Genotype vectors are constructed using the value in `g.nNonRefAlleles`
+4. The following R commands are run:
 
 ```
 # 1. Run Null Model

--- a/src/dist/scripts/skato.r
+++ b/src/dist/scripts/skato.r
@@ -1,0 +1,102 @@
+#! /usr/bin/env Rscript
+
+# Setup sink so only JSON is returned in stdout
+sink('stdout', type = c("output", "message"))
+
+# load libraries
+suppressPackageStartupMessages(library("jsonlite"))
+suppressWarnings(library("SKAT"))
+
+# read json data from stdin
+args <- commandArgs(trailingOnly = TRUE)
+json_data <-
+  fromJSON(file("stdin"), simplifyVector = TRUE, simplifyMatrix = TRUE)
+
+# get variables
+Y <- json_data$Y
+yType <- json_data$yType
+nResampling <- json_data$nResampling
+typeResampling <- json_data$typeResampling
+adjustment <- json_data$adjustment
+kernel <- json_data$kernel
+method <- json_data$method
+weightsBeta <- json_data$weightsBeta
+imputeMethod <- json_data$imputeMethod
+rCorr <- json_data$rCorr
+missingCutoff <- json_data$missingCutoff
+estimateMAF <- json_data$estimateMAF
+seed <- json_data$seed
+
+# Set random seed
+set.seed(seed)
+
+# calculate null model
+if ("COV" %in% names(json_data)) {
+  obj <- suppressWarnings(
+    SKAT_Null_Model(
+      Y ~ json_data$COV,
+      out_type = yType,
+      n.Resampling = nResampling,
+      type.Resampling = typeResampling,
+      Adjustment = adjustment
+    )
+  )
+} else {
+  obj <- suppressWarnings(
+    SKAT_Null_Model(
+      Y ~ 1,
+      out_type = yType,
+      n.Resampling = nResampling,
+      type.Resampling = typeResampling,
+      Adjustment = adjustment
+    )
+  )
+}
+
+group_data <- json_data$groups
+
+runSkatO <- function(name, data) {
+  Z <- t(data)
+  
+  res <- try(suppressWarnings(SKAT(
+    Z, obj,
+    kernel = kernel,
+    method = method,
+    weights.beta = weightsBeta,
+    impute.method = imputeMethod,
+    r.corr = rCorr,
+    missing_cutoff = missingCutoff,
+    estimate_MAF = estimateMAF
+  )))
+  
+  if (class(res) == "try-error") {
+    res <-
+      list(
+        p.value = NA, n.marker = NA, p.value.noadj = NA, n.marker.test = NA
+      )
+  }
+  
+  return(
+    list(
+      groupName = unbox(name),
+      pValue = unbox(res$p.value),
+      pValueNoAdj = unbox(res$p.value.noadj),
+      nMarker = unbox(res$param$n.marker),
+      nMarkerTest = unbox(res$param$n.marker.test)
+    )
+  )
+}
+
+group_data <- json_data$groups
+groupNames <- names(group_data)
+results <-
+  lapply(groupNames, function(k)
+    runSkatO(k, group_data[[k]]))
+
+# remove sink for stdout
+sink()
+
+# output json with results to stdout
+cat(minify(toJSON(
+  results, digits = I(4), null = "null", na = "null"
+)))

--- a/src/main/scala/org/broadinstitute/hail/driver/Command.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/Command.scala
@@ -44,17 +44,15 @@ object ToplevelCommands {
         + cmd.description))
   }
 
-  register(AggregateIntervals)
   register(AnnotateSamples)
   register(AnnotateVariants)
   register(AnnotateGlobal)
   register(Cache)
-  register(CommandMetadata)
+  register(ImportAnnotations)
   register(CompareVDS)
   register(Count)
   register(DownsampleVariants)
   register(ExportPlink)
-  register(ExportGEN)
   register(ExportGenotypes)
   register(ExportSamples)
   register(ExportVariants)
@@ -67,16 +65,13 @@ object ToplevelCommands {
   register(FilterVariants)
   register(GenDataset)
   register(Grep)
+  register(GroupTest)
+  register(GroupTestSKATO)
   register(GRM)
   register(GQByDP)
   register(GQHist)
-  register(ImportAnnotations)
-  register(ImportBGEN)
-  register(ImportGEN)
-  register(ImportPlink)
   register(ImportVCF)
   register(ImputeSex)
-  register(IndexBGEN)
   register(LinearRegressionCommand)
   register(MendelErrorsCommand)
   register(SplitMulti)
@@ -87,7 +82,6 @@ object ToplevelCommands {
   register(RenameSamples)
   register(Repartition)
   register(SampleQC)
-  register(SeqrServerCommand)
   register(PrintSchema)
   register(ShowGlobalAnnotations)
   register(VariantQC)
@@ -150,7 +144,7 @@ abstract class SuperCommand extends Command {
 
   override def parseArgs(args: Array[String]): Options = {
     val options = newOptions
-    if (args(0) == "-h")
+    if (args(0) ==  "-h")
       options.printUsage = true
 
     val subArgs = args.dropWhile(_ == "-h")

--- a/src/main/scala/org/broadinstitute/hail/driver/GroupTest.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/GroupTest.scala
@@ -1,0 +1,10 @@
+package org.broadinstitute.hail.driver
+
+
+object GroupTest extends SuperCommand {
+  def name = "grouptest"
+
+  def description = "Group-based tests"
+
+  register(GroupTestSKATO)
+}

--- a/src/main/scala/org/broadinstitute/hail/driver/GroupTestSKATO.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/GroupTestSKATO.scala
@@ -1,0 +1,378 @@
+package org.broadinstitute.hail.driver
+
+import java.io.{FileInputStream, IOException}
+import java.util.Properties
+
+import org.apache.spark.storage.StorageLevel
+import org.broadinstitute.hail.Utils._
+import org.broadinstitute.hail.expr._
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+import org.kohsuke.args4j.{Option => Args4jOption}
+
+import scala.collection.JavaConverters._
+import scala.language.existentials
+import scala.util.Random
+
+
+object GroupTestSKATO extends Command {
+
+  class Options extends BaseOptions {
+
+    //Input parameters
+    @Args4jOption(required = true, name = "-k", aliases = Array("--group-key"),
+      usage = "annotation to be used as grouping variable (must be attribute of va)", metaVar = "ANNOT")
+    var groupKey: String = _
+
+    @Args4jOption(required = false, name = "--splat", usage = "expand out --group-key that are lists, sets, or arrays")
+    var splat: Boolean = false
+
+    @Args4jOption(required = false, name = "-q", aliases = Array("--quantitative"), usage = "y is a quantitative phenotype")
+    var quantitative: Boolean = false
+
+    @Args4jOption(required = true, name = "-y", aliases = Array("--y"), usage = "Response sample annotation", metaVar = "ANNOT")
+    var ySA: String = _
+
+    @Args4jOption(required = false, name = "-c", aliases = Array("--covariates"),
+      usage = "Covariate sample annotations, comma-separated", metaVar = "ANNOT")
+    var covSA: String = ""
+
+
+    // Configuration options
+    @Args4jOption(required = true, name = "-o", aliases = Array("--output"), usage = "path of output tsv", metaVar = "FILE")
+    var output: String = _
+
+    @Args4jOption(required = false, name = "--config", usage = "SKAT-O configuration file", metaVar = "FILE")
+    var config: String = _
+
+    @Args4jOption(name = "--block-size", usage = "# of Groups per SKAT-O invocation", metaVar = "SIZE")
+    var blockSize = 1000
+
+    @Args4jOption(required = false, name = "--seed", usage = "number to set random seed to [default=1]", metaVar = "SEED")
+    var seed: Int = 1
+
+    @Args4jOption(required = false, name = "--random-seed", usage = "use a random seed")
+    var randomize: Boolean = false
+
+    @Args4jOption(required = false, name = "-d", usage = "seperator to use when outputting group keys with more than one item in tsv file", metaVar = "DELIM")
+    var groupNameSep: String = ","
+
+
+    //SKAT_Null_Model options
+    @Args4jOption(required = false, name = "--n-resampling", metaVar = "COUNT",
+      usage = "Number of times to resample residuals")
+    var nResampling: Int = 0
+
+    @Args4jOption(required = false, name = "--type-resampling", metaVar = "NAME",
+      usage = "Resampling method. One of [bootstrap, bootstrap.fast, permutation]")
+    var typeResampling: String = "bootstrap"
+
+    @Args4jOption(required = false, name = "--no-adjustment",
+      usage = "No adjustment for small sample sizes")
+    var noAdjustment: Boolean = false
+
+
+    //SKAT options
+    @Args4jOption(required = false, name = "--kernel", metaVar = "NAME",
+      usage = "SKAT-O kernel type. One of [linear, linear.weighted, IBS, IBS.weighted, quadratic, 2wayIX]")
+    var kernel: String = "linear.weighted"
+
+    @Args4jOption(required = false, name = "--method", metaVar = "NAME",
+      usage = "Method for calculating p-values. One of [davies, liu, liu.mod, optimal.adj, optimal]")
+    var method: String = "davies"
+
+    @Args4jOption(required = false, name = "--weights-beta", metaVar = "WGT1,WGT2",
+      usage = "Comma-separated parameters for beta function for calculating weights. Default is 1,25")
+    var weightsBeta: String = "1,25"
+
+    @Args4jOption(required = false, name = "--impute-method", metaVar = "NAME",
+      usage = "Method for imputing missing genotypes. One of [fixed, random, bestguess]")
+    var imputeMethod: String = "fixed"
+
+    @Args4jOption(required = false, name = "--r-corr", metaVar = "r1,r2,...,rN",
+      usage = "The rho parameter for the unified test. rho=0 is SKAT only. rho=1 is Burden only. Can also be multiple comma-separated values")
+    var rCorr: String = "0.0"
+
+    @Args4jOption(required = false, name = "--missing-cutoff", metaVar = "CUTOFF",
+      usage = "Missing rate cutoff for variant inclusion")
+    var missingCutoff: Double = 0.15
+
+    @Args4jOption(required = false, name = "--estimate-maf", metaVar = "TYPE",
+      usage = "Method for estimating MAF. 1 = use all samples to estimate MAF. 2 = use samples with non-missing phenotypes and covariates")
+    var estimateMAF: Int = 1
+
+  }
+
+  val availMethods = Set("davies", "liu", "liu.mod", "optimal.adj", "optimal")
+  val availKernels = Set("linear", "linear.weighted", "IBS", "IBS.weighted", "quadratic", "2wayIX")
+  val availResamplingTypes = Set("bootstrap", "bootstrap.fast", "permutation")
+  val availMafEstimate = Set(1, 2)
+  val availImputeMethod = Set("fixed", "random", "bestguess")
+
+  def newOptions = new Options
+
+  def name = "grouptest skato"
+
+  def description = "Run SKAT-O on groups specified by a variant annotation"
+
+  def supportsMultiallelic = false
+
+  def requiresVDS = true
+
+  val skatoElementSignature = TStruct(
+    "groupName" -> TInt,
+    "pValue" -> TDouble,
+    "pValueNoAdj" -> TDouble,
+    "nMarker" -> TInt,
+    "nMarkerTest" -> TInt
+  )
+
+  val skatoSignature = TArray(skatoElementSignature)
+
+  val header = "groupName\tpValue\tpValueNoAdj\tnMarker\tnMarkerTest"
+
+  def run(state: State, options: Options): State = {
+    val vds = state.vds
+    val sampleIds = vds.sampleIds
+
+    if (vds.nVariants == 0)
+      warn("No variants found in VDS.")
+
+    val properties = try {
+      val p = new Properties()
+      if (options.config != null) {
+        val is = new FileInputStream(options.config)
+        p.load(is)
+        is.close()
+      }
+      p
+    } catch {
+      case e: IOException =>
+        fatal(s"could not open file: ${ e.getMessage }")
+    }
+
+    val yType = if (options.quantitative) "C" else "D"
+    val nResampling = options.nResampling
+    val typeResampling = options.typeResampling
+    val adjustment = !options.noAdjustment
+    val kernel = options.kernel
+    val method = options.method
+    val weightsBeta = options.weightsBeta
+    val imputeMethod = options.imputeMethod
+    val rCorr = options.rCorr
+    val missingCutoff = options.missingCutoff
+    val estimateMAF = options.estimateMAF
+    val quantitative = options.quantitative
+    val splat = options.splat
+    val groupNameSep = options.groupNameSep
+
+    val R = properties.getProperty("hail.skato.Rscript", "Rscript")
+    val skatoScript = properties.getProperty("hail.skato.script", "src/dist/scripts/skato.r")
+
+
+    val rCorrArray = try {
+      rCorr.split(",").map(_.toDouble)
+    } catch {
+      case e: NumberFormatException => fatal(s"Arguments to --r-corr must be numeric, between 0.0 and 1.0, and comma-separated. Did not find numeric input type [${rCorr}]")
+    }
+
+    if (!rCorrArray.forall(d => d >= 0.0 && d <= 1.0))
+      fatal(s"Arguments to --r-corr must be numeric, between 0.0 and 1.0, and comma-separated. Found ${ options.rCorr }")
+
+    val weightBetaArray = try {
+      weightsBeta.split(",").map(_.toDouble)
+    } catch {
+      case e: NumberFormatException => fatal(s"Arguments to --weights-beta must be numeric and comma-separated. Did not find numeric input type [${weightsBeta}]")
+    }
+
+    if (weightBetaArray.length != 2)
+      fatal(s"Must give two comma-separated arguments to --weights-beta. Found ${ options.weightsBeta }")
+
+    if (!availMethods.contains(method))
+      fatal(s"Did not recognize option specified for --method. Use one of [${ availMethods.mkString(", ") }]")
+
+    if (!availKernels.contains(kernel))
+      fatal(s"Did not recognize option specified for --kernel. Use one of [${ availKernels.mkString(", ") }]")
+
+    if (!availMafEstimate.contains(estimateMAF))
+      fatal(s"Did not recognize option specified for --estimate-maf. Use one of [${ availMafEstimate.mkString(", ") }].")
+
+    if (!availResamplingTypes.contains(typeResampling))
+      fatal(s"Did not recognize option specified for --type-resampling. Use one of [${ availResamplingTypes.mkString(", ") }]. bootstrap.fast only available for non-quantitative variables")
+
+    if (quantitative && typeResampling == "bootstrap.fast")
+      fatal("Can only use bootstrap.fast for --type-resampling if -q is not set (dichotomous variables only).")
+
+    if (!availImputeMethod.contains(imputeMethod))
+      fatal(s"Did not recognize option specified for --impute-method. Use one of [${ availImputeMethod.mkString(", ") }")
+
+    if (!(rCorrArray.length == 1 && rCorrArray(0) == 0.0) && kernel != "linear" && kernel != "linear.weighted")
+      fatal("Non-zero r.corr only can be used with linear or linear.weighted kernels")
+
+    def toDouble(t: BaseType, code: String): Any => Double = t match {
+      case TInt => _.asInstanceOf[Int].toDouble
+      case TLong => _.asInstanceOf[Long].toDouble
+      case TFloat => _.asInstanceOf[Float].toDouble
+      case TDouble => _.asInstanceOf[Double]
+      case TBoolean => _.asInstanceOf[Boolean].toDouble
+      case _ => fatal(s"Sample annotation `$code' must be numeric or Boolean, got $t")
+    }
+
+    val symTab = Map(
+      "s" ->(0, TSample),
+      "sa" ->(1, vds.saSignature),
+      "va" ->(2, vds.vaSignature))
+
+    val ec = EvalContext(symTab)
+    val a = ec.a
+
+    val (yT, yQ) = Parser.parse(options.ySA, ec)
+
+    val yToDouble = toDouble(yT, options.ySA)
+    val ySA = vds.sampleIdsAndAnnotations.map { case (s, sa) =>
+      a(0) = s
+      a(1) = sa
+      yQ().map(yToDouble)
+    }
+
+    val (covT, covQ) = Parser.parseExprs(options.covSA, ec).unzip
+    val covToDouble = (covT, options.covSA.split(",").map(_.trim)).zipped.map(toDouble)
+    val covSA = vds.sampleIdsAndAnnotations.map { case (s, sa) =>
+      a(0) = s
+      a(1) = sa
+      (covQ.map(_ ()), covToDouble).zipped.map(_.map(_))
+    }
+    val nCovar = covT.size
+
+    val (yDefined, covDefined, samplesDefined) =
+      (ySA, covSA, sampleIds)
+        .zipped
+        .filter((y, c, s) => y.isDefined && c.forall(_.isDefined))
+
+    if (samplesDefined.length < 1) {
+      val sb = new StringBuilder()
+      sb.append(s"No samples with non-missing phenotype [${ options.ySA }]")
+      if (nCovar > 0)
+        sb.append(s" and covariates [${ options.covSA }]")
+      fatal(sb.result())
+    }
+    info(s"${ samplesDefined.length } samples with non-missing phenotypes")
+
+    val seed = if (options.randomize) Random.nextInt() else options.seed
+    info(s"Using a random seed of [$seed]")
+
+    val cmd = Array(R, skatoScript)
+
+    val localBlockSize = options.blockSize
+
+    val ySABC = state.sc.broadcast(ySA)
+    val covSABC = state.sc.broadcast(covSA)
+    val splatBC = state.sc.broadcast(options.splat)
+
+    def printContext(w: (String) => Unit) = {
+      val y = pretty(JArray(ySABC.value.map { y => if (y.isDefined) JDouble(y.get) else JNull }.toList))
+      val cov = pretty(JArray(covSABC.value.map { cov => JArray(cov.map { c => if (c.isDefined) JDouble(c.get) else JNull }.toList) }.toList))
+      val covString = if (nCovar > 0) s""""COV":$cov,""" else ""
+      w(
+        s"""{"yType":"$yType",
+            |"nResampling":$nResampling,
+            |"typeResampling":"$typeResampling",
+            |"adjustment":$adjustment,
+            |"kernel":"$kernel",
+            |"method":"$method",
+            |"weightsBeta":[$weightsBeta],
+            |"imputeMethod":"$imputeMethod",
+            |"rCorr":[$rCorr],
+            |"missingCutoff":$missingCutoff,
+            |"estimateMAF":$estimateMAF,
+            |"seed":$seed,
+            |"Y":$y,
+            |$covString
+            |"groups":{""".stripMargin)
+    }
+
+    def printSep(w: (String) => Unit) = {
+      w(",")
+    }
+
+    def printFooter(w: (String) => Unit) = {
+      w("}}")
+    }
+
+    def printElement(w: (String) => Unit, g: (Any, Iterable[Iterable[Int]])) = {
+      val a = JArray(g._2.map(a => JArray(a.map(JInt(_)).toList)).toList)
+      w( s""""${ g._1 }":${ pretty(a) }""")
+    }
+
+    val (baseType, qGroupKey) = vds.queryVA(options.groupKey)
+
+
+    if (options.splat) {
+      baseType match {
+        case t: TIterable =>
+        case _ => fatal(s"Cannot use --splat with group-key that is not an array or set. Found type $baseType")
+      }
+    }
+
+    val groups = vds.rdd.flatMap { case (v, (va, gs)) =>
+      val key = qGroupKey(va)
+      val genotypes = gs.map { g => g.nNonRefAlleles.getOrElse(9) } //SKAT-O null value is +9
+      key match {
+        case Some(x) =>
+          if (splat)
+            for (k <- x.asInstanceOf[Iterable[_]]) yield (k, (v, genotypes))
+          else
+            Some((x, (v, genotypes)))
+        case None => None
+      }
+    }.groupByKey().persist(StorageLevel.MEMORY_AND_DISK)
+
+    val qGroupName = skatoElementSignature.query("groupName")
+    val qPValue = skatoElementSignature.query("pValue")
+    val qPValueNoAdj = skatoElementSignature.query("pValueNoAdj")
+    val qNMarker = skatoElementSignature.query("nMarker")
+    val qNMarkerTest = skatoElementSignature.query("nMarkerTest")
+
+
+    groups.mapPartitions { it =>
+      val pb = new java.lang.ProcessBuilder(cmd.toList.asJava)
+      val sb = new StringBuilder
+
+      it.grouped(localBlockSize)
+        .flatMap {
+          group =>
+            val groupDistinctVariants = group.map { case (k, data) => (k, data.reduceByKey((gs1, gs2) => gs1).values) }
+            val keys = groupDistinctVariants.map(_._1).toIndexedSeq
+
+            groupDistinctVariants
+              .zipWithIndex.map { case ((k, gss), ind) => (ind, gss) }
+              .iterator
+              .pipe(pb, printContext, printElement, printFooter, printSep)
+              .map { result =>
+                val a = JSONAnnotationImpex.importAnnotation(parse(result), skatoSignature, "<root>")
+                a.asInstanceOf[IndexedSeq[_]]
+                  .sortBy(a => qGroupName(a).get.asInstanceOf[Int])
+                  .zipWithIndex
+                  .foreachBetween { case (ann, i) =>
+                    val realName = keys(i)
+                    sb.tsvAppend(realName, groupNameSep)
+                    sb += '\t'
+                    sb.tsvAppend(qPValue(ann))
+                    sb += '\t'
+                    sb.tsvAppend(qPValueNoAdj(ann))
+                    sb += '\t'
+                    sb.tsvAppend(qNMarker(ann))
+                    sb += '\t'
+                    sb.tsvAppend(qNMarkerTest(ann))
+                    sb += '\t'
+                  }(sb += '\n')
+                sb.result()
+              }
+        }
+    }.writeTable(options.output, Some(header), deleteTmpFiles = true)
+
+    groups.unpersist()
+
+    state
+  }
+}

--- a/src/main/scala/org/broadinstitute/hail/driver/VEP.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/VEP.scala
@@ -172,8 +172,12 @@ object VEP extends Command {
     "variant_class" -> TString)
 
   def printContext(w: (String) => Unit) {
-    w("##fileformat=VCFv4.1")
-    w("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT")
+    w("##fileformat=VCFv4.1\n")
+    w("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\n")
+  }
+
+  def printSep(w: (String) => Unit) {
+    w("\n")
   }
 
   def printElement(w: (String) => Unit, v: Variant) {
@@ -189,6 +193,10 @@ object VEP extends Command {
     w(sb.result())
   }
 
+  def printFooter(w: (String) => Unit) {
+    w("\n")
+  }
+
   def variantFromInput(input: String): Variant = {
     val a = input.split("\t")
     Variant(a(0),
@@ -199,7 +207,7 @@ object VEP extends Command {
 
   def run(state: State, options: Options): State = {
     val vds = state.vds
-    
+
     val root = Parser.parseAnnotationRoot(options.root, Annotation.VARIANT_HEAD)
 
     val rootType =
@@ -302,7 +310,8 @@ object VEP extends Command {
         .flatMap(_.iterator.pipe(pb,
           printContext,
           printElement,
-          _ => ())
+          printFooter,
+          printSep)
           .map { s =>
             val a = JSONAnnotationImpex.importAnnotation(parse(s), vepSignature)
             val v = variantFromInput(inputQuery(a).get.asInstanceOf[String])

--- a/src/test/resources/testSkatoPlink.r
+++ b/src/test/resources/testSkatoPlink.r
@@ -1,0 +1,83 @@
+#! /usr/bin/env Rscript
+
+# Setup sink
+sink('stdout', type=c("output", "message"))
+
+# load libraries
+suppressWarnings(library("SKAT"))
+suppressPackageStartupMessages(library("optparse"))
+
+option_list <- list(
+  make_option("--plink-root",action="store", help="file path where plink binary files can be found"),
+  make_option("--covariates",action="store", help="file path to covariates file (no FID or IID columns)"),
+  make_option("--setid", action="store", help="file path to set id file"),
+  make_option("--y-type",action="store", help="C or D for y variable type"),
+  make_option("--ssd-file", action="store", help="output file for SSD"),
+  make_option("--info-file", action="store", help="output file for info file"),
+  make_option("--results-file", action="store", help="output file for results"),
+  make_option("--ncovar", action="store", type="integer", help="number of covariates"),
+  make_option("--seed", action="store", type="integer", default=1, help="random seed"),
+  make_option("--n-resampling", action="store", type="integer", default=0, help="number of times to resample residuals"),
+  make_option("--type-resampling", action="store", default="bootstrap", help="resampling method"),
+  make_option("--no-adjustment", action="store_true", default=FALSE, help="No adjustment for small sample sizes"),
+  make_option("--kernel", action="store", default="linear.weighted"),
+  make_option("--impute-method", action="store", default="fixed"),
+  make_option("--method", action="store", default="davies"),
+  make_option("--r-corr", action="store", default="0"),
+  make_option("--estimate-maf", action="store", default="1"),
+  make_option("--missing-cutoff", action="store", type="double"),
+  make_option("--weights-beta", action="store", default="1,25")
+)
+
+opt <- parse_args(OptionParser(option_list=option_list))
+
+plinkRoot <- opt$`plink-root`
+covar <- opt$covariates
+setID <- opt$setid
+phenoType <- opt$`y-type`
+ssdFile <- opt$`ssd-file`
+infoFile <- opt$`info-file`
+resultsFile <- opt$`results-file`
+nCovar <- opt$ncovar
+seed <- opt$seed
+rCorr <- as.numeric(strsplit(opt$`r-corr`, ",")[[1]])
+weightsBeta <- as.numeric(strsplit(opt$`weights-beta`,",")[[1]])
+
+set.seed(seed)
+
+suppressWarnings(Generate_SSD_SetID(paste(plinkRoot, ".bed", sep=""), 
+                   paste(plinkRoot, ".bim", sep=""),
+                   paste(plinkRoot, ".fam", sep=""),
+                   setID,
+                   ssdFile,
+                   infoFile))
+
+SSD.INFO <- suppressWarnings(Open_SSD(ssdFile, infoFile))
+
+isBinary <- TRUE
+if (phenoType == "C") {
+  isBinary <-FALSE
+}
+
+if (nCovar > 0) {
+  PHENO <- suppressWarnings(Read_Plink_FAM(paste(plinkRoot, ".fam", sep=""), Is.binary=isBinary))
+  Y <- PHENO$Phenotype
+  X <- as.matrix(read.table(covar, header=FALSE))
+  for(i in 1:nCovar){
+    id.missing <- which(X[,i] == -9)
+    if (length(id.missing) > 0){
+      X[id.missing,i] <- NA
+    }
+  }
+  obj <- suppressWarnings(SKAT_Null_Model(Y ~ X, out_type=phenoType, n.Resampling = opt$`n-resampling`, type.Resampling = opt$`type-resampling`, Adjustment = !opt$`no-adjustment`))
+} else {
+  PHENO <- suppressWarnings(Read_Plink_FAM(paste(plinkRoot, ".fam", sep=""), Is.binary=isBinary))
+  Y <- PHENO$Phenotype  
+  obj <- suppressWarnings(SKAT_Null_Model(Y ~ 1, out_type=phenoType, n.Resampling = opt$`n-resampling`, type.Resampling = opt$`type-resampling`, Adjustment = !opt$`no-adjustment`))
+}
+
+out <- suppressWarnings(SKAT.SSD.All(SSD.INFO, obj, impute.method=opt$`impute-method`, kernel=opt$kernel, method=opt$method, r.corr=rCorr, 
+                                     estimate_MAF=opt$`estimate-maf`, missing_cutoff=opt$`missing-cutoff`, weights.beta=weightsBeta))
+suppressWarnings(Close_SSD())
+sink()
+write.table(out$results, resultsFile, row.names = FALSE, col.names = FALSE, quote = FALSE)

--- a/src/test/scala/org/broadinstitute/hail/methods/SkatoSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/SkatoSuite.scala
@@ -1,0 +1,390 @@
+package org.broadinstitute.hail.methods
+
+import org.broadinstitute.hail.Utils._
+import org.broadinstitute.hail.annotations.Annotation
+import org.broadinstitute.hail.check.Prop._
+import org.broadinstitute.hail.check._
+import org.broadinstitute.hail.driver._
+import org.broadinstitute.hail.expr._
+import org.broadinstitute.hail.variant._
+import org.broadinstitute.hail.{FatalException, SparkSuite}
+import org.testng.annotations.Test
+import org.broadinstitute.hail.check.Arbitrary._
+
+import scala.collection.mutable
+import scala.language._
+import scala.math.Numeric.Implicits._
+import scala.sys.process._
+
+class SkatoSuite extends SparkSuite {
+
+  val testVepSignature = TStruct("transcript_consequences" -> TArray(TStruct("lof_flag" -> TBoolean, "gene_id" -> TString)))
+  val sampleSignature = TStruct("phenotype" -> TBoolean)
+
+  def genAnnotation(genes: Array[String]) = for (flag <- arbitrary[Boolean]; gene <- Gen.oneOfSeq(genes)) yield Annotation(flag, gene)
+
+  def genAnnotations(n: Int, genes: Array[String]) = Gen.buildableOfN[IndexedSeq, Annotation](n, genAnnotation(genes))
+
+  def genVariantAnnotation(genes: Array[String]) = for (n <- Gen.choose(0, 10); va <- genAnnotations(n, genes)) yield Annotation(va)
+
+  def dichotomousPhenotype(nSamples: Int) = Gen.buildableOfN[Array, Option[Boolean]](nSamples, Gen.option(arbitrary[Boolean], 0.95))
+
+  def quantitativePhenotype(nSamples: Int) = Gen.buildableOfN[Array, Option[Double]](nSamples, Gen.option(Gen.choose(-0.5, 0.5), 0.95))
+
+  def covariateMatrix(nSamples: Int, numCovar: Int) = Gen.buildableOfN[Array, Array[Option[Double]]](numCovar, quantitativePhenotype(nSamples))
+
+  def readResults(file: String) = {
+    readLines(file, sc.hadoopConfiguration) { lines =>
+      lines.drop(1).map {
+        _.map { line =>
+          val Array(groupName, pValue, pValueNoAdj, nMarkers, nMarkersTested) = line.split( """\t""")
+          groupName
+        }
+      }.toArray
+    }
+  }
+
+  object Spec extends Properties("SKAT-O") {
+    val compGen = for (vds: VariantDataset <- VariantSampleMatrix.gen[Genotype](sc, VSMSubgen.random);
+      blockSize: Int <- Gen.choose(1, 1000);
+      quantitative: Boolean <- arbitrary[Boolean];
+      nCovar: Int <- Gen.choose(0, 5);
+      nGroups: Int <- Gen.choose(1, 50);
+      y <- if (quantitative) quantitativePhenotype(vds.nSamples) else dichotomousPhenotype(vds.nSamples);
+      x <- covariateMatrix(vds.nSamples, nCovar);
+      seed <- Gen.posInt;
+      nRho <- Gen.choose(1, 10);
+      rCorr <- Gen.frequency(
+        (3, Gen.buildableOfN[Array, Double](1, Gen.const[Double](0.0))),
+        (3, Gen.buildableOfN[Array, Double](1, Gen.const[Double](1.0))),
+        (3, Gen.distinctBuildableOfN[Array, Double](nRho, Gen.choose(0.0, 1.0))));
+      imputeMethod <- Gen.oneOf("fixed", "bestguess"); //cannot test random because order of groups not identical between PLINK and Hail
+      kernel <- Gen.frequency((5, Gen.const("linear")), (5, Gen.const("linear.weighted")), (1, Gen.oneOf("IBS", "IBS.weighted", "quadratic", "2wayIX")));
+      nResampling <- Gen.frequency((5, Gen.const(0)), (5, Gen.choose(0, 100)));
+      typeResampling <- if (quantitative) Gen.oneOf("bootstrap", "permutation") else Gen.oneOf("bootstrap", "bootstrap.fast", "permutation");
+      noAdjustment <- arbitrary[Boolean];
+      method <- Gen.oneOf("davies", "liu", "liu.mod", "optimal.adj", "optimal");
+      missingCutoff <- Gen.choose(0.1, 0.6);
+      weightsBeta <- Gen.buildableOfN[Array, Int](2, Gen.choose(1, 25));
+      estimateMAF <- Gen.oneOf(1, 2)
+
+    ) yield (vds, blockSize, quantitative, nCovar, nGroups,
+      y, x, seed, rCorr, imputeMethod, kernel, nResampling,
+      typeResampling, noAdjustment, method, missingCutoff, weightsBeta, estimateMAF)
+
+    property("Hail groups give same result as plink input") =
+      forAll(compGen) { case (vds: VariantSampleMatrix[Genotype], blockSize: Int,
+      quantitative: Boolean, nCovar: Int, nGroups: Int, y, x,
+      seed: Int, rCorr, imputeMethod, kernel, nResampling, typeResampling, noAdjustment,
+      method, missingCutoff, weightsBeta, estimateMAF) =>
+
+        val fileRoot = tmpDir.createTempFile("skatoTest")
+        val plinkRoot = fileRoot + ".plink"
+        val ssd = fileRoot + ".SSD"
+        val info = fileRoot + ".info"
+        val resultsFile = fileRoot + ".results"
+        val sampleAnnotations = fileRoot + ".sampleAnnotations.tsv"
+        val variantAnnotations = fileRoot + ".variantAnnotations.tsv"
+        val hailOutputFile = fileRoot + ".hailResults.tsv"
+        val setID = fileRoot + ".setid"
+        val covarFile = fileRoot + ".covar"
+
+        var s = State(sc, sqlContext, vds.filterVariants((v, va, gs) => v.toString.length < 50 && divOption(gs.flatMap(_.nNonRefAlleles).sum, gs.count(_.isCalled) * 2) != Option(0.5))) //hack because SKAT-O won't accept snp ids with > 50 characters
+        s = SplitMulti.run(s, Array.empty[String])
+        s = VariantQC.run(s, Array.empty[String])
+        s = FilterVariantsExpr.run(s, Array("--keep", "-c", "va.qc.AF < 0.4")) //problem with MAF flip if too close to 0.5
+        s = s.copy(vds = s.vds.filterVariants((v, va, gs) => v.toString.length < 50)) //hack because SKAT-O won't accept snp ids with > 50 characters
+        s = ExportPlink.run(s, Array("-o", plinkRoot))
+
+        val nNonMissing =
+          if (x.isEmpty)
+            y.count(_.isDefined)
+          else
+            y.zip(x.transpose[Option[Double]]).count { case (yi, xi) => yi.isDefined && (xi.isEmpty || xi.forall(_.isDefined)) }
+
+        if (s.vds.nSamples < 1 || s.vds.nVariants < 1 || nNonMissing < 1) //skat-o from plink files will fail if 0 variants or samples
+          true
+        else {
+
+          // assign variants to groups
+          val groups = s.vds.variants.zipWithIndex.map { case (v, i) =>
+            val groupNum = i % nGroups
+            (v, groupNum)
+          }.collect()
+
+          // Write set ID list
+          writeTextFile(setID, sc.hadoopConfiguration) { w =>
+            groups.foreach { case (v, i) => w.write(s"group_$i" + "\t" + v.toString + "\n") }
+          }
+
+          // Write covariate file
+          writeTextFile(covarFile, sc.hadoopConfiguration) { w =>
+            s.vds.sampleIds.zipWithIndex.foreach { case (sid, i) =>
+              val sb = new StringBuilder()
+              for (j <- 0 until nCovar) {
+                if (j != 0)
+                  sb.append("\t")
+                sb.append(x(j)(i).getOrElse(-9))
+              }
+              sb.append("\n")
+              w.write(sb.result())
+            }
+          }
+
+          // Write phenotype into fam file
+          writeTextFile(plinkRoot + ".fam", sc.hadoopConfiguration) { w =>
+            s.vds.sampleIds.zipWithIndex.foreach { case (sid, i) =>
+              val phenoString = y(i).map(_.toString) match {
+                case None => -9
+                case Some("true") => 2
+                case Some("false") => 1
+                case Some(p) => p
+              }
+              w.write(s"0\t$sid\t0\t0\t0\t$phenoString\n")
+            }
+          }
+
+          // Run SKAT-O from PLINK file
+          val adjustString = if (noAdjustment) "--no-adjustment" else ""
+          val yType = if (quantitative) "C" else "D"
+
+          val plinkCommand =
+            s"""Rscript src/test/resources/testSkatoPlink.r
+                |--plink-root $plinkRoot
+                |--covariates $covarFile
+                |--setid $setID
+                |--y-type $yType
+                |--ssd-file $ssd
+                |--info-file $info
+                |--results-file $resultsFile
+                |--ncovar $nCovar
+                |--seed $seed
+                |$adjustString
+                |--kernel $kernel
+                |--n-resampling $nResampling
+                |--type-resampling $typeResampling
+                |--impute-method $imputeMethod
+                |--method $method
+                |--r-corr ${ rCorr.mkString(",") }
+                |--missing-cutoff $missingCutoff
+                |--weights-beta ${ weightsBeta.mkString(",") }
+                |--estimate-maf $estimateMAF
+               """.stripMargin
+
+          val plinkSkatExitCode = plinkCommand !
+
+          val plinkResults = sc.parallelize(readLines(resultsFile, sc.hadoopConfiguration) { lines =>
+            lines.map {
+              _.map { line =>
+                val Array(groupName, pValue, nMarkers, nMarkersTested) = line.split( """\s+""")
+                (groupName, (pValue, nMarkers, nMarkersTested))
+              }.value
+            }.toIndexedSeq
+          })
+
+          // Annotate samples with covariates and phenotype
+          writeTextFile(sampleAnnotations, sc.hadoopConfiguration) { w =>
+            val sb = new StringBuilder()
+            sb.append("Sample\tPhenotype")
+            for (j <- 0 until nCovar) {
+              sb.append(s"\tC$j")
+            }
+            sb.append("\n")
+            w.write(sb.result())
+
+            s.vds.sampleIds.zipWithIndex.foreach { case (sid, i) =>
+              val sb = new StringBuilder()
+              sb.append(sid)
+              sb.append("\t")
+              sb.append(y(i).getOrElse("NA"))
+
+              for (j <- 0 until nCovar) {
+                sb.append("\t")
+                sb.append(x(j)(i).getOrElse("NA"))
+              }
+              sb.append("\n")
+              w.write(sb.result())
+            }
+          }
+
+          val sb = new StringBuilder()
+          if (!quantitative)
+            sb.append("Phenotype: Boolean")
+          else
+            sb.append("Phenotype: Double")
+
+          for (j <- 0 until nCovar) {
+            sb.append(s",C$j: Double")
+          }
+          s = AnnotateSamplesTable.run(s, Array("-i", sampleAnnotations, "-e", "Sample", "-r", "sa.pheno", "-t", sb.result()))
+
+          // Annotate variants with group names
+          writeTextFile(variantAnnotations, sc.hadoopConfiguration) { w =>
+            w.write("Variant\tGroup\n")
+            groups.foreach { case (v, i) => w.write(v.toString + "\t" + s"group_$i\n")
+            }
+          }
+          s = AnnotateVariants.run(s, Array("table", variantAnnotations, "-r", "va.groups", "-e", "Variant", "-t", "Variant: Variant"))
+
+          var cmd = collection.mutable.ArrayBuffer("-k", "va.groups.Group", "--block-size", blockSize.toString,
+            "-y", "sa.pheno.Phenotype", "-o", hailOutputFile, "--seed", seed.toString,
+            "--kernel", kernel, "--n-resampling", nResampling.toString, "--type-resampling", typeResampling, "--impute-method", imputeMethod,
+            "--method", method, "--r-corr", rCorr.mkString(","), "--missing-cutoff", missingCutoff.toString,
+            "--weights-beta", weightsBeta.mkString(","), "--estimate-maf", estimateMAF.toString
+          )
+
+          if (quantitative)
+            cmd += "-q"
+
+          if (nCovar > 0) {
+            cmd += "-c"
+            cmd += (0 until nCovar).map { i => s"sa.pheno.C$i" }.mkString(",")
+          }
+
+          if (noAdjustment)
+            cmd += "--no-adjustment"
+
+          if (!(rCorr.length == 1 && rCorr(0) == 0.0) && kernel != "linear" && kernel != "linear.weighted") {
+            try {
+              s = GroupTestSKATO.run(s, cmd.toArray)
+              false
+            } catch {
+              case e: FatalException => true
+              case _: Throwable => false
+            }
+          } else {
+
+            s = GroupTestSKATO.run(s, cmd.toArray)
+
+            val hailResults = sc.parallelize(readLines(hailOutputFile, sc.hadoopConfiguration) { lines =>
+              lines.drop(1)
+              lines.map {
+                _.map { line =>
+                  val Array(groupName, pValue, pValueResampling, nMarkers, nMarkersTested) = line.split( """\s+""")
+                  (groupName, (pValue, nMarkers, nMarkersTested))
+                }.value
+              }.toIndexedSeq
+            })
+
+            plinkResults.fullOuterJoin(hailResults).forall { case (g, (p, h)) =>
+
+              val p2 = p match {
+                case None => (Double.NaN, 0, 0)
+                case Some(res) => (if (res._1 == "NA") -9.0 else res._1.toDouble, if (res._2 == "NA") 0 else res._2.toInt, if (res._3 == "NA") 0 else res._3.toInt)
+              }
+
+              val h2 = h match {
+                case None => (Double.NaN, 0, 0)
+                case Some(res) => (if (res._1 == "NA") -9.0 else res._1.toDouble, if (res._2 == "NA") 0 else res._2.toInt, if (res._3 == "NA") 0 else res._3.toInt)
+              }
+
+              if (p2 == h2)
+                true
+              else if ((math.abs(p2._1 - h2._1) < 1e-3 || p2._1 == h2._1) && p2._2 == h2._2 && p2._3 == h2._3)
+                true
+              else {
+                println(s"group: $g")
+                println(s"PValue: plink=${ p2._1 } hail=${ h2._1 } ${ p2._1 == h2._1 }")
+                println(s"nMarkers: plink=${ p2._2 } hail=${ h2._2 } ${ p2._2 == h2._2 }")
+                println(s"nMarkersTested: plink=${ p2._3 } hail=${ h2._3 } ${ p2._3 == h2._3 }")
+                false
+              }
+            }
+          }
+        }
+      }
+
+
+    def compositeAnnotationGen = for (vds: VariantDataset <- VariantSampleMatrix.gen[Genotype](sc, VSMSubgen.random);
+      nGroups <- Gen.choose(1, 10);
+      genes <- Gen.buildableOfN[Array, String](nGroups, arbitrary[String]);
+      phenotypes <- dichotomousPhenotype(vds.nSamples);
+      annotations <- Gen.buildableOfN[Array, Annotation](vds.nVariants.toInt, genVariantAnnotation(genes));
+      annotType <- Gen.oneOf("Set", "Array")
+    ) yield (vds, annotations, genes, phenotypes, annotType)
+
+    property("handle splat") =
+      forAll(compositeAnnotationGen) { case (vds, annotations, genes, phenotypes, annotType) =>
+        val tmpOutput = tmpDir.createTempFile("splatTest")
+
+        val variantAnnotations = sc.parallelize(vds.variants.collect().zip(annotations))
+        val phenotypeMap = vds.sampleIds.zip(phenotypes.map { case p => Annotation(p.orNull) }).toMap
+
+        val groupKeyQueryString =
+          if (annotType == "Set")
+            s"let x = va.vep.transcript_consequences.map(csq => csq.gene_id).toSet in if (x.size == 0) NA: Set[String] else x"
+          else
+            s"let x = va.vep.transcript_consequences.map(csq => csq.gene_id) in if (x.length == 0) NA: Array[String] else x"
+
+        val splatResults = tmpOutput + ".splat.tsv"
+        val noSplatResults = tmpOutput + ".nosplat.tsv"
+
+        val (finalType, inserter): (Type, (Annotation, Option[Annotation]) => Annotation) =
+          vds.insertVA(testVepSignature, List("vep"))
+
+        var s = State(sc, sqlContext, vds
+          .annotateVariants(variantAnnotations, finalType, inserter)
+          .annotateSamples(phenotypeMap, sampleSignature, List("pheno")))
+        s = SplitMulti.run(s, Array.empty[String])
+
+        val nNonMissingPheno = phenotypes.count(_.isDefined)
+        val nVariants = s.vds.nVariants
+
+
+        val cmdNoSplat = mutable.ArrayBuffer(
+          "-k", groupKeyQueryString,
+          "-y", "sa.pheno.phenotype"
+        )
+        val cmdSplat = mutable.ArrayBuffer(
+          "-k", groupKeyQueryString,
+          "-y", "sa.pheno.phenotype"
+        )
+
+        cmdNoSplat += "-o"
+        cmdNoSplat += noSplatResults
+
+        cmdSplat += "-o"
+        cmdSplat += splatResults
+        cmdSplat += "--splat"
+
+        if (nNonMissingPheno == 0) {
+          try {
+            s = GroupTestSKATO.run(s, cmdNoSplat.result().toArray)
+            s = GroupTestSKATO.run(s, cmdSplat.result().toArray)
+            false
+          } catch {
+            case e: FatalException => true
+            case _: Throwable => false
+          }
+        } else {
+          s = GroupTestSKATO.run(s, cmdNoSplat.result().toArray)
+          s = GroupTestSKATO.run(s, cmdSplat.result().toArray)
+
+          val (baseType, querier) = s.vds.queryVA(groupKeyQueryString)
+
+          val (nSplatGroupsAnswer, nNoSplatGroupsAnswer) = baseType match {
+            case _: TSet =>
+              val trueGroups = s.vds.rdd.flatMap { case (v, (va, gs)) => querier(va) }.map(_.asInstanceOf[Set[String]]).collect()
+              val nSplatGroupsAnswer = trueGroups.foldLeft(Set.empty[String])((comb, s) => comb.union(s)).size
+              val nNoSplatGroupsAnswer = trueGroups.toSet.size
+              (nSplatGroupsAnswer, nNoSplatGroupsAnswer)
+            case _: TArray =>
+              val trueGroups = s.vds.rdd.flatMap { case (v, (va, gs)) => querier(va) }.map(_.asInstanceOf[IndexedSeq[String]]).collect()
+              val nSplatGroupsAnswer = trueGroups.foldLeft(Set.empty[String])((comb, sid) => comb.union(sid.toSet)).size
+              val nNoSplatGroupsAnswer = trueGroups.toSet.size
+              (nSplatGroupsAnswer, nNoSplatGroupsAnswer)
+            case _ => fatal(s"Can't test type $baseType for splat")
+          }
+
+          val nSplatGroupsOutput = readResults(splatResults).length
+          val nNoSplatGroupOutput = readResults(noSplatResults).length
+
+          nSplatGroupsAnswer == nSplatGroupsOutput && nNoSplatGroupsAnswer == nNoSplatGroupsAnswer && nSplatGroupsAnswer <= genes.length
+        }
+      }
+  }
+
+  @Test def testSKATO() {
+    Spec.check()
+  }
+}

--- a/src/test/scala/org/broadinstitute/hail/methods/SkatoSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/SkatoSuite.scala
@@ -308,7 +308,7 @@ class SkatoSuite extends SparkSuite {
         val tmpOutput = tmpDir.createTempFile("splatTest")
 
         val variantAnnotations = sc.parallelize(vds.variants.collect().zip(annotations))
-        val phenotypeMap = vds.sampleIds.zip(phenotypes.map { case p => Annotation(p.orNull) }).toMap
+        val phenotypeMap = vds.sampleIds.zip(phenotypes.map { p => Annotation(p.orNull) }).toMap
 
         val groupKeyQueryString =
           if (annotType == "Set")


### PR DESCRIPTION
 - calls 'SKAT' package in R using pipe through stdin, stdout
 - results are output as TSV file
 - for duplicate variants, one is randomly chosen
 - R script that is running SKAT-O is at src/dist/scripts/skato.r
 - Modified pipe command to handle arbitrary separator between elements
 - if group keys are iterable elements, user can specify whether to splat the keys
 - No variant information is currently written out (to do in future)