### PR TITLE
Fixed use of grid partitioner

### DIFF
--- a/src/main/scala/is/hail/utils/richUtils/RichIndexedRowMatrix.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichIndexedRowMatrix.scala
@@ -19,10 +19,10 @@ object RichIndexedRowMatrix {
   val intClass = classTag[Int].runtimeClass
   val gpConstructor = Class.forName("org.apache.spark.mllib.linalg.distributed.GridPartitioner")
     .getDeclaredConstructor(intClass,intClass,intClass,intClass)
-  def sneakyGridPartitioner(nRowBlocks: Int, nColBlocks: Int, nRowsPerPart: Int, nColsPerPart: Int): Partitioner = try {
+  def sneakyGridPartitioner(nRowBlocks: Int, nColBlocks: Int, suggestedNumParts: Int): Partitioner = try {
     gpConstructor.setAccessible(true)
     gpConstructor.newInstance(nRowBlocks: java.lang.Integer, nColBlocks: java.lang.Integer,
-      nRowsPerPart: java.lang.Integer, nColsPerPart: java.lang.Integer).asInstanceOf[Partitioner]
+      suggestedNumParts).asInstanceOf[Partitioner]
   } finally {
     gpConstructor.setAccessible(false)
   }
@@ -58,7 +58,7 @@ object RichIndexedRowMatrix {
           .map({ case (values, blockColumn) =>
             ((blockRow.toInt, blockColumn), (rowInBlock.toInt, values))
           })
-      }).groupByKey(sneakyGridPartitioner(numRowBlocks, numColBlocks, rowsPerBlock, colsPerBlock)).map({
+      }).groupByKey(sneakyGridPartitioner(numRowBlocks, numColBlocks, indexedRowMatrix.rows.getNumPartitions)).map({
         case ((blockRow, blockColumn), itr) =>
           val actualNumRows: Int = if (blockRow == lastRowBlockIndex) lastRowBlockSize else rowsPerBlock
           val actualNumColumns: Int = if (blockColumn == lastColBlockIndex) lastColBlockSize else colsPerBlock


### PR DESCRIPTION
Accidentally set things up so that there would only be one block per partition. That should not be the case. 