### PR TITLE
addPrimitive becomes addIRIntermediate

### DIFF
--- a/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -129,13 +129,16 @@ class StagedRegionValueBuilder private(val fb: FunctionBuilder[_], val typ: Type
 
   def addStruct(t: TStruct, f: (StagedRegionValueBuilder => Code[Unit]), init: LocalRef[Boolean] = null): Code[Unit] = f(new StagedRegionValueBuilder(fb, t, this))
 
-  def addPrimitive(t: Type): (Code[_]) => Code[Unit] = t.fundamentalType match {
+  def addIRIntermediate(t: Type): (Code[_]) => Code[Unit] = t.fundamentalType match {
     case _: TBoolean => v => addBoolean(v.asInstanceOf[Code[Boolean]])
     case _: TInt32 => v => addInt32(v.asInstanceOf[Code[Int]])
     case _: TInt64 => v => addInt64(v.asInstanceOf[Code[Long]])
     case _: TFloat32 => v => addFloat32(v.asInstanceOf[Code[Float]])
     case _: TFloat64 => v => addFloat64(v.asInstanceOf[Code[Double]])
-    case t => throw new UnsupportedOperationException("addPrimitive only supports primitive types: " + t)
+    case _: TStruct => v => region.copyFrom(region, v.asInstanceOf[Code[Long]], currentOffset, t.byteSize)
+    case _: TArray => v => region.storeAddress(v.asInstanceOf[Code[Long]], currentOffset)
+    case _: TBinary => v => region.storeAddress(v.asInstanceOf[Code[Long]], currentOffset)
+    case ft => throw new UnsupportedOperationException("Unknown fundamental type: " + ft)
   }
 
   def advance(): Code[Unit] = {

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -154,7 +154,7 @@ object Compile {
 
       case MakeArray(args, typ) =>
         val srvb = new StagedRegionValueBuilder(fb, typ)
-        val addElement = srvb.addPrimitive(typ.elementType)
+        val addElement = srvb.addIRIntermediate(typ.elementType)
         val mvargs = args.map(compile(_))
         present(Code(
           srvb.start(args.length, init = true),
@@ -206,7 +206,7 @@ object Compile {
         val tin = a.typ.asInstanceOf[TArray]
         val tout = x.typ.asInstanceOf[TArray]
         val srvb = new StagedRegionValueBuilder(fb, tout)
-        val addElement = srvb.addPrimitive(tout.elementType)
+        val addElement = srvb.addIRIntermediate(tout.elementType)
         val eti = typeToTypeInfo(elementTyp).asInstanceOf[TypeInfo[Any]]
         val xa = fb.newLocal[Long]("am_a")
         val xmv = mb.newBit()
@@ -292,7 +292,7 @@ object Compile {
           Code(initializers.map { case (t, (dov, mv, vv)) =>
             Code(
               dov,
-              mv.mux(srvb.setMissing(), srvb.addPrimitive(t)(vv)),
+              mv.mux(srvb.setMissing(), srvb.addIRIntermediate(t)(vv)),
               srvb.advance()) }: _*),
           srvb.offset))
       case GetField(o, name, _) =>

--- a/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
+++ b/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
@@ -362,11 +362,11 @@ class StagedRegionValueSuite extends SparkSuite {
     fb.emit(
       Code(
         srvb.start(),
-        srvb.addPrimitive(TInt32())(fb.getArg[Int](2)),
+        srvb.addIRIntermediate(TInt32())(fb.getArg[Int](2)),
         srvb.advance(),
-        srvb.addPrimitive(TBoolean())(fb.getArg[Boolean](3)),
+        srvb.addIRIntermediate(TBoolean())(fb.getArg[Boolean](3)),
         srvb.advance(),
-        srvb.addPrimitive(TFloat64())(fb.getArg[Double](4)),
+        srvb.addIRIntermediate(TFloat64())(fb.getArg[Double](4)),
         srvb.advance(),
         srvb.returnStart()
       )


### PR DESCRIPTION
An IR Intermediate is:

 - a value of a primitive type capable of being stored in a JVM stack
   slot (or two, as the case may be), or

 - a pointer to a value of a non-primitive type (e.g. Array, Struct)

Pointers are of type `Long` and are implicitly in the working region of
the this IR fragment.