### PR TITLE
Added set_va_attributes to expose setting Field attributes

### DIFF
--- a/docs/reference/HailExpressionLanguage.md
+++ b/docs/reference/HailExpressionLanguage.md
@@ -108,6 +108,7 @@ Several Hail commands provide the ability to perform a broad array of computatio
      - filter: `set.filter(v => expr)` -- Returns a new set subsetted to the elements where `expr` evaluated to true
      - exists: `set.exists(v => expr)` -- Returns a boolean which is true if **any** element satisfies `expr`, false otherwise
      - forall: `set.forall(v => expr)` -- returns a boolean which is true if the set is empty, or `expr` evaluates to `true` for **every** element
+     - toArray: `set.toArray` -- Returns an `Array` containing the elements of the set
 
  - Dict Operations:
      - select: `dict[key]` -- returns the value keyed by the string `key`.  Example: `global.genemap["SCN2A"]`.  This method will fail if the key is not contained in the dict.

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -3199,7 +3199,7 @@ class VariantDataset(object):
         """
 
         try:
-            return VariantDataset(self.hc, self._jvds.setVAattribute(root,key,value))
+            return VariantDataset(self.hc, self._jvds.setVAattribute(ann_path,key,value))
         except Py4JJavaError as e:
             raise_py4j_exception(e)
 

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -3160,17 +3160,46 @@ class VariantDataset(object):
 
         self.hc._run_command(self, ['sparkinfo'])
 
-    def set_va_attribute(self, code, key, value):
+    def set_va_attribute(self, ann_path, key, value):
         """Sets an attribute for a variant annotation signature.
         Attributes are key/value pairs that can be attached to a variant annotation field.
         Of note, the following attributes are used to generate the VCF header when using export_vcf:
         - INFO fields attributes (attached to (`va.info.XXX`)):
             - 'Number' (default is `0` for **Boolean**, `.` for **Arrays** and 1 for all other types)
             - 'Description' (default is '')
-        - FILTER entries in the VCF header are generated based on the attributes of `va.filters`. Each key/value pair in the attributes will generate a FILTER entry in the VCF with ID = key and Description = value."""
+        - FILTER entries in the VCF header are generated based on the attributes of `va.filters`. Each key/value pair in the attributes will generate a FILTER entry in the VCF with ID = key and Description = value.
+
+        **Examples**
+
+        Consider the following command which adds an INFO field `test` and a filter `random` with probability 0.5:
+        >>> vds = (hc.import_vcf('data/sample.vcf')
+        >>>   .annotate_variants_expr(['va.info.test = "test"', 'va.filters = if(pcoin(0.5)) va.filters else [va.filters,["random"].toSet].toSet.flatten'])
+
+        If we now export this VDS as VCF, it would (1) be missing the FILTER entry and (2) the INFO line for our new field `test` would be:
+        ```
+        ##INFO=<ID=test,Number=1,Type=String,Description=""
+        ```
+
+        We can now set the attributes:
+        >>> vds = (vds.set_va_attributes('va.info.test','Description','This is a test for setting attributes.')
+        >>>           .set_va_attributes('va.filters','random','This is a random filter with probability 0.5'))
+
+        Exporting the VDS with the attributes now prints the following header lines:
+        ```
+        ##INFO=<ID=test,Number=1,Type=String,Description="This is a test for setting attributes."
+        ##FILTER=<ID=random,Description="This is a random filter with probability 0.5">
+        ```
+
+        :param str ann_path: Path to variant annotation beginning with `va`.
+        :param str key: Attribute key.
+        :param str value: Attribute value.
+
+        :return: Annotated dataset with new sample qc annotations.
+        :rtype: :class:`.VariantDataset`
+        """
 
         try:
-            return VariantDataset(self.hc, self._jvds.setVAattribute(code,key,value))
+            return VariantDataset(self.hc, self._jvds.setVAattribute(root,key,value))
         except Py4JJavaError as e:
             raise_py4j_exception(e)
 

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -1555,7 +1555,7 @@ class VariantDataset(object):
             pargs.append('--overwrite')
         self.hc._run_command(self, pargs)
 
