### PR TITLE
Added asOrderedRDD and toOrderedRDD that takes ranges.

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsLoci.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsLoci.scala
@@ -68,7 +68,7 @@ object AnnotateVariantsLoci extends Command with JoinAnnotator {
       _.map { a =>
         locusQuery(a).map(l => (l, a))
       }.value
-    }
+    }.toOrderedRDD[Locus]
 
     state.copy(vds = vds
       .withGenotypeStream()

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsTable.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsTable.scala
@@ -5,7 +5,7 @@ import org.broadinstitute.hail.Utils._
 import org.broadinstitute.hail.annotations._
 import org.broadinstitute.hail.expr._
 import org.broadinstitute.hail.utils._
-import org.broadinstitute.hail.variant.Variant
+import org.broadinstitute.hail.variant.{Locus, Variant}
 import org.kohsuke.args4j.{Argument, Option => Args4jOption}
 
 import scala.collection.JavaConverters._
@@ -68,7 +68,7 @@ object AnnotateVariantsTable extends Command with JoinAnnotator {
       _.map { a =>
         variantQuery(a).map(v => (v, a))
       }.value
-    }
+    }.toOrderedRDD[Locus]
 
     state.copy(vds = vds
       .withGenotypeStream()

--- a/src/main/scala/org/broadinstitute/hail/driver/FilterVariantsList.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/FilterVariantsList.scala
@@ -66,7 +66,7 @@ object FilterVariantsList extends Command {
               }
             }
           }, preservesPartitioning = true)
-          .toOrderedRDD[Locus]
+          .asOrderedRDD[Locus]
       ))
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/LinearRegressionCommand.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/LinearRegressionCommand.scala
@@ -101,7 +101,7 @@ object LinearRegressionCommand extends Command {
             assert(v == v2)
             (v, (inserter(va, comb.map(_.toAnnotation)), gs))
           }
-        }.toOrderedRDD[Locus],
+        }.asOrderedRDD[Locus],
         vaSignature = newVAS
       )
     )

--- a/src/main/scala/org/broadinstitute/hail/driver/VEP.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/VEP.scala
@@ -312,7 +312,7 @@ object VEP extends Command {
           .map { case (v, ((va, gs), vaVep)) =>
             (v, (vaVep.map(a => insertVEP(va, Some(a))).getOrElse(va), gs))
           }
-      }.toOrderedRDD[Locus]
+      }.asOrderedRDD[Locus]
 
     val newVDS = vds.copy(rdd = newRDD,
       vaSignature = newVASignature)

--- a/src/main/scala/org/broadinstitute/hail/driver/VariantQC.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/VariantQC.scala
@@ -253,7 +253,7 @@ object VariantQC extends Command {
             assert(v == v2)
             (v, (insertQC(va, Some(comb.asAnnotation)), gs))
           }
-        }.toOrderedRDD[Locus], vaSignature = newVAS)
+        }.asOrderedRDD[Locus], vaSignature = newVAS)
     )
   }
 


### PR DESCRIPTION
asOrderedRDD asserts the VSM is an OrderedRDD or partitioned by a OrderedPartitioner.
added new toOrderedRDD that takes ranges and always shuffles.