### PR TITLE
Remove attributes from Type

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -1453,8 +1453,9 @@ class VariantDataset(HistoryMixin):
     @write_history('output')
     @typecheck_method(output=strlike,
                       append_to_header=nullable(strlike),
-                      parallel=bool)
-    def export_vcf(self, output, append_to_header=None, parallel=False):
+                      parallel=bool,
+                      metadata=nullable(dictof(strlike, dictof(strlike, dictof(strlike, strlike)))))
+    def export_vcf(self, output, append_to_header=None, parallel=False, metadata=None):
         """Export variant dataset as a .vcf or .vcf.bgz file.
 
         .. include:: _templates/req_tvariant.rst
@@ -1499,7 +1500,15 @@ class VariantDataset(HistoryMixin):
 
         >>> vds.export_vcf('output/example_out.vcf')
 
-        The *example_out.vcf* header will contain the FORMAT, FILTER, and INFO lines present in *example.vcf*. However, it will *not* contain CONTIG lines or lines added by external tools (such as bcftools and GATK) unless they are explicitly inserted using the ``append_to_header`` option.
+        The *example_out.vcf* header will contain FORMAT lines for each genotype field, CONTIG lines for the reference genome
+        of the dataset, and INFO lines for all fields in ``va.info``, but they
+        will have empty Description fields and the Number and Type fields will be determined from their corresponding Hail types.
+        To add a desired Description, Number, and/or Type to a FORMAT or INFO field or to specify FILTER lines, use the
+        ``metadata`` option to supply a dictionary with the relevant information.
+        See :py:class:`~hail.HailContext.get_vcf_metadata` for how this dictionary should be structured.
+
+
+        The *example_out.vcf* header will *not* contain lines added by external tools (such as bcftools and GATK) unless they are explicitly inserted using the ``append_to_header`` option.
 
         .. caution::
 
@@ -1518,9 +1527,13 @@ class VariantDataset(HistoryMixin):
         :type append_to_header: str or None
 
         :param bool parallel: If true, return a set of VCF files (one per partition) rather than serially concatenating these files.
+
+        :param metadata: Dictionary with information to fill in the VCF header. See :py:class:`~hail.HailContext.get_vcf_metadata` for an example.
+        :type metadata: (dict of str to (dict of str to (dict of str to str))) or None
         """
 
-        self._jvds.exportVCF(output, joption(append_to_header), parallel)
+        typ = TDict(TString(), TDict(TString(), TDict(TString(), TString())))
+        self._jvds.exportVCF(output, joption(append_to_header), parallel, joption(typ._convert_to_j(metadata)))
 
     @handle_py4j
     @write_history('output', is_dir=True)
@@ -4514,138 +4527,6 @@ class VariantDataset(HistoryMixin):
 
         js = self._jvds.summarize()
         return Summary._from_java(js)
-
-    @handle_py4j
-    @record_method
-    @typecheck_method(ann_path=strlike,
-                      attributes=dictof(strlike, strlike))
-    def set_va_attributes(self, ann_path, attributes):
-        """Sets attributes for a variant annotation.
-        Attributes are key/value pairs that can be attached to a variant annotation field.
-
-        The following attributes are read from the VCF header when importing a VCF and written
-        to the VCF header when exporting a VCF:
-
-        - INFO fields attributes (attached to (`va.info.*`)):
-
-          - 'Number': The arity of the field. Can take values
-
-            - `0` (Boolean flag),
-            - `1` (single value),
-            - `R` (one value per allele, including the reference),
-            - `A` (one value per non-reference allele),
-            - `G` (one value per genotype), and
-            - `.` (any number of values)
-
-              - When importing: The value in read from the VCF INFO field definition
-              - When exporting: The default value is `0` for **Boolean**, `.` for **Arrays** and 1 for all other types
-
-            - 'Description' (default is '')
-
-        - FILTER entries in the VCF header are generated based on the attributes
-          of `va.filters`.  Each key/value pair in the attributes will generate
-          a FILTER entry in the VCF with ID = key and Description = value.
-
-        **Examples**
-
-        Consider the following command which adds a filter and an annotation to the VDS (we're assuming a split VDS for simplicity):
-
-        1) an INFO field `AC_HC`, which stores the allele count of high
-           confidence genotypes (DP >= 10, GQ >= 20) for each non-reference allele,
-
-        2) a filter `HardFilter` that filters all sites with the `GATK suggested hard filters <http://gatkforums.broadinstitute.org/gatk/discussion/2806/howto-apply-hard-filters-to-a-call-set>`__:
-
-           - For SNVs: QD < 2.0 || FS < 60 || MQ < 40 || MQRankSum < -12.5 || ReadPosRankSum < -8.0
-
-           - For Indels (and other complex): QD < 2.0 || FS < 200.0 || ReadPosRankSum < 20.0
-
-        >>> annotated_vds = vds.annotate_variants_expr([
-        ... 'va.info.AC_HC = gs.filter(g => g.dp >= 10 && g.gq >= 20).callStats(g => v).AC[1:]',
-        ... 'va.filters = if((v.altAllele.isSNP && (va.info.QD < 2.0 || va.info.FS < 60 || va.info.MQ < 40 || ' +
-        ... 'va.info.MQRankSum < -12.5 || va.info.ReadPosRankSum < -8.0)) || ' +
-        ... '(va.info.QD < 2.0 || va.info.FS < 200.0 || va.info.ReadPosRankSum < 20.0)) va.filters.add("HardFilter") else va.filters'])
-
-        If we now export this VDS as VCF, it would produce the following header (for these new fields):
-
-        .. code-block:: text
-
-            ##INFO=<ID=AC_HC,Number=.,Type=String,Description=""
-
-        This header doesn't contain all information that should be present in an optimal VCF header:
-        1) There is no FILTER entry for `HardFilter`
-        2) Since `AC_HC` has one entry per non-reference allele, its `Number` should be `A`
-        3) `AC_HC` should have a Description
-
-        We can fix this by setting the attributes of these fields:
-
-        >>> annotated_vds = (annotated_vds
-        ...     .set_va_attributes(
-        ...         'va.info.AC_HC',
-        ...         {'Description': 'Allele count for high quality genotypes (DP >= 10, GQ >= 20)',
-        ...          'Number': 'A'})
-        ...     .set_va_attributes(
-        ...         'va.filters',
-        ...         {'HardFilter': 'This site fails GATK suggested hard filters.'}))
-
-        Exporting the VDS with the attributes now prints the following header lines:
-
-        .. code-block:: text
-
-            ##INFO=<ID=test,Number=A,Type=String,Description="Allele count for high quality genotypes (DP >= 10, GQ >= 20)"
-            ##FILTER=<ID=HardFilter,Description="This site fails GATK suggested hard filters.">
-
-        :param str ann_path: Path to variant annotation beginning with `va`.
-
-        :param dict attributes: A str-str dict containing the attributes to set
-
-        :return: Annotated dataset with the attribute added to the variant annotation.
-        :rtype: :class:`.VariantDataset`
-
-        """
-
-        return VariantDataset(self.hc, self._jvds.setVaAttributes(ann_path, Env.jutils().javaMapToMap(attributes)))
-
-    @handle_py4j
-    @record_method
-    @typecheck_method(ann_path=strlike,
-                      attribute=strlike)
-    def delete_va_attribute(self, ann_path, attribute):
-        """Removes an attribute from a variant annotation field.
-        Attributes are key/value pairs that can be attached to a variant annotation field.
-
-        The following attributes are read from the VCF header when importing a VCF and written
-        to the VCF header when exporting a VCF:
-
-        - INFO fields attributes (attached to (`va.info.*`)):
-
-          - 'Number': The arity of the field. Can take values
-
-            - `0` (Boolean flag),
-            - `1` (single value),
-            - `R` (one value per allele, including the reference),
-            - `A` (one value per non-reference allele),
-            - `G` (one value per genotype), and
-            - `.` (any number of values)
-
-              - When importing: The value in read from the VCF INFO field definition
-              - When exporting: The default value is `0` for **Boolean**, `.` for **Arrays** and 1 for all other types
-
-            - 'Description' (default is '')
-
-        - FILTER entries in the VCF header are generated based on the attributes
-          of `va.filters`. Each key/value pair in the attributes will generate a
-          FILTER entry in the VCF with ID = key and Description = value.
-
-        :param str ann_path: Variant annotation path starting with 'va', period-delimited.
-
-        :param str attribute: The attribute to remove (key).
-
-        :return: Annotated dataset with the updated variant annotation without the attribute.
-        :rtype: :class:`.VariantDataset`
-
-        """
-
-        return VariantDataset(self.hc, self._jvds.deleteVaAttribute(ann_path, attribute))
 
     @handle_py4j
     @require_biallelic

