### PR TITLE
Improve Random Generation: Avoid Excessive Collection Nesting

### DIFF
--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -57,6 +57,7 @@ object Type {
     s <- Gen.size
     // prefer smaller type and bigger values
     fraction <- Gen.choose(0.1, 0.3)
+    x = (fraction * s).toInt
     y = s - x
     t <- Type.genStruct.resize(x)
     v <- t.genValue.resize(y)

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -27,6 +27,9 @@ object Type {
       genScalar
     else
       Gen.oneOfGen(genScalar,
+        genScalar,
+        genScalar,
+        genScalar,
         genArb.resize(size - 1).map(TArray),
         genArb.resize(size - 1).map(TSet),
         Gen.zip(genArb, genArb).map { case (k, v) => TDict(k, v) },
@@ -49,6 +52,15 @@ object Type {
         .toIndexedSeq))
 
   def genArb: Gen[Type] = Gen.sized(genSized)
+
+  def genWithValue: Gen[(Type, Annotation)] = for {
+    s <- Gen.size
+    // prefer smaller type and bigger values
+    fraction <- Gen.choose(0.1, 0.3)
+    y = s - x
+    t <- Type.genStruct.resize(x)
+    v <- t.genValue.resize(y)
+  } yield (t, v)
 
   implicit def arbType = Arbitrary(genArb)
 


### PR DESCRIPTION
This PR extends #1902, merge that one first.

Now, 50% of the time a type is a Scalar type rather than a recursive one. Additionally, this PR adds a generator for pairs of types and values of that type.

Here's a few samples:
```scala
t Struct{
    W: Call,
    GL: Genotype,
    nsfJ: Long,
    tiX0pLA: Int,
    B7vWAW: Call,
    a6_mm: Boolean,
    AGS1Eh: Interval,
    tqbHQbDv: Dict[AltAllele, Long],
    HUh: Set[Double],
    Xgb26Wlws: Double,
    qe_XlLJt7_X: Dict[Double, Int],
    U: Array[Call],
    j: Double
}
v [ 1
  , 5/6:.:.:.:GP=0.0,0.0,6.103515625E-4,0.0,0.0,0.0,0.0,0.00286865234375,0.0,0.058441162109375,0.0,0.0,0.0,0.00567626953125,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.004730224609375,0.153839111328125,0.0,0.0,0.0,0.704742431640625,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.018402099609375,0.050689697265625,0.0,0.0,0.0,0.0,0.0,0.0,376902925948550232
  , 2147483647
  , 1
  , true
  , 15:396751431-18:1945111790
  , Map(GT/C -> -9223372036854775808, GC/TGTG -> 0, GTCAC/AC -> 1, TCG/G -> -2853243060319614448, TTTG/G -> 0)
  , Set(0.0, 1.2590508536333097E308, -26.66700965052354, -1.0, 1.7976931348623157E308)
  , -44.18866673875504
  , Map(4.9E-324 -> 1069254047, -29.21881886290265 -> 0, -7.511481628119398E307 -> -51783790, 78.3075905923555 -> -1679218199, -1.0 -> -1476797686, 66.69344244874847 -> -2147483648, -74.87563451361888 -> -50, 8.529797881337316E306 -> -38)
  , WrappedArray(2, 2, null, 2, 2, 1)
  , 1.7044473544408425E308
  ]
```
```scala
t Struct{
    jHUkH: Interval,
    c: Struct{
        EZyb77: Boolean,
        qckA6k: Empty
    },
    K: Interval,
    X: Locus,
    BuujVaardN: Call,
    drTH1J: Set[Locus],
    DJL9uj7D: Variant,
    vwuq: Set[Int],
    cKAObAm1oh7: Boolean,
    FqhLLOlV4p: Struct{
        Ri631ZK2TiA: Empty
    },
    vtQ: Set[String],
    HzHvw: Locus,
    g: Double,
    inwJHuBmLUM: Boolean,
    Q: Float,
    i: Genotype,
    q: Float,
    p_Wmn2Q: Variant,
    Y6foXEa7F: Dict[Set[Float], Double],
    SuXouO__uX: Int,
    hrfM: Locus,
    k: Variant,
    V1WzY: Struct{
        xWj: Struct{
            bg: AltAllele
        }
    },
    L3Ol_: Call,
    Bmt: Variant,
    EExpF_H: Struct{
        DyAZQ1pL: Empty
    },
    JSc3FhxVxoM: Array[Dict[String, Empty]],
    Iuu: Dict[Variant, Double],
    qXBGmKS: Long,
    QQfQtf3ct: Call,
    bSsLYsTDI: Array[Array[Call]],
    ad1iBzwaFZf: Dict[String, Locus],
    Z2cD2KmFIkG: Call,
    VSqH: AltAllele,
    XVZqCYGf3_: Double,
    NBdmoAaGkoL: Boolean,
    r: Array[AltAllele],
    W_NOSJIvTd: Double,
    s3B8QiAqQ: Long,
    lk: Float,
    S1Fo: Float,
    PEcTjU8vomh: Empty,
    REgY: Double,
    ZUB: Variant,
    b9UtO: Set[Float],
    sT8o_aQ: Array[Call],
    Igr1: Call,
    A6ditFSwmRK: Call,
    EmxV: Boolean,
    a7: Struct{
        JtHJhnfateR: Empty
    }
}
v [ 14:1955123271-18:1272376844
  , [false,null]
  , 14:1256937813-17:1583114455
  , 3:4546980
  , 2
  , Set(null, 15:1947873743, 13:866526696, 6:1573282210, 19:891774512)
  , GCaO16Nsy8:77911856:ATA:TG
  , Set(72)
  , false
  , [null]
  , Set(F&S~b)
  , 7:472895707
  , null
  , true
  , Infinity
  , ./.:22,28:75:108:PL=167,0,83
  , Infinity
  , rdQ:630981228:T:CTA
  , Map()
  , -28
  , 11:810964873
  , RFJrknBvIH:1425413812:TAT:GC
  , [[GCCAC/A]]
  , 1
  , qxomnU6Nqr:1347703197:G:A
  , [null]
  , WrappedArray()
  , Map(m:190688303:C:AG -> -1.7976931348623157E308, lcg7p:2050711280:G:GATC -> 4.9E-324, DBeo6xuPH:1588993816:T:CTA -> 8.537643765112484E307)
  , -5599614078518791215
  , 1
  , null
  , Map(y -> 17:750270934)
  , 0
  , G/CATG
  , -1.4729264086204403E307
  , false
  , WrappedArray()
  , null
  , -9223372036854775808
  , 12.945546
  , -Infinity
  , null
  , null
  , QWxPKk:173048886:GTC:TCTT
  , null
  , WrappedArray()
  , null
  , 2
  , false
  , [null]
  ]
```
```scala
t Struct{
    CKkepccXC: Float,
    Np: Locus,
    fP8kTXty9: Double,
    Qp6uH: Set[Set[Double]],
    K7wSG1F3: Variant,
    lLo85q: AltAllele,
    v1du: Genotype
}
v [ -Infinity
  , 5:2134996951
  , 0.0
  , Set( Set(7.482063689522203E307, -4.3155177478799624E305, -1.428773456444566E308, 9.332975286117578E307)
       , Set()
       , null
       , Set(49.15738854346134, 1.5361471805543802E308)
       , Set(-7.448920624629132E306, 13.921804085458959, 4.9E-324, -40.02694783286595, -54.20909301114429)
       , Set(-83.09343891814032, -9.62087242188959E307)
       , Set(1.0, -1.187010079565314E308)
       , Set(63.00077009047835)
       , Set(-1.3633961562402215E308, 1.0)
       , Set(12.662410481996574, 67.13193558644645)
       , Set(-78.81449395803094)
       , Set(1.7283261397633746E308, -8.611348087572712E307, -7.64522521854318E307)
       , Set(4.9E-324)
       , Set(1.0)
       , Set(-1.650631596617604E308, -70.42650232974452, 1.0)
       , Set(-5.249660537956704E307, 1.378948908122762E308)
       )
  , ufg2CarjGf:682440091:C:GG
  , A/G
  , 0/0:.:.:.:GP=0.737579345703125,0.251190185546875,0.01123046875
  ]
```
```scala
t Struct{
    Fm9ba: AltAllele,
    t0_xi1m: Variant,
    or8z4gwOp: Array[Set[AltAllele]],
    OP: Interval,
    bT: Array[Boolean],
    iSJ9a0UwQpG: String,
    WQwn: Array[Interval],
    jGqh3xtcro: Double,
    g0Kv11a: Variant,
    ky36: AltAllele,
    Jb8: Float,
    MoBxPDdvGw: Float,
    gW: Array[Interval],
    a4: Struct{
        B09aTY: Set[Long]
    },
    HkUrazxdp: Set[Struct{
        L9XR6: Empty,
        JJeICteE3Tm: Locus
    }],
    mBv9ljpHD: Int,
    st: Array[Interval]
}
v [ C/AGTG
  , AF:1132740736:CTG:GGCCT
  , WrappedArray(null, Set(C/AC))
  , 13:791385633-15:44039816
  , WrappedArray(null, false, false, false, true)
  , caE
  , null
  , -1.0
  , uAvZ6S5txx:551788563:CA:CC
  , ACG/CA
  , -9.697367
  , 1.0
  , WrappedArray(5:421782041-MT:51623882, 13:1157604585-X:1520033480, 2:246980474-5:355241032, 19:105200491-20:1422252263, 1:1169885632-7:583182317, 18:342278997-19:366035620)
  , [null]
  , Set([null,4:557653812], [null,null])
  , 2147483647
  , WrappedArray()
  ]
```