### PR TITLE
Fix incorrect partitioner.

### DIFF
--- a/src/main/scala/is/hail/sparkextras/OrderedRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/OrderedRDD.scala
@@ -194,13 +194,7 @@ object OrderedRDD {
     import kOk._
 
     import Ordering.Implicits._
-
-    rdd.partitioner match {
-      /* if we verified rdd is K-sorted, it won't necessarily be partitioned */
-      case Some(p) => assert(p eq orderedPartitioner)
-      case _ =>
-    }
-
+    
     val rangeBoundsBc = rdd.sparkContext.broadcast(orderedPartitioner.rangeBounds)
     new OrderedRDD(
       rdd.mapPartitionsWithIndex { case (i, it) =>

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -972,7 +972,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VSMMetadata,
       ins: (Annotation, S) => Annotation): OrderedRDD[Locus, Variant, (Annotation, Iterable[T])] = {
       OrderedRDD(joinedRDD.mapPartitions({ it =>
         it.map { case (l, ((v, (va, gs)), annotation)) => (v, (ins(va, annotation), gs)) }
-      }, preservesPartitioning = true),
+      }),
         rdd.orderedPartitioner)
     }
 

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -975,7 +975,7 @@ class VariantSampleMatrix[T](val hc: HailContext, val metadata: VSMMetadata,
       }, preservesPartitioning = true),
         rdd.orderedPartitioner)
     }
-    
+
     val locusKeyedRDD = rdd
       .mapMonotonic(OrderedKeyFunction(_.locus), { case (v, vags) => (v, vags) })
 


### PR DESCRIPTION
asOrderedRDD preserves the the same partitioner.  In this case,
joinedRDD is Locus-partitioned, but we want the result to be
Variant-partitioned.

@tpoterba Is it possible this will fix @konradjk's cast exception?
