### PR TITLE
[0.1] Added KeyTable.show (#2191)

### DIFF
--- a/python/hail/keytable.py
+++ b/python/hail/keytable.py
@@ -1304,6 +1304,38 @@ class KeyTable(object):
 
         return KeyTable(self.hc, self._jkt.indexed(name))
 
+    @typecheck_method(n=integral,
+                      truncate_to=nullable(integral),
+                      print_types=bool)
+    def show(self, n=10, truncate_to=None, print_types=True):
+        """Show the first few rows of the table in human-readable format.
+
+        **Examples**
+
+        Show, with default parameters (10 rows, no truncation, and column types):
+
+        >>> kt1.show()
+
+        Truncate long columns to 25 characters and only write 5 rows:
+
+        >>> kt1.show(5, truncate_to=25)
+
+        **Notes**
+
+        If the ``truncate_to`` argument is ``None``, then no truncation will
+        occur. This is the default behavior. An integer argument will truncate
+        each cell to the specified number of characters.
+
+        :param int n: Number of rows to show.
+
+        :param truncate_to: Truncate columns to the desired number of characters.
+        :type truncate_to: int or None
+
+        :param bool print_types: Print a line with column types.
+        """
+        to_print = self._jkt.showString(n, joption(truncate_to), print_types)
+        print(to_print)
+
     @staticmethod
     @handle_py4j
     @typecheck(n=integral,

--- a/python/hail/tests/tests.py
+++ b/python/hail/tests/tests.py
@@ -483,7 +483,10 @@ class ContextTests(unittest.TestCase):
         kt.flatten()
         kt.expand_types()
 
-        kt.to_dataframe()
+        kt.to_dataframe().count()
+
+        kt.show(10)
+        kt.show(4, print_types=False, truncate_to=15)
 
         kt.annotate("newField = [0, 1, 2]").explode(["newField"])
 


### PR DESCRIPTION
* Added KeyTable.show

This method functions very similarly to to_dataframe().show(), with
some important distinctions.
 - Don't call flatten / expandTypes. Instead, expand only structs and call
   Type.str on non-struct types.
 - Right-align numeric columns, left-align everything else
 - Customizable truncation
 - Column types are printed optionally (default true)

* Address comments and expand docs