### PR TITLE
Reorganize & Code-ify UnsafeOrdering

### DIFF
--- a/src/main/scala/is/hail/annotations/InplaceSort.scala
+++ b/src/main/scala/is/hail/annotations/InplaceSort.scala
@@ -1,0 +1,37 @@
+package is.hail.annotations
+
+import is.hail.utils._
+import is.hail.expr.ir.TypeToTypeInfo
+import is.hail.expr._
+import is.hail.asm4s._
+
+object InplaceSort {
+  def insertionSort(region: Code[MemoryBuffer], fb: FunctionBuilder[_], mb: StagedBitSet, aOff: Code[Long], t: TArray): Code[Unit] = {
+    val iVal = fb.newLocal()(TypeToTypeInfo(t.elementType)).asInstanceOf[LocalRef[Any]]
+    val i = fb.newLocal[Int]
+    val j = fb.newLocal[Int]
+    val x = fb.newLocal[Long]
+    val y = fb.newLocal[Long]
+    val ord = t.elementType.unsafeOrdering(true)
+    Code(
+      i := 1,
+      Code.whileLoop(i < TContainer.loadLength(region, aOff),
+        x := t.loadElement(region, aOff, i),
+        iVal := region.loadIRIntermediate(t.elementType)(x),
+        j := i - 1,
+        y := t.loadElement(region, aOff, j),
+        Code.whileLoop(j > 0 && (ord.compare(region, x, region, y)(fb, mb) < 0),
+          region.copyFrom(region, y, t.loadElement(region, aOff, j + 1), t.elementType.byteSize),
+          y := t.loadElement(region, aOff, j),
+          j := j - 1
+        ),
+        region.storeIRIntermediate(t.elementType)(t.loadElement(region, aOff, j + 1), iVal),
+        i := i + 1
+      )
+    )
+  }
+
+  def apply(region: Code[MemoryBuffer], fb: FunctionBuilder[_], mb: StagedBitSet, aOff: Code[Long], t: TArray): Code[Unit] = {
+    insertionSort(region, fb, mb, aOff, t)
+  }
+}

--- a/src/main/scala/is/hail/annotations/MemoryBlock.scala
+++ b/src/main/scala/is/hail/annotations/MemoryBlock.scala
@@ -209,6 +209,9 @@ final class MemoryBuffer(private var mem: Array[Byte], private var end: Long = 0
     off
   }
 
