### PR TITLE
use nonExtremeDouble to avoid test failures

### DIFF
--- a/src/main/scala/is/hail/check/Gen.scala
+++ b/src/main/scala/is/hail/check/Gen.scala
@@ -28,6 +28,11 @@ case class Parameters(rng: RandomDataGenerator, size: Int, count: Int) {
 
 object Gen {
 
+  val nonExtremeDouble: Gen[Double] = oneOfGen(
+    oneOf(1e30, -1.0, -1e-30, 0.0, 1e-30, 1.0, 1e30),
+    choose(-100.0, 100.0),
+    choose(-1e150, 1e150))
+
   def squareOfAreaAtMostSize: Gen[(Int, Int)] =
     nCubeOfVolumeAtMostSize(2).map(x => (x(0), x(1)))
 

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -232,8 +232,7 @@ class BlockMatrixSuite extends SparkSuite {
   @Test
   def rowwiseMultiplicationRandom() {
     val g = for {
-      blockSize <- Gen.interestingPosInt
-      l <- blockMatrixPreGen(blockSize)
+      l <- blockMatrixGen()
       v <- Gen.buildableOfN[Array, Double](l.cols.toInt, arbitrary[Double])
     } yield (l, v)
 
@@ -269,8 +268,7 @@ class BlockMatrixSuite extends SparkSuite {
   @Test
   def colwiseMultiplicationRandom() {
     val g = for {
-      blockSize <- Gen.interestingPosInt
-      l <- blockMatrixPreGen(blockSize)
+      l <- blockMatrixGen()
       v <- Gen.buildableOfN[Array, Double](l.rows.toInt, arbitrary[Double])
     } yield (l, v)
 
@@ -417,7 +415,7 @@ class BlockMatrixSuite extends SparkSuite {
 
   @Test
   def doubleTransposeIsIdentity() {
-    forAll(blockMatrixGen(Gen.nonExtremeDouble)) { (m: BlockMatrix) =>
+    forAll(blockMatrixGen(element = Gen.nonExtremeDouble)) { (m: BlockMatrix) =>
       val mt = m.t.cache()
       val mtt = m.t.t.cache()
       assert(mtt.rows == m.rows)

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -41,6 +41,7 @@ class BlockMatrixSuite extends SparkSuite {
   private val defaultDims = nonEmptySquareOfAreaAtMostSize
   private val defaultTransposed = coin()
   private val defaultElement = arbitrary[Double]
+
   def blockMatrixGen(
     blockSize: Gen[Int] = defaultBlockSize,
     dims: Gen[(Int, Int)] = defaultDims,
@@ -68,9 +69,9 @@ class BlockMatrixSuite extends SparkSuite {
     element = element
   )
 
-  def twoMultipliableBlockMatrices(element: Gen[Double] = arbitrary[Double]): Gen[(BlockMatrix, BlockMatrix)] = for {
+  def twoMultipliableBlockMatrices(element: Gen[Double] = defaultElement): Gen[(BlockMatrix, BlockMatrix)] = for {
     Array(rows, inner, cols) <- nonEmptyNCubeOfVolumeAtMostSize(3)
-    blockSize <- interestingPosInt.map(math.pow(_, 1.0/3.0).toInt)
+    blockSize <- interestingPosInt.map(math.pow(_, 1.0 / 3.0).toInt)
     transposed <- coin()
     l <- blockMatrixGen(const(blockSize), const(rows -> inner), const(transposed), element)
     r <- blockMatrixGen(const(blockSize), const(inner -> cols), const(transposed), element)

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -42,7 +42,7 @@ class BlockMatrixSuite extends SparkSuite {
   private val defaultElement = arbitrary[Double]
   def blockMatrixGen(
     blockSize: Gen[Int] = defaultBlockSize,
-    dims: Gen[(Int,Int)] = defaultDims,
+    dims: Gen[(Int, Int)] = defaultDims,
     transposed: Gen[Boolean] = defaultTransposed,
     element: Gen[Double] = defaultElement
   ): Gen[BlockMatrix] = for {
@@ -68,19 +68,11 @@ class BlockMatrixSuite extends SparkSuite {
   )
 
   def twoMultipliableBlockMatrices(element: Gen[Double] = arbitrary[Double]): Gen[(BlockMatrix, BlockMatrix)] = for {
-    Array(rows, inner, columns) <- Gen.nonEmptyNCubeOfVolumeAtMostSize(3)
+    Array(rows, inner, cols) <- Gen.nonEmptyNCubeOfVolumeAtMostSize(3)
     blockSize = Gen.interestingPosInt.map(math.pow(_, 1.0/3.0).toInt)
     transposed <- Gen.coin()
-    l <- blockMatrixGen(
-      blockSize = blockSize,
-      dims = Gen.const(rows -> inner),
-      transposed = Gen.const(transposed),
-      element = element)
-    r <- blockMatrixGen(
-      blockSize = blockSize,
-      dims = Gen.const(inner -> columns),
-      transposed = Gen.const(transposed),
-      element = element)
+    l <- blockMatrixGen(blockSize, Gen.const(rows -> inner), Gen.const(transposed), element)
+    r <- blockMatrixGen(blockSize, Gen.const(inner -> cols), Gen.const(transposed), element)
   } yield if (transposed) (r, l) else (l, r)
 
   implicit val arbitraryBlockMatrix =


### PR DESCRIPTION
The native libraries sometimes play tricks to squeeze out better
precision if the memory layout is amenable to it. This causes some
of our tests to fail, particularly those related to transposition.
We avoid extreme values which should keep us from encountering
situations where naive arithmetic produces Infinity.