### PR TITLE
Added PropertySuite.

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/check/Prop.scala
+++ b/src/main/scala/org/broadinstitute/hail/check/Prop.scala
@@ -1,24 +1,10 @@
 package org.broadinstitute.hail.check
 
-import org.broadinstitute.hail.Utils._
 import org.apache.commons.math3.random.RandomDataGenerator
-
-import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
 abstract class Prop {
   def apply(p: Parameters, name: Option[String] = None): Unit
-
-  def check() {
-    val size = System.getProperty("check.size", "1000").toInt
-    val count = System.getProperty("check.count", "10").toInt
-
-    println(s"check: size = $size, count = $count")
-
-    val rng = new RandomDataGenerator()
-    rng.reSeed(Prop.seed)
-    apply(Parameters(rng, size, count))
-  }
 }
 
 class GenProp1[T1](g1: Gen[T1], f: (T1) => Boolean) extends Prop {
@@ -75,23 +61,6 @@ class GenProp3[T1, T2, T3](g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], f: (T1, T2, T3
   }
 }
 
-class Properties(val name: String) extends Prop {
-  val properties = ArrayBuffer.empty[(String, Prop)]
-
-  class PropertySpecifier {
-    def update(propName: String, prop: Prop) {
-      properties += (name + "." + propName) -> prop
-    }
-  }
-
-  lazy val property = new PropertySpecifier
-
-  override def apply(p: Parameters, prefix: Option[String]) {
-    for ((propName, prop) <- properties)
-      prop(p, prefix.map(_ + "." + propName).orElse(Some(propName)))
-  }
-}
-
 object Prop {
   lazy val _seed: Int = {
     val seedStr = System.getProperty("check.seed")
@@ -106,10 +75,6 @@ object Prop {
   def seed: Int = {
     println(s"check: seed = ${ _seed }")
     _seed
-  }
-
-  def check(prop: Prop) {
-    prop.check()
   }
 
   def forAll[T1](g1: Gen[T1])(p: (T1) => Boolean): Prop =

--- a/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
@@ -164,7 +164,7 @@ object VariantSampleMatrix {
           }
       }.getOrElse(sc.emptyRDD[(Variant, (Annotation, Iterable[Genotype]))])
     }
-    
+
     val partitioner = {
         try {
           Some(readObjectFile(dirname + "/partitioner", sqlContext.sparkContext.hadoopConfiguration) { in =>

--- a/src/test/scala/org/broadinstitute/hail/SparkSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/SparkSuite.scala
@@ -2,47 +2,75 @@ package org.broadinstitute.hail
 
 import java.io.File
 
+import org.apache.commons.math3.random.RandomDataGenerator
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.SparkContext
 import org.broadinstitute.hail.driver.{HailConfiguration, SparkManager}
 import org.scalatest.testng.TestNGSuite
-import org.testng.annotations.{AfterClass, BeforeClass}
+import org.testng.annotations.{AfterClass, BeforeClass, Test}
 import org.apache.hadoop
+import org.broadinstitute.hail.check.{Parameters, Prop}
 
-class SparkSuite extends TestNGSuite {
-  var sc: SparkContext = _
-  var sqlContext: SQLContext = _
+import scala.collection.mutable.ArrayBuffer
+
+trait SparkSuite extends TestNGSuite {
+  lazy val sc: SparkContext = {
+    val jar = getClass.getProtectionDomain.getCodeSource.getLocation.toURI.getPath
+    HailConfiguration.installDir = new File(jar).getParent + "/.."
+    HailConfiguration.tmpDir = "/tmp"
+
+    Logger.getLogger("org").setLevel(Level.OFF)
+    Logger.getLogger("akka").setLevel(Level.OFF)
+
+    val master = System.getProperty("hail.master")
+    SparkManager.createSparkContext("Hail.TestNG", Option(master), "local")
+  }
+
+  lazy val sqlContext: SQLContext = {
+    // force
+    sc
+
+    SparkManager.createSQLContext()
+  }
+
   lazy val hadoopConf: hadoop.conf.Configuration =
     sc.hadoopConfiguration
 
   val noArgs: Array[String] = Array.empty[String]
 
   var _tmpDir: TempDir = _
+
   def tmpDir: TempDir = {
     if (_tmpDir == null)
       _tmpDir = TempDir("/tmp", hadoopConf)
     _tmpDir
   }
+}
 
-  @BeforeClass
-  def startSpark() {
-    val master = System.getProperty("hail.master")
-    sc = SparkManager.createSparkContext("Hail.TestNG", Option(master), "local")
+trait PropertySuite extends SparkSuite {
+  val properties = ArrayBuffer.empty[(String, Prop)]
 
-    sqlContext = SparkManager.createSQLContext()
-
-    Logger.getLogger("org").setLevel(Level.OFF)
-    Logger.getLogger("akka").setLevel(Level.OFF)
-
-    val jar = getClass.getProtectionDomain.getCodeSource.getLocation.toURI.getPath
-    HailConfiguration.installDir = new File(jar).getParent + "/.."
-    HailConfiguration.tmpDir = "/tmp"
+  class PropertySpecifier {
+    def update(propName: String, prop: Prop) {
+      properties += propName -> prop
+    }
   }
 
-  @AfterClass(alwaysRun = true)
-  def stopSparkContext() {
-    sc = null
-    sqlContext = null
+  lazy val property = new PropertySpecifier
+
+  @Test def test() {
+    val size = System.getProperty("check.size", "1000").toInt
+    val count = System.getProperty("check.count", "10").toInt
+
+    println(s"check: size = $size, count = $count")
+
+    val rng = new RandomDataGenerator()
+    rng.reSeed(Prop.seed)
+    val p = Parameters(rng, size, count)
+
+    properties.foreach { case (name, prop) =>
+      prop(p, Some(name))
+    }
   }
 }

--- a/src/test/scala/org/broadinstitute/hail/driver/FilterVariantsSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/driver/FilterVariantsSuite.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.hail.driver
 
-import org.broadinstitute.hail.SparkSuite
+import org.broadinstitute.hail.{PropertySuite, SparkSuite}
 import org.broadinstitute.hail.Utils._
 import org.broadinstitute.hail.check.Arbitrary._
 import org.broadinstitute.hail.check.Prop._
@@ -8,38 +8,6 @@ import org.broadinstitute.hail.check.{Gen, Prop}
 import org.testng.annotations.Test
 
 class FilterVariantsSuite extends SparkSuite {
-  @Test def test() {
-    var s = State(sc, sqlContext)
-
-    s = ImportVCF.run(s, Array("src/test/resources/sample2.vcf"))
-
-    val variants = s.vds.variants.collect().toSet
-
-    val f = tmpDir.createTempFile("test", extension = ".variant_list")
-    Prop.check(forAll(Gen.subset(variants), arbitrary[Boolean]) { case (subset, keep) =>
-      writeTextFile(f, s.hadoopConf) { s =>
-        for (v <- subset) {
-          s.write(v.toString)
-          s.write("\n")
-        }
-      }
-
-      val t = FilterVariantsList.run(s, Array(
-        if (keep)
-          "--keep"
-        else
-          "--remove",
-        "-i", f))
-
-      val tVariants = t.vds.variants.collect().toSet
-      if (keep)
-        tVariants == subset
-      else
-        (tVariants.union(subset) == variants
-          && tVariants.intersect(subset).isEmpty)
-    })
-  }
-
   @Test def testFilterAll() {
     var s = State(sc, sqlContext)
 
@@ -48,4 +16,37 @@ class FilterVariantsSuite extends SparkSuite {
 
     assert(s.vds.nVariants == 0)
   }
+}
+
+class FilterVariantsProperties extends PropertySuite {
+  var s = State(sc, sqlContext)
+  s = ImportVCF.run(s, Array("src/test/resources/sample2.vcf"))
+
+  val variants = s.vds.variants.collect().toSet
+
+  val f = tmpDir.createTempFile("test", extension = ".variant_list")
+
+  property("test") = forAll(Gen.subset(variants), arbitrary[Boolean]) { case (subset, keep) =>
+    writeTextFile(f, s.hadoopConf) { s =>
+      for (v <- subset) {
+        s.write(v.toString)
+        s.write("\n")
+      }
+    }
+
+    val t = FilterVariantsList.run(s, Array(
+      if (keep)
+        "--keep"
+      else
+        "--remove",
+      "-i", f))
+
+    val tVariants = t.vds.variants.collect().toSet
+    if (keep)
+      tVariants == subset
+    else
+      (tVariants.union(subset) == variants
+        && tVariants.intersect(subset).isEmpty)
+  }
+
 }

--- a/src/test/scala/org/broadinstitute/hail/io/ImportPlinkSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/io/ImportPlinkSuite.scala
@@ -3,60 +3,47 @@ package org.broadinstitute.hail.io
 import org.apache.spark.rdd.RDD
 import org.broadinstitute.hail.check.Gen._
 import org.broadinstitute.hail.check.Prop._
-import org.broadinstitute.hail.check.Properties
 import org.broadinstitute.hail.driver._
 import org.broadinstitute.hail.io.plink.PlinkLoader
 import org.broadinstitute.hail.variant._
-import org.broadinstitute.hail.Utils._
-import org.broadinstitute.hail.{FatalException, SparkSuite}
-import org.testng.annotations.Test
+import org.broadinstitute.hail.{FatalException, PropertySuite, SparkSuite}
 
 import scala.language.postfixOps
 import scala.sys.process._
 
-class ImportPlinkSuite extends SparkSuite {
+class ImportPlinkSuite extends PropertySuite {
 
-  object Spec extends Properties("ImportPlink") {
-    val compGen = for (vds: VariantDataset <- VariantSampleMatrix.gen[Genotype](sc, VSMSubgen.random);
-      nPartitions: Int <- choose(1, PlinkLoader.expectedBedSize(vds.nSamples, vds.nVariants).toInt.min(10))) yield (vds, nPartitions)
+  val compGen = for (vds: VariantDataset <- VariantSampleMatrix.gen[Genotype](sc, VSMSubgen.random);
+    nPartitions: Int <- choose(1, PlinkLoader.expectedBedSize(vds.nSamples, vds.nVariants).toInt.min(10))) yield (vds, nPartitions)
 
-    property("import generates same output as export") =
-      forAll(compGen) { case (vds: VariantSampleMatrix[Genotype], nPartitions: Int) =>
+  property("import generates same output as export") =
+    forAll(compGen) { case (vds: VariantSampleMatrix[Genotype], nPartitions: Int) =>
 
-        val tmpTruthRoot = tmpDir.createTempFile(prefix = "truth")
-        val tmpTestRoot = tmpDir.createTempFile(prefix = "test")
+      val tmpTruthRoot = tmpDir.createTempFile(prefix = "truth")
+      val tmpTestRoot = tmpDir.createTempFile(prefix = "test")
 
-        var s = State(sc, sqlContext, vds)
+      var s = State(sc, sqlContext, vds)
 
-        s = SplitMulti.run(s, Array[String]())
-        val save = s.vds
-        s = ExportPlink.run(s, Array("-o", tmpTruthRoot))
-        if (s.vds.nSamples == 0 || s.vds.nVariants == 0)
-          try {
-            s = ImportPlink.run(s, Array("--bfile", tmpTruthRoot, "-n", nPartitions.toString))
-            false
-          } catch {
-            case e: FatalException => true
-            case _: Throwable => false
-          }
-        else {
+      s = SplitMulti.run(s, Array[String]())
+      val save = s.vds
+      s = ExportPlink.run(s, Array("-o", tmpTruthRoot))
+      if (s.vds.nSamples == 0 || s.vds.nVariants == 0)
+        try {
           s = ImportPlink.run(s, Array("--bfile", tmpTruthRoot, "-n", nPartitions.toString))
-          s = ExportPlink.run(s, Array("-o", tmpTestRoot))
-
-          val exitCodeFam = s"diff $tmpTruthRoot.fam $tmpTestRoot.fam" !
-          val exitCodeBim = s"diff $tmpTruthRoot.bim $tmpTestRoot.bim" !
-          val exitCodeBed = s"diff $tmpTruthRoot.bed $tmpTestRoot.bed" !
-
-          if (exitCodeFam == 0 && exitCodeBim == 0 && exitCodeBed == 0)
-            true
-          else {
-            false
-          }
+          false
+        } catch {
+          case e: FatalException => true
+          case _: Throwable => false
         }
-      }
-  }
+      else {
+        s = ImportPlink.run(s, Array("--bfile", tmpTruthRoot, "-n", nPartitions.toString))
+        s = ExportPlink.run(s, Array("-o", tmpTestRoot))
 
-  @Test def testPlinkImportRandom() {
-    Spec.check()
-  }
+        val exitCodeFam = s"diff $tmpTruthRoot.fam $tmpTestRoot.fam" !
+        val exitCodeBim = s"diff $tmpTruthRoot.bim $tmpTestRoot.bim" !
+        val exitCodeBed = s"diff $tmpTruthRoot.bed $tmpTestRoot.bed" !
+
+        exitCodeFam == 0 && exitCodeBim == 0 && exitCodeBed == 0
+      }
+    }
 }

--- a/src/test/scala/org/broadinstitute/hail/io/IndexBTreeSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/io/IndexBTreeSuite.scala
@@ -1,75 +1,69 @@
 package org.broadinstitute.hail.io
 
-import org.broadinstitute.hail.SparkSuite
+import org.broadinstitute.hail.{PropertySuite, SparkSuite}
 import org.broadinstitute.hail.Utils._
 import org.broadinstitute.hail.check.Gen._
 import org.broadinstitute.hail.check.Prop._
-import org.broadinstitute.hail.check.Properties
 import org.testng.annotations.Test
 
 import scala.language.implicitConversions
 import scala.math.Numeric.Implicits._
 
-class IndexBTreeSuite extends SparkSuite {
+class IndexBTreeProperties extends PropertySuite {
 
-  object Spec extends Properties("BTree") {
+  val arraySizeGenerator = for (depth: Int <- frequency((4, const(1)), (5, const(2)), (1, const(3)));
+    arraySize: Int <- choose(math.max(1, math.pow(10, (depth - 1) * math.log10(1024)).toInt),
+      math.min(1100000, math.pow(10, depth * math.log10(1024)).toInt))) yield (depth, arraySize)
 
-    val arraySizeGenerator = for (depth: Int <- frequency((4,const(1)),(5,const(2)),(1,const(3)));
-                              arraySize: Int <- choose(math.max(1, math.pow(10, (depth - 1) * math.log10(1024)).toInt),
-                                math.min(1100000,math.pow(10, depth * math.log10(1024)).toInt))) yield (depth, arraySize)
-
-    def fillRandomArray(arraySize: Int): Array[Long] = {
-      val randArray = new Array[Long](arraySize)
-      var pos = 24.toLong
-      var nIndices = 0
-      while (nIndices != arraySize) {
-        randArray(nIndices) = pos
-        pos += choose(5.toLong,5000.toLong).sample()
-        nIndices += 1
-      }
-      randArray
+  def fillRandomArray(arraySize: Int): Array[Long] = {
+    val randArray = new Array[Long](arraySize)
+    var pos = 24.toLong
+    var nIndices = 0
+    while (nIndices != arraySize) {
+      randArray(nIndices) = pos
+      pos += choose(5.toLong, 5000.toLong).sample()
+      nIndices += 1
     }
+    randArray
+  }
 
-    property("query gives same answer as array") =
-      forAll(arraySizeGenerator) { case (depth: Int, arraySize: Int) =>
-        val arrayRandomStarts = fillRandomArray(arraySize)
-        val maxLong = arrayRandomStarts.takeRight(1)(0)
-        val index = tmpDir.createTempFile(prefix = "testBtree", extension = ".idx")
+  property("query gives same answer as array") =
+    forAll(arraySizeGenerator) { case (depth, arraySize) =>
+      val arrayRandomStarts = fillRandomArray(arraySize)
+      val maxLong = arrayRandomStarts.takeRight(1)(0)
+      val index = tmpDir.createTempFile(prefix = "testBtree", extension = ".idx")
 
-        hadoopDelete(index, sc.hadoopConfiguration, true)
-        IndexBTree.write(arrayRandomStarts, index, sc.hadoopConfiguration)
-        val btree = new IndexBTree(index, sc.hadoopConfiguration)
+      IndexBTree.write(arrayRandomStarts, index, sc.hadoopConfiguration)
+      val btree = new IndexBTree(index, sc.hadoopConfiguration)
 
-        val indexSize = hadoopGetFileSize(index, sc.hadoopConfiguration)
-        val padding = 1024 - (arraySize % 1024)
-        val numEntries = arraySize + padding + (1 until depth).map{math.pow(1024,_).toInt}.sum
+      val indexSize = hadoopGetFileSize(index, sc.hadoopConfiguration)
+      val padding = 1024 - (arraySize % 1024)
+      val numEntries = arraySize + padding + (1 until depth).map { math.pow(1024, _).toInt }.sum
 
-        // make sure index size is correct
-        val indexCorrectSize = if (indexSize == (numEntries * 8)) true else false
+      // make sure index size is correct
+      val indexCorrectSize = if (indexSize == (numEntries * 8)) true else false
 
-        // make sure depth is correct
-        val estimatedDepth = btree.calcDepth()
-        val depthCorrect = if (estimatedDepth == depth) true else false
+      // make sure depth is correct
+      val estimatedDepth = btree.calcDepth()
+      val depthCorrect = estimatedDepth == depth
 
-        // make sure query is correct
-        val queryCorrect = if (arrayRandomStarts.length < 100)
-          arrayRandomStarts.forall{case (l) => btree.queryIndex(l-1).contains(l)}
-        else {
-          val randomIndices = Array(0) ++ Array.fill(100)(choose(0,arraySize - 1).sample())
-          randomIndices.map(arrayRandomStarts).forall { case (l) => btree.queryIndex(l-1).contains(l)}
-        }
-
-        if (!depthCorrect || !indexCorrectSize || !queryCorrect)
-          println(s"depth=$depthCorrect indexCorrect=$indexCorrectSize queryCorrect=$queryCorrect")
-
-        btree.close()
-        depthCorrect && indexCorrectSize && queryCorrect
+      // make sure query is correct
+      val queryCorrect = if (arrayRandomStarts.length < 100)
+        arrayRandomStarts.forall { case (l) => btree.queryIndex(l - 1).contains(l) }
+      else {
+        val randomIndices = Array(0) ++ Array.fill(100)(choose(0, arraySize - 1).sample())
+        randomIndices.map(arrayRandomStarts).forall { case (l) => btree.queryIndex(l - 1).contains(l) }
       }
-  }
 
-  @Test def test() {
-    Spec.check()
-  }
+      if (!depthCorrect || !indexCorrectSize || !queryCorrect)
+        println(s"depth=$depthCorrect indexCorrect=$indexCorrectSize queryCorrect=$queryCorrect")
+
+      btree.close()
+      depthCorrect && indexCorrectSize && queryCorrect
+    }
+}
+
+class IndexBTreeSuite extends SparkSuite {
 
   @Test def oneVariant() {
     val index = Array(24.toLong)
@@ -77,12 +71,11 @@ class IndexBTreeSuite extends SparkSuite {
     val idxFile = tmpDir.createTempFile(prefix = "testBtree_1variant", extension = ".idx")
     val hConf = sc.hadoopConfiguration
 
-    hadoopDelete(idxFile, sc.hadoopConfiguration, true)
     IndexBTree.write(index, idxFile, hConf)
     val btree = new IndexBTree(idxFile, sc.hadoopConfiguration)
 
 
-    intercept[IllegalArgumentException]{
+    intercept[IllegalArgumentException] {
       btree.queryIndex(-5)
     }
 
@@ -98,7 +91,6 @@ class IndexBTreeSuite extends SparkSuite {
     intercept[IllegalArgumentException] {
       val index = Array[Long]()
       val idxFile = tmpDir.createTempFile(prefix = "testBtree_0variant", extension = ".idx")
-      hadoopDelete(idxFile, sc.hadoopConfiguration, true)
       IndexBTree.write(index, idxFile, sc.hadoopConfiguration)
     }
   }

--- a/src/test/scala/org/broadinstitute/hail/methods/ImputeSexSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/ImputeSexSuite.scala
@@ -1,19 +1,15 @@
 package org.broadinstitute.hail.methods
 
-import org.broadinstitute.hail.SparkSuite
+import org.broadinstitute.hail.{PropertySuite, SparkSuite}
 import org.broadinstitute.hail.Utils._
 import org.broadinstitute.hail.check.Prop._
-import org.broadinstitute.hail.check.Properties
 import org.broadinstitute.hail.driver._
-import org.broadinstitute.hail.annotations._
 import org.broadinstitute.hail.variant._
-import org.testng.annotations.Test
 
 import scala.language._
 import scala.sys.process._
 
-
-class ImputeSexSuite extends SparkSuite {
+class ImputeSexSuite extends PropertySuite {
 
   def parsePlinkSexCheck(file: String): Map[String, (Option[Int], Option[Double])] =
     readLines(file, sc.hadoopConfiguration)(_.drop(1).map(_.map { line =>
@@ -33,69 +29,64 @@ class ImputeSexSuite extends SparkSuite {
     }.value
     ).toMap)
 
-  object Spec extends Properties("ImputeSex") {
+  property("hail generates same results as PLINK v1.9") =
+    forAll(VariantSampleMatrix.gen[Genotype](sc, VSMSubgen.random)) { case (vds: VariantSampleMatrix[Genotype]) =>
 
-    property("hail generates same results as PLINK v1.9") =
-      forAll(VariantSampleMatrix.gen[Genotype](sc, VSMSubgen.random)) { case (vds: VariantSampleMatrix[Genotype]) =>
+      var s = State(sc, sqlContext).copy(vds = vds.copy(rdd =
+        vds.rdd.map { case (v, (va, gs)) => (v.copy(contig = "X"), (va, gs)) }
+          .toOrderedRDD[Locus]))
 
-        var s = State(sc, sqlContext).copy(vds = vds.copy(rdd =
-          vds.rdd.map { case (v, (va, gs)) => (v.copy(contig = "X"), (va, gs)) }
-            .toOrderedRDD[Locus]))
+      s = SplitMulti.run(s)
+      s = VariantQC.run(s)
+      s = FilterVariantsExpr.run(s, Array("--keep", "-c", "va.qc.AC > 0"))
 
-        s = SplitMulti.run(s)
-        s = VariantQC.run(s)
-        s = FilterVariantsExpr.run(s, Array("--keep", "-c", "va.qc.AC > 0"))
+      if (s.vds.nSamples < 5 || s.vds.nVariants < 5) {
+        true
+      } else {
+        val fileRoot = tmpDir.createTempFile(prefix = "plinksexCheck")
+        val vcfOutputFile = fileRoot + ".vcf"
+        val plinkSexCheckRoot = fileRoot
 
-        if (s.vds.nSamples < 5 || s.vds.nVariants < 5) {
-          true
-        } else {
-          val fileRoot = tmpDir.createTempFile(prefix = "plinksexCheck")
-          val vcfOutputFile = fileRoot + ".vcf"
-          val plinkSexCheckRoot = fileRoot
+        s = ImputeSex.run(s, Array("-m", "0.0", "--include-par"))
+        s = ExportVCF.run(s, Array("-o", vcfOutputFile))
 
-          s = ImputeSex.run(s, Array("-m", "0.0", "--include-par"))
-          s = ExportVCF.run(s, Array("-o", vcfOutputFile))
+        s"plink --vcf $vcfOutputFile --const-fid --check-sex --silent --out $plinkSexCheckRoot" !
 
-          s"plink --vcf $vcfOutputFile --const-fid --check-sex --silent --out $plinkSexCheckRoot" !
+        val plinkResult = parsePlinkSexCheck(plinkSexCheckRoot + ".sexcheck")
 
-          val plinkResult = parsePlinkSexCheck(plinkSexCheckRoot + ".sexcheck")
+        val (_, imputedSexQuery) = s.vds.querySA("if (sa.imputesex.isFemale) 2 else 1")
+        val (_, fQuery) = s.vds.querySA("sa.imputesex.Fstat")
 
-          val (_, imputedSexQuery) = s.vds.querySA("if (sa.imputesex.isFemale) 2 else 1")
-          val (_, fQuery) = s.vds.querySA("sa.imputesex.Fstat")
+        val hailResult = s.vds.sampleIdsAndAnnotations.map { case (sample, sa) =>
+          (sample, (imputedSexQuery(sa).map(_.asInstanceOf[Int]), fQuery(sa).map(_.asInstanceOf[Double])))
+        }.toMap
 
-          val hailResult = s.vds.sampleIdsAndAnnotations.map { case (sample, sa) =>
-            (sample, (imputedSexQuery(sa).map(_.asInstanceOf[Int]), fQuery(sa).map(_.asInstanceOf[Double])))
-          }.toMap
+        assert(plinkResult.keySet == hailResult.keySet)
 
-          assert(plinkResult.keySet == hailResult.keySet)
+        val result = plinkResult.forall { case (sample, (plinkSex, plinkF)) =>
 
-          val result = plinkResult.forall { case (sample, (plinkSex, plinkF)) =>
+          val (hailSex, hailF) = hailResult(sample)
 
-            val (hailSex, hailF) = hailResult(sample)
+          val resultSex = plinkSex == hailSex
+          val resultF = plinkF.liftedZip(hailF).forall { case (p, h) => math.abs(p - h) < 1e-3 }
 
-            val resultSex = plinkSex == hailSex
-            val resultF = plinkF.liftedZip(hailF).forall { case (p, h) => math.abs(p - h) < 1e-3 }
-
-            if (resultSex && resultF)
-              true
-            else {
-              println(s"$sample plink=${
-                plinkSex.liftedZip(plinkF).getOrElse("NA") } hail=${
-                hailSex.liftedZip(hailF).getOrElse("NA") } $resultSex $resultF")
-              false
-            }
+          if (resultSex && resultF)
+            true
+          else {
+            println(s"$sample plink=${
+              plinkSex.liftedZip(plinkF).getOrElse("NA")
+            } hail=${
+              hailSex.liftedZip(hailF).getOrElse("NA")
+            } $resultSex $resultF")
+            false
           }
-
-          val countAnnotated = AnnotateVariantsExpr.run(s,
-            Array("-c", "va.maf = let a = gs.map(g => g.oneHotAlleles(v)).sum() in a[1] / a.sum"))
-          val sexcheck2 = ImputeSex.run(countAnnotated, Array("--pop-freq", "va.maf", "--include-par"))
-
-          result && sexcheck2.vds.sampleAnnotations == s.vds.sampleAnnotations
         }
-      }
-  }
 
-  @Test def testImputeSexPlinkVersion() {
-    Spec.check()
-  }
+        val countAnnotated = AnnotateVariantsExpr.run(s,
+          Array("-c", "va.maf = let a = gs.map(g => g.oneHotAlleles(v)).sum() in a[1] / a.sum"))
+        val sexcheck2 = ImputeSex.run(countAnnotated, Array("--pop-freq", "va.maf", "--include-par"))
+
+        result && sexcheck2.vds.sampleAnnotations == s.vds.sampleAnnotations
+      }
+    }
 }

--- a/src/test/scala/org/broadinstitute/hail/methods/PedigreeSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/PedigreeSuite.scala
@@ -1,10 +1,9 @@
 package org.broadinstitute.hail.methods
 
-import org.broadinstitute.hail.SparkSuite
+import org.broadinstitute.hail.{PropertySuite, SparkSuite}
 import org.broadinstitute.hail.check.Prop._
 import org.broadinstitute.hail.io.vcf.LoadVCF
 import org.testng.annotations.Test
-
 
 class PedigreeSuite extends SparkSuite {
   @Test def test() {
@@ -42,16 +41,14 @@ class PedigreeSuite extends SparkSuite {
     // FIXME: How to test
     // ped.writeSummary("/tmp/pedigree.sumfam", sc.hadoopConfiguration)
   }
+}
 
-  @Test def generated() {
+class PedigreeProperties extends PropertySuite {
 
-    val p = forAll(Pedigree.genWithIds()) { case (ids: IndexedSeq[String], ped: Pedigree) =>
-      val f = tmpDir.createTempFile(extension = ".fam")
-      ped.write(f, hadoopConf)
-      val ped2 = Pedigree.read(f, hadoopConf, ids)
-      (ped.trios: IndexedSeq[Trio]) == (ped2.trios: IndexedSeq[Trio])
-    }
-
-    p.check()
+  property("generated") = forAll(Pedigree.genWithIds()) { case (ids: IndexedSeq[String], ped: Pedigree) =>
+    val f = tmpDir.createTempFile(extension = ".fam")
+    ped.write(f, hadoopConf)
+    val ped2 = Pedigree.read(f, hadoopConf, ids)
+    (ped.trios: IndexedSeq[Trio]) == (ped2.trios: IndexedSeq[Trio])
   }
 }

--- a/src/test/scala/org/broadinstitute/hail/stats/FisherExactTestSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/stats/FisherExactTestSuite.scala
@@ -1,10 +1,9 @@
 package org.broadinstitute.hail.stats
 
-import org.broadinstitute.hail.SparkSuite
+import org.broadinstitute.hail.{PropertySuite, SparkSuite}
 import org.broadinstitute.hail.Utils._
 import org.broadinstitute.hail.check.Gen._
 import org.broadinstitute.hail.check.Prop._
-import org.broadinstitute.hail.check.Properties
 import org.broadinstitute.hail.driver._
 import org.broadinstitute.hail.variant.{VariantDataset, _}
 import org.testng.annotations.Test
@@ -31,106 +30,100 @@ class FisherExactTestSuite extends SparkSuite {
     assert(math.abs(result(2) - 0.122593) < 1e-4)
     assert(math.abs(result(3) - 1.597972) < 1e-4)
   }
+}
 
-  object Spec extends Properties("FisherExactTest") {
-    val twoBytwoMatrix = for (n: Int <- choose(10, 500); k: Int <- choose(1, n - 1); x: Int <- choose(1, n - 1)) yield (k, n - k, x, n - x)
+class FisherExactProperties extends PropertySuite {
 
-    property("import generates same output as export") =
-      forAll(twoBytwoMatrix) { case (a, b, c, d) =>
+  val twoBytwoMatrix = for (n: Int <- choose(10, 500); k: Int <- choose(1, n - 1); x: Int <- choose(1, n - 1)) yield (k, n - k, x, n - x)
 
-        val rResultTwoSided = s"Rscript src/test/resources/fisherExactTest.r two.sided $a $b $c $d" !!
+  property("import generates same output as export") =
+    forAll(twoBytwoMatrix) { case (a, b, c, d) =>
 
-        val rResultLess = s"Rscript src/test/resources/fisherExactTest.r less $a $b $c $d" !!
+      val rResultTwoSided = s"Rscript src/test/resources/fisherExactTest.r two.sided $a $b $c $d" !!
 
-        val rResultGreater = s"Rscript src/test/resources/fisherExactTest.r greater $a $b $c $d" !!
+      val rResultLess = s"Rscript src/test/resources/fisherExactTest.r less $a $b $c $d" !!
+
+      val rResultGreater = s"Rscript src/test/resources/fisherExactTest.r greater $a $b $c $d" !!
 
 
-        val rTwoSided = rResultTwoSided.split(" ").take(4)
-          .map { s => if (s == "Inf") Double.PositiveInfinity else if (s == "NaN") Double.NaN else s.toDouble }
-        val rLess = rResultLess.split(" ").take(4)
-          .map { s => if (s == "Inf") Double.PositiveInfinity else if (s == "NaN") Double.NaN else s.toDouble }
-        val rGreater = rResultGreater.split(" ").take(4)
-          .map { s => if (s == "Inf") Double.PositiveInfinity else if (s == "NaN") Double.NaN else s.toDouble }
+      val rTwoSided = rResultTwoSided.split(" ").take(4)
+        .map { s => if (s == "Inf") Double.PositiveInfinity else if (s == "NaN") Double.NaN else s.toDouble }
+      val rLess = rResultLess.split(" ").take(4)
+        .map { s => if (s == "Inf") Double.PositiveInfinity else if (s == "NaN") Double.NaN else s.toDouble }
+      val rGreater = rResultGreater.split(" ").take(4)
+        .map { s => if (s == "Inf") Double.PositiveInfinity else if (s == "NaN") Double.NaN else s.toDouble }
 
-        val hailTwoSided = FisherExactTest(a, b, c, d, alternative = "two.sided")
-        val hailLess = FisherExactTest(a, b, c, d, alternative = "less")
-        val hailGreater = FisherExactTest(a, b, c, d, alternative = "greater")
+      val hailTwoSided = FisherExactTest(a, b, c, d, alternative = "two.sided")
+      val hailLess = FisherExactTest(a, b, c, d, alternative = "less")
+      val hailGreater = FisherExactTest(a, b, c, d, alternative = "greater")
 
-        val hailResults = Array(hailTwoSided, hailLess, hailGreater).map {
-          _.map {
-            _.getOrElse(Double.NaN)
-          }
-        }
-        val rResults = Array(rTwoSided, rLess, rGreater)
-
-        hailResults.zip(rResults).forall { case (h, r) =>
-          val res = D_==(h(0), r(0)) &&
-            D_==(h(1), h(1)) &&
-            D_==(h(2), r(2)) &&
-            D_==(h(3), r(3))
-          if (!res) {
-            println(h(0), r(0), D_==(h(0), r(0)))
-            println(h(1), r(1), D_==(h(1), h(1)))
-            println(h(2), r(2), D_==(h(2), r(2)))
-            println(h(3), r(3), D_==(h(3), r(3)))
-          }
-          res
+      val hailResults = Array(hailTwoSided, hailLess, hailGreater).map {
+        _.map {
+          _.getOrElse(Double.NaN)
         }
       }
+      val rResults = Array(rTwoSided, rLess, rGreater)
 
-    property("expr gives same result as class") =
-      forAll(VariantSampleMatrix.gen[Genotype](sc, VSMSubgen.random)) { (vds: VariantDataset) =>
-        var s = State(sc, sqlContext, vds)
-        val sampleIds = vds.sampleIds
-        val phenotypes = sampleIds.zipWithIndex.map { case (sample, i) =>
-          if (i % 3 == 0)
-            (sample, "ADHD")
-          else if (i % 3 == 1)
-            (sample, "Control")
-          else
-            (sample, "NA")
+      hailResults.zip(rResults).forall { case (h, r) =>
+        val res = D_==(h(0), r(0)) &&
+          D_==(h(1), h(1)) &&
+          D_==(h(2), r(2)) &&
+          D_==(h(3), r(3))
+        if (!res) {
+          println(h(0), r(0), D_==(h(0), r(0)))
+          println(h(1), r(1), D_==(h(1), h(1)))
+          println(h(2), r(2), D_==(h(2), r(2)))
+          println(h(3), r(3), D_==(h(3), r(3)))
         }
-
-        val phenotypeFile = tmpDir.createTempFile("phenotypeAnnotation", ".txt")
-        writeTextFile(phenotypeFile, sc.hadoopConfiguration) { w =>
-          w.write("Sample\tPheno1\n")
-          phenotypes.foreach { case (sample, p) => w.write(s"$sample\t$p\n") }
-        }
-
-        s = AnnotateSamplesTable.run(s, Array("-i", phenotypeFile, "-r", "sa.pheno", "-e", "Sample"))
-
-        s = AnnotateVariantsExpr.run(s, Array("-c", """va.macCase = gs.filter(g => sa.pheno.Pheno1 == "ADHD" && g.isHet).count() + 2 * gs.filter(g => sa.pheno.Pheno1 == "ADHD" && g.isHomVar).count()"""))
-        s = AnnotateVariantsExpr.run(s, Array("-c", """va.majCase = gs.filter(g => sa.pheno.Pheno1 == "ADHD" && g.isHet).count() + 2 * gs.filter(g => sa.pheno.Pheno1 == "ADHD" && g.isHomRef).count()"""))
-        s = AnnotateVariantsExpr.run(s, Array("-c", """va.macControl = gs.filter(g => sa.pheno.Pheno1 == "Control" && g.isHet).count() + 2 * gs.filter(g => sa.pheno.Pheno1 == "ADHD" && g.isHomVar).count()"""))
-        s = AnnotateVariantsExpr.run(s, Array("-c", """va.majControl = gs.filter(g => sa.pheno.Pheno1 == "Control" && g.isHet).count() + 2 * gs.filter(g => sa.pheno.Pheno1 == "ADHD" && g.isHomRef).count()"""))
-
-        s = AnnotateVariantsExpr.run(s, Array("-c", """va.fet = fet(va.macCase.toInt, va.majCase.toInt, va.macControl.toInt, va.majControl.toInt)"""))
-
-
-        val (_, q1) = s.vds.queryVA("va.macCase")
-        val (_, q2) = s.vds.queryVA("va.majCase")
-        val (_, q3) = s.vds.queryVA("va.macControl")
-        val (_, q4) = s.vds.queryVA("va.majControl")
-        val (_, q5) = s.vds.queryVA("va.fet.pValue")
-        val (_, q6) = s.vds.queryVA("va.fet.oddsRatio")
-        val (_, q7) = s.vds.queryVA("va.fet.ci95Lower")
-        val (_, q8) = s.vds.queryVA("va.fet.ci95Upper")
-
-        s.vds.variantsAndAnnotations.forall { case (v, va) =>
-          val result = FisherExactTest(q1(va).get.asInstanceOf[Long].toInt, q2(va).get.asInstanceOf[Long].toInt,
-            q3(va).get.asInstanceOf[Long].toInt, q4(va).get.asInstanceOf[Long].toInt)
-          val annotationResult = Array(q5(va).asInstanceOf[Option[Double]], q6(va).asInstanceOf[Option[Double]],
-            q7(va).asInstanceOf[Option[Double]], q8(va).asInstanceOf[Option[Double]])
-
-          if (result sameElements annotationResult)
-            true
-          else
-            false
-        }
+        res
       }
-  }
+    }
 
-  @Test def testFisherExactTest() {
-    Spec.check()
-  }
+  property("expr gives same result as class") =
+    forAll(VariantSampleMatrix.gen[Genotype](sc, VSMSubgen.random)) { (vds: VariantDataset) =>
+      var s = State(sc, sqlContext, vds)
+      val sampleIds = vds.sampleIds
+      val phenotypes = sampleIds.zipWithIndex.map { case (sample, i) =>
+        if (i % 3 == 0)
+          (sample, "ADHD")
+        else if (i % 3 == 1)
+          (sample, "Control")
+        else
+          (sample, "NA")
+      }
+
+      val phenotypeFile = tmpDir.createTempFile("phenotypeAnnotation", ".txt")
+      writeTextFile(phenotypeFile, sc.hadoopConfiguration) { w =>
+        w.write("Sample\tPheno1\n")
+        phenotypes.foreach { case (sample, p) => w.write(s"$sample\t$p\n") }
+      }
+
+      s = AnnotateSamplesTable.run(s, Array("-i", phenotypeFile, "-r", "sa.pheno", "-e", "Sample"))
+
+      s = AnnotateVariantsExpr.run(s, Array("-c", """va.macCase = gs.filter(g => sa.pheno.Pheno1 == "ADHD" && g.isHet).count() + 2 * gs.filter(g => sa.pheno.Pheno1 == "ADHD" && g.isHomVar).count()"""))
+      s = AnnotateVariantsExpr.run(s, Array("-c", """va.majCase = gs.filter(g => sa.pheno.Pheno1 == "ADHD" && g.isHet).count() + 2 * gs.filter(g => sa.pheno.Pheno1 == "ADHD" && g.isHomRef).count()"""))
+      s = AnnotateVariantsExpr.run(s, Array("-c", """va.macControl = gs.filter(g => sa.pheno.Pheno1 == "Control" && g.isHet).count() + 2 * gs.filter(g => sa.pheno.Pheno1 == "ADHD" && g.isHomVar).count()"""))
+      s = AnnotateVariantsExpr.run(s, Array("-c", """va.majControl = gs.filter(g => sa.pheno.Pheno1 == "Control" && g.isHet).count() + 2 * gs.filter(g => sa.pheno.Pheno1 == "ADHD" && g.isHomRef).count()"""))
+
+      s = AnnotateVariantsExpr.run(s, Array("-c", """va.fet = fet(va.macCase.toInt, va.majCase.toInt, va.macControl.toInt, va.majControl.toInt)"""))
+
+
+      val (_, q1) = s.vds.queryVA("va.macCase")
+      val (_, q2) = s.vds.queryVA("va.majCase")
+      val (_, q3) = s.vds.queryVA("va.macControl")
+      val (_, q4) = s.vds.queryVA("va.majControl")
+      val (_, q5) = s.vds.queryVA("va.fet.pValue")
+      val (_, q6) = s.vds.queryVA("va.fet.oddsRatio")
+      val (_, q7) = s.vds.queryVA("va.fet.ci95Lower")
+      val (_, q8) = s.vds.queryVA("va.fet.ci95Upper")
+
+      s.vds.variantsAndAnnotations.forall { case (v, va) =>
+        val result = FisherExactTest(q1(va).get.asInstanceOf[Long].toInt, q2(va).get.asInstanceOf[Long].toInt,
+          q3(va).get.asInstanceOf[Long].toInt, q4(va).get.asInstanceOf[Long].toInt)
+        val annotationResult = Array(q5(va).asInstanceOf[Option[Double]], q6(va).asInstanceOf[Option[Double]],
+          q7(va).asInstanceOf[Option[Double]], q8(va).asInstanceOf[Option[Double]])
+
+        result sameElements annotationResult
+      }
+    }
 }

--- a/src/test/scala/org/broadinstitute/hail/utils/LEB128Suite.scala
+++ b/src/test/scala/org/broadinstitute/hail/utils/LEB128Suite.scala
@@ -1,13 +1,11 @@
 package org.broadinstitute.hail.utils
 
-import org.broadinstitute.hail.ByteIterator
-import org.broadinstitute.hail.check.Properties
+import org.broadinstitute.hail.{ByteIterator, PropertySuite}
 import org.broadinstitute.hail.check.Prop._
 import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.Test
 
 import scala.collection.mutable
-
 import org.broadinstitute.hail.Utils._
 
 object LEB128Suite {
@@ -25,20 +23,9 @@ object LEB128Suite {
     i == new ByteIterator(b.result()).readSLEB128()
   }
 
-  object Spec extends Properties("LEB128") {
-    property("readWrite") = forAll { n: Int =>
-      (n >= 0) ==> ulebReadWriteEqual(n)
-    }
-
-    property("readWrite") = forAll { n: Int =>
-      slebReadWriteEqual(n)
-    }
-  }
-
 }
 
 class LEB128Suite extends TestNGSuite {
-
   import LEB128Suite._
 
   def testReadWrite(i: Int) {
@@ -62,7 +49,17 @@ class LEB128Suite extends TestNGSuite {
     testSLEBReadWrite(-129)
     (0 until 31).foreach(i =>
       testSLEBReadWrite(0xdeadbeef >>> i))
+  }
+}
 
-    Spec.check
+class LEB128Properties extends PropertySuite {
+  import LEB128Suite._
+
+  property("readWrite") = forAll { n: Int =>
+    (n >= 0) ==> ulebReadWriteEqual(n)
+  }
+
+  property("readWrite") = forAll { n: Int =>
+    slebReadWriteEqual(n)
   }
 }

--- a/src/test/scala/org/broadinstitute/hail/utils/OrderedRDDSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/utils/OrderedRDDSuite.scala
@@ -2,159 +2,147 @@ package org.broadinstitute.hail.utils
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
-import org.broadinstitute.hail.SparkSuite
+import org.broadinstitute.hail.{PropertySuite, SparkSuite}
 import org.broadinstitute.hail.Utils._
 import org.broadinstitute.hail.check.Arbitrary._
-import org.broadinstitute.hail.check.{Gen, Prop, Properties}
+import org.broadinstitute.hail.check.{Gen, Prop}
 import org.broadinstitute.hail.sparkextras.{OrderedPartitioner, _}
 import org.broadinstitute.hail.variant.{Locus, Variant}
-import org.testng.annotations.Test
 
-class OrderedRDDSuite extends SparkSuite {
+class OrderedRDDSuite extends PropertySuite {
 
-  object Spec extends Properties("OrderedRDDFunctions") {
-    val v = for (pos <- Gen.choose(1, 1000);
-      alt <- Gen.oneOfGen(Gen.const("T"), Gen.const("C"), Gen.const("G"), Gen.const("TTT"), Gen.const("ATA")))
-      yield Variant("16", pos, "A", alt)
+  val v = for (pos <- Gen.choose(1, 1000);
+    alt <- Gen.oneOfGen(Gen.const("T"), Gen.const("C"), Gen.const("G"), Gen.const("TTT"), Gen.const("ATA")))
+    yield Variant("16", pos, "A", alt)
 
-    val g = for (uniqueVariants <- Gen.buildableOf[Set, Variant](v).map(set => set.toIndexedSeq);
-      toZip <- Gen.buildableOfN[IndexedSeq, String](uniqueVariants.size, arbitrary[String]);
-      nPar <- Gen.choose(1, 10)) yield (nPar, uniqueVariants.zip(toZip))
+  val g = for (uniqueVariants <- Gen.buildableOf[Set, Variant](v).map(set => set.toIndexedSeq);
+    toZip <- Gen.buildableOfN[IndexedSeq, String](uniqueVariants.size, arbitrary[String]);
+    nPar <- Gen.choose(1, 10)) yield (nPar, uniqueVariants.zip(toZip))
 
-    val random = for ((n, v) <- g;
-      shuffled <- Gen.shuffle(v)) yield (n, shuffled)
+  val random = for ((n, v) <- g;
+    shuffled <- Gen.shuffle(v)) yield (n, shuffled)
 
-    val locusSorted = for ((n, v) <- g;
-      locusSorted <- Gen.const(v.sortBy(_._1.locus))) yield (n, locusSorted)
+  val locusSorted = for ((n, v) <- g;
+    locusSorted <- Gen.const(v.sortBy(_._1.locus))) yield (n, locusSorted)
 
-    val sorted = for ((n, v) <- g;
-      sorted <- Gen.const(v.sortBy(_._1))) yield (n, sorted)
+  val sorted = for ((n, v) <- g;
+    sorted <- Gen.const(v.sortBy(_._1))) yield (n, sorted)
 
-    def check(rdd: OrderedRDD[Locus, Variant, String]): Boolean = {
-      val p = rdd.orderedPartitioner
-      val partitionSummaries = rdd.mapPartitionsWithIndex { case (partitionIndex, iter) =>
-        val a = iter.toArray
-        val keys = a.map(_._1)
-        val sorted = keys.isSorted
-        val correctPartitioning = keys.forall(k => p.getPartition(k) == partitionIndex)
-        Iterator((partitionIndex, sorted, correctPartitioning, if (a.nonEmpty) Some((a.head._1, a.last._1)) else None))
-      }.collect().sortBy(_._1)
+  def check(rdd: OrderedRDD[Locus, Variant, String]): Boolean = {
+    val p = rdd.orderedPartitioner
+    val partitionSummaries = rdd.mapPartitionsWithIndex { case (partitionIndex, iter) =>
+      val a = iter.toArray
+      val keys = a.map(_._1)
+      val sorted = keys.isSorted
+      val correctPartitioning = keys.forall(k => p.getPartition(k) == partitionIndex)
+      Iterator((partitionIndex, sorted, correctPartitioning, if (a.nonEmpty) Some((a.head._1, a.last._1)) else None))
+    }.collect().sortBy(_._1)
 
-      partitionSummaries.flatMap(_._4.map(_._1)).headOption match {
-        case Some(first) =>
-          val sortedWithin = partitionSummaries.forall(_._2)
-          val partitionedCorrectly = partitionSummaries.forall(_._3)
-          val sortedBetween = partitionSummaries.flatMap(_._4)
-            .tail
-            .foldLeft((true, first)) { case ((b, last), (start, end)) =>
-              (b && start > last, end)
-            }._1
-          sortedWithin && partitionedCorrectly && sortedBetween
-        case None => true
-      }
-    }
-
-
-    def checkJoin(nPar1: Int, is1: IndexedSeq[(Variant, String)],
-      nPar2: Int, is2: IndexedSeq[(Variant, String)]): Boolean = {
-      val m2 = is2.toMap
-
-      val rdd1 = sc.parallelize(is1, nPar1).cache()
-      val rdd2 = sc.parallelize(is2, nPar2).cache()
-
-      val join: IndexedSeq[(Variant, (String, Option[String]))] = rdd1.toOrderedRDD[Locus]
-        .orderedLeftJoinDistinct(rdd2.toOrderedRDD[Locus])
-        .collect()
-        .toIndexedSeq
-
-      val check1 = is1.toMap == join.map { case (k, (v1, _)) => (k, v1) }.toMap
-      val check2 = join.forall { case (k, (_, v2)) => v2 == m2.get(k) }
-      val check3 = rdd1.leftOuterJoinDistinct(rdd2).collect().toMap == join.toMap
-
-      check1 && check2 && check3
-    }
-
-    property("randomlyOrdered") = Prop.forAll(random) { case (nPar, s) =>
-      check(sc.parallelize(s, nPar).toOrderedRDD[Locus])
-    }
-
-    property("locusSorted") = Prop.forAll(locusSorted) { case (nPar, s) =>
-      check(sc.parallelize(s, nPar).toOrderedRDD[Locus])
-    }
-
-    property("fullySorted") = Prop.forAll(sorted) { case (nPar, s) =>
-      check(sc.parallelize(s, nPar).toOrderedRDD[Locus])
-    }
-
-    property("join1") = Prop.forAll(g, g) { case ((nPar1, is1), (nPar2, is2)) =>
-      checkJoin(nPar1, is1, nPar2, is2)
-    }
-
-    // check different levels of partition skipping and sparsity
-    val v2 = for (pos <- Gen.oneOfGen(Gen.choose(1, 100), Gen.choose(400, 500), Gen.choose(900, 1000));
-      alt <- Gen.oneOfGen(Gen.const("T"), Gen.const("C"), Gen.const("G"), Gen.const("TTT"), Gen.const("ATA")))
-      yield Variant("16", pos, "A", alt)
-
-    val g2 = for (uniqueVariants <- Gen.buildableOf[Set, Variant](v2).map(set => set.toIndexedSeq);
-      toZip <- Gen.buildableOfN[IndexedSeq, String](uniqueVariants.size, arbitrary[String]);
-      nPar <- Gen.choose(1, 25)) yield (nPar, uniqueVariants.zip(toZip))
-
-    property("join2") = Prop.forAll(g, g2) { case ((nPar1, is1), (nPar2, is2)) =>
-      checkJoin(nPar1, is1, nPar2, is2)
-    }
-
-    property("join3") = Prop.forAll(g, g2) { case ((_, is1), (nPar2, is2)) =>
-      checkJoin(1, is1, nPar2, is2)
-    }
-
-    property("join4") = Prop.forAll(g2, g) { case ((nPar1, is1), (nPar2, is2)) =>
-      checkJoin(nPar1, is1, nPar2, is2)
-    }
-
-    property("join4") = Prop.forAll(g2, g) { case ((_, is1), (nPar2, is2)) =>
-      checkJoin(1, is1, nPar2, is2)
-    }
-
-
-    val tmpPartitioner = tmpDir.createTempFile("partitioner")
-    val tmpRdd = tmpDir.createTempFile("rdd", ".parquet")
-
-    property("writeRead") = Prop.forAll(g) { case (nPar, is) =>
-      val rdd = sc.parallelize(is, nPar).toOrderedRDD[Locus]
-      val schema = StructType(Array(
-        StructField("variant", Variant.schema, nullable = false),
-        StructField("str", StringType, nullable = false)))
-      hadoopDelete(tmpRdd, hadoopConf, recursive = true)
-      val df = sqlContext.createDataFrame(rdd.map { case (v, s) => Row.fromSeq(Seq(v.toRow, s)) }, schema)
-        .write.parquet(tmpRdd)
-
-      writeObjectFile(tmpPartitioner, hadoopConf) { out =>
-        rdd.partitioner.get.asInstanceOf[OrderedPartitioner[Variant, String]].write(out)
-      }
-
-      val status = hadoopFileStatus(tmpPartitioner, hadoopConf)
-
-      val rddReadBack = sqlContext.sortedParquetRead(tmpRdd)
-        .get
-        .rdd
-        .map(r => (Variant.fromRow(r.getAs[Row](0)), r.getAs[String](1)))
-
-      val readBackPartitioner = readObjectFile(tmpPartitioner, hadoopConf) { in =>
-        OrderedPartitioner.read[Locus, Variant](in)
-      }
-
-      val orderedRddRB = OrderedRDD[Locus, Variant, String](rddReadBack, readBackPartitioner)
-
-      orderedRddRB.zipPartitions(rdd) { case (it1, it2) =>
-        it1.zip(it2)
-      }
-        .collect()
-        .forall { case (v1, v2) => v1 == v2 }
+    partitionSummaries.flatMap(_._4.map(_._1)).headOption match {
+      case Some(first) =>
+        val sortedWithin = partitionSummaries.forall(_._2)
+        val partitionedCorrectly = partitionSummaries.forall(_._3)
+        val sortedBetween = partitionSummaries.flatMap(_._4)
+          .tail
+          .foldLeft((true, first)) { case ((b, last), (start, end)) =>
+            (b && start > last, end)
+          }._1
+        sortedWithin && partitionedCorrectly && sortedBetween
+      case None => true
     }
   }
 
-  @Test def test() {
-    Spec.check()
+
+  def checkJoin(nPar1: Int, is1: IndexedSeq[(Variant, String)],
+    nPar2: Int, is2: IndexedSeq[(Variant, String)]): Boolean = {
+    val m2 = is2.toMap
+
+    val rdd1 = sc.parallelize(is1, nPar1).cache()
+    val rdd2 = sc.parallelize(is2, nPar2).cache()
+
+    val join: IndexedSeq[(Variant, (String, Option[String]))] = rdd1.toOrderedRDD[Locus]
+      .orderedLeftJoinDistinct(rdd2.toOrderedRDD[Locus])
+      .collect()
+      .toIndexedSeq
+
+    val check1 = is1.toMap == join.map { case (k, (v1, _)) => (k, v1) }.toMap
+    val check2 = join.forall { case (k, (_, v2)) => v2 == m2.get(k) }
+    val check3 = rdd1.leftOuterJoinDistinct(rdd2).collect().toMap == join.toMap
+
+    check1 && check2 && check3
+  }
+
+  property("randomlyOrdered") = Prop.forAll(random) { case (nPar, s) =>
+    check(sc.parallelize(s, nPar).toOrderedRDD[Locus])
+  }
+
+  property("locusSorted") = Prop.forAll(locusSorted) { case (nPar, s) =>
+    check(sc.parallelize(s, nPar).toOrderedRDD[Locus])
+  }
+
+  property("fullySorted") = Prop.forAll(sorted) { case (nPar, s) =>
+    check(sc.parallelize(s, nPar).toOrderedRDD[Locus])
+  }
+
+  property("join1") = Prop.forAll(g, g) { case ((nPar1, is1), (nPar2, is2)) =>
+    checkJoin(nPar1, is1, nPar2, is2)
+  }
+
+  // check different levels of partition skipping and sparsity
+  val v2 = for (pos <- Gen.oneOfGen(Gen.choose(1, 100), Gen.choose(400, 500), Gen.choose(900, 1000));
+    alt <- Gen.oneOfGen(Gen.const("T"), Gen.const("C"), Gen.const("G"), Gen.const("TTT"), Gen.const("ATA")))
+    yield Variant("16", pos, "A", alt)
+
+  val g2 = for (uniqueVariants <- Gen.buildableOf[Set, Variant](v2).map(set => set.toIndexedSeq);
+    toZip <- Gen.buildableOfN[IndexedSeq, String](uniqueVariants.size, arbitrary[String]);
+    nPar <- Gen.choose(1, 25)) yield (nPar, uniqueVariants.zip(toZip))
+
+  property("join2") = Prop.forAll(g, g2) { case ((nPar1, is1), (nPar2, is2)) =>
+    checkJoin(nPar1, is1, nPar2, is2)
+  }
+
+  property("join3") = Prop.forAll(g, g2) { case ((_, is1), (nPar2, is2)) =>
+    checkJoin(1, is1, nPar2, is2)
+  }
+
+  property("join4") = Prop.forAll(g2, g) { case ((nPar1, is1), (nPar2, is2)) =>
+    checkJoin(nPar1, is1, nPar2, is2)
+  }
+
+  property("join4") = Prop.forAll(g2, g) { case ((_, is1), (nPar2, is2)) =>
+    checkJoin(1, is1, nPar2, is2)
+  }
+
+
+  val tmpPartitioner = tmpDir.createTempFile("partitioner")
+  val tmpRdd = tmpDir.createTempFile("rdd", ".parquet")
+
+  property("writeRead") = Prop.forAll(g) { case (nPar, is) =>
+    val rdd = sc.parallelize(is, nPar).toOrderedRDD[Locus]
+    val schema = StructType(Array(
+      StructField("variant", Variant.schema, nullable = false),
+      StructField("str", StringType, nullable = false)))
+    hadoopDelete(tmpRdd, hadoopConf, recursive = true)
+    val df = sqlContext.createDataFrame(rdd.map { case (v, s) => Row.fromSeq(Seq(v.toRow, s)) }, schema)
+      .write.parquet(tmpRdd)
+
+    writeObjectFile(tmpPartitioner, hadoopConf) { out =>
+      rdd.partitioner.get.asInstanceOf[OrderedPartitioner[Variant, String]].write(out)
+    }
+
+    val rddReadBack = sqlContext.sortedParquetRead(tmpRdd)
+      .get
+      .rdd
+      .map(r => (Variant.fromRow(r.getAs[Row](0)), r.getAs[String](1)))
+
+    val readBackPartitioner = readObjectFile(tmpPartitioner, hadoopConf) { in =>
+      OrderedPartitioner.read[Locus, Variant](in)
+    }
+
+    val orderedRddRB = OrderedRDD[Locus, Variant, String](rddReadBack, readBackPartitioner)
+
+    orderedRddRB.zip(rdd)
+      .forall { case (v1, v2) => v1 == v2 }
   }
 }
 

--- a/src/test/scala/org/broadinstitute/hail/variant/GenotypeStreamSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/variant/GenotypeStreamSuite.scala
@@ -1,33 +1,19 @@
 package org.broadinstitute.hail.variant
 
-import org.broadinstitute.hail.check.{Gen, Properties}
+import org.broadinstitute.hail.PropertySuite
+import org.broadinstitute.hail.check.Gen
 import org.broadinstitute.hail.check.Prop._
-import org.scalatest.testng.TestNGSuite
-import org.testng.annotations.Test
 
-object GenotypeStreamSuite {
+class GenotypeStreamProperties extends PropertySuite {
 
-  object Spec extends Properties("GenotypeStream") {
-
-    property("iterateBuild") = forAll(for (
-      v <- Variant.gen;
-      gs <- Gen.buildableOf[Iterable, Genotype](Genotype.genExtreme(v.nAlleles)))
-      yield (v, gs)) { case (v: Variant, it: Iterable[Genotype]) =>
-      val b = new GenotypeStreamBuilder(v.nAlleles)
-      b ++= it
-      val gs = b.result()
-      val a2 = gs.toArray
-      it.sameElements(a2)
-    }
-  }
-
-}
-
-class GenotypeStreamSuite extends TestNGSuite {
-
-  import GenotypeStreamSuite._
-
-  @Test def testGenotypeStream() {
-    Spec.check()
+  property("iterateBuild") = forAll(for (
+    v <- Variant.gen;
+    gs <- Gen.buildableOf[Iterable, Genotype](Genotype.genExtreme(v.nAlleles)))
+    yield (v, gs)) { case (v, it) =>
+    val b = new GenotypeStreamBuilder(v.nAlleles)
+    b ++= it
+    val gs = b.result()
+    val a2 = gs.toArray
+    it.sameElements(a2)
   }
 }

--- a/src/test/scala/org/broadinstitute/hail/variant/vsm/PartitioningSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/variant/vsm/PartitioningSuite.scala
@@ -1,35 +1,33 @@
 package org.broadinstitute.hail.variant.vsm
 
-import org.broadinstitute.hail.SparkSuite
-import org.broadinstitute.hail.check.{Gen, Prop}
+import org.broadinstitute.hail.{PropertySuite, SparkSuite}
+import org.broadinstitute.hail.check.Gen
+import org.broadinstitute.hail.check.Prop._
 import org.broadinstitute.hail.driver.{Coalesce, Read, State, Write}
 import org.broadinstitute.hail.variant.{VSMSubgen, VariantSampleMatrix}
-import org.testng.annotations.Test
 
-class PartitioningSuite extends SparkSuite {
+class PartitioningProperties extends PropertySuite {
 
-  @Test def testParquetWriteRead() {
-    Prop.forAll(VariantSampleMatrix.gen(sc, VSMSubgen.random), Gen.choose(1, 10)) { case (vds, nPar) =>
-      var state = State(sc, sqlContext, vds)
-      state = Coalesce.run(state, Array("-n", nPar.toString))
-      val out = tmpDir.createTempFile("out", ".vds")
-      val out2 = tmpDir.createTempFile("out", ".vds")
-      state = Write.run(state, Array("-o", out))
+  property("parquet read write") = forAll(VariantSampleMatrix.gen(sc, VSMSubgen.random), Gen.choose(1, 10)) { case (vds, nPar) =>
+    var state = State(sc, sqlContext, vds)
+    state = Coalesce.run(state, Array("-n", nPar.toString))
+    val out = tmpDir.createTempFile("out", ".vds")
+    val out2 = tmpDir.createTempFile("out", ".vds")
+    state = Write.run(state, Array("-o", out))
 
-      // need to do 2 writes to ensure that the RDD is ordered
-      state = Read.run(state, Array("-i", out))
-      state = Write.run(state, Array("-o", out2))
-      val readback = Read.run(state, Array("-i", out2))
+    // need to do 2 writes to ensure that the RDD is ordered
+    state = Read.run(state, Array("-i", out))
+    state = Write.run(state, Array("-o", out2))
+    val readback = Read.run(state, Array("-i", out2))
 
-      val original = state.vds.variantsAndAnnotations
-        .mapPartitionsWithIndex { case (i, it) => it.zipWithIndex.map(x => (i, x)) }
-        .collect()
-        .toSet
-      val rb = readback.vds.variantsAndAnnotations
-        .mapPartitionsWithIndex { case (i, it) => it.zipWithIndex.map(x => (i, x)) }
-        .collect()
-        .toSet
-      rb == original
-    }.check()
+    val original = state.vds.variantsAndAnnotations
+      .mapPartitionsWithIndex { case (i, it) => it.zipWithIndex.map(x => (i, x)) }
+      .collect()
+      .toSet
+    val rb = readback.vds.variantsAndAnnotations
+      .mapPartitionsWithIndex { case (i, it) => it.zipWithIndex.map(x => (i, x)) }
+      .collect()
+      .toSet
+    rb == original
   }
 }


### PR DESCRIPTION
I added a `PropertySuite` and deleted the `check` business.  I feel this is an improvement, but also that we can do better.

You can still have an orphaned `Prop` by writing:

```
class MyProperties extends PropertySuite {
  forAll ... // no property("name") = ...
}
```

I think better would be for `PropretySuite` to declare `forAll` and make `forAll` take a name.

`PropertySuite` extends `SparkSuite`.  I was seeing some strange behavior that I don't fully understand if I made it extend `TestNGSuite` and then mixed `PropertySuite` and `SparkSuite` in a test suite.

Thoughts?
