### PR TITLE
Added fastKeys option to BGEN and PLINK import.

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/io/IndexedBinaryInputFormat.scala
+++ b/src/main/scala/org/broadinstitute/hail/io/IndexedBinaryInputFormat.scala
@@ -6,8 +6,7 @@ import org.broadinstitute.hail.variant._
 import scala.collection.mutable.ArrayBuffer
 
 
-abstract class IndexedBinaryInputFormat[K] extends FileInputFormat[LongWritable, VariantRecord[K]] {
+abstract class IndexedBinaryInputFormat[T] extends FileInputFormat[LongWritable, T] {
 
-  def getRecordReader(split: InputSplit, job: JobConf, reporter: Reporter): RecordReader[LongWritable,
-    VariantRecord[K]]
+  def getRecordReader(split: InputSplit, job: JobConf, reporter: Reporter): RecordReader[LongWritable, T]
 }

--- a/src/main/scala/org/broadinstitute/hail/io/bgen/BgenInputFormat.scala
+++ b/src/main/scala/org/broadinstitute/hail/io/bgen/BgenInputFormat.scala
@@ -2,12 +2,12 @@ package org.broadinstitute.hail.io.bgen
 
 import org.apache.hadoop.io.LongWritable
 import org.apache.hadoop.mapred._
-import org.broadinstitute.hail.io.{IndexedBinaryInputFormat, VariantRecord}
+import org.broadinstitute.hail.io.{IndexedBinaryInputFormat, KeySerializedValueRecord}
 import org.broadinstitute.hail.variant.Variant
 
-class BgenInputFormat extends IndexedBinaryInputFormat[Variant] {
+class BgenInputFormat extends IndexedBinaryInputFormat[BgenRecord] {
   override def getRecordReader(split: InputSplit, job: JobConf, reporter: Reporter): RecordReader[LongWritable,
-    VariantRecord[Variant]] = {
+    BgenRecord] = {
     reporter.setStatus(split.toString)
     new BgenBlockReader(job, split.asInstanceOf[FileSplit])
   }

--- a/src/main/scala/org/broadinstitute/hail/io/plink/PlinkBlockReader.scala
+++ b/src/main/scala/org/broadinstitute/hail/io/plink/PlinkBlockReader.scala
@@ -3,24 +3,47 @@ package org.broadinstitute.hail.io.plink
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.LongWritable
 import org.apache.hadoop.mapred.FileSplit
-import org.broadinstitute.hail.io.{IndexedBinaryBlockReader, VariantRecord}
-import org.broadinstitute.hail.variant.{GenotypeBuilder, GenotypeStreamBuilder, Variant}
+import org.broadinstitute.hail.io.{KeySerializedValueRecord, IndexedBinaryBlockReader}
+import org.broadinstitute.hail.variant.{Genotype, GenotypeBuilder, GenotypeStreamBuilder}
 
-import scala.collection.mutable
+class PlinkRecord(nSamples: Int, gb: GenotypeBuilder, gsb: GenotypeStreamBuilder) extends KeySerializedValueRecord[Int, Iterable[Genotype]] {
+  override def getValue: Iterable[Genotype] = {
+    require(input != null, "called getValue before serialized value was set")
+
+    gsb.clear()
+
+    input
+      .iterator
+      .flatMap { i => Iterator(i & 3, (i >> 2) & 3, (i >> 4) & 3, (i >> 6) & 3) }
+      .take(nSamples)
+      .map(PlinkBlockReader.GT_CONVERSION)
+      .foreach { i =>
+        gb.clear()
+        if (i >= 0)
+          gb.setGT(i)
+        gsb.write(gb)
+      }
+    gsb.result()
+  }
+}
+
 
 object PlinkBlockReader {
   final val GT_CONVERSION = Array(2, -1, 1, 0)
 }
 
-class PlinkBlockReader(job: Configuration, split: FileSplit) extends IndexedBinaryBlockReader[Int](job, split) {
+class PlinkBlockReader(job: Configuration, split: FileSplit) extends IndexedBinaryBlockReader[PlinkRecord](job, split) {
   var variantIndex: Long = 0L
   val nSamples = job.getInt("nSamples", 0)
   val compressGS = job.getBoolean("compressGS", false)
   val blockLength = (nSamples + 3) / 4
 
-  val ab = new mutable.ArrayBuilder.ofByte
+  val gb = new GenotypeBuilder(2, isDosage = false)
+  val gsb = new GenotypeStreamBuilder(2, isDosage = false, compress = compressGS)
 
   seekToFirstBlockInSplit(split.getStart)
+
+  override def createValue(): PlinkRecord = new PlinkRecord(nSamples, gb, gsb)
 
   def seekToFirstBlockInSplit(start: Long) {
     variantIndex = math.max(0, (start - 3 + blockLength - 1) / blockLength)
@@ -36,26 +59,11 @@ class PlinkBlockReader(job: Configuration, split: FileSplit) extends IndexedBina
     bfis.seek(pos)
   }
 
-  def next(key: LongWritable, value: VariantRecord[Int]): Boolean = {
+  def next(key: LongWritable, value: PlinkRecord): Boolean = {
     if (pos >= end)
       false
     else {
-      val b = new GenotypeStreamBuilder(2, isDosage = false, compress = compressGS)
-      val genoBuilder = new GenotypeBuilder(2, isDosage = false)
-
-      bfis.readBytes(blockLength)
-        .iterator
-        .flatMap { i => Iterator(i & 3, (i >> 2) & 3, (i >> 4) & 3, (i >> 6) & 3) }
-        .take(nSamples)
-        .map(PlinkBlockReader.GT_CONVERSION)
-        .foreach { i =>
-          genoBuilder.clear()
-          if (i >= 0)
-            genoBuilder.setGT(i)
-          b.write(genoBuilder)
-        }
-
-      value.setGS(b.result())
+      value.setSerializedValue(bfis.readBytes(blockLength))
 
       assert(variantIndex >= 0 && variantIndex <= Integer.MAX_VALUE)
       value.setKey(variantIndex.toInt)

--- a/src/main/scala/org/broadinstitute/hail/io/plink/PlinkInputFormat.scala
+++ b/src/main/scala/org/broadinstitute/hail/io/plink/PlinkInputFormat.scala
@@ -2,11 +2,11 @@ package org.broadinstitute.hail.io.plink
 
 import org.apache.hadoop.io.LongWritable
 import org.apache.hadoop.mapred._
-import org.broadinstitute.hail.io.{IndexedBinaryInputFormat, VariantRecord}
+import org.broadinstitute.hail.io.{IndexedBinaryInputFormat, KeySerializedValueRecord}
 
-class PlinkInputFormat extends IndexedBinaryInputFormat[Int] {
+class PlinkInputFormat extends IndexedBinaryInputFormat[PlinkRecord] {
   override def getRecordReader(split: InputSplit, job: JobConf, reporter: Reporter): RecordReader[LongWritable,
-    VariantRecord[Int]] = {
+    PlinkRecord] = {
     reporter.setStatus(split.toString)
     new PlinkBlockReader(job, split.asInstanceOf[FileSplit])
   }


### PR DESCRIPTION
Refactored VariantRecord to RecordDecoder, made genotype decoding
lazy.  This allows us to get out fastKeys and the genotypes with the
same abstraction.

Refactored multiple BGEN file handling to BgenLoader, where it should be.

Added assertions that we silently relied on.