### PR TITLE
Extract CM into asm4s

### DIFF
--- a/src/main/scala/is/hail/asm4s/CM.scala
+++ b/src/main/scala/is/hail/asm4s/CM.scala
@@ -101,19 +101,6 @@ object CM {
   def initialValueArray(): CM[Code[mutable.ArrayBuffer[AnyRef]]] = fb().map(_.arg2)
 
   def st(): CM[AnyRef] = CM { (e, s) => (s.st, s) }
-  // def currentSymbolTable(): CM[SymbolTable] = CM { (e, s) => (s.st, s) }
-  // def ecNewPosition(): CM[(Int, mutable.ArrayBuffer[Any])] = CM { (e, s) =>
-  //   val idx = s.ec.a.length
-  //   val localA = s.ec.a
-  //   localA += null
-  //   ((idx, localA), s)
-  // }
-  // returns a thunk that looks up the result of this aggregation
-  // def addAggregation(lhs: AST, agg: Aggregator): CM[() => Any] = CM { (e, s) =>
-  //   val b = RefBox(null)
-  //   s.ec.aggregations += ((b, lhs.runAggregator(s.ec), agg))
-  //   (() => b.v, s)
-  // }
 
   def newLocal[T](implicit tti: TypeInfo[T]): CM[LocalRef[T]] = fb().map(_.newLocal[T])
   def memoize[T](mc: CM[Code[T]])(implicit tti: TypeInfo[T]): CM[(Code[Unit], Code[T])] = for (

--- a/src/main/scala/is/hail/asm4s/CM.scala
+++ b/src/main/scala/is/hail/asm4s/CM.scala
@@ -13,10 +13,6 @@ object preCM {
 
 import preCM._
 
-
-/**
-  * Created by dking on 4/19/17.
-  */
 case class CM[+T](mt: (E, S) => (T, S)) {
   def map[U](f: (T) => U): CM[U] = CM { (e, s1) =>
     val (t,s2) = mt(e,s1)

--- a/src/main/scala/is/hail/asm4s/CM.scala
+++ b/src/main/scala/is/hail/asm4s/CM.scala
@@ -1,20 +1,22 @@
-package is.hail.expr
-
-import is.hail.asm4s.{Code, _}
+package is.hail.asm4s
 
 import scala.collection.mutable
 import scala.reflect.ClassTag
 
 object preCM {
-  case class E(m: Map[String, (Type, Code[AnyRef])], fb: Function2Builder[Array[AnyRef],mutable.ArrayBuffer[AnyRef],AnyRef])
-  case class S(fa: Array[AnyRef], ec: EvalContext)
+  case class E(m: Map[String, (ClassTag[AnyRef], Code[AnyRef])], fb: Function2Builder[Array[AnyRef],mutable.ArrayBuffer[AnyRef],AnyRef])
+  case class S(fa: Array[AnyRef], st: AnyRef)
 
-  def emptyE = E(Map[String, (Type, Code[AnyRef])](), new Function2Builder[Array[AnyRef],mutable.ArrayBuffer[AnyRef],AnyRef]())
-  def emptyS(ec: EvalContext) = S(Array[AnyRef](), ec)
+  def emptyE = E(Map[String, (ClassTag[AnyRef], Code[AnyRef])](), new Function2Builder[Array[AnyRef],mutable.ArrayBuffer[AnyRef],AnyRef]())
+  def emptyS(ec: AnyRef) = S(Array[AnyRef](), ec)
 }
 
 import preCM._
 
+
+/**
+  * Created by dking on 4/19/17.
+  */
 case class CM[+T](mt: (E, S) => (T, S)) {
   def map[U](f: (T) => U): CM[U] = CM { (e, s1) =>
     val (t,s2) = mt(e,s1)
@@ -34,9 +36,9 @@ case class CM[+T](mt: (E, S) => (T, S)) {
   }
   def filter(test: (T) => Boolean): CM[T] = withFilter(test)
 
-  def run(ec: EvalContext)(implicit ev: T <:< Code[AnyRef]): () => AnyRef = {
+  def run(s0: AnyRef)(implicit ev: T <:< Code[AnyRef]): () => AnyRef = {
     val e = emptyE
-    val (code, s2) = mt(e,emptyS(ec))
+    val (code, s2) = mt(e,emptyS(s0))
     val primitiveFunctionArray = s2.fa.reverse
     val f = e.fb.result(code)
 
@@ -49,21 +51,21 @@ case class CM[+T](mt: (E, S) => (T, S)) {
       }
     }
   }
-  def run(bindings: Seq[(String, Type, AnyRef)], ec: EvalContext)(implicit ev: T <:< Code[AnyRef]): () => AnyRef = {
-    val typedNames = bindings.map { case (name, typ, _) => (name, typ) }
+  def run(bindings: Seq[(String, ClassTag[AnyRef], AnyRef)], s0: AnyRef)(implicit ev: T <:< Code[AnyRef]): () => AnyRef = {
+    val typedNames = bindings.map { case (name, ct, _) => (name, ct) }
     val values: mutable.ArrayBuffer[AnyRef] = bindings.map(_._3).to[mutable.ArrayBuffer]
-    val f: mutable.ArrayBuffer[AnyRef] => AnyRef = runWithDelayedValues(typedNames, ec)
+    val f: mutable.ArrayBuffer[AnyRef] => AnyRef = runWithDelayedValues(typedNames, s0)
 
     () => f(values)
   }
-  def runWithDelayedValues(typedNames: Seq[(String, Type)], ec: EvalContext)(implicit ev: T <:< Code[AnyRef]): mutable.ArrayBuffer[AnyRef] => AnyRef = {
+  def runWithDelayedValues(typedNames: Seq[(String, ClassTag[AnyRef])], s0: AnyRef)(implicit ev: T <:< Code[AnyRef]): mutable.ArrayBuffer[AnyRef] => AnyRef = {
     val e = emptyE
-    val codeBindings = typedNames.zipWithIndex.map { case ((name, typ), i) =>
-      (name, (typ, Code.checkcast(e.fb.arg2.invoke[Int, AnyRef]("apply", i))(typ.scalaClassTag)))
+    val codeBindings = typedNames.zipWithIndex.map { case ((name, ct), i) =>
+      (name, (ct, Code.checkcast(e.fb.arg2.invoke[Int, AnyRef]("apply", i))(ct)))
     }
     val e2 = e.copy(m = codeBindings.toMap)
 
-    val (code, s2) = mt(e2,emptyS(ec))
+    val (code, s2) = mt(e2,emptyS(s0))
     val primitiveFunctionArray = s2.fa.reverse
     val f = e2.fb.result(code)
 
@@ -87,7 +89,7 @@ object CM {
   def ret[T](t: T): CM[T] = CM((e,a) => (t, a))
 
   def fb(): CM[Function2Builder[Array[AnyRef],mutable.ArrayBuffer[AnyRef],AnyRef]] = CM { (e, s) => (e.fb, s) }
-  def availableBindings(): CM[Map[String, (Type, Code[AnyRef])]] = CM { case (e, s) => (e.m, s) }
+  def availableBindings(): CM[Map[String, (ClassTag[AnyRef], Code[AnyRef])]] = CM { case (e, s) => (e.m, s) }
 
   def addForeignFun(f: AnyRef): CM[Int] = CM { (e, s) => (s.fa.length, s.copy(fa = f +: s.fa)) }
   def foreignFunArray(): CM[Code[Array[AnyRef]]] = fb().map(_.arg1)
@@ -98,20 +100,20 @@ object CM {
 
   def initialValueArray(): CM[Code[mutable.ArrayBuffer[AnyRef]]] = fb().map(_.arg2)
 
-  def ec(): CM[EvalContext] = CM { (e, s) => (s.ec, s) }
-  def currentSymbolTable(): CM[SymbolTable] = CM { (e, s) => (s.ec.st, s) }
-  def ecNewPosition(): CM[(Int, mutable.ArrayBuffer[Any])] = CM { (e, s) =>
-    val idx = s.ec.a.length
-    val localA = s.ec.a
-    localA += null
-    ((idx, localA), s)
-  }
+  def st(): CM[AnyRef] = CM { (e, s) => (s.st, s) }
+  // def currentSymbolTable(): CM[SymbolTable] = CM { (e, s) => (s.st, s) }
+  // def ecNewPosition(): CM[(Int, mutable.ArrayBuffer[Any])] = CM { (e, s) =>
+  //   val idx = s.ec.a.length
+  //   val localA = s.ec.a
+  //   localA += null
+  //   ((idx, localA), s)
+  // }
   // returns a thunk that looks up the result of this aggregation
-  def addAggregation(lhs: AST, agg: Aggregator): CM[() => Any] = CM { (e, s) =>
-    val b = RefBox(null)
-    s.ec.aggregations += ((b, lhs.runAggregator(s.ec), agg))
-    (() => b.v, s)
-  }
+  // def addAggregation(lhs: AST, agg: Aggregator): CM[() => Any] = CM { (e, s) =>
+  //   val b = RefBox(null)
+  //   s.ec.aggregations += ((b, lhs.runAggregator(s.ec), agg))
+  //   (() => b.v, s)
+  // }
 
   def newLocal[T](implicit tti: TypeInfo[T]): CM[LocalRef[T]] = fb().map(_.newLocal[T])
   def memoize[T](mc: CM[Code[T]])(implicit tti: TypeInfo[T]): CM[(Code[Unit], Code[T])] = for (
@@ -123,22 +125,22 @@ object CM {
   ) yield (x.store(c), x.load().asInstanceOf[Code[T]])
 
   // references to its argument will be duplicated
-  def bindInRaw[T](name: String, typ: Type, c: Code[AnyRef])(body: CM[Code[T]]): CM[Code[T]] = CM { case (e, s) =>
+  def bindInRaw[T](name: String, typ: ClassTag[AnyRef], c: Code[AnyRef])(body: CM[Code[T]]): CM[Code[T]] = CM { case (e, s) =>
     body.mt(e.copy(m = e.m + ((name, (typ, c)))), s)
   }
-  def bindRepInRaw[T](bindings: Seq[(String, Type, CM[Code[AnyRef]])])(body: CM[Code[T]]): CM[Code[T]] = bindings match {
+  def bindRepInRaw[T](bindings: Seq[(String, ClassTag[AnyRef], CM[Code[AnyRef]])])(body: CM[Code[T]]): CM[Code[T]] = bindings match {
     case Seq() => body
     case Seq((name, typ, cmc), rest @ _*) =>
       cmc.flatMap(c => bindInRaw(name, typ, c)(bindRepInRaw(rest)(body)))
   }
   // its argument is stored in a local variable, only refernece to the variable
   // are dupliacted
-  def bindIn[T](name: String, typ: Type, c: Code[AnyRef])(body: CM[Code[T]]): CM[Code[T]] =
-    memoize(c).flatMap { case (st, v) => bindInRaw(name, typ, v)(body.map(x => Code(st, x))) }
-  def bindRepIn[T](bindings: Seq[(String, Type, CM[Code[AnyRef]])])(body: CM[Code[T]]): CM[Code[T]] = bindings match {
+  def bindIn[T](name: String, ct: ClassTag[AnyRef], c: Code[AnyRef])(body: CM[Code[T]]): CM[Code[T]] =
+    memoize(c).flatMap { case (st, v) => bindInRaw(name, ct, v)(body.map(x => Code(st, x))) }
+  def bindRepIn[T](bindings: Seq[(String, ClassTag[AnyRef], CM[Code[AnyRef]])])(body: CM[Code[T]]): CM[Code[T]] = bindings match {
     case Seq() => body
-    case Seq((name, typ, cmc), rest @ _*) =>
-      cmc.flatMap(c => bindIn(name, typ, c)(bindRepIn(rest)(body)))
+    case Seq((name, ct, cmc), rest @ _*) =>
+      cmc.flatMap(c => bindIn(name, ct, c)(bindRepIn(rest)(body)))
   }
   def lookup(name: String): CM[Code[AnyRef]] = CM { case (e, s) =>
     (e.m(name)._2, s)
@@ -165,16 +167,16 @@ object CM {
   def invokePrimitive6[A,B,C,D,E,F,R](fn: (A, B, C, D, E, F) => R)(a: Code[A], b: Code[B], c: Code[C], d: Code[D], e: Code[E], f: Code[F])
     (implicit act: ClassTag[A], bct: ClassTag[B], cct: ClassTag[C], dct: ClassTag[D], ect: ClassTag[E], fct: ClassTag[F], rct: ClassTag[R]) : CM[Code[R]] =
     foreignFun(fn).map(_.invoke[R]("apply", Array[Class[_]](act.runtimeClass, bct.runtimeClass, cct.runtimeClass, dct.runtimeClass, ect.runtimeClass, fct.runtimeClass), Array(a, b, c, d, e, f)))
-  def createLambda[T <: AnyRef](name: String, typ: Type, body: CM[Code[T]])(implicit tti: TypeInfo[T]): CM[Code[(AnyRef) => T]] = {
+  def createLambda[T <: AnyRef](name: String, ct: ClassTag[AnyRef], body: CM[Code[T]])(implicit tti: TypeInfo[T]): CM[Code[(AnyRef) => T]] = {
     val cc = (for (
       v <- initialValueArray();
-      result <- bindInRaw(name, typ, Code.checkcast(v.invoke[Int, AnyRef]("apply", 0))(typ.scalaClassTag))(body)
+      result <- bindInRaw(name, ct, Code.checkcast(v.invoke[Int, AnyRef]("apply", 0))(ct))(body)
     ) yield result)
     for (
       bindings <- availableBindings();
-      cvalues = CompilationHelp.arrayOf(bindings.map { case (_, (_, code)) => code }.toIndexedSeq);
-      ec <- ec();
-      compiledCode = cc.runWithDelayedValues((name, typ) +: bindings.map { case (name, (typ, _)) => (name, typ) }.toSeq, ec);
+      cvalues = CMHelp.arrayOf(bindings.map { case (_, (_, code)) => code }.toIndexedSeq);
+      st <- st();
+      compiledCode = cc.runWithDelayedValues((name, ct) +: bindings.map { case (name, (ct, _)) => (name, ct) }.toSeq, st);
       f <- invokePrimitive1(((vs: Array[AnyRef]) => (x: AnyRef) => compiledCode((x +: vs).to[mutable.ArrayBuffer])).asInstanceOf[AnyRef => AnyRef])(cvalues)
     ) yield f.asInstanceOf[Code[AnyRef => T]]
   }
@@ -204,6 +206,6 @@ object CM {
     Code.whileLoop(i < n,
       Code(b.update(i, newElement), i.store(i + 1))
     ),
-    CompilationHelp.arrayToWrappedArray(b)
+    CMHelp.arrayToWrappedArray(b)
   )
 }

--- a/src/main/scala/is/hail/asm4s/CMHelp.scala
+++ b/src/main/scala/is/hail/asm4s/CMHelp.scala
@@ -1,6 +1,6 @@
-package is.hail.expr
+package is.hail.asm4s
 
-import is.hail.asm4s.{Code, TypeInfo, _}
+import is.hail.expr.{TNumeric, Type}
 import org.objectweb.asm.Opcodes._
 import org.objectweb.asm.tree.{AbstractInsnNode, InsnNode}
 
@@ -9,11 +9,11 @@ import scala.collection.mutable
 import scala.reflect.ClassTag
 
 // Without this, we can't use invokeStatic with CompilationHelp as a type.
-case class CompilationHelp() {}
+case class CMHelp() {}
 
-object CompilationHelp {
+object CMHelp {
   def arrayToWrappedArray[T](a: Code[Array[T]])(implicit tct: ClassTag[T]): Code[IndexedSeq[T]] =
-    Code.invokeStatic[CompilationHelp, Array[T], mutable.WrappedArray[T]]("__arrayToWrappedArray", a)
+    Code.invokeStatic[CMHelp, Array[T], mutable.WrappedArray[T]]("__arrayToWrappedArray", a)
 
   def __arrayToWrappedArray(a: Array[Double]): mutable.WrappedArray[Double] = a
   def __arrayToWrappedArray(a: Array[Int]): mutable.WrappedArray[Int] = a

--- a/src/main/scala/is/hail/asm4s/CMHelp.scala
+++ b/src/main/scala/is/hail/asm4s/CMHelp.scala
@@ -8,7 +8,7 @@ import scala.collection.generic.Growable
 import scala.collection.mutable
 import scala.reflect.ClassTag
 
-// Without this, we can't use invokeStatic with CompilationHelp as a type.
+// Without this, we can't use invokeStatic with CMHelp as a type.
 case class CMHelp() {}
 
 object CMHelp {

--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -145,9 +145,10 @@ object Code {
 
   def _throw[T <: java.lang.Throwable, U](cerr: Code[T]): Code[U] = Code(cerr, new InsnNode(ATHROW))
 
-  def checkcast[T](v: Code[AnyRef])(implicit tct: ClassTag[T]): Code[T] = Code(
+
+  def checkcast[T](v: Code[AnyRef])(implicit tti: TypeInfo[T]): Code[T] = Code(
     v,
-    new TypeInsnNode(CHECKCAST, Type.getInternalName(tct.runtimeClass)))
+    new TypeInsnNode(CHECKCAST, tti.iname))
 
   def boxBoolean(cb: Code[Boolean]): Code[java.lang.Boolean] = Code.newInstance[java.lang.Boolean, Boolean](cb)
   def boxInt(ci: Code[Int]): Code[java.lang.Integer] = Code.newInstance[java.lang.Integer, Int](ci)

--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -1,6 +1,5 @@
 package is.hail.asm4s
 
-import is.hail.expr.CM
 import java.lang.reflect.{Constructor, Field, Method, Modifier}
 
 import org.objectweb.asm.Opcodes._

--- a/src/main/scala/is/hail/asm4s/package.scala
+++ b/src/main/scala/is/hail/asm4s/package.scala
@@ -14,6 +14,7 @@ package object asm4s {
 
   trait TypeInfo[T] {
     val name: String
+    val iname: String = name // override if T <: AnyRef
     val loadOp: Int
     val storeOp: Int
     val aloadOp: Int

--- a/src/main/scala/is/hail/asm4s/package.scala
+++ b/src/main/scala/is/hail/asm4s/package.scala
@@ -122,7 +122,7 @@ package object asm4s {
   implicit def classInfo[C <: AnyRef](implicit cct: ClassTag[C]): TypeInfo[C] = {
     new TypeInfo[C] {
       val name = Type.getDescriptor(cct.runtimeClass)
-      val iname = Type.getInternalName(cct.runtimeClass)
+      override val iname = Type.getInternalName(cct.runtimeClass)
       val loadOp = ALOAD
       val storeOp = ASTORE
       val aloadOp = AALOAD
@@ -136,7 +136,7 @@ package object asm4s {
   implicit def arrayInfo[T](implicit tct: ClassTag[Array[T]]): TypeInfo[Array[T]] = {
     new TypeInfo[Array[T]] {
       val name = Type.getDescriptor(tct.runtimeClass)
-      val iname = Type.getInternalName(tct.runtimeClass)
+      override val iname = Type.getInternalName(tct.runtimeClass)
       val loadOp = ALOAD
       val storeOp = ASTORE
       val aloadOp = AALOAD

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -236,7 +236,7 @@ sealed abstract class AST(pos: Position, subexprs: Array[AST] = Array.empty) {
   def runAggregator(ec: EvalContext): CPS[Any] = {
     val typedNames = ec.st.toSeq
       .sortBy { case (_, (i, _)) => i }
-      .map { case (name, (_, typ)) => (name, typ) }
+      .map { case (name, (_, typ)) => (name, typ.scalaClassTag.asInstanceOf[ClassTag[AnyRef]]) }
     val values = ec.a.asInstanceOf[mutable.ArrayBuffer[AnyRef]]
 
     val idx = ec.a.length
@@ -350,9 +350,9 @@ case class ArrayConstructor(posn: Position, elements: Array[AST]) extends AST(po
 
   def compile() = for (
     celements <- CM.sequence(elements.map(_.compile()));
-    convertedArray <- CompilationHelp.arrayOfWithConversion(`type`.asInstanceOf[TArray].elementType, celements))
+    convertedArray <- CMHelp.arrayOfWithConversion(`type`.asInstanceOf[TArray].elementType, celements))
   yield
-    CompilationHelp.arrayToWrappedArray(convertedArray)
+    CMHelp.arrayToWrappedArray(convertedArray)
 }
 
 case class StructConstructor(posn: Position, names: Array[String], elements: Array[AST]) extends AST(posn, elements) {
@@ -373,7 +373,7 @@ case class StructConstructor(posn: Position, names: Array[String], elements: Arr
 
   def compile() = for (
     celements <- CM.sequence(elements.map(_.compile()))
-  ) yield arrayToAnnotation(CompilationHelp.arrayOf(celements))
+  ) yield arrayToAnnotation(CMHelp.arrayOf(celements))
 }
 
 case class Lambda(posn: Position, param: String, body: AST) extends AST(posn, body) {
@@ -644,7 +644,8 @@ case class Let(posn: Position, bindings: Array[(String, AST)], body: AST) extend
 
   def compileAggregator(): CMCodeCPS[AnyRef] = throw new UnsupportedOperationException
 
-  def compile() = CM.bindRepIn(bindings.map { case (name, expr) => (name, expr.`type`, expr.compile()) })(body.compile())
+  def compile() =
+    CM.bindRepIn(bindings.map { case (name, expr) => (name, expr.`type`.scalaClassTag.asInstanceOf[ClassTag[AnyRef]], expr.compile()) })(body.compile())
 }
 
 case class SymRef(posn: Position, symbol: String) extends AST(posn) {

--- a/src/main/scala/is/hail/expr/Fun.scala
+++ b/src/main/scala/is/hail/expr/Fun.scala
@@ -1,6 +1,6 @@
 package is.hail.expr
 
-import is.hail.asm4s.Code
+import is.hail.asm4s.{CM, Code}
 
 sealed trait Fun {
   def retType: Type

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -4,7 +4,7 @@ import breeze.linalg.DenseVector
 import is.hail.annotations.Annotation
 import is.hail.asm4s.Code._
 import is.hail.asm4s.{Code, _}
-import is.hail.expr.CompilationHelp.arrayToWrappedArray
+import is.hail.asm4s.CMHelp.arrayToWrappedArray
 import is.hail.methods._
 import is.hail.stats._
 import is.hail.utils.EitherIsAMonad._

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -192,10 +192,10 @@ object FunctionRegistry {
             fb <- fb();
             bindings = (bodyST.toSeq
               .map { case (name, (i, typ)) =>
-              (name, typ.scalaClassTag.asInstanceOf[ClassTag[AnyRef]], ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", i))(typ.scalaClassTag)))
-            } :+ ((param, paramType.scalaClassTag.asInstanceOf[ClassTag[AnyRef]], ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", idx))(paramType.scalaClassTag)))));
+              (name, typ.scalaClassTag, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", i))(typ.scalaClassTag)))
+            } :+ ((param, paramType.scalaClassTag, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", idx))(paramType.scalaClassTag)))));
             res <- bindRepInRaw(bindings)(body.compile())
-          ) yield res).runWithDelayedValues(bodyST.toSeq.map { case (name, (_, typ)) => (name, typ.scalaClassTag.asInstanceOf[ClassTag[AnyRef]]) }, ec);
+          ) yield res).runWithDelayedValues(bodyST.toSeq.map { case (name, (_, typ)) => (name, typ.scalaClassTag) }, ec);
 
           g = (x: Any) => {
             localA(idx) = x
@@ -225,10 +225,10 @@ object FunctionRegistry {
             fb <- fb();
             bindings = (bodyST.toSeq
               .map { case (name, (i, typ)) =>
-              (name, typ.scalaClassTag.asInstanceOf[ClassTag[AnyRef]], ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", i))(typ.scalaClassTag)))
-            } :+ ((param, paramType.scalaClassTag.asInstanceOf[ClassTag[AnyRef]], ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", idx))(paramType.scalaClassTag)))));
+              (name, typ.scalaClassTag, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", i))(typ.scalaClassTag)))
+            } :+ ((param, paramType.scalaClassTag, ret(Code.checkcast(fb.arg2.invoke[Int, AnyRef]("apply", idx))(paramType.scalaClassTag)))));
             res <- bindRepInRaw(bindings)(body.compile())
-          ) yield res).runWithDelayedValues(bodyST.toSeq.map { case (name, (_, typ)) => (name, typ.scalaClassTag.asInstanceOf[ClassTag[AnyRef]]) }, ec);
+          ) yield res).runWithDelayedValues(bodyST.toSeq.map { case (name, (_, typ)) => (name, typ.scalaClassTag) }, ec);
 
           g = (x: Any) => {
             localA(idx) = x
@@ -276,7 +276,7 @@ object FunctionRegistry {
           f(xs.asInstanceOf[t], lam.asInstanceOf[Any => Any]).asInstanceOf[AnyRef])
 
         for (
-          lamc <- createLambda(param, paramType.scalaClassTag.asInstanceOf[ClassTag[AnyRef]], body.compile());
+          lamc <- createLambda(param, paramType.scalaClassTag, body.compile());
           res <- AST.evalComposeCodeM(args(0)) { xs =>
             invokePrimitive2[AnyRef, AnyRef, AnyRef](g)(xs, lamc)
           }
@@ -295,7 +295,7 @@ object FunctionRegistry {
           f(xs.asInstanceOf[t], lam.asInstanceOf[Any => Any], y.asInstanceOf[v]).asInstanceOf[AnyRef])
 
         for (
-          lamc <- createLambda(param, paramType.scalaClassTag.asInstanceOf[ClassTag[AnyRef]], body.compile());
+          lamc <- createLambda(param, paramType.scalaClassTag, body.compile());
           res <- AST.evalComposeCodeM(args(0), args(2)) { (xs, y) =>
             invokePrimitive3[AnyRef, AnyRef, AnyRef, AnyRef](g)(xs, lamc, y)
           }

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -46,7 +46,7 @@ object Parser extends JavaTokenParsers {
   private def evalNoTypeCheck(t: AST, ec: EvalContext): () => Any = {
     val typedNames = ec.st.toSeq
       .sortBy { case (name, (i, _)) => i }
-      .map { case (name, (_, typ)) => (name, typ.scalaClassTag.asInstanceOf[ClassTag[AnyRef]]) }
+      .map { case (name, (_, typ)) => (name, typ.typeInfo) }
     val f = t.compile().runWithDelayedValues(typedNames.toSeq, ec)
 
     // FIXME: ec.a is actually mutable.ArrayBuffer[AnyRef] because Annotation is

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -5,6 +5,7 @@ import is.hail.utils._
 import org.apache.spark.sql.Row
 
 import scala.collection.mutable
+import scala.reflect.ClassTag
 import scala.util.parsing.combinator.JavaTokenParsers
 import scala.util.parsing.input.Position
 
@@ -45,7 +46,7 @@ object Parser extends JavaTokenParsers {
   private def evalNoTypeCheck(t: AST, ec: EvalContext): () => Any = {
     val typedNames = ec.st.toSeq
       .sortBy { case (name, (i, _)) => i }
-      .map { case (name, (_, typ)) => (name, typ) }
+      .map { case (name, (_, typ)) => (name, typ.scalaClassTag.asInstanceOf[ClassTag[AnyRef]]) }
     val f = t.compile().runWithDelayedValues(typedNames.toSeq, ec)
 
     // FIXME: ec.a is actually mutable.ArrayBuffer[AnyRef] because Annotation is

--- a/src/main/scala/is/hail/expr/package.scala
+++ b/src/main/scala/is/hail/expr/package.scala
@@ -52,6 +52,7 @@ package object expr extends HailRepFunctions {
   def castCode[T](ti: TypeInfo[T], c: CM[Code[AnyRef]]): (TypeInfo[T], CM[Code[T]]) =
     (ti, c.map(Code.checkcast(_)(ti)))
 
-  def unsafeCastCode[T](ti: TypeInfo[T], c: CM[Code[AnyRef]]) = (ti, c.asInstanceOf[CM[Code[T]]])
+  def unsafeCastCode[T](ti: TypeInfo[T], c: CM[Code[AnyRef]]): (TypeInfo[T], CM[Code[T]]) =
+    (ti, c.asInstanceOf[CM[Code[T]]])
 
 }

--- a/src/main/scala/is/hail/expr/package.scala
+++ b/src/main/scala/is/hail/expr/package.scala
@@ -2,7 +2,7 @@ package is.hail
 
 import scala.collection.mutable
 import scala.language.implicitConversions
-import is.hail.asm4s.{CM, Code}
+import is.hail.asm4s.{CM, Code, TypeInfo}
 
 package object expr extends HailRepFunctions {
   type SymbolTable = Map[String, (Int, Type)]
@@ -48,5 +48,10 @@ package object expr extends HailRepFunctions {
     ec.aggregations += ((b, lhs.runAggregator(ec), agg))
     () => b.v
   }
+
+  def castCode[T](ti: TypeInfo[T], c: CM[Code[AnyRef]]): (TypeInfo[T], CM[Code[T]]) =
+    (ti, c.map(Code.checkcast(_)(ti)))
+
+  def unsafeCastCode[T](ti: TypeInfo[T], c: CM[Code[AnyRef]]) = (ti, c.asInstanceOf[CM[Code[T]]])
 
 }

--- a/src/main/scala/is/hail/expr/package.scala
+++ b/src/main/scala/is/hail/expr/package.scala
@@ -1,7 +1,8 @@
 package is.hail
 
+import scala.collection.mutable
 import scala.language.implicitConversions
-import is.hail.asm4s.Code
+import is.hail.asm4s.{CM, Code}
 
 package object expr extends HailRepFunctions {
   type SymbolTable = Map[String, (Int, Type)]
@@ -23,4 +24,29 @@ package object expr extends HailRepFunctions {
 
   type CPS[T] = (T => Unit) => Unit
   type CMCodeCPS[T] = (Code[T] => CM[Code[Unit]]) => CM[Code[Unit]]
+
+  def ec(): CM[EvalContext] =
+    CM.st().map(_.asInstanceOf[EvalContext])
+  def currentSymbolTable(): CM[SymbolTable] = for (
+    ec <- CM.st().map(_.asInstanceOf[EvalContext])
+  ) yield ec.st
+
+  def ecNewPosition(): CM[(Int, mutable.ArrayBuffer[Any])] = for (
+    ec <- CM.st().map(_.asInstanceOf[EvalContext])
+  ) yield {
+    val idx = ec.a.length
+    val localA = ec.a
+    localA += null
+    (idx, localA)
+  }
+
+  // returns a thunk that looks up the result of this aggregation
+  def addAggregation(lhs: AST, agg: Aggregator): CM[() => Any] =  for (
+    ec <- CM.st().map(_.asInstanceOf[EvalContext])
+  ) yield {
+    val b = RefBox(null)
+    ec.aggregations += ((b, lhs.runAggregator(ec), agg))
+    () => b.v
+  }
+
 }

--- a/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -1,5 +1,6 @@
 package is.hail.methods
 
+import is.hail.asm4s
 import is.hail.TestUtils._
 import is.hail.annotations.Annotation
 import is.hail.check.Prop._
@@ -147,7 +148,7 @@ class ExprSuite extends SparkSuite {
       .sortBy { case (name, (i, _)) => i }
       .map { case (name, (_, typ)) => (name, typ) }
       .zip(a)
-      .map { case ((name, typ), value) => (name, typ.scalaClassTag.asInstanceOf[ClassTag[AnyRef]], value.asInstanceOf[AnyRef]) }
+      .map { case ((name, typ), value) => (name, (typ.typeInfo.asInstanceOf[asm4s.TypeInfo[AnyRef]], value.asInstanceOf[AnyRef])) }
 
     def eval[T](s: String): Option[T] = {
       val compiledCode = Parser.parseToAST(s, ec).compile().run(bindings, ec)

--- a/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -16,6 +16,8 @@ import org.scalatest.Matchers._
 import org.scalatest._
 import org.testng.annotations.Test
 
+import scala.reflect.ClassTag
+
 class ExprSuite extends SparkSuite {
 
   @Test def compileTest() {
@@ -145,7 +147,7 @@ class ExprSuite extends SparkSuite {
       .sortBy { case (name, (i, _)) => i }
       .map { case (name, (_, typ)) => (name, typ) }
       .zip(a)
-      .map { case ((name, typ), value) => (name, typ, value.asInstanceOf[AnyRef]) }
+      .map { case ((name, typ), value) => (name, typ.scalaClassTag.asInstanceOf[ClassTag[AnyRef]], value.asInstanceOf[AnyRef]) }
 
     def eval[T](s: String): Option[T] = {
       val compiledCode = Parser.parseToAST(s, ec).compile().run(bindings, ec)


### PR DESCRIPTION
Now the CM carries around an opaque `AnyRef` state value. It probably
shouldn't even carry this around, but this works for now. The extra
state value will be completely eliminated anyway in a follow up pull
request.

All references to `Type` in the CM were converted to `ClassTag`, which
is the only information we actually need.