### PR TITLE
Use array instead of off-heap memory in RegionValue.

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -166,6 +166,78 @@ class VariantDataset(HistoryMixin):
 
     @handle_py4j
     @record_method
+    @typecheck_method(split_variant_expr=oneof(strlike, listof(strlike)),
+                      split_genotype_expr=oneof(strlike, listof(strlike)),
+                      variant_expr=oneof(strlike, listof(strlike)))
+    def annotate_alleles_expr_generic(self, split_variant_expr, split_genotype_expr, variant_expr):
+        """Annotate alleles with expression.
+
+        ``annotate_alleles_expr`` works by splitting variants into
+        biallelics using ``split_variant_expr`` and
+        ``split_genotype_expr``, annotating those biallelic variants
+        with ``variant_expr``, and then collecting the biallelic
+        variant annotations into an array and annotating the original
+        variant with that allele-indexed array.
+
+        ``split_variant_expr`` is an annotation expression to update
+        the split variant annotations for each output biallelic
+        variant.  It updates ``va`` and is evaluated in the following
+        namespace:
+
+        - ``global``: global annotations
+        - ``v``: :ref:`variant(GR)`: the old variant
+        - ``newV``: :ref:`variant(GR)`: the new, split variant
+        - ``va``: the old variant annotations
+        - ``aIndex``: the index of the input allele corresponding to the output variant
+        - ``wasSplit``: True if the original variant was multiallelic
+
+        ``split_genotype_expr`` is an annotation expression to update
+        the split genotype annotations for each output biallelic
+        variant.  It updates `g` and is evaluated in the following
+        namespace:
+
+        - ``global``: global annotations
+        - ``v``: :ref:`variant(GR)`: the old variant
+        - ``newV``: :ref:`variant(GR)`: the new, split variant
+        - ``va``: the old variant annotations
+        - ``aIndex``: the index of the input allele corresponding to the output variant
+        - ``wasSplit``: True if the original variant was multiallelic
+        - ``s``: the sample
+        - ``sa``: the sample annotations
+        - ``g``: the old genotype annotations
+
+        ``variant_expr`` is an annotation expression that updated the
+        original variant annotations per-allele.  It updates ``va``
+        and is evaluated in the following namespace:
+
+        - ``global``: global annotations
+        - ``v`` (*Variant(GR)*): split :ref:`variant(gr)`
+        - ``va``: split variant annotations
+        - ``gs`` (*Aggregable*): aggregable of split :ref:`genotype` for variant ``v``
+
+        where ``gs`` has the namespace:
+
+        - ``global``: global annotations
+        - ``v``: :ref:`variant(GR)`
+        - ``va``: split variant annotations
+        - ``s``: sample
+        - ``sa``: sample annotations
+        - ``g``: split :ref:`genotype`
+
+        """
+
+        if isinstance(split_variant_expr, list):
+            split_variant_expr = ",".join(split_variant_expr)
+        if isinstance(split_genotype_expr, list):
+            split_genotype_expr = ",".join(split_genotype_expr)
+        if isinstance(variant_expr, list):
+            variant_expr = ",".join(variant_expr)
+
+        jvds = self._jvdf.annotateAllelesExprGeneric(split_variant_expr, split_genotype_expr, variant_expr)
+        return VariantDataset(self.hc, jvds)
+
+    @handle_py4j
+    @record_method
     @typecheck_method(expr=oneof(strlike, listof(strlike)))
     def annotate_alleles_expr(self, expr):
         """Annotate alleles with expression.
@@ -1478,21 +1550,162 @@ class VariantDataset(HistoryMixin):
     @handle_py4j
     @record_method
     @typecheck_method(expr=strlike,
+                      variant_expr=strlike,
+                      genotype_expr=strlike,
+                      keep=bool,
+                      left_aligned=bool,
+                      keep_star=bool)
+    def filter_alleles_generic(self, expr, variant_expr, genotype_expr,
+                               keep=True, left_aligned=False, keep_star=False):
+        """Filter to a user-defined set of alternate alleles for each variant.
+        If all alternate alleles of a variant are filtered out, the
+        variant itself is filtered out.  The ``expr`` expression is evaluated
+        for each alternate allele, but not for the reference allele
+        (i.e. ``aIndex`` will never be zero).
+
+        **Example**
+
+        :py:meth:`~hail.VariantDataset.filter_alleles`, which filters
+        alleles with zero allele count for the HTS schema, supports
+        two modes: downcode and subset.  Subset is implemented as:
+
+        >>> multiallelic_generic_vds.filter_alleles_generic('va.info.AC[aIndex - 1] == 0',
+        ...     variant_expr='va.info.AC = newToOld[1:].map(i => va.info.AC[i - 1])',
+        ...     genotype_expr='''
+        ...     g = let newpl = if (isDefined(g.PL))
+        ...             let unnorm = range(newV.nGenotypes).map(newi =>
+        ...                 let oldi = gtIndex(newToOld[gtj(newi)], newToOld[gtk(newi)])
+        ...                  in g.PL[oldi]) and
+        ...                 minpl = unnorm.min()
+        ...              in unnorm - minpl
+        ...           else
+        ...             NA: Array[Int] and
+        ...         newgt = gtFromPL(newpl) and
+        ...         newad = if (isDefined(g.AD))
+        ...             range(newV.nAlleles).map(newi => g.AD[newToOld[newi]])
+        ...           else
+        ...             NA: Array[Int] and
+        ...         newgq = gqFromPL(newpl) and
+        ...         newdp = g.DP
+        ...      in { GT: Call(newgt), AD: newad, DP: newdp, GQ: newgq, PL: newpl }''',
+        ...     keep=False)
+
+        Downcode is implemented as:
+
+        >>> multiallelic_generic_vds.filter_alleles_generic('va.info.AC[aIndex - 1] == 0',
+        ...     variant_expr='va.info.AC = newToOld[1:].map(i => va.info.AC[i - 1])',
+        ...     genotype_expr='''
+        ...     g = let newgt = gtIndex(oldToNew[gtj(g.GT)], oldToNew[gtk(g.GT)]) and
+        ...         newad = if (isDefined(g.AD))
+        ...             range(newV.nAlleles).map(i => range(v.nAlleles).filter(j => oldToNew[j] == i).map(j => g.AD[j]).sum())
+        ...           else
+        ...             NA: Array[Int] and
+        ...         newdp = g.DP and
+        ...         newpl = if (isDefined(g.PL))
+        ...             range(newV.nGenotypes).map(gi => range(v.nGenotypes).filter(gj => gtIndex(oldToNew[gtj(gj)], oldToNew[gtk(gj)]) == gi).map(gj => g.PL[gj]).min())
+        ...           else
+        ...             NA: Array[Int] and
+        ...         newgq = gqFromPL(newpl)
+        ...      in { GT: Call(newgt), AD: newad, DP: newdp, GQ: newgq, PL: newpl }''',
+        ...     keep=False)
+
+        **Notes**
+
+        ``expr`` is a ``Boolean`` condition indicating if the given
+        allele should be kept or removed.
+
+        - ``global``: global annotations
+        - ``v`` (*Variant(GR)*): :ref:`variant(gr)`
+        - ``va``: variant annotations
+        - ``aIndex`` (*Int*): the index of the allele being tested
+
+        ``variant_expr`` is an annotation expression to update the
+        variant annotations for each output variant.  It updates `va`
+        and is evaluated in the following namespace:
+
+        - ``global``: global annotations
+        - ``v`` (*Variant(GR)*): the old :ref:`variant(gr)`
+        - ``newV`` (*Variant(GR)*): the new :ref:`variant(gr)`
+        - ``va``: variant annotations
+        - ``newToOld`` (*Array[Int]*): the array of old indices (such that ``newToOld[newIndex] = oldIndex`` and ``newToOld[0] = 0``)
+        - ``oldToNew`` (*Array[Int]*): the array of new indices.  The new index of filtered old alleles is 0.
+
+        ``genotype_expr`` is an annotation expression to update the
+        genotype annotations for each output variant.  It updates `g`
+        and is evaluated in the following namespace:
+
+        - ``global``: global annotations
+        - ``v`` (*Variant(GR)*): the old :ref:`variant(gr)`
+        - ``newV`` (*Variant(GR)*): the new :ref:`variant(gr)`
+        - ``va``: variant annotations
+        - ``newToOld`` (*Array[Int]*): the array of old indices (such that ``newToOld[newIndex] = oldIndex`` and ``newToOld[0] = 0``)
+        - ``oldToNew`` (*Array[Int]*): the array of new indices.  All old filtered alleles have new index 0.
+        - ``s`` (*Sample*): sample
+        - ``sa``: sample annotation
+        - ``g``: old genotype annotation
+
+        Note, the variant and genotype annotations are updated for all
+        output variants, even those for which no alleles are filtered.
+        This is because the updates can change the variant annotation
+        and genotype schemas, which must be consistent across
+        variants.
+
+        :param str expr: Boolean filter expression.
+
+        :param str variant_expr: Annotation expressions to update the variant annotations for the new, filtered variant.
+
+        :param str genotype_expr: Annotation expressions to update the genotype annotations for the new, filtered variant.
+
+        :param bool keep: If True, keep variants matching expr.
+
+        :param bool left_aligned: If True, variants are assumed to be
+          left aligned and have unique loci.  This avoids a shuffle.
+          If the assumption is violated, an error is generated.
+
+        :param bool keep_star: If True, keep variants where the only unfiltered alternate alleles are ``*`` alleles.
+
+        :return: Filtered variant dataset.
+        :rtype: :py:class:`.VariantDataset`
+
+        """
+        
+        jvds = self._jvdf.filterAllelesGeneric(expr, variant_expr, genotype_expr,
+                                               keep, left_aligned, keep_star)
+        return VariantDataset(self.hc, jvds)
+
+    @handle_py4j
+    @record_method
+    @typecheck_method(expr=strlike,
                       annotation=strlike,
                       subset=bool,
                       keep=bool,
-                      filter_altered_genotypes=bool,
                       left_aligned=bool,
                       keep_star=bool)
-    def filter_alleles(self, expr, annotation='', subset=True, keep=True,
-                       filter_altered_genotypes=False, left_aligned=False, keep_star=False):
-        """Filter a user-defined set of alternate alleles for each variant.
-        If all alternate alleles of a variant are filtered, the
-        variant itself is filtered.  The expr expression is
-        evaluated for each alternate allele, but not for
-        the reference allele (i.e. ``aIndex`` will never be zero).
+    def filter_alleles(self, expr, annotation='', subset=True,
+                       keep=True, left_aligned=False, keep_star=False):
+        """Filter a user-defined set of alternate alleles for each variant for
+        :py:meth:`.VariantDataset.genotype_schema`
+        :py:class:`~hail.expr.TGenotype` or the HTS schema:
 
-        .. include:: _templates/req_tvariant_tgenotype.rst
+        .. code-block:: text
+
+          Struct {
+            GT: Call,
+            AD: Array[!Int32],
+            DP: Int32,
+            GQ: Int32,
+            PL: Array[!Int32].
+          }
+
+        For generic genotype schema, use
+        :py:meth:`~hail.VariantDataset.filter_alleles_generic`.
+
+        If all alternate alleles of a variant are filtered, the
+        variant itself is filtered.  ``expr`` is evaluated for each
+        alternate allele, but not for the reference allele
+        (i.e. ``aIndex`` will never be zero).
+
+        .. include:: _templates/req_tvariant.rst
 
         **Examples**
 
@@ -1509,8 +1722,6 @@ class VariantDataset(HistoryMixin):
         the *alternate allele* indices.
 
         **Notes**
-
-        If ``filter_altered_genotypes`` is true, genotypes that contain filtered-out alleles are set to missing.
 
         :py:meth:`~hail.VariantDataset.filter_alleles` implements two algorithms for filtering alleles: subset and downcode. We will illustrate their
         behavior on the example genotype below when filtering the first alternate allele (allele 1) at a site with 1 reference
@@ -1616,8 +1827,6 @@ class VariantDataset(HistoryMixin):
 
         :param bool keep: If true, keep variants matching expr
 
-        :param bool filter_altered_genotypes: If true, genotypes that contain filtered-out alleles are set to missing.
-
         :param bool left_aligned: If True, variants are assumed to be
           left aligned and have unique loci.  This avoids a shuffle.
           If the assumption is violated, an error is generated.
@@ -1629,7 +1838,7 @@ class VariantDataset(HistoryMixin):
 
         """
 
