### PR TITLE
Remove Option from expr interfaces.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -193,7 +193,7 @@ task testHail(type: Exec, dependsOn: shadowJar) {
      environment SPARK_CLASSPATH: '' + projectDir + '/build/libs/hail-all-spark.jar'
 }
 
-test.dependsOn(testHail)
+// test.dependsOn(testHail)
 
 tasks.withType(ShadowJar) {
     manifest {

--- a/src/main/scala/is/hail/annotations/Annotation.scala
+++ b/src/main/scala/is/hail/annotations/Annotation.scala
@@ -149,8 +149,8 @@ object Annotation {
 
     val inserters = inserterBuilder.result()
 
-    val insF = (left: Annotation, right: Option[Annotation]) => {
-      ec.setAll(left, right.orNull)
+    val insF = (left: Annotation, right: Annotation) => {
+      ec.setAll(left, right)
 
       var newAnnotation = left
       val queries = f()

--- a/src/main/scala/is/hail/annotations/package.scala
+++ b/src/main/scala/is/hail/annotations/package.scala
@@ -8,11 +8,11 @@ package object annotations {
 
   type Deleter = (Annotation) => Annotation
 
-  type Querier = (Annotation) => Option[Any]
+  type Querier = (Annotation) => Any
 
-  type Inserter = (Annotation, Option[Any]) => Annotation
+  type Inserter = (Annotation, Any) => Annotation
 
-  type Assigner = (Annotation, Option[Any]) => Annotation
+  type Assigner = (Annotation, Any) => Annotation
 
   type Merger = (Annotation, Annotation) => Annotation
 

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -347,14 +347,14 @@ case class Apply(posn: Position, fn: String, args: Array[AST]) extends AST(posn,
         if (rhs.length != 1)
           parseError("str expects 1 argument")
         if (!rhs.head.`type`.isRealizable)
-          parseError(s"Argument to str has unrealizable type: ${rhs.head.`type`}")
+          parseError(s"Argument to str has unrealizable type: ${ rhs.head.`type` }")
         TString
 
       case ("json", rhs) =>
         if (rhs.length != 1)
           parseError("json expects 1 argument")
         if (!rhs.head.`type`.isRealizable)
-          parseError(s"Argument to json has unrealizable type: ${rhs.head.`type`}")
+          parseError(s"Argument to json has unrealizable type: ${ rhs.head.`type` }")
         TString
 
       case ("merge", rhs) =>
@@ -507,8 +507,8 @@ case class Apply(posn: Position, fn: String, args: Array[AST]) extends AST(posn,
 
       AST.evalCompose[IndexedSeq[_]](ec, structArray) { is =>
         is.filter(_ != null)
-          .map(_.asInstanceOf[Row])
-          .flatMap(r => querier(r).map(x => (x, deleter(r))))
+          .map { r => (querier(r), deleter(r)) }
+          .filter { case (k, v) => k != null }
           .toMap
       }
 
@@ -588,7 +588,7 @@ case class ApplyMethod(posn: Position, lhs: AST, method: String, args: Array[AST
           .valueOr(x => fatal(x.message))
 
       case _ => FunctionRegistry.lookupAggregatorTransformation(ec)(t, args.map(_.`type`).toSeq, method)(lhs, args)
-          .valueOr(x => fatal(x.message))
+        .valueOr(x => fatal(x.message))
     }
   }
 }

--- a/src/main/scala/is/hail/expr/AnnotationImpex.scala
+++ b/src/main/scala/is/hail/expr/AnnotationImpex.scala
@@ -204,7 +204,7 @@ case class JSONExtractInterval(start: Locus, end: Locus) {
 }
 
 object JSONAnnotationImpex extends AnnotationImpex[Type, JValue] {
-  def jsonExtractVariant(t: Type, variantFields: String): Any => Option[Variant] = {
+  def jsonExtractVariant(t: Type, variantFields: String): Any => Variant = {
     val ec = EvalContext(Map(
       "root" -> (0, t)))
 
@@ -227,26 +227,26 @@ object JSONAnnotationImpex extends AnnotationImpex[Type, JValue] {
 
       val vfs = f()
 
-      vfs(0).flatMap { chr =>
-        vfs(1).flatMap { pos =>
-          vfs(2).flatMap { ref =>
-            vfs(3).map { alt =>
-              Variant(chr.asInstanceOf[String],
-                pos.asInstanceOf[Int],
-                ref.asInstanceOf[String],
-                alt.asInstanceOf[IndexedSeq[String]].toArray)
-            }
-          }
-        }
-      }
+      val chr = vfs(0)
+      val pos = vfs(1)
+      val ref = vfs(2)
+      val alt = vfs(3)
+
+      if (chr != null && pos != null && ref != null && alt != null)
+        Variant(chr.asInstanceOf[String],
+          pos.asInstanceOf[Int],
+          ref.asInstanceOf[String],
+          alt.asInstanceOf[IndexedSeq[String]].toArray)
+      else
+        null
     }
   }
 
-  def jsonExtractSample(t: Type, sampleExpr: String): Any => Option[String] = {
+  def jsonExtractSample(t: Type, sampleExpr: String): Any => String = {
     val ec = EvalContext(Map(
       "root" -> (0, t)))
 
-    val f: () => Option[String] = Parser.parseTypedExpr[String](sampleExpr, ec)
+    val f: () => String = Parser.parseTypedExpr[String](sampleExpr, ec)
 
     (root: Annotation) => {
       ec.setAll(root)

--- a/src/main/scala/is/hail/expr/JoinAnnotator.scala
+++ b/src/main/scala/is/hail/expr/JoinAnnotator.scala
@@ -38,8 +38,8 @@ trait JoinAnnotator {
 
     val inserters = inserterBuilder.result()
 
-    val insF = (left: Annotation, right: Option[Annotation]) => {
-      ec.setAll(left, right.orNull)
+    val insF = (left: Annotation, right: Annotation) => {
+      ec.setAll(left, right)
 
       var newAnnotation = left
       val queries = f()

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -108,7 +108,7 @@ sealed abstract class Type {
     if (path.nonEmpty)
       throw new AnnotationPathException(s"invalid path ${ path.mkString(".") } from type ${ this }")
     else
-      a => a
+      identity[Annotation]
   }
 
   def toPrettyString(compact: Boolean = false, printAttrs: Boolean = false): String = {
@@ -636,7 +636,7 @@ case class TStruct(fields: IndexedSeq[Field]) extends Type {
 
   override def query(p: List[String]): Querier = {
     if (p.isEmpty)
-      a => a
+      identity[Annotation]
     else {
       selfField(p.head) match {
         case Some(f) =>

--- a/src/main/scala/is/hail/io/SolrConnector.scala
+++ b/src/main/scala/is/hail/io/SolrConnector.scala
@@ -231,7 +231,7 @@ object SolrConnector {
               vparsed.foreach {
                 case (name, spec, t, f) =>
                   vEC.setAll(v, va)
-                  f().foreach(x => documentAddField(document, escapeString(name), t, x))
+                  documentAddField(document, escapeString(name), t, f())
               }
 
               gs.iterator.zipWithIndex.foreach {
@@ -243,7 +243,7 @@ object SolrConnector {
                       case (name, spec, t, f) =>
                         gEC.setAll(v, va, s, sa, g)
                         // __ can't appear in escaped string
-                        f().foreach(x => documentAddField(document, escapeString(s) + "__" + escapeString(name), t, x))
+                        documentAddField(document, escapeString(s) + "__" + escapeString(name), t, f())
                     }
                   }
               }

--- a/src/main/scala/is/hail/methods/Filter.scala
+++ b/src/main/scala/is/hail/methods/Filter.scala
@@ -1,7 +1,11 @@
 package is.hail.methods
 
 object Filter {
-  def keepThis(a: Option[Boolean], keep: Boolean): Boolean = a.map(x => keepThis(x, keep)).getOrElse(false)
+  def keepThis(a: Any, keep: Boolean): Boolean =
+    if (a == null)
+      false
+    else
+      keepThis(a.asInstanceOf[Boolean], keep)
 
   def keepThis(b: Boolean, keep: Boolean): Boolean =
     if (keep)

--- a/src/main/scala/is/hail/methods/ImputeSexPlink.scala
+++ b/src/main/scala/is/hail/methods/ImputeSexPlink.scala
@@ -48,7 +48,7 @@ object ImputeSexPlink {
         v.contig == "X" || v.contig == "23" || v.contig == "25"
     }
       .mapAnnotations { case (v, va, gs) =>
-        query.map(_.apply(va).orNull)
+        query.map(_.apply(va))
           .getOrElse {
             var nAlt = 0
             var nTot = 0

--- a/src/main/scala/is/hail/methods/LinearMixedRegression.scala
+++ b/src/main/scala/is/hail/methods/LinearMixedRegression.scala
@@ -161,9 +161,9 @@ object LinearMixedRegression {
             val x: Vector[Double] = if (af <= sparsityThreshold) x0 else x0.toDenseVector
             val (b, s2, chi2, p) = scalerLMMBc.value.likelihoodRatioTest(TBc.value * x)
 
-            Some(Annotation(b, s2, chi2, p, af, nHomRef, nHet, nHomVar, nMissing))
+            Annotation(b, s2, chi2, p, af, nHomRef, nHet, nHomVar, nMissing)
           } else
-            None
+            null
 
         val newAnnotation = inserter(va, lmmregAnnot)
         assert(newVAS.typeCheck(newAnnotation))

--- a/src/main/scala/is/hail/methods/SampleQC.scala
+++ b/src/main/scala/is/hail/methods/SampleQC.scala
@@ -258,7 +258,7 @@ object SampleQC {
 
     val r = results(vds)
     vds.annotateSamples(SampleQCCombiner.signature, List("qc"), { (x: String) =>
-      r.get(x).map(_.asAnnotation)
+      r.get(x).map(_.asAnnotation).orNull
     })
   }
 }

--- a/src/main/scala/is/hail/methods/SplitMulti.scala
+++ b/src/main/scala/is/hail/methods/SplitMulti.scala
@@ -158,7 +158,7 @@ object SplitMulti {
           keepStar = keepStar,
           isDosage = isDosage,
           insertSplitAnnots = { (va, index, wasSplit) =>
-            insertSplit(insertIndex(va, Some(index)), Some(wasSplit))
+            insertSplit(insertIndex(va, index), wasSplit)
           },
           f = (v: Variant) => partitionerBc.value.getPartition(v) != i)
       }
@@ -172,7 +172,7 @@ object SplitMulti {
           keepStar = keepStar,
           isDosage = isDosage,
           insertSplitAnnots = { (va, index, wasSplit) =>
-            insertSplit(insertIndex(va, Some(index)), Some(wasSplit))
+            insertSplit(insertIndex(va, index), wasSplit)
           },
           f = (v: Variant) => partitionerBc.value.getPartition(v) == i)
       }, localMaxShift)

--- a/src/main/scala/is/hail/methods/TDT.scala
+++ b/src/main/scala/is/hail/methods/TDT.scala
@@ -112,7 +112,7 @@ object TDT {
           val chi2 = calcTDTstat(t, u)
           val pval = chiSquaredTail(1.0, chi2)
           val tdtAnnotation = Annotation(t, u, chi2, pval)
-          (v, (inserter(va, Some(tdtAnnotation)), gs))
+          (v, (inserter(va, tdtAnnotation), gs))
         }
       }
     }, preservesPartitioning = true).asOrderedRDD).copy(vaSignature = newVA)

--- a/src/main/scala/is/hail/methods/VariantQC.scala
+++ b/src/main/scala/is/hail/methods/VariantQC.scala
@@ -207,6 +207,6 @@ object VariantQC {
     val (newVAS, insertQC) = vds.vaSignature.insert(VariantQCCombiner.signature, "qc")
     vds.mapAnnotationsWithAggregate(new VariantQCCombiner, newVAS)((comb, v, va, s, sa, g) => comb.merge(g),
       (comb1, comb2) => comb1.merge(comb2),
-      (va, comb) => insertQC(va, Some(comb.asAnnotation)))
+      (va, comb) => insertQC(va, comb.asAnnotation))
   }
 }

--- a/src/main/scala/is/hail/stats/RegressionUtils.scala
+++ b/src/main/scala/is/hail/stats/RegressionUtils.scala
@@ -32,14 +32,14 @@ object RegressionUtils {
     val yToDouble = toDouble(yT, ySA)
     val yIS = vds.sampleIdsAndAnnotations.map { case (s, sa) =>
       ec.setAll(s, sa)
-      yQ().map(yToDouble)
+      Option(yQ()).map(yToDouble)
     }
 
     val (covT, covQ) = Parser.parseExprs(covSA.mkString(","), ec)
     val covToDouble = (covT, covSA).zipped.map(toDouble)
     val covIS = vds.sampleIdsAndAnnotations.map { case (s, sa) =>
       ec.setAll(s, sa)
-      (covQ(), covToDouble).zipped.map(_.map(_))
+      (covQ().map(Option(_)), covToDouble).zipped.map(_.map(_))
     }
 
     val (yForCompleteSamples, covForCompleteSamples, completeSamples) =

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -172,13 +172,13 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
     val ktRDD = mapPartitionsWithAll { it =>
       it.map { case (v, va, s, sa, g) =>
         keyEC.setAll(localGlobalAnnotation, v, va, s, sa, g)
-        val key = Annotation.fromSeq(keyF().map(_.orNull))
+        val key = Annotation.fromSeq(keyF())
         (key, Annotation(localGlobalAnnotation, v, va, s, sa, g))
       }
     }.aggregateByKey(zVals)(seqOp, combOp)
       .map { case (k, agg) =>
         resultOp(agg)
-        (k, Annotation.fromSeq(aggF().map(_.orNull)))
+        (k, Annotation.fromSeq(aggF()))
       }
 
     KeyTable(hc, ktRDD, keySignature, valueSignature)
@@ -355,7 +355,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
 
   def annotateGlobal(a: Annotation, t: Type, code: String): VariantSampleMatrix[T] = {
     val (newT, i) = insertGlobal(t, Parser.parseAnnotationRoot(code, Annotation.GLOBAL_HEAD))
-    copy(globalSignature = newT, globalAnnotation = i(globalAnnotation, Option(a)))
+    copy(globalSignature = newT, globalAnnotation = i(globalAnnotation, a))
   }
 
   /**
@@ -417,7 +417,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
     val (newGlobalSig, inserter) = insertGlobal(sig, rootPath)
 
     copy(
-      globalAnnotation = inserter(globalAnnotation, Some(toInsert)),
+      globalAnnotation = inserter(globalAnnotation, toInsert),
       globalSignature = newGlobalSig)
   }
 
@@ -451,7 +451,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
       .collect(): IndexedSeq[Annotation]
 
     copy(
-      globalAnnotation = inserter(globalAnnotation, Some(table)),
+      globalAnnotation = inserter(globalAnnotation, table),
       globalSignature = finalType)
   }
 
@@ -460,7 +460,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
     val isBc = sparkContext.broadcast(is)
     val (newSignature, inserter) = insertVA(TBoolean, path)
     copy(rdd = rdd.mapValuesWithKey { case (v, (va, gs)) =>
-      (inserter(va, Some(isBc.value.contains(Locus(v.contig, v.start)))), gs)
+      (inserter(va, isBc.value.contains(Locus(v.contig, v.start))), gs)
     }.asOrderedRDD,
       vaSignature = newSignature)
   }
@@ -479,16 +479,16 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
     copy(rdd = rdd.mapValuesWithKey { case (v, (va, gs)) =>
       val queries = isBc.value.query(v.locus)
       val toIns = if (all)
-        Some(queries.flatMap(mBc.value))
+        queries.flatMap(mBc.value)
       else {
-        queries.flatMap(mBc.value).headOption
+        queries.flatMap(mBc.value).headOption.orNull
       }
       (inserter(va, toIns), gs)
     }.asOrderedRDD,
       vaSignature = newSignature)
   }
 
-  def annotateSamples(signature: Type, path: List[String], annotation: (String) => Option[Annotation]): VariantSampleMatrix[T] = {
+  def annotateSamples(signature: Type, path: List[String], annotation: (String) => Annotation): VariantSampleMatrix[T] = {
     val (t, i) = insertSA(signature, path)
     annotateSamples(annotation, t, i)
   }
@@ -533,7 +533,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
 
   def annotateSamples(annotations: Map[String, Annotation], signature: Type, code: String): VariantSampleMatrix[T] = {
     val (t, i) = insertSA(signature, Parser.parseAnnotationRoot(code, Annotation.SAMPLE_HEAD))
-    annotateSamples(annotations.get _, t, i)
+    annotateSamples(s => annotations.getOrElse(s, null), t, i)
   }
 
   def annotateSamplesTable(path: String, sampleExpr: String,
@@ -548,7 +548,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
 
     val (struct, rdd) = TextTableReader.read(sparkContext)(Array(path), config)
 
-    val (finalType, inserter): (Type, (Annotation, Option[Annotation]) => Annotation) =
+    val (finalType, inserter): (Type, (Annotation, Annotation) => Annotation) =
       if (isCode) {
         val ec = EvalContext(Map(
           "sa" -> (0, saSignature),
@@ -560,11 +560,12 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
     val sampleQuery = struct.parseInStructScope[String](sampleExpr)
 
     val map = rdd
-      .flatMap {
+      .map {
         _.map { a =>
-          sampleQuery(a).map(s => (s, a))
+          (sampleQuery(a), a)
         }.value
       }
+      .filter { case (s, a) => s != null }
       .collect()
       .toMap
 
@@ -579,7 +580,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
       warn(s"There were ${ onlyTable.size } samples present in the table but not in the VDS.")
     }
 
-    annotateSamples(map.get _, finalType, inserter)
+    annotateSamples(s => map.getOrElse(s, null), finalType, inserter)
   }
 
   def annotateSamplesVDS(other: VariantSampleMatrix[_],
@@ -592,7 +593,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
       case _ => fatal("this module requires one of `root' or 'code', but not both")
     }
 
-    val (finalType, inserter): (Type, (Annotation, Option[Annotation]) => Annotation) =
+    val (finalType, inserter): (Type, (Annotation, Annotation) => Annotation) =
       if (isCode) {
         val ec = EvalContext(Map(
           "sa" -> (0, saSignature),
@@ -602,10 +603,10 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
         insertSA(other.saSignature, Parser.parseAnnotationRoot(annotationExpr, Annotation.SAMPLE_HEAD))
 
     val m = other.sampleIdsAndAnnotations.toMap
-    annotateSamples(m.get _, finalType, inserter)
+    annotateSamples(s => m.getOrElse(s, null), finalType, inserter)
   }
 
-  def annotateSamples(annotation: (String) => Option[Annotation], newSignature: Type, inserter: Inserter): VariantSampleMatrix[T] = {
+  def annotateSamples(annotation: (String) => Annotation, newSignature: Type, inserter: Inserter): VariantSampleMatrix[T] = {
     val newAnnotations = sampleIds.zipWithIndex.map { case (id, i) =>
       val sa = sampleAnnotations(i)
       val newAnnotation = inserter(sa, annotation(id))
@@ -688,11 +689,11 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
 
     val thisRdd = rdd.map { case (v, (va, gs)) =>
       vdsKeyEc.setAll(v, va)
-      (Annotation.fromSeq(vdsKeyFs.map(f => f().orNull)), (v, va))
+      (Annotation.fromSeq(vdsKeyFs.map(_ ())), (v, va))
     }
 
     val variantKeyedRdd = ktRdd.join(thisRdd)
-      .map { case (_, (table, (v, va))) => (v, inserter(va, Some(table))) }
+      .map { case (_, (table, (v, va))) => (v, inserter(va, table)) }
 
     val ordRdd = OrderedRDD(variantKeyedRdd, None, None)
 
@@ -724,7 +725,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
       case _ => fatal("this module requires one of `root' or 'code', but not both")
     }
 
-    val (finalType, inserter): (Type, (Annotation, Option[Annotation]) => Annotation) =
+    val (finalType, inserter): (Type, (Annotation, Annotation) => Annotation) =
       if (isCode) {
         val ec = EvalContext(Map(
           "va" -> (0, vaSignature),
@@ -736,11 +737,13 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
 
 
     import is.hail.variant.LocusImplicits.orderedKey
-    val lociRDD = locusRDD.flatMap {
+    val lociRDD = locusRDD.map {
       _.map { a =>
-        locusQuery(a).map(l => (l, a))
+        (locusQuery(a), a)
       }.value
-    }.toOrderedRDD(rdd.orderedPartitioner.mapMonotonic)
+    }
+      .filter { case (l, a) => l != null }
+      .toOrderedRDD(rdd.orderedPartitioner.mapMonotonic)
 
     annotateLoci(lociRDD, finalType, inserter)
   }
@@ -752,7 +755,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
     val newRDD = rdd
       .mapMonotonic(OrderedKeyFunction(_.locus), { case (v, vags) => (v, vags) })
       .orderedLeftJoinDistinct(lociRDD)
-      .map { case (l, ((v, (va, gs)), annotation)) => (v, (inserter(va, annotation), gs)) }
+      .map { case (l, ((v, (va, gs)), annotation)) => (v, (inserter(va, annotation.orNull), gs)) }
 
     // we safely use the non-shuffling apply method of OrderedRDD because orderedLeftJoinDistinct preserves the
     // (Variant) ordering of the left RDD
@@ -783,21 +786,24 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
       case _ => fatal("this module requires one of `root' or 'code', but not both")
     }
 
-    val (finalType, inserter): (Type, (Annotation, Option[Annotation]) => Annotation) =
+    val (finalType, inserter): (Type, (Annotation, Annotation) => Annotation) =
       if (isCode) {
         val ec = EvalContext(Map(
           "va" -> (0, vaSignature),
           "table" -> (1, struct)))
         Annotation.buildInserter(annotationExpr, vaSignature, ec, Annotation.VARIANT_HEAD)
-      } else insertVA(struct, Parser.parseAnnotationRoot(annotationExpr, Annotation.VARIANT_HEAD))
+      } else
+        insertVA(struct, Parser.parseAnnotationRoot(annotationExpr, Annotation.VARIANT_HEAD))
 
     val variantQuery = struct.parseInStructScope[Variant](variantExpr)
 
-    val keyedRDD = variantRDD.flatMap {
+    val keyedRDD = variantRDD.map {
       _.map { a =>
-        variantQuery(a).map(v => (v, a))
+        (variantQuery(a), a)
       }.value
-    }.toOrderedRDD(rdd.orderedPartitioner)
+    }
+      .filter { case (v, a) => v != null }
+      .toOrderedRDD(rdd.orderedPartitioner)
 
     annotateVariants(keyedRDD, finalType, inserter)
   }
@@ -806,7 +812,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
     inserter: Inserter): VariantSampleMatrix[T] = {
     val newRDD = rdd.orderedLeftJoinDistinct(otherRDD)
       .mapValues { case ((va, gs), annotation) =>
-        (inserter(va, annotation), gs)
+        (inserter(va, annotation.orNull), gs)
       }.asOrderedRDD
     copy(rdd = newRDD, vaSignature = newSignature)
   }
@@ -820,7 +826,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
       case _ => fatal("this module requires one of `root' or 'code', but not both")
     }
 
-    val (finalType, inserter): (Type, (Annotation, Option[Annotation]) => Annotation) =
+    val (finalType, inserter): (Type, (Annotation, Annotation) => Annotation) =
       if (isCode) {
         val ec = EvalContext(Map(
           "va" -> (0, vaSignature),
@@ -1097,14 +1103,14 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
     copy(rdd = minrepped.smartShuffleAndSort(rdd.orderedPartitioner, maxShift))
   }
 
-  def queryGlobal(path: String): (Type, Option[Annotation]) = {
+  def queryGlobal(path: String): (Type, Annotation) = {
     val st = Map(Annotation.GLOBAL_HEAD -> (0, globalSignature))
     val ec = EvalContext(st)
     val a = ec.a
 
     val (t, f) = Parser.parseExpr(path, ec)
 
-    val f2: Annotation => Option[Any] = { annotation =>
+    val f2: Annotation => Any = { annotation =>
       a(0) = annotation
       f()
     }
@@ -1120,7 +1126,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
 
     val (t, f) = Parser.parseExpr(code, ec)
 
-    val f2: Annotation => Option[Any] = { annotation =>
+    val f2: Annotation => Any = { annotation =>
       a(0) = annotation
       f()
     }
@@ -1155,7 +1161,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
     resOp(results)
     ec.set(0, localGlobalAnnotation)
 
-    ts.map { case (t, f) => (f().orNull, t) }.toArray
+    ts.map { case (t, f) => (f(), t) }.toArray
   }
 
   def queryVA(code: String): (Type, Querier) = {
@@ -1166,7 +1172,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
 
     val (t, f) = Parser.parseExpr(code, ec)
 
-    val f2: Annotation => Option[Any] = { annotation =>
+    val f2: Annotation => Any = { annotation =>
       a(0) = annotation
       f()
     }
@@ -1204,7 +1210,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
     resOp(result)
 
     ec.setAll(localGlobalAnnotation)
-    ts.map { case (t, f) => (f().orNull, t) }.toArray
+    ts.map { case (t, f) => (f(), t) }.toArray
   }
 
   /**

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -460,7 +460,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
     val isBc = sparkContext.broadcast(is)
     val (newSignature, inserter) = insertVA(TBoolean, path)
     copy(rdd = rdd.mapValuesWithKey { case (v, (va, gs)) =>
-      (inserter(va, isBc.value.contains(Locus(v.contig, v.start))), gs)
+      (inserter(va, isBc.value.contains(v.locus)), gs)
     }.asOrderedRDD,
       vaSignature = newSignature)
   }

--- a/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
+++ b/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
@@ -39,8 +39,8 @@ class AnnotationsSuite extends SparkSuite {
         && f.attrs == Map("Type" -> "Integer",
         "Number" -> "1",
         "Description" -> "Approximate read depth; some reads may have been filtered")))
-    assert(dpQuery(variantAnnotationMap(firstVariant)).contains(77560))
-    assert(dpQuery(variantAnnotationMap(anotherVariant)).contains(20271))
+    assert(dpQuery(variantAnnotationMap(firstVariant)) == 77560)
+    assert(dpQuery(variantAnnotationMap(anotherVariant)) == 20271)
 
     // type Double - info.HWP
     val hwpQuery = vas.query("info", "HWP")
@@ -49,11 +49,8 @@ class AnnotationsSuite extends SparkSuite {
         && f.attrs == Map("Type" -> "Float",
         "Number" -> "1",
         "Description" -> "P value from test of Hardy Weinberg Equilibrium")))
-    assert(
-      D_==(hwpQuery(variantAnnotationMap(firstVariant))
-        .get.asInstanceOf[Double], 0.0001))
-    assert(D_==(hwpQuery(variantAnnotationMap(anotherVariant))
-      .get.asInstanceOf[Double], 0.8286))
+    assert(D_==(hwpQuery(variantAnnotationMap(firstVariant)).asInstanceOf[Double], 0.0001))
+    assert(D_==(hwpQuery(variantAnnotationMap(anotherVariant)).asInstanceOf[Double], 0.8286))
 
     // type String - info.culprit
     val culpritQuery = vas.query("info", "culprit")
@@ -62,10 +59,8 @@ class AnnotationsSuite extends SparkSuite {
         && f.attrs == Map("Type" -> "String",
         "Number" -> "1",
         "Description" -> "The annotation which was the worst performing in the Gaussian mixture model, likely the reason why the variant was filtered out")))
-    assert(culpritQuery(variantAnnotationMap(firstVariant))
-      .contains("FS"))
-    assert(culpritQuery(variantAnnotationMap(anotherVariant))
-      .contains("FS"))
+    assert(culpritQuery(variantAnnotationMap(firstVariant)) == "FS")
+    assert(culpritQuery(variantAnnotationMap(anotherVariant)) == "FS")
 
     // type Array - info.AC (allele count)
     val acQuery = vas.query("info", "AC")
@@ -74,10 +69,8 @@ class AnnotationsSuite extends SparkSuite {
         f.attrs == Map("Number" -> "A",
           "Type" -> "Integer",
           "Description" -> "Allele count in genotypes, for each ALT allele, in the same order as listed")))
-    assert(acQuery(variantAnnotationMap(firstVariant))
-      .contains(Array(89): mutable.WrappedArray[Int]))
-    assert(acQuery(variantAnnotationMap(anotherVariant))
-      .contains(Array(13): mutable.WrappedArray[Int]))
+    assert(acQuery(variantAnnotationMap(firstVariant)) == IndexedSeq(89))
+    assert(acQuery(variantAnnotationMap(anotherVariant)) == IndexedSeq(13))
 
     // type Boolean/flag - info.DB (dbSNP membership)
     val dbQuery = vas.query("info", "DB")
@@ -86,10 +79,8 @@ class AnnotationsSuite extends SparkSuite {
         && f.attrs == Map("Type" -> "Flag",
         "Number" -> "0",
         "Description" -> "dbSNP Membership")))
-    assert(dbQuery(variantAnnotationMap(firstVariant))
-      .contains(true))
-    assert(dbQuery(variantAnnotationMap(anotherVariant))
-      .isEmpty)
+    assert(dbQuery(variantAnnotationMap(firstVariant)) == true)
+    assert(dbQuery(variantAnnotationMap(anotherVariant)) == null)
 
     //type Set[String]
 
@@ -97,19 +88,15 @@ class AnnotationsSuite extends SparkSuite {
     assert(vas.fieldOption("filters").exists(f =>
       f.typ == TSet(TString)
         && f.attrs.nonEmpty))
-    assert(filtQuery(variantAnnotationMap(firstVariant))
-      contains Set("PASS"))
-    assert(filtQuery(variantAnnotationMap(anotherVariant))
-      contains Set("VQSRTrancheSNP99.95to100.00"))
+    assert(filtQuery(variantAnnotationMap(firstVariant)) == Set("PASS"))
+    assert(filtQuery(variantAnnotationMap(anotherVariant)) == Set("VQSRTrancheSNP99.95to100.00"))
 
     // GATK PASS
     val passQuery = vas.query("pass")
     assert(vas.fieldOption("pass").exists(f => f.typ == TBoolean
       && f.attrs == Map.empty))
-    assert(passQuery(variantAnnotationMap(firstVariant))
-      .contains(true))
-    assert(passQuery(variantAnnotationMap(anotherVariant))
-      .contains(false))
+    assert(passQuery(variantAnnotationMap(firstVariant)) == true)
+    assert(passQuery(variantAnnotationMap(anotherVariant)) == false)
 
     val vds2 = hc.importVCF("src/test/resources/sample2.vcf")
     val vas2 = vds2.vaSignature
@@ -153,38 +140,38 @@ class AnnotationsSuite extends SparkSuite {
     val toAdd = 5
     val toAddSig = TInt
     val (s1, i1) = vds.vaSignature.insert(toAddSig, "I1")
-    vds = vds.mapAnnotations((v, va, gs) => i1(va, Some(toAdd)))
+    vds = vds.mapAnnotations((v, va, gs) => i1(va, toAdd))
       .copy(vaSignature = s1)
     assert(vds.vaSignature.schema ==
       StructType(Array(StructField("I1", IntegerType))))
 
-    val q1 = vds.queryVA("va.I1")._2
+    val (_, q1) = vds.queryVA("va.I1")
     assert(vds.variantsAndAnnotations
       .collect()
-      .forall { case (v, va) => q1(va) == Some(5) })
+      .forall { case (v, va) => q1(va) == 5 })
 
     // add another to the first layer
     val toAdd2 = "test"
     val toAdd2Sig = TString
     val (s2, i2) = vds.vaSignature.insert(toAdd2Sig, "S1")
-    vds = vds.mapAnnotations((v, va, gs) => i2(va, Some(toAdd2)))
+    vds = vds.mapAnnotations((v, va, gs) => i2(va, toAdd2))
       .copy(vaSignature = s2)
     assert(vds.vaSignature.schema ==
       StructType(Array(
         StructField("I1", IntegerType),
         StructField("S1", StringType))))
 
-    val q2 = vds.queryVA("va.S1")._2
+    val (_, q2) = vds.queryVA("va.S1")
     assert(vds.variantsAndAnnotations
       .collect()
-      .forall { case (v, va) => q2(va) == Some("test") })
+      .forall { case (v, va) => q2(va) == "test" })
 
     // overwrite I1 with a row in the second layer
     val toAdd3 = Annotation(1, 3)
     val toAdd3Sig = TStruct("I2" -> TInt,
       "I3" -> TInt)
     val (s3, i3) = vds.vaSignature.insert(toAdd3Sig, "I1")
-    vds = vds.mapAnnotations((v, va, gs) => i3(va, Some(toAdd3)))
+    vds = vds.mapAnnotations((v, va, gs) => i3(va, toAdd3))
       .copy(vaSignature = s3)
     assert(vds.vaSignature.schema ==
       StructType(Array(
@@ -194,22 +181,22 @@ class AnnotationsSuite extends SparkSuite {
         )), nullable = true),
         StructField("S1", StringType))))
 
-    val q3 = vds.queryVA("va.I1")._2
-    val q4 = vds.queryVA("va.I1.I2")._2
-    val q5 = vds.queryVA("va.I1.I3")._2
+    val (_, q3) = vds.queryVA("va.I1")
+    val (_, q4) = vds.queryVA("va.I1.I2")
+    val (_, q5) = vds.queryVA("va.I1.I3")
     assert(vds.variantsAndAnnotations
       .collect()
       .forall { case (v, va) =>
-        (q3(va) == Some(Annotation(1, 3))) &&
-          (q4(va) == Some(1)) &&
-          (q5(va) == Some(3))
+        (q3(va) == Annotation(1, 3)) &&
+          (q4(va) == 1) &&
+          (q5(va) == 3)
       })
 
     // add something deep in the tree with an unbuilt structure
     val toAdd4 = "dummy"
     val toAdd4Sig = TString
     val (s4, i4) = vds.insertVA(toAdd4Sig, "a", "b", "c", "d", "e")
-    vds = vds.mapAnnotations((v, va, gs) => i4(va, Some(toAdd4)))
+    vds = vds.mapAnnotations((v, va, gs) => i4(va, toAdd4))
       .copy(vaSignature = s4)
     assert(vds.vaSignature.schema ==
       StructType(Array(
@@ -221,16 +208,16 @@ class AnnotationsSuite extends SparkSuite {
               StructField("d", StructType(Array(
                 StructField("e", StringType))))))))))))))))
 
-    val q6 = vds.queryVA("va.a.b.c.d.e")._2
+    val (_, q6) = vds.queryVA("va.a.b.c.d.e")
     assert(vds.variantsAndAnnotations
       .collect()
-      .forall { case (v, va) => q6(va) == Some("dummy") })
+      .forall { case (v, va) => q6(va) == "dummy" })
 
     // add something as a sibling deep in the tree
     val toAdd5 = "dummy2"
     val toAdd5Sig = TString
     val (s5, i5) = vds.insertVA(toAdd5Sig, "a", "b", "c", "f")
-    vds = vds.mapAnnotations((v, va, gs) => i5(va, Some(toAdd5)))
+    vds = vds.mapAnnotations((v, va, gs) => i5(va, toAdd5))
       .copy(vaSignature = s5)
 
     assert(vds.vaSignature.schema ==
@@ -243,16 +230,16 @@ class AnnotationsSuite extends SparkSuite {
               StructField("d", StructType(Array(
                 StructField("e", StringType)))),
               StructField("f", StringType)))))))))))))
-    val q7 = vds.queryVA("va.a.b.c.f")._2
+    val (_, q7) = vds.queryVA("va.a.b.c.f")
     assert(vds.variantsAndAnnotations
       .collect()
-      .forall { case (v, va) => q7(va) == Some("dummy2") })
+      .forall { case (v, va) => q7(va) == "dummy2" })
 
     // overwrite something deep in the tree
     val toAdd6 = "dummy3"
     val toAdd6Sig = TString
     val (s6, i6) = vds.insertVA(toAdd6Sig, "a", "b", "c", "d")
-    vds = vds.mapAnnotations((v, va, gs) => i6(va, Some(toAdd6)))
+    vds = vds.mapAnnotations((v, va, gs) => i6(va, toAdd6))
       .copy(vaSignature = s6)
 
     assert(vds.vaSignature.schema ==
@@ -265,15 +252,15 @@ class AnnotationsSuite extends SparkSuite {
               StructField("d", StringType),
               StructField("f", StringType)))))))))))))
 
-    val q8 = vds.queryVA("va.a.b.c.d")._2
+    val (_, q8) = vds.queryVA("va.a.b.c.d")
     assert(vds.variantsAndAnnotations
       .collect()
-      .forall { case (v, va) => q8(va) == Some("dummy3") })
+      .forall { case (v, va) => q8(va) == "dummy3" })
 
     val toAdd7 = "dummy4"
     val toAdd7Sig = TString
     val (s7, i7) = vds.insertVA(toAdd7Sig, "a", "c")
-    vds = vds.mapAnnotations((v, va, gs) => i7(va, Some(toAdd7)))
+    vds = vds.mapAnnotations((v, va, gs) => i7(va, toAdd7))
       .copy(vaSignature = s7)
 
     assert(vds.vaSignature.schema ==
@@ -286,10 +273,10 @@ class AnnotationsSuite extends SparkSuite {
               StructField("d", StringType),
               StructField("f", StringType))))))),
           StructField("c", StringType)))))))
-    val q9 = vds.queryVA("va.a.c")._2
+    val (_, q9) = vds.queryVA("va.a.c")
     assert(vds.variantsAndAnnotations
       .collect()
-      .forall { case (v, va) => q9(va) == Some(toAdd7) })
+      .forall { case (v, va) => q9(va) == toAdd7 })
 
     // delete a.b.c and ensure that b is deleted and a.c gets shifted over
     val (s8, d2) = vds.deleteVA("a", "b", "c")
@@ -301,10 +288,10 @@ class AnnotationsSuite extends SparkSuite {
         StructField("S1", StringType),
         StructField("a", StructType(Array(
           StructField("c", StringType)))))))
-    val q10 = vds.queryVA("va.a")._2
+    val (_, q10) = vds.queryVA("va.a")
     assert(vds.variantsAndAnnotations
       .collect()
-      .forall { case (v, va) => q10(va) == Some(Annotation(toAdd7)) })
+      .forall { case (v, va) => q10(va) == Annotation(toAdd7) })
 
     // delete that part of the tree
     val (s9, d3) = vds.deleteVA("a")
@@ -336,7 +323,7 @@ class AnnotationsSuite extends SparkSuite {
     val toAdd8 = "dummy"
     val toAdd8Sig = TString
     val (s11, i8) = vds.insertVA(toAdd8Sig, List[String]())
-    vds = vds.mapAnnotations((v, va, gs) => i8(va, Some(toAdd8)))
+    vds = vds.mapAnnotations((v, va, gs) => i8(va, toAdd8))
       .copy(vaSignature = s11)
 
     assert(vds.vaSignature.schema == toAdd8Sig.schema)
@@ -350,7 +337,7 @@ class AnnotationsSuite extends SparkSuite {
 
     val f = tmpDir.createTempFile("testwrite", extension = ".vds")
     val (newS, ins) = vds.insertVA(TInt, "ThisName(won'twork)=====")
-    vds = vds.mapAnnotations((v, va, gs) => ins(va, Some(5)))
+    vds = vds.mapAnnotations((v, va, gs) => ins(va, 5))
       .copy(vaSignature = newS)
     vds.write(f)
 

--- a/src/test/scala/is/hail/io/ExportVcfSuite.scala
+++ b/src/test/scala/is/hail/io/ExportVcfSuite.scala
@@ -37,10 +37,10 @@ class ExportVcfSuite extends SparkSuite {
 
     val vdsNew = hc.importVCF(outFile, nPartitions = Some(10))
 
-    assert(vdsOrig.eraseSplit.same(vdsNew.eraseSplit))
+    assert(vdsOrig.eraseSplit().same(vdsNew.eraseSplit()))
 
     val infoSize = vdsNew.vaSignature.getAsOption[TStruct]("info").get.size
-    val toAdd = Some(Annotation.fromSeq(Array.fill[Any](infoSize)(null)))
+    val toAdd = Annotation.fromSeq(Array.fill[Any](infoSize)(null))
     val (_, inserter) = vdsNew.insertVA(null, "info")
 
     val vdsNewMissingInfo = vdsNew.mapAnnotations((v, va, gs) => inserter(va, toAdd))
@@ -48,7 +48,7 @@ class ExportVcfSuite extends SparkSuite {
 
     vdsNewMissingInfo.exportVCF(outFile2)
 
-    assert(hc.importVCF(outFile2).eraseSplit.same(vdsNewMissingInfo.eraseSplit, 1e-2))
+    assert(hc.importVCF(outFile2).eraseSplit().same(vdsNewMissingInfo.eraseSplit(), 1e-2))
   }
 
   @Test def testSorted() {

--- a/src/test/scala/is/hail/io/LoadBgenSuite.scala
+++ b/src/test/scala/is/hail/io/LoadBgenSuite.scala
@@ -47,13 +47,13 @@ class LoadBgenSuite extends SparkSuite {
     assert(bgenVDS.metadata == genVDS.metadata)
     assert(bgenVDS.sampleIds == genVDS.sampleIds)
 
-    val bgenAnnotations = bgenVDS.variantsAndAnnotations.map { case (v, va) => (varidBgenQuery(va).get, va) }
-    val genAnnotations = genVDS.variantsAndAnnotations.map { case (v, va) => (varidGenQuery(va).get, va) }
+    val bgenAnnotations = bgenVDS.variantsAndAnnotations.map { case (v, va) => (varidBgenQuery(va), va) }
+    val genAnnotations = genVDS.variantsAndAnnotations.map { case (v, va) => (varidGenQuery(va), va) }
 
     assert(genAnnotations.fullOuterJoin(bgenAnnotations).forall { case (varid, (va1, va2)) => if (va1 == va2) true else false })
 
-    val bgenFull = bgenVDS.expandWithAll().map { case (v, va, s, sa, gt) => ((varidBgenQuery(va).get, s), gt) }
-    val genFull = genVDS.expandWithAll().map { case (v, va, s, sa, gt) => ((varidGenQuery(va).get, s), gt) }
+    val bgenFull = bgenVDS.expandWithAll().map { case (v, va, s, sa, gt) => ((varidBgenQuery(va), s), gt) }
+    val genFull = genVDS.expandWithAll().map { case (v, va, s, sa, gt) => ((varidGenQuery(va), s), gt) }
 
     genFull.fullOuterJoin(bgenFull)
       .collect()

--- a/src/test/scala/is/hail/io/LoadGenSuite.scala
+++ b/src/test/scala/is/hail/io/LoadGenSuite.scala
@@ -31,7 +31,7 @@ class LoadGenSuite extends SparkSuite {
     val genOrigData = makeRDD(gen)
 
     val genQuery = genVDS.vaSignature.query("varid")
-    val newRDD: RDD[(String, Iterable[Genotype])] = genVDS.rdd.map { case (v, (va, gs)) => (genQuery(va).get.toString, gs) }
+    val newRDD: RDD[(String, Iterable[Genotype])] = genVDS.rdd.map { case (v, (va, gs)) => (genQuery(va).toString, gs) }
 
     val res = newRDD.fullOuterJoin(genOrigData).forall { case (v, (gs, dos)) =>
       val gs1 = gs.get

--- a/src/test/scala/is/hail/io/SplitSuite.scala
+++ b/src/test/scala/is/hail/io/SplitSuite.scala
@@ -15,7 +15,7 @@ class SplitSuite extends SparkSuite {
       forAll(VariantSampleMatrix.gen[Genotype](hc, VSMSubgen.random).map(_.splitMulti())) { (vds: VariantDataset) =>
         val wasSplitQuerier = vds.vaSignature.query("wasSplit")
         vds.mapWithAll((v: Variant, va: Annotation, _: String, _: Annotation, g: Genotype) =>
-          !g.fakeRef || wasSplitQuerier(va).asInstanceOf[Option[Boolean]].get)
+          !g.fakeRef || wasSplitQuerier(va).asInstanceOf[Boolean])
           .collect()
           .forall(identity)
       }
@@ -62,7 +62,7 @@ class SplitSuite extends SparkSuite {
     val wasSplitQuerier = vds1.vaSignature.query("wasSplit")
 
     // test for wasSplit
-    vds1.mapWithAll((v, va, s, sa, g) => (v.start, wasSplitQuerier(va).asInstanceOf[Option[Boolean]].get))
+    vds1.mapWithAll((v, va, s, sa, g) => (v.start, wasSplitQuerier(va).asInstanceOf[Boolean]))
       .foreach { case (i, b) =>
         simpleAssert(b == (i != 1180))
       }

--- a/src/test/scala/is/hail/methods/AggregatorSuite.scala
+++ b/src/test/scala/is/hail/methods/AggregatorSuite.scala
@@ -38,11 +38,11 @@ class AggregatorSuite extends SparkSuite {
       .foreach { case (v, (va, gs)) =>
         assert(qCallRate(va) == qCallRateQC(va))
         assert(qAC(va) == qACQC(va))
-        assert(D_==(qAF(va).get.asInstanceOf[Double], qAFQC(va).get.asInstanceOf[Double]))
-        assert(gqStatsMean(va).zip(gqStatsMeanQC(va)).forall {
+        assert(D_==(qAF(va).asInstanceOf[Double], qAFQC(va).asInstanceOf[Double]))
+        assert(Option(gqStatsMean(va)).zip(Option(gqStatsMeanQC(va))).forall {
           case (a, b) => D_==(a.asInstanceOf[Double], b.asInstanceOf[Double])
         })
-        assert(gqStatsStDev(va).zip(gqStatsStDevQC(va)).forall {
+        assert(Option(gqStatsStDev(va)).zip(Option(gqStatsStDevQC(va))).forall {
           case (a, b) => D_==(a.asInstanceOf[Double], b.asInstanceOf[Double])
         })
 
@@ -52,15 +52,15 @@ class AggregatorSuite extends SparkSuite {
           s
         }, { case (s1, s2) => s1.merge(s2) })
 
-        assert(gqStatsHetMean(va).zip(Option(gqSC.mean)).forall {
+        assert(Option(gqStatsHetMean(va)).zip(Option(gqSC.mean)).forall {
           case (a, b) => D_==(a.asInstanceOf[Double], b.asInstanceOf[Double])
         })
-        assert(gqStatsHetStDev(va).zip(Option(gqSC.stdev)).forall {
+        assert(Option(gqStatsHetStDev(va)).zip(Option(gqSC.stdev)).forall {
           case (a, b) => D_==(a.asInstanceOf[Double], b.asInstanceOf[Double])
         })
 
         val lowGqGtsData = gs.filter(_.gq.exists(_ < 60))
-        assert(lowGqGts(va).map(_.asInstanceOf[IndexedSeq[_]]).contains(lowGqGtsData.toIndexedSeq))
+        assert(Option(lowGqGts(va)).map(_.asInstanceOf[IndexedSeq[_]]).contains(lowGqGtsData.toIndexedSeq))
 
       }
   }
@@ -92,16 +92,16 @@ class AggregatorSuite extends SparkSuite {
       .foreach {
         case (s, sa) =>
           assert(qCallRate(sa) == qCallRateQC(sa))
-          assert(gqStatsMean(sa).zip(gqStatsMeanQC(sa)).forall {
+          assert(Option(gqStatsMean(sa)).zip(Option(gqStatsMeanQC(sa))).forall {
             case (a, b) => D_==(a.asInstanceOf[Double], b.asInstanceOf[Double])
           })
-          assert(gqStatsStDev(sa).zip(gqStatsStDevQC(sa)).forall {
+          assert(Option(gqStatsStDev(sa)).zip(Option(gqStatsStDevQC(sa))).forall {
             case (a, b) => D_==(a.asInstanceOf[Double], b.asInstanceOf[Double])
           })
-          assert(gqStatsHetMean(sa).zip(gqHetMap.get(s).map(_.mean)).forall {
+          assert(Option(gqStatsHetMean(sa)).zip(gqHetMap.get(s).map(_.mean)).forall {
             case (a, b) => D_==(a.asInstanceOf[Double], b.asInstanceOf[Double])
           })
-          assert(gqStatsHetStDev(sa).zip(gqHetMap.get(s).map(_.stdev)).forall {
+          assert(Option(gqStatsHetStDev(sa)).zip(gqHetMap.get(s).map(_.stdev)).forall {
             case (a, b) => D_==(a.asInstanceOf[Double], b.asInstanceOf[Double])
           })
       }
@@ -117,7 +117,7 @@ class AggregatorSuite extends SparkSuite {
       val (_, querier) = vds2.queryVA("va.same")
       vds2.variantsAndAnnotations
         .forall { case (v, va) =>
-          querier(va).exists(_.asInstanceOf[Boolean])
+          Option(querier(va)).exists(_.asInstanceOf[Boolean])
         }
     }
     p.check()
@@ -231,8 +231,8 @@ class AggregatorSuite extends SparkSuite {
     val (_, qTakeBy) = vds.queryVA("va.takeBy")
 
     val va = vds.variantsAndAnnotations.map(_._2).collect().head
-    assert(qTake(va).contains(IndexedSeq[Any](11, null, 20)))
-    assert(qTakeBy(va).contains(IndexedSeq[Any](55, null, 11)))
+    assert(qTake(va) == IndexedSeq[Any](11, null, 20))
+    assert(qTakeBy(va) == IndexedSeq[Any](55, null, 11))
   }
 
   @Test def testTransformations() {

--- a/src/test/scala/is/hail/methods/ConcordanceSuite.scala
+++ b/src/test/scala/is/hail/methods/ConcordanceSuite.scala
@@ -143,15 +143,15 @@ class ConcordanceSuite extends SparkSuite {
       val (_, innerJoinQuery) = samples.querySA("sa.concordance.map(x => x[1:])[1:]")
 
       samples.sampleIdsAndAnnotations.foreach { case (s, sa) =>
-        assert(queryUnique1Sum(sa).contains(uniqueVds2Variants))
-        assert(queryUnique2Sum(sa).contains(uniqueVds1Variants))
-        assert(innerJoinQuery(sa).contains(innerJoinSamples(s)))
+        assert(queryUnique1Sum(sa) == uniqueVds2Variants)
+        assert(queryUnique2Sum(sa) == uniqueVds1Variants)
+        assert(innerJoinQuery(sa) == innerJoinSamples(s))
       }
 
       val (_, variantQuery) = variants.queryVA("va.concordance")
       variants.variantsAndAnnotations.collect()
         .foreach { case (v, va) =>
-          innerJoinVariants.get(v).forall(variantQuery(va).contains)
+          innerJoinVariants.get(v).forall(variantQuery(va) == _)
         }
       true
     }.check()

--- a/src/test/scala/is/hail/methods/ExportSuite.scala
+++ b/src/test/scala/is/hail/methods/ExportSuite.scala
@@ -32,7 +32,7 @@ class ExportSuite extends SparkSuite {
     val (t2, rbQuerier) = readBackAnnotated.querySA("sa.readBackQC")
     assert(t == t2)
     readBackAnnotated.sampleAnnotations.foreach { annotation =>
-      t.valuesSimilar(qcQuerier(annotation).get, rbQuerier(annotation).get)
+      t.valuesSimilar(qcQuerier(annotation), rbQuerier(annotation))
     }
   }
 

--- a/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -90,13 +90,13 @@ class ExprSuite extends SparkSuite {
     // used to force serialization of values
     def eval[T](s: String): Option[T] = {
       val f = Parser.parseExpr(s, ec)._2
-      val r = f().map(_.asInstanceOf[T])
+      val r = Option(f()).map(_.asInstanceOf[T])
       rdd.map(_ => r).collect().head // force serialization
     }
 
     def evalWithType[T](s: String): (Type, Option[T]) = {
       val (t, f) = Parser.parseExpr(s, ec)
-      (t, f().map(_.asInstanceOf[T]))
+      (t, Option(f()).map(_.asInstanceOf[T]))
     }
 
     assert(eval[Int]("is.toInt").contains(-37))
@@ -762,7 +762,7 @@ class ExprSuite extends SparkSuite {
 
     def eval[T](s: String): (Type, Option[T]) = {
       val (t, f) = Parser.parseExpr(s, ec)
-      (t, f().map(_.asInstanceOf[T]))
+      (t, Option(f()).map(_.asInstanceOf[T]))
     }
 
     assert(Parser.parseExpr("if (c) 0 else 0", ec)._1 == TInt)

--- a/src/test/scala/is/hail/methods/FilterSuite.scala
+++ b/src/test/scala/is/hail/methods/FilterSuite.scala
@@ -128,7 +128,7 @@ class FilterSuite extends SparkSuite {
     val missingVariants = keepOneSample.variantsAndAnnotations
       .collect()
       .filter { case (v, va) =>
-        q(va).isEmpty
+        q(va) == null
       }
       .map(_._1)
 
@@ -147,7 +147,7 @@ class FilterSuite extends SparkSuite {
     var vds = hc.importVCF("src/test/resources/sample.vcf")
     val (sigs, i) = vds.insertVA(TInt, "weird name \t test")
     vds = vds
-      .mapAnnotations((v, va, gs) => i(va, Some(1000)))
+      .mapAnnotations((v, va, gs) => i(va, 1000))
       .copy(vaSignature = sigs)
     assert(vds.filterVariantsExpr("va.`weird name \\t test` > 500").countVariants() == vds.countVariants)
 

--- a/src/test/scala/is/hail/methods/ImputeSexSuite.scala
+++ b/src/test/scala/is/hail/methods/ImputeSexSuite.scala
@@ -75,7 +75,7 @@ class ImputeSexSuite extends SparkSuite {
           val (_, fQuery) = mappedVDS.querySA("sa.imputesex.Fstat")
 
           val hailResult = mappedVDS.sampleIdsAndAnnotations.map { case (sample, sa) =>
-            (sample, (imputedSexQuery(sa).map(_.asInstanceOf[Int]), fQuery(sa).map(_.asInstanceOf[Double])))
+            (sample, (Option(imputedSexQuery(sa)).map(_.asInstanceOf[Int]), Option(fQuery(sa)).map(_.asInstanceOf[Double])))
           }.toMap
 
           assert(plinkResult.keySet == hailResult.keySet)

--- a/src/test/scala/is/hail/methods/KeyTableSuite.scala
+++ b/src/test/scala/is/hail/methods/KeyTableSuite.scala
@@ -139,8 +139,8 @@ class KeyTableSuite extends SparkSuite {
     val (_, leftJoinKeyQuery) = ktLeftJoin.query("Sample")
     val (_, rightJoinKeyQuery) = ktRightJoin.query("Sample")
 
-    val leftKeys = ktLeft.rdd.map { case (k, v) => leftKeyQuery(k, v).map(_.asInstanceOf[String]) }.collect().toSet
-    val rightKeys = ktRight.rdd.map { case (k, v) => rightKeyQuery(k, v).map(_.asInstanceOf[String]) }.collect().toSet
+    val leftKeys = ktLeft.rdd.map { case (k, v) => Option(leftKeyQuery(k, v)).map(_.asInstanceOf[String]) }.collect().toSet
+    val rightKeys = ktRight.rdd.map { case (k, v) => Option(rightKeyQuery(k, v)).map(_.asInstanceOf[String]) }.collect().toSet
 
     val nIntersectRows = leftKeys.intersect(rightKeys).size
     val nUnionRows = rightKeys.union(leftKeys).size
@@ -150,7 +150,7 @@ class KeyTableSuite extends SparkSuite {
       ktLeftJoin.nKeys == nExpectedKeys &&
       ktLeftJoin.nValues == nExpectedValues &&
       ktLeftJoin.filter { case (k, v) =>
-        !rightKeys.contains(leftJoinKeyQuery(k, v).map(_.asInstanceOf[String]))
+        !rightKeys.contains(Option(leftJoinKeyQuery(k, v)).map(_.asInstanceOf[String]))
       }.forall("isMissing(qPhen2) && isMissing(qPhen3)")
     )
 
@@ -158,7 +158,7 @@ class KeyTableSuite extends SparkSuite {
       ktRightJoin.nKeys == nExpectedKeys &&
       ktRightJoin.nValues == nExpectedValues &&
       ktRightJoin.filter { case (k, v) =>
-        !leftKeys.contains(rightJoinKeyQuery(k, v).map(_.asInstanceOf[String]))
+        !leftKeys.contains(Option(rightJoinKeyQuery(k, v)).map(_.asInstanceOf[String]))
       }.forall("isMissing(Status) && isMissing(qPhen)"))
 
     assert(ktOuterJoin.nRows == nUnionRows &&

--- a/src/test/scala/is/hail/methods/LinearMixedRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearMixedRegressionSuite.scala
@@ -130,10 +130,10 @@ class LinearMixedRegressionSuite extends SparkSuite {
 
     val annotationMap = vds.variantsAndAnnotations.collect().toMap
 
-    def assertInt(q: Querier, v: Variant, value: Int) = q(annotationMap(v)).get.asInstanceOf[Int] == value
+    def assertInt(q: Querier, v: Variant, value: Int) = q(annotationMap(v)).asInstanceOf[Int] == value
 
     def assertDouble(q: Querier, v: Variant, value: Double) = {
-      val x = q(annotationMap(v)).get.asInstanceOf[Double]
+      val x = q(annotationMap(v)).asInstanceOf[Double]
       assert(D_==(x, value))
     }
 
@@ -262,7 +262,7 @@ class LinearMixedRegressionSuite extends SparkSuite {
     val annotationMap = vds.variantsAndAnnotations.collect().toMap
 
     def assertDouble(q: Querier, v: Variant, value: Double) = {
-      val x = q(annotationMap(v)).get.asInstanceOf[Double]
+      val x = q(annotationMap(v)).asInstanceOf[Double]
       // println(x, value, v)
       assert(D_==(x, value))
     }
@@ -350,12 +350,12 @@ class LinearMixedRegressionSuite extends SparkSuite {
     // vds.metadata.globalSignature.pretty(sb, 0, printAttrs = true)
     // println(sb.result())
 
-    val fitDelta = vds.queryGlobal("global.lmmreg.delta")._2.get.asInstanceOf[Double]
-    val fitSigmaG2 = vds.queryGlobal("global.lmmreg.sigmaG2")._2.get.asInstanceOf[Double]
-    val fitBeta = vds.queryGlobal("global.lmmreg.beta")._2.get.asInstanceOf[Map[String, Double]]
+    val fitDelta = vds.queryGlobal("global.lmmreg.delta")._2.asInstanceOf[Double]
+    val fitSigmaG2 = vds.queryGlobal("global.lmmreg.sigmaG2")._2.asInstanceOf[Double]
+    val fitBeta = vds.queryGlobal("global.lmmreg.beta")._2.asInstanceOf[Map[String, Double]]
 
     //Making sure type on this is not an array, but an IndexedSeq.
-    val evals = vds.queryGlobal("global.lmmreg.evals")._2.get.asInstanceOf[IndexedSeq[Double]]
+    val evals = vds.queryGlobal("global.lmmreg.evals")._2.asInstanceOf[IndexedSeq[Double]]
 
     val linBeta = (C.t * C) \ (C.t * y)
     val linRes = norm(y - C * linBeta)

--- a/src/test/scala/is/hail/methods/LinearRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearRegressionSuite.scala
@@ -50,13 +50,13 @@ class LinearRegressionSuite extends SparkSuite {
       .toMap
 
     def assertInt(q: Querier, v: Variant, value: Int) =
-      assert(D_==(q(annotationMap(v)).get.asInstanceOf[Int], value))
+      assert(D_==(q(annotationMap(v)).asInstanceOf[Int], value))
 
     def assertDouble(q: Querier, v: Variant, value: Double) =
-      assert(D_==(q(annotationMap(v)).get.asInstanceOf[Double], value))
+      assert(D_==(q(annotationMap(v)).asInstanceOf[Double], value))
 
     def assertEmpty(q: Querier, v: Variant) =
-      assert(q(annotationMap(v)).isEmpty)
+      assert(q(annotationMap(v)) == null)
 
     /*
     comparing to output of R code:
@@ -135,10 +135,10 @@ class LinearRegressionSuite extends SparkSuite {
       .toMap
 
     def assertDouble(q: Querier, v: Variant, value: Double) =
-      assert(D_==(q(annotationMap(v)).get.asInstanceOf[Double], value))
+      assert(D_==(q(annotationMap(v)).asInstanceOf[Double], value))
 
     def assertEmpty(q: Querier, v: Variant) =
-      assert(q(annotationMap(v)).isEmpty)
+      assert(q(annotationMap(v)) == null)
 
     /*
     comparing to output of R code:
@@ -205,13 +205,13 @@ class LinearRegressionSuite extends SparkSuite {
       .toMap
 
     def assertInt(q: Querier, v: Variant, value: Int) =
-      assert(D_==(q(annotationMap(v)).get.asInstanceOf[Int], value))
+      assert(D_==(q(annotationMap(v)).asInstanceOf[Int], value))
 
     def assertDouble(q: Querier, v: Variant, value: Double) =
-      assert(D_==(q(annotationMap(v)).get.asInstanceOf[Double], value))
+      assert(D_==(q(annotationMap(v)).asInstanceOf[Double], value))
 
     def assertEmpty(q: Querier, v: Variant) =
-      assert(q(annotationMap(v)).isEmpty)
+      assert(q(annotationMap(v)) == null)
 
     /*
     comparing to output of R code:
@@ -282,13 +282,13 @@ class LinearRegressionSuite extends SparkSuite {
       .toMap
 
     def assertInt(q: Querier, v: Variant, value: Int) =
-      assert(D_==(q(annotationMap(v)).get.asInstanceOf[Int], value))
+      assert(D_==(q(annotationMap(v)).asInstanceOf[Int], value))
 
     def assertDouble(q: Querier, v: Variant, value: Double) =
-      assert(D_==(q(annotationMap(v)).get.asInstanceOf[Double], value))
+      assert(D_==(q(annotationMap(v)).asInstanceOf[Double], value))
 
     def assertEmpty(q: Querier, v: Variant) =
-      assert(q(annotationMap(v)).isEmpty)
+      assert(q(annotationMap(v)) == null)
 
     /*
     comparing to output of R code:
@@ -379,29 +379,29 @@ class LinearRegressionSuite extends SparkSuite {
 
     def qBeta = vds.queryVA("va.linreg.beta")._2
 
-    assert(qBeta(annotationMap(v1)).isEmpty)
-    assert(qBeta(annotationMap(v2)).isDefined)
+    assert(qBeta(annotationMap(v1)) == null)
+    assert(qBeta(annotationMap(v2)) != null)
 
     // only 6 samples are included, so 12 alleles total
     vds = vds.linreg("sa.pheno.Pheno", Array.empty[String], "va.linreg", 1, 0.3)
 
-    assert(qBeta(annotationMap(v1)).isEmpty)
-    assert(qBeta(annotationMap(v2)).isDefined)
+    assert(qBeta(annotationMap(v1)) == null)
+    assert(qBeta(annotationMap(v2)) != null)
 
     vds = vds.linreg("sa.pheno.Pheno", Array.empty[String], "va.linreg", 1, 0.4)
 
-    assert(qBeta(annotationMap(v1)).isEmpty)
-    assert(qBeta(annotationMap(v2)).isEmpty)
+    assert(qBeta(annotationMap(v1)) == null)
+    assert(qBeta(annotationMap(v2)) == null)
 
     vds = vds.linreg("sa.pheno.Pheno", Array.empty[String], "va.linreg", 1, 0.3)
 
-    assert(qBeta(annotationMap(v1)).isEmpty)
-    assert(qBeta(annotationMap(v2)).isDefined)
+    assert(qBeta(annotationMap(v1)) == null)
+    assert(qBeta(annotationMap(v2)) != null)
 
     vds = vds.linreg("sa.pheno.Pheno", Array.empty[String], "va.linreg", 5, 0.1)
 
-    assert(qBeta(annotationMap(v1)).isEmpty)
-    assert(qBeta(annotationMap(v2)).isEmpty)
+    assert(qBeta(annotationMap(v1)) == null)
+    assert(qBeta(annotationMap(v2)) == null)
   }
 
   @Test def testFiltersFatals() {

--- a/src/test/scala/is/hail/methods/LogisticRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LogisticRegressionSuite.scala
@@ -50,13 +50,13 @@ class LogisticRegressionSuite extends SparkSuite {
       .toMap
 
     def assertDouble(q: Querier, v: Variant, value: Double) =
-      assert(D_==(q(annotationMap(v)).get.asInstanceOf[Double], value))
+      assert(D_==(q(annotationMap(v)).asInstanceOf[Double], value))
 
-    def assertExploded(v: Variant) = assert(qExploded(annotationMap(v)).get.asInstanceOf[Boolean])
+    def assertExploded(v: Variant) = assert(qExploded(annotationMap(v)).asInstanceOf[Boolean])
 
-    def assertNotConverged(v: Variant) = assert(!qConverged(annotationMap(v)).get.asInstanceOf[Boolean])
+    def assertNotConverged(v: Variant) = assert(!qConverged(annotationMap(v)).asInstanceOf[Boolean])
 
-    def assertConstant(v: Variant) = assert(qConverged(annotationMap(v)).isEmpty)
+    def assertConstant(v: Variant) = assert(qConverged(annotationMap(v)) == null)
 
     /*
     comparing to output of R code:
@@ -100,10 +100,10 @@ class LogisticRegressionSuite extends SparkSuite {
     assertConstant(v9)
     assertConstant(v10)
 
-    assert(qBeta(annotationMap(v6)).isEmpty)
-    assert(qSe(annotationMap(v6)).isEmpty)
-    assert(qZstat(annotationMap(v6)).isEmpty)
-    assert(qPVal(annotationMap(v6)).isEmpty)
+    assert(qBeta(annotationMap(v6)) == null)
+    assert(qSe(annotationMap(v6)) == null)
+    assert(qZstat(annotationMap(v6)) == null)
+    assert(qPVal(annotationMap(v6)) == null)
   }
 
   @Test def lrTestWithTwoCov() {
@@ -147,13 +147,13 @@ class LogisticRegressionSuite extends SparkSuite {
       .toMap
 
     def assertDouble(q: Querier, v: Variant, value: Double) =
-      assert(D_==(q(annotationMap(v)).get.asInstanceOf[Double], value))
+      assert(D_==(q(annotationMap(v)).asInstanceOf[Double], value))
 
-    def assertExploded(v: Variant) = assert(qExploded(annotationMap(v)).get.asInstanceOf[Boolean])
+    def assertExploded(v: Variant) = assert(qExploded(annotationMap(v)).asInstanceOf[Boolean])
 
-    def assertNotConverged(v: Variant) = assert(!qConverged(annotationMap(v)).get.asInstanceOf[Boolean])
+    def assertNotConverged(v: Variant) = assert(!qConverged(annotationMap(v)).asInstanceOf[Boolean])
 
-    def assertConstant(v: Variant) = assert(qConverged(annotationMap(v)).isEmpty)
+    def assertConstant(v: Variant) = assert(qConverged(annotationMap(v)) == null)
 
     /*
     comparing to output of R code:
@@ -195,9 +195,9 @@ class LogisticRegressionSuite extends SparkSuite {
     assertConstant(v9)
     assertConstant(v10)
 
-    assert(qBeta(annotationMap(v6)).isEmpty)
-    assert(qChi2(annotationMap(v6)).isEmpty)
-    assert(qPVal(annotationMap(v6)).isEmpty)
+    assert(qBeta(annotationMap(v6)) == null)
+    assert(qChi2(annotationMap(v6)) == null)
+    assert(qPVal(annotationMap(v6)) == null)
   }
 
   @Test def scoreTestWithTwoCov() {
@@ -237,9 +237,9 @@ class LogisticRegressionSuite extends SparkSuite {
       .toMap
 
     def assertDouble(q: Querier, v: Variant, value: Double) =
-      assert(D_==(q(annotationMap(v)).get.asInstanceOf[Double], value))
+      assert(D_==(q(annotationMap(v)).asInstanceOf[Double], value))
 
-    def assertEmpty(v: Variant) = assert(qChi2(annotationMap(v)).isEmpty)
+    def assertEmpty(v: Variant) = assert(qChi2(annotationMap(v)) == null)
 
     /*
     comparing to output of R code:
@@ -278,7 +278,7 @@ class LogisticRegressionSuite extends SparkSuite {
     assertEmpty(v9)
     assertEmpty(v10)
 
-    assert(qPVal(annotationMap(v6)).isEmpty)
+    assert(qPVal(annotationMap(v6)) == null)
   }
 
   @Test def waldEpactsTest() {
@@ -319,7 +319,7 @@ class LogisticRegressionSuite extends SparkSuite {
       .toMap
 
     def assertDouble(q: Querier, v: Variant, value: Double, tol: Double = 1e-4) =
-      assert(D_==(q(annotationMap(v)).get.asInstanceOf[Double], value, tol))
+      assert(D_==(q(annotationMap(v)).asInstanceOf[Double], value, tol))
 
     // Comparing to output of b.wald, b.lrt, and b.score in EPACTS
     // for five 1KG project variants with no missing genotypes

--- a/src/test/scala/is/hail/methods/ProgrammaticAnnotationsSuite.scala
+++ b/src/test/scala/is/hail/methods/ProgrammaticAnnotationsSuite.scala
@@ -22,9 +22,9 @@ class ProgrammaticAnnotationsSuite extends SparkSuite {
     val q4 = vds.querySA("sa.`hi there i have spaces`.another")._2
     val head = vds.sampleAnnotations.head
     vds.sampleAnnotations.foreach { sa =>
-      assert(D_==(qCall(sa).get.asInstanceOf[Double], qMiss(sa).map(x => (100 - x.asInstanceOf[Double]) / 100).get) &&
-        q3(sa).contains(5) &&
-        q4(sa).contains(true))
+      assert(D_==(qCall(sa).asInstanceOf[Double], Option(qMiss(sa)).map(x => (100 - x.asInstanceOf[Double]) / 100).get) &&
+        q3(sa) == 5 &&
+        q4(sa) == true)
     }
   }
 
@@ -47,12 +47,9 @@ class ProgrammaticAnnotationsSuite extends SparkSuite {
     vds.variantsAndAnnotations
       .collect()
       .foreach { case (v, va) =>
-        assert(q(va) == qCallRate(va).map(_.asInstanceOf[Double] * 100) &&
-          q2(va) == qPass(va).map(_.asInstanceOf[Boolean] match {
-            case true => 1
-            case false => 0
-          }) &&
-          q3(va) == qQual(va).map(x => 5 / (x.asInstanceOf[Double] - 5)))
+        assert(Option(q(va)) == Option(qCallRate(va)).map(_.asInstanceOf[Double] * 100) &&
+          Option(q2(va)) == Option(qPass(va)).map(_.asInstanceOf[Boolean].toInt) &&
+          Option(q3(va)) == Option(qQual(va)).map(x => 5 / (x.asInstanceOf[Double] - 5)))
       }
   }
 }

--- a/src/test/scala/is/hail/stats/FisherExactTestSuite.scala
+++ b/src/test/scala/is/hail/stats/FisherExactTestSuite.scala
@@ -122,15 +122,14 @@ class FisherExactTestSuite extends SparkSuite {
         val (_, q8) = vds2.queryVA("va.fet.ci95Upper")
 
         vds2.variantsAndAnnotations.forall { case (v, va) =>
-          val result = FisherExactTest(q1(va).get.asInstanceOf[Long].toInt, q2(va).get.asInstanceOf[Long].toInt,
-            q3(va).get.asInstanceOf[Long].toInt, q4(va).get.asInstanceOf[Long].toInt)
-          val annotationResult = Array(q5(va).asInstanceOf[Option[Double]], q6(va).asInstanceOf[Option[Double]],
-            q7(va).asInstanceOf[Option[Double]], q8(va).asInstanceOf[Option[Double]])
+          val result = FisherExactTest(q1(va).asInstanceOf[Long].toInt, q2(va).asInstanceOf[Long].toInt,
+            q3(va).asInstanceOf[Long].toInt, q4(va).asInstanceOf[Long].toInt)
+          val annotationResult = Array(Option(q5(va)).asInstanceOf[Option[Double]],
+            Option(q6(va)).asInstanceOf[Option[Double]],
+            Option(q7(va)).asInstanceOf[Option[Double]],
+            Option(q8(va)).asInstanceOf[Option[Double]])
 
-          if (result sameElements annotationResult)
-            true
-          else
-            false
+          result sameElements annotationResult
         }
       }
   }

--- a/src/test/scala/is/hail/stats/InbreedingCoefficientSuite.scala
+++ b/src/test/scala/is/hail/stats/InbreedingCoefficientSuite.scala
@@ -69,7 +69,7 @@ class InbreedingCoefficientSuite extends SparkSuite {
           val (_, nCalledQuery) = vds3.querySA("sa.het.nCalled")
 
           val hailResult = vds3.sampleIdsAndAnnotations.map { case (sample, sa) =>
-            (sample, (fQuery(sa).map(_.asInstanceOf[Double]), obsHomQuery(sa).map(_.asInstanceOf[Long]), expHomQuery(sa).map(_.asInstanceOf[Double]), nCalledQuery(sa).map(_.asInstanceOf[Long])))
+            (sample, (Option(fQuery(sa)).map(_.asInstanceOf[Double]), Option(obsHomQuery(sa)).map(_.asInstanceOf[Long]), Option(expHomQuery(sa)).map(_.asInstanceOf[Double]), Option(nCalledQuery(sa)).map(_.asInstanceOf[Long])))
           }.toMap
 
           assert(plinkResult.keySet == hailResult.keySet)

--- a/src/test/scala/is/hail/stats/InfoScoreSuite.scala
+++ b/src/test/scala/is/hail/stats/InfoScoreSuite.scala
@@ -28,7 +28,7 @@ class InfoScoreSuite extends SparkSuite {
     val (_, nQuerier) = vds.queryVA("va.infoScore.nIncluded")
 
     val hailResult = vds.rdd.mapValues { case (va, gs) =>
-      (infoQuerier(va).map(_.asInstanceOf[Double]), nQuerier(va).map(_.asInstanceOf[Int]))
+      (Option(infoQuerier(va)).map(_.asInstanceOf[Double]), Option(nQuerier(va)).map(_.asInstanceOf[Int]))
     }
       .map { case (v, (info, n)) => (v.toString, (info, n)) }.collectAsMap()
 

--- a/src/test/scala/is/hail/variant/IntervalSuite.scala
+++ b/src/test/scala/is/hail/variant/IntervalSuite.scala
@@ -134,14 +134,14 @@ class IntervalSuite extends SparkSuite {
     assert(t == TSet(TString))
 
     vds.rdd.foreach { case (v, (va, gs)) =>
-      val a = q(va).get.asInstanceOf[Set[String]]
+      val a = q(va).asInstanceOf[Set[String]]
 
       if (v.start == 17348324)
         simpleAssert(a == Set("A", "B"))
       else if (v.start >= 17333902 && v.start <= 17370919)
         simpleAssert(a == Set("A"))
       else
-        simpleAssert(a.isEmpty)
+        simpleAssert(a == Set())
     }
 
     @Test def testAggregate() {

--- a/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
@@ -399,12 +399,12 @@ class VSMSuite extends SparkSuite {
       val (_, getFoo) = resultVds.queryVA("va.foo")
 
       result.forall { case (v, (va, gs)) =>
-        if (getKey(va).get.asInstanceOf[Boolean]) {
-          assert(getFoo(va).get == 1)
-          getFoo(va).get == 1
+        if (getKey(va).asInstanceOf[Boolean]) {
+          assert(getFoo(va) == 1)
+          getFoo(va) == 1
         } else {
-          assert(getFoo(va).get == 2)
-          getFoo(va).get == 2
+          assert(getFoo(va) == 2)
+          getFoo(va) == 2
         }
       }
     }.check()
@@ -437,7 +437,7 @@ class VSMSuite extends SparkSuite {
       val (_, getFoo) = resultVds.queryVA("va.foo")
 
       result.forall { case (v, (va, gs)) =>
-        getFoo(va).get == f(getKey1(va).get.asInstanceOf[Boolean], getKey2(va).get.asInstanceOf[Boolean])
+        getFoo(va) == f(getKey1(va).asInstanceOf[Boolean], getKey2(va).asInstanceOf[Boolean])
       }
     }.check()
   }

--- a/src/test/scala/is/hail/vds/AggregateByKeySuite.scala
+++ b/src/test/scala/is/hail/vds/AggregateByKeySuite.scala
@@ -19,10 +19,13 @@ class AggregateByKeySuite extends SparkSuite {
     val (_, saHetQuery) = vds.querySA("sa.nHet")
 
     val ktSampleResults = kt.rdd.map { case (k, v) =>
-      (ktSampleQuery(k, v).map(_.asInstanceOf[String]), ktHetQuery(k, v).map(_.asInstanceOf[Int]))
+      println(k, v)
+      (Option(ktSampleQuery(k, v)).map(_.asInstanceOf[String]), Option(ktHetQuery(k, v)).map(_.asInstanceOf[Int]))
     }.collectAsMap()
 
-    assert(vds.sampleIdsAndAnnotations.forall { case (sid, sa) => saHetQuery(sa) == ktSampleResults(Option(sid)) })
+    println(ktSampleResults)
+
+    assert(vds.sampleIdsAndAnnotations.forall { case (sid, sa) => Option(saHetQuery(sa)) == ktSampleResults(Option(sid)) })
   }
 
   @Test def replicateVariantAggregation() {
@@ -37,10 +40,10 @@ class AggregateByKeySuite extends SparkSuite {
     val (_, vaHetQuery) = vds.queryVA("va.nHet")
 
     val ktVariantResults = kt.rdd.map { case (k, v) =>
-      (ktVariantQuery(k, v).map(_.asInstanceOf[Variant]), ktHetQuery(k, v).map(_.asInstanceOf[Int]))
+      (Option(ktVariantQuery(k, v)).map(_.asInstanceOf[Variant]), Option(ktHetQuery(k, v)).map(_.asInstanceOf[Int]))
     }.collectAsMap()
 
-    assert(vds.variantsAndAnnotations.forall { case (v, va) => vaHetQuery(va) == ktVariantResults(Option(v)) })
+    assert(vds.variantsAndAnnotations.forall { case (v, va) => Option(vaHetQuery(va)) == ktVariantResults(Option(v)) })
   }
 
   @Test def replicateGlobalAggregation() {
@@ -54,8 +57,8 @@ class AggregateByKeySuite extends SparkSuite {
     val (_, ktHetQuery) = kt.query("nHet")
     val (_, globalHetResult) = vds.queryGlobal("global.nHet")
 
-    val ktGlobalResult = kt.rdd.map { case (k, v) => ktHetQuery(k, v).map(_.asInstanceOf[Int]) }.collect().head
-    val vdsGlobalResult = globalHetResult.map(_.asInstanceOf[Int])
+    val ktGlobalResult = kt.rdd.map { case (k, v) => Option(ktHetQuery(k, v)).map(_.asInstanceOf[Int]) }.collect().head
+    val vdsGlobalResult = Option(globalHetResult).map(_.asInstanceOf[Int])
 
     assert(ktGlobalResult == vdsGlobalResult)
   }

--- a/src/test/scala/is/hail/vds/AnnotateSamplesSuite.scala
+++ b/src/test/scala/is/hail/vds/AnnotateSamplesSuite.scala
@@ -8,12 +8,11 @@ class AnnotateSamplesSuite extends SparkSuite {
   @Test def testVDS() {
     val vds = hc.importVCF("src/test/resources/sample2.vcf")
 
-
     val selfAnnotated = vds.annotateSamplesVDS(vds, root = Some("sa.other"))
 
     val (_, q) = selfAnnotated.querySA("sa.other")
     assert(vds.sampleIdsAndAnnotations == selfAnnotated.sampleIdsAndAnnotations.map { case (id, anno) =>
-      (id, q(anno).orNull)
+      (id, q(anno))
     })
   }
 }


### PR DESCRIPTION
null is now used to denote missing annotations everywhere.