### PR TITLE
Removed unnecessary methods (last VDS methods that take files)

### DIFF
--- a/python/hail/tests.py
+++ b/python/hail/tests.py
@@ -101,10 +101,6 @@ class ContextTests(unittest.TestCase):
 
             dataset.count()
 
-            dataset.aggregate_intervals(test_resources + '/annotinterall.interval_list',
-                                        'N = variants.count()',
-                                        '/tmp/annotinter.tsv')
-
             dataset.query_variants(['variants.count()'])
             dataset.query_samples(['samples.count()'])
 

--- a/python/hail/tests.py
+++ b/python/hail/tests.py
@@ -108,16 +108,8 @@ class ContextTests(unittest.TestCase):
             dataset.query_variants(['variants.count()'])
             dataset.query_samples(['samples.count()'])
 
-            dataset.annotate_global_list(test_resources + '/global_list.txt', 'global.genes', as_set=True).globals
-
-            (dataset.annotate_global_table(hc.import_table(test_resources + '/global_table.tsv'), 'global.genes')
-             .globals)
-
             (dataset.annotate_samples_expr('sa.nCalled = gs.filter(g => {0}.isCalled()).count()'.format(gt))
              .export_samples('/tmp/sa.tsv', 's = s, nCalled = sa.nCalled'))
-
-            dataset.annotate_samples_list(test_resources + '/sample2.sample_list',
-                                          'sa.listed')
 
             dataset.annotate_global_expr('global.foo = 5')
             dataset.annotate_global_expr(['global.foo = 5', 'global.bar = 6'])
@@ -749,14 +741,14 @@ class ContextTests(unittest.TestCase):
         i1 = 5
         i2 = None
         itype = TInt()
-        self.assertEqual(vds.annotate_global_py(path, i1, itype).globals.annotation, i1)
-        self.assertEqual(vds.annotate_global_py(path, i2, itype).globals.annotation, i2)
+        self.assertEqual(vds.annotate_global(path, i1, itype).globals.annotation, i1)
+        self.assertEqual(vds.annotate_global(path, i2, itype).globals.annotation, i2)
 
         l1 = 5L
         l2 = None
         ltype = TLong()
-        self.assertEqual(vds.annotate_global_py(path, l1, ltype).globals.annotation, l1)
-        self.assertEqual(vds.annotate_global_py(path, l2, ltype).globals.annotation, l2)
+        self.assertEqual(vds.annotate_global(path, l1, ltype).globals.annotation, l1)
+        self.assertEqual(vds.annotate_global(path, l2, ltype).globals.annotation, l2)
 
         # FIXME add these back in when we update py4j, or rip out TFloat altogether.
         # f1 = float(5)
@@ -768,92 +760,92 @@ class ContextTests(unittest.TestCase):
         d1 = float(5)
         d2 = None
         dtype = TDouble()
-        self.assertEqual(vds.annotate_global_py(path, d1, dtype).globals.annotation, d1)
-        self.assertEqual(vds.annotate_global_py(path, d2, dtype).globals.annotation, d2)
+        self.assertEqual(vds.annotate_global(path, d1, dtype).globals.annotation, d1)
+        self.assertEqual(vds.annotate_global(path, d2, dtype).globals.annotation, d2)
 
         b1 = True
         b2 = None
         btype = TBoolean()
-        self.assertEqual(vds.annotate_global_py(path, b1, btype).globals.annotation, b1)
-        self.assertEqual(vds.annotate_global_py(path, b2, btype).globals.annotation, b2)
+        self.assertEqual(vds.annotate_global(path, b1, btype).globals.annotation, b1)
+        self.assertEqual(vds.annotate_global(path, b2, btype).globals.annotation, b2)
 
         arr1 = [1, 2, 3, 4]
         arr2 = [1, 2, None, 4]
         arr3 = None
         arr4 = []
         arrtype = TArray(TInt())
-        self.assertEqual(vds.annotate_global_py(path, arr1, arrtype).globals.annotation, arr1)
-        self.assertEqual(vds.annotate_global_py(path, arr2, arrtype).globals.annotation, arr2)
-        self.assertEqual(vds.annotate_global_py(path, arr3, arrtype).globals.annotation, arr3)
-        self.assertEqual(vds.annotate_global_py(path, arr4, arrtype).globals.annotation, arr4)
+        self.assertEqual(vds.annotate_global(path, arr1, arrtype).globals.annotation, arr1)
+        self.assertEqual(vds.annotate_global(path, arr2, arrtype).globals.annotation, arr2)
+        self.assertEqual(vds.annotate_global(path, arr3, arrtype).globals.annotation, arr3)
+        self.assertEqual(vds.annotate_global(path, arr4, arrtype).globals.annotation, arr4)
 
         set1 = {1, 2, 3, 4}
         set2 = {1, 2, None, 4}
         set3 = None
         set4 = set()
         settype = TSet(TInt())
