### PR TITLE
Added query functionality to scala and python.

### DIFF
--- a/python/pyhail/dataset.py
+++ b/python/pyhail/dataset.py
@@ -25,6 +25,24 @@ class VariantDataset(object):
         except Py4JJavaError as e:
             self._raise_py4j_exception(e)
 
+    def sample_annotations(self):
+        """Return a dict of sample annotations.
+
+        The keys of this dictionary are the sample IDs (strings).
+        The values are sample annotations.
+
+        :return: dict
+        """
+
+        schema = self.jvds.saSignature()
+        zipped_annotations = scala_package_object(self.hc.jvm.org.broadinstitute.hail.utils).makeArrayList(
+            self.jvds.sampleIdsAndAnnotations()
+        )
+        r = {}
+        for element in zipped_annotations:
+            r[element._1()] = schema.makePy4jConvertible(element._2())
+        return r
+
     def num_partitions(self):
         """Number of RDD partitions.
 
@@ -1822,6 +1840,13 @@ class VariantDataset(object):
                  '-i', input]
         return self.hc.run_command(self, pargs)
 
+    def global_annotations(self):
+        """return global annotation
+
+        :return: annotation
+        """
+        return self.jvds.globalSignature().makePy4jConvertible(self.jvds.globalAnnotation)
+
     def grm(self, format, output, id_file=None, n_file=None):
         """Compute the Genetic Relatedness Matrix (GMR).
 
@@ -2448,6 +2473,88 @@ class VariantDataset(object):
         if print_global:
             pargs.append('--global')
         return self.hc.run_command(self, pargs)
