### PR TITLE
Back json and str out of FunctionRegistry.

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/expr/AST.scala
+++ b/src/main/scala/org/broadinstitute/hail/expr/AST.scala
@@ -338,14 +338,14 @@ case class Apply(posn: Position, fn: String, args: Array[AST]) extends AST(posn,
         if (rhs.length != 1)
           parseError("str expects 1 argument")
         if (!rhs.head.`type`.isRealizable)
-          parseError("Argument to str of unrealizable type")
+          parseError(s"Argument to str has unrealizable type: ${rhs.head.`type`}")
         TString
 
       case ("json", rhs) =>
         if (rhs.length != 1)
           parseError("json expects 1 argument")
         if (!rhs.head.`type`.isRealizable)
-          parseError("Argument to json of unrealizable type")
+          parseError(s"Argument to json has unrealizable type: ${rhs.head.`type`}")
         TString
 
       case ("merge", rhs) =>

--- a/src/main/scala/org/broadinstitute/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/org/broadinstitute/hail/expr/FunctionRegistry.scala
@@ -1029,9 +1029,6 @@ object FunctionRegistry {
   registerSpecial("isMissing", (g: () => Any) => g() == null)(TTHr, boolHr)
   registerSpecial("isDefined", (g: () => Any) => g() != null)(TTHr, boolHr)
 
-  registerSpecial("json", (f: () => Any) => JsonMethods.compact(TT.t.toJSON(f())))(TTHr, stringHr)
-  registerSpecial("str", (f: () => Any) => TT.t.str(f()))(TTHr, stringHr)
-
   registerSpecial("||", { (f1: () => Any, f2: () => Any) =>
     val x1 = f1()
     if (x1 != null) {


### PR DESCRIPTION
They don't work.  TT.t gets overwritten when matching other functions.