### PR TITLE
Configure spark version once, re-use in future builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,10 +40,11 @@ if (!(new File("gradle.properties")).exists())
 
 if (!hasProperty('sparkVersion') || System.getProperty('spark.version') != null)
     ant.fail('''\
-The sparkVersion must now be explicitly specified in the `gradle.properties`
-file. This version *must* match the version of the spark installed on the
-machine or cluster that will execute hail. You can override the setting in
-`gradle.properties` with a command line like:
+The spark version must now be explicitly specified in the `gradle.properties`
+file. Do *not* specify it with `-Dspark.version`. This version *must* match the
+version of the spark installed on the machine or cluster that will execute
+hail. You can override the setting in `gradle.properties` with a command line
+like:
 
     ./gradlew -PsparkVersion=2.1.1 shadowJar
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ buildScan {
 
 String sparkVersion = System.getProperty("spark.version")
 if (sparkVersion == null)
-    ant.fail('Hail now requires an explicit spark version. You can specify this on the command line like: `./gradlew -Dspark.version=2.0.2 shadowJar`. The previous implicit default was 2.0.2.')
+    ant.fail('Hail now requires an explicit spark version. This version *must* match the version of the spark installed on the machine or cluster that will execute hail. You can specify this on the command line like: `./gradlew -Dspark.version=2.0.2 shadowJar`. The previous implicit default was 2.0.2.')
 
 if (!(sparkVersion ==~ /^2\..*/))
     ant.fail('Hail does not support Spark version ' + sparkVersion + '. Hail team recommends version 2.0.2.')

--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,16 @@ buildScan {
 if (!(new File("gradle.properties")).exists())
    ant.fail('Please generate a gradle.properties file first by executing ./configure')
 
-if (sparkVersion == null)
-    ant.fail('The sparkVersion must now be explicitly specified in the `gradle.properties` file. This version *must* match the version of the spark installed on the machine or cluster that will execute hail. You can specify this on the command line like: `./gradlew -Dspark.version=2.0.2 shadowJar`. The previous implicit default was 2.0.2.')
+if (!hasProperty('sparkVersion') || System.getProperty('spark.version') != null)
+    ant.fail('''\
+The sparkVersion must now be explicitly specified in the `gradle.properties`
+file. This version *must* match the version of the spark installed on the
+machine or cluster that will execute hail. You can override the setting in
+`gradle.properties` with a command line like:
+
+    ./gradlew -PsparkVersion=2.1.1 shadowJar
+
+The previous implicit, default spark version was 2.0.2.''')
 
 if (!(sparkVersion ==~ /^2\..*/))
     ant.fail('Hail does not support Spark version ' + sparkVersion + '. Hail team recommends version 2.0.2.')

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,9 @@ buildScan {
     licenseAgree = 'yes'
 }
 
-String sparkVersion = System.getProperty("spark.version","2.0.2")
+String sparkVersion = System.getProperty("spark.version")
+if (sparkVersion == null)
+    ant.fail('Hail now requires an explicit spark version. You can specify this on the command line like: `./gradlew -Dspark.version=2.0.2 shadowJar`. The previous implicit default was 2.0.2.')
 
 if (!(sparkVersion ==~ /^2\..*/))
     ant.fail('Hail does not support Spark version ' + sparkVersion + '. Hail team recommends version 2.0.2.')
@@ -175,8 +177,6 @@ test {
     testLogging {
         events "passed", "skipped", "failed"
     }
-
-    jvmArgs = ['-Dcom.github.fommil.netlib.BLAS=com.github.fommil.netlib.F2jBLAS','-Dcom.github.fommil.netlib.LAPACK=com.github.fommil.netlib.F2jLAPACK','-Dcom.github.fommil.netlib.ARPACK=com.github.fommil.netlib.F2jARPACK']
 
     // listen to events in the test execution lifecycle
     beforeTest { descriptor ->

--- a/build.gradle
+++ b/build.gradle
@@ -35,9 +35,11 @@ buildScan {
     licenseAgree = 'yes'
 }
 
-String sparkVersion = System.getProperty("spark.version")
+if (!(new File("gradle.properties")).exists())
+   ant.fail('Please generate a gradle.properties file first by executing ./configure')
+
 if (sparkVersion == null)
-    ant.fail('Hail now requires an explicit spark version. This version *must* match the version of the spark installed on the machine or cluster that will execute hail. You can specify this on the command line like: `./gradlew -Dspark.version=2.0.2 shadowJar`. The previous implicit default was 2.0.2.')
+    ant.fail('The sparkVersion must now be explicitly specified in the `gradle.properties` file. This version *must* match the version of the spark installed on the machine or cluster that will execute hail. You can specify this on the command line like: `./gradlew -Dspark.version=2.0.2 shadowJar`. The previous implicit default was 2.0.2.')
 
 if (!(sparkVersion ==~ /^2\..*/))
     ant.fail('Hail does not support Spark version ' + sparkVersion + '. Hail team recommends version 2.0.2.')

--- a/build.gradle
+++ b/build.gradle
@@ -176,6 +176,8 @@ test {
         events "passed", "skipped", "failed"
     }
 
+    jvmArgs = ['-Dcom.github.fommil.netlib.BLAS=com.github.fommil.netlib.F2jBLAS','-Dcom.github.fommil.netlib.LAPACK=com.github.fommil.netlib.F2jLAPACK','-Dcom.github.fommil.netlib.ARPACK=com.github.fommil.netlib.F2jARPACK']
+
     // listen to events in the test execution lifecycle
     beforeTest { descriptor ->
         logger.lifecycle("Running test: " + descriptor)

--- a/configure
+++ b/configure
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+spark_version_default=2.0.2
+gradle_properties_file="gradle.properties"
+
+if [[ -e "${gradle_properties_file}" ]]
+then
+    printf "${gradle_properties_file} already exists, should I overwrite it? (y/n)  "
+    read -r prompt
+    if [[ "${prompt}" == "y" ]]
+    then
+        rm -rf "${gradle_properties_file}"
+    else
+        printf "${gradle_properties_file} already exists, should I append to it? (y/n)  "
+        read -r prompt
+        if [[ ! "${prompt}" == "y" ]]
+        then
+            printf "We must either overwrite or append.\n"
+            exit 1
+        fi
+    fi
+fi
+
+
+printf "With what version of Spark will you run Hail? (default: ${spark_version_default})\n"
+read -r spark_version
+
+if [[ -z "${spark_version}" ]]
+then
+    printf "using default version: ${spark_version_default}\n"
+    spark_version=${spark_version_default}
+elif [[ ! $spark_version =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]
+then
+    printf "error: version has invalid formatting: $spark_version\n"
+    exit -1
+fi
+
+write_gradle_properties () {
+    printf "sparkVersion=${spark_version}\n"
+}
+
+write_gradle_properties >> gradle.properties


### PR DESCRIPTION
If the gradle.properties file doesn't exist, our gradle script errors and asks the user to run ./configure.

The ./configure script queries the user for sparkVersion and generates a valid gradle.properties file.

Afterwards, the user can execute gradle normally without any -D parameters. Users may still override the sparkVersion variable on the command line by specifying -PsparkVersion=2.1.1.