### PR TITLE
Write history to file for all export/write commands

### DIFF
--- a/python/hail/context.py
+++ b/python/hail/context.py
@@ -114,6 +114,7 @@ class HailContext(object):
             sys.stderr.write('WARNING: This is an unstable development build.')
 
     def _set_history(self, history):
+        assert self._history is None, "Cannot set history for HailContext more than once."
         self._history = history.set_varid("hc")
         
     @staticmethod

--- a/python/hail/context.py
+++ b/python/hail/context.py
@@ -47,6 +47,7 @@ class HailContext(HistoryMixin):
     :vartype sc: :class:`.pyspark.SparkContext`
     """
 
+    @record_init
     @typecheck_method(sc=nullable(SparkContext),
                       app_name=strlike,
                       master=nullable(strlike),
@@ -58,7 +59,6 @@ class HailContext(HistoryMixin):
                       min_block_size=integral,
                       branching_factor=integral,
                       tmp_dir=strlike)
-    @record_init
     def __init__(self, sc=None, app_name="Hail", master=None, local='local[*]',
                  log='hail.log', quiet=False, append=False, parquet_compression='snappy',
                  min_block_size=1, branching_factor=50, tmp_dir='/tmp'):
@@ -471,7 +471,6 @@ class HailContext(HistoryMixin):
 
         jkt = self._jhc.importTable(paths, key, min_partitions, jtypes, comment, delimiter, missing,
                                     no_header, impute, quote)
-
         return KeyTable(self, jkt)
 
     @handle_py4j

--- a/python/hail/context.py
+++ b/python/hail/context.py
@@ -13,7 +13,7 @@ from hail.utils import wrap_to_list
 from hail.history import *
 
 
-class HailContext(object):
+class HailContext(HasHistory):
     """The main entry point for Hail functionality.
 
     .. warning::
@@ -90,8 +90,7 @@ class HailContext(object):
         self.sc = sc if sc else SparkContext(gateway=self._gateway, jsc=self._jvm.JavaSparkContext(self._jsc))
         self._jsql_context = self._jhc.sqlContext()
         self._sql_context = SQLContext(self.sc, self._jsql_context)
-
-        self._history = None
+        super(HailContext, self).__init__()
 
         # do this at the end in case something errors, so we don't raise the above error without a real HC
         Env._hc = self

--- a/python/hail/context.py
+++ b/python/hail/context.py
@@ -10,6 +10,7 @@ from hail.java import *
 from hail.keytable import KeyTable
 from hail.stats import UniformDist, TruncatedBetaDist, BetaDist
 from hail.utils import wrap_to_list
+from hail.history import *
 
 
 class HailContext(object):
@@ -57,6 +58,7 @@ class HailContext(object):
                       min_block_size=integral,
                       branching_factor=integral,
                       tmp_dir=strlike)
+    @record_init
     def __init__(self, sc=None, app_name="Hail", master=None, local='local[*]',
                  log='hail.log', quiet=False, append=False, parquet_compression='snappy',
                  min_block_size=1, branching_factor=50, tmp_dir='/tmp'):
@@ -89,6 +91,8 @@ class HailContext(object):
         self._jsql_context = self._jhc.sqlContext()
         self._sql_context = SQLContext(self.sc, self._jsql_context)
 
+        self._history = None
+
         # do this at the end in case something errors, so we don't raise the above error without a real HC
         Env._hc = self
 
@@ -109,6 +113,9 @@ class HailContext(object):
         if self.version.startswith('devel'):
             sys.stderr.write('WARNING: This is an unstable development build.')
 
+    def _set_history(self, history):
+        self._history = history.set_varid("hc")
+        
     @staticmethod
     def get_running():
         """Return the running Hail context in this Python session.
@@ -169,6 +176,7 @@ class HailContext(object):
         self._jhc.grep(regex, jindexed_seq_args(path), max_count)
 
     @handle_py4j
+    @record_method
     @typecheck_method(path=oneof(strlike, listof(strlike)),
                       tolerance=numeric,
                       sample_file=nullable(strlike),
@@ -236,6 +244,7 @@ class HailContext(object):
         return VariantDataset(self, jvds)
 
     @handle_py4j
+    @record_method
     @typecheck_method(path=oneof(strlike, listof(strlike)),
                       sample_file=nullable(strlike),
                       tolerance=numeric,
@@ -300,6 +309,7 @@ class HailContext(object):
         return VariantDataset(self, jvds)
 
     @handle_py4j
+    @record_method
     @typecheck_method(paths=oneof(strlike, listof(strlike)),
                       key=oneof(strlike, listof(strlike)),
                       min_partitions=nullable(int),
@@ -461,9 +471,11 @@ class HailContext(object):
 
         jkt = self._jhc.importTable(paths, key, min_partitions, jtypes, comment, delimiter, missing,
                                     no_header, impute, quote)
+
         return KeyTable(self, jkt)
 
     @handle_py4j
+    @record_method
     @typecheck_method(bed=strlike,
                       bim=strlike,
                       fam=strlike,
@@ -541,6 +553,7 @@ class HailContext(object):
         return VariantDataset(self, jvds)
 
     @handle_py4j
+    @record_method
     @typecheck_method(path=oneof(strlike, listof(strlike)),
                       drop_samples=bool,
                       drop_variants=bool)
@@ -570,6 +583,7 @@ class HailContext(object):
             self._jhc.readAll(jindexed_seq_args(path), drop_samples, drop_variants))
 
     @handle_py4j
+    @record_method
     @typecheck_method(path=oneof(strlike, listof(strlike)),
                       force=bool,
                       force_bgz=bool,
@@ -726,6 +740,7 @@ class HailContext(object):
         self._jhc.indexBgen(jindexed_seq_args(path))
 
     @handle_py4j
+    @record_method
     @typecheck_method(populations=integral,
                       samples=integral,
                       variants=integral,
@@ -886,6 +901,7 @@ class HailContext(object):
         Env._hc = None
 
     @handle_py4j
+    @record_method
     @typecheck_method(path=strlike)
     def read_table(self, path):
         """Read a KT file as key table.

--- a/python/hail/context.py
+++ b/python/hail/context.py
@@ -13,7 +13,7 @@ from hail.utils import wrap_to_list
 from hail.history import *
 
 
-class HailContext(HasHistory):
+class HailContext(HistoryMixin):
     """The main entry point for Hail functionality.
 
     .. warning::

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -50,6 +50,7 @@ class VariantDataset(HasHistory):
         self._num_samples = None
         self._jvdf_cache = None
         self._jvkdf_cache = None
+        super(VariantDataset, self).__init__()
 
     @classmethod
     @handle_py4j
@@ -1606,7 +1607,7 @@ class VariantDataset(HasHistory):
         self._jvkdf.exportVCF(output, joption(append_to_header), parallel)
 
     @handle_py4j
-    @write_history('output')
+    @write_history('output', is_dir=True)
     @typecheck_method(output=strlike,
                       overwrite=bool)
     def write(self, output, overwrite=False):

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -1116,6 +1116,7 @@ class VariantDataset(object):
         return self
 
     @handle_py4j
+    @record_method
     def cache(self):
         """Mark this variant dataset to be cached in memory.
 

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -1310,6 +1310,8 @@ class VariantDataset(HistoryMixin):
         - ID_1 and ID_2 are identical and set to the sample ID (``s``).
         - The third column ("missing") is set to 0 for all samples.
 
+        A text file containing the python code to generate this output file is available at ``<output>.history.txt``.
+
         :param str output: Output file base.  Will write GEN and SAMPLE files.
         :param int precision: Number of digits after the decimal point each probability is truncated to.
         """
@@ -1340,6 +1342,8 @@ class VariantDataset(HistoryMixin):
         :py:meth:`~hail.VariantDataset.export_genotypes` outputs one line per non-missing cell (genotype) in the data set.
 
         The ``expr`` argument is a comma-separated list of fields or expressions, all of which must be of the form ``IDENTIFIER = <expression>``, or else of the form ``<expression>``.  If some fields have identifiers and some do not, Hail will throw an exception. The accessible namespace includes ``g``, ``s``, ``sa``, ``v``, ``va``, and ``global``.
+
+        A text file containing the python code to generate this output file is available at ``<output>.history.txt``.
 
         :param str output: Output path.
 
@@ -1409,6 +1413,8 @@ class VariantDataset(HistoryMixin):
           file may disagree.
         - PLINK uses the rsID for the BIM file ID.
 
+        A text file containing the python code to generate this output file is available at ``<output>.history.txt``.
+
         :param str output: Output file base.  Will write BED, BIM, and FAM files.
 
         :param str fam_expr: Expression for FAM file fields.
@@ -1446,6 +1452,8 @@ class VariantDataset(HistoryMixin):
         - ``sa``: sample annotations
         - ``global``: global annotations
         - ``gs`` (*Aggregable[Genotype]*): aggregable of :ref:`genotype` for sample ``s``
+
+        A text file containing the python code to generate this output file is available at ``<output>.history.txt``.
 
         :param str output: Output file.
 
@@ -1534,6 +1542,7 @@ class VariantDataset(HistoryMixin):
         comma-separated list of fields to print. These fields take the
         form ``IDENTIFIER = <expression>``.
 
+        A text file containing the python code to generate this output file is available at ``<output>.history.txt``.
 
         :param str output: Output file.
 
@@ -1596,6 +1605,8 @@ class VariantDataset(HistoryMixin):
             ...     .annotate_variants_expr('va.info.AC = va.qc.AC')
             ...     .export_vcf('output/example.vcf.bgz'))
 
+        A text file containing the python code to generate this output file is available at ``<output>.history.txt``.
+
         :param str output: Path of .vcf file to write.
 
         :param append_to_header: Path of file to append to VCF header.
@@ -1618,6 +1629,10 @@ class VariantDataset(HistoryMixin):
         Import data from a VCF file and then write the data to a VDS file:
 
         >>> vds.write("output/sample.vds")
+
+        **Notes**
+
+        A text file containing the python code to generate this output file is available at ``<output>/history.txt``.
 
         :param str output: Path of VDS file to write.
 

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -18,7 +18,7 @@ warnings.filterwarnings(module=__name__, action='once')
 
 vds_type = lazy()
 
-class VariantDataset(object):
+class VariantDataset(HasHistory):
     """Hail's primary representation of genomic data, a matrix keyed by sample and variant.
 
     Variant datasets may be generated from other formats using the :py:class:`.HailContext` import methods,
@@ -50,15 +50,6 @@ class VariantDataset(object):
         self._num_samples = None
         self._jvdf_cache = None
         self._jvkdf_cache = None
-        self._history = None
-
-    def _set_history(self, history):
-        self._history = history
-
-    def with_id(self, id):
-        self._set_history(self._history.set_varid(id))
-        return self
-
 
     @classmethod
     @handle_py4j

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -18,7 +18,7 @@ warnings.filterwarnings(module=__name__, action='once')
 
 vds_type = lazy()
 
