### PR TITLE
Fix coalesce/repartition

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/driver/ExportGEN.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/ExportGEN.scala
@@ -87,13 +87,7 @@ object ExportGEN extends Command {
 
       val isDosage = vds.isDosage
 
-      val kvRDD = vds.rdd.map { case (v, (a, gs)) =>
-        (v, (a, gs.toGenotypeStream(v, isDosage, compress = false)))
-      }
-      kvRDD.persist(StorageLevel.MEMORY_AND_DISK)
-      kvRDD
-        .repartitionAndSortWithinPartitions(new RangePartitioner[Variant, (Annotation, Iterable[Genotype])](vds.rdd.partitions.length, kvRDD))
-        .mapPartitions { it: Iterator[(Variant, (Annotation, Iterable[Genotype]))] =>
+      vds.rdd.mapPartitions { it: Iterator[(Variant, (Annotation, Iterable[Genotype]))] =>
           val sb = new StringBuilder
           it.map { case (v, (va, gs)) =>
             sb.clear()
@@ -101,7 +95,6 @@ object ExportGEN extends Command {
             sb.result()
           }
         }.writeTable(options.output + ".gen", None)
-      kvRDD.unpersist()
     }
 
     writeSampleFile()

--- a/src/main/scala/org/broadinstitute/hail/sparkextras/OrderedRDD.scala
+++ b/src/main/scala/org/broadinstitute/hail/sparkextras/OrderedRDD.scala
@@ -376,7 +376,7 @@ class OrderedRDD[PK, K, V] private(rdd: RDD[(K, V)], val orderedPartitioner: Ord
     (implicit ord: Ordering[(K, V)] = null): RDD[(K, V)] = {
     require(maxPartitions > 0, "cannot coalesce to nPartitions <= 0")
     val n = rdd.partitions.length
-    if (maxPartitions == n || n == 0 || !shuffle && (n >= maxPartitions))
+    if (maxPartitions == n || n == 0 || !shuffle && (maxPartitions > n))
       return this
     if (shuffle) {
       val shuffled = super.coalesce(maxPartitions, shuffle)
@@ -385,7 +385,7 @@ class OrderedRDD[PK, K, V] private(rdd: RDD[(K, V)], val orderedPartitioner: Ord
     } else {
 
       val partSize = rdd.context.runJob(rdd, getIteratorSize _)
-      info(s"partSize = ${ partSize.toSeq }")
+      log.info(s"partSize = ${ partSize.toSeq }")
 
       val partCumulativeSize = mapAccumulate[Array, Long, Long, Long](partSize, 0)((s, acc) => (s + acc, s + acc))
       val totalSize = partCumulativeSize.last

--- a/src/test/scala/org/broadinstitute/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/variant/vsm/VSMSuite.scala
@@ -324,6 +324,8 @@ class VSMSuite extends SparkSuite {
 
     forAll(g) { case (vsm, k) =>
       val coalesced = vsm.coalesce(k)
+      val n = coalesced.nPartitions
+      val partitionCheck = n == 1 || n < k
       VSMSuite.checkOrderedRDD(coalesced.rdd) && vsm.same(coalesced)
     }.check()
   }

--- a/src/test/scala/org/broadinstitute/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/variant/vsm/VSMSuite.scala
@@ -325,8 +325,8 @@ class VSMSuite extends SparkSuite {
     forAll(g) { case (vsm, k) =>
       val coalesced = vsm.coalesce(k)
       val n = coalesced.nPartitions
-      val partitionCheck = n == 1 || n < k
-      VSMSuite.checkOrderedRDD(coalesced.rdd) && vsm.same(coalesced)
+      val partitionCheck = n == 1 || n <= k
+      VSMSuite.checkOrderedRDD(coalesced.rdd) && vsm.same(coalesced) && partitionCheck
     }.check()
   }
 

--- a/src/test/scala/org/broadinstitute/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/variant/vsm/VSMSuite.scala
@@ -325,8 +325,7 @@ class VSMSuite extends SparkSuite {
     forAll(g) { case (vsm, k) =>
       val coalesced = vsm.coalesce(k)
       val n = coalesced.nPartitions
-      val partitionCheck = n == 1 || n <= k
-      VSMSuite.checkOrderedRDD(coalesced.rdd) && vsm.same(coalesced) && partitionCheck
+      VSMSuite.checkOrderedRDD(coalesced.rdd) && vsm.same(coalesced) && n <= k
     }.check()
   }
 


### PR DESCRIPTION
Fixed bug that cause --no-shuffle mode to do nothing, no matter what.

Fixed bug that caused shuffle mode to shuffle lazily mapped iterators