### PR TITLE
speed up genotype parsing

### DIFF
--- a/src/main/scala/is/hail/variant/Genotype.scala
+++ b/src/main/scala/is/hail/variant/Genotype.scala
@@ -545,10 +545,16 @@ object Genotype {
     val dp =
       if (flagHasDP(flags)) {
         if (flagHasAD(flags)) {
+          var i = 0
+          var adsum = 0
+          while (i < ad.length) {
+            adsum += ad(i)
+            i += 1
+          }
           if (flagSimpleDP(flags))
-            ad.sum
+            adsum
           else
-            ad.sum + a.readULEB128()
+            adsum + a.readULEB128()
         } else
           a.readULEB128()
       } else


### PR DESCRIPTION
This was identified as a cost center during my compiler investigations. The effect is not measurable on the standard benchmark [1]. More investigation is needed. As we improve the performance of the expression language, I suspect this will constitute a more significant fraction of execution time.

[1]:
```
filtergenotypes -c ' g.dp > 400 ||
     (g.isHomRef && (g.ad[0] / g.dp < 0.9 || g.gq < 20)) ||
     (g.isHomVar && (g.ad[1] / g.dp < 0.9 || g.pl[0] < 20)) ||
     (g.isHet && ( (g.ad[0] + g.ad[1]) / g.dp < 0.9 || g.ad[1] / g.dp < 0.20 || g.pl[0] < 20 ))' --keep
```