### PR TITLE
Add HailContext.eval_expr{_typed}.

### DIFF
--- a/python/hail/context.py
+++ b/python/hail/context.py
@@ -5,6 +5,7 @@ from pyspark.sql import SQLContext
 from hail.dataset import VariantDataset
 from hail.java import *
 from hail.keytable import KeyTable
+from hail.type import Type
 from hail.utils import TextTableConfig
 from hail.stats import UniformDist, BetaDist, TruncatedBetaDist
 
@@ -609,6 +610,33 @@ class HailContext(object):
 
         jkeys = jarray(self._jvm.java.lang.String, keys)
         return KeyTable(self, self._hail.keytable.KeyTable.fromDF(self._jhc, df._jdf, jkeys))
+
+    @handle_py4j
+    def eval_expr_typed(self, expr):
+        """Evaluate an expression and return the result as well as its type.
+
+        :param str expr: Expression to evaluate.
+
+        :rtype: (annotation, :class:`.Type`)
+
+        """
+
+        x = self._jhc.eval(expr)
+        t = Type._from_java(x._2())
+        v = t._convert_to_py(x._1())
+        return (v, t)
+
+    @handle_py4j
+    def eval_expr(self, expr):
+        """Evaluate an expression.
+
+        :param str expr: Expression to evaluate.
+
+        :rtype: annotation
+        """
+
+        r, t = self.eval_expr_typed(expr)
+        return r
 
     def stop(self):
         """ Shut down the Hail Context """

--- a/python/hail/tests.py
+++ b/python/hail/tests.py
@@ -67,8 +67,8 @@ class ContextTests(unittest.TestCase):
         self.assertEqual(bn_count['nSamples'], 10)
         self.assertEqual(bn_count['nVariants'], 100)
 
-        self.assertEqual(hc.eval_expr_typed('[1, 2, 3].map(x => x * 2)') == ([2, 4, 6], TArray(TInt())))
-        self.assertEqual(hc.eval_expr('[1, 2, 3].map(x => x * 2)') == [2, 4, 6])
+        self.assertEqual(hc.eval_expr_typed('[1, 2, 3].map(x => x * 2)'), ([2, 4, 6], TArray(TInt())))
+        self.assertEqual(hc.eval_expr('[1, 2, 3].map(x => x * 2)'), [2, 4, 6])
 
     def test_dataset(self):
         test_resources = 'src/test/resources'

--- a/python/hail/tests.py
+++ b/python/hail/tests.py
@@ -67,6 +67,9 @@ class ContextTests(unittest.TestCase):
         self.assertEqual(bn_count['nSamples'], 10)
         self.assertEqual(bn_count['nVariants'], 100)
 
+        self.assertEqual(hc.eval_expr_typed('[1, 2, 3].map(x => x * 2)') == ([2, 4, 6], TArray(TInt())))
+        self.assertEqual(hc.eval_expr('[1, 2, 3].map(x => x * 2)') == [2, 4, 6])
+
     def test_dataset(self):
         test_resources = 'src/test/resources'
 

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -576,6 +576,12 @@ class HailContext private(val sc: SparkContext,
 
   def genDataset(): VariantDataset = VSMSubgen.realistic.gen(this).sample()
 
+  def eval(expr: String): (Annotation, Type) = {
+    val ec = EvalContext()
+    val (t, f) = Parser.parseExpr(expr, ec)
+    (f(), t)
+  }
+
   /**
     *
     *


### PR DESCRIPTION
Example:

```
In[9]: hc.eval_expr_typed('[1, 2, 3].map(x => x * 2)')
Out[9]: ([2, 4, 6], Array[Int])
```
