### PR TITLE
 Use region values in SplitMulti.

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -4768,13 +4768,14 @@ class VariantDataset(HistoryMixin):
 
     @handle_py4j
     @record_method
-    @typecheck_method(propagate_gq=bool,
+    @typecheck_method(variant_expr=oneof(strlike, listof(strlike)),
+                      genotype_expr=oneof(strlike, listof(strlike)),
                       keep_star_alleles=bool,
-                      max_shift=integral)
-    def split_multi(self, propagate_gq=False, keep_star_alleles=False, max_shift=100):
+                      left_aligned=bool)
+    # FIXME default split for HTS genotype + GP
+    def split_multi(self, variant_expr='', genotype_expr='', keep_star_alleles=False, left_aligned=False):
+        # FIXME update docs
         """Split multiallelic variants.
-
-        .. include:: _templates/req_tvariant_tgenotype.rst
 
         **Examples**
 
@@ -4898,7 +4899,13 @@ class VariantDataset(HistoryMixin):
         :rtype: :py:class:`.VariantDataset`
         """
 
-        jvds = self._jvdf.splitMulti(propagate_gq, keep_star_alleles, max_shift)
+        if isinstance(variant_expr, list):
+            variant_expr = ",".join(variant_expr)
+
+        if isinstance(genotype_expr, list):
+            genotype_expr = ",".join(genotype_expr)
+
+        jvds = self._jvdf.splitMulti(variant_expr, genotype_expr, keep_star_alleles, left_aligned)
         return VariantDataset(self.hc, jvds)
 
     @handle_py4j

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -4768,13 +4768,10 @@ class VariantDataset(HistoryMixin):
 
     @handle_py4j
     @record_method
-    @typecheck_method(variant_expr=oneof(strlike, listof(strlike)),
-                      genotype_expr=oneof(strlike, listof(strlike)),
+    @typecheck_method(propagate_gq=bool,
                       keep_star_alleles=bool,
                       left_aligned=bool)
-    # FIXME default split for HTS genotype + GP
-    def split_multi(self, variant_expr='', genotype_expr='', keep_star_alleles=False, left_aligned=False):
-        # FIXME update docs
+    def split_multi(self, propagate_gq=False, keep_star_alleles=False, left_aligned=False):
         """Split multiallelic variants.
 
         **Examples**
@@ -4890,22 +4887,15 @@ class VariantDataset(HistoryMixin):
           ``import_vcf(store_gq=True)``.  This option will be obviated
           in the future by generic genotype schemas.  Experimental.
         :param bool keep_star_alleles: Do not filter out * alleles.
-        :param int max_shift: maximum number of base pairs by which
-          a split variant can move.  Affects memory usage, and will
-          cause Hail to throw an error if a variant that moves further
-          is encountered.
+        :param bool left_aligned: If True, variants are assumed to be
+          left aligned and have unique loci.  This avoids a shuffle.
+          If the assumption is violated, an error is generated.
 
         :return: A biallelic variant dataset.
         :rtype: :py:class:`.VariantDataset`
         """
 
-        if isinstance(variant_expr, list):
-            variant_expr = ",".join(variant_expr)
-
-        if isinstance(genotype_expr, list):
-            genotype_expr = ",".join(genotype_expr)
-
-        jvds = self._jvdf.splitMulti(variant_expr, genotype_expr, keep_star_alleles, left_aligned)
+        jvds = self._jvkdf.splitMulti(propagate_gq, keep_star_alleles, left_aligned)
         return VariantDataset(self.hc, jvds)
 
     @handle_py4j

--- a/python/hail/representation/genotype.py
+++ b/python/hail/representation/genotype.py
@@ -47,7 +47,7 @@ class Genotype(HistoryMixin):
             jpl = jnone()
 
         self._jgenotype = Genotype._genotype_jobject
-        jrep = self._jgenotype.apply(jgt, jad, jdp, jgq, jpl, False)
+        jrep = self._jgenotype.apply(jgt, jad, jdp, jgq, jpl)
         self._gt = gt
         self._ad = ad
         self._dp = dp
@@ -59,9 +59,8 @@ class Genotype(HistoryMixin):
         return self._jrep.toString()
 
     def __repr__(self):
-        fake_ref = 'FakeRef=True' if self._jrep._fakeRef() else ''
-        return 'Genotype(GT=%s, AD=%s, DP=%s, GQ=%s, PL=%s%s)' % \
-            (self.gt, self.ad, self.dp, self.gq, self.pl, fake_ref)
+        return 'Genotype(GT=%s, AD=%s, DP=%s, GQ=%s, PL=%s)' % \
+            (self.gt, self.ad, self.dp, self.gq, self.pl)
 
     def __eq__(self, other):
         return self._jrep.equals(other._jrep)

--- a/python/hail2/expr/column.py
+++ b/python/hail2/expr/column.py
@@ -962,10 +962,6 @@ class GenotypeColumn(Column):
     def dp(self):
         return self._field("dp", TInt32())
 
-    @property
-    def fake_ref(self):
-        return self._field("fakeRef", TBoolean())
-
     def fraction_reads_ref(self):
         return self._method("fractionReadsRef", TFloat64())
 

--- a/src/main/scala/is/hail/annotations/Annotation.scala
+++ b/src/main/scala/is/hail/annotations/Annotation.scala
@@ -153,5 +153,25 @@ object Annotation {
 
     (finalType, insF)
   }
+
+  def copy(t: Type, a: Annotation): Annotation = {
+    t match {
+      case t: TStruct =>
+        val region = MemoryBuffer()
+        val rvb = new RegionValueBuilder(region)
+        rvb.start(t)
+        rvb.addAnnotation(t, a)
+        new UnsafeRow(t, region, rvb.end())
+
+      case t: TArray =>
+        val region = MemoryBuffer()
+        val rvb = new RegionValueBuilder(region)
+        rvb.start(t)
+        rvb.addAnnotation(t, a)
+        new UnsafeIndexedSeq(t, region, rvb.end())
+
+      case _ => a
+    }
+  }
 }
 

--- a/src/main/scala/is/hail/annotations/MemoryBlock.scala
+++ b/src/main/scala/is/hail/annotations/MemoryBlock.scala
@@ -1000,7 +1000,6 @@ class RegionValueBuilder(var region: MemoryBuffer) {
             endArray()
           }
 
-          addBoolean(g._fakeRef)
           endStruct()
 
         case t: TLocus =>

--- a/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -241,9 +241,8 @@ object UnsafeRow {
             readArrayInt(region, ft.loadField(region, offset, 4))
           else
             null
-        val fakeRef = region.loadByte(ft.loadField(region, offset, 5)) != 0
 
-        new GenericGenotype(gt, ad, dp, gq, px, fakeRef)
+        new GenericGenotype(gt, ad, dp, gq, px)
     }
   }
 }

--- a/src/main/scala/is/hail/expr/AnnotationImpex.scala
+++ b/src/main/scala/is/hail/expr/AnnotationImpex.scala
@@ -81,8 +81,7 @@ object SparkAnnotationImpex extends AnnotationImpex[DataType, Any] {
             Option(r.get(1)).map(_.asInstanceOf[Seq[Int]].toArray),
             Option(r.get(2)).map(_.asInstanceOf[Int]),
             Option(r.get(3)).map(_.asInstanceOf[Int]),
-            Option(r.get(4)).map(_.asInstanceOf[Seq[Int]].toArray),
-            r.get(5).asInstanceOf[Boolean])
+            Option(r.get(4)).map(_.asInstanceOf[Seq[Int]].toArray))
         case TAltAllele =>
           val r = a.asInstanceOf[Row]
           AltAllele(r.getAs[String](0), r.getAs[String](1))
@@ -195,10 +194,9 @@ case class JSONExtractGenotype(
   ad: Option[Array[Int]],
   dp: Option[Int],
   gq: Option[Int],
-  px: Option[Array[Int]],
-  fakeRef: Boolean) {
+  px: Option[Array[Int]]) {
   def toGenotype =
-    Genotype(gt, ad, dp, gq, px, fakeRef)
+    Genotype(gt, ad, dp, gq, px)
 }
 
 case class JSONExtractVariant(contig: String,

--- a/src/main/scala/is/hail/expr/Fun.scala
+++ b/src/main/scala/is/hail/expr/Fun.scala
@@ -91,6 +91,12 @@ case class Arity0Aggregator[T, U](retType: Type, ctor: () => TypedAggregator[U])
   }
 }
 
+case class Arity0DependentAggregator[T, U](retType: Type, ctor: () => (() => TypedAggregator[U])) extends Fun {
+  def subst() = Arity0Aggregator[T, U](retType.subst(), ctor())
+
+  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = ???
+}
+
 class TransformedAggregator[T](val prev: TypedAggregator[T], transform: (Any) => Any) extends TypedAggregator[T] {
   def seqOp(x: Any) = prev.seqOp(transform(x))
 
@@ -113,6 +119,12 @@ case class Arity1Aggregator[T, U, V](retType: Type, ctor: (U) => TypedAggregator
         transformations(0).f)
     })
   }
