### PR TITLE
Moved variant, sample QC to method objects.

### DIFF
--- a/python/hail/api1/dataset.py
+++ b/python/hail/api1/dataset.py
@@ -4508,7 +4508,7 @@ class VariantDataset(HistoryMixin):
         :rtype: :class:`.VariantDataset`
         """
 
-        return VariantDataset(self.hc, self._jvds.sampleQC(root))
+        return VariantDataset(self.hc, Env.hail().methods.SampleQC.apply(self._jvds, root))
 
     @handle_py4j
     def storage_level(self):
@@ -5214,7 +5214,7 @@ class VariantDataset(HistoryMixin):
         :rtype: :py:class:`.VariantDataset`
         """
 
-        return VariantDataset(self.hc, self._jvds.variantQC(root))
+        return VariantDataset(self.hc, Env.hail().methods.VariantQC.apply(self._jvds, root))
 
     @handle_py4j
     @record_method

--- a/python/hail/methods/qc.py
+++ b/python/hail/methods/qc.py
@@ -1,5 +1,5 @@
 from hail.typecheck import *
-from hail.utils.java import handle_py4j
+from hail.utils.java import Env, handle_py4j
 from hail.api2 import MatrixTable
 
 
@@ -81,4 +81,4 @@ def sample_qc(dataset, name='sample_qc'):
     :rtype: :class:`.MatrixTable`
     """
 
-    return MatrixTable(dataset._hc, dataset._jvds.sampleQC('sa.`{}`'.format(name)))
+    return MatrixTable(dataset._hc, Env.hail().methods.SampleQC(dataset._jvds, 'sa.`{}`'.format(name)))

--- a/python/hail/methods/qc.py
+++ b/python/hail/methods/qc.py
@@ -81,4 +81,4 @@ def sample_qc(dataset, name='sample_qc'):
     :rtype: :class:`.MatrixTable`
     """
 
-    return MatrixTable(dataset._hc, Env.hail().methods.SampleQC(dataset._jvds, 'sa.`{}`'.format(name)))
+    return MatrixTable(dataset._hc, Env.hail().methods.SampleQC.apply(dataset._jvds, 'sa.`{}`'.format(name)))

--- a/src/main/scala/is/hail/methods/SampleQC.scala
+++ b/src/main/scala/is/hail/methods/SampleQC.scala
@@ -211,7 +211,9 @@ object SampleQC {
       Array.fill(nSamples)(new SampleQCCombiner)
   }
 
