### PR TITLE
Add `flatMap` for aggregables

### DIFF
--- a/docs/reference/HailExpressionLanguage.md
+++ b/docs/reference/HailExpressionLanguage.md
@@ -183,18 +183,22 @@ Identifier | Description
 `va` | Variant annotations
 `global` | Global annotations
 
-### Map and Filter
+### Map, Filter, and FlatMap
 
 ```
 <aggregable>.map( <Any lambda expression> )
 <aggregable>.filter( <Boolean lambda expression> )
+<aggregable>.flatMap( <Array or Set lambda expression> )
 ```
 
-These two generic helper functions allow the proceeding calculations to be totally general and modular.
+These three generic helper functions allow the proceeding calculations to be totally general and modular.
 
 `map` changes the type of an aggregable: `gs.map(g => g.gq)` takes the `Aggregable[Genotype]` "gs" and returns an `Aggregable[Int]`.
 
 `filter` subsets an aggregable by excluding/including elements based on a lambda expression.  Note: does not change the type of an aggregable.  `gs.filter(g => g.isHet)` produces an aggregable where only heterozygous genotypes are considered.
+
+`flatMap` expands a single element into many elements. For example, `gs.map(g =>
+g.pl).hist()` creates a histogram of the pls for this variant over all samples.
 
 ### <a class="jumptarget" name="#aggregables_count"></a> Count
 

--- a/src/main/scala/org/broadinstitute/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/org/broadinstitute/hail/expr/FunctionRegistry.scala
@@ -875,6 +875,21 @@ object FunctionRegistry {
 
   val aggST = Box[SymbolTable]()
 
+  registerLambdaAggregatorTransformer("flatMap", { (a: CPS[Any], f: (Any) => Any) =>
+    { (k: Any => Any) => a { x =>
+      val r = f(x).asInstanceOf[IndexedSeq[Any]]
+      var i = 0
+      while (i < r.size) {
+        k(r(i))
+        i += 1
+      }
+    } }
+  })(aggregableHr(TTHr, aggST), unaryHr(TTHr, arrayHr(TUHr)), aggregableHr(TUHr, aggST))
+
+  registerLambdaAggregatorTransformer("flatMap", { (a: CPS[Any], f: (Any) => Any) =>
+    { (k: Any => Any) => a { x => f(x).asInstanceOf[Set[Any]].foreach(k) } }
+  })(aggregableHr(TTHr, aggST), unaryHr(TTHr, setHr(TUHr)), aggregableHr(TUHr, aggST))
+
   registerLambdaAggregatorTransformer("filter", { (a: CPS[Any], f: (Any) => Any) =>
     { (k: Any => Any) => a { x =>
       val r = f(x)

--- a/src/test/scala/org/broadinstitute/hail/methods/AggregatorSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/AggregatorSuite.scala
@@ -284,4 +284,64 @@ class AggregatorSuite extends SparkSuite {
 
     assert(result.contains(0))
   }
+
+  @Test def testFlatMap1() {
+    val p = Prop.forAll(VariantSampleMatrix.gen(sc, VSMSubgen.random.copy(sampleIdGen=Gen.const(Array("a", "b"))))) { vds =>
+      var s = State(sc, sqlContext, vds)
+      s = AnnotateGlobalExprBySample.run(s, Array("-c", "global.result = samples.flatMap(g => [1]).sum()"))
+
+      val (_, result) = s.vds.queryGlobal("global.result")
+
+      result.contains(2)
+    }
+    p.check()
+  }
+
+  @Test def testFlatMap2() {
+    val p = Prop.forAll(VariantSampleMatrix.gen(sc, VSMSubgen.random.copy(sampleIdGen=Gen.const(Array("a", "b"))))) { vds =>
+      var s = State(sc, sqlContext, vds)
+      s = AnnotateGlobalExprBySample.run(s, Array("-c", "global.result = samples.flatMap(g => [0][:0]).sum()"))
+
+      val (_, result) = s.vds.queryGlobal("global.result")
+
+      result.contains(0)
+    }
+    p.check()
+  }
+
+  @Test def testFlatMap3() {
+    val p = Prop.forAll(VariantSampleMatrix.gen(sc, VSMSubgen.random.copy(sampleIdGen=Gen.const(Array("a", "b"))))) { vds =>
+      var s = State(sc, sqlContext, vds)
+      s = AnnotateGlobalExprBySample.run(s, Array("-c", "global.result = samples.flatMap(g => [1,2]).sum()"))
+
+      val (_, result) = s.vds.queryGlobal("global.result")
+
+      result.contains(6)
+    }
+    p.check()
+  }
+
+  @Test def testFlatMap4() {
+    val p = Prop.forAll(VariantSampleMatrix.gen(sc, VSMSubgen.random.copy(sampleIdGen=Gen.const(Array("a", "b"))))) { vds =>
+      var s = State(sc, sqlContext, vds)
+      s = AnnotateGlobalExprBySample.run(s, Array("-c", "global.result = samples.flatMap(g => [1,2]).filter(x => x % 2 == 0).sum()"))
+
+      val (_, result) = s.vds.queryGlobal("global.result")
+
+      result.contains(4)
+    }
+    p.check()
+  }
+
+  @Test def testFlatMap5() {
+    val p = Prop.forAll(VariantSampleMatrix.gen(sc, VSMSubgen.random.copy(sampleIdGen=Gen.const(Array("a", "b"))))) { vds =>
+      var s = State(sc, sqlContext, vds)
+      s = AnnotateGlobalExprBySample.run(s, Array("-c", "global.result = samples.flatMap(g => [1,2,2].toSet).filter(x => x % 2 == 0).sum()"))
+
+      val (_, result) = s.vds.queryGlobal("global.result")
+
+      result.contains(4)
+    }
+    p.check()
+  }
 }


### PR DESCRIPTION
Expressions such as
```
samples.flatMap(g => [1,2]).sum()
```
are now valid Hail expressions.

Should merge cleanly after #1220 