### PR TITLE
Specify Size in toBlockMatrixDense (1 line fix)

### DIFF
--- a/src/main/scala/is/hail/utils/richUtils/RichIndexedRowMatrix.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichIndexedRowMatrix.scala
@@ -60,7 +60,7 @@ class RichIndexedRowMatrix(indexedRowMatrix: IndexedRowMatrix) {
         }
         new DenseMatrix(actualNumRows, actualNumColumns, matrixAsArray)
     }
-    new BlockMatrix(blocks, rowsPerBlock, colsPerBlock)
+    new BlockMatrix(blocks, rowsPerBlock, colsPerBlock, n, m)
   }
 }
 

--- a/src/main/scala/is/hail/utils/richUtils/RichIndexedRowMatrix.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichIndexedRowMatrix.scala
@@ -60,7 +60,7 @@ class RichIndexedRowMatrix(indexedRowMatrix: IndexedRowMatrix) {
         }
         new DenseMatrix(actualNumRows, actualNumColumns, matrixAsArray)
     }
-    new BlockMatrix(blocks, rowsPerBlock, colsPerBlock, n, m)
+    new BlockMatrix(blocks, rowsPerBlock, colsPerBlock, m, n)
   }
 }
 


### PR DESCRIPTION
toBlockMatrixDense method did not specify size of matrix in constructor, meaning that querying its size later performed an RDD action. 