### PR TITLE
Simplifed RegUtils and retrofit to 0.1

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -2438,16 +2438,16 @@ class VariantDataset(object):
         such as when all genotypes are homozygous reference. One can further
         restrict computation to those variants with at least :math:`k` observed
         alternate alleles (AC) or alternate allele frequency (AF) at least
-        :math:`p` in the included samples using the options ``minac=k`` or
-        ``minaf=p``, respectively. Unlike the :py:meth:`.filter_variants_expr`
+        :math:`p` in the included samples using the options ``min_ac=k`` or
+        ``min_af=p``, respectively. Unlike the :py:meth:`.filter_variants_expr`
         method, these filters do not remove variants from the underlying
-        variant dataset. Adding both filters is equivalent to applying the more
-        stringent of the two, as AF equals AC over twice the number of included
-        samples.
+        variant dataset; rather the linear regression annotations for variants with
+        low AC or AF are set to missing. Adding both filters is equivalent to applying
+        the more stringent of the two.
 
         Phenotype and covariate sample annotations may also be specified using `programmatic expressions <exprlang.html>`__ without identifiers, such as:
 
-        >>> vds_result = vds.linreg('if (sa.pheno.isFemale) sa.pheno.age else (2 * sa.pheno.age + 10)', covariates=[])
+        >>> vds_result = vds.linreg('if (sa.pheno.isFemale) sa.pheno.age else (2 * sa.pheno.age + 10)')
 
         For Boolean covariate types, true is coded as 1 and false as 0. In particular, for the sample annotation ``sa.fam.isCase`` added by importing a FAM file with case-control phenotype, case is 1 and control is 0.
 
@@ -2819,7 +2819,8 @@ class VariantDataset(object):
         | ``va.lmmreg.pval``     | Double | :math:`p`-value                                                         |
         +------------------------+--------+-------------------------------------------------------------------------+
 
-        Those variants that don't vary across the included samples (e.g., all genotypes are HomRef) will have missing annotations.
+        :py:meth:`.lmmreg` skips variants that don't vary across the included samples,
+        such as when all genotypes are homozygous reference.
 
         The simplest way to export all resulting annotations is:
 
@@ -3067,6 +3068,9 @@ class VariantDataset(object):
         The Firth test reduces bias from small counts and resolves the issue of separation by penalizing maximum likelihood estimation by the `Jeffrey's invariant prior <https://en.wikipedia.org/wiki/Jeffreys_prior>`__. This test is slower, as both the null and full model must be fit per variant, and convergence of the modified Newton method is linear rather than quadratic. For Firth, 100 iterations are attempted for the null model and, if that is successful, for the full model as well. In testing we find 20 iterations nearly always suffices. If the null model fails to converge, then the ``sa.lmmreg.fit`` annotations reflect the null model; otherwise, they reflect the full model.
 
         See `Recommended joint and meta-analysis strategies for case-control association testing of single low-count variants <http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4049324/>`__ for an empirical comparison of the logistic Wald, LRT, score, and Firth tests. The theoretical foundations of the Wald, likelihood ratio, and score tests may be found in Chapter 3 of Gesine Reinert's notes `Statistical Theory <http://www.stats.ox.ac.uk/~reinert/stattheory/theoryshort09.pdf>`__.  Firth introduced his approach in `Bias reduction of maximum likelihood estimates, 1993 <http://www2.stat.duke.edu/~scs/Courses/Stat376/Papers/GibbsFieldEst/BiasReductionMLE.pdf>`__. Heinze and Schemper further analyze Firth's approach in `A solution to the problem of separation in logistic regression, 2002 <https://cemsiis.meduniwien.ac.at/fileadmin/msi_akim/CeMSIIS/KB/volltexte/Heinze_Schemper_2002_Statistics_in_Medicine.pdf>`__.
+
+        :py:meth:`.logreg` skips variants that don't vary across the included samples,
+        such as when all genotypes are homozygous reference.
 
         Phenotype and covariate sample annotations may also be specified using `programmatic expressions <exprlang.html>`__ without identifiers, such as:
 

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -2434,8 +2434,8 @@ class VariantDataset(object):
         is coded as :math:`1` for true (female) and :math:`0` for false (male). The null
         model sets :math:`\beta_1 = 0`.
 
-        :py:meth:`.linreg` skips variants that don't vary across the included samples,
-        such as when all genotypes are homozygous reference. One can further
+        Those variants that don't vary across the included samples (e.g., all genotypes
+        are HomRef) will have missing annotations. One can further
         restrict computation to those variants with at least :math:`k` observed
         alternate alleles (AC) or alternate allele frequency (AF) at least
         :math:`p` in the included samples using the options ``min_ac=k`` or
@@ -2819,8 +2819,8 @@ class VariantDataset(object):
         | ``va.lmmreg.pval``     | Double | :math:`p`-value                                                         |
         +------------------------+--------+-------------------------------------------------------------------------+
 
-        :py:meth:`.lmmreg` skips variants that don't vary across the included samples,
-        such as when all genotypes are homozygous reference.
+        Those variants that don't vary across the included samples (e.g., all genotypes
+        are HomRef) will have missing annotations.
 
         The simplest way to export all resulting annotations is:
 
