### PR TITLE
added ToIndexedRowMatrixFromBlockMatrix to sparkextras

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/check/Gen.scala
+++ b/src/main/scala/org/broadinstitute/hail/check/Gen.scala
@@ -7,6 +7,7 @@ import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable
 import scala.math.Numeric.Implicits._
 import scala.language.higherKinds
+import scala.reflect.ClassTag
 
 object Parameters {
   val default = Parameters(new RandomDataGenerator(), 1000, 10)
@@ -153,7 +154,7 @@ object Gen {
       b.result()
     }
 
-  def denseMatrix[T](n: Int, m: Int)(g: Gen[T]): Gen[DenseMatrix[T]] =
+  def denseMatrix[T](n: Int, m: Int)(g: Gen[T])(implicit tct: ClassTag[T]): Gen[DenseMatrix[T]] =
     Gen { (p: Parameters) =>
       DenseMatrix.fill[T](n, m)(g.resize(p.size / (n * m))(p))
     }

--- a/src/main/scala/org/broadinstitute/hail/check/Gen.scala
+++ b/src/main/scala/org/broadinstitute/hail/check/Gen.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.hail.check
 
+import breeze.linalg.DenseMatrix
 import org.apache.commons.math3.random._
 
 import scala.collection.generic.CanBuildFrom
@@ -101,6 +102,10 @@ object Gen {
     p.rng.nextUniform(min, max, true)
   }
 
+  def gaussian(mu: Double, sigma: Double): Gen[Double] = Gen { (p: Parameters) =>
+    p.rng.nextGaussian(mu, sigma)
+  }
+
   def shuffle[T](is: IndexedSeq[T]): Gen[IndexedSeq[T]] = {
     Gen { (p: Parameters) =>
       if (is.isEmpty)
@@ -147,6 +152,12 @@ object Gen {
       gs.foreach { g => b += g(p) }
       b.result()
     }
+
+  def denseMatrix[T](n: Int, m: Int)(g: Gen[T]): Gen[DenseMatrix[T]] =
+    Gen { (p: Parameters) =>
+      DenseMatrix.fill[T](n, m)(g.resize(p.size / (n * m))(p))
+    }
+
 
   /**
     * In general, for any Traversable type T and any Monad M, we may convert an {@code F[M[T]]} to an {@code M[F[T]]} by

--- a/src/main/scala/org/broadinstitute/hail/check/Gen.scala
+++ b/src/main/scala/org/broadinstitute/hail/check/Gen.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.hail.check
 
 import breeze.linalg.DenseMatrix
+import breeze.storage.Zero
 import org.apache.commons.math3.random._
 
 import scala.collection.generic.CanBuildFrom
@@ -154,7 +155,7 @@ object Gen {
       b.result()
     }
 
-  def denseMatrix[T](n: Int, m: Int)(g: Gen[T])(implicit tct: ClassTag[T]): Gen[DenseMatrix[T]] =
+  def denseMatrix[T](n: Int, m: Int)(g: Gen[T])(implicit tct: ClassTag[T], tzero: Zero[T]): Gen[DenseMatrix[T]] =
     Gen { (p: Parameters) =>
       DenseMatrix.fill[T](n, m)(g.resize(p.size / (n * m))(p))
     }

--- a/src/main/scala/org/broadinstitute/hail/sparkextras/ToIndexedRowMatrixFromBlockMatrix.scala
+++ b/src/main/scala/org/broadinstitute/hail/sparkextras/ToIndexedRowMatrixFromBlockMatrix.scala
@@ -1,0 +1,59 @@
+package org.broadinstitute.hail.sparkextras
+
+import org.apache.spark.mllib.linalg.{DenseMatrix, DenseVector, SparseMatrix}
+import org.apache.spark.mllib.linalg.distributed.{BlockMatrix, IndexedRow, IndexedRowMatrix}
+import org.broadinstitute.hail.utils
+
+// Copied with modification from Spark 2.0 so as to avoid going through CoordinateMatrix as in Spark 1.6
+object ToIndexedRowMatrixFromBlockMatrix {
+  def apply(bm: BlockMatrix): IndexedRowMatrix = {
+    val cols = bm.numCols().toInt
+    val blocks = bm.blocks
+    val rowsPerBlock = bm.rowsPerBlock
+    val colsPerBlock = bm.colsPerBlock
+
+    require(cols < Int.MaxValue, s"The number of columns should be less than Int.MaxValue ($cols).")
+
+    val rows = blocks.flatMap { case ((blockRowIdx, blockColIdx), mat) =>
+      val dmat = mat match {
+        case mat: DenseMatrix => mat
+        case mat: SparseMatrix => mat.toDense
+      }
+      rowIter(mat.asInstanceOf[DenseMatrix]).zipWithIndex.map {
+        case (vector, rowIdx) =>
+          blockRowIdx * rowsPerBlock + rowIdx -> (blockColIdx, utils.toBDenseVector(vector))
+      }
+    }.groupByKey().map { case (rowIdx, vectors) =>
+      val wholeVector = breeze.linalg.DenseVector.zeros[Double](cols)
+
+      vectors.foreach { case (blockColIdx: Int, vec: breeze.linalg.DenseVector[Double]) =>
+        val offset = colsPerBlock * blockColIdx
+        wholeVector(offset until Math.min(cols, offset + colsPerBlock)) := vec
+      }
+      IndexedRow(rowIdx, utils.toSDenseVector(wholeVector))
+    }
+    new IndexedRowMatrix(rows)
+  }
+
+  def rowIter(mat: DenseMatrix): Iterator[DenseVector] = colIter(mat.transpose)
+
+  def colIter(mat: DenseMatrix): Iterator[DenseVector] = {
+    if (mat.isTransposed) {
+      Iterator.tabulate(mat.numCols) { j =>
+        val col = new Array[Double](mat.numRows)
+        var i = 0
+        var k = j
+        while (i < mat.numRows) {
+          col(i) = mat.values(k)
+          i += 1
+          k += mat.numCols
+        }
+        new DenseVector(col)
+      }
+    } else {
+      Iterator.tabulate(mat.numCols) { j =>
+        new DenseVector(mat.values.slice(j * mat.numRows, (j + 1) * mat.numRows))
+      }
+    }
+  }
+}

--- a/src/main/scala/org/broadinstitute/hail/sparkextras/ToIndexedRowMatrixFromBlockMatrix.scala
+++ b/src/main/scala/org/broadinstitute/hail/sparkextras/ToIndexedRowMatrixFromBlockMatrix.scala
@@ -4,7 +4,8 @@ import org.apache.spark.mllib.linalg.{DenseMatrix, DenseVector, SparseMatrix}
 import org.apache.spark.mllib.linalg.distributed.{BlockMatrix, IndexedRow, IndexedRowMatrix}
 import org.broadinstitute.hail.utils
 
-// Copied with modification from Spark 2.0 so as to avoid going through CoordinateMatrix as in Spark 1.6
+// Back-ported with modification from Spark 2.0 so as to avoid going through CoordinateMatrix as in Spark 1.5 and 1.6
+// Specialized for dense blocks with GRM in mind
 object ToIndexedRowMatrixFromBlockMatrix {
   def apply(bm: BlockMatrix): IndexedRowMatrix = {
     val cols = bm.numCols().toInt

--- a/src/main/scala/org/broadinstitute/hail/sparkextras/ToIndexedRowMatrixFromBlockMatrix.scala
+++ b/src/main/scala/org/broadinstitute/hail/sparkextras/ToIndexedRowMatrixFromBlockMatrix.scala
@@ -9,13 +9,12 @@ import org.broadinstitute.hail.utils
 object ToIndexedRowMatrixFromBlockMatrix {
   def apply(bm: BlockMatrix): IndexedRowMatrix = {
     val cols = bm.numCols().toInt
-    val blocks = bm.blocks
     val rowsPerBlock = bm.rowsPerBlock
     val colsPerBlock = bm.colsPerBlock
 
     require(cols < Int.MaxValue, s"The number of columns should be less than Int.MaxValue ($cols).")
 
-    val rows = blocks.flatMap { case ((blockRowIdx, blockColIdx), mat) =>
+    val rows = bm.blocks.flatMap { case ((blockRowIdx, blockColIdx), mat) =>
       val dmat = mat match {
         case mat: DenseMatrix => mat
         case mat: SparseMatrix => mat.toDense

--- a/src/test/scala/org/broadinstitute/hail/utils/UtilsSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/utils/UtilsSuite.scala
@@ -152,35 +152,37 @@ class UtilsSuite extends SparkSuite {
   }
 
   @Test def toIndexedRowMatrixFromDenseBlockMatrixTest() = {
+
     val n = 5
     val m = 10
 
-    scala.util.Random.setSeed(0)
-    val bmat = BDenseMatrix.fill[Double](n, m)(scala.util.Random.nextGaussian())
+    Prop.forAll(Gen.denseMatrix(n, m)(Gen.gaussian(0.0, 1.0))) { bmat =>
+      val smat = new DenseMatrix(n, m, bmat.data)
 
-    val smat = new DenseMatrix(n, m, bmat.data)
-
-    val blockmat = new IndexedRowMatrix(sc.parallelize(((0 until n).map(_.toLong),
+      val blockmat = new IndexedRowMatrix(sc.parallelize(((0 until n).map(_.toLong),
         ToIndexedRowMatrixFromBlockMatrix.rowIter(smat).toIterable)
         .zipped.map(IndexedRow)), n, m).toBlockMatrix()
 
-    val gram1 = blockmat.multiply(blockmat.transpose)
+      val gram1 = blockmat.multiply(blockmat.transpose)
 
-    val gram1a = smat.multiply(smat.transpose)
-    val gram1b = gram1.toIndexedRowMatrix().toBlockMatrix().toLocalMatrix()
-    val gram1c = ToIndexedRowMatrixFromBlockMatrix(gram1).toBlockMatrix().toLocalMatrix()
+      val gram1a = smat.multiply(smat.transpose)
+      val gram1b = gram1.toIndexedRowMatrix().toBlockMatrix().toLocalMatrix()
+      val gram1c = ToIndexedRowMatrixFromBlockMatrix(gram1).toBlockMatrix().toLocalMatrix()
 
-    TestUtils.assertMatrixEqualityDouble(new BDenseMatrix(n, n, gram1a.toArray), new BDenseMatrix(n, n, gram1b.toArray))
-    TestUtils.assertMatrixEqualityDouble(new BDenseMatrix(n, n, gram1b.toArray), new BDenseMatrix(n, n, gram1c.toArray))
+      TestUtils.assertMatrixEqualityDouble(new BDenseMatrix(n, n, gram1a.toArray), new BDenseMatrix(n, n, gram1b.toArray))
+      TestUtils.assertMatrixEqualityDouble(new BDenseMatrix(n, n, gram1b.toArray), new BDenseMatrix(n, n, gram1c.toArray))
 
 
-    val gram2 = blockmat.transpose.multiply(blockmat)
+      val gram2 = blockmat.transpose.multiply(blockmat)
 
-    val gram2a = smat.transpose.multiply(smat)
-    val gram2b = gram2.toIndexedRowMatrix().toBlockMatrix().toLocalMatrix()
-    val gram2c = ToIndexedRowMatrixFromBlockMatrix(gram2).toBlockMatrix().toLocalMatrix()
+      val gram2a = smat.transpose.multiply(smat)
+      val gram2b = gram2.toIndexedRowMatrix().toBlockMatrix().toLocalMatrix()
+      val gram2c = ToIndexedRowMatrixFromBlockMatrix(gram2).toBlockMatrix().toLocalMatrix()
 
-    TestUtils.assertMatrixEqualityDouble(new BDenseMatrix(n, n, gram2a.toArray), new BDenseMatrix(n, n, gram2b.toArray))
-    TestUtils.assertMatrixEqualityDouble(new BDenseMatrix(n, n, gram2b.toArray), new BDenseMatrix(n, n, gram2c.toArray))
+      TestUtils.assertMatrixEqualityDouble(new BDenseMatrix(n, n, gram2a.toArray), new BDenseMatrix(n, n, gram2b.toArray))
+      TestUtils.assertMatrixEqualityDouble(new BDenseMatrix(n, n, gram2b.toArray), new BDenseMatrix(n, n, gram2c.toArray))
+
+      true
+    }
   }
 }

--- a/src/test/scala/org/broadinstitute/hail/utils/UtilsSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/utils/UtilsSuite.scala
@@ -1,11 +1,13 @@
 package org.broadinstitute.hail.utils
 
-import org.apache.hadoop.fs.FileStatus
+import breeze.linalg.{DenseMatrix => BDenseMatrix}
+import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix}
+import org.apache.spark.mllib.linalg.{DenseMatrix, DenseVector, SparseMatrix}
 import org.broadinstitute.hail.check.Arbitrary._
 import org.broadinstitute.hail.check.{Gen, Prop}
-import org.broadinstitute.hail.sparkextras.OrderedRDD
+import org.broadinstitute.hail.sparkextras.{OrderedRDD, ToIndexedRowMatrixFromBlockMatrix}
 import org.broadinstitute.hail.variant._
-import org.broadinstitute.hail.SparkSuite
+import org.broadinstitute.hail.{SparkSuite, TestUtils}
 import org.broadinstitute.hail.utils.richUtils.RichHadoopConfiguration
 import org.testng.annotations.Test
 
@@ -147,5 +149,38 @@ class UtilsSuite extends SparkSuite {
     val partFileNames = rhc.glob("src/test/resources/part-*").sortBy(fs => getPartNumber(fs.getPath.getName)).map(_.getPath.getName)
 
     assert(partFileNames(0) == "part-40001" && partFileNames(1) == "part-100001")
+  }
+
+  @Test def toIndexedRowMatrixFromDenseBlockMatrixTest() = {
+    val n = 5
+    val m = 10
+
+    scala.util.Random.setSeed(0)
+    val bmat = BDenseMatrix.fill[Double](n, m)(scala.util.Random.nextGaussian())
+
+    val smat = new DenseMatrix(n, m, bmat.data)
+
+    val blockmat = new IndexedRowMatrix(sc.parallelize(((0 until n).map(_.toLong),
+        ToIndexedRowMatrixFromBlockMatrix.rowIter(smat).toIterable)
+        .zipped.map(IndexedRow)), n, m).toBlockMatrix()
+
+    val gram1 = blockmat.multiply(blockmat.transpose)
+
+    val gram1a = smat.multiply(smat.transpose)
+    val gram1b = gram1.toIndexedRowMatrix().toBlockMatrix().toLocalMatrix()
+    val gram1c = ToIndexedRowMatrixFromBlockMatrix(gram1).toBlockMatrix().toLocalMatrix()
+
+    TestUtils.assertMatrixEqualityDouble(new BDenseMatrix(n, n, gram1a.toArray), new BDenseMatrix(n, n, gram1b.toArray))
+    TestUtils.assertMatrixEqualityDouble(new BDenseMatrix(n, n, gram1b.toArray), new BDenseMatrix(n, n, gram1c.toArray))
+
+
+    val gram2 = blockmat.transpose.multiply(blockmat)
+
+    val gram2a = smat.transpose.multiply(smat)
+    val gram2b = gram2.toIndexedRowMatrix().toBlockMatrix().toLocalMatrix()
+    val gram2c = ToIndexedRowMatrixFromBlockMatrix(gram2).toBlockMatrix().toLocalMatrix()
+
+    TestUtils.assertMatrixEqualityDouble(new BDenseMatrix(n, n, gram2a.toArray), new BDenseMatrix(n, n, gram2b.toArray))
+    TestUtils.assertMatrixEqualityDouble(new BDenseMatrix(n, n, gram2b.toArray), new BDenseMatrix(n, n, gram2c.toArray))
   }
 }


### PR DESCRIPTION
- based on Spark 2.0
- converts directly without passing through CoordinateMatrix
- added test to UtilsSuite
