### PR TITLE
improve staged Type methods

### DIFF
--- a/src/main/scala/is/hail/annotations/MemoryBlock.scala
+++ b/src/main/scala/is/hail/annotations/MemoryBlock.scala
@@ -739,15 +739,15 @@ class RegionValueBuilder(var region: MemoryBuffer) {
         if (t.isElementDefined(fromRegion, fromAOff, i)) {
           t.elementType match {
             case t2: TStruct =>
-              fixupStruct(t2, t.elementOffset(toAOff, length, i), fromRegion, t.elementOffset(fromAOff, length, i))
+              fixupStruct(t2, t.elementOffsetInRegion(toAOff, length, i), fromRegion, t.elementOffsetInRegion(fromAOff, length, i))
 
             case t2: TArray =>
               val toAOff2 = fixupArray(t2, fromRegion, t.loadElement(fromRegion, fromAOff, length, i))
-              region.storeAddress(t.elementOffset(toAOff, length, i), toAOff2)
+              region.storeAddress(t.elementOffsetInRegion(toAOff, length, i), toAOff2)
 
             case TBinary =>
               val toBOff = fixupBinary(fromRegion, t.loadElement(fromRegion, fromAOff, length, i))
-              region.storeAddress(t.elementOffset(toAOff, length, i), toBOff)
+              region.storeAddress(t.elementOffsetInRegion(toAOff, length, i), toBOff)
 
             case _ =>
           }
@@ -798,7 +798,7 @@ class RegionValueBuilder(var region: MemoryBuffer) {
   def addElement(t: TArray, fromRegion: MemoryBuffer, fromAOff: Long, i: Int) {
     if (t.isElementDefined(fromRegion, fromAOff, i))
       addRegionValue(t.elementType, fromRegion,
-        t.elementOffset(fromRegion, fromAOff, i))
+        t.elementOffsetInRegion(fromRegion, fromAOff, i))
     else
       setMissing()
   }

--- a/src/main/scala/is/hail/annotations/MemoryBlock.scala
+++ b/src/main/scala/is/hail/annotations/MemoryBlock.scala
@@ -739,15 +739,15 @@ class RegionValueBuilder(var region: MemoryBuffer) {
         if (t.isElementDefined(fromRegion, fromAOff, i)) {
           t.elementType match {
             case t2: TStruct =>
-              fixupStruct(t2, t.elementOffsetInRegion(toAOff, length, i), fromRegion, t.elementOffsetInRegion(fromAOff, length, i))
+              fixupStruct(t2, t.elementOffset(toAOff, length, i), fromRegion, t.elementOffset(fromAOff, length, i))
 
             case t2: TArray =>
               val toAOff2 = fixupArray(t2, fromRegion, t.loadElement(fromRegion, fromAOff, length, i))
-              region.storeAddress(t.elementOffsetInRegion(toAOff, length, i), toAOff2)
+              region.storeAddress(t.elementOffset(toAOff, length, i), toAOff2)
 
             case TBinary =>
               val toBOff = fixupBinary(fromRegion, t.loadElement(fromRegion, fromAOff, length, i))
-              region.storeAddress(t.elementOffsetInRegion(toAOff, length, i), toBOff)
+              region.storeAddress(t.elementOffset(toAOff, length, i), toBOff)
 
             case _ =>
           }

--- a/src/main/scala/is/hail/annotations/UnsafeUtils.scala
+++ b/src/main/scala/is/hail/annotations/UnsafeUtils.scala
@@ -1,11 +1,18 @@
 package is.hail.annotations
 
+import is.hail.asm4s._
 import is.hail.expr.Type
 
 object UnsafeUtils {
   def arrayElementSize(t: Type): Long = roundUpAlignment(t.byteSize, t.alignment)
 
   def roundUpAlignment(offset: Long, alignment: Long): Long = {
+    assert(alignment > 0)
+    assert((alignment & (alignment - 1)) == 0) // power of 2
+    (offset + (alignment - 1)) & ~(alignment - 1)
+  }
+
+  def roundUpAlignment(offset: Code[Long], alignment: Long): Code[Long] = {
     assert(alignment > 0)
     assert((alignment & (alignment - 1)) == 0) // power of 2
     (offset + (alignment - 1)) & ~(alignment - 1)

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -708,20 +708,20 @@ abstract class TContainer extends Type {
     region.setBit(aoff + 4L, i.toL)
   }
 
-  def elementOffsetInRegion(aoff: Long, length: Int, i: Int): Long =
+  def elementOffset(aoff: Long, length: Int, i: Int): Long =
     aoff + elementsOffset(length) + i * elementByteSize
 
   def elementOffsetInRegion(region: MemoryBuffer, aoff: Long, i: Int): Long =
-    elementOffsetInRegion(aoff, region.loadInt(aoff), i)
+    elementOffset(aoff, region.loadInt(aoff), i)
 
-  def elementOffsetInRegion(aoff: Code[Long], length: Code[Int], i: Code[Int]): Code[Long] =
+  def elementOffset(aoff: Code[Long], length: Code[Int], i: Code[Int]): Code[Long] =
     aoff + elementsOffset(length) + i.toL * const(elementByteSize)
 
   def elementOffsetInRegion(region: Code[MemoryBuffer], aoff: Code[Long], i: Code[Int]): Code[Long] =
-    elementOffsetInRegion(aoff, region.loadInt(aoff), i)
+    elementOffset(aoff, region.loadInt(aoff), i)
 
   def loadElement(region: MemoryBuffer, aoff: Long, length: Int, i: Int): Long = {
-    val off = elementOffsetInRegion(aoff, length, i)
+    val off = elementOffset(aoff, length, i)
     elementType.fundamentalType match {
       case _: TArray | TBinary => region.loadAddress(off)
       case _ => off
@@ -729,7 +729,7 @@ abstract class TContainer extends Type {
   }
 
   def loadElement(region: Code[MemoryBuffer], aoff: Code[Long], length: Code[Int], i: Code[Int]): Code[Long] = {
-    val off = elementOffsetInRegion(aoff, length, i)
+    val off = elementOffset(aoff, length, i)
     elementType.fundamentalType match {
       case _: TArray | TBinary => region.loadAddress(off)
       case _ => off

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -642,6 +642,14 @@ final case class TAggregable(elementType: Type) extends TContainer {
     throw new RuntimeException("TAggregable is not realizable")
 }
 
+object TContainer {
+  def loadLength(region: MemoryBuffer, aoff: Long): Int =
+    region.loadInt(aoff)
+
+  def loadLength(region: Code[MemoryBuffer], aoff: Code[Long]): Code[Int] =
+    region.invoke[Long, Int]("loadInt", aoff)
+}
+
 abstract class TContainer extends Type {
   def elementType: Type
 
@@ -653,8 +661,17 @@ abstract class TContainer extends Type {
 
   override def children = Seq(elementType)
 
+  final def loadLength(region: MemoryBuffer, aoff: Long): Int =
+    TContainer.loadLength(region,  aoff)
+
+  final def loadLength(region: Code[MemoryBuffer], aoff: Code[Long]): Code[Int] =
+    TContainer.loadLength(region, aoff)
+
   def _elementsOffset(length: Int): Long =
     UnsafeUtils.roundUpAlignment(4 + ((length + 7) >>> 3), elementType.alignment)
+
+  def _elementsOffset(length: Code[Int]): Code[Long] =
+    UnsafeUtils.roundUpAlignment(((length.toL + 7) >>> 3) + 4, elementType.alignment)
 
   var elementsOffsetTable: Array[Long] = _
 
@@ -669,10 +686,8 @@ abstract class TContainer extends Type {
   }
 
   def elementsOffset(length: Code[Int]): Code[Long] = {
-    val alignment = elementType.alignment
-    assert(alignment > 0)
-    assert((alignment & (alignment - 1)) == 0) // power of 2
-    ((((length + 7) >>> 3) + 4).toL + (alignment - 1)) & ~(alignment - 1)
+    // FIXME: incorporate table, maybe?
+    _elementsOffset(length)
   }
 
   def contentsByteSize(length: Int): Long =
@@ -681,12 +696,6 @@ abstract class TContainer extends Type {
   def contentsByteSize(length: Code[Int]): Code[Long] = {
     elementsOffset(length) + length.toL * elementByteSize
   }
-
-  def loadLength(region: MemoryBuffer, aoff: Long): Int =
-    region.loadInt(aoff)
-
-  def loadLength(region: Code[MemoryBuffer], aoff: Code[Long]): Code[Int] =
-    region.invoke[Long, Int]("loadInt", aoff)
 
   def isElementDefined(region: MemoryBuffer, aoff: Long, i: Int): Boolean =
     !region.loadBit(aoff + 4, i)
@@ -705,15 +714,32 @@ abstract class TContainer extends Type {
   def elementOffset(region: MemoryBuffer, aoff: Long, i: Int): Long =
     elementOffset(aoff, region.loadInt(aoff), i)
 
+  def elementOffset(aoff: Code[Long], length: Code[Int], i: Code[Int]): Code[Long] =
+    aoff + elementsOffset(length) + i.toL * const(elementByteSize)
+
+  def elementOffsetInRegion(region: Code[MemoryBuffer], aoff: Code[Long], i: Code[Int]): Code[Long] =
+    elementOffset(aoff, region.loadInt(aoff), i)
+
   def loadElement(region: MemoryBuffer, aoff: Long, length: Int, i: Int): Long = {
     val off = elementOffset(aoff, length, i)
     elementType.fundamentalType match {
-      case _: TArray | TBinary => region.loadInt(off)
+      case _: TArray | TBinary => region.loadAddress(off)
+      case _ => off
+    }
+  }
+
+  def loadElement(region: Code[MemoryBuffer], aoff: Code[Long], length: Code[Int], i: Code[Int]): Code[Long] = {
+    val off = elementOffset(aoff, length, i)
+    elementType.fundamentalType match {
+      case _: TArray | TBinary => region.loadAddress(off)
       case _ => off
     }
   }
 
   def loadElement(region: MemoryBuffer, aoff: Long, i: Int): Long =
+    loadElement(region, aoff, region.loadInt(aoff), i)
+
+  def loadElement(region: Code[MemoryBuffer], aoff: Code[Long], i: Code[Int]): Code[Long] =
     loadElement(region, aoff, region.loadInt(aoff), i)
 
   def allocate(region: MemoryBuffer, length: Int): Long = {
@@ -1967,6 +1993,9 @@ final case class TStruct(fields: IndexedSeq[Field]) extends Type {
   }
 
   def fieldOffset(offset: Long, fieldIdx: Int): Long =
+    offset + byteOffsets(fieldIdx)
+
+  def fieldOffset(offset: Code[Long], fieldIdx: Int): Code[Long] =
     offset + byteOffsets(fieldIdx)
 
   def loadField(rv: RegionValue, fieldIdx: Int): Long = loadField(rv.region, rv.offset, fieldIdx)

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -712,13 +712,13 @@ abstract class TContainer extends Type {
     aoff + elementsOffset(length) + i * elementByteSize
 
   def elementOffsetInRegion(region: MemoryBuffer, aoff: Long, i: Int): Long =
-    elementOffset(aoff, region.loadInt(aoff), i)
+    elementOffset(aoff, loadLength(region, aoff), i)
 
   def elementOffset(aoff: Code[Long], length: Code[Int], i: Code[Int]): Code[Long] =
     aoff + elementsOffset(length) + i.toL * const(elementByteSize)
 
   def elementOffsetInRegion(region: Code[MemoryBuffer], aoff: Code[Long], i: Code[Int]): Code[Long] =
-    elementOffset(aoff, region.loadInt(aoff), i)
+    elementOffset(aoff, loadLength(region, aoff), i)
 
   def loadElement(region: MemoryBuffer, aoff: Long, length: Int, i: Int): Long = {
     val off = elementOffset(aoff, length, i)

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -647,7 +647,7 @@ object TContainer {
     region.loadInt(aoff)
 
   def loadLength(region: Code[MemoryBuffer], aoff: Code[Long]): Code[Int] =
-    region.invoke[Long, Int]("loadInt", aoff)
+    region.loadInt(aoff)
 }
 
 abstract class TContainer extends Type {
@@ -708,20 +708,20 @@ abstract class TContainer extends Type {
     region.setBit(aoff + 4L, i.toL)
   }
 
-  def elementOffset(aoff: Long, length: Int, i: Int): Long =
+  def elementOffsetInRegion(aoff: Long, length: Int, i: Int): Long =
     aoff + elementsOffset(length) + i * elementByteSize
 
-  def elementOffset(region: MemoryBuffer, aoff: Long, i: Int): Long =
-    elementOffset(aoff, region.loadInt(aoff), i)
+  def elementOffsetInRegion(region: MemoryBuffer, aoff: Long, i: Int): Long =
+    elementOffsetInRegion(aoff, region.loadInt(aoff), i)
 
-  def elementOffset(aoff: Code[Long], length: Code[Int], i: Code[Int]): Code[Long] =
+  def elementOffsetInRegion(aoff: Code[Long], length: Code[Int], i: Code[Int]): Code[Long] =
     aoff + elementsOffset(length) + i.toL * const(elementByteSize)
 
   def elementOffsetInRegion(region: Code[MemoryBuffer], aoff: Code[Long], i: Code[Int]): Code[Long] =
-    elementOffset(aoff, region.loadInt(aoff), i)
+    elementOffsetInRegion(aoff, region.loadInt(aoff), i)
 
   def loadElement(region: MemoryBuffer, aoff: Long, length: Int, i: Int): Long = {
-    val off = elementOffset(aoff, length, i)
+    val off = elementOffsetInRegion(aoff, length, i)
     elementType.fundamentalType match {
       case _: TArray | TBinary => region.loadAddress(off)
       case _ => off
@@ -729,7 +729,7 @@ abstract class TContainer extends Type {
   }
 
   def loadElement(region: Code[MemoryBuffer], aoff: Code[Long], length: Code[Int], i: Code[Int]): Code[Long] = {
-    val off = elementOffset(aoff, length, i)
+    val off = elementOffsetInRegion(aoff, length, i)
     elementType.fundamentalType match {
       case _: TArray | TBinary => region.loadAddress(off)
       case _ => off

--- a/src/main/scala/is/hail/utils/richUtils/RichCodeMemoryBuffer.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichCodeMemoryBuffer.scala
@@ -55,6 +55,26 @@ class RichCodeMemoryBuffer(val region: Code[MemoryBuffer]) extends AnyVal {
     region.invoke[Long, Boolean]("loadBoolean", off)
   }
 
+  def loadInt(off: Code[Long]): Code[Int] = {
+    region.invoke[Long, Int]("loadInt", off)
+  }
+
+  def loadLong(off: Code[Long]): Code[Long] = {
+    region.invoke[Long, Long]("loadLong", off)
+  }
+
+  def loadFloat(off: Code[Long]): Code[Float] = {
+    region.invoke[Long, Float]("loadFloat", off)
+  }
+
+  def loadDouble(off: Code[Long]): Code[Double] = {
+    region.invoke[Long, Double]("loadDouble", off)
+  }
+
+  def loadAddress(off: Code[Long]): Code[Long] = {
+    region.invoke[Long, Long]("loadAddress", off)
+  }
+
   def loadBit(byteOff: Code[Long], bitOff: Code[Long]): Code[Boolean] = {
     region.invoke[Long, Long, Boolean]("loadBit", byteOff, bitOff)
   }

--- a/src/main/scala/is/hail/variant/HTSGenotypeView.scala
+++ b/src/main/scala/is/hail/variant/HTSGenotypeView.scala
@@ -102,7 +102,7 @@ class TGenotypeView(rs: TStruct) extends HTSGenotypeView {
       throw new ArrayIndexOutOfBoundsException(idx)
     assert(HTSGenotypeView.tArrayInt32.isElementDefined(m, adOffset, idx))
 
-    val elementOffset = HTSGenotypeView.tArrayInt32.elementOffset(adOffset, length, idx)
+    val elementOffset = HTSGenotypeView.tArrayInt32.elementOffsetInRegion(adOffset, length, idx)
     m.loadInt(elementOffset)
   }
 
@@ -122,7 +122,7 @@ class TGenotypeView(rs: TStruct) extends HTSGenotypeView {
     if (idx < 0 || idx >= length)
       throw new ArrayIndexOutOfBoundsException(idx)
     assert(HTSGenotypeView.tArrayInt32.isElementDefined(m, pxOffset, idx))
-    val elementOffset = HTSGenotypeView.tArrayInt32.elementOffset(pxOffset, length, idx)
+    val elementOffset = HTSGenotypeView.tArrayInt32.elementOffsetInRegion(pxOffset, length, idx)
     m.loadInt(elementOffset)
   }
 
@@ -192,7 +192,7 @@ private class StructGenotypeView(rs: TStruct) extends HTSGenotypeView {
       throw new ArrayIndexOutOfBoundsException(idx)
     assert(HTSGenotypeView.tArrayInt32.isElementDefined(m, adOffset, idx))
 
-    val elementOffset = HTSGenotypeView.tArrayInt32.elementOffset(adOffset, length, idx)
+    val elementOffset = HTSGenotypeView.tArrayInt32.elementOffsetInRegion(adOffset, length, idx)
     m.loadInt(elementOffset)
   }
 
@@ -212,7 +212,7 @@ private class StructGenotypeView(rs: TStruct) extends HTSGenotypeView {
     if (idx < 0 || idx >= length)
       throw new ArrayIndexOutOfBoundsException(idx)
     assert(HTSGenotypeView.tArrayInt32.isElementDefined(m, pxOffset, idx))
-    val elementOffset = HTSGenotypeView.tArrayInt32.elementOffset(pxOffset, length, idx)
+    val elementOffset = HTSGenotypeView.tArrayInt32.elementOffsetInRegion(pxOffset, length, idx)
     m.loadInt(elementOffset)
   }
 

--- a/src/main/scala/is/hail/variant/HTSGenotypeView.scala
+++ b/src/main/scala/is/hail/variant/HTSGenotypeView.scala
@@ -102,7 +102,7 @@ class TGenotypeView(rs: TStruct) extends HTSGenotypeView {
       throw new ArrayIndexOutOfBoundsException(idx)
     assert(HTSGenotypeView.tArrayInt32.isElementDefined(m, adOffset, idx))
 
-    val elementOffset = HTSGenotypeView.tArrayInt32.elementOffsetInRegion(adOffset, length, idx)
+    val elementOffset = HTSGenotypeView.tArrayInt32.elementOffset(adOffset, length, idx)
     m.loadInt(elementOffset)
   }
 
@@ -122,7 +122,7 @@ class TGenotypeView(rs: TStruct) extends HTSGenotypeView {
     if (idx < 0 || idx >= length)
       throw new ArrayIndexOutOfBoundsException(idx)
     assert(HTSGenotypeView.tArrayInt32.isElementDefined(m, pxOffset, idx))
-    val elementOffset = HTSGenotypeView.tArrayInt32.elementOffsetInRegion(pxOffset, length, idx)
+    val elementOffset = HTSGenotypeView.tArrayInt32.elementOffset(pxOffset, length, idx)
     m.loadInt(elementOffset)
   }
 
@@ -192,7 +192,7 @@ private class StructGenotypeView(rs: TStruct) extends HTSGenotypeView {
       throw new ArrayIndexOutOfBoundsException(idx)
     assert(HTSGenotypeView.tArrayInt32.isElementDefined(m, adOffset, idx))
 
-    val elementOffset = HTSGenotypeView.tArrayInt32.elementOffsetInRegion(adOffset, length, idx)
+    val elementOffset = HTSGenotypeView.tArrayInt32.elementOffset(adOffset, length, idx)
     m.loadInt(elementOffset)
   }
 
@@ -212,7 +212,7 @@ private class StructGenotypeView(rs: TStruct) extends HTSGenotypeView {
     if (idx < 0 || idx >= length)
       throw new ArrayIndexOutOfBoundsException(idx)
     assert(HTSGenotypeView.tArrayInt32.isElementDefined(m, pxOffset, idx))
-    val elementOffset = HTSGenotypeView.tArrayInt32.elementOffsetInRegion(pxOffset, length, idx)
+    val elementOffset = HTSGenotypeView.tArrayInt32.elementOffset(pxOffset, length, idx)
     m.loadInt(elementOffset)
   }
 


### PR DESCRIPTION
 - `TContainer.loadLength` is now on the object so creating byte code to
   read the length does not require knowledge of the element type

 - in `elementsOffset`, use the non-Code pattern of delegating to
   `roundUpAlignment`

 - add staged `TContainer.elementOffset`, `TContainer.loadElement`,
   `TStruct.fieldOffset`, `UnsafeUtils.roundUpAlignment`

 - fix bug: loadElement reads addresses using `loadAddress` instead of
   `loadInt`

 - add several `loadX` methods to `RichCodeMemoryBuffer`.