### PR TITLE
Added asm4s lightweight bytecode generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,9 @@ dependencies {
 
     compile 'com.jayway.restassured:rest-assured:2.8.0'
 
+    compile group: 'org.ow2.asm', name: 'asm', version: '5.1'
+    compile group: 'org.ow2.asm', name: 'asm-util', version: '5.1'
+
     testCompile 'org.testng:testng:6.8.21'
     testCompile 'org.scalatest:scalatest_' + scalaMajorVersion + ':2.2.4'
 }

--- a/src/main/scala/org/broadinstitute/hail/asm4s/Code.scala
+++ b/src/main/scala/org/broadinstitute/hail/asm4s/Code.scala
@@ -1,0 +1,352 @@
+package org.broadinstitute.hail.asm4s
+
+import java.lang.reflect.{Constructor, Field, Method, Modifier}
+
+import org.objectweb.asm.tree._
+import org.objectweb.asm.Opcodes._
+import org.objectweb.asm.Type
+
+import scala.reflect.ClassTag
+
+object Code {
+  def apply[T](insn: => AbstractInsnNode): Code[T] = new Code[T] {
+    def emit(il: InsnList): Unit = {
+      il.add(insn)
+    }
+  }
+
+  def apply[S1, S2](c1: Code[S1], c2: Code[S2]): Code[S2] =
+    new Code[S2] {
+      def emit(il: InsnList): Unit = {
+        c1.emit(il)
+        c2.emit(il)
+      }
+    }
+
+  def apply[S1, S2, S3](c1: Code[S1], c2: Code[S2], c3: Code[S3]): Code[S3] =
+    new Code[S3] {
+      def emit(il: InsnList): Unit = {
+        c1.emit(il)
+        c2.emit(il)
+        c3.emit(il)
+      }
+    }
+
+  def apply[S1, S2, S3, S4](c1: Code[S1], c2: Code[S2], c3: Code[S3], c4: Code[S4]): Code[S4] =
+    new Code[S4] {
+      def emit(il: InsnList): Unit = {
+        c1.emit(il)
+        c2.emit(il)
+        c3.emit(il)
+        c4.emit(il)
+      }
+    }
+
+  def apply[S1, S2, S3, S4, S5](c1: Code[S1], c2: Code[S2], c3: Code[S3], c4: Code[S4], c5: Code[S5]): Code[S5] =
+    new Code[S5] {
+      def emit(il: InsnList): Unit = {
+        c1.emit(il)
+        c2.emit(il)
+        c3.emit(il)
+        c4.emit(il)
+        c5.emit(il)
+      }
+    }
+
+  def apply[S1, S2, S3, S4, S5, S6](c1: Code[S1], c2: Code[S2], c3: Code[S3], c4: Code[S4], c5: Code[S5], c6: Code[S6]): Code[S6] =
+    new Code[S6] {
+      def emit(il: InsnList): Unit = {
+        c1.emit(il)
+        c2.emit(il)
+        c3.emit(il)
+        c4.emit(il)
+        c5.emit(il)
+        c6.emit(il)
+      }
+    }
+}
+
+trait Code[T] {
+  self =>
+  def emit(il: InsnList): Unit
+
+  def empty: Code[Unit] = new Code[Unit] {
+    def emit(il: InsnList): Unit = {
+      // nothing
+    }
+  }
+
+  def compare(opcode: Int, rhs: Code[T]): CodeConditional =
+    new CodeConditional {
+      def emitConditional(il: InsnList): (LabelNode, LabelNode) = {
+        val ltrue = new LabelNode
+        val lfalse = new LabelNode
+        self.emit(il)
+        rhs.emit(il)
+        il.add(new JumpInsnNode(opcode, ltrue))
+        il.add(new JumpInsnNode(GOTO, lfalse))
+        (ltrue, lfalse)
+      }
+    }
+}
+
+trait CodeConditional extends Code[Boolean] { self =>
+  def emit(il: InsnList): Unit = {
+    val lafter = new LabelNode
+    val (ltrue, lfalse) = emitConditional(il)
+    il.add(lfalse)
+    il.add(new LdcInsnNode(0))
+    il.add(new JumpInsnNode(GOTO, lafter))
+    il.add(ltrue)
+    il.add(new LdcInsnNode(1))
+    il.add(lafter)
+  }
+
+  // returns (ltrue, lfalse)
+  def emitConditional(il: InsnList): (LabelNode, LabelNode)
+
+  def unary_!(): CodeConditional =
+    new CodeConditional {
+      def emitConditional(il: InsnList): (LabelNode, LabelNode) = {
+        val (ltrue, lfalse) = self.emitConditional(il)
+        (lfalse, ltrue)
+      }
+    }
+}
+
+class CodeBoolean(val lhs: Code[Boolean]) extends AnyVal {
+  def toConditional: CodeConditional = lhs match {
+    case cond: CodeConditional =>
+      cond
+
+    case _ =>
+      new CodeConditional {
+        def emitConditional(il: InsnList): (LabelNode, LabelNode) = {
+          val ltrue = new LabelNode
+          val lfalse = new LabelNode
+          lhs.emit(il)
+          il.add(new JumpInsnNode(IFEQ, lfalse))
+          il.add(new JumpInsnNode(GOTO, ltrue))
+          (ltrue, lfalse)
+        }
+      }
+  }
+
+  def unary_!(): Code[Boolean] =
+    !lhs.toConditional
+
+  def mux[T](cthen: Code[T], celse: Code[T]): Code[T] = {
+    val cond = lhs.toConditional
+    new Code[T] {
+      def emit(il: InsnList): Unit = {
+        val lafter = new LabelNode
+        val (ltrue, lfalse) = cond.emitConditional(il)
+        il.add(lfalse)
+        celse.emit(il)
+        il.add(new JumpInsnNode(GOTO, lafter))
+        il.add(ltrue)
+        cthen.emit(il)
+        // fall through
+        il.add(lafter)
+      }
+    }
+  }
+}
+
+class CodeInt(val lhs: Code[Int]) extends AnyVal {
+  def +(rhs: Code[Int]): Code[Int] = Code(lhs, rhs, new InsnNode(IADD))
+
+  def -(rhs: Code[Int]): Code[Int] = Code(lhs, rhs, new InsnNode(ISUB))
+
+  def *(rhs: Code[Int]): Code[Int] = Code(lhs, rhs, new InsnNode(IMUL))
+
+  def /(rhs: Code[Int]): Code[Int] = Code(lhs, rhs, new InsnNode(IDIV))
+
+  def >(rhs: Code[Int]): Code[Boolean] = lhs.compare(IF_ICMPGT, rhs)
+
+  def >=(rhs: Code[Int]): Code[Boolean] = lhs.compare(IF_ICMPGE, rhs)
+
+  def <(rhs: Code[Int]): Code[Boolean] = lhs.compare(IF_ICMPLT, rhs)
+
+  def <=(rhs: Code[Int]): Code[Boolean] = lhs.compare(IF_ICMPLE, rhs)
+
+  def ceq(rhs: Code[Int]): Code[Boolean] = lhs.compare(IF_ICMPEQ, rhs)
+
+  def cne(rhs: Code[Int]): Code[Boolean] = lhs.compare(IF_ICMPNE, rhs)
+}
+
+class CodeDouble(val lhs: Code[Double]) extends AnyVal {
+  def +(rhs: Code[Double]): Code[Double] = Code(lhs, rhs, new InsnNode(DADD))
+
+  def -(rhs: Code[Double]): Code[Double] = Code(lhs, rhs, new InsnNode(DSUB))
+
+  def *(rhs: Code[Double]): Code[Double] = Code(lhs, rhs, new InsnNode(DMUL))
+
+  def /(rhs: Code[Double]): Code[Double] = Code(lhs, rhs, new InsnNode(DDIV))
+
+  // FIXME DCMPG vs DCMPL
+  def compare(rhs: Code[Double]): Code[Int] = Code(lhs, rhs, new InsnNode(DCMPG))
+
+  def >(rhs: Code[Double]): Code[Boolean] = compare(rhs) > 0
+
+  def >=(rhs: Code[Double]): Code[Boolean] = compare(rhs) >= 0
+
+  def <(rhs: Code[Double]): Code[Boolean] = compare(rhs) < 0
+
+  def <=(rhs: Code[Double]): Code[Boolean] = compare(rhs) <= 0
+
+  def ceq(rhs: Code[Double]): Code[Boolean] = compare(rhs).ceq(0)
+
+  def cne(rhs: Code[Double]): Code[Boolean] = compare(rhs).cne(0)
+}
+
+class CodeArray[T](val lhs: Code[Array[T]])(implicit tti: TypeInfo[T]) {
+  def apply(i: Code[Int]): Code[T] =
+    Code(lhs, i, new InsnNode(tti.aloadOp))
+
+  def update(i: Code[Int], x: Code[T]): Code[Unit] =
+    Code(lhs, i, x, new InsnNode(tti.astoreOp))
+}
+
+object Invokeable {
+  def apply[T](c: Constructor[_])(implicit tct: ClassTag[T]): Invokeable[T, Unit] = new Invokeable[T, Unit]("<init>",
+    isStatic = false,
+    isInterface = false,
+    INVOKESPECIAL,
+    Type.getConstructorDescriptor(c))
+
+  def apply[T, S](m: Method)(implicit tct: ClassTag[T]): Invokeable[T, S] = {
+    val isInterface = m.getDeclaringClass.isInterface
+    val isStatic = Modifier.isStatic(m.getModifiers)
+    assert(!(isInterface && isStatic))
+    new Invokeable[T, S](m.getName,
+      isStatic,
+      isInterface,
+      if (isInterface)
+        INVOKEINTERFACE
+      else if (isStatic)
+        INVOKESTATIC
+      else
+        INVOKEVIRTUAL,
+      Type.getMethodDescriptor(m))
+  }
+
+  def lookupMethod[T, S](method: String, parameterTypes: Array[Class[_]])(implicit tct: ClassTag[T], sct: ClassTag[S]): Invokeable[T, S] = {
+    val m = tct.runtimeClass.getDeclaredMethod(method, parameterTypes: _*)
+    assert(m != null,
+      s"no such method ${tct.runtimeClass.getName}.$method(${
+        parameterTypes.map(_.getName).mkString(", ")
+      })")
+
+    assert(m.getReturnType == sct.runtimeClass,
+      s"when invoking ${tct.runtimeClass.getName}.$method(): ${m.getReturnType.getName}: wrong return type ${sct.runtimeClass.getName}")
+
+    Invokeable(m)
+  }
+
+  def lookupConstructor[T](parameterTypes: Array[Class[_]])(implicit tct: ClassTag[T]): Invokeable[T, Unit] = {
+    val c = tct.runtimeClass.getDeclaredConstructor(parameterTypes: _*)
+    assert(c != null,
+      s"no such method ${tct.runtimeClass.getName}(${
+        parameterTypes.map(_.getName).mkString(", ")
+      })")
+
+    Invokeable[T](c)
+  }
+}
+
+class Invokeable[T, S](val name: String,
+                       val isStatic: Boolean,
+                       val isInterface: Boolean,
+                       val invokeOp: Int,
+                       val descriptor: String)(implicit tct: ClassTag[T]) {
+  def invoke(lhs: Code[T], args: Array[Code[_]]): Code[S] =
+    new Code[S] {
+      def emit(il: InsnList): Unit = {
+        if (!isStatic && lhs != null)
+          lhs.emit(il)
+        args.foreach(_.emit(il))
+        il.add(new MethodInsnNode(invokeOp,
+          Type.getInternalName(tct.runtimeClass), name, descriptor, isInterface))
+      }
+    }
+}
+
+object FieldRef {
+  def apply[T, S](field: String)(implicit tct: ClassTag[T], sct: ClassTag[S], sti: TypeInfo[S]): FieldRef[T, S] = {
+    val f = tct.runtimeClass.getDeclaredField(field)
+    assert(f.getType == sct.runtimeClass,
+      s"when getting field ${tct.runtimeClass.getName}.$field: ${f.getType.getName}: wrong type ${sct.runtimeClass.getName} ")
+
+    new FieldRef(f)
+  }
+}
+
+class LocalRef[T](i: Int)(implicit tti: TypeInfo[T]) {
+  def load(): Code[T] =
+    new Code[T] {
+      def emit(il: InsnList): Unit = {
+        il.add(new IntInsnNode(tti.loadOp, i))
+      }
+    }
+
+  def store(rhs: Code[T]): Code[T] =
+    new Code[T] {
+      def emit(il: InsnList): Unit = {
+        rhs.emit(il)
+        il.add(new IntInsnNode(tti.storeOp, i))
+      }
+    }
+}
+
+class FieldRef[T, S](f: Field)(implicit tct: ClassTag[T], sti: TypeInfo[S]) {
+  def isStatic: Boolean = Modifier.isStatic(f.getModifiers)
+
+  def getOp = if (isStatic) GETSTATIC else GETFIELD
+
+  def putOp = if (isStatic) PUTSTATIC else PUTFIELD
+
+  def get(lhs: Code[T]): Code[S] =
+    new Code[S] {
+      def emit(il: InsnList): Unit = {
+        if (!isStatic)
+          lhs.emit(il)
+        il.add(new FieldInsnNode(getOp,
+          Type.getInternalName(tct.runtimeClass), f.getName, sti.name))
+      }
+    }
+
+  def put(lhs: Code[T], rhs: Code[S]): Code[Unit] =
+    new Code[Unit] {
+      def emit(il: InsnList): Unit = {
+        if (!isStatic)
+          lhs.emit(il)
+        rhs.emit(il)
+        il.add(new FieldInsnNode(putOp,
+          Type.getInternalName(tct.runtimeClass), f.getName, sti.name))
+      }
+    }
+}
+
+class CodeObject[T <: AnyRef](val lhs: Code[T])(implicit tct: ClassTag[T], tti: TypeInfo[T]) {
+  def get[S](field: String)(implicit sct: ClassTag[S], sti: TypeInfo[S]): Code[S] =
+    FieldRef[T, S](field).get(lhs)
+
+  def put[S](field: String, rhs: Code[S])(implicit sct: ClassTag[S], sti: TypeInfo[S]): Code[Unit] =
+    FieldRef[T, S](field).put(lhs, rhs)
+
+  def invoke[S](method: String, parameterTypes: Array[Class[_]], args: Array[Code[_]])
+               (implicit sct: ClassTag[S]): Code[S] =
+    Invokeable.lookupMethod[T, S](method, parameterTypes).invoke(lhs, args)
+
+  def invoke[S](method: String)(implicit sct: ClassTag[S]): Code[S] =
+    invoke[S](method, Array[Class[_]](), Array[Code[_]]())
+
+  def invoke[A1, S](method: String, a1: Code[A1])(implicit a1ct: ClassTag[A1],
+                                                  sct: ClassTag[S]): Code[S] =
+    invoke[S](method, Array[Class[_]](a1ct.runtimeClass), Array[Code[_]](a1))
+
+  def invoke[A1, A2, S](method: String, a1: Code[A1], a2: Code[A2])(implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2],
+                                                                    sct: ClassTag[S]): Code[S] =
+    invoke[S](method, Array[Class[_]](a1ct.runtimeClass, a2ct.runtimeClass), Array[Code[_]](a1, a2))
+}