+}
+
+case class Arity1DependentAggregator[T, U, V](retType: Type, ctor: () => ((U) => TypedAggregator[V])) extends Fun {
+  def subst() = Arity1Aggregator[T, U, V](retType.subst(), ctor())
+
+  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = ???
 }
 
 case class Arity3Aggregator[T, U, V, W, X](retType: Type, ctor: (U, V, W) => TypedAggregator[X]) extends Fun {
@@ -140,6 +152,13 @@ case class UnaryLambdaAggregator[T, U, V](retType: Type, ctor: ((Any) => Any) =>
 
 case class BinaryLambdaAggregator[T, U, V, W](retType: Type, ctor: ((Any) => Any, V) => TypedAggregator[W]) extends Fun {
   def subst() = BinaryLambdaAggregator[T, U, V, W](retType.subst(), ctor)
+
+  // conversion can't apply to function type
+  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = ???
+}
+
+case class BinaryDependentLambdaAggregator[T, U, V, W](retType: Type, ctor: () => (((Any) => Any, V) => TypedAggregator[W])) extends Fun {
+  def subst() = BinaryLambdaAggregator[T, U, V, W](retType.subst(), ctor())
 
   // conversion can't apply to function type
   def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = ???

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -793,8 +793,6 @@ object FunctionRegistry {
       (stsum, sum) <- CM.memoize(intArraySumCode(ad))
     ) yield Code(stad, stsum, sum.ceq(0).mux(Code._null, boxDouble(ad(0).toD / sum.toD)))
   }, "the ratio of ref reads to the sum of all *informative* reads.")
-  registerFieldCode("fakeRef", { (x: Code[Genotype]) => CM.ret(boxBoolean(x.invoke[Boolean]("_fakeRef"))) },
-    "True if this genotype was downcoded in :py:meth:`~hail.VariantDataset.split_multi`.  This can happen if a ``1/2`` call is split to ``0/1``, ``0/1``.")
   registerFieldCode("isLinearScale", { (x: Code[Genotype]) => CM.ret(boxBoolean(x.invoke[Boolean]("isLinearScale"))) },
     "True if the data was imported from :py:meth:`~hail.HailContext.import_gen` or :py:meth:`~hail.HailContext.import_bgen`.")
   registerFieldCode("contig", { (x: Code[Variant]) => CM.ret(x.invoke[String]("contig")) },

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -613,6 +613,11 @@ object FunctionRegistry {
     bind(name, MethodType(hrt.typ), Arity0Aggregator[T, U](hru.typ, ctor), MetaData(Option(docstring), argNames))
   }
 
+  def registerDependentAggregator[T, U](name: String, ctor: () => (() => TypedAggregator[U]), docstring: String, argNames: (String, String)*)
+    (implicit hrt: HailRep[T], hru: HailRep[U]) = {
+    bind(name, MethodType(hrt.typ), Arity0DependentAggregator[T, U](hru.typ, ctor), MetaData(Option(docstring), argNames))
+  }
+
   def registerLambdaAggregator[T, U, V](name: String, ctor: ((Any) => Any) => TypedAggregator[V], docstring: String, argNames: (String, String)*)
     (implicit hrt: HailRep[T], hru: HailRep[U], hrv: HailRep[V]) = {
     bind(name, MethodType(hrt.typ, hru.typ), UnaryLambdaAggregator[T, U, V](hrv.typ, ctor), MetaData(Option(docstring), argNames))
@@ -623,9 +628,19 @@ object FunctionRegistry {
     bind(name, MethodType(hrt.typ, hru.typ, hrv.typ), BinaryLambdaAggregator[T, U, V, W](hrw.typ, ctor), MetaData(Option(docstring), argNames))
   }
 
+  def registerDependentLambdaAggregator[T, U, V, W](name: String, ctor: () => (((Any) => Any, V) => TypedAggregator[W]), docstring: String, argNames: (String, String)*)
+    (implicit hrt: HailRep[T], hru: HailRep[U], hrv: HailRep[V], hrw: HailRep[W]) = {
+    bind(name, MethodType(hrt.typ, hru.typ, hrv.typ), BinaryDependentLambdaAggregator[T, U, V, W](hrw.typ, ctor), MetaData(Option(docstring), argNames))
+  }
+
   def registerAggregator[T, U, V](name: String, ctor: (U) => TypedAggregator[V], docstring: String, argNames: (String, String)*)
     (implicit hrt: HailRep[T], hru: HailRep[U], hrv: HailRep[V]) = {
     bind(name, MethodType(hrt.typ, hru.typ), Arity1Aggregator[T, U, V](hrv.typ, ctor), MetaData(Option(docstring), argNames))
+  }
+
+  def registerDependentAggregator[T, U, V](name: String, ctor: () => ((U) => TypedAggregator[V]), docstring: String, argNames: (String, String)*)
+    (implicit hrt: HailRep[T], hru: HailRep[U], hrv: HailRep[V]) = {
+    bind(name, MethodType(hrt.typ, hru.typ), Arity1DependentAggregator[T, U, V](hrv.typ, ctor), MetaData(Option(docstring), argNames))
   }
 
   def registerAggregator[T, U, V, W, X](name: String, ctor: (U, V, W) => TypedAggregator[X], docstring: String, argNames: (String, String)*)
@@ -1971,7 +1986,10 @@ object FunctionRegistry {
     """
   )(aggregableHr(TTHr), int64Hr)
 
-  registerAggregator[Any, IndexedSeq[Any]]("collect", () => new CollectAggregator(),
+  registerDependentAggregator[Any, IndexedSeq[Any]]("collect", () => {
+    val t = TT.t
+    () => new CollectAggregator(t)
+  },
     """
     Returns an array with all of the elements in the aggregable. Order is not guaranteed.
 
@@ -1985,7 +2003,10 @@ object FunctionRegistry {
     """
   )(aggregableHr(TTHr), arrayHr(TTHr))
 
-  registerAggregator[Any, Set[Any]]("collectAsSet", () => new CollectSetAggregator(),
+  registerDependentAggregator[Any, Set[Any]]("collectAsSet", () => {
+    val t = TT.t
+    () => new CollectSetAggregator(t)
+  },
     """
     Returns the vset of all unique elements in the aggregable.
     """
@@ -2122,7 +2143,10 @@ object FunctionRegistry {
       def typ = HWECombiner.signature
     })
 
-  registerAggregator[Any, Any]("counter", () => new CounterAggregator(),
+  registerDependentAggregator[Any, Any]("counter", () => {
+    val t = TT.t
+    () => new CounterAggregator(t)
+  },
     """
     Counts the number of occurrences of each element in an aggregable.
 
@@ -2306,7 +2330,10 @@ object FunctionRegistry {
     """,
     "expr" -> "Lambda expression.")(aggregableHr(TTHr), unaryHr(TTHr, boxedboolHr), boolHr)
 
-  registerAggregator("take", (n: Int) => new TakeAggregator(n),
+  registerDependentAggregator("take", () => {
+    val t = TT.t
+    (n: Int) => new TakeAggregator(t, n)
+  },
     """
     Take the first ``n`` items of an aggregable.
 
@@ -2318,7 +2345,8 @@ object FunctionRegistry {
     """, "n" -> "Number of items to take.")(
     aggregableHr(TTHr), int32Hr, arrayHr(TTHr))
 
-  private val genericTakeByDocs = """
+  private val genericTakeByDocs =
+    """
     Returns the first ``n`` items of an aggregable in ascending order, ordered
     by the result of ``f``. ``NA`` always appears last. If the aggregable
     contains less than ``n`` items, then the result will contain as many
@@ -2326,7 +2354,8 @@ object FunctionRegistry {
 
     """
 
-  private val integralTakeByDocs = genericTakeByDocs ++ """
+  private val integralTakeByDocs = genericTakeByDocs ++
+    """
     **Examples**
 
     Consider an aggregable ``gs`` containing these elements::
@@ -2353,14 +2382,22 @@ object FunctionRegistry {
 
     """
 
-  registerLambdaAggregator("takeBy", (f: (Any) => Any, n: Int) => new TakeByAggregator[Int](f, n),
+  registerDependentLambdaAggregator("takeBy", () => {
+    val t = TT.t
+    (f: (Any) => Any, n: Int) => new TakeByAggregator[Int](t, f, n)
+  },
     integralTakeByDocs, "f" -> "Lambda expression for mapping an aggregable to an ordered value.", "n" -> "Number of items to take."
   )(aggregableHr(TTHr), unaryHr(TTHr, boxedInt32Hr), int32Hr, arrayHr(TTHr))
-  registerLambdaAggregator("takeBy", (f: (Any) => Any, n: Int) => new TakeByAggregator[Long](f, n),
+
+  registerDependentLambdaAggregator("takeBy", () => {
+    val t = TT.t
+    (f: (Any) => Any, n: Int) => new TakeByAggregator[Long](t, f, n)
+  },
     integralTakeByDocs, "f" -> "Lambda expression for mapping an aggregable to an ordered value.", "n" -> "Number of items to take."
   )(aggregableHr(TTHr), unaryHr(TTHr, boxedInt64Hr), int32Hr, arrayHr(TTHr))
 
-  private val floatingPointTakeByDocs = genericTakeByDocs ++ """
+  private val floatingPointTakeByDocs = genericTakeByDocs ++
+    """
     Note that ``NaN`` always appears after any finite or infinite floating-point
     numbers but before ``NA``. For example, consider an aggregable containing
     these elements::
@@ -2377,14 +2414,24 @@ object FunctionRegistry {
 
     """
 
-  registerLambdaAggregator("takeBy", (f: (Any) => Any, n: Int) => new TakeByAggregator[Float](f, n),
+  registerDependentLambdaAggregator("takeBy", () => {
+    val t = TT.t
+    (f: (Any) => Any, n: Int) => new TakeByAggregator[Float](t, f, n)
+  },
     floatingPointTakeByDocs, "f" -> "Lambda expression for mapping an aggregable to an ordered value.", "n" -> "Number of items to take."
   )(aggregableHr(TTHr), unaryHr(TTHr, boxedFloat32Hr), int32Hr, arrayHr(TTHr))
-  registerLambdaAggregator("takeBy", (f: (Any) => Any, n: Int) => new TakeByAggregator[Double](f, n),
+
+  registerDependentLambdaAggregator("takeBy", () => {
+    val t = TT.t
+    (f: (Any) => Any, n: Int) => new TakeByAggregator[Double](t, f, n)
+  },
     floatingPointTakeByDocs, "f" -> "Lambda expression for mapping an aggregable to an ordered value.", "n" -> "Number of items to take."
   )(aggregableHr(TTHr), unaryHr(TTHr, boxedFloat64Hr), int32Hr, arrayHr(TTHr))
 
-  registerLambdaAggregator("takeBy", (f: (Any) => Any, n: Int) => new TakeByAggregator[String](f, n),
+  registerDependentLambdaAggregator("takeBy", () => {
+    val t = TT.t
+    (f: (Any) => Any, n: Int) => new TakeByAggregator[String](t, f, n)
+  },
     genericTakeByDocs, "f" -> "Lambda expression for mapping an aggregable to an ordered value.", "n" -> "Number of items to take."
   )(aggregableHr(TTHr), unaryHr(TTHr, stringHr), int32Hr, arrayHr(TTHr))
 

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -862,7 +862,7 @@ object FunctionRegistry {
     Downcode call by sending all alleles except i to the reference.
     """,
     "gt" -> "genotype call to be downcoded",
-    "i" -> "allele to become the referene allele")(callHr, int32Hr, callHr)
+    "i" -> "allele to become the reference allele")(callHr, int32Hr, callHr)
 
   register("gqFromPL", { pl: IndexedSeq[Int] =>
     // FIXME toArray

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -466,7 +466,7 @@ case class FilterSamples(
 
     val f: () => java.lang.Boolean = Parser.evalTypedExpr[java.lang.Boolean](pred, ec)
 
-    val sampleAggregationOption = Aggregators.buildSampleAggregations[Annotation, Annotation, Annotation](hc, prev, ec)
+    val sampleAggregationOption = Aggregators.buildSampleAggregations(hc, prev, ec)
 
     val p = (s: Annotation, sa: Annotation) => {
       sampleAggregationOption.foreach(f => f.apply(s))
@@ -498,8 +498,8 @@ case class FilterVariants(
 
     val f: () => java.lang.Boolean = Parser.evalTypedExpr[java.lang.Boolean](pred, ec)
 
-    val aggregatorOption = Aggregators.buildVariantAggregations[Annotation, Annotation, Annotation](
-      prev.rdd2.sparkContext, prev.localValue, ec)
+    val aggregatorOption = Aggregators.buildVariantAggregations(
+      prev.rdd2.sparkContext, prev.typ, prev.localValue, ec)
 
     val localPrevRowType = prev.typ.rowType
     val p = (rv: RegionValue) => {
@@ -507,8 +507,7 @@ case class FilterVariants(
 
       val v = ur.get(1)
       val va = ur.get(2)
-      val gs = ur.getAs[IndexedSeq[Annotation]](3)
-      aggregatorOption.foreach(f => f(v, va, gs))
+      aggregatorOption.foreach(f => f(rv))
 
       ec.setAll(localGlobalAnnotation, v, va)
 

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -1017,8 +1017,7 @@ case object TGenotype extends ComplexType {
     "ad" -> TArray(TInt32),
     "dp" -> TInt32,
     "gq" -> TInt32,
-    "pl" -> TArray(TInt32),
-    "fakeRef" -> TBoolean)
+    "pl" -> TArray(TInt32))
 
   def typeCheck(a: Any): Boolean = a == null || a.isInstanceOf[Genotype]
 

--- a/src/main/scala/is/hail/methods/Aggregators.scala
+++ b/src/main/scala/is/hail/methods/Aggregators.scala
@@ -3,7 +3,7 @@ package is.hail.methods
 import java.io.{ObjectInputStream, ObjectOutputStream}
 
 import is.hail.HailContext
-import is.hail.annotations.Annotation
+import is.hail.annotations.{Annotation, RegionValue, UnsafeRow}
 import is.hail.expr._
 import is.hail.stats._
 import is.hail.utils._
@@ -17,33 +17,41 @@ import scala.reflect.ClassTag
 
 object Aggregators {
 
-  def buildVariantAggregations[RPK, RK, T >: Null](vsm: VariantSampleMatrix[RPK, RK, T], ec: EvalContext): Option[(RK, Annotation, Iterable[T]) => Unit] =
-    buildVariantAggregations[RPK, RK, T](vsm.sparkContext, vsm.value.localValue, ec)
+  def buildVariantAggregations[RPK, RK, T >: Null](vsm: VariantSampleMatrix[RPK, RK, T], ec: EvalContext): Option[(RegionValue) => Unit] =
+    buildVariantAggregations(vsm.sparkContext, vsm.matrixType, vsm.value.localValue, ec)
 
-  def buildVariantAggregations[RPK, RK, T >: Null](sc: SparkContext,
+  def buildVariantAggregations(sc: SparkContext,
+    typ: MatrixType,
     localValue: VSMLocalValue,
-    ec: EvalContext): Option[(RK, Annotation, Iterable[T]) => Unit] = {
+    ec: EvalContext): Option[(RegionValue) => Unit] = {
 
     val aggregations = ec.aggregations
     if (aggregations.isEmpty)
       return None
 
     val localA = ec.a
+    val localNSamples = localValue.nSamples
     val localSamplesBc = sc.broadcast(localValue.sampleIds)
     val localAnnotationsBc = sc.broadcast(localValue.sampleAnnotations)
     val localGlobalAnnotations = localValue.globalAnnotation
+    val localRowType = typ.rowType
 
-    Some({ (v: RK, va: Annotation, gs: Iterable[T]) =>
+    Some({ (rv: RegionValue) =>
+      val ur = new UnsafeRow(localRowType, rv.region, rv.offset)
+
+      val v = ur.get(1)
+      val va = ur.get(2)
+      val gs = ur.getAs[IndexedSeq[Annotation]](3)
+
       val aggs = aggregations.map { case (_, _, agg0) => agg0.copy() }
       localA(0) = localGlobalAnnotations
       localA(1) = v
       localA(2) = va
 
-      val gsIt = gs.iterator
       var i = 0
-      // gsIt assume hasNext is always called before next
-      while (gsIt.hasNext) {
-        localA(3) = gsIt.next
+      val git = gs.iterator
+      while (i < localNSamples) {
+        localA(3) = git.next()
         localA(4) = localSamplesBc.value(i)
         localA(5) = localAnnotationsBc.value(i)
 
@@ -64,7 +72,7 @@ object Aggregators {
     })
   }
 
-  def buildSampleAggregations[RPK, RK, T >: Null](hc: HailContext, value: MatrixValue, ec: EvalContext): Option[(Annotation) => Unit] = {
+  def buildSampleAggregations(hc: HailContext, value: MatrixValue, ec: EvalContext): Option[(Annotation) => Unit] = {
 
     val aggregations = ec.aggregations
 
@@ -86,17 +94,25 @@ object Aggregators {
       baseArray.update(i, j, aggregations(j)._3.copy())
     }
 
-    val result = value.rdd[RPK, RK, T].treeAggregate(baseArray)({ case (arr, (v, (va, gs))) =>
+    val localRowType = value.typ.rowType
+
+    val result = value.rdd2.treeAggregate(baseArray)({ case (arr, rv) =>
+      val ur = new UnsafeRow(localRowType, rv.region, rv.offset)
+
+      val v = ur.get(1)
+      val va = ur.get(2)
+      val gs = ur.getAs[IndexedSeq[Annotation]](3)
+
       localA(0) = localGlobalAnnotations
       localA(4) = v
       localA(5) = va
 
-      val gsIt = gs.iterator
+      var git = gs.iterator
       var i = 0
       while (i < localNSamples) {
         localA(1) = localSamplesBc.value(i)
         localA(2) = localSampleAnnotationsBc.value(i)
-        localA(3) = gsIt.next
+        localA(3) = git.next()
 
         var j = 0
         while (j < nAggregations) {
@@ -349,13 +365,15 @@ class StatAggregator() extends TypedAggregator[Annotation] {
   def copy() = new StatAggregator()
 }
 
-class CounterAggregator extends TypedAggregator[Map[Annotation, Long]] {
+class CounterAggregator(t: Type) extends TypedAggregator[Map[Annotation, Long]] {
   var m = new mutable.HashMap[Any, Long]
 
   def result: Map[Annotation, Long] = m.toMap
 
   def seqOp(x: Any) {
-    m.updateValue(x, 0L, _ + 1)
+    // FIXME only need to copy on the first one
+    val cx = Annotation.copy(t, x)
+    m.updateValue(cx, 0L, _ + 1)
   }
 
   def combOp(agg2: this.type) {
@@ -364,7 +382,7 @@ class CounterAggregator extends TypedAggregator[Map[Annotation, Long]] {
     }
   }
 
-  def copy() = new CounterAggregator()
+  def copy() = new CounterAggregator(t)
 }
 
 class HistAggregator(indices: Array[Double])
@@ -386,34 +404,34 @@ class HistAggregator(indices: Array[Double])
   def copy() = new HistAggregator(indices)
 }
 
-class CollectSetAggregator extends TypedAggregator[Set[Any]] {
+class CollectSetAggregator(t: Type) extends TypedAggregator[Set[Any]] {
 
   var _state = new mutable.HashSet[Any]
 
   def result = _state.toSet
 
   def seqOp(x: Any) {
-    _state += x
+    _state += Annotation.copy(t, x)
   }
 
   def combOp(agg2: this.type) = _state ++= agg2._state
 
-  def copy() = new CollectSetAggregator()
+  def copy() = new CollectSetAggregator(t)
 }
 
-class CollectAggregator extends TypedAggregator[ArrayBuffer[Any]] {
+class CollectAggregator(t: Type) extends TypedAggregator[ArrayBuffer[Any]] {
 
   var _state = new ArrayBuffer[Any]
 
   def result = _state
 
   def seqOp(x: Any) {
-    _state += x
+    _state += Annotation.copy(t, x)
   }
 
   def combOp(agg2: this.type) = _state ++= agg2._state
 
-  def copy() = new CollectAggregator()
+  def copy() = new CollectAggregator(t)
 }
 
 class InfoScoreAggregator extends TypedAggregator[Annotation] {
@@ -650,25 +668,25 @@ class InbreedingAggregator(getAF: (Genotype) => Any) extends TypedAggregator[Ann
   def copy() = new InbreedingAggregator(getAF)
 }
 
-class TakeAggregator(n: Int) extends TypedAggregator[IndexedSeq[Any]] {
+class TakeAggregator(t: Type, n: Int) extends TypedAggregator[IndexedSeq[Any]] {
   var _state = new ArrayBuffer[Any]()
 
   def result = _state.toArray[Any]: IndexedSeq[Any]
 
   def seqOp(x: Any) = {
     if (_state.length < n)
-      _state += x
+      _state += Annotation.copy(t, x)
   }
 
   def combOp(agg2: this.type) {
     agg2._state.foreach(seqOp)
   }
 
-  def copy() = new TakeAggregator(n)
+  def copy() = new TakeAggregator(t, n)
 }
 
-class TakeByAggregator[T](var f: (Any) => Any, var n: Int)(implicit var tord: Ordering[T]) extends TypedAggregator[IndexedSeq[Any]] {
-  def this() = this(null, 0)(null)
+class TakeByAggregator[T](var t: Type, var f: (Any) => Any, var n: Int)(implicit var tord: Ordering[T]) extends TypedAggregator[IndexedSeq[Any]] {
+  def this() = this(null, null, 0)(null)
 
   def makeOrd(): Ordering[(Any, Any)] =
     if (tord != null)
@@ -689,7 +707,10 @@ class TakeByAggregator[T](var f: (Any) => Any, var n: Int)(implicit var tord: Or
 
   def result = _state.clone.dequeueAll.toArray[(Any, Any)].map(_._1).reverse: IndexedSeq[Any]
 
-  def seqOp(x: Any) = seqOp(x, f(x))
+  def seqOp(x: Any) = {
+    val cx = Annotation.copy(t, x)
+    seqOp(cx, f(cx))
+  }
 
   private def seqOp(x: Any, sortKey: Any) = {
     val p = (x, sortKey)
@@ -707,9 +728,10 @@ class TakeByAggregator[T](var f: (Any) => Any, var n: Int)(implicit var tord: Or
     agg2._state.foreach { case (x, p) => seqOp(x, p) }
   }
 
-  def copy() = new TakeByAggregator(f, n)
+  def copy() = new TakeByAggregator(t, f, n)
 
   private def writeObject(oos: ObjectOutputStream) {
+    oos.writeObject(t)
     oos.writeObject(f)
     oos.writeInt(n)
     oos.writeObject(tord)
@@ -717,6 +739,7 @@ class TakeByAggregator[T](var f: (Any) => Any, var n: Int)(implicit var tord: Or
   }
 
   private def readObject(ois: ObjectInputStream) {
+    t = ois.readObject().asInstanceOf[Type]
     f = ois.readObject().asInstanceOf[(Any) => Any]
     n = ois.readInt()
     tord = ois.readObject().asInstanceOf[Ordering[T]]

--- a/src/main/scala/is/hail/methods/SplitMulti.scala
+++ b/src/main/scala/is/hail/methods/SplitMulti.scala
@@ -1,158 +1,213 @@
 package is.hail.methods
 
-import is.hail.annotations.Annotation
+import is.hail.annotations._
 import is.hail.expr._
-import is.hail.sparkextras.OrderedRDD
+import is.hail.sparkextras.OrderedRDD2
 import is.hail.utils._
-import is.hail.variant.{Genotype, GenotypeBuilder, Variant, VariantDataset}
+import is.hail.variant.{Locus, Variant, VariantSampleMatrix}
+import org.apache.spark.rdd.RDD
 
-object SplitMulti {
+import scala.reflect.ClassTag
 
-  def splitGT(gt: Int, i: Int): Int = {
-    val p = Genotype.gtPair(gt)
-    (if (p.j == i) 1 else 0) +
-      (if (p.k == i) 1 else 0)
+class ExprAnnotator(val ec: EvalContext, t: Type, expr: String, head: Option[String]) {
+  private val (paths, types, f) = Parser.parseAnnotationExprs(expr, ec, head)
+
+  private val inserters = new Array[Inserter](types.length)
+  val newT = {
+    var newT = t
+    var i = 0
+    while (i < types.length) {
+      val (newSig, ins) = newT.insert(types(i), paths(i))
+      inserters(i) = ins
+      newT = newSig
+      i += 1
+    }
+    newT
   }
 
-  def split(v: Variant,
-    va: Annotation,
-    it: Iterable[Genotype],
-    propagateGQ: Boolean,
-    keepStar: Boolean,
-    insertSplitAnnots: (Annotation, Int, Boolean) => Annotation,
-    f: (Variant) => Boolean): Iterator[(Variant, (Annotation, Iterable[Genotype]))] = {
-
-    if (v.isBiallelic) {
-      val minrep = v.minRep
-      if (f(minrep))
-        return Iterator((minrep, (insertSplitAnnots(va, 1, false), it)))
-      else
-        return Iterator()
+  def insert(a: Annotation): Annotation = {
+    var newA = a
+    var i = 0
+    var xs = f()
+    while (i < xs.length) {
+      newA = inserters(i)(newA, xs(i))
+      i += 1
     }
+    newA
+  }
+}
 
-    val splitVariants = v.altAlleles.iterator.zipWithIndex
+class SplitMultiPartitionContext(
+  keepStar: Boolean,
+  nSamples: Int, globalAnnotation: Annotation, rowType: TStruct,
+  vAnnotator: ExprAnnotator, gAnnotator: ExprAnnotator, newRowType: TStruct) {
+  var prevLocus: Locus = null
+  var rv: RegionValue = _
+  var ur = new UnsafeRow(rowType)
+  val splitRegion = MemoryBuffer()
+  val rvb = new RegionValueBuilder()
+  val splitrv = RegionValue()
+
+  def splitRow(sortAlleles: Boolean, removeLeftAligned: Boolean, removeMoving: Boolean, verifyLeftAligned: Boolean): Iterator[RegionValue] = {
+    require(!(removeMoving && verifyLeftAligned))
+
+    // FIXME check type, move to VSM
+    val v = ur.getAs[Variant](1)
+
+    var isLeftAligned = true
+    if (prevLocus != null && prevLocus == v.locus)
+      isLeftAligned = false
+    var splitVariants = v.altAlleles.iterator.zipWithIndex
       .filter(keepStar || !_._1.isStar)
-      .map { case (aa, aai) => (Variant(v.contig, v.start, v.ref, Array(aa)).minRep, aai + 1) }
-      .filter { case (sv, _) => f(sv) }
+      .map { case (aa, aai) =>
+        val splitv = Variant(v.contig, v.start, v.ref, Array(aa))
+        val minsplitv = splitv.minRep
+
+        if (splitv.locus != minsplitv.locus)
+          isLeftAligned = false
+
+        (minsplitv, aai + 1)
+      }
       .toArray
 
     if (splitVariants.isEmpty)
       return Iterator()
 
-    val splitGenotypeBuilders = splitVariants.map { case (sv, _) => new GenotypeBuilder(sv.nAlleles) }
-    val splitGenotypeStreamBuilders = splitVariants.map { case (sv, _) => new ArrayBuilder[Genotype]() }
-
-    for (g <- it) {
-      val gadsum = Genotype.ad(g).map(gadx => (gadx, gadx.sum))
-
-      // svj corresponds to the ith allele of v
-      for (((svj, i), j) <- splitVariants.iterator.zipWithIndex) {
-        val gb = splitGenotypeBuilders(j)
-        gb.clear()
-
-        if (g == null)
-          gb.setMissing()
-        else {
-          Genotype.gt(g).foreach { ggtx =>
-            val gtx = splitGT(ggtx, i)
-            gb.setGT(gtx)
-
-            val p = Genotype.gtPair(ggtx)
-            if (gtx != p.nNonRefAlleles)
-              gb.setFakeRef()
-          }
-
-          gadsum.foreach { case (gadx, sum) =>
-            // what bcftools does
-            // Array(gadx(0), gadx(i))
-            gb.setAD(Array(sum - gadx(i), gadx(i)))
-          }
-
-          Genotype.dp(g).foreach { dpx => gb.setDP(dpx) }
-
-          if (propagateGQ)
-            Genotype.gq(g).foreach { gqx => gb.setGQ(gqx) }
-
-          Genotype.pl(g).foreach { gplx =>
-            val plx = gplx.iterator.zipWithIndex
-              .map { case (p, k) => (splitGT(k, i), p) }
-              .reduceByKeyToArray(3, Int.MaxValue)(_ min _)
-            gb.setPX(plx)
-
-            if (!propagateGQ) {
-              val gq = Genotype.gqFromPL(plx)
-              gb.setGQ(gq)
-            }
-          }
-        }
-
-        splitGenotypeStreamBuilders(j) += gb.result()
-      }
+    if (isLeftAligned) {
+      if (removeLeftAligned)
+        return Iterator()
+    } else {
+      if (removeMoving)
+        return Iterator()
+      else if (verifyLeftAligned)
+        fatal("found non-left aligned variant: $v")
     }
 
-    splitVariants.iterator
-      .zip(splitGenotypeStreamBuilders.iterator)
-      .map { case ((v, ind), gsb) =>
-        (v, (insertSplitAnnots(va, ind, true), gsb.result()))
+    val va = ur.get(2)
+
+    if (v.isBiallelic) {
+      val (minrep, _) = splitVariants(0)
+      assert(v.minRep == minrep)
+
+      rvb.set(rv.region)
+      rvb.start(newRowType)
+      rvb.startStruct()
+      rvb.addAnnotation(newRowType.fieldType(0), minrep.locus) // pk
+      rvb.addAnnotation(newRowType.fieldType(1), minrep) // pk
+
+      vAnnotator.ec.setAll(globalAnnotation, v, va, 1, false)
+      rvb.addAnnotation(newRowType.fieldType(2), vAnnotator.insert(va))
+
+      rvb.addField(rowType, rv, 3) // gs
+      rvb.endStruct()
+      splitrv.set(rv.region, rvb.end())
+
+      return Iterator(splitrv)
+    }
+
+    if (sortAlleles)
+      splitVariants = splitVariants.sortBy { case (svj, i) => svj }
+
+    val nAlleles = v.nAlleles
+    val nGenotypes = v.nGenotypes
+
+    val gs = ur.getAs[IndexedSeq[Any]](3)
+
+    splitVariants.iterator.zipWithIndex
+      .map { case ((svj, i), j) =>
+        splitRegion.clear()
+        rvb.set(splitRegion)
+        rvb.start(newRowType)
+        rvb.startStruct()
+        rvb.addAnnotation(newRowType.fieldType(0), svj.locus)
+        rvb.addAnnotation(newRowType.fieldType(1), svj)
+
+        vAnnotator.ec.setAll(globalAnnotation, v, va, i, true)
+        rvb.addAnnotation(newRowType.fieldType(2), vAnnotator.insert(va))
+
+        rvb.startArray(nSamples) // gs
+        gAnnotator.ec.setAll(globalAnnotation, v, va, i, true)
+        var k = 0
+        while (k < nSamples) {
+          val g = gs(k)
+          gAnnotator.ec.set(5, g)
+          rvb.addAnnotation(newRowType.fieldType(3).asInstanceOf[TArray].elementType, gAnnotator.insert(g))
+          k += 1
+        }
+        rvb.endArray() // gs
+
+        rvb.endStruct()
+        splitrv.set(splitRegion, rvb.end())
+        splitrv
       }
   }
+}
 
-  def splitNumber(str: String): String =
-    if (str == "A" || str == "R" || str == "G")
-      "."
-    else str
+class SplitMulti[RPK, RK, T >: Null](vsm: VariantSampleMatrix[RPK, RK, T], variantExpr: String, genotypeExpr: String, keepStar: Boolean, leftAligned: Boolean)(implicit tct: ClassTag[T]) {
+  val vEC = EvalContext(Map(
+    "global" -> (0, vsm.globalSignature),
+    "v" -> (1, vsm.vSignature),
+    "va" -> (2, vsm.vaSignature),
+    "aIndex" -> (3, TInt32)))
+  val vAnnotator = new ExprAnnotator(vEC, vsm.vSignature, variantExpr, Some(Annotation.VARIANT_HEAD))
 
-  def apply(vds: VariantDataset, propagateGQ: Boolean = false, keepStar: Boolean = false,
-    maxShift: Int = 100): VariantDataset = {
+  val gEC = EvalContext(Map(
+    "global" -> (5, vsm.globalSignature),
+    "v" -> (0, vsm.vSignature),
+    "va" -> (1, vsm.vaSignature),
+    "s" -> (2, vsm.sSignature),
+    "sa" -> (3, vsm.saSignature),
+    "g" -> (4, vsm.genotypeSignature),
+    "aIndex" -> (6, TInt32)))
+  val gAnnotator = new ExprAnnotator(gEC, vsm.genotypeSignature, genotypeExpr, Some(Annotation.GENOTYPE_HEAD))
 
-    if (vds.wasSplit) {
-      warn("called redundant split on an already split VDS")
-      return vds
-    }
+  val newMatrixType = vsm.matrixType.copy(vaType = vAnnotator.newT, genotypeType = gAnnotator.newT)
 
-    val (vas2, insertIndex) = vds.vaSignature.insert(TInt32, "aIndex")
-    val (vas3, insertSplit) = vas2.insert(TBoolean, "wasSplit")
+  def split(sortAlleles: Boolean, removeLeftAligned: Boolean, removeMoving: Boolean, verifyLeftAligned: Boolean): RDD[RegionValue] = {
+    val localKeepStar = keepStar
+    val localGlobalAnnotation = vsm.globalAnnotation
+    val localNSamples = vsm.nSamples
+    val localRowType = vsm.rowType
 
-    val vas4 = vas3.getAsOption[TStruct]("info").map { s =>
-      val updatedInfoSignature = TStruct(s.fields.map { f =>
-        f.attrs.get("Number").map(splitNumber) match {
-          case Some(n) => f.copy(attrs = f.attrs + ("Number" -> n))
-          case None => f
-        }
-      })
-      val (newSignature, _) = vas3.insert(updatedInfoSignature, "info")
-      newSignature
-    }.getOrElse(vas3)
+    val newRowType = newMatrixType.rowType
 
-    val partitionerBc = vds.sparkContext.broadcast(vds.rdd.orderedPartitioner)
+    vsm.rdd2.mapPartitions { it =>
+      val context = new SplitMultiPartitionContext(
+        localKeepStar,
+        localNSamples, localGlobalAnnotation, localRowType,
+        vAnnotator, gAnnotator, newRowType)
 
-    val shuffledVariants = vds.rdd.mapPartitionsWithIndex { case (i, it) =>
-      it.flatMap { case (v, (va, gs)) =>
-        split(v, va, gs,
-          propagateGQ = propagateGQ,
-          keepStar = keepStar,
-          insertSplitAnnots = { (va, index, wasSplit) =>
-            insertSplit(insertIndex(va, index), wasSplit)
-          },
-          f = (v: Variant) => partitionerBc.value.getPartition(v) != i)
+      it.flatMap { rv =>
+        context.rv = rv
+        context.ur.set(rv)
+        val splitit = context.splitRow(sortAlleles, removeLeftAligned, removeMoving, verifyLeftAligned)
+        context.prevLocus = context.ur.getAs[Locus](0)
+        splitit
       }
-    }.orderedRepartitionBy(vds.rdd.orderedPartitioner)
-
-    val localMaxShift = maxShift
-    val staticVariants = vds.rdd.mapPartitionsWithIndex { case (i, it) =>
-      LocalVariantSortIterator(it.flatMap { case (v, (va, gs)) =>
-        split(v, va, gs,
-          propagateGQ = propagateGQ,
-          keepStar = keepStar,
-          insertSplitAnnots = { (va, index, wasSplit) =>
-            insertSplit(insertIndex(va, index), wasSplit)
-          },
-          f = (v: Variant) => partitionerBc.value.getPartition(v) == i)
-      }, localMaxShift)
     }
+  }
 
-    val newRDD = OrderedRDD.partitionedSortedUnion(staticVariants, shuffledVariants, vds.rdd.orderedPartitioner)
+  def split(): VariantSampleMatrix[RPK, RK, T] = {
+    val newRDD2: OrderedRDD2 =
+      if (leftAligned) {
+        OrderedRDD2(
+          newMatrixType.orderedRDD2Type,
+          vsm.rdd2.orderedPartitioner,
+          split(sortAlleles = true, removeLeftAligned = false, removeMoving = false, verifyLeftAligned = true))
+      } else {
+        val leftAlignedVariants = OrderedRDD2(
+          newMatrixType.orderedRDD2Type,
+          vsm.rdd2.orderedPartitioner,
+          split(sortAlleles = true, removeLeftAligned = false, removeMoving = true, verifyLeftAligned = false))
 
-    vds.copy(rdd = newRDD, vaSignature = vas4, wasSplit = true)
+        val movedVariants = OrderedRDD2.shuffle(
+          newMatrixType.orderedRDD2Type,
+          vsm.rdd2.orderedPartitioner,
+          split(sortAlleles = false, removeLeftAligned = true, removeMoving = false, verifyLeftAligned = false))
+
+        leftAlignedVariants.partitionSortedUnion(movedVariants)
+      }
+
+    vsm.copy2[RPK, RK, T](rdd2 = newRDD2, vaSignature = vAnnotator.newT, genotypeSignature = gAnnotator.newT, wasSplit = true)
   }
 }

--- a/src/main/scala/is/hail/variant/Genotype.scala
+++ b/src/main/scala/is/hail/variant/Genotype.scala
@@ -519,8 +519,8 @@ object Genotype {
         m2 = pl(i)
       i += 1
     }
-    assert(m == 0, s"$m, $m2, [${ pl.mkString(",") }]")
-    m2
+    assert(m <= m2)
+    m2 - m
   }
 
   def gtFromLinear(a: Array[Int]): Option[Int] = {

--- a/src/main/scala/is/hail/variant/Genotype.scala
+++ b/src/main/scala/is/hail/variant/Genotype.scala
@@ -66,8 +66,6 @@ abstract class Genotype extends Serializable {
 
   def _unboxedPX: Array[Int]
 
-  def _fakeRef: Boolean
-
   def check(nAlleles: Int) {
     val nGenotypes = triangle(nAlleles)
     assert(Genotype.gt(this).forall(i => i >= 0 && i < nGenotypes))
@@ -79,8 +77,7 @@ abstract class Genotype extends Serializable {
     ad: Option[Array[Int]] = Genotype.ad(this),
     dp: Option[Int] = Genotype.dp(this),
     gq: Option[Int] = Genotype.gq(this),
-    px: Option[Array[Int]] = Genotype.px(this),
-    fakeRef: Boolean = this._fakeRef): Genotype = Genotype(gt, ad, dp, gq, px, fakeRef)
+    px: Option[Array[Int]] = Genotype.px(this)): Genotype = Genotype(gt, ad, dp, gq, px)
 
   override def equals(that: Any): Boolean = that match {
     case g: Genotype =>
@@ -88,8 +85,7 @@ abstract class Genotype extends Serializable {
         util.Arrays.equals(_unboxedAD, g._unboxedAD) &&
         _unboxedDP == g._unboxedDP &&
         _unboxedGQ == g._unboxedGQ &&
-        util.Arrays.equals(_unboxedPX, g._unboxedPX) &&
-        _fakeRef == g._fakeRef
+        util.Arrays.equals(_unboxedPX, g._unboxedPX)
 
     case _ => false
   }
@@ -101,7 +97,6 @@ abstract class Genotype extends Serializable {
       .append(_unboxedDP)
       .append(_unboxedGQ)
       .append(util.Arrays.hashCode(_unboxedPX))
-      .append(_fakeRef)
       .toHashCode
 
   override def toString: String = {
@@ -111,10 +106,6 @@ abstract class Genotype extends Serializable {
       val p = Genotype.gtPair(gt)
       s"${ p.j }/${ p.k }"
     }.getOrElse("./."))
-
-    if (_fakeRef) {
-      b += '*'
-    }
 
     b += ':'
     b.append(Genotype.ad(this).map(_.mkString(",")).getOrElse("."))
@@ -234,8 +225,7 @@ object Genotype {
           null
         else {
           val r = a.asInstanceOf[Row]
-          val g = new GenericGenotype(gtq(r), adq(r), dpq(r), gqq(r), plq(r),
-            _fakeRef = false)
+          val g = new GenericGenotype(gtq(r), adq(r), dpq(r), gqq(r), plq(r))
           g
         }
     }
@@ -374,8 +364,6 @@ object Genotype {
     else
       None
 
-  def fakeRef(g: Genotype): Option[Boolean] = if (g == null) None else Some(g._fakeRef)
-
   def fractionReadsRef(g: Genotype): Option[Double] = {
     val uad = unboxedAD(g)
     if (uad != null) {
@@ -452,7 +440,7 @@ object Genotype {
     else
       None
 
-  def apply(gtx: Int): Genotype = new GenericGenotype(gtx, null, -1, -1, null, false)
+  def apply(gtx: Int): Genotype = new GenericGenotype(gtx, null, -1, -1, null)
 
   def toRow(g: Genotype): Row =
     if (g == null)
@@ -466,8 +454,7 @@ object Genotype {
         unboxedAD(g): IndexedSeq[Int],
         if (dp == -1) null else dp,
         if (gq == -1) null else gq,
-        unboxedPX(g): IndexedSeq[Int],
-        g._fakeRef)
+        unboxedPX(g): IndexedSeq[Int])
     }
 
   def toJSON(g: Genotype): JValue =
@@ -479,8 +466,7 @@ object Genotype {
         ("ad", Genotype.ad(g).map(ads => JArray(ads.map(JInt(_)).toList)).getOrElse(JNull)),
         ("dp", Genotype.dp(g).map(JInt(_)).getOrElse(JNull)),
         ("gq", Genotype.gq(g).map(JInt(_)).getOrElse(JNull)),
-        ("px", Genotype.px(g).map(pxs => JArray(pxs.map(JInt(_)).toList)).getOrElse(JNull)),
-        ("fakeRef", JBool(g._fakeRef)))
+        ("px", Genotype.px(g).map(pxs => JArray(pxs.map(JInt(_)).toList)).getOrElse(JNull)))
 
   def apply(call: Call): Genotype = {
     val gtx: Int = if (call == null) -1 else call
@@ -492,21 +478,17 @@ object Genotype {
     val dpx: Int = if (dp == null) -1 else dp
     val gqx: Int = if (gq == null) -1 else gq
 
-    val g = new GenericGenotype(gtx, ad, dpx, gqx, pl, _fakeRef = false)
+    val g = new GenericGenotype(gtx, ad, dpx, gqx, pl)
     g.check(nAlleles)
     g
   }
-
-  def apply(unboxedGT: Int, fakeRef: Boolean): Genotype =
-    new GenericGenotype(unboxedGT, null, -1, -1, null, fakeRef)
 
   def apply(gt: Option[Int] = None,
     ad: Option[Array[Int]] = None,
     dp: Option[Int] = None,
     gq: Option[Int] = None,
-    px: Option[Array[Int]] = None,
-    fakeRef: Boolean = false): Genotype = {
-    new GenericGenotype(gt.getOrElse(-1), ad.map(_.toArray).orNull, dp.getOrElse(-1), gq.getOrElse(-1), px.map(_.toArray).orNull, fakeRef)
+    px: Option[Array[Int]] = None): Genotype = {
+    new GenericGenotype(gt.getOrElse(-1), ad.map(_.toArray).orNull, dp.getOrElse(-1), gq.getOrElse(-1), px.map(_.toArray).orNull)
   }
 
   def sparkSchema: DataType = StructType(Array(
@@ -514,8 +496,7 @@ object Genotype {
     StructField("ad", ArrayType(IntegerType, containsNull = false)),
     StructField("dp", IntegerType),
     StructField("gq", IntegerType),
-    StructField("px", ArrayType(IntegerType, containsNull = false)),
-    StructField("fakeRef", BooleanType, nullable = false)))
+    StructField("px", ArrayType(IntegerType, containsNull = false))))
 
   def fromRow(r: Row): Genotype = {
     new GenericGenotype(
@@ -523,8 +504,7 @@ object Genotype {
       if (r.isNullAt(1)) null else r.getAs[IndexedSeq[Int]](1).toArray,
       if (r.isNullAt(2)) -1 else r.getInt(2),
       if (r.isNullAt(3)) -1 else r.getInt(3),
-      if (r.isNullAt(4)) null else r.getAs[IndexedSeq[Int]](4).toArray,
-      r.getBoolean(5))
+      if (r.isNullAt(4)) null else r.getAs[IndexedSeq[Int]](4).toArray)
   }
 
   def gqFromPL(pl: Array[Int]): Int = {
@@ -853,98 +833,7 @@ class GenericGenotype(val _unboxedGT: Int,
   val _unboxedAD: Array[Int],
   val _unboxedDP: Int,
   val _unboxedGQ: Int,
-  val _unboxedPX: Array[Int],
-  val _fakeRef: Boolean) extends Genotype {
+  val _unboxedPX: Array[Int]) extends Genotype {
   require(_unboxedGT >= -1, s"invalid _unboxedGT value: ${ _unboxedGT }")
   require(_unboxedDP >= -1, s"invalid _unboxedDP value: ${ _unboxedDP }")
-}
-
-class GenotypeBuilder(nAlleles: Int) {
-  require(nAlleles > 0, s"tried to create genotype builder with $nAlleles ${ plural(nAlleles, "allele") }")
-  val isBiallelic = nAlleles == 2
-  val nGenotypes = triangle(nAlleles)
-
-  private var gt: Int = -1
-  private var ad: Array[Int] = _
-  private var dp: Int = -1
-  private var gq: Int = -1
-  private var px: Array[Int] = _
-  private var fakeRef: Boolean = false
-  private var missing: Boolean = false
-
-  def clear() {
-    gt = -1
-    dp = -1
-    gq = -1
-    ad = null
-    px = null
-    fakeRef = false
-    missing = false
-  }
-
-  def hasGT: Boolean = gt >= 0
-
-  def setGT(newGT: Int) {
-    if (newGT < 0)
-      fatal(s"invalid GT value `$newGT': negative value")
-    if (newGT > nGenotypes)
-      fatal(s"invalid GT value `$newGT': value larger than maximum number of genotypes $nGenotypes")
-    if (hasGT)
-      fatal(s"invalid GT, genotype already had GT")
-    gt = newGT
-  }
-
-  def setAD(newAD: Array[Int]) {
-    if (newAD.length != nAlleles)
-      fatal(s"invalid AD field `${ newAD.mkString(",") }': expected $nAlleles values, but got ${ newAD.length }.")
-    ad = newAD
-  }
-
-  def setDP(newDP: Int) {
-    if (newDP < 0)
-      fatal(s"invalid DP field `$newDP': negative value")
-    dp = newDP
-  }
-
-  def setGQ(newGQ: Int) {
-    if (newGQ < 0)
-      fatal(s"invalid GQ field `$newGQ': negative value")
-    gq = newGQ
-  }
-
-  def setPX(newPX: Array[Int]) {
-    if (newPX.length != nGenotypes)
-      fatal(s"invalid PL field `${ newPX.mkString(",") }': expected $nGenotypes values, but got ${ newPX.length }.")
-    px = newPX
-  }
-
-  def setFakeRef() {
-    fakeRef = true
-  }
-
-  def setMissing() {
-    missing = true
-  }
-
-  def set(g: Genotype) {
-    if (g == null) {
-      setMissing()
-    } else {
-      Genotype.gt(g).foreach(setGT)
-      Genotype.ad(g).foreach(setAD)
-      Genotype.dp(g).foreach(setDP)
-      Genotype.gq(g).foreach(setGQ)
-      Genotype.px(g).foreach(setPX)
-
-      if (g._fakeRef)
-        setFakeRef()
-    }
-  }
-
-  def result(): Genotype = {
-    if (missing)
-      null
-    else
-      new GenericGenotype(gt, ad, dp, gq, px, fakeRef)
-  }
 }

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -19,7 +19,7 @@ object VariantDataset {
     kt.keyFields.map(_.typ) match {
       case Array(TVariant(_)) =>
       case arr => fatal("Require one key column of type Variant to produce a variant dataset, " +
-        s"but found [ ${ arr.mkString(", ") } ]")
+        s"but found [ ${arr.mkString(", ")} ]")
     }
 
     val rdd = kt.keyedRDD()
@@ -127,7 +127,7 @@ class VariantDatasetFunctions(private val vds: VariantDataset) extends AnyVal {
     }
 
 
-    def formatGP(d: Double): String = d.formatted(s"%.${ precision }f")
+    def formatGP(d: Double): String = d.formatted(s"%.${precision}f")
 
     val emptyGP = Array(0d, 0d, 0d)
 
@@ -248,7 +248,7 @@ class VariantDatasetFunctions(private val vds: VariantDataset) extends AnyVal {
     val badSampleIds = vds.stringSampleIds.filter(id => spaceRegex.findFirstIn(id).isDefined)
     if (badSampleIds.nonEmpty) {
       fatal(
-        s"""Found ${ badSampleIds.length } sample IDs with whitespace
+        s"""Found ${badSampleIds.length} sample IDs with whitespace
            |  Please run `renamesamples' to fix this problem before exporting to plink format
            |  Bad sample IDs: @1 """.stripMargin, badSampleIds)
     }
@@ -286,16 +286,16 @@ class VariantDatasetFunctions(private val vds: VariantDataset) extends AnyVal {
 
   /**
     *
-    * @param filterExpr Filter expression involving v (variant), va (variant annotations), and aIndex (allele index)
-    * @param annotationExpr Annotation modifying expression involving v (new variant), va (old variant annotations),
-    * and aIndices (maps from new to old indices)
+    * @param filterExpr             Filter expression involving v (variant), va (variant annotations), and aIndex (allele index)
+    * @param annotationExpr         Annotation modifying expression involving v (new variant), va (old variant annotations),
+    *                               and aIndices (maps from new to old indices)
     * @param filterAlteredGenotypes any call that contains a filtered allele is set to missing instead
-    * @param keep Keep variants matching condition
-    * @param subset subsets the PL and AD. Genotype and GQ are set based on the resulting PLs.  Downcodes by default.
-    * @param maxShift Maximum possible position change during minimum representation calculation
+    * @param keep                   Keep variants matching condition
+    * @param subset                 subsets the PL and AD. Genotype and GQ are set based on the resulting PLs.  Downcodes by default.
+    * @param maxShift               Maximum possible position change during minimum representation calculation
     */
   def filterAlleles(filterExpr: String, annotationExpr: String = "va = va", filterAlteredGenotypes: Boolean = false,
-    keep: Boolean = true, subset: Boolean = true, maxShift: Int = 100, keepStar: Boolean = false): VariantDataset = {
+                    keep: Boolean = true, subset: Boolean = true, maxShift: Int = 100, keepStar: Boolean = false): VariantDataset = {
     FilterAlleles(vds, filterExpr, annotationExpr, filterAlteredGenotypes, keep, subset, maxShift, keepStar)
   }
 
@@ -317,28 +317,28 @@ class VariantDatasetFunctions(private val vds: VariantDataset) extends AnyVal {
   /**
     *
     * @param computeMafExpr An expression for the minor allele frequency of the current variant, `v', given
-    * the variant annotations `va'. If unspecified, MAF will be estimated from the dataset
-    * @param bounded Allows the estimations for Z0, Z1, Z2, and PI_HAT to take on biologically-nonsense values
-    * (e.g. outside of [0,1]).
-    * @param minimum Sample pairs with a PI_HAT below this value will not be included in the output. Must be in [0,1]
-    * @param maximum Sample pairs with a PI_HAT above this value will not be included in the output. Must be in [0,1]
+    *                       the variant annotations `va'. If unspecified, MAF will be estimated from the dataset
+    * @param bounded        Allows the estimations for Z0, Z1, Z2, and PI_HAT to take on biologically-nonsense values
+    *                       (e.g. outside of [0,1]).
+    * @param minimum        Sample pairs with a PI_HAT below this value will not be included in the output. Must be in [0,1]
+    * @param maximum        Sample pairs with a PI_HAT above this value will not be included in the output. Must be in [0,1]
     */
   def ibd(computeMafExpr: Option[String] = None, bounded: Boolean = true,
-    minimum: Option[Double] = None, maximum: Option[Double] = None): KeyTable = {
+          minimum: Option[Double] = None, maximum: Option[Double] = None): KeyTable = {
     require(vds.wasSplit)
     IBD.toKeyTable(vds.hc, IBD.validateAndCall(vds, computeMafExpr, bounded, minimum, maximum))
   }
 
   /**
     *
-    * @param mafThreshold Minimum minor allele frequency threshold
-    * @param includePAR Include pseudoautosomal regions
+    * @param mafThreshold     Minimum minor allele frequency threshold
+    * @param includePAR       Include pseudoautosomal regions
     * @param fFemaleThreshold Samples are called females if F < femaleThreshold
-    * @param fMaleThreshold Samples are called males if F > maleThreshold
-    * @param popFreqExpr Use an annotation expression for estimate of MAF rather than computing from the data
+    * @param fMaleThreshold   Samples are called males if F > maleThreshold
+    * @param popFreqExpr      Use an annotation expression for estimate of MAF rather than computing from the data
     */
   def imputeSex(mafThreshold: Double = 0.0, includePAR: Boolean = false, fFemaleThreshold: Double = 0.2,
-    fMaleThreshold: Double = 0.8, popFreqExpr: Option[String] = None): VariantDataset = {
+                fMaleThreshold: Double = 0.8, popFreqExpr: Option[String] = None): VariantDataset = {
     require(vds.wasSplit)
 
     val result = ImputeSexPlink(vds,
@@ -374,14 +374,14 @@ class VariantDatasetFunctions(private val vds: VariantDataset) extends AnyVal {
 
   /**
     *
-    * @param scoresRoot Sample annotation path for scores (period-delimited path starting in 'sa')
-    * @param k Number of principal components
+    * @param scoresRoot   Sample annotation path for scores (period-delimited path starting in 'sa')
+    * @param k            Number of principal components
     * @param loadingsRoot Variant annotation path for site loadings (period-delimited path starting in 'va')
-    * @param eigenRoot Global annotation path for eigenvalues (period-delimited path starting in 'global'
-    * @param asArrays Store score and loading results as arrays, rather than structs
+    * @param eigenRoot    Global annotation path for eigenvalues (period-delimited path starting in 'global'
+    * @param asArrays     Store score and loading results as arrays, rather than structs
     */
   def pca(scoresRoot: String, k: Int = 10, loadingsRoot: Option[String] = None, eigenRoot: Option[String] = None,
-    asArrays: Boolean = false): VariantDataset = {
+          asArrays: Boolean = false): VariantDataset = {
     require(vds.wasSplit)
 
     if (k < 1)
@@ -436,15 +436,6 @@ class VariantDatasetFunctions(private val vds: VariantDataset) extends AnyVal {
     KinshipMatrix(vds.hc, vds.sSignature, rrm, vds.sampleIds.toArray, m)
   }
 
-  def splitMulti(keepStar: Boolean = false, leftAligned: Boolean = false): VariantDataset = {
-    ???
-  }
-
-  def splitMulti(variantExpr: String, genotypeExpr: String, keepStar: Boolean = false, leftAligned: Boolean = false): VariantDataset = {
-    val splitmulti = new SplitMulti(vds, variantExpr, genotypeExpr, keepStar, leftAligned)
-    splitmulti.split()
-  }
-
   def tdt(ped: Pedigree, tdtRoot: String = "va.tdt"): VariantDataset = {
     require(vds.wasSplit)
     vds.requireSampleTString("TDT")
@@ -458,12 +449,12 @@ class VariantDatasetFunctions(private val vds: VariantDataset) extends AnyVal {
   }
 
   def deNovo(ped: Pedigree,
-    referenceAF: String,
-    minGQ: Int = 20,
-    minPDeNovo: Double = 0.05,
-    maxParentAB: Double = 0.05,
-    minChildAB: Double = 0.20,
-    minDepthRatio: Double = 0.10): KeyTable = {
+             referenceAF: String,
+             minGQ: Int = 20,
+             minPDeNovo: Double = 0.05,
+             maxParentAB: Double = 0.05,
+             minChildAB: Double = 0.20,
+             minDepthRatio: Double = 0.10): KeyTable = {
     require(vds.wasSplit)
     vds.requireSampleTString("de novo")
 

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -78,6 +78,10 @@ class VariantDatasetFunctions(private val vds: VariantDataset) extends AnyVal {
 
     vds.mapAnnotations(finalType, { case (v, va, gs) =>
 
+      // FIXME
+      val annotations: Array[Array[Any]] = ???
+
+      /*
       val annotations = SplitMulti.split(v, va, gs,
         propagateGQ = propagateGQ,
         keepStar = true,
@@ -90,7 +94,7 @@ class VariantDatasetFunctions(private val vds: VariantDataset) extends AnyVal {
             ec.setAll(localGlobalAnnotation, v, va)
             aggregateOption.foreach(f => f(v, va, gs))
             f()
-        }).toArray
+        }).toArray */
 
       inserters.zipWithIndex.foldLeft(va) {
         case (va, (inserter, i)) =>
@@ -432,16 +436,13 @@ class VariantDatasetFunctions(private val vds: VariantDataset) extends AnyVal {
     KinshipMatrix(vds.hc, vds.sSignature, rrm, vds.sampleIds.toArray, m)
   }
 
+  def splitMulti(keepStar: Boolean = false, leftAligned: Boolean = false): VariantDataset = {
+    ???
+  }
 
-  /**
-    *
-    * @param propagateGQ Propagate GQ instead of computing from PL
-    * @param keepStar Do not filter * alleles
-    * @param maxShift Maximum possible position change during minimum representation calculation
-    */
-  def splitMulti(propagateGQ: Boolean = false, keepStar: Boolean = false,
-    maxShift: Int = 100): VariantDataset = {
-    SplitMulti(vds, propagateGQ, keepStar, maxShift)
+  def splitMulti(variantExpr: String, genotypeExpr: String, keepStar: Boolean = false, leftAligned: Boolean = false): VariantDataset = {
+    val splitmulti = new SplitMulti(vds, variantExpr, genotypeExpr, keepStar, leftAligned)
+    splitmulti.split()
   }
 
   def tdt(ped: Pedigree, tdtRoot: String = "va.tdt"): VariantDataset = {

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -724,7 +724,7 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
     val aggregateOption = Aggregators.buildVariantAggregations(this, ec)
 
     val localRowType = rowType
-    insertIntoRow[UnsafeRow](() => new UnsafeRow(localRowType))(
+    insertIntoRow(() => new UnsafeRow(localRowType))(
       newVASignature, List("va"), { (ur, rv, rvb) =>
         ur.set(rv)
         

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -576,7 +576,7 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
     }
     val inserters = inserterBuilder.result()
 
-    val sampleAggregationOption = Aggregators.buildSampleAggregations[RPK, RK, T](hc, value, ec)
+    val sampleAggregationOption = Aggregators.buildSampleAggregations(hc, value, ec)
 
     ec.set(0, globalAnnotation)
     val newAnnotations = sampleIdsAndAnnotations.map { case (s, sa) =>
@@ -734,7 +734,7 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
 
         ec.setAll(localGlobalAnnotation, v, va)
 
-        aggregateOption.foreach(f => f(v, va, gs))
+        aggregateOption.foreach(f => f(rv))
 
         var newVA = va
         var i = 0

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -2061,6 +2061,9 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
     new VariantSampleMatrix[RPK, RK, Genotype](hc, metadata, ast)
   }
 
+  def makeGenotypeGeneric(): VariantSampleMatrix[RPK, RK, Annotation] =
+    new VariantSampleMatrix[RPK, RK, Annotation](hc, metadata, ast)
+
   def toVKDS: VariantSampleMatrix[Locus, Variant, T] = makeVariantConcrete()
 
   def toVDS: VariantDataset = makeVariantConcrete().makeGenotypeConcrete()

--- a/src/test/scala/is/hail/io/HardCallsSuite.scala
+++ b/src/test/scala/is/hail/io/HardCallsSuite.scala
@@ -8,9 +8,9 @@ import is.hail.variant.{VSMSubgen, VariantSampleMatrix, _}
 import org.testng.annotations.Test
 
 class HardCallsSuite extends SparkSuite {
-  def gtTriples(vds: VariantDataset): Set[(Variant, Annotation, (Option[Int], Option[Boolean]))] =
+  def gtTriples(vds: VariantDataset): Set[(Variant, Annotation, Option[Int])] =
     vds.expand()
-      .map { case (v, va, g) => (v, va, (Genotype.gt(g), Genotype.fakeRef(g))) }
+      .map { case (v, va, g) => (v, va, Genotype.gt(g)) }
       .collect()
       .toSet
 

--- a/src/test/scala/is/hail/io/SplitSuite.scala
+++ b/src/test/scala/is/hail/io/SplitSuite.scala
@@ -11,16 +11,6 @@ import org.testng.annotations.Test
 class SplitSuite extends SparkSuite {
 
   object Spec extends Properties("MultiSplit") {
-    property("fakeRef implies wasSplit") =
-      forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random).map(_.splitMulti())) { (vds: VariantDataset) =>
-        val wasSplitQuerier = vds.vaSignature.query("wasSplit")
-        vds.mapWithAll { (v: Variant, va: Annotation, _: Annotation, _: Annotation, g: Genotype) =>
-          g == null || wasSplitQuerier(va).asInstanceOf[Boolean] || !Genotype.fakeRef(g).get
-        }
-          .collect()
-          .forall(identity)
-      }
-
     val splittableVariantGen = for {
       contig <- Gen.const("1")
       start <- Gen.choose(1, 100)
@@ -39,7 +29,6 @@ class SplitSuite extends SparkSuite {
           }
       }.collect().toSet
 
-      println(method1, method2)
       method1 == method2
     }
   }
@@ -53,7 +42,7 @@ class SplitSuite extends SparkSuite {
     val vds2 = hc.importVCF("src/test/resources/split_test_b.vcf")
 
     // test splitting and downcoding
-    vds1.mapWithKeys((v, s, g) => ((v, s), g.copy(fakeRef = false)))
+    vds1.mapWithKeys((v, s, g) => ((v, s), g))
       .join(vds2.mapWithKeys((v, s, g) => ((v, s), g)))
       .foreach { case (k, (g1, g2)) =>
         if (g1 != g2)
@@ -68,13 +57,5 @@ class SplitSuite extends SparkSuite {
       .foreach { case (i, b) =>
         simpleAssert(b == (i != 1180))
       }
-
-    // test for fakeRef
-    assert(vds1.mapWithKeys((v, s, g) => ((v.start, v.alt, s), g._fakeRef)).filter(_._2).map(_._1.toString).collect.toSet
-      == Set("(2167,AAAAC,HG00097)", "(2167,A,HG00100)", "(2167,AAAACAAAC,HG00103)", "(1183,C,HG00100)", "(2167,A,HG00103)", "(2167,AAAAC,HG00099)",
-      "(2167,AAAAC,HG00104)", "(2167,AAAACAAAC,HG00104)", "(1783,TA,HG00100)", "(2167,A,HG00101)", "(2167,A,HG00099)", "(1183,C,HG00103)",
-      "(2167,AAAAC,HG00103)", "(1183,C,HG00104)", "(1783,TA,HG00101)", "(2167,AAAACAAAC,HG00101)", "(2167,AAAAC,HG00101)", "(1783,T,HG00099)",
-      "(2167,A,HG00097)", "(2167,AAAAC,HG00102)", "(2167,AAAACAAAC,HG00100)", "(1783,T,HG00101)", "(1783,TA,HG00102)", "(1783,T,HG00097)",
-      "(2167,AAAACAAAC,HG00102)"))
   }
 }

--- a/src/test/scala/is/hail/methods/DeNovoSuite.scala
+++ b/src/test/scala/is/hail/methods/DeNovoSuite.scala
@@ -71,7 +71,7 @@ class DeNovoSuite extends SparkSuite {
               Array(gq, 0, gq)
             else
               Array(gq * 3, gq, 0))
-          } yield if (isMissing) Genotype() else new GenericGenotype(gt, ad, dp, math.min(gq, 99), pls, false)
+          } yield if (isMissing) Genotype() else new GenericGenotype(gt, ad, dp, math.min(gq, 99), pls)
         }
       )).filter(vds => vds.countVariants() > 0 && vds.nSamples > 0)
       ped <- Pedigree.gen(vds.stringSampleIds)

--- a/src/test/scala/is/hail/variant/GenotypeSuite.scala
+++ b/src/test/scala/is/hail/variant/GenotypeSuite.scala
@@ -9,21 +9,7 @@ import org.testng.annotations.Test
 import scala.collection.mutable
 
 object GenotypeSuite {
-  def readWriteEqual(nAlleles: Int, g: Genotype): Boolean = {
-    
-    val gb = new GenotypeBuilder(nAlleles)
-
-    gb.set(g)
-    val g2 = gb.result()
-
-    g == g2
-  }
-
   object Spec extends Properties("Genotype") {
-
-    property("readWrite") = forAll[(Variant, Genotype)](Genotype.genVariantGenotype) { case (v, g) =>
-      readWriteEqual(v.nAlleles, g)
-    }
 
     property("gt") = forAll { g: Genotype =>
       Genotype.gt(g).isDefined == Genotype.isCalled(g)
@@ -51,10 +37,6 @@ class GenotypeSuite extends TestNGSuite {
 
   val v = Variant("1", 1, "A", "T")
 
-  def testReadWrite(g: Genotype) {
-    assert(readWriteEqual(v.nAlleles, g))
-  }
-
   @Test def testGenotype() {
     intercept[IllegalArgumentException] {
       Genotype(Some(-2), Some(Array(2, 0)), Some(2), None)
@@ -74,11 +56,6 @@ class GenotypeSuite extends TestNGSuite {
     assert(Genotype.gt(homRef).isDefined)
     assert(Genotype.gt(het).isDefined)
     assert(Genotype.gt(homVar).isDefined)
-
-    testReadWrite(noCall)
-    testReadWrite(homRef)
-    testReadWrite(het)
-    testReadWrite(homVar)
 
     assert(Genotype.pAB(Genotype(None, None, None, None)).isEmpty)
     assert(Genotype.pAB(Genotype(None, Some(Array(0, 0)), Some(0), None, None)).isEmpty)


### PR DESCRIPTION
Generic: computation of split values is done in expression language.
Support HTS-like split of generic schema.
Removed fakeRef, which I don't think anyone ever used.  If anyone wants it, can be added through expression language once that is exposed.

@tpoterba FYI I removed fakeRef.
