### PR TITLE
KeyTable improvements.

### DIFF
--- a/python/pyhail/dataset.py
+++ b/python/pyhail/dataset.py
@@ -1105,7 +1105,11 @@ class VariantDataset(object):
         :param genotype_condition: Genotype annotation expressions.
           Per sample field names in the result are formed by
           concatening the sample ID with the genotype_condition left
-          hand side with (.).
+          hand side with dot (.).  If the left hand side is empty::
+
+            `` = expr
+
+          then the dot (.) is ommited.
 
         :type genotype_condition: str or list of str
 

--- a/python/pyhail/dataset.py
+++ b/python/pyhail/dataset.py
@@ -1100,18 +1100,46 @@ class VariantDataset(object):
     def make_keytable(self, variant_condition, genotype_condition, key_names):
         """Make a KeyTable with one row per variant.
 
+        Per sample field names in the result are formed by concatening
+        the sample ID with the genotype_condition left hand side with
+        dot (.).  If the left hand side is empty::
+
+          `` = expr
+
+        then the dot (.) is ommited.
+
+        **Example**
+
+        Consider a ``VariantDataset`` ``vds`` with 2 variants and 3 samples::
+
+          Variant	FORMAT	A	B	C
+          1:1:A:T	GT:GQ	0/1:99	./.	0/0:99
+          1:2:G:C	GT:GQ	0/1:89	0/1:99	1/1:93
+
+        Then:
+
+          vds.make_keytable('v = v', 'gt = g.gt', gq = g.gq', [])
+
+        returns a ``KeyTable`` with schema::
+
+          v: Variant
+          A.gt: Int
+          B.gt: Int
+          C.gt: Int
+          A.gq: Int
+          B.gq: Int
+          C.gq: Int
+
+        in particular, the values would be:
+
+          v	A.gt	B.gt	C.gt	A.gq	B.gq	C.gq
+          1:1:A:T	1	NA	0	99	NA	99
+          1:2:G:C	1	1	2	89	99	93
+
         :param variant_condition: Variant annotation expressions.
         :type variant_condition: str or list of str
 
         :param genotype_condition: Genotype annotation expressions.
-          Per sample field names in the result are formed by
-          concatening the sample ID with the genotype_condition left
-          hand side with dot (.).  If the left hand side is empty::
-
-            `` = expr
-
-          then the dot (.) is ommited.
-
         :type genotype_condition: str or list of str
 
         :param key_names: list of key columns

--- a/python/pyhail/dataset.py
+++ b/python/pyhail/dataset.py
@@ -1,7 +1,6 @@
 from pyhail.java import scala_package_object
 from pyhail.keytable import KeyTable
 
-import pyspark
 from py4j.protocol import Py4JJavaError
 
 class VariantDataset(object):
@@ -1082,19 +1081,17 @@ class VariantDataset(object):
             pargs.append('--csq')
         return self.hc.run_command(self, pargs)
 
-    def variants_to_pandas(self):
-        """Convert variants and variant annotations to Pandas dataframe."""
+    def variants_keytable(self):
+        """Convert variants and variant annotations to a KeyTable."""
 
         try:
-            return pyspark.sql.DataFrame(self.jvds.variantsDF(self.hc.jsql_context),
-                                         self.hc.sql_context).toPandas()
+            return KeyTable(self.hc, self.jvds.variantsKT())
         except Py4JJavaError as e:
             self._raise_py4j_exception(e)
 
-    def samples_to_pandas(self):
-        """Convert samples and sample annotations to Pandas dataframe."""
+    def samples_keytable(self):
+        """Convert samples and sample annotations to KeyTable."""
         try:
-            return pyspark.sql.DataFrame(self.jvds.samplesDF(self.hc.jsql_context),
-                                         self.hc.sql_context).toPandas()
+            return KeyTable(self.hc, self.jvds.samplesKT())
         except Py4JJavaError as e:
             self._raise_py4j_exception(e)

--- a/python/pyhail/dataset.py
+++ b/python/pyhail/dataset.py
@@ -1126,7 +1126,7 @@ class VariantDataset(object):
           1:1:A:T	GT:GQ	0/1:99	./.	0/0:99
           1:2:G:C	GT:GQ	0/1:89	0/1:99	1/1:93
 
-        Then:
+        Then::
 
           vds.make_keytable('v = v', 'gt = g.gt', gq = g.gq', [])
 

--- a/python/pyhail/dataset.py
+++ b/python/pyhail/dataset.py
@@ -1128,7 +1128,8 @@ class VariantDataset(object):
 
         Then::
 
-          vds.make_keytable('v = v', 'gt = g.gt', gq = g.gq', [])
+          >>> vds = hc.import_vcf('data/sample.vcf')
+          >>> vds.make_keytable('v = v', 'gt = g.gt', gq = g.gq', [])
 
         returns a ``KeyTable`` with schema::
 

--- a/python/pyhail/dataset.py
+++ b/python/pyhail/dataset.py
@@ -1091,6 +1091,7 @@ class VariantDataset(object):
 
     def samples_keytable(self):
         """Convert samples and sample annotations to KeyTable."""
+
         try:
             return KeyTable(self.hc, self.jvds.samplesKT())
         except Py4JJavaError as e:

--- a/python/pyhail/dataset.py
+++ b/python/pyhail/dataset.py
@@ -11,6 +11,16 @@ class VariantDataset(object):
     def _raise_py4j_exception(self, e):
         self.hc._raise_py4j_exception(e)
 
+    def sample_ids(self):
+        """Return sampleIDs.
+
+        :return: List of sample IDs.
+
+        :rtype: list of str
+        """
+
+        return list(self.jvds.sampleIdsAsArray())
+
     def aggregate_by_key(self, key_code, agg_code):
         """Aggregate by user-defined key and aggregation expressions.
         Equivalent of a group-by operation in SQL.

