### PR TITLE
Added generic filter_alleles, annotate_alleles.

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -166,6 +166,77 @@ class VariantDataset(HistoryMixin):
 
     @handle_py4j
     @record_method
+    @typecheck_method(split_variant_expr=oneof(strlike, listof(strlike)),
+                      split_genotype_expr=oneof(strlike, listof(strlike)),
+                      variant_expr=oneof(strlike, listof(strlike)))
+    def annotate_alleles_expr_generic(self, split_variant_expr, split_genotype_expr, variant_expr):
+        """Annotate alleles with expression.
+
+        ``annotate_alleles_expr`` works by splitting variants into
+        biallelics using ``split_genotype_expr``, annotating those
+        biallelic variants with ``variant_expr``, and then collecting
+        the biallelic variant annotations into an array and annotating
+        the original variants with that allele-indexed array.
+
+        ``split_variant_expr`` is an annotation expression to update
+        the split variant annotations for each outupt biallelic
+        variant.  It updates ``va`` and is evaluated in the following
+        namespace:
+
+        - ``global``: global annotations
+        - ``v``: :ref:`variant(GR)`: the old variant
+        - ``newV``: :ref:`variant(GR)`: the new, split variant
+        - ``va``: the old variant annotations
+        - ``aIndex``: the index of the input allele to the output variant
+        - ``wasSplit``: True if the original variant was multiallelic
+
+        ``split_genotype_expr`` is an annotation expression to update
+        the split genotype annotations for each output biallelic
+        variant.  It updates `g` and is evaluated in the following
+        namespace:
+
+        - ``global``: global annotations
+        - ``v``: :ref:`variant(GR)`: the old variant
+        - ``newV``: :ref:`variant(GR)`: the new, split variant
+        - ``va``: the old variant annotations
+        - ``aIndex``: the index of the input allele to the output variant
+        - ``wasSplit``: True if the original variant was multiallelic
+        - ``s``: the sample
+        - ``sa``: the sample annotations
+        - ``g``: the old genotype annotations
+
+        ``variant_expr`` is an annotation expression that the original
+        variant annotations per-allele.  It updates ``va`` and is
+        evaluated in the following namespace:
+
+        - ``global``: global annotations
+        - ``v`` (*Variant(GR)*): split :ref:`variant(gr)`
+        - ``va``: split variant annotations
+        - ``gs`` (*Aggregable*): aggregable of split :ref:`genotype` for variant ``v``
+
+        where ``gs`` has the namespace:
+
+        - ``global``: global annotations
+        - ``v``: :ref:`variant(GR)`
+        - ``va``: split variant annotations
+        - ``s``: sample
+        - ``sa``: sample annotations
+        - ``g``: split :ref:`genotype`
+
+        """
+
+        if isinstance(split_variant_expr, list):
+            split_variant_expr = ",".join(split_variant_expr)
+        if isinstance(split_genotype_expr, list):
+            split_genotype_expr = ",".join(split_genotype_expr)
+        if isinstance(variant_expr, list):
+            variant_expr = ",".join(variant_expr)
+
+        jvds = self._jvdf.annotateAllelesExprGeneric(split_variant_expr, split_genotype_expr, variant_expr)
+        return VariantDataset(self.hc, jvds)
+
+    @handle_py4j
+    @record_method
     @typecheck_method(expr=oneof(strlike, listof(strlike)))
     def annotate_alleles_expr(self, expr):
         """Annotate alleles with expression.
@@ -1664,21 +1735,163 @@ class VariantDataset(HistoryMixin):
     @handle_py4j
     @record_method
     @typecheck_method(expr=strlike,
+                      variant_expr=strlike,
+                      genotype_expr=strlike,
+                      keep=bool,
+                      left_aligned=bool,
+                      keep_star=bool)
+    def filter_alleles_generic(self, expr, variant_expr, genotype_expr,
+                               keep=True, left_aligned=False, keep_star=False):
+        """Filter a user-defined set of alternate alleles for each variant.
+        If all alternate alleles of a variant are filtered, the
+        variant itself is filtered.  The expr expression is evaluated
+        for each alternate allele, but not for the reference allele
+        (i.e. ``aIndex`` will never be zero).
+
+        **Example**
+
+        :py:meth:`~hail.VariantDataset.filter_alleles`, which filters
+        alleles for the HTS schema, supports two modes: downcode and
+        subset.  Subset is implemented as:
+
+        >>> multiallelic_generic_vds.filter_alleles_generic('va.info.AC[aIndex - 1] == 0',
+        ...     variant_expr='va.info.AC = newToOld[1:].map(i => va.info.AC[i - 1])',
+        ...     genotype_expr='''
+        ...     g = let newpl = if (isDefined(g.PL))
+        ...             let unnorm = range(newV.nGenotypes).map(newi =>
+        ...                 let oldi = gtIndex(newToOld[gtj(newi)], newToOld[gtk(newi)])
+        ...                  in g.PL[oldi]) and
+        ...                 minpl = unnorm.min()
+        ...              in unnorm - minpl
+        ...           else
+        ...             NA: Array[Int] and
+        ...         newgt = gtFromPL(newpl) and
+        ...         newad = if (isDefined(g.AD))
+        ...             range(newV.nAlleles).map(newi => g.AD[newToOld[newi]])
+        ...           else
+        ...             NA: Array[Int] and
+        ...         newgq = gqFromPL(newpl) and
+        ...         newdp = g.DP
+        ...      in { GT: Call(newgt), AD: newad, DP: newdp, GQ: newgq, PL: newpl }''',
+        ...     keep=False)
+
+        Downcode is implemented as:
+
+        >>> multiallelic_generic_vds.filter_alleles_generic('va.info.AC[aIndex - 1] == 0',
+        ...     variant_expr='va.info.AC = newToOld[1:].map(i => va.info.AC[i - 1])',
+        ...     genotype_expr='''
+        ...     g = let newgt = gtIndex(oldToNew[gtj(g.GT)], oldToNew[gtk(g.GT)]) and
+        ...         newad = if (isDefined(g.AD))
+        ...             range(newV.nAlleles).map(i => range(v.nAlleles).filter(j => oldToNew[j] == i).map(j => g.AD[j]).sum())
+        ...           else
+        ...             NA: Array[Int] and
+        ...         newdp = g.DP and
+        ...         newpl = if (isDefined(g.PL))
+        ...             range(newV.nGenotypes).map(gi => range(v.nGenotypes).filter(gj => gtIndex(oldToNew[gtj(gj)], oldToNew[gtk(gj)]) == gi).map(gj => g.PL[gj]).min())
+        ...           else
+        ...             NA: Array[Int] and
+        ...         newgq = gqFromPL(newpl)
+        ...      in { GT: Call(newgt), AD: newad, DP: newdp, GQ: newgq, PL: newpl }''',
+        ...     keep=False)
+
+        **Notes**
+
+        ``expr`` is a boolean condition indicating if the given allele
+        should be kept or removed.  ``aIndex`` (allele index)
+        indicates the allele being tested.
+
+        - ``global``: global annotations
+        - ``v`` (*Variant(GR)*): :ref:`variant(gr)`
+        - ``va``: variant annotations
+        - ``aIndex`` (*Int*): the index of the allele being tested
+
+        ``variant_expr`` is an annotation expression to update the
+        variant annotations for each output variant.  It updates `va`
+        and is evaluated in the following namespace:
+
+        - ``global``: global annotations
+        - ``v`` (*Variant(GR)*): the old :ref:`variant(gr)`
+        - ``newV`` (*Variant(GR)*): the new :ref:`variant(gr)`
+        - ``va``: variant annotations
+        - ``newToOld`` (*Array[Int]*): the array of old indices (such that ``newToOld[newIndex] = oldIndex`` and ``newToOld[0] = 0``)
+        - ``oldToNew`` (*Array[Int]*): the array of new indices.  The new index of filtered old alleles is 0.
+
+        ``genotype_expr`` is an annotation expression to update the
+        genotype annotations for each output variant.  It updates `g`
+        and is evaluated in the following namespace:
+
+        - ``global``: global annotations
+        - ``v`` (*Variant(GR)*): the old :ref:`variant(gr)`
+        - ``newV`` (*Variant(GR)*): the new :ref:`variant(gr)`
+        - ``va``: variant annotations
+        - ``newToOld`` (*Array[Int]*): the array of old indices (such that ``newToOld[newIndex] = oldIndex`` and ``newToOld[0] = 0``)
+        - ``oldToNew`` (*Array[Int]*): the array of new indices.  The new index of filtered old alleles is 0.
+        - ``s`` (*Sample*): sample
+        - ``sa``: sample annotation
+        - ``g``: old genotype annotation
+
+        Note, the variant and genotype annotations are updated for all
+        output variants, even those for which no alleles are filtered.
+        This is because the updates can change the variant annotation
+        and genotype schemas, which must be consistent across
+        variants.
+
+        :param str expr: Boolean filter expression.
+
+        :param str variant_expr: Annotation expressions to update the variant annotations for the new, filtered variant.
+
+        :param str genotype_expr: Annotation expressions to update the genotype annotations for the new, filtered variant.
+
+        :param bool keep: If True, keep variants matching expr
+
+        :param bool left_aligned: If True, variants are assumed to be
+          left aligned and have unique loci.  This avoids a shuffle.
+          If the assumption is violated, an error is generated.
+
+        :param bool keep_star: If True, keep variants where the only allele left is a ``*`` allele.
+
+        :return: Filtered variant dataset.
+        :rtype: :py:class:`.VariantDataset`
+
+        """
+        
+        jvds = self._jvdf.filterAllelesGeneric(expr, variant_expr, genotype_expr,
+                                               keep, left_aligned, keep_star)
+        return VariantDataset(self.hc, jvds)
+
+    @handle_py4j
+    @record_method
+    @typecheck_method(expr=strlike,
                       annotation=strlike,
                       subset=bool,
                       keep=bool,
-                      filter_altered_genotypes=bool,
                       left_aligned=bool,
                       keep_star=bool)
-    def filter_alleles(self, expr, annotation='', subset=True, keep=True,
-                       filter_altered_genotypes=False, left_aligned=False, keep_star=False):
-        """Filter a user-defined set of alternate alleles for each variant.
-        If all alternate alleles of a variant are filtered, the
-        variant itself is filtered.  The expr expression is
-        evaluated for each alternate allele, but not for
-        the reference allele (i.e. ``aIndex`` will never be zero).
+    def filter_alleles(self, expr, annotation='', subset=True,
+                       keep=True, left_aligned=False, keep_star=False):
+        """Filter a user-defined set of alternate alleles for each variant for
+        :py:meth:`.VariantDataset.genotype_schema`
+        :py:class:`~hail.expr.TGenotype` or the HTS schema:
 
-        .. include:: _templates/req_tvariant_tgenotype.rst
+        .. code-block:: text
+
+          Struct {
+            GT: Call,
+            AD: Array[!Int32],
+            DP: Int32,
+            GQ: Int32,
+            PL: Array[!Int32].
+          }
+
+        For generic genotype schema, use
+        :py:meth:`~hail.VariantDataset.filter_alleles_generic`.
+
+        If all alternate alleles of a variant are filtered, the
+        variant itself is filtered.  ``expr`` is evaluated for each
+        alternate allele, but not for the reference allele
+        (i.e. ``aIndex`` will never be zero).
+
+        .. include:: _templates/req_tvariant.rst
 
         **Examples**
 
@@ -1695,8 +1908,6 @@ class VariantDataset(HistoryMixin):
         the *alternate allele* indices.
 
         **Notes**
-
-        If ``filter_altered_genotypes`` is true, genotypes that contain filtered-out alleles are set to missing.
 
         :py:meth:`~hail.VariantDataset.filter_alleles` implements two algorithms for filtering alleles: subset and downcode. We will illustrate their
         behavior on the example genotype below when filtering the first alternate allele (allele 1) at a site with 1 reference
@@ -1802,8 +2013,6 @@ class VariantDataset(HistoryMixin):
 
         :param bool keep: If true, keep variants matching expr
 
-        :param bool filter_altered_genotypes: If true, genotypes that contain filtered-out alleles are set to missing.
-
         :param bool left_aligned: If True, variants are assumed to be
           left aligned and have unique loci.  This avoids a shuffle.
           If the assumption is violated, an error is generated.
@@ -1815,7 +2024,7 @@ class VariantDataset(HistoryMixin):
 
         """
 
