### PR TITLE
Added type check to jarray

### DIFF
--- a/python/hail/java.py
+++ b/python/hail/java.py
@@ -44,11 +44,13 @@ class Env:
 
 
 def jarray(jtype, lst):
+    if not isinstance(lst, list):
+        raise FatalError(str(lst) + ' is not an array')
+        
     jarr = Env.gateway().new_array(jtype, len(lst))
     for i, s in enumerate(lst):
         jarr[i] = s
     return jarr
-
 
 def scala_object(jpackage, name):
     return getattr(getattr(jpackage, name + '$'), 'MODULE$')

--- a/python/hail/java.py
+++ b/python/hail/java.py
@@ -52,6 +52,7 @@ def jarray(jtype, lst):
         jarr[i] = s
     return jarr
 
+
 def scala_object(jpackage, name):
     return getattr(getattr(jpackage, name + '$'), 'MODULE$')
 


### PR DESCRIPTION
for `vds.linreg('sa.pheno', 'sa.cov1')` the error is now:

```
sa.cov1 is not an array
```

rather than

```
FatalError                                Traceback (most recent call last)
<ipython-input-18-89d0abef0d0a> in <module>()
----> 1 vds1 = vds.linreg('sa.pheno', 'sa.cov1').count()

<decorator-gen-240> in linreg(self, y, covariates, root, use_dosages, min_ac, min_af)

/Users/jbloom/hail/python/hail/java.pyc in handle_py4j(func, *args, **kwargs)
    111         raise FatalError('%s\n\nJava stack trace:\n%s\n'
    112                          'Hail version: %s\n'
--> 113                          'Error summary: %s' % (deepest, full, Env.hc().version, deepest))
    114     except py4j.protocol.Py4JError as e:
    115         if e.args[0].startswith('An error occurred while calling'):

FatalError: HailException: symbol `a' not found
  Available symbols:
    s: String
    sa: Struct 
<input>:1:a
          ^

Java stack trace:
is.hail.utils.HailException: symbol `a' not found
  Available symbols:
    s: String
    sa: Struct 
<input>:1:a
          ^
    at is.hail.utils.ErrorHandling$class.fatal(ErrorHandling.scala:6)
    at is.hail.utils.package$.fatal(package.scala:20)
    at is.hail.expr.ParserUtils$.error(Parser.scala:24)
    at is.hail.expr.AST.parseError(AST.scala:222)
    at is.hail.expr.SymRef.typecheckThis(AST.scala:648)
    at is.hail.expr.AST.typecheck(AST.scala:219)
    at is.hail.expr.Parser$.is$hail$expr$Parser$$eval(Parser.scala:57)
    at is.hail.expr.Parser$.parseExpr(Parser.scala:67)
    at is.hail.stats.RegressionUtils$$anonfun$3.apply(RegressionUtils.scala:36)
    at is.hail.stats.RegressionUtils$$anonfun$3.apply(RegressionUtils.scala:36)
    at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
    at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
    at scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
    at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
    at scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
    at scala.collection.mutable.ArrayOps$ofRef.map(ArrayOps.scala:186)
    at is.hail.stats.RegressionUtils$.getPhenoCovCompleteSamples(RegressionUtils.scala:36)
    at is.hail.methods.LinearRegression$.apply(LinearRegression.scala:21)
    at is.hail.variant.VariantDatasetFunctions$.linreg$extension(VariantDataset.scala:848)
    at is.hail.variant.VariantDatasetFunctions.linreg(VariantDataset.scala:846)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:497)
    at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:237)
    at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
    at py4j.Gateway.invoke(Gateway.java:280)
    at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
    at py4j.commands.CallCommand.execute(CallCommand.java:79)
    at py4j.GatewayConnection.run(GatewayConnection.java:214)
    at java.lang.Thread.run(Thread.java:745)

Hail version: devel-07f60b2
Error summary: HailException: symbol `a' not found
  Available symbols:
    s: String
    sa: Struct 
<input>:1:a
          ^
```