### PR TITLE
IR / RegionValue Aggregators

### DIFF
--- a/src/main/scala/is/hail/annotations/MemoryBlock.scala
+++ b/src/main/scala/is/hail/annotations/MemoryBlock.scala
@@ -27,7 +27,7 @@ final class MemoryBuffer(var mem: Long, var length: Long, var offset: Long = 0) 
     assert(size <= length)
     assert(other.size <= other.length)
     assert(n >= 0)
-    assert(readStart >= 0 && readStart + n <= other.size, s"$readStart, ${other.size} ${n}")
+    assert(readStart >= 0 && readStart + n <= other.size)
     assert(writeStart >= 0 && writeStart + n <= size)
     Memory.memcpy(mem + writeStart, other.mem + readStart, n)
   }

--- a/src/main/scala/is/hail/annotations/MemoryBlock.scala
+++ b/src/main/scala/is/hail/annotations/MemoryBlock.scala
@@ -27,7 +27,7 @@ final class MemoryBuffer(var mem: Long, var length: Long, var offset: Long = 0) 
     assert(size <= length)
     assert(other.size <= other.length)
     assert(n >= 0)
-    assert(readStart >= 0 && readStart + n <= other.size)
+    assert(readStart >= 0 && readStart + n <= other.size, s"$readStart, ${other.size} ${n}")
     assert(writeStart >= 0 && writeStart + n <= size)
     Memory.memcpy(mem + writeStart, other.mem + readStart, n)
   }
@@ -188,33 +188,47 @@ final class MemoryBuffer(var mem: Long, var length: Long, var offset: Long = 0) 
       clearBit(byteOff, bitOff)
   }
 
