### PR TITLE
Moved pyspark imports to be local to matrices

### DIFF
--- a/python/hail/kinshipMatrix.py
+++ b/python/hail/kinshipMatrix.py
@@ -2,7 +2,6 @@ from decorator import decorator
 
 from hail.typecheck import *
 
-from pyspark.mllib.linalg.distributed import IndexedRowMatrix
 from hail.java import *
 from hail.expr import Type, TString
 
@@ -45,6 +44,8 @@ class KinshipMatrix:
         :return: Matrix of kinship values.
         :rtype: `IndexedRowMatrix <https://spark.apache.org/docs/latest/api/python/pyspark.mllib.html#pyspark.mllib.linalg.distributed.IndexedRowMatrix>`__
         """
+        from pyspark.mllib.linalg.distributed import IndexedRowMatrix
+
         return IndexedRowMatrix(self._jkm.matrix())
 
     @typecheck_method(output=strlike)

--- a/python/hail/ldMatrix.py
+++ b/python/hail/ldMatrix.py
@@ -1,5 +1,3 @@
-from pyspark.mllib.linalg.distributed import IndexedRowMatrix
-from pyspark.mllib.linalg import DenseMatrix
 from hail.representation import Variant
 
 class LDMatrix:
@@ -26,6 +24,8 @@ class LDMatrix:
         :return: Matrix of Pearson correlation values.
         :rtype: `IndexedRowMatrix <https://spark.apache.org/docs/latest/api/python/pyspark.mllib.html#pyspark.mllib.linalg.distributed.IndexedRowMatrix>`__
         """
+        from pyspark.mllib.linalg.distributed import IndexedRowMatrix
+
         return IndexedRowMatrix(self._jldm.matrix())
 
     def to_local_matrix(self):
@@ -39,5 +39,7 @@ class LDMatrix:
         :return: Matrix of Pearson correlation values.
         :rtype: `Matrix <https://spark.apache.org/docs/2.1.0/api/python/pyspark.mllib.html#pyspark.mllib.linalg.Matrix>`__
         """
+        from pyspark.mllib.linalg import DenseMatrix
+
         j_local_mat = self._jldm.toLocalMatrix()
         return DenseMatrix(j_local_mat.numRows(), j_local_mat.numCols(), list(j_local_mat.toArray()), j_local_mat.isTransposed())


### PR DESCRIPTION
Moved pyspark imports to be local to methods, removing numpy dependency