### PR TITLE
Grm to kinship matrix

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -2167,14 +2167,14 @@ class VariantDataset(object):
 
     @handle_py4j
     @requireTGenotype
-    def grm(self, output, format, id_file=None, n_file=None):
+    def grm(self):
         """Compute the Genetic Relatedness Matrix (GRM).
 
         .. include:: requireTGenotype.rst
 
         **Examples**
         
-        >>> vds.grm('data/grm.rel', 'rel')
+        >>> km = vds.grm()
         
         **Notes**
         
@@ -2188,21 +2188,11 @@ class VariantDataset(object):
         
         .. math::
 
-          G_{ik} = \\frac{1}{m} \\sum_{j=1}^m \\frac{(C_{ij}-2p_j)(C_{kj}-2p_j)}{2 p_j (1-p_j)}
-        
-        The output formats are consistent with `PLINK formats <https://www.cog-genomics.org/plink2/formats>`_ as created by the `make-rel and make-grm commands <https://www.cog-genomics.org/plink2/distance#make_rel>`_ and used by `GCTA <http://cnsgenomics.com/software/gcta/estimate_grm.html>`_.
-
-        :param str output: Output file.
-
-        :param str format: Output format.  One of: 'rel', 'gcta-grm', 'gcta-grm-bin'.
-
-        :param str id_file: ID file.
-
-        :param str n_file: N file, for gcta-grm-bin only.
+          G_{ik} = \\frac{1}{m} \\sum_{j=1}^m \\frac{(C_{ij}-2p_j)(C_{kj}-2p_j)}{2 p_j (1-p_j)}        
         """
 
-        jvds = self._jvdf.grm(output, format, joption(id_file), joption(n_file))
-        return VariantDataset(self.hc, jvds)
+        jkm = self._jvdf.grm()
+        return KinshipMatrix(jkm)
 
     @handle_py4j
     @requireTGenotype

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -2188,7 +2188,10 @@ class VariantDataset(object):
         
         .. math::
 
-          G_{ik} = \\frac{1}{m} \\sum_{j=1}^m \\frac{(C_{ij}-2p_j)(C_{kj}-2p_j)}{2 p_j (1-p_j)}        
+          G_{ik} = \\frac{1}{m} \\sum_{j=1}^m \\frac{(C_{ij}-2p_j)(C_{kj}-2p_j)}{2 p_j (1-p_j)}  
+                
+        :return: Genetic Relatedness Matrix for all samples.
+        :rtype: :py:class:`KinshipMatrix`
         """
 
         jkm = self._jvdf.grm()

--- a/python/hail/kinshipMatrix.py
+++ b/python/hail/kinshipMatrix.py
@@ -1,8 +1,12 @@
 from pyspark.mllib.linalg.distributed import IndexedRowMatrix
+from hail.java import *
 
 class KinshipMatrix:
     """
     Represents a symmetric matrix encoding the relatedness of each pair of samples in the accompanying sample list.
+    
+    The output formats are consistent with `PLINK formats <https://www.cog-genomics.org/plink2/formats>`_ as created by the `make-rel and make-grm commands <https://www.cog-genomics.org/plink2/distance#make_rel>`_ and used by `GCTA <http://cnsgenomics.com/software/gcta/estimate_grm.html>`_.
+
     """
     def __init__(self, jkm):
         self._jkm = jkm
@@ -32,3 +36,37 @@ class KinshipMatrix:
         :param string output: The file path to output the matrix to. 
         """
         self._jkm.exportTSV(output)
+
+    def export_rel(self, output):
+        """
+        Export kinship matrix as .rel file. See `PLINK formats <https://www.cog-genomics.org/plink2/formats>`_.
+        
+        :param output: The file path to output to. 
+        """
+        self._jkm.exportRel(output)
+
+    def export_gcta_grm(self, output):
+        """
+        Export kinship matrix as .grm file. See `PLINK formats <https://www.cog-genomics.org/plink2/formats>`_.
+        
+        :param output: The file path to output to.
+        """
+        self._jkm.exportGctaGrm(self, output)
+
+    def export_gcta_grm_bin(self, output, opt_n_file=None):
+        """
+        Export kinship matrix as .grm.bin file or as .grm.N.bin file, depending on whether an N file is specified. See `PLINK formats <https://www.cog-genomics.org/plink2/formats>`_.
+        
+        :param output: The file path to output to. 
+        
+        :param opt_n_file: The file path to the N file. 
+        """
+        self._jkm.exportGctaGrmBin(self, output, joption(opt_n_file))
+
+    def export_id_file(self, output):
+        """
+        Export samples as .id file. See `PLINK formats <https://www.cog-genomics.org/plink2/formats>`_.
+        
+        :param output: The file to output to.
+        """
+        self._jkm.exportIdFile(output)

