### PR TITLE
add useful error messages

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/expr/AST.scala
+++ b/src/main/scala/org/broadinstitute/hail/expr/AST.scala
@@ -1024,7 +1024,11 @@ case class ApplyMethod(posn: Position, lhs: AST, method: String, args: Array[AST
         }
 
       case (agg: TAggregable, "map", rhs) =>
-        val Array(Lambda(_, param, body)) = rhs
+        val (param, body) = rhs match {
+          case Array(Lambda(_, p, b)) => (p, b)
+          case _ => parseError(s"method `$method' expects a lambda function (param => Any), " +
+            s"e.g. `x => x < 5' or `tc => tc.canonical'")
+        }
 
         val localIdx = agg.ec.a.length
         val localA = agg.ec.a
@@ -1044,7 +1048,11 @@ case class ApplyMethod(posn: Position, lhs: AST, method: String, args: Array[AST
         }
 
       case (agg: TAggregable, "filter", rhs) =>
-        val Array(Lambda(_, param, body)) = rhs
+        val (param, body) = rhs match {
+          case Array(Lambda(_, p, b)) => (p, b)
+          case _ => parseError(s"method `$method' expects a lambda function (param => Boolean), " +
+            s"e.g. `x => x < 5' or `tc => tc.canonical == 1'")
+        }
 
         val localIdx = agg.ec.a.length
         val localA = agg.ec.a


### PR DESCRIPTION
When the user fails to provide a lambda to an aggregation
they now receive a suggestion to use a lambda rather than
a Scala match error.

@tpoterba this should hold us over until we have something nicer like that `projectT` function.

resolves #786 