### PR TITLE
In MIS example, throw away conflicting columns before joining

### DIFF
--- a/python/hail/keytable.py
+++ b/python/hail/keytable.py
@@ -1517,6 +1517,7 @@ class KeyTable(HistoryMixin):
         >>> related_samples = related_pairs.query('i.flatMap(i => [i,j]).collectAsSet()')
         >>> related_samples_to_keep = (related_pairs
         ...   .key_by("i").join(vds.samples_table()).annotate('iAndCase = { id: i, isCase: sa.isCase }')
+        ...   .select(['j', 'iAndCase'])
         ...   .key_by("j").join(vds.samples_table()).annotate('jAndCase = { id: j, isCase: sa.isCase }')
         ...   .select(['iAndCase', 'jAndCase'])
         ...   .maximal_independent_set("iAndCase", "jAndCase",


### PR DESCRIPTION
Somehow, this didn't trigger an error in master but did in 0.1. Nonetheless, removing unnecessary data seems good.