### PR TITLE
Made BGEN query_genotypes 3x faster

### DIFF
--- a/src/main/scala/is/hail/io/bgen/BgenLoader.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenLoader.scala
@@ -90,7 +90,7 @@ object BgenLoader {
       isLinearScale = true),
       VSMLocalValue(globalAnnotation = Annotation.empty,
         sampleIds = samples,
-        sampleAnnotations = IndexedSeq.fill(nSamples)(Annotation.empty)),
+        sampleAnnotations = Array.fill(nSamples)(Annotation.empty)),
       rdd)
   }
 

--- a/src/main/scala/is/hail/methods/Aggregators.scala
+++ b/src/main/scala/is/hail/methods/Aggregators.scala
@@ -216,16 +216,20 @@ object Aggregators {
 
     val seqOp = (array: Array[Aggregator], t: T) => {
       setEC(ec, t)
-      for (i <- array.indices) {
+      var i = 0
+      while (i < array.length) {
         aggregations(i)._2(array(i).seqOp)
+        i += 1
       }
       array
     }
 
     val combOp = (arr1: Array[Aggregator], arr2: Array[Aggregator]) => {
-      for (i <- arr1.indices) {
+      var i = 0
+      while (i < arr1.length) {
         val a1 = arr1(i)
         a1.combOp(arr2(i).asInstanceOf[a1.type])
+        i += 1
       }
       arr1
     }


### PR DESCRIPTION
Added while loop and replaced a vector to speed up queryGenotypes call rate by about 3x running off a BGEN