### PR TITLE
Fix bug inserting into missing structs.

### DIFF
--- a/python/hail/representation/genotype.py
+++ b/python/hail/representation/genotype.py
@@ -325,39 +325,33 @@ class Call(HistoryMixin):
 
     _call_jobject = None
 
-    @handle_py4j
-    @record_init
-    def __init__(self, call):
-        """Initialize a Call object."""
-
+    @staticmethod
+    def call_jobject():
         if not Call._call_jobject:
             Call._call_jobject = scala_object(Env.hail().variant, 'Call')
+        return Call._call_jobject
 
-        jrep = Call._call_jobject.apply(call)
-        self._init_from_java(jrep)
+    @handle_py4j
+    @record_init
+    @typecheck_method(gt=integral)
+    def __init__(self, gt):
+        """Initialize a Call object."""
+
+        assert gt >= 0
+        self._gt = gt
 
     def __str__(self):
-        return self._jrep.toString()
+        return Call.call_jobject().toString(self._gt)
 
     def __repr__(self):
-        return 'Call(gt=%s)' % self._jrep
+        return 'Call(gt=%s)' % self._gt
 
     def __eq__(self, other):
-        return self._jrep.equals(other._jrep)
+        return isinstance(other, Call) and self.gt == other.gt
 
     def __hash__(self):
-        return self._jrep.hashCode()
-
-    def _init_from_java(self, jrep):
-        self._jcall = Call._call_jobject
-        self._jrep = jrep
-
-    @classmethod
-    @record_classmethod
-    def _from_java(cls, jrep):
-        c = Call.__new__(cls)
-        c._init_from_java(jrep)
-        return c
+        # hash('Call') = 0x16f6c8bfbd18ab94
+        return hash(self.gt) ^ 0x16f6c8bfbd18ab94
 
     @property
     def gt(self):
@@ -366,7 +360,7 @@ class Call(HistoryMixin):
         :rtype: int or None
         """
 
-        return self._jrep
+        return self._gt
 
     def is_hom_ref(self):
         """True if the call is 0/0
@@ -374,7 +368,7 @@ class Call(HistoryMixin):
         :rtype: bool
         """
 
-        return self._jcall.isHomRef(self._jrep)
+        return Call.call_jobject().isHomRef(self._gt)
 
     def is_het(self):
         """True if the call contains two different alleles.
@@ -382,7 +376,7 @@ class Call(HistoryMixin):
         :rtype: bool
         """
 
-        return self._jcall.isHet(self._jrep)
+        return Call.call_jobject().isHet(self._gt)
 
     def is_hom_var(self):
         """True if the call contains two identical alternate alleles.
@@ -390,15 +384,15 @@ class Call(HistoryMixin):
         :rtype: bool
         """
 
-        return self._jcall.isHomVar(self._jrep)
+        return Call.call_jobject().isHomVar(self._gt)
 
-    def is_called_non_ref(self):
+    def is_non_ref(self):
         """True if the call contains any non-reference alleles.
 
         :rtype: bool
         """
 
-        return self._jcall.isCalledNonRef(self._jrep)
+        return Call.call_jobject().isCalledNonRef(self._gt)
 
     def is_het_non_ref(self):
         """True if the call contains two different alternate alleles.
@@ -406,7 +400,7 @@ class Call(HistoryMixin):
         :rtype: bool
         """
 
-        return self._jcall.isHetNonRef(self._jrep)
+        return Call.call_jobject().isHetNonRef(self._gt)
 
     def is_het_ref(self):
         """True if the call contains one reference and one alternate allele.
@@ -414,23 +408,7 @@ class Call(HistoryMixin):
         :rtype: bool
         """
 
-        return self._jcall.isHetRef(self._jrep)
-
-    def is_not_called(self):
-        """True if the call is missing.
-
-        :rtype: bool
-        """
-
-        return self._jcall.isNotCalled(self._jrep)
-
-    def is_called(self):
-        """True if the call is non-missing.
-
-        :rtype: bool
-        """
-
-        return self._jcall.isCalled(self._jrep)
+        return Call.call_jobject().isHetRef(self._gt)
 
     def num_alt_alleles(self):
         """Returns the count of non-reference alleles.
@@ -440,7 +418,7 @@ class Call(HistoryMixin):
         :rtype: int or None
         """
 
-        return self._jcall.nNonRefAlleles(self._jrep)
+        return Call.call_jobject().nNonRefAlleles(self._gt)
 
     @handle_py4j
     @typecheck_method(num_alleles=integral)
@@ -473,7 +451,7 @@ class Call(HistoryMixin):
         :param int num_alleles: number of possible alternate alleles
         :rtype: list of int or None
         """
-        return jiterable_to_list(self._jcall.oneHotAlleles(self._jrep, num_alleles))
+        return jiterable_to_list(Call.call_jobject().oneHotAlleles(self._gt, num_alleles))
 
     @handle_py4j
     @typecheck_method(num_genotypes=integral)
