### PR TITLE
scala handles universals better than existentials

### DIFF
--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -391,7 +391,7 @@ g = let newgt = gtIndex(oldToNew[gtj(g.GT)], oldToNew[gtk(g.GT)]) and
     filterIntervals(iList, keep)
   }
 
-  def filterIntervals[T](iList: IntervalTree[Locus, _], keep: Boolean): VariantSampleMatrix = {
+  def filterIntervals[T, U](iList: IntervalTree[Locus, U], keep: Boolean): VariantSampleMatrix = {
     implicit val locusOrd = vsm.matrixType.locusType.ordering(missingGreatest = true)
 
     val ab = new ArrayBuilder[(Interval[Annotation], Annotation)]()


### PR DESCRIPTION
The prior form raises a warning about existential types that cannot be expressed using wildcards.

Here we use the rule that

    (exists t. t) => u

is equivalent to

    (forall t. t => u)

which is basically how quantifiers switch when moving through implication arrows.