### PR TITLE
Fixed two links to old docs. 

### DIFF
--- a/python/hail/keytable.py
+++ b/python/hail/keytable.py
@@ -296,7 +296,7 @@ class KeyTable(object):
         The scope for both ``key_expr`` and ``agg_expr`` is all column names in the input :class:`KeyTable`.
 
         For more information, see the documentation on writing :ref:`expressions <overview-expressions>`
-        and using the `Hail's Expression Language <https://hail.is/expr_lang.html>`_
+        and using the `Hail Expression Language <https://hail.is/expr_lang.html>`_
 
         :param key_expr: Named expression(s) for how to compute the keys of the new key table.
         :type key_expr: str or list of str

--- a/python/hail/keytable.py
+++ b/python/hail/keytable.py
@@ -295,8 +295,8 @@ class KeyTable(object):
 
         The scope for both ``key_expr`` and ``agg_expr`` is all column names in the input :class:`KeyTable`.
 
-        For more information, see the documentation on writing `expressions <../overview.html#expressions>`_
-        and using the `Hail Expression Language <../reference.html#HailExpressionLanguage>`_.
+        For more information, see the documentation on writing :ref:`expressions <overview-expressions>`
+        and using the `Hail's Expression Language <https://hail.is/expr_lang.html>`_
 
         :param key_expr: Named expression(s) for how to compute the keys of the new key table.
         :type key_expr: str or list of str


### PR DESCRIPTION
It's unclear to me what the right way to link to expression language page is, and the examples of that I found in the actual docs were just links to actual Hail website as it is here. 