### PR TITLE
Rowgeno

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -1479,7 +1479,7 @@ class VariantDataset(object):
         self._jvdf.exportVCF(output, joption(append_to_header), export_pp, parallel)
 
     @handle_py4j
-    def write(self, output, overwrite=False):
+    def write(self, output, overwrite=False, parquet_genotypes=False):
         """Write as VDS file.
 
         **Examples**
@@ -1488,12 +1488,15 @@ class VariantDataset(object):
 
         >>> vds.write("output/sample.vds")
 
-        :param str output: Path of .vds file to write.
+        :param str output: Path of VDS file to write.
 
         :param bool overwrite: If True, overwrite any existing VDS file. Cannot be used to read from and write to the same path.
+
+        :param bool parquet_genotypes: If True, store genotypes as Parquet rather than Hail's serialization.  The resulting VDS will be larger and slower in Hail but the genotypes will be accessible from other tools that support Parquet.
+
         """
 
-        self._jvdf.write(output, overwrite)
+        self._jvdf.write(output, overwrite, parquet_genotypes)
 
     @handle_py4j
     def filter_alleles(self, condition, annotation='va = va', subset=True, keep=True,

--- a/python/hail/tests.py
+++ b/python/hail/tests.py
@@ -57,8 +57,10 @@ class ContextTests(unittest.TestCase):
 
         vcf.write('/tmp/sample.vds', overwrite=True)
         vds = hc.read('/tmp/sample.vds')
-
         self.assertTrue(vcf.same(vds))
+
+        vcf.write('/tmp/sample.pq.vds', parquet_genotypes=True, overwrite=True)
+        self.assertTrue(vcf.same(hc.read('/tmp/sample.pq.vds')))
 
         bn = hc.balding_nichols_model(3, 10, 100, 8)
         bn_count = bn.count()

--- a/src/main/scala/is/hail/variant/Genotype.scala
+++ b/src/main/scala/is/hail/variant/Genotype.scala
@@ -336,12 +336,12 @@ object Genotype {
 
   def schema: DataType = StructType(Array(
     StructField("gt", IntegerType),
-    StructField("ad", ArrayType(IntegerType)),
+    StructField("ad", ArrayType(IntegerType, containsNull = false)),
     StructField("dp", IntegerType),
     StructField("gq", IntegerType),
-    StructField("px", ArrayType(IntegerType)),
-    StructField("fakeRef", BooleanType),
-    StructField("isDosage", BooleanType)))
+    StructField("px", ArrayType(IntegerType, containsNull = false)),
+    StructField("fakeRef", BooleanType, nullable = false),
+    StructField("isDosage", BooleanType, nullable = false)))
 
   def t: Type = TStruct(
     "gt" -> TInt,

--- a/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
@@ -169,10 +169,20 @@ class VSMSuite extends SparkSuite {
     }
   }
 
-  @Test def testReadWrite() {
+  @Test def testWriteRead() {
     val p = forAll(VariantSampleMatrix.gen[Genotype](hc, VSMSubgen.random)) { vds =>
-      val f = tmpDir.createTempFile(extension = ".vds")
+      val f = tmpDir.createTempFile(extension = "vds")
       vds.write(f)
+      hc.read(f).same(vds)
+    }
+
+    p.check()
+  }
+
+  @Test def testWriteParquetRead() {
+    val p = forAll(VariantSampleMatrix.gen[Genotype](hc, VSMSubgen.random)) { vds =>
+      val f = tmpDir.createTempFile(extension = "vds")
+      vds.write(f, parquetGenotypes = true)
       hc.read(f).same(vds)
     }
 


### PR DESCRIPTION
@tomwhite @jkeebler Added a parquet_genotypes flag to VDS.write:

```
import hail
hc = hail.HailContext()
vds = hc.import_vcf('sample.vcf')
vds.count()
vds.write('sample.pq.vds', overwrite=True, parquet_genotypes=True)
```

Then in the Spark shell:

```
scala> val df = spark.read.parquet("sample.pq.vds/rdd.parquet")
scala> df.printSchema()
root
 |-- variant: struct (nullable = true)
[variant and annotation fields elided]
 |-- gs: array (nullable = true)
 |    |-- element: struct (containsNull = true)
 |    |    |-- gt: integer (nullable = true)
 |    |    |-- ad: array (nullable = true)
 |    |    |    |-- element: integer (containsNull = true)
 |    |    |-- dp: integer (nullable = true)
 |    |    |-- gq: integer (nullable = true)
 |    |    |-- px: array (nullable = true)
 |    |    |    |-- element: integer (containsNull = true)
 |    |    |-- fakeRef: boolean (nullable = true)
 |    |    |-- isDosage: boolean (nullable = true)
```

I added correctness tests, but no performance testing on the Hail side yet.

Note, the `px` field is the `PL` in the case of sequence data and 16-bit fixed-point dosages in the case of array data (See `Gentoype` for more details.)  We know if we have dosage or not globally (`VariantMetadata.isDosage`), so I can customize the resulting schema in v2.

Finally, I'm seeing `containsNull = true` here, but I set it to `containsNull = false` when I constructed the schema programatically.  Spark/Parquet seem to be consistently ignoring my non-missing hints.  Have you seen this before?  Any idea why it is happening?

From `Genotype.schema`:

```
  def schema: DataType = StructType(Array(
    StructField("gt", IntegerType),
    StructField("ad", ArrayType(IntegerType, containsNull = false)),
    StructField("dp", IntegerType),
    StructField("gq", IntegerType),
    StructField("px", ArrayType(IntegerType, containsNull = false)),
    StructField("fakeRef", BooleanType, nullable = false),
    StructField("isDosage", BooleanType, nullable = false)))
```
