### PR TITLE
format field parser

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -4318,7 +4318,7 @@ class VariantDataset(HistoryMixin):
     def sample_qc(self, root='sa.qc'):
         """Compute per-sample QC metrics.
 
-        .. include:: _templates/req_tvariant_tgenotype.rst
+        .. include:: _templates/req_tvariant.rst
 
         **Annotations**
 
@@ -4382,7 +4382,7 @@ class VariantDataset(HistoryMixin):
         :rtype: :class:`.VariantDataset`
         """
 
-        return VariantDataset(self.hc, self._jvdf.sampleQC(root))
+        return VariantDataset(self.hc, self._jvds.sampleQC(root))
 
     @handle_py4j
     def storage_level(self):
@@ -5022,9 +5022,8 @@ class VariantDataset(HistoryMixin):
     def variant_qc(self, root='va.qc'):
         """Compute common variant statistics (quality control metrics).
 
-        .. include:: _templates/req_tvariant_tgenotype.rst
-
         .. include:: _templates/req_biallelic.rst
+        .. include:: _templates/req_tvariant.rst
 
         **Examples**
 
@@ -5088,8 +5087,7 @@ class VariantDataset(HistoryMixin):
         :rtype: :py:class:`.VariantDataset`
         """
 
-        jvds = self._jvdf.variantQC(root)
-        return VariantDataset(self.hc, jvds)
+        return VariantDataset(self.hc, self._jvds.variantQC(root))
 
     @handle_py4j
     @record_method

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -210,7 +210,7 @@ class HailContext private(val sc: SparkContext,
     sc.textFilesLines(hadoopConf.globAll(files))
       .filter(line => regexp.findFirstIn(line.value).isDefined)
       .take(maxLines)
-      .groupBy(_.source.asInstanceOf[TextContext].file)
+      .groupBy(_.source.asInstanceOf[Context].file)
       .foreach { case (file, lines) =>
         info(s"$file: ${ lines.length } ${ plural(lines.length, "match", "matches") }:")
         lines.map(_.value).foreach { line =>

--- a/src/main/scala/is/hail/annotations/MemoryBlock.scala
+++ b/src/main/scala/is/hail/annotations/MemoryBlock.scala
@@ -636,19 +636,23 @@ class RegionValueBuilder(var region: MemoryBuffer) {
     advance()
   }
 
+  def setFieldIndex(newI: Int) {
+    assert(typestk.top.isInstanceOf[TStruct])
+    indexstk(0) = newI
+  }
+
   def setMissing() {
     val i = indexstk.top
     typestk.top match {
       case t: TStruct =>
         if (t.fieldType(i).required)
-          fatal(s"cannot set missing field for required type ${t.fieldType(i)}")
+          fatal(s"cannot set missing field for required type ${ t.fieldType(i) }")
         t.setFieldMissing(region, offsetstk.top, i)
       case t: TArray =>
         if (t.elementType.required)
-          fatal(s"cannot set missing field for required type ${t.elementType}")
+          fatal(s"cannot set missing field for required type ${ t.elementType }")
         t.setElementMissing(region, offsetstk.top, i)
     }
-
     advance()
   }
 

--- a/src/main/scala/is/hail/io/RowStore.scala
+++ b/src/main/scala/is/hail/io/RowStore.scala
@@ -119,8 +119,7 @@ abstract class OutputBuffer {
 }
 
 object LZ4Buffer {
-  final val blockSize: Int = 128 * 1024
-  // final val blockSize = 16
+  final val blockSize: Int = 32 * 1024
 }
 
 class LZ4OutputBuffer(out: OutputStream) extends OutputBuffer {

--- a/src/main/scala/is/hail/methods/SampleQC.scala
+++ b/src/main/scala/is/hail/methods/SampleQC.scala
@@ -3,7 +3,7 @@ package is.hail.methods
 import is.hail.annotations.Annotation
 import is.hail.expr.{TStruct, _}
 import is.hail.utils._
-import is.hail.variant.{AltAlleleType, GenericDataset, Genotype, HTSGenotypeView, Variant}
+import is.hail.variant.{AltAlleleType, GenericDataset, Genotype, HTSGenotypeView, Variant, VariantSampleMatrix}
 import org.apache.spark.util.StatCounter
 
 object SampleQCCombiner {
@@ -156,19 +156,20 @@ class SampleQCCombiner extends Serializable {
 }
 
 object SampleQC {
-  def results(vds: GenericDataset): Array[SampleQCCombiner] = {
-    val depth = treeAggDepth(vds.hc, vds.nPartitions)
-    val rowType = vds.rowType
-    val nSamples = vds.nSamples
-    if (vds.rdd.partitions.nonEmpty)
-      vds.unsafeRowRDD
+  def results[RPK, RK, T >: Null](vsm: VariantSampleMatrix[RPK, RK, T]): Array[SampleQCCombiner] = {
+    val depth = treeAggDepth(vsm.hc, vsm.nPartitions)
+    val rowType = vsm.rowType
+    val nSamples = vsm.nSamples
+    if (vsm.rdd2.partitions.nonEmpty)
+      vsm.rdd2
           .mapPartitions { it =>
             val view = HTSGenotypeView(rowType)
             val acc = Array.fill[SampleQCCombiner](nSamples)(new SampleQCCombiner)
 
-            it.foreach { r =>
-              view.setRegion(r.region, r.offset)
-              val v = r.getAs[Variant](1)
+            it.foreach { rv =>
+              view.setRegion(rv)
+              val v = Variant.fromRegionValue(rv.region,
+                rowType.loadField(rv, 1))
               val ais = SampleQCCombiner.alleleIndices(v)
               val acs = Array.fill(v.asInstanceOf[Variant].nAlleles)(0)
 
@@ -210,8 +211,8 @@ object SampleQC {
       Array.fill(nSamples)(new SampleQCCombiner)
   }
 
-  def apply(vds: GenericDataset, root: String): GenericDataset = {
-    val r = results(vds).map(_.asAnnotation)
-    vds.annotateSamples(SampleQCCombiner.signature, Parser.parseAnnotationRoot(root, Annotation.SAMPLE_HEAD), r)
+  def apply[RPK, RK, T >: Null](vsm: VariantSampleMatrix[RPK, RK, T], root: String): VariantSampleMatrix[RPK, RK, T] = {
+    val r = results(vsm).map(_.asAnnotation)
+    vsm.annotateSamples(SampleQCCombiner.signature, Parser.parseAnnotationRoot(root, Annotation.SAMPLE_HEAD), r)
   }
 }

--- a/src/main/scala/is/hail/methods/VariantQC.scala
+++ b/src/main/scala/is/hail/methods/VariantQC.scala
@@ -2,13 +2,9 @@ package is.hail.methods
 
 import is.hail.annotations._
 import is.hail.expr.{TStruct, _}
-import is.hail.sparkextras.{OrderedRDD, OrderedRDD2}
 import is.hail.stats.LeveneHaldane
-import is.hail.utils._
-import is.hail.variant.{GenericDataset, Genotype, HTSGenotypeView, Variant, VariantDataset}
+import is.hail.variant.{HTSGenotypeView, VariantSampleMatrix}
 import org.apache.spark.util.StatCounter
-
-import scala.reflect.classTag
 
 final class VariantQCCombiner {
   var nNotCalled: Int = 0
@@ -133,11 +129,11 @@ object VariantQC {
     "rExpectedHetFrequency" -> TFloat64(),
     "pHWE" -> TFloat64())
 
-  def apply(vds: GenericDataset, root: String): GenericDataset = {
-    val localNSamples = vds.nSamples
-    val localRowType = vds.rowType
+  def apply[RPK, RK, T >: Null](vsm: VariantSampleMatrix[RPK, RK, T], root: String): VariantSampleMatrix[RPK, RK, T] = {
+    val localNSamples = vsm.nSamples
+    val localRowType = vsm.rowType
 
-    vds.insertIntoRow(() => HTSGenotypeView(localRowType))(VariantQC.signature,
+    vsm.insertIntoRow(() => HTSGenotypeView(localRowType))(VariantQC.signature,
       "va" :: Parser.parseAnnotationRoot(root, Annotation.VARIANT_HEAD), { (view, rv, rvb) =>
         view.setRegion(rv.region, rv.offset)
         val comb = new VariantQCCombiner

--- a/src/main/scala/is/hail/utils/Context.scala
+++ b/src/main/scala/is/hail/utils/Context.scala
@@ -1,19 +1,27 @@
 package is.hail.utils
 
-abstract class Context {
-  def wrapException(e: Throwable): Nothing
-}
+case class Context(line: String, file: String, position: Option[Int]) {
+  def locationString: String =
+    position match {
+      case Some(p) => s"$file:$p"
+      case None => file
+    }
 
-case class TextContext(line: String, file: String, position: Option[Int]) extends Context {
+  def locationString(col: Int): String =
+    position match {
+      case Some(p) => s"$file:$p.$col"
+      case None => s"$file:column $col"
+    }
+
   def wrapException(e: Throwable): Nothing = {
     e match {
       case _: HailException =>
         fatal(
-          s"""$file${ position.map(ln => ":" + (ln + 1)).getOrElse("") }: ${ e.getMessage }
+          s"""$locationString: ${ e.getMessage }
              |  offending line: @1""".stripMargin, line, e)
       case _ =>
         fatal(
-          s"""$file${ position.map(ln => ":" + (ln + 1)).getOrElse("") }: caught ${ e.getClass.getName() }: ${ e.getMessage }
+          s"""$locationString: caught ${ e.getClass.getName }: ${ e.getMessage }
              |  offending line: @1""".stripMargin, line, e)
     }
   }

--- a/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
@@ -4,7 +4,7 @@ import java.io._
 
 import com.esotericsoftware.kryo.io.{Input, Output}
 import is.hail.io.compress.BGzipCodec
-import is.hail.utils.{TextContext, WithContext, _}
+import is.hail.utils._
 import net.jpountz.lz4.{LZ4BlockOutputStream, LZ4Compressor}
 import org.apache.hadoop
 import org.apache.hadoop.fs.FileStatus
@@ -268,7 +268,7 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
           .zipWithIndex
           .map {
             case (value, position) =>
-              val source = TextContext(value, filename, Some(position))
+              val source = Context(value, filename, Some(position))
               WithContext(value, source)
           }
         reader(lines)

--- a/src/main/scala/is/hail/utils/richUtils/RichSparkContext.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichSparkContext.scala
@@ -21,12 +21,12 @@ class RichSparkContext(val sc: SparkContext) extends AnyVal {
         // FIXME subclass TextInputFormat to return (file, line)
         val file = partitionFile(i)
         it.map { line =>
-          WithContext(line, TextContext(line, file, None))
+          WithContext(line, Context(line, file, None))
         }
       }
   }
 
   def textFileLines(file: String, nPartitions: Int = sc.defaultMinPartitions): RDD[WithContext[String]] =
     sc.textFile(file, nPartitions)
-      .map(l => WithContext(l, TextContext(l, file, None)))
+      .map(l => WithContext(l, Context(l, file, None)))
 }

--- a/src/main/scala/is/hail/variant/Genotype.scala
+++ b/src/main/scala/is/hail/variant/Genotype.scala
@@ -70,7 +70,6 @@ abstract class Genotype extends Serializable {
     val nGenotypes = triangle(nAlleles)
     assert(Genotype.gt(this).forall(i => i >= 0 && i < nGenotypes))
     assert(Genotype.ad(this).forall(a => a.length == nAlleles))
-    assert(Genotype.px(this).forall(a => a.length == nGenotypes))
   }
 
   def copy(gt: Option[Int] = Genotype.gt(this),

--- a/src/main/scala/is/hail/variant/HTSGenotypeView.scala
+++ b/src/main/scala/is/hail/variant/HTSGenotypeView.scala
@@ -22,6 +22,10 @@ object HTSGenotypeView {
 sealed abstract class HTSGenotypeView {
   def setRegion(mb: MemoryBuffer, offset: Long)
 
+  def setRegion(rv: RegionValue) {
+    setRegion(rv.region, rv.offset)
+  }
+
   def setGenotype(idx: Int)
 
   def gIsDefined: Boolean

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -243,7 +243,7 @@ g = let
 
   def exportPlink(path: String, famExpr: String = "id = s") {
     require(vds.wasSplit)
-    vds.requireSampleTString("export plink")
+    vds.requireColKeyString("export plink")
 
     val ec = EvalContext(Map(
       "s" -> (0, TString()),
@@ -453,7 +453,7 @@ g = let newgt = ${ filterGT("gtIndex(oldToNew[gtj(g.gt)], oldToNew[gtk(g.gt)])")
 
   def mendelErrors(ped: Pedigree): (KeyTable, KeyTable, KeyTable, KeyTable) = {
     require(vds.wasSplit)
-    vds.requireSampleTString("mendel errors")
+    vds.requireColKeyString("mendel errors")
 
     val men = MendelErrors(vds, ped.filterTo(vds.stringSampleIdSet).completeTrios)
 
@@ -518,8 +518,6 @@ g = let newgt = ${ filterGT("gtIndex(oldToNew[gtj(g.gt)], oldToNew[gtk(g.gt)])")
     PCRelate.toKeyTable(vds, pcs, maf, blockSize, minKinship, statistics)
   }
 
-  def sampleQC(root: String = "sa.qc"): VariantDataset = SampleQC(vds.toGDS, root).toVDS
-
   def rrm(forceBlock: Boolean = false, forceGramian: Boolean = false): KinshipMatrix = {
     require(vds.wasSplit)
     info(s"rrm: Computing Realized Relationship Matrix...")
@@ -530,14 +528,9 @@ g = let newgt = ${ filterGT("gtIndex(oldToNew[gtj(g.gt)], oldToNew[gtk(g.gt)])")
 
   def tdt(ped: Pedigree, tdtRoot: String = "va.tdt"): VariantDataset = {
     require(vds.wasSplit)
-    vds.requireSampleTString("TDT")
+    vds.requireColKeyString("TDT")
     TDT(vds, ped.filterTo(vds.stringSampleIdSet).completeTrios,
       Parser.parseAnnotationRoot(tdtRoot, Annotation.VARIANT_HEAD))
-  }
-
-  def variantQC(root: String = "va.qc"): VariantDataset = {
-    require(vds.wasSplit)
-    VariantQC(vds.toGDS, root).toVDS
   }
 
   def deNovo(ped: Pedigree,
@@ -548,7 +541,7 @@ g = let newgt = ${ filterGT("gtIndex(oldToNew[gtj(g.gt)], oldToNew[gtk(g.gt)])")
     minChildAB: Double = 0.20,
     minDepthRatio: Double = 0.10): KeyTable = {
     require(vds.wasSplit)
-    vds.requireSampleTString("de novo")
+    vds.requireColKeyString("de novo")
 
     DeNovo(vds, ped, referenceAF, minGQ, minPDeNovo, maxParentAB, minChildAB, minDepthRatio)
   }

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -2232,6 +2232,7 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
           minRep1(removeLeftAligned = true, removeMoving = false, verifyLeftAligned = false))
 
     copy2(rdd2 = newRDD2)
+  }
 
   def sampleQC(root: String = "sa.qc"): VariantSampleMatrix[RPK, RK, T] = {
     requireRowKeyVariant("sample_qc")

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -2178,7 +2178,6 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
     Skat(this, variantKeys, singleKey,  weightExpr, y, x, covariates, logistic, maxSize, accuracy, iterations)
   }
 
-<<<<<<< 49ce8a821797c0169ad84939654f63960bb2e3f9
   def minRep(leftAligned: Boolean = false): VariantSampleMatrix[Locus, Variant, T] = {
     requireRowKeyVariant("min_rep")
 
@@ -2233,7 +2232,7 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
           minRep1(removeLeftAligned = true, removeMoving = false, verifyLeftAligned = false))
 
     copy2(rdd2 = newRDD2)
-=======
+
   def sampleQC(root: String = "sa.qc"): VariantSampleMatrix[RPK, RK, T] = {
     requireRowKeyVariant("sample_qc")
     SampleQC(this, root)
@@ -2243,6 +2242,5 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
     require(wasSplit)
     requireRowKeyVariant("variant_qc")
     VariantQC(this, root)
->>>>>>> Made QC methods generic.
   }
 }

--- a/src/test/scala/is/hail/io/ImportVCFSuite.scala
+++ b/src/test/scala/is/hail/io/ImportVCFSuite.scala
@@ -67,7 +67,7 @@ class ImportVCFSuite extends SparkSuite {
     val e = intercept[SparkException] {
       hc.importVCF("src/test/resources/malformed.vcf").countVariants()
     }
-    assert(e.getMessage.contains("caught htsjdk.tribble.TribbleException$InternalCodecException: "))
+    assert(e.getMessage.contains("invalid character"))
   }
   
   @Test def testHaploid() {
@@ -96,7 +96,7 @@ class ImportVCFSuite extends SparkSuite {
       Some(Array(0, 6)),
       Some(7),
       Some(70),
-      Some(Array(70, HtsjdkRecordReader.haploidNonsensePL, 0))
+      Some(Array(70, 0))
     ))
     assert(r(v2, s1) == Genotype(
       Some(5),
@@ -110,8 +110,7 @@ class ImportVCFSuite extends SparkSuite {
       Some(Array(0, 0, 9)),
       Some(9),
       Some(24),
-      Some(Array(24, HtsjdkRecordReader.haploidNonsensePL, 40, HtsjdkRecordReader.haploidNonsensePL,
-        HtsjdkRecordReader.haploidNonsensePL, 0))
+      Some(Array(24, 40, 0))
     ))
   }
 

--- a/src/test/scala/is/hail/utils/TextTableSuite.scala
+++ b/src/test/scala/is/hail/utils/TextTableSuite.scala
@@ -38,7 +38,7 @@ class TextTableSuite extends SparkSuite {
       "-129 -129 . 1230192 1:1:A:AAA false GRCH12.1:151515",
       "0 0 . gene123.1 1:100:A:* false GRCH12.1:123",
       "-200 -200.0 . 155.2 GRCH123.2:2:A:T true 1:2"
-    ), 3).map { x => WithContext(x, TextContext(x, "none", None)) }
+    ), 3).map { x => WithContext(x, Context(x, "none", None)) }
 
     val imputed = TextTableReader.imputeTypes(rdd, Array("1", "2", "3", "4", "5", "6", "7"), "\\s+", ".", null)
 


### PR DESCRIPTION
Parse format field directly, don't use HTSJDK.

I also lowered the compression block size to balance size and speed.

Sizes:

```
original:
214M profile.vcf.bgz
1.2G gnomad.genomes.r2.0.2.sites.chr21.vcf.bgz
631M exac_table.tsv.bgz

fastvcf:
248M profile.vds
1.4G gnomad.sites.vds
688M exac.kt

is/master
224M profile.vds
1.2G gnomad.sites.vds
610M exac.kt

is/master
207M profile.vds
1.1G gnomad.sites.vds
550M exac.kt
```

So the sizes for fastvcf are slightly worse than master and 0.1, about 10-15% larger than the originals.

Speed:

```
fastvcf:
import_vcf/count 7.8s
import_vcf/write 15.3s
import_gnomad_sites/write 51.4s
read/count 2.1s
import_table/write 99.4s
read_table/count 7s

is/master:
import_vcf/count 14s
import_vcf/write 25.5s
import_gnomad_sites/write 57.8s
read/count 2.1s
import_table/write 101s
read_table/count 6.7s

is/0.1:
import_vcf/count 14.3s
import_vcf/write 15.1s
import_gnomad_sites/write 94s
read/count 0.4s
import_table/write 118s
read_table/count 24.7s
```

import_vcf/count is 2x faster than anywhere else and import_vcf/write is comparable with 0.1 and much faster than master.   read_table/count is still faster in 0.1 because it doesn't decompress/decode the genotypes.  With this we have rough parity with 0.1 while being fully generic.  This doesn't include improvements from making use of required fields.