### PR TITLE
Include partition counts in VSM/KT metadata.

### DIFF
--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -352,6 +352,8 @@ object MatrixIR {
 abstract sealed class MatrixIR extends BaseIR {
   def typ: MatrixType
 
+  def partitionCounts: Option[Array[Long]] = None
+
   def execute(hc: HailContext): MatrixValue
 }
 
@@ -378,8 +380,9 @@ case class MatrixRead(
   fileMetadata: VSMFileMetadata,
   dropSamples: Boolean,
   dropVariants: Boolean) extends MatrixIR {
-
   def typ: MatrixType = MatrixType(fileMetadata.metadata)
+
+  override def partitionCounts: Option[Array[Long]] = fileMetadata.partitionCounts
 
   def children: IndexedSeq[BaseIR] = Array.empty[BaseIR]
 

--- a/src/main/scala/is/hail/io/RowStore.scala
+++ b/src/main/scala/is/hail/io/RowStore.scala
@@ -524,7 +524,7 @@ object RichRDDRegionValue {
 }
 
 class RichRDDRegionValue(val rdd: RDD[RegionValue]) extends AnyVal {
-  def writeRows(path: String, t: TStruct) {
+  def writeRows(path: String, t: TStruct): Array[Long] = {
     rdd.writePartitions(path, RichRDDRegionValue.writeRowsPartition(t))
   }
 }

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -2,12 +2,12 @@ package is.hail.rvd
 
 import is.hail.annotations.{MemoryBuffer, RegionValue, RegionValueBuilder}
 import is.hail.expr.Type
+import is.hail.utils._
 import org.apache.spark.{Partition, SparkContext}
 import org.apache.spark.rdd.{AggregateWithContext, RDD}
 import org.apache.spark.storage.StorageLevel
 
 import scala.reflect.ClassTag
-
 
 object RVD {
   def apply(rowType: Type, rdd: RDD[RegionValue]): ConcreteRVD = new ConcreteRVD(rowType, rdd)
@@ -58,6 +58,8 @@ trait RVD {
   }
 
   def count(): Long = rdd.count()
+
+  def countPerPartition(): Array[Long] = rdd.countPerPartition()
 
   protected def persistRVRDD(level: StorageLevel): PersistedRVRDD = {
     val localRowType = rowType

--- a/src/main/scala/is/hail/variant/VariantMetadata.scala
+++ b/src/main/scala/is/hail/variant/VariantMetadata.scala
@@ -24,6 +24,8 @@ case class VSMLocalValue(
 }
 
 object VSMFileMetadata {
+  def apply(metadata: VSMMetadata, localValue: VSMLocalValue): VSMFileMetadata = VSMFileMetadata(metadata, localValue, None)
+
   def apply(sampleIds: IndexedSeq[String],
     sampleAnnotations: IndexedSeq[Annotation] = null,
     globalAnnotation: Annotation = Annotation.empty,
@@ -47,7 +49,9 @@ object VSMFileMetadata {
 
 case class VSMFileMetadata(
   metadata: VSMMetadata,
-  localValue: VSMLocalValue)
+  localValue: VSMLocalValue,
+  partitionCounts: Option[Array[Long]]) {
+}
 
 case class VSMMetadata(
   sSignature: Type = TString(),


### PR DESCRIPTION
Use partitionCounts in VSM.count, VSM.toIndexedRowMatrix and ToNormalizedIndexedRowMatrix.
