### PR TITLE
End the serialiation madness.

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/driver/package.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/package.scala
@@ -50,7 +50,7 @@ package object driver {
   def configureAndCreateSparkContext(appName: String, master: Option[String], local: String = "local[*]",
     logFile: String = "hail.log", quiet: Boolean = false, append: Boolean = false, parquetCompression: String = "uncompressed",
     blockSize: Long = 1L, branchingFactor: Int = 50, tmpDir: String = "/tmp"): SparkContext = {
-    require(blockSize > 0)
+    require(blockSize >= 0)
     require(branchingFactor > 0)
 
     HailConfiguration.tmpDir = tmpDir

--- a/src/main/scala/org/broadinstitute/hail/sparkextras/OrderedPartitioner.scala
+++ b/src/main/scala/org/broadinstitute/hail/sparkextras/OrderedPartitioner.scala
@@ -60,16 +60,19 @@ case class OrderedPartitioner[PK, K](rangeBounds: Array[PK], numPartitions: Int)
   }
 
   override def equals(other: Any): Boolean = other match {
-    case r: OrderedPartitioner[_, _] => r.rangeBounds.sameElements(rangeBounds) && r.numPartitions == numPartitions
+    case r: OrderedPartitioner[_, _] =>
+      r.rangeBounds.sameElements(rangeBounds) &&
+        r.numPartitions == numPartitions &&
+        r.kOk == kOk
     case _ => false
   }
 
-  override def hashCode: Int = {
-    val b = new HashCodeBuilder(43, 19)
-    rangeBounds.foreach(b.append(_))
-    b.append(numPartitions)
+  override def hashCode: Int =
+    new HashCodeBuilder(43, 19)
+      .append(rangeBounds)
+      .append(numPartitions)
+      .append(kOk)
       .toHashCode
-  }
 
   def mapMonotonic[K2](implicit k2Ok: OrderedKey[PK, K2]): OrderedPartitioner[PK, K2] = {
     new OrderedPartitioner(rangeBounds, numPartitions)

--- a/src/main/scala/org/broadinstitute/hail/utils/JSON.scala
+++ b/src/main/scala/org/broadinstitute/hail/utils/JSON.scala
@@ -11,11 +11,3 @@ trait JSONReader[T] {
 }
 
 trait JSONReaderWriter[T] extends JSONReader[T] with JSONWriter[T]
-
-class RichJSONWritable[T](x: T, jw: JSONWriter[T]) {
-  def toJSON: JValue = jw.toJSON(x)
-}
-
-class RichJValue(jv: JValue) {
-  def fromJSON[T](implicit jr: JSONReader[T]): T = jr.fromJSON(jv)
-}

--- a/src/main/scala/org/broadinstitute/hail/utils/JSON.scala
+++ b/src/main/scala/org/broadinstitute/hail/utils/JSON.scala
@@ -1,0 +1,21 @@
+package org.broadinstitute.hail.utils
+
+import org.json4s.JValue
+
+trait JSONWriter[T] {
+  def toJSON(x: T): JValue
+}
+
+trait JSONReader[T] {
+  def fromJSON(jv: JValue): T
+}
+
+trait JSONReaderWriter[T] extends JSONReader[T] with JSONWriter[T]
+
+class RichJSONWritable[T](x: T, jw: JSONWriter[T]) {
+  def toJSON: JValue = jw.toJSON(x)
+}
+
+class RichJValue(jv: JValue) {
+  def fromJSON[T](implicit jr: JSONReader[T]): T = jr.fromJSON(jv)
+}

--- a/src/main/scala/org/broadinstitute/hail/utils/package.scala
+++ b/src/main/scala/org/broadinstitute/hail/utils/package.scala
@@ -433,9 +433,6 @@ package object utils extends Logging
     }
   }
 
-  implicit def toRichJSONWritable[T](x: T)(implicit jw: JSONWriter[T]): RichJSONWritable[T] = new RichJSONWritable(x, jw)
-  implicit def toRichJValue(jv: JValue): RichJValue = new RichJValue(jv)
-
   implicit val jsonFormatsNoTypeHints: Formats = Serialization.formats(NoTypeHints)
 
   def caseClassJSONReaderWriter[T](implicit mf: scala.reflect.Manifest[T]): JSONReaderWriter[T] = new JSONReaderWriter[T] {

--- a/src/main/scala/org/broadinstitute/hail/utils/richUtils/Implicits.scala
+++ b/src/main/scala/org/broadinstitute/hail/utils/richUtils/Implicits.scala
@@ -7,7 +7,8 @@ import org.apache.spark.mllib.linalg.distributed.IndexedRow
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Row, SQLContext}
 import org.apache.spark.storage.StorageLevel
-import org.broadinstitute.hail.utils.{MultiArray2, Truncatable}
+import org.broadinstitute.hail.utils.{JSONWriter, MultiArray2, Truncatable}
+import org.json4s.JValue
 
 import scala.collection.{TraversableOnce, mutable}
 import scala.language.implicitConversions
@@ -88,4 +89,8 @@ trait Implicits {
   implicit def toTruncatable[T](it: Iterable[T]): Truncatable = it.truncatable()
 
   implicit def toTruncatable(arr: Array[_]): Truncatable = toTruncatable(arr: Iterable[_])
+
+  implicit def toJSONWritable[T](x: T)(implicit jw: JSONWriter[T]): JSONWritable[T] = new JSONWritable(x, jw)
+
+  implicit def toRichJValue(jv: JValue): RichJValue = new RichJValue(jv)
 }

