### PR TITLE
added Balding-Nichols model to TestUtils

### DIFF
--- a/src/test/scala/org/broadinstitute/hail/TestUtils.scala
+++ b/src/test/scala/org/broadinstitute/hail/TestUtils.scala
@@ -1,6 +1,8 @@
 package org.broadinstitute.hail
 
-import breeze.linalg.Matrix
+import breeze.linalg._
+import breeze.stats.distributions.{Beta, Binomial, Multinomial, Uniform, RandBasis}
+import org.apache.commons.math3.random.JDKRandomGenerator
 import org.broadinstitute.hail.utils._
 import org.apache.spark.SparkContext
 import org.broadinstitute.hail.annotations.Annotation
@@ -40,6 +42,59 @@ object TestUtils {
     ).toOrderedRDD
 
     new VariantDataset(VariantMetadata(sampleIds), rdd)
+  }
+
+  // K populations, N samples, M variants, pi is K-vector proportional to population sizes, F is K-vector of F_st values
+  def baldingNichols(K: Int, N: Int, M: Int, seed: Int = 0,
+    piVect: Option[DenseVector[Double]] = None,
+    FVect: Option[DenseVector[Double]] = None): DenseMatrix[Int] = {
+
+    require(piVect.forall(_.length == K))
+    require(piVect.forall(_.forall(_ >= 0d)))
+    require(FVect.forall(_.length == K))
+    require(FVect.forall(_.forall(Fk => Fk > 0d && Fk < 1d)))
+
+    val gen = new JDKRandomGenerator()
+    gen.setSeed(seed)
+
+    implicit val rand: RandBasis = new RandBasis(gen)
+
+    val pi = Multinomial(piVect.getOrElse(DenseVector.fill[Double](K)(1.0)))
+    val k_n = DenseVector.fill[Int](N)(pi.draw())
+
+    val F = FVect.getOrElse(DenseVector.fill[Double](K)(0.1))
+    val F1 = (1d - F) :/ F
+
+    val P0 = Uniform(0.1, 0.9)
+    val p0_m = DenseVector.fill[Double](M)(P0.draw())
+
+    val p_km = DenseMatrix.zeros[Double](K, M)
+
+    var k = 0
+    var m = 0
+    while (k < K) {
+      m = 0
+      while (m < M) {
+        p_km(k,m) = new Beta((1 - p0_m(m)) * F1(k), p0_m(m) * F1(k)).draw()
+        m += 1
+      }
+      k += 1
+    }
+
+    val g_nm = DenseMatrix.zeros[Int](N,M)
+
+    var n = 0
+    while (n < N) {
+      m = 0
+      while (m < M) {
+        val p_nm = p_km(k_n(n), m)
+        g_nm(n, m) = Binomial(2, p_nm).draw()
+        m += 1
+      }
+      n += 1
+    }
+
+    g_nm
   }
 }
 

--- a/src/test/scala/org/broadinstitute/hail/TestUtils.scala
+++ b/src/test/scala/org/broadinstitute/hail/TestUtils.scala
@@ -69,30 +69,14 @@ object TestUtils {
     val p0_m = DenseVector.fill[Double](M)(P0.draw())
 
     val p_km = DenseMatrix.zeros[Double](K, M)
-
-    var k = 0
-    var m = 0
-    while (k < K) {
-      m = 0
-      while (m < M) {
-        p_km(k,m) = new Beta((1 - p0_m(m)) * F1(k), p0_m(m) * F1(k)).draw()
-        m += 1
-      }
-      k += 1
-    }
+    (0 until K).foreach(k =>
+      (0 until M).foreach(m =>
+        p_km(k,m) = new Beta((1 - p0_m(m)) * F1(k), p0_m(m) * F1(k)).draw()))
 
     val g_nm = DenseMatrix.zeros[Int](N,M)
-
-    var n = 0
-    while (n < N) {
-      m = 0
-      while (m < M) {
-        val p_nm = p_km(k_n(n), m)
-        g_nm(n, m) = Binomial(2, p_nm).draw()
-        m += 1
-      }
-      n += 1
-    }
+    (0 until N).foreach(n =>
+      (0 until M).foreach(m =>
+        g_nm(n, m) = Binomial(2, p_km(k_n(n), m)).draw()))
 
     g_nm
   }

--- a/src/test/scala/org/broadinstitute/hail/TestUtilsSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/TestUtilsSuite.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.hail
 
-import breeze.linalg.DenseMatrix
+import breeze.linalg.{DenseMatrix, svd}
 import org.broadinstitute.hail.variant.Variant
 import org.testng.annotations.Test
 
@@ -19,5 +19,12 @@ class TestUtilsSuite extends SparkSuite {
     for (i <- 0 to 2)
       for (j <- 0 to 1)
         assert(G(i, j) == G1(i, j))
+  }
+
+  @Test def baldingNicholsTest() = {
+    val G = TestUtils.baldingNichols(4, 10, 20)
+    val G0 = TestUtils.baldingNichols(4, 10, 20, 0)
+
+    assert(G == G0)
   }
 }


### PR DESCRIPTION
Combined with vdsFromMatrix, this allows Alex to generate a vds and then vcf with a proscribed population structure as needed for methods dev. Later we can move this to main and/or integrate into our generative testing framework.