### PR TITLE
Fix potential crash.

### DIFF
--- a/python/hail/representation/genotype.py
+++ b/python/hail/representation/genotype.py
@@ -330,40 +330,33 @@ class Call(HistoryMixin):
 
     _call_jobject = None
 
-    @handle_py4j
-    @record_init
-    @typecheck_method(call=nullable(integral))
-    def __init__(self, call):
-        """Initialize a Call object."""
-
+    @staticmethod
+    def call_jobject():
         if not Call._call_jobject:
             Call._call_jobject = scala_object(Env.hail().variant, 'Call')
+        return Call._call_jobject
 
-        jrep = Call._call_jobject.apply(call)
-        self._init_from_java(jrep)
+    @handle_py4j
+    @record_init
+    @typecheck_method(gt=integral)
+    def __init__(self, gt):
+        """Initialize a Call object."""
+
+        assert gt >= 0
+        self._gt = gt
 
     def __str__(self):
-        return self._jrep.toString()
+        return Call.call_jobject().toString(self._gt)
 
     def __repr__(self):
-        return 'Call(gt=%s)' % self._jrep
+        return 'Call(gt=%s)' % self._gt
 
     def __eq__(self, other):
-        return isinstance(other, Call) and self._jrep.equals(other._jrep)
+        return isinstance(other, Call) and self.gt == other.gt
 
     def __hash__(self):
-        return self._jrep.hashCode()
-
-    def _init_from_java(self, jrep):
-        self._jcall = Call._call_jobject
-        self._jrep = jrep
-
-    @classmethod
-    def _from_java(cls, jrep):
-        c = Call.__new__(cls)
-        c._init_from_java(jrep)
-        super(Call, c).__init__()
-        return c
+        # hash('Call') = 0x16f6c8bfbd18ab94
+        return hash(self.gt) ^ 0x16f6c8bfbd18ab94
 
     @property
     def gt(self):
@@ -372,7 +365,7 @@ class Call(HistoryMixin):
         :rtype: int or None
         """
 
-        return self._jrep
+        return self._gt
 
     def is_hom_ref(self):
         """True if the call is 0/0
@@ -380,7 +373,7 @@ class Call(HistoryMixin):
         :rtype: bool
         """
 
-        return self._jcall.isHomRef(self._jrep)
+        return Call.call_jobject().isHomRef(self._gt)
 
     def is_het(self):
         """True if the call contains two different alleles.
@@ -388,7 +381,7 @@ class Call(HistoryMixin):
         :rtype: bool
         """
 
-        return self._jcall.isHet(self._jrep)
+        return Call.call_jobject().isHet(self._gt)
 
     def is_hom_var(self):
         """True if the call contains two identical alternate alleles.
@@ -396,15 +389,15 @@ class Call(HistoryMixin):
         :rtype: bool
         """
 
-        return self._jcall.isHomVar(self._jrep)
+        return Call.call_jobject().isHomVar(self._gt)
 
-    def is_called_non_ref(self):
+    def is_non_ref(self):
         """True if the call contains any non-reference alleles.
 
         :rtype: bool
         """
 
-        return self._jcall.isCalledNonRef(self._jrep)
+        return Call.call_jobject().isCalledNonRef(self._gt)
 
     def is_het_non_ref(self):
         """True if the call contains two different alternate alleles.
@@ -412,7 +405,7 @@ class Call(HistoryMixin):
         :rtype: bool
         """
 
-        return self._jcall.isHetNonRef(self._jrep)
+        return Call.call_jobject().isHetNonRef(self._gt)
 
     def is_het_ref(self):
         """True if the call contains one reference and one alternate allele.
@@ -420,23 +413,7 @@ class Call(HistoryMixin):
         :rtype: bool
         """
 
-        return self._jcall.isHetRef(self._jrep)
-
-    def is_not_called(self):
-        """True if the call is missing.
-
-        :rtype: bool
-        """
-
-        return self._jcall.isNotCalled(self._jrep)
-
-    def is_called(self):
-        """True if the call is non-missing.
-
-        :rtype: bool
-        """
-
-        return self._jcall.isCalled(self._jrep)
+        return Call.call_jobject().isHetRef(self._gt)
 
     def num_alt_alleles(self):
         """Returns the count of non-reference alleles.
