### PR TITLE
Fix Genotype from linear function

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/variant/Genotype.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/Genotype.scala
@@ -363,7 +363,7 @@ object Genotype {
       else
         f(i + 1, m, mi, count)
     }
-    f(1, 0, a(0), 1)
+    f(0, 0, a(0), 1)
   }
 
   def weightsToLinear[T: Numeric](a: Array[T]): Array[Int] = {
@@ -599,8 +599,7 @@ object Genotype {
 
   def genDosage(nAlleles: Int): Gen[Genotype] = {
     val nGenotypes = triangle(nAlleles)
-    // FIXME hack, add Gen.partition(nParts) and Gen.partitionN(nParts, size)
-    for (px <- Gen.option(Gen.partition(nGenotypes).resize(32768))) yield {
+    for (px <- Gen.option(Gen.partition(nGenotypes, 32768))) yield {
       val gt = px.flatMap(gtFromLinear)
       val g = Genotype(gt = gt, px = px, isDosage = true)
       g.check(nAlleles)

--- a/src/main/scala/org/broadinstitute/hail/variant/Variant.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/Variant.scala
@@ -192,6 +192,8 @@ object VariantSubgen {
   val plinkCompatible = random.copy(
     contigGen = Gen.choose(1, 22).map(_.toString)
   )
+
+  val biallelic = random.copy(nAllelesGen = Gen.const(2))
 }
 
 case class VariantSubgen(

--- a/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
@@ -257,7 +257,7 @@ case class VSMSubgen[T](
 
   def gen(sc: SparkContext)(implicit tct: ClassTag[T]): Gen[VariantSampleMatrix[T]] =
     for (size <- Gen.size;
-      subsizes <- Gen.partition(5).resize(size / 10);
+      subsizes <- Gen.partitionSize(5).resize(size / 10);
       vaSig <- vaSigGen.resize(subsizes(0));
       saSig <- saSigGen.resize(subsizes(1));
       globalSig <- globalSigGen.resize(subsizes(2));
@@ -270,7 +270,7 @@ case class VSMSubgen[T](
       nSamples = sampleIds.length;
       saValues <- Gen.buildableOfN[IndexedSeq, Annotation](nSamples, saGen(saSig)).resize(subsizes(4));
       rows <- Gen.distinctBuildableOf[Seq, (Variant, (Annotation, Iterable[T]))](
-        for (subsubsizes <- Gen.partition(3);
+        for (subsubsizes <- Gen.partitionSize(3);
           v <- vGen.resize(subsubsizes(0));
           va <- vaGen(vaSig).resize(subsubsizes(1));
           ts <- Gen.buildableOfN[Iterable, T](nSamples, tGen(v.nAlleles)).resize(subsubsizes(2)))


### PR DESCRIPTION
Fix bug in Genotype.gtFromLinear

We had a destructive bug in this function that
caused dosages to never result in a HomRef call.
Our tests were inadequate because we used this
function both in the generator and import, i.e.
testing it against itself.  I added a unit test for
this method.

Fixes #714