-class VariantDataset(HasHistory):
+class VariantDataset(HistoryMixin):
     """Hail's primary representation of genomic data, a matrix keyed by sample and variant.
 
     Variant datasets may be generated from other formats using the :py:class:`.HailContext` import methods,

--- a/python/hail/expr.py
+++ b/python/hail/expr.py
@@ -121,7 +121,7 @@ class TInt32(Type):
             raise TypeCheckError("TInt32 expected type 'int', but found type '%s'" % type(annotation))
 
     def __repr__(self):
-        return "TInt()"
+        return "TInt32()"
 
 class TInt64(Type):
     """
@@ -152,7 +152,7 @@ class TInt64(Type):
             raise TypeCheckError("TInt64 expected type 'int' or 'long', but found type '%s'" % type(annotation))
 
     def __repr__(self):
-        return "TLong()"
+        return "TInt64()"
 
 
 class TFloat32(Type):
@@ -187,7 +187,7 @@ class TFloat32(Type):
             raise TypeCheckError("TFloat32 expected type 'float', but found type '%s'" % type(annotation))
 
     def __repr__(self):
-        return "TFloat()"
+        return "TFloat32()"
 
 
 class TFloat64(Type):
@@ -219,7 +219,7 @@ class TFloat64(Type):
             raise TypeCheckError("TFloat64 expected type 'float', but found type '%s'" % type(annotation))
 
     def __repr__(self):
-        return "TDouble()"
+        return "TFloat64()"
 
 
 class TString(Type):

--- a/python/hail/expr.py
+++ b/python/hail/expr.py
@@ -1,6 +1,7 @@
 import abc
 from hail.java import scala_object, Env, jset
 from hail.representation import Variant, AltAllele, Genotype, Locus, Interval, Struct, Call
+from hail.history import *
 
 
 class TypeCheckError(Exception):
@@ -26,6 +27,7 @@ class Type(object):
 
     def __init__(self, jtype):
         self._jtype = jtype
+        self._history = None
 
     def __repr__(self):
         return str(self)
@@ -38,6 +40,9 @@ class Type(object):
 
     def __hash__(self):
         return self._jtype.hashCode()
+
+    def _set_history(self, history):
+        self._history = history
 
     def pretty(self, indent=0, attrs=False):
         """Returns a prettily formatted string representation of the type.
@@ -104,6 +109,7 @@ class TInt32(Type):
     """
     __metaclass__ = SingletonType
 
+    @record_init
     def __init__(self):
         super(TInt32, self).__init__(scala_object(Env.hail().expr, 'TInt32'))
 
@@ -133,6 +139,7 @@ class TInt64(Type):
     """
     __metaclass__ = SingletonType
 
+    @record_init
     def __init__(self):
         super(TInt64, self).__init__(scala_object(Env.hail().expr, 'TInt64'))
 
@@ -162,6 +169,7 @@ class TFloat32(Type):
     """
     __metaclass__ = SingletonType
 
+    @record_init
     def __init__(self):
         super(TFloat32, self).__init__(scala_object(Env.hail().expr, 'TFloat32'))
 
@@ -194,6 +202,7 @@ class TFloat64(Type):
     """
     __metaclass__ = SingletonType
 
+    @record_init
     def __init__(self):
         super(TFloat64, self).__init__(scala_object(Env.hail().expr, 'TFloat64'))
 
@@ -223,6 +232,7 @@ class TString(Type):
     """
     __metaclass__ = SingletonType
 
+    @record_init
     def __init__(self):
         super(TString, self).__init__(scala_object(Env.hail().expr, 'TString'))
 
@@ -249,6 +259,7 @@ class TBoolean(Type):
     """
     __metaclass__ = SingletonType
 
+    @record_init
     def __init__(self):
         super(TBoolean, self).__init__(scala_object(Env.hail().expr, 'TBoolean'))
 
@@ -279,6 +290,7 @@ class TArray(Type):
     :vartype element_type: :class:`.Type`
     """
 
+    @record_init
     def __init__(self, element_type):
         """
         :param :class:`.Type` element_type: Hail type of array element
@@ -333,6 +345,7 @@ class TSet(Type):
     :vartype element_type: :class:`.Type`
     """
 
+    @record_init
     def __init__(self, element_type):
         """
         :param :class:`.Type` element_type: Hail type of set element
@@ -391,6 +404,7 @@ class TDict(Type):
     :vartype value_type: :class:`.Type`
     """
 
+    @record_init
     def __init__(self, key_type, value_type):
         jtype = scala_object(Env.hail().expr, 'TDict').apply(key_type._jtype, value_type._jtype)
         self.key_type = key_type
@@ -470,6 +484,7 @@ class TStruct(Type):
     :vartype fields: list of :class:`.Field`
     """
 
+    @record_init
     def __init__(self, names, types):
         """
         """
@@ -536,6 +551,7 @@ class TVariant(Type):
     """
     __metaclass__ = SingletonType
 
+    @record_init
     def __init__(self):
         super(TVariant, self).__init__(scala_object(Env.hail().expr, 'TVariant'))
 
@@ -569,6 +585,7 @@ class TAltAllele(Type):
     """
     __metaclass__ = SingletonType
 
+    @record_init
     def __init__(self):
         super(TAltAllele, self).__init__(scala_object(Env.hail().expr, 'TAltAllele'))
 
@@ -602,6 +619,7 @@ class TGenotype(Type):
     """
     __metaclass__ = SingletonType
 
+    @record_init
     def __init__(self):
         super(TGenotype, self).__init__(scala_object(Env.hail().expr, 'TGenotype'))
 
@@ -635,6 +653,7 @@ class TCall(Type):
     """
     __metaclass__ = SingletonType
 
+    @record_init
     def __init__(self):
         super(TCall, self).__init__(scala_object(Env.hail().expr, 'TCall'))
 
@@ -668,6 +687,7 @@ class TLocus(Type):
     """
     __metaclass__ = SingletonType
 
+    @record_init
     def __init__(self):
         super(TLocus, self).__init__(scala_object(Env.hail().expr, 'TLocus'))
 