@@ -446,7 +423,7 @@ class Call(HistoryMixin):
         :rtype: int or None
         """
 
-        return self._jcall.nNonRefAlleles(self._jrep)
+        return Call.call_jobject().nNonRefAlleles(self._gt)
 
     @handle_py4j
     @typecheck_method(num_alleles=integral)
@@ -479,7 +456,7 @@ class Call(HistoryMixin):
         :param int num_alleles: number of possible alternate alleles
         :rtype: list of int or None
         """
-        return jiterable_to_list(self._jcall.oneHotAlleles(self._jrep, num_alleles))
+        return jiterable_to_list(Call.call_jobject().oneHotAlleles(self._gt, num_alleles))
 
     @handle_py4j
     @typecheck_method(num_genotypes=integral)
@@ -512,5 +489,5 @@ class Call(HistoryMixin):
         :rtype: list of int or None
         """
 
-        return jiterable_to_list(self._jcall.oneHotGenotype(self._jrep, num_genotypes))
+        return jiterable_to_list(Call.call_jobject().oneHotGenotype(self._gt, num_genotypes))
     

--- a/python/hail/tests/tests.py
+++ b/python/hail/tests/tests.py
@@ -736,7 +736,6 @@ class ContextTests(unittest.TestCase):
 
         self.assertEqual(g.fraction_reads_ref(), 12.0 / (10 + 12))
 
-        c_nocall = Call(None)
         c_hom_ref = Call(0)
 
         self.assertEqual(c_hom_ref.gt, 0)
@@ -744,26 +743,11 @@ class ContextTests(unittest.TestCase):
         self.assertTrue(c_hom_ref.one_hot_alleles(2) == [2, 0])
         self.assertTrue(c_hom_ref.one_hot_genotype(3) == [1, 0, 0])
         self.assertTrue(c_hom_ref.is_hom_ref())
-        self.assertTrue(c_hom_ref.is_called())
-        self.assertFalse(c_hom_ref.is_not_called())
         self.assertFalse(c_hom_ref.is_het())
         self.assertFalse(c_hom_ref.is_hom_var())
-        self.assertFalse(c_hom_ref.is_called_non_ref())
+        self.assertFalse(c_hom_ref.is_non_ref())
         self.assertFalse(c_hom_ref.is_het_non_ref())
         self.assertFalse(c_hom_ref.is_het_ref())
-
-        self.assertEqual(c_nocall.gt, None)
-        self.assertEqual(c_nocall.num_alt_alleles(), None)
-        self.assertEqual(c_nocall.one_hot_alleles(2), None)
-        self.assertEqual(c_nocall.one_hot_genotype(3), None)
-        self.assertFalse(c_nocall.is_hom_ref())
-        self.assertFalse(c_nocall.is_called())
-        self.assertTrue(c_nocall.is_not_called())
-        self.assertFalse(c_nocall.is_het())
-        self.assertFalse(c_nocall.is_hom_var())
-        self.assertFalse(c_nocall.is_called_non_ref())
-        self.assertFalse(c_nocall.is_het_non_ref())
-        self.assertFalse(c_nocall.is_het_ref())
 
         gr = GenomeReference.GRCh37()
         self.assertEqual(gr.name, "GRCh37")

--- a/python/hail/typ.py
+++ b/python/hail/typ.py
@@ -1,7 +1,7 @@
 import abc
 from hail.java import scala_object, Env, jset, jindexed_seq
 from hail.representation import Variant, AltAllele, Genotype, Locus, Interval, Struct, Call, GenomeReference
-from hail.typecheck import typecheck_method, nullable
+from hail.typecheck import typecheck_method, nullable, integral
 from hail.history import *
 
 
@@ -129,10 +129,10 @@ class TInt32(Type):
         return annotation
 
     def _convert_to_j(self, annotation):
-        if annotation:
+        if annotation is not None:
             return Env.jutils().makeInt(annotation)
         else:
-            return annotation
+            return None
 
     def _typecheck(self, annotation):
         if not annotation and self.required:
@@ -164,10 +164,10 @@ class TInt64(Type):
         return annotation
 
     def _convert_to_j(self, annotation):
-        if annotation:
+        if annotation is not None:
             return Env.jutils().makeLong(annotation)
         else:
-            return annotation
+            return None
 
     def _typecheck(self, annotation):
         if not annotation and self.required:
@@ -237,10 +237,10 @@ class TFloat64(Type):
         return annotation
 
     def _convert_to_j(self, annotation):
-        if annotation:
+        if annotation is not None:
             return Env.jutils().makeDouble(annotation)
         else:
-            return annotation
+            return None
 
     def _typecheck(self, annotation):
         if not annotation and self.required:
@@ -351,11 +351,11 @@ class TArray(Type):
         return t
 
     def _convert_to_py(self, annotation):
-        if annotation:
+        if annotation is not None:
             lst = Env.jutils().iterableToArrayList(annotation)
             return [self.element_type._convert_to_py(x) for x in lst]
         else:
-            return annotation
+            return None
 
     def _convert_to_j(self, annotation):
         if annotation is not None:
@@ -363,7 +363,7 @@ class TArray(Type):
                 [self.element_type._convert_to_j(elt) for elt in annotation]
             )
         else:
-            return annotation
+            return None
 
     def _typecheck(self, annotation):
         if annotation:
@@ -413,11 +413,11 @@ class TSet(Type):
         return t
 
     def _convert_to_py(self, annotation):
-        if annotation:
+        if annotation is not None:
             lst = Env.jutils().iterableToArrayList(annotation)
             return set([self.element_type._convert_to_py(x) for x in lst])
         else:
-            return annotation
+            return None
 
     def _convert_to_j(self, annotation):
         if annotation is not None:
@@ -425,7 +425,7 @@ class TSet(Type):
                 [self.element_type._convert_to_j(elt) for elt in annotation]
             )
         else:
-            return annotation
+            return None
 
     def _typecheck(self, annotation):
         if annotation:
@@ -479,14 +479,14 @@ class TDict(Type):
         return t
 
     def _convert_to_py(self, annotation):
-        if annotation:
+        if annotation is not None:
             lst = Env.jutils().iterableToArrayList(annotation)
             d = dict()
             for x in lst:
                 d[self.key_type._convert_to_py(x._1())] = self.value_type._convert_to_py(x._2())
             return d
         else:
-            return annotation
+            return None
 
     def _convert_to_j(self, annotation):
         if annotation is not None:
@@ -494,7 +494,7 @@ class TDict(Type):
                 {self.key_type._convert_to_j(k): self.value_type._convert_to_j(v) for k, v in annotation.iteritems()}
             )
         else:
-            return annotation
+            return None
 
     def _typecheck(self, annotation):
         if annotation:
@@ -592,13 +592,13 @@ class TStruct(Type):
         self.fields = [Field(f.name(), Type._from_java(f.typ()), dict(f.attrsJava())) for f in jfields]
 
     def _convert_to_py(self, annotation):
-        if annotation:
+        if annotation is not None:
             d = dict()
             for i, f in enumerate(self.fields):
                 d[f.name] = f.typ._convert_to_py(annotation.get(i))
             return Struct(d)
         else:
-            return annotation
+            return None
 
     def _convert_to_j(self, annotation):
         if annotation is not None:
@@ -608,7 +608,7 @@ class TStruct(Type):
                 )
             )
         else:
-            return annotation
+            return None
 
     def _typecheck(self, annotation):
         if annotation:
@@ -669,16 +669,16 @@ class TVariant(Type):
         return v
 
     def _convert_to_py(self, annotation):
-        if annotation:
+        if annotation is not None:
             return Variant._from_java(annotation, self._rg)
         else:
-            return annotation
+            return None
 
     def _convert_to_j(self, annotation):
         if annotation is not None:
             return annotation._jrep
         else:
-            return annotation
+            return None
 
     def _typecheck(self, annotation):
         if annotation and not isinstance(annotation, Variant):
@@ -715,16 +715,16 @@ class TAltAllele(Type):
         super(TAltAllele, self).__init__(scala_object(Env.hail().expr, 'TAltAllele').apply(required))
 
     def _convert_to_py(self, annotation):
-        if annotation:
+        if annotation is not None:
             return AltAllele._from_java(annotation)
         else:
-            return annotation
+            return None
 
     def _convert_to_j(self, annotation):
         if annotation is not None:
             return annotation._jrep
         else:
-            return annotation
+            return None
 
     def _typecheck(self, annotation):
         if not annotation and self.required:
@@ -792,17 +792,19 @@ class TCall(Type):
     def __init__(self, required=False):
         super(TCall, self).__init__(scala_object(Env.hail().expr, 'TCall').apply(required))
 
+    @typecheck_method(annotation=nullable(integral))
     def _convert_to_py(self, annotation):
-        if annotation:
-            return Call._from_java(annotation)
+        if annotation is not None:
+            return Call(annotation)
         else:
-            return annotation
+            return None
 
+    @typecheck_method(annotation=nullable(Call))
     def _convert_to_j(self, annotation):
         if annotation is not None:
-            return annotation._jrep
+            return annotation.gt
         else:
-            return annotation
+            return None
 
     def _typecheck(self, annotation):
         if not annotation and self.required:
@@ -847,16 +849,16 @@ class TLocus(Type):
         return l
 
     def _convert_to_py(self, annotation):
-        if annotation:
+        if annotation is not None:
             return Locus._from_java(annotation, self._rg)
         else:
-            return annotation
+            return None
 
     def _convert_to_j(self, annotation):
         if annotation is not None:
             return annotation._jrep
         else:
-            return annotation
+            return None
 
     def _typecheck(self, annotation):
         if not annotation and self.required:
@@ -909,16 +911,16 @@ class TInterval(Type):
         return i
 
     def _convert_to_py(self, annotation):
-        if annotation:
+        if annotation is not None:
             return Interval._from_java(annotation, self._rg)
         else:
-            return annotation
+            return None
 
     def _convert_to_j(self, annotation):
         if annotation is not None:
             return annotation._jrep
         else:
-            return annotation
+            return None
 
     def _typecheck(self, annotation):
         if not annotation and self.required:

--- a/src/main/scala/is/hail/annotations/MemoryBlock.scala
+++ b/src/main/scala/is/hail/annotations/MemoryBlock.scala
@@ -901,10 +901,12 @@ class RegionValueBuilder(var region: MemoryBuffer) {
   }
 
   def addUnsafeRow(t: TStruct, ur: UnsafeRow) {
+    assert(t == ur.t)
     addRegionValue(t, ur.region, ur.offset)
   }
 
   def addUnsafeArray(t: TArray, uis: UnsafeIndexedSeq) {
+    assert(t == uis.t)
     addRegionValue(t, uis.region, uis.aoff)
   }
 
@@ -923,7 +925,7 @@ class RegionValueBuilder(var region: MemoryBuffer) {
 
         case t: TArray =>
           a match {
-            case uis: UnsafeIndexedSeq =>
+            case uis: UnsafeIndexedSeq if t == uis.t =>
               addUnsafeArray(t, uis)
 
             case is: IndexedSeq[Annotation] =>
@@ -938,7 +940,7 @@ class RegionValueBuilder(var region: MemoryBuffer) {
 
         case t: TStruct =>
           a match {
-            case ur: UnsafeRow =>
+            case ur: UnsafeRow if t == ur.t =>
               addUnsafeRow(t, ur)
             case r: Row =>
               addRow(t, r)

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -1843,13 +1843,22 @@ final case class TStruct(fields: IndexedSeq[Field], override val required: Boole
             rvb.startStruct()
             var i = 0
             while (i < j) {
-              rvb.addField(this, region, offset, i)
+              if (region != null)
+                rvb.addField(this, region, offset, i)
+              else
+                rvb.setMissing()
               i += 1
             }
-            fieldInserter(region, loadField(region, offset, j), rvb, inserter)
+            if (region != null && isFieldDefined(region, offset, j))
+              fieldInserter(region, loadField(region, offset, j), rvb, inserter)
+            else
+              fieldInserter(null, 0, rvb, inserter)
             i += 1
             while (i < localSize) {
-              rvb.addField(this, region, offset, i)
+              if (region != null)
+                rvb.addField(this, region, offset, i)
+              else
+                rvb.setMissing()
               i += 1
             }
             rvb.endStruct()
@@ -1862,7 +1871,10 @@ final case class TStruct(fields: IndexedSeq[Field], override val required: Boole
             rvb.startStruct()
             var i = 0
             while (i < localSize) {
-              rvb.addField(this, region, offset, i)
+              if (region != null)
+                rvb.addField(this, region, offset, i)
+              else
+                rvb.setMissing()
               i += 1
             }
             fieldInserter(null, 0, rvb, inserter)

--- a/src/main/scala/is/hail/methods/Aggregators.scala
+++ b/src/main/scala/is/hail/methods/Aggregators.scala
@@ -121,6 +121,12 @@ object Aggregators {
         }
         i += 1
       }
+
+      // clean up
+      localA.indices.foreach { i =>
+        localA(i) = null
+      }
+
       arr
     }, { case (arr1, arr2) =>
       for (i <- 0 until nSamples; j <- 0 until nAggregations) {


### PR DESCRIPTION
Aggregators can close over a, so the tree aggregation step in the
aggregators can cause any values left over in a to be serialized.
Since we're putting annotations backed by region values into a, that
can go bad.