### PR TITLE
Avoid computation in suite allocation

### DIFF
--- a/src/test/scala/is/hail/methods/DeNovoSuite.scala
+++ b/src/test/scala/is/hail/methods/DeNovoSuite.scala
@@ -21,7 +21,7 @@ class DeNovoSuite extends SparkSuite {
     * Since the random tests are slow, we disable them by default. We check in one generated VCF and .fam
     * combination that produces a good distribution of de novo calls, and test against only this VCF.
     */
-  val gen: Gen[(VariantDataset, Pedigree)] = {
+  lazy val gen: Gen[(VariantDataset, Pedigree)] = {
     for {
       vds <- VariantSampleMatrix.gen[Locus, Variant, Genotype](hc, VSMSubgen.plinkSafeBiallelic.copy(
         saSigGen = Gen.const(TStruct.empty),

--- a/src/test/scala/is/hail/methods/LDMatrixSuite.scala
+++ b/src/test/scala/is/hail/methods/LDMatrixSuite.scala
@@ -12,9 +12,9 @@ class LDMatrixSuite extends SparkSuite {
   val m = 100
   val n = 100
   val seed = scala.util.Random.nextInt()
-  val vds = hc.baldingNicholsModel(1, n, m, seed = seed)
-  val distLDMatrix = LDMatrix.apply(vds, Some(false))
-  val localLDMatrix = vds.ldMatrix(forceLocal = true)
+  lazy val vds = hc.baldingNicholsModel(1, n, m, seed = seed)
+  lazy val distLDMatrix = LDMatrix.apply(vds, Some(false))
+  lazy val localLDMatrix = vds.ldMatrix(forceLocal = true)
 
   /**
     * Tests that entries in LDMatrix agree with those computed by LDPrune.computeR. Also tests

--- a/src/test/scala/is/hail/methods/SkatSuite.scala
+++ b/src/test/scala/is/hail/methods/SkatSuite.scala
@@ -156,7 +156,7 @@ class SkatSuite extends SparkSuite {
 
   // 18 complete samples from sample2.vcf, 5 genes
   // Using specified weights in Hail and R
-  val vdsSkat: VariantDataset = {
+  lazy val vdsSkat: VariantDataset = {
     val covSkat = hc.importTable("src/test/resources/skat.cov",
       impute = true).keyBy("Sample")
 
@@ -182,7 +182,7 @@ class SkatSuite extends SparkSuite {
   // R uses a small sample correction for logistic below 2000 samples, Hail does not
   // So here we make a large deterministic example using the Balding-Nichols model (only hardcalls)
   // Using default weights in both Hail and R
-  val vdsBN: VariantDataset = {
+  lazy val vdsBN: VariantDataset = {
     val seed = 0
     val nSamples = 2001
     val nVariants = 50


### PR DESCRIPTION
Every suite is allocated by the gradle test framework, and then only those matching the requested filters are executed. Ergo, non-lazy fields on a suite will be executed (and may trigger errors) even though the suite wasn't requested by the gradle user.