@@ -701,6 +721,7 @@ class TInterval(Type):
     """
     __metaclass__ = SingletonType
 
+    @record_init
     def __init__(self):
         super(TInterval, self).__init__(scala_object(Env.hail().expr, 'TInterval'))
 

--- a/python/hail/expr.py
+++ b/python/hail/expr.py
@@ -499,9 +499,6 @@ class TStruct(Type):
         """
         """
 
-        self._names = names
-        self._types = types
-
         if len(names) != len(types):
             raise ValueError('length of names and types not equal: %d and %d' % (len(names), len(types)))
         jtype = scala_object(Env.hail().expr, 'TStruct').apply(names, map(lambda t: t._jtype, types))
@@ -552,7 +549,8 @@ class TStruct(Type):
                 f.typ._typecheck((annotation[f.name]))
 
     def __repr__(self):
-        return "TStruct({}, {})".format(repr(self._names), repr(self._types))
+        names, types = zip(*[(fd.name, fd.typ) for fd in self.fields])
+        return "TStruct({}, {})".format(repr(list(names)), repr(list(types)))
 
 
 class TVariant(Type):

--- a/python/hail/history.py
+++ b/python/hail/history.py
@@ -39,7 +39,7 @@ def record_method(func, obj, *args, **kwargs):
     postnl_args, kwargs_not_default = parse_args(func, args, kwargs)
 
     def set_history(item, index=None, key_name=None):
-        if hasattr(item, "_history"):
+        if isinstance(item, HasHistory):
             item._set_history(obj._history.add_method(func.__name__,
                                                       postnl_args,
                                                       kwargs_not_default,
@@ -98,7 +98,7 @@ def format_args(arg, stmts):
     elif isinstance(arg, dict):
         return {format_args(k, stmts): format_args(v, stmts) for k, v in arg.iteritems()}
     else:
-        if hasattr(arg, "_history"):
+        if isinstance(arg, HasHistory):
             stmts += remove_dup_stmts(stmts, arg._history.stmts)
             return arg._history
         else:
@@ -107,6 +107,7 @@ def format_args(arg, stmts):
 
 def remove_dup_stmts(stmts1, stmts2):
     return [s2 for s1, s2 in itertools.izip_longest(stmts1, stmts2) if s2 and s1 != s2]
+
 
 class History(object):
     def __init__(self, expr="", stmts=[]):
@@ -154,3 +155,15 @@ class History(object):
             history += (stmt + "\n\n")
         history += ("(" + self.expr + ")")
         return autopep8.fix_code(history)
+
+
+class HasHistory(object):
+    def __init__(self):
+        self._history = None
+
+    def _set_history(self, history):
+        self._history = history
+
+    def with_id(self, id):
+        self._set_history(self._history.set_varid(id))
+        return self

--- a/python/hail/history.py
+++ b/python/hail/history.py
@@ -1,6 +1,5 @@
 from __future__ import print_function  # Python 2 and 3 print compatibility
 
-import autopep8
 import datetime
 import inspect
 import itertools
@@ -151,7 +150,11 @@ class History(object):
         for stmt in self.stmts:
             history += (stmt + "\n\n")
         history += ("(" + self.expr + ")")
-        return autopep8.fix_code(history)
+        try:
+            import autopep8
+            return autopep8.fix_code(history)
+        except:
+            return history
 
 
 class HasHistory(object):

--- a/python/hail/history.py
+++ b/python/hail/history.py
@@ -136,7 +136,7 @@ class History(object):
 
     def formatted(self):
         now = datetime.datetime.now()
-        history = "# {}\n# version: {}\n\n".format(now.isoformat(), Env._hc.version)
+        history = "# {}\n# version: {}\n\n".format(now.isoformat(), Env.hc.version)
         history += "from hail import *\n\n"
         for stmt in self.statements:
             history += (stmt + "\n\n")

--- a/python/hail/history.py
+++ b/python/hail/history.py
@@ -155,7 +155,7 @@ class HistoryMixin(object):
         self._history = None
 
     def with_id(self, id):
-        """Set identifier for an object in the history file.
+        """Set identifier for this object in the history file.
 
         **Examples**
 

--- a/python/hail/history.py
+++ b/python/hail/history.py
@@ -38,7 +38,7 @@ def record_method(func, obj, *args, **kwargs):
     postnl_args, kwargs_not_default = parse_args(func, args, kwargs)
 
     def set_history(item, index=None, key_name=None):
-        if isinstance(item, HasHistory):
+        if isinstance(item, HistoryMixin):
             item._set_history(obj
                               ._get_history()
                               .add_method(func.__name__, postnl_args, kwargs_not_default, index=index, key_name=key_name))
@@ -48,7 +48,7 @@ def record_method(func, obj, *args, **kwargs):
         for k, r in result.iteritems():
             set_history(r, key_name=k)
     elif isinstance(result, list) or isinstance(result, tuple):
-        for i, r in enumerate(list(result)):
+        for i, r in enumerate(result):
             set_history(r, index=i)
     else:
         set_history(result)
@@ -91,7 +91,7 @@ def format_args(arg, stmts):
     elif isinstance(arg, dict):
         return {format_args(k, stmts): format_args(v, stmts) for k, v in arg.iteritems()}
     else:
-        if isinstance(arg, HasHistory):
+        if isinstance(arg, HistoryMixin):
             h = arg._get_history()
             stmts += remove_dup_stmts(stmts, h.stmts)
             return h
@@ -155,7 +155,7 @@ class History(object):
             return history
 
 
-class HasHistory(object):
+class HistoryMixin(object):
     def __init__(self):
         self._history = None
 

--- a/python/hail/history.py
+++ b/python/hail/history.py
@@ -5,43 +5,38 @@ import inspect
 import itertools
 from collections import OrderedDict
 from decorator import decorator
-from hail.utils import hadoop_write, wrap_to_list
+from hail.utils import hadoop_write
 from hail.java import Env
 
 
-def parse_args(f, args, kwargs):
+def parse_args(f, args, kwargs, is_method=True):
     argspec = inspect.getargspec(f)
-    kwargs_not_default = OrderedDict({})
 
-    if argspec.defaults:
-        n_postnl_args = len(argspec.args) - len(argspec.defaults)
-        kwargs_not_default.update(OrderedDict({k:v for k, (v, d) in zip(argspec.args[n_postnl_args:], zip(args[n_postnl_args - 1:], argspec.defaults)) if v != d}))
-        postnl_args = args[:n_postnl_args - 1]
-    else:
-        postnl_args = args
+    arg_names = argspec.args[1:] if is_method else argspec.args
+    defaults = list(argspec.defaults) if argspec.defaults else []
+    n_postnl_args = len(arg_names) - len(defaults)
+    defaults = n_postnl_args * [None] + defaults
 
-    kwargs_not_default.update(OrderedDict({k:v for k,v in kwargs.iteritems()}))
-
-    return postnl_args, kwargs_not_default
+    parsed_args = OrderedDict({k: v for k, (v, d) in zip(arg_names, zip(args, defaults)) if v != d})
+    parsed_args.update(OrderedDict({k:v for k,v in kwargs.iteritems()}))
+    return parsed_args
 
 
 @decorator
 def record_init(func, obj, *args, **kwargs):
-    postnl_args, kwargs_not_default = parse_args(func, args, kwargs)
-    h = History.from_init(type(obj).__name__, postnl_args, kwargs_not_default)
+    parsed_args = parse_args(func, args, kwargs)
+    h = History.from_init(type(obj).__name__, parsed_args)
     func(obj, *args, **kwargs)
-    obj._set_history(h)
+    obj._history = h
 
 
 @decorator
 def record_method(func, obj, *args, **kwargs):
-    postnl_args, kwargs_not_default = parse_args(func, args, kwargs)
+    parsed_args = parse_args(func, args, kwargs)
 
     def set_history(item, index=None, key_name=None):
         if isinstance(item, HistoryMixin):
-            item._set_history(obj
-                              ._get_history()
-                              .add_method(func.__name__, postnl_args, kwargs_not_default, index=index, key_name=key_name))
+            item._history = (obj._history.add_method(func.__name__, parsed_args, index=index, key_name=key_name))
 
     result = func(obj, *args, **kwargs)
     if isinstance(result, dict):
@@ -57,15 +52,15 @@ def record_method(func, obj, *args, **kwargs):
 
 @decorator
 def record_classmethod(func, cls, *args, **kwargs):
-    postnl_args, kwargs_not_default = parse_args(func, args, kwargs)
+    parsed_args = parse_args(func, args, kwargs)
     result = func(cls, *args, **kwargs)
-    result._set_history(History.from_classmethod(cls.__name__, func.__name__, postnl_args, kwargs_not_default))
+    result._history = History.from_classmethod(cls.__name__, func.__name__, parsed_args)
     return result
 
 
 def write_history(path_arg_name, is_dir=False):
     def _write(f, obj, *args, **kwargs):
-        postnl_args, kwargs_not_default = parse_args(f, args, kwargs)
+        parsed_args = parse_args(f, args, kwargs)
         argnames = inspect.getcallargs(f, obj, *args, **kwargs)
         result = f(obj, *args, **kwargs)
 
@@ -76,64 +71,64 @@ def write_history(path_arg_name, is_dir=False):
             output_path += ".history.txt"
 
         (obj._history
-         .add_method(f.__name__, postnl_args, kwargs_not_default)
+         .add_method(f.__name__, parsed_args)
          .write(output_path))
 
         return result
     return decorator(_write)
 
 
-def format_args(arg, stmts):
+def format_args(arg, statements):
     if isinstance(arg, list):
-        return [format_args(a, stmts) for a in arg]
+        return [format_args(a, statements) for a in arg]
     elif isinstance(arg, tuple):
-        return tuple([format_args(a, stmts) for a in arg])
+        return tuple([format_args(a, statements) for a in arg])
     elif isinstance(arg, dict):
-        return {format_args(k, stmts): format_args(v, stmts) for k, v in arg.iteritems()}
+        return {format_args(k, statements): format_args(v, statements) for k, v in arg.iteritems()}
     else:
         if isinstance(arg, HistoryMixin):
-            h = arg._get_history()
-            stmts += remove_dup_stmts(stmts, h.stmts)
+            h = arg._history
+            statements += remove_dup_statements(statements, h.statements)
             return h
         else:
             return arg
 
 
-def remove_dup_stmts(stmts1, stmts2):
-    return [s2 for s1, s2 in itertools.izip_longest(stmts1, stmts2) if s2 and s1 != s2]
+def remove_dup_statements(statements1, statements2):
+    return [s2 for s1, s2 in itertools.izip_longest(statements1, statements2) if s2 and s1 != s2]
 
 
 class History(object):
-    def __init__(self, expr="", stmts=[]):
+    def __init__(self, expr="", statements=[]):
         self.expr = expr
-        self.stmts = stmts
+        self.statements = statements
 
     def set_varid(self, id):
-        return History(id, self.stmts + ['{} = ({})'.format(id, self.expr)])
+        return History(id, self.statements + ['{} = ({})'.format(id, self.expr)])
 
-    def add_method(self, f_name, args, kwargs, index=None, key_name=None):
-        stmts = list(self.stmts) # make a copy
-        f_args = [repr(format_args(a, stmts)) for a in args] + ["{}={}".format(k, repr(format_args(v, stmts))) for k, v in kwargs.iteritems()]
-        expr = self.expr + ("\n    ." + f_name + "(" + ", ".join(f_args) + ")")
+    def add_method(self, f_name, kwargs, index=None, key_name=None):
+        statements = self.statements[:]
+        f_args = ["{}={}".format(k, repr(format_args(v, statements))) for k, v in kwargs.iteritems()]
+        expr = "{expr}\n.{f_name}({f_args})".format(expr=self.expr, f_name=f_name, f_args=", ".join(f_args))
         if index:
             expr += "[{}]".format(index)
         elif key_name:
             expr += "[{}]".format(repr(key_name))
-        return History(expr, stmts)
+        return History(expr, statements)
 
     @staticmethod
-    def from_classmethod(cls_name, f_name, args, kwargs):
-        stmts = []
-        f_args = [repr(format_args(a, stmts)) for a in args] + ["{}={}".format(k, repr(format_args(v, stmts))) for k, v in kwargs.iteritems()]
-        expr = cls_name + "." + f_name + "(" + ", ".join(f_args) + ")"
-        return History(expr, stmts)
+    def from_classmethod(cls_name, f_name, kwargs):
+        statements = []
+        f_args = ["{}={}".format(k, repr(format_args(v, statements))) for k, v in kwargs.iteritems()]
+        expr = "{cls_name}.{f_name}({args})".format(cls_name=cls_name, f_name=f_name, args=", ".join(f_args))
+        return History(expr, statements)
 
     @staticmethod
-    def from_init(cls_name, args, kwargs):
-        stmts = []
-        f_args = [repr(format_args(a, stmts)) for a in args] + ["{}={}".format(k, repr(format_args(v, stmts))) for k, v in kwargs.iteritems()]
-        expr = cls_name + "(" + ", ".join(f_args) + ")"
-        return History(expr, stmts)
+    def from_init(cls_name, kwargs):
+        statements = []
+        f_args = ["{}={}".format(k, repr(format_args(v, statements))) for k, v in kwargs.iteritems()]
+        expr = "{cls_name}({args})".format(cls_name=cls_name, args=", ".join(f_args))
+        return History(expr, statements)
 
     def write(self, file):
         with hadoop_write(file) as f:
@@ -145,13 +140,13 @@ class History(object):
     def __str__(self):
         now = datetime.datetime.now()
         history = "# {}\n# version: {}\n\n".format(now.isoformat(), Env._hc.version)
-        for stmt in self.stmts:
+        for stmt in self.statements:
             history += (stmt + "\n\n")
         history += ("(" + self.expr + ")")
         try:
             import autopep8
             return autopep8.fix_code(history)
-        except:
+        except ImportError:
             return history
 
 
@@ -159,12 +154,6 @@ class HistoryMixin(object):
     def __init__(self):
         self._history = None
 
-    def _set_history(self, history):
-        self._history = history
-
-    def _get_history(self):
-        return self._history
-
     def with_id(self, id):
-        self._set_history(self._history.set_varid(id))
+        self._history = self._history.set_varid(id)
         return self

--- a/python/hail/history.py
+++ b/python/hail/history.py
@@ -132,14 +132,12 @@ class History(object):
 
     def write(self, file):
         with hadoop_write(file) as f:
-            f.write(str(self) + "\n")
+            f.write(self.formatted() + "\n")
 
-    def __repr__(self):
-        return self.expr
-
-    def __str__(self):
+    def formatted(self):
         now = datetime.datetime.now()
         history = "# {}\n# version: {}\n\n".format(now.isoformat(), Env._hc.version)
+        history += "from hail import *\n\n"
         for stmt in self.statements:
             history += (stmt + "\n\n")
         history += ("(" + self.expr + ")")
@@ -148,6 +146,9 @@ class History(object):
             return autopep8.fix_code(history)
         except ImportError:
             return history
+
+    def __repr__(self):
+        return self.expr
 
 
 class HistoryMixin(object):

--- a/python/hail/history.py
+++ b/python/hail/history.py
@@ -154,6 +154,7 @@ class HistoryMixin(object):
     def __init__(self):
         self._history = None
 
+    @record_method
     def with_id(self, id):
         self._history = self._history.set_varid(id)
         return self

--- a/python/hail/history.py
+++ b/python/hail/history.py
@@ -67,19 +67,16 @@ def record_classmethod(func, cls, *args, **kwargs):
     return result
 
 
-def write_history(path_arg_name):
+def write_history(path_arg_name, is_dir=False):
     def _write(f, obj, *args, **kwargs):
         postnl_args, kwargs_not_default = parse_args(f, args, kwargs)
         argnames = inspect.getcallargs(f, obj, *args, **kwargs)
         result = f(obj, *args, **kwargs)
 
         output_path = argnames[path_arg_name]
-        try:
-            if Env.jutils().isDir(output_path, Env.hc()._jhc):
-                output_path = output_path + "/history.txt"
-            else:
-                output_path += ".history.txt"
-        except:
+        if is_dir:
+            output_path = output_path + "/history.txt"
+        else:
             output_path += ".history.txt"
 
         (obj._history

--- a/python/hail/history.py
+++ b/python/hail/history.py
@@ -50,12 +50,11 @@ def record_method(func, obj, *args, **kwargs):
     if isinstance(result, dict):
         for k, r in result.iteritems():
             set_history(r, key_name=k)
+    elif isinstance(result, list) or isinstance(result, tuple):
+        for i, r in enumerate(list(result)):
+            set_history(r, index=i)
     else:
-        try:
-            for i, r in enumerate(list(result)):
-                set_history(r, index=i)
-        except:
-            set_history(result)
+        set_history(result)
     return result
 
 
@@ -96,8 +95,9 @@ def format_args(arg, stmts):
         return {format_args(k, stmts): format_args(v, stmts) for k, v in arg.iteritems()}
     else:
         if isinstance(arg, HasHistory):
-            stmts += remove_dup_stmts(stmts, arg._history.stmts)
-            return arg._history
+            h = arg._get_history()
+            stmts += remove_dup_stmts(stmts, h.stmts)
+            return h
         else:
             return arg
 
@@ -160,6 +160,9 @@ class HasHistory(object):
 
     def _set_history(self, history):
         self._history = history
+
+    def _get_history(self):
+        return self._history
 
     def with_id(self, id):
         self._set_history(self._history.set_varid(id))

--- a/python/hail/history.py
+++ b/python/hail/history.py
@@ -39,11 +39,9 @@ def record_method(func, obj, *args, **kwargs):
 
     def set_history(item, index=None, key_name=None):
         if isinstance(item, HasHistory):
-            item._set_history(obj._history.add_method(func.__name__,
-                                                      postnl_args,
-                                                      kwargs_not_default,
-                                                      index=index,
-                                                      key_name=key_name))
+            item._set_history(obj
+                              ._get_history()
+                              .add_method(func.__name__, postnl_args, kwargs_not_default, index=index, key_name=key_name))
 
     result = func(obj, *args, **kwargs)
     if isinstance(result, dict):

--- a/python/hail/history.py
+++ b/python/hail/history.py
@@ -136,7 +136,7 @@ class History(object):
 
     def formatted(self):
         now = datetime.datetime.now()
-        history = "# {}\n# version: {}\n\n".format(now.isoformat(), Env.hc.version)
+        history = "# {}\n# version: {}\n\n".format(now.isoformat(), Env.hc().version)
         history += "from hail import *\n\n"
         for stmt in self.statements:
             history += (stmt + "\n\n")

--- a/python/hail/history.py
+++ b/python/hail/history.py
@@ -1,0 +1,156 @@
+from __future__ import print_function  # Python 2 and 3 print compatibility
+
+import autopep8
+import datetime
+import inspect
+import itertools
+from collections import OrderedDict
+from decorator import decorator
+from hail.utils import hadoop_write, wrap_to_list
+from hail.java import Env
+
+
+def parse_args(f, args, kwargs):
+    argspec = inspect.getargspec(f)
+    kwargs_not_default = OrderedDict({})
+
+    if argspec.defaults:
+        n_postnl_args = len(argspec.args) - len(argspec.defaults)
+        kwargs_not_default.update(OrderedDict({k:v for k, (v, d) in zip(argspec.args[n_postnl_args:], zip(args[n_postnl_args - 1:], argspec.defaults)) if v != d}))
+        postnl_args = args[:n_postnl_args - 1]
+    else:
+        postnl_args = args
+
+    kwargs_not_default.update(OrderedDict({k:v for k,v in kwargs.iteritems()}))
+
+    return postnl_args, kwargs_not_default
+
+
+@decorator
+def record_init(func, obj, *args, **kwargs):
+    postnl_args, kwargs_not_default = parse_args(func, args, kwargs)
+    h = History.from_init(type(obj).__name__, postnl_args, kwargs_not_default)
+    func(obj, *args, **kwargs)
+    obj._set_history(h)
+
+
+@decorator
+def record_method(func, obj, *args, **kwargs):
+    postnl_args, kwargs_not_default = parse_args(func, args, kwargs)
+
+    def set_history(item, index=None, key_name=None):
+        if hasattr(item, "_history"):
+            item._set_history(obj._history.add_method(func.__name__,
+                                                      postnl_args,
+                                                      kwargs_not_default,
+                                                      index=index,
+                                                      key_name=key_name))
+
+    result = func(obj, *args, **kwargs)
+    if isinstance(result, dict):
+        for k, r in result.iteritems():
+            set_history(r, key_name=k)
+    else:
+        try:
+            for i, r in enumerate(list(result)):
+                set_history(r, index=i)
+        except:
+            set_history(result)
+    return result
+
+
+@decorator
+def record_classmethod(func, cls, *args, **kwargs):
+    postnl_args, kwargs_not_default = parse_args(func, args, kwargs)
+    result = func(cls, *args, **kwargs)
+    result._set_history(History.from_classmethod(cls.__name__, func.__name__, postnl_args, kwargs_not_default))
+    return result
+
+
+def write_history(path_arg_name):
+    def _write(f, obj, *args, **kwargs):
+        postnl_args, kwargs_not_default = parse_args(f, args, kwargs)
+        argnames = inspect.getcallargs(f, obj, *args, **kwargs)
+        result = f(obj, *args, **kwargs)
+
+        output_path = argnames[path_arg_name]
+        try:
+            if Env.jutils().isDir(output_path, Env.hc()._jhc):
+                output_path = output_path + "/history.txt"
+            else:
+                output_path += ".history.txt"
+        except:
+            output_path += ".history.txt"
+
+        (obj._history
+         .add_method(f.__name__, postnl_args, kwargs_not_default)
+         .write(output_path))
+
+        return result
+    return decorator(_write)
+
+
+def format_args(arg, stmts):
+    if isinstance(arg, list):
+        return [format_args(a, stmts) for a in arg]
+    elif isinstance(arg, tuple):
+        return tuple([format_args(a, stmts) for a in arg])
+    elif isinstance(arg, dict):
+        return {format_args(k, stmts): format_args(v, stmts) for k, v in arg.iteritems()}
+    else:
+        if hasattr(arg, "_history"):
+            stmts += remove_dup_stmts(stmts, arg._history.stmts)
+            return arg._history
+        else:
+            return arg
+
+
+def remove_dup_stmts(stmts1, stmts2):
+    return [s2 for s1, s2 in itertools.izip_longest(stmts1, stmts2) if s2 and s1 != s2]
+
+class History(object):
+    def __init__(self, expr="", stmts=[]):
+        self.expr = expr
+        self.stmts = stmts
+
+    def set_varid(self, id):
+        return History(id, self.stmts + ['{} = ({})'.format(id, self.expr)])
+
+    def add_method(self, f_name, args, kwargs, index=None, key_name=None):
+        stmts = list(self.stmts) # make a copy
+        f_args = [repr(format_args(a, stmts)) for a in args] + ["{}={}".format(k, repr(format_args(v, stmts))) for k, v in kwargs.iteritems()]
+        expr = self.expr + ("\n    ." + f_name + "(" + ", ".join(f_args) + ")")
+        if index:
+            expr += "[{}]".format(index)
+        elif key_name:
+            expr += "[{}]".format(repr(key_name))
+        return History(expr, stmts)
+
+    @staticmethod
+    def from_classmethod(cls_name, f_name, args, kwargs):
+        stmts = []
+        f_args = [repr(format_args(a, stmts)) for a in args] + ["{}={}".format(k, repr(format_args(v, stmts))) for k, v in kwargs.iteritems()]
+        expr = cls_name + "." + f_name + "(" + ", ".join(f_args) + ")"
+        return History(expr, stmts)
+
+    @staticmethod
+    def from_init(cls_name, args, kwargs):
+        stmts = []
+        f_args = [repr(format_args(a, stmts)) for a in args] + ["{}={}".format(k, repr(format_args(v, stmts))) for k, v in kwargs.iteritems()]
+        expr = cls_name + "(" + ", ".join(f_args) + ")"
+        return History(expr, stmts)
+
+    def write(self, file):
+        with hadoop_write(file) as f:
+            f.write(str(self) + "\n")
+
+    def __repr__(self):
+        return self.expr
+
+    def __str__(self):
+        now = datetime.datetime.now()
+        history = "# {}\n# version: {}\n\n".format(now.isoformat(), Env._hc.version)
+        for stmt in self.stmts:
+            history += (stmt + "\n\n")
+        history += ("(" + self.expr + ")")
+        return autopep8.fix_code(history)

--- a/python/hail/history.py
+++ b/python/hail/history.py
@@ -154,7 +154,40 @@ class HistoryMixin(object):
     def __init__(self):
         self._history = None
 
-    @record_method
     def with_id(self, id):
+        """Set identifier for an object in the history file.
+
+        **Examples**
+
+        Given the following code that writes a VDS:
+
+        .. code-block: python
+
+            vds1 = hc.import_vcf('src/test/resources/sample.vcf').with_id('foo')
+            vds2 = hc.import_vcf('src/test/resources/sample.vcf').with_id('bar')
+            vds1.join(vds2).write('output/vds3.vds')
+
+        the corresponding history file generated for `vds3.vds` will be as follows:
+
+        .. code-block: python
+
+            foo = hc.import_vcf('src/test/resources/sample.vcf')
+            bar = hc.import_vcf('src/test/resources/sample.vcf')
+            foo.join(bar).write('output/vds3.vds')
+
+        If `with_id` is not used, the corresponding history file would be:
+
+        .. code-block: python
+
+            hc.import_vcf('src/test/resources/sample.vcf')
+                .join(hc.import_vcf('src/test/resources/sample.vcf'))
+                .write('/tmp/vds3.vds')
+
+        :param id: Identifier for object.
+        :type id: str
+
+        :return: Input object.
+        """
+
         self._history = self._history.set_varid(id)
         return self

--- a/python/hail/keytable.py
+++ b/python/hail/keytable.py
@@ -258,6 +258,10 @@ class KeyTable(HistoryMixin):
         >>> (kt1.rename({'HT' : 'Height'})
         ...     .export("output/kt1_renamed.tsv"))
 
+        **Notes**
+
+        A text file containing the python code to generate this output file is available at ``<output>.history.txt``.
+
         :param str output: Output file path.
 
         :param str types_file: Output path of types file.
@@ -921,7 +925,11 @@ class KeyTable(HistoryMixin):
 
         >>> kt1.write('output/kt1.kt')
 
-        .. note:: The write path must end in ".kt".       
+        .. note:: The write path must end in ".kt".
+
+        **Notes**
+
+        A text file containing the python code to generate this output file is available at ``<output>/history.txt``.
 
         :param str output: Path of KT file to write.
 

--- a/python/hail/keytable.py
+++ b/python/hail/keytable.py
@@ -13,16 +13,15 @@ class Ascending(HasHistory):
     @record_init
     def __init__(self, col):
         self._jrep = scala_package_object(Env.hail().keytable).asc(col)
-        self._history = None
-
-    def _set_history(self, history):
-        self._history = history
+        super(Ascending, self).__init__()
 
 
 class Descending(HasHistory):
     @record_init
     def __init__(self, col):
         self._jrep = scala_package_object(Env.hail().keytable).desc(col)
+        super(Descending, self).__init__()
+
 
 def asc(col):
     """Sort by ``col`` ascending."""
@@ -89,6 +88,8 @@ class KeyTable(HasHistory):
         self._num_columns = None
         self._key = None
         self._column_names = None
+
+        super(KeyTable, self).__init__()
 
     def __repr__(self):
         return self._jkt.toString()
@@ -914,7 +915,7 @@ class KeyTable(HasHistory):
         self._jkt.typeCheck()
 
     @handle_py4j
-    @write_history('output')
+    @write_history('output', is_dir=True)
     @typecheck_method(output=strlike,
                       overwrite=bool)
     def write(self, output, overwrite=False):

--- a/python/hail/keytable.py
+++ b/python/hail/keytable.py
@@ -9,7 +9,7 @@ from pyspark.sql import DataFrame
 from hail.history import *
 
 
-class Ascending(object):
+class Ascending(HasHistory):
     @record_init
     def __init__(self, col):
         self._jrep = scala_package_object(Env.hail().keytable).asc(col)
@@ -19,14 +19,10 @@ class Ascending(object):
         self._history = history
 
 
-class Descending(object):
+class Descending(HasHistory):
     @record_init
     def __init__(self, col):
         self._jrep = scala_package_object(Env.hail().keytable).desc(col)
-        self._history = None
-
-    def _set_history(self, history):
-        self._history = history
 
 def asc(col):
     """Sort by ``col`` ascending."""
@@ -43,7 +39,7 @@ def desc(col):
 kt_type = lazy()
 
 
-class KeyTable(object):
+class KeyTable(HasHistory):
     """Hail's version of a SQL table where columns can be designated as keys.
 
     Key tables may be imported from a text file or Spark DataFrame with :py:meth:`~hail.HailContext.import_table`
