### PR TITLE
Set Locus serial version UID.

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/variant/Locus.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/Locus.scala
@@ -37,6 +37,7 @@ object Locus {
   def gen: Gen[Locus] = gen(simpleContigs)
 }
 
+@SerialVersionUID(9197069433877243281L)
 case class Locus(contig: String, position: Int) extends Ordered[Locus] {
   def compare(that: Locus): Int = {
     var c = Contig.compare(contig, that.contig)


### PR DESCRIPTION
This allows Spark 2 Hail to load partitioning information from VDSes
written by the Spark 1 version, but loading partitioning from previous
Spark 2 versions will now fail.  Since there are far more VDSes in
uses written with Spark 1 in use, this seems like a good trade-off.

There are now to serial version UIDs in the wild for Locus.  I don't
see how to write code to load both of them (except maybe
loading/unloading different versions of the Locus class which seems
painful.)  I would prefer a tool that converts the partitioning to
JSON instead (once support for JSON is ready).

The partitioning information should be stored as JSON instead of Java
serialization, which is not a good long-term storage format.