### PR TITLE
Introduce OrderedKey and OrderedKeyFunction

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/driver/FilterVariantsAll.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/FilterVariantsAll.scala
@@ -19,6 +19,6 @@ object FilterVariantsAll extends Command {
   def requiresVDS = true
 
   def run(state: State, options: Options): State = {
-    state.copy(vds = state.vds.copy(rdd = OrderedRDD.empty[Locus, Variant, (Annotation, Iterable[Genotype])](state.sc, _.locus)))
+    state.copy(vds = state.vds.copy(rdd = OrderedRDD.empty(state.sc)))
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/FilterVariantsList.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/FilterVariantsList.scala
@@ -55,7 +55,7 @@ object FilterVariantsList extends Command {
     state.copy(
       vds = vds.copy(
         rdd = vds.rdd
-          .orderedLeftJoinDistinct(variants.toOrderedRDD(_.locus))
+          .orderedLeftJoinDistinct(variants.toOrderedRDD[Locus])
           .mapPartitions({ it =>
             it.flatMap { case (v, ((va, gs), o)) =>
               o match {
@@ -66,7 +66,7 @@ object FilterVariantsList extends Command {
               }
             }
           }, preservesPartitioning = true)
-          .toOrderedRDD(_.locus)
+          .toOrderedRDD[Locus]
       ))
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/ImportAnnotations.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/ImportAnnotations.scala
@@ -67,7 +67,7 @@ object ImportAnnotationsTable extends Command with JoinAnnotator {
         ec.setAll(a.asInstanceOf[Row].toSeq: _*)
         variantFn().map(v => (v, (fn(null, Some(a)), Iterable.empty[Genotype])))
       }.value
-    }.toOrderedRDD(_.locus)
+    }.toOrderedRDD[Locus]
 
     val vds: VariantDataset = VariantSampleMatrix(VariantMetadata(Array.empty[String], IndexedSeq.empty[Annotation], Annotation.empty,
       TStruct.empty, finalType, TStruct.empty), keyedRDD)

--- a/src/main/scala/org/broadinstitute/hail/driver/ImportBGEN.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/ImportBGEN.scala
@@ -91,7 +91,7 @@ object ImportBGEN extends Command {
     val signature = TStruct("rsid" -> TString, "varid" -> TString)
 
     val vds = VariantSampleMatrix(VariantMetadata(samples).copy(isDosage = true),
-      sc.union(results.map(_.rdd)).toOrderedRDD(_.locus))
+      sc.union(results.map(_.rdd)).toOrderedRDD[Locus])
       .copy(vaSignature = signature, wasSplit = true)
 
     state.copy(vds = vds)

--- a/src/main/scala/org/broadinstitute/hail/driver/ImportGEN.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/ImportGEN.scala
@@ -88,7 +88,7 @@ object ImportGEN extends Command {
     val signature = TStruct("rsid" -> TString, "varid" -> TString)
 
     val vds = VariantSampleMatrix(VariantMetadata(samples).copy(isDosage = true),
-      sc.union(results.map(_.rdd)).toOrderedRDD(_.locus))
+      sc.union(results.map(_.rdd)).toOrderedRDD[Locus])
       .copy(vaSignature = signature, wasSplit = true)
 
     state.copy(vds = vds)

--- a/src/main/scala/org/broadinstitute/hail/driver/LinearRegressionCommand.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/LinearRegressionCommand.scala
@@ -101,7 +101,7 @@ object LinearRegressionCommand extends Command {
             assert(v == v2)
             (v, (inserter(va, comb.map(_.toAnnotation)), gs))
           }
-        }.toOrderedRDD(_.locus),
+        }.toOrderedRDD[Locus],
         vaSignature = newVAS
       )
     )

--- a/src/main/scala/org/broadinstitute/hail/driver/SplitMulti.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/SplitMulti.scala
@@ -201,7 +201,7 @@ object SplitMulti extends Command {
             })
         }
       }, preservesPartitioning = true)
