### PR TITLE
NaN always compares false in ASM4S

### DIFF
--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -319,15 +319,17 @@ class CodeFloat(val lhs: Code[Float]) extends AnyVal {
 
   def /(rhs: Code[Float]): Code[Float] = Code(lhs, rhs, new InsnNode(FDIV))
 
-  // FIXME: FCMPG vs FCMPL
-  def compare(rhs: Code[Float]): Code[Int] = Code(lhs, rhs, new InsnNode(FCMPG))
+  def >(rhs: Code[Float]): Code[Boolean] = Code[Float, Float, Int](lhs, rhs, new InsnNode(FCMPL)) > 0
 
-  def <(rhs: Code[Float]): Code[Boolean] = compare(rhs) < 0
-  def >(rhs: Code[Float]): Code[Boolean] = compare(rhs) > 0
-  def <=(rhs: Code[Float]): Code[Boolean] = compare(rhs) <= 0
-  def >=(rhs: Code[Float]): Code[Boolean] = compare(rhs) >= 0
-  def ceq(rhs: Code[Float]): Code[Boolean] = compare(rhs).ceq(0)
-  def cne(rhs: Code[Float]): Code[Boolean] = compare(rhs).cne(0)
+  def >=(rhs: Code[Float]): Code[Boolean] = Code[Float, Float, Int](lhs, rhs, new InsnNode(FCMPL)) >= 0
+
+  def <(rhs: Code[Float]): Code[Boolean] = Code[Float, Float, Int](lhs, rhs, new InsnNode(FCMPG)) < 0
+
+  def <=(rhs: Code[Float]): Code[Boolean] = Code[Float, Float, Int](lhs, rhs, new InsnNode(FCMPG)) <= 0
+
+  def ceq(rhs: Code[Float]): Code[Boolean] = Code[Float, Float, Int](lhs, rhs, new InsnNode(FCMPL)).ceq(0)
+
+  def cne(rhs: Code[Float]): Code[Boolean] = Code[Float, Float, Int](lhs, rhs, new InsnNode(FCMPL)).cne(0)
 
   def toI: Code[Int] = Code(lhs, new InsnNode(F2I))
   def toL: Code[Long] = Code(lhs, new InsnNode(F2L))
@@ -344,20 +346,17 @@ class CodeDouble(val lhs: Code[Double]) extends AnyVal {
 
   def /(rhs: Code[Double]): Code[Double] = Code(lhs, rhs, new InsnNode(DDIV))
 
-  // FIXME DCMPG vs DCMPL
-  def compare(rhs: Code[Double]): Code[Int] = Code(lhs, rhs, new InsnNode(DCMPG))
+  def >(rhs: Code[Double]): Code[Boolean] = Code[Double, Double, Int](lhs, rhs, new InsnNode(DCMPL)) > 0
 
-  def >(rhs: Code[Double]): Code[Boolean] = compare(rhs) > 0
+  def >=(rhs: Code[Double]): Code[Boolean] = Code[Double, Double, Int](lhs, rhs, new InsnNode(DCMPL)) >= 0
 
-  def >=(rhs: Code[Double]): Code[Boolean] = compare(rhs) >= 0
+  def <(rhs: Code[Double]): Code[Boolean] = Code[Double, Double, Int](lhs, rhs, new InsnNode(DCMPG)) < 0
 
-  def <(rhs: Code[Double]): Code[Boolean] = compare(rhs) < 0
+  def <=(rhs: Code[Double]): Code[Boolean] = Code[Double, Double, Int](lhs, rhs, new InsnNode(DCMPG)) <= 0
 
-  def <=(rhs: Code[Double]): Code[Boolean] = compare(rhs) <= 0
+  def ceq(rhs: Code[Double]): Code[Boolean] = Code[Double, Double, Int](lhs, rhs, new InsnNode(DCMPL)).ceq(0)
 
-  def ceq(rhs: Code[Double]): Code[Boolean] = compare(rhs).ceq(0)
-
-  def cne(rhs: Code[Double]): Code[Boolean] = compare(rhs).cne(0)
+  def cne(rhs: Code[Double]): Code[Boolean] = Code[Double, Double, Int](lhs, rhs, new InsnNode(DCMPL)).cne(0)
 
   def toI: Code[Int] = Code(lhs, new InsnNode(D2I))
   def toL: Code[Long] = Code(lhs, new InsnNode(D2L))

--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -324,6 +324,10 @@ class CodeFloat(val lhs: Code[Float]) extends AnyVal {
 
   def <(rhs: Code[Float]): Code[Boolean] = compare(rhs) < 0
   def >(rhs: Code[Float]): Code[Boolean] = compare(rhs) > 0
+  def <=(rhs: Code[Float]): Code[Boolean] = compare(rhs) <= 0
+  def >=(rhs: Code[Float]): Code[Boolean] = compare(rhs) >= 0
+  def ceq(rhs: Code[Float]): Code[Boolean] = compare(rhs).ceq(0)
+  def cne(rhs: Code[Float]): Code[Boolean] = compare(rhs).cne(0)
 
   def toI: Code[Int] = Code(lhs, new InsnNode(F2I))
   def toL: Code[Long] = Code(lhs, new InsnNode(F2L))

--- a/src/main/scala/is/hail/asm4s/package.scala
+++ b/src/main/scala/is/hail/asm4s/package.scala
@@ -313,5 +313,7 @@ package object asm4s {
 
   implicit def const(l: Long): Code[Long] = Code(new LdcInsnNode(l))
 
+  implicit def const(f: Float): Code[Float] = Code(new LdcInsnNode(f))
+
   implicit def const(d: Double): Code[Double] = Code(new LdcInsnNode(d))
 }

--- a/src/main/scala/is/hail/check/Arbitrary.scala
+++ b/src/main/scala/is/hail/check/Arbitrary.scala
@@ -24,8 +24,13 @@ object Arbitrary {
       Gen.choose(-100, 100),
       Gen { p => p.rng.getRandomGenerator.nextLong() }))
 
+  implicit def arbFloat: Arbitrary[Float] = new Arbitrary(
+    Gen.oneOfGen(Gen.oneOf(Float.MinValue, -1.0f, -Float.MinPositiveValue, 0.0f, Float.MinPositiveValue, 1.0f, Float.MaxValue),
+      Gen.choose(-100.0f, 100.0f),
+      Gen { p => p.rng.nextUniform(Float.MinValue, Float.MaxValue, true).toFloat }))
+
   implicit def arbDouble: Arbitrary[Double] = new Arbitrary(
-    Gen.oneOfGen(Gen.oneOf(Double.MinValue, -1.0, 0.0, Double.MinPositiveValue, 1.0, Double.MaxValue),
+    Gen.oneOfGen(Gen.oneOf(Double.MinValue, -1.0, -Double.MinPositiveValue, 0.0, Double.MinPositiveValue, 1.0, Double.MaxValue),
       Gen.choose(-100.0, 100.0),
       Gen { p => p.rng.nextUniform(Double.MinValue, Double.MaxValue, true) }))
 

--- a/src/main/scala/is/hail/check/Gen.scala
+++ b/src/main/scala/is/hail/check/Gen.scala
@@ -116,6 +116,10 @@ object Gen {
     Gen { (p: Parameters) => p.rng.nextLong(min, max) }
   }
 
+  def choose(min: Float, max: Float): Gen[Float] = Gen { (p: Parameters) =>
+    p.rng.nextUniform(min, max, true).toFloat
+  }
+
   def choose(min: Double, max: Double): Gen[Double] = Gen { (p: Parameters) =>
     p.rng.nextUniform(min, max, true)
   }

--- a/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
+++ b/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
@@ -198,4 +198,90 @@ class ASM4SSuite extends TestNGSuite {
     }
   }
 
+  @Test def nanAlwaysComparesFalse(): Unit = {
+    Prop.forAll { (x: Double) =>
+      {
+        val fb = functionBuilder[Boolean]
+        fb.emit(_return(Double.NaN < x))
+        val f = fb.result()()
+        assert(!f())
+      }
+      {
+        val fb = functionBuilder[Boolean]
+        fb.emit(_return(Double.NaN <= x))
+        val f = fb.result()()
+        assert(!f())
+      }
+      {
+        val fb = functionBuilder[Boolean]
+        fb.emit(_return(Double.NaN > x))
+        val f = fb.result()()
+        assert(!f())
+      }
+      {
+        val fb = functionBuilder[Boolean]
+        fb.emit(_return(Double.NaN >= x))
+        val f = fb.result()()
+        assert(!f())
+      }
+      {
+        val fb = functionBuilder[Boolean]
+        fb.emit(_return(new CodeDouble(Double.NaN).ceq(x)))
+        val f = fb.result()()
+        assert(!f())
+      }
+      {
+        val fb = functionBuilder[Boolean]
+        fb.emit(_return(new CodeDouble(Double.NaN).cne(x)))
+        val f = fb.result()()
+        assert(f())
+      }
+
+      true
+    }.check()
+  }
+
+  @Test def nanFloatAlwaysComparesFalse(): Unit = {
+    Prop.forAll { (x: Float) =>
+      {
+        val fb = functionBuilder[Boolean]
+        fb.emit(_return(Float.NaN < x))
+        val f = fb.result()()
+        assert(!f())
+      }
+      {
+        val fb = functionBuilder[Boolean]
+        fb.emit(_return(Float.NaN <= x))
+        val f = fb.result()()
+        assert(!f())
+      }
+      {
+        val fb = functionBuilder[Boolean]
+        fb.emit(_return(Float.NaN > x))
+        val f = fb.result()()
+        assert(!f())
+      }
+      {
+        val fb = functionBuilder[Boolean]
+        fb.emit(_return(Float.NaN >= x))
+        val f = fb.result()()
+        assert(!f())
+      }
+      {
+        val fb = functionBuilder[Boolean]
+        fb.emit(_return(new CodeFloat(Float.NaN).ceq(x)))
+        val f = fb.result()()
+        assert(!f())
+      }
+      {
+        val fb = functionBuilder[Boolean]
+        fb.emit(_return(new CodeFloat(Float.NaN).cne(x)))
+        val f = fb.result()()
+        assert(f())
+      }
+
+      true
+    }.check()
+  }
+
 }

--- a/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -206,6 +206,30 @@ class ExprSuite extends SparkSuite {
     assert(eval[Boolean]("1.0 // -2.0 == -1.0").contains(true))
     assert(eval[Boolean]("-1.0 // -2.0 == 0.0").contains(true))
 
+    assert(eval[Double]("0 / 0").forall(_.isNaN))
+    assert(eval[Double]("0.0 / 0.0").forall(_.isNaN))
+    assert(eval[Double]("0 / 0 + 1").forall(_.isNaN))
+    assert(eval[Double]("0.0 / 0.0 + 1").forall(_.isNaN))
+    assert(eval[Double]("0 / 0 * 1").forall(_.isNaN))
+    assert(eval[Double]("0.0 / 0.0 * 1").forall(_.isNaN))
+    assert(eval[Double]("1 / 0").contains(Double.PositiveInfinity))
+    assert(eval[Double]("1.0 / 0.0").contains(Double.PositiveInfinity))
+    assert(eval[Double]("-1 / 0").contains(Double.NegativeInfinity))
+    assert(eval[Double]("-1.0 / 0.0").contains(Double.NegativeInfinity))
+    // NB: the -0 is parsed as the zero integer, which is converted to +0.0
+    assert(eval[Double]("1 / -0").contains(Double.PositiveInfinity))
+    assert(eval[Double]("1.0 / -0.0").contains(Double.NegativeInfinity))
+    assert(eval[Double]("0/0 * 1/0").forall(_.isNaN))
+    assert(eval[Double]("0.0/0.0 * 1.0/0.0").forall(_.isNaN))
+    for { x <- Array("-1.0/0.0", "-1.0", "0.0", "1.0", "1.0/0.0") } {
+      assert(eval[Boolean](s"0.0/0.0 < $x").contains(false))
+      assert(eval[Boolean](s"0.0/0.0 <= $x").contains(false))
+      assert(eval[Boolean](s"0.0/0.0 > $x").contains(false))
+      assert(eval[Boolean](s"0.0/0.0 >= $x").contains(false))
+      assert(eval[Boolean](s"0.0/0.0 == $x").contains(false))
+      assert(eval[Boolean](s"0.0/0.0 != $x").contains(true))
+    }
+
     assert(eval[Boolean]("isMissing(gs.noCall.gt)").contains(true))
     assert(eval[Boolean]("gs.noCall.gt").isEmpty)
 


### PR DESCRIPTION
Addresses #1943 

[JVM Spec, Chapter 6](https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-6.html) states, regarding, DCMPG and DCMPL:
> NaN is unordered, so any double comparison fails if either or both of its operands are NaN. With both dcmpg and dcmpl available, any double comparison may be compiled to push the same result onto the operand stack whether the comparison fails on non-NaN values or fails because it encountered a NaN. For more information, see [§3.5](https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-3.html#jvms-3.5).

The `G` and `L` suffices refer to whether the presence of one or more `NaN`s should be indicated by returning "greater than" or "less than". Ergo, when we're checking `x > y` we use `DCMPL` so the NaN case produces `-1` with which the downstream comparison to `0` produces `false`.

Confusingly, the simple intuition is, if you're checking **L**ess Than, you should use the **G** version. If you're checking **G**reater Than, you should use the **L** version.