@@ -93,17 +89,9 @@ class KeyTable(object):
         self._num_columns = None
         self._key = None
         self._column_names = None
-        self._history = None
 
     def __repr__(self):
         return self._jkt.toString()
-
-    def _set_history(self, history):
-        self._history = history
-
-    def with_id(self, id):
-        self._set_history(self._history.set_varid(id))
-        return self
 
     @classmethod
     @handle_py4j

--- a/python/hail/keytable.py
+++ b/python/hail/keytable.py
@@ -13,14 +13,12 @@ class Ascending(HistoryMixin):
     @record_init
     def __init__(self, col):
         self._jrep = scala_package_object(Env.hail().keytable).asc(col)
-        super(Ascending, self).__init__()
 
 
 class Descending(HistoryMixin):
     @record_init
     def __init__(self, col):
         self._jrep = scala_package_object(Env.hail().keytable).desc(col)
-        super(Descending, self).__init__()
 
 
 def asc(col):
@@ -88,8 +86,6 @@ class KeyTable(HistoryMixin):
         self._num_columns = None
         self._key = None
         self._column_names = None
-
-        super(KeyTable, self).__init__()
 
     def __repr__(self):
         return self._jkt.toString()

--- a/python/hail/keytable.py
+++ b/python/hail/keytable.py
@@ -9,14 +9,14 @@ from pyspark.sql import DataFrame
 from hail.history import *
 
 