-        jvds = self._jvdf.filterAlleles(expr, annotation, filter_altered_genotypes, keep, subset,
+        jvds = self._jvdf.filterAlleles(expr, annotation, keep, subset,
                                         left_aligned, keep_star)
         return VariantDataset(self.hc, jvds)
 

--- a/src/main/scala/is/hail/methods/SplitMulti.scala
+++ b/src/main/scala/is/hail/methods/SplitMulti.scala
@@ -33,7 +33,6 @@ class ExprAnnotator(val ec: EvalContext, t: Type, expr: String, head: Option[Str
       newA = inserters(i)(newA, xs(i))
       i += 1
     }
-    assert(newT.typeCheck(newA))
     newA
   }
 }
@@ -94,7 +93,6 @@ class SplitMultiPartitionContext(
     val nGenotypes = v.nGenotypes
 
     val gs = ur.getAs[IndexedSeq[Any]](3)
-
     splitVariants.iterator
       .map { case (svj, i) =>
         splitRegion.clear()
@@ -105,7 +103,7 @@ class SplitMultiPartitionContext(
         rvb.addAnnotation(newRowType.fieldType(1), svj)
 
         vAnnotator.ec.setAll(globalAnnotation, v, svj, va, i, wasSplit)
-        rvb.addAnnotation(newRowType.fieldType(2), vAnnotator.insert(va))
+        rvb.addAnnotation(vAnnotator.newT, vAnnotator.insert(va))
 
         rvb.startArray(nSamples) // gs
         gAnnotator.ec.setAll(globalAnnotation, v, svj, va, i, wasSplit)
@@ -113,7 +111,7 @@ class SplitMultiPartitionContext(
         while (k < nSamples) {
           val g = gs(k)
           gAnnotator.ec.set(6, g)
-          rvb.addAnnotation(newRowType.fieldType(3).asInstanceOf[TArray].elementType, gAnnotator.insert(g))
+          rvb.addAnnotation(gAnnotator.newT, gAnnotator.insert(g))
           k += 1
         }
         rvb.endArray() // gs

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -42,23 +42,49 @@ object VariantDataset {
 class VariantDatasetFunctions(private val vsm: VariantSampleMatrix) extends AnyVal {
 
   def annotateAllelesExpr(expr: String): VariantDataset = {
+    val splitVariantExpr = "va.aIndex = aIndex, va.wasSplit = wasSplit"
+    val gType = vsm.genotypeSignature
+    val splitGenotypeExpr =
+      if (gType.isOfType(TGenotype())) {
+        """
+          g = let
+              newgt = downcode(Call(g.gt), aIndex) and
+              newad = if (isDefined(g.ad))
+                  let sum = g.ad.sum() and adi = g.ad[aIndex] in [sum - adi, adi]
+                else
+                  NA: Array[Int] and
+              newpl = if (isDefined(g.pl))
+                  range(3).map(i => range(g.pl.length).filter(j => downcode(Call(j), aIndex) == Call(i)).map(j => g.pl[j]).min())
+                else
+                  NA: Array[Int] and
+              newgq = gqFromPL(newpl)
+            in Genotype(newV, newgt, newad, g.dp, newgq, newpl)"""
+      } else {
+        if (!vsm.genotypeSignature.isOfType(Genotype.htsGenotypeType))
+          fatal(s"annotate_alleles: genotype_schema must be TGenotype or the HTS genotype schema, found: ${ vsm.genotypeSignature }")
 
-    val splitmulti = new SplitMulti(vsm,
-      "va.aIndex = aIndex, va.wasSplit = wasSplit",
-      s"""
-g = let
-    newgt = downcode(Call(g.gt), aIndex) and
-    newad = if (isDefined(g.ad))
-        let sum = g.ad.sum() and adi = g.ad[aIndex] in [sum - adi, adi]
-      else
-        NA: Array[Int] and
-    newpl = if (isDefined(g.pl))
-        range(3).map(i => range(g.pl.length).filter(j => downcode(Call(j), aIndex) == Call(i)).map(j => g.pl[j]).min())
-      else
-        NA: Array[Int] and
-    newgq = gqFromPL(newpl)
-  in Genotype(newV, newgt, newad, g.dp, newgq, newpl)
-    """, keepStar = true, leftAligned = false)
+        """
+          g = let
+            newgt = downcode(g.GT, aIndex) and
+            newad = if (isDefined(g.AD))
+                let sum = g.AD.sum() and adi = g.AD[aIndex] in [sum - adi, adi]
+              else
+                NA: Array[Int] and
+            newpl = if (isDefined(g.PL))
+                range(3).map(i => range(g.PL.length).filter(j => downcode(Call(j), aIndex) == Call(i)).map(j => g.PL[j]).min())
+              else
+                NA: Array[Int] and
+            newgq = gqFromPL(newpl)
+          in { GT: newgt, AD: newad, DP: g.DP, GQ: newgq, PL: newpl }"""
+      }
+
+    annotateAllelesExprGeneric(splitVariantExpr, splitGenotypeExpr, variantExpr = expr)
+  }
+
+  def annotateAllelesExprGeneric(splitVariantExpr: String, splitGenotypeExpr: String, variantExpr: String): VariantDataset = {
+
+    val splitmulti = new SplitMulti(vsm, splitVariantExpr, splitGenotypeExpr,
+      keepStar = true, leftAligned = false)
 
     val splitMatrixType = splitmulti.newMatrixType
 
@@ -66,16 +92,16 @@ g = let
       "global" -> (0, vsm.globalSignature),
       "v" -> (1, vsm.vSignature),
       "va" -> (2, splitMatrixType.vaType),
-      "g" -> (3, TGenotype()),
+      "g" -> (3, splitMatrixType.genotypeType),
       "s" -> (4, TString()),
       "sa" -> (5, vsm.saSignature))
     val ec = EvalContext(Map(
       "global" -> (0, vsm.globalSignature),
       "v" -> (1, vsm.vSignature),
       "va" -> (2, splitMatrixType.vaType),
-      "gs" -> (3, TAggregable(TGenotype(), aggregationST))))
+      "gs" -> (3, TAggregable(splitMatrixType.genotypeType, aggregationST))))
 
-    val (paths, types, f) = Parser.parseAnnotationExprs(expr, ec, Some(Annotation.VARIANT_HEAD))
+    val (paths, types, f) = Parser.parseAnnotationExprs(variantExpr, ec, Some(Annotation.VARIANT_HEAD))
 
     val inserterBuilder = new ArrayBuilder[Inserter]()
     val newType = (paths, types).zipped.foldLeft(vsm.vaSignature) { case (vas, (ids, signature)) =>
@@ -140,7 +166,7 @@ g = let
           val ur = new UnsafeRow(localRowType, rv.region, rv.offset)
           val va = ur.get(2)
           val newVA = inserters.zipWithIndex.foldLeft(va) { case (va, (inserter, i)) =>
-              inserter(va, annotations.map(_ (i)): IndexedSeq[Any])
+            inserter(va, annotations.map(_ (i)): IndexedSeq[Any])
           }
           rv2b.addAnnotation(finalType, newVA)
 
@@ -262,17 +288,11 @@ g = let
       }))
   }
 
-  def filterAlleles(filterExpr: String, variantExpr: String = "", filterAlteredGenotypes: Boolean = false,
+  def filterAlleles(filterExpr: String, variantExpr: String = "",
     keep: Boolean = true, subset: Boolean = true, leftAligned: Boolean = false, keepStar: Boolean = false): VariantDataset = {
-    def filterGT(gtexpr: String): String = {
-      if (filterAlteredGenotypes)
-      // FIXME this can't possibly be right
-        s"let newrawgt = $gtexpr in if (newrawgt == g.gt) newrawgt else NA: Int"
-      else
-        gtexpr
-    }
 
-    val genotypeExpr =
+    val gType = vsm.genotypeSignature
+    val genotypeExpr = if (gType.isOfType(TGenotype())) {
       if (subset) {
         """
 g = let newpl = if (isDefined(g.pl))
@@ -295,7 +315,7 @@ g = let newpl = if (isDefined(g.pl))
       } else {
         // downcode
         s"""
-g = let newgt = ${ filterGT("gtIndex(oldToNew[gtj(g.gt)], oldToNew[gtk(g.gt)])") } and
+g = let newgt = gtIndex(oldToNew[gtj(g.gt)], oldToNew[gtk(g.gt)]) and
     newad = if (isDefined(g.ad))
         range(newV.nAlleles).map(i => range(v.nAlleles).filter(j => oldToNew[j] == i).map(j => g.ad[j]).sum())
       else
@@ -309,7 +329,54 @@ g = let newgt = ${ filterGT("gtIndex(oldToNew[gtj(g.gt)], oldToNew[gtk(g.gt)])")
  in Genotype(newV, Call(newgt), newad, newdp, newgq, newpl)
         """
       }
+    } else {
+      if (!vsm.genotypeSignature.isOfType(Genotype.htsGenotypeType))
+        fatal(s"filter_alleles: genotype_schema must be TGenotype or the HTS genotype schema, found: ${ vsm.genotypeSignature }")
 
+      if (subset) {
+        """
+g = let newpl = if (isDefined(g.PL))
+        let unnorm = range(newV.nGenotypes).map(newi =>
+            let oldi = gtIndex(newToOld[gtj(newi)], newToOld[gtk(newi)])
+             in g.PL[oldi]) and
+            minpl = unnorm.min()
+         in unnorm - minpl
+      else
+        NA: Array[Int] and
+    newgt = gtFromPL(newpl) and
+    newad = if (isDefined(g.AD))
+        range(newV.nAlleles).map(newi => g.AD[newToOld[newi]])
+      else
+        NA: Array[Int] and
+    newgq = gqFromPL(newpl) and
+    newdp = g.DP
+ in { GT: Call(newgt), AD: newad, DP: newdp, GQ: newgq, PL: newpl }
+        """
+      } else {
+        // downcode
+        s"""
+g = let newgt = gtIndex(oldToNew[gtj(g.GT)], oldToNew[gtk(g.GT)]) and
+    newad = if (isDefined(g.AD))
+        range(newV.nAlleles).map(i => range(v.nAlleles).filter(j => oldToNew[j] == i).map(j => g.AD[j]).sum())
+      else
+        NA: Array[Int] and
+    newdp = g.DP and
+    newpl = if (isDefined(g.PL))
+        range(newV.nGenotypes).map(gi => range(v.nGenotypes).filter(gj => gtIndex(oldToNew[gtj(gj)], oldToNew[gtk(gj)]) == gi).map(gj => g.PL[gj]).min())
+      else
+        NA: Array[Int] and
+    newgq = gqFromPL(newpl)
+ in { GT: Call(newgt), AD: newad, DP: newdp, GQ: newgq, PL: newpl }
+        """
+      }
+    }
+
+    FilterAlleles(vsm, filterExpr, variantExpr, genotypeExpr,
+      keep = keep, leftAligned = leftAligned, keepStar = keepStar)
+  }
+
+  def filterAllelesGeneric(filterExpr: String, variantExpr: String, genotypeExpr: String,
+    keep: Boolean = true, leftAligned: Boolean = false, keepStar: Boolean = false): VariantSampleMatrix = {
     FilterAlleles(vsm, filterExpr, variantExpr, genotypeExpr,
       keep = keep, leftAligned = leftAligned, keepStar = keepStar)
   }
@@ -579,7 +646,7 @@ g = let newgt = ${ filterGT("gtIndex(oldToNew[gtj(g.gt)], oldToNew[gtk(g.gt)])")
       vsm.splitMultiGeneric("va.aIndex = aIndex, va.wasSplit = wasSplit",
         s"""g =
     let
-      newgt = downcode(Call(g.GT), aIndex) and
+      newgt = downcode(g.GT, aIndex) and
       newad = if (isDefined(g.AD))
           let sum = g.AD.sum() and adi = g.AD[aIndex] in [sum - adi, adi]
         else

--- a/src/test/scala/is/hail/vds/FilterAllelesSuite.scala
+++ b/src/test/scala/is/hail/vds/FilterAllelesSuite.scala
@@ -151,35 +151,7 @@ class FilterAllelesSuite extends SparkSuite {
 
     assert(vds.rdd.collect().toSeq == Seq(newRow1))
   }
-
-  @Test def filterSecondOfTwoAllelesFilterAlteredGenotypes(): Unit = {
-    val variant1 = new Variant("contig", 0, "ref", IndexedSeq("alt1", "alt2").map(AltAllele("ref", _)))
-    val va1 = null
-    val genotype11 = Genotype(Option(1), Option(Array(25, 5, 30)), Option(100), Option(5), Option(Array(10, 0, 10, 10, 5, 7)))
-    val genotype12 = Genotype(Option(2), Option(Array(25, 35, 0)), Option(100), Option(5), Option(Array(10, 10, 0, 7, 5, 10)))
-    val genotype13 = Genotype(Option(3), Option(Array(25, 10, 10)), Option(100), Option(5), Option(Array(10, 10, 10, 0, 5, 7)))
-    val genotypes1 = Seq(genotype11, genotype12, genotype13)
-    val row1: (Variant, (Annotation, Iterable[Genotype])) = (variant1, (va1, genotypes1))
-
-    val vds = VariantSampleMatrix.fromLegacy(hc, VSMFileMetadata(Array("1", "2", "3"),
-      IndexedSeq[Annotation](null, null, null),
-      null,
-      TString(),
-      TStruct.empty()),
-      sc.parallelize(Seq(row1)))
-      .filterAlleles("aIndex == 2", subset = true, keep = false, filterAlteredGenotypes = true)
-
-    val newVariant1 = variant1.copy(altAlleles = variant1.altAlleles.take(1))
-    val newVa1 = va1
-    val newGenotype11 = genotype11.copy(gt = Option(1), ad = Option(Array(25, 5)), gq = Option(10), px = Option(Array(10, 0, 10)))
-    val newGenotype12 = genotype12.copy(gt = Option(2), ad = Option(Array(25, 35)), gq = Option(10), px = Option(Array(10, 10, 0)))
-    val newGenotype13 = genotype13.copy(gt = None, ad = Option(Array(25, 10)), gq = Option(0), px = Option(Array(0, 0, 0)))
-    val newGenotypes1 = Seq(newGenotype11, newGenotype12, newGenotype13)
-    val newRow1 = (newVariant1, (newVa1, newGenotypes1))
-
-    assert(vds.rdd.collect().toSeq == Seq(newRow1))
-  }
-
+  
   @Test def filterOneAlleleAndModifyAnnotation(): Unit = {
     val variant1 = new Variant("contig", 0, "ref", IndexedSeq("alt1", "alt2").map(AltAllele("ref", _)))
     val va1 = null


### PR DESCRIPTION
Also nuked filter_altered_genotypes which I don't think anyone was using, couldn't possibly have been the intended implementation, and can now be done generically.

I copied the existing annotate_alleles interface but, in light of generics, I don't like it anymore.  I will propose an alternative on the dev forum.