-    def filter_alleles(self, condition, annotation=None, subset=True, keep=True, 
+    def filter_alleles(self, condition, annotation=None, subset=True, keep=True,
                        filter_altered_genotypes=False, max_shift=100):
         """Filter a user-defined set of alternate alleles for each variant.
         If all alternate alleles of a variant are filtered, the
@@ -1704,7 +1704,7 @@ class VariantDataset(object):
 
         if filter_altered_genotypes:
             pargs.append('--filterAlteredGenotypes')
-            
+
         pargs.extend(['--max-shift', str(max_shift)])
 
         return self.hc._run_command(self, pargs)
@@ -3159,6 +3159,20 @@ class VariantDataset(object):
         """Displays the number of partitions and persistence level of the dataset."""
 
         self.hc._run_command(self, ['sparkinfo'])
+
+    def set_va_attribute(self, code, key, value):
+        """Sets an attribute for a variant annotation signature.
+        Attributes are key/value pairs that can be attached to a variant annotation field.
+        Of note, the following attributes are used to generate the VCF header when using export_vcf:
+        - INFO fields attributes (attached to (`va.info.XXX`)):
+            - 'Number' (default is `0` for **Boolean**, `.` for **Arrays** and 1 for all other types)
+            - 'Description' (default is '')
+        - FILTER entries in the VCF header are generated based on the attributes of `va.filters`. Each key/value pair in the attributes will generate a FILTER entry in the VCF with ID = key and Description = value."""
+
+        try:
+            return VariantDataset(self.hc, self._jvds.setVAattribute(code,key,value))
+        except Py4JJavaError as e:
+            raise_py4j_exception(e)
 
     def split_multi(self, propagate_gq=False, keep_star_alleles=False, max_shift=100):
         """Split multiallelic variants.

--- a/src/main/scala/is/hail/driver/AnnotateAllelesExpr.scala
+++ b/src/main/scala/is/hail/driver/AnnotateAllelesExpr.scala
@@ -90,6 +90,9 @@ object AnnotateAllelesExpr extends Command {
       }
 
     }.copy(vaSignature = finalType)
-    state.copy(vds = annotated)
+
+    state.copy(vds = annotated.copy(
+      vaSignature = paths.foldLeft(annotated.vaSignature.asInstanceOf[TStruct])({
+        case (res, path) => res.setFieldAttributes(path,Map("Number" -> "A")) })))
   }
 }

--- a/src/main/scala/is/hail/driver/ExportVCF.scala
+++ b/src/main/scala/is/hail/driver/ExportVCF.scala
@@ -66,7 +66,7 @@ object ExportVCF extends Command {
         case t =>
           sb.append(f.name)
           sb += '='
-          sb.append(t.str(value))
+          sb.append(t.strVCF(value))
           true
       }
   }

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -631,6 +631,26 @@ case class TStruct(fields: IndexedSeq[Field]) extends Type {
         f.flatMap(_.typ.fieldOption(path.tail))
     }
 
