### PR TITLE
Fix wasSplit for BGEN loader [0.1]

### DIFF
--- a/src/main/scala/is/hail/io/bgen/BgenLoader.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenLoader.scala
@@ -76,13 +76,21 @@ object BgenLoader {
       (decoder.getKey, (decoder.getAnnotation, decoder.getValue))
     })).toOrderedRDD[Locus](fastKeys)
 
+    val noMulti = rdd.forall(_._1.nAlleles == 2)
+
+    if (noMulti)
+      info("No multiallelics detected.")
+    if (!noMulti)
+      info("Multiallelic variants detected. Some methods require splitting or filtering multiallelics first.")
+
+
     new VariantSampleMatrix(hc, VSMMetadata(
       TString,
       saSignature = TStruct.empty,
       TVariant,
       vaSignature = signature,
       globalSignature = TStruct.empty,
-      wasSplit = true,
+      wasSplit = noMulti,
       isLinearScale = true),
       VSMLocalValue(globalAnnotation = Annotation.empty,
         sampleIds = samples,


### PR DESCRIPTION
Bug discovered when reviewing #2228. Should not be an issue in 0.2 after #2228 is done. If this fix makes UK Biobank import too slow, then I can change the `BgenBlockReaderV12` code to not accept multi-allelic variants.