### PR TITLE
Removed “use this script” for fresh Ubuntu install

### DIFF
--- a/python/hail/docs/getting_started.rst
+++ b/python/hail/docs/getting_started.rst
@@ -71,8 +71,6 @@ Building Hail from source
 
   You may also want to install `Seaborn <http://seaborn.pydata.org>`_, a Python library for statistical data visualization, using ``conda install seaborn`` or ``pip install seaborn``. While not technically necessary, Seaborn is used in the tutorials to make prettier plots.
 
-To install all dependencies for running locally on a fresh Ubuntu installation, use this `script <https://github.com/hail-is/hail/wiki/Install-Hail-dependencies-on-a-fresh-Ubuntu-VM>`_.
-
 The following commands are relative to the ``hail`` directory.
 
 The single command


### PR DESCRIPTION
The script link is dead as the wiki is gone. @danking I'm removing as you suggested, but I recall this had half-dozen lines that included apt-get of java and natives (a bit tricky), which may be helpful info for developers in devel.