### PR TITLE
Added get_va_attributse, set_va_attributes and delete_va_attribute

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -3437,6 +3437,126 @@ class VariantDataset(object):
         return self._jvds.storageLevel()
 
     @handle_py4j
+    def set_va_attribute(self, ann_path, key, value):
+        """Sets an attribute for a variant annotation.
+        Attributes are key/value pairs that can be attached to a variant annotation field.
+
+        The following attributes are read from the VCF header when importing a VCF and written
+        to the VCF header when exporting a VCF:
+        - INFO fields attributes (attached to (`va.info.*`)):
+            - 'Number': The arity of the field. Can take values
+            `0` (Boolean flag),
+            `1` (single value),
+            `R` (one value per allele, including the reference),
+            `A` (one value per non-reference allele),
+            `G` (one value per genotype), and
+            `.` (any number of values)
+                - When importing: The value in read from the VCF INFO field definition
+                - When exporting: The default value is `0` for **Boolean**, `.` for **Arrays** and 1 for all other types
+            - 'Description' (default is '')
+        - FILTER entries in the VCF header are generated based on the attributes of `va.filters`. Each key/value pair in the attributes will generate a FILTER entry in the VCF with ID = key and Description = value.
+
+        **Examples**
+
+        Consider the following command which a filter and an annotation to the VDS (we're assuming a split VDS for simplicity):
+        1) an INFO field `AC_HC`, which stores the allele count of high confidence genotypes (DP >= 10, GQ >= 20) for each non-reference allele,
+        2) a filter `HardFilter` that filters all sites with the [GATK suggested hard filters](http://gatkforums.broadinstitute.org/gatk/discussion/2806/howto-apply-hard-filters-to-a-call-set):
+            - For SNVs: QD < 2.0 || FS < 60 || MQ < 40 || MQRankSum < -12.5 || ReadPosRankSum < -8.0
+            - For Indels (and other complex): QD < 2.0 || FS < 200.0 || ReadPosRankSum < 20.0
+        >>> vds = hc.read('data/example.vds')
+        >>> vds = vds.annotate_variants_expr(['va.info.AC_HC = gs.filter(g => g.dp >= 10 && g.gq >= 20).callStats(g => v).AC[1:]', 'va.filters = if((v.altAllele.isSNP && (va.info.QD < 2.0 || va.info.FS < 60 || va.info.MQ < 40 || va.info.MQRankSum < -12.5 || va.info.ReadPosRankSum < -8.0)) || (va.info.QD < 2.0 || va.info.FS < 200.0 || va.info.ReadPosRankSum < 20.0)) va.filters.add("HardFilter") else va.filters'])
+
+        If we now export this VDS as VCF, it would produce the following header (for these new fields):
+        ```
+        ##INFO=<ID=AC_HC,Number=.,Type=String,Description=""
+        ```
+
+        This isn't a properly formatted VCF header for the following reasons:
+        1) There is no FILTER entry for `HardFilter`
+        2) Since `AC_HC` has one entry per non-reference allele, its `Number` should be `A`
+        3) `AC_HC` should have a Description
+
+        We can fix this by setting the attributes of these fields:
+        >>> vds = vds.set_va_attribute('va.info.AC_HC','Description','Allele count for high quality genotypes (DP >= 10, GQ >= 20)')
+        >>> vds = vds.set_va_attribute('va.info.AC_HC','Number','A')
+        >>> vds = vds.set_va_attribute('va.filters','HardFilter','This site fails GATK suggested hard filters.')
+
+        Exporting the VDS with the attributes now prints the following header lines:
+        ```
+        ##INFO=<ID=test,Number=A,Type=String,Description="Allele count for high quality genotypes (DP >= 10, GQ >= 20)"
+        ##FILTER=<ID=random,Description="This site is filtered due to poor quality.">
+        ```
+
+        :param str ann_path: Path to variant annotation beginning with `va`.
+        :param str key: Attribute key.
+        :param str value: Attribute value.
+
+        :return: Annotated dataset with the attribute added to the variant annotation.
+        :rtype: :class:`.VariantDataset`
+        """
+
+        return VariantDataset(self.hc, self._jvds.setVAattribute(ann_path,key,value))
+
+    @handle_py4j
+    def get_va_attributes(self, ann_path):
+        """
+        Gets all attributes for attached to a variant annotation as a dict.
+        Attributes are key/value pairs that can be attached to a variant annotation field.
+
+        Attributes can be attached to any variant annotation using `set_va_attribute`. In addition,
+        the following attributes are read from the VCF header when importing a VCF, and written
+        to the VCF header when exporting a VCF:
+        - INFO fields attributes (attached to (`va.info.*`)):
+            - 'Number': The arity of the field. Can take values
+            `0` (Boolean flag),
+            `1` (single value),
+            `R` (one value per allele, including the reference),
+            `A` (one value per non-reference allele),
+            `G` (one value per genotype), and
+            `.` (any number of values)
+                - When importing: The value in read from the VCF INFO field definition
+                - When exporting: The default value is `0` for **Boolean**, `.` for **Arrays** and 1 for all other types
+            - 'Description' (default is '')
+        - FILTER entries in the VCF header are generated based on the attributes of `va.filters`. Each key/value pair in the attributes will generate a FILTER entry in the VCF with ID = key and Description = value.
+
+        :param str ann_path: Path to variant annotation beginning with `va`.
+
+        :return: A dict with all attributes attached to the variant annotation.
+        :rtype: dict
+        """
+        return dict(self._jvds.getVAattributesAsJava(ann_path))
+
+    @handle_py4j
+    def delete_va_attribute(self, ann_path, attribute):
+        """Removes an attribute from a variant annotation field.
+        Attributes are key/value pairs that can be attached to a variant annotation field.
+
+        The following attributes are read from the VCF header when importing a VCF and written
+        to the VCF header when exporting a VCF:
+        - INFO fields attributes (attached to (`va.info.*`)):
+            - 'Number': The arity of the field. Can take values
+            `0` (Boolean flag),
+            `1` (single value),
+            `R` (one value per allele, including the reference),
+            `A` (one value per non-reference allele),
+            `G` (one value per genotype), and
+            `.` (any number of values)
+                - When importing: The value in read from the VCF INFO field definition
+                - When exporting: The default value is `0` for **Boolean**, `.` for **Arrays** and 1 for all other types
+            - 'Description' (default is '')
+        - FILTER entries in the VCF header are generated based on the attributes of `va.filters`. Each key/value pair in the attributes will generate a FILTER entry in the VCF with ID = key and Description = value.
+
+        :param str ann_path: Path to variant annotation beginning with `va`.
+        :param str attribute: The attribute to remove (key).
+
+        :return: Annotated dataset with the updated variant annotation without the attribute.
+        :rtype: :class:`.VariantDataset`
+        """
+
+        return VariantDataset(self.hc, self._jvds.deleteVAattribute(ann_path,attribute))
+
+
+    @handle_py4j
     @requireTGenotype
     def split_multi(self, propagate_gq=False, keep_star_alleles=False, max_shift=100):
         """Split multiallelic variants.

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -3437,8 +3437,8 @@ class VariantDataset(object):
         return self._jvds.storageLevel()
 
     @handle_py4j
-    def set_va_attribute(self, ann_path, key, value):
-        """Sets an attribute for a variant annotation.
+    def set_va_attributes(self, ann_path, attributes):
+        """Sets attributes for a variant annotation.
         Attributes are key/value pairs that can be attached to a variant annotation field.
 
         The following attributes are read from the VCF header when importing a VCF and written
@@ -3454,48 +3454,53 @@ class VariantDataset(object):
                 - When importing: The value in read from the VCF INFO field definition
                 - When exporting: The default value is `0` for **Boolean**, `.` for **Arrays** and 1 for all other types
             - 'Description' (default is '')
-        - FILTER entries in the VCF header are generated based on the attributes of `va.filters`. Each key/value pair in the attributes will generate a FILTER entry in the VCF with ID = key and Description = value.
+        - FILTER entries in the VCF header are generated based on the attributes of `va.filters`.
+        Each key/value pair in the attributes will generate a FILTER entry in the VCF with ID = key and Description = value.
 
         **Examples**
 
-        Consider the following command which a filter and an annotation to the VDS (we're assuming a split VDS for simplicity):
+        Consider the following command which adds a filter and an annotation to the VDS (we're assuming a split VDS for simplicity):
         1) an INFO field `AC_HC`, which stores the allele count of high confidence genotypes (DP >= 10, GQ >= 20) for each non-reference allele,
-        2) a filter `HardFilter` that filters all sites with the [GATK suggested hard filters](http://gatkforums.broadinstitute.org/gatk/discussion/2806/howto-apply-hard-filters-to-a-call-set):
+        2) a filter `HardFilter` that filters all sites with the [GATK suggested hard filters]
+        (http://gatkforums.broadinstitute.org/gatk/discussion/2806/howto-apply-hard-filters-to-a-call-set):
             - For SNVs: QD < 2.0 || FS < 60 || MQ < 40 || MQRankSum < -12.5 || ReadPosRankSum < -8.0
             - For Indels (and other complex): QD < 2.0 || FS < 200.0 || ReadPosRankSum < 20.0
-        >>> vds = hc.read('data/example.vds')
-        >>> vds = vds.annotate_variants_expr(['va.info.AC_HC = gs.filter(g => g.dp >= 10 && g.gq >= 20).callStats(g => v).AC[1:]', 'va.filters = if((v.altAllele.isSNP && (va.info.QD < 2.0 || va.info.FS < 60 || va.info.MQ < 40 || va.info.MQRankSum < -12.5 || va.info.ReadPosRankSum < -8.0)) || (va.info.QD < 2.0 || va.info.FS < 200.0 || va.info.ReadPosRankSum < 20.0)) va.filters.add("HardFilter") else va.filters'])
+        >>> annotated_vds = vds.annotate_variants_expr([
+        ... 'va.info.AC_HC = gs.filter(g => g.dp >= 10 && g.gq >= 20).callStats(g => v).AC[1:]',
+        ... 'va.filters = if((v.altAllele.isSNP && (va.info.QD < 2.0 || va.info.FS < 60 || va.info.MQ < 40 || ' +
+        ... 'va.info.MQRankSum < -12.5 || va.info.ReadPosRankSum < -8.0)) || ' +
+        ... '(va.info.QD < 2.0 || va.info.FS < 200.0 || va.info.ReadPosRankSum < 20.0)) va.filters.add("HardFilter") else va.filters'])
 
         If we now export this VDS as VCF, it would produce the following header (for these new fields):
         ```
         ##INFO=<ID=AC_HC,Number=.,Type=String,Description=""
         ```
 
-        This isn't a properly formatted VCF header for the following reasons:
+        This header doesn't contain all information that should be present in an optimal VCF header:
         1) There is no FILTER entry for `HardFilter`
         2) Since `AC_HC` has one entry per non-reference allele, its `Number` should be `A`
         3) `AC_HC` should have a Description
 
         We can fix this by setting the attributes of these fields:
-        >>> vds = vds.set_va_attribute('va.info.AC_HC','Description','Allele count for high quality genotypes (DP >= 10, GQ >= 20)')
-        >>> vds = vds.set_va_attribute('va.info.AC_HC','Number','A')
-        >>> vds = vds.set_va_attribute('va.filters','HardFilter','This site fails GATK suggested hard filters.')
+        >>> annotated_vds = vds.set_va_attributes('va.info.AC_HC', {'Description':'Allele count for high quality genotypes (DP >= 10, GQ >= 20)',
+        ... 'Number': 'A'})
+        >>> annotated_vds = vds.set_va_attributes('va.filters', {'HardFilter': 'This site fails GATK suggested hard filters.'})
 
         Exporting the VDS with the attributes now prints the following header lines:
         ```
         ##INFO=<ID=test,Number=A,Type=String,Description="Allele count for high quality genotypes (DP >= 10, GQ >= 20)"
-        ##FILTER=<ID=random,Description="This site is filtered due to poor quality.">
+        ##FILTER=<ID=HardFilter,Description="This site fails GATK suggested hard filters.">
         ```
 
         :param str ann_path: Path to variant annotation beginning with `va`.
-        :param str key: Attribute key.
-        :param str value: Attribute value.
+
+        :param dict attributes: A str-str dict containing the attributes to set
 
         :return: Annotated dataset with the attribute added to the variant annotation.
         :rtype: :class:`.VariantDataset`
         """
 
