### PR TITLE
Update keytable.py

### DIFF
--- a/python/pyhail/keytable.py
+++ b/python/pyhail/keytable.py
@@ -1,4 +1,5 @@
 from pyhail.type import Type
+from py4j.protocol import Py4JJavaError
 
 class KeyTable(object):
     """:class:`.KeyTable` is Hail's version of a SQL table where fields


### PR DESCRIPTION
Fixes this error: ```except Py4JJavaError as e:
NameError: global name 'Py4JJavaError' is not defined```