+  def appendAddress(l: Long): Long =
+    appendLong(l)
+
   def appendByte(b: Byte): Long = {
     val off = allocate(1)
     storeByte(off, b)

--- a/src/main/scala/is/hail/annotations/UnsafeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/UnsafeOrdering.scala
@@ -1,6 +1,9 @@
 package is.hail.annotations
 
-abstract class UnsafeOrdering extends Ordering[RegionValue] with Serializable {
+import is.hail.utils._
+import is.hail.asm4s._
+
+trait UnsafeOrdering extends Ordering[RegionValue] with Serializable {
   def compare(r1: MemoryBuffer, o1: Long, r2: MemoryBuffer, o2: Long): Int
 
   def compare(rv1: RegionValue, rv2: RegionValue): Int =
@@ -11,4 +14,9 @@ abstract class UnsafeOrdering extends Ordering[RegionValue] with Serializable {
 
   def compare(r1: MemoryBuffer, o1: Long, rv2: RegionValue): Int =
     compare(r1, o1, rv2.region, rv2.offset)
+}
+
+
+trait CodifiedUnsafeOrdering extends UnsafeOrdering {
+  def compare(r1: Code[MemoryBuffer], o1: Code[Long], r2: Code[MemoryBuffer], o2: Code[Long]): BindingCode[Int]
 }

--- a/src/main/scala/is/hail/annotations/ordering/BinaryUnsafeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/ordering/BinaryUnsafeOrdering.scala
@@ -1,0 +1,15 @@
+package is.hail.annotations.ordering
+
+import is.hail.asm4s._
+import is.hail.annotations._
+import is.hail.expr._
+
+object BinaryUnsafeOrdering extends CodifiedUnsafeOrdering {
+  def compare(r1: MemoryBuffer, o1: Long, r2: MemoryBuffer, o2: Long): Int =
+    StaticBinaryUnsafeOrdering.compare(r1, o1, r2, o2)
+
+  def compare(r1: Code[MemoryBuffer], o1: Code[Long], r2: Code[MemoryBuffer], o2: Code[Long])
+      : BindingCode[Int] = { (fb, mb) =>
+    Code.invokeStatic[StaticBinaryUnsafeOrdering, MemoryBuffer, Long, MemoryBuffer, Long, Int]("compare", r1, o1, r2, o2)
+  }
+}

--- a/src/main/scala/is/hail/annotations/ordering/BooleanUnsafeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/ordering/BooleanUnsafeOrdering.scala
@@ -1,0 +1,16 @@
+package is.hail.annotations.ordering
+
+import is.hail.asm4s._
+import is.hail.annotations._
+import is.hail.expr._
+import is.hail.utils._
+
+object BooleanUnsafeOrdering extends CodifiedUnsafeOrdering {
+  def compare(r1: MemoryBuffer, o1: Long, r2: MemoryBuffer, o2: Long): Int =
+    java.lang.Boolean.compare(r1.loadBoolean(o1), r2.loadBoolean(o2))
+
+  def compare(r1: Code[MemoryBuffer], o1: Code[Long], r2: Code[MemoryBuffer], o2: Code[Long])
+      : BindingCode[Int] = { (fb, mb) =>
+    Code.invokeStatic[java.lang.Boolean, Boolean, Boolean, Int]("compare", r1.loadBoolean(o1), r2.loadBoolean(o2))
+  }
+}

--- a/src/main/scala/is/hail/annotations/ordering/ContainerUnsafeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/ordering/ContainerUnsafeOrdering.scala
@@ -1,0 +1,71 @@
+package is.hail.annotations.ordering
+
+import is.hail.asm4s._
+import is.hail.annotations._
+import is.hail.expr._
+import is.hail.utils._
+
+class ContainerUnsafeOrdering(t: TContainer, eltOrd: CodifiedUnsafeOrdering, missingIsGreatest: Boolean) extends CodifiedUnsafeOrdering {
+  override def compare(r1: MemoryBuffer, o1: Long, r2: MemoryBuffer, o2: Long): Int = {
+    val length1 = t.loadLength(r1, o1)
+    val length2 = t.loadLength(r2, o2)
+
+    var i = 0
+    while (i < math.min(length1, length2)) {
+      val leftDefined = t.isElementDefined(r1, o1, i)
+      val rightDefined = t.isElementDefined(r2, o2, i)
+
+      if (leftDefined && rightDefined) {
+        val eOff1 = t.loadElement(r1, o1, length1, i)
+        val eOff2 = t.loadElement(r2, o2, length2, i)
+        val c = eltOrd.compare(r1, eOff1, r2, eOff2)
+        if (c != 0)
+          return c
+      } else if (leftDefined != rightDefined) {
+        val c = if (leftDefined) -1 else 1
+        if (missingIsGreatest)
+          return c
+        else
+          return -c
+      }
+      i += 1
+    }
+    Integer.compare(length1, length2)
+  }
+
+  def compare(r1: Code[MemoryBuffer], o1: Code[Long], r2: Code[MemoryBuffer], o2: Code[Long])
+      : BindingCode[Int] = { (fb, mb) =>
+    val length1 = fb.newLocal[Int]
+    val length2 = fb.newLocal[Int]
+    val i = fb.newLocal[Int]
+    val min = fb.newLocal[Int]
+    val leftDefined = mb.newBit
+    val rightDefined = mb.newBit
+    val temp = fb.newLocal[Int]
+    val out = fb.newLocal[Int]
+
+    Code(
+      length1 := t.loadLength(r1, o1),
+      length2 := t.loadLength(r2, o2),
+      i := 0,
+      min := Code.invokeStatic[java.lang.Math, Int, Int, Int]("min", length1, length2),
+      out := 0,
+      Code.whileLoop(i < min,
+        leftDefined := t.isElementDefined(r1, o1, i),
+        rightDefined := t.isElementDefined(r2, o2, i),
+        (leftDefined & rightDefined & out.cne(0)).mux(
+          Code(
+            temp := eltOrd.compare(
+              r1, t.loadElement(r1, o1, length1, i),
+              r2, t.loadElement(r2, o2, length2, i))(fb, mb),
+            temp.cne(0).mux(Code._empty, out := temp)),
+          (leftDefined ^ rightDefined).mux(
+            out :=
+              (if (missingIsGreatest) leftDefined.mux(-1, 1)
+              else leftDefined.mux(1, -1)),
+            Code._empty)),
+        i += 1
+      ),
+      out.cne(0).mux(out, Code.invokeStatic[Integer, Int, Int, Int]("compare", length1, length2)))
+  }
+}

--- a/src/main/scala/is/hail/annotations/ordering/DoubleUnsafeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/ordering/DoubleUnsafeOrdering.scala
@@ -1,0 +1,16 @@
+package is.hail.annotations.ordering
+
+import is.hail.asm4s._
+import is.hail.annotations._
+import is.hail.expr._
+import is.hail.utils._
+
+object DoubleUnsafeOrdering extends CodifiedUnsafeOrdering {
+  def compare(r1: MemoryBuffer, o1: Long, r2: MemoryBuffer, o2: Long): Int =
+    java.lang.Double.compare(r1.loadDouble(o1), r2.loadDouble(o2))
+
+  def compare(r1: Code[MemoryBuffer], o1: Code[Long], r2: Code[MemoryBuffer], o2: Code[Long])
+      : BindingCode[Int] = { (fb, mb) =>
+    Code.invokeStatic[java.lang.Double, Double, Double, Int]("compare", r1.loadDouble(o1), r2.loadDouble(o2))
+  }
+}

--- a/src/main/scala/is/hail/annotations/ordering/FloatUnsafeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/ordering/FloatUnsafeOrdering.scala
@@ -1,0 +1,16 @@
+package is.hail.annotations.ordering
+
+import is.hail.asm4s._
+import is.hail.annotations._
+import is.hail.expr._
+import is.hail.utils._
+
+object FloatUnsafeOrdering extends CodifiedUnsafeOrdering {
+  def compare(r1: MemoryBuffer, o1: Long, r2: MemoryBuffer, o2: Long): Int =
+    java.lang.Float.compare(r1.loadFloat(o1), r2.loadFloat(o2))
+
+  def compare(r1: Code[MemoryBuffer], o1: Code[Long], r2: Code[MemoryBuffer], o2: Code[Long])
+      : BindingCode[Int] = { (fb, mb) =>
+    Code.invokeStatic[java.lang.Float, Float, Float, Int]("compare", r1.loadFloat(o1), r2.loadFloat(o2))
+  }
+}

--- a/src/main/scala/is/hail/annotations/ordering/IntegerUnsafeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/ordering/IntegerUnsafeOrdering.scala
@@ -1,0 +1,16 @@
+package is.hail.annotations.ordering
+
+import is.hail.asm4s._
+import is.hail.annotations._
+import is.hail.expr._
+import is.hail.utils._
+
+object IntegerUnsafeOrdering extends CodifiedUnsafeOrdering {
+  def compare(r1: MemoryBuffer, o1: Long, r2: MemoryBuffer, o2: Long): Int =
+    Integer.compare(r1.loadInt(o1), r2.loadInt(o2))
+
+  def compare(r1: Code[MemoryBuffer], o1: Code[Long], r2: Code[MemoryBuffer], o2: Code[Long])
+      : BindingCode[Int] = { (fb, mb) =>
+    Code.invokeStatic[Integer, Int, Int, Int]("compare", r1.loadInt(o1), r2.loadInt(o2))
+  }
+}

--- a/src/main/scala/is/hail/annotations/ordering/IntervalUnsafeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/ordering/IntervalUnsafeOrdering.scala
@@ -1,0 +1,41 @@
+package is.hail.annotations.ordering
+
+import is.hail.variant.Contig
+import is.hail.asm4s._
+import is.hail.annotations._
+import is.hail.expr._
+import is.hail.utils._
+
+class IntervalUnsafeOrdering(t: TInterval, missingIsGreatest: Boolean) extends CodifiedUnsafeOrdering {
+  private val representation = t.representation
+  private val locusOrd = TLocus(t.gr).unsafeOrdering(missingIsGreatest)
+
+  def compare(r1: MemoryBuffer, o1: Long, r2: MemoryBuffer, o2: Long): Int = {
+    val sOff1 = representation.loadField(r1, o1, 0)
+    val sOff2 = representation.loadField(r2, o2, 0)
+
+    val c1 = locusOrd.compare(r1, sOff1, r2, sOff2)
+    if (c1 != 0)
+      return c1
+
+    val eOff1 = representation.loadField(r1, o1, 1)
+    val eOff2 = representation.loadField(r2, o2, 1)
+
+    locusOrd.compare(r1, eOff1, r2, eOff2)
+  }
+
+  def compare(r1: Code[MemoryBuffer], o1: Code[Long], r2: Code[MemoryBuffer], o2: Code[Long])
+      : BindingCode[Int] = { (fb, mb) =>
+    val out = fb.newLocal[Int]
+
+    Code(
+      out := locusOrd.compare(
+        r1, representation.loadField(r1, o1, 0),
+        r2, representation.loadField(r2, o2, 0))(fb, mb),
+        out.cne(0).mux(
+          out,
+          locusOrd.compare(
+            r1, representation.loadField(r1, o1, 1),
+            r2, representation.loadField(r2, o2, 1))(fb, mb)))
+  }
+}

--- a/src/main/scala/is/hail/annotations/ordering/LocusUnsafeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/ordering/LocusUnsafeOrdering.scala
@@ -1,0 +1,42 @@
+package is.hail.annotations.ordering
+
+import is.hail.variant.Contig
+import is.hail.asm4s._
+import is.hail.annotations._
+import is.hail.expr._
+import is.hail.utils._
+
+class LocusUnsafeOrdering(t: TLocus, missingIsGreatest: Boolean) extends CodifiedUnsafeOrdering {
+  private val repr = t.representation.fundamentalType
+
+  def compare(r1: MemoryBuffer, o1: Long, r2: MemoryBuffer, o2: Long): Int = {
+    val cOff1 = repr.loadField(r1, o1, 0)
+    val cOff2 = repr.loadField(r2, o2, 0)
+
+    val contig1 = TString.loadString(r1, cOff1)
+    val contig2 = TString.loadString(r2, cOff2)
+
+    val c = Contig.compare(contig1, contig2)
+    if (c != 0)
+      return c
+
+    val posOff1 = repr.loadField(r1, o1, 1)
+    val posOff2 = repr.loadField(r2, o2, 1)
+    Integer.compare(r1.loadInt(posOff1), r2.loadInt(posOff2))
+  }
+
+  def compare(r1: Code[MemoryBuffer], o1: Code[Long], r2: Code[MemoryBuffer], o2: Code[Long])
+      : BindingCode[Int] = { (fb, mb) =>
+    val out = fb.newLocal[Int]
+
+    Code(
+      out := Code.invokeStatic[StaticContigUnsafeOrdering, String, String, Int]("compare",
+        TString.loadString(r1, repr.loadField(r1, o1, 0)),
+        TString.loadString(r2, repr.loadField(r2, o2, 0))),
+      out.cne(0).mux(
+        out,
+        Code.invokeStatic[Integer, Int, Int, Int]("compare",
+          r1.loadInt(repr.loadField(r1, o1, 1)),
+          r2.loadInt(repr.loadField(r2, o2, 1)))))
+  }
+}

--- a/src/main/scala/is/hail/annotations/ordering/LongUnsafeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/ordering/LongUnsafeOrdering.scala
@@ -1,0 +1,16 @@
+package is.hail.annotations.ordering
+
+import is.hail.asm4s._
+import is.hail.annotations._
+import is.hail.expr._
+import is.hail.utils._
+
+object LongUnsafeOrdering extends CodifiedUnsafeOrdering {
+  def compare(r1: MemoryBuffer, o1: Long, r2: MemoryBuffer, o2: Long): Int =
+    java.lang.Long.compare(r1.loadLong(o1), r2.loadLong(o2))
+
+  def compare(r1: Code[MemoryBuffer], o1: Code[Long], r2: Code[MemoryBuffer], o2: Code[Long])
+      : BindingCode[Int] = { (fb, mb) =>
+    Code.invokeStatic[java.lang.Long, Long, Long, Int]("compare", r1.loadLong(o1), r2.loadLong(o2))
+  }
+}

--- a/src/main/scala/is/hail/annotations/ordering/StaticBinaryUnsafeOrdering.java
+++ b/src/main/scala/is/hail/annotations/ordering/StaticBinaryUnsafeOrdering.java
@@ -1,0 +1,25 @@
+package is.hail.annotations.ordering;
+
+import is.hail.expr.*;
+import is.hail.annotations.*;
+
+public class StaticBinaryUnsafeOrdering {
+  public static int compare(MemoryBuffer r1, long o1, MemoryBuffer r2, long o2) {
+    int length1 = TBinary.loadLength(r1, o1);
+    int length2 = TBinary.loadLength(r2, o2);
+
+    long bOff1 = TBinary.bytesOffset(o1);
+    long bOff2 = TBinary.bytesOffset(o2);
+
+    int lim = java.lang.Math.min(length1, length2);
+
+    for (int i = 0; i < lim; ++i) {
+      byte b1 = r1.loadByte(bOff1 + i);
+      byte b2 = r2.loadByte(bOff2 + i);
+      if (b1 != b2)
+        return Byte.compare(b1, b2);
+    }
+
+    return Integer.compare(length1, length2);
+  }
+}

--- a/src/main/scala/is/hail/annotations/ordering/StaticContigUnsafeOrdering.java
+++ b/src/main/scala/is/hail/annotations/ordering/StaticContigUnsafeOrdering.java
@@ -1,0 +1,11 @@
+package is.hail.annotations.ordering;
+
+import is.hail.expr.*;
+import is.hail.annotations.*;
+import is.hail.variant.Contig;
+
+public class StaticContigUnsafeOrdering {
+  public static int contigCompare(String l, String r) {
+    return Contig.compare(l, r);
+  }
+}

--- a/src/main/scala/is/hail/annotations/ordering/StructUnsafeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/ordering/StructUnsafeOrdering.scala
@@ -1,0 +1,53 @@
+package is.hail.annotations.ordering
+
+import is.hail.variant.Contig
+import is.hail.asm4s._
+import is.hail.annotations._
+import is.hail.expr._
+import is.hail.utils._
+
+class StructUnsafeOrdering(private val t: TStruct, missingIsGreatest: Boolean) extends CodifiedUnsafeOrdering {
+  private val fieldOrderings = t.fields.map(_.typ.unsafeOrdering(missingIsGreatest)).toArray
+
+  def compare(r1: MemoryBuffer, o1: Long, r2: MemoryBuffer, o2: Long): Int = {
+    var i = 0
+    while (i < t.size) {
+      val leftDefined = t.isFieldDefined(r1, o1, i)
+      val rightDefined = t.isFieldDefined(r2, o2, i)
+
+      if (leftDefined && rightDefined) {
+        val c = fieldOrderings(i).compare(r1, t.loadField(r1, o1, i), r2, t.loadField(r2, o2, i))
+        if (c != 0)
+          return c
+      } else if (leftDefined != rightDefined) {
+        val c = if (leftDefined) -1 else 1
+        if (missingIsGreatest)
+          return c
+        else
+          return -c
+      }
+      i += 1
+    }
+    0
+  }
+
+  def compare(r1: Code[MemoryBuffer], o1: Code[Long], r2: Code[MemoryBuffer], o2: Code[Long])
+      : BindingCode[Int] = { (fb, mb) =>
+    val out = fb.newLocal[Int]
+    val leftDefined = mb.newBit
+    val rightDefined = mb.newBit
+
+    (0 until t.size).foldRight[Code[Int]](0) { (i, checkSubsequentFields) =>
+      Code(
+        leftDefined := t.isFieldDefined(r1, o1, i),
+        rightDefined := t.isFieldDefined(r2, o2, i),
+        out :=
+          (leftDefined && rightDefined).mux(
+            fieldOrderings(i).compare(r1, t.loadField(r1, o1, i), r2, t.loadField(r2, o2, i))(fb, mb),
+            (leftDefined ^ rightDefined).mux(
+              if (missingIsGreatest) leftDefined.mux(-1, 1) else leftDefined.mux(1, -1),
+              0)),
+        out.cne(0).mux(out, checkSubsequentFields))
+    }
+  }
+}

--- a/src/main/scala/is/hail/annotations/ordering/VariantUnsafeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/ordering/VariantUnsafeOrdering.scala
@@ -1,0 +1,54 @@
+package is.hail.annotations.ordering
+
+import is.hail.variant._
+import is.hail.asm4s._
+import is.hail.annotations._
+import is.hail.expr._
+import is.hail.utils._
+
+class VariantUnsafeOrdering(t: TVariant, missingIsGreatest: Boolean) extends CodifiedUnsafeOrdering {
+  private val fundamentalComparators = t.representation.fields.map(_.typ.unsafeOrdering(missingIsGreatest)).toArray
+  private val repr = t.representation.fundamentalType
+
+  def compare(r1: MemoryBuffer, o1: Long, r2: MemoryBuffer, o2: Long): Int = {
+    val cOff1 = repr.loadField(r1, o1, 0)
+    val cOff2 = repr.loadField(r2, o2, 0)
+
+    val contig1 = TString.loadString(r1, cOff1)
+    val contig2 = TString.loadString(r2, cOff2)
+
+    val c = Contig.compare(contig1, contig2)
+    if (c != 0)
+      return c
+
+    var i = 1
+    while (i < repr.size) {
+      val fOff1 = repr.loadField(r1, o1, i)
+      val fOff2 = repr.loadField(r2, o2, i)
+
+      val c = fundamentalComparators(i).compare(r1, fOff1, r2, fOff2)
+      if (c != 0)
+        return c
+
+      i += 1
+    }
+    0
+  }
+
+  def compare(r1: Code[MemoryBuffer], o1: Code[Long], r2: Code[MemoryBuffer], o2: Code[Long])
+      : BindingCode[Int] = { (fb, mb) =>
+    val out = fb.newLocal[Int]
+    val i = fb.newLocal[Int]
+
+    Code(
+      out := Code.invokeStatic[StaticContigUnsafeOrdering, String, String, Int]("compare",
+        TString.loadString(r1, repr.loadField(r1, o1, 0)),
+        TString.loadString(r2, repr.loadField(r2, o2, 0))),
+      out.cne(0).mux(
+        out,
+        (0 until repr.size).foldRight[Code[Int]](0) { (i, subsequentChecks) =>
+          Code(
+            fundamentalComparators(i).compare(r1, repr.loadField(r1, o1, i), r2, repr.loadField(r2, o2, i))(fb, mb),
+            out.cne(0).mux(out, subsequentChecks)) }))
+  }
+}

--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -359,6 +359,9 @@ class CodeBoolean(val lhs: Code[Boolean]) extends AnyVal {
   def ||(rhs: Code[Boolean]): Code[Boolean] =
     lhs.toConditional || rhs.toConditional
 
+  def ^(rhs: Code[Boolean]): Code[Boolean] =
+    Code(lhs, rhs, new InsnNode(IXOR))
+
   // on the JVM Booleans are represented as Ints
   def toI: Code[Int] = lhs.asInstanceOf[Code[Int]]
 }

--- a/src/main/scala/is/hail/asm4s/package.scala
+++ b/src/main/scala/is/hail/asm4s/package.scala
@@ -10,6 +10,8 @@ import scala.reflect.ClassTag
 
 package object asm4s {
 
+  type BindingCode[T] = (FunctionBuilder[_], StagedBitSet) => Code[T]
+
   def typeInfo[T](implicit tti: TypeInfo[T]): TypeInfo[T] = tti
 
   def coerce[T](c: Code[_]): Code[T] =

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -42,14 +42,20 @@ object Children {
       Array(a, body)
     case ArrayFold(a, zero, accumName, valueName, body, typ) =>
       Array(a, zero, body)
-    case MakeStruct(fields) =>
-      fields.map(_._3)
     case AggIn(_) =>
       none
     case AggMap(a, _, body, _) =>
       Array(a, body)
     case AggSum(a, _) =>
       Array(a)
+    case MakeStruct(fields) =>
+      fields.map(_._3)
+    case MakeSet(args, _) =>
+      args
+    case SetAdd(set, element, _) =>
+      Array(set, element)
+    case SetContains(set, element) =>
+      Array(set, element)
     case GetField(o, name, typ) =>
       Array(o)
     case GetFieldMissingness(o, name) =>

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -64,6 +64,15 @@ object Copy {
       case MakeStruct(fields) =>
         assert(fields.length == children.length)
         MakeStruct(fields.zip(children).map { case ((n, t, _), v) => (n, t, v) })
+      case MakeSet(args, typ) =>
+        assert(args.length == children.length)
+        MakeSet(children.toArray, typ)
+      case SetAdd(_, _, elementType) =>
+        val IndexedSeq(set, element) = children
+        SetAdd(set, element, elementType)
+      case SetContains(_, _) =>
+        val IndexedSeq(set, element) = children
+        SetContains(set, element)
       case GetField(_, name, typ) =>
         val IndexedSeq(o) = children
         GetField(o, name, typ)

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir
 
-import is.hail.expr.{BaseIR, TAggregable, TBoolean, TFloat32, TFloat64, TInt32, TInt64, TStruct, TVoid, Type, TArray}
+import is.hail.expr.{BaseIR, TAggregable, TBoolean, TFloat32, TFloat64, TInt32, TInt64, TStruct, TVoid, Type, TArray, TSet}
 
 sealed trait IR extends BaseIR {
   def typ: Type
@@ -53,6 +53,13 @@ case class MakeStruct(fields: Array[(String, Type, IR)]) extends IR {
 }
 case class GetField(o: IR, name: String, var typ: Type = null) extends IR
 case class GetFieldMissingness(o: IR, name: String) extends IR { val typ: Type = TBoolean() }
+
+case class MakeSet(args: Array[IR], var elementType: Type = null) extends IR {
+  def typ: TSet = TSet(elementType)
+  override def toString(): String = s"MakeSet(${args: IndexedSeq[IR]}, $typ)"
+}
+case class SetAdd(set: IR, element: IR, var elementType: Type = null) extends IR { def typ: TSet = TSet(elementType) }
+case class SetContains(set: IR, element: IR) extends IR { val typ: Type = TBoolean() }
 
 case class In(i: Int, var typ: Type) extends IR
 case class InMissingness(i: Int) extends IR { val typ: Type = TBoolean() }

--- a/src/main/scala/is/hail/expr/ir/TypeToTypeInfo.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeToTypeInfo.scala
@@ -1,0 +1,15 @@
+package is.hail.expr.ir
+
+import is.hail.expr._
+import is.hail.asm4s._
+
+object TypeToTypeInfo {
+  def apply(t: Type): TypeInfo[_] = t match {
+    case _: TInt32 => typeInfo[Int]
+    case _: TInt64 => typeInfo[Long]
+    case _: TFloat32 => typeInfo[Float]
+    case _: TFloat64 => typeInfo[Double]
+    case _: TBoolean => typeInfo[Boolean]
+    case _ => typeInfo[Long] // reference types
+  }
+}

--- a/src/main/scala/is/hail/rvd/OrderedRVPartitioner.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVPartitioner.scala
@@ -24,7 +24,7 @@ class OrderedRVPartitioner(
   val rangeBoundsType = TArray(pkType)
   assert(rangeBoundsType.typeCheck(rangeBounds))
 
-  val ordering: Ordering[Annotation] = pkType.ordering(missingGreatest = true)
+  val ordering: Ordering[Annotation] = pkType.ordering(missingIsGreatest = true)
   require(rangeBounds.isEmpty || rangeBounds.zip(rangeBounds.tail).forall { case (left, right) => ordering.compare(left, right) < 0 })
 
   def region: MemoryBuffer = rangeBounds.region

--- a/src/main/scala/is/hail/rvd/OrderedRVType.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVType.scala
@@ -27,8 +27,8 @@ class OrderedRVType(
   val pkKFieldIdx: Array[Int] = partitionKey.map(n => kType.fieldIdx(n))
   assert(pkKFieldIdx sameElements (0 until pkType.size))
 
-  val pkOrd: UnsafeOrdering = pkType.unsafeOrdering(missingGreatest = true)
-  val kOrd: UnsafeOrdering = kType.unsafeOrdering(missingGreatest = true)
+  val pkOrd: UnsafeOrdering = pkType.unsafeOrdering(missingIsGreatest = true)
+  val kOrd: UnsafeOrdering = kType.unsafeOrdering(missingIsGreatest = true)
 
   val pkRowOrd: UnsafeOrdering = OrderedRVType.selectUnsafeOrdering(pkType, (0 until pkType.size).toArray, rowType, pkRowFieldIdx)
   val pkKOrd: UnsafeOrdering = OrderedRVType.selectUnsafeOrdering(pkType, (0 until pkType.size).toArray, kType, pkKFieldIdx)
@@ -82,7 +82,7 @@ object OrderedRVType {
     })
 
     val nFields = fields1.length
-    val fieldOrderings = fields1.map(f1 => t1.fieldType(f1).unsafeOrdering(missingGreatest = true))
+    val fieldOrderings = fields1.map(f1 => t1.fieldType(f1).unsafeOrdering(missingIsGreatest = true))
 
     new UnsafeOrdering {
       def compare(r1: MemoryBuffer, o1: Long, r2: MemoryBuffer, o2: Long): Int = {

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -370,7 +370,7 @@ g = let newgt = gtIndex(oldToNew[gtj(g.GT)], oldToNew[gtk(g.GT)]) and
   }
 
   def filterIntervals[T](iList: IntervalTree[Locus, _], keep: Boolean): VariantSampleMatrix = {
-    implicit val locusOrd = vsm.matrixType.locusType.ordering(missingGreatest = true)
+    implicit val locusOrd = vsm.matrixType.locusType.ordering(missingIsGreatest = true)
 
     val ab = new ArrayBuilder[(Interval[Annotation], Annotation)]()
     iList.foreach { case (i, v) =>

--- a/src/test/scala/is/hail/annotations/UnsafeSuite.scala
+++ b/src/test/scala/is/hail/annotations/UnsafeSuite.scala
@@ -224,8 +224,8 @@ class UnsafeSuite extends SparkSuite {
     rvb2.addAnnotation(t, v2)
     val rv2 = RegionValue(region2, rvb2.end())
 
-    assert(math.signum(t.ordering(missingGreatest = true).compare(v1, v2)) ==
-      math.signum(t.unsafeOrdering(missingGreatest = true).compare(rv, rv2)))
+    assert(math.signum(t.ordering(missingIsGreatest = true).compare(v1, v2)) ==
+      math.signum(t.unsafeOrdering(missingIsGreatest = true).compare(rv, rv2)))
   }
 
   @Test def testUnsafeOrdering() {

--- a/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -1076,7 +1076,7 @@ class ExprSuite extends SparkSuite {
       b <- t.genValue) yield (t, a, b)
 
     val p = forAll(g) { case (t, a, b) =>
-      val ord = t.ordering(missingGreatest = true)
+      val ord = t.ordering(missingIsGreatest = true)
       ord.compare(a, b) == -ord.compare(b, a)
     }
     p.check()


### PR DESCRIPTION
To properly implement IR sets, I need to staged UnsafeOrdering's, or, at the very least, I need to be able to call them from `Code`-land.

Since objects at IR-compile-time are not available at IR-run-time (without shipping them to the nodes and passing them as arguments, which I'd like to avoid), I must be able to call static methods, or have fully code-ified versions of every UnsafeOrdering used in the IR. Whenever possible, I tried to call static methods. In a few cases, I couldn't figure out how to make that work, so I had to reimplement the operation in `Code`.

I also had to introduce `BindingCode[T]` which is a type alias for `(FunctionBuilder, StagedBitSet) => Code[T]`. The function builder is used to allocate new variables and the `StagedBitSet` is used to compactly store boolean values.

I am also somewhat confused by the `missingGreatest` parameter which existed on the original `UnsafeOrdering`s (which I refactored while Code-ifying). cc: @cseed, I guess this parameter is only sensible on compound data? It seems like there should be a:

```
def compare(r1: MemoryBuffer, o1: Long, m1: Boolean, r2: MemoryBuffer, o2: Long, m2: Boolean): Int
```

which correctly applies the `missingGreatest` parameter. 