### PR TITLE
Fix interactive python shell and document running on CDH cluster

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -325,6 +325,11 @@ task testJar(type: Jar) {
     from sourceSets.test.output
 }
 
+task archiveZip(type: Zip) {
+    from fileTree('python')
+    classifier = 'python'
+}
+
 task wrapper(type: Wrapper) {
     gradleVersion = '2.14.1'
 }

--- a/python/hail/docs/getting_started.rst
+++ b/python/hail/docs/getting_started.rst
@@ -125,22 +125,6 @@ Try running :py:meth:`~hail.VariantDataset.count` on *sample.filtered.vds* to se
 
 Note that during each run Hail writes a ``hail.log`` file in the current directory; this is useful to developers for debugging.
 
-Building with other versions of Spark 2
-=======================================
-
-Hail should work with other versions of Spark 2.  To build against a
-different version, such as Spark 2.1.0, modify the above
-instructions as follows:
-
- - Set the Spark version in the gradle command
-  .. code-block:: text
-      
-      $ ./gradlew -Dspark.version=2.1.0 shadowJar
-
- - ``SPARK_HOME`` should point to an installation of the desired version of Spark, such as *spark-2.1.0-bin-hadoop2.7*
-
- - The version of the Py4J ZIP file in the hail alias must match the version in ``$SPARK_HOME/python/lib`` in your version of Spark.
-
 Running on a CDH Spark cluster
 ==============================
 
@@ -219,6 +203,22 @@ Running in the cloud
 
 `Google <https://cloud.google.com/dataproc/>`_ and `Amazon <https://aws.amazon.com/emr/details/spark/>`_ offer optimized Spark performance and exceptional scalability to tens of thousands of cores without the overhead of installing and managing an on-prem cluster.
 To get started running Hail on the Google Cloud Platform, see this `forum post <http://discuss.hail.is/t/using-hail-on-the-google-cloud-platform/80>`_.
+
+Building with other versions of Spark 2
+=======================================
+
+Hail should work with other versions of Spark 2.  To build against a
+different version, such as Spark 2.1.0, modify the above
+instructions as follows:
+
+ - Set the Spark version in the gradle command
+  .. code-block:: text
+
+      $ ./gradlew -Dspark.version=2.1.0 shadowJar
+
+ - ``SPARK_HOME`` should point to an installation of the desired version of Spark, such as *spark-2.1.0-bin-hadoop2.7*
+
+ - The version of the Py4J ZIP file in the hail alias must match the version in ``$SPARK_HOME/python/lib`` in your version of Spark.
 
 ---------------
 BLAS and LAPACK

--- a/python/hail/docs/getting_started.rst
+++ b/python/hail/docs/getting_started.rst
@@ -161,18 +161,20 @@ constructor.
 
     >>> import hail
     >>> hc = hail.HailContext(sc)
+    
+Files can be accessed from both Hadoop and Google Storage. If you're running on Google's Dataproc, you'll want to store your files in Google Storage. In most on premises clusters, you'll want to store your files in Hadoop.
 
-In a separate shell, you can copy a VCF file to HDFS:
-
-  .. code-block:: text
-
-    $ hadoop fs -put src/test/resources/sample.vcf sample.vcf
-
-To convert *sample.vcf* into Hail's **.vds** format, run:
+To convert *sample.vcf* stored in Google Storage into Hail's **.vds** format, run:
 
   .. code-block:: python
 
-    >>> hc.import_vcf('sample.vcf').write('sample.vds')
+    >>> hc.import_vcf('gs:///path/to/sample.vcf').write('gs:///output/path/sample.vds')
+    
+To convert *sample.vcf* stored in Hadoop into Hail's **.vds** format, run:
+
+   .. code-block:: python
+
+    >>> hc.import_vcf('/path/to/sample.vcf').write('/output/path/sample.vds')
 
 It is also possible to run Hail non-interactively, by passing a Python script to
 ``spark-submit``. In this case, it is not necessary to set any environment
@@ -186,13 +188,13 @@ For example,
                    --py-files build/distributions/hail-python.zip \
                    hailscript.py
 
-runs the script `hailscript.py`:
+runs the script `hailscript.py` (which reads and writes files from Hadoop):
 
   .. code-block:: python
 
     import hail
     hc = hail.HailContext()
