### PR TITLE
PC Relate: Add a desired output flag [PCRI-2]

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -3845,8 +3845,9 @@ class VariantDataset(object):
     @typecheck_method(k=integral,
                       maf=numeric,
                       block_size=integral,
-                      min_kinship=numeric)
-    def pc_relate(self, k, maf, block_size=512, min_kinship=-float("inf")):
+                      min_kinship=numeric,
+                      desire=enumeration("phi", "phik2", "phik2k0", "all"))
+    def pc_relate(self, k, maf, block_size=512, min_kinship=-float("inf"), desire="all"):
         """Compute relatedness estimates between individuals using a variant of the
         PC-Relate method.
 
@@ -4045,7 +4046,9 @@ class VariantDataset(object):
 
         """
 
-        return KeyTable(self.hc, self._jvdf.pcRelate(k, maf, block_size, min_kinship))
+        intdesire = { "phi" : 0, "phik2" : 1, "phik2k0" : 2, "all" : 3 }[desire]
+
+        return KeyTable(self.hc, self._jvdf.pcRelate(k, maf, block_size, min_kinship, intdesire))
 
     @handle_py4j
     @typecheck_method(storage_level=strlike)

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -3846,8 +3846,8 @@ class VariantDataset(object):
                       maf=numeric,
                       block_size=integral,
                       min_kinship=numeric,
-                      desire=enumeration("phi", "phik2", "phik2k0", "all"))
-    def pc_relate(self, k, maf, block_size=512, min_kinship=-float("inf"), desire="all"):
+                      statistics=enumeration("phi", "phik2", "phik2k0", "all"))
+    def pc_relate(self, k, maf, block_size=512, min_kinship=-float("inf"), statistics="all"):
         """Compute relatedness estimates between individuals using a variant of the
         PC-Relate method.
 
@@ -4021,6 +4021,27 @@ class VariantDataset(object):
         the threshold, then the variant's contribution to relatedness estimates
         is zero.
 
+        Under the PC-Relate model, kinship, \[ \phi_{ij} \], ranges from 0 to
+        0.5, and is precisely half of the
+        fraction-of-genetic-material-shared. Listed below are the statistics for
+        a few pairings:
+
+         - Monozygotic twins share all their genetic material so their kinship
+           statistic is 0.5 in expection.
+
+         - Parent-child and sibling pairs both have kinship 0.25 in expectation
+           and are separated by the identity-by-descent-zero, \[ k^{(2)}_{ij} \],
+           statistic which is zero for parent-child pairs and 0.25 for sibling
+           pairs.
+
+         - Avuncular pairs and grand-parent/-child pairs both have kinship 0.125
+           in expectation and both have identity-by-descent-zero 0.5 in expectation
+
+         - "Third degree relatives" are those pairs sharing
+           \[ 2^{-3} = 12.5 % \] of their genetic material, the results of
+           PCRelate are often too noisy to reliably distinguish these pairs from
+           higher-degree-relative-pairs or unrelated pairs.
+
         The resulting :py:class:`.KeyTable` entries have the type: *{ i: String,
         j: String, kin: Double, k2: Double, k1: Double, k0: Double }*. The key
         list is: *i: String, j: String*.
@@ -4040,15 +4061,23 @@ class VariantDataset(object):
         :param float min_kinship: Pairs of samples with kinship lower than
                                   ``min_kinship`` are excluded from the results.
 
+        :param str statistics: the set of statistics to compute, 'phi' will only
+                               compute the kinship statistic, 'phik2' will
+                               compute the kinship and identity-by-descent two
+                               statistics, 'phik2k0' will compute the kinship
+                               statistics and both identity-by-descent two and
+                               zero, 'all' computes the kinship statistic and
+                               all three identity-by-descent statistics.
+
         :return: A :py:class:`.KeyTable` mapping pairs of samples to estimations
                  of their kinship and identity-by-descent zero, one, and two.
         :rtype: :py:class:`.KeyTable`
 
         """
 
-        intdesire = { "phi" : 0, "phik2" : 1, "phik2k0" : 2, "all" : 3 }[desire]
+        intstatistics = { "phi" : 0, "phik2" : 1, "phik2k0" : 2, "all" : 3 }[statistics]
 
-        return KeyTable(self.hc, self._jvdf.pcRelate(k, maf, block_size, min_kinship, intdesire))
+        return KeyTable(self.hc, self._jvdf.pcRelate(k, maf, block_size, min_kinship, intstatistics))
 
     @handle_py4j
     @typecheck_method(storage_level=strlike)

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -4030,7 +4030,7 @@ class VariantDataset(object):
            statistic is 0.5 in expection.
 
          - Parent-child and sibling pairs both have kinship 0.25 in expectation
-           and are separated by the identity-by-descent-zero, \[ k^{(2)}_{ij} \],
+           and are separated by the identity-by-descent-zero, \[ k^{(2)}_{ij} \],
            statistic which is zero for parent-child pairs and 0.25 for sibling
            pairs.
 
@@ -4038,7 +4038,7 @@ class VariantDataset(object):
            in expectation and both have identity-by-descent-zero 0.5 in expectation
 
          - "Third degree relatives" are those pairs sharing
