### PR TITLE
add HailKryoRegistrator and fix cloud tests

### DIFF
--- a/python/hail/docs/getting_started.rst
+++ b/python/hail/docs/getting_started.rst
@@ -142,6 +142,7 @@ the same as above, except:
              --py-files build/distributions/hail-python.zip \
              --conf spark.sql.files.openCostInBytes=1099511627776 \
              --conf spark.sql.files.maxPartitionBytes=1099511627776 \
+             --conf spark.kryo.registrator=is.hail.kryo.HailKryoRegistrator \
              --conf spark.hadoop.parquet.block.size=1099511627776
 
  - Cloudera's version of ``spark-submit`` is called ``spark2-submit``.

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -56,6 +56,7 @@ object HailContext {
         "org.apache.hadoop.io.compress.GzipCodec")
 
     conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+    conf.set("spark.kryo.registrator", "is.hail.kryo.HailKryoRegistrator")
 
     conf.set("spark.sql.parquet.compression.codec", parquetCompression)
     conf.set("spark.sql.files.openCostInBytes", tera.toString)
@@ -111,6 +112,9 @@ object HailContext {
     val kryoSerializer = "org.apache.spark.serializer.KryoSerializer"
     if (serializer != kryoSerializer)
       problems += s"Invalid configuration property spark.serializer: required $kryoSerializer.  Found: $serializer."
+
+    if (conf.get("spark.kryo.registrator") != "is.hail.kryo.HailKryoRegistrator")
+      problems += s"Invalid config parameter: spark.kryo.registrator must be set to is.hail.kryo.HailKryoRegistrator"
 
     if (problems.nonEmpty)
       fatal(

--- a/src/main/scala/is/hail/kryo/HailKryoRegistrator.scala
+++ b/src/main/scala/is/hail/kryo/HailKryoRegistrator.scala
@@ -1,0 +1,12 @@
+package is.hail.kryo
+
+import org.apache.spark.serializer.KryoRegistrator
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.serializers.JavaSerializer
+import is.hail.utils.SerializableHadoopConfiguration
+
+class HailKryoRegistrator extends KryoRegistrator {
+  override def registerClasses(kryo: Kryo) {
+    kryo.register(classOf[SerializableHadoopConfiguration], new JavaSerializer())
+  }
+}


### PR DESCRIPTION
`sc.broadcast` uses Kryo for serialization. If Kryo sees an unknown class, it uses the `FieldSerializer` which ignores `@transient` fields and does not call any `java.io.Serializable`. As a result, Kryo always deserializes `SerializableHadoopConfiguration` with a `null` `value` field. The code in `HailKryoRegistrator` instructs Kryo to use Java Serialization instead.