### PR TITLE
infrastructure for query optimizer

### DIFF
--- a/python/hail/context.py
+++ b/python/hail/context.py
@@ -496,15 +496,9 @@ class HailContext(object):
 
         """
 
-        metadata = self._jhc.readAllMetadata(jindexed_seq_args(path))
-        is_generic_genotype = metadata[0]._1().isGenericGenotype()
-
-        if is_generic_genotype:
-            jvds = self._jhc.readAllGDS(jindexed_seq_args(path), drop_samples, drop_variants, joption(metadata))
-        else:
-            jvds = self._jhc.readAll(jindexed_seq_args(path), drop_samples, drop_variants, joption(metadata))
-
-        return VariantDataset(self, jvds)
+        return VariantDataset(
+            self,
+            self._jhc.readAll(jindexed_seq_args(path), drop_samples, drop_variants))
 
     @handle_py4j
     def write_partitioning(self, path):

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -435,10 +435,10 @@ class HailContext private(val sc: SparkContext,
       VariantSampleMatrix.read(this, input, dropSamples = dropSamples, dropVariants = dropVariants)
     }
 
-    checkDatasetSchemasCompatible(vsms, inputs)
-
     if (vsms.length == 1)
       return vsms(0)
+
+    checkDatasetSchemasCompatible(vsms, inputs)
 
     // I can't figure out how to write this with existentials -cs
     if (vsms(0).isGenericGenotype) {

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -12,15 +12,16 @@ import is.hail.keytable.KeyTable
 import is.hail.methods.DuplicateReport
 import is.hail.stats.{BaldingNicholsModel, Distribution, UniformDist}
 import is.hail.utils.{log, _}
-import is.hail.variant.{GenericDataset, Genotype, VSMSubgen, Variant, VariantDataset, VariantMetadata, VariantSampleMatrix}
+import is.hail.variant.{GenericDataset, VSMFileMetadata, VSMSubgen, VariantDataset, VariantSampleMatrix}
 import org.apache.hadoop
 import org.apache.log4j.{LogManager, PropertyConfigurator}
 import org.apache.spark.deploy.SparkHadoopUtil
-import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.{ProgressBarBuilder, SparkConf, SparkContext}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
+import scala.language.existentials
 
 object HailContext {
 
@@ -295,9 +296,9 @@ class HailContext private(val sc: SparkContext,
 
     val signature = TStruct("rsid" -> TString, "varid" -> TString)
 
-    VariantSampleMatrix(this, VariantMetadata(samples).copy(isLinearScale = true),
+    new VariantSampleMatrix(this,
+      VSMFileMetadata(samples, vaSignature = signature, isLinearScale = true, wasSplit = true),
       sc.union(results.map(_.rdd)).toOrderedRDD)
-      .copy(vaSignature = signature, wasSplit = true)
   }
 
   def importTable(inputs: java.util.ArrayList[String],
@@ -366,7 +367,7 @@ class HailContext private(val sc: SparkContext,
       nPartitions, delimiter, missing, quantPheno)
   }
 
-  def checkDatasetSchemasCompatible[T](datasets: Array[VariantSampleMatrix[T]], inputs: Array[String]) {
+  def checkDatasetSchemasCompatible(datasets: Array[VariantSampleMatrix[_]], inputs: Array[String]) {
     val sampleIds = datasets.head.sampleIds
     val vaSchema = datasets.head.vaSignature
     val wasSplit = datasets.head.wasSplit
@@ -422,58 +423,55 @@ class HailContext private(val sc: SparkContext,
       info(s"Using sample and global annotations from ${ inputs(0) }")
   }
 
-  def readMetadata(file: String): (VariantMetadata, Boolean) = VariantDataset.readMetadata(hadoopConf, file)
+  def read(file: String, dropSamples: Boolean = false, dropVariants: Boolean = false): VariantSampleMatrix[_] =
+    readAll(List(file), dropSamples, dropVariants)
 
-  def readAllMetadata(files: Seq[String]): Array[(VariantMetadata, Boolean)] = files.map(readMetadata).toArray
-
-  def read(file: String, dropSamples: Boolean = false, dropVariants: Boolean = false,
-    metadata: Option[Array[(VariantMetadata, Boolean)]] = None): VariantDataset =
-    readAll(List(file), dropSamples, dropVariants, metadata)
-
-  def readAll(files: Seq[String], dropSamples: Boolean = false, dropVariants: Boolean = false,
-    metadata: Option[Array[(VariantMetadata, Boolean)]] = None): VariantDataset = {
+  def readAll(files: Seq[String], dropSamples: Boolean = false, dropVariants: Boolean = false): VariantSampleMatrix[_] = {
     val inputs = hadoopConf.globAll(files)
     if (inputs.isEmpty)
       fatal("arguments refer to no files")
 
-    val (mdArray, pqgtArray) = metadata match {
-      case Some(data) => data.unzip
-      case _ => inputs.map(VariantDataset.readMetadata(sc.hadoopConfiguration, _)).unzip
+    val vsms = inputs.map { input =>
+      VariantSampleMatrix.read(this, input, dropSamples = dropSamples, dropVariants = dropVariants)
     }
 
-    val vdses = inputs.zipWithIndex.map { case (input, i) =>
-      VariantDataset.read(this, input, mdArray(i), pqgtArray(i),
-        dropSamples = dropSamples, dropVariants = dropVariants)
+    checkDatasetSchemasCompatible(vsms, inputs)
+
+    if (vsms.length == 1)
+      return vsms(0)
+
+    // I can't figure out how to write this with existentials -cs
+    if (vsms(0).isGenericGenotype) {
+      val gdses = vsms.asInstanceOf[Array[GenericDataset]]
+      gdses(0).copy(
+        rdd = sc.union(gdses.map(_.rdd)).toOrderedRDD)
+    } else {
+      val vdses = vsms.asInstanceOf[Array[VariantDataset]]
+      vdses(0).copy(
+        rdd = sc.union(vdses.map(_.rdd)).toOrderedRDD)
     }
-
-    checkDatasetSchemasCompatible(vdses, inputs)
-
-    vdses(0).copy(rdd = sc.union(vdses.map(_.rdd)).toOrderedRDD)
   }
 
-  def readGDS(file: String, dropSamples: Boolean = false, dropVariants: Boolean = false,
-    metadata: Option[Array[(VariantMetadata, Boolean)]] = None): GenericDataset =
-    readAllGDS(List(file), dropSamples, dropVariants, metadata)
+  def readVDS(file: String, dropSamples: Boolean = false, dropVariants: Boolean = false): VariantDataset =
+    readVDSAll(List(file), dropSamples, dropVariants)
 
-  def readAllGDS(files: Seq[String], dropSamples: Boolean = false, dropVariants: Boolean = false,
-    metadata: Option[Array[(VariantMetadata, Boolean)]] = None): GenericDataset = {
-    val inputs = hadoopConf.globAll(files)
-    if (inputs.isEmpty)
-      fatal("arguments refer to no files")
+  def readVDSAll(files: Seq[String], dropSamples: Boolean = false, dropVariants: Boolean = false): VariantDataset = {
+    val vds = readAll(files, dropSamples, dropVariants)
 
-    val (mdArray, pqgtArray) = metadata match {
-      case Some(data) => data.unzip
-      case _ => inputs.map(VariantDataset.readMetadata(sc.hadoopConfiguration, _)).unzip
-    }
+    if (vds.isGenericGenotype)
+      fatal("Cannot read datasets with generic genotypes as VDS.  Read as GDS.")
+    vds.asInstanceOf[VariantDataset]
+  }
 
-    val gdses = inputs.zipWithIndex.map { case (input, i) =>
-      GenericDataset.read(this, input, mdArray(i), pqgtArray(i),
-        dropSamples = dropSamples, dropVariants = dropVariants)
-    }
+  def readGDS(file: String, dropSamples: Boolean = false, dropVariants: Boolean = false): GenericDataset =
+    readAllGDS(List(file), dropSamples, dropVariants)
 
-    checkDatasetSchemasCompatible(gdses, inputs)
+  def readAllGDS(files: Seq[String], dropSamples: Boolean = false, dropVariants: Boolean = false): GenericDataset = {
+    val vds = readAll(files, dropSamples, dropVariants)
 
-    gdses(0).copy(rdd = sc.union(gdses.map(_.rdd)).toOrderedRDD)
+    if (!vds.isGenericGenotype)
+      fatal("Cannot read dataset without generic genotypes as GDS.  Read as VDS.")
+    vds.asInstanceOf[GenericDataset]
   }
 
   def readTable(path: String): KeyTable =
@@ -481,8 +479,8 @@ class HailContext private(val sc: SparkContext,
 
   /**
     *
-    * @param path path to Kudu database
-    * @param table table name
+    * @param path   path to Kudu database
+    * @param table  table name
     * @param master Kudu master address
     */
   def readKudu(path: String, table: String, master: String): VariantDataset = {

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -220,6 +220,8 @@ case class Positioned[T](x: T) extends Positional
 sealed abstract class AST(pos: Position, subexprs: Array[AST] = Array.empty) {
   var `type`: Type = _
 
+  def getPos: Position = pos
+
   def this(posn: Position, subexpr1: AST) = this(posn, Array(subexpr1))
 
   def this(posn: Position, subexpr1: AST, subexpr2: AST) = this(posn, Array(subexpr1, subexpr2))

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -63,6 +63,16 @@ object Parser extends JavaTokenParsers {
     (t.`type`, thunk)
   }
 
+  def evalTypedExpr[T](ast: AST, ec: EvalContext)(implicit hr: HailRep[T]): () => T = {
+    val (t, f) = evalExpr(ast, ec)
+    if (t != hr.typ)
+      fatal(s"expression has wrong type: expected `${ hr.typ }', got $t")
+
+    () => f().asInstanceOf[T]
+  }
+
+  def evalExpr(ast: AST, ec: EvalContext): (Type, () => Any) = eval(ast, ec)
+
   def parseExpr(code: String, ec: EvalContext): (Type, () => Any) = {
     eval(expr.parse(code), ec)
   }

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -68,7 +68,7 @@ object NewAST {
   def genericRewriteTopDown(ast: NewAST, rule: PartialFunction[NewAST, NewAST]): NewAST = {
     def rewrite(ast: NewAST): NewAST = {
       rule.lift(ast) match {
-        case Some(newAST) if newAST ne ast =>
+        case Some(newAST) if newAST != ast =>
           rewrite(newAST)
         case None =>
           val newChildren = ast.children.map(rewrite)
@@ -100,7 +100,7 @@ object NewAST {
           ast.copy(newChildren)
 
       rule.lift(rewritten) match {
-        case Some(newAST) if newAST ne rewritten =>
+        case Some(newAST) if newAST != rewritten =>
           rewrite(newAST)
         case None =>
           rewritten

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -1,0 +1,378 @@
+package is.hail.expr
+
+import java.io.FileNotFoundException
+
+import is.hail.HailContext
+import is.hail.annotations.Annotation
+import is.hail.methods.{Aggregators, Filter}
+import is.hail.sparkextras.{OrderedPartitioner, OrderedRDD}
+import is.hail.variant.{Genotype, Locus, VSMLocalValue, VSMMetadata, Variant, VariantDataset, VariantSampleMatrix}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
+import is.hail.utils._
+import org.apache.spark.SparkContext
+import org.apache.spark.broadcast.Broadcast
+import org.json4s.jackson.JsonMethods
+
+import scala.reflect.ClassTag
+
+case class MatrixType(
+  metadata: VSMMetadata) {
+  def globalType: Type = metadata.globalSignature
+
+  def saType: Type = metadata.saSignature
+
+  def vaType: Type = metadata.vaSignature
+
+  def genotypeType: Type = metadata.genotypeSignature
+
+  def typ = TStruct(
+    "v" -> TVariant,
+    "va" -> vaType,
+    "s" -> TString,
+    "sa" -> saType,
+    "g" -> genotypeType)
+
+  def sampleEC: EvalContext = {
+    val aggregationST = Map(
+      "global" -> (0, globalType),
+      "s" -> (1, TString),
+      "sa" -> (2, saType),
+      "g" -> (3, genotypeType),
+      "v" -> (4, TVariant),
+      "va" -> (5, vaType))
+    EvalContext(Map(
+      "global" -> (0, globalType),
+      "s" -> (1, TString),
+      "sa" -> (2, saType),
+      "gs" -> (3, TAggregable(genotypeType, aggregationST))))
+  }
+
+  def variantEC: EvalContext = {
+    val aggregationST = Map(
+      "global" -> (0, globalType),
+      "v" -> (1, TVariant),
+      "va" -> (2, vaType),
+      "g" -> (3, genotypeType),
+      "s" -> (4, TString),
+      "sa" -> (5, saType))
+    EvalContext(Map(
+      "global" -> (0, globalType),
+      "v" -> (1, TVariant),
+      "va" -> (2, vaType),
+      "gs" -> (3, TAggregable(genotypeType, aggregationST))))
+  }
+}
+
+object NewAST {
+  def genericRewriteTopDown(ast: NewAST, rule: PartialFunction[NewAST, NewAST]): NewAST = {
+    def rewrite(ast: NewAST): NewAST = {
+      rule.lift(ast) match {
+        case Some(newAST) if newAST ne ast =>
+          rewrite(newAST)
+        case None =>
+          val newChildren = ast.children.map(rewrite)
+          if ((ast.children, newChildren).zipped.forall(_ eq _))
+            ast
+          else
+            ast.copy(newChildren)
+      }
+    }
+
+    rewrite(ast)
+  }
+
+  def rewriteTopDown[T](ast: MatrixAST[T], rule: PartialFunction[NewAST, NewAST]): MatrixAST[T] =
+    genericRewriteTopDown(ast, rule).asInstanceOf[MatrixAST[T]]
+
+  def rewriteTopDown[T](ast: KeyTableAST, rule: PartialFunction[NewAST, NewAST]): KeyTableAST =
+    genericRewriteTopDown(ast, rule).asInstanceOf[KeyTableAST]
+
+  def genericRewriteBottomUp(ast: NewAST, rule: PartialFunction[NewAST, NewAST]): NewAST = {
+    def rewrite(ast: NewAST): NewAST = {
+      val newChildren = ast.children.map(rewrite)
+
+      // only recons if necessary
+      val rewritten =
+        if ((ast.children, newChildren).zipped.forall(_ eq _))
+          ast
+        else
+          ast.copy(newChildren)
+
+      rule.lift(rewritten) match {
+        case Some(newAST) if newAST ne rewritten =>
+          rewrite(newAST)
+        case None =>
+          rewritten
+      }
+    }
+
+    rewrite(ast)
+  }
+  
+  def rewriteBottomUp[T](ast: MatrixAST[T], rule: PartialFunction[NewAST, NewAST]): MatrixAST[T] =
+    genericRewriteBottomUp(ast, rule).asInstanceOf[MatrixAST[T]]
+
+  def rewriteBottomUp[T](ast: KeyTableAST, rule: PartialFunction[NewAST, NewAST]): KeyTableAST =
+    genericRewriteBottomUp(ast, rule).asInstanceOf[KeyTableAST]
+}
+
+abstract class NewAST {
+  def children: IndexedSeq[NewAST]
+
+  def copy(newChildren: IndexedSeq[NewAST]): NewAST
+
+  def mapChildren(f: (NewAST) => NewAST): NewAST = {
+    copy(children.map(f))
+  }
+}
+
+case class MatrixValue[T](
+  localValue: VSMLocalValue,
+  rdd: OrderedRDD[Locus, Variant, (Any, Iterable[T])])(implicit tct: ClassTag[T]) {
+  def sparkContext: SparkContext = rdd.sparkContext
+
+  def nPartitions: Int = rdd.partitions.length
+
+  def nSamples: Int = localValue.nSamples
+
+  def globalAnnotation: Annotation = localValue.globalAnnotation
+
+  def sampleIds: IndexedSeq[String] = localValue.sampleIds
+
+  def sampleAnnotations: IndexedSeq[Annotation] = localValue.sampleAnnotations
+
+  lazy val sampleIdsBc: Broadcast[IndexedSeq[String]] = sparkContext.broadcast(sampleIds)
+
+  lazy val sampleAnnotationsBc: Broadcast[IndexedSeq[Annotation]] = sparkContext.broadcast(sampleAnnotations)
+
+  def sampleIdsAndAnnotations: IndexedSeq[(String, Annotation)] = sampleIds.zip(sampleAnnotations)
+
+  def filterSamples(p: (String, Annotation) => Boolean): MatrixValue[T] = {
+    val mask = sampleIdsAndAnnotations.map { case (s, sa) => p(s, sa) }
+    val maskBc = sparkContext.broadcast(mask)
+    val localtct = tct
+    copy(localValue =
+      localValue.copy(
+        sampleIds = sampleIds.zipWithIndex
+          .filter { case (s, i) => mask(i) }
+          .map(_._1),
+        sampleAnnotations = sampleAnnotations.zipWithIndex
+          .filter { case (sa, i) => mask(i) }
+          .map(_._1)),
+      rdd = rdd.mapValues { case (va, gs) =>
+        (va, gs.lazyFilterWith(maskBc.value, (g: T, m: Boolean) => m))
+      }.asOrderedRDD)
+  }
+}
+
+object MatrixAST {
+  def optimize[T](ast: MatrixAST[T]): MatrixAST[T] = {
+    NewAST.rewriteTopDown(ast, {
+      case FilterVariants(
+      MatrixRead(hc, path, metadata, dropSamples, _, typ),
+      Const(_, false, TBoolean)) =>
+        MatrixRead(hc, path, metadata, dropSamples, dropVariants = true, typ)
+      case FilterSamples(
+      MatrixRead(hc, path, metadata, _, dropVariants, typ),
+      Const(_, false, TBoolean)) =>
+        MatrixRead(hc, path, metadata, dropSamples = true, dropVariants, typ)
+
+      case FilterVariants(m, Const(_, true, TBoolean)) =>
+        m
+      case FilterSamples(m, Const(_, true, TBoolean)) =>
+        m
+
+      // minor, but push FilterVariants into FilterSamples
+      case FilterVariants(FilterSamples(m, spred), vpred) =>
+        FilterSamples(FilterVariants(m, vpred), spred)
+
+      case FilterVariants(FilterVariants(m, pred1), pred2) =>
+        FilterVariants(m, Apply(pred1.getPos, "&&", Array(pred1, pred2)))
+
+      case FilterSamples(FilterSamples(m, pred1), pred2) =>
+        FilterVariants(m, Apply(pred1.getPos, "&&", Array(pred1, pred2)))
+    })
+  }
+}
+
+abstract sealed class MatrixAST[T] extends NewAST {
+  def typ: MatrixType
+
+  def execute(hc: HailContext): MatrixValue[T]
+}
+
+case class MatrixLiteral[T](
+  typ: MatrixType,
+  value: MatrixValue[T]) extends MatrixAST[T] {
+
+  def children: IndexedSeq[NewAST] = Array.empty[NewAST]
+
+  def execute(hc: HailContext): MatrixValue[T] = value
+
+  def copy(newChildren: IndexedSeq[NewAST]): MatrixLiteral[T] = {
+    assert(newChildren.isEmpty)
+    this
+  }
+
+  override def toString: String = "MatrixLiteral(...)"
+}
+
+case class MatrixRead[T](
+  hc: HailContext,
+  path: String,
+  metadata: VSMMetadata,
+  dropSamples: Boolean,
+  dropVariants: Boolean,
+  typ: MatrixType)(implicit ev: T =:= Genotype) extends MatrixAST[T] {
+
+  def children: IndexedSeq[NewAST] = Array.empty[NewAST]
+
+  def copy(newChildren: IndexedSeq[NewAST]): MatrixRead[T] = {
+    assert(newChildren.isEmpty)
+    this
+  }
+
+  def execute(hc: HailContext): MatrixValue[T] = {
+    val sc = hc.sc
+    val hConf = sc.hadoopConfiguration
+    val sqlContext = hc.sqlContext
+
+    val parquetFile = path + "/rdd.parquet"
+
+    val vaSignature = typ.vaType
+    val vaRequiresConversion = SparkAnnotationImpex.requiresConversion(vaSignature)
+    val isLinearScale = metadata.isLinearScale
+
+    val orderedRDD =
+      if (dropVariants) {
+        OrderedRDD.empty[Locus, Variant, (Annotation, Iterable[Genotype])](sc)
+      } else {
+        val rdd = if (dropSamples)
+          sqlContext.readParquetSorted(parquetFile, Some(Array("variant", "annotations")))
+            .map(row => (row.getVariant(0),
+              (if (vaRequiresConversion) SparkAnnotationImpex.importAnnotation(row.get(1), vaSignature) else row.get(1),
+                Iterable.empty[Genotype])))
+        else {
+          val rdd = sqlContext.readParquetSorted(parquetFile)
+
+          rdd.map { row =>
+            val v = row.getVariant(0)
+            (v,
+              (if (vaRequiresConversion) SparkAnnotationImpex.importAnnotation(row.get(1), vaSignature) else row.get(1),
+                row.getGenotypeStream(v, 2, isLinearScale): Iterable[Genotype]))
+          }
+        }
+
+        val partitioner: OrderedPartitioner[Locus, Variant] =
+          try {
+            val jv = hConf.readFile(path + "/partitioner.json.gz")(JsonMethods.parse(_))
+            jv.fromJSON[OrderedPartitioner[Locus, Variant]]
+          } catch {
+            case _: FileNotFoundException =>
+              fatal("missing partitioner.json.gz when loading VDS, create with HailContext.write_partitioning.")
+          }
+
+        OrderedRDD(rdd, partitioner)
+      }
+
+    val (fileMetadata, _) = VariantSampleMatrix.readFileMetadata(hConf, path)
+    val localValue = fileMetadata.localValue
+
+    MatrixValue(
+      if (dropSamples)
+        localValue.dropSamples()
+      else
+        localValue,
+      orderedRDD)
+      .asInstanceOf[MatrixValue[T]]
+  }
+
+  override def toString: String = s"MatrixRead($path, dropSamples = $dropSamples, dropVariants = $dropVariants)"
+}
+
+case class FilterSamples[T](
+  child: MatrixAST[T],
+  pred: AST) extends MatrixAST[T] {
+  def children: IndexedSeq[NewAST] = Array(child)
+
+  def copy(newChildren: IndexedSeq[NewAST]): FilterSamples[T] = {
+    assert(newChildren.length == 1)
+    FilterSamples(newChildren(0).asInstanceOf[MatrixAST[T]], pred)
+  }
+
+  def typ: MatrixType = child.typ
+
+  def execute(hc: HailContext): MatrixValue[T] = {
+    val prev = child.execute(hc)
+
+    val localGlobalAnnotation = prev.localValue.globalAnnotation
+    val sas = typ.metadata.saSignature
+    val ec = typ.sampleEC
+
+    val f: () => java.lang.Boolean = Parser.evalTypedExpr[java.lang.Boolean](pred, ec)
+
+    val sampleAggregationOption = Aggregators.buildSampleAggregations(hc, prev, ec)
+
+    val p = (s: String, sa: Annotation) => {
+      sampleAggregationOption.foreach(f => f.apply(s))
+      ec.setAll(localGlobalAnnotation, s, sa)
+      f() == true
+    }
+    prev.filterSamples(p)
+  }
+}
+
+case class FilterVariants[T](
+  child: MatrixAST[T],
+  pred: AST)(implicit tct: ClassTag[T]) extends MatrixAST[T] {
+  def children: IndexedSeq[NewAST] = Array(child)
+
+  def copy(newChildren: IndexedSeq[NewAST]): FilterVariants[T] = {
+    assert(newChildren.length == 1)
+    FilterVariants(newChildren(0).asInstanceOf[MatrixAST[T]], pred)
+  }
+
+  def typ: MatrixType = child.typ
+
+  def execute(hc: HailContext): MatrixValue[T] = {
+    val prev = child.execute(hc)
+
+    val localGlobalAnnotation = prev.localValue.globalAnnotation
+    val ec = child.typ.variantEC
+
+    val f: () => java.lang.Boolean = Parser.evalTypedExpr[java.lang.Boolean](pred, ec)
+
+    val aggregatorOption = Aggregators.buildVariantAggregations(
+      prev.rdd.sparkContext, prev.localValue, ec)
+
+    val p = (v: Variant, va: Annotation, gs: Iterable[T]) => {
+      aggregatorOption.foreach(f => f(v, va, gs))
+
+      ec.setAll(localGlobalAnnotation, v, va)
+
+      // null => false
+      f() == true
+    }
+
+    prev.copy(rdd = prev.rdd.filter { case (v, (va, gs)) => p(v, va, gs) }.asOrderedRDD)
+  }
+}
+
+abstract sealed class KeyTableAST extends NewAST {
+  def execute(hc: HailContext): RDD[Row]
+}
+
+case class KeyTableLiteral(
+  typ: TStruct,
+  rdd: RDD[Row]) {
+
+  def children: IndexedSeq[NewAST] = Array.empty[NewAST]
+
+  def copy(newChildren: IndexedSeq[NewAST]): KeyTableLiteral = {
+    assert(newChildren.isEmpty)
+    this
+  }
+
+  def execute(hc: HailContext): RDD[Row] = rdd
+}

--- a/src/main/scala/is/hail/io/bgen/BgenLoader.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenLoader.scala
@@ -58,13 +58,13 @@ object BgenLoader {
     if (unequalSamples.length > 0)
       fatal(
         s"""The following BGEN files did not contain the expected number of samples $nSamples:
