### PR TITLE
Semi-native mapValueWithAll (it can only be semi-native)

### DIFF
--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -276,7 +276,7 @@ case class MatrixValue(
       localValue.copy(
         sampleIds = keep.map(sampleIds),
         sampleAnnotations = keep.map(sampleAnnotations)),
-      rdd2 = rdd2.mapPartitionsPreservesPartitioning { it =>
+      rdd2 = rdd2.mapPartitionsPreservesPartitioning(typ.orderedRDD2Type, { it =>
         var rv2b = new RegionValueBuilder()
         var rv2 = RegionValue()
 
@@ -305,7 +305,7 @@ case class MatrixValue(
 
           rv2
         }
-      })
+      }))
   }
 }
 
@@ -397,7 +397,7 @@ case class MatrixRead(
           new ReadRowsRDD(hc.sc, path, typ.rowType, nPartitions))
         if (dropSamples) {
           val localRowType = typ.rowType
-          rdd = rdd.mapPartitionsPreservesPartitioning { it =>
+          rdd = rdd.mapPartitionsPreservesPartitioning(typ.orderedRDD2Type, { it =>
             var rv2b = new RegionValueBuilder()
             var rv2 = RegionValue()
 
@@ -419,7 +419,7 @@ case class MatrixRead(
 
               rv2
             }
-          }
+          })
         }
 
         rdd

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -271,14 +271,13 @@ case class MatrixValue(
       .map(_._2)
     val keepBc = sparkContext.broadcast(keep)
     val localRowType = typ.rowType
-    val localNSamples = nSamples
     copy(localValue =
       localValue.copy(
         sampleIds = keep.map(sampleIds),
         sampleAnnotations = keep.map(sampleAnnotations)),
       rdd2 = rdd2.mapPartitionsPreservesPartitioning(typ.orderedRDD2Type, { it =>
-        var rv2b = new RegionValueBuilder()
-        var rv2 = RegionValue()
+        val rv2b = new RegionValueBuilder()
+        val rv2 = RegionValue()
 
         it.map { rv =>
           rv2b.set(rv.region)
@@ -290,7 +289,6 @@ case class MatrixValue(
 
           rv2b.startArray(keepBc.value.length)
           val gst = localRowType.fieldType(3).asInstanceOf[TArray]
-          val gt = gst.elementType
           val aoff = localRowType.loadField(rv, 3)
           var i = 0
           val length = keepBc.value.length
@@ -379,7 +377,6 @@ case class MatrixRead(
   }
 
   def execute(hc: HailContext): MatrixValue = {
-    val metadata = fileMetadata.metadata
     val localValue =
       if (dropSamples)
         fileMetadata.localValue.dropSamples()
@@ -398,8 +395,8 @@ case class MatrixRead(
         if (dropSamples) {
           val localRowType = typ.rowType
           rdd = rdd.mapPartitionsPreservesPartitioning(typ.orderedRDD2Type, { it =>
-            var rv2b = new RegionValueBuilder()
-            var rv2 = RegionValue()
+            val rv2b = new RegionValueBuilder()
+            val rv2 = RegionValue()
 
             it.map { rv =>
               rv2b.set(rv.region)

--- a/src/main/scala/is/hail/sparkextras/OrderedRDD2.scala
+++ b/src/main/scala/is/hail/sparkextras/OrderedRDD2.scala
@@ -680,13 +680,8 @@ class OrderedRDD2 private(
       })
   }
 
-  def mapPreservesPartitioning(f: (RegionValue) => RegionValue): OrderedRDD2 =
-    OrderedRDD2(typ,
-      orderedPartitioner,
-      rdd.map(f))
-
-  def mapPartitionsPreservesPartitioning(f: (Iterator[RegionValue]) => Iterator[RegionValue]): OrderedRDD2 =
-    OrderedRDD2(typ,
+  def mapPartitionsPreservesPartitioning(newType: OrderedRDD2Type, f: (Iterator[RegionValue]) => Iterator[RegionValue]): OrderedRDD2 =
+    OrderedRDD2(newType,
       orderedPartitioner,
       rdd.mapPartitions(f))
 

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -309,46 +309,6 @@ class VariantDatasetFunctions(private val vds: VariantDataset) extends AnyVal {
     FilterAlleles(vds, filterExpr, annotationExpr, filterAlteredGenotypes, keep, subset, maxShift, keepStar)
   }
 
-  /**
-    *
-    * @param filterExpr filter expression involving v (Variant), va (variant annotations), s (sample),
-    * sa (sample annotations), and g (genotype), which returns a boolean value
-    * @param keep keep genotypes where filterExpr evaluates to true
-    */
-  def filterGenotypes(filterExpr: String, keep: Boolean = true): VariantDataset = {
-    val vas = vds.vaSignature
-    val sas = vds.saSignature
-
-    val symTab = Map(
-      "v" -> (0, TVariant(GenomeReference.GRCh37)),
-      "va" -> (1, vas),
-      "s" -> (2, TString),
-      "sa" -> (3, sas),
-      "g" -> (4, TGenotype),
-      "global" -> (5, vds.globalSignature))
-
-
-    val ec = EvalContext(symTab)
-    ec.set(5, vds.globalAnnotation)
-    val f: () => java.lang.Boolean = Parser.parseTypedExpr[java.lang.Boolean](filterExpr, ec)
-
-    val sampleIdsBc = vds.sampleIdsBc
-    val sampleAnnotationsBc = vds.sampleAnnotationsBc
-
-    (vds.sampleIds, vds.sampleAnnotations).zipped.map((_, _))
-
-    val noCall = Genotype()
-    val localKeep = keep
-    vds.mapValuesWithAll(vds.genotypeSignature, { (v: Variant, va: Annotation, s: Annotation, sa: Annotation, g: Genotype) =>
-      ec.setAll(v, va, s, sa, g)
-
-      if (Filter.boxedKeepThis(f(), localKeep))
-        g
-      else
-        noCall
-    })
-  }
-
   def grm(): KinshipMatrix = {
     require(vds.wasSplit)
     info("Computing GRM...")

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -1355,7 +1355,6 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
 
           val v = ur.getAs[RK](1)
           val va = ur.get(2)
-          val gs = ur.getAs[Iterable[T]](3)
 
           rv2b.set(rv.region)
           rv2b.start(newRowType)
@@ -1365,7 +1364,8 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
           rv2b.addField(localRowType, rv, 2) // va
 
           rv2b.startArray(localNSamples) // gs
-        val gsAOff = localRowType.loadField(rv, 3)
+
+          val gsAOff = localRowType.loadField(rv, 3)
           var i = 0
           while (i < localNSamples) {
             if (gsType.isElementDefined(rv.region, gsAOff, i)) {

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -1335,6 +1335,9 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
 
   def mapValuesWithAll[U >: Null](newGSignature: Type, f: (RK, Annotation, Annotation, Annotation, T) => U)
     (implicit uct: ClassTag[U]): VariantSampleMatrix[RPK, RK, U] = {
+    val newMatrixType = matrixType.copy(genotypeType = newGSignature)
+    val newRowType = newMatrixType.rowType
+
     val localRowType = rowType
     val gsType = rowType.fieldType(3).asInstanceOf[TArray]
     val gType = gsType.elementType
@@ -1356,7 +1359,7 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
           val gs = ur.getAs[Iterable[T]](3)
 
           rv2b.set(rv.region)
-          rv2b.start(localRowType)
+          rv2b.start(newRowType)
           rv2b.startStruct()
           rv2b.addField(localRowType, rv, 0) // locus
           rv2b.addField(localRowType, rv, 1) // v
@@ -1372,7 +1375,7 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
               val s = localSampleIdsBc.value(i)
               val sa = localSampleAnnotationsBc.value(i)
               val g = UnsafeRow.read(gType, rv.region, gOff).asInstanceOf[T]
-              rv2b.addAnnotation(gType, f(v, va, s, sa, g))
+              rv2b.addAnnotation(newGSignature, f(v, va, s, sa, g))
             } else
               rv2b.setMissing()
 

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -1365,7 +1365,7 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
           rv2b.addField(localRowType, rv, 2) // va
 
           rv2b.startArray(localNSamples) // gs
-          val gsAOff = localRowType.loadField(rv, 3)
+        val gsAOff = localRowType.loadField(rv, 3)
           var i = 0
           while (i < localNSamples) {
             if (gsType.isElementDefined(rv.region, gsAOff, i)) {
@@ -1841,7 +1841,13 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
 
   def setVaAttributes(path: List[String], kv: Map[String, String]): VariantSampleMatrix[RPK, RK, T] = {
     vaSignature match {
-      case t: TStruct => copy2(vaSignature = t.setFieldAttributes(path, kv))
+      case t: TStruct =>
+        val newVAType = t.setFieldAttributes(path, kv)
+        val newMatrixType = matrixType.copy(vaType = newVAType)
+        copy2(vaSignature = newVAType,
+          rdd2 = OrderedRDD2(newMatrixType.orderedRDD2Type,
+            rdd2.orderedPartitioner,
+            rdd2))
       case t => fatal(s"Cannot set va attributes to ${ path.mkString(".") } since va is not a Struct.")
     }
   }
@@ -1852,7 +1858,13 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
 
   def deleteVaAttribute(path: List[String], attribute: String): VariantSampleMatrix[RPK, RK, T] = {
     vaSignature match {
-      case t: TStruct => copy2(vaSignature = t.deleteFieldAttribute(path, attribute))
+      case t: TStruct =>
+        val newVAType = t.deleteFieldAttribute(path, attribute)
+        val newMatrixType = matrixType.copy(vaType = newVAType)
+        copy2(vaSignature = newVAType,
+          rdd2 = OrderedRDD2(newMatrixType.orderedRDD2Type,
+            rdd2.orderedPartitioner,
+            rdd2))
       case t => fatal(s"Cannot delete va attributes from ${ path.mkString(".") } since va is not a Struct.")
     }
   }

--- a/src/test/scala/is/hail/io/LoadBgenSuite.scala
+++ b/src/test/scala/is/hail/io/LoadBgenSuite.scala
@@ -273,11 +273,9 @@ class LoadBgenSuite extends SparkSuite {
   @Test def testReIterate() {
     hc.indexBgen("src/test/resources/example.v11.bgen")
     val vds = hc.importBgen("src/test/resources/example.v11.bgen", Some("src/test/resources/example.sample"))
-      .annotateGenotypesExpr("g = Genotype(v, g.GT, g.GP)")
-      .toVDS
 
-    assert(vds.annotateVariantsExpr("va.cr1 = gs.fraction(g => g.isCalled())")
-      .annotateVariantsExpr("va.cr2 = gs.fraction(g => g.isCalled())")
+    assert(vds.annotateVariantsExpr("va.cr1 = gs.fraction(g => g.GT.isCalled())")
+      .annotateVariantsExpr("va.cr2 = gs.fraction(g => g.GT.isCalled())")
       .variantsKT()
       .forall("va.cr1 == va.cr2"))
   }


### PR DESCRIPTION
mapValuesWithAll should go away eventually (as should all routines representing runtime values as Annotation).
This makes filterGenotypes semi-native in particular.
Removed unused filterGenotypes on VariantDataset.
Removed unused mapPartitionsWithAll.