### PR TITLE
RV-ify naive coalesce.

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -4233,7 +4233,7 @@ class VariantDataset(HistoryMixin):
 
           :py:meth:`~hail.VariantDataset.naive_coalesce` simply combines adjacent partitions to achieve the desired number.  It does not attempt to rebalance, unlike :py:meth:`~hail.VariantDataset.repartition`, so it can produce a heavily unbalanced dataset.  An unbalanced dataset can be inefficient to operate on because the work is not evenly distributed across partitions.
 
-        :param int max_partitions: Desired number of partitions.  If the current number of partitions is less than ``max_partitions``, do nothing.
+        :param int max_partitions: Desired number of partitions.  If the current number of partitions is less than or equal to ``max_partitions``, do nothing.
 
         :return: Variant dataset with the number of partitions equal to at most ``max_partitions``
         :rtype: :class:`.VariantDataset`

--- a/src/main/scala/is/hail/sparkextras/OrderedRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/OrderedRDD.scala
@@ -449,25 +449,6 @@ class OrderedRDD[PK, K, V] private(rdd: RDD[(K, V)], val orderedPartitioner: Ord
     }
   }
 
-  def naiveCoalesce(maxPartitions: Int): OrderedRDD[PK, K, V] = {
-    val n = orderedPartitioner.numPartitions
-    if (maxPartitions > n)
-      return this
-
-    val newN = maxPartitions
-    val newNParts = Array.tabulate(newN)(i => (n - i + newN - 1) / newN)
-    assert(newNParts.sum == n)
-    assert(newNParts.forall(_ > 0))
-
-    val newPartEnd = newNParts.scanLeft(-1)( _ + _ ).tail
-    assert(newPartEnd.last == n - 1)
-
-    val newRangeBounds = newPartEnd.init.map(orderedPartitioner.rangeBounds)
-
-    new OrderedRDD[PK, K, V](new BlockedRDD(rdd, newPartEnd),
-      new OrderedPartitioner(newRangeBounds, newN))
-  }
-
   def filterIntervals(intervals: IntervalTree[PK, _]): OrderedRDD[PK, K, V] = {
 
     import kOk.pkOrd

--- a/src/main/scala/is/hail/sparkextras/OrderedRDD2.scala
+++ b/src/main/scala/is/hail/sparkextras/OrderedRDD2.scala
@@ -762,7 +762,7 @@ class OrderedRDD2 private(
 
   def naiveCoalesce(maxPartitions: Int): OrderedRDD2 = {
     val n = orderedPartitioner.numPartitions
-    if (maxPartitions > n)
+    if (maxPartitions >= n)
       return this
 
     val newN = maxPartitions

--- a/src/main/scala/is/hail/sparkextras/OrderedRDD2.scala
+++ b/src/main/scala/is/hail/sparkextras/OrderedRDD2.scala
@@ -759,6 +759,30 @@ class OrderedRDD2 private(
     rdd: RDD[RegionValue] = rdd): OrderedRDD2 = {
     OrderedRDD2(typ, orderedPartitioner, rdd)
   }
+
+  def naiveCoalesce(maxPartitions: Int): OrderedRDD2 = {
+    val n = orderedPartitioner.numPartitions
+    if (maxPartitions > n)
+      return this
+
+    val newN = maxPartitions
+    val newNParts = Array.tabulate(newN)(i => (n - i + newN - 1) / newN)
+    assert(newNParts.sum == n)
+    assert(newNParts.forall(_ > 0))
+
+    val newPartEnd = newNParts.scanLeft(-1)( _ + _ ).tail
+    assert(newPartEnd.last == n - 1)
+
+    val newRangeBounds = UnsafeIndexedSeq(
+      TArray(typ.pkType),
+      newPartEnd.init.map(orderedPartitioner.rangeBounds))
+
+    OrderedRDD2(
+      typ,
+      new OrderedPartitioner2(newN, typ.partitionKey, typ.kType, newRangeBounds),
+      new BlockedRDD(rdd, newPartEnd))
+  }
+
 }
 
 class OrderedDependency2(left: OrderedRDD2, right: OrderedRDD2) extends NarrowDependency[RegionValue](right) {

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -2123,7 +2123,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
   def unpersist(): VariantSampleMatrix = copy2(rdd2 = rdd2.unpersist2())
 
   def naiveCoalesce(maxPartitions: Int): VariantSampleMatrix =
-    copy(rdd = rdd.naiveCoalesce(maxPartitions))
+    copy2(rdd2 = rdd2.naiveCoalesce(maxPartitions))
 
   /**
     * @param filterExpr filter expression involving v (Variant), va (variant annotations), s (sample),


### PR DESCRIPTION
Well, OrderedRDD2-ify.

@jbloom22 This needed by Robert to export the cohorts.  Timely review appreciate.