-        return VariantDataset(self.hc, self._jvds.setVaAttribute(ann_path,key,value))
+        return VariantDataset(self.hc, self._jvds.setVaAttributes(ann_path, Env.jutils().javaMapToMap(attributes)))
 
 
     @handle_py4j
@@ -3516,16 +3521,18 @@ class VariantDataset(object):
                 - When importing: The value in read from the VCF INFO field definition
                 - When exporting: The default value is `0` for **Boolean**, `.` for **Arrays** and 1 for all other types
             - 'Description' (default is '')
-        - FILTER entries in the VCF header are generated based on the attributes of `va.filters`. Each key/value pair in the attributes will generate a FILTER entry in the VCF with ID = key and Description = value.
+        - FILTER entries in the VCF header are generated based on the attributes of `va.filters`.
+        Each key/value pair in the attributes will generate a FILTER entry in the VCF with ID = key and Description = value.
 
-        :param str ann_path: Path to variant annotation beginning with `va`.
+        :param str ann_path: Variant annotation path starting with 'va', period-delimited.
+
         :param str attribute: The attribute to remove (key).
 
         :return: Annotated dataset with the updated variant annotation without the attribute.
         :rtype: :class:`.VariantDataset`
         """
 
-        return VariantDataset(self.hc, self._jvds.deleteVaAttribute(ann_path,attribute))
+        return VariantDataset(self.hc, self._jvds.deleteVaAttribute(ann_path, attribute))
 
 
     @handle_py4j

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -3495,36 +3495,8 @@ class VariantDataset(object):
         :rtype: :class:`.VariantDataset`
         """
 
