### PR TITLE
added aggregate_by_sample_and_variant_key

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -234,12 +234,13 @@ class VariantDataset(object):
 
     @handle_py4j
     def aggregate_by_sample_and_variant_key(self, key_name, variant_keys, single_key, agg_expr):
-        r"""Aggregate values per sample and variant key using a user-defined aggregation expression to produce a
+        r"""Aggregate values by sample and variant key using a user-defined aggregation expression to produce a
         KeyTable with a key column, a column for each sample, and a row for each key.
 
         **Examples**
         Make a key table with the maximum genotype per gene per sample. Here ``va.genes`` is a variant annotation
-        of type Set[String] giving the set of genes containing the variant.
+        of type Set[String] giving the set of genes containing the variant, and the variant dataset is bi-allelic
+        so ``g.gt`` takes values 0, 1, 2, or missing.
 
         >>> kt = (hc.read('data/example_burden.vds')
         ...     .aggregate_by_sample_and_variant_key(key_name='gene',
@@ -272,8 +273,8 @@ class VariantDataset(object):
 
         **Notes**
 
-        For each key and sample, this method aggregate genotypes across variants with that key to produce a numeric score.
-           ``agg_expr`` must be of numeric type and has the following symbols are in scope:
+        For each sample and key, this method aggregate values across variants with that key.
+           ``agg_expr`` has the following symbols are in scope:
 
            - ``s`` (*Sample*): sample
            - ``sa``: sample annotations
@@ -283,7 +284,7 @@ class VariantDataset(object):
            Note that ``v``, ``va``, and ``g`` are accessible through
            `Aggregable methods <https://hail.is/hail/types.html#aggregable>`_ on ``gs``.
 
-           The resulting key table has key column ``key_name`` and a column of aggregated values for each sample
+           The resulting key table has key column ``key_name`` and a column of aggregated results for each sample
            named by the sample ID.
 
         **Extended example**

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -273,19 +273,25 @@ class VariantDataset(object):
 
         **Notes**
 
-        For each sample and key, this method aggregate values across variants with that key.
-           ``agg_expr`` has the following symbols are in scope:
+        To run linear or logistic burden tests on the resulting key table, use :py:meth:`.linreg_burden` or
+        :py:meth:`.logreg_burden` instead. The sample key table produced by those methods is the same
+        as the key table produced by :py:meth:`.aggregate_by_sample_and_variant_key` except that in the former those
+        columns corresponding to samples missing a phenotype or covariate dropped. Unlike those methods,
+        :py:meth:`.aggregate_by_sample_and_variant_key` does not require aggregate values to have numeric type.
+
+        For each sample and key, this method computes a value using the ``agg_expr``, which has
+        the following symbols are in scope:
 
            - ``s`` (*Sample*): sample
            - ``sa``: sample annotations
            - ``global``: global annotations
            - ``gs`` (*Aggregable[Genotype]*): aggregable of :ref:`genotype` for sample ``s``
 
-           Note that ``v``, ``va``, and ``g`` are accessible through
-           `Aggregable methods <https://hail.is/hail/types.html#aggregable>`_ on ``gs``.
+        Note that ``v``, ``va``, and ``g`` are accessible through
+        `Aggregable methods <https://hail.is/hail/types.html#aggregable>`_ on ``gs``.
 
-           The resulting key table has key column ``key_name`` and a column of aggregated results for each sample
-           named by the sample ID.
+        The resulting key table has key column ``key_name`` and a column of aggregated results for each sample
+        named by the sample ID.
 
         **Extended example**
 
@@ -2720,13 +2726,11 @@ class VariantDataset(object):
         r"""Test each keyed group of variants for association by aggregating (collapsing) genotypes and applying the
         linear regression model.
 
-        .. include:: requireTGenotype.rst
-
         **Examples**
 
         Run a gene burden test using linear regression on the maximum genotype per gene. Here ``va.genes`` is a variant
         annotation of type Set[String] giving the set of genes containing the variant (see **Extended example** below
-        for a deep dive):
+        for a deep dive), and the variant dataset is bi-allelic so ``g.gt`` takes values 0, 1, 2, or missing:
 
         >>> linreg_kt, sample_kt = (hc.read('data/example_burden.vds')
         ...     .linreg_burden(key_name='gene',
@@ -3305,13 +3309,12 @@ class VariantDataset(object):
         r"""Test each keyed group of variants for association by aggregating (collapsing) genotypes and applying the
         logistic regression model.
 
-        .. include:: requireTGenotype.rst
-
         **Examples**
 
         Run a gene burden test using the logistic Wald test on the maximum genotype per gene. Here ``va.genes`` is
         a variant annotation of type Set[String] giving the set of genes containing the variant
-        (see **Extended example** in :py:meth:`.linreg_burden` for a deeper  dive in the context of linear regression):
+        (see **Extended example** in :py:meth:`.linreg_burden` for a deeper  dive in the context of linear regression),
+        and the variant dataset is bi-allelic so ``g.gt`` takes values 0, 1, 2, or missing:
 
         >>> logreg_kt, sample_kt = (hc.read('data/example_burden.vds')
         ...     .logreg_burden(key_name='gene',

--- a/src/main/scala/is/hail/methods/LinearRegressionBurden.scala
+++ b/src/main/scala/is/hail/methods/LinearRegressionBurden.scala
@@ -40,7 +40,7 @@ object LinearRegressionBurden {
       fatal(s"Key name '$keyName' clashes with reserved linreg columns $linregFields")
 
     def sampleKT = vds.filterSamples((s, sa) => completeSamplesSet(s))
-      .aggregateBySamplePerVariantKey(keyName, variantKeys, aggExpr, singleKey)
+      .aggregateBySampleAndVariantKey(keyName, variantKeys, singleKey, aggExpr)
       .cache()
 
     val keyType = sampleKT.fields(0).typ

--- a/src/main/scala/is/hail/methods/LogisticRegressionBurden.scala
+++ b/src/main/scala/is/hail/methods/LogisticRegressionBurden.scala
@@ -53,7 +53,7 @@ object LogisticRegressionBurden {
     info(s"Aggregating variants by '$keyName' for $n samples...")
 
     def sampleKT = vds.filterSamples((s, sa) => completeSamplesSet(s))
-      .aggregateBySamplePerVariantKey(keyName, variantKeys, aggExpr, singleKey)
+      .aggregateBySampleAndVariantKey(keyName, variantKeys, singleKey, aggExpr)
       .cache()
 
     val keyType = sampleKT.fields(0).typ

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -210,7 +210,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VariantMetadata,
   }
 
 
-  def aggregateBySamplePerVariantKey(keyName: String, variantKeysVA: String, aggExpr: String, singleKey: Boolean = false): KeyTable = {
+  def aggregateBySampleAndVariantKey(keyName: String, variantKeysVA: String, singleKey: Boolean = false, aggExpr: String): KeyTable = {
 
     val (keysType, keysQuerier) = queryVA(variantKeysVA)
 

--- a/src/test/scala/is/hail/vds/AggregateBySampleAndVariantKeySuite.scala
+++ b/src/test/scala/is/hail/vds/AggregateBySampleAndVariantKeySuite.scala
@@ -1,0 +1,24 @@
+package is.hail.vds
+
+import is.hail.SparkSuite
+import is.hail.utils._
+import is.hail.expr.TDouble
+import org.testng.annotations.Test
+
+class AggregateBySampleAndVariantKeySuite extends SparkSuite {
+  @Test def test() {
+    val vds = hc.importVCF("src/test/resources/regressionLinear.vcf")
+      .annotateVariantsIntervals("src/test/resources/regressionLinear.interval_list", "va.genes", all=true)
+      .annotateVariantsExpr("va.weight = v.start.toDouble")
+      .annotateSamplesTable("src/test/resources/regressionLinear.pheno", "Sample", root = Some("sa.pheno"),
+        config = TextTableConfiguration(types = Map("Pheno" -> TDouble), missing = "0"))
+
+    val (_, sampleKT) = vds.linregBurden("gene", "va.genes", singleKey = false,
+      "gs.map(g => va.weight * g.gt).sum()", "sa.pheno.Pheno")
+
+    val kt = vds.aggregateBySampleAndVariantKey("gene", "va.genes", singleKey = false,
+      "gs.map(g => va.weight * g.gt).sum()")
+
+    assert(sampleKT same kt.select(sampleKT.fieldNames, sampleKT.keyNames))
+  }
+}


### PR DESCRIPTION
This is the common use case for collapsed burden testing, and will eventually be the input to linreg_burden and logreg_burden. The resulting table can by pushed to Python or PySpark for flexible analysis. Unlike in the burden regression methods, this table need not have numeric values, and it doesn't filter out samples with missing phenotype or covariates (since there are none to speak of here).