### PR TITLE
Implement 5-independent tabulation hash

### DIFF
--- a/src/main/scala/is/hail/utils/HashMethods.scala
+++ b/src/main/scala/is/hail/utils/HashMethods.scala
@@ -37,7 +37,7 @@ object FiveIndepTabulationHash32 {
   def apply(rand: RandomDataGenerator): FiveIndepTabulationHash32 =
     new FiveIndepTabulationHash32(
       Array.fill[Long](256 * 4)(rand.getRandomGenerator.nextLong()),
-      Array.fill[Int](261 * 3)(rand.getRandomGenerator.nextInt())
+      Array.fill[Int](259 * 3)(rand.getRandomGenerator.nextInt())
     )
 }
 
@@ -45,7 +45,7 @@ object FiveIndepTabulationHash32 {
 // Second Moment Estimation", section A.7
 class FiveIndepTabulationHash32(keyTable: Array[Long], derivedKeyTable: Array[Int]) extends (Int => Int) {
   require(keyTable.length == 256 * 4)
-  require(derivedKeyTable.length == 261 * 3)
+  require(derivedKeyTable.length == 259 * 3)
 
   override def apply(key: Int): Int = {
     var out: Int = 0

--- a/src/main/scala/is/hail/utils/HashMethods.scala
+++ b/src/main/scala/is/hail/utils/HashMethods.scala
@@ -32,3 +32,45 @@ class TwoIndepHash32(outBits: Int, a: Long, b: Long) extends (Int => Int) {
 
   override def apply(key: Int): Int = ((a * key + b) >>> shift).toInt
 }
+
+object FiveIndepTabulationHash32 {
+  def apply(rand: RandomDataGenerator): FiveIndepTabulationHash32 =
+    new FiveIndepTabulationHash32(
+      Array.fill[Long](256 * 4)(rand.getRandomGenerator.nextLong()),
+      Array.fill[Int](261 * 3)(rand.getRandomGenerator.nextInt())
+    )
+}
+
+// compare to Thorup and Zhang, "Tabulation-Based 5-Independent Hashing with Applications to Linear Probing and
+// Second Moment Estimation", section A.7
+class FiveIndepTabulationHash32(keyTable: Array[Long], derivedKeyTable: Array[Int]) extends (Int => Int) {
+  require(keyTable.length == 256 * 4)
+  require(derivedKeyTable.length == 261 * 3)
+
+  override def apply(key: Int): Int = {
+    var out: Int = 0
+    var derivedKeys: Int = 0
+    var keyBuffer: Int = key
+    var offset = 0
+
+    while (offset < 1024) {
+      val compoundEntry: Long = keyTable(offset + (keyBuffer & 0xff))
+      out ^= (compoundEntry & 0xffffffffL).toInt
+      derivedKeys += (compoundEntry >>> 32).toInt
+      offset += 256
+      keyBuffer >>>= 8
+    }
+
+    def mask1: Int = 0x00300c03 // == (3 << 20) + (3 << 10) + 3
+    def mask2: Int = 0x0ff3fcff // == (255 << 20) + (255 << 10) + 255
+    derivedKeys = mask1 + (derivedKeys & mask2) - ((derivedKeys >> 8) & mask1)
+
+    offset = 0
+    while (offset < 3) {
+      out ^= derivedKeyTable(offset + (derivedKeys & 0x3ff))
+      offset += 261
+      derivedKeys >>> 10
+    }
+    out
+  }
+}


### PR DESCRIPTION
Implements a more involved tabulation based hash function which achieves 5-independence (which will be needed in one of the basic primitives for randomized linear algebra). This method is described in [Tabulation-Based 5-Independent Hashing with Applications to Linear Probing and Second Moment Estimation](http://www.cs.utexas.edu/~yzhang/papers/5-indep-sicomp12.pdf), which provides C code in section A.7.