### PR TITLE
remove TChar

### DIFF
--- a/src/main/scala/is/hail/annotations/Annotation.scala
+++ b/src/main/scala/is/hail/annotations/Annotation.scala
@@ -36,7 +36,6 @@ object Annotation {
   }
 
   def expandType(t: Type): Type = t match {
-    case TChar => TString
     case TVariant => Variant.expandedType
     case TGenotype => Genotype.expandedType
     case TLocus => Locus.expandedType

--- a/src/main/scala/is/hail/expr/AnnotationImpex.scala
+++ b/src/main/scala/is/hail/expr/AnnotationImpex.scala
@@ -111,7 +111,6 @@ object SparkAnnotationImpex extends AnnotationImpex[DataType, Any] {
     case TFloat => FloatType
     case TDouble => DoubleType
     case TString => StringType
-    case TChar => StringType
     case TBinary => BinaryType
     case TArray(elementType) => ArrayType(exportType(elementType))
     case TSet(elementType) => ArrayType(exportType(elementType))
@@ -262,7 +261,6 @@ object JSONAnnotationImpex extends AnnotationImpex[Type, JValue] {
     else {
       (t: @unchecked) match {
         case TBoolean => JBool(a.asInstanceOf[Boolean])
-        case TChar => JString(a.asInstanceOf[String])
         case TInt => JInt(a.asInstanceOf[Int])
         case TLong => JInt(a.asInstanceOf[Long])
         case TFloat => JDouble(a.asInstanceOf[Float])
@@ -313,7 +311,6 @@ object JSONAnnotationImpex extends AnnotationImpex[Type, JValue] {
       case (JString("-Infinity"), TFloat) => Float.NegativeInfinity
       case (JDouble(x), TFloat) => x.toFloat
       case (JString(x), TString) => x
-      case (JString(x), TChar) => x
       case (JString(x), TInt) =>
         x.toInt
       case (JString(x), TDouble) =>
@@ -434,7 +431,6 @@ object TableAnnotationImpex extends AnnotationImpex[Unit, String] {
         case Array(ref, alt) => AltAllele(ref, alt)
       }
       case TGenotype => JSONAnnotationImpex.importAnnotation(JsonMethods.parse(a), t)
-      case TChar => a
       case t: TArray => JSONAnnotationImpex.importAnnotation(JsonMethods.parse(a), t)
       case t: TSet => JSONAnnotationImpex.importAnnotation(JsonMethods.parse(a), t)
       case t: TDict => JSONAnnotationImpex.importAnnotation(JsonMethods.parse(a), t)

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -2506,7 +2506,7 @@ object FunctionRegistry {
         let s = "genetics" in s[6]
         result: "c"
     """, "i" -> "Index of the character to return."
-  )(stringHr, intHr, charHr)
+  )(stringHr, intHr, stringHr)
 
   registerMethod("[:]", (a: IndexedSeq[Any]) => a,
     """

--- a/src/main/scala/is/hail/expr/HailRep.scala
+++ b/src/main/scala/is/hail/expr/HailRep.scala
@@ -14,10 +14,6 @@ trait HailRepFunctions {
     def typ = TBoolean
   }
 
-  object charHr extends HailRep[String] {
-    def typ = TChar
-  }
-
   implicit object intHr extends HailRep[Int] {
     def typ = TInt
   }

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -527,7 +527,7 @@ object Parser extends JavaTokenParsers {
     "Empty" ^^ { _ => TStruct.empty } |
       "Interval" ^^ { _ => TInterval } |
       "Boolean" ^^ { _ => TBoolean } |
-      "Char" ^^ { _ => TChar } |
+      "Char" ^^ { _ => TString } | // FIXME backward-compatibility, remove this at some point
       "Int" ^^ { _ => TInt } |
       "Long" ^^ { _ => TLong } |
       "Float" ^^ { _ => TFloat } |

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -16,7 +16,7 @@ import scala.reflect.ClassTag
 import scala.reflect.classTag
 
 object Type {
-  val genScalar = Gen.oneOf[Type](TBoolean, TChar, TInt, TLong, TFloat, TDouble, TString,
+  val genScalar = Gen.oneOf[Type](TBoolean, TInt, TLong, TFloat, TDouble, TString,
     TVariant, TAltAllele, TGenotype, TLocus, TInterval, TCall)
 
   def genSized(size: Int): Gen[Type] = {
@@ -187,22 +187,6 @@ case object TBoolean extends Type {
 
   def ordering(missingGreatest: Boolean): Ordering[Annotation] =
     extendOrderingToNull(missingGreatest)(implicitly[Ordering[Boolean]])
-}
-
-case object TChar extends Type {
-  override def toString = "Char"
-
-  def typeCheck(a: Any): Boolean = a == null || (a.isInstanceOf[String]
-    && a.asInstanceOf[String].length == 1)
-
-  override def genNonmissingValue: Gen[Annotation] = arbitrary[String]
-    .filter(_.nonEmpty)
-    .map(s => s.substring(0, 1))
-
-  override def scalaClassTag: ClassTag[java.lang.String] = classTag[java.lang.String]
-
-  def ordering(missingGreatest: Boolean): Ordering[Annotation] =
-    extendOrderingToNull(missingGreatest)(implicitly[Ordering[String]])
 }
 
 object TNumeric {

--- a/src/main/scala/is/hail/io/CassandraConnector.scala
+++ b/src/main/scala/is/hail/io/CassandraConnector.scala
@@ -52,7 +52,6 @@ object CassandraImpex {
     case TFloat => DataType.cfloat()
     case TDouble => DataType.cdouble()
     case TString => DataType.text()
-    case TChar => DataType.text()
     case TBinary => DataType.blob()
     case TCall => DataType.cint()
     case TArray(elementType) => DataType.list(exportType(elementType, depth + 1), depth == 1)
@@ -107,7 +106,6 @@ object CassandraImpex {
     case TFloat => a
     case TDouble => a
     case TString => a
-    case TChar => a
     case TBinary => ByteBuffer.wrap(a.asInstanceOf[Array[Byte]])
     case TCall => a
     case TArray(elementType) =>

--- a/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -1,7 +1,7 @@
 package is.hail.io.vcf
 
 import is.hail.annotations.{Annotation, Querier}
-import is.hail.expr.{Field, TArray, TBoolean, TCall, TChar, TDouble, TFloat, TGenotype, TInt, TIterable, TLong, TSet, TString, TStruct, Type}
+import is.hail.expr.{Field, TArray, TBoolean, TCall, TDouble, TFloat, TGenotype, TInt, TIterable, TLong, TSet, TString, TStruct, Type}
 import is.hail.utils._
 import is.hail.variant.{Call, GenericDataset, Genotype, Variant}
 import org.apache.spark.sql.Row
@@ -93,7 +93,6 @@ object ExportVCF {
     case TLong => "Integer"
     case TDouble => "Float"
     case TFloat => "Float"
-    case TChar => "Character"
     case TString => "String"
     case TBoolean => "Flag"
     case _ => fatal(s"Cannot export type `$t' to VCF INFO field.")
@@ -106,7 +105,6 @@ object ExportVCF {
     case TLong => "Integer"
     case TDouble => "Float"
     case TFloat => "Float"
-    case TChar => "Character"
     case TString => "String"
     case TCall => "String"
     case _ => fatal(s"Cannot export type `$t' to VCF FORMAT field.")
@@ -189,7 +187,6 @@ object ExportVCF {
   def validFormatType(typ: Type): Boolean = {
     typ match {
       case TString => true
-      case TChar => true
       case TDouble => true
       case TFloat => true
       case TInt => true

--- a/src/main/scala/is/hail/io/vcf/HtsjdkRecordReader.scala
+++ b/src/main/scala/is/hail/io/vcf/HtsjdkRecordReader.scala
@@ -351,12 +351,9 @@ object HtsjdkRecordReader {
         s.split(",").map(x => (if (x == ".") null else x.toDouble): java.lang.Double): IndexedSeq[java.lang.Double]
       case (s: String, TArray(TString)) =>
         s.split(",").map(x => if (x == ".") null else x): IndexedSeq[String]
-      case (s: String, TArray(TChar)) =>
-        s.split(",").map(x => if (x == ".") null else x): IndexedSeq[String]
       case (s: String, TBoolean) => s.toBoolean
       case (b: Boolean, TBoolean) => b
       case (s: String, TString) => s
-      case (s: String, TChar) => s
       case (s: String, TInt) => s.toInt
       case (s: String, TDouble) => if (s == "nan") Double.NaN else s.toDouble
 
@@ -389,8 +386,6 @@ object HtsjdkRecordReader {
           case i: Int => i.toString
           case d: Double => d.toString
         }.toArray[String]: IndexedSeq[String]
-      case (l: java.util.List[_], TArray(TChar)) =>
-        l.asScala.iterator.map(_.asInstanceOf[String]).toArray[String]: IndexedSeq[String]
 
       case (i: Int, TCall) => i
       case (s: String, TCall) => s.toInt

--- a/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -166,7 +166,7 @@ object LoadVCF {
       case (VCFHeaderLineType.Float, false) => TDouble
       case (VCFHeaderLineType.String, true) => TCall
       case (VCFHeaderLineType.String, false) => TString
-      case (VCFHeaderLineType.Character, false) => TChar
+      case (VCFHeaderLineType.Character, false) => TString
       case (VCFHeaderLineType.Flag, false) => TBoolean
       case (_, true) => fatal(s"Can only convert a header line with type `String' to a Call Type. Found `${ line.getType }'.")
     }

--- a/src/test/scala/is/hail/vds/FilterAllelesSuite.scala
+++ b/src/test/scala/is/hail/vds/FilterAllelesSuite.scala
@@ -3,7 +3,7 @@ package is.hail.vds
 import is.hail.SparkSuite
 import is.hail.annotations._
 import is.hail.check.Prop
-import is.hail.expr.{TChar, TStruct}
+import is.hail.expr.{TString, TStruct}
 import is.hail.utils._
 import is.hail.variant.{AltAllele, Genotype, VSMSubgen, Variant, VariantMetadata, VariantSampleMatrix}
 import org.testng.annotations.Test
@@ -37,9 +37,9 @@ class FilterAllelesSuite extends SparkSuite {
     val vds = VariantSampleMatrix(hc, VariantMetadata(Array("1", "2", "3"),
       IndexedSeq[Annotation](null, null, null),
       null,
-      TChar,
+      TString,
       TStruct.empty,
-      TChar),
+      TString),
       sc.parallelize(Seq(row1)).toOrderedRDD)
       .filterAlleles("aIndex == 2", subset = false, keep = false)
 
@@ -66,9 +66,9 @@ class FilterAllelesSuite extends SparkSuite {
     val vds = VariantSampleMatrix(hc, VariantMetadata(Array("1", "2", "3"),
       IndexedSeq[Annotation](null, null, null),
       null,
-      TChar,
+      TString,
       TStruct.empty,
-      TChar),
+      TString),
       sc.parallelize(Seq(row1)).toOrderedRDD)
       .filterAlleles("aIndex == 1", subset = false, keep = false)
 
@@ -95,9 +95,9 @@ class FilterAllelesSuite extends SparkSuite {
     val vds = VariantSampleMatrix(hc, VariantMetadata(Array("1", "2", "3"),
       IndexedSeq[Annotation](null, null, null),
       null,
-      TChar,
+      TString,
       TStruct.empty,
-      TChar),
+      TString),
       sc.parallelize(Seq(row1)).toOrderedRDD)
       .filterAlleles("aIndex == 1", subset = true, keep = false)
 
@@ -124,9 +124,9 @@ class FilterAllelesSuite extends SparkSuite {
     val vds = VariantSampleMatrix(hc, VariantMetadata(Array("1", "2", "3"),
       IndexedSeq[Annotation](null, null, null),
       null,
-      TChar,
+      TString,
       TStruct.empty,
-      TChar),
+      TString),
       sc.parallelize(Seq(row1)).toOrderedRDD)
       .filterAlleles("aIndex == 2", subset = true, keep = false)
 
@@ -153,9 +153,9 @@ class FilterAllelesSuite extends SparkSuite {
     val vds = VariantSampleMatrix(hc, VariantMetadata(Array("1", "2", "3"),
       IndexedSeq[Annotation](null, null, null),
       null,
-      TChar,
+      TString,
       TStruct.empty,
-      TChar),
+      TString),
       sc.parallelize(Seq(row1)).toOrderedRDD)
       .filterAlleles("aIndex == 2", subset = true, keep = false, filterAlteredGenotypes = true)
 
@@ -179,9 +179,9 @@ class FilterAllelesSuite extends SparkSuite {
     val vds = VariantSampleMatrix(hc, VariantMetadata(Array("1", "2", "3"),
       IndexedSeq[Annotation](null, null, null),
       null,
-      TChar,
+      TString,
       TStruct.empty,
-      TChar),
+      TString),
       sc.parallelize(Seq(row1)).toOrderedRDD)
       .filterAlleles("aIndex == 2", keep = false, subset = false, annotationExpr = "va = aIndices")
 


### PR DESCRIPTION
Data formats that use Characters (including old VDSes) will now be loaded as `TString`s.

Resolves #1710