+  def setFieldAttributes(path: List[String], kv: Map[String, String]): TStruct = {
+
+    if (path.isEmpty)
+      throw new AnnotationPathException(s"Empty path for attribute annotation is not allowed.")
+
+    if (!hasField(path.head))
+      throw new AnnotationPathException(s"struct has no field ${ path.head }")
+
+    this.copy(fields.map({
+      f => if (f.name == path.head){
+        if(path.length == 1)
+          f.copy(attrs = f.attrs ++ kv)
+        else
+          f.copy(typ = f.typ.asInstanceOf[TStruct].setFieldAttributes(path.tail, kv))
+      }
+      else
+        f
+    }))
+  }
+
   override def query(p: List[String]): Querier = {
     if (p.isEmpty)
       a => Option(a)

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -865,7 +865,7 @@ case class TStruct(fields: IndexedSeq[Field]) extends Type {
         Annotation.fromSeq(newValues)
       }
 
-    (TStruct(newFields), filterer)
+    (TStruct(newFields.zipWithIndex.map({case (f,i) => f.copy(index = i)})), filterer)
   }
 
   override def toString = if (size == 0) "Empty" else "Struct"

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -222,6 +222,18 @@ case object TFloat extends TNumeric {
 
   override def str(a: Annotation): String = if (a == null) "NA" else a.asInstanceOf[Float].formatted("%.5e")
 
+  override def strVCF(a: Annotation): String = {
+    if (a == null)
+      "."
+    else {
+      val f = a.asInstanceOf[Float]
+      if (f.isNaN)
+        "."
+      else
+        f.formatted("%.5e")
+    }
+  }
+
   override def genValue: Gen[Annotation] = arbitrary[Double].map(_.toFloat)
 
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double): Boolean =
@@ -236,6 +248,18 @@ case object TDouble extends TNumeric {
   def typeCheck(a: Any): Boolean = a == null || a.isInstanceOf[Double]
 
   override def str(a: Annotation): String = if (a == null) "NA" else a.asInstanceOf[Double].formatted("%.5e")
+
+  override def strVCF(a: Annotation): String = {
+    if (a == null)
+      "."
+    else {
+      val f = a.asInstanceOf[Double]
+      if (f.isNaN)
+        "."
+      else
+        f.formatted("%.5e")
+    }
+  }
 
   override def genValue: Gen[Annotation] = arbitrary[Double]
 

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -129,7 +129,7 @@ sealed abstract class Type {
 
   def str(a: Annotation): String = if (a == null) "NA" else a.toString
 
-  def strVCF(a: Annotation): String = if (a == null) "." else a.toString
+  def strVCF(a: Annotation): String = if (a == null) "." else str(a)
 
   def toJSON(a: Annotation): JValue = JSONAnnotationImpex.exportAnnotation(a, this)
 
@@ -841,7 +841,7 @@ case class TStruct(fields: IndexedSeq[Field]) extends Type {
     val newFields = fields.zip(included)
       .flatMap { case (field, incl) =>
         if (incl)
-          Some(field.name -> field.typ)
+          Some(field)
         else
           None
       }
@@ -865,7 +865,7 @@ case class TStruct(fields: IndexedSeq[Field]) extends Type {
         Annotation.fromSeq(newValues)
       }
 
-    (TStruct(newFields: _*), filterer)
+    (TStruct(newFields), filterer)
   }
 
   override def toString = if (size == 0) "Empty" else "Struct"

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -12,7 +12,7 @@ import is.hail.utils._
 import is.hail.driver.{HailConfiguration, Main}
 import is.hail.annotations._
 import is.hail.check.Gen
-import is.hail.expr.{EvalContext, _}
+import is.hail.expr.{EvalContext, TStruct, _}
 import is.hail.io.vcf.BufferedLineIterator
 import is.hail.sparkextras._
 import org.json4s._
@@ -969,6 +969,22 @@ class VariantSampleMatrix[T](val metadata: VariantMetadata,
 
   def insertGlobal(sig: Type, path: List[String]): (Type, Inserter) = {
     globalSignature.insert(sig, path)
+  }
+
+  def setVAattribute(path: String, key: String, value: String): VariantSampleMatrix[T] = {
+    setVAattributes(path, Map(key -> value))
+  }
+
+  def setVAattribute(path: List[String], key: String, value: String): VariantSampleMatrix[T] = {
+    setVAattributes(path, Map(key -> value))
+  }
+
+  def setVAattributes(path: String, kv: Map[String, String]): VariantSampleMatrix[T] = {
+    setVAattributes(Parser.parseAnnotationRoot(path, Annotation.VARIANT_HEAD), kv)
+  }
+
+  def setVAattributes(path: List[String], kv: Map[String, String]): VariantSampleMatrix[T] = {
+    this.copy(vaSignature = vaSignature.asInstanceOf[TStruct].setFieldAttributes(path, kv))
   }
 
   override def toString = s"VariantSampleMatrix(metadata=$metadata, rdd=$rdd, sampleIds=$sampleIds, nSamples=$nSamples, vaSignature=$vaSignature, saSignature=$saSignature, globalSignature=$globalSignature, sampleAnnotations=$sampleAnnotations, sampleIdsAndAnnotations=$sampleIdsAndAnnotations, globalAnnotation=$globalAnnotation, wasSplit=$wasSplit)"


### PR DESCRIPTION
Needed to output correct VCF Header
In addition:
- Annotations generated using annotate_alleles_expr now have 'Number=A'
- VEP now parses the Description when using csq=True option (required to know the fields stored in the  |-delimited field)
- VEP annotations with csq=True option is now of type Array[String]. (how it should be)