@@ -506,5 +484,5 @@ class Call(HistoryMixin):
         :rtype: list of int or None
         """
 
-        return jiterable_to_list(self._jcall.oneHotGenotype(self._jrep, num_genotypes))
+        return jiterable_to_list(Call.call_jobject().oneHotGenotype(self._gt, num_genotypes))
     

--- a/python/hail/tests/tests.py
+++ b/python/hail/tests/tests.py
@@ -737,7 +737,6 @@ class ContextTests(unittest.TestCase):
 
         self.assertEqual(g.fraction_reads_ref(), 12.0 / (10 + 12))
 
-        c_nocall = Call(None)
         c_hom_ref = Call(0)
 
         self.assertEqual(c_hom_ref.gt, 0)
@@ -745,26 +744,11 @@ class ContextTests(unittest.TestCase):
         self.assertTrue(c_hom_ref.one_hot_alleles(2) == [2, 0])
         self.assertTrue(c_hom_ref.one_hot_genotype(3) == [1, 0, 0])
         self.assertTrue(c_hom_ref.is_hom_ref())
-        self.assertTrue(c_hom_ref.is_called())
-        self.assertFalse(c_hom_ref.is_not_called())
         self.assertFalse(c_hom_ref.is_het())
         self.assertFalse(c_hom_ref.is_hom_var())
-        self.assertFalse(c_hom_ref.is_called_non_ref())
+        self.assertFalse(c_hom_ref.is_non_ref())
         self.assertFalse(c_hom_ref.is_het_non_ref())
         self.assertFalse(c_hom_ref.is_het_ref())
-
-        self.assertEqual(c_nocall.gt, None)
-        self.assertEqual(c_nocall.num_alt_alleles(), None)
-        self.assertEqual(c_nocall.one_hot_alleles(2), None)
-        self.assertEqual(c_nocall.one_hot_genotype(3), None)
-        self.assertFalse(c_nocall.is_hom_ref())
-        self.assertFalse(c_nocall.is_called())
-        self.assertTrue(c_nocall.is_not_called())
-        self.assertFalse(c_nocall.is_het())
-        self.assertFalse(c_nocall.is_hom_var())
-        self.assertFalse(c_nocall.is_called_non_ref())
-        self.assertFalse(c_nocall.is_het_non_ref())
-        self.assertFalse(c_nocall.is_het_ref())
 
         gr = GenomeReference.GRCh37()
         self.assertEqual(gr.name, "GRCh37")

--- a/src/main/scala/is/hail/annotations/MemoryBlock.scala
+++ b/src/main/scala/is/hail/annotations/MemoryBlock.scala
@@ -901,10 +901,12 @@ class RegionValueBuilder(var region: MemoryBuffer) {
   }
 
   def addUnsafeRow(t: TStruct, ur: UnsafeRow) {
+    assert(t == ur.t)
     addRegionValue(t, ur.region, ur.offset)
   }
 
   def addUnsafeArray(t: TArray, uis: UnsafeIndexedSeq) {
+    assert(t == uis.t)
     addRegionValue(t, uis.region, uis.aoff)
   }
 
@@ -923,7 +925,7 @@ class RegionValueBuilder(var region: MemoryBuffer) {
 
         case t: TArray =>
           a match {
-            case uis: UnsafeIndexedSeq =>
+            case uis: UnsafeIndexedSeq if t == uis.t =>
               addUnsafeArray(t, uis)
 
             case is: IndexedSeq[Annotation] =>
@@ -938,7 +940,7 @@ class RegionValueBuilder(var region: MemoryBuffer) {
 
         case t: TStruct =>
           a match {
-            case ur: UnsafeRow =>
+            case ur: UnsafeRow if t == ur.t =>
               addUnsafeRow(t, ur)
             case r: Row =>
               addRow(t, r)

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -1843,13 +1843,22 @@ final case class TStruct(fields: IndexedSeq[Field], override val required: Boole
             rvb.startStruct()
             var i = 0
             while (i < j) {
-              rvb.addField(this, region, offset, i)
+              if (region != null)
+                rvb.addField(this, region, offset, i)
+              else
+                rvb.setMissing()
               i += 1
             }
-            fieldInserter(region, loadField(region, offset, j), rvb, inserter)
+            if (region != null && isFieldDefined(region, offset, j))
+              fieldInserter(region, loadField(region, offset, j), rvb, inserter)
+            else
+              fieldInserter(null, 0, rvb, inserter)
             i += 1
             while (i < localSize) {
-              rvb.addField(this, region, offset, i)
+              if (region != null)
+                rvb.addField(this, region, offset, i)
+              else
+                rvb.setMissing()
               i += 1
             }
             rvb.endStruct()
@@ -1862,7 +1871,10 @@ final case class TStruct(fields: IndexedSeq[Field], override val required: Boole
             rvb.startStruct()
             var i = 0
             while (i < localSize) {
-              rvb.addField(this, region, offset, i)
+              if (region != null)
+                rvb.addField(this, region, offset, i)
+              else
+                rvb.setMissing()
               i += 1
             }
             fieldInserter(null, 0, rvb, inserter)


### PR DESCRIPTION
When instantiating structs inserting into missing structs, make sure
to set all fields (except the one we're inserting into) to missing.