### PR TITLE
fix tutorial formatting for website

### DIFF
--- a/python/hail/docs/tutorial.ipynb
+++ b/python/hail/docs/tutorial.ipynb
@@ -99,7 +99,7 @@
    "source": [
     "## Import data\n",
     "\n",
-    "We must first import variant data into Hail's internal format of Variant Dataset (VDS). We use the [`import_vcf`](https://hail.is/hail/hail.HailContext.html#hail.HailContext.import_vcf) method on [`HailContext`](https://hail.is/hail/hail.HailContext.html) to load the downsampled 1000 Genomes VCF into Hail. The VCF file is block-compressed (`.vcf.bgz`) which enables Hail to read the file in parallel. Reading files that have not been block-compressed (`.vcf`, `.vcf.gz`) is _significantly_ slower and should be avoided (though often `.vcf.gz` files are in fact block-compressed, in which case renaming to `.vcf.bgz` solves the problem)."
+    "We must first import variant data into Hail's internal format of Variant Dataset (VDS). We use the [import_vcf](https://hail.is/hail/hail.HailContext.html#hail.HailContext.import_vcf) method on [HailContext](https://hail.is/hail/hail.HailContext.html) to load the downsampled 1000 Genomes VCF into Hail. The VCF file is block-compressed (`.vcf.bgz`) which enables Hail to read the file in parallel. Reading files that have not been block-compressed (`.vcf`, `.vcf.gz`) is _significantly_ slower and should be avoided (though often `.vcf.gz` files are in fact block-compressed, in which case renaming to `.vcf.bgz` solves the problem)."
    ]
   },
   {
@@ -117,7 +117,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We next use the [`split_multi`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.split_multi) method on `dataset` to split multi-allelic variants into biallelic variants. For example, the variant `1:1000:A:T,C` would become two variants: `1:1000:A:T` and `1:1000:A:C`."
+    "We next use the [split_multi](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.split_multi) method on `dataset` to split multi-allelic variants into biallelic variants. For example, the variant `1:1000:A:T,C` would become two variants: `1:1000:A:T` and `1:1000:A:C`."
    ]
   },
   {
@@ -135,7 +135,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We next use the [`import_table`](https://hail.is/hail/hail.HailContext.html#hail.HailContext.import_table) method to load phenotypic information into a Hail [`KeyTable`](https://hail.is/hail/hail.KeyTable.html#hail.KeyTable) object. We can use this to annotate samples."
+    "We next use the [import_table](https://hail.is/hail/hail.HailContext.html#hail.HailContext.import_table) method to load phenotypic information into a Hail [KeyTable](https://hail.is/hail/hail.KeyTable.html#hail.KeyTable) object. We can use this to annotate samples."
    ]
   },
   {
@@ -190,7 +190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, let's annotate the dataset with this table. We do this with the [`annotate_samples_table`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.annotate_samples_table) method.\n",
+    "Now, let's annotate the dataset with this table. We do this with the [annotate_samples_table](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.annotate_samples_table) method.\n",
     "\n",
     "In this method, the `root` argument specifies where in sample annotations to put this data. For sample annotations, the root must start with `sa` followed by a `.` and the rest is up to you, so let's use `sa.pheno`."
    ]
