### PR TITLE
Sphinx CSS fixes

### DIFF
--- a/python/pyhail/docs/_static/custom.css
+++ b/python/pyhail/docs/_static/custom.css
@@ -13,6 +13,14 @@ div.body h1 {
   font-size: 2.5em;
 }
 
+div.body h2 {
+  font-family: Georgia, Palatino, 'Palatino Linotype', Times, 'Times New Roman', serif;
+  color: #111;
+  line-height: 125%;
+  font-weight: normal;
+  font-size: 2em;
+}
+
 table.field-list td {
    padding: 10px;
 }

--- a/python/pyhail/docs/_static/custom.css
+++ b/python/pyhail/docs/_static/custom.css
@@ -34,4 +34,40 @@ table.field-list th {
     margin-top: 35px;
 }
 
+blockquote {
+    font-size: 14px;
+    padding: 10px;
+}
+
+blockquote ul.simple {
+    margin-top: 0px;
+}
+
+blockquote ul.simple li {
+    margin-bottom: 10px;
+}
+
+blockquote ul.simple li:last-child {
+    margin-bottom: 0px;
+}
+
+div.highlight pre {
+    margin-left: 0px;
+    padding-left: 30px;
+}
+
+dl.class dt {
+    background: #d4d7e8;
+    padding: 6px;
+    border-radius: 3px;
+}
+
+dl.method dt {
+    background: #e7f2fa;
+    padding: 6px;
+    border-radius: 3px;
+}
+
+
+
 

--- a/python/pyhail/docs/conf.py
+++ b/python/pyhail/docs/conf.py
@@ -181,7 +181,9 @@ html_extra_path = ['_static/navbar_pyhail.html']
 
 # Custom sidebar templates, maps document names to template names.
 #
-# html_sidebars = {}
+html_sidebars = {
+    '**': [ 'localtoc.html', 'searchbox.html']
+}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.

--- a/python/pyhail/docs/index.rst
+++ b/python/pyhail/docs/index.rst
@@ -3,21 +3,33 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-
 Python API
 ==========
 
 .. toctree::
    :maxdepth: 2
 
+HailContext
+-----------
+
 .. autoclass:: pyhail.HailContext
    :members:
+
+VariantDataset
+--------------
 
 .. autoclass:: pyhail.VariantDataset
    :members:
 
+KeyTable
+--------
+
 .. autoclass:: pyhail.KeyTable
    :members:
+
+
+TextTableConfig
+---------------
 
 .. autoclass:: pyhail.TextTableConfig
    :members:

--- a/www/style.css
+++ b/www/style.css
@@ -97,13 +97,6 @@ h6 {
   font-size: 0.9em;
 }
 
-blockquote {
-  color: #666666;
-  margin: 0;
-  padding-left: 3em;
-  border-left: 0.5em #EEE solid;
-}
-
 hr {
   display: block;
   height: 2px;


### PR DESCRIPTION
 - Fixed blockquote formatting
 - Fixed code blocks filling page
 - Added highlighting of class and method names. To fix colors, change css here: `python/pyhail/docs/_static/custom.css`