### PR TITLE
improve variable names in VariantPackage object

### DIFF
--- a/src/main/scala/is/hail/variant/package.scala
+++ b/src/main/scala/is/hail/variant/package.scala
@@ -7,28 +7,28 @@ import scala.language.implicitConversions
 package object variant {
   type VariantDataset = VariantSampleMatrix[Genotype]
 
-  class RichIterableGenotype(val git: Iterable[Genotype]) extends AnyVal {
+  class RichIterableGenotype(val ig: Iterable[Genotype]) extends AnyVal {
     def toGenotypeStream(v: Variant, isDosage: Boolean, compress: Boolean): GenotypeStream =
-      git match {
+      ig match {
         case gs: GenotypeStream => gs
         case _ =>
           val b: GenotypeStreamBuilder = new GenotypeStreamBuilder(v.nAlleles, isDosage = isDosage, compress = compress)
-          b ++= git
+          b ++= ig
           b.result()
       }
 
-    def hardCallIterator: IntIterator = git match {
+    def hardCallIterator: IntIterator = ig match {
       case gs: GenotypeStream => gs.gsHardCallIterator
       case _ =>
         new IntIterator {
-          val it: Iterator[Genotype] = git.iterator
+          val it: Iterator[Genotype] = ig.iterator
           override def hasNext: Boolean = it.hasNext
           override def nextInt(): Int = it.next().unboxedGT
         }
     }
   }
 
-  implicit def toRichIterableGenotype(it: Iterable[Genotype]): RichIterableGenotype = new RichIterableGenotype(it)
+  implicit def toRichIterableGenotype(ig: Iterable[Genotype]): RichIterableGenotype = new RichIterableGenotype(ig)
 
   implicit def toRichVDS(vsm: VariantDataset): RichVDS = new RichVDS(vsm)
 }


### PR DESCRIPTION
Our convention has been to reserve it for iterators, so I've changed `git` and `it` in #1325 (of type Iterable[Genotype]) to `ig`.