### PR TITLE
escape 'dataset_id' column name

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/driver/ExportVariantsCass.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/ExportVariantsCass.scala
@@ -204,8 +204,8 @@ object ExportVariantsCass extends Command {
     if (tableMetadata == null) {
       info(s"creating table ${qualifiedTable}")
       try {
-        session.execute(s"CREATE TABLE $qualifiedTable (dataset_id text, chrom text, start int, ref text, alt text, " +
-          "PRIMARY KEY ((dataset_id, chrom, start), ref, alt))") // WITH COMPACT STORAGE")
+        session.execute(s"CREATE TABLE $qualifiedTable (${escapeString("dataset_id")} text, chrom text, start int, ref text, alt text, " +
+          s"PRIMARY KEY ((${escapeString("dataset_id")}, chrom, start), ref, alt))") // WITH COMPACT STORAGE")
       } catch {
         case e: Exception => fatal(s"exportvariantscass: unable to create table ${qualifiedTable}: ${e}")
       }


### PR DESCRIPTION
This is so it matches the column name computed from the -v expression.