### PR TITLE
removed nMissing from linreg output

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/methods/LinearRegression.scala
+++ b/src/main/scala/org/broadinstitute/hail/methods/LinearRegression.scala
@@ -11,15 +11,14 @@ import scala.collection.mutable
 
 object LinRegStats {
   def `type`: Type = TStruct(
-    ("nMissing", TInt),
     ("beta", TDouble),
     ("se", TDouble),
     ("tstat", TDouble),
     ("pval", TDouble))
 }
 
-case class LinRegStats(nMissing: Int, beta: Double, se: Double, t: Double, p: Double) {
-  def toAnnotation: Annotation = Annotation(nMissing, beta, se, t, p)
+case class LinRegStats(beta: Double, se: Double, t: Double, p: Double) {
+  def toAnnotation: Annotation = Annotation(beta, se, t, p)
 }
 
 class LinRegBuilder extends Serializable {
@@ -75,7 +74,7 @@ class LinRegBuilder extends Serializable {
     this
   }
 
-  def stats(y: DenseVector[Double], n: Int): Option[(SparseVector[Double], Double, Double, Int)] = {
+  def stats(y: DenseVector[Double], n: Int): Option[(SparseVector[Double], Double, Double)] = {
     val missingRowIndicesArray = missingRowIndices.result()
     val nMissing = missingRowIndicesArray.size
     val nPresent = n - nMissing
@@ -97,7 +96,7 @@ class LinRegBuilder extends Serializable {
       val xx = sumXX + meanX * meanX * nMissing
       val xy = sumXY + meanX * sumYMissing
 
-      Some((x, xx, xy, nMissing))
+      Some((x, xx, xy))
     }
   }
 }
@@ -139,7 +138,7 @@ object LinearRegression {
         (lrb1, lrb2) => lrb1.merge(lrb2))
       .mapValues { lrb =>
         lrb.stats(yBc.value, n).map { stats => {
-          val (x, xx, xy, nMissing) = stats
+          val (x, xx, xy) = stats
 
           val qtx = qtBc.value * x
           val qty = qtyBc.value
@@ -152,7 +151,7 @@ object LinearRegression {
           val t = b / se
           val p = 2 * tDistBc.value.cumulativeProbability(-math.abs(t))
 
-          LinRegStats(nMissing, b, se, t, p) }
+          LinRegStats(b, se, t, p) }
         }
       }
     )

--- a/src/test/scala/org/broadinstitute/hail/methods/LinearRegressionSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/LinearRegressionSuite.scala
@@ -43,7 +43,6 @@ class LinearRegressionSuite extends SparkSuite {
     val v9 = Variant("1", 9, "C", "T")   // x = (., 1, 1, 1, 1, 1)
     val v10 = Variant("1", 10, "C", "T") // x = (., 2, 2, 2, 2, 2)
 
-    val qMissing = s.vds.queryVA("va.linreg.nMissing")._2
     val qBeta = s.vds.queryVA("va.linreg.beta")._2
     val qSe = s.vds.queryVA("va.linreg.se")._2
     val qTstat = s.vds.queryVA("va.linreg.tstat")._2
@@ -74,7 +73,6 @@ class LinearRegressionSuite extends SparkSuite {
 
     */
 
-    assertInt(qMissing, v1, 0)
     assertDouble(qBeta, v1, -0.28589421)
     assertDouble(qSe, v1, 1.2739153)
     assertDouble(qTstat, v1, -0.22442167)
@@ -85,7 +83,6 @@ class LinearRegressionSuite extends SparkSuite {
     x = c(1, 2, 1, 2, 0, 0)
     */
 
-    assertInt(qMissing, v2, 2)
     assertDouble(qBeta, v2, -0.5417647)
     assertDouble(qSe, v2, 0.3350599)
     assertDouble(qTstat, v2, -1.616919)
@@ -96,7 +93,6 @@ class LinearRegressionSuite extends SparkSuite {
     x = c(0, 0.75, 1, 1, 1, 0.75)
     */
 
-    assertInt(qMissing, v3, 2)
     assertDouble(qBeta, v3, 1.07367185)
     assertDouble(qSe, v3, 0.6764348)
     assertDouble(qTstat, v3, 1.5872510)
@@ -208,7 +204,6 @@ class LinearRegressionSuite extends SparkSuite {
     val v9 = Variant("1", 9, "C", "T")   // x = (., 1, 1, 1, 1, 1)
     val v10 = Variant("1", 10, "C", "T") // x = (., 2, 2, 2, 2, 2)
 
-    val (_, qMissing) = s.vds.queryVA("va.linreg.nMissing")
     val (_, qBeta) = s.vds.queryVA("va.linreg.beta")
     val (_, qSe) = s.vds.queryVA("va.linreg.se")
     val (_, qTstat) = s.vds.queryVA("va.linreg.tstat")
@@ -239,7 +234,6 @@ class LinearRegressionSuite extends SparkSuite {
 
     */
 
-    assertInt(qMissing, v1, 0)
     assertDouble(qBeta, v1, -0.28589421)
     assertDouble(qSe, v1, 1.2739153)
     assertDouble(qTstat, v1, -0.22442167)
@@ -250,7 +244,6 @@ class LinearRegressionSuite extends SparkSuite {
     x = c(1, 2, 1, 2, 0, 0)
     */
 
-    assertInt(qMissing, v2, 2)
     assertDouble(qBeta, v2, -0.5417647)
     assertDouble(qSe, v2, 0.3350599)
     assertDouble(qTstat, v2, -1.616919)
@@ -293,7 +286,6 @@ class LinearRegressionSuite extends SparkSuite {
     val v9 = Variant("1", 9, "C", "T")   // x = (., 1, 1, 1, 1, 1)
     val v10 = Variant("1", 10, "C", "T") // x = (., 2, 2, 2, 2, 2)
 
-    val qMissing = s.vds.queryVA("va.linreg.nMissing")._2
     val qBeta = s.vds.queryVA("va.linreg.beta")._2
     val qSe = s.vds.queryVA("va.linreg.se")._2
     val qTstat = s.vds.queryVA("va.linreg.tstat")._2
@@ -324,7 +316,6 @@ class LinearRegressionSuite extends SparkSuite {
 
     */
 
-    assertInt(qMissing, v1, 0)
     assertDouble(qBeta, v1, -0.28589421)
     assertDouble(qSe, v1, 1.2739153)
     assertDouble(qTstat, v1, -0.22442167)
@@ -335,7 +326,6 @@ class LinearRegressionSuite extends SparkSuite {
     x = c(1, 2, 1, 2, 0, 0)
     */
 
-    assertInt(qMissing, v2, 2)
     assertDouble(qBeta, v2, -0.5417647)
     assertDouble(qSe, v2, 0.3350599)
     assertDouble(qTstat, v2, -1.616919)


### PR DESCRIPTION
in the interest of modularity, the nMissing annotation need not be attached separately by linreg.  I had updated this before in #645 but strangely only the documentation update when through. here are the corresponding code changes.