### PR TITLE
Send correct types to Java in vep

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -3249,7 +3249,7 @@ class VariantDataset(object):
         pargs = ['vep', '--config', config]
         if block_size:
             pargs.append('--block-size')
-            pargs.append(block_size)
+            pargs.append(str(block_size))
         if root:
             pargs.append('--root')
             pargs.append(root)


### PR DESCRIPTION
This prevents an error in _run_command where we attempt to put an int into an array of `java.lang.String`s