-            |  ${ unequalSamples.map(x => s"""(${ x._2 } ${ x._1 }""").mkString("\n  ") }""".stripMargin)
+           |  ${ unequalSamples.map(x => s"""(${ x._2 } ${ x._1 }""").mkString("\n  ") }""".stripMargin)
 
     val noVariants = results.filter(_.nVariants == 0).map(_.file)
     if (noVariants.length > 0)
       fatal(
         s"""The following BGEN files did not contain at least 1 variant:
-            |  ${ noVariants.mkString("\n  ") })""".stripMargin)
+           |  ${ noVariants.mkString("\n  ") })""".stripMargin)
 
     val nVariants = results.map(_.nVariants).sum
 
@@ -80,15 +80,16 @@ object BgenLoader {
       (decoder.getKey, (decoder.getAnnotation, decoder.getValue))
     })).toOrderedRDD[Locus](fastKeys)
 
-    VariantSampleMatrix(hc, VariantMetadata(
-      sampleIds = samples,
-      sampleAnnotations = IndexedSeq.fill(nSamples)(Annotation.empty),
-      globalAnnotation = Annotation.empty,
+    new VariantSampleMatrix(hc, VSMMetadata(
       saSignature = TStruct.empty,
       vaSignature = signature,
       globalSignature = TStruct.empty,
       wasSplit = true,
-      isLinearScale = true), rdd)
+      isLinearScale = true),
+      VSMLocalValue(globalAnnotation = Annotation.empty,
+        sampleIds = samples,
+        sampleAnnotations = IndexedSeq.fill(nSamples)(Annotation.empty)),
+      rdd)
   }
 
   def index(hConf: org.apache.hadoop.conf.Configuration, file: String) {

--- a/src/main/scala/is/hail/io/plink/PlinkLoader.scala
+++ b/src/main/scala/is/hail/io/plink/PlinkLoader.scala
@@ -133,14 +133,15 @@ object PlinkLoader {
         (v, (Annotation(rsId), vr.getValue))
     }.toOrderedRDD(fastKeys)
 
-    VariantSampleMatrix(hc, VariantMetadata(
-      sampleIds = sampleIds,
-      sampleAnnotations = sampleAnnotations,
-      globalAnnotation = Annotation.empty,
+    new VariantSampleMatrix(hc, VSMMetadata(
       saSignature = sampleAnnotationSignature,
       vaSignature = plinkSchema,
       globalSignature = TStruct.empty,
-      wasSplit = true), variantRDD)
+      wasSplit = true),
+      VSMLocalValue(globalAnnotation = Annotation.empty,
+        sampleIds = sampleIds,
+        sampleAnnotations = sampleAnnotations),
+      variantRDD)
   }
 
   def apply(hc: HailContext, bedPath: String, bimPath: String, famPath: String, ffConfig: FamFileConfig,
@@ -184,7 +185,7 @@ object PlinkLoader {
       val n = duplicateIds.length
       warn(
         s"""found $n duplicate sample ${ plural(n, "ID") }
