### PR TITLE
Fixed == to require same-type arguments

### DIFF
--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -419,6 +419,13 @@ case class Apply(posn: Position, fn: String, args: Array[AST]) extends AST(posn,
 
         t
 
+      case ("==" | "!=", Array(left, right)) =>
+        val lt = left.`type`
+        val rt = right.`type`
+        if (!lt.canCompare(rt))
+          parseError(s"Cannot compare arguments of type $lt and $rt")
+        else
+          TBoolean
       case (_, _) => FunctionRegistry.lookupFunReturnType(fn, args.map(_.`type`).toSeq)
         .valueOr(x => parseError(x.message))
     }

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -1659,8 +1659,8 @@ object FunctionRegistry {
     Add a new variant annotation that calculates HWE p-value by phenotype:
 
     >>> vds_result = vds.annotate_variants_expr([
-    ...   'va.hweCase = gs.filter(g => sa.pheno == "Case").hardyWeinberg()',
-    ...   'va.hweControl = gs.filter(g => sa.pheno == "Control").hardyWeinberg()'])
+    ...   'va.hweCase = gs.filter(g => sa.pheno.isCase).hardyWeinberg()',
+    ...   'va.hweControl = gs.filter(g => !sa.pheno.isCase).hardyWeinberg()'])
 
     **Notes**
 

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -202,7 +202,7 @@ object TNumeric {
 }
 
 abstract class TNumeric extends Type {
-  def conv: NumericConversion[_,_]
+  def conv: NumericConversion[_, _]
 
   override def canCompare(other: Type): Boolean = other.isInstanceOf[TNumeric]
 }
@@ -539,7 +539,6 @@ case class TDict(keyType: Type, valueType: Type) extends TContainer {
     case _ => false
   }
 
-
   def elementType: Type = valueType
 
   override def children = Seq(keyType, valueType)