-        return VariantDataset(self.hc, self._jvds.setVAattribute(ann_path,key,value))
+        return VariantDataset(self.hc, self._jvds.setVaAttribute(ann_path,key,value))
 
-    @handle_py4j
-    def get_va_attributes(self, ann_path):
-        """
-        Gets all attributes for attached to a variant annotation as a dict.
-        Attributes are key/value pairs that can be attached to a variant annotation field.
-
-        Attributes can be attached to any variant annotation using `set_va_attribute`. In addition,
-        the following attributes are read from the VCF header when importing a VCF, and written
-        to the VCF header when exporting a VCF:
-        - INFO fields attributes (attached to (`va.info.*`)):
-            - 'Number': The arity of the field. Can take values
-            `0` (Boolean flag),
-            `1` (single value),
-            `R` (one value per allele, including the reference),
-            `A` (one value per non-reference allele),
-            `G` (one value per genotype), and
-            `.` (any number of values)
-                - When importing: The value in read from the VCF INFO field definition
-                - When exporting: The default value is `0` for **Boolean**, `.` for **Arrays** and 1 for all other types
-            - 'Description' (default is '')
-        - FILTER entries in the VCF header are generated based on the attributes of `va.filters`. Each key/value pair in the attributes will generate a FILTER entry in the VCF with ID = key and Description = value.
-
-        :param str ann_path: Path to variant annotation beginning with `va`.
-
-        :return: A dict with all attributes attached to the variant annotation.
-        :rtype: dict
-        """
-        return dict(self._jvds.getVAattributesAsJava(ann_path))
 
     @handle_py4j
     def delete_va_attribute(self, ann_path, attribute):
