### PR TITLE
Add simple- and twisted-tabulation hashes

### DIFF
--- a/src/main/scala/is/hail/utils/HashMethods.scala
+++ b/src/main/scala/is/hail/utils/HashMethods.scala
@@ -60,24 +60,23 @@ class SimpleTabulationHash32(table: Array[Array[Int]]) extends (Int => Int) {
 
 object TwistedTabulationHash32 {
   def apply(rand: RandomDataGenerator): TwistedTabulationHash32 = {
-    new TwistedTabulationHash32(Array.fill[Array[Long]](4)(Array.fill[Long](256)(rand.getRandomGenerator.nextLong())))
+    new TwistedTabulationHash32(Array.fill[Long](256 * 4)(rand.getRandomGenerator.nextLong()))
   }
 }
 
-class TwistedTabulationHash32(table: Array[Array[Long]]) extends (Int => Int) {
-  require(table.length == 4)
-  require(table.forall(_.length == 256))
+class TwistedTabulationHash32(table: Array[Long]) extends (Int => Int) {
+  require(table.length == 256 * 4)
 
   override def apply(key: Int): Int = {
     var out: Long = 0
     var keyBuffer: Int = key
-    var i = 0
-    while (i < 3) {
-      out ^= table(i)(keyBuffer & 255)
-      i += 1
+    var offset = 0
+    while (offset < 768) {
+      out ^= table(offset + (keyBuffer & 0xff))
+      offset += 256
       keyBuffer >>>= 8
     }
-    out ^= table(i)((keyBuffer ^ out.toInt) & 255)
+    out ^= table(offset + ((keyBuffer ^ out.toInt) & 0xff))
     (out >>> 32).toInt
   }
 }

--- a/src/main/scala/is/hail/utils/HashMethods.scala
+++ b/src/main/scala/is/hail/utils/HashMethods.scala
@@ -34,11 +34,8 @@ class TwoIndepHash32(outBits: Int, a: Long, b: Long) extends (Int => Int) {
 }
 
 object SimpleTabulationHash32 {
-
-  //TODO: replace java.util.Random with a better PRNG
-  def apply(seed: Long): SimpleTabulationHash32 = {
-    val random = new Random(seed)
-    new SimpleTabulationHash32(Array.fill[Array[Int]](4)(random.ints(256).toArray()))
+  def apply(rand: RandomDataGenerator): SimpleTabulationHash32 = {
+    new SimpleTabulationHash32(Array.fill[Array[Int]](4)(Array.fill[Int](256)(rand.getRandomGenerator.nextInt())))
   }
 }
 
@@ -62,17 +59,14 @@ class SimpleTabulationHash32(table: Array[Array[Int]]) extends (Int => Int) {
 }
 
 object TwistedTabulationHash32 {
-
-  //TODO: replace java.util.Random with a better PRNG
-  def apply(seed: Long): TwistedTabulationHash32 = {
-    val random = new Random(seed)
-    new TwistedTabulationHash32(Array.fill[Array[Long]](4)(random.longs(256).toArray()))
+  def apply(rand: RandomDataGenerator): TwistedTabulationHash32 = {
+    new TwistedTabulationHash32(Array.fill[Array[Long]](4)(Array.fill[Long](256)(rand.getRandomGenerator.nextLong())))
   }
 }
 
 class TwistedTabulationHash32(table: Array[Array[Long]]) extends (Int => Int) {
   require(table.length == 4)
-  for (i <- 0 to 3) require(table(i).length == 256)
+  require(table.forall(_.length == 256))
 
   override def apply(key: Int): Int = {
     var out: Long = 0

--- a/src/main/scala/is/hail/utils/HashMethods.scala
+++ b/src/main/scala/is/hail/utils/HashMethods.scala
@@ -35,23 +35,22 @@ class TwoIndepHash32(outBits: Int, a: Long, b: Long) extends (Int => Int) {
 
 object SimpleTabulationHash32 {
   def apply(rand: RandomDataGenerator): SimpleTabulationHash32 = {
-    new SimpleTabulationHash32(Array.fill[Array[Int]](4)(Array.fill[Int](256)(rand.getRandomGenerator.nextInt())))
+    new SimpleTabulationHash32(Array.fill[Int](256 * 4)(rand.getRandomGenerator.nextInt()))
   }
 }
 
 // see e.g. Thorup, "Fast and Powerful Hashing using Tabulation", for explanation of both simple and twisted tabulation
 // hashing
-class SimpleTabulationHash32(table: Array[Array[Int]]) extends (Int => Int) {
-  require(table.length == 4)
-  require(table(0).length == 256)
+class SimpleTabulationHash32(table: Array[Int]) extends (Int => Int) {
+  require(table.length == 256 * 4)
 
   override def apply(key: Int): Int = {
     var out: Int = 0
     var keyBuffer: Int = key
-    var i = 0
-    while (i < 4) {
-      out ^= table(i)(keyBuffer & 255)
-      i += 1
+    var offset = 0
+    while (offset < 1024) {
+      out ^= table(offset + (keyBuffer & 0xff))
+      offset += 256
       keyBuffer >>>= 8
     }
     out


### PR DESCRIPTION
Implements simple tabulation and twisted tabulation hash methods. See [Fast and Powerful Hashing using Tabulation](http://arxiv.org/abs/1505.01523v5): simple tabulation is described in Section 2, twisted tabulation is described in Section 3, and Figure 1 on p.9 has C code for both.