### PR TITLE
MinRep fix and better Star allele support

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -1758,7 +1758,7 @@ class VariantDataset(object):
     @handle_py4j
     @requireTGenotype
     def filter_alleles(self, condition, annotation='va = va', subset=True, keep=True,
-                       filter_altered_genotypes=False, max_shift=100):
+                       filter_altered_genotypes=False, max_shift=100, keep_star=False):
         """Filter a user-defined set of alternate alleles for each variant.
         If all alternate alleles of a variant are filtered, the
         variant itself is filtered.  The condition expression is
@@ -1893,11 +1893,13 @@ class VariantDataset(object):
             cause Hail to throw an error if a variant that moves further
             is encountered.
 
+        :param bool keepStar: If true, keep variants where the only allele left is a ``*`` allele.
+
         :return: Filtered variant dataset.
         :rtype: :py:class:`.VariantDataset`
         """
 
-        jvds = self._jvdf.filterAlleles(condition, annotation, filter_altered_genotypes, keep, subset, max_shift)
+        jvds = self._jvdf.filterAlleles(condition, annotation, filter_altered_genotypes, keep, subset, max_shift, keep_star)
         return VariantDataset(self.hc, jvds)
 
     @handle_py4j

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -698,7 +698,8 @@ object FunctionRegistry {
   registerMethod("isIndel", { (x: AltAllele) => x.isIndel }, "True if an insertion or a deletion.")
   registerMethod("isInsertion", { (x: AltAllele) => x.isInsertion }, "True if ``v.alt`` begins with and is longer than ``v.ref``.")
   registerMethod("isDeletion", { (x: AltAllele) => x.isDeletion }, "True if ``v.ref`` begins with and is longer than ``v.alt``.")
-  registerMethod("isComplex", { (x: AltAllele) => x.isComplex }, "True if not a SNP, MNP, insertion, or deletion.")
+  registerMethod("isStar", { (x: AltAllele) => x.isStar }, "True if ``v.alt`` is ``*``.")
+  registerMethod("isComplex", { (x: AltAllele) => x.isComplex }, "True if not a SNP, MNP, star, insertion, or deletion.")
   registerMethod("isTransition", { (x: AltAllele) => x.isTransition }, "True if a purine-purine or pyrimidine-pyrimidine SNP.")
   registerMethod("isTransversion", { (x: AltAllele) => x.isTransversion }, "True if a purine-pyrimidine SNP.")
 

--- a/src/main/scala/is/hail/methods/FilterAlleles.scala
+++ b/src/main/scala/is/hail/methods/FilterAlleles.scala
@@ -13,7 +13,7 @@ object FilterAlleles {
 
   def apply(vds: VariantDataset, filterExpr: String, annotationExpr: String = "va = va",
     filterAlteredGenotypes: Boolean = false, keep: Boolean = true,
-    subset: Boolean = true, maxShift: Int = 100): VariantDataset = {
+    subset: Boolean = true, maxShift: Int = 100, keepStar: Boolean = false): VariantDataset = {
 
     if (vds.wasSplit)
       warn("this VDS was already split; this module was designed to handle multi-allelics, perhaps you should use filtervariants instead.")
@@ -66,7 +66,7 @@ object FilterAlleles {
           .map { case (_, idx) => v.altAlleles(idx - 1) }
           .toArray
 
-        Some((v.copy(altAlleles = altAlleles).minrep, newToOld: IndexedSeq[Int], oldToNew))
+        Some((v.copy(altAlleles = altAlleles).minRep, newToOld: IndexedSeq[Int], oldToNew))
       }
     }
 
@@ -151,7 +151,7 @@ object FilterAlleles {
             val newGs = updateGenotypes(gs, oldToNew, newToOld.length)
             (newV, (newVa, newGs))
           }
-        }
+        }.filter { case (v, (va, gs)) => keepStar || !(v.isBiallelic && v.altAllele.isStar) }
 
 
     val partitionerBc = vds.sparkContext.broadcast(vds.rdd.orderedPartitioner)