+
+    def query_samples(self, exprs):
+        """Perform aggregation queries over samples and sample annotations.
+
+        **Example**
+
+        >>> low_callrate_samples = vds.query_samples(
+        >>>     'samples.filter(s => sa.qc.callRate < 0.95).collect()')
+
+        **Details**
+
+        This method evaluates Hail expressions over samples and sample
+        annotations.  The ``exprs`` argument requires either a single
+        string, in which case the method will return the result for
+        that one query, or a list of strings, in which case the method
+        will return a list of results.  The latter functionality can
+        be used to improve performance by evaluating multiple queries
+        at once.
+
+        The namespace of the expressions includes:
+
+        - ``global``: global annotations
+        - ``samples`` (*Aggregable[Sample]*): aggregable of :ref:`sample`
+
+        Map and filter expressions on this aggregable have the additional
+        namespace:
+
+        - ``global``: global annotations
+        - ``s``: sample
+        - ``sa``: sample annotations
+
+
+        :param exprs: str or list of str
+        :return: annotation or list of annotation
+        """
+        if (isinstance(exprs, list)):
+            result_list = self.jvds.querySamples(jarray(self.hc.gateway, self.hc.jvm.java.lang.String, exprs))
+            return [x._2().makePy4jConvertible(x._1()) for x in result_list]
+        else:
+            result = self.jvds.querySamples(exprs)
+            return result._2().makePy4jConvertible(result._1())
+
+    def query_variants(self, exprs):
+        """Perform aggregation queries over variants and variant annotations.
+
+        **Example**
+
+        >>> lof_variant_count = vds.query_variants(
+        >>>     'variants.filter(v => va.csq == "LOF").count()')
+
+        **Details**
+
+        This method evaluates Hail expressions over variants and variant
+        annotations.  The ``exprs`` argument requires either a single
+        string, in which case the method will return the result for
+        that one query, or a list of strings, in which case the method
+        will return a list of results.  The latter functionality can
+        be used to improve performance by evaluating multiple queries
+        at once.
+
+        The namespace of the expressions includes:
+
+        - ``global``: global annotations
+        - ``variants`` (*Aggregable[Variant]*): aggregable of :ref:`variant`
+
+        Map and filter expressions on this aggregable have the additional
+        namespace:
+
+        - ``global``: global annotations
+        - ``v``: :ref:`variant`
+        - ``va``: variant annotations
+
+
+        :param exprs: str or list of str
+        :return: annotation or list of annotation
+        """
+        if (isinstance(exprs, list)):
+            result_list = self.jvds.queryVariants(jarray(self.hc.gateway, self.hc.jvm.java.lang.String, exprs))
+            return [x._2().makePy4jConvertible(x._1()) for x in result_list]
+        else:
+            result = self.jvds.queryVariants(exprs)
+            return result._2().makePy4jConvertible(result._1())
 
     def rename_samples(self, input):
         """Rename samples.

--- a/src/main/scala/org/broadinstitute/hail/expr/Type.scala
+++ b/src/main/scala/org/broadinstitute/hail/expr/Type.scala
@@ -15,6 +15,7 @@ import org.json4s.jackson.JsonMethods
 
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
+import scala.collection.JavaConverters._
 
 object Type {
   val genScalar = Gen.oneOf[Type](TBoolean, TChar, TInt, TLong, TFloat, TDouble, TString,
@@ -139,6 +140,8 @@ sealed abstract class Type {
   def isRealizable: Boolean = children.forall(_.isRealizable)
 
   def typeCheck(a: Any): Boolean
+
+  def makePy4jConvertible(a: Annotation): Any = a
 
   /* compare values for equality, but compare Float and Double values using D_== */
   def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double = utils.defaultTolerance): Boolean = a1 == a2
@@ -413,6 +416,17 @@ case class TArray(elementType: Type) extends TIterable {
 
   override def str(a: Annotation): String = JsonMethods.compact(toJSON(a))
 
+  override def makePy4jConvertible(a: Annotation): Any = {
+    if (a == null)
+      a
+    else {
+      var list = new java.util.ArrayList[Any]()
+      for (elem <- a.asInstanceOf[IndexedSeq[_]])
+        list.add(elementType.makePy4jConvertible(elem))
+      list
+    }
+  }
+
   override def genValue: Gen[Annotation] = Gen.buildableOf[IndexedSeq, Annotation](elementType.genValue)
 }
 
@@ -436,6 +450,13 @@ case class TSet(elementType: Type) extends TIterable {
   }
 
   override def str(a: Annotation): String = JsonMethods.compact(toJSON(a))
+
+  override def makePy4jConvertible(a: Annotation): Any = {
+    if (a == null)
+      a
+    else
+      a.asInstanceOf[Set[_]].map { elem => elementType.makePy4jConvertible(elem) }.asJava
+  }
 
   override def genValue: Gen[Annotation] = Gen.buildableOf[Set, Annotation](elementType.genValue)
 }
@@ -474,6 +495,13 @@ case class TDict(elementType: Type) extends TContainer {
         .forall { case (_, (o1, o2)) =>
           o1.liftedZip(o2).exists { case (v1, v2) => elementType.valuesSimilar(v1, v2, tolerance) }
         }
+
+  override def makePy4jConvertible(a: Annotation): Any = {
+    if (a == null)
+      a
+    else
+      a.asInstanceOf[Map[_, _]].map { case (k, elem) => (k, elementType.makePy4jConvertible(elem)) }.asJava
+  }
 }
 
 case object TSample extends Type {
@@ -877,4 +905,12 @@ case class TStruct(fields: IndexedSeq[Field]) extends Type {
       .forall { case ((f, x1), x2) =>
         f.`type`.valuesSimilar(x1, x2, tolerance)
       })
+
+  override def makePy4jConvertible(a: Annotation): Any = {
+    if (a == null)
+      a
+    else
+      a.asInstanceOf[Row].toSeq.zip(fields).map { case (elem, f) => (f.name, f.`type`.makePy4jConvertible(elem)) }.toMap.asJava
+  }
+
 }

--- a/src/main/scala/org/broadinstitute/hail/utils/package.scala
+++ b/src/main/scala/org/broadinstitute/hail/utils/package.scala
@@ -103,6 +103,13 @@ package object utils extends Logging
     if (!p) throw new AssertionError
   }
 
+  def makeArrayList[T](it: Iterable[T]): java.util.ArrayList[T] = {
+    val list = new java.util.ArrayList[T]()
+    for (elem <- it)
+      list.add(elem)
+    list
+  }
+
   def optionCheckInRangeInclusive[A](low: A, high: A)(name: String, a: A)(implicit ord: Ordering[A]): Unit =
     if (ord.lt(a, low) || ord.gt(a, high)) {
       fatal(s"$name cannot lie outside [$low, $high]: $a")

--- a/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
@@ -9,10 +9,10 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.apache.spark.{SparkContext, SparkEnv}
 import org.broadinstitute.hail.utils._
-import org.broadinstitute.hail.driver.Main
+import org.broadinstitute.hail.driver.{HailConfiguration, Main}
 import org.broadinstitute.hail.annotations._
 import org.broadinstitute.hail.check.Gen
-import org.broadinstitute.hail.expr.{EvalContext, _}
+import org.broadinstitute.hail.expr.{EvalContext, TAggregable, _}
 import org.broadinstitute.hail.io.vcf.BufferedLineIterator
 import org.broadinstitute.hail.sparkextras._
 import org.json4s._
@@ -986,6 +986,67 @@ class VariantSampleMatrix[T](val metadata: VariantMetadata,
         "s" -> TSample,
         "sa" -> saSignature),
       Array("s"))
+  }
+
+  def querySamples(expr: String): (Annotation, Type) = {
+    val qs = querySamples(Array(expr))
+    assert(qs.length == 1)
+    qs.head
+  }
+
+  def querySamples(exprs: Array[String]): Array[(Annotation, Type)] = {
+    val aggregationST = Map(
+      "global" -> (0, globalSignature),
+      "s" -> (1, TSample),
+      "sa" -> (2, saSignature))
+    val ec = EvalContext(Map(
+      "global" -> (0, globalSignature),
+      "samples" -> (1, TAggregable(TSample, aggregationST))))
+
+    val ts = exprs.map(e => Parser.parseExpr(e, ec))
+
+    val localGlobalAnnotation = globalAnnotation
+    val (zVal, seqOp, combOp, resOp) = Aggregators.makeFunctions[(String, Annotation)](ec, { case (ec, (s, sa)) =>
+      ec.setAll(localGlobalAnnotation, s, sa)
+    })
+
+    val results = sampleIdsAndAnnotations
+      .aggregate(zVal)(seqOp, combOp)
+    resOp(results)
+    ec.set(0, localGlobalAnnotation)
+
+    ts.map { case (t, f) => (f().orNull, t) }.toArray
+  }
+
+  def queryVariants(expr: String): (Annotation, Type) = {
+    val qv = queryVariants(Array(expr))
+    assert(qv.length == 1)
+    qv.head
+  }
+
+  def queryVariants(exprs: Array[String]): Array[(Annotation, Type)] = {
+
+    val aggregationST = Map(
+      "global" -> (0, globalSignature),
+      "v" -> (1, TVariant),
+      "va" -> (2, vaSignature))
+    val ec = EvalContext(Map(
+      "global" -> (0, globalSignature),
+      "variants" -> (1, TAggregable(TVariant, aggregationST))))
+
+    val ts = exprs.map(e => Parser.parseExpr(e, ec))
+
+    val localGlobalAnnotation = globalAnnotation
+    val (zVal, seqOp, combOp, resOp) = Aggregators.makeFunctions[(Variant, Annotation)](ec, { case (ec, (v, va)) =>
+      ec.setAll(localGlobalAnnotation, v, va)
+    })
+
+    val result = variantsAndAnnotations
+      .treeAggregate(zVal)(seqOp, combOp, depth = HailConfiguration.treeAggDepth(nPartitions))
+    resOp(result)
+
+    ec.setAll(localGlobalAnnotation)
+    ts.map { case (t, f) => (f().orNull, t) }.toArray
   }
 }
 


### PR DESCRIPTION
Added functions to make annotations py4j-convertible.
Exposed global and sample annotations in python.

This is the start of a long list of changes that need to be made before our interface starts to actually look nice in python.  Doing `annotate_global_expr_by_sample` followed by `show_globals` to do aggregations is horrible -- here you can just do 

```
>>> europeans = vds.query_samples('samples.filter(s => sa.pop == "EUR").collect()')
```