### PR TITLE
Added generic filter_alleles, annotate_alleles.

### DIFF
--- a/src/main/scala/is/hail/methods/SplitMulti.scala
+++ b/src/main/scala/is/hail/methods/SplitMulti.scala
@@ -33,7 +33,6 @@ class ExprAnnotator(val ec: EvalContext, t: Type, expr: String, head: Option[Str
       newA = inserters(i)(newA, xs(i))
       i += 1
     }
-    assert(newT.typeCheck(newA))
     newA
   }
 }
@@ -94,7 +93,6 @@ class SplitMultiPartitionContext(
     val nGenotypes = v.nGenotypes
 
     val gs = ur.getAs[IndexedSeq[Any]](3)
-
     splitVariants.iterator
       .map { case (svj, i) =>
         splitRegion.clear()
@@ -105,7 +103,7 @@ class SplitMultiPartitionContext(
         rvb.addAnnotation(newRowType.fieldType(1), svj)
 
         vAnnotator.ec.setAll(globalAnnotation, v, svj, va, i, wasSplit)
-        rvb.addAnnotation(newRowType.fieldType(2), vAnnotator.insert(va))
+        rvb.addAnnotation(vAnnotator.newT, vAnnotator.insert(va))
 
         rvb.startArray(nSamples) // gs
         gAnnotator.ec.setAll(globalAnnotation, v, svj, va, i, wasSplit)
@@ -113,7 +111,7 @@ class SplitMultiPartitionContext(
         while (k < nSamples) {
           val g = gs(k)
           gAnnotator.ec.set(6, g)
-          rvb.addAnnotation(newRowType.fieldType(3).asInstanceOf[TArray].elementType, gAnnotator.insert(g))
+          rvb.addAnnotation(gAnnotator.newT, gAnnotator.insert(g))
           k += 1
         }
         rvb.endArray() // gs

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -69,9 +69,11 @@ object VariantSampleMatrix {
     rdd: RDD[(RK, (Annotation, Iterable[T]))]): VariantSampleMatrix = {
     implicit val kOk = metadata.vSignature.orderedKey
     VariantSampleMatrix(hc, metadata, localValue,
-      rdd.map { case (v, (va, gs)) =>
-        (v: Annotation, (va, gs: Iterable[Annotation]))
-      }.toOrderedRDD)
+      rdd.mapPartitions({ it =>
+        it.map { case (v, (va, gs)) =>
+          (v: Annotation, (va, gs: Iterable[Annotation]))
+        }
+      }, preservesPartitioning = true).toOrderedRDD)
   }
 
   def fromLegacy[RK, T](hc: HailContext,
@@ -82,9 +84,11 @@ object VariantSampleMatrix {
     implicit val kOk = metadata.vSignature.orderedKey
     VariantSampleMatrix(hc, metadata, localValue,
       OrderedRDD(
-        rdd.map { case (v, (va, gs)) =>
-          (v: Annotation, (va, gs: Iterable[Annotation]))
-        },
+        rdd.mapPartitions({ it =>
+          it.map { case (v, (va, gs)) =>
+            (v: Annotation, (va, gs: Iterable[Annotation]))
+          }
+        }, preservesPartitioning = true),
         Some(fastKeys.map { k => k: Annotation }), None))
   }
 

--- a/src/test/scala/is/hail/vds/FilterAllelesSuite.scala
+++ b/src/test/scala/is/hail/vds/FilterAllelesSuite.scala
@@ -151,35 +151,7 @@ class FilterAllelesSuite extends SparkSuite {
 
     assert(vds.rdd.collect().toSeq == Seq(newRow1))
   }
-
-  @Test def filterSecondOfTwoAllelesFilterAlteredGenotypes(): Unit = {
-    val variant1 = new Variant("contig", 0, "ref", IndexedSeq("alt1", "alt2").map(AltAllele("ref", _)))
-    val va1 = null
-    val genotype11 = Genotype(Option(1), Option(Array(25, 5, 30)), Option(100), Option(5), Option(Array(10, 0, 10, 10, 5, 7)))
-    val genotype12 = Genotype(Option(2), Option(Array(25, 35, 0)), Option(100), Option(5), Option(Array(10, 10, 0, 7, 5, 10)))
-    val genotype13 = Genotype(Option(3), Option(Array(25, 10, 10)), Option(100), Option(5), Option(Array(10, 10, 10, 0, 5, 7)))
-    val genotypes1 = Seq(genotype11, genotype12, genotype13)
-    val row1: (Variant, (Annotation, Iterable[Genotype])) = (variant1, (va1, genotypes1))
-
-    val vds = VariantSampleMatrix.fromLegacy(hc, VSMFileMetadata(Array("1", "2", "3"),
-      IndexedSeq[Annotation](null, null, null),
-      null,
-      TString(),
-      TStruct.empty()),
-      sc.parallelize(Seq(row1)))
-      .filterAlleles("aIndex == 2", subset = true, keep = false, filterAlteredGenotypes = true)
-
-    val newVariant1 = variant1.copy(altAlleles = variant1.altAlleles.take(1))
-    val newVa1 = va1
-    val newGenotype11 = genotype11.copy(gt = Option(1), ad = Option(Array(25, 5)), gq = Option(10), px = Option(Array(10, 0, 10)))
-    val newGenotype12 = genotype12.copy(gt = Option(2), ad = Option(Array(25, 35)), gq = Option(10), px = Option(Array(10, 10, 0)))
-    val newGenotype13 = genotype13.copy(gt = None, ad = Option(Array(25, 10)), gq = Option(0), px = Option(Array(0, 0, 0)))
-    val newGenotypes1 = Seq(newGenotype11, newGenotype12, newGenotype13)
-    val newRow1 = (newVariant1, (newVa1, newGenotypes1))
-
-    assert(vds.rdd.collect().toSeq == Seq(newRow1))
-  }
-
+  
   @Test def filterOneAlleleAndModifyAnnotation(): Unit = {
     val variant1 = new Variant("contig", 0, "ref", IndexedSeq("alt1", "alt2").map(AltAllele("ref", _)))
     val va1 = null


### PR DESCRIPTION
Also nuked filter_altered_genotypes which I don't think anyone was using, couldn't possibly have been the intended implementation, and can now be done generically.

I copied the existing annotate_alleles interface but, in light of generics, I don't like it anymore. I will propose an alternative on the dev forum.
