### PR TITLE
Improve inference of anyFailAllFail

### DIFF
--- a/src/main/scala/is/hail/check/Gen.scala
+++ b/src/main/scala/is/hail/check/Gen.scala
@@ -283,14 +283,26 @@ object Gen {
   def stringOf[T](g: Gen[T])(implicit cbf: CanBuildFrom[Nothing, T, String]): Gen[String] =
     unsafeBuildableOf(g)
 
-  def buildableOf[C[_], T](g: Gen[T])(implicit cbf: CanBuildFrom[Nothing, T, C[T]]): Gen[C[T]] =
-    unsafeBuildableOf(g)
+  sealed trait BuildableOf[C[_]] {
+    def apply[T](g: Gen[T])(implicit cbf: CanBuildFrom[Nothing, T, C[T]]): Gen[C[T]] =
+      unsafeBuildableOf(g)
+  }
+
+  private object buildableOfInstance extends BuildableOf[Nothing]
+
+  def buildableOf[C[_]] = buildableOfInstance.asInstanceOf[BuildableOf[C]]
 
   implicit def buildableOfFromElements[C[_], T](implicit g: Gen[T], cbf: CanBuildFrom[Nothing, T, C[T]]): Gen[C[T]] =
-    buildableOf[C, T](g)
+    buildableOf[C](g)
 
-  def buildableOf2[C[_, _], T, U](g: Gen[(T, U)])(implicit cbf: CanBuildFrom[Nothing, (T, U), C[T, U]]): Gen[C[T, U]] =
-    unsafeBuildableOf(g)
+  sealed trait BuildableOf2[C[_]] {
+    def apply[T, U](g: Gen[(T, U)])(implicit cbf: CanBuildFrom[Nothing, (T, U), C[T, U]]): Gen[C[T, U]] =
+      unsafeBuildableOf(g)
+  }
+
+  private object buildableOf2Instance extends BuildableOf2[Nothing]
+
+  def buildableOf2[C[_, _]] = buildableOf2Instance.asInstanceOf[C]
 
   private val buildableOfAlpha = 3
   private val buildableOfBeta = 6

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -429,7 +429,7 @@ case class StructConstructor(posn: Position, names: Array[String], elements: Arr
   ) yield arrayToAnnotation(CompilationHelp.arrayOf(celements))
 
   def toIR: Option[IR] = for {
-    irElements <- anyFailAllFail[Array, (Type, IR)](elements.map(x => x.toIR.map(ir => (x.`type`, ir))))
+    irElements <- anyFailAllFail[Array](elements.map(x => x.toIR.map(ir => (x.`type`, ir))))
     fields = names.zip(irElements).map { case (x, (y, z)) => (x, z) }
   } yield ir.MakeStruct(fields)
 }

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -87,7 +87,7 @@ object FunctionRegistry {
             None
         }
 
