### PR TITLE
orderedPartitionerInt and toIndexedRowMatrixOrderedPartitioner

### DIFF
--- a/src/main/scala/is/hail/utils/richUtils/Implicits.scala
+++ b/src/main/scala/is/hail/utils/richUtils/Implicits.scala
@@ -5,7 +5,7 @@ import is.hail.utils.{ArrayBuilder, HailIterator, JSONWriter, MultiArray2, Trunc
 import is.hail.variant.Variant
 import org.apache.hadoop
 import org.apache.spark.SparkContext
-import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix}
+import org.apache.spark.mllib.linalg.distributed.{BlockMatrix, IndexedRow, IndexedRowMatrix}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Row, SQLContext}
 import org.apache.spark.storage.StorageLevel
@@ -35,6 +35,8 @@ trait Implicits {
   implicit def toRichHadoopConfiguration(hConf: hadoop.conf.Configuration): RichHadoopConfiguration =
     new RichHadoopConfiguration(hConf)
 
+  implicit def toRichBlockMatrix(bm: BlockMatrix): RichBlockMatrix = new RichBlockMatrix(bm)
+  
   implicit def toRichIndexedRow(r: IndexedRow): RichIndexedRow = new RichIndexedRow(r)
 
   implicit def toRichInt(i: Int): RichInt = new RichInt(i)

--- a/src/main/scala/is/hail/utils/richUtils/RichBlockMatrix.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichBlockMatrix.scala
@@ -1,0 +1,40 @@
+package is.hail.utils.richUtils
+
+import org.apache.spark.mllib.linalg.{DenseVector => SparkDenseVector}
+import org.apache.spark.mllib.linalg.distributed.{BlockMatrix, IndexedRow, IndexedRowMatrix}
+import breeze.linalg.{DenseVector, Vector}
+import is.hail.sparkextras.{OrderedPartitioner, OrderedRDD}
+import org.apache.spark.rdd.ShuffledRDD
+
+class RichBlockMatrix(bm: BlockMatrix) {
+  def toIndexedRowMatrixOrderedPartitioner(partitioner: OrderedPartitioner[Int, Int]): IndexedRowMatrix = {
+    val cols = bm.numCols().toInt
+
+    require(cols < Int.MaxValue, s"The number of columns must be less than 2^31, got $cols.")
+
+    val rowsPerBlock = bm.rowsPerBlock
+    val colsPerBlock = bm.colsPerBlock
+
+    import partitioner.kOk
+    val rows = OrderedRDD(new ShuffledRDD[Int, (Int, DenseVector[Double]), (Int, DenseVector[Double])](bm.blocks
+      .flatMap { case ((blockRowIdx, blockColIdx), mat) =>
+        mat.rowIter.zipWithIndex.map {
+          case (vector, rowIdx) =>
+            blockRowIdx * rowsPerBlock + rowIdx -> (blockColIdx, new DenseVector[Double](vector.toDense.values))
+        }
+      }, partitioner)
+      .setKeyOrdering(Ordering[Int]), partitioner)
+      .groupByKey()
+      .map { case (rowIdx, vectors) =>
+        val wholeVector = DenseVector.zeros[Double](cols)
+
+        vectors.foreach { case (blockColIdx: Int, vec: Vector[Double]) =>
+          val offset = colsPerBlock * blockColIdx
+          wholeVector(offset until Math.min(cols, offset + colsPerBlock)) := vec
+        }
+        IndexedRow(rowIdx, new SparkDenseVector(wholeVector.data))
+      }
+
+    new IndexedRowMatrix(rows, bm.numRows(), cols)
+  }
+}

--- a/src/test/scala/is/hail/utils/OrderedRDDSuite.scala
+++ b/src/test/scala/is/hail/utils/OrderedRDDSuite.scala
@@ -262,5 +262,16 @@ class OrderedRDDSuite extends SparkSuite {
     val (status, rdd) = OrderedRDD.coerce(emptyPartitions)
     assert(status == OrderedRDD.AS_IS)
   }
+  
+  @Test def testOrderedPartitionerInt() {
+    import OrderedKeyIntImplicits.orderedKey
+    
+    val rdd = OrderedRDD(sc.parallelize((0 until 10).map(i => (i, i)), numSlices = 4), None, None)
+    val op = rdd.orderedPartitioner
+    val OrderedPartitioner(rangeBounds, numPartitions) = rdd.orderedPartitionerInt()
+    
+    assert(rangeBounds sameElements op.rangeBounds)
+    assert(numPartitions == op.numPartitions)
+  }
 }
 

--- a/src/test/scala/is/hail/utils/RichBlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/utils/RichBlockMatrixSuite.scala
@@ -1,0 +1,27 @@
+package is.hail.utils
+
+import is.hail.SparkSuite
+import is.hail.sparkextras.{OrderedPartitioner, OrderedRDD}
+import is.hail.distributedmatrix.BlockMatrixIsDistributedMatrix._
+import org.apache.spark.mllib.linalg.distributed.IndexedRow
+import org.apache.spark.mllib.linalg.{DenseMatrix => SparkDenseMatrix}
+import org.testng.annotations.Test
+
+class RichBlockMatrixSuite extends SparkSuite {
+  @Test def testToIndexedRowMatrixOrderedPartitioner() {
+    val rangeBounds = Array(1, 4, 6)
+    val numPartitions = 4
+
+    import is.hail.sparkextras.OrderedKeyIntImplicits.orderedKey
+
+    val opInt = OrderedPartitioner[Int, Int](rangeBounds, numPartitions)
+
+    val bm = from(sc, SparkDenseMatrix.zeros(10, 5), 3, 2)
+    
+    val irm = bm.toIndexedRowMatrixOrderedPartitioner(opInt)
+
+    val rdd = irm.rows.map { case IndexedRow(i, v) => (i.toInt, v) }
+
+    val check = OrderedRDD(rdd, opInt)
+  }
+}


### PR DESCRIPTION
- added RichBlockMatrix with toIndexedRowMatrixOrderedPartitioner
- added RichBlockMatrixSuite with test
- added orderedPartitionerInt() to OrderedRDD
- added test to OrderedRDDSuite
- added OrderedKeyIntImplicits with implicit val orderedKey

These are helpful when converting VDS to BlockMatrix to IRM, where the IRM is partitioned as the VDS when constructed so it can be joined back to the VDS without an additional shuffle. This will be used in low rank LMM.