### PR TITLE
Add defaults to ldPrune to match Python API

### DIFF
--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -793,7 +793,7 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     vds.annotateSamples(result, signature, "sa.imputesex")
   }
 
-  def ldPrune(r2Threshold: Double, windowSize: Int, nCores: Int, memoryPerCore: Long): VariantDataset = {
+  def ldPrune(r2Threshold: Double = 0.2, windowSize: Int = 1000000, nCores: Int = 1, memoryPerCore: Long = 256): VariantDataset = {
     requireSplit("LD Prune")
     LDPrune(vds, r2Threshold, windowSize, nCores, memoryPerCore)
   }


### PR DESCRIPTION
ld_prune in Python has signature
`ld_prune(self, r2=0.2, window=1000000, memory_per_core=256, num_cores=1)`

Add same defaults to Scala ldPrune method.