### PR TITLE
Clean up withGenotypeStream.

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsLoci.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsLoci.scala
@@ -71,7 +71,6 @@ object AnnotateVariantsLoci extends Command with JoinAnnotator {
     }.toOrderedRDD(vds.rdd.orderedPartitioner.mapMonotonic)
 
     state.copy(vds = vds
-      .withGenotypeStream()
       .annotateLoci(lociRDD, finalType, inserter))
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsTable.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsTable.scala
@@ -71,7 +71,6 @@ object AnnotateVariantsTable extends Command with JoinAnnotator {
     }.toOrderedRDD(vds.rdd.orderedPartitioner)
 
     state.copy(vds = vds
-      .withGenotypeStream()
       .annotateVariants(keyedRDD, finalType, inserter))
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsVCF.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsVCF.scala
@@ -68,7 +68,6 @@ object AnnotateVariantsVCF extends Command with VCFImporter with JoinAnnotator {
     } else vds.insertVA(otherVds.vaSignature, Parser.parseAnnotationRoot(code, Annotation.VARIANT_HEAD))
 
     state.copy(vds = vds
-      .withGenotypeStream()
       .annotateVariants(otherVds.variantsAndAnnotations, finalType, inserter))
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsVDS.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AnnotateVariantsVDS.scala
@@ -62,7 +62,6 @@ object AnnotateVariantsVDS extends Command with JoinAnnotator {
     } else vds.insertVA(otherVds.vaSignature, Parser.parseAnnotationRoot(code, Annotation.VARIANT_HEAD))
 
     state.copy(vds = vds
-      .withGenotypeStream()
       .annotateVariants(otherVds.variantsAndAnnotations, finalType, inserter))
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/Coalesce.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/Coalesce.scala
@@ -34,6 +34,8 @@ object Coalesce extends Command {
             |  In order to run with more partitions, use the --blocksize global option and reimport.""".stripMargin)
     }
 
-    state.copy(vds = state.vds.coalesce(k))
+    state.copy(vds = state.vds
+      .withGenotypeStream(compress = true)
+      .coalesce(k))
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/ExportPlink.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/ExportPlink.scala
@@ -46,6 +46,8 @@ object ExportPlink extends Command {
     plinkRDD.map { case (v, bed) => ExportBedBimFam.makeBimRow(v) }
       .writeTable(options.output + ".bim")
 
+    plinkRDD.unpersist()
+
     val famRows = vds
       .sampleIds
       .map(ExportBedBimFam.makeFamRow)

--- a/src/main/scala/org/broadinstitute/hail/driver/SplitMulti.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/SplitMulti.scala
@@ -200,7 +200,7 @@ object SplitMulti extends Command {
           })
       }
         .map[(Variant, (Annotation, Iterable[Genotype]))] { case (v, (va, gs)) =>
-        (v, (va, gs.toGenotypeStream(v, isDosage, compress = true)))
+        (v, (va, gs))
       }
         .orderedRepartitionBy(vds.rdd.orderedPartitioner))
 

--- a/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
@@ -1038,7 +1038,7 @@ class RichVDS(vds: VariantDataset) {
       vds
   }
 
-  def withGenotypeStream(compress: Boolean = false): VariantDataset = {
+  def withGenotypeStream(compress: Boolean = true): VariantDataset = {
     val isDosage = vds.isDosage
     vds.copy(rdd = vds.rdd.mapValuesWithKey[(Annotation, Iterable[Genotype])] { case (v, (va, gs)) =>
       (va, gs.toGenotypeStream(v, isDosage, compress = compress))


### PR DESCRIPTION
Only call before perist or (real) shuffle: just in coalesce.
Unpersist plinkRDD in exportplink.