### PR TITLE
Improved logreg code, added Firth

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -2546,7 +2546,7 @@ class VariantDataset(object):
 
         For Boolean covariate types, true is coded as 1 and false as 0. In particular, for the sample annotation ``sa.fam.isCase`` added by importing a FAM file with case-control phenotype, case is 1 and control is 0.
 
-        Hail's logistic regression tests correspond to the ``b.wald``, ``b.lrt``, and ``b.score`` tests in `EPACTS <http://genome.sph.umich.edu/wiki/EPACTS#Single_Variant_Tests>`_. For each variant, Hail imputes missing genotypes as the mean of called genotypes, whereas EPACTS subsets to those samples with called genotypes. Hence, Hail and EPACTS results will currently only agree for variants with no missing genotypes.
+        Hail's logistic regression tests correspond to the ``b.wald``, ``b.lrt``, ``b.firth``, and ``b.score`` tests in `EPACTS <http://genome.sph.umich.edu/wiki/EPACTS#Single_Variant_Tests>`_. For each variant, Hail imputes missing genotypes as the mean of called genotypes, whereas EPACTS subsets to those samples with called genotypes. Hence, Hail and EPACTS results will currently only agree for variants with no missing genotypes.
 
         See `Recommended joint and meta-analysis strategies for case-control association testing of single low-count variants <http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4049324/>`_ for an empirical comparison of the logistic Wald, LRT, score, and Firth tests. The theoretical foundations of the Wald, likelihood ratio, and score tests may be found in Chapter 3 of Gesine Reinert's notes `Statistical Theory <http://www.stats.ox.ac.uk/~reinert/stattheory/theoryshort09.pdf>`_.
 

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -2496,19 +2496,22 @@ class VariantDataset(object):
         LRT   ``va.logreg.lrt.beta``   Double fit genotype coefficient, :math:`\hat\\beta_1`
         LRT   ``va.logreg.lrt.chi2``   Double likelihood ratio test statistic (deviance) testing :math:`\\beta_1 = 0`
         LRT   ``va.logreg.lrt.pval``   Double likelihood ratio test p-value
+        Firth ``va.logreg.firth.beta``   Double fit genotype coefficient, :math:`\hat\\beta_1`
+        Firth ``va.logreg.firth.chi2``   Double Firth statistic testing :math:`\\beta_1 = 0`
+        Firth ``va.logreg.firth.pval``   Double Firth test p-value
         Score ``va.logreg.score.chi2`` Double score statistic testing :math:`\\beta_1 = 0`
         Score ``va.logreg.score.pval`` Double score test p-value
         ===== ======================== ====== =====
 
-        For the Wald and likelihood ratio tests, Hail fits the logistic model for each variant using Newton iteration and only emits the above annotations when the maximum likelihood estimate of the coefficients converges. To help diagnose convergence issues, Hail also emits three variant annotations which summarize the iterative fitting process:
+        For the Wald and likelihood ratio tests, Hail fits the logistic model for each variant using Newton iteration and only emits the above annotations when the maximum likelihood estimate of the coefficients converges. For the Firth test, Newton iteration is modified. To help diagnose convergence issues, Hail also emits three variant annotations which summarize the iterative fitting process:
 
-        ========= =========================== ======= =====
-        Test      Annotation                  Type    Value
-        ========= =========================== ======= =====
-        Wald, LRT ``va.logreg.fit.nIter``     Int     number of iterations until convergence, explosion, or reaching the max (25)
-        Wald, LRT ``va.logreg.fit.converged`` Boolean true if iteration converged
-        Wald, LRT ``va.logreg.fit.exploded``  Boolean true if iteration exploded
-        ========= =========================== ======= =====
+        ================ =========================== ======= =====
+        Test             Annotation                  Type    Value
+        ================ =========================== ======= =====
+        Wald, LRT, Firth ``va.logreg.fit.nIter``     Int     number of iterations until convergence, explosion, or reaching the max (25)
+        Wald, LRT, Firth ``va.logreg.fit.converged`` Boolean true if iteration converged
+        Wald, LRT, Firth ``va.logreg.fit.exploded``  Boolean true if iteration exploded
+        ================ =========================== ======= =====
 
         We consider iteration to have converged when every coordinate of :math:`\\beta` changes by less than :math:`10^{-6}`. Up to 25 iterations are attempted; in testing we find 4 or 5 iterations nearly always suffice. Convergence may also fail due to explosion, which refers to low-level numerical linear algebra exceptions caused by manipulating ill-conditioned matrices. Explosion may result from (nearly) linearly dependent covariates or complete `separation <https://en.wikipedia.org/wiki/Separation_(statistics)>`_.
 
@@ -2547,8 +2550,7 @@ class VariantDataset(object):
 
         See `Recommended joint and meta-analysis strategies for case-control association testing of single low-count variants <http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4049324/>`_ for an empirical comparison of the logistic Wald, LRT, score, and Firth tests. The theoretical foundations of the Wald, likelihood ratio, and score tests may be found in Chapter 3 of Gesine Reinert's notes `Statistical Theory <http://www.stats.ox.ac.uk/~reinert/stattheory/theoryshort09.pdf>`_.
 
-        :param str test: Statistical test, one of: wald, lrt, or score.
-
+        :param str test: Statistical test, one of: wald, lrt, firth, or score.
         :param str y: Response expression.  Must evaluate to Boolean or
             numeric with all values 0 or 1.
 

