### PR TITLE
Fixed bug on Skat key type

### DIFF
--- a/src/main/scala/is/hail/methods/Skat.scala
+++ b/src/main/scala/is/hail/methods/Skat.scala
@@ -201,7 +201,7 @@ object Skat {
           keyIterator(key).map((_, gVector -> w))
         case _ => Iterator.empty
       }
-    }.groupByKey(), keysType)
+    }.groupByKey(), keyType)
   }
 
   /*

--- a/src/test/scala/is/hail/methods/SkatSuite.scala
+++ b/src/test/scala/is/hail/methods/SkatSuite.scala
@@ -214,10 +214,12 @@ class SkatSuite extends SparkSuite {
     
     val (vds, singleKey, weightExpr) = if (useBN) (vdsBN, false, None) else (vdsSkat, true, Some("va.weight"))
     
-    val resultHail = vds.skat("va.genes", singleKey = singleKey, "sa.pheno", Array("sa.cov.Cov1", "sa.cov.Cov2"),
+    val hailKT = vds.skat("va.genes", singleKey = singleKey, "sa.pheno", Array("sa.cov.Cov1", "sa.cov.Cov2"),
       weightExpr, useLogistic, useDosages, useLargeN)
-      .rdd
-      .collect()
+
+    hailKT.typeCheck()
+    
+    val resultHail = hailKT.rdd.collect()
 
     val resultsR = skatInR(vds, "va.genes", singleKey = singleKey, "sa.pheno", Array("sa.cov.Cov1", "sa.cov.Cov2"),
       weightExpr, useLogistic, useDosages)


### PR DESCRIPTION
Added typecheck to SkatSuite as regression test.

keysType was being passed instead of keyType, which resulted for example in Array[String] instead of String as the type of key when the variantKeys was an Array[String] annotation and singleKey was False.