### PR TITLE
Clean up / increase efficiency of LD Matrix method

### DIFF
--- a/src/main/scala/is/hail/methods/LDMatrix.scala
+++ b/src/main/scala/is/hail/methods/LDMatrix.scala
@@ -61,7 +61,7 @@ object LDMatrix {
       import is.hail.distributedmatrix.DistributedMatrix.implicits._
       val dm = DistributedMatrix[BlockMatrix]
       import dm.ops._
-      indexedRowMatrix = (normalizedBlockMatrix * normalizedBlockMatrix.transpose)
+      indexedRowMatrix = (normalizedBlockMatrix * normalizedBlockMatrix.t)
         .toIndexedRowMatrix()
     }
 

--- a/src/main/scala/is/hail/methods/LDMatrix.scala
+++ b/src/main/scala/is/hail/methods/LDMatrix.scala
@@ -2,9 +2,9 @@ package is.hail.methods
 
 import is.hail.distributedmatrix.{BlockMatrixIsDistributedMatrix, DistributedMatrix}
 import is.hail.utils._
-import is.hail.stats.ToNormalizedIndexedRowMatrix
+import is.hail.stats.{RegressionUtils, ToNormalizedIndexedRowMatrix}
 import is.hail.variant.{Variant, VariantDataset}
-import org.apache.spark.mllib.linalg.{DenseMatrix, Matrix}
+import org.apache.spark.mllib.linalg.{DenseMatrix, Matrix, Vectors}
 import org.apache.spark.mllib.linalg.distributed.{BlockMatrix, IndexedRow, IndexedRowMatrix}
 import org.apache.spark.storage.StorageLevel
 
@@ -18,31 +18,26 @@ object LDMatrix {
     */
   def apply(vds : VariantDataset, optComputeLocally: Option[Boolean]): LDMatrix = {
     val nSamples = vds.nSamples
-    val originalVariants = vds.variants.collect()
-    assert(originalVariants.isSorted, "Array of variants is not sorted. This is a bug.")
+    val nVariants = vds.countVariants()
 
-    val normalizedIRM = ToNormalizedIndexedRowMatrix(vds)
-    normalizedIRM.rows.persist()
-    val variantKeptIndices = normalizedIRM.rows.map{case IndexedRow(idx, _) => idx.toInt}.collect()
-    assert(variantKeptIndices.isSorted, "Array of kept variants is not sorted. This is a bug.")
-    val variantsKept = variantKeptIndices.map(idx => originalVariants(idx))
+    val normalizedHardCalls = vds.rdd.map { case (v, (va, gs)) => (v, RegressionUtils.normalizedHardCalls(gs, nSamples))}
+    val filteredNormalizedHardCalls = normalizedHardCalls.filter{ case (v, opt) => !opt.isEmpty}
+
+    val variantsKept = filteredNormalizedHardCalls.map(_._1).collect()
+    assert(variantsKept.isSorted, "ld_matrix: Array of variants is not sorted. This is a bug")
+
+    val normalizedIndexedRows = filteredNormalizedHardCalls.map(_._2.get).zipWithIndex()
+      .map{ case (values, idx) => IndexedRow(idx, Vectors.dense(values))}
+    val normalizedIRM = new IndexedRowMatrix(normalizedIndexedRows)
+    val normalizedBlockMatrix = normalizedIRM.toBlockMatrixDense()
 
     val nVariantsKept = variantsKept.length
-    val nVariantsDropped = originalVariants.length - nVariantsKept
+    val nVariantsDropped = nVariants - nVariantsKept
 
     info(s"Computing LD Matrix with ${variantsKept.length} variants using $nSamples samples. $nVariantsDropped variants were dropped.")
 
-    //The indices can be expected to be correct from the zip since the VDS is backed by an OrderedRDD of variants.
-    val normalizedFilteredRows = normalizedIRM.rows.zipWithIndex()
-      .map {case (IndexedRow(_, data), idx) => IndexedRow(idx, data)}
-
-    val normalizedBlockMatrix = new IndexedRowMatrix(normalizedFilteredRows).toBlockMatrixDense()
-    normalizedBlockMatrix.persist(StorageLevel.MEMORY_AND_DISK)
-    normalizedBlockMatrix.blocks.count()
-    normalizedIRM.rows.unpersist()
-
     val localBound = 5000 * 5000
-    val nEntries: Long = variantsKept.length * variantsKept.length
+    val nEntries: Long = nVariantsKept * nVariantsKept
 
     val computeLocally = optComputeLocally.getOrElse(nEntries <= localBound)
 
@@ -54,13 +49,15 @@ object LDMatrix {
       val localMat: DenseMatrix = normalizedBlockMatrix.toLocalMatrix().asInstanceOf[DenseMatrix]
       val product = localMat multiply localMat.transpose
       indexedRowMatrix =
-        BlockMatrixIsDistributedMatrix.from(normalizedBlockMatrix.blocks.sparkContext, product,
-          normalizedBlockMatrix.rowsPerBlock, normalizedBlockMatrix.colsPerBlock).toIndexedRowMatrix()
+        BlockMatrixIsDistributedMatrix.from(vds.sparkContext, product, normalizedBlockMatrix.rowsPerBlock,
+          normalizedBlockMatrix.colsPerBlock).toIndexedRowMatrix()
     }
     else {
       import is.hail.distributedmatrix.DistributedMatrix.implicits._
       val dm = DistributedMatrix[BlockMatrix]
       import dm.ops._
+      normalizedBlockMatrix.persist(StorageLevel.MEMORY_AND_DISK)
+      normalizedBlockMatrix.blocks.count()
       indexedRowMatrix = (normalizedBlockMatrix * normalizedBlockMatrix.t)
         .toIndexedRowMatrix()
     }
@@ -68,7 +65,7 @@ object LDMatrix {
     val scaledIndexedRowMatrix = new IndexedRowMatrix(indexedRowMatrix.rows
       .map{case IndexedRow(idx, vals) => IndexedRow(idx, vals.map(d => d * nSamplesInverse))})
 
-    LDMatrix(scaledIndexedRowMatrix, variantsKept, vds.nSamples)
+    LDMatrix(scaledIndexedRowMatrix, variantsKept, nSamples)
   }
 }
 

--- a/src/main/scala/is/hail/methods/LDMatrix.scala
+++ b/src/main/scala/is/hail/methods/LDMatrix.scala
@@ -1,11 +1,11 @@
 package is.hail.methods
 
-import is.hail.distributedmatrix.{BlockMatrixIsDistributedMatrix}
+import is.hail.distributedmatrix.{BlockMatrixIsDistributedMatrix, DistributedMatrix}
 import is.hail.utils._
 import is.hail.stats.ToNormalizedIndexedRowMatrix
 import is.hail.variant.{Variant, VariantDataset}
 import org.apache.spark.mllib.linalg.{DenseMatrix, Matrix}
-import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix}
+import org.apache.spark.mllib.linalg.distributed.{BlockMatrix, IndexedRow, IndexedRowMatrix}
 import org.apache.spark.storage.StorageLevel
 
 
