### PR TITLE
Simplify read logic

### DIFF
--- a/python/hail/context.py
+++ b/python/hail/context.py
@@ -555,17 +555,13 @@ class HailContext(HistoryMixin):
 
     @handle_py4j
     @record_method
-    @typecheck_method(path=oneof(strlike, listof(strlike)),
+    @typecheck_method(path=strlike,
                       drop_samples=bool,
                       drop_variants=bool)
     def read(self, path, drop_samples=False, drop_variants=False):
-        """Read .vds files as variant dataset.
+        """Read .vds file as a variant dataset.
 
-        When loading multiple VDS files, they must have the same
-        sample IDs, genotype schema, split status and variant metadata.
-
-        :param path: VDS files to read.
-        :type path: str or list of str
+        :param str path: VDS file to read.
 
         :param bool drop_samples: If True, create sites-only variant
           dataset.  Don't load sample ids, sample annotations
@@ -581,7 +577,7 @@ class HailContext(HistoryMixin):
 
         return VariantDataset(
             self,
-            self._jhc.readAll(jindexed_seq_args(path), drop_samples, drop_variants))
+            self._jhc.read(path, drop_samples, drop_variants))
 
     @handle_py4j
     @record_method

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -354,11 +354,7 @@ class HailContext private(val sc: SparkContext,
   }
 
   def read(file: String, dropSamples: Boolean = false, dropVariants: Boolean = false): VariantSampleMatrix[_, _, _] = {
-    val vsm = VariantSampleMatrix.read(this, file, dropSamples = dropSamples, dropVariants = dropVariants)
-
-    if (vsm.genotypeSignature == TGenotype)
-      vsm.asInstanceOf[VariantSampleMatrix[Annotation, Annotation, Annotation]]
-    else vsm.asInstanceOf[VariantDataset]
+    VariantSampleMatrix.read(this, file, dropSamples = dropSamples, dropVariants = dropVariants)
   }
 
   def readVDS(file: String, dropSamples: Boolean = false, dropVariants: Boolean = false): VariantDataset =

--- a/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
@@ -322,32 +322,6 @@ class VSMSuite extends SparkSuite {
     }.check()
   }
 
-  @Test def testUnionRead() {
-    val g = for (vds <- VariantSampleMatrix.gen(hc, VSMSubgen.random);
-      variants = vds.variants.collect();
-      groups <- Gen.buildableOfN[Array, Int](variants.length, Gen.choose(1, 3)).map(groups => variants.zip(groups).toMap)
-    ) yield (vds, groups)
-
-    forAll(g) { case (vds, groups) =>
-      val path1 = tmpDir.createTempFile("file1", "vds")
-      val path2 = tmpDir.createTempFile("file2", "vds")
-      val path3 = tmpDir.createTempFile("file3", "vds")
-
-      vds.filterVariants { case (v, _, _) => groups(v) == 1 }
-        .write(path1)
-
-      vds.filterVariants { case (v, _, _) => groups(v) == 2 }
-        .write(path2)
-
-      vds.filterVariants { case (v, _, _) => groups(v) == 3 }
-        .write(path3)
-
-      hc.readVDSAll(Array(path1, path2, path3))
-        .same(vds)
-
-    }.check()
-  }
-
   @Test def testOverwrite() {
     val out = tmpDir.createTempFile("out", "vds")
     val vds = hc.importVCF("src/test/resources/sample2.vcf")


### PR DESCRIPTION
Simplify the read logic by no longer reading multiple files at once. This functionality is preserved in the newly-added union function.