--- a/src/main/scala/org/broadinstitute/hail/asm4s/FunctionBuilder.scala
+++ b/src/main/scala/org/broadinstitute/hail/asm4s/FunctionBuilder.scala
@@ -1,0 +1,212 @@
+package org.broadinstitute.hail.asm4s
+
+import java.io.PrintWriter
+
+import org.objectweb.asm.Opcodes._
+import org.objectweb.asm.tree._
+import java.util
+
+import org.objectweb.asm.util.{Textifier, TraceClassVisitor}
+import org.objectweb.asm.{ClassReader, ClassWriter, Type}
+
+import scala.language.implicitConversions
+import scala.reflect.ClassTag
+
+object FunctionBuilder {
+  var count = 0
+
+  def newUniqueID(): Int = {
+    val id = count
+    count += 1
+    id
+  }
+}
+
+abstract class FunctionBuilder[R](parameterTypeInfo: Array[TypeInfo[_]], returnTypeInfo: TypeInfo[R],
+                                  packageName: String = "is/hail/codegen/generated") {
+
+  import FunctionBuilder._
+
+  val cn = new ClassNode()
+  cn.version = V1_8
+  cn.access = ACC_PUBLIC
+
+  cn.name = packageName + "/C" + newUniqueID()
+  cn.superName = "java/lang/Object"
+
+  def signature: String = s"(${parameterTypeInfo.map(_.name).mkString})${returnTypeInfo.name}"
+
+  val mn = new MethodNode(ACC_PUBLIC + ACC_STATIC, "f", signature, null, null)
+  // FIXME why is cast necessary?
+  cn.methods.asInstanceOf[util.List[MethodNode]].add(mn)
+  val il = mn.instructions
+
+  val start = new LabelNode
+  val end = new LabelNode
+
+  val layout: Array[Int] =
+    parameterTypeInfo.scanLeft(0) { case (prev, ti) => prev + ti.slots }
+  val argIndex: Array[Int] = layout.init
+  var locals: Int = layout.last
+
+  def allocLocal[T]()(implicit tti: TypeInfo[T]): Int = {
+    val i = locals
+    locals += tti.slots
+
+    mn.localVariables.asInstanceOf[util.List[LocalVariableNode]]
+      .add(new LocalVariableNode("local" + i, tti.name, null, start, end, i))
+    i
+  }
+
+  def newLocal[T]()(implicit tti: TypeInfo[T]): LocalRef[T] =
+    new LocalRef[T](allocLocal[T]())
+
+  def invokeStatic[T, S](method: String, parameterTypes: Array[Class[_]], args: Array[Code[_]])(implicit tct: ClassTag[T], sct: ClassTag[S]): Code[S] = {
+    val m = Invokeable.lookupMethod[T, S](method, parameterTypes)
+    assert(m.isStatic)
+    m.invoke(null, args)
+  }
+
+  def invokeStatic[T, S](method: String)(implicit tct: ClassTag[T], sct: ClassTag[S]): Code[S] =
+    invokeStatic[T, S](method, Array[Class[_]](), Array[Code[_]]())
+
+  def invokeStatic[T, A1, S](method: String, a1: Code[A1])(implicit tct: ClassTag[T], sct: ClassTag[S], a1ct: ClassTag[A1]): Code[S] =
+    invokeStatic[T, S](method, Array[Class[_]](a1ct.runtimeClass), Array[Code[_]](a1))
+
+  def invokeStatic[T, A1, A2, S](method: String, a1: Code[A1], a2: Code[A2])(implicit tct: ClassTag[T], sct: ClassTag[S], a1ct: ClassTag[A1], a2ct: ClassTag[A2]): Code[S] =
+    invokeStatic[T, S](method, Array[Class[_]](a1ct.runtimeClass, a2ct.runtimeClass), Array[Code[_]](a1, a2))
+
+  def getStatic[T, S](field: String)(implicit tct: ClassTag[T], sct: ClassTag[S], sti: TypeInfo[S]): Code[S] = {
+    val f = FieldRef[T, S](field)
+    assert(f.isStatic)
+    f.get(null)
+  }
+
+  def putStatic[T, S](field: String, rhs: Code[S])(implicit tct: ClassTag[T], sct: ClassTag[S], sti: TypeInfo[S]): Code[Unit] = {
+    val f = FieldRef[T, S](field)
+    assert(f.isStatic)
+    f.put(null, rhs)
+  }
+
+  def newArray[T](size: Code[Int])(implicit tti: TypeInfo[T],
+                                   atti: TypeInfo[Array[T]]): (Code[Unit], Code[Array[T]]) = {
+    val arri = allocLocal[Array[T]]()
+    (new Code[Unit] {
+      def emit(il: InsnList): Unit = {
+        size.emit(il)
+        il.add(tti.newArray())
+        il.add(new IntInsnNode(atti.storeOp, arri))
+      }
+    }, new Code[Array[T]] {
+      def emit(il: InsnList): Unit = {
+        il.add(new IntInsnNode(atti.loadOp, arri))
+      }
+    })
+  }
+
+  def newInstance[T](parameterTypes: Array[Class[_]], args: Array[Code[_]])(implicit tct: ClassTag[T], tti: TypeInfo[T]): (Code[Unit], Code[T]) = {
+    val inst = allocLocal[T]()
+    val ctor = Invokeable.lookupConstructor[T](Array()).invoke(null, Array())
+    (new Code[Unit] {
+      def emit(il: InsnList): Unit = {
+        il.add(new TypeInsnNode(NEW, Type.getInternalName(tct.runtimeClass)))
+        il.add(new InsnNode(DUP))
+        il.add(new IntInsnNode(tti.storeOp, inst))
+        ctor.emit(il)
+      }
+    },
+      new Code[T] {
+        def emit(il: InsnList): Unit = {
+          il.add(new IntInsnNode(tti.loadOp, inst))
+        }
+      })
+  }
+
+  def newInstance[T]()(implicit tct: ClassTag[T], tti: TypeInfo[T]): (Code[Unit], Code[T]) =
+    newInstance[T](Array[Class[_]](), Array[Code[_]]())
+
+  def newInstance[T, A1](a1: Code[A1])(implicit a1ct: ClassTag[A1],
+                                       tct: ClassTag[T], tti: TypeInfo[T]): (Code[Unit], Code[T]) =
+    newInstance[T](Array[Class[_]](a1ct.runtimeClass), Array[Code[_]](a1))
+
+  def newInstance[T, A1, A2](a1: Code[A1], a2: Code[A2])(implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2],
+                                                         tct: ClassTag[T], tti: TypeInfo[T]): (Code[Unit], Code[T]) =
+    newInstance[T](Array[Class[_]](a1ct.runtimeClass, a2ct.runtimeClass), Array[Code[_]](a1, a2))
+
+  def getArg[T](i: Int)(implicit tti: TypeInfo[T]): LocalRef[T] = {
+    assert(i >= 0)
+    assert(i < parameterTypeInfo.length)
+    new LocalRef[T](argIndex(i))
+  }
+
+  def resultClass(c: Code[R]): Class[_] = {
+    mn.instructions.add(start)
+    c.emit(mn.instructions)
+    mn.instructions.add(new InsnNode(returnTypeInfo.returnOp))
+    mn.instructions.add(end)
+
+    val cw = new ClassWriter(ClassWriter.COMPUTE_MAXS +
+      ClassWriter.COMPUTE_FRAMES)
+    cn.accept(cw)
+    val b = cw.toByteArray
+    val clazz = loadClass(null, b)
+
+    // print bytecode for debugging
+    /*
+    val cr = new ClassReader(b)
+    val tcv = new TraceClassVisitor(null, new Textifier, new PrintWriter(System.out))
+    cr.accept(tcv, 0)
+    */
+
+    clazz
+  }
+
+  def whileLoop(condition: Code[Boolean], body: Code[_]): Code[Unit] = {
+    val l1 = new LabelNode
+    val l2 = new LabelNode
+    new Code[Unit] {
+      def emit(il: InsnList): Unit = {
+        il.add(l1)
+        condition.emit(il)
+        il.add(new LdcInsnNode(0))
+        il.add(new JumpInsnNode(IF_ICMPEQ, l2))
+        body.emit(il)
+        il.add(new JumpInsnNode(GOTO, l1))
+        il.add(l2)
+      }
+    }
+  }
+}
+
+class Function0Builder[R](implicit rti: TypeInfo[R]) extends FunctionBuilder[R](Array[TypeInfo[_]](), rti) {
+  def result(c: Code[R]): () => R = {
+    val clazz = resultClass(c)
+    val m = clazz.getMethod("f")
+    () => m.invoke(null).asInstanceOf[R]
+  }
+}
+
+class Function1Builder[A, R](implicit act: ClassTag[A], ati: TypeInfo[A],
+                             rti: TypeInfo[R]) extends FunctionBuilder[R](Array[TypeInfo[_]](ati), rti) {
+  def arg1 = getArg[A](0)
+
+  def result(c: Code[R]): (A) => R = {
+    val clazz = resultClass(c)
+    val m = clazz.getMethod("f", act.runtimeClass)
+    (a: A) => m.invoke(null, a.asInstanceOf[AnyRef]).asInstanceOf[R]
+  }
+}
+
+class Function2Builder[A1, A2, R](implicit a1ct: ClassTag[A1], a1ti: TypeInfo[A1],
+                                  a2ct: ClassTag[A2], a2ti: TypeInfo[A2],
+                                  rti: TypeInfo[R]) extends FunctionBuilder[R](Array[TypeInfo[_]](a1ti, a2ti), rti) {
+  def arg1 = getArg[A1](0)
+
+  def arg2 = getArg[A2](1)
+
+  def result(c: Code[R]): (A1, A2) => R = {
+    val clazz = resultClass(c)
+    val m = clazz.getMethod("f", a1ct.runtimeClass, a2ct.runtimeClass)
+    (a1: A1, a2: A2) => m.invoke(null, a1.asInstanceOf[AnyRef], a2.asInstanceOf[AnyRef]).asInstanceOf[R]
+  }
+}