--- a/python/hail/tests/tests.py
+++ b/python/hail/tests/tests.py
@@ -73,6 +73,8 @@ class ContextTests(unittest.TestCase):
         self.assertEqual(hc.eval_expr_typed('[1, 2, 3].map(x => x * 2)'), ([2, 4, 6], TArray(TInt32())))
         self.assertEqual(hc.eval_expr('[1, 2, 3].map(x => x * 2)'), [2, 4, 6])
 
+        vcf_metadata = hc.get_vcf_metadata(test_resources + '/sample.vcf.bgz')
+
         gds = hc.import_vcf(test_resources + '/sample.vcf.bgz', generic=True)
         # can't compare directly because attributes won't match
         self.assertEqual([f.name for f in gds.genotype_schema.fields],
@@ -84,9 +86,12 @@ class ContextTests(unittest.TestCase):
         gds_read = hc.read('/tmp/sample_generic.vds')
         self.assertTrue(gds.same(gds_read))
 
-        gds.export_vcf('/tmp/sample_generic.vcf')
+        gds.export_vcf('/tmp/sample_generic.vcf', metadata=vcf_metadata)
         gds_imported = hc.import_vcf('/tmp/sample_generic.vcf', generic=True)
         self.assertTrue(gds.same(gds_imported))
+
+        metadata_imported = hc.get_vcf_metadata('/tmp/sample_generic.vcf')
+        self.assertDictEqual(vcf_metadata, metadata_imported)
 
         matrix = hc.import_matrix(test_resources + '/samplematrix1.txt')
         self.assertEqual(matrix.count()[1], 10)

--- a/python/hail/typ.py
+++ b/python/hail/typ.py
@@ -38,7 +38,7 @@ class Type(HistoryMixin):
         return self._toString()
 
     def __str__(self):
-        return self._jtype.toPrettyString(0, True, False)
+        return self._jtype.toPrettyString(0, True)
 
     def __eq__(self, other):
         return self._jtype.equals(other._jtype)
@@ -46,17 +46,15 @@ class Type(HistoryMixin):
     def __hash__(self):
         return self._jtype.hashCode()
 
-    def pretty(self, indent=0, attrs=False):
+    def pretty(self, indent=0):
         """Returns a prettily formatted string representation of the type.
 
         :param int indent: Number of spaces to indent.
 
-        :param bool attrs: Print struct field attributes.
-
         :rtype: str
         """
 
-        return self._jtype.toPrettyString(indent, False, attrs)
+        return self._jtype.toPrettyString(indent, False)
 
     @classmethod
     def _from_java(cls, jtype):
@@ -512,22 +510,20 @@ class TDict(Type):
 
 class Field(object):
     """
-    Helper class for :class:`.TStruct`: contains attribute names and types.
+    Helper class for :class:`.TStruct`.
 
     :param str name: name of field
     :param typ: type of field
     :type typ: :class:`.Type`
-    :param dict attributes: key/value attributes of field
 
     :ivar str name: name of field
     :ivar typ: type of field
     :vartype typ: :class:`.Type`
     """
 
-    def __init__(self, name, typ, attributes={}):
+    def __init__(self, name, typ):
         self.name = name
         self.typ = typ
-        self.attributes = attributes
 
 
 class TStruct(Type):
@@ -572,8 +568,7 @@ class TStruct(Type):
 
         struct = TStruct.__new__(cls)
         struct.fields = fields
-        jfields = [scala_object(Env.hail().expr, 'Field').apply(
-            f.name, f.typ._jtype, i, Env.jutils().javaMapToMap(f.attributes)) for i,f in enumerate(fields)]
+        jfields = [scala_object(Env.hail().expr, 'Field').apply(f.name, f.typ._jtype, i) for i, f in enumerate(fields)]
         jtype = scala_object(Env.hail().expr, 'TStruct').apply(jindexed_seq(jfields), required)
         return TStruct._from_java(jtype)
 
@@ -589,7 +584,7 @@ class TStruct(Type):
     def _init_from_java(self, jtype):
 
         jfields = Env.jutils().iterableToArrayList(jtype.fields())
-        self.fields = [Field(f.name(), Type._from_java(f.typ()), dict(f.attrsJava())) for f in jfields]
+        self.fields = [Field(f.name(), Type._from_java(f.typ())) for f in jfields]
 
     def _convert_to_py(self, annotation):
         if annotation is not None:

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -442,6 +442,14 @@ class HailContext private(val sc: SparkContext,
   def readRows(path: String, t: TStruct, nPartitions: Int): RDD[RegionValue] =
     readPartitions(path, nPartitions, HailContext.readRowsPartition(t))
 
+  def parseVCFMetadata(files: Seq[String]): Map[String, Map[String, Map[String, String]]] =
+    parseVCFMetadata(files.head)
+
+  def parseVCFMetadata(file: String): Map[String, Map[String, Map[String, String]]] = {
+    val reader = new HtsjdkRecordReader(Set.empty)
+    LoadVCF.parseHeaderMetadata(this, reader, file)
+  }
+
   def importVCF(file: String, force: Boolean = false,
     forceBGZ: Boolean = false,
     headerFile: Option[String] = None,

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -1118,10 +1118,8 @@ object FunctionRegistry {
     "keys" -> "Keys of Dict.",
     "values" -> "Values of Dict.")(arrayHr(TTHr), arrayHr(TUHr), dictHr(TTHr, TUHr))
 
-  val combineVariantsStruct = TStruct(Array(("variant", TVariant(GR), "Resulting combined variant."),
-    ("laIndices", TDict(TInt32(), TInt32()), "Mapping from new to old allele index for the left variant."),
-    ("raIndices", TDict(TInt32(), TInt32()), "Mapping from new to old allele index for the right variant.")
-  ).zipWithIndex.map { case ((n, t, d), i) => Field(n, t, i, Map(("desc", d))) })
+  val combineVariantsStruct = TStruct("variant" -> TVariant(GR), "laIndices" -> TDict(TInt32(), TInt32()),
+    "raIndices" -> TDict(TInt32(), TInt32()))
 
   registerAnn("combineVariants",
     combineVariantsStruct, { (left: Variant, right: Variant) =>
@@ -1204,8 +1202,7 @@ object FunctionRegistry {
     "startLocus" -> "Start position of interval",
     "endLocus" -> "End position of interval")(locusHr(GR), locusHr(GR), locusIntervalHr(GR))
 
-  val hweStruct = TStruct(Array(("rExpectedHetFrequency", TFloat64(), "Expected rHeterozygosity based on Hardy Weinberg Equilibrium"),
-    ("pHWE", TFloat64(), "P-value")).zipWithIndex.map { case ((n, t, d), i) => Field(n, t, i, Map(("desc", d))) })
+  val hweStruct = TStruct("rExpectedHetFrequency" -> TFloat64(), "pHWE" -> TFloat64())
 
   registerAnn("hwe", hweStruct, { (nHomRef: Int, nHet: Int, nHomVar: Int) =>
     if (nHomRef < 0 || nHet < 0 || nHomVar < 0)
@@ -1259,7 +1256,7 @@ object FunctionRegistry {
   }
 
 
-  val chisqStruct = TStruct(Array(("pValue", TFloat64(), "p-value"), ("oddsRatio", TFloat64(), "odds ratio")).zipWithIndex.map { case ((n, t, d), i) => Field(n, t, i, Map(("desc", d))) })
+  val chisqStruct = TStruct("pValue" -> TFloat64(), "oddsRatio" -> TFloat64())
   registerAnn("chisq", chisqStruct, { (c1: Int, c2: Int, c3: Int, c4: Int) =>
     if (c1 < 0 || c2 < 0 || c3 < 0 || c4 < 0)
       fatal(s"got invalid argument to function `chisq': chisq($c1, $c2, $c3, $c4)")
@@ -1288,9 +1285,8 @@ object FunctionRegistry {
     "c1" -> "value for cell 1", "c2" -> "value for cell 2", "c3" -> "value for cell 3", "c4" -> "value for cell 4", "minCellCount" -> "Minimum cell count for using chi-squared approximation"
   )
 
-  val fetStruct = TStruct(Array(("pValue", TFloat64(), "p-value"), ("oddsRatio", TFloat64(), "odds ratio"),
-    ("ci95Lower", TFloat64(), "lower bound for 95% confidence interval"), ("ci95Upper", TFloat64(), "upper bound for 95% confidence interval")).zipWithIndex.map { case ((n, t, d), i) => Field(n, t, i, Map(("desc", d))) })
-
+  val fetStruct = TStruct("pValue" -> TFloat64(), "oddsRatio" -> TFloat64(),
+    "ci95Lower" -> TFloat64(), "ci95Upper" -> TFloat64())
 
   registerAnn("fet", fetStruct, { (c1: Int, c2: Int, c3: Int, c4: Int) =>
     if (c1 < 0 || c2 < 0 || c3 < 0 || c4 < 0)
@@ -2303,10 +2299,8 @@ object FunctionRegistry {
     The ``stats()`` aggregator can be used to replicate some of the values computed by :py:meth:`~hail.VariantDataset.variant_qc` and :py:meth:`~hail.VariantDataset.sample_qc` such as ``dpMean`` and ``dpStDev``.
     """)(aggregableHr(float64Hr),
     new HailRep[Any] {
-      def typ = TStruct(Array(
-        ("mean", TFloat64(), "Mean value"), ("stdev", TFloat64(), "Standard deviation"), ("min", TFloat64(), "Minimum value"),
-        ("max", TFloat64(), "Maximum value"), ("nNotMissing", TInt64(), "Number of non-missing values"), ("sum", TFloat64(), "Sum of all elements")
-      ).zipWithIndex.map { case ((n, t, d), i) => Field(n, t, i, Map(("desc", d))) })
+      def typ = TStruct("mean" -> TFloat64(), "stdev" -> TFloat64(), "min" -> TFloat64(),
+        "max" -> TFloat64(), "nNotMissing" -> TInt64(), "sum" -> TFloat64())
     })
 
   registerAggregator[Double, Double, Double, Int, Any]("hist", (start: Double, end: Double, bins: Int) => {

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -520,19 +520,11 @@ object Parser extends JavaTokenParsers {
   def named_exprs[T](name: Parser[T]): Parser[Seq[(Option[T], AST, Boolean)]] =
     repsep(named_expr(name), ",")
 
-  def decorator: Parser[(String, String)] =
-    ("@" ~> (identifier <~ "=")) ~ stringLiteral ^^ { case name ~ desc =>
-      //    ("@" ~> (identifier <~ "=")) ~ stringLiteral("\"" ~> "[^\"]".r <~ "\"") ^^ { case name ~ desc =>
-      (name, desc)
-    }
-
-  def type_field: Parser[(String, Type, Map[String, String])] =
-    (identifier <~ ":") ~ type_expr ~ rep(decorator) ^^ { case name ~ t ~ decorators =>
-      (name, t, decorators.toMap)
-    }
+  def type_field: Parser[(String, Type)] =
+    (identifier <~ ":") ~ type_expr ^^ { case name ~ t => (name, t) }
 
   def type_fields: Parser[Array[Field]] = repsep(type_field, ",") ^^ {
-    _.zipWithIndex.map { case ((id, t, attrs), index) => Field(id, t, index, attrs) }
+    _.zipWithIndex.map { case ((id, t), index) => Field(id, t, index) }
       .toArray
   }
 

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -1307,12 +1307,12 @@ object TGenotype {
   }
   
   def representationWithVCFAttributes(required: Boolean = false): TStruct = {
-    val t = TStruct(IndexedSeq(
-      Field("GT", TCall(), 0),
-      Field("AD", TArray(TInt32()), 1),
-      Field("DP", TInt32(), 2),
-      Field("GQ", TInt32(), 3),
-      Field("PL", TArray(TInt32()), 4)))
+    val t = TStruct(
+      "GT" -> TCall(),
+      "AD" -> TArray(TInt32()),
+      "DP" -> TInt32(),
+      "GQ" -> TInt32(),
+      "PL" -> TArray(TInt32()))
 
     t.setRequired(required).asInstanceOf[TStruct]
   }

--- a/src/main/scala/is/hail/io/package.scala
+++ b/src/main/scala/is/hail/io/package.scala
@@ -11,7 +11,7 @@ package object io {
       info.foreachBetween { case (name, t) =>
         sb.append(prettyIdentifier(name))
         sb.append(":")
-        t.pretty(sb, printAttrs = true, compact = true)
+        t.pretty(sb, compact = true)
       } { sb += ',' }
 
       out.write(sb.result())

--- a/src/main/scala/is/hail/io/package.scala
+++ b/src/main/scala/is/hail/io/package.scala
@@ -5,6 +5,10 @@ import is.hail.utils._
 import org.apache.hadoop.conf.Configuration
 
 package object io {
+  type VCFFieldAttributes = Map[String, String]
+  type VCFAttributes = Map[String, VCFFieldAttributes]
+  type VCFMetadata = Map[String, VCFAttributes]
+
   def exportTypes(filename: String, hConf: Configuration, info: Array[(String, Type)]) {
     val sb = new StringBuilder
     hConf.writeTextFile(filename) { out =>

--- a/src/main/scala/is/hail/io/vcf/LoadGDB.scala
+++ b/src/main/scala/is/hail/io/vcf/LoadGDB.scala
@@ -6,8 +6,7 @@ import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.expr.{TStruct, _}
 import is.hail.utils._
-import is.hail.variant.{GenomeReference, Locus, VSMLocalValue, VSMMetadata, Variant, VariantSampleMatrix}
-import org.apache.spark.storage.StorageLevel
+import is.hail.variant.{GenomeReference, VSMLocalValue, VSMMetadata, Variant, VariantSampleMatrix}
 import org.json4s._
 
 import scala.collection.JavaConversions._
@@ -53,7 +52,7 @@ object LoadGDB {
   }
 
   def formatHeaderSignature[T <: VCFCompoundHeaderLine](lines: java.util.Collection[T],
-    callFields: Set[String] = Set.empty[String], arrayElementsRequired: Boolean = true): (TStruct, Int) = {
+    callFields: Set[String] = Set.empty[String], arrayElementsRequired: Boolean = true): (TStruct, Int, Map[String, Map[String, String]]) = {
     val canonicalFields = Array(
       "GT" -> TCall(),
       "AD" -> TArray(TInt32(arrayElementsRequired)),
@@ -61,7 +60,7 @@ object LoadGDB {
       "GQ" -> TInt32(),
       "PL" -> TArray(TInt32(arrayElementsRequired)))
 
-    val raw = headerSignature(lines, callFields, arrayElementsRequired)
+    val (raw, attrs) = headerSignature(lines, callFields, arrayElementsRequired)
 
     var canonicalFlags = 0
     var i = 0
@@ -72,7 +71,7 @@ object LoadGDB {
         val f = raw.field(id)
         if (f.typ == t) {
           done += f.index
-          fb += Field(f.name, f.typ, i, f.attrs)
+          fb += Field(f.name, f.typ, i)
           canonicalFlags |= (1 << j)
           i += 1
         }
@@ -81,12 +80,12 @@ object LoadGDB {
 
     raw.fields.foreach { f =>
       if (!done.contains(f.index)) {
-        fb += Field(f.name, f.typ, i, f.attrs)
+        fb += Field(f.name, f.typ, i)
         i += 1
       }
     }
 
-    (TStruct(fb.result()), canonicalFlags)
+    (TStruct(fb.result()), canonicalFlags, attrs)
   }
 
   /* PATH PARAMETERS REQUIRE ABSOLUTE PATHS */
@@ -118,11 +117,11 @@ object LoadGDB {
       .asInstanceOf[VCFHeader]
 
     // FIXME apply descriptions when HTSJDK is fixed to expose filter descriptions
-    val immutableFilters: Map[String, String] = header
+    val immutableFilters: Map[String, Map[String, String]] = header
       .getFilterLines
       .toList
       //(ID, description)
-      .map(line => (line.getID, ""))
+      .map(line => (line.getID, Map("Description" -> "")))
       .toMap
 
     var filters = immutableFilters
@@ -134,15 +133,15 @@ object LoadGDB {
     }
 
     val infoHeader = header.getInfoHeaderLines
-    val infoSignature = LoadVCF.headerSignature(infoHeader)
+    val (infoSignature, infoAttrs) = LoadVCF.headerSignature(infoHeader)
 
     val formatHeader = header.getFormatHeaderLines
-    val (genotypeSignature, canonicalFlags) = formatHeaderSignature(formatHeader, reader.callFields)
+    val (genotypeSignature, canonicalFlags, formatAttrs) = formatHeaderSignature(formatHeader, reader.callFields)
 
     val variantAnnotationSignatures = TStruct(Array(
       Field("rsid", TString(), 0),
       Field("qual", TFloat64(), 1),
-      Field("filters", TSet(TString()), 2, filters),
+      Field("filters", TSet(TString()), 2),
       Field("info", infoSignature, 3)))
 
     val sampleIds: Array[String] =

--- a/src/main/scala/is/hail/io/vcf/LoadGDB.scala
+++ b/src/main/scala/is/hail/io/vcf/LoadGDB.scala
@@ -13,6 +13,7 @@ import scala.collection.JavaConversions._
 import scala.collection.JavaConverters.asScalaIteratorConverter
 import java.io.{File, FileWriter}
 
+import is.hail.io.VCFAttributes
 import is.hail.io.vcf.LoadVCF.headerSignature
 
 import scala.collection.mutable
@@ -52,7 +53,7 @@ object LoadGDB {
   }
 
   def formatHeaderSignature[T <: VCFCompoundHeaderLine](lines: java.util.Collection[T],
-    callFields: Set[String] = Set.empty[String], arrayElementsRequired: Boolean = true): (TStruct, Int, Map[String, Map[String, String]]) = {
+    callFields: Set[String] = Set.empty[String], arrayElementsRequired: Boolean = true): (TStruct, Int, VCFAttributes) = {
     val canonicalFields = Array(
       "GT" -> TCall(),
       "AD" -> TArray(TInt32(arrayElementsRequired)),
@@ -117,7 +118,7 @@ object LoadGDB {
       .asInstanceOf[VCFHeader]
 
     // FIXME apply descriptions when HTSJDK is fixed to expose filter descriptions
-    val immutableFilters: Map[String, Map[String, String]] = header
+    val immutableFilters: VCFAttributes = header
       .getFilterLines
       .toList
       //(ID, description)

--- a/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -17,7 +17,8 @@ import scala.language.implicitConversions
 import scala.collection.mutable
 import scala.io.Source
 
-case class VCFHeaderInfo(sampleIds: Array[String], infoSignature: TStruct, vaSignature: TStruct, genotypeSignature: TStruct)
+case class VCFHeaderInfo(sampleIds: Array[String], infoSignature: TStruct, vaSignature: TStruct, genotypeSignature: TStruct,
+  filtersAttrs: Map[String, Map[String, String]], infoAttrs: Map[String, Map[String, String]], formatAttrs: Map[String, Map[String, String]])
 
 object VCFLine {
   def invalidRef(ref: String): Boolean = {
@@ -591,7 +592,6 @@ class ParseLineContext(gType: TStruct, headerLines: BufferedLineIterator) {
 }
 
 object LoadVCF {
-
   def warnDuplicates(ids: Array[String]) {
     val duplicates = ids.counter().filter(_._2 > 1)
     if (duplicates.nonEmpty) {
@@ -659,7 +659,7 @@ object LoadVCF {
     case VCFHeaderLineType.String => "String"
   }
 
-  def headerField(line: VCFCompoundHeaderLine, i: Int, callFields: Set[String], arrayElementsRequired: Boolean = false): Field = {
+  def headerField(line: VCFCompoundHeaderLine, i: Int, callFields: Set[String], arrayElementsRequired: Boolean = false): (Field, (String, Map[String, String])) = {
     val id = line.getID
     val isCall = id == "GT" || callFields.contains(id)
 
@@ -680,44 +680,45 @@ object LoadVCF {
     if (line.isFixedCount &&
       (line.getCount == 1 ||
         (line.getType == VCFHeaderLineType.Flag && line.getCount == 0)))
-      Field(id, baseType, i, attrs)
+      (Field(id, baseType, i), (id, attrs))
     else
-      Field(id, TArray(baseType.setRequired(arrayElementsRequired)), i, attrs)
+      (Field(id, TArray(baseType.setRequired(arrayElementsRequired)), i), (id, attrs))
   }
 
   def headerSignature[T <: VCFCompoundHeaderLine](lines: java.util.Collection[T],
-    callFields: Set[String] = Set.empty[String], arrayElementsRequired: Boolean = false): TStruct = {
-    TStruct(lines
+    callFields: Set[String] = Set.empty[String], arrayElementsRequired: Boolean = false): (TStruct, Map[String, Map[String, String]]) = {
+    val (fields, attrs) = lines
       .zipWithIndex
       .map { case (line, i) => headerField(line, i, callFields, arrayElementsRequired) }
-      .toArray)
+      .unzip
+
+    (TStruct(fields.toArray), attrs.toMap)
   }
 
   def parseHeader(reader: HtsjdkRecordReader, lines: Array[String], arrayElementsRequired: Boolean = true): VCFHeaderInfo = {
-
     val codec = new htsjdk.variant.vcf.VCFCodec()
     val header = codec.readHeader(new BufferedLineIterator(lines.iterator.buffered))
       .getHeaderValue
       .asInstanceOf[htsjdk.variant.vcf.VCFHeader]
 
     // FIXME apply descriptions when HTSJDK is fixed to expose filter descriptions
-    val filters: Map[String, String] = header
+    val filterAttrs: Map[String, Map[String, String]] = header
       .getFilterLines
       .toList
       // (ID, description)
-      .map(line => (line.getID, ""))
+      .map(line => (line.getID, Map("Description" -> "")))
       .toMap
 
     val infoHeader = header.getInfoHeaderLines
-    val infoSignature = headerSignature(infoHeader)
+    val (infoSignature, infoAttrs) = headerSignature(infoHeader)
 
     val formatHeader = header.getFormatHeaderLines
-    val gSignature = headerSignature(formatHeader, reader.callFields, arrayElementsRequired = arrayElementsRequired)
+    val (gSignature, formatAttrs) = headerSignature(formatHeader, reader.callFields, arrayElementsRequired = arrayElementsRequired)
 
     val vaSignature = TStruct(Array(
       Field("rsid", TString(), 0),
       Field("qual", TFloat64(), 1),
-      Field("filters", TSet(TString()), 2, filters),
+      Field("filters", TSet(TString()), 2),
       Field("info", infoSignature, 3)))
 
     val headerLine = lines.last
@@ -728,7 +729,7 @@ object LoadVCF {
 
     val sampleIds: Array[String] = headerLine.split("\t").drop(9)
 
-    VCFHeaderInfo(sampleIds, infoSignature, vaSignature, gSignature)
+    VCFHeaderInfo(sampleIds, infoSignature, vaSignature, gSignature, filterAttrs, infoAttrs, formatAttrs)
   }
 
   def getHeaderLines[T](hConf: Configuration, file: String): Array[String] = hConf.readFile(file) { s =>
@@ -847,20 +848,20 @@ object LoadVCF {
         if (hd1.genotypeSignature != hd.genotypeSignature)
           fatal(
             s"""invalid genotype signature: expected signatures to be identical for all inputs.
-             |   ${ files(0) }: ${ hd1.genotypeSignature.toPrettyString(compact = true, printAttrs = true) }
-             |   $file: ${ hd.genotypeSignature.toPrettyString(compact = true, printAttrs = true) }""".stripMargin)
+             |   ${ files(0) }: ${ hd1.genotypeSignature.toPrettyString(compact = true) }
+             |   $file: ${ hd.genotypeSignature.toPrettyString(compact = true) }""".stripMargin)
 
         if (hd1.vaSignature != hd.vaSignature)
           fatal(
             s"""invalid variant annotation signature: expected signatures to be identical for all inputs.
-             |   ${ files(0) }: ${ hd1.vaSignature.toPrettyString(compact = true, printAttrs = true) }
-             |   $file: ${ hd.vaSignature.toPrettyString(compact = true, printAttrs = true) }""".stripMargin)
+             |   ${ files(0) }: ${ hd1.vaSignature.toPrettyString(compact = true) }
+             |   $file: ${ hd.vaSignature.toPrettyString(compact = true) }""".stripMargin)
       }
     } else {
       warn("Loading user-provided header file. The number of samples, sample IDs, variant annotation schema and genotype schema were not checked for agreement with input data.")
     }
 
-    val VCFHeaderInfo(sampleIdsHeader, infoSignature, vaSignature, genotypeSignature) = header1
+    val VCFHeaderInfo(sampleIdsHeader, infoSignature, vaSignature, genotypeSignature, _, _, _) = header1
 
     val sampleIds: Array[String] = if (dropSamples) Array.empty else sampleIdsHeader
     val localNSamples = sampleIds.length
@@ -931,5 +932,13 @@ object LoadVCF {
         sampleIds,
         Annotation.emptyIndexedSeq(sampleIds.length)),
       rdd)
+  }
+
+  def parseHeaderMetadata(hc: HailContext, reader: HtsjdkRecordReader, headerFile: String): Map[String, Map[String, Map[String, String]]] = {
+    val hConf = hc.hadoopConf
+    val headerLines = getHeaderLines(hConf, headerFile)
+    val VCFHeaderInfo(_, _, _, _, filtersAttrs, infoAttrs, formatAttrs) = parseHeader(reader, headerLines)
+
+    Map("filter" -> filtersAttrs, "info" -> infoAttrs, "format" -> formatAttrs)
   }
 }

--- a/src/main/scala/is/hail/keytable/KeyTable.scala
+++ b/src/main/scala/is/hail/keytable/KeyTable.scala
@@ -797,8 +797,8 @@ class KeyTable(val hc: HailContext,
 
     val metadata = KeyTableMetadata(KeyTable.fileVersion,
       key,
-      signature.toPrettyString(printAttrs = true, compact = true),
-      Some(globalSignature.toPrettyString(printAttrs = true, compact = true)),
+      signature.toPrettyString(compact = true),
+      Some(globalSignature.toPrettyString(compact = true)),
       Some(JSONAnnotationImpex.exportAnnotation(globals, globalSignature)),
       rdd2.partitions.length)
     hc.hadoopConf.writeTextFile(path + "/metadata.json.gz")(out =>

--- a/src/main/scala/is/hail/methods/LDMatrix.scala
+++ b/src/main/scala/is/hail/methods/LDMatrix.scala
@@ -109,7 +109,7 @@ case class LDMatrix(hc: HailContext, matrix: IndexedRowMatrix, variants: Array[V
 
     hadoop.writeTextFile(uri + metadataRelativePath) { os =>
       jackson.Serialization.write(
-        LDMatrixMetadata(variants, nSamples, vTyp.toPrettyString(compact = true, printAttrs = true)),
+        LDMatrixMetadata(variants, nSamples, vTyp.toPrettyString(compact = true)),
         os)
     }
   }

--- a/src/main/scala/is/hail/methods/VEP.scala
+++ b/src/main/scala/is/hail/methods/VEP.scala
@@ -401,8 +401,7 @@ object VEP {
       }
 
     (csq, newVASignature) match {
-      case (true, t: TStruct) => vsm.copyLegacy(rdd = newRDD,
-        vaSignature = t.setFieldAttributes(parsedRoot, Map("Description" -> csqHeader)))
+      case (true, t: TStruct) => vsm.copyLegacy(rdd = newRDD)
       case _ => vsm.copyLegacy(rdd = newRDD, vaSignature = newVASignature)
     }
   }

--- a/src/main/scala/is/hail/stats/CallStatsCombiner.scala
+++ b/src/main/scala/is/hail/stats/CallStatsCombiner.scala
@@ -6,11 +6,11 @@ import is.hail.utils._
 import is.hail.variant.{Genotype, Variant}
 
 object CallStats {
-  def schema = TStruct(Array(("AC", TArray(TInt32()), "Allele count. One element per allele **including reference**. There are two elements for a biallelic variant, or 4 for a variant with three alternate alleles."),
-    ("AF", TArray(TFloat64()), "Allele frequency. One element per allele including reference. Sums to 1."),
-    ("AN", TInt32(), "Allele number. This is equal to the sum of AC, or 2 * the total number of called genotypes in the aggregable."),
-    ("GC", TArray(TInt32()), "Genotype count. One element per possible genotype, including reference genotypes -- 3 for biallelic, 6 for triallelic, 10 for 3 alt alleles, and so on. The sum of this array is the number of called genotypes in the aggregable.")
-  ).zipWithIndex.map { case ((n, t, d), i) => Field(n, t, i, Map(("desc", d))) })
+  def schema = TStruct(
+    "AC" -> TArray(TInt32()),
+    "AF" -> TArray(TFloat64()),
+    "AN" -> TInt32(),
+    "GC" -> TArray(TInt32()))
 }
 
 case class CallStats(alleleCount: IndexedSeq[Int], alleleFrequency: Option[IndexedSeq[Double]], alleleNumber: Int,

--- a/src/main/scala/is/hail/stats/HWECombiner.scala
+++ b/src/main/scala/is/hail/stats/HWECombiner.scala
@@ -6,10 +6,7 @@ import is.hail.utils._
 import is.hail.variant.Genotype
 
 object HWECombiner {
-  def signature = TStruct(Array(
-    ("rExpectedHetFrequency", TFloat64(), "Expected rHeterozygosity based on Hardy Weinberg Equilibrium"),
-    ("pHWE", TFloat64(), "p-value")
-  ).zipWithIndex.map { case ((n, t, d), i) => Field(n, t, i, Map(("desc", d))) })
+  def signature = TStruct("rExpectedHetFrequency" -> TFloat64(), "pHWE" -> TFloat64())
 }
 
 class HWECombiner extends Serializable {

--- a/src/main/scala/is/hail/stats/HistogramCombiner.scala
+++ b/src/main/scala/is/hail/stats/HistogramCombiner.scala
@@ -6,12 +6,11 @@ import is.hail.annotations.Annotation
 import is.hail.expr._
 
 object HistogramCombiner {
-  def schema: Type = TStruct(Array(
-    ("binEdges", TArray(TFloat64()), "Array of bin cutoffs"),
-    ("binFrequencies", TArray(TInt64()), "Number of elements that fall in each bin."),
-    ("nLess", TInt64(), "Number of elements less than the minimum bin"),
-    ("nGreater", TInt64(), "Number of elements greater than the maximum bin")
-  ).zipWithIndex.map { case ((n, t, d), i) => Field(n, t, i, Map(("desc", d))) })
+  def schema: Type = TStruct(
+    "binEdges" -> TArray(TFloat64()),
+    "binFrequencies" -> TArray(TInt64()),
+    "nLess" -> TInt64(),
+    "nGreater" -> TInt64())
 }
 
 class HistogramCombiner(indices: Array[Double]) extends Serializable {

--- a/src/main/scala/is/hail/stats/InbreedingCombiner.scala
+++ b/src/main/scala/is/hail/stats/InbreedingCombiner.scala
@@ -7,12 +7,12 @@ import is.hail.utils._
 import is.hail.variant.Genotype
 
 object InbreedingCombiner {
-  def signature = TStruct(Array(("Fstat", TFloat64(), "Inbreeding coefficient"),
-    ("nTotal", TInt64(), "Number of genotypes analyzed"),
-    ("nCalled", TInt64(), "number of genotypes with non-missing calls"),
-    ("expectedHoms", TFloat64(), "Expected number of homozygote calls"),
-    ("observedHoms", TInt64(), "Total number of homozygote calls observed")
-  ).zipWithIndex.map { case ((n, t, d), i) => Field(n, t, i, Map(("desc", d))) })
+  def signature = TStruct(
+    "Fstat" -> TFloat64(),
+    "nTotal" -> TInt64(),
+    "nCalled" -> TInt64(),
+    "expectedHoms" -> TFloat64(),
+    "observedHoms" -> TInt64())
 }
 
 class InbreedingCombiner extends Serializable {

--- a/src/main/scala/is/hail/stats/InfoScoreCombiner.scala
+++ b/src/main/scala/is/hail/stats/InfoScoreCombiner.scala
@@ -6,10 +6,7 @@ import is.hail.utils._
 import is.hail.variant.Genotype
 
 object InfoScoreCombiner {
-  def signature = TStruct(Array(
-    ("score", TFloat64(), "IMPUTE info score"),
-    ("nIncluded", TInt32(), "Number of samples with non-missing genotype probability distribution")
-  ).zipWithIndex.map { case ((n, t, d), i) => Field(n, t, i, Map(("desc", d))) })
+  def signature = TStruct("score" -> TFloat64(), "nIncluded" -> TInt32())
 }
 
 class InfoScoreCombiner extends Serializable {

--- a/src/main/scala/is/hail/utils/FunctionDocumentation.scala
+++ b/src/main/scala/is/hail/utils/FunctionDocumentation.scala
@@ -156,39 +156,6 @@ case class DocumentationEntry(name: String, category: String, objType: Option[Ty
     sb.result()
   }
 
-  def emitField(sb: StringBuilder, fd: Field, prefix: Option[String]): Array[String] = {
-    val name = prefix match {
-      case Some(p) => s"$p.${ fd.name }"
-      case None => fd.name
-    }
-
-    val desc = fd.attr("desc") match {
-      case Some(d) => s"-- $d"
-      case None => ""
-    }
-
-    fd.typ match {
-      case f: TStruct =>
-        f.fields.flatMap(child => emitField(sb, child, Option(name))).toArray
-      case _ => Array(s" - **$name** (*${ fd.typ }*) $desc")
-    }
-  }
-
-  def emitAnnotation: String = {
-    val sb = new StringBuilder()
-    retType match {
-      case rt: TStruct =>
-        if (rt.fields.nonEmpty) {
-          val fields = rt.fields.flatMap(fd => emitField(sb, fd, None)).map(s => "\t" + s.replaceAll("\\?", "").replaceAll("!",""))
-          val output = (Array(".. container:: annotation\n") ++ fields).map(s => "\t" + s).mkString("\n")
-
-          sb.append(output)
-        }
-      case _ =>
-    }
-    sb.result()
-  }
-
   def emitHeaderSymbol = {
     require(nArgs == 2)
     val arg1 = args(0)
@@ -238,11 +205,6 @@ case class DocumentationEntry(name: String, category: String, objType: Option[Ty
       sb.append(emitHeader)
     else
       sb.append(emitHeaderSymbol)
-
-    if (hasAnnotation) {
-      sb.append("\n\n")
-      sb.append(emitAnnotation)
-    }
 
     if (nLinesDocstring == 0)
       sb.append("\n\n")

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer
 import is.hail.annotations._
 import is.hail.check.Gen
 import is.hail.expr._
+import is.hail.io.VCFAttributes
 import is.hail.io.vcf.ExportVCF
 import is.hail.keytable.KeyTable
 import is.hail.methods.Aggregators.SampleFunctions
@@ -2237,7 +2238,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     * @param parallel export VCF in parallel using the path argument as a directory
     * @param metadata metadata to export in header
     */
-  def exportVCF(path: String, append: Option[String] = None, parallel: Boolean = false, metadata: Option[Map[String, Any]] = None) {
+  def exportVCF(path: String, append: Option[String] = None, parallel: Boolean = false, metadata: Option[VCFAttributes] = None) {
     ExportVCF(this, path, append, parallel, metadata)
   }
 

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -205,16 +205,16 @@ object VariantSampleMatrix {
           s"""cannot combine datasets with different column key schemata
              |  Schema in datasets[0]: @1
              |  Schema in datasets[$i]: @2""".stripMargin,
-          colKeySchema.toPrettyString(compact = true, printAttrs = true),
-          ssig.toPrettyString(compact = true, printAttrs = true)
+          colKeySchema.toPrettyString(compact = true),
+          ssig.toPrettyString(compact = true)
         )
       } else if (vsig != rowKeySchema) {
         fatal(
           s"""cannot combine datasets with different row key schemata
              |  Schema in datasets[0]: @1
              |  Schema in datasets[$i]: @2""".stripMargin,
-          rowKeySchema.toPrettyString(compact = true, printAttrs = true),
-          vsig.toPrettyString(compact = true, printAttrs = true)
+          rowKeySchema.toPrettyString(compact = true),
+          vsig.toPrettyString(compact = true)
         )
       } else if (ids != sampleIds) {
         fatal(
@@ -231,16 +231,16 @@ object VariantSampleMatrix {
           s"""cannot combine datasets with different row annotation schemata
              |  Schema in datasets[0]: @1
              |  Schema in datasets[$i]: @2""".stripMargin,
-          vaSchema.toPrettyString(compact = true, printAttrs = true),
-          vas.toPrettyString(compact = true, printAttrs = true)
+          vaSchema.toPrettyString(compact = true),
+          vas.toPrettyString(compact = true)
         )
       } else if (gsig != genotypeSchema) {
         fatal(
           s"""cannot read datasets with different cell schemata
              |  Schema in datasets[0]: @1
              |  Schema in datasets[$i]: @2""".stripMargin,
-          genotypeSchema.toPrettyString(compact = true, printAttrs = true),
-          gsig.toPrettyString(compact = true, printAttrs = true)
+          genotypeSchema.toPrettyString(compact = true),
+          gsig.toPrettyString(compact = true)
         )
       }
     }
@@ -1282,8 +1282,8 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
         s"""cannot join datasets with different genotype schemata
            |  left genotype schema: @1
            |  right genotype schema: @2""".stripMargin,
-        genotypeSignature.toPrettyString(compact = true, printAttrs = true),
-        right.genotypeSignature.toPrettyString(compact = true, printAttrs = true))
+        genotypeSignature.toPrettyString(compact = true),
+        right.genotypeSignature.toPrettyString(compact = true))
     }
 
     if (saSignature != right.saSignature) {
@@ -1291,8 +1291,8 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
         s"""cannot join datasets with different sample schemata
            |  left sample schema: @1
            |  right sample schema: @2""".stripMargin,
-        saSignature.toPrettyString(compact = true, printAttrs = true),
-        right.saSignature.toPrettyString(compact = true, printAttrs = true))
+        saSignature.toPrettyString(compact = true),
+        right.saSignature.toPrettyString(compact = true))
     }
 
     if (vSignature != right.vSignature) {
@@ -1300,8 +1300,8 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
         s"""cannot join datasets with different variant schemata
            |  left variant schema: @1
            |  right variant schema: @2""".stripMargin,
-        vSignature.toPrettyString(compact = true, printAttrs = true),
-        right.vSignature.toPrettyString(compact = true, printAttrs = true))
+        vSignature.toPrettyString(compact = true),
+        right.vSignature.toPrettyString(compact = true))
     }
 
     val newSampleIds = sampleIds ++ right.sampleIds
@@ -1964,28 +1964,6 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
       .result(localNSamples)
   }
 
-  def setVaAttributes(path: String, kv: Map[String, String]): VariantSampleMatrix = {
-    setVaAttributes(Parser.parseAnnotationRoot(path, Annotation.VARIANT_HEAD), kv)
-  }
-
-  def setVaAttributes(path: List[String], kv: Map[String, String]): VariantSampleMatrix = {
-    vaSignature match {
-      case t: TStruct => copy2(vaSignature = t.setFieldAttributes(path, kv))
-      case t => fatal(s"Cannot set va attributes to ${ path.mkString(".") } since va is not a Struct.")
-    }
-  }
-
-  def deleteVaAttribute(path: String, attribute: String): VariantSampleMatrix = {
-    deleteVaAttribute(Parser.parseAnnotationRoot(path, Annotation.VARIANT_HEAD), attribute)
-  }
-
-  def deleteVaAttribute(path: List[String], attribute: String): VariantSampleMatrix = {
-    vaSignature match {
-      case t: TStruct => copy2(vaSignature = t.deleteFieldAttribute(path, attribute))
-      case t => fatal(s"Cannot delete va attributes from ${ path.mkString(".") } since va is not a Struct.")
-    }
-  }
-
   override def toString =
     s"VariantSampleMatrix(metadata=$metadata, rdd=$rdd, sampleIds=$sampleIds, nSamples=$nSamples, vaSignature=$vaSignature, saSignature=$saSignature, globalSignature=$globalSignature, sampleAnnotations=$sampleAnnotations, sampleIdsAndAnnotations=$sampleIdsAndAnnotations, globalAnnotation=$globalAnnotation, wasSplit=$wasSplit)"
 
@@ -2129,12 +2107,12 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     val metadata = VDSMetadata(
       version = VariantSampleMatrix.fileVersion,
       split = wasSplit,
-      sample_schema = sSignature.toPrettyString(printAttrs = true, compact = true),
-      sample_annotation_schema = saSignature.toPrettyString(printAttrs = true, compact = true),
-      variant_schema = vSignature.toPrettyString(printAttrs = true, compact = true),
-      variant_annotation_schema = vaSignature.toPrettyString(printAttrs = true, compact = true),
-      genotype_schema = genotypeSignature.toPrettyString(printAttrs = true, compact = true),
-      global_schema = globalSignature.toPrettyString(printAttrs = true, compact = true),
+      sample_schema = sSignature.toPrettyString(compact = true),
+      sample_annotation_schema = saSignature.toPrettyString(compact = true),
+      variant_schema = vSignature.toPrettyString(compact = true),
+      variant_annotation_schema = vaSignature.toPrettyString(compact = true),
+      genotype_schema = genotypeSignature.toPrettyString(compact = true),
+      global_schema = globalSignature.toPrettyString(compact = true),
       sample_annotations = sampleAnnotationsJ,
       global_annotation = globalJ,
       n_partitions = nPartitions)
@@ -2257,9 +2235,10 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     * @param path     output path
     * @param append   append file to header
     * @param parallel export VCF in parallel using the path argument as a directory
+    * @param metadata metadata to export in header
     */
-  def exportVCF(path: String, append: Option[String] = None, parallel: Boolean = false) {
-    ExportVCF(this, path, append, parallel)
+  def exportVCF(path: String, append: Option[String] = None, parallel: Boolean = false, metadata: Option[Map[String, Any]] = None) {
+    ExportVCF(this, path, append, parallel, metadata)
   }
 
   def minRep(leftAligned: Boolean = false): VariantSampleMatrix = {

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -5,7 +5,7 @@ import java.nio.ByteBuffer
 import is.hail.annotations._
 import is.hail.check.Gen
 import is.hail.expr._
-import is.hail.io.VCFAttributes
+import is.hail.io.VCFMetadata
 import is.hail.io.vcf.ExportVCF
 import is.hail.keytable.KeyTable
 import is.hail.methods.Aggregators.SampleFunctions
@@ -2238,7 +2238,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     * @param parallel export VCF in parallel using the path argument as a directory
     * @param metadata metadata to export in header
     */
-  def exportVCF(path: String, append: Option[String] = None, parallel: Boolean = false, metadata: Option[VCFAttributes] = None) {
+  def exportVCF(path: String, append: Option[String] = None, parallel: Boolean = false, metadata: Option[VCFMetadata] = None) {
     ExportVCF(this, path, append, parallel, metadata)
   }
 

--- a/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -990,16 +990,15 @@ class ExprSuite extends SparkSuite {
     val sb = new StringBuilder
     check(forAll { (t: Type) =>
       sb.clear()
-      t.pretty(sb, compact = true, printAttrs = true)
+      t.pretty(sb, compact = true)
       val res = sb.result()
       val parsed = Parser.parseType(res)
       t == parsed
     })
     check(forAll { (t: Type) =>
       sb.clear()
-      t.pretty(sb, printAttrs = true)
+      t.pretty(sb)
       val res = sb.result()
-      //      println(res)
       val parsed = Parser.parseType(res)
       t == parsed
     })


### PR DESCRIPTION
I'm getting this warning:

```
/Users/jigold/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala:199: non-variable type argument String in type pattern scala.collection.immutable.Map[String,Any] (the underlying of Map[String,Any]) is unchecked since it is eliminated by erasure
          case Some(x: Map[String, Any]) => getAttributes(path.tail, Some(x))
```

If you have suggestions on how to improve the `getAttributes` function, I'd appreciate it!