--- a/src/main/scala/is/hail/methods/SplitMulti.scala
+++ b/src/main/scala/is/hail/methods/SplitMulti.scala
@@ -24,7 +24,7 @@ object SplitMulti {
     f: (Variant) => Boolean): Iterator[(Variant, (Annotation, Iterable[Genotype]))] = {
 
     if (v.isBiallelic) {
-      val minrep = v.minrep
+      val minrep = v.minRep
       if (f(minrep))
         return Iterator((minrep, (insertSplitAnnots(va, 1, false), it)))
       else
@@ -32,8 +32,8 @@ object SplitMulti {
     }
 
     val splitVariants = v.altAlleles.iterator.zipWithIndex
-      .filter(keepStar || _._1.alt != "*")
-      .map { case (aa, aai) => (Variant(v.contig, v.start, v.ref, Array(aa)).minrep, aai + 1) }
+      .filter(keepStar || !_._1.isStar)
+      .map { case (aa, aai) => (Variant(v.contig, v.start, v.ref, Array(aa)).minRep, aai + 1) }
       .filter { case (sv, _) => f(sv) }
       .toArray
 

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -694,8 +694,8 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     * @param maxShift Maximum possible position change during minimum representation calculation
     */
   def filterAlleles(filterExpr: String, annotationExpr: String = "va = va", filterAlteredGenotypes: Boolean = false,
-    keep: Boolean = true, subset: Boolean = true, maxShift: Int = 100): VariantDataset = {
-    FilterAlleles(vds, filterExpr, annotationExpr, filterAlteredGenotypes, keep, subset, maxShift)
+    keep: Boolean = true, subset: Boolean = true, maxShift: Int = 100, keepStar: Boolean = false): VariantDataset = {
+    FilterAlleles(vds, filterExpr, annotationExpr, filterAlteredGenotypes, keep, subset, maxShift, keepStar)
   }
 
   /**

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -1514,11 +1514,11 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
     }.asOrderedRDD)
   }
 
-  def minrep(maxShift: Int = 100): VariantSampleMatrix[T] = {
+  def minRep(maxShift: Int = 100): VariantSampleMatrix[T] = {
     require(maxShift > 0, s"invalid value for maxShift: $maxShift. Parameter must be a positive integer.")
     val minrepped = rdd.map {
       case (v, (va, gs)) =>
-        (v.minrep, (va, gs))
+        (v.minRep, (va, gs))
     }
     copy(rdd = minrepped.smartShuffleAndSort(rdd.orderedPartitioner, maxShift))
   }

--- a/src/test/scala/is/hail/io/SplitSuite.scala
+++ b/src/test/scala/is/hail/io/SplitSuite.scala
@@ -34,7 +34,7 @@ class SplitSuite extends SparkSuite {
       val method2 = vds.variants.flatMap { v =>
         v.altAlleles.iterator
           .map { aa =>
-            Variant(v.contig, v.start, v.ref, Array(aa)).minrep
+            Variant(v.contig, v.start, v.ref, Array(aa)).minRep
           }
       }.collect().toSet
 

--- a/src/test/scala/is/hail/vds/FilterAllelesSuite.scala
+++ b/src/test/scala/is/hail/vds/FilterAllelesSuite.scala
@@ -20,7 +20,7 @@ class FilterAllelesSuite extends SparkSuite {
 
   @Test def filterNoAlleles(): Unit = {
     Prop.forAll(VSMSubgen.random.gen(hc)) { vds =>
-      vds.filterAlleles("true", subset = true)
+      vds.filterAlleles("true", subset = true, keepStar = true)
         .countVariants() == vds.countVariants()
     }.check()
   }

--- a/src/test/scala/is/hail/vds/MinRepSuite.scala
+++ b/src/test/scala/is/hail/vds/MinRepSuite.scala
@@ -8,16 +8,16 @@ class MinRepSuite extends SparkSuite {
 
   @Test def minrep() {
 
-    assert(Variant("1",10, "TAA", Array("TA")).minrep.compare(Variant("1",10, "TA", Array("T"))) == 0)
-    assert(Variant("1",10, "ACTG", Array("ACT")).minrep.compare(Variant("1",12, "TG", Array("T"))) == 0)
-    assert(Variant("1",10, "AAACAAAC", Array("AAAC")).minrep.compare(Variant("1",10, "AAACA", Array("A"))) == 0)
-    assert(Variant("1",10, "AATAA", Array("AAGAA")).minrep.compare(Variant("1",12, "T", Array("G"))) == 0)
+    assert(Variant("1",10, "TAA", Array("TA")).minRep.compare(Variant("1",10, "TA", Array("T"))) == 0)
+    assert(Variant("1",10, "ACTG", Array("ACT")).minRep.compare(Variant("1",12, "TG", Array("T"))) == 0)
+    assert(Variant("1",10, "AAACAAAC", Array("AAAC")).minRep.compare(Variant("1",10, "AAACA", Array("A"))) == 0)
+    assert(Variant("1",10, "AATAA", Array("AAGAA")).minRep.compare(Variant("1",12, "T", Array("G"))) == 0)
 
-    assert(Variant("1",10, "TAA", Array("TA","TTA")).minrep
+    assert(Variant("1",10, "TAA", Array("TA","TTA")).minRep
       .compare(Variant("1",10, "TA", Array("T","TT"))) == 0)
-    assert(Variant("1",10, "GCTAA", Array("GCAAA","G")).minrep
+    assert(Variant("1",10, "GCTAA", Array("GCAAA","G")).minRep
       .compare(Variant("1",10, "GCTAA", Array("GCAAA","G"))) == 0)
-    assert(Variant("1",10, "GCTAA", Array("GCAAA","GCCAA")).minrep
+    assert(Variant("1",10, "GCTAA", Array("GCAAA","GCCAA")).minRep
       .compare(Variant("1",12, "T", Array("A","C"))) == 0)
   }
 }


### PR DESCRIPTION
* CamelCased minRep (was inconsistent globally and more importantly camelcased in python interface!)
* Added `isStar` to `AltAllele` and made sure that `*` alleles aren't counted as `SNP`s anymore
* Modified minRep to ignore `*` alleles and correctly minrep in their presence
* FilterAlleles now filters sites where only a `*` allele is left by default (keepStar option allows overriding this behavior)