### PR TITLE
generic column (sample) key

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -17,13 +17,6 @@ warnings.filterwarnings(module=__name__, action='once')
 
 
 @decorator
-def requireSampleTString(func, vds, *args, **kwargs):
-    if vds.colkey_schema != TString():
-        raise TypeError("column key (sample) schema must be String, but found '%s'" % str(vds.rowkey_schema))
-
-    return func(vds, *args, **kwargs)
-
-@decorator
 def requireTGenotype(func, vds, *args, **kwargs):
     if vds._is_generic_genotype:
         if vds.genotype_schema != TGenotype:
@@ -1171,7 +1164,6 @@ class VariantDataset(object):
             self._jvdf.exportGenotypes(output, expr, types, export_ref, export_missing)
 
     @handle_py4j
-    @requireSampleTString
     @requireTGenotype
     @typecheck_method(output=strlike,
                       fam_expr=strlike)
@@ -2492,7 +2484,6 @@ class VariantDataset(object):
         return VariantDataset(self.hc, jvds)
 
     @handle_py4j
-    @requireSampleTString
     @typecheck_method(key_name=strlike,
                       variant_keys=strlike,
                       single_key=bool,
@@ -3102,7 +3093,6 @@ class VariantDataset(object):
         return VariantDataset(self.hc, jvds)
 
     @handle_py4j
-    @requireSampleTString
     @typecheck_method(key_name=strlike,
                       variant_keys=strlike,
                       single_key=bool,
@@ -3221,7 +3211,6 @@ class VariantDataset(object):
 
     @handle_py4j
     @requireTGenotype
-    @requireSampleTString
     @typecheck_method(pedigree=Pedigree)
     def mendel_errors(self, pedigree):
         """Find Mendel errors; count per variant, individual and nuclear
@@ -3889,7 +3878,6 @@ class VariantDataset(object):
         return r
 
     @handle_py4j
-    @requireSampleTString
     @typecheck_method(mapping=dictof(strlike, strlike))
     def rename_samples(self, mapping):
         """Rename samples.
@@ -4385,7 +4373,6 @@ class VariantDataset(object):
 
     @handle_py4j
     @requireTGenotype
-    @requireSampleTString
     @typecheck_method(pedigree=Pedigree,
                       root=strlike)
     def tdt(self, pedigree, root='va.tdt'):
@@ -4870,7 +4857,6 @@ class VariantDataset(object):
         return KeyTable(self.hc, self._jvds.genotypeKT())
 
     @handle_py4j
-    @requireSampleTString
     @typecheck_method(variant_expr=oneof(strlike, listof(strlike)),
                       genotype_expr=oneof(strlike, listof(strlike)),
                       key=oneof(strlike, listof(strlike)),

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -4,12 +4,10 @@ import warnings
 
 from decorator import decorator
 
-from hail.expr import TVariant
-from hail.expr import Type, TGenotype, TString
+from hail.expr import Type, TGenotype, TString, TVariant
 from hail.typecheck import *
 from hail.java import *
 from hail.keytable import KeyTable
-from hail.expr import Type, TGenotype, TVariant
 from hail.representation import Interval, Pedigree, Variant
 from hail.utils import Summary, wrap_to_list
 from hail.kinshipMatrix import KinshipMatrix

--- a/python/hail/kinshipMatrix.py
+++ b/python/hail/kinshipMatrix.py
@@ -6,13 +6,6 @@ from pyspark.mllib.linalg.distributed import IndexedRowMatrix
 from hail.java import *
 from hail.expr import Type, TString
 
-@decorator
-def requireSampleTString(func, km, *args, **kwargs):
-    if km.key_schema != TString():
-        raise TypeError("key (sample) schema must be String, but found '%s'" % str(km.key_schema))
-
-    return func(km, *args, **kwargs)
-
 class KinshipMatrix:
     """
     Represents a symmetric matrix encoding the relatedness of each pair of samples in the accompanying sample list.
@@ -93,7 +86,6 @@ class KinshipMatrix:
         """
         self._jkm.exportGctaGrmBin(output, joption(opt_n_file))
 
-    @requireSampleTString
     @typecheck_method(output=strlike)
     def export_id_file(self, output):
         """

--- a/src/main/scala/is/hail/io/bgen/BgenLoader.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenLoader.scala
@@ -81,7 +81,9 @@ object BgenLoader {
     })).toOrderedRDD[Locus](fastKeys)
 
     new VariantSampleMatrix(hc, VSMMetadata(
+      TString,
       saSignature = TStruct.empty,
+      TVariant,
       vaSignature = signature,
       globalSignature = TStruct.empty,
       wasSplit = true,

--- a/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -328,7 +328,9 @@ object LoadVCF {
     justVariants.unpersist()
 
     new VariantSampleMatrix[T](hc, VSMMetadata(
+      TString,
       TStruct.empty,
+      TVariant,
       variantAnnotationSignatures,
       TStruct.empty,
       genotypeSignature,

--- a/src/main/scala/is/hail/methods/Aggregators.scala
+++ b/src/main/scala/is/hail/methods/Aggregators.scala
@@ -64,7 +64,7 @@ object Aggregators {
     })
   }
 
-  def buildSampleAggregations[T](hc: HailContext, value: MatrixValue[T], ec: EvalContext): Option[(String) => Unit] = {
+  def buildSampleAggregations[T](hc: HailContext, value: MatrixValue[T], ec: EvalContext): Option[(Annotation) => Unit] = {
 
     val aggregations = ec.aggregations
 
@@ -115,7 +115,7 @@ object Aggregators {
     }, depth = depth)
 
     val sampleIndex = value.sampleIds.zipWithIndex.toMap
-    Some((s: String) => {
+    Some((s: Annotation) => {
       val i = sampleIndex(s)
       for (j <- 0 until nAggregations) {
         aggregations(j)._1.v = result(i, j).result

--- a/src/main/scala/is/hail/methods/GQByDPBins.scala
+++ b/src/main/scala/is/hail/methods/GQByDPBins.scala
@@ -1,5 +1,6 @@
 package is.hail.methods
 
+import is.hail.annotations.Annotation
 import is.hail.variant.VariantDataset
 
 object GQByDPBins {
@@ -30,7 +31,7 @@ object GQByDPBins {
   }
 
   // ((sample, bin), %GQ)
-  def apply(vds: VariantDataset): Map[(String, Int), Double] = {
+  def apply(vds: VariantDataset): Map[(Annotation, Int), Double] = {
     vds
       .flatMapWithKeys((v, s, g) => {
         val bin = g.dp.flatMap(dpBin)

--- a/src/main/scala/is/hail/methods/GRM.scala
+++ b/src/main/scala/is/hail/methods/GRM.scala
@@ -19,6 +19,6 @@ object GRM {
     assert(grm.numCols == nSamples
       && grm.numRows == nSamples)
 
-    new KinshipMatrix(vds.hc, grm.toIndexedRowMatrix, vds.stringSampleIds.toArray, vds.countVariants())
+    KinshipMatrix(vds.hc, grm.toIndexedRowMatrix, vds.sampleIds.toArray, vds.countVariants())
   }
 }

--- a/src/main/scala/is/hail/methods/GRM.scala
+++ b/src/main/scala/is/hail/methods/GRM.scala
@@ -19,6 +19,6 @@ object GRM {
     assert(grm.numCols == nSamples
       && grm.numRows == nSamples)
 
-    new KinshipMatrix(vds.hc, grm.toIndexedRowMatrix, vds.sampleIds.toArray, vds.countVariants())
+    new KinshipMatrix(vds.hc, grm.toIndexedRowMatrix, vds.sampleIds.map(_.asInstanceOf[String]).toArray, vds.countVariants())
   }
 }

--- a/src/main/scala/is/hail/methods/GRM.scala
+++ b/src/main/scala/is/hail/methods/GRM.scala
@@ -19,6 +19,6 @@ object GRM {
     assert(grm.numCols == nSamples
       && grm.numRows == nSamples)
 
-    new KinshipMatrix(vds.hc, grm.toIndexedRowMatrix, vds.sampleIds.map(_.asInstanceOf[String]).toArray, vds.countVariants())
+    new KinshipMatrix(vds.hc, grm.toIndexedRowMatrix, vds.stringSampleIds.toArray, vds.countVariants())
   }
 }

--- a/src/main/scala/is/hail/methods/GRM.scala
+++ b/src/main/scala/is/hail/methods/GRM.scala
@@ -19,6 +19,6 @@ object GRM {
     assert(grm.numCols == nSamples
       && grm.numRows == nSamples)
 
-    KinshipMatrix(vds.hc, grm.toIndexedRowMatrix, vds.sampleIds.toArray, vds.countVariants())
+    KinshipMatrix(vds.hc, vds.sSignature, grm.toIndexedRowMatrix, vds.sampleIds.toArray, vds.countVariants())
   }
 }

--- a/src/main/scala/is/hail/methods/ImputeSexPlink.scala
+++ b/src/main/scala/is/hail/methods/ImputeSexPlink.scala
@@ -31,7 +31,7 @@ object ImputeSexPlink {
     includePar: Boolean,
     fMaleThreshold: Double,
     fFemaleThreshold: Double,
-    popFrequencyExpr: Option[String]): Map[String, Annotation] = {
+    popFrequencyExpr: Option[String]): Map[Annotation, Annotation] = {
 
     val query = popFrequencyExpr.map { code =>
       val (t, f) = vds.queryVA(code)

--- a/src/main/scala/is/hail/methods/KinshipMatrix.scala
+++ b/src/main/scala/is/hail/methods/KinshipMatrix.scala
@@ -5,6 +5,7 @@ import java.io.DataOutputStream
 import breeze.linalg.SparseVector
 import is.hail.HailContext
 import is.hail.annotations.Annotation
+import is.hail.expr.Type
 import is.hail.utils._
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix}
@@ -14,7 +15,7 @@ import scala.collection.Searching._
 /**
   * Represents a KinshipMatrix. Entry (i, j) encodes the relatedness of the ith and jth samples in sampleIds.
   */
-case class KinshipMatrix(hc: HailContext, matrix: IndexedRowMatrix, sampleIds: Array[Annotation], numVariantsUsed: Long) {
+case class KinshipMatrix(hc: HailContext, sampleSignature: Type, matrix: IndexedRowMatrix, sampleIds: Array[Annotation], numVariantsUsed: Long) {
   assert(matrix.numCols().toInt == matrix.numRows().toInt && matrix.numCols().toInt == sampleIds.length)
 
   /**
@@ -35,10 +36,10 @@ case class KinshipMatrix(hc: HailContext, matrix: IndexedRowMatrix, sampleIds: A
       val index = ir.index - numBelowToDelete
       val vecArray = ir.vector.toArray
       val filteredArray = sampleIndicesToTakeArray.map(i => vecArray(i))
-      new IndexedRow(index, Vectors.dense(filteredArray))
+      IndexedRow(index, Vectors.dense(filteredArray))
     })
 
-    new KinshipMatrix(hc, new IndexedRowMatrix(filteredRowsAndCols), filteredSamplesIds, numVariantsUsed)
+    KinshipMatrix(hc, sampleSignature, new IndexedRowMatrix(filteredRowsAndCols), filteredSamplesIds, numVariantsUsed)
   }
 
   /**

--- a/src/main/scala/is/hail/methods/LinearMixedRegression.scala
+++ b/src/main/scala/is/hail/methods/LinearMixedRegression.scala
@@ -39,7 +39,7 @@ object LinearMixedRegression {
 
     val (y, cov, completeSamples) = RegressionUtils.getPhenoCovCompleteSamples(assocVds, yExpr, covExpr)
     val completeSamplesSet = completeSamples.toSet
-    val sampleMask = assocVds.stringSampleIds.map(s => completeSamplesSet(s)).toArray
+    val sampleMask = assocVds.sampleIds.map(s => completeSamplesSet(s)).toArray
 
     optDelta.foreach(delta =>
       if (delta <= 0d)

--- a/src/main/scala/is/hail/methods/LinearMixedRegression.scala
+++ b/src/main/scala/is/hail/methods/LinearMixedRegression.scala
@@ -38,8 +38,9 @@ object LinearMixedRegression {
     Parser.validateAnnotationRoot(rootGA, Annotation.GLOBAL_HEAD)
 
     val (y, cov, completeSamples) = RegressionUtils.getPhenoCovCompleteSamples(assocVds, yExpr, covExpr)
+    // FIXME require Samples = String
     val completeSamplesSet = completeSamples.toSet
-    val sampleMask = assocVds.sampleIds.map(completeSamplesSet).toArray
+    val sampleMask = assocVds.sampleIds.map(s => completeSamplesSet(s.asInstanceOf[String])).toArray
 
     optDelta.foreach(delta =>
       if (delta <= 0d)

--- a/src/main/scala/is/hail/methods/LinearMixedRegression.scala
+++ b/src/main/scala/is/hail/methods/LinearMixedRegression.scala
@@ -38,9 +38,8 @@ object LinearMixedRegression {
     Parser.validateAnnotationRoot(rootGA, Annotation.GLOBAL_HEAD)
 
     val (y, cov, completeSamples) = RegressionUtils.getPhenoCovCompleteSamples(assocVds, yExpr, covExpr)
-    // FIXME require Samples = String
     val completeSamplesSet = completeSamples.toSet
-    val sampleMask = assocVds.sampleIds.map(s => completeSamplesSet(s.asInstanceOf[String])).toArray
+    val sampleMask = assocVds.stringSampleIds.map(s => completeSamplesSet(s)).toArray
 
     optDelta.foreach(delta =>
       if (delta <= 0d)

--- a/src/main/scala/is/hail/methods/LinearMixedRegression.scala
+++ b/src/main/scala/is/hail/methods/LinearMixedRegression.scala
@@ -39,7 +39,7 @@ object LinearMixedRegression {
 
     val (y, cov, completeSamples) = RegressionUtils.getPhenoCovCompleteSamples(assocVds, yExpr, covExpr)
     val completeSamplesSet = completeSamples.toSet
-    val sampleMask = assocVds.sampleIds.map(s => completeSamplesSet(s)).toArray
+    val sampleMask = assocVds.sampleIds.map(completeSamplesSet).toArray
 
     optDelta.foreach(delta =>
       if (delta <= 0d)

--- a/src/main/scala/is/hail/methods/MendelErrors.scala
+++ b/src/main/scala/is/hail/methods/MendelErrors.scala
@@ -1,6 +1,7 @@
 package is.hail.methods
 
 import is.hail.HailContext
+import is.hail.annotations.Annotation
 import is.hail.expr.{TInt, TString, TStruct, TVariant}
 import is.hail.keytable.KeyTable
 import is.hail.utils.{MultiArray2, _}
@@ -87,8 +88,8 @@ object MendelErrors {
 
     val zeroVal: MultiArray2[GenotypeType] = MultiArray2.fill(trios.length, 3)(NoCall)
 
-    def seqOp(a: MultiArray2[GenotypeType], s: String, g: Genotype): MultiArray2[GenotypeType] = {
-      sampleTrioRolesBc.value.get(s).foreach(l => l.foreach { case (ti, ri) => a.update(ti, ri, g.gtType) })
+    def seqOp(a: MultiArray2[GenotypeType], s: Annotation, g: Genotype): MultiArray2[GenotypeType] = {
+      sampleTrioRolesBc.value.get(s.asInstanceOf[String]).foreach(l => l.foreach { case (ti, ri) => a.update(ti, ri, g.gtType) })
       a
     }
 
@@ -99,7 +100,7 @@ object MendelErrors {
       a
     }
 
-    new MendelErrors(vds.hc, trios, vds.sampleIds,
+    new MendelErrors(vds.hc, trios, vds.sampleIds.map(_.asInstanceOf[String]),
       vds
         .aggregateByVariantWithKeys(zeroVal)(
           (a, v, s, g) => seqOp(a, s, g),

--- a/src/main/scala/is/hail/methods/MendelErrors.scala
+++ b/src/main/scala/is/hail/methods/MendelErrors.scala
@@ -100,7 +100,7 @@ object MendelErrors {
       a
     }
 
-    new MendelErrors(vds.hc, trios, vds.sampleIds.map(_.asInstanceOf[String]),
+    new MendelErrors(vds.hc, trios, vds.stringSampleIds,
       vds
         .aggregateByVariantWithKeys(zeroVal)(
           (a, v, s, g) => seqOp(a, s, g),

--- a/src/main/scala/is/hail/methods/SamplePCA.scala
+++ b/src/main/scala/is/hail/methods/SamplePCA.scala
@@ -24,7 +24,7 @@ object SamplePCA {
 
 
   def apply(vds: VariantDataset, k: Int, computeLoadings: Boolean, computeEigenvalues: Boolean,
-    asArray: Boolean): (Map[String, Annotation], Option[RDD[(Variant, Annotation)]], Option[Annotation]) = {
+    asArray: Boolean): (Map[Annotation, Annotation], Option[RDD[(Variant, Annotation)]], Option[Annotation]) = {
 
     val (variants, mat) = ToHWENormalizedIndexedRowMatrix(vds)
     val sc = vds.sparkContext

--- a/src/main/scala/is/hail/methods/SampleQC.scala
+++ b/src/main/scala/is/hail/methods/SampleQC.scala
@@ -227,7 +227,7 @@ class SampleQCCombiner(val keepStar: Boolean) extends Serializable {
 }
 
 object SampleQC {
-  def results(vds: VariantDataset, keepStar: Boolean): Map[String, SampleQCCombiner] = {
+  def results(vds: VariantDataset, keepStar: Boolean): Map[Annotation, SampleQCCombiner] = {
     val depth = treeAggDepth(vds.hc, vds.nPartitions)
     vds.sampleIds.iterator
       .zip(
@@ -259,7 +259,7 @@ object SampleQC {
 
     val r = results(vds, keepStar)
     vds.annotateSamples(SampleQCCombiner.signature,
-      Parser.parseAnnotationRoot(root, Annotation.SAMPLE_HEAD), { (x: String) =>
+      Parser.parseAnnotationRoot(root, Annotation.SAMPLE_HEAD), { (x: Annotation) =>
         r.get(x).map(_.asAnnotation).orNull
       })
   }

--- a/src/main/scala/is/hail/methods/TDT.scala
+++ b/src/main/scala/is/hail/methods/TDT.scala
@@ -73,7 +73,7 @@ object TDT {
       sampleTrioRolesMap += (t.knownMom -> ((tidx, 2) :: sampleTrioRolesMap.getOrElse(t.knownMom, Nil)))
     }
 
-    val sampleTrioRolesArray = vds.sampleIds.map(s => sampleTrioRolesMap.getOrElse(s.asInstanceOf[String], Nil))
+    val sampleTrioRolesArray = vds.stringSampleIds.map(s => sampleTrioRolesMap.getOrElse(s, Nil))
 
     val sc = vds.sparkContext
     val sampleTrioRolesBc = vds.sparkContext.broadcast(sampleTrioRolesArray)

--- a/src/main/scala/is/hail/methods/TDT.scala
+++ b/src/main/scala/is/hail/methods/TDT.scala
@@ -73,7 +73,7 @@ object TDT {
       sampleTrioRolesMap += (t.knownMom -> ((tidx, 2) :: sampleTrioRolesMap.getOrElse(t.knownMom, Nil)))
     }
 
-    val sampleTrioRolesArray = vds.sampleIds.map(sampleTrioRolesMap.getOrElse(_, Nil))
+    val sampleTrioRolesArray = vds.sampleIds.map(s => sampleTrioRolesMap.getOrElse(s.asInstanceOf[String], Nil))
 
     val sc = vds.sparkContext
     val sampleTrioRolesBc = vds.sparkContext.broadcast(sampleTrioRolesArray)

--- a/src/main/scala/is/hail/stats/BaldingNicholsModel.scala
+++ b/src/main/scala/is/hail/stats/BaldingNicholsModel.scala
@@ -4,7 +4,7 @@ import breeze.linalg.{DenseVector, sum, _}
 import breeze.stats.distributions._
 import is.hail.HailContext
 import is.hail.annotations.Annotation
-import is.hail.expr.{TArray, TDouble, TInt, TString, TStruct}
+import is.hail.expr.{TArray, TDouble, TInt, TString, TStruct, TVariant}
 import is.hail.utils._
 import is.hail.variant.{Genotype, VSMLocalValue, VSMMetadata, Variant, VariantDataset}
 import org.apache.commons.math3.random.JDKRandomGenerator
@@ -138,7 +138,7 @@ object BaldingNicholsModel {
       "ancestralAFDist" -> ancestralAFAnnotationSignature,
       "seed" -> TInt)
     new VariantDataset(hc,
-      VSMMetadata(saSignature, vaSignature, globalSignature, wasSplit = true),
+      VSMMetadata(TString, saSignature, TVariant, vaSignature, globalSignature, wasSplit = true),
       VSMLocalValue(globalAnnotation, sampleIds, sampleAnnotations), rdd)
   }
 }

--- a/src/main/scala/is/hail/stats/RegressionUtils.scala
+++ b/src/main/scala/is/hail/stats/RegressionUtils.scala
@@ -1,6 +1,7 @@
 package is.hail.stats
 
 import breeze.linalg.{DenseMatrix, DenseVector, SparseVector}
+import is.hail.annotations.Annotation
 import is.hail.expr._
 import is.hail.utils._
 import is.hail.variant.{Genotype, VariantDataset}
@@ -41,7 +42,7 @@ object RegressionUtils {
   def getPhenoCovCompleteSamples(
     vds: VariantDataset,
     yExpr: String,
-    covExpr: Array[String]): (DenseVector[Double], DenseMatrix[Double], IndexedSeq[String]) = {
+    covExpr: Array[String]): (DenseVector[Double], DenseMatrix[Double], IndexedSeq[Annotation]) = {
 
     val nCovs = covExpr.size + 1 // intercept
 
@@ -80,7 +81,7 @@ object RegressionUtils {
   def getPhenosCovCompleteSamples(
     vds: VariantDataset,
     yExpr: Array[String],
-    covExpr: Array[String]): (DenseMatrix[Double], DenseMatrix[Double], IndexedSeq[String]) = {
+    covExpr: Array[String]): (DenseMatrix[Double], DenseMatrix[Double], IndexedSeq[Annotation]) = {
 
     val nPhenos = yExpr.size
     val nCovs = covExpr.size + 1 // intercept

--- a/src/main/scala/is/hail/variant/GenericDataset.scala
+++ b/src/main/scala/is/hail/variant/GenericDataset.scala
@@ -47,7 +47,7 @@ class GenericDatasetFunctions(private val gds: VariantSampleMatrix[Annotation]) 
              |  New: ${finalType.toPrettyString(compact = true)}""".stripMargin)
 
     gds.mapValuesWithAll(
-      (v: Variant, va: Annotation, s: String, sa: Annotation, g: Annotation) => {
+      (v: Variant, va: Annotation, s: Annotation, sa: Annotation, g: Annotation) => {
         ec.setAll(v, va, s, sa, g)
         f().zip(inserters)
           .foldLeft(g) { case (ga, (a, inserter)) =>
@@ -102,7 +102,7 @@ class GenericDatasetFunctions(private val gds: VariantSampleMatrix[Annotation]) 
 
     val localKeep = keep
     gds.mapValuesWithAll(
-      (v: Variant, va: Annotation, s: String, sa: Annotation, g: Annotation) => {
+      (v: Variant, va: Annotation, s: Annotation, sa: Annotation, g: Annotation) => {
         ec.setAll(v, va, s, sa, g)
 
         if (Filter.boxedKeepThis(f(), localKeep))

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -376,7 +376,6 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     }
 
     val spaceRegex = """\s+""".r
-    // FIXME require sample = string
     val badSampleIds = vds.stringSampleIds.filter(id => spaceRegex.findFirstIn(id).isDefined)
     if (badSampleIds.nonEmpty) {
       fatal(

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -324,6 +324,7 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
 
   def exportPlink(path: String, famExpr: String = "id = s") {
     requireSplit("export plink")
+    vds.requireSampleTString("export plink")
 
     val ec = EvalContext(Map(
       "s" -> (0, TString),
@@ -571,6 +572,7 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
 
   def linregBurden(keyName: String, variantKeys: String, singleKey: Boolean, aggExpr: String, y: String, covariates: Array[String] = Array.empty[String]): (KeyTable, KeyTable) = {
     requireSplit("linear burden regression")
+    vds.requireSampleTString("linear burden regression")
     LinearRegressionBurden(vds, keyName, variantKeys, singleKey, aggExpr, y, covariates)
   }
 
@@ -606,6 +608,7 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
 
   def logregBurden(keyName: String, variantKeys: String, singleKey: Boolean, aggExpr: String, test: String, y: String, covariates: Array[String] = Array.empty[String]): (KeyTable, KeyTable) = {
     requireSplit("linear burden regression")
+    vds.requireSampleTString("linear burden regression")
     LogisticRegressionBurden(vds, keyName, variantKeys, singleKey, aggExpr, test, y, covariates)
   }
 
@@ -614,6 +617,7 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
 
   def mendelErrors(ped: Pedigree): (KeyTable, KeyTable, KeyTable, KeyTable) = {
     requireSplit("mendel errors")
+    vds.requireSampleTString("mendel errors")
 
     val men = MendelErrors(vds, ped.filterTo(vds.stringSampleIdSet).completeTrios)
 
@@ -680,6 +684,7 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
 
   def tdt(ped: Pedigree, tdtRoot: String = "va.tdt"): VariantDataset = {
     requireSplit("TDT")
+    vds.requireSampleTString("TDT")
 
     TDT(vds, ped.filterTo(vds.stringSampleIdSet).completeTrios,
       Parser.parseAnnotationRoot(tdtRoot, Annotation.VARIANT_HEAD))

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -663,7 +663,7 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     info(s"rrm: Computing Realized Relationship Matrix...")
     val (rrm, m) = ComputeRRM(vds, forceBlock, forceGramian)
     info(s"rrm: RRM computed using $m variants.")
-    new KinshipMatrix(vds.hc, rrm, vds.stringSampleIds.toArray, m)
+    KinshipMatrix(vds.hc, vds.sSignature, rrm, vds.stringSampleIds.toArray, m)
   }
 
 

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -377,7 +377,7 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
 
     val spaceRegex = """\s+""".r
     // FIXME require sample = string
-    val badSampleIds = vds.sampleIds.filter(id => spaceRegex.findFirstIn(id.asInstanceOf[String]).isDefined)
+    val badSampleIds = vds.stringSampleIds.filter(id => spaceRegex.findFirstIn(id).isDefined)
     if (badSampleIds.nonEmpty) {
       fatal(
         s"""Found ${ badSampleIds.length } sample IDs with whitespace
@@ -513,10 +513,10 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
 
       s.write("\n")
 
-      for (sample <- vds.sampleIds) {
-        s.write(sample.asInstanceOf[String])
+      for (sample <- vds.stringSampleIds) {
+        s.write(sample)
         for (b <- 0 until GQByDPBins.nBins) {
-          gqbydp.get((sample.asInstanceOf[String], b)) match {
+          gqbydp.get((sample, b)) match {
             case Some(percentGQ) => s.write("\t" + percentGQ)
             case None => s.write("\tNA")
           }
@@ -643,7 +643,7 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
   def mendelErrors(ped: Pedigree): (KeyTable, KeyTable, KeyTable, KeyTable) = {
     requireSplit("mendel errors")
 
-    val men = MendelErrors(vds, ped.filterTo(vds.sampleIds.map(_.asInstanceOf[String]).toSet).completeTrios)
+    val men = MendelErrors(vds, ped.filterTo(vds.stringSampleIdSet).completeTrios)
 
     (men.mendelKT(), men.fMendelKT(), men.iMendelKT(), men.lMendelKT())
   }
@@ -691,7 +691,7 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     info(s"rrm: Computing Realized Relationship Matrix...")
     val (rrm, m) = ComputeRRM(vds, forceBlock, forceGramian)
     info(s"rrm: RRM computed using $m variants.")
-    new KinshipMatrix(vds.hc, rrm, vds.sampleIds.map(_.asInstanceOf[String]).toArray, m)
+    new KinshipMatrix(vds.hc, rrm, vds.stringSampleIds.toArray, m)
   }
 
 
@@ -709,7 +709,7 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
   def tdt(ped: Pedigree, tdtRoot: String = "va.tdt"): VariantDataset = {
     requireSplit("TDT")
 
-    TDT(vds, ped.filterTo(vds.sampleIds.toSet.map((s: Annotation) => s.asInstanceOf[String])).completeTrios,
+    TDT(vds, ped.filterTo(vds.stringSampleIdSet).completeTrios,
       Parser.parseAnnotationRoot(tdtRoot, Annotation.VARIANT_HEAD))
   }
 

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -498,33 +498,6 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     }
   }
 
-
-  def gqByDP(path: String) {
-    val nBins = GQByDPBins.nBins
-    val binStep = GQByDPBins.binStep
-    val firstBinLow = GQByDPBins.firstBinLow
-    val gqbydp = GQByDPBins(vds)
-
-    vds.hadoopConf.writeTextFile(path) { s =>
-      s.write("sample")
-      for (b <- 0 until nBins)
-        s.write("\t" + GQByDPBins.binLow(b) + "-" + GQByDPBins.binHigh(b))
-
-      s.write("\n")
-
-      for (sample <- vds.stringSampleIds) {
-        s.write(sample)
-        for (b <- 0 until GQByDPBins.nBins) {
-          gqbydp.get((sample, b)) match {
-            case Some(percentGQ) => s.write("\t" + percentGQ)
-            case None => s.write("\tNA")
-          }
-        }
-        s.write("\n")
-      }
-    }
-  }
-
   def grm(): KinshipMatrix = {
     requireSplit("GRM")
     info("Computing GRM...")

--- a/src/main/scala/is/hail/variant/VariantMetadata.scala
+++ b/src/main/scala/is/hail/variant/VariantMetadata.scala
@@ -5,7 +5,7 @@ import is.hail.expr._
 import is.hail.utils._
 
 object VSMLocalValue {
-  def apply(sampleIds: IndexedSeq[String]): VSMLocalValue =
+  def apply(sampleIds: IndexedSeq[Annotation]): VSMLocalValue =
     VSMLocalValue(Annotation.empty,
       sampleIds,
       Annotation.emptyIndexedSeq(sampleIds.length))
@@ -13,7 +13,7 @@ object VSMLocalValue {
 
 case class VSMLocalValue(
   globalAnnotation: Annotation,
-  sampleIds: IndexedSeq[String],
+  sampleIds: IndexedSeq[Annotation],
   sampleAnnotations: IndexedSeq[Annotation]) {
   assert(sampleIds.areDistinct(), s"Sample ID names are not distinct: ${ sampleIds.duplicates().mkString(", ") }")
   assert(sampleIds.length == sampleAnnotations.length)
@@ -21,7 +21,7 @@ case class VSMLocalValue(
   def nSamples: Int = sampleIds.length
 
   def dropSamples(): VSMLocalValue = VSMLocalValue(globalAnnotation,
-    IndexedSeq.empty[String],
+    IndexedSeq.empty[Annotation],
     IndexedSeq.empty[Annotation])
 }
 
@@ -29,14 +29,16 @@ object VSMFileMetadata {
   def apply(sampleIds: IndexedSeq[String],
     sampleAnnotations: IndexedSeq[Annotation] = null,
     globalAnnotation: Annotation = Annotation.empty,
+    sSignature: Type = TString,
     saSignature: Type = TStruct.empty,
+    vSignature: Type = TVariant,
     vaSignature: Type = TStruct.empty,
     globalSignature: Type = TStruct.empty,
     genotypeSignature: Type = TGenotype,
     wasSplit: Boolean = false,
     isLinearScale: Boolean = false): VSMFileMetadata = {
     VSMFileMetadata(
-      VSMMetadata(saSignature, vaSignature, globalSignature, genotypeSignature, wasSplit, isLinearScale),
+      VSMMetadata(sSignature, saSignature, vSignature, vaSignature, globalSignature, genotypeSignature, wasSplit, isLinearScale),
       VSMLocalValue(globalAnnotation, sampleIds,
         if (sampleAnnotations == null)
           Annotation.emptyIndexedSeq(sampleIds.length)
@@ -50,7 +52,9 @@ case class VSMFileMetadata(
   localValue: VSMLocalValue)
 
 case class VSMMetadata(
+  sSignature: Type = TString,
   saSignature: Type = TStruct.empty,
+  vSignature: Type = TVariant,
   vaSignature: Type = TStruct.empty,
   globalSignature: Type = TStruct.empty,
   genotypeSignature: Type = TGenotype,

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -500,7 +500,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VSMMetadata,
         Row.fromSeq(results)
       }
 
-    val signature = TStruct((keyName -> keyType) +: sampleIds.map(id => id.asInstanceOf[String] -> resultType): _*)
+    val signature = TStruct((keyName -> keyType) +: stringSampleIds.map(id => id -> resultType): _*)
 
     new KeyTable(hc, ktRDD, signature, key = Array(keyName))
   }
@@ -1522,12 +1522,12 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VSMMetadata,
     val (gNames, gTypes, gf) = Parser.parseNamedExprs(genotypeCondition, gEC)
 
     val sig = TStruct(((vNames, vTypes).zipped ++
-      sampleIds.flatMap { s =>
+      stringSampleIds.flatMap { s =>
         (gNames, gTypes).zipped.map { case (n, t) =>
           (if (n.isEmpty)
-            s.asInstanceOf[String]
+            s
           else
-            s.asInstanceOf[String] + seperator + n, t)
+            s + seperator + n, t)
         }
       }).toSeq: _*)
 

--- a/src/test/scala/is/hail/PipelineSuite.scala
+++ b/src/test/scala/is/hail/PipelineSuite.scala
@@ -20,7 +20,6 @@ class PipelineSuite extends SparkSuite {
       .sampleQC()
       .variantQC()
 
-    qc.gqByDP(gqByDPFile)
     qc.mendelErrors(Pedigree.read("src/test/resources/sample.fam", hadoopConf))._1.export(mendelBase)
     qc.count()
     qc.filterVariantsExpr("va.qc.AF > 0.01 && va.qc.AF < 0.99")

--- a/src/test/scala/is/hail/io/HardCallsSuite.scala
+++ b/src/test/scala/is/hail/io/HardCallsSuite.scala
@@ -1,13 +1,14 @@
 package is.hail.io
 
 import is.hail.SparkSuite
+import is.hail.annotations.Annotation
 import is.hail.check.Prop._
 import is.hail.utils._
 import is.hail.variant.{VSMSubgen, VariantSampleMatrix, _}
 import org.testng.annotations.Test
 
 class HardCallsSuite extends SparkSuite {
-  def gtTriples(vds: VariantDataset): Set[(Variant, String, (Option[Int], Boolean))] =
+  def gtTriples(vds: VariantDataset): Set[(Variant, Annotation, (Option[Int], Boolean))] =
     vds.mapValues { g => (g.gt, g.fakeRef) }
       .expand()
       .collect()

--- a/src/test/scala/is/hail/io/SplitSuite.scala
+++ b/src/test/scala/is/hail/io/SplitSuite.scala
@@ -14,7 +14,7 @@ class SplitSuite extends SparkSuite {
     property("fakeRef implies wasSplit") =
       forAll(VariantSampleMatrix.gen[Genotype](hc, VSMSubgen.random).map(_.splitMulti())) { (vds: VariantDataset) =>
         val wasSplitQuerier = vds.vaSignature.query("wasSplit")
-        vds.mapWithAll((v: Variant, va: Annotation, _: String, _: Annotation, g: Genotype) =>
+        vds.mapWithAll((v: Variant, va: Annotation, _: Annotation, _: Annotation, g: Genotype) =>
           !g.fakeRef || wasSplitQuerier(va).asInstanceOf[Boolean])
           .collect()
           .forall(identity)

--- a/src/test/scala/is/hail/methods/AggregatorSuite.scala
+++ b/src/test/scala/is/hail/methods/AggregatorSuite.scala
@@ -158,7 +158,7 @@ class AggregatorSuite extends SparkSuite {
     val ktProduct = new KeyTable(hc, rdd, signature)
       .aggregate("group = group", ((0 until 11).map(i => s"s$i = s$i.product()") :+ ("empty = s10.filter(x => false).product()")).mkString(","))
 
-    assert(ktProduct.collect() == IndexedSeq(Row("a", 0l, 2l, 2l, 6l, -1l, -3l, 80l, 1l, 0l, -4 d, 0d, 1d)))
+    assert(ktProduct.collect() == IndexedSeq(Row("a", 0l, 2l, 2l, 6l, -1l, -3l, 80l, 1l, 0l, -4d, 0d, 1d)))
 
   }
 

--- a/src/test/scala/is/hail/methods/AnnotateSuite.scala
+++ b/src/test/scala/is/hail/methods/AnnotateSuite.scala
@@ -46,7 +46,7 @@ class AnnotateSuite extends SparkSuite {
     assert(anno1.sampleIdsAndAnnotations
       .forall {
         case (id, sa) =>
-          fileMap.get(id).forall { case (status, qphen) =>
+          fileMap.get(id.asInstanceOf[String]).forall { case (status, qphen) =>
             status.liftedZip(Option(q1(sa))).exists { case (v1, v2) => v1 == v2 } &&
               (qphen.isEmpty && Option(q2(sa)).isEmpty || qphen.liftedZip(Option(q2(sa))).exists { case (v1, v2) => v1 == v2 })
           }
@@ -61,7 +61,7 @@ class AnnotateSuite extends SparkSuite {
     List("0", "0.0", ".0", "-01", "1e5", "1e10", "1.1e10", ".1E-10").foreach(assertNumeric)
     List("", "a", "1.", ".1.", "1e", "e", "E0", "1e1.", "1e.1", "1e1.1").foreach(assertNonNumeric)
 
-    def qMap(query: String, vds: VariantDataset): Map[String, Option[Any]] = {
+    def qMap(query: String, vds: VariantDataset): Map[Annotation, Option[Any]] = {
       val q = vds.querySA(query)._2
       vds.sampleIds
         .zip(vds.sampleAnnotations)

--- a/src/test/scala/is/hail/methods/AnnotateSuite.scala
+++ b/src/test/scala/is/hail/methods/AnnotateSuite.scala
@@ -31,7 +31,7 @@ class AnnotateSuite extends SparkSuite {
             case "NA" => None
             case x => Some(x.toInt)
           }
-          (split(0), (Some(split(1)), f3))
+          (split(0): Annotation, (Some(split(1)), f3))
         })
         .toMap
     }
@@ -44,9 +44,8 @@ class AnnotateSuite extends SparkSuite {
     val q2 = anno1.querySA("sa.`my phenotype`.qPhen")._2
 
     assert(anno1.sampleIdsAndAnnotations
-      .forall {
-        case (id, sa) =>
-          fileMap.get(id.asInstanceOf[String]).forall { case (status, qphen) =>
+      .forall { case (id, sa) =>
+          fileMap.get(id).forall { case (status, qphen) =>
             status.liftedZip(Option(q1(sa))).exists { case (v1, v2) => v1 == v2 } &&
               (qphen.isEmpty && Option(q2(sa)).isEmpty || qphen.liftedZip(Option(q2(sa))).exists { case (v1, v2) => v1 == v2 })
           }

--- a/src/test/scala/is/hail/methods/FilterSuite.scala
+++ b/src/test/scala/is/hail/methods/FilterSuite.scala
@@ -1,5 +1,6 @@
 package is.hail.methods
 
+import is.hail.annotations.Annotation
 import is.hail.expr._
 import is.hail.io.annotators.IntervalList
 import is.hail.utils._
@@ -104,7 +105,7 @@ class FilterSuite extends SparkSuite {
     val vds = TestRDDBuilder.buildRDD(8, 8, hc)
       .splitMulti()
 
-    val sampleList = hadoopConf.readLines("src/test/resources/filter.sample_list")(_.map(_.value).toSet)
+    val sampleList = hadoopConf.readLines("src/test/resources/filter.sample_list")(_.map(_.value: Annotation).toSet)
     assert(vds.filterSamplesList(sampleList).nSamples == 3)
 
     assert(vds.filterSamplesList(sampleList, keep = false).nSamples == 5)

--- a/src/test/scala/is/hail/methods/IBDSuite.scala
+++ b/src/test/scala/is/hail/methods/IBDSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.methods
 
 import is.hail.SparkSuite
+import is.hail.annotations.Annotation
 import is.hail.check.Prop._
 import is.hail.check.{Gen, Properties}
 import is.hail.expr.{TDouble, TInt, TString}
@@ -46,7 +47,7 @@ class IBDSuite extends SparkSuite {
 
   private def runPlinkIBD(vds: VariantDataset,
     min: Option[Double] = None,
-    max: Option[Double] = None): Map[(String, String), ExtendedIBDInfo] = {
+    max: Option[Double] = None): Map[(Annotation, Annotation), ExtendedIBDInfo] = {
 
     val tmpdir = tmpDir.createTempFile(prefix = "plinkIBD")
     val localTmpdir = tmpDir.createLocalTempFile(prefix = "plinkIBD")
@@ -79,8 +80,8 @@ class IBDSuite extends SparkSuite {
       .map { ann =>
         // _, fid1, iid1, fid2, iid2, rt, ez, z0, z1, z2, pihat, phe, dst, ppc, ratio, ibs0, ibs1, ibs2, homhom, hethet
         val row = ann.asInstanceOf[Row]
-        val iid1 = toS(row(2))
-        val iid2 = toS(row(4))
+        val iid1 = toS(row(2)): Annotation
+        val iid2 = toS(row(4)): Annotation
         val z0 = toD(row(7))
         val z1 = toD(row(8))
         val z2 = toD(row(9))

--- a/src/test/scala/is/hail/methods/KinshipMatrixSuite.scala
+++ b/src/test/scala/is/hail/methods/KinshipMatrixSuite.scala
@@ -5,6 +5,7 @@ import is.hail.utils._
 import scala.io.Source
 import is.hail.SparkSuite
 import is.hail.annotations.Annotation
+import is.hail.expr.TString
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix}
 import org.testng.annotations.Test
@@ -38,7 +39,7 @@ class KinshipMatrixSuite extends SparkSuite {
     val irdd = sc.parallelize(data)
     val irm = new IndexedRowMatrix(irdd)
     val samples = (0 to 3).map(i => s"S$i")
-    val km = new KinshipMatrix(hc, irm, samples.toArray, 10)
+    val km = KinshipMatrix(hc, TString, irm, samples.toArray, 10)
 
     val kmOneEntry = km.filterSamples(s => s == "S2")
     assert(kmOneEntry.matrix.toBlockMatrix().toLocalMatrix()(0, 0) == 11)
@@ -51,7 +52,7 @@ class KinshipMatrixSuite extends SparkSuite {
     val irdd = sc.parallelize(data)
     val irm = new IndexedRowMatrix(irdd)
     val samples = (0 to 3).map(i => s"S$i")
-    val km = new KinshipMatrix(hc, irm, samples.toArray, 10)
+    val km = KinshipMatrix(hc, TString, irm, samples.toArray, 10)
 
     val out = tmpDir.createTempFile("kinshipMatrixExportTSVTest", ".tsv")
 

--- a/src/test/scala/is/hail/methods/LinearRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearRegressionSuite.scala
@@ -7,6 +7,7 @@ import is.hail.expr.TDouble
 import is.hail.annotations.Querier
 import is.hail.expr.{TDouble, TString}
 import is.hail.io.plink.FamFileConfig
+import is.hail.keytable.KeyTable
 import is.hail.utils._
 import is.hail.variant.Variant
 import org.testng.annotations.Test
@@ -266,7 +267,7 @@ class LinearRegressionSuite extends SparkSuite {
 
     val vds = hc.importVCF("src/test/resources/regressionLinear.vcf")
       .annotateSamplesTable(covariates, root = "sa.cov")
-      .annotateSamplesFam("src/test/resources/regressionLinear.fam")
+      .annotateSamplesTable(KeyTable.importFam(hc, "src/test/resources/regressionLinear.fam"), root = "sa.fam")
       .linreg("sa.fam.isCase", Array("sa.cov.Cov1", "sa.cov.Cov2"))
 
     val qBeta = vds.queryVA("va.linreg.beta")._2
@@ -316,8 +317,7 @@ class LinearRegressionSuite extends SparkSuite {
 
     val vds = hc.importVCF("src/test/resources/regressionLinear.vcf")
       .annotateSamplesTable(covariates, root = "sa.cov")
-      .annotateSamplesFam("src/test/resources/regressionLinear.fam",
-        config = FamFileConfig(isQuantitative = true, missingValue = "0"))
+      .annotateSamplesTable(KeyTable.importFam(hc, "src/test/resources/regressionLinear.fam", isQuantitative = true, missingValue = "0"), root = "sa.fam")
       .linreg("sa.fam.qPheno", Array("sa.cov.Cov1", "sa.cov.Cov2"))
 
     val qBeta = vds.queryVA("va.linreg.beta")._2

--- a/src/test/scala/is/hail/methods/LogisticRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LogisticRegressionSuite.scala
@@ -3,6 +3,7 @@ package is.hail.methods
 import is.hail.SparkSuite
 import is.hail.annotations.{Annotation, Querier}
 import is.hail.expr.{TBoolean, TDouble}
+import is.hail.keytable.KeyTable
 import is.hail.utils._
 import is.hail.variant.Variant
 import org.testng.annotations.Test
@@ -345,7 +346,7 @@ class LogisticRegressionSuite extends SparkSuite {
       types = Map("PC1" -> TDouble, "PC2" -> TDouble), missing = "0").keyBy("IND_ID")
 
     val vds = hc.importVCF("src/test/resources/regressionLogisticEpacts.vcf")
-      .annotateSamplesFam("src/test/resources/regressionLogisticEpacts.fam")
+      .annotateSamplesTable(KeyTable.importFam(hc, "src/test/resources/regressionLogisticEpacts.fam"), root = "sa.fam")
       .annotateSamplesTable(covariates, root = "sa.pc")
       .logreg("wald", "sa.fam.isCase", Array("sa.fam.isFemale", "sa.pc.PC1", "sa.pc.PC2"), "va.wald")
       .logreg("lrt", "sa.fam.isCase", Array("sa.fam.isFemale", "sa.pc.PC1", "sa.pc.PC2"), "va.lrt")

--- a/src/test/scala/is/hail/methods/MendelErrorsSuite.scala
+++ b/src/test/scala/is/hail/methods/MendelErrorsSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.methods
 
 import is.hail.SparkSuite
+import is.hail.annotations.Annotation
 import is.hail.variant.Variant
 import org.testng.annotations.Test
 
@@ -8,7 +9,7 @@ class MendelErrorsSuite extends SparkSuite {
   @Test def test() {
     val vds = hc.importVCF("src/test/resources/mendel.vcf")
     val ped = Pedigree.read("src/test/resources/mendel.fam", sc.hadoopConfiguration)
-    val men = MendelErrors(vds, ped.filterTo(vds.sampleIds.toSet).completeTrios)
+    val men = MendelErrors(vds, ped.filterTo(vds.sampleIds.toSet[Annotation].map(_.asInstanceOf[String])).completeTrios)
 
     val nPerFam = men.nErrorPerNuclearFamily.collectAsMap()
     val nPerIndiv = men.nErrorPerIndiv.collectAsMap()
@@ -58,7 +59,7 @@ class MendelErrorsSuite extends SparkSuite {
     men.lMendelKT().typeCheck()
 
     val ped2 = Pedigree.read("src/test/resources/mendelWithMissingSex.fam", sc.hadoopConfiguration)
-    val men2 = MendelErrors(vds, ped2.filterTo(vds.sampleIds.toSet).completeTrios)
+    val men2 = MendelErrors(vds, ped2.filterTo(vds.stringSampleIdSet).completeTrios)
 
     assert(men2.mendelErrors.collect().toSet == men.mendelErrors.filter(_.trio.kid == "Dtr1").collect().toSet)
   }

--- a/src/test/scala/is/hail/methods/MendelErrorsSuite.scala
+++ b/src/test/scala/is/hail/methods/MendelErrorsSuite.scala
@@ -9,7 +9,7 @@ class MendelErrorsSuite extends SparkSuite {
   @Test def test() {
     val vds = hc.importVCF("src/test/resources/mendel.vcf")
     val ped = Pedigree.read("src/test/resources/mendel.fam", sc.hadoopConfiguration)
-    val men = MendelErrors(vds, ped.filterTo(vds.sampleIds.toSet[Annotation].map(_.asInstanceOf[String])).completeTrios)
+    val men = MendelErrors(vds, ped.filterTo(vds.stringSampleIdSet).completeTrios)
 
     val nPerFam = men.nErrorPerNuclearFamily.collectAsMap()
     val nPerIndiv = men.nErrorPerIndiv.collectAsMap()

--- a/src/test/scala/is/hail/methods/PCASuite.scala
+++ b/src/test/scala/is/hail/methods/PCASuite.scala
@@ -19,7 +19,8 @@ class PCASuite extends SparkSuite {
     val arrayT = TArray(TDouble)
     val structT = TStruct("PC1" -> TDouble, "PC2" -> TDouble, "PC3" -> TDouble)
 
-    val pyScores = Map("C1046::HG02024" -> IndexedSeq(-0.55141958610810227, 0.6480766747061064, -0.3559869584014231),
+    val pyScores = Map[Annotation, IndexedSeq[Double]](
+      "C1046::HG02024" -> IndexedSeq(-0.55141958610810227, 0.6480766747061064, -0.3559869584014231),
       "C1046::HG02025" -> IndexedSeq(-0.6916959815105279, -0.7626843185339386, -0.13868806289543628),
       "C1046::HG02026" -> IndexedSeq(1.487286902938744, -0.08212707761864713, -0.09901636248685303),
       "C1047::HG00731" -> IndexedSeq(-0.2441713353201146, 0.19673472144647947, 0.5936913837837123))

--- a/src/test/scala/is/hail/methods/PedigreeSuite.scala
+++ b/src/test/scala/is/hail/methods/PedigreeSuite.scala
@@ -8,10 +8,10 @@ import org.testng.annotations.Test
 class PedigreeSuite extends SparkSuite {
   @Test def test() {
     val vds = hc.importVCF("src/test/resources/pedigree.vcf")
-    val ped = Pedigree.read("src/test/resources/pedigree.fam", sc.hadoopConfiguration).filterTo(vds.sampleIds.toSet)
+    val ped = Pedigree.read("src/test/resources/pedigree.fam", sc.hadoopConfiguration).filterTo(vds.stringSampleIdSet)
     val f = tmpDir.createTempFile("pedigree", ".fam")
     ped.write(f, sc.hadoopConfiguration)
-    val pedwr = Pedigree.read(f, sc.hadoopConfiguration).filterTo(vds.sampleIds.toSet)
+    val pedwr = Pedigree.read(f, sc.hadoopConfiguration).filterTo(vds.stringSampleIdSet)
     assert(ped.trios == pedwr.trios) // this passes because all samples in .fam are in pedigree.vcf
 
     val nuclearFams = Pedigree.nuclearFams(ped.completeTrios)
@@ -25,7 +25,7 @@ class PedigreeSuite extends SparkSuite {
     assert(ped.nSatisfying(_.isMale) == 6 && ped.nSatisfying(_.isFemale) == 5)
 
     val ped2 = Pedigree.read("src/test/resources/pedigreeWithExtraSample.fam", sc.hadoopConfiguration)
-      .filterTo(vds.sampleIds.toSet)
+      .filterTo(vds.stringSampleIdSet)
 
     assert(ped.trios.toSet == ped2.trios.toSet)
   }

--- a/src/test/scala/is/hail/methods/RenameSamplesSuite.scala
+++ b/src/test/scala/is/hail/methods/RenameSamplesSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.methods
 
 import is.hail.SparkSuite
+import is.hail.annotations.Annotation
 import is.hail.check.Gen
 import is.hail.utils.{HailException, _}
 import org.testng.annotations.Test
@@ -16,7 +17,7 @@ class RenameSamplesSuite extends SparkSuite {
   @Test def testCollision() {
     val vds = hc.importVCF("src/test/resources/sample.vcf")
 
-    val m = mutable.Map[String, String](
+    val m = mutable.Map[Annotation, String](
       vds.sampleIds(0) -> "a",
       vds.sampleIds(1) -> "a"
     )
@@ -31,8 +32,8 @@ class RenameSamplesSuite extends SparkSuite {
     val vds = hc.importVCF("src/test/resources/sample.vcf")
 
     val samples = vds.sampleIds.toSet
-    val newSamples = mutable.Set[String](samples.toArray: _*)
-    val m = mutable.Map.empty[String, String]
+    val newSamples = mutable.Set[Annotation](samples.toArray: _*)
+    val m = mutable.Map.empty[Annotation, Annotation]
     val genNewSample = Gen.identifier.filter(newS => !newSamples.contains(newS))
     for (s <- vds.sampleIds) {
       Gen.option(genNewSample, 0.5).sample() match {

--- a/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
@@ -215,7 +215,7 @@ class VSMSuite extends SparkSuite {
 
     val samples = vds.sampleIds
     for (n <- 0 until 20) {
-      val keep = mutable.Set.empty[String]
+      val keep = mutable.Set.empty[Annotation]
 
       // n == 0: none
       if (n == 1) {

--- a/src/test/scala/is/hail/vds/AggregateByKeySuite.scala
+++ b/src/test/scala/is/hail/vds/AggregateByKeySuite.scala
@@ -19,7 +19,7 @@ class AggregateByKeySuite extends SparkSuite {
     val (_, saHetQuerier) = vds.querySA("sa.nHet")
 
     val ktSampleResults = kt.rdd.map { a =>
-      (Option(ktSampleQuerier(a)).map(_.asInstanceOf[String]), Option(ktHetQuerier(a)).map(_.asInstanceOf[Int]))
+      (Option(ktSampleQuerier(a)), Option(ktHetQuerier(a)).map(_.asInstanceOf[Int]))
     }.collectAsMap()
 
     assert(vds.sampleIdsAndAnnotations.forall { case (sid, sa) => Option(saHetQuerier(sa)) == ktSampleResults(Option(sid)) })


### PR DESCRIPTION
... and some infrastructure for generic row (variant) key.

Some VSM methods require sample key is String, basically those that use pedigrees.

I think it is feature complete but there is currently no way to create a non-string column key and there is no non-string column key tests.
