### PR TITLE
PC Relate with Persist annotations [PCRI-4]

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -3844,8 +3844,9 @@ class VariantDataset(object):
     @handle_py4j
     @typecheck_method(k=integral,
                       maf=numeric,
-                      block_size=integral)
-    def pc_relate(self, k, maf, block_size=512):
+                      block_size=integral,
+                      min_kinship=numeric)
+    def pc_relate(self, k, maf, block_size=512, min_kinship=-float("inf")):
         """Compute relatedness estimates between individuals using a variant of the
         PC-Relate method.
 
@@ -3865,7 +3866,13 @@ class VariantDataset(object):
 
         >>> rel = vds.pc_relate(5, 0.01, 1024)
 
-        **Method**
+        Calculate values as above, excluding sample-pairs with kinship lower
+        than 0.1. This is more efficient than producing the full key table and
+        filtering using :py:meth:`~hail.KeyTable.filter`.
+
+        >>> rel = vds.pc_relate(5, 0.01, min_kinship=0.1)
+
+        **Method*
 
         The traditional estimator for kinship between a pair of individuals
         :math:`i` and :math:`j`, sharing the set :math:`S_{ij}` of
@@ -4035,7 +4042,7 @@ class VariantDataset(object):
 
         """
 
-        return KeyTable(self.hc, self._jvdf.pcRelate(k, maf, block_size))
+        return KeyTable(self.hc, self._jvdf.pcRelate(k, maf, block_size, min_kinship))
 
     @handle_py4j
     @typecheck_method(storage_level=strlike)

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -3845,8 +3845,9 @@ class VariantDataset(object):
     @typecheck_method(k=integral,
                       maf=numeric,
                       block_size=integral,
-                      min_kinship=numeric)
-    def pc_relate(self, k, maf, block_size=512, min_kinship=-float("inf")):
+                      min_kinship=numeric,
+                      desire=enumeration("phi", "phik2", "phik2k0", "all"))
+    def pc_relate(self, k, maf, block_size=512, min_kinship=-float("inf"), desire="all"):
         """Compute relatedness estimates between individuals using a variant of the
         PC-Relate method.
 
@@ -4045,7 +4046,9 @@ class VariantDataset(object):
 
         """
 
-        return KeyTable(self.hc, self._jvdf.pcRelate(k, maf, block_size, min_kinship))
+        intdesire = { "phi" : 0, "phik2" : 1, "phik2k0" : 2, "all" : 3 }[desire]
+
+        return KeyTable(self.hc, self._jvdf.pcRelate(k, maf, block_size, min_kinship, intdesire))
 
     @handle_py4j
     @typecheck_method(storage_level=strlike)

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -3872,7 +3872,7 @@ class VariantDataset(object):
 
         >>> rel = vds.pc_relate(5, 0.01, min_kinship=0.1)
 
-        **Method*
+        **Method**
 
         The traditional estimator for kinship between a pair of individuals
         :math:`i` and :math:`j`, sharing the set :math:`S_{ij}` of

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -4036,6 +4036,9 @@ class VariantDataset(object):
                                memory (in addition to all other objects
                                necessary for Spark and Hail)
 
+        :param float min_kinship: Pairs of samples with kinship lower than
+                                  ``min_kinship`` are excluded from the results
+
         :return: A :py:class:`.KeyTable` mapping pairs of samples to estimations
                  of their kinship and identity-by-descent zero, one, and two
         :rtype: :py:class:`.KeyTable`

--- a/python/hail/typecheck/__init__.py
+++ b/python/hail/typecheck/__init__.py
@@ -13,4 +13,5 @@ __all__ = ['typecheck',
            'integral',
            'numeric',
            'char',
-           'lazy']
+           'lazy',
+           'enumeration']

--- a/python/hail/typecheck/check.py
+++ b/python/hail/typecheck/check.py
@@ -121,6 +121,17 @@ class LazyChecker(TypeChecker):
             raise RuntimeError("LazyChecker not initialized. Use 'set' to provide the expected type")
         return extract(self.t)
 
+class ExactlyTypeChecker(TypeChecker):
+    def __init__(self, v):
+        self.v = v
+        super(ExactlyTypeChecker, self).__init__()
+
+    def check(self, x):
+        return x == self.v
+
+    def expects(self):
+        return str(v)
+
 
 def only(t):
     if isinstance(t, type) or type(t) is ClassType:
@@ -131,8 +142,16 @@ def only(t):
         raise RuntimeError("invalid typecheck signature: expected 'type' or 'TypeChecker', found '%s'" % type(t))
 
 
+def exactly(v):
+    return ExactlyTypeChecker(v)
+
+
 def oneof(*args):
     return MultipleTypeChecker([only(x) for x in args])
+
+
+def enumeration(*args):
+    return MultipleTypeChecker([exactly(x) for x in args])
 
 
 def nullable(t):

--- a/python/hail/typecheck/check.py
+++ b/python/hail/typecheck/check.py
@@ -130,7 +130,7 @@ class ExactlyTypeChecker(TypeChecker):
         return x == self.v
 
     def expects(self):
-        return str(v)
+        return str(self.v)
 
 
 def only(t):

--- a/src/main/scala/is/hail/distributedmatrix/BlockMatrixIsDistributedMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/BlockMatrixIsDistributedMatrix.scala
@@ -6,6 +6,7 @@ import org.apache.spark._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.mllib.linalg._
 import org.apache.spark.mllib.linalg.distributed._
+import breeze.linalg.{DenseMatrix => BDM}
 import org.apache.hadoop.io._
 import java.io._
 import org.json4s._
