### PR TITLE
Block export on IRM v2

### DIFF
--- a/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
@@ -687,3 +687,27 @@ private class BlockMatrixMultiplyRDD(l: BlockMatrix, r: BlockMatrix)
 }
 
 case class IntPartition(index: Int) extends Partition
+
+// FIXME: requires dense IRM, no missing rows
+// FIXME: start with function on IRM, then make directly on VSM?
+class WriteBlocksRDD(irm: IndexedRowMatrix, path: String, blockSize: Int) extends RDD[Int](irm.rows.sparkContext, Nil) {
+
+//  override def getDependencies: Seq[Dependency[_]] = {
+//    new NarrowDependency(irm.rows) {
+//      def getParents(partitionId: Int): Seq[Int] = {
+//          val row = _partitioner.blockRowIndex(partitionId)
+//          val deps = new Array[Int](nProducts)
+//          var j = 0
+//          while (j < nProducts) {
+//            deps(j) = lPartitioner.partitionIdFromBlockIndices(row, j)
+//            j += 1
+//          }
+//          deps
+//        }
+//    }
+//  }
+  
+  protected def getPartitions: Array[Partition] = ???
+  
+  def compute(split: Partition, context: TaskContext): Iterator[Int] = ???
+}

--- a/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
@@ -22,14 +22,10 @@ object BlockMatrix {
 
   def from(sc: SparkContext, lm: BDM[Double], blockSize: Int): M = {
     assertCompatibleLocalMatrix(lm)
-    val partitioner = GridPartitioner(blockSize, lm.rows, lm.cols)
+    val gp = GridPartitioner(blockSize, lm.rows, lm.cols)
     val lmBc = sc.broadcast(lm)
-    val rowPartitions = partitioner.rowPartitions
-    val colPartitions = partitioner.colPartitions
-    val truncatedBlockRow = lm.rows / blockSize
-    val truncatedBlockCol = lm.cols / blockSize
-    val excessRows = lm.rows % blockSize
-    val excessCols = lm.cols % blockSize
+    val rowPartitions = gp.rowPartitions
+    val colPartitions = gp.colPartitions
     val indices = for {
       i <- 0 until rowPartitions
       j <- 0 until colPartitions
@@ -37,8 +33,8 @@ object BlockMatrix {
     val blocks = sc.parallelize(indices).map { case (i, j) =>
       val iOffset = i * blockSize
       val jOffset = j * blockSize
-      val rowsInBlock = if (i == truncatedBlockRow) excessRows else blockSize
-      val colsInBlock = if (j == truncatedBlockCol) excessCols else blockSize
+      val rowsInBlock = gp.rowPartitionRows(i)
+      val colsInBlock = gp.colPartitionCols(j)
       val a = new Array[Double](rowsInBlock * colsInBlock)
       var jj = 0
       while (jj < colsInBlock) {
@@ -50,7 +46,7 @@ object BlockMatrix {
         jj += 1
       }
       ((i, j), new BDM(rowsInBlock, colsInBlock, a))
-    }.partitionBy(partitioner)
+    }.partitionBy(gp)
     new BlockMatrix(blocks, blockSize, lm.rows, lm.cols)
   }
 
@@ -617,23 +613,14 @@ private class BlockMatrixMultiplyRDD(l: BlockMatrix, r: BlockMatrix)
   private val lPartitions = l.blocks.partitions
   private val rPartitioner = r.partitioner
   private val rPartitions = r.blocks.partitions
-  private val rows = l.rows
-  private val cols = r.cols
-  private val blockSize = l.blockSize
-  private val rowPartitions = lPartitioner.rowPartitions
-  private val colPartitions = rPartitioner.colPartitions
-  private val truncatedBlockRow = rows / blockSize
-  private val truncatedBlockCol = cols / blockSize
   private val nProducts = lPartitioner.colPartitions
-  private val excessRows = (rows % blockSize).toInt
-  private val excessCols = (cols % blockSize).toInt
-  private val nPartitions = rowPartitions * colPartitions
+  private val gp = GridPartitioner(l.blockSize, l.rows, r.cols)
 
   override def getDependencies: Seq[Dependency[_]] =
     Array[Dependency[_]](
       new NarrowDependency(l.blocks) {
         def getParents(partitionId: Int): Seq[Int] = {
-          val row = _partitioner.blockRowIndex(partitionId)
+          val row = gp.blockRowIndex(partitionId)
           val deps = new Array[Int](nProducts)
           var j = 0
           while (j < nProducts) {
@@ -645,7 +632,7 @@ private class BlockMatrixMultiplyRDD(l: BlockMatrix, r: BlockMatrix)
       },
       new NarrowDependency(r.blocks) {
         def getParents(partitionId: Int): Seq[Int] = {
-          val col = _partitioner.blockColIndex(partitionId)
+          val col = gp.blockColIndex(partitionId)
           val deps = new Array[Int](nProducts)
           var i = 0
           while (i < nProducts) {
@@ -663,10 +650,10 @@ private class BlockMatrixMultiplyRDD(l: BlockMatrix, r: BlockMatrix)
     block(r, rPartitions, rPartitioner, context, i, j)
 
   def compute(split: Partition, context: TaskContext): Iterator[((Int, Int), BDM[Double])] = {
-    val i = _partitioner.blockRowIndex(split.index)
-    val j = _partitioner.blockColIndex(split.index)
-    val rowsInBlock: Int = if (i == truncatedBlockRow) excessRows else blockSize
-    val colsInBlock: Int = if (j == truncatedBlockCol) excessCols else blockSize
+    val i = gp.blockRowIndex(split.index)
+    val j = gp.blockColIndex(split.index)
+    val rowsInBlock = gp.rowPartitionRows(i)
+    val colsInBlock: Int = gp.colPartitionCols(j)
 
     val product = BDM.zeros[Double](rowsInBlock, colsInBlock)
     var k = 0
@@ -679,36 +666,54 @@ private class BlockMatrixMultiplyRDD(l: BlockMatrix, r: BlockMatrix)
   }
 
   protected def getPartitions: Array[Partition] =
-    (0 until nPartitions).map(IntPartition).toArray[Partition]
+    (0 until gp.numPartitions).map(IntPartition).toArray[Partition]
 
-  private val _partitioner = GridPartitioner(blockSize, rows, cols)
-  /** Optionally overridden by subclasses to specify how they are partitioned. */
   @transient override val partitioner: Option[Partitioner] =
-    Some(_partitioner)
+    Some(gp)
 }
 
 case class IntPartition(index: Int) extends Partition
 
-
+// On compute, WriteBlocksRDDPartition writes the blockRow with blockRowIndex index
+// [start, end] is the range of indices of IRM (parent) partitions overlapping this blockRow
+// skip is the index in start corresponding to the first row of this blockRow
 case class WriteBlocksRDDPartition(index: Int, start: Int, skip: Int, end: Int) extends Partition {
   def range: Range = start to end
 }
 
-object WriteBlocksRDD {
-  // a(blockRowIndex) = (start, skip, end) where [start, end] are the parent partitions overlapping this blockRow
-  // and skip is the index in start corresponding to the first row in this blockRow
-  def computeBlockRowDependencies(parentPartitionBoundaries: Array[Long], gp: GridPartitioner): Array[(Int, Int, Int)] = {
+// IRM must be complete (IRM numRows == RDD count) and ordered (IndexedRow index == RDD index); checked by assertions
+class WriteBlocksRDD(irm: IndexedRowMatrix, path: String, gp: GridPartitioner) extends RDD[Int](irm.rows.sparkContext, Nil) {
+  private val parentPartitions = irm.rows.partitions
+  private val parentPartitionBoundaries: Array[Long] = irm.rows.countPerPartition().scanLeft(0L)(_ + _)
+  
+  assert(gp.rows == parentPartitionBoundaries.last,
+    s"IndexedRowMatrix has ${gp.rows} rows but RDD only has ${parentPartitionBoundaries.last} IndexedRows.")
+  
+  private val blockSize = gp.blockSize
+  private val d = digitsNeeded(gp.numPartitions)
+  private val sHadoopBc = irm.rows.sparkContext.broadcast(
+    new SerializableHadoopConfiguration(irm.rows.sparkContext.hadoopConfiguration))
+
+  override def getDependencies: Seq[Dependency[_]] = {  
+    Array[Dependency[_]](
+      new NarrowDependency(irm.rows) {
+        def getParents(partitionId: Int): Seq[Int] =
+          partitions(partitionId).asInstanceOf[WriteBlocksRDDPartition].range
+      }
+    )
+  }
+
+  protected def getPartitions: Array[Partition] = {
     val rows = parentPartitionBoundaries.last
     assert(rows == gp.rows)
     val nBlockRows = gp.rowPartitions
-    val blockSize = gp.blockSize
-    
-    val a = Array.ofDim[(Int, Int, Int)](nBlockRows)
+        
+    val parts = Array.ofDim[Partition](nBlockRows)
     
     var firstRowInBlock = 0L
     var firstRowInNextBlock = 0L
     var p = 0 // parent partition index
-    var blockRowIndex = 0
+    var blockRowIndex = 0    
     while (blockRowIndex < nBlockRows) {
       val skip = (firstRowInBlock - parentPartitionBoundaries(p)).toInt
       
@@ -723,60 +728,22 @@ object WriteBlocksRDD {
       if (parentPartitionBoundaries(p) > firstRowInNextBlock)
         p -= 1
       
-      a(blockRowIndex) = (start, skip, end)
+      parts(blockRowIndex) = WriteBlocksRDDPartition(blockRowIndex, start, skip, end)
       
       firstRowInBlock = firstRowInNextBlock
       blockRowIndex += 1
     }
-    
-    a
-  }
-}
 
-// IRM must be complete (IRM numRows == RDD count) and ordered (IndexedRow index == RDD index); checked by assertions
-class WriteBlocksRDD(irm: IndexedRowMatrix, path: String, blockSize: Int) extends RDD[Int](irm.rows.sparkContext, Nil) {
-  private val rows = irm.numRows()
-  private val cols = irm.numCols()
-  private val parentPartitions = irm.rows.partitions
-  private val parentPartitionBoundaries: Array[Long] = irm.rows.countPerPartition().scanLeft(0L)(_ + _)
-  
-  assert(rows == parentPartitionBoundaries.last,
-    s"IndexedRowMatrix has $rows rows but RDD only has ${parentPartitionBoundaries.last} IndexedRows.")
-  
-  private val gp = GridPartitioner(blockSize, rows, cols)
-  private val truncatedBlockRow = rows / blockSize
-  private val truncatedBlockCol = cols / blockSize
-  private val excessRows = (rows % blockSize).toInt
-  private val excessCols = (cols % blockSize).toInt
-  
-  private val d = digitsNeeded(gp.numPartitions)
-  private val sHadoopBc = irm.rows.sparkContext.broadcast(
-    new SerializableHadoopConfiguration(irm.rows.sparkContext.hadoopConfiguration))
-
-  override def getDependencies: Seq[Dependency[_]] = {  
-    Array[Dependency[_]](
-      new NarrowDependency(irm.rows) {
-        def getParents(partitionId: Int): Seq[Int] =
-          partitions(partitionId).asInstanceOf[WriteBlocksRDDPartition].range
-      }
-    )
-  }
-  
-  protected def getPartitions: Array[Partition] = {
-    WriteBlocksRDD.computeBlockRowDependencies(parentPartitionBoundaries, gp)
-      .zipWithIndex
-      .map { case ((start, skip, end), blockRowIndex) =>
-          WriteBlocksRDDPartition(blockRowIndex, start, skip, end)
-      }
+    parts
   }
   
   def compute(split: Partition, context: TaskContext): Iterator[Int] = {
     val blockRowIndex = split.index
     val firstRowInBlock = blockRowIndex.toLong * blockSize
-    val nRowsInBlock = if (blockRowIndex != truncatedBlockRow) blockSize else excessRows
+    val nRowsInBlock = gp.rowPartitionRows(blockRowIndex)
 
     val dosArray = Array.tabulate(gp.colPartitions) { blockColIndex =>
-      val nColsInBlock = if (blockColIndex == truncatedBlockCol) excessCols else blockSize
+      val nColsInBlock = gp.colPartitionCols(blockColIndex)
 
       val is = gp.partitionIdFromBlockIndices(blockRowIndex, blockColIndex).toString
       assert(is.length <= d)
@@ -791,17 +758,19 @@ class WriteBlocksRDD(irm: IndexedRowMatrix, path: String, blockSize: Int) extend
       dos
     }
     
-    val split0 = split.asInstanceOf[WriteBlocksRDDPartition]
-    val start = split0.start
-    var i = -split0.skip
-    split0.range.foreach { p =>
+    val writeBlocksPart = split.asInstanceOf[WriteBlocksRDDPartition]
+    val start = writeBlocksPart.start
+    var i = 0
+    writeBlocksPart.range.foreach { p =>
       val indexedRows = irm.rows.iterator(parentPartitions(p), context)
 
-      if (p == start)
-        while (i < 0) {
+      if (p == start) {
+        var j = 0
+        while (j < writeBlocksPart.skip) {
           indexedRows.next()
-          i += 1
+          j += 1
         }
+      }
 
       while (indexedRows.hasNext && i < nRowsInBlock) {
         val indexedRow = indexedRows.next()
@@ -813,10 +782,9 @@ class WriteBlocksRDD(irm: IndexedRowMatrix, path: String, blockSize: Int) extend
         var j = 0
         while (blockColIndex < gp.colPartitions) {
           val dos = dosArray(blockColIndex)
-          val nColsInBlock = if (blockColIndex != truncatedBlockCol) blockSize else excessCols
-          lastColInBlock += nColsInBlock
+          lastColInBlock += gp.colPartitionCols(blockColIndex)
           while (j < lastColInBlock) {
-            dos.writeDouble(indexedRow.vector(j))            
+            dos.writeDouble(indexedRow.vector(j))
             j += 1
           }
           blockColIndex += 1

--- a/src/main/scala/is/hail/distributedmatrix/GridPartitioner.scala
+++ b/src/main/scala/is/hail/distributedmatrix/GridPartitioner.scala
@@ -10,7 +10,16 @@ case class GridPartitioner(blockSize: Int, rows: Long, cols: Long, transposed: B
 
   val rowPartitions: Int = ((rows - 1) / blockSize + 1).toInt
   val colPartitions: Int = ((cols - 1) / blockSize + 1).toInt
-
+  
+  val truncatedBlockRow: Int = (rows / blockSize).toInt
+  val truncatedBlockCol: Int = (cols / blockSize).toInt
+  
+  val excessRows: Int = (rows % blockSize).toInt
+  val excessCols: Int = (cols % blockSize).toInt
+  
+  def rowPartitionRows(i: Int): Int = if (i != truncatedBlockRow) blockSize else excessRows
+  def colPartitionCols(j: Int): Int = if (j != truncatedBlockCol) blockSize else excessCols
+  
   override val numPartitions: Int = rowPartitions * colPartitions
   assert(numPartitions >= rowPartitions && numPartitions >= colPartitions)
   

--- a/src/main/scala/is/hail/utils/richUtils/RichIndexedRowMatrix.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichIndexedRowMatrix.scala
@@ -106,7 +106,7 @@ class RichIndexedRowMatrix(indexedRowMatrix: IndexedRowMatrix) {
     // write metadata
     hadoop.writeDataFile(uri + BlockMatrix.metadataRelativePath) { os =>
       jackson.Serialization.write(
-        BlockMatrixMetadata(blockSize, rows, cols, transposed = false),
+        BlockMatrixMetadata(blockSize, rows, cols),
         os)
     }
   }

--- a/src/main/scala/is/hail/utils/richUtils/RichIndexedRowMatrix.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichIndexedRowMatrix.scala
@@ -98,8 +98,8 @@ class RichIndexedRowMatrix(indexedRowMatrix: IndexedRowMatrix) {
     
     // write blocks
     hadoop.mkDir(uri + "/parts")
-    val blockCount = new WriteBlocksRDD(indexedRowMatrix, uri, blockSize).reduce(_ + _)
     val gp = GridPartitioner(blockSize, rows, cols)
+    val blockCount = new WriteBlocksRDD(indexedRowMatrix, uri, gp).reduce(_ + _)
     assert(blockCount == gp.numPartitions)
     info(s"Wrote all $blockCount blocks of $rows x $cols matrix with block size $blockSize.")
     

--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -196,4 +196,12 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
     
     itemCount
   }
+  
+  // FIXME: persist issues?
+  // returns index of first element in each partition and number of elements
+  // |P1| = 3, |P2| = 5, |P3| = 4 => [0, 3, 8, 12]
+  def computeBoundaries(): Array[Long] =
+    r.mapPartitions(it => Iterator(it.length), preservesPartitioning = true)
+      .collect()
+      .scanLeft(0L)(_ + _)
 }

--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -196,12 +196,4 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
     
     itemCount
   }
-  
-  // FIXME: persist issues?
-  // returns cumulative index of first element in each partition and total number of elements
-  // example: three partitions with |P1| = 3, |P2| = 5, |P3| = 4; returns [0, 3, 8, 12]
-  def computePartitionBoundaries(): Array[Long] =
-    r.mapPartitions(it => Iterator(it.length), preservesPartitioning = true)
-      .collect()
-      .scanLeft(0L)(_ + _)
 }

--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -198,9 +198,9 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
   }
   
   // FIXME: persist issues?
-  // returns index of first element in each partition and total number of elements
+  // returns cumulative index of first element in each partition and total number of elements
   // example: three partitions with |P1| = 3, |P2| = 5, |P3| = 4; returns [0, 3, 8, 12]
-  def computeBoundaries(): Array[Long] =
+  def computePartitionBoundaries(): Array[Long] =
     r.mapPartitions(it => Iterator(it.length), preservesPartitioning = true)
       .collect()
       .scanLeft(0L)(_ + _)

--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -198,8 +198,8 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
   }
   
   // FIXME: persist issues?
-  // returns index of first element in each partition and number of elements
-  // |P1| = 3, |P2| = 5, |P3| = 4 => [0, 3, 8, 12]
+  // returns index of first element in each partition and total number of elements
+  // example: three partitions with |P1| = 3, |P2| = 5, |P3| = 4; returns [0, 3, 8, 12]
   def computeBoundaries(): Array[Long] =
     r.mapPartitions(it => Iterator(it.length), preservesPartitioning = true)
       .collect()

--- a/src/test/scala/is/hail/TestUtils.scala
+++ b/src/test/scala/is/hail/TestUtils.scala
@@ -20,13 +20,23 @@ object TestUtils {
            |  Found: ${thrown.getMessage} """.stripMargin)
     assert(p)
   }
-
+  
   def interceptSpark(regex: String)(f: => Any) {
     val thrown = intercept[SparkException](f)
     val p = regex.r.findFirstIn(thrown.getMessage).isDefined
     if (!p)
       println(
         s"""expected fatal exception with pattern `$regex'
+           |  Found: ${thrown.getMessage} """.stripMargin)
+    assert(p)
+  }
+  
+  def interceptAssertion(regex: String)(f: => Any) {
+    val thrown = intercept[AssertionError](f)
+    val p = regex.r.findFirstIn(thrown.getMessage).isDefined
+    if (!p)
+      println(
+        s"""expected assertion error with pattern `$regex'
            |  Found: ${thrown.getMessage} """.stripMargin)
     assert(p)
   }

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -588,9 +588,10 @@ class BlockMatrixSuite extends SparkSuite {
     val gp = GridPartitioner(blockSize = 2, rows = 9, cols = 4) 
     // 0   2   4   6   8 9
     // 0     3 4 5   7 8 9
-    val (starts, ends) = WriteBlocksRDD.computeBlockRowDependencies(Array(0, 3, 4, 4, 5, 7, 8, 9), gp)
+    val parentPartitionBoundaries = Array[Long](0, 3, 4, 4, 5, 7, 8, 9)
     
-    assert(starts sameElements Array(0, 0, 2, 4, 6))
-    assert(ends sameElements Array(0, 1, 4, 5, 6))
+    assert(WriteBlocksRDD.computeBlockRowDependencies(parentPartitionBoundaries, gp)
+      sameElements
+      Array((0, 0, 0), (0, 2, 1), (2, 0, 4), (4, 1, 5), (6, 0, 6)))
   }
 }

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -582,5 +582,19 @@ class BlockMatrixSuite extends SparkSuite {
     assert(mt.t.map2WithIndex(m.t.t, (i,j,x,y) => 3 * x + 5 * y + i * 2 + j + 1).toLocalMatrix() ===
       9.0 * lm)
   }
-
+  
+  @Test
+  def blockRowDependencies() {
+    val gp = GridPartitioner(blockSize = 2, rows = 9, cols = 4) 
+    // 0   2   4   6   8 9
+    // 0     3 4 5   7 8 9
+    val deps = WriteBlocksRDD.computeBlockRowDependencies(Array(0, 3, 4, 4, 5, 7, 8, 9), gp)
+    
+    assert(
+      (deps(0) sameElements Array(0)) &&
+      (deps(1) sameElements Array(0, 1)) &&
+      (deps(2) sameElements Array(3, 4)) &&
+      (deps(3) sameElements Array(4, 5)) &&
+      (deps(4) sameElements Array(6)))
+  }
 }

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -588,13 +588,9 @@ class BlockMatrixSuite extends SparkSuite {
     val gp = GridPartitioner(blockSize = 2, rows = 9, cols = 4) 
     // 0   2   4   6   8 9
     // 0     3 4 5   7 8 9
-    val deps = WriteBlocksRDD.computeBlockRowDependencies(Array(0, 3, 4, 4, 5, 7, 8, 9), gp)
+    val (starts, ends) = WriteBlocksRDD.computeBlockRowDependencies(Array(0, 3, 4, 4, 5, 7, 8, 9), gp)
     
-    assert(
-      (deps(0) sameElements Array(0)) &&
-      (deps(1) sameElements Array(0, 1)) &&
-      (deps(2) sameElements Array(3, 4)) &&
-      (deps(3) sameElements Array(4, 5)) &&
-      (deps(4) sameElements Array(6)))
+    assert(starts sameElements Array(0, 0, 2, 4, 6))
+    assert(ends sameElements Array(0, 1, 4, 5, 6))
   }
 }

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -8,9 +8,6 @@ import is.hail.check.Gen._
 import is.hail.check._
 import is.hail.distributedmatrix.BlockMatrix.ops._
 import is.hail.utils._
-import org.apache.spark.mllib.linalg.Vectors
-import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix}
-import org.apache.spark.rdd.RDD
 import org.testng.annotations.Test
 
 class BlockMatrixSuite extends SparkSuite {
@@ -585,4 +582,5 @@ class BlockMatrixSuite extends SparkSuite {
     assert(mt.t.map2WithIndex(m.t.t, (i,j,x,y) => 3 * x + 5 * y + i * 2 + j + 1).toLocalMatrix() ===
       9.0 * lm)
   }
+
 }

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -35,26 +35,22 @@ class BlockMatrixSuite extends SparkSuite {
   def toBM(lm: BDM[Double], blockSize: Int): BlockMatrix =
     BlockMatrix.from(sc, lm, blockSize)
  
-  private val defaultBlockSize = choose(0, 1 << 6)
+  private val defaultBlockSize = choose(1, 1 << 6)
   private val defaultDims = nonEmptySquareOfAreaAtMostSize
-  private val defaultTransposed = coin()
   private val defaultElement = arbitrary[Double]
 
   def blockMatrixGen(
     blockSize: Gen[Int] = defaultBlockSize,
     dims: Gen[(Int, Int)] = defaultDims,
-    transposed: Gen[Boolean] = defaultTransposed,
     element: Gen[Double] = defaultElement
   ): Gen[BlockMatrix] = for {
     blockSize <- blockSize
     (rows, columns) <- dims
-    transposed <- transposed
     arrays <- buildableOfN[Seq, Array[Double]](rows, buildableOfN(columns, element))
     m = toBM(arrays, blockSize)
-  } yield if (transposed) m.t else m
+  } yield m
 
   def squareBlockMatrixGen(
-    transposed: Gen[Boolean] = defaultTransposed,
     element: Gen[Double] = defaultElement
   ): Gen[BlockMatrix] = blockMatrixGen(
     blockSize = interestingPosInt.map(math.sqrt(_).toInt),
@@ -63,17 +59,15 @@ class BlockMatrixSuite extends SparkSuite {
       l <- interestingPosInt
       s = math.sqrt(math.min(l, size)).toInt
     } yield (s, s),
-    transposed = transposed,
     element = element
   )
 
   def twoMultipliableBlockMatrices(element: Gen[Double] = defaultElement): Gen[(BlockMatrix, BlockMatrix)] = for {
     Array(rows, inner, cols) <- nonEmptyNCubeOfVolumeAtMostSize(3)
     blockSize <- interestingPosInt.map(math.pow(_, 1.0 / 3.0).toInt)
-    transposed <- coin()
-    l <- blockMatrixGen(const(blockSize), const(rows -> inner), const(transposed), element)
-    r <- blockMatrixGen(const(blockSize), const(inner -> cols), const(transposed), element)
-  } yield if (transposed) (r, l) else (l, r)
+    l <- blockMatrixGen(const(blockSize), const(rows -> inner), element)
+    r <- blockMatrixGen(const(blockSize), const(inner -> cols), element)
+  } yield (l, r)
 
   implicit val arbitraryBlockMatrix =
     Arbitrary(blockMatrixGen())

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -585,7 +585,7 @@ class BlockMatrixSuite extends SparkSuite {
     assert(mt.t.map2WithIndex(m.t.t, (i,j,x,y) => 3 * x + 5 * y + i * 2 + j + 1).toLocalMatrix() ===
       9.0 * lm)
   }
-
+  
   @Test
   def writeBlocksRDD() {
     // FIXME: duplicates matrix in RichIRMSuite
@@ -602,7 +602,7 @@ class BlockMatrixSuite extends SparkSuite {
       (7L, Vectors.dense(4.0, 5.0, 6.0, 1.0, 1.0, 1.0)),
       (8L, Vectors.dense(7.0, 8.0, 9.0, 1.0, 1.0, 1.0))
     ).map(IndexedRow.tupled)
-    `
+    
     val indexedRows: RDD[IndexedRow] = sc.parallelize(data, numSlices = 4)
 
     val irm = new IndexedRowMatrix(indexedRows, rows, cols)
@@ -612,9 +612,6 @@ class BlockMatrixSuite extends SparkSuite {
     
     assert(b.last == rows) // will catch missing rows
     
-    def dependencies(blockRow: Int) = ???
-
     // val blockMat = irm.toHailBlockMatrix(2)
-    }
   }
 }

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -583,15 +583,4 @@ class BlockMatrixSuite extends SparkSuite {
       9.0 * lm)
   }
   
-  @Test
-  def blockRowDependencies() {
-    val gp = GridPartitioner(blockSize = 2, rows = 9, cols = 4) 
-    // 0   2   4   6   8 9
-    // 0     3 4 5   7 8 9
-    val parentPartitionBoundaries = Array[Long](0, 3, 4, 4, 5, 7, 8, 9)
-    
-    assert(WriteBlocksRDD.computeBlockRowDependencies(parentPartitionBoundaries, gp)
-      sameElements
-      Array((0, 0, 0), (0, 2, 1), (2, 0, 4), (4, 1, 5), (6, 0, 6)))
-  }
 }

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -585,40 +585,4 @@ class BlockMatrixSuite extends SparkSuite {
     assert(mt.t.map2WithIndex(m.t.t, (i,j,x,y) => 3 * x + 5 * y + i * 2 + j + 1).toLocalMatrix() ===
       9.0 * lm)
   }
-  
-  @Test
-  def writeBlocksRDD() {
-    // FIXME: duplicates matrix in RichIRMSuite
-    val rows = 9L
-    val cols = 6
-    val data = Seq(
-      (0L, Vectors.dense(0.0, 1.0, 2.0, 1.0, 3.0, 4.0)),
-      (1L, Vectors.dense(3.0, 4.0, 5.0, 1.0, 1.0, 1.0)),
-      (2L, Vectors.dense(9.0, 0.0, 2.0, 1.0, 1.0, 1.0)),
-      (3L, Vectors.dense(9.0, 0.0, 1.0, 1.0, 1.0, 1.0)),
-      (4L, Vectors.dense(9.0, 0.0, 1.0, 1.0, 1.0, 1.0)),
-      (5L, Vectors.dense(9.0, 0.0, 1.0, 1.0, 1.0, 1.0)),
-      (6L, Vectors.dense(1.0, 2.0, 3.0, 1.0, 1.0, 1.0)),
-      (7L, Vectors.dense(4.0, 5.0, 6.0, 1.0, 1.0, 1.0)),
-      (8L, Vectors.dense(7.0, 8.0, 9.0, 1.0, 1.0, 1.0))
-    ).map(IndexedRow.tupled)
-    
-    val indexedRows: RDD[IndexedRow] = sc.parallelize(data, numSlices = 4)
-    
-    val irm = new IndexedRowMatrix(indexedRows, rows, cols)
-    
-    val boundaries = indexedRows.computeBoundaries()
-    println(boundaries.toIndexedSeq)
-    
-    assert(boundaries.last == rows) // will catch missing rows
-
-    val blockSize = 100
-    val nBlockRows = ((irm.numRows() - 1) / blockSize + 1).toInt
-    
-    assert(boundaries.last == irm.numRows())
-    val deps = WriteBlocksRDD.allDependencies(boundaries, nBlockRows, blockSize)
-    deps.zipWithIndex.foreach { case (a, i) => println(s"block=$i, dep=${a.mkString(",")}") }
-    
-    // val blockMat = irm.toHailBlockMatrix(2)
-  }
 }

--- a/src/test/scala/is/hail/distributedmatrix/GridPartitionerSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/GridPartitionerSuite.scala
@@ -15,7 +15,7 @@ class GridPartitionerSuite extends TestNGSuite {
   }
 
   @Test
-  def untransposedSquareIsColumnMajor() {
+  def squareIsColumnMajor() {
     assertLayout(GridPartitioner(2, 4, 4),
       (0, 0) -> 0,
       (1, 0) -> 1,
@@ -25,7 +25,7 @@ class GridPartitionerSuite extends TestNGSuite {
   }
 
   @Test
-  def untransposedRectangleMoreRowsIsColumnMajor() {
+  def rectangleMoreRowsIsColumnMajor() {
     assertLayout(GridPartitioner(2, 6, 4),
       (0, 0) -> 0,
       (1, 0) -> 1,
@@ -37,52 +37,13 @@ class GridPartitionerSuite extends TestNGSuite {
   }
 
   @Test
-  def untransposedRectangleMoreColsIsColumnMajor() {
+  def rectangleMoreColsIsColumnMajor() {
     assertLayout(GridPartitioner(2, 4, 6),
       (0, 0) -> 0,
       (1, 0) -> 1,
       (0, 1) -> 2,
       (1, 1) -> 3,
       (0, 2) -> 4,
-      (1, 2) -> 5
-    )
-  }
-
-  @Test
-  def transposedSquare() {
-    assertLayout(GridPartitioner(2, 4, 4, transposed=true),
-      (0, 0) -> 0,
-      (1, 0) -> 2,
-      (0, 1) -> 1,
-      (1, 1) -> 3
-    )
-  }
-
-  @Test
-  def transposedRectangleMoreRows() {
-    assertLayout(GridPartitioner(2, 6, 4, transposed=true),
-      // 0 1
-      // 2 3
-      // 4 5
-      (0, 0) -> 0,
-      (0, 1) -> 1,
-      (1, 0) -> 2,
-      (1, 1) -> 3,
-      (2, 0) -> 4,
-      (2, 1) -> 5
-    )
-  }
-
-  @Test
-  def transposedRectangleMoreCols() {
-    assertLayout(GridPartitioner(2, 4, 6, transposed=true),
-      // 0 1 2
-      // 3 4 5
-      (0, 0) -> 0,
-      (0, 1) -> 1,
-      (0, 2) -> 2,
-      (1, 0) -> 3,
-      (1, 1) -> 4,
       (1, 2) -> 5
     )
   }

--- a/src/test/scala/is/hail/utils/RichIndexedRowMatrixSuite.scala
+++ b/src/test/scala/is/hail/utils/RichIndexedRowMatrixSuite.scala
@@ -87,7 +87,7 @@ class RichIndexedRowMatrixSuite extends SparkSuite {
       (0L, Vectors.dense(0.0, 1.0, 2.0, 1.0, 3.0, 4.0)),
       (1L, Vectors.dense(3.0, 4.0, 5.0, 1.0, 1.0, 1.0)),
       (2L, Vectors.dense(9.0, 0.0, 2.0, 1.0, 2.0, 9.0)),
-      (3L, Vectors.dense(0.0, 0.0, 1.0, 1.0, 1.0, 1.0)),
+      (3L, Vectors.dense(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)),
       (4L, Vectors.dense(9.0, 1.0, 7.0, 1.0, 1.0, 2.0)),
       (5L, Vectors.dense(6.0, 0.0, 1.0, 1.0, 1.0, 1.0)),
       (6L, Vectors.dense(1.0, 2.0, 3.0, 4.0, 2.0, 1.0)),

--- a/src/test/scala/is/hail/utils/RichIndexedRowMatrixSuite.scala
+++ b/src/test/scala/is/hail/utils/RichIndexedRowMatrixSuite.scala
@@ -107,4 +107,26 @@ class RichIndexedRowMatrixSuite extends SparkSuite {
       assert(BlockMatrix.read(hc, filename).toLocalMatrix() === irm.toHailBlockMatrix().toLocalMatrix())
     }
   }
+  
+//    @Test def testWriteAsBlockMatrixSmall() {
+//    val rows = 3L
+//    val cols = 4L
+//    val data = Seq(
+//      (0L, Vectors.dense(0.0, 1.0, 2.0, 3.0)),
+//      (1L, Vectors.dense(4.0, 5.0, 6.0, 7.0)),
+//      (2L, Vectors.dense(8.0, 9.0, 10.0, 11.0))
+//    ).map(IndexedRow.tupled)
+//
+//    val filename = tmpDir.createTempFile()
+//    
+//    for {
+//      numSlices <- Seq(2) //Seq(1, 2, 4, 5)
+//      blockSize <- Seq(2) //Seq(1, 2, 3, 4, 6)
+//    } {
+//      val irm = new IndexedRowMatrix(sc.parallelize(data, numSlices))
+//      irm.writeAsBlockMatrix(filename, blockSize)
+//      
+//      assert(BlockMatrix.read(hc, filename).toLocalMatrix() === irm.toHailBlockMatrix().toLocalMatrix())
+//    }
+//  }
 }

--- a/src/test/scala/is/hail/utils/RichIndexedRowMatrixSuite.scala
+++ b/src/test/scala/is/hail/utils/RichIndexedRowMatrixSuite.scala
@@ -94,24 +94,13 @@ class RichIndexedRowMatrixSuite extends SparkSuite {
       (7L, Vectors.dense(4.0, 5.0, 6.0, 1.0, 1.0, 5.0)),
       (8L, Vectors.dense(7.0, 8.0, 9.0, 1.0, 0.0, 1.0))
     ).map(IndexedRow.tupled)
-        
-//    val boundaries = indexedRows.computeBoundaries()
-//    println(boundaries.toIndexedSeq)
-//    
-//    assert(boundaries.last == rows) // will catch missing rows
-//
-//    val blockSize = 2
-//    val nBlockRows = ((irm.numRows() - 1) / blockSize + 1).toInt
-//    
-//    assert(boundaries.last == irm.numRows())
-//    val deps = WriteBlocksRDD.allDependencies(boundaries, nBlockRows, blockSize)
-//    deps.zipWithIndex.foreach { case (a, i) => println(s"block=$i, dep=${a.mkString(",")}") }
+
+    val filename = tmpDir.createTempFile()
     
     for {
       numSlices <- Seq(1, 2, 4, 9, 11)
       blockSize <- Seq(1, 2, 3, 4, 6, 7, 9, 10)
     } {
-      val filename = tmpDir.createTempFile("test")
       val irm = new IndexedRowMatrix(sc.parallelize(data, numSlices))
       irm.writeAsBlockMatrix(filename, blockSize)
       

--- a/src/test/scala/is/hail/utils/RichIndexedRowMatrixSuite.scala
+++ b/src/test/scala/is/hail/utils/RichIndexedRowMatrixSuite.scala
@@ -86,13 +86,13 @@ class RichIndexedRowMatrixSuite extends SparkSuite {
     val data = Seq(
       (0L, Vectors.dense(0.0, 1.0, 2.0, 1.0, 3.0, 4.0)),
       (1L, Vectors.dense(3.0, 4.0, 5.0, 1.0, 1.0, 1.0)),
-      (2L, Vectors.dense(9.0, 0.0, 2.0, 1.0, 1.0, 1.0)),
-      (3L, Vectors.dense(9.0, 0.0, 1.0, 1.0, 1.0, 1.0)),
-      (4L, Vectors.dense(9.0, 0.0, 1.0, 1.0, 1.0, 1.0)),
-      (5L, Vectors.dense(9.0, 0.0, 1.0, 1.0, 1.0, 1.0)),
-      (6L, Vectors.dense(1.0, 2.0, 3.0, 1.0, 1.0, 1.0)),
-      (7L, Vectors.dense(4.0, 5.0, 6.0, 1.0, 1.0, 1.0)),
-      (8L, Vectors.dense(7.0, 8.0, 9.0, 1.0, 1.0, 1.0))
+      (2L, Vectors.dense(9.0, 0.0, 2.0, 1.0, 2.0, 9.0)),
+      (3L, Vectors.dense(0.0, 0.0, 1.0, 1.0, 1.0, 1.0)),
+      (4L, Vectors.dense(9.0, 1.0, 7.0, 1.0, 1.0, 2.0)),
+      (5L, Vectors.dense(6.0, 0.0, 1.0, 1.0, 1.0, 1.0)),
+      (6L, Vectors.dense(1.0, 2.0, 3.0, 4.0, 2.0, 1.0)),
+      (7L, Vectors.dense(4.0, 5.0, 6.0, 1.0, 1.0, 5.0)),
+      (8L, Vectors.dense(7.0, 8.0, 9.0, 1.0, 0.0, 1.0))
     ).map(IndexedRow.tupled)
         
 //    val boundaries = indexedRows.computeBoundaries()

--- a/src/test/scala/is/hail/utils/RichIndexedRowMatrixSuite.scala
+++ b/src/test/scala/is/hail/utils/RichIndexedRowMatrixSuite.scala
@@ -2,6 +2,7 @@ package is.hail.utils
 
 import breeze.linalg.{DenseMatrix => BDM, _}
 import is.hail.SparkSuite
+import is.hail.distributedmatrix.{BlockMatrix, WriteBlocksRDD}
 import is.hail.distributedmatrix.BlockMatrix.ops._
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.linalg.distributed.{DistributedMatrix, IndexedRow, IndexedRowMatrix}
@@ -33,22 +34,22 @@ class RichIndexedRowMatrixSuite extends SparkSuite {
     ).map(IndexedRow.tupled)
     val indexedRows: RDD[IndexedRow] = sc.parallelize(data)
 
-    val idxRowMat = new IndexedRowMatrix(indexedRows)
+    val irm = new IndexedRowMatrix(indexedRows)
 
     for {
-      blockSize <- Seq(1,2,3,4,6,7,9,10)
+      blockSize <- Seq(1, 2, 3, 4, 6, 7, 9, 10)
     } {
-      val blockMat = idxRowMat.toHailBlockMatrix(blockSize)
+      val blockMat = irm.toHailBlockMatrix(blockSize)
       assert(blockMat.rows === rows)
       assert(blockMat.cols === cols)
-      assert(blockMat.toLocalMatrix() === convertDistributedMatrixToBreeze(idxRowMat))
+      assert(blockMat.toLocalMatrix() === convertDistributedMatrixToBreeze(irm))
     }
 
     intercept[IllegalArgumentException] {
-      idxRowMat.toHailBlockMatrix(-1)
+      irm.toHailBlockMatrix(-1)
     }
     intercept[IllegalArgumentException] {
-      idxRowMat.toHailBlockMatrix(0)
+      irm.toHailBlockMatrix(0)
     }
   }
 
@@ -62,12 +63,12 @@ class RichIndexedRowMatrixSuite extends SparkSuite {
       (8L, Vectors.dense(1.0, 2.0))
     ).map(IndexedRow.tupled)
 
-    val idxRowMat = new IndexedRowMatrix(sc.parallelize(data))
+    val irm = new IndexedRowMatrix(sc.parallelize(data))
 
-    val m = idxRowMat.toHailBlockMatrix(2)
+    val m = irm.toHailBlockMatrix(2)
     assert(m.rows == rows)
     assert(m.cols == cols)
-    assert(m.toLocalMatrix() == convertDistributedMatrixToBreeze(idxRowMat))
+    assert(m.toLocalMatrix() == convertDistributedMatrixToBreeze(irm))
     assert(m.blocks.count() == 5)
 
     (m * m.t).toLocalMatrix() // assert no exception
@@ -78,5 +79,43 @@ class RichIndexedRowMatrixSuite extends SparkSuite {
         10.0, 11.0, 12.0, 15.0, 16.0, 17.0, 16.0, 17.0, 20.0
       )))
   }
-
+  
+  @Test def testWriteAsBlockMatrix() {
+    val rows = 9L
+    val cols = 6L
+    val data = Seq(
+      (0L, Vectors.dense(0.0, 1.0, 2.0, 1.0, 3.0, 4.0)),
+      (1L, Vectors.dense(3.0, 4.0, 5.0, 1.0, 1.0, 1.0)),
+      (2L, Vectors.dense(9.0, 0.0, 2.0, 1.0, 1.0, 1.0)),
+      (3L, Vectors.dense(9.0, 0.0, 1.0, 1.0, 1.0, 1.0)),
+      (4L, Vectors.dense(9.0, 0.0, 1.0, 1.0, 1.0, 1.0)),
+      (5L, Vectors.dense(9.0, 0.0, 1.0, 1.0, 1.0, 1.0)),
+      (6L, Vectors.dense(1.0, 2.0, 3.0, 1.0, 1.0, 1.0)),
+      (7L, Vectors.dense(4.0, 5.0, 6.0, 1.0, 1.0, 1.0)),
+      (8L, Vectors.dense(7.0, 8.0, 9.0, 1.0, 1.0, 1.0))
+    ).map(IndexedRow.tupled)
+        
+//    val boundaries = indexedRows.computeBoundaries()
+//    println(boundaries.toIndexedSeq)
+//    
+//    assert(boundaries.last == rows) // will catch missing rows
+//
+//    val blockSize = 2
+//    val nBlockRows = ((irm.numRows() - 1) / blockSize + 1).toInt
+//    
+//    assert(boundaries.last == irm.numRows())
+//    val deps = WriteBlocksRDD.allDependencies(boundaries, nBlockRows, blockSize)
+//    deps.zipWithIndex.foreach { case (a, i) => println(s"block=$i, dep=${a.mkString(",")}") }
+    
+    for {
+      numSlices <- Seq(1, 2, 4, 9, 11)
+      blockSize <- Seq(1, 2, 3, 4, 6, 7, 9, 10)
+    } {
+      val filename = tmpDir.createTempFile("test")
+      val irm = new IndexedRowMatrix(sc.parallelize(data, numSlices))
+      irm.writeAsBlockMatrix(filename, blockSize)
+      
+      assert(BlockMatrix.read(hc, filename).toLocalMatrix() === irm.toHailBlockMatrix().toLocalMatrix())
+    }
+  }
 }

--- a/src/test/scala/is/hail/utils/RichIndexedRowMatrixSuite.scala
+++ b/src/test/scala/is/hail/utils/RichIndexedRowMatrixSuite.scala
@@ -107,26 +107,4 @@ class RichIndexedRowMatrixSuite extends SparkSuite {
       assert(BlockMatrix.read(hc, filename).toLocalMatrix() === irm.toHailBlockMatrix().toLocalMatrix())
     }
   }
-  
-//    @Test def testWriteAsBlockMatrixSmall() {
-//    val rows = 3L
-//    val cols = 4L
-//    val data = Seq(
-//      (0L, Vectors.dense(0.0, 1.0, 2.0, 3.0)),
-//      (1L, Vectors.dense(4.0, 5.0, 6.0, 7.0)),
-//      (2L, Vectors.dense(8.0, 9.0, 10.0, 11.0))
-//    ).map(IndexedRow.tupled)
-//
-//    val filename = tmpDir.createTempFile()
-//    
-//    for {
-//      numSlices <- Seq(2) //Seq(1, 2, 4, 5)
-//      blockSize <- Seq(2) //Seq(1, 2, 3, 4, 6)
-//    } {
-//      val irm = new IndexedRowMatrix(sc.parallelize(data, numSlices))
-//      irm.writeAsBlockMatrix(filename, blockSize)
-//      
-//      assert(BlockMatrix.read(hc, filename).toLocalMatrix() === irm.toHailBlockMatrix().toLocalMatrix())
-//    }
-//  }
 }


### PR DESCRIPTION
@cseed after comments in #2482, I reworked this so that for each block row, each overlapping parent partition is iterated through once, writing out the full row into files corresponding to block columns.

Based on the WriteBlocksRDDPartition comment and looking at BlockedRDD, now rather than computing the indices of all non-empty overlapping parent partitions, I switched to just computing the first and last overlapping parent partitions, and the number of rows to skip in the first partition, and put this in WriteBlocksRDDPartition. I'd appreciate feedback on this approach, and whether I've put the "right" data in WriteBlocksRDDPartition. In particular, I'm unsure why `computeBlockRowDependencies` would have been called multiple times given that it's a private val in the class. Is the class serialized to workers before function evaluation? Is parentPartitionBoundaries recomputed as well? I don't have a clear model.

The function `computeBlockRowDependencies` could be moved directly into getDependencies; I kept it separate in order to write a simple test. I'm not a huge fan of the array of tuples but it seemed more natural than three arrays.