### PR TITLE
Fix: TakeBy Merge Bug, TakeBy Result Not Ordered

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ if (!(sparkVersion ==~ /^2\..*/))
 
 String scalaVersion = '2.11.8'
 String scalaMajorVersion = '2.11'
-String breezeVersion = '0.11.2'
+String breezeVersion = '0.12'
 
 String py4jVersion
 if (sparkVersion ==~ /^2\.1.*/)

--- a/src/main/scala/is/hail/methods/Aggregators.scala
+++ b/src/main/scala/is/hail/methods/Aggregators.scala
@@ -608,7 +608,7 @@ class TakeByAggregator[T](var f: (Any) => Any, var n: Int)(implicit var tord: Or
   else
     null
 
-  def result = _state.toArray[(Any, Any)].map(_._1).reverse: IndexedSeq[Any]
+  def result = _state.clone.dequeueAll.toArray[(Any, Any)].map(_._1).reverse: IndexedSeq[Any]
 
   def seqOp(x: Any) = seqOp(x, f(x))
 

--- a/src/main/scala/is/hail/methods/Aggregators.scala
+++ b/src/main/scala/is/hail/methods/Aggregators.scala
@@ -610,8 +610,10 @@ class TakeByAggregator[T](var f: (Any) => Any, var n: Int)(implicit var tord: Or
 
   def result = _state.toArray[(Any, Any)].map(_._1).reverse: IndexedSeq[Any]
 
-  def seqOp(x: Any) = {
-    val p = (x, f(x))
+  def seqOp(x: Any) = seqOp(x, f(x))
+
+  private def seqOp(x: Any, sortKey: Any) = {
+    val p = (x, sortKey)
     if (_state.length < n)
       _state += p
     else {
@@ -623,7 +625,7 @@ class TakeByAggregator[T](var f: (Any) => Any, var n: Int)(implicit var tord: Or
   }
 
   def combOp(agg2: this.type) {
-    agg2._state.foreach { case (x, p) => seqOp(x) }
+    agg2._state.foreach { case (x, p) => seqOp(x, p) }
   }
 
   def copy() = new TakeByAggregator(f, n)

--- a/src/test/scala/is/hail/methods/AggregatorSuite.scala
+++ b/src/test/scala/is/hail/methods/AggregatorSuite.scala
@@ -310,7 +310,7 @@ class AggregatorSuite extends SparkSuite {
 
   private def equalModuloDisordering[T,K](orderOn: T => K)(xs: Seq[T], ys: Seq[T]): Boolean = {
     val sameOrdering = xs.zip(ys).forall { case (x, y) => orderOn(x) == orderOn(y) }
-    val sameElements = (xs.groupBy(orderOn) zip ys.groupBy(orderOn)).forall { case (xs, ys) => xs.toSet == ys.toSet }
+    val sameElements = (xs.groupBy(orderOn) zip ys.groupBy(orderOn)).forall { case ((_, xs), (_, ys)) => xs.toSet == ys.toSet }
 
     sameOrdering && sameElements
   }

--- a/src/test/scala/is/hail/methods/AggregatorSuite.scala
+++ b/src/test/scala/is/hail/methods/AggregatorSuite.scala
@@ -324,7 +324,7 @@ class AggregatorSuite extends SparkSuite {
         "gs.map(g => [g.dp, g.gq]).takeBy(x => x[1], 10)"))
       val x = a.asInstanceOf[IndexedSeq[IndexedSeq[Int]]]
       val y = b.asInstanceOf[IndexedSeq[IndexedSeq[Int]]]
-      if (equalModuloDisordering(x, y)) {
+      if (!equalModuloDisordering((x: Seq[Int]) => x(1))(x, y)) {
         println(s"The following IndexedSeqs were not the same up to irrelevant disorderings\n$x\n$y")
         false
       } else {
@@ -342,7 +342,7 @@ class AggregatorSuite extends SparkSuite {
         "gs.map(g => [g.dp, g.gq]).takeBy(x => g.gq, 10)"))
       val x = a.asInstanceOf[IndexedSeq[IndexedSeq[Int]]]
       val y = b.asInstanceOf[IndexedSeq[IndexedSeq[Int]]]
-      if (equalModuloDisordering(x, y)) {
+      if (!equalModuloDisordering((x: Seq[Int]) => x(1))(x, y)) {
         println(s"The following IndexedSeqs were not the same up to irrelevant disorderings\n$x\n$y")
         false
       } else {


### PR DESCRIPTION
 - In the `combOp`, the `TakeByAggregator` was calling the `seqOp` which recomputes the sort-key. Since the evaluation context was not set correctly for the keys, the expression that evaluates the sort-key obviously produced the wrong value for the given key.

 - `TakeByAggregator.result` used `PriorityQueue.toArray`, which is not guaranteed to produce the elements in sorted order, according to [the PriorityQueue docs](http://www.scala-lang.org/api/current/scala/collection/mutable/PriorityQueue.html). Instead, we must `clone` the `PriorityQueue` and then `dequeueAll` the elements. I'm not certain the `clone` is necessary. @cseed, does the Aggregator interface permit multiple calls to `result`?

> Only the dequeue and dequeueAll methods will return elements in priority order (while removing elements from the heap). Standard collection methods including drop, iterator, and toString will remove or traverse the heap in whichever order seems most convenient.

I also added some fairly robust tests that compare `takeBy(f, 10)` to `collect().sortBy(f)`. In particular: 
 - the `takeBy` should be a prefix of `sortBy` when lensing by `f`,
 - for every sort-key except last one, the elements should be the same as in `sortBy`, and
 - for the last sort-key, the elements should be a subset of those in `sortBy`
