### PR TITLE
PC Relate with Persist annotations [PCRI-3]

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -3844,8 +3844,9 @@ class VariantDataset(object):
     @handle_py4j
     @typecheck_method(k=integral,
                       maf=numeric,
-                      block_size=integral)
-    def pc_relate(self, k, maf, block_size=512):
+                      block_size=integral,
+                      min_kinship=numeric)
+    def pc_relate(self, k, maf, block_size=512, min_kinship=-float("inf")):
         """Compute relatedness estimates between individuals using a variant of the
         PC-Relate method.
 
@@ -3865,7 +3866,13 @@ class VariantDataset(object):
 
         >>> rel = vds.pc_relate(5, 0.01, 1024)
 
-        **Method**
+        Calculate values as above, excluding sample-pairs with kinship lower
+        than 0.1. This is more efficient than producing the full key table and
+        filtering using :py:meth:`~hail.KeyTable.filter`.
+
+        >>> rel = vds.pc_relate(5, 0.01, min_kinship=0.1)
+
+        **Method*
 
         The traditional estimator for kinship between a pair of individuals
         :math:`i` and :math:`j`, sharing the set :math:`S_{ij}` of
@@ -4035,7 +4042,7 @@ class VariantDataset(object):
 
         """
 
-        return KeyTable(self.hc, self._jvdf.pcRelate(k, maf, block_size))
+        return KeyTable(self.hc, self._jvdf.pcRelate(k, maf, block_size, min_kinship))
 
     @handle_py4j
     @typecheck_method(storage_level=strlike)

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -3845,8 +3845,9 @@ class VariantDataset(object):
     @typecheck_method(k=integral,
                       maf=numeric,
                       block_size=integral,
-                      min_kinship=numeric)
-    def pc_relate(self, k, maf, block_size=512, min_kinship=-float("inf")):
+                      min_kinship=numeric,
+                      desire=enumeration("phi", "phik2", "phik2k0", "all"))
+    def pc_relate(self, k, maf, block_size=512, min_kinship=-float("inf"), desire="all"):
         """Compute relatedness estimates between individuals using a variant of the
         PC-Relate method.
 
@@ -4045,7 +4046,9 @@ class VariantDataset(object):
 
         """
 
-        return KeyTable(self.hc, self._jvdf.pcRelate(k, maf, block_size, min_kinship))
+        intdesire = { "phi" : 0, "phik2" : 1, "phik2k0" : 2, "all" : 3 }[desire]
+
+        return KeyTable(self.hc, self._jvdf.pcRelate(k, maf, block_size, min_kinship, intdesire))
 
     @handle_py4j
     @typecheck_method(storage_level=strlike)

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -3872,7 +3872,7 @@ class VariantDataset(object):
 
         >>> rel = vds.pc_relate(5, 0.01, min_kinship=0.1)
 
-        **Method*
+        **Method**
 
         The traditional estimator for kinship between a pair of individuals
         :math:`i` and :math:`j`, sharing the set :math:`S_{ij}` of

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -4036,6 +4036,9 @@ class VariantDataset(object):
                                memory (in addition to all other objects
                                necessary for Spark and Hail)
 
+        :param float min_kinship: Pairs of samples with kinship lower than
+                                  ``min_kinship`` are excluded from the results
+
         :return: A :py:class:`.KeyTable` mapping pairs of samples to estimations
                  of their kinship and identity-by-descent zero, one, and two
         :rtype: :py:class:`.KeyTable`

--- a/python/hail/typecheck/__init__.py
+++ b/python/hail/typecheck/__init__.py
@@ -13,4 +13,5 @@ __all__ = ['typecheck',
            'integral',
            'numeric',
            'char',
-           'lazy']
+           'lazy',
+           'enumeration']

--- a/python/hail/typecheck/check.py
+++ b/python/hail/typecheck/check.py
@@ -121,6 +121,17 @@ class LazyChecker(TypeChecker):
             raise RuntimeError("LazyChecker not initialized. Use 'set' to provide the expected type")
         return extract(self.t)
 
+class ExactlyTypeChecker(TypeChecker):
+    def __init__(self, v):
+        self.v = v
+        super(ExactlyTypeChecker, self).__init__()
+
+    def check(self, x):
+        return x == self.v
+
+    def expects(self):
+        return str(v)
+
 
 def only(t):
     if isinstance(t, type) or type(t) is ClassType:
