### PR TITLE
implement genInsertable

### DIFF
--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -535,7 +535,7 @@ object Parser extends JavaTokenParsers {
   def _required_type: Parser[Boolean] = "!" ^^ {_ => true} | success(false)
 
   def _type_expr: Parser[Type] =
-    "Empty" ^^ { _ => TStruct.empty } |
+    "Empty" ^^ { _ => TStruct.empty() } |
       ("Interval" ~ "(") ~> identifier <~ ")" ^^ { id => GenomeReference.getReference(id).interval } |
       "Boolean" ^^ { _ => TBoolean() } |
       "Int32" ^^ { _ => TInt32() } |

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -31,7 +31,7 @@ object Type {
   val genRequiredScalar = genScalar(true)
 
   def genComplexType(required: Boolean) = {
-    val grDependents = GenomeReference.references.values.flatMap(gr =>
+    val grDependents = GenomeReference.references.values.toArray.flatMap(gr =>
       Array(TVariant(gr, required), TLocus(gr, required), TInterval(gr, required)))
     val others = Array(
       TAltAllele(required), TGenotype(required), TCall(required))

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -1621,6 +1621,7 @@ final case class Field(name: String, typ: Type,
 object TStruct {
   private val requiredEmpty = TStruct(Array.empty[Field], true)
   private val optionalEmpty = TStruct(Array.empty[Field], false)
+
   def empty(required: Boolean = false): TStruct = if (required) requiredEmpty else optionalEmpty
 
   def apply(args: (String, Type)*): TStruct =

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -22,39 +22,26 @@ import scala.reflect.classTag
 abstract class BaseType
 
 object Type {
-  val genOptionalScalar: Gen[Type] = Gen.oneOf[Type](TBooleanOptional, TInt32Optional, TInt64Optional, TFloat32Optional, TFloat64Optional, TStringOptional,
-    TVariant(GenomeReference.GRCh37, false), TAltAlleleOptional, TGenotypeOptional, TLocus(GenomeReference.GRCh37, false), TInterval(GenomeReference.GRCh37, false), TCallOptional)
+  def genScalar(required: Boolean) =
+    Gen.oneOf(TBoolean(required), TInt32(required), TInt64(required), TFloat32(required),
+      TFloat64(required), TString(required), TAltAllele(required), TGenotype(required), TCall(required))
 
-  val genRequiredScalar: Gen[Type] = Gen.oneOf[Type](TBooleanRequired, TInt32Required, TInt64Required, TFloat32Required, TFloat64Required, TStringRequired,
-    TVariant(GenomeReference.GRCh37, true), TAltAlleleRequired, TGenotypeRequired, TLocus(GenomeReference.GRCh37, true), TInterval(GenomeReference.GRCh37, true), TCallRequired)
+  val genOptionalScalar = genScalar(false)
 
-  val genScalar: Gen[Type] = Gen.coin(0.2).flatMap( r => if (r) genRequiredScalar else genOptionalScalar )
+  val genRequiredScalar = genScalar(true)
 
-  def genSized(size: Int): Gen[Type] = {
-    if (size < 1)
-      Gen.const(TStruct.empty)
-    else if (size < 2)
-      genScalar
-    else {
-      val genMaybeRequired: Gen[Type] = for {
-        t <- genArb.resize(size - 1)
-        req <- Gen.coin(0.2)
-      } yield if (req) !t else t
-      Gen.oneOfGen(genScalar,
-        genScalar,
-        genScalar,
-        genScalar,
-        genMaybeRequired.map { TArray(_) },
-        genMaybeRequired.map { TSet(_) },
-        Gen.zip(genArb.resize(size - 1), genMaybeRequired).map { case (k, v) => TDict(k, v) },
-        genStruct.resize(size))
-    }
-  }
+  def genGenomeReferenceType(required: Boolean) =
+    Gen.oneOfSeq(GenomeReference.references.values.flatMap(gr =>
+      Array(TVariant(gr, required), TLocus(gr, required), TInterval(gr, required))).toArray[Type])
 
-  def genStruct: Gen[TStruct] =
+  val optionalGenomeReferenceTypes = genGenomeReferenceType(false)
+
+  val requiredGenomeReferenceTypes = genGenomeReferenceType(true)
+
+  def preGenStruct(required: Boolean, genFieldType: Gen[Type]): Gen[TStruct] =
     Gen.buildableOf[Array, (String, Type, Map[String, String])](
       Gen.zip(Gen.identifier,
-        genArb,
+        genFieldType,
         Gen.option(
           Gen.buildableOf2[Map, String, String](
             Gen.zip(arbitrary[String].filter(s => !s.isEmpty), arbitrary[String])), someFraction = 0.05)
@@ -65,8 +52,47 @@ object Type {
         .zipWithIndex
         .map { case ((k, t, m), i) => Field(k, t, i, m) }
         .toIndexedSeq))
+      .map(t => if (required) (!t).asInstanceOf[TStruct] else t)
 
-  def genArb: Gen[Type] = Gen.sized(genSized)
+  private val defaultRequiredGenRatio = 0.2
+
+  def genStruct: Gen[TStruct] = Gen.coin(defaultRequiredGenRatio).flatMap(preGenStruct(_, genArb))
+
+  val genOptionalStruct = preGenStruct(false, genArb)
+
+  val genRequiredStruct = preGenStruct(true, genArb)
+
+  val genInsertableStruct: Gen[TStruct] = Gen.coin(defaultRequiredGenRatio).flatMap(required =>
+    if (required)
+      preGenStruct(true, genArb)
+    else
+      preGenStruct(false, genOptional))
+
+  def genSized(size: Int, required: Boolean, genTStruct: Gen[TStruct]): Gen[Type] =
+    if (size < 1)
+      Gen.const(TStruct.empty(required))
+    else if (size < 2)
+      genScalar(required)
+    else {
+      Gen.frequency(
+        (8, genScalar(required)),
+        (1, genGenomeReferenceType(required)),
+        (2, genArb.map { TArray(_) }),
+        (2, genArb.map { TSet(_) }),
+        (2, Gen.zip(genRequired, genArb).map { case (k, v) => TDict(k, v) }),
+        (2, genTStruct.resize(size)))
+    }
+
+  def preGenArb(required: Boolean, genStruct: Gen[TStruct] = genStruct): Gen[Type] =
+    Gen.sized(genSized(_, required, genStruct))
+
+  def genArb: Gen[Type] = Gen.coin(0.2).flatMap(preGenArb(_))
+
+  val genOptional: Gen[Type] = preGenArb(false)
+
+  val genRequired: Gen[Type] = preGenArb(true)
+
+  val genInsertable: Gen[Type] = Gen.coin(0.2).flatMap(preGenArb(_, genInsertableStruct))
 
   def genWithValue: Gen[(Type, Annotation)] = for {
     s <- Gen.size
@@ -127,17 +153,17 @@ sealed abstract class Type extends BaseType with Serializable {
     if (path.nonEmpty)
       throw new AnnotationPathException(s"invalid path ${ path.mkString(".") } from type ${ this }")
     else
-      (TStruct.empty, a => null)
+      (TStruct.empty(), a => null)
   }
 
   def unsafeInsert(typeToInsert: Type, path: List[String]): (Type, UnsafeInserter) =
-    TStruct.empty.unsafeInsert(typeToInsert, path)
+    TStruct.empty().unsafeInsert(typeToInsert, path)
 
   def insert(signature: Type, fields: String*): (Type, Inserter) = insert(signature, fields.toList)
 
   def insert(signature: Type, path: List[String]): (Type, Inserter) = {
     if (path.nonEmpty)
-      TStruct.empty.insert(signature, path)
+      TStruct.empty().insert(signature, path)
     else
       (signature, (a, toIns) => toIns)
   }
@@ -1589,7 +1615,9 @@ final case class Field(name: String, typ: Type,
 }
 
 object TStruct {
-  def empty: TStruct = TStruct(Array.empty[Field])
+  private val requiredEmpty = TStruct(Array.empty[Field], true)
+  private val optionalEmpty = TStruct(Array.empty[Field], false)
+  def empty(required: Boolean = false): TStruct = if (required) requiredEmpty else optionalEmpty
 
   def apply(args: (String, Type)*): TStruct =
     TStruct(args
@@ -1721,7 +1749,7 @@ final case class TStruct(fields: IndexedSeq[Field], override val required: Boole
 
   override def delete(p: List[String]): (Type, Deleter) = {
     if (p.isEmpty)
-      (TStruct.empty, a => null)
+      (TStruct.empty(), a => null)
     else {
       val key = p.head
       val f = selfField(key) match {
@@ -1731,12 +1759,12 @@ final case class TStruct(fields: IndexedSeq[Field], override val required: Boole
       val index = f.index
       val (newFieldType, d) = f.typ.delete(p.tail)
       val newType: Type =
-        if (newFieldType == TStruct.empty)
+        if (newFieldType == TStruct.empty())
           deleteKey(key, f.index)
         else
           updateKey(key, f.index, newFieldType)
 
-      val localDeleteFromRow = newFieldType == TStruct.empty
+      val localDeleteFromRow = newFieldType == TStruct.empty()
 
       val deleter: Deleter = { a =>
         if (a == null)
@@ -1782,7 +1810,7 @@ final case class TStruct(fields: IndexedSeq[Field], override val required: Boole
           })
 
         case None =>
-          val (insertedFieldType, fieldInserter) = TStruct.empty.unsafeInsert(typeToInsert, path.tail)
+          val (insertedFieldType, fieldInserter) = TStruct.empty().unsafeInsert(typeToInsert, path.tail)
 
           (appendKey(key, insertedFieldType), { (region, offset, rvb, inserter) =>
             rvb.startStruct()
@@ -1807,7 +1835,7 @@ final case class TStruct(fields: IndexedSeq[Field], override val required: Boole
       val keyIndex = f.map(_.index)
       val (newKeyType, keyF) = f
         .map(_.typ)
-        .getOrElse(TStruct.empty)
+        .getOrElse(TStruct.empty())
         .insert(signature, p.tail)
 
       val newSignature = keyIndex match {
@@ -1844,7 +1872,7 @@ final case class TStruct(fields: IndexedSeq[Field], override val required: Boole
   def deleteKey(key: String, index: Int): Type = {
     assert(fieldIdx.contains(key))
     if (fields.length == 1)
-      TStruct.empty
+      TStruct.empty()
     else {
       val newFields = Array.fill[Field](fields.length - 1)(null)
       for (i <- 0 until index)

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -79,12 +79,12 @@ object Type {
       genScalar(required)
     else {
       Gen.frequency(
-        (8, genScalar(required)),
+        (4, genScalar(required)),
         (1, genComplexType(required)),
-        (2, genArb.map { TArray(_) }),
-        (2, genArb.map { TSet(_) }),
-        (2, Gen.zip(genRequired, genArb).map { case (k, v) => TDict(k, v) }),
-        (2, genTStruct.resize(size)))
+        (1, genArb.map { TArray(_) }),
+        (1, genArb.map { TSet(_) }),
+        (1, Gen.zip(genRequired, genArb).map { case (k, v) => TDict(k, v) }),
+        (1, genTStruct.resize(size)))
     }
 
   def preGenArb(required: Boolean, genStruct: Gen[TStruct] = genStruct): Gen[Type] =

--- a/src/main/scala/is/hail/io/bgen/BgenLoader.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenLoader.scala
@@ -77,11 +77,11 @@ object BgenLoader {
 
     new GenericDataset(hc, VSMMetadata(
       TString(),
-      saSignature = TStruct.empty,
+      saSignature = TStruct.empty(),
       TVariant(gr),
       vaSignature = signature,
       genotypeSignature = TStruct("GT" -> TCall(), "GP" -> TArray(TFloat64())),
-      globalSignature = TStruct.empty),
+      globalSignature = TStruct.empty()),
       VSMLocalValue(globalAnnotation = Annotation.empty,
         sampleIds = sampleIds,
         sampleAnnotations = Array.fill(nSamples)(Annotation.empty)),

--- a/src/main/scala/is/hail/io/plink/PlinkLoader.scala
+++ b/src/main/scala/is/hail/io/plink/PlinkLoader.scala
@@ -147,7 +147,7 @@ object PlinkLoader {
       saSignature = sampleAnnotationSignature,
       vaSignature = plinkSchema,
       vSignature = TVariant(gr),
-      globalSignature = TStruct.empty,
+      globalSignature = TStruct.empty(),
       genotypeSignature = TStruct("GT" -> TCall()),
       wasSplit = true),
       VSMLocalValue(globalAnnotation = Annotation.empty,

--- a/src/main/scala/is/hail/io/vcf/LoadGDB.scala
+++ b/src/main/scala/is/hail/io/vcf/LoadGDB.scala
@@ -150,10 +150,10 @@ object LoadGDB {
 
     new VariantSampleMatrix(hc, VSMMetadata(
       TString(),
-      TStruct.empty,
+      TStruct.empty(),
       TVariant(GenomeReference.GRCh37),
       variantAnnotationSignatures,
-      TStruct.empty,
+      TStruct.empty(),
       genotypeSignature),
       VSMLocalValue(Annotation.empty,
         sampleIds,

--- a/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -489,10 +489,10 @@ object LoadVCF {
     val gr = GenomeReference.GRCh37
     val vsmMetadata = VSMMetadata(
       TString(),
-      TStruct.empty,
+      TStruct.empty(),
       TVariant(gr),
       vaSignature,
-      TStruct.empty,
+      TStruct.empty(),
       genotypeSignature)
     val matrixType = MatrixType(vsmMetadata)
 

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -30,9 +30,9 @@ object VariantDataset {
       .toOrderedRDD
 
     val metadata = VSMMetadata(
-      saSignature = TStruct.empty,
+      saSignature = TStruct.empty(),
       vaSignature = kt.valueSignature,
-      globalSignature = TStruct.empty)
+      globalSignature = TStruct.empty())
 
     new VariantSampleMatrix[Locus, Variant, Genotype](kt.hc, metadata,
       VSMLocalValue(Annotation.empty, Array.empty[Annotation], Array.empty[Annotation]), rdd)

--- a/src/main/scala/is/hail/variant/VariantMetadata.scala
+++ b/src/main/scala/is/hail/variant/VariantMetadata.scala
@@ -29,10 +29,10 @@ object VSMFileMetadata {
     sampleAnnotations: IndexedSeq[Annotation] = null,
     globalAnnotation: Annotation = Annotation.empty,
     sSignature: Type = TString(),
-    saSignature: Type = TStruct.empty,
+    saSignature: Type = TStruct.empty(),
     vSignature: Type = TVariant(GenomeReference.GRCh37),
-    vaSignature: Type = TStruct.empty,
-    globalSignature: Type = TStruct.empty,
+    vaSignature: Type = TStruct.empty(),
+    globalSignature: Type = TStruct.empty(),
     genotypeSignature: Type = TGenotype(),
     wasSplit: Boolean = false): VSMFileMetadata = {
     VSMFileMetadata(
@@ -51,9 +51,9 @@ case class VSMFileMetadata(
 
 case class VSMMetadata(
   sSignature: Type = TString(),
-  saSignature: Type = TStruct.empty,
+  saSignature: Type = TStruct.empty(),
   vSignature: Type = TVariant(GenomeReference.GRCh37),
-  vaSignature: Type = TStruct.empty,
-  globalSignature: Type = TStruct.empty,
+  vaSignature: Type = TStruct.empty(),
+  globalSignature: Type = TStruct.empty(),
   genotypeSignature: Type = TGenotype(),
   wasSplit: Boolean = false)

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -272,10 +272,10 @@ case class VSMSubgen[RPK, RK, T >: Null](
 object VSMSubgen {
   val random = VSMSubgen[Locus, Variant, Genotype](
     sSigGen = Gen.const(TString()),
-    saSigGen = Type.genArb,
+    saSigGen = Type.genInsertable,
     vSigGen = Gen.const(TVariant(GenomeReference.GRCh37)),
-    vaSigGen = Type.genArb,
-    globalSigGen = Type.genArb,
+    vaSigGen = Type.genInsertable,
+    globalSigGen = Type.genInsertable,
     tSigGen = Gen.const(TGenotype()),
     sGen = (t: Type) => Gen.identifier.map(s => s: Annotation),
     saGen = (t: Type) => t.genValue,
@@ -292,10 +292,10 @@ object VSMSubgen {
 
   val dosage = VSMSubgen[Locus, Variant, Annotation](
     sSigGen = Gen.const(TString()),
-    saSigGen = Type.genArb,
+    saSigGen = Type.genInsertable,
     vSigGen = Gen.const(TVariant(GenomeReference.GRCh37)),
-    vaSigGen = Type.genArb,
-    globalSigGen = Type.genArb,
+    vaSigGen = Type.genInsertable,
+    globalSigGen = Type.genInsertable,
     tSigGen = Gen.const(TStruct(
       "GT" -> TCall(),
       "GP" -> TArray(TFloat64()))),
@@ -731,6 +731,8 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
 
     val aggregateOption = Aggregators.buildVariantAggregations(this, ec)
 
+    val lnewVASignature = newVASignature
+    val lVaSignature = vaSignature
     val localRowType = rowType
     insertIntoRow(() => new UnsafeRow(localRowType))(
       newVASignature, List("va"), { (ur, rv, rvb) =>
@@ -752,7 +754,9 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
           i += 1
         }
 
-        rvb.addAnnotation(newVASignature, newVA)
+        try {
+          rvb.addAnnotation(newVASignature, newVA)
+        } catch { case e: Exception => throw new RuntimeException(s"$lnewVASignature\n$lVaSignature\n$newVA") }
       })
   }
 

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -731,8 +731,6 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
 
     val aggregateOption = Aggregators.buildVariantAggregations(this, ec)
 
-    val lnewVASignature = newVASignature
-    val lVaSignature = vaSignature
     val localRowType = rowType
     insertIntoRow(() => new UnsafeRow(localRowType))(
       newVASignature, List("va"), { (ur, rv, rvb) =>
@@ -754,9 +752,7 @@ class VariantSampleMatrix[RPK, RK, T >: Null](val hc: HailContext, val metadata:
           i += 1
         }
 
-        try {
-          rvb.addAnnotation(newVASignature, newVA)
-        } catch { case e: Exception => throw new RuntimeException(s"$lnewVASignature\n$lVaSignature\n$newVA") }
+        rvb.addAnnotation(newVASignature, newVA)
       })
   }
 

--- a/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
+++ b/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
@@ -153,7 +153,7 @@ class AnnotationsSuite extends SparkSuite {
     // clear everything
     val (emptyS, d1) = vds.deleteVA()
     vds = vds.mapAnnotations(emptyS, (v, va, gs) => d1(va))
-    assert(emptyS == TStruct.empty)
+    assert(emptyS == TStruct.empty())
 
     // add to the first layer
     val toAdd = 5

--- a/src/test/scala/is/hail/methods/DeNovoSuite.scala
+++ b/src/test/scala/is/hail/methods/DeNovoSuite.scala
@@ -24,9 +24,9 @@ class DeNovoSuite extends SparkSuite {
   lazy val gen: Gen[(VariantDataset, Pedigree)] = {
     for {
       vds <- VariantSampleMatrix.gen[Locus, Variant, Genotype](hc, VSMSubgen.plinkSafeBiallelic.copy(
-        saSigGen = Gen.const(TStruct.empty),
-        vaSigGen = Gen.const(TStruct.empty),
-        globalSigGen = Gen.const(TStruct.empty),
+        saSigGen = Gen.const(TStruct.empty()),
+        vaSigGen = Gen.const(TStruct.empty()),
+        globalSigGen = Gen.const(TStruct.empty()),
         vGen = (TVariant) => (for {
           pos <- Gen.choose(100000, 100000000)
           alt <- Gen.oneOf("T", "AA") // represent indels and snps

--- a/src/test/scala/is/hail/vds/FilterAllelesSuite.scala
+++ b/src/test/scala/is/hail/vds/FilterAllelesSuite.scala
@@ -53,7 +53,7 @@ class FilterAllelesSuite extends SparkSuite {
       IndexedSeq[Annotation](null, null, null),
       null,
       TString(),
-      TStruct.empty),
+      TStruct.empty()),
       sc.parallelize(Seq(row1)).toOrderedRDD)
       .filterAlleles("aIndex == 2", subset = false, keep = false)
 
@@ -81,7 +81,7 @@ class FilterAllelesSuite extends SparkSuite {
       IndexedSeq[Annotation](null, null, null),
       null,
       TString(),
-      TStruct.empty),
+      TStruct.empty()),
       sc.parallelize(Seq(row1)).toOrderedRDD)
       .filterAlleles("aIndex == 1", subset = false, keep = false)
 
@@ -109,7 +109,7 @@ class FilterAllelesSuite extends SparkSuite {
       IndexedSeq[Annotation](null, null, null),
       null,
       TString(),
-      TStruct.empty),
+      TStruct.empty()),
       sc.parallelize(Seq(row1)).toOrderedRDD)
       .filterAlleles("aIndex == 1", subset = true, keep = false)
 
@@ -137,7 +137,7 @@ class FilterAllelesSuite extends SparkSuite {
       IndexedSeq[Annotation](null, null, null),
       null,
       TString(),
-      TStruct.empty),
+      TStruct.empty()),
       sc.parallelize(Seq(row1)).toOrderedRDD)
       .filterAlleles("aIndex == 2", subset = true, keep = false)
 
@@ -165,7 +165,7 @@ class FilterAllelesSuite extends SparkSuite {
       IndexedSeq[Annotation](null, null, null),
       null,
       TString(),
-      TStruct.empty),
+      TStruct.empty()),
       sc.parallelize(Seq(row1)).toOrderedRDD)
       .filterAlleles("aIndex == 2", subset = true, keep = false, filterAlteredGenotypes = true)
 
@@ -190,7 +190,7 @@ class FilterAllelesSuite extends SparkSuite {
       IndexedSeq[Annotation](null, null, null),
       null,
       TString(),
-      TStruct.empty),
+      TStruct.empty()),
       sc.parallelize(Seq(row1)).toOrderedRDD)
       .filterAlleles("aIndex == 2", variantExpr = "va = newToOld", keep = false, subset = false)
 


### PR DESCRIPTION
Insertable types are those that can have .insert called.

In particular, we cannot insert into an optional struct
containing required fields because there is no sensible
defaults for those required fields.

I also did some clean up of the Type generators while
implementing this