-class Ascending(HasHistory):
+class Ascending(HistoryMixin):
     @record_init
     def __init__(self, col):
         self._jrep = scala_package_object(Env.hail().keytable).asc(col)
         super(Ascending, self).__init__()
 
 
-class Descending(HasHistory):
+class Descending(HistoryMixin):
     @record_init
     def __init__(self, col):
         self._jrep = scala_package_object(Env.hail().keytable).desc(col)
@@ -38,7 +38,7 @@ def desc(col):
 kt_type = lazy()
 
 
-class KeyTable(HasHistory):
+class KeyTable(HistoryMixin):
     """Hail's version of a SQL table where columns can be designated as keys.
 
     Key tables may be imported from a text file or Spark DataFrame with :py:meth:`~hail.HailContext.import_table`

--- a/python/hail/kinshipMatrix.py
+++ b/python/hail/kinshipMatrix.py
@@ -58,6 +58,10 @@ class KinshipMatrix(HistoryMixin):
     def export_tsv(self, output):
         """
         Export kinship matrix to tab-delimited text file with sample list as header.
+
+        **Notes**
+
+        A text file containing the python code to generate this output file is available at ``<output>.history.txt``.
         
         :param str output: File path for output. 
         """
@@ -69,7 +73,11 @@ class KinshipMatrix(HistoryMixin):
     def export_rel(self, output):
         """
         Export kinship matrix as .rel file. See `PLINK formats <https://www.cog-genomics.org/plink2/formats>`_.
-        
+
+        **Notes**
+
+        A text file containing the python code to generate this output file is available at ``<output>.history.txt``.
+
         :param str output: File path for output. 
         """
         self._jkm.exportRel(output)
@@ -80,7 +88,11 @@ class KinshipMatrix(HistoryMixin):
     def export_gcta_grm(self, output):
         """
         Export kinship matrix as .grm file. See `PLINK formats <https://www.cog-genomics.org/plink2/formats>`_.
-        
+
+        **Notes**
+
+        A text file containing the python code to generate this output file is available at ``<output>.history.txt``.
+
         :param str output: File path for output.
         """
         self._jkm.exportGctaGrm(output)
@@ -92,7 +104,11 @@ class KinshipMatrix(HistoryMixin):
     def export_gcta_grm_bin(self, output, opt_n_file=None):
         """
         Export kinship matrix as .grm.bin file or as .grm.N.bin file, depending on whether an N file is specified. See `PLINK formats <https://www.cog-genomics.org/plink2/formats>`_.
-        
+
+        **Notes**
+
+        A text file containing the python code to generate this output file is available at ``<output>.history.txt``.
+
         :param str output: File path for output. 
         
         :param opt_n_file: The file path to the N file. 
@@ -106,7 +122,11 @@ class KinshipMatrix(HistoryMixin):
     def export_id_file(self, output):
         """
         Export samples as .id file. See `PLINK formats <https://www.cog-genomics.org/plink2/formats>`_.
-        
+
+        **Notes**
+
+        A text file containing the python code to generate this output file is available at ``<output>.history.txt``.
+
         :param str output: File path for output.
         """
         self._jkm.exportIdFile(output)

--- a/python/hail/kinshipMatrix.py
+++ b/python/hail/kinshipMatrix.py
@@ -5,6 +5,7 @@ from hail.history import *
 from hail.java import *
 from hail.expr import Type, TString
 
+
 class KinshipMatrix(HasHistory):
     """
     Represents a symmetric matrix encoding the relatedness of each pair of samples in the accompanying sample list.
@@ -15,6 +16,7 @@ class KinshipMatrix(HasHistory):
     def __init__(self, jkm):
         self._key_schema = None
         self._jkm = jkm
+        super(KinshipMatrix, self).__init__()
 
     @property
     @handle_py4j

--- a/python/hail/kinshipMatrix.py
+++ b/python/hail/kinshipMatrix.py
@@ -16,7 +16,6 @@ class KinshipMatrix(HistoryMixin):
     def __init__(self, jkm):
         self._key_schema = None
         self._jkm = jkm
-        super(KinshipMatrix, self).__init__()
 
     @property
     @handle_py4j

--- a/python/hail/kinshipMatrix.py
+++ b/python/hail/kinshipMatrix.py
@@ -5,7 +5,7 @@ from hail.history import *
 from hail.java import *
 from hail.expr import Type, TString
 
-class KinshipMatrix:
+class KinshipMatrix(HasHistory):
     """
     Represents a symmetric matrix encoding the relatedness of each pair of samples in the accompanying sample list.
     
@@ -15,14 +15,6 @@ class KinshipMatrix:
     def __init__(self, jkm):
         self._key_schema = None
         self._jkm = jkm
-        self._history = None
-
-    def _set_history(self, history):
-        self._history = history
-
-    def with_id(self, id):
-        self._set_history(self._history.set_varid(id))
-        return self
 
     @property
     @handle_py4j

--- a/python/hail/kinshipMatrix.py
+++ b/python/hail/kinshipMatrix.py
@@ -1,7 +1,7 @@
 from decorator import decorator
 
 from hail.typecheck import *
-
+from hail.history import *
 from hail.java import *
 from hail.expr import Type, TString
 
@@ -15,8 +15,17 @@ class KinshipMatrix:
     def __init__(self, jkm):
         self._key_schema = None
         self._jkm = jkm
+        self._history = None
+
+    def _set_history(self, history):
+        self._history = history
+
+    def with_id(self, id):
+        self._set_history(self._history.set_varid(id))
+        return self
 
     @property
+    @handle_py4j
     def key_schema(self):
         """
         Returns the signature of the key indexing this matrix.
@@ -28,6 +37,7 @@ class KinshipMatrix:
             self._key_schema = Type._from_java(self._jkm.sampleSignature())
         return self._key_schema
 
+    @handle_py4j
     def sample_list(self):
         """
         Gets the list of samples. The (i, j) entry of the matrix encodes the relatedness of the ith and jth samples.
@@ -37,6 +47,7 @@ class KinshipMatrix:
         """
         return [self.key_schema._convert_to_py(s) for s in self._jkm.sampleIds()]
 
+    @handle_py4j
     def matrix(self):
         """
         Gets the matrix backing this kinship matrix.
@@ -48,7 +59,9 @@ class KinshipMatrix:
 
         return IndexedRowMatrix(self._jkm.matrix())
 
+    @handle_py4j
     @typecheck_method(output=strlike)
+    @write_history('output')
     def export_tsv(self, output):
         """
         Export kinship matrix to tab-delimited text file with sample list as header.
@@ -57,7 +70,9 @@ class KinshipMatrix:
         """
         self._jkm.exportTSV(output)
 
+    @handle_py4j
     @typecheck_method(output=strlike)
+    @write_history('output')
     def export_rel(self, output):
         """
         Export kinship matrix as .rel file. See `PLINK formats <https://www.cog-genomics.org/plink2/formats>`_.
@@ -66,7 +81,9 @@ class KinshipMatrix:
         """
         self._jkm.exportRel(output)
 
+    @handle_py4j
     @typecheck_method(output=strlike)
+    @write_history('output')
     def export_gcta_grm(self, output):
         """
         Export kinship matrix as .grm file. See `PLINK formats <https://www.cog-genomics.org/plink2/formats>`_.
@@ -75,8 +92,10 @@ class KinshipMatrix:
         """
         self._jkm.exportGctaGrm(output)
 
+    @handle_py4j
     @typecheck_method(output=strlike,
                       opt_n_file=nullable(strlike))
+    @write_history('output')
     def export_gcta_grm_bin(self, output, opt_n_file=None):
         """
         Export kinship matrix as .grm.bin file or as .grm.N.bin file, depending on whether an N file is specified. See `PLINK formats <https://www.cog-genomics.org/plink2/formats>`_.
@@ -88,7 +107,9 @@ class KinshipMatrix:
         """
         self._jkm.exportGctaGrmBin(output, joption(opt_n_file))
 
+    @handle_py4j
     @typecheck_method(output=strlike)
