### PR TITLE
fixes to help cloud tests pass on lmm and log

### DIFF
--- a/src/test/scala/is/hail/methods/LinearMixedRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearMixedRegressionSuite.scala
@@ -211,7 +211,7 @@ class LinearMixedRegressionSuite extends SparkSuite {
     }
 
     val rrm = (W * W.t) / mW.toDouble // RRM
-    val delta = scala.util.Random.nextGaussian()
+    val delta = math.exp(10 * scala.util.Random.nextDouble() - 5)
 
     // Now testing global model
     // First solve directly with Cholesky

--- a/src/test/scala/is/hail/methods/LogisticRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LogisticRegressionSuite.scala
@@ -19,7 +19,7 @@ class LogisticRegressionSuite extends SparkSuite {
   }
 
   def assertConsistentWithConstant(converged: Annotation, pval: Annotation) {
-    assert(!converged.asInstanceOf[Boolean] || pval.asInstanceOf[Double].isNaN)
+    assert(!converged.asInstanceOf[Boolean] || pval.asInstanceOf[Double].isNaN || 1 - pval.asInstanceOf[Double] < 1e-4)
   }
 
   // x = (0, 1, 0, 0, 0, 1, 0, 0, 0, 0)
@@ -48,7 +48,7 @@ class LogisticRegressionSuite extends SparkSuite {
     val vds = hc.importVCF("src/test/resources/regressionLogistic.vcf")
       .annotateSamplesTable(covariates, root = "sa.cov")
       .annotateSamplesTable(phenotypes, root = "sa.pheno")
-      .logreg("wald", "sa.pheno", Array("sa.cov.Cov1", "sa.cov.Cov2"), "va.logreg")
+      .logreg("wald", "sa.pheno", Array("sa.cov.Cov1", "sa.cov.Cov2"))
 
     val qBeta = vds.queryVA("va.logreg.beta")._2
     val qSe = vds.queryVA("va.logreg.se")._2


### PR DESCRIPTION
@danking the lmm change can be considered a bug fix since delta should never be negative. The log change should make the tests more robust to which JVM. Let me know if this fixes the failures and I'll PR against 0.1 as well.