--- a/python/pyhail/dataset.py
+++ b/python/pyhail/dataset.py
@@ -1140,7 +1140,7 @@ class VariantDataset(object):
           B.gq: Int
           C.gq: Int
 
-        in particular, the values would be:
+        in particular, the values would be::
 
           v	A.gt	B.gt	C.gt	A.gq	B.gq	C.gq
           1:1:A:T	1	NA	0	99	NA	99

--- a/python/pyhail/keytable.py
+++ b/python/pyhail/keytable.py
@@ -265,7 +265,7 @@ class KeyTable(object):
         :param key_names: List of fields to be used as keys.
         :type key_names: list of str
 
-        :return: A ``KeyTable`` whose key fields are givne by
+        :return: A ``KeyTable`` whose key fields are given by
           ``key_names``.
 
         :rtype: KeyTable
@@ -360,7 +360,7 @@ class KeyTable(object):
         except Py4JJavaError as e:
             self._raise_py4j_exception(e)
 
-    def toDF(self, expand=True, flatten=True):
+    def to_dataframe(self, expand=True, flatten=True):
         """Converts this KeyTable to a Spark DataFrame.
 
         :param bool expand: If true, expand_types before converting to

--- a/python/pyhail/keytable.py
+++ b/python/pyhail/keytable.py
@@ -118,22 +118,15 @@ class KeyTable(object):
         except Py4JJavaError as e:
             self._raise_py4j_exception(e)
 
-    def annotate(self, code, key_names=''):
+    def annotate(self, code):
         """Add fields to key-table.
 
         :param str code: Annotation expression.
 
