### PR TITLE
asm4s.Code additions

### DIFF
--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -208,7 +208,7 @@ trait CodeConditional extends Code[Boolean] { self =>
   def unary_!(): CodeConditional =
     new CodeConditional {
       def emitConditional(il: Growable[AbstractInsnNode], ltrue: LabelNode, lfalse: LabelNode) {
-        self.emitConditional(il, ltrue, lfalse)
+        self.emitConditional(il, lfalse, ltrue)
       }
     }
 

--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -180,13 +180,10 @@ trait Code[+T] {
   def compare[U >: T](opcode: Int, rhs: Code[U]): CodeConditional =
     new CodeConditional {
       def emitConditional(il: Growable[AbstractInsnNode], ltrue: LabelNode, lfalse: LabelNode) {
-        val ltrue = new LabelNode
-        val lfalse = new LabelNode
         self.emit(il)
         rhs.emit(il)
         il += new JumpInsnNode(opcode, ltrue)
         il += new JumpInsnNode(GOTO, lfalse)
-        (ltrue, lfalse)
       }
     }
 }

--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -202,7 +202,6 @@ trait CodeConditional extends Code[Boolean] { self =>
     il += lafter
   }
 
-  // returns (ltrue, lfalse)
   def emitConditional(il: Growable[AbstractInsnNode], ltrue: LabelNode, lfalse: LabelNode): Unit
 
   def unary_!(): CodeConditional =

--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -427,7 +427,6 @@ class CodeArray[T](val lhs: Code[Array[T]])(implicit tti: TypeInfo[T]) {
 
   def length(): Code[Int] =
     Code(lhs, new InsnNode(ARRAYLENGTH))
-
 }
 
 object Invokeable {

--- a/src/main/scala/is/hail/asm4s/package.scala
+++ b/src/main/scala/is/hail/asm4s/package.scala
@@ -265,17 +265,13 @@ package object asm4s {
 
   implicit def toCodeBoolean(c: Code[Boolean]): CodeBoolean = new CodeBoolean(c)
 
-
-
   implicit def toCodeInt(c: Code[Int]): CodeInt = new CodeInt(c)
 
-  implicit def byteToCodeInt(c: Code[Byte]): CodeInt = toCodeInt(new Code[Int] {
-    def emit(il: Growable[AbstractInsnNode]) = c.emit(il)
-  })
-
-  implicit def byteToCodeInt2(c: Code[Byte]): Code[Int] = new Code[Int] {
+  implicit def byteToCodeInt(c: Code[Byte]): Code[Int] = new Code[Int] {
     def emit(il: Growable[AbstractInsnNode]) = c.emit(il)
   }
+
+  implicit def byteToCodeInt2(c: Code[Byte]): CodeInt = toCodeInt(byteToCodeInt(c))
 
   implicit def toCodeLong(c: Code[Long]): CodeLong = new CodeLong(c)
 

--- a/src/main/scala/is/hail/asm4s/package.scala
+++ b/src/main/scala/is/hail/asm4s/package.scala
@@ -136,8 +136,8 @@ package object asm4s {
     val name = "B"
     val loadOp = ILOAD
     val storeOp = ISTORE
-    val aloadOp = IALOAD
-    val astoreOp = IASTORE
+    val aloadOp = BALOAD
+    val astoreOp = BASTORE
     val returnOp = IRETURN
     val newarrayOp = NEWARRAY
 
@@ -265,7 +265,17 @@ package object asm4s {
 
   implicit def toCodeBoolean(c: Code[Boolean]): CodeBoolean = new CodeBoolean(c)
 
+
+
   implicit def toCodeInt(c: Code[Int]): CodeInt = new CodeInt(c)
+
+  implicit def byteToCodeInt(c: Code[Byte]): CodeInt = toCodeInt(new Code[Int] {
+    def emit(il: Growable[AbstractInsnNode]) = c.emit(il)
+  })
+
+  implicit def byteToCodeInt2(c: Code[Byte]): Code[Int] = new Code[Int] {
+    def emit(il: Growable[AbstractInsnNode]) = c.emit(il)
+  }
 
   implicit def toCodeLong(c: Code[Long]): CodeLong = new CodeLong(c)
 
@@ -316,4 +326,6 @@ package object asm4s {
   implicit def const(f: Float): Code[Float] = Code(new LdcInsnNode(f))
 
   implicit def const(d: Double): Code[Double] = Code(new LdcInsnNode(d))
+
+  implicit def const(b: Byte): Code[Byte] = Code(new LdcInsnNode(b))
 }


### PR DESCRIPTION
fixes and additions to asm4s.Code

- added invokeStatic with 4 args, fixed invokeStatic with 3 args
- for CodeBoolean, changed && -> & and || -> | for bitwise operations; implemented new && and || as short-circuit boolean operations
- defined some new ops for CodeInt and CodeLong
- fixed TypeInfo for Byte to use BALOAD and BASTORE
- implicit conversions for Byte->Code[Byte], Code[Byte]->CodeInt, Code[Byte]->Code[Int]