### PR TITLE
Added split_multi_generic.

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -4786,8 +4786,8 @@ class VariantDataset(HistoryMixin):
 
         >>> vds.split_multi_generic(
         ...   'va.aIndex = aIndex, va.wasSplit = wasSplit',
-        ...   'let
-        ...         newgt = downcode(Call(g.GT), aIndex) and
+        ...   '''let
+        ...         newgt = downcode(g.GT, aIndex) and
         ...         newad = if (isDefined(g.AD))
         ...             let sum = g.AD.sum() and adi = g.AD[aIndex] in [sum - adi, adi]
         ...           else
@@ -4797,7 +4797,7 @@ class VariantDataset(HistoryMixin):
         ...           else
         ...             NA: Array[Int] and
         ...         newgq = gqFromPL(newpl)
-        ...    in { GT: newgt, AD: newad, DP: g.DP, GQ: newgq, PL: newPL }')
+        ...    in { GT: newgt, AD: newad, DP: g.DP, GQ: newgq, PL: newPL }''')
 
         **Notes**
 

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -4786,7 +4786,7 @@ class VariantDataset(HistoryMixin):
 
         >>> multiallelic_generic_vds.split_multi_generic(
         ...   'va.aIndex = aIndex, va.wasSplit = wasSplit',
-        ...   '''let
+        ...   '''g = let
         ...         newgt = downcode(g.GT, aIndex) and
         ...         newad = if (isDefined(g.AD))
         ...             let sum = g.AD.sum() and adi = g.AD[aIndex] in [sum - adi, adi]

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -4779,9 +4779,10 @@ class VariantDataset(HistoryMixin):
 
         **Example**
 
-        :py:meth:`~hail.VariantDataset.split_multi`, which spilts
-        multiallelic variants and updates the genotype annotations by
-        downcoding the genotype, is implemented as:
+        :py:meth:`~hail.VariantDataset.split_multi`, which splits
+        multiallelic variants for the HTS genotype schema and updates
+        the genotype annotations by downcoding the genotype, is
+        implemented as:
 
         >>> vds.split_multi_generic(
         ...   'va.aIndex = aIndex, va.wasSplit = wasSplit',

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -4786,17 +4786,17 @@ class VariantDataset(HistoryMixin):
         >>> vds.split_multi_generic(
         ...   'va.aIndex = aIndex, va.wasSplit = wasSplit',
         ...   'let
-        ...         newgt = downcode(Call(g.gt), aIndex) and
-        ...         newad = if (isDefined(g.ad))
-        ...             let sum = g.ad.sum() and adi = g.ad[aIndex] in [sum - adi, adi]
+        ...         newgt = downcode(Call(g.GT), aIndex) and
+        ...         newad = if (isDefined(g.AD))
+        ...             let sum = g.AD.sum() and adi = g.AD[aIndex] in [sum - adi, adi]
         ...           else
         ...             NA: Array[Int] and
-        ...         newpl = if (isDefined(g.pl))
-        ...             range(3).map(i => range(g.pl.length).filter(j => downcode(Call(j), aIndex) == Call(i)).map(j => g.pl[j]).min())
+        ...         newpl = if (isDefined(g.PL))
+        ...             range(3).map(i => range(g.PL.length).filter(j => downcode(Call(j), aIndex) == Call(i)).map(j => g.PL[j]).min())
         ...           else
         ...             NA: Array[Int] and
         ...         newgq = gqFromPL(newpl)
-        ...    in { GT: newgt, AD: newad, DP: g.dp, GQ: newgq, PL: newPL }')
+        ...    in { GT: newgt, AD: newad, DP: g.DP, GQ: newgq, PL: newPL }')
 
         **Notes**
 

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -4784,7 +4784,7 @@ class VariantDataset(HistoryMixin):
         the genotype annotations by downcoding the genotype, is
         implemented as:
 
-        >>> vds.split_multi_generic(
+        >>> multiallelic_generic_vds.split_multi_generic(
         ...   'va.aIndex = aIndex, va.wasSplit = wasSplit',
         ...   '''let
         ...         newgt = downcode(g.GT, aIndex) and

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -4863,7 +4863,7 @@ class VariantDataset(HistoryMixin):
             PL: Array[!Int32].
           }
         
-        For generic genotype schema, use :py:meth:`~hail.VariantDataset.split_multi`.
+        For generic genotype schema, use :py:meth:`~hail.VariantDataset.split_multi_generic`.
 
         **Examples**
 

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -166,9 +166,8 @@ class VariantDataset(HistoryMixin):
 
     @handle_py4j
     @record_method
-    @typecheck_method(expr=oneof(strlike, listof(strlike)),
-               propagate_gq=bool)
-    def annotate_alleles_expr(self, expr, propagate_gq=False):
+    @typecheck_method(expr=oneof(strlike, listof(strlike)))
+    def annotate_alleles_expr(self, expr):
         """Annotate alleles with expression.
 
         .. include:: _templates/req_tvariant_tgenotype.rst
@@ -189,7 +188,6 @@ class VariantDataset(HistoryMixin):
 
         :param expr: Annotation expression.
         :type expr: str or list of str
-        :param bool propagate_gq: Propagate GQ instead of computing from (split) PL.
 
         :return: Annotated variant dataset.
         :rtype: :py:class:`.VariantDataset`
@@ -198,7 +196,7 @@ class VariantDataset(HistoryMixin):
         if isinstance(expr, list):
             expr = ",".join(expr)
 
-        jvds = self._jvdf.annotateAllelesExpr(expr, propagate_gq)
+        jvds = self._jvdf.annotateAllelesExpr(expr)
         return VariantDataset(self.hc, jvds)
 
     @handle_py4j
@@ -4772,11 +4770,99 @@ class VariantDataset(HistoryMixin):
 
     @handle_py4j
     @record_method
-    @typecheck_method(propagate_gq=bool,
+    @typecheck_method(variant_expr=strlike,
+                      genotype_expr=strlike,
                       keep_star_alleles=bool,
                       left_aligned=bool)
-    def split_multi(self, propagate_gq=False, keep_star_alleles=False, left_aligned=False):
+    def split_multi_generic(self, variant_expr, genotype_expr, keep_star_alleles=False, left_aligned=False):
         """Split multiallelic variants.
+
+        **Example**
+
+        :py:meth:`~hail.VariantDataset.split_multi`, which spilts
+        multiallelic variants and updates the genotype annotations by
+        downcoding the genotype, is implemented as:
+
+        >>> vds.split_multi_generic(
+        ...   'va.aIndex = aIndex, va.wasSplit = wasSplit',
+        ...   'let
+        ...         newgt = downcode(Call(g.gt), aIndex) and
+        ...         newad = if (isDefined(g.ad))
+        ...             let sum = g.ad.sum() and adi = g.ad[aIndex] in [sum - adi, adi]
+        ...           else
+        ...             NA: Array[Int] and
+        ...         newpl = if (isDefined(g.pl))
+        ...             range(3).map(i => range(g.pl.length).filter(j => downcode(Call(j), aIndex) == Call(i)).map(j => g.pl[j]).min())
+        ...           else
+        ...             NA: Array[Int] and
+        ...         newgq = gqFromPL(newpl)
+        ...    in { GT: newgt, AD: newad, DP: g.dp, GQ: newgq, PL: newPL }')
+
+        **Notes**
+
+        ``variant_expr`` is an annotation expression to update the
+        variant annotations for each output variant.  It updates `va`
+        and is evaluated in the following namespace:
+
+        - ``global``: global annotations
+        - ``v``: :ref:`variant(GR)`: the old variant
+        - ``newV``: :ref:`variant(GR)`: the new, split variant
+        - ``va``: the old variant annotations
+        - ``aIndex``: the index of the input allele to the output variant
+        - ``wasSplit``: True if the original variant was multiallelic
+
+        ``genotype_expr`` is an annotation expression to update the
+        genotype annotations for each output variant.  It updates `g`
+        and is evaluated in the following namespace:
+
+        - ``global``: global annotations
+        - ``v``: :ref:`variant(GR)`: the old variant
+        - ``newV``: :ref:`variant(GR)`: the new, split variant
+        - ``va``: the old variant annotations
+        - ``aIndex``: the index of the input allele to the output variant
+        - ``wasSplit``: True if the original variant was multiallelic
+        - ``s``: the sample
+        - ``sa``: the sample annotations
+        - ``g``: the old genotype annotations
+
+        Note, the variant and genotype annotations are updated for all
+        output variants, even those that were originally biallelic.
+        This is because the updates can change the variant annotation
+        and genotype schemas, which must be consistent across
+        variants.
+
+        :param str variant_expr: Annotation expressions to update the variant annotations for the new, split variants.
+
+        :param str genotype_expr: Annotation expressions to update the genotype annotations for the new, split variants.
+        
+        :param bool keep_star_alleles: Do not filter out * alleles.
+        :param bool left_aligned: If True, variants are assumed to be
+          left aligned and have unique loci.  This avoids a shuffle.
+          If the assumption is violated, an error is generated.
+
+        """
+
+        jvds = self._jvdf.splitMultiGeneric(variant_expr, genotype_expr, keep_star_alleles, left_aligned)
+        return VariantDataset(self.hc, jvds)
+
+    @handle_py4j
+    @record_method
+    @typecheck_method(keep_star_alleles=bool,
+                      left_aligned=bool)
+    def split_multi(self, keep_star_alleles=False, left_aligned=False):
+        """Split multiallelic variants for :py:meth:`.VariantDataset.genotype_schema` :py:class:`~hail.expr.TGenotype` or the HTS schema:
+
+        .. code-block:: text
+
+          Struct {
+            GT: Call,
+            AD: Array[!Int32],
+            DP: Int32,
+            GQ: Int32,
+            PL: Array[!Int32].
+          }
+        
+        For generic genotype schema, use :py:meth:`~hail.VariantDataset.split_multi`.
 
         **Examples**
 
@@ -4824,9 +4910,7 @@ class VariantDataset(HistoryMixin):
         is the minimum over multiallelic PL entries for genotypes that
         map to that genotype.
 
-        By default, GQ is recomputed from PL. If ``propagate_gq=True``
-        is passed, the biallelic GQ field is simply the multiallelic
-        GQ field, that is, genotype qualities are unchanged.
+        GQ is recomputed from PL.
 
         Here is a second example for a het non-ref
 
@@ -4884,12 +4968,6 @@ class VariantDataset(HistoryMixin):
            into two variants: 1:100:A:T with ``aIndex = 1`` and
            1:100:A:C with ``aIndex = 2``.
 
-        :param bool propagate_gq: Set the GQ of output (split)
-          genotypes to be the GQ of the input (multi-allelic) variants
-          instead of recompute GQ as the difference between the two
-          smallest PL values.  Intended to be used in conjunction with
-          ``import_vcf(store_gq=True)``.  This option will be obviated
-          in the future by generic genotype schemas.  Experimental.
         :param bool keep_star_alleles: Do not filter out * alleles.
         :param bool left_aligned: If True, variants are assumed to be
           left aligned and have unique loci.  This avoids a shuffle.
@@ -4899,7 +4977,7 @@ class VariantDataset(HistoryMixin):
         :rtype: :py:class:`.VariantDataset`
         """
 
-        jvds = self._jvdf.splitMulti(propagate_gq, keep_star_alleles, left_aligned)
+        jvds = self._jvdf.splitMulti(keep_star_alleles, left_aligned)
         return VariantDataset(self.hc, jvds)
 
     @handle_py4j

--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -4797,7 +4797,7 @@ class VariantDataset(HistoryMixin):
         ...           else
         ...             NA: Array[Int] and
         ...         newgq = gqFromPL(newpl)
-        ...    in { GT: newgt, AD: newad, DP: g.DP, GQ: newgq, PL: newPL }''')
+        ...    in { GT: newgt, AD: newad, DP: g.DP, GQ: newgq, PL: newpl }''')
 
         **Notes**
 

--- a/python/hail/docs/conf.py
+++ b/python/hail/docs/conf.py
@@ -90,6 +90,9 @@ hc = HailContext(log="output/hail.log", quiet=True)
  .split_multi()
  .write("data/example2.vds", overwrite=True))
 
+(hc.import_vcf("data/sample.vcf.bgz", generic=True)
+ .write("data/example2.multi.generic.vds", overwrite=True))
+
 (hc.import_vcf('data/sample.vcf.bgz')
  .split_multi()
  .variant_qc()
@@ -106,6 +109,8 @@ hc = HailContext(log="output/hail.log", quiet=True)
  .write('data/example_burden.vds', overwrite=True))
 
 vds = hc.read('data/example.vds')
+
+multiallelic_generic_vds = hc.read('data/example2.multi.generic.vds')
 
 vds.split_multi().ld_matrix().write("data/ld_matrix")
 

--- a/python/hail2/dataset.py
+++ b/python/hail2/dataset.py
@@ -174,7 +174,7 @@ class VariantDataset(DatasetTemplate):
     ...                                      x2 = vds_ann.gs.fraction(lambda g, _: False),
     ...                                      x3 = vds_ann.gs.filter(lambda g, _: True).count(),
     ...                                      x4 = vds_ann.va.info.AC + vds_ann.globals.foo)
-    ...               .annotate_alleles(propagate_gq=False, a1 = vds_ann.gs.count()))
+    ...               .annotate_alleles(a1 = vds_ann.gs.count()))
 
     >>> vds_ann = vds_ann.annotate_samples(apple = 6)
     >>> vds_ann = vds_ann.annotate_samples(x1 = vds_ann.gs.count(),
@@ -243,7 +243,7 @@ class VariantDataset(DatasetTemplate):
                       kwargs=dictof(strlike, anytype))
     def annotate_alleles(self, propagate_gq=False, **kwargs):
         exprs = ", ".join(["va." + k + " = " + to_expr(v) for k, v in kwargs.items()])
-        jvds = self._jvdf.annotateAllelesExpr(exprs, propagate_gq)
+        jvds = self._jvdf.annotateAllelesExpr(exprs)
         return VariantDataset(self.hc, jvds)
 
     @handle_py4j

--- a/python/hail2/tests.py
+++ b/python/hail2/tests.py
@@ -241,7 +241,7 @@ class DatasetTests(unittest.TestCase):
                                      x2 = vds.gs.fraction(lambda g, _: False),
                                      x3 = vds.gs.filter(lambda g, _: True).count(),
                                      x4 = vds.va.info.AC + vds.globals.foo)
-               .annotate_alleles(propagate_gq=False, a1 = vds.gs.count()))
+               .annotate_alleles(a1 = vds.gs.count()))
 
         expected_fields = [(fd.name, fd.typ) for fd in orig_variant_schema.fields] + \
                           [('x1', TInt64()),

--- a/src/main/scala/is/hail/methods/SplitMulti.scala
+++ b/src/main/scala/is/hail/methods/SplitMulti.scala
@@ -95,8 +95,8 @@ class SplitMultiPartitionContext(
 
     val gs = ur.getAs[IndexedSeq[Any]](3)
 
-    splitVariants.iterator.zipWithIndex
-      .map { case ((svj, i), j) =>
+    splitVariants.iterator
+      .map { case (svj, i) =>
         splitRegion.clear()
         rvb.set(splitRegion)
         rvb.start(newRowType)

--- a/src/main/scala/is/hail/methods/SplitMulti.scala
+++ b/src/main/scala/is/hail/methods/SplitMulti.scala
@@ -104,15 +104,15 @@ class SplitMultiPartitionContext(
         rvb.addAnnotation(newRowType.fieldType(0), svj.locus)
         rvb.addAnnotation(newRowType.fieldType(1), svj)
 
-        vAnnotator.ec.setAll(globalAnnotation, svj, va, i, wasSplit)
+        vAnnotator.ec.setAll(globalAnnotation, v, svj, va, i, wasSplit)
         rvb.addAnnotation(newRowType.fieldType(2), vAnnotator.insert(va))
 
         rvb.startArray(nSamples) // gs
-        gAnnotator.ec.setAll(globalAnnotation, svj, va, i, wasSplit)
+        gAnnotator.ec.setAll(globalAnnotation, v, svj, va, i, wasSplit)
         var k = 0
         while (k < nSamples) {
           val g = gs(k)
-          gAnnotator.ec.set(5, g)
+          gAnnotator.ec.set(6, g)
           rvb.addAnnotation(newRowType.fieldType(3).asInstanceOf[TArray].elementType, gAnnotator.insert(g))
           k += 1
         }
@@ -138,18 +138,20 @@ class SplitMulti(vsm: VariantSampleMatrix, variantExpr: String, genotypeExpr: St
   val vEC = EvalContext(Map(
     "global" -> (0, vsm.globalSignature),
     "v" -> (1, vsm.vSignature),
-    "va" -> (2, vsm.vaSignature),
-    "aIndex" -> (3, TInt32()),
-    "wasSplit" -> (4, TBoolean())))
+    "newV" -> (2, vsm.vSignature),
+    "va" -> (3, vsm.vaSignature),
+    "aIndex" -> (4, TInt32()),
+    "wasSplit" -> (5, TBoolean())))
   val vAnnotator = new ExprAnnotator(vEC, vsm.vaSignature, variantExpr, Some(Annotation.VARIANT_HEAD))
 
   val gEC = EvalContext(Map(
     "global" -> (0, vsm.globalSignature),
     "v" -> (1, vsm.vSignature),
-    "va" -> (2, vsm.vaSignature),
-    "aIndex" -> (3, TInt32()),
-    "wasSplit" -> (4, TBoolean()),
-    "g" -> (5, vsm.genotypeSignature)))
+    "newV" -> (2, vsm.vSignature),
+    "va" -> (3, vsm.vaSignature),
+    "aIndex" -> (4, TInt32()),
+    "wasSplit" -> (5, TBoolean()),
+    "g" -> (6, vsm.genotypeSignature)))
   val gAnnotator = new ExprAnnotator(gEC, vsm.genotypeSignature, genotypeExpr, Some(Annotation.GENOTYPE_HEAD))
 
   val newMatrixType = vsm.matrixType.copy(vaType = vAnnotator.newT, genotypeType = gAnnotator.newT)

--- a/src/main/scala/is/hail/variant/Genotype.scala
+++ b/src/main/scala/is/hail/variant/Genotype.scala
@@ -120,6 +120,13 @@ abstract class Genotype extends Serializable {
 }
 
 object Genotype {
+  val htsGenotypeType: TStruct = TStruct(
+    "GT" -> TCall(),
+    "AD" -> TArray(!TInt32()),
+    "DP" -> TInt32(),
+    "GQ" -> TInt32(),
+    "PL" -> TArray(!TInt32()))
+
   def unboxedGT(g: Genotype): Int = if (g != null) g._unboxedGT else -1
 
   def unboxedAD(g: Genotype): Array[Int] = if (g != null) g._unboxedAD else null

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -41,7 +41,7 @@ object VariantDataset {
 
 class VariantDatasetFunctions(private val vsm: VariantSampleMatrix) extends AnyVal {
 
-  def annotateAllelesExpr(expr: String, propagateGQ: Boolean = false): VariantDataset = {
+  def annotateAllelesExpr(expr: String): VariantDataset = {
 
     val splitmulti = new SplitMulti(vsm,
       "va.aIndex = aIndex, va.wasSplit = wasSplit",
@@ -56,7 +56,7 @@ g = let
         range(3).map(i => range(g.pl.length).filter(j => downcode(Call(j), aIndex) == Call(i)).map(j => g.pl[j]).min())
       else
         NA: Array[Int] and
-    newgq = ${ if (propagateGQ) "g.gq" else "gqFromPL(newpl)" }
+    newgq = gqFromPL(newpl)
   in Genotype(v, newgt, newad, g.dp, newgq, newpl)
     """, keepStar = true, leftAligned = false)
 
@@ -570,63 +570,47 @@ g = let newgt = ${ filterGT("gtIndex(oldToNew[gtj(g.gt)], oldToNew[gtk(g.gt)])")
     writeGenFile()
   }
 
-  def splitMulti(propagateGQ: Boolean = false, keepStar: Boolean = false, leftAligned: Boolean = false): VariantSampleMatrix = {
-    if (vsm.genotypeSignature.isOfType(TGenotype())) {
-      vsm.splitMulti("va.aIndex = aIndex, va.wasSplit = wasSplit", s"""
-g = let
-    newgt = downcode(Call(g.gt), aIndex) and
-    newad = if (isDefined(g.ad))
-        let sum = g.ad.sum() and adi = g.ad[aIndex] in [sum - adi, adi]
-      else
-        NA: Array[Int] and
-    newpl = if (isDefined(g.pl))
-        range(3).map(i => range(g.pl.length).filter(j => downcode(Call(j), aIndex) == Call(i)).map(j => g.pl[j]).min())
-      else
-        NA: Array[Int] and
-    newgq = ${ if (propagateGQ) "g.gq" else "gqFromPL(newpl)" }
-  in Genotype(v, newgt, newad, g.dp, newgq, newpl)
-    """,
+  def splitMulti(keepStar: Boolean = false, leftAligned: Boolean = false): VariantSampleMatrix = {
+    val gType = vsm.genotypeSignature
+    if (gType.isOfType(TGenotype())) {
+      vsm.splitMultiGeneric("va.aIndex = aIndex, va.wasSplit = wasSplit",
+        s"""g =
+    let
+      newgt = downcode(Call(g.gt), aIndex) and
+      newad = if (isDefined(g.ad))
+          let sum = g.ad.sum() and adi = g.ad[aIndex] in [sum - adi, adi]
+        else
+          NA: Array[Int] and
+      newpl = if (isDefined(g.pl))
+          range(3).map(i => range(g.pl.length).filter(j => downcode(Call(j), aIndex) == Call(i)).map(j => g.pl[j]).min())
+        else
+          NA: Array[Int] and
+      newgq = gqFromPL(newpl)
+    in Genotype(newV, newgt, newad, g.dp, newgq, newpl)""",
         keepStar, leftAligned)
     } else {
-      def hasGenotypeFieldOfType(name: String, expected: Type): Boolean = {
-        vsm.genotypeSignature match {
-          case t: TStruct =>
-            t.selfField(name) match {
-              case Some(f) => f.typ.isOfType(expected)
-              case None => false
-            }
-          case _ => false
-        }
-      }
+      if (!vsm.genotypeSignature.isOfType(Genotype.htsGenotypeType))
+        fatal(s"split_multi: genotype_schema must be TGenotype or the HTS genotype schema, found: ${ vsm.genotypeSignature }")
 
-      val b = new ArrayBuilder[String]()
-      if (hasGenotypeFieldOfType("GT", TCall()))
-        b += "g.GT = downcode(g.GT, aIndex)"
-      if (hasGenotypeFieldOfType("AD", TArray(!TInt32())))
-        b += """
-g.AD = if (isDefined(g.AD))
-  let sum = g.AD.sum() and adi = g.AD[aIndex] in [sum - adi, adi]
-else
-  NA: Array[Int]
-        """
-      if (hasGenotypeFieldOfType("PL", TArray(!TInt32())))
-        b += """
-g.PL = if (isDefined(g.PL))
-  range(3).map(i => range(g.PL.length).filter(j => downcode(Call(j), aIndex) == Call(i)).map(j => g.PL[j]).min())
-else
-  NA: Array[Int]
-        """
-
-      var vsm2 = vsm.splitMulti("va.aIndex = aIndex, va.wasSplit = wasSplit", b.result().mkString(","), keepStar, leftAligned)
-
-      if (!propagateGQ && hasGenotypeFieldOfType("GQ", TInt32())) {
-        vsm2.annotateGenotypesExpr("g.GQ = gqFromPL(g.PL)")
-      } else
-        vsm2
+      vsm.splitMultiGeneric("va.aIndex = aIndex, va.wasSplit = wasSplit",
+        s"""g =
+    let
+      newgt = downcode(Call(g.GT), aIndex) and
+      newad = if (isDefined(g.AD))
+          let sum = g.AD.sum() and adi = g.AD[aIndex] in [sum - adi, adi]
+        else
+          NA: Array[Int] and
+      newpl = if (isDefined(g.PL))
+          range(3).map(i => range(g.PL.length).filter(j => downcode(Call(j), aIndex) == Call(i)).map(j => g.PL[j]).min())
+        else
+          NA: Array[Int] and
+      newgq = gqFromPL(newpl)
+    in { GT: newgt, AD: newad, DP: g.DP, GQ: newgq, PL: newPL }""",
+        keepStar, leftAligned)
     }
   }
 
-  def splitMulti(variantExpr: String, genotypeExpr: String, keepStar: Boolean, leftAligned: Boolean): VariantSampleMatrix = {
+  def splitMultiGeneric(variantExpr: String, genotypeExpr: String, keepStar: Boolean, leftAligned: Boolean): VariantSampleMatrix = {
     val splitmulti = new SplitMulti(vsm, variantExpr, genotypeExpr, keepStar, leftAligned)
     splitmulti.split()
   }

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -57,7 +57,7 @@ g = let
       else
         NA: Array[Int] and
     newgq = gqFromPL(newpl)
-  in Genotype(v, newgt, newad, g.dp, newgq, newpl)
+  in Genotype(newV, newgt, newad, g.dp, newgq, newpl)
     """, keepStar = true, leftAligned = false)
 
     val splitMatrixType = splitmulti.newMatrixType

--- a/src/test/scala/is/hail/methods/AnnotateAllelesSuite.scala
+++ b/src/test/scala/is/hail/methods/AnnotateAllelesSuite.scala
@@ -9,7 +9,7 @@ class AnnotateAllelesSuite extends SparkSuite {
 
     val vds = hc.importVCF("src/test/resources/sample2.vcf")
       .annotateAllelesExpr("va.gqMean = gs.map(g => g.gq).stats().mean," +
-        "va.AC = gs.map(g => g.nNonRefAlleles()).sum()", propagateGQ = true)
+        "va.AC = gs.map(g => g.nNonRefAlleles()).sum()")
       .annotateVariantsExpr("va.callStatsAC = gs.callStats(g => v).AC[1:]")
 
     val testq = vds.queryVA("va.AC")._2
@@ -21,7 +21,7 @@ class AnnotateAllelesSuite extends SparkSuite {
         assert(testq(va) == truthq(va))
       }
 
-    val vds2 = vds.splitMulti(propagateGQ = true)
+    val vds2 = vds.splitMulti()
       .annotateVariantsExpr("va.splitGqMean = gs.map(g => g.gq).stats().mean")
 
     val (_, testq2) = vds2.queryVA("va.gqMean")


### PR DESCRIPTION
Which exposes the generic split_multi interface.
When we nuke Genotype, I will rename split_multi_generic => split_multi and split_multi => split_multi_hts.
Updated the interface slightly.  The rule I'm using is: v, va, g, etc. all denote the old annotations and newV denotes the new, split variant.