### PR TITLE
Change KeyTable internals

### DIFF
--- a/python/hail/keytable.py
+++ b/python/hail/keytable.py
@@ -239,7 +239,7 @@ class KeyTable(object):
         return KeyTable(self.hc, self._jkt.annotate(expr))
 
     def join(self, right, how='inner'):
-        """Join two KeyTables together.
+        """Join two key tables together.
 
         **Examples**
 
@@ -259,9 +259,9 @@ class KeyTable(object):
 
         The non-key fields in ``kt2`` must have non-overlapping column names with ``kt1``.
 
-        Both KeyTables must have the same number of keys and the corresponding types of each key must be the same (order matters), but the key names can be different.
-        For example, if ``kt1`` has the key schema ``Struct{("a", Int), ("b", String)}``, ``kt1`` can be merged with a KeyTable that has a key schema equal to
-        ``Struct{("b", Int), ("c", String)}`` but cannot be merged to a KeyTable with key schema ``Struct{("b", "String"), ("a", Int)}``. The ``kt_joined`` will have the same key names and schema as ``kt1``.
+        Both key tables must have the same number of keys and the corresponding types of each key must be the same (order matters), but the key names can be different.
+        For example, if ``kt1`` has the key schema ``Struct{("a", Int), ("b", String)}``, ``kt1`` can be merged with a key table that has a key schema equal to
+        ``Struct{("b", Int), ("c", String)}`` but cannot be merged to a key table with key schema ``Struct{("b", "String"), ("a", Int)}``. ``kt_joined`` will have the same key names and schema as ``kt1``.
 
         :param  right: KeyTable to join
         :type right: :class:`.KeyTable`
@@ -284,7 +284,7 @@ class KeyTable(object):
 
         >>> kt_ht_by_sex = kt1.aggregate_by_key("SEX = SEX", "MEAN_HT = HT.stats().mean")
 
-        The result of :py:meth:`.aggregate_by_key` is a KeyTable ``kt_ht_by_sex`` with the following data:
+        The result of :py:meth:`.aggregate_by_key` is a key table ``kt_ht_by_sex`` with the following data:
 
         +--------+----------+
         |   SEX  |MEAN_HT   |

--- a/python/hail/keytable.py
+++ b/python/hail/keytable.py
@@ -257,8 +257,11 @@ class KeyTable(object):
          - **left** -- Key present in ``kt1``. For keys only in ``kt1``, the value of non-key columns from ``kt2`` is set to missing.
          - **right** -- Key present in ``kt2``. For keys only in ``kt2``, the value of non-key columns from ``kt1`` is set to missing.
 
-        .. note::
-            Both KeyTables must have identical key schemas and non-overlapping column names.
+        The non-key fields in ``kt2`` must have non-overlapping column names with ``kt1``.
+
+        Both KeyTables must have the same number of keys and the corresponding types of each key must be the same (order matters), but the key names can be different.
+        For example, if ``kt1`` has the key schema ``Struct{("a", Int), ("b", String)}``, ``kt1`` can be merged with a KeyTable that has a key schema equal to
+        ``Struct{("b", Int), ("c", String)}`` but cannot be merged to a KeyTable with key schema ``Struct{("b", "String"), ("a", Int)}``. The ``kt_joined`` will have the same key names and schema as ``kt1``.
 
         :param  right: KeyTable to join
         :type right: :class:`.KeyTable`
@@ -416,11 +419,6 @@ class KeyTable(object):
 
         >>> kt_result = kt1.key_by([])
 
-        **Notes**
-
-        The order of the columns will be the original order with the key
-        columns moved to the beginning in the order given by ``key_names``.
-
         :param key_names: List of columns to be used as keys.
         :type key_names: list of str
 
@@ -501,16 +499,10 @@ class KeyTable(object):
 
         >>> kt_result = kt1.select([])
 
-        **Notes**
-
-        The order of the columns will be the order given
-        by ``column_names`` with the key columns moved to the beginning
-        in the order of the key columns in this :py:class:`.KeyTable`.
-
         :param column_names: List of columns to be selected.
         :type: list of str
 
