### PR TITLE
Fixed Empty return type for Struct in docs

### DIFF
--- a/src/main/scala/is/hail/utils/FunctionDocumentation.scala
+++ b/src/main/scala/is/hail/utils/FunctionDocumentation.scala
@@ -108,7 +108,7 @@ case class DocumentationEntry(name: String, category: String, objType: Option[Ty
 
   def hasAnnotation = retType.isInstanceOf[TStruct]
 
-  val retTypePretty = retType.toString.replaceAll("\\?", "")
+  val retTypePretty = retType.toString.replaceAll("\\?", "").replaceAll("Empty", "Struct")
   val objTypePretty = objType.getOrElse("").toString.replaceAll("\\?", "")
 
   def formatDocstring: (Int, String) = {


### PR DESCRIPTION
- Example of fix is for `index` in doc page for functions
- Issue caused by changing the `.toString` behavior for Structs to print "Empty" if the Struct is empty.