### PR TITLE
add a method to return the type of alt allele

### DIFF
--- a/python/hail/representation/variant.py
+++ b/python/hail/representation/variant.py
@@ -403,6 +403,18 @@ class AltAllele(object):
 
         return self._jrep.isTransversion()
 
+    def alt_allele_type(self):
+        """Returns the type of alt, i.e one of
+            SNP,
+            Insertion,
+            Deletion,
+            Star,
+            MNP,
+            Complex
+
+        :rtype: string
+        """
+        return self._jrep.altAlleleType()
 
 class Locus(object):
     """

--- a/python/hail/representation/variant.py
+++ b/python/hail/representation/variant.py
@@ -403,7 +403,8 @@ class AltAllele(object):
 
         return self._jrep.isTransversion()
 
-    def alt_allele_type(self):
+    @handle_py4j
+    def category(self):
         """Returns the type of alt, i.e one of
             SNP,
             Insertion,
@@ -412,7 +413,7 @@ class AltAllele(object):
             MNP,
             Complex
 
-        :rtype: string
+        :rtype: str
         """
         return self._jrep.altAlleleType()
 

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -804,6 +804,7 @@ object FunctionRegistry {
   registerMethod("isComplex", { (x: AltAllele) => x.isComplex }, "True if not a SNP, MNP, star, insertion, or deletion.")
   registerMethod("isTransition", { (x: AltAllele) => x.isTransition }, "True if a purine-purine or pyrimidine-pyrimidine SNP.")
   registerMethod("isTransversion", { (x: AltAllele) => x.isTransversion }, "True if a purine-pyrimidine SNP.")
+  registerMethod("altAlleleType", { (x: AltAllele) => x.altAlleleType.toString }, "the alt allele type")
 
   registerMethod("length", { (x: String) => x.length }, "Length of the string.")
 

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -804,7 +804,7 @@ object FunctionRegistry {
   registerMethod("isComplex", { (x: AltAllele) => x.isComplex }, "True if not a SNP, MNP, star, insertion, or deletion.")
   registerMethod("isTransition", { (x: AltAllele) => x.isTransition }, "True if a purine-purine or pyrimidine-pyrimidine SNP.")
   registerMethod("isTransversion", { (x: AltAllele) => x.isTransversion }, "True if a purine-pyrimidine SNP.")
-  registerMethod("altAlleleType", { (x: AltAllele) => x.altAlleleType.toString }, "the alt allele type")
+  registerMethod("category", { (x: AltAllele) => x.altAlleleType.toString }, "the alt allele type, i.e one of SNP, Insertion, Deletion, Star, MNP, Complex")
 
   registerMethod("length", { (x: String) => x.length }, "Length of the string.")
 


### PR DESCRIPTION
### What
Hi hail team, what do you think about supporting `alt_allele_type` through the python API?

### Why
This came about because I'd like to be able to export the alt allele type per variant using [export_variants](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.export_variants)