### PR TITLE
Add a threshold flag for IBD output filtering

### DIFF
--- a/docs/commands/ibd.md
+++ b/docs/commands/ibd.md
@@ -32,8 +32,16 @@ sample1	sample5	0.1966	0.0000	0.8034	0.8034
 #### Examples
 
 ```
-... ibd --minor-allele-frequency 'va.mafs[v]' -o ibd.tsv
+... ibd --minor-allele-frequency 'va.mafs[v]' -o ibd.tsv --min 0.2 --max 0.9
 ```
 
-This invocation writes the full IBD matrix to `ibd.tsv`. It also uses the
-provided allele frequencies.
+This invocation writes only those sample pairs with `pi_hat` at or above `0.2`
+and at or below `0.9` to `ibd.tsv`. It uses the provided expression to compute
+the minor allele frequency.
+
+```
+... ibd -o ibd.tsv
+```
+
+This invocation writes the full IBD matrix to `ibd.tsv`. It computes the minor
+allele frequency from the dataset.

--- a/src/main/scala/org/broadinstitute/hail/expr/AnnotationImpex.scala
+++ b/src/main/scala/org/broadinstitute/hail/expr/AnnotationImpex.scala
@@ -397,7 +397,7 @@ object TableAnnotationImpex extends AnnotationImpex[Unit, String] {
       case TInt => a.toInt
       case TLong => a.toLong
       case TFloat => a.toFloat
-      case TDouble => a.toDouble
+      case TDouble => if (a == "nan") Double.NaN else a.toDouble
       case TBoolean => a.toBoolean
       case TLocus => a.split(":") match {
         case Array(chr, pos) => Locus(chr, pos.toInt)


### PR DESCRIPTION
This PR depends on PR #738. Merge that first.

This adds `--min` and `--max` flags to the `ibd` command. The resulting TSV will only contain sample pairs with `pi_hat` above the minimum and below the maximum, inclusively of both.