### PR TITLE
Add simplest hash functions

### DIFF
--- a/src/main/scala/is/hail/utils/HashMethods.scala
+++ b/src/main/scala/is/hail/utils/HashMethods.scala
@@ -1,0 +1,20 @@
+package is.hail.utils
+
+// see e.g. Thorup, "High Speed Hashing for Integers and Strings", for explanation of "multiply-shift" hash functions,
+// both the universal and 2-independent constructions
+class UnivHash32(outBits: Int, factor: Int) extends (Int => Int) {
+  require(0 <= outBits && outBits <= 32)
+
+  val oddFactor = factor | 1
+  val shift: Int = 32 - outBits
+
+  override def apply(key: Int): Int = (key * oddFactor) >>> shift
+}
+
+class TwoIndepHash32(outBits: Int, a: Long, b: Long) extends (Int => Int) {
+  require(0 <= outBits && outBits <= 32)
+
+  val shift: Int = 64 - outBits
+
+  override def apply(key: Int): Int = ((a * key + b) >>> shift).toInt
+}

--- a/src/main/scala/is/hail/utils/HashMethods.scala
+++ b/src/main/scala/is/hail/utils/HashMethods.scala
@@ -1,20 +1,34 @@
 package is.hail.utils
 
+import org.apache.commons.math3.random.RandomDataGenerator
+
+object UnivHash32 {
+  def apply(outBits: Int, rand: RandomDataGenerator): UnivHash32 = {
+    new UnivHash32(outBits, rand.getRandomGenerator.nextInt() | 1)
+  }
+}
+
 // see e.g. Thorup, "High Speed Hashing for Integers and Strings", for explanation of "multiply-shift" hash functions,
 // both the universal and 2-independent constructions
 class UnivHash32(outBits: Int, factor: Int) extends (Int => Int) {
   require(0 <= outBits && outBits <= 32)
+  require((factor & 1) == 1)
 
-  val oddFactor = factor | 1
-  val shift: Int = 32 - outBits
+  def shift: Int = 32 - outBits
 
-  override def apply(key: Int): Int = (key * oddFactor) >>> shift
+  override def apply(key: Int): Int = (key * factor) >>> shift
+}
+
+object TwoIndepHash32 {
+  def apply(outBits: Int, rand: RandomDataGenerator): TwoIndepHash32 = {
+    new TwoIndepHash32(outBits, rand.getRandomGenerator.nextInt(), rand.getRandomGenerator.nextInt())
+  }
 }
 
 class TwoIndepHash32(outBits: Int, a: Long, b: Long) extends (Int => Int) {
   require(0 <= outBits && outBits <= 32)
 
-  val shift: Int = 64 - outBits
+  def shift: Int = 64 - outBits
 
   override def apply(key: Int): Int = ((a * key + b) >>> shift).toInt
 }


### PR DESCRIPTION
Implements the two "multiply-shift" hash functions, as described in [High Speed Hashing for Integers and Strings](http://arxiv.org/abs/1504.06804v3), sections 2.3 and 3.3. They have the weakest still useful distributional properties, but are often sufficient, and very very fast.