### PR TITLE
Add annotate_variants_db decorators

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -855,6 +855,10 @@ class VariantDataset(HistoryMixin):
 
         return VariantDataset(self.hc, jvds)
 
+    @handle_py4j
+    @record_method
+    @typecheck_method(annotations=oneof(strlike, listof(strlike)),
+                      gene_key=nullable(strlike))
     def annotate_variants_db(self, annotations, gene_key=None):
         """
         Annotate variants using the Hail annotation database.


### PR DESCRIPTION
`record_method` works for `annotate_variants_db` with no additional modifications based on how History is structured. I confirmed that any additional method calls in the function are not showing up in the `history.txt` file.