@@ -3069,8 +3069,8 @@ class VariantDataset(object):
 
         See `Recommended joint and meta-analysis strategies for case-control association testing of single low-count variants <http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4049324/>`__ for an empirical comparison of the logistic Wald, LRT, score, and Firth tests. The theoretical foundations of the Wald, likelihood ratio, and score tests may be found in Chapter 3 of Gesine Reinert's notes `Statistical Theory <http://www.stats.ox.ac.uk/~reinert/stattheory/theoryshort09.pdf>`__.  Firth introduced his approach in `Bias reduction of maximum likelihood estimates, 1993 <http://www2.stat.duke.edu/~scs/Courses/Stat376/Papers/GibbsFieldEst/BiasReductionMLE.pdf>`__. Heinze and Schemper further analyze Firth's approach in `A solution to the problem of separation in logistic regression, 2002 <https://cemsiis.meduniwien.ac.at/fileadmin/msi_akim/CeMSIIS/KB/volltexte/Heinze_Schemper_2002_Statistics_in_Medicine.pdf>`__.
 
-        :py:meth:`.logreg` skips variants that don't vary across the included samples,
-        such as when all genotypes are homozygous reference.
+        Those variants that don't vary across the included samples (e.g., all genotypes
+        are HomRef) will have missing annotations.
 
         Phenotype and covariate sample annotations may also be specified using `programmatic expressions <exprlang.html>`__ without identifiers, such as:
 

