### PR TITLE
moved PCA / PCRelate from spark to breeze dense matrices, other improvements

### DIFF
--- a/src/main/scala/is/hail/methods/PCA.scala
+++ b/src/main/scala/is/hail/methods/PCA.scala
@@ -7,7 +7,6 @@ import is.hail.keytable.KeyTable
 import is.hail.utils._
 import is.hail.variant.VariantSampleMatrix
 
-
 object PCA {
   def pcSchema(k: Int, asArray: Boolean = false): Type =
     if (asArray)
@@ -52,10 +51,12 @@ object PCA {
       new KeyTable(vsm.hc, rdd, rowType, Array("v"))
     })
 
+    val data =
+      if (!svd.V.isTransposed)
+        svd.V.asInstanceOf[org.apache.spark.mllib.linalg.DenseMatrix].values
+      else
+        svd.V.toArray
     
-
-    assert(!svd.V.isTransposed)
-    val data = svd.V.asInstanceOf[org.apache.spark.mllib.linalg.DenseMatrix].values
     val V = new DenseMatrix[Double](svd.V.numRows, svd.V.numCols, data)
     val S = DenseVector(svd.s.toArray)
 

--- a/src/main/scala/is/hail/methods/PCA.scala
+++ b/src/main/scala/is/hail/methods/PCA.scala
@@ -1,11 +1,12 @@
 package is.hail.methods
 
+import breeze.linalg.{*, DenseMatrix, DenseVector}
 import is.hail.annotations._
 import is.hail.expr._
 import is.hail.keytable.KeyTable
 import is.hail.utils._
 import is.hail.variant.VariantSampleMatrix
