### PR TITLE
specify desired C++ compatibility

### DIFF
--- a/python/hail/docs/getting_started.rst
+++ b/python/hail/docs/getting_started.rst
@@ -9,7 +9,7 @@ You'll need:
 - The `Java 8 JDK <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`_.
 - `Spark 2.0.2 <http://spark.apache.org/downloads.html>`_. Hail should work with other versions of Spark 2, see below.
 - Python 2.7 and IPython. We recommend the free `Anaconda distribution <https://www.continuum.io/downloads>`_.
-- `CMake <http://cmake.org>`_ and a C++ compiler.
+- `CMake <http://cmake.org>`_ and a C++ compiler that supports `-std=c++11` (we recommend at least GCC 4.7 or Clang 3.3).
 
   On a Debian-based Linux OS like Ubuntu, run:
 

--- a/python/hail/docs/getting_started.rst
+++ b/python/hail/docs/getting_started.rst
@@ -9,7 +9,7 @@ You'll need:
 - The `Java 8 JDK <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`_.
 - `Spark 2.0.2 <http://spark.apache.org/downloads.html>`_. Hail should work with other versions of Spark 2, see below.
 - Python 2.7 and IPython. We recommend the free `Anaconda distribution <https://www.continuum.io/downloads>`_.
-- `CMake <http://cmake.org>`_ and a C++ compiler that supports `-std=c++11` (we recommend at least GCC 4.7 or Clang 3.3).
+- `CMake <http://cmake.org>`_ and a C++ compiler that supports ``-std=c++11`` (we recommend at least GCC 4.7 or Clang 3.3).
 
   On a Debian-based Linux OS like Ubuntu, run:
 


### PR DESCRIPTION
Based on https://clang.llvm.org/cxx_status.html and https://gcc.gnu.org/gcc-4.7/cxx0x_status.html Clang 3.3 and GCC 4.7 should be sufficient to prevent compile errors arising from not supporting C++11 features.


FYI @cseed @tpoterba 