@@ -3553,7 +3525,7 @@ class VariantDataset(object):
         :rtype: :class:`.VariantDataset`
         """
 
-        return VariantDataset(self.hc, self._jvds.deleteVAattribute(ann_path,attribute))
+        return VariantDataset(self.hc, self._jvds.deleteVaAttribute(ann_path,attribute))
 
 
     @handle_py4j

--- a/python/hail/type.py
+++ b/python/hail/type.py
@@ -376,15 +376,17 @@ class Field(object):
     :param str name: name of field
     :param typ: type of field
     :type typ: :class:`.Type`
+    :param dict attributes: key/value attributes of field
 
     :ivar str name: name of field
     :ivar typ: type of field
     :vartype typ: :class:`.Type`
     """
 
-    def __init__(self, name, typ):
+    def __init__(self, name, typ, attributes = {}):
         self.name = name
         self.typ = typ
+        self.attributes = attributes
 
 
 class TStruct(Type):
@@ -421,7 +423,7 @@ class TStruct(Type):
     def _init_from_java(self, jtype):
 
         jfields = Env.jutils().iterableToArrayList(jtype.fields())
-        self.fields = [Field(f.name(), Type._from_java(f.typ())) for f in jfields]
+        self.fields = [Field(f.name(), Type._from_java(f.typ()), dict(f.attrsJava())) for f in jfields]
 
     def _convert_to_py(self, annotation):
         if annotation:

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -770,7 +770,7 @@ case class TStruct(fields: IndexedSeq[Field]) extends Type {
             field.copy(attrs = f(field.attrs))
           else {
             field.typ match {
-              case struct: TStruct => field.copy(typ = field.typ.asInstanceOf[TStruct].updateFieldAttributes(path.tail, f))
+              case struct: TStruct => field.copy(typ = struct.updateFieldAttributes(path.tail, f))
               case t => fatal(s"Field ${ field.name } is not a Struct and cannot contain field ${ path.tail.mkString(".") }")
             }
           }

--- a/src/main/scala/is/hail/methods/VEP.scala
+++ b/src/main/scala/is/hail/methods/VEP.scala
@@ -394,7 +394,13 @@ object VEP {
         }
       }.asOrderedRDD
 
-    vsm.copy(rdd = newRDD,
-      vaSignature = newVASignature)
+    if (csq)
+      vsm.copy(rdd = newRDD,
+        vaSignature = newVASignature.asInstanceOf[TStruct]
+          .setFieldAttributes(parsedRoot, Map("Description" -> csqHeader)))
+    else
+      vsm.copy(rdd = newRDD,
+        vaSignature = newVASignature)
+
   }
 }

--- a/src/main/scala/is/hail/methods/VEP.scala
+++ b/src/main/scala/is/hail/methods/VEP.scala
@@ -394,13 +394,10 @@ object VEP {
         }
       }.asOrderedRDD
 
-    if (csq && newVASignature.isInstanceOf[TStruct])
-      vsm.copy(rdd = newRDD,
-        vaSignature = newVASignature.asInstanceOf[TStruct]
-          .setFieldAttributes(parsedRoot, Map("Description" -> csqHeader)))
-    else
-      vsm.copy(rdd = newRDD,
-        vaSignature = newVASignature)
-
+    (csq, newVASignature) match {
+      case (true, t: TStruct) => vsm.copy(rdd = newRDD, vaSignature = newVASignature.asInstanceOf[TStruct]
+        .setFieldAttributes(parsedRoot, Map("Description" -> csqHeader)))
+      case _ => vsm.copy(rdd = newRDD, vaSignature = newVASignature)
+    }
   }
 }

--- a/src/main/scala/is/hail/methods/VEP.scala
+++ b/src/main/scala/is/hail/methods/VEP.scala
@@ -394,7 +394,7 @@ object VEP {
         }
       }.asOrderedRDD
 
-    if (csq)
+    if (csq && newVASignature.isInstanceOf[TStruct])
       vsm.copy(rdd = newRDD,
         vaSignature = newVASignature.asInstanceOf[TStruct]
           .setFieldAttributes(parsedRoot, Map("Description" -> csqHeader)))

