### PR TITLE
improve aggregator performance

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/methods/Aggregators.scala
+++ b/src/main/scala/org/broadinstitute/hail/methods/Aggregators.scala
@@ -47,18 +47,27 @@ object Aggregators {
       localA(0) = localGlobalAnnotations
       localA(1) = v
       localA(2) = va
-      (gs, localSamplesBc.value, localAnnotationsBc.value).zipped
-        .foreach { case (g, s, sa) =>
-          localA(3) = g
-          localA(4) = s
-          localA(5) = sa
-          (aggs, aggregations).zipped.foreach { case (agg, (_, f, _)) =>
-            f(agg.seqOp)
-          }
+
+      val gsIt = gs.iterator
+      var i = 0
+      while (i < localSamplesBc.value.size) {
+        localA(3) = gsIt.next()
+        localA(4) = localSamplesBc.value(i)
+        localA(5) = localAnnotationsBc.value(i)
+
+        var j = 0
+        while (j < aggs.size) {
+          aggregations(j)._2(aggs(j).seqOp)
+          j += 1
         }
 
-      (aggs, aggregations).zipped.foreach { case (agg, (idx, _, _)) =>
-        localA(idx) = agg.result
+        i += 1
+      }
+
+      i = 0
+      while (i < aggs.size) {
+        localA(aggregations(i)._1) = aggs(i).result
+        i += 1
       }
     })
   }
@@ -103,11 +112,13 @@ object Aggregators {
       localA(0) = localGlobalAnnotation
       localA(4) = v
       localA(5) = va
+
+      val gsIt = gs.iterator
       var i = 0
-      gs.foreach { g =>
+      while (i < localSamplesBc.value.size) {
         localA(1) = localSamplesBc.value(i)
         localA(2) = localSampleAnnotationsBc.value(i)
-        localA(3) = g
+        localA(3) = gsIt.next
 
         var j = 0
         while (j < nAggregations) {


### PR DESCRIPTION
Convert three foreach calls to while loops.

I see about a 15% reduction in variant aggregation time. I executed

```
hail read profile225.vds \
  annotatevariants expr -c 'va.foo = gs.map(g => 1).sum()' \
  exportvariants -c 'va.foo' -o 'foo.tsv'
```

Here are the comparisons between this PR, master, and some part-solutions that I tried. We always compare to this PR. In each case, the first row of numbers is the same row of timings for this PR. The second row of numbers is the timings for the alternative. Note that converting the outer loop and the last loop, but not the inner loop, seems to be slower than master. I suspect these measurements are fairly noisy, but perhaps there's something else going on in that case. Regardless, this PR is the clear winner and we know why: `while` loops are faster than `for` loops.

vs master
```
(/ (/ (+ 49.736 50.335 48.197 51.034 47.737) 5)
   (/ (+ 62.9 55.362 57.100 57.815 60.5) 5))

0.84
```

vs inner and last only
```
(/ (/ (+ 49.736 50.335 48.197 51.034 47.737) 5)
   (/ (+ 52.982 63.1 57.481 56.480 51.814) 5))

0.88
```

vs outer and last only
```
(/ (/ (+ 49.736 50.335 48.197 51.034 47.737) 5)
   (/ (+ 74.6 69.0 55.750 69.7 68.5) 5))

0.73
```




