### PR TITLE
Some keytable cleanup.

### DIFF
--- a/python/hail/keytable.py
+++ b/python/hail/keytable.py
@@ -156,7 +156,7 @@ class KeyTable(HistoryMixin):
         """
 
         if self._num_columns is None:
-            self._num_columns = self._jkt.nFields()
+            self._num_columns = self._jkt.nColumns()
         return self._num_columns
 
     @property
@@ -208,7 +208,7 @@ class KeyTable(HistoryMixin):
         """
 
         if self._column_names is None:
-            self._column_names = list(self._jkt.fieldNames())
+            self._column_names = list(self._jkt.columns())
         return self._column_names
 
     @handle_py4j
@@ -599,8 +599,8 @@ class KeyTable(HistoryMixin):
 
     @handle_py4j
     @record_method
-    @typecheck_method(column_names=oneof(strlike, listof(strlike)))
-    def select(self, column_names):
+    @typecheck_method(selected_columns=oneof(strlike, listof(strlike)))
+    def select(self, selected_columns):
         """Select a subset of columns.
 
         **Examples**
@@ -620,16 +620,15 @@ class KeyTable(HistoryMixin):
 
         >>> kt_result = kt1.select([])
 
-        :param column_names: List of columns to be selected.
+        :param selected_columns: List of columns to be selected.
         :type: str or list of str
 
         :return: Key table with selected columns.
         :rtype: :class:`.KeyTable`
         """
 
-        column_names = wrap_to_list(column_names)
-        new_key = [k for k in self.key if k in column_names]
-        return KeyTable(self.hc, self._jkt.select(column_names, new_key))
+        selected_columns = wrap_to_list(selected_columns)
+        return KeyTable(self.hc, self._jkt.select(selected_columns))
 
     @handle_py4j
     @record_method