-  def appendInt(i: Int) {
-    storeInt(alignAndAllocate(4), i)
+  def appendInt(i: Int): Long = {
+    val off = alignAndAllocate(4)
+    storeInt(off, i)
+    off
   }
 
-  def appendLong(l: Long) {
-    storeLong(alignAndAllocate(8), l)
+  def appendLong(l: Long): Long = {
+    val off = alignAndAllocate(8)
+    storeLong(off, l)
+    off
   }
 
-  def appendFloat(f: Float) {
-    storeFloat(alignAndAllocate(4), f)
+  def appendFloat(f: Float): Long = {
+    val off = alignAndAllocate(4)
+    storeFloat(off, f)
+    off
   }
 
-  def appendDouble(d: Double) {
-    storeDouble(alignAndAllocate(8), d)
+  def appendDouble(d: Double): Long = {
+    val off = alignAndAllocate(8)
+    storeDouble(off, d)
+    off
   }
 
-  def appendByte(b: Byte) {
-    storeByte(allocate(1), b)
+  def appendByte(b: Byte): Long = {
+    val off = allocate(1)
+    storeByte(off, b)
+    off
   }
 
-  def appendBytes(bytes: Array[Byte]) {
-    storeBytes(allocate(bytes.length), bytes)
+  def appendBytes(bytes: Array[Byte]): Long = {
+    val off = allocate(bytes.length)
+    storeBytes(off, bytes)
+    off
   }
 
-  def appendBytes(bytes: Array[Byte], bytesOff: Long, n: Int) {
+  def appendBytes(bytes: Array[Byte], bytesOff: Long, n: Int): Long = {
     assert(bytesOff + n <= bytes.length)
-    storeBytes(allocate(n), bytes, bytesOff, n)
+    val off = allocate(n)
+    storeBytes(off, bytes, bytesOff, n)
+    off
   }
 
   def clear(newEnd: Long) {

--- a/src/main/scala/is/hail/annotations/ScalaToRegionValue.scala
+++ b/src/main/scala/is/hail/annotations/ScalaToRegionValue.scala
@@ -1,0 +1,96 @@
+package is.hail.annotations
+
+import is.hail.expr._
+
+object ScalaToRegionValue {
+
+  def addStruct[T: HailRep](region: MemoryBuffer,
+    n1: String, v1: T): Long = {
+    val rvb = new RegionValueBuilder(region)
+    rvb.start(TStruct(
+      n1 -> hailType[T]))
+    rvb.startStruct()
+    rvb.addAnnotation(hailType[T], v1)
+    rvb.endStruct()
+    rvb.end()
+  }
+
+  def addStruct(region: MemoryBuffer,
+    n1: String, t1: Type, offset1: Long): Long = {
+    val rvb = new RegionValueBuilder(region)
+    rvb.start(TStruct(n1 -> t1))
+    rvb.startStruct()
+    rvb.addRegionValue(t1, region, offset1)
+    rvb.endStruct()
+    rvb.end()
+  }
+
+  def addStruct[T: HailRep](region: MemoryBuffer,
+    n1: String, v1: T,
+    n2: String, t2: Type, offset2: Long): Long = {
+    val rvb = new RegionValueBuilder(region)
+    rvb.start(TStruct(n1 -> hailType[T], n2 -> t2))
+    rvb.startStruct()
+    rvb.addAnnotation(hailType[T], v1)
+    rvb.addRegionValue(t2, region, offset2)
+    rvb.endStruct()
+    rvb.end()
+  }
+
+  def addStruct[T: HailRep, U: HailRep](region: MemoryBuffer,
+    n1: String, v1: T,
+    n2: String, v2: U): Long = {
+
+    val rvb = new RegionValueBuilder(region)
+    rvb.start(TStruct(
+      n1 -> hailType[T],
+      n2 -> hailType[U]))
+    rvb.startStruct()
+    rvb.addAnnotation(hailType[T], v1)
+    rvb.addAnnotation(hailType[U], v2)
+    rvb.endStruct()
+    rvb.end()
+  }
+
+  def addStruct[T: HailRep, U: HailRep, V: HailRep](region: MemoryBuffer,
+    n1: String, v1: T,
+    n2: String, v2: U,
+    n3: String, v3: V): Long = {
+
+    val rvb = new RegionValueBuilder(region)
+    rvb.start(TStruct(
+      n1 -> hailType[T],
+      n2 -> hailType[U],
+      n3 -> hailType[V]))
+    rvb.startStruct()
+    rvb.addAnnotation(hailType[T], v1)
+    rvb.addAnnotation(hailType[U], v2)
+    rvb.addAnnotation(hailType[U], v3)
+    rvb.endStruct()
+    rvb.end()
+  }
+
+  def addArray(region: MemoryBuffer, a: Array[Double]): Long = {
+    val rvb = new RegionValueBuilder(region)
+    rvb.start(TArray(TFloat64()))
+    rvb.startArray(a.length)
+    a.foreach(rvb.addDouble(_))
+    rvb.endArray()
+    rvb.end()
+  }
+
+  def addBoxedArray(region: MemoryBuffer, a: Array[java.lang.Double]): Long = {
+    val rvb = new RegionValueBuilder(region)
+    rvb.start(TArray(TFloat64()))
+    rvb.startArray(a.length)
+    a.foreach { e =>
+      if (e == null)
+        rvb.setMissing()
+      else
+        rvb.addDouble(e)
+    }
+    rvb.endArray()
+    rvb.end()
+  }
+
+}

--- a/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -129,12 +129,13 @@ class StagedRegionValueBuilder private(val fb: FunctionBuilder[_], val typ: Type
 
   def addStruct(t: TStruct, f: (StagedRegionValueBuilder => Code[Unit]), init: LocalRef[Boolean] = null): Code[Unit] = f(new StagedRegionValueBuilder(fb, t, this))
 
-  def addPrimitive(t: Type): (Code[_]) => Code[Unit] = t.fundamentalType match {
+  def addRegionValue(t: Type): (Code[_]) => Code[Unit] = t.fundamentalType match {
     case _: TBoolean => v => addBoolean(v.asInstanceOf[Code[Boolean]])
     case _: TInt32 => v => addInt32(v.asInstanceOf[Code[Int]])
     case _: TInt64 => v => addInt64(v.asInstanceOf[Code[Long]])
     case _: TFloat32 => v => addFloat32(v.asInstanceOf[Code[Float]])
     case _: TFloat64 => v => addFloat64(v.asInstanceOf[Code[Double]])
+    case _: TStruct => v => region.copyFrom(region, v.asInstanceOf[Code[Long]], currentOffset, t.byteSize)
     case t => throw new UnsupportedOperationException("addPrimitive only supports primitive types: " + t)
   }
 

--- a/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -136,7 +136,7 @@ class StagedRegionValueBuilder private(val fb: FunctionBuilder[_], val typ: Type
     case _: TFloat32 => v => addFloat32(v.asInstanceOf[Code[Float]])
     case _: TFloat64 => v => addFloat64(v.asInstanceOf[Code[Double]])
     case _: TStruct => v => region.copyFrom(region, v.asInstanceOf[Code[Long]], currentOffset, t.byteSize)
-    case t => throw new UnsupportedOperationException("addPrimitive only supports primitive types: " + t)
+    case t => throw new UnsupportedOperationException("addRegionValue only supports primitive types and structs: " + t)
   }
 
   def advance(): Code[Unit] = {

--- a/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -129,14 +129,16 @@ class StagedRegionValueBuilder private(val fb: FunctionBuilder[_], val typ: Type
 
   def addStruct(t: TStruct, f: (StagedRegionValueBuilder => Code[Unit]), init: LocalRef[Boolean] = null): Code[Unit] = f(new StagedRegionValueBuilder(fb, t, this))
 
-  def addRegionValue(t: Type): (Code[_]) => Code[Unit] = t.fundamentalType match {
+  def addIRIntermediate(t: Type): (Code[_]) => Code[Unit] = t.fundamentalType match {
     case _: TBoolean => v => addBoolean(v.asInstanceOf[Code[Boolean]])
     case _: TInt32 => v => addInt32(v.asInstanceOf[Code[Int]])
     case _: TInt64 => v => addInt64(v.asInstanceOf[Code[Long]])
     case _: TFloat32 => v => addFloat32(v.asInstanceOf[Code[Float]])
     case _: TFloat64 => v => addFloat64(v.asInstanceOf[Code[Double]])
     case _: TStruct => v => region.copyFrom(region, v.asInstanceOf[Code[Long]], currentOffset, t.byteSize)
-    case t => throw new UnsupportedOperationException("addRegionValue only supports primitive types and structs: " + t)
+    case _: TArray => v => region.storeAddress(v.asInstanceOf[Code[Long]], currentOffset)
+    case _: TBinary => v => region.storeAddress(v.asInstanceOf[Code[Long]], currentOffset)
+    case ft => throw new UnsupportedOperationException("Unknown fundamental type: " + ft)
   }
 
   def advance(): Code[Unit] = {

--- a/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -39,7 +39,7 @@ object UnsafeIndexedSeq {
     rvb.endArray()
     new UnsafeIndexedSeq(t, region, rvb.end())
   }
-  (0 to 10).iterator
+
   def empty(t: TArray): UnsafeIndexedSeq = {
     val region = MemoryBuffer()
     val rvb = new RegionValueBuilder(region)

--- a/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -39,7 +39,7 @@ object UnsafeIndexedSeq {
     rvb.endArray()
     new UnsafeIndexedSeq(t, region, rvb.end())
   }
-
+  (0 to 10).iterator
   def empty(t: TArray): UnsafeIndexedSeq = {
     val region = MemoryBuffer()
     val rvb = new RegionValueBuilder(region)

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueSumAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueSumAggregator.scala
@@ -1,0 +1,117 @@
+package is.hail.annotations.aggregators
+
+import is.hail.expr._
+import is.hail.annotations._
+import is.hail.expr.RegionValueAggregator
+
+object RegionValueSumAggregator {
+  def apply(t: Type): RegionValueAggregator = t match {
+    case _: TBoolean => new RegionValueSumBooleanAggregator()
+    case _: TInt32 => new RegionValueSumIntAggregator()
+    case _: TInt64 => new RegionValueSumLongAggregator()
+    case _: TFloat32 => new RegionValueSumFloatAggregator()
+    case _: TFloat64 => new RegionValueSumDoubleAggregator()
+  }
+}
+
+class RegionValueSumBooleanAggregator extends RegionValueAggregator {
+  private var sum: Boolean = false
+
+  def typ: TBoolean = TBoolean(true)
+
+  def seqOp(region: MemoryBuffer, off: Long, missing: Boolean) {
+    if (!missing)
+      sum |= region.loadBoolean(off)
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    sum |= agg2.asInstanceOf[RegionValueSumBooleanAggregator].sum
+  }
+
+  def result(region: MemoryBuffer): Long =
+    region.appendByte(if (sum) 1.toByte else 0.toByte)
+
+  def copy(): RegionValueSumBooleanAggregator = new RegionValueSumBooleanAggregator()
+}
+
+class RegionValueSumIntAggregator extends RegionValueAggregator {
+  private var sum: Int = 0
+
+  def typ: TInt32 = TInt32(true)
+
+  def seqOp(region: MemoryBuffer, off: Long, missing: Boolean) {
+    println(s"hello $off $missing")
+    println(s"hello ${region.loadInt(off)}")
+    if (!missing)
+      sum += region.loadInt(off)
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    sum += agg2.asInstanceOf[RegionValueSumIntAggregator].sum
+  }
+
+  def result(region: MemoryBuffer): Long =
+    region.appendInt(sum)
+
+  def copy(): RegionValueSumIntAggregator = new RegionValueSumIntAggregator()
+}
+
+class RegionValueSumLongAggregator extends RegionValueAggregator {
+  private var sum: Long = 0L
+
+  def typ: TInt64 = TInt64(true)
+
+  def seqOp(region: MemoryBuffer, off: Long, missing: Boolean) {
+    if (!missing)
+      sum += region.loadLong(off)
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    sum += agg2.asInstanceOf[RegionValueSumLongAggregator].sum
+  }
+
+  def result(region: MemoryBuffer): Long =
+    region.appendLong(sum)
+
+  def copy(): RegionValueSumLongAggregator = new RegionValueSumLongAggregator()
+}
+
+class RegionValueSumFloatAggregator extends RegionValueAggregator {
+  private var sum: Float = 0.0f
+
+  def typ: TFloat32 = TFloat32(true)
+
+  def seqOp(region: MemoryBuffer, off: Long, missing: Boolean) {
+    if (!missing)
+      sum += region.loadFloat(off)
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    sum += agg2.asInstanceOf[RegionValueSumFloatAggregator].sum
+  }
+
+  def result(region: MemoryBuffer): Long =
+    region.appendFloat(sum)
+
+  def copy(): RegionValueSumFloatAggregator = new RegionValueSumFloatAggregator()
+}
+
+class RegionValueSumDoubleAggregator extends RegionValueAggregator {
+  private var sum: Double = 0.0
+
+  def typ: TFloat64 = TFloat64(true)
+
+  def seqOp(region: MemoryBuffer, off: Long, missing: Boolean) {
+    if (!missing)
+      sum += region.loadDouble(off)
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    sum += agg2.asInstanceOf[RegionValueSumDoubleAggregator].sum
+  }
+
+  def result(region: MemoryBuffer): Long =
+    region.appendDouble(sum)
+
+  def copy(): RegionValueSumDoubleAggregator = new RegionValueSumDoubleAggregator()
+}

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueSumAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueSumAggregator.scala
@@ -11,6 +11,7 @@ object RegionValueSumAggregator {
     case _: TInt64 => new RegionValueSumLongAggregator()
     case _: TFloat32 => new RegionValueSumFloatAggregator()
     case _: TFloat64 => new RegionValueSumDoubleAggregator()
+    case _ => throw new IllegalArgumentException(s"Cannot sum over values of type $t")
   }
 }
 
@@ -40,8 +41,6 @@ class RegionValueSumIntAggregator extends RegionValueAggregator {
   def typ: TInt32 = TInt32(true)
 
   def seqOp(region: MemoryBuffer, off: Long, missing: Boolean) {
-    println(s"hello $off $missing")
-    println(s"hello ${region.loadInt(off)}")
     if (!missing)
       sum += region.loadInt(off)
   }

--- a/src/main/scala/is/hail/annotations/aggregators/TransformedRegionValueAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/TransformedRegionValueAggregator.scala
@@ -1,0 +1,70 @@
+package is.hail.annotations.aggregators
+
+import is.hail.asm4s._
+import is.hail.expr._
+import is.hail.expr.ir._
+import is.hail.annotations._
+
+object TransformedRegionValueAggregator {
+  /**
+    * {@code tAggIn} is aggregable type to which
+    * TransformedRegionValueAggregator.seqOp will be applied
+    *
+    * The argument to {@code makeTransform} is an IR that evalutes to the
+    * aggregation carrier struct. The output is an IR that evaluates to the
+    * desired input to {@code next.seqOp}.
+    *
+    **/
+  def apply(tAggIn: TAggregable,
+    makeTransform: IR => IR,
+    next: RegionValueAggregator): TransformedRegionValueAggregator = {
+
+    val transform = makeTransform(In(0, tAggIn.carrierStruct))
+    // this struct has Hail type
+    // TransformedRegionValueAggregator.missingnessCarrier
+    val out = MakeStruct(Array(("it", transform.typ, transform)))
+    val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Long]
+    Compile(out, fb)
+    new TransformedRegionValueAggregator(fb.result(), transform.typ, next)
+  }
+}
+
+/**
+  * {@code getTransformer} is a thunk of a function that transforms an
+  * aggregation carrier struct to the desired input to {@code next.seqOp}.
+  *
+  **/
+class TransformedRegionValueAggregator(
+  getTransformer: () => AsmFunction3[MemoryBuffer, Long, Boolean, Long],
+  t: Type,
+  val next: RegionValueAggregator) extends RegionValueAggregator {
+
+  val typ = next.typ
+
+  private val missingnessCarrier = TStruct(true, "x" -> t)
+
+  private val elementIndex = missingnessCarrier.fieldIdx("x")
+
+  private def extractElement(region: MemoryBuffer, offset: Long): Long =
+    missingnessCarrier.loadField(region, offset, elementIndex)
+
+  private def isElementMissing(region: MemoryBuffer, offset: Long): Boolean =
+    !missingnessCarrier.isFieldDefined(region, offset, elementIndex)
+
+  def seqOp(region: MemoryBuffer, offset: Long, missing: Boolean) {
+    val outOffset = getTransformer()(region, offset, missing)
+    next.seqOp(region, extractElement(region, outOffset), isElementMissing(region, outOffset))
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    next.combOp(agg2.asInstanceOf[TransformedRegionValueAggregator].next)
+  }
+
+  def result(region: MemoryBuffer): Long = {
+    next.result(region)
+  }
+
+  def copy(): TransformedRegionValueAggregator =
+    new TransformedRegionValueAggregator(getTransformer, t, next)
+}
+

--- a/src/main/scala/is/hail/annotations/aggregators/TransformedRegionValueAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/TransformedRegionValueAggregator.scala
@@ -19,7 +19,7 @@ object TransformedRegionValueAggregator {
     makeTransform: IR => IR,
     next: RegionValueAggregator): TransformedRegionValueAggregator = {
 
-    val transform = makeTransform(In(0, tAggIn.withScopeStruct))
+    val transform = makeTransform(In(0, tAggIn.elementAndScopeStruct))
     val out = makeCarrier(transform)
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Long]
     Compile(out, fb)

--- a/src/main/scala/is/hail/annotations/aggregators/ZippedRegionValueAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/ZippedRegionValueAggregator.scala
@@ -1,0 +1,38 @@
+package is.hail.annotations.aggregators
+
+import is.hail.expr._
+import is.hail.annotations._
+
+/**
+  * This class gaurantees that the fields of the resulting struct are numbered
+  * in the same order as the array of aggregators given to the constructor
+  *
+  **/
+class ZippedRegionValueAggregator(val aggs: Array[RegionValueAggregator]) extends RegionValueAggregator {
+
+  private val fields = aggs.map(_.typ).zipWithIndex.map { case (t, i) => (i.toString -> t) }
+
+  val typ: TStruct = TStruct(true, fields:_*)
+
+  def seqOp(region: MemoryBuffer, off: Long, missing: Boolean) {
+    aggs.foreach(_.seqOp(region, off, missing))
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    (aggs zip agg2.asInstanceOf[ZippedRegionValueAggregator].aggs)
+      .foreach { case (l,r) => l.combOp(r) }
+  }
+
+  def result(region: MemoryBuffer): Long = {
+    val rvb = new RegionValueBuilder(region)
+    rvb.start(typ)
+    rvb.startStruct()
+    aggs.foreach(agg => rvb.addRegionValue(agg.typ, region, agg.result(region)))
+    rvb.endStruct()
+    rvb.end()
+  }
+
+  def copy(): ZippedRegionValueAggregator =
+    new ZippedRegionValueAggregator(aggs.map(_.copy))
+}
+

--- a/src/main/scala/is/hail/annotations/aggregators/ZippedRegionValueAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/ZippedRegionValueAggregator.scala
@@ -19,7 +19,7 @@ class ZippedRegionValueAggregator(val aggs: Array[RegionValueAggregator]) extend
   }
 
   def combOp(agg2: RegionValueAggregator) {
-    (aggs zip agg2.asInstanceOf[ZippedRegionValueAggregator].aggs)
+    aggs.zip(agg2.asInstanceOf[ZippedRegionValueAggregator].aggs)
       .foreach { case (l,r) => l.combOp(r) }
   }
 

--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -699,6 +699,10 @@ class CodeObject[T >: Null](val lhs: Code[T])(implicit tct: ClassTag[T], tti: Ty
     (implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2], a3ct: ClassTag[A3], sct: ClassTag[S]): Code[S] =
     invoke[S](method, Array[Class[_]](a1ct.runtimeClass, a2ct.runtimeClass, a3ct.runtimeClass), Array[Code[_]](a1, a2, a3))
 
+  def invoke[A1, A2, A3, A4, S](method: String, a1: Code[A1], a2: Code[A2], a3: Code[A3], a4: Code[A4])
+    (implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2], a3ct: ClassTag[A3], a4ct: ClassTag[A4], sct: ClassTag[S]): Code[S] =
+    invoke[S](method, Array[Class[_]](a1ct.runtimeClass, a2ct.runtimeClass, a3ct.runtimeClass, a4ct.runtimeClass), Array[Code[_]](a1, a2, a3, a4))
+
   def ifNull[T](cnullcase: Code[T], cnonnullcase: Code[T]): Code[T] =
     new Code[T] {
       def emit(il: Growable[AbstractInsnNode]): Unit = {

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -840,6 +840,12 @@ final case class TAggregable(elementType: Type, override val required: Boolean =
   def bindingTypes: Array[(String, Type)] =
     symTab.map { case (n, (_, t)) => (n, t) }.toArray
 
+  def elementWithScopeType: TStruct =
+    TStruct((("x", elementType) +: bindingTypes):_*)
+
+  import is.hail.expr.ir.{IR, GetField}
+  def getElement(agg: IR): IR = GetField(agg, "x")
+
   override def unify(concrete: Type): Boolean = {
     concrete match {
       case TAggregable(celementType, _) => elementType.unify(celementType)

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -846,6 +846,11 @@ final case class TAggregable(elementType: Type, override val required: Boolean =
   def carrierStruct: TStruct =
     TStruct("x" -> elementType, "scope" -> scopeStruct)
 
+  /**
+    * For testing only because {@code Annotation} is not an allocation free
+    * interface.
+    *
+    **/
   def createCarrier(region: MemoryBuffer, x: Annotation, bindingValues: Annotation*): Long = {
     val rvb = new RegionValueBuilder()
     rvb.set(region)
@@ -854,6 +859,110 @@ final case class TAggregable(elementType: Type, override val required: Boolean =
     rvb.addAnnotation(elementType, x)
     rvb.startStruct()
     (bindings.map(_._2) zip bindingValues).foreach((rvb.addAnnotation _).tupled)
+    rvb.endStruct()
+    rvb.endStruct()
+    rvb.end()
+  }
+
+  /**
+    * FIXME: how to abstract over the next five methods without allocation
+    *
+    **/
+  def createCarrier(region: MemoryBuffer,
+    x: Long, mx: Boolean,
+    a0: Long, ma0: Boolean): Long = {
+    assert(bindings.length == 1)
+    val rvb = new RegionValueBuilder()
+    rvb.set(region)
+    rvb.start(carrierStruct)
+    rvb.startStruct()
+    if (mx) rvb.setMissing() else rvb.addAnnotation(elementType, mx)
+    rvb.startStruct()
+    if (ma0) rvb.setMissing() else rvb.addAnnotation(bindings(0)._2, a0)
+    rvb.endStruct()
+    rvb.endStruct()
+    rvb.end()
+  }
+
+  def createCarrier(region: MemoryBuffer,
+    x: Long, mx: Boolean,
+    a0: Long, ma0: Boolean,
+    a1: Long, ma1: Boolean): Long = {
+    assert(bindings.length == 2)
+    val rvb = new RegionValueBuilder()
+    rvb.set(region)
+    rvb.start(carrierStruct)
+    rvb.startStruct()
+    if (mx) rvb.setMissing() else rvb.addAnnotation(elementType, mx)
+    rvb.startStruct()
+    if (ma0) rvb.setMissing() else rvb.addAnnotation(bindings(0)._2, a0)
+    if (ma1) rvb.setMissing() else rvb.addAnnotation(bindings(1)._2, a1)
+    rvb.endStruct()
+    rvb.endStruct()
+    rvb.end()
+  }
+
+  def createCarrier(region: MemoryBuffer,
+    x: Long, mx: Boolean,
+    a0: Long, ma0: Boolean,
+    a1: Long, ma1: Boolean,
+    a2: Long, ma2: Boolean): Long = {
+    assert(bindings.length == 3)
+    val rvb = new RegionValueBuilder()
+    rvb.set(region)
+    rvb.start(carrierStruct)
+    rvb.startStruct()
+    if (mx) rvb.setMissing() else rvb.addAnnotation(elementType, mx)
+    rvb.startStruct()
+    if (ma0) rvb.setMissing() else rvb.addAnnotation(bindings(0)._2, a0)
+    if (ma1) rvb.setMissing() else rvb.addAnnotation(bindings(1)._2, a1)
+    if (ma2) rvb.setMissing() else rvb.addAnnotation(bindings(2)._2, a2)
+    rvb.endStruct()
+    rvb.endStruct()
+    rvb.end()
+  }
+
+  def createCarrier(region: MemoryBuffer,
+    x: Long, mx: Boolean,
+    a0: Long, ma0: Boolean,
+    a1: Long, ma1: Boolean,
+    a2: Long, ma2: Boolean,
+    a3: Long, ma3: Boolean): Long = {
+    assert(bindings.length == 4)
+    val rvb = new RegionValueBuilder()
+    rvb.set(region)
+    rvb.start(carrierStruct)
+    rvb.startStruct()
+    if (mx) rvb.setMissing() else rvb.addAnnotation(elementType, mx)
+    rvb.startStruct()
+    if (ma0) rvb.setMissing() else rvb.addAnnotation(bindings(0)._2, a0)
+    if (ma1) rvb.setMissing() else rvb.addAnnotation(bindings(1)._2, a1)
+    if (ma2) rvb.setMissing() else rvb.addAnnotation(bindings(2)._2, a2)
+    if (ma3) rvb.setMissing() else rvb.addAnnotation(bindings(3)._2, a3)
+    rvb.endStruct()
+    rvb.endStruct()
+    rvb.end()
+  }
+
+  def createCarrier(region: MemoryBuffer,
+    x: Long, mx: Boolean,
+    a0: Long, ma0: Boolean,
+    a1: Long, ma1: Boolean,
+    a2: Long, ma2: Boolean,
+    a3: Long, ma3: Boolean,
+    a4: Long, ma4: Boolean): Long = {
+    assert(bindings.length == 5)
+    val rvb = new RegionValueBuilder()
+    rvb.set(region)
+    rvb.start(carrierStruct)
+    rvb.startStruct()
+    if (mx) rvb.setMissing() else rvb.addAnnotation(elementType, mx)
+    rvb.startStruct()
+    if (ma0) rvb.setMissing() else rvb.addAnnotation(bindings(0)._2, a0)
+    if (ma1) rvb.setMissing() else rvb.addAnnotation(bindings(1)._2, a1)
+    if (ma2) rvb.setMissing() else rvb.addAnnotation(bindings(2)._2, a2)
+    if (ma3) rvb.setMissing() else rvb.addAnnotation(bindings(3)._2, a3)
+    if (ma4) rvb.setMissing() else rvb.addAnnotation(bindings(4)._2, a4)
     rvb.endStruct()
     rvb.endStruct()
     rvb.end()

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -1684,12 +1684,16 @@ object TStruct {
 
   def empty(required: Boolean = false): TStruct = if (required) requiredEmpty else optionalEmpty
 
-  def apply(args: (String, Type)*): TStruct =
+  def apply(required: Boolean, args: (String, Type)*): TStruct =
     TStruct(args
       .iterator
       .zipWithIndex
       .map { case ((n, t), i) => Field(n, t, i) }
-      .toArray)
+      .toArray,
+      required)
+
+  def apply(args: (String, Type)*): TStruct =
+    apply(false, args:_*)
 
   def apply(names: java.util.ArrayList[String], types: java.util.ArrayList[Type], required: Boolean): TStruct = {
     val sNames = names.asScala.toArray

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -847,7 +847,7 @@ final case class TAggregable(elementType: Type, override val required: Boolean =
 
   private val scopeField = "scope"
 
-  def withScopeStruct: TStruct =
+  def elementAndScopeStruct: TStruct =
     TStruct(elementField -> elementType, scopeField -> scopeStruct)
 
   import is.hail.expr.ir.{IR, GetField, MakeStruct, Let}
@@ -865,13 +865,13 @@ final case class TAggregable(elementType: Type, override val required: Boolean =
     * FIXME: how to abstract over the next five methods without allocation
     *
     **/
-  def createCarrier(region: MemoryBuffer,
+  def createScopeCarrier(region: MemoryBuffer,
     x: Long, mx: Boolean,
     a0: Long, ma0: Boolean): Long = {
     assert(bindings.length == 1)
     val rvb = new RegionValueBuilder()
     rvb.set(region)
-    rvb.start(withScopeStruct)
+    rvb.start(elementAndScopeStruct)
     rvb.startStruct()
     if (mx) rvb.setMissing() else rvb.addRegionValue(elementType, region, x)
     rvb.startStruct()
@@ -881,14 +881,14 @@ final case class TAggregable(elementType: Type, override val required: Boolean =
     rvb.end()
   }
 
-  def createCarrier(region: MemoryBuffer,
+  def createScopeCarrier(region: MemoryBuffer,
     x: Long, mx: Boolean,
     a0: Long, ma0: Boolean,
     a1: Long, ma1: Boolean): Long = {
     assert(bindings.length == 2)
     val rvb = new RegionValueBuilder()
     rvb.set(region)
-    rvb.start(withScopeStruct)
+    rvb.start(elementAndScopeStruct)
     rvb.startStruct()
     if (mx) rvb.setMissing() else rvb.addRegionValue(elementType, region, x)
     rvb.startStruct()
@@ -899,7 +899,7 @@ final case class TAggregable(elementType: Type, override val required: Boolean =
     rvb.end()
   }
 
-  def createCarrier(region: MemoryBuffer,
+  def createScopeCarrier(region: MemoryBuffer,
     x: Long, mx: Boolean,
     a0: Long, ma0: Boolean,
     a1: Long, ma1: Boolean,
@@ -907,7 +907,7 @@ final case class TAggregable(elementType: Type, override val required: Boolean =
     assert(bindings.length == 3)
     val rvb = new RegionValueBuilder()
     rvb.set(region)
-    rvb.start(withScopeStruct)
+    rvb.start(elementAndScopeStruct)
     rvb.startStruct()
     if (mx) rvb.setMissing() else rvb.addRegionValue(elementType, region, x)
     rvb.startStruct()
@@ -919,7 +919,7 @@ final case class TAggregable(elementType: Type, override val required: Boolean =
     rvb.end()
   }
 
-  def createCarrier(region: MemoryBuffer,
+  def createScopeCarrier(region: MemoryBuffer,
     x: Long, mx: Boolean,
     a0: Long, ma0: Boolean,
     a1: Long, ma1: Boolean,
@@ -928,7 +928,7 @@ final case class TAggregable(elementType: Type, override val required: Boolean =
     assert(bindings.length == 4)
     val rvb = new RegionValueBuilder()
     rvb.set(region)
-    rvb.start(withScopeStruct)
+    rvb.start(elementAndScopeStruct)
     rvb.startStruct()
     if (mx) rvb.setMissing() else rvb.addRegionValue(elementType, region, x)
     rvb.startStruct()
@@ -941,7 +941,7 @@ final case class TAggregable(elementType: Type, override val required: Boolean =
     rvb.end()
   }
 
-  def createCarrier(region: MemoryBuffer,
+  def createScopeCarrier(region: MemoryBuffer,
     x: Long, mx: Boolean,
     a0: Long, ma0: Boolean,
     a1: Long, ma1: Boolean,
@@ -951,7 +951,7 @@ final case class TAggregable(elementType: Type, override val required: Boolean =
     assert(bindings.length == 5)
     val rvb = new RegionValueBuilder()
     rvb.set(region)
-    rvb.start(withScopeStruct)
+    rvb.start(elementAndScopeStruct)
     rvb.startStruct()
     if (mx) rvb.setMissing() else rvb.addRegionValue(elementType, region, x)
     rvb.startStruct()

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -837,6 +837,9 @@ final case class TAggregable(elementType: Type, override val required: Boolean =
   // not used for equality
   var symTab: SymbolTable = _
 
+  def bindingTypes: Array[(String, Type)] =
+    symTab.map { case (n, (_, t)) => (n, t) }.toArray
+
   override def unify(concrete: Type): Boolean = {
     concrete match {
       case TAggregable(celementType, _) => elementType.unify(celementType)

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -154,7 +154,7 @@ object Compile {
 
       case MakeArray(args, typ) =>
         val srvb = new StagedRegionValueBuilder(fb, typ)
-        val addElement = srvb.addRegionValue(typ.elementType)
+        val addElement = srvb.addIRIntermediate(typ.elementType)
         val mvargs = args.map(compile(_))
         present(Code(
           srvb.start(args.length, init = true),
@@ -206,7 +206,7 @@ object Compile {
         val tin = a.typ.asInstanceOf[TArray]
         val tout = x.typ.asInstanceOf[TArray]
         val srvb = new StagedRegionValueBuilder(fb, tout)
-        val addElement = srvb.addRegionValue(tout.elementType)
+        val addElement = srvb.addIRIntermediate(tout.elementType)
         val eti = typeToTypeInfo(elementTyp).asInstanceOf[TypeInfo[Any]]
         val xa = fb.newLocal[Long]("am_a")
         val xmv = mb.newBit()
@@ -292,7 +292,7 @@ object Compile {
           Code(initializers.map { case (t, (dov, mv, vv)) =>
             Code(
               dov,
-              mv.mux(srvb.setMissing(), srvb.addRegionValue(t)(vv)),
+              mv.mux(srvb.setMissing(), srvb.addIRIntermediate(t)(vv)),
               srvb.advance()) }: _*),
           srvb.offset))
       case GetField(o, name, _) =>

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -288,7 +288,7 @@ object Compile {
         val initializers = fields.map { case (_, t, v) => (t, compile(v)) }
         val srvb = new StagedRegionValueBuilder(fb, t)
         present(Code(
-          srvb.start(false),
+          srvb.start(true),
           Code(initializers.map { case (t, (dov, mv, vv)) =>
             Code(
               dov,
@@ -307,7 +307,7 @@ object Compile {
           xo := coerce[Long](xmo.mux(defaultValue(t), vo)))
         (setup,
           xmo || !t.isFieldDefined(region, xo, fieldIdx),
-          region.loadPrimitive(t)(t.fieldOffset(xo, fieldIdx)))
+          region.loadPrimitive(t.fieldType(fieldIdx))(t.fieldOffset(xo, fieldIdx)))
       case GetFieldMissingness(o, name) =>
         val t = o.typ.asInstanceOf[TStruct]
         val fieldIdx = t.fieldIdx(name)

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -154,7 +154,7 @@ object Compile {
 
       case MakeArray(args, typ) =>
         val srvb = new StagedRegionValueBuilder(fb, typ)
-        val addElement = srvb.addPrimitive(typ.elementType)
+        val addElement = srvb.addRegionValue(typ.elementType)
         val mvargs = args.map(compile(_))
         present(Code(
           srvb.start(args.length, init = true),
@@ -206,7 +206,7 @@ object Compile {
         val tin = a.typ.asInstanceOf[TArray]
         val tout = x.typ.asInstanceOf[TArray]
         val srvb = new StagedRegionValueBuilder(fb, tout)
-        val addElement = srvb.addPrimitive(tout.elementType)
+        val addElement = srvb.addRegionValue(tout.elementType)
         val eti = typeToTypeInfo(elementTyp).asInstanceOf[TypeInfo[Any]]
         val xa = fb.newLocal[Long]("am_a")
         val xmv = mb.newBit()
@@ -292,7 +292,7 @@ object Compile {
           Code(initializers.map { case (t, (dov, mv, vv)) =>
             Code(
               dov,
-              mv.mux(srvb.setMissing(), srvb.addPrimitive(t)(vv)),
+              mv.mux(srvb.setMissing(), srvb.addRegionValue(t)(vv)),
               srvb.advance()) }: _*),
           srvb.offset))
       case GetField(o, name, _) =>

--- a/src/main/scala/is/hail/expr/ir/Env.scala
+++ b/src/main/scala/is/hail/expr/ir/Env.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir
 
 object Env {
   type K = String
+  def empty[V]: Env[V] = new Env()
 }
 
 class Env[V] private (val m: Map[Env.K,V]) {

--- a/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -30,7 +30,7 @@ object ExtractAggregators {
         assert(typ.isRealizable)
         ir
       case AggIn(_) =>
-        throw new RuntimeException(s"AggMap must be used inside an AggSum, but found: $ir")
+        throw new RuntimeException(s"AggIn must be used inside an AggSum, but found: $ir")
       case AggMap(a, name, body, typ) =>
         throw new RuntimeException(s"AggMap must be used inside an AggSum, but found: $ir")
       case AggSum(a, typ) =>
@@ -53,16 +53,16 @@ object ExtractAggregators {
         aggIn
       case AggMap(a, name, body, typ) =>
         val tA = a.typ.asInstanceOf[TAggregable]
-        val tLoweredA = tA.carrierStruct
+        val tLoweredA = tA.withScopeStruct
         val la = lower(a)
-        assert(la.typ == tLoweredA, s"type after lowering, ${la.typ}, should be the carrier struct of ${a.typ}")
-        tA.inContext(la, e => Let(name, e, lower(body), typ.elementType))
+        assert(la.typ == tLoweredA, s"type after lowering, ${la.typ}, should be the carrier struct of ${a.typ}; $ir")
+        tA.inScope(la, e => Let(name, e, lower(body), typ.elementType))
       case AggSum(_, _) =>
-        throw new RuntimeException(s"Found aggregator inside an aggregator: $ir")
+        throw new RuntimeException(s"No nested aggregations allowed: $ir")
       case In(i, typ) =>
-        throw new RuntimeException(s"Referenced input inside an aggregator, that's a no-no: $ir")
+        throw new RuntimeException(s"No inputs may be referenced inside an aggregator: $ir")
       case InMissingness(i) =>
-        throw new RuntimeException(s"Referenced input inside an aggregator, that's a no-no: $ir")
+        throw new RuntimeException(s"No inputs may be referenced inside an aggregator: $ir")
       case _ => Recur(lower)(ir)
     }
   }

--- a/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -1,14 +1,8 @@
 package is.hail.expr.ir
 
-import is.hail.methods._
-import is.hail.annotations._
 import is.hail.annotations.aggregators._
-import is.hail.asm4s._
-import is.hail.expr
-import is.hail.expr.{Type, Aggregator, TAggregable, TArray, TBoolean, TContainer, TFloat32, TFloat64, TInt32, TInt64, TStruct, RegionValueAggregator}
+import is.hail.expr.{RegionValueAggregator, TAggregable}
 import is.hail.utils._
-import org.objectweb.asm.Opcodes._
-import org.objectweb.asm.tree._
 
 import scala.language.existentials
 
@@ -16,90 +10,21 @@ object ExtractAggregators {
 
   private case class IRAgg(in: In, agg: RegionValueAggregator) { }
 
-  private object TransformedRegionValueAggregator {
-    def apply(aggT: TAggregable,
-      makeTransform: IR => IR,
-      next: RegionValueAggregator): TransformedRegionValueAggregator = {
-      val transform = makeTransform(In(0, aggT.carrierStruct))
-      // without a struct we cannot return the missingness of `transform`
-      assert(transform.typ != null, s"found null type: $transform")
-      println(s"transform: $transform")
-      val outT = TStruct(true, "it" -> transform.typ)
-      val itIndex = outT.fieldIdx("it")
-      val out = MakeStruct(Array(("it", transform.typ, transform)))
-      val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Long]
-      Compile(out, fb)
-      new TransformedRegionValueAggregator(aggT, fb.result(), outT, itIndex, next)
-    }
+  def apply(ir: IR, tAggIn: TAggregable): (IR, RegionValueAggregator) = {
+    val (ir2, aggs) = extract(ir, tAggIn)
+    val combined = new ZippedRegionValueAggregator(aggs map (_.agg))
+    aggs.foreach(_.in.typ = combined.typ)
+    (ir2, combined)
   }
 
-  private class TransformedRegionValueAggregator(
-    aggT: TAggregable,
-    getTransformer: () => AsmFunction3[MemoryBuffer, Long, Boolean, Long],
-    outT: TStruct,
-    itIndex: Int,
-    val next: RegionValueAggregator) extends RegionValueAggregator {
-    val typ = next.typ
-
-    def seqOp(region: MemoryBuffer, off: Long, missing: Boolean) {
-      val outOff = getTransformer()(region, off, missing)
-      println(s"seqOp ${outT.loadField(region, outOff, itIndex)} ${!outT.isFieldDefined(region, outOff, itIndex)}")
-      next.seqOp(region, outT.loadField(region, outOff, itIndex), !outT.isFieldDefined(region, outOff, itIndex))
-    }
-
-    def combOp(agg2: RegionValueAggregator) {
-      next.combOp(agg2.asInstanceOf[TransformedRegionValueAggregator].next)
-    }
-
-    def result(region: MemoryBuffer): Long = {
-      next.result(region)
-    }
-
-    def copy(): TransformedRegionValueAggregator =
-      new TransformedRegionValueAggregator(aggT, getTransformer, outT, itIndex, next)
-  }
-
-  class ZippedRegionValueAggregator(val aggs: Array[RegionValueAggregator]) {
-    private val fields = aggs.map(_.typ).zipWithIndex.map { case (t, i) => (i.toString -> t) }
-    val typ: TStruct = TStruct(true, fields:_*)
-
-    def seqOp(region: MemoryBuffer, off: Long, missing: Boolean) {
-      aggs.foreach(_.seqOp(region, off, missing))
-    }
-
-    def combOp(agg2: RegionValueAggregator) {
-      (aggs zip agg2.asInstanceOf[ZippedRegionValueAggregator].aggs)
-        .foreach { case (l,r) => l.combOp(r) }
-    }
-
-    def result(region: MemoryBuffer): Long = {
-      val rvb = new RegionValueBuilder(region)
-      rvb.start(typ)
-      rvb.startStruct()
-      aggs.foreach(agg => rvb.addRegionValue(agg.typ, region, agg.result(region)))
-      rvb.endStruct()
-      rvb.end()
-    }
-
-    def copy(): ZippedRegionValueAggregator =
-      new ZippedRegionValueAggregator(aggs.map(_.copy))
-  }
-
-  def apply(ir: IR, aggT: TAggregable): (IR, ZippedRegionValueAggregator) = {
-    val (ir2, aggs) = extract(ir, aggT)
-    val zrva = new ZippedRegionValueAggregator(aggs map (_.agg))
-    aggs.foreach(_.in.typ = zrva.typ)
-    (ir2, zrva)
-  }
-
-  private def extract(ir: IR, aggT: TAggregable): (IR, Array[IRAgg]) = {
+  private def extract(ir: IR, tAggIn: TAggregable): (IR, Array[IRAgg]) = {
     val ab = new ArrayBuilder[IRAgg]()
-    val ir2 = extract(ir, ab, aggT)
+    val ir2 = extract(ir, ab, tAggIn)
     (ir2, ab.result())
   }
 
-  private def extract(ir: IR, ab: ArrayBuilder[IRAgg], aggT: TAggregable): IR = {
-    def extract(ir: IR): IR = this.extract(ir, ab, aggT)
+  private def extract(ir: IR, ab: ArrayBuilder[IRAgg], tAggIn: TAggregable): IR = {
+    def extract(ir: IR): IR = this.extract(ir, ab, tAggIn)
     ir match {
       case Ref(name, typ) =>
         assert(typ.isRealizable)
@@ -109,28 +34,29 @@ object ExtractAggregators {
       case AggMap(a, name, body, typ) =>
         throw new RuntimeException(s"AggMap must be used inside an AggSum, but found: $ir")
       case AggSum(a, typ) =>
-        val tAgg = a.typ.asInstanceOf[TAggregable]
+        val tChildAgg = a.typ.asInstanceOf[TAggregable]
         val in = In(0, null)
         ab += IRAgg(in,
-          TransformedRegionValueAggregator(aggT,
-            aggin => tAgg.getElement(lower(a, aggin)),
-            RegionValueSumAggregator(tAgg.elementType)))
+          TransformedRegionValueAggregator(tAggIn,
+            aggin => tChildAgg.getElement(lower(a, aggin, tAggIn)),
+            RegionValueSumAggregator(tChildAgg.elementType)))
         GetField(in, (ab.length - 1).toString(), typ)
       case _ => Recur(extract)(ir)
     }
   }
 
-  private def lower(ir: IR, aggIn: IR): IR = {
-    def lower(ir: IR): IR = this.lower(ir, aggIn)
+  private def lower(ir: IR, aggIn: IR, tAggIn: TAggregable): IR = {
+    def lower(ir: IR): IR = this.lower(ir, aggIn, tAggIn)
     ir match {
       case AggIn(typ) =>
+        assert(tAggIn == typ)
         aggIn
       case AggMap(a, name, body, typ) =>
-        val tAgg = a.typ.asInstanceOf[TAggregable]
-        val tA = tAgg.carrierStruct
+        val tA = a.typ.asInstanceOf[TAggregable]
+        val tLoweredA = tA.carrierStruct
         val la = lower(a)
-        assert(la.typ == tA, s"should have same type ${la.typ} $tA, $la")
-        tAgg.inContext(la, e => Let(name, e, lower(body), typ.elementType))
+        assert(la.typ == tLoweredA, s"type after lowering, ${la.typ}, should be the carrier struct of ${a.typ}")
+        tA.inContext(la, e => Let(name, e, lower(body), typ.elementType))
       case AggSum(_, _) =>
         throw new RuntimeException(s"Found aggregator inside an aggregator: $ir")
       case In(i, typ) =>

--- a/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -1,0 +1,193 @@
+package is.hail.expr.ir
+
+import is.hail.annotations._
+import is.hail.asm4s._
+import is.hail.expr
+import is.hail.expr.{Type, Aggregator, TAggregable, TArray, TBoolean, TContainer, TFloat32, TFloat64, TInt32, TInt64, TStruct}
+import is.hail.utils._
+import org.objectweb.asm.Opcodes._
+import org.objectweb.asm.tree._
+
+import scala.language.existentials
+
+object ExtractAggregators {
+
+  private case class IRAgg(in: In, t: Type, z: IR, seq: (IR, IR) => IR, comb: (IR, IR) => IR) { }
+
+  trait Aggregable {
+    def aggregate(zero: Long, seq: (Long, Long) => Long, comb: (Long, Long) => Long): Long
+  }
+
+  def apply(ir: IR, t: TAggregable): (IR, TStruct, (MemoryBuffer, Aggregable) => Long) = {
+    val (ir2, aggs) = extract(ir)
+    val fields = aggs.map(_.t).zipWithIndex.map { case (t, i) => (i.toString -> t) }
+    val tT: TStruct = TStruct("x" -> t.elementType, t.bindingTypes:_*)
+    val tU: TStruct = TStruct(fields:_*)
+    def zipValues(irs: Iterable[IR]): IR =
+      MakeStruct(fields.zip(irs).map { case ((n, t), v) => (n, t, v) })
+    val zeroFb = FunctionBuilder.functionBuilder[Long]
+    Compile(zipValues(aggs.map(_.z)), zeroFb)
+    val seqFb = FunctionBuilder.functionBuilder[Long, Long, Long]
+    Compile(zipValues(aggs.zipWithIndex.map { case (x, i) =>
+      x.seq(GetField(In(0, tU), i.toString()), In(1, tT)) }), seqFb)
+    val combFb = FunctionBuilder.functionBuilder[Long, Long, Long]
+    Compile(zipValues(aggs.zipWithIndex.map { case (x, i) =>
+      x.comb(GetField(In(0, tU), i.toString()), GetField(In(0, tU), i.toString())) }), combFb)
+
+    // update all the references to the intermedaite
+    aggs.map(_.in).foreach(_.typ = tU)
+
+    val zero = zeroFb.result()
+    val seq = seqFb.result()
+    val comb = combFb.result()
+
+    (ir2, tU, { (r, agg) =>
+      // load classes into JVM
+      val f = seq()
+      val g = comb()
+      agg.aggregate(zero()(), (t, u) => f(t, u), (l, r) => g(l, r))
+    })
+  }
+
+  private def extract(ir: IR): (IR, Array[IRAgg]) = {
+    val ab = new ArrayBuilder[IRAgg]()
+    val ir2 = extract(ir, ab)
+    (ir2, ab.result())
+  }
+
+  private def extract(ir: IR, ab: ArrayBuilder[IRAgg]): IR = {
+    def extract(ir: IR): IR = this.extract(ir, ab)
+    ir match {
+      case I32(x) => ir
+      case I64(x) => ir
+      case F32(x) => ir
+      case F64(x) => ir
+      case True() => ir
+      case False() => ir
+      case Cast(v, typ) =>
+        extract(v)
+      case NA(typ) => ir
+      case MapNA(name, value, body, typ) =>
+        MapNA(name, extract(value), extract(body), typ)
+      case IsNA(value) =>
+        IsNA(extract(value))
+      case If(cond, cnsq, altr, typ) =>
+        If(extract(cond), extract(cnsq), extract(altr), typ)
+      case Let(name, value, body, typ) =>
+        Let(name, extract(value), extract(body), typ)
+      case Ref(name, typ) =>
+        assert(typ.isRealizable)
+        Ref(name, typ)
+      case ApplyBinaryPrimOp(op, l, r, typ) =>
+        ApplyBinaryPrimOp(op, extract(l), extract(r), typ)
+      case ApplyUnaryPrimOp(op, x, typ) =>
+        ApplyUnaryPrimOp(op, extract(x), typ)
+      case MakeArray(args, typ) =>
+        MakeArray(args map extract, typ)
+      case MakeArrayN(len, elementType) =>
+        MakeArrayN(extract(len), elementType)
+      case ArrayRef(a, i, typ) =>
+        ArrayRef(extract(a), extract(i), typ)
+      case ArrayMissingnessRef(a, i) =>
+        ArrayMissingnessRef(extract(a), extract(i))
+      case ArrayLen(a) =>
+        ArrayLen(extract(a))
+      case ArrayMap(a, name, body, elementTyp) =>
+        ArrayMap(extract(a), name, noAgg(body), elementTyp)
+      case ArrayFold(a, zero, accumName, valueName, body, typ) =>
+        ArrayFold(extract(a), extract(zero), accumName, valueName, noAgg(body), typ)
+      case AggMap(a, name, body, typ) =>
+        throw new RuntimeException(s"AggMap must be used inside an AggSum, but found: $ir")
+      case x@AggSum(a) =>
+        val in = In(0, null)
+        ab += IRAgg(in, x.typ, zeroValue(x.typ), (u, t) => ApplyBinaryPrimOp(Add(), u, lower(a, t)), (l, r) => ApplyBinaryPrimOp(Add(), l, r))
+        GetField(in, ab.length.toString())
+      case MakeStruct(fields) =>
+        MakeStruct(fields map { case (x,y,z) => (x,y,extract(z)) })
+      case GetField(o, name, typ) =>
+        GetField(extract(o), name, typ)
+      case GetFieldMissingness(o, name) =>
+        GetFieldMissingness(extract(o), name)
+      case In(i, typ) =>
+        In(i, typ)
+      case InMissingness(i) =>
+        InMissingness(i)
+      case Die(message) =>
+        Die(message)
+    }
+  }
+
+  private def lower(ir: IR, aggIn: IR): IR = {
+    def lower(ir: IR): IR = this.lower(ir, aggIn)
+    ir match {
+      case I32(x) => ir
+      case I64(x) => ir
+      case F32(x) => ir
+      case F64(x) => ir
+      case True() => ir
+      case False() => ir
+      case Cast(v, typ) =>
+        Cast(lower(v), typ)
+      case NA(typ) => ir
+      case MapNA(name, value, body, typ) =>
+        MapNA(name, lower(value), lower(body), typ)
+      case IsNA(value) =>
+        IsNA(lower(value))
+      case If(cond, cnsq, altr, typ) =>
+        If(lower(cond), lower(cnsq), lower(altr), typ)
+      case Let(name, value, body, typ) =>
+        Let(name, lower(value), lower(body), typ)
+      case Ref(name, typ) => ir
+      case ApplyBinaryPrimOp(op, l, r, typ) =>
+        ApplyBinaryPrimOp(op, lower(l), lower(r), typ)
+      case ApplyUnaryPrimOp(op, x, typ) =>
+        ApplyUnaryPrimOp(op, lower(x), typ)
+      case MakeArray(args, typ) =>
+        MakeArray(args map lower, typ)
+      case MakeArrayN(len, elementType) =>
+        MakeArrayN(lower(len), elementType)
+      case ArrayRef(a, i, typ) =>
+        ArrayRef(lower(a), lower(i), typ)
+      case ArrayMissingnessRef(a, i) =>
+        ArrayMissingnessRef(lower(a), lower(i))
+      case ArrayLen(a) =>
+        ArrayLen(lower(a))
+      case ArrayMap(a, name, body, elementTyp) =>
+        ArrayMap(lower(a), name, lower(body), elementTyp)
+      case ArrayFold(a, zero, accumName, valueName, body, typ) =>
+        ArrayFold(lower(a), lower(zero), accumName, valueName, lower(body), typ)
+      case AggIn(typ) =>
+        aggIn
+      case AggMap(a, name, body, typ) =>
+        Let(name, lower(a), lower(body), typ)
+      case AggSum(a) =>
+        throw new RuntimeException(s"Found aggregator inside an aggregator: $ir")
+      case MakeStruct(fields) =>
+        MakeStruct(fields.map { case (x,y,z) => (x,y,lower(z)) })
+      case GetField(o, name, typ) =>
+        GetField(lower(o), name, typ)
+      case GetFieldMissingness(o, name) =>
+        GetFieldMissingness(lower(o), name)
+      case In(i, typ) =>
+        throw new RuntimeException(s"Referenced input inside an aggregator, that's a no-no: $ir")
+      case InMissingness(i) =>
+        throw new RuntimeException(s"Referenced input inside an aggregator, that's a no-no: $ir")
+      case Die(message) => ir
+    }
+  }
+
+  private def noAgg(ir: IR): IR = {
+    // FIXME: assert no children reference AggMap or AggSum
+    ir
+  }
+
+  private def zeroValue(t: Type): IR = {
+    t match {
+      case _: TBoolean => False()
+      case _: TInt32 => I32(0)
+      case _: TInt64 => I64(0L)
+      case _: TFloat32 => F32(0.0f)
+      case _: TFloat64 => F64(0.0)
+    }
+  }
+}

--- a/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -17,25 +17,27 @@ object ExtractAggregators {
   trait Aggregable {
     def aggregate(
       zero: (MemoryBuffer) => Long,
-      seq: (MemoryBuffer, Long, Long) => Long,
-      comb: (MemoryBuffer, Long, Long) => Long): Long
+      seq: (MemoryBuffer, Long, Boolean, Long, Boolean) => Long,
+      comb: (MemoryBuffer, Long, Boolean, Long, Boolean) => Long): Long
   }
 
   def apply(ir: IR, t: TAggregable): (IR, TStruct, (MemoryBuffer, Aggregable) => Long) = {
     val (ir2, aggs) = extract(ir)
     val fields = aggs.map(_.t).zipWithIndex.map { case (t, i) => (i.toString -> t) }
-    val tT: TStruct = t.elementWithScopeType
+    val tT: TStruct = t.carrierStruct
     val tU: TStruct = TStruct(fields:_*)
     def zipValues(irs: Iterable[IR]): IR =
       MakeStruct(fields.zip(irs).map { case ((n, t), v) => (n, t, v) })
     val zeroFb = FunctionBuilder.functionBuilder[MemoryBuffer, Long]
     Compile(zipValues(aggs.map(_.z)), zeroFb)
-    val seqFb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Long, Long]
+    val seqFb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Long, Boolean, Long]
+    println(zipValues(aggs.zipWithIndex.map { case (x, i) =>
+      x.seq(GetField(In(0, tU), i.toString(), x.t), In(1, tT)) }))
     Compile(zipValues(aggs.zipWithIndex.map { case (x, i) =>
-      x.seq(GetField(In(0, tU), i.toString()), In(1, tT)) }), seqFb)
-    val combFb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Long, Long]
+      x.seq(GetField(In(0, tU), i.toString(), x.t), In(1, tT)) }), seqFb)
+    val combFb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Long, Boolean, Long]
     Compile(zipValues(aggs.zipWithIndex.map { case (x, i) =>
-      x.comb(GetField(In(0, tU), i.toString()), GetField(In(0, tU), i.toString())) }), combFb)
+      x.comb(GetField(In(0, tU), i.toString(), x.t), GetField(In(0, tU), i.toString(), x.t)) }), combFb)
 
     // update all the references to the intermediate
     aggs.map(_.in).foreach(_.typ = tU)
@@ -51,8 +53,8 @@ object ExtractAggregators {
       val g = comb()
       agg.aggregate(
         r => z(r),
-        (r, t, u) => f(r, t, u),
-        (region, l, r) => g(region, l, r))
+        (r, t, mt, u, mu) => f(r, t, mt, u, mu),
+        (region, l, ml, r, mr) => g(region, l, ml, r, mr))
     })
   }
 
@@ -65,141 +67,45 @@ object ExtractAggregators {
   private def extract(ir: IR, ab: ArrayBuilder[IRAgg]): IR = {
     def extract(ir: IR): IR = this.extract(ir, ab)
     ir match {
-      case I32(x) => ir
-      case I64(x) => ir
-      case F32(x) => ir
-      case F64(x) => ir
-      case True() => ir
-      case False() => ir
-      case Cast(v, typ) =>
-        extract(v)
-      case NA(typ) => ir
-      case MapNA(name, value, body, typ) =>
-        MapNA(name, extract(value), extract(body), typ)
-      case IsNA(value) =>
-        IsNA(extract(value))
-      case If(cond, cnsq, altr, typ) =>
-        If(extract(cond), extract(cnsq), extract(altr), typ)
-      case Let(name, value, body, typ) =>
-        Let(name, extract(value), extract(body), typ)
       case Ref(name, typ) =>
         assert(typ.isRealizable)
-        Ref(name, typ)
-      case ApplyBinaryPrimOp(op, l, r, typ) =>
-        ApplyBinaryPrimOp(op, extract(l), extract(r), typ)
-      case ApplyUnaryPrimOp(op, x, typ) =>
-        ApplyUnaryPrimOp(op, extract(x), typ)
-      case MakeArray(args, typ) =>
-        MakeArray(args map extract, typ)
-      case MakeArrayN(len, elementType) =>
-        MakeArrayN(extract(len), elementType)
-      case ArrayRef(a, i, typ) =>
-        ArrayRef(extract(a), extract(i), typ)
-      case ArrayMissingnessRef(a, i) =>
-        ArrayMissingnessRef(extract(a), extract(i))
-      case ArrayLen(a) =>
-        ArrayLen(extract(a))
-      case ArrayMap(a, name, body, elementTyp) =>
-        ArrayMap(extract(a), name, extract(body), elementTyp)
-      case ArrayFold(a, zero, accumName, valueName, body, typ) =>
-        ArrayFold(extract(a), extract(zero), accumName, valueName, extract(body), typ)
+        ir
+      case AggIn(_) =>
+        throw new RuntimeException(s"AggMap must be used inside an AggSum, but found: $ir")
       case AggMap(a, name, body, typ) =>
         throw new RuntimeException(s"AggMap must be used inside an AggSum, but found: $ir")
-      case x@AggSum(a) =>
+      case AggSum(a, typ) =>
+        val tAgg = a.typ.asInstanceOf[TAggregable]
         val in = In(0, null)
-        ab += IRAgg(in, x.typ, zeroValue(x.typ), (u, t) => ApplyBinaryPrimOp(Add(), u, lower(a, t)), (l, r) => ApplyBinaryPrimOp(Add(), l, r))
-        GetField(in, ab.length.toString())
-      case MakeStruct(fields) =>
-        MakeStruct(fields map { case (x,y,z) => (x,y,extract(z)) })
-      case GetField(o, name, typ) =>
-        GetField(extract(o), name, typ)
-      case GetFieldMissingness(o, name) =>
-        GetFieldMissingness(extract(o), name)
-      case In(i, typ) =>
-        In(i, typ)
-      case InMissingness(i) =>
-        InMissingness(i)
-      case Die(message) =>
-        Die(message)
+        ab += IRAgg(in,
+          typ,
+          zeroValue(typ),
+          (u, t) => ApplyBinaryPrimOp(Add(), u, tAgg.getElement(lower(a, t)), typ),
+          (l, r) => ApplyBinaryPrimOp(Add(), l, r, typ))
+
+        GetField(in, (ab.length - 1).toString())
+      case _ => Recur(extract)(ir)
     }
   }
 
-  private def lower(ir: IR, aggIn: IR): IR =
-    lower(ir, aggIn, Env.empty)
-
-  private def lower(ir: IR, aggIn: IR, env: Env[Unit]): IR = {
-    def lower(ir: IR, env: Env[Unit] = env): IR = this.lower(ir, aggIn, env)
+  private def lower(ir: IR, aggIn: IR): IR = {
+    def lower(ir: IR): IR = this.lower(ir, aggIn)
     ir match {
-      case I32(x) => ir
-      case I64(x) => ir
-      case F32(x) => ir
-      case F64(x) => ir
-      case True() => ir
-      case False() => ir
-      case Cast(v, typ) =>
-        Cast(lower(v), typ)
-      case NA(typ) => ir
-      case MapNA(name, value, body, typ) =>
-        MapNA(name, lower(value), lower(body), typ)
-      case IsNA(value) =>
-        IsNA(lower(value))
-      case If(cond, cnsq, altr, typ) =>
-        If(lower(cond), lower(cnsq), lower(altr), typ)
-      case Let(name, value, body, typ) =>
-        Let(name, lower(value), lower(body, env = env.bind(name, ())), typ)
-      case Ref(name, typ) => ir
-      case ApplyBinaryPrimOp(op, l, r, typ) =>
-        ApplyBinaryPrimOp(op, lower(l), lower(r), typ)
-      case ApplyUnaryPrimOp(op, x, typ) =>
-        ApplyUnaryPrimOp(op, lower(x), typ)
-      case MakeArray(args, typ) =>
-        MakeArray(args map (lower(_)), typ)
-      case MakeArrayN(len, elementType) =>
-        MakeArrayN(lower(len), elementType)
-      case ArrayRef(a, i, typ) =>
-        ArrayRef(lower(a), lower(i), typ)
-      case ArrayMissingnessRef(a, i) =>
-        ArrayMissingnessRef(lower(a), lower(i))
-      case ArrayLen(a) =>
-        ArrayLen(lower(a))
-      case ArrayMap(a, name, body, elementTyp) =>
-        val bodyEnv = env.bind(name, ())
-        ArrayMap(lower(a), name, lower(body, env = bodyEnv), elementTyp)
-      case ArrayFold(a, zero, accumName, valueName, body, typ) =>
-        val bodyEnv = env.bind((accumName, ()), (valueName, ()))
-        ArrayFold(lower(a), lower(zero), accumName, valueName, lower(body, env = bodyEnv), typ)
       case AggIn(typ) =>
         aggIn
       case AggMap(a, name, body, typ) =>
         val tAgg = a.typ.asInstanceOf[TAggregable]
-        val extraBindings = tAgg.bindingTypes
-        val tA = tAgg.elementWithScopeType
+        val tA = tAgg.carrierStruct
         val la = lower(a)
         assert(la.typ == tA, s"should have same type ${la.typ} $tA, $la")
-        val (aggName, bodyEnv) = env
-          .bind(extraBindings.map(_._1 -> ()):_*)
-          .bindFresh("AggMapValue", ())
-        // NB: the map name should shadow any names in the scope so it must be
-        // the deepest Let
-        var bodyWithBindings = Let(name, tAgg.getElement(Ref(aggName, tA)),
-          lower(body, env = bodyEnv), typ)
-        extraBindings.foreach { case (n, t) =>
-          bodyWithBindings = Let(n, Ref(aggName, tA), bodyWithBindings)
-        }
-        Let(aggName, lower(a), bodyWithBindings, typ)
-      case AggSum(a) =>
+        tAgg.inContext(la, e => Let(name, e, lower(body)))
+      case AggSum(_, _) =>
         throw new RuntimeException(s"Found aggregator inside an aggregator: $ir")
-      case MakeStruct(fields) =>
-        MakeStruct(fields.map { case (x,y,z) => (x,y,lower(z)) })
-      case GetField(o, name, typ) =>
-        GetField(lower(o), name, typ)
-      case GetFieldMissingness(o, name) =>
-        GetFieldMissingness(lower(o), name)
       case In(i, typ) =>
         throw new RuntimeException(s"Referenced input inside an aggregator, that's a no-no: $ir")
       case InMissingness(i) =>
         throw new RuntimeException(s"Referenced input inside an aggregator, that's a no-no: $ir")
-      case Die(message) => ir
+      case _ => Recur(lower)(ir)
     }
   }
 
@@ -210,6 +116,7 @@ object ExtractAggregators {
       case _: TInt64 => I64(0L)
       case _: TFloat32 => F32(0.0f)
       case _: TFloat64 => F64(0.0)
+      case _ => throw new RuntimeException(s"no zero for $t")
     }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -53,7 +53,7 @@ object ExtractAggregators {
         aggIn
       case AggMap(a, name, body, typ) =>
         val tA = a.typ.asInstanceOf[TAggregable]
-        val tLoweredA = tA.withScopeStruct
+        val tLoweredA = tA.elementAndScopeStruct
         val la = lower(a)
         assert(la.typ == tLoweredA, s"type after lowering, ${la.typ}, should be the carrier struct of ${a.typ}; $ir")
         tA.inScope(la, e => Let(name, e, lower(body), typ.elementType))

--- a/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -12,7 +12,7 @@ object ExtractAggregators {
 
   def apply(ir: IR, tAggIn: TAggregable): (IR, RegionValueAggregator) = {
     val (ir2, aggs) = extract(ir, tAggIn)
-    val combined = new ZippedRegionValueAggregator(aggs map (_.agg))
+    val combined = new ZippedRegionValueAggregator(aggs.map(_.agg))
     aggs.foreach(_.in.typ = combined.typ)
     (ir2, combined)
   }

--- a/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -13,6 +13,8 @@ object ExtractAggregators {
   def apply(ir: IR, tAggIn: TAggregable): (IR, RegionValueAggregator) = {
     val (ir2, aggs) = extract(ir, tAggIn)
     val combined = new ZippedRegionValueAggregator(aggs.map(_.agg))
+    // mutate the type of the input IR node now that we know what the combined
+    // struct's type is
     aggs.foreach(_.in.typ = combined.typ)
     (ir2, combined)
   }

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir
 
-import is.hail.expr.{BaseIR, TBoolean, TFloat32, TFloat64, TInt32, TInt64, TStruct, TVoid, Type, TArray}
+import is.hail.expr.{BaseIR, TAggregable, TBoolean, TFloat32, TFloat64, TInt32, TInt64, TStruct, TVoid, Type, TArray}
 
 sealed trait IR extends BaseIR {
   def typ: Type
@@ -42,9 +42,9 @@ case class ArrayLen(a: IR) extends IR { val typ = TInt32() }
 case class ArrayMap(a: IR, name: String, body: IR, var elementTyp: Type = null) extends IR { def typ: TArray = TArray(elementTyp) }
 case class ArrayFold(a: IR, zero: IR, accumName: String, valueName: String, body: IR, var typ: Type = null) extends IR
 
-case class AggIn(typ: Type) extends IR
-case class AggMap(a: IR, name: String, body: IR, var typ: Type = null) extends IR
-case class AggSum(a: IR) extends IR { def typ: TInt64 = TInt64() }
+case class AggIn(typ: TAggregable) extends IR
+case class AggMap(a: IR, name: String, body: IR, var typ: TAggregable = null) extends IR
+case class AggSum(a: IR, var typ: Type = null) extends IR
 
 case class MakeStruct(fields: Array[(String, Type, IR)]) extends IR {
   val typ: TStruct = TStruct(fields.map(x => x._1 -> x._2):_*)

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -42,6 +42,10 @@ case class ArrayLen(a: IR) extends IR { val typ = TInt32() }
 case class ArrayMap(a: IR, name: String, body: IR, var elementTyp: Type = null) extends IR { def typ: TArray = TArray(elementTyp) }
 case class ArrayFold(a: IR, zero: IR, accumName: String, valueName: String, body: IR, var typ: Type = null) extends IR
 
+case class AggIn(typ: Type) extends IR
+case class AggMap(a: IR, name: String, body: IR, var typ: Type = null) extends IR
+case class AggSum(a: IR) extends IR { def typ: TInt64 = TInt64() }
+
 case class MakeStruct(fields: Array[(String, Type, IR)]) extends IR {
   val typ: TStruct = TStruct(fields.map(x => x._1 -> x._2):_*)
   override def toString(): String =
@@ -50,7 +54,7 @@ case class MakeStruct(fields: Array[(String, Type, IR)]) extends IR {
 case class GetField(o: IR, name: String, var typ: Type = null) extends IR
 case class GetFieldMissingness(o: IR, name: String) extends IR { val typ: Type = TBoolean() }
 
-case class In(i: Int, val typ: Type) extends IR
+case class In(i: Int, var typ: Type) extends IR
 case class InMissingness(i: Int) extends IR { val typ: Type = TBoolean() }
 // FIXME: should be type any
 case class Die(message: String) extends IR { val typ = TVoid }

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -91,13 +91,14 @@ object Infer {
         infer(a)
         val tagg = a.typ.asInstanceOf[TAggregable]
         val env = Env.empty
+          .bind(tagg.bindings:_*)
           .bind(name, tagg.elementType)
-          .bind(tagg.bindingTypes:_*)
         infer(body, env = env)
         x.typ = tagg.copy(elementType = body.typ)
-      case x@AggSum(a) =>
+      case x@AggSum(a, _) =>
         infer(a)
-        assert(a.typ.isInstanceOf[TAggregable])
+        val tAgg = a.typ.asInstanceOf[TAggregable]
+        x.typ = tAgg.elementType
       case MakeStruct(fields) =>
         fields.map { case (_, typ, v) =>
           infer(v)

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -7,10 +7,10 @@ import is.hail.expr.{TAggregable, TInt32, TInt64, TArray, TContainer, TStruct, T
 import is.hail.annotations.StagedRegionValueBuilder
 
 object Infer {
-  def apply(ir: IR) { apply(ir, new Env[Type]()) }
+  def apply(ir: IR, tAgg: Option[TAggregable] = None) { apply(ir, tAgg, new Env[Type]()) }
 
-  def apply(ir: IR, env: Env[Type]) {
-    def infer(ir: IR, env: Env[Type] = env) { apply(ir, env) }
+  def apply(ir: IR, tAgg: Option[TAggregable], env: Env[Type]) {
+    def infer(ir: IR, env: Env[Type] = env) { apply(ir, tAgg, env) }
     ir match {
       case I32(x) =>
       case I64(x) =>
@@ -85,8 +85,8 @@ object Infer {
         infer(body, env.bind(accumName -> zero.typ, valueName -> tarray.elementType))
         assert(body.typ == zero.typ)
         x.typ = zero.typ
-      case AggIn(_) =>
-        // FIXME: all AggIn should be the same type
+      case AggIn(typ) =>
+        tAgg.foreach(x => assert(typ == x))
       case x@AggMap(a, name, body, _) =>
         infer(a)
         val tagg = a.typ.asInstanceOf[TAggregable]

--- a/src/main/scala/is/hail/expr/ir/Recur.scala
+++ b/src/main/scala/is/hail/expr/ir/Recur.scala
@@ -1,0 +1,45 @@
+package is.hail.expr.ir
+
+import is.hail.annotations._
+import is.hail.asm4s._
+import is.hail.expr
+import is.hail.expr.{Type, Aggregator, TAggregable, TArray, TBoolean, TContainer, TFloat32, TFloat64, TInt32, TInt64, TStruct}
+import is.hail.utils._
+import org.objectweb.asm.Opcodes._
+import org.objectweb.asm.tree._
+
+object Recur {
+  def apply(f: IR => IR)(ir: IR): IR = ir match {
+    case I32(x) => ir
+    case I64(x) => ir
+    case F32(x) => ir
+    case F64(x) => ir
+    case True() => ir
+    case False() => ir
+    case Cast(v, typ) => Cast(f(v), typ)
+    case NA(typ) => ir
+    case MapNA(name, value, body, typ) => MapNA(name, f(value), f(body), typ)
+    case IsNA(value) => IsNA(value)
+    case If(cond, cnsq, altr, typ) => If(f(cond), f(cnsq), f(altr), typ)
+    case Let(name, value, body, typ) => Let(name, f(value), f(body), typ)
+    case Ref(name, typ) => ir
+    case ApplyBinaryPrimOp(op, l, r, typ) => ApplyBinaryPrimOp(op, f(l), f(r), typ)
+    case ApplyUnaryPrimOp(op, x, typ) => ApplyUnaryPrimOp(op, f(x), typ)
+    case MakeArray(args, typ) => MakeArray(args map f, typ)
+    case MakeArrayN(len, elementType) => MakeArrayN(f(len), elementType)
+    case ArrayRef(a, i, typ) => ArrayRef(f(a), f(i), typ)
+    case ArrayMissingnessRef(a, i) => ArrayMissingnessRef(f(a), i)
+    case ArrayLen(a) => ArrayLen(f(a))
+    case ArrayMap(a, name, body, elementTyp) => ArrayMap(f(a), name, f(body), elementTyp)
+    case ArrayFold(a, zero, accumName, valueName, body, typ) => ArrayFold(f(a), f(zero), accumName, valueName, f(body), typ)
+    case AggIn(typ) => ir
+    case AggMap(a, name, body, typ) => AggMap(f(a), name, f(body), typ)
+    case AggSum(a, typ) => AggSum(f(a), typ)
+    case MakeStruct(fields) => MakeStruct(fields map { case (x,y,z) => (x,y,f(z)) })
+    case GetField(o, name, typ) => GetField(f(o), name, typ)
+    case GetFieldMissingness(o, name) => GetFieldMissingness(f(o), name)
+    case In(i, typ) => ir
+    case InMissingness(i) => ir
+    case Die(message) => ir
+  }
+}

--- a/src/main/scala/is/hail/expr/ir/RunAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/RunAggregators.scala
@@ -7,7 +7,7 @@ object RunAggregators {
   def onArray(ir: IR, tAgg: TAggregable, region: MemoryBuffer, aOff: Long,
     v0: Long, m0: Boolean): (IR, Long) =
     genericOnArray(ir, tAgg, region, aOff, { (agg, region, e, me, i) =>
-      agg.seqOp(region, tAgg.createCarrier(region,
+      agg.seqOp(region, tAgg.createScopeCarrier(region,
         e, me,
         v0, m0), false)
     })
@@ -16,7 +16,7 @@ object RunAggregators {
     v0: Long, m0: Boolean,
     v1: Long, m1: Boolean): (IR, Long) =
     genericOnArray(ir, tAgg, region, aOff, { (agg, region, e, me, i) =>
-      agg.seqOp(region, tAgg.createCarrier(region,
+      agg.seqOp(region, tAgg.createScopeCarrier(region,
         e, me,
         v0, m0, v1, m1), false)
     })
@@ -26,7 +26,7 @@ object RunAggregators {
     v1: Long, m1: Boolean,
     v2: Long, m2: Boolean): (IR, Long) =
     genericOnArray(ir, tAgg, region, aOff, { (agg, region, e, me, i) =>
-      agg.seqOp(region, tAgg.createCarrier(region,
+      agg.seqOp(region, tAgg.createScopeCarrier(region,
         e, me,
         v0, m0, v1, m1, v2, m2), false)
     })
@@ -37,7 +37,7 @@ object RunAggregators {
     v2: Long, m2: Boolean,
     v3: Long, m3: Boolean): (IR, Long) =
     genericOnArray(ir, tAgg, region, aOff, { (agg, region, e, me, i) =>
-      agg.seqOp(region, tAgg.createCarrier(region,
+      agg.seqOp(region, tAgg.createScopeCarrier(region,
         e, me,
         v0, m0, v1, m1, v2, m2, v3, m3), false)
     })
@@ -49,7 +49,7 @@ object RunAggregators {
     v3: Long, m3: Boolean,
     v4: Long, m4: Boolean): (IR, Long) =
     genericOnArray(ir, tAgg, region, aOff, { (agg, region, e, me, i) =>
-      agg.seqOp(region, tAgg.createCarrier(region,
+      agg.seqOp(region, tAgg.createScopeCarrier(region,
         e, me,
         v0, m0, v1, m1, v2, m2, v3, m3, v4, m4), false)
     })

--- a/src/main/scala/is/hail/expr/ir/RunAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/RunAggregators.scala
@@ -1,0 +1,28 @@
+package is.hail.expr.ir
+
+import is.hail.annotations._
+import is.hail.expr.{TAggregable, TArray}
+
+object RunAggregators {
+  // FIXME: don't use annotation interface
+  def onArray(ir: IR, tAgg: TAggregable, region: MemoryBuffer, aOff: Long, elementToAnnotation: (MemoryBuffer, Long) => Annotation, extraBindings: (Int) => Array[Annotation]): (IR, Long) = {
+    val tArray = TArray(tAgg.elementType)
+    Infer(ir)
+    val (post, agg) = ExtractAggregators(ir, tAgg)
+    val perElementStart = region.offset
+    var i = 0
+    while (i < tArray.loadLength(region, aOff)) {
+      val v = if (tArray.isElementDefined(region, aOff, i))
+         tArray.loadElement(region, aOff, i)
+      else
+        null
+      agg.seqOp(region, tAgg.createCarrier(region, v, extraBindings(i):_*), false)
+      // all allocated memory is unreachable because the aggregator value is
+      // stored off-region
+      region.offset = perElementStart
+      i += 1
+    }
+    val outOff = agg.result(region)
+    (post, outOff)
+  }
+}

--- a/src/main/scala/is/hail/expr/ir/RunAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/RunAggregators.scala
@@ -1,22 +1,69 @@
 package is.hail.expr.ir
 
 import is.hail.annotations._
-import is.hail.expr.{TAggregable, TArray}
+import is.hail.expr.{TAggregable, TArray, RegionValueAggregator}
 
 object RunAggregators {
-  // FIXME: don't use annotation interface
-  def onArray(ir: IR, tAgg: TAggregable, region: MemoryBuffer, aOff: Long, elementToAnnotation: (MemoryBuffer, Long) => Annotation, extraBindings: (Int) => Array[Annotation]): (IR, Long) = {
+  def onArray(ir: IR, tAgg: TAggregable, region: MemoryBuffer, aOff: Long,
+    v0: Long, m0: Boolean): (IR, Long) =
+    genericOnArray(ir, tAgg, region, aOff, { (agg, region, e, me, i) =>
+      agg.seqOp(region, tAgg.createCarrier(region,
+        e, me,
+        v0, m0), false)
+    })
+
+  def onArray(ir: IR, tAgg: TAggregable, region: MemoryBuffer, aOff: Long,
+    v0: Long, m0: Boolean,
+    v1: Long, m1: Boolean): (IR, Long) =
+    genericOnArray(ir, tAgg, region, aOff, { (agg, region, e, me, i) =>
+      agg.seqOp(region, tAgg.createCarrier(region,
+        e, me,
+        v0, m0, v1, m1), false)
+    })
+
+  def onArray(ir: IR, tAgg: TAggregable, region: MemoryBuffer, aOff: Long,
+    v0: Long, m0: Boolean,
+    v1: Long, m1: Boolean,
+    v2: Long, m2: Boolean): (IR, Long) =
+    genericOnArray(ir, tAgg, region, aOff, { (agg, region, e, me, i) =>
+      agg.seqOp(region, tAgg.createCarrier(region,
+        e, me,
+        v0, m0, v1, m1, v2, m2), false)
+    })
+
+  def onArray(ir: IR, tAgg: TAggregable, region: MemoryBuffer, aOff: Long,
+    v0: Long, m0: Boolean,
+    v1: Long, m1: Boolean,
+    v2: Long, m2: Boolean,
+    v3: Long, m3: Boolean): (IR, Long) =
+    genericOnArray(ir, tAgg, region, aOff, { (agg, region, e, me, i) =>
+      agg.seqOp(region, tAgg.createCarrier(region,
+        e, me,
+        v0, m0, v1, m1, v2, m2, v3, m3), false)
+    })
+
+  def onArray(ir: IR, tAgg: TAggregable, region: MemoryBuffer, aOff: Long,
+    v0: Long, m0: Boolean,
+    v1: Long, m1: Boolean,
+    v2: Long, m2: Boolean,
+    v3: Long, m3: Boolean,
+    v4: Long, m4: Boolean): (IR, Long) =
+    genericOnArray(ir, tAgg, region, aOff, { (agg, region, e, me, i) =>
+      agg.seqOp(region, tAgg.createCarrier(region,
+        e, me,
+        v0, m0, v1, m1, v2, m2, v3, m3, v4, m4), false)
+    })
+
+  private def genericOnArray(ir: IR, tAgg: TAggregable, region: MemoryBuffer, aOff: Long, seqOp: (RegionValueAggregator, MemoryBuffer, Long, Boolean, Int) => Unit): (IR, Long) = {
     val tArray = TArray(tAgg.elementType)
-    Infer(ir)
+    Infer(ir, Some(tAgg))
     val (post, agg) = ExtractAggregators(ir, tAgg)
     val perElementStart = region.offset
     var i = 0
     while (i < tArray.loadLength(region, aOff)) {
-      val v = if (tArray.isElementDefined(region, aOff, i))
-        elementToAnnotation(region, tArray.loadElement(region, aOff, i))
-      else
-        null
-      agg.seqOp(region, tAgg.createCarrier(region, v, extraBindings(i):_*), false)
+      val me = tArray.isElementMissing(region, aOff, i)
+      val e = if (me) 0 else tArray.loadElement(region, aOff, i)
+      seqOp(agg, region, e, me, i)
       // all allocated memory is unreachable because the aggregator value is
       // stored off-region
       region.offset = perElementStart

--- a/src/main/scala/is/hail/expr/ir/RunAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/RunAggregators.scala
@@ -4,72 +4,74 @@ import is.hail.annotations._
 import is.hail.expr.{TAggregable, TArray, RegionValueAggregator}
 
 object RunAggregators {
-  def onArray(ir: IR, tAgg: TAggregable, region: MemoryBuffer, aOff: Long,
-    v0: Long, m0: Boolean): (IR, Long) =
-    genericOnArray(ir, tAgg, region, aOff, { (agg, region, e, me, i) =>
+  def onArray(ir: IR, tAgg: TAggregable, aOff: Long,
+    v0: Long, m0: Boolean): (IR, (MemoryBuffer) => Long) =
+    genericOnArray(ir, tAgg, aOff, { (agg, region, e, me, i) =>
       agg.seqOp(region, tAgg.createScopeCarrier(region,
         e, me,
         v0, m0), false)
     })
 
-  def onArray(ir: IR, tAgg: TAggregable, region: MemoryBuffer, aOff: Long,
+  def onArray(ir: IR, tAgg: TAggregable, aOff: Long,
     v0: Long, m0: Boolean,
-    v1: Long, m1: Boolean): (IR, Long) =
-    genericOnArray(ir, tAgg, region, aOff, { (agg, region, e, me, i) =>
+    v1: Long, m1: Boolean): (IR, (MemoryBuffer) => Long) =
+    genericOnArray(ir, tAgg, aOff, { (agg, region, e, me, i) =>
       agg.seqOp(region, tAgg.createScopeCarrier(region,
         e, me,
         v0, m0, v1, m1), false)
     })
 
-  def onArray(ir: IR, tAgg: TAggregable, region: MemoryBuffer, aOff: Long,
+  def onArray(ir: IR, tAgg: TAggregable, aOff: Long,
     v0: Long, m0: Boolean,
     v1: Long, m1: Boolean,
-    v2: Long, m2: Boolean): (IR, Long) =
-    genericOnArray(ir, tAgg, region, aOff, { (agg, region, e, me, i) =>
+    v2: Long, m2: Boolean): (IR, (MemoryBuffer) => Long) =
+    genericOnArray(ir, tAgg, aOff, { (agg, region, e, me, i) =>
       agg.seqOp(region, tAgg.createScopeCarrier(region,
         e, me,
         v0, m0, v1, m1, v2, m2), false)
     })
 
-  def onArray(ir: IR, tAgg: TAggregable, region: MemoryBuffer, aOff: Long,
+  def onArray(ir: IR, tAgg: TAggregable, aOff: Long,
     v0: Long, m0: Boolean,
     v1: Long, m1: Boolean,
     v2: Long, m2: Boolean,
-    v3: Long, m3: Boolean): (IR, Long) =
-    genericOnArray(ir, tAgg, region, aOff, { (agg, region, e, me, i) =>
+    v3: Long, m3: Boolean): (IR, (MemoryBuffer) => Long) =
+    genericOnArray(ir, tAgg, aOff, { (agg, region, e, me, i) =>
       agg.seqOp(region, tAgg.createScopeCarrier(region,
         e, me,
         v0, m0, v1, m1, v2, m2, v3, m3), false)
     })
 
-  def onArray(ir: IR, tAgg: TAggregable, region: MemoryBuffer, aOff: Long,
+  def onArray(ir: IR, tAgg: TAggregable, aOff: Long,
     v0: Long, m0: Boolean,
     v1: Long, m1: Boolean,
     v2: Long, m2: Boolean,
     v3: Long, m3: Boolean,
-    v4: Long, m4: Boolean): (IR, Long) =
-    genericOnArray(ir, tAgg, region, aOff, { (agg, region, e, me, i) =>
+    v4: Long, m4: Boolean): (IR, (MemoryBuffer) => Long) =
+    genericOnArray(ir, tAgg, aOff, { (agg, region, e, me, i) =>
       agg.seqOp(region, tAgg.createScopeCarrier(region,
         e, me,
         v0, m0, v1, m1, v2, m2, v3, m3, v4, m4), false)
     })
 
-  private def genericOnArray(ir: IR, tAgg: TAggregable, region: MemoryBuffer, aOff: Long, seqOp: (RegionValueAggregator, MemoryBuffer, Long, Boolean, Int) => Unit): (IR, Long) = {
+  private def genericOnArray(ir: IR, tAgg: TAggregable, aOff: Long, seqOp: (RegionValueAggregator, MemoryBuffer, Long, Boolean, Int) => Unit): (IR, (MemoryBuffer) => Long) = {
     val tArray = TArray(tAgg.elementType)
     Infer(ir, Some(tAgg))
     val (post, agg) = ExtractAggregators(ir, tAgg)
-    val perElementStart = region.offset
-    var i = 0
-    while (i < tArray.loadLength(region, aOff)) {
-      val me = tArray.isElementMissing(region, aOff, i)
-      val e = if (me) 0 else tArray.loadElement(region, aOff, i)
-      seqOp(agg, region, e, me, i)
-      // all allocated memory is unreachable because the aggregator value is
-      // stored off-region
-      region.offset = perElementStart
-      i += 1
+    val runAggregation = { (region: MemoryBuffer) =>
+      val perElementStart = region.offset
+      var i = 0
+      while (i < tArray.loadLength(region, aOff)) {
+        val me = tArray.isElementMissing(region, aOff, i)
+        val e = if (me) 0 else tArray.loadElement(region, aOff, i)
+        seqOp(agg, region, e, me, i)
+        // all allocated memory is unreachable because the aggregator value is
+        // stored off-region
+        region.offset = perElementStart
+        i += 1
+      }
+      agg.result(region)
     }
-    val outOff = agg.result(region)
-    (post, outOff)
+    (post, runAggregation)
   }
 }

--- a/src/main/scala/is/hail/expr/ir/RunAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/RunAggregators.scala
@@ -13,7 +13,7 @@ object RunAggregators {
     var i = 0
     while (i < tArray.loadLength(region, aOff)) {
       val v = if (tArray.isElementDefined(region, aOff, i))
-         tArray.loadElement(region, aOff, i)
+        elementToAnnotation(region, tArray.loadElement(region, aOff, i))
       else
         null
       agg.seqOp(region, tAgg.createCarrier(region, v, extraBindings(i):_*), false)

--- a/src/main/scala/is/hail/expr/package.scala
+++ b/src/main/scala/is/hail/expr/package.scala
@@ -1,5 +1,6 @@
 package is.hail
 
+import is.hail.annotations._
 import scala.language.implicitConversions
 import is.hail.asm4s.Code
 
@@ -17,6 +18,16 @@ package object expr extends HailRepFunctions {
     def result: S
 
     def copy(): TypedAggregator[S]
+  }
+
+  trait RegionValueAggregator extends Serializable {
+    def typ: Type
+
+    def seqOp(region: MemoryBuffer, off: Long, missing: Boolean): Unit
+
+    def combOp(agg2: RegionValueAggregator): Unit
+
+    def result(region: MemoryBuffer): Long
   }
 
   implicit def toRichParser[T](parser: Parser.Parser[T]): RichParser[T] = new RichParser(parser)

--- a/src/main/scala/is/hail/expr/package.scala
+++ b/src/main/scala/is/hail/expr/package.scala
@@ -8,6 +8,8 @@ package object expr extends HailRepFunctions {
   type SymbolTable = Map[String, (Int, Type)]
   def emptySymTab = Map.empty[String, (Int, Type)]
 
+  def hailType[T: HailRep]: Type = implicitly[HailRep[T]].typ
+
   type Aggregator = TypedAggregator[Any]
 
   abstract class TypedAggregator[+S] extends Serializable {

--- a/src/main/scala/is/hail/expr/package.scala
+++ b/src/main/scala/is/hail/expr/package.scala
@@ -28,6 +28,8 @@ package object expr extends HailRepFunctions {
     def combOp(agg2: RegionValueAggregator): Unit
 
     def result(region: MemoryBuffer): Long
+
+    def copy(): RegionValueAggregator
   }
 
   implicit def toRichParser[T](parser: Parser.Parser[T]): RichParser[T] = new RichParser(parser)

--- a/src/main/scala/is/hail/utils/richUtils/RichCodeMemoryBuffer.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichCodeMemoryBuffer.scala
@@ -11,6 +11,10 @@ class RichCodeMemoryBuffer(val region: Code[MemoryBuffer]) extends AnyVal {
 
   def offset: Code[Long] = region.invoke[Long]("size")
 
+  def copyFrom(other: Code[MemoryBuffer], readStart: Code[Long], writeStart: Code[Long], n: Code[Long]): Code[Unit] = {
+    region.invoke[MemoryBuffer, Long, Long, Long, Unit]("copyFrom", other, readStart, writeStart, n)
+  }
+
   def storeInt32(off: Code[Long], v: Code[Int]): Code[Unit] = {
     region.invoke[Long,Int,Unit]("storeInt", off, v)
   }

--- a/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
+++ b/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
@@ -390,11 +390,11 @@ class StagedRegionValueSuite extends SparkSuite {
     fb.emit(
       Code(
         srvb.start(),
-        srvb.addRegionValue(TInt32())(fb.getArg[Int](2)),
+        srvb.addIRIntermediate(TInt32())(fb.getArg[Int](2)),
         srvb.advance(),
-        srvb.addRegionValue(TBoolean())(fb.getArg[Boolean](3)),
+        srvb.addIRIntermediate(TBoolean())(fb.getArg[Boolean](3)),
         srvb.advance(),
-        srvb.addRegionValue(TFloat64())(fb.getArg[Double](4)),
+        srvb.addIRIntermediate(TFloat64())(fb.getArg[Double](4)),
         srvb.advance(),
         srvb.returnStart()
       )

--- a/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
+++ b/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
@@ -390,11 +390,11 @@ class StagedRegionValueSuite extends SparkSuite {
     fb.emit(
       Code(
         srvb.start(),
-        srvb.addPrimitive(TInt32())(fb.getArg[Int](2)),
+        srvb.addRegionValue(TInt32())(fb.getArg[Int](2)),
         srvb.advance(),
-        srvb.addPrimitive(TBoolean())(fb.getArg[Boolean](3)),
+        srvb.addRegionValue(TBoolean())(fb.getArg[Boolean](3)),
         srvb.advance(),
-        srvb.addPrimitive(TFloat64())(fb.getArg[Double](4)),
+        srvb.addRegionValue(TFloat64())(fb.getArg[Double](4)),
         srvb.advance(),
         srvb.returnStart()
       )

--- a/src/test/scala/is/hail/expr/ir/CompileSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/CompileSuite.scala
@@ -329,7 +329,7 @@ class CompileSuite {
       "scope", scopeStruct, addStruct(region, "foo", 7))
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Long, Boolean, Long]
     doit(ir, fb)
-    val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
+    val f = fb.result()()
     val outOff = f(region, loff, false, roff, false)
     assert(tOut.isFieldDefined(region, outOff, tOut.fieldIdx("0")))
     assert(region.loadDouble(tOut.loadField(region, outOff, tOut.fieldIdx("0"))) === 8.0)

--- a/src/test/scala/is/hail/expr/ir/ExtractAggregatorsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/ExtractAggregatorsSuite.scala
@@ -1,0 +1,73 @@
+package is.hail.methods.ir
+
+import is.hail.annotations._
+import is.hail.asm4s._
+import is.hail.check.{Gen, Parameters, Prop}
+import is.hail.expr.{TAggregable, TArray, TFloat64, TInt32}
+import is.hail.expr.ir._
+import org.testng.annotations.Test
+import org.scalatest._
+import Matchers._
+
+class ExtractAggregatorsSuite {
+
+  private def addArray(mb: MemoryBuffer, a: Array[Double]): Long = {
+    val rvb = new RegionValueBuilder(mb)
+    rvb.start(TArray(TFloat64()))
+    rvb.startArray(a.length)
+    a.foreach(rvb.addDouble(_))
+    rvb.endArray()
+    rvb.end()
+  }
+
+  private def addBoxedArray(mb: MemoryBuffer, a: Array[java.lang.Double]): Long = {
+    val rvb = new RegionValueBuilder(mb)
+    rvb.start(TArray(TFloat64()))
+    rvb.startArray(a.length)
+    a.foreach { e =>
+      if (e == null)
+        rvb.setMissing()
+      else
+        rvb.addDouble(e)
+    }
+    rvb.endArray()
+    rvb.end()
+  }
+
+  def doit(ir: IR, fb: FunctionBuilder2) {
+    Infer(ir)
+    println(ir)
+    Compile(ir, fb)
+  }
+
+  @Test
+  def sum() {
+    val tAgg = TAggregable(TFloat64(), Map("foo" -> (0, TInt32())))
+    val ir: IR = AggSum(AggIn(tAgg))
+    val (post, t, f) = ExtractAggregators(ir, tAgg)
+    println(post)
+    val region = MemoryBuffer()
+    val tArray = TArray(TFloat64())
+    val rvb = new RegionValueBuilder()
+    rvb.set(region)
+    rvb.start(tArray)
+    rvb.startArray(100)
+    (0 to 100).foreach(rvb.addDouble(_))
+    rvb.endArray()
+    val aoff = rvb.end()
+    val agg = new ExtractAggregators.Aggregable {
+      def aggregate(
+        zero: (MemoryBuffer) => Long,
+        seq: (MemoryBuffer, Long, Long) => Long,
+        comb: (MemoryBuffer, Long, Long) => Long): Long = {
+        var i = 0
+        var z = zero(region)
+        while (i < 100) {
+          z = seq(region, z, tArray.loadElement(region, aoff, i))
+        }
+        z
+      }
+    }
+    assert(region.loadFloat(f(region, agg)) === 5050)
+  }
+}

--- a/src/test/scala/is/hail/expr/ir/ExtractAggregatorsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/ExtractAggregatorsSuite.scala
@@ -19,13 +19,13 @@ class ExtractAggregatorsSuite {
     val aOff = addArray(region, (0 to 100).map(_.toDouble).toArray)
 
     val ir: IR = AggSum(AggIn(tAgg))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, region.appendInt(10), false)
+    val (post, runAggregations) = RunAggregators.onArray(ir, tAgg, aOff, region.appendInt(10), false)
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
 
     // out is never missing
-    assert(fb.result()()(region, outOff, false) === 5050.0)
+    assert(fb.result()()(region, runAggregations(region), false) === 5050.0)
   }
 
 
@@ -36,13 +36,13 @@ class ExtractAggregatorsSuite {
     val aOff = addArray(region, Array())
 
     val ir: IR = AggSum(AggIn(tAgg))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, region.appendInt(10), false)
+    val (post, runAggregations) = RunAggregators.onArray(ir, tAgg, aOff, region.appendInt(10), false)
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
 
     // out is never missing
-    assert(fb.result()()(region, outOff, false) === 0.0)
+    assert(fb.result()()(region, runAggregations(region), false) === 0.0)
   }
 
   @Test
@@ -52,13 +52,13 @@ class ExtractAggregatorsSuite {
     val aOff = addArray(region, Array(42.0))
 
     val ir: IR = AggSum(AggIn(tAgg))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, region.appendInt(10), false)
+    val (post, runAggregations) = RunAggregators.onArray(ir, tAgg, aOff, region.appendInt(10), false)
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
 
     // out is never missing
-    assert(fb.result()()(region, outOff, false) === 42.0)
+    assert(fb.result()()(region, runAggregations(region), false) === 42.0)
   }
 
   @Test
@@ -68,13 +68,13 @@ class ExtractAggregatorsSuite {
     val aOff = addBoxedArray(region, Array[java.lang.Double](null, 42.0, null))
 
     val ir: IR = AggSum(AggIn(tAgg))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, region.appendInt(10), false)
+    val (post, runAggregations) = RunAggregators.onArray(ir, tAgg, aOff, region.appendInt(10), false)
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
 
     // out is never missing
-    assert(fb.result()()(region, outOff, false) === 42.0)
+    assert(fb.result()()(region, runAggregations(region), false) === 42.0)
   }
 
   @Test
@@ -84,13 +84,13 @@ class ExtractAggregatorsSuite {
     val aOff = addBoxedArray(region, Array[java.lang.Double](null, null, null))
 
     val ir: IR = AggSum(AggIn(tAgg))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, region.appendInt(10), false)
+    val (post, runAggregations) = RunAggregators.onArray(ir, tAgg, aOff, region.appendInt(10), false)
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
 
     // out is never missing
-    assert(fb.result()()(region, outOff, false) === 0.0)
+    assert(fb.result()()(region, runAggregations(region), false) === 0.0)
   }
 
   @Test
@@ -102,13 +102,13 @@ class ExtractAggregatorsSuite {
     val ir: IR = AggSum(AggMap(AggIn(tAgg), "x",
       Ref("foo"),
       TAggregable(TInt32(), Map("foo" -> (0, TInt32())))))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, region.appendInt(10), false)
+    val (post, runAggregations) = RunAggregators.onArray(ir, tAgg, aOff, region.appendInt(10), false)
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Int]
     Compile(post, fb)
 
     // out is never missing
-    assert(fb.result()()(region, outOff, false) === 30)
+    assert(fb.result()()(region, runAggregations(region), false) === 30)
   }
 
   @Test
@@ -120,13 +120,13 @@ class ExtractAggregatorsSuite {
     val ir: IR = AggSum(AggMap(AggIn(tAgg), "x",
       Ref("foo"),
       TAggregable(TInt32(), Map("foo" -> (0, TInt32())))))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, region.appendInt(10), false)
+    val (post, runAggregations) = RunAggregators.onArray(ir, tAgg, aOff, region.appendInt(10), false)
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Int]
     Compile(post, fb)
 
     // out is never missing
-    assert(fb.result()()(region, outOff, false) === 30)
+    assert(fb.result()()(region, runAggregations(region), false) === 30)
   }
 
   @Test
@@ -138,12 +138,12 @@ class ExtractAggregatorsSuite {
     val ir: IR = AggSum(AggMap(AggIn(tAgg), "x",
       ApplyBinaryPrimOp(Multiply(), Ref("foo"), Ref("x")),
       TAggregable(TInt32(), Map("foo" -> (0, TInt32())))))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, region.appendDouble(10.0), false)
+    val (post, runAggregations) = RunAggregators.onArray(ir, tAgg, aOff, region.appendDouble(10.0), false)
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
 
     // out is never missing
-    assert(fb.result()()(region, outOff, false) === 110.0)
+    assert(fb.result()()(region, runAggregations(region), false) === 110.0)
   }
 }

--- a/src/test/scala/is/hail/expr/ir/ExtractAggregatorsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/ExtractAggregatorsSuite.scala
@@ -25,9 +25,7 @@ class ExtractAggregatorsSuite {
     Compile(post, fb)
 
     // out is never missing
-    println(s"region size before: ${region.size}")
     assert(fb.result()()(region, outOff, false) === 5050.0)
-    println(s"region size after: ${region.size}")
   }
 
 
@@ -44,9 +42,7 @@ class ExtractAggregatorsSuite {
     Compile(post, fb)
 
     // out is never missing
-    println(s"region size before: ${region.size}")
     assert(fb.result()()(region, outOff, false) === 0.0)
-    println(s"region size after: ${region.size}")
   }
 
   @Test
@@ -62,9 +58,7 @@ class ExtractAggregatorsSuite {
     Compile(post, fb)
 
     // out is never missing
-    println(s"region size before: ${region.size}")
     assert(fb.result()()(region, outOff, false) === 42.0)
-    println(s"region size after: ${region.size}")
   }
 
   @Test
@@ -80,9 +74,7 @@ class ExtractAggregatorsSuite {
     Compile(post, fb)
 
     // out is never missing
-    println(s"region size before: ${region.size}")
     assert(fb.result()()(region, outOff, false) === 42.0)
-    println(s"region size after: ${region.size}")
   }
 
   @Test
@@ -98,9 +90,7 @@ class ExtractAggregatorsSuite {
     Compile(post, fb)
 
     // out is never missing
-    println(s"region size before: ${region.size}")
     assert(fb.result()()(region, outOff, false) === 0.0)
-    println(s"region size after: ${region.size}")
   }
 
   @Test
@@ -118,9 +108,7 @@ class ExtractAggregatorsSuite {
     Compile(post, fb)
 
     // out is never missing
-    println(s"region size before: ${region.size}")
     assert(fb.result()()(region, outOff, false) === 30)
-    println(s"region size after: ${region.size}")
   }
 
   @Test
@@ -138,9 +126,7 @@ class ExtractAggregatorsSuite {
     Compile(post, fb)
 
     // out is never missing
-    println(s"region size before: ${region.size}")
     assert(fb.result()()(region, outOff, false) === 30)
-    println(s"region size after: ${region.size}")
   }
 
   @Test
@@ -158,8 +144,6 @@ class ExtractAggregatorsSuite {
     Compile(post, fb)
 
     // out is never missing
-    println(s"region size before: ${region.size}")
     assert(fb.result()()(region, outOff, false) === 110.0)
-    println(s"region size after: ${region.size}")
   }
 }

--- a/src/test/scala/is/hail/expr/ir/ExtractAggregatorsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/ExtractAggregatorsSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.methods.ir
 
 import is.hail.annotations._
+import ScalaToRegionValue._
 import is.hail.asm4s._
 import is.hail.check.{Gen, Parameters, Prop}
 import is.hail.expr.{TAggregable, TArray, TFloat64, TInt32, TStruct}
@@ -11,29 +12,6 @@ import Matchers._
 
 class ExtractAggregatorsSuite {
 
-  private def addArray(mb: MemoryBuffer, a: Array[Double]): Long = {
-    val rvb = new RegionValueBuilder(mb)
-    rvb.start(TArray(TFloat64()))
-    rvb.startArray(a.length)
-    a.foreach(rvb.addDouble(_))
-    rvb.endArray()
-    rvb.end()
-  }
-
-  private def addBoxedArray(mb: MemoryBuffer, a: Array[java.lang.Double]): Long = {
-    val rvb = new RegionValueBuilder(mb)
-    rvb.start(TArray(TFloat64()))
-    rvb.startArray(a.length)
-    a.foreach { e =>
-      if (e == null)
-        rvb.setMissing()
-      else
-        rvb.addDouble(e)
-    }
-    rvb.endArray()
-    rvb.end()
-  }
-
   @Test
   def sum() {
     val tAgg = TAggregable(TFloat64(), Map("foo" -> (0, TInt32())))
@@ -41,13 +19,15 @@ class ExtractAggregatorsSuite {
     val aOff = addArray(region, (0 to 100).map(_.toDouble).toArray)
 
     val ir: IR = AggSum(AggIn(tAgg))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadDouble(_), idx => Array(10))
+    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, region.appendInt(10), false)
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
 
     // out is never missing
+    println(s"region size before: ${region}")
     assert(fb.result()()(region, outOff, false) === 5050.0)
+    println(s"region size after: ${region}")
   }
 
 
@@ -58,13 +38,15 @@ class ExtractAggregatorsSuite {
     val aOff = addArray(region, Array())
 
     val ir: IR = AggSum(AggIn(tAgg))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadDouble(_), idx => Array(10))
+    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, region.appendInt(10), false)
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
 
     // out is never missing
+    println(s"region size before: ${region}")
     assert(fb.result()()(region, outOff, false) === 0.0)
+    println(s"region size after: ${region}")
   }
 
   @Test
@@ -74,13 +56,15 @@ class ExtractAggregatorsSuite {
     val aOff = addArray(region, Array(42.0))
 
     val ir: IR = AggSum(AggIn(tAgg))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadDouble(_), idx => Array(10))
+    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, region.appendInt(10), false)
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
 
     // out is never missing
+    println(s"region size before: ${region}")
     assert(fb.result()()(region, outOff, false) === 42.0)
+    println(s"region size after: ${region}")
   }
 
   @Test
@@ -90,13 +74,15 @@ class ExtractAggregatorsSuite {
     val aOff = addBoxedArray(region, Array[java.lang.Double](null, 42.0, null))
 
     val ir: IR = AggSum(AggIn(tAgg))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadDouble(_), idx => Array(10))
+    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, region.appendInt(10), false)
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
 
     // out is never missing
+    println(s"region size before: ${region}")
     assert(fb.result()()(region, outOff, false) === 42.0)
+    println(s"region size after: ${region}")
   }
 
   @Test
@@ -106,13 +92,15 @@ class ExtractAggregatorsSuite {
     val aOff = addBoxedArray(region, Array[java.lang.Double](null, null, null))
 
     val ir: IR = AggSum(AggIn(tAgg))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadDouble(_), idx => Array(10))
+    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, region.appendInt(10), false)
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
 
     // out is never missing
+    println(s"region size before: ${region}")
     assert(fb.result()()(region, outOff, false) === 0.0)
+    println(s"region size after: ${region}")
   }
 
   @Test
@@ -124,13 +112,15 @@ class ExtractAggregatorsSuite {
     val ir: IR = AggSum(AggMap(AggIn(tAgg), "x",
       Ref("foo"),
       TAggregable(TInt32(), Map("foo" -> (0, TInt32())))))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadDouble(_), idx => Array(10))
+    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, region.appendInt(10), false)
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Int]
     Compile(post, fb)
 
     // out is never missing
+    println(s"region size before: ${region}")
     assert(fb.result()()(region, outOff, false) === 30)
+    println(s"region size after: ${region}")
   }
 
   @Test
@@ -142,13 +132,15 @@ class ExtractAggregatorsSuite {
     val ir: IR = AggSum(AggMap(AggIn(tAgg), "x",
       Ref("foo"),
       TAggregable(TInt32(), Map("foo" -> (0, TInt32())))))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadDouble(_), idx => Array(10))
+    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, region.appendInt(10), false)
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Int]
     Compile(post, fb)
 
     // out is never missing
+    println(s"region size before: ${region}")
     assert(fb.result()()(region, outOff, false) === 30)
+    println(s"region size after: ${region}")
   }
 
   @Test
@@ -160,12 +152,14 @@ class ExtractAggregatorsSuite {
     val ir: IR = AggSum(AggMap(AggIn(tAgg), "x",
       ApplyBinaryPrimOp(Multiply(), Ref("foo"), Ref("x")),
       TAggregable(TInt32(), Map("foo" -> (0, TInt32())))))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadDouble(_), idx => Array(10.0))
+    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, region.appendDouble(10.0), false)
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
 
     // out is never missing
+    println(s"region size before: ${region.size}")
     assert(fb.result()()(region, outOff, false) === 110.0)
+    println(s"region size after: ${region.size}")
   }
 }

--- a/src/test/scala/is/hail/expr/ir/ExtractAggregatorsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/ExtractAggregatorsSuite.scala
@@ -34,13 +34,18 @@ class ExtractAggregatorsSuite {
     rvb.end()
   }
 
-  private def runAggregatorsOnArray(ir: IR, tAgg: TAggregable, region: MemoryBuffer, aOff: Long, inContext: (MemoryBuffer, Long, Boolean) => Long): (IR, Long) = {
+  private def runAggregatorsOnArray(ir: IR, tAgg: TAggregable, region: MemoryBuffer, aOff: Long, extraBindings: (Int) => Array[Annotation]): (IR, Long) = {
     val tArray = TArray(tAgg.elementType)
     Infer(ir)
     val (post, agg) = ExtractAggregators(ir, tAgg)
     var i = 0
     while (i < tArray.loadLength(region, aOff)) {
-      agg.seqOp(region, inContext(region, tArray.loadElement(region, aOff, i), !tArray.isElementDefined(region, aOff, i)), false)
+      val v = if (tArray.isElementDefined(region, aOff, i))
+        tArray.loadElement(region, aOff, i)
+      else
+        null
+
+      agg.seqOp(region, tAgg.createCarrier(region, v, extraBindings(i):_*), false)
       i += 1
     }
     val outOff = agg.result(region)
@@ -54,9 +59,7 @@ class ExtractAggregatorsSuite {
     val aOff = addArray(region, (0 to 100).map(_.toDouble).toArray)
 
     val ir: IR = AggSum(AggIn(tAgg))
-    val (post, outOff) = runAggregatorsOnArray(ir, tAgg, region, aOff, { (region, eOff, m) =>
-      tAgg.createCarrier(region, if (m) null else region.loadDouble(eOff), 10)
-    } )
+    val (post, outOff) = runAggregatorsOnArray(ir, tAgg, region, aOff, idx => Array(10))
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
@@ -73,9 +76,7 @@ class ExtractAggregatorsSuite {
     val aOff = addArray(region, Array())
 
     val ir: IR = AggSum(AggIn(tAgg))
-    val (post, outOff) = runAggregatorsOnArray(ir, tAgg, region, aOff, { (region, eOff, m) =>
-      tAgg.createCarrier(region, if (m) null else region.loadDouble(eOff), 10)
-    } )
+    val (post, outOff) = runAggregatorsOnArray(ir, tAgg, region, aOff, idx => Array(10))
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
@@ -91,9 +92,7 @@ class ExtractAggregatorsSuite {
     val aOff = addArray(region, Array(42.0))
 
     val ir: IR = AggSum(AggIn(tAgg))
-    val (post, outOff) = runAggregatorsOnArray(ir, tAgg, region, aOff, { (region, eOff, m) =>
-      tAgg.createCarrier(region, if (m) null else region.loadDouble(eOff), 10)
-    } )
+    val (post, outOff) = runAggregatorsOnArray(ir, tAgg, region, aOff, idx => Array(10))
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
@@ -109,9 +108,7 @@ class ExtractAggregatorsSuite {
     val aOff = addBoxedArray(region, Array[java.lang.Double](null, 42.0, null))
 
     val ir: IR = AggSum(AggIn(tAgg))
-    val (post, outOff) = runAggregatorsOnArray(ir, tAgg, region, aOff, { (region, eOff, m) =>
-      tAgg.createCarrier(region, if (m) null else region.loadDouble(eOff), 10)
-    } )
+    val (post, outOff) = runAggregatorsOnArray(ir, tAgg, region, aOff, idx => Array(10))
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
@@ -127,9 +124,7 @@ class ExtractAggregatorsSuite {
     val aOff = addBoxedArray(region, Array[java.lang.Double](null, null, null))
 
     val ir: IR = AggSum(AggIn(tAgg))
-    val (post, outOff) = runAggregatorsOnArray(ir, tAgg, region, aOff, { (region, eOff, m) =>
-      tAgg.createCarrier(region, if (m) null else region.loadDouble(eOff), 10)
-    } )
+    val (post, outOff) = runAggregatorsOnArray(ir, tAgg, region, aOff, idx => Array(10))
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
@@ -147,9 +142,7 @@ class ExtractAggregatorsSuite {
     val ir: IR = AggSum(AggMap(AggIn(tAgg), "x",
       Ref("foo"),
       TAggregable(TInt32(), Map("foo" -> (0, TInt32())))))
-    val (post, outOff) = runAggregatorsOnArray(ir, tAgg, region, aOff, { (region, eOff, m) =>
-      tAgg.createCarrier(region, if (m) null else region.loadDouble(eOff), 10)
-    } )
+    val (post, outOff) = runAggregatorsOnArray(ir, tAgg, region, aOff, idx => Array(10))
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Int]
     Compile(post, fb)
@@ -167,9 +160,7 @@ class ExtractAggregatorsSuite {
     val ir: IR = AggSum(AggMap(AggIn(tAgg), "x",
       Ref("foo"),
       TAggregable(TInt32(), Map("foo" -> (0, TInt32())))))
-    val (post, outOff) = runAggregatorsOnArray(ir, tAgg, region, aOff, { (region, eOff, m) =>
-      tAgg.createCarrier(region, if (m) null else region.loadDouble(eOff), 10)
-    } )
+    val (post, outOff) = runAggregatorsOnArray(ir, tAgg, region, aOff, idx => Array(10))
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Int]
     Compile(post, fb)
@@ -187,9 +178,7 @@ class ExtractAggregatorsSuite {
     val ir: IR = AggSum(AggMap(AggIn(tAgg), "x",
       ApplyBinaryPrimOp(Multiply(), Ref("foo"), Ref("x")),
       TAggregable(TInt32(), Map("foo" -> (0, TInt32())))))
-    val (post, outOff) = runAggregatorsOnArray(ir, tAgg, region, aOff, { (region, eOff, m) =>
-      tAgg.createCarrier(region, if (m) null else region.loadDouble(eOff), 10.0)
-    } )
+    val (post, outOff) = runAggregatorsOnArray(ir, tAgg, region, aOff, idx => Array(10.0))
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)

--- a/src/test/scala/is/hail/expr/ir/ExtractAggregatorsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/ExtractAggregatorsSuite.scala
@@ -41,7 +41,7 @@ class ExtractAggregatorsSuite {
     val aOff = addArray(region, (0 to 100).map(_.toDouble).toArray)
 
     val ir: IR = AggSum(AggIn(tAgg))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadFloat(_), idx => Array(10))
+    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadDouble(_), idx => Array(10))
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
@@ -58,7 +58,7 @@ class ExtractAggregatorsSuite {
     val aOff = addArray(region, Array())
 
     val ir: IR = AggSum(AggIn(tAgg))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadFloat(_), idx => Array(10))
+    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadDouble(_), idx => Array(10))
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
@@ -74,7 +74,7 @@ class ExtractAggregatorsSuite {
     val aOff = addArray(region, Array(42.0))
 
     val ir: IR = AggSum(AggIn(tAgg))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadFloat(_), idx => Array(10))
+    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadDouble(_), idx => Array(10))
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
@@ -90,7 +90,7 @@ class ExtractAggregatorsSuite {
     val aOff = addBoxedArray(region, Array[java.lang.Double](null, 42.0, null))
 
     val ir: IR = AggSum(AggIn(tAgg))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadFloat(_), idx => Array(10))
+    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadDouble(_), idx => Array(10))
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
@@ -106,7 +106,7 @@ class ExtractAggregatorsSuite {
     val aOff = addBoxedArray(region, Array[java.lang.Double](null, null, null))
 
     val ir: IR = AggSum(AggIn(tAgg))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadFloat(_), idx => Array(10))
+    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadDouble(_), idx => Array(10))
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)
@@ -124,7 +124,7 @@ class ExtractAggregatorsSuite {
     val ir: IR = AggSum(AggMap(AggIn(tAgg), "x",
       Ref("foo"),
       TAggregable(TInt32(), Map("foo" -> (0, TInt32())))))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadFloat(_), idx => Array(10))
+    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadDouble(_), idx => Array(10))
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Int]
     Compile(post, fb)
@@ -142,7 +142,7 @@ class ExtractAggregatorsSuite {
     val ir: IR = AggSum(AggMap(AggIn(tAgg), "x",
       Ref("foo"),
       TAggregable(TInt32(), Map("foo" -> (0, TInt32())))))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadFloat(_), idx => Array(10))
+    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadDouble(_), idx => Array(10))
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Int]
     Compile(post, fb)
@@ -160,7 +160,7 @@ class ExtractAggregatorsSuite {
     val ir: IR = AggSum(AggMap(AggIn(tAgg), "x",
       ApplyBinaryPrimOp(Multiply(), Ref("foo"), Ref("x")),
       TAggregable(TInt32(), Map("foo" -> (0, TInt32())))))
-    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadFloat(_), idx => Array(10.0))
+    val (post, outOff) = RunAggregators.onArray(ir, tAgg, region, aOff, _.loadDouble(_), idx => Array(10.0))
 
     val fb = FunctionBuilder.functionBuilder[MemoryBuffer, Long, Boolean, Double]
     Compile(post, fb)

--- a/src/test/scala/is/hail/expr/ir/ExtractAggregatorsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/ExtractAggregatorsSuite.scala
@@ -25,9 +25,9 @@ class ExtractAggregatorsSuite {
     Compile(post, fb)
 
     // out is never missing
-    println(s"region size before: ${region}")
+    println(s"region size before: ${region.size}")
     assert(fb.result()()(region, outOff, false) === 5050.0)
-    println(s"region size after: ${region}")
+    println(s"region size after: ${region.size}")
   }
 
 
@@ -44,9 +44,9 @@ class ExtractAggregatorsSuite {
     Compile(post, fb)
 
     // out is never missing
-    println(s"region size before: ${region}")
+    println(s"region size before: ${region.size}")
     assert(fb.result()()(region, outOff, false) === 0.0)
-    println(s"region size after: ${region}")
+    println(s"region size after: ${region.size}")
   }
 
   @Test
@@ -62,9 +62,9 @@ class ExtractAggregatorsSuite {
     Compile(post, fb)
 
     // out is never missing
-    println(s"region size before: ${region}")
+    println(s"region size before: ${region.size}")
     assert(fb.result()()(region, outOff, false) === 42.0)
-    println(s"region size after: ${region}")
+    println(s"region size after: ${region.size}")
   }
 
   @Test
@@ -80,9 +80,9 @@ class ExtractAggregatorsSuite {
     Compile(post, fb)
 
     // out is never missing
-    println(s"region size before: ${region}")
+    println(s"region size before: ${region.size}")
     assert(fb.result()()(region, outOff, false) === 42.0)
-    println(s"region size after: ${region}")
+    println(s"region size after: ${region.size}")
   }
 
   @Test
@@ -98,9 +98,9 @@ class ExtractAggregatorsSuite {
     Compile(post, fb)
 
     // out is never missing
-    println(s"region size before: ${region}")
+    println(s"region size before: ${region.size}")
     assert(fb.result()()(region, outOff, false) === 0.0)
-    println(s"region size after: ${region}")
+    println(s"region size after: ${region.size}")
   }
 
   @Test
@@ -118,9 +118,9 @@ class ExtractAggregatorsSuite {
     Compile(post, fb)
 
     // out is never missing
-    println(s"region size before: ${region}")
+    println(s"region size before: ${region.size}")
     assert(fb.result()()(region, outOff, false) === 30)
-    println(s"region size after: ${region}")
+    println(s"region size after: ${region.size}")
   }
 
   @Test
@@ -138,9 +138,9 @@ class ExtractAggregatorsSuite {
     Compile(post, fb)
 
     // out is never missing
-    println(s"region size before: ${region}")
+    println(s"region size before: ${region.size}")
     assert(fb.result()()(region, outOff, false) === 30)
-    println(s"region size after: ${region}")
+    println(s"region size after: ${region.size}")
   }
 
   @Test


### PR DESCRIPTION
I added "Reviewers" who are folks that might be interested in this PR.

The PR die came up Tim.

If you prefer, I can probably break it up a bit.

The big changes are:

 - `RegionValueAggregator` an interface and associated set of concrete implementations that work on region values rather than `Annotation`s

 - The magic happens in ExtractAggregators.scala and RunAggregtors.scala. The former rips out references to aggregations and replaces them with references to the 2nd (index 1) input. The latter packages up running an aggregator on a region value array with some "context" (i.e. the `EvalContext`).