### PR TITLE
add UnionFind data structure with tests

### DIFF
--- a/src/main/scala/is/hail/utils/UnionFind.scala
+++ b/src/main/scala/is/hail/utils/UnionFind.scala
@@ -1,0 +1,62 @@
+package is.hail.utils
+
+class UnionFind(initialCapacity: Int = 32) {
+  private var a: Array[Int] = new Array[Int](initialCapacity)
+  private var rank: Array[Int] = new Array[Int](initialCapacity)
+  private var count: Int = 0
+
+  def size: Int = count
+
+  private def ensure(i: Int) {
+    if (i >= a.length) {
+      var newLength = a.length
+      do {
+        newLength = newLength << 1
+      } while (i >= newLength);
+      val a2 = new Array[Int](newLength)
+      Array.copy(a, 0, a2, 0, a.length)
+      a = a2
+      val rank2 = new Array[Int](newLength)
+      Array.copy(rank, 0, rank2, 0, rank.length)
+      rank = rank2
+    }
+  }
+
+  def makeSet(i: Int) {
+    ensure(i)
+    a(i) = i
+    count += 1
+  }
+
+  def find(x: Int): Int = {
+    var representative = x
+    while (representative != a(representative)) {
+      representative = a(representative)
+    }
+    var current = x
+    while (representative != current) {
+      val temp = a(current)
+      a(current) = representative
+      current = temp
+    }
+    current
+  }
+
+  def union(x: Int, y: Int) {
+    val xroot = find(x)
+    val yroot = find(y)
+
+    if (xroot != yroot) {
+      count -= 1
+      if (rank(xroot) < rank(yroot)) {
+        a(xroot) = yroot
+      } else if (rank(xroot) > rank(yroot)) {
+        a(yroot) = xroot
+      } else {
+        a(xroot) = yroot
+        rank(yroot) += 1
+      }
+    }
+  }
+
+}

