### PR TITLE
Issue 1205

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/org/broadinstitute/hail/expr/FunctionRegistry.scala
@@ -874,7 +874,8 @@ object FunctionRegistry {
   })(aggregableHr(TTHr, aggST), unaryHr(TTHr, boolHr), aggregableHr(TTHr, aggST))
 
   registerLambdaSpecial("map", { (a: () => Any, f: (Any) => Any) =>
-    f(a())
+    val x = a()
+    if (x == null) null else f(x)
   })(aggregableHr(TTHr, aggST), unaryHr(TTHr, TUHr), aggregableHr(TUHr, aggST))
 
   type Id[T] = T


### PR DESCRIPTION
resolves #1205 

I'm rather uncomfortable about how we `null` is both a user-facing thing and the representation of "filtered" in aggregators. Consider these two expressions from the expr language:

```
[1,2,NA:Int].map(x => x).sum()
```
```
[1,2,NA:Int].map(x => 3).sum()
```

The former evaluates to `3`, the latter evaluates to `9`. This is what I would expect.

The conceptually similar:

```
gs.map(x => 3).sum()
```

Will not have the same behavior because `NA` items will be treated like filtered items. In particular if `gs` contained three genotypes, two of which were missing, the result would be `3`, not `9`.