-import org.apache.spark.mllib.linalg.DenseMatrix
+
 
 object PCA {
   def pcSchema(k: Int, asArray: Boolean = false): Type =
@@ -15,10 +16,10 @@ object PCA {
       TStruct((1 to k).map(i => (s"PC$i", TFloat64())): _*)
 
   //returns (sample scores, variant loadings, eigenvalues)
-  def apply(vsm: VariantSampleMatrix, expr: String, k: Int, computeLoadings: Boolean, asArray: Boolean = false): (IndexedSeq[Double], DenseMatrix, Option[KeyTable]) = {
+  def apply(vsm: VariantSampleMatrix, expr: String, k: Int, computeLoadings: Boolean, asArray: Boolean = false): (IndexedSeq[Double], DenseMatrix[Double], Option[KeyTable]) = {
     val sc = vsm.sparkContext
-    val (maybeVariants, mat) = vsm.toIndexedRowMatrix(expr, computeLoadings)
-    val svd = mat.computeSVD(k, computeLoadings)
+    val (irm, optionVariants) = vsm.toIndexedRowMatrix(expr, computeLoadings)
+    val svd = irm.computeSVD(k, computeLoadings)
     if (svd.s.size < k)
       fatal(
         s"""Found only ${ svd.s.size } non-zero (or nearly zero) eigenvalues, but user requested ${ k }
@@ -27,7 +28,7 @@ object PCA {
     val optionLoadings = someIf(computeLoadings, {
       val rowType = TStruct("v" -> vsm.vSignature, "pcaLoadings" -> pcSchema(k, asArray))
       val rowTypeBc = vsm.sparkContext.broadcast(rowType)
-      val variantsBc = vsm.sparkContext.broadcast(maybeVariants.get)
+      val variantsBc = vsm.sparkContext.broadcast(optionVariants.get)
       val rdd = svd.U.rows.mapPartitions[RegionValue] { it =>
         val region = Region()
         val rv = RegionValue(region)
@@ -51,6 +52,16 @@ object PCA {
       new KeyTable(vsm.hc, rdd, rowType, Array("v"))
     })
 
-    (svd.s.toArray.map(math.pow(_, 2)), svd.V.multiply(DenseMatrix.diag(svd.s)), optionLoadings)
+    
+
+    assert(!svd.V.isTransposed)
+    val data = svd.V.asInstanceOf[org.apache.spark.mllib.linalg.DenseMatrix].values
+    val V = new DenseMatrix[Double](svd.V.numRows, svd.V.numCols, data)
+    val S = DenseVector(svd.s.toArray)
+
+    val eigenvalues = svd.s.toArray.map(math.pow(_, 2))
+    val scaledEigenvectors = V(*, ::) :* S
+    
+    (eigenvalues, scaledEigenvectors, optionLoadings)
   }
 }

--- a/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
@@ -6,15 +6,7 @@ import breeze.linalg.DenseMatrix
 import is.hail.annotations.Memory
 import is.hail.utils.ArrayBuilder
 
-object RichDenseMatrixDouble {
-  def horzcat(oms: Option[DenseMatrix[Double]]*): Option[DenseMatrix[Double]] = {
-    val ms = oms.flatten
-    if (ms.isEmpty)
-      None
-    else
-      Some(DenseMatrix.horzcat(ms: _*))
-  }
-  
+object RichDenseMatrixDouble {  
   // copies n doubles as bytes from data to dos
   def writeDoubles(dos: DataOutputStream, data: Array[Double], n: Int) {
     assert(n <= data.length)

--- a/src/test/scala/is/hail/methods/PCASuite.scala
+++ b/src/test/scala/is/hail/methods/PCASuite.scala
@@ -1,19 +1,22 @@
 package is.hail.methods
 
+import breeze.linalg.DenseMatrix
 import is.hail.SparkSuite
 import is.hail.annotations.Annotation
 import is.hail.expr.{TArray, TFloat64, TStruct}
 import is.hail.keytable.KeyTable
 import is.hail.variant.{Variant, VariantSampleMatrix}
-import org.apache.spark.mllib.linalg.DenseMatrix
 import org.testng.annotations.Test
 
 object PCASuite {
-  def samplePCA(vsm: VariantSampleMatrix, k: Int = 10, computeLoadings: Boolean = false, asArray: Boolean = false): (IndexedSeq[Double], DenseMatrix, Option[KeyTable]) = {
+  def samplePCA(vsm: VariantSampleMatrix, k: Int = 10, computeLoadings: Boolean = false, 
+    asArray: Boolean = false): (IndexedSeq[Double], DenseMatrix[Double], Option[KeyTable]) = {
+    
     val prePCA = vsm.annotateVariantsExpr("va.AC = gs.map(g => g.GT.gt).sum(), va.nCalled = gs.filter(g => isDefined(g.GT)).count()")
       .filterVariantsExpr("va.AC > 0 && va.AC < 2 * va.nCalled").persist()
     val nVariants = prePCA.countVariants()
     val expr = s"let mean = va.AC / va.nCalled in if (isDefined(g.GT)) (g.GT.gt - mean) / sqrt(mean * (2 - mean) * $nVariants / 2) else 0"
+    
     PCA(prePCA, expr, k, computeLoadings, asArray)
   }
 }
@@ -60,8 +63,8 @@ class PCASuite extends SparkSuite {
     val vds = hc.importVCF("src/test/resources/tiny_m.vcf").filterMulti()
     val (eigenvalues, scores, loadings) = PCA(vds, "if (isDefined(g.GT)) g.GT.gt else 0", 3, true, true)
 
-    println(scores)
-    println(loadings.get.collect())
-    println(eigenvalues)
+//    println(scores)
+//    println(loadings.get.collect())
+//    println(eigenvalues)
   }
 }

--- a/src/test/scala/is/hail/methods/PCASuite.scala
+++ b/src/test/scala/is/hail/methods/PCASuite.scala
@@ -62,9 +62,5 @@ class PCASuite extends SparkSuite {
   @Test def testExpr() {
     val vds = hc.importVCF("src/test/resources/tiny_m.vcf").filterMulti()
     val (eigenvalues, scores, loadings) = PCA(vds, "if (isDefined(g.GT)) g.GT.gt else 0", 3, true, true)
-
-//    println(scores)
-//    println(loadings.get.collect())
-//    println(eigenvalues)
   }
 }


### PR DESCRIPTION
-pulled PCA and PCRelate from Spark to Breeze DenseMatrix
-improved PCA math to not realize diagonal matrix when rescaling scores
-deleted unused horzcat on RichDenseMatrix
-improved formatting/readability