### PR TITLE
Fixed annotatevariants intervals --all

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/Utils.scala
+++ b/src/main/scala/org/broadinstitute/hail/Utils.scala
@@ -526,7 +526,7 @@ class RichEnumeration[T <: Enumeration](val e: T) extends AnyVal {
 }
 
 class RichMutableMap[K, V](val m: mutable.Map[K, V]) extends AnyVal {
-  def updateValue(k: K, default: V, f: (V) => V) {
+  def updateValue(k: K, default: => V, f: (V) => V) {
     m += ((k, f(m.getOrElse(k, default))))
   }
 }


### PR DESCRIPTION
Now identical intervals will produce the full set of
string values when parameter --all is passed.