### PR TITLE
Fix region value builder copy bug introduced by stripping required fi…

### DIFF
--- a/src/main/scala/is/hail/annotations/MemoryBlock.scala
+++ b/src/main/scala/is/hail/annotations/MemoryBlock.scala
@@ -901,10 +901,12 @@ class RegionValueBuilder(var region: MemoryBuffer) {
   }
 
   def addUnsafeRow(t: TStruct, ur: UnsafeRow) {
+    assert(t == ur.t)
     addRegionValue(t, ur.region, ur.offset)
   }
 
   def addUnsafeArray(t: TArray, uis: UnsafeIndexedSeq) {
+    assert(t == uis.t)
     addRegionValue(t, uis.region, uis.aoff)
   }
 
@@ -923,7 +925,7 @@ class RegionValueBuilder(var region: MemoryBuffer) {
 
         case t: TArray =>
           a match {
-            case uis: UnsafeIndexedSeq =>
+            case uis: UnsafeIndexedSeq if t == uis.t =>
               addUnsafeArray(t, uis)
 
             case is: IndexedSeq[Annotation] =>
@@ -938,7 +940,7 @@ class RegionValueBuilder(var region: MemoryBuffer) {
 
         case t: TStruct =>
           a match {
-            case ur: UnsafeRow =>
+            case ur: UnsafeRow if t == ur.t =>
               addUnsafeRow(t, ur)
             case r: Row =>
               addRow(t, r)


### PR DESCRIPTION
…eld.

Introduced by https://github.com/hail-is/hail/pull/2455.

This cause objects with required fields to potentially be treated as not having required fields.

This is a potentially expensive comparison deep inside the region value builder.  I don't see a way around it at this point.