-        .toOrderedRDD(_.locus))
+        .toOrderedRDD[Locus])
     state.copy(vds = newVDS)
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/VEP.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/VEP.scala
@@ -4,6 +4,7 @@ import java.io.{FileInputStream, IOException}
 import java.util.Properties
 
 import org.apache.spark.storage.StorageLevel
+import org.broadinstitute.hail.RichPairIterator
 import org.broadinstitute.hail.Utils._
 import org.broadinstitute.hail.annotations.Annotation
 import org.broadinstitute.hail.expr._
@@ -311,7 +312,7 @@ object VEP extends Command {
           .map { case (v, ((va, gs), vaVep)) =>
             (v, (vaVep.map(a => insertVEP(va, Some(a))).getOrElse(va), gs))
           }
-      }.toOrderedRDD(_.locus)
+      }.toOrderedRDD[Locus]
 
     val newVDS = vds.copy(rdd = newRDD,
       vaSignature = newVASignature)

--- a/src/main/scala/org/broadinstitute/hail/driver/VariantQC.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/VariantQC.scala
@@ -253,7 +253,7 @@ object VariantQC extends Command {
             assert(v == v2)
             (v, (insertQC(va, Some(comb.asAnnotation)), gs))
           }
-        }.toOrderedRDD(_.locus), vaSignature = newVAS)
+        }.toOrderedRDD[Locus], vaSignature = newVAS)
     )
   }
 

--- a/src/main/scala/org/broadinstitute/hail/io/plink/PlinkLoader.scala
+++ b/src/main/scala/org/broadinstitute/hail/io/plink/PlinkLoader.scala
@@ -124,7 +124,7 @@ object PlinkLoader {
       case (lw, vr) =>
         val (v, rsId) = variantsBc.value(vr.getKey)
         (v, (Annotation(rsId), vr.getGS))
-    }.toOrderedRDD(_.locus)
+    }.toOrderedRDD[Locus]
 
     VariantSampleMatrix(VariantMetadata(
       sampleIds = sampleIds,

--- a/src/main/scala/org/broadinstitute/hail/io/vcf/LoadVCF.scala
+++ b/src/main/scala/org/broadinstitute/hail/io/vcf/LoadVCF.scala
@@ -264,7 +264,7 @@ object LoadVCF {
           }.value
           }
         }
-    }).toOrderedRDD(_.locus, Some(justVariants))
+    }).toOrderedRDD[Locus](Some(justVariants))
 
     justVariants.unpersist()
 

--- a/src/main/scala/org/broadinstitute/hail/sparkextras/OrderedDependency.scala
+++ b/src/main/scala/org/broadinstitute/hail/sparkextras/OrderedDependency.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.hail.sparkextras
 import org.apache.spark.NarrowDependency
 import org.apache.spark.rdd.RDD
 
