### PR TITLE
fixed explode to handle sets and annotate samples with key elements

### DIFF
--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -1081,7 +1081,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
       val ur = new UnsafeRow(localRowType)
       it.flatMap { rv =>
         ur.set(rv)
-        val keys = querier(ur).asInstanceOf[IndexedSeq[Any]]
+        val keys = querier(ur).asInstanceOf[Iterable[Any]]
         if (keys == null)
           None
         else
@@ -1108,21 +1108,38 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
       case TSet(e, _) => e
       case t => fatal(s"Expected annotation of type Array or Set; found $t")
     }
-    val keys = sampleAnnotations.map { sa => {
-      val ks = querier(sa).asInstanceOf[IndexedSeq[Any]]
+    var size = 0
+    val keys = sampleAnnotations.map { sa =>
+      val ks = querier(sa).asInstanceOf[Iterable[Any]]
       if (ks == null)
-        IndexedSeq.empty[Any]
-      else
+        Iterable.empty[Any]
+      else {
+        size += ks.size
         ks
+      }
     }
-    }
-    val sampleMap = (0 until nSamples).flatMap { i => keys(i).iterator.map { _ => i } }
-    val localRowType = rowType
-    val localGSsig = rowType.fieldType(3).asInstanceOf[TArray]
-
+    
     val (newSASig, inserter) = saSignature.insert(keyType, path)
-    val newSampleAnnotations = sampleMap.map { i => inserter(sampleAnnotations(i), keys(i)) }
-    val newSampleIds = sampleMap.map { i => sampleIds(i) }
+    
+    val sampleMap = new Array[Int](size)
+    val newSampleIds = new Array[Annotation](size)
+    val newSampleAnnotations = new Array[Annotation](size)
+
+    var i = 0
+    var j = 0
+    while (i < nSamples) {
+      keys(i).foreach { e =>
+        sampleMap(j) = i
+        newSampleIds(j) = sampleIds(i)
+        newSampleAnnotations(j) = inserter(sampleAnnotations(i), e)
+        j += 1
+      }
+      i += 1
+    }
+    
+    val sampleMapBc = sparkContext.broadcast(sampleMap)
+    val localRowType = rowType
+    val localGSSig = rowType.fieldType(3).asInstanceOf[TArray]
 
     val newRDD = rdd2.rdd.mapPartitions { it =>
       val region2 = MemoryBuffer()
@@ -1141,7 +1158,9 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
         i = 0
         val arrayOff = localRowType.loadField(rv, 3)
         while (i < newSampleIds.length) {
-          rv2b.addRegionValue(localGSsig.elementType, rv.region, localGSsig.loadElement(rv.region, arrayOff, sampleMap(i)))
+          rv2b.addRegionValue(localGSSig.elementType, rv.region, 
+            localGSSig.loadElement(rv.region, arrayOff, sampleMapBc.value(i)))
+          i += 1
         }
         rv2b.endArray()
         rv2b.endStruct()

--- a/src/test/scala/is/hail/variant/vsm/ExplodeSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/ExplodeSuite.scala
@@ -1,43 +1,46 @@
 package is.hail.variant.vsm
 
 import is.hail.SparkSuite
-import is.hail.TestUtils
+import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
 class ExplodeSuite extends SparkSuite {
   @Test def testExplode() {
     val vsm = hc.importVCF("src/test/resources/sample.vcf")
-      .annotateVariantsExpr("va.foo = [1, 2, 3]")
-    val exploded = vsm.explodeVariants("va.foo")
-    assert(exploded.countVariants() == vsm.countVariants()*3)
-
-    val vsm2 = hc.importVCF("src/test/resources/sample.vcf")
-      .annotateSamplesExpr("sa.foo = [1, 2, 3]")
-    val exploded2 = vsm2.explodeSamples("sa.foo")
-    assert(exploded2.nSamples == vsm.nSamples*3)
+      .annotateVariantsExpr("va.foo = [1, 2, 2], va.bar = [1, 2, 2].toSet()")
+      .annotateSamplesExpr("sa.foo = [1, 2, 2], sa.bar = [1, 2, 2].toSet()")
+        
+    assert(vsm.explodeVariants("va.foo").countVariants() == vsm.countVariants() * 3)
+    assert(vsm.explodeVariants("va.bar").countVariants() == vsm.countVariants() * 2)
+    assert(vsm.explodeSamples("sa.foo").nSamples == vsm.nSamples * 3)
+    assert(vsm.explodeSamples("sa.bar").nSamples == vsm.nSamples * 2)
+    
+    val key = vsm.sampleAnnotations(0).asInstanceOf[Row].get(0)
+    val explodedKey = vsm.explodeSamples("sa.foo").sampleAnnotations.take(3).asInstanceOf[IndexedSeq[Row]].map(_.get(0))       
+    assert(key == explodedKey)    
   }
 
   @Test def testExplodeUnwrap() {
     val vsm = hc.importVCF("src/test/resources/sample.vcf")
       .annotateVariantsExpr("va.foo = [1]")
+      .annotateSamplesExpr("sa.foo = [3]")
+    
     val exploded = vsm.explodeVariants("va.foo")
     assert(vsm.variants.collect().sameElements(exploded.variants.collect()))
 
-    val vsm2 = hc.importVCF("src/test/resources/sample.vcf")
-      .annotateSamplesExpr("sa.foo = [3]")
-    val exploded2 = vsm2.explodeSamples("sa.foo")
-    assert(exploded2.sampleIds.sameElements(vsm.sampleIds))
+    val exploded2 = vsm.explodeSamples("sa.foo")
+    assert(exploded2.sampleIds == vsm.sampleIds)
   }
 
   @Test def testNoElements() {
     val vsm = hc.importVCF("src/test/resources/sample.vcf")
       .annotateVariantsExpr("va.foo = NA: Array[Int32]")
+      .annotateSamplesExpr("sa.foo = NA: Array[Int32]")
+    
     val exploded = vsm.explodeVariants("va.foo")
     assert(exploded.countVariants() == 0)
 
-    val vsm2 = hc.importVCF("src/test/resources/sample.vcf")
-      .annotateSamplesExpr("sa.foo = NA: Array[Int32]")
-    val exploded2 = vsm2.explodeSamples("sa.foo")
+    val exploded2 = vsm.explodeSamples("sa.foo")
     assert(exploded2.nSamples == 0)
   }
 }


### PR DESCRIPTION
explodeVariants and explodeSamples are failing on Set keys because of cast to IndexedSeq. And on key=[1, 2], explodeSamples is annotating each sample with [1,2] rather than with 1 and then 2. Here are fixes and regression tests.