+    @write_history('output')
     def export_id_file(self, output):
         """
         Export samples as .id file. See `PLINK formats <https://www.cog-genomics.org/plink2/formats>`_.

--- a/python/hail/kinshipMatrix.py
+++ b/python/hail/kinshipMatrix.py
@@ -6,7 +6,7 @@ from hail.java import *
 from hail.expr import Type, TString
 
 
-class KinshipMatrix(HasHistory):
+class KinshipMatrix(HistoryMixin):
     """
     Represents a symmetric matrix encoding the relatedness of each pair of samples in the accompanying sample list.
     

--- a/python/hail/ldMatrix.py
+++ b/python/hail/ldMatrix.py
@@ -8,6 +8,7 @@ class LDMatrix(HasHistory):
     """
     def __init__(self, jldm):
         self._jldm = jldm
+        super(LDMatrix, self).__init__()
 
     def variant_list(self):
         """

--- a/python/hail/ldMatrix.py
+++ b/python/hail/ldMatrix.py
@@ -1,4 +1,6 @@
 from hail.representation import Variant
+from hail.history import *
+
 
 class LDMatrix:
     """
@@ -6,6 +8,14 @@ class LDMatrix:
     """
     def __init__(self, jldm):
         self._jldm = jldm
+        self._history = None
+
+    def _set_history(self, history):
+        self._history = history
+
+    def with_id(self, id):
+        self._set_history(self._history.set_varid(id))
+        return self
 
     def variant_list(self):
         """

--- a/python/hail/ldMatrix.py
+++ b/python/hail/ldMatrix.py
@@ -8,7 +8,6 @@ class LDMatrix(HistoryMixin):
     """
     def __init__(self, jldm):
         self._jldm = jldm
-        super(LDMatrix, self).__init__()
 
     def variant_list(self):
         """

--- a/python/hail/ldMatrix.py
+++ b/python/hail/ldMatrix.py
@@ -2,7 +2,7 @@ from hail.representation import Variant
 from hail.history import *
 
 
-class LDMatrix(HasHistory):
+class LDMatrix(HistoryMixin):
     """
     Represents a symmetric matrix encoding the Pearson correlation between each pair of variants in the accompanying variant list.
     """

--- a/python/hail/ldMatrix.py
+++ b/python/hail/ldMatrix.py
@@ -2,20 +2,12 @@ from hail.representation import Variant
 from hail.history import *
 
 
-class LDMatrix:
+class LDMatrix(HasHistory):
     """
     Represents a symmetric matrix encoding the Pearson correlation between each pair of variants in the accompanying variant list.
     """
     def __init__(self, jldm):
         self._jldm = jldm
-        self._history = None
-
-    def _set_history(self, history):
-        self._history = history
-
-    def with_id(self, id):
-        self._set_history(self._history.set_varid(id))
-        return self
 
     def variant_list(self):
         """

--- a/python/hail/representation/annotations.py
+++ b/python/hail/representation/annotations.py
@@ -2,7 +2,7 @@ from hail.typecheck import *
 from hail.history import *
 
 
-class Struct(HasHistory):
+class Struct(HistoryMixin):
     """
     Nested annotation structure.
 

--- a/python/hail/representation/annotations.py
+++ b/python/hail/representation/annotations.py
@@ -1,4 +1,5 @@
 from hail.typecheck import *
+from hail.history import *
 
 
 class Struct(object):
@@ -31,9 +32,10 @@ class Struct(object):
     :param dict attributes: struct members.
     """
 
+    @record_init
     def __init__(self, attributes):
-
         self._attrs = attributes
+        self._history = None
 
     def __getattr__(self, item):
         assert (self._attrs)
@@ -65,6 +67,10 @@ class Struct(object):
     def __hash__(self):
         return 37 + hash(tuple(sorted(self._attrs.items())))
 
+    def _set_history(self, history):
+        self._history = history
+
+    @record_method
     @typecheck_method(item=strlike,
                       default=anytype)
     def get(self, item, default=None):

--- a/python/hail/representation/annotations.py
+++ b/python/hail/representation/annotations.py
@@ -2,7 +2,7 @@ from hail.typecheck import *
 from hail.history import *
 
 
-class Struct(object):
+class Struct(HasHistory):
     """
     Nested annotation structure.
 
@@ -35,7 +35,6 @@ class Struct(object):
     @record_init
     def __init__(self, attributes):
         self._attrs = attributes
-        self._history = None
 
     def __getattr__(self, item):
         assert (self._attrs)
@@ -66,9 +65,6 @@ class Struct(object):
 
     def __hash__(self):
         return 37 + hash(tuple(sorted(self._attrs.items())))
-
-    def _set_history(self, history):
-        self._history = history
 
     @record_method
     @typecheck_method(item=strlike,

--- a/python/hail/representation/annotations.py
+++ b/python/hail/representation/annotations.py
@@ -35,6 +35,7 @@ class Struct(HasHistory):
     @record_init
     def __init__(self, attributes):
         self._attrs = attributes
+        super(Struct, self).__init__()
 
     def __getattr__(self, item):
         assert (self._attrs)

--- a/python/hail/representation/annotations.py
+++ b/python/hail/representation/annotations.py
@@ -35,7 +35,6 @@ class Struct(HistoryMixin):
     @record_init
     def __init__(self, attributes):
         self._attrs = attributes
-        super(Struct, self).__init__()
 
     def __getattr__(self, item):
         assert (self._attrs)

--- a/python/hail/representation/genotype.py
+++ b/python/hail/representation/genotype.py
@@ -1,5 +1,6 @@
 from hail.java import *
 from hail.typecheck import *
+from hail.history import *
 
 class Genotype(object):
     """
@@ -24,6 +25,7 @@ class Genotype(object):
     _genotype_jobject = None
 
     @handle_py4j
+    @record_init
     def __init__(self, gt, ad=None, dp=None, gq=None, pl=None):
         """Initialize a Genotype object."""
 
@@ -52,6 +54,8 @@ class Genotype(object):
         self._pl = pl
         self._init_from_java(jrep)
 
+        self._history = None
+
     def __str__(self):
         return self._jrep.toString()
 
@@ -72,6 +76,9 @@ class Genotype(object):
 
     def _init_from_java(self, jrep):
         self._jrep = jrep
+
+    def _set_history(self, history):
+        self._history = history
 
     @classmethod
     def _from_java(cls, jrep):
@@ -345,6 +352,7 @@ class Call(object):
     _call_jobject = None
 
     @handle_py4j
+    @record_init
     def __init__(self, call):
         """Initialize a Call object."""
 
@@ -353,6 +361,7 @@ class Call(object):
 
         jrep = Call._call_jobject.apply(call)
         self._init_from_java(jrep)
+        self._history = None
 
     def __str__(self):
         return self._jrep.toString()
@@ -369,6 +378,9 @@ class Call(object):
     def _init_from_java(self, jrep):
         self._jcall = Call._call_jobject
         self._jrep = jrep
+
+    def _set_history(self, history):
+        self._history = history
 
     @classmethod
     def _from_java(cls, jrep):

--- a/python/hail/representation/genotype.py
+++ b/python/hail/representation/genotype.py
@@ -54,7 +54,6 @@ class Genotype(HistoryMixin):
         self._gq = gq
         self._pl = pl
         self._init_from_java(jrep)
-        super(Genotype, self).__init__()
 
     def __str__(self):
         return self._jrep.toString()
@@ -359,7 +358,6 @@ class Call(HistoryMixin):
 
         jrep = Call._call_jobject.apply(call)
         self._init_from_java(jrep)
-        super(Call, self).__init__()
 
     def __str__(self):
         return self._jrep.toString()

--- a/python/hail/representation/genotype.py
+++ b/python/hail/representation/genotype.py
@@ -54,6 +54,7 @@ class Genotype(HasHistory):
         self._gq = gq
         self._pl = pl
         self._init_from_java(jrep)
+        super(Genotype, self).__init__()
 
     def __str__(self):
         return self._jrep.toString()
@@ -357,6 +358,7 @@ class Call(HasHistory):
 
         jrep = Call._call_jobject.apply(call)
         self._init_from_java(jrep)
+        super(Call, self).__init__()
 
     def __str__(self):
         return self._jrep.toString()

--- a/python/hail/representation/genotype.py
+++ b/python/hail/representation/genotype.py
@@ -3,7 +3,7 @@ from hail.typecheck import *
 from hail.history import *
 
 
-class Genotype(HasHistory):
+class Genotype(HistoryMixin):
     """
     An object that represents an individual's genotype at a genomic locus.
 
@@ -339,7 +339,7 @@ class Genotype(HasHistory):
         return from_option(self._jgenotype.fractionReadsRef(self._jrep))
 
 
-class Call(HasHistory):
+class Call(HistoryMixin):
     """
     An object that represents an individual's call at a genomic locus.
 

--- a/python/hail/representation/genotype.py
+++ b/python/hail/representation/genotype.py
@@ -2,7 +2,8 @@ from hail.java import *
 from hail.typecheck import *
 from hail.history import *
 
-class Genotype(object):
+
+class Genotype(HasHistory):
     """
     An object that represents an individual's genotype at a genomic locus.
 
@@ -54,8 +55,6 @@ class Genotype(object):
         self._pl = pl
         self._init_from_java(jrep)
 
-        self._history = None
-
     def __str__(self):
         return self._jrep.toString()
 
@@ -76,9 +75,6 @@ class Genotype(object):
 
     def _init_from_java(self, jrep):
         self._jrep = jrep
-
-    def _set_history(self, history):
-        self._history = history
 
     @classmethod
     def _from_java(cls, jrep):
@@ -341,7 +337,7 @@ class Genotype(object):
         return from_option(self._jgenotype.fractionReadsRef(self._jrep))
 
 
-class Call(object):
+class Call(HasHistory):
     """
     An object that represents an individual's call at a genomic locus.
 
@@ -361,7 +357,6 @@ class Call(object):
 
         jrep = Call._call_jobject.apply(call)
         self._init_from_java(jrep)
-        self._history = None
 
     def __str__(self):
         return self._jrep.toString()
@@ -378,9 +373,6 @@ class Call(object):
     def _init_from_java(self, jrep):
         self._jcall = Call._call_jobject
         self._jrep = jrep
-
-    def _set_history(self, history):
-        self._history = history
 
     @classmethod
     def _from_java(cls, jrep):

--- a/python/hail/representation/genotype.py
+++ b/python/hail/representation/genotype.py
@@ -78,6 +78,7 @@ class Genotype(HasHistory):
         self._jrep = jrep
 
     @classmethod
+    @record_classmethod
     def _from_java(cls, jrep):
         if not Genotype._genotype_jobject:
             Genotype._genotype_jobject = scala_object(Env.hail().variant, 'Genotype')
@@ -377,6 +378,7 @@ class Call(HasHistory):
         self._jrep = jrep
 
     @classmethod
+    @record_classmethod
     def _from_java(cls, jrep):
         c = Call.__new__(cls)
         c._init_from_java(jrep)

--- a/python/hail/representation/interval.py
+++ b/python/hail/representation/interval.py
@@ -5,7 +5,7 @@ from hail.history import *
 
 interval_type = lazy()
 