@@ -131,8 +142,16 @@ def only(t):
         raise RuntimeError("invalid typecheck signature: expected 'type' or 'TypeChecker', found '%s'" % type(t))
 
 
+def exactly(v):
+    return ExactlyTypeChecker(v)
+
+
 def oneof(*args):
     return MultipleTypeChecker([only(x) for x in args])
+
+
+def enumeration(*args):
+    return MultipleTypeChecker([exactly(x) for x in args])
 
 
 def nullable(t):

--- a/python/hail/typecheck/check.py
+++ b/python/hail/typecheck/check.py
@@ -130,7 +130,7 @@ class ExactlyTypeChecker(TypeChecker):
         return x == self.v
 
     def expects(self):
-        return str(v)
+        return str(self.v)
 
 
 def only(t):

--- a/src/main/scala/is/hail/distributedmatrix/BlockMatrixIsDistributedMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/BlockMatrixIsDistributedMatrix.scala
@@ -175,8 +175,8 @@ object BlockMatrixIsDistributedMatrix extends DistributedMatrix[BlockMatrix] {
     new BlockMatrix(blocks, l.rowsPerBlock, l.colsPerBlock, l.numRows(), l.numCols())
   }
 
-  def pointwiseAdd(l: M, r: M): M = l.add(r)
-  def pointwiseSubtract(l: M, r: M): M = l.subtract(r)
+  def pointwiseAdd(l: M, r: M): M = map2(_ + _)(r)
+  def pointwiseSubtract(l: M, r: M): M = map2(_ - _)(r)
   def pointwiseMultiply(l: M, r: M): M = map2(_ * _)(l, r)
   def pointwiseDivide(l: M, r: M): M = map2(_ / _)(l, r)
 

--- a/src/main/scala/is/hail/distributedmatrix/BlockMatrixIsDistributedMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/BlockMatrixIsDistributedMatrix.scala
@@ -175,8 +175,8 @@ object BlockMatrixIsDistributedMatrix extends DistributedMatrix[BlockMatrix] {
     new BlockMatrix(blocks, l.rowsPerBlock, l.colsPerBlock, l.numRows(), l.numCols())
   }
 
-  def pointwiseAdd(l: M, r: M): M = map2(_ + _)(r)
-  def pointwiseSubtract(l: M, r: M): M = map2(_ - _)(r)
+  def pointwiseAdd(l: M, r: M): M = map2(_ + _)(l, r)
+  def pointwiseSubtract(l: M, r: M): M = map2(_ - _)(l, r)
   def pointwiseMultiply(l: M, r: M): M = map2(_ * _)(l, r)
   def pointwiseDivide(l: M, r: M): M = map2(_ / _)(l, r)
 

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -211,9 +211,9 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
     val phi = this.phi(mu, variance, blockedG).cache()
 
     if (desire >= PhiK2) {
-      val k2 = this.k2(phi, mu, variance, blockedG)
+      val k2 = this.k2(phi, mu, variance, blockedG).cache()
       if (desire >= PhiK2K0) {
-        val k0 = this.k0(phi, mu, k2, blockedG, ibs0(blockedG, mu, blockSize))
+        val k0 = this.k0(phi, mu, k2, blockedG, ibs0(blockedG, mu, blockSize)).cache()
         if (desire >= PhiK2K0K1) {
           val k1 = 1.0 - (k2 :+ k0)
           Result(phi, k0, k1, k2)
@@ -247,7 +247,7 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
     }(g, mu)
     val stddev = dm.map(math.sqrt _)(variance)
 
-    (gram(centeredG.t) :/ gram(stddev.t)) / 4.0
+    (gram(centeredG) :/ gram(stddev)) / 4.0
   }
 
   private[methods] def ibs0(g: M, mu: M, blockSize: Int): M = {
@@ -274,7 +274,7 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
         }
     } (g, mu)
 
-    gram(normalizedGD.t) :/ gram(variance.t)
+    gram(normalizedGD) :/ gram(variance)
   }
 
   private[methods] def k0(phi: M, mu: M, k2: M, g: M, ibs0: M): M = {

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -153,7 +153,7 @@ object PCRelate {
         new IndexedRow(variantIdxBc.value(v), new DenseVector(a))
       }
     }