--- a/python/hail/kinshipMatrix.py
+++ b/python/hail/kinshipMatrix.py
@@ -51,7 +51,7 @@ class KinshipMatrix:
         
         :param output: The file path to output to.
         """
-        self._jkm.exportGctaGrm(self, output)
+        self._jkm.exportGctaGrm(output)
 
     def export_gcta_grm_bin(self, output, opt_n_file=None):
         """
@@ -61,7 +61,7 @@ class KinshipMatrix:
         
         :param opt_n_file: The file path to the N file. 
         """
-        self._jkm.exportGctaGrmBin(self, output, joption(opt_n_file))
+        self._jkm.exportGctaGrmBin(output, joption(opt_n_file))
 
     def export_id_file(self, output):
         """

--- a/python/hail/tests.py
+++ b/python/hail/tests.py
@@ -301,7 +301,7 @@ class ContextTests(unittest.TestCase):
 
         sample2.filter_multi().count()
 
-        sample2.split_multi().grm('/tmp/sample2.grm', 'gcta-grm-bin')
+        sample2.split_multi().grm().export_gcta_grm_bin('/tmp/sample2.grm')
 
         sample2.hardcalls().count()
 

--- a/src/main/scala/is/hail/methods/GRM.scala
+++ b/src/main/scala/is/hail/methods/GRM.scala
@@ -1,25 +1,11 @@
 package is.hail.methods
 
-import java.io.DataOutputStream
-
-import breeze.linalg.SparseVector
 import is.hail.stats.ToHWENormalizedIndexedRowMatrix
 import is.hail.utils._
 import is.hail.variant.VariantDataset
