### PR TITLE
Preparation for OrderedRDD2.

### DIFF
--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -104,8 +104,13 @@ object HailContext {
     sqlFileKeys.foreach { k =>
       val param = conf.getLong(k, 0)
       if (param < enoughGigs)
-        problems += s"Invalid config parameter '$k': too small. Found $param, require at least 50G"
+        problems += s"Invalid configuration property $k: too small, at least 50G required. Found: $param."
     }
+
+    val serializer = conf.get("spark.serializer")
+    val kryoSerializer = "org.apache.spark.serializer.KryoSerializer"
+    if (serializer != kryoSerializer)
+      problems += s"Invalid configuration property spark.serializer: required $kryoSerializer.  Found: $serializer."
 
     if (problems.nonEmpty)
       fatal(

--- a/src/main/scala/is/hail/annotations/Memory.scala
+++ b/src/main/scala/is/hail/annotations/Memory.scala
@@ -1,0 +1,59 @@
+package is.hail.annotations
+
+import sun.misc.Unsafe
+
+object Memory {
+  private var unsafe = {
+    val unsafeField = classOf[Unsafe].getDeclaredField("theUnsafe")
+    unsafeField.setAccessible(true)
+    unsafeField.get(null).asInstanceOf[Unsafe]
+  }
+
+  def loadBoolean(addr: Long): Boolean = unsafe.getByte(addr) != 0
+
+  def loadByte(addr: Long): Byte = unsafe.getByte(addr)
+
+  def loadShort(addr: Long): Short = unsafe.getShort(addr)
+
+  def loadInt(addr: Long): Int = unsafe.getInt(addr)
+
+  def loadLong(addr: Long): Long = unsafe.getLong(addr)
+
+  def loadFloat(addr: Long): Float = unsafe.getFloat(addr)
+
+  def loadDouble(addr: Long): Double = unsafe.getDouble(addr)
+
+  def loadAddress(addr: Long): Long = unsafe.getAddress(addr)
+
+  def storeBoolean(addr: Long, b: Boolean): Unit = unsafe.putByte(addr, if (b) 1 else 0)
+
+  def storeByte(addr: Long, b: Byte): Unit = unsafe.putByte(addr, b)
+
+  def storeShort(addr: Long, s: Short): Unit = unsafe.putShort(addr, s)
+
+  def storeInt(addr: Long, i: Int): Unit = unsafe.putInt(addr, i)
+
+  def storeLong(addr: Long, l: Long): Unit = unsafe.putLong(addr, l)
+
+  def storeFloat(addr: Long, f: Float): Unit = unsafe.putFloat(addr, f)
+
+  def storeDouble(addr: Long, d: Double): Unit = unsafe.putDouble(addr, d)
+
+  def storeAddress(addr: Long, a: Long): Unit = unsafe.putAddress(addr, a)
+
+  def malloc(size: Long): Long = unsafe.allocateMemory(size)
+
+  def free(a: Long): Unit = unsafe.freeMemory(a)
+
+  def realloc(a: Long, newSize: Long): Long = unsafe.reallocateMemory(a, newSize)
+
+  def memcpy(dst: Long, src: Long, n: Long): Unit = unsafe.copyMemory(src, dst, n)
+
+  def copyToArray(dst: Array[Byte], src: Long, n: Long): Unit = {
+    unsafe.copyMemory(null, src, dst, Unsafe.ARRAY_BYTE_BASE_OFFSET, n)
+  }
+
+  def copyFromArray(dst: Long, src: Array[Byte], n: Long): Unit = {
+    unsafe.copyMemory(src, Unsafe.ARRAY_BYTE_BASE_OFFSET, null, dst, n)
+  }
+}

--- a/src/main/scala/is/hail/annotations/UnsafeUtils.scala
+++ b/src/main/scala/is/hail/annotations/UnsafeUtils.scala
@@ -3,7 +3,7 @@ package is.hail.annotations
 import is.hail.expr.Type
 
 object UnsafeUtils {
-  def arrayElementSize(t: Type): Int = {
+  def arrayElementSize(t: Type): Long = {
     var eltSize = t.byteSize
     if (eltSize > 0) {
       val mod = eltSize % t.alignment
@@ -13,7 +13,7 @@ object UnsafeUtils {
     eltSize
   }
 
-  def roundUpAlignment(offset: Int, alignment: Int): Int = {
+  def roundUpAlignment(offset: Long, alignment: Long): Long = {
     assert(alignment > 0, s"invalid alignment: $alignment")
     assert((alignment & (alignment - 1)) == 0, s"invalid alignment: $alignment") // power of 2
     (offset + (alignment - 1)) & ~(alignment - 1)

--- a/src/main/scala/is/hail/utils/BytePacker.scala
+++ b/src/main/scala/is/hail/utils/BytePacker.scala
@@ -3,13 +3,13 @@ package is.hail.utils
 import scala.collection.mutable
 
 class BytePacker {
-  val slots = new mutable.TreeSet[(Int, Int)]
+  val slots = new mutable.TreeSet[(Long, Long)]
 
-  def insertSpace(size: Int, start: Int) {
+  def insertSpace(size: Long, start: Long) {
     slots += size -> start
   }
 
-  def getSpace(size: Int, alignment: Int): Option[Int] = {
+  def getSpace(size: Long, alignment: Long): Option[Long] = {
 
     // disregard spaces smaller than size
     slots.iteratorFrom(size -> 0)
@@ -18,7 +18,7 @@ class BytePacker {
         val start = x._2
 
         // find a start position with the proper alignment
-        var i = 0
+        var i = 0L
         while (i + size <= spaceSize) {
           // space found
           if ((start + i) % alignment == 0) {

--- a/src/main/scala/is/hail/variant/HTSGenotypeView.scala
+++ b/src/main/scala/is/hail/variant/HTSGenotypeView.scala
@@ -18,7 +18,7 @@ object HTSGenotypeView {
 
 // FIXME: This is removed, and StructGenotypeView becomes the only genotype view when TGenotype is removed
 sealed abstract class HTSGenotypeView {
-  def setRegion(mb: MemoryBuffer, offset: Int)
+  def setRegion(mb: MemoryBuffer, offset: Long)
 
   def setGenotype(idx: Int)
 
@@ -55,12 +55,12 @@ private class TGenotypeView(rs: TStruct) extends HTSGenotypeView {
   private val linearScaleIndex = 6
 
   private var m: MemoryBuffer = _
-  private var gsOffset: Int = _
+  private var gsOffset: Long = _
   private var gsLength: Int = _
-  private var gOffset: Int = _
+  private var gOffset: Long = _
   private var gIsDefined: Boolean = _
 
-  def setRegion(mb: MemoryBuffer, offset: Int) {
+  def setRegion(mb: MemoryBuffer, offset: Long) {
     this.m = mb
     gsOffset = rs.loadField(m, offset, 2)
     gsLength = tgs.loadLength(m, gsOffset)
@@ -138,12 +138,12 @@ private class StructGenotypeView(rs: TStruct) extends HTSGenotypeView {
   private val (plExists, plIndex) = lookupField("PL", HTSGenotypeView.tArrayInt32)
 
   private var m: MemoryBuffer = _
-  private var gsOffset: Int = _
+  private var gsOffset: Long = _
   private var gsLength: Int = _
-  private var gOffset: Int = _
+  private var gOffset: Long = _
   private var gIsDefined: Boolean = _
 
-  def setRegion(mb: MemoryBuffer, offset: Int) {
+  def setRegion(mb: MemoryBuffer, offset: Long) {
     this.m = mb
     gsOffset = rs.loadField(m, offset, 2)
     gsLength = tgs.loadLength(m, gsOffset)

--- a/src/test/scala/is/hail/annotations/UnsafeSuite.scala
+++ b/src/test/scala/is/hail/annotations/UnsafeSuite.scala
@@ -31,13 +31,13 @@ class UnsafeSuite extends SparkSuite {
 
       hadoopConf.writeDataFile(path) { out =>
         val en = new Encoder(out)
-        en.writeRegionValue(f, region, offset)
+        en.writeRegionValue(t, region, offset)
       }
 
       region2.clear()
       val offset2 = hadoopConf.readDataFile(path) { in =>
         val dec = new Decoder(in)
-        dec.readRegionValue(f, region2)
+        dec.readRegionValue(t, region2)
       }
 
       val ur2 = new UnsafeRow(BroadcastTypeTree(sc, t), region2, offset2)


### PR DESCRIPTION
Use off-heap storage.
Replaced Platform => is.hail.annotations.Memory.
Offsets are now Long, including stored offests to binary and arrays.