### PR TITLE
Fixed code-block in annotate-globals-list

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -429,7 +429,7 @@ class VariantDataset(object):
 
         For the gene list
 
-        .. code-block: text
+        .. code-block:: text
 
             $ cat data/genes.txt
             SCN2A


### PR DESCRIPTION
It was missing a colon