-        self.assertEqual(vds.annotate_global_py(path, set1, settype).globals.annotation, set1)
-        self.assertEqual(vds.annotate_global_py(path, set2, settype).globals.annotation, set2)
-        self.assertEqual(vds.annotate_global_py(path, set3, settype).globals.annotation, set3)
-        self.assertEqual(vds.annotate_global_py(path, set4, settype).globals.annotation, set4)
+        self.assertEqual(vds.annotate_global(path, set1, settype).globals.annotation, set1)
+        self.assertEqual(vds.annotate_global(path, set2, settype).globals.annotation, set2)
+        self.assertEqual(vds.annotate_global(path, set3, settype).globals.annotation, set3)
+        self.assertEqual(vds.annotate_global(path, set4, settype).globals.annotation, set4)
 
         dict1 = {'a': 'foo', 'b': 'bar'}
         dict2 = {'a': None, 'b': 'bar'}
         dict3 = None
         dict4 = dict()
         dicttype = TDict(TString(), TString())
-        self.assertEqual(vds.annotate_global_py(path, dict1, dicttype).globals.annotation, dict1)
-        self.assertEqual(vds.annotate_global_py(path, dict2, dicttype).globals.annotation, dict2)
-        self.assertEqual(vds.annotate_global_py(path, dict3, dicttype).globals.annotation, dict3)
-        self.assertEqual(vds.annotate_global_py(path, dict4, dicttype).globals.annotation, dict4)
+        self.assertEqual(vds.annotate_global(path, dict1, dicttype).globals.annotation, dict1)
+        self.assertEqual(vds.annotate_global(path, dict2, dicttype).globals.annotation, dict2)
+        self.assertEqual(vds.annotate_global(path, dict3, dicttype).globals.annotation, dict3)
+        self.assertEqual(vds.annotate_global(path, dict4, dicttype).globals.annotation, dict4)
 
         map5 = {Locus("1", 100): 5, Locus("5", 205): 100}
         map6 = None
         map7 = dict()
         map8 = {Locus("1", 100): None, Locus("5", 205): 100}
         maptype2 = TDict(TLocus(), TInt())
-        self.assertEqual(vds.annotate_global_py(path, map5, maptype2).globals.annotation, map5)
-        self.assertEqual(vds.annotate_global_py(path, map6, maptype2).globals.annotation, map6)
-        self.assertEqual(vds.annotate_global_py(path, map7, maptype2).globals.annotation, map7)
-        self.assertEqual(vds.annotate_global_py(path, map8, maptype2).globals.annotation, map8)
+        self.assertEqual(vds.annotate_global(path, map5, maptype2).globals.annotation, map5)
+        self.assertEqual(vds.annotate_global(path, map6, maptype2).globals.annotation, map6)
+        self.assertEqual(vds.annotate_global(path, map7, maptype2).globals.annotation, map7)
+        self.assertEqual(vds.annotate_global(path, map8, maptype2).globals.annotation, map8)
 
         struct1 = Struct({'field1': 5, 'field2': 10, 'field3': [1, 2]})
         struct2 = Struct({'field1': 5, 'field2': None, 'field3': None})
         struct3 = None
         structtype = TStruct(['field1', 'field2', 'field3'], [TInt(), TInt(), TArray(TInt())])
-        self.assertEqual(vds.annotate_global_py(path, struct1, structtype).globals.annotation, struct1)
-        self.assertEqual(vds.annotate_global_py(path, struct2, structtype).globals.annotation, struct2)
-        self.assertEqual(vds.annotate_global_py(path, struct3, structtype).globals.annotation, struct3)
+        self.assertEqual(vds.annotate_global(path, struct1, structtype).globals.annotation, struct1)
+        self.assertEqual(vds.annotate_global(path, struct2, structtype).globals.annotation, struct2)
+        self.assertEqual(vds.annotate_global(path, struct3, structtype).globals.annotation, struct3)
 
         variant1 = Variant.parse('1:1:A:T,C')
         variant2 = None
         varianttype = TVariant()
-        self.assertEqual(vds.annotate_global_py(path, variant1, varianttype).globals.annotation, variant1)
-        self.assertEqual(vds.annotate_global_py(path, variant2, varianttype).globals.annotation, variant2)
+        self.assertEqual(vds.annotate_global(path, variant1, varianttype).globals.annotation, variant1)
+        self.assertEqual(vds.annotate_global(path, variant2, varianttype).globals.annotation, variant2)
 
         altallele1 = AltAllele('T', 'C')
         altallele2 = None
         altalleletype = TAltAllele()
-        self.assertEqual(vds.annotate_global_py(path, altallele1, altalleletype).globals.annotation, altallele1)
-        self.assertEqual(vds.annotate_global_py(path, altallele2, altalleletype).globals.annotation, altallele2)
+        self.assertEqual(vds.annotate_global(path, altallele1, altalleletype).globals.annotation, altallele1)
+        self.assertEqual(vds.annotate_global(path, altallele2, altalleletype).globals.annotation, altallele2)
 
         locus1 = Locus.parse('1:100')
         locus2 = None
         locustype = TLocus()
