### PR TITLE
Abstracted partitioned read/write and used in BlockMatrix

### DIFF
--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -16,7 +16,6 @@ import is.hail.variant.{GenericDataset, GenomeReference, Genotype, Locus, VSMFil
 import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop
 import org.apache.log4j.{ConsoleAppender, LogManager, PatternLayout, PropertyConfigurator}
-import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SQLContext
 import org.apache.spark._
@@ -408,7 +407,6 @@ class HailContext private(val sc: SparkContext,
     val d = digitsNeeded(nPartitions)
 
     new RDD[T](sc, Nil) {
-      
       def getPartitions: Array[Partition] = Array.tabulate(nPartitions)(i => ReadRDDPartition(i))
       
       override def compute(split: Partition, context: TaskContext): Iterator[T] = {

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -417,7 +417,7 @@ class HailContext private(val sc: SparkContext,
         
         val filename = path + "/parts/part-" + pis
         
-        sHadoopConfBc.value.value.readPartition(filename)(makeStream, read(i))
+        sHadoopConfBc.value.value.unsafeReadPartition(filename)(makeStream, read(i))
       }
       
       @transient override val partitioner: Option[Partitioner] = _partitioner

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -1,5 +1,6 @@
 package is.hail
 
+import java.io.InputStream
 import java.util.Properties
 
 import is.hail.annotations.Annotation
@@ -15,6 +16,7 @@ import is.hail.variant.{GenericDataset, GenomeReference, Genotype, Locus, VSMFil
 import org.apache.hadoop
 import org.apache.log4j.{ConsoleAppender, LogManager, PatternLayout, PropertyConfigurator}
 import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.{ProgressBarBuilder, SparkConf, SparkContext}
 
@@ -366,6 +368,13 @@ class HailContext private(val sc: SparkContext,
   def readTable(path: String): KeyTable =
     KeyTable.read(this, path)
 
+  def readPartitions[T, S](
+    makeStream: (InputStream) => S,
+    read: (S, Int) => Iterator[T]): RDD[T] = {
+    
+    
+  }
+  
   def importVCF(file: String, force: Boolean = false,
     forceBGZ: Boolean = false,
     headerFile: Option[String] = None,

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -168,7 +168,7 @@ object HailContext {
     hc
   }
   
-  def readRow(t: TStruct)(in: InputStream, i: Int): Iterator[RegionValue] = {
+  def readRow(t: TStruct)(i: Int)(in: InputStream): Iterator[RegionValue] = {
     
     new Iterator[RegionValue] {
       val region = MemoryBuffer()
@@ -400,7 +400,7 @@ class HailContext private(val sc: SparkContext,
     path: String,
     nPartitions: Int,
     makeStream: (InputStream) => S,
-    read: (S, Int) => Iterator[T],
+    read: Int => S => Iterator[T],
     _partitioner: Option[Partitioner] = None): RDD[T] = {
     
     val sHadoopConfBc = sc.broadcast(new SerializableHadoopConfiguration(sc.hadoopConfiguration))
@@ -417,7 +417,7 @@ class HailContext private(val sc: SparkContext,
         
         val filename = path + "/parts/part-" + pis
         
-        sHadoopConfBc.value.value.readPartition(filename)(makeStream, i, read)
+        sHadoopConfBc.value.value.readPartition(filename)(makeStream, read(i))
       }
       
       @transient override val partitioner: Option[Partitioner] = _partitioner

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -321,7 +321,7 @@ class HailContext private(val sc: SparkContext,
     missing: String,
     noHeader: Boolean,
     impute: Boolean,
-    quote: java.lang.Character): KeyTable = importTables(inputs.asScala, keyNames.asScala.toArray, Option(nPartitions),
+    quote: java.lang.Character): KeyTable = importTables(inputs.asScala, keyNames.asScala.toArray, if (nPartitions == null) None else Some(nPartitions),
     types.asScala.toMap, Option(commentChar), separator, missing, noHeader, impute, quote)
 
   def importTable(input: String,

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -424,7 +424,7 @@ class HailContext private(val sc: SparkContext,
     }
   }
   
-  def readRowsRDD(path: String, t: TStruct, nPartitions: Int): RDD[RegionValue] =
+  def readRows(path: String, t: TStruct, nPartitions: Int): RDD[RegionValue] =
     readPartitions(path, nPartitions, is => is, HailContext.readRow(t))
   
   def importVCF(file: String, force: Boolean = false,

--- a/src/main/scala/is/hail/annotations/ReadRowsRDD.scala
+++ b/src/main/scala/is/hail/annotations/ReadRowsRDD.scala
@@ -478,7 +478,7 @@ final class Encoder(out: OutputBuffer) {
 }
 
 object RichRDDRegionValue {
-  def writeRow(t: TStruct)(os: OutputStream, i: Int, it: Iterator[RegionValue]): Long = {
+  def writeRow(t: TStruct)(i: Int, it: Iterator[RegionValue])(os: OutputStream): Long = {
     val en = new Encoder(new LZ4OutputBuffer(os))
     var rowCount = 0L
     

--- a/src/main/scala/is/hail/annotations/ReadRowsRDD.scala
+++ b/src/main/scala/is/hail/annotations/ReadRowsRDD.scala
@@ -565,4 +565,10 @@ class ReadRowsRDD(sc: SparkContext,
       }
     }
   }
+  
+  def makeStream(in: InputStream): InputStream = in
+  
+  def read(in: InputStream, i: Int): Iterator[RegionValue] = {
+    
+  }
 }

--- a/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -5,6 +5,7 @@ import java.io.{ObjectInputStream, ObjectOutputStream}
 import com.esotericsoftware.kryo.io.{Input, Output}
 import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
 import is.hail.expr._
+import is.hail.io._
 import is.hail.utils._
 import is.hail.variant.{AltAllele, GRBase, GenericGenotype, Locus, Variant}
 import org.apache.spark.sql.Row

--- a/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
@@ -84,7 +84,7 @@ object BlockMatrix {
     val nBlocks = blockRows * blockCols
     assert(nBlocks >= blockRows && nBlocks >= blockCols)
     
-    def readBlock(dis: DataInputStream, i: Int): Iterator[((Int, Int), BDM[Double])] = {
+    def readBlock(i: Int)(dis: DataInputStream): Iterator[((Int, Int), BDM[Double])] = {
       val bdm = RichDenseMatrixDouble.read(dis)
 
       Iterator.single(
@@ -258,7 +258,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     val hadoop = blocks.sparkContext.hadoopConfiguration
     hadoop.mkDir(uri)
 
-    def writeBlock(dos: DataOutputStream, i: Int, it: Iterator[((Int, Int), BDM[Double])]): Int = {
+    def writeBlock(i: Int, it: Iterator[((Int, Int), BDM[Double])])(dos: DataOutputStream): Int = {
       assert(it.hasNext)
       val (_, bdm) = it.next()
       assert(!it.hasNext)

--- a/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
@@ -86,6 +86,7 @@ object BlockMatrix {
     
     def readBlock(i: Int)(dis: DataInputStream): Iterator[((Int, Int), BDM[Double])] = {
       val bdm = RichDenseMatrixDouble.read(dis)
+      dis.close()
 
       Iterator.single(
         if (transposed)

--- a/src/main/scala/is/hail/distributedmatrix/GridPartitioner.scala
+++ b/src/main/scala/is/hail/distributedmatrix/GridPartitioner.scala
@@ -2,7 +2,7 @@ package is.hail.distributedmatrix
 
 import org.apache.spark.Partitioner
 
-case class GridPartitioner(rows: Long, cols: Long, blockSize: Int, transposed: Boolean = false) extends Partitioner {
+case class GridPartitioner(blockSize: Int, rows: Long, cols: Long, transposed: Boolean = false) extends Partitioner {
   require(rows > 0)
   require(cols > 0)
   require((rows - 1) / blockSize + 1 < Int.MaxValue)
@@ -12,7 +12,8 @@ case class GridPartitioner(rows: Long, cols: Long, blockSize: Int, transposed: B
   val colPartitions: Int = ((cols - 1) / blockSize + 1).toInt
 
   override val numPartitions: Int = rowPartitions * colPartitions
-
+  assert(numPartitions >= rowPartitions && numPartitions >= colPartitions)
+  
   override def getPartition(key: Any): Int = key match {
     case (i: Int, j: Int) => partitionIdFromBlockIndices(i, j)
   }
@@ -41,5 +42,5 @@ case class GridPartitioner(rows: Long, cols: Long, blockSize: Int, transposed: B
   }
 
   def transpose: GridPartitioner =
-    GridPartitioner(this.cols, this.rows, this.blockSize, !this.transposed)
+    GridPartitioner(this.blockSize, this.cols, this.rows, !this.transposed)
 }

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -404,7 +404,7 @@ case class MatrixRead(
           typ.orderedRDD2Type,
           OrderedPartitioner2(hc.sc,
             hc.hadoopConf.readFile(path + "/partitioner.json.gz")(JsonMethods.parse(_))),
-          hc.readRowsRDD(path, typ.rowType, nPartitions))
+          hc.readRows(path, typ.rowType, nPartitions))
         if (dropSamples) {
           val localRowType = typ.rowType
           rdd = rdd.mapPartitionsPreservesPartitioning { it =>

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -404,7 +404,7 @@ case class MatrixRead(
           typ.orderedRDD2Type,
           OrderedPartitioner2(hc.sc,
             hc.hadoopConf.readFile(path + "/partitioner.json.gz")(JsonMethods.parse(_))),
-          new ReadRowsRDD(hc.sc, path, typ.rowType, nPartitions))
+          hc.readRowsRDD(path, typ.rowType, nPartitions))
         if (dropSamples) {
           val localRowType = typ.rowType
           rdd = rdd.mapPartitionsPreservesPartitioning { it =>

--- a/src/main/scala/is/hail/keytable/KeyTable.scala
+++ b/src/main/scala/is/hail/keytable/KeyTable.scala
@@ -83,7 +83,7 @@ object KeyTable {
     val schema = Parser.parseType(metadata.schema).asInstanceOf[TStruct]
 
     KeyTable(hc,
-      hc.readRowsRDD(path, schema, metadata.n_partitions)
+      hc.readRows(path, schema, metadata.n_partitions)
         .map { rv =>
           new UnsafeRow(schema, rv.region.copy(), rv.offset): Row
         },

--- a/src/main/scala/is/hail/keytable/KeyTable.scala
+++ b/src/main/scala/is/hail/keytable/KeyTable.scala
@@ -83,7 +83,7 @@ object KeyTable {
     val schema = Parser.parseType(metadata.schema).asInstanceOf[TStruct]
 
     KeyTable(hc,
-      new ReadRowsRDD(hc.sc, path, schema, metadata.n_partitions)
+      hc.readRowsRDD(path, schema, metadata.n_partitions)
         .map { rv =>
           new UnsafeRow(schema, rv.region.copy(), rv.offset): Row
         },

--- a/src/main/scala/is/hail/utils/richUtils/Implicits.scala
+++ b/src/main/scala/is/hail/utils/richUtils/Implicits.scala
@@ -3,8 +3,9 @@ package is.hail.utils.richUtils
 import java.io.InputStream
 
 import breeze.linalg.DenseMatrix
-import is.hail.annotations.{MemoryBuffer, RegionValue, RichRDDRegionValue}
+import is.hail.annotations.{MemoryBuffer, RegionValue}
 import is.hail.asm4s.Code
+import is.hail.io.RichRDDRegionValue
 import is.hail.utils.{ArrayBuilder, HailIterator, JSONWriter, MultiArray2, Truncatable, WithContext}
 import is.hail.variant.Variant
 import org.apache.hadoop

--- a/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
@@ -1,5 +1,7 @@
 package is.hail.utils.richUtils
 
+import java.io.{DataInputStream, DataOutputStream}
+
 import breeze.linalg.DenseMatrix
 import is.hail.utils.ArrayBuilder
 
@@ -10,6 +12,20 @@ object RichDenseMatrixDouble {
       None
     else
       Some(DenseMatrix.horzcat(ms: _*))
+  }
+  
+  def read(in: DataInputStream): DenseMatrix[Double] = {
+    val rows = in.readInt()
+    val cols = in.readInt()
+    
+    val data = new Array[Double](rows * cols)
+    var i = 0
+    while (i < rows * cols) {
+      data(i) = in.readDouble()
+      i += 1
+    }
+    
+    new DenseMatrix[Double](rows, cols, data)
   }
 }
 
@@ -61,6 +77,18 @@ class RichDenseMatrixDouble(val m: DenseMatrix[Double]) extends AnyVal {
         m(i, j) = m(j, i)
         j += 1
       }
+      i += 1
+    }
+  }
+  
+  def write(out: DataOutputStream) {
+    out.writeInt(m.rows)
+    out.writeInt(m.cols)
+
+    val data = m.toArray
+    var i = 0
+    while (i < m.rows * m.cols) {
+      out.writeDouble(data(i))
       i += 1
     }
   }

--- a/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
@@ -263,8 +263,11 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
   def writePartition[T, S <: Closeable, U](filename: String)(makeStream: (OutputStream) => S, f: S => T): T =
     using(create(filename)) { os => using(makeStream(os))(f) }
 
-  def readPartition[T, S <: Closeable](filename: String)(makeStream: (InputStream) => S, f: S => T): T =
-    using(open(filename)) { is => using(makeStream(is))(f) }
+  def unsafeReadPartition[T, S <: Closeable](filename: String)(makeStream: (InputStream) => S, f: S => T): T =
+    f(makeStream(open(filename)))
+    
+//  def readPartition[T, S <: Closeable](filename: String)(makeStream: (InputStream) => S, f: S => T): T =
+//    using(open(filename)) { is => using(makeStream(is))(f) }
   
   def readLines[T](filename: String)(reader: (Iterator[WithContext[String]] => T)): T = {
     readFile[T](filename) {

--- a/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
@@ -260,19 +260,11 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
   def writeFile[T](filename: String)(f: (OutputStream) => T): T =
     using(create(filename))(f)
 
-  def writePartition[T, S <: Closeable, U](filename: String)(makeStream: (OutputStream) => S, 
-    i: Int, it: Iterator[U], f: (S, Int, Iterator[U]) => T): T =
-    using(create(filename)) { os => using(makeStream(os))(f(_, i, it)) }
+  def writePartition[T, S <: Closeable, U](filename: String)(makeStream: (OutputStream) => S, f: S => T): T =
+    using(create(filename)) { os => using(makeStream(os))(f) }
 
-  def readPartition[T, S <: Closeable](filename: String)(makeStream: (InputStream) => S, i: Int, f: (S, Int) => T): T =
-    using(open(filename)) { is => using(makeStream(is))(f(_, i)) }
-
-//  def writePartition[T, S <: Closeable, U](filename: String)(makeStream: (OutputStream) => S, 
-//    i: Int, it: Iterator[U], f: (S, Int, Iterator[U]) => T): T =
-//    using(makeStream(create(filename)))(f(_, i, it))
-//
-//  def readPartition[T, S <: Closeable](filename: String)(makeStream: (InputStream) => S, i: Int, f: (S, Int) => T): T =
-//    using(makeStream(open(filename)))(f(_, i))
+  def readPartition[T, S <: Closeable](filename: String)(makeStream: (InputStream) => S, f: S => T): T =
+    using(open(filename)) { is => using(makeStream(is))(f) }
   
   def readLines[T](filename: String)(reader: (Iterator[WithContext[String]] => T)): T = {
     readFile[T](filename) {

--- a/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
@@ -259,16 +259,7 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
 
   def writeFile[T](filename: String)(f: (OutputStream) => T): T =
     using(create(filename))(f)
-
-  def writePartition[T, S <: Closeable, U](filename: String)(makeStream: (OutputStream) => S, f: S => T): T =
-    using(create(filename)) { os => using(makeStream(os))(f) }
-
-  def unsafeReadPartition[T, S <: Closeable](filename: String)(makeStream: (InputStream) => S, f: S => T): T =
-    f(makeStream(open(filename)))
-    
-//  def readPartition[T, S <: Closeable](filename: String)(makeStream: (InputStream) => S, f: S => T): T =
-//    using(open(filename)) { is => using(makeStream(is))(f) }
-  
+      
   def readLines[T](filename: String)(reader: (Iterator[WithContext[String]] => T)): T = {
     readFile[T](filename) {
       is =>

--- a/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
@@ -262,10 +262,17 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
 
   def writePartition[T, S <: Closeable, U](filename: String)(makeStream: (OutputStream) => S, 
     i: Int, it: Iterator[U], f: (S, Int, Iterator[U]) => T): T =
-    using(makeStream(create(filename)))(f(_, i, it))
+    using(create(filename)) { os => using(makeStream(os))(f(_, i, it)) }
 
   def readPartition[T, S <: Closeable](filename: String)(makeStream: (InputStream) => S, i: Int, f: (S, Int) => T): T =
-    using(makeStream(open(filename)))(f(_, i))
+    using(open(filename)) { is => using(makeStream(is))(f(_, i)) }
+
+//  def writePartition[T, S <: Closeable, U](filename: String)(makeStream: (OutputStream) => S, 
+//    i: Int, it: Iterator[U], f: (S, Int, Iterator[U]) => T): T =
+//    using(makeStream(create(filename)))(f(_, i, it))
+//
+//  def readPartition[T, S <: Closeable](filename: String)(makeStream: (InputStream) => S, i: Int, f: (S, Int) => T): T =
+//    using(makeStream(open(filename)))(f(_, i))
   
   def readLines[T](filename: String)(reader: (Iterator[WithContext[String]] => T)): T = {
     readFile[T](filename) {

--- a/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
@@ -259,7 +259,7 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
 
   def writeFile[T](filename: String)(f: (OutputStream) => T): T =
     using(create(filename))(f)
-      
+
   def readLines[T](filename: String)(reader: (Iterator[WithContext[String]] => T)): T = {
     readFile[T](filename) {
       is =>

--- a/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
@@ -138,7 +138,7 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
     delete(destinationFile, recursive = true) // overwriting by default
 
     val headerFileStatus = glob(sourceFolder + "/header")
-    
+
     if (hasHeader && headerFileStatus.isEmpty)
       fatal(s"Missing header file")
     else if (!hasHeader && headerFileStatus.nonEmpty)
@@ -147,10 +147,10 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
     val partFileStatuses = glob(sourceFolder + "/part-*").sortBy(fs => getPartNumber(fs.getPath.getName))
 
     if (partFileStatuses.length != numPartFilesExpected)
-      fatal(s"Expected $numPartFilesExpected part files but found ${partFileStatuses.length}")
-        
+      fatal(s"Expected $numPartFilesExpected part files but found ${ partFileStatuses.length }")
+
     val filesToMerge = headerFileStatus ++ partFileStatuses
-    
+
     val (_, dt) = time {
       copyMergeList(filesToMerge, destinationFile, deleteSource)
     }
@@ -257,6 +257,9 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
   def readFile[T](filename: String)(f: (InputStream) => T): T =
     using(open(filename))(f)
 
+  def readPartition[T, S <: Closeable](filename: String)(makeStream: (InputStream) => S, i: Int, f: (S, Int) => T): T =
+    using(makeStream(open(filename)))(f(_, i))
+  
   def writeFile[T](filename: String)(f: (OutputStream) => T): T =
     using(create(filename))(f)
 

--- a/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
@@ -257,12 +257,16 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
   def readFile[T](filename: String)(f: (InputStream) => T): T =
     using(open(filename))(f)
 
-  def readPartition[T, S <: Closeable](filename: String)(makeStream: (InputStream) => S, i: Int, f: (S, Int) => T): T =
-    using(makeStream(open(filename)))(f(_, i))
-  
   def writeFile[T](filename: String)(f: (OutputStream) => T): T =
     using(create(filename))(f)
 
+  def writePartition[T, S <: Closeable, U](filename: String)(makeStream: (OutputStream) => S, 
+    i: Int, it: Iterator[U], f: (S, Int, Iterator[U]) => T): T =
+    using(makeStream(create(filename)))(f(_, i, it))
+
+  def readPartition[T, S <: Closeable](filename: String)(makeStream: (InputStream) => S, i: Int, f: (S, Int) => T): T =
+    using(makeStream(open(filename)))(f(_, i))
+  
   def readLines[T](filename: String)(reader: (Iterator[WithContext[String]] => T)): T = {
     readFile[T](filename) {
       is =>

--- a/src/main/scala/is/hail/utils/richUtils/RichIndexedRowMatrix.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichIndexedRowMatrix.scala
@@ -28,7 +28,7 @@ class RichIndexedRowMatrix(indexedRowMatrix: IndexedRowMatrix) {
         .map { case (values, blockColumn) =>
           ((i.toInt, blockColumn), (ii.toInt, values))
         }
-    }.groupByKey(GridPartitioner(rows, cols, blockSize)).mapValuesWithKey {
+    }.groupByKey(GridPartitioner(blockSize, rows, cols)).mapValuesWithKey {
       case ((i, j), it) =>
         val rowsInBlock: Int = if (i == truncatedBlockRow) excessRows else blockSize
         val colsInBlock: Int = if (j == truncatedBlockCol) excessCols else blockSize

--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -167,7 +167,7 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
       .subsetPartitions((0 to idxLast).toArray)
   }
   
-  def writePartitions[S](makeStream: (OutputStream) => S, write: (S, Int, Iterator[T]) => ()) {
-    
-  }
+//  def writePartitions[S](makeStream: (OutputStream) => S, write: (S, Int, Iterator[T]) => ()) {
+//    
+//  }
 }

--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -168,7 +168,7 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
   }
   
   def writePartitions[S <: Closeable](path: String, 
-    makeStream: (OutputStream) => S, write: (S, Int, Iterator[T]) => Long): Long = {
+    makeStream: (OutputStream) => S, write: (Int, Iterator[T]) => S => Long): Long = {
     
     val sc = r.sparkContext
     val hadoopConf = sc.hadoopConfiguration
@@ -187,7 +187,7 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
 
       val filename = path + "/parts/part-" + pis
 
-      Iterator.single(sHadoopConfBc.value.value.writePartition(filename)(makeStream, i, it, write))
+      Iterator.single(sHadoopConfBc.value.value.writePartition(filename)(makeStream, write(i, it)))
     }
       .fold(0L)(_ + _)
 

--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -1,9 +1,10 @@
 package is.hail.utils.richUtils
 
-import java.io.OutputStream
+import java.io.{Closeable, OutputStream}
 
 import is.hail.sparkextras.ReorderedPartitionsRDD
 import is.hail.utils._
+import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop
 import org.apache.hadoop.io.compress.CompressionCodecFactory
 import org.apache.spark.{NarrowDependency, Partition, TaskContext}
@@ -31,7 +32,6 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
 
     val codecFactory = new CompressionCodecFactory(hConf)
     val codec = Option(codecFactory.getCodec(new hadoop.fs.Path(filename)))
-    val headerExt = codec.map(_.getDefaultExtension).getOrElse("")
 
     hConf.delete(filename, recursive = true) // overwriting by default
 
@@ -64,7 +64,7 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
       fatal("write failed: no success indicator found")
 
     if (!parallelWrite) {
-      hConf.copyMerge(parallelOutputPath, filename, rWithHeader.getNumPartitions, true, false)
+      hConf.copyMerge(parallelOutputPath, filename, rWithHeader.getNumPartitions, hasHeader = false)
     }
   }
 
@@ -167,7 +167,32 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
       .subsetPartitions((0 to idxLast).toArray)
   }
   
-//  def writePartitions[S](makeStream: (OutputStream) => S, write: (S, Int, Iterator[T]) => ()) {
-//    
-//  }
+  def writePartitions[S <: Closeable](path: String, 
+    makeStream: (OutputStream) => S, write: (S, Int, Iterator[T]) => Long): Long = {
+    
+    val sc = r.sparkContext
+    val hadoopConf = sc.hadoopConfiguration
+    
+    hadoopConf.mkDir(path + "/parts")
+    
+    val sHadoopConfBc = sc.broadcast(new SerializableHadoopConfiguration(hadoopConf))
+    
+    val nPartitions = r.getNumPartitions
+    val d = digitsNeeded(nPartitions)
+
+    val itemCount = r.mapPartitionsWithIndex { case (i, it) =>
+      val is = i.toString
+      assert(is.length <= d)
+      val pis = StringUtils.leftPad(is, d, "0")
+
+      val filename = path + "/parts/part-" + pis
+
+      Iterator.single(sHadoopConfBc.value.value.writePartition(filename)(makeStream, i, it, write))
+    }
+      .fold(0L)(_ + _)
+
+    info(s"wrote $itemCount items in $nPartitions partitions")
+    
+    itemCount
+  }
 }

--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -1,5 +1,7 @@
 package is.hail.utils.richUtils
 
+import java.io.OutputStream
+
 import is.hail.sparkextras.ReorderedPartitionsRDD
 import is.hail.utils._
 import org.apache.hadoop
@@ -163,5 +165,9 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
         it
     }, preservesPartitioning = true)
       .subsetPartitions((0 to idxLast).toArray)
+  }
+  
+  def writePartitions[S](makeStream: (OutputStream) => S, write: (S, Int, Iterator[T]) => ()) {
+    
   }
 }

--- a/src/test/scala/is/hail/annotations/UnsafeSuite.scala
+++ b/src/test/scala/is/hail/annotations/UnsafeSuite.scala
@@ -4,7 +4,7 @@ import is.hail.SparkSuite
 import is.hail.check._
 import is.hail.check.Arbitrary._
 import is.hail.expr._
-import is.hail.io.{Encoder, _}
+import is.hail.io._
 import is.hail.utils._
 import is.hail.variant.{GenomeReference, Variant}
 import org.apache.spark.SparkEnv

--- a/src/test/scala/is/hail/annotations/UnsafeSuite.scala
+++ b/src/test/scala/is/hail/annotations/UnsafeSuite.scala
@@ -4,6 +4,7 @@ import is.hail.SparkSuite
 import is.hail.check._
 import is.hail.check.Arbitrary._
 import is.hail.expr._
+import is.hail.io.{Encoder, _}
 import is.hail.utils._
 import is.hail.variant.{GenomeReference, Variant}
 import org.apache.spark.SparkEnv

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -396,7 +396,6 @@ class BlockMatrixSuite extends SparkSuite {
   def readWriteIdentityRandom() {
     forAll(blockMatrixGen()) { (m: BlockMatrix) =>
       val fname = tmpDir.createTempFile("test")
-      //println(s"blockSize=${m.blockSize}", s"rows=${m.rows}", s"cols=${m.cols}", s"trans=${m.partitioner.transposed}")
       m.write(fname)
       assert(sameDoubleMatrixNaNEqualsNaN(m.toLocalMatrix(), BlockMatrix.read(hc, fname).toLocalMatrix()))
       true

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -1,7 +1,6 @@
 package is.hail.distributedmatrix
 
 import breeze.linalg.{DenseMatrix => BDM}
-import breeze.stats.distributions.Rand
 import is.hail.SparkSuite
 import is.hail.check.Arbitrary._
 import is.hail.check.Prop._
@@ -9,7 +8,6 @@ import is.hail.check.Gen._
 import is.hail.check._
 import is.hail.distributedmatrix.BlockMatrix.ops._
 import is.hail.utils._
-import org.apache.commons.math3.random.{RandomDataGenerator, RandomGenerator}
 import org.testng.annotations.Test
 
 class BlockMatrixSuite extends SparkSuite {
@@ -398,6 +396,7 @@ class BlockMatrixSuite extends SparkSuite {
   def readWriteIdentityRandom() {
     forAll(blockMatrixGen()) { (m: BlockMatrix) =>
       val fname = tmpDir.createTempFile("test")
+      println(s"blockSize=${m.blockSize}", s"rows=${m.rows}", s"cols=${m.cols}", s"trans=${m.partitioner.transposed}")
       BlockMatrix.write(m, fname)
       assert(sameDoubleMatrixNaNEqualsNaN(m.toLocalMatrix(), BlockMatrix.read(hc, fname).toLocalMatrix()))
       true

--- a/src/test/scala/is/hail/distributedmatrix/GridPartitionerSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/GridPartitionerSuite.scala
@@ -16,7 +16,7 @@ class GridPartitionerSuite extends TestNGSuite {
 
   @Test
   def untransposedSquareIsColumnMajor() {
-    assertLayout(GridPartitioner(4, 4, 2),
+    assertLayout(GridPartitioner(2, 4, 4),
       (0, 0) -> 0,
       (1, 0) -> 1,
       (0, 1) -> 2,
@@ -26,7 +26,7 @@ class GridPartitionerSuite extends TestNGSuite {
 
   @Test
   def untransposedRectangleMoreRowsIsColumnMajor() {
-    assertLayout(GridPartitioner(6, 4, 2),
+    assertLayout(GridPartitioner(2, 6, 4),
       (0, 0) -> 0,
       (1, 0) -> 1,
       (2, 0) -> 2,
@@ -38,7 +38,7 @@ class GridPartitionerSuite extends TestNGSuite {
 
   @Test
   def untransposedRectangleMoreColsIsColumnMajor() {
-    assertLayout(GridPartitioner(4, 6, 2),
+    assertLayout(GridPartitioner(2, 4, 6),
       (0, 0) -> 0,
       (1, 0) -> 1,
       (0, 1) -> 2,
@@ -50,7 +50,7 @@ class GridPartitionerSuite extends TestNGSuite {
 
   @Test
   def transposedSquare() {
-    assertLayout(GridPartitioner(4, 4, 2, transposed=true),
+    assertLayout(GridPartitioner(2, 4, 4, transposed=true),
       (0, 0) -> 0,
       (1, 0) -> 2,
       (0, 1) -> 1,
@@ -60,7 +60,7 @@ class GridPartitionerSuite extends TestNGSuite {
 
   @Test
   def transposedRectangleMoreRows() {
-    assertLayout(GridPartitioner(6, 4, 2, transposed=true),
+    assertLayout(GridPartitioner(2, 6, 4, transposed=true),
       // 0 1
       // 2 3
       // 4 5
@@ -75,7 +75,7 @@ class GridPartitionerSuite extends TestNGSuite {
 
   @Test
   def transposedRectangleMoreCols() {
-    assertLayout(GridPartitioner(4, 6, 2, transposed=true),
+    assertLayout(GridPartitioner(2, 4, 6, transposed=true),
       // 0 1 2
       // 3 4 5
       (0, 0) -> 0,
@@ -86,5 +86,4 @@ class GridPartitionerSuite extends TestNGSuite {
       (1, 2) -> 5
     )
   }
-
 }

--- a/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
@@ -1,6 +1,5 @@
 package is.hail.variant.vsm
 
-import is.hail.TestUtils._
 import is.hail.annotations._
 import is.hail.check.Prop._
 import is.hail.check.{Gen, Parameters}
@@ -200,14 +199,12 @@ class VSMSuite extends SparkSuite {
     p.check()
   }
   
-  @Test def testWriteRead2() {
+  @Test def testWriteReadFile() {
     val vds = hc.importVCF("src/test/resources/sample.vcf")
-
     val f = tmpDir.createTempFile(extension = "vds")
     vds.write(f)
     assert(hc.readVDS(f).same(vds))
   }
-
 
   @Test def testFilterSamples() {
     val vds = hc.importVCF("src/test/resources/sample.vcf.gz", force = true)

--- a/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
@@ -198,13 +198,6 @@ class VSMSuite extends SparkSuite {
 
     p.check()
   }
-  
-  @Test def testWriteReadFile() {
-    val vds = hc.importVCF("src/test/resources/sample.vcf")
-    val f = tmpDir.createTempFile(extension = "vds")
-    vds.write(f)
-    assert(hc.readVDS(f).same(vds))
-  }
 
   @Test def testFilterSamples() {
     val vds = hc.importVCF("src/test/resources/sample.vcf.gz", force = true)

--- a/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
@@ -199,6 +199,15 @@ class VSMSuite extends SparkSuite {
 
     p.check()
   }
+  
+  @Test def testWriteRead2() {
+    val vds = hc.importVCF("src/test/resources/sample.vcf")
+
+    val f = tmpDir.createTempFile(extension = "vds")
+    vds.write(f)
+    assert(hc.readVDS(f).same(vds))
+  }
+
 
   @Test def testFilterSamples() {
     val vds = hc.importVCF("src/test/resources/sample.vcf.gz", force = true)


### PR DESCRIPTION
@cseed I've implemented `readPartitions` on `HailContext` and `writePartitions` on `RichRDD`, re-implemented read/write of blocks on `BlockMatrix` to preserve partitioning using these, and moved MatrixValue and KeyTable row read/write to use these.

readPartitions and writePartitions use `unsafeReadPartition` and `writePartition` in RichHadoopConfig.  `readRow` includes `close()`, and I've added `close()` to `readBlock` as well. At first I used `using` (see `readPartition` which is remarked out), but this closes the resource before the iterator iterated in the readRows case. Yet somehow, `testWriteRead` in VSMSuite passes even with `readPartition`. This test just creates a random VDS, writes, reads, compares.  I added `testWriteRead2` which imports `sample.vcf`, writes, reads, compares. And indeed, the latter fails with `readPartition`. I have no explanation for why the behavior would differ (could the former be somehow cached?). I'm not happy with the asymmetry or lake of read safety if closing isn't propagated backward (I think it is for DataInputStream), but would like to get your feedback before messing around with these functions further.

I've left the filename that had ReadRowsRDD with that name so it's easier to compare, but will change prior to merging since that class is gone. No class jumps out, should I just use the first one, `ArrayInputStream`, or a name that's not a class?

`ReadRDDPartition` in file ReadRowsRDDs and `IntPartition` in `BlockMatrix` have the same definition (the latter is used for more than just reading). I'm thinking of just having IntPartition located somewhere other than BlockMatrix. Any thoughts on where?

I added `sqrt` on blockSize in `blockMatrixGen` in order to get more cases with `blockSize < min(rows, cols)`. Only 1 of 10 had this property in `readWriteIdentityRandom` and its an important case to check with respect to the GridPartitioner dealing with block indices corrected (particularly with transpose in the mix).