### PR TITLE
Change mathjax cdn

### DIFF
--- a/python/hail/docs/conf.py
+++ b/python/hail/docs/conf.py
@@ -44,6 +44,8 @@ extensions = [
     'IPython.sphinxext.ipython_console_highlighting' # https://github.com/spatialaudio/nbsphinx/issues/24#issuecomment-187172022 and https://github.com/ContinuumIO/anaconda-issues/issues/1430
 ]
 
+mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js'
+
 nbsphinx_timeout = 300
 nbsphinx_allow_errors = False
 

--- a/python/hail/docs/conf.py
+++ b/python/hail/docs/conf.py
@@ -44,7 +44,7 @@ extensions = [
     'IPython.sphinxext.ipython_console_highlighting' # https://github.com/spatialaudio/nbsphinx/issues/24#issuecomment-187172022 and https://github.com/ContinuumIO/anaconda-issues/issues/1430
 ]
 
-mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js'
+mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
 
 nbsphinx_timeout = 300
 nbsphinx_allow_errors = False


### PR DESCRIPTION
Default Mathjax CDN is no longer active. https://www.mathjax.org/cdn-shutting-down/