### PR TITLE
set maxParallelForks to 4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -191,6 +191,8 @@ task(checkSettings) << {
 test {
     useTestNG {}
 
+    maxParallelForks 4
+
     systemProperties System.getProperties()
 
     testLogging {


### PR DESCRIPTION
Curious if this makes our builds faster.

Gradle is per-test-suite parallel, but not per-method-parallel.