### PR TITLE
include contigs in export vcf header

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -1615,6 +1615,9 @@ class VariantDataset(HistoryMixin):
         Sets and Arrays are output with the same comma-separated format.
         Lastly, fields of type Boolean are allowed in ``va.info`` to generate INFO fields of type Flag.
 
+        Hail also exports the name of the genome reference (e.g. ``GRCh37``), as well as contig names and lengths,
+        as VCF header lines.
+
         Consider the workflow of importing a VCF to VDS and immediately exporting VDS to VCF:
 
         >>> vds.export_vcf('output/example_out.vcf')

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -8,7 +8,7 @@ from hail.typ import Type, TGenotype, TString, TVariant, TArray
 from hail.typecheck import *
 from hail.java import *
 from hail.keytable import KeyTable
-from hail.representation import Interval, Pedigree, Variant
+from hail.representation import Interval, Pedigree, Variant, GenomeReference
 from hail.utils import Summary, wrap_to_list, hadoop_read
 from hail.kinshipMatrix import KinshipMatrix
 from hail.ldMatrix import LDMatrix
@@ -1615,8 +1615,8 @@ class VariantDataset(HistoryMixin):
         Sets and Arrays are output with the same comma-separated format.
         Lastly, fields of type Boolean are allowed in ``va.info`` to generate INFO fields of type Flag.
 
-        Hail also exports the name of the genome reference (e.g. ``GRCh37``), as well as contig names and lengths,
-        as VCF header lines.
+        Hail also exports the name, length, and assembly of each contig as a VCF header line, where the assembly is set
+        to the :class:`.GenomeReference` name.
 
         Consider the workflow of importing a VCF to VDS and immediately exporting VDS to VCF:
 

--- a/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -241,7 +241,7 @@ object ExportVCF {
       val sb = new StringBuilder()
 
       sb.append("##fileformat=VCFv4.2\n")
-      sb.append(s"##hailversion=${hail.HAIL_PRETTY_VERSION}\n")
+      sb.append(s"##hailversion=${ hail.HAIL_PRETTY_VERSION }\n")
       sb.append(s"##reference=${ gr.name }\n")
       
       gr.contigs.foreachBetween { c =>

--- a/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -232,7 +232,8 @@ object ExportVCF {
       } else
         TStruct.empty()
     
-    val gr = vsm.vSignature.asInstanceOf[TVariant].gr.asInstanceOf[GenomeReference] 
+    val gr = vsm.vSignature.asInstanceOf[TVariant].gr.asInstanceOf[GenomeReference]
+    val assembly = gr.name
     
     val localNSamples = vsm.nSamples
     val hasSamples = localNSamples > 0
@@ -242,13 +243,14 @@ object ExportVCF {
 
       sb.append("##fileformat=VCFv4.2\n")
       sb.append(s"##hailversion=${ hail.HAIL_PRETTY_VERSION }\n")
-      sb.append(s"##reference=${ gr.name }\n")
       
       gr.contigs.foreachBetween { c =>
         sb.append("##contig=<ID=")
         sb.append(c)
         sb.append(",length=")
         sb.append(gr.contigLength(c))
+        sb.append(",assembly=")
+        sb.append(assembly)
         sb += '>'
       }(sb += '\n')
       

--- a/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -4,7 +4,7 @@ import is.hail
 import is.hail.annotations.MemoryBuffer
 import is.hail.expr._
 import is.hail.utils._
-import is.hail.variant.{Genotype, Variant, VariantSampleMatrix}
+import is.hail.variant.{GenomeReference, Genotype, Variant, VariantSampleMatrix}
 
 import scala.io.Source
 import scala.reflect.ClassTag
@@ -232,6 +232,8 @@ object ExportVCF {
       } else
         TStruct.empty()
     
+    val gr = vsm.vSignature.asInstanceOf[TVariant].gr.asInstanceOf[GenomeReference] 
+    
     val localNSamples = vsm.nSamples
     val hasSamples = localNSamples > 0
 
@@ -240,7 +242,18 @@ object ExportVCF {
 
       sb.append("##fileformat=VCFv4.2\n")
       sb.append(s"##hailversion=${hail.HAIL_PRETTY_VERSION}\n")
-
+      sb.append(s"##reference=${ gr.name }\n")
+      
+      gr.contigs.foreachBetween { c =>
+        sb.append("##contig=<ID=")
+        sb.append(c)
+        sb.append(",length=")
+        sb.append(gr.contigLength(c))
+        sb += '>'
+      }(sb += '\n')
+      
+      sb += '\n'
+      
       tg.fields.foreachBetween { f =>
         sb.append("##FORMAT=<ID=")
         sb.append(f.name)

--- a/src/test/scala/is/hail/io/ExportVCFSuite.scala
+++ b/src/test/scala/is/hail/io/ExportVCFSuite.scala
@@ -324,22 +324,12 @@ class ExportVCFSuite extends SparkSuite {
   @Test def testContigs() {
     val vds = hc.importVCF("src/test/resources/sample.vcf", dropSamples = true)
 
-    var found = 0
     val out = tmpDir.createLocalTempFile("foo", "vcf")
     vds.exportVCF(out)
     hadoopConf.readLines(out) { lines =>
-      lines.foreach { l =>
-        if (l.value.startsWith("##reference")) {
-          found += 1
-          l.value == "##reference=GRCh37"
-        }
-        else if (l.value.startsWith("##contig=<ID=10")) {
-          found += 1
-          l.value == "##contig=<ID=10,length=135534747>"
-        }
+      lines.filter(_.value.startsWith("##contig=<ID=10")).foreach { l =>
+        l.value == "##contig=<ID=10,length=135534747,assembly=GRCh37>"
       }
     }
-      
-    assert(found == 2)
   }
 }

--- a/src/test/scala/is/hail/io/ExportVCFSuite.scala
+++ b/src/test/scala/is/hail/io/ExportVCFSuite.scala
@@ -320,4 +320,26 @@ class ExportVCFSuite extends SparkSuite {
 
     p.check()
   }
+  
+  @Test def testContigs() {
+    val vds = hc.importVCF("src/test/resources/sample.vcf", dropSamples = true)
+
+    var found = 0
+    val out = tmpDir.createLocalTempFile("foo", "vcf")
+    vds.exportVCF(out)
+    hadoopConf.readLines(out) { lines =>
+      lines.foreach { l =>
+        if (l.value.startsWith("##reference")) {
+          found += 1
+          l.value == "##reference=GRCh37"
+        }
+        else if (l.value.startsWith("##contig=<ID=10")) {
+          found += 1
+          l.value == "##contig=<ID=10,length=135534747>"
+        }
+      }
+    }
+      
+    assert(found == 2)
+  }
 }


### PR DESCRIPTION
- added reference and contig names/lengths to header in export_vcf
- added line in docs
- added a test
- renamed ExportVcfSuite to ExportVCFSuite to match classname and ImportVCFSuite

@jigold is going to update GenomeReference to capture MD5, at which point I'll make a PR to export other metadata.