### PR TITLE
Renamed VSM => MatrixTable, KeyTable => Table.

### DIFF
--- a/python/hail/api1/dataset.py
+++ b/python/hail/api1/dataset.py
@@ -2683,7 +2683,7 @@ class VariantDataset(HistoryMixin):
         elif len(datasets) == 1:
             return datasets[0]
         else:
-            return VariantDataset(Env.hc(), Env.hail().variant.VariantSampleMatrix.union([d._jvds for d in datasets]))
+            return VariantDataset(Env.hc(), Env.hail().variant.MatrixTable.union([d._jvds for d in datasets]))
 
 
     @handle_py4j
@@ -3465,7 +3465,7 @@ class VariantDataset(HistoryMixin):
                       compute_loadings=bool,
                       as_array=bool)
     def pca(self, entry_expr, k=10, compute_loadings=False, as_array=False):
-        """Run Principal Component Analysis (PCA) on a VariantSampleMatrix, using ``entry_expr`` to convert each entry into a numeric value.
+        """Run Principal Component Analysis (PCA) on a MatrixTable, using ``entry_expr`` to convert each entry into a numeric value.
 
         **Examples**
 

--- a/python/hail/api1/keytable.py
+++ b/python/hail/api1/keytable.py
@@ -13,13 +13,13 @@ from hail.utils.java import *
 class Ascending(HistoryMixin):
     @record_init
     def __init__(self, col):
-        self._jrep = scala_package_object(Env.hail().keytable).asc(col)
+        self._jrep = scala_package_object(Env.hail().table).asc(col)
 
 
 class Descending(HistoryMixin):
     @record_init
     def __init__(self, col):
-        self._jrep = scala_package_object(Env.hail().keytable).desc(col)
+        self._jrep = scala_package_object(Env.hail().table).desc(col)
 
 
 def asc(col):
@@ -141,7 +141,7 @@ class KeyTable(HistoryMixin):
 
         return KeyTable(
             Env.hc(),
-            Env.hail().keytable.KeyTable.parallelize(
+            Env.hail().table.Table.parallelize(
                 Env.hc()._jhc, [schema._convert_to_j(r) for r in rows],
                 schema._jtype, wrap_to_list(key), joption(num_partitions)))
 
@@ -1062,7 +1062,7 @@ class KeyTable(HistoryMixin):
 
         jsort_columns = [asc(col)._jrep if isinstance(col, str) else col._jrep for col in cols]
         return KeyTable(self.hc,
-                        self._jkt.orderBy(jarray(Env.hail().keytable.SortColumn, jsort_columns)))
+                        self._jkt.orderBy(jarray(Env.hail().table.SortColumn, jsort_columns)))
 
     @handle_py4j
     def num_partitions(self):
@@ -1127,7 +1127,7 @@ class KeyTable(HistoryMixin):
         """
 
         rg = reference_genome if reference_genome else Env.hc().default_reference
-        jkt = Env.hail().keytable.KeyTable.importIntervalList(Env.hc()._jhc, path, rg._jrep)
+        jkt = Env.hail().table.Table.importIntervalList(Env.hc()._jhc, path, rg._jrep)
         return KeyTable(Env.hc(), jkt)
 
     @classmethod
@@ -1199,7 +1199,7 @@ class KeyTable(HistoryMixin):
         """
 
         rg = reference_genome if reference_genome else Env.hc().default_reference
-        jkt = Env.hail().keytable.KeyTable.importBED(Env.hc()._jhc, path, rg._jrep)
+        jkt = Env.hail().table.Table.importBED(Env.hc()._jhc, path, rg._jrep)
         return KeyTable(Env.hc(), jkt)
 
     @classmethod
@@ -1242,7 +1242,7 @@ class KeyTable(HistoryMixin):
         :rtype: :class:`.KeyTable`
         """
 
-        return KeyTable(Env.hc(), Env.hail().keytable.KeyTable.fromDF(Env.hc()._jhc, df._jdf, wrap_to_list(key)))
+        return KeyTable(Env.hc(), Env.hail().table.Table.fromDF(Env.hc()._jhc, df._jdf, wrap_to_list(key)))
 
     @handle_py4j
     @record_method
@@ -1319,7 +1319,7 @@ class KeyTable(HistoryMixin):
         """
 
         hc = Env.hc()
-        jkt = Env.hail().keytable.KeyTable.importFam(hc._jhc, path, quantitative, delimiter, missing)
+        jkt = Env.hail().table.Table.importFam(hc._jhc, path, quantitative, delimiter, missing)
         return KeyTable(hc, jkt)
 
     @handle_py4j
@@ -1501,7 +1501,7 @@ class KeyTable(HistoryMixin):
         :rtype: :class:`.KeyTable`
         """
 
-        return KeyTable(Env.hc(), Env.hail().keytable.KeyTable.range(Env.hc()._jhc, n, joption(num_partitions)))
+        return KeyTable(Env.hc(), Env.hail().table.Table.range(Env.hc()._jhc, n, joption(num_partitions)))
 
     @handle_py4j
     @record_method

--- a/python/hail/api2/table.py
+++ b/python/hail/api2/table.py
@@ -348,7 +348,7 @@ class Table(TableTemplate):
     def parallelize(cls, rows, schema, key=[], num_partitions=None):
         return Table(
             Env.hc(),
-            Env.hail().keytable.KeyTable.parallelize(
+            Env.hail().table.Table.parallelize(
                 Env.hc()._jhc, [schema._convert_to_j(r) for r in rows],
                 schema._jtype, wrap_to_list(key), joption(num_partitions)))
 
@@ -1130,7 +1130,7 @@ class Table(TableTemplate):
         :class:`Table`
             Table with one field, `index`.
         """
-        return Table(Env.hc(), Env.hail().keytable.KeyTable.range(Env.hc()._jhc, n, joption(num_partitions)))
+        return Table(Env.hc(), Env.hail().table.Table.range(Env.hc()._jhc, n, joption(num_partitions)))
 
     @handle_py4j
     def cache(self):

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -11,7 +11,7 @@ import is.hail.io.bgen.BgenLoader
 import is.hail.io.gen.GenLoader
 import is.hail.io.plink.{FamFileConfig, PlinkLoader}
 import is.hail.io.vcf._
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.rvd.OrderedRVD
 import is.hail.stats.{BaldingNicholsModel, Distribution, UniformDist}
 import is.hail.utils.{log, _}

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -4,7 +4,7 @@ import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.asm4s.FunctionBuilder
 import is.hail.expr.ir._
-import is.hail.keytable.KTLocalValue
+import is.hail.table.KTLocalValue
 import is.hail.methods.Aggregators
 import is.hail.sparkextras._
 import is.hail.rvd._

--- a/src/main/scala/is/hail/io/CassandraConnector.scala
+++ b/src/main/scala/is/hail/io/CassandraConnector.scala
@@ -5,7 +5,7 @@ import java.nio.ByteBuffer
 import com.datastax.driver.core.querybuilder.QueryBuilder
 import com.datastax.driver.core.{Cluster, DataType, Session, TableMetadata, Row => CassRow}
 import is.hail.expr._
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.utils._
 import org.apache.spark.sql.Row
 import org.json4s._

--- a/src/main/scala/is/hail/io/CassandraConnector.scala
+++ b/src/main/scala/is/hail/io/CassandraConnector.scala
@@ -5,7 +5,7 @@ import java.nio.ByteBuffer
 import com.datastax.driver.core.querybuilder.QueryBuilder
 import com.datastax.driver.core.{Cluster, DataType, Session, TableMetadata, Row => CassRow}
 import is.hail.expr._
-import is.hail.keytable.KeyTable
+import is.hail.keytable.Table
 import is.hail.utils._
 import org.apache.spark.sql.Row
 import org.json4s._
@@ -217,7 +217,7 @@ object CassandraConnector {
     }
   }
 
