### PR TITLE
propagate root-cause exceptions

### DIFF
--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -2460,8 +2460,8 @@ object FunctionRegistry {
             Code(stx, sty, b.update(i, z), i.store(i + 1))
           ),
           CompilationHelp.arrayToWrappedArray(b)).asInstanceOf[Code[IndexedSeq[S]]],
-        Code._throw(Code.newInstance[is.hail.utils.HailException, String, Option[String]](
-          s"""Cannot apply operation $name to arrays of unequal length.""".stripMargin, Code.invokeStatic[scala.Option[String], scala.Option[String]]("empty"))))),
+        Code._throw(Code.newInstance[is.hail.utils.HailException, String, Option[String], Throwable](
+          s"""Cannot apply operation $name to arrays of unequal length.""".stripMargin, Code.invokeStatic[scala.Option[String], scala.Option[String], Throwable]("empty", Code._null[Throwable]))))),
       null)
   }
 

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -2461,7 +2461,9 @@ object FunctionRegistry {
           ),
           CompilationHelp.arrayToWrappedArray(b)).asInstanceOf[Code[IndexedSeq[S]]],
         Code._throw(Code.newInstance[is.hail.utils.HailException, String, Option[String], Throwable](
-          s"""Cannot apply operation $name to arrays of unequal length.""".stripMargin, Code.invokeStatic[scala.Option[String], scala.Option[String], Throwable]("empty", Code._null[Throwable]))))),
+          s"""Cannot apply operation $name to arrays of unequal length.""".stripMargin,
+          Code.invokeStatic[scala.Option[String], scala.Option[String]]("empty"),
+          Code._null[Throwable])))),
       null)
   }
 

--- a/src/main/scala/is/hail/utils/Context.scala
+++ b/src/main/scala/is/hail/utils/Context.scala
@@ -10,11 +10,11 @@ case class TextContext(line: String, file: String, position: Option[Int]) extend
       case _: HailException =>
         fatal(
           s"""$file${ position.map(ln => ":" + (ln + 1)).getOrElse("") }: ${ e.getMessage }
-             |  offending line: @1""".stripMargin, line)
+             |  offending line: @1""".stripMargin, line, e)
       case _ =>
         fatal(
           s"""$file${ position.map(ln => ":" + (ln + 1)).getOrElse("") }: caught ${ e.getClass.getName() }: ${ e.getMessage }
-             |  offending line: @1""".stripMargin, line)
+             |  offending line: @1""".stripMargin, line, e)
     }
   }
 }

--- a/src/main/scala/is/hail/utils/ErrorHandling.scala
+++ b/src/main/scala/is/hail/utils/ErrorHandling.scala
@@ -1,19 +1,25 @@
 package is.hail.utils
 
-class HailException(val msg: String, val logMsg: Option[String] = None) extends RuntimeException(msg)
+class HailException(val msg: String, val logMsg: Option[String] = None, cause: Throwable = null) extends RuntimeException(msg, cause)
 
 trait ErrorHandling {
   def fatal(msg: String): Nothing = throw new HailException(msg)
 
-  def fatal(msg: String, t: Truncatable): Nothing = {
+  def fatal(msg: String, t: Truncatable): Nothing =
+    fatal(msg, t, null: Throwable)
+
+  def fatal(msg: String, t: Truncatable, e: Throwable): Nothing = {
     val (screen, logged) = t.strings
-    throw new HailException(format(msg, screen), Some(format(msg, logged)))
+    throw new HailException(format(msg, screen), Some(format(msg, logged)), e)
   }
 
   def fatal(msg: String, t1: Truncatable, t2: Truncatable): Nothing = {
+    fatal(msg, t1, t2, null)
+
+  def fatal(msg: String, t1: Truncatable, t2: Truncatable, e: Throwable): Nothing = {
     val (screen1, logged1) = t1.strings
     val (screen2, logged2) = t2.strings
-    throw new HailException(format(msg, screen1, screen2), Some(format(msg, logged1, logged2)))
+    throw new HailException(format(msg, screen1, screen2), Some(format(msg, logged1, logged2)), e)
   }
 
   def deepestMessage(e: Throwable): String = {

--- a/src/main/scala/is/hail/utils/ErrorHandling.scala
+++ b/src/main/scala/is/hail/utils/ErrorHandling.scala
@@ -13,7 +13,7 @@ trait ErrorHandling {
     throw new HailException(format(msg, screen), Some(format(msg, logged)), e)
   }
 
-  def fatal(msg: String, t1: Truncatable, t2: Truncatable): Nothing = {
+  def fatal(msg: String, t1: Truncatable, t2: Truncatable): Nothing =
     fatal(msg, t1, t2, null)
 
   def fatal(msg: String, t1: Truncatable, t2: Truncatable, e: Throwable): Nothing = {


### PR DESCRIPTION
I thought we fixed this already? Maybe it was never back ported to 0.1. This should preserve the stack traces for exceptions encountered inside a `WithContext.map`