### PR TITLE
Modified GenomeReference constructor

### DIFF
--- a/python/hail/representation/genomeref.py
+++ b/python/hail/representation/genomeref.py
@@ -47,7 +47,9 @@ class GenomeReference(HistoryMixin):
         x_contigs = wrap_to_list(x_contigs)
         y_contigs = wrap_to_list(y_contigs)
         mt_contigs = wrap_to_list(mt_contigs)
-        self._par_jrep = Env.hail().variant.Locus.parseIntervals(wrap_to_list(["{}:{}-{}".format(contig, start, end) for (contig, start, end) in par]))
+
+        par_strings = ["{}:{}-{}".format(contig, start, end) for (contig, start, end) in par]
+        self._par_jrep = Env.hail().variant.Locus.parseIntervals(wrap_to_list(par_strings))
 
         jrep = (Env.hail().variant.GenomeReference
                 .apply(name,
@@ -56,7 +58,7 @@ class GenomeReference(HistoryMixin):
                        x_contigs,
                        y_contigs,
                        mt_contigs,
-                       self._par_jrep))
+                       par_strings))
 
         self._init_from_java(jrep)
         self._name = name

--- a/src/main/scala/is/hail/expr/AnnotationImpex.scala
+++ b/src/main/scala/is/hail/expr/AnnotationImpex.scala
@@ -195,6 +195,8 @@ case class JSONExtractVariant(contig: String,
 
 case class JSONExtractInterval(start: Locus, end: Locus) {
   def toInterval = Interval(start, end)
+
+  def toLocusTuple: (Locus, Locus) = (start, end)
 }
 
 case class JSONExtractContig(name: String, length: Int)
@@ -203,7 +205,7 @@ case class JSONExtractGenomeReference(name: String, contigs: Array[JSONExtractCo
   yContigs: Set[String], mtContigs: Set[String], par: Array[JSONExtractInterval]) {
 
   def toGenomeReference: GenomeReference = GenomeReference(name, contigs.map(_.name),
-    contigs.map(c => (c.name, c.length)).toMap, xContigs, yContigs, mtContigs, par.map(_.toInterval))
+    contigs.map(c => (c.name, c.length)).toMap, xContigs, yContigs, mtContigs, par.map(_.toLocusTuple))
 }
 
 object JSONAnnotationImpex extends AnnotationImpex[Type, JValue] {

--- a/src/test/scala/is/hail/variant/GenomeReferenceSuite.scala
+++ b/src/test/scala/is/hail/variant/GenomeReferenceSuite.scala
@@ -43,22 +43,14 @@ class GenomeReferenceSuite extends SparkSuite {
   }
 
   @Test def testAssertions() {
-    TestUtils.interceptFatal("The following X contig names are absent from the reference:")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5),
-      Set("X"), Set.empty[String], Set.empty[String], Array.empty[Interval[Locus]]))
-    TestUtils.interceptFatal("No lengths given for the following contigs:")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5),
-      Set.empty[String], Set.empty[String], Set.empty[String], Array.empty[Interval[Locus]]))
-    TestUtils.interceptFatal("Contigs found in `lengths' that are not present in `contigs'")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5, "4" -> 100),
-      Set.empty[String], Set.empty[String], Set.empty[String], Array.empty[Interval[Locus]]))
-    TestUtils.interceptFatal("The following Y contig names are absent from the reference:")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5),
-      Set.empty[String], Set("Y"), Set.empty[String], Array.empty[Interval[Locus]]))
-    TestUtils.interceptFatal("The following mitochondrial contig names are absent from the reference:")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5),
-      Set.empty[String], Set.empty[String], Set("MT"), Array.empty[Interval[Locus]]))
-    TestUtils.interceptFatal("Must have at least one contig in the reference genome.")(GenomeReference("test", Array.empty[String], Map.empty[String, Int],
-      Set.empty[String], Set.empty[String], Set.empty[String], Array.empty[Interval[Locus]]))
-    TestUtils.interceptFatal("The contig name for PAR interval")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5),
-      Set.empty[String], Set.empty[String], Set.empty[String], Array(Interval(Locus("X", 1), Locus("X", 5)))))
-    TestUtils.interceptFatal("in both X and Y contigs.")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5),
-      Set("1"), Set("1"), Set.empty[String], Array.empty[Interval[Locus]]))
+    TestUtils.interceptFatal("Must have at least one contig in the reference genome.")(GenomeReference("test", Array.empty[String], Map.empty[String, Int]))
+    TestUtils.interceptFatal("No lengths given for the following contigs:")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5)))
+    TestUtils.interceptFatal("Contigs found in `lengths' that are not present in `contigs'")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5, "4" -> 100)))
+    TestUtils.interceptFatal("The following X contig names are absent from the reference:")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5), xContigs = Set("X")))
+    TestUtils.interceptFatal("The following Y contig names are absent from the reference:")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5), yContigs = Set("Y")))
+    TestUtils.interceptFatal("The following mitochondrial contig names are absent from the reference:")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5), mtContigs = Set("MT")))
+    TestUtils.interceptFatal("The contig name for PAR interval")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5), parInput = Array((Locus("X", 1), Locus("X", 5)))))
+    TestUtils.interceptFatal("in both X and Y contigs.")(GenomeReference("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5), xContigs = Set("1"), yContigs = Set("1")))
   }
 
   @Test def testVariant() {
@@ -91,8 +83,7 @@ class GenomeReferenceSuite extends SparkSuite {
   }
 
   @Test def testParser() {
-    val gr = GenomeReference("foo", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5),
-      Set.empty[String], Set.empty[String], Set.empty[String], Array.empty[Interval[Locus]])
+    val gr = GenomeReference("foo", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5))
     GenomeReference.addReference(gr)
 
     val vds = hc.importVCF("src/test/resources/sample.vcf")
@@ -169,8 +160,7 @@ class GenomeReferenceSuite extends SparkSuite {
       "l1.position == 100 && l2.position == 100 &&" +
       """i1.start == Locus(GRCh37)("1", 5) && !i2.contains(l1)"""))
 
-    val gr = GenomeReference("foo2", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5),
-        Set.empty[String], Set.empty[String], Set.empty[String], Array.empty[Interval[Locus]])
+    val gr = GenomeReference("foo2", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5))
     GenomeReference.addReference(gr)
     GenomeReference.setDefaultReference(gr)
     assert(kt.annotate("""v1 = Variant("chrX:156030895:A:T")""").signature.field("v1").typ == gr.variant)


### PR DESCRIPTION
- Intervals cannot be in GenomeReference constructor because intervals
are parameterized by reference with Ordering[Locus]