-  def export(kt: KeyTable,
+  def export(kt: Table,
     address: String, keyspace: String, table: String,
     blockSize: Int = 100, rate: Int = 1000) {
 

--- a/src/main/scala/is/hail/io/LoadMatrix.scala
+++ b/src/main/scala/is/hail/io/LoadMatrix.scala
@@ -158,7 +158,7 @@ object LoadMatrix {
     cellType: Type = TInt64(),
     sep: String = "\t",
     missingValue: String = "NA",
-    hasRowIDName: Boolean = false): VariantSampleMatrix = {
+    hasRowIDName: Boolean = false): MatrixTable = {
 
     val cellParser: (String, Int, RegionValueBuilder, Char, String, String, String, Int) => Int = cellType match {
       case _: TInt32 => setInt
@@ -306,7 +306,7 @@ object LoadMatrix {
         }
       }
 
-    new VariantSampleMatrix(hc,
+    new MatrixTable(hc,
       VSMMetadata(TString(), vSignature = TString(), genotypeSignature = cellType),
       VSMLocalValue(Annotation.empty,
         sampleIds,

--- a/src/main/scala/is/hail/io/SolrConnector.scala
+++ b/src/main/scala/is/hail/io/SolrConnector.scala
@@ -3,7 +3,7 @@ package is.hail.io
 import java.util
 
 import is.hail.expr._
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.utils._
 import is.hail.variant.MatrixTable
 import org.apache.solr.client.solrj.impl.{CloudSolrClient, HttpSolrClient}

--- a/src/main/scala/is/hail/io/SolrConnector.scala
+++ b/src/main/scala/is/hail/io/SolrConnector.scala
@@ -3,9 +3,9 @@ package is.hail.io
 import java.util
 
 import is.hail.expr._
-import is.hail.keytable.KeyTable
+import is.hail.keytable.Table
 import is.hail.utils._
-import is.hail.variant.VariantSampleMatrix
+import is.hail.variant.MatrixTable
 import org.apache.solr.client.solrj.impl.{CloudSolrClient, HttpSolrClient}
 import org.apache.solr.client.solrj.request.CollectionAdminRequest
 import org.apache.solr.client.solrj.request.schema.SchemaRequest
@@ -97,7 +97,7 @@ object SolrConnector {
     cc
   }
 
-  def export(kt: KeyTable,
+  def export(kt: Table,
     zkHost: String,
     collection: String,
     blockSize: Int) {

--- a/src/main/scala/is/hail/io/annotators/BedAnnotator.scala
+++ b/src/main/scala/is/hail/io/annotators/BedAnnotator.scala
@@ -2,7 +2,7 @@ package is.hail.io.annotators
 
 import is.hail.HailContext
 import is.hail.expr._
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.utils.{Interval, _}
 import is.hail.variant._
 import org.apache.spark.sql.Row

--- a/src/main/scala/is/hail/io/annotators/BedAnnotator.scala
+++ b/src/main/scala/is/hail/io/annotators/BedAnnotator.scala
@@ -2,13 +2,13 @@ package is.hail.io.annotators
 
 import is.hail.HailContext
 import is.hail.expr._
-import is.hail.keytable.KeyTable
+import is.hail.keytable.Table
 import is.hail.utils.{Interval, _}
 import is.hail.variant._
 import org.apache.spark.sql.Row
 
 object BedAnnotator {
-  def apply(hc: HailContext, filename: String, gr: GenomeReference = GenomeReference.defaultReference): KeyTable = {
+  def apply(hc: HailContext, filename: String, gr: GenomeReference = GenomeReference.defaultReference): Table = {
     // this annotator reads files in the UCSC BED spec defined here: https://genome.ucsc.edu/FAQ/FAQformat.html#format1
 
     val hasTarget = hc.hadoopConf.readLines(filename) { lines =>
@@ -68,6 +68,6 @@ object BedAnnotator {
         }.value
       }
 
-    KeyTable(hc, rdd, schema, Array("interval"))
+    Table(hc, rdd, schema, Array("interval"))
   }
 }

--- a/src/main/scala/is/hail/io/annotators/IntervalList.scala
+++ b/src/main/scala/is/hail/io/annotators/IntervalList.scala
@@ -2,7 +2,7 @@ package is.hail.io.annotators
 
 import is.hail.HailContext
 import is.hail.expr._
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.utils.{Interval, _}
 import is.hail.variant._
 import org.apache.spark.sql.Row

--- a/src/main/scala/is/hail/io/annotators/IntervalList.scala
+++ b/src/main/scala/is/hail/io/annotators/IntervalList.scala
@@ -2,7 +2,7 @@ package is.hail.io.annotators
 
 import is.hail.HailContext
 import is.hail.expr._
-import is.hail.keytable.KeyTable
+import is.hail.keytable.Table
 import is.hail.utils.{Interval, _}
 import is.hail.variant._
 import org.apache.spark.sql.Row
@@ -12,7 +12,7 @@ object IntervalList {
 
   val intervalRegex = """([^:]*)[:\t](\d+)[\-\t](\d+)""".r
 
-  def read(hc: HailContext, filename: String, gr: GenomeReference = GenomeReference.defaultReference): KeyTable = {
+  def read(hc: HailContext, filename: String, gr: GenomeReference = GenomeReference.defaultReference): Table = {
     val hasValue = hc.hadoopConf.readLines(filename) {
       lines =>
         val skipHeader = lines.filter(l => !l.value.isEmpty && l.value(0) != '@')
@@ -61,6 +61,6 @@ object IntervalList {
         }.value
       }
 
-    KeyTable(hc, rdd, schema, Array("interval"))
+    Table(hc, rdd, schema, Array("interval"))
   }
 }

--- a/src/main/scala/is/hail/io/bgen/BgenLoader.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenLoader.scala
@@ -22,7 +22,7 @@ object BgenLoader {
 
   def load(hc: HailContext, files: Array[String], sampleFile: Option[String] = None,
     tolerance: Double, nPartitions: Option[Int] = None, gr: GenomeReference = GenomeReference.defaultReference,
-    contigRecoding: Map[String, String] = Map.empty[String, String]): VariantSampleMatrix = {
+    contigRecoding: Map[String, String] = Map.empty[String, String]): MatrixTable = {
     require(files.nonEmpty)
     val sampleIds = sampleFile.map(file => BgenLoader.readSampleFile(hc.hadoopConf, file))
       .getOrElse(BgenLoader.readSamples(hc.hadoopConf, files.head))
@@ -126,7 +126,7 @@ object BgenLoader {
       }
     }))
 
-    new VariantSampleMatrix(hc, metadata,
+    new MatrixTable(hc, metadata,
       VSMLocalValue(globalAnnotation = Annotation.empty,
         sampleIds = sampleIds,
         sampleAnnotations = Array.fill(nSamples)(Annotation.empty)),

--- a/src/main/scala/is/hail/io/plink/PlinkLoader.scala
+++ b/src/main/scala/is/hail/io/plink/PlinkLoader.scala
@@ -117,7 +117,7 @@ object PlinkLoader {
     variants: Array[(Variant, String)],
     nPartitions: Option[Int] = None,
     a2Reference: Boolean = true,
-    gr: GenomeReference = GenomeReference.defaultReference): VariantSampleMatrix = {
+    gr: GenomeReference = GenomeReference.defaultReference): MatrixTable = {
 
     val sc = hc.sc
     val nSamples = sampleIds.length
@@ -184,7 +184,7 @@ object PlinkLoader {
       }
     }
 
-    new VariantSampleMatrix(hc, metadata,
+    new MatrixTable(hc, metadata,
       VSMLocalValue(globalAnnotation = Annotation.empty,
         sampleIds = sampleIds,
         sampleAnnotations = sampleAnnotations),
@@ -193,7 +193,7 @@ object PlinkLoader {
 
   def apply(hc: HailContext, bedPath: String, bimPath: String, famPath: String, ffConfig: FamFileConfig,
     nPartitions: Option[Int] = None, a2Reference: Boolean = true, gr: GenomeReference = GenomeReference.defaultReference,
-    contigRecoding: Map[String, String] = Map.empty[String, String]): VariantSampleMatrix = {
+    contigRecoding: Map[String, String] = Map.empty[String, String]): MatrixTable = {
     val (sampleInfo, signature) = parseFam(famPath, ffConfig, hc.hadoopConf)
     val nSamples = sampleInfo.length
     if (nSamples <= 0)

--- a/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -5,7 +5,7 @@ import is.hail.annotations.Region
 import is.hail.expr._
 import is.hail.io.{VCFAttributes, VCFFieldAttributes, VCFMetadata}
 import is.hail.utils._
-import is.hail.variant.{Genotype, Variant, VariantSampleMatrix}
+import is.hail.variant.{Genotype, Variant, MatrixTable}
 
 import scala.io.Source
 
@@ -198,7 +198,7 @@ object ExportVCF {
   def getAttributes(k1: String, k2: String, k3: String, attributes: Option[VCFMetadata]): Option[String] =
     getAttributes(k1, k2, attributes).flatMap(_.get(k3))
 
-  def apply(vsm: VariantSampleMatrix, path: String, append: Option[String] = None,
+  def apply(vsm: MatrixTable, path: String, append: Option[String] = None,
     parallel: Boolean = false, metadata: Option[VCFMetadata] = None) {
     
     vsm.requireColKeyString("export_vcf")

--- a/src/main/scala/is/hail/io/vcf/LoadGDB.scala
+++ b/src/main/scala/is/hail/io/vcf/LoadGDB.scala
@@ -6,7 +6,7 @@ import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.expr.{TStruct, _}
 import is.hail.utils._
-import is.hail.variant.{GenomeReference, VSMLocalValue, VSMMetadata, Variant, VariantSampleMatrix}
+import is.hail.variant.{GenomeReference, VSMLocalValue, VSMMetadata, Variant, MatrixTable}
 import org.json4s._
 
 import scala.collection.JavaConversions._
@@ -100,7 +100,7 @@ object LoadGDB {
                vcfHeaderPath: Option[String],
                nPartitions: Option[Int] = None,
                dropSamples: Boolean = false,
-               gr: GenomeReference = GenomeReference.defaultReference): VariantSampleMatrix = {
+               gr: GenomeReference = GenomeReference.defaultReference): MatrixTable = {
     val sc = hc.sc
 
     val codec = new htsjdk.variant.vcf.VCFCodec()
@@ -188,7 +188,7 @@ object LoadGDB {
 
     queryFile.delete()
 
-    VariantSampleMatrix.fromLegacy(hc, VSMMetadata(
+    MatrixTable.fromLegacy(hc, VSMMetadata(
       TString(),
       TStruct.empty(),
       TVariant(gr),

--- a/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -814,7 +814,7 @@ object LoadVCF {
     dropSamples: Boolean = false,
     gr: GenomeReference = GenomeReference.defaultReference,
     contigRecoding: Map[String, String] = Map.empty[String, String],
-    arrayElementsRequired: Boolean = true): VariantSampleMatrix = {
+    arrayElementsRequired: Boolean = true): MatrixTable = {
     val sc = hc.sc
     val hConf = hc.hadoopConf
 
@@ -929,7 +929,7 @@ object LoadVCF {
       }(lines, rowType, contigRecoding),
       Some(justVariants), None)
 
-    new VariantSampleMatrix(hc,
+    new MatrixTable(hc,
       vsmMetadata,
       VSMLocalValue(Annotation.empty,
         sampleIds,

--- a/src/main/scala/is/hail/keytable/Table.scala
+++ b/src/main/scala/is/hail/keytable/Table.scala
@@ -48,31 +48,31 @@ case class KeyTableMetadata(
 
 case class KTLocalValue(globals: Row)
 
-object KeyTable {
+object Table {
   final val fileVersion: Int = 0x101
 
-  def range(hc: HailContext, n: Int, partitions: Option[Int] = None): KeyTable = {
+  def range(hc: HailContext, n: Int, partitions: Option[Int] = None): Table = {
     val range = Range(0, n).view.map(Row(_))
     val rdd = partitions match {
       case Some(parts) => hc.sc.parallelize(range, numSlices = parts)
       case None => hc.sc.parallelize(range)
     }
-    KeyTable(hc, rdd, TStruct("index" -> TInt32()), Array("index"))
+    Table(hc, rdd, TStruct("index" -> TInt32()), Array("index"))
   }
 
-  def fromDF(hc: HailContext, df: DataFrame, key: java.util.ArrayList[String]): KeyTable = {
+  def fromDF(hc: HailContext, df: DataFrame, key: java.util.ArrayList[String]): Table = {
     fromDF(hc, df, key.asScala.toArray)
   }
 
-  def fromDF(hc: HailContext, df: DataFrame, key: Array[String] = Array.empty[String]): KeyTable = {
+  def fromDF(hc: HailContext, df: DataFrame, key: Array[String] = Array.empty[String]): Table = {
     val signature = SparkAnnotationImpex.importType(df.schema).asInstanceOf[TStruct]
-    KeyTable(hc, df.rdd.map { r =>
+    Table(hc, df.rdd.map { r =>
       SparkAnnotationImpex.importAnnotation(r, signature).asInstanceOf[Row]
     },
       signature, key)
   }
 
-  def read(hc: HailContext, path: String): KeyTable = {
+  def read(hc: HailContext, path: String): Table = {
     if (!hc.hadoopConf.exists(path))
       fatal(s"$path does not exist")
     else if (!path.endsWith(".kt") && !path.endsWith(".kt/"))
@@ -81,7 +81,7 @@ object KeyTable {
     val metadataFile = path + "/metadata.json.gz"
     if (!hc.hadoopConf.exists(metadataFile))
       fatal(
-        s"corrupt KeyTable: metadata file does not exist: $metadataFile")
+        s"corrupt Table: metadata file does not exist: $metadataFile")
 
     val metadata = hc.hadoopConf.readFile(metadataFile) { in =>
       // FIXME why doesn't this work?  Serialization.read[KeyTableMetadata](in)
@@ -93,7 +93,7 @@ object KeyTable {
     val globalSchema = metadata.globalSchema.map(str => Parser.parseType(str).asInstanceOf[TStruct]).getOrElse(TStruct.empty())
     val globals = metadata.globals.map(g => JSONAnnotationImpex.importAnnotation(g, globalSchema).asInstanceOf[Row])
       .getOrElse(Row.empty)
-    new KeyTable(hc, ReadKT(path,
+    Table(hc, ReadKT(path,
       KeyTableType(schema, metadata.key, globalSchema),
       KTLocalValue(globals),
       dropRows = false,
@@ -102,9 +102,9 @@ object KeyTable {
   }
 
   def parallelize(hc: HailContext, rows: java.util.ArrayList[Row], signature: TStruct,
-    keyNames: java.util.ArrayList[String], nPartitions: Option[Int]): KeyTable = {
+    keyNames: java.util.ArrayList[String], nPartitions: Option[Int]): Table = {
     val sc = hc.sc
-    KeyTable(hc,
+    Table(hc,
       nPartitions match {
         case Some(n) =>
           sc.parallelize(rows.asScala, n)
@@ -114,18 +114,18 @@ object KeyTable {
   }
 
   def importIntervalList(hc: HailContext, filename: String,
-    gr: GenomeReference = GenomeReference.defaultReference): KeyTable = {
+    gr: GenomeReference = GenomeReference.defaultReference): Table = {
     IntervalList.read(hc, filename, gr)
   }
 
   def importBED(hc: HailContext, filename: String,
-    gr: GenomeReference = GenomeReference.defaultReference): KeyTable = {
+    gr: GenomeReference = GenomeReference.defaultReference): Table = {
     BedAnnotator.apply(hc, filename, gr)
   }
 
   def importFam(hc: HailContext, path: String, isQuantitative: Boolean = false,
     delimiter: String = "\\t",
-    missingValue: String = "NA"): KeyTable = {
+    missingValue: String = "NA"): Table = {
 
     val ffConfig = FamFileConfig(isQuantitative, delimiter, missingValue)
 
@@ -137,11 +137,11 @@ object KeyTable {
     val newFields = List("ID" -> TString()) ++ typ.asInstanceOf[TStruct].fields.map(f => (f.name, f.typ))
     val struct = TStruct(newFields: _*)
 
-    KeyTable(hc, rdd, struct, Array("ID"))
+    Table(hc, rdd, struct, Array("ID"))
   }
 
   def apply(hc: HailContext, rdd: RDD[Row], signature: TStruct, key: Array[String] = Array.empty,
-    globalSignature: TStruct = TStruct.empty(), globals: Row = Row.empty): KeyTable = {
+    globalSignature: TStruct = TStruct.empty(), globals: Row = Row.empty): Table = {
     val rdd2 = rdd.mapPartitions { it =>
       val region = Region()
       val rvb = new RegionValueBuilder(region)
@@ -155,7 +155,7 @@ object KeyTable {
       }
     }
 
-    new KeyTable(hc, KeyTableLiteral(
+    new Table(hc, KeyTableLiteral(
       KeyTableValue(KeyTableType(signature, key, globalSignature),
         KTLocalValue(globals),
         RVD(signature, rdd2))
@@ -163,7 +163,7 @@ object KeyTable {
   }
 }
 
-class KeyTable(val hc: HailContext,
+class Table(val hc: HailContext,
   val ir: KeyTableIR) {
 
   def this(hc: HailContext, rdd: RDD[RegionValue], signature: TStruct, key: Array[String] = Array.empty,
@@ -253,7 +253,7 @@ class KeyTable(val hc: HailContext,
     rdd.map { r => (Row.fromSeq(keyIndices.map(r.get)), Row.fromSeq(valueIndices.map(r.get))) }
   }
 
-  def same(other: KeyTable): Boolean = {
+  def same(other: Table): Boolean = {
     if (signature != other.signature) {
       info(
         s"""different signatures:
@@ -354,12 +354,12 @@ class KeyTable(val hc: HailContext,
     (t, f2)
   }
 
-  def annotateGlobal(a: Annotation, t: Type, name: String): KeyTable = {
+  def annotateGlobal(a: Annotation, t: Type, name: String): Table = {
     val (newT, i) = globalSignature.insert(t, name)
     copy2(globalSignature = newT.asInstanceOf[TStruct], globals = i(globals, a).asInstanceOf[Row])
   }
 
-  def annotateGlobalExpr(expr: String): KeyTable = {
+  def annotateGlobalExpr(expr: String): Table = {
     val ec = EvalContext(globalSignature.fields.map(fd => (fd.name, fd.typ)): _*)
 
     ec.setAllFromRow(globals.asInstanceOf[Row])
@@ -385,7 +385,7 @@ class KeyTable(val hc: HailContext,
       globalSignature = finalType)
   }
 
-  def selectGlobal(exprs: java.util.ArrayList[String]): KeyTable = {
+  def selectGlobal(exprs: java.util.ArrayList[String]): Table = {
     val ec = EvalContext(globalSignature.fields.map(fd => (fd.name, fd.typ)): _*)
     ec.setAllFromRow(globals.asInstanceOf[Row])
 
@@ -424,7 +424,7 @@ class KeyTable(val hc: HailContext,
     copy2(globalSignature = finalSignature, globals = newGlobal)
   }
 
-  def annotate(cond: String): KeyTable = {
+  def annotate(cond: String): Table = {
     val ec = rowEvalContext()
 
     val (paths, types, f) = Parser.parseAnnotationExprs(cond, ec, None)
@@ -451,12 +451,12 @@ class KeyTable(val hc: HailContext,
     copy(rdd = mapAnnotations(annotF), signature = finalSignature, key = key)
   }
 
-  def filter(cond: String, keep: Boolean): KeyTable = {
+  def filter(cond: String, keep: Boolean): Table = {
     var filterAST = Parser.expr.parse(cond)
     val pred = filterAST.toIR
     pred match {
       case Some(irPred) =>
-        new KeyTable(hc, FilterKT(ir, if (keep) irPred else ApplyUnaryPrimOp(Bang(), irPred)))
+        new Table(hc, FilterKT(ir, if (keep) irPred else ApplyUnaryPrimOp(Bang(), irPred)))
       case None =>
         info("No AST to IR conversion found. Falling back to AST predicate for FilterKT.")
         if (!keep)
@@ -486,17 +486,17 @@ class KeyTable(val hc: HailContext,
     }
   }
 
-  def head(n: Long): KeyTable = {
+  def head(n: Long): Table = {
     if (n < 0)
       fatal(s"n must be non-negative! Found `$n'.")
     copy(rdd = rdd.head(n))
   }
 
-  def keyBy(key: String*): KeyTable = keyBy(key)
+  def keyBy(key: String*): Table = keyBy(key)
 
-  def keyBy(key: java.util.ArrayList[String]): KeyTable = keyBy(key.asScala)
+  def keyBy(key: java.util.ArrayList[String]): Table = keyBy(key.asScala)
 
-  def keyBy(key: Iterable[String]): KeyTable = {
+  def keyBy(key: Iterable[String]): Table = {
     val colSet = columns.toSet
     val badKeys = key.filter(!colSet.contains(_))
 
@@ -508,7 +508,7 @@ class KeyTable(val hc: HailContext,
     copy(key = key.toArray)
   }
 
-  def select(exprs: Array[String], qualifiedName: Boolean = false): KeyTable = {
+  def select(exprs: Array[String], qualifiedName: Boolean = false): Table = {
     val ec = rowEvalContext()
 
     val (maybePaths, types, f, isNamedExpr) = Parser.parseSelectExprs(exprs, ec)
@@ -555,12 +555,12 @@ class KeyTable(val hc: HailContext,
     copy(rdd = mapAnnotations(annotF), signature = finalSignature, key = newKey)
   }
 
-  def select(selectedColumns: String*): KeyTable = select(selectedColumns.toArray)
+  def select(selectedColumns: String*): Table = select(selectedColumns.toArray)
 
-  def select(selectedColumns: java.util.ArrayList[String], mangle: Boolean): KeyTable =
+  def select(selectedColumns: java.util.ArrayList[String], mangle: Boolean): Table =
     select(selectedColumns.asScala.toArray, mangle)
 
-  def drop(columnsToDrop: Array[String]): KeyTable = {
+  def drop(columnsToDrop: Array[String]): Table = {
     val nonexistentColumns = columnsToDrop.diff(columns)
     if (nonexistentColumns.nonEmpty)
       fatal(s"Columns `${ nonexistentColumns.mkString(", ") }' do not exist in key table. Choose from `${ columns.mkString(", ") }'.")
@@ -569,9 +569,9 @@ class KeyTable(val hc: HailContext,
     select(selectedColumns)
   }
 
-  def drop(columnsToDrop: java.util.ArrayList[String]): KeyTable = drop(columnsToDrop.asScala.toArray)
+  def drop(columnsToDrop: java.util.ArrayList[String]): Table = drop(columnsToDrop.asScala.toArray)
 
-  def rename(columnMap: Map[String, String]): KeyTable = {
+  def rename(columnMap: Map[String, String]): Table = {
     val newSignature = TStruct(signature.fields.map { fd => fd.copy(name = columnMap.getOrElse(fd.name, fd.name)) })
     val newColumns = newSignature.fields.map(_.name)
     val newKey = key.map(n => columnMap.getOrElse(n, n))
@@ -585,18 +585,18 @@ class KeyTable(val hc: HailContext,
     copy(rdd = rdd, signature = newSignature, key = newKey)
   }
 
-  def rename(newColumns: Array[String]): KeyTable = {
+  def rename(newColumns: Array[String]): Table = {
     if (newColumns.length != nColumns)
       fatal(s"Found ${ newColumns.length } new column names but need $nColumns.")
 
     rename((columns, newColumns).zipped.toMap)
   }
 
-  def rename(columnMap: java.util.HashMap[String, String]): KeyTable = rename(columnMap.asScala.toMap)
+  def rename(columnMap: java.util.HashMap[String, String]): Table = rename(columnMap.asScala.toMap)
 
-  def rename(newColumns: java.util.ArrayList[String]): KeyTable = rename(newColumns.asScala.toArray)
+  def rename(newColumns: java.util.ArrayList[String]): Table = rename(newColumns.asScala.toArray)
 
-  def join(other: KeyTable, joinType: String): KeyTable = {
+  def join(other: Table, joinType: String): Table = {
     if (key.length != other.key.length || !(keyFields.map(_.typ) sameElements other.keyFields.map(_.typ)))
       fatal(
         s"""Both key tables must have the same number of keys and the types of keys must be identical. Order matters.
@@ -717,7 +717,7 @@ class KeyTable(val hc: HailContext,
     }.writeTable(output, hc.tmpDir, Some(fields.map(_.name).mkString("\t")).filter(_ => header), parallelWrite = parallel)
   }
 
-  def aggregate(keyCond: String, aggCond: String, nPartitions: Option[Int] = None): KeyTable = {
+  def aggregate(keyCond: String, aggCond: String, nPartitions: Option[Int] = None): Table = {
 
     val aggregationST = (fields.map { f => f.name -> f.typ } ++
       globalSignature.fields.map { f => f.name -> f.typ })
@@ -774,21 +774,21 @@ class KeyTable(val hc: HailContext,
     copy(rdd = newRDD, signature = keySignature.merge(aggSignature)._1, key = newKey)
   }
 
-  def ungroup(column: String, mangle: Boolean = false): KeyTable = {
+  def ungroup(column: String, mangle: Boolean = false): Table = {
     val (finalSignature, ungrouper) = signature.ungroup(column, mangle)
     copy(rdd = rdd.map(ungrouper), signature = finalSignature)
   }
 
-  def group(dest: String, columns: java.util.ArrayList[String]): KeyTable = group(dest, columns.asScala.toArray)
+  def group(dest: String, columns: java.util.ArrayList[String]): Table = group(dest, columns.asScala.toArray)
 
-  def group(dest: String, columns: Array[String]): KeyTable = {
+  def group(dest: String, columns: Array[String]): Table = {
     val (newSignature, grouper) = signature.group(dest, columns)
     val newKey = key.filter(!columns.contains(_))
     copy(rdd = rdd.map(grouper), signature = newSignature, key = newKey)
   }
 
 
-  def expandTypes(): KeyTable = {
+  def expandTypes(): Table = {
     val localSignature = signature
     val expandedSignature = Annotation.expandType(localSignature).asInstanceOf[TStruct]
 
@@ -797,7 +797,7 @@ class KeyTable(val hc: HailContext,
       key = key)
   }
 
-  def flatten(): KeyTable = {
+  def flatten(): Table = {
     val localSignature = signature
     val keySignature = TStruct(keyFields)
     val flattenedSignature = Annotation.flattenType(localSignature).asInstanceOf[TStruct]
@@ -817,14 +817,14 @@ class KeyTable(val hc: HailContext,
       signature.schema.asInstanceOf[StructType])
   }
 
-  def explode(columnToExplode: String): KeyTable = {
+  def explode(columnToExplode: String): Table = {
 
     val explodeField = signature.fieldOption(columnToExplode) match {
       case Some(x) => x
       case None =>
         fatal(
-          s"""Input field name `${ columnToExplode }' not found in KeyTable.
-             |KeyTable field names are `${ columns.mkString(", ") }'.""".stripMargin)
+          s"""Input field name `${ columnToExplode }' not found in Table.
+             |Table field names are `${ columns.mkString(", ") }'.""".stripMargin)
     }
 
     val index = explodeField.index
@@ -849,11 +849,11 @@ class KeyTable(val hc: HailContext,
     copy(rdd = explodedRDD, signature = newSignature, key = key)
   }
 
-  def explode(columnNames: Array[String]): KeyTable = {
+  def explode(columnNames: Array[String]): Table = {
     columnNames.foldLeft(this)((kt, name) => kt.explode(name))
   }
 
-  def explode(columnNames: java.util.ArrayList[String]): KeyTable = explode(columnNames.asScala.toArray)
+  def explode(columnNames: java.util.ArrayList[String]): Table = explode(columnNames.asScala.toArray)
 
   def collect(): IndexedSeq[Annotation] = rdd.collect()
 
@@ -870,7 +870,7 @@ class KeyTable(val hc: HailContext,
 
     val partitionCounts = rvd.rdd.writeRows(path, signature)
 
-    val metadata = KeyTableMetadata(KeyTable.fileVersion,
+    val metadata = KeyTableMetadata(Table.fileVersion,
       key,
       signature.toPrettyString(compact = true),
       Some(globalSignature.toPrettyString(compact = true)),
@@ -884,9 +884,9 @@ class KeyTable(val hc: HailContext,
     hc.hadoopConf.writeTextFile(path + "/_SUCCESS")(out => ())
   }
 
-  def cache(): KeyTable = persist("MEMORY_ONLY")
+  def cache(): Table = persist("MEMORY_ONLY")
 
-  def persist(storageLevel: String): KeyTable = {
+  def persist(storageLevel: String): Table = {
     val level = try {
       StorageLevel.fromString(storageLevel)
     } catch {
@@ -902,10 +902,10 @@ class KeyTable(val hc: HailContext,
     rdd.unpersist()
   }
 
-  def orderBy(sortCols: SortColumn*): KeyTable =
+  def orderBy(sortCols: SortColumn*): Table =
     orderBy(sortCols.toArray)
 
-  def orderBy(sortCols: Array[SortColumn]): KeyTable = {
+  def orderBy(sortCols: Array[SortColumn]): Table = {
     val sortColIndexOrd = sortCols.map { case SortColumn(n, so) =>
       val i = signature.fieldIdx(n)
       val f = signature.fields(i)
@@ -944,11 +944,11 @@ class KeyTable(val hc: HailContext,
     CassandraConnector.export(this, address, keyspace, table, blockSize, rate)
   }
 
-  def repartition(n: Int, shuffle: Boolean = true): KeyTable = copy(rdd = rdd.coalesce(n, shuffle))
+  def repartition(n: Int, shuffle: Boolean = true): Table = copy(rdd = rdd.coalesce(n, shuffle))
 
-  def union(kts: java.util.ArrayList[KeyTable]): KeyTable = union(kts.asScala.toArray: _*)
+  def union(kts: java.util.ArrayList[Table]): Table = union(kts.asScala.toArray: _*)
 
-  def union(kts: KeyTable*): KeyTable = {
+  def union(kts: Table*): Table = {
     kts.foreach { kt =>
       if (signature != kt.signature)
         fatal("cannot union tables with different schemas")
@@ -961,7 +961,7 @@ class KeyTable(val hc: HailContext,
 
   def take(n: Int): Array[Row] = rdd.take(n)
 
-  def indexed(name: String = "index"): KeyTable = {
+  def indexed(name: String = "index"): Table = {
     if (columns.contains(name))
       fatal(s"name collision: cannot index table, because column '$name' already exists")
 
@@ -1117,16 +1117,16 @@ class KeyTable(val hc: HailContext,
     signature: TStruct = signature,
     key: Array[String] = key,
     globalSignature: TStruct = globalSignature,
-    globals: Row = globals): KeyTable = {
-    KeyTable(hc, rdd, signature, key, globalSignature, globals)
+    globals: Row = globals): Table = {
+    Table(hc, rdd, signature, key, globalSignature, globals)
   }
 
   def copy2(rvd: RVD = rvd,
     signature: TStruct = signature,
     key: Array[String] = key,
     globalSignature: TStruct = globalSignature,
-    globals: Row = globals): KeyTable = {
-    new KeyTable(hc, KeyTableLiteral(
+    globals: Row = globals): Table = {
+    new Table(hc, KeyTableLiteral(
       KeyTableValue(KeyTableType(signature, key, globalSignature), KTLocalValue(globals), rvd)
     ))
   }

--- a/src/main/scala/is/hail/methods/Aggregators.scala
+++ b/src/main/scala/is/hail/methods/Aggregators.scala
@@ -18,7 +18,7 @@ import scala.reflect.ClassTag
 
 object Aggregators {
 
-  def buildVariantAggregationsByKey(vsm: VariantSampleMatrix, nKeys: Int, keyMap: Array[Int], ec: EvalContext): (RegionValue) => Array[() => Unit] =
+  def buildVariantAggregationsByKey(vsm: MatrixTable, nKeys: Int, keyMap: Array[Int], ec: EvalContext): (RegionValue) => Array[() => Unit] =
     buildVariantAggregationsByKey(vsm.sparkContext, vsm.matrixType, vsm.value.localValue, nKeys, keyMap, ec)
 
   // keyMap is just a mapping of sampleIds.map { s => newKey(s) }
@@ -86,7 +86,7 @@ object Aggregators {
     }
   }
 
-  def buildVariantAggregations(vsm: VariantSampleMatrix, ec: EvalContext): Option[(RegionValue) => Unit] =
+  def buildVariantAggregations(vsm: MatrixTable, ec: EvalContext): Option[(RegionValue) => Unit] =
     buildVariantAggregations(vsm.sparkContext, vsm.matrixType, vsm.value.localValue, ec)
 
   def buildVariantAggregations(sc: SparkContext,
@@ -214,7 +214,7 @@ object Aggregators {
     })
   }
 
-  def makeSampleFunctions(vsm: VariantSampleMatrix, aggExpr: String): SampleFunctions = {
+  def makeSampleFunctions(vsm: MatrixTable, aggExpr: String): SampleFunctions = {
     val ec = vsm.sampleEC
 
     val (resultNames, resultTypes, aggF) = Parser.parseAnnotationExprs(aggExpr, ec, None)

--- a/src/main/scala/is/hail/methods/Aggregators.scala
+++ b/src/main/scala/is/hail/methods/Aggregators.scala
@@ -5,7 +5,7 @@ import java.io.{ObjectInputStream, ObjectOutputStream}
 import is.hail.HailContext
 import is.hail.annotations.{Annotation, RegionValue, RegionValueBuilder, UnsafeRow}
 import is.hail.expr._
-import is.hail.keytable.KTLocalValue
+import is.hail.table.KTLocalValue
 import is.hail.stats._
 import is.hail.utils._
 import is.hail.variant._

--- a/src/main/scala/is/hail/methods/CalculateConcordance.scala
+++ b/src/main/scala/is/hail/methods/CalculateConcordance.scala
@@ -1,7 +1,7 @@
 package is.hail.methods
 
 import is.hail.expr._
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.utils._
 import is.hail.variant._
 import org.apache.spark.sql.Row

--- a/src/main/scala/is/hail/methods/CalculateConcordance.scala
+++ b/src/main/scala/is/hail/methods/CalculateConcordance.scala
@@ -1,7 +1,7 @@
 package is.hail.methods
 
 import is.hail.expr._
-import is.hail.keytable.KeyTable
+import is.hail.keytable.Table
 import is.hail.utils._
 import is.hail.variant._
 import org.apache.spark.sql.Row
@@ -66,7 +66,7 @@ class ConcordanceCombiner extends Serializable {
 
 object CalculateConcordance {
 
-  def apply(left: VariantSampleMatrix, right: VariantSampleMatrix): (IndexedSeq[IndexedSeq[Long]], KeyTable, KeyTable) = {
+  def apply(left: MatrixTable, right: MatrixTable): (IndexedSeq[IndexedSeq[Long]], Table, Table) = {
     require(left.wasSplit && right.wasSplit, "passed unsplit dataset to Concordance")
     val overlap = left.sampleIds.toSet.intersect(right.sampleIds.toSet)
     if (overlap.isEmpty)
@@ -191,9 +191,9 @@ object CalculateConcordance {
     val sampleRDD = left.hc.sc.parallelize(leftFiltered.sampleIds.zip(sampleResults)
       .map { case (id, comb) => Row(id, comb.nDiscordant, comb.toAnnotation) })
 
-    val sampleKT = KeyTable(left.hc, sampleRDD, sampleSchema, Array("s"))
+    val sampleKT = Table(left.hc, sampleRDD, sampleSchema, Array("s"))
 
-    val variantKT = KeyTable(left.hc, variantRDD, variantSchema, Array("v"))
+    val variantKT = Table(left.hc, variantRDD, variantSchema, Array("v"))
 
     (global.toAnnotation, sampleKT, variantKT)
   }

--- a/src/main/scala/is/hail/methods/FilterAlleles.scala
+++ b/src/main/scala/is/hail/methods/FilterAlleles.scala
@@ -4,15 +4,15 @@ import is.hail.annotations._
 import is.hail.expr.{EvalContext, Parser, TArray, TInt32, TVariant}
 import is.hail.rvd.{OrderedRVD, RVD}
 import is.hail.utils._
-import is.hail.variant.{GenomeReference, Locus, Variant, VariantSampleMatrix}
+import is.hail.variant.{GenomeReference, Locus, Variant, MatrixTable}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 
 object FilterAlleles {
-  def apply(vsm: VariantSampleMatrix, filterExpr: String,
+  def apply(vsm: MatrixTable, filterExpr: String,
     variantExpr: String = "",
     genotypeExpr: String = "",
-    keep: Boolean = true, leftAligned: Boolean = false, keepStar: Boolean = false): VariantSampleMatrix = {
+    keep: Boolean = true, leftAligned: Boolean = false, keepStar: Boolean = false): MatrixTable = {
     if (vsm.wasSplit)
       warn("this VDS was already split; this module was designed to handle multi-allelics, perhaps you should use filter_variants instead.")
 

--- a/src/main/scala/is/hail/methods/GRM.scala
+++ b/src/main/scala/is/hail/methods/GRM.scala
@@ -3,10 +3,10 @@ package is.hail.methods
 import is.hail.distributedmatrix.BlockMatrix.ops._
 import is.hail.stats.ToHWENormalizedIndexedRowMatrix
 import is.hail.utils._
-import is.hail.variant.VariantSampleMatrix
+import is.hail.variant.MatrixTable
 
 object GRM {
-  def apply(vds: VariantSampleMatrix): KinshipMatrix = {
+  def apply(vds: MatrixTable): KinshipMatrix = {
 
     val (_, irm) = ToHWENormalizedIndexedRowMatrix(vds)
 

--- a/src/main/scala/is/hail/methods/IBD.scala
+++ b/src/main/scala/is/hail/methods/IBD.scala
@@ -2,7 +2,7 @@ package is.hail.methods
 
 import is.hail.HailContext
 import is.hail.expr.{EvalContext, Parser, TFloat64, TInt64, TString, TStruct, TVariant}
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.annotations.{Annotation, Region, RegionValue, RegionValueBuilder, UnsafeRow}
 import is.hail.expr._
 import is.hail.variant.{GenomeReference, Genotype, HardCallView, Variant, MatrixTable}

--- a/src/main/scala/is/hail/methods/IBD.scala
+++ b/src/main/scala/is/hail/methods/IBD.scala
@@ -2,10 +2,10 @@ package is.hail.methods
 
 import is.hail.HailContext
 import is.hail.expr.{EvalContext, Parser, TFloat64, TInt64, TString, TStruct, TVariant}
-import is.hail.keytable.KeyTable
+import is.hail.keytable.Table
 import is.hail.annotations.{Annotation, Region, RegionValue, RegionValueBuilder, UnsafeRow}
 import is.hail.expr._
-import is.hail.variant.{GenomeReference, Genotype, HardCallView, Variant, VariantSampleMatrix}
+import is.hail.variant.{GenomeReference, Genotype, HardCallView, Variant, MatrixTable}
 import is.hail.methods.IBD.generateComputeMaf
 import is.hail.rvd.RVD
 import org.apache.spark.rdd.RDD
@@ -203,7 +203,7 @@ object IBD {
 
   final val chunkSize = 1024
 
-  def computeIBDMatrix(vds: VariantSampleMatrix,
+  def computeIBDMatrix(vds: MatrixTable,
     computeMaf: Option[(RegionValue) => Double],
     min: Option[Double],
     max: Option[Double],
@@ -296,11 +296,11 @@ object IBD {
       }
   }
 
-  def apply(vds: VariantSampleMatrix,
+  def apply(vds: MatrixTable,
     computeMafExpr: Option[String] = None,
     bounded: Boolean = true,
     min: Option[Double] = None,
-    max: Option[Double] = None): KeyTable = {
+    max: Option[Double] = None): Table = {
 
     min.foreach(min => optionCheckInRangeInclusive(0.0, 1.0)("minimum", min))
     max.foreach(max => optionCheckInRangeInclusive(0.0, 1.0)("maximum", max))
@@ -316,17 +316,17 @@ object IBD {
     val sampleIds = vds.sampleIds.asInstanceOf[IndexedSeq[String]]
 
     val ktRdd2 = computeIBDMatrix(vds, computeMaf, min, max, sampleIds, bounded)
-    new KeyTable(vds.hc, ktRdd2, ibdSignature, Array("i", "j"))
+    new Table(vds.hc, ktRdd2, ibdSignature, Array("i", "j"))
   }
 
   private val (ibdSignature, ibdMerger) = TStruct(("i", TString()), ("j", TString())).merge(ExtendedIBDInfo.signature)
 
-  def toKeyTable(sc: HailContext, ibdMatrix: RDD[((Annotation, Annotation), ExtendedIBDInfo)]): KeyTable = {
+  def toKeyTable(sc: HailContext, ibdMatrix: RDD[((Annotation, Annotation), ExtendedIBDInfo)]): Table = {
     val ktRdd = ibdMatrix.map { case ((i, j), eibd) => ibdMerger(Annotation(i, j), eibd.toAnnotation).asInstanceOf[Row] }
-    KeyTable(sc, ktRdd, ibdSignature, Array("i", "j"))
+    Table(sc, ktRdd, ibdSignature, Array("i", "j"))
   }
 
-  def toRDD(kt: KeyTable): RDD[((Annotation, Annotation), ExtendedIBDInfo)] = {
+  def toRDD(kt: Table): RDD[((Annotation, Annotation), ExtendedIBDInfo)] = {
     val rvd = kt.rvd
     rvd.map { rv =>
       val region = rv.region
@@ -341,7 +341,7 @@ object IBD {
     }
   }
 
-  private[methods] def generateComputeMaf(vds: VariantSampleMatrix,
+  private[methods] def generateComputeMaf(vds: MatrixTable,
     computeMafExpr: String): (RegionValue) => Double = {
 
     val mafSymbolTable = Map("v" -> (0, vds.vSignature), "va" -> (1, vds.vaSignature))

--- a/src/main/scala/is/hail/methods/ImputeSexPlink.scala
+++ b/src/main/scala/is/hail/methods/ImputeSexPlink.scala
@@ -2,15 +2,15 @@ package is.hail.methods
 
 import is.hail.expr._
 import is.hail.utils._
-import is.hail.variant.{GenomeReference, Locus, VariantSampleMatrix}
+import is.hail.variant.{GenomeReference, Locus, MatrixTable}
 
 object ImputeSexPlink {
-  def apply(in: VariantSampleMatrix,
+  def apply(in: MatrixTable,
     mafThreshold: Double,
     includePar: Boolean,
     fMaleThreshold: Double,
     fFemaleThreshold: Double,
-    popFrequencyExpr: Option[String]): VariantSampleMatrix = {
+    popFrequencyExpr: Option[String]): MatrixTable = {
     var vsm = in
 
     val gr = vsm.genomeReference

--- a/src/main/scala/is/hail/methods/LDMatrix.scala
+++ b/src/main/scala/is/hail/methods/LDMatrix.scala
@@ -8,7 +8,7 @@ import is.hail.distributedmatrix.BlockMatrix.ops._
 import is.hail.expr.{Parser, TVariant}
 import is.hail.stats.RegressionUtils
 import is.hail.utils._
-import is.hail.variant.{HardCallView, Variant, VariantSampleMatrix}
+import is.hail.variant.{HardCallView, Variant, MatrixTable}
 import org.apache.hadoop.io._
 import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix}
 import org.apache.spark.mllib.linalg.{DenseMatrix, DenseVector, Matrix, Vectors}
@@ -20,7 +20,7 @@ object LDMatrix {
     * @param vds VDS on which to compute Pearson correlation between pairs of variants.
     * @return LDMatrix.
     */
-  def apply(vds : VariantSampleMatrix, optForceLocal: Option[Boolean]): LDMatrix = {
+  def apply(vds : MatrixTable, optForceLocal: Option[Boolean]): LDMatrix = {
     val maxEntriesForLocalProduct = 25e6 // 5000 * 5000
     
     val nSamples = vds.nSamples

--- a/src/main/scala/is/hail/methods/LDPrune.scala
+++ b/src/main/scala/is/hail/methods/LDPrune.scala
@@ -411,8 +411,8 @@ object LDPrune {
     (maxQueueSize, nPartitions)
   }
 
-  def apply(vsm: VariantSampleMatrix, nCores: Int,
-    r2Threshold: Double, windowSize: Int, memoryPerCore: Long): VariantSampleMatrix = {
+  def apply(vsm: MatrixTable, nCores: Int,
+    r2Threshold: Double, windowSize: Int, memoryPerCore: Long): MatrixTable = {
     if (nCores <= 0)
       fatal(s"Number of cores must be positive.")
 

--- a/src/main/scala/is/hail/methods/LinearMixedRegression.scala
+++ b/src/main/scala/is/hail/methods/LinearMixedRegression.scala
@@ -7,7 +7,7 @@ import is.hail.expr._
 import is.hail.stats._
 import is.hail.stats.eigSymD.DenseEigSymD
 import is.hail.utils._
-import is.hail.variant.VariantSampleMatrix
+import is.hail.variant.MatrixTable
 import org.apache.commons.math3.analysis.UnivariateFunction
 import org.apache.commons.math3.optim.MaxEval
 import org.apache.commons.math3.optim.nonlinear.scalar.GoalType
@@ -22,7 +22,7 @@ object LinearMixedRegression {
     ("pval", TFloat64()))
 
   def apply(
-    assocVSM: VariantSampleMatrix,
+    assocVSM: MatrixTable,
     kinshipMatrix: KinshipMatrix,
     yExpr: String,
     xExpr: String,
@@ -34,7 +34,7 @@ object LinearMixedRegression {
     optDelta: Option[Double],
     sparsityThreshold: Double,
     optNEigs: Option[Int],
-    optDroppedVarianceFraction: Option[Double]): VariantSampleMatrix = {
+    optDroppedVarianceFraction: Option[Double]): MatrixTable = {
 
     val pathVA = Parser.parseAnnotationRoot(rootVA, Annotation.VARIANT_HEAD)
     Parser.validateAnnotationRoot(rootGA, Annotation.GLOBAL_HEAD)

--- a/src/main/scala/is/hail/methods/LinearRegression.scala
+++ b/src/main/scala/is/hail/methods/LinearRegression.scala
@@ -19,9 +19,9 @@ object LinearRegression {
     ("tstat", TArray(TFloat64())),
     ("pval", TArray(TFloat64())))
 
-  def apply(vsm: VariantSampleMatrix,
+  def apply(vsm: MatrixTable,
     ysExpr: Array[String], xExpr: String, covExpr: Array[String], root: String, variantBlockSize: Int
-  ): VariantSampleMatrix = {
+  ): MatrixTable = {
     val ec = vsm.matrixType.genotypeEC
     val xf = RegressionUtils.parseExprAsDouble(xExpr, ec)
 

--- a/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -12,12 +12,12 @@ import scala.reflect.ClassTag
 
 object LogisticRegression {
 
-  def apply(vsm: VariantSampleMatrix,
+  def apply(vsm: MatrixTable,
     test: String,
     yExpr: String,
     xExpr: String,
     covExpr: Array[String],
-    root: String): VariantSampleMatrix = {
+    root: String): MatrixTable = {
     val logRegTest = LogisticRegressionTest.tests.getOrElse(test,
       fatal(s"Supported tests are ${ LogisticRegressionTest.tests.keys.mkString(", ") }, got: $test"))
 

--- a/src/main/scala/is/hail/methods/MendelErrors.scala
+++ b/src/main/scala/is/hail/methods/MendelErrors.scala
@@ -3,7 +3,7 @@ package is.hail.methods
 import is.hail.HailContext
 import is.hail.annotations.Annotation
 import is.hail.expr.{TInt32, TString, TStruct, Type}
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.utils._
 import is.hail.variant.CopyState._
 import is.hail.variant.GenotypeType._

--- a/src/main/scala/is/hail/methods/Nirvana.scala
+++ b/src/main/scala/is/hail/methods/Nirvana.scala
@@ -6,7 +6,7 @@ import java.util.Properties
 import is.hail.annotations.{Annotation, Querier}
 import is.hail.expr.{JSONAnnotationImpex, Parser, TArray, TBoolean, TFloat64, TInt32, TSet, TString, TStruct, Type}
 import is.hail.utils._
-import is.hail.variant.{Locus, Variant, VariantSampleMatrix}
+import is.hail.variant.{Locus, Variant, MatrixTable}
 import org.apache.spark.storage.StorageLevel
 import org.json4s.jackson.JsonMethods
 
@@ -220,7 +220,7 @@ object Nirvana {
     Variant(contig, start, ref, altAlleles)
   }
 
-  def annotate(vds: VariantSampleMatrix, config: String, blockSize: Int, root: String = "va.nirvana"): VariantSampleMatrix = {
+  def annotate(vds: MatrixTable, config: String, blockSize: Int, root: String = "va.nirvana"): MatrixTable = {
     val parsedRoot = Parser.parseAnnotationRoot(root, Annotation.VARIANT_HEAD)
 
     val rootType =

--- a/src/main/scala/is/hail/methods/PCA.scala
+++ b/src/main/scala/is/hail/methods/PCA.scala
@@ -3,7 +3,7 @@ package is.hail.methods
 import breeze.linalg.{*, DenseMatrix, DenseVector}
 import is.hail.annotations._
 import is.hail.expr._
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.utils._
 import is.hail.variant.MatrixTable
 

--- a/src/main/scala/is/hail/methods/PCA.scala
+++ b/src/main/scala/is/hail/methods/PCA.scala
@@ -3,9 +3,9 @@ package is.hail.methods
 import breeze.linalg.{*, DenseMatrix, DenseVector}
 import is.hail.annotations._
 import is.hail.expr._
-import is.hail.keytable.KeyTable
+import is.hail.keytable.Table
 import is.hail.utils._
-import is.hail.variant.VariantSampleMatrix
+import is.hail.variant.MatrixTable
 
 object PCA {
   def pcSchema(k: Int, asArray: Boolean = false): Type =
@@ -15,7 +15,7 @@ object PCA {
       TStruct((1 to k).map(i => (s"PC$i", TFloat64())): _*)
 
   //returns (sample scores, variant loadings, eigenvalues)
-  def apply(vsm: VariantSampleMatrix, expr: String, k: Int, computeLoadings: Boolean, asArray: Boolean = false): (IndexedSeq[Double], DenseMatrix[Double], Option[KeyTable]) = {
+  def apply(vsm: MatrixTable, expr: String, k: Int, computeLoadings: Boolean, asArray: Boolean = false): (IndexedSeq[Double], DenseMatrix[Double], Option[Table]) = {
     val sc = vsm.sparkContext
     val (irm, optionVariants) = vsm.toIndexedRowMatrix(expr, computeLoadings)
     val svd = irm.computeSVD(k, computeLoadings)
@@ -48,7 +48,7 @@ object PCA {
           rv
         }
       }
-      new KeyTable(vsm.hc, rdd, rowType, Array("v"))
+      new Table(vsm.hc, rdd, rowType, Array("v"))
     })
 
     val data =

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -5,7 +5,7 @@ import is.hail.annotations.Annotation
 import is.hail.distributedmatrix.BlockMatrix
 import is.hail.distributedmatrix.BlockMatrix.ops._
 import is.hail.expr.{TFloat64, TString, TStruct}
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.utils._
 import is.hail.variant.{HardCallView, Variant, MatrixTable}
 import org.apache.commons.math3.stat.regression.OLSMultipleLinearRegression

--- a/src/main/scala/is/hail/methods/SampleQC.scala
+++ b/src/main/scala/is/hail/methods/SampleQC.scala
@@ -3,7 +3,7 @@ package is.hail.methods
 import is.hail.annotations.Annotation
 import is.hail.expr.{TStruct, _}
 import is.hail.utils._
-import is.hail.variant.{AltAlleleType, Genotype, HTSGenotypeView, Variant, VariantSampleMatrix}
+import is.hail.variant.{AltAlleleType, Genotype, HTSGenotypeView, Variant, MatrixTable}
 import org.apache.spark.util.StatCounter
 
 object SampleQCCombiner {
@@ -156,7 +156,7 @@ class SampleQCCombiner extends Serializable {
 }
 
 object SampleQC {
-  def results(vsm: VariantSampleMatrix): Array[SampleQCCombiner] = {
+  def results(vsm: MatrixTable): Array[SampleQCCombiner] = {
     val depth = treeAggDepth(vsm.hc, vsm.nPartitions)
     val rowType = vsm.rowType
     val nSamples = vsm.nSamples
@@ -211,9 +211,8 @@ object SampleQC {
       Array.fill(nSamples)(new SampleQCCombiner)
   }
 
-  def apply(vsm: VariantSampleMatrix, root: String = "sa.qc"): VariantSampleMatrix = {
+  def apply(vsm: MatrixTable, root: String = "sa.qc"): MatrixTable = {
     vsm.requireRowKeyVariant("sample_qc")
-
     val r = results(vsm).map(_.asAnnotation)
     vsm.annotateSamples(SampleQCCombiner.signature, Parser.parseAnnotationRoot(root, Annotation.SAMPLE_HEAD), r)
   }

--- a/src/main/scala/is/hail/methods/Skat.scala
+++ b/src/main/scala/is/hail/methods/Skat.scala
@@ -3,7 +3,7 @@ package is.hail.methods
 import is.hail.utils._
 import is.hail.variant._
 import is.hail.expr._
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.stats.{LogisticRegressionModel, RegressionUtils, eigSymD}
 import is.hail.annotations.Annotation
 
@@ -127,7 +127,7 @@ object Skat {
             // using q / sigmaSq since Z.t * Z = gramian / sigmaSq
             val (pval, fault) = computePval(q / sigmaSq, gramian, accuracy, iterations)
             
-            // returning qstat = q / (2 * sigmaSq) to agree with skat R package convention
+            // returning qstat = q / (2 * sigmaSq) to agree with skat R table convention
             Row(key, size, q / (2 * sigmaSq), pval, fault)
           } else {
             Row(key, size, null, null, null)
@@ -178,7 +178,7 @@ object Skat {
           val (q, gramian) = computeGramian(skatTuples, size.toLong * n <= maxEntriesForSmallN)
           val (pval, fault) = computePval(q, gramian, accuracy, iterations)
   
-          // returning qstat = q / 2 to agree with skat R package convention
+          // returning qstat = q / 2 to agree with skat R table convention
           Row(key, size, q / 2, pval, fault)
         } else {
           Row(key, size, null, null, null)

--- a/src/main/scala/is/hail/methods/Skat.scala
+++ b/src/main/scala/is/hail/methods/Skat.scala
@@ -3,7 +3,7 @@ package is.hail.methods
 import is.hail.utils._
 import is.hail.variant._
 import is.hail.expr._
-import is.hail.keytable.KeyTable
+import is.hail.keytable.Table
 import is.hail.stats.{LogisticRegressionModel, RegressionUtils, eigSymD}
 import is.hail.annotations.Annotation
 
@@ -57,7 +57,7 @@ case class SkatTuple(q: Double, a: DenseVector[Double], b: DenseVector[Double])
 object Skat {
   val hardMaxEntriesForSmallN = 64e6 // 8000 x 8000 => 512MB of doubles
   
-  def apply(vsm: VariantSampleMatrix,
+  def apply(vsm: MatrixTable,
     keyExpr: String,
     weightExpr: String,
     yExpr: String,
@@ -66,7 +66,7 @@ object Skat {
     logistic: Boolean,
     maxSize: Int,
     accuracy: Double,
-    iterations: Int): KeyTable = {
+    iterations: Int): Table = {
     
     if (maxSize <= 0 || maxSize > 46340)
       fatal(s"Maximum group size must be in [1, 46340], got $maxSize")
@@ -195,10 +195,10 @@ object Skat {
       ("pval", TFloat64()),
       ("fault", TInt32()))
 
-    KeyTable(vsm.hc, skatRdd, skatSignature, Array("key"))
+    Table(vsm.hc, skatRdd, skatSignature, Array("key"))
   }
 
-  def computeKeyGsWeightRdd(vsm: VariantSampleMatrix,
+  def computeKeyGsWeightRdd(vsm: MatrixTable,
     xExpr: String,
     completeSampleIndex: Array[Int],
     keyExpr: String,

--- a/src/main/scala/is/hail/methods/SplitMulti.scala
+++ b/src/main/scala/is/hail/methods/SplitMulti.scala
@@ -4,7 +4,7 @@ import is.hail.annotations._
 import is.hail.expr._
 import is.hail.rvd.OrderedRVD
 import is.hail.utils._
-import is.hail.variant.{Locus, Variant, VariantSampleMatrix}
+import is.hail.variant.{Locus, Variant, MatrixTable}
 import org.apache.spark.rdd.RDD
 
 import scala.reflect.ClassTag
@@ -132,7 +132,7 @@ object SplitMulti {
   }
 }
 
-class SplitMulti(vsm: VariantSampleMatrix, variantExpr: String, genotypeExpr: String, keepStar: Boolean, leftAligned: Boolean) {
+class SplitMulti(vsm: MatrixTable, variantExpr: String, genotypeExpr: String, keepStar: Boolean, leftAligned: Boolean) {
   val vEC = EvalContext(Map(
     "global" -> (0, vsm.globalSignature),
     "v" -> (1, vsm.vSignature),
@@ -178,7 +178,7 @@ class SplitMulti(vsm: VariantSampleMatrix, variantExpr: String, genotypeExpr: St
     }
   }
 
-  def split(): VariantSampleMatrix = {
+  def split(): MatrixTable = {
     val newRDD2: OrderedRVD =
       if (leftAligned)
         OrderedRVD(

--- a/src/main/scala/is/hail/methods/VEP.scala
+++ b/src/main/scala/is/hail/methods/VEP.scala
@@ -6,7 +6,7 @@ import java.util.Properties
 import is.hail.annotations.Annotation
 import is.hail.expr._
 import is.hail.utils._
-import is.hail.variant.{Locus, Variant, VariantSampleMatrix}
+import is.hail.variant.{Locus, Variant, MatrixTable}
 import org.apache.spark.sql.Row
 import org.apache.spark.storage.StorageLevel
 import org.json4s.jackson.JsonMethods
@@ -214,8 +214,8 @@ object VEP {
     alleleMap
   }
 
-  def annotate(vsm: VariantSampleMatrix, config: String, root: String = "va.vep", csq: Boolean,
-    blockSize: Int): VariantSampleMatrix = {
+  def annotate(vsm: MatrixTable, config: String, root: String = "va.vep", csq: Boolean,
+    blockSize: Int): MatrixTable = {
 
     val parsedRoot = Parser.parseAnnotationRoot(root, Annotation.VARIANT_HEAD)
 

--- a/src/main/scala/is/hail/methods/VariantQC.scala
+++ b/src/main/scala/is/hail/methods/VariantQC.scala
@@ -3,7 +3,7 @@ package is.hail.methods
 import is.hail.annotations._
 import is.hail.expr.{TStruct, _}
 import is.hail.stats.LeveneHaldane
-import is.hail.variant.{HTSGenotypeView, VariantSampleMatrix}
+import is.hail.variant.{HTSGenotypeView, MatrixTable}
 import org.apache.spark.util.StatCounter
 
 final class VariantQCCombiner {
@@ -129,7 +129,7 @@ object VariantQC {
     "rExpectedHetFrequency" -> TFloat64(),
     "pHWE" -> TFloat64())
 
-  def apply(vsm: VariantSampleMatrix, root: String = "va.qc"): VariantSampleMatrix = {
+  def apply(vsm: MatrixTable, root: String = "va.qc"): MatrixTable = {
     require(vsm.wasSplit)
     vsm.requireRowKeyVariant("variant_qc")
 

--- a/src/main/scala/is/hail/stats/BaldingNicholsModel.scala
+++ b/src/main/scala/is/hail/stats/BaldingNicholsModel.scala
@@ -7,7 +7,7 @@ import is.hail.annotations._
 import is.hail.expr.{MatrixType, TArray, TCall, TFloat64, TInt32, TLocus, TString, TStruct, TVariant}
 import is.hail.rvd.OrderedRVD
 import is.hail.utils._
-import is.hail.variant.{GenomeReference, Genotype, VSMLocalValue, VSMMetadata, Variant, VariantSampleMatrix}
+import is.hail.variant.{GenomeReference, Genotype, VSMLocalValue, VSMMetadata, Variant, MatrixTable}
 import org.apache.commons.math3.random.JDKRandomGenerator
 
 object BaldingNicholsModel {
@@ -15,7 +15,7 @@ object BaldingNicholsModel {
   def apply(hc: HailContext, nPops: Int, nSamples: Int, nVariants: Int,
     popDistArrayOpt: Option[Array[Double]], FstOfPopArrayOpt: Option[Array[Double]],
     seed: Int, nPartitionsOpt: Option[Int], af_dist: Distribution,
-    gr: GenomeReference = GenomeReference.defaultReference): VariantSampleMatrix = {
+    gr: GenomeReference = GenomeReference.defaultReference): MatrixTable = {
 
     val sc = hc.sc
 
@@ -205,7 +205,7 @@ object BaldingNicholsModel {
     // FIXME: should use fast keys
     val ordrdd = OrderedRVD(matrixType.orderedRVType, rdd, None, None)
 
-    new VariantSampleMatrix(hc,
+    new MatrixTable(hc,
       vsmMetadata,
       VSMLocalValue(globalAnnotation, sampleIds, sampleAnnotations),
       ordrdd)

--- a/src/main/scala/is/hail/stats/ComputeRRM.scala
+++ b/src/main/scala/is/hail/stats/ComputeRRM.scala
@@ -5,7 +5,7 @@ import breeze.linalg.DenseMatrix
 import is.hail.annotations.UnsafeRow
 import is.hail.expr.TVariant
 import is.hail.utils._
-import is.hail.variant.{HardCallView, Locus, Variant, VariantSampleMatrix}
+import is.hail.variant.{HardCallView, Locus, Variant, MatrixTable}
 import org.apache.spark.SparkContext
 import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix, RowMatrix}
 import org.apache.spark.mllib.linalg.{Matrices, Matrix, Vectors}
@@ -30,7 +30,7 @@ object ComputeGramian {
 // diagonal values are approximately 1 assuming independent variants by Central Limit Theorem
 object ComputeRRM {
 
-  def apply(vds: VariantSampleMatrix, forceBlock: Boolean = false, forceGramian: Boolean = false): (IndexedRowMatrix, Long) = {
+  def apply(vds: MatrixTable, forceBlock: Boolean = false, forceGramian: Boolean = false): (IndexedRowMatrix, Long) = {
     def scaleMatrix(matrix: Matrix, scalar: Double): Matrix = {
       Matrices.dense(matrix.numRows, matrix.numCols, matrix.toArray.map(_ * scalar))
     }
@@ -70,7 +70,7 @@ object LocalDenseMatrixToIndexedRowMatrix {
 
 // each row has mean 0, norm sqrt(n), variance 1, constant variants are dropped
 object ToNormalizedRowMatrix {
-  def apply(vds: VariantSampleMatrix): RowMatrix = {
+  def apply(vds: MatrixTable): RowMatrix = {
     require(vds.wasSplit)
 
     val n = vds.nSamples
@@ -92,7 +92,7 @@ object ToNormalizedRowMatrix {
 
 // each row has mean 0, norm sqrt(n), variance 1
 object ToNormalizedIndexedRowMatrix {
-  def apply(vds: VariantSampleMatrix): IndexedRowMatrix = {
+  def apply(vds: MatrixTable): IndexedRowMatrix = {
     require(vds.wasSplit)
     val n = vds.nSamples
 
@@ -122,7 +122,7 @@ object ToNormalizedIndexedRowMatrix {
 
 // each row has mean 0, norm approx sqrt(n), variance approx 1, constant variants are included as zero vector
 object ToHWENormalizedIndexedRowMatrix {
-  def apply(vsm: VariantSampleMatrix): (Array[Variant], IndexedRowMatrix) = {
+  def apply(vsm: MatrixTable): (Array[Variant], IndexedRowMatrix) = {
     require(vsm.wasSplit)
     val rowType = vsm.rowType
 

--- a/src/main/scala/is/hail/stats/RegressionUtils.scala
+++ b/src/main/scala/is/hail/stats/RegressionUtils.scala
@@ -4,7 +4,7 @@ import breeze.linalg._
 import is.hail.annotations.Annotation
 import is.hail.expr._
 import is.hail.utils._
-import is.hail.variant.{HardCallView, VariantSampleMatrix}
+import is.hail.variant.{HardCallView, MatrixTable}
 
 object RegressionUtils {
   def inputVector(x: DenseVector[Double],
@@ -135,7 +135,7 @@ object RegressionUtils {
   }
 
   // IndexedSeq indexed by samples, Array by annotations
-  def getSampleAnnotations(vds: VariantSampleMatrix, annots: Array[String], ec: EvalContext): IndexedSeq[Array[Option[Double]]] = {
+  def getSampleAnnotations(vds: MatrixTable, annots: Array[String], ec: EvalContext): IndexedSeq[Array[Option[Double]]] = {
     val aQs = annots.map(parseExprAsDouble(_, ec))
 
     vds.sampleIdsAndAnnotations.map { case (s, sa) =>
@@ -151,7 +151,7 @@ object RegressionUtils {
   }
 
   def getPhenoCovCompleteSamples(
-    vsm: VariantSampleMatrix,
+    vsm: MatrixTable,
     yExpr: String,
     covExpr: Array[String]): (DenseVector[Double], DenseMatrix[Double], Array[Int]) = {
     
@@ -161,7 +161,7 @@ object RegressionUtils {
   }
   
   def getPhenosCovCompleteSamples(
-    vsm: VariantSampleMatrix,
+    vsm: MatrixTable,
     yExpr: Array[String],
     covExpr: Array[String]): (DenseMatrix[Double], DenseMatrix[Double], Array[Int]) = {
 

--- a/src/main/scala/is/hail/stats/package.scala
+++ b/src/main/scala/is/hail/stats/package.scala
@@ -4,7 +4,7 @@ import breeze.linalg.Matrix
 import is.hail.annotations.Annotation
 import is.hail.expr.{TArray, TFloat64, TStruct, TVariant}
 import is.hail.utils._
-import is.hail.variant.{GenomeReference, Genotype, VSMFileMetadata, Variant, VariantSampleMatrix}
+import is.hail.variant.{GenomeReference, Genotype, VSMFileMetadata, Variant, MatrixTable}
 import net.sourceforge.jdistlib.disttest.{DistributionTest, TestKind}
 import net.sourceforge.jdistlib.{Beta, ChiSquare, Normal, Poisson}
 import org.apache.commons.math3.distribution.HypergeometricDistribution
@@ -334,7 +334,7 @@ package object stats {
   def vdsFromGtMatrix(hc: HailContext)(
     gtMat: Matrix[Int],
     samplesIdsOpt: Option[Array[String]] = None,
-    nPartitions: Int = hc.sc.defaultMinPartitions): VariantSampleMatrix = {
+    nPartitions: Int = hc.sc.defaultMinPartitions): MatrixTable = {
 
     require(samplesIdsOpt.forall(_.length == gtMat.rows))
     require(samplesIdsOpt.forall(_.areDistinct()))
@@ -353,7 +353,7 @@ package object stats {
       },
       nPartitions)
 
-    VariantSampleMatrix.fromLegacy(hc, VSMFileMetadata(sampleIds, wasSplit = true), rdd)
+    MatrixTable.fromLegacy(hc, VSMFileMetadata(sampleIds, wasSplit = true), rdd)
   }
 
   // genotypes(i,j) is genotype of variant j in sample i; i and j are 0-based indices
@@ -363,7 +363,7 @@ package object stats {
     nAlleles: Int,
     gpMat: Matrix[Array[Double]],
     samplesIdsOpt: Option[Array[String]] = None,
-    nPartitions: Int = hc.sc.defaultMinPartitions): VariantSampleMatrix = {
+    nPartitions: Int = hc.sc.defaultMinPartitions): MatrixTable = {
 
     require(samplesIdsOpt.forall(_.length == gpMat.rows))
     require(samplesIdsOpt.forall(_.areDistinct()))
@@ -380,7 +380,7 @@ package object stats {
       },
       nPartitions)
 
-    VariantSampleMatrix.fromLegacy(hc, VSMFileMetadata(sampleIds,
+    MatrixTable.fromLegacy(hc, VSMFileMetadata(sampleIds,
       vSignature = TVariant(GenomeReference.defaultReference),
       genotypeSignature = TStruct(
         "GP" -> TArray(TFloat64())),

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -1,4 +1,4 @@
-package is.hail.keytable
+package is.hail.table
 
 import is.hail.HailContext
 import is.hail.annotations._

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -93,7 +93,7 @@ object Table {
     val globalSchema = metadata.globalSchema.map(str => Parser.parseType(str).asInstanceOf[TStruct]).getOrElse(TStruct.empty())
     val globals = metadata.globals.map(g => JSONAnnotationImpex.importAnnotation(g, globalSchema).asInstanceOf[Row])
       .getOrElse(Row.empty)
-    Table(hc, ReadKT(path,
+    new Table(hc, ReadKT(path,
       KeyTableType(schema, metadata.key, globalSchema),
       KTLocalValue(globals),
       dropRows = false,

--- a/src/main/scala/is/hail/table/package.scala
+++ b/src/main/scala/is/hail/table/package.scala
@@ -1,6 +1,6 @@
 package is.hail
 
-package object keytable {
+package object table {
   def asc(field: String): SortColumn = SortColumn(field, Ascending)
 
   def desc(field: String): SortColumn = SortColumn(field, Descending)

--- a/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -3,8 +3,8 @@ package is.hail.utils
 import java.io.{InputStream, OutputStream}
 
 import is.hail.HailContext
-import is.hail.keytable.KeyTable
-import is.hail.variant.{GenomeReference, Locus, VariantSampleMatrix}
+import is.hail.keytable.Table
+import is.hail.variant.{GenomeReference, Locus, MatrixTable}
 
 import scala.collection.JavaConverters._
 
@@ -88,19 +88,19 @@ trait Py4jUtils {
     error(msg)
   }
 
-  def joinGlobals(left: KeyTable, right: KeyTable, identifier: String): KeyTable = {
+  def joinGlobals(left: Table, right: Table, identifier: String): Table = {
     left.annotateGlobal(right.globals, right.globalSignature, identifier)
   }
 
-  def joinGlobals(left: KeyTable, right: VariantSampleMatrix, identifier: String): KeyTable = {
+  def joinGlobals(left: Table, right: MatrixTable, identifier: String): Table = {
     left.annotateGlobal(right.globalAnnotation, right.globalSignature, identifier)
   }
 
-  def joinGlobals(left: VariantSampleMatrix, right: KeyTable, identifier: String): VariantSampleMatrix = {
+  def joinGlobals(left: MatrixTable, right: Table, identifier: String): MatrixTable = {
     left.annotateGlobal(right.globals, right.globalSignature, "global." + identifier)
   }
 
-  def joinGlobals(left: VariantSampleMatrix, right: VariantSampleMatrix, identifier: String): VariantSampleMatrix = {
+  def joinGlobals(left: MatrixTable, right: MatrixTable, identifier: String): MatrixTable = {
     left.annotateGlobal(right.globalAnnotation, right.globalSignature, "global." + identifier)
   }
 }

--- a/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -3,7 +3,7 @@ package is.hail.utils
 import java.io.{InputStream, OutputStream}
 
 import is.hail.HailContext
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.variant.{GenomeReference, Locus, MatrixTable}
 
 import scala.collection.JavaConverters._

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -6,7 +6,7 @@ import is.hail.distributedmatrix._
 import is.hail.expr._
 import is.hail.io.VCFMetadata
 import is.hail.io.vcf.ExportVCF
-import is.hail.keytable.KeyTable
+import is.hail.keytable.Table
 import is.hail.methods.Aggregators.SampleFunctions
 import is.hail.methods._
 import is.hail.sparkextras._
@@ -46,14 +46,14 @@ case class VDSMetadata(
   n_partitions: Int,
   partition_counts: Option[Array[Long]])
 
-object VariantSampleMatrix {
+object MatrixTable {
   final val fileVersion: Int = 0x101
 
   def read(hc: HailContext, dirname: String,
-    dropSamples: Boolean = false, dropVariants: Boolean = false): VariantSampleMatrix = {
+    dropSamples: Boolean = false, dropVariants: Boolean = false): MatrixTable = {
     // FIXME check _SUCCESS next time we force reimport
     val (fileMetadata, nPartitions) = readFileMetadata(hc.hadoopConf, dirname)
-    new VariantSampleMatrix(hc,
+    new MatrixTable(hc,
       fileMetadata.metadata,
       MatrixRead(dirname, nPartitions, fileMetadata, dropSamples, dropVariants))
   }
@@ -61,22 +61,22 @@ object VariantSampleMatrix {
   def apply(hc: HailContext,
     metadata: VSMMetadata,
     localValue: VSMLocalValue,
-    rdd: OrderedRDD[Annotation, Annotation, (Annotation, Iterable[Annotation])]): VariantSampleMatrix =
-    new VariantSampleMatrix(hc, metadata,
+    rdd: OrderedRDD[Annotation, Annotation, (Annotation, Iterable[Annotation])]): MatrixTable =
+    new MatrixTable(hc, metadata,
       MatrixLiteral(
         MatrixType(metadata),
         MatrixValue(MatrixType(metadata), localValue, rdd)))
 
   def apply(hc: HailContext, fileMetadata: VSMFileMetadata,
-    rdd: OrderedRDD[Annotation, Annotation, (Annotation, Iterable[Annotation])]): VariantSampleMatrix =
-    VariantSampleMatrix(hc, fileMetadata.metadata, fileMetadata.localValue, rdd)
+    rdd: OrderedRDD[Annotation, Annotation, (Annotation, Iterable[Annotation])]): MatrixTable =
+    MatrixTable(hc, fileMetadata.metadata, fileMetadata.localValue, rdd)
 
   def fromLegacy[RK, T](hc: HailContext,
     metadata: VSMMetadata,
     localValue: VSMLocalValue,
-    rdd: RDD[(RK, (Annotation, Iterable[T]))]): VariantSampleMatrix = {
+    rdd: RDD[(RK, (Annotation, Iterable[T]))]): MatrixTable = {
     implicit val kOk = metadata.vSignature.orderedKey
-    VariantSampleMatrix(hc, metadata, localValue,
+    MatrixTable(hc, metadata, localValue,
       rdd.mapPartitions({ it =>
         it.map { case (v, (va, gs)) =>
           (v: Annotation, (va, gs: Iterable[Annotation]))
@@ -88,9 +88,9 @@ object VariantSampleMatrix {
     metadata: VSMMetadata,
     localValue: VSMLocalValue,
     rdd: RDD[(RK, (Annotation, Iterable[T]))],
-    fastKeys: RDD[RK]): VariantSampleMatrix = {
+    fastKeys: RDD[RK]): MatrixTable = {
     implicit val kOk = metadata.vSignature.orderedKey
-    VariantSampleMatrix(hc, metadata, localValue,
+    MatrixTable(hc, metadata, localValue,
       OrderedRDD(
         rdd.mapPartitions({ it =>
           it.map { case (v, (va, gs)) =>
@@ -102,7 +102,7 @@ object VariantSampleMatrix {
 
   def fromLegacy[RK, T](hc: HailContext,
     fileMetadata: VSMFileMetadata,
-    rdd: RDD[(RK, (Annotation, Iterable[T]))]): VariantSampleMatrix =
+    rdd: RDD[(RK, (Annotation, Iterable[T]))]): MatrixTable =
     fromLegacy(hc, fileMetadata.metadata, fileMetadata.localValue, rdd)
 
   def readFileMetadata(hConf: hadoop.conf.Configuration, dirname: String,
@@ -133,7 +133,7 @@ object VariantSampleMatrix {
       }
     }
 
-    if (metadata.version != VariantSampleMatrix.fileVersion)
+    if (metadata.version != MatrixTable.fileVersion)
       fatal(
         s"""Invalid VDS: old version [${ metadata.version }]
            |  Recreate VDS with current version of Hail.
@@ -172,10 +172,10 @@ object VariantSampleMatrix {
       metadata.n_partitions)
   }
 
-  def gen(hc: HailContext, gen: VSMSubgen): Gen[VariantSampleMatrix] =
+  def gen(hc: HailContext, gen: VSMSubgen): Gen[MatrixTable] =
     gen.gen(hc)
 
-  def genGeneric(hc: HailContext): Gen[VariantSampleMatrix] =
+  def genGeneric(hc: HailContext): Gen[MatrixTable] =
     VSMSubgen(
       sSigGen = Type.genArb,
       saSigGen = Type.genArb,
@@ -191,7 +191,7 @@ object VariantSampleMatrix {
       tGen = (t: Type, v: Annotation) => t.genValue.resize(20))
       .gen(hc)
 
-  def checkDatasetSchemasCompatible(datasets: Array[VariantSampleMatrix]) {
+  def checkDatasetSchemasCompatible(datasets: Array[MatrixTable]) {
     val first = datasets(0)
     val sampleIds = first.sampleIds
     val vaSchema = first.vaSignature
@@ -254,10 +254,10 @@ object VariantSampleMatrix {
     }
   }
 
-  def union(datasets: java.util.ArrayList[VariantSampleMatrix]): VariantSampleMatrix =
+  def union(datasets: java.util.ArrayList[MatrixTable]): MatrixTable =
     union(datasets.asScala.toArray)
 
-  def union(datasets: Array[VariantSampleMatrix]): VariantSampleMatrix = {
+  def union(datasets: Array[MatrixTable]): MatrixTable = {
     require(datasets.length >= 2)
 
     checkDatasetSchemasCompatible(datasets)
@@ -281,7 +281,7 @@ case class VSMSubgen(
   tGen: (Type, Annotation) => Gen[Annotation],
   wasSplit: Boolean = false) {
 
-  def gen(hc: HailContext): Gen[VariantSampleMatrix] =
+  def gen(hc: HailContext): Gen[MatrixTable] =
     for (size <- Gen.size;
       (l, w) <- Gen.squareOfAreaAtMostSize.resize((size / 3 / 10) * 8);
 
@@ -307,7 +307,7 @@ case class VSMSubgen(
       yield {
         assert(sampleIds.forall(_ != null))
         assert(rows.forall(_._1 != null))
-        VariantSampleMatrix.fromLegacy(hc,
+        MatrixTable.fromLegacy(hc,
           VSMMetadata(sSig, saSig, vSig, vaSig, globalSig, tSig, wasSplit = wasSplit),
           VSMLocalValue(global, sampleIds, saValues),
           hc.sc.parallelize(rows, nPartitions))
@@ -355,7 +355,7 @@ object VSMSubgen {
     tGen = (t: Type, v: Annotation) => Genotype.genRealistic(v.asInstanceOf[Variant]))
 }
 
-class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
+class MatrixTable(val hc: HailContext, val metadata: VSMMetadata,
   val ast: MatrixIR) extends JoinAnnotator {
 
   implicit val kOk: OrderedKey[Annotation, Annotation] = ast.typ.vType.orderedKey
@@ -449,7 +449,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
 
   def take(n: Int): Array[UnsafeRow] = unsafeRowRDD().take(n)
 
-  def groupSamplesBy(keyExpr: String, aggExpr: String): VariantSampleMatrix = {
+  def groupSamplesBy(keyExpr: String, aggExpr: String): MatrixTable = {
     val localRowType = rowType
     val sEC = EvalContext(Map(Annotation.GLOBAL_HEAD -> (0, globalSignature),
       "s" -> (1, sSignature),
@@ -519,7 +519,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
       genotypeSignature = entryType)
   }
 
-  def groupVariantsBy(keyExpr: String, aggExpr: String): VariantSampleMatrix = {
+  def groupVariantsBy(keyExpr: String, aggExpr: String): MatrixTable = {
     val localRowType = rowType
     val vEC = EvalContext(Map(Annotation.GLOBAL_HEAD -> (0, globalSignature),
       "v" -> (1, vSignature),
@@ -573,7 +573,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
       genotypeSignature = resultType)
   }
 
-  def annotateGlobal(a: Annotation, t: Type, code: String): VariantSampleMatrix = {
+  def annotateGlobal(a: Annotation, t: Type, code: String): MatrixTable = {
     val (newT, i) = insertGlobal(t, Parser.parseAnnotationRoot(code, Annotation.GLOBAL_HEAD))
     copy2(globalSignature = newT, globalAnnotation = i(globalAnnotation, a))
   }
@@ -583,7 +583,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     *
     * @param expr Annotation expression
     */
-  def annotateGlobalExpr(expr: String): VariantSampleMatrix = {
+  def annotateGlobalExpr(expr: String): MatrixTable = {
     val ec = EvalContext(Map(
       "global" -> (0, globalSignature)))
 
@@ -614,7 +614,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     globalSignature.insert(sig, path)
   }
 
-  def annotateSamples(signature: Type, path: List[String], annotations: Array[Annotation]): VariantSampleMatrix = {
+  def annotateSamples(signature: Type, path: List[String], annotations: Array[Annotation]): MatrixTable = {
     val (t, ins) = insertSA(signature, path)
 
     val newAnnotations = new Array[Annotation](nSamples)
@@ -627,7 +627,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     copy(sampleAnnotations = newAnnotations, saSignature = t)
   }
 
-  def annotateSamplesExpr(expr: String): VariantSampleMatrix = {
+  def annotateSamplesExpr(expr: String): MatrixTable = {
     val ec = sampleEC
 
     val (paths, types, f) = Parser.parseAnnotationExprs(expr, ec, Some(Annotation.SAMPLE_HEAD))
@@ -659,17 +659,17 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     )
   }
 
-  def annotateSamples(annotations: Map[Annotation, Annotation], signature: Type, code: String): VariantSampleMatrix = {
+  def annotateSamples(annotations: Map[Annotation, Annotation], signature: Type, code: String): MatrixTable = {
     val (t, i) = insertSA(signature, Parser.parseAnnotationRoot(code, Annotation.SAMPLE_HEAD))
     annotateSamples(s => annotations.getOrElse(s, null), t, i)
   }
 
-  def annotateSamplesTable(kt: KeyTable, vdsKey: java.util.ArrayList[String],
-    root: String, expr: String, product: Boolean): VariantSampleMatrix =
+  def annotateSamplesTable(kt: Table, vdsKey: java.util.ArrayList[String],
+    root: String, expr: String, product: Boolean): MatrixTable =
     annotateSamplesTable(kt, if (vdsKey != null) vdsKey.asScala else null, root, expr, product)
 
-  def annotateSamplesTable(kt: KeyTable, vdsKey: Seq[String] = null,
-    root: String = null, expr: String = null, product: Boolean = false): VariantSampleMatrix = {
+  def annotateSamplesTable(kt: Table, vdsKey: Seq[String] = null,
+    root: String = null, expr: String = null, product: Boolean = false): MatrixTable = {
 
     if (root == null && expr == null || root != null && expr != null)
       fatal("method `annotateSamplesTable' requires one of `root' or 'expr', but not both")
@@ -752,7 +752,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     }
   }
 
-  def annotateSamples(annotation: (Annotation) => Annotation, newSignature: Type, inserter: Inserter): VariantSampleMatrix = {
+  def annotateSamples(annotation: (Annotation) => Annotation, newSignature: Type, inserter: Inserter): MatrixTable = {
     val newAnnotations = sampleIds.zipWithIndex.map { case (id, i) =>
       val sa = sampleAnnotations(i)
       val newAnnotation = inserter(sa, annotation(id))
@@ -763,7 +763,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     copy2(sampleAnnotations = newAnnotations, saSignature = newSignature)
   }
 
-  def mapAnnotations(newVASignature: Type, f: (Annotation, Annotation, Iterable[Annotation]) => Annotation): VariantSampleMatrix = {
+  def mapAnnotations(newVASignature: Type, f: (Annotation, Annotation, Iterable[Annotation]) => Annotation): MatrixTable = {
     val localRowType = rowType
     insertIntoRow(() => new UnsafeRow(localRowType))(newVASignature, List("va"), { case (ur, rv, rvb) =>
       ur.set(rv)
@@ -774,7 +774,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     })
   }
 
-  def annotateVariantsExpr(expr: String): VariantSampleMatrix = {
+  def annotateVariantsExpr(expr: String): MatrixTable = {
     val localGlobalAnnotation = globalAnnotation
 
     val ec = variantEC
@@ -817,12 +817,12 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
       })
   }
 
-  def annotateVariantsTable(kt: KeyTable, vdsKey: java.util.ArrayList[String],
-    root: String, expr: String, product: Boolean): VariantSampleMatrix =
+  def annotateVariantsTable(kt: Table, vdsKey: java.util.ArrayList[String],
+    root: String, expr: String, product: Boolean): MatrixTable =
     annotateVariantsTable(kt, if (vdsKey != null) vdsKey.asScala else null, root, expr, product)
 
-  def annotateVariantsTable(kt: KeyTable, vdsKey: Seq[String] = null,
-    root: String = null, expr: String = null, product: Boolean = false): VariantSampleMatrix = {
+  def annotateVariantsTable(kt: Table, vdsKey: Seq[String] = null,
+    root: String = null, expr: String = null, product: Boolean = false): MatrixTable = {
 
     if (root == null && expr == null || root != null && expr != null)
       fatal("method `annotateVariantsTable' requires one of `root' or 'expr', but not both")
@@ -944,7 +944,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
   }
 
   def annotateLoci(lociRDD: OrderedRDD[Annotation, Annotation, Annotation], newSignature: Type,
-    inserter: Inserter, product: Boolean): VariantSampleMatrix = {
+    inserter: Inserter, product: Boolean): MatrixTable = {
 
     def annotate[S](joinedRDD: RDD[(Annotation, ((Annotation, (Annotation, Iterable[Annotation])), S))],
       ins: (Annotation, S) => Annotation): OrderedRDD[Annotation, Annotation, (Annotation, Iterable[Annotation])] = {
@@ -969,7 +969,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
 
   def nPartitions: Int = rdd2.partitions.length
 
-  def annotateVariants2(rightRDD2: OrderedRVD, newVAType: Type, inserter: Inserter): VariantSampleMatrix = {
+  def annotateVariants2(rightRDD2: OrderedRVD, newVAType: Type, inserter: Inserter): MatrixTable = {
     val leftRowType = rowType
     val rightRowType = rightRDD2.typ.rowType
 
@@ -1020,7 +1020,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
   }
 
   def annotateVariants(otherRDD: OrderedRDD[Annotation, Annotation, Annotation], newSignature: Type,
-    inserter: Inserter, product: Boolean): VariantSampleMatrix = {
+    inserter: Inserter, product: Boolean): MatrixTable = {
     val newRDD = if (product)
       rdd.orderedLeftJoin(otherRDD)
         .mapValues { case ((va, gs), annotation) =>
@@ -1035,8 +1035,8 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     copy(rdd = newRDD, vaSignature = newSignature)
   }
 
-  def annotateVariantsVDS(right: VariantSampleMatrix,
-    root: Option[String] = None, code: Option[String] = None): VariantSampleMatrix = {
+  def annotateVariantsVDS(right: MatrixTable,
+    root: Option[String] = None, code: Option[String] = None): MatrixTable = {
 
     val (isCode, annotationExpr) = (root, code) match {
       case (Some(r), None) => (false, r)
@@ -1061,7 +1061,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
 
   def variants: RDD[Annotation] = rdd.keys
 
-  def deduplicate(): VariantSampleMatrix =
+  def deduplicate(): MatrixTable =
     copy2(rdd2 = rdd2.mapPartitionsPreservesPartitioning(rdd2.typ)(
       SortedDistinctRowIterator.transformer(rdd2.typ)))
 
@@ -1069,12 +1069,12 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
 
   def deleteVA(path: List[String]): (Type, Deleter) = vaSignature.delete(path)
 
-  def dropSamples(): VariantSampleMatrix =
+  def dropSamples(): MatrixTable =
     copyAST(ast = FilterSamples(ast, Const(null, false, TBoolean())))
 
-  def dropVariants(): VariantSampleMatrix = copy2(rdd2 = OrderedRVD.empty(sparkContext, matrixType.orderedRVType))
+  def dropVariants(): MatrixTable = copy2(rdd2 = OrderedRVD.empty(sparkContext, matrixType.orderedRVType))
 
-  def explodeVariants(code: String): VariantSampleMatrix = {
+  def explodeVariants(code: String): MatrixTable = {
     val path = List(Annotation.VARIANT_HEAD) ++ Parser.parseAnnotationRoot(code, Annotation.VARIANT_HEAD)
     val (keysType, querier) = rowType.queryTyped(path)
     val keyType = keysType match {
@@ -1113,7 +1113,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     copy2(vaSignature = newVAType, rdd2 = rdd2.copy(typ = newMatrixType.orderedRVType, rdd = explodedRDD))
   }
 
-  def explodeSamples(code: String): VariantSampleMatrix = {
+  def explodeSamples(code: String): MatrixTable = {
     val path = Parser.parseAnnotationRoot(code, Annotation.SAMPLE_HEAD)
     val (keysType, querier) = saSignature.queryTyped(path)
     val keyType = keysType match {
@@ -1189,7 +1189,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
       rdd2 = rdd2.copy(rdd = newRDD))
   }
 
-  def annotateGenotypesExpr(expr: String): VariantSampleMatrix = {
+  def annotateGenotypesExpr(expr: String): MatrixTable = {
     val symTab = Map(
       "v" -> (0, vSignature),
       "va" -> (1, vaSignature),
@@ -1220,7 +1220,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     })
   }
 
-  def filterVariants(p: (Annotation, Annotation, Iterable[Annotation]) => Boolean): VariantSampleMatrix = {
+  def filterVariants(p: (Annotation, Annotation, Iterable[Annotation]) => Boolean): MatrixTable = {
     val localRowType = matrixType.rowType
     copy2(rdd2 = rdd2.filter { rv =>
       // FIXME ur could be allocate once and set
@@ -1234,7 +1234,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     })
   }
 
-  def filterSamples(p: (Annotation, Annotation) => Boolean): VariantSampleMatrix = {
+  def filterSamples(p: (Annotation, Annotation) => Boolean): MatrixTable = {
     copyAST(ast = MatrixLiteral(matrixType, value.filterSamples(p)))
   }
 
@@ -1244,14 +1244,14 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     * @param filterExpr Filter expression involving `s' (sample) and `sa' (sample annotations)
     * @param keep       keep where filterExpr evaluates to true
     */
-  def filterSamplesExpr(filterExpr: String, keep: Boolean = true): VariantSampleMatrix = {
+  def filterSamplesExpr(filterExpr: String, keep: Boolean = true): MatrixTable = {
     var filterAST = Parser.expr.parse(filterExpr)
     if (!keep)
       filterAST = Apply(filterAST.getPos, "!", Array(filterAST))
     copyAST(ast = FilterSamples(ast, filterAST))
   }
 
-  def filterSamplesList(samples: java.util.ArrayList[Annotation], keep: Boolean): VariantSampleMatrix =
+  def filterSamplesList(samples: java.util.ArrayList[Annotation], keep: Boolean): MatrixTable =
     filterSamplesList(samples.asScala.toSet, keep)
 
   /**
@@ -1260,12 +1260,12 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     * @param samples Set of samples to keep or remove
     * @param keep    Keep listed samples.
     */
-  def filterSamplesList(samples: Set[Annotation], keep: Boolean = true): VariantSampleMatrix = {
+  def filterSamplesList(samples: Set[Annotation], keep: Boolean = true): MatrixTable = {
     val p = (s: Annotation, sa: Annotation) => Filter.keepThis(samples.contains(s), keep)
     filterSamples(p)
   }
 
-  def filterSamplesTable(table: KeyTable, keep: Boolean): VariantSampleMatrix = {
+  def filterSamplesTable(table: Table, keep: Boolean): MatrixTable = {
     table.keyFields.map(_.typ) match {
       case Array(`sSignature`) =>
         val sampleSet = table.keyedRDD()
@@ -1287,17 +1287,17 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     * @param keep       keep variants where filterExpr evaluates to true
     * @return
     */
-  def filterVariantsExpr(filterExpr: String, keep: Boolean = true): VariantSampleMatrix = {
+  def filterVariantsExpr(filterExpr: String, keep: Boolean = true): MatrixTable = {
     var filterAST = Parser.expr.parse(filterExpr)
     if (!keep)
       filterAST = Apply(filterAST.getPos, "!", Array(filterAST))
     copyAST(ast = FilterVariants(ast, filterAST))
   }
 
-  def filterVariantsList(variants: java.util.ArrayList[Annotation], keep: Boolean): VariantSampleMatrix =
+  def filterVariantsList(variants: java.util.ArrayList[Annotation], keep: Boolean): MatrixTable =
     filterVariantsList(variants.asScala.toSet, keep)
 
-  def filterVariantsList(variants: Set[Annotation], keep: Boolean): VariantSampleMatrix = {
+  def filterVariantsList(variants: Set[Annotation], keep: Boolean): MatrixTable = {
     if (keep) {
       val partitionVariants = variants
         .groupBy(v => rdd.orderedPartitioner.getPartition(v))
@@ -1328,7 +1328,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     }
   }
 
-  def filterVariantsTable(kt: KeyTable, keep: Boolean = true): VariantSampleMatrix = {
+  def filterVariantsTable(kt: Table, keep: Boolean = true): MatrixTable = {
     val keyFields = kt.keyFields.map(_.typ)
     val filt = keyFields match {
       case Array(`vSignature`) =>
@@ -1413,7 +1413,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
 
   def hadoopConf: hadoop.conf.Configuration = hc.hadoopConf
 
-  def head(n: Long): VariantSampleMatrix = {
+  def head(n: Long): MatrixTable = {
     if (n < 0)
       fatal(s"n must be non-negative! Found `$n'.")
     copy(rdd = rdd.head(n))
@@ -1429,7 +1429,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     * @param maximum        Sample pairs with a PI_HAT above this value will not be included in the output. Must be in [0,1]
     */
   def ibd(computeMafExpr: Option[String] = None, bounded: Boolean = true,
-    minimum: Option[Double] = None, maximum: Option[Double] = None): KeyTable = {
+    minimum: Option[Double] = None, maximum: Option[Double] = None): Table = {
     require(wasSplit)
     IBD(this, computeMafExpr, bounded, minimum, maximum)
   }
@@ -1443,7 +1443,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
   }
 
   def insertIntoRow[PC](makePartitionContext: () => PC)(typeToInsert: Type, path: List[String],
-    inserter: (PC, RegionValue, RegionValueBuilder) => Unit): VariantSampleMatrix = {
+    inserter: (PC, RegionValue, RegionValueBuilder) => Unit): MatrixTable = {
     val newRDD2 = rdd2.insert(makePartitionContext)(typeToInsert, path, inserter)
     copy2(rdd2 = newRDD2,
       // don't need to update vSignature, insert can't change the keys
@@ -1455,7 +1455,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     *
     * @param right right-hand dataset with which to join
     */
-  def join(right: VariantSampleMatrix): VariantSampleMatrix = {
+  def join(right: MatrixTable): MatrixTable = {
     if (wasSplit != right.wasSplit) {
       warn(
         s"""cannot join split and unsplit datasets
@@ -1548,7 +1548,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
       rdd2 = OrderedRVD(rdd2.typ, rdd2.partitioner, joined))
   }
 
-  def makeKT(variantCondition: String, genotypeCondition: String, keyNames: Array[String] = Array.empty, seperator: String = "."): KeyTable = {
+  def makeKT(variantCondition: String, genotypeCondition: String, keyNames: Array[String] = Array.empty, seperator: String = "."): Table = {
     requireColKeyString("make table")
 
     val vSymTab = Map(
@@ -1584,7 +1584,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     val localSampleIdsBc = sampleIdsBc
     val localSampleAnnotationsBc = sampleAnnotationsBc
 
-    KeyTable(hc,
+    Table(hc,
       rdd.mapPartitions { it =>
         val n = vNames.length + gNames.length * localNSamples
 
@@ -1617,7 +1617,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
   }
 
   def mapValuesWithAll[U >: Null](newGSignature: Type, f: (Annotation, Annotation, Annotation, Annotation, Annotation) => U)
-    (implicit uct: ClassTag[U]): VariantSampleMatrix = {
+    (implicit uct: ClassTag[U]): MatrixTable = {
     val localSampleIdsBc = sampleIdsBc
     val localSampleAnnotationsBc = sampleAnnotationsBc
     copy(genotypeSignature = newGSignature,
@@ -1627,7 +1627,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
       })
   }
 
-  def mendelErrors(ped: Pedigree): (KeyTable, KeyTable, KeyTable, KeyTable) = {
+  def mendelErrors(ped: Pedigree): (Table, Table, Table, Table) = {
     require(wasSplit)
     requireColKeyString("mendel errors")
     requireRowKeyVariant("mendel errors")
@@ -1780,10 +1780,10 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     ts.map { case (t, f) => (f(), t) }
   }
 
-  def reorderSamples(newIds: java.util.ArrayList[Annotation]): VariantSampleMatrix =
+  def reorderSamples(newIds: java.util.ArrayList[Annotation]): MatrixTable =
     reorderSamples(newIds.asScala.toArray)
 
-  def reorderSamples(newIds: Array[Annotation]): VariantSampleMatrix = {
+  def reorderSamples(newIds: Array[Annotation]): MatrixTable = {
     requireUniqueSamples("reorder_samples")
 
     val oldOrder = sampleIds.zipWithIndex.toMap
@@ -1834,24 +1834,24 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     copy(rdd = reorderedRdd, sampleIds = newIds, sampleAnnotations = newAnnotations)
   }
 
-  def renameSamples(newIds: java.util.ArrayList[Annotation]): VariantSampleMatrix =
+  def renameSamples(newIds: java.util.ArrayList[Annotation]): MatrixTable =
     renameSamples(newIds.asScala.toArray)
 
-  def renameSamples(newIds: Array[Annotation]): VariantSampleMatrix = {
+  def renameSamples(newIds: Array[Annotation]): MatrixTable = {
     if (newIds.length != sampleIds.length)
       fatal(s"dataset contains $nSamples samples, but new ID list contains ${ newIds.length }")
     copy2(sampleIds = newIds)
   }
 
-  def renameSamples(mapping: java.util.Map[Annotation, Annotation]): VariantSampleMatrix =
+  def renameSamples(mapping: java.util.Map[Annotation, Annotation]): MatrixTable =
     renameSamples(mapping.asScala.toMap)
 
-  def renameSamples(mapping: Map[Annotation, Annotation]): VariantSampleMatrix = {
+  def renameSamples(mapping: Map[Annotation, Annotation]): MatrixTable = {
     val newSampleIds = sampleIds.map(s => mapping.getOrElse(s, s))
     copy2(sampleIds = newSampleIds)
   }
 
-  def renameDuplicates(): VariantSampleMatrix = {
+  def renameDuplicates(): MatrixTable = {
     requireColKeyString("rename duplicates")
     val (newIds, duplicates) = mangle(stringSampleIds.toArray)
     if (duplicates.nonEmpty)
@@ -1864,7 +1864,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     copy2(sampleIds = newIds, saSignature = newSchema, sampleAnnotations = newAnnotations)
   }
 
-  def same(that: VariantSampleMatrix, tolerance: Double = utils.defaultTolerance): Boolean = {
+  def same(that: MatrixTable, tolerance: Double = utils.defaultTolerance): Boolean = {
     var metadataSame = true
     if (vaSignature != that.vaSignature) {
       metadataSame = false
@@ -1982,14 +1982,14 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
       "gs" -> (3, TAggregable(genotypeSignature, aggregationST))))
   }
 
-  def sampleAnnotationsSimilar(that: VariantSampleMatrix, tolerance: Double = utils.defaultTolerance): Boolean = {
+  def sampleAnnotationsSimilar(that: MatrixTable, tolerance: Double = utils.defaultTolerance): Boolean = {
     require(saSignature == that.saSignature)
     sampleAnnotations.zip(that.sampleAnnotations)
       .forall { case (s1, s2) => saSignature.valuesSimilar(s1, s2, tolerance)
       }
   }
 
-  def sampleVariants(fraction: Double, seed: Int = 1): VariantSampleMatrix = {
+  def sampleVariants(fraction: Double, seed: Int = 1): MatrixTable = {
     require(fraction > 0 && fraction < 1, s"the 'fraction' parameter must fall between 0 and 1, found $fraction")
     copy2(rdd2 = rdd2.sample(withReplacement = false, fraction, seed))
   }
@@ -2004,8 +2004,8 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     vaSignature: Type = vaSignature,
     globalSignature: Type = globalSignature,
     genotypeSignature: Type = genotypeSignature,
-    wasSplit: Boolean = wasSplit): VariantSampleMatrix =
-    VariantSampleMatrix(hc,
+    wasSplit: Boolean = wasSplit): MatrixTable =
+    MatrixTable(hc,
       VSMMetadata(sSignature, saSignature, vSignature, vaSignature, globalSignature, genotypeSignature, wasSplit),
       VSMLocalValue(globalAnnotation, sampleIds, sampleAnnotations), rdd)
 
@@ -2019,8 +2019,8 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     vaSignature: Type = vaSignature,
     globalSignature: Type = globalSignature,
     genotypeSignature: Type = genotypeSignature,
-    wasSplit: Boolean = wasSplit): VariantSampleMatrix =
-    VariantSampleMatrix.fromLegacy(hc,
+    wasSplit: Boolean = wasSplit): MatrixTable =
+    MatrixTable.fromLegacy(hc,
       VSMMetadata(sSignature, saSignature, vSignature, vaSignature, globalSignature, genotypeSignature, wasSplit),
       VSMLocalValue(globalAnnotation, sampleIds, sampleAnnotations),
       rdd)
@@ -2035,8 +2035,8 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     vaSignature: Type = vaSignature,
     globalSignature: Type = globalSignature,
     genotypeSignature: Type = genotypeSignature,
-    wasSplit: Boolean = wasSplit): VariantSampleMatrix =
-    new VariantSampleMatrix(hc,
+    wasSplit: Boolean = wasSplit): MatrixTable =
+    new MatrixTable(hc,
       VSMMetadata(sSignature, saSignature, vSignature, vaSignature, globalSignature, genotypeSignature, wasSplit),
       VSMLocalValue(globalAnnotation, sampleIds, sampleAnnotations), rdd2)
 
@@ -2047,13 +2047,13 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     vaSignature: Type = vaSignature,
     globalSignature: Type = globalSignature,
     genotypeSignature: Type = genotypeSignature,
-    wasSplit: Boolean = wasSplit): VariantSampleMatrix =
-    new VariantSampleMatrix(hc,
+    wasSplit: Boolean = wasSplit): MatrixTable =
+    new MatrixTable(hc,
       VSMMetadata(sSignature, saSignature, vSignature, vaSignature, globalSignature, genotypeSignature, wasSplit),
       ast)
 
-  def samplesKT(): KeyTable = {
-    KeyTable(hc, sparkContext.parallelize(sampleIdsAndAnnotations)
+  def samplesKT(): Table = {
+    Table(hc, sparkContext.parallelize(sampleIdsAndAnnotations)
       .map { case (s, sa) =>
         Row(s, sa)
       },
@@ -2081,7 +2081,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
   }
 
   override def toString =
-    s"VariantSampleMatrix(metadata=$metadata, rdd=$rdd, sampleIds=$sampleIds, nSamples=$nSamples, vaSignature=$vaSignature, saSignature=$saSignature, globalSignature=$globalSignature, sampleAnnotations=$sampleAnnotations, sampleIdsAndAnnotations=$sampleIdsAndAnnotations, globalAnnotation=$globalAnnotation, wasSplit=$wasSplit)"
+    s"MatrixTable(metadata=$metadata, rdd=$rdd, sampleIds=$sampleIds, nSamples=$nSamples, vaSignature=$vaSignature, saSignature=$saSignature, globalSignature=$globalSignature, sampleAnnotations=$sampleAnnotations, sampleIdsAndAnnotations=$sampleIdsAndAnnotations, globalAnnotation=$globalAnnotation, wasSplit=$wasSplit)"
 
   def nSamples: Int = sampleIds.length
 
@@ -2139,12 +2139,12 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
       "gs" -> (3, TAggregable(genotypeSignature, aggregationST))))
   }
 
-  def variantsKT(): KeyTable = {
+  def variantsKT(): Table = {
     val localRowType = rowType
     val typ = TStruct(
       "v" -> vSignature,
       "va" -> vaSignature)
-    new KeyTable(hc, rdd2.mapPartitions { it =>
+    new Table(hc, rdd2.mapPartitions { it =>
       val rv2b = new RegionValueBuilder()
       val rv2 = RegionValue()
       it.map { rv =>
@@ -2162,7 +2162,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
       Array("v"))
   }
 
-  def genotypeKT(): KeyTable = {
+  def genotypeKT(): Table = {
     val localNSamples = nSamples
     val localSType = sSignature
     val localSAType = saSignature
@@ -2176,7 +2176,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     val gsType = localRowType.fieldType(3).asInstanceOf[TArray]
     val localSampleIdsBc = sampleIdsBc
     val localSampleAnnotationsBc = sampleAnnotationsBc
-    new KeyTable(hc, rdd2.mapPartitions { it =>
+    new Table(hc, rdd2.mapPartitions { it =>
       val rv2b = new RegionValueBuilder()
       val rv2 = RegionValue()
       it.flatMap { rv =>
@@ -2224,7 +2224,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     val globalJ = JSONAnnotationImpex.exportAnnotation(globalAnnotation, globalSignature)
 
     val metadata = VDSMetadata(
-      version = VariantSampleMatrix.fileVersion,
+      version = MatrixTable.fileVersion,
       split = wasSplit,
       sample_schema = sSignature.toPrettyString(compact = true),
       sample_annotation_schema = saSignature.toPrettyString(compact = true),
@@ -2241,9 +2241,9 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
       Serialization.write(metadata, out))
   }
 
-  def coalesce(k: Int, shuffle: Boolean = true): VariantSampleMatrix = copy2(rdd2 = rdd2.coalesce(k, shuffle))
+  def coalesce(k: Int, shuffle: Boolean = true): MatrixTable = copy2(rdd2 = rdd2.coalesce(k, shuffle))
 
-  def persist(storageLevel: String = "MEMORY_AND_DISK"): VariantSampleMatrix = {
+  def persist(storageLevel: String = "MEMORY_AND_DISK"): MatrixTable = {
     val level = try {
       StorageLevel.fromString(storageLevel)
     } catch {
@@ -2254,11 +2254,11 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     copy2(rdd2 = rdd2.persist(level))
   }
 
-  def cache(): VariantSampleMatrix = persist("MEMORY_ONLY")
+  def cache(): MatrixTable = persist("MEMORY_ONLY")
 
-  def unpersist(): VariantSampleMatrix = copy2(rdd2 = rdd2.unpersist())
+  def unpersist(): MatrixTable = copy2(rdd2 = rdd2.unpersist())
 
-  def naiveCoalesce(maxPartitions: Int): VariantSampleMatrix =
+  def naiveCoalesce(maxPartitions: Int): MatrixTable =
     copy2(rdd2 = rdd2.naiveCoalesce(maxPartitions))
 
   /**
@@ -2266,7 +2266,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     *                   sa (sample annotations), and g (genotype annotation), which returns a boolean value
     * @param keep       keep genotypes where filterExpr evaluates to true
     */
-  def filterGenotypes(filterExpr: String, keep: Boolean = true): VariantSampleMatrix = {
+  def filterGenotypes(filterExpr: String, keep: Boolean = true): MatrixTable = {
 
     val symTab = Map(
       "v" -> (0, vSignature),
@@ -2312,13 +2312,13 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     hadoopConf.writeTextFile(dirname + "/_SUCCESS")(out => ())
   }
 
-  def linreg(ysExpr: Array[String], xExpr: String, covExpr: Array[String] = Array.empty[String], root: String = "va.linreg", variantBlockSize: Int = 16): VariantSampleMatrix = {
+  def linreg(ysExpr: Array[String], xExpr: String, covExpr: Array[String] = Array.empty[String], root: String = "va.linreg", variantBlockSize: Int = 16): MatrixTable = {
     LinearRegression(this, ysExpr, xExpr, covExpr, root, variantBlockSize)
   }
 
   def logreg(test: String,
     y: String, x: String, covariates: Array[String] = Array.empty[String],
-    root: String = "va.logreg"): VariantSampleMatrix = {
+    root: String = "va.logreg"): MatrixTable = {
     LogisticRegression(this, test, y, x, covariates, root)
   }
 
@@ -2333,7 +2333,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     delta: Option[Double] = None,
     sparsityThreshold: Double = 1.0,
     nEigs: Option[Int] = None,
-    optDroppedVarianceFraction: Option[Double] = None): VariantSampleMatrix = {
+    optDroppedVarianceFraction: Option[Double] = None): MatrixTable = {
     LinearMixedRegression(this, kinshipMatrix, y, x, covariates, useML, rootGA, rootVA,
       runAssoc, delta, sparsityThreshold, nEigs, optDroppedVarianceFraction)
   }
@@ -2346,7 +2346,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     logistic: Boolean = false,
     maxSize: Int = 46340, // floor(sqrt(Int.MaxValue))
     accuracy: Double = 1e-6,
-    iterations: Int = 10000): KeyTable = {
+    iterations: Int = 10000): Table = {
     Skat(this, keyExpr, weightExpr, y, x, covariates, logistic, maxSize, accuracy, iterations)
   }
 
@@ -2361,7 +2361,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     ExportVCF(this, path, append, parallel, metadata)
   }
 
-  def minRep(leftAligned: Boolean = false): VariantSampleMatrix = {
+  def minRep(leftAligned: Boolean = false): MatrixTable = {
     requireRowKeyVariant("min_rep")
 
     val localRowType = rowType
@@ -2417,13 +2417,28 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     copy2(rdd2 = newRDD2)
   }
 
+<<<<<<< 4e50b291a72a86a0529d75f29e1520edf5bef894:src/main/scala/is/hail/variant/VariantSampleMatrix.scala
   def ldPrune(nCores: Int, r2Threshold: Double = 0.2, windowSize: Int = 1000000, memoryPerCore: Int = 256): VariantSampleMatrix = {
+=======
+  def sampleQC(root: String = "sa.qc"): MatrixTable = {
+    requireRowKeyVariant("sample_qc")
+    SampleQC(this, root)
+  }
+
+  def variantQC(root: String = "va.qc"): MatrixTable = {
+    require(wasSplit)
+    requireRowKeyVariant("variant_qc")
+    VariantQC(this, root)
+  }
+
+  def ldPrune(nCores: Int, r2Threshold: Double = 0.2, windowSize: Int = 1000000, memoryPerCore: Int = 256): MatrixTable = {
+>>>>>>> Renamed VSM => MatrixTable, KeyTable => Table.:src/main/scala/is/hail/variant/MatrixTable.scala
     require(wasSplit)
     requireRowKeyVariant("ld_prune")
     LDPrune(this, nCores, r2Threshold, windowSize, memoryPerCore * 1024L * 1024L)
   }
 
-  def trioMatrix(pedigree: Pedigree, completeTrios: Boolean): VariantSampleMatrix = {
+  def trioMatrix(pedigree: Pedigree, completeTrios: Boolean): MatrixTable = {
     if (!sSignature.isInstanceOf[TString])
       fatal("trio_matrix requires column keys of type String")
     requireUniqueSamples("trio_matrix")
@@ -2556,7 +2571,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
       genotypeSignature = newEntryType)
   }
 
-  def pca(expr: String, k: Int = 10, computeLoadings: Boolean = false, asArrays: Boolean = false): (IndexedSeq[Double], KeyTable, Option[KeyTable]) = {
+  def pca(expr: String, k: Int = 10, computeLoadings: Boolean = false, asArrays: Boolean = false): (IndexedSeq[Double], Table, Option[Table]) = {
     if (k < 1)
       fatal(
         s"""requested invalid number of components: $k
@@ -2593,7 +2608,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
         rv
       }
     }
-    val scores = new KeyTable(hc,
+    val scores = new Table(hc,
       scoresrdd,
       rowType,
       Array("s"))
@@ -2613,7 +2628,7 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     *                   objects necessary for Spark and Hail).
     * @param statistics which subset of the four statistics to compute
     */
-  def pcRelate(k: Int, pcaScores: KeyTable, maf: Double, blockSize: Int, minKinship: Double = PCRelate.defaultMinKinship, statistics: PCRelate.StatisticSubset = PCRelate.defaultStatisticSubset): KeyTable = {
+  def pcRelate(k: Int, pcaScores: Table, maf: Double, blockSize: Int, minKinship: Double = PCRelate.defaultMinKinship, statistics: PCRelate.StatisticSubset = PCRelate.defaultStatisticSubset): Table = {
     require(wasSplit)
     val scoreArray = new Array[Double](nSamples * k)
     val pcs = pcaScores.collect().asInstanceOf[IndexedSeq[UnsafeRow]]

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -6,7 +6,7 @@ import is.hail.distributedmatrix._
 import is.hail.expr._
 import is.hail.io.VCFMetadata
 import is.hail.io.vcf.ExportVCF
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.methods.Aggregators.SampleFunctions
 import is.hail.methods._
 import is.hail.sparkextras._

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -2417,22 +2417,7 @@ class MatrixTable(val hc: HailContext, val metadata: VSMMetadata,
     copy2(rdd2 = newRDD2)
   }
 
-<<<<<<< 4e50b291a72a86a0529d75f29e1520edf5bef894:src/main/scala/is/hail/variant/VariantSampleMatrix.scala
-  def ldPrune(nCores: Int, r2Threshold: Double = 0.2, windowSize: Int = 1000000, memoryPerCore: Int = 256): VariantSampleMatrix = {
-=======
-  def sampleQC(root: String = "sa.qc"): MatrixTable = {
-    requireRowKeyVariant("sample_qc")
-    SampleQC(this, root)
-  }
-
-  def variantQC(root: String = "va.qc"): MatrixTable = {
-    require(wasSplit)
-    requireRowKeyVariant("variant_qc")
-    VariantQC(this, root)
-  }
-
   def ldPrune(nCores: Int, r2Threshold: Double = 0.2, windowSize: Int = 1000000, memoryPerCore: Int = 256): MatrixTable = {
->>>>>>> Renamed VSM => MatrixTable, KeyTable => Table.:src/main/scala/is/hail/variant/MatrixTable.scala
     require(wasSplit)
     requireRowKeyVariant("ld_prune")
     LDPrune(this, nCores, r2Threshold, windowSize, memoryPerCore * 1024L * 1024L)

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -3,7 +3,7 @@ package is.hail.variant
 import is.hail.annotations.{Annotation, _}
 import is.hail.expr.{EvalContext, Parser, TAggregable, TString, TStruct, Type, _}
 import is.hail.io.plink.ExportBedBimFam
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.methods._
 import is.hail.rvd.OrderedRVD
 import is.hail.stats.ComputeRRM

--- a/src/main/scala/is/hail/variant/package.scala
+++ b/src/main/scala/is/hail/variant/package.scala
@@ -24,5 +24,5 @@ package object variant {
 
   implicit def toRichIterableGenotype(ig: Iterable[Annotation]): RichIterableGenotype = new RichIterableGenotype(ig)
 
-  implicit def toVDSFunctions(vds: VariantSampleMatrix): VariantDatasetFunctions = new VariantDatasetFunctions(vds)
+  implicit def toVDSFunctions(vds: MatrixTable): VariantDatasetFunctions = new VariantDatasetFunctions(vds)
 }

--- a/src/test/scala/is/hail/TestUtils.scala
+++ b/src/test/scala/is/hail/TestUtils.scala
@@ -1,9 +1,9 @@
 package is.hail
 
 import breeze.linalg.{DenseMatrix, Matrix, Vector}
-import is.hail.keytable.KeyTable
+import is.hail.keytable.Table
 import is.hail.utils._
-import is.hail.variant.{Genotype, Locus, Variant, VariantSampleMatrix}
+import is.hail.variant.{Genotype, Locus, Variant, MatrixTable}
 import org.apache.spark.SparkException
 import org.apache.spark.sql.Row
 
@@ -71,14 +71,14 @@ object TestUtils {
   }
 
   // missing is -1
-  def vdsToMatrixInt(vds: VariantSampleMatrix): DenseMatrix[Int] =
+  def vdsToMatrixInt(vds: MatrixTable): DenseMatrix[Int] =
     new DenseMatrix[Int](
       vds.nSamples,
       vds.countVariants().toInt,
       vds.typedRDD[Locus, Variant].map(_._2._2.map(g => Genotype.unboxedGT(g))).collect().flatten)
 
   // missing is Double.NaN
-  def vdsToMatrixDouble(vds: VariantSampleMatrix): DenseMatrix[Double] =
+  def vdsToMatrixDouble(vds: MatrixTable): DenseMatrix[Double] =
     new DenseMatrix[Double](
       vds.nSamples,
       vds.countVariants().toInt,
@@ -93,7 +93,7 @@ object TestUtils {
         D_==(x.doubleValue(), y.doubleValue(), tolerance = tol)
     }
 
-  def keyTableBoxedDoubleToMap[T](kt: KeyTable): Map[T, IndexedSeq[java.lang.Double]] =
+  def keyTableBoxedDoubleToMap[T](kt: Table): Map[T, IndexedSeq[java.lang.Double]] =
     kt.collect().map { r =>
       val s = r.asInstanceOf[Row].toSeq
       s.head.asInstanceOf[T] -> s.tail.map(_.asInstanceOf[java.lang.Double]).toIndexedSeq

--- a/src/test/scala/is/hail/TestUtils.scala
+++ b/src/test/scala/is/hail/TestUtils.scala
@@ -1,7 +1,7 @@
 package is.hail
 
 import breeze.linalg.{DenseMatrix, Matrix, Vector}
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.utils._
 import is.hail.variant.{Genotype, Locus, Variant, MatrixTable}
 import org.apache.spark.SparkException

--- a/src/test/scala/is/hail/expr/TableIRSuite.scala
+++ b/src/test/scala/is/hail/expr/TableIRSuite.scala
@@ -1,7 +1,7 @@
 package is.hail.expr
 
 import is.hail.SparkSuite
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.expr.ir
 import org.apache.spark.sql.Row
 import org.testng.annotations.Test

--- a/src/test/scala/is/hail/expr/TableIRSuite.scala
+++ b/src/test/scala/is/hail/expr/TableIRSuite.scala
@@ -1,11 +1,12 @@
 package is.hail.expr
 
 import is.hail.SparkSuite
-import is.hail.keytable.KeyTable
+import is.hail.keytable.Table
+import is.hail.expr.ir
 import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
-class KeyTableIRSuite extends SparkSuite {
+class TableIRSuite extends SparkSuite {
 
   @Test def testFilter() {
     val data = Array(Array("Sample1", 9, 5), Array("Sample2", 3, 5), Array("Sample3", 2, 5), Array("Sample4", 1, 5))
@@ -13,8 +14,8 @@ class KeyTableIRSuite extends SparkSuite {
     val signature = TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32()))
     val keyNames = Array("Sample")
 
-    val kt = KeyTable(hc, rdd, signature, keyNames)
-    val kt2 = new KeyTable(hc, FilterKT(kt.ir, ir.ApplyBinaryPrimOp(ir.EQ(), ir.Ref("field1"), ir.I32(3))))
+    val kt = Table(hc, rdd, signature, keyNames)
+    val kt2 = new Table(hc, FilterKT(kt.ir, ir.ApplyBinaryPrimOp(ir.EQ(), ir.Ref("field1"), ir.I32(3))))
     assert(kt2.count() == 1)
   }
 
@@ -24,8 +25,8 @@ class KeyTableIRSuite extends SparkSuite {
     val signature = TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32()))
     val keyNames = Array("Sample")
 
-    val kt = KeyTable(hc, rdd, signature, keyNames).annotateGlobalExpr("g = 3")
-    val kt2 = new KeyTable(hc, FilterKT(kt.ir, ir.ApplyBinaryPrimOp(ir.EQ(), ir.Ref("field1"), ir.Ref("g"))))
+    val kt = Table(hc, rdd, signature, keyNames).annotateGlobalExpr("g = 3")
+    val kt2 = new Table(hc, FilterKT(kt.ir, ir.ApplyBinaryPrimOp(ir.EQ(), ir.Ref("field1"), ir.Ref("g"))))
     assert(kt2.count() == 1)
   }
 }

--- a/src/test/scala/is/hail/io/ExportPlinkSuite.scala
+++ b/src/test/scala/is/hail/io/ExportPlinkSuite.scala
@@ -1,7 +1,7 @@
 package is.hail.io
 
 import is.hail.SparkSuite
-import is.hail.keytable.KeyTable
+import is.hail.keytable.Table
 import is.hail.utils._
 import org.testng.annotations.Test
 
@@ -71,7 +71,7 @@ class ExportPlinkSuite extends SparkSuite {
     val vds = hc.importVCF("src/test/resources/mendel.vcf")
       .splitMulti()
       .hardCalls()
-      .annotateSamplesTable(KeyTable.importFam(hc, "src/test/resources/mendel.fam", delimiter = "\\\\s+"), expr = "sa.fam = table")
+      .annotateSamplesTable(Table.importFam(hc, "src/test/resources/mendel.fam", delimiter = "\\\\s+"), expr = "sa.fam = table")
       .annotateSamplesExpr("sa = sa.fam")
       .annotateVariantsExpr("va = {rsid: str(v)}")
 

--- a/src/test/scala/is/hail/io/ExportPlinkSuite.scala
+++ b/src/test/scala/is/hail/io/ExportPlinkSuite.scala
@@ -1,7 +1,7 @@
 package is.hail.io
 
 import is.hail.SparkSuite
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.utils._
 import org.testng.annotations.Test
 

--- a/src/test/scala/is/hail/io/ExportVCFSuite.scala
+++ b/src/test/scala/is/hail/io/ExportVCFSuite.scala
@@ -7,7 +7,7 @@ import is.hail.check.Prop._
 import is.hail.expr._
 import is.hail.utils._
 import is.hail.testUtils._
-import is.hail.variant.{VSMSubgen, Variant, VariantSampleMatrix}
+import is.hail.variant.{VSMSubgen, Variant, MatrixTable}
 import org.testng.annotations.Test
 
 import scala.io.Source
@@ -75,7 +75,7 @@ class ExportVCFSuite extends SparkSuite {
   @Test def testReadWrite() {
     val out = tmpDir.createTempFile("foo", "vcf.bgz")
     val out2 = tmpDir.createTempFile("foo2", "vcf.bgz")
-    val p = forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random), Gen.choose(1, 10),
+    val p = forAll(MatrixTable.gen(hc, VSMSubgen.random), Gen.choose(1, 10),
       Gen.choose(1, 10)) { case (vds, nPar1, nPar2) =>
       hadoopConf.delete(out, recursive = true)
       hadoopConf.delete(out2, recursive = true)
@@ -312,7 +312,7 @@ class ExportVCFSuite extends SparkSuite {
       tGen = (t: Type, v: Annotation) => t.genValue)
     
     val out = tmpDir.createTempFile("foo", "vcf.bgz")
-    val p = forAll(VariantSampleMatrix.gen(hc, genericFormatFieldVCF)) { vsm =>
+    val p = forAll(MatrixTable.gen(hc, genericFormatFieldVCF)) { vsm =>
         hadoopConf.delete(out, recursive = true)
         vsm.exportVCF(out)
       

--- a/src/test/scala/is/hail/io/HardCallsSuite.scala
+++ b/src/test/scala/is/hail/io/HardCallsSuite.scala
@@ -3,12 +3,12 @@ package is.hail.io
 import is.hail.SparkSuite
 import is.hail.check.Prop._
 import is.hail.expr.{TCall, TStruct}
-import is.hail.variant.{VSMSubgen, VariantSampleMatrix, _}
+import is.hail.variant.{VSMSubgen, MatrixTable, _}
 import org.testng.annotations.Test
 
 class HardCallsSuite extends SparkSuite {
   @Test def test() {
-    val p = forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vds =>
+    val p = forAll(MatrixTable.gen(hc, VSMSubgen.random)) { vds =>
       val hard = vds.hardCalls()
       assert(hard.queryGenotypes("gs.map(g => g.GT).counter()") ==
         vds.queryGenotypes("gs.map(g => g.GT).counter()"))

--- a/src/test/scala/is/hail/io/ImportMatrixSuite.scala
+++ b/src/test/scala/is/hail/io/ImportMatrixSuite.scala
@@ -5,7 +5,7 @@ import is.hail.annotations.Annotation
 import is.hail.check.Gen
 import is.hail.check.Prop.forAll
 import is.hail.expr._
-import is.hail.variant.{VSMSubgen, VariantSampleMatrix}
+import is.hail.variant.{VSMSubgen, MatrixTable}
 import org.apache.spark.SparkException
 import org.testng.annotations.Test
 import is.hail.utils._
@@ -46,9 +46,9 @@ class ImportMatrixSuite extends SparkSuite {
       vGen = (t: Type) => Gen.identifier,
       tGen = (t: Type, v: Annotation) => t.genValue)
 
-    forAll(VariantSampleMatrix.gen(hc, genMatrix)
+    forAll(MatrixTable.gen(hc, genMatrix)
         .filter(vsm => !vsm.sampleIds.contains("v"))) { vsm =>
-      val actual: VariantSampleMatrix = {
+      val actual: MatrixTable = {
         val f = tmpDir.createTempFile(extension="txt")
         vsm.makeKT("v = v", "`` = g", Array("v")).export(f)
         LoadMatrix(hc, Array(f), cellType = vsm.genotypeSignature, hasRowIDName = true)
@@ -58,7 +58,7 @@ class ImportMatrixSuite extends SparkSuite {
       val tmp1 = tmpDir.createTempFile(extension = "vds")
       vsm.write(tmp1, true)
 
-      val vsm2 = VariantSampleMatrix.read(hc, tmp1)
+      val vsm2 = MatrixTable.read(hc, tmp1)
       assert(vsm.same(vsm2))
       true
     }.check()

--- a/src/test/scala/is/hail/io/ImportPlinkSuite.scala
+++ b/src/test/scala/is/hail/io/ImportPlinkSuite.scala
@@ -17,12 +17,12 @@ class ImportPlinkSuite extends SparkSuite {
 
   object Spec extends Properties("ImportPlink") {
     val compGen = for {
-      vds <- VariantSampleMatrix.gen(hc, VSMSubgen.random).map(_.cache().splitMulti())
+      vds <- MatrixTable.gen(hc, VSMSubgen.random).map(_.cache().splitMulti())
       nPartitions <- choose(1, PlinkLoader.expectedBedSize(vds.nSamples, vds.countVariants()).toInt.min(10))
     } yield (vds, nPartitions)
 
     property("import generates same output as export") =
-      forAll(compGen) { case (vds: VariantSampleMatrix, nPartitions: Int) =>
+      forAll(compGen) { case (vds: MatrixTable, nPartitions: Int) =>
 
         val truthRoot = tmpDir.createTempFile("truth")
         val testRoot = tmpDir.createTempFile("test")

--- a/src/test/scala/is/hail/io/ImportVCFSuite.scala
+++ b/src/test/scala/is/hail/io/ImportVCFSuite.scala
@@ -3,7 +3,7 @@ package is.hail.io
 import is.hail.check.Prop._
 import is.hail.SparkSuite
 import is.hail.io.vcf.LoadVCF
-import is.hail.variant.{Call, Genotype, VSMSubgen, Variant, VariantSampleMatrix}
+import is.hail.variant.{Call, Genotype, VSMSubgen, Variant, MatrixTable}
 import org.apache.spark.SparkException
 import org.testng.annotations.Test
 import is.hail.utils._
@@ -178,7 +178,7 @@ class ImportVCFSuite extends SparkSuite {
   }
 
   @Test def randomExportImportIsIdentity() {
-    forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vds =>
+    forAll(MatrixTable.gen(hc, VSMSubgen.random)) { vds =>
 
       val truth = {
         val f = tmpDir.createTempFile(extension="vcf")

--- a/src/test/scala/is/hail/io/LoadBgenSuite.scala
+++ b/src/test/scala/is/hail/io/LoadBgenSuite.scala
@@ -109,7 +109,7 @@ class LoadBgenSuite extends SparkSuite {
   }
 
   object Spec extends Properties("ImportBGEN") {
-    val compGen = for (vds <- VariantSampleMatrix.gen(hc,
+    val compGen = for (vds <- MatrixTable.gen(hc,
       VSMSubgen.dosage.copy(
         vGen = _ => VariantSubgen.biallelic.gen.map(v => v.copy(contig = "01")),
         sGen = _ => Gen.identifier.filter(_ != "NA")))

--- a/src/test/scala/is/hail/io/SplitSuite.scala
+++ b/src/test/scala/is/hail/io/SplitSuite.scala
@@ -5,7 +5,7 @@ import is.hail.check.Prop._
 import is.hail.check.{Gen, Properties}
 import is.hail.utils._
 import is.hail.testUtils._
-import is.hail.variant.{AltAllele, VSMSubgen, Variant, VariantSampleMatrix}
+import is.hail.variant.{AltAllele, VSMSubgen, Variant, MatrixTable}
 import org.testng.annotations.Test
 
 class SplitSuite extends SparkSuite {
@@ -19,7 +19,7 @@ class SplitSuite extends SparkSuite {
       alts <- Gen.distinctBuildableOf[Array](Gen.choose(1, 10).map(motif * _).filter(_ != ref).map(a => AltAllele(ref, a)))
     } yield Variant(contig, start, ref, alts)
 
-    property("splitMulti maintains variants") = forAll(VariantSampleMatrix.gen(hc,
+    property("splitMulti maintains variants") = forAll(MatrixTable.gen(hc,
       VSMSubgen.random.copy(vGen = _ => splittableVariantGen))) { vds =>
       val method1 = vds.splitMulti().variants.collect().toSet
       val method2 = vds.variants.flatMap { v1 =>

--- a/src/test/scala/is/hail/methods/AggregatorSuite.scala
+++ b/src/test/scala/is/hail/methods/AggregatorSuite.scala
@@ -2,7 +2,7 @@ package is.hail.methods
 
 import is.hail.check.{Gen, Prop}
 import is.hail.expr._
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.utils._
 import is.hail.testUtils._
 import is.hail.variant.{VSMSubgen, Variant, MatrixTable}

--- a/src/test/scala/is/hail/methods/AnnotateSuite.scala
+++ b/src/test/scala/is/hail/methods/AnnotateSuite.scala
@@ -7,7 +7,7 @@ import is.hail.check.Prop
 import is.hail.expr.{TFloat64, TInt32, TString, TStruct}
 import is.hail.io.annotators.{BedAnnotator, IntervalList}
 import is.hail.io.plink.{FamFileConfig, PlinkLoader}
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.utils._
 import is.hail.testUtils._
 import is.hail.variant._

--- a/src/test/scala/is/hail/methods/ConcordanceSuite.scala
+++ b/src/test/scala/is/hail/methods/ConcordanceSuite.scala
@@ -4,15 +4,15 @@ import is.hail.SparkSuite
 import is.hail.check.{Gen, Prop}
 import is.hail.utils._
 import is.hail.testUtils._
-import is.hail.variant.{Genotype, VSMSubgen, Variant, VariantSampleMatrix}
+import is.hail.variant.{Genotype, VSMSubgen, Variant, MatrixTable}
 import org.apache.spark.SparkContext
 import org.testng.annotations.Test
 
 import scala.language._
 
 class ConcordanceSuite extends SparkSuite {
-  def gen(sc: SparkContext) = for (vds1 <- VariantSampleMatrix.gen(hc, VSMSubgen.plinkSafeBiallelic);
-    vds2 <- VariantSampleMatrix.gen(hc, VSMSubgen.plinkSafeBiallelic);
+  def gen(sc: SparkContext) = for (vds1 <- MatrixTable.gen(hc, VSMSubgen.plinkSafeBiallelic);
+    vds2 <- MatrixTable.gen(hc, VSMSubgen.plinkSafeBiallelic);
     scrambledIds1 <- Gen.shuffle(vds1.sampleIds).map(_.iterator);
     newIds2 <- Gen.parameterized { p =>
       Gen.const(vds2.sampleIds.map { id =>

--- a/src/test/scala/is/hail/methods/IBDSuite.scala
+++ b/src/test/scala/is/hail/methods/IBDSuite.scala
@@ -45,7 +45,7 @@ class IBDSuite extends SparkSuite {
     }
   }
 
-  private def runPlinkIBD(vds: VariantSampleMatrix,
+  private def runPlinkIBD(vds: MatrixTable,
     min: Option[Double] = None,
     max: Option[Double] = None): Map[(Annotation, Annotation), ExtendedIBDInfo] = {
 
@@ -97,7 +97,7 @@ class IBDSuite extends SparkSuite {
   }
 
   object Spec extends Properties("IBD") {
-    val plinkSafeBiallelicVDS = VariantSampleMatrix.gen(hc, VSMSubgen.plinkSafeBiallelic)
+    val plinkSafeBiallelicVDS = MatrixTable.gen(hc, VSMSubgen.plinkSafeBiallelic)
       .resize(1000)
       .map { vds =>
         val gr = vds.genomeReference

--- a/src/test/scala/is/hail/methods/ImputeSexSuite.scala
+++ b/src/test/scala/is/hail/methods/ImputeSexSuite.scala
@@ -33,12 +33,12 @@ class ImputeSexSuite extends SparkSuite {
     ).toMap)
 
   object Spec extends Properties("ImputeSex") {
-    val plinkSafeBiallelicVDS = VariantSampleMatrix.gen(hc, VSMSubgen.plinkSafeBiallelic.copy(vGen = (t: Type) =>
+    val plinkSafeBiallelicVDS = MatrixTable.gen(hc, VSMSubgen.plinkSafeBiallelic.copy(vGen = (t: Type) =>
       VariantSubgen.biallelic.copy(contigGen = Contig.gen(GenomeReference.GRCh37, "X")).gen))
       .filter(vds => vds.countVariants() > 5 && vds.nSamples > 5)
 
     property("hail generates same results as PLINK v1.9") =
-      forAll(plinkSafeBiallelicVDS) { case (vds: VariantSampleMatrix) =>
+      forAll(plinkSafeBiallelicVDS) { case (vds: MatrixTable) =>
         var mappedVDS = VariantQC(vds)
           .filterVariantsExpr("va.qc.AC > 1 && va.qc.AF >= 1e-8 && " +
             "va.qc.nCalled * 2 - va.qc.AC > 1 && va.qc.AF <= 1 - 1e-8")

--- a/src/test/scala/is/hail/methods/LDMatrixSuite.scala
+++ b/src/test/scala/is/hail/methods/LDMatrixSuite.scala
@@ -15,7 +15,7 @@ class LDMatrixSuite extends SparkSuite {
   val m = 50
   val n = 60
   val seed: Int = scala.util.Random.nextInt()
-  lazy val vds: VariantSampleMatrix = hc.baldingNicholsModel(1, n, m, seed = seed)
+  lazy val vds: MatrixTable = hc.baldingNicholsModel(1, n, m, seed = seed)
   lazy val distLDMatrix: LDMatrix = LDMatrix.apply(vds, Some(false))
   lazy val localLDMatrix: LDMatrix = vds.ldMatrix(forceLocal = true)
 

--- a/src/test/scala/is/hail/methods/LDPruneSuite.scala
+++ b/src/test/scala/is/hail/methods/LDPruneSuite.scala
@@ -126,7 +126,7 @@ class LDPruneSuite extends SparkSuite {
     new MultiArray2(nVariants, nVariants, r2.toArray)
   }
 
-  def isUncorrelated(vds: VariantSampleMatrix, r2Threshold: Double, windowSize: Int): Boolean = {
+  def isUncorrelated(vds: MatrixTable, r2Threshold: Double, windowSize: Int): Boolean = {
     val nSamplesLocal = vds.nSamples
     val r2Matrix = correlationMatrix(vds.typedRDD[Locus, Variant].map { case (v, (va, gs)) => gs }.collect(), nSamplesLocal)
     val variantMap = vds.variants.zipWithIndex().map { case (v, i) => (i.toInt, v.asInstanceOf[Variant]) }.collectAsMap()

--- a/src/test/scala/is/hail/methods/LinearMixedRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearMixedRegressionSuite.scala
@@ -7,7 +7,7 @@ import is.hail.annotations._
 import is.hail.expr.{TArray, TFloat64, TStruct}
 import is.hail.stats._
 import is.hail.utils._
-import is.hail.variant.{Variant, VariantSampleMatrix}
+import is.hail.variant.{Variant, MatrixTable}
 import is.hail.{SparkSuite, TestUtils}
 import org.testng.annotations.Test
 
@@ -439,7 +439,7 @@ class LinearMixedRegressionSuite extends SparkSuite {
 
   //Tests that k eigenvectors give the same result as all n eigenvectors for a rank-k kinship matrix on n samples.
   @Test def testFullRankAndLowRank() {
-    val vdsChr1: VariantSampleMatrix = vdsFastLMM.filterVariantsExpr("""v.contig == "1"""")
+    val vdsChr1: MatrixTable = vdsFastLMM.filterVariantsExpr("""v.contig == "1"""")
 
     val notChr1VDSDownsampled = vdsFastLMM.filterVariantsExpr("""v.contig == "3" && v.start < 2242""")
 
@@ -460,7 +460,7 @@ class LinearMixedRegressionSuite extends SparkSuite {
     globalLMMCompare(vdsChr1FullRankML, vdsChr1LowRankML)
   }
 
-  private def globalLMMCompare(vds1: VariantSampleMatrix, vds2: VariantSampleMatrix) {
+  private def globalLMMCompare(vds1: MatrixTable, vds2: MatrixTable) {
     assert(D_==(vds1.queryGlobal("global.lmmreg.beta")._2.asInstanceOf[Map[String, Double]].apply("intercept"),
       vds2.queryGlobal("global.lmmreg.beta")._2.asInstanceOf[Map[String, Double]].apply("intercept")))
 

--- a/src/test/scala/is/hail/methods/LinearRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearRegressionSuite.scala
@@ -4,7 +4,7 @@ import is.hail.SparkSuite
 import is.hail.TestUtils._
 import is.hail.annotations.Annotation
 import is.hail.expr.{TFloat64, TString}
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.utils._
 import is.hail.variant.Variant
 import org.testng.annotations.Test

--- a/src/test/scala/is/hail/methods/LinearRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearRegressionSuite.scala
@@ -4,7 +4,7 @@ import is.hail.SparkSuite
 import is.hail.TestUtils._
 import is.hail.annotations.Annotation
 import is.hail.expr.{TFloat64, TString}
-import is.hail.keytable.KeyTable
+import is.hail.keytable.Table
 import is.hail.utils._
 import is.hail.variant.Variant
 import org.testng.annotations.Test
@@ -261,7 +261,7 @@ class LinearRegressionSuite extends SparkSuite {
     val vds = hc.importVCF("src/test/resources/regressionLinear.vcf")
       .verifyBiallelic()
       .annotateSamplesTable(covariates, root = "sa.cov")
-      .annotateSamplesTable(KeyTable.importFam(hc, "src/test/resources/regressionLinear.fam"), root = "sa.fam")
+      .annotateSamplesTable(Table.importFam(hc, "src/test/resources/regressionLinear.fam"), root = "sa.fam")
       .linreg(Array("sa.fam.isCase"), "g.GT.nNonRefAlleles()", Array("sa.cov.Cov1", "sa.cov.Cov2"))
 
     val qBeta = vds.queryVA("va.linreg.beta")._2
@@ -312,7 +312,7 @@ class LinearRegressionSuite extends SparkSuite {
     val vds = hc.importVCF("src/test/resources/regressionLinear.vcf")
       .verifyBiallelic()
       .annotateSamplesTable(covariates, root = "sa.cov")
-      .annotateSamplesTable(KeyTable.importFam(hc, "src/test/resources/regressionLinear.fam", isQuantitative = true, missingValue = "0"), root = "sa.fam")
+      .annotateSamplesTable(Table.importFam(hc, "src/test/resources/regressionLinear.fam", isQuantitative = true, missingValue = "0"), root = "sa.fam")
       .linreg(Array("sa.fam.qPheno"), "g.GT.nNonRefAlleles()", Array("sa.cov.Cov1", "sa.cov.Cov2"))
 
     val qBeta = vds.queryVA("va.linreg.beta")._2

--- a/src/test/scala/is/hail/methods/LogisticRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LogisticRegressionSuite.scala
@@ -3,7 +3,7 @@ package is.hail.methods
 import is.hail.SparkSuite
 import is.hail.annotations.{Annotation, Querier}
 import is.hail.expr.{TBoolean, TFloat64}
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.utils._
 import is.hail.variant.Variant
 import org.testng.annotations.Test

--- a/src/test/scala/is/hail/methods/LogisticRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LogisticRegressionSuite.scala
@@ -3,7 +3,7 @@ package is.hail.methods
 import is.hail.SparkSuite
 import is.hail.annotations.{Annotation, Querier}
 import is.hail.expr.{TBoolean, TFloat64}
-import is.hail.keytable.KeyTable
+import is.hail.keytable.Table
 import is.hail.utils._
 import is.hail.variant.Variant
 import org.testng.annotations.Test
@@ -350,7 +350,7 @@ class LogisticRegressionSuite extends SparkSuite {
 
     val vds = hc.importVCF("src/test/resources/regressionLogisticEpacts.vcf")
       .verifyBiallelic()
-      .annotateSamplesTable(KeyTable.importFam(hc, "src/test/resources/regressionLogisticEpacts.fam"), root = "sa.fam")
+      .annotateSamplesTable(Table.importFam(hc, "src/test/resources/regressionLogisticEpacts.fam"), root = "sa.fam")
       .annotateSamplesTable(covariates, root = "sa.pc")
       .logreg("wald", "sa.fam.isCase", "g.GT.nNonRefAlleles()", Array("sa.fam.isFemale", "sa.pc.PC1", "sa.pc.PC2"), "va.wald")
       .logreg("lrt", "sa.fam.isCase", "g.GT.nNonRefAlleles()", Array("sa.fam.isFemale", "sa.pc.PC1", "sa.pc.PC2"), "va.lrt")

--- a/src/test/scala/is/hail/methods/PCASuite.scala
+++ b/src/test/scala/is/hail/methods/PCASuite.scala
@@ -4,13 +4,13 @@ import breeze.linalg.DenseMatrix
 import is.hail.SparkSuite
 import is.hail.annotations.Annotation
 import is.hail.expr.{TArray, TFloat64, TStruct}
-import is.hail.keytable.KeyTable
-import is.hail.variant.{Variant, VariantSampleMatrix}
+import is.hail.keytable.Table
+import is.hail.variant.{Variant, MatrixTable}
 import org.testng.annotations.Test
 
 object PCASuite {
-  def samplePCA(vsm: VariantSampleMatrix, k: Int = 10, computeLoadings: Boolean = false, 
-    asArray: Boolean = false): (IndexedSeq[Double], DenseMatrix[Double], Option[KeyTable]) = {
+  def samplePCA(vsm: MatrixTable, k: Int = 10, computeLoadings: Boolean = false,
+    asArray: Boolean = false): (IndexedSeq[Double], DenseMatrix[Double], Option[Table]) = {
     
     val prePCA = vsm.annotateVariantsExpr("va.AC = gs.map(g => g.GT.gt).sum(), va.nCalled = gs.filter(g => isDefined(g.GT)).count()")
       .filterVariantsExpr("va.AC > 0 && va.AC < 2 * va.nCalled").persist()

--- a/src/test/scala/is/hail/methods/PCASuite.scala
+++ b/src/test/scala/is/hail/methods/PCASuite.scala
@@ -4,7 +4,7 @@ import breeze.linalg.DenseMatrix
 import is.hail.SparkSuite
 import is.hail.annotations.Annotation
 import is.hail.expr.{TArray, TFloat64, TStruct}
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.variant.{Variant, MatrixTable}
 import org.testng.annotations.Test
 

--- a/src/test/scala/is/hail/methods/PCRelateReferenceImplementation.scala
+++ b/src/test/scala/is/hail/methods/PCRelateReferenceImplementation.scala
@@ -1,10 +1,10 @@
 package is.hail.methods
 
 import breeze.linalg.{DenseMatrix, inv}
-import is.hail.variant.{Genotype, Locus, Variant, VariantSampleMatrix}
+import is.hail.variant.{Genotype, Locus, Variant, MatrixTable}
 
 object PCRelateReferenceImplementation {
-  def apply(vds: VariantSampleMatrix, pcs: DenseMatrix[Double], maf: Double = 0.0): (Map[(String, String), (Double, Double, Double, Double)], DenseMatrix[Double], DenseMatrix[Double], DenseMatrix[Double]) = {
+  def apply(vds: MatrixTable, pcs: DenseMatrix[Double], maf: Double = 0.0): (Map[(String, String), (Double, Double, Double, Double)], DenseMatrix[Double], DenseMatrix[Double], DenseMatrix[Double]) = {
     val indexToId: Map[Int, String] = vds.stringSampleIds.zipWithIndex.map { case (id, index) => (index, id) }.toMap
 
     val gts = vds.typedRDD[Locus, Variant].zipWithIndex.map { case ((v, (va, gs)), i) =>

--- a/src/test/scala/is/hail/methods/PCRelateSuite.scala
+++ b/src/test/scala/is/hail/methods/PCRelateSuite.scala
@@ -6,7 +6,7 @@ import is.hail.distributedmatrix.BlockMatrix
 import is.hail.expr.{TFloat64, TString}
 import is.hail.stats._
 import is.hail.utils.{TextTableReader, _}
-import is.hail.variant.VariantSampleMatrix
+import is.hail.variant.MatrixTable
 import is.hail.methods.PCASuite.samplePCA
 import org.apache.spark.sql.Row
 import org.testng.annotations.Test
@@ -31,15 +31,15 @@ class PCRelateSuite extends SparkSuite {
   private def quadMap[T,U](f: T => U): (T, T, T, T) => (U, U, U, U) =
     { case (x, y, z, w) => (f(x), f(y), f(z), f(w)) }
 
-  def runPcRelateHail(vds: VariantSampleMatrix, pcs: DenseMatrix[Double], maf: Double): Map[(String, String), (Double, Double, Double, Double)] =
+  def runPcRelateHail(vds: MatrixTable, pcs: DenseMatrix[Double], maf: Double): Map[(String, String), (Double, Double, Double, Double)] =
     runPcRelateHail(vds, pcs, maf, PCRelate.defaultMinKinship, PCRelate.defaultStatisticSubset)
       .mapValues(quadMap(toD).tupled)
 
-  def runPcRelateHail(vds: VariantSampleMatrix, pcs: DenseMatrix[Double], maf: Double, minKinship: Double): Map[(String, String), (Double, Double, Double, Double)] =
+  def runPcRelateHail(vds: MatrixTable, pcs: DenseMatrix[Double], maf: Double, minKinship: Double): Map[(String, String), (Double, Double, Double, Double)] =
     runPcRelateHail(vds, pcs, maf, minKinship, PCRelate.defaultStatisticSubset)
       .mapValues(quadMap(toD).tupled)
 
-  def runPcRelateHail(vds: VariantSampleMatrix, pcs: DenseMatrix[Double], maf: Double, minKinship: Double, statistics: PCRelate.StatisticSubset): Map[(String, String), (java.lang.Double, java.lang.Double, java.lang.Double, java.lang.Double)] =
+  def runPcRelateHail(vds: MatrixTable, pcs: DenseMatrix[Double], maf: Double, minKinship: Double, statistics: PCRelate.StatisticSubset): Map[(String, String), (java.lang.Double, java.lang.Double, java.lang.Double, java.lang.Double)] =
     PCRelate.toKeyTable(vds, pcs, maf, blockSize, minKinship, statistics)
       .collect()
       .map(x => x.asInstanceOf[Row])
@@ -49,7 +49,7 @@ class PCRelateSuite extends SparkSuite {
       .asInstanceOf[Map[(String, String), (java.lang.Double, java.lang.Double, java.lang.Double, java.lang.Double)]]
 
   def runPcRelateR(
-    vds: VariantSampleMatrix,
+    vds: MatrixTable,
     maf: Double,
     rFile: String = "src/test/resources/is/hail/methods/runPcRelate.R"): Map[(String, String), (Double, Double, Double, Double)] = {
 
@@ -124,7 +124,7 @@ class PCRelateSuite extends SparkSuite {
     val seed = 0
     val n = 100
     val nVariants = 10000
-    val vds: VariantSampleMatrix = BaldingNicholsModel(hc, 3, n, nVariants, None, None, seed, None, UniformDist(0.1,0.9))
+    val vds: MatrixTable = BaldingNicholsModel(hc, 3, n, nVariants, None, None, seed, None, UniformDist(0.1,0.9))
     val pcs = samplePCA(vds, 2, false)._2
     val truth = PCRelateReferenceImplementation(vds, pcs, maf=0.01)._1
     val actual = runPcRelateHail(vds, pcs, maf=0.01)
@@ -137,7 +137,7 @@ class PCRelateSuite extends SparkSuite {
     val seed = 0
     val n = 100
     val nVariants = 10000
-    val vds: VariantSampleMatrix = BaldingNicholsModel(hc, 3, n, nVariants, None, None, seed, None, UniformDist(0.1,0.9))
+    val vds: MatrixTable = BaldingNicholsModel(hc, 3, n, nVariants, None, None, seed, None, UniformDist(0.1,0.9))
     val pcs = samplePCA(vds, 2, false)._2
     val truth = runPcRelateR(vds, maf=0.01)
     val actual = PCRelateReferenceImplementation(vds, pcs, maf=0.01)._1

--- a/src/test/scala/is/hail/methods/SkatSuite.scala
+++ b/src/test/scala/is/hail/methods/SkatSuite.scala
@@ -22,7 +22,7 @@ import scala.language.postfixOps
 case class SkatAggForR(xs: ArrayBuilder[DenseVector[Double]], weights: ArrayBuilder[Double])
 
 class SkatSuite extends SparkSuite {
-  def skatInR(vds: VariantSampleMatrix,
+  def skatInR(vds: MatrixTable,
     keyExpr: String,
     weightExpr: String,
     yExpr: String,
@@ -119,7 +119,7 @@ class SkatSuite extends SparkSuite {
 
   // 18 complete samples from sample2.vcf
   // 5 genes with sizes 24, 13, 66, 27, and 51
-  lazy val vdsSkat: VariantSampleMatrix = {
+  lazy val vdsSkat: MatrixTable = {
     val covSkat = hc.importTable("src/test/resources/skat.cov",
       impute = true).keyBy("Sample")
 
@@ -143,7 +143,7 @@ class SkatSuite extends SparkSuite {
   }
   
   // A larger deterministic example using the Balding-Nichols model (only hardcalls)
-  lazy val vdsBN: VariantSampleMatrix = {
+  lazy val vdsBN: MatrixTable = {
     val seed = 0
     val nSamples = 500
     val nVariants = 50

--- a/src/test/scala/is/hail/methods/TableSuite.scala
+++ b/src/test/scala/is/hail/methods/TableSuite.scala
@@ -3,7 +3,7 @@ package is.hail.methods
 import is.hail.{SparkSuite, TestUtils}
 import is.hail.annotations._
 import is.hail.expr._
-import is.hail.keytable.KeyTable
+import is.hail.keytable.Table
 import is.hail.utils._
 import org.apache.spark.sql.Row
 import org.apache.spark.util.StatCounter
@@ -11,36 +11,36 @@ import org.testng.annotations.Test
 
 import scala.collection.mutable
 
-class KeyTableSuite extends SparkSuite {
-  def sampleKT1: KeyTable = {
+class TableSuite extends SparkSuite {
+  def sampleKT1: Table = {
     val data = Array(Array("Sample1", 9, 5), Array("Sample2", 3, 5), Array("Sample3", 2, 5), Array("Sample4", 1, 5))
     val rdd = sc.parallelize(data.map(Row.fromSeq(_)))
     val signature = TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32()))
     val keyNames = Array("Sample")
 
-    val kt = KeyTable(hc, rdd, signature, keyNames)
+    val kt = Table(hc, rdd, signature, keyNames)
     kt.typeCheck()
     kt
   }
 
-  def sampleKT2: KeyTable = {
+  def sampleKT2: Table = {
     val data = Array(Array("Sample1", IndexedSeq(9, 1), 5), Array("Sample2", IndexedSeq(3), 5),
       Array("Sample3", IndexedSeq(2, 3, 4), 5), Array("Sample4", IndexedSeq.empty[Int], 5))
     val rdd = sc.parallelize(data.map(Row.fromSeq(_)))
     val signature = TStruct(("Sample", TString()), ("field1", TArray(TInt32())), ("field2", TInt32()))
     val keyNames = Array("Sample")
-    val kt = KeyTable(hc, rdd, signature, keyNames)
+    val kt = Table(hc, rdd, signature, keyNames)
     kt.typeCheck()
     kt
   }
 
-  def sampleKT3: KeyTable = {
+  def sampleKT3: Table = {
     val data = Array(Array("Sample1", IndexedSeq(IndexedSeq(9, 10), IndexedSeq(1)), IndexedSeq(5, 6)), Array("Sample2", IndexedSeq(IndexedSeq(3), IndexedSeq.empty[Int]), IndexedSeq(5, 3)),
       Array("Sample3", IndexedSeq(IndexedSeq(2, 3, 4), IndexedSeq(3), IndexedSeq(4, 10)), IndexedSeq.empty[Int]), Array("Sample4", IndexedSeq.empty[Int], IndexedSeq(5)))
     val rdd = sc.parallelize(data.map(Row.fromSeq(_)))
     val signature = TStruct(("Sample", TString()), ("field1", TArray(TArray(TInt32()))), ("field2", TArray(TInt32())))
     val keyNames = Array("Sample")
-    val kt = KeyTable(hc, rdd, signature, keyNames)
+    val kt = Table(hc, rdd, signature, keyNames)
     kt.typeCheck()
     kt
   }
@@ -78,7 +78,7 @@ class KeyTableSuite extends SparkSuite {
     assert(kt1columns ++ Set("qPhen2", "NotStatus", "X") == kt2columns)
     assert(kt2 same kt3)
 
-    def getDataAsMap(kt: KeyTable) = {
+    def getDataAsMap(kt: Table) = {
       val columns = kt.columns
       kt.rdd.map { a => columns.zip(a.toSeq).toMap }.collect().toSet
     }
@@ -101,7 +101,7 @@ class KeyTableSuite extends SparkSuite {
     val signature = TStruct(("field1", TInt32()), ("field2", TInt32()), ("field3", TInt32()))
     val keyNames = Array("field1")
 
-    val kt1 = KeyTable(hc, rdd, signature, keyNames)
+    val kt1 = Table(hc, rdd, signature, keyNames)
     kt1.typeCheck()
     val kt2 = kt1.filter("field1 < 3", keep = true)
     val kt3 = kt1.filter("field1 < 3 && field3 == 4", keep = true)
@@ -199,7 +199,7 @@ class KeyTableSuite extends SparkSuite {
     val signature = TStruct(("field1", TString()), ("field2", TInt32()), ("field3", TInt32()))
     val keyNames = Array("field1")
 
-    val kt1 = KeyTable(hc, rdd, signature, keyNames)
+    val kt1 = Table(hc, rdd, signature, keyNames)
     kt1.typeCheck()
     val kt2 = kt1.aggregate("Status = field1",
       "A = field2.sum(), " +
@@ -213,7 +213,7 @@ class KeyTableSuite extends SparkSuite {
     val result = Array(Array("Case", 12, 12, 16, 2L, 1L), Array("Control", 3, 3, 11, 2L, 0L))
     val resRDD = sc.parallelize(result.map(Row.fromSeq(_)))
     val resSignature = TStruct(("Status", TString()), ("A", TInt32()), ("B", TInt32()), ("C", TInt32()), ("D", TInt64()), ("E", TInt64()))
-    val ktResult = KeyTable(hc, resRDD, resSignature, key = Array("Status"))
+    val ktResult = Table(hc, resRDD, resSignature, key = Array("Status"))
     ktResult.typeCheck()
 
     assert(kt2 same ktResult)
@@ -228,7 +228,7 @@ class KeyTableSuite extends SparkSuite {
     val signature = TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32()))
     val keyNames = Array("Sample")
 
-    val kt = KeyTable(hc, rdd, signature, keyNames)
+    val kt = Table(hc, rdd, signature, keyNames)
     kt.typeCheck()
     assert(kt.forall("field2 == 5 && field1 != 0"))
     assert(!kt.forall("field2 == 0 && field1 == 5"))
@@ -242,7 +242,7 @@ class KeyTableSuite extends SparkSuite {
     val signature = TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32()))
     val keyNames = Array("Sample")
 
-    val kt = KeyTable(hc, rdd, signature, keyNames)
+    val kt = Table(hc, rdd, signature, keyNames)
     kt.typeCheck()
 
     val rename1 = kt.rename(Array("ID1", "ID2", "ID3"))
@@ -267,7 +267,7 @@ class KeyTableSuite extends SparkSuite {
     val signature = TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32()), ("field3", TStruct(("A", TInt32()), ("B", TString()))))
     val keyNames = Array("Sample")
 
-    val kt = KeyTable(hc, rdd, signature, keyNames)
+    val kt = Table(hc, rdd, signature, keyNames)
     kt.typeCheck()
 
     val select1 = kt.select("field1").keyBy("field1")
@@ -305,7 +305,7 @@ class KeyTableSuite extends SparkSuite {
     val rdd = sc.parallelize(data.map(Row.fromSeq(_)))
     val signature = TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32()))
 
-    val kt = KeyTable(hc, rdd, signature, Array("Sample"))
+    val kt = Table(hc, rdd, signature, Array("Sample"))
     kt.typeCheck()
     val drop0 = kt.drop(Array.empty[String])
     assert((drop0.key sameElements Array("Sample")) && (drop0.columns sameElements Array("Sample", "field1", "field2")))
@@ -320,7 +320,7 @@ class KeyTableSuite extends SparkSuite {
     val drop5 = kt.drop(Array("Sample", "field1", "field2"))
     assert((drop5.key sameElements Array.empty[String]) && (drop5.columns sameElements Array.empty[String]))
 
-    val kt2 = KeyTable(hc, rdd, signature, Array("field1", "field2"))
+    val kt2 = Table(hc, rdd, signature, Array("field1", "field2"))
     val drop6 = kt2.drop(Array("field1"))
     assert((drop6.key sameElements Array("field2")) && (drop6.columns sameElements Array("Sample", "field2")))
 
@@ -339,13 +339,13 @@ class KeyTableSuite extends SparkSuite {
     val result2 = Array(Array("Sample1", 9, 5), Array("Sample1", 1, 5), Array("Sample2", 3, 5), Array("Sample3", 2, 5),
       Array("Sample3", 3, 5), Array("Sample3", 4, 5))
     val resRDD2 = sc.parallelize(result2.map(Row.fromSeq(_)))
-    val ktResult2 = KeyTable(hc, resRDD2, TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32())), key = Array("Sample"))
+    val ktResult2 = Table(hc, resRDD2, TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32())), key = Array("Sample"))
     ktResult2.typeCheck()
 
     val result3 = Array(Array("Sample1", 9, 5), Array("Sample1", 10, 5), Array("Sample1", 9, 6), Array("Sample1", 10, 6),
       Array("Sample1", 1, 5), Array("Sample1", 1, 6), Array("Sample2", 3, 5), Array("Sample2", 3, 3))
     val resRDD3 = sc.parallelize(result3.map(Row.fromSeq(_)))
-    val ktResult3 = KeyTable(hc, resRDD3, TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32())), key = Array("Sample"))
+    val ktResult3 = Table(hc, resRDD3, TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32())), key = Array("Sample"))
     ktResult3.typeCheck()
 
     intercept[HailException](kt1.explode(Array("Sample")))
@@ -368,7 +368,7 @@ class KeyTableSuite extends SparkSuite {
     val df = kt.toDF(sqlContext)
     df.printSchema()
     df.show()
-    assert(KeyTable.fromDF(hc, df).same(kt))
+    assert(Table.fromDF(hc, df).same(kt))
   }
 
   @Test def testKeyTableToDF2() {
@@ -380,7 +380,7 @@ class KeyTableSuite extends SparkSuite {
       .flatten()
 
     val df = kt.toDF(sqlContext)
-    val kt2 = KeyTable.fromDF(hc, df, key = Array("v"))
+    val kt2 = Table.fromDF(hc, df, key = Array("v"))
     assert(kt2.same(kt))
   }
 
@@ -419,14 +419,14 @@ class KeyTableSuite extends SparkSuite {
       .select("v", "`va.id`")
       .keyBy("va.id")
 
-    val kt2 = KeyTable(hc, vds.variants.map(v => Row(v.toString, 5)),
+    val kt2 = Table(hc, vds.variants.map(v => Row(v.toString, 5)),
       TStruct("v" -> TString(), "value" -> TInt32()), Array("v"))
 
     kt.join(kt2, "inner").toDF(sqlContext).count()
   }
 
   @Test def testKeyOrder() {
-    val kt1 = KeyTable(hc,
+    val kt1 = Table(hc,
       sc.parallelize(Array(Row("foo", "bar", 3, "baz"))),
       TStruct(
         "f1" -> TString(),
@@ -437,7 +437,7 @@ class KeyTableSuite extends SparkSuite {
       Array("f3", "f2", "f1"))
     kt1.typeCheck()
 
-    val kt2 = KeyTable(hc,
+    val kt2 = Table(hc,
       sc.parallelize(Array(Row(3, "foo", "bar", "qux"))),
       TStruct(
         "f3" -> TInt32(),
@@ -464,7 +464,7 @@ class KeyTableSuite extends SparkSuite {
   }
 
   @Test def testUngroup() {
-    // test KeyTable method
+    // test Table method
     val data1 = Array(
       Array("Sample1", 5, Row(23.0f, "rabbit"), Row(1, "foo")),
       Array("Sample1", 5, null, Row(1, "foo")))
@@ -473,7 +473,7 @@ class KeyTableSuite extends SparkSuite {
       ("field1", TInt32()),
       ("field2", TStruct(("1", TFloat32()), ("2", TString()))),
       ("field3", TStruct(("1", TInt32()), ("2", TString()))))
-    val kt1 = KeyTable(hc, sc.parallelize(data1.map(Row.fromSeq(_))), sig1)
+    val kt1 = Table(hc, sc.parallelize(data1.map(Row.fromSeq(_))), sig1)
     kt1.typeCheck()
 
     val ungroupedData1 = Array(
@@ -487,7 +487,7 @@ class KeyTableSuite extends SparkSuite {
       ("field2.1", TFloat32()),
       ("field2.2", TString())
     )
-    val ungroupedKt1 = KeyTable(hc, sc.parallelize(ungroupedData1.map(Row.fromSeq(_))), ungroupedSig1)
+    val ungroupedKt1 = Table(hc, sc.parallelize(ungroupedData1.map(Row.fromSeq(_))), ungroupedSig1)
     ungroupedKt1.typeCheck()
 
     assert(kt1.ungroup("field3").ungroup("field2", mangle = true).same(ungroupedKt1))
@@ -499,19 +499,19 @@ class KeyTableSuite extends SparkSuite {
     // test ungroup/group gives same result
     val data2 = Array(Array(Row(23, 1)))
     val rdd2 = sc.parallelize(data2.map(Row.fromSeq(_)))
-    val kt2 = KeyTable(hc, rdd2, TStruct(("A", TStruct(("c1", TInt32()), ("c2", TInt32())))))
+    val kt2 = Table(hc, rdd2, TStruct(("A", TStruct(("c1", TInt32()), ("c2", TInt32())))))
     kt2.typeCheck()
     assert(kt2.ungroup("A").group("A", Array("c1", "c2")).same(kt2))
 
     // test function registry method
     val data3 = Array(Array(Row(6, Row("hello"))))
     val sig3 = TStruct(("foo", TStruct(("a", TInt32()), ("b", TStruct(("i", TString()))))))
-    val kt3 = KeyTable(hc, sc.parallelize(data3.map(Row.fromSeq(_))), sig3)
+    val kt3 = Table(hc, sc.parallelize(data3.map(Row.fromSeq(_))), sig3)
     kt3.typeCheck()
 
     val ungroupedData3 = Array(Array(Row(6, "hello")))
     val ungroupedSig3 = TStruct(("foo", TStruct(("a", TInt32()), ("i", TString()))))
-    val ungroupedKt3 = KeyTable(hc, sc.parallelize(ungroupedData3.map(Row.fromSeq(_))), ungroupedSig3)
+    val ungroupedKt3 = Table(hc, sc.parallelize(ungroupedData3.map(Row.fromSeq(_))), ungroupedSig3)
     ungroupedKt3.typeCheck()
 
     assert(kt3.annotate("foo = ungroup(foo, b, false)").same(ungroupedKt3))
@@ -529,7 +529,7 @@ class KeyTableSuite extends SparkSuite {
       Row("Sample1", Row(23.0f, "rabbit"), 9, 5))
 
     val rdd = sc.parallelize(data)
-    val kt = KeyTable(hc, rdd, TStruct(
+    val kt = Table(hc, rdd, TStruct(
       ("Sample", TString()),
       ("field0", TStruct(("1", TFloat32()), ("2", TString()))),
       ("field1", TInt32()),
@@ -546,12 +546,12 @@ class KeyTableSuite extends SparkSuite {
 
     val data2 = Array(Row(Row("Sample1", 5)))
     val rdd2 = sc.parallelize(data2)
-    val kt2 = KeyTable(hc, rdd2, TStruct(("foo", TStruct(("a", TString()), ("b", TInt32())))))
+    val kt2 = Table(hc, rdd2, TStruct(("foo", TStruct(("a", TString()), ("b", TInt32())))))
     kt2.typeCheck()
 
     val dataExpected = Array(Array(Row("Sample1", 5), Row(Row(5, "Sample1"))))
     val sigExpected = TStruct(("foo", TStruct(("a", TString()), ("b", TInt32()))), ("X", TStruct(("a", TStruct(("b", TInt32()), ("a", TString()))))))
-    val kt2Expected = KeyTable(hc, sc.parallelize(dataExpected.map(Row.fromSeq(_))), sigExpected)
+    val kt2Expected = Table(hc, sc.parallelize(dataExpected.map(Row.fromSeq(_))), sigExpected)
     kt2Expected.typeCheck()
 
     assert(kt2.annotate("X = group(foo, a, b, a)").same(kt2Expected))
@@ -564,9 +564,9 @@ class KeyTableSuite extends SparkSuite {
   }
 
   @Test def issue2231() {
-    assert(KeyTable.range(hc, 100)
+    assert(Table.range(hc, 100)
       .annotate("j = 1.0, i = 1")
-      .keyBy("i").join(KeyTable.range(hc, 100), "inner")
+      .keyBy("i").join(Table.range(hc, 100), "inner")
       .signature.fields.map(f => (f.name, f.typ)).toSet
       ===
       Set(("index", TInt32()), ("i", TInt32()), ("j", TFloat64())))
@@ -574,7 +574,7 @@ class KeyTableSuite extends SparkSuite {
 
   @Test def mis() {
     // prefer to remove nodes with higher index
-    assert(KeyTable.range(hc, 10)
+    assert(Table.range(hc, 10)
       .annotate("i = index, j = index + 10")
       .maximalIndependentSet("i", "j", Some("l - r"))
       .toSet
@@ -583,7 +583,7 @@ class KeyTableSuite extends SparkSuite {
   }
 
   @Test def testGlobalAnnotations() {
-    val kt = KeyTable.range(hc, 10)
+    val kt = Table.range(hc, 10)
       .annotateGlobalExpr("foo = [1,2,3]")
       .annotateGlobal(Map(5 -> "bar"), TDict(TInt32Optional, TStringOptional), "dict")
       .annotateGlobalExpr("another = foo[1]")
@@ -603,7 +603,7 @@ class KeyTableSuite extends SparkSuite {
   }
 
   @Test def testSchemaAttrParse() { // FIXME: This should be deleted when not parsing attributes in types
-    val kt = KeyTable.range(hc, 10).annotate("FOO = if (false) {AC: [0, 5]} else NA:Struct{AC:Array[Int32]" +
+    val kt = Table.range(hc, 10).annotate("FOO = if (false) {AC: [0, 5]} else NA:Struct{AC:Array[Int32]" +
       "@Description=\"Allele count in genotypes, for each ALT allele, in the same order as listed\"@Number=\"A\"@Type=\"Integer\"}")
   }
 }

--- a/src/test/scala/is/hail/methods/TableSuite.scala
+++ b/src/test/scala/is/hail/methods/TableSuite.scala
@@ -3,7 +3,7 @@ package is.hail.methods
 import is.hail.{SparkSuite, TestUtils}
 import is.hail.annotations._
 import is.hail.expr._
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.utils._
 import org.apache.spark.sql.Row
 import org.apache.spark.util.StatCounter

--- a/src/test/scala/is/hail/stats/FisherExactTestSuite.scala
+++ b/src/test/scala/is/hail/stats/FisherExactTestSuite.scala
@@ -5,7 +5,7 @@ import is.hail.check.Gen._
 import is.hail.check.Prop._
 import is.hail.check.Properties
 import is.hail.utils._
-import is.hail.variant.{VariantSampleMatrix, _}
+import is.hail.variant.{MatrixTable, _}
 import org.testng.annotations.Test
 
 import scala.language.postfixOps
@@ -78,7 +78,7 @@ class FisherExactTestSuite extends SparkSuite {
       }
 
     property("expr gives same result as class") =
-      forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { (vds: VariantSampleMatrix) =>
+      forAll(MatrixTable.gen(hc, VSMSubgen.random)) { (vds: MatrixTable) =>
         val sampleIds = vds.sampleIds
         val phenotypes = sampleIds.zipWithIndex.map { case (sample, i) =>
           if (i % 3 == 0)

--- a/src/test/scala/is/hail/stats/HWESuite.scala
+++ b/src/test/scala/is/hail/stats/HWESuite.scala
@@ -30,7 +30,7 @@ class HWESuite extends SparkSuite {
   }
 
   @Test def testExpr() {
-    val p = Prop.forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vds: VariantSampleMatrix =>
+    val p = Prop.forAll(MatrixTable.gen(hc, VSMSubgen.random)) { vds: MatrixTable =>
       val vds2 = VariantQC(vds.splitMulti())
         .annotateVariantsExpr("va.hweExpr = hwe(va.qc.nHomRef, va.qc.nHet, va.qc.nHomVar)")
         .annotateVariantsExpr("va.hweAgg = gs.map(g => g.GT).hardyWeinberg()")

--- a/src/test/scala/is/hail/stats/InbreedingCoefficientSuite.scala
+++ b/src/test/scala/is/hail/stats/InbreedingCoefficientSuite.scala
@@ -30,7 +30,7 @@ class InbreedingCoefficientSuite extends SparkSuite {
 
   object Spec extends Properties("InbreedingCoefficient") {
 
-    val plinkSafeBiallelicVDS = VariantSampleMatrix.gen(hc, VSMSubgen.plinkSafeBiallelic)
+    val plinkSafeBiallelicVDS = MatrixTable.gen(hc, VSMSubgen.plinkSafeBiallelic)
       .resize(1000)
       .map { vds =>
         val gr = vds.genomeReference
@@ -41,7 +41,7 @@ class InbreedingCoefficientSuite extends SparkSuite {
       .filter(vds => vds.countVariants > 2 && vds.nSamples >= 2)
 
     property("hail generates same results as PLINK v1.9") =
-      forAll(plinkSafeBiallelicVDS) { case (vds: VariantSampleMatrix) =>
+      forAll(plinkSafeBiallelicVDS) { case (vds: MatrixTable) =>
 
         val vds2 = VariantQC(vds)
           .filterVariantsExpr("va.qc.AC > 1 && va.qc.AF >= 1e-8 && va.qc.nCalled * 2 - va.qc.AC > 1 && va.qc.AF <= 1 - 1e-8")

--- a/src/test/scala/is/hail/testUtils/package.scala
+++ b/src/test/scala/is/hail/testUtils/package.scala
@@ -1,10 +1,10 @@
 package is.hail
 
 import is.hail.utils.RichVariantSampleMatrix
-import is.hail.variant.VariantSampleMatrix
+import is.hail.variant.MatrixTable
 
 import scala.language.implicitConversions
 
 package object testUtils {
-  implicit def toRichVariantSampleMatrix(vsm: VariantSampleMatrix): RichVariantSampleMatrix = new RichVariantSampleMatrix(vsm)
+  implicit def toRichVariantSampleMatrix(vsm: MatrixTable): RichVariantSampleMatrix = new RichVariantSampleMatrix(vsm)
 }

--- a/src/test/scala/is/hail/utils/RichVariantSampleMatrix.scala
+++ b/src/test/scala/is/hail/utils/RichVariantSampleMatrix.scala
@@ -2,12 +2,12 @@ package is.hail.utils
 
 import is.hail.annotations.{Annotation, Inserter, Querier, UnsafeRow}
 import is.hail.expr.{EvalContext, Parser, Type}
-import is.hail.variant.VariantSampleMatrix
+import is.hail.variant.MatrixTable
 import org.apache.spark.rdd.RDD
 
 import scala.reflect.ClassTag
 
-class RichVariantSampleMatrix(vsm: VariantSampleMatrix) {
+class RichVariantSampleMatrix(vsm: MatrixTable) {
   def expand(): RDD[(Annotation, Annotation, Annotation)] =
     mapWithKeys[(Annotation, Annotation, Annotation)]((v, s, g) => (v, s, g))
 
@@ -35,7 +35,7 @@ class RichVariantSampleMatrix(vsm: VariantSampleMatrix) {
       }
   }
 
-  def annotateSamplesF(signature: Type, path: List[String], annotation: (Annotation) => Annotation): VariantSampleMatrix = {
+  def annotateSamplesF(signature: Type, path: List[String], annotation: (Annotation) => Annotation): MatrixTable = {
     val (t, i) = vsm.insertSA(signature, path)
     vsm.annotateSamples(annotation, t, i)
   }

--- a/src/test/scala/is/hail/utils/TestRDDBuilder.scala
+++ b/src/test/scala/is/hail/utils/TestRDDBuilder.scala
@@ -80,7 +80,7 @@ object TestRDDBuilder {
   def buildRDD(nSamples: Int, nVariants: Int, hc: HailContext,
                       gqArray: Option[Array[Array[Int]]] = None,
                       dpArray: Option[Array[Array[Int]]] = None,
-                      gtArray: Option[Array[Array[Int]]] = None): VariantSampleMatrix = {
+                      gtArray: Option[Array[Array[Int]]] = None): MatrixTable = {
     /* Takes the arguments:
     nSamples(Int) -- number of samples (columns) to produce in VCF
     nVariants(Int) -- number of variants(rows) to produce in VCF
@@ -124,6 +124,6 @@ object TestRDDBuilder {
       }.toArray
     
     val variantRDD = hc.sc.parallelize(variantArray)
-    VariantSampleMatrix.fromLegacy(hc, VSMFileMetadata(sampleList), variantRDD)
+    MatrixTable.fromLegacy(hc, VSMFileMetadata(sampleList), variantRDD)
   }
 }

--- a/src/test/scala/is/hail/utils/TextTableSuite.scala
+++ b/src/test/scala/is/hail/utils/TextTableSuite.scala
@@ -3,7 +3,7 @@ package is.hail.utils
 import is.hail.SparkSuite
 import is.hail.check._
 import is.hail.expr._
-import is.hail.variant.{GenomeReference, VSMSubgen, VariantSampleMatrix}
+import is.hail.variant.{GenomeReference, VSMSubgen, MatrixTable}
 import org.testng.annotations.Test
 
 import scala.io.Source
@@ -92,8 +92,8 @@ class TextTableSuite extends SparkSuite {
 
   @Test def testAnnotationsReadWrite() {
     val outPath = tmpDir.createTempFile("annotationOut", ".tsv")
-    val p = Prop.forAll(VariantSampleMatrix.gen(hc, VSMSubgen.realistic)
-      .filter(vds => vds.countVariants > 0 && !vds.vaSignature.isOfType(TFloat64()))) { vds: VariantSampleMatrix =>
+    val p = Prop.forAll(MatrixTable.gen(hc, VSMSubgen.realistic)
+      .filter(vds => vds.countVariants > 0 && !vds.vaSignature.isOfType(TFloat64()))) { vds: MatrixTable =>
 
       vds.variantsKT().export(outPath, typesFile = outPath + ".types")
 

--- a/src/test/scala/is/hail/variant/GenericDatasetSuite.scala
+++ b/src/test/scala/is/hail/variant/GenericDatasetSuite.scala
@@ -12,7 +12,7 @@ class GenericDatasetSuite extends SparkSuite {
   @Test def testReadWrite() {
     val path = tmpDir.createTempFile(extension = "vds")
 
-    val p = forAll(VariantSampleMatrix.genGeneric(hc)) { gds =>
+    val p = forAll(MatrixTable.genGeneric(hc)) { gds =>
       val f = tmpDir.createTempFile(extension = "vds")
       gds.write(f)
       hc.readGDS(f).same(gds)

--- a/src/test/scala/is/hail/variant/GenomeReferenceSuite.scala
+++ b/src/test/scala/is/hail/variant/GenomeReferenceSuite.scala
@@ -3,7 +3,7 @@ package is.hail.variant
 import java.io.FileNotFoundException
 
 import is.hail.expr.{TInterval, TLocus, TStruct, TVariant}
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.utils.Interval
 import is.hail.{SparkSuite, TestUtils}
 import org.apache.spark.sql.Row

--- a/src/test/scala/is/hail/variant/GenomeReferenceSuite.scala
+++ b/src/test/scala/is/hail/variant/GenomeReferenceSuite.scala
@@ -3,7 +3,7 @@ package is.hail.variant
 import java.io.FileNotFoundException
 
 import is.hail.expr.{TInterval, TLocus, TStruct, TVariant}
-import is.hail.keytable.KeyTable
+import is.hail.keytable.Table
 import is.hail.utils.Interval
 import is.hail.{SparkSuite, TestUtils}
 import org.apache.spark.sql.Row
@@ -115,22 +115,22 @@ class GenomeReferenceSuite extends SparkSuite {
     val sig = TStruct(("v37", TVariant(GenomeReference.GRCh37)), ("v38", TVariant(GenomeReference.GRCh38)))
 
     val data1 = Array(Row(Variant("X", 154931044, "A", "G"), Variant("chrX", 156030895, "A", "G")))
-    val kt1 = KeyTable(hc, sc.parallelize(data1), sig)
+    val kt1 = Table(hc, sc.parallelize(data1), sig)
     kt1.typeCheck()
     assert(kt1.forall("v37.inXPar() && v38.inXPar()"))
 
     val data2 = Array(Row(Variant("Y", 2649520, "A", "G"), Variant("chrY", 2649520, "A", "G")))
-    val kt2 = KeyTable(hc, sc.parallelize(data2), sig)
+    val kt2 = Table(hc, sc.parallelize(data2), sig)
     kt2.typeCheck()
     assert(kt2.forall("v37.inYPar() && v38.inYPar()"))
 
     val data3 = Array(Row(Variant("X", 157701382, "A", "G"), Variant("chrX", 157701382, "A", "G")))
-    val kt3 = KeyTable(hc, sc.parallelize(data3), sig)
+    val kt3 = Table(hc, sc.parallelize(data3), sig)
     kt3.typeCheck()
     assert(kt3.forall("v37.inXNonPar() && v38.inXNonPar()"))
 
     val data4 = Array(Row(Variant("Y", 2781480, "A", "G"), Variant("chrY", 2781480, "A", "G")))
-    val kt4 = KeyTable(hc, sc.parallelize(data4), sig)
+    val kt4 = Table(hc, sc.parallelize(data4), sig)
     kt4.typeCheck()
     assert(kt4.forall("v37.inYNonPar() && v38.inYNonPar()"))
 
@@ -138,7 +138,7 @@ class GenomeReferenceSuite extends SparkSuite {
       Row(Variant("1", 2781480, "A", "G"), Variant("X", 2781480, "A", "G"), Variant("chr1", 2781480, "A", "G"), Variant("chrX", 2781480, "A", "G")),
       Row(Variant("6", 2781480, "A", "G"), Variant("Y", 2781480, "A", "G"), Variant("chr6", 2781480, "A", "G"), Variant("chrY", 2781480, "A", "G")),
       Row(Variant("21", 2781480, "A", "G"), Variant("MT", 2781480, "A", "G"), Variant("chr21", 2781480, "A", "G"), Variant("chrM", 2781480, "A", "G")))
-    val kt5 = KeyTable(hc, sc.parallelize(data5), TStruct(
+    val kt5 = Table(hc, sc.parallelize(data5), TStruct(
       ("v37a", TVariant(GenomeReference.GRCh37)), ("v37na", TVariant(GenomeReference.GRCh37)),
       ("v38a", TVariant(GenomeReference.GRCh38)), ("v38na", TVariant(GenomeReference.GRCh38))))
     kt5.typeCheck()

--- a/src/test/scala/is/hail/variant/IntervalSuite.scala
+++ b/src/test/scala/is/hail/variant/IntervalSuite.scala
@@ -49,7 +49,7 @@ class IntervalSuite extends SparkSuite {
   }
 
   @Test def testAll() {
-    val vds = VariantSampleMatrix.fromLegacy(hc, VSMFileMetadata(Array.empty[String]),
+    val vds = MatrixTable.fromLegacy(hc, VSMFileMetadata(Array.empty[String]),
       sc.parallelize(Seq((Variant("1", 100, "A", "T"), (Annotation.empty, Iterable.empty[Annotation])))))
 
     val intervalFile = tmpDir.createTempFile("intervals")

--- a/src/test/scala/is/hail/variant/vsm/GroupBySuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/GroupBySuite.scala
@@ -8,7 +8,7 @@ import is.hail.TestUtils._
 import is.hail.annotations.UnsafeRow
 import is.hail.check.Prop.forAll
 import is.hail.utils._
-import is.hail.variant.{VSMSubgen, VariantSampleMatrix}
+import is.hail.variant.{VSMSubgen, MatrixTable}
 
 
 class GroupBySuite extends SparkSuite {
@@ -36,7 +36,7 @@ class GroupBySuite extends SparkSuite {
   @Test def testRandomVSMEquivalence() {
     var vSkipped = 0
     var sSkipped = 0
-    val p = forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vsm =>
+    val p = forAll(MatrixTable.gen(hc, VSMSubgen.random)) { vsm =>
       val variants = vsm.variants.collect()
       val uniqueVariants = variants.toSet
       if (variants.length != uniqueVariants.size) {

--- a/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -2,12 +2,12 @@ package is.hail.variant.vsm
 
 import is.hail.SparkSuite
 import is.hail.check.{Gen, Prop}
-import is.hail.variant.{VSMSubgen, VariantSampleMatrix}
+import is.hail.variant.{VSMSubgen, MatrixTable}
 import org.testng.annotations.Test
 
 class PartitioningSuite extends SparkSuite {
 
-  def compare(vds1: VariantSampleMatrix, vds2: VariantSampleMatrix): Boolean = {
+  def compare(vds1: MatrixTable, vds2: MatrixTable): Boolean = {
     val s1 = vds1.variantsAndAnnotations
       .mapPartitionsWithIndex { case (i, it) => it.zipWithIndex.map(x => (i, x)) }
       .collect()
@@ -20,7 +20,7 @@ class PartitioningSuite extends SparkSuite {
   }
 
   @Test def testWriteRead() {
-    Prop.forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random), Gen.choose(1, 10)) { case (vds, nPar) =>
+    Prop.forAll(MatrixTable.gen(hc, VSMSubgen.random), Gen.choose(1, 10)) { case (vds, nPar) =>
 
       val out = tmpDir.createTempFile("out", ".vds")
       val out2 = tmpDir.createTempFile("out", ".vds")

--- a/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
@@ -6,7 +6,7 @@ import is.hail.check.Prop._
 import is.hail.check.{Gen, Parameters}
 import is.hail.distributedmatrix.BlockMatrix
 import is.hail.expr._
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.sparkextras.OrderedRDD
 import is.hail.utils._
 import is.hail.testUtils._

--- a/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
@@ -6,7 +6,7 @@ import is.hail.check.Prop._
 import is.hail.check.{Gen, Parameters}
 import is.hail.distributedmatrix.BlockMatrix
 import is.hail.expr._
-import is.hail.keytable.KeyTable
+import is.hail.keytable.Table
 import is.hail.sparkextras.OrderedRDD
 import is.hail.utils._
 import is.hail.testUtils._
@@ -170,15 +170,15 @@ class VSMSuite extends SparkSuite {
         Iterable(Genotype(0),
           Genotype(0))))))
 
-    val vdss = Array(VariantSampleMatrix.fromLegacy(hc, s3mdata, s3rdd1),
-      VariantSampleMatrix.fromLegacy(hc, s3mdata, s3rdd2),
-      VariantSampleMatrix.fromLegacy(hc, s3mdata, s3rdd3),
-      VariantSampleMatrix.fromLegacy(hc, s2mdata, s2rdd4),
-      VariantSampleMatrix.fromLegacy(hc, s3mdata, s3rdd5),
-      VariantSampleMatrix.fromLegacy(hc, s3mdata, s3rdd6),
-      VariantSampleMatrix.fromLegacy(hc, s1mdata, s1rdd7),
-      VariantSampleMatrix.fromLegacy(hc, s2mdata, s2rdd8),
-      VariantSampleMatrix.fromLegacy(hc, s4mdata, s4rdd9))
+    val vdss = Array(MatrixTable.fromLegacy(hc, s3mdata, s3rdd1),
+      MatrixTable.fromLegacy(hc, s3mdata, s3rdd2),
+      MatrixTable.fromLegacy(hc, s3mdata, s3rdd3),
+      MatrixTable.fromLegacy(hc, s2mdata, s2rdd4),
+      MatrixTable.fromLegacy(hc, s3mdata, s3rdd5),
+      MatrixTable.fromLegacy(hc, s3mdata, s3rdd6),
+      MatrixTable.fromLegacy(hc, s1mdata, s1rdd7),
+      MatrixTable.fromLegacy(hc, s2mdata, s2rdd8),
+      MatrixTable.fromLegacy(hc, s4mdata, s4rdd9))
 
     for (vds <- vdss)
       vds.typecheck()
@@ -193,7 +193,7 @@ class VSMSuite extends SparkSuite {
   }
 
   @Test def testWriteRead() {
-    val p = forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vds =>
+    val p = forAll(MatrixTable.gen(hc, VSMSubgen.random)) { vds =>
       val f = tmpDir.createTempFile(extension = "vds")
       vds.write(f)
       hc.readVDS(f).same(vds)
@@ -266,9 +266,9 @@ class VSMSuite extends SparkSuite {
   @Test(enabled = false) def testVSMGenIsLinearSpaceInSizeParameter() {
     val minimumRSquareValue = 0.7
 
-    def vsmOfSize(size: Int): VariantSampleMatrix = {
+    def vsmOfSize(size: Int): MatrixTable = {
       val parameters = Parameters.default.copy(size = size, count = 1)
-      VariantSampleMatrix.gen(hc, VSMSubgen.random).apply(parameters)
+      MatrixTable.gen(hc, VSMSubgen.random).apply(parameters)
     }
 
     def spaceStatsOf[T](factory: () => T): SummaryStatistics = {
@@ -300,7 +300,7 @@ class VSMSuite extends SparkSuite {
 
   @Test def testCoalesce() {
     val g = for (
-      vsm <- VariantSampleMatrix.gen(hc, VSMSubgen.random);
+      vsm <- MatrixTable.gen(hc, VSMSubgen.random);
       k <- Gen.choose(1, math.max(1, vsm.nPartitions)))
       yield (vsm, k)
 
@@ -314,7 +314,7 @@ class VSMSuite extends SparkSuite {
 
   @Test def testNaiveCoalesce() {
     val g = for (
-      vsm <- VariantSampleMatrix.gen(hc, VSMSubgen.random);
+      vsm <- MatrixTable.gen(hc, VSMSubgen.random);
       k <- Gen.choose(1, math.max(1, vsm.nPartitions)))
       yield (vsm, k)
 
@@ -346,7 +346,7 @@ class VSMSuite extends SparkSuite {
   }
 
   @Test def testAnnotateVariantsKeyTable() {
-    forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vds =>
+    forAll(MatrixTable.gen(hc, VSMSubgen.random)) { vds =>
       val vds2 = vds.annotateVariantsExpr("va.bar = va")
       val kt = vds2.variantsKT()
       val resultVds = vds2.annotateVariantsTable(kt, expr = "va.foo = table.bar")
@@ -361,10 +361,10 @@ class VSMSuite extends SparkSuite {
   }
 
   @Test def testAnnotateVariantsKeyTableWithComputedKey() {
-    forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vds =>
+    forAll(MatrixTable.gen(hc, VSMSubgen.random)) { vds =>
       val vds2 = vds.annotateVariantsExpr("va.key = v.start % 2 == 0")
 
-      val kt = KeyTable(hc, sc.parallelize(Array(Row(true, 1), Row(false, 2))),
+      val kt = Table(hc, sc.parallelize(Array(Row(true, 1), Row(false, 2))),
         TStruct(("key", TBoolean()), ("value", TInt32())), Array("key"))
 
       val resultVds = vds2.annotateVariantsTable(kt, vdsKey = Seq("va.key"), root = "va.foo")
@@ -385,7 +385,7 @@ class VSMSuite extends SparkSuite {
   }
 
   @Test def testAnnotateVariantsKeyTableWithComputedKey2() {
-    forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vds =>
+    forAll(MatrixTable.gen(hc, VSMSubgen.random)) { vds =>
       val vds2 = vds.annotateVariantsExpr("va.key1 =  v.start % 2 == 0, va.key2 = v.contig.length() % 2 == 0")
 
       def f(a: Boolean, b: Boolean): Int =
@@ -402,7 +402,7 @@ class VSMSuite extends SparkSuite {
         makeAnnotation(false, true),
         makeAnnotation(false, false)))
 
-      val kt = KeyTable(hc, mapping, TStruct(("key1", TBoolean()), ("key2", TBoolean()), ("value", TInt32())), Array("key1", "key2"))
+      val kt = Table(hc, mapping, TStruct(("key1", TBoolean()), ("key2", TBoolean()), ("value", TInt32())), Array("key1", "key2"))
 
       val resultVds = vds2.annotateVariantsTable(kt, vdsKey = Seq("va.key1", "va.key2"),
         expr = "va.foo = table")
@@ -430,7 +430,7 @@ class VSMSuite extends SparkSuite {
     val filteredVds = vds.filterSamplesList(origOrder.toSet)
     val reorderedVds = filteredVds.reorderSamples(newOrder)
 
-    def getGenotypes(vds: VariantSampleMatrix): RDD[((Variant, Annotation), Annotation)] = {
+    def getGenotypes(vds: MatrixTable): RDD[((Variant, Annotation), Annotation)] = {
       val sampleIds = vds.sampleIds
       vds.typedRDD[Locus, Variant].flatMap { case (v, (_, gs)) =>
         gs.zip(sampleIds).map { case (g, s) =>

--- a/src/test/scala/is/hail/vds/FilterAllelesSuite.scala
+++ b/src/test/scala/is/hail/vds/FilterAllelesSuite.scala
@@ -5,7 +5,7 @@ import is.hail.annotations._
 import is.hail.check.Prop
 import is.hail.expr.{TString, TStruct}
 import is.hail.utils._
-import is.hail.variant.{AltAllele, Genotype, VSMFileMetadata, VSMSubgen, Variant, VariantSampleMatrix}
+import is.hail.variant.{AltAllele, Genotype, VSMFileMetadata, VSMSubgen, Variant, MatrixTable}
 import org.testng.annotations.Test
 
 class FilterAllelesSuite extends SparkSuite {
@@ -49,7 +49,7 @@ class FilterAllelesSuite extends SparkSuite {
     val genotypes1 = Seq(genotype11, genotype12, genotype13)
     val row1: (Variant, (Annotation, Iterable[Annotation])) = (variant1, (va1, genotypes1))
 
-    val vds = VariantSampleMatrix.fromLegacy(hc, VSMFileMetadata(Array("1", "2", "3"),
+    val vds = MatrixTable.fromLegacy(hc, VSMFileMetadata(Array("1", "2", "3"),
       IndexedSeq[Annotation](null, null, null),
       null,
       TString(),
@@ -77,7 +77,7 @@ class FilterAllelesSuite extends SparkSuite {
     val genotypes1 = Seq(genotype11, genotype12, genotype13)
     val row1: (Variant, (Annotation, Iterable[Annotation])) = (variant1, (va1, genotypes1))
 
-    val vds = VariantSampleMatrix.fromLegacy(hc, VSMFileMetadata(Array("1", "2", "3"),
+    val vds = MatrixTable.fromLegacy(hc, VSMFileMetadata(Array("1", "2", "3"),
       IndexedSeq[Annotation](null, null, null),
       null,
       TString(),
@@ -106,7 +106,7 @@ class FilterAllelesSuite extends SparkSuite {
     val genotypes1 = Seq(genotype11, genotype12, genotype13)
     val row1: (Variant, (Annotation, Iterable[Annotation])) = (variant1, (va1, genotypes1))
 
-    val vds = VariantSampleMatrix.fromLegacy(hc, VSMFileMetadata(Array("1", "2", "3"),
+    val vds = MatrixTable.fromLegacy(hc, VSMFileMetadata(Array("1", "2", "3"),
       IndexedSeq[Annotation](null, null, null),
       null,
       TString(),
@@ -134,7 +134,7 @@ class FilterAllelesSuite extends SparkSuite {
     val genotypes1 = Seq(genotype11, genotype12, genotype13)
     val row1: (Variant, (Annotation, Iterable[Annotation])) = (variant1, (va1, genotypes1))
 
-    val vds = VariantSampleMatrix.fromLegacy(hc, VSMFileMetadata(Array("1", "2", "3"),
+    val vds = MatrixTable.fromLegacy(hc, VSMFileMetadata(Array("1", "2", "3"),
       IndexedSeq[Annotation](null, null, null),
       null,
       TString(),
@@ -159,7 +159,7 @@ class FilterAllelesSuite extends SparkSuite {
     val genotypes1 = Seq(Genotype(1), Genotype(2), Genotype(3))
     val row1: (Variant, (Annotation, Iterable[Annotation])) = (variant1, (va1, genotypes1))
 
-    val vds = VariantSampleMatrix.fromLegacy(hc, VSMFileMetadata(Array("1", "2", "3"),
+    val vds = MatrixTable.fromLegacy(hc, VSMFileMetadata(Array("1", "2", "3"),
       IndexedSeq[Annotation](null, null, null),
       null,
       TString(),

--- a/src/test/scala/is/hail/vds/GenotypeTableSuite.scala
+++ b/src/test/scala/is/hail/vds/GenotypeTableSuite.scala
@@ -3,7 +3,7 @@ package is.hail.vds
 import is.hail.SparkSuite
 import org.testng.annotations.Test
 
-class GenotypeKeyTableSuite extends SparkSuite {
+class GenotypeTableSuite extends SparkSuite {
   @Test def test() {
     val vds = hc.importVCF("src/test/resources/sample.vcf")
 

--- a/src/test/scala/is/hail/vds/JoinSuite.scala
+++ b/src/test/scala/is/hail/vds/JoinSuite.scala
@@ -3,7 +3,7 @@ package is.hail.vds
 import is.hail.SparkSuite
 import is.hail.annotations.UnsafeRow
 import is.hail.expr.{TStruct, TVariant}
-import is.hail.keytable.Table
+import is.hail.table.Table
 import is.hail.variant.{GenomeReference, Variant, MatrixTable, VariantDataset}
 import is.hail.utils._
 

--- a/src/test/scala/is/hail/vds/JoinSuite.scala
+++ b/src/test/scala/is/hail/vds/JoinSuite.scala
@@ -3,8 +3,8 @@ package is.hail.vds
 import is.hail.SparkSuite
 import is.hail.annotations.UnsafeRow
 import is.hail.expr.{TStruct, TVariant}
-import is.hail.keytable.KeyTable
-import is.hail.variant.{GenomeReference, Variant, VariantSampleMatrix, VariantDataset}
+import is.hail.keytable.Table
+import is.hail.variant.{GenomeReference, Variant, MatrixTable, VariantDataset}
 import is.hail.utils._
 
 import scala.language.implicitConversions
@@ -54,11 +54,11 @@ class JoinSuite extends SparkSuite {
       Variant("1", 13, "A", "T"),
       Variant("1", 15, "A", "T"))
 
-    val leftKt = KeyTable(hc, sc.parallelize(leftVariants.map(Row(_))), TStruct("v" -> TVariant(GenomeReference.GRCh37))).keyBy("v")
+    val leftKt = Table(hc, sc.parallelize(leftVariants.map(Row(_))), TStruct("v" -> TVariant(GenomeReference.GRCh37))).keyBy("v")
     leftKt.typeCheck()
     val left = VariantDataset.fromKeyTable(leftKt)
 
-    val rightKt = KeyTable(hc, sc.parallelize(rightVariants.map(Row(_))), TStruct("v" -> TVariant(GenomeReference.GRCh37))).keyBy("v")
+    val rightKt = Table(hc, sc.parallelize(rightVariants.map(Row(_))), TStruct("v" -> TVariant(GenomeReference.GRCh37))).keyBy("v")
     rightKt.typeCheck()
     val right = VariantDataset.fromKeyTable(rightKt)
 


### PR DESCRIPTION
I hereby declare the api1 deprecated.  Changing Scala to match api2 names.  I'll try to do things in moderately manageable chunks.  I'll do the MatrixTable methods next (filterSamples => filterColumns, etc.)