### PR TITLE
hail.vep.assembly setting to allow assemblies other than GRCh37

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -4170,8 +4170,10 @@ class VariantDataset(object):
         - **hail.vep.location** -- Location of the VEP Perl script.  Required.
         - **hail.vep.cache_dir** -- Location of the VEP cache dir, passed to VEP with the `--dir` option.  Required.
         - **hail.vep.fasta** -- Location of the FASTA file to use to look up the reference sequence, passed to VEP with the `--fasta` option.  Required.
-        - **hail.vep.lof.human_ancestor** -- Location of the human ancestor file for the LOFTEE plugin.  Required.
-        - **hail.vep.lof.conservation_file** -- Location of the conservation file for the LOFTEE plugin.  Required.
+        - **hail.vep.plugin** -- VEP plugin, passed to VEP with the `--plugin` option.  Optional. Overrides `hail.vep.lof.human_ancestor` and `hail.vep.lof.conservation_file`.
+        - **hail.vep.lof.human_ancestor** -- Location of the human ancestor file for the LOFTEE plugin.  Ignored if `hail.vep.plugin` is set. Required otherwise.
+        - **hail.vep.lof.conservation_file** -- Location of the conservation file for the LOFTEE plugin.  Ignored if `hail.vep.plugin` is set. Required otherwise.
+
 
         Here is an example `vep.properties` configuration file
 

--- a/src/main/scala/is/hail/methods/VEP.scala
+++ b/src/main/scala/is/hail/methods/VEP.scala
@@ -244,13 +244,21 @@ object VEP {
     if (cacheDir == null)
       fatal("property `hail.vep.cache_dir' required")
 
-    val humanAncestor = properties.getProperty("hail.vep.lof.human_ancestor")
-    if (humanAncestor == null)
-      fatal("property `hail.vep.lof.human_ancestor' required")
 
-    val conservationFile = properties.getProperty("hail.vep.lof.conservation_file")
-    if (conservationFile == null)
-      fatal("property `hail.vep.lof.conservation_file' required")
+    val plugin = if (properties.getProperty("hail.vep.plugin") != null) {
+         properties.getProperty("hail.vep.plugin")
+    } else {
+
+        val humanAncestor = properties.getProperty("hail.vep.lof.human_ancestor")
+        if (humanAncestor == null)
+          fatal("property `hail.vep.lof.human_ancestor' required")
+
+        val conservationFile = properties.getProperty("hail.vep.lof.conservation_file")
+        if (conservationFile == null)
+          fatal("property `hail.vep.lof.conservation_file' required")
+
+        s"LoF,human_ancestor_fa:$humanAncestor,filter_position:0.05,min_intron_size:15,conservation_file:$conservationFile"
+    }
 
     val fasta = properties.getProperty("hail.vep.fasta")
     if (fasta == null)
@@ -261,11 +269,6 @@ object VEP {
       warn("property `hail.vep.assembly' not specified. Setting to GRCh37")
       assembly = "GRCh37"
     }
-
-    var plugins = s"LoF,human_ancestor_fa:$humanAncestor,filter_position:0.05,min_intron_size:15,conservation_file:$conservationFile"
-    val extraPlugins = properties.getProperty("hail.vep.extra_plugins")
-    if (extraPlugins != null)
-        plugins = s"$plugins,$extraPlugins"
 
     val cmd =
       Array(
@@ -281,7 +284,7 @@ object VEP {
         "--fasta", s"$fasta",
         "--minimal",
         "--assembly", s"$assembly",
-        "--plugin", s"$plugins",
+        "--plugin", s"$plugin",
         "-o", "STDOUT")
 
     val inputQuery = vepSignature.query("input")

--- a/src/main/scala/is/hail/methods/VEP.scala
+++ b/src/main/scala/is/hail/methods/VEP.scala
@@ -256,6 +256,17 @@ object VEP {
     if (fasta == null)
       fatal("property `hail.vep.fasta' required")
 
+    var assembly = properties.getProperty("hail.vep.assembly")
+    if (assembly == null) {
+      warn("property `hail.vep.assembly' not specified. Setting to GRCh37")
+      assembly = "GRCh37"
+    }
+
+    var plugins = s"LoF,human_ancestor_fa:$humanAncestor,filter_position:0.05,min_intron_size:15,conservation_file:$conservationFile"
+    val extraPlugins = properties.getProperty("hail.vep.extra_plugins")
+    if (extraPlugins != null)
+        plugins = s"$plugins,$extraPlugins"
+
     val cmd =
       Array(
         perl,
@@ -269,8 +280,8 @@ object VEP {
         "--dir", s"$cacheDir",
         "--fasta", s"$fasta",
         "--minimal",
-        "--assembly", "GRCh37",
-        "--plugin", s"LoF,human_ancestor_fa:$humanAncestor,filter_position:0.05,min_intron_size:15,conservation_file:$conservationFile",
+        "--assembly", s"$assembly",
+        "--plugin", s"$plugins",
         "-o", "STDOUT")
 
     val inputQuery = vepSignature.query("input")
@@ -365,7 +376,7 @@ object VEP {
 
             val rc = proc.waitFor()
             if (rc != 0)
-              fatal(s"vep command failed with non-zero exit status $rc")
+              fatal(s"vep command '${cmd.mkString(" ")}' failed with non-zero exit status $rc")
 
             r
           }


### PR DESCRIPTION
Also, added hail.vep.extra_plugins for specifying additional plugins beyond the default ones (such as LoF_splice.pm for predicting variants' probability of splice junction disruption or creation)