### PR TITLE
assert directory does not exist

### DIFF
--- a/src/main/scala/is/hail/utils/TempDir.scala
+++ b/src/main/scala/is/hail/utils/TempDir.scala
@@ -13,9 +13,9 @@ object TempDir {
       try {
         val dir = tmpdir + "/hail." + Random.alphanumeric.take(12).mkString
 
-        // assert true == assert created a new directory (as opposed to the
-        // directory already existing)
-        assert(hConf.mkDir(dir))
+        assert(!hConf.exists(dir))
+
+        hConf.mkDir(dir)
 
         val fs = hConf.fileSystem(tmpdir)
         val qDir = fs.makeQualified(new hadoop.fs.Path(dir))


### PR DESCRIPTION
I was wrong about the return value of `RichHadoopConfiguration.mkdir`. This is better than nothing, but still susceptible to races :(