-class Interval(HasHistory):
+class Interval(HistoryMixin):
     """
     A genomic interval marked by start and end loci.
 

--- a/python/hail/representation/interval.py
+++ b/python/hail/representation/interval.py
@@ -47,6 +47,7 @@ class Interval(HasHistory):
         self._start = Locus._from_java(self._jrep.start())
 
     @classmethod
+    @record_classmethod
     def _from_java(cls, jrep):
         interval = Interval.__new__(cls)
         interval._init_from_java(jrep)

--- a/python/hail/representation/interval.py
+++ b/python/hail/representation/interval.py
@@ -5,7 +5,7 @@ from hail.history import *
 
 interval_type = lazy()
 
-class Interval(object):
+class Interval(HasHistory):
     """
     A genomic interval marked by start and end loci.
 
@@ -28,7 +28,6 @@ class Interval(object):
                             (str(type(start)), str(type(end))))
         jrep = scala_object(Env.hail().variant, 'Locus').makeInterval(start._jrep, end._jrep)
         self._init_from_java(jrep)
-        self._history = None
 
     def __str__(self):
         return self._jrep.toString()
@@ -45,9 +44,6 @@ class Interval(object):
     def _init_from_java(self, jrep):
         self._jrep = jrep
         self._start = Locus._from_java(self._jrep.start())
-
-    def _set_history(self, history):
-        self._history = history
 
     @classmethod
     def _from_java(cls, jrep):

--- a/python/hail/representation/interval.py
+++ b/python/hail/representation/interval.py
@@ -28,6 +28,7 @@ class Interval(HasHistory):
                             (str(type(start)), str(type(end))))
         jrep = scala_object(Env.hail().variant, 'Locus').makeInterval(start._jrep, end._jrep)
         self._init_from_java(jrep)
+        super(Interval, self).__init__()
 
     def __str__(self):
         return self._jrep.toString()

--- a/python/hail/representation/interval.py
+++ b/python/hail/representation/interval.py
@@ -28,7 +28,6 @@ class Interval(HistoryMixin):
                             (str(type(start)), str(type(end))))
         jrep = scala_object(Env.hail().variant, 'Locus').makeInterval(start._jrep, end._jrep)
         self._init_from_java(jrep)
-        super(Interval, self).__init__()
 
     def __str__(self):
         return self._jrep.toString()

--- a/python/hail/representation/pedigree.py
+++ b/python/hail/representation/pedigree.py
@@ -40,9 +40,9 @@ class Trio(HasHistory):
         self._father = father
         self._mother = mother
         self._is_female = is_female
-        super(Trio, self).__init__()
 
     @classmethod
+    @record_classmethod
     def _from_java(cls, jrep):
         trio = Trio.__new__(cls)
         trio._jrep = jrep
@@ -177,10 +177,9 @@ class Pedigree(HasHistory):
 
         self._jrep = Env.hail().methods.Pedigree(jindexed_seq([t._jrep for t in trios]))
         self._trios = trios
-        self._history = None
-        super(Pedigree, self).__init__()
 
     @classmethod
+    @record_classmethod
     def _from_java(cls, jrep):
         ped = Pedigree.__new__(cls)
         ped._jrep = jrep
@@ -196,9 +195,6 @@ class Pedigree(HasHistory):
     @handle_py4j
     def __hash__(self):
         return self._jrep.hashCode()
-
-    def _set_history(self, history):
-        self._history = history
 
     @classmethod
     @handle_py4j

--- a/python/hail/representation/pedigree.py
+++ b/python/hail/representation/pedigree.py
@@ -174,7 +174,6 @@ class Pedigree(HistoryMixin):
     @handle_py4j
     @record_init
     def __init__(self, trios):
-
         self._jrep = Env.hail().methods.Pedigree(jindexed_seq([t._jrep for t in trios]))
         self._trios = trios
 

--- a/python/hail/representation/pedigree.py
+++ b/python/hail/representation/pedigree.py
@@ -40,6 +40,7 @@ class Trio(HasHistory):
         self._father = father
         self._mother = mother
         self._is_female = is_female
+        super(Trio, self).__init__()
 
     @classmethod
     def _from_java(cls, jrep):
@@ -163,7 +164,7 @@ class Trio(HasHistory):
         return self._complete
 
 
-class Pedigree(object):
+class Pedigree(HasHistory):
     """Class containing a list of trios, with extra functionality.
 
     :param trios: list of trio objects to include in pedigree
@@ -177,6 +178,7 @@ class Pedigree(object):
         self._jrep = Env.hail().methods.Pedigree(jindexed_seq([t._jrep for t in trios]))
         self._trios = trios
         self._history = None
+        super(Pedigree, self).__init__()
 
     @classmethod
     def _from_java(cls, jrep):

--- a/python/hail/representation/pedigree.py
+++ b/python/hail/representation/pedigree.py
@@ -286,6 +286,8 @@ class Pedigree(HistoryMixin):
             Use the key table method :py:meth:`~hail.KeyTable.import_fam` to manipulate this
             information.
 
+        A text file containing the python code to generate this output file is available at ``<output>.history.txt``.
+
         :param path: output path
         :type path: str
         """

--- a/python/hail/representation/pedigree.py
+++ b/python/hail/representation/pedigree.py
@@ -2,7 +2,7 @@ from hail.java import *
 from hail.typecheck import *
 from hail.history import *
 
-class Trio(object):
+class Trio(HasHistory):
     """Class containing information about nuclear family relatedness and sex.
 
     :param str proband: Sample ID of proband.
@@ -40,7 +40,6 @@ class Trio(object):
         self._father = father
         self._mother = mother
         self._is_female = is_female
-        self._history = None
 
     @classmethod
     def _from_java(cls, jrep):
@@ -67,9 +66,6 @@ class Trio(object):
     @handle_py4j
     def __hash__(self):
         return self._jrep.hashCode()
-
-    def _set_history(self, history):
-        self._history = history
 
     @property
     @handle_py4j

--- a/python/hail/representation/pedigree.py
+++ b/python/hail/representation/pedigree.py
@@ -2,7 +2,7 @@ from hail.java import *
 from hail.typecheck import *
 from hail.history import *
 
-class Trio(HasHistory):
+class Trio(HistoryMixin):
     """Class containing information about nuclear family relatedness and sex.
 
     :param str proband: Sample ID of proband.
@@ -164,7 +164,7 @@ class Trio(HasHistory):
         return self._complete
 
 
-class Pedigree(HasHistory):
+class Pedigree(HistoryMixin):
     """Class containing a list of trios, with extra functionality.
 
     :param trios: list of trio objects to include in pedigree

--- a/python/hail/representation/variant.py
+++ b/python/hail/representation/variant.py
@@ -49,6 +49,7 @@ class Variant(HasHistory):
         self._alt_alleles = map(AltAllele._from_java, [jrep.altAlleles().apply(i) for i in xrange(jrep.nAltAlleles())])
 
     @classmethod
+    @record_classmethod
     def _from_java(cls, jrep):
         v = Variant.__new__(cls)
         v._init_from_java(jrep)
@@ -293,6 +294,7 @@ class AltAllele(HasHistory):
         self._jrep = jrep
 
     @classmethod
+    @record_classmethod
     def _from_java(cls, jaa):
         aa = AltAllele.__new__(cls)
         aa._init_from_java(jaa)
@@ -462,6 +464,7 @@ class Locus(HasHistory):
         self._jrep = jrep
 
     @classmethod
+    @record_classmethod
     def _from_java(cls, jrep):
         l = Locus.__new__(cls)
         l._init_from_java(jrep)

--- a/python/hail/representation/variant.py
+++ b/python/hail/representation/variant.py
@@ -2,7 +2,7 @@ from hail.java import scala_object, Env, handle_py4j
 from hail.typecheck import *
 from hail.history import *
 
-class Variant(object):
+class Variant(HasHistory):
     """
     An object that represents a genomic polymorphism.
 
@@ -29,7 +29,6 @@ class Variant(object):
         self._contig = contig
         self._start = start
         self._ref = ref
-        self._history = None
 
     def __str__(self):
         return self._jrep.toString()
@@ -46,9 +45,6 @@ class Variant(object):
     def _init_from_java(self, jrep):
         self._jrep = jrep
         self._alt_alleles = map(AltAllele._from_java, [jrep.altAlleles().apply(i) for i in xrange(jrep.nAltAlleles())])
-
-    def _set_history(self, history):
-        self._history = history
 
     @classmethod
     def _from_java(cls, jrep):
@@ -262,7 +258,7 @@ class Variant(object):
         return self._jrep.inYNonPar()
 
 
-class AltAllele(object):
+class AltAllele(HasHistory):
     """
     An object that represents an allele in a polymorphism deviating from the reference allele.
 
@@ -277,7 +273,6 @@ class AltAllele(object):
         self._init_from_java(jaa)
         self._ref = ref
         self._alt = alt
-        self._history = None
 
     def __str__(self):
         return self._jrep.toString()
@@ -293,9 +288,6 @@ class AltAllele(object):
 
     def _init_from_java(self, jrep):
         self._jrep = jrep
-
-    def _set_history(self, history):
-        self._history = history
 
     @classmethod
     def _from_java(cls, jaa):
@@ -430,7 +422,7 @@ class AltAllele(object):
         """
         return self._jrep.altAlleleType()
 
-class Locus(object):
+class Locus(HasHistory):
     """
     An object that represents a location in the genome.
 
@@ -448,7 +440,6 @@ class Locus(object):
         self._init_from_java(jrep)
         self._contig = contig
         self._position = position
-        self._history = None
 
     def __str__(self):
         return self._jrep.toString()
@@ -464,9 +455,6 @@ class Locus(object):
 
     def _init_from_java(self, jrep):
         self._jrep = jrep
-
-    def _set_history(self, history):
-        self._history = history
 
     @classmethod
     def _from_java(cls, jrep):

--- a/python/hail/representation/variant.py
+++ b/python/hail/representation/variant.py
@@ -30,7 +30,6 @@ class Variant(HistoryMixin):
         self._contig = contig
         self._start = start
         self._ref = ref
-        super(Variant, self).__init__()
 
     def __str__(self):
         return self._jrep.toString()
@@ -276,7 +275,6 @@ class AltAllele(HistoryMixin):
         self._init_from_java(jaa)
         self._ref = ref
         self._alt = alt
-        super(AltAllele, self).__init__()
 
     def __str__(self):
         return self._jrep.toString()
@@ -446,7 +444,6 @@ class Locus(HistoryMixin):
         self._init_from_java(jrep)
         self._contig = contig
         self._position = position
-        super(Locus, self).__init__()
 
     def __str__(self):
         return self._jrep.toString()

--- a/python/hail/representation/variant.py
+++ b/python/hail/representation/variant.py
@@ -2,6 +2,7 @@ from hail.java import scala_object, Env, handle_py4j
 from hail.typecheck import *
 from hail.history import *
 
+
 class Variant(HasHistory):
     """
     An object that represents a genomic polymorphism.
@@ -29,6 +30,7 @@ class Variant(HasHistory):
         self._contig = contig
         self._start = start
         self._ref = ref
+        super(Variant, self).__init__()
 
     def __str__(self):
         return self._jrep.toString()