-        self.assertEqual(vds.annotate_global_py(path, locus1, locustype).globals.annotation, locus1)
-        self.assertEqual(vds.annotate_global_py(path, locus2, locustype).globals.annotation, locus2)
+        self.assertEqual(vds.annotate_global(path, locus1, locustype).globals.annotation, locus1)
+        self.assertEqual(vds.annotate_global(path, locus2, locustype).globals.annotation, locus2)
 
         interval1 = Interval.parse('1:1-100')
         interval2 = None
         intervaltype = TInterval()
-        self.assertEqual(vds.annotate_global_py(path, interval1, intervaltype).globals.annotation, interval1)
-        self.assertEqual(vds.annotate_global_py(path, interval2, intervaltype).globals.annotation, interval2)
+        self.assertEqual(vds.annotate_global(path, interval1, intervaltype).globals.annotation, interval1)
+        self.assertEqual(vds.annotate_global(path, interval2, intervaltype).globals.annotation, interval2)
 
         genotype1 = Genotype(1)
         genotype2 = None
         genotypetype = TGenotype()
-        self.assertEqual(vds.annotate_global_py(path, genotype1, genotypetype).globals.annotation, genotype1)
-        self.assertEqual(vds.annotate_global_py(path, genotype2, genotypetype).globals.annotation, genotype2)
+        self.assertEqual(vds.annotate_global(path, genotype1, genotypetype).globals.annotation, genotype1)
+        self.assertEqual(vds.annotate_global(path, genotype2, genotypetype).globals.annotation, genotype2)
 
     def test_concordance(self):
         bn1 = hc.balding_nichols_model(3, 1, 50, 1, seed=10)

--- a/src/test/scala/is/hail/methods/AnnotateSuite.scala
+++ b/src/test/scala/is/hail/methods/AnnotateSuite.scala
@@ -113,32 +113,6 @@ class AnnotateSuite extends SparkSuite {
 
   }
 
-  @Test def testSampleListAnnotator() {
-    var vds = hc.importVCF("src/test/resources/sample.vcf")
-
-    val sampleList1 = Array("foo1", "foo2", "foo3", "foo4")
-    val sampleList2 = Array("C1046::HG02024", "C1046::HG02025", "C1046::HG02026",
-      "C1047::HG00731", "C1047::HG00732", "C1047::HG00733", "C1048::HG02024")
-    val sampleList3 = vds.sampleIds.toArray
-
-    val fileRoot = tmpDir.createTempFile(prefix = "sampleListAnnotator")
-    hadoopConf.writeTable(fileRoot + "file1.txt", sampleList1)
-    hadoopConf.writeTable(fileRoot + "file2.txt", sampleList2)
-    hadoopConf.writeTable(fileRoot + "file3.txt", sampleList3)
-
-    vds = vds.annotateSamplesList(fileRoot + "file1.txt", root = "sa.test1")
-    vds = vds.annotateSamplesList(fileRoot + "file2.txt", root = "sa.test2")
-    vds = vds.annotateSamplesList(fileRoot + "file3.txt", root = "sa.test3")
-
-    val (_, querier1) = vds.querySA("sa.test1")
-    val (_, querier2) = vds.querySA("sa.test2")
-    val (_, querier3) = vds.querySA("sa.test3")
-
-    assert(vds.sampleIdsAndAnnotations.forall { case (sample, sa) => querier1(sa) == false })
-    assert(vds.sampleIdsAndAnnotations.forall { case (sample, sa) => querier3(sa) == true })
-    assert(vds.sampleIdsAndAnnotations.forall { case (sample, sa) => querier2(sa) == sampleList2.contains(sample) })
-  }
-
   @Test def testVariantTSVAnnotator() {
     val vds = hc.importVCF("src/test/resources/sample.vcf")
       .splitMulti()

--- a/src/test/scala/is/hail/vds/AnnotateSamplesSuite.scala
+++ b/src/test/scala/is/hail/vds/AnnotateSamplesSuite.scala
@@ -5,18 +5,6 @@ import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
 class AnnotateSamplesSuite extends SparkSuite {
-
-  @Test def testVDS() {
-    val vds = hc.importVCF("src/test/resources/sample2.vcf")
-
-    val selfAnnotated = vds.annotateSamplesVDS(vds, root = Some("sa.other"))
-
-    val (_, q) = selfAnnotated.querySA("sa.other")
-    assert(vds.sampleIdsAndAnnotations == selfAnnotated.sampleIdsAndAnnotations.map { case (id, anno) =>
-      (id, q(anno))
-    })
-  }
-
   @Test def testKeyTable() {
     val kt = hc.importTable("src/test/resources/sampleAnnotations.tsv", impute = true).keyBy("Sample")
 


### PR DESCRIPTION
  - aggregate intervals (easy to implement with key tables)
  - annotate samples list (easy to implement with annotate_samples_table)
  - annotate global list and annotate global table (easy to implement with key table and annotate_global (renamed from annotate_global_py)

Also cleaned up VSM interface (removed annotateSamplesList)