### PR TITLE
switched to unsafeValueAt in RichDenseMatrixDouble

### DIFF
--- a/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
@@ -24,7 +24,7 @@ class RichDenseMatrixDouble(val m: DenseMatrix[Double]) extends AnyVal {
       if (keepRow(row)) {
         nRows += 1
         for (col <- 0 until m.cols)
-          ab += m(row, col)
+          ab += m.unsafeValueAt(row, col)
       }
 
     if (nRows > 0)
@@ -42,7 +42,7 @@ class RichDenseMatrixDouble(val m: DenseMatrix[Double]) extends AnyVal {
       if (keepCol(col)) {
         nCols += 1
         for (row <- 0 until m.rows)
-          ab += m(row, col)
+          ab += m.unsafeValueAt(row, col)
       }
 
     if (nCols > 0)


### PR DESCRIPTION
It's safe here since we're within bounds and don't use negative indexing.
```
  def unsafeValueAt(row: Int, col: Int): V = data(linearIndex(row, col))
```
