### PR TITLE
add repositories necessary for compiling against hortonworks Spark

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ repositories {
     jcenter()
     maven {
         url "https://repository.cloudera.com/artifactory/cloudera-repos/"
+        url "http://repo.hortonworks.com/content/repositories/releases/"
+        url "http://repo.spring.io/plugins-release/"
     }
 }
 


### PR DESCRIPTION
@cseed @tpoterba Thoughts? this is necessary to compile against hortonworks Spark. We already include cloudera stuff. Should we include both? Only cloudera? Neither?