-  def apply[RPK, RK, T >: Null](vsm: VariantSampleMatrix, root: String): VariantSampleMatrix = {
+  def apply(vsm: VariantSampleMatrix, root: String = "sa.qc"): VariantSampleMatrix = {
+    vsm.requireRowKeyVariant("sample_qc")
+
     val r = results(vsm).map(_.asAnnotation)
     vsm.annotateSamples(SampleQCCombiner.signature, Parser.parseAnnotationRoot(root, Annotation.SAMPLE_HEAD), r)
   }

--- a/src/main/scala/is/hail/methods/VariantQC.scala
+++ b/src/main/scala/is/hail/methods/VariantQC.scala
@@ -129,7 +129,10 @@ object VariantQC {
     "rExpectedHetFrequency" -> TFloat64(),
     "pHWE" -> TFloat64())
 
-  def apply(vsm: VariantSampleMatrix, root: String): VariantSampleMatrix = {
+  def apply(vsm: VariantSampleMatrix, root: String = "va.qc"): VariantSampleMatrix = {
+    require(vsm.wasSplit)
+    vsm.requireRowKeyVariant("variant_qc")
+
     val localNSamples = vsm.nSamples
     val localRowType = vsm.rowType
 

--- a/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/is/hail/variant/VariantSampleMatrix.scala
@@ -2417,17 +2417,6 @@ class VariantSampleMatrix(val hc: HailContext, val metadata: VSMMetadata,
     copy2(rdd2 = newRDD2)
   }
 
-  def sampleQC(root: String = "sa.qc"): VariantSampleMatrix = {
-    requireRowKeyVariant("sample_qc")
-    SampleQC(this, root)
-  }
-
-  def variantQC(root: String = "va.qc"): VariantSampleMatrix = {
-    require(wasSplit)
-    requireRowKeyVariant("variant_qc")
-    VariantQC(this, root)
-  }
-
   def ldPrune(nCores: Int, r2Threshold: Double = 0.2, windowSize: Int = 1000000, memoryPerCore: Int = 256): VariantSampleMatrix = {
     require(wasSplit)
     requireRowKeyVariant("ld_prune")

--- a/src/test/scala/is/hail/annotations/SplatSuite.scala
+++ b/src/test/scala/is/hail/annotations/SplatSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.annotations
 
 import is.hail.SparkSuite
+import is.hail.methods.VariantQC
 import is.hail.utils._
 import org.testng.annotations.Test
 
@@ -11,9 +12,8 @@ class SplatSuite extends SparkSuite {
     val out3 = tmpDir.createLocalTempFile("out3", ".txt")
     val out4 = tmpDir.createLocalTempFile("out4", ".txt")
 
-    val vkt = hc.importVCF("src/test/resources/sample2.vcf")
-      .splitMulti()
-      .variantQC()
+    val vkt = VariantQC(hc.importVCF("src/test/resources/sample2.vcf")
+      .splitMulti())
       .variantsKT()
 
     vkt.select("variant = v", "va.qc.callRate", "va.qc.AC", "va.qc.AF", "va.qc.nCalled", "va.qc.nNotCalled",

--- a/src/test/scala/is/hail/expr/KeyTableIRSuite.scala
+++ b/src/test/scala/is/hail/expr/KeyTableIRSuite.scala
@@ -14,7 +14,7 @@ class KeyTableIRSuite extends SparkSuite {
     val keyNames = Array("Sample")
 
     val kt = KeyTable(hc, rdd, signature, keyNames)
-    val kt2 = new KeyTable(hc, new FilterKT(kt.ir, ir.ApplyBinaryPrimOp(ir.EQ(), ir.Ref("field1"), ir.I32(3))))
+    val kt2 = new KeyTable(hc, FilterKT(kt.ir, ir.ApplyBinaryPrimOp(ir.EQ(), ir.Ref("field1"), ir.I32(3))))
     assert(kt2.count() == 1)
   }
 
@@ -25,7 +25,7 @@ class KeyTableIRSuite extends SparkSuite {
     val keyNames = Array("Sample")
 
     val kt = KeyTable(hc, rdd, signature, keyNames).annotateGlobalExpr("g = 3")
-    val kt2 = new KeyTable(hc, new FilterKT(kt.ir, ir.ApplyBinaryPrimOp(ir.EQ(), ir.Ref("field1"), ir.Ref("g"))))
+    val kt2 = new KeyTable(hc, FilterKT(kt.ir, ir.ApplyBinaryPrimOp(ir.EQ(), ir.Ref("field1"), ir.Ref("g"))))
     assert(kt2.count() == 1)
   }
 }

--- a/src/test/scala/is/hail/io/ImportPlinkSuite.scala
+++ b/src/test/scala/is/hail/io/ImportPlinkSuite.scala
@@ -4,6 +4,7 @@ import is.hail.check.Gen._
 import is.hail.check.Prop._
 import is.hail.check.Properties
 import is.hail.io.plink.PlinkLoader
+import is.hail.methods.VariantQC
 import is.hail.utils._
 import is.hail.variant._
 import is.hail.{SparkSuite, TestUtils}
@@ -77,16 +78,14 @@ class ImportPlinkSuite extends SparkSuite {
 
     val a2ref = hc.importPlinkBFile(plinkFileRoot, a2Reference = true)
 
-    val a1kt = a1ref
-      .variantQC()
+    val a1kt = VariantQC(a1ref)
       .variantsKT()
       .select("va.rsid", "v", "va.qc.nNotCalled", "va.qc.nHomRef", "va.qc.nHet", "va.qc.nHomVar")
       .rename(Map("v" -> "vA1", "nNotCalled" -> "nNotCalledA1",
         "nHomRef" -> "nHomRefA1", "nHet" -> "nHetA1", "nHomVar" -> "nHomVarA1"))
       .keyBy("rsid")
 
-    val a2kt = a2ref
-      .variantQC()
+    val a2kt = VariantQC(a2ref)
       .variantsKT()
       .select("va.rsid", "v", "va.qc.nNotCalled", "va.qc.nHomRef", "va.qc.nHet", "va.qc.nHomVar")
       .rename(Map("v" -> "vA2", "nNotCalled" -> "nNotCalledA2",

--- a/src/test/scala/is/hail/methods/AggregatorSuite.scala
+++ b/src/test/scala/is/hail/methods/AggregatorSuite.scala
@@ -14,9 +14,8 @@ import org.testng.annotations.Test
 class AggregatorSuite extends SparkSuite {
 
   @Test def testRows() {
-    val vds = hc.importVCF("src/test/resources/sample2.vcf")
-      .splitMulti()
-      .variantQC()
+    val vds = VariantQC(hc.importVCF("src/test/resources/sample2.vcf")
+      .splitMulti())
       .annotateVariantsExpr(
         """va.test.callrate = gs.fraction(g => isDefined(g.GT)),
           |va.test.AC = gs.map(g => g.GT.nNonRefAlleles()).sum(),
@@ -53,8 +52,7 @@ class AggregatorSuite extends SparkSuite {
   }
 
   @Test def testColumns() {
-    val vds = hc.importVCF("src/test/resources/sample2.vcf")
-      .sampleQC()
+    val vds = SampleQC(hc.importVCF("src/test/resources/sample2.vcf"))
       .annotateSamplesExpr(
         """sa.test.callrate = gs.fraction(g => isDefined(g.GT)),
           |sa.test.nCalled = gs.filter(g => isDefined(g.GT)).count(),
@@ -111,8 +109,7 @@ class AggregatorSuite extends SparkSuite {
 
   @Test def testSum() {
     val p = Prop.forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vds =>
-      val vds2 = vds.splitMulti()
-        .variantQC()
+      val vds2 = VariantQC(vds.splitMulti())
         .annotateVariantsExpr("va.oneHotAC = gs.map(g => g.GT.oneHotAlleles(v)).sum()")
         .annotateVariantsExpr("va.same = (gs.filter(g => isDefined(g.GT)).count() == 0) || " +
           "(va.oneHotAC[0] == va.qc.nCalled * 2  - va.qc.AC) && (va.oneHotAC[1] == va.qc.nHet + 2 * va.qc.nHomVar)")

--- a/src/test/scala/is/hail/methods/AnnotateGlobalSuite.scala
+++ b/src/test/scala/is/hail/methods/AnnotateGlobalSuite.scala
@@ -11,10 +11,10 @@ import org.testng.annotations.Test
 class AnnotateGlobalSuite extends SparkSuite {
   @Test def test() {
 
-    val vds = hc.importVCF("src/test/resources/sample2.vcf")
-      .splitMulti()
-      .variantQC()
-      .sampleQC()
+    val vds = SampleQC(
+      VariantQC(
+        hc.importVCF("src/test/resources/sample2.vcf")
+          .splitMulti()))
 
     val (afDist, _) = vds.queryVariants("variants.map(v => va.qc.AF).stats()")
     val (singStats, _) = vds.querySamples("samples.filter(s => sa.qc.nSingleton > 2).count()")

--- a/src/test/scala/is/hail/methods/ExportSuite.scala
+++ b/src/test/scala/is/hail/methods/ExportSuite.scala
@@ -11,9 +11,8 @@ import scala.io.Source
 class ExportSuite extends SparkSuite {
 
   @Test def test() {
-    val vds = hc.importVCF("src/test/resources/sample.vcf")
-      .splitMulti()
-      .sampleQC()
+    val vds = SampleQC(hc.importVCF("src/test/resources/sample.vcf")
+      .splitMulti())
 
     val out = tmpDir.createTempFile("out", ".tsv")
     vds.samplesKT().select("Sample = s", "sa.qc.*").export(out)
@@ -100,9 +99,8 @@ class ExportSuite extends SparkSuite {
 
     // this should run without errors
     val f = tmpDir.createTempFile("samples", ".tsv")
-    hc.importVCF("src/test/resources/sample.vcf")
-      .splitMulti()
-      .sampleQC()
+    SampleQC(hc.importVCF("src/test/resources/sample.vcf")
+      .splitMulti())
       .samplesKT()
       .select("computation = 5 * (if (sa.qc.callRate < .95) 0 else 1)")
       .export(f)

--- a/src/test/scala/is/hail/methods/FilterSuite.scala
+++ b/src/test/scala/is/hail/methods/FilterSuite.scala
@@ -33,7 +33,7 @@ class FilterSuite extends SparkSuite {
 
     assert(vds.filterVariantsExpr("""va.rsid == "."""", keep = false).countVariants() == 258)
 
-    val sQcVds = vds.sampleQC()
+    val sQcVds = SampleQC(vds)
 
     assert(sQcVds.filterSamplesExpr("sa.qc.nCalled == 337").nSamples == 17)
 
@@ -42,7 +42,7 @@ class FilterSuite extends SparkSuite {
     assert(sQcVds.filterSamplesExpr("if (\"^C1048\" ~ s) {sa.qc.rTiTv > 3.5 && sa.qc.nSingleton < 10000000} else sa.qc.rTiTv > 3")
       .nSamples == 16)
 
-    val vQcVds = vds.variantQC()
+    val vQcVds = VariantQC(vds)
 
     assert(vQcVds.filterVariantsExpr("va.qc.nCalled < 100").countVariants() == 36)
 
@@ -119,8 +119,7 @@ class FilterSuite extends SparkSuite {
   @Test def MissingTest() {
     val vds = hc.importVCF("src/test/resources/sample.vcf")
       .splitMulti()
-    val keepOneSample = vds.filterSamplesExpr("s == \"C1046::HG02024\"")
-      .variantQC()
+    val keepOneSample = VariantQC(vds.filterSamplesExpr("s == \"C1046::HG02024\""))
 
     val q = keepOneSample.queryVA("va.qc.rHetHomVar")._2
     val missingVariants = keepOneSample.variantsAndAnnotations

--- a/src/test/scala/is/hail/methods/ImputeSexSuite.scala
+++ b/src/test/scala/is/hail/methods/ImputeSexSuite.scala
@@ -39,8 +39,7 @@ class ImputeSexSuite extends SparkSuite {
 
     property("hail generates same results as PLINK v1.9") =
       forAll(plinkSafeBiallelicVDS) { case (vds: VariantSampleMatrix) =>
-        var mappedVDS = vds
-          .variantQC()
+        var mappedVDS = VariantQC(vds)
           .filterVariantsExpr("va.qc.AC > 1 && va.qc.AF >= 1e-8 && " +
             "va.qc.nCalled * 2 - va.qc.AC > 1 && va.qc.AF <= 1 - 1e-8")
 

--- a/src/test/scala/is/hail/methods/ProgrammaticAnnotationsSuite.scala
+++ b/src/test/scala/is/hail/methods/ProgrammaticAnnotationsSuite.scala
@@ -9,10 +9,9 @@ class ProgrammaticAnnotationsSuite extends SparkSuite {
 
   @Test def testSamples() {
 
-    val vds = hc.importVCF("src/test/resources/sample.vcf")
+    val vds = SampleQC(hc.importVCF("src/test/resources/sample.vcf")
       .cache()
-      .splitMulti()
-      .sampleQC()
+      .splitMulti())
       .annotateSamplesExpr(
         "sa.userdefined.missingness = (1 - sa.qc.callRate) * 100, sa.anotherthing = 5, " +
           "sa.`hi there i have spaces`.another = true")
@@ -30,11 +29,10 @@ class ProgrammaticAnnotationsSuite extends SparkSuite {
   }
 
   @Test def testVariants() {
-    val vds = hc.importVCF("src/test/resources/sample.vcf")
+    val vds = VariantQC(hc.importVCF("src/test/resources/sample.vcf")
       .cache()
       .filterVariantsExpr("v.start == 10019093")
-      .splitMulti()
-      .variantQC()
+      .splitMulti())
       .annotateVariantsExpr(
         "va.a.b.c.d.e = va.qc.callRate * 100, va.a.c = if (va.filters.isEmpty) 1 else 0, va.`weird spaces name` = 5 / (va.qual - 5)")
 

--- a/src/test/scala/is/hail/methods/gqDpStatsSuite.scala
+++ b/src/test/scala/is/hail/methods/gqDpStatsSuite.scala
@@ -22,9 +22,8 @@ class gqDpStatsSuite extends SparkSuite {
 
     // DP test first
     val dpVds = TestRDDBuilder.buildRDD(8, 4, hc, dpArray = Some(arr), gqArray = None)
-    val dpVariantR = dpVds
-      .filterMulti()
-      .variantQC()
+    val dpVariantR = VariantQC(dpVds
+      .filterMulti())
       .variantsKT()
       .query(Array("index(v.map(v => {v: v, dpMean: va.qc.dpMean, dpStDev: va.qc.dpStDev}).collect(), v)"))
       .apply(0)._1.asInstanceOf[Map[Variant, Row]]
@@ -51,9 +50,8 @@ class gqDpStatsSuite extends SparkSuite {
 
     // now test GQ
     val gqVds = TestRDDBuilder.buildRDD(8, 4, hc, dpArray = None, gqArray = Some(arr))
-    val gqVariantR = gqVds
-      .filterMulti()
-      .variantQC()
+    val gqVariantR = VariantQC(gqVds
+      .filterMulti())
       .variantsKT()
       .query(Array("index(v.map(v => {v: v, gqMean: va.qc.gqMean, gqStDev: va.qc.gqStDev}).collect(), v)"))
       .apply(0)._1.asInstanceOf[Map[Variant, Row]]

--- a/src/test/scala/is/hail/stats/HWESuite.scala
+++ b/src/test/scala/is/hail/stats/HWESuite.scala
@@ -2,6 +2,7 @@ package is.hail.stats
 
 import is.hail.SparkSuite
 import is.hail.check._
+import is.hail.methods.VariantQC
 import is.hail.utils._
 import is.hail.variant._
 import org.apache.spark.sql.Row
@@ -10,9 +11,8 @@ import org.testng.annotations.Test
 class HWESuite extends SparkSuite {
 
   @Test def test() {
-    val a = hc.importVCF("src/test/resources/HWE_test.vcf")
-      .verifyBiallelic()
-      .variantQC()
+    val a = VariantQC(hc.importVCF("src/test/resources/HWE_test.vcf")
+      .verifyBiallelic())
       .variantsKT()
       .query(Array("v.map(v => v.start).collect()",
         "v.map(v => {r: va.qc.rExpectedHetFrequency, p: va.qc.pHWE}).collect()"))
@@ -31,8 +31,7 @@ class HWESuite extends SparkSuite {
 
   @Test def testExpr() {
     val p = Prop.forAll(VariantSampleMatrix.gen(hc, VSMSubgen.random)) { vds: VariantSampleMatrix =>
-      val vds2 = vds.splitMulti()
-        .variantQC()
+      val vds2 = VariantQC(vds.splitMulti())
         .annotateVariantsExpr("va.hweExpr = hwe(va.qc.nHomRef, va.qc.nHet, va.qc.nHomVar)")
         .annotateVariantsExpr("va.hweAgg = gs.map(g => g.GT).hardyWeinberg()")
 

--- a/src/test/scala/is/hail/stats/InbreedingCoefficientSuite.scala
+++ b/src/test/scala/is/hail/stats/InbreedingCoefficientSuite.scala
@@ -3,6 +3,7 @@ package is.hail.stats
 import is.hail.SparkSuite
 import is.hail.check.Prop._
 import is.hail.check.Properties
+import is.hail.methods.VariantQC
 import is.hail.utils._
 import is.hail.testUtils._
 import is.hail.variant._
@@ -42,8 +43,7 @@ class InbreedingCoefficientSuite extends SparkSuite {
     property("hail generates same results as PLINK v1.9") =
       forAll(plinkSafeBiallelicVDS) { case (vds: VariantSampleMatrix) =>
 
-        val vds2 = vds
-          .variantQC()
+        val vds2 = VariantQC(vds)
           .filterVariantsExpr("va.qc.AC > 1 && va.qc.AF >= 1e-8 && va.qc.nCalled * 2 - va.qc.AC > 1 && va.qc.AF <= 1 - 1e-8")
 
         if (vds2.nSamples < 5 || vds2.countVariants() < 5) {

--- a/src/test/scala/is/hail/vds/BiallelicMethodsSuite.scala
+++ b/src/test/scala/is/hail/vds/BiallelicMethodsSuite.scala
@@ -1,5 +1,6 @@
 package is.hail.vds
 
+import is.hail.methods.VariantQC
 import is.hail.{SparkSuite, TestUtils}
 import org.testng.annotations.Test
 
@@ -54,7 +55,7 @@ class BiallelicMethodsSuite extends SparkSuite {
     }
 
     interceptRequire {
-      multi.variantQC()
+      VariantQC(multi)
     }
   }
 }


### PR DESCRIPTION
Moved sample and variant QC methods from VDS to their own objects, and call the object apply methods from elsewhere (tests and python).

If we're happy with this model (following the hail2 api) I'll change everything else.

Long chains of `vds.f().g().h()` will need to get broken up as

```
  var vdss = ...
   vds = f(vds)
   vds = g(vds)
   vds =  h(vds)
```

to avoid unnecessary nesting (and clarity).