--- a/src/test/scala/is/hail/methods/AnnotateSuite.scala
+++ b/src/test/scala/is/hail/methods/AnnotateSuite.scala
@@ -477,7 +477,7 @@ class AnnotateSuite extends SparkSuite {
 
     val vds = hc.importVCF("src/test/resources/sample2.vcf").cache()
 
-    val vkt = vds.variantsKT().select(Array("v"), Array("v"))
+    val vkt = vds.variantsKT().select("v")
       .filter("v.start != 16054957", keep = true)
       .repartition(6)
       .cache()
@@ -550,8 +550,7 @@ class AnnotateSuite extends SparkSuite {
           assert(va == IndexedSeq(Row(5, 10), Row(5, 10)))
       }
 
-    val lkt = vkt.annotate("l = v.locus").select(Array("l"), Array("l"))
-      .select(Array("l"), Array("l"))
+    val lkt = vkt.annotate("l = v.locus").select("l").keyBy("l")
 
     // locus key, 0 elements in value, product false
     val loc1 = vds.annotateVariantsTable(lkt, root = "va")
@@ -574,7 +573,7 @@ class AnnotateSuite extends SparkSuite {
     val loc6 = vds.annotateVariantsTable(lkt3.union(lkt3), root = "va", product = true)
 
     val ikt = vkt.annotate("i = Interval(Locus(v.contig, v.start), Locus(v.contig, v.start + 1))")
-      .select(Array("i"), Array("i"))
+      .select("i").keyBy("i")
 
     // interval key, 0 elements in value, product false
     val int1 = vds.annotateVariantsTable(ikt, root = "va")
@@ -645,7 +644,7 @@ class AnnotateSuite extends SparkSuite {
     assert(gen6.dropSamples().same(drop6))
 
 
-    val skt = vds.samplesKT().select(Array("s"), Array("s"))
+    val skt = vds.samplesKT().select(Array("s"))
       .filter("s != \"HG00112\"", keep = true)
       .repartition(6)
       .cache()

--- a/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -225,7 +225,7 @@ class ExprSuite extends SparkSuite {
     assert(eval[Double]("1.0 / -0.0").contains(Double.NegativeInfinity))
     assert(eval[Double]("0/0 * 1/0").forall(_.isNaN))
     assert(eval[Double]("0.0/0.0 * 1.0/0.0").forall(_.isNaN))
-    for { x <- Array("-1.0/0.0", "-1.0", "0.0", "1.0", "1.0/0.0") } {
+    for {x <- Array("-1.0/0.0", "-1.0", "0.0", "1.0", "1.0/0.0")} {
       assert(eval[Boolean](s"0.0/0.0 < $x").contains(false))
       assert(eval[Boolean](s"0.0/0.0 <= $x").contains(false))
       assert(eval[Boolean](s"0.0/0.0 > $x").contains(false))
@@ -1074,9 +1074,10 @@ class ExprSuite extends SparkSuite {
       b <- t.genValue) yield (t, a, b)
 
     val p = forAll(g) { case (t, a, b) =>
-        val ord = t.ordering(missingGreatest = true)
-        ord.compare(a, b) == - ord.compare(b, a)
+      val ord = t.ordering(missingGreatest = true)
+      ord.compare(a, b) == -ord.compare(b, a)
     }
+    p.check()
   }
 
   @Test def testContext() {

--- a/src/test/scala/is/hail/methods/KeyTableSuite.scala
+++ b/src/test/scala/is/hail/methods/KeyTableSuite.scala
@@ -72,8 +72,7 @@ class KeyTableSuite extends SparkSuite {
 
     def getDataAsMap(kt: KeyTable) = {
       val columns = kt.columns
-      val nColumns = kt.nColumns
-      kt.rdd.map { a => columns.zip(a.asInstanceOf[Row].toSeq).toMap }.collect().toSet
+      kt.rdd.map { a => columns.zip(a.toSeq).toMap }.collect().toSet
     }
 
     val kt3data = getDataAsMap(kt3)
@@ -118,7 +117,7 @@ class KeyTableSuite extends SparkSuite {
     val ktInnerJoin = ktLeft.join(ktRight, "inner")
     val ktOuterJoin = ktLeft.join(ktRight, "outer")
 
-    val nExpectedFields = ktLeft.nColumns + ktRight.nColumns - ktRight.nKeys
+    val nExpectedColumns = ktLeft.nColumns + ktRight.nColumns - ktRight.nKeys
 
     val i: IndexedSeq[Int] = Array(1, 2, 3)
 
@@ -136,7 +135,7 @@ class KeyTableSuite extends SparkSuite {
 
     assert(ktLeftJoin.count == ktLeft.count &&
       ktLeftJoin.nKeys == nExpectedKeys &&
-      ktLeftJoin.nColumns == nExpectedFields &&
+      ktLeftJoin.nColumns == nExpectedColumns &&
       ktLeftJoin.filter { a =>
         !rightKeys.contains(Option(leftJoinKeyQuerier(a)).map(_.asInstanceOf[String]))
       }.forall("isMissing(qPhen2) && isMissing(qPhen3)")
@@ -144,18 +143,18 @@ class KeyTableSuite extends SparkSuite {
 
     assert(ktRightJoin.count == ktRight.count &&
       ktRightJoin.nKeys == nExpectedKeys &&
-      ktRightJoin.nColumns == nExpectedFields &&
+      ktRightJoin.nColumns == nExpectedColumns &&
       ktRightJoin.filter { a =>
         !leftKeys.contains(Option(rightJoinKeyQuerier(a)).map(_.asInstanceOf[String]))
       }.forall("isMissing(Status) && isMissing(qPhen)"))
 
     assert(ktOuterJoin.count == nUnionRows &&
       ktOuterJoin.nKeys == ktLeft.nKeys &&
-      ktOuterJoin.nColumns == nExpectedFields)
+      ktOuterJoin.nColumns == nExpectedColumns)
 
     assert(ktInnerJoin.count == nIntersectRows &&
       ktInnerJoin.nKeys == nExpectedKeys &&
-      ktInnerJoin.nColumns == nExpectedFields)
+      ktInnerJoin.nColumns == nExpectedColumns)
 
     val outputFile = tmpDir.createTempFile("join", "tsv")
     ktLeftJoin.export(outputFile)

--- a/src/test/scala/is/hail/methods/KeyTableSuite.scala
+++ b/src/test/scala/is/hail/methods/KeyTableSuite.scala
@@ -37,7 +37,7 @@ class KeyTableSuite extends SparkSuite {
     KeyTable(hc, rdd, signature, keyNames)
   }
 
-  @Test def testImportExport() = {
+  @Test def testImportExport() {
     val inputFile = "src/test/resources/sampleAnnotations.tsv"
     val outputFile = tmpDir.createTempFile("ktImpExp", "tsv")
     val kt = hc.importTable(inputFile).keyBy("Sample", "Status")
@@ -53,34 +53,34 @@ class KeyTableSuite extends SparkSuite {
     assert(importedData == exportedData)
   }
 
-  @Test def testAnnotate() = {
+  @Test def testAnnotate() {
     val inputFile = "src/test/resources/sampleAnnotations.tsv"
     val kt1 = hc.importTable(inputFile, impute = true).keyBy("Sample")
     val kt2 = kt1.annotate("""qPhen2 = pow(qPhen, 2), NotStatus = Status == "CASE", X = qPhen == 5""")
     val kt3 = kt2.annotate("")
-    val kt4 = kt3.select(kt3.fieldNames, Array("qPhen", "NotStatus"))
+    val kt4 = kt3.select(kt3.columns).keyBy("qPhen", "NotStatus")
 
-    val kt1FieldNames = kt1.fieldNames.toSet
-    val kt2FieldNames = kt2.fieldNames.toSet
+    val kt1columns = kt1.columns.toSet
+    val kt2columns = kt2.columns.toSet
 
     assert(kt1.nKeys == 1)
     assert(kt2.nKeys == 1)
-    assert(kt1.nFields == 3 && kt2.nFields == 6)
+    assert(kt1.nColumns == 3 && kt2.nColumns == 6)
     assert(kt1.keyFields.zip(kt2.keyFields).forall { case (fd1, fd2) => fd1.name == fd2.name && fd1.typ == fd2.typ })
-    assert(kt1FieldNames ++ Set("qPhen2", "NotStatus", "X") == kt2FieldNames)
+    assert(kt1columns ++ Set("qPhen2", "NotStatus", "X") == kt2columns)
     assert(kt2 same kt3)
 
     def getDataAsMap(kt: KeyTable) = {
-      val fieldNames = kt.fieldNames
-      val nFields = kt.nFields
-      kt.rdd.map { a => fieldNames.zip(a.asInstanceOf[Row].toSeq).toMap }.collect().toSet
+      val columns = kt.columns
+      val nColumns = kt.nColumns
+      kt.rdd.map { a => columns.zip(a.asInstanceOf[Row].toSeq).toMap }.collect().toSet
     }
 
     val kt3data = getDataAsMap(kt3)
     val kt4data = getDataAsMap(kt4)
 
     assert(kt4.key.toSet == Set("qPhen", "NotStatus") &&
-      kt4.fieldNames.toSet -- kt4.key == Set("qPhen2", "X", "Sample", "Status") &&
+      kt4.columns.toSet -- kt4.key == Set("qPhen2", "X", "Sample", "Status") &&
       kt3data == kt4data
     )
 
@@ -118,7 +118,7 @@ class KeyTableSuite extends SparkSuite {
     val ktInnerJoin = ktLeft.join(ktRight, "inner")
     val ktOuterJoin = ktLeft.join(ktRight, "outer")
 
-    val nExpectedFields = ktLeft.nFields + ktRight.nFields - ktRight.nKeys
+    val nExpectedFields = ktLeft.nColumns + ktRight.nColumns - ktRight.nKeys
 
     val i: IndexedSeq[Int] = Array(1, 2, 3)
 
@@ -136,7 +136,7 @@ class KeyTableSuite extends SparkSuite {
 
     assert(ktLeftJoin.count == ktLeft.count &&
       ktLeftJoin.nKeys == nExpectedKeys &&
-      ktLeftJoin.nFields == nExpectedFields &&
+      ktLeftJoin.nColumns == nExpectedFields &&
       ktLeftJoin.filter { a =>
         !rightKeys.contains(Option(leftJoinKeyQuerier(a)).map(_.asInstanceOf[String]))
       }.forall("isMissing(qPhen2) && isMissing(qPhen3)")
@@ -144,18 +144,18 @@ class KeyTableSuite extends SparkSuite {
 
     assert(ktRightJoin.count == ktRight.count &&
       ktRightJoin.nKeys == nExpectedKeys &&
-      ktRightJoin.nFields == nExpectedFields &&
+      ktRightJoin.nColumns == nExpectedFields &&
       ktRightJoin.filter { a =>
         !leftKeys.contains(Option(rightJoinKeyQuerier(a)).map(_.asInstanceOf[String]))
       }.forall("isMissing(Status) && isMissing(qPhen)"))
 
     assert(ktOuterJoin.count == nUnionRows &&
       ktOuterJoin.nKeys == ktLeft.nKeys &&
-      ktOuterJoin.nFields == nExpectedFields)
+      ktOuterJoin.nColumns == nExpectedFields)
 
     assert(ktInnerJoin.count == nIntersectRows &&
       ktInnerJoin.nKeys == nExpectedKeys &&
-      ktInnerJoin.nFields == nExpectedFields)
+      ktInnerJoin.nColumns == nExpectedFields)
 
     val outputFile = tmpDir.createTempFile("join", "tsv")
     ktLeftJoin.export(outputFile)
@@ -163,7 +163,7 @@ class KeyTableSuite extends SparkSuite {
     val noNull = ktLeft.filter("isDefined(qPhen) && isDefined(Status)", keep = true).keyBy(List("Sample", "Status"))
     assert(noNull.join(
       noNull.rename(Map("qPhen" -> "qPhen_")), "outer"
-    ).rdd.forall { r => !r.toSeq.exists(_ == null)})
+    ).rdd.forall { r => !r.toSeq.exists(_ == null) })
   }
 
   @Test def testJoinDiffKeyNames() = {
@@ -174,7 +174,7 @@ class KeyTableSuite extends SparkSuite {
     val ktRight = hc.importTable(inputFile2, impute = true)
       .keyBy("Sample")
       .rename(Map("Sample" -> "sample"))
-    val ktBad = ktRight.select(ktRight.fieldNames, Array("qPhen2"))
+    val ktBad = ktRight.select(ktRight.columns).keyBy("qPhen2")
 
     intercept[HailException] {
       val ktJoinBad = ktLeft.join(ktBad, "left")
@@ -234,10 +234,10 @@ class KeyTableSuite extends SparkSuite {
     val kt = KeyTable(hc, rdd, signature, keyNames)
 
     val rename1 = kt.rename(Array("ID1", "ID2", "ID3"))
-    assert(rename1.fieldNames sameElements Array("ID1", "ID2", "ID3"))
+    assert(rename1.columns sameElements Array("ID1", "ID2", "ID3"))
 
     val rename2 = kt.rename(Map("field1" -> "ID1"))
-    assert(rename2.fieldNames sameElements Array("Sample", "ID1", "field2"))
+    assert(rename2.columns sameElements Array("Sample", "ID1", "field2"))
 
     intercept[HailException](kt.rename(Array("ID1")))
 
@@ -257,20 +257,20 @@ class KeyTableSuite extends SparkSuite {
 
     val kt = KeyTable(hc, rdd, signature, keyNames)
 
-    val select1 = kt.select(Array("field1"), Array("field1"))
-    assert((select1.key sameElements Array("field1")) && (select1.fieldNames sameElements Array("field1")))
+    val select1 = kt.select("field1").keyBy("field1")
+    assert((select1.key sameElements Array("field1")) && (select1.columns sameElements Array("field1")))
 
-    val select2 = kt.select(Array("Sample", "field2", "field1"), Array("Sample"))
-    assert((select2.key sameElements Array("Sample")) && (select2.fieldNames sameElements Array("Sample", "field2", "field1")))
+    val select2 = kt.select("Sample", "field2", "field1").keyBy("Sample")
+    assert((select2.key sameElements Array("Sample")) && (select2.columns sameElements Array("Sample", "field2", "field1")))
 
-    val select3 = kt.select(Array("field2", "field1", "Sample"), Array.empty[String])
-    assert((select3.key sameElements Array.empty[String]) && (select3.fieldNames sameElements Array("field2", "field1", "Sample")))
+    val select3 = kt.select("field2", "field1", "Sample").keyBy()
+    assert((select3.key sameElements Array.empty[String]) && (select3.columns sameElements Array("field2", "field1", "Sample")))
 
-    val select4 = kt.select(Array.empty[String], Array.empty[String])
-    assert((select4.key sameElements Array.empty[String]) && (select4.fieldNames sameElements Array.empty[String]))
+    val select4 = kt.select()
+    assert((select4.key sameElements Array.empty[String]) && (select4.columns sameElements Array.empty[String]))
 
-    intercept[HailException](kt.select(Array.empty[String], Array("Sample")))
-    intercept[HailException](kt.select(Array("Sample", "field2", "field5"), Array("Sample")))
+    intercept[HailException](kt.select().keyBy("Sample"))
+    intercept[HailException](kt.select("Sample", "field2", "field5").keyBy("Sample"))
 
     for (drop <- Array(select1, select2, select3, select4)) {
       drop.export(tmpDir.createTempFile("select", "tsv"))
@@ -284,21 +284,21 @@ class KeyTableSuite extends SparkSuite {
 
     val kt = KeyTable(hc, rdd, signature, Array("Sample"))
     val drop0 = kt.drop(Array.empty[String])
-    assert((drop0.key sameElements Array("Sample")) && (drop0.fieldNames sameElements Array("Sample", "field1", "field2")))
+    assert((drop0.key sameElements Array("Sample")) && (drop0.columns sameElements Array("Sample", "field1", "field2")))
     val drop1 = kt.drop(Array("Sample"))
-    assert((drop1.key sameElements Array.empty[String]) && (drop1.fieldNames sameElements Array("field1", "field2")))
+    assert((drop1.key sameElements Array.empty[String]) && (drop1.columns sameElements Array("field1", "field2")))
     val drop2 = kt.drop(Array("field1", "field2"))
-    assert((drop2.key sameElements Array("Sample")) && (drop2.fieldNames sameElements Array("Sample")))
+    assert((drop2.key sameElements Array("Sample")) && (drop2.columns sameElements Array("Sample")))
     val drop3 = kt.drop(Array("Sample", "field1"))
-    assert((drop3.key sameElements Array.empty[String]) && (drop3.fieldNames sameElements Array("field2")))
+    assert((drop3.key sameElements Array.empty[String]) && (drop3.columns sameElements Array("field2")))
     val drop4 = kt.drop(Array("Sample", "field2"))
-    assert((drop4.key sameElements Array.empty[String]) && (drop4.fieldNames sameElements Array("field1")))
+    assert((drop4.key sameElements Array.empty[String]) && (drop4.columns sameElements Array("field1")))
     val drop5 = kt.drop(Array("Sample", "field1", "field2"))
-    assert((drop5.key sameElements Array.empty[String]) && (drop5.fieldNames sameElements Array.empty[String]))
+    assert((drop5.key sameElements Array.empty[String]) && (drop5.columns sameElements Array.empty[String]))
 
     val kt2 = KeyTable(hc, rdd, signature, Array("field1", "field2"))
     val drop6 = kt2.drop(Array("field1"))
-    assert((drop6.key sameElements Array("field2")) && (drop6.fieldNames sameElements Array("Sample", "field2")))
+    assert((drop6.key sameElements Array("field2")) && (drop6.columns sameElements Array("Sample", "field2")))
 
     for (drop <- Array(drop0, drop1, drop2, drop3, drop4, drop5, drop6)) {
       drop.export(tmpDir.createTempFile("drop", "tsv"))
@@ -337,7 +337,7 @@ class KeyTableSuite extends SparkSuite {
       .variantsKT()
       .expandTypes()
       .flatten()
-      .select(Array("va.info.MQRankSum"), Array.empty[String])
+      .select(Array("va.info.MQRankSum"))
 
     val df = kt.toDF(sqlContext)
     df.printSchema()
@@ -376,7 +376,8 @@ class KeyTableSuite extends SparkSuite {
     val kt = vds.annotateVariantsExpr("va.id = str(v)")
       .variantsKT()
       .flatten()
-      .select(Array("v", "va.id"), Array("va.id"))
+      .select("v", "va.id")
+      .keyBy("va.id")
 
     val kt2 = KeyTable(hc, vds.variants.map(v => Row(v.toString, 5)),
       TStruct("v" -> TString, "value" -> TInt32), Array("v"))

--- a/src/test/scala/is/hail/methods/LogisticRegressionBurdenSuite.scala
+++ b/src/test/scala/is/hail/methods/LogisticRegressionBurdenSuite.scala
@@ -42,8 +42,8 @@ class LogisticRegressionBurdenSuite extends SparkSuite {
 
     val sampleMap = keyTableBoxedDoubleToMap[String](sampleKT)
 
-    val logregWaldMap = keyTableBoxedDoubleToMap[String](logregWaldKT.select(logregWaldKT.fieldNames.dropRight(1), logregWaldKT.key))
-    val logregLRTMap = keyTableBoxedDoubleToMap[String](logregLRTKT.select(logregLRTKT.fieldNames.dropRight(1), logregLRTKT.key))
+    val logregWaldMap = keyTableBoxedDoubleToMap[String](logregWaldKT.select(logregWaldKT.columns.dropRight(1)))
+    val logregLRTMap = keyTableBoxedDoubleToMap[String](logregLRTKT.select(logregLRTKT.columns.dropRight(1)))
     val logregScoreMap = keyTableBoxedDoubleToMap[String](logregScoreKT)
 
     /*

--- a/src/test/scala/is/hail/variant/IntervalSuite.scala
+++ b/src/test/scala/is/hail/variant/IntervalSuite.scala
@@ -46,7 +46,7 @@ class IntervalSuite extends SparkSuite {
     assert(ex1wr.same(ex1))
 
     val ex2 = IntervalList.read(hc, "src/test/resources/example2.interval_list")
-    assert(ex1.select(Array("interval"), Array("interval")).same(ex2))
+    assert(ex1.select(Array("interval")).same(ex2))
   }
 
   @Test def testAll() {


### PR DESCRIPTION
Verify Field index is the index within the TStruct.
field => column in keytable.  This was an old rename but looks like
some things got missed.
Simplify KT.select interface in Scala (and mathc Python).