### PR TITLE
resolves #836 -- add edit links to FAQ

### DIFF
--- a/docs/faq/Annotations.md
+++ b/docs/faq/Annotations.md
@@ -1,4 +1,4 @@
-## <a class="jumptarget" name="annotations"></a> Annotations 
+## <a class="jumptarget" name="annotations"></a> Annotations
 
 #### How can I find the current schema of variant, sample, and global annotations?
 

--- a/docs/javascript/buildDocs.js
+++ b/docs/javascript/buildDocs.js
@@ -91,6 +91,7 @@ exports.buildCommand = function (command, pandocOutputDir, $) {
 exports.buildFaqHeader = function (name, $) {
     return new Promise(function (resolve, reject) {
         $("#" + name + " h2").append("<span style=\"font-size: 50%; vertical-align: middle; color: #555\"> [ <a href=\"https://github.com/hail-is/hail/edit/master/docs/faq/"+name+".md\" target=\"_blank\">edit</a> ]</span>");
+        resolve();
     });
 }
 

--- a/docs/javascript/buildDocs.js
+++ b/docs/javascript/buildDocs.js
@@ -88,6 +88,12 @@ exports.buildCommand = function (command, pandocOutputDir, $) {
     });
 }
 
+exports.buildFaqHeader = function (name, $) {
+    return new Promise(function (resolve, reject) {
+        $("#" + name + " h2").append("<span style=\"font-size: 50%; vertical-align: middle; color: #555\"> [ <a href=\"https://github.com/hail-is/hail/edit/master/docs/faq/"+name+".md\" target=\"_blank\">edit</a> ]</span>");
+    });
+}
+
 exports.buildFaqTOC = function ($) {
   return new Promise(function (resolve, reject) {
       function listItem(id, text) { return "<li><a href=#" + id + ">" + text + "</a></li>"; }

--- a/docs/javascript/buildDocs.js
+++ b/docs/javascript/buildDocs.js
@@ -106,6 +106,7 @@ exports.buildFaqTOC = function ($) {
           var text = element.text();
           $("#TOC ul").append(listItem(id, text));
           element.prepend(anchor(id));
+          element.addClass("faq");
       });
 
       resolve();

--- a/docs/javascript/compileDocsNode.js
+++ b/docs/javascript/compileDocsNode.js
@@ -142,23 +142,25 @@ function buildFAQ(htmlTemplate, outputFileName) {
 
         const $ = require('jquery')(window);
 
-    var loadFaqPromises =  ["Annotations",
-                            "DataRepresentation",
-                            "DevTools",
-                            "ErrorMessages",
-                            "ExportingData",
-                            "ExpressionLanguage",
-                            "FilteringData",
-                            "General",
-                            "ImportingData",
-                            "Installation",
-                            "Methods",
-                            "OptimizePipeline"]
-                            .map(name => loadReq("#" + name, pandocOutputDir + "faq/" + name + ".html", $));
+    var faqNames = ["Annotations",
+                    "DataRepresentation",
+                    "DevTools",
+                    "ErrorMessages",
+                    "ExportingData",
+                    "ExpressionLanguage",
+                    "FilteringData",
+                    "General",
+                    "ImportingData",
+                    "Installation",
+                    "Methods",
+                    "OptimizePipeline"];
+
+    var loadFaqPromises = faqNames.map(name => loadReq("#" + name, pandocOutputDir + "faq/" + name + ".html", $));
 
         Promise.all(loadFaqPromises)
             .then(function () {
                 buildDocs.buildFaqTOC($);
+                faqNames.map(name => buildDocs.buildFaqHeader(name, $));
             }, error)
             .then(function() {
                  var document = jsdom.jsdom($('html').html());

--- a/www/style.css
+++ b/www/style.css
@@ -460,3 +460,7 @@ img#logo {
     height: 50px;
     margin: -50px 0 0;
 }
+
+h4.faq {
+    z-index: -999;
+}


### PR DESCRIPTION
@danking: I can't figure out why all of the edit links are clickable except for the Annotations and Exporting Data ones. They're auto-generated with the same code.
