### PR TITLE
Modified GenomeReference constructor

### DIFF
--- a/src/main/scala/is/hail/expr/AnnotationImpex.scala
+++ b/src/main/scala/is/hail/expr/AnnotationImpex.scala
@@ -195,6 +195,8 @@ case class JSONExtractVariant(contig: String,
 
 case class JSONExtractInterval(start: Locus, end: Locus) {
   def toInterval = Interval(start, end)
+
+  def toIntervalTuple: (String, Int, Int) = (start.contig, start.position, end.position)
 }
 
 case class JSONExtractContig(name: String, length: Int)
@@ -203,7 +205,7 @@ case class JSONExtractGenomeReference(name: String, contigs: Array[JSONExtractCo
   yContigs: Set[String], mtContigs: Set[String], par: Array[JSONExtractInterval]) {
 
   def toGenomeReference: GenomeReference = GenomeReference(name, contigs.map(_.name),
-    contigs.map(c => (c.name, c.length)).toMap, xContigs, yContigs, mtContigs, par.map(_.toInterval))
+    contigs.map(c => (c.name, c.length)).toMap, xContigs, yContigs, mtContigs, par.map(_.toIntervalTuple))
 }
 
 object JSONAnnotationImpex extends AnnotationImpex[Type, JValue] {

--- a/src/test/scala/is/hail/variant/GenomeReferenceSuite.scala
+++ b/src/test/scala/is/hail/variant/GenomeReferenceSuite.scala
@@ -44,21 +44,21 @@ class GenomeReferenceSuite extends SparkSuite {
 
   @Test def testAssertions() {
     TestUtils.interceptFatal("The following X contig names are absent from the reference:")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5),
-      Set("X"), Set.empty[String], Set.empty[String], Array.empty[Interval[Locus]]))
+      Set("X"), Set.empty[String], Set.empty[String], Array.empty[(String, Int, Int)]))
     TestUtils.interceptFatal("No lengths given for the following contigs:")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5),
-      Set.empty[String], Set.empty[String], Set.empty[String], Array.empty[Interval[Locus]]))
+      Set.empty[String], Set.empty[String], Set.empty[String], Array.empty[(String, Int, Int)]))
     TestUtils.interceptFatal("Contigs found in `lengths' that are not present in `contigs'")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5, "4" -> 100),
-      Set.empty[String], Set.empty[String], Set.empty[String], Array.empty[Interval[Locus]]))
+      Set.empty[String], Set.empty[String], Set.empty[String], Array.empty[(String, Int, Int)]))
     TestUtils.interceptFatal("The following Y contig names are absent from the reference:")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5),
-      Set.empty[String], Set("Y"), Set.empty[String], Array.empty[Interval[Locus]]))
+      Set.empty[String], Set("Y"), Set.empty[String], Array.empty[(String, Int, Int)]))
     TestUtils.interceptFatal("The following mitochondrial contig names are absent from the reference:")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5),
-      Set.empty[String], Set.empty[String], Set("MT"), Array.empty[Interval[Locus]]))
+      Set.empty[String], Set.empty[String], Set("MT"), Array.empty[(String, Int, Int)]))
     TestUtils.interceptFatal("Must have at least one contig in the reference genome.")(GenomeReference("test", Array.empty[String], Map.empty[String, Int],
-      Set.empty[String], Set.empty[String], Set.empty[String], Array.empty[Interval[Locus]]))
+      Set.empty[String], Set.empty[String], Set.empty[String], Array.empty[(String, Int, Int)]))
     TestUtils.interceptFatal("The contig name for PAR interval")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5),
-      Set.empty[String], Set.empty[String], Set.empty[String], Array(Interval(Locus("X", 1), Locus("X", 5)))))
+      Set.empty[String], Set.empty[String], Set.empty[String], Array(("X", 1, 5))))
     TestUtils.interceptFatal("in both X and Y contigs.")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5),
-      Set("1"), Set("1"), Set.empty[String], Array.empty[Interval[Locus]]))
+      Set("1"), Set("1"), Set.empty[String], Array.empty[(String, Int, Int)]))
   }
 
   @Test def testVariant() {
@@ -92,7 +92,7 @@ class GenomeReferenceSuite extends SparkSuite {
 
   @Test def testParser() {
     val gr = GenomeReference("foo", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5),
-      Set.empty[String], Set.empty[String], Set.empty[String], Array.empty[Interval[Locus]])
+      Set.empty[String], Set.empty[String], Set.empty[String], Array.empty[(String, Int, Int)])
     GenomeReference.addReference(gr)
 
     val vds = hc.importVCF("src/test/resources/sample.vcf")
@@ -170,7 +170,7 @@ class GenomeReferenceSuite extends SparkSuite {
       """i1.start == Locus(GRCh37)("1", 5) && !i2.contains(l1)"""))
 
     val gr = GenomeReference("foo2", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5),
-        Set.empty[String], Set.empty[String], Set.empty[String], Array.empty[Interval[Locus]])
+        Set.empty[String], Set.empty[String], Set.empty[String], Array.empty[(String, Int, Int)])
     GenomeReference.addReference(gr)
     GenomeReference.setDefaultReference(gr)
     assert(kt.annotate("""v1 = Variant("chrX:156030895:A:T")""").signature.field("v1").typ == gr.variant)


### PR DESCRIPTION
- Intervals cannot be in GenomeReference constructor because intervals
are parameterized by reference
- Made python genome reference operations lazy