-            |  Duplicate IDs: @1""".stripMargin, duplicateIds)
+           |  Duplicate IDs: @1""".stripMargin, duplicateIds)
     }
 
     val vds = parseBed(hc, bedPath, ids, annotations, signature, variants, nPartitions)

--- a/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -327,14 +327,16 @@ object LoadVCF {
 
     justVariants.unpersist()
 
-    VariantSampleMatrix[T](hc, VariantMetadata(sampleIds,
-      Annotation.emptyIndexedSeq(sampleIds.length),
-      Annotation.empty,
+    new VariantSampleMatrix[T](hc, VSMMetadata(
       TStruct.empty,
       variantAnnotationSignatures,
       TStruct.empty,
       genotypeSignature,
       isGenericGenotype = reader.genericGenotypes,
-      wasSplit = noMulti), rdd)
+      wasSplit = noMulti),
+      VSMLocalValue(Annotation.empty,
+        sampleIds,
+        Annotation.emptyIndexedSeq(sampleIds.length)),
+      rdd)
   }
 }

--- a/src/main/scala/is/hail/methods/Aggregators.scala
+++ b/src/main/scala/is/hail/methods/Aggregators.scala
@@ -2,11 +2,13 @@ package is.hail.methods
 
 import java.io.{ObjectInputStream, ObjectOutputStream}
 
