### PR TITLE
Fixed KeyTable same method

### DIFF
--- a/src/main/scala/is/hail/keytable/KeyTable.scala
+++ b/src/main/scala/is/hail/keytable/KeyTable.scala
@@ -177,11 +177,7 @@ case class KeyTable(hc: HailContext, rdd: RDD[Row],
   }
 
   def keyedRDD(): RDD[(Row, Row)] = {
-    if (nKeys == 0)
-      fatal("cannot produce a keyed RDD from a key table with no key columns")
-
     val fieldIndices = fields.map(f => f.name -> f.index).toMap
-
     val keyIndices = key.map(fieldIndices)
     val keyIndexSet = keyIndices.toSet
     val valueIndices = fields.filter(f => !keyIndexSet.contains(f.index)).map(_.index)

--- a/src/test/scala/is/hail/methods/KeyTableSuite.scala
+++ b/src/test/scala/is/hail/methods/KeyTableSuite.scala
@@ -408,4 +408,9 @@ class KeyTableSuite extends SparkSuite {
     assert(kt1.join(kt2, "inner").count() == 1L)
     kt1.join(kt2, "outer").typeCheck()
   }
+
+  @Test def testSame() {
+    val kt = hc.importTable("src/test/resources/sampleAnnotations.tsv", impute = true)
+    assert(kt.same(kt))
+  }
 }


### PR DESCRIPTION
If a KeyTable has no keys, then the KeyedRDD should have an empty row as the key rather than throwing a fatal error. This was causing problems when using `same` for KeyTables with no keys.