### PR TITLE
Fixed IBDPrune so optional parameters actually get used

### DIFF
--- a/src/main/scala/is/hail/methods/IBD.scala
+++ b/src/main/scala/is/hail/methods/IBD.scala
@@ -1,6 +1,5 @@
 package is.hail.methods
 
-import org.apache.spark.rdd.RDD
 import is.hail.HailContext
 import is.hail.expr.{EvalContext, Parser, TDouble, TLong, TString, TStruct, TVariant}
 import is.hail.utils._
@@ -8,7 +7,6 @@ import is.hail.keytable.KeyTable
 import is.hail.annotations.Annotation
 import is.hail.expr._
 import is.hail.methods.IBD.generateComputeMaf
-import is.hail.utils._
 import is.hail.variant.{Genotype, Variant, VariantDataset}
 import org.apache.spark.rdd.RDD
 import is.hail.utils._

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -808,9 +808,7 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
   def ibdPrune(threshold: Double, computeMafExpr: Option[String] = None, bounded: Boolean = true): VariantDataset = {
     requireSplit("IBD Prune")
 
-    val computeMaf = None
-
-    IBDPrune(vds, threshold)
+    IBDPrune(vds, threshold, computeMafExpr, bounded)
   }
 
   /**


### PR DESCRIPTION
I realized that not all the optional IBDPrune parameters were getting passed along, so some were being ignored. This is no longer the case with this change. 