### PR TITLE
modifed python test of lmmreg, fixed bug, added test to lmmreg

### DIFF
--- a/src/main/scala/is/hail/methods/LinearMixedRegression.scala
+++ b/src/main/scala/is/hail/methods/LinearMixedRegression.scala
@@ -88,9 +88,6 @@ object LinearMixedRegression {
     val Ut = eigK.eigenvectors.t
     val S = eigK.eigenvalues // increasing order
 
-    println(n, S.length)
-    println(S)
-
     assert(S.length == n)
 
     info("lmmreg: 20 largest evals: " + ((n - 1) to math.max(0, n - 20) by -1).map(S(_).formatted("%.5f")).mkString(", "))

--- a/src/main/scala/is/hail/methods/LinearMixedRegression.scala
+++ b/src/main/scala/is/hail/methods/LinearMixedRegression.scala
@@ -79,7 +79,7 @@ object LinearMixedRegression {
 
     info(s"lmmreg: Computing RRM for $n samples...")
 
-    val (rrm, m) = ComputeRRM(kinshipVds, useBlock)
+    val (rrm, m) = ComputeRRM(filtKinshipVds, useBlock)
 
     info(s"lmmreg: RRM computed using $m variants")
     info(s"lmmreg: Computing eigenvectors of RRM...")
@@ -87,6 +87,9 @@ object LinearMixedRegression {
     val eigK = eigSymD(rrm)
     val Ut = eigK.eigenvectors.t
     val S = eigK.eigenvalues // increasing order
+
+    println(n, S.length)
+    println(S)
 
     assert(S.length == n)
 


### PR DESCRIPTION
Now the lmmreg test is deterministic.  And I found a bug in lmmreg by implementing the same test in LinearMixedRegressionSuite, which I then fixed.  Namely: `kinshipVds` should have been `filtKinshipVds`.  I've left this in as a regression test.