-    new IndexedRowMatrix(rdd, variants.length, nSamples)
+    new IndexedRowMatrix(rdd.cache(), variants.length, nSamples)
   }
 
   /**
@@ -190,12 +190,16 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
     mu <= maf || mu >= antimaf || mu <= 0.0 || mu >= 1.0
   def badgt(gt: Double): Boolean =
     gt != 0.0 && gt != 1.0 && gt != 2.0
+  private def gram(m: M): M = {
+    val mc = m.cache()
+    mc.t * mc
+  }
 
   def apply(vds: VariantDataset, pcs: DenseMatrix, desire: Desire = defaultDesire): Result[M] = {
     val g = vdsToMeanImputedMatrix(vds)
 
-    val mu = this.mu(g, pcs)
-    val blockedG = dm.from(g, blockSize, blockSize)
+    val mu = this.mu(g, pcs).cache()
+    val blockedG = dm.from(g, blockSize, blockSize).cache()
 
     val variance = dm.map2 { (g, mu) =>
       if (badgt(g) || badmu(mu))
@@ -204,7 +208,7 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
         mu * (1.0 - mu)
     }(blockedG, mu)
 
-    val phi = this.phi(mu, variance, blockedG)
+    val phi = this.phi(mu, variance, blockedG).cache()
 
     if (desire >= PhiK2) {
       val k2 = this.k2(phi, mu, variance, blockedG)
@@ -243,16 +247,16 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
     }(g, mu)
     val stddev = dm.map(math.sqrt _)(variance)
 
-    ((centeredG.t * centeredG) :/ (stddev.t * stddev)) / 4.0
+    (gram(centeredG.t) :/ gram(stddev.t)) / 4.0
   }
 
   private[methods] def ibs0(g: M, mu: M, blockSize: Int): M = {
-    val homalt = dm.map2 { (g, mu) =>
+    val homalt = (dm.map2 { (g, mu) =>
       if (badgt(g) || badmu(mu) || g != 2.0) 0.0 else 1.0
-    } (g, mu)
-    val homref = dm.map2 { (g, mu) =>
+    } (g, mu)).cache()
+    val homref = (dm.map2 { (g, mu) =>
       if (badgt(g) || badmu(mu) || g != 0.0) 0.0 else 1.0
-    } (g, mu)
+    } (g, mu)).cache
     (homalt.t * homref) :+ (homref.t * homalt)
   }
 
@@ -270,22 +274,22 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
         }
     } (g, mu)
 
-    (normalizedGD.t * normalizedGD) :/ (variance.t * variance)
+    gram(normalizedGD.t) :/ gram(variance.t)
   }
 
   private[methods] def k0(phi: M, mu: M, k2: M, g: M, ibs0: M): M = {
-    val mu2 = dm.map2 { (g, mu) =>
+    val mu2 = (dm.map2 { (g, mu) =>
       if (badgt(g) || badmu(mu))
         0.0
       else
         mu * mu
-    }(g, mu)
-    val oneMinusMu2 = dm.map2 { (g, mu) =>
+    }(g, mu)).cache()
+    val oneMinusMu2 = (dm.map2 { (g, mu) =>
       if (badgt(g) || badmu(mu))
         0.0
       else
         (1.0 - mu) * (1.0 - mu)
-    }(g, mu)
+    }(g, mu)).cache()
     val denom = (mu2.t * oneMinusMu2) :+ (oneMinusMu2.t * mu2)
     dm.map4 { (phi: Double, denom: Double, k2: Double, ibs0: Double) =>
       if (phi <= k0cutoff)

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -51,22 +51,27 @@ object PCRelate {
         j < i2 && i2 < j2) {
         val size = m1.numRows * m1.numCols
         val ab = new ArrayBuilder[Row]()
-        var jj = 1
-        while (jj < m1.numCols) {
-          // fixme: broken for non-square blocks
-          var ii = 0
-          val rowsAboveDiagonal = if (blocki < blockj) m1.numRows else jj
-          while (ii < rowsAboveDiagonal) {
-            val kin = m1(ii, jj)
-            if (kin >= minKinship) {
-              val k0 = m2(ii, jj)
-              val k1 = m3(ii, jj)
-              val k2 = m4(ii, jj)
-              ab += Annotation(indexToId(i + ii), indexToId(j + jj), kin, k0, k1, k2).asInstanceOf[Row]
+        try {
+          var jj = 1
+          while (jj < m1.numCols) {
+            // fixme: broken for non-square blocks
+            var ii = 0
+            val rowsAboveDiagonal = if (blocki < blockj) m1.numRows else jj
+            while (ii < rowsAboveDiagonal) {
+              val kin = m1(ii, jj)
+              if (kin >= minKinship) {
+                val k0 = m2(ii, jj)
+                val k1 = m3(ii, jj)
+                val k2 = m4(ii, jj)
+                ab += Annotation(indexToId(i + ii), indexToId(j + jj), kin, k0, k1, k2).asInstanceOf[Row]
+              }
+              ii += 1
             }
-            ii += 1
+            jj += 1
           }
-          jj += 1
+        } catch {
+          case e: Exception =>
+            throw new RuntimeException(s"$i, $j; $blocki, $blockj; $i2, $j2; ${m1.numRows}, ${m1.numCols}", e)
         }
         ab.result()
       } else

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -21,24 +21,31 @@ object PCRelate {
   val dm = BlockMatrixIsDistributedMatrix
   import dm.ops._
 
+  type Desire = Int
+  val PhiOnly: Desire = 0
+  val PhiK2: Desire = 1
+  val PhiK2K0: Desire = 2
+  val PhiK2K0K1: Desire = 3
+
   case class Result[M](phiHat: M, k0: M, k1: M, k2: M) {
     def map[N](f: M => N): Result[N] = Result(f(phiHat), f(k0), f(k1), f(k2))
   }
 
   val defaultMinKinship = Double.NegativeInfinity
+  val defaultDesire: Desire = PhiK2K0K1
 
-  def apply(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int): Result[M] =
-    new PCRelate(maf, blockSize)(vds, pcs)
+  def apply(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int, desire: Desire = defaultDesire): Result[M] =
+    new PCRelate(maf, blockSize)(vds, pcs, desire)
 
   private val signature =
     TStruct(("i", TString), ("j", TString), ("kin", TDouble), ("k0", TDouble), ("k1", TDouble), ("k2", TDouble))
   private val keys = Array("i", "j")
 
-  private def toRowRdd(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int, minKinship: Double): RDD[Row] = {
+  private def toRowRdd(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int, minKinship: Double, desire: Desire): RDD[Row] = {
     val indexToId: Map[Int, Annotation] = vds.sampleIds.zipWithIndex.map { case (id, index) => (index, id) }.toMap
-    val Result(phi, k0, k1, k2) = apply(vds, pcs, maf, blockSize)
+    val Result(phi, k0, k1, k2) = apply(vds, pcs, maf, blockSize, desire)
 
-    (phi.blocks join k0.blocks join k1.blocks join k2.blocks).flatMap { case ((blocki, blockj), (((m1, m2), m3), m4)) =>
+    def fuseBlocks(blocki: Int, blockj: Int, mk1: Matrix, mk2: Matrix, mk3: Matrix, mk4: Matrix) = {
       val i = blocki * phi.rowsPerBlock
       val j = blockj * phi.colsPerBlock
       val i2 = i + phi.rowsPerBlock
@@ -49,42 +56,48 @@ object PCRelate {
         i < j2 && j2 < i2 ||
         j <= i && i < j2 ||
         j < i2 && i2 < j2) {
-        val size = m1.numRows * m1.numCols
+        val size = mk1.numRows * mk1.numCols
         val ab = new ArrayBuilder[Row]()
-        try {
-          var jj = 1
-          while (jj < m1.numCols) {
-            // fixme: broken for non-square blocks
-            var ii = 0
-            val rowsAboveDiagonal = if (blocki < blockj) m1.numRows else jj
-            while (ii < rowsAboveDiagonal) {
-              val kin = m1(ii, jj)
-              if (kin >= minKinship) {
-                val k0 = m2(ii, jj)
-                val k1 = m3(ii, jj)
-                val k2 = m4(ii, jj)
-                ab += Annotation(indexToId(i + ii), indexToId(j + jj), kin, k0, k1, k2).asInstanceOf[Row]
-              }
-              ii += 1
+        var jj = 1
+        while (jj < mk1.numCols) {
+          // fixme: broken for non-square blocks
+          var ii = 0
+          val rowsAboveDiagonal = if (blocki < blockj) mk1.numRows else jj
+          while (ii < rowsAboveDiagonal) {
+            val kin = mk1(ii, jj)
+            if (kin >= minKinship) {
+              val k0 = if (mk2 == null) null else mk2(ii, jj)
+              val k1 = if (mk3 == null) null else mk3(ii, jj)
+              val k2 = if (mk4 == null) null else mk4(ii, jj)
+              ab += Annotation(indexToId(i + ii), indexToId(j + jj), kin, k0, k1, k2).asInstanceOf[Row]
             }
-            jj += 1
+            ii += 1
           }
-        } catch {
-          case e: Exception =>
-            throw new RuntimeException(s"$i, $j; $blocki, $blockj; $i2, $j2; ${m1.numRows}, ${m1.numCols}", e)
+          jj += 1
         }
         ab.result()
       } else
         new Array[Row](0)
     }
+
+    desire match {
+      case PhiOnly => phi.blocks
+          .flatMap { case ((blocki, blockj), phi) => fuseBlocks(blocki, blockj, phi, null, null, null) }
+      case PhiK2 => (phi.blocks join k2.blocks)
+          .flatMap { case ((blocki, blockj), (phi, k2)) => fuseBlocks(blocki, blockj, phi, null, null, k2) }
+      case PhiK2K0 => (phi.blocks join k0.blocks join k2.blocks)
+          .flatMap { case ((blocki, blockj), ((phi, k0), k2)) => fuseBlocks(blocki, blockj, phi, k0, null, k2) }
+      case PhiK2K0K1 => (phi.blocks join k0.blocks join k1.blocks join k2.blocks)
+          .flatMap { case ((blocki, blockj), (((phi, k0), k1), k2)) => fuseBlocks(blocki, blockj, phi, k0, k1, k2) }
+    }
   }
 
-  def toKeyTable(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int, minKinship: Double = defaultMinKinship): KeyTable =
-    KeyTable(vds.hc, toRowRdd(vds, pcs, maf, blockSize, minKinship), signature, keys)
+  def toKeyTable(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int, minKinship: Double = defaultMinKinship, desire: Desire = defaultDesire): KeyTable =
+    KeyTable(vds.hc, toRowRdd(vds, pcs, maf, blockSize, minKinship, desire), signature, keys)
 
-  def toPairRdd(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int, minKinship: Double = defaultMinKinship)
+  def toPairRdd(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int, minKinship: Double = defaultMinKinship, desire: Desire = defaultDesire)
       : RDD[((Annotation, Annotation), (Double, Double, Double, Double))] =
-     toRowRdd(vds, pcs, maf, blockSize, minKinship)
+     toRowRdd(vds, pcs, maf, blockSize, minKinship, desire)
        .map(r => ((r(0), r(1)), (r(2).asInstanceOf[Double], r(3).asInstanceOf[Double], r(4).asInstanceOf[Double], r(5).asInstanceOf[Double])))
 
   private val k0cutoff = math.pow(2.0, (-5.0 / 2.0))
@@ -178,7 +191,7 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
   def badgt(gt: Double): Boolean =
     gt != 0.0 && gt != 1.0 && gt != 2.0
 
-  def apply(vds: VariantDataset, pcs: DenseMatrix): Result[M] = {
+  def apply(vds: VariantDataset, pcs: DenseMatrix, desire: Desire = defaultDesire): Result[M] = {
     val g = vdsToMeanImputedMatrix(vds)
 
     val mu = this.mu(g, pcs)
@@ -193,11 +206,19 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
 
     val phi = this.phi(mu, variance, blockedG)
 
-    val k2 = this.k2(phi, mu, variance, blockedG)
-    val k0 = this.k0(phi, mu, k2, blockedG, ibs0(blockedG, mu, blockSize))
-    val k1 = 1.0 - (k2 :+ k0)
-
-    Result(phi, k0, k1, k2)
+    if (desire >= PhiK2) {
+      val k2 = this.k2(phi, mu, variance, blockedG)
+      if (desire >= PhiK2K0) {
+        val k0 = this.k0(phi, mu, k2, blockedG, ibs0(blockedG, mu, blockSize))
+        if (desire >= PhiK2K0K1) {
+          val k1 = 1.0 - (k2 :+ k0)
+          Result(phi, k0, k1, k2)
+        } else
+          Result(phi, k0, null, k2)
+      } else
+        Result(phi, null, null, k2)
+    } else
+      Result(phi, null, null, null)
   }
 
   /**

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -25,45 +25,7 @@ object PCRelate {
     def map[N](f: M => N): Result[N] = Result(f(phiHat), f(k0), f(k1), f(k2))
   }
 
-  def toPairRdd(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int): RDD[((Annotation, Annotation), (Double, Double, Double, Double))] = {
-    val indexToId: Map[Int, Annotation] = vds.sampleIds.zipWithIndex.map { case (id, index) => (index, id) }.toMap
-    def upperTriangularEntires(bm: BlockMatrix): RDD[((Annotation, Annotation), Double)] = {
-      val rowsPerBlock = bm.rowsPerBlock
-      val colsPerBlock = bm.colsPerBlock
-
-      bm.blocks.filter { case ((blocki, blockj), m) =>
-        blocki < blockj || {
-          val i = blocki * rowsPerBlock
-          val j = blockj * colsPerBlock
-          val i2 = i + rowsPerBlock
-          val j2 = i + colsPerBlock
-          i <= j && j < i2 ||
-          i < j2 && j2 < i2 ||
-          j <= i && i < j2 ||
-          j < i2 && i2 < j2
-        }
-      }.flatMap { case ((blocki, blockj), m) =>
-          val ioffset = blocki * rowsPerBlock
-          val joffset = blockj * colsPerBlock
-          for {
-            i <- 0 until m.numRows
-            // FIXME: only works with square blocks
-            jstart = if (blocki < blockj) 0 else i+1
-            j <- jstart until m.numCols
-          } yield ((indexToId(i + ioffset), indexToId(j + joffset)), m(i, j))
-      }
-    }
-
-    val result = apply(vds, pcs, maf, blockSize)
-
-    val a = upperTriangularEntires(result.phiHat)
-    val b = upperTriangularEntires(result.k0)
-    val c = upperTriangularEntires(result.k1)
-    val d = upperTriangularEntires(result.k2)
-
-    (a join b join c join d)
-        .mapValues { case (((kin, k0), k1), k2) => (kin, k0, k1, k2) }
-  }
+  val defaultMinKinship = Double.NegativeInfinity
 
   def apply(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int): Result[M] =
     new PCRelate(maf, blockSize)(vds, pcs)
@@ -72,11 +34,53 @@ object PCRelate {
     TStruct(("i", TString), ("j", TString), ("kin", TDouble), ("k0", TDouble), ("k1", TDouble), ("k2", TDouble))
   private val keys = Array("i", "j")
 
-  def toKeyTable(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int): KeyTable =
-    KeyTable(vds.hc,
-      toPairRdd(vds, pcs, maf, blockSize).map { case ((i, j), (kin, k0, k1, k2)) => Annotation(i, j, kin, k0, k1, k2).asInstanceOf[Row] },
-      signature,
-      keys)
+  private def toRowRdd(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int, minKinship: Double): RDD[Row] = {
+    val indexToId: Map[Int, Annotation] = vds.sampleIds.zipWithIndex.map { case (id, index) => (index, id) }.toMap
+    val Result(phi, k0, k1, k2) = apply(vds, pcs, maf, blockSize)
+
+    (phi.blocks join k0.blocks join k1.blocks join k2.blocks).flatMap { case ((blocki, blockj), (((m1, m2), m3), m4)) =>
+      val i = blocki * phi.rowsPerBlock
+      val j = blockj * phi.colsPerBlock
+      val i2 = i + phi.rowsPerBlock
+      val j2 = i + phi.colsPerBlock
+
+      if (blocki < blockj ||
+        i <= j && j < i2 ||
+        i < j2 && j2 < i2 ||
+        j <= i && i < j2 ||
+        j < i2 && i2 < j2) {
+        val size = m1.numRows * m1.numCols
+        val ab = new ArrayBuilder[Row]()
+        var jj = 1
+        while (jj < m1.numCols) {
+          // fixme: broken for non-square blocks
+          var ii = 0
+          val rowsAboveDiagonal = if (blocki < blockj) m1.numRows else jj
+          while (ii < rowsAboveDiagonal) {
+            val kin = m1(ii, jj)
+            if (kin >= minKinship) {
+              val k0 = m2(ii, jj)
+              val k1 = m3(ii, jj)
+              val k2 = m4(ii, jj)
+              ab += Annotation(indexToId(i + ii), indexToId(j + jj), kin, k0, k1, k2).asInstanceOf[Row]
+            }
+            ii += 1
+          }
+          jj += 1
+        }
+        ab.result()
+      } else
+        new Array[Row](0)
+    }
+  }
+
+  def toKeyTable(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int, minKinship: Double = defaultMinKinship): KeyTable =
+    KeyTable(vds.hc, toRowRdd(vds, pcs, maf, blockSize, minKinship), signature, keys)
+
+  def toPairRdd(vds: VariantDataset, pcs: DenseMatrix, maf: Double, blockSize: Int, minKinship: Double = defaultMinKinship)
+      : RDD[((Annotation, Annotation), (Double, Double, Double, Double))] =
+     toRowRdd(vds, pcs, maf, blockSize, minKinship)
+       .map(r => ((r(0), r(1)), (r(2).asInstanceOf[Double], r(3).asInstanceOf[Double], r(4).asInstanceOf[Double], r(5).asInstanceOf[Double])))
 
   private val k0cutoff = math.pow(2.0, (-5.0 / 2.0))
 

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -185,11 +185,15 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
 
   require(maf >= 0.0)
   require(maf <= 1.0)
+
   val antimaf = (1.0 - maf)
+
   def badmu(mu: Double): Boolean =
     mu <= maf || mu >= antimaf || mu <= 0.0 || mu >= 1.0
+
   def badgt(gt: Double): Boolean =
     gt != 0.0 && gt != 1.0 && gt != 2.0
+
   private def gram(m: M): M = {
     val mc = m.cache()
     mc.t * mc

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -205,12 +205,12 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
     val mu = this.mu(g, pcs).cache()
     val blockedG = dm.from(g, blockSize, blockSize).cache()
 
-    val variance = dm.map2 { (g, mu) =>
+    val variance = (dm.map2 { (g, mu) =>
       if (badgt(g) || badmu(mu))
         0.0
       else
         mu * (1.0 - mu)
-    }(blockedG, mu)
+    } (blockedG, mu)).cache()
 
     val phi = this.phi(mu, variance, blockedG).cache()
 
@@ -260,7 +260,7 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
     } (g, mu)).cache()
     val homref = (dm.map2 { (g, mu) =>
       if (badgt(g) || badmu(mu) || g != 0.0) 0.0 else 1.0
-    } (g, mu)).cache
+    } (g, mu)).cache()
     (homalt.t * homref) :+ (homref.t * homalt)
   }
 

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -184,12 +184,11 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
     val mu = this.mu(g, pcs)
     val blockedG = dm.from(g, blockSize, blockSize)
 
-    val variance = dm.map2 {
-      case (g, mu) =>
-        if (badgt(g) || badmu(mu))
-          0.0
-        else
-          mu * (1.0 - mu)
+    val variance = dm.map2 { (g, mu) =>
+      if (badgt(g) || badmu(mu))
+        0.0
+      else
+        mu * (1.0 - mu)
     }(blockedG, mu)
 
     val phi = this.phi(mu, variance, blockedG)
@@ -227,10 +226,10 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
   }
 
   private[methods] def ibs0(g: M, mu: M, blockSize: Int): M = {
-    val homalt = dm.map2 { case (g, mu) =>
+    val homalt = dm.map2 { (g, mu) =>
       if (badgt(g) || badmu(mu) || g != 2.0) 0.0 else 1.0
     } (g, mu)
-    val homref = dm.map2 { case (g, mu) =>
+    val homref = dm.map2 { (g, mu) =>
       if (badgt(g) || badmu(mu) || g != 0.0) 0.0 else 1.0
     } (g, mu)
     (homalt.t * homref) :+ (homref.t * homalt)
@@ -238,7 +237,7 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
 
   private[methods] def k2(phi: M, mu: M, variance: M, g: M): M = {
     val twoPhi_ii = dm.diagonal(phi).map(2.0 * _)
-    val normalizedGD = dm.map2WithIndex { case (_, i, g, mu) =>
+    val normalizedGD = dm.map2WithIndex { (_, i, g, mu) =>
         if (badmu(mu) || badgt(g))
           0.0  // https://github.com/Bioconductor-mirror/GENESIS/blob/release-3.5/R/pcrelate.R#L391
         else {
@@ -254,19 +253,17 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
   }
 
   private[methods] def k0(phi: M, mu: M, k2: M, g: M, ibs0: M): M = {
-    val mu2 = dm.map2 {
-      case (g, mu) =>
-        if (badgt(g) || badmu(mu))
-          0.0
-        else
-          mu * mu
+    val mu2 = dm.map2 { (g, mu) =>
+      if (badgt(g) || badmu(mu))
+        0.0
+      else
+        mu * mu
     }(g, mu)
-    val oneMinusMu2 = dm.map2 {
-      case (g, mu) =>
-        if (badgt(g) || badmu(mu))
-          0.0
-        else
-          (1.0 - mu) * (1.0 - mu)
+    val oneMinusMu2 = dm.map2 { (g, mu) =>
+      if (badgt(g) || badmu(mu))
+        0.0
+      else
+        (1.0 - mu) * (1.0 - mu)
     }(g, mu)
     val denom = (mu2.t * oneMinusMu2) :+ (oneMinusMu2.t * mu2)
     dm.map4 { (phi: Double, denom: Double, k2: Double, ibs0: Double) =>

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -42,7 +42,7 @@ object PCRelate {
       val i = blocki * phi.rowsPerBlock
       val j = blockj * phi.colsPerBlock
       val i2 = i + phi.rowsPerBlock
-      val j2 = i + phi.colsPerBlock
+      val j2 = j + phi.colsPerBlock
 
       if (blocki < blockj ||
         i <= j && j < i2 ||

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -677,7 +677,7 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     *                  these matrices fit in memory (in addition to all other
     *                  objects necessary for Spark and Hail).
     */
