### PR TITLE
Some improvements for VEP.

### DIFF
--- a/src/main/scala/is/hail/methods/VEP.scala
+++ b/src/main/scala/is/hail/methods/VEP.scala
@@ -246,18 +246,18 @@ object VEP {
 
 
     val plugin = if (properties.getProperty("hail.vep.plugin") != null) {
-         properties.getProperty("hail.vep.plugin")
+      properties.getProperty("hail.vep.plugin")
     } else {
 
-        val humanAncestor = properties.getProperty("hail.vep.lof.human_ancestor")
-        if (humanAncestor == null)
-          fatal("property `hail.vep.lof.human_ancestor' required")
+      val humanAncestor = properties.getProperty("hail.vep.lof.human_ancestor")
+      if (humanAncestor == null)
+        fatal("property `hail.vep.lof.human_ancestor' required")
 
-        val conservationFile = properties.getProperty("hail.vep.lof.conservation_file")
-        if (conservationFile == null)
-          fatal("property `hail.vep.lof.conservation_file' required")
+      val conservationFile = properties.getProperty("hail.vep.lof.conservation_file")
+      if (conservationFile == null)
+        fatal("property `hail.vep.lof.conservation_file' required")
 
-        s"LoF,human_ancestor_fa:$humanAncestor,filter_position:0.05,min_intron_size:15,conservation_file:$conservationFile"
+      s"LoF,human_ancestor_fa:$humanAncestor,filter_position:0.05,min_intron_size:15,conservation_file:$conservationFile"
     }
 
     val fasta = properties.getProperty("hail.vep.fasta")
@@ -296,6 +296,7 @@ object VEP {
     val csqHeader = if (csq) getCSQHeaderDefinition(cmd, perl5lib, path).getOrElse("") else ""
     val alleleNumIndex = if (csq) csqHeader.split("\\|").indexOf("ALLELE_NUM") else -1
 
+    val localRowType = vsm.rowType
     val annotations = vsm.rdd2
       .mapPartitions({ it =>
         val pb = new ProcessBuilder(cmd.toList.asJava)
@@ -306,7 +307,9 @@ object VEP {
           env.put("PATH", path)
 
         it
-          .map { rv => Variant.fromRegionValue(rv) }
+          .map { rv =>
+            Variant.fromRegionValue(rv.region, localRowType.loadField(rv, 1))
+          }
           .grouped(localBlockSize)
           .flatMap { block =>
             val (jt, proc) = block.iterator.pipe(pb,
@@ -380,7 +383,7 @@ object VEP {
 
             val rc = proc.waitFor()
             if (rc != 0)
-              fatal(s"vep command '${cmd.mkString(" ")}' failed with non-zero exit status $rc")
+              fatal(s"vep command '${ cmd.mkString(" ") }' failed with non-zero exit status $rc")
 
             r
           }

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -69,9 +69,11 @@ object VariantSampleMatrix {
     rdd: RDD[(RK, (Annotation, Iterable[T]))]): VariantSampleMatrix = {
     implicit val kOk = metadata.vSignature.orderedKey
     VariantSampleMatrix(hc, metadata, localValue,
-      rdd.map { case (v, (va, gs)) =>
-        (v: Annotation, (va, gs: Iterable[Annotation]))
-      }.toOrderedRDD)
+      rdd.mapPartitions({ it =>
+        it.map { case (v, (va, gs)) =>
+          (v: Annotation, (va, gs: Iterable[Annotation]))
+        }
+      }, preservesPartitioning = true).toOrderedRDD)
   }
 
   def fromLegacy[RK, T](hc: HailContext,
@@ -82,9 +84,11 @@ object VariantSampleMatrix {
     implicit val kOk = metadata.vSignature.orderedKey
     VariantSampleMatrix(hc, metadata, localValue,
       OrderedRDD(
-        rdd.map { case (v, (va, gs)) =>
-          (v: Annotation, (va, gs: Iterable[Annotation]))
-        },
+        rdd.mapPartitions({ it =>
+          it.map { case (v, (va, gs)) =>
+            (v: Annotation, (va, gs: Iterable[Annotation]))
+          }
+        }, preservesPartitioning = true),
         Some(fastKeys.map { k => k: Annotation }), None))
   }
 


### PR DESCRIPTION
RV-ify the easy case.
Preserve partitioning where possible in VSM legacy constructors.