--- a/src/main/scala/org/broadinstitute/hail/utils/richUtils/JSONWritable.scala
+++ b/src/main/scala/org/broadinstitute/hail/utils/richUtils/JSONWritable.scala
@@ -1,0 +1,8 @@
+package org.broadinstitute.hail.utils.richUtils
+
+import org.broadinstitute.hail.utils.JSONWriter
+import org.json4s.JValue
+
+class JSONWritable[T](x: T, jw: JSONWriter[T]) {
+  def toJSON: JValue = jw.toJSON(x)
+}

--- a/src/main/scala/org/broadinstitute/hail/utils/richUtils/RichJValue.scala
+++ b/src/main/scala/org/broadinstitute/hail/utils/richUtils/RichJValue.scala
@@ -1,0 +1,8 @@
+package org.broadinstitute.hail.utils.richUtils
+
+import org.broadinstitute.hail.utils.JSONReader
+import org.json4s.JValue
+
+class RichJValue(jv: JValue) {
+  def fromJSON[T](implicit jr: JSONReader[T]): T = jr.fromJSON(jv)
+}

--- a/src/main/scala/org/broadinstitute/hail/variant/Locus.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/Locus.scala
@@ -3,7 +3,10 @@ package org.broadinstitute.hail.variant
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.broadinstitute.hail.check.Gen
 import org.broadinstitute.hail.sparkextras.OrderedKey
+import org.broadinstitute.hail.utils._
 import org.json4s._
+import org.json4s.Extraction.decompose
+import org.json4s.jackson.Serialization
 
 import scala.reflect.ClassTag
 
@@ -35,6 +38,8 @@ object Locus {
       .map { case (contig, pos) => Locus(contig, pos) }
 
   def gen: Gen[Locus] = gen(simpleContigs)
+
+  implicit val locusJSONRWer: JSONReaderWriter[Locus] = caseClassJSONReaderWriter[Locus]
 }
 
 case class Locus(contig: String, position: Int) extends Ordered[Locus] {

--- a/src/main/scala/org/broadinstitute/hail/variant/Locus.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/Locus.scala
@@ -12,7 +12,7 @@ import scala.reflect.ClassTag
 
 object LocusImplicits {
   /* We cannot add this to the Locus companion object because it breaks serialization. */
-  implicit def orderedKey = new OrderedKey[Locus, Locus] {
+  implicit val orderedKey = new OrderedKey[Locus, Locus] {
     def project(key: Locus): Locus = key
 
     def kOrd: Ordering[Locus] = implicitly[Ordering[Locus]]

--- a/src/main/scala/org/broadinstitute/hail/variant/Variant.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/Variant.scala
@@ -168,7 +168,7 @@ object Variant {
         .map(s => AltAllele.fromRow(s))
         .toArray)
 
-  implicit def orderedKey: OrderedKey[Locus, Variant] =
+  implicit val orderedKey: OrderedKey[Locus, Variant] =
     new OrderedKey[Locus, Variant] {
       def project(key: Variant): Locus = key.locus
 

--- a/src/test/scala/org/broadinstitute/hail/utils/OrderedRDDSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/utils/OrderedRDDSuite.scala
@@ -9,6 +9,7 @@ import org.broadinstitute.hail.check.Arbitrary._
 import org.broadinstitute.hail.check.{Gen, Prop, Properties}
 import org.broadinstitute.hail.sparkextras.{OrderedPartitioner, _}
 import org.broadinstitute.hail.variant._
+import org.json4s.jackson.JsonMethods
 import org.testng.annotations.Test
 
 import scala.math.Ordering.Implicits._
@@ -159,8 +160,7 @@ class OrderedRDDSuite extends SparkSuite {
       checkJoin(1, is1, nPar2, is2)
     }
 
-
-    val tmpPartitioner = tmpDir.createTempFile("partitioner")
+    val tmpPartitioner = tmpDir.createTempFile("partitioner.json.gz")
     val tmpRdd = tmpDir.createTempFile("rdd", ".parquet")
 
     property("writeRead") = Prop.forAll(g) { case (nPar, is) =>
@@ -172,8 +172,8 @@ class OrderedRDDSuite extends SparkSuite {
       val df = sqlContext.createDataFrame(rdd.map { case (v, s) => Row.fromSeq(Seq(v.toRow, s)) }, schema)
         .write.parquet(tmpRdd)
 
-      hadoopConf.writeObjectFile(tmpPartitioner) { out =>
-        rdd.partitioner.get.asInstanceOf[OrderedPartitioner[Variant, String]].write(out)
+      hadoopConf.writeTextFile(tmpPartitioner) { out =>
+        out.write(JsonMethods.compact(rdd.partitioner.get.asInstanceOf[OrderedPartitioner[Locus, Variant]].toJSON))
       }
 
       val status = hadoopConf.fileStatus(tmpPartitioner)
@@ -181,8 +181,8 @@ class OrderedRDDSuite extends SparkSuite {
       val rddReadBack = sqlContext.readParquetSorted(tmpRdd)
         .map(r => (Variant.fromRow(r.getAs[Row](0)), r.getAs[String](1)))
 
-      val readBackPartitioner = hadoopConf.readObjectFile(tmpPartitioner) { in =>
-        OrderedPartitioner.read[Locus, Variant](in, rddReadBack.partitions.length)
+      val readBackPartitioner = hadoopConf.readFile(tmpPartitioner) { in =>
+        JsonMethods.parse(in).fromJSON[OrderedPartitioner[Locus, Variant]]
       }
 
       val orderedRddRB = OrderedRDD[Locus, Variant, String](rddReadBack, readBackPartitioner)


### PR DESCRIPTION
Allow -b 0.
Added typeclasses for converting to/from JSON.
Implemented for OrderedPartitioner and Locus.
Use in VSM.{read, write}.
Remove OrderedPartitioner.ascending.  It wasn't properly implemented.

Still try to load serialized .vds/partitioner if partitioner.json.gz
isn't there.