### PR TITLE
Towards fullgeneric 6: rowstore codec

### DIFF
--- a/src/main/scala/is/hail/annotations/MemoryBlock.scala
+++ b/src/main/scala/is/hail/annotations/MemoryBlock.scala
@@ -373,7 +373,7 @@ class RegionValueBuilder(region: MemoryBuffer) {
 
   def addBinary(bytes: Array[Byte]) {
     current() match {
-      case (TFloat64, off) =>
+      case (TBinary, off) =>
         region.align(4)
         val boff = region.offset
         region.storeInt(off, boff)
@@ -385,18 +385,7 @@ class RegionValueBuilder(region: MemoryBuffer) {
   }
 
   def addString(s: String) {
-    current() match {
-      case (TString, off) =>
-        region.align(4)
-        val soff = region.offset
-        region.storeInt(off, soff)
-
-        val bytes = s.getBytes
-        region.appendInt(bytes.length)
-        region.appendBytes(bytes)
-
-        advance()
-    }
+    addBinary(s.getBytes)
   }
 
   def addRow(t: TStruct, r: Row) {
@@ -426,7 +415,7 @@ class RegionValueBuilder(region: MemoryBuffer) {
     t match {
       case t: TStruct => t.fields.exists(f => requiresFixup(f.typ))
       case t: TArray => true
-      case TString | TBinary => true
+      case TBinary => true
       case _ => false
     }
   }
@@ -458,7 +447,7 @@ class RegionValueBuilder(region: MemoryBuffer) {
               val elemFromAOff = fromRegion.loadInt(fromAOff + off)
               fixupArray(t2, toAOff + off, fromRegion, elemFromAOff)
 
-            case TString | TBinary =>
+            case TBinary =>
               fixupBinary(toAOff + off, fromRegion, fromAOff + off)
 
             case _ =>
@@ -479,7 +468,7 @@ class RegionValueBuilder(region: MemoryBuffer) {
           case t2: TStruct =>
             fixupStruct(t2, toOff + fieldOff, fromRegion, fromOff + fieldOff)
 
-          case TString | TBinary =>
+          case TBinary =>
             fixupBinary(toOff + fieldOff, fromRegion, fromOff + fieldOff)
 
           case t2: TArray =>

--- a/src/main/scala/is/hail/annotations/ReadRowsRDD.scala
+++ b/src/main/scala/is/hail/annotations/ReadRowsRDD.scala
@@ -1,14 +1,251 @@
 package is.hail.annotations
 
-import java.io.DataInputStream
+import java.io.{DataInputStream, DataOutputStream}
 
-import is.hail.expr.TStruct
+import is.hail.expr._
 import is.hail.utils.{SerializableHadoopConfiguration, _}
 import net.jpountz.lz4.{LZ4BlockInputStream, LZ4Factory}
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.{Partition, SparkContext, TaskContext}
+
+class Decoder(in: DataInputStream) {
+
+  def readByte(): Byte = {
+    val i = in.read()
+    assert(i != -1)
+    i.toByte
+  }
+
+  def readBoolean(): Boolean = readByte() != 0
+
+  def readInt(): Int = {
+    var b: Byte = readByte()
+    var x: Int = b & 0x7f
+    var shift: Int = 7
+    while ((b & 0x80) != 0) {
+      b = readByte()
+      x |= ((b & 0x7f) << shift)
+      shift += 7
+    }
+
+    x
+  }
+
+  def readLong(): Long = {
+    var b: Byte = readByte()
+    var x: Long = b & 0x7fL
+    var shift: Int = 7
+    while ((b & 0x80) != 0) {
+      b = readByte()
+      x |= ((b & 0x7fL) << shift)
+      shift += 7
+    }
+
+    x
+  }
+
+  def readFloat(): Float = in.readFloat()
+
+  def readDouble(): Double = in.readDouble()
+
+  def readBytes(b: Array[Byte], off: Int, n: Int) {
+    var totalRead = 0
+    while (totalRead < n) {
+      val read = in.read(b, off + totalRead, n - totalRead)
+      assert(read > 0)
+      totalRead += read
+    }
+  }
+
+  def readBinary(region: MemoryBuffer, off: Int) {
+    val length = readInt()
+    region.align(4)
+    val boff = region.allocate(4 + length)
+    region.storeInt(off, boff)
+    region.storeInt(boff, length)
+    readBytes(region.mem, boff + 4, length)
+  }
+
+  def readArray(t: TArray, region: MemoryBuffer, offset: Int) {
+    val length = readInt()
+
+    val contentSize = t.contentsByteSize(length)
+    region.align(t.contentsAlignment)
+    val aoff = region.allocate(contentSize)
+
+    region.storeInt(offset, aoff)
+
+    val nMissingBytes = (length + 7) / 8
+    region.storeInt(aoff, length)
+    readBytes(region.mem, aoff + 4, nMissingBytes)
+
+    val elemsOff = aoff + t.elementsOffset(length)
+    val elemSize = UnsafeUtils.arrayElementSize(t.elementType)
+
+    var i = 0
+    while (i < length) {
+      if (!region.loadBit(aoff + 4, i)) {
+        val off = elemsOff + i * elemSize
+        t.elementType match {
+          case t2: TStruct => readStruct(t2, region, off)
+          case t2: TArray => readArray(t2, region, off)
+          case TBoolean => region.storeByte(off, readBoolean().toByte)
+          case TInt32 => region.storeInt(off, readInt())
+          case TInt64 => region.storeLong(off, readLong())
+          case TFloat32 => region.storeFloat(off, readFloat())
+          case TFloat64 => region.storeDouble(off, readDouble())
+          case TBinary => readBinary(region, off)
+        }
+      }
+      i += 1
+    }
+  }
+
+  def readStruct(t: TStruct, region: MemoryBuffer, offset: Int) {
+    val nMissingBytes = (t.size + 7) / 8
+    readBytes(region.mem, offset, nMissingBytes)
+
+    var i = 0
+    while (i < t.size) {
+      if (!region.loadBit(offset, i)) {
+        val f = t.fields(i)
+        val off = offset + t.byteOffsets(i)
+        f.typ match {
+          case t2: TStruct => readStruct(t2, region, off)
+          case t2: TArray => readArray(t2, region, off)
+          case TBoolean => region.storeByte(off, readBoolean().toByte)
+          case TInt32 => region.storeInt(off, readInt())
+          case TInt64 => region.storeLong(off, readLong())
+          case TFloat32 => region.storeFloat(off, readFloat())
+          case TFloat64 => region.storeDouble(off, readDouble())
+          case TBinary => readBinary(region, off)
+        }
+      }
+      i += 1
+    }
+  }
+
+  def readRegionValue(t: TStruct, region: MemoryBuffer): Int = {
+    region.align(t.alignment)
+    val start = region.allocate(t.byteSize)
+
+    readStruct(t, region, start)
+
+    start
+  }
+}
+
+class Encoder(out: DataOutputStream) {
+
+  def writeByte(b: Byte) {
+    out.write(b)
+  }
+
+  def writeBoolean(b: Boolean) {
+    writeByte(b.toByte)
+  }
+
+  def writeInt(i: Int) {
+    var j = i
+    do {
+      var b = j & 0x7f
+      j >>>= 7
+      if (j != 0)
+        b |= 0x80
+      writeByte(b.toByte)
+    } while (j != 0)
+  }
+
+  def writeLong(l: Long) {
+    var j = l
+    do {
+      var b = j & 0x7f
+      j >>>= 7
+      if (j != 0)
+        b |= 0x80
+      writeByte(b.toByte)
+    } while (j != 0)
+  }
+
+  def writeFloat(f: Float) {
+    out.writeFloat(f)
+  }
+
+  def writeDouble(d: Double) {
+    out.writeDouble(d)
+  }
+
+  def writeBytes(b: Array[Byte], off: Int, n: Int) {
+    out.write(b, off, n)
+  }
+
+  def writeBinary(region: MemoryBuffer, offset: Int) {
+    val boff = region.loadInt(offset)
+    val length = region.loadInt(boff)
+    writeInt(length)
+    writeBytes(region.mem, boff + 4, length)
+  }
+
+  def writeArray(t: TArray, region: MemoryBuffer, offset: Int) {
+    val aoff = region.loadInt(offset)
+    val length = region.loadInt(aoff)
+
+    val nMissingBytes = (length + 7) / 8
+    writeInt(length)
+    writeBytes(region.mem, aoff + 4, nMissingBytes)
+
+    val elemsOff = aoff + t.elementsOffset(length)
+    val elemSize = UnsafeUtils.arrayElementSize(t.elementType)
+    var i = 0
+    while (i < length) {
+      if (!region.loadBit(aoff + 4, i)) {
+        val off = elemsOff + i * elemSize
+        t.elementType match {
+          case t2: TStruct => writeStruct(t2, region, off)
+          case t2: TArray => writeArray(t2, region, off)
+          case TBoolean => writeBoolean(region.loadByte(off) != 0)
+          case TInt32 => writeInt(region.loadInt(off))
+          case TInt64 => writeLong(region.loadLong(off))
+          case TFloat32 => writeFloat(region.loadFloat(off))
+          case TFloat64 => writeDouble(region.loadDouble(off))
+          case TBinary => writeBinary(region, off)
+        }
+      }
+
+      i += 1
+    }
+  }
+
+  def writeStruct(t: TStruct, region: MemoryBuffer, offset: Int) {
+    val nMissingBytes = (t.size + 7) / 8
+    writeBytes(region.mem, offset, nMissingBytes)
+
+    var i = 0
+    while (i < t.size) {
+      if (!region.loadBit(offset, i)) {
+        val off = offset + t.byteOffsets(i)
+        t.fields(i).typ match {
+          case t2: TStruct => writeStruct(t2, region, off)
+          case t2: TArray => writeArray(t2, region, off)
+          case TBoolean => writeBoolean(region.loadByte(off) != 0)
+          case TInt32 => writeInt(region.loadInt(off))
+          case TInt64 => writeLong(region.loadLong(off))
+          case TFloat32 => writeFloat(region.loadFloat(off))
+          case TFloat64 => writeDouble(region.loadDouble(off))
+          case TBinary => writeBinary(region, off)
+        }
+      }
+
+      i += 1
+    }
+  }
+
+  def writeRegionValue(t: TStruct, region: MemoryBuffer, offset: Int) {
+    writeStruct(t, region, offset)
+  }
+}
 
 class RichRDDRow(val rdd: RDD[Row]) extends AnyVal {
   def writeRows(path: String, t: TStruct) {
@@ -39,23 +276,18 @@ class RichRDDRow(val rdd: RDD[Row]) extends AnyVal {
       sHadoopConfBc.value.value.writeLZ4DataFile(path + "/rowstore/part-" + pis,
         64 * 1024,
         LZ4Factory.fastestInstance().highCompressor()) { out =>
+        val en = new Encoder(out)
+
         it.foreach { r =>
           region.clear()
           rvb.start(f)
           rvb.addRow(t, r)
           val offset = rvb.end()
-          assert(offset == 0)
 
           val rowSize = region.offset
           out.writeInt(rowSize)
 
-          var totalWritten = 0
-          while (totalWritten < rowSize) {
-            val toWrite = buffer.length.min(rowSize - totalWritten)
-            region.loadBytes(totalWritten, toWrite, buffer)
-            out.write(buffer, 0, toWrite)
-            totalWritten += toWrite
-          }
+          en.writeRegionValue(f, region, offset)
 
           rowCount += 1
         }
@@ -101,6 +333,10 @@ class ReadRowsRDD(sc: SparkContext,
       private val buffer = new Array[Byte](8 * 1024)
       private val region = MemoryBuffer(rowSize.max(8 * 1024))
 
+      private val dec = new Decoder(in)
+
+      private val t = ttBc.value.typ.asInstanceOf[TStruct]
+
       def hasNext: Boolean = rowSize != -1
 
       def next(): UnsafeRow = {
@@ -110,16 +346,7 @@ class ReadRowsRDD(sc: SparkContext,
         region.clear()
         region.ensure(rowSize)
 
-        var totalRead = 0
-        while (totalRead < rowSize) {
-          val read = in.read(buffer, 0, (rowSize - totalRead).min(buffer.length))
-          assert(read > 0)
-
-          region.appendBytes(buffer, read)
-
-          totalRead += read
-        }
-        assert(region.offset == rowSize)
+        dec.readRegionValue(t.fundamentalType, region)
 
         rowSize = in.readInt()
         if (rowSize == -1)

--- a/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -49,14 +49,14 @@ object UnsafeRow {
     new String(readBinary(region, offset))
 
   def readLocus(region: MemoryBuffer, offset: Int): Locus = {
-    val ft = TLocus.fundamentalType
+    val ft = TLocus.fundamentalType.asInstanceOf[TStruct]
     Locus(
       readString(region, offset + ft.byteOffsets(0)),
       region.loadInt(offset + ft.byteOffsets(1)))
   }
 
   def readAltAllele(region: MemoryBuffer, offset: Int): AltAllele = {
-    val ft = TAltAllele.fundamentalType
+    val ft = TAltAllele.fundamentalType.asInstanceOf[TStruct]
     AltAllele(
       readString(region, offset + ft.byteOffsets(0)),
       readString(region, offset + ft.byteOffsets(1)))
@@ -121,7 +121,7 @@ object UnsafeRow {
         readStruct(region, offset, ttBc)
 
       case TVariant =>
-        val ft = TVariant.fundamentalType
+        val ft = TVariant.fundamentalType.asInstanceOf[TStruct]
         Variant(
           readString(region, offset + ft.byteOffsets(0)),
           region.loadInt(offset + ft.byteOffsets(1)),
@@ -130,12 +130,12 @@ object UnsafeRow {
       case TLocus => readLocus(region, offset)
       case TAltAllele => readAltAllele(region, offset)
       case TInterval =>
-        val ft = TInterval.fundamentalType
+        val ft = TInterval.fundamentalType.asInstanceOf[TStruct]
         Interval[Locus](
           readLocus(region, offset + ft.byteOffsets(0)),
           readLocus(region, offset + ft.byteOffsets(1)))
       case TGenotype =>
-        val ft = TGenotype.fundamentalType
+        val ft = TGenotype.fundamentalType.asInstanceOf[TStruct]
         val gt: Int =
           if (region.loadBit(offset, 0))
             -1

--- a/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -15,10 +15,11 @@ class UnsafeIndexedSeqAnnotation(val region: MemoryBuffer,
     assert(i >= 0 && i < length)
     if (region.loadBit(offset + 4, i))
       null
-    else
+    else {
       UnsafeRow.read(region, elemOffset + i * elemSize,
         arrayTTBc.value.typ.asInstanceOf[TContainer].elementType,
         arrayTTBc.value.subtree(0))
+    }
   }
 }
 

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -613,7 +613,7 @@ case class TArray(elementType: Type) extends TIterable {
 
   override def scalaClassTag: ClassTag[IndexedSeq[AnyRef]] = classTag[IndexedSeq[AnyRef]]
 
-  override lazy val fundamentalType: Type = {
+  override lazy val fundamentalType: TArray = {
     val elementFundamentalType = elementType.fundamentalType
     if (elementFundamentalType == elementType)
       this

--- a/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -253,7 +253,9 @@ object LoadVCF {
               } else {
                 region.clear()
                 rvb.start(rowType.fundamentalType)
+                rvb.startStruct()
                 reader.readRecord(vc, rvb, infoSignatureBc.value, genotypeSignatureBc.value, canonicalFlags)
+                rvb.endStruct()
 
                 val ur = new UnsafeRow(rowTypeTreeBc, region.copy(), rvb.end())
 

--- a/src/test/scala/is/hail/SparkSuite.scala
+++ b/src/test/scala/is/hail/SparkSuite.scala
@@ -9,7 +9,7 @@ import org.scalatest.testng.TestNGSuite
 object SparkSuite {
   lazy val hc = HailContext(master = Option(System.getProperty("hail.master")),
     appName = "Hail.TestNG",
-    local = "local[1]",
+    local = "local[2]",
     quiet = true,
     minBlockSize = 0)
 }

--- a/src/test/scala/is/hail/SparkSuite.scala
+++ b/src/test/scala/is/hail/SparkSuite.scala
@@ -9,7 +9,7 @@ import org.scalatest.testng.TestNGSuite
 object SparkSuite {
   lazy val hc = HailContext(master = Option(System.getProperty("hail.master")),
     appName = "Hail.TestNG",
-    local = "local[2]",
+    local = "local[1]",
     quiet = true,
     minBlockSize = 0)
 }

--- a/src/test/scala/is/hail/annotations/UnsafeSuite.scala
+++ b/src/test/scala/is/hail/annotations/UnsafeSuite.scala
@@ -11,7 +11,9 @@ import org.testng.annotations.Test
 class UnsafeSuite extends SparkSuite {
   @Test def testRegionValue() {
     val region = MemoryBuffer()
+    val region2 = MemoryBuffer()
     val rvb = new RegionValueBuilder(region)
+    val rvb2 = new RegionValueBuilder(region2)
 
     val g = Type.genStruct
       .flatMap(t => Gen.zip(Gen.const(t), t.genValue))
@@ -29,6 +31,15 @@ class UnsafeSuite extends SparkSuite {
 
       val ur = new UnsafeRow(BroadcastTypeTree(sc, t), region, offset)
       assert(t.valuesSimilar(a, ur))
+
+      region2.clear()
+      rvb2.start(f)
+      rvb2.addRow(t, ur)
+      val offset2 = rvb2.end()
+      assert(offset2 == 0)
+
+      val ur2 = new UnsafeRow(BroadcastTypeTree(sc, t), region2, offset2)
+      assert(t.valuesSimilar(a, ur2))
 
       true
     }

--- a/src/test/scala/is/hail/annotations/UnsafeSuite.scala
+++ b/src/test/scala/is/hail/annotations/UnsafeSuite.scala
@@ -24,7 +24,6 @@ class UnsafeSuite extends SparkSuite {
       val f = t.fundamentalType
 
       region.clear()
-
       rvb.start(f)
       rvb.addRow(t, a.asInstanceOf[Row])
       val offset = rvb.end()
@@ -36,9 +35,16 @@ class UnsafeSuite extends SparkSuite {
       rvb2.start(f)
       rvb2.addRow(t, ur)
       val offset2 = rvb2.end()
-      assert(offset2 == 0)
 
       val ur2 = new UnsafeRow(BroadcastTypeTree(sc, t), region2, offset2)
+      assert(t.valuesSimilar(a, ur2))
+
+      // don't clear, just add on
+      rvb2.start(f)
+      rvb2.addUnsafeRow(t, ur)
+      val offset3 = rvb2.end()
+
+      val ur3 = new UnsafeRow(BroadcastTypeTree(sc, t), region2, offset3)
       assert(t.valuesSimilar(a, ur2))
 
       true

--- a/src/test/scala/is/hail/io/ExportPlinkSuite.scala
+++ b/src/test/scala/is/hail/io/ExportPlinkSuite.scala
@@ -1,7 +1,6 @@
 package is.hail.io
 
 import is.hail.SparkSuite
-import is.hail.io.plink.FamFileConfig
 import is.hail.keytable.KeyTable
 import is.hail.utils._
 import org.testng.annotations.Test


### PR DESCRIPTION
builds on: https://github.com/hail-is/hail/pull/2081

profile225 is now 10% larger (instead of ~4x) than the 0.1 VDS or VCF:

```
$ ls -lh profile225.vcf.bgz
 ... 2.0G ... profile225.vcf.bgz
$ du -sh profile225.vds
2.2G	profile225.vds
```

import_vcf/write is still slower than 0.1.  I'm not quite sure why.