-  def pcRelate(k: Int, maf: Double, blockSize: Int, minKinship: Int = PCRelate.defaultMinKinship): KeyTable = {
+  def pcRelate(k: Int, maf: Double, blockSize: Int, minKinship: Double = PCRelate.defaultMinKinship): KeyTable = {
     requireSplit("PCRelate")
     val pcs = SamplePCA.justScores(vds, k)
     PCRelate.toKeyTable(vds, pcs, maf, blockSize, minKinship)

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -677,10 +677,10 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     *                  these matrices fit in memory (in addition to all other
     *                  objects necessary for Spark and Hail).
     */
-  def pcRelate(k: Int, maf: Double, blockSize: Int): KeyTable = {
+  def pcRelate(k: Int, maf: Double, blockSize: Int, minKinship: Int = PCRelate.defaultMinKinship): KeyTable = {
     requireSplit("PCRelate")
     val pcs = SamplePCA.justScores(vds, k)
-    PCRelate.toKeyTable(vds, pcs, maf, blockSize)
+    PCRelate.toKeyTable(vds, pcs, maf, blockSize, minKinship)
   }
 
   def sampleQC(root: String = "sa.qc", keepStar: Boolean = false): VariantDataset = SampleQC(vds, root, keepStar)

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -677,10 +677,10 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     *                  these matrices fit in memory (in addition to all other
     *                  objects necessary for Spark and Hail).
     */
-  def pcRelate(k: Int, maf: Double, blockSize: Int, minKinship: Double = PCRelate.defaultMinKinship): KeyTable = {
+  def pcRelate(k: Int, maf: Double, blockSize: Int, minKinship: Double = PCRelate.defaultMinKinship, desire: PCRelate.Desire = PCRelate.defaultDesire): KeyTable = {
     requireSplit("PCRelate")
     val pcs = SamplePCA.justScores(vds, k)
-    PCRelate.toKeyTable(vds, pcs, maf, blockSize, minKinship)
+    PCRelate.toKeyTable(vds, pcs, maf, blockSize, minKinship, desire)
   }
 
   def sampleQC(root: String = "sa.qc", keepStar: Boolean = false): VariantDataset = SampleQC(vds, root, keepStar)


### PR DESCRIPTION
The third in a series of PCRelate Improvements. Depends on #2249 

Sprinkling `cache` on any RDD which is used more than once dramatically improved runtime. On a benchmark program (included below) PCRelate took 40 seconds with four cores on 1000 samples and 10,000 variants.

```
from hail import *
from timeit import default_timer as timer

hc = HailContext()
vds = hc.balding_nichols_model(20, 1000, 10000).repartition(10).persist()
vds.count()

start = timer()
vds.pc_relate(5, 0.01, min_kinship=0.1, desire="all").count()
end = timer()
print(end-start)
```