### PR TITLE
made lmm python test deterministic, fixed bug in lmmreg and lazyFilterWith

### DIFF
--- a/src/main/scala/is/hail/methods/LinearMixedRegression.scala
+++ b/src/main/scala/is/hail/methods/LinearMixedRegression.scala
@@ -87,9 +87,6 @@ object LinearMixedRegression {
     val Ut = eigK.eigenvectors.t
     val S = eigK.eigenvalues // increasing order
 
-    println(n, S.length)
-    println(S)
-
     assert(S.length == n)
 
     info("lmmreg: 20 largest evals: " + ((n - 1) to math.max(0, n - 20) by -1).map(S(_).formatted("%.5f")).mkString(", "))

--- a/src/main/scala/is/hail/methods/LinearMixedRegression.scala
+++ b/src/main/scala/is/hail/methods/LinearMixedRegression.scala
@@ -78,7 +78,7 @@ object LinearMixedRegression {
 
     info(s"lmmreg: Computing RRM for $n samples...")
 
-    val (rrm, m) = ComputeRRM(kinshipVds, useBlock)
+    val (rrm, m) = ComputeRRM(filtKinshipVds, useBlock)
 
     info(s"lmmreg: RRM computed using $m variants")
     info(s"lmmreg: Computing eigenvectors of RRM...")
@@ -86,6 +86,9 @@ object LinearMixedRegression {
     val eigK = eigSymD(rrm)
     val Ut = eigK.eigenvectors.t
     val S = eigK.eigenvalues // increasing order
+
+    println(n, S.length)
+    println(S)
 
     assert(S.length == n)
 

--- a/src/main/scala/is/hail/utils/richUtils/RichIterable.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichIterable.scala
@@ -55,7 +55,7 @@ class RichIterable[T](val i: Iterable[T]) extends Serializable {
         var pending: Boolean = false
         var pendingNext: T = _
 
-        def hasNext: Boolean = {
+        def setNext() {
           while (!pending && it.hasNext && it2.hasNext) {
             val n = it.next()
             val n2 = it2.next()
@@ -64,11 +64,16 @@ class RichIterable[T](val i: Iterable[T]) extends Serializable {
               pendingNext = n
             }
           }
+        }
+
+        def hasNext: Boolean = {
+          setNext()
           pending
         }
 
         def next(): T = {
-          assert(pending)
+          if (!pending)
+            setNext()
           pending = false
           pendingNext
         }

--- a/src/test/scala/is/hail/methods/LinearMixedRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearMixedRegressionSuite.scala
@@ -301,6 +301,7 @@ class LinearMixedRegressionSuite extends SparkSuite {
     assert(D_==(h2Chr3, 0.14276116822096985))
   }
 
+  // this test parallels the lmmreg Python test, and is a regression test related to filtering samples first
   @Test def filterTest() {
 
     var vdsAssoc = hc.importVCF("src/test/resources/regressionLinear.vcf")

--- a/src/test/scala/is/hail/methods/LinearMixedRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearMixedRegressionSuite.scala
@@ -301,7 +301,7 @@ class LinearMixedRegressionSuite extends SparkSuite {
     assert(D_==(h2Chr3, 0.14276116822096985))
   }
 
-  @Test def pythonTest() {
+  @Test def filterTest() {
 
     var vdsAssoc = hc.importVCF("src/test/resources/regressionLinear.vcf")
       .filterMulti()


### PR DESCRIPTION
Now the lmmreg python test is deterministic. And I found another bug in lmmreg by implementing the same test in LinearMixedRegressionSuite, which I then fixed, namely, kinshipVds should have been filtKinshipVds. Upon rebasing, that test failed again due to interaction of IntIterator and lazyFilterWith, which I've also fixed.  I've added a regression test to LinearMixedRegressionSuite, paralleling the Python test, that catches both bugs.