-import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix}
 
 object GRM {
-  def writeFloatLittleEndian(s: DataOutputStream, f: Float) {
-    val bits: Int = java.lang.Float.floatToRawIntBits(f)
-    s.write(bits & 0xff)
-    s.write((bits >> 8) & 0xff)
-    s.write((bits >> 16) & 0xff)
-    s.write(bits >> 24)
-  }
-
   def apply(vds: VariantDataset): KinshipMatrix = {
-    /*if (!Set("rel", "gcta-grm-bin", "gcta-grm").contains(format))
-      fatal(s"unknown format `$format', expect one of `rel', `gcta-grm', `gcta-grm-bin'")*/
 
     val (_, mat) = ToHWENormalizedIndexedRowMatrix(vds)
 
@@ -33,6 +19,6 @@ object GRM {
     assert(grm.numCols == nSamples
       && grm.numRows == nSamples)
 
-    new KinshipMatrix(grm.toIndexedRowMatrix, vds.sampleIds.toArray)
+    new KinshipMatrix(vds.hc, grm.toIndexedRowMatrix, vds.sampleIds.toArray, vds.countVariants())
   }
 }

--- a/src/main/scala/is/hail/methods/GRM.scala
+++ b/src/main/scala/is/hail/methods/GRM.scala
@@ -6,7 +6,7 @@ import breeze.linalg.SparseVector
 import is.hail.stats.ToHWENormalizedIndexedRowMatrix
 import is.hail.utils._
 import is.hail.variant.VariantDataset
-import org.apache.spark.mllib.linalg.distributed.IndexedRow
+import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix}
 
 object GRM {
   def writeFloatLittleEndian(s: DataOutputStream, f: Float) {
@@ -17,12 +17,11 @@ object GRM {
     s.write(bits >> 24)
   }
 
-  def apply(vds: VariantDataset, path: String, format: String,
-    idFile: Option[String] = None, nFile: Option[String] = None) {
-    if (!Set("rel", "gcta-grm-bin", "gcta-grm").contains(format))
-      fatal(s"unknown format `$format', expect one of `rel', `gcta-grm', `gcta-grm-bin'")
+  def apply(vds: VariantDataset): KinshipMatrix = {
+    /*if (!Set("rel", "gcta-grm-bin", "gcta-grm").contains(format))
+      fatal(s"unknown format `$format', expect one of `rel', `gcta-grm', `gcta-grm-bin'")*/
 
-    val (variants, mat) = ToHWENormalizedIndexedRowMatrix(vds)
+    val (_, mat) = ToHWENormalizedIndexedRowMatrix(vds)
 
     val nSamples = vds.nSamples
     assert(nSamples == mat.numCols())
@@ -34,94 +33,6 @@ object GRM {
     assert(grm.numCols == nSamples
       && grm.numRows == nSamples)
 
-    idFile.foreach { f =>
-      vds.sparkContext.hadoopConfiguration.writeTextFile(f) { s =>
-        for (id <- vds.sampleIds) {
-          s.write(id)
-          s.write("\t")
-          s.write(id)
-          s.write("\n")
-        }
-      }
-    }
-
-    if (format != "gcta-grm-bin"
-      && nFile.isDefined)
-      warn(s"format $format: ignoring `--N-file'")
-
-    val zeroVector = SparseVector.zeros[Double](nSamples)
-
-    val indexSortedRowMatrix = grm.toIndexedRowMatrix
-      .rows
-      .map(x => (x.index, x.vector))
-      .rightOuterJoin(vds.sparkContext.parallelize(0L until nSamples).map(x => (x, ())))
-      .map {
-        case (idx, (Some(v), _)) => IndexedRow(idx, v)
-        case (idx, (None, _)) => IndexedRow(idx, zeroVector)
-      }
-      .sortBy(_.index)
-
-    (format: @unchecked) match {
-      case "rel" =>
-        indexSortedRowMatrix
-          .map { (row: IndexedRow) =>
-            val i = row.index
-            val arr = row.vector.toArray
-            val sb = new StringBuilder
-            var j = 0
-            while (j <= i) {
-              if (j > 0)
-                sb += '\t'
-              sb.append(arr(j))
-              j += 1
-            }
-            sb.toString()
-          }
-          .writeTable(path, vds.hc.tmpDir)
-
-      case "gcta-grm" =>
-        indexSortedRowMatrix
-          .map { (row: IndexedRow) =>
-            val i = row.index
-            val arr = row.vector.toArray
-            val sb = new StringBuilder
-            var j = 0
-            while (j <= i) {
-              sb.append(s"${ i + 1 }\t${ j + 1 }\t$nVariants\t${ arr(j) }")
-              if (j < i) {
-                sb.append("\n")
-              }
-              j += 1
-            }
-            sb.toString()
-          }
-          .writeTable(path, vds.hc.tmpDir)
-
-      case "gcta-grm-bin" =>
-        indexSortedRowMatrix
-          .map { (row: IndexedRow) =>
-            val i = row.index
-            val arr = row.vector.toArray
-            val result = new Array[Byte](4 * i.toInt + 4)
-            var j = 0
-            while (j <= i) {
-              val bits: Int = java.lang.Float.floatToRawIntBits(arr(j).toFloat)
-              result(j * 4) = (bits & 0xff).toByte
-              result(j * 4 + 1) = ((bits >> 8) & 0xff).toByte
-              result(j * 4 + 2) = ((bits >> 16) & 0xff).toByte
-              result(j * 4 + 3) = (bits >> 24).toByte
-              j += 1
-            }
-            result
-          }
-          .saveFromByteArrays(path, vds.hc.tmpDir)
-
-        nFile.foreach { f =>
-          vds.sparkContext.hadoopConfiguration.writeDataFile(f) { s =>
-            for (_ <- 0 until nSamples * (nSamples + 1) / 2)
-              writeFloatLittleEndian(s, nVariants.toFloat)
-          }
-        }
-    }
+    new KinshipMatrix(grm.toIndexedRowMatrix, vds.sampleIds.toArray)
   }
 }

--- a/src/main/scala/is/hail/methods/GRM.scala
+++ b/src/main/scala/is/hail/methods/GRM.scala
@@ -28,7 +28,7 @@ object GRM {
     assert(nSamples == mat.numCols())
     val nVariants = mat.numRows() // mat cached
 
-    val bmat = mat.toBlockMatrix().cache()
+    val bmat = mat.toBlockMatrixDense().cache()
     val grm = bmat.transpose.multiply(bmat)
 
     assert(grm.numCols == nSamples

--- a/src/main/scala/is/hail/methods/KinshipMatrix.scala
+++ b/src/main/scala/is/hail/methods/KinshipMatrix.scala
@@ -53,7 +53,7 @@ case class KinshipMatrix(val hc: HailContext, val matrix: IndexedRowMatrix, val 
 
   def exportRel(output: String) {
     prepareMatrixForExport(matrix).rows
-    .mapPartitions(itr => {
+    .mapPartitions{ itr =>
       val sb = new StringBuilder
       itr.foreach{ (row: IndexedRow) =>
         val i = row.index
@@ -68,13 +68,13 @@ case class KinshipMatrix(val hc: HailContext, val matrix: IndexedRowMatrix, val 
         sb += '\n'
       }
       sb.lines
-    }).writeTable(output, hc.tmpDir)
+    }.writeTable(output, hc.tmpDir)
   }
 
   def exportGctaGrm(output: String) {
     val nVars = numVariantsUsed //required to avoid serialization error.
     prepareMatrixForExport(matrix).rows
-    .mapPartitions((itr: Iterator[IndexedRow]) => {
+    .mapPartitions{ (itr: Iterator[IndexedRow]) =>
       val sb = new StringBuilder
       itr.foreach{ (row: IndexedRow) =>
         val i = row.index
@@ -90,7 +90,7 @@ case class KinshipMatrix(val hc: HailContext, val matrix: IndexedRowMatrix, val 
         sb += '\n'
       }
       sb.lines
-    }).writeTable(output, hc.tmpDir)
+    }.writeTable(output, hc.tmpDir)
   }
 
   def exportGctaGrmBin(output: String, nFile: Option[String] = None) {

--- a/src/main/scala/is/hail/methods/KinshipMatrix.scala
+++ b/src/main/scala/is/hail/methods/KinshipMatrix.scala
@@ -2,6 +2,7 @@ package is.hail.methods
 
 import breeze.linalg.SparseVector
 import is.hail.HailContext
+import is.hail.variant.VariantDataset
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix}
 
@@ -57,7 +58,6 @@ class KinshipMatrix(val hc: HailContext, val matrix: IndexedRowMatrix, val sampl
     */
   private def prepareMatrixForExport(matToComplete: IndexedRowMatrix): IndexedRowMatrix = {
     val zeroVector = SparseVector.zeros[Double](sampleIds.length)
-
     new IndexedRowMatrix(matToComplete
       .rows
       .map(x => (x.index, x.vector))

--- a/src/main/scala/is/hail/methods/KinshipMatrix.scala
+++ b/src/main/scala/is/hail/methods/KinshipMatrix.scala
@@ -121,7 +121,7 @@ class KinshipMatrix(val hc: HailContext, val matrix: IndexedRowMatrix, val sampl
 
   def exportIdFile(idFile: String) {
     hc.sc.hadoopConfiguration.writeTextFile(idFile) { s =>
-      for (id <- this.sampleIds) {
+      for (id <- sampleIds) {
         s.write(id)
         s.write("\t")
         s.write(id)

--- a/src/main/scala/is/hail/methods/KinshipMatrix.scala
+++ b/src/main/scala/is/hail/methods/KinshipMatrix.scala
@@ -13,7 +13,7 @@ import is.hail.utils._
 /**
   * Represents a KinshipMatrix. Entry (i, j) encodes the relatedness of the ith and jth samples in sampleIds.
   */
-class KinshipMatrix(val hc: HailContext, val matrix: IndexedRowMatrix, val sampleIds: Array[String], val numVariantsUsed: Long) {
+case class KinshipMatrix(val hc: HailContext, val matrix: IndexedRowMatrix, val sampleIds: Array[String], val numVariantsUsed: Long) {
   assert(matrix.numCols().toInt == matrix.numRows().toInt && matrix.numCols().toInt == sampleIds.length)
 
   /**

--- a/src/main/scala/is/hail/methods/KinshipMatrix.scala
+++ b/src/main/scala/is/hail/methods/KinshipMatrix.scala
@@ -4,11 +4,11 @@ import java.io.DataOutputStream
 
 import breeze.linalg.SparseVector
 import is.hail.HailContext
+import is.hail.utils._
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix}
 
 import scala.collection.Searching._
-import is.hail.utils._
 
 /**
   * Represents a KinshipMatrix. Entry (i, j) encodes the relatedness of the ith and jth samples in sampleIds.

--- a/src/main/scala/is/hail/stats/ComputeRRM.scala
+++ b/src/main/scala/is/hail/stats/ComputeRRM.scala
@@ -3,7 +3,6 @@ package is.hail.stats
 
 import breeze.linalg.DenseMatrix
 import is.hail.utils._
-import is.hail.utils.richUtils.RichIndexedRowMatrix._
 
 import is.hail.variant.{Variant, VariantDataset}
 import org.apache.spark.SparkContext

--- a/src/main/scala/is/hail/utils/richUtils/Implicits.scala
+++ b/src/main/scala/is/hail/utils/richUtils/Implicits.scala
@@ -5,7 +5,7 @@ import is.hail.utils.{ArrayBuilder, JSONWriter, MultiArray2, Truncatable}
 import is.hail.variant.Variant
 import org.apache.hadoop
 import org.apache.spark.SparkContext
-import org.apache.spark.mllib.linalg.distributed.IndexedRow
+import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Row, SQLContext}
 import org.apache.spark.storage.StorageLevel
@@ -33,6 +33,8 @@ trait Implicits {
     new RichHadoopConfiguration(hConf)
 
   implicit def toRichIndexedRow(r: IndexedRow): RichIndexedRow = new RichIndexedRow(r)
+
+  implicit def toRichIndexedRowMatrix(irm: IndexedRowMatrix): RichIndexedRowMatrix = new RichIndexedRowMatrix(irm)
 
   implicit def toRichIntPairTraversableOnce[V](t: TraversableOnce[(Int, V)]): RichIntPairTraversableOnce[V] =
     new RichIntPairTraversableOnce[V](t)

--- a/src/main/scala/is/hail/utils/richUtils/RichIndexedRowMatrix.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichIndexedRowMatrix.scala
@@ -14,71 +14,72 @@ import scala.reflect.classTag
   * since it seems broadly useful.
   */
 
-object RichIndexedRowMatrix {
-
-  val intClass = classTag[Int].runtimeClass
-  val gpObjectClass = Class.forName("org.apache.spark.mllib.linalg.distributed.GridPartitioner$")
-  val gpApply = gpObjectClass.getMethod("apply", intClass, intClass, intClass)
-
-  def sneakyGridPartitioner(nRowBlocks: Int, nColBlocks: Int, suggestedNumPartitions: Int): Partitioner = try {
-    gpApply.setAccessible(true)
-    gpApply.invoke(gpObjectClass.getField("MODULE$").get(null), nRowBlocks: java.lang.Integer,
-      nColBlocks: java.lang.Integer, suggestedNumPartitions: java.lang.Integer).asInstanceOf[Partitioner]
-  } finally {
-    gpApply.setAccessible(false)
+class RichIndexedRowMatrix(indexedRowMatrix: IndexedRowMatrix) {
+  def toBlockMatrixDense(): BlockMatrix = {
+    toBlockMatrixDense(1024, 1024)
   }
 
-  implicit class RichIndexedRowMatrix(indexedRowMatrix: IndexedRowMatrix) {
-    def toBlockMatrixDense(): BlockMatrix = {
-      toBlockMatrixDense(1024, 1024)
-    }
+  /**
+    * Gets a GridParitioner instance from spark mllib using reflection, since the constructor is private.
+    */
+  private def sneakyGridPartitioner(nRowBlocks: Int, nColBlocks: Int, suggestedNumPartitions: Int): Partitioner = {
+    val intClass = classTag[Int].runtimeClass
+    val gpObjectClass = Class.forName("org.apache.spark.mllib.linalg.distributed.GridPartitioner$")
+    val gpApply = gpObjectClass.getMethod("apply", intClass, intClass, intClass)
 
-    def toBlockMatrixDense(rowsPerBlock: Int, colsPerBlock: Int): BlockMatrix = {
-      require(rowsPerBlock > 0,
-        s"rowsPerBlock needs to be greater than 0. rowsPerBlock: $rowsPerBlock")
-      require(colsPerBlock > 0,
-        s"colsPerBlock needs to be greater than 0. colsPerBlock: $colsPerBlock")
-
-      val m = indexedRowMatrix.numRows()
-      val n = indexedRowMatrix.numCols()
-      val lastRowBlockIndex = m / rowsPerBlock
-      val lastColBlockIndex = n / colsPerBlock
-      val lastRowBlockSize = (m % rowsPerBlock).toInt
-      val lastColBlockSize = (n % colsPerBlock).toInt
-      val numRowBlocks = (m / rowsPerBlock + (if (m % rowsPerBlock == 0) 0 else 1)).toInt
-      val numColBlocks = (n / colsPerBlock + (if (n % colsPerBlock == 0) 0 else 1)).toInt
-
-
-      val blocks: RDD[((Int, Int), Matrix)] = indexedRowMatrix.rows.flatMap({ ir =>
-        val blockRow = ir.index / rowsPerBlock
-        val rowInBlock = ir.index % rowsPerBlock
-
-        ir.vector.toArray
-          .grouped(colsPerBlock)
-          .zipWithIndex
-          .map({ case (values, blockColumn) =>
-            ((blockRow.toInt, blockColumn), (rowInBlock.toInt, values))
-          })
-      }).groupByKey(sneakyGridPartitioner(numRowBlocks, numColBlocks, indexedRowMatrix.rows.getNumPartitions)).map({
-        case ((blockRow, blockColumn), itr) =>
-          val actualNumRows: Int = if (blockRow == lastRowBlockIndex) lastRowBlockSize else rowsPerBlock
-          val actualNumColumns: Int = if (blockColumn == lastColBlockIndex) lastColBlockSize else colsPerBlock
-
-          val arraySize = actualNumRows * actualNumColumns
-          val matrixAsArray = new Array[Double](arraySize)
-          itr.foreach({ case (rowWithinBlock, values) =>
-            var i = 0
-            while (i < values.length) {
-              matrixAsArray.update(i * actualNumRows + rowWithinBlock, values(i))
-              i += 1
-            }
-          })
-          ((blockRow, blockColumn), new DenseMatrix(actualNumRows, actualNumColumns, matrixAsArray))
-      })
-      new BlockMatrix(blocks, rowsPerBlock, colsPerBlock)
+    try {
+      gpApply.setAccessible(true)
+      gpApply.invoke(gpObjectClass.getField("MODULE$").get(null), nRowBlocks: java.lang.Integer,
+        nColBlocks: java.lang.Integer, suggestedNumPartitions: java.lang.Integer).asInstanceOf[Partitioner]
+    } finally {
+      gpApply.setAccessible(false)
     }
   }
 
+  def toBlockMatrixDense(rowsPerBlock: Int, colsPerBlock: Int): BlockMatrix = {
+    require(rowsPerBlock > 0,
+      s"rowsPerBlock needs to be greater than 0. rowsPerBlock: $rowsPerBlock")
+    require(colsPerBlock > 0,
+      s"colsPerBlock needs to be greater than 0. colsPerBlock: $colsPerBlock")
+
+    val m = indexedRowMatrix.numRows()
+    val n = indexedRowMatrix.numCols()
+    val lastRowBlockIndex = m / rowsPerBlock
+    val lastColBlockIndex = n / colsPerBlock
+    val lastRowBlockSize = (m % rowsPerBlock).toInt
+    val lastColBlockSize = (n % colsPerBlock).toInt
+    val numRowBlocks = (m / rowsPerBlock + (if (m % rowsPerBlock == 0) 0 else 1)).toInt
+    val numColBlocks = (n / colsPerBlock + (if (n % colsPerBlock == 0) 0 else 1)).toInt
+
+
+    val blocks: RDD[((Int, Int), Matrix)] = indexedRowMatrix.rows.flatMap({ ir =>
+      val blockRow = ir.index / rowsPerBlock
+      val rowInBlock = ir.index % rowsPerBlock
+
+      ir.vector.toArray
+        .grouped(colsPerBlock)
+        .zipWithIndex
+        .map({ case (values, blockColumn) =>
+          ((blockRow.toInt, blockColumn), (rowInBlock.toInt, values))
+        })
+    }).groupByKey(sneakyGridPartitioner(numRowBlocks, numColBlocks, indexedRowMatrix.rows.getNumPartitions)).map({
+      case ((blockRow, blockColumn), itr) =>
+        val actualNumRows: Int = if (blockRow == lastRowBlockIndex) lastRowBlockSize else rowsPerBlock
+        val actualNumColumns: Int = if (blockColumn == lastColBlockIndex) lastColBlockSize else colsPerBlock
+
+        val arraySize = actualNumRows * actualNumColumns
+        val matrixAsArray = new Array[Double](arraySize)
+        itr.foreach({ case (rowWithinBlock, values) =>
+          var i = 0
+          while (i < values.length) {
+            matrixAsArray.update(i * actualNumRows + rowWithinBlock, values(i))
+            i += 1
+          }
+        })
+        ((blockRow, blockColumn), new DenseMatrix(actualNumRows, actualNumColumns, matrixAsArray))
+    })
+    new BlockMatrix(blocks, rowsPerBlock, colsPerBlock)
+  }
 }
 
 

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -737,6 +737,7 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
 
   def grm(): KinshipMatrix = {
     requireSplit("GRM")
+    info("Computing GRM...")
     GRM(vds)
   }
 

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -742,9 +742,9 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     * @param idFile write ID file to this path
     * @param nFile N file path, used with gcta-grm-bin only
     */
-  def grm(path: String, format: String, idFile: Option[String] = None, nFile: Option[String] = None) {
+  def grm(path: String, format: String, idFile: Option[String] = None, nFile: Option[String] = None): KinshipMatrix = {
     requireSplit("GRM")
-    GRM(vds, path, format, idFile, nFile)
+    GRM(vds)
   }
 
   def hardCalls(): VariantDataset = {

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -735,14 +735,7 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     }
   }
 
-  /**
-    *
-    * @param path output path
-    * @param format output format: one of rel, gcta-grm, gcta-grm-bin
-    * @param idFile write ID file to this path
-    * @param nFile N file path, used with gcta-grm-bin only
-    */
-  def grm(path: String, format: String, idFile: Option[String] = None, nFile: Option[String] = None): KinshipMatrix = {
+  def grm(): KinshipMatrix = {
     requireSplit("GRM")
     GRM(vds)
   }
@@ -895,7 +888,7 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     info(s"rrm: Computing Realized Relationship Matrix...")
     val (rrm, m) = ComputeRRM(vds, forceBlock, forceGramian)
     info(s"rrm: RRM computed using $m variants.")
-    new KinshipMatrix(vds.hc, rrm, vds.sampleIds.toArray)
+    new KinshipMatrix(vds.hc, rrm, vds.sampleIds.toArray, m)
   }
 
 

--- a/src/test/scala/is/hail/methods/KinshipMatrixSuite.scala
+++ b/src/test/scala/is/hail/methods/KinshipMatrixSuite.scala
@@ -8,7 +8,7 @@ import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix}
 import org.testng.annotations.Test
 
 /**
-  * Tests for KinshipMatrix.
+  * Tests for KinshipMatrix. See GRMSuite for tests relevant to other export methods.
   */
 class KinshipMatrixSuite extends SparkSuite {
 
@@ -33,7 +33,7 @@ class KinshipMatrixSuite extends SparkSuite {
     val irdd = sc.parallelize(data)
     val irm = new IndexedRowMatrix(irdd)
     val samples = (0 to 3).map(i => s"S$i")
-    val km = new KinshipMatrix(hc, irm, samples.toArray)
+    val km = new KinshipMatrix(hc, irm, samples.toArray, 10)
 
     val kmOneEntry = km.filterSamples(Set("S2").contains)
     assert(kmOneEntry.matrix.toBlockMatrix().toLocalMatrix()(0, 0) == 11)
@@ -46,7 +46,7 @@ class KinshipMatrixSuite extends SparkSuite {
     val irdd = sc.parallelize(data)
     val irm = new IndexedRowMatrix(irdd)
     val samples = (0 to 3).map(i => s"S$i")
-    val km = new KinshipMatrix(hc, irm, samples.toArray)
+    val km = new KinshipMatrix(hc, irm, samples.toArray, 10)
 
     val out = tmpDir.createTempFile("kinshipMatrixExportTSVTest", ".tsv")
 

--- a/src/test/scala/is/hail/utils/RichIndexedRowMatrixSuite.scala
+++ b/src/test/scala/is/hail/utils/RichIndexedRowMatrixSuite.scala
@@ -2,7 +2,6 @@ package is.hail.utils
 
 import breeze.linalg.Matrix
 import is.hail.SparkSuite
-import is.hail.utils.richUtils.RichIndexedRowMatrix._
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.linalg.distributed.{DistributedMatrix, IndexedRow, IndexedRowMatrix}
 import org.apache.spark.rdd.RDD

--- a/src/test/scala/is/hail/vds/BiallelicMethodsSuite.scala
+++ b/src/test/scala/is/hail/vds/BiallelicMethodsSuite.scala
@@ -29,7 +29,7 @@ class BiallelicMethodsSuite extends SparkSuite {
     }
 
     catchError {
-      multi.grm("foo", "foo")
+      multi.grm()
     }
 
     catchError {

--- a/src/test/scala/is/hail/vds/GRMSuite.scala
+++ b/src/test/scala/is/hail/vds/GRMSuite.scala
@@ -155,7 +155,6 @@ class GRMSuite extends SparkSuite {
 
             assert(loadIDFile(bFile + ".rel.id").toIndexedSeq == vds.sampleIds)
 
-            //vds.grm(relFile, format = "rel", idFile = Some(relIDFile))
             grm.exportRel(relFile)
 
             assert(loadIDFile(relIDFile).toIndexedSeq == vds.sampleIds)
@@ -168,7 +167,6 @@ class GRMSuite extends SparkSuite {
 
             assert(loadIDFile(bFile + ".grm.id").toIndexedSeq == vds.sampleIds)
 
-            //vds.grm(grmFile, format = "gcta-grm")
             grm.exportGctaGrm(grmFile)
 
             compare(loadGRM(nSamples, nVariants, bFile + ".grm.gz"),
@@ -179,7 +177,6 @@ class GRMSuite extends SparkSuite {
 
             assert(loadIDFile(bFile + ".grm.id").toIndexedSeq == vds.sampleIds)
 
-            //vds.grm(grmBinFile, format = "gcta-grm-bin", nFile = Some(grmNBinFile))
             grm.exportGctaGrmBin(grmBinFile, Some(grmNBinFile))
 
             (compare(loadBin(nSamples, bFile + ".grm.bin"),

--- a/src/test/scala/is/hail/vds/GRMSuite.scala
+++ b/src/test/scala/is/hail/vds/GRMSuite.scala
@@ -146,13 +146,17 @@ class GRMSuite extends SparkSuite {
 
         vds.exportPlink(bFile)
 
+        val grm = vds.grm()
+        grm.exportIdFile(relIDFile)
+
         format match {
           case "rel" =>
             s"plink --bfile ${ uriPath(bFile) } --make-rel --out ${ uriPath(bFile) }" !
 
             assert(loadIDFile(bFile + ".rel.id").toIndexedSeq == vds.sampleIds)
 
-            vds.grm(relFile, format = "rel", idFile = Some(relIDFile))
+            //vds.grm(relFile, format = "rel", idFile = Some(relIDFile))
+            grm.exportRel(relFile)
 
             assert(loadIDFile(relIDFile).toIndexedSeq == vds.sampleIds)
 
@@ -164,7 +168,8 @@ class GRMSuite extends SparkSuite {
 
             assert(loadIDFile(bFile + ".grm.id").toIndexedSeq == vds.sampleIds)
 
-            vds.grm(grmFile, format = "gcta-grm")
+            //vds.grm(grmFile, format = "gcta-grm")
+            grm.exportGctaGrm(grmFile)
 
             compare(loadGRM(nSamples, nVariants, bFile + ".grm.gz"),
               loadGRM(nSamples, nVariants, grmFile))
@@ -174,7 +179,8 @@ class GRMSuite extends SparkSuite {
 
             assert(loadIDFile(bFile + ".grm.id").toIndexedSeq == vds.sampleIds)
 
-            vds.grm(grmBinFile, format = "gcta-grm-bin", nFile = Some(grmNBinFile))
+            //vds.grm(grmBinFile, format = "gcta-grm-bin", nFile = Some(grmNBinFile))
+            grm.exportGctaGrmBin(grmBinFile, Some(grmNBinFile))
 
             (compare(loadBin(nSamples, bFile + ".grm.bin"),
               loadBin(nSamples, grmBinFile))


### PR DESCRIPTION
-Changed the "grm()" method to return instances of KinshipMatrix. 

-Added various export to file methods that were supported by GRM to the KinshipMatrix.

-Modified GRM tests appropriately. 

-Add RichIndexedRowMatrix implicit to the hail utils implicit file. 
