### PR TITLE
Fix PipelineSuite file io race

### DIFF
--- a/src/main/scala/is/hail/utils/TempDir.scala
+++ b/src/main/scala/is/hail/utils/TempDir.scala
@@ -13,7 +13,9 @@ object TempDir {
       try {
         val dir = tmpdir + "/hail." + Random.alphanumeric.take(12).mkString
 
-        hConf.mkDir(dir)
+        // assert true == assert created a new directory (as opposed to the
+        // directory already existing)
+        assert(hConf.mkDir(dir))
 
         val fs = hConf.fileSystem(tmpdir)
         val qDir = fs.makeQualified(new hadoop.fs.Path(dir))

--- a/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
@@ -51,7 +51,10 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
     files.forall(filename => fileSystem(filename).exists(new hadoop.fs.Path(filename)))
   }
 
-  def mkDir(dirname: String) {
+  /**
+    * @return true if a new directory was created, false otherwise
+    **/
+  def mkDir(dirname: String): Boolean = {
     fileSystem(dirname).mkdirs(new hadoop.fs.Path(dirname))
   }
 


### PR DESCRIPTION
If you follow the call path of a `org.apache.hadoop.fs.LocalFileSystem.mkdirs`,
you'll find that it's actually implemented on
`org.apache.hadoop.fs.FilterFileSystem` which implements it in terms of some
internal `fs` variable, which in `LocalFileSystem`'s case is
`org.apache.hadoop.fs.RawLocalFileSystem`. This class has `mkOneDirWithMode`,
which delegates to `java.io.File`. Now we're at ground truth. This is a well
 documented Java API. It returns true if the directory was created, false
otherwise. No `IOException`s. Going back up through the callstack, we find that
`IOException`s are thrown for a variety of unusual circumstances (like if
you're creating `/foo/bar/baz` and `/foo/bar` is a file that isn't a
directory), but, ultimately, if the directory *already exists* `mkdirs`
returns `false`, it does *not* throw an `IOException`.