### PR TITLE
Fix memoryPerCore arg in ldPrune

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -2493,7 +2493,6 @@ class VariantDataset(object):
         :rtype: VariantDataset
         """
 
-        memory_per_core = int(memory_per_core * 1024 * 1024)
         jvds = self._jvdf.ldPrune(r2, window, num_cores, memory_per_core)
         return VariantDataset(self.hc, jvds)
 

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -793,9 +793,9 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     vds.annotateSamples(result, signature, "sa.imputesex")
   }
 
-  def ldPrune(r2Threshold: Double = 0.2, windowSize: Int = 1000000, nCores: Int = 1, memoryPerCore: Long = 268435456): VariantDataset = {
+  def ldPrune(r2Threshold: Double = 0.2, windowSize: Int = 1000000, nCores: Int = 1, memoryPerCore: Long = 256): VariantDataset = {
     requireSplit("LD Prune")
-    LDPrune(vds, r2Threshold, windowSize, nCores, memoryPerCore)
+    LDPrune(vds, r2Threshold, windowSize, nCores, memoryPerCore * 1024 * 1024)
   }
 
   def linreg(y: String, covariates: Array[String] = Array.empty[String], root: String = "va.linreg", useDosages: Boolean = false, minAC: Int = 1, minAF: Double = 0d): VariantDataset = {

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -793,7 +793,7 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     vds.annotateSamples(result, signature, "sa.imputesex")
   }
 
-  def ldPrune(r2Threshold: Double = 0.2, windowSize: Int = 1000000, nCores: Int = 1, memoryPerCore: Long = 256): VariantDataset = {
+  def ldPrune(r2Threshold: Double = 0.2, windowSize: Int = 1000000, nCores: Int = 1, memoryPerCore: Long = 268435456): VariantDataset = {
     requireSplit("LD Prune")
     LDPrune(vds, r2Threshold, windowSize, nCores, memoryPerCore)
   }

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -793,9 +793,9 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     vds.annotateSamples(result, signature, "sa.imputesex")
   }
 
-  def ldPrune(r2Threshold: Double = 0.2, windowSize: Int = 1000000, nCores: Int = 1, memoryPerCore: Long = 256): VariantDataset = {
+  def ldPrune(r2Threshold: Double = 0.2, windowSize: Int = 1000000, nCores: Int = 1, memoryPerCore: Int = 256): VariantDataset = {
     requireSplit("LD Prune")
-    LDPrune(vds, r2Threshold, windowSize, nCores, memoryPerCore * 1024 * 1024)
+    LDPrune(vds, r2Threshold, windowSize, nCores, memoryPerCore * 1024L * 1024L)
   }
 
   def linreg(y: String, covariates: Array[String] = Array.empty[String], root: String = "va.linreg", useDosages: Boolean = false, minAC: Int = 1, minAF: Double = 0d): VariantDataset = {


### PR DESCRIPTION
I hadn't noticed that the memory_per_core argument in Python uses different units.