@@ -210,7 +210,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, we'll [`write`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.write) the dataset to disk so that all future computations begin by reading in the fast VDS rather than the slow VCF."
+    "Finally, we'll [write](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.write) the dataset to disk so that all future computations begin by reading in the fast VDS rather than the slow VCF."
    ]
   },
   {
@@ -231,7 +231,7 @@
    "source": [
     "## Start exploring\n",
     "\n",
-    "Now we're ready to start exploring! Let's practice [`reading`](https://hail.is/hail/hail.HailContext.html#hail.HailContext.read) the dataset back in:"
+    "Now we're ready to start exploring! Let's practice [reading](https://hail.is/hail/hail.HailContext.html#hail.HailContext.read) the dataset back in:"
    ]
   },
   {
@@ -249,7 +249,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, we'll print some statistics about the size of the dataset using [`summarize`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.summarize):"
+    "First, we'll print some statistics about the size of the dataset using [summarize](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.summarize):"
    ]
   },
   {
@@ -292,9 +292,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note the annotations imported from the original VCF, as well as the sample annotations added above. Notice how those six sample annotations loaded above are nested inside `sa.pheno` as defined by the `root` option in [`annotate_samples_table`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.annotate_samples_table).\n",
+    "Note the annotations imported from the original VCF, as well as the sample annotations added above. Notice how those six sample annotations loaded above are nested inside `sa.pheno` as defined by the `root` option in [annotate_samples_table](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.annotate_samples_table).\n",
     "\n",
-    "Next we'll add some global annotations including the list of populations that are present in our dataset and the number of samples in each population, using the Hail expression language and the [`query_samples`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.query_samples) method. The 1000 Genomes Super-Population codings are:\n",
+    "Next we'll add some global annotations including the list of populations that are present in our dataset and the number of samples in each population, using the Hail expression language and the [query_samples](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.query_samples) method. The 1000 Genomes Super-Population codings are:\n",
     "\n",
     "  - SAS = South Asian\n",
     "  - AMR = Americas\n",
@@ -331,7 +331,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now it's easy to count samples by population using the [`counter()`](https://hail.is/hail/types.html#aggregable-t) aggregator:"
+    "Now it's easy to count samples by population using the [counter()](https://hail.is/hail/types.html#aggregable-t) aggregator:"
    ]
   },
   {
@@ -365,7 +365,7 @@
     "\n",
     "### Filter genotypes\n",
     "\n",
-    "Let's filter genotypes based on allelic balance using the [`filter_genotypes`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.filter_genotypes) method."
+    "Let's filter genotypes based on allelic balance using the [filter_genotypes](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.filter_genotypes) method."
    ]
   },
   {
@@ -409,7 +409,7 @@
     "\n",
     "### Filter samples\n",
     "\n",
-    "Having removed suspect genotypes, let's next remove variants with low call rate using [`filter_variants_expr`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.filter_variants_expr) and then calculate summary statistics per sample with the [`sample_qc`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.sample_qc) method."
+    "Having removed suspect genotypes, let's next remove variants with low call rate using [filter_variants_expr](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.filter_variants_expr) and then calculate summary statistics per sample with the [sample_qc](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.sample_qc) method."
    ]
   },
   {
@@ -532,7 +532,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As before, let's use the [`query_samples`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.query_samples) method to count the number of samples by phenotype that remain in the dataset after filtering."
+    "As before, let's use the [query_samples](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.query_samples) method to count the number of samples by phenotype that remain in the dataset after filtering."
    ]
   },
   {
@@ -558,7 +558,7 @@
     "\n",
     "We now have `vds_gAB_sCR_sGQ`, a VDS where low-quality genotypes and samples have been removed.\n",
     "\n",
-    "Let's use the [`variant_qc`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.variant_qc) method to start exploring variant metrics:"
+    "Let's use the [variant_qc](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.variant_qc) method to start exploring variant metrics:"
    ]
   },
   {
@@ -627,7 +627,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's use the [`annotate_variants_expr`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.annotate_variants_expr) method to programmatically compute Hardy Weinberg Equilibrium for each population. First, we construct `hwe-expressions`."
+    "Let's use the [annotate_variants_expr](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.annotate_variants_expr) method to programmatically compute Hardy Weinberg Equilibrium for each population. First, we construct `hwe-expressions`."
    ]
   },
   {
@@ -669,7 +669,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can go ahead and use [`annotate_variants_expr`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.annotate_variants_expr)."
+    "Now we can go ahead and use [annotate_variants_expr](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.annotate_variants_expr)."
    ]
   },
   {
@@ -691,7 +691,7 @@
    "source": [
     "Above, for each variant, we filter the genotypes to only those genotypes from the population of interest using a filter function on the [genotype aggregable](https://hail.is/hail/types.html#aggregable-genotype) and then calculate the Hardy-Weinberg Equilibrium p-value using the `hardyWeinberg()` function on the filtered genotype aggregable.\n",
     "\n",
-    "The [`persist`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.persist) method caches the dataset in its current state on memory/disk, so that downstream processing will be faster. \n",
+    "The [persist](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.persist) method caches the dataset in its current state on memory/disk, so that downstream processing will be faster. \n",
     "\n",
     "Printing the schema reveals that we've added new fields to the variant annotations for HWE p-values for each population. We've got quite a few variant annotations now! Notice that the results of these annotation statements are structs containing two elements:\n",
     "\n",
@@ -742,9 +742,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Running [`count_variants`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.count_variants), we see that by calculating HWE p-values in each population separately, we keep 10891 variants, filtering out 70.  We would have filtered far more if we used the population-agnostic single statistic!\n",
+    "Running [count_variants](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.count_variants), we see that by calculating HWE p-values in each population separately, we keep 10891 variants, filtering out 70.  We would have filtered far more if we used the population-agnostic single statistic!\n",
     "\n",
-    "Lastly we use the [`filter_variants_expr`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.filter_variants_expr) method again to keep only those variants with a mean GQ greater than or equal to 20."
+    "Lastly we use the [filter_variants_expr](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.filter_variants_expr) method again to keep only those variants with a mean GQ greater than or equal to 20."
    ]
   },
   {
@@ -837,7 +837,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For sex check, we first use the [`impute_sex`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.impute_sex) method with a minimum minor allele frequency threshold `maf_threshold` argument of 0.05 to determine the genetic sex of each sample based on the inbreeding coefficient. `impute_sex` adds the Boolean sample annotation `sa.imputesex.isFemale` and we then create a new Boolean sample annotation `sa.sexcheck` which indicates whether the imputed sex `sa.imputesex.isFemale` is the same as the reported sex `sa.pheno.isFemale`."
+    "For sex check, we first use the [impute_sex](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.impute_sex) method with a minimum minor allele frequency threshold `maf_threshold` argument of 0.05 to determine the genetic sex of each sample based on the inbreeding coefficient. `impute_sex` adds the Boolean sample annotation `sa.imputesex.isFemale` and we then create a new Boolean sample annotation `sa.sexcheck` which indicates whether the imputed sex `sa.imputesex.isFemale` is the same as the reported sex `sa.pheno.isFemale`."
    ]
   },
   {
@@ -906,7 +906,7 @@
     "\n",
     "To account for population stratification in association testing, we use principal component analysis to compute features that are proxies for genetic similarity. PCA is typically performed on variants in linkage equilibrium. The text file *purcell5k.interval_list* contains a list of such independent common variants.\n",
     "\n",
-    "To calculate principal components, we first use the [`filter_variants_table`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.filter_variants_table) method to filter down to SNPs from this list. Next, we use the [`pca`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.pca) method to calculate the first 10 principal components (10 is the default number). The results are stored as sample annotations with root given by the `scores` parameter."
+    "To calculate principal components, we first use the [filter_variants_table](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.filter_variants_table) method to filter down to SNPs from this list. Next, we use the [pca](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.pca) method to calculate the first 10 principal components (10 is the default number). The results are stored as sample annotations with root given by the `scores` parameter."
    ]
   },
   {
@@ -957,7 +957,7 @@
     "\n",
     "### Linear regression with covariates\n",
     "\n",
-    "Let's run linear regression on `vds_QCed`. First, we will filter to variants with a allele frequency between 5% and 95%. Next, we use the [`linreg`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.linreg) method, specifying the response variable `y` to be the sample annotation `sa.pheno.CaffeineConsumption`. We use four sample covariates in addition to the (implicit) intercept: `sa.pca.PC1`, `sa.pca.PC2`, `sa.pca.PC3`, `sa.pheno.isFemale`."
+    "Let's run linear regression on `vds_QCed`. First, we will filter to variants with a allele frequency between 5% and 95%. Next, we use the [linreg](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.linreg) method, specifying the response variable `y` to be the sample annotation `sa.pheno.CaffeineConsumption`. We use four sample covariates in addition to the (implicit) intercept: `sa.pca.PC1`, `sa.pca.PC2`, `sa.pca.PC3`, `sa.pheno.isFemale`."
    ]
   },
   {
@@ -1028,7 +1028,7 @@
    "source": [
     "### Logistic regression with covariates\n",
     "\n",
-    "We continue from `vds_gwas`. The logistic regression method [`logreg`](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.logreg) also takes a test type argument. We will use the Wald test."
+    "We continue from `vds_gwas`. The logistic regression method [logreg](https://hail.is/hail/hail.VariantDataset.html#hail.VariantDataset.logreg) also takes a test type argument. We will use the Wald test."
    ]
   },
   {
@@ -1160,15 +1160,6 @@
     "    .annotate_variants_expr('''va.fet = fet(va.minorCase.toInt(), va.minorControl.toInt(),\n",
     "                                            va.majorCase.toInt(), va.majorControl.toInt())'''))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Markdown supports links to be formatted as literals, but Restructured Text does not. https://stackoverflow.com/questions/4743845/format-text-in-a-link-in-restructuredtext