-        :return: A key table with selected columns in the order given by ``column_names``.
+        :return: A key table with selected columns.
         :rtype: :class:`.KeyTable`
         """
 

--- a/src/main/scala/is/hail/methods/IBD.scala
+++ b/src/main/scala/is/hail/methods/IBD.scala
@@ -261,10 +261,10 @@ object IBD {
       .map { case ((i, j), ibd) => ((sampleIds(i), sampleIds(j)), ibd) }
   }
 
-  private val ibdKeySignature = TStruct(("i", TString), ("j", TString))
+  private val ibdSignature = TStruct(("i", TString), ("j", TString)).merge(ExtendedIBDInfo.signature)._1
   def toKeyTable(sc: HailContext, ibdMatrix: RDD[((String, String), ExtendedIBDInfo)]): KeyTable = {
-    val ktRdd = ibdMatrix.map { case ((i, j), eibd) => (Annotation(i, j), eibd.toAnnotation) }
-    KeyTable(sc, ktRdd, ibdKeySignature, ExtendedIBDInfo.signature)
+    val ktRdd = ibdMatrix.map { case ((i, j), eibd) => Annotation(i, j, eibd.toAnnotation) }
+    KeyTable(sc, ktRdd, ibdSignature, Array("i", "j"))
   }
 
   private def generateComputeMaf(vds: VariantDataset, computeMafExpr: String): (Variant, Annotation) => Double = {

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -658,7 +658,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
     val (finalType, inserter) =
       buildInserter(code, vaSignature, inserterEc, Annotation.VARIANT_HEAD)
 
-    val keyedRDD = kt.keyedRDD().map { case (k: Row, a) => (k(0).asInstanceOf[Variant], a)}
+    val keyedRDD = kt.keyedRDD().map { case (k: Row, a) => (k(0).asInstanceOf[Variant], a) }
 
     val ordRdd = OrderedRDD(keyedRDD, None, None)
 
@@ -675,7 +675,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
 
     val keyTypes = kt.keyFields.map(_.typ)
     if (!(keyTypes sameElements vdsKeyType))
-      fatal(s"Key signature of KeyTable, `${keyTypes.mkString(", ")}', must match type of computed key, `${ vdsKeyType.mkString(", ")}'.")
+      fatal(s"Key signature of KeyTable, `${ keyTypes.mkString(", ") }', must match type of computed key, `${ vdsKeyType.mkString(", ") }'.")
 
     val ktSig = kt.signature
 
@@ -968,7 +968,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
     * The function {@code f} must be monotonic with respect to the ordering on {@code Locus}
     */
   def flatMapVariants(f: (Variant, Annotation, Iterable[T]) => TraversableOnce[(Variant, (Annotation, Iterable[T]))]): VariantSampleMatrix[T] =
-    copy(rdd = rdd.flatMapMonotonic[(Annotation, Iterable[T])] { case (v, (va, gs)) => f(v, va, gs) })
+  copy(rdd = rdd.flatMapMonotonic[(Annotation, Iterable[T])] { case (v, (va, gs)) => f(v, va, gs) })
 
   def foldBySample(zeroValue: T)(combOp: (T, T) => T): RDD[(String, T)] = {
 

--- a/src/test/scala/is/hail/methods/KeyTableSuite.scala
+++ b/src/test/scala/is/hail/methods/KeyTableSuite.scala
@@ -64,7 +64,7 @@ class KeyTableSuite extends SparkSuite {
     assert(kt1.nKeys == 1)
     assert(kt2.nKeys == 1)
     assert(kt1.nFields == 3 && kt2.nFields == 6)
-    assert(kt1.keyFields.zip(kt2.keyFields).forall{ case (fd1, fd2) => fd1.name == fd2.name && fd1.typ == fd2.typ})
+    assert(kt1.keyFields.zip(kt2.keyFields).forall { case (fd1, fd2) => fd1.name == fd2.name && fd1.typ == fd2.typ })
     assert(kt1FieldNames ++ Set("qPhen2", "NotStatus", "X") == kt2FieldNames)
     assert(kt2 same kt3)
 
@@ -118,7 +118,7 @@ class KeyTableSuite extends SparkSuite {
 
     val nExpectedFields = ktLeft.nFields + ktRight.nFields - ktRight.nKeys
 
-    val i: IndexedSeq[Int] = Array(1,2,3)
+    val i: IndexedSeq[Int] = Array(1, 2, 3)
 
     val (_, leftKeyQuery) = ktLeft.query("Sample")
     val (_, rightKeyQuery) = ktRight.query("Sample")
@@ -167,7 +167,7 @@ class KeyTableSuite extends SparkSuite {
     val ktRight = hc.importKeyTable(List(inputFile2), List("Sample"), None, TextTableConfiguration(impute = true)).rename(Map("Sample" -> "sample"))
     val ktBad = ktRight.select(ktRight.fieldNames, Array("qPhen2"))
 
-    intercept[FatalException]{
+    intercept[FatalException] {
       val ktJoinBad = ktLeft.join(ktBad, "left")
       assert(ktJoinBad.keyNames sameElements Array("Sample"))
     }
@@ -185,10 +185,10 @@ class KeyTableSuite extends SparkSuite {
     val kt1 = KeyTable(hc, rdd, signature, keyNames)
     val kt2 = kt1.aggregate("Status = field1",
       "A = field2.sum(), " +
-      "B = field2.map(f => field2).sum(), " +
-      "C = field2.map(f => field2 + field3).sum(), " +
-      "D = field2.count(), " +
-      "E = field2.filter(f => field2 == 3).count()"
+        "B = field2.map(f => field2).sum(), " +
+        "C = field2.map(f => field2 + field3).sum(), " +
+        "D = field2.count(), " +
+        "E = field2.filter(f => field2 == 3).count()"
     )
 
     val result = Array(Array("Case", 12, 12, 16, 2L, 1L), Array("Control", 3, 3, 11, 2L, 0L))
@@ -304,6 +304,7 @@ class KeyTableSuite extends SparkSuite {
 
     val kt = vds
       .variantsKT()
+      .expandTypes()
       .flatten()
       .select(Array("va.info.MQRankSum"), Array.empty[String])
 

--- a/src/test/scala/is/hail/methods/KeyTableSuite.scala
+++ b/src/test/scala/is/hail/methods/KeyTableSuite.scala
@@ -120,13 +120,13 @@ class KeyTableSuite extends SparkSuite {
 
     val i: IndexedSeq[Int] = Array(1, 2, 3)
 
-    val (_, leftKeyQuery) = ktLeft.query("Sample")
-    val (_, rightKeyQuery) = ktRight.query("Sample")
-    val (_, leftJoinKeyQuery) = ktLeftJoin.query("Sample")
-    val (_, rightJoinKeyQuery) = ktRightJoin.query("Sample")
+    val (_, leftKeyQuerier) = ktLeft.rowQuerier("Sample")
+    val (_, rightKeyQuerier) = ktRight.rowQuerier("Sample")
+    val (_, leftJoinKeyQuerier) = ktLeftJoin.rowQuerier("Sample")
+    val (_, rightJoinKeyQuerier) = ktRightJoin.rowQuerier("Sample")
 
-    val leftKeys = ktLeft.rdd.map { a => Option(leftKeyQuery(a)).map(_.asInstanceOf[String]) }.collect().toSet
-    val rightKeys = ktRight.rdd.map { a => Option(rightKeyQuery(a)).map(_.asInstanceOf[String]) }.collect().toSet
+    val leftKeys = ktLeft.rdd.map { a => Option(leftKeyQuerier(a)).map(_.asInstanceOf[String]) }.collect().toSet
+    val rightKeys = ktRight.rdd.map { a => Option(rightKeyQuerier(a)).map(_.asInstanceOf[String]) }.collect().toSet
 
     val nIntersectRows = leftKeys.intersect(rightKeys).size
     val nUnionRows = rightKeys.union(leftKeys).size
@@ -136,7 +136,7 @@ class KeyTableSuite extends SparkSuite {
       ktLeftJoin.nKeys == nExpectedKeys &&
       ktLeftJoin.nFields == nExpectedFields &&
       ktLeftJoin.filter { a =>
-        !rightKeys.contains(Option(leftJoinKeyQuery(a)).map(_.asInstanceOf[String]))
+        !rightKeys.contains(Option(leftJoinKeyQuerier(a)).map(_.asInstanceOf[String]))
       }.forall("isMissing(qPhen2) && isMissing(qPhen3)")
     )
 
@@ -144,7 +144,7 @@ class KeyTableSuite extends SparkSuite {
       ktRightJoin.nKeys == nExpectedKeys &&
       ktRightJoin.nFields == nExpectedFields &&
       ktRightJoin.filter { a =>
-        !leftKeys.contains(Option(rightJoinKeyQuery(a)).map(_.asInstanceOf[String]))
+        !leftKeys.contains(Option(rightJoinKeyQuerier(a)).map(_.asInstanceOf[String]))
       }.forall("isMissing(Status) && isMissing(qPhen)"))
 
     assert(ktOuterJoin.nRows == nUnionRows &&

--- a/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
@@ -390,8 +390,8 @@ class VSMSuite extends SparkSuite {
     forAll(VariantSampleMatrix.gen[Genotype](hc, VSMSubgen.random)) { vds =>
       val vds2 = vds.annotateVariantsExpr("va.key = pcoin(0.5)")
 
-      val kt = KeyTable(hc, sc.parallelize(Array((Annotation(true), Annotation(1)), (Annotation(false), Annotation(2)))),
-        TStruct(("key", TBoolean)), TStruct(("value", TInt)))
+      val kt = KeyTable(hc, sc.parallelize(Array(Annotation(true, 1), Annotation(false, 2))),
+        TStruct(("key", TBoolean), ("value", TInt)), Array("key"))
 
       val resultVds = vds2.annotateVariantsKeyTable(kt, Seq("va.key"), "va.foo = table.value")
       val result = resultVds.rdd.collect()
@@ -419,16 +419,16 @@ class VSMSuite extends SparkSuite {
           if (b) 1 else 2
         else if (b) 3 else 4
 
-      def makeAnnotationPair(a: Boolean, b: Boolean): (Annotation, Annotation) =
-        (Annotation(a, b), Annotation(f(a, b)))
+      def makeAnnotation(a: Boolean, b: Boolean): Annotation =
+        Annotation(a, b, f(a, b))
 
       val mapping = sc.parallelize(Array(
-        makeAnnotationPair(true, true),
-        makeAnnotationPair(true, false),
-        makeAnnotationPair(false, true),
-        makeAnnotationPair(false, false)))
+        makeAnnotation(true, true),
+        makeAnnotation(true, false),
+        makeAnnotation(false, true),
+        makeAnnotation(false, false)))
 
-      val kt = KeyTable(hc, mapping, TStruct(("key1", TBoolean), ("key2", TBoolean)), TStruct(("value", TInt)))
+      val kt = KeyTable(hc, mapping, TStruct(("key1", TBoolean), ("key2", TBoolean), ("value", TInt)), Array("key1", "key2"))
 
       val resultVds = vds2.annotateVariantsKeyTable(kt, Seq("va.key1", "va.key2"), "va.foo = table.value")
       val result = resultVds.rdd.collect()

--- a/src/test/scala/is/hail/vds/AggregateByKeySuite.scala
+++ b/src/test/scala/is/hail/vds/AggregateByKeySuite.scala
@@ -14,8 +14,8 @@ class AggregateByKeySuite extends SparkSuite {
 
     val kt = vds.aggregateByKey("Sample = s", "nHet = g.map(g => g.isHet.toInt).sum()")
 
-    val (_, ktHetQuerier) = kt.rowQuerier("nHet")
-    val (_, ktSampleQuerier) = kt.rowQuerier("Sample")
+    val (_, ktHetQuerier) = kt.queryRow("nHet")
+    val (_, ktSampleQuerier) = kt.queryRow("Sample")
     val (_, saHetQuerier) = vds.querySA("sa.nHet")
 
     val ktSampleResults = kt.rdd.map { a =>
@@ -32,8 +32,8 @@ class AggregateByKeySuite extends SparkSuite {
 
     val kt = vds.aggregateByKey("Variant = v", "nHet = g.map(g => g.isHet.toInt).sum()")
 
-    val (_, ktHetQuerier) = kt.rowQuerier("nHet")
-    val (_, ktVariantQuerier) = kt.rowQuerier("Variant")
+    val (_, ktHetQuerier) = kt.queryRow("nHet")
+    val (_, ktVariantQuerier) = kt.queryRow("Variant")
     val (_, vaHetQuerier) = vds.queryVA("va.nHet")
 
     val ktVariantResults = kt.rdd.map { a =>
@@ -51,7 +51,7 @@ class AggregateByKeySuite extends SparkSuite {
     vds = vds.annotateGlobal(vds.queryVariants("variants.map(v => va.nHet).sum()")._1, TLong, "global.nHet")
     val kt = vds.aggregateByKey("", "nHet = g.map(g => g.isHet.toInt).sum()")
 
-    val (_, ktHetQuerier) = kt.rowQuerier("nHet")
+    val (_, ktHetQuerier) = kt.queryRow("nHet")
     val (_, globalHetResult) = vds.queryGlobal("global.nHet")
 
     val ktGlobalResult = kt.rdd.map { a => Option(ktHetQuerier(a)).map(_.asInstanceOf[Int]) }.collect().head

--- a/src/test/scala/is/hail/vds/AggregateByKeySuite.scala
+++ b/src/test/scala/is/hail/vds/AggregateByKeySuite.scala
@@ -18,12 +18,9 @@ class AggregateByKeySuite extends SparkSuite {
     val (_, ktSampleQuery) = kt.query("Sample")
     val (_, saHetQuery) = vds.querySA("sa.nHet")
 
-    val ktSampleResults = kt.rdd.map { case (k, v) =>
-      println(k, v)
-      (Option(ktSampleQuery(k, v)).map(_.asInstanceOf[String]), Option(ktHetQuery(k, v)).map(_.asInstanceOf[Int]))
+    val ktSampleResults = kt.rdd.map { a =>
+      (Option(ktSampleQuery(a)).map(_.asInstanceOf[String]), Option(ktHetQuery(a)).map(_.asInstanceOf[Int]))
     }.collectAsMap()
-
-    println(ktSampleResults)
 
     assert(vds.sampleIdsAndAnnotations.forall { case (sid, sa) => Option(saHetQuery(sa)) == ktSampleResults(Option(sid)) })
   }
@@ -39,8 +36,8 @@ class AggregateByKeySuite extends SparkSuite {
     val (_, ktVariantQuery) = kt.query("Variant")
     val (_, vaHetQuery) = vds.queryVA("va.nHet")
 
-    val ktVariantResults = kt.rdd.map { case (k, v) =>
-      (Option(ktVariantQuery(k, v)).map(_.asInstanceOf[Variant]), Option(ktHetQuery(k, v)).map(_.asInstanceOf[Int]))
+    val ktVariantResults = kt.rdd.map { a =>
+      (Option(ktVariantQuery(a)).map(_.asInstanceOf[Variant]), Option(ktHetQuery(a)).map(_.asInstanceOf[Int]))
     }.collectAsMap()
 
     assert(vds.variantsAndAnnotations.forall { case (v, va) => Option(vaHetQuery(va)) == ktVariantResults(Option(v)) })
@@ -57,7 +54,7 @@ class AggregateByKeySuite extends SparkSuite {
     val (_, ktHetQuery) = kt.query("nHet")
     val (_, globalHetResult) = vds.queryGlobal("global.nHet")
 
-    val ktGlobalResult = kt.rdd.map { case (k, v) => Option(ktHetQuery(k, v)).map(_.asInstanceOf[Int]) }.collect().head
+    val ktGlobalResult = kt.rdd.map { a => Option(ktHetQuery(a)).map(_.asInstanceOf[Int]) }.collect().head
     val vdsGlobalResult = Option(globalHetResult).map(_.asInstanceOf[Int])
 
     assert(ktGlobalResult == vdsGlobalResult)


### PR DESCRIPTION
 - Switched rdd from `RDD[(Annotation, Annotation)]` to rdd `RDD[Annotation]` with a `signature` and `keyNames: Array[String]` rather than `keySignature` and `valueSignature`.
 - Changed join behavior to not join based on key name, but join on the order and number of the types matching.