### PR TITLE
Don't relocate math3.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,10 +72,7 @@ dependencies {
     compile 'org.apache.spark:spark-sql_' + scalaMajorVersion + ':' + sparkVersion
     compile 'org.apache.spark:spark-mllib_' + scalaMajorVersion + ':' + sparkVersion
     compile 'net.jpountz.lz4:lz4:1.3.0'
-    compile 'org.apache.commons:commons-math3:3.5'
-    compile 'org.apache.commons:commons-lang3:3.4'
     compile 'org.scalanlp:breeze_' + scalaMajorVersion + ':0.11.2'
-    // compile 'org.scalanlp:breeze_' + scalaMajorVersion + ':0.12'
     compile 'org.scalanlp:breeze-natives_' + scalaMajorVersion + ':0.11.2'
     compile 'args4j:args4j:2.32'
     compile 'com.github.samtools:htsjdk:2.5.0'
@@ -155,7 +152,6 @@ tasks.withType(ShadowJar) {
     mergeServiceFiles()
     zip64 true
     // conflict with version in default Hadoop/Spark install
-    relocate 'org.apache.commons.math3', 'org.broadinstitute.hail.relocated.org.apache.commons.math3'
     relocate 'org.apache.http', 'org.broadinstitute.hail.relocated.org.apache.http'
     relocate 'com.google.common', 'org.broadinstitute.hail.relocated.com.google.common'
     relocate 'org.objectweb', 'org.broadinstitute.hail.relocated.org.objectweb'
@@ -167,7 +163,6 @@ shadowJar {
     configurations = [project.configurations.runtime]
     dependencies {
         include(dependency('net.jpountz.lz4:lz4:.*'))
-        include(dependency('org.apache.commons:commons-math3:.*'))
         include(dependency('org.scalanlp:breeze-natives_' + scalaMajorVersion + ':.*'))
         include(dependency('args4j:args4j:.*'))
         include(dependency('com.github.samtools:htsjdk:.*'))
@@ -207,7 +202,6 @@ task shadowTestJar(type: ShadowJar) {
     configurations = [project.configurations.testRuntime]
     dependencies {
         include(dependency('net.jpountz.lz4:lz4:.*'))
-        include(dependency('org.apache.commons:commons-math3:.*'))
         include(dependency('org.scalanlp:breeze-natives_' + scalaMajorVersion + ':.*'))
         include(dependency('args4j:args4j:.*'))
         include(dependency('com.github.samtools:htsjdk:.*'))


### PR DESCRIPTION
Rely on versions of math3 and lang3 pulled in by other dependencies,
e.g., Spark.