### PR TITLE
rudimentary matrix export as text facilities (#2450)

### DIFF
--- a/python/hail/ldMatrix.py
+++ b/python/hail/ldMatrix.py
@@ -1,5 +1,6 @@
 from hail.java import *
 from hail.representation import Variant
+from hail.typecheck import *
 
 class LDMatrix:
     """
@@ -81,3 +82,112 @@ class LDMatrix:
 
         jldm = Env.hail().methods.LDMatrix.read(Env.hc()._jhc, path)
         return LDMatrix(jldm)
+
+    @typecheck_method(path=strlike,
+                      column_delimiter=strlike,
+                      header=nullable(strlike),
+                      parallel_write=bool,
+                      entries=enumeration('full', 'lower', 'strict_lower', 'upper', 'strict_upper'))
+    def export(self, path, column_delimiter, header=None, parallel_write=False, entries='full'):
+        """Exports this matrix as a delimited text file.
+
+        **Examples**
+
+        Write a full LD matrix as a tab-separated file:
+
+        >>> vds.ld_matrix().export('output/ld_matrix.tsv', column_delimiter='\t')
+
+        Write a full LD matrix as a comma-separated file with the variant list as a header:
+
+        >>> ldm = vds.ld_matrix()
+        >>> ldm.export('output/ld_matrix.tsv',
+        ...            column_delimiter=',',
+        ...            header=','.join([str(v) for v in ldm.variant_list()]))
+
+        Write a full LD matrix as a folder of comma-separated file shards:
+
+        >>> ldm = vds.ld_matrix()
+        >>> ldm.export('output/ld_matrix.tsv',
+        ...            column_delimiter=',',
+        ...            header=None,
+        ...            parallel_write=True)
+
+        Write the upper-triangle with the diagonal as a comma-separated file:
+
+        >>> ldm = vds.ld_matrix()
+        >>> ldm.export('output/ld_matrix.tsv',
+        ...            column_delimiter=',',
+        ...            entries='strict_upper')
+
+        **Notes**
+
+        A matrix cannot be exported if it has more than ``2^31 - 1`` columns.
+
+        A full, 3x3 LD matrix written as a comma-separated file looks like this:
+
+        .. code-block:: text
+
+            1.0,0.8,0.7
+            0.8,1.0,0.3
+            0.7,0.3,1.0
+
+        The lower triangle:
+
+        .. code-block:: text
+
+            0.8
+            0.7,0.3
+
+        The strict lower triangle:
+
+        .. code-block:: text
+
+            1.0
+            0.8,1.0
+            0.7,0.3,1.0
+
+        The upper triangle:
+
+        .. code-block:: text
+
+            0.8,0.7
+            0.3
+
+        The strict upper triangle:
+
+        .. code-block:: text
+
+            1.0,0.8,0.7
+            1.0,0.3
+            1.0
+
+        :param path: the path at which to write the LD matrix
+        :type path: str
+
+        :param column_delimiter: the column delimiter
+        :type column_delimiter: str
+
+        :param header: a string to append before the first row of the matrix
+        :type path: str or None
+
+        :param parallel_write: if false, a single file is produced, otherwise a
+                               folder of file shards is produce; if set to false
+                               the export will be slower
+        :type parallel_write: bool
+
+        :param entries: describes what portion of the entries should be printed,
+                        see the notes for a detailed description
+        :type entries: str
+
+        """
+
+        if entries == 'full':
+            self._jldm.export(path, column_delimiter, joption(header), parallel_write)
+        elif entries == 'lower':
+            self._jldm.exportLowerTriangle(path, column_delimiter, joption(header), parallel_write)
+        elif entries == 'strict_lower':
+            self._jldm.exportStrictLowerTriangle(path, column_delimiter, joption(header), parallel_write)
+        elif entries == 'upper':
+            self._jldm.exportUpperTriangle(path, column_delimiter, joption(header), parallel_write)
+        else:
+            self._jldm.exportStrictUpperTriangle(path, column_delimiter, joption(header), parallel_write)

--- a/python/hail/ldMatrix.py
+++ b/python/hail/ldMatrix.py
@@ -117,7 +117,7 @@ class LDMatrix:
         >>> ldm = vds.ld_matrix()
         >>> ldm.export('output/ld_matrix.tsv',
         ...            column_delimiter=',',
-        ...            entries='strict_upper')
+        ...            entries='upper')
 
         **Notes**
 
@@ -131,14 +131,14 @@ class LDMatrix:
             0.8,1.0,0.3
             0.7,0.3,1.0
 
-        The lower triangle:
+        The strict lower triangle:
 
         .. code-block:: text
 
             0.8
             0.7,0.3
 
-        The strict lower triangle:
+        The lower triangle:
 
         .. code-block:: text
 
@@ -146,14 +146,14 @@ class LDMatrix:
             0.8,1.0
             0.7,0.3,1.0
 
-        The upper triangle:
+        The strict upper triangle:
 
         .. code-block:: text
 
             0.8,0.7
             0.3
 
-        The strict upper triangle:
+        The upper triangle:
 
         .. code-block:: text
 

--- a/src/main/scala/is/hail/methods/ExportableMatrix.scala
+++ b/src/main/scala/is/hail/methods/ExportableMatrix.scala
@@ -14,21 +14,21 @@ trait ExportableMatrix {
     exportDelimitedRowSlices(path, columnDelimiter, header, parallelWrite, i => 0, (i, v) => v.length)
   }
 
-  def exportLowerTriangle(path: String, columnDelimiter: String, header: Option[String], parallelWrite: Boolean) {
+  def exportStrictLowerTriangle(path: String, columnDelimiter: String, header: Option[String], parallelWrite: Boolean) {
     exportDelimitedRowSlices(path, columnDelimiter, header, parallelWrite, i => 0, (i, v) => i)
   }
 
   // includes the diagonal
-  def exportStrictLowerTriangle(path: String, columnDelimiter: String, header: Option[String], parallelWrite: Boolean) {
+  def exportLowerTriangle(path: String, columnDelimiter: String, header: Option[String], parallelWrite: Boolean) {
     exportDelimitedRowSlices(path, columnDelimiter, header, parallelWrite, i => 0, (i, v) => i + 1)
   }
 
   // includes the diagonal
-  def exportStrictUpperTriangle(path: String, columnDelimiter: String, header: Option[String], parallelWrite: Boolean) {
+  def exportUpperTriangle(path: String, columnDelimiter: String, header: Option[String], parallelWrite: Boolean) {
     exportDelimitedRowSlices(path, columnDelimiter, header, parallelWrite, i => i, (i, v) => v.length)
   }
 
-  def exportUpperTriangle(path: String, columnDelimiter: String, header: Option[String], parallelWrite: Boolean) {
+  def exportStrictUpperTriangle(path: String, columnDelimiter: String, header: Option[String], parallelWrite: Boolean) {
     exportDelimitedRowSlices(path, columnDelimiter, header, parallelWrite, i => i + 1, (i, v) => v.length)
   }
 

--- a/src/main/scala/is/hail/methods/ExportableMatrix.scala
+++ b/src/main/scala/is/hail/methods/ExportableMatrix.scala
@@ -1,0 +1,86 @@
+package is.hail.methods
+
+import is.hail.HailContext
+import breeze.linalg.SparseVector
+import is.hail.utils._
+import org.apache.spark.mllib.linalg.Vector
+import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix}
+
+trait ExportableMatrix {
+  def matrix: IndexedRowMatrix
+  def hc: HailContext
+
+  def export(path: String, columnDelimiter: String, header: Option[String], parallelWrite: Boolean) {
+    exportDelimitedRowSlices(path, columnDelimiter, header, parallelWrite, i => 0, (i, v) => v.length)
+  }
+
+  def exportLowerTriangle(path: String, columnDelimiter: String, header: Option[String], parallelWrite: Boolean) {
+    exportDelimitedRowSlices(path, columnDelimiter, header, parallelWrite, i => 0, (i, v) => i)
+  }
+
+  // includes the diagonal
+  def exportStrictLowerTriangle(path: String, columnDelimiter: String, header: Option[String], parallelWrite: Boolean) {
+    exportDelimitedRowSlices(path, columnDelimiter, header, parallelWrite, i => 0, (i, v) => i + 1)
+  }
+
+  // includes the diagonal
+  def exportStrictUpperTriangle(path: String, columnDelimiter: String, header: Option[String], parallelWrite: Boolean) {
+    exportDelimitedRowSlices(path, columnDelimiter, header, parallelWrite, i => i, (i, v) => v.length)
+  }
+
+  def exportUpperTriangle(path: String, columnDelimiter: String, header: Option[String], parallelWrite: Boolean) {
+    exportDelimitedRowSlices(path, columnDelimiter, header, parallelWrite, i => i + 1, (i, v) => v.length)
+  }
+
+  // convert elements in [start, end) of each vector into a string, delimited by
+  // columnDelimiter, dropping empty rows
+  def exportDelimitedRowSlices(path: String, columnDelimiter: String, header: Option[String], parallelWrite: Boolean, start: (Int) => Int, end: (Int, Vector) => Int) {
+    genericExport(path, header, parallelWrite, { (sb, i, v) =>
+      val l = start(i)
+      val r = end(i, v)
+      var j = l
+      while (j < r) {
+        if (j > l)
+          sb ++= columnDelimiter
+        sb.append(v(j))
+        j += 1
+      }
+    })
+  }
+
+  // uses writeRow to convert each row to a String and writes that to a file,
+  // unless the String is empty
+  def genericExport(path: String, header: Option[String], parallelWrite: Boolean, writeRow: (StringBuilder, Int, Vector) => Unit) {
+    prepareMatrixForExport(matrix).rows.mapPartitions { it =>
+      val sb = new StringBuilder()
+      it.map { (row: IndexedRow) =>
+        sb.clear()
+        writeRow(sb, row.index.toInt, row.vector)
+        sb.result()
+      }.filter(s => s.nonEmpty)
+    }.writeTable(path, hc.tmpDir, header, parallelWrite)
+  }
+
+  /**
+    * Creates an IndexedRowMatrix whose backing RDD is sorted by row index and has an entry for every row index.
+    *
+    * @param matToComplete The matrix to be completed.
+    * @return The completed matrix.
+    */
+  private[methods] def prepareMatrixForExport(matToComplete: IndexedRowMatrix): IndexedRowMatrix = {
+    val longCols = matrix.numCols()
+    require(longCols <= Integer.MAX_VALUE,
+      "Cannot export matrices with more than Integer.MAX_VALUE cols")
+    val cols = longCols.toInt
+    val zeroVector = SparseVector.zeros[Double](cols)
+    new IndexedRowMatrix(matToComplete
+      .rows
+      .map(x => (x.index, x.vector))
+      .rightOuterJoin(hc.sc.parallelize(0L until cols).map(x => (x, ())))
+      .map {
+        case (idx, (Some(v), _)) => IndexedRow(idx, v)
+        case (idx, (None, _)) => IndexedRow(idx, zeroVector)
+      }.sortBy(_.index))
+  }
+
+}

--- a/src/main/scala/is/hail/methods/KinshipMatrix.scala
+++ b/src/main/scala/is/hail/methods/KinshipMatrix.scala
@@ -58,7 +58,7 @@ case class KinshipMatrix(hc: HailContext, sampleSignature: Type, matrix: Indexed
   }
 
   def exportRel(output: String) {
-    exportStrictLowerTriangle(output, "\t", None, false)
+    exportLowerTriangle(output, "\t", None, false)
   }
 
   def exportGctaGrm(output: String) {

--- a/src/main/scala/is/hail/methods/LDMatrix.scala
+++ b/src/main/scala/is/hail/methods/LDMatrix.scala
@@ -57,7 +57,7 @@ object LDMatrix {
     val scaledIRM = new IndexedRowMatrix(irm.rows
       .map{case IndexedRow(idx, vec) => IndexedRow(idx, vec.map(d => d * nSamplesInverse))})
 
-    LDMatrix(scaledIRM, variantsKept, nSamples)
+    LDMatrix(vds.hc, scaledIRM, variantsKept, nSamples)
   }
 
   private val metadataRelativePath = "/metadata.json"
@@ -75,7 +75,7 @@ object LDMatrix {
         jackson.Serialization.read[LDMatrixMetadata](isr)
       }
 
-    new LDMatrix(new IndexedRowMatrix(rdd), variants, nSamples)
+    new LDMatrix(hc, new IndexedRowMatrix(rdd), variants, nSamples)
   }
 }
 
@@ -85,7 +85,7 @@ object LDMatrix {
   * @param variants Array of variants indexing the rows and columns of the matrix.
   * @param nSamples Number of samples used to compute this matrix.
   */
-case class LDMatrix(matrix: IndexedRowMatrix, variants: Array[Variant], nSamples: Int) {
+case class LDMatrix(hc: HailContext, matrix: IndexedRowMatrix, variants: Array[Variant], nSamples: Int) extends ExportableMatrix {
   import LDMatrix._
 
   def toLocalMatrix: BDM[Double] = {

--- a/src/test/scala/is/hail/methods/LDMatrixSuite.scala
+++ b/src/test/scala/is/hail/methods/LDMatrixSuite.scala
@@ -3,7 +3,7 @@ package is.hail.methods
 import breeze.linalg.{DenseMatrix, convert, norm}
 import breeze.stats.mean
 import is.hail.utils._
-import is.hail.variant.VariantDataset
+import is.hail.variant.{Variant, VariantDataset}
 import is.hail.{SparkSuite, TestUtils, stats}
 import org.apache.spark.mllib.linalg._
 import org.apache.spark.mllib.linalg.distributed._

--- a/src/test/scala/is/hail/methods/LDMatrixSuite.scala
+++ b/src/test/scala/is/hail/methods/LDMatrixSuite.scala
@@ -136,21 +136,21 @@ class LDMatrixSuite extends SparkSuite {
     exportImportAssert(ldm.export(_, ",", header=None, parallelWrite=false),
       fullExpected:_*)
 
-    exportImportAssert(ldm.exportLowerTriangle(_, ",", header=None, parallelWrite=false),
+    exportImportAssert(ldm.exportStrictLowerTriangle(_, ",", header=None, parallelWrite=false),
       Array(4.0),
       Array(7.0, 8.0))
 
-    exportImportAssert(ldm.exportStrictLowerTriangle(_, ",", header=None, parallelWrite=false),
+    exportImportAssert(ldm.exportLowerTriangle(_, ",", header=None, parallelWrite=false),
       Array(1.0),
       Array(4.0, 5.0),
       Array(7.0, 8.0, 9.0))
 
-    exportImportAssert(ldm.exportStrictUpperTriangle(_, ",", header=None, parallelWrite=false),
+    exportImportAssert(ldm.exportUpperTriangle(_, ",", header=None, parallelWrite=false),
       Array(1.0, 2.0, 3.0),
       Array(5.0, 6.0),
       Array(9.0))
 
-    exportImportAssert(ldm.exportUpperTriangle(_, ",", header=None, parallelWrite=false),
+    exportImportAssert(ldm.exportStrictUpperTriangle(_, ",", header=None, parallelWrite=false),
       Array(2.0, 3.0),
       Array(6.0))
   }
@@ -168,21 +168,21 @@ class LDMatrixSuite extends SparkSuite {
       Array(0.0, 0.0, 0.0),
       Array(0.0, 0.0, 0.0))
 
-    exportImportAssert(ldm.exportLowerTriangle(_, ",", header=None, parallelWrite=false),
+    exportImportAssert(ldm.exportStrictLowerTriangle(_, ",", header=None, parallelWrite=false),
       Array(0.0),
       Array(0.0, 0.0))
 
-    exportImportAssert(ldm.exportStrictLowerTriangle(_, ",", header=None, parallelWrite=false),
+    exportImportAssert(ldm.exportLowerTriangle(_, ",", header=None, parallelWrite=false),
       Array(0.0),
       Array(0.0, 0.0),
       Array(0.0, 0.0, 0.0))
 
-    exportImportAssert(ldm.exportStrictUpperTriangle(_, ",", header=None, parallelWrite=false),
+    exportImportAssert(ldm.exportUpperTriangle(_, ",", header=None, parallelWrite=false),
       Array(0.0, 0.0, 0.0),
       Array(0.0, 0.0),
       Array(0.0))
 
-    exportImportAssert(ldm.exportUpperTriangle(_, ",", header=None, parallelWrite=false),
+    exportImportAssert(ldm.exportStrictUpperTriangle(_, ",", header=None, parallelWrite=false),
       Array(0.0, 0.0),
       Array(0.0))
   }
@@ -198,26 +198,26 @@ class LDMatrixSuite extends SparkSuite {
     exportImportAssert(distLDMatrix.export(_, ",", header=None, parallelWrite=false),
       expected:_*)
 
-    exportImportAssert(distLDMatrix.exportLowerTriangle(_, ",", header=None, parallelWrite=false),
+    exportImportAssert(distLDMatrix.exportStrictLowerTriangle(_, ",", header=None, parallelWrite=false),
       expected.zipWithIndex
         .map { case (a,i) =>
           a.zipWithIndex.filter { case (_, j) => j < i }.map(_._1).toArray[Double] }
         .filter(_.nonEmpty)
         .toArray[Array[Double]]:_*)
 
-    exportImportAssert(distLDMatrix.exportStrictLowerTriangle(_, ",", header=None, parallelWrite=false),
+    exportImportAssert(distLDMatrix.exportLowerTriangle(_, ",", header=None, parallelWrite=false),
       expected.zipWithIndex
         .map { case (a,i) =>
           a.zipWithIndex.filter { case (_, j) => j <= i }.map(_._1).toArray[Double] }
         .toArray[Array[Double]]:_*)
 
-    exportImportAssert(distLDMatrix.exportStrictUpperTriangle(_, ",", header=None, parallelWrite=false),
+    exportImportAssert(distLDMatrix.exportUpperTriangle(_, ",", header=None, parallelWrite=false),
       expected.zipWithIndex
         .map { case (a,i) =>
           a.zipWithIndex.filter { case (_, j) => j >= i }.map(_._1).toArray[Double] }
         .toArray[Array[Double]]:_*)
 
-    exportImportAssert(distLDMatrix.exportUpperTriangle(_, ",", header=None, parallelWrite=false),
+    exportImportAssert(distLDMatrix.exportStrictUpperTriangle(_, ",", header=None, parallelWrite=false),
       expected.zipWithIndex
         .map { case (a,i) =>
           a.zipWithIndex.filter { case (_, j) => j > i }.map(_._1).toArray[Double] }

--- a/src/test/scala/is/hail/methods/LDMatrixSuite.scala
+++ b/src/test/scala/is/hail/methods/LDMatrixSuite.scala
@@ -5,6 +5,8 @@ import breeze.stats.mean
 import is.hail.utils._
 import is.hail.variant.VariantDataset
 import is.hail.{SparkSuite, TestUtils, stats}
+import org.apache.spark.mllib.linalg._
+import org.apache.spark.mllib.linalg.distributed._
 import org.testng.Assert
 import org.testng.annotations.Test
 
@@ -96,4 +98,130 @@ class LDMatrixSuite extends SparkSuite {
     assert(actual.toLocalMatrix == LDMatrix.read(hc, fname).toLocalMatrix)
   }
 
+  private def readCSV(fname: String): Array[Array[Double]] =
+    hc.hadoopConf.readLines(fname) { it =>
+      it.map(_.value)
+        .map(_.split(",").map(_.toDouble))
+        .toArray[Array[Double]]
+    }
+
+  private def exportImportAssert(export: (String) => Unit, expected: Array[Double]*) {
+    val fname = tmpDir.createTempFile("test")
+    export(fname)
+    assert(readCSV(fname) === expected.toArray[Array[Double]])
+  }
+
+  private def rowArrayToIRM(a: Array[Array[Double]]): IndexedRowMatrix = {
+    val rows = a.length
+    val cols = if (rows == 0) 0 else a(0).length
+    new IndexedRowMatrix(
+      sc.parallelize(a.zipWithIndex.map { case (a, i) => new IndexedRow(i, new DenseVector(a)) }),
+      rows,
+      cols)
+  }
+
+  private def rowArrayToLDMatrix(a: Array[Array[Double]]): LDMatrix = {
+    val m = rowArrayToIRM(a)
+    LDMatrix(hc, m, (0 until m.numRows().toInt).map(_ => Variant.gen.sample()).toArray[Variant], m.numCols().toInt)
+  }
+
+  @Test
+  def exportSimple() {
+    val fullExpected = Array(
+      Array(1.0, 2.0, 3.0),
+      Array(4.0, 5.0, 6.0),
+      Array(7.0, 8.0, 9.0))
+    val ldm = rowArrayToLDMatrix(fullExpected)
+
+    exportImportAssert(ldm.export(_, ",", header=None, parallelWrite=false),
+      fullExpected:_*)
+
+    exportImportAssert(ldm.exportLowerTriangle(_, ",", header=None, parallelWrite=false),
+      Array(4.0),
+      Array(7.0, 8.0))
+
+    exportImportAssert(ldm.exportStrictLowerTriangle(_, ",", header=None, parallelWrite=false),
+      Array(1.0),
+      Array(4.0, 5.0),
+      Array(7.0, 8.0, 9.0))
+
+    exportImportAssert(ldm.exportStrictUpperTriangle(_, ",", header=None, parallelWrite=false),
+      Array(1.0, 2.0, 3.0),
+      Array(5.0, 6.0),
+      Array(9.0))
+
+    exportImportAssert(ldm.exportUpperTriangle(_, ",", header=None, parallelWrite=false),
+      Array(2.0, 3.0),
+      Array(6.0))
+  }
+
+  @Test
+  def exportAllZeros() {
+    val allZeros = Array(
+      Array(0.0, 0.0, 0.0),
+      Array(0.0, 0.0, 0.0),
+      Array(0.0, 0.0, 0.0))
+    val ldm = rowArrayToLDMatrix(allZeros)
+
+    exportImportAssert(ldm.export(_, ",", header=None, parallelWrite=false),
+      Array(0.0, 0.0, 0.0),
+      Array(0.0, 0.0, 0.0),
+      Array(0.0, 0.0, 0.0))
+
+    exportImportAssert(ldm.exportLowerTriangle(_, ",", header=None, parallelWrite=false),
+      Array(0.0),
+      Array(0.0, 0.0))
+
+    exportImportAssert(ldm.exportStrictLowerTriangle(_, ",", header=None, parallelWrite=false),
+      Array(0.0),
+      Array(0.0, 0.0),
+      Array(0.0, 0.0, 0.0))
+
+    exportImportAssert(ldm.exportStrictUpperTriangle(_, ",", header=None, parallelWrite=false),
+      Array(0.0, 0.0, 0.0),
+      Array(0.0, 0.0),
+      Array(0.0))
+
+    exportImportAssert(ldm.exportUpperTriangle(_, ",", header=None, parallelWrite=false),
+      Array(0.0, 0.0),
+      Array(0.0))
+  }
+
+  @Test
+  def exportBigish() {
+    val lm = distLDMatrix.toLocalMatrix
+    val expected = (0 until lm.rows)
+      .map(i => (0 until lm.cols).map(j =>
+        lm(i, j)).toArray[Double])
+      .toArray[Array[Double]]
+
+    exportImportAssert(distLDMatrix.export(_, ",", header=None, parallelWrite=false),
+      expected:_*)
+
+    exportImportAssert(distLDMatrix.exportLowerTriangle(_, ",", header=None, parallelWrite=false),
+      expected.zipWithIndex
+        .map { case (a,i) =>
+          a.zipWithIndex.filter { case (_, j) => j < i }.map(_._1).toArray[Double] }
+        .filter(_.nonEmpty)
+        .toArray[Array[Double]]:_*)
+
+    exportImportAssert(distLDMatrix.exportStrictLowerTriangle(_, ",", header=None, parallelWrite=false),
+      expected.zipWithIndex
+        .map { case (a,i) =>
+          a.zipWithIndex.filter { case (_, j) => j <= i }.map(_._1).toArray[Double] }
+        .toArray[Array[Double]]:_*)
+
+    exportImportAssert(distLDMatrix.exportStrictUpperTriangle(_, ",", header=None, parallelWrite=false),
+      expected.zipWithIndex
+        .map { case (a,i) =>
+          a.zipWithIndex.filter { case (_, j) => j >= i }.map(_._1).toArray[Double] }
+        .toArray[Array[Double]]:_*)
+
+    exportImportAssert(distLDMatrix.exportUpperTriangle(_, ",", header=None, parallelWrite=false),
+      expected.zipWithIndex
+        .map { case (a,i) =>
+          a.zipWithIndex.filter { case (_, j) => j > i }.map(_._1).toArray[Double] }
+        .filter(_.nonEmpty)
+        .toArray[Array[Double]]:_*)
+  }
 }


### PR DESCRIPTION
#2450 for 0.1.