-        :param key_names: field names to be treated as a key
-        :type key_names: str or list of str
-
         :rtype: :class:`.KeyTable`
         """
         try:
-            if isinstance(key_names, list):
-                key_names = ",".join(key_names)
-
-            return KeyTable(self.hc, self.jkt.annotate(code, key_names))
-
+            return KeyTable(self.hc, self.jkt.annotate(code))
         except Py4JJavaError as e:
             self._raise_py4j_exception(e)
 

--- a/python/pyhail/tests.py
+++ b/python/pyhail/tests.py
@@ -219,7 +219,8 @@ class ContextTests(unittest.TestCase):
 
         sample2_split.variant_qc().print_schema()
         
-        sample2.variants_to_pandas()
+        sample2.variants_keytable()
+        sample2.samples_keytable()
 
         sample_split.annotate_variants_expr("va.nHet = gs.filter(g => g.isHet).count()")
 
@@ -263,6 +264,7 @@ class ContextTests(unittest.TestCase):
         self.assertFalse(kt.forall('Status == "CASE"'))
         self.assertTrue(kt.exists('Status == "CASE"'))
 
+
         kt.rename({"Sample": "ID"})
         kt.rename(["Field1", "Field2", "Field3"])
         kt.rename([name + "_a" for name in kt.field_names()])
@@ -272,3 +274,8 @@ class ContextTests(unittest.TestCase):
 
         kt.key_by(['Sample', 'Status'])
         kt.key_by([])
+
+        kt.flatten()
+        kt.expand_types()
+
+        kt.toDF()

--- a/python/pyhail/tests.py
+++ b/python/pyhail/tests.py
@@ -226,7 +226,7 @@ class ContextTests(unittest.TestCase):
         
         sample_split.aggregate_by_key("Variant = v", "nHet = g.map(g => g.isHet.toInt).sum().toLong")
         
-        vds.make_keytable('v = v, info = va.info', 'gt = g.gt', ['v'])
+        sample2.make_keytable('v = v, info = va.info', 'gt = g.gt', ['v'])
 
     def test_keytable(self):
         test_resources = 'src/test/resources'

--- a/python/pyhail/tests.py
+++ b/python/pyhail/tests.py
@@ -223,8 +223,10 @@ class ContextTests(unittest.TestCase):
         sample2.samples_keytable()
 
         sample_split.annotate_variants_expr("va.nHet = gs.filter(g => g.isHet).count()")
-
-        kt = sample_split.aggregate_by_key("Variant = v", "nHet = g.map(g => g.isHet.toInt).sum().toLong")
+        
+        sample_split.aggregate_by_key("Variant = v", "nHet = g.map(g => g.isHet.toInt).sum().toLong")
+        
+        vds.make_keytable('v = v, info = va.info', 'gt = g.gt', ['v'])
 
     def test_keytable(self):
         test_resources = 'src/test/resources'

--- a/python/pyhail/tests.py
+++ b/python/pyhail/tests.py
@@ -299,4 +299,4 @@ class ContextTests(unittest.TestCase):
         kt.flatten()
         kt.expand_types()
 
-        kt.toDF()
+        kt.to_dataframe()

--- a/src/main/scala/org/broadinstitute/hail/annotations/Annotation.scala
+++ b/src/main/scala/org/broadinstitute/hail/annotations/Annotation.scala
@@ -116,7 +116,7 @@ object Annotation {
         else
           a.asInstanceOf[Row].toSeq
 
-      (s, t.fields).zipped.flatMap { case (ai, f) =>
+      val fs = (s, t.fields).zipped.flatMap { case (ai, f) =>
         f.`type` match {
           case t: TStruct =>
             flattenAnnotation(ai, f.`type`).asInstanceOf[Row].toSeq
@@ -125,7 +125,8 @@ object Annotation {
             Seq(ai)
         }
       }
-
+      Row.fromSeq(fs)
+      
     case _ => a
   }
 

--- a/src/main/scala/org/broadinstitute/hail/annotations/Annotation.scala
+++ b/src/main/scala/org/broadinstitute/hail/annotations/Annotation.scala
@@ -126,7 +126,7 @@ object Annotation {
         }
       }
       Row.fromSeq(fs)
-      
+
     case _ => a
   }
 

--- a/src/main/scala/org/broadinstitute/hail/annotations/Annotation.scala
+++ b/src/main/scala/org/broadinstitute/hail/annotations/Annotation.scala
@@ -1,6 +1,9 @@
 package org.broadinstitute.hail.annotations
 
 import org.apache.spark.sql.Row
+import org.broadinstitute.hail.expr._
+import org.broadinstitute.hail.utils.Interval
+import org.broadinstitute.hail.variant._
 
 object Annotation {
 
@@ -21,11 +24,109 @@ object Annotation {
       case r: Row =>
         "Struct:\n" +
           r.toSeq.zipWithIndex.map { case (elem, index) =>
-            s"""$spaces[$index] ${ printAnnotation(elem, nSpace + 4) }"""
+            s"""$spaces[$index] ${printAnnotation(elem, nSpace + 4)}"""
           }
             .mkString("\n")
       case a => a.toString + ": " + a.getClass.getSimpleName
     }
+  }
+
+  def expandType(t: Type): Type = t match {
+    case TChar => TString
+    case TVariant => Variant.t
+    case TSample => TString
+    case TGenotype => Genotype.t
+    case TLocus => Locus.t
+    case TArray(elementType) =>
+      TArray(expandType(elementType))
+    case TStruct(fields) =>
+      TStruct(fields.map { f => f.copy(`type` = expandType(f.`type`)) })
+    case TSet(elementType) =>
+      TArray(expandType(elementType))
+    case TDict(elementType) =>
+      TArray(TStruct(
+        "key" -> TString,
+        "value" -> expandType(elementType)))
+    case TAltAllele => AltAllele.t
+    case TInterval =>
+      TStruct(
+        "start" -> Locus.t,
+        "end" -> Locus.t)
+    case _ => t
+  }
+
+  def expandAnnotation(a: Annotation, t: Type): Annotation =
+    if (a == null)
+      null
+    else
+      t match {
+        case TVariant => a.asInstanceOf[Variant].toRow
+        case TGenotype => a.asInstanceOf[Genotype].toRow
+        case TLocus => a.asInstanceOf[Locus].toRow
+
+        case TArray(elementType) =>
+          a.asInstanceOf[IndexedSeq[_]].map(expandAnnotation(_, elementType))
+        case TStruct(fields) =>
+          Row.fromSeq((a.asInstanceOf[Row].toSeq, fields).zipped.map { case (ai, f) =>
+            expandAnnotation(ai, f.`type`)
+          })
+
+        case TSet(elementType) =>
+          (a.asInstanceOf[Set[_]]
+            .toArray[Any] : IndexedSeq[_])
+            .map(expandAnnotation(_, elementType))
+
+        case TDict(elementType) =>
+          (a.asInstanceOf[Map[String, _]]
+            .toArray[(String, Any)]: IndexedSeq[(String, Any)])
+            .map(expandAnnotation(_, elementType))
+
+        case TAltAllele => a.asInstanceOf[AltAllele].toRow
+
+        case TInterval =>
+          val i = a.asInstanceOf[Interval[Locus]]
+          Annotation(i.start.toRow,
+            i.end.toRow)
+
+        // including TChar, TSample
+        case _ => a
+      }
+
+  def flattenType(t: Type): Type = t match {
+    case t: TStruct =>
+      val flatFields = t.fields.flatMap { f =>
+        flattenType(f.`type`) match {
+          case t2: TStruct =>
+            t2.fields.map { f2 => (f.name + "." + f2.name, f2.`type`) }
+
+          case _ => Seq(f.name -> f.`type`)
+        }
+      }
+
+      TStruct(flatFields: _*)
+
+    case _ => t
+  }
+
+  def flattenAnnotation(a: Annotation, t: Type): Annotation = t match {
+    case t: TStruct =>
+      val s =
+        if (a == null)
+          Seq.fill(t.fields.length)(null)
+        else
+          a.asInstanceOf[Row].toSeq
+
+      (s, t.fields).zipped.flatMap { case (ai, f) =>
+        f.`type` match {
+          case t: TStruct =>
+            flattenAnnotation(ai, f.`type`).asInstanceOf[Row].toSeq
+
+          case _ =>
+            Seq(ai)
+        }
+      }
+
+    case _ => a
   }
 
   def apply(args: Any*): Annotation = Row.fromSeq(args)

--- a/src/main/scala/org/broadinstitute/hail/driver/package.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/package.scala
@@ -5,12 +5,16 @@ import java.util.Properties
 
 import org.apache.log4j.{LogManager, PropertyConfigurator}
 import org.apache.spark.deploy.SparkHadoopUtil
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.{Row, SQLContext}
 import org.apache.spark.{ProgressBarBuilder, SparkConf, SparkContext}
+import org.broadinstitute.hail.annotations.Annotation
+import org.broadinstitute.hail.expr._
+import org.broadinstitute.hail.keytable.KeyTable
 import org.broadinstitute.hail.utils._
-import org.broadinstitute.hail.variant.VariantDataset
+import org.broadinstitute.hail.variant._
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 package object driver {
 
@@ -45,6 +49,64 @@ package object driver {
         (vds.nVariants, None)
 
     CountResult(vds.nSamples, nVariants, nCalled)
+  }
+
+  def makeKT(vds: VariantDataset, variantCondition: String, genotypeCondition: String, keyNames: Array[String]): KeyTable = {
+    val vSymTab = Map(
+      "v" -> (0, TVariant),
+      "va" -> (1, vds.vaSignature))
+    val vEC = EvalContext(vSymTab)
+    val vA = vEC.a
+
+    val (vNames, vTypes, vf) = Parser.parseNamedExprs(variantCondition, vEC)
+
+    val gSymTab = Map(
+      "v" -> (0, TVariant),
+      "va" -> (1, vds.vaSignature),
+      "s" -> (2, TSample),
+      "sa" -> (3, vds.saSignature),
+      "g" -> (4, TGenotype))
+    val gEC = EvalContext(gSymTab)
+    val gA = gEC.a
+
+    val (gNames, gTypes, gf) = Parser.parseNamedExprs(genotypeCondition, gEC)
+
+    val sig = TStruct(((vNames, vTypes).zipped ++
+      vds.sampleIds.flatMap { s =>
+        (gNames, gTypes).zipped.map { case (n, t) =>
+          (s + "." + n, t)
+        }
+      }).toSeq: _*)
+
+    val localSampleIdsBc = vds.sampleIdsBc
+    val localSampleAnnotationsBc = vds.sampleAnnotationsBc
+
+    KeyTable(
+      vds.rdd.mapPartitions { it =>
+        val ab = mutable.ArrayBuilder.make[Any]
+
+        it.map { case (v, (va, gs)) =>
+          ab.clear()
+
+          vEC.setAll(v, va)
+          vf().foreach { x =>
+            ab += x.orNull
+          }
+
+          gs.iterator.zipWithIndex.foreach { case (g, i) =>
+            val s = localSampleIdsBc.value(i)
+            val sa = localSampleAnnotationsBc.value(i)
+            gEC.setAll(v, va, s, sa, g)
+            gf().foreach { x =>
+              ab += x.orNull
+            }
+          }
+
+          Row.fromSeq(ab.result()): Annotation
+        }
+      },
+      sig,
+      keyNames)
   }
 
   def configureAndCreateSparkContext(appName: String, master: Option[String], local: String = "local[*]",

--- a/src/main/scala/org/broadinstitute/hail/driver/package.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/package.scala
@@ -74,7 +74,10 @@ package object driver {
     val sig = TStruct(((vNames, vTypes).zipped ++
       vds.sampleIds.flatMap { s =>
         (gNames, gTypes).zipped.map { case (n, t) =>
-          (s + "." + n, t)
+          (if (n.isEmpty)
+            s
+          else
+            s + "." + n, t)
         }
       }).toSeq: _*)
 

--- a/src/main/scala/org/broadinstitute/hail/expr/AnnotationImpex.scala
+++ b/src/main/scala/org/broadinstitute/hail/expr/AnnotationImpex.scala
@@ -8,9 +8,6 @@ import org.broadinstitute.hail.utils.Interval
 import org.broadinstitute.hail.variant.{AltAllele, Genotype, Locus, Sample, Variant}
 import org.json4s._
 import org.json4s.jackson.{JsonMethods, Serialization}
-import scala.collection.JavaConverters._
-
-
 
 abstract class AnnotationImpex[T, A] {
   // FIXME for now, schema must be specified on import

--- a/src/main/scala/org/broadinstitute/hail/keytable/KeyTable.scala
+++ b/src/main/scala/org/broadinstitute/hail/keytable/KeyTable.scala
@@ -432,12 +432,16 @@ case class KeyTable(rdd: RDD[(Annotation, Annotation)], keySignature: TStruct, v
   def expandTypes(): KeyTable = {
     val localKeySignature = keySignature
     val localValueSignature = valueSignature
+
+    val expandedKeySignature = Annotation.expandType(keySignature).asInstanceOf[TStruct]
+    val expandedValueSignature = Annotation.expandType(valueSignature).asInstanceOf[TStruct]
+
     KeyTable(rdd.map { case (k, v) =>
-      (Annotation.expandAnnotation(v, localKeySignature),
-        Annotation.expandAnnotation(k, localValueSignature))
+      (Annotation.expandAnnotation(k, localKeySignature),
+        Annotation.expandAnnotation(v, localValueSignature))
     },
-      Annotation.expandType(keySignature).asInstanceOf[TStruct],
-      Annotation.expandType(valueSignature).asInstanceOf[TStruct])
+      expandedKeySignature,
+      expandedValueSignature)
   }
 
   def flatten(): KeyTable = {

--- a/src/main/scala/org/broadinstitute/hail/variant/Genotype.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/Genotype.scala
@@ -4,9 +4,11 @@ import java.util
 
 import org.apache.commons.lang3.builder.HashCodeBuilder
 import org.apache.commons.math3.distribution.BinomialDistribution
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 import org.broadinstitute.hail.utils._
 import org.broadinstitute.hail.check.{Arbitrary, Gen}
+import org.broadinstitute.hail.expr.{TArray, TBoolean, TInt, TStruct, Type}
 import org.broadinstitute.hail.utils.ByteIterator
 import org.json4s._
 
@@ -267,6 +269,9 @@ class Genotype(private val _gt: Int,
     arr => divOption(arr(0), arr.sum)
   }
 
+  def toRow: Row =
+    Row(gt.orNull, ad.map(_.toSeq).orNull, dp.orNull, gq.orNull, px.map(_.toSeq).orNull, fakeRef, isDosage)
+
   def toJSON: JValue = JObject(
     ("gt", gt.map(JInt(_)).getOrElse(JNull)),
     ("ad", ad.map(ads => JArray(ads.map(JInt(_)).toList)).getOrElse(JNull)),
@@ -301,6 +306,15 @@ object Genotype {
     StructField("px", ArrayType(IntegerType)),
     StructField("fakeRef", BooleanType),
     StructField("isDosage", BooleanType)))
+
+  def t: Type = TStruct(
+    "gt" -> TInt,
+    "ad" -> TArray(TInt),
+    "dp" -> TInt,
+    "gq" -> TInt,
+    "px" -> TArray(TInt),
+    "fakeRef" -> TBoolean,
+    "isDosage" -> TBoolean)
 
   final val flagMultiHasGTBit = 0x1
   final val flagMultiGTRefBit = 0x2

--- a/src/main/scala/org/broadinstitute/hail/variant/Locus.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/Locus.scala
@@ -1,7 +1,9 @@
 package org.broadinstitute.hail.variant
 
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.broadinstitute.hail.check.Gen
+import org.broadinstitute.hail.expr.{TInt, TString, TStruct, Type}
 import org.broadinstitute.hail.sparkextras.OrderedKey
 import org.broadinstitute.hail.utils._
 import org.json4s._
@@ -33,6 +35,10 @@ object Locus {
       StructField("contig", StringType, nullable = false),
       StructField("position", IntegerType, nullable = false)))
 
+  val t: Type = TStruct(
+    "contig" -> TString,
+    "position" -> TInt)
+
   def gen(contigs: Seq[String]): Gen[Locus] =
     Gen.zip(Gen.oneOfSeq(contigs), Gen.posInt)
       .map { case (contig, pos) => Locus(contig, pos) }
@@ -51,6 +57,8 @@ case class Locus(contig: String, position: Int) extends Ordered[Locus] {
 
     position.compare(that.position)
   }
+
+  def toRow: Row = Row(contig, position)
 
   def toJSON: JValue = JObject(
     ("contig", JString(contig)),

--- a/src/main/scala/org/broadinstitute/hail/variant/Variant.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/Variant.scala
@@ -117,6 +117,8 @@ case class AltAllele(ref: String,
     (ref, alt).zipped.dropWhile { case (a, b) => a == b }.head
   }
 
+  def toRow: Row = Row(ref, alt)
+
   def toJSON: JValue = JObject(
     ("ref", JString(ref)),
     ("alt", JString(alt))

--- a/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
@@ -332,6 +332,8 @@ class VariantSampleMatrix[T](val metadata: VariantMetadata,
 
   def sampleIds: IndexedSeq[String] = metadata.sampleIds
 
+  def sampleIdsAsArray: Array[String] = sampleIds.toArray
+
   lazy val sampleIdsBc = sparkContext.broadcast(sampleIds)
 
   def nSamples: Int = metadata.sampleIds.length

--- a/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
@@ -23,6 +23,7 @@ import org.broadinstitute.hail.keytable.KeyTable
 import org.broadinstitute.hail.methods.{Aggregators, Filter}
 import org.broadinstitute.hail.utils
 
+import scala.collection.mutable
 import scala.io.Source
 import scala.language.implicitConversions
 import scala.reflect.ClassTag

--- a/src/test/scala/org/broadinstitute/hail/methods/KeyTableSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/KeyTableSuite.scala
@@ -42,9 +42,9 @@ class KeyTableSuite extends SparkSuite {
   @Test def testAnnotate() = {
     val inputFile = "src/test/resources/sampleAnnotations.tsv"
     val kt1 = KeyTable.importTextTable(sc, Array(inputFile), "Sample", sc.defaultMinPartitions, TextTableConfiguration(impute = true))
-    val kt2 = kt1.annotate("""qPhen2 = pow(qPhen, 2), NotStatus = Status == "CASE", X = qPhen == 5""", kt1.keyNames.mkString(","))
-    val kt3 = kt2.annotate("", kt2.keyNames.mkString(","))
-    val kt4 = kt3.annotate("", "qPhen, NotStatus")
+    val kt2 = kt1.annotate("""qPhen2 = pow(qPhen, 2), NotStatus = Status == "CASE", X = qPhen == 5""")
+    val kt3 = kt2.annotate("")
+    val kt4 = kt3.select(kt3.fieldNames, Array("qPhen", "NotStatus"))
 
     val kt1ValueNames = kt1.valueNames.toSet
     val kt2ValueNames = kt2.valueNames.toSet


### PR DESCRIPTION
Replaced VariantDataset ..._to_pandas with ..._keytable.
Added expand_types and flatten to KeyTable.  These probably need to be more configurable but are a start.
Added KeyTable.toDF.  This allows KeyTables to be easily written to Parquet.
