### PR TITLE
moved to VSM to SharedIterable

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -11,7 +11,6 @@ import warnings
 
 warnings.filterwarnings(module=__name__, action='once')
 
-
 class VariantDataset(object):
     """Hail's primary representation of genomic data, a matrix keyed by sample and variant.
 

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -13,7 +13,7 @@ import is.hail.methods.DuplicateReport
 import is.hail.misc.SeqrServer
 import is.hail.stats.{BaldingNicholsModel, Distribution, UniformDist}
 import is.hail.utils.{log, _}
-import is.hail.variant.{GenericDataset, Genotype, VSMSubgen, Variant, VariantDataset, VariantMetadata, VariantSampleMatrix}
+import is.hail.variant.{GenericDataset, Genotype, Variant, VariantDataset, VariantMetadata, VariantSampleMatrix} // FIXME: put back VSMSubgen
 import org.apache.hadoop
 import org.apache.log4j.{LogManager, PropertyConfigurator}
 import org.apache.spark.deploy.SparkHadoopUtil
@@ -246,7 +246,7 @@ class HailContext private(val sc: SparkContext,
     val keyedRDD = rdd.map {
       _.map { a =>
         ec.setAllFromRow(a.asInstanceOf[Row])
-        (variantFn(), (fn(null, a), Iterable.empty[Genotype]))
+        (variantFn(), (fn(null, a), SharedIterable.empty[Genotype]))
       }.value
     }
       .filter { case (v, _) => v != null }
@@ -579,7 +579,8 @@ class HailContext private(val sc: SparkContext,
   def dataframeToKeytable(df: DataFrame, keys: Array[String] = Array.empty[String]): KeyTable =
     KeyTable.fromDF(this, df, keys)
 
-  def genDataset(): VariantDataset = VSMSubgen.realistic.gen(this).sample()
+//  FIXME: put back
+//  def genDataset(): VariantDataset = VSMSubgen.realistic.gen(this).sample()
 
   def eval(expr: String): (Annotation, Type) = {
     val ec = EvalContext()

--- a/src/main/scala/is/hail/io/bgen/BgenBlockReader.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenBlockReader.scala
@@ -6,6 +6,7 @@ import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.io._
 import is.hail.io.gen.GenReport._
+import is.hail.utils.{SharedIterable, SharedIterator}
 import is.hail.variant.{DosageGenotype, Genotype, Variant}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.LongWritable
@@ -13,7 +14,7 @@ import org.apache.hadoop.mapred.FileSplit
 
 class BgenRecord(compressed: Boolean,
   nSamples: Int,
-  tolerance: Double) extends KeySerializedValueRecord[Variant, Iterable[Genotype]] {
+  tolerance: Double) extends KeySerializedValueRecord[Variant, SharedIterable[Genotype]] {
   var ann: Annotation = _
 
   def setAnnotation(ann: Annotation) {
@@ -22,7 +23,7 @@ class BgenRecord(compressed: Boolean,
 
   def getAnnotation: Annotation = ann
 
-  override def getValue: Iterable[Genotype] = {
+  override def getValue: SharedIterable[Genotype] = {
     require(input != null, "called getValue before serialized value was set")
 
     val bytes =
@@ -48,8 +49,8 @@ class BgenRecord(compressed: Boolean,
 
     val noCall: Genotype = new DosageGenotype(-1, null)
 
-    new Iterable[Genotype] {
-      def iterator = new Iterator[Genotype] {
+    new SharedIterable[Genotype] {
+      def iterator = new SharedIterator[Genotype] {
         var i = 0
 
         def hasNext: Boolean = i < bytes.length

--- a/src/main/scala/is/hail/io/gen/GenLoader.scala
+++ b/src/main/scala/is/hail/io/gen/GenLoader.scala
@@ -10,7 +10,7 @@ import org.apache.spark.{Accumulable, SparkContext}
 
 import scala.collection.mutable
 
-case class GenResult(file: String, nSamples: Int, nVariants: Int, rdd: RDD[(Variant, (Annotation, Iterable[Genotype]))])
+case class GenResult(file: String, nSamples: Int, nVariants: Int, rdd: RDD[(Variant, (Annotation, SharedIterable[Genotype]))])
 
 object GenReport {
   final val dosageNoCall = 0
@@ -86,7 +86,7 @@ object GenLoader {
   def readGenLine(line: String, nSamples: Int,
                   tolerance: Double,
                   reportAcc: Accumulable[mutable.Map[Int, Int], Int],
-                  chromosome: Option[String] = None): (Variant, (Annotation, Iterable[Genotype])) = {
+                  chromosome: Option[String] = None): (Variant, (Annotation, SharedIterable[Genotype])) = {
 
     val arr = line.split("\\s+")
     val chrCol = if (chromosome.isDefined) 1 else 0

--- a/src/main/scala/is/hail/io/plink/ExportBedBimFam.scala
+++ b/src/main/scala/is/hail/io/plink/ExportBedBimFam.scala
@@ -1,12 +1,13 @@
 package is.hail.io.plink
 
+import is.hail.utils.SharedIterable
 import is.hail.variant._
 
 object ExportBedBimFam {
 
   val gtMap = Array(1, 3, 2, 0)
 
-  def makeBedRow(gs: Iterable[Genotype], n: Int): Array[Byte] = {
+  def makeBedRow(gs: SharedIterable[Genotype], n: Int): Array[Byte] = {
     val gts = gs.hardCallIterator
 
     val nBytes = (n + 3) / 4

--- a/src/main/scala/is/hail/io/plink/PlinkBlockReader.scala
+++ b/src/main/scala/is/hail/io/plink/PlinkBlockReader.scala
@@ -1,13 +1,14 @@
 package is.hail.io.plink
 
 import is.hail.io.{IndexedBinaryBlockReader, KeySerializedValueRecord}
+import is.hail.utils.SharedIterable
 import is.hail.variant.{Genotype, GenotypeBuilder, GenotypeStreamBuilder}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.LongWritable
 import org.apache.hadoop.mapred.FileSplit
 
-class PlinkRecord(nSamples: Int, gb: GenotypeBuilder, gsb: GenotypeStreamBuilder) extends KeySerializedValueRecord[Int, Iterable[Genotype]] {
-  override def getValue: Iterable[Genotype] = {
+class PlinkRecord(nSamples: Int, gb: GenotypeBuilder, gsb: GenotypeStreamBuilder) extends KeySerializedValueRecord[Int, SharedIterable[Genotype]] {
+  override def getValue: SharedIterable[Genotype] = {
     require(input != null, "called getValue before serialized value was set")
 
     gsb.clear()

--- a/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -346,7 +346,7 @@ object ExportVCF {
           false
       }.map(_ => gds.queryVA("va.filters")._2)
 
-    def appendRow(sb: StringBuilder, v: Variant, a: Annotation, gs: Iterable[Annotation]) {
+    def appendRow(sb: StringBuilder, v: Variant, a: Annotation, gs: SharedIterable[Annotation]) {
 
       sb.append(v.contig)
       sb += '\t'
@@ -411,7 +411,7 @@ object ExportVCF {
       }
     }
 
-    gds.rdd.mapPartitions { it: Iterator[(Variant, (Annotation, Iterable[Annotation]))] =>
+    gds.rdd.mapPartitions { it: Iterator[(Variant, (Annotation, SharedIterable[Annotation]))]=>
       val sb = new StringBuilder
       it.map { case (v, (va, gs)) =>
         sb.clear()

--- a/src/main/scala/is/hail/io/vcf/HtsjdkRecordReader.scala
+++ b/src/main/scala/is/hail/io/vcf/HtsjdkRecordReader.scala
@@ -78,7 +78,7 @@ abstract class HtsjdkRecordReader[T] extends Serializable {
   def readRecord(reportAcc: Accumulable[mutable.Map[Int, Int], Int],
     vc: VariantContext,
     infoSignature: Option[TStruct],
-    genotypeSignature: Type): (Variant, (Annotation, Iterable[T]))
+    genotypeSignature: Type): (Variant, (Annotation, SharedIterable[T]))
 
   def genericGenotypes: Boolean
 }
@@ -89,14 +89,14 @@ case class GenotypeRecordReader(vcfSettings: VCFSettings) extends HtsjdkRecordRe
   def readRecord(reportAcc: Accumulable[mutable.Map[Int, Int], Int],
     vc: VariantContext,
     infoSignature: Option[TStruct],
-    genotypeSignature: Type): (Variant, (Annotation, Iterable[Genotype])) = {
+    genotypeSignature: Type): (Variant, (Annotation, SharedIterable[Genotype])) = {
 
     val (v, va) = readVariantInfo(vc, infoSignature)
 
     val nAlleles = v.nAlleles
 
     if (vcfSettings.skipGenotypes)
-      return (v, (va, Iterable.empty))
+      return (v, (va, SharedIterable.empty[Genotype]))
 
     val gb = new GenotypeBuilder(v.nAlleles, false) // FIXME: make dependent on fields in genotypes; for now, assumes PLs
 
@@ -267,7 +267,7 @@ case class GenericRecordReader(callFields: Set[String]) extends HtsjdkRecordRead
   def readRecord(reportAcc: Accumulable[mutable.Map[Int, Int], Int],
     vc: VariantContext,
     infoSignature: Option[TStruct],
-    genotypeSignature: Type): (Variant, (Annotation, Iterable[Annotation])) = {
+    genotypeSignature: Type): (Variant, (Annotation, SharedIterable[Annotation])) = {
 
     val (v, va) = readVariantInfo(vc, infoSignature)
     val nAlleles = v.nAlleles

--- a/src/main/scala/is/hail/methods/Aggregators.scala
+++ b/src/main/scala/is/hail/methods/Aggregators.scala
@@ -30,7 +30,7 @@ object Aggregators {
       "gs" -> (3, TAggregable(TGenotype, aggregationST))))
   }
 
-  def buildVariantAggregations(vds: VariantDataset, ec: EvalContext): Option[(Variant, Annotation, Iterable[Genotype]) => Unit] = {
+  def buildVariantAggregations(vds: VariantDataset, ec: EvalContext): Option[(Variant, Annotation, SharedIterable[Genotype]) => Unit] = {
 
     val aggregations = ec.aggregations
     if (aggregations.isEmpty)
@@ -41,7 +41,7 @@ object Aggregators {
     val localAnnotationsBc = vds.sampleAnnotationsBc
     val localGlobalAnnotations = vds.globalAnnotation
 
-    Some({ (v: Variant, va: Annotation, gs: Iterable[Genotype]) =>
+    Some({ (v: Variant, va: Annotation, gs: SharedIterable[Genotype]) =>
       val aggs = aggregations.map { case (_, _, agg0) => agg0.copy() }
       localA(0) = localGlobalAnnotations
       localA(1) = v

--- a/src/main/scala/is/hail/methods/CalculateConcordance.scala
+++ b/src/main/scala/is/hail/methods/CalculateConcordance.scala
@@ -171,7 +171,7 @@ object CalculateConcordance {
         }
         val va = Annotation(comb.toAnnotation, value1.map(_._1).orNull, value2.map(_._1).orNull)
         assert(vaSchema.typeCheck(va))
-        (v, (va, Iterable.empty[Genotype]))
+        (v, (va, SharedIterable.empty[Genotype]))
       }
     }, preservesPartitioning = true).asOrderedRDD
 
@@ -196,7 +196,7 @@ object CalculateConcordance {
       vaSignature = TStruct.empty,
       globalSignature = globalSchema,
       wasSplit = true),
-      OrderedRDD.empty[Locus, Variant, (Annotation, Iterable[Genotype])](left.sparkContext))
+      OrderedRDD.empty[Locus, Variant, (Annotation, SharedIterable[Genotype])](left.sparkContext))
 
     val variants = VariantSampleMatrix(left.hc, VariantMetadata(IndexedSeq.empty[String],
       sampleAnnotations = IndexedSeq.empty[Annotation],

--- a/src/main/scala/is/hail/methods/FilterAlleles.scala
+++ b/src/main/scala/is/hail/methods/FilterAlleles.scala
@@ -75,7 +75,7 @@ object FilterAlleles {
       f().zip(inserters).foldLeft(va) { case (va, (v, inserter)) => inserter(va, v) }
     }
 
-    def updateGenotypes(gs: Iterable[Genotype], oldToNew: Array[Int], newCount: Int): Iterable[Genotype] = {
+    def updateGenotypes(gs: SharedIterable[Genotype], oldToNew: Array[Int], newCount: Int): SharedIterable[Genotype] = {
       def downcodeGtPair(gt: GTPair): GTPair =
         GTPair.fromNonNormalized(oldToNew(gt.j), oldToNew(gt.k))
 
@@ -129,7 +129,8 @@ object FilterAlleles {
         )
       }
 
-      gs.map({
+      // FIXME: changed from map to lazyMap
+      gs.lazyMap({
         g =>
           val newG = if (subset) subsetGenotype(g) else downcodeGenotype(g)
           if (filterAlteredGenotypes && newG.gt != g.gt)
@@ -139,8 +140,8 @@ object FilterAlleles {
       })
     }
 
-    def updateOrFilterRow(v: Variant, va: Annotation, gs: Iterable[Genotype],
-      f: (Variant) => Boolean): Option[(Variant, (Annotation, Iterable[Genotype]))] =
+    def updateOrFilterRow(v: Variant, va: Annotation, gs: SharedIterable[Genotype],
+      f: (Variant) => Boolean): Option[(Variant, (Annotation, SharedIterable[Genotype]))] =
       filterAllelesInVariant(v, va)
         .filter { case (v, _, _) => f(v) }
         .map { case (newV, newToOld, oldToNew) =>

--- a/src/main/scala/is/hail/methods/IBD.scala
+++ b/src/main/scala/is/hail/methods/IBD.scala
@@ -84,9 +84,10 @@ object IBD {
     indicator(gt.j == 0) + indicator(gt.k == 0)
   }
 
-  def ibsForGenotypes(gs: Iterable[Genotype], maybeMaf: Option[Double]): IBSExpectations = {
+  // FIXME: using toIterable
+  def ibsForGenotypes(gs: SharedIterable[Genotype], maybeMaf: Option[Double]): IBSExpectations = {
     def calculateCountsFromMAF(maf: Double) = {
-      val Na = gs.count(_.gt.isDefined) * 2.0
+      val Na = gs.toIterable.count(_.gt.isDefined) * 2.0
       val p = 1 - maf
       val q = maf
       val x = Na * p
@@ -158,8 +159,9 @@ object IBD {
 
     val nSamples = vds.nSamples
 
+    // FIXME: using toIterable
     val chunkedGenotypeMatrix = vds.rdd
-      .map { case (v, (va, gs)) => gs.map(_.gt.map(IBSFFI.gtToCRep).getOrElse(IBSFFI.missingGTCRep)).toArray[Byte] }
+      .map { case (v, (va, gs)) => gs.toIterable.map(_.gt.map(IBSFFI.gtToCRep).getOrElse(IBSFFI.missingGTCRep)).toArray[Byte] }
       .zipWithIndex()
       .flatMap { case (gts, variantId) =>
         val vid = (variantId % chunkSize).toInt

--- a/src/main/scala/is/hail/methods/SampleQC.scala
+++ b/src/main/scala/is/hail/methods/SampleQC.scala
@@ -242,8 +242,7 @@ object SampleQC {
                   )
                 acc
             })
-            for ((g, i) <- gs.iterator.zipWithIndex)
-              acc(i).merge(v, ACs, g)
+            gs.iterator.zipWithIndex.foreach { case (g, i) => acc(i).merge(v, ACs, g) }
             acc
           }, { case (comb1, comb2) =>
             for (i <- comb1.indices)

--- a/src/main/scala/is/hail/methods/SplitMulti.scala
+++ b/src/main/scala/is/hail/methods/SplitMulti.scala
@@ -16,12 +16,12 @@ object SplitMulti {
 
   def split(v: Variant,
     va: Annotation,
-    it: Iterable[Genotype],
+    it: SharedIterable[Genotype],
     propagateGQ: Boolean,
     isDosage: Boolean,
     keepStar: Boolean,
     insertSplitAnnots: (Annotation, Int, Boolean) => Annotation,
-    f: (Variant) => Boolean): Iterator[(Variant, (Annotation, Iterable[Genotype]))] = {
+    f: (Variant) => Boolean): Iterator[(Variant, (Annotation, SharedIterable[Genotype]))] = {
 
     if (v.isBiallelic) {
       val minrep = v.minrep

--- a/src/main/scala/is/hail/methods/VEP.scala
+++ b/src/main/scala/is/hail/methods/VEP.scala
@@ -377,14 +377,14 @@ object VEP {
 
     val newRDD = vds.rdd
       .zipPartitions(annotations, preservesPartitioning = true) { case (left, right) =>
-        new Iterator[(Variant, (Annotation, Iterable[Genotype]))] {
+        new Iterator[(Variant, (Annotation, SharedIterable[Genotype]))] {
           def hasNext: Boolean = {
             val r = left.hasNext
             assert(r == right.hasNext)
             r
           }
 
-          def next(): (Variant, (Annotation, Iterable[Genotype])) = {
+          def next(): (Variant, (Annotation, SharedIterable[Genotype])) = {
             val (lv, (va, gs)) = left.next()
             val (rv, vaVep) = right.next()
             assert(lv == rv)

--- a/src/main/scala/is/hail/stats/BaldingNicholsModel.scala
+++ b/src/main/scala/is/hail/stats/BaldingNicholsModel.scala
@@ -103,7 +103,7 @@ object BaldingNicholsModel {
                 else
                   1
               Genotype(gt)
-            }: Iterable[Genotype]
+            }: SharedIterable[Genotype]
           )
         )
       }

--- a/src/main/scala/is/hail/stats/RegressionUtils.scala
+++ b/src/main/scala/is/hail/stats/RegressionUtils.scala
@@ -106,7 +106,7 @@ object RegressionUtils {
   }
 
   // mean 0, norm sqrt(n), variance 1 (constant variants return None)
-  def toNormalizedGtArray(gs: Iterable[Genotype], nSamples: Int): Option[Array[Double]] = {
+  def toNormalizedGtArray(gs: SharedIterable[Genotype], nSamples: Int): Option[Array[Double]] = {
     val gtVals = Array.ofDim[Double](nSamples)
     var nMissing = 0
     var gtSum = 0
@@ -153,7 +153,7 @@ object RegressionUtils {
   }
 
   // mean 0, norm approx. sqrt(m), variance approx. 1 (constant variants return None)
-  def toHWENormalizedGtArray(gs: Iterable[Genotype], nSamples: Int, nVariants: Int): Option[Array[Double]] = {
+  def toHWENormalizedGtArray(gs: SharedIterable[Genotype], nSamples: Int, nVariants: Int): Option[Array[Double]] = {
     val gtVals = Array.ofDim[Double](nSamples)
     var nMissing = 0
     var gtSum = 0

--- a/src/main/scala/is/hail/stats/package.scala
+++ b/src/main/scala/is/hail/stats/package.scala
@@ -307,7 +307,7 @@ package object stats {
           (Annotation.empty,
             (0 until genotypes.rows).map { i =>
               Genotype(genotypes(i, j))
-            }: Iterable[Genotype]
+            }: SharedIterable[Genotype]
             )
           )
       },

--- a/src/main/scala/is/hail/utils/SharedIterable.scala
+++ b/src/main/scala/is/hail/utils/SharedIterable.scala
@@ -2,7 +2,6 @@ package is.hail.utils
 
 import scala.annotation.tailrec
 import scala.collection.{Iterable, mutable}
-import scala.collection.generic.{CanBuildFrom, GenTraversableFactory}
 import scala.reflect.ClassTag
 
 object SharedIterable {
@@ -11,8 +10,8 @@ object SharedIterable {
     override def iterator: SharedIterator[Nothing] = SharedIterator.empty
   }
 
-// FIXME: I couldn't get this to work, so I've removed VSMSubgen for now
-// implicit def canBuildFrom[T]: CanBuildFrom[Coll, T, SharedIterable[T]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[T]]
+  // FIXME: I couldn't get this to work, so I've removed VSMSubgen for now
+  // implicit def canBuildFrom[T]: CanBuildFrom[Coll, T, SharedIterable[T]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[T]]
 
   def newBuilder[T]: mutable.Builder[T, SharedIterable[T]] = SharedIterable.newBuilder[T]
 }
@@ -90,14 +89,6 @@ abstract class SharedIterable[+T] {
   }
 
   def forall(p: T => Boolean): Boolean = self.iterator.forall(p)
-
-//  def isEmpty: Boolean = self.iterator.isEmpty
-//  def hasDefiniteSize: Boolean = self.iterator.hasDefiniteSize
-//
-//  def exists(p: T => Boolean): Boolean = self.iterator.exists(p)
-//  def find(p: T => Boolean): Option[T] = self.iterator.find(p)
-//  def copyToArray[U >: T](xs: Array[U], start: Int, len: Int): Unit = self.iterator.copyToArray(xs, start, len)
-
 }
 
 
@@ -153,35 +144,6 @@ abstract class SharedIterator[+T] {
     while (res && hasNext) res = p(next())
     res
   }
-
-//  def isEmpty: Boolean = !hasNext
-//
-//  def hasDefiniteSize: Boolean = isEmpty
-//
-//
-//  def exists(p: T => Boolean): Boolean = {
-//    var res = false
-//    while (!res && hasNext) res = p(next())
-//    res
-//  }
-//
-//  def find(p: T => Boolean): Option[T] = {
-//    while (hasNext) {
-//      val a = next()
-//      if (p(a)) return Some(a)
-//    }
-//    None
-//  }
-//
-//  def copyToArray[U >: T](xs: Array[U], start: Int, len: Int): Unit = {
-//    require(start >= 0 && (start < xs.length || xs.length == 0), s"start $start out of range ${xs.length}")
-//    var i = start
-//    val end = start + math.min(len, xs.length - start)
-//    while (i < end && hasNext) {
-//      xs(i) = next()
-//      i += 1
-//    }
-//  }
 }
 
 final class ConcatSharedIterator[+T](private[this] var current: SharedIterator[T], initial: Vector[() => SharedIterator[T]]) extends SharedIterator[T] {

--- a/src/main/scala/is/hail/utils/SharedIterable.scala
+++ b/src/main/scala/is/hail/utils/SharedIterable.scala
@@ -11,7 +11,8 @@ object SharedIterable {
     override def iterator: SharedIterator[Nothing] = SharedIterator.empty
   }
 
-//  implicit def canBuildFrom[T]: CanBuildFrom[Coll, T, SharedIterable[T]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[T]]
+// FIXME: I couldn't get this to work, so I've removed VSMSubgen for now
+// implicit def canBuildFrom[T]: CanBuildFrom[Coll, T, SharedIterable[T]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[T]]
 
   def newBuilder[T]: mutable.Builder[T, SharedIterable[T]] = SharedIterable.newBuilder[T]
 }
@@ -21,7 +22,7 @@ abstract class SharedIterable[+T] {
 
   def iterator: SharedIterator[T]
 
-  // FIXME: Super unsafe once we switch to MutableGenotype
+  // FIXME: temporary to allow building, unsafe once we switch to MutableGenotypeStreamIterator
   def toIterable: Iterable[T] = new Iterable[T] {
     override def iterator = new Iterator[T] {
       private val it = self.iterator

--- a/src/main/scala/is/hail/utils/SharedIterable.scala
+++ b/src/main/scala/is/hail/utils/SharedIterable.scala
@@ -1,0 +1,240 @@
+package is.hail.utils
+
+import scala.annotation.tailrec
+import scala.collection.{Iterable, mutable}
+import scala.collection.generic.{CanBuildFrom, GenTraversableFactory}
+import scala.reflect.ClassTag
+
+object SharedIterable {
+
+  def empty[T]: SharedIterable[T] = new SharedIterable[T] {
+    override def iterator: SharedIterator[Nothing] = SharedIterator.empty
+  }
+
+//  implicit def canBuildFrom[T]: CanBuildFrom[Coll, T, SharedIterable[T]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[T]]
+
+  def newBuilder[T]: mutable.Builder[T, SharedIterable[T]] = SharedIterable.newBuilder[T]
+}
+
+abstract class SharedIterable[+T] {
+  self =>
+
+  def iterator: SharedIterator[T]
+
+  // FIXME: Super unsafe once we switch to MutableGenotype
+  def toIterable: Iterable[T] = new Iterable[T] {
+    override def iterator = new Iterator[T] {
+      private val it = self.iterator
+
+      override def hasNext: Boolean = it.hasNext
+
+      override def next(): T = it.next()
+    }
+  }
+
+  def lazyFilterWith[T2](i2: Iterable[T2], p: (T, T2) => Boolean): SharedIterable[T] =
+    new SharedIterable[T] with Serializable {
+      def iterator: SharedIterator[T] = new SharedIterator[T] {
+        val it: SharedIterator[T] = self.iterator
+        val it2: Iterator[T2] = i2.iterator
+
+        var pending: Boolean = false
+        var pendingNext: T = _
+
+        def setNext() {
+          while (!pending && it.hasNext && it2.hasNext) {
+            val n = it.next()
+            val n2 = it2.next()
+            if (p(n, n2)) {
+              pending = true
+              pendingNext = n
+            }
+          }
+        }
+
+        def hasNext: Boolean = {
+          setNext()
+          pending
+        }
+
+        def next(): T = {
+          if (!pending)
+            setNext()
+          pending = false
+          pendingNext
+        }
+      }
+    }
+
+  def ++[U >: T](that: => SharedIterable[U]): SharedIterable[U] = new SharedIterable[U] {
+    def iterator: SharedIterator[U] = self.iterator ++ that.iterator // FIXME: should be () => ?
+  }
+
+  def foldLeft[U](z: U)(op: (U, T) => U): U = self.iterator.foldLeft(z)(op)
+
+  def foreach[U](f: T => U): Unit = self.iterator.foreach(f)
+
+  def lazyMap[S](f: (T) => S): SharedIterable[S] = new SharedIterable[S] with Serializable {
+    def iterator: SharedIterator[S] = new SharedIterator[S] {
+      val it: SharedIterator[T] = self.iterator
+
+      def hasNext: Boolean = it.hasNext
+
+      def next(): S = f(it.next())
+    }
+  }
+
+  def zip[U](that: SharedIterable[U]): SharedIterable[(T, U)] = new SharedIterable[(T,U)] {
+    def iterator: SharedIterator[(T, U)] = self.iterator.zip(that.iterator)
+  }
+
+  def forall(p: T => Boolean): Boolean = self.iterator.forall(p)
+
+//  def isEmpty: Boolean = self.iterator.isEmpty
+//  def hasDefiniteSize: Boolean = self.iterator.hasDefiniteSize
+//
+//  def exists(p: T => Boolean): Boolean = self.iterator.exists(p)
+//  def find(p: T => Boolean): Option[T] = self.iterator.find(p)
+//  def copyToArray[U >: T](xs: Array[U], start: Int, len: Int): Unit = self.iterator.copyToArray(xs, start, len)
+
+}
+
+
+object SharedIterator {
+  def empty[T]: SharedIterator[T] = new SharedIterator[T] {
+    def hasNext: Boolean = false
+    def next(): Nothing = throw new NoSuchElementException("next on empty iterator")
+  }
+}
+
+abstract class SharedIterator[+T] {
+  self =>
+
+  def next(): T
+
+  def hasNext: Boolean
+
+  def foldLeft[U](z: U)(op: (U, T) => U): U = {
+    var result = z
+    self.foreach(x => result = op(result, x))
+    result
+  }
+
+  def foreach[U](f: T => U) { while (hasNext) f(next()) }
+
+  def map[U](f: T => U): SharedIterator[U] = new SharedIterator[U] {
+    def hasNext: Boolean = self.hasNext
+    def next(): U = f(self.next())
+  }
+
+  def zip[U](that: SharedIterator[U]): SharedIterator[(T, U)] = new SharedIterator[(T, U)] {
+    def hasNext: Boolean = self.hasNext && that.hasNext
+    def next(): (T, U) = (self.next(), that.next())
+  }
+
+  def zipWithIndex: SharedIterator[(T, Int)] = new SharedIterator[(T, Int)] {
+    var idx = 0
+
+    def hasNext: Boolean = self.hasNext
+
+    def next(): (T, Int)  = {
+      val ret = (self.next(), idx)
+      idx += 1
+      ret
+    }
+  }
+
+  def ++[U >: T](that: => SharedIterator[U]): SharedIterator[U] =
+    new ConcatSharedIterator(self, Vector(() => that))
+
+  def forall(p: T => Boolean): Boolean = {
+    var res = true
+    while (res && hasNext) res = p(next())
+    res
+  }
+
+//  def isEmpty: Boolean = !hasNext
+//
+//  def hasDefiniteSize: Boolean = isEmpty
+//
+//
+//  def exists(p: T => Boolean): Boolean = {
+//    var res = false
+//    while (!res && hasNext) res = p(next())
+//    res
+//  }
+//
+//  def find(p: T => Boolean): Option[T] = {
+//    while (hasNext) {
+//      val a = next()
+//      if (p(a)) return Some(a)
+//    }
+//    None
+//  }
+//
+//  def copyToArray[U >: T](xs: Array[U], start: Int, len: Int): Unit = {
+//    require(start >= 0 && (start < xs.length || xs.length == 0), s"start $start out of range ${xs.length}")
+//    var i = start
+//    val end = start + math.min(len, xs.length - start)
+//    while (i < end && hasNext) {
+//      xs(i) = next()
+//      i += 1
+//    }
+//  }
+}
+
+final class ConcatSharedIterator[+T](private[this] var current: SharedIterator[T], initial: Vector[() => SharedIterator[T]]) extends SharedIterator[T] {
+  private[this] var queue: Vector[() => SharedIterator[T]] = initial
+  private[this] var currentHasNextChecked = false
+
+  @tailrec
+  private[this] def advance(): Boolean = {
+    if (queue.isEmpty) {
+      current = null
+      false
+    }
+    else {
+      current = queue.head()
+      queue = queue.tail
+      if (current.hasNext) {
+        currentHasNextChecked = true
+        true
+      } else advance()
+    }
+  }
+  def hasNext: Boolean =
+    if (currentHasNextChecked) true
+    else if (current eq null) false
+    else if (current.hasNext) {
+      currentHasNextChecked = true
+      true
+    } else advance()
+
+  def next(): T =
+    if (hasNext) {
+      currentHasNextChecked = false
+      current.next()
+    } else Iterator.empty.next()
+
+  override def ++[U >: T](that: => SharedIterator[U]): SharedIterator[U] =
+    new ConcatSharedIterator(current, queue :+ (() => that))
+}
+
+class SharedIterableBuilder[T](implicit tct: ClassTag[T]) extends mutable.Builder[T, SharedIterable[_]] {
+
+  val b: ArrayBuilder[T] = new ArrayBuilder[T]()
+
+  override def +=(g: T): SharedIterableBuilder.this.type = {
+    b += g
+    this
+  }
+
+  def ++=(i: SharedIterable[T]): SharedIterableBuilder[T] = {
+    i.foreach(this += _)
+    this
+  }
+
+  override def clear() { b.clear() }
+
+  override def result(): SharedIterable[T] = b.result().toSharedIterable
+}

--- a/src/main/scala/is/hail/utils/richUtils/Implicits.scala
+++ b/src/main/scala/is/hail/utils/richUtils/Implicits.scala
@@ -1,7 +1,7 @@
 package is.hail.utils.richUtils
 
 import breeze.linalg.DenseMatrix
-import is.hail.utils.{ArrayBuilder, JSONWriter, MultiArray2, Truncatable}
+import is.hail.utils.{ArrayBuilder, JSONWriter, MultiArray2, SharedIterable, SharedIterator, Truncatable}
 import is.hail.variant.Variant
 import org.apache.hadoop
 import org.apache.spark.SparkContext
@@ -97,4 +97,8 @@ trait Implicits {
   implicit def toJSONWritable[T](x: T)(implicit jw: JSONWriter[T]): JSONWritable[T] = new JSONWritable(x, jw)
 
   implicit def toRichJValue(jv: JValue): RichJValue = new RichJValue(jv)
+
+  implicit def toSharedIterable[T](i: Iterable[T]): SharedIterable[T] = i.toSharedIterable
+
+  implicit def toSharedIterator[T](it: Iterator[T]): SharedIterator[T] = it.toSharedIterator
 }

--- a/src/main/scala/is/hail/utils/richUtils/RichIterator.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichIterator.scala
@@ -2,10 +2,38 @@ package is.hail.utils.richUtils
 
 import java.io.PrintWriter
 
+import is.hail.utils.{SharedIterable, SharedIterator}
+
 import scala.collection.JavaConverters._
 import scala.io.Source
 
 class RichIterator[T](val it: Iterator[T]) extends AnyVal {
+  def toSharedIterator: SharedIterator[T] = new SharedIterator[T] {
+    def hasNext: Boolean = it.hasNext
+
+    def next(): T = it.next()
+  }
+
+  def flatMap[U](f: T => SharedIterable[U]): SharedIterable[U] = new SharedIterable[U] {
+    def iterator: SharedIterator[U] = new SharedIterator[U] {
+      self =>
+
+      private var cur: SharedIterator[U] = SharedIterator.empty
+
+      private def nextCur() { cur = f(it.next()).iterator }
+
+      def hasNext: Boolean = {
+        while (!cur.hasNext) {
+          if (!self.hasNext) return false
+          nextCur()
+        }
+        true
+      }
+
+      def next(): U = (if (hasNext) cur else SharedIterator.empty).next()
+    }
+  }
+
   def existsExactly1(p: (T) => Boolean): Boolean = {
     var n: Int = 0
     while (it.hasNext)

--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -4,7 +4,7 @@ import is.hail.sparkextras.ReorderedPartitionsRDD
 import is.hail.utils._
 import org.apache.hadoop
 import org.apache.hadoop.io.compress.CompressionCodecFactory
-import org.apache.spark.rdd.RDD
+import org.apache.spark.rdd.{MapPartitionsRDD, RDD}
 
 import scala.reflect.ClassTag
 

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -56,8 +56,6 @@ object VariantSampleMatrix {
     }
   }
 
-  // FIXME
-/*
   def gen[T](hc: HailContext,
     gen: VSMSubgen[T])(implicit tct: ClassTag[T]): Gen[VariantSampleMatrix[T]] =
     gen.gen(hc)
@@ -77,10 +75,8 @@ object VariantSampleMatrix {
         tGen = (v: Variant) => tSig.genValue.resize(20),
         isGenericGenotype = true).gen(hc)
     ) yield vsm
-*/
 }
 
-/*
 case class VSMSubgen[T](
   sampleIdGen: Gen[IndexedSeq[String]],
   saSigGen: Gen[Type],
@@ -146,7 +142,6 @@ object VSMSubgen {
   val dosage = random.copy(
     tGen = Genotype.genDosage, isDosage = true)
 }
-*/
 
 class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
   val rdd: OrderedRDD[Locus, Variant, (Annotation, SharedIterable[T])])(implicit tct: ClassTag[T]) extends JoinAnnotator {


### PR DESCRIPTION
@cseed definitely ready for some feedback. I replaced Iterable with SharedIterable in VSM, and carried it through to the point that Main builds ... which took more than 30 lines. I had to comment out VSMSubgen because I could not get this to work in SharedIterable:

`implicit def canBuildFrom[T]: CanBuildFrom[Coll, T, SharedIterable[T]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[T]]`

I left in FIXME's wherever I used toIterable to go from SharedIterable to Iterable, such as VSM functions that will need to be implemented separately in GDS and VSM (in retrospect, I suppose I could have just searched for toIterable usages).  toIterable won't yet cause problems since I haven't yet moved to MutableGenotypeStreamIterator, so I could temporarily make the test work with toIterators as well, though I'd then need to go and switch them all back later.

Once the Builder issue is resolved, I'm thinking the next step would be to make SharedIterable abstract and add abstract functions that are necessary to remove the toIterables and for the tests (like `expandCollect`).  Then I'd have two realizations, SharedIterableGenotype for VDS which takes advantage of copy on Genotype, and UnsharedIterable (names need adjustment) for GDS which assumes no sharing.

If all tests pass, I'd then switch over to MutableGenotypeStreamIterator...and in principal everything should pass.