### PR TITLE
Add ScalaToRegionValue convenience functions

### DIFF
--- a/src/main/scala/is/hail/annotations/MemoryBlock.scala
+++ b/src/main/scala/is/hail/annotations/MemoryBlock.scala
@@ -228,6 +228,16 @@ final class MemoryBuffer(private var mem: Array[Byte], private var end: Long = 0
     off
   }
 
+  def appendBinary(bytes: Array[Byte]): Long = {
+    align(TBinary.contentAlignment)
+    val startOff = appendInt(bytes.length)
+    appendBytes(bytes)
+    startOff
+  }
+
+  def appendString(s: String): Long =
+    appendBinary(s.getBytes)
+
   def clear(newEnd: Long) {
     assert(newEnd <= end)
     end = newEnd

--- a/src/main/scala/is/hail/expr/package.scala
+++ b/src/main/scala/is/hail/expr/package.scala
@@ -7,6 +7,8 @@ package object expr extends HailRepFunctions {
   type SymbolTable = Map[String, (Int, Type)]
   def emptySymTab = Map.empty[String, (Int, Type)]
 
+  def hailType[T: HailRep]: Type = implicitly[HailRep[T]].typ
+
   type Aggregator = TypedAggregator[Any]
 
   abstract class TypedAggregator[+S] extends Serializable {

--- a/src/main/scala/is/hail/utils/richUtils/RichCodeMemoryBuffer.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichCodeMemoryBuffer.scala
@@ -157,8 +157,11 @@ class RichCodeMemoryBuffer(val region: Code[MemoryBuffer]) extends AnyVal {
     region.invoke[Array[Byte],Long, Int, Long]("appendBytes", bytes, bytesOff, n)
   }
 
+  def appendString(string: Code[String]): Code[Long] = {
+    region.invoke[String, Long]("appendString", string)
+  }
+
   def clear(): Code[Unit] = {
     region.invoke[Unit]("clear")
   }
-
 }

--- a/src/test/scala/is/hail/annotations/ScalaToRegionValue.scala
+++ b/src/test/scala/is/hail/annotations/ScalaToRegionValue.scala
@@ -1,0 +1,96 @@
+package is.hail.annotations
+
+import is.hail.expr._
+
+object ScalaToRegionValue {
+
+  def addStruct[T: HailRep](region: MemoryBuffer,
+    n1: String, v1: T): Long = {
+    val rvb = new RegionValueBuilder(region)
+    rvb.start(TStruct(
+      n1 -> hailType[T]))
+    rvb.startStruct()
+    rvb.addAnnotation(hailType[T], v1)
+    rvb.endStruct()
+    rvb.end()
+  }
+
+  def addStruct(region: MemoryBuffer,
+    n1: String, t1: Type, offset1: Long): Long = {
+    val rvb = new RegionValueBuilder(region)
+    rvb.start(TStruct(n1 -> t1))
+    rvb.startStruct()
+    rvb.addRegionValue(t1, region, offset1)
+    rvb.endStruct()
+    rvb.end()
+  }
+
+  def addStruct[T: HailRep](region: MemoryBuffer,
+    n1: String, v1: T,
+    n2: String, t2: Type, offset2: Long): Long = {
+    val rvb = new RegionValueBuilder(region)
+    rvb.start(TStruct(n1 -> hailType[T], n2 -> t2))
+    rvb.startStruct()
+    rvb.addAnnotation(hailType[T], v1)
+    rvb.addRegionValue(t2, region, offset2)
+    rvb.endStruct()
+    rvb.end()
+  }
+
+  def addStruct[T: HailRep, U: HailRep](region: MemoryBuffer,
+    n1: String, v1: T,
+    n2: String, v2: U): Long = {
+
+    val rvb = new RegionValueBuilder(region)
+    rvb.start(TStruct(
+      n1 -> hailType[T],
+      n2 -> hailType[U]))
+    rvb.startStruct()
+    rvb.addAnnotation(hailType[T], v1)
+    rvb.addAnnotation(hailType[U], v2)
+    rvb.endStruct()
+    rvb.end()
+  }
+
+  def addStruct[T: HailRep, U: HailRep, V: HailRep](region: MemoryBuffer,
+    n1: String, v1: T,
+    n2: String, v2: U,
+    n3: String, v3: V): Long = {
+
+    val rvb = new RegionValueBuilder(region)
+    rvb.start(TStruct(
+      n1 -> hailType[T],
+      n2 -> hailType[U],
+      n3 -> hailType[V]))
+    rvb.startStruct()
+    rvb.addAnnotation(hailType[T], v1)
+    rvb.addAnnotation(hailType[U], v2)
+    rvb.addAnnotation(hailType[U], v3)
+    rvb.endStruct()
+    rvb.end()
+  }
+
+  def addArray[T: HailRep](region: MemoryBuffer, a: T*): Long = {
+    val rvb = new RegionValueBuilder(region)
+    rvb.start(TArray(hailType[T]))
+    rvb.startArray(a.length)
+    a.foreach(rvb.addAnnotation(hailType[T], _))
+    rvb.endArray()
+    rvb.end()
+  }
+
+  def addBoxedArray[T: HailRep](region: MemoryBuffer, a: T*): Long = {
+    val rvb = new RegionValueBuilder(region)
+    rvb.start(TArray(hailType[T]))
+    rvb.startArray(a.length)
+    a.foreach { e =>
+      if (e == null)
+        rvb.setMissing()
+      else
+        rvb.addAnnotation(hailType[T], e)
+    }
+    rvb.endArray()
+    rvb.end()
+  }
+
+}

--- a/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
+++ b/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
@@ -1,8 +1,9 @@
 package is.hail.annotations
 
 import is.hail.SparkSuite
-import is.hail.asm4s.{Code, _}
-import is.hail.asm4s.Code._
+import is.hail.annotations._
+import ScalaToRegionValue._
+import is.hail.asm4s._
 import is.hail.expr._
 import is.hail.utils._
 import org.testng.annotations.Test
@@ -37,11 +38,7 @@ class StagedRegionValueSuite extends SparkSuite {
 
     val region2 = MemoryBuffer()
     val rv2 = RegionValue(region2)
-    val rvb = new RegionValueBuilder(region2)
-
-    rvb.start(rt)
-    rvb.addString(input)
-    rv.setOffset(rvb.end())
+    rv2.setOffset(region2.appendString(input))
 
     if (showRVInfo) {
       printRegion(region2, "string")
@@ -78,11 +75,7 @@ class StagedRegionValueSuite extends SparkSuite {
 
     val region2 = MemoryBuffer()
     val rv2 = RegionValue(region2)
-    val rvb = new RegionValueBuilder(region2)
-
-    rvb.start(rt)
-    rvb.addInt(input)
-    rv.setOffset(rvb.end())
+    rv2.setOffset(region2.appendInt(input))
 
     if (showRVInfo) {
       printRegion(region2, "int")
@@ -120,13 +113,7 @@ class StagedRegionValueSuite extends SparkSuite {
 
     val region2 = MemoryBuffer()
     val rv2 = RegionValue(region2)
-    val rvb = new RegionValueBuilder(region2)
-
-    rvb.start(rt)
-    rvb.startArray(1)
-    rvb.addInt(input)
-    rvb.endArray()
-    rv.setOffset(rvb.end())
+    rv2.setOffset(addArray(region2, input))
 
     if (showRVInfo) {
       printRegion(region2, "array")
@@ -167,14 +154,7 @@ class StagedRegionValueSuite extends SparkSuite {
 
     val region2 = MemoryBuffer()
     val rv2 = RegionValue(region2)
-    val rvb = new RegionValueBuilder(region2)
-
-    rvb.start(rt)
-    rvb.startStruct()
-    rvb.addString("hello")
-    rvb.addInt(input)
-    rvb.endStruct()
-    rv.setOffset(rvb.end())
+    rv2.setOffset(addStruct(region2, "a", "hello", "b", input))
 
     if (showRVInfo) {
       printRegion(region2, "struct")
@@ -227,7 +207,6 @@ class StagedRegionValueSuite extends SparkSuite {
     val region2 = MemoryBuffer()
     val rv2 = RegionValue(region2)
     val rvb = new RegionValueBuilder(region2)
-
     rvb.start(rt)
     rvb.startArray(2)
     for (i <- 1 to 2) {
@@ -343,14 +322,7 @@ class StagedRegionValueSuite extends SparkSuite {
 
     val region2 = MemoryBuffer()
     val rv2 = RegionValue(region2)
-    val rvb = new RegionValueBuilder(region2)
-
-    rvb.start(rt)
-    rvb.startArray(2)
-    rvb.addInt(input)
-    rvb.setMissing()
-    rvb.endArray()
-    rv.setOffset(rvb.end())
+    rv2.setOffset(addArray[java.lang.Integer](region2, input, null))
 
     if (showRVInfo) {
       printRegion(region2, "missing array")

--- a/src/test/scala/is/hail/expr/ir/CompileSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/CompileSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.methods.ir
 
 import is.hail.annotations._
+import ScalaToRegionValue._
 import is.hail.asm4s._
 import is.hail.check.{Gen, Parameters, Prop}
 import is.hail.expr.{TArray, TFloat64, TInt32}
@@ -10,30 +11,6 @@ import org.scalatest._
 import Matchers._
 
 class CompileSuite {
-
-  private def addArray(mb: MemoryBuffer, a: Array[Double]): Long = {
-    val rvb = new RegionValueBuilder(mb)
-    rvb.start(TArray(TFloat64()))
-    rvb.startArray(a.length)
-    a.foreach(rvb.addDouble(_))
-    rvb.endArray()
-    rvb.end()
-  }
-
-  private def addBoxedArray(mb: MemoryBuffer, a: Array[java.lang.Double]): Long = {
-    val rvb = new RegionValueBuilder(mb)
-    rvb.start(TArray(TFloat64()))
-    rvb.startArray(a.length)
-    a.foreach { e =>
-      if (e == null)
-        rvb.setMissing()
-      else
-        rvb.addDouble(e)
-    }
-    rvb.endArray()
-    rvb.end()
-  }
-
   def doit(ir: IR, fb: FunctionBuilder[_]) {
     Infer(ir)
     println(ir)
@@ -54,7 +31,7 @@ class CompileSuite {
     val f = fb.result()()
     def run(a: Array[Double]): Double = {
       val mb = MemoryBuffer()
-      val aoff = addArray(mb, a)
+      val aoff = addArray(mb, a:_*)
       f(mb, aoff, false)
     }
 
@@ -91,7 +68,7 @@ class CompileSuite {
 
     def run(a: Array[java.lang.Double]): Int = {
       val mb = MemoryBuffer()
-      val aoff = addBoxedArray(mb, a)
+      val aoff = addBoxedArray(mb, a:_*)
       val t = TArray(TFloat64())
       f(mb, aoff, false)
     }
@@ -114,7 +91,7 @@ class CompileSuite {
 
     def run(a: Array[java.lang.Double]): Double = {
       val mb = MemoryBuffer()
-      val aoff = addBoxedArray(mb, a)
+      val aoff = addBoxedArray(mb, a:_*)
       val t = TArray(TFloat64())
       f(mb, aoff, false)
     }
@@ -139,7 +116,7 @@ class CompileSuite {
 
     def run(a: Array[java.lang.Double]): Double = {
       val mb = MemoryBuffer()
-      val aoff = addBoxedArray(mb, a)
+      val aoff = addBoxedArray(mb, a:_*)
       val t = TArray(TFloat64())
       f(mb, aoff, false)
     }
@@ -162,7 +139,7 @@ class CompileSuite {
 
     def run(a: Array[java.lang.Double]): Double = {
       val mb = MemoryBuffer()
-      val aoff = addBoxedArray(mb, a)
+      val aoff = addBoxedArray(mb, a:_*)
       val t = TArray(TFloat64())
       f(mb, aoff, false)
     }
@@ -191,7 +168,7 @@ class CompileSuite {
 
     def run(a: Array[java.lang.Double]): Double = {
       val mb = MemoryBuffer()
-      val aoff = addBoxedArray(mb, a)
+      val aoff = addBoxedArray(mb, a:_*)
       val t = TArray(TFloat64())
       f(mb, aoff, false)
     }
@@ -232,7 +209,7 @@ class CompileSuite {
     val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
     def run(a: Array[java.lang.Double]): Array[java.lang.Double] = {
       val mb = MemoryBuffer()
-      val aoff = addBoxedArray(mb, a)
+      val aoff = addBoxedArray(mb, a:_*)
       val t = TArray(TFloat64())
       val roff = f(mb, aoff, false)
       println(s"array location $roff")
@@ -270,7 +247,7 @@ class CompileSuite {
     val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
     def run(a: Array[java.lang.Double]): Array[java.lang.Double] = {
       val mb = MemoryBuffer()
-      val aoff = addBoxedArray(mb, a)
+      val aoff = addBoxedArray(mb, a:_*)
       val t = TArray(TFloat64())
       val roff = f(mb, aoff, false)
       Array.tabulate[java.lang.Double](a.length) { i =>
@@ -300,7 +277,7 @@ class CompileSuite {
     val f = fb.result()()
     def run(a: Array[java.lang.Double], i: Int): Double = {
       val mb = MemoryBuffer()
-      val aoff = if (a != null) addBoxedArray(mb, a) else -1L
+      val aoff = if (a != null) addBoxedArray(mb, a:_*) else -1L
       f(mb, aoff, a == null, i, false)
     }
 


### PR DESCRIPTION
I think I also fixed a couple bugs in the tests where we set `rv`
instead of `rv2`.