--- a/src/main/scala/is/hail/methods/VEP.scala
+++ b/src/main/scala/is/hail/methods/VEP.scala
@@ -395,8 +395,8 @@ object VEP {
       }.asOrderedRDD
 
     (csq, newVASignature) match {
-      case (true, t: TStruct) => vsm.copy(rdd = newRDD, vaSignature = newVASignature.asInstanceOf[TStruct]
-        .setFieldAttributes(parsedRoot, Map("Description" -> csqHeader)))
+      case (true, t: TStruct) => vsm.copy(rdd = newRDD,
+        vaSignature = t.setFieldAttributes(parsedRoot, Map("Description" -> csqHeader)))
       case _ => vsm.copy(rdd = newRDD, vaSignature = newVASignature)
     }
   }

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -333,11 +333,14 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     val (paths, types, f) = Parser.parseAnnotationExprs(expr, ec, Some(Annotation.VARIANT_HEAD))
 
     val inserterBuilder = mutable.ArrayBuilder.make[Inserter]
-    val finalType = (paths, types).zipped.foldLeft(vds.vaSignature) { case (vas, (ids, signature)) =>
+    val newType = (paths, types).zipped.foldLeft(vds.vaSignature) { case (vas, (ids, signature)) =>
       val (s, i) = vas.insert(TArray(signature), ids)
       inserterBuilder += i
       s
     }
+    val finalType = paths.foldLeft(newType.asInstanceOf[TStruct])({
+      case (res, path) => res.setFieldAttributes(path, Map("Number" -> "A"))
+    })
     val inserters = inserterBuilder.result()
 
     val aggregateOption = Aggregators.buildVariantAggregations(vds, ec)

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -338,9 +338,12 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
       inserterBuilder += i
       s
     }
-    val finalType = paths.foldLeft(newType.asInstanceOf[TStruct])({
-      case (res, path) => res.setFieldAttributes(path, Map("Number" -> "A"))
-    })
+    val finalType = if (newType.isInstanceOf[TStruct])
+      paths.foldLeft(newType.asInstanceOf[TStruct]) {
+        case (res, path) => res.setFieldAttributes(path, Map("Number" -> "A"))
+      }
+    else newType
+
     val inserters = inserterBuilder.result()
 
     val aggregateOption = Aggregators.buildVariantAggregations(vds, ec)

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -1850,7 +1850,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
 
   def setVaAttributes(path: List[String], kv: Map[String, String]): VariantSampleMatrix[T] = {
     vaSignature match{
-      case struct: TStruct => copy(vaSignature = vaSignature.asInstanceOf[TStruct].setFieldAttributes(path, kv))
+      case t: TStruct => copy(vaSignature = t.setFieldAttributes(path, kv))
       case t => fatal(s"Cannot set va attributes to ${path.mkString(".")} since va is not a Struct.")
     }
   }
@@ -1861,7 +1861,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
 
   def deleteVaAttribute(path: List[String], attribute: String): VariantSampleMatrix[T] = {
     vaSignature match{
-      case struct: TStruct => copy(vaSignature = vaSignature.asInstanceOf[TStruct].deleteFieldAttribute(path, attribute))
+      case t: TStruct => copy(vaSignature = t.deleteFieldAttribute(path, attribute))
       case t => fatal(s"Cannot delete va attributes from ${path.mkString(".")} since va is not a Struct.")
     }
   }

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -1,6 +1,8 @@
 package is.hail.variant
 
 import java.nio.ByteBuffer
+import java.util
+import scala.collection.JavaConverters._
 
 import is.hail.annotations._
 import is.hail.check.Gen
@@ -1841,6 +1843,41 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
   }
 
   def storageLevel: String = rdd.getStorageLevel.toReadableString()
+
+  def setVAattribute(path: String, key: String, value: String): VariantSampleMatrix[T] = {
+    setVAattributes(path, Map(key -> value))
+  }
+
+  def setVAattribute(path: List[String], key: String, value: String): VariantSampleMatrix[T] = {
+    setVAattributes(path, Map(key -> value))
+  }
+
+  def setVAattributes(path: String, kv: Map[String, String]): VariantSampleMatrix[T] = {
+    setVAattributes(Parser.parseAnnotationRoot(path, Annotation.VARIANT_HEAD), kv)
+  }
+
+  def setVAattributes(path: List[String], kv: Map[String, String]): VariantSampleMatrix[T] = {
+    this.copy(vaSignature = vaSignature.asInstanceOf[TStruct].setFieldAttributes(path, kv))
+  }
+
+  def deleteVAattribute(path: String, attribute: String): VariantSampleMatrix[T] = {
+    deleteVAattribute(Parser.parseAnnotationRoot(path, Annotation.VARIANT_HEAD), attribute)
+  }
+
+  def deleteVAattribute(path: List[String], attribute: String): VariantSampleMatrix[T] = {
+    this.copy(vaSignature = vaSignature.asInstanceOf[TStruct].deleteFieldAttributes(path, attribute))
+  }
+
+  def getVAattributes(path: String): Map[String, String] = {
+    vaSignature.asInstanceOf[TStruct]
+      .fieldOption(Parser.parseAnnotationRoot(path, Annotation.VARIANT_HEAD))
+      .map(f => f.attrs)
+      .getOrElse(Map[String, String]())
+  }
+
+  def getVAattributesAsJava(path: String): util.Map[String, String] = {
+    getVAattributes(path).asJava
+  }
 
   override def toString = s"VariantSampleMatrix(metadata=$metadata, rdd=$rdd, sampleIds=$sampleIds, nSamples=$nSamples, vaSignature=$vaSignature, saSignature=$saSignature, globalSignature=$globalSignature, sampleAnnotations=$sampleAnnotations, sampleIdsAndAnnotations=$sampleIdsAndAnnotations, globalAnnotation=$globalAnnotation, wasSplit=$wasSplit)"
 

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -1844,31 +1844,29 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
 
   def storageLevel: String = rdd.getStorageLevel.toReadableString()
 