@@ -586,7 +585,7 @@ case class TDict(keyType: Type, valueType: Type) extends TContainer {
     A ``Dict`` is an unordered collection of key-value pairs. Each key can only appear once in the collection.
     """
 
-  override def scalaClassTag: ClassTag[Map[_,_]] = classTag[Map[_,_]]
+  override def scalaClassTag: ClassTag[Map[_, _]] = classTag[Map[_, _]]
 }
 
 case object TGenotype extends Type {
@@ -676,7 +675,7 @@ case class Field(name: String, typ: Type,
   attrs: Map[String, String] = Map.empty) {
   def attr(s: String): Option[String] = attrs.get(s)
 
-  def attrsJava() : java.util.Map[String, String] = attrs.asJava
+  def attrsJava(): java.util.Map[String, String] = attrs.asJava
 
   def unify(cf: Field): Boolean =
     name == cf.name &&

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -147,6 +147,8 @@ sealed abstract class Type {
   def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double = utils.defaultTolerance): Boolean = a1 == a2
 
   def scalaClassTag: ClassTag[_ <: AnyRef]
+
+  def canCompare(other: Type): Boolean = this == other
 }
 
 case object TBinary extends Type {
@@ -201,6 +203,8 @@ object TNumeric {
 
 abstract class TNumeric extends Type {
   def conv: NumericConversion[_,_]
+
+  override def canCompare(other: Type): Boolean = other.isInstanceOf[TNumeric]
 }
 
 abstract class TIntegral extends TNumeric
@@ -343,6 +347,8 @@ case class TAggregableVariable(elementType: Type, st: Box[SymbolTable]) extends 
 
   override def desc: String = TAggregable.desc
 
+  override def canCompare(other: Type): Boolean = false
+
   override def scalaClassTag: ClassTag[AnyRef] = throw new RuntimeException("TAggregableVariable is not realizable")
 }
 
@@ -423,6 +429,11 @@ abstract class TIterable extends TContainer {
       && (a1.asInstanceOf[Iterable[_]].size == a2.asInstanceOf[Iterable[_]].size)
       && a1.asInstanceOf[Iterable[_]].zip(a2.asInstanceOf[Iterable[_]])
       .forall { case (e1, e2) => elementType.valuesSimilar(e1, e2, tolerance) })
+
+  override def canCompare(other: Type): Boolean = other match {
+    case TArray(otherType) => elementType.canCompare(otherType)
+    case _ => false
+  }
 }
 
 case class TArray(elementType: Type) extends TIterable {
@@ -522,6 +533,12 @@ case class TSet(elementType: Type) extends TIterable {
 }
 
 case class TDict(keyType: Type, valueType: Type) extends TContainer {
+
+  override def canCompare(other: Type): Boolean = other match {
+    case TDict(okt, ovt) => keyType.canCompare(okt) && valueType.canCompare(ovt)
+    case _ => false
+  }
+
 
   def elementType: Type = valueType
 
@@ -715,6 +732,13 @@ object TStruct {
 
 case class TStruct(fields: IndexedSeq[Field]) extends Type {
   override def children = fields.map(_.typ)
+
+  override def canCompare(other: Type): Boolean = other match {
+    case t: TStruct => size == t.size && fields.zip(t.fields).forall { case (f1, f2) =>
+      f1.name == f2.name && f1.typ.canCompare(f2.typ)
+    }
+    case _ => false
+  }
 
   override def unify(concrete: Type) = concrete match {
     case TStruct(cfields) =>

--- a/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -839,7 +839,6 @@ class ExprSuite extends SparkSuite {
     assert(eval("{a: 1, b: NA: Genotype} != {a: 2, b: NA: Genotype}").contains(true))
     assert(eval("{a: 1, b: NA: Genotype} == {a: 1, b: NA: Genotype}").contains(true))
 
-    //    TestUtils.interceptFatal("cannot compare")
     TestUtils.interceptFatal("Cannot compare arguments") {
       eval("1 == str(1)")
     }

--- a/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -493,11 +493,11 @@ class ExprSuite extends SparkSuite {
 
     assert(eval[Map[_, _]](""" genedict.mapValues(x => x + 1) """).contains(Map("gene1" -> 3, "gene2" -> 11, "gene3" -> 15)))
 
-    assert(eval[IndexedSeq[Int]]("""genedict.values""").contains(IndexedSeq(2,10,14)))
-    assert(eval[IndexedSeq[String]]("""genedict.keys""").contains(IndexedSeq("gene1","gene2","gene3")))
+    assert(eval[IndexedSeq[Int]]("""genedict.values""").contains(IndexedSeq(2, 10, 14)))
+    assert(eval[IndexedSeq[String]]("""genedict.keys""").contains(IndexedSeq("gene1", "gene2", "gene3")))
     val ks = eval[Set[String]]("""genedict.keySet""")
     assert(ks.isDefined)
-    ks.get should contain theSameElementsAs Seq("gene1","gene2","gene3")
+    ks.get should contain theSameElementsAs Seq("gene1", "gene2", "gene3")
 
     // caused exponential blowup previously
     assert(eval[Boolean](
@@ -833,6 +833,19 @@ class ExprSuite extends SparkSuite {
       assert(eval("-2 ** -2").contains(-0.25))
     }
 
+    assert(eval("1 == 1.0").contains(true))
+    assert(eval("[1,2] == [1.0, 2.0]").contains(true))
+    assert(eval("[1,2] != [1.1, 2.0]").contains(true))
+    assert(eval("{a: 1, b: NA: Genotype} != {a: 2, b: NA: Genotype}").contains(true))
+    assert(eval("{a: 1, b: NA: Genotype} == {a: 1, b: NA: Genotype}").contains(true))
+
+    //    TestUtils.interceptFatal("cannot compare")
+    TestUtils.interceptFatal("Cannot compare arguments") {
+      eval("1 == str(1)")
+    }
+    TestUtils.interceptFatal("Cannot compare arguments") {
+      eval("str(1) == 1")
+    }
   }
 
   @Test def testParseTypes() {


### PR DESCRIPTION
Assigning Dan because it involves a somewhat weird expr motif -- putting in a special comparison for typecheck, but using the function registry for the eval/compile