### PR TITLE
allow creation of arrayInfo from element TypeInfo

### DIFF
--- a/src/main/scala/is/hail/asm4s/AsmFunction.scala
+++ b/src/main/scala/is/hail/asm4s/AsmFunction.scala
@@ -3,3 +3,6 @@ package is.hail.asm4s
 trait AsmFunction0[R] { def apply(): R }
 trait AsmFunction1[A,R] { def apply(a: A): R }
 trait AsmFunction2[A,B,R] { def apply(a: A, b: B): R }
+trait AsmFunction3[A,B,C,R] { def apply(a: A, b: B, c: C): R }
+trait AsmFunction4[A,B,C,D,R] { def apply(a: A, b: B, c: C, d: D): R }
+trait AsmFunction5[A,B,C,D,E,R] { def apply(a: A, b: B, c: C, d: D, e: E): R }

--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -67,6 +67,48 @@ object Code {
       }
     }
 
+  def apply[S1, S2, S3, S4, S5, S6, S7](c1: Code[S1], c2: Code[S2], c3: Code[S3], c4: Code[S4], c5: Code[S5], c6: Code[S6], c7: Code[S7]): Code[S7] =
+    new Code[S7] {
+      def emit(il: Growable[AbstractInsnNode]): Unit = {
+        c1.emit(il)
+        c2.emit(il)
+        c3.emit(il)
+        c4.emit(il)
+        c5.emit(il)
+        c6.emit(il)
+        c7.emit(il)
+      }
+    }
+
+  def apply[S1, S2, S3, S4, S5, S6, S7, S8](c1: Code[S1], c2: Code[S2], c3: Code[S3], c4: Code[S4], c5: Code[S5], c6: Code[S6], c7: Code[S7], c8: Code[S8]): Code[S8] =
+    new Code[S8] {
+      def emit(il: Growable[AbstractInsnNode]): Unit = {
+        c1.emit(il)
+        c2.emit(il)
+        c3.emit(il)
+        c4.emit(il)
+        c5.emit(il)
+        c6.emit(il)
+        c7.emit(il)
+        c8.emit(il)
+      }
+    }
+
+  def apply[S1, S2, S3, S4, S5, S6, S7, S8, S9](c1: Code[S1], c2: Code[S2], c3: Code[S3], c4: Code[S4], c5: Code[S5], c6: Code[S6], c7: Code[S7], c8: Code[S8], c9: Code[S9]): Code[S9] =
+    new Code[S9] {
+      def emit(il: Growable[AbstractInsnNode]): Unit = {
+        c1.emit(il)
+        c2.emit(il)
+        c3.emit(il)
+        c4.emit(il)
+        c5.emit(il)
+        c6.emit(il)
+        c7.emit(il)
+        c8.emit(il)
+        c9.emit(il)
+      }
+    }
+
   def apply(cs: Code[_]*): Code[_] =
     new Code[Unit] {
       def emit(il: Growable[AbstractInsnNode]): Unit = {
@@ -186,6 +228,18 @@ object Code {
   def floatValue(x: Code[java.lang.Number]): Code[Float] = x.invoke[Float]("floatValue")
 
   def doubleValue(x: Code[java.lang.Number]): Code[Double] = x.invoke[Double]("doubleValue")
+
+  def getStatic[T : ClassTag, S : ClassTag : TypeInfo](field: String): Code[S] = {
+    val f = FieldRef[T, S](field)
+    assert(f.isStatic)
+    f.get(null)
+  }
+
+  def putStatic[T : ClassTag, S : ClassTag : TypeInfo](field: String, rhs: Code[S]): Code[Unit] = {
+    val f = FieldRef[T, S](field)
+    assert(f.isStatic)
+    f.put(null, rhs)
+  }
 }
 
 trait Code[+T] {
@@ -295,9 +349,14 @@ class CodeBoolean(val lhs: Code[Boolean]) extends AnyVal {
 
   def ||(rhs: Code[Boolean]): Code[Boolean] =
     lhs.toConditional || rhs.toConditional
+
+  // on the JVM Booleans are represented as Ints
+  def toI: Code[Int] = lhs.asInstanceOf[Code[Int]]
 }
 
 class CodeInt(val lhs: Code[Int]) extends AnyVal {
+  def unary_-(): Code[Int] = Code(lhs, new InsnNode(INEG))
+
   def +(rhs: Code[Int]): Code[Int] = Code(lhs, rhs, new InsnNode(IADD))
 
   def -(rhs: Code[Int]): Code[Int] = Code(lhs, rhs, new InsnNode(ISUB))
@@ -322,6 +381,8 @@ class CodeInt(val lhs: Code[Int]) extends AnyVal {
 
   def &(rhs: Code[Int]): Code[Int] = Code(lhs, rhs, new InsnNode(IAND))
 
+  def |(rhs: Code[Int]): Code[Int] = Code(lhs, rhs, new InsnNode(IOR))
+
   def ^(rhs: Code[Int]): Code[Int] = Code(lhs, rhs, new InsnNode(IXOR))
 
   def unary_~(): Code[Int] = lhs ^ const(-1)
@@ -329,8 +390,6 @@ class CodeInt(val lhs: Code[Int]) extends AnyVal {
   def ceq(rhs: Code[Int]): Code[Boolean] = lhs.compare(IF_ICMPEQ, rhs)
 
   def cne(rhs: Code[Int]): Code[Boolean] = lhs.compare(IF_ICMPNE, rhs)
-
-  def negate(): Code[Int] = Code(lhs, new InsnNode(INEG))
 
   def toI: Code[Int] = lhs
 
@@ -341,9 +400,14 @@ class CodeInt(val lhs: Code[Int]) extends AnyVal {
   def toD: Code[Double] = Code(lhs, new InsnNode(I2D))
 
   def toB: Code[Byte] = Code(lhs, new InsnNode(I2B))
+
+  // on the JVM Booleans are represented as Ints
+  def toZ: Code[Boolean] = lhs.asInstanceOf[Code[Boolean]]
 }
 
 class CodeLong(val lhs: Code[Long]) extends AnyVal {
+  def unary_-(): Code[Long] = Code(lhs, new InsnNode(LNEG))
+
   def +(rhs: Code[Long]): Code[Long] = Code(lhs, rhs, new InsnNode(LADD))
 
   def -(rhs: Code[Long]): Code[Long] = Code(lhs, rhs, new InsnNode(LSUB))
@@ -370,6 +434,8 @@ class CodeLong(val lhs: Code[Long]) extends AnyVal {
 
   def &(rhs: Code[Long]): Code[Long] = Code(lhs, rhs, new InsnNode(LAND))
 
+  def |(rhs: Code[Long]): Code[Long] = Code(lhs, rhs, new InsnNode(LOR))
+
   def ^(rhs: Code[Long]): Code[Long] = Code(lhs, rhs, new InsnNode(LXOR))
 
   def unary_~(): Code[Long] = lhs ^ const(-1L)
@@ -384,6 +450,8 @@ class CodeLong(val lhs: Code[Long]) extends AnyVal {
 }
 
 class CodeFloat(val lhs: Code[Float]) extends AnyVal {
+  def unary_-(): Code[Float] = Code(lhs, new InsnNode(FNEG))
+
   def +(rhs: Code[Float]): Code[Float] = Code(lhs, rhs, new InsnNode(FADD))
 
   def -(rhs: Code[Float]): Code[Float] = Code(lhs, rhs, new InsnNode(FSUB))
@@ -414,6 +482,8 @@ class CodeFloat(val lhs: Code[Float]) extends AnyVal {
 }
 
 class CodeDouble(val lhs: Code[Double]) extends AnyVal {
+  def unary_-(): Code[Double] = Code(lhs, new InsnNode(DNEG))
+
   def +(rhs: Code[Double]): Code[Double] = Code(lhs, rhs, new InsnNode(DADD))
 
   def -(rhs: Code[Double]): Code[Double] = Code(lhs, rhs, new InsnNode(DSUB))
@@ -537,7 +607,13 @@ object FieldRef {
   }
 }
 
-class LocalRef[T](val i: Int)(implicit tti: TypeInfo[T]) {
+trait Settable[T] {
+  def load(): Code[T]
+  def store(rhs: Code[T]): Code[Unit]
+  def :=(rhs: Code[T]): Code[Unit] = store(rhs)
+}
+
+class LocalRef[T](val i: Int)(implicit tti: TypeInfo[T]) extends Settable[T] {
   def load(): Code[T] =
     new Code[T] {
       def emit(il: Growable[AbstractInsnNode]): Unit = {
@@ -554,8 +630,6 @@ class LocalRef[T](val i: Int)(implicit tti: TypeInfo[T]) {
     }
 
   def storeInsn: Code[Unit] = Code(new IntInsnNode(tti.storeOp, i))
-
-  def :=(rhs: Code[T]): Code[Unit] = store(rhs)
 }
 
 class LocalRefInt(val v: LocalRef[Int]) extends AnyRef {

--- a/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -65,7 +65,7 @@ class FunctionBuilder[F >: Null](parameterTypeInfo: Array[MaybeGenericTypeInfo[_
   cn.superName = "java/lang/Object"
   cn.interfaces.asInstanceOf[java.util.List[String]].add("java/io/Serializable")
 
-  def descriptor: String = s"(${ parameterTypeInfo.map(_.name).mkString })${ returnTypeInfo.name }"
+  def descriptor: String = s"(${ parameterTypeInfo.map(_.base.name).mkString })${ returnTypeInfo.base.name }"
 
   val mn = new MethodNode(ACC_PUBLIC, "apply", descriptor, null, null)
   val init = new MethodNode(ACC_PUBLIC, "<init>", "()V", null, null)
@@ -81,7 +81,7 @@ class FunctionBuilder[F >: Null](parameterTypeInfo: Array[MaybeGenericTypeInfo[_
   val end = new LabelNode
 
   val layout: Array[Int] =
-    0 +: (parameterTypeInfo.scanLeft(1) { case (prev, ti) => prev + ti.slots })
+    0 +: (parameterTypeInfo.scanLeft(1) { case (prev, gti) => prev + gti.base.slots })
   val argIndex: Array[Int] = layout.init
   var locals: Int = layout.last
 
@@ -152,7 +152,7 @@ class FunctionBuilder[F >: Null](parameterTypeInfo: Array[MaybeGenericTypeInfo[_
     val dupes = l.groupBy(x => x).map(_._2.toArray).filter(_.length > 1).toArray
     assert(dupes.isEmpty, s"some instructions were repeated in the instruction list: ${dupes: Seq[Any]}")
     l.foreach(mn.instructions.add _)
-    mn.instructions.add(new InsnNode(returnTypeInfo.returnOp))
+    mn.instructions.add(new InsnNode(returnTypeInfo.base.returnOp))
     mn.instructions.add(end)
 
     val cw = new ClassWriter(ClassWriter.COMPUTE_MAXS + ClassWriter.COMPUTE_FRAMES)

--- a/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -45,6 +45,15 @@ object FunctionBuilder {
   def functionBuilder[A: TypeInfo, B: TypeInfo, R: TypeInfo]: FunctionBuilder[AsmFunction2[A, B, R]] =
     new FunctionBuilder(Array(GenericTypeInfo[A], GenericTypeInfo[B]), GenericTypeInfo[R])
 
+  def functionBuilder[A: TypeInfo, B: TypeInfo, C: TypeInfo, R: TypeInfo]: FunctionBuilder[AsmFunction3[A, B, C, R]] =
+    new FunctionBuilder(Array(GenericTypeInfo[A], GenericTypeInfo[B], GenericTypeInfo[C]), GenericTypeInfo[R])
+
+  def functionBuilder[A: TypeInfo, B: TypeInfo, C: TypeInfo, D: TypeInfo, R: TypeInfo]: FunctionBuilder[AsmFunction4[A, B, C, D, R]] =
+    new FunctionBuilder(Array(GenericTypeInfo[A], GenericTypeInfo[B], GenericTypeInfo[C], GenericTypeInfo[D]), GenericTypeInfo[R])
+
+  def functionBuilder[A: TypeInfo, B: TypeInfo, C: TypeInfo, D: TypeInfo, E: TypeInfo, R: TypeInfo]: FunctionBuilder[AsmFunction5[A, B, C, D, E, R]] =
+    new FunctionBuilder(Array(GenericTypeInfo[A], GenericTypeInfo[B], GenericTypeInfo[C], GenericTypeInfo[D], GenericTypeInfo[E]), GenericTypeInfo[R])
+
   private implicit def methodNodeToGrowable(mn: MethodNode): Growable[AbstractInsnNode] = new Growable[AbstractInsnNode] {
     def +=(e: AbstractInsnNode) = { mn.instructions.add(e); this }
     def clear() { throw new UnsupportedOperationException() }
@@ -108,29 +117,20 @@ class FunctionBuilder[F >: Null](parameterTypeInfo: Array[MaybeGenericTypeInfo[_
     ).emit(genericMn)
   }
 
-  def allocLocal[T]()(implicit tti: TypeInfo[T]): Int = {
+  def allocLocal[T](name: String = null)(implicit tti: TypeInfo[T]): Int = {
     val i = locals
     locals += tti.slots
 
     mn.localVariables.asInstanceOf[util.List[LocalVariableNode]]
-      .add(new LocalVariableNode("local" + i, tti.name, null, start, end, i))
+      .add(new LocalVariableNode(if (name == null) "local" + i else name, tti.name, null, start, end, i))
     i
   }
 
-  def newLocal[T]()(implicit tti: TypeInfo[T]): LocalRef[T] =
-    new LocalRef[T](allocLocal[T]())
+  def newLocal[T](implicit tti: TypeInfo[T]): LocalRef[T] =
+    newLocal()
 
-  def getStatic[T, S](field: String)(implicit tct: ClassTag[T], sct: ClassTag[S], sti: TypeInfo[S]): Code[S] = {
-    val f = FieldRef[T, S](field)
-    assert(f.isStatic)
-    f.get(null)
-  }
-
-  def putStatic[T, S](field: String, rhs: Code[S])(implicit tct: ClassTag[T], sct: ClassTag[S], sti: TypeInfo[S]): Code[Unit] = {
-    val f = FieldRef[T, S](field)
-    assert(f.isStatic)
-    f.put(null, rhs)
-  }
+  def newLocal[T](name: String = null)(implicit tti: TypeInfo[T]): LocalRef[T] =
+    new LocalRef[T](allocLocal[T](name))
 
   def getArg[T](i: Int)(implicit tti: TypeInfo[T]): LocalRef[T] = {
     assert(i >= 0)

--- a/src/main/scala/is/hail/asm4s/GenericTypeInfo.scala
+++ b/src/main/scala/is/hail/asm4s/GenericTypeInfo.scala
@@ -1,0 +1,78 @@
+package is.hail.asm4s
+
+import scala.language.implicitConversions
+import scala.reflect.ClassTag
+
+sealed abstract class MaybeGenericTypeInfo[T : TypeInfo] {
+  def castFromGeneric(x: Code[_]): Code[T]
+  def castToGeneric(x: Code[T]): Code[_]
+
+  val base: TypeInfo[_]
+  val generic: TypeInfo[_]
+  val isGeneric: Boolean
+}
+
+final case class GenericTypeInfo[T : TypeInfo]() extends MaybeGenericTypeInfo[T] {
+  val base = typeInfo[T]
+
+  def castFromGeneric(_x: Code[_]) = {
+    val x = _x.asInstanceOf[Code[AnyRef]]
+    base match {
+      case _: IntInfo.type =>
+        Code.intValue(Code.checkcast[java.lang.Integer](x)).asInstanceOf[Code[T]]
+      case _: LongInfo.type =>
+        Code.longValue(Code.checkcast[java.lang.Long](x)).asInstanceOf[Code[T]]
+      case _: FloatInfo.type =>
+        Code.floatValue(Code.checkcast[java.lang.Float](x)).asInstanceOf[Code[T]]
+      case _: DoubleInfo.type =>
+        Code.doubleValue(Code.checkcast[java.lang.Double](x)).asInstanceOf[Code[T]]
+      case _: ShortInfo.type =>
+        Code.checkcast[java.lang.Short](x).invoke[Short]("shortValue").asInstanceOf[Code[T]]
+      case _: ByteInfo.type =>
+        Code.checkcast[java.lang.Byte](x).invoke[Byte]("byteValue").asInstanceOf[Code[T]]
+      case _: BooleanInfo.type =>
+        Code.checkcast[java.lang.Boolean](x).invoke[Boolean]("booleanValue").asInstanceOf[Code[T]]
+      case _: CharInfo.type =>
+        Code.checkcast[java.lang.Character](x).invoke[Char]("charValue").asInstanceOf[Code[T]]
+      case cti: ClassInfo[_] =>
+        Code.checkcast[T](x)(cti.cct.asInstanceOf[ClassTag[T]])
+      case ati: ArrayInfo[_] =>
+        Code.checkcast[T](x)(ati.tct.asInstanceOf[ClassTag[T]])
+    }
+  }
+
+  def castToGeneric(x: Code[T]) = base match {
+    case _: IntInfo.type =>
+      Code.boxInt(x.asInstanceOf[Code[Int]])
+    case _: LongInfo.type =>
+      Code.boxLong(x.asInstanceOf[Code[Long]])
+    case _: FloatInfo.type =>
+      Code.boxFloat(x.asInstanceOf[Code[Float]])
+    case _: DoubleInfo.type =>
+      Code.boxDouble(x.asInstanceOf[Code[Double]])
+    case _: ShortInfo.type =>
+      Code.newInstance[java.lang.Short, Short](x.asInstanceOf[Code[Short]])
+    case _: ByteInfo.type =>
+      Code.newInstance[java.lang.Byte, Byte](x.asInstanceOf[Code[Byte]])
+    case _: BooleanInfo.type =>
+      Code.boxBoolean(x.asInstanceOf[Code[Boolean]])
+    case _: CharInfo.type =>
+      Code.newInstance[java.lang.Character, Char](x.asInstanceOf[Code[Char]])
+    case cti: ClassInfo[_] =>
+      x
+    case ati: ArrayInfo[_] =>
+      x
+  }
+
+  val generic = classInfo[java.lang.Object]
+  val isGeneric = true
+}
+
+final case class NotGenericTypeInfo[T : TypeInfo]() extends MaybeGenericTypeInfo[T] {
+  def castFromGeneric = (x: Code[_]) => x.asInstanceOf[Code[T]]
+  def castToGeneric = (x: Code[_]) => x
+
+  val base = typeInfo[T]
+  val generic = base
+  val isGeneric = false
+}

--- a/src/main/scala/is/hail/asm4s/GenericTypeInfo.scala
+++ b/src/main/scala/is/hail/asm4s/GenericTypeInfo.scala
@@ -69,8 +69,8 @@ final case class GenericTypeInfo[T : TypeInfo]() extends MaybeGenericTypeInfo[T]
 }
 
 final case class NotGenericTypeInfo[T : TypeInfo]() extends MaybeGenericTypeInfo[T] {
-  def castFromGeneric = (x: Code[_]) => x.asInstanceOf[Code[T]]
-  def castToGeneric = (x: Code[_]) => x
+  def castFromGeneric(x: Code[_]): Code[T] = x.asInstanceOf[Code[T]]
+  def castToGeneric(x: Code[T]): Code[_] = x
 
   val base = typeInfo[T]
   val generic = base

--- a/src/main/scala/is/hail/asm4s/StagedBitSet.scala
+++ b/src/main/scala/is/hail/asm4s/StagedBitSet.scala
@@ -1,0 +1,37 @@
+package is.hail.asm4s
+
+import org.objectweb.asm.tree._
+import scala.collection.generic.Growable
+
+class StagedBitSet(fb: FunctionBuilder[_]) {
+  private var used = 0
+  private var bits: LocalRef[Long] = null
+  private var count = 0
+
+  def newBit(): SettableBit = {
+    if (used >= 64 || bits == null) {
+      bits = fb.newLocal[Long]
+      count += 1
+      fb.emit(bits.store(0L))
+      used = 0
+    }
+
+    used += 1
+    new SettableBit(bits, used - 1)
+  }
+}
+
+class SettableBit(bits: LocalRef[Long], i: Int) extends Code[Boolean] with Settable[Boolean] {
+  assert(i >= 0)
+  assert(i < 64)
+
+  def store(b: Code[Boolean]): Code[Unit] = {
+    bits := bits & ~(1L << i) | (b.toI.toL << i)
+  }
+
+  def emit(il: Growable[AbstractInsnNode]): Unit = {
+    ((bits >> i) & 1L).toI.emit(il)
+  }
+
+  def load(): Code[Boolean] = this
+}

--- a/src/main/scala/is/hail/asm4s/package.scala
+++ b/src/main/scala/is/hail/asm4s/package.scala
@@ -1,9 +1,5 @@
 package is.hail
 
-import java.io.PrintWriter
-import java.lang.reflect.Method
-
-import is.hail.utils._
 import org.objectweb.asm.Opcodes._
 import org.objectweb.asm.Type
 import org.objectweb.asm.tree._
@@ -11,7 +7,6 @@ import org.objectweb.asm.tree._
 import scala.collection.generic.Growable
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
-import scala.reflect
 
 package object asm4s {
 
@@ -29,102 +24,6 @@ package object asm4s {
 
     def newArray(): AbstractInsnNode
     def classTag: ClassTag[T] = reflect.classTag
-  }
-
-  sealed abstract class MaybeGenericTypeInfo[T : TypeInfo] extends TypeInfo[T]()(typeInfo[T].classTag) {
-    def castFromGeneric: Code[_] => Code[T]
-    def castToGeneric: Code[T] => Code[_]
-
-    val generic: TypeInfo[_]
-    val isGeneric: Boolean
-  }
-
-  final case class GenericTypeInfo[T : TypeInfo]() extends MaybeGenericTypeInfo[T] {
-    private val ti = typeInfo[T]
-
-    val name = ti.name
-    val loadOp = ti.loadOp
-    val storeOp = ti.storeOp
-    val aloadOp = ti.aloadOp
-    val astoreOp = ti.astoreOp
-    val returnOp = ti.returnOp
-    override val slots = ti.slots
-
-    def newArray() = ti.newArray
-
-    def castFromGeneric = (_x: Code[_]) => {
-      val x = _x.asInstanceOf[Code[AnyRef]]
-      ti match {
-        case _: IntInfo.type =>
-          Code.intValue(Code.checkcast[java.lang.Integer](x)).asInstanceOf[Code[T]]
-        case _: LongInfo.type =>
-          Code.longValue(Code.checkcast[java.lang.Long](x)).asInstanceOf[Code[T]]
-        case _: FloatInfo.type =>
-          Code.floatValue(Code.checkcast[java.lang.Float](x)).asInstanceOf[Code[T]]
-        case _: DoubleInfo.type =>
-          Code.doubleValue(Code.checkcast[java.lang.Double](x)).asInstanceOf[Code[T]]
-        case _: ShortInfo.type =>
-          Code.checkcast[java.lang.Short](x).invoke[Short]("shortValue").asInstanceOf[Code[T]]
-        case _: ByteInfo.type =>
-          Code.checkcast[java.lang.Byte](x).invoke[Byte]("byteValue").asInstanceOf[Code[T]]
-        case _: BooleanInfo.type =>
-          Code.checkcast[java.lang.Boolean](x).invoke[Boolean]("booleanValue").asInstanceOf[Code[T]]
-        case _: CharInfo.type =>
-          Code.checkcast[java.lang.Character](x).invoke[Char]("charValue").asInstanceOf[Code[T]]
-        case cti: ClassInfo[_] =>
-          Code.checkcast[T](x)(cti.cct.asInstanceOf[ClassTag[T]])
-        case ati: ArrayInfo[_] =>
-          Code.checkcast[T](x)(ati.tct.asInstanceOf[ClassTag[T]])
-      }
-    }
-
-    def castToGeneric = (x: Code[T]) => ti match {
-      case _: IntInfo.type =>
-        Code.boxInt(x.asInstanceOf[Code[Int]])
-      case _: LongInfo.type =>
-        Code.boxLong(x.asInstanceOf[Code[Long]])
-      case _: FloatInfo.type =>
-        Code.boxFloat(x.asInstanceOf[Code[Float]])
-      case _: DoubleInfo.type =>
-        Code.boxDouble(x.asInstanceOf[Code[Double]])
-      case _: ShortInfo.type =>
-        Code.newInstance[java.lang.Short, Short](x.asInstanceOf[Code[Short]])
-      case _: ByteInfo.type =>
-        Code.newInstance[java.lang.Byte, Byte](x.asInstanceOf[Code[Byte]])
-      case _: BooleanInfo.type =>
-        Code.boxBoolean(x.asInstanceOf[Code[Boolean]])
-      case _: CharInfo.type =>
-        Code.newInstance[java.lang.Character, Char](x.asInstanceOf[Code[Char]])
-      case cti: ClassInfo[_] =>
-        x
-      case ati: ArrayInfo[_] =>
-        x
-    }
-
-    val generic = classInfo[java.lang.Object]
-    val isGeneric = true
-
-  }
-
-  final case class NotGenericTypeInfo[T : TypeInfo]() extends MaybeGenericTypeInfo[T] {
-    private val ti = typeInfo[T]
-
-    val name = ti.name
-    val loadOp = ti.loadOp
-    val storeOp = ti.storeOp
-    val aloadOp = ti.aloadOp
-    val astoreOp = ti.astoreOp
-    val returnOp = ti.returnOp
-    override val slots = ti.slots
-
-    def newArray() = ti.newArray
-
-    def castFromGeneric = (x: Code[_]) => x.asInstanceOf[Code[T]]
-    def castToGeneric = (x: Code[_]) => x
-
-    val generic = ti
-    val isGeneric = false
-
   }
 
   implicit object BooleanInfo extends TypeInfo[Boolean] {

--- a/src/main/scala/is/hail/asm4s/package.scala
+++ b/src/main/scala/is/hail/asm4s/package.scala
@@ -12,7 +12,7 @@ package object asm4s {
 
   def typeInfo[T](implicit tti: TypeInfo[T]): TypeInfo[T] = tti
 
-  abstract class TypeInfo[T : ClassTag] {
+  abstract class TypeInfo[T] {
     val name: String
     val iname: String = name
     val loadOp: Int
@@ -23,7 +23,6 @@ package object asm4s {
     val slots: Int = 1
 
     def newArray(): AbstractInsnNode
-    def classTag: ClassTag[T] = reflect.classTag
   }
 
   implicit object BooleanInfo extends TypeInfo[Boolean] {
@@ -138,12 +137,7 @@ package object asm4s {
   implicit def arrayInfo[T](implicit cct: ClassTag[Array[T]]): TypeInfo[Array[T]] =
     new ArrayInfo
 
-  implicit def arrayInfo[T](implicit tti: TypeInfo[T]): TypeInfo[Array[T]] =
-    new ArrayInfo(tti)
-
   class ArrayInfo[T](implicit val tct: ClassTag[Array[T]]) extends TypeInfo[Array[T]] {
-    def this(tti: TypeInfo[T]) = this()(tti.classTag.wrap)
-
     val name = Type.getDescriptor(tct.runtimeClass)
     override val iname = Type.getInternalName(tct.runtimeClass)
     val loadOp = ALOAD

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -230,6 +230,14 @@ sealed abstract class Type extends BaseType with Serializable {
   def fundamentalType: Type = this
 }
 
+case object TVoid extends Type {
+  override def toString = "Void"
+  override def ordering(missingGreatest: Boolean): Ordering[is.hail.annotations.Annotation] = throw new UnsupportedOperationException("No ordering on Void")
+  override def scalaClassTag: scala.reflect.ClassTag[_ <: AnyRef] = throw new UnsupportedOperationException("No ClassTag for Void")
+  override def typeCheck(a: Any): Boolean = throw new UnsupportedOperationException("No elements of Void")
+  override def isRealizable = false
+}
+
 abstract class ComplexType extends Type {
   val representation: Type
 
@@ -704,6 +712,9 @@ abstract class TContainer extends Type {
 
   def isElementDefined(region: MemoryBuffer, aoff: Long, i: Int): Boolean =
     !region.loadBit(aoff + 4, i)
+
+  def isElementDefined(region: Code[MemoryBuffer], aoff: Code[Long], i: Code[Int]): Code[Boolean] =
+    !region.loadBit(aoff + 4, i.toL)
 
   def setElementMissing(region: MemoryBuffer, aoff: Long, i: Int) {
     region.setBit(aoff + 4, i)
@@ -2029,6 +2040,9 @@ final case class TStruct(fields: IndexedSeq[Field]) extends Type {
   }
 
   def isFieldDefined(region: MemoryBuffer, offset: Long, fieldIdx: Int): Boolean =
+    !region.loadBit(offset, fieldIdx)
+
+  def isFieldDefined(region: Code[MemoryBuffer], offset: Code[Long], fieldIdx: Int): Code[Boolean] =
     !region.loadBit(offset, fieldIdx)
 
   def setFieldMissing(region: MemoryBuffer, offset: Long, fieldIdx: Int) {

--- a/src/main/scala/is/hail/expr/ir/BinaryOp.scala
+++ b/src/main/scala/is/hail/expr/ir/BinaryOp.scala
@@ -1,0 +1,67 @@
+package is.hail.expr.ir
+
+import is.hail.asm4s._
+import is.hail.expr._
+
+object BinaryOp {
+  def inferReturnType(op: BinaryOp, l: Type, r: Type): Type = op match {
+    case Add() | Subtract() | Multiply() |  Divide() => (l, r) match {
+      case (TInt32, TInt32) => TInt32
+      case (TInt64, TInt64) => TInt64
+      case (TFloat32, TFloat32) => TFloat32
+      case (TFloat64, TFloat64) => TFloat64
+      case types => throw new RuntimeException(s"$op cannot be applied to $types")
+    }
+    case DoubleAmpersand() | DoublePipe() => (l, r) match {
+      case (TBoolean, TBoolean) => TBoolean
+      case types => throw new RuntimeException(s"$op cannot be applied to $types")
+    }
+  }
+
+  def compile(op: BinaryOp, lt: Type, rt: Type, l: Code[_], r: Code[_]): Code[_] = (lt, rt) match {
+    case (TInt32, TInt32) =>
+      val ll = coerce[Int](l)
+      val rr = coerce[Int](r)
+      op match {
+        case Add() => ll + rr
+        case Subtract() => ll - rr
+        case Multiply() => ll * rr
+        case Divide() => ll / rr
+      }
+    case (TInt64, TInt64) =>
+      val ll = coerce[Long](l)
+      val rr = coerce[Long](r)
+      op match {
+        case Add() => ll + rr
+        case Subtract() => ll - rr
+        case Multiply() => ll * rr
+        case Divide() => ll / rr
+      }
+    case (TFloat32, TFloat32) =>
+      val ll = coerce[Float](l)
+      val rr = coerce[Float](r)
+      op match {
+        case Add() => ll + rr
+        case Subtract() => ll - rr
+        case Multiply() => ll * rr
+        case Divide() => ll / rr
+      }
+    case (TFloat64, TFloat64) =>
+      val ll = coerce[Double](l)
+      val rr = coerce[Double](r)
+      op match {
+        case Add() => ll + rr
+        case Subtract() => ll - rr
+        case Multiply() => ll * rr
+        case Divide() => ll / rr
+      }
+  }
+}
+
+sealed trait BinaryOp { }
+case class Add() extends BinaryOp { }
+case class Subtract() extends BinaryOp { }
+case class Multiply() extends BinaryOp { }
+case class Divide() extends BinaryOp { }
+case class DoubleAmpersand() extends BinaryOp { }
+case class DoublePipe() extends BinaryOp { }

--- a/src/main/scala/is/hail/expr/ir/Casts.scala
+++ b/src/main/scala/is/hail/expr/ir/Casts.scala
@@ -1,0 +1,21 @@
+package is.hail.expr.ir
+
+import is.hail.asm4s._
+import is.hail.expr.{TInt32, TInt64, TArray, TContainer, TStruct, TFloat32, TFloat64, TBoolean, Type, TVoid, TFunction}
+
+object Casts {
+  private val casts: Map[(Type, Type), (Code[T] => Code[_]) forSome {type T}] = Map(
+    (TInt32, TInt64) -> ((x: Code[Int]) => x.toL),
+    (TInt32, TFloat32) -> ((x: Code[Int]) => x.toF),
+    (TInt32, TFloat64) -> ((x: Code[Int]) => x.toD),
+    (TInt64, TFloat32) -> ((x: Code[Long]) => x.toF),
+    (TInt64, TFloat64) -> ((x: Code[Long]) => x.toD),
+    (TFloat32, TFloat64) -> ((x: Code[Float]) => x.toD)
+)
+
+  def get(from: Type, to: Type): Code[_] => Code[_] =
+    casts(from -> to).asInstanceOf[Code[_] => Code[_]]
+
+  def valid(from: Type, to: Type): Boolean =
+    casts.contains(from -> to)
+}

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -1,0 +1,56 @@
+package is.hail.expr.ir
+
+import is.hail.expr.BaseIR
+
+object Children {
+  private def none: IndexedSeq[BaseIR] = Array.empty[BaseIR]
+  def apply(x: IR): IndexedSeq[BaseIR] = x match {
+    case I32(x) => none
+    case I64(x) => none
+    case F32(x) => none
+    case F64(x) => none
+    case True() => none
+    case False() => none
+    case NA(typ) => none
+    case MapNA(name, value, body, typ) =>
+      Array(value, body)
+    case IsNA(value) =>
+      Array(value)
+    case If(cond, cnsq, altr, typ) =>
+      Array(cond, cnsq, altr)
+    case Let(name, value, body, typ) =>
+      Array(value, body)
+    case Ref(name, typ) =>
+      none
+    case ApplyBinaryPrimOp(op, l, r, typ) =>
+      Array(l, r)
+    case ApplyUnaryPrimOp(op, x, typ) =>
+      Array(x)
+    case MakeArray(args, typ) =>
+      args
+    case MakeArrayN(len, elementType) =>
+      Array(len)
+    case ArrayRef(a, i, typ) =>
+      Array(a, i)
+    case ArrayMissingnessRef(a, i) =>
+      Array(a, i)
+    case ArrayLen(a) =>
+      Array(a)
+    case ArrayMap(a, name, body, elementTyp) =>
+      Array(a, body)
+    case ArrayFold(a, zero, accumName, valueName, body, typ) =>
+      Array(a, zero, body)
+    case MakeStruct(fields) =>
+      fields.map(_._3)
+    case GetField(o, name, typ) =>
+      Array(o)
+    case GetFieldMissingness(o, name) =>
+      Array(o)
+    case In(i, typ) =>
+      none
+    case InMissingness(i) =>
+      none
+    case Die(message) =>
+      none
+  }
+}

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -1,0 +1,324 @@
+package is.hail.expr.ir
+
+import is.hail.annotations.{MemoryBuffer, StagedRegionValueBuilder}
+import is.hail.asm4s._
+import is.hail.expr
+import is.hail.expr.{TArray, TBoolean, TContainer, TFloat32, TFloat64, TInt32, TInt64, TStruct}
+import is.hail.utils._
+import org.objectweb.asm.Opcodes._
+import org.objectweb.asm.tree._
+
+import scala.language.existentials
+
+object Compile {
+  private def defaultValue(t: expr.Type): Code[_] = t match {
+    case TBoolean => false
+    case TInt32 => 0
+    case TInt64 => 0L
+    case TFloat32 => 0.0f
+    case TFloat64 => 0.0
+    case _ => 0L // reference types
+  }
+  private def typeToTypeInfo(t: expr.Type): TypeInfo[_] = t match {
+    case TInt32 => typeInfo[Int]
+    case TInt64 => typeInfo[Long]
+    case TFloat32 => typeInfo[Float]
+    case TFloat64 => typeInfo[Double]
+    case TBoolean => typeInfo[Boolean]
+    case _ => typeInfo[Long] // reference types
+  }
+
+  type E = Env[(TypeInfo[_], Code[Boolean], Code[_])]
+
+  def apply(ir: IR, fb: FunctionBuilder[_]) {
+    apply(ir, fb, new Env())
+  }
+
+  def apply(ir: IR, fb: FunctionBuilder[_], env: E) {
+    val (dov, mv, vv) = compile(ir, fb, env, new StagedBitSet(fb))
+    typeToTypeInfo(ir.typ) match { case ti: TypeInfo[t] =>
+      fb.emit(Code(dov, mv.mux(
+        Code._throw(Code.newInstance[RuntimeException, String]("cannot return empty")),
+        coerce[t](vv))))
+    }
+  }
+
+  private def present(x: Code[_]): (Code[Unit], Code[Boolean], Code[_]) =
+    (Code._empty, const(false), x)
+  private def tcoerce[T <: expr.Type](x: expr.Type): T = x.asInstanceOf[T]
+
+  // the return value is interpreted as: (precompute, missingness, value)
+  // rules:
+  //  1. evaluate each returned Code[_] at most once
+  //  2. evaluate precompute *on all static code-paths* leading to missingness or value
+  //  3. gaurd the the evaluation of value by missingness
+  //
+  // JVM gotcha:
+  //  a variable must be initialized on all static code-paths to its use (ergo defaultValue)
+  def compile(ir: IR, fb: FunctionBuilder[_], env: E, mb: StagedBitSet): (Code[Unit], Code[Boolean], Code[_]) = {
+    val region = fb.getArg[MemoryBuffer](1).load()
+    def compile(ir: IR, fb: FunctionBuilder[_] = fb, env: E = env, mb: StagedBitSet = mb): (Code[Unit], Code[Boolean], Code[_]) =
+      Compile.compile(ir, fb, env, mb)
+    ir match {
+      case I32(x) =>
+        present(const(x))
+      case I64(x) =>
+        present(const(x))
+      case F32(x) =>
+        present(const(x))
+      case F64(x) =>
+        present(const(x))
+      case True() =>
+        present(const(true))
+      case False() =>
+        present(const(false))
+
+      case Cast(v, typ) =>
+        val (dov, mv, vv) = compile(v)
+        val cast = Casts.get(v.typ, typ)
+        (dov, mv, cast(vv))
+
+      case NA(typ) =>
+        (Code._empty, const(true), defaultValue(typ))
+      case IsNA(v) =>
+        val (dov, mv, _) = compile(v)
+        (dov, const(false), mv)
+      case MapNA(name, value, body, typ) =>
+        val vti = typeToTypeInfo(value.typ)
+        val bti = typeToTypeInfo(typ)
+        val mx = mb.newBit()
+        val x = fb.newLocal(name)(vti).asInstanceOf[LocalRef[Any]]
+        val mout = mb.newBit()
+        val out = fb.newLocal(name)(bti).asInstanceOf[LocalRef[Any]]
+        val (dovalue, mvalue, vvalue) = compile(value)
+        val bodyenv = env.bind(name -> (vti, mx, x))
+        val (dobody, mbody, vbody) = compile(body, env = bodyenv)
+        val setup = Code(
+          dovalue,
+          mx := mvalue,
+          mx.mux(
+            Code(mout := true, out := defaultValue(typ)),
+            Code(x := vvalue, dobody, mout := mbody, out := vbody)))
+
+        (setup, mout, out)
+
+      case expr.ir.If(cond, cnsq, altr, typ) =>
+        val (docond, mcond, vcond) = compile(cond)
+        val xvcond = mb.newBit()
+        val out = fb.newLocal()(typeToTypeInfo(typ)).asInstanceOf[LocalRef[Any]]
+        val mout = mb.newBit()
+        val (docnsq, mcnsq, vcnsq) = compile(cnsq)
+        val (doaltr, maltr, valtr) = compile(altr)
+        val setup = Code(
+          docond,
+          mcond.mux(
+            Code(mout := true, out := defaultValue(typ)),
+            Code(
+              xvcond := coerce[Boolean](vcond),
+              coerce[Boolean](xvcond).mux(
+                Code(docnsq, mout := mcnsq, out := vcnsq),
+                Code(doaltr, mout := maltr, out := valtr)))))
+
+        (setup, mout, out)
+
+      case expr.ir.Let(name, value, body, typ) =>
+        val vti = typeToTypeInfo(value.typ)
+        val mx = mb.newBit()
+        val x = fb.newLocal(name)(vti).asInstanceOf[LocalRef[Any]]
+        val (dovalue, mvalue, vvalue) = compile(value)
+        val bodyenv = env.bind(name -> (vti, mx, x))
+        val (dobody, mbody, vbody) = compile(body, env = bodyenv)
+        val setup = Code(
+          dovalue,
+          mx := mvalue,
+          x := vvalue,
+          dobody)
+
+        (setup, mbody, vbody)
+      case Ref(name, typ) =>
+        val ti = typeToTypeInfo(typ)
+        val (t, m, v) = env.lookup(name)
+        assert(t == ti, s"$name type annotation, $typ, doesn't match typeinfo: $ti")
+        (Code._empty, m, v)
+
+      case ApplyBinaryPrimOp(op, l, r, typ) =>
+        val (dol, ml, vl) = compile(l)
+        val (dor, mr, vr) = compile(r)
+        (Code(dol, dor),
+          ml || mr,
+          BinaryOp.compile(op, l.typ, r.typ, vl, vr))
+      case ApplyUnaryPrimOp(op, x, typ) =>
+        val (dox, mx, vx) = compile(x)
+        (dox, mx, UnaryOp.compile(op, x.typ, vx))
+
+      case MakeArray(args, typ) =>
+        val srvb = new StagedRegionValueBuilder(fb, typ)
+        val addElement = srvb.addPrimitive(typ.elementType)
+        val mvargs = args.map(compile(_))
+        present(Code(
+          srvb.start(args.length, init = true),
+          Code(mvargs.map { case (dov, m, v) =>
+            Code(dov, m.mux(srvb.setMissing(), addElement(v)), srvb.advance())
+          }: _*),
+          srvb.offset))
+      case x@MakeArrayN(len, elementType) =>
+        val srvb = new StagedRegionValueBuilder(fb, x.typ)
+        val (dolen, mlen, vlen) = compile(len)
+        (dolen,
+          mlen,
+          Code(srvb.start(coerce[Int](vlen), init = true),
+            srvb.offset))
+      case ArrayRef(a, i, typ) =>
+        val ti = typeToTypeInfo(typ)
+        val tarray = TArray(typ)
+        val ati = typeToTypeInfo(tarray).asInstanceOf[TypeInfo[Long]]
+        val (doa, ma, va) = compile(a)
+        val (doi, mi, vi) = compile(i)
+        val xma = mb.newBit()
+        val xa = fb.newLocal()(ati)
+        val xi = fb.newLocal[Int]
+        val xmi = mb.newBit()
+        val xmv = mb.newBit()
+        val setup = Code(
+          doa,
+          xma := ma,
+          xa := coerce[Long](xma.mux(defaultValue(tarray), va)),
+          doi,
+          xmi := mi,
+          xi := coerce[Int](xmi.mux(defaultValue(TInt32), vi)),
+          xmv := xma || xmi || !tarray.isElementDefined(region, xa, xi))
+
+        (setup, xmv, region.loadPrimitive(typ)(tarray.loadElement(region, xa, xi)))
+      case ArrayMissingnessRef(a, i) =>
+        val tarray = tcoerce[TArray](a.typ)
+        val ati = typeToTypeInfo(tarray).asInstanceOf[TypeInfo[Long]]
+        val (doa, ma, va) = compile(a)
+        val (doi, mi, vi) = compile(i)
+        present(Code(
+          doa,
+          doi,
+          ma || mi || !tarray.isElementDefined(region, coerce[Long](va), coerce[Int](vi))))
+      case ArrayLen(a) =>
+        val (doa, ma, va) = compile(a)
+        (doa, ma, TContainer.loadLength(region, coerce[Long](va)))
+      case x@ArrayMap(a, name, body, elementTyp) =>
+        val tin = a.typ.asInstanceOf[TArray]
+        val tout = x.typ.asInstanceOf[TArray]
+        val srvb = new StagedRegionValueBuilder(fb, tout)
+        val addElement = srvb.addPrimitive(tout.elementType)
+        val eti = typeToTypeInfo(elementTyp).asInstanceOf[TypeInfo[Any]]
+        val xa = fb.newLocal[Long]("am_a")
+        val xmv = mb.newBit()
+        val xvv = fb.newLocal(name)(eti)
+        val i = fb.newLocal[Int]("am_i")
+        val len = fb.newLocal[Int]("am_len")
+        val out = fb.newLocal[Long]("am_out")
+        val bodyenv = env.bind(name -> (eti, xmv, xvv))
+        val lmissing = new LabelNode()
+        val lnonmissing = new LabelNode()
+        val ltop = new LabelNode()
+        val lnext = new LabelNode()
+        val lend = new LabelNode()
+        val (doa, ma, va) = compile(a)
+        val (dobody, mbody, vbody) = compile(body, env = bodyenv)
+
+        (doa, ma, Code(
+          xa := coerce[Long](va),
+          len := TContainer.loadLength(region, xa),
+          i := 0,
+          srvb.start(len, init = true),
+          Code.whileLoop(i < len,
+            xmv := !tin.isElementDefined(region, xa, i),
+            xvv := xmv.mux(
+              defaultValue(elementTyp),
+              region.loadPrimitive(tin.elementType)(tin.loadElement(region, xa, i))),
+            dobody,
+            mbody.mux(srvb.setMissing(), addElement(vbody)),
+            srvb.advance(),
+            i := i + 1),
+          srvb.offset))
+      case ArrayFold(a, zero, name1, name2, body, typ) =>
+        val tarray = a.typ.asInstanceOf[TArray]
+        val tti = typeToTypeInfo(typ)
+        val eti = typeToTypeInfo(tarray.elementType)
+        val xma = mb.newBit()
+        val xa = fb.newLocal[Long]("af_array")
+        val xmv = mb.newBit()
+        val xvv = fb.newLocal(name2)(eti).asInstanceOf[LocalRef[Any]]
+        val xmout = mb.newBit()
+        val xvout = fb.newLocal(name1)(tti).asInstanceOf[LocalRef[Any]]
+        val i = fb.newLocal[Int]("af_i")
+        val len = fb.newLocal[Int]("af_len")
+        val bodyenv = env.bind(
+          name1 -> (tti, xmout, xvout.load()),
+          name2 -> (eti, xmv, xvv.load()))
+        val lmissing = new LabelNode()
+        val lnonmissing = new LabelNode()
+        val ltop = new LabelNode()
+        val lnext = new LabelNode()
+        val lend = new LabelNode()
+        val (doa, ma, va) = compile(a)
+        val (dozero, mzero, vzero) = compile(zero)
+        val (dobody, mbody, vbody) = compile(body, env = bodyenv)
+        val setup = Code(
+          doa,
+          ma.mux(
+            Code(xmout := true, xvout := defaultValue(typ)),
+            Code(
+              xa := coerce[Long](va),
+              len := TContainer.loadLength(region, xa),
+              i := 0,
+              dozero,
+              xmout := mzero,
+              xvout := xmout.mux(defaultValue(typ), vzero),
+              Code.whileLoop(i < len,
+                xmv := !tarray.isElementDefined(region, xa, i),
+                xvv := xmv.mux(
+                  defaultValue(tarray.elementType),
+                  region.loadPrimitive(tarray.elementType)(tarray.loadElement(region, xa, i))),
+                dobody,
+                xmout := mbody,
+                xvout := xmout.mux(defaultValue(typ), vbody),
+                i := i + 1))))
+        (setup, xmout, xvout)
+
+      case MakeStruct(fields) =>
+        val t = TStruct(fields.map { case (name, t, _) => (name, t) }: _*)
+        val initializers = fields.map { case (_, t, v) => (t, compile(v)) }
+        val srvb = new StagedRegionValueBuilder(fb, t)
+        present(Code(
+          srvb.start(false),
+          Code(initializers.map { case (t, (dov, mv, vv)) =>
+            Code(
+              dov,
+              mv.mux(srvb.setMissing(), srvb.addPrimitive(t)(vv)),
+              srvb.advance()) }: _*),
+          srvb.offset))
+      case GetField(o, name, _) =>
+        val t = o.typ.asInstanceOf[TStruct]
+        val fieldIdx = t.fieldIdx(name)
+        val (doo, mo, vo) = compile(o)
+        val xmo = mb.newBit()
+        val xo = fb.newLocal[Long]
+        val setup = Code(
+          doo,
+          xmo := mo,
+          xo := coerce[Long](xmo.mux(defaultValue(t), vo)))
+        (setup,
+          xmo || !t.isFieldDefined(region, xo, fieldIdx),
+          region.loadPrimitive(t)(t.fieldOffset(xo, fieldIdx)))
+      case GetFieldMissingness(o, name) =>
+        val t = o.typ.asInstanceOf[TStruct]
+        val fieldIdx = t.fieldIdx(name)
+        val (doo, mo, vo) = compile(o)
+        present(Code(doo, mo || !t.isFieldDefined(region, coerce[Long](vo), fieldIdx)))
+
+      case In(i, typ) =>
+        (Code._empty, fb.getArg[Boolean](i*2 + 3), fb.getArg(i*2 + 2)(typeToTypeInfo(typ)))
+      case InMissingness(i) =>
+        present(fb.getArg[Boolean](i*2 + 3))
+      case Die(m) =>
+        present(Code._throw(Code.newInstance[RuntimeException, String](m)))
+    }
+  }
+}

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -19,6 +19,7 @@ object Compile {
     case TFloat64 => 0.0
     case _ => 0L // reference types
   }
+
   private def typeToTypeInfo(t: expr.Type): TypeInfo[_] = t match {
     case TInt32 => typeInfo[Int]
     case TInt64 => typeInfo[Long]

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -1,0 +1,78 @@
+package is.hail.expr.ir
+
+import is.hail.expr.BaseIR
+
+object Copy {
+  def apply(x: IR, newChildren: IndexedSeq[BaseIR]): BaseIR = {
+    val children = newChildren.asInstanceOf[IndexedSeq[IR]]
+    lazy val same = {
+      assert(children.isEmpty)
+      x
+    }
+    x match {
+      case I32(_) => same
+      case I64(_) => same
+      case F32(_) => same
+      case F64(_) => same
+      case True() => same
+      case False() => same
+      case NA(_) => same
+      case MapNA(name, _, _, typ) =>
+        val IndexedSeq(value, body) = children
+        MapNA(name, value, body, typ)
+      case IsNA(value) =>
+        val IndexedSeq(value) = children
+        IsNA(value)
+      case If(_, _, _, typ) =>
+        val IndexedSeq(cond, cnsq, altr) = children
+        If(cond, cnsq, altr, typ)
+      case Let(name, _, _, typ) =>
+        val IndexedSeq(value, body) = children
+        Let(name, value, body, typ)
+      case Ref(_, _) =>
+        same
+      case ApplyBinaryPrimOp(op, _, _, typ) =>
+        val IndexedSeq(l, r) = children
+        ApplyBinaryPrimOp(op, l, r, typ)
+      case ApplyUnaryPrimOp(op, _, typ) =>
+        val IndexedSeq(x) = children
+        ApplyUnaryPrimOp(op, x, typ)
+      case MakeArray(args, typ) =>
+        assert(args.length == children.length)
+        MakeArray(children.toArray, typ)
+      case MakeArrayN(_, elementType) =>
+        val IndexedSeq(len) = children
+        MakeArrayN(len, elementType)
+      case ArrayRef(_, _, typ) =>
+        val IndexedSeq(a, i) = children
+        ArrayRef(a, i, typ)
+      case ArrayMissingnessRef(_, _) =>
+        val IndexedSeq(a, i) = children
+        ArrayMissingnessRef(a, i)
+      case ArrayLen(_) =>
+        val IndexedSeq(a) = children
+        ArrayLen(a)
+      case ArrayMap(_, name, _, elementTyp) =>
+        val IndexedSeq(a, body) = children
+        ArrayMap(a, name, body, elementTyp)
+      case ArrayFold(_, _, accumName, valueName, _, typ) =>
+        val IndexedSeq(a, zero, body) = children
+        ArrayFold(a, zero, accumName, valueName, body, typ)
+      case MakeStruct(fields) =>
+        assert(fields.length == children.length)
+        MakeStruct(fields.zip(children).map { case ((n, t, _), v) => (n, t, v) })
+      case GetField(_, name, typ) =>
+        val IndexedSeq(o) = children
+        GetField(o, name, typ)
+      case GetFieldMissingness(_, name) =>
+        val IndexedSeq(o) = children
+        GetFieldMissingness(o, name)
+      case In(_, _) =>
+        same
+      case InMissingness(_) =>
+        same
+      case Die(message) =>
+        same
+    }
+  }
+}

--- a/src/main/scala/is/hail/expr/ir/Env.scala
+++ b/src/main/scala/is/hail/expr/ir/Env.scala
@@ -1,0 +1,56 @@
+package is.hail.expr.ir
+
+object Env {
+  type K = String
+}
+
+class Env[V] private (val m: Map[Env.K,V]) {
+  def this() {
+    this(Map())
+  }
+
+  def lookup(name: String) =
+    m.get(name)
+      .getOrElse(throw new RuntimeException(s"Cannot find $name in $m"))
+
+  def lookup(r: Ref): V =
+    lookup(r.name)
+
+  def bind(name: String, v: V): Env[V] =
+    new Env(m + (name -> v))
+
+  def bind(bindings: (String, V)*): Env[V] =
+    new Env(m ++ bindings)
+
+  def freshName(prefix: String): String = {
+    var i = 0
+    var name = prefix
+    while (m.keySet.contains(name)) {
+      name = prefix + i
+      i += 1
+    }
+    name
+  }
+
+  def freshNames(prefixes: String*): Array[String] =
+    (prefixes map freshName).toArray
+
+  def bindFresh(prefix: String, v: V): (String, Env[V]) = {
+    val name = freshName(prefix)
+    (name, new Env(m + (name -> v)))
+  }
+
+  def bindFresh(bindings: (String, V)*): (Array[String], Env[V]) = {
+    val names = new Array[String](bindings.length)
+    var i = 0
+    var e = this
+    while (i < bindings.length) {
+      val (prefix, v) = bindings(i)
+      val (name, e2) = e.bindFresh(prefix, v)
+      names(i) = name
+      e = e2
+      i += 1
+    }
+    (names, e)
+  }
+}

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -1,0 +1,56 @@
+package is.hail.expr.ir
+
+import is.hail.expr.{BaseIR, TBoolean, TFloat32, TFloat64, TInt32, TInt64, TStruct, TVoid, Type, TArray}
+
+sealed trait IR extends BaseIR {
+  def typ: Type
+
+  override def children: IndexedSeq[BaseIR] =
+    Children(this)
+
+  override def copy(newChildren: IndexedSeq[BaseIR]): BaseIR =
+    Copy(this, newChildren)
+}
+case class I32(x: Int) extends IR { val typ = TInt32 }
+case class I64(x: Long) extends IR { val typ = TInt64 }
+case class F32(x: Float) extends IR { val typ = TFloat32 }
+case class F64(x: Double) extends IR { val typ = TFloat64 }
+case class True() extends IR { val typ = TBoolean }
+case class False() extends IR { val typ = TBoolean }
+
+case class Cast(v: IR, typ: Type) extends IR
+
+case class NA(typ: Type) extends IR
+case class MapNA(name: String, value: IR, body: IR, var typ: Type = null) extends IR
+case class IsNA(value: IR) extends IR { val typ = TBoolean }
+
+case class If(cond: IR, cnsq: IR, altr: IR, var typ: Type = null) extends IR
+
+case class Let(name: String, value: IR, body: IR, var typ: Type = null) extends IR
+case class Ref(name: String, var typ: Type = null) extends IR
+
+case class ApplyBinaryPrimOp(op: BinaryOp, l: IR, r: IR, var typ: Type = null) extends IR
+case class ApplyUnaryPrimOp(op: UnaryOp, x: IR, var typ: Type = null) extends IR
+
+case class MakeArray(args: Array[IR], var typ: TArray = null) extends IR {
+  override def toString(): String = s"MakeArray(${args: IndexedSeq[IR]}, $typ)"
+}
+case class MakeArrayN(len: IR, elementType: Type) extends IR { def typ: TArray = TArray(elementType) }
+case class ArrayRef(a: IR, i: IR, var typ: Type = null) extends IR
+case class ArrayMissingnessRef(a: IR, i: IR) extends IR { val typ: Type = TBoolean }
+case class ArrayLen(a: IR) extends IR { val typ = TInt32 }
+case class ArrayMap(a: IR, name: String, body: IR, var elementTyp: Type = null) extends IR { def typ: TArray = TArray(elementTyp) }
+case class ArrayFold(a: IR, zero: IR, accumName: String, valueName: String, body: IR, var typ: Type = null) extends IR
+
+case class MakeStruct(fields: Array[(String, Type, IR)]) extends IR {
+  val typ: TStruct = TStruct(fields.map(x => x._1 -> x._2):_*)
+  override def toString(): String =
+    s"MakeStruct(${fields: IndexedSeq[(String, Type, IR)]})"
+}
+case class GetField(o: IR, name: String, var typ: Type = null) extends IR
+case class GetFieldMissingness(o: IR, name: String) extends IR { val typ: Type = TBoolean }
+
+case class In(i: Int, val typ: Type) extends IR
+case class InMissingness(i: Int) extends IR { val typ: Type = TBoolean }
+// FIXME: should be type any
+case class Die(message: String) extends IR { val typ = TVoid }

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -1,0 +1,107 @@
+package is.hail.expr.ir
+
+import is.hail.utils._
+import is.hail.annotations.MemoryBuffer
+import is.hail.asm4s._
+import is.hail.expr.{TInt32, TInt64, TArray, TContainer, TStruct, TFloat32, TFloat64, TBoolean, Type, TVoid, TFunction, TNumeric}
+import is.hail.annotations.StagedRegionValueBuilder
+
+object Infer {
+  def apply(ir: IR) { apply(ir, new Env[Type]()) }
+
+  def apply(ir: IR, env: Env[Type]) {
+    def infer(ir: IR, env: Env[Type] = env) { apply(ir, env) }
+    ir match {
+      case I32(x) =>
+      case I64(x) =>
+      case F32(x) =>
+      case F64(x) =>
+      case True() =>
+      case False() =>
+
+      case Cast(v, typ) =>
+        infer(v)
+        assert(Casts.valid(v.typ, typ))
+
+      case NA(t) =>
+      case x@MapNA(name, value, body, _) =>
+        infer(value)
+        infer(body, env = env.bind(name, value.typ))
+        x.typ = body.typ
+      case IsNA(v) =>
+        infer(v)
+
+      case x@If(cond, cnsq, altr, _) =>
+        infer(cond)
+        infer(cnsq)
+        infer(altr)
+        assert(cond.typ == TBoolean)
+        assert(cnsq.typ == altr.typ, s"${cnsq.typ}, ${altr.typ}")
+        x.typ = cnsq.typ
+
+      case x@Let(name, value, body, _) =>
+        infer(value)
+        infer(body, env = env.bind(name, value.typ))
+        println("let body: " + body.typ)
+        x.typ = body.typ
+      case x@Ref(_, _) =>
+        x.typ = env.lookup(x)
+      case x@ApplyBinaryPrimOp(op, l, r, _) =>
+        infer(l)
+        infer(r)
+        x.typ = BinaryOp.inferReturnType(op, l.typ, r.typ)
+      case x@ApplyUnaryPrimOp(op, v, _) =>
+        infer(v)
+        x.typ = UnaryOp.inferReturnType(op, v.typ)
+      case x@MakeArray(args, _) =>
+        args.map(infer(_))
+        val t = args.head.typ
+        args.map(_.typ).zipWithIndex.tail.foreach { case (x, i) => assert(x == t, s"at position $i type mismatch: $t $x") }
+        x.typ = TArray(t)
+      case MakeArrayN(len, _) =>
+        infer(len)
+        assert(len.typ == TInt32)
+      case x@ArrayRef(a, i, _) =>
+        infer(a)
+        infer(i)
+        assert(i.typ == TInt32)
+        x.typ = a.typ.asInstanceOf[TArray].elementType
+      case ArrayMissingnessRef(a, i) =>
+        infer(a)
+        infer(i)
+        assert(i.typ == TInt32)
+      case ArrayLen(a) =>
+        infer(a)
+        assert(a.typ.isInstanceOf[TArray])
+      case x@ArrayMap(a, name, body, _) =>
+        infer(a)
+        val tarray = a.typ.asInstanceOf[TArray]
+        infer(body, env = env.bind(name, tarray.elementType))
+        x.elementTyp = body.typ
+      case x@ArrayFold(a, zero, accumName, valueName, body, _) =>
+        infer(a)
+        val tarray = a.typ.asInstanceOf[TArray]
+        infer(zero)
+        infer(body, env.bind(accumName -> zero.typ, valueName -> tarray.elementType))
+        assert(body.typ == zero.typ)
+        x.typ = zero.typ
+      case MakeStruct(fields) =>
+        fields.map { case (_, typ, v) =>
+          infer(v)
+          assert(typ == v.typ)
+        }
+      case x@GetField(o, name, _) =>
+        infer(o)
+        val t = o.typ.asInstanceOf[TStruct]
+        assert(t.index(name).nonEmpty)
+        x.typ = t.field(name).typ
+      case GetFieldMissingness(o, name) =>
+        infer(o)
+        val t = o.typ.asInstanceOf[TStruct]
+        assert(t.index(name).nonEmpty)
+      case In(i, typ) =>
+        assert(typ != null)
+      case InMissingness(i) =>
+      case Die(msg) =>
+    } }
+}

--- a/src/main/scala/is/hail/expr/ir/UnaryOp.scala
+++ b/src/main/scala/is/hail/expr/ir/UnaryOp.scala
@@ -1,0 +1,51 @@
+package is.hail.expr.ir
+
+import is.hail.asm4s._
+import is.hail.expr._
+
+object UnaryOp {
+  def inferReturnType(op: UnaryOp, t: Type): Type = op match {
+    case Negate() => t match {
+      case TInt32 => TInt32
+      case TInt64 => TInt64
+      case TFloat32 => TFloat32
+      case TFloat64 => TFloat64
+      case _ => throw new RuntimeException(s"$op cannot be applied to $t")
+    }
+    case Bang() => t match {
+      case TBoolean => TBoolean
+    }
+  }
+
+  def compile(op: UnaryOp, t: Type, x: Code[_]): Code[_] = t match {
+    case TBoolean =>
+      val xx = coerce[Boolean](x)
+      op match {
+        case Bang() => !xx
+      }
+    case TInt32 =>
+      val xx = coerce[Int](x)
+      op match {
+        case Negate() => -xx
+      }
+    case TInt64 =>
+      val xx = coerce[Long](x)
+      op match {
+        case Negate() => -xx
+      }
+    case TFloat32 =>
+      val xx = coerce[Float](x)
+      op match {
+        case Negate() => -xx
+      }
+    case TFloat64 =>
+      val xx = coerce[Double](x)
+      op match {
+        case Negate() => -xx
+      }
+  }
+}
+
+sealed trait UnaryOp { }
+case class Negate() extends UnaryOp { }
+case class Bang() extends UnaryOp { }

--- a/src/main/scala/is/hail/expr/ir/package.scala
+++ b/src/main/scala/is/hail/expr/ir/package.scala
@@ -1,0 +1,7 @@
+package is.hail.expr
+
+import is.hail.asm4s._
+
+package object ir {
+  def coerce[T](x: Code[_]): Code[T] = x.asInstanceOf[Code[T]]
+}

--- a/src/main/scala/is/hail/utils/richUtils/RichCodeMemoryBuffer.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichCodeMemoryBuffer.scala
@@ -1,5 +1,6 @@
 package is.hail.utils.richUtils
 
+import is.hail.expr._
 import is.hail.annotations.MemoryBuffer
 import is.hail.asm4s.Code
 
@@ -77,6 +78,36 @@ class RichCodeMemoryBuffer(val region: Code[MemoryBuffer]) extends AnyVal {
 
   def loadBit(byteOff: Code[Long], bitOff: Code[Long]): Code[Boolean] = {
     region.invoke[Long, Long, Boolean]("loadBit", byteOff, bitOff)
+  }
+
+  def loadPrimitive(typ: Type): Code[Long] => Code[_] = typ match {
+    case TBoolean =>
+      this.loadBoolean(_)
+    case TInt32 =>
+      this.loadInt(_)
+    case TInt64 =>
+      this.loadLong(_)
+    case TFloat32 =>
+      this.loadFloat(_)
+    case TFloat64 =>
+      this.loadDouble(_)
+    case _ =>
+      off => off
+  }
+
+  def appendPrimitive(typ: Type): (Code[_]) => Code[Unit] = typ match {
+    case TBoolean =>
+      x => this.appendInt32(x.asInstanceOf[Code[Int]])
+    case TInt32 =>
+      x => this.appendInt32(x.asInstanceOf[Code[Int]])
+    case TInt64 =>
+      x => this.appendInt64(x.asInstanceOf[Code[Long]])
+    case TFloat32 =>
+      x => this.appendFloat32(x.asInstanceOf[Code[Float]])
+    case TFloat64 =>
+      x => this.appendFloat64(x.asInstanceOf[Code[Double]])
+    case _ =>
+      throw new UnsupportedOperationException("cannot append non-primitive type: $typ")
   }
 
   def setBit(byteOff: Code[Long], bitOff: Code[Long]): Code[Unit] = {

--- a/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
+++ b/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
@@ -107,7 +107,7 @@ class ASM4SSuite extends TestNGSuite {
     fb.emit(_return(Code(
       inst.store(Code.newInstance[A]()),
       inst.put("j", -2),
-      fb.getStatic[A, Int]("j"))))
+      Code.getStatic[A, Int]("j"))))
     val f = fb.result()()
     assert(f() == -2)
   }

--- a/src/test/scala/is/hail/asm4s/StagedBitSetSuite.scala
+++ b/src/test/scala/is/hail/asm4s/StagedBitSetSuite.scala
@@ -1,0 +1,124 @@
+package is.hail.asm4s
+
+import is.hail.asm4s._
+import is.hail.asm4s.Code._
+import is.hail.check.{Gen, Prop}
+import org.scalatest.testng.TestNGSuite
+import org.testng.annotations.Test
+import is.hail.asm4s.FunctionBuilder._
+
+class StagedBitSetSuite extends TestNGSuite {
+  def withOneBit(f : SettableBit => Code[Boolean]): Boolean = {
+    val fb = functionBuilder[Boolean]
+    val bs = new StagedBitSet(fb)
+    val x = bs.newBit()
+    fb.emit(f(x))
+    fb.result()()()
+  }
+
+  def withTwoBits(f : (SettableBit, SettableBit) => Code[Boolean]): Boolean = {
+    val fb = functionBuilder[Boolean]
+    val bs = new StagedBitSet(fb)
+    val x = bs.newBit()
+    val y = bs.newBit()
+    fb.emit(f(x, y))
+    fb.result()()()
+  }
+
+  def withNBits(n: Int)(f: Array[SettableBit] => Code[Boolean]): Boolean = {
+    val fb = functionBuilder[Boolean]
+    val bs = new StagedBitSet(fb)
+    val x = Array.tabulate(n)(i => bs.newBit())
+    fb.emit(f(x))
+    fb.result()()()
+  }
+
+  @Test
+  def testSetOneBit() {
+    assert(withOneBit(x => Code(x := true, x)))
+  }
+
+  @Test
+  def testSetTwoBits1() {
+    assert(withTwoBits((x, y) =>
+      Code(x := true, y := false, x)))
+  }
+
+  @Test
+  def testSetTwoBits2() {
+    assert(!withTwoBits((x, y) =>
+      Code(x := true, y := false, y)))
+  }
+
+  @Test
+  def testSetTwoBits3() {
+    assert(withTwoBits((x, y) =>
+      Code(x := true, y := true, x && y)))
+  }
+
+  @Test
+  def testSetBitTwice1() {
+    assert(!withOneBit(x =>
+      Code(x := true, x := false, x)))
+  }
+
+  @Test
+  def testSetBitThrice() {
+    assert(withOneBit(x =>
+      Code(x := true, x := false, x := true, x)))
+  }
+
+  @Test
+  def testSetBitFromBit1() {
+    assert(!withTwoBits((x, y) =>
+      Code(x := true, y := false, x := y, x)))
+  }
+
+  @Test
+  def testSetBitFromBit2() {
+    assert(withTwoBits((x, y) =>
+      Code(x := true, y := false, y := x, y)))
+  }
+
+  @Test
+  def testSetBitFromBit3() {
+    assert(withTwoBits((x, y) =>
+      Code(x := true, y := false, y := x, x)))
+  }
+
+  @Test
+  def moreThan64Bits() {
+    for (i <- 0 until 66) {
+      val b = withNBits(66) { bits =>
+        Code(
+          Code(bits.zipWithIndex.map { case (b,i) => b := const(i % 3 == 0) }:_*),
+          bits(i))
+      }
+      assert(b == (i % 3 == 0), s"at position $i, $b was not ${(i % 3 == 0)}")
+    }
+  }
+
+  @Test
+  def moreThan64Bits2() {
+    def gadget(ret: Array[SettableBit] => Code[Boolean]) = withNBits(66) { bits =>
+      val b63 = bits(63)
+      val b64 = bits(64)
+      val b65 = bits(65)
+      Code(
+        b65 := false,
+        b63 := true,
+        b64 := false,
+        b65 := true,
+        ret(bits))
+    }
+
+    assert(!gadget(_(64)))
+    assert(gadget(_(65)))
+    assert(gadget(_(63)))
+    assert(gadget(!_(64)))
+    assert(!gadget(!_(65)))
+    assert(!gadget(!_(63)))
+    assert(!gadget(bs => bs(63) && bs(64)))
+    assert(gadget(bs => bs(63) && !bs(64)))
+  }
+}

--- a/src/test/scala/is/hail/expr/ir/CompileSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/CompileSuite.scala
@@ -1,0 +1,316 @@
+package is.hail.methods.ir
+
+import is.hail.annotations._
+import is.hail.asm4s._
+import is.hail.check.{Gen, Parameters, Prop}
+import is.hail.expr.{TArray, TFloat64, TInt32}
+import is.hail.expr.ir._
+import org.testng.annotations.Test
+import org.scalatest._
+import Matchers._
+
+class CompileSuite {
+
+  private def addArray(mb: MemoryBuffer, a: Array[Double]): Long = {
+    val rvb = new RegionValueBuilder(mb)
+    rvb.start(TArray(TFloat64))
+    rvb.startArray(a.length)
+    a.foreach(rvb.addDouble(_))
+    rvb.endArray()
+    rvb.end()
+  }
+
+  private def addBoxedArray(mb: MemoryBuffer, a: Array[java.lang.Double]): Long = {
+    val rvb = new RegionValueBuilder(mb)
+    rvb.start(TArray(TFloat64))
+    rvb.startArray(a.length)
+    a.foreach { e =>
+      if (e == null)
+        rvb.setMissing()
+      else
+        rvb.addDouble(e)
+    }
+    rvb.endArray()
+    rvb.end()
+  }
+
+  def doit(ir: IR, fb: FunctionBuilder[_]) {
+    Infer(ir)
+    println(ir)
+    Compile(ir, fb)
+  }
+
+  @Test
+  def mean() {
+    val meanIr =
+      Let("x", In(0, TArray(TFloat64)),
+        ApplyBinaryPrimOp(Divide(),
+          ArrayFold(Ref("x"), F64(0.0), "sum", "v",
+            ApplyBinaryPrimOp(Add(), Ref("sum"), Ref("v"))),
+          Cast(ArrayLen(Ref("x")), TFloat64)))
+
+    val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
+    doit(meanIr, fb)
+    val f = fb.result()()
+    def run(a: Array[Double]): Double = {
+      val mb = MemoryBuffer()
+      val aoff = addArray(mb, a)
+      f(mb, aoff, false)
+    }
+
+    assert(run(Array()).isNaN)
+    assert(run(Array(1.0)) == 1.0)
+    assert(run(Array(1.0,2.0,3.0)) == 2.0)
+    assert(run(Array(-1.0,0.0,1.0)) == 0.0)
+  }
+
+  @Test
+  def letAdd() {
+    val letAddIr =
+      Let("foo", F64(0),
+        ApplyBinaryPrimOp(Add(),
+          Ref("foo"), Cast(I32(1), TFloat64)))
+
+    val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Double]
+    doit(letAddIr, fb)
+    val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
+    val mb = MemoryBuffer()
+    assert(f(mb) === 1.0)
+  }
+
+  @Test
+  def count() {
+    val letAddIr =
+      Let("in", In(0, TArray(TFloat64)),
+        ArrayFold(Ref("in"), I32(0), "count", "v",
+          ApplyBinaryPrimOp(Add(), Ref("count"), I32(1))))
+
+    val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Int]
+    doit(letAddIr, fb)
+    val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
+
+    def run(a: Array[java.lang.Double]): Int = {
+      val mb = MemoryBuffer()
+      val aoff = addBoxedArray(mb, a)
+      val t = TArray(TFloat64)
+      f(mb, aoff, false)
+    }
+
+    assert(run(Array()) === 0)
+    assert(run(Array(5.0)) === 1)
+    assert(run(Array(5.0, 6.0, 1.0)) === 3)
+  }
+
+  @Test
+  def sum() {
+    val letAddIr =
+      Let("in", In(0, TArray(TFloat64)),
+        ArrayFold(Ref("in"), F64(0), "sum", "v",
+          ApplyBinaryPrimOp(Add(), Ref("sum"), Ref("v"))))
+
+    val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
+    doit(letAddIr, fb)
+    val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
+
+    def run(a: Array[java.lang.Double]): Double = {
+      val mb = MemoryBuffer()
+      val aoff = addBoxedArray(mb, a)
+      val t = TArray(TFloat64)
+      f(mb, aoff, false)
+    }
+
+    assert(run(Array()) === 0.0)
+    assert(run(Array(5.0)) === 5.0)
+    assert(run(Array(5.0, 6.0)) === 11.0)
+    assert(run(Array(5.0, 6.0, 8.0)) === 19.0)
+    intercept[RuntimeException](run(Array(null)))
+  }
+
+  @Test
+  def countNonMissing() {
+    val letAddIr =
+      Let("in", In(0, TArray(TFloat64)),
+        ArrayFold(Ref("in"), I32(0), "count", "v",
+          ApplyBinaryPrimOp(Add(), Ref("count"), If(IsNA(Ref("v")), I32(0), I32(1)))))
+
+    val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Int]
+    doit(letAddIr, fb)
+    val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
+
+    def run(a: Array[java.lang.Double]): Double = {
+      val mb = MemoryBuffer()
+      val aoff = addBoxedArray(mb, a)
+      val t = TArray(TFloat64)
+      f(mb, aoff, false)
+    }
+
+    assert(run(Array()) === 0)
+    assert(run(Array(null)) === 0)
+    assert(run(Array(0.0)) === 1)
+    assert(run(Array(null, 0.0)) === 1)
+    assert(run(Array(0.0, null)) === 1)
+  }
+
+  @Test
+  def nonMissingSum() {
+    val sumIr =
+      ArrayFold(In(0, TArray(TFloat64)), F64(0), "sum", "v",
+        ApplyBinaryPrimOp(Add(), Ref("sum"), If(IsNA(Ref("v")), F64(0.0), Ref("v"))))
+    val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
+    doit(sumIr, fb)
+    val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
+
+    def run(a: Array[java.lang.Double]): Double = {
+      val mb = MemoryBuffer()
+      val aoff = addBoxedArray(mb, a)
+      val t = TArray(TFloat64)
+      f(mb, aoff, false)
+    }
+
+    assert(run(Array(1.0)) === 1.0)
+    assert(run(Array(1.0, null)) === 1.0)
+    assert(run(Array(null, 1.0)) === 1.0)
+    assert(run(Array(1.0, null, 3.0)) === 4.0)
+  }
+
+  @Test
+  def nonMissingMean() {
+    val letAddIr =
+      Let("in", In(0, TArray(TFloat64)),
+        Let("nonMissing",
+          ArrayFold(Ref("in"), I32(0), "count", "v",
+            ApplyBinaryPrimOp(Add(), Ref("count"), If(IsNA(Ref("v")), I32(0), I32(1)))),
+          Let("sum",
+            ArrayFold(Ref("in"), F64(0), "sum", "v",
+              ApplyBinaryPrimOp(Add(), Ref("sum"), If(IsNA(Ref("v")), F64(0.0), Ref("v")))),
+            ApplyBinaryPrimOp(Divide(), Ref("sum"), Cast(Ref("nonMissing"), TFloat64)))))
+
+    val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
+    doit(letAddIr, fb)
+    val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
+
+    def run(a: Array[java.lang.Double]): Double = {
+      val mb = MemoryBuffer()
+      val aoff = addBoxedArray(mb, a)
+      val t = TArray(TFloat64)
+      f(mb, aoff, false)
+    }
+
+    assert(run(Array(1.0)) === 1.0)
+    assert(run(Array(null, 1.0)) === 1.0)
+    assert(run(Array(1.0, null)) === 1.0)
+    assert(run(Array(1.0, null, 3.0)) === 2.0)
+  }
+
+
+  def printRegion(region: MemoryBuffer, string: String) {
+    println(string)
+    val size = region.size
+    println("Region size: " + size.toString)
+    val bytes = region.loadBytes(0, size.toInt)
+    println("Array: ")
+    var j = 0
+    for (i <- bytes) {
+      j += 1
+      print(i)
+      if (j % 32 == 0) {
+        print('\n')
+      } else {
+        print('\t')
+      }
+    }
+    print('\n')
+  }
+  @Test
+  def replaceMissingValues() {
+    val replaceMissingIr =
+      Let("mean", F64(42.0),
+        ArrayMap(In(0, TArray(TFloat64)), "v",
+          If(IsNA(Ref("v")), Ref("mean"), Ref("v"))))
+    val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Long]
+    doit(replaceMissingIr, fb)
+    val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
+    def run(a: Array[java.lang.Double]): Array[java.lang.Double] = {
+      val mb = MemoryBuffer()
+      val aoff = addBoxedArray(mb, a)
+      val t = TArray(TFloat64)
+      val roff = f(mb, aoff, false)
+      println(s"array location $roff")
+      printRegion(mb, "hi amanda")
+      Array.tabulate[java.lang.Double](a.length) { i =>
+        if (t.isElementDefined(mb, roff, i)) {
+          println(s" $i")
+          mb.loadDouble(t.loadElement(mb, roff, i))
+        } else
+          null
+      }
+    }
+
+    assert(run(Array(-1.0,null,1.0)) === Array(-1.0,42.0,1.0))
+    assert(run(Array(-1.0,null,null)) === Array(-1.0,42.0,42.0))
+  }
+
+  @Test
+  def meanImpute() {
+    val meanImputeIr =
+      Let("in", In(0, TArray(TFloat64)),
+        Let("nonMissing",
+          ArrayFold(Ref("in"), I32(0), "count", "v",
+            ApplyBinaryPrimOp(Add(), Ref("count"), If(IsNA(Ref("v")), I32(0), I32(1)))),
+          Let("sum",
+            ArrayFold(Ref("in"), F64(0), "sum", "v",
+              ApplyBinaryPrimOp(Add(), Ref("sum"), If(IsNA(Ref("v")), F64(0.0), Ref("v")))),
+            Let("mean",
+              ApplyBinaryPrimOp(Divide(), Ref("sum"), Cast(Ref("nonMissing"), TFloat64)),
+              ArrayMap(Ref("in"), "v",
+                If(IsNA(Ref("v")), Ref("mean"), Ref("v")))))))
+
+    val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Long]
+    doit(meanImputeIr, fb)
+    val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
+    def run(a: Array[java.lang.Double]): Array[java.lang.Double] = {
+      val mb = MemoryBuffer()
+      val aoff = addBoxedArray(mb, a)
+      val t = TArray(TFloat64)
+      val roff = f(mb, aoff, false)
+      Array.tabulate[java.lang.Double](a.length) { i =>
+        if (t.isElementDefined(mb, roff, i))
+          mb.loadDouble(t.loadElement(mb, roff, i))
+        else
+          null
+      }
+    }
+
+    assert(run(Array()) === Array())
+    assert(run(Array(1.0)) === Array(1.0))
+    assert(run(Array(1.0,2.0,3.0)) === Array(1.0,2.0,3.0))
+    assert(run(Array(-1.0,0.0,1.0)) === Array(-1.0,0.0,1.0))
+
+    assert(run(Array(-1.0,null,1.0)) === Array(-1.0,0.0,1.0))
+    assert(run(Array(-1.0,null,null)) === Array(-1.0,-1.0,-1.0))
+  }
+
+  @Test
+  def mapNA() {
+    val mapNaIr = MapNA("foo", In(0, TArray(TFloat64)),
+      ArrayRef(Ref("foo"), In(1, TInt32)))
+
+    val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Int, Boolean, Double]
+    doit(mapNaIr, fb)
+    val f = fb.result()()
+    def run(a: Array[java.lang.Double], i: Int): Double = {
+      val mb = MemoryBuffer()
+      val aoff = if (a != null) addBoxedArray(mb, a) else -1L
+      f(mb, aoff, a == null, i, false)
+    }
+
+    assert(run(Array(1.0), 0) === 1.0)
+    assert(run(Array(1.0,2.0,3.0), 2) === 3.0)
+    assert(run(Array(-1.0,0.0,1.0), 0) === -1.0)
+
+    intercept[RuntimeException](run(null, 5))
+    intercept[RuntimeException](run(null, 0))
+    intercept[RuntimeException](run(Array(-1.0,null,1.0), 1))
+  }
+
+}


### PR DESCRIPTION
To achieve this we need TypeInfo[T] to require ClassTag[T], to keep
the requirements to one type class, we switch from implicits to
type class constraints and an implicit extracting method, `typeInfo`.