### PR TITLE
add eager annotation type checking

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateSamplesTable.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateSamplesTable.scala
@@ -67,6 +67,6 @@ object AnnotateSamplesTable extends Command with JoinAnnotator {
       .collect()
       .toMap
 
-    state.copy(vds = vds.annotateSamples(map, finalType, inserter))
+    state.copy(vds = vds.annotateSamples(map.get _, finalType, inserter))
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/ImputeSex.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/ImputeSex.scala
@@ -49,16 +49,6 @@ object ImputeSex extends Command {
 
     val signature = ImputeSexPlink.schema
 
-    val (newSAS, insertSexCheck) = state.vds.saSignature.insert(signature, "imputesex")
-    val newSampleAnnotations = state.vds.sampleIdsAndAnnotations
-      .map { case (s, sa) =>
-        insertSexCheck(sa, result.get(s))
-      }
-
-    state.copy(
-      vds = state.vds.copy(
-        sampleAnnotations = newSampleAnnotations,
-        saSignature = newSAS)
-    )
+    state.copy(vds = state.vds.annotateSamples(result, signature, List("imputesex")))
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/SampleQC.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/SampleQC.scala
@@ -312,16 +312,8 @@ object SampleQC extends Command {
         }, Some("Sample\t" + SampleQCCombiner.header))
     }
 
-    val (newSAS, insertQC) = vds.saSignature.insert(SampleQCCombiner.signature, "qc")
-    val newSampleAnnotations = vds.sampleIdsAndAnnotations
-      .map { case (s, sa) =>
-        insertQC(sa, r.get(s).map(_.asAnnotation))
-      }
-
-    state.copy(
-      vds = vds.copy(
-        sampleAnnotations = newSampleAnnotations,
-        saSignature = newSAS)
-    )
+    state.copy(vds = vds.annotateSamples(SampleQCCombiner.signature, List("qc"), { (x: String) =>
+      r.get(x).map(_.asAnnotation)
+    }))
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
@@ -770,14 +770,20 @@ class VariantSampleMatrix[T](val metadata: VariantMetadata,
 
   def annotateSamples(annotations: Map[String, Annotation], signature: Type, path: List[String]): VariantSampleMatrix[T] = {
     val (t, i) = insertSA(signature, path)
-    annotateSamples(annotations, t, i)
+    annotateSamples(annotations.get _, t, i)
   }
 
-  def annotateSamples(annotations: Map[String, Annotation], newSignature: Type,
-    inserter: Inserter): VariantSampleMatrix[T] = {
+  def annotateSamples(signature: Type, path: List[String], annotation: (String) => Option[Annotation]): VariantSampleMatrix[T] = {
+    val (t, i) = insertSA(signature, path)
+    annotateSamples(annotation, t, i)
+  }
+
+  def annotateSamples(annotation: (String) => Option[Annotation], newSignature: Type, inserter: Inserter): VariantSampleMatrix[T] = {
     val newAnnotations = sampleIds.zipWithIndex.map { case (id, i) =>
       val sa = sampleAnnotations(i)
-      inserter(sa, annotations.get(id))
+      val newAnnotation = annotation(id)
+      newAnnotation.foreach(newSignature.typeCheck)
+      inserter(sa, newAnnotation)
     }
 
     copy(sampleAnnotations = newAnnotations, saSignature = newSignature)


### PR DESCRIPTION
resolves #791 

This should cause type errors much sooner if a signature disagrees with the actual types.

Much of the sample annotating code uses multiple inserters and therefore cannot be rewritten to use `annotateSamples`.