### PR TITLE
better parsing of covariate list

### DIFF
--- a/src/main/scala/is/hail/stats/RegressionUtils.scala
+++ b/src/main/scala/is/hail/stats/RegressionUtils.scala
@@ -35,7 +35,8 @@ object RegressionUtils {
       Option(yQ()).map(yToDouble)
     }
 
-    val (covT, covQ) = Parser.parseExprs(covSA.mkString(","), ec)
+    val (covT, covQ0) = covSA.map(Parser.parseExpr(_, ec)).unzip
+    val covQ = () => covQ0.map(_.apply())
     val covToDouble = (covT, covSA).zipped.map(toDouble)
     val covIS = vds.sampleIdsAndAnnotations.map { case (s, sa) =>
       ec.setAll(s, sa)


### PR DESCRIPTION
Now the command:
```
pca_vds.logreg('wald', 'sa.isCase', ['sa.scores.PC1, sa.scores.PC2']).count()
```
gives the right error
```
FatalError                                Traceback (most recent call last)
<ipython-input-28-2fb5c41b2314> in <module>()
----> 1 pca_vds.logreg('wald', 'sa.isCase', ['sa.scores.PC1, sa.scores.PC2']).count()

<decorator-gen-218> in logreg(self, test, y, covariates, root)

/Users/jbloom/hail/python/hail/java.pyc in handle_py4j(func, *args, **kwargs)
    105     except Py4JJavaError as e:
    106         msg = env.jutils.getMinimalMessage(e.java_exception)
--> 107         raise FatalError(msg)
    108     except Py4JError as e:
    109         env.jutils.log().error('hail: caught python exception: ' + str(e))

FatalError: `|' expected but `,' found
<input>:1:sa.scores.PC1, sa.scores.PC2
                       ^
```