### PR TITLE
Fix Cloudera Build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,9 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 repositories {
     mavenCentral()
     jcenter()
+    maven {
+        url "https://repository.cloudera.com/artifactory/cloudera-repos/"
+    }
 }
 
 buildScan {


### PR DESCRIPTION
For Cloudera builds we must compile against Cloudera's Spark package. Without this maven repository, we cannot find the spark package and the build fails.