### PR TITLE
fixed interval type export to match import parser

### DIFF
--- a/src/main/scala/is/hail/utils/IntervalTree.scala
+++ b/src/main/scala/is/hail/utils/IntervalTree.scala
@@ -32,6 +32,8 @@ case class Interval[T](start: T, end: T)(implicit ev: Ordering[T]) extends Order
   }
 
   def toJSON(f: (T) => JValue): JValue = JObject("start" -> f(start), "end" -> f(end))
+
+  override def toString: String = start + "-" + end
 }
 
 object Interval {


### PR DESCRIPTION
Resolves error where exportVariants exported an Interval as `Interval(14:968765858,22:1565768082)` and import parser expects `14:968765858-22:1565768082`