-class OrderedDependency[T, K1, K2, V](p1: OrderedPartitioner[T, K1], p2: OrderedPartitioner[T, K2],
+class OrderedDependency[PK, K1, K2, V](p1: OrderedPartitioner[PK, K1], p2: OrderedPartitioner[PK, K2],
   rdd: RDD[(K2, V)]) extends NarrowDependency[(K2, V)](rdd) {
   override def getParents(partitionId: Int): Seq[Int] = {
     val (start, end) = OrderedDependency.getDependencies(p1, p2)(partitionId)
@@ -12,7 +12,7 @@ class OrderedDependency[T, K1, K2, V](p1: OrderedPartitioner[T, K1], p2: Ordered
 }
 
 object OrderedDependency {
-  def getDependencies[T](p1: OrderedPartitioner[T, _], p2: OrderedPartitioner[T, _])(partitionId: Int): (Int, Int) = {
+  def getDependencies[PK](p1: OrderedPartitioner[PK, _], p2: OrderedPartitioner[PK, _])(partitionId: Int): (Int, Int) = {
 
     val lastPartition = if (partitionId == p1.rangeBounds.length)
       p2.numPartitions - 1

--- a/src/main/scala/org/broadinstitute/hail/variant/Locus.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/Locus.scala
@@ -2,7 +2,10 @@ package org.broadinstitute.hail.variant
 
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.broadinstitute.hail.check.Gen
+import org.broadinstitute.hail.sparkextras.OrderedKey
 import org.json4s._
+
+import scala.reflect.ClassTag
 
 object Locus {
   val simpleContigs: Seq[String] = (1 to 22).map(_.toString) ++ Seq("X", "Y", "MT")
@@ -17,6 +20,19 @@ object Locus {
       .map { case (contig, pos) => Locus(contig, pos) }
 
   def gen: Gen[Locus] = gen(simpleContigs)
+
+
+  implicit def orderedKey = new OrderedKey[Locus, Locus] {
+    def project(key: Locus): Locus = key
+
+    def kOrd: Ordering[Locus] = implicitly[Ordering[Locus]]
+
+    def pkOrd: Ordering[Locus] = implicitly[Ordering[Locus]]
+
+    def kct: ClassTag[Locus] = implicitly[ClassTag[Locus]]
+
+    def pkct: ClassTag[Locus] = implicitly[ClassTag[Locus]]
+  }
 }
 
 case class Locus(contig: String, position: Int) extends Ordered[Locus] {

--- a/src/main/scala/org/broadinstitute/hail/variant/Variant.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/Variant.scala
@@ -5,9 +5,11 @@ import org.apache.spark.sql.types._
 import org.broadinstitute.hail.Utils._
 import org.broadinstitute.hail.check.{Arbitrary, Gen}
 import org.broadinstitute.hail.expr._
+import org.broadinstitute.hail.sparkextras.OrderedKey
 import org.json4s._
 
 import scala.math.Numeric.Implicits._
+import scala.reflect.ClassTag
 
 object Contig {
   val standardContigs = (1 to 23).map(_.toString) ++ IndexedSeq("X", "Y", "MT")
@@ -163,6 +165,19 @@ object Variant {
       r.getSeq[Row](3)
         .map(s => AltAllele.fromRow(s))
         .toArray)
+
+  implicit def orderedKey: OrderedKey[Locus, Variant] =
+    new OrderedKey[Locus, Variant] {
+      def project(key: Variant): Locus = key.locus
+
+      def kOrd: Ordering[Variant] = implicitly[Ordering[Variant]]
+
+      def pkOrd: Ordering[Locus] = implicitly[Ordering[Locus]]
+
+      def kct: ClassTag[Variant] = implicitly[ClassTag[Variant]]
+
+      def pkct: ClassTag[Locus] = implicitly[ClassTag[Locus]]
+    }
 }
 
 object VariantSubgen {

--- a/src/test/scala/org/broadinstitute/hail/methods/ImputeSexSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/ImputeSexSuite.scala
@@ -40,7 +40,7 @@ class ImputeSexSuite extends SparkSuite {
 
         var s = State(sc, sqlContext).copy(vds = vds.copy(rdd =
           vds.rdd.map { case (v, (va, gs)) => (v.copy(contig = "X"), (va, gs)) }
-            .toOrderedRDD(_.locus)))
+            .toOrderedRDD[Locus]))
 
         s = SplitMulti.run(s)
         s = VariantQC.run(s)

--- a/src/test/scala/org/broadinstitute/hail/utils/TestRDDBuilder.scala
+++ b/src/test/scala/org/broadinstitute/hail/utils/TestRDDBuilder.scala
@@ -127,6 +127,6 @@ object TestRDDBuilder {
         }
         (variant, (Annotation.empty, b.result(): Iterable[Genotype]))
     }
-    VariantSampleMatrix(VariantMetadata(sampleList), streamRDD.toOrderedRDD(_.locus))
+    VariantSampleMatrix(VariantMetadata(sampleList), streamRDD.toOrderedRDD[Locus])
   }
 }

--- a/src/test/scala/org/broadinstitute/hail/utils/UtilsSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/utils/UtilsSuite.scala
@@ -3,8 +3,9 @@ package org.broadinstitute.hail.utils
 import org.broadinstitute.hail.Utils._
 import org.broadinstitute.hail.check.Arbitrary._
 import org.broadinstitute.hail.check.{Gen, Prop}
+import org.broadinstitute.hail.sparkextras.OrderedRDD
 import org.broadinstitute.hail.variant._
-import org.broadinstitute.hail.{SpanningIterator, SparkSuite}
+import org.broadinstitute.hail.{RichPairIterator, SpanningIterator, SparkSuite}
 import org.testng.annotations.Test
 
 class UtilsSuite extends SparkSuite {
@@ -131,9 +132,9 @@ class UtilsSuite extends SparkSuite {
     val p = Prop.forAll(Gen.buildableOf[IndexedSeq, (Variant, Int)](g)) { is =>
       val kSorted = is.sortBy(_._1)
       val tSorted = is.sortBy(_._1.locus)
-      val localKeySort = is.sortBy(_._1.locus).iterator.localKeySort[Locus](_.locus).toIndexedSeq
+      val localKeySorted = OrderedRDD.localKeySort(is.sortBy(_._1.locus).iterator).toIndexedSeq
 
-      kSorted == localKeySort
+      kSorted == localKeySorted
     }
 
     p.check()

--- a/src/test/scala/org/broadinstitute/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/variant/vsm/VSMSuite.scala
@@ -101,7 +101,7 @@ class VSMSuite extends SparkSuite {
       (v2, (va2,
         Iterable(Genotype(0),
           Genotype(0),
-          Genotype(1)))))).toOrderedRDD(_.locus)
+          Genotype(1)))))).toOrderedRDD[Locus]
 
     // differ in variant
     val rdd2 = sc.parallelize(Seq((v1, (va1,
@@ -111,7 +111,7 @@ class VSMSuite extends SparkSuite {
       (v3, (va2,
         Iterable(Genotype(0),
           Genotype(0),
-          Genotype(1)))))).toOrderedRDD(_.locus)
+          Genotype(1)))))).toOrderedRDD[Locus]
 
     // differ in genotype
     val rdd3 = sc.parallelize(Seq((v1, (va1,
@@ -121,7 +121,7 @@ class VSMSuite extends SparkSuite {
       (v2, (va2,
         Iterable(Genotype(0),
           Genotype(0),
-          Genotype(1)))))).toOrderedRDD(_.locus)
+          Genotype(1)))))).toOrderedRDD[Locus]
 
     // for mdata2
     val rdd4 = sc.parallelize(Seq((v1, (va1,
@@ -129,12 +129,12 @@ class VSMSuite extends SparkSuite {
         Genotype(0)))),
       (v2, (va2, Iterable(
         Genotype(0),
-        Genotype(0)))))).toOrderedRDD(_.locus)
+        Genotype(0)))))).toOrderedRDD[Locus]
 
     // differ in number of variants
     val rdd5 = sc.parallelize(Seq((v1, (va1,
       Iterable(Genotype(),
-        Genotype(0)))))).toOrderedRDD(_.locus)
+        Genotype(0)))))).toOrderedRDD[Locus]
 
     // differ in annotations
     val rdd6 = sc.parallelize(Seq((v1, (va1,
@@ -144,7 +144,7 @@ class VSMSuite extends SparkSuite {
       (v2, (va3,
         Iterable(Genotype(0),
           Genotype(0),
-          Genotype(1)))))).toOrderedRDD(_.locus)
+          Genotype(1)))))).toOrderedRDD[Locus]
 
     val vdss = Array(new VariantDataset(mdata1, rdd1),
       new VariantDataset(mdata1, rdd2),


### PR DESCRIPTION
An `OrderedKey[PK,K]` is a proof that there exists a monotone function
from `K` to `PK`, which of course requires orderings on `K` and `PK`. For
convenience in our particular use-case, we demand class tags for `K` and
`PK`.

An `OrderedKeyFunction[K1,PK1,K2,PK2]` transforms from one pair to
another. In particular, the transformation must be monotonic at the `K`
and `PK` levels. Moreover, these transformations must commute with the
respective project methods of `OrderedKey[PK,K]`.