### PR TITLE
Add one-stop-shopping Compile interface to ir.

### DIFF
--- a/src/main/scala/is/hail/annotations/Region.scala
+++ b/src/main/scala/is/hail/annotations/Region.scala
@@ -238,6 +238,16 @@ final class Region(private var mem: Array[Byte], private var end: Long = 0) exte
   def appendString(s: String): Long =
     appendBinary(s.getBytes)
 
+  def appendArrayInt(a: Array[Int]): Long = {
+    val off = appendInt(a.length)
+    var i = 0
+    while (i < a.length) {
+      appendInt(a(i))
+      i += 1
+    }
+    off
+  }
+
   def clear(newEnd: Long) {
     assert(newEnd <= end)
     end = newEnd

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -15,8 +15,6 @@ import org.apache.spark.SparkContext
 import org.apache.spark.broadcast.Broadcast
 import org.json4s.jackson.JsonMethods
 
-import scala.reflect.{ClassTag, classTag}
-
 case class MatrixType(
   metadata: VSMMetadata) extends BaseType {
   def globalType: Type = metadata.globalSignature

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -2,6 +2,7 @@ package is.hail.expr
 
 import is.hail.HailContext
 import is.hail.annotations._
+import is.hail.asm4s.FunctionBuilder
 import is.hail.expr.ir._
 import is.hail.keytable.KTLocalValue
 import is.hail.methods.Aggregators

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -1,0 +1,35 @@
+package is.hail.expr.ir
+
+import is.hail.annotations.Region
+import is.hail.asm4s.{AsmFunction5, FunctionBuilder, GenericTypeInfo, TypeInfo}
+import is.hail.expr.{HailRep, Type, ir}
+
+import scala.reflect.{ClassTag, classTag}
+
+case class RegionValueRep[RVT: ClassTag](typ: Type) {
+  assert(TypeToPrimitiveClassTag(typ) == classTag[RVT])
+}
+
+case class ScalaRep[T, RVT: ClassTag](implicit hr: HailRep[T]) {
+  assert(TypeToPrimitiveClassTag(hr.typ) == classTag[RVT])
+}
+
+object Compile {
+  def apply[T0: TypeInfo, T1: TypeInfo, R: TypeInfo](name0: String, rep0: RegionValueRep[T0], name1: String, rep1: RegionValueRep[T1], rRep: RegionValueRep[R], body: ir.IR): () => AsmFunction5[Region, T0, Boolean, T1, Boolean, R] = {
+    val fb = new FunctionBuilder[AsmFunction5[Region, T0, Boolean, T1, Boolean, R]](Array(
+      GenericTypeInfo[Region](),
+      GenericTypeInfo[T0](), GenericTypeInfo[Boolean](),
+      GenericTypeInfo[T1](), GenericTypeInfo[Boolean]()),
+      GenericTypeInfo[R]())
+
+    var e = body
+    val env = new Env[IR]()
+      .bind(name0, In(0, rep0.typ))
+      .bind(name1, In(1, rep1.typ))
+    e = Subst(e, env)
+    ir.Infer(e)
+    assert(e.typ == rRep.typ)
+    ir.Emit(e, fb)
+    fb.result()
+  }
+}

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -1,35 +1,26 @@
 package is.hail.expr.ir
 
 import is.hail.annotations.Region
-import is.hail.asm4s.{AsmFunction5, FunctionBuilder, GenericTypeInfo, TypeInfo}
-import is.hail.expr.{HailRep, Type, ir}
+import is.hail.asm4s.{AsmFunction5, FunctionBuilder, TypeInfo}
+import is.hail.expr.Type
 
 import scala.reflect.{ClassTag, classTag}
 
 case class RegionValueRep[RVT: ClassTag](typ: Type) {
-  assert(TypeToPrimitiveClassTag(typ) == classTag[RVT])
-}
-
-case class ScalaRep[T, RVT: ClassTag](implicit hr: HailRep[T]) {
-  assert(TypeToPrimitiveClassTag(hr.typ) == classTag[RVT])
+  assert(TypeToIRIntermediateClassTag(typ) == classTag[RVT])
 }
 
 object Compile {
-  def apply[T0: TypeInfo, T1: TypeInfo, R: TypeInfo](name0: String, rep0: RegionValueRep[T0], name1: String, rep1: RegionValueRep[T1], rRep: RegionValueRep[R], body: ir.IR): () => AsmFunction5[Region, T0, Boolean, T1, Boolean, R] = {
-    val fb = new FunctionBuilder[AsmFunction5[Region, T0, Boolean, T1, Boolean, R]](Array(
-      GenericTypeInfo[Region](),
-      GenericTypeInfo[T0](), GenericTypeInfo[Boolean](),
-      GenericTypeInfo[T1](), GenericTypeInfo[Boolean]()),
-      GenericTypeInfo[R]())
-
+  def apply[T0: TypeInfo, T1: TypeInfo, R: TypeInfo](name0: String, rep0: RegionValueRep[T0], name1: String, rep1: RegionValueRep[T1], rRep: RegionValueRep[R], body: IR): () => AsmFunction5[Region, T0, Boolean, T1, Boolean, R] = {
+    val fb = FunctionBuilder.functionBuilder[Region, T0, Boolean, T1, Boolean, R]
     var e = body
     val env = new Env[IR]()
       .bind(name0, In(0, rep0.typ))
       .bind(name1, In(1, rep1.typ))
     e = Subst(e, env)
-    ir.Infer(e)
+    Infer(e)
     assert(e.typ == rRep.typ)
-    ir.Emit(e, fb)
+    Emit(e, fb)
     fb.result()
   }
 }

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -19,15 +19,6 @@ object Emit {
     case _ => 0L // reference types
   }
 
-  private def typeToTypeInfo(t: expr.Type): TypeInfo[_] = t match {
-    case _: TInt32 => typeInfo[Int]
-    case _: TInt64 => typeInfo[Long]
-    case _: TFloat32 => typeInfo[Float]
-    case _: TFloat64 => typeInfo[Double]
-    case _: TBoolean => typeInfo[Boolean]
-    case _ => typeInfo[Long] // reference types
-  }
-
   type E = Env[(TypeInfo[_], Code[Boolean], Code[_])]
 
   def apply(ir: IR, fb: FunctionBuilder[_]) {

--- a/src/main/scala/is/hail/expr/ir/Env.scala
+++ b/src/main/scala/is/hail/expr/ir/Env.scala
@@ -10,9 +10,13 @@ class Env[V] private (val m: Map[Env.K,V]) {
     this(Map())
   }
 
-  def lookup(name: String) =
+  def lookup(name: String): V =
     m.get(name)
       .getOrElse(throw new RuntimeException(s"Cannot find $name in $m"))
+
+  def lookupOption(name: String): Option[V] = m.get(name)
+
+  def delete(name: String): Env[V] = new Env(m - name)
 
   def lookup(r: Ref): V =
     lookup(r.name)

--- a/src/main/scala/is/hail/expr/ir/Subst.scala
+++ b/src/main/scala/is/hail/expr/ir/Subst.scala
@@ -1,21 +1,21 @@
 package is.hail.expr.ir
 
 object Subst {
-  def apply(e: IR): IR = apply(e, new Env[IR]())
+  def apply(e: IR): IR = apply(e, Env.empty)
   def apply(e: IR, env: Env[IR]): IR = {
-    def infer(e: IR, env: Env[IR] = env): IR = apply(e, env)
+    def subst(e: IR, env: Env[IR] = env): IR = apply(e, env)
     e match {
       case x@Ref(name, _) => env.lookupOption(name).getOrElse(x)
       case Let(name, v, body, _) =>
-        Let(name, infer(v), infer(body, env.delete(name)))
+        Let(name, subst(v), subst(body, env.delete(name)))
       case MapNA(name, v, body, _) =>
-        MapNA(name, infer(v), infer(body, env.delete(name)))
+        MapNA(name, subst(v), subst(body, env.delete(name)))
       case ArrayMap(a, name, body, _) =>
-        ArrayMap(infer(a), name, infer(body, env.delete(name)))
+        ArrayMap(subst(a), name, subst(body, env.delete(name)))
       case ArrayFold(a, zero, accumName, valueName, body, _) =>
-        ArrayFold(infer(a), infer(zero), accumName, valueName, infer(body, env.delete(accumName).delete(valueName)))
+        ArrayFold(subst(a), subst(zero), accumName, valueName, subst(body, env.delete(accumName).delete(valueName)))
       case _ =>
-        Recur(infer(_))(e)
+        Recur(subst(_))(e)
     }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/Subst.scala
+++ b/src/main/scala/is/hail/expr/ir/Subst.scala
@@ -1,0 +1,21 @@
+package is.hail.expr.ir
+
+object Subst {
+  def apply(e: IR): IR = apply(e, new Env[IR]())
+  def apply(e: IR, env: Env[IR]): IR = {
+    def infer(e: IR, env: Env[IR] = env): IR = apply(e, env)
+    e match {
+      case x@Ref(name, _) => env.lookupOption(name).getOrElse(x)
+      case Let(name, v, body, _) =>
+        Let(name, infer(v), infer(body, env.delete(name)))
+      case MapNA(name, v, body, _) =>
+        MapNA(name, infer(v), infer(body, env.delete(name)))
+      case ArrayMap(a, name, body, _) =>
+        ArrayMap(infer(a), name, infer(body, env.delete(name)))
+      case ArrayFold(a, zero, accumName, valueName, body, _) =>
+        ArrayFold(infer(a), infer(zero), accumName, valueName, infer(body, env.delete(accumName).delete(valueName)))
+      case _ =>
+        Recur(infer(_))(e)
+    }
+  }
+}

--- a/src/main/scala/is/hail/expr/ir/TypeToIRIntermediateClassTag.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeToIRIntermediateClassTag.scala
@@ -4,7 +4,7 @@ import is.hail.expr.{TArray, TBoolean, TFloat32, TFloat64, TInt32, TInt64, TStru
 
 import scala.reflect.{ClassTag, classTag}
 
-object TypeToPrimitiveClassTag {
+object TypeToIRIntermediateClassTag {
   def apply(t: Type): ClassTag[_] = t.fundamentalType match {
     case _: TBoolean => classTag[Boolean]
     case _: TInt32 => classTag[Int]

--- a/src/main/scala/is/hail/expr/ir/TypeToPrimitiveClassTag.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeToPrimitiveClassTag.scala
@@ -1,0 +1,16 @@
+package is.hail.expr.ir
+
+import is.hail.expr.{TArray, TBoolean, TFloat32, TFloat64, TInt32, TInt64, TStruct, Type}
+
+import scala.reflect.{ClassTag, classTag}
+
+object TypeToPrimitiveClassTag {
+  def apply(t: Type): ClassTag[_] = t.fundamentalType match {
+    case _: TBoolean => classTag[Boolean]
+    case _: TInt32 => classTag[Int]
+    case _: TInt64 => classTag[Long]
+    case _: TFloat32 => classTag[Float]
+    case _: TFloat64 => classTag[Double]
+    case _: TStruct | _: TArray => classTag[Long]
+  }
+}

--- a/src/main/scala/is/hail/expr/ir/package.scala
+++ b/src/main/scala/is/hail/expr/ir/package.scala
@@ -1,7 +1,29 @@
 package is.hail.expr
 
 import is.hail.asm4s._
+import is.hail.expr
 
 package object ir {
   def coerce[T](x: Code[_]): Code[T] = x.asInstanceOf[Code[T]]
+
+  def typeToTypeInfo(t: expr.Type): TypeInfo[_] = t match {
+    case _: TBoolean => typeInfo[Boolean]
+    case _: TInt32 => typeInfo[Int]
+    case _: TInt64 => typeInfo[Long]
+    case _: TFloat32 => typeInfo[Float]
+    case _: TFloat64 => typeInfo[Double]
+    case _ => typeInfo[Long] // reference types
+  }
+
+  // FIXME add InsertStruct IR node
+  def insertStruct(s: ir.IR, typ: TStruct, name: String, v: ir.IR): ir.IR = {
+    assert(typ.hasField(name))
+    ir.MakeStruct(typ.fields.zipWithIndex.map { case (f, i) =>
+      (f.name,
+        if (f.name == name)
+          v
+        else
+          ir.GetField(s, f.name))
+    }.toArray)
+  }
 }


### PR DESCRIPTION
Use in filterSamples.

I might stop here for the moment.  This seems about as good for the interface as one could hope modulo and easier way to write the IR.

I'll come back to `InsertStruct` once physical types are in.

@catoverdrive FYI this might be a useful idiom when adding the IR to key tables, etc.
