### PR TITLE
Fixed min, max, mean, median on empty sets and arrays

### DIFF
--- a/docs/reference/HailExpressionLanguage.md
+++ b/docs/reference/HailExpressionLanguage.md
@@ -85,21 +85,22 @@ Several Hail commands provide the ability to perform a broad array of computatio
      - sortBy: `arr.sortBy(v => expr[,ascending])` -- Returns a new array with the same elements in ascending order according to the value of `expr`, which must be numeric or string. For descending order, use `arr.sortBy(v => expr, false)`. Elements with missing `expr` values are always placed at the end.
 
  - Numeric Array Operations:
-     - min: `arr.min` -- valid only for numeric arrays, returns the minimum value
-     - max: `arr.max` -- valid only for numeric arrays, returns the minimum value
-     - median: `arr.median` -- valid only for numeric arrays, returns the median value (`NA`'s are ignored). Element type is preserved so the median of `[0, 3]` is `(0 + 3) / 2 = 1`. To get `1.5` instead, use `arr.map(_.toDouble).median`
-     - mean: `arr.mean` -- valid only for numeric arrays, returns the mean as a `Double` (`NA`'s are ignored)
      - arithmetic: `+ - * /`
         - Array with scalar will apply the operation to each element of the array.  `[1, 2, 3] * 2` = `[2, 4, 6]`.
-        - Array with Array will apply the operation positionally.  `[1, 2, 3] * [1, 0, -1]` = `[1, 0, -3]`.  _Fails if the dimension of the two arrays does not match._
+        - Array with Array will apply the operation positionally.  `[1, 2, 3] * [1, 0, -1]` = `[1, 0, -3]`.  _Fails if array dimensions do not match._
 
+ - Numeric Array and Numeric Set Operations (`NA` values are ignored):
+     - sum: `arr.sum` -- returns the sum, 0 if empty
+     - min: `arr.min` -- returns the minimum, missing if empty
+     - max: `arr.max` -- returns the maximum, missing if empty
+     - mean: `arr.mean` -- returns the mean as a `Double`, missing if empty
+     - median: `arr.median` -- returns the median, missing if empty. Element type is preserved so the median of `[0, 3]` is `(0 + 3) / 2 = 1`. To get `1.5` instead, use `arr.map(_.toDouble).median`
+ 
  - Set Operations:
      - contains: `set.contains(elem)` -- returns true if the element is contained in the array, otherwise false
      - size: `set.size` -- returns the number of elements in the set as an integer
      - isEmpty: `set.isEmpty` -- returns true if the set contains 0 elements
      - equals: `set1 == set2` -- returns true if both sets contain the same elements
-     - min: `set.min` -- valid only for numeric sets, returns the minimum value
-     - max: `set.max` -- valid only for numeric sets, returns the minimum value
      - find: `set.find(v => expr)` -- Returns the first non-missing element of `set` for which `expr` is true.  If no element satisfies the predicate, `find` returns NA.
      - map: `set.map(v => expr)` -- Returns a new set produced by applying `expr` to each element
      - flatMap: `set.flatMap(v => expr)` -- valid only for `expr` of type Set. Returns a new set by mapping each element of `set` and taking the union of the resulting sets

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -536,15 +536,15 @@ object FunctionRegistry {
   registerUnaryNAFilteredCollectionMethod("sum", { (x: TraversableOnce[Float]) => x.sum })
   registerUnaryNAFilteredCollectionMethod("sum", { (x: TraversableOnce[Double]) => x.sum })
 
-  registerUnaryNAFilteredCollectionMethod("min", { (x: TraversableOnce[Int]) => x.min })
-  registerUnaryNAFilteredCollectionMethod("min", { (x: TraversableOnce[Long]) => x.min })
-  registerUnaryNAFilteredCollectionMethod("min", { (x: TraversableOnce[Float]) => x.min })
-  registerUnaryNAFilteredCollectionMethod("min", { (x: TraversableOnce[Double]) => x.min })
+  registerUnaryNAFilteredCollectionMethod("min", { (x: TraversableOnce[Int]) => if (x.nonEmpty) x.min else null })(intHr, boxedintHr)
+  registerUnaryNAFilteredCollectionMethod("min", { (x: TraversableOnce[Long]) => if (x.nonEmpty) x.min else null })(longHr, boxedlongHr)
+  registerUnaryNAFilteredCollectionMethod("min", { (x: TraversableOnce[Float]) => if (x.nonEmpty) x.min else null })(floatHr, boxedfloatHr)
+  registerUnaryNAFilteredCollectionMethod("min", { (x: TraversableOnce[Double]) => if (x.nonEmpty) x.min else null })(doubleHr, boxeddoubleHr)
 
-  registerUnaryNAFilteredCollectionMethod("max", { (x: TraversableOnce[Int]) => x.max })
-  registerUnaryNAFilteredCollectionMethod("max", { (x: TraversableOnce[Long]) => x.max })
-  registerUnaryNAFilteredCollectionMethod("max", { (x: TraversableOnce[Float]) => x.max })
-  registerUnaryNAFilteredCollectionMethod("max", { (x: TraversableOnce[Double]) => x.max })
+  registerUnaryNAFilteredCollectionMethod("max", { (x: TraversableOnce[Int]) => if (x.nonEmpty) x.max else null })(intHr, boxedintHr)
+  registerUnaryNAFilteredCollectionMethod("max", { (x: TraversableOnce[Long]) => if (x.nonEmpty) x.max else null })(longHr, boxedlongHr)
+  registerUnaryNAFilteredCollectionMethod("max", { (x: TraversableOnce[Float]) => if (x.nonEmpty) x.max else null })(floatHr, boxedfloatHr)
+  registerUnaryNAFilteredCollectionMethod("max", { (x: TraversableOnce[Double]) => if (x.nonEmpty) x.max else null })(doubleHr, boxeddoubleHr)
 
   registerUnaryNAFilteredCollectionMethod("median", { (x: TraversableOnce[Int]) => breeze.stats.median(DenseVector(x.toArray)) })
   registerUnaryNAFilteredCollectionMethod("median", { (x: TraversableOnce[Long]) => breeze.stats.median(DenseVector(x.toArray)) })

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -546,15 +546,15 @@ object FunctionRegistry {
   registerUnaryNAFilteredCollectionMethod("max", { (x: TraversableOnce[Float]) => if (x.nonEmpty) x.max else null })(floatHr, boxedfloatHr)
   registerUnaryNAFilteredCollectionMethod("max", { (x: TraversableOnce[Double]) => if (x.nonEmpty) x.max else null })(doubleHr, boxeddoubleHr)
 
-  registerUnaryNAFilteredCollectionMethod("median", { (x: TraversableOnce[Int]) => breeze.stats.median(DenseVector(x.toArray)) })
-  registerUnaryNAFilteredCollectionMethod("median", { (x: TraversableOnce[Long]) => breeze.stats.median(DenseVector(x.toArray)) })
-  registerUnaryNAFilteredCollectionMethod("median", { (x: TraversableOnce[Float]) => breeze.stats.median(DenseVector(x.toArray)) })
-  registerUnaryNAFilteredCollectionMethod("median", { (x: TraversableOnce[Double]) => breeze.stats.median(DenseVector(x.toArray)) })
+  registerUnaryNAFilteredCollectionMethod("median", { (x: TraversableOnce[Int]) => if (x.nonEmpty) breeze.stats.median(DenseVector(x.toArray)) else null })(intHr, boxedintHr)
+  registerUnaryNAFilteredCollectionMethod("median", { (x: TraversableOnce[Long]) => if (x.nonEmpty) breeze.stats.median(DenseVector(x.toArray)) else null })(longHr, boxedlongHr)
+  registerUnaryNAFilteredCollectionMethod("median", { (x: TraversableOnce[Float]) => if (x.nonEmpty) breeze.stats.median(DenseVector(x.toArray)) else null })(floatHr, boxedfloatHr)
+  registerUnaryNAFilteredCollectionMethod("median", { (x: TraversableOnce[Double]) => if (x.nonEmpty) breeze.stats.median(DenseVector(x.toArray)) else null })(doubleHr, boxeddoubleHr)
 
-  registerUnaryNAFilteredCollectionMethod("mean", { (x: TraversableOnce[Int]) => x.sum / x.size.toDouble })
-  registerUnaryNAFilteredCollectionMethod("mean", { (x: TraversableOnce[Long]) => x.sum / x.size.toDouble })
-  registerUnaryNAFilteredCollectionMethod("mean", { (x: TraversableOnce[Float]) => x.sum / x.size.toDouble })
-  registerUnaryNAFilteredCollectionMethod("mean", { (x: TraversableOnce[Double]) => x.sum / x.size })
+  registerUnaryNAFilteredCollectionMethod("mean", { (x: TraversableOnce[Int]) => if (x.nonEmpty) x.sum / x.size.toDouble else null })(intHr, boxeddoubleHr)
+  registerUnaryNAFilteredCollectionMethod("mean", { (x: TraversableOnce[Long]) => if (x.nonEmpty) x.sum / x.size.toDouble else null })(longHr, boxeddoubleHr)
+  registerUnaryNAFilteredCollectionMethod("mean", { (x: TraversableOnce[Float]) => if (x.nonEmpty) x.sum / x.size.toDouble else null })(floatHr, boxeddoubleHr)
+  registerUnaryNAFilteredCollectionMethod("mean", { (x: TraversableOnce[Double]) => if (x.nonEmpty) x.sum / x.size.toDouble else null })(doubleHr, boxeddoubleHr)
 
   register("range", { (x: Int) => 0 until x: IndexedSeq[Int] })
   register("range", { (x: Int, y: Int) => x until y: IndexedSeq[Int] })

--- a/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -321,6 +321,12 @@ class ExprSuite extends SparkSuite {
     assert(eval[Int]("""a.min""").contains(-1))
     assert(eval[Int]("""a.max""").contains(8))
     assert(eval[Int]("""a.median""").contains(3))
+    println(eval[Int]("""emptyarr.sum"""))
+    println(eval[Int]("""emptyarr.mean"""))
+    println(eval[Int]("""emptyarr.min"""))
+    println(eval[Int]("""emptyarr.max"""))
+    println(eval[Int]("""emptyarr.median"""))
+
     assert(eval[Double]("""a.mean""").contains(22/7.0))
     assert(eval[Int]("""a.sum""").contains(IndexedSeq(1, 2, 6, 3, 3, -1, 8).sum))
     assert(eval[String]("""str(i)""").contains("5"))

--- a/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -321,11 +321,18 @@ class ExprSuite extends SparkSuite {
     assert(eval[Int]("""a.min""").contains(-1))
     assert(eval[Int]("""a.max""").contains(8))
     assert(eval[Int]("""a.median""").contains(3))
-    println(eval[Int]("""emptyarr.sum"""))
-    println(eval[Int]("""emptyarr.mean"""))
-    println(eval[Int]("""emptyarr.min"""))
-    println(eval[Int]("""emptyarr.max"""))
-    println(eval[Int]("""emptyarr.median"""))
+
+    assert(eval[Int]("""emptyarr.sum""").contains(0))
+    assert(eval[Int]("""emptyarr.mean""").isEmpty)
+    assert(eval[Int]("""emptyarr.min""").isEmpty)
+    assert(eval[Int]("""emptyarr.max""").isEmpty)
+    assert(eval[Int]("""emptyarr.median""").isEmpty)
+
+    assert(eval[Int]("""emptyset.sum""").contains(0))
+    assert(eval[Int]("""emptyset.mean""").isEmpty)
+    assert(eval[Int]("""emptyset.min""").isEmpty)
+    assert(eval[Int]("""emptyset.max""").isEmpty)
+    assert(eval[Int]("""emptyset.median""").isEmpty)
 
     assert(eval[Double]("""a.mean""").contains(22/7.0))
     assert(eval[Int]("""a.sum""").contains(IndexedSeq(1, 2, 6, 3, 3, -1, 8).sum))


### PR DESCRIPTION
fixed numeric aggregations behavior on empty arrays and sets
- modified min, max, mean, and median functions in FunctionRegistry
- added regression tests for empty sets and empty arrays to ExprSuite
- updated and refactored ExpressionLanguage docs to reflect changes