### PR TITLE
repartition/coalesce improvements + filteralleles bug fix

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/driver/Cache.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/Cache.scala
@@ -1,10 +1,13 @@
 package org.broadinstitute.hail.driver
 
 object Cache extends Command {
+
   class Options extends BaseOptions
+
   def newOptions = new Options
 
   def name = "cache"
+
   def description = "Cache current dataset in memory"
 
   def supportsMultiallelic = true
@@ -12,6 +15,8 @@ object Cache extends Command {
   def requiresVDS = true
 
   def run(state: State, options: Options): State = {
-    state.copy(vds = state.vds.cache())
+    state.copy(vds = state.vds
+      .withGenotypeStream()
+      .cache())
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/Coalesce.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/Coalesce.scala
@@ -35,7 +35,6 @@ object Coalesce extends Command {
     }
 
     state.copy(vds = state.vds
-      .withGenotypeStream(compress = true)
       .coalesce(k))
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/FilterAlleles.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/FilterAlleles.scala
@@ -79,7 +79,6 @@ object FilterAlleles extends Command {
       inserterBuilder += i
       newVas
     }
-    val updateAnn = state.vds.vaSignature != finalType
     val inserters = inserterBuilder.result()
 
     val keep = options.keep
@@ -189,13 +188,14 @@ object FilterAlleles extends Command {
 
     def updateOrFilterRow(v: Variant, va: Annotation, gs: Iterable[Genotype]): Option[(Variant, (Annotation, Iterable[Genotype]))] =
       filterAllelesInVariant(v, va).map { case (newV, newToOld, oldToNew) =>
-        val newVa = if(updateAnn) updateAnnotation(v, va, newToOld) else va
+        val newVa = updateAnnotation(v, va, newToOld)
         val newGs = updateGenotypes(gs, oldToNew, newToOld.length)
         (newV, (newVa, newGs))
       }
 
     val newVds = state.vds
       .flatMapVariants { case (v, va, gs) => updateOrFilterRow(v, va, gs) }
+      .copy(vaSignature = finalType)
 
     state.copy(vds = newVds)
   }

--- a/src/main/scala/org/broadinstitute/hail/driver/Persist.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/Persist.scala
@@ -29,10 +29,12 @@ object Persist extends Command {
       StorageLevel.fromString(options.level)
     } catch {
       case e: IllegalArgumentException =>
-      fatal(s"unknown StorageLevel `${options.level}'")
+        fatal(s"unknown StorageLevel `${ options.level }'")
     }
 
     state.copy(
-      vds = vds.copy(rdd = vds.rdd.persist(level)))
+      vds = vds
+        .withGenotypeStream()
+        .copy(rdd = vds.rdd.persist(level)))
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/sparkextras/OrderedRDD.scala
+++ b/src/main/scala/org/broadinstitute/hail/sparkextras/OrderedRDD.scala
@@ -371,7 +371,7 @@ class OrderedRDD[PK, K, V] private(rdd: RDD[(K, V)], val orderedPartitioner: Ord
     val partSize = rdd.context.runJob(rdd, getIteratorSize _)
     info(s"partSize = ${ partSize.toSeq }")
 
-    val partCommulativeSize = mapAccumulate[Array, Int, Int, Int](partSize, 0)((s, acc) => (s + acc, s + acc))
+    val partCommulativeSize = mapAccumulate[Array, Long, Long, Long](partSize, 0)((s, acc) => (s + acc, s + acc))
     val totalSize = partCommulativeSize.last
 
     var newPartEnd = (0 until maxPartitions).map { i =>

--- a/src/main/scala/org/broadinstitute/hail/sparkextras/OrderedRDD.scala
+++ b/src/main/scala/org/broadinstitute/hail/sparkextras/OrderedRDD.scala
@@ -6,7 +6,6 @@ import org.apache.spark.rdd.{PartitionPruningRDD, RDD, ShuffledRDD}
 import org.apache.spark.storage.StorageLevel
 import org.broadinstitute.hail.utils._
 import org.apache.spark.{SparkContext, _}
-import org.broadinstitute.hail.variant.Variant
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -369,12 +368,8 @@ class OrderedRDD[PK, K, V] private(rdd: RDD[(K, V)], val orderedPartitioner: Ord
     if (maxPartitions >= n)
       return this
 
-    val persisted = rdd.persist(StorageLevel.MEMORY_AND_DISK)
-
-    val partSize = new Array[Int](n)
-    persisted.mapPartitionsWithIndex((i, it) => Iterator((i, it.length)))
-      .collect()
-      .foreach { case (i, size) => partSize(i) = size }
+    val partSize = rdd.context.runJob(rdd, getIteratorSize _)
+    info(s"partSize = ${ partSize.toSeq }")
 
     val partCommulativeSize = mapAccumulate[Array, Int, Int, Int](partSize, 0)((s, acc) => (s + acc, s + acc))
     val totalSize = partCommulativeSize.last
@@ -398,6 +393,8 @@ class OrderedRDD[PK, K, V] private(rdd: RDD[(K, V)], val orderedPartitioner: Ord
     newPartEnd = newPartEnd.zipWithIndex.filter { case (end, i) => i == 0 || newPartEnd(i) != newPartEnd(i - 1) }
       .map(_._1)
 
+    info(s"newPartEnd = ${ newPartEnd.toSeq }")
+
     assert(newPartEnd.last == n - 1)
     assert(newPartEnd.zip(newPartEnd.tail).forall { case (i, inext) => i < inext })
 
@@ -406,7 +403,7 @@ class OrderedRDD[PK, K, V] private(rdd: RDD[(K, V)], val orderedPartitioner: Ord
 
     val newRangeBounds = newPartEnd.init.map(orderedPartitioner.rangeBounds)
     val partitioner = new OrderedPartitioner(newRangeBounds, newPartEnd.length)
-    new OrderedRDD[PK, K, V](new BlockedRDD(persisted, newPartEnd), partitioner)
+    new OrderedRDD[PK, K, V](new BlockedRDD(rdd, newPartEnd), partitioner)
   }
 }
 

--- a/src/main/scala/org/broadinstitute/hail/utils/package.scala
+++ b/src/main/scala/org/broadinstitute/hail/utils/package.scala
@@ -324,4 +324,12 @@ package object utils extends Logging
     }
   }
 
+  def getIteratorSize[T](iterator: Iterator[T]): Int = {
+    var count = 0
+    while (iterator.hasNext) {
+      count += 1
+      iterator.next()
+    }
+    count
+  }
 }

--- a/src/main/scala/org/broadinstitute/hail/utils/package.scala
+++ b/src/main/scala/org/broadinstitute/hail/utils/package.scala
@@ -324,10 +324,10 @@ package object utils extends Logging
     }
   }
 
-  def getIteratorSize[T](iterator: Iterator[T]): Int = {
-    var count = 0
+  def getIteratorSize[T](iterator: Iterator[T]): Long = {
+    var count = 0L
     while (iterator.hasNext) {
-      count += 1
+      count += 1L
       iterator.next()
     }
     count


### PR DESCRIPTION
Don't presist in repartition/coalesce.
Fixed Int overflow bug in OrderedRDD.coalesce.
Convert to GenotypeStream in cache, persist.
Fixed filteralleles annotation bug.
