### PR TITLE
Added support for multi-allelic sites to sampleqc

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/variant/Genotype.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/Genotype.scala
@@ -45,6 +45,11 @@ class GTPair(val p: Int) extends AnyVal {
 
   def nNonRefAlleles: Int =
     (if (j != 0) 1 else 0) + (if (k != 0) 1 else 0)
+
+  def alleleIndices : Array[Int] = {
+    Array(this.j, this.k )
+  }
+
 }
 
 class Genotype(private val _gt: Int,

--- a/src/test/scala/org/broadinstitute/hail/methods/FilterSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/FilterSuite.scala
@@ -51,7 +51,7 @@ class FilterSuite extends SparkSuite {
       .vds.nSamples == 7)
 
     assert(FilterSamplesExpr.run(stateWithSampleQC, Array("--keep", "-c", "if (\"^C1048\" ~ s.id) {sa.qc.rTiTv > 3.5 && sa.qc.nSingleton < 10000000} else sa.qc.rTiTv > 3"))
-      .vds.nSamples == 14)
+      .vds.nSamples == 16)
 
     val stateWithVariantQC = VariantQC.run(state, Array.empty[String])
 


### PR DESCRIPTION
Note that there are a few additional changes in the way counts are computed:
- Each allele counts towards its respective count, so a homozygous transition counts as 2 transitions
- Singletons are restricted to a single individual carrying a single allele (so a homVar genotype in a single sample is not considered a singleton any more).