+import is.hail.HailContext
 import is.hail.annotations.Annotation
 import is.hail.expr._
 import is.hail.stats._
 import is.hail.utils._
 import is.hail.variant._
+import org.apache.spark.SparkContext
 import org.apache.spark.util.StatCounter
 
 import scala.collection.mutable
@@ -15,16 +17,21 @@ import scala.reflect.ClassTag
 
 object Aggregators {
 
-  def buildVariantAggregations[T](vsm: VariantSampleMatrix[T], ec: EvalContext): Option[(Variant, Annotation, Iterable[T]) => Unit] = {
+  def buildVariantAggregations[T](vsm: VariantSampleMatrix[T], ec: EvalContext): Option[(Variant, Annotation, Iterable[T]) => Unit] =
+    buildVariantAggregations(vsm.sparkContext, vsm.value.localValue, ec)
+
+  def buildVariantAggregations[T](sc: SparkContext,
+    localValue: VSMLocalValue,
+    ec: EvalContext): Option[(Variant, Annotation, Iterable[T]) => Unit] = {
 
     val aggregations = ec.aggregations
     if (aggregations.isEmpty)
       return None
 
     val localA = ec.a
-    val localSamplesBc = vsm.sampleIdsBc
-    val localAnnotationsBc = vsm.sampleAnnotationsBc
-    val localGlobalAnnotations = vsm.globalAnnotation
+    val localSamplesBc = sc.broadcast(localValue.sampleIds)
+    val localAnnotationsBc = sc.broadcast(localValue.sampleAnnotations)
+    val localGlobalAnnotations = localValue.globalAnnotation
 
     Some({ (v: Variant, va: Annotation, gs: Iterable[T]) =>
       val aggs = aggregations.map { case (_, _, agg0) => agg0.copy() }
@@ -57,7 +64,7 @@ object Aggregators {
     })
   }
 
-  def buildSampleAggregations[T](vsm: VariantSampleMatrix[T], ec: EvalContext): Option[(String) => Unit] = {
+  def buildSampleAggregations[T](hc: HailContext, value: MatrixValue[T], ec: EvalContext): Option[(String) => Unit] = {
 
     val aggregations = ec.aggregations
 
@@ -65,21 +72,21 @@ object Aggregators {
       return None
 
     val localA = ec.a
-    val localNSamples = vsm.nSamples
-    val localGlobalAnnotations = vsm.globalAnnotation
-    val localSamplesBc = vsm.sampleIdsBc
-    val localSampleAnnotationsBc = vsm.sampleAnnotationsBc
+    val localNSamples = value.nSamples
+    val localGlobalAnnotations = value.globalAnnotation
+    val localSamplesBc = value.sampleIdsBc
+    val localSampleAnnotationsBc = value.sampleAnnotationsBc
 
     val nAggregations = aggregations.length
-    val nSamples = vsm.nSamples
-    val depth = treeAggDepth(vsm.hc, vsm.nPartitions)
+    val nSamples = value.nSamples
+    val depth = treeAggDepth(hc, value.nPartitions)
 
     val baseArray = MultiArray2.fill[Aggregator](nSamples, nAggregations)(null)
     for (i <- 0 until nSamples; j <- 0 until nAggregations) {
       baseArray.update(i, j, aggregations(j)._3.copy())
     }
 
-    val result = vsm.rdd.treeAggregate(baseArray)({ case (arr, (v, (va, gs))) =>
+    val result = value.rdd.treeAggregate(baseArray)({ case (arr, (v, (va, gs))) =>
       localA(0) = localGlobalAnnotations
       localA(4) = v
       localA(5) = va
@@ -107,7 +114,7 @@ object Aggregators {
       arr1
     }, depth = depth)
 
-    val sampleIndex = vsm.sampleIds.zipWithIndex.toMap
+    val sampleIndex = value.sampleIds.zipWithIndex.toMap
     Some((s: String) => {
       val i = sampleIndex(s)
       for (j <- 0 until nAggregations) {
@@ -189,14 +196,14 @@ object Aggregators {
     SampleFunctions(zVal, seqOp, combOp, resultOp, resultType)
   }
 
-case class SampleFunctions[T](
-  zero: MultiArray2[Aggregator],
-  seqOp: (MultiArray2[Aggregator], (Variant, Annotation, Iterable[T])) => MultiArray2[Aggregator],
-  combOp: (MultiArray2[Aggregator], MultiArray2[Aggregator]) => MultiArray2[Aggregator],
-  resultOp: (MultiArray2[Aggregator] => Array[Annotation]),
-  resultType: Type)
+  case class SampleFunctions[T](
+    zero: MultiArray2[Aggregator],
+    seqOp: (MultiArray2[Aggregator], (Variant, Annotation, Iterable[T])) => MultiArray2[Aggregator],
+    combOp: (MultiArray2[Aggregator], MultiArray2[Aggregator]) => MultiArray2[Aggregator],
+    resultOp: (MultiArray2[Aggregator] => Array[Annotation]),
+    resultType: Type)
 
-def makeFunctions[T](ec: EvalContext, setEC: (EvalContext, T) => Unit): (Array[Aggregator],
+  def makeFunctions[T](ec: EvalContext, setEC: (EvalContext, T) => Unit): (Array[Aggregator],
     (Array[Aggregator], T) => Array[Aggregator],
     (Array[Aggregator], Array[Aggregator]) => Array[Aggregator],
     (Array[Aggregator] => Unit)) = {
@@ -420,7 +427,7 @@ class SumArrayAggregator[T](implicit ev: scala.math.Numeric[T], ct: ClassTag[T])
         if (r.length != _state.length)
           fatal(
             s"""cannot aggregate arrays of unequal length with `sum'
-                |Found conflicting arrays of size (${ _state.length }) and (${ r.length })""".stripMargin)
+               |Found conflicting arrays of size (${ _state.length }) and (${ r.length })""".stripMargin)
         else {
           var i = 0
           while (i < _state.length) {
@@ -441,7 +448,7 @@ class SumArrayAggregator[T](implicit ev: scala.math.Numeric[T], ct: ClassTag[T])
       if (_state.length != agg2state.length)
         fatal(
           s"""cannot aggregate arrays of unequal length with `sum'
-              |  Found conflicting arrays of size (${ _state.length }) and (${ agg2state.length })""".
+             |  Found conflicting arrays of size (${ _state.length }) and (${ agg2state.length })""".
             stripMargin)
       for (i <- _state.indices)
         _state(i) += agg2state(i)

--- a/src/main/scala/is/hail/stats/package.scala
+++ b/src/main/scala/is/hail/stats/package.scala
@@ -3,7 +3,7 @@ package is.hail
 import breeze.linalg.Matrix
 import is.hail.annotations.Annotation
 import is.hail.utils._
-import is.hail.variant.{Genotype, Variant, VariantDataset, VariantMetadata}
+import is.hail.variant.{Genotype, VSMFileMetadata, Variant, VariantDataset}
 import net.sourceforge.jdistlib.{ChiSquare, Normal, Poisson}
 import org.apache.commons.math3.distribution.HypergeometricDistribution
 
@@ -328,6 +328,6 @@ package object stats {
       nPartitions
     ).toOrderedRDD
 
-    new VariantDataset(hc, VariantMetadata(sampleIds, wasSplit = true), rdd)
+    new VariantDataset(hc, VSMFileMetadata(sampleIds, wasSplit = true), rdd)
   }
 }

--- a/src/test/scala/is/hail/PipelineSuite.scala
+++ b/src/test/scala/is/hail/PipelineSuite.scala
@@ -16,7 +16,7 @@ class PipelineSuite extends SparkSuite {
     vds.splitMulti()
       .write(vdsFile)
 
-    val qc = hc.read(vdsFile)
+    val qc = hc.readVDS(vdsFile)
       .sampleQC()
       .variantQC()
 

--- a/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
+++ b/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
@@ -97,7 +97,7 @@ class AnnotationsSuite extends SparkSuite {
     // Check that VDS can be written to disk and retrieved while staying the same
     val f = tmpDir.createTempFile("sample", extension = ".vds")
     vds2.write(f)
-    val readBack = hc.read(f)
+    val readBack = hc.readVDS(f)
 
     assert(readBack.same(vds2))
 
@@ -124,7 +124,7 @@ class AnnotationsSuite extends SparkSuite {
     // Write VCF and check that annotaions are the same
     val f2 = tmpDir.createTempFile("sample2", extension = ".vds")
     vds_attr.write(f2)
-    val readBack_attr = hc.read(f2)
+    val readBack_attr = hc.readVDS(f2)
 
     assert(readBack_attr.same(vds_attr))
   }
@@ -136,7 +136,7 @@ class AnnotationsSuite extends SparkSuite {
 
     val f = tmpDir.createTempFile("sample", extension = ".vds")
     vds1.write(f)
-    val vds3 = hc.read(f)
+    val vds3 = hc.readVDS(f)
     assert(vds3.same(vds1))
   }
 
@@ -403,6 +403,6 @@ class AnnotationsSuite extends SparkSuite {
       .copy(vaSignature = newS)
     vds.write(f)
 
-    assert(hc.read(f).same(vds))
+    assert(hc.readVDS(f).same(vds))
   }
 }

--- a/src/test/scala/is/hail/methods/FilterSuite.scala
+++ b/src/test/scala/is/hail/methods/FilterSuite.scala
@@ -24,6 +24,7 @@ class FilterSuite extends SparkSuite {
 
     TestUtils.interceptFatal("out-of-place expression") {
       vds.filterVariantsExpr("x => v.altAllele.isSNP()")
+        .countVariants() // force evaluation
     }
 
     assert(vds.filterVariantsExpr("""va.filters.contains("VQSRTrancheSNP99.60to99.80")""").countVariants() == 3)

--- a/src/test/scala/is/hail/utils/TestRDDBuilder.scala
+++ b/src/test/scala/is/hail/utils/TestRDDBuilder.scala
@@ -126,6 +126,6 @@ object TestRDDBuilder {
         }
         (variant, (Annotation.empty, b.result(): Iterable[Genotype]))
     }
-    VariantSampleMatrix(hc, VariantMetadata(sampleList), streamRDD.toOrderedRDD)
+    new VariantSampleMatrix(hc, VSMFileMetadata(sampleList), streamRDD.toOrderedRDD)
   }
 }

--- a/src/test/scala/is/hail/variant/GenericDatasetSuite.scala
+++ b/src/test/scala/is/hail/variant/GenericDatasetSuite.scala
@@ -20,7 +20,7 @@ class GenericDatasetSuite extends SparkSuite {
     gds.write(path)
 
     intercept[HailException] {
-      hc.read(path)
+      hc.readVDS(path)
     }
 
     assert(gds same hc.readGDS(path))

--- a/src/test/scala/is/hail/variant/IntervalSuite.scala
+++ b/src/test/scala/is/hail/variant/IntervalSuite.scala
@@ -50,7 +50,7 @@ class IntervalSuite extends SparkSuite {
   }
 
   @Test def testAll() {
-    val vds = VariantSampleMatrix(hc, VariantMetadata(Array.empty[String]),
+    val vds = new VariantSampleMatrix(hc, VSMFileMetadata(Array.empty[String]),
       sc.parallelize(Seq((Variant("1", 100, "A", "T"), (Annotation.empty, Iterable.empty[Genotype])))).toOrderedRDD)
 
     val intervalFile = tmpDir.createTempFile("intervals")

--- a/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -27,15 +27,15 @@ class PartitioningSuite extends SparkSuite {
 
       val orig = vds.coalesce(nPar)
         orig.write(out)
-      val problem = hc.read(out)
+      val problem = hc.readVDS(out)
 
-      hc.read(out).annotateVariantsExpr("va = va").countVariants()
+      hc.readVDS(out).annotateVariantsExpr("va = va").countVariants()
 
       // need to do 2 writes to ensure that the RDD is ordered
-      hc.read(out)
+      hc.readVDS(out)
         .write(out2)
 
-      val readback = hc.read(out2)
+      val readback = hc.readVDS(out2)
 
       compare(orig, readback)
     }.check()

--- a/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
@@ -365,6 +365,7 @@ class VSMSuite extends SparkSuite {
 
     interceptFatal("missing partitioner") {
       hc.readVDS(path)
+        .countVariants() // force execution
     }
 
     hc.writePartitioning(path)

--- a/src/test/scala/is/hail/vds/FilterAllelesSuite.scala
+++ b/src/test/scala/is/hail/vds/FilterAllelesSuite.scala
@@ -5,7 +5,7 @@ import is.hail.annotations._
 import is.hail.check.Prop
 import is.hail.expr.{TString, TStruct}
 import is.hail.utils._
-import is.hail.variant.{AltAllele, Genotype, VSMSubgen, Variant, VariantMetadata, VariantSampleMatrix}
+import is.hail.variant.{AltAllele, Genotype, VSMFileMetadata, VSMSubgen, Variant, VariantSampleMatrix}
 import org.testng.annotations.Test
 
 class FilterAllelesSuite extends SparkSuite {
@@ -34,7 +34,7 @@ class FilterAllelesSuite extends SparkSuite {
     val genotypes1 = Seq(genotype11, genotype12, genotype13)
     val row1: (Variant, (Annotation, Iterable[Genotype])) = (variant1, (va1, genotypes1))
 
-    val vds = VariantSampleMatrix(hc, VariantMetadata(Array("1", "2", "3"),
+    val vds = new VariantSampleMatrix(hc, VSMFileMetadata(Array("1", "2", "3"),
       IndexedSeq[Annotation](null, null, null),
       null,
       TString,
@@ -63,7 +63,7 @@ class FilterAllelesSuite extends SparkSuite {
     val genotypes1 = Seq(genotype11, genotype12, genotype13)
     val row1: (Variant, (Annotation, Iterable[Genotype])) = (variant1, (va1, genotypes1))
 
-    val vds = VariantSampleMatrix(hc, VariantMetadata(Array("1", "2", "3"),
+    val vds = new VariantSampleMatrix(hc, VSMFileMetadata(Array("1", "2", "3"),
       IndexedSeq[Annotation](null, null, null),
       null,
       TString,
@@ -92,7 +92,7 @@ class FilterAllelesSuite extends SparkSuite {
     val genotypes1 = Seq(genotype11, genotype12, genotype13)
     val row1: (Variant, (Annotation, Iterable[Genotype])) = (variant1, (va1, genotypes1))
 
-    val vds = VariantSampleMatrix(hc, VariantMetadata(Array("1", "2", "3"),
+    val vds = new VariantSampleMatrix(hc, VSMFileMetadata(Array("1", "2", "3"),
       IndexedSeq[Annotation](null, null, null),
       null,
       TString,
@@ -121,7 +121,7 @@ class FilterAllelesSuite extends SparkSuite {
     val genotypes1 = Seq(genotype11, genotype12, genotype13)
     val row1: (Variant, (Annotation, Iterable[Genotype])) = (variant1, (va1, genotypes1))
 
-    val vds = VariantSampleMatrix(hc, VariantMetadata(Array("1", "2", "3"),
+    val vds = new VariantSampleMatrix(hc, VSMFileMetadata(Array("1", "2", "3"),
       IndexedSeq[Annotation](null, null, null),
       null,
       TString,
@@ -150,7 +150,7 @@ class FilterAllelesSuite extends SparkSuite {
     val genotypes1 = Seq(genotype11, genotype12, genotype13)
     val row1: (Variant, (Annotation, Iterable[Genotype])) = (variant1, (va1, genotypes1))
 
-    val vds = VariantSampleMatrix(hc, VariantMetadata(Array("1", "2", "3"),
+    val vds = new VariantSampleMatrix(hc, VSMFileMetadata(Array("1", "2", "3"),
       IndexedSeq[Annotation](null, null, null),
       null,
       TString,
@@ -176,7 +176,7 @@ class FilterAllelesSuite extends SparkSuite {
     val genotypes1 = Seq(Genotype(1), Genotype(2), Genotype(3))
     val row1: (Variant, (Annotation, Iterable[Genotype])) = (variant1, (va1, genotypes1))
 
-    val vds = VariantSampleMatrix(hc, VariantMetadata(Array("1", "2", "3"),
+    val vds = new VariantSampleMatrix(hc, VSMFileMetadata(Array("1", "2", "3"),
       IndexedSeq[Annotation](null, null, null),
       null,
       TString,

--- a/src/test/scala/is/hail/vds/JoinSuite.scala
+++ b/src/test/scala/is/hail/vds/JoinSuite.scala
@@ -16,6 +16,6 @@ class JoinSuite extends SparkSuite {
     // make sure joined VDS writes
     left.join(right).write(joinedPath)
 
-    assert(joined.same(hc.read(joinedPath)))
+    assert(joined.same(hc.readVDS(joinedPath)))
   }
 }


### PR DESCRIPTION
Mostly infrastructure.

Added NewAST base class for Matrix and KeyTable ASTs with a primitive term rewriting engine.  This should eventually be a base for AST, too (because we'll want to rewrite value expressions, too).

I broke VariantMetadata into two parts: VSMMetadata (static types/metdata for VSM) and VSMLocalValue (part of MatrixValue that is computed/stored on master and broadcast).

Added MatrixRead, FilterSamples and FilterVariants matrix AST nodes.  Simple optimizer that pushes filters into read and some minor optimizations of filters.