--- a/src/main/scala/is/hail/methods/LinearMixedRegression.scala
+++ b/src/main/scala/is/hail/methods/LinearMixedRegression.scala
@@ -140,24 +140,15 @@ object LinearMixedRegression {
       val (newVAS, inserter) = vds2.insertVA(LinearMixedRegression.schema, pathVA)
 
       vds2.mapAnnotations { case (v, va, gs) =>
-        val (x0, nHet, nHomVar, nMissing) = RegressionUtils.hardCallStats(gs, sampleMaskBc.value)
-        val ac = nHet + 2 * nHomVar
-        val nPresent = n - nMissing
-        val isValid = !(ac == 0 || ac == 2 * nPresent || (ac == nPresent && x0.forall(_ == 1)))
+        val x = RegressionUtils.hardCalls(gs, n, sampleMaskBc.value)
 
-        val lmmregAnnot =
-          if (isValid) {
-            val x: Vector[Double] = {
-              val sparsity = (nHet + nHomVar + nMissing).toDouble / n
-              if (sparsity <= sparsityThreshold)
-                x0
-              else
-                x0.toDenseVector
-            }
-            scalerLMMBc.value.likelihoodRatioTest(TBc.value * x)
-          } else
-            null
-
+        // constant checking to be removed in 0.2
+        val nonConstant = !RegressionUtils.constantHardCalls(x)
+        
+        val x0 = if (x.used <= sparsityThreshold * n) x else x.toDenseVector
+        
+        val lmmregAnnot = if (nonConstant) scalerLMMBc.value.likelihoodRatioTest(TBc.value * x0) else null
+        println(v, lmmregAnnot)
         val newAnnotation = inserter(va, lmmregAnnot)
         assert(newVAS.typeCheck(newAnnotation))
         newAnnotation

--- a/src/main/scala/is/hail/methods/LinearMixedRegression.scala
+++ b/src/main/scala/is/hail/methods/LinearMixedRegression.scala
@@ -143,12 +143,11 @@ object LinearMixedRegression {
         val x = RegressionUtils.hardCalls(gs, n, sampleMaskBc.value)
 
         // constant checking to be removed in 0.2
-        val nonConstant = !RegressionUtils.constantHardCalls(x)
+        val nonConstant = !RegressionUtils.constantVector(x)
         
         val x0 = if (x.used <= sparsityThreshold * n) x else x.toDenseVector
         
         val lmmregAnnot = if (nonConstant) scalerLMMBc.value.likelihoodRatioTest(TBc.value * x0) else null
-        println(v, lmmregAnnot)
         val newAnnotation = inserter(va, lmmregAnnot)
         assert(newVAS.typeCheck(newAnnotation))
         newAnnotation

--- a/src/main/scala/is/hail/methods/LinearRegression.scala
+++ b/src/main/scala/is/hail/methods/LinearRegression.scala
@@ -27,7 +27,7 @@ object LinearRegression {
 
     if (minAC < 1)
       fatal(s"Minumum alternate allele count must be a positive integer, got $minAC")
-    if (minAF < 0d || minAF > 1d)
+    if (minAF < 0 || minAF > 1)
       fatal(s"Minumum alternate allele frequency must lie in [0.0, 1.0], got $minAF")
     val combinedMinAC = math.max(minAC, (math.ceil(2 * n * minAF) + 0.5).toInt)
 
@@ -50,18 +50,18 @@ object LinearRegression {
     val (newVAS, inserter) = vds.insertVA(LinearRegression.schema, pathVA)
 
     vds.mapAnnotations { case (v, va, gs) =>
-
-      val (x: Vector[Double], isValid: Boolean) =
-        if (useDosages) {
-          val (x, mean) = RegressionUtils.dosageStats(gs, sampleMaskBc.value, n)
-          (x, n * mean >= combinedMinAC)
-        } else {
-          val (x, nHet, nHomVar, nMissing) = RegressionUtils.hardCallStats(gs, sampleMaskBc.value)
-          val ac = nHet + 2 * nHomVar
-          (x, !(ac < combinedMinAC || ac == 2 * (n - nMissing) || (ac == (n - nMissing) && x.forall(_ == 1))))
+      val (x: Vector[Double], ac) =
+        if (!useDosages) // replace by hardCalls in 0.2, with ac post-imputation
+          RegressionUtils.hardCallsWithAC(gs, n, sampleMaskBc.value)
+        else {
+          val x0 = RegressionUtils.dosages(gs, n, sampleMaskBc.value)
+          (x0, sum(x0))
         }
 
-      val linregAnnot = if (isValid) {
+      // constant checking to be removed in 0.2
+      val nonConstant = useDosages || !RegressionUtils.constantHardCalls(x)
+      
+      val linregAnnot = if (ac >= combinedMinAC && nonConstant) {
         val qtx = QtBc.value * x
         val qty = QtyBc.value
         val xxp: Double = (x dot x) - (qtx dot qtx)

--- a/src/main/scala/is/hail/methods/LinearRegressionMultiPheno.scala
+++ b/src/main/scala/is/hail/methods/LinearRegressionMultiPheno.scala
@@ -48,24 +48,22 @@ object LinearRegressionMultiPheno {
     val QtyBc = sc.broadcast(Qty)
     val yypBc = sc.broadcast(y.t(*, ::).map(r => r dot r) - Qty.t(*, ::).map(r => r dot r))
 
-    val yDummyBc = sc.broadcast(DenseVector.zeros[Double](n)) // dummy input in order to reuse RegressionUtils
-
     val pathVA = Parser.parseAnnotationRoot(root, Annotation.VARIANT_HEAD)
     val (newVAS, inserter) = vds.insertVA(LinearRegressionMultiPheno.schema, pathVA)
 
     vds.mapAnnotations { case (v, va, gs) =>
-
-      val (x: Vector[Double], isValid: Boolean) =
-        if (useDosages) {
-          val (x, mean) = RegressionUtils.dosageStats(gs, sampleMaskBc.value, n)
-          (x, n * mean >= combinedMinAC)
-        } else {
-          val (x, nHet, nHomVar, nMissing) = RegressionUtils.hardCallStats(gs, sampleMaskBc.value)
-          val ac = nHet + 2 * nHomVar
-          (x, !(ac < combinedMinAC || ac == 2 * (n - nMissing) || (ac == (n - nMissing) && x.forall(_ == 1))))
+      val (x: Vector[Double], ac) =
+        if (!useDosages) // replace by hardCalls in 0.2, with ac post-imputation
+          RegressionUtils.hardCallsWithAC(gs, n, sampleMaskBc.value)
+        else {
+          val x0 = RegressionUtils.dosages(gs, n, sampleMaskBc.value)
+          (x0, sum(x0))
         }
 
-      val linregAnnot = if (isValid) {
+      // constant checking to be removed in 0.2
+      val nonConstant = useDosages || !RegressionUtils.constantHardCalls(x)
+      
+      val linregAnnot = if (ac >= combinedMinAC && nonConstant) {
         val qtx: DenseVector[Double] = QtBc.value * x
         val qty: DenseMatrix[Double] = QtyBc.value
         val xxpRec: Double = 1 / ((x dot x) - (qtx dot qtx))

--- a/src/main/scala/is/hail/methods/LinearRegressionMultiPheno.scala
+++ b/src/main/scala/is/hail/methods/LinearRegressionMultiPheno.scala
@@ -61,7 +61,7 @@ object LinearRegressionMultiPheno {
         }
 
       // constant checking to be removed in 0.2
-      val nonConstant = useDosages || !RegressionUtils.constantHardCalls(x)
+      val nonConstant = useDosages || !RegressionUtils.constantVector(x)
       
       val linregAnnot = if (ac >= combinedMinAC && nonConstant) {
         val qtx: DenseVector[Double] = QtBc.value * x

--- a/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -60,18 +60,18 @@ object LogisticRegression {
     vds.copy(rdd = vds.rdd.mapPartitions( { it =>
       val X = XBc.value.copy
       it.map { case (v, (va, gs)) =>
-        val isNotDegenerate =
-          if (useDosages)
-            RegressionUtils.setLastColumnToMaskedGts(X, gs.dosageIterator, sampleMaskBc.value, useHardCalls=false)
+        val x: Vector[Double] = 
+          if (!useDosages)
+            RegressionUtils.hardCalls(gs, n, sampleMaskBc.value)
           else
-            RegressionUtils.setLastColumnToMaskedGts(X, gs.hardCallIterator, sampleMaskBc.value, useHardCalls=true)
+            RegressionUtils.dosages(gs, n, sampleMaskBc.value)
 
-        val logregAnnot =
-          if (isNotDegenerate)
-            logRegTestBc.value.test(X, yBc.value, nullFitBc.value).toAnnotation
-          else
-            null
+        X(::, -1) := x
 
+        // constant checking to be removed in 0.2
+        val nonConstant = useDosages || !RegressionUtils.constantHardCalls(x)
+        
+        val logregAnnot = if (nonConstant) logRegTestBc.value.test(X, yBc.value, nullFitBc.value).toAnnotation else null
         val newAnnotation = inserter(va, logregAnnot)
         assert(newVAS.typeCheck(newAnnotation))
         (v, (newAnnotation, gs))

--- a/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -69,7 +69,7 @@ object LogisticRegression {
         X(::, -1) := x
 
         // constant checking to be removed in 0.2
-        val nonConstant = useDosages || !RegressionUtils.constantHardCalls(x)
+        val nonConstant = useDosages || !RegressionUtils.constantVector(x)
         
         val logregAnnot = if (nonConstant) logRegTestBc.value.test(X, yBc.value, nullFitBc.value).toAnnotation else null
         val newAnnotation = inserter(va, logregAnnot)

--- a/src/main/scala/is/hail/methods/LogisticRegressionBurden.scala
+++ b/src/main/scala/is/hail/methods/LogisticRegressionBurden.scala
@@ -78,7 +78,9 @@ object LogisticRegressionBurden {
       val X = XBc.value.copy
       it.map { keyedRow =>
         X(::, -1) := RegressionUtils.keyedRowToVectorDouble(keyedRow)
-        merger(Row(keyedRow.get(0)), logRegTestBc.value.test(X, yBc.value, nullFitBc.value).toAnnotation).asInstanceOf[Row]
+        merger(
+          Row(keyedRow.get(0)),
+          logRegTestBc.value.test(X, yBc.value, nullFitBc.value).toAnnotation).asInstanceOf[Row]
       }
     })
 

--- a/src/main/scala/is/hail/stats/LinearRegressionModel.scala
+++ b/src/main/scala/is/hail/stats/LinearRegressionModel.scala
@@ -1,0 +1,20 @@
+package is.hail.stats
+
+import breeze.linalg.{Matrix, Vector}
+import is.hail.annotations.Annotation
+import net.sourceforge.jdistlib.T
+
+object LinearRegressionModel {
+    def fit(x: Vector[Double], y: Vector[Double], yyp: Double, qt: Matrix[Double], qty: Vector[Double], d: Int): Annotation = {
+      val qtx = qt * x
+      val xxp = (x dot x) - (qtx dot qtx)
+      val xyp = (x dot y) - (qtx dot qty)
+
+      val b = xyp / xxp
+      val se = math.sqrt((yyp / xxp - b * b) / d)
+      val t = b / se
+      val p = 2 * T.cumulative(-math.abs(t), d, true, false)
+
+      Annotation(b, se, t, p)
+    }
+}

--- a/src/main/scala/is/hail/stats/RegressionUtils.scala
+++ b/src/main/scala/is/hail/stats/RegressionUtils.scala
@@ -1,6 +1,6 @@
 package is.hail.stats
 
-import breeze.linalg.{DenseMatrix, DenseVector, SparseVector}
+import breeze.linalg._
 import is.hail.annotations.Annotation
 import is.hail.expr._
 import is.hail.utils._
@@ -8,6 +8,168 @@ import is.hail.variant.{Genotype, VariantDataset}
 import org.apache.spark.sql.Row
 
 object RegressionUtils {
+  // mask == null is interpreted as no mask
+  // impute uses mean for missing gt rather than Double.NaN
+  def hardCalls(gs: Iterable[Genotype], nKept: Int, mask: Array[Boolean] = null, impute: Boolean = true): SparseVector[Double] = {
+    val gts = gs.hardCallIterator
+    val rows = new ArrayBuilder[Int]()
+    val vals = new ArrayBuilder[Double]()
+    val missingSparseIndices = new ArrayBuilder[Int]()
+    var i = 0
+    var row = 0
+    var sum = 0
+    while (gts.hasNext) {
+      val gt = gts.next()
+      if (mask == null || mask(i)) {
+        if (gt != 0) {
+          rows += row
+          if (gt != -1) {
+            sum += gt
+            vals += gt.toDouble
+          } else {
+            missingSparseIndices += vals.size
+            vals += Double.NaN
+          }
+        }
+        row += 1
+      }
+      i += 1
+    }
+    assert((mask == null || i == mask.size) && row == nKept)
+
+    val valsArray = vals.result()
+    val nMissing = missingSparseIndices.size
+    if (impute) {
+      val mean = sum.toDouble / (nKept - nMissing)
+      i = 0
+      while (i < nMissing) {
+        valsArray(missingSparseIndices(i)) = mean
+        i += 1
+      }
+    }
+
+    new SparseVector[Double](rows.result(), valsArray, row)
+  }
+
+  // mask == null is interpreted as no mask
+  // impute uses mean for missing dosage rather than Double.NaN
+  def dosages(gs: Iterable[Genotype], nKept: Int, mask: Array[Boolean] = null, impute: Boolean = true): DenseVector[Double] = {
+    val gts = gs.dosageIterator
+    val vals = Array.ofDim[Double](nKept)
+    val missingRows = new ArrayBuilder[Int]()
+    var i = 0
+    var row = 0
+    var sum = 0d
+    while (gts.hasNext) {
+      val gt = gts.next()
+      if (mask == null || mask(i)) {
+        if (gt != -1) {
+          sum += gt
+          vals(row) = gt
+        } else
+          missingRows += row
+        row += 1
+      }
+      i += 1
+    }
+    assert((mask == null || i == mask.size) && row == nKept)
+
+    val nMissing = missingRows.size
+    val meanValue = if (impute) sum / (nKept - nMissing) else Double.NaN
+    i = 0
+    while (i < nMissing) {
+      vals(missingRows(i)) = meanValue
+      i += 1
+    }
+
+    DenseVector(vals)
+  }
+
+  // keyedRow consists of row key followed by numeric data
+  // impute uses mean for missing value rather than Double.NaN
+  // if any non-missing value is Double.NaN, then mean is Double.NaN
+  def keyedRowToVectorDouble(keyedRow: Row, impute: Boolean = true): DenseVector[Double] = {
+    val n = keyedRow.length - 1
+    val vals = Array.ofDim[Double](n)
+    val missingRows = new ArrayBuilder[Int]()
+    var sum = 0d
+    var row = 0
+    while (row < n) {
+      val e0 = keyedRow.get(row + 1)
+      if (e0 != null) {
+        val e = e0.asInstanceOf[java.lang.Number].doubleValue()
+        vals(row) = e
+        sum += e
+      } else
+        missingRows += row
+      row += 1
+    }
+
+    val nMissing = missingRows.size
+    val missingValue = if (impute) sum / (n - nMissing) else Double.NaN
+    var i = 0
+    while (i < nMissing) {
+      vals(missingRows(i)) = missingValue
+      i += 1
+    }
+
+    DenseVector[Double](vals)
+  }
+
+  // !useHWE: mean 0, norm exactly sqrt(n), variance 1
+  // useHWE: mean 0, norm approximately sqrt(m), variance approx. m / n
+  // missing gt are mean imputed, constant variants return None, only HWE uses nVariants
+  def normalizedHardCalls(gs: Iterable[Genotype], nSamples: Int, useHWE: Boolean = false, nVariants: Int = -1): Option[Array[Double]] = {
+    require(!(useHWE && nVariants == -1))
+    val gts = gs.hardCallIterator
+    val vals = Array.ofDim[Double](nSamples)
+    var nMissing = 0
+    var sum = 0
+    var sumSq = 0
+
+    var row = 0
+    while (row < nSamples) {
+      val gt = gts.next()
+      vals(row) = gt
+      (gt: @unchecked) match {
+        case 0 =>
+        case 1 =>
+          sum += 1
+          sumSq += 1
+        case 2 =>
+          sum += 2
+          sumSq += 4
+        case -1 =>
+          nMissing += 1
+      }
+      row += 1
+    }
+
+    val nPresent = nSamples - nMissing
+    val nonConstant = !(sum == 0 || sum == 2 * nPresent || sum == nPresent && sumSq == nPresent)
+
+    if (nonConstant) {
+      val mean = sum.toDouble / nPresent
+      val stdDev = math.sqrt(
+        if (useHWE)
+          mean * (2 - mean) * nVariants / 2
+        else {
+          val meanSq = (sumSq + nMissing * mean * mean) / nSamples
+          meanSq - mean * mean
+        })
+
+      val gtDict = Array(0, - mean / stdDev, (1 - mean) / stdDev, (2 - mean) / stdDev)
+      var i = 0
+      while (i < nSamples) {
+        vals(i) = gtDict(vals(i).toInt + 1)
+        i += 1
+      }
+      
+      Some(vals)
+    } else
+      None
+  }
+
   def toDouble(t: Type, code: String): Any => Double = t match {
     case TInt => _.asInstanceOf[Int].toDouble
     case TLong => _.asInstanceOf[Long].toDouble
@@ -119,336 +281,59 @@ object RegressionUtils {
     (y, cov, completeSamples)
   }
 
-  def setLastColumnToMaskedGts(X: DenseMatrix[Double], gts: HailIterator[Double], mask: Array[Boolean], useHardCalls: Boolean): Boolean = {
-    require(X.offset == 0 && X.majorStride == X.rows && !X.isTranspose)
-
-    val nMaskedSamples = X.rows
-    val k = X.cols - 1
-    var missingIndices = new ArrayBuilder[Int]()
-    var i = 0
-    var j = k * nMaskedSamples
-    var gtSum = 0d
-    while (i < mask.length) {
-      val gt = gts.next()
-      if (mask(i)) {
-        if (gt != -1) {
-          gtSum += gt
-          X.data(j) = gt
-        } else
-          missingIndices += j
-        j += 1
-      }
+  // Retrofitting for 0.1, will be removed at 2.0 when constant checking is dropped (unless otherwise useful)
+  def constantHardCalls(x: Vector[Double]): Boolean = {
+    require(x.size > 0)
+    var curr = x(0)
+    var i = 1
+    while (i < x.size) {
+      val next = x(i)
+      if (next != curr) return false
+      curr = next
       i += 1
     }
-
-    val missingIndicesArray = missingIndices.result()
-    val nPresent = nMaskedSamples - missingIndicesArray.size
-
-    if (nPresent > 0) {
-      val gtMean = gtSum / nPresent
-
-      i = 0
-      while (i < missingIndicesArray.size) {
-        X.data(missingIndicesArray(i)) = gtMean
-        i += 1
-      }
-    }
-
-    (useHardCalls &&
-      !(gtSum == 0 || gtSum == 2 * nPresent || (gtSum == nPresent && X.data.drop(nMaskedSamples * k).forall(_ == 1d)))) ||
-      (!useHardCalls && nPresent > 0)
+    true
   }
-
-  //keyedRow consists of row key followed by numeric data (passed with key to avoid copying, key is ignored here)
-  def setLastColumnToKeyedRow(X: DenseMatrix[Double], keyedRow: Row): Boolean = {
-    val n = X.rows
-    val k = X.cols - 1
-    var missingRowIndices = new ArrayBuilder[Int]()
-    var gtSum = 0d
-
-    var i = 0
-    var j = k * n
-    while (i < n) {
-      if (keyedRow.get(i + 1) == null)
-        missingRowIndices += j + i
-      else {
-        val e = keyedRow.get(i + 1).asInstanceOf[java.lang.Number].doubleValue()
-        X.data(j + i) = e
-        gtSum += e
-      }
-      i += 1
-    }
-
-    val missingIndicesArray = missingRowIndices.result()
-    val nMissing = missingIndicesArray.length
-    val nPresent = n - nMissing
-    val somePresent = nPresent > 0
-
-    if (somePresent) {
-      val gtMean = gtSum / nPresent
-
-      i = 0
-      while (i < missingIndicesArray.length) {
-        X.data(missingIndicesArray(i)) = gtMean
-        i += 1
-      }
-    }
-
-    somePresent
-  }
-
-  // mean 0, norm sqrt(n), variance 1 (constant variants return None)
-  def toNormalizedGtArray(gs: Iterable[Genotype], nSamples: Int): Option[Array[Double]] = {
-    val gtVals = Array.ofDim[Double](nSamples)
-    var nMissing = 0
-    var gtSum = 0
-    var gtSumSq = 0
+    
+  // Retrofitting for 0.1, will be removed at 2.0 when linreg AC is calculated post-imputation
+  def hardCallsWithAC(gs: Iterable[Genotype], nKept: Int, mask: Array[Boolean] = null, impute: Boolean = true): (SparseVector[Double], Double) = {
     val gts = gs.hardCallIterator
-
+    val rows = new ArrayBuilder[Int]()
+    val vals = new ArrayBuilder[Double]()
+    val missingSparseIndices = new ArrayBuilder[Int]()
     var i = 0
-    while (i < nSamples) {
-      val gt = gts.next()
-      gtVals(i) = gt
-      (gt: @unchecked) match {
-        case 0 =>
-        case 1 =>
-          gtSum += 1
-          gtSumSq += 1
-        case 2 =>
-          gtSum += 2
-          gtSumSq += 4
-        case -1 =>
-          nMissing += 1
-      }
-      i += 1
-    }
-
-    val nPresent = nSamples - nMissing
-
-    if (gtSum == 0 || gtSum == 2 * nPresent || gtSum == nPresent && gtSumSq == nPresent)
-      None
-    else {
-      val gtMean = gtSum.toDouble / nPresent
-      val gtMeanSqAll = (gtSumSq + nMissing * gtMean * gtMean) / nSamples
-      val gtStdDevRec = 1 / math.sqrt(gtMeanSqAll - gtMean * gtMean)
-
-      val gtDict = Array(0, (-gtMean) * gtStdDevRec, (1 - gtMean) * gtStdDevRec, (2 - gtMean) * gtStdDevRec)
-
-      var j = 0
-      while (j < nSamples) {
-        gtVals(j) = gtDict(gtVals(j).toInt + 1)
-        j += 1
-      }
-
-      Some(gtVals)
-    }
-  }
-
-  // mean 0, norm approx. sqrt(m), variance approx. 1 (constant variants return None)
-  def toHWENormalizedGtArray(gs: Iterable[Genotype], nSamples: Int, nVariants: Int): Option[Array[Double]] = {
-    val gtVals = Array.ofDim[Double](nSamples)
-    var nMissing = 0
-    var gtSum = 0
-    val gts = gs.hardCallIterator
-
-    var i = 0
-    while (i < nSamples) {
-      val gt = gts.next()
-      gtVals(i) = gt
-      (gt: @unchecked) match {
-        case 0 =>
-        case 1 =>
-          gtSum += 1
-        case 2 =>
-          gtSum += 2
-        case -1 =>
-          nMissing += 1
-      }
-      i += 1
-    }
-
-    val nPresent = nSamples - nMissing
-
-    if (gtSum == 0 || gtSum == 2 * nPresent || gtSum == nPresent && gtVals.forall(gt => gt == 1 || gt == -1))
-      None
-    else {
-      val gtMean = gtSum.toDouble / nPresent
-      val p = 0.5 * gtMean
-      val hweStdDevRec = 1 / math.sqrt(2 * p * (1 - p) * nVariants)
-
-      val gtDict = Array(0, (-gtMean) * hweStdDevRec, (1 - gtMean) * hweStdDevRec, (2 - gtMean) * hweStdDevRec)
-
-      var j = 0
-      while (j < nSamples) {
-        gtVals(j) = gtDict(gtVals(j).toInt + 1)
-        j += 1
-      }
-
-      Some(gtVals)
-    }
-  }
-
-  // constructs DenseVector x of hard calls with missing values mean-imputed
-  // mask == null implies no mask
-  def dosageStats(gs: Iterable[Genotype], mask: Array[Boolean], nKept: Int): (DenseVector[Double], Double) = {
-    val valsX = Array.ofDim[Double](nKept)
-    val missingRowIndices = new ArrayBuilder[Int]()
-    var sumX = 0d
-    var nMissing = 0
     var row = 0
-    val gts = gs.dosageIterator
-
-    var i = 0
+    var sum = 0
     while (gts.hasNext) {
       val gt = gts.next()
       if (mask == null || mask(i)) {
-        if (gt != -1) {
-          valsX(row) = gt
-          sumX += gt
-        } else {
-          nMissing += 1
-          missingRowIndices += row
+        if (gt != 0) {
+          rows += row
+          if (gt != -1) {
+            sum += gt
+            vals += gt.toDouble
+          } else {
+            missingSparseIndices += vals.size
+            vals += Double.NaN
+          }
         }
         row += 1
       }
       i += 1
     }
-    assert(row == nKept)
+    assert((mask == null || i == mask.size) && row == nKept)
 
-    val nPresent = nKept - nMissing
-    val meanX = if (nPresent > 0) sumX / nPresent else Double.NaN
-    val missingRowIndicesArray = missingRowIndices.result()
-
-    i = 0
-    while (i < missingRowIndicesArray.length) {
-      valsX(missingRowIndicesArray(i)) = meanX
-      i += 1
-    }
-
-    (DenseVector(valsX), meanX)
-  }
-
-  // constructs SparseVector x of hard calls with missing values mean-imputed
-  // mask == null implies no mask
-  // returns (x, nHet, nHomVar, nMissing)
-  def hardCallStats(gs: Iterable[Genotype], mask: Array[Boolean]): (SparseVector[Double], Int, Int, Int) = {
-
-    val sb = new HardCallBuilder()
-    val gts = gs.hardCallIterator
-
-    var i = 0
-    while (gts.hasNext) {
-      val gt = gts.next()
-      if (mask == null || mask(i))
-        sb.merge(gt)
-      i += 1
-    }
-
-    sb.toHardCallStats
-  }
-
-  //keyedRow consists of row key followed by numeric data (passed with key to avoid copying, key is ignored here)
-  def statsKeyedRow(keyedRow: Row, y: DenseVector[Double]): Option[(DenseVector[Double], Double, Double)] = {
-    val n = keyedRow.length - 1
-    assert(y.length == n)
-
-    val valsX = Array.ofDim[Double](n)
-    var sumX = 0.0
-    var sumXX = 0.0
-    var sumXY = 0.0
-    var sumYMissing = 0.0
-    val missingRowIndices = new ArrayBuilder[Int]()
-
-    var i = 0
-    while (i < n) {
-      if (keyedRow.get(i + 1) == null) {
-        missingRowIndices += i
-        sumYMissing += y(i)
+    val valsArray = vals.result()
+    val nMissing = missingSparseIndices.size
+    if (impute) {
+      val mean = sum.toDouble / (nKept - nMissing)
+      i = 0
+      while (i < nMissing) {
+        valsArray(missingSparseIndices(i)) = mean
+        i += 1
       }
-      else {
-        val e = keyedRow.get(i + 1).asInstanceOf[java.lang.Number].doubleValue()
-        valsX(i) = e
-        sumX += e
-        sumXX += e * e
-        sumXY += e * y(i)
-      }
-      i += 1
     }
 
-    val missingRowIndicesArray = missingRowIndices.result()
-    val nMissing = missingRowIndicesArray.length
-    val nPresent = n - nMissing
-
-    if (nPresent > 0) {
-      val meanX = sumX / nPresent
-
-      var j = 0
-      while (j < nMissing) {
-        valsX(missingRowIndicesArray(j)) = meanX
-        j += 1
-      }
-
-      val x = DenseVector[Double](valsX)
-      val xx = sumXX + meanX * meanX * nMissing
-      val xy = sumXY + meanX * sumYMissing
-
-      Some(x, xx, xy)
-    }
-    else
-      None
-  }
-}
-
-class HardCallBuilder extends Serializable {
-  private val missingRowIndices = new ArrayBuilder[Int]()
-  private val rowsX = new ArrayBuilder[Int]()
-  private val valsX = new ArrayBuilder[Double]()
-  private var row = 0
-  private var sparseLength = 0 // current length of rowsX and valsX, used to track missingRowIndices
-  private var nHet = 0
-  private var nHomVar = 0
-
-  def merge(gt: Int): HardCallBuilder = {
-    (gt: @unchecked) match {
-      case 0 =>
-      case 1 =>
-        rowsX += row
-        valsX += 1
-        sparseLength += 1
-        nHet += 1
-      case 2 =>
-        rowsX += row
-        valsX += 2
-        sparseLength += 1
-        nHomVar += 1
-      case -1 =>
-        missingRowIndices += sparseLength
-        rowsX += row
-        valsX += 0 // placeholder for meanX
-        sparseLength += 1
-    }
-    row += 1
-
-    this
-  }
-
-  def toHardCallStats: (SparseVector[Double], Int, Int, Int) = {
-    val nSamples = row
-    val rowsXArray = rowsX.result()
-    val valsXArray = valsX.result()
-    val missingRowIndicesArray = missingRowIndices.result()
-    val nMissing = missingRowIndicesArray.size
-
-    val meanX = (nHet + 2 * nHomVar).toDouble / (nSamples - nMissing)
-
-    var i = 0
-    while (i < nMissing) {
-      valsXArray(missingRowIndicesArray(i)) = meanX
-      i += 1
-    }
-
-    val x = new SparseVector[Double](rowsXArray, valsXArray, nSamples)
-
-    (x, nHet, nHomVar, nMissing)
+    (new SparseVector[Double](rows.result(), valsArray, row), sum.toDouble)
   }
 }

--- a/src/main/scala/is/hail/stats/RegressionUtils.scala
+++ b/src/main/scala/is/hail/stats/RegressionUtils.scala
@@ -282,7 +282,7 @@ object RegressionUtils {
   }
 
   // Retrofitting for 0.1, will be removed at 2.0 when constant checking is dropped (unless otherwise useful)
-  def constantHardCalls(x: Vector[Double]): Boolean = {
+  def constantVector(x: Vector[Double]): Boolean = {
     require(x.size > 0)
     var curr = x(0)
     var i = 1

--- a/src/test/scala/is/hail/methods/LDPruneSuite.scala
+++ b/src/test/scala/is/hail/methods/LDPruneSuite.scala
@@ -149,8 +149,8 @@ class LDPruneSuite extends SparkSuite {
         val gs2 = convertGtsToGs(v2)
         val bv1 = LDPrune.toBitPackedVector(gs1.hardCallIterator, nSamples)
         val bv2 = LDPrune.toBitPackedVector(gs2.hardCallIterator, nSamples)
-        val sgs1 = RegressionUtils.toNormalizedGtArray(gs1, nSamples).map(math.sqrt(1d / nSamples) * BVector(_))
-        val sgs2 = RegressionUtils.toNormalizedGtArray(gs2, nSamples).map(math.sqrt(1d / nSamples) * BVector(_))
+        val sgs1 = RegressionUtils.normalizedHardCalls(gs1, nSamples).map(math.sqrt(1d / nSamples) * BVector(_))
+        val sgs2 = RegressionUtils.normalizedHardCalls(gs2, nSamples).map(math.sqrt(1d / nSamples) * BVector(_))
 
         (bv1, bv2, sgs1, sgs2) match {
           case (Some(a), Some(b), Some(c: BVector[Double]), Some(d: BVector[Double])) =>

--- a/src/test/scala/is/hail/methods/LinearRegressionBurdenSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearRegressionBurdenSuite.scala
@@ -1,7 +1,7 @@
 package is.hail.methods
 
 import is.hail.SparkSuite
-import is.hail.expr.{TDouble, TString}
+import is.hail.expr.TDouble
 import is.hail.utils._
 import is.hail.TestUtils._
 import is.hail.io.annotators.IntervalList

--- a/src/test/scala/is/hail/methods/LinearRegressionMultiPhenoSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearRegressionMultiPhenoSuite.scala
@@ -4,7 +4,7 @@ import is.hail.SparkSuite
 import is.hail.annotations.Querier
 import is.hail.expr.TDouble
 import is.hail.utils._
-import is.hail.variant.{Genotype, Variant}
+import is.hail.variant.Variant
 import org.testng.annotations.Test
 
 class LinearRegressionMultiPhenoSuite extends SparkSuite {

--- a/src/test/scala/is/hail/methods/LinearRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearRegressionSuite.scala
@@ -3,8 +3,6 @@ package is.hail.methods
 import is.hail.SparkSuite
 import is.hail.TestUtils._
 import is.hail.annotations.Annotation
-import is.hail.expr.TDouble
-import is.hail.annotations.Querier
 import is.hail.expr.{TDouble, TString}
 import is.hail.io.plink.FamFileConfig
 import is.hail.keytable.KeyTable

--- a/src/test/scala/is/hail/stats/ComputeRRMSuite.scala
+++ b/src/test/scala/is/hail/stats/ComputeRRMSuite.scala
@@ -23,7 +23,7 @@ class ComputeRRMSuite extends SparkSuite {
     val vds = stats.vdsFromMatrix(hc)(G0)
 
     val n = vds.nSamples
-    val gtVects = vds.rdd.collect().flatMap { case (v, (va, gs)) => RegressionUtils.toNormalizedGtArray(gs, n) }.map(DenseVector(_))
+    val gtVects = vds.rdd.collect().flatMap { case (v, (va, gs)) => RegressionUtils.normalizedHardCalls(gs, n) }.map(DenseVector(_))
 
     for (gts <- gtVects) {
       assert(math.abs(mean(gts)) < 1e-6)
@@ -35,7 +35,7 @@ class ComputeRRMSuite extends SparkSuite {
       W(::, i) *= math.sqrt(n) / norm(W(::, i))
     }
     val Klocal = (W * W.t) / W.cols.toDouble
-    val KwithoutBlock = ComputeRRM(vds, forceBlock = false)._1
+    val KwithoutBlock = ComputeRRM(vds)._1
     val KwithBlock = ComputeRRM(vds, forceBlock = true)._1
 
 
@@ -70,7 +70,7 @@ class ComputeRRMSuite extends SparkSuite {
     }
 
     val K1local = (W1 * W1.t) / W1.cols.toDouble
-    val K1withoutBlock = ComputeRRM(vds1, forceBlock = false)._1
+    val K1withoutBlock = ComputeRRM(vds1)._1
     val K1withBlock = ComputeRRM(vds1, forceBlock = true)._1
 
     TestUtils.assertMatrixEqualityDouble(K1local, convertToBreeze(K1withoutBlock))


### PR DESCRIPTION
- removed repeated imports in dataset
- fixed typos and clarified docs
- collapsed RegUtils to provide one ingest function each for hardCalls, dosages, and keyedRows. These optionally impute missing and produce sparse, dense, and dense vectors respectively. The first two also optionally take a mask. hardCalls no longer checks for constant vectors.
- killed the two RegUtils mutate matrix functions entirely
- simplified code in regression methods taking Vector[Double] input
- temp added constantHardCalls to RegUtils and in regressions to retrofit changes to preserve 0.1 behavior of missing for constant vectors. In 0.2 constant vectors will be treated the same as others, resulting in lack of convergence, Double.NaN, etc.
- temp added hardCallsAndAC to RegUtils and in linreg to retrofit changes to preserve 0.1 behavior of calculating AC pre-imputation for filtering. In 0.2, AC will be calculated post-imputation for hardCalls and dosages using sum(x)
- combined empirical and HWE normalized arrays into one function
- removed various default parameters in tests

About 75 lines are due to retrofit, so for 0.2 it's about 200 added and 420 deleted.