-           \[ 2^{-3} = 12.5 % \] of their genetic material, the results of
+           \[ 2^{-3} = 12.5 % \] of their genetic material, the results of
            PCRelate are often too noisy to reliably distinguish these pairs from
            higher-degree-relative-pairs or unrelated pairs.
 

--- a/python/hail/typecheck/__init__.py
+++ b/python/hail/typecheck/__init__.py
@@ -13,4 +13,5 @@ __all__ = ['typecheck',
            'integral',
            'numeric',
            'char',
-           'lazy']
+           'lazy',
+           'enumeration']

--- a/python/hail/typecheck/check.py
+++ b/python/hail/typecheck/check.py
@@ -121,6 +121,17 @@ class LazyChecker(TypeChecker):
             raise RuntimeError("LazyChecker not initialized. Use 'set' to provide the expected type")
         return extract(self.t)
 
+class ExactlyTypeChecker(TypeChecker):
+    def __init__(self, v):
+        self.v = v
+        super(ExactlyTypeChecker, self).__init__()
+
+    def check(self, x):
+        return x == self.v
+
+    def expects(self):
+        return str(v)
+
 
 def only(t):
     if isinstance(t, type) or type(t) is ClassType:
@@ -131,8 +142,16 @@ def only(t):
         raise RuntimeError("invalid typecheck signature: expected 'type' or 'TypeChecker', found '%s'" % type(t))
 
 
+def exactly(v):
+    return ExactlyTypeChecker(v)
+
+
 def oneof(*args):
     return MultipleTypeChecker([only(x) for x in args])
+
+
+def enumeration(*args):
+    return MultipleTypeChecker([exactly(x) for x in args])
 
 
 def nullable(t):

--- a/python/hail/typecheck/check.py
+++ b/python/hail/typecheck/check.py
@@ -130,7 +130,7 @@ class ExactlyTypeChecker(TypeChecker):
         return x == self.v
 
     def expects(self):
-        return str(v)
+        return str(self.v)
 
 
 def only(t):

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -677,10 +677,10 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     *                  these matrices fit in memory (in addition to all other
     *                  objects necessary for Spark and Hail).
     */
-  def pcRelate(k: Int, maf: Double, blockSize: Int, minKinship: Double = PCRelate.defaultMinKinship): KeyTable = {
+  def pcRelate(k: Int, maf: Double, blockSize: Int, minKinship: Double = PCRelate.defaultMinKinship, desire: PCRelate.Desire = PCRelate.defaultDesire): KeyTable = {
     requireSplit("PCRelate")
     val pcs = SamplePCA.justScores(vds, k)
-    PCRelate.toKeyTable(vds, pcs, maf, blockSize, minKinship)
+    PCRelate.toKeyTable(vds, pcs, maf, blockSize, minKinship, desire)
   }
 
   def sampleQC(root: String = "sa.qc", keepStar: Boolean = false): VariantDataset = SampleQC(vds, root, keepStar)

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -668,19 +668,20 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
 
   /**
     *
-    * @param k         the number of principal components to use to distinguish
-    *                  ancestries
-    * @param maf       the minimum individual-specific allele frequency for an
-    *                  allele used to measure relatedness
-    * @param blockSize the side length of the blocks of the block-distributed
-    *                  matrices; this should be set such that atleast three of
-    *                  these matrices fit in memory (in addition to all other
-    *                  objects necessary for Spark and Hail).
+    * @param k          the number of principal components to use to distinguish
+    *                   ancestries
+    * @param maf        the minimum individual-specific allele frequency for an
+    *                   allele used to measure relatedness
+    * @param blockSize  the side length of the blocks of the block-distributed
+    *                   matrices; this should be set such that atleast three of
+    *                   these matrices fit in memory (in addition to all other
+    *                   objects necessary for Spark and Hail).
+    * @param statistics which subset of the four statistics to compute
     */
-  def pcRelate(k: Int, maf: Double, blockSize: Int, minKinship: Double = PCRelate.defaultMinKinship, desire: PCRelate.Desire = PCRelate.defaultDesire): KeyTable = {
+  def pcRelate(k: Int, maf: Double, blockSize: Int, minKinship: Double = PCRelate.defaultMinKinship, statistics: PCRelate.StatisticSubset = PCRelate.defaultStatisticSubset): KeyTable = {
     requireSplit("PCRelate")
     val pcs = SamplePCA.justScores(vds, k)
-    PCRelate.toKeyTable(vds, pcs, maf, blockSize, minKinship, desire)
+    PCRelate.toKeyTable(vds, pcs, maf, blockSize, minKinship, statistics)
   }
 
   def sampleQC(root: String = "sa.qc", keepStar: Boolean = false): VariantDataset = SampleQC(vds, root, keepStar)


### PR DESCRIPTION
Builds on PC Relate Unified Filtering #2238.

I think this practically much more valuable to our users than filtering.

This avoids computation of unneeded statistics (they appear as NA in the output).

I'm happy to rebase without unified filtering, but it's some work to do that, so I'd rather decide one way or the other on filtering first.