### PR TITLE
Teach Aggregable[T] how to groupBy

### DIFF
--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -264,6 +264,8 @@ sealed abstract class AST(pos: Position, subexprs: Array[AST] = Array.empty) {
       f(values)
     }
   }
+
+  def downstreamAggregator(): CM[(CMCodeCPS[AnyRef], TypedAggregator[_])]
 }
 
 case class Const(posn: Position, value: Any, t: Type) extends AST(posn) {
@@ -282,6 +284,8 @@ case class Const(posn: Position, value: Any, t: Type) extends AST(posn) {
   })
 
   override def typecheckThis(): Type = t
+
+  def downstreamAggregator(): CM[(CMCodeCPS[AnyRef], TypedAggregator[_])] = throw new UnsupportedOperationException
 }
 
 case class Select(posn: Position, lhs: AST, rhs: String) extends AST(posn, lhs) {
@@ -327,6 +331,8 @@ case class Select(posn: Position, lhs: AST, rhs: String) extends AST(posn, lhs) 
         case otherwise => fatal(otherwise.message)
       }
   }
+
+  def downstreamAggregator(): CM[(CMCodeCPS[AnyRef], TypedAggregator[_])] = throw new UnsupportedOperationException
 }
 
 case class ArrayConstructor(posn: Position, elements: Array[AST]) extends AST(posn, elements) {
@@ -357,6 +363,8 @@ case class ArrayConstructor(posn: Position, elements: Array[AST]) extends AST(po
     convertedArray <- CompilationHelp.arrayOfWithConversion(`type`.asInstanceOf[TArray].elementType, celements))
   yield
     CompilationHelp.arrayToWrappedArray(convertedArray)
+
+  def downstreamAggregator(): CM[(CMCodeCPS[AnyRef], TypedAggregator[_])] = throw new UnsupportedOperationException
 }
 
 case class StructConstructor(posn: Position, names: Array[String], elements: Array[AST]) extends AST(posn, elements) {
@@ -378,6 +386,8 @@ case class StructConstructor(posn: Position, names: Array[String], elements: Arr
   def compile() = for (
     celements <- CM.sequence(elements.map(_.compile()))
   ) yield arrayToAnnotation(CompilationHelp.arrayOf(celements))
+
+  def downstreamAggregator(): CM[(CMCodeCPS[AnyRef], TypedAggregator[_])] = throw new UnsupportedOperationException
 }
 
 case class Lambda(posn: Position, param: String, body: AST) extends AST(posn, body) {
@@ -386,6 +396,8 @@ case class Lambda(posn: Position, param: String, body: AST) extends AST(posn, bo
   def compileAggregator(): CMCodeCPS[AnyRef] = throw new UnsupportedOperationException
 
   def compile() = throw new UnsupportedOperationException
+
+  def downstreamAggregator(): CM[(CMCodeCPS[AnyRef], TypedAggregator[_])] = throw new UnsupportedOperationException
 }
 
 case class Apply(posn: Position, fn: String, args: Array[AST]) extends AST(posn, args) {
@@ -563,6 +575,8 @@ case class Apply(posn: Position, fn: String, args: Array[AST]) extends AST(posn,
     case (_, _) =>
       FunctionRegistry.call(fn, args, args.map(_.`type`).toSeq)
   }
+
+  def downstreamAggregator(): CM[(CMCodeCPS[AnyRef], TypedAggregator[_])] = throw new UnsupportedOperationException
 }
 
 case class ApplyMethod(posn: Position, lhs: AST, method: String, args: Array[AST]) extends AST(posn, lhs +: args) {
@@ -576,6 +590,15 @@ case class ApplyMethod(posn: Position, lhs: AST, method: String, args: Array[AST
   override def typecheck(ec: EvalContext) {
     lhs.typecheck(ec)
     (lhs.`type`, method, args) match {
+
+      case (it: TAggregable, "groupBy", Array(Lambda(_, param1, body1), Lambda(_, param2, body2), rest@_*)) =>
+        rest.foreach(_.typecheck(ec.copy(st = emptySymTab)))
+        body1.typecheck(ec.copy(st = it.symTab + ((param1, (-1, it.elementType)))))
+        body2.typecheck(ec.copy(st = ec.st + ((param2, (it.symTab.find { case (_, (_, t)) => t == it.elementType }.get._2._1, it)))))
+        val funType1 = TFunction(Array(it.elementType), body1.`type`)
+        val funType2 = TFunction(Array(it), body2.`type`)
+        `type` = FunctionRegistry.lookupMethodReturnType(it, funType1 +: funType2 +: rest.map(_.`type`), method)
+          .valueOr(x => parseError(x.message))
 
       case (it: TAggregable, _, Array(Lambda(_, param, body), rest@_*)) =>
         rest.foreach(_.typecheck(ec.copy(st = emptySymTab)))
@@ -625,10 +648,34 @@ case class ApplyMethod(posn: Position, lhs: AST, method: String, args: Array[AST
   }
 
   def compile() = ((lhs.`type`, method, args): @unchecked) match {
+    case (it: TContainer, "groupBy", Array(Lambda(_, param, body), Lambda(_, param2, body2), rest@_*)) =>
+      val funType1 = TFunction(Array(it.elementType), body.`type`)
+      val funType2 = TFunction(Array(it), body2.`type`)
+      FunctionRegistry.call(method, lhs +: args, it +: funType1 +: funType2 +: rest.map(_.`type`))
     case (it: TContainer, _, Array(Lambda(_, param, body), rest@_*)) =>
       val funType = TFunction(Array(it.elementType), body.`type`)
       FunctionRegistry.call(method, lhs +: args, it +: funType +: rest.map(_.`type`))
     case (t, _, _) => FunctionRegistry.call(method, lhs +: args, t +: args.map(_.`type`))
+  }
+
+  def downstreamAggregator(): CM[(CMCodeCPS[AnyRef], TypedAggregator[_])] = ((lhs.`type`, method, args): @unchecked) match {
+    case (it: TAggregable, "groupBy", Array(Lambda(_, param1, body1), Lambda(_, param2, body2), rest@_*)) =>
+      val funType1 = TFunction(Array(it.elementType), body1.`type`)
+      val funType2 = TFunction(Array(it), body2.`type`)
+      `type` = FunctionRegistry.lookupMethodReturnType(it, funType1 +: funType2 +: rest.map(_.`type`), method)
+        .valueOr(x => parseError(x.message))
+      for {
+        aggregator <- FunctionRegistry.lookupAggregator(method, lhs +: args, it +: funType1 +: funType2 +: rest.map(_.`type`))
+      } yield (lhs.compileAggregator(), aggregator)
+
+    case (it: TContainer, _, Array(Lambda(_, param, body), rest@_*)) =>
+      val funType = TFunction(Array(it.elementType), body.`type`)
+      for {
+        aggregator <- FunctionRegistry.lookupAggregator(method, lhs +: args, it +: funType +: rest.map(_.`type`))
+      } yield (lhs.compileAggregator(), aggregator)
+    case (t, _, _) => for {
+        aggregator <- FunctionRegistry.lookupAggregator(method, lhs +: args, t +: args.map(_.`type`))
+      } yield (lhs.compileAggregator(), aggregator)
   }
 }
 
@@ -648,6 +695,12 @@ case class Let(posn: Position, bindings: Array[(String, AST)], body: AST) extend
   def compileAggregator(): CMCodeCPS[AnyRef] = throw new UnsupportedOperationException
 
   def compile() = CM.bindRepIn(bindings.map { case (name, expr) => (name, expr.`type`, expr.compile()) })(body.compile())
+
+  def downstreamAggregator(): CM[(CMCodeCPS[AnyRef], TypedAggregator[_])] = for {
+    (downstreamCode, downstreamAggregator) <- body.downstreamAggregator();
+    code = { (k: Code[AnyRef] => CM[Code[Unit]]) =>
+      CM.bindRepIn(bindings.map { case (name, expr) => (name, expr.`type`, expr.compile()) })(downstreamCode(k)) }
+  } yield (code, downstreamAggregator)
 }
 
 case class SymRef(posn: Position, symbol: String) extends AST(posn) {
@@ -670,6 +723,8 @@ case class SymRef(posn: Position, symbol: String) extends AST(posn) {
   }
 
   def compile() = CM.lookup(symbol)
+
+  def downstreamAggregator(): CM[(CMCodeCPS[AnyRef], TypedAggregator[_])] = throw new UnsupportedOperationException
 }
 
 case class If(pos: Position, cond: AST, thenTree: AST, elseTree: AST)
@@ -699,4 +754,6 @@ case class If(pos: Position, cond: AST, thenTree: AST, elseTree: AST)
         coerce(cc.invoke[Boolean]("booleanValue").mux(tc, ec)))
     ) yield result
   }
+
+  def downstreamAggregator(): CM[(CMCodeCPS[AnyRef], TypedAggregator[_])] = throw new UnsupportedOperationException
 }

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -651,7 +651,33 @@ object FunctionRegistry {
   bind("groupBy",
     MethodType(aggregableHr(TTHr).typ, unaryHr(TTHr, TUHr).typ, unaryHr(aggregableHr(TTHr), TVHr).typ),
     GroupByAggregatorFun(dictHr(TUHr, TVHr).typ),
-    MetaData(Option(null), Seq()))
+    MetaData(
+      Option("""Groups a group of elements sharing a key and applies a separate aggregation
+               |to each group. For example, we can calculate Hardy Weinberg for each
+               |population separately:
+               |
+               |.. code-block:: text
+               |     :emphasize-lines: 2
+               |
+               |     gs.groupBy(x => sa.population, gs => gs.hardyWeinberg())
+               |
+               |Multiple `groupBy` aggregators can be nested to produce nested dictionaries:
+               |
+               |.. code-block:: text
+               |     :emphasize-lines: 2
+               |
+               |     gs.groupBy(x => sa.population, gs.groupBy(x => sa.sub_population, gs => gs.hardyWeinberg()))
+               |
+               |If we preferred a single dictionary with a compound key we can use a Struct
+               |
+               |.. code-block:: text
+               |     :emphasize-lines: 2
+               |
+               |     gs.groupBy(x => { pop: sa.population, subpop: sa.sub_population }, gs => gs.hardyWeinberg())
+               |""".stripMargin),
+      Seq(
+        "keyFun" -> "a lambda expression evaluating to the key for the given element",
+        "downstream" -> "a lambda expression whose argument is an aggregable of elements sharing a key, it should produce an aggregated value for this key")))
 
 
   import is.hail.variant.Call._

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -130,10 +130,14 @@ object FunctionRegistry {
   }
 
   def lookupAggregator(name: String, args: Seq[AST], argTypes: Seq[Type]): CM[TypedAggregator[_]] = {
-    val m = FunctionRegistry.lookup(name, MethodType(argTypes: _*))
+    val f = FunctionRegistry.lookup(name, MethodType(argTypes: _*))
       .valueOr(x => fatal(x.message))
 
-    m match {
+    buildAggregator(f, name, args, argTypes)
+  }
+
+  private def buildAggregator(f: Fun, name: String, args: Seq[AST], argTypes: Seq[Type]): CM[TypedAggregator[_]] = {
+    f match {
       case aggregator: Arity0Aggregator[_, _] =>
         ret(aggregator.ctor())
       case aggregator: Arity1Aggregator[_, u, _] =>
@@ -319,198 +323,16 @@ object FunctionRegistry {
       .valueOr(x => fatal(x.message))
 
     (m match {
-      case aggregator: Arity0Aggregator[_, _] =>
-        for (
-          aggregationResultThunk <- addAggregation(args(0), aggregator.ctor());
-          res <- invokePrimitive0(aggregationResultThunk)
-        ) yield res.asInstanceOf[Code[AnyRef]]
-
-      case aggregator: Arity1Aggregator[_, u, _] =>
-        for (
-          ec <- ec();
-          u = args(1).run(ec)();
-
-          _ = (if (u == null)
-            fatal(s"Argument evaluated to missing in call to aggregator $name"));
-
-          aggregationResultThunk <- addAggregation(args(0), aggregator.ctor(u.asInstanceOf[u]));
-          res <- invokePrimitive0(aggregationResultThunk)
-        ) yield res.asInstanceOf[Code[AnyRef]]
-
-      case aggregator: Arity3Aggregator[_, u, v, w, _] =>
-        for (
-          ec <- ec();
-          u = args(1).run(ec)();
-          v = args(2).run(ec)();
-          w = args(3).run(ec)();
-
-          _ = (if (u == null)
-            fatal(s"Argument 1 evaluated to missing in call to aggregator $name"));
-          _ = (if (v == null)
-            fatal(s"Argument 2 evaluated to missing in call to aggregator $name"));
-          _ = (if (w == null)
-            fatal(s"Argument 3 evaluated to missing in call to aggregator $name"));
-
-
-          aggregationResultThunk <- addAggregation(args(0), aggregator.ctor(
-            u.asInstanceOf[u],
-            v.asInstanceOf[v],
-            w.asInstanceOf[w]));
-          res <- invokePrimitive0(aggregationResultThunk)
-        ) yield res.asInstanceOf[Code[AnyRef]]
-
-      case aggregator: UnaryLambdaAggregator[t, u, v] =>
-        val Lambda(_, param, body) = args(1)
-        val TFunction(Seq(paramType), _) = argTypes(1)
+      case (_: Arity0Aggregator[_, _]
+         | _: Arity1Aggregator[_, u, _]
+         | _: Arity3Aggregator[_, u, v, w, _]
+         | _: UnaryLambdaAggregator[t, u, v]
+         | _: BinaryLambdaAggregator[t, u, v, w]
+         | _: GroupByAggregatorFun[t]) =>
 
         for (
-          ec <- ec();
-          st <- currentSymbolTable();
-          (idx, localA) <- ecNewPosition();
-
-          bodyST = args(0).`type` match {
-            case tagg: TAggregable => tagg.symTab
-            case _ => st
-          };
-
-          bodyFn = (for (
-            fb <- fb();
-            bindings = (bodyST.toSeq
-              .map { case (name, (i, typ)) =>
-              (name, typ, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", i))(typ.scalaClassTag)))
-            } :+ ((param, paramType, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", idx))(paramType.scalaClassTag)))));
-            res <- bindRepInRaw(bindings)(body.compile())
-          ) yield res).runWithDelayedValues(bodyST.toSeq.map { case (name, (_, typ)) => (name, typ) }, ec);
-
-          g = (x: Any) => {
-            localA(idx) = x
-            bodyFn(localA.asInstanceOf[mutable.ArrayBuffer[AnyRef]])
-          };
-
-          aggregationResultThunk <- addAggregation(args(0), aggregator.ctor(g));
-
-          res <- invokePrimitive0(aggregationResultThunk)
-        ) yield res.asInstanceOf[Code[AnyRef]]
-
-      case aggregator: BinaryLambdaAggregator[t, u, v, w] =>
-        val Lambda(_, param, body) = args(1)
-        val TFunction(Seq(paramType), _) = argTypes(1)
-
-        for (
-          ec <- ec();
-          st <- currentSymbolTable();
-          (idx, localA) <- ecNewPosition();
-
-          bodyST = args(0).`type` match {
-            case tagg: TAggregable => tagg.symTab
-            case _ => st
-          };
-
-          bodyFn = (for (
-            fb <- fb();
-            bindings = (bodyST.toSeq
-              .map { case (name, (i, typ)) =>
-              (name, typ, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", i))(typ.scalaClassTag)))
-            } :+ ((param, paramType, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", idx))(paramType.scalaClassTag)))));
-            res <- bindRepInRaw(bindings)(body.compile())
-          ) yield res).runWithDelayedValues(bodyST.toSeq.map { case (name, (_, typ)) => (name, typ) }, ec);
-
-          g = (x: Any) => {
-            localA(idx) = x
-            bodyFn(localA.asInstanceOf[mutable.ArrayBuffer[AnyRef]])
-          };
-
-          v = args(2).run(ec)();
-
-          _ = (if (v == null)
-            fatal(s"Argument evaluated to missing in call to aggregator $name"));
-
-          aggregationResultThunk <- addAggregation(args(0), aggregator.ctor(g, v.asInstanceOf[v]));
-
-          res <- invokePrimitive0(aggregationResultThunk)
-        ) yield res.asInstanceOf[Code[AnyRef]]
-
-      case aggregator: GroupByAggregatorFun[t] =>
-        // val downstreamBodyFn = CM.ret(Code._null[AnyRef]).runWithDelayedValues(Seq(), EvalContext());
-
-        val Lambda(_, keyParam, keyBody) = args(1)
-        val TFunction(Seq(keyParamType), _) = argTypes(1)
-
-        val Lambda(_, downstreamParam, downstreamBody) = args(2)
-        val TFunction(Seq(downstreamParamType), _) = argTypes(2)
-
-        val kbc = keyBody.compile()
-
-        val a0 = args(0)
-
-        val a0type = a0.`type`
-
-        for (
-          (downstreamBodyCompiled, downstreamAggregator) <- downstreamBody.downstreamAggregator();
-
-          ec <- ec();
-          (idx, localA) <- ecNewPosition();
-
-          bodyST = a0type match {
-            case tagg: TAggregable => tagg.symTab
-            case _ => ec.st
-          };
-
-          keyBodyFn = (for (
-            fb <- fb();
-            bindings = (bodyST.toSeq
-              .map { case (name, (i, typ)) =>
-                (name, typ, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", i))(typ.scalaClassTag)))
-            } :+ ((keyParam, keyParamType, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", idx))(keyParamType.scalaClassTag)))));
-            res <- bindRepInRaw(bindings)(kbc)
-          ) yield res).runWithDelayedValues(bodyST.toSeq.map { case (name, (_, typ)) => (name, typ) }, ec);
-
-          key = (x: Any) => {
-            localA(idx) = x
-            keyBodyFn(localA.asInstanceOf[mutable.ArrayBuffer[AnyRef]])
-          };
-
-          (downstreamParamId, localA2) <- ecNewPosition();
-
-          downstreamParamTypeFixed = {
-            val x = downstreamParamType.asInstanceOf[TAggregable].copy();
-            // FIXME filter out old bindings
-            x.symTab = downstreamParamType.asInstanceOf[TAggregable].symTab + ((downstreamParam, (downstreamParamId, downstreamParamType.asInstanceOf[TAggregable].elementType)))
-            x
-          };
-
-          (continuationId, localA3) <- ecNewPosition();
-
-          downstreamBodyFn = (for (
-            fb <- fb();
-            bindings = (bodyST.toSeq
-              .map { case (name, (i, typ)) =>
-                (name, typ, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", i))(typ.scalaClassTag)))
-            } :+ ((downstreamParam, downstreamParamType, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", downstreamParamId))(downstreamParamTypeFixed.scalaClassTag))))
-            );
-            k = Code.checkcast[AnyRef => Unit](fb.arg2.invoke[Int, AnyRef]("apply", continuationId));
-            res <- bindRepInRaw(bindings)(downstreamBodyCompiled { (value: Code[AnyRef]) =>
-              CM.ret(Code(k.invoke[AnyRef, AnyRef]("apply", value), Code._pop[Unit]))
-            })
-          ) yield res
-          ).map(x => Code(x, Code._null[AnyRef])).runWithDelayedValues(
-            bodyST.toSeq.map { case (name, (_, typ)) => (name, typ) },
-            ec.copy(st = (ec.st.filter { case (_, (_, typ)) => !typ.isInstanceOf[TAggregable] }) + ((downstreamParam, (downstreamParamId, downstreamParamTypeFixed)))));
-
-          transformation = {
-            val localA = localA3
-            val dpid = downstreamParamId
-            val cid = continuationId
-            val dbf = downstreamBodyFn
-            (x: Any, k: Any => Any) => {
-              localA(dpid) = x
-              localA(cid) = k
-              dbf(localA.asInstanceOf[mutable.ArrayBuffer[AnyRef]])
-            }
-          };
-
-          aggregationResultThunk <- addAggregation(a0, aggregator.ctor(key, transformation, downstreamAggregator.asInstanceOf[TypedAggregator[t]]));
-
+          aggregator <- buildAggregator(m, names, args, argTypes);
+          aggregationResultThunk <- addAggregation(args(0), aggregator);
           res <- invokePrimitive0(aggregationResultThunk)
         ) yield res.asInstanceOf[Code[AnyRef]]
 

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -4,6 +4,9 @@ import breeze.linalg.DenseVector
 import is.hail.annotations.Annotation
 import is.hail.asm4s.{Code, _}
 import is.hail.methods._
+import is.hail.asm4s._
+import is.hail.asm4s.Code
+import is.hail.expr.CM._
 import is.hail.stats._
 import is.hail.utils.EitherIsAMonad._
 import is.hail.utils._
@@ -126,6 +129,189 @@ object FunctionRegistry {
     }
   }
 
+  def lookupAggregator(name: String, args: Seq[AST], argTypes: Seq[Type]): CM[TypedAggregator[_]] = {
+    val m = FunctionRegistry.lookup(name, MethodType(argTypes: _*))
+      .valueOr(x => fatal(x.message))
+
+    m match {
+      case aggregator: Arity0Aggregator[_, _] =>
+        ret(aggregator.ctor())
+      case aggregator: Arity1Aggregator[_, u, _] =>
+        for (
+          ec <- ec();
+          u = args(1).run(ec)();
+
+          _ = (if (u == null)
+            fatal(s"Argument evaluated to missing in call to aggregator $name"))
+
+        ) yield aggregator.ctor(u.asInstanceOf[u])
+
+      case aggregator: Arity3Aggregator[_, u, v, w, _] =>
+        for (
+          ec <- ec();
+          u = args(1).run(ec)();
+          v = args(2).run(ec)();
+          w = args(3).run(ec)();
+
+          _ = (if (u == null)
+            fatal(s"Argument 1 evaluated to missing in call to aggregator $name"));
+          _ = (if (v == null)
+            fatal(s"Argument 2 evaluated to missing in call to aggregator $name"));
+          _ = (if (w == null)
+            fatal(s"Argument 3 evaluated to missing in call to aggregator $name"))
+
+        ) yield aggregator.ctor(u.asInstanceOf[u],v.asInstanceOf[v],w.asInstanceOf[w])
+
+      case aggregator: UnaryLambdaAggregator[t, u, v] =>
+        val Lambda(_, param, body) = args(1)
+        val TFunction(Seq(paramType), _) = argTypes(1)
+
+        for (
+          ec <- ec();
+          st <- currentSymbolTable();
+          (idx, localA) <- ecNewPosition();
+
+          bodyST = args(0).`type` match {
+            case tagg: TAggregable => tagg.symTab
+            case _ => st
+          };
+
+          bodyFn = (for (
+            fb <- fb();
+            bindings = (bodyST.toSeq
+              .map { case (name, (i, typ)) =>
+              (name, typ, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", i))(typ.scalaClassTag)))
+            } :+ ((param, paramType, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", idx))(paramType.scalaClassTag)))));
+            res <- bindRepInRaw(bindings)(body.compile())
+          ) yield res).runWithDelayedValues(bodyST.toSeq.map { case (name, (_, typ)) => (name, typ) }, ec);
+
+          g = (x: Any) => {
+            localA(idx) = x
+            bodyFn(localA.asInstanceOf[mutable.ArrayBuffer[AnyRef]])
+          }
+        ) yield aggregator.ctor(g)
+
+      case aggregator: BinaryLambdaAggregator[t, u, v, w] =>
+        val Lambda(_, param, body) = args(1)
+        val TFunction(Seq(paramType), _) = argTypes(1)
+
+        for (
+          ec <- ec();
+          st <- currentSymbolTable();
+          (idx, localA) <- ecNewPosition();
+
+          bodyST = args(0).`type` match {
+            case tagg: TAggregable => tagg.symTab
+            case _ => st
+          };
+
+          bodyFn = (for (
+            fb <- fb();
+            bindings = (bodyST.toSeq
+              .map { case (name, (i, typ)) =>
+              (name, typ, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", i))(typ.scalaClassTag)))
+            } :+ ((param, paramType, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", idx))(paramType.scalaClassTag)))));
+            res <- bindRepInRaw(bindings)(body.compile())
+          ) yield res).runWithDelayedValues(bodyST.toSeq.map { case (name, (_, typ)) => (name, typ) }, ec);
+
+          g = (x: Any) => {
+            localA(idx) = x
+            bodyFn(localA.asInstanceOf[mutable.ArrayBuffer[AnyRef]])
+          };
+
+          v = args(2).run(ec)();
+
+          _ = (if (v == null)
+            fatal(s"Argument evaluated to missing in call to aggregator $name"))
+
+        ) yield aggregator.ctor(g, v.asInstanceOf[v])
+
+      case aggregator: GroupByAggregatorFun[t] =>
+        // val downstreamBodyFn = CM.ret(Code._null[AnyRef]).runWithDelayedValues(Seq(), EvalContext());
+
+        val Lambda(_, keyParam, keyBody) = args(1)
+        val TFunction(Seq(keyParamType), _) = argTypes(1)
+
+        val Lambda(_, downstreamParam, downstreamBody) = args(2)
+        val TFunction(Seq(downstreamParamType), _) = argTypes(2)
+
+        val kbc = keyBody.compile()
+
+        val a0 = args(0)
+
+        val a0type = a0.`type`
+
+        for (
+          (downstreamBodyCompiled, downstreamAggregator) <- downstreamBody.downstreamAggregator();
+
+          ec <- ec();
+          (idx, localA) <- ecNewPosition();
+
+          bodyST = a0type match {
+            case tagg: TAggregable => tagg.symTab
+            case _ => ec.st
+          };
+
+          keyBodyFn = (for (
+            fb <- fb();
+            bindings = (bodyST.toSeq
+              .map { case (name, (i, typ)) =>
+                (name, typ, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", i))(typ.scalaClassTag)))
+            } :+ ((keyParam, keyParamType, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", idx))(keyParamType.scalaClassTag)))));
+            res <- bindRepInRaw(bindings)(kbc)
+          ) yield res).runWithDelayedValues(bodyST.toSeq.map { case (name, (_, typ)) => (name, typ) }, ec);
+
+          key = (x: Any) => {
+            localA(idx) = x
+            keyBodyFn(localA.asInstanceOf[mutable.ArrayBuffer[AnyRef]])
+          };
+
+          (downstreamParamId, localA2) <- ecNewPosition();
+
+          downstreamParamTypeFixed = {
+            val x = downstreamParamType.asInstanceOf[TAggregable].copy();
+            // FIXME filter out old bindings
+            x.symTab = downstreamParamType.asInstanceOf[TAggregable].symTab + ((downstreamParam, (downstreamParamId, downstreamParamType.asInstanceOf[TAggregable].elementType)))
+            x
+          };
+
+          (continuationId, localA3) <- ecNewPosition();
+
+          downstreamBodyFn = (for (
+            fb <- fb();
+            bindings = (bodyST.toSeq
+              .map { case (name, (i, typ)) =>
+                (name, typ, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", i))(typ.scalaClassTag)))
+            } :+ ((downstreamParam, downstreamParamType, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", downstreamParamId))(downstreamParamTypeFixed.scalaClassTag))))
+            );
+            k = Code.checkcast[AnyRef => Unit](fb.arg2.invoke[Int, AnyRef]("apply", continuationId));
+            res <- bindRepInRaw(bindings)(downstreamBodyCompiled { (value: Code[AnyRef]) =>
+              CM.ret(Code(k.invoke[AnyRef, AnyRef]("apply", value), Code._pop[Unit]))
+            })
+          ) yield res
+          ).map(x => Code(x, Code._null[AnyRef])).runWithDelayedValues(
+            bodyST.toSeq.map { case (name, (_, typ)) => (name, typ) },
+            ec.copy(st = (ec.st.filter { case (_, (_, typ)) => !typ.isInstanceOf[TAggregable] }) + ((downstreamParam, (downstreamParamId, downstreamParamTypeFixed)))));
+
+          transformation = {
+            val localA = localA3
+            val dpid = downstreamParamId
+            val cid = continuationId
+            val dbf = downstreamBodyFn
+            (x: Any, k: Any => Any) => {
+              localA(dpid) = x
+              localA(cid) = k
+              dbf(localA.asInstanceOf[mutable.ArrayBuffer[AnyRef]])
+            }
+          }
+        ) yield aggregator.ctor(key, transformation, downstreamAggregator.asInstanceOf[TypedAggregator[t]]);
+      case f: BinaryLambdaAggregatorTransformer[t, _, _] =>
+        throw new RuntimeException(s"Internal hail error, aggregator transformation ($name : ${argTypes.mkString(",")}) in non-aggregator position")
+      case x =>
+        throw new RuntimeException(s"Internal hail error, unexpected Fun type: ${x.getClass} $x")
+    }
+  }
+
   def call(name: String, args: Seq[AST], argTypes: Seq[Type]): CM[Code[AnyRef]] = {
     import is.hail.expr.CM._
 
@@ -240,6 +426,90 @@ object FunctionRegistry {
             fatal(s"Argument evaluated to missing in call to aggregator $name"));
 
           aggregationResultThunk <- addAggregation(args(0), aggregator.ctor(g, v.asInstanceOf[v]));
+
+          res <- invokePrimitive0(aggregationResultThunk)
+        ) yield res.asInstanceOf[Code[AnyRef]]
+
+      case aggregator: GroupByAggregatorFun[t] =>
+        // val downstreamBodyFn = CM.ret(Code._null[AnyRef]).runWithDelayedValues(Seq(), EvalContext());
+
+        val Lambda(_, keyParam, keyBody) = args(1)
+        val TFunction(Seq(keyParamType), _) = argTypes(1)
+
+        val Lambda(_, downstreamParam, downstreamBody) = args(2)
+        val TFunction(Seq(downstreamParamType), _) = argTypes(2)
+
+        val kbc = keyBody.compile()
+
+        val a0 = args(0)
+
+        val a0type = a0.`type`
+
+        for (
+          (downstreamBodyCompiled, downstreamAggregator) <- downstreamBody.downstreamAggregator();
+
+          ec <- ec();
+          (idx, localA) <- ecNewPosition();
+
+          bodyST = a0type match {
+            case tagg: TAggregable => tagg.symTab
+            case _ => ec.st
+          };
+
+          keyBodyFn = (for (
+            fb <- fb();
+            bindings = (bodyST.toSeq
+              .map { case (name, (i, typ)) =>
+                (name, typ, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", i))(typ.scalaClassTag)))
+            } :+ ((keyParam, keyParamType, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", idx))(keyParamType.scalaClassTag)))));
+            res <- bindRepInRaw(bindings)(kbc)
+          ) yield res).runWithDelayedValues(bodyST.toSeq.map { case (name, (_, typ)) => (name, typ) }, ec);
+
+          key = (x: Any) => {
+            localA(idx) = x
+            keyBodyFn(localA.asInstanceOf[mutable.ArrayBuffer[AnyRef]])
+          };
+
+          (downstreamParamId, localA2) <- ecNewPosition();
+
+          downstreamParamTypeFixed = {
+            val x = downstreamParamType.asInstanceOf[TAggregable].copy();
+            // FIXME filter out old bindings
+            x.symTab = downstreamParamType.asInstanceOf[TAggregable].symTab + ((downstreamParam, (downstreamParamId, downstreamParamType.asInstanceOf[TAggregable].elementType)))
+            x
+          };
+
+          (continuationId, localA3) <- ecNewPosition();
+
+          downstreamBodyFn = (for (
+            fb <- fb();
+            bindings = (bodyST.toSeq
+              .map { case (name, (i, typ)) =>
+                (name, typ, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", i))(typ.scalaClassTag)))
+            } :+ ((downstreamParam, downstreamParamType, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", downstreamParamId))(downstreamParamTypeFixed.scalaClassTag))))
+            );
+            k = Code.checkcast[AnyRef => Unit](fb.arg2.invoke[Int, AnyRef]("apply", continuationId));
+            res <- bindRepInRaw(bindings)(downstreamBodyCompiled { (value: Code[AnyRef]) =>
+              CM.ret(Code(k.invoke[AnyRef, AnyRef]("apply", value), Code._pop[Unit]))
+            })
+          ) yield res
+          ).map(x => Code(x, Code._null[AnyRef])).runWithDelayedValues(
+            bodyST.toSeq.map { case (name, (_, typ)) => (name, typ) },
+            ec.copy(st = (ec.st.filter { case (_, (_, typ)) => !typ.isInstanceOf[TAggregable] }) + ((downstreamParam, (downstreamParamId, downstreamParamTypeFixed)))));
+
+          transformation = {
+            val localA = localA3
+            val dpid = downstreamParamId
+            val cid = continuationId
+            val dbf = downstreamBodyFn
+            (x: Any, k: Any => Any) => {
+              localA(dpid) = x
+              localA(cid) = k
+              dbf(localA.asInstanceOf[mutable.ArrayBuffer[AnyRef]])
+            }
+          };
+
+          aggregationResultThunk <- addAggregation(a0, aggregator.ctor(key, transformation, downstreamAggregator.asInstanceOf[TypedAggregator[t]]));
 
           res <- invokePrimitive0(aggregationResultThunk)
         ) yield res.asInstanceOf[Code[AnyRef]]
@@ -555,6 +825,12 @@ object FunctionRegistry {
   val BoxedTTHr = new HailRep[AnyRef] {
     def typ = TTBoxed
   }
+
+  bind("groupBy",
+    MethodType(aggregableHr(TTHr).typ, unaryHr(TTHr, TUHr).typ, unaryHr(aggregableHr(TTHr), TVHr).typ),
+    GroupByAggregatorFun(dictHr(TUHr, TVHr).typ),
+    MetaData(Option(null), Seq()))
+
 
   import is.hail.variant.Call._
   registerField("gt", { (c: Call) => c}, "the integer ``gt = k*(k+1)/2 + j`` for call ``j/k`` (0 = 0/0, 1 = 0/1, 2 = 1/1, 3 = 0/2, etc.).")(callHr, boxedintHr)

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -324,14 +324,14 @@ object FunctionRegistry {
 
     (m match {
       case (_: Arity0Aggregator[_, _]
-         | _: Arity1Aggregator[_, u, _]
-         | _: Arity3Aggregator[_, u, v, w, _]
-         | _: UnaryLambdaAggregator[t, u, v]
-         | _: BinaryLambdaAggregator[t, u, v, w]
-         | _: GroupByAggregatorFun[t]) =>
+         | _: Arity1Aggregator[_, _, _]
+         | _: Arity3Aggregator[_, _, _, _, _]
+         | _: UnaryLambdaAggregator[_, _, _]
+         | _: BinaryLambdaAggregator[_, _, _, _]
+         | _: GroupByAggregatorFun[_]) =>
 
         for (
-          aggregator <- buildAggregator(m, names, args, argTypes);
+          aggregator <- buildAggregator(m, name, args, argTypes);
           aggregationResultThunk <- addAggregation(args(0), aggregator);
           res <- invokePrimitive0(aggregationResultThunk)
         ) yield res.asInstanceOf[Code[AnyRef]]

--- a/src/main/scala/is/hail/methods/Aggregators.scala
+++ b/src/main/scala/is/hail/methods/Aggregators.scala
@@ -510,3 +510,28 @@ class TakeByAggregator[T](var f: (Any) => Any, var n: Int)(implicit var tord: Or
     _state = mutable.PriorityQueue[(Any, Any)](elems: _*)(ord)
   }
 }
+
+class GroupByAggregator[T](key: Any => Any, transformation: (Any, (Any => Any)) => Any, downstream: TypedAggregator[T]) extends TypedAggregator[Map[Any, T]] {
+  var _state = mutable.Map[Any, TypedAggregator[T]]()
+
+  def result = _state.toMap.mapValues(_.result)
+
+  def seqOp(x: Any) = {
+    val k = key(x)
+
+    val next = _state.getOrElseUpdate(k, downstream.copy())
+
+    transformation(x, next.seqOp)
+  }
+
+  def combOp(agg2: this.type) {
+    agg2._state.foreach { case (k, v) =>
+      _state.get(k) match {
+        case Some(myV) => myV.combOp(v.asInstanceOf[myV.type])
+        case None => _state += ((k, v))
+      }
+    }
+  }
+
+  def copy() = new GroupByAggregator(key, transformation, downstream)
+}

--- a/src/test/scala/is/hail/methods/AggregatorSuite.scala
+++ b/src/test/scala/is/hail/methods/AggregatorSuite.scala
@@ -285,18 +285,6 @@ class AggregatorSuite extends SparkSuite {
     }.check()
   }
 
-  @Test def trivialGroupBy() {
-    Prop.forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vds =>
-      val vds2 = vds.annotateSamplesExpr("sa.pop = if (pcoin(0.5)) (if (pcoin(0.5)) \"EUR\" else \"EAS\") else (if (pcoin(0.5)) \"AMR\" else \"AFR\")")
-      val queryResult = vds2.queryGenotypes("gs.groupBy(x => sa.pop, gs => 1)")._1.asInstanceOf[Map[String, Int]]
-      val (_, querier) = vds2.querySA("sa.pop")
-      val expectedResult =
-        vds2.sampleAnnotations.map(querier.asInstanceOf[Any => String]).groupBy(x => x).mapValues(x => 1)
-
-      expectedResult == queryResult
-    }.check()
-  }
-
   @Test def groupByAndCount() {
     Prop.forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vds =>
       val vds2 = vds.annotateSamplesExpr("sa.pop = if (pcoin(0.5)) (if (pcoin(0.5)) \"EUR\" else \"EAS\") else (if (pcoin(0.5)) \"AMR\" else \"AFR\")")

--- a/src/test/scala/is/hail/methods/AggregatorSuite.scala
+++ b/src/test/scala/is/hail/methods/AggregatorSuite.scala
@@ -284,4 +284,54 @@ class AggregatorSuite extends SparkSuite {
       p1 && p2
     }.check()
   }
+
+  @Test def trivialGroupBy() {
+    Prop.forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vds =>
+      val vds2 = vds.annotateSamplesExpr("sa.pop = if (pcoin(0.5)) (if (pcoin(0.5) \"EUR\" else \"EAS\") else (if (pcoin(0.5)) \"AMR\" else \"AFR\")")
+      val queryResult = vds.queryGenotypes("gs.groupBy(x => sa.pop, gs => 1)")._1.asInstanceOf[Map[String, Int]]
+      val (_, querier) = vds2.querySA("sa.pop")
+      val expectedResult =
+        vds2.sampleAnnotations.map(querier.asInstanceOf[Any => String]).groupBy(x => x).mapValues(x => 1)
+
+      expectedResult == queryResult
+    }.check()
+  }
+
+  @Test def groupByAndCount() {
+    Prop.forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vds =>
+      val vds2 = vds.annotateSamplesExpr("sa.pop = if (pcoin(0.5)) (if (pcoin(0.5) \"EUR\" else \"EAS\") else (if (pcoin(0.5)) \"AMR\" else \"AFR\")")
+      val queryResult = vds.queryGenotypes("gs.groupBy(x => sa.pop, gs => gs.count())")._1.asInstanceOf[Map[String, Int]]
+      val (_, querier) = vds2.querySA("sa.pop")
+
+      val expectedResult = vds.mapValuesWithAll { case (v, va, s, sa, g) => (querier(sa).asInstanceOf[String], 1) }
+        .map(x => x)
+        .reduceByKey(_ + _)
+        .collectAsMap()
+
+      expectedResult == queryResult
+    }.check()
+  }
+
+  @Test def groupByWithMap() {
+    Prop.forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vds =>
+      val vds2 = vds.annotateSamplesExpr("sa.pop = if (pcoin(0.5)) (if (pcoin(0.5) \"EUR\" else \"EAS\") else (if (pcoin(0.5)) \"AMR\" else \"AFR\")")
+      val queryResult = vds.queryGenotypes("gs.groupBy(x => sa.pop, gs => gs.map(x => 2).sum())")._1.asInstanceOf[Map[String, Int]]
+      val (_, querier) = vds2.querySA("sa.pop")
+
+      val expectedResult = vds.mapValuesWithAll { case (v, va, s, sa, g) => (querier(sa).asInstanceOf[String], 2) }
+        .map(x => x)
+        .reduceByKey(_ + _)
+        .collectAsMap()
+
+      expectedResult == queryResult
+    }.check()
+  }
+
+  @Test def groupByNoExceptionOnRealData() {
+    hc.importVCF("src/test/resources/sample2.vcf")
+      .annotateSamplesExpr("sa.foo = if (pcoin(0.5)) \"Red\" else \"Blue\"")
+      .annotateVariantsExpr("va.byFoo = gs.groupBy(x => sa.foo, foos => foos.map(x => x.gt).sum())")
+      .exportVariants("/tmp/test.out", "v, va.byFoo")
+  }
+
 }

--- a/src/test/scala/is/hail/methods/AggregatorSuite.scala
+++ b/src/test/scala/is/hail/methods/AggregatorSuite.scala
@@ -287,7 +287,7 @@ class AggregatorSuite extends SparkSuite {
 
   @Test def trivialGroupBy() {
     Prop.forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vds =>
-      val vds2 = vds.annotateSamplesExpr("sa.pop = if (pcoin(0.5)) (if (pcoin(0.5) \"EUR\" else \"EAS\") else (if (pcoin(0.5)) \"AMR\" else \"AFR\")")
+      val vds2 = vds.annotateSamplesExpr("sa.pop = if (pcoin(0.5)) (if (pcoin(0.5)) \"EUR\" else \"EAS\") else (if (pcoin(0.5)) \"AMR\" else \"AFR\")")
       val queryResult = vds.queryGenotypes("gs.groupBy(x => sa.pop, gs => 1)")._1.asInstanceOf[Map[String, Int]]
       val (_, querier) = vds2.querySA("sa.pop")
       val expectedResult =
@@ -299,7 +299,7 @@ class AggregatorSuite extends SparkSuite {
 
   @Test def groupByAndCount() {
     Prop.forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vds =>
-      val vds2 = vds.annotateSamplesExpr("sa.pop = if (pcoin(0.5)) (if (pcoin(0.5) \"EUR\" else \"EAS\") else (if (pcoin(0.5)) \"AMR\" else \"AFR\")")
+      val vds2 = vds.annotateSamplesExpr("sa.pop = if (pcoin(0.5)) (if (pcoin(0.5)) \"EUR\" else \"EAS\") else (if (pcoin(0.5)) \"AMR\" else \"AFR\")")
       val queryResult = vds.queryGenotypes("gs.groupBy(x => sa.pop, gs => gs.count())")._1.asInstanceOf[Map[String, Int]]
       val (_, querier) = vds2.querySA("sa.pop")
 
@@ -314,7 +314,7 @@ class AggregatorSuite extends SparkSuite {
 
   @Test def groupByWithMap() {
     Prop.forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vds =>
-      val vds2 = vds.annotateSamplesExpr("sa.pop = if (pcoin(0.5)) (if (pcoin(0.5) \"EUR\" else \"EAS\") else (if (pcoin(0.5)) \"AMR\" else \"AFR\")")
+      val vds2 = vds.annotateSamplesExpr("sa.pop = if (pcoin(0.5)) (if (pcoin(0.5)) \"EUR\" else \"EAS\") else (if (pcoin(0.5)) \"AMR\" else \"AFR\")")
       val queryResult = vds.queryGenotypes("gs.groupBy(x => sa.pop, gs => gs.map(x => 2).sum())")._1.asInstanceOf[Map[String, Int]]
       val (_, querier) = vds2.querySA("sa.pop")
 

--- a/src/test/scala/is/hail/methods/AggregatorSuite.scala
+++ b/src/test/scala/is/hail/methods/AggregatorSuite.scala
@@ -288,7 +288,7 @@ class AggregatorSuite extends SparkSuite {
   @Test def trivialGroupBy() {
     Prop.forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vds =>
       val vds2 = vds.annotateSamplesExpr("sa.pop = if (pcoin(0.5)) (if (pcoin(0.5)) \"EUR\" else \"EAS\") else (if (pcoin(0.5)) \"AMR\" else \"AFR\")")
-      val queryResult = vds.queryGenotypes("gs.groupBy(x => sa.pop, gs => 1)")._1.asInstanceOf[Map[String, Int]]
+      val queryResult = vds2.queryGenotypes("gs.groupBy(x => sa.pop, gs => 1)")._1.asInstanceOf[Map[String, Int]]
       val (_, querier) = vds2.querySA("sa.pop")
       val expectedResult =
         vds2.sampleAnnotations.map(querier.asInstanceOf[Any => String]).groupBy(x => x).mapValues(x => 1)
@@ -300,10 +300,10 @@ class AggregatorSuite extends SparkSuite {
   @Test def groupByAndCount() {
     Prop.forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vds =>
       val vds2 = vds.annotateSamplesExpr("sa.pop = if (pcoin(0.5)) (if (pcoin(0.5)) \"EUR\" else \"EAS\") else (if (pcoin(0.5)) \"AMR\" else \"AFR\")")
-      val queryResult = vds.queryGenotypes("gs.groupBy(x => sa.pop, gs => gs.count())")._1.asInstanceOf[Map[String, Int]]
+      val queryResult = vds2.queryGenotypes("gs.groupBy(x => sa.pop, gs => gs.count())")._1.asInstanceOf[Map[String, Int]]
       val (_, querier) = vds2.querySA("sa.pop")
 
-      val expectedResult = vds.mapValuesWithAll { case (v, va, s, sa, g) => (querier(sa).asInstanceOf[String], 1) }
+      val expectedResult = vds2.mapValuesWithAll { case (v, va, s, sa, g) => (querier(sa).asInstanceOf[String], 1) }
         .map(x => x)
         .reduceByKey(_ + _)
         .collectAsMap()
@@ -315,10 +315,10 @@ class AggregatorSuite extends SparkSuite {
   @Test def groupByWithMap() {
     Prop.forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vds =>
       val vds2 = vds.annotateSamplesExpr("sa.pop = if (pcoin(0.5)) (if (pcoin(0.5)) \"EUR\" else \"EAS\") else (if (pcoin(0.5)) \"AMR\" else \"AFR\")")
-      val queryResult = vds.queryGenotypes("gs.groupBy(x => sa.pop, gs => gs.map(x => 2).sum())")._1.asInstanceOf[Map[String, Int]]
+      val queryResult = vds2.queryGenotypes("gs.groupBy(x => sa.pop, gs => gs.map(x => 2).sum())")._1.asInstanceOf[Map[String, Int]]
       val (_, querier) = vds2.querySA("sa.pop")
 
-      val expectedResult = vds.mapValuesWithAll { case (v, va, s, sa, g) => (querier(sa).asInstanceOf[String], 2) }
+      val expectedResult = vds2.mapValuesWithAll { case (v, va, s, sa, g) => (querier(sa).asInstanceOf[String], 2) }
         .map(x => x)
         .reduceByKey(_ + _)
         .collectAsMap()

--- a/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -23,6 +23,13 @@ import org.apache.spark.sql.Row
 
 class ExprSuite extends SparkSuite {
 
+  @Test def groupByTest() {
+    hc.read("/Users/dking/projects/hail-data/profile.vds")
+      .annotateSamplesExpr("sa.foo = if (pcoin(0.5)) \"Red\" else \"Blue\"")
+      .annotateVariantsExpr("va.byFoo = gs.groupBy(x => sa.foo, foos => foos.map(x => x.gt).sum())")
+      .exportVariants("/tmp/test.out", "v, va.byFoo")
+  }
+
   @Test def compileTest() {
     def run[T](s: String): Option[T] =
       Option(Parser.parseToAST(s, EvalContext()).run(EvalContext())().asInstanceOf[T])

--- a/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -23,13 +23,6 @@ import org.apache.spark.sql.Row
 
 class ExprSuite extends SparkSuite {
 
-  @Test def groupByTest() {
-    hc.read("/Users/dking/projects/hail-data/profile.vds")
-      .annotateSamplesExpr("sa.foo = if (pcoin(0.5)) \"Red\" else \"Blue\"")
-      .annotateVariantsExpr("va.byFoo = gs.groupBy(x => sa.foo, foos => foos.map(x => x.gt).sum())")
-      .exportVariants("/tmp/test.out", "v, va.byFoo")
-  }
-
   @Test def compileTest() {
     def run[T](s: String): Option[T] =
       Option(Parser.parseToAST(s, EvalContext()).run(EvalContext())().asInstanceOf[T])


### PR DESCRIPTION
AST now can be asked to produce a pair of a TypedAggregator and a CMCPSCode[T]. The former is the Aggregator corresponding to the terminal expression, the latter represents the series of transformations to the aggregable that should be applied before the aggregator's sequence op.

The syntax looks like:

```
gs.groupBy(x => sa.population, gs => gs.hardyWeinberg())
```

Nested `groupBy` is permitted:

```
gs.groupBy(x  => sa.population,
           gs => gs.groupBy(x  => sa.subPopulation,
                            gs => gs.hardyWeinberg())
```

Addresses #878