### PR TITLE
Added global context to filtergenotypes and exportgenotypes commands.

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/driver/ExportGenotypes.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/ExportGenotypes.scala
@@ -54,10 +54,11 @@ object ExportGenotypes extends Command with TextExporter {
       "va" -> (1, vas),
       "s" -> (2, TSample),
       "sa" -> (3, sas),
-      "g" -> (4, TGenotype))
+      "g" -> (4, TGenotype),
+      "global" -> (5, vds.globalSignature) )
 
     val ec = EvalContext(symTab)
-
+    ec.set(5, vds.globalAnnotation)
     val (header, fs) = if (cond.endsWith(".columns")) {
       val (h, functions) = Parser.parseColumnsFile(ec, cond, sc.hadoopConfiguration)
       (Some(h), functions)

--- a/src/main/scala/org/broadinstitute/hail/driver/FilterGenotypes.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/FilterGenotypes.scala
@@ -48,9 +48,12 @@ object FilterGenotypes extends Command {
       "va" ->(1, vas),
       "s" ->(2, TSample),
       "sa" ->(3, sas),
-      "g" ->(4, TGenotype))
+      "g" ->(4, TGenotype),
+      "global" -> (5, vds.globalSignature) )
+
 
     val ec = EvalContext(symTab)
+    ec.set(5, vds.globalAnnotation)
     val f: () => Option[Boolean] = Parser.parse[Boolean](cond, ec, TBoolean)
 
     val sampleIdsBc = vds.sampleIdsBc


### PR DESCRIPTION
Fixes issue #844 global not accessible from filtergenotypes and exportgenotypes.  