### PR TITLE
Optimize import annotations.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/SparkExport.scala
+++ b/src/main/scala/org/apache/spark/sql/SparkExport.scala
@@ -1,9 +1,11 @@
 package org.apache.spark.sql
 
-import org.apache.hadoop.mapreduce.InputSplit
+import org.apache.hadoop.mapreduce.{InputSplit => NewInputSplit}
+import org.apache.hadoop.mapred.InputSplit
 import org.apache.spark.Partition
-import org.apache.spark.rdd.SqlNewHadoopPartition
+import org.apache.spark.rdd.{HadoopPartition, SqlNewHadoopPartition}
 
 object SparkExport {
-  def sqlNewHadoopPartitionRawSplit(p: Partition): InputSplit = p.asInstanceOf[SqlNewHadoopPartition].serializableHadoopSplit.value
+  def sqlNewHadoopPartitionRawSplit(p: Partition): NewInputSplit = p.asInstanceOf[SqlNewHadoopPartition].serializableHadoopSplit.value
+  def hadoopPartitionSplit(p: Partition): InputSplit = p.asInstanceOf[HadoopPartition].inputSplit.value
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateGlobalTable.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateGlobalTable.scala
@@ -32,7 +32,7 @@ object AnnotateGlobalTable extends Command with JoinAnnotator {
 
     val path = Parser.parseAnnotationRoot(options.root, Annotation.GLOBAL_HEAD)
 
-    val (struct, rdd) = TextTableReader.read(state.sc, Array(options.input), options.config)
+    val (struct, rdd) = TextTableReader.read(state.sc)(Array(options.input), options.config)
     val arrayType = TArray(struct)
 
     val (finalType, inserter) = vds.insertGlobal(arrayType, Parser.parseAnnotationRoot(options.root, Annotation.GLOBAL_HEAD))

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateSamplesTable.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateSamplesTable.scala
@@ -46,16 +46,17 @@ object AnnotateSamplesTable extends Command with JoinAnnotator {
       case _ => fatal("this module requires one of `--root' or `--code', but not both")
     }
 
-    val (struct, rdd) = TextTableReader.read(state.sc, Array(options.input), options.config)
+    val (struct, rdd) = TextTableReader.read(state.sc)(Array(options.input), options.config)
 
-    val (finalType, inserter): (Type, (Annotation, Option[Annotation]) => Annotation) = if (expr) {
-      val ec = EvalContext(Map(
-        "sa" -> (0, vds.saSignature),
-        "table" -> (1, struct)))
-      buildInserter(code, vds.saSignature, ec, Annotation.SAMPLE_HEAD)
-
-    } else vds.insertSA(struct, Parser.parseAnnotationRoot(code, Annotation.SAMPLE_HEAD))
-
+    val (finalType, inserter): (Type, (Annotation, Option[Annotation]) => Annotation) =
+      if (expr) {
+        val ec = EvalContext(Map(
+          "sa" -> (0, vds.saSignature),
+          "table" -> (1, struct)))
+        buildInserter(code, vds.saSignature, ec, Annotation.SAMPLE_HEAD)
+      } else
+        vds.insertSA(struct, Parser.parseAnnotationRoot(code, Annotation.SAMPLE_HEAD))
+    
     val sampleQuery = struct.parseInStructScope[String](options.sampleExpr, TString)
 
     val map = rdd

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsLoci.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsLoci.scala
@@ -53,7 +53,7 @@ object AnnotateVariantsLoci extends Command with JoinAnnotator {
       case _ => fatal("this module requires one of `--root' or `--code', but not both")
     }
 
-    val (struct, rdd) = TextTableReader.read(state.sc, files, options.config)
+    val (struct, rdd) = TextTableReader.read(state.sc)(files, options.config, vds.nPartitions)
 
     val (finalType, inserter): (Type, (Annotation, Option[Annotation]) => Annotation) = if (expr) {
       val ec = EvalContext(Map(
@@ -68,7 +68,7 @@ object AnnotateVariantsLoci extends Command with JoinAnnotator {
       _.map { a =>
         locusQuery(a).map(l => (l, a))
       }.value
-    }.toOrderedRDD
+    }.toOrderedRDD(vds.rdd.orderedPartitioner.mapMonotonic)
 
     state.copy(vds = vds
       .withGenotypeStream()

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsTable.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsTable.scala
@@ -53,7 +53,7 @@ object AnnotateVariantsTable extends Command with JoinAnnotator {
       case _ => fatal("this module requires one of `--root' or `--code', but not both")
     }
 
-    val (struct, rdd) = TextTableReader.read(state.sc, files, options.config)
+    val (struct, rdd) = TextTableReader.read(state.sc)(files, options.config, vds.nPartitions)
 
     val (finalType, inserter): (Type, (Annotation, Option[Annotation]) => Annotation) = if (expr) {
       val ec = EvalContext(Map(
@@ -68,7 +68,7 @@ object AnnotateVariantsTable extends Command with JoinAnnotator {
       _.map { a =>
         variantQuery(a).map(v => (v, a))
       }.value
-    }.toOrderedRDD
+    }.toOrderedRDD(vds.rdd.orderedPartitioner)
 
     state.copy(vds = vds
       .withGenotypeStream()

--- a/src/main/scala/org/broadinstitute/hail/driver/Main.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/Main.scala
@@ -73,7 +73,7 @@ object Main {
 
     @Args4jOption(required = false, name = "--master", usage = "Set Spark master (default: system default or local[*])")
     var master: String = _
-    
+
     @Args4jOption(name = "-b", aliases = Array("--min-block-size"), usage = "Minimum size of file splits in MB")
     var blockSize: Int = 1
 

--- a/src/main/scala/org/broadinstitute/hail/driver/Main.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/Main.scala
@@ -73,9 +73,9 @@ object Main {
 
     @Args4jOption(required = false, name = "--master", usage = "Set Spark master (default: system default or local[*])")
     var master: String = _
-
-    @Args4jOption(name = "-b", aliases = Array("--blocksize"), usage = "Minimum size of file system splits")
-    var blockSize: Int = 128
+    
+    @Args4jOption(name = "-b", aliases = Array("--min-block-size"), usage = "Minimum size of file splits in MB")
+    var blockSize: Int = 1
 
     @Args4jOption(required = false, name = "--parquet-compression", usage = "Parquet compression codec")
     var parquetCompression = "uncompressed"

--- a/src/main/scala/org/broadinstitute/hail/driver/SplitMulti.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/SplitMulti.scala
@@ -202,7 +202,7 @@ object SplitMulti extends Command {
         .map[(Variant, (Annotation, Iterable[Genotype]))] { case (v, (va, gs)) =>
         (v, (va, gs.toGenotypeStream(v, isDosage, compress = true)))
       }
-        .toOrderedRDD(vds.rdd.orderedPartitioner))
+        .orderedRepartitionBy(vds.rdd.orderedPartitioner))
 
     state.copy(vds = newVDS)
   }

--- a/src/main/scala/org/broadinstitute/hail/sparkextras/OrderedPartitioner.scala
+++ b/src/main/scala/org/broadinstitute/hail/sparkextras/OrderedPartitioner.scala
@@ -13,7 +13,7 @@ import scala.reflect.{ClassTag, classTag}
 import scala.util.Random
 import scala.util.hashing.{MurmurHash3, byteswap32}
 
-case class OrderedPartitioner[PK, K](rangeBounds: Array[PK], nPartitions: Int, ascending: Boolean = true)
+case class OrderedPartitioner[PK, K](rangeBounds: Array[PK], numPartitions: Int, ascending: Boolean = true)
   (implicit val kOk: OrderedKey[PK, K])
   extends Partitioner {
 
@@ -21,16 +21,14 @@ case class OrderedPartitioner[PK, K](rangeBounds: Array[PK], nPartitions: Int, a
   import kOk.pkOrd
   import Ordering.Implicits._
 
-  require(nPartitions == 0 && rangeBounds.isEmpty || nPartitions == rangeBounds.length + 1,
-    s"nPartitions = $nPartitions, ranges = ${rangeBounds.length}")
+  require(numPartitions == 0 && rangeBounds.isEmpty || numPartitions == rangeBounds.length + 1,
+    s"nPartitions = $numPartitions, ranges = ${rangeBounds.length}")
   require(rangeBounds.isEmpty || rangeBounds.zip(rangeBounds.tail).forall { case (left, right) => left < right })
 
   def write(out: ObjectOutputStream) {
     out.writeBoolean(ascending)
     out.writeObject(rangeBounds)
   }
-
-  def numPartitions: Int = nPartitions
 
   var binarySearch: (Array[PK], PK) => Int = OrderedPartitioner.makeBinarySearch[PK]
 
@@ -85,7 +83,7 @@ case class OrderedPartitioner[PK, K](rangeBounds: Array[PK], nPartitions: Int, a
   }
 
   def mapMonotonic[K2](implicit k2Ok: OrderedKey[PK, K2]): OrderedPartitioner[PK, K2] = {
-    new OrderedPartitioner(rangeBounds, nPartitions, ascending)
+    new OrderedPartitioner(rangeBounds, numPartitions, ascending)
   }
 }
 

--- a/src/main/scala/org/broadinstitute/hail/sparkextras/OrderedRDD.scala
+++ b/src/main/scala/org/broadinstitute/hail/sparkextras/OrderedRDD.scala
@@ -6,6 +6,7 @@ import org.apache.spark.rdd.{PartitionPruningRDD, RDD, ShuffledRDD}
 import org.apache.spark.storage.StorageLevel
 import org.broadinstitute.hail.utils._
 import org.apache.spark.{SparkContext, _}
+import org.broadinstitute.hail.variant.Variant
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -78,7 +79,6 @@ object OrderedRDD {
       else
         Iterator()
     }.collect()
-
 
     log.info(s"keyInfo = ${ keyInfo.toSeq }")
 

--- a/src/main/scala/org/broadinstitute/hail/utils/richUtils/RichPairRDD.scala
+++ b/src/main/scala/org/broadinstitute/hail/utils/richUtils/RichPairRDD.scala
@@ -39,14 +39,22 @@ class RichPairRDD[K, V](val rdd: RDD[(K, V)]) extends AnyVal {
   def asOrderedRDD[PK](implicit kOk: OrderedKey[PK, K], vct: ClassTag[V]): OrderedRDD[PK, K, V] =
     OrderedRDD.cast[PK, K, V](rdd)
 
-  def toOrderedRDD[PK](partitioner: OrderedPartitioner[PK, K])(implicit kOk: OrderedKey[PK, K], vct: ClassTag[V]): OrderedRDD[PK, K, V] = {
+  def orderedRepartitionBy[PK](partitioner: OrderedPartitioner[PK, K])(implicit kOk: OrderedKey[PK, K], vct: ClassTag[V]): OrderedRDD[PK, K, V] = {
     OrderedRDD.shuffle(rdd, partitioner)
   }
 
   def toOrderedRDD[PK](reducedRepresentation: RDD[K])
     (implicit kOk: OrderedKey[PK, K], vct: ClassTag[V]): OrderedRDD[PK, K, V] =
-    OrderedRDD[PK, K, V](rdd, Some(reducedRepresentation))
+    OrderedRDD[PK, K, V](rdd, Some(reducedRepresentation), None)
+
+  def toOrderedRDD[PK](hintPartitioner: OrderedPartitioner[PK, K])
+    (implicit kOk: OrderedKey[PK, K], vct: ClassTag[V]): OrderedRDD[PK, K, V] =
+    OrderedRDD[PK, K, V](rdd, None, Some(hintPartitioner))
+
+  def toOrderedRDD[PK](reducedRepresentation: RDD[K], hintPartitioner: OrderedPartitioner[PK, K])
+    (implicit kOk: OrderedKey[PK, K], vct: ClassTag[V]): OrderedRDD[PK, K, V] =
+    OrderedRDD[PK, K, V](rdd, Some(reducedRepresentation), Some(hintPartitioner))
 
   def toOrderedRDD[PK](implicit kOk: OrderedKey[PK, K], vct: ClassTag[V]): OrderedRDD[PK, K, V] =
-    OrderedRDD[PK, K, V](rdd, None)
+    OrderedRDD[PK, K, V](rdd, None, None)
 }

--- a/src/main/scala/org/broadinstitute/hail/utils/richUtils/RichSparkContext.scala
+++ b/src/main/scala/org/broadinstitute/hail/utils/richUtils/RichSparkContext.scala
@@ -1,16 +1,31 @@
 package org.broadinstitute.hail.utils.richUtils
 
+import org.apache.hadoop.mapred.FileSplit
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SparkExport
 import org.broadinstitute.hail.utils._
 
 class RichSparkContext(val sc: SparkContext) extends AnyVal {
-  def textFilesLines(files: Array[String], f: String => Unit = s => (),
+  def textFilesLines(files: Array[String],
     nPartitions: Int = sc.defaultMinPartitions): RDD[WithContext[String]] = {
-    files.foreach(f)
-    sc.union(
-      files.map(file =>
-        sc.textFileLines(file, nPartitions)))
+
+    /*
+     * Don't use:
+     *   sc.union(files.map(sc.textFile, nPartitions))
+     * since it asks for nPartitions per file instead of nPartitions over all.
+     */
+    val rdd = sc.textFile(files.mkString(","), nPartitions)
+    val partitionsBc = sc.broadcast(rdd.partitions)
+
+    rdd
+      .mapPartitionsWithIndex { case (i, it) =>
+        // FIXME subclass TextInputFormat to return (file, line)
+        val file = SparkExport.hadoopPartitionSplit(partitionsBc.value(i)).asInstanceOf[FileSplit].getPath.toString
+        it.map { line =>
+          WithContext(line, TextContext(line, file, None))
+        }
+      }
   }
 
   def textFileLines(file: String, nPartitions: Int = sc.defaultMinPartitions): RDD[WithContext[String]] =

--- a/src/test/scala/org/broadinstitute/hail/utils/TextTableSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/utils/TextTableSuite.scala
@@ -39,7 +39,7 @@ class TextTableSuite extends SparkSuite {
     assert(TextTableReader.guessType(Seq("true", ".", "false"), ".") == Some(TBoolean))
     assert(TextTableReader.guessType(locusStrings, ".") == Some(TLocus))
 
-    val (schema, _) = TextTableReader.read(sc, Array("src/test/resources/variantAnnotations.tsv"),
+    val (schema, _) = TextTableReader.read(sc)(Array("src/test/resources/variantAnnotations.tsv"),
       config = TextTableConfiguration().copy(impute = true))
     assert(schema == TStruct(
       "Chromosome" -> TInt,
@@ -50,7 +50,7 @@ class TextTableSuite extends SparkSuite {
       "Rand2" -> TDouble,
       "Gene" -> TString))
 
-    val (schema2, _) = TextTableReader.read(sc, Array("src/test/resources/variantAnnotations.tsv"),
+    val (schema2, _) = TextTableReader.read(sc)(Array("src/test/resources/variantAnnotations.tsv"),
       config = TextTableConfiguration().copy(types = Map("Chromosome" -> TString), impute = true))
     assert(schema2 == TStruct(
       "Chromosome" -> TString,
@@ -61,7 +61,7 @@ class TextTableSuite extends SparkSuite {
       "Rand2" -> TDouble,
       "Gene" -> TString))
 
-    val (schema3, _) = TextTableReader.read(sc, Array("src/test/resources/variantAnnotations.alternateformat.tsv"),
+    val (schema3, _) = TextTableReader.read(sc)(Array("src/test/resources/variantAnnotations.alternateformat.tsv"),
       config = TextTableConfiguration().copy(impute = true))
     assert(schema3 == TStruct(
       "Chromosome:Position:Ref:Alt" -> TVariant,
@@ -69,7 +69,7 @@ class TextTableSuite extends SparkSuite {
       "Rand2" -> TDouble,
       "Gene" -> TString))
 
-    val (schema4, _) = TextTableReader.read(sc, Array("src/test/resources/sampleAnnotations.tsv"),
+    val (schema4, _) = TextTableReader.read(sc)(Array("src/test/resources/sampleAnnotations.tsv"),
       config = TextTableConfiguration().copy(impute = true))
     assert(schema4 == TStruct(
       "Sample" -> TString,


### PR DESCRIPTION
TextTableReader.read takes (optional) nPartitions.
importannotations: new option -n/--npartitions.
Added hintPartition to OrderedRDD coerce and friends.
When loading variant annotations, load with as many partitions as the RDD we're going to join with, and hint with its partitioner.