### PR TITLE
moved linreg(multi) fit and schema into linreg model

### DIFF
--- a/src/main/scala/is/hail/methods/LinearRegression.scala
+++ b/src/main/scala/is/hail/methods/LinearRegression.scala
@@ -6,15 +6,8 @@ import is.hail.expr._
 import is.hail.stats._
 import is.hail.utils._
 import is.hail.variant._
-import net.sourceforge.jdistlib.T
 
 object LinearRegression {
-  val schema = TStruct(
-    ("beta", TDouble),
-    ("se", TDouble),
-    ("tstat", TDouble),
-    ("pval", TDouble))
-
   def apply(vds: VariantDataset, yExpr: String, covExpr: Array[String], root: String, useDosages: Boolean, minAC: Int, minAF: Double): VariantDataset = {
     require(vds.wasSplit)
 
@@ -52,7 +45,7 @@ object LinearRegression {
     val yypBc = sc.broadcast((y dot y) - (Qty dot Qty))
 
     val pathVA = Parser.parseAnnotationRoot(root, Annotation.VARIANT_HEAD)
-    val (newVAS, inserter) = vds.insertVA(LinearRegression.schema, pathVA)
+    val (newVAS, inserter) = vds.insertVA(LinearRegressionModel.schema, pathVA)
 
     vds.mapAnnotations { case (v, va, gs) =>
       val (x: Vector[Double], ac) =
@@ -68,7 +61,7 @@ object LinearRegression {
 
       val linregAnnot =
         if (ac >= combinedMinAC && nonConstant)
-          LinearRegressionModel.fit(x, yBc.value, yypBc.value, QtBc.value, QtyBc.value, d)
+          LinearRegressionModel.fit(x, yBc.value, yypBc.value, QtBc.value, QtyBc.value, d).toAnnotation
         else
           null
 

--- a/src/main/scala/is/hail/methods/LinearRegressionBurden.scala
+++ b/src/main/scala/is/hail/methods/LinearRegressionBurden.scala
@@ -1,13 +1,11 @@
 package is.hail.methods
 
 import breeze.linalg._
-import is.hail.annotations.Annotation
 import is.hail.keytable.KeyTable
 import is.hail.stats._
 import is.hail.utils._
 import is.hail.expr._
 import is.hail.variant._
-import net.sourceforge.jdistlib.T
 import org.apache.spark.sql.Row
 
 object LinearRegressionBurden {
@@ -35,7 +33,7 @@ object LinearRegressionBurden {
     if (completeSamplesSet(keyName))
       fatal(s"Key name '$keyName' clashes with a sample name")
 
-    val linregFields = LinearRegression.schema.fields.map(_.name).toSet
+    val linregFields = LinearRegressionModel.schema.fields.map(_.name).toSet
     if (linregFields(keyName))
       fatal(s"Key name '$keyName' clashes with reserved linreg columns $linregFields")
 
@@ -51,7 +49,7 @@ object LinearRegressionBurden {
     if (!numericType.isInstanceOf[TNumeric])
       fatal(s"aggregate_expr type must be numeric, found $numericType")
 
-    info(s"Running linear regression burden test for ${sampleKT.count} keys on $n samples with $k ${ plural(k, "covariate") } including intercept...")
+    info(s"Running linear regression burden test for ${sampleKT.count()} keys on $n samples with $k ${ plural(k, "covariate") } including intercept...")
 
     val Qt = qr.reduced.justQ(cov).t
     val Qty = Qt * y
@@ -62,13 +60,13 @@ object LinearRegressionBurden {
     val QtyBc = sc.broadcast(Qty)
     val yypBc = sc.broadcast((y dot y) - (Qty dot Qty))
 
-    val (linregSignature, merger) = TStruct(keyName -> keyType).merge(LinearRegression.schema)
+    val (linregSignature, merger) = TStruct(keyName -> keyType).merge(LinearRegressionModel.schema)
     
     val linregRDD = sampleKT.mapAnnotations { keyedRow =>
       val x = RegressionUtils.keyedRowToVectorDouble(keyedRow)
       merger(
         Row(keyedRow.get(0)),
-        LinearRegressionModel.fit(x, yBc.value, yypBc.value, QtBc.value, QtyBc.value, d)).asInstanceOf[Row]
+        LinearRegressionModel.fit(x, yBc.value, yypBc.value, QtBc.value, QtyBc.value, d).toAnnotation).asInstanceOf[Row]
     }
     val linregKT = new KeyTable(sampleKT.hc, linregRDD, signature = linregSignature, key = Array(keyName))
 

--- a/src/main/scala/is/hail/stats/LinearRegressionModel.scala
+++ b/src/main/scala/is/hail/stats/LinearRegressionModel.scala
@@ -1,20 +1,58 @@
 package is.hail.stats
 
-import breeze.linalg.{Matrix, Vector}
+import breeze.linalg._
+import breeze.numerics.sqrt
 import is.hail.annotations.Annotation
+import is.hail.expr.{TArray, TDouble, TStruct}
 import net.sourceforge.jdistlib.T
 
+case class LinearRegressionStats(b: Double, se: Double, t: Double, p: Double) {
+  def toAnnotation: Annotation = Annotation(b, se, t, p)
+}
+
+case class LinearRegressionMultiPhenoStats(b: Array[Double], se: Array[Double], t: Array[Double], p: Array[Double]) {
+  def toAnnotation: Annotation = Annotation(b: IndexedSeq[Double], se: IndexedSeq[Double], t: IndexedSeq[Double], p: IndexedSeq[Double])
+}
+
 object LinearRegressionModel {
-    def fit(x: Vector[Double], y: Vector[Double], yyp: Double, qt: Matrix[Double], qty: Vector[Double], d: Int): Annotation = {
-      val qtx = qt * x
-      val xxp = (x dot x) - (qtx dot qtx)
-      val xyp = (x dot y) - (qtx dot qty)
+  def schema = TStruct(
+    ("beta", TDouble),
+    ("se", TDouble),
+    ("tstat", TDouble),
+    ("pval", TDouble))
 
-      val b = xyp / xxp
-      val se = math.sqrt((yyp / xxp - b * b) / d)
-      val t = b / se
-      val p = 2 * T.cumulative(-math.abs(t), d, true, false)
+  def fit(x: Vector[Double], y: Vector[Double], yyp: Double, qt: Matrix[Double], qty: Vector[Double], d: Int): LinearRegressionStats = {
+    val qtx = qt * x
+    val xxp = (x dot x) - (qtx dot qtx)
+    val xyp = (x dot y) - (qtx dot qty)
 
-      Annotation(b, se, t, p)
-    }
+    val b = xyp / xxp
+    val se = math.sqrt((yyp / xxp - b * b) / d)
+    val t = b / se
+    val p = 2 * T.cumulative(-math.abs(t), d, true, false)
+
+    LinearRegressionStats(b, se, t, p)
+  }
+
+  def schemaMultiPheno = TStruct(
+    ("beta", TArray(TDouble)),
+    ("se", TArray(TDouble)),
+    ("tstat", TArray(TDouble)),
+    ("pval", TArray(TDouble)))
+
+  def fitMultiPheno(x: Vector[Double], y: DenseMatrix[Double], yyp: DenseVector[Double], qt: Matrix[Double],
+    qty: DenseMatrix[Double], d: Int): LinearRegressionMultiPhenoStats = {
+    
+    val qtx = qt * x
+    val xxpRec = 1 / ((x dot x) - (qtx dot qtx))
+    val xyp: Vector[Double] = (y.t * x) - (qty.t * qtx)
+
+    val dRec = 1.0 / d
+    val b = xxpRec * xyp
+    val se = sqrt(dRec * (xxpRec * yyp - (b :* b)))
+    val t = b :/ se
+    val p = t.map(stat => 2 * T.cumulative(-math.abs(stat), d, true, false))
+    
+    LinearRegressionMultiPhenoStats(b.toArray, se.toArray, t.toArray, p.toArray)
+  }
 }


### PR DESCRIPTION
A small bit of refactoring. I've moved schema and math for both LinearRegression and LinearRegressionMultiPheno to the LinearRegressionModel class, and now fit returns LinearRegressionStats which in turn have toAnnotation functions. This provides better separation of data prep and annotation from core math, in line with structure of LogisticRegression(Model), and sets stage for next step of generalizing genotype field. I've left LinearRegression3 as is for now, full consolidation may wait until 0.2.