--- a/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -29,8 +29,6 @@ object LogisticRegression {
     if (!tests.isDefinedAt(test))
       fatal(s"Supported tests are ${tests.keys.mkString(", ")}, got: $test")
 
-    val useFirth = test == "firth"
-
     val n = y.size
     val k = cov.cols
     val d = n - k - 1

--- a/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -41,7 +41,7 @@ object LogisticRegression {
     info(s"Running logreg on $n samples with $k ${ plural(k, "covariate") } including intercept...")
 
     val nullModel = new LogisticRegressionModel(cov, y)
-    val nullFit = nullModel.nullFit(nullModel.bInterceptOnly(), useFirth=useFirth)
+    val nullFit = nullModel.fit(nullModel.bInterceptOnly())
 
     if (!nullFit.converged)
       fatal("Failed to fit logistic regression null model (covariates only): " + (
@@ -65,7 +65,7 @@ object LogisticRegression {
 
       val logRegAnnot =
         buildGtColumn(maskedGts).map { gts =>
-          val X = DenseMatrix.horzcat(gts, covBc.value)
+          val X = DenseMatrix.horzcat(covBc.value, gts)
           logRegTestBc.value.test(X, yBc.value, nullFitBc.value).toAnnotation
         }
 

--- a/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -39,11 +39,7 @@ object LogisticRegression {
     info(s"Running $test logreg on $n samples with $k ${ plural(k, "covariate") } including intercept...")
 
     val nullModel = new LogisticRegressionModel(cov, y)
-    val nullFit = nullModel.fit(
-      nullModel.bInterceptOnly(),
-      computeScoreFisher = test == "score",
-      computeSe = test == "wald",
-      computeLogLkld = test == "lrt" || test == "firth")
+    val nullFit = nullModel.fit()
 
     if (!nullFit.converged)
       fatal("Failed to fit (unregulatized) logistic regression null model (covariates only): " + (

--- a/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -41,7 +41,7 @@ object LogisticRegression {
     val nullModel = new LogisticRegressionModel(cov, y)
     val nullFit = nullModel.fit(
       nullModel.bInterceptOnly(),
-      computeScoreR = test == "score",
+      computeScoreFisher = test == "score",
       computeSe = test == "wald",
       computeLogLkld = test == "lrt" || test == "firth")
 

--- a/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -29,6 +29,8 @@ object LogisticRegression {
     if (!tests.isDefinedAt(test))
       fatal(s"Supported tests are ${tests.keys.mkString(", ")}, got: $test")
 
+    val useFirth = test == "firth"
+
     val n = y.size
     val k = cov.cols
     val d = n - k - 1
@@ -39,7 +41,7 @@ object LogisticRegression {
     info(s"Running logreg on $n samples with $k ${ plural(k, "covariate") } including intercept...")
 
     val nullModel = new LogisticRegressionModel(cov, y)
-    val nullFit = nullModel.nullFit(nullModel.bInterceptOnly())
+    val nullFit = nullModel.nullFit(nullModel.bInterceptOnly(), useFirth=useFirth)
 
     if (!nullFit.converged)
       fatal("Failed to fit logistic regression null model (covariates only): " + (

--- a/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -16,7 +16,7 @@ object LogisticRegression {
     if (!vds.wasSplit)
       fatal("logreg requires bi-allelic VDS. Run split_multi or filter_multi first")
 
-    def tests = Map("wald" -> WaldTest, "lrt" -> LikelihoodRatioTest, "score" -> ScoreTest)
+    def tests = Map("wald" -> WaldTest, "lrt" -> LikelihoodRatioTest, "score" -> ScoreTest, "firth" -> FirthTest)
 
     val logRegTest = tests(test)
 

--- a/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -44,7 +44,7 @@ object LogisticRegression {
     val nullFit = nullModel.fit(nullModel.bInterceptOnly())
 
     if (!nullFit.converged)
-      fatal("Failed to fit logistic regression null model (covariates only): " + (
+      fatal("Failed to fit (unregulatized) logistic regression null model (covariates only): " + (
         if (nullFit.exploded)
          s"exploded at Newton iteration ${nullFit.nIter}"
         else

--- a/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -39,7 +39,11 @@ object LogisticRegression {
     info(s"Running $test logreg on $n samples with $k ${ plural(k, "covariate") } including intercept...")
 
     val nullModel = new LogisticRegressionModel(cov, y)
-    val nullFit = nullModel.fit(nullModel.bInterceptOnly())
+    val nullFit = nullModel.fit(
+      nullModel.bInterceptOnly(),
+      computeScoreR = test == "score",
+      computeSe = test == "wald",
+      computeLogLkld = test == "lrt" || test == "firth")
 
     if (!nullFit.converged)
       fatal("Failed to fit (unregulatized) logistic regression null model (covariates only): " + (

--- a/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -36,7 +36,7 @@ object LogisticRegression {
     if (d < 1)
       fatal(s"$n samples and $k ${plural(k, "covariate")} including intercept implies $d degrees of freedom.")
 
-    info(s"Running logreg on $n samples with $k ${ plural(k, "covariate") } including intercept...")
+    info(s"Running $test logreg on $n samples with $k ${ plural(k, "covariate") } including intercept...")
 
     val nullModel = new LogisticRegressionModel(cov, y)
     val nullFit = nullModel.fit(nullModel.bInterceptOnly())

--- a/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
+++ b/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
@@ -99,9 +99,9 @@ case class LikelihoodRatioStats(b: DenseVector[Double], chi2: Double, p: Double)
 
 
 object FirthTest extends LogisticRegressionTest {
-  def test(X: DenseMatrix[Double], y: DenseVector[Double], nullFit: LogisticRegressionFit): LogisticRegressionTestResultWithFit[LikelihoodRatioStats] = {
+  def test(X: DenseMatrix[Double], y: DenseVector[Double], nullFit: LogisticRegressionFit): LogisticRegressionTestResultWithFit[FirthStats] = {
     val model = new LogisticRegressionModel(X, y)
-    val fit = model.fit(nullFit.b)
+    val fit = model.fitFirth(nullFit.b)
 
     val firthStats =
       if (fit.converged) {
@@ -277,12 +277,12 @@ class LogisticRegressionModel(X: DenseMatrix[Double], y: DenseVector[Double]) {
     LogisticRegressionFit(b, score, fisher, logLkhd, 0, iter, converged, exploded)
   }
 
-  def nullFit(b0: DenseVector[Double] = DenseVector.zeros[Double](m), df: Int = 1, maxIter: Int = 25, tol: Double = 1E-6): LogisticRegressionFit = {
+  def nullFit(b0: DenseVector[Double] = DenseVector.zeros[Double](m), df: Int = 1, maxIter: Int = 25, tol: Double = 1E-6, useFirth: Boolean = false): LogisticRegressionFit = {
     val m = df + X.cols
     val b = DenseVector.zeros[Double](m)
     val score = DenseVector.zeros[Double](m)
     val fisher = DenseMatrix.zeros[Double](m, m)
-    val fit0 = fit(b0, maxIter, tol)
+    val fit0 = if (useFirth) fitFirth(b0, colsToFit = m - df + 1, maxIter=maxIter, tol=tol) else fit(b0, maxIter, tol) // FIXME: is colsToFit right?
 
     b(df until m) := fit0.b
     score(df until m) := fit0.score

--- a/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
+++ b/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
@@ -127,7 +127,9 @@ object FirthTest extends LogisticRegressionTest {
         val chi2 = 2 * (fitFirth.logLkhd - nullFitFirth.logLkhd)
         val p = chiSquaredTail(m - m0, chi2)
 
-        println(s"nullFitFirthb = ${nullFitFirth.b}")
+        println(s"nullFitFirthB = ${nullFitFirth.b}")
+        println(s"nullFitFirthScore = ${nullFitFirth.score}")
+        println(s"nullFitFirthFisher = ${nullFitFirth.fisher}")
         println(s"nullFitFirthLkhd = ${nullFitFirth.logLkhd}")
         println(s"fitFirthLkhd = ${fitFirth.logLkhd}")
         println(s"chi2 = $chi2")

--- a/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
+++ b/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
@@ -247,11 +247,12 @@ class LogisticRegressionModel(X: DenseMatrix[Double], y: DenseVector[Double]) {
     var converged = false
     var exploded = false
 
+    val X0 = X(::, 0 until colsToFit)
+
     while (!converged && !exploded && iter < maxIter) {
       try {
         iter += 1
 
-        val X0 = X(::, 0 until colsToFit)
         val mu = sigmoid(X0 * b)
         val XsqrtW = X(::,*) :* sqrt(mu :* (1d - mu))
         val QR = qr.reduced(XsqrtW)
@@ -282,7 +283,11 @@ class LogisticRegressionModel(X: DenseMatrix[Double], y: DenseVector[Double]) {
     val b = DenseVector.zeros[Double](m)
     val score = DenseVector.zeros[Double](m)
     val fisher = DenseMatrix.zeros[Double](m, m)
-    val fit0 = if (useFirth) fitFirth(b0, colsToFit = m - df + 1, maxIter=maxIter, tol=tol) else fit(b0, maxIter, tol) // FIXME: is colsToFit right?
+    val fit0 =
+      if (useFirth)
+        fitFirth(b0, colsToFit = m - df + 1, maxIter=maxIter, tol=tol)
+      else
+        fit(b0, maxIter, tol)
 
     b(df until m) := fit0.b
     score(df until m) := fit0.score

--- a/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
+++ b/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
@@ -117,29 +117,24 @@ object FirthTest extends LogisticRegressionTest {
     val model = new LogisticRegressionModel(X, y)
     val nullFitFirth = model.fitFirth(nullFit.b)
 
-    val nullFitFirthb = DenseVector.zeros[Double](m)
-    nullFitFirthb(0 until m0) := nullFitFirth.b
+    if (nullFitFirth.converged) {
+      val nullFitFirthb = DenseVector.zeros[Double](m)
+      nullFitFirthb(0 until m0) := nullFitFirth.b
 
-    val fitFirth = model.fitFirth(nullFitFirthb)
+      val fitFirth = model.fitFirth(nullFitFirthb)
 
-    val firthStats =
-      if (nullFitFirth.converged && fitFirth.converged) {
-        val chi2 = 2 * (fitFirth.logLkhd - nullFitFirth.logLkhd)
-        val p = chiSquaredTail(m - m0, chi2)
+      val firthStats =
+        if (fitFirth.converged) {
+          val chi2 = 2 * (fitFirth.logLkhd - nullFitFirth.logLkhd)
+          val p = chiSquaredTail(m - m0, chi2)
 
-        println(s"nullFitFirthB = ${nullFitFirth.b}")
-        println(s"nullFitFirthScore = ${nullFitFirth.score}")
-        println(s"nullFitFirthFisher = ${nullFitFirth.fisher}")
-        println(s"nullFitFirthLkhd = ${nullFitFirth.logLkhd}")
-        println(s"fitFirthLkhd = ${fitFirth.logLkhd}")
-        println(s"chi2 = $chi2")
-        println(s"p = $p")
+          Some(new FirthStats(fitFirth.b, chi2, p))
+        } else
+          None
 
-        Some(new FirthStats(fitFirth.b, chi2, p))
-      } else
-        None
-
-    new LogisticRegressionTestResultWithFit[FirthStats](firthStats, fitFirth) // FIXME: modify fit annotations to deal with fitting null as well
+      new LogisticRegressionTestResultWithFit[FirthStats](firthStats, fitFirth)
+    } else
+      new LogisticRegressionTestResultWithFit[FirthStats](None, nullFitFirth)
   }
 
   def `type` = TStruct(

--- a/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
+++ b/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
@@ -288,13 +288,12 @@ class LogisticRegressionModel(X: DenseMatrix[Double], y: DenseVector[Double]) {
         val QR = qr.reduced(XsqrtW)
         val sqrtH = norm(QR.q(*, ::))
         score = X0.t * (y - mu + (sqrtH :* sqrtH :* (0.5 - mu)))
-        val fisherSqrt = if (fitAll) QR.r else QR.r(::, 0 until m0)
+        fisherSqrt = QR.r(::, 0 until m0)
         deltaB = (fisherSqrt.t * fisherSqrt) \ score
 
         if (max(abs(deltaB)) < tol && iter > 1) {
           converged = true
-          val logDetFisherSqrtAll = if (fitAll) sum(log(diag(fisherSqrt))) else breeze.linalg.logdet(XsqrtW)._2
-          logLkhd = sum(breeze.numerics.log((y :* mu) + ((1d - y) :* (1d - mu)))) + logDetFisherSqrtAll
+          logLkhd = sum(breeze.numerics.log((y :* mu) + ((1d - y) :* (1d - mu)))) + sum(log(abs(diag(QR.r))))
         } else {
           iter += 1
           b += deltaB

--- a/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
+++ b/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
@@ -37,7 +37,7 @@ object WaldTest extends LogisticRegressionTest {
       try {
         val se = sqrt(diag(inv(fit.fisher)))
         val z = fit.b :/ se
-        val p = z.map(zi => chiSquaredTail(1, zi * zi)) // fixme: change to normal tail?
+        val p = z.map(zi => 2 * pnorm(-math.abs(zi)))
 
         Some(new WaldStats(fit.b, se, z, p))
       } catch {
@@ -284,7 +284,7 @@ class LogisticRegressionModel(X: DenseMatrix[Double], y: DenseVector[Double]) {
         val mu = sigmoid(X0 * b)
         val XsqrtW = X(::,*) :* sqrt(mu :* (1d - mu))
         val QR = qr.reduced(XsqrtW)
-        val sqrtH = norm(QR.q(*, ::)) // FIXME: implement norm2
+        val sqrtH = norm(QR.q(*, ::))
         score = X0.t * (y - mu + (sqrtH :* sqrtH :* (0.5 - mu)))
         val r = if (fitAll) QR.r else QR.r(::, 0 until m0)
         fisher = r.t * r

--- a/src/main/scala/is/hail/stats/eigSymD.scala
+++ b/src/main/scala/is/hail/stats/eigSymD.scala
@@ -136,21 +136,21 @@ object eigSymR extends UFunc {
   }
 }
 
-// FIXME: what assumptions does this make about B and A?
 object TriSolve {
-  /* Solve for X in A * X = B with upper triangular A
-  // http://www.netlib.org/lapack/explore-html/da/dba/group__double_o_t_h_e_rcomputational_ga4e87e579d3e1a56b405d572f868cd9a1.html
-   */
-  def apply(A: DenseMatrix[Double], B: DenseMatrix[Double]): DenseMatrix[Double] = {
-    require(A.rows == A.cols)
-    require(A.rows == B.rows)
+  /*
+  Solve for x in A * x = b with upper triangular A
+  http://www.netlib.org/lapack/explore-html/da/dba/group__double_o_t_h_e_rcomputational_ga4e87e579d3e1a56b405d572f868cd9a1.html
+  */
 
-    val X = B.copy
-    assert(!X.isTranspose)
+  def apply(A: DenseMatrix[Double], b: DenseVector[Double]): DenseVector[Double] = {
+    require(A.rows == A.cols)
+    require(A.rows == b.length)
+
+    val x = DenseVector(b.toArray)
 
     val info: Int = {
       val info = new intW(0)
-      lapack.dtrtrs("U", "N", "N", A.rows, B.cols, A.data, A.rows, X.data, X.rows, info) // X := A \ X
+      lapack.dtrtrs("U", "N", "N", A.rows, 1, A.toArray, A.rows, x.data, x.length, info) // x := A \ x
       info.`val`
     }
 
@@ -159,8 +159,6 @@ object TriSolve {
     else if (info < 0)
       throw new IllegalArgumentException()
 
-    X
+    x
   }
-
-  def apply(A: DenseMatrix[Double], v: DenseVector[Double]): DenseVector[Double] = new DenseVector(TriSolve(A, new DenseMatrix[Double](v.length, 1, v.data)).data)
 }

--- a/src/test/resources/regressionLogistic.R
+++ b/src/test/resources/regressionLogistic.R
@@ -28,12 +28,12 @@ scorePVal <- scorefit[["Pr(>Chi)"]][2]
 
 write.table(c(scoreChi2, scorePVal), args[4], row.names=FALSE, col.names=FALSE, sep="\t")
 
-#firthfit <- logistf(y ~ X, control=logistf.control(xconv=1e-8))
-#firthcoef <- firthfit["coefficients"]
+firthfit <- logistf(y ~ X, control=logistf.control(xconv=1e-8))
+firthcoef <- firthfit["coefficients"]
 
-#write.table(firthcoef, args[5], row.names=FALSE, col.names=FALSE, sep="\t")
+write.table(firthcoef, args[5], row.names=FALSE, col.names=FALSE, sep="\t")
 
-#firthloglik <- firthfit[["loglik"]]
-#firthpval <- logistftest(firthfit)[["prob"]]
+firthloglik <- firthfit[["loglik"]]
+firthpval <- logistftest(firthfit)[["prob"]]
 
-#write.table(c(firthloglik, firthpval), args[6], row.names=FALSE, col.names=FALSE, sep="\t")
+write.table(c(firthloglik, firthpval), args[6], row.names=FALSE, col.names=FALSE, sep="\t")

--- a/src/test/resources/regressionLogistic.R
+++ b/src/test/resources/regressionLogistic.R
@@ -1,5 +1,5 @@
 suppressPackageStartupMessages(library("jsonlite"))
-#suppressPackageStartupMessages(library("logistf"))
+suppressPackageStartupMessages(library("logistf"))
 
 args <- commandArgs(trailingOnly=TRUE)
 #args <- c("/tmp/input.json", "/tmp/wald.tsv", "/tmp/lrt.tsv", "/tmp/score.tsv", "/tmp/firthB.tsv", "/tmp/firthlrt.tsv")

--- a/src/test/scala/is/hail/methods/LogisticRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LogisticRegressionSuite.scala
@@ -292,9 +292,10 @@ class LogisticRegressionSuite extends SparkSuite {
       "-t", "PC1: Double, PC2: Double",
       "-e", "IND_ID"))
 
-    val vds = LogisticRegression(s.vds, "wald", "sa.fam.isCase", Array("sa.fam.isFemale", "sa.pc.PC1", "sa.pc.PC2"), "va.logreg")
-    val vds2 = LogisticRegression(vds, "lrt", "sa.fam.isCase", Array("sa.fam.isFemale", "sa.pc.PC1", "sa.pc.PC2"), "va.logreg2")
-    val vds3 = LogisticRegression(vds2, "score", "sa.fam.isCase", Array("sa.fam.isFemale", "sa.pc.PC1", "sa.pc.PC2"), "va.logreg3")
+    val vds = LogisticRegression(s.vds, "wald", "sa.fam.isCase", Array("sa.fam.isFemale", "sa.pc.PC1", "sa.pc.PC2"), "va.wald")
+    val vds2 = LogisticRegression(vds, "lrt", "sa.fam.isCase", Array("sa.fam.isFemale", "sa.pc.PC1", "sa.pc.PC2"), "va.lrt")
+    val vds3 = LogisticRegression(vds2, "score", "sa.fam.isCase", Array("sa.fam.isFemale", "sa.pc.PC1", "sa.pc.PC2"), "va.score")
+    val vds4 = LogisticRegression(vds3, "firth", "sa.fam.isCase", Array("sa.fam.isFemale", "sa.pc.PC1", "sa.pc.PC2"), "va.firth")
 
     // 2535 samples from 1K Genomes Project
     val v1 = Variant("22", 16060511, "T", "TTC") // MAC  623
@@ -303,14 +304,16 @@ class LogisticRegressionSuite extends SparkSuite {
     val v4 = Variant("22", 16117940, "T", "G")   // MAC    7
     val v5 = Variant("22", 16117953, "G", "C")   // MAC   21
 
-    val qBeta = vds3.queryVA("va.logreg.wald.beta")._2
-    val qSe = vds3.queryVA("va.logreg.wald.se")._2
-    val qZstat = vds3.queryVA("va.logreg.wald.zstat")._2
-    val qPVal = vds3.queryVA("va.logreg.wald.pval")._2
-    val qPValLR = vds3.queryVA("va.logreg2.lrt.pval")._2
-    val qPValScore = vds3.queryVA("va.logreg3.score.pval")._2
+    val qBeta = vds4.queryVA("va.wald.wald.beta")._2
+    val qSe = vds4.queryVA("va.wald.wald.se")._2
+    val qZstat = vds4.queryVA("va.wald.wald.zstat")._2
+    val qPVal = vds4.queryVA("va.wald.wald.pval")._2
+    val qPValLR = vds4.queryVA("va.lrt.lrt.pval")._2
+    val qPValScore = vds4.queryVA("va.score.score.pval")._2
+    val qBetaFirth = vds4.queryVA("va.firth.firth.beta")._2
+    val qPValFirth = vds4.queryVA("va.firth.firth.pval")._2
 
-    val annotationMap = vds3.variantsAndAnnotations
+    val annotationMap = vds4.variantsAndAnnotations
       .collect()
       .toMap
 
@@ -327,6 +330,8 @@ class LogisticRegressionSuite extends SparkSuite {
     assertDouble(qPVal, v1, 0.26516)
     assertDouble(qPValLR, v1, 0.26475)
     assertDouble(qPValScore, v1, 0.26499)
+    assertDouble(qBetaFirth, v1, -0.097079)
+    assertDouble(qPValFirth, v1, 0.26593)
 
     assertDouble(qBeta, v2, -0.052632)
     assertDouble(qSe, v2, 0.11272)
@@ -334,6 +339,8 @@ class LogisticRegressionSuite extends SparkSuite {
     assertDouble(qPVal, v2, 0.64056)
     assertDouble(qPValLR, v2, 0.64046)
     assertDouble(qPValScore, v2, 0.64054)
+    assertDouble(qBetaFirth, v2, -0.052301)
+    assertDouble(qPValFirth, v2, 0.64197)
 
     assertDouble(qBeta, v3, -0.15598)
     assertDouble(qSe, v3, 0.079508)
@@ -341,6 +348,8 @@ class LogisticRegressionSuite extends SparkSuite {
     assertDouble(qPVal, v3, 0.049779)
     assertDouble(qPValLR, v3, 0.049675)
     assertDouble(qPValScore, v3, 0.049717)
+    assertDouble(qBetaFirth, v3, -0.15567)
+    assertDouble(qPValFirth, v3, 0.04991	)
 
     assertDouble(qBeta, v4, -0.88059)
     assertDouble(qSe, v4, 0.83769, 1e-3)
@@ -348,6 +357,8 @@ class LogisticRegressionSuite extends SparkSuite {
     assertDouble(qPVal, v4, 0.29316, 1e-2)
     assertDouble(qPValLR, v4, 0.26984)
     assertDouble(qPValScore, v4, 0.27828)
+    assertDouble(qBetaFirth, v4, -0.7524)
+    assertDouble(qPValFirth, v4, 0.30731)
 
     assertDouble(qBeta, v5, 0.54921)
     assertDouble(qSe, v5, 0.4517, 1e-3)
@@ -355,5 +366,7 @@ class LogisticRegressionSuite extends SparkSuite {
     assertDouble(qPVal, v5, 0.22403, 1e-3)
     assertDouble(qPValLR, v5, 0.21692)
     assertDouble(qPValScore, v5, 0.21849)
+    assertDouble(qBetaFirth, v5, 0.5258)
+    assertDouble(qPValFirth, v5, 0.22562)
   }
 }

--- a/src/test/scala/is/hail/stats/LogisticRegressionModelSuite.scala
+++ b/src/test/scala/is/hail/stats/LogisticRegressionModelSuite.scala
@@ -50,7 +50,7 @@ class LogisticRegressionModelSuite extends SparkSuite {
 
     assert(D_==(waldStats.z(0), 0.7710228, tolerance = 1.0E-6))
     assert(D_==(waldStats.z(1), -0.5740389, tolerance = 1.0E-6))
-    assert(D_==(waldStats.z(2), 0.4216421, tolerance = 1.0E-6))
+    assert(D_==(waldStats.z(2), 0.4216421, tolerance = 1.0E-5))
 
     assert(D_==(waldStats.p(0), 0.4406934, tolerance = 1.0E-6))
     assert(D_==(waldStats.p(1), 0.5659415, tolerance = 1.0E-6))

--- a/src/test/scala/is/hail/stats/LogisticRegressionModelSuite.scala
+++ b/src/test/scala/is/hail/stats/LogisticRegressionModelSuite.scala
@@ -32,7 +32,7 @@ class LogisticRegressionModelSuite extends SparkSuite {
     val ones = DenseMatrix.fill[Double](6, 1)(1d)
 
     val nullModel = new LogisticRegressionModel(ones, y)
-    val nullFit = nullModel.fit(nullModel.bInterceptOnly(), computeScoreR = true, computeSe = true, computeLogLkld = true)
+    val nullFit = nullModel.fit(nullModel.bInterceptOnly(), computeScoreFisher = true, computeSe = true, computeLogLkld = true)
 
     val X = DenseMatrix.horzcat(ones, C)
 
@@ -89,7 +89,7 @@ class LogisticRegressionModelSuite extends SparkSuite {
     val gts = DenseVector(0d, 1d, 2d, 0d, 0d, 1d)
 
     val nullModel = new LogisticRegressionModel(C, y)
-    val nullFit = nullModel.fit(nullModel.bInterceptOnly(), computeScoreR = true, computeSe = true, computeLogLkld = true)
+    val nullFit = nullModel.fit(nullModel.bInterceptOnly(), computeScoreFisher = true, computeSe = true, computeLogLkld = true)
 
     val X = DenseMatrix.horzcat(C, gts.asDenseMatrix.t)
 
@@ -212,7 +212,7 @@ class LogisticRegressionModelSuite extends SparkSuite {
     val ones = DenseMatrix.fill[Double](6, 1)(1d)
 
     val nullModel = new LogisticRegressionModel(ones, y)
-    val nullFit = nullModel.fit(nullModel.bInterceptOnly(), computeScoreR = true, computeSe = true, computeLogLkld = true)
+    val nullFit = nullModel.fit(nullModel.bInterceptOnly(), computeScoreFisher = true, computeSe = true, computeLogLkld = true)
 
     val X = DenseMatrix.horzcat(ones, C)
 

--- a/src/test/scala/is/hail/stats/LogisticRegressionModelSuite.scala
+++ b/src/test/scala/is/hail/stats/LogisticRegressionModelSuite.scala
@@ -31,30 +31,30 @@ class LogisticRegressionModelSuite extends SparkSuite {
 
     val ones = DenseMatrix.fill[Double](6, 1)(1d)
 
-    val X = DenseMatrix.horzcat(C, ones)
-
     val nullModel = new LogisticRegressionModel(ones, y)
-    val nullFit = nullModel.nullFit(df = 2)
+    val nullFit = nullModel.fit(nullModel.bInterceptOnly())
+
+    val X = DenseMatrix.horzcat(ones, C)
 
     val waldStats = WaldTest.test(X, y, nullFit).stats.get
     val lrStats = LikelihoodRatioTest.test(X, y, nullFit).stats.get
     val scoreStats = ScoreTest.test(X, y, nullFit).stats.get
 
-    assert(D_==(waldStats.b(0), -0.3585773, tolerance = 1.0E-6))
-    assert(D_==(waldStats.b(1), 0.1922622, tolerance = 1.0E-6))
-    assert(D_==(waldStats.b(2), 0.7245034, tolerance = 1.0E-6))
+    assert(D_==(waldStats.b(0), 0.7245034, tolerance = 1.0E-6))
+    assert(D_==(waldStats.b(1), -0.3585773, tolerance = 1.0E-6))
+    assert(D_==(waldStats.b(2), 0.1922622, tolerance = 1.0E-6))
 
-    assert(D_==(waldStats.se(0), 0.6246568, tolerance = 1.0E-6))
-    assert(D_==(waldStats.se(1), 0.4559844, tolerance = 1.0E-6))
-    assert(D_==(waldStats.se(2), 0.9396654, tolerance = 1.0E-6))
+    assert(D_==(waldStats.se(0), 0.9396654, tolerance = 1.0E-6))
+    assert(D_==(waldStats.se(1), 0.6246568, tolerance = 1.0E-6))
+    assert(D_==(waldStats.se(2), 0.4559844, tolerance = 1.0E-6))
 
-    assert(D_==(waldStats.z(0), -0.5740389, tolerance = 1.0E-6))
-    assert(D_==(waldStats.z(1), 0.4216421, tolerance = 1.0E-6))
-    assert(D_==(waldStats.z(2), 0.7710228, tolerance = 1.0E-6))
+    assert(D_==(waldStats.z(0), 0.7710228, tolerance = 1.0E-6))
+    assert(D_==(waldStats.z(1), -0.5740389, tolerance = 1.0E-6))
+    assert(D_==(waldStats.z(2), 0.4216421, tolerance = 1.0E-6))
 
-    assert(D_==(waldStats.p(0), 0.5659415, tolerance = 1.0E-6))
-    assert(D_==(waldStats.p(1), 0.6732863, tolerance = 1.0E-6))
-    assert(D_==(waldStats.p(2), 0.4406934, tolerance = 1.0E-6))
+    assert(D_==(waldStats.p(0), 0.4406934, tolerance = 1.0E-6))
+    assert(D_==(waldStats.p(1), 0.5659415, tolerance = 1.0E-6))
+    assert(D_==(waldStats.p(2), 0.6732863, tolerance = 1.0E-6))
 
     assert(D_==(nullFit.logLkhd, -3.81908501, tolerance = 1.0E-6))
     assert(D_==(lrStats.chi2, 0.351536062, tolerance = 1.0E-6))
@@ -88,34 +88,36 @@ class LogisticRegressionModelSuite extends SparkSuite {
 
     val gts = DenseVector(0d, 1d, 2d, 0d, 0d, 1d)
 
-    val X = DenseMatrix.horzcat(gts.asDenseMatrix.t, C)
-
     val nullModel = new LogisticRegressionModel(C, y)
-    val nullFit = nullModel.nullFit(nullModel.bInterceptOnly())
+    val nullFit = nullModel.fit(nullModel.bInterceptOnly())
+
+    val X = DenseMatrix.horzcat(C, gts.asDenseMatrix.t)
 
     val waldStats = WaldTest.test(X, y, nullFit).stats.get
     val lrStats = LikelihoodRatioTest.test(X, y, nullFit).stats.get
     val scoreStats = ScoreTest.test(X, y, nullFit).stats.get
 
-    assert(D_==(waldStats.b(0), 3.1775729, tolerance = 1.0E-6))
-    assert(D_==(waldStats.b(1), -0.4811418, tolerance = 1.0E-6))
-    assert(D_==(waldStats.b(2), -0.4293547, tolerance = 1.0E-6))
-    assert(D_==(waldStats.b(3), -0.4214875, tolerance = 1.0E-6))
+    println(waldStats.b)
 
-    assert(D_==(waldStats.se(0), 4.1094207, tolerance = 1.0E-6))
-    assert(D_==(waldStats.se(1), 1.6203668, tolerance = 1.0E-6))
-    assert(D_==(waldStats.se(2), 0.7256665, tolerance = 1.0E-6))
-    assert(D_==(waldStats.se(3), 0.9223569, tolerance = 1.0E-6))
+    assert(D_==(waldStats.b(0), -0.4811418, tolerance = 1.0E-6))
+    assert(D_==(waldStats.b(1), -0.4293547, tolerance = 1.0E-6))
+    assert(D_==(waldStats.b(2), -0.4214875, tolerance = 1.0E-6))
+    assert(D_==(waldStats.b(3), 3.1775729, tolerance = 1.0E-6))
 
-    assert(D_==(waldStats.z(0), 0.7732411, tolerance = 1.0E-6))
-    assert(D_==(waldStats.z(1), -0.2969339, tolerance = 1.0E-6))
-    assert(D_==(waldStats.z(2), -0.5916695, tolerance = 1.0E-6))
-    assert(D_==(waldStats.z(3), -0.4569679, tolerance = 1.0E-6))
+    assert(D_==(waldStats.se(0), 1.6203668, tolerance = 1.0E-6))
+    assert(D_==(waldStats.se(1), 0.7256665, tolerance = 1.0E-6))
+    assert(D_==(waldStats.se(2), 0.9223569, tolerance = 1.0E-6))
+    assert(D_==(waldStats.se(3), 4.1094207, tolerance = 1.0E-6))
 
-    assert(D_==(waldStats.p(0), 0.4393797, tolerance = 1.0E-6))
-    assert(D_==(waldStats.p(1), 0.7665170, tolerance = 1.0E-6))
-    assert(D_==(waldStats.p(2), 0.5540720, tolerance = 1.0E-6))
-    assert(D_==(waldStats.p(3), 0.6476941, tolerance = 1.0E-6))
+    assert(D_==(waldStats.z(0), -0.2969339, tolerance = 1.0E-6))
+    assert(D_==(waldStats.z(1), -0.5916695, tolerance = 1.0E-6))
+    assert(D_==(waldStats.z(2), -0.4569679, tolerance = 1.0E-6))
+    assert(D_==(waldStats.z(3), 0.7732411, tolerance = 1.0E-6))
+
+    assert(D_==(waldStats.p(0), 0.7665170, tolerance = 1.0E-6))
+    assert(D_==(waldStats.p(1), 0.5540720, tolerance = 1.0E-6))
+    assert(D_==(waldStats.p(2), 0.6476941, tolerance = 1.0E-6))
+    assert(D_==(waldStats.p(3), 0.4393797, tolerance = 1.0E-6))
 
     /* R code:
     logfitnull <- glm(y0 ~ c1 + c2, family=binomial(link="logit"))
@@ -207,26 +209,32 @@ class LogisticRegressionModelSuite extends SparkSuite {
     val firthBR = firthFitR.map(_(0))
     val firthLogLkhd0R = firthLrtR(0)(0)
     val firthLogLkhdR = firthLrtR(1)(0)
+    val firthChi2R = 2 * (firthLogLkhdR - firthLogLkhd0R)
     val firthPValR = firthLrtR(2)(0)
 
     val y = DenseVector(yArray)
     val C = new DenseMatrix(rows, cols, XArray)
     val ones = DenseMatrix.fill[Double](6, 1)(1d)
-    val X = DenseMatrix.horzcat(C, ones)
 
     val nullModel = new LogisticRegressionModel(ones, y)
-    val nullFit = nullModel.nullFit(df = 2)
-    val nullFitFirth = nullModel.nullFit(df = 2, useFirth = true)
+    val nullFit = nullModel.fit(nullModel.bInterceptOnly())
+
+    println(nullFit)
+
+    val X = DenseMatrix.horzcat(ones, C)
 
     val waldStats = WaldTest.test(X, y, nullFit).stats.get
     val lrStats = LikelihoodRatioTest.test(X, y, nullFit).stats.get
     val scoreStats = ScoreTest.test(X, y, nullFit).stats.get
-    val firthStats = FirthTest.test(X, y, nullFitFirth).stats.get
+    val firthStats = FirthTest.test(X, y, nullFit).stats.get
 
-    assertArray(waldStats.b, cycle(waldBR))
-    assertArray(waldStats.se, cycle(waldSeR))
-    assertArray(waldStats.z, cycle(waldZR))
-    assertArray(waldStats.p, cycle(waldPR))
+    //val firthB0 = DenseVector(nullFitFirth.b(0), 0d, 0d)
+    //val firthLogLkhd0 = nullFitFirth.firthLogLkhd(firthB0)
+
+    assertArray(waldStats.b, waldBR)
+    assertArray(waldStats.se, waldSeR)
+    assertArray(waldStats.z, waldZR)
+    assertArray(waldStats.p, waldPR)
 
     assert(D_==(lrStats.chi2, lrtChi2R, tol))
     assert(D_==(lrStats.p, lrtPR, tol))
@@ -234,6 +242,19 @@ class LogisticRegressionModelSuite extends SparkSuite {
     assert(D_==(scoreStats.chi2, scoreChi2R, tol))
     assert(D_==(scoreStats.p, scorePR, tol))
 
+    assertArray(firthStats.b, firthBR)
+
+    println(s"firthLogLkhd0R = $firthLogLkhd0R")
+    println(s"firthLogLkhdR = $firthLogLkhdR")
+    println(s"firthChi2R = $firthChi2R")
+    println(s"firthPValR = $firthPValR")
+
+    //assert(D_==(firthLogLkhd0, firthLogLkhd0R, tol))
+    //assert(D_==(firthStats.logLkhd, firthLogLkhdR, tol))
+
+    println(firthStats.p)
+
     assert(D_==(firthStats.p, firthPValR, tol))
+
   }
 }

--- a/src/test/scala/is/hail/stats/LogisticRegressionModelSuite.scala
+++ b/src/test/scala/is/hail/stats/LogisticRegressionModelSuite.scala
@@ -32,7 +32,7 @@ class LogisticRegressionModelSuite extends SparkSuite {
     val ones = DenseMatrix.fill[Double](6, 1)(1d)
 
     val nullModel = new LogisticRegressionModel(ones, y)
-    val nullFit = nullModel.fit(nullModel.bInterceptOnly())
+    val nullFit = nullModel.fit(nullModel.bInterceptOnly(), computeScoreR = true, computeSe = true, computeLogLkld = true)
 
     val X = DenseMatrix.horzcat(ones, C)
 
@@ -56,7 +56,7 @@ class LogisticRegressionModelSuite extends SparkSuite {
     assert(D_==(waldStats.p(1), 0.5659415, tolerance = 1.0E-6))
     assert(D_==(waldStats.p(2), 0.6732863, tolerance = 1.0E-6))
 
-    assert(D_==(nullFit.logLkhd, -3.81908501, tolerance = 1.0E-6))
+    assert(D_==(nullFit.optLogLkhd.get, -3.81908501, tolerance = 1.0E-6))
     assert(D_==(lrStats.chi2, 0.351536062, tolerance = 1.0E-6))
     assert(D_==(lrStats.p, 0.8388125392, tolerance = 1.0E-5))
 
@@ -89,7 +89,7 @@ class LogisticRegressionModelSuite extends SparkSuite {
     val gts = DenseVector(0d, 1d, 2d, 0d, 0d, 1d)
 
     val nullModel = new LogisticRegressionModel(C, y)
-    val nullFit = nullModel.fit(nullModel.bInterceptOnly())
+    val nullFit = nullModel.fit(nullModel.bInterceptOnly(), computeScoreR = true, computeSe = true, computeLogLkld = true)
 
     val X = DenseMatrix.horzcat(C, gts.asDenseMatrix.t)
 
@@ -124,7 +124,7 @@ class LogisticRegressionModelSuite extends SparkSuite {
     pval <- lrtest[["Pr(>Chi)"]][2]
     */
 
-    assert(D_==(nullFit.logLkhd, -3.643316979, tolerance = 1.0E-6))
+    assert(D_==(nullFit.optLogLkhd.get, -3.643316979, tolerance = 1.0E-6))
     assert(D_==(lrStats.chi2, 0.8733246, tolerance = 1.0E-6))
     assert(D_==(lrStats.p, 0.3500365602, tolerance = 1.0E-6))
 
@@ -212,7 +212,7 @@ class LogisticRegressionModelSuite extends SparkSuite {
     val ones = DenseMatrix.fill[Double](6, 1)(1d)
 
     val nullModel = new LogisticRegressionModel(ones, y)
-    val nullFit = nullModel.fit(nullModel.bInterceptOnly())
+    val nullFit = nullModel.fit(nullModel.bInterceptOnly(), computeScoreR = true, computeSe = true, computeLogLkld = true)
 
     val X = DenseMatrix.horzcat(ones, C)
 
@@ -235,7 +235,7 @@ class LogisticRegressionModelSuite extends SparkSuite {
     assert(D_==(scoreStats.p, scorePR, tol))
 
     assertArray(firthStats.b, firthBR)
-    assert(D_==(firthFit.logLkhd, firthLogLkhdR, tol))
+    assert(D_==(firthFit.optLogLkhd.get, firthLogLkhdR, tol))
     assert(D_==(firthStats.p, firthPValR, tol))
   }
 }

--- a/src/test/scala/is/hail/stats/LogisticRegressionModelSuite.scala
+++ b/src/test/scala/is/hail/stats/LogisticRegressionModelSuite.scala
@@ -97,8 +97,6 @@ class LogisticRegressionModelSuite extends SparkSuite {
     val lrStats = LikelihoodRatioTest.test(X, y, nullFit).stats.get
     val scoreStats = ScoreTest.test(X, y, nullFit).stats.get
 
-    println(waldStats.b)
-
     assert(D_==(waldStats.b(0), -0.4811418, tolerance = 1.0E-6))
     assert(D_==(waldStats.b(1), -0.4293547, tolerance = 1.0E-6))
     assert(D_==(waldStats.b(2), -0.4214875, tolerance = 1.0E-6))
@@ -148,9 +146,6 @@ class LogisticRegressionModelSuite extends SparkSuite {
       assert(v.length == a.length)
       (v.data, a).zipped.foreach((ai, bi) => assert(D_==(ai, bi, tolerance)))
     }
-
-    // R returns intercept first, WaldTest returns tested coefficients first
-    def cycle(a: Array[Double]) = a.tail :+ a.head
 
     def readResults(file: String) = {
       hadoopConf.readLines(file) {
@@ -219,17 +214,14 @@ class LogisticRegressionModelSuite extends SparkSuite {
     val nullModel = new LogisticRegressionModel(ones, y)
     val nullFit = nullModel.fit(nullModel.bInterceptOnly())
 
-    println(nullFit)
-
     val X = DenseMatrix.horzcat(ones, C)
 
     val waldStats = WaldTest.test(X, y, nullFit).stats.get
     val lrStats = LikelihoodRatioTest.test(X, y, nullFit).stats.get
     val scoreStats = ScoreTest.test(X, y, nullFit).stats.get
-    val firthStats = FirthTest.test(X, y, nullFit).stats.get
-
-    //val firthB0 = DenseVector(nullFitFirth.b(0), 0d, 0d)
-    //val firthLogLkhd0 = nullFitFirth.firthLogLkhd(firthB0)
+    val firthTest = FirthTest.test(X, y, nullFit)
+    val firthStats = firthTest.stats.get
+    val firthFit = firthTest.fitStats
 
     assertArray(waldStats.b, waldBR)
     assertArray(waldStats.se, waldSeR)
@@ -243,18 +235,7 @@ class LogisticRegressionModelSuite extends SparkSuite {
     assert(D_==(scoreStats.p, scorePR, tol))
 
     assertArray(firthStats.b, firthBR)
-
-    println(s"firthLogLkhd0R = $firthLogLkhd0R")
-    println(s"firthLogLkhdR = $firthLogLkhdR")
-    println(s"firthChi2R = $firthChi2R")
-    println(s"firthPValR = $firthPValR")
-
-    //assert(D_==(firthLogLkhd0, firthLogLkhd0R, tol))
-    //assert(D_==(firthStats.logLkhd, firthLogLkhdR, tol))
-
-    println(firthStats.p)
-
+    assert(D_==(firthFit.logLkhd, firthLogLkhdR, tol))
     assert(D_==(firthStats.p, firthPValR, tol))
-
   }
 }

--- a/src/test/scala/is/hail/stats/LogisticRegressionModelSuite.scala
+++ b/src/test/scala/is/hail/stats/LogisticRegressionModelSuite.scala
@@ -32,7 +32,7 @@ class LogisticRegressionModelSuite extends SparkSuite {
     val ones = DenseMatrix.fill[Double](6, 1)(1d)
 
     val nullModel = new LogisticRegressionModel(ones, y)
-    val nullFit = nullModel.fit(nullModel.bInterceptOnly(), computeScoreFisher = true, computeSe = true, computeLogLkld = true)
+    val nullFit = nullModel.fit()
 
     val X = DenseMatrix.horzcat(ones, C)
 
@@ -56,7 +56,7 @@ class LogisticRegressionModelSuite extends SparkSuite {
     assert(D_==(waldStats.p(1), 0.5659415, tolerance = 1.0E-6))
     assert(D_==(waldStats.p(2), 0.6732863, tolerance = 1.0E-6))
 
-    assert(D_==(nullFit.optLogLkhd.get, -3.81908501, tolerance = 1.0E-6))
+    assert(D_==(nullFit.logLkhd, -3.81908501, tolerance = 1.0E-6))
     assert(D_==(lrStats.chi2, 0.351536062, tolerance = 1.0E-6))
     assert(D_==(lrStats.p, 0.8388125392, tolerance = 1.0E-5))
 
@@ -89,7 +89,7 @@ class LogisticRegressionModelSuite extends SparkSuite {
     val gts = DenseVector(0d, 1d, 2d, 0d, 0d, 1d)
 
     val nullModel = new LogisticRegressionModel(C, y)
-    val nullFit = nullModel.fit(nullModel.bInterceptOnly(), computeScoreFisher = true, computeSe = true, computeLogLkld = true)
+    val nullFit = nullModel.fit()
 
     val X = DenseMatrix.horzcat(C, gts.asDenseMatrix.t)
 
@@ -124,7 +124,7 @@ class LogisticRegressionModelSuite extends SparkSuite {
     pval <- lrtest[["Pr(>Chi)"]][2]
     */
 
-    assert(D_==(nullFit.optLogLkhd.get, -3.643316979, tolerance = 1.0E-6))
+    assert(D_==(nullFit.logLkhd, -3.643316979, tolerance = 1.0E-6))
     assert(D_==(lrStats.chi2, 0.8733246, tolerance = 1.0E-6))
     assert(D_==(lrStats.p, 0.3500365602, tolerance = 1.0E-6))
 
@@ -212,7 +212,7 @@ class LogisticRegressionModelSuite extends SparkSuite {
     val ones = DenseMatrix.fill[Double](6, 1)(1d)
 
     val nullModel = new LogisticRegressionModel(ones, y)
-    val nullFit = nullModel.fit(nullModel.bInterceptOnly(), computeScoreFisher = true, computeSe = true, computeLogLkld = true)
+    val nullFit = nullModel.fit()
 
     val X = DenseMatrix.horzcat(ones, C)
 
@@ -235,7 +235,7 @@ class LogisticRegressionModelSuite extends SparkSuite {
     assert(D_==(scoreStats.p, scorePR, tol))
 
     assertArray(firthStats.b, firthBR)
-    assert(D_==(firthFit.optLogLkhd.get, firthLogLkhdR, tol))
+    assert(D_==(firthFit.logLkhd, firthLogLkhdR, tol))
     assert(D_==(firthStats.p, firthPValR, tol))
   }
 }

--- a/src/test/scala/is/hail/stats/eigSymDSuite.scala
+++ b/src/test/scala/is/hail/stats/eigSymDSuite.scala
@@ -1,9 +1,8 @@
 package is.hail.stats
 
-import breeze.linalg.{DenseMatrix, eigSym, svd}
+import breeze.linalg.{DenseMatrix, DenseVector, eigSym, svd}
 import org.apache.commons.math3.random.JDKRandomGenerator
-import org.apache.commons.math3.random.MersenneTwister
-import is.hail.SparkSuite
+import is.hail.{SparkSuite, TestUtils}
 import org.testng.annotations.Test
 import is.hail.utils._
 
@@ -106,16 +105,15 @@ class eigSymDSuite extends SparkSuite {
     rand.setSeed(seed)
 
     val n = 5
-    val m = 2
 
     val A = DenseMatrix.zeros[Double](n, n)
     (0 until n).foreach(i => (i until n).foreach(j => A(i,j) = rand.nextGaussian()))
 
-    val X = DenseMatrix.fill[Double](n, m)(rand.nextGaussian())
+    val x = DenseVector.fill[Double](n)(rand.nextGaussian())
 
-    val B = A * X
-    val X1 = TriSolve(A, B)
+    val B = A * x
+    val x1 = TriSolve(A, B)
 
-    TestUtils.assertMatrixEqualityDouble(X, X1)
+    TestUtils.assertVectorEqualityDouble(x, x1)
   }
 }

--- a/src/test/scala/is/hail/stats/eigSymDSuite.scala
+++ b/src/test/scala/is/hail/stats/eigSymDSuite.scala
@@ -104,16 +104,13 @@ class eigSymDSuite extends SparkSuite {
     val rand = new JDKRandomGenerator()
     rand.setSeed(seed)
 
-    val n = 5
+    (1 to 5).foreach { n =>
+      val A = DenseMatrix.zeros[Double](n, n)
+      (0 until n).foreach(i => (i until n).foreach(j => A(i,j) = rand.nextGaussian()))
 
-    val A = DenseMatrix.zeros[Double](n, n)
-    (0 until n).foreach(i => (i until n).foreach(j => A(i,j) = rand.nextGaussian()))
+      val x = DenseVector.fill[Double](n)(rand.nextGaussian())
 
-    val x = DenseVector.fill[Double](n)(rand.nextGaussian())
-
-    val B = A * x
-    val x1 = TriSolve(A, B)
-
-    TestUtils.assertVectorEqualityDouble(x, x1)
+      TestUtils.assertVectorEqualityDouble(x, TriSolve(A, A * x))
+    }
   }
 }

--- a/src/test/scala/is/hail/stats/eigSymDSuite.scala
+++ b/src/test/scala/is/hail/stats/eigSymDSuite.scala
@@ -98,4 +98,24 @@ class eigSymDSuite extends SparkSuite {
 
     timeSymEig()
   }
+
+  @Test def triSolveTest() {
+    val seed = 0
+
+    val rand = new JDKRandomGenerator()
+    rand.setSeed(seed)
+
+    val n = 5
+    val m = 2
+
+    val A = DenseMatrix.zeros[Double](n, n)
+    (0 until n).foreach(i => (i until n).foreach(j => A(i,j) = rand.nextGaussian()))
+
+    val X = DenseMatrix.fill[Double](n, m)(rand.nextGaussian())
+
+    val B = A * X
+    val X1 = TriSolve(A, B)
+
+    TestUtils.assertMatrixEqualityDouble(X, X1)
+  }
 }


### PR DESCRIPTION
- removed nullFit function entirely, simplifying code
- null model variables are first rather than last, simplifying code
- logreg fit now only computes margins of score and firth on first iteration
- score and fisher are Options in LogisticRegressionFit (not computed by Firth)
- added Firth test to logreg
- added R test of Firth test
- added Firth to EPACTS test
- added Firth to logreg documentation
- added TriSolve for solving triangular systems (LAPACK dtrtrs), used in fitFirth
- added TriSolve test