-    hc.import_vcf('sample.vcf').write('sample.vds')
+    hc.import_vcf('/path/to/sample.vcf').write('/output/path/sample.vds')
 
 Running on a Cloudera Cluster
 =============================

--- a/python/hail/docs/getting_started.rst
+++ b/python/hail/docs/getting_started.rst
@@ -146,17 +146,11 @@ cluster for ``SPARK_HOME`` and ``HAIL_HOME``::
     $ export HAIL_HOME=/path/to/hail
     $ export PYTHONPATH="$PYTHONPATH:$HAIL_HOME/build/distributions/hail-python.zip:$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-*-src.zip"
 
-You can open an interactive Python shell with the ``pyspark`` command:
+You can open an IPython shell with the ``ipython`` command:
 
   .. code-block:: text
 
-    $ pyspark --jars build/libs/hail-all-spark.jar \
-              --py-files build/distributions/hail-python.zip \
-              --conf spark.hadoop.io.compression.codecs=org.apache.hadoop.io.compress.DefaultCodec,is.hail.io.compress.BGzipCodec,org.apache.hadoop.io.compress.GzipCodec \
-              --conf spark.sql.files.openCostInBytes=1099511627776 \
-              --conf spark.sql.files.maxPartitionBytes=1099511627776 \
-              --conf spark.hadoop.mapreduce.input.fileinputformat.split.minsize=1099511627776 \
-              --conf spark.hadoop.parquet.block.size=1099511627776
+    $ ipython
 
 Within the interactive shell, check that you can successfully create a
 ``HailContext`` by running the following commands. Note that you have to pass in
@@ -215,7 +209,15 @@ as above, except:
  - On a Cloudera cluster, ``SPARK_HOME`` should be set as:
    ``SPARK_HOME=/opt/cloudera/parcels/SPARK2/lib/spark2``,
 
- - Cloudera's version of ``pyspark`` is called ``pyspark2``, and
+ - On Cloudera, you can create an interactive Python shell using ``pyspark2``:
+ 
+     $ pyspark2 --jars build/libs/hail-all-spark.jar \
+              --py-files build/distributions/hail-python.zip \
+              --conf spark.hadoop.io.compression.codecs=org.apache.hadoop.io.compress.DefaultCodec,is.hail.io.compress.BGzipCodec,org.apache.hadoop.io.compress.GzipCodec \
+              --conf spark.sql.files.openCostInBytes=1099511627776 \
+              --conf spark.sql.files.maxPartitionBytes=1099511627776 \
+              --conf spark.hadoop.mapreduce.input.fileinputformat.split.minsize=1099511627776 \
+              --conf spark.hadoop.parquet.block.size=1099511627776
 
  - Cloudera's version of ``spark-submit`` is called ``spark2-submit``.
 

--- a/python/hail/docs/getting_started.rst
+++ b/python/hail/docs/getting_started.rst
@@ -144,7 +144,7 @@ cluster for ``SPARK_HOME`` and ``HAIL_HOME``::
 
     $ export SPARK_HOME=/path/to/spark/
     $ export HAIL_HOME=/path/to/hail
-    $ export PYTHONPATH="$PYTHONPATH:$HAIL_HOME/build/distributions/hail-python.zip:$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.10.3-src.zip"
+    $ export PYTHONPATH="$PYTHONPATH:$HAIL_HOME/build/distributions/hail-python.zip:$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-*-src.zip"
 
 You can open an interactive Python shell with the ``pyspark`` command:
 

--- a/python/hail/docs/getting_started.rst
+++ b/python/hail/docs/getting_started.rst
@@ -143,7 +143,7 @@ Then set the following environment variables::
 
     $ export SPARK_HOME=/opt/cloudera/parcels/SPARK2/lib/spark2
     $ export HAIL_HOME=/path/to/hail
-    $ export PYTHONPATH="$PYTHONPATH:$HAIL_HOME/python:$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.10.3-src.zip"
+    $ export PYTHONPATH="$PYTHONPATH:$HAIL_HOME/build/distributions/hail-python.zip:$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.10.3-src.zip"
 
 Create an interactive Python shell by running the following (note ``pyspark2`` is the CDH
 version of Spark 2's ``pyspark``).


### PR DESCRIPTION
This change fixes a bug in the Python code for HailContext that I found when trying to get Hail to run in interactive mode on a CDH cluster. (Inspired by https://docs.databricks.com/spark/latest/training/1000-genomes.html.)

I also added a build task to generate a zipfile of the Python code.

