### PR TITLE
expose OrderedRDD.flatMapMonotonic

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
@@ -440,6 +440,12 @@ class VariantSampleMatrix[T](val metadata: VariantMetadata,
       }
   }
 
+  /**
+    * The function {@code f} must be monotonic with respect to the ordering on {@code Locus}
+    */
+  def flatMapVariants(f: (Variant, Annotation, Iterable[T]) => TraversableOnce[(Variant, (Annotation, Iterable[T]))]): VariantSampleMatrix[T] =
+    copy(rdd = rdd.flatMapMonotonic[(Annotation, Iterable[T])] { case (v, (va, gs)) => f(v, va, gs) })
+
   def filterVariants(p: (Variant, Annotation, Iterable[T]) => Boolean): VariantSampleMatrix[T] =
     copy(rdd = rdd.filter { case (v, (va, gs)) => p(v, va, gs) }.toOrderedRDD)
 


### PR DESCRIPTION
This function permits developers to preserve ordering
when flatMaping a function which produces elements
montonically related to the source element.

This change depends on PR #706. Merging that commit will simplify this diff.