### PR TITLE
Speed up gradle test by 3s

### DIFF
--- a/python/hail/docs/getting_started_developing.rst
+++ b/python/hail/docs/getting_started_developing.rst
@@ -14,15 +14,13 @@ You'll need:
 Building a Hail JAR
 -------------------
 
-The minimal set of tools necessary to build Hail from source are a C++ compiler and CMake. On a Debian-based OS like Ubuntu, these tools can be installed with apt-get::
+The minimal set of tools necessary to build Hail from source are a C++ compiler. On a Debian-based OS like Ubuntu, these tools can be installed with apt-get::
 
-    sudo apt-get install g++ cmake
+    sudo apt-get install g++
 
-On Mac OS X, a C++ compiler is provided by the Apple Xcode, and CMake is in
-`Homebrew <http://brew.sh>`_::
+On Mac OS X, a C++ compiler is provided by the Apple Xcode::
 
     xcode-select --install
-    brew install cmake
 
 The Hail source code is hosted `on GitHub <https://github.com/broadinstitute/hail>`_::
 

--- a/python/hail/docs/getting_started_developing.rst
+++ b/python/hail/docs/getting_started_developing.rst
@@ -14,7 +14,7 @@ You'll need:
 Building a Hail JAR
 -------------------
 
-The minimal set of tools necessary to build Hail from source are a C++ compiler. On a Debian-based OS like Ubuntu, these tools can be installed with apt-get::
+The minimal set of tools necessary to build Hail from source is a C++ compiler. On a Debian-based OS like Ubuntu, a C++ compiler can be installed with apt-get::
 
     sudo apt-get install g++
 

--- a/src/main/c/Makefile
+++ b/src/main/c/Makefile
@@ -26,9 +26,11 @@ endif
 
 default: $(shared_library)
 
-test: ibs.cpp test.cpp
+build/functional-tests: ibs.cpp test.cpp
 	mkdir -p build
 	${CXX} ${CXXFLAGS} -DNUMBER_OF_GENOTYPES_PER_ROW=256 ibs.cpp test.cpp -o build/functional-tests
+
+test: build/functional-tests
 	./build/functional-tests
 
 clean:

--- a/src/main/c/Makefile
+++ b/src/main/c/Makefile
@@ -47,10 +47,7 @@ libsimdpp-2.0-rc2.tar.gz:
 libsimdpp-2.0-rc2: libsimdpp-2.0-rc2.tar.gz
 	tar -xzf libsimdpp-2.0-rc2.tar.gz
 
-libsimdpp: libsimdpp-2.0-rc2
-	(cd libsimdpp-2.0-rc2 && cmake .)
-
-$(shared_library): libsimdpp ${OBJECTS}
+$(shared_library): libsimdpp-2.0-rc2 ${OBJECTS}
 	mkdir -p $(basename $(shared_library))
 	${CXX} ${LIBFLAGS} ${CXXFLAGS} ${OBJECTS} -o $@
 


### PR DESCRIPTION
`libsimdpp` only requires CMake for creating a distribution that can be installed on a given system. We only need the header files at compile time, so there's no need to install it. This removes our dependency on CMake and prevents recompilation of the C code on each call to `gradle test` (as well as `compileScala` and `compileTestScala`).