--- a/src/main/scala/is/hail/utils/UnionFind.scala
+++ b/src/main/scala/is/hail/utils/UnionFind.scala
@@ -9,10 +9,10 @@ class UnionFind(initialCapacity: Int = 32) {
 
   private def ensure(i: Int) {
     if (i >= a.length) {
-      var newLength = a.length
-      do {
+      var newLength = a.length << 1
+      while (i >= newLength) {
         newLength = newLength << 1
-      } while (i >= newLength);
+      }
       val a2 = new Array[Int](newLength)
       Array.copy(a, 0, a2, 0, a.length)
       a = a2
@@ -29,6 +29,7 @@ class UnionFind(initialCapacity: Int = 32) {
   }
 
   def find(x: Int): Int = {
+    require(x < a.length)
     var representative = x
     while (representative != a(representative)) {
       representative = a(representative)
@@ -59,4 +60,8 @@ class UnionFind(initialCapacity: Int = 32) {
     }
   }
 
+  def sameSet(x: Int, y: Int): Boolean = {
+    require(x < a.length && y < a.length)
+    find(x) == find(y)
+  }
 }

--- a/src/test/scala/is/hail/utils/UnionFindSuite.scala
+++ b/src/test/scala/is/hail/utils/UnionFindSuite.scala
@@ -51,7 +51,7 @@ class UnionFindSuite extends TestNGSuite {
     assert(uf.find(1000) == 1000)
     assert(uf.find(1024) == 1024)
     assert(uf.find(4097) == 4097)
-    assert(uf.find(4096) == 4096)
+    assert(uf.find(4095) == 4095)
     assert(uf.size == 4)
   }
 
@@ -100,14 +100,14 @@ class UnionFindSuite extends TestNGSuite {
     uf.makeSet(5)
     uf.makeSet(6)
 
-    assert(uf.size == 5)
+    assert(uf.size == 6)
 
     uf.union(1, 2)
     uf.union(1, 4)
     uf.union(5, 3)
     uf.union(2, 6)
 
-    assert(uf.size == 3)
+    assert(uf.size == 2)
     assert(uf.find(1) == uf.find(2))
     assert(uf.find(1) == uf.find(4))
     assert(uf.find(5) == uf.find(3))

--- a/src/test/scala/is/hail/utils/UnionFindSuite.scala
+++ b/src/test/scala/is/hail/utils/UnionFindSuite.scala
@@ -1,0 +1,117 @@
+package is.hail.utils
+
+import org.scalatest.testng.TestNGSuite
+import org.testng.annotations.Test
+
+class UnionFindSuite extends TestNGSuite {
+  @Test
+  def emptyUnionFindHasNoSets() {
+    assert(new UnionFind().size == 0)
+  }
+
+  @Test
+  def growingPastInitialCapacityOK() {
+    val uf = new UnionFind(4)
+    uf.makeSet(0)
+    uf.makeSet(1)
+    uf.makeSet(2)
+    uf.makeSet(3)
+    uf.makeSet(4)
+    assert(uf.find(0) == 0)
+    assert(uf.find(1) == 1)
+    assert(uf.find(2) == 2)
+    assert(uf.find(3) == 3)
+    assert(uf.find(4) == 4)
+    assert(uf.size == 5)
+  }
+
+  @Test
+  def simpleUnions() {
+    val uf = new UnionFind()
+
+    uf.makeSet(0)
+    uf.makeSet(1)
+
+    uf.union(0, 1)
+
+    val (x, y) = (uf.find(0), uf.find(1))
+    assert(x == y)
+    assert(x == 0 || x == 1)
+  }
+
+  @Test
+  def nonMonotonicMakeSet() {
+    val uf = new UnionFind()
+
+    uf.makeSet(1000)
+    uf.makeSet(1024)
+    uf.makeSet(4097)
+    uf.makeSet(4095)
+
+    assert(uf.find(1000) == 1000)
+    assert(uf.find(1024) == 1024)
+    assert(uf.find(4097) == 4097)
+    assert(uf.find(4096) == 4096)
+    assert(uf.size == 4)
+  }
+
+  @Test
+  def multipleUnions() {
+    val uf = new UnionFind()
+
+    uf.makeSet(1)
+    uf.makeSet(2)
+    uf.makeSet(3)
+    uf.makeSet(4)
+    assert(uf.size == 4)
+
+    uf.union(1, 2)
+
+    assert(uf.find(1) == uf.find(2))
+    assert(uf.find(1) != uf.find(3))
+    assert(uf.find(1) != uf.find(4))
+    assert(uf.find(3) != uf.find(4))
+    assert(uf.size == 3)
+
+    uf.union(1, 4)
+
+    assert(uf.find(1) == uf.find(2))
+    assert(uf.find(1) != uf.find(3))
+    assert(uf.find(1) == uf.find(4))
+    assert(uf.find(3) != uf.find(4))
+    assert(uf.size == 2)
+
+    uf.union(2, 3)
+
+    assert(uf.find(1) == uf.find(2))
+    assert(uf.find(1) == uf.find(3))
+    assert(uf.find(1) == uf.find(4))
+    assert(uf.size == 1)
+  }
+
+  @Test
+  def unionsNoInterveningFinds() {
+    val uf = new UnionFind()
+
+    uf.makeSet(1)
+    uf.makeSet(2)
+    uf.makeSet(3)
+    uf.makeSet(4)
+    uf.makeSet(5)
+    uf.makeSet(6)
+
+    assert(uf.size == 5)
+
+    uf.union(1, 2)
+    uf.union(1, 4)
+    uf.union(5, 3)
+    uf.union(2, 6)
+
+    assert(uf.size == 3)
+    assert(uf.find(1) == uf.find(2))
+    assert(uf.find(1) == uf.find(4))
+    assert(uf.find(5) == uf.find(3))
+    assert(uf.find(1) == uf.find(6))
+    assert(uf.find(1) != uf.find(5))
+  }
+}

--- a/src/test/scala/is/hail/utils/UnionFindSuite.scala
+++ b/src/test/scala/is/hail/utils/UnionFindSuite.scala
@@ -52,12 +52,12 @@ class UnionFindSuite extends TestNGSuite {
     assert(uf.find(1024) == 1024)
     assert(uf.find(4097) == 4097)
     assert(uf.find(4095) == 4095)
-    assert(uf.find(1000) != uf.find(1024))
-    assert(uf.find(1000) != uf.find(4097))
-    assert(uf.find(1000) != uf.find(4095))
-    assert(uf.find(1024) != uf.find(4097))
-    assert(uf.find(1024) != uf.find(4095))
-    assert(uf.find(4097) != uf.find(4095))
+    assert(!uf.sameSet(1000, 1024))
+    assert(!uf.sameSet(1000, 4097))
+    assert(!uf.sameSet(1000, 4095))
+    assert(!uf.sameSet(1024, 4097))
+    assert(!uf.sameSet(1024, 4095))
+    assert(!uf.sameSet(4097, 4095))
     assert(uf.size == 4)
   }
 
@@ -73,25 +73,25 @@ class UnionFindSuite extends TestNGSuite {
 
     uf.union(1, 2)
 
-    assert(uf.find(1) == uf.find(2))
-    assert(uf.find(1) != uf.find(3))
-    assert(uf.find(1) != uf.find(4))
-    assert(uf.find(3) != uf.find(4))
+    assert(uf.sameSet(1, 2))
+    assert(!uf.sameSet(1, 3))
+    assert(!uf.sameSet(1, 4))
+    assert(!uf.sameSet(3, 4))
     assert(uf.size == 3)
 
     uf.union(1, 4)
 
-    assert(uf.find(1) == uf.find(2))
-    assert(uf.find(1) != uf.find(3))
-    assert(uf.find(1) == uf.find(4))
-    assert(uf.find(3) != uf.find(4))
+    assert(uf.sameSet(1, 2))
+    assert(!uf.sameSet(1, 3))
+    assert(uf.sameSet(1, 4))
+    assert(!uf.sameSet(3, 4))
     assert(uf.size == 2)
 
     uf.union(2, 3)
 
-    assert(uf.find(1) == uf.find(2))
-    assert(uf.find(1) == uf.find(3))
-    assert(uf.find(1) == uf.find(4))
+    assert(uf.sameSet(1, 2))
+    assert(uf.sameSet(1, 3))
+    assert(uf.sameSet(1, 4))
     assert(uf.size == 1)
   }
 
@@ -114,11 +114,11 @@ class UnionFindSuite extends TestNGSuite {
     uf.union(2, 6)
 
     assert(uf.size == 2)
-    assert(uf.find(1) == uf.find(2))
-    assert(uf.find(1) == uf.find(4))
-    assert(uf.find(5) == uf.find(3))
-    assert(uf.find(1) == uf.find(6))
-    assert(uf.find(1) != uf.find(5))
+    assert(uf.sameSet(1, 2))
+    assert(uf.sameSet(1, 4))
+    assert(uf.sameSet(5, 3))
+    assert(uf.sameSet(1, 6))
+    assert(!uf.sameSet(1, 5))
   }
 
   @Test

--- a/src/test/scala/is/hail/utils/UnionFindSuite.scala
+++ b/src/test/scala/is/hail/utils/UnionFindSuite.scala
@@ -52,6 +52,12 @@ class UnionFindSuite extends TestNGSuite {
     assert(uf.find(1024) == 1024)
     assert(uf.find(4097) == 4097)
     assert(uf.find(4095) == 4095)
+    assert(uf.find(1000) != uf.find(1024))
+    assert(uf.find(1000) != uf.find(4097))
+    assert(uf.find(1000) != uf.find(4095))
+    assert(uf.find(1024) != uf.find(4097))
+    assert(uf.find(1024) != uf.find(4095))
+    assert(uf.find(4097) != uf.find(4095))
     assert(uf.size == 4)
   }
 

--- a/src/test/scala/is/hail/utils/UnionFindSuite.scala
+++ b/src/test/scala/is/hail/utils/UnionFindSuite.scala
@@ -120,4 +120,35 @@ class UnionFindSuite extends TestNGSuite {
     assert(uf.find(1) == uf.find(6))
     assert(uf.find(1) != uf.find(5))
   }
+
+  @Test
+  def sameSetWorks() {
+    val uf = new UnionFind()
+
+    uf.makeSet(1)
+    uf.makeSet(2)
+    uf.makeSet(3)
+    uf.makeSet(1024)
+    uf.makeSet(4097)
+    uf.makeSet(4096)
+
+    assert(!uf.sameSet(1, 1024))
+    assert(!uf.sameSet(1, 4097))
+    assert(!uf.sameSet(1, 4096))
+    assert(!uf.sameSet(2, 1024))
+    assert(!uf.sameSet(2, 4097))
+    assert(!uf.sameSet(2, 4096))
+
+    uf.union(1024, 4096)
+    uf.union(4097, 1)
+
+    assert(!uf.sameSet(1, 1024))
+    assert(uf.sameSet(1, 4097))
+    assert(!uf.sameSet(1, 4096))
+    assert(!uf.sameSet(2, 1024))
+    assert(!uf.sameSet(2, 4097))
+    assert(!uf.sameSet(2, 4096))
+
+    assert(uf.sameSet(1024, 4096))
+  }
 }


### PR DESCRIPTION
This has no current practical use, but we may find a UnionFind structure useful in the future. I implemented this for fun a couple weekends ago.