--- a/src/main/scala/org/broadinstitute/hail/asm4s/package.scala
+++ b/src/main/scala/org/broadinstitute/hail/asm4s/package.scala
@@ -172,6 +172,8 @@ package object asm4s {
 
   implicit def toCodeDouble(f: LocalRef[Double]): CodeDouble = new CodeDouble(f.load())
 
+  implicit def toCodeArray[T](f: LocalRef[Array[T]])(implicit tti: TypeInfo[T]): CodeArray[T] = new CodeArray(f.load())
+
   implicit def toCodeBoolean(f: LocalRef[Boolean]): CodeBoolean = new CodeBoolean(f.load())
 
   implicit def toCodeObject[T <: AnyRef](f: LocalRef[T])(implicit tti: TypeInfo[T], tct: ClassTag[T]): CodeObject[T] = new CodeObject[T](f.load())

--- a/src/main/scala/org/broadinstitute/hail/asm4s/package.scala
+++ b/src/main/scala/org/broadinstitute/hail/asm4s/package.scala
@@ -1,0 +1,184 @@
+package org.broadinstitute.hail
+
+import java.lang.reflect.Method
+
+import org.objectweb.asm.Type
+import org.objectweb.asm.Opcodes._
+import org.objectweb.asm.tree._
+
+import scala.language.implicitConversions
+import scala.reflect.ClassTag
+
+package object asm4s {
+
+  trait TypeInfo[T] {
+    val name: String
+    val loadOp: Int
+    val storeOp: Int
+    val aloadOp: Int
+    val astoreOp: Int
+    val returnOp: Int
+    val slots: Int = 1
+
+    def newArray(): AbstractInsnNode
+  }
+
+  implicit object BooealnInfo extends TypeInfo[Boolean] {
+    val name = "Z"
+    val loadOp = ILOAD
+    val storeOp = ISTORE
+    val aloadOp = IALOAD
+    val astoreOp = IASTORE
+    val returnOp = IRETURN
+    val newarrayOp = NEWARRAY
+
+    def newArray() = new IntInsnNode(NEWARRAY, T_BOOLEAN)
+  }
+
+  implicit object ByteInfo extends TypeInfo[Byte] {
+    val name = "B"
+    val loadOp = ILOAD
+    val storeOp = ISTORE
+    val aloadOp = IALOAD
+    val astoreOp = IASTORE
+    val returnOp = IRETURN
+    val newarrayOp = NEWARRAY
+
+    def newArray() = new IntInsnNode(NEWARRAY, T_BYTE)
+  }
+
+  implicit object ShortInfo extends TypeInfo[Short] {
+    val name = "S"
+    val loadOp = ILOAD
+    val storeOp = ISTORE
+    val aloadOp = IALOAD
+    val astoreOp = IASTORE
+    val returnOp = IRETURN
+    val newarrayOp = NEWARRAY
+
+    def newArray() = new IntInsnNode(NEWARRAY, T_SHORT)
+  }
+
+  implicit object IntInfo extends TypeInfo[Int] {
+    val name = "I"
+    val loadOp = ILOAD
+    val storeOp = ISTORE
+    val aloadOp = IALOAD
+    val astoreOp = IASTORE
+    val returnOp = IRETURN
+
+    def newArray() = new IntInsnNode(NEWARRAY, T_INT)
+  }
+
+  implicit object LongInfo extends TypeInfo[Long] {
+    val name = "J"
+    val loadOp = LLOAD
+    val storeOp = LSTORE
+    val aloadOp = LALOAD
+    val astoreOp = LASTORE
+    val returnOp = LRETURN
+    override val slots = 2
+
+    def newArray() = new IntInsnNode(NEWARRAY, T_LONG)
+  }
+
+  implicit object FloatInfo extends TypeInfo[Float] {
+    val name = "F"
+    val loadOp = FLOAD
+    val storeOp = FSTORE
+    val aloadOp = FALOAD
+    val astoreOp = FASTORE
+    val returnOp = FRETURN
+
+    def newArray() = new IntInsnNode(NEWARRAY, T_FLOAT)
+  }
+
+  implicit object DoubleInfo extends TypeInfo[Double] {
+    val name = "D"
+    val loadOp = DLOAD
+    val storeOp = DSTORE
+    val aloadOp = DALOAD
+    val astoreOp = DASTORE
+    val returnOp = DRETURN
+    override val slots = 2
+
+    def newArray() = new IntInsnNode(NEWARRAY, T_DOUBLE)
+  }
+
+  implicit object CharInfo extends TypeInfo[Char] {
+    val name = "C"
+    val loadOp = ILOAD
+    val storeOp = ISTORE
+    val aloadOp = IALOAD
+    val astoreOp = IASTORE
+    val returnOp = IRETURN
+    override val slots = 2
+
+    def newArray() = new IntInsnNode(NEWARRAY, T_CHAR)
+  }
+
+  implicit def classInfo[C <: AnyRef](implicit cct: ClassTag[C]): TypeInfo[C] = {
+    new TypeInfo[C] {
+      val name = Type.getDescriptor(cct.runtimeClass)
+      val loadOp = ALOAD
+      val storeOp = ASTORE
+      val aloadOp = AALOAD
+      val astoreOp = AASTORE
+      val returnOp = ARETURN
+
+      def newArray() = new TypeInsnNode(ANEWARRAY, name)
+    }
+  }
+
+  def loadClass(className: String, b: Array[Byte]): Class[_] = {
+    // override classDefine (as it is protected) and define the class.
+    var clazz: Class[_] = null
+    val loader: ClassLoader = ClassLoader.getSystemClassLoader
+    val cls: Class[_] = Class.forName("java.lang.ClassLoader")
+    val method: Method = cls.getDeclaredMethod("defineClass", classOf[String], classOf[Array[Byte]], classOf[Int], classOf[Int])
+
+    // protected method invocaton
+    method.setAccessible(true)
+
+    clazz = method.invoke(loader, null, b, new Integer(0), new Integer(b.length)).asInstanceOf[Class[_]]
+
+    method.setAccessible(false)
+
+    clazz
+  }
+
+  def ??? = throw new UnsupportedOperationException
+
+  implicit def toCodeBoolean(c: Code[Boolean]): CodeBoolean = new CodeBoolean(c)
+
+  implicit def toCodeInt(c: Code[Int]): CodeInt = new CodeInt(c)
+
+  implicit def toCodeDouble(c: Code[Double]): CodeDouble = new CodeDouble(c)
+
+  implicit def toCodeArray[T](c: Code[Array[T]])(implicit tti: TypeInfo[T]): CodeArray[T] = new CodeArray(c)
+
+  implicit def toCodeObject[T <: AnyRef](c: Code[T])(implicit tti: TypeInfo[T], tct: ClassTag[T]): CodeObject[T] =
+    new CodeObject(c)
+
+  implicit def toCode[T](insn: => AbstractInsnNode): Code[T] = new Code[T] {
+    def emit(il: InsnList): Unit = {
+      il.add(insn)
+    }
+  }
+
+  implicit def toCode[T](f: LocalRef[T]): Code[T] = f.load()
+
+  implicit def toCodeInt(f: LocalRef[Int]): CodeInt = new CodeInt(f.load())
+
+  implicit def toCodeDouble(f: LocalRef[Double]): CodeDouble = new CodeDouble(f.load())
+
+  implicit def toCodeBoolean(f: LocalRef[Boolean]): CodeBoolean = new CodeBoolean(f.load())
+
+  implicit def toCodeObject[T <: AnyRef](f: LocalRef[T])(implicit tti: TypeInfo[T], tct: ClassTag[T]): CodeObject[T] = new CodeObject[T](f.load())
+
+  implicit def const(b: Boolean): Code[Boolean] = Code(new LdcInsnNode(if (b) 1 else 0))
+
+  implicit def const(i: Int): Code[Int] = Code(new LdcInsnNode(i))
+
+  implicit def const(d: Double): Code[Double] = Code(new LdcInsnNode(d))
+}

--- a/src/main/scala/org/broadinstitute/hail/asm4s/package.scala
+++ b/src/main/scala/org/broadinstitute/hail/asm4s/package.scala
@@ -23,7 +23,7 @@ package object asm4s {
     def newArray(): AbstractInsnNode
   }
 
-  implicit object BooealnInfo extends TypeInfo[Boolean] {
+  implicit object BooleanInfo extends TypeInfo[Boolean] {
     val name = "Z"
     val loadOp = ILOAD
     val storeOp = ISTORE

--- a/src/test/scala/org/broadinstitute/hail/asm4s/A.java
+++ b/src/test/scala/org/broadinstitute/hail/asm4s/A.java
@@ -1,0 +1,9 @@
+package org.broadinstitute.hail.asm4s;
+
+public class A {
+    public static int j = 11;
+    public int i = 5;
+
+    public int f() { return i + 1; }
+    public int g(int j) { return i + j; }
+}

--- a/src/test/scala/org/broadinstitute/hail/asm4s/ASM4SSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/asm4s/ASM4SSuite.scala
@@ -26,9 +26,9 @@ class ASM4SSuite extends TestNGSuite {
 
   @Test def array(): Unit = {
     val hb = new Function1Builder[Int, Int]
-    val (create, arr) = hb.newArray[Int](3)
+    val arr = hb.newLocal[Array[Int]]()
     val h = hb.result(Code(
-      create,
+      arr.store(hb.newArray[Int](3)),
       arr(0) = 6,
       arr(1) = 7,
       arr(2) = -6,
@@ -65,18 +65,16 @@ class ASM4SSuite extends TestNGSuite {
 
   @Test def newInstance(): Unit = {
     val fb = new Function0Builder[Int]
-    val (create, inst) = fb.newInstance[A]()
-    val f = fb.result(Code(
-      create,
-      inst.invoke[Int]("f")))
+    val f = fb.result(
+      fb.newInstance[A]().invoke[Int]("f"))
     assert(f() == 6)
   }
 
   @Test def put(): Unit = {
     val fb = new Function0Builder[Int]
-    val (create, inst) = fb.newInstance[A]()
+    val inst = fb.newLocal[A]()
     val f = fb.result(Code(
-      create,
+      inst.store(fb.newInstance[A]()),
       inst.put("i", -2),
       inst.get("i")))
     assert(f() == -2)
@@ -84,9 +82,9 @@ class ASM4SSuite extends TestNGSuite {
 
   @Test def staticPut(): Unit = {
     val fb = new Function0Builder[Int]
-    val (create, inst) = fb.newInstance[A]()
+    val inst = fb.newLocal[A]()
     val f = fb.result(Code(
-      create,
+      inst.store(fb.newInstance[A]()),
       inst.put("j", -2),
       fb.getStatic[A, Int]("j")))
     assert(f() == -2)
@@ -135,12 +133,11 @@ class ASM4SSuite extends TestNGSuite {
 
   @Test def anewarray(): Unit = {
     val fb = new Function0Builder[Int]
-    val (createarr, arr) = fb.newArray[A](2)
-    val (createa, a) = fb.newInstance[A]()
+    val arr = fb.newLocal[Array[A]]()
     val f = fb.result(Code(
-      createarr,
-      createa, arr(0) = a,
-      createa, arr(1) = a,
+      arr.store(fb.newArray[A](2)),
+      arr(0) = fb.newInstance[A](),
+      arr(1) = fb.newInstance[A](),
       arr(0).get[Int]("i") + arr(1).get[Int]("i")
     ))
     assert(f() == 10)

--- a/src/test/scala/org/broadinstitute/hail/asm4s/ASM4SSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/asm4s/ASM4SSuite.scala
@@ -1,0 +1,148 @@
+package org.broadinstitute.hail.asm4s
+
+import org.scalatest.testng.TestNGSuite
+import org.testng.annotations.Test
+
+class ASM4SSuite extends TestNGSuite {
+  @Test def not(): Unit = {
+    val notb = new Function1Builder[Boolean, Boolean]
+    val not = notb.result(!notb.arg1)
+    assert(!not(true))
+    assert(not(false))
+  }
+
+  @Test def mux(): Unit = {
+    val gb = new Function1Builder[Boolean, Int]
+    val g = gb.result(gb.arg1.mux(11, -1))
+    assert(g(true) == 11)
+    assert(g(false) == -1)
+  }
+
+  @Test def add(): Unit = {
+    val fb = new Function1Builder[Int, Int]
+    val f = fb.result(fb.arg1 + 5)
+    assert(f(-2) == 3)
+  }
+
+  @Test def array(): Unit = {
+    val hb = new Function1Builder[Int, Int]
+    val (create, arr) = hb.newArray[Int](3)
+    val h = hb.result(Code(
+      create,
+      arr(0) = 6,
+      arr(1) = 7,
+      arr(2) = -6,
+      arr(hb.arg1)
+    ))
+    assert(h(0) == 6)
+    assert(h(1) == 7)
+    assert(h(2) == -6)
+  }
+
+  @Test def get(): Unit = {
+    val ib = new Function1Builder[A, Int]
+    val i = ib.result(ib.arg1.get[Int]("i"))
+
+    val a = new A
+    assert(i(a) == 5)
+  }
+
+  @Test def invoke(): Unit = {
+    val ib = new Function1Builder[A, Int]
+    val i = ib.result(ib.arg1.invoke[Int]("f"))
+
+    val a = new A
+    assert(i(a) == 6)
+  }
+
+  @Test def invoke2(): Unit = {
+    val jb = new Function1Builder[A, Int]
+    val j = jb.result(jb.arg1.invoke[Int, Int]("g", 6))
+
+    val a = new A
+    assert(j(a) == 11)
+  }
+
+  @Test def newInstance(): Unit = {
+    val fb = new Function0Builder[Int]
+    val (create, inst) = fb.newInstance[A]()
+    val f = fb.result(Code(
+      create,
+      inst.invoke[Int]("f")))
+    assert(f() == 6)
+  }
+
+  @Test def put(): Unit = {
+    val fb = new Function0Builder[Int]
+    val (create, inst) = fb.newInstance[A]()
+    val f = fb.result(Code(
+      create,
+      inst.put("i", -2),
+      inst.get("i")))
+    assert(f() == -2)
+  }
+
+  @Test def staticPut(): Unit = {
+    val fb = new Function0Builder[Int]
+    val (create, inst) = fb.newInstance[A]()
+    val f = fb.result(Code(
+      create,
+      inst.put("j", -2),
+      fb.getStatic[A, Int]("j")))
+    assert(f() == -2)
+  }
+
+  @Test def f2(): Unit = {
+    val fb = new Function2Builder[Int, Int, Int]
+    val f = fb.result(fb.arg1 + fb.arg2)
+    assert(f(3, 5) == 8)
+  }
+
+  @Test def compare(): Unit = {
+    val fb = new Function2Builder[Int, Int, Boolean]
+    val f = fb.result(fb.arg1 > fb.arg2)
+    assert(f(5, 2))
+    assert(!f(-1, -1))
+    assert(!f(2, 5))
+  }
+
+  @Test def fact(): Unit = {
+    val fb = new Function1Builder[Int, Int]
+    val i = fb.arg1
+    val r = fb.newLocal[Int]()
+    val f = fb.result(Code(
+      r.store(1),
+      fb.whileLoop(
+        fb.arg1 > 1,
+        Code(
+          r.store(r * i),
+          i.store(i - 1))),
+      r))
+
+    assert(f(3) == 6)
+    assert(f(4) == 24)
+  }
+
+  @Test def dcmp(): Unit = {
+    val fb = new Function2Builder[Double, Double, Boolean]
+    val f = fb.result(fb.arg1 > fb.arg2)
+    assert(f(5.2, 2.3))
+
+    val d = -2.3
+    assert(!f(d, d))
+    assert(!f(2.3, 5.2))
+  }
+
+  @Test def anewarray(): Unit = {
+    val fb = new Function0Builder[Int]
+    val (createarr, arr) = fb.newArray[A](2)
+    val (createa, a) = fb.newInstance[A]()
+    val f = fb.result(Code(
+      createarr,
+      createa, arr(0) = a,
+      createa, arr(1) = a,
+      arr(0).get[Int]("i") + arr(1).get[Int]("i")
+    ))
+    assert(f() == 10)
+  }  
+}


### PR DESCRIPTION
@danking, I started playing with your ASM experiment and wrote a library for lightweight bytecode generation.

The primary abstractions are `FunctionBuilder` and `Code[T]`.  The latter is an object that can generate bytecode to produce a value of type `T` on the top of the stack.

I'm reasonably happy with the interface, see this example for factorial:

https://github.com/cseed/hail/commit/93d95982bccd16ffa531f67fa47163f3fc8cbdde#diff-e434fa9004c38142a8f6f64ffa73b48eR109

No ClassBuilder yet.  Apart from that, all the major features are there.  There are a bunch of missing operations (type conversions, for example) and I only have wrapper classes for `Int` and `Double`.  Once we fill it out I think it will make an excellent stand-alone library.

While I optimized conditional generation to be smart about converting between indicator values (0, 1) and branch targets, it still emits some unnecessary GOTOs for fall through and could be improved.

There are two double comparison bytecodes (DCMPG and DCMPL) that treat NAN differently.  I wasn't sure which one to use.  We should probably emulate Java/Scala.

I can't tell if ASM is generating short bytecodes for load from small local indices (e.g. ILOAD_2) or small constants (e.g., ICONST_3).  It isn't clear if the pretty printer that comes with ASM makes a distinction.  We probably need to dump to a file and run `javap`.