@@ -91,6 +92,11 @@ object BlockMatrixIsDistributedMatrix extends DistributedMatrix[BlockMatrix] {
     */
   def multiply(l: M, r: M): M =
     BetterBlockMatrix.multiply(l, r)
+  def multiply(l: M, r: BDM[Double]): M = {
+    require(l.numCols() == r.rows,
+      s"incompatible matrix dimensions: ${l.numRows()}x${l.numCols()} and ${r.rows}x${r.cols}")
+    multiply(l, from(l.blocks.sparkContext, new DenseMatrix(r.rows, r.cols, r.data), l.colsPerBlock, l.rowsPerBlock))
+  }
   def multiply(l: M, r: DenseMatrix): M = {
     require(l.numCols() == r.numRows,
       s"incompatible matrix dimensions: ${l.numRows()}x${l.numCols()} and ${r.numRows}x${r.numCols}")
@@ -98,6 +104,9 @@ object BlockMatrixIsDistributedMatrix extends DistributedMatrix[BlockMatrix] {
   }
 
   def map4(op: (Double, Double, Double, Double) => Double)(a: M, b: M, c: M, d: M): M = {
+    assert(a.blocks.partitioner == b.blocks.partitioner, s"${a.blocks.partitioner} ${b.blocks.partitioner}")
+    assert(b.blocks.partitioner == c.blocks.partitioner, s"${b.blocks.partitioner} ${c.blocks.partitioner}")
+    assert(c.blocks.partitioner == d.blocks.partitioner, s"${c.blocks.partitioner} ${d.blocks.partitioner}")
     require(a.numRows() == b.numRows(), s"expected a's dimensions to match b's dimensions, but: ${a.numRows()} x ${a.numCols()},  ${b.numRows()} x ${b.numCols()}")
     require(b.numRows() == c.numRows(), s"expected b's dimensions to match c's dimensions, but: ${b.numRows()} x ${b.numCols()},  ${c.numRows()} x ${c.numCols()}")
     require(c.numRows() == d.numRows(), s"expected c's dimensions to match d's dimensions, but: ${c.numRows()} x ${c.numCols()},  ${d.numRows()} x ${d.numCols()}")
@@ -125,6 +134,15 @@ object BlockMatrixIsDistributedMatrix extends DistributedMatrix[BlockMatrix] {
       new DenseMatrix(m1.numRows, m1.numCols, result)
     }
     new BlockMatrix(blocks, a.rowsPerBlock, a.colsPerBlock, a.numRows(), a.numCols())
+  }
+
+  def blockMap2(op: (Matrix, Matrix) => DenseMatrix)(l: M, r: M): M = {
+    require(l.numRows() == r.numRows())
+    require(l.numCols() == r.numCols())
+    require(l.rowsPerBlock == r.rowsPerBlock, s"blocks must be same size, but actually were ${l.rowsPerBlock}x${l.colsPerBlock} and ${r.rowsPerBlock}x${l.colsPerBlock}")
+    require(l.colsPerBlock == r.colsPerBlock, s"blocks must be same size, but actually were ${l.rowsPerBlock}x${l.colsPerBlock} and ${r.rowsPerBlock}x${l.colsPerBlock}")
+    val blocks: RDD[((Int, Int), Matrix)] = l.blocks.join(r.blocks).mapValues(op.tupled)
+    new BlockMatrix(blocks, l.rowsPerBlock, l.colsPerBlock, l.numRows(), l.numCols())
   }
 
   def map2(op: (Double, Double) => Double)(l: M, r: M): M = {
@@ -274,7 +292,10 @@ object BlockMatrixIsDistributedMatrix extends DistributedMatrix[BlockMatrix] {
 
   def toBlockRdd(m: M): RDD[((Int, Int), Matrix)] = m.blocks
 
-  def toLocalMatrix(m: M): Matrix = m.toLocalMatrix()
+  def toLocalMatrix(m: M): BDM[Double] = {
+    val sm = m.toLocalMatrix().asInstanceOf[DenseMatrix]
+    new BDM[Double](sm.numRows, sm.numCols, sm.values)
+  }
 
   private class PairWriter(var i: Int, var j: Int) extends Writable {
     def this() {

--- a/src/main/scala/is/hail/distributedmatrix/BlockMatrixIsDistributedMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/BlockMatrixIsDistributedMatrix.scala
@@ -175,8 +175,8 @@ object BlockMatrixIsDistributedMatrix extends DistributedMatrix[BlockMatrix] {
     new BlockMatrix(blocks, l.rowsPerBlock, l.colsPerBlock, l.numRows(), l.numCols())
   }
 
-  def pointwiseAdd(l: M, r: M): M = l.add(r)
-  def pointwiseSubtract(l: M, r: M): M = l.subtract(r)
+  def pointwiseAdd(l: M, r: M): M = map2(_ + _)(r)
+  def pointwiseSubtract(l: M, r: M): M = map2(_ - _)(r)
   def pointwiseMultiply(l: M, r: M): M = map2(_ * _)(l, r)
   def pointwiseDivide(l: M, r: M): M = map2(_ / _)(l, r)
 

--- a/src/main/scala/is/hail/distributedmatrix/BlockMatrixIsDistributedMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/BlockMatrixIsDistributedMatrix.scala
@@ -175,8 +175,8 @@ object BlockMatrixIsDistributedMatrix extends DistributedMatrix[BlockMatrix] {
     new BlockMatrix(blocks, l.rowsPerBlock, l.colsPerBlock, l.numRows(), l.numCols())
   }
 
-  def pointwiseAdd(l: M, r: M): M = map2(_ + _)(r)
-  def pointwiseSubtract(l: M, r: M): M = map2(_ - _)(r)
+  def pointwiseAdd(l: M, r: M): M = map2(_ + _)(l, r)
+  def pointwiseSubtract(l: M, r: M): M = map2(_ - _)(l, r)
   def pointwiseMultiply(l: M, r: M): M = map2(_ * _)(l, r)
   def pointwiseDivide(l: M, r: M): M = map2(_ / _)(l, r)
 

--- a/src/main/scala/is/hail/distributedmatrix/DistributedMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/DistributedMatrix.scala
@@ -3,6 +3,7 @@ package is.hail.distributedmatrix
 import org.apache.spark.rdd.RDD
 import org.apache.spark.mllib.linalg._
 import org.apache.spark.mllib.linalg.distributed._
+import breeze.linalg.{DenseMatrix => BDM}
 
 import scala.reflect.ClassTag
 
@@ -16,7 +17,7 @@ trait DistributedMatrix[M] {
   def diagonal(m: M): Array[Double]
 
   def multiply(l: M, r: M): M
-  def multiply(l: M, r: DenseMatrix): M
+  def multiply(l: M, r: BDM[Double]): M
 
   def map4(f: (Double, Double, Double, Double) => Double)(a: M, b: M, c: M, d: M): M
 
@@ -43,7 +44,7 @@ trait DistributedMatrix[M] {
 
   def toBlockRdd(m: M): RDD[((Int, Int), Matrix)]
 
-  def toLocalMatrix(m: M): Matrix
+  def toLocalMatrix(m: M): BDM[Double]
 
   object ops {
     implicit class Shim(l: M) {
@@ -54,7 +55,7 @@ trait DistributedMatrix[M] {
 
       def *(r: M): M =
         multiply(l, r)
-      def *(r: DenseMatrix): M =
+      def *(r: BDM[Double]): M =
         multiply(l, r)
 
       def :+(r: M): M =

--- a/src/main/scala/is/hail/distributedmatrix/HailBlockMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/HailBlockMatrix.scala
@@ -1,0 +1,308 @@
+package is.hail.distributedmatrix
+
+import breeze.linalg.{DenseMatrix => BDM}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.StorageLevel
+import is.hail.utils._
+import org.apache.spark._
+
+class HailBlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
+  val blockSize: Int,
+  val rows: Long,
+  val cols: Long) extends Serializable {
+
+  require(blocks.partitioner.isDefined)
+  require(blocks.partitioner.get.isInstanceOf[HailGridPartitioner])
+
+  val partitioner = blocks.partitioner.get.asInstanceOf[HailGridPartitioner]
+
+  def transpose(): HailBlockMatrix =
+    new HailBlockMatrix(new HailBlockMatrixTransposeRDD(this), blockSize, cols, rows)
+
+  def add(other: HailBlockMatrix): HailBlockMatrix =
+    blockMap2(other, _ + _)
+
+  def subtract(other: HailBlockMatrix): HailBlockMatrix =
+    blockMap2(other, _ - _)
+
+  def pointwiseMultiply(other: HailBlockMatrix): HailBlockMatrix =
+    blockMap2(other, _ :* _)
+
+  def pointwiseDivide(other: HailBlockMatrix): HailBlockMatrix =
+    blockMap2(other, _ :/ _)
+
+  def multiply(other: HailBlockMatrix): HailBlockMatrix =
+    new HailBlockMatrix(new HailBlockMatrixMultiplyRDD(this, other), blockSize, rows, other.cols)
+
+  def cache(): this.type = {
+    blocks.cache()
+    this
+  }
+
+  def persist(storageLevel: StorageLevel): this.type = {
+    blocks.persist(storageLevel)
+    this
+  }
+
+  def toLocalMatrix(): BDM[Double] = {
+    require(this.rows < Int.MaxValue, "The number of rows of this matrix should be less than " +
+      s"Int.MaxValue. Currently numRows: ${this.rows}")
+    require(this.cols < Int.MaxValue, "The number of columns of this matrix should be less than " +
+      s"Int.MaxValue. Currently numCols: ${this.cols}")
+    require(this.rows * this.cols < Int.MaxValue, "The length of the values array must be " +
+      s"less than Int.MaxValue. Currently rows * cols: ${this.rows * this.cols}")
+    val rows = this.rows.toInt
+    val cols = this.cols.toInt
+    val localBlocks = blocks.collect()
+    val values = new Array[Double](rows * cols)
+    var bi = 0
+    while (bi < localBlocks.length) {
+      val ((blocki, blockj), m) = localBlocks(bi)
+      val ioffset = blocki * blockSize
+      val joffset = blockj * blockSize
+      m.foreachPair { case ((i, j), v) =>
+        values((joffset + j) * rows + ioffset + i) = v
+      }
+      bi += 1
+    }
+    new BDM(rows, cols, values)
+  }
+
+  def blockMap(op: BDM[Double] => BDM[Double]): HailBlockMatrix =
+    new HailBlockMatrix(blocks.mapValues(op), blockSize, rows, cols)
+
+  private def requireZippable(other: HailBlockMatrix) {
+    require(rows == other.rows,
+      s"must have same number of rows, but actually: ${rows}x${cols}, ${other.rows}x${other.cols}")
+    require(cols == other.cols,
+      s"must have same number of cols, but actually: ${rows}x${cols}, ${other.rows}x${other.cols}")
+    require(blockSize == other.blockSize,
+      s"blocks must be same size, but actually were ${blockSize}x${blockSize} and ${other.blockSize}x${other.blockSize}")
+  }
+
+  def blockMap2(other: HailBlockMatrix, op: (BDM[Double], BDM[Double]) => BDM[Double]): HailBlockMatrix = {
+    requireZippable(other)
+    new HailBlockMatrix(blocks.join(other.blocks).mapValues(op.tupled), blockSize, rows, cols)
+  }
+
+  def map(op: Double => Double): HailBlockMatrix = {
+    val blocks2 = blocks.mapValues { m =>
+      val src = m.data
+      val dst = new Array[Double](src.length)
+      var i = 0
+      while (i < src.length) {
+        dst(i) = op(src(i))
+        i += 1
+      }
+      new BDM(m.rows, m.cols, dst)
+    }
+    new HailBlockMatrix(blocks2, blockSize, rows, cols)
+  }
+
+  def map2(other: HailBlockMatrix, op: (Double, Double) => Double): HailBlockMatrix = {
+    requireZippable(other)
+    val blocks2 = blocks.join(other.blocks).mapValues { case (m1, m2) =>
+      val src1 = m1.data
+      val src2 = m2.data
+      val dst = new Array[Double](src1.length)
+      var i = 0
+      while (i < src1.length) {
+        dst(i) = op(src1(i), src2(i))
+        i += 1
+      }
+      new BDM(m1.rows, m1.cols, dst)
+    }
+    new HailBlockMatrix(blocks2, blockSize, rows, cols)
+  }
+
+  def map3(hbm2: HailBlockMatrix, hbm3: HailBlockMatrix, op: (Double, Double, Double) => Double): HailBlockMatrix = {
+    requireZippable(hbm2)
+    requireZippable(hbm3)
+    val blocks2 = blocks.join(hbm2.blocks).join(hbm3.blocks).mapValues { case ((m1, m2), m3) =>
+      val src1 = m1.data
+      val src2 = m2.data
+      val src3 = m3.data
+      val dst = new Array[Double](src1.length)
+      var i = 0
+      while (i < src1.length) {
+        dst(i) = op(src1(i), src2(i), src3(i))
+        i += 1
+      }
+      new BDM(m1.rows, m1.cols, dst)
+    }
+    new HailBlockMatrix(blocks2, blockSize, rows, cols)
+  }
+
+  def map4(hbm2: HailBlockMatrix, hbm3: HailBlockMatrix, hbm4: HailBlockMatrix, op: (Double, Double, Double, Double) => Double): HailBlockMatrix = {
+    requireZippable(hbm2)
+    requireZippable(hbm3)
+    requireZippable(hbm4)
+    val blocks2 = blocks.join(hbm2.blocks).join(hbm3.blocks).join(hbm4.blocks).mapValues { case (((m1, m2), m3), m4) =>
+      val src1 = m1.data
+      val src2 = m2.data
+      val src3 = m3.data
+      val src4 = m4.data
+      val dst = new Array[Double](src1.length)
+      var i = 0
+      while (i < src1.length) {
+        dst(i) = op(src1(i), src2(i), src3(i), src4(i))
+        i += 1
+      }
+      new BDM(m1.rows, m1.cols, dst)
+    }
+    new HailBlockMatrix(blocks2, blockSize, rows, cols)
+  }
+
+  def mapWithIndex(op: (Long, Long, Double) => Double): HailBlockMatrix = {
+    val blockSize = this.blockSize
+    val blocks2 = blocks.mapValuesWithKey { case ((blocki, blockj), m) =>
+      val iprefix = blocki.toLong * blockSize
+      val jprefix = blockj.toLong * blockSize
+      val size = m.cols * m.rows
+      val result = new Array[Double](size)
+      var j = 0
+      while (j < m.cols) {
+        var i = 0
+        while (i < m.rows) {
+          result(i + j*m.rows) = op(iprefix + i, jprefix + j, m(i, j))
+          i += 1
+        }
+        j += 1
+      }
+      new BDM(m.rows, m.cols, result)
+    }
+    new HailBlockMatrix(blocks2, blockSize, rows, cols)
+  }
+
+  def map2WithIndex(other: HailBlockMatrix, op: (Long, Long, Double, Double) => Double): HailBlockMatrix = {
+    requireZippable(other)
+    val blockSize = this.blockSize
+    val blocks2 = blocks.join(other.blocks).mapValuesWithKey { case ((blocki, blockj), (m1, m2)) =>
+      val iprefix = blocki.toLong * blockSize
+      val jprefix = blockj.toLong * blockSize
+      val size = m1.cols * m1.rows
+      val result = new Array[Double](size)
+      var j = 0
+      while (j < m1.cols) {
+        var i = 0
+        while (i < m1.rows) {
+          result(i + j*m1.rows) = op(iprefix + i, jprefix + j, m1(i, j), m2(i, j))
+          i += 1
+        }
+        j += 1
+      }
+      new BDM(m1.rows, m1.cols, result)
+    }
+    new HailBlockMatrix(blocks2, blockSize, rows, cols)
+  }
+
+}
+
+private class HailBlockMatrixTransposeRDD(m: HailBlockMatrix)
+    extends RDD[((Int, Int), BDM[Double])](m.blocks.sparkContext, Seq[Dependency[_]](new OneToOneDependency(m.blocks))) {
+  def compute(split: Partition, context: TaskContext): Iterator[((Int, Int), BDM[Double])] =
+    m.blocks.iterator(split, context).map { case ((i, j), m) => ((j, i), m.t) }
+
+  protected def getPartitions: Array[Partition] =
+    m.blocks.partitions
+
+  private val prevPartitioner = m.partitioner
+  @transient override val partitioner: Option[Partitioner] =
+    Some(HailGridPartitioner(m.rows, m.cols, m.blockSize, transposed=true))
+}
+
+private class HailBlockMatrixMultiplyRDD(l: HailBlockMatrix, r: HailBlockMatrix)
+    extends RDD[((Int, Int), BDM[Double])](l.blocks.sparkContext, Nil) {
+  require(l.cols == r.rows,
+    s"inner dimension must match, but given: ${l.rows}x${l.cols}, ${r.rows}x${r.cols}")
+  require(l.blockSize == r.blockSize,
+    s"blocks must be same size, but actually were ${l.blockSize}x${l.blockSize} and ${r.blockSize}x${r.blockSize}")
+
+  private val lPartitioner = l.partitioner
+  private val lPartitions = l.blocks.partitions
+  private val rPartitioner = r.partitioner
+  private val rPartitions = r.blocks.partitions
+  private val rows = l.rows
+  private val cols = r.cols
+  private val blockSize = l.blockSize
+  private val rowBlocks = lPartitioner.rowPartitions
+  private val colBlocks = rPartitioner.colPartitions
+  private val nProducts = lPartitioner.colPartitions
+  private val rowsRemainder = (rows % blockSize).toInt
+  private val colsRemainder = (cols % blockSize).toInt
+  private val nParts = rowBlocks * colBlocks
+
+  override def getDependencies: Seq[Dependency[_]] =
+    Array[Dependency[_]](
+      new NarrowDependency(l.blocks) {
+        def getParents(partitionId: Int): Seq[Int] = {
+          val row = _partitioner.blockRowIndex(partitionId)
+          val deps = new Array[Int](nProducts)
+          var i = 0
+          while (i < nProducts) {
+            deps(i) = lPartitioner.partitionIdFromBlockIndices(row, i)
+            i += 1
+          }
+          deps
+        }
+      },
+      new NarrowDependency(r.blocks) {
+        def getParents(partitionId: Int): Seq[Int] = {
+          val col = _partitioner.blockColIndex(partitionId)
+          val deps = new Array[Int](nProducts)
+          var i = 0
+          while (i < nProducts) {
+            deps(i) = rPartitioner.partitionIdFromBlockIndices(i, col)
+            i += 1
+          }
+          deps
+        }
+      })
+
+  private def block(hbm: HailBlockMatrix, bmPartitions: Array[Partition], p: HailGridPartitioner, context: TaskContext, i: Int, j: Int): BDM[Double] =
+    try {
+      hbm.blocks
+        .iterator(bmPartitions(p.partitionIdFromBlockIndices(i, j)), context)
+        .next()
+        ._2
+    } catch {
+      case e: Exception => throw new RuntimeException(s"couldn't get block at $i, $j with partition id ${p.partitionIdFromBlockIndices(i,j)}; ${l.rows} ${l.cols} ${l.blockSize}; ${r.rows} ${r.cols} ${r.blockSize}; --- ; ${lPartitions.toSeq}, ${rPartitions.toSeq} ;; $nParts ;; $rowBlocks, $colBlocks", e)
+    }
+
+  private def leftBlock(i: Int, j: Int, context: TaskContext): BDM[Double] =
+    block(l, lPartitions, lPartitioner, context, i, j)
+  private def rightBlock(i: Int, j: Int, context: TaskContext): BDM[Double] =
+    block(r, rPartitions, rPartitioner, context, i, j)
+
+  def compute(split: Partition, context: TaskContext): Iterator[((Int, Int), BDM[Double])] = {
+    val row = _partitioner.blockRowIndex(split.index)
+    val col = _partitioner.blockColIndex(split.index)
+    val rowsInThisBlock: Int = if (row + 1 == rowBlocks && rowsRemainder != 0) rowsRemainder else blockSize
+    val colsInThisBlock: Int = if (col + 1 == colBlocks && colsRemainder != 0) colsRemainder else blockSize
+
+    val result = BDM.zeros[Double](rowsInThisBlock, colsInThisBlock)
+    var i = 0
+    while (i < nProducts) {
+      val left = leftBlock(row, i, context)
+      val right = rightBlock(i, col, context)
+      try {
+        result :+= (left * right)
+      } catch {
+        case e: Exception => throw new RuntimeException(s"$row , $i , $col ;; $rowBlocks , $nProducts , $colBlocks ;; ${result.rows} x ${result.cols} :+= (${left.rows} x ${left.cols} * ${right.rows} x ${right.cols})", e)
+      }
+      i += 1
+    }
+
+    Iterator.single(((row, col), result))
+  }
+
+  protected def getPartitions: Array[Partition] =
+    (0 until nParts).map(IntPartition.apply _).toArray[Partition]
+
+  private val _partitioner = HailGridPartitioner(rows, cols, blockSize)
+  /** Optionally overridden by subclasses to specify how they are partitioned. */
+  @transient override val partitioner: Option[Partitioner] =
+    Some(_partitioner)
+}
+
+case class IntPartition(index: Int) extends Partition { }

--- a/src/main/scala/is/hail/distributedmatrix/HailBlockMatrixIsDistributedMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/HailBlockMatrixIsDistributedMatrix.scala
@@ -1,0 +1,238 @@
+package is.hail.distributedmatrix
+
+import is.hail._
+import is.hail.utils._
+import org.apache.spark.SparkContext
+import org.apache.spark.mllib.linalg._
+import org.apache.spark.mllib.linalg.distributed._
+import breeze.linalg.{DenseMatrix => BDM, Matrix => BM, _}
+import breeze.numerics._
+import org.apache.spark.rdd.RDD
+import org.apache.hadoop.io._
+import java.io._
+import org.json4s._
+import java.net._
+
+import scala.reflect.ClassTag
+
+object HailBlockMatrixIsDistributedMatrix extends DistributedMatrix[HailBlockMatrix] {
+  type M = HailBlockMatrix
+
+  def cache(m: M): M = m.cache()
+
+  def from(sc: SparkContext, bdm: BDM[Double], blockSize: Int): M = {
+    val partitioner = HailGridPartitioner(bdm.rows, bdm.cols, blockSize)
+    val rbc = sc.broadcast(bdm)
+    val rowBlocks = partitioner.rowPartitions
+    val colBlocks = partitioner.colPartitions
+    val rowsRemainder = bdm.rows % blockSize
+    val colsRemainder = bdm.cols % blockSize
+    val indices = for {
+      i <- 0 until rowBlocks
+      j <- 0 until colBlocks
+    } yield (i, j)
+    val rMats = sc.parallelize(indices).map { case (i, j) =>
+      val rowsInThisBlock = (if (i + 1 == rowBlocks && rowsRemainder != 0) rowsRemainder else blockSize)
+      val colsInThisBlock = (if (j + 1 == colBlocks && colsRemainder != 0) colsRemainder else blockSize)
+      val a = new Array[Double](rowsInThisBlock * colsInThisBlock)
+      for {
+        ii <- 0 until rowsInThisBlock
+        jj <- 0 until colsInThisBlock
+      } {
+        a(jj*rowsInThisBlock + ii) = rbc.value(i*blockSize + ii, j*blockSize + jj)
+      }
+      ((i, j), new BDM(rowsInThisBlock, colsInThisBlock, a))
+    }.partitionBy(partitioner)
+    new HailBlockMatrix(rMats, blockSize, bdm.rows, bdm.cols)
+  }
+  def from(irm: IndexedRowMatrix): M =
+    from(irm, true)
+  def from(irm: IndexedRowMatrix, dense: Boolean): M =
+    from(irm, dense, 1024)
+  def from(irm: IndexedRowMatrix, blockSize: Int): M =
+    from(irm, true, blockSize)
+  def from(irm: IndexedRowMatrix, dense: Boolean, blockSize: Int): M =
+    if (dense)
+      irm.toHailBlockMatrixDense()
+    else
+      ???
+  def from(bm: BlockMatrix): M = ???
+
+  def transpose(m: M): M = m.transpose()
+  def diagonal(m: M): Array[Double] = {
+    require(m.rows == m.cols,
+      s"diagonal only works on square matrices, given ${m.rows}x${m.cols}")
+
+    def diagonal(block: BDM[Double]): Array[Double] = {
+      val length = math.min(block.rows, block.cols)
+      val diagonal = new Array[Double](length)
+      var i = 0
+      while (i < length) {
+        diagonal(i) = block(i, i)
+        i += 1
+      }
+      diagonal
+    }
+
+    m.blocks
+      .filter{ case ((i, j), block) => i == j}
+      .map { case ((i, j), block) => (i, diagonal(block)) }
+      .collect()
+      .sortBy(_._1)
+      .map(_._2)
+      .fold(Array[Double]())(_ ++ _)
+  }
+
+  def multiply(l: M, r: M): M = l.multiply(r)
+  def multiply(l: M, r: BDM[Double]): M = {
+    require(l.cols == r.rows,
+      s"incompatible matrix dimensions: ${l.rows}x${l.cols} and ${r.rows}x${r.cols}")
+    multiply(l, from(l.blocks.sparkContext, r, l.blockSize))
+  }
+
+  def map4(f: (Double, Double, Double, Double) => Double)(a: M, b: M, c: M, d: M): M =
+    a.map4(b,c,d,f)
+  def map2(f: (Double, Double) => Double)(l: M, r: M): M =
+    l.map2(r,f)
+  def pointwiseAdd(l: M, r: M): M =
+    l.add(r)
+  def pointwiseSubtract(l: M, r: M): M =
+    l.subtract(r)
+  def pointwiseMultiply(l: M, r: M): M =
+    l.pointwiseMultiply(r)
+  def pointwiseDivide(l: M, r: M): M =
+    l.pointwiseDivide(r)
+  def map(f: Double => Double)(m: M): M =
+    m.map(f)
+  def scalarAdd(m: M, i: Double): M =
+    m.blockMap(_ + i)
+  def scalarSubtract(m: M, i: Double): M =
+    m.blockMap(_ - i)
+  def scalarSubtract(i: Double, m: M): M =
+    m.blockMap(i - _)
+  def scalarMultiply(m: M, i: Double): M =
+    m.blockMap(_ :* i)
+  def scalarDivide(m: M, i: Double): M =
+    m.blockMap(_ / i)
+  def scalarDivide(i: Double, m: M): M =
+    m.blockMap(i / _)
+  def vectorAddToEveryColumn(v: Array[Double])(m: M): M = {
+    require(v.length == m.rows, s"vector length, ${v.length}, must equal number of matrix rows ${m.rows}; v: $v, m: $m")
+    val vbc = m.blocks.sparkContext.broadcast(v)
+    m.mapWithIndex((i,j,x) => x + vbc.value(i.toInt))
+  }
+  def vectorPointwiseMultiplyEveryColumn(v: Array[Double])(m: M): M = {
+    require(v.length == m.rows, s"vector length, ${v.length}, must equal number of matrix rows ${m.rows}; v: $v, m: $m")
+    val vbc = m.blocks.sparkContext.broadcast(v)
+    m.mapWithIndex((i,j,x) => x * vbc.value(i.toInt))
+  }
+  def vectorPointwiseMultiplyEveryRow(v: Array[Double])(m: M): M = {
+    require(v.length == m.cols, s"vector length, ${v.length}, must equal number of matrix columns ${m.cols}; v: $v, m: $m")
+    val vbc = m.blocks.sparkContext.broadcast(v)
+    m.mapWithIndex((i,j,x) => x * vbc.value(j.toInt))
+  }
+
+  def mapRows[U](m: M, f: Array[Double] => U)(implicit uct: ClassTag[U]): RDD[U] = ???
+
+  def toBlockRdd(m: M): RDD[((Int, Int), Matrix)] = ???
+
+  def toLocalMatrix(m: M): BDM[Double] = m.toLocalMatrix()
+
+  private class PairWriter(var i: Int, var j: Int) extends Writable {
+    def this() {
+      this(0,0)
+    }
+
+    def write(out: DataOutput) {
+      out.writeInt(i)
+      out.writeInt(j)
+    }
+
+    def readFields(in: DataInput) {
+      i = in.readInt()
+      j = in.readInt()
+    }
+  }
+
+  private class MatrixWriter(var rows: Int, var cols: Int, var m: Array[Double]) extends Writable {
+    def this() {
+      this(0, 0, null)
+    }
+
+    def write(out: DataOutput) {
+      out.writeInt(rows)
+      out.writeInt(cols)
+      var i = 0
+      while (i < rows * cols) {
+        out.writeDouble(m(i))
+        i += 1
+      }
+    }
+
+    def readFields(in: DataInput) {
+      rows = in.readInt()
+      cols = in.readInt()
+      m = new Array[Double](rows * cols)
+      var i = 0
+      while (i < rows * cols) {
+        m(i) = in.readDouble()
+        i += 1
+      }
+    }
+
+    def toDenseMatrix(): DenseMatrix = {
+      new DenseMatrix(rows, cols, m)
+    }
+
+    def toBDM(): BDM[Double] = {
+      new BDM[Double](rows, cols, m)
+    }
+  }
+
+  private val metadataRelativePath = "/metadata.json"
+  private val matrixRelativePath = "/matrix"
+  /**
+    * Writes the matrix {@code m} to a Hadoop sequence file at location {@code
+    * uri}.
+    *
+    **/
+  def write(m: M, uri: String) {
+    val hadoop = m.blocks.sparkContext.hadoopConfiguration
+    hadoop.mkDir(uri)
+
+    m.blocks.map { case ((i, j), m) =>
+      (new PairWriter(i, j), new MatrixWriter(m.rows, m.cols, m.data)) }
+      .saveAsSequenceFile(uri+matrixRelativePath)
+
+    hadoop.writeDataFile(uri+metadataRelativePath) { os =>
+      jackson.Serialization.write(
+        HailBlockMatrixMetadata(m.blockSize, m.rows, m.cols),
+        os)
+    }
+  }
+
+  /**
+    * Reads a BlockMatrix matrix written by {@code write} at location {@code
+    * uri}.
+    *
+    **/
+  def read(hc: HailContext, uri: String): M = {
+    val hadoop = hc.hadoopConf
+    hadoop.mkDir(uri)
+
+    val rdd = hc.sc.sequenceFile[PairWriter, MatrixWriter](uri+matrixRelativePath).map { case (pw, mw) =>
+      ((pw.i, pw.j), mw.toBDM())
+    }
+
+    val HailBlockMatrixMetadata(blockSize, rows, cols) =
+      hadoop.readTextFile(uri+metadataRelativePath) { isr  =>
+        jackson.Serialization.read[HailBlockMatrixMetadata](isr)
+      }
+
+    new HailBlockMatrix(rdd.partitionBy(HailGridPartitioner(rows, cols, blockSize)), blockSize, rows, cols)
+  }
+}
+
+// must be top-level for Jackson to serialize correctly
+case class HailBlockMatrixMetadata(blockSize: Int, rows: Long, cols: Long)
+

--- a/src/main/scala/is/hail/distributedmatrix/HailBlockMatrixIsDistributedMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/HailBlockMatrixIsDistributedMatrix.scala
@@ -53,7 +53,7 @@ object HailBlockMatrixIsDistributedMatrix extends DistributedMatrix[HailBlockMat
     from(irm, true, blockSize)
   def from(irm: IndexedRowMatrix, dense: Boolean, blockSize: Int): M =
     if (dense)
-      irm.toHailBlockMatrixDense()
+      irm.toHailBlockMatrixDense(blockSize)
     else
       ???
   def from(bm: BlockMatrix): M = ???
@@ -105,15 +105,15 @@ object HailBlockMatrixIsDistributedMatrix extends DistributedMatrix[HailBlockMat
   def map(f: Double => Double)(m: M): M =
     m.map(f)
   def scalarAdd(m: M, i: Double): M =
-    m.blockMap(_ + i)
+    m.blockMap { x => x :+= i; x }
   def scalarSubtract(m: M, i: Double): M =
-    m.blockMap(_ - i)
+    m.blockMap { x => x :-= i; x }
   def scalarSubtract(i: Double, m: M): M =
     m.blockMap(i - _)
   def scalarMultiply(m: M, i: Double): M =
-    m.blockMap(_ :* i)
+    m.blockMap { x => x :*= i; x }
   def scalarDivide(m: M, i: Double): M =
-    m.blockMap(_ / i)
+    m.blockMap { x => x :/= i; x }
   def scalarDivide(i: Double, m: M): M =
     m.blockMap(i / _)
   def vectorAddToEveryColumn(v: Array[Double])(m: M): M = {

--- a/src/main/scala/is/hail/distributedmatrix/HailGridPartitioner.scala
+++ b/src/main/scala/is/hail/distributedmatrix/HailGridPartitioner.scala
@@ -1,0 +1,53 @@
+package is.hail.distributedmatrix
+
+import org.apache.spark.Partitioner
+
+case class HailGridPartitioner(rows: Long, cols: Long, blockSize: Int, transposed: Boolean = false) extends Partitioner {
+  require(rows > 0)
+  require(cols > 0)
+  require((rows - 1) / blockSize + 1 < Int.MaxValue)
+  require((cols - 1) / blockSize + 1 < Int.MaxValue)
+
+  private val untransposedRowPartitions = ((rows - 1) / blockSize + 1).toInt
+  private val untransposedColPartitions = ((cols - 1) / blockSize + 1).toInt
+
+  val rowPartitions = if (transposed) untransposedColPartitions else untransposedRowPartitions
+  val colPartitions = if (transposed) untransposedRowPartitions else untransposedColPartitions
+
+  override val numPartitions: Int = rowPartitions * colPartitions
+
+  override def getPartition(key: Any): Int = key match {
+    case (i: Int, j: Int) => partitionIdFromBlockIndices(i, j)
+  }
+
+  def blockRowIndex(pid: Int) =
+    if (transposed) pid / rowPartitions else pid % rowPartitions
+  def blockColIndex(pid: Int) =
+    if (transposed) pid % rowPartitions else pid / rowPartitions
+  def blockCoordinates(pid: Int) =
+    (blockRowIndex(pid), blockColIndex(pid))
+
+  def partitionIdFromBlockIndices(i: Int, j: Int): Int = {
+    if (transposed) {
+      require(0 <= j && j < untransposedRowPartitions, s"Row index $j out of range [0, $untransposedRowPartitions).")
+      require(0 <= i && i < untransposedColPartitions, s"Column index $i out of range [0, $untransposedColPartitions).")
+      j + i * untransposedRowPartitions
+    } else {
+      require(0 <= i && i < untransposedRowPartitions, s"Row index $i out of range [0, $untransposedRowPartitions).")
+      require(0 <= j && j < untransposedColPartitions, s"Column index $j out of range [0, $untransposedColPartitions).")
+      i + j * untransposedRowPartitions
+    }
+  }
+
+  def partitionIdFromGlobalIndices(i: Int, j: Int): Int = {
+    if (transposed) {
+      require(0 <= j && j < rows, s"Row index $j out of range [0, $rows).")
+      require(0 <= i && i < cols, s"Column index $i out of range [0, $cols).")
+      partitionIdFromBlockIndices(j / blockSize, i / blockSize)
+    } else {
+      require(0 <= i && i < rows, s"Row index $i out of range [0, $rows).")
+      require(0 <= j && j < cols, s"Column index $j out of range [0, $cols).")
+      partitionIdFromBlockIndices(i / blockSize, j / blockSize)
+    }
+  }
+}

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -48,7 +48,6 @@ object PCRelate {
     val Result(phi, k0, k1, k2) = apply(vds, pcs, maf, blockSize, desire)
     val m = phi.rows
     val n = phi.cols
-    val blockSize = phi.blockSize
 
     def fuseBlocks(blocki: Int, blockj: Int, mk1: BDM[Double], mk2: BDM[Double], mk3: BDM[Double], mk4: BDM[Double]) = {
       val i = blocki * blockSize
@@ -61,7 +60,7 @@ object PCRelate {
         i < j2 && j2 < i2 ||
         j <= i && i < j2 ||
         j < i2 && i2 < j2) {
-        val size = mk1.numRows * mk1.numCols
+        val size = mk1.rows * mk1.cols
         val ab = new ArrayBuilder[Row]()
         var jj = 1
         while (jj < mk1.cols) {

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -51,22 +51,27 @@ object PCRelate {
         j < i2 && i2 < j2) {
         val size = m1.numRows * m1.numCols
         val ab = new ArrayBuilder[Row]()
-        var jj = 1
-        while (jj < m1.numCols) {
-          // fixme: broken for non-square blocks
-          var ii = 0
-          val rowsAboveDiagonal = if (blocki < blockj) m1.numRows else jj
-          while (ii < rowsAboveDiagonal) {
-            val kin = m1(ii, jj)
-            if (kin >= minKinship) {
-              val k0 = m2(ii, jj)
-              val k1 = m3(ii, jj)
-              val k2 = m4(ii, jj)
-              ab += Annotation(indexToId(i + ii), indexToId(j + jj), kin, k0, k1, k2).asInstanceOf[Row]
+        try {
+          var jj = 1
+          while (jj < m1.numCols) {
+            // fixme: broken for non-square blocks
+            var ii = 0
+            val rowsAboveDiagonal = if (blocki < blockj) m1.numRows else jj
+            while (ii < rowsAboveDiagonal) {
+              val kin = m1(ii, jj)
+              if (kin >= minKinship) {
+                val k0 = m2(ii, jj)
+                val k1 = m3(ii, jj)
+                val k2 = m4(ii, jj)
+                ab += Annotation(indexToId(i + ii), indexToId(j + jj), kin, k0, k1, k2).asInstanceOf[Row]
+              }
+              ii += 1
             }
-            ii += 1
+            jj += 1
           }
-          jj += 1
+        } catch {
+          case e: Exception =>
+            throw new RuntimeException(s"$i, $j; $blocki, $blockj; $i2, $j2; ${m1.numRows}, ${m1.numCols}", e)
         }
         ab.result()
       } else

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -21,24 +21,31 @@ object PCRelate {
   val dm = BlockMatrixIsDistributedMatrix
   import dm.ops._
 
+  type Desire = Int
+  val PhiOnly: Desire = 0
+  val PhiK2: Desire = 1
+  val PhiK2K0: Desire = 2
+  val PhiK2K0K1: Desire = 3
+
   case class Result[M](phiHat: M, k0: M, k1: M, k2: M) {
     def map[N](f: M => N): Result[N] = Result(f(phiHat), f(k0), f(k1), f(k2))
   }
 
   val defaultMinKinship = Double.NegativeInfinity
+  val defaultDesire: Desire = PhiK2K0K1
 
-  def apply(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int): Result[M] =
-    new PCRelate(maf, blockSize)(vds, pcs)
+  def apply(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int, desire: Desire = defaultDesire): Result[M] =
+    new PCRelate(maf, blockSize)(vds, pcs, desire)
 
   private val signature =
     TStruct(("i", TString), ("j", TString), ("kin", TDouble), ("k0", TDouble), ("k1", TDouble), ("k2", TDouble))
   private val keys = Array("i", "j")
 
-  private def toRowRdd(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int, minKinship: Double): RDD[Row] = {
+  private def toRowRdd(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int, minKinship: Double, desire: Desire): RDD[Row] = {
     val indexToId: Map[Int, Annotation] = vds.sampleIds.zipWithIndex.map { case (id, index) => (index, id) }.toMap
-    val Result(phi, k0, k1, k2) = apply(vds, pcs, maf, blockSize)
+    val Result(phi, k0, k1, k2) = apply(vds, pcs, maf, blockSize, desire)
 
-    (phi.blocks join k0.blocks join k1.blocks join k2.blocks).flatMap { case ((blocki, blockj), (((m1, m2), m3), m4)) =>
+    def fuseBlocks(blocki: Int, blockj: Int, mk1: Matrix, mk2: Matrix, mk3: Matrix, mk4: Matrix) = {
       val i = blocki * phi.rowsPerBlock
       val j = blockj * phi.colsPerBlock
       val i2 = i + phi.rowsPerBlock
@@ -49,42 +56,48 @@ object PCRelate {
         i < j2 && j2 < i2 ||
         j <= i && i < j2 ||
         j < i2 && i2 < j2) {
-        val size = m1.numRows * m1.numCols
+        val size = mk1.numRows * mk1.numCols
         val ab = new ArrayBuilder[Row]()
-        try {
-          var jj = 1
-          while (jj < m1.numCols) {
-            // fixme: broken for non-square blocks
-            var ii = 0
-            val rowsAboveDiagonal = if (blocki < blockj) m1.numRows else jj
-            while (ii < rowsAboveDiagonal) {
-              val kin = m1(ii, jj)
-              if (kin >= minKinship) {
-                val k0 = m2(ii, jj)
-                val k1 = m3(ii, jj)
-                val k2 = m4(ii, jj)
-                ab += Annotation(indexToId(i + ii), indexToId(j + jj), kin, k0, k1, k2).asInstanceOf[Row]
-              }
-              ii += 1
+        var jj = 1
+        while (jj < mk1.numCols) {
+          // fixme: broken for non-square blocks
+          var ii = 0
+          val rowsAboveDiagonal = if (blocki < blockj) mk1.numRows else jj
+          while (ii < rowsAboveDiagonal) {
+            val kin = mk1(ii, jj)
+            if (kin >= minKinship) {
+              val k0 = if (mk2 == null) null else mk2(ii, jj)
+              val k1 = if (mk3 == null) null else mk3(ii, jj)
+              val k2 = if (mk4 == null) null else mk4(ii, jj)
+              ab += Annotation(indexToId(i + ii), indexToId(j + jj), kin, k0, k1, k2).asInstanceOf[Row]
             }
-            jj += 1
+            ii += 1
           }
-        } catch {
-          case e: Exception =>
-            throw new RuntimeException(s"$i, $j; $blocki, $blockj; $i2, $j2; ${m1.numRows}, ${m1.numCols}", e)
+          jj += 1
         }
         ab.result()
       } else
         new Array[Row](0)
     }
+
+    desire match {
+      case PhiOnly => phi.blocks
+          .flatMap { case ((blocki, blockj), phi) => fuseBlocks(blocki, blockj, phi, null, null, null) }
+      case PhiK2 => (phi.blocks join k2.blocks)
+          .flatMap { case ((blocki, blockj), (phi, k2)) => fuseBlocks(blocki, blockj, phi, null, null, k2) }
+      case PhiK2K0 => (phi.blocks join k0.blocks join k2.blocks)
+          .flatMap { case ((blocki, blockj), ((phi, k0), k2)) => fuseBlocks(blocki, blockj, phi, k0, null, k2) }
+      case PhiK2K0K1 => (phi.blocks join k0.blocks join k1.blocks join k2.blocks)
+          .flatMap { case ((blocki, blockj), (((phi, k0), k1), k2)) => fuseBlocks(blocki, blockj, phi, k0, k1, k2) }
+    }
   }
 
-  def toKeyTable(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int, minKinship: Double = defaultMinKinship): KeyTable =
-    KeyTable(vds.hc, toRowRdd(vds, pcs, maf, blockSize, minKinship), signature, keys)
+  def toKeyTable(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int, minKinship: Double = defaultMinKinship, desire: Desire = defaultDesire): KeyTable =
+    KeyTable(vds.hc, toRowRdd(vds, pcs, maf, blockSize, minKinship, desire), signature, keys)
 
-  def toPairRdd(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int, minKinship: Double = defaultMinKinship)
+  def toPairRdd(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int, minKinship: Double = defaultMinKinship, desire: Desire = defaultDesire)
       : RDD[((Annotation, Annotation), (Double, Double, Double, Double))] =
-     toRowRdd(vds, pcs, maf, blockSize, minKinship)
+     toRowRdd(vds, pcs, maf, blockSize, minKinship, desire)
        .map(r => ((r(0), r(1)), (r(2).asInstanceOf[Double], r(3).asInstanceOf[Double], r(4).asInstanceOf[Double], r(5).asInstanceOf[Double])))
 
   private val k0cutoff = math.pow(2.0, (-5.0 / 2.0))
@@ -178,7 +191,7 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
   def badgt(gt: Double): Boolean =
     gt != 0.0 && gt != 1.0 && gt != 2.0
 
-  def apply(vds: VariantDataset, pcs: DenseMatrix): Result[M] = {
+  def apply(vds: VariantDataset, pcs: DenseMatrix, desire: Desire = defaultDesire): Result[M] = {
     val g = vdsToMeanImputedMatrix(vds)
 
     val mu = this.mu(g, pcs)
@@ -193,11 +206,19 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
 
     val phi = this.phi(mu, variance, blockedG)
 
-    val k2 = this.k2(phi, mu, variance, blockedG)
-    val k0 = this.k0(phi, mu, k2, blockedG, ibs0(blockedG, mu, blockSize))
-    val k1 = 1.0 - (k2 :+ k0)
-
-    Result(phi, k0, k1, k2)
+    if (desire >= PhiK2) {
+      val k2 = this.k2(phi, mu, variance, blockedG)
+      if (desire >= PhiK2K0) {
+        val k0 = this.k0(phi, mu, k2, blockedG, ibs0(blockedG, mu, blockSize))
+        if (desire >= PhiK2K0K1) {
+          val k1 = 1.0 - (k2 :+ k0)
+          Result(phi, k0, k1, k2)
+        } else
+          Result(phi, k0, null, k2)
+      } else
+        Result(phi, null, null, k2)
+    } else
+      Result(phi, null, null, null)
   }
 
   /**

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -157,7 +157,7 @@ object PCRelate {
         new IndexedRow(variantIdxBc.value(v), new DenseVector(a))
       }
     }
-    new IndexedRowMatrix(rdd, variants.length, nSamples)
+    new IndexedRowMatrix(rdd.cache(), variants.length, nSamples)
   }
 
   /**
@@ -194,12 +194,16 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
     mu <= maf || mu >= antimaf || mu <= 0.0 || mu >= 1.0
   def badgt(gt: Double): Boolean =
     gt != 0.0 && gt != 1.0 && gt != 2.0
+  private def gram(m: M): M = {
+    val mc = m.cache()
+    mc.t * mc
+  }
 
   def apply(vds: VariantDataset, pcs: DenseMatrix, desire: Desire = defaultDesire): Result[M] = {
     val g = vdsToMeanImputedMatrix(vds)
 
-    val mu = this.mu(g, pcs)
-    val blockedG = dm.from(g, blockSize)
+    val mu = this.mu(g, pcs).cache()
+    val blockedG = dm.from(g, blockSize).cache()
 
     val variance = dm.map2 { (g, mu) =>
       if (badgt(g) || badmu(mu))
@@ -208,7 +212,7 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
         mu * (1.0 - mu)
     }(blockedG, mu)
 
-    val phi = this.phi(mu, variance, blockedG)
+    val phi = this.phi(mu, variance, blockedG).cache()
 
     if (desire >= PhiK2) {
       val k2 = this.k2(phi, mu, variance, blockedG)
@@ -247,16 +251,16 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
     }(g, mu)
     val stddev = dm.map(math.sqrt _)(variance)
 
-    ((centeredG.t * centeredG) :/ (stddev.t * stddev)) / 4.0
+    (gram(centeredG.t) :/ gram(stddev.t)) / 4.0
   }
 
   private[methods] def ibs0(g: M, mu: M, blockSize: Int): M = {
-    val homalt = dm.map2 { (g, mu) =>
+    val homalt = (dm.map2 { (g, mu) =>
       if (badgt(g) || badmu(mu) || g != 2.0) 0.0 else 1.0
-    } (g, mu)
-    val homref = dm.map2 { (g, mu) =>
+    } (g, mu)).cache()
+    val homref = (dm.map2 { (g, mu) =>
       if (badgt(g) || badmu(mu) || g != 0.0) 0.0 else 1.0
-    } (g, mu)
+    } (g, mu)).cache
     (homalt.t * homref) :+ (homref.t * homalt)
   }
 
@@ -274,22 +278,22 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
         }
     })
 
-    (normalizedGD.t * normalizedGD) :/ (variance.t * variance)
+    gram(normalizedGD.t) :/ gram(variance.t)
   }
 
   private[methods] def k0(phi: M, mu: M, k2: M, g: M, ibs0: M): M = {
-    val mu2 = dm.map2 { (g, mu) =>
+    val mu2 = (dm.map2 { (g, mu) =>
       if (badgt(g) || badmu(mu))
         0.0
       else
         mu * mu
-    }(g, mu)
-    val oneMinusMu2 = dm.map2 { (g, mu) =>
+    }(g, mu)).cache()
+    val oneMinusMu2 = (dm.map2 { (g, mu) =>
       if (badgt(g) || badmu(mu))
         0.0
       else
         (1.0 - mu) * (1.0 - mu)
-    }(g, mu)
+    }(g, mu)).cache()
     val denom = (mu2.t * oneMinusMu2) :+ (oneMinusMu2.t * mu2)
     dm.map4 { (phi: Double, denom: Double, k2: Double, ibs0: Double) =>
       if (phi <= k0cutoff)

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -25,45 +25,7 @@ object PCRelate {
     def map[N](f: M => N): Result[N] = Result(f(phiHat), f(k0), f(k1), f(k2))
   }
 
-  def toPairRdd(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int): RDD[((Annotation, Annotation), (Double, Double, Double, Double))] = {
-    val indexToId: Map[Int, Annotation] = vds.sampleIds.zipWithIndex.map { case (id, index) => (index, id) }.toMap
-    def upperTriangularEntires(bm: BlockMatrix): RDD[((Annotation, Annotation), Double)] = {
-      val rowsPerBlock = bm.rowsPerBlock
-      val colsPerBlock = bm.colsPerBlock
-
-      bm.blocks.filter { case ((blocki, blockj), m) =>
-        blocki < blockj || {
-          val i = blocki * rowsPerBlock
-          val j = blockj * colsPerBlock
-          val i2 = i + rowsPerBlock
-          val j2 = i + colsPerBlock
-          i <= j && j < i2 ||
-          i < j2 && j2 < i2 ||
-          j <= i && i < j2 ||
-          j < i2 && i2 < j2
-        }
-      }.flatMap { case ((blocki, blockj), m) =>
-          val ioffset = blocki * rowsPerBlock
-          val joffset = blockj * colsPerBlock
-          for {
-            i <- 0 until m.numRows
-            // FIXME: only works with square blocks
-            jstart = if (blocki < blockj) 0 else i+1
-            j <- jstart until m.numCols
-          } yield ((indexToId(i + ioffset), indexToId(j + joffset)), m(i, j))
-      }
-    }
-
-    val result = apply(vds, pcs, maf, blockSize)
-
-    val a = upperTriangularEntires(result.phiHat)
-    val b = upperTriangularEntires(result.k0)
-    val c = upperTriangularEntires(result.k1)
-    val d = upperTriangularEntires(result.k2)
-
-    (a join b join c join d)
-        .mapValues { case (((kin, k0), k1), k2) => (kin, k0, k1, k2) }
-  }
+  val defaultMinKinship = Double.NegativeInfinity
 
   def apply(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int): Result[M] =
     new PCRelate(maf, blockSize)(vds, pcs)
@@ -72,11 +34,53 @@ object PCRelate {
     TStruct(("i", TString), ("j", TString), ("kin", TDouble), ("k0", TDouble), ("k1", TDouble), ("k2", TDouble))
   private val keys = Array("i", "j")
 
-  def toKeyTable(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int): KeyTable =
-    KeyTable(vds.hc,
-      toPairRdd(vds, pcs, maf, blockSize).map { case ((i, j), (kin, k0, k1, k2)) => Annotation(i, j, kin, k0, k1, k2).asInstanceOf[Row] },
-      signature,
-      keys)
+  private def toRowRdd(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int, minKinship: Double): RDD[Row] = {
+    val indexToId: Map[Int, Annotation] = vds.sampleIds.zipWithIndex.map { case (id, index) => (index, id) }.toMap
+    val Result(phi, k0, k1, k2) = apply(vds, pcs, maf, blockSize)
+
+    (phi.blocks join k0.blocks join k1.blocks join k2.blocks).flatMap { case ((blocki, blockj), (((m1, m2), m3), m4)) =>
+      val i = blocki * phi.rowsPerBlock
+      val j = blockj * phi.colsPerBlock
+      val i2 = i + phi.rowsPerBlock
+      val j2 = i + phi.colsPerBlock
+
+      if (blocki < blockj ||
+        i <= j && j < i2 ||
+        i < j2 && j2 < i2 ||
+        j <= i && i < j2 ||
+        j < i2 && i2 < j2) {
+        val size = m1.numRows * m1.numCols
+        val ab = new ArrayBuilder[Row]()
+        var jj = 1
+        while (jj < m1.numCols) {
+          // fixme: broken for non-square blocks
+          var ii = 0
+          val rowsAboveDiagonal = if (blocki < blockj) m1.numRows else jj
+          while (ii < rowsAboveDiagonal) {
+            val kin = m1(ii, jj)
+            if (kin >= minKinship) {
+              val k0 = m2(ii, jj)
+              val k1 = m3(ii, jj)
+              val k2 = m4(ii, jj)
+              ab += Annotation(indexToId(i + ii), indexToId(j + jj), kin, k0, k1, k2).asInstanceOf[Row]
+            }
+            ii += 1
+          }
+          jj += 1
+        }
+        ab.result()
+      } else
+        new Array[Row](0)
+    }
+  }
+
+  def toKeyTable(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int, minKinship: Double = defaultMinKinship): KeyTable =
+    KeyTable(vds.hc, toRowRdd(vds, pcs, maf, blockSize, minKinship), signature, keys)
+
+  def toPairRdd(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int, minKinship: Double = defaultMinKinship)
+      : RDD[((Annotation, Annotation), (Double, Double, Double, Double))] =
+     toRowRdd(vds, pcs, maf, blockSize, minKinship)
+       .map(r => ((r(0), r(1)), (r(2).asInstanceOf[Double], r(3).asInstanceOf[Double], r(4).asInstanceOf[Double], r(5).asInstanceOf[Double])))
 
   private val k0cutoff = math.pow(2.0, (-5.0 / 2.0))
 

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -184,12 +184,11 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
     val mu = this.mu(g, pcs)
     val blockedG = dm.from(g, blockSize, blockSize)
 
-    val variance = dm.map2 {
-      case (g, mu) =>
-        if (badgt(g) || badmu(mu))
-          0.0
-        else
-          mu * (1.0 - mu)
+    val variance = dm.map2 { (g, mu) =>
+      if (badgt(g) || badmu(mu))
+        0.0
+      else
+        mu * (1.0 - mu)
     }(blockedG, mu)
 
     val phi = this.phi(mu, variance, blockedG)
@@ -227,10 +226,10 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
   }
 
   private[methods] def ibs0(g: M, mu: M, blockSize: Int): M = {
-    val homalt = dm.map2 { case (g, mu) =>
+    val homalt = dm.map2 { (g, mu) =>
       if (badgt(g) || badmu(mu) || g != 2.0) 0.0 else 1.0
     } (g, mu)
-    val homref = dm.map2 { case (g, mu) =>
+    val homref = dm.map2 { (g, mu) =>
       if (badgt(g) || badmu(mu) || g != 0.0) 0.0 else 1.0
     } (g, mu)
     (homalt.t * homref) :+ (homref.t * homalt)
@@ -238,7 +237,7 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
 
   private[methods] def k2(phi: M, mu: M, variance: M, g: M): M = {
     val twoPhi_ii = dm.diagonal(phi).map(2.0 * _)
-    val normalizedGD = dm.map2WithIndex { case (_, i, g, mu) =>
+    val normalizedGD = dm.map2WithIndex { (_, i, g, mu) =>
         if (badmu(mu) || badgt(g))
           0.0  // https://github.com/Bioconductor-mirror/GENESIS/blob/release-3.5/R/pcrelate.R#L391
         else {
@@ -254,19 +253,17 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
   }
 
   private[methods] def k0(phi: M, mu: M, k2: M, g: M, ibs0: M): M = {
-    val mu2 = dm.map2 {
-      case (g, mu) =>
-        if (badgt(g) || badmu(mu))
-          0.0
-        else
-          mu * mu
+    val mu2 = dm.map2 { (g, mu) =>
+      if (badgt(g) || badmu(mu))
+        0.0
+      else
+        mu * mu
     }(g, mu)
-    val oneMinusMu2 = dm.map2 {
-      case (g, mu) =>
-        if (badgt(g) || badmu(mu))
-          0.0
-        else
-          (1.0 - mu) * (1.0 - mu)
+    val oneMinusMu2 = dm.map2 { (g, mu) =>
+      if (badgt(g) || badmu(mu))
+        0.0
+      else
+        (1.0 - mu) * (1.0 - mu)
     }(g, mu)
     val denom = (mu2.t * oneMinusMu2) :+ (oneMinusMu2.t * mu2)
     dm.map4 { (phi: Double, denom: Double, k2: Double, ibs0: Double) =>

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -215,9 +215,9 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
     val phi = this.phi(mu, variance, blockedG).cache()
 
     if (desire >= PhiK2) {
-      val k2 = this.k2(phi, mu, variance, blockedG)
+      val k2 = this.k2(phi, mu, variance, blockedG).cache()
       if (desire >= PhiK2K0) {
-        val k0 = this.k0(phi, mu, k2, blockedG, ibs0(blockedG, mu, blockSize))
+        val k0 = this.k0(phi, mu, k2, blockedG, ibs0(blockedG, mu, blockSize)).cache()
         if (desire >= PhiK2K0K1) {
           val k1 = 1.0 - (k2 :+ k0)
           Result(phi, k0, k1, k2)
@@ -251,7 +251,7 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
     }(g, mu)
     val stddev = dm.map(math.sqrt _)(variance)
 
-    (gram(centeredG.t) :/ gram(stddev.t)) / 4.0
+    (gram(centeredG) :/ gram(stddev)) / 4.0
   }
 
   private[methods] def ibs0(g: M, mu: M, blockSize: Int): M = {
@@ -278,7 +278,7 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
         }
     })
 
-    gram(normalizedGD.t) :/ gram(variance.t)
+    gram(normalizedGD) :/ gram(variance)
   }
 
   private[methods] def k0(phi: M, mu: M, k2: M, g: M, ibs0: M): M = {

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -42,7 +42,7 @@ object PCRelate {
       val i = blocki * phi.rowsPerBlock
       val j = blockj * phi.colsPerBlock
       val i2 = i + phi.rowsPerBlock
-      val j2 = i + phi.colsPerBlock
+      val j2 = j + phi.colsPerBlock
 
       if (blocki < blockj ||
         i <= j && j < i2 ||

--- a/src/main/scala/is/hail/utils/richUtils/RichIndexedRowMatrix.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichIndexedRowMatrix.scala
@@ -1,5 +1,7 @@
 package is.hail.utils.richUtils
 
+import breeze.linalg.{DenseMatrix => BDM}
+import is.hail.distributedmatrix._
 import org.apache.spark.mllib.linalg.{DenseMatrix, Matrix}
 import org.apache.spark.mllib.linalg.distributed.{BlockMatrix, IndexedRowMatrix}
 import org.apache.spark.rdd.RDD
@@ -61,6 +63,53 @@ class RichIndexedRowMatrix(indexedRowMatrix: IndexedRowMatrix) {
         new DenseMatrix(actualNumRows, actualNumColumns, matrixAsArray)
     }
     new BlockMatrix(blocks, rowsPerBlock, colsPerBlock, m, n)
+  }
+
+  def toHailBlockMatrixDense(): HailBlockMatrix = {
+    toHailBlockMatrixDense(1024)
+  }
+
+  def toHailBlockMatrixDense(blockSize: Int): HailBlockMatrix = {
+    require(blockSize > 0,
+      s"rowsPerBlock needs to be greater than 0. rowsPerBlock: $blockSize")
+
+    val m = indexedRowMatrix.numRows()
+    val n = indexedRowMatrix.numCols()
+    val lastRowBlockIndex = m / blockSize
+    val lastColBlockIndex = n / blockSize
+    val lastRowBlockSize = (m % blockSize).toInt
+    val lastColBlockSize = (n % blockSize).toInt
+    val numRowBlocks = (m / blockSize + (if (m % blockSize == 0) 0 else 1)).toInt
+    val numColBlocks = (n / blockSize + (if (n % blockSize == 0) 0 else 1)).toInt
+
+
+    val blocks: RDD[((Int, Int), BDM[Double])] = indexedRowMatrix.rows.flatMap{ ir =>
+      val blockRow = ir.index / blockSize
+      val rowInBlock = ir.index % blockSize
+
+      ir.vector.toArray
+        .grouped(blockSize)
+        .zipWithIndex
+        .map{ case (values, blockColumn) =>
+          ((blockRow.toInt, blockColumn), (rowInBlock.toInt, values))
+        }
+    }.groupByKey(HailGridPartitioner(m, n, blockSize)).mapValuesWithKey{
+      case ((blockRow, blockColumn), itr) =>
+        val actualNumRows: Int = if (blockRow == lastRowBlockIndex) lastRowBlockSize else blockSize
+        val actualNumColumns: Int = if (blockColumn == lastColBlockIndex) lastColBlockSize else blockSize
+
+        val arraySize = actualNumRows * actualNumColumns
+        val matrixAsArray = new Array[Double](arraySize)
+        itr.foreach{ case (rowWithinBlock, values) =>
+          var i = 0
+          while (i < values.length) {
+            matrixAsArray.update(i * actualNumRows + rowWithinBlock, values(i))
+            i += 1
+          }
+        }
+        new BDM[Double](actualNumRows, actualNumColumns, matrixAsArray)
+    }
+    new HailBlockMatrix(blocks, blockSize, m, n)
   }
 }
 

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -677,7 +677,7 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     *                  these matrices fit in memory (in addition to all other
     *                  objects necessary for Spark and Hail).
     */
-  def pcRelate(k: Int, maf: Double, blockSize: Int, minKinship: Int = PCRelate.defaultMinKinship): KeyTable = {
+  def pcRelate(k: Int, maf: Double, blockSize: Int, minKinship: Double = PCRelate.defaultMinKinship): KeyTable = {
     requireSplit("PCRelate")
     val pcs = SamplePCA.justScores(vds, k)
     PCRelate.toKeyTable(vds, pcs, maf, blockSize, minKinship)

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -677,10 +677,10 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     *                  these matrices fit in memory (in addition to all other
     *                  objects necessary for Spark and Hail).
     */
-  def pcRelate(k: Int, maf: Double, blockSize: Int): KeyTable = {
+  def pcRelate(k: Int, maf: Double, blockSize: Int, minKinship: Int = PCRelate.defaultMinKinship): KeyTable = {
     requireSplit("PCRelate")
     val pcs = SamplePCA.justScores(vds, k)
-    PCRelate.toKeyTable(vds, pcs, maf, blockSize)
+    PCRelate.toKeyTable(vds, pcs, maf, blockSize, minKinship)
   }
 
   def sampleQC(root: String = "sa.qc", keepStar: Boolean = false): VariantDataset = SampleQC(vds, root, keepStar)

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -677,10 +677,10 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     *                  these matrices fit in memory (in addition to all other
     *                  objects necessary for Spark and Hail).
     */
-  def pcRelate(k: Int, maf: Double, blockSize: Int, minKinship: Double = PCRelate.defaultMinKinship): KeyTable = {
+  def pcRelate(k: Int, maf: Double, blockSize: Int, minKinship: Double = PCRelate.defaultMinKinship, desire: PCRelate.Desire = PCRelate.defaultDesire): KeyTable = {
     requireSplit("PCRelate")
     val pcs = SamplePCA.justScores(vds, k)
-    PCRelate.toKeyTable(vds, pcs, maf, blockSize, minKinship)
+    PCRelate.toKeyTable(vds, pcs, maf, blockSize, minKinship, desire)
   }
 
   def sampleQC(root: String = "sa.qc", keepStar: Boolean = false): VariantDataset = SampleQC(vds, root, keepStar)

--- a/src/test/scala/is/hail/distributedmatrix/HailBlockMatrixIsDistributedMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/HailBlockMatrixIsDistributedMatrixSuite.scala
@@ -1,0 +1,388 @@
+package is.hail.distributedmatrix
+
+import is.hail.check.Arbitrary._
+import is.hail.check.Prop._
+import is.hail.check.Gen._
+import is.hail.check._
+import is.hail.utils._
+import is.hail.SparkSuite
+
+import breeze.linalg.{DenseMatrix => BDM, DenseVector => BDV, _}
+import org.apache.spark.rdd.RDD
+import org.testng.annotations.Test
+import scala.reflect.ClassTag
+import org.scalactic._
+
+import scala.util.Random
+
+class HailBlockMatrixIsDistributedMatrixSuite extends SparkSuite {
+  import is.hail.distributedmatrix.DistributedMatrix.implicits._
+
+  val dm = HailBlockMatrixIsDistributedMatrix
+  import dm.ops._
+
+  private val defaultBlockSize = 1024
+
+  def toBM(rows: Seq[Array[Double]]): HailBlockMatrix =
+    toBM(rows, defaultBlockSize)
+
+  def toBM(rows: Seq[Array[Double]], blockSize: Int): HailBlockMatrix = {
+    val n = rows.length
+    val m = if (n == 0) 0 else rows(0).length
+
+    dm.from(sc, new BDM[Double](m, n, rows.flatten.toArray).t, blockSize)
+  }
+
+  def toBM(x: BDM[Double]): HailBlockMatrix =
+    toBM(x, defaultBlockSize)
+
+  def toBM(x: BDM[Double], blockSize: Int): HailBlockMatrix =
+    dm.from(sc, x, blockSize)
+
+  def toBreeze(a: Array[Double]): BDV[Double] =
+    new BDV(a)
+
+  def blockMatrixPreGen(blockSize: Int): Gen[HailBlockMatrix] = for {
+    (l, w) <- Gen.nonEmptySquareOfAreaAtMostSize
+    bm <- blockMatrixPreGen(l, w, blockSize)
+  } yield bm
+
+  def blockMatrixPreGen(rows: Int, columns: Int, blockSize: Int): Gen[HailBlockMatrix] = for {
+    arrays <- Gen.buildableOfN[Seq, Array[Double]](rows, Gen.buildableOfN(columns, arbDouble.arbitrary))
+  } yield toBM(arrays, blockSize)
+
+  val squareBlockMatrixGen = for {
+    size <- Gen.size
+    l <- Gen.interestingPosInt
+    s = math.sqrt(math.min(l, size)).toInt
+    blockSize <- Gen.interestingPosInt
+    bm <- blockMatrixPreGen(s, s, blockSize)
+  } yield bm
+
+  val blockMatrixGen = for {
+    blockSize <- Gen.interestingPosInt
+    bm <- blockMatrixPreGen(blockSize)
+  } yield bm
+
+  val twoMultipliableBlockMatrices = for {
+    Array(rows, inner, columns) <- Gen.nonEmptyNCubeOfVolumeAtMostSize(3)
+    blockSize <- Gen.interestingPosInt
+    x <- blockMatrixPreGen(rows, inner, blockSize)
+    y <- blockMatrixPreGen(inner, columns, blockSize)
+  } yield (x, y)
+
+  implicit val arbitraryHailBlockMatrix =
+    Arbitrary(blockMatrixGen)
+
+  @Test
+  def pointwiseSubtractCorrect() {
+    val m = toBM(Seq(
+      Array[Double](1,2,3,4),
+      Array[Double](5,6,7,8),
+      Array[Double](9,10,11,12),
+      Array[Double](13,14,15,16)))
+
+    val expected = new BDM[Double](4,4,Array[Double](
+      0,-3,-6,-9,
+      3,0,-3,-6,
+      6,3,0,-3,
+      9,6,3,0)).t
+
+    val actual = (m :- (m.t)).toLocalMatrix()
+    assert(actual == expected)
+  }
+
+  @Test
+  def multiplyByLocalMatrix() {
+    val bl = new BDM[Double](4, 4, Array[Double](
+      1,2,3,4,
+      5,6,7,8,
+      9,10,11,12,
+      13,14,15,16)).t
+    val l = toBM(bl)
+
+    val r = new BDM[Double](4, 1, Array[Double](1,2,3,4))
+
+    assert(bl * r === (l * r).toLocalMatrix())
+  }
+
+  @Test
+  def multiplyByLocalMatrix2() {
+    val bl = new BDM[Double](3,8,Array[Double](
+      -0.0, -0.0, 0.0,
+      0.24999999999999994, 0.5000000000000001, -0.5,
+      0.4999999999999998, 2.220446049250313E-16, 2.220446049250313E-16,
+      0.75, 0.5, -0.5,
+      0.25, -0.5, 0.5,
+      0.5000000000000001, 1.232595164407831E-32, -2.220446049250313E-16,
+      0.75, -0.5000000000000001, 0.5,
+      1.0, -0.0, 0.0)).t
+    val l = toBM(bl)
+
+    val r = new BDM[Double](3, 4, Array[Double](1.0,0.0,1.0,
+      1.0,1.0,1.0,
+      1.0,1.0,0.0,
+      1.0,0.0,0.0))
+
+    assert(bl * r === (l * r).toLocalMatrix())
+  }
+
+  private def arrayEqualNaNEqualsNaN(x: Array[Double], y: Array[Double], absoluteTolerance: Double = 1e-15): Boolean = {
+    if (x.length != y.length) {
+      return false
+    } else {
+      var i = 0
+      while (i < x.length) {
+        if (math.abs(x(i) - y(i)) > absoluteTolerance && !(x(i).isNaN && y(i).isNaN)) {
+          println(s"inequality found at $i: ${x(i)} and ${y(i)}")
+          return false
+        }
+        i += 1
+      }
+      return true
+    }
+  }
+
+  @Test
+  def multiplySameAsBreeze() {
+    {
+      val a = BDM.rand[Double](4,4)
+      val b = BDM.rand[Double](4,4)
+      val da = toBM(a, 2)
+      val db = toBM(b, 2)
+
+      assert(arrayEqualNaNEqualsNaN((da * db).toLocalMatrix().toArray, (a * b).toArray))
+    }
+
+    {
+      val a = BDM.rand[Double](9,9)
+      val b = BDM.rand[Double](9,9)
+      val da = toBM(a, 3)
+      val db = toBM(b, 3)
+
+      assert(arrayEqualNaNEqualsNaN((da * db).toLocalMatrix().toArray, (a * b).toArray))
+    }
+
+    {
+      val a = BDM.rand[Double](9,9)
+      val b = BDM.rand[Double](9,9)
+      val da = toBM(a, 2)
+      val db = toBM(b, 2)
+
+      assert(arrayEqualNaNEqualsNaN((da * db).toLocalMatrix().toArray, (a * b).toArray))
+    }
+
+    {
+      val a = BDM.rand[Double](2,10)
+      val b = BDM.rand[Double](10,2)
+      val da = toBM(a, 3)
+      val db = toBM(b, 3)
+
+      assert(arrayEqualNaNEqualsNaN((da * db).toLocalMatrix().toArray, (a * b).toArray))
+    }
+  }
+
+  @Test
+  def multiplySameAsBreezeRandomized() {
+    forAll(twoMultipliableBlockMatrices) { case (a: HailBlockMatrix, b: HailBlockMatrix) =>
+      val truth = (a * b).toLocalMatrix()
+      val expected = a.toLocalMatrix() * b.toLocalMatrix()
+
+      if (arrayEqualNaNEqualsNaN(truth.toArray, expected.toArray))
+        true
+      else {
+        println(s"${a.toLocalMatrix()}")
+        println(s"${b.toLocalMatrix()}")
+        println(s"$truth != $expected")
+        false
+      }
+    }.check()
+  }
+
+  @Test
+  def rowwiseMultiplication() {
+    // row major
+    val l = toBM(Seq(
+      Array[Double](1,2,3,4),
+      Array[Double](5,6,7,8),
+      Array[Double](9,10,11,12),
+      Array[Double](13,14,15,16)))
+
+    val r = Array[Double](1,2,3,4)
+
+    // col major
+    val result = new BDM[Double](4,4, Array[Double](
+      1,5,9,13,
+      4,12,20,28,
+      9,21,33,45,
+      16,32,48,64
+    ))
+
+    assert(dm.toLocalMatrix(l --* r) == result)
+  }
+
+  @Test
+  def rowwiseMultiplicationRandom() {
+    val g = for {
+      blockSize <- Gen.interestingPosInt
+      l <- blockMatrixPreGen(blockSize)
+      r <- Gen.buildableOfN[Array, Double](l.cols.toInt, arbitrary[Double])
+    } yield (l, r)
+
+    forAll(g) { case (l: HailBlockMatrix, r: Array[Double]) =>
+      val truth = (l --* r).toLocalMatrix()
+      val repeatedR = (0 until l.rows.toInt).map(x => r).flatten.toArray
+      val repeatedRMatrix = new BDM(r.size, l.rows.toInt, repeatedR).t
+      val expected = dm.toLocalMatrix(l) :* repeatedRMatrix
+
+      if (arrayEqualNaNEqualsNaN(truth.toArray, expected.toArray))
+        true
+      else {
+        println(s"$truth != $expected")
+        false
+      }
+    }.check()
+  }
+
+  @Test
+  def colwiseMultiplication() {
+    // row major
+    val l = toBM(Seq(
+      Array[Double](1,2,3,4),
+      Array[Double](5,6,7,8),
+      Array[Double](9,10,11,12),
+      Array[Double](13,14,15,16)
+    ))
+
+    val r = Array[Double](1,2,3,4)
+
+    // col major
+    val result = new BDM[Double](4,4, Array[Double](
+      1,10,27,52,
+      2,12,30,56,
+      3,14,33,60,
+      4,16,36,64
+    ))
+
+    assert(dm.toLocalMatrix(l :* r) == result)
+  }
+
+  @Test
+  def colwiseMultiplicationRandom() {
+    val g = for {
+      blockSize <- Gen.interestingPosInt
+      l <- blockMatrixPreGen(blockSize)
+      r <- Gen.buildableOfN[Array, Double](l.rows.toInt, arbitrary[Double])
+    } yield (l, r)
+
+    forAll(g) { case (l: HailBlockMatrix, r: Array[Double]) =>
+      val truth = (l :* r).toLocalMatrix()
+      val repeatedR = (0 until l.cols.toInt).map(x => r).flatten.toArray
+      val repeatedRMatrix = new BDM(r.size, l.cols.toInt, repeatedR)
+      val expected = dm.toLocalMatrix(l) :* repeatedRMatrix
+
+      if (arrayEqualNaNEqualsNaN(truth.toArray, expected.toArray))
+        true
+      else {
+        println(s"${dm.toLocalMatrix(l).toArray.toSeq}\n*\n${r.toSeq}")
+        println(s"${truth.toString(10000,10000)}\n!=\n${expected.toString(10000,10000)}")
+        false
+      }
+    }.check()
+  }
+
+  @Test
+  def colwiseAddition() {
+    // row major
+    val l = toBM(Seq(
+      Array[Double](1,2,3,4),
+      Array[Double](5,6,7,8),
+      Array[Double](9,10,11,12),
+      Array[Double](13,14,15,16)
+    ))
+
+    val r = Array[Double](1,2,3,4)
+
+    // col major
+    val result = new BDM[Double](4,4, Array[Double](
+      2, 7,12,17,
+      3, 8,13,18,
+      4, 9,14,19,
+      5,10,15,20
+    ))
+
+    assert(dm.toLocalMatrix(l :+ r) == result)
+  }
+
+  @Test
+  def diagonalTestTiny() {
+    val l = toBM(Seq(
+      Array[Double](1,2,3,4),
+      Array[Double](5,6,7,8),
+      Array[Double](9,10,11,12),
+      Array[Double](13,14,15,16)
+    ))
+
+    assert(l.diag.toSeq == Seq(1,6,11,16))
+  }
+
+  @Test
+  def diagonalTestRandomized() {
+    forAll(squareBlockMatrixGen) { (mat: HailBlockMatrix) =>
+      val lm = mat.toLocalMatrix()
+      val diagonalLength = math.min(lm.rows, lm.cols)
+      val diagonal = (0 until diagonalLength).map(i => lm(i,i)).toArray
+
+      if (mat.diag.toSeq == diagonal.toSeq)
+        true
+      else {
+        println(s"mat: $lm")
+        println(s"${mat.diag.toSeq} != ${diagonal.toSeq}")
+        false
+      }
+    }.check()
+  }
+
+  @Test
+  def fromLocalTest() {
+    val numRows = 100
+    val numCols = 100
+    val local = BDM.rand[Double](numRows, numCols)
+    assert(local === HailBlockMatrixIsDistributedMatrix.from(sc, local, numRows - 1).toLocalMatrix())
+  }
+
+  @Test
+  def readWriteIdentityTrivial() {
+    val actual = toBM(Seq(
+      Array[Double](1,2,3,4),
+      Array[Double](5,6,7,8),
+      Array[Double](9,10,11,12),
+      Array[Double](13,14,15,16)))
+
+    val fname = tmpDir.createTempFile("test")
+    dm.write(actual, fname)
+    assert(actual.toLocalMatrix() == dm.read(hc, fname).toLocalMatrix())
+  }
+
+  @Test
+  def readWriteIdentityRandom() {
+    forAll(blockMatrixGen) { (bm: HailBlockMatrix) =>
+      val fname = tmpDir.createTempFile("test")
+      dm.write(bm, fname)
+      assert(bm.toLocalMatrix() == dm.read(hc, fname).toLocalMatrix())
+      true
+    }.check()
+  }
+
+  @Test
+  def transpose() {
+    forAll(blockMatrixGen) { (bm: HailBlockMatrix) =>
+      val transposed = bm.toLocalMatrix().t
+      assert(transposed.rows == bm.cols)
+      assert(transposed.cols == bm.rows)
+      assert(transposed === bm.t.toLocalMatrix())
+      true
+    }.check()
+  }
+
+}

--- a/src/test/scala/is/hail/methods/PCRelateSuite.scala
+++ b/src/test/scala/is/hail/methods/PCRelateSuite.scala
@@ -25,7 +25,7 @@ import is.hail.stats._
 import is.hail.utils.{TextTableReader, _}
 
 import scala.sys.process._
-import is.hail.distributedmatrix.{BlockMatrixIsDistributedMatrix, DistributedMatrix}
+import is.hail.distributedmatrix.{HailBlockMatrixIsDistributedMatrix, DistributedMatrix, HailBlockMatrix}
 import is.hail.distributedmatrix.DistributedMatrix.implicits._
 
 class PCRelateSuite extends SparkSuite {
@@ -160,19 +160,13 @@ class PCRelateSuite extends SparkSuite {
     assert(fails.isEmpty)
   }
 
-  private def blockMatrixToBDM(m: BlockMatrix): BDM[Double] = {
-    val foo = m.toLocalMatrix().asInstanceOf[DenseMatrix]
-    new BDM[Double](foo.numRows, foo.numCols, foo.toArray)
-  }
-
-
   @Test
   def sampleVcfMatchesReference() {
     val vds = hc.importVCF("src/test/resources/sample.vcf.bgz")
 
     val pcs = SamplePCA.justScores(vds.coalesce(10), 2)
 
-    val dm = BlockMatrixIsDistributedMatrix
+    val dm = HailBlockMatrixIsDistributedMatrix
     import dm.ops._
 
     val (truth, truth_g, truth_ibs0, truth_mu) = PCRelateReferenceImplementation(vds, pcs, maf=0.01)
@@ -181,11 +175,11 @@ class PCRelateSuite extends SparkSuite {
     val g = PCRelate.vdsToMeanImputedMatrix(vds)
     val dmu = pcr.mu(g, pcs)
     // blockedG : variant x sample
-    val blockedG = dm.from(g, blockSize, blockSize)
+    val blockedG = dm.from(g, blockSize)
     val actual = runPcRelateHail(vds, pcs, 0.01)
-    val actual_g = blockMatrixToBDM(blockedG.t)
-    val actual_ibs0 = blockMatrixToBDM(pcr.ibs0(blockedG, dmu, blockSize))
-    val actual_mean = blockMatrixToBDM(dmu)
+    val actual_g = blockedG.t.toLocalMatrix()
+    val actual_ibs0 = pcr.ibs0(blockedG, dmu, blockSize).toLocalMatrix()
+    val actual_mean = dmu.toLocalMatrix()
 
     compareBDMs(actual_mean, truth_mu, tolerance=1e-14)
     compareBDMs(actual_ibs0, truth_ibs0, tolerance=1e-14)


### PR DESCRIPTION
The fourth in a series of PCRelate Improvements.

Sprinkling `cache` on any RDD which is used more than once dramatically improved runtime. On a benchmark program (included below) PCRelate took 36 seconds with four cores on 1000 samples and 10,000 variants.

```
from hail import *
from timeit import default_timer as timer

hc = HailContext()
vds = hc.balding_nichols_model(20, 1000, 10000).repartition(10).persist()
vds.count()

start = timer()
vds.pc_relate(5, 0.01, min_kinship=0.1, desire="phi").count()
end = timer()
print(end-start)
```