### PR TITLE
fix latent bug in readObjectFile

### DIFF
--- a/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
@@ -223,11 +223,18 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
   def fileStatus(filename: String): FileStatus = fileSystem(filename).getFileStatus(new hadoop.fs.Path(filename))
 
   def readObjectFile[T](filename: String)(f: (ObjectInputStream) => T): T = {
-    val ois = new ObjectInputStream(open(filename))
+    val is = open(filename)
     try {
-      f(ois)
+      // NB: ObjectInputStream constructor can throw an exception without closing is
+      val ois = new ObjectInputStream(is)
+      try {
+        f(ois)
+      } finally {
+        ois.close()
+      }
     } finally {
-      ois.close()
+      // Closable.close() is idempotent
+      is.close()
     }
   }
 

--- a/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
@@ -212,11 +212,18 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
   }
 
   def writeObjectFile[T](filename: String)(f: (ObjectOutputStream) => T): T = {
-    val oos = new ObjectOutputStream(create(filename))
+    val os = create(filename)
     try {
-      f(oos)
+      // NB: ObjectOutputStream constructor can throw an exception without closing is
+      val oos = new ObjectOutputStream(create(filename))
+      try {
+        f(oos)
+      } finally {
+        oos.close()
+      }
     } finally {
-      oos.close()
+      // Closable.close() is idempotent
+      os.close()
     }
   }
 


### PR DESCRIPTION
The [constructor of `ObjectInputStream`](https://docs.oracle.com/javase/8/docs/api/java/io/ObjectInputStream.html#ObjectInputStream-java.io.InputStream-) can, sadly, throw an exception and we must therefore have two finally blocks. One in the case of an exception during reading, and one in the case that the constructor itself throws an exception. Luckily `InputStream`'s `close` method is an implementation of `Closeable.close`, ergo it may be called twice with no effect.