### PR TITLE
Stacktrace

### DIFF
--- a/python/hail/java.py
+++ b/python/hail/java.py
@@ -4,6 +4,7 @@ import sys
 from threading import Thread
 
 import py4j
+from pyspark.sql.utils import CapturedException
 from decorator import decorator
 
 
@@ -160,6 +161,10 @@ def handle_py4j(func, *args, **kwargs):
                              'Error summary: %s' % (msg, e.message, Env.hc().version, msg))
         else:
             raise e
+    except CapturedException as e:
+        raise FatalError('%s\n\nJava stack trace:\n%s\n'
+                         'Hail version: %s\n'
+                         'Error summary: %s' % (e.desc, e.stackTrace, Env.hc().version, e.desc))
     return r
 
 


### PR DESCRIPTION
Output for a requirement failed exception now looks like:

```
Traceback (most recent call last):
  File "hail_extract_cohorts.py", line 37, in <module>
    vds = vds.annotate_global('global.samples_to_exclude', set(samples_to_exclude_list), hail.TSet(hail.TString()))
  File "<decorator-gen-390>", line 2, in annotate_global
  File "/home/cotton/hail/python/hail/java.py", line 167, in handle_py4j
    'Error summary: %s' % (e.desc, e.stackTrace, Env.hc().version, e.desc))
hail.java.FatalError: requirement failed

Java stack trace:
scala.Predef$.require(Predef.scala:212)
	 at is.hail.variant.VariantSampleMatrix.annotateGlobal(VariantSampleMatrix.scala:564)
	 at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	 at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	 at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	 at java.lang.reflect.Method.invoke(Method.java:498)
	 at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:237)
	 at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
	 at py4j.Gateway.invoke(Gateway.java:280)
	 at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
	 at py4j.commands.CallCommand.execute(CallCommand.java:79)
	 at py4j.GatewayConnection.run(GatewayConnection.java:214)
	 at java.lang.Thread.run(Thread.java:748)
Hail version: devel-75de081
Error summary: requirement failed
```
