### PR TITLE
Reworked logging to route log output through Python stderr

### DIFF
--- a/python/hail/java.py
+++ b/python/hail/java.py
@@ -140,11 +140,24 @@ class SimpleServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer):
     daemon_threads = True
     allow_reuse_address = True
 
-    def __init__(self, server_address, RequestHandlerClass):
-        SocketServer.TCPServer.__init__(self, server_address, RequestHandlerClass)
+    def __init__(self, server_address, handler_class):
+        SocketServer.TCPServer.__init__(self, server_address, handler_class)
 
 
 def connect_logger(host, port):
+    """
+    This method starts a simple server which listens on a port for a
+    client to connect and start writing messages. Whenever a message
+    is received, it is written to sys.stderr. The server is run in
+    a daemon thread from the caller, which is killed when the caller
+    thread dies.
+
+    If the socket is in use, then the server tries to listen on the
+    next port (port + 1). After 25 tries, it gives up.
+
+    :param str host: Hostname for server.
+    :param int port: Port to listen on.
+    """
     server = None
     tries = 0
     max_tries = 25

--- a/python/hail/java.py
+++ b/python/hail/java.py
@@ -1,5 +1,11 @@
+import SocketServer
+import socket
+import sys
+from threading import Thread
+
 import py4j
 from decorator import decorator
+
 
 class FatalError(Exception):
     """:class:`.FatalError` is an error thrown by Hail method failures"""
@@ -77,12 +83,15 @@ def from_option(x):
 def jindexed_seq(x):
     return Env.jutils().arrayListToISeq(x)
 
+
 def jset(x):
     return Env.jutils().arrayListToSet(x)
+
 
 def jindexed_seq_args(x):
     args = [x] if isinstance(x, str) or isinstance(x, unicode) else x
     return jindexed_seq(args)
+
 
 def jset_args(x):
     args = [x] if isinstance(x, str) or isinstance(x, unicode) else x
@@ -119,3 +128,42 @@ def handle_py4j(func, *args, **kwargs):
         else:
             raise e
     return r
+
+
+class LoggingTCPHandler(SocketServer.StreamRequestHandler):
+    def handle(self):
+        for line in self.rfile:
+            sys.stderr.write(line)
+
+
+class SimpleServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def __init__(self, server_address, RequestHandlerClass):
+        SocketServer.TCPServer.__init__(self, server_address, RequestHandlerClass)
+
+
+def connect_logger(host, port):
+    server = None
+    tries = 0
+    max_tries = 25
+    while not server:
+        try:
+            server = SimpleServer((host, port), LoggingTCPHandler)
+        except socket.error:
+            port += 1
+            tries += 1
+
+            if tries >= max_tries:
+                sys.stderr.write(
+                    'WARNING: Could not find a free port for logger, maximum retries {} exceeded.'.format(max_tries))
+                return
+
+    t = Thread(target=server.serve_forever, args=())
+
+    # The thread should be a daemon so that it shuts down when the parent thread is killed
+    t.daemon = True
+
+    t.start()
+    Env.jutils().addSocketAppender(host, port)

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -177,15 +177,8 @@ object HailContext {
     val sqlContext = new org.apache.spark.sql.SQLContext(sparkContext)
     val hc = new HailContext(sparkContext, sqlContext, tmpDir, branchingFactor)
     sparkContext.uiWebUrl.foreach(ui => info(s"SparkUI: $ui"))
-    val welcomeMessage =
-      """
-        |Welcome to
-        |     __  __     <>__
-        |    / /_/ /__  __/ /
-        |   / __  / _ `/ / /
-        |  /_/ /_/\_,_/_/_/   version """.stripMargin + is.hail.HAIL_PRETTY_VERSION
 
-    info(welcomeMessage)
+    info(s"Running Hail version ${hc.version}")
     hc
   }
 }

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -13,9 +13,9 @@ import is.hail.stats.{BaldingNicholsModel, Distribution, UniformDist}
 import is.hail.utils.{log, _}
 import is.hail.variant.{GenericDataset, Genotype, Locus, VSMFileMetadata, VSMSubgen, Variant, VariantDataset, VariantSampleMatrix}
 import org.apache.hadoop
-import org.apache.log4j.{LogManager, PropertyConfigurator}
+import org.apache.log4j.{ConsoleAppender, LogManager, PatternLayout, PropertyConfigurator}
 import org.apache.spark.deploy.SparkHadoopUtil
-import org.apache.spark.sql.{DataFrame, SQLContext}
+import org.apache.spark.sql.SQLContext
 import org.apache.spark.{ProgressBarBuilder, SparkConf, SparkContext}
 
 import scala.collection.JavaConverters._