-        jvds = self._jvdf.filterAlleles(expr, annotation, filter_altered_genotypes, keep, subset,
+        jvds = self._jvdf.filterAlleles(expr, annotation, keep, subset,
                                         left_aligned, keep_star)
         return VariantDataset(self.hc, jvds)
 

--- a/src/main/scala/is/hail/annotations/Annotation.scala
+++ b/src/main/scala/is/hail/annotations/Annotation.scala
@@ -26,7 +26,7 @@ object Annotation {
       case r: Row =>
         "Struct:\n" +
           r.toSeq.zipWithIndex.map { case (elem, index) =>
-            s"""$spaces[$index] ${printAnnotation(elem, nSpace + 4)}"""
+            s"""$spaces[$index] ${ printAnnotation(elem, nSpace + 4) }"""
           }
             .mkString("\n")
       case a => a.toString + ": " + a.getClass.getSimpleName
@@ -66,7 +66,7 @@ object Annotation {
 
         case TSet(elementType, _) =>
           (a.asInstanceOf[Set[_]]
-            .toArray[Any] : IndexedSeq[_])
+            .toArray[Any]: IndexedSeq[_])
             .map(expandAnnotation(_, elementType))
 
         case TDict(keyType, valueType, _) =>
@@ -155,6 +155,9 @@ object Annotation {
   }
 
   def copy(t: Type, a: Annotation): Annotation = {
+    if (a == null)
+      return null
+
     t match {
       case t: TStruct =>
         val region = MemoryBuffer()

--- a/src/main/scala/is/hail/annotations/Memory.java
+++ b/src/main/scala/is/hail/annotations/Memory.java
@@ -15,12 +15,20 @@ public final class Memory {
         unsafe.putInt(mem, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, i);
     }
 
+    public static void storeLong(byte[] mem, long off, long l) {
+        unsafe.putLong(mem, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, l);
+    }
+
     public static void storeFloat(byte[] mem, long off, float f) {
         unsafe.putFloat(mem, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, f);
     }
 
     public static void storeDouble(byte[] mem, long off, double d) {
         unsafe.putDouble(mem, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, d);
+    }
+
+    public static void storeAddress(byte[] mem, long off, long a) {
+        unsafe.putLong(mem, Unsafe.ARRAY_BYTE_BASE_OFFSET + off, a);
     }
 
     public static byte loadByte(byte[] mem, long off) {
@@ -35,8 +43,17 @@ public final class Memory {
         return unsafe.getInt(mem, Unsafe.ARRAY_BYTE_BASE_OFFSET + off);
     }
 
+    public static long loadLong(byte[] mem, long off) {
+        return unsafe.getLong(mem, Unsafe.ARRAY_BYTE_BASE_OFFSET + off);
+    }
+
     public static double loadDouble(byte[] mem, long off) {
         return unsafe.getDouble(mem, Unsafe.ARRAY_BYTE_BASE_OFFSET + off);
+    }
+
+    public static long loadAddress(byte[] mem, long off) {
+        // Unsafe has no getAddress on Object
+        return unsafe.getLong(mem, Unsafe.ARRAY_BYTE_BASE_OFFSET + off);
     }
 
     public static void memcpy(byte[] dst, long dstOff, byte[] src, long srcOff, long n) {

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -23,7 +23,6 @@ import org.json4s.jackson.JsonMethods
 
 case class MetaData(docstring: Option[String], args: Seq[(String, String)] = Seq.empty[(String, String)])
 
-
 object FunctionRegistry {
 
   sealed trait LookupError {
@@ -962,7 +961,20 @@ object FunctionRegistry {
   registerUnaryNAFilteredCollectionMethod("mean", { (x: TraversableOnce[Float]) => if (x.nonEmpty) box(x.sum / x.size.toDouble) else null }, meanDocstring)(float32Hr, boxedFloat64Hr)
   registerUnaryNAFilteredCollectionMethod("mean", { (x: TraversableOnce[Double]) => if (x.nonEmpty) box(x.sum / x.size.toDouble) else null }, meanDocstring)(float64Hr, boxedFloat64Hr)
 
-  register("range", { (x: Int) => 0 until x: IndexedSeq[Int] },
+  register("range", { (x: Int) =>
+    val a = if (x <= 0) {
+      new Array[Int](0)
+    } else {
+      val a = new Array[Int](x)
+      var i = 0
+      while (i < x) {
+        a(i) = i
+        i += 1
+      }
+      a
+    }
+    a: IndexedSeq[Int]
+  },
     """
     Generate an ``Array`` with values in the interval ``[0, stop)``.
 
@@ -973,7 +985,21 @@ object FunctionRegistry {
         result: [0, 1, 2]
     """,
     "stop" -> "Number of integers (whole numbers) to generate, starting from zero.")
-  register("range", { (x: Int, y: Int) => x until y: IndexedSeq[Int] },
+  register("range", { (x: Int, y: Int) =>
+    val a = if (y <= x) {
+      new Array[Int](0)
+    } else {
+      val l = y - x
+      val a = new Array[Int](l)
+      var i = 0
+      while (i < l) {
+        a(i) = x + i
+        i += 1
+      }
+      a
+    }
+    a: IndexedSeq[Int]
+  },
     """
     Generate an ``Array`` with values in the interval ``[start, stop)``.
 
@@ -985,7 +1011,7 @@ object FunctionRegistry {
     """,
     "start" -> "Starting number of the sequence.",
     "stop" -> "Generate numbers up to, but not including this number.")
-  register("range", { (x: Int, y: Int, step: Int) => x until y by step: IndexedSeq[Int] },
+  register("range", { (x: Int, y: Int, step: Int) => (x until y by step).toArray: IndexedSeq[Int] },
     """
     Generate an ``Array`` with values in the interval ``[start, stop)`` in increments of step.
 
@@ -999,7 +1025,7 @@ object FunctionRegistry {
     "stop" -> "Generate numbers up to, but not including this number.",
     "step" -> "Difference between each number in the sequence.")
 
-  register("Call", { (gt: java.lang.Integer) => gt },
+  registerCode("Call", (gt: Code[java.lang.Integer]) => CM.ret(gt),
     """
     Construct a :ref:`call` from an integer.
     """, "gt" -> "integer")(boxedInt32Hr, callHr)
@@ -1847,8 +1873,17 @@ object FunctionRegistry {
     "expr" -> "Lambda expression."
   )(setHr(TTHr), unaryHr(TTHr, boolHr), TTHr)
 
-  registerLambdaMethod("map", (a: IndexedSeq[Any], f: (Any) => Any) =>
-    a.map(f),
+  registerLambdaMethod("map", (a: IndexedSeq[Any], f: (Any) => Any) => {
+    val l = a.length
+    val r = new Array[Any](a.length)
+    var i = 0
+    while (i < l) {
+      r(i) = f(a(i))
+      i += 1
+    }
+
+    r: IndexedSeq[Any]
+  },
     """
     Returns a new array produced by applying ``expr`` to each element.
 
@@ -1993,11 +2028,21 @@ object FunctionRegistry {
     "expr" -> "Lambda expression."
   )(setHr(TTHr), unaryHr(TTHr, boolHr), boolHr)
 
-  registerLambdaMethod("filter", (a: IndexedSeq[Any], f: (Any) => Any) =>
-    a.filter { x =>
-      val r = f(x)
-      r != null && r.asInstanceOf[Boolean]
-    },
+  registerLambdaMethod("filter", (a: IndexedSeq[Any], f: (Any) => Any) => {
+    val b = new ArrayBuilder[Any](
+      math.min(a.length, ArrayBuilder.defaultInitialCapacity))
+    val l = a.length
+    var i = 0
+    while (i < l) {
+      val x = a(i)
+      val p = f(x)
+      if (p != null && p.asInstanceOf[Boolean]) {
+        b += x
+      }
+      i += 1
+    }
+    new TruncatedArrayIndexedSeq(b.underlying(), b.length): IndexedSeq[Any]
+  },
     """
     Returns a new array subsetted to the elements where ``expr`` evaluates to true.
 

--- a/src/main/scala/is/hail/methods/SplitMulti.scala
+++ b/src/main/scala/is/hail/methods/SplitMulti.scala
@@ -33,7 +33,6 @@ class ExprAnnotator(val ec: EvalContext, t: Type, expr: String, head: Option[Str
       newA = inserters(i)(newA, xs(i))
       i += 1
     }
-    assert(newT.typeCheck(newA))
     newA
   }
 }
@@ -94,7 +93,6 @@ class SplitMultiPartitionContext(
     val nGenotypes = v.nGenotypes
 
     val gs = ur.getAs[IndexedSeq[Any]](3)
-
     splitVariants.iterator
       .map { case (svj, i) =>
         splitRegion.clear()
@@ -105,7 +103,7 @@ class SplitMultiPartitionContext(
         rvb.addAnnotation(newRowType.fieldType(1), svj)
 
         vAnnotator.ec.setAll(globalAnnotation, v, svj, va, i, wasSplit)
-        rvb.addAnnotation(newRowType.fieldType(2), vAnnotator.insert(va))
+        rvb.addAnnotation(vAnnotator.newT, vAnnotator.insert(va))
 
         rvb.startArray(nSamples) // gs
         gAnnotator.ec.setAll(globalAnnotation, v, svj, va, i, wasSplit)
@@ -113,7 +111,7 @@ class SplitMultiPartitionContext(
         while (k < nSamples) {
           val g = gs(k)
           gAnnotator.ec.set(6, g)
-          rvb.addAnnotation(newRowType.fieldType(3).asInstanceOf[TArray].elementType, gAnnotator.insert(g))
+          rvb.addAnnotation(gAnnotator.newT, gAnnotator.insert(g))
           k += 1
         }
         rvb.endArray() // gs

--- a/src/main/scala/is/hail/utils/ArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/ArrayBuilder.scala
@@ -2,11 +2,15 @@ package is.hail.utils
 
 import scala.reflect.ClassTag
 
+object ArrayBuilder {
+  final val defaultInitialCapacity: Int = 16
+}
+
 final class ArrayBuilder[@specialized T](initialCapacity: Int)(implicit tct: ClassTag[T]) {
   private var b: Array[T] = new Array[T](initialCapacity)
   private var size_ : Int = 0
 
-  def this()(implicit tct: ClassTag[T]) = this(16)
+  def this()(implicit tct: ClassTag[T]) = this(ArrayBuilder.defaultInitialCapacity)
 
   def size: Int = size_
 
@@ -57,4 +61,6 @@ final class ArrayBuilder[@specialized T](initialCapacity: Int)(implicit tct: Cla
     Array.copy(b, 0, r, 0, size_)
     r
   }
+
+  def underlying(): Array[T] = b
 }

--- a/src/main/scala/is/hail/utils/TruncatedArrayIndexedSeq.scala
+++ b/src/main/scala/is/hail/utils/TruncatedArrayIndexedSeq.scala
@@ -1,0 +1,12 @@
+package is.hail.utils
+
+class TruncatedArrayIndexedSeq[T](a: Array[T], newLength: Int) extends IndexedSeq[T] with Serializable {
+  def length: Int = newLength
+
+  def apply(idx: Int): T = {
+    if (idx < 0 || idx >= newLength)
+      throw new IndexOutOfBoundsException(idx.toString)
+    a(idx)
+  }
+}
+

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -69,9 +69,11 @@ object VariantSampleMatrix {
     rdd: RDD[(RK, (Annotation, Iterable[T]))]): VariantSampleMatrix = {
     implicit val kOk = metadata.vSignature.orderedKey
     VariantSampleMatrix(hc, metadata, localValue,
-      rdd.map { case (v, (va, gs)) =>
-        (v: Annotation, (va, gs: Iterable[Annotation]))
-      }.toOrderedRDD)
+      rdd.mapPartitions({ it =>
+        it.map { case (v, (va, gs)) =>
+          (v: Annotation, (va, gs: Iterable[Annotation]))
+        }
+      }, preservesPartitioning = true).toOrderedRDD)
   }
 
   def fromLegacy[RK, T](hc: HailContext,
@@ -82,9 +84,11 @@ object VariantSampleMatrix {
     implicit val kOk = metadata.vSignature.orderedKey
     VariantSampleMatrix(hc, metadata, localValue,
       OrderedRDD(
-        rdd.map { case (v, (va, gs)) =>
-          (v: Annotation, (va, gs: Iterable[Annotation]))
-        },
+        rdd.mapPartitions({ it =>
+          it.map { case (v, (va, gs)) =>
+            (v: Annotation, (va, gs: Iterable[Annotation]))
+          }
+        }, preservesPartitioning = true),
         Some(fastKeys.map { k => k: Annotation }), None))
   }
 

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -2017,7 +2017,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
       val rv2b = new RegionValueBuilder()
       val rv2 = RegionValue()
       it.flatMap { rv =>
-        val rvEnd = rv.region.end
+        val rvEnd = rv.region.size
         rv2b.set(rv.region)
         val gsOffset = localRowType.loadField(rv, 3)
         (0 until localNSamples).iterator.map { i =>

--- a/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -755,6 +755,12 @@ class ExprSuite extends SparkSuite {
     assert(eval[IndexedSeq[Int]]("range(10, 14)").contains(IndexedSeq(10, 11, 12, 13)))
     assert(eval[IndexedSeq[Int]]("range(-2, 2)").contains(IndexedSeq(-2, -1, 0, 1)))
 
+    assert(eval[IndexedSeq[Int]]("range(0)").contains(IndexedSeq()))
+    assert(eval[IndexedSeq[Int]]("range(-2)").contains(IndexedSeq()))
+
+    assert(eval[IndexedSeq[Int]]("range(10, 10)").contains(IndexedSeq()))
+    assert(eval[IndexedSeq[Int]]("range(10, 0)").contains(IndexedSeq()))
+
     assert(eval[Boolean]("pcoin(2.0)").contains(true))
     assert(eval[Boolean]("pcoin(-1.0)").contains(false))
     assert(eval[Boolean]("pcoin(2.0.toFloat32())").contains(true))

--- a/src/test/scala/is/hail/vds/FilterAllelesSuite.scala
+++ b/src/test/scala/is/hail/vds/FilterAllelesSuite.scala
@@ -151,35 +151,7 @@ class FilterAllelesSuite extends SparkSuite {
 
     assert(vds.rdd.collect().toSeq == Seq(newRow1))
   }
-
-  @Test def filterSecondOfTwoAllelesFilterAlteredGenotypes(): Unit = {
-    val variant1 = new Variant("contig", 0, "ref", IndexedSeq("alt1", "alt2").map(AltAllele("ref", _)))
-    val va1 = null
-    val genotype11 = Genotype(Option(1), Option(Array(25, 5, 30)), Option(100), Option(5), Option(Array(10, 0, 10, 10, 5, 7)))
-    val genotype12 = Genotype(Option(2), Option(Array(25, 35, 0)), Option(100), Option(5), Option(Array(10, 10, 0, 7, 5, 10)))
-    val genotype13 = Genotype(Option(3), Option(Array(25, 10, 10)), Option(100), Option(5), Option(Array(10, 10, 10, 0, 5, 7)))
-    val genotypes1 = Seq(genotype11, genotype12, genotype13)
-    val row1: (Variant, (Annotation, Iterable[Genotype])) = (variant1, (va1, genotypes1))
-
-    val vds = VariantSampleMatrix.fromLegacy(hc, VSMFileMetadata(Array("1", "2", "3"),
-      IndexedSeq[Annotation](null, null, null),
-      null,
-      TString(),
-      TStruct.empty()),
-      sc.parallelize(Seq(row1)))
-      .filterAlleles("aIndex == 2", subset = true, keep = false, filterAlteredGenotypes = true)
-
-    val newVariant1 = variant1.copy(altAlleles = variant1.altAlleles.take(1))
-    val newVa1 = va1
-    val newGenotype11 = genotype11.copy(gt = Option(1), ad = Option(Array(25, 5)), gq = Option(10), px = Option(Array(10, 0, 10)))
-    val newGenotype12 = genotype12.copy(gt = Option(2), ad = Option(Array(25, 35)), gq = Option(10), px = Option(Array(10, 10, 0)))
-    val newGenotype13 = genotype13.copy(gt = None, ad = Option(Array(25, 10)), gq = Option(0), px = Option(Array(0, 0, 0)))
-    val newGenotypes1 = Seq(newGenotype11, newGenotype12, newGenotype13)
-    val newRow1 = (newVariant1, (newVa1, newGenotypes1))
-
-    assert(vds.rdd.collect().toSeq == Seq(newRow1))
-  }
-
+  
   @Test def filterOneAlleleAndModifyAnnotation(): Unit = {
     val variant1 = new Variant("contig", 0, "ref", IndexedSeq("alt1", "alt2").map(AltAllele("ref", _)))
     val va1 = null


### PR DESCRIPTION
Allocating memory off-heap but relying on the GC to deallocate will
never work.  Since regions are allocated for iterators, it is
difficult to know when we can free the memory.  When hasNext returns
false, but ending iteration early will lead to a memory leak.  We
could define something like a CloseableIterator which closes itself at
the end of iteration and clients have to close if they exit early, but
this won't play nicely with Spark (or Scala iterators, for that
matter).

This doesn't matter in the current setup but will make it somewhat
more difficult to push things into C/C++.