### PR TITLE
Improvements to Solr export and seqrserver

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/driver/ExportVariantsSolr.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/ExportVariantsSolr.scala
@@ -142,7 +142,6 @@ object ExportVariantsSolr extends Command with Serializable {
     val vEC = EvalContext(vSymTab)
     val vA = vEC.a
 
-    // FIXME use custom parser with constraint on Solr field name
     val vparsed = Parser.parseSolrNamedArgs(vCond, vEC)
 
     val gSymTab = Map(

--- a/src/main/scala/org/broadinstitute/hail/driver/ExportVariantsSolr.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/ExportVariantsSolr.scala
@@ -9,6 +9,7 @@ import org.apache.solr.common.{SolrException, SolrInputDocument}
 import org.broadinstitute.hail.utils._
 import org.broadinstitute.hail.expr._
 import org.kohsuke.args4j.{Option => Args4jOption}
+import org.broadinstitute.hail.utils.StringEscapeUtils._
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -65,31 +66,17 @@ object ExportVariantsSolr extends Command with Serializable {
     case _ => fatal("")
   }
 
-  def escapeSolrFieldName(name: String): String = {
-    val sb = new StringBuilder
-
-    if (name.head.isDigit)
-      sb += '_'
-
-    name.foreach { c =>
-      if (c.isLetterOrDigit)
-        sb += c
-      else
-        sb += '_'
-    }
-
-    sb.result()
-  }
+  def escapeString(name: String): String =
+    escapeStringSimple(name, '_', _.isLetter, _.isLetterOrDigit)
 
   def addFieldReq(preexistingFields: Set[String], name: String, spec: Map[String, AnyRef], t: Type): Option[SchemaRequest.AddField] = {
-    val escapedName = escapeSolrFieldName(name)
-    if (preexistingFields(escapedName))
+    if (preexistingFields(name))
       return None
 
     var m = spec
 
     if (!m.contains("name"))
-      m += "name" -> escapedName
+      m += "name" -> name
 
     if (!m.contains("type"))
       m += "type" -> toSolrType(t)
@@ -107,10 +94,10 @@ object ExportVariantsSolr extends Command with Serializable {
   def documentAddField(document: SolrInputDocument, name: String, t: Type, value: Any) {
     if (t.isInstanceOf[TIterable]) {
       value.asInstanceOf[Traversable[_]].foreach { xi =>
-        document.addField(escapeSolrFieldName(name), xi)
+        document.addField(name, xi)
       }
     } else
-      document.addField(escapeSolrFieldName(name), value)
+      document.addField(name, value)
   }
 
   def processResponse(action: String, res: SolrResponse) {
@@ -200,14 +187,11 @@ object ExportVariantsSolr extends Command with Serializable {
       .map(_.asScala("name").asInstanceOf[String])
       .toSet
 
-    val addFieldReqs = vparsed.flatMap {
-      case (name, spec, t, f) =>
-        addFieldReq(preexistingFields, name, spec, t)
-    } ++ vds.sampleIds.flatMap {
-      s =>
-        gparsed.flatMap {
-          case (name, spec, t, f) =>
-            addFieldReq(preexistingFields, s + "_" + name, spec, t)
+    val addFieldReqs = vparsed.flatMap { case (name, spec, t, f) =>
+        addFieldReq(preexistingFields, escapeString(name), spec, t)
+    } ++ vds.sampleIds.flatMap { s =>
+        gparsed.flatMap { case (name, spec, t, f) =>
+            addFieldReq(preexistingFields, escapeString(s) + "_" + escapeString(name), spec, t)
         }
     }
 
@@ -240,7 +224,7 @@ object ExportVariantsSolr extends Command with Serializable {
             vparsed.foreach {
               case (name, spec, t, f) =>
                 vEC.setAll(v, va)
-                f().foreach(x => documentAddField(document, name, t, x))
+                f().foreach(x => documentAddField(document, escapeString(name), t, x))
             }
 
             gs.iterator.zipWithIndex.foreach {
@@ -251,7 +235,8 @@ object ExportVariantsSolr extends Command with Serializable {
                   gparsed.foreach {
                     case (name, spec, t, f) =>
                       gEC.setAll(v, va, s, sa, g)
-                      f().foreach(x => documentAddField(document, s + "_" + name, t, x))
+                      // __ can't appear in escaped string
+                      f().foreach(x => documentAddField(document, escapeString(s) + "__" + escapeString(name), t, x))
                   }
                 }
             }

--- a/src/main/scala/org/broadinstitute/hail/utils/StringEscapeUtils.scala
+++ b/src/main/scala/org/broadinstitute/hail/utils/StringEscapeUtils.scala
@@ -8,6 +8,37 @@ object StringEscapeUtils {
 
   def hex(ch: Char): String = Integer.toHexString(ch).toUpperCase(Locale.ENGLISH)
 
+  def escapeStringSimple(str: String, escapeChar: Char, escape: (Char) => Boolean): String = {
+    val sb = new StringBuilder
+    str.flatMap { c =>
+      if (escape(c)) {
+        val i = c.toInt
+        assert(i >= 0 && i < 256)
+        val h = Integer.toHexString(i)
+        assert(h.length == 2)
+        sb.append(h)
+      } else
+        sb += c
+    }
+    sb.result()
+  }
+
+  def unescapeStringSimple(str: String, escapeChar: Char): String = {
+    val sb = new StringBuilder
+    var i: Int = 0
+    while (i < str.length) {
+      val c = str(i)
+      if (c == escapeChar) {
+        Integer.parseInt(str.substring(i + 1, i + 3), 16)
+        i += 3
+      } else {
+        sb += c
+        i += 1
+      }
+    }
+    sb.result()
+  }
+
   def escapeString(str: String, backticked: Boolean = false): String =
     escapeString(str, new StringBuilder(capacity = str.length * 2), backticked)
 

--- a/src/main/scala/org/broadinstitute/hail/utils/StringEscapeUtils.scala
+++ b/src/main/scala/org/broadinstitute/hail/utils/StringEscapeUtils.scala
@@ -36,8 +36,8 @@ object StringEscapeUtils {
     sb.result()
   }
 
-  def escapeStringSimple(str: String, escapeChar: Char, escape: (Char) => Boolean): String
-  = escapeStringSimple(str, escapeChar, escape, escape)
+  def escapeStringSimple(str: String, escapeChar: Char, escape: (Char) => Boolean): String =
+    escapeStringSimple(str, escapeChar, escape, escape)
 
   def unescapeStringSimple(str: String, escapeChar: Char): String = {
     val sb = new StringBuilder

--- a/src/main/scala/org/broadinstitute/hail/utils/StringEscapeUtils.scala
+++ b/src/main/scala/org/broadinstitute/hail/utils/StringEscapeUtils.scala
@@ -8,20 +8,32 @@ object StringEscapeUtils {
 
   def hex(ch: Char): String = Integer.toHexString(ch).toUpperCase(Locale.ENGLISH)
 
-  def escapeStringSimple(str: String, escapeChar: Char, escape: (Char) => Boolean): String = {
+  def escapeStringSimple(str: String, escapeChar: Char,
+    escapeFirst: (Char) => Boolean,
+    escape: (Char) => Boolean): String = {
     val sb = new StringBuilder
-    str.flatMap { c =>
-      if (escape(c)) {
+    var i: Int = 0
+    while (i < str.length) {
+      val c = str(i)
+      if (c == escapeChar || escape(c) || (i == 0 && escapeFirst(c))) {
         val i = c.toInt
-        assert(i >= 0 && i < 256)
-        val h = Integer.toHexString(i)
-        assert(h.length == 2)
-        sb.append(h)
+        if (i < 256) {
+          val h = Integer.toHexString(i)
+          assert(h.length == 2)
+          sb += escapeChar
+          sb.append(h)
+        } else {
+
+        }
       } else
         sb += c
+      i += 1
     }
     sb.result()
   }
+
+  def escapeStringSimple(str: String, escapeChar: Char, escape: (Char) => Boolean): String
+   = escapeStringSimple(str, escapeChar, escape, escape)
 
   def unescapeStringSimple(str: String, escapeChar: Char): String = {
     val sb = new StringBuilder
@@ -29,7 +41,7 @@ object StringEscapeUtils {
     while (i < str.length) {
       val c = str(i)
       if (c == escapeChar) {
-        Integer.parseInt(str.substring(i + 1, i + 3), 16)
+        sb += Integer.parseInt(str.substring(i + 1, i + 3), 16).toChar
         i += 3
       } else {
         sb += c

--- a/src/test/scala/org/broadinstitute/hail/methods/ExprSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/ExprSuite.scala
@@ -525,6 +525,14 @@ class ExprSuite extends SparkSuite {
     p.check()
   }
 
+  @Test def testEscapingSimple() {
+    val p = forAll { (s: String) =>
+      s == unescapeStringSimple(escapeStringSimple(s, '_', c => c.isLetterOrDigit), '_')
+    }
+    
+    p.check()
+  }
+
   @Test def testImpexes() {
 
     val g = for {t <- Type.genArb

--- a/src/test/scala/org/broadinstitute/hail/methods/ExprSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/ExprSuite.scala
@@ -230,7 +230,7 @@ class ExprSuite extends SparkSuite {
 
     TestUtils.interceptFatal("""expects type Array\[Array\[T\]\] or Set\[Set\[T\]\], got Array\[Int\]""")(
       eval[Set[_]](""" [0].flatten() """))
-    
+
     TestUtils.interceptFatal("""does not take parameters, use flatten()""")(
       eval[Set[_]](""" [[0]].flatten(0) """))
 
@@ -526,10 +526,18 @@ class ExprSuite extends SparkSuite {
   }
 
   @Test def testEscapingSimple() {
+    // a == 0x61, _ = 0x5f
+    assert(escapeStringSimple("abc", '_', _ => false) == "abc")
+    assert(escapeStringSimple("abc", '_', _ == 'a') == "_61bc")
+    assert(escapeStringSimple("abc_", '_', _ => false) == "abc_5f")
+    assert(unescapeStringSimple("abc", '_') == "abc")
+    assert(unescapeStringSimple("abc_5f", '_') == "abc_")
+    assert(unescapeStringSimple("_61bc", '_') == "abc")
+
     val p = forAll { (s: String) =>
-      s == unescapeStringSimple(escapeStringSimple(s, '_', c => c.isLetterOrDigit), '_')
+      s == unescapeStringSimple(escapeStringSimple(s, '_', _.isLetterOrDigit, _.isLetterOrDigit), '_')
     }
-    
+
     p.check()
   }
 

--- a/src/test/scala/org/broadinstitute/hail/methods/ExprSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/ExprSuite.scala
@@ -533,6 +533,9 @@ class ExprSuite extends SparkSuite {
     assert(unescapeStringSimple("abc", '_') == "abc")
     assert(unescapeStringSimple("abc_5f", '_') == "abc_")
     assert(unescapeStringSimple("_61bc", '_') == "abc")
+    assert(unescapeStringSimple("_u0061bc", '_') == "abc")
+    assert(escapeStringSimple("my name is 名谦", '_', _ => false) == "my name is _u540d_u8c26")
+    assert(unescapeStringSimple("my name is _u540d_u8c26", '_') == "my name is 名谦")
 
     val p = forAll { (s: String) =>
       s == unescapeStringSimple(escapeStringSimple(s, '_', _.isLetterOrDigit, _.isLetterOrDigit), '_')


### PR DESCRIPTION
By default, don't use Solr Trie types.
Escape field names, sample subfields separated by __ after escaping.
Unescape in seqrserver.
seqrserver: added sample_filters.
seqrserver: decode json fields, --json-fields argument.
