### PR TITLE
rename_samples now takes a dict instead of a file.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -193,7 +193,7 @@ task testHail(type: Exec, dependsOn: shadowJar) {
      environment SPARK_CLASSPATH: '' + projectDir + '/build/libs/hail-all-spark.jar'
 }
 
-// test.dependsOn(testHail)
+test.dependsOn(testHail)
 
 tasks.withType(ShadowJar) {
     manifest {

--- a/python/hail/context.py
+++ b/python/hail/context.py
@@ -214,7 +214,7 @@ class HailContext(object):
         return VariantDataset(self, jvds)
 
     @handle_py4j
-    def import_keytable(self, path, key_names, npartitions=None, config=TextTableConfig()):
+    def import_keytable(self, path, key_names=[], npartitions=None, config=TextTableConfig()):
         """Import delimited text file (text table) as KeyTable.
 
         :param path: files to import.

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -2956,37 +2956,20 @@ class VariantDataset(object):
         return r
 
     @handle_py4j
-    def rename_samples(self, input):
+    def rename_samples(self, mapping):
         """Rename samples.
 
         **Examples**
 
-        >>> vds_result = vds.rename_samples('data/sample.map')
+        >>> vds_result = vds.rename_samples({'ID1': 'id1', 'ID2': 'id2'})
 
-        **Details**
-
-        The input file is a two-column, tab-separated file with no header. The first column is the current sample
-        name, the second column is the new sample name.  Samples which do not
-        appear in the first column will not be renamed.  Lines in the input that
-        do not correspond to any sample in the current dataset will be ignored.
-
-        :py:meth:`~hail.VariantDataset.export_samples` can be used to generate a template for renaming
-        samples. For example, suppose you want to rename samples to remove
-        spaces.  First, run:
-
-        >>> vds.export_samples('output/sample.map', 's.id, s.id')
-
-        Then edit *sample.map* to remove spaces from the sample names in the
-        second column and run the example above. Renaming samples is fast so there is no need to save out the resulting dataset
-        before performing analyses.
-
-        :param str input: Input file.
+        :param dict mapping: Mapping from old to new sample IDs.
 
         :return: Dataset with remapped sample IDs.
         :rtype: :class:`.VariantDataset`
         """
 
-        jvds = self._jvds.renameSamples(input)
+        jvds = self._jvds.renameSamples(mapping)
         return VariantDataset(self.hc, jvds)
 
     @handle_py4j
@@ -3656,7 +3639,7 @@ class VariantDataset(object):
         return KeyTable(self.hc, self._jvds.samplesKT())
 
     @handle_py4j
-    def make_keytable(self, variant_expr, genotype_expr, key_names):
+    def make_keytable(self, variant_expr, genotype_expr, key_names=[]):
         """Make a KeyTable with one row per variant.
 
         Per sample field names in the result are formed by concatenating the

--- a/python/hail/keytable.py
+++ b/python/hail/keytable.py
@@ -1,7 +1,7 @@
 from __future__ import print_function  # Python 2 and 3 print compatibility
 
 from hail.java import scala_package_object, handle_py4j
-from hail.type import Type, TStruct
+from hail.type import Type, TArray, TStruct
 from py4j.protocol import Py4JJavaError
 from pyspark.sql import DataFrame
 
@@ -617,6 +617,12 @@ class KeyTable(object):
             column_names = [column_names]
         return KeyTable(self.hc, self._jkt.explode(column_names))
 
+    @handle_py4j
+    def collect(self):
+        """Collect key table as a python object."""
+
+        return TArray(self.schema)._convert_to_py(self._jkt.collect())
+    
     @handle_py4j
     def _typecheck(self):
         """Check if all values with the schema."""

--- a/python/hail/tests.py
+++ b/python/hail/tests.py
@@ -199,7 +199,10 @@ class ContextTests(unittest.TestCase):
 
         self.assertTrue(isinstance(sample2.genotype_schema, TGenotype))
 
-        self.assertEqual(sample2.join(sample2.rename_samples(test_resources + '/sample2_rename.tsv'))
+        m2 = {r._0: r._1 for r in hc.import_keytable(test_resources + '/sample2_rename.tsv',
+                                                     config=TextTableConfig(noheader=True))
+              .collect()}
+        self.assertEqual(sample2.join(sample2.rename_samples(m2))
                          .count()['nSamples'], 200)
 
         linreg = (hc.import_vcf(test_resources + '/regressionLinear.vcf')

--- a/src/main/scala/is/hail/keytable/KeyTable.scala
+++ b/src/main/scala/is/hail/keytable/KeyTable.scala
@@ -423,4 +423,6 @@ case class KeyTable(hc: HailContext, rdd: RDD[Annotation],
   }
 
   def explode(columnNames: java.util.ArrayList[String]): KeyTable = explode(columnNames.asScala.toArray)
+
+  def collect(): IndexedSeq[Annotation] = rdd.collect()
 }

--- a/src/test/scala/is/hail/methods/RenameSamplesSuite.scala
+++ b/src/test/scala/is/hail/methods/RenameSamplesSuite.scala
@@ -21,13 +21,9 @@ class RenameSamplesSuite extends SparkSuite {
       vds.sampleIds(1) -> "a"
     )
 
-    val samplesMapFile = tmpDir.createTempFile("samples", extension = ".map")
-
-    writeSampleMap(samplesMapFile, m)
-
     // FIXME keyword
     intercept[FatalException] {
-      vds.renameSamples(samplesMapFile)
+      vds.renameSamples(m.toMap)
     }
   }
 
@@ -55,11 +51,7 @@ class RenameSamplesSuite extends SparkSuite {
       m += newS -> s
     }
 
-    val samplesMapFile = tmpDir.createTempFile("samples", extension = ".map")
-
-    writeSampleMap(samplesMapFile, m)
-
-    val vds2 = vds.renameSamples(samplesMapFile)
+    val vds2 = vds.renameSamples(m.toMap)
 
     assert(vds2.sampleIds.toSet == newSamples)
   }


### PR DESCRIPTION
Added KeyTable.collect()
Default key_names to [].