### PR TITLE
read POSIX TMPDIR for hail temporary directory

### DIFF
--- a/python/hail/context.py
+++ b/python/hail/context.py
@@ -40,8 +40,8 @@ class HailContext(HistoryMixin):
     :param branching_factor: Branching factor for tree aggregation.
 
     :param tmp_dir: Temporary directory for file merging. If None, use the value
-                    of the environment variable TMPDIR, unless TMPDIR is unset
-                    or the empty string, in which case use '/tmp'.
+                    of the environment variable TMPDIR, unless TMPDIR is unset,
+                    in which case use '/tmp'.
 
     :ivar sc: Spark context
     :vartype sc: :class:`.pyspark.SparkContext`

--- a/python/hail/context.py
+++ b/python/hail/context.py
@@ -9,7 +9,7 @@ from hail.expr import Type
 from hail.java import *
 from hail.keytable import KeyTable
 from hail.stats import UniformDist, TruncatedBetaDist, BetaDist
-from hail.utils import wrap_to_list
+from hail.utils import wrap_to_list, get_env_or_default
 from hail.history import *
 
 
@@ -55,10 +55,10 @@ class HailContext(HistoryMixin):
                       append=bool,
                       min_block_size=integral,
                       branching_factor=integral,
-                      tmp_dir=strlike)
+                      maybe_tmp_dir=nullable(strlike))
     def __init__(self, sc=None, app_name="Hail", master=None, local='local[*]',
                  log='hail.log', quiet=False, append=False,
-                 min_block_size=1, branching_factor=50, tmp_dir='/tmp'):
+                 min_block_size=1, branching_factor=50, maybe_tmp_dir=None):
 
         if Env._hc:
             raise FatalError('Hail Context has already been created, restart session '
@@ -76,6 +76,8 @@ class HailContext(HistoryMixin):
         Env._gateway = self._gateway
 
         jsc = sc._jsc.sc() if sc else None
+
+        tmp_dir = get_env_or_default(maybe_tmp_dir, 'TMPDIR', '/tmp')
 
         # we always pass 'quiet' to the JVM because stderr output needs
         # to be routed through Python separately.

--- a/python/hail/context.py
+++ b/python/hail/context.py
@@ -39,10 +39,13 @@ class HailContext(HistoryMixin):
 
     :param branching_factor: Branching factor for tree aggregation.
 
-    :param tmp_dir: Temporary directory for file merging.
+    :param tmp_dir: Temporary directory for file merging. If None, use the value
+                    of the environment variable TMPDIR, unless TMPDIR is unset
+                    or the empty string, in which case use '/tmp'.
 
     :ivar sc: Spark context
     :vartype sc: :class:`.pyspark.SparkContext`
+
     """
 
     @record_init
@@ -55,10 +58,10 @@ class HailContext(HistoryMixin):
                       append=bool,
                       min_block_size=integral,
                       branching_factor=integral,
-                      maybe_tmp_dir=nullable(strlike))
+                      tmp_dir=nullable(strlike))
     def __init__(self, sc=None, app_name="Hail", master=None, local='local[*]',
                  log='hail.log', quiet=False, append=False,
-                 min_block_size=1, branching_factor=50, maybe_tmp_dir=None):
+                 min_block_size=1, branching_factor=50, tmp_dir=None):
 
         if Env._hc:
             raise FatalError('Hail Context has already been created, restart session '
@@ -77,7 +80,7 @@ class HailContext(HistoryMixin):
 
         jsc = sc._jsc.sc() if sc else None
 
-        tmp_dir = get_env_or_default(maybe_tmp_dir, 'TMPDIR', '/tmp')
+        tmp_dir = get_env_or_default(tmp_dir, 'TMPDIR', '/tmp')
 
         # we always pass 'quiet' to the JVM because stderr output needs
         # to be routed through Python separately.

--- a/python/hail/utils.py
+++ b/python/hail/utils.py
@@ -232,3 +232,13 @@ def wrap_to_list(s):
         return s
     else:
         return [s]
+
+def get_env_or_default(maybe, envvar, default):
+    import os
+
+    if (maybe != None):
+        return maybe
+    elif (envvar in os.environ and os.environ[envvar] != ""):
+        return os.environ[envvar]
+    else:
+        return default

--- a/python/hail/utils.py
+++ b/python/hail/utils.py
@@ -236,9 +236,4 @@ def wrap_to_list(s):
 def get_env_or_default(maybe, envvar, default):
     import os
 
-    if (maybe != None):
-        return maybe
-    elif (envvar in os.environ and os.environ[envvar] != ""):
-        return os.environ[envvar]
-    else:
-        return default
+    return maybe or os.environ.get(envvar) or default


### PR DESCRIPTION
> TMPDIR
>     This variable shall represent a pathname of a directory made
>     available for programs that need a place to create temporary
>     files.

http://pubs.opengroup.org/onlinepubs/9699919799/

Requested by the discuss user rca:

http://discuss.hail.is/t/hailcontext-tmp-dir/323