-  def setVAattribute(path: String, key: String, value: String): VariantSampleMatrix[T] = {
-    setVAattributes(path, Map(key -> value))
+  def setVaAttribute(path: String, key: String, value: String): VariantSampleMatrix[T] = {
+    setVaAttributes(Parser.parseAnnotationRoot(path, Annotation.VARIANT_HEAD), Map(key -> value))
   }
 
-  def setVAattribute(path: List[String], key: String, value: String): VariantSampleMatrix[T] = {
-    setVAattributes(path, Map(key -> value))
+  def setVaAttributes(path: List[String], kv: Map[String, String]): VariantSampleMatrix[T] = {
+    if(!vaSignature.isInstanceOf[TStruct])
+      fatal(s"Cannot set VA attributes to ${path.mkString(".")} since va is not a Struct.")
+    copy(vaSignature = vaSignature.asInstanceOf[TStruct].setFieldAttributes(path, kv))
   }
 
-  def setVAattributes(path: String, kv: Map[String, String]): VariantSampleMatrix[T] = {
-    setVAattributes(Parser.parseAnnotationRoot(path, Annotation.VARIANT_HEAD), kv)
+  def deleteVaAttribute(path: String, attribute: String): VariantSampleMatrix[T] = {
+    deleteVaAttribute(Parser.parseAnnotationRoot(path, Annotation.VARIANT_HEAD), attribute)
   }
 
-  def setVAattributes(path: List[String], kv: Map[String, String]): VariantSampleMatrix[T] = {
-    this.copy(vaSignature = vaSignature.asInstanceOf[TStruct].setFieldAttributes(path, kv))
+  def deleteVaAttribute(path: List[String], attribute: String): VariantSampleMatrix[T] = {
+    if(!vaSignature.isInstanceOf[TStruct])
+      fatal(s"Cannot delete VA attributes from ${path.mkString(".")} since va is not a Struct.")
+    copy(vaSignature = vaSignature.asInstanceOf[TStruct].deleteFieldAttributes(path, attribute))
   }
 
-  def deleteVAattribute(path: String, attribute: String): VariantSampleMatrix[T] = {
-    deleteVAattribute(Parser.parseAnnotationRoot(path, Annotation.VARIANT_HEAD), attribute)
-  }
-
-  def deleteVAattribute(path: List[String], attribute: String): VariantSampleMatrix[T] = {
-    this.copy(vaSignature = vaSignature.asInstanceOf[TStruct].deleteFieldAttributes(path, attribute))
-  }
-
-  def getVAattributes(path: String): Map[String, String] = {
+  def getVaAttributes(path: String): Map[String, String] = {
+    if(!vaSignature.isInstanceOf[TStruct])
+      fatal(s"Cannot get VA attributes from ${path.mkString(".")} since va is not a Struct.")
     vaSignature.asInstanceOf[TStruct]
       .fieldOption(Parser.parseAnnotationRoot(path, Annotation.VARIANT_HEAD))
       .map(f => f.attrs)
@@ -1876,7 +1874,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
   }
 
   def getVAattributesAsJava(path: String): util.Map[String, String] = {
-    getVAattributes(path).asJava
+    getVaAttributes(path).asJava
   }
 
   override def toString = s"VariantSampleMatrix(metadata=$metadata, rdd=$rdd, sampleIds=$sampleIds, nSamples=$nSamples, vaSignature=$vaSignature, saSignature=$saSignature, globalSignature=$globalSignature, sampleAnnotations=$sampleAnnotations, sampleIdsAndAnnotations=$sampleIdsAndAnnotations, globalAnnotation=$globalAnnotation, wasSplit=$wasSplit)"

--- a/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
+++ b/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
@@ -100,6 +100,33 @@ class AnnotationsSuite extends SparkSuite {
     val readBack = hc.read(f)
 
     assert(readBack.same(vds2))
+
+    //Check that adding attributes to FILTERS / INFO outputs the correct Number/Description
+    val vds_attr = vds
+      .setVAattribute("va.filters", "testFilter", "testFilterDesc")
+      .setVAattributes("va.info.MQ", Map("Number" -> ".", "Description" -> "testMQ", "foo" -> "bar"))
+
+    assert(vds_attr.vaSignature.fieldOption("filters")
+      .map(f => f.attrs.getOrElse("testFilter", "") == "testFilterDesc")
+      .getOrElse(false))
+
+    assert(vds_attr.vaSignature.fieldOption(List("info", "MQ"))
+      .map(f => f.attrs.getOrElse("foo", "") == "bar")
+      .getOrElse(false))
+    assert(vds_attr.vaSignature.fieldOption(List("info", "MQ"))
+      .map(f => f.attrs.getOrElse("Description", "") == "testMQ")
+      .getOrElse(false))
+    assert(vds_attr.vaSignature.fieldOption(List("info", "MQ"))
+      .map(f => f.attrs.getOrElse("Number", "") == ".")
+      .getOrElse(false))
+
+
+    // Write VCF and check that annotaions are the same
+    val f2 = tmpDir.createTempFile("sample2", extension = ".vds")
+    vds_attr.write(f2)
+    val readBack_attr = hc.read(f2)
+
+    assert(readBack_attr.same(vds_attr))
   }
 
   @Test def testReadWrite() {
@@ -322,6 +349,32 @@ class AnnotationsSuite extends SparkSuite {
     assert(vds.vaSignature.schema == toAdd8Sig.schema)
     assert(vds.variantsAndAnnotations.collect()
       .forall { case (v, va) => va == "dummy" })
+  }
+
+  @Test def testAttributeOperations() {
+
+    /*
+      This test method performs a number of attribute annotation operations on a vds, and ensures that the signatures
+      and annotations in the RDD elements are what is expected after each step.
+    */
+
+    var vds = hc.importVCF("src/test/resources/sample.vcf").cache()
+
+    vds = vds.setVAattribute("va.info.DP", "new_key", "new_value")
+    assert(vds.getVAattributes("va.info.DP").getOrElse("new_key", "missing_value") == "new_value")
+
+    vds = vds.setVAattribute("va.info.DP", "new_key", "modified_value")
+    assert(vds.getVAattributes("va.info.DP").getOrElse("new_key", "missing_value") == "modified_value")
+
+    vds = vds.setVAattributes("va.info.DP", Map("key1" -> "value1", "key2" -> "value2"))
+    assert(vds.getVAattributes("va.info.DP").getOrElse("key1", "missing_value") == "value1")
+    assert(vds.getVAattributes("va.info.DP").getOrElse("key2", "missing_value") == "value2")
+
+    vds = vds.deleteVAattribute("va.info.DP", "new_key")
+    assert(!vds.getVAattributes("va.info.DP").contains("new_key"))
+
+    vds = vds.deleteVAattribute("va.info.DP", "new_key")
+
   }
 
   @Test def testWeirdNamesReadWrite() {

--- a/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
+++ b/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
@@ -103,8 +103,8 @@ class AnnotationsSuite extends SparkSuite {
 
     //Check that adding attributes to FILTERS / INFO outputs the correct Number/Description
     val vds_attr = vds
-      .setVAattribute("va.filters", "testFilter", "testFilterDesc")
-      .setVAattributes("va.info.MQ", Map("Number" -> ".", "Description" -> "testMQ", "foo" -> "bar"))
+      .setVaAttribute("va.filters", "testFilter", "testFilterDesc")
+      .setVaAttributes(Parser.parseAnnotationRoot("va.info.MQ", Annotation.VARIANT_HEAD), Map("Number" -> ".", "Description" -> "testMQ", "foo" -> "bar"))
 
     assert(vds_attr.vaSignature.fieldOption("filters")
       .map(f => f.attrs.getOrElse("testFilter", "") == "testFilterDesc")
@@ -360,20 +360,20 @@ class AnnotationsSuite extends SparkSuite {
 
     var vds = hc.importVCF("src/test/resources/sample.vcf").cache()
 
-    vds = vds.setVAattribute("va.info.DP", "new_key", "new_value")
-    assert(vds.getVAattributes("va.info.DP").getOrElse("new_key", "missing_value") == "new_value")
+    vds = vds.setVaAttribute("va.info.DP", "new_key", "new_value")
+    assert(vds.getVaAttributes("va.info.DP").getOrElse("new_key", "missing_value") == "new_value")
 
-    vds = vds.setVAattribute("va.info.DP", "new_key", "modified_value")
-    assert(vds.getVAattributes("va.info.DP").getOrElse("new_key", "missing_value") == "modified_value")
+    vds = vds.setVaAttribute("va.info.DP", "new_key", "modified_value")
+    assert(vds.getVaAttributes("va.info.DP").getOrElse("new_key", "missing_value") == "modified_value")
 
-    vds = vds.setVAattributes("va.info.DP", Map("key1" -> "value1", "key2" -> "value2"))
-    assert(vds.getVAattributes("va.info.DP").getOrElse("key1", "missing_value") == "value1")
-    assert(vds.getVAattributes("va.info.DP").getOrElse("key2", "missing_value") == "value2")
+    vds = vds.setVaAttributes(Parser.parseAnnotationRoot("va.info.DP", Annotation.VARIANT_HEAD), Map("key1" -> "value1", "key2" -> "value2"))
+    assert(vds.getVaAttributes("va.info.DP").getOrElse("key1", "missing_value") == "value1")
+    assert(vds.getVaAttributes("va.info.DP").getOrElse("key2", "missing_value") == "value2")
 
-    vds = vds.deleteVAattribute("va.info.DP", "new_key")
-    assert(!vds.getVAattributes("va.info.DP").contains("new_key"))
+    vds = vds.deleteVaAttribute("va.info.DP", "new_key")
+    assert(!vds.getVaAttributes("va.info.DP").contains("new_key"))
 
-    vds = vds.deleteVAattribute("va.info.DP", "new_key")
+    vds = vds.deleteVaAttribute("va.info.DP", "new_key")
 
   }
 

--- a/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
+++ b/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
@@ -103,8 +103,8 @@ class AnnotationsSuite extends SparkSuite {
 
     //Check that adding attributes to FILTERS / INFO outputs the correct Number/Description
     val vds_attr = vds
-      .setVaAttribute("va.filters", "testFilter", "testFilterDesc")
-      .setVaAttributes(Parser.parseAnnotationRoot("va.info.MQ", Annotation.VARIANT_HEAD), Map("Number" -> ".", "Description" -> "testMQ", "foo" -> "bar"))
+      .setVaAttributes("va.filters", Map("testFilter" -> "testFilterDesc"))
+      .setVaAttributes("va.info.MQ", Map("Number" -> ".", "Description" -> "testMQ", "foo" -> "bar"))
 
     assert(vds_attr.vaSignature.fieldOption("filters")
       .map(f => f.attrs.getOrElse("testFilter", "") == "testFilterDesc")
@@ -360,18 +360,34 @@ class AnnotationsSuite extends SparkSuite {
 
     var vds = hc.importVCF("src/test/resources/sample.vcf").cache()
 
-    vds = vds.setVaAttribute("va.info.DP", "new_key", "new_value")
-    assert(vds.getVaAttributes("va.info.DP").getOrElse("new_key", "missing_value") == "new_value")
+    vds = vds.setVaAttributes("va.info.DP", Map("new_key" -> "new_value"))
+    var infoAttr = vds.vaSignature.asInstanceOf[TStruct]
+      .fieldOption(Parser.parseAnnotationRoot("va.info.DP", Annotation.VARIANT_HEAD))
+      .map(_.attrs)
+      .getOrElse(Map[String,String]())
+    assert(infoAttr.getOrElse("new_key", "missing_value") == "new_value")
 
-    vds = vds.setVaAttribute("va.info.DP", "new_key", "modified_value")
-    assert(vds.getVaAttributes("va.info.DP").getOrElse("new_key", "missing_value") == "modified_value")
+    vds = vds.setVaAttributes("va.info.DP", Map("new_key" -> "modified_value"))
+    infoAttr = vds.vaSignature.asInstanceOf[TStruct]
+      .fieldOption(Parser.parseAnnotationRoot("va.info.DP", Annotation.VARIANT_HEAD))
+      .map(_.attrs)
+      .getOrElse(Map[String,String]())
+    assert(infoAttr.getOrElse("new_key", "missing_value") == "modified_value")
 
-    vds = vds.setVaAttributes(Parser.parseAnnotationRoot("va.info.DP", Annotation.VARIANT_HEAD), Map("key1" -> "value1", "key2" -> "value2"))
-    assert(vds.getVaAttributes("va.info.DP").getOrElse("key1", "missing_value") == "value1")
-    assert(vds.getVaAttributes("va.info.DP").getOrElse("key2", "missing_value") == "value2")
+    vds = vds.setVaAttributes("va.info.DP", Map("key1" -> "value1", "key2" -> "value2"))
+    infoAttr = vds.vaSignature.asInstanceOf[TStruct]
+      .fieldOption(Parser.parseAnnotationRoot("va.info.DP", Annotation.VARIANT_HEAD))
+      .map(_.attrs)
+      .getOrElse(Map[String,String]())
+    assert(infoAttr.getOrElse("key1", "missing_value") == "value1")
+    assert(infoAttr.getOrElse("key2", "missing_value") == "value2")
 
     vds = vds.deleteVaAttribute("va.info.DP", "new_key")
-    assert(!vds.getVaAttributes("va.info.DP").contains("new_key"))
+    infoAttr = vds.vaSignature.asInstanceOf[TStruct]
+      .fieldOption(Parser.parseAnnotationRoot("va.info.DP", Annotation.VARIANT_HEAD))
+      .map(_.attrs)
+      .getOrElse(Map[String,String]())
+    assert(!infoAttr.contains("new_key"))
 
     vds = vds.deleteVaAttribute("va.info.DP", "new_key")
 


### PR DESCRIPTION
The functions expose Field attributes (useful for VCF header)
- Annotations generated using annotate_alleles_expr now have 'Number=A'
- VEP now parses the Description when using csq=True option (required to know the fields stored in the  |-delimited field)