### PR TITLE
improvements to LDMatrix

### DIFF
--- a/src/main/scala/is/hail/methods/LDMatrix.scala
+++ b/src/main/scala/is/hail/methods/LDMatrix.scala
@@ -14,54 +14,54 @@ object LDMatrix {
   /**
     * Computes the LD matrix for the given VDS.
     * @param vds VDS on which to compute Pearson correlation between pairs of variants.
-    * @return An LDMatrix.
+    * @return LDMatrix.
     */
-  def apply(vds : VariantDataset, optComputeLocally: Option[Boolean]): LDMatrix = {
+  def apply(vds : VariantDataset, optForceLocal: Option[Boolean]): LDMatrix = {
+    val maxEntriesForLocalProduct = 25e6 // 5000 * 5000
+    
     val nSamples = vds.nSamples
-    val nVariants = vds.countVariants()
 
     val filteredNormalizedHardCalls = vds.rdd.flatMap { 
-      case (v, (va, gs)) => RegressionUtils.normalizedHardCalls(gs, nSamples).map(x => (v, x))
+      case (v, (_, gs)) => RegressionUtils.normalizedHardCalls(gs, nSamples).map(x => (v, x))
     }
+      .persist()
     
     val variantsKept = filteredNormalizedHardCalls.map(_._1).collect()
     assert(variantsKept.isSorted, "ld_matrix: Array of variants is not sorted. This is a bug")
+    val nVariantsKept = variantsKept.length
 
     val normalizedIndexedRows = filteredNormalizedHardCalls.map(_._2).zipWithIndex()
       .map{ case (values, idx) => IndexedRow(idx, Vectors.dense(values))}
-    val normalizedBlockMatrix = new IndexedRowMatrix(normalizedIndexedRows).toBlockMatrixDense()
 
-    val nVariantsKept = variantsKept.length
-    val nVariantsDropped = nVariants - nVariantsKept
+    val normalizedBlockMatrix = new IndexedRowMatrix(normalizedIndexedRows, nVariantsKept, nSamples).toBlockMatrixDense()
 
-    info(s"Computing LD matrix with ${variantsKept.length} variants using $nSamples samples. $nVariantsDropped variants were dropped.")
+    filteredNormalizedHardCalls.unpersist()
 
-    val localBound = 5000 * 5000
+    info(s"Computing LD matrix with ${variantsKept.length} variants using $nSamples samples.")
+
     val nEntries: Long = nVariantsKept * nVariantsKept
     val nSamplesInverse = 1.0 / nSamples
 
-    val computeLocally = optComputeLocally.getOrElse(nEntries <= localBound)
+    val computeProductLocally = optForceLocal.getOrElse(nEntries <= maxEntriesForLocalProduct)
 
-    var indexedRowMatrix: IndexedRowMatrix = null
+    val irm: IndexedRowMatrix =
+      if (computeProductLocally) {
+        val localMat: DenseMatrix = normalizedBlockMatrix.toLocalMatrix().asInstanceOf[DenseMatrix]
+        val product = localMat multiply localMat.transpose
 
-    if (computeLocally) {
-      val localMat: DenseMatrix = normalizedBlockMatrix.toLocalMatrix().asInstanceOf[DenseMatrix]
-      val product = localMat multiply localMat.transpose
-      indexedRowMatrix =
         BlockMatrixIsDistributedMatrix.from(vds.sparkContext, product, normalizedBlockMatrix.rowsPerBlock,
-          normalizedBlockMatrix.colsPerBlock).toIndexedRowMatrix()
-    } else {
-      import is.hail.distributedmatrix.DistributedMatrix.implicits._
-      val dm = DistributedMatrix[BlockMatrix]
-      import dm.ops._
-      indexedRowMatrix = (normalizedBlockMatrix * normalizedBlockMatrix.t)
-        .toIndexedRowMatrix()
-    }
+          normalizedBlockMatrix.colsPerBlock).toIndexedRowMatrix() 
+      } else {
+        import is.hail.distributedmatrix.DistributedMatrix.implicits._
+        val dm = DistributedMatrix[BlockMatrix]
+        import dm.ops._
+        (normalizedBlockMatrix * normalizedBlockMatrix.t).toIndexedRowMatrix()
+      }
+    
+    val scaledIRM = new IndexedRowMatrix(irm.rows
+      .map{case IndexedRow(idx, vec) => IndexedRow(idx, vec.map(d => d * nSamplesInverse))})
 
-    val scaledIndexedRowMatrix = new IndexedRowMatrix(indexedRowMatrix.rows
-      .map{case IndexedRow(idx, vals) => IndexedRow(idx, vals.map(d => d * nSamplesInverse))})
-
-    LDMatrix(scaledIndexedRowMatrix, variantsKept, nSamples)
+    LDMatrix(scaledIRM, variantsKept, nSamples)
   }
 
   private val metadataRelativePath = "/metadata.json"
@@ -71,11 +71,11 @@ object LDMatrix {
     hadoop.mkDir(uri)
 
     val rdd = hc.sc.sequenceFile[LongWritable, ArrayPrimitiveWritable](uri+matrixRelativePath).map { case (lw, apw) =>
-      new IndexedRow(lw.get(), new DenseVector(apw.get().asInstanceOf[Array[Double]]))
+      IndexedRow(lw.get(), new DenseVector(apw.get().asInstanceOf[Array[Double]]))
     }
 
     val LDMatrixMetadata(variants, nSamples) =
-      hc.hadoopConf.readTextFile(uri+metadataRelativePath) { isr =>
+      hc.hadoopConf.readTextFile(uri + metadataRelativePath) { isr =>
         jackson.Serialization.read[LDMatrixMetadata](isr)
       }
 
@@ -101,9 +101,9 @@ case class LDMatrix(matrix: IndexedRowMatrix, variants: Array[Variant], nSamples
     hadoop.mkDir(uri)
 
     matrix.rows.map { case IndexedRow(i, v) => (new LongWritable(i), new ArrayPrimitiveWritable(v.toArray)) }
-      .saveAsSequenceFile(uri+matrixRelativePath)
+      .saveAsSequenceFile(uri + matrixRelativePath)
 
-    hadoop.writeTextFile(uri+metadataRelativePath) { os =>
+    hadoop.writeTextFile(uri + metadataRelativePath) { os =>
       jackson.Serialization.write(
         LDMatrixMetadata(variants, nSamples),
         os)

--- a/src/test/scala/is/hail/methods/LDMatrixSuite.scala
+++ b/src/test/scala/is/hail/methods/LDMatrixSuite.scala
@@ -3,18 +3,18 @@ package is.hail.methods
 import breeze.linalg.{DenseMatrix, convert, norm}
 import breeze.stats.mean
 import is.hail.utils._
+import is.hail.variant.VariantDataset
 import is.hail.{SparkSuite, TestUtils, stats}
 import org.testng.Assert
 import org.testng.annotations.Test
 
 class LDMatrixSuite extends SparkSuite {
-
-  val m = 100
-  val n = 100
-  val seed = scala.util.Random.nextInt()
-  val vds = hc.baldingNicholsModel(1, n, m, seed = seed)
-  val distLDMatrix = LDMatrix.apply(vds, Some(false))
-  val localLDMatrix = vds.ldMatrix(forceLocal = true)
+  val m = 50
+  val n = 60
+  val seed: Int = scala.util.Random.nextInt()
+  val vds: VariantDataset = hc.baldingNicholsModel(1, n, m, seed = seed)
+  val distLDMatrix: LDMatrix = LDMatrix.apply(vds, Some(false))
+  val localLDMatrix: LDMatrix = vds.ldMatrix(forceLocal = true)
 
   /**
     * Tests that entries in LDMatrix agree with those computed by LDPrune.computeR. Also tests
@@ -53,8 +53,6 @@ class LDMatrixSuite extends SparkSuite {
     * Tests that the method agrees with local Breeze math.
     */
   @Test def localTest() {
-    val m = 2
-    val n = 3
     val genotypes: DenseMatrix[Int] = DenseMatrix((0, 2, 1),
                                                   (1, 0, 0))
 


### PR DESCRIPTION
Removes two unnecessary stages and persists to prevent recomputing stages. These changes are orthogonal to improvement from HailBlockMatrix and should go in master as well once this is in.