-        anyFailAllFail[Array, Option[(Int, Transformation[Any, Any])]](conversions)
+        anyFailAllFail[Array](conversions)
           .map { arr =>
             if (arr.forall(_.isEmpty))
               0 -> (tt.subst(), f.captureType().subst())

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -1599,7 +1599,7 @@ object FunctionRegistry {
   registerMethod("isSubset", (x: Set[Any], a: Set[Any]) => x.subsetOf(a), "Returns true if this Set is a subset of Set `a`.")(setHr(TTHr), setHr(TTHr), boolHr)
 
   registerMethod("flatten", (a: IndexedSeq[IndexedSeq[Any]]) =>
-    flattenOrNull[IndexedSeq, Any](IndexedSeq.newBuilder[Any], a),
+    flattenOrNull[IndexedSeq](IndexedSeq.newBuilder[Any], a),
     """
     Flattens a nested array by concatenating all its rows into a single array.
 
@@ -1612,7 +1612,7 @@ object FunctionRegistry {
   )(arrayHr(arrayHr(TTHr)), arrayHr(TTHr))
 
   registerMethod("flatten", (s: Set[Set[Any]]) =>
-    flattenOrNull[Set, Any](Set.newBuilder[Any], s),
+    flattenOrNull[Set](Set.newBuilder[Any], s),
     """
     Flattens a nested set by concatenating all its elements into a single set.
 
@@ -1809,7 +1809,7 @@ object FunctionRegistry {
   //  )(TTHr, TUHr, unaryHr(TUHr, TVHr), TVHr)
 
   registerLambdaMethod("flatMap", (a: IndexedSeq[Any], f: (Any) => Any) =>
-    flattenOrNull[IndexedSeq, Any](IndexedSeq.newBuilder[Any],
+    flattenOrNull[IndexedSeq](IndexedSeq.newBuilder[Any],
       a.map(f).asInstanceOf[IndexedSeq[IndexedSeq[Any]]]),
     """
     Returns a new array by applying a function to each subarray and concatenating the resulting arrays.
@@ -1824,7 +1824,7 @@ object FunctionRegistry {
   )(arrayHr(TTHr), unaryHr(TTHr, arrayHr(TUHr)), arrayHr(TUHr))
 
   registerLambdaMethod("flatMap", (s: Set[Any], f: (Any) => Any) =>
-    flattenOrNull[Set, Any](Set.newBuilder[Any],
+    flattenOrNull[Set](Set.newBuilder[Any],
       s.map(f).asInstanceOf[Set[Set[Any]]]),
     """
     Returns a new set by applying a function to each subset and concatenating the resulting sets.

--- a/src/main/scala/is/hail/expr/Type.scala
+++ b/src/main/scala/is/hail/expr/Type.scala
@@ -43,7 +43,7 @@ object Type {
   val requiredComplex = genComplexType(true)
 
   def preGenStruct(required: Boolean, genFieldType: Gen[Type]): Gen[TStruct] =
-    Gen.buildableOf[Array, (String, Type)](
+    Gen.buildableOf[Array](
       Gen.zip(Gen.identifier, genFieldType))
       .filter(fields => fields.map(_._1).areDistinct())
       .map(fields => TStruct(fields
@@ -1098,7 +1098,7 @@ final case class TArray(elementType: Type, override val required: Boolean = fals
   override def str(a: Annotation): String = JsonMethods.compact(toJSON(a))
 
   override def genNonmissingValue: Gen[Annotation] =
-    Gen.buildableOf[Array, Annotation](elementType.genValue).map(x => x: IndexedSeq[Annotation])
+    Gen.buildableOf[Array](elementType.genValue).map(x => x: IndexedSeq[Annotation])
 
   def ordering(missingGreatest: Boolean): Ordering[Annotation] =
     annotationOrdering(extendOrderingToNull(missingGreatest)(
@@ -1175,7 +1175,7 @@ final case class TSet(elementType: Type, override val required: Boolean = false)
 
   override def str(a: Annotation): String = JsonMethods.compact(toJSON(a))
 
-  override def genNonmissingValue: Gen[Annotation] = Gen.buildableOf[Set, Annotation](elementType.genValue)
+  override def genNonmissingValue: Gen[Annotation] = Gen.buildableOf[Set](elementType.genValue)
 
   override def desc: String =
     """
@@ -1243,7 +1243,7 @@ final case class TDict(keyType: Type, valueType: Type, override val required: Bo
   override def str(a: Annotation): String = JsonMethods.compact(toJSON(a))
 
   override def genNonmissingValue: Gen[Annotation] =
-    Gen.buildableOf2[Map, Annotation, Annotation](Gen.zip(keyType.genValue, valueType.genValue))
+    Gen.buildableOf2[Map](Gen.zip(keyType.genValue, valueType.genValue))
 
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double): Boolean =
     a1 == a2 || (a1 != null && a2 != null &&

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -178,7 +178,7 @@ class OrderedRVD private(
       val partSize = rdd.context.runJob(rdd, getIteratorSize _)
       log.info(s"partSize = ${ partSize.toSeq }")
 
-      val partCumulativeSize = mapAccumulate[Array, Long, Long, Long](partSize, 0)((s, acc) => (s + acc, s + acc))
+      val partCumulativeSize = mapAccumulate[Array](partSize, 0)((s, acc) => (s + acc, s + acc))
       val totalSize = partCumulativeSize.last
 
       var newPartEnd = (0 until maxPartitions).map { i =>

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -178,7 +178,7 @@ class OrderedRVD private(
       val partSize = rdd.context.runJob(rdd, getIteratorSize _)
       log.info(s"partSize = ${ partSize.toSeq }")
 
-      val partCumulativeSize = mapAccumulate[Array](partSize, 0)((s, acc) => (s + acc, s + acc))
+      val partCumulativeSize = mapAccumulate[Array, Long](partSize, 0L)((s, acc) => (s + acc, s + acc))
       val totalSize = partCumulativeSize.last
 
       var newPartEnd = (0 until maxPartitions).map { i =>

--- a/src/main/scala/is/hail/sparkextras/OrderedRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/OrderedRDD.scala
@@ -413,7 +413,7 @@ class OrderedRDD[PK, K, V] private(rdd: RDD[(K, V)], val orderedPartitioner: Ord
       val partSize = rdd.context.runJob(rdd, getIteratorSize _)
       log.info(s"partSize = ${ partSize.toSeq }")
 
-      val partCumulativeSize = mapAccumulate[Array, Long, Long, Long](partSize, 0)((s, acc) => (s + acc, s + acc))
+      val partCumulativeSize = mapAccumulate[Array](partSize, 0)((s, acc) => (s + acc, s + acc))
       val totalSize = partCumulativeSize.last
 
       var newPartEnd = (0 until maxPartitions).map { i =>

--- a/src/main/scala/is/hail/sparkextras/OrderedRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/OrderedRDD.scala
@@ -413,7 +413,7 @@ class OrderedRDD[PK, K, V] private(rdd: RDD[(K, V)], val orderedPartitioner: Ord
       val partSize = rdd.context.runJob(rdd, getIteratorSize _)
       log.info(s"partSize = ${ partSize.toSeq }")
 
-      val partCumulativeSize = mapAccumulate[Array](partSize, 0)((s, acc) => (s + acc, s + acc))
+      val partCumulativeSize = mapAccumulate[Array, Long](partSize, 0L)((s, acc) => (s + acc, s + acc))
       val totalSize = partCumulativeSize.last
 
       var newPartEnd = (0 until maxPartitions).map { i =>

--- a/src/main/scala/is/hail/utils/IntervalTree.scala
+++ b/src/main/scala/is/hail/utils/IntervalTree.scala
@@ -123,7 +123,7 @@ object IntervalTree {
   }
 
   def gen[T: Ordering](tgen: Gen[T]): Gen[IntervalTree[T, Unit]] = {
-    Gen.buildableOf[Array, Interval[T]](Interval.gen(tgen)).map(IntervalTree.apply(_))
+    Gen.buildableOf[Array](Interval.gen(tgen)).map(IntervalTree.apply(_))
   }
 }
 

--- a/src/main/scala/is/hail/utils/package.scala
+++ b/src/main/scala/is/hail/utils/package.scala
@@ -276,8 +276,8 @@ package object utils extends Logging
 
   def uninitialized[T]: T = null.asInstanceOf[T]
 
-  sealed trait MapAccumulate[C[_]] {
-    def apply[T, S, U](a: Iterable[T], z: S)(f: (T, S) => (U, S))
+  sealed trait MapAccumulate[C[_], U] {
+    def apply[T, S](a: Iterable[T], z: S)(f: (T, S) => (U, S))
       (implicit uct: ClassTag[U], cbf: CanBuildFrom[Nothing, U, C[U]]): C[U] = {
       val b = cbf()
       var acc = z
@@ -290,10 +290,10 @@ package object utils extends Logging
     }
   }
 
-  private object mapAccumulateInstance extends MapAccumulate[Nothing]
+  private object mapAccumulateInstance extends MapAccumulate[Nothing, Nothing]
 
-  def mapAccumulate[C[_]] =
-    mapAccumulateInstance.asInstanceOf[MapAccumulate[C]]
+  def mapAccumulate[C[_], U] =
+    mapAccumulateInstance.asInstanceOf[MapAccumulate[C, U]]
 
   /**
     * An abstraction for building an {@code Array} of known size. Guarantees a left-to-right traversal

--- a/src/main/scala/is/hail/utils/package.scala
+++ b/src/main/scala/is/hail/utils/package.scala
@@ -251,7 +251,8 @@ package object utils extends Logging
     }
   }
 
-  private object flattenOrNullInstance extends FlattenOrNull[Nothing]
+  // NB: can't use Nothing here because it is not a super type of Null
+  private object flattenOrNullInstance extends FlattenOrNull[Array]
 
   def flattenOrNull[C[_] >: Null] =
     flattenOrNullInstance.asInstanceOf[FlattenOrNull[C]]

--- a/src/main/scala/is/hail/utils/package.scala
+++ b/src/main/scala/is/hail/utils/package.scala
@@ -249,16 +249,23 @@ package object utils extends Logging
     b.result()
   }
 
-  def anyFailAllFail[C[_], T](ts: TraversableOnce[Option[T]])(implicit cbf: CanBuildFrom[Nothing, T, C[T]]): Option[C[T]] = {
-    val b = cbf()
-    for (t <- ts) {
-      if (t.isEmpty)
-        return None
-      else
-        b += t.get
+  sealed trait AnyFailAllFail[C[_]] {
+    def apply[T](ts: TraversableOnce[Option[T]])(implicit cbf: CanBuildFrom[Nothing, T, C[T]]): Option[C[T]] = {
+      val b = cbf()
+      for (t <- ts) {
+        if (t.isEmpty)
+          return None
+        else
+          b += t.get
+      }
+      Some(b.result())
     }
-    Some(b.result())
   }
+
+  private final object anyFailAllFailInstance extends AnyFailAllFail[Nothing]
+
+  def anyFailAllFail[C[_]]: AnyFailAllFail[C] =
+    anyFailAllFailInstance.asInstanceOf[AnyFailAllFail[C]]
 
   def uninitialized[T]: T = null.asInstanceOf[T]
 

--- a/src/main/scala/is/hail/variant/GenomeReference.scala
+++ b/src/main/scala/is/hail/variant/GenomeReference.scala
@@ -338,8 +338,8 @@ object GenomeReference {
   def gen: Gen[GenomeReference] = for {
     name <- Gen.identifier
     nContigs <- Gen.choose(3, 50)
-    contigs <- Gen.distinctBuildableOfN[Array, String](nContigs, Gen.identifier)
-    lengths <- Gen.distinctBuildableOfN[Array, Int](nContigs, Gen.choose(1000000, 500000000))
+    contigs <- Gen.distinctBuildableOfN[Array](nContigs, Gen.identifier)
+    lengths <- Gen.distinctBuildableOfN[Array](nContigs, Gen.choose(1000000, 500000000))
     contigsIndex = contigs.zip(lengths).toMap
     xContig <- Gen.oneOfSeq(contigs)
     yContig <- Gen.oneOfSeq((contigs.toSet - xContig).toSeq)
@@ -353,8 +353,8 @@ object GenomeReference {
         Integer.compare(x.position, y.position)
       }
     }
-    parX <- Gen.distinctBuildableOfN[Array, Interval[Locus]](2, Interval.gen(Locus.gen(xContig, contigsIndex(xContig)))(locusOrd))
-    parY <- Gen.distinctBuildableOfN[Array, Interval[Locus]](2, Interval.gen(Locus.gen(yContig, contigsIndex(yContig)))(locusOrd))
+    parX <- Gen.distinctBuildableOfN[Array](2, Interval.gen(Locus.gen(xContig, contigsIndex(xContig)))(locusOrd))
+    parY <- Gen.distinctBuildableOfN[Array](2, Interval.gen(Locus.gen(yContig, contigsIndex(yContig)))(locusOrd))
   } yield GenomeReference(name, contigs, contigs.zip(lengths).toMap, Set(xContig), Set(yContig), Set(mtContig),
     (parX ++ parY).map(i => (i.start, i.end)))
 

--- a/src/main/scala/is/hail/variant/Genotype.scala
+++ b/src/main/scala/is/hail/variant/Genotype.scala
@@ -328,12 +328,12 @@ object Genotype {
     val m = Int.MaxValue / (nAlleles + 1)
     val nGenotypes = triangle(nAlleles)
     val gg = for (gt: Option[Int] <- Gen.option(Gen.choose(0, nGenotypes - 1));
-      ad <- Gen.option(Gen.buildableOfN[Array, Int](nAlleles, Gen.choose(0, m)));
+      ad <- Gen.option(Gen.buildableOfN[Array](nAlleles, Gen.choose(0, m)));
       dp <- Gen.option(Gen.choose(0, m));
       gq <- Gen.option(Gen.choose(0, 10000));
       pl <- Gen.oneOfGen(
-        Gen.option(Gen.buildableOfN[Array, Int](nGenotypes, Gen.choose(0, m))),
-        Gen.option(Gen.buildableOfN[Array, Int](nGenotypes, Gen.choose(0, 100))))) yield {
+        Gen.option(Gen.buildableOfN[Array](nGenotypes, Gen.choose(0, m))),
+        Gen.option(Gen.buildableOfN[Array](nGenotypes, Gen.choose(0, 100))))) yield {
       gt.foreach { gtx =>
         pl.foreach { pla => pla(gtx) = 0 }
       }
@@ -365,17 +365,17 @@ object Genotype {
     val nAlleles = v.nAlleles
     val nGenotypes = triangle(nAlleles)
     val gg = for (callRate <- Gen.choose(0d, 1d);
-      alleleFrequencies <- Gen.buildableOfN[Array, Double](nAlleles, Gen.choose(1e-6, 1d)) // avoid divison by 0
+      alleleFrequencies <- Gen.buildableOfN[Array](nAlleles, Gen.choose(1e-6, 1d)) // avoid divison by 0
         .map { rawWeights =>
         val sum = rawWeights.sum
         rawWeights.map(_ / sum)
       };
       gt <- Gen.option(Gen.zip(Gen.chooseWithWeights(alleleFrequencies), Gen.chooseWithWeights(alleleFrequencies))
         .map { case (gti, gtj) => gtIndexWithSwap(gti, gtj) }, callRate);
-      ad <- Gen.option(Gen.buildableOfN[Array, Int](nAlleles,
+      ad <- Gen.option(Gen.buildableOfN[Array](nAlleles,
         Gen.choose(0, 50)));
       dp <- Gen.choose(0, 30).map(d => ad.map(o => o.sum + d));
-      pl <- Gen.option(Gen.buildableOfN[Array, Int](nGenotypes, Gen.choose(0, 1000)).map { arr =>
+      pl <- Gen.option(Gen.buildableOfN[Array](nGenotypes, Gen.choose(0, 1000)).map { arr =>
         gt match {
           case Some(i) =>
             arr(i) = 0

--- a/src/main/scala/is/hail/variant/Variant.scala
+++ b/src/main/scala/is/hail/variant/Variant.scala
@@ -158,7 +158,7 @@ case class VariantSubgen(
       start <- Gen.choose(1, length);
       nAlleles <- nAllelesGen;
       ref <- refGen;
-      altAlleles <- Gen.distinctBuildableOfN[Array, String](
+      altAlleles <- Gen.distinctBuildableOfN[Array](
         nAlleles - 1,
         altGen)
         .filter(!_.contains(ref))) yield

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -295,15 +295,15 @@ case class VSMSubgen(
       global <- globalGen(globalSig).resize(25);
       nPartitions <- Gen.choose(1, 10);
 
-      sampleIds <- Gen.buildableOfN[Array, Annotation](w, sGen(sSig).resize(3))
+      sampleIds <- Gen.buildableOfN[Array](w, sGen(sSig).resize(3))
         .map(ids => ids.distinct);
       nSamples = sampleIds.length;
-      saValues <- Gen.buildableOfN[Array, Annotation](nSamples, saGen(saSig).resize(5));
-      rows <- Gen.distinctBuildableOfN[Array, (Annotation, (Annotation, Iterable[Annotation]))](l,
+      saValues <- Gen.buildableOfN[Array](nSamples, saGen(saSig).resize(5));
+      rows <- Gen.distinctBuildableOfN[Array](l,
         for (
           v <- vGen(vSig).resize(3);
           va <- vaGen(vaSig).resize(5);
-          ts <- Gen.buildableOfN[Array, Annotation](nSamples, tGen(tSig, v).resize(3)))
+          ts <- Gen.buildableOfN[Array](nSamples, tGen(tSig, v).resize(3)))
           yield (v, (va, ts: Iterable[Annotation]))))
       yield {
         assert(sampleIds.forall(_ != null))

--- a/src/test/scala/is/hail/annotations/UnsafeSuite.scala
+++ b/src/test/scala/is/hail/annotations/UnsafeSuite.scala
@@ -348,7 +348,7 @@ class UnsafeSuite extends SparkSuite {
   @Test def testRegionSer() {
     val region = Region()
     val path = tmpDir.createTempFile(extension = "ser")
-    val g = Gen.buildableOf[Array, Byte](arbitrary[Byte])
+    val g = Gen.buildableOf[Array](arbitrary[Byte])
     val p = Prop.forAll(g) { (a: Array[Byte]) =>
       region.clear()
       region.appendBytes(a)
@@ -376,7 +376,7 @@ class UnsafeSuite extends SparkSuite {
 
     val region = Region()
     val path = tmpDir.createTempFile(extension = "ser")
-    val g = Gen.buildableOf[Array, Byte](arbitrary[Byte])
+    val g = Gen.buildableOf[Array](arbitrary[Byte])
     val p = Prop.forAll(g) { (a: Array[Byte]) =>
       region.clear()
       region.appendBytes(a)

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -49,7 +49,7 @@ class BlockMatrixSuite extends SparkSuite {
   ): Gen[BlockMatrix] = for {
     blockSize <- blockSize
     (rows, columns) <- dims
-    arrays <- buildableOfN[Seq](rows, buildableOfN(columns, element))
+    arrays <- buildableOfN[Seq](rows, buildableOfN[Array](columns, element))
     m = toBM(arrays, blockSize)
   } yield m
 

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -49,7 +49,7 @@ class BlockMatrixSuite extends SparkSuite {
   ): Gen[BlockMatrix] = for {
     blockSize <- blockSize
     (rows, columns) <- dims
-    arrays <- buildableOfN[Seq, Array[Double]](rows, buildableOfN(columns, element))
+    arrays <- buildableOfN[Seq](rows, buildableOfN(columns, element))
     m = toBM(arrays, blockSize)
   } yield m
 
@@ -230,7 +230,7 @@ class BlockMatrixSuite extends SparkSuite {
   def rowwiseMultiplicationRandom() {
     val g = for {
       l <- blockMatrixGen()
-      v <- buildableOfN[Array, Double](l.cols.toInt, arbitrary[Double])
+      v <- buildableOfN[Array](l.cols.toInt, arbitrary[Double])
     } yield (l, v)
 
     forAll(g) { case (l: BlockMatrix, v: Array[Double]) =>
@@ -266,7 +266,7 @@ class BlockMatrixSuite extends SparkSuite {
   def colwiseMultiplicationRandom() {
     val g = for {
       l <- blockMatrixGen()
-      v <- buildableOfN[Array, Double](l.rows.toInt, arbitrary[Double])
+      v <- buildableOfN[Array](l.rows.toInt, arbitrary[Double])
     } yield (l, v)
 
     forAll(g) { case (l: BlockMatrix, v: Array[Double]) =>

--- a/src/test/scala/is/hail/io/ExportVCFSuite.scala
+++ b/src/test/scala/is/hail/io/ExportVCFSuite.scala
@@ -296,7 +296,7 @@ class ExportVCFSuite extends SparkSuite {
       TSet(TInt32()), TSet(TFloat32()), TSet(TFloat64()), TSet(TString()), TSet(TCall()))
   
   def genFormatStructVCF: Gen[TStruct] =
-    Gen.buildableOf[Array, (String, Type)](
+    Gen.buildableOf[Array](
       Gen.zip(Gen.identifier, genFormatFieldVCF))
       .filter(fields => fields.map(_._1).areDistinct())
       .map(fields => TStruct(fields

--- a/src/test/scala/is/hail/io/LoadBgenSuite.scala
+++ b/src/test/scala/is/hail/io/LoadBgenSuite.scala
@@ -224,7 +224,7 @@ class LoadBgenSuite extends SparkSuite {
       nGenotypes <- Gen.choose(3, 5);
       nProbabilities = nSamples * (nGenotypes - 1);
       totalProb = ((1L << nBitsPerProb) - 1).toUInt;
-      sampleProbs <- Gen.buildableOfN[Array, Array[UInt]](nSamples, Gen.partition(nGenotypes - 1, totalProb));
+      sampleProbs <- Gen.buildableOfN[Array](nSamples, Gen.partition(nGenotypes - 1, totalProb));
       input = sampleProbs.flatten
     ) yield (nBitsPerProb, nSamples, nGenotypes, input)
 

--- a/src/test/scala/is/hail/io/SplitSuite.scala
+++ b/src/test/scala/is/hail/io/SplitSuite.scala
@@ -16,7 +16,7 @@ class SplitSuite extends SparkSuite {
       start <- Gen.choose(1, 100)
       motif <- Gen.oneOf("AT", "AC", "CT", "GA", "GT", "CCA", "CAT", "CCT")
       ref <- Gen.choose(1, 10).map(motif * _)
-      alts <- Gen.distinctBuildableOf[Array, AltAllele](Gen.choose(1, 10).map(motif * _).filter(_ != ref).map(a => AltAllele(ref, a)))
+      alts <- Gen.distinctBuildableOf[Array](Gen.choose(1, 10).map(motif * _).filter(_ != ref).map(a => AltAllele(ref, a)))
     } yield Variant(contig, start, ref, alts)
 
     property("splitMulti maintains variants") = forAll(VariantSampleMatrix.gen(hc,

--- a/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
+++ b/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
@@ -91,7 +91,7 @@ class BGzipCodecSuite extends SparkSuite {
     val g = for (n <- Gen.oneOfGen(
       Gen.choose(0, 10),
       Gen.choose(0, 100));
-      rawSplits <- Gen.buildableOfN[Array, Long](n,
+      rawSplits <- Gen.buildableOfN[Array](n,
         Gen.oneOfGen(Gen.choose(0, compLength),
           Gen.applyGen(Gen.oneOf[(Long) => Long](identity, _ - 1, _ + 1),
             Gen.oneOfSeq(compSplits)))))

--- a/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
+++ b/src/test/scala/is/hail/io/compress/BGzipCodecSuite.scala
@@ -92,7 +92,7 @@ class BGzipCodecSuite extends SparkSuite {
       Gen.choose(0, 10),
       Gen.choose(0, 100));
       rawSplits <- Gen.buildableOfN[Array](n,
-        Gen.oneOfGen(Gen.choose(0, compLength),
+        Gen.oneOfGen(Gen.choose(0L, compLength),
           Gen.applyGen(Gen.oneOf[(Long) => Long](identity, _ - 1, _ + 1),
             Gen.oneOfSeq(compSplits)))))
       yield

--- a/src/test/scala/is/hail/methods/ConcordanceSuite.scala
+++ b/src/test/scala/is/hail/methods/ConcordanceSuite.scala
@@ -113,7 +113,7 @@ class ConcordanceSuite extends SparkSuite {
   @Test def testNDiscordant() {
     val g = (for {i <- Gen.choose(-2, 2)
       j <- Gen.choose(-2, 2)} yield (i, j)).filter { case (i, j) => !(i == -2 && j == -2) }
-    val seqG = Gen.buildableOf[Array, (Int, Int)](g)
+    val seqG = Gen.buildableOf[Array](g)
 
     val comb = new ConcordanceCombiner
 

--- a/src/test/scala/is/hail/methods/LDPruneSuite.scala
+++ b/src/test/scala/is/hail/methods/LDPruneSuite.scala
@@ -218,8 +218,8 @@ class LDPruneSuite extends SparkSuite {
       nPartitions: Int <- Gen.choose(5, 10)) yield (r2, windowSize, nPartitions)
 
     val vectorGen = for (nSamples: Int <- Gen.choose(1, 1000);
-      v1: Array[Int] <- Gen.buildableOfN[Array, Int](nSamples, Gen.choose(-1, 2));
-      v2: Array[Int] <- Gen.buildableOfN[Array, Int](nSamples, Gen.choose(-1, 2))
+      v1: Array[Int] <- Gen.buildableOfN[Array](nSamples, Gen.choose(-1, 2));
+      v2: Array[Int] <- Gen.buildableOfN[Array](nSamples, Gen.choose(-1, 2))
     ) yield (nSamples, v1, v2)
 
     property("bitPacked pack and unpack give same as orig") =

--- a/src/test/scala/is/hail/utils/BitVectorSuite.scala
+++ b/src/test/scala/is/hail/utils/BitVectorSuite.scala
@@ -22,7 +22,7 @@ class BitVectorSuite extends TestNGSuite {
     val g =
       for (
         n <- Gen.choose(1, 1000);
-        s <- Gen.buildableOf[Set, Int](Gen.choose(0, n - 1))
+        s <- Gen.buildableOf[Set](Gen.choose(0, n - 1))
       ) yield {
         val bv = new BitVector(n)
 

--- a/src/test/scala/is/hail/utils/OrderedRDDSuite.scala
+++ b/src/test/scala/is/hail/utils/OrderedRDDSuite.scala
@@ -34,7 +34,7 @@ class OrderedRDDSuite extends SparkSuite {
       yield Variant("16", pos, "A", alt)
 
     val g = for (uniqueVariants <- Gen.buildableOf[Set](v).map(set => set.toIndexedSeq);
-      toZip <- Gen.buildableOfN[IndexedSeq, String](uniqueVariants.size, arbitrary[String]);
+      toZip <- Gen.buildableOfN[IndexedSeq](uniqueVariants.size, arbitrary[String]);
       nPar <- Gen.choose(1, 10)) yield (nPar, uniqueVariants.zip(toZip))
 
     val random = for ((n, v) <- g;
@@ -189,7 +189,7 @@ class OrderedRDDSuite extends SparkSuite {
       } yield Variant("1", pos, "A", alt)
 
       val localG = for (variants <- Gen.buildableOf[Array](localV).map(x => x: IndexedSeq[Variant]);
-        toZip <- Gen.buildableOfN[Array, String](variants.size, arbitrary[String]);
+        toZip <- Gen.buildableOfN[Array](variants.size, arbitrary[String]);
         nPar <- Gen.choose(1, 10)) yield (nPar, variants.zip(toZip))
 
       Prop.forAll(localG, localG) { case ((n1, left), (n2, right)) => checkLeftJoin(n1, left, n2, right) }
@@ -201,7 +201,7 @@ class OrderedRDDSuite extends SparkSuite {
       yield Variant("16", pos, "A", alt)
 
     val g2 = for (uniqueVariants <- Gen.buildableOf[Set](v2).map(set => set.toIndexedSeq);
-      toZip <- Gen.buildableOfN[IndexedSeq, String](uniqueVariants.size, arbitrary[String]);
+      toZip <- Gen.buildableOfN[IndexedSeq](uniqueVariants.size, arbitrary[String]);
       nPar <- Gen.choose(1, 10)) yield (nPar, uniqueVariants.zip(toZip))
 
     property("join2") = Prop.forAll(g, g2) { case ((nPar1, is1), (nPar2, is2)) =>

--- a/src/test/scala/is/hail/utils/OrderedRDDSuite.scala
+++ b/src/test/scala/is/hail/utils/OrderedRDDSuite.scala
@@ -33,7 +33,7 @@ class OrderedRDDSuite extends SparkSuite {
       alt <- Gen.oneOfGen(Gen.const("T"), Gen.const("C"), Gen.const("G"), Gen.const("TTT"), Gen.const("ATA")))
       yield Variant("16", pos, "A", alt)
 
-    val g = for (uniqueVariants <- Gen.buildableOf[Set, Variant](v).map(set => set.toIndexedSeq);
+    val g = for (uniqueVariants <- Gen.buildableOf[Set](v).map(set => set.toIndexedSeq);
       toZip <- Gen.buildableOfN[IndexedSeq, String](uniqueVariants.size, arbitrary[String]);
       nPar <- Gen.choose(1, 10)) yield (nPar, uniqueVariants.zip(toZip))
 
@@ -188,7 +188,7 @@ class OrderedRDDSuite extends SparkSuite {
         alt <- Gen.oneOf("T", "C")
       } yield Variant("1", pos, "A", alt)
 
-      val localG = for (variants <- Gen.buildableOf[Array, Variant](localV).map(x => x: IndexedSeq[Variant]);
+      val localG = for (variants <- Gen.buildableOf[Array](localV).map(x => x: IndexedSeq[Variant]);
         toZip <- Gen.buildableOfN[Array, String](variants.size, arbitrary[String]);
         nPar <- Gen.choose(1, 10)) yield (nPar, variants.zip(toZip))
 
@@ -200,7 +200,7 @@ class OrderedRDDSuite extends SparkSuite {
       alt <- Gen.oneOfGen(Gen.const("T"), Gen.const("C"), Gen.const("G"), Gen.const("TTT"), Gen.const("ATA")))
       yield Variant("16", pos, "A", alt)
 
-    val g2 = for (uniqueVariants <- Gen.buildableOf[Set, Variant](v2).map(set => set.toIndexedSeq);
+    val g2 = for (uniqueVariants <- Gen.buildableOf[Set](v2).map(set => set.toIndexedSeq);
       toZip <- Gen.buildableOfN[IndexedSeq, String](uniqueVariants.size, arbitrary[String]);
       nPar <- Gen.choose(1, 10)) yield (nPar, uniqueVariants.zip(toZip))
 

--- a/src/test/scala/is/hail/utils/UtilsSuite.scala
+++ b/src/test/scala/is/hail/utils/UtilsSuite.scala
@@ -105,7 +105,7 @@ class UtilsSuite extends SparkSuite {
 
   @Test def testLeftJoinIterators() {
     val g = for (uniqueInts <- Gen.buildableOf[Set](Gen.choose(0, 1000)).map(set => set.toIndexedSeq.sorted);
-      toZip <- Gen.buildableOfN[IndexedSeq, String](uniqueInts.size, arbitrary[String])
+      toZip <- Gen.buildableOfN[IndexedSeq](uniqueInts.size, arbitrary[String])
     ) yield {
       uniqueInts.zip(toZip)
     }
@@ -127,7 +127,7 @@ class UtilsSuite extends SparkSuite {
   @Test def testKeySortIterator() {
     val g = for {
       gr <- GenomeReference.gen
-      seq <- Gen.distinctBuildableOf[IndexedSeq, (Variant, Int)](Gen.zip(VariantSubgen.fromGenomeRef(gr).gen, arbitrary[Int]))
+      seq <- Gen.distinctBuildableOf[IndexedSeq](Gen.zip(VariantSubgen.fromGenomeRef(gr).gen, arbitrary[Int]))
     } yield (gr, seq)
 
     val p = Prop.forAll(g) { case (gr, indSeq) =>

--- a/src/test/scala/is/hail/utils/UtilsSuite.scala
+++ b/src/test/scala/is/hail/utils/UtilsSuite.scala
@@ -104,7 +104,7 @@ class UtilsSuite extends SparkSuite {
   }
 
   @Test def testLeftJoinIterators() {
-    val g = for (uniqueInts <- Gen.buildableOf[Set, Int](Gen.choose(0, 1000)).map(set => set.toIndexedSeq.sorted);
+    val g = for (uniqueInts <- Gen.buildableOf[Set](Gen.choose(0, 1000)).map(set => set.toIndexedSeq.sorted);
       toZip <- Gen.buildableOfN[IndexedSeq, String](uniqueInts.size, arbitrary[String])
     ) yield {
       uniqueInts.zip(toZip)
@@ -164,8 +164,8 @@ class UtilsSuite extends SparkSuite {
     val g = for {
       gr <- GenomeReference.gen
       v = VariantSubgen.fromGenomeRef(gr).gen
-      a1 <- Gen.buildableOf[Array, Variant](v)
-      a2 <- Gen.buildableOf[Array, Variant](v)
+      a1 <- Gen.buildableOf[Array](v)
+      a2 <- Gen.buildableOf[Array](v)
     } yield (gr, a1, a2)
 
     val p = Prop.forAll(g) {
@@ -260,7 +260,7 @@ class UtilsSuite extends SparkSuite {
   }
 
   @Test def testCollectAsSet() {
-    Prop.forAll(Gen.buildableOf[Array, Int](Gen.choose(-1000, 1000)), Gen.choose(1, 10)) { case (values, parts) =>
+    Prop.forAll(Gen.buildableOf[Array](Gen.choose(-1000, 1000)), Gen.choose(1, 10)) { case (values, parts) =>
       val rdd = sc.parallelize(values, numSlices = parts)
       rdd.collectAsSet() == rdd.collect().toSet
     }.check()
@@ -289,7 +289,7 @@ class UtilsSuite extends SparkSuite {
 
   @Test def testBinarySearch() {
     val g = for {
-      a <- Gen.buildableOf[Array, Int](arbitrary[Int])
+      a <- Gen.buildableOf[Array](arbitrary[Int])
       s = a.sorted
       i <- Gen.choose(0, a.length - 1)
       v <- arbitrary[Int]

--- a/src/test/scala/is/hail/variant/IntervalSuite.scala
+++ b/src/test/scala/is/hail/variant/IntervalSuite.scala
@@ -162,7 +162,7 @@ class IntervalSuite extends SparkSuite {
       end <- Gen.choose(start, endPos))
       yield Interval(Locus("22", start), Locus("22", end))
     val intervalsGen = for (nIntervals <- Gen.choose(0, 10);
-      g <- Gen.buildableOfN[Array, Interval[Locus]](nIntervals, intervalGen)) yield g
+      g <- Gen.buildableOfN[Array](nIntervals, intervalGen)) yield g
 
     Prop.forAll(intervalsGen.filter(_.nonEmpty)) { intervals =>
       hadoopConf.writeTextFile(iList) { out =>


### PR DESCRIPTION
The core issue is that we want Scala to infer the T parameter
but not the C[_] parameter. Unfortunately, Scala does not provide
a facility to partially specify type parameters of a method
the changes herein achieve this with no run-time allocation
one cast, and one level of indirection.