### PR TITLE
Added KeyTable.show

### DIFF
--- a/python/hail/keytable.py
+++ b/python/hail/keytable.py
@@ -1343,20 +1343,36 @@ class KeyTable(HistoryMixin):
 
         return KeyTable(self.hc, self._jkt.indexed(name))
 
-    @typecheck_method(rows=integral,
+    @typecheck_method(n=integral,
                       truncate_to=nullable(integral),
                       print_types=bool)
-    def show(self, rows=10, truncate_to=None, print_types=True):
+    def show(self, n=10, truncate_to=None, print_types=True):
         """Show the first few rows of the table in human-readable format.
 
-        :param int rows: Number of rows to show.
+        **Examples**
+
+        Show, with default parameters (10 rows, no truncation, and column types):
+
+        >>> kt1.show()
+
+        Truncate long columns to 25 characters and only write 5 rows:
+
+        >>> kt1.show(5, truncate_to=25)
+
+        **Notes**
+
+        If the ``truncate_to`` argument is ``None``, then no truncation will
+        occur. This is the default behavior. An integer argument will truncate
+        each cell to the specified number of characters.
+
+        :param int n: Number of rows to show.
 
         :param truncate_to: Truncate columns to the desired number of characters.
         :type truncate_to: int or None
 
         :param bool print_types: Print a line with column types.
         """
-        to_print = self._jkt.showString(rows, joption(truncate_to), print_types)
+        to_print = self._jkt.showString(n, joption(truncate_to), print_types)
         print(to_print)
 
     @classmethod

--- a/python/hail/keytable.py
+++ b/python/hail/keytable.py
@@ -1343,6 +1343,22 @@ class KeyTable(HistoryMixin):
 
         return KeyTable(self.hc, self._jkt.indexed(name))
 
+    @typecheck_method(rows=integral,
+                      truncate_to=nullable(integral),
+                      print_types=bool)
+    def show(self, rows=10, truncate_to=None, print_types=True):
+        """Show the first few rows of the table in human-readable format.
+
+        :param int rows: Number of rows to show.
+
+        :param truncate_to: Truncate columns to the desired number of characters.
+        :type truncate_to: int or None
+
+        :param bool print_types: Print a line with column types.
+        """
+        to_print = self._jkt.showString(rows, joption(truncate_to), print_types)
+        print(to_print)
+
     @classmethod
     @handle_py4j
     @record_classmethod

--- a/python/hail/tests/tests.py
+++ b/python/hail/tests/tests.py
@@ -509,7 +509,10 @@ class ContextTests(unittest.TestCase):
         kt.flatten()
         kt.expand_types()
 
-        kt.to_dataframe()
+        kt.to_dataframe().count()
+
+        kt.show(10)
+        kt.show(4, print_types=False, truncate_to=15)
 
         kt.annotate("newField = [0, 1, 2]").explode(["newField"])
 

--- a/src/main/scala/is/hail/keytable/KeyTable.scala
+++ b/src/main/scala/is/hail/keytable/KeyTable.scala
@@ -762,19 +762,19 @@ case class KeyTable(hc: HailContext, rdd: RDD[Row],
     Graph.maximalIndependentSet(edgeRdd.collect())
   }
 
-  def showString(rows: Int = 10, truncate: Option[Int] = None, printTypes: Boolean = true): String = {
+  def showString(n: Int = 10, truncate: Option[Int] = None, printTypes: Boolean = true): String = {
     /**
       * Parts of this method are lifted from:
       *   org.apache.spark.sql.Dataset.showString
       *   Spark version 2.0.2
       */
 
-    require(rows >= 0, s"number of rows to show must be non-negative, found $rows")
+    require(n >= 0, s"number of rows to show must be non-negative, found $n")
     truncate.foreach { tr => require(tr > 3, s"truncation length too small: $tr") }
 
-    val takeResult = take(rows + 1)
-    val hasMoreData = takeResult.length > rows
-    val data = takeResult.take(rows)
+    val takeResult = take(n + 1)
+    val hasMoreData = takeResult.length > n
+    val data = takeResult.take(n)
 
     def convertType(t: Type, name: String, ab: ArrayBuilder[(String, String, Boolean)]) {
       t match {
@@ -867,7 +867,7 @@ case class KeyTable(hc: HailContext, rdd: RDD[Row],
     sb.append(sep)
 
     if (hasMoreData)
-      sb.append(s"showing top $rows ${ plural(rows, "row") }\n")
+      sb.append(s"showing top $n ${ plural(n, "row") }\n")
 
     sb.result()
   }

--- a/src/main/scala/is/hail/keytable/KeyTable.scala
+++ b/src/main/scala/is/hail/keytable/KeyTable.scala
@@ -8,13 +8,14 @@ import is.hail.io.plink.{FamFileConfig, PlinkLoader}
 import is.hail.io.{CassandraConnector, SolrConnector, exportTypes}
 import is.hail.methods.{Aggregators, Filter}
 import is.hail.utils._
+import org.apache.commons.lang3.StringUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.apache.spark.storage.StorageLevel
-import org.json4s.jackson.Serialization
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
+import org.json4s.jackson.Serialization
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -761,4 +762,113 @@ case class KeyTable(hc: HailContext, rdd: RDD[Row],
     Graph.maximalIndependentSet(edgeRdd.collect())
   }
 
+  def showString(rows: Int = 10, truncate: Option[Int] = None, printTypes: Boolean = true): String = {
+    /**
+      * Parts of this method are lifted from:
+      *   org.apache.spark.sql.Dataset.showString
+      *   Spark version 2.0.2
+      */
+
+    require(rows >= 0, s"number of rows to show must be non-negative, found $rows")
+    truncate.foreach { tr => require(tr > 3, s"truncation length too small: $tr") }
+
+    val takeResult = take(rows + 1)
+    val hasMoreData = takeResult.length > rows
+    val data = takeResult.take(rows)
+
+    def convertType(t: Type, name: String, ab: ArrayBuilder[(String, String, Boolean)]) {
+      t match {
+        case s: TStruct => s.fields.foreach { f =>
+          convertType(f.typ, if (name == null) f.name else name + "." + f.name, ab)
+        }
+        case _ =>
+          ab += (name, t.toPrettyString(compact = true), t.isInstanceOf[TNumeric])
+      }
+    }
+
+    val headerBuilder = new ArrayBuilder[(String, String, Boolean)]()
+    convertType(signature, null, headerBuilder)
+    val (names, types, rightAlign) = headerBuilder.result().unzip3
+
+    def convertValue(t: Type, v: Annotation, ab: ArrayBuilder[String]) {
+      t match {
+        case s: TStruct =>
+          val r = v.asInstanceOf[Row]
+          s.fields.foreach(f => convertValue(f.typ, if (r == null) null else r.get(f.index), ab))
+        case _ =>
+          ab += t.str(v)
+      }
+    }
+
+    val valueBuilder = new ArrayBuilder[String]()
+    val dataStrings = data.map { r =>
+      valueBuilder.clear()
+      convertValue(signature, r, valueBuilder)
+      valueBuilder.result()
+    }
+
+    val allStrings = (Iterator(names, types) ++ dataStrings.iterator).map { arr =>
+      arr.map { str =>
+        truncate match {
+          case Some(tr) if str.length > tr => str.substring(0, tr - 3) + "..."
+          case _ => str
+        }
+      }
+    }.toArray
+
+    // Initialize the width of each column to a minimum value of '3'
+    val nCols = names.length
+    val colWidths = Array.fill(nCols)(3)
+
+    // Compute the width of each column
+    for (i <- allStrings.indices)
+      for (j <- 0 until nCols)
+        colWidths(j) = math.max(colWidths(j), allStrings(i)(j).length)
+
+    // create separator
+    val sep: String = colWidths.map("-" * _).addString(new StringBuilder(), "+-", "-+-", "-+\n").toString()
+
+    val sb = new StringBuilder()
+    sb.clear()
+    sb.append(sep)
+
+    // column names
+    allStrings(0).zipWithIndex.map { case (cell, i) =>
+      if (rightAlign(i))
+        StringUtils.leftPad(cell, colWidths(i))
+      else
+        StringUtils.rightPad(cell, colWidths(i))
+    }.addString(sb, "| ", " | ", " |\n")
+
+    sb.append(sep)
+
+    if (printTypes) {
+      // column types
+      allStrings(1).zipWithIndex.map { case (cell, i) =>
+        if (rightAlign(i))
+          StringUtils.leftPad(cell, colWidths(i))
+        else
+          StringUtils.rightPad(cell, colWidths(i))
+      }.addString(sb, "| ", " | ", " |\n")
+
+      sb.append(sep)
+    }
+
+    // data
+    allStrings.drop(2).foreach {
+      _.zipWithIndex.map { case (cell, i) =>
+        if (rightAlign(i))
+          StringUtils.leftPad(cell, colWidths(i))
+        else
+          StringUtils.rightPad(cell, colWidths(i))
+      }.addString(sb, "| ", " | ", " |\n")
+    }
+
+    sb.append(sep)
+
+    if (hasMoreData)
+      sb.append(s"showing top $rows ${ plural(rows, "row") }\n")
+
+    sb.result()
+  }
 }


### PR DESCRIPTION
This method functions very similarly to to_dataframe().show(), with
some important distinctions.
 - Don't call flatten / expandTypes. Instead, expand only structs and call
   Type.str on non-struct types.
 - Right-align numeric columns, left-align everything else
 - Customizable truncation
 - Column types are printed optionally (default true)