@@ -26,6 +26,8 @@ import scala.reflect.classTag
 object HailContext {
 
   val tera = 1024L * 1024L * 1024L * 1024L
+
+  val logFormat: String = "%d{yyyy-MM-dd HH:mm:ss} %c{1}: %p: %m%n"
 
   def configureAndCreateSparkContext(appName: String, master: Option[String], local: String,
     parquetCompression: String, blockSize: Long): SparkContext = {
@@ -44,6 +46,7 @@ object HailContext {
           conf.setMaster(local)
     }
 
+    conf.set("spark.logConf", "true")
     conf.set("spark.ui.showConsoleProgress", "false")
 
     conf.set(
@@ -101,7 +104,7 @@ object HailContext {
     sqlFileKeys.foreach { k =>
       val param = conf.getLong(k, 0)
       if (param < enoughGigs)
-        problems += s"Invalid config parameter '$k=': too small. Found $param, require at least 50G"
+        problems += s"Invalid config parameter '$k': too small. Found $param, require at least 50G"
     }
 
     if (problems.nonEmpty)
@@ -112,25 +115,20 @@ object HailContext {
 
   def configureLogging(logFile: String, quiet: Boolean, append: Boolean) {
     val logProps = new Properties()
-    if (quiet) {
-      logProps.put("log4j.rootLogger", "OFF, stderr")
-      logProps.put("log4j.appender.stderr", "org.apache.log4j.ConsoleAppender")
-      logProps.put("log4j.appender.stderr.Target", "System.err")
-      logProps.put("log4j.appender.stderr.threshold", "OFF")
-      logProps.put("log4j.appender.stderr.layout", "org.apache.log4j.PatternLayout")
-      logProps.put("log4j.appender.stderr.layout.ConversionPattern", "%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n")
-    } else {
-      logProps.put("log4j.rootLogger", "INFO, logfile")
-      logProps.put("log4j.appender.logfile", "org.apache.log4j.FileAppender")
-      logProps.put("log4j.appender.logfile.append", append.toString)
-      logProps.put("log4j.appender.logfile.file", logFile)
-      logProps.put("log4j.appender.logfile.threshold", "INFO")
-      logProps.put("log4j.appender.logfile.layout", "org.apache.log4j.PatternLayout")
-      logProps.put("log4j.appender.logfile.layout.ConversionPattern", "%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n")
-    }
+
+    logProps.put("log4j.rootLogger", "INFO, logfile")
+    logProps.put("log4j.appender.logfile", "org.apache.log4j.FileAppender")
+    logProps.put("log4j.appender.logfile.append", append.toString)
+    logProps.put("log4j.appender.logfile.file", logFile)
+    logProps.put("log4j.appender.logfile.threshold", "INFO")
+    logProps.put("log4j.appender.logfile.layout", "org.apache.log4j.PatternLayout")
+    logProps.put("log4j.appender.logfile.layout.ConversionPattern", HailContext.logFormat)
 
     LogManager.resetConfiguration()
     PropertyConfigurator.configure(logProps)
+
+    if (!quiet)
+      consoleLog.addAppender(new ConsoleAppender(new PatternLayout(HailContext.logFormat), "System.err"))
   }
 
   def apply(sc: SparkContext = null,
@@ -174,25 +172,20 @@ object HailContext {
         "org.apache.hadoop.io.compress.GzipCodec"
     )
 
-    sparkContext.uiWebUrl.foreach(ui => info(s"SparkUI: $ui"))
     ProgressBarBuilder.build(sparkContext)
-
-    log.info(s"Spark properties: ${
-      sparkContext.getConf.getAll.map { case (k, v) =>
-        s"$k=$v"
-      }.mkString(", ")
-    }")
 
     val sqlContext = new org.apache.spark.sql.SQLContext(sparkContext)
     val hc = new HailContext(sparkContext, sqlContext, tmpDir, branchingFactor)
+    sparkContext.uiWebUrl.foreach(ui => info(s"SparkUI: $ui"))
     val welcomeMessage =
-      """Welcome to
+      """
+        |Welcome to
         |     __  __     <>__
         |    / /_/ /__  __/ /
         |   / __  / _ `/ / /
         |  /_/ /_/\_,_/_/_/   version """.stripMargin + is.hail.HAIL_PRETTY_VERSION
-    println(welcomeMessage)
-    log.info(welcomeMessage)
+
+    info(welcomeMessage)
     hc
   }
 }

--- a/src/main/scala/is/hail/sparkextras/OrderedRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/OrderedRDD.scala
@@ -73,7 +73,7 @@ object OrderedRDD {
         Iterator()
     }.collect()
 
-    log.info(s"keyInfo = ${ keyInfo.toSeq }")
+    log.info(s"Partition summaries: ${ keyInfo.zipWithIndex.map { case (pki, i) => s"i=$i,min=${pki.min},max=${pki.max}" }.mkString(";")}")
 
     if (keyInfo.isEmpty)
       return (AS_IS, empty(rdd.sparkContext))

--- a/src/main/scala/is/hail/utils/ErrorHandling.scala
+++ b/src/main/scala/is/hail/utils/ErrorHandling.scala
@@ -46,7 +46,7 @@ trait ErrorHandling {
     val expanded = expandException(e, false)
     val logExpanded = expandException(e, true)
 
-    log.error(s"hail: fatal: $short\nFrom $logExpanded")
+    log.error(s"$short\nFrom $logExpanded")
 
     (short, expanded)
   }

--- a/src/main/scala/is/hail/utils/LoggerOutputStream.scala
+++ b/src/main/scala/is/hail/utils/LoggerOutputStream.scala
@@ -1,10 +1,9 @@
 package is.hail.utils
 
-import org.slf4j.Logger
-import org.slf4j.event.Level
-
 import java.io.{ByteArrayOutputStream, IOException, OutputStream}
 import java.nio.charset.StandardCharsets
+
+import org.apache.log4j.{Level, Logger}
 
 class LoggerOutputStream(logger: Logger, level: Level) extends OutputStream {
   private val buffer = new ByteArrayOutputStream()

--- a/src/main/scala/is/hail/utils/Logging.scala
+++ b/src/main/scala/is/hail/utils/Logging.scala
@@ -25,7 +25,7 @@ trait Logging {
   def info(msg: String, t: Truncatable) {
     val (screen, logged) = t.strings
     if (screen == logged)
-      log.info(format(msg, screen))
+      consoleLog.info(format(msg, screen))
     else {
       // writes twice to the log file, but this isn't a big problem
       consoleLog.info(format(msg, screen))

--- a/src/main/scala/is/hail/utils/Logging.scala
+++ b/src/main/scala/is/hail/utils/Logging.scala
@@ -1,37 +1,50 @@
 package is.hail.utils
 
-import org.slf4j.{Logger, LoggerFactory}
+import org.apache.log4j.{LogManager, Logger}
 
 trait Logging {
-  @transient var log_ : Logger = _
+  @transient private var logger: Logger = _
+  @transient private var consoleLogger: Logger = _
 
   def log: Logger = {
-    if (log_ == null)
-      log_ = LoggerFactory.getLogger("Hail")
-    log_
+    if (logger == null)
+      logger = LogManager.getRootLogger
+    logger
+  }
+
+  def consoleLog: Logger = {
+    if (consoleLogger == null)
+      consoleLogger = LogManager.getLogger("Hail")
+    consoleLogger
   }
 
   def info(msg: String) {
-    log.info(msg)
-    System.err.println("hail: info: " + msg)
+    consoleLog.info(msg)
   }
 
   def info(msg: String, t: Truncatable) {
     val (screen, logged) = t.strings
-
-    log.info(format(msg, logged))
-    System.err.println("hail: info: " + format(msg, screen))
+    if (screen == logged)
+      log.info(format(msg, screen))
+    else {
+      // writes twice to the log file, but this isn't a big problem
+      consoleLog.info(format(msg, screen))
+      log.info(format(msg, logged))
+    }
   }
 
   def warn(msg: String) {
-    log.warn(msg)
-    System.err.println("hail: warning: " + msg)
+    consoleLog.warn(msg)
   }
 
   def warn(msg: String, t: Truncatable) {
     val (screen, logged) = t.strings
-
-    log.warn(format(msg, logged))
-    System.err.println("hail: warning: " + format(msg, screen))
+    if (screen == logged)
+      consoleLog.warn(format(msg, screen))
+    else {
+      // writes twice to the log file, but this isn't a big problem
+      consoleLog.warn(format(msg, screen))
+      log.warn(format(msg, logged))
+    }
   }
 }

--- a/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -66,7 +66,7 @@ trait Py4jUtils {
   }
 
   def addSocketAppender(hostname: String, port: Int) {
-    val app = new StringSocketAppender(hostname, port, "%d{yyyy-MM-dd HH:mm:ss} %c{1}: %p: %m%n")
+    val app = new StringSocketAppender(hostname, port, HailContext.logFormat)
     consoleLog.addAppender(app)
   }
 }

--- a/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -1,14 +1,11 @@
 package is.hail.utils
 
-import java.io.{InputStream, OutputStream, OutputStreamWriter}
-import java.util
+import java.io.{InputStream, OutputStream}
 
 import is.hail.HailContext
-import is.hail.utils._
 import is.hail.variant.Locus
 
 import scala.collection.JavaConverters._
-import scala.io.{BufferedSource, Source}
 
 trait Py4jUtils {
   def arrayToArrayList[T](arr: Array[T]): java.util.ArrayList[T] = {
@@ -66,6 +63,11 @@ trait Py4jUtils {
 
   def copyFile(from: String, to: String, hc: HailContext) {
     hc.hadoopConf.copy(from, to)
+  }
+
+  def addSocketAppender(hostname: String, port: Int) {
+    val app = new StringSocketAppender("localhost", port, "%d{yyyy-MM-dd HH:mm:ss} %c{1}: %p: %m%n")
+    consoleLog.addAppender(app)
   }
 }
 

--- a/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -66,7 +66,7 @@ trait Py4jUtils {
   }
 
   def addSocketAppender(hostname: String, port: Int) {
-    val app = new StringSocketAppender("localhost", port, "%d{yyyy-MM-dd HH:mm:ss} %c{1}: %p: %m%n")
+    val app = new StringSocketAppender(hostname, port, "%d{yyyy-MM-dd HH:mm:ss} %c{1}: %p: %m%n")
     consoleLog.addAppender(app)
   }
 }

--- a/src/main/scala/is/hail/utils/StringSocketAppender.scala
+++ b/src/main/scala/is/hail/utils/StringSocketAppender.scala
@@ -53,10 +53,9 @@ class StringSocketAppender() extends AppenderSkeleton {
       }
       os = null
     }
-    if (connector != null) { //LogLog.debug("Interrupting the connector.");
+    if (connector != null) {
       connector.interrupted = true
       connector = null // allow gc
-
     }
   }
 
@@ -73,8 +72,7 @@ class StringSocketAppender() extends AppenderSkeleton {
           msg += " We will try again later."
           fireConnector() // fire the connector thread
 
-        }
-        else {
+        } else {
           msg += " We are not retrying."
           errorHandler.error(msg, e, ErrorCode.GENERIC_FAILURE)
         }

--- a/src/main/scala/is/hail/utils/package.scala
+++ b/src/main/scala/is/hail/utils/package.scala
@@ -11,12 +11,11 @@ import org.apache.commons.io.output.TeeOutputStream
 import org.apache.hadoop.fs.PathIOException
 import org.apache.hadoop.mapred.FileSplit
 import org.apache.hadoop.mapreduce.lib.input.{FileSplit => NewFileSplit}
+import org.apache.log4j.Level
 import org.apache.spark.Partition
 import org.json4s.Extraction.decompose
 import org.json4s.jackson.Serialization
 import org.json4s.{Formats, JValue, NoTypeHints}
-import org.slf4j.event.Level
-import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.generic.CanBuildFrom
 import scala.collection.{GenTraversableOnce, TraversableOnce, mutable}
@@ -31,7 +30,7 @@ package object utils extends Logging
   with ErrorHandling {
 
   def getStderrAndLogOutputStream[T](implicit tct: ClassTag[T]): OutputStream =
-    new TeeOutputStream(new LoggerOutputStream(LoggerFactory.getLogger(tct.runtimeClass), Level.ERROR), System.err)
+    new TeeOutputStream(new LoggerOutputStream(log, Level.ERROR), System.err)
 
   trait Truncatable {
     def truncate: String

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -1210,8 +1210,8 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
     if (genotypeSignature != right.genotypeSignature) {
       fatal(
         s"""cannot join datasets with different genotype schemata
-           |  left sample schema: @1
-           |  right sample schema: @2""".stripMargin,
+           |  left genotype schema: @1
+           |  right genotype schema: @2""".stripMargin,
         genotypeSignature.toPrettyString(compact = true, printAttrs = true),
         right.genotypeSignature.toPrettyString(compact = true, printAttrs = true))
     }

--- a/src/test/scala/is/hail/SparkSuite.scala
+++ b/src/test/scala/is/hail/SparkSuite.scala
@@ -10,7 +10,6 @@ object SparkSuite {
   lazy val hc = HailContext(master = Option(System.getProperty("hail.master")),
     appName = "Hail.TestNG",
     local = "local[2]",
-    quiet = true,
     minBlockSize = 0)
 }
 


### PR DESCRIPTION
 - Removed SLF4J, everything goes directly through log4j now.
 - Removed the explicitly System.err.write calls inside info / warn.
 - Separated console logging and log file logging
 - Stripped the huge stack traces out of python errors; they are logged
   to the screen / cell through log4j.