### PR TITLE
Fixed bug where rows not explcitily in RDD would not be included

### DIFF
--- a/src/test/scala/is/hail/methods/KinshipMatrixSuite.scala
+++ b/src/test/scala/is/hail/methods/KinshipMatrixSuite.scala
@@ -13,7 +13,6 @@ import org.testng.annotations.Test
 class KinshipMatrixSuite extends SparkSuite {
 
   val data = Seq(
-    IndexedRow(0L, Vectors.dense(1, 2, 3, 4)),
     IndexedRow(1L, Vectors.dense(5, 6, 7, 8)),
     IndexedRow(2L, Vectors.dense(9, 10, 11, 12)),
     IndexedRow(3L, Vectors.dense(13, 14, 15, 16))
@@ -59,6 +58,9 @@ class KinshipMatrixSuite extends SparkSuite {
         .drop(1)
         .map(s => s.split("\t").map(_.toDouble)).toArray
     }
+
+    //Ensures that all 4 rows of data matrix got written out and read back in, even though row 0 is not explicity included in data.
+    assert(readInValues.length == irm.numRows())
 
     assert(km.matrix.toBlockMatrix().toLocalMatrix().rowIter.map(v => v.toArray).toArray.deep == readInValues.deep)
 


### PR DESCRIPTION
To be clear, the bug was that if the rdd of IndexedRows backing the IndexedRowMatrix omitted some rows (as a way of indicating that they contained only 0's), that omitted row would not get written to TSV file. This has been corrected, and a test was created for it by making the test data in the Suite more interesting and adding an assertion. 