### PR TITLE
Improvements to VCF impex

### DIFF
--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -133,8 +133,6 @@ sealed abstract class Type {
 
   def str(a: Annotation): String = if (a == null) "NA" else a.toString
 
-  def strVCF(a: Annotation): String = if (a == null) "." else str(a)
-
   def toJSON(a: Annotation): JValue = JSONAnnotationImpex.exportAnnotation(a, this)
 
   def genNonmissingValue: Gen[Annotation] = Gen.const(Annotation.empty)
@@ -240,18 +238,6 @@ case object TFloat extends TNumeric {
 
   override def str(a: Annotation): String = if (a == null) "NA" else a.asInstanceOf[Float].formatted("%.5e")
 
-  override def strVCF(a: Annotation): String = {
-    if (a == null)
-      "."
-    else {
-      val f = a.asInstanceOf[Float]
-      if (f.isNaN)
-        "."
-      else
-        f.formatted("%.5e")
-    }
-  }
-
   override def genNonmissingValue: Gen[Annotation] = arbitrary[Double].map(_.toFloat)
 
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double): Boolean =
@@ -270,18 +256,6 @@ case object TDouble extends TNumeric {
   override def str(a: Annotation): String = if (a == null) "NA" else a.asInstanceOf[Double].formatted("%.5e")
 
   override def genNonmissingValue: Gen[Annotation] = arbitrary[Double]
-
-  override def strVCF(a: Annotation): String = {
-    if (a == null)
-      "."
-    else {
-      val f = a.asInstanceOf[Double]
-      if (f.isNaN)
-        "."
-      else
-        f.formatted("%.5e")
-    }
-  }
 
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double): Boolean =
     a1 == a2 || (a1 != null && a2 != null && D_==(a1.asInstanceOf[Double], a2.asInstanceOf[Double], tolerance))

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -133,7 +133,7 @@ sealed abstract class Type {
 
   def str(a: Annotation): String = if (a == null) "NA" else a.toString
 
-  def strVCF(a: Annotation): String = if (a == null) "." else a.toString
+  def strVCF(a: Annotation): String = if (a == null) "." else str(a)
 
   def toJSON(a: Annotation): JValue = JSONAnnotationImpex.exportAnnotation(a, this)
 
@@ -240,6 +240,18 @@ case object TFloat extends TNumeric {
 
   override def str(a: Annotation): String = if (a == null) "NA" else a.asInstanceOf[Float].formatted("%.5e")
 
+  override def strVCF(a: Annotation): String = {
+    if (a == null)
+      "."
+    else {
+      val f = a.asInstanceOf[Float]
+      if (f.isNaN)
+        "."
+      else
+        f.formatted("%.5e")
+    }
+  }
+
   override def genNonmissingValue: Gen[Annotation] = arbitrary[Double].map(_.toFloat)
 
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double): Boolean =
@@ -258,6 +270,18 @@ case object TDouble extends TNumeric {
   override def str(a: Annotation): String = if (a == null) "NA" else a.asInstanceOf[Double].formatted("%.5e")
 
   override def genNonmissingValue: Gen[Annotation] = arbitrary[Double]
+
+  override def strVCF(a: Annotation): String = {
+    if (a == null)
+      "."
+    else {
+      val f = a.asInstanceOf[Double]
+      if (f.isNaN)
+        "."
+      else
+        f.formatted("%.5e")
+    }
+  }
 
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double): Boolean =
     a1 == a2 || (a1 != null && a2 != null && D_==(a1.asInstanceOf[Double], a2.asInstanceOf[Double], tolerance))

--- a/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -16,8 +16,8 @@ object ExportVCF {
     case _ => "1"
   }
 
-  def strVCF(sb: StringBuilder, elementType: Type, a: Annotation) : Unit = {
-    if(a == null)
+  def strVCF(sb: StringBuilder, elementType: Type, a: Annotation): Unit = {
+    if (a == null)
       sb += '.'
     else {
       elementType match {

--- a/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -41,7 +41,7 @@ object ExportVCF {
         case t =>
           sb.append(f.name)
           sb += '='
-          sb.append(t.str(value))
+          sb.append(t.strVCF(value))
           true
       }
   }
@@ -259,7 +259,7 @@ object ExportVCF {
           if (f.nonEmpty)
             f.foreachBetween(s => sb.append(s))(sb += ';')
           else
-            sb += '.'
+            sb.append("PASS")
         case None => sb += '.'
       }
 

--- a/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -16,7 +16,7 @@ object ExportVCF {
     case _ => "1"
   }
 
-  def strVCF(sb: StringBuilder, elementType: Type, a: Annotation): Unit = {
+  def strVCF(sb: StringBuilder, elementType: Type, a: Annotation) {
     if (a == null)
       sb += '.'
     else {
@@ -50,7 +50,7 @@ object ExportVCF {
           } else {
             sb.append(f.name)
             sb += '='
-            arr.foreachBetween(a => strVCF(sb,it.elementType,a))(sb += ',')
+            arr.foreachBetween(a => strVCF(sb, it.elementType, a))(sb += ',')
             true
           }
         case TBoolean => value match {
@@ -63,7 +63,7 @@ object ExportVCF {
         case t =>
           sb.append(f.name)
           sb += '='
-          strVCF(sb,t,value)
+          strVCF(sb, t, value)
           true
       }
   }

--- a/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -16,24 +16,26 @@ object ExportVCF {
     case _ => "1"
   }
 
-  def strVCF(element_type: Type, a: Annotation) : String = {
-    element_type match{
-      case null => "."
-      case TFloat =>
-        val x = a.asInstanceOf[Float]
-        if(x.isNaN)
-          "."
-        else
-          x.formatted("%.5e")
-      case TDouble =>
-        val x = a.asInstanceOf[Double]
-        if(x.isNaN)
-          "."
-        else
-          x.formatted("%.5e")
-      case _ => element_type.str(a)
+  def strVCF(sb: StringBuilder, element_type: Type, a: Annotation) : Unit = {
+    if(a == null)
+      sb += '.'
+    else {
+      element_type match {
+        case TFloat =>
+          val x = a.asInstanceOf[Float]
+          if (x.isNaN)
+            sb += '.'
+          else
+            sb.append(x.formatted("%.5e"))
+        case TDouble =>
+          val x = a.asInstanceOf[Double]
+          if (x.isNaN)
+            sb += '.'
+          else
+            sb.append(x.formatted("%.5e"))
+        case _ => sb.append(element_type.str(a))
+      }
     }
-
   }
 
   def emitInfo(f: Field, sb: StringBuilder, value: Annotation): Boolean = {
@@ -48,7 +50,7 @@ object ExportVCF {
           } else {
             sb.append(f.name)
             sb += '='
-            arr.foreachBetween(a => sb.append(strVCF(it.elementType,a)))(sb += ',')
+            arr.foreachBetween(a => strVCF(sb,it.elementType,a))(sb += ',')
             true
           }
         case TBoolean => value match {
@@ -61,7 +63,7 @@ object ExportVCF {
         case t =>
           sb.append(f.name)
           sb += '='
-          sb.append(strVCF(t,value))
+          strVCF(sb,t,value)
           true
       }
   }

--- a/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -16,11 +16,11 @@ object ExportVCF {
     case _ => "1"
   }
 
-  def strVCF(sb: StringBuilder, element_type: Type, a: Annotation) : Unit = {
+  def strVCF(sb: StringBuilder, elementType: Type, a: Annotation) : Unit = {
     if(a == null)
       sb += '.'
     else {
-      element_type match {
+      elementType match {
         case TFloat =>
           val x = a.asInstanceOf[Float]
           if (x.isNaN)
@@ -33,7 +33,7 @@ object ExportVCF {
             sb += '.'
           else
             sb.append(x.formatted("%.5e"))
-        case _ => sb.append(element_type.str(a))
+        case _ => sb.append(elementType.str(a))
       }
     }
   }

--- a/src/main/scala/is/hail/io/vcf/HtsjdkRecordReader.scala
+++ b/src/main/scala/is/hail/io/vcf/HtsjdkRecordReader.scala
@@ -28,7 +28,7 @@ abstract class HtsjdkRecordReader[T] extends Serializable {
 
   def readVariantInfo(vc: VariantContext, infoSignature: Option[TStruct]): (Variant, Annotation) = {
     val filters: Set[String] = {
-      if(!vc.filtersWereApplied)
+      if (!vc.filtersWereApplied)
         null
       else if (vc.isNotFiltered)
         Set()
@@ -58,8 +58,8 @@ abstract class HtsjdkRecordReader[T] extends Serializable {
             case e: Exception =>
               fatal(
                 s"""variant $v: INFO field ${ f.name }:
-                   |  unable to convert $a (of class ${ a.getClass.getCanonicalName }) to ${ f.typ }:
-                   |  caught $e""".stripMargin)
+                    |  unable to convert $a (of class ${ a.getClass.getCanonicalName }) to ${ f.typ }:
+                    |  caught $e""".stripMargin)
           }
         }: _*)
       assert(sig.typeCheck(a))
@@ -267,8 +267,8 @@ class GenericRecordReader extends HtsjdkRecordReader[Annotation] {
             case e: Exception =>
               fatal(
                 s"""variant $v: Genotype field ${ f.name }:
-                 |  unable to convert $a (of class ${ a.getClass.getCanonicalName }) to ${ f.typ }:
-                 |  caught $e""".stripMargin)
+                    |  unable to convert $a (of class ${ a.getClass.getCanonicalName }) to ${ f.typ }:
+                    |  caught $e""".stripMargin)
           }
         }: _*)
       assert(genotypeSignature.typeCheck(a))

--- a/src/main/scala/is/hail/io/vcf/HtsjdkRecordReader.scala
+++ b/src/main/scala/is/hail/io/vcf/HtsjdkRecordReader.scala
@@ -27,10 +27,11 @@ abstract class HtsjdkRecordReader[T] extends Serializable {
   import HtsjdkRecordReader._
 
   def readVariantInfo(vc: VariantContext, infoSignature: Option[TStruct]): (Variant, Annotation) = {
-    val pass = vc.filtersWereApplied() && vc.getFilters.isEmpty
     val filters: Set[String] = {
-      if (vc.filtersWereApplied && vc.isNotFiltered)
-        Set("PASS")
+      if(!vc.filtersWereApplied)
+        null
+      else if (vc.isNotFiltered)
+        Set()
       else
         vc.getFilters.asScala.toSet
     }
@@ -66,8 +67,8 @@ abstract class HtsjdkRecordReader[T] extends Serializable {
     }
 
     val va = info match {
-      case Some(infoAnnotation) => Annotation(rsid, vc.getPhredScaledQual, filters, pass, infoAnnotation)
-      case None => Annotation(rsid, vc.getPhredScaledQual, filters, pass)
+      case Some(infoAnnotation) => Annotation(rsid, vc.getPhredScaledQual, filters, infoAnnotation)
+      case None => Annotation(rsid, vc.getPhredScaledQual, filters)
     }
 
     (v, va)

--- a/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -232,8 +232,7 @@ object LoadVCF {
         Some(Field("rsid", TString, 0)),
         Some(Field("qual", TDouble, 1)),
         Some(Field("filters", TSet(TString), 2, filters)),
-        Some(Field("pass", TBoolean, 3)),
-        infoSignature.map(sig => Field("info", sig, 4))
+        infoSignature.map(sig => Field("info", sig, 3))
       ).flatten)
 
     val headerLine = headerLines.last

--- a/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
+++ b/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
@@ -88,15 +88,8 @@ class AnnotationsSuite extends SparkSuite {
     assert(vas.fieldOption("filters").exists(f =>
       f.typ == TSet(TString)
         && f.attrs.nonEmpty))
-    assert(filtQuery(variantAnnotationMap(firstVariant)) == Set("PASS"))
+    assert(filtQuery(variantAnnotationMap(firstVariant)) == Set())
     assert(filtQuery(variantAnnotationMap(anotherVariant)) == Set("VQSRTrancheSNP99.95to100.00"))
-
-    // GATK PASS
-    val passQuery = vas.query("pass")
-    assert(vas.fieldOption("pass").exists(f => f.typ == TBoolean
-      && f.attrs == Map.empty))
-    assert(passQuery(variantAnnotationMap(firstVariant)) == true)
-    assert(passQuery(variantAnnotationMap(anotherVariant)) == false)
 
     val vds2 = hc.importVCF("src/test/resources/sample2.vcf")
     val vas2 = vds2.vaSignature

--- a/src/test/scala/is/hail/methods/FilterSuite.scala
+++ b/src/test/scala/is/hail/methods/FilterSuite.scala
@@ -16,7 +16,7 @@ class FilterSuite extends SparkSuite {
 
     assert(vds.filterVariantsExpr("v.start >= 14066228", keep = false).countVariants() == 173)
 
-    assert(vds.filterVariantsExpr("va.pass").countVariants() == 312)
+    assert(vds.filterVariantsExpr("va.filters.isEmpty").countVariants() == 312)
 
     assert(vds.filterVariantsExpr("va.info.AN == 200").countVariants() == 310)
 

--- a/src/test/scala/is/hail/methods/ProgrammaticAnnotationsSuite.scala
+++ b/src/test/scala/is/hail/methods/ProgrammaticAnnotationsSuite.scala
@@ -35,14 +35,14 @@ class ProgrammaticAnnotationsSuite extends SparkSuite {
       .splitMulti()
       .variantQC()
       .annotateVariantsExpr(
-        "va.a.b.c.d.e = va.qc.callRate * 100, va.a.c = if (va.pass) 1 else 0, va.`weird spaces name` = 5 / (va.qual - 5)")
+        "va.a.b.c.d.e = va.qc.callRate * 100, va.a.c = if (va.filters.isEmpty) 1 else 0, va.`weird spaces name` = 5 / (va.qual - 5)")
 
     val vaa = vds.variantsAndAnnotations.collect()
     val q = vds.queryVA("va.a.b.c.d.e")._2
     val q2 = vds.queryVA("va.a.c")._2
     val q3 = vds.queryVA("va.`weird spaces name`")._2
     val qCallRate = vds.queryVA("va.qc.callRate")._2
-    val qPass = vds.queryVA("va.pass")._2
+    val qPass = vds.queryVA("va.filters.isEmpty")._2
     val qQual = vds.queryVA("va.qual")._2
     vds.variantsAndAnnotations
       .collect()


### PR DESCRIPTION
- Values of types other than `Array` and `Boolean` get output in VCF format (e.g. `.` instead of `NA` for missing values)
- `NaN` values are converted to missing (`.`) when exporting VCF since VCF doesn't handle `NaN`
- Changes to handling of filters:
    - `.` <=> `NA:Set[String]`
    - `PASS` <=> `{}:Set[String]`
    - `other` <=> `{"other"}:Set[String]"`
- Removed `va.pass` entirely (redundant with `va.filters` and needs constant synchronization)