@@ -58,7 +58,10 @@ object LDMatrix {
           normalizedBlockMatrix.rowsPerBlock, normalizedBlockMatrix.colsPerBlock).toIndexedRowMatrix()
     }
     else {
-      indexedRowMatrix = (normalizedBlockMatrix multiply normalizedBlockMatrix.transpose)
+      import is.hail.distributedmatrix.DistributedMatrix.implicits._
+      val dm = DistributedMatrix[BlockMatrix]
+      import dm.ops._
+      indexedRowMatrix = (normalizedBlockMatrix * normalizedBlockMatrix.transpose)
         .toIndexedRowMatrix()
     }
 

--- a/src/main/scala/is/hail/methods/LDMatrix.scala
+++ b/src/main/scala/is/hail/methods/LDMatrix.scala
@@ -2,7 +2,7 @@ package is.hail.methods
 
 import is.hail.distributedmatrix.{BlockMatrixIsDistributedMatrix, DistributedMatrix}
 import is.hail.utils._
-import is.hail.stats.{RegressionUtils, ToNormalizedIndexedRowMatrix}
+import is.hail.stats.{RegressionUtils}
 import is.hail.variant.{Variant, VariantDataset}
 import org.apache.spark.mllib.linalg.{DenseMatrix, Matrix, Vectors}
 import org.apache.spark.mllib.linalg.distributed.{BlockMatrix, IndexedRow, IndexedRowMatrix}


### PR DESCRIPTION
I don't know what I was doing when I first wrote this. I guess I thought I had to use the `toNormalizedIndexedRowMatrix` method and worked to accommodate that? Anyway, this had too many calls to `collect()` in it and was more complicated than it needed to be. 

I also replaced the default Spark multiply operation with Dan's matrix multiply, which is a massive improvement. 


Addresses #2009