### PR TITLE
fix: include inttypes.h and __STDC_FORMAT_MACROS

### DIFF
--- a/src/main/c/test.cpp
+++ b/src/main/c/test.cpp
@@ -1,5 +1,5 @@
-#include <stdint.h>
-#include <stdio.h>
+#define __STDC_FORMAT_MACROS // see: http://stackoverflow.com/questions/8132399/how-to-printf-uint64-t and https://sourceware.org/bugzilla/show_bug.cgi?id=15366
+#include <inttypes.h> i#include <stdio.h>
 #include <stdlib.h>
 #include "ibs.h"
 


### PR DESCRIPTION
`inttypes.h` is definitely needed for standards compliant usage of
printf format strings. The latter is safe, but should not be necessary
on recent C++ compilers with recent stdlibs.

Compiling with a C++ compiler and a somewhat old version of glibc will
not provide PRIu64 and friends unless this macro is defined before
including `inttypes.h`. For more details see [1] with associated comments
and the related bug fix [2] which landed in glibc 2.18.

[1] http://stackoverflow.com/questions/8132399/how-to-printf-uint64-t
[2] https://sourceware.org/bugzilla/show_bug.cgi?id=15366