### PR TITLE
fix to make delta > 0 in LMM suite

### DIFF
--- a/src/test/scala/is/hail/methods/LinearMixedRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearMixedRegressionSuite.scala
@@ -211,7 +211,7 @@ class LinearMixedRegressionSuite extends SparkSuite {
     }
 
     val rrm = (W * W.t) / mW.toDouble // RRM
-    val delta = scala.util.Random.nextGaussian()
+    val delta = math.exp(10 * scala.util.Random.nextDouble() - 5)
 
     // Now testing global model
     // First solve directly with Cholesky


### PR DESCRIPTION
In old code, there's 50% change of generative a negative delta.