@@ -273,6 +275,7 @@ class AltAllele(HasHistory):
         self._init_from_java(jaa)
         self._ref = ref
         self._alt = alt
+        super(AltAllele, self).__init__()
 
     def __str__(self):
         return self._jrep.toString()
@@ -422,6 +425,7 @@ class AltAllele(HasHistory):
         """
         return self._jrep.altAlleleType()
 
+
 class Locus(HasHistory):
     """
     An object that represents a location in the genome.
@@ -440,6 +444,7 @@ class Locus(HasHistory):
         self._init_from_java(jrep)
         self._contig = contig
         self._position = position
+        super(Locus, self).__init__()
 
     def __str__(self):
         return self._jrep.toString()

--- a/python/hail/representation/variant.py
+++ b/python/hail/representation/variant.py
@@ -3,7 +3,7 @@ from hail.typecheck import *
 from hail.history import *
 
 
-class Variant(HasHistory):
+class Variant(HistoryMixin):
     """
     An object that represents a genomic polymorphism.
 
@@ -261,7 +261,7 @@ class Variant(HasHistory):
         return self._jrep.inYNonPar()
 
 
-class AltAllele(HasHistory):
+class AltAllele(HistoryMixin):
     """
     An object that represents an allele in a polymorphism deviating from the reference allele.
 
@@ -428,7 +428,7 @@ class AltAllele(HasHistory):
         return self._jrep.altAlleleType()
 
 
-class Locus(HasHistory):
+class Locus(HistoryMixin):
     """
     An object that represents a location in the genome.
 

--- a/python/hail/stats.py
+++ b/python/hail/stats.py
@@ -13,6 +13,7 @@ class BetaDist(HasHistory):
     def __init__(self, a, b):
         self.a = a
         self.b = b
+        super(BetaDist, self).__init__()
 
     def _jrep(self):
         return Env.hail().stats.BetaDist.apply(float(self.a), float(self.b))
@@ -31,6 +32,7 @@ class UniformDist(HasHistory):
             raise ValueError("min must be less than max")
         self.minVal = minVal
         self.maxVal = maxVal
+        super(UniformDist, self).__init__()
 
     def _jrep(self):
         return Env.hail().stats.UniformDist.apply(float(self.minVal), float(self.maxVal))
@@ -58,6 +60,7 @@ class TruncatedBetaDist(HasHistory):
         self.maxVal = maxVal
         self.a = a
         self.b = b
+        super(TruncatedBetaDist, self).__init__()
 
     def _jrep(self):
         return Env.hail().stats.TruncatedBetaDist.apply(float(self.a), float(self.b), float(self.minVal), float(self.maxVal))

--- a/python/hail/stats.py
+++ b/python/hail/stats.py
@@ -14,7 +14,6 @@ class BetaDist(HistoryMixin):
     def __init__(self, a, b):
         self.a = a
         self.b = b
-        super(BetaDist, self).__init__()
 
     def _jrep(self):
         return Env.hail().stats.BetaDist.apply(float(self.a), float(self.b))
@@ -33,7 +32,6 @@ class UniformDist(HistoryMixin):
             raise ValueError("min must be less than max")
         self.minVal = minVal
         self.maxVal = maxVal
-        super(UniformDist, self).__init__()
 
     def _jrep(self):
         return Env.hail().stats.UniformDist.apply(float(self.minVal), float(self.maxVal))
@@ -61,7 +59,6 @@ class TruncatedBetaDist(HistoryMixin):
         self.maxVal = maxVal
         self.a = a
         self.b = b
-        super(TruncatedBetaDist, self).__init__()
 
     def _jrep(self):
         return Env.hail().stats.TruncatedBetaDist.apply(float(self.a), float(self.b), float(self.minVal), float(self.maxVal))

--- a/python/hail/stats.py
+++ b/python/hail/stats.py
@@ -2,6 +2,7 @@ from hail.java import Env
 from hail.typecheck import *
 from hail.history import *
 
+
 class BetaDist(HasHistory):
     """
     Represents a beta distribution with parameters a and b.

--- a/python/hail/stats.py
+++ b/python/hail/stats.py
@@ -2,7 +2,7 @@ from hail.java import Env
 from hail.typecheck import *
 from hail.history import *
 
-class BetaDist:
+class BetaDist(HasHistory):
     """
     Represents a beta distribution with parameters a and b.
     """
@@ -13,16 +13,12 @@ class BetaDist:
     def __init__(self, a, b):
         self.a = a
         self.b = b
-        self._history = None
 
     def _jrep(self):
         return Env.hail().stats.BetaDist.apply(float(self.a), float(self.b))
 
-    def _set_history(self, history):
-        self._history = history
 
-
-class UniformDist:
+class UniformDist(HasHistory):
     """
     Represents a uniform distribution on the interval [minVal, maxVal].
     """
@@ -35,16 +31,12 @@ class UniformDist:
             raise ValueError("min must be less than max")
         self.minVal = minVal
         self.maxVal = maxVal
-        self._history = None
 
     def _jrep(self):
         return Env.hail().stats.UniformDist.apply(float(self.minVal), float(self.maxVal))
 
-    def _set_history(self, history):
-        self._history = history
 
-
-class TruncatedBetaDist:
+class TruncatedBetaDist(HasHistory):
     """
     Represents a truncated beta distribution with parameters a and b and support [minVal, maxVal]. Draws are made
     via rejection sampling, which may be slow if the probability mass of Beta(a,b) over [minVal, maxVal] is small.
@@ -66,10 +58,6 @@ class TruncatedBetaDist:
         self.maxVal = maxVal
         self.a = a
         self.b = b
-        self._history = None
 
     def _jrep(self):
         return Env.hail().stats.TruncatedBetaDist.apply(float(self.a), float(self.b), float(self.minVal), float(self.maxVal))
-
-    def _set_history(self, history):
-        self._history = history

--- a/python/hail/stats.py
+++ b/python/hail/stats.py
@@ -3,7 +3,7 @@ from hail.typecheck import *
 from hail.history import *
 
 
-class BetaDist(HasHistory):
+class BetaDist(HistoryMixin):
     """
     Represents a beta distribution with parameters a and b.
     """
@@ -20,7 +20,7 @@ class BetaDist(HasHistory):
         return Env.hail().stats.BetaDist.apply(float(self.a), float(self.b))
 
 
-class UniformDist(HasHistory):
+class UniformDist(HistoryMixin):
     """
     Represents a uniform distribution on the interval [minVal, maxVal].
     """
@@ -39,7 +39,7 @@ class UniformDist(HasHistory):
         return Env.hail().stats.UniformDist.apply(float(self.minVal), float(self.maxVal))
 
 
-class TruncatedBetaDist(HasHistory):
+class TruncatedBetaDist(HistoryMixin):
     """
     Represents a truncated beta distribution with parameters a and b and support [minVal, maxVal]. Draws are made
     via rejection sampling, which may be slow if the probability mass of Beta(a,b) over [minVal, maxVal] is small.

--- a/python/hail/stats.py
+++ b/python/hail/stats.py
@@ -1,35 +1,48 @@
 from hail.java import Env
 from hail.typecheck import *
+from hail.history import *
 
 class BetaDist:
     """
     Represents a beta distribution with parameters a and b.
     """
+
     @typecheck_method(a=numeric,
                       b=numeric)
+    @record_init
     def __init__(self, a, b):
         self.a = a
         self.b = b
-
+        self._history = None
 
     def _jrep(self):
         return Env.hail().stats.BetaDist.apply(float(self.a), float(self.b))
+
+    def _set_history(self, history):
+        self._history = history
 
 
 class UniformDist:
     """
     Represents a uniform distribution on the interval [minVal, maxVal].
     """
+
     @typecheck_method(minVal=numeric,
                       maxVal=numeric)
+    @record_init
     def __init__(self, minVal, maxVal):
         if minVal >= maxVal:
             raise ValueError("min must be less than max")
         self.minVal = minVal
         self.maxVal = maxVal
+        self._history = None
 
     def _jrep(self):
         return Env.hail().stats.UniformDist.apply(float(self.minVal), float(self.maxVal))
+
+    def _set_history(self, history):
+        self._history = history
+
 
 class TruncatedBetaDist:
     """
@@ -40,6 +53,7 @@ class TruncatedBetaDist:
                       b=numeric,
                       minVal=numeric,
                       maxVal=numeric)
+    @record_init
     def __init__(self, a, b, minVal, maxVal):
         if minVal >= maxVal:
             raise ValueError("min must be less than max")
@@ -52,6 +66,10 @@ class TruncatedBetaDist:
         self.maxVal = maxVal
         self.a = a
         self.b = b
+        self._history = None
 
     def _jrep(self):
         return Env.hail().stats.TruncatedBetaDist.apply(float(self.a), float(self.b), float(self.minVal), float(self.maxVal))
+
+    def _set_history(self, history):
+        self._history = history

--- a/python/hail/tests/tests.py
+++ b/python/hail/tests/tests.py
@@ -942,3 +942,28 @@ class ContextTests(unittest.TestCase):
         self.assertEqual(t1.is_complete(), False)
         self.assertEqual(t1.is_female, True)
         self.assertEqual(t1.is_male, False)
+
+    def test_repr(self):
+        tv = TVariant()
+        tl = TLocus()
+        ti = TInterval()
+        tg = TGenotype()
+        tc = TCall()
+        taa = TAltAllele()
+
+        ti32 = TInt32()
+        ti64 = TInt64()
+        tf32 = TFloat32()
+        tf64 = TFloat64()
+        ts = TString()
+        tb = TBoolean()
+
+        tdict = TDict(TInterval(), TFloat32())
+        tarray = TArray(TString())
+        tset = TSet(TVariant())
+        tstruct = TStruct(['a', 'b'], [TBoolean(), TArray(TString())])
+
+        for typ in [tv, tl, ti, tg, tc, taa,
+                    ti32, ti64, tf32, tf64, ts, tb,
+                    tdict, tarray, tset, tstruct]:
+            self.assertEqual(eval(repr(typ)), typ)

--- a/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -65,10 +65,6 @@ trait Py4jUtils {
     hc.hadoopConf.copy(from, to)
   }
 
-  def isDir(path: String, hc: HailContext): Boolean = {
-    hc.hadoopConf.isDir(path)
-  }
-
   def addSocketAppender(hostname: String, port: Int) {
     val app = new StringSocketAppender(hostname, port, HailContext.logFormat)
     consoleLog.addAppender(app)

--- a/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -65,6 +65,10 @@ trait Py4jUtils {
     hc.hadoopConf.copy(from, to)
   }
 
+  def isDir(path: String, hc: HailContext): Boolean = {
+    hc.hadoopConf.isDir(path)
+  }
+
   def addSocketAppender(hostname: String, port: Int) {
     val app = new StringSocketAppender(hostname, port, HailContext.logFormat)
     consoleLog.addAppender(app)


### PR DESCRIPTION
 - Resolves #1105, #196
 - For VDS and KT writes, writes history to `<output_path>/history.txt`
 - For all other file types, writes history to `<output>.history.txt`
 - Requires new Python dependency: `pip install autopep8`