### PR TITLE
Generalize AggSum to AggOp, add many Aggregators

### DIFF
--- a/src/main/scala/is/hail/annotations/Region.scala
+++ b/src/main/scala/is/hail/annotations/Region.scala
@@ -191,6 +191,9 @@ final class Region(private var mem: Array[Byte], private var end: Long = 0) exte
     off
   }
 
+  def appendBoolean(b: Boolean): Long =
+    appendByte(b.toByte)
+
   def appendLong(l: Long): Long = {
     val off = allocate(8, 8)
     storeLong(off, l)

--- a/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -149,5 +149,8 @@ class StagedRegionValueBuilder private(val fb: FunctionBuilder[_], val typ: Type
     }
   }
 
-  def returnStart(): Code[Unit] = _return(startOffset)
+  // FIXME, remove this?
+  def returnStart(): Code[Unit] = _return(end())
+
+  def end(): Code[Long] = startOffset
 }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCollectAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCollectAggregator.scala
@@ -1,0 +1,119 @@
+package is.hail.annotations.aggregators
+
+import is.hail.expr._
+import is.hail.annotations._
+import is.hail.utils._
+
+import scala.collection.mutable.BitSet
+
+class RegionValueCollectBooleanAggregator extends RegionValueAggregator {
+  private var length = 0
+  private val elements = new BitSet()
+  private val isMissing = new BitSet()
+
+  def seqOp(b: Boolean, missing: Boolean) {
+    if (missing)
+      isMissing.add(length)
+    else if (b)
+      elements.add(length)
+    length += 1
+  }
+
+  def seqOp(region: Region, off: Long, missing: Boolean) {
+    seqOp(region.loadBoolean(off), missing)
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    val other = agg2.asInstanceOf[RegionValueCollectBooleanAggregator]
+    var i = 0
+    while (i < other.length) {
+      if (other.isMissing(i))
+        isMissing.add(i)
+      else if (other.elements(i))
+        elements.add(length + i)
+      i += 1
+    }
+    length += other.length
+  }
+
+  private val rvb = new RegionValueBuilder()
+
+  private val typ = TArray(TBoolean())
+
+  def result(region: Region): Long = {
+    rvb.set(region)
+    rvb.start(typ)
+    rvb.startArray(length)
+    var i = 0
+    while (i < length) {
+      if (isMissing(i))
+        rvb.setMissing()
+      else
+        rvb.addBoolean(elements(i))
+      i += 1
+    }
+    rvb.endArray()
+    rvb.end()
+  }
+
+  def copy(): RegionValueCollectBooleanAggregator = new RegionValueCollectBooleanAggregator()
+}
+
+class RegionValueCollectIntAggregator extends RegionValueAggregator {
+  private var length = 0
+  private val elements = new ArrayBuilder[Int]()
+  private val isMissing = new BitSet()
+
+  def seqOp(b: Int, missing: Boolean) {
+    if (missing)
+      isMissing.add(length)
+    else
+      elements += (b)
+    length += 1
+  }
+
+  def seqOp(region: Region, off: Long, missing: Boolean) {
+    seqOp(region.loadInt(off), missing)
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    val other = agg2.asInstanceOf[RegionValueCollectIntAggregator]
+    var i = 0
+    var j = 0
+    while (i < other.length) {
+      if (isMissing(i))
+        isMissing.add(length + i)
+      else {
+        elements += other.elements(j)
+        j += 1
+      }
+      i += 1
+    }
+    length += other.length
+  }
+
+  private val rvb = new RegionValueBuilder()
+
+  private val typ = TArray(TInt32())
+
+  def result(region: Region): Long = {
+    rvb.set(region)
+    rvb.start(typ)
+    rvb.startArray(length)
+    var i = 0
+    var j = 0
+    while (i < length) {
+      if (isMissing(i))
+        rvb.setMissing()
+      else {
+        rvb.addInt(elements(j))
+        j += 1
+      }
+      i += 1
+    }
+    rvb.endArray()
+    rvb.end()
+  }
+
+  def copy(): RegionValueCollectIntAggregator = new RegionValueCollectIntAggregator()
+}

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueFractionAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueFractionAggregator.scala
@@ -1,0 +1,33 @@
+package is.hail.annotations.aggregators
+
+import is.hail.asm4s._
+import is.hail.expr._
+import is.hail.expr.ir._
+import is.hail.annotations._
+import is.hail.expr.RegionValueAggregator
+
+class FractionAggregator extends RegionValueAggregator {
+  private var _num = 0L
+  private var _denom = 0L
+
+
+  def result =
+    if (_denom == 0L)
+      null
+    else
+      _num.toDouble / _denom
+
+  def seqOp(x: Any) {
+    val r = f(x)
+    _denom += 1
+    if (r.asInstanceOf[Boolean])
+      _num += 1
+  }
+
+  def combOp(agg2: this.type) {
+    _num += agg2._num
+    _denom += agg2._denom
+  }
+
+  def copy() = new FractionAggregator(f)
+}

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueFractionAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueFractionAggregator.scala
@@ -1,33 +1,31 @@
 package is.hail.annotations.aggregators
 
-import is.hail.asm4s._
-import is.hail.expr._
-import is.hail.expr.ir._
 import is.hail.annotations._
 import is.hail.expr.RegionValueAggregator
 
-class FractionAggregator extends RegionValueAggregator {
-  private var _num = 0L
-  private var _denom = 0L
+class RegionValueFractionAggregator extends RegionValueAggregator {
+  private var trues = 0L
+  private var total = 0L
 
-
-  def result =
-    if (_denom == 0L)
-      null
-    else
-      _num.toDouble / _denom
-
-  def seqOp(x: Any) {
-    val r = f(x)
-    _denom += 1
-    if (r.asInstanceOf[Boolean])
-      _num += 1
+  def seqOp(i: Boolean, missing: Boolean) {
+    total += 1
+    if (!missing && i)
+      trues += 1
   }
 
-  def combOp(agg2: this.type) {
-    _num += agg2._num
-    _denom += agg2._denom
+  def seqOp(region: Region, off: Long, missing: Boolean) {
+    seqOp(region.loadBoolean(off), missing)
   }
 
-  def copy() = new FractionAggregator(f)
+  def result(region: Region): Long =
+    // FIXME: divide by zero should be NA not NaN
+    region.appendDouble(trues.toDouble / total)
+
+  def combOp(agg2: RegionValueAggregator) {
+    val other = agg2.asInstanceOf[RegionValueFractionAggregator]
+    trues += other.trues
+    total += other.total
+  }
+
+  def copy() = new RegionValueFractionAggregator()
 }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueHistogramAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueHistogramAggregator.scala
@@ -7,7 +7,7 @@ import is.hail.stats.HistogramCombiner
 import is.hail.utils._
 
 object RegionValueHistogramAggregator {
-  val typ = HistogramCombiner.schema
+  val typ: TStruct = HistogramCombiner.schema
 
   def stagedNew(start: Code[Double], mstart: Code[Boolean], end: Code[Double], mend: Code[Boolean], bins: Code[Int], mbins: Code[Boolean]): Code[RegionValueHistogramAggregator] =
     (mbins | mstart | mend).mux(
@@ -50,6 +50,7 @@ class RegionValueHistogramAggregator(start: Double, end: Double, bins: Int) exte
   def result(region: Region): Long = {
     rvb.set(region)
     rvb.start(typ)
+    rvb.startStruct()
     rvb.startArray(combiner.indices.length)
     combiner.indices.foreach(rvb.addDouble _)
     rvb.endArray()
@@ -58,6 +59,7 @@ class RegionValueHistogramAggregator(start: Double, end: Double, bins: Int) exte
     rvb.endArray()
     rvb.addLong(combiner.nLess)
     rvb.addLong(combiner.nGreater)
+    rvb.endStruct()
     rvb.end()
   }
 

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueHistogramAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueHistogramAggregator.scala
@@ -1,0 +1,54 @@
+package is.hail.annotations.aggregators
+
+import is.hail.annotations._
+import is.hail.asm4s._
+import is.hail.expr._
+import is.hail.stats.HistogramCombiner
+import is.hail.utils._
+
+class RegionValueHistogramAggregator(start: Double, end: Double, bins: Int) extends RegionValueAggregator {
+  if (bins <= 0)
+    fatal(s"""method `hist' expects `bins' argument to be > 0, but got $bins""")
+
+  private val binSize = (end - start) / bins
+  if (binSize <= 0)
+    fatal(
+      s"""invalid bin size from given arguments (start = $start, end = $end, bins = $bins)
+           |  Method requires positive bin size [(end - start) / bins], but got ${ binSize.formatted("%.2f") }
+                  """.stripMargin)
+
+  private val indices = Array.tabulate(bins + 1)(i => start + i * binSize)
+
+  private val combiner = new HistogramCombiner(indices)
+
+  def seqOp(x: Double, missing: Boolean) {
+    if (!missing)
+      combiner.merge(x)
+  }
+
+  def seqOp(region: Region, off: Long, missing: Boolean) {
+    seqOp(region.loadDouble(off), missing)
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    combiner.merge(agg2.asInstanceOf[RegionValueHistogramAggregator].combiner)
+  }
+
+  private val rvb = new RegionValueBuilder()
+
+  def result(region: Region): Long = {
+    rvb.set(region)
+    rvb.start(HistogramCombiner.schema)
+    rvb.startArray(combiner.indices.length)
+    combiner.indices.foreach(rvb.addDouble _)
+    rvb.endArray()
+    rvb.startArray(combiner.frequency.length)
+    combiner.frequency.foreach(rvb.addLong _)
+    rvb.endArray()
+    rvb.addLong(combiner.nLess)
+    rvb.addLong(combiner.nGreater)
+    rvb.end()
+  }
+
+  def copy() = new RegionValueHistogramAggregator(start, end, bins)
+}

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueMaxIntAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueMaxIntAggregator.scala
@@ -1,0 +1,154 @@
+package is.hail.annotations.aggregators
+
+import is.hail.annotations._
+import is.hail.expr.RegionValueAggregator
+
+class RegionValueMaxBooleanAggregator extends RegionValueAggregator {
+  private var max: Boolean = false
+  private var found: Boolean = false
+
+  def seqOp(i: Boolean, missing: Boolean) {
+    found = true
+    if (i > max)
+      max = i
+  }
+
+  def seqOp(region: Region, off: Long, missing: Boolean) {
+    seqOp(region.loadBoolean(off), missing)
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    val that = agg2.asInstanceOf[RegionValueMaxBooleanAggregator]
+    if (that.max > max)
+      max = that.max
+  }
+
+  def result(region: Region): Long =
+    // FIXME: missingness???
+    if (found)
+      region.appendBoolean(max)
+    else
+      ???
+
+  def copy(): RegionValueMaxBooleanAggregator = new RegionValueMaxBooleanAggregator()
+}
+
+class RegionValueMaxIntAggregator extends RegionValueAggregator {
+  private var max: Int = 0
+  private var found: Boolean = false
+
+  def seqOp(i: Int, missing: Boolean) {
+    found = true
+    if (i > max)
+      max = i
+  }
+
+  def seqOp(region: Region, off: Long, missing: Boolean) {
+    seqOp(region.loadInt(off), missing)
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    val that = agg2.asInstanceOf[RegionValueMaxIntAggregator]
+    if (that.max > max)
+      max = that.max
+  }
+
+  def result(region: Region): Long =
+    // FIXME: missingness???
+    if (found)
+      region.appendInt(max)
+    else
+      ???
+
+  def copy(): RegionValueMaxIntAggregator = new RegionValueMaxIntAggregator()
+}
+
+class RegionValueMaxLongAggregator extends RegionValueAggregator {
+  private var max: Long = 0L
+  private var found: Boolean = false
+
+  def seqOp(i: Long, missing: Boolean) {
+    found = true
+    if (i > max)
+      max = i
+  }
+
+  def seqOp(region: Region, off: Long, missing: Boolean) {
+    seqOp(region.loadLong(off), missing)
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    val that = agg2.asInstanceOf[RegionValueMaxLongAggregator]
+    if (that.max > max)
+      max = that.max
+  }
+
+  def result(region: Region): Long =
+    // FIXME: missingness???
+    if (found)
+      region.appendLong(max)
+    else
+      ???
+
+  def copy(): RegionValueMaxLongAggregator = new RegionValueMaxLongAggregator()
+}
+
+class RegionValueMaxFloatAggregator extends RegionValueAggregator {
+  private var max: Float = 0.0f
+  private var found: Boolean = false
+
+  def seqOp(i: Float, missing: Boolean) {
+    found = true
+    if (i > max)
+      max = i
+  }
+
+  def seqOp(region: Region, off: Long, missing: Boolean) {
+    seqOp(region.loadFloat(off), missing)
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    val that = agg2.asInstanceOf[RegionValueMaxFloatAggregator]
+    if (that.max > max)
+      max = that.max
+  }
+
+  def result(region: Region): Long =
+    // FIXME: missingness???
+    if (found)
+      region.appendFloat(max)
+    else
+      ???
+
+  def copy(): RegionValueMaxFloatAggregator = new RegionValueMaxFloatAggregator()
+}
+
+class RegionValueMaxDoubleAggregator extends RegionValueAggregator {
+  private var max: Double = 0.0
+  private var found: Boolean = false
+
+  def seqOp(i: Double, missing: Boolean) {
+    found = true
+    if (i > max)
+      max = i
+  }
+
+  def seqOp(region: Region, off: Long, missing: Boolean) {
+    seqOp(region.loadDouble(off), missing)
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    val that = agg2.asInstanceOf[RegionValueMaxDoubleAggregator]
+    if (that.max > max)
+      max = that.max
+  }
+
+  def result(region: Region): Long =
+    // FIXME: missingness???
+    if (found)
+      region.appendDouble(max)
+    else
+      ???
+
+  def copy(): RegionValueMaxDoubleAggregator = new RegionValueMaxDoubleAggregator()
+}

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueStatisticsAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueStatisticsAggregator.scala
@@ -1,0 +1,55 @@
+package is.hail.annotations.aggregators
+
+import is.hail.annotations._
+import is.hail.asm4s._
+import is.hail.expr._
+import org.apache.spark.util.StatCounter
+
+object RegionValueStatisticsAggregator {
+  val typ: TStruct = TStruct(
+    "mean" -> TFloat64(),
+    "stddev" -> TFloat64(),
+    "min" -> TFloat64(), // FIXME should really preserve the input type
+    "max" -> TFloat64(),
+    "count" -> TInt64(),
+    "sum" -> TFloat64())
+
+  private val fb = FunctionBuilder.functionBuilder[Region, StatCounter, Long]
+  private val statCounter = fb.getArg[StatCounter](2)
+  private val srvb = new StagedRegionValueBuilder(fb, typ)
+  fb.emit(Code(srvb.start(),
+    srvb.addDouble(statCounter.invoke("mean")),
+    srvb.addDouble(statCounter.invoke("stddev")),
+    srvb.addDouble(statCounter.invoke("min")),
+    srvb.addDouble(statCounter.invoke("max")),
+    srvb.addLong(statCounter.invoke("count")),
+    srvb.addDouble(statCounter.invoke("sum")),
+    srvb.returnStart()))
+
+  private val makeF = fb.result()
+  def result(region: Region, sc: StatCounter): Long =
+    makeF()(region, sc)
+}
+
+class RegionValueStatisticsAggregator extends RegionValueAggregator {
+  private val sc = new StatCounter()
+
+  def seqOp(x: Double, missing: Boolean) {
+    if (!missing)
+      sc.merge(x)
+  }
+
+  def seqOp(region: Region, off: Long, missing: Boolean) {
+    seqOp(region.loadDouble(off), missing)
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    sc.merge(agg2.asInstanceOf[RegionValueStatisticsAggregator].sc)
+  }
+
+  def result(region: Region): Long =
+    // FIXME: divide by zero should be NA not NaN
+    RegionValueStatisticsAggregator.result(region, sc)
+
+  def copy() = new RegionValueStatisticsAggregator()
+}

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueSumAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueSumAggregator.scala
@@ -6,32 +6,6 @@ import is.hail.expr.ir._
 import is.hail.annotations._
 import is.hail.expr.RegionValueAggregator
 
-import scala.reflect.ClassTag
-
-object RegionValueSumAggregator {
-  private def seqOp[Agg >: Null : ClassTag : TypeInfo, T : ClassTag](t: Type): (Code[RegionValueAggregator], Code[_], Code[Boolean]) => Code[Unit] =
-  { (rva: Code[RegionValueAggregator], v: Code[_], mv: Code[Boolean]) =>
-    mv.mux(
-      Code.checkcast[Agg](rva).invoke[T, Boolean, Unit]("seqOp", coerce[T](defaultValue(t)), true),
-      Code.checkcast[Agg](rva).invoke[T, Boolean, Unit]("seqOp", coerce[T](v), false)) }
-
-  def apply(t: Type): ((Code[RegionValueAggregator], Code[_], Code[Boolean]) => Code[Unit], RegionValueAggregator) = {
-    t match {
-      case _: TBoolean =>
-        (seqOp[RegionValueSumBooleanAggregator, Boolean](t),  new RegionValueSumBooleanAggregator())
-      case _: TInt32 =>
-        (seqOp[RegionValueSumIntAggregator, Int](t),  new RegionValueSumIntAggregator())
-      case _: TInt64 =>
-        (seqOp[RegionValueSumLongAggregator, Long](t),  new RegionValueSumLongAggregator())
-      case _: TFloat32 =>
-        (seqOp[RegionValueSumFloatAggregator, Float](t),  new RegionValueSumFloatAggregator())
-      case _: TFloat64 =>
-        (seqOp[RegionValueSumDoubleAggregator, Double](t),  new RegionValueSumDoubleAggregator())
-      case _ => throw new IllegalArgumentException(s"Cannot sum over values of type ${t}")
-    }
-  }
-}
-
 class RegionValueSumBooleanAggregator extends RegionValueAggregator {
   private var sum: Boolean = false
 

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueSumAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueSumAggregator.scala
@@ -1,8 +1,5 @@
 package is.hail.annotations.aggregators
 
-import is.hail.asm4s._
-import is.hail.expr._
-import is.hail.expr.ir._
 import is.hail.annotations._
 import is.hail.expr.RegionValueAggregator
 

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueTakeAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueTakeAggregator.scala
@@ -1,0 +1,43 @@
+package is.hail.annotations.aggregators
+
+import is.hail.annotations._
+import is.hail.expr.RegionValueAggregator
+
+class RegionValueTakeBooleanAggregator(n: Int) extends RegionValueAggregator {
+  private var a: Array[Boolean] = new Array(n)
+  private var filled: Int = 0
+
+  def seqOp(x: Boolean, missing: Boolean) {
+    if (filled < n) {
+      a(filled) = x
+      filled += 1
+    }
+  }
+
+  def seqOp(region: Region, off: Long, missing: Boolean) {
+    seqOp(region.loadBoolean(off), missing)
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    val that = agg2.asInstanceOf[RegionValueTakeBooleanAggregator]
+    var i = 0
+    while (filled < n) {
+      a(filled) = that.a(i)
+      filled += 1
+      i += 1
+    }
+  }
+
+  val typ = TArray(TBoolean())
+  private val rvb = new RegionValueBuilder()
+
+  def result(region: Region): Long = {
+    rvb.start(newRoot: Type)
+  }
+
+  def copy(): RegionValueTakeBooleanAggregator = new RegionValueTakeBooleanAggregator(n)
+}
+
+class RegionValueTakeIntAggregator extends RegionValueAggregator {
+
+}

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueTakeAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueTakeAggregator.scala
@@ -1,17 +1,26 @@
 package is.hail.annotations.aggregators
 
 import is.hail.annotations._
-import is.hail.expr.RegionValueAggregator
+import is.hail.asm4s._
+import is.hail.expr._
+import is.hail.utils._
+
+object RegionValueTakeBooleanAggregator {
+  def stagedNew(n: Code[Int], mn: Code[Boolean]): Code[RegionValueTakeBooleanAggregator] =
+    (mn).mux(
+      Code._throw(Code.newInstance[RuntimeException, String]("Take-aggregator cannot take NA for length")),
+      Code.newInstance[RegionValueTakeBooleanAggregator, Int](n))
+}
 
 class RegionValueTakeBooleanAggregator(n: Int) extends RegionValueAggregator {
-  private var a: Array[Boolean] = new Array(n)
-  private var filled: Int = 0
+  private val ab = new MissingBooleanArrayBuilder()
 
   def seqOp(x: Boolean, missing: Boolean) {
-    if (filled < n) {
-      a(filled) = x
-      filled += 1
-    }
+    if (ab.length() < n)
+      if (missing)
+        ab.addMissing()
+      else
+        ab.add(x)
   }
 
   def seqOp(region: Region, off: Long, missing: Boolean) {
@@ -20,24 +29,173 @@ class RegionValueTakeBooleanAggregator(n: Int) extends RegionValueAggregator {
 
   def combOp(agg2: RegionValueAggregator) {
     val that = agg2.asInstanceOf[RegionValueTakeBooleanAggregator]
-    var i = 0
-    while (filled < n) {
-      a(filled) = that.a(i)
-      filled += 1
-      i += 1
+    that.ab.foreach { _ =>
+      if (ab.length() < n)
+        ab.addMissing()
+    } { (_, v) =>
+      if (ab.length() < n)
+        ab.add(v)
     }
   }
 
-  val typ = TArray(TBoolean())
-  private val rvb = new RegionValueBuilder()
-
-  def result(region: Region): Long = {
-    rvb.start(newRoot: Type)
-  }
+  def result(region: Region): Long =
+    ab.writeIntoRegion(region)
 
   def copy(): RegionValueTakeBooleanAggregator = new RegionValueTakeBooleanAggregator(n)
 }
 
-class RegionValueTakeIntAggregator extends RegionValueAggregator {
+object RegionValueTakeIntAggregator {
+  def stagedNew(n: Code[Int], mn: Code[Boolean]): Code[RegionValueTakeIntAggregator] =
+    (mn).mux(
+      Code._throw(Code.newInstance[RuntimeException, String]("Take-aggregator cannot take NA for length")),
+      Code.newInstance[RegionValueTakeIntAggregator, Int](n))
+}
 
+class RegionValueTakeIntAggregator(n: Int) extends RegionValueAggregator {
+  private val ab = new MissingIntArrayBuilder()
+
+  def seqOp(x: Int, missing: Boolean) {
+    if (ab.length() < n)
+      if (missing)
+        ab.addMissing()
+      else
+        ab.add(x)
+  }
+
+  def seqOp(region: Region, off: Long, missing: Boolean) {
+    seqOp(region.loadInt(off), missing)
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    val that = agg2.asInstanceOf[RegionValueTakeIntAggregator]
+    that.ab.foreach { _ =>
+      if (ab.length() < n)
+        ab.addMissing()
+    } { (_, v) =>
+      if (ab.length() < n)
+        ab.add(v)
+    }
+  }
+
+  def result(region: Region): Long =
+    ab.writeIntoRegion(region)
+
+  def copy(): RegionValueTakeIntAggregator = new RegionValueTakeIntAggregator(n)
+}
+
+object RegionValueTakeLongAggregator {
+  def stagedNew(n: Code[Int], mn: Code[Boolean]): Code[RegionValueTakeLongAggregator] =
+    (mn).mux(
+      Code._throw(Code.newInstance[RuntimeException, String]("Take-aggregator cannot take NA for length")),
+      Code.newInstance[RegionValueTakeLongAggregator, Int](n))
+}
+
+class RegionValueTakeLongAggregator(n: Int) extends RegionValueAggregator {
+  private val ab = new MissingLongArrayBuilder()
+
+  def seqOp(x: Long, missing: Boolean) {
+    if (ab.length() < n)
+      if (missing)
+        ab.addMissing()
+      else
+        ab.add(x)
+  }
+
+  def seqOp(region: Region, off: Long, missing: Boolean) {
+    seqOp(region.loadLong(off), missing)
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    val that = agg2.asInstanceOf[RegionValueTakeLongAggregator]
+    that.ab.foreach { _ =>
+      if (ab.length() < n)
+        ab.addMissing()
+    } { (_, v) =>
+      if (ab.length() < n)
+        ab.add(v)
+    }
+  }
+
+  def result(region: Region): Long =
+    ab.writeIntoRegion(region)
+
+  def copy(): RegionValueTakeLongAggregator = new RegionValueTakeLongAggregator(n)
+}
+
+object RegionValueTakeFloatAggregator {
+  def stagedNew(n: Code[Int], mn: Code[Boolean]): Code[RegionValueTakeFloatAggregator] =
+    (mn).mux(
+      Code._throw(Code.newInstance[RuntimeException, String]("Take-aggregator cannot take NA for length")),
+      Code.newInstance[RegionValueTakeFloatAggregator, Int](n))
+}
+
+class RegionValueTakeFloatAggregator(n: Int) extends RegionValueAggregator {
+  private val ab = new MissingFloatArrayBuilder()
+
+  def seqOp(x: Float, missing: Boolean) {
+    if (ab.length() < n)
+      if (missing)
+        ab.addMissing()
+      else
+        ab.add(x)
+  }
+
+  def seqOp(region: Region, off: Long, missing: Boolean) {
+    seqOp(region.loadFloat(off), missing)
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    val that = agg2.asInstanceOf[RegionValueTakeFloatAggregator]
+    that.ab.foreach { _ =>
+      if (ab.length() < n)
+        ab.addMissing()
+    } { (_, v) =>
+      if (ab.length() < n)
+        ab.add(v)
+    }
+  }
+
+  def result(region: Region): Long =
+    ab.writeIntoRegion(region)
+
+  def copy(): RegionValueTakeFloatAggregator = new RegionValueTakeFloatAggregator(n)
+}
+
+object RegionValueTakeDoubleAggregator {
+  def stagedNew(n: Code[Int], mn: Code[Boolean]): Code[RegionValueTakeDoubleAggregator] =
+    (mn).mux(
+      Code._throw(Code.newInstance[RuntimeException, String]("Take-aggregator cannot take NA for length")),
+      Code.newInstance[RegionValueTakeDoubleAggregator, Int](n))
+}
+
+class RegionValueTakeDoubleAggregator(n: Int) extends RegionValueAggregator {
+  private val ab = new MissingDoubleArrayBuilder()
+
+  def seqOp(x: Double, missing: Boolean) {
+    if (ab.length() < n)
+      if (missing)
+        ab.addMissing()
+      else
+        ab.add(x)
+  }
+
+  def seqOp(region: Region, off: Long, missing: Boolean) {
+    seqOp(region.loadDouble(off), missing)
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    val that = agg2.asInstanceOf[RegionValueTakeDoubleAggregator]
+    that.ab.foreach { _ =>
+      if (ab.length() < n)
+        ab.addMissing()
+    } { (_, v) =>
+      if (ab.length() < n)
+        ab.add(v)
+    }
+  }
+
+  def result(region: Region): Long =
+    ab.writeIntoRegion(region)
+
+  def copy(): RegionValueTakeDoubleAggregator = new RegionValueTakeDoubleAggregator(n)
 }

--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -686,7 +686,7 @@ class FieldRef[T, S](f: Field)(implicit tct: ClassTag[T], sti: TypeInfo[S]) {
     }
 }
 
-class CodeObject[T >: Null](val lhs: Code[T])(implicit tct: ClassTag[T], tti: TypeInfo[T]) {
+class CodeObject[T <: AnyRef : ClassTag](val lhs: Code[T]) {
   def get[S](field: String)(implicit sct: ClassTag[S], sti: TypeInfo[S]): Code[S] =
     FieldRef[T, S](field).get(lhs)
 
@@ -715,7 +715,9 @@ class CodeObject[T >: Null](val lhs: Code[T])(implicit tct: ClassTag[T], tti: Ty
   def invoke[A1, A2, A3, A4, S](method: String, a1: Code[A1], a2: Code[A2], a3: Code[A3], a4: Code[A4])
     (implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2], a3ct: ClassTag[A3], a4ct: ClassTag[A4], sct: ClassTag[S]): Code[S] =
     invoke[S](method, Array[Class[_]](a1ct.runtimeClass, a2ct.runtimeClass, a3ct.runtimeClass, a4ct.runtimeClass), Array[Code[_]](a1, a2, a3, a4))
+}
 
+class CodeNullable[T >: Null : TypeInfo](val lhs: Code[T]) {
   def ifNull[T](cnullcase: Code[T], cnonnullcase: Code[T]): Code[T] =
     new Code[T] {
       def emit(il: Growable[AbstractInsnNode]): Unit = {

--- a/src/main/scala/is/hail/asm4s/package.scala
+++ b/src/main/scala/is/hail/asm4s/package.scala
@@ -201,8 +201,11 @@ package object asm4s {
 
   implicit def toCodeArray[T](c: Code[Array[T]])(implicit tti: TypeInfo[T]): CodeArray[T] = new CodeArray(c)
 
-  implicit def toCodeObject[T >: Null](c: Code[T])(implicit tti: TypeInfo[T], tct: ClassTag[T]): CodeObject[T] =
+  implicit def toCodeObject[T <: AnyRef : ClassTag](c: Code[T]): CodeObject[T] =
     new CodeObject(c)
+
+  implicit def toCodeNullable[T >: Null : TypeInfo](c: Code[T]): CodeNullable[T] =
+    new CodeNullable(c)
 
   implicit def toCode[T](insn: => AbstractInsnNode): Code[T] = new Code[T] {
     def emit(il: Growable[AbstractInsnNode]): Unit = {
@@ -229,7 +232,9 @@ package object asm4s {
 
   implicit def toCodeBoolean(f: LocalRef[Boolean]): CodeBoolean = new CodeBoolean(f.load())
 
-  implicit def toCodeObject[T >: Null](f: LocalRef[T])(implicit tti: TypeInfo[T], tct: ClassTag[T]): CodeObject[T] = new CodeObject[T](f.load())
+  implicit def toCodeObject[T <: AnyRef : ClassTag](f: LocalRef[T]): CodeObject[T] = new CodeObject[T](f.load())
+
+  implicit def toCodeNullable[T >: Null : TypeInfo](f: LocalRef[T]): CodeNullable[T] = new CodeNullable[T](f.load())
 
   implicit def toLocalRefInt(f: LocalRef[Int]): LocalRefInt = new LocalRefInt(f)
 

--- a/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -13,10 +13,11 @@ final case class Collect() extends NullaryAggOp { }
 // final case class HardyWeinberg() extends NullaryAggOp { } // remove when prefixes work
 final case class Sum() extends NullaryAggOp { }
 // final case class Product() extends NullaryAggOp { }
-// final case class Max() extends NullaryAggOp { }
+final case class Max() extends NullaryAggOp { }
 // final case class Min() extends NullaryAggOp { }
-// final case class Take() extends NullaryAggOp { }
-// final case class TakeBy() extends NullaryAggOp { }
+
+sealed trait UnaryAggOp { }
+final case class Take() extends UnaryAggOp { }
 
 sealed trait TernaryAggOp { }
 final case class Histogram() extends TernaryAggOp { }
@@ -36,53 +37,71 @@ final case class Histogram() extends TernaryAggOp { }
 // Counter needs Dict
 // CollectSet needs Set
 
+// TakeBy needs lambdas
+
 object AggOp {
 
   def getNullary(op: NullaryAggOp, r: Type): CodeAggregator.Nullary =
-    nullary((op, r)).getOrElse(incompatible(op, r))._1
+    nullary((op, r)).getOrElse(incompatible(op, r))
 
   def getNullaryType(op: NullaryAggOp, r: Type): Type =
-    nullary((op, r)).getOrElse(incompatible(op, r))._2
+    nullary((op, r)).getOrElse(incompatible(op, r)).out
+
+  def getUnary(op: UnaryAggOp, t: Type, r: Type): CodeAggregator.Unary =
+    unary((op, t, r)).getOrElse(incompatible(op, t, r))
+
+  def getUnaryType(op: UnaryAggOp, t: Type, r: Type): Type =
+    unary((op, t, r)).getOrElse(incompatible(op, t, r)).out
 
   def getTernary(op: TernaryAggOp, t: Type, u: Type, v: Type, r: Type): CodeAggregator.Ternary =
-    ternary((op, t, u, v, r)).getOrElse(incompatible(op, t, u, v, r))._1
+    ternary((op, t, u, v, r)).getOrElse(incompatible(op, t, u, v, r))
 
   def getTernaryType(op: TernaryAggOp, t: Type, u: Type, v: Type, r: Type): Type =
-    ternary((op, t, u, v, r)).getOrElse(incompatible(op, t, u, v, r))._2
+    ternary((op, t, u, v, r)).getOrElse(incompatible(op, t, u, v, r)).out
 
-  private val nullary: ((NullaryAggOp, Type)) => Option[(CodeAggregator.Nullary, Type)] = lift {
-    case (Fraction(), _: TBoolean) => (CodeAggregator.nullary[Boolean](new RegionValueFractionAggregator()), TFloat64())
-    case (Statistics(), _: TFloat64) => (CodeAggregator.nullary[Double](new RegionValueStatisticsAggregator()), RegionValueStatisticsAggregator.typ)
-    case (Collect(), _: TBoolean) => (CodeAggregator.nullary[Boolean](new RegionValueCollectBooleanAggregator()), TArray(TBoolean()))
-    case (Collect(), _: TInt32) => (CodeAggregator.nullary[Int](new RegionValueCollectIntAggregator()), TArray(TInt32()))
+  private val nullary: ((NullaryAggOp, Type)) => Option[CodeAggregator.Nullary] = lift {
+    case (Fraction(), _: TBoolean) => CodeAggregator.nullary[Boolean](new RegionValueFractionAggregator(), TFloat64())
+    case (Statistics(), _: TFloat64) => CodeAggregator.nullary[Double](new RegionValueStatisticsAggregator(), RegionValueStatisticsAggregator.typ)
+    case (Collect(), _: TBoolean) => CodeAggregator.nullary[Boolean](new RegionValueCollectBooleanAggregator(), TArray(TBoolean()))
+    case (Collect(), _: TInt32) => CodeAggregator.nullary[Int](new RegionValueCollectIntAggregator(), TArray(TInt32()))
     // FIXME: implement these
     // case (Collect(), _: TInt64) => CodeAggregator.nullary[Long](new RegionValueCollectLongAggregator())
     // case (Collect(), _: TFloat32) => CodeAggregator.nullary[Float](new RegionValueCollectFloatAggregator())
     // case (Collect(), _: TFloat64) => CodeAggregator.nullary[Double](new RegionValueCollectDoubleAggregator())
     // case (Collect(), _: TArray) => CodeAggregator.nullary[Long](new RegionValueCollectArrayAggregator())
     // case (Collect(), _: TStruct) => CodeAggregator.nullary[Long](new RegionValueCollectStructAggregator())
-    case (Sum(), _: TInt32) => (CodeAggregator.nullary[Int](new RegionValueSumIntAggregator()), TInt32())
-    case (Sum(), _: TInt64) => (CodeAggregator.nullary[Int](new RegionValueSumLongAggregator()), TInt64())
-    case (Sum(), _: TFloat32) => (CodeAggregator.nullary[Int](new RegionValueSumFloatAggregator()), TFloat32())
-    case (Sum(), _: TFloat64) => (CodeAggregator.nullary[Int](new RegionValueSumDoubleAggregator()), TFloat64())
-      // case (InfoScore() =>
-      // case (HardyWeinberg() =>
-      // case (Sum() =>
-      // case (Product() =>
-      // case (Max() =>
-      // case (Min() =>
-      // case (Take() =>
-      // case (TakeBy() =>
+    // case (InfoScore() =>
+    case (Sum(), _: TInt32) => CodeAggregator.nullary[Int](new RegionValueSumIntAggregator(), TInt32())
+    case (Sum(), _: TInt64) => CodeAggregator.nullary[Long](new RegionValueSumLongAggregator(), TInt64())
+    case (Sum(), _: TFloat32) => CodeAggregator.nullary[Float](new RegionValueSumFloatAggregator(), TFloat32())
+    case (Sum(), _: TFloat64) => CodeAggregator.nullary[Double](new RegionValueSumDoubleAggregator(), TFloat64())
+    // case (HardyWeinberg(), _: T) =>
+    // case (Product(), _: T) =>
+    case (Max(), _: TBoolean) => CodeAggregator.nullary[Boolean](new RegionValueMaxBooleanAggregator(), TBoolean())
+    case (Max(), _: TInt32) => CodeAggregator.nullary[Int](new RegionValueMaxIntAggregator(), TInt32())
+    case (Max(), _: TInt64) => CodeAggregator.nullary[Long](new RegionValueMaxLongAggregator(), TInt64())
+    case (Max(), _: TFloat32) => CodeAggregator.nullary[Float](new RegionValueMaxFloatAggregator(), TFloat32())
+    case (Max(), _: TFloat64) => CodeAggregator.nullary[Double](new RegionValueMaxDoubleAggregator(), TFloat64())
+    // case (Min(), _: T) =>
   }
 
-  private val ternary: ((TernaryAggOp, Type, Type, Type, Type)) => Option[(CodeAggregator.Ternary, Type)] = lift {
+  private val unary: ((UnaryAggOp, Type, Type)) => Option[CodeAggregator.Unary] = lift {
+    case (Take(), _: TInt32, _: TBoolean) => CodeAggregator.unary[Int, Boolean](new RegionValueTakeBooleanAggregator(), TArray(TBoolean()))
+    case (Take(), _: TInt32, _: TInt32) => CodeAggregator.unary[Int, Int](new RegionValueTakeIntAggregator(), TArray(TInt32()))
+    case (Take(), _: TInt32, _: TInt64) => CodeAggregator.unary[Int, Long](new RegionValueTakeLongAggregator(), TArray(TInt32()))
+  }
+
+  private val ternary: ((TernaryAggOp, Type, Type, Type, Type)) => Option[CodeAggregator.Ternary] = lift {
     case (Histogram(), _: TFloat64, _: TFloat64, _: TInt32, _: TFloat64) =>
-      (CodeAggregator.ternary[Double, Double, Int, Double](RegionValueHistogramAggregator.stagedNew), RegionValueHistogramAggregator.typ)
+      CodeAggregator.ternary[Double, Double, Int, Double](RegionValueHistogramAggregator.stagedNew, RegionValueHistogramAggregator.typ)
   }
 
   private def incompatible(op: NullaryAggOp, r: Type): Nothing =
-    throw new RuntimeException(s"no aggregator named $op operating on aggregables of $r")
+    throw new RuntimeException(s"no aggregator named $op operating on aggregables of type $r")
+
+  private def incompatible(op: UnaryAggOp, t: Type, r: Type): Nothing =
+    throw new RuntimeException(s"no aggregator named $op with arguments of type $t, operating on aggregables of type $r")
 
   private def incompatible(op: TernaryAggOp, t: Type, u: Type, v: Type, r: Type): Nothing =
-    throw new RuntimeException(s"no aggregator named $op with arguments $t, $u, and $v operating on aggregables of $r")
+    throw new RuntimeException(s"no aggregator named $op with arguments of type $t, $u, and $v operating on aggregables of type $r")
 }

--- a/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -8,14 +8,14 @@ import is.hail.utils._
 import scala.reflect.ClassTag
 
 object AggOp {
-  private val m: PartialFunction[(AggOp, Type, Type), Code[_] => Code[_]] = {
-    case (Fraction(), _: TInt32, _: TInt32) => aggregatorCode[Int](RegionValueIntFractionAggregator)
-    case (Fraction(), _: TInt64, _: TInt64) => aggregatorCode[Long](RegionValueLongFractionAggregator)
-    case (Fraction(), _: TFloat32, _: TFloat32) => aggregatorCode[Float](RegionValueFloatFractionAggregator)
-    case (Fraction(), _: TFloat64, _: TFloat64) => aggregatorCode[Double](RegionValueDoubleFractionAggregator)
-      // case (Statistics() =>
-      // case (Counter()) =>
-      // case (Histogram() =>
+  private val ternary: PartialFunction[(AggOp, Type, Type), TernaryAggregatorCode[_, _, _, _ <: RegionValueAggregator, _]] = {
+    case (Histogram(), _: TFloat64, TArray(TFloat64(_), _)) =>
+      ternaryAggregatorCode[Double, Double, Int, Double](new RegionValueHistogramAggregator(_, _, _))
+  }
+
+  private val nullary: PartialFunction[(AggOp, Type), NullaryAggregatorCode[_ <: RegionValueAggregator, _]] = {
+    case (Fraction(), _: TBoolean) => nullaryAggregatorCode[Boolean](new RegionValueFractionAggregator())
+    case (Statistics(), _: TFloat64) => nullaryAggregatorCode[Double](new RegionValueStatisticsAggregator())
       // case (CollectSet() =>
       // case (Collect() =>
       // case (InfoScore() =>
@@ -29,27 +29,86 @@ object AggOp {
   }
 
 
-  sealed trait AggregatorCodeCurried[T] {
-    def apply[Agg >: Null : ClassTag : TypeInfo](t: Type, aggregator: Agg)(implicit tct: ClassTag[T]): AggregatorCode[Agg, T] =
-      new AggregatorCode(t, aggregator)
+  sealed trait NullaryAggregatorCodeCurried[T] {
+    def apply[Agg >: Null : ClassTag : TypeInfo]
+      (aggregator: Agg)
+      (implicit tct: ClassTag[T], hrt: HailRep[T]): NullaryAggregatorCode[Agg, T] =
+      new NullaryAggregatorCode(hailType[T], aggregator)
   }
 
-  private object aggregatorCodeCurriedInstance extends AggregatorCodeCurried[Nothing]
+  private object nullaryAggregatorCodeCurriedInstance extends NullaryAggregatorCodeCurried[Nothing]
 
-  def aggregatorCode[T] = aggregatorCodeCurriedInstance.asInstanceOf[AggregatorCodeCurried[T]]
+  def nullaryAggregatorCode[T] = nullaryAggregatorCodeCurriedInstance.asInstanceOf[NullaryAggregatorCodeCurried[T]]
 
-  class AggregatorCode[Agg >: Null : ClassTag : TypeInfo, T : ClassTag](t: Type, val aggregator: Agg) {
-    def seqOp(rva: Code[RegionValueAggregator], v: Code[_], mv: Code[Boolean]): Code[Unit] =
+  class NullaryAggregatorCode[Agg >: Null : ClassTag : TypeInfo, T : ClassTag]
+    (t: Type, val aggregator: Agg) {
+    def seqOp(rva: Code[RegionValueAggregator], v: Code[T], mv: Code[Boolean]): Code[Unit] =
       mv.mux(
         Code.checkcast[Agg](rva).invoke[T, Boolean, Unit]("seqOp", coerce[T](defaultValue(t)), true),
         Code.checkcast[Agg](rva).invoke[T, Boolean, Unit]("seqOp", coerce[T](v), false))
+  }
+
+  sealed trait UnaryAggregatorCodeCurried[T, U] {
+    def apply[Agg >: Null : ClassTag : TypeInfo]
+      (aggregator: (T) => Agg)
+      (implicit uct: ClassTag[U], hrt: HailRep[U]): UnaryAggregatorCode[T, Agg, U] =
+      new UnaryAggregatorCode(hailType[U], aggregator)
+  }
+
+  private object unaryAggregatorCodeCurriedInstance extends UnaryAggregatorCodeCurried[Nothing, Nothing]
+
+  def unaryAggregatorCode[T, U] = unaryAggregatorCodeCurriedInstance.asInstanceOf[UnaryAggregatorCodeCurried[T, U]]
+
+  class UnaryAggregatorCode[T, Agg >: Null : ClassTag : TypeInfo, U : ClassTag]
+    (t: Type, val aggregator: (T) => Agg) {
+    def seqOp(rva: Code[RegionValueAggregator], v: Code[U], mv: Code[Boolean]): Code[Unit] =
+      mv.mux(
+        Code.checkcast[Agg](rva).invoke[U, Boolean, Unit]("seqOp", coerce[U](defaultValue(t)), true),
+        Code.checkcast[Agg](rva).invoke[U, Boolean, Unit]("seqOp", coerce[U](v), false))
+  }
+
+  sealed trait BinaryAggregatorCodeCurried[T, U, V] {
+    def apply[Agg >: Null : ClassTag : TypeInfo]
+      (aggregator: (T, U) => Agg)
+      (implicit uct: ClassTag[V], hrt: HailRep[V]): BinaryAggregatorCode[T, U, Agg, V] =
+      new BinaryAggregatorCode(hailType[V], aggregator)
+  }
+
+  private object binaryAggregatorCodeCurriedInstance extends BinaryAggregatorCodeCurried[Nothing, Nothing, Nothing]
+
+  def binaryAggregatorCode[T, U, V] = binaryAggregatorCodeCurriedInstance.asInstanceOf[BinaryAggregatorCodeCurried[T, U, V]]
+
+  class BinaryAggregatorCode[T, U, Agg >: Null : ClassTag : TypeInfo, V : ClassTag]
+    (t: Type, val aggregator: (T, U) => Agg) {
+    def seqOp(rva: Code[RegionValueAggregator], v: Code[V], mv: Code[Boolean]): Code[Unit] =
+      mv.mux(
+        Code.checkcast[Agg](rva).invoke[V, Boolean, Unit]("seqOp", coerce[V](defaultValue(t)), true),
+        Code.checkcast[Agg](rva).invoke[V, Boolean, Unit]("seqOp", coerce[V](v), false))
+  }
+
+  sealed trait TernaryAggregatorCodeCurried[T, U, V, W] {
+    def apply[Agg >: Null : ClassTag : TypeInfo]
+      (aggregator: (T, U, V) => Agg)
+      (implicit uct: ClassTag[W], hrt: HailRep[W]): TernaryAggregatorCode[T, U, V, Agg, W] =
+      new TernaryAggregatorCode(hailType[W], aggregator)
+  }
+
+  private object ternaryAggregatorCodeCurriedInstance extends TernaryAggregatorCodeCurried[Nothing, Nothing, Nothing, Nothing]
+
+  def ternaryAggregatorCode[T, U, V, W] = ternaryAggregatorCodeCurriedInstance.asInstanceOf[TernaryAggregatorCodeCurried[T, U, V, W]]
+
+  class TernaryAggregatorCode[T, U, V, Agg >: Null : ClassTag : TypeInfo, W : ClassTag]
+    (t: Type, val aggregator: (T, U, V) => Agg) {
+    def seqOp(rva: Code[RegionValueAggregator], v: Code[W], mv: Code[Boolean]): Code[Unit] =
+      mv.mux(
+        Code.checkcast[Agg](rva).invoke[W, Boolean, Unit]("seqOp", coerce[W](defaultValue(t)), true),
+        Code.checkcast[Agg](rva).invoke[W, Boolean, Unit]("seqOp", coerce[W](v), false))
   }
 }
 
 sealed trait AggOp { }
 final case class Fraction() extends AggOp { } // remove when prefixes work
 final case class Statistics() extends AggOp { } // remove when prefixes work
-final case class Counter() extends AggOp { }
 final case class Histogram() extends AggOp { }
 final case class CollectSet() extends AggOp { }
 final case class Collect() extends AggOp { }
@@ -69,4 +128,9 @@ final case class TakeBy() extends AggOp { }
 // forall === map(p).product, needs short-circuiting aggs
 // Count === map(x => 1).sum
 // SumArray === Sum, Sum should work on product or union of summables
+// Fraction === map(x => p(x)).fraction
+// Statistics === map(x => Cast(x, TDouble())).stats
+// Histogram === map(x => Cast(x, TDouble())).hist
+
+// Counter needs Dict
 

--- a/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -1,0 +1,72 @@
+package is.hail.expr.ir
+
+import is.hail.annotations.aggregators._
+import is.hail.asm4s._
+import is.hail.expr._
+import is.hail.utils._
+
+import scala.reflect.ClassTag
+
+object AggOp {
+  private val m: PartialFunction[(AggOp, Type, Type), Code[_] => Code[_]] = {
+    case (Fraction(), _: TInt32, _: TInt32) => aggregatorCode[Int](RegionValueIntFractionAggregator)
+    case (Fraction(), _: TInt64, _: TInt64) => aggregatorCode[Long](RegionValueLongFractionAggregator)
+    case (Fraction(), _: TFloat32, _: TFloat32) => aggregatorCode[Float](RegionValueFloatFractionAggregator)
+    case (Fraction(), _: TFloat64, _: TFloat64) => aggregatorCode[Double](RegionValueDoubleFractionAggregator)
+      // case (Statistics() =>
+      // case (Counter()) =>
+      // case (Histogram() =>
+      // case (CollectSet() =>
+      // case (Collect() =>
+      // case (InfoScore() =>
+      // case (HardyWeinberg() =>
+      // case (Sum() =>
+      // case (Product() =>
+      // case (Max() =>
+      // case (Min() =>
+      // case (Take() =>
+      // case (TakeBy() =>
+  }
+
+
+  sealed trait AggregatorCodeCurried[T] {
+    def apply[Agg >: Null : ClassTag : TypeInfo](t: Type, aggregator: Agg)(implicit tct: ClassTag[T]): AggregatorCode[Agg, T] =
+      new AggregatorCode(t, aggregator)
+  }
+
+  private object aggregatorCodeCurriedInstance extends AggregatorCodeCurried[Nothing]
+
+  def aggregatorCode[T] = aggregatorCodeCurriedInstance.asInstanceOf[AggregatorCodeCurried[T]]
+
+  class AggregatorCode[Agg >: Null : ClassTag : TypeInfo, T : ClassTag](t: Type, val aggregator: Agg) {
+    def seqOp(rva: Code[RegionValueAggregator], v: Code[_], mv: Code[Boolean]): Code[Unit] =
+      mv.mux(
+        Code.checkcast[Agg](rva).invoke[T, Boolean, Unit]("seqOp", coerce[T](defaultValue(t)), true),
+        Code.checkcast[Agg](rva).invoke[T, Boolean, Unit]("seqOp", coerce[T](v), false))
+  }
+}
+
+sealed trait AggOp { }
+final case class Fraction() extends AggOp { } // remove when prefixes work
+final case class Statistics() extends AggOp { } // remove when prefixes work
+final case class Counter() extends AggOp { }
+final case class Histogram() extends AggOp { }
+final case class CollectSet() extends AggOp { }
+final case class Collect() extends AggOp { }
+final case class InfoScore() extends AggOp { }
+final case class HardyWeinberg() extends AggOp { } // remove when prefixes work
+final case class Sum() extends AggOp { }
+final case class Product() extends AggOp { }
+final case class Max() extends AggOp { }
+final case class Min() extends AggOp { }
+final case class Take() extends AggOp { }
+final case class TakeBy() extends AggOp { }
+
+// what to do about CallStats
+// what to do about InbreedingAggregator
+
+// exists === map(p).sum, needs short-circuiting aggs
+// forall === map(p).product, needs short-circuiting aggs
+// Count === map(x => 1).sum
+// SumArray === Sum, Sum should work on product or union of summables
+

--- a/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -86,9 +86,11 @@ object AggOp {
   }
 
   private val unary: ((UnaryAggOp, Type, Type)) => Option[CodeAggregator.Unary] = lift {
-    case (Take(), _: TInt32, _: TBoolean) => CodeAggregator.unary[Int, Boolean](new RegionValueTakeBooleanAggregator(), TArray(TBoolean()))
-    case (Take(), _: TInt32, _: TInt32) => CodeAggregator.unary[Int, Int](new RegionValueTakeIntAggregator(), TArray(TInt32()))
-    case (Take(), _: TInt32, _: TInt64) => CodeAggregator.unary[Int, Long](new RegionValueTakeLongAggregator(), TArray(TInt32()))
+    case (Take(), _: TInt32, _: TBoolean) => CodeAggregator.unary[Int, Boolean](RegionValueTakeBooleanAggregator.stagedNew, TArray(TBoolean()))
+    case (Take(), _: TInt32, _: TInt32) => CodeAggregator.unary[Int, Int](RegionValueTakeIntAggregator.stagedNew, TArray(TInt32()))
+    case (Take(), _: TInt32, _: TInt64) => CodeAggregator.unary[Int, Long](RegionValueTakeLongAggregator.stagedNew, TArray(TInt64()))
+    case (Take(), _: TInt32, _: TFloat32) => CodeAggregator.unary[Int, Float](RegionValueTakeFloatAggregator.stagedNew, TArray(TFloat32()))
+    case (Take(), _: TInt32, _: TFloat64) => CodeAggregator.unary[Int, Double](RegionValueTakeDoubleAggregator.stagedNew, TArray(TFloat64()))
   }
 
   private val ternary: ((TernaryAggOp, Type, Type, Type, Type)) => Option[CodeAggregator.Ternary] = lift {

--- a/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -5,137 +5,22 @@ import is.hail.asm4s._
 import is.hail.expr._
 import is.hail.utils._
 
-import scala.reflect.ClassTag
+sealed trait NullaryAggOp { }
+final case class Fraction() extends NullaryAggOp { } // remove when prefixes work
+final case class Statistics() extends NullaryAggOp { } // remove when prefixes work
+final case class Collect() extends NullaryAggOp { }
+// final case class InfoScore() extends NullaryAggOp { }
+// final case class HardyWeinberg() extends NullaryAggOp { } // remove when prefixes work
+final case class Sum() extends NullaryAggOp { }
+// final case class Product() extends NullaryAggOp { }
+// final case class Max() extends NullaryAggOp { }
+// final case class Min() extends NullaryAggOp { }
+// final case class Take() extends NullaryAggOp { }
+// final case class TakeBy() extends NullaryAggOp { }
 
-object AggOp {
+sealed trait TernaryAggOp { }
+final case class Histogram() extends TernaryAggOp { }
 
-  def getNullary(op: AggOp, t: Type): NullaryAggregatorCode[_ <: RegionValueAggregator, _] =
-    nullary((op,t))._1
-
-  def getNullaryType(op: AggOp, t: Type): Type =
-    nullary((op,t))._2
-
-  private val ternary: PartialFunction[(AggOp, Type, Type), TernaryAggregatorCode[_, _, _, _ <: RegionValueAggregator, _]] = {
-    case (Histogram(), _: TFloat64, TArray(TFloat64(_), _)) =>
-      ternaryAggregatorCode[Double, Double, Int, Double](new RegionValueHistogramAggregator(_, _, _))
-  }
-
-  private val nullary: PartialFunction[(AggOp, Type), (NullaryAggregatorCode[_ <: RegionValueAggregator, _], Type)] = {
-    case (Fraction(), _: TBoolean) => (nullaryAggregatorCode[Boolean](new RegionValueFractionAggregator()), TFloat64())
-    case (Statistics(), _: TFloat64) => (nullaryAggregatorCode[Double](new RegionValueStatisticsAggregator()), RegionValueStatisticsAggregator.typ)
-    case (Collect(), _: TBoolean) => (nullaryAggregatorCode[Boolean](new RegionValueCollectBooleanAggregator()), TArray(TBoolean()))
-    case (Collect(), _: TInt32) => (nullaryAggregatorCode[Int](new RegionValueCollectIntAggregator()), TArray(TInt32()))
-    // FIXME: implement these
-    // case (Collect(), _: TInt64) => nullaryAggregatorCode[Long](new RegionValueCollectLongAggregator())
-    // case (Collect(), _: TFloat32) => nullaryAggregatorCode[Float](new RegionValueCollectFloatAggregator())
-    // case (Collect(), _: TFloat64) => nullaryAggregatorCode[Double](new RegionValueCollectDoubleAggregator())
-    // case (Collect(), _: TArray) => nullaryAggregatorCode[Long](new RegionValueCollectArrayAggregator())
-    // case (Collect(), _: TStruct) => nullaryAggregatorCode[Long](new RegionValueCollectStructAggregator())
-    case (Sum(), _: TInt32) => (nullaryAggregatorCode[Int](new RegionValueSumIntAggregator()), TInt32())
-    case (Sum(), _: TInt64) => (nullaryAggregatorCode[Int](new RegionValueSumLongAggregator()), TInt64())
-    case (Sum(), _: TFloat32) => (nullaryAggregatorCode[Int](new RegionValueSumFloatAggregator()), TFloat32())
-    case (Sum(), _: TFloat64) => (nullaryAggregatorCode[Int](new RegionValueSumDoubleAggregator()), TFloat64())
-      // case (InfoScore() =>
-      // case (HardyWeinberg() =>
-      // case (Sum() =>
-      // case (Product() =>
-      // case (Max() =>
-      // case (Min() =>
-      // case (Take() =>
-      // case (TakeBy() =>
-  }
-
-
-  sealed trait NullaryAggregatorCodeCurried[T] {
-    def apply[Agg >: Null <: RegionValueAggregator : ClassTag : TypeInfo]
-      (aggregator: Agg)
-      (implicit tct: ClassTag[T], hrt: HailRep[T]): NullaryAggregatorCode[Agg, T] =
-      new NullaryAggregatorCode(hailType[T], aggregator)
-  }
-
-  private object nullaryAggregatorCodeCurriedInstance extends NullaryAggregatorCodeCurried[Nothing]
-
-  def nullaryAggregatorCode[T] = nullaryAggregatorCodeCurriedInstance.asInstanceOf[NullaryAggregatorCodeCurried[T]]
-
-  class NullaryAggregatorCode[Agg >: Null <: RegionValueAggregator : ClassTag : TypeInfo, T : ClassTag]
-    (t: Type, val aggregator: Agg) {
-    def seqOp(rva: Code[RegionValueAggregator], v: Code[_], mv: Code[Boolean]): Code[Unit] =
-      mv.mux(
-        Code.checkcast[Agg](rva).invoke[T, Boolean, Unit]("seqOp", coerce[T](defaultValue(t)), true),
-        Code.checkcast[Agg](rva).invoke[T, Boolean, Unit]("seqOp", coerce[T](v), false))
-  }
-
-  sealed trait UnaryAggregatorCodeCurried[T, U] {
-    def apply[Agg >: Null : ClassTag : TypeInfo]
-      (aggregator: (T) => Agg)
-      (implicit uct: ClassTag[U], hrt: HailRep[U]): UnaryAggregatorCode[T, Agg, U] =
-      new UnaryAggregatorCode(hailType[U], aggregator)
-  }
-
-  private object unaryAggregatorCodeCurriedInstance extends UnaryAggregatorCodeCurried[Nothing, Nothing]
-
-  def unaryAggregatorCode[T, U] = unaryAggregatorCodeCurriedInstance.asInstanceOf[UnaryAggregatorCodeCurried[T, U]]
-
-  class UnaryAggregatorCode[T, Agg >: Null : ClassTag : TypeInfo, U : ClassTag]
-    (t: Type, val aggregator: (T) => Agg) {
-    def seqOp(rva: Code[RegionValueAggregator], v: Code[U], mv: Code[Boolean]): Code[Unit] =
-      mv.mux(
-        Code.checkcast[Agg](rva).invoke[U, Boolean, Unit]("seqOp", coerce[U](defaultValue(t)), true),
-        Code.checkcast[Agg](rva).invoke[U, Boolean, Unit]("seqOp", coerce[U](v), false))
-  }
-
-  sealed trait BinaryAggregatorCodeCurried[T, U, V] {
-    def apply[Agg >: Null : ClassTag : TypeInfo]
-      (aggregator: (T, U) => Agg)
-      (implicit uct: ClassTag[V], hrt: HailRep[V]): BinaryAggregatorCode[T, U, Agg, V] =
-      new BinaryAggregatorCode(hailType[V], aggregator)
-  }
-
-  private object binaryAggregatorCodeCurriedInstance extends BinaryAggregatorCodeCurried[Nothing, Nothing, Nothing]
-
-  def binaryAggregatorCode[T, U, V] = binaryAggregatorCodeCurriedInstance.asInstanceOf[BinaryAggregatorCodeCurried[T, U, V]]
-
-  class BinaryAggregatorCode[T, U, Agg >: Null : ClassTag : TypeInfo, V : ClassTag]
-    (t: Type, val aggregator: (T, U) => Agg) {
-    def seqOp(rva: Code[RegionValueAggregator], v: Code[V], mv: Code[Boolean]): Code[Unit] =
-      mv.mux(
-        Code.checkcast[Agg](rva).invoke[V, Boolean, Unit]("seqOp", coerce[V](defaultValue(t)), true),
-        Code.checkcast[Agg](rva).invoke[V, Boolean, Unit]("seqOp", coerce[V](v), false))
-  }
-
-  sealed trait TernaryAggregatorCodeCurried[T, U, V, W] {
-    def apply[Agg >: Null : ClassTag : TypeInfo]
-      (aggregator: (T, U, V) => Agg)
-      (implicit uct: ClassTag[W], hrt: HailRep[W]): TernaryAggregatorCode[T, U, V, Agg, W] =
-      new TernaryAggregatorCode(hailType[W], aggregator)
-  }
-
-  private object ternaryAggregatorCodeCurriedInstance extends TernaryAggregatorCodeCurried[Nothing, Nothing, Nothing, Nothing]
-
-  def ternaryAggregatorCode[T, U, V, W] = ternaryAggregatorCodeCurriedInstance.asInstanceOf[TernaryAggregatorCodeCurried[T, U, V, W]]
-
-  class TernaryAggregatorCode[T, U, V, Agg >: Null : ClassTag : TypeInfo, W : ClassTag]
-    (t: Type, val aggregator: (T, U, V) => Agg) {
-    def seqOp(rva: Code[RegionValueAggregator], v: Code[W], mv: Code[Boolean]): Code[Unit] =
-      mv.mux(
-        Code.checkcast[Agg](rva).invoke[W, Boolean, Unit]("seqOp", coerce[W](defaultValue(t)), true),
-        Code.checkcast[Agg](rva).invoke[W, Boolean, Unit]("seqOp", coerce[W](v), false))
-  }
-}
-
-sealed trait AggOp { }
-final case class Fraction() extends AggOp { } // remove when prefixes work
-final case class Statistics() extends AggOp { } // remove when prefixes work
-final case class Histogram() extends AggOp { }
-final case class Collect() extends AggOp { }
-// final case class InfoScore() extends AggOp { }
-// final case class HardyWeinberg() extends AggOp { } // remove when prefixes work
-final case class Sum() extends AggOp { }
-// final case class Product() extends AggOp { }
-// final case class Max() extends AggOp { }
-// final case class Min() extends AggOp { }
-// final case class Take() extends AggOp { }
-// final case class TakeBy() extends AggOp { }
 
 // what to do about CallStats
 // what to do about InbreedingAggregator
@@ -150,3 +35,54 @@ final case class Sum() extends AggOp { }
 
 // Counter needs Dict
 // CollectSet needs Set
+
+object AggOp {
+
+  def getNullary(op: NullaryAggOp, r: Type): CodeAggregator.Nullary =
+    nullary((op, r)).getOrElse(incompatible(op, r))._1
+
+  def getNullaryType(op: NullaryAggOp, r: Type): Type =
+    nullary((op, r)).getOrElse(incompatible(op, r))._2
+
+  def getTernary(op: TernaryAggOp, t: Type, u: Type, v: Type, r: Type): CodeAggregator.Ternary =
+    ternary((op, t, u, v, r)).getOrElse(incompatible(op, t, u, v, r))._1
+
+  def getTernaryType(op: TernaryAggOp, t: Type, u: Type, v: Type, r: Type): Type =
+    ternary((op, t, u, v, r)).getOrElse(incompatible(op, t, u, v, r))._2
+
+  private val nullary: ((NullaryAggOp, Type)) => Option[(CodeAggregator.Nullary, Type)] = lift {
+    case (Fraction(), _: TBoolean) => (CodeAggregator.nullary[Boolean](new RegionValueFractionAggregator()), TFloat64())
+    case (Statistics(), _: TFloat64) => (CodeAggregator.nullary[Double](new RegionValueStatisticsAggregator()), RegionValueStatisticsAggregator.typ)
+    case (Collect(), _: TBoolean) => (CodeAggregator.nullary[Boolean](new RegionValueCollectBooleanAggregator()), TArray(TBoolean()))
+    case (Collect(), _: TInt32) => (CodeAggregator.nullary[Int](new RegionValueCollectIntAggregator()), TArray(TInt32()))
+    // FIXME: implement these
+    // case (Collect(), _: TInt64) => CodeAggregator.nullary[Long](new RegionValueCollectLongAggregator())
+    // case (Collect(), _: TFloat32) => CodeAggregator.nullary[Float](new RegionValueCollectFloatAggregator())
+    // case (Collect(), _: TFloat64) => CodeAggregator.nullary[Double](new RegionValueCollectDoubleAggregator())
+    // case (Collect(), _: TArray) => CodeAggregator.nullary[Long](new RegionValueCollectArrayAggregator())
+    // case (Collect(), _: TStruct) => CodeAggregator.nullary[Long](new RegionValueCollectStructAggregator())
+    case (Sum(), _: TInt32) => (CodeAggregator.nullary[Int](new RegionValueSumIntAggregator()), TInt32())
+    case (Sum(), _: TInt64) => (CodeAggregator.nullary[Int](new RegionValueSumLongAggregator()), TInt64())
+    case (Sum(), _: TFloat32) => (CodeAggregator.nullary[Int](new RegionValueSumFloatAggregator()), TFloat32())
+    case (Sum(), _: TFloat64) => (CodeAggregator.nullary[Int](new RegionValueSumDoubleAggregator()), TFloat64())
+      // case (InfoScore() =>
+      // case (HardyWeinberg() =>
+      // case (Sum() =>
+      // case (Product() =>
+      // case (Max() =>
+      // case (Min() =>
+      // case (Take() =>
+      // case (TakeBy() =>
+  }
+
+  private val ternary: ((TernaryAggOp, Type, Type, Type, Type)) => Option[(CodeAggregator.Ternary, Type)] = lift {
+    case (Histogram(), _: TFloat64, _: TFloat64, _: TInt32, _: TFloat64) =>
+      (CodeAggregator.ternary[Double, Double, Int, Double](RegionValueHistogramAggregator.stagedNew), RegionValueHistogramAggregator.typ)
+  }
+
+  private def incompatible(op: NullaryAggOp, r: Type): Nothing =
+    throw new RuntimeException(s"no aggregator named $op operating on aggregables of $r")
+
+  private def incompatible(op: TernaryAggOp, t: Type, u: Type, v: Type, r: Type): Nothing =
+    throw new RuntimeException(s"no aggregator named $op with arguments $t, $u, and $v operating on aggregables of $r")
+}

--- a/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -8,16 +8,33 @@ import is.hail.utils._
 import scala.reflect.ClassTag
 
 object AggOp {
+
+  def getNullary(op: AggOp, t: Type): NullaryAggregatorCode[_ <: RegionValueAggregator, _] =
+    nullary((op,t))._1
+
+  def getNullaryType(op: AggOp, t: Type): Type =
+    nullary((op,t))._2
+
   private val ternary: PartialFunction[(AggOp, Type, Type), TernaryAggregatorCode[_, _, _, _ <: RegionValueAggregator, _]] = {
     case (Histogram(), _: TFloat64, TArray(TFloat64(_), _)) =>
       ternaryAggregatorCode[Double, Double, Int, Double](new RegionValueHistogramAggregator(_, _, _))
   }
 
-  private val nullary: PartialFunction[(AggOp, Type), NullaryAggregatorCode[_ <: RegionValueAggregator, _]] = {
-    case (Fraction(), _: TBoolean) => nullaryAggregatorCode[Boolean](new RegionValueFractionAggregator())
-    case (Statistics(), _: TFloat64) => nullaryAggregatorCode[Double](new RegionValueStatisticsAggregator())
-      // case (CollectSet() =>
-      // case (Collect() =>
+  private val nullary: PartialFunction[(AggOp, Type), (NullaryAggregatorCode[_ <: RegionValueAggregator, _], Type)] = {
+    case (Fraction(), _: TBoolean) => (nullaryAggregatorCode[Boolean](new RegionValueFractionAggregator()), TFloat64())
+    case (Statistics(), _: TFloat64) => (nullaryAggregatorCode[Double](new RegionValueStatisticsAggregator()), RegionValueStatisticsAggregator.typ)
+    case (Collect(), _: TBoolean) => (nullaryAggregatorCode[Boolean](new RegionValueCollectBooleanAggregator()), TArray(TBoolean()))
+    case (Collect(), _: TInt32) => (nullaryAggregatorCode[Int](new RegionValueCollectIntAggregator()), TArray(TInt32()))
+    // FIXME: implement these
+    // case (Collect(), _: TInt64) => nullaryAggregatorCode[Long](new RegionValueCollectLongAggregator())
+    // case (Collect(), _: TFloat32) => nullaryAggregatorCode[Float](new RegionValueCollectFloatAggregator())
+    // case (Collect(), _: TFloat64) => nullaryAggregatorCode[Double](new RegionValueCollectDoubleAggregator())
+    // case (Collect(), _: TArray) => nullaryAggregatorCode[Long](new RegionValueCollectArrayAggregator())
+    // case (Collect(), _: TStruct) => nullaryAggregatorCode[Long](new RegionValueCollectStructAggregator())
+    case (Sum(), _: TInt32) => (nullaryAggregatorCode[Int](new RegionValueSumIntAggregator()), TInt32())
+    case (Sum(), _: TInt64) => (nullaryAggregatorCode[Int](new RegionValueSumLongAggregator()), TInt64())
+    case (Sum(), _: TFloat32) => (nullaryAggregatorCode[Int](new RegionValueSumFloatAggregator()), TFloat32())
+    case (Sum(), _: TFloat64) => (nullaryAggregatorCode[Int](new RegionValueSumDoubleAggregator()), TFloat64())
       // case (InfoScore() =>
       // case (HardyWeinberg() =>
       // case (Sum() =>
@@ -30,7 +47,7 @@ object AggOp {
 
 
   sealed trait NullaryAggregatorCodeCurried[T] {
-    def apply[Agg >: Null : ClassTag : TypeInfo]
+    def apply[Agg >: Null <: RegionValueAggregator : ClassTag : TypeInfo]
       (aggregator: Agg)
       (implicit tct: ClassTag[T], hrt: HailRep[T]): NullaryAggregatorCode[Agg, T] =
       new NullaryAggregatorCode(hailType[T], aggregator)
@@ -40,9 +57,9 @@ object AggOp {
 
   def nullaryAggregatorCode[T] = nullaryAggregatorCodeCurriedInstance.asInstanceOf[NullaryAggregatorCodeCurried[T]]
 
-  class NullaryAggregatorCode[Agg >: Null : ClassTag : TypeInfo, T : ClassTag]
+  class NullaryAggregatorCode[Agg >: Null <: RegionValueAggregator : ClassTag : TypeInfo, T : ClassTag]
     (t: Type, val aggregator: Agg) {
-    def seqOp(rva: Code[RegionValueAggregator], v: Code[T], mv: Code[Boolean]): Code[Unit] =
+    def seqOp(rva: Code[RegionValueAggregator], v: Code[_], mv: Code[Boolean]): Code[Unit] =
       mv.mux(
         Code.checkcast[Agg](rva).invoke[T, Boolean, Unit]("seqOp", coerce[T](defaultValue(t)), true),
         Code.checkcast[Agg](rva).invoke[T, Boolean, Unit]("seqOp", coerce[T](v), false))
@@ -110,16 +127,15 @@ sealed trait AggOp { }
 final case class Fraction() extends AggOp { } // remove when prefixes work
 final case class Statistics() extends AggOp { } // remove when prefixes work
 final case class Histogram() extends AggOp { }
-final case class CollectSet() extends AggOp { }
 final case class Collect() extends AggOp { }
-final case class InfoScore() extends AggOp { }
-final case class HardyWeinberg() extends AggOp { } // remove when prefixes work
+// final case class InfoScore() extends AggOp { }
+// final case class HardyWeinberg() extends AggOp { } // remove when prefixes work
 final case class Sum() extends AggOp { }
-final case class Product() extends AggOp { }
-final case class Max() extends AggOp { }
-final case class Min() extends AggOp { }
-final case class Take() extends AggOp { }
-final case class TakeBy() extends AggOp { }
+// final case class Product() extends AggOp { }
+// final case class Max() extends AggOp { }
+// final case class Min() extends AggOp { }
+// final case class Take() extends AggOp { }
+// final case class TakeBy() extends AggOp { }
 
 // what to do about CallStats
 // what to do about InbreedingAggregator
@@ -133,4 +149,4 @@ final case class TakeBy() extends AggOp { }
 // Histogram === map(x => Cast(x, TDouble())).hist
 
 // Counter needs Dict
-
+// CollectSet needs Set

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -52,7 +52,7 @@ object Children {
       Array(a, body)
     case AggFlatMap(a, name, body, typ) =>
       Array(a, body)
-    case AggSum(a, _) =>
+    case ApplyAggNullaryOp(a, op, _) =>
       Array(a)
     case GetField(o, name, typ) =>
       Array(o)

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -54,6 +54,8 @@ object Children {
       Array(a, body)
     case ApplyAggNullaryOp(a, op, _) =>
       Array(a)
+    case ApplyAggUnaryOp(a, op, arg1, _) =>
+      Array(a, arg1)
     case ApplyAggTernaryOp(a, op, arg1, arg2, arg3, _) =>
       Array(a, arg1, arg2, arg3)
     case GetField(o, name, typ) =>

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -54,6 +54,8 @@ object Children {
       Array(a, body)
     case ApplyAggNullaryOp(a, op, _) =>
       Array(a)
+    case ApplyAggTernaryOp(a, op, arg1, arg2, arg3, _) =>
+      Array(a, arg1, arg2, arg3)
     case GetField(o, name, typ) =>
       Array(o)
     case GetFieldMissingness(o, name) =>

--- a/src/main/scala/is/hail/expr/ir/CodeAggregator.scala
+++ b/src/main/scala/is/hail/expr/ir/CodeAggregator.scala
@@ -1,0 +1,104 @@
+package is.hail.expr.ir
+
+import is.hail.annotations._
+import is.hail.asm4s._
+import is.hail.expr._
+
+import scala.reflect.ClassTag
+
+object CodeAggregator {
+  type Nullary = NullaryCodeAggregator[_ <: RegionValueAggregator, _]
+
+  def nullary[T] = nullaryCodeAggregatorCurriedInstance.asInstanceOf[NullaryCodeAggregatorCurried[T]]
+
+  type Unary = UnaryCodeAggregator[_, _ <: RegionValueAggregator, _]
+
+  def unary[T, U] = unaryCodeAggregatorCurriedInstance.asInstanceOf[UnaryCodeAggregatorCurried[T, U]]
+
+  type Binary = BinaryCodeAggregator[_, _, _ <: RegionValueAggregator, _]
+
+  def binary[T, U, V] = binaryCodeAggregatorCurriedInstance.asInstanceOf[BinaryCodeAggregatorCurried[T, U, V]]
+
+  type Ternary = TernaryCodeAggregator[_, _, _, _ <: RegionValueAggregator, _]
+
+  def ternary[T, U, V, W] = ternaryCodeAggregatorCurriedInstance.asInstanceOf[TernaryCodeAggregatorCurried[T, U, V, W]]
+}
+
+/**
+  * Pair the aggregator with a staged seqOp that calls the non-generic seqOp
+  * method and handles missingness correctly
+  *
+  **/
+class NullaryCodeAggregator[Agg <: RegionValueAggregator : ClassTag : TypeInfo, T : ClassTag]
+  (t: Type, val aggregator: Agg) {
+  def seqOp(rva: Code[RegionValueAggregator], v: Code[_], mv: Code[Boolean]): Code[Unit] =
+    mv.mux(
+      Code.checkcast[Agg](rva).invoke[T, Boolean, Unit]("seqOp", coerce[T](defaultValue(t)), true),
+      Code.checkcast[Agg](rva).invoke[T, Boolean, Unit]("seqOp", coerce[T](v), false))
+}
+
+class UnaryCodeAggregator[T, Agg <: RegionValueAggregator : ClassTag : TypeInfo, U : ClassTag]
+  (t: Type, val aggregator: (T) => Agg) {
+  def seqOp(rva: Code[RegionValueAggregator], v: Code[_], mv: Code[Boolean]): Code[Unit] =
+    mv.mux(
+      Code.checkcast[Agg](rva).invoke[U, Boolean, Unit]("seqOp", coerce[U](defaultValue(t)), true),
+      Code.checkcast[Agg](rva).invoke[U, Boolean, Unit]("seqOp", coerce[U](v), false))
+}
+
+class BinaryCodeAggregator[T, U, Agg <: RegionValueAggregator : ClassTag : TypeInfo, V : ClassTag]
+  (t: Type, val aggregator: (T, U) => Agg) {
+  def seqOp(rva: Code[RegionValueAggregator], v: Code[_], mv: Code[Boolean]): Code[Unit] =
+    mv.mux(
+      Code.checkcast[Agg](rva).invoke[V, Boolean, Unit]("seqOp", coerce[V](defaultValue(t)), true),
+      Code.checkcast[Agg](rva).invoke[V, Boolean, Unit]("seqOp", coerce[V](v), false))
+}
+
+class TernaryCodeAggregator[T, U, V, Agg <: RegionValueAggregator : ClassTag : TypeInfo, W : ClassTag]
+  (t: Type, val aggregator: (Code[T], Code[Boolean], Code[U], Code[Boolean], Code[V], Code[Boolean]) => Code[Agg]) {
+  def seqOp(rva: Code[RegionValueAggregator], v: Code[_], mv: Code[Boolean]): Code[Unit] =
+    mv.mux(
+      Code.checkcast[Agg](rva).invoke[W, Boolean, Unit]("seqOp", coerce[W](defaultValue(t)), true),
+      Code.checkcast[Agg](rva).invoke[W, Boolean, Unit]("seqOp", coerce[W](v), false))
+}
+
+
+/**
+  * Curries the type arguments which enables inference on Agg, with manual
+  * annotation of T, U, V, and W
+  *
+  **/
+sealed trait NullaryCodeAggregatorCurried[T] {
+  def apply[Agg <: RegionValueAggregator : ClassTag : TypeInfo]
+    (aggregator: Agg)
+    (implicit tct: ClassTag[T], hrt: HailRep[T]): NullaryCodeAggregator[Agg, T] =
+    new NullaryCodeAggregator(hailType[T], aggregator)
+}
+
+private object nullaryCodeAggregatorCurriedInstance extends NullaryCodeAggregatorCurried[Nothing]
+
+sealed trait UnaryCodeAggregatorCurried[T, U] {
+  def apply[Agg <: RegionValueAggregator : ClassTag : TypeInfo]
+    (aggregator: (T) => Agg)
+    (implicit uct: ClassTag[U], hrt: HailRep[U]): UnaryCodeAggregator[T, Agg, U] =
+    new UnaryCodeAggregator(hailType[U], aggregator)
+}
+
+private object unaryCodeAggregatorCurriedInstance extends UnaryCodeAggregatorCurried[Nothing, Nothing]
+
+sealed trait BinaryCodeAggregatorCurried[T, U, V] {
+  def apply[Agg <: RegionValueAggregator : ClassTag : TypeInfo]
+    (aggregator: (T, U) => Agg)
+    (implicit uct: ClassTag[V], hrt: HailRep[V]): BinaryCodeAggregator[T, U, Agg, V] =
+    new BinaryCodeAggregator(hailType[V], aggregator)
+}
+
+private object binaryCodeAggregatorCurriedInstance extends BinaryCodeAggregatorCurried[Nothing, Nothing, Nothing]
+
+sealed trait TernaryCodeAggregatorCurried[T, U, V, W] {
+  def apply[Agg <: RegionValueAggregator : ClassTag : TypeInfo]
+    (aggregator: (Code[T], Code[Boolean], Code[U], Code[Boolean], Code[V], Code[Boolean]) => Code[Agg])
+    (implicit uct: ClassTag[W], hrt: HailRep[W]): TernaryCodeAggregator[T, U, V, Agg, W] =
+    new TernaryCodeAggregator(hailType[W], aggregator)
+}
+
+private object ternaryCodeAggregatorCurriedInstance extends TernaryCodeAggregatorCurried[Nothing, Nothing, Nothing, Nothing]

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -84,6 +84,9 @@ object Copy {
       case ApplyAggNullaryOp(_, op, typ) =>
         val IndexedSeq(a) = children
         ApplyAggNullaryOp(a, op, typ)
+      case ApplyAggUnaryOp(_, op, _, typ) =>
+        val IndexedSeq(a, arg1) = children
+        ApplyAggUnaryOp(a, op, arg1, typ)
       case ApplyAggTernaryOp(_, op, _, _, _, typ) =>
         val IndexedSeq(a, arg1, arg2, arg3) = children
         ApplyAggTernaryOp(a, op, arg1, arg2, arg3, typ)

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -81,9 +81,9 @@ object Copy {
       case AggFlatMap(_, name, _, typ) =>
         val IndexedSeq(a, body) = children
         AggFlatMap(a, name, body, typ)
-      case AggSum(a, typ) =>
+      case ApplyAggNullaryOp(_, op, typ) =>
         val IndexedSeq(a) = children
-        AggSum(a, typ)
+        ApplyAggNullaryOp(a, op, typ)
       case In(_, _) =>
         same
       case InMissingness(_) =>

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -84,6 +84,9 @@ object Copy {
       case ApplyAggNullaryOp(_, op, typ) =>
         val IndexedSeq(a) = children
         ApplyAggNullaryOp(a, op, typ)
+      case ApplyAggTernaryOp(_, op, _, _, _, typ) =>
+        val IndexedSeq(a, arg1, arg2, arg3) = children
+        ApplyAggTernaryOp(a, op, arg1, arg2, arg3, typ)
       case In(_, _) =>
         same
       case InMissingness(_) =>

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -302,7 +302,7 @@ object Emit {
         val (doo, mo, vo) = emit(o)
         present(Code(doo, mo || !t.isFieldDefined(region, coerce[Long](vo), fieldIdx)))
 
-      case _: AggIn | _: AggMap | _: AggFilter | _: AggFlatMap | _: AggSum =>
+      case _: AggIn | _: AggMap | _: AggFilter | _: AggFlatMap | _: ApplyAggNullaryOp =>
         throw new RuntimeException(s"Aggregations must be extracted with ExtractAggregators before compilation: $ir")
 
       case In(i, typ) =>

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -302,7 +302,7 @@ object Emit {
         val (doo, mo, vo) = emit(o)
         present(Code(doo, mo || !t.isFieldDefined(region, coerce[Long](vo), fieldIdx)))
 
-      case _: AggIn | _: AggMap | _: AggFilter | _: AggFlatMap | _: ApplyAggNullaryOp =>
+      case _: AggIn | _: AggMap | _: AggFilter | _: AggFlatMap | _: ApplyAggNullaryOp | _: ApplyAggTernaryOp =>
         throw new RuntimeException(s"Aggregations must be extracted with ExtractAggregators before compilation: $ir")
 
       case In(i, typ) =>

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -302,7 +302,7 @@ object Emit {
         val (doo, mo, vo) = emit(o)
         present(Code(doo, mo || !t.isFieldDefined(region, coerce[Long](vo), fieldIdx)))
 
-      case _: AggIn | _: AggMap | _: AggFilter | _: AggFlatMap | _: ApplyAggNullaryOp | _: ApplyAggTernaryOp =>
+      case _: AggIn | _: AggMap | _: AggFilter | _: AggFlatMap | _: ApplyAggNullaryOp | _: ApplyAggUnaryOp | _: ApplyAggTernaryOp =>
         throw new RuntimeException(s"Aggregations must be extracted with ExtractAggregators before compilation: $ir")
 
       case In(i, typ) =>

--- a/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -76,15 +76,27 @@ object ExtractAggregators {
         fb.emit(emitAgg2(a, tAggIn, agg.seqOp(loadAggArray(fb)(i), _, _),
           fb, new StagedBitSet(fb), Env.empty.bind(scopeBindings: _*)))
         agg.aggregator
+      case (ApplyAggUnaryOp(a, op, arg1, typ), i) =>
+        val agg = AggOp.getUnary(op, arg1.typ, a.typ.asInstanceOf[TAggregable].elementType)
+        fb.emit(emitAgg2(a, tAggIn, agg.seqOp(loadAggArray(fb)(i), _, _),
+          fb, new StagedBitSet(fb), Env.empty.bind(scopeBindings: _*)))
+
+        val constfb = FunctionBuilder.functionBuilder[Region, RegionValueAggregator]
+        val (doarg1, marg1, varg1) = Emit.toCode(arg1, constfb)
+        constfb.emit(Code(
+          doarg1,
+          agg.aggregator.asInstanceOf[(Code[Any], Code[Boolean]) => Code[RegionValueAggregator]](
+            varg1, coerce[Boolean](marg1))))
+        constfb.result()()(Region())
       case (ApplyAggTernaryOp(a, op, arg1, arg2, arg3, typ), i) =>
         val agg = AggOp.getTernary(op, arg1.typ, arg2.typ, arg3.typ, a.typ.asInstanceOf[TAggregable].elementType)
         fb.emit(emitAgg2(a, tAggIn, agg.seqOp(loadAggArray(fb)(i), _, _),
           fb, new StagedBitSet(fb), Env.empty.bind(scopeBindings: _*)))
 
         val constfb = FunctionBuilder.functionBuilder[Region, RegionValueAggregator]
-        val (doarg1, varg1, marg1) = Emit.toCode(arg1, constfb)
-        val (doarg2, varg2, marg2) = Emit.toCode(arg2, constfb)
-        val (doarg3, varg3, marg3) = Emit.toCode(arg3, constfb)
+        val (doarg1, marg1, varg1) = Emit.toCode(arg1, constfb)
+        val (doarg2, marg2, varg2) = Emit.toCode(arg2, constfb)
+        val (doarg3, marg3, varg3) = Emit.toCode(arg3, constfb)
         constfb.emit(Code(
           doarg1,
           doarg2,

--- a/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -76,22 +76,22 @@ object ExtractAggregators {
         fb.emit(emitAgg2(a, tAggIn, agg.seqOp(loadAggArray(fb)(i), _, _),
           fb, new StagedBitSet(fb), Env.empty.bind(scopeBindings: _*)))
         agg.aggregator
-      case (ApplyAggTernaryOp(a, op, arg1, arg2, arg3, typ), i) => 
+      case (ApplyAggTernaryOp(a, op, arg1, arg2, arg3, typ), i) =>
         val agg = AggOp.getTernary(op, arg1.typ, arg2.typ, arg3.typ, a.typ.asInstanceOf[TAggregable].elementType)
         fb.emit(emitAgg2(a, tAggIn, agg.seqOp(loadAggArray(fb)(i), _, _),
           fb, new StagedBitSet(fb), Env.empty.bind(scopeBindings: _*)))
 
-        val fb = FunctionBuilder.functionBuilder[Region, RegionValueAggregator]
-        val (doarg1, varg1, marg1) = Emit.toCode(arg1, fb)
-        val (doarg2, varg2, marg2) = Emit.toCode(arg2, fb)
-        val (doarg3, varg3, marg3) = Emit.toCode(arg3, fb)
-        fb.emit(Code(
+        val constfb = FunctionBuilder.functionBuilder[Region, RegionValueAggregator]
+        val (doarg1, varg1, marg1) = Emit.toCode(arg1, constfb)
+        val (doarg2, varg2, marg2) = Emit.toCode(arg2, constfb)
+        val (doarg3, varg3, marg3) = Emit.toCode(arg3, constfb)
+        constfb.emit(Code(
           doarg1,
           doarg2,
           doarg3,
           agg.aggregator.asInstanceOf[(Code[Any], Code[Boolean], Code[Any], Code[Boolean], Code[Any], Code[Boolean]) => Code[RegionValueAggregator]](
             varg1, coerce[Boolean](marg1), varg2, coerce[Boolean](marg2), varg3, coerce[Boolean](marg3))))
-        fb.result()()(Region())
+        constfb.result()()(Region())
     }
   }
 

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -12,28 +12,28 @@ sealed trait IR extends BaseIR {
   override def copy(newChildren: IndexedSeq[BaseIR]): BaseIR =
     Copy(this, newChildren)
 }
-case class I32(x: Int) extends IR { val typ = TInt32() }
-case class I64(x: Long) extends IR { val typ = TInt64() }
-case class F32(x: Float) extends IR { val typ = TFloat32() }
-case class F64(x: Double) extends IR { val typ = TFloat64() }
-case class True() extends IR { val typ = TBoolean() }
-case class False() extends IR { val typ = TBoolean() }
+final case class I32(x: Int) extends IR { val typ = TInt32() }
+final case class I64(x: Long) extends IR { val typ = TInt64() }
+final case class F32(x: Float) extends IR { val typ = TFloat32() }
+final case class F64(x: Double) extends IR { val typ = TFloat64() }
+final case class True() extends IR { val typ = TBoolean() }
+final case class False() extends IR { val typ = TBoolean() }
 
-case class Cast(v: IR, typ: Type) extends IR
+final case class Cast(v: IR, typ: Type) extends IR
 
-case class NA(typ: Type) extends IR
-case class MapNA(name: String, value: IR, body: IR, var typ: Type = null) extends IR
-case class IsNA(value: IR) extends IR { val typ = TBoolean() }
+final case class NA(typ: Type) extends IR
+final case class MapNA(name: String, value: IR, body: IR, var typ: Type = null) extends IR
+final case class IsNA(value: IR) extends IR { val typ = TBoolean() }
 
-case class If(cond: IR, cnsq: IR, altr: IR, var typ: Type = null) extends IR
+final case class If(cond: IR, cnsq: IR, altr: IR, var typ: Type = null) extends IR
 
-case class Let(name: String, value: IR, body: IR, var typ: Type = null) extends IR
-case class Ref(name: String, var typ: Type = null) extends IR
+final case class Let(name: String, value: IR, body: IR, var typ: Type = null) extends IR
+final case class Ref(name: String, var typ: Type = null) extends IR
 
-case class ApplyBinaryPrimOp(op: BinaryOp, l: IR, r: IR, var typ: Type = null) extends IR
-case class ApplyUnaryPrimOp(op: UnaryOp, x: IR, var typ: Type = null) extends IR
+final case class ApplyBinaryPrimOp(op: BinaryOp, l: IR, r: IR, var typ: Type = null) extends IR
+final case class ApplyUnaryPrimOp(op: UnaryOp, x: IR, var typ: Type = null) extends IR
 
-case class MakeArray(args: Array[IR], var typ: TArray = null) extends IR {
+final case class MakeArray(args: Array[IR], var typ: TArray = null) extends IR {
   override def toString: String = s"MakeArray(${ args.toFastIndexedSeq }, $typ)"
   override def hashCode(): Int =
     scala.util.hashing.MurmurHash3.arrayHash(args) + typ.##
@@ -45,20 +45,23 @@ case class MakeArray(args: Array[IR], var typ: TArray = null) extends IR {
     case _ => false
   }
 }
-case class MakeArrayN(len: IR, elementType: Type) extends IR { def typ: TArray = TArray(elementType) }
-case class ArrayRef(a: IR, i: IR, var typ: Type = null) extends IR
-case class ArrayMissingnessRef(a: IR, i: IR) extends IR { val typ: Type = TBoolean() }
-case class ArrayLen(a: IR) extends IR { val typ = TInt32() }
-case class ArrayMap(a: IR, name: String, body: IR, var elementTyp: Type = null) extends IR { def typ: TArray = TArray(elementTyp) }
-case class ArrayFold(a: IR, zero: IR, accumName: String, valueName: String, body: IR, var typ: Type = null) extends IR
+final case class MakeArrayN(len: IR, elementType: Type) extends IR { def typ: TArray = TArray(elementType) }
+final case class ArrayRef(a: IR, i: IR, var typ: Type = null) extends IR
+final case class ArrayMissingnessRef(a: IR, i: IR) extends IR { val typ: Type = TBoolean() }
+final case class ArrayLen(a: IR) extends IR { val typ = TInt32() }
+final case class ArrayMap(a: IR, name: String, body: IR, var elementTyp: Type = null) extends IR { def typ: TArray = TArray(elementTyp) }
+final case class ArrayFold(a: IR, zero: IR, accumName: String, valueName: String, body: IR, var typ: Type = null) extends IR
 
-case class AggIn(var typ: TAggregable = null) extends IR
-case class AggMap(a: IR, name: String, body: IR, var typ: TAggregable = null) extends IR
-case class AggFilter(a: IR, name: String, body: IR, var typ: TAggregable = null) extends IR
-case class AggFlatMap(a: IR, name: String, body: IR, var typ: TAggregable = null) extends IR
-case class ApplyAggNullaryOp(a: IR, op: AggOp, var typ: Type = null) extends IR
+final case class AggIn(var typ: TAggregable = null) extends IR
+final case class AggMap(a: IR, name: String, body: IR, var typ: TAggregable = null) extends IR
+final case class AggFilter(a: IR, name: String, body: IR, var typ: TAggregable = null) extends IR
+final case class AggFlatMap(a: IR, name: String, body: IR, var typ: TAggregable = null) extends IR
 
-case class MakeStruct(fields: Array[(String, IR)], var typ: TStruct = null) extends IR {
+sealed trait ApplyAggOp extends IR { }
+final case class ApplyAggNullaryOp(a: IR, op: NullaryAggOp, var typ: Type = null) extends ApplyAggOp
+final case class ApplyAggTernaryOp(a: IR, op: TernaryAggOp, arg1: IR, arg2: IR, arg3: IR, var typ: Type = null) extends ApplyAggOp
+
+final case class MakeStruct(fields: Array[(String, IR)], var typ: TStruct = null) extends IR {
   override def toString: String = s"MakeStruct(${ fields.toFastIndexedSeq })"
   override def hashCode(): Int =
     scala.util.hashing.MurmurHash3.arrayHash(fields)
@@ -69,10 +72,10 @@ case class MakeStruct(fields: Array[(String, IR)], var typ: TStruct = null) exte
     case _ => false
   }
 }
-case class GetField(o: IR, name: String, var typ: Type = null) extends IR
-case class GetFieldMissingness(o: IR, name: String) extends IR { val typ: Type = TBoolean() }
+final case class GetField(o: IR, name: String, var typ: Type = null) extends IR
+final case class GetFieldMissingness(o: IR, name: String) extends IR { val typ: Type = TBoolean() }
 
-case class In(i: Int, var typ: Type) extends IR
-case class InMissingness(i: Int) extends IR { val typ: Type = TBoolean() }
+final case class In(i: Int, var typ: Type) extends IR
+final case class InMissingness(i: Int) extends IR { val typ: Type = TBoolean() }
 // FIXME: should be type any
-case class Die(message: String) extends IR { val typ = TVoid }
+final case class Die(message: String) extends IR { val typ = TVoid }

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -59,6 +59,7 @@ final case class AggFlatMap(a: IR, name: String, body: IR, var typ: TAggregable 
 
 sealed trait ApplyAggOp extends IR { }
 final case class ApplyAggNullaryOp(a: IR, op: NullaryAggOp, var typ: Type = null) extends ApplyAggOp
+final case class ApplyAggUnaryOp(a: IR, op: UnaryAggOp, arg1: IR, var typ: Type = null) extends ApplyAggOp
 final case class ApplyAggTernaryOp(a: IR, op: TernaryAggOp, arg1: IR, arg2: IR, arg3: IR, var typ: Type = null) extends ApplyAggOp
 
 final case class MakeStruct(fields: Array[(String, IR)], var typ: TStruct = null) extends IR {

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -56,7 +56,7 @@ case class AggIn(var typ: TAggregable = null) extends IR
 case class AggMap(a: IR, name: String, body: IR, var typ: TAggregable = null) extends IR
 case class AggFilter(a: IR, name: String, body: IR, var typ: TAggregable = null) extends IR
 case class AggFlatMap(a: IR, name: String, body: IR, var typ: TAggregable = null) extends IR
-case class AggSum(a: IR, var typ: Type = null) extends IR
+case class ApplyAggOp(a: IR, op: AggOp, var typ: Type = null) extends IR
 
 case class MakeStruct(fields: Array[(String, IR)], var typ: TStruct = null) extends IR {
   override def toString: String = s"MakeStruct(${ fields.toFastIndexedSeq })"

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -56,7 +56,7 @@ case class AggIn(var typ: TAggregable = null) extends IR
 case class AggMap(a: IR, name: String, body: IR, var typ: TAggregable = null) extends IR
 case class AggFilter(a: IR, name: String, body: IR, var typ: TAggregable = null) extends IR
 case class AggFlatMap(a: IR, name: String, body: IR, var typ: TAggregable = null) extends IR
-case class ApplyAggOp(a: IR, op: AggOp, var typ: Type = null) extends IR
+case class ApplyAggNullaryOp(a: IR, op: AggOp, var typ: Type = null) extends IR
 
 case class MakeStruct(fields: Array[(String, IR)], var typ: TStruct = null) extends IR {
   override def toString: String = s"MakeStruct(${ fields.toFastIndexedSeq })"

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -114,10 +114,10 @@ object Infer {
         val tagg2 = tagg.copy(elementType = tout.elementType)
         tagg2.symTab = tagg.symTab
         x.typ = tagg2
-      case x@AggSum(a, _) =>
+      case x@ApplyAggNullaryOp(a, op, _) =>
         infer(a)
         val tAgg = a.typ.asInstanceOf[TAggregable]
-        x.typ = tAgg.elementType
+        x.typ = AggOp.getNullaryType(op, tAgg.elementType)
       case x@MakeStruct(fields, _) =>
         fields.foreach { case (name, a) => infer(a) }
         x.typ = TStruct(fields.map { case (name, a) =>

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -118,6 +118,11 @@ object Infer {
         infer(a)
         val tAgg = a.typ.asInstanceOf[TAggregable]
         x.typ = AggOp.getNullaryType(op, tAgg.elementType)
+      case x@ApplyAggUnaryOp(a, op, arg1, _) =>
+        infer(a)
+        infer(arg1)
+        val tAgg = a.typ.asInstanceOf[TAggregable]
+        x.typ = AggOp.getUnaryType(op, arg1.typ, tAgg.elementType)
       case x@ApplyAggTernaryOp(a, op, arg1, arg2, arg3, _) =>
         infer(a)
         infer(arg1)

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -118,6 +118,13 @@ object Infer {
         infer(a)
         val tAgg = a.typ.asInstanceOf[TAggregable]
         x.typ = AggOp.getNullaryType(op, tAgg.elementType)
+      case x@ApplyAggTernaryOp(a, op, arg1, arg2, arg3, _) =>
+        infer(a)
+        infer(arg1)
+        infer(arg2)
+        infer(arg3)
+        val tAgg = a.typ.asInstanceOf[TAggregable]
+        x.typ = AggOp.getTernaryType(op, arg1.typ, arg2.typ, arg3.typ, tAgg.elementType)
       case x@MakeStruct(fields, _) =>
         fields.foreach { case (name, a) => infer(a) }
         x.typ = TStruct(fields.map { case (name, a) =>

--- a/src/main/scala/is/hail/expr/ir/Recur.scala
+++ b/src/main/scala/is/hail/expr/ir/Recur.scala
@@ -32,6 +32,7 @@ object Recur {
     case AggFilter(a, name, body, typ) => AggFilter(f(a), name, f(body), typ)
     case AggFlatMap(a, name, body, typ) => AggFlatMap(f(a), name, f(body), typ)
     case ApplyAggNullaryOp(a, op, typ) => ApplyAggNullaryOp(f(a), op, typ)
+    case ApplyAggUnaryOp(a, op, arg1, typ) => ApplyAggUnaryOp(f(a), op, f(arg1), typ)
     case ApplyAggTernaryOp(a, op, arg1, arg2, arg3, typ) => ApplyAggTernaryOp(f(a), op, f(arg1), f(arg2), f(arg3), typ)
     case In(i, typ) => ir
     case InMissingness(i) => ir

--- a/src/main/scala/is/hail/expr/ir/Recur.scala
+++ b/src/main/scala/is/hail/expr/ir/Recur.scala
@@ -31,7 +31,7 @@ object Recur {
     case AggMap(a, name, body, typ) => AggMap(f(a), name, f(body), typ)
     case AggFilter(a, name, body, typ) => AggFilter(f(a), name, f(body), typ)
     case AggFlatMap(a, name, body, typ) => AggFlatMap(f(a), name, f(body), typ)
-    case AggSum(a, typ) => AggSum(f(a), typ)
+    case ApplyAggNullaryOp(a, op, typ) => ApplyAggNullaryOp(f(a), op, typ)
     case In(i, typ) => ir
     case InMissingness(i) => ir
     case Die(message) => ir

--- a/src/main/scala/is/hail/expr/ir/Recur.scala
+++ b/src/main/scala/is/hail/expr/ir/Recur.scala
@@ -32,6 +32,7 @@ object Recur {
     case AggFilter(a, name, body, typ) => AggFilter(f(a), name, f(body), typ)
     case AggFlatMap(a, name, body, typ) => AggFlatMap(f(a), name, f(body), typ)
     case ApplyAggNullaryOp(a, op, typ) => ApplyAggNullaryOp(f(a), op, typ)
+    case ApplyAggTernaryOp(a, op, arg1, arg2, arg3, typ) => ApplyAggTernaryOp(f(a), op, f(arg1), f(arg2), f(arg3), typ)
     case In(i, typ) => ir
     case InMissingness(i) => ir
     case Die(message) => ir

--- a/src/main/scala/is/hail/expr/ir/Subst.scala
+++ b/src/main/scala/is/hail/expr/ir/Subst.scala
@@ -14,6 +14,15 @@ object Subst {
         ArrayMap(subst(a), name, subst(body, env.delete(name)))
       case ArrayFold(a, zero, accumName, valueName, body, _) =>
         ArrayFold(subst(a), subst(zero), accumName, valueName, subst(body, env.delete(accumName).delete(valueName)))
+      case AggMap(a, name, body, typ) =>
+        // body has empty environment, ergo substitutions to be made
+        AggMap(subst(a), name, body, typ)
+      case AggFilter(a, name, body, typ) =>
+        // body has empty environment, ergo substitutions to be made
+        AggFilter(subst(a), name, body, typ)
+      case AggFlatMap(a, name, body, typ) =>
+        // body has empty environment, ergo substitutions to be made
+        AggFlatMap(subst(a), name, body, typ)
       case _ =>
         Recur(subst(_))(e)
     }

--- a/src/main/scala/is/hail/stats/HistogramCombiner.scala
+++ b/src/main/scala/is/hail/stats/HistogramCombiner.scala
@@ -6,7 +6,7 @@ import is.hail.annotations.Annotation
 import is.hail.expr._
 
 object HistogramCombiner {
-  def schema: Type = TStruct(
+  def schema: TStruct = TStruct(
     "binEdges" -> TArray(TFloat64()),
     "binFrequencies" -> TArray(TInt64()),
     "nLess" -> TInt64(),

--- a/src/main/scala/is/hail/stats/HistogramCombiner.scala
+++ b/src/main/scala/is/hail/stats/HistogramCombiner.scala
@@ -13,7 +13,7 @@ object HistogramCombiner {
     "nGreater" -> TInt64())
 }
 
-class HistogramCombiner(indices: Array[Double]) extends Serializable {
+class HistogramCombiner(val indices: Array[Double]) extends Serializable {
 
   val min = indices.head
   val max = indices(indices.length - 1)

--- a/src/main/scala/is/hail/utils/MissingBooleanArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingBooleanArrayBuilder.scala
@@ -1,0 +1,57 @@
+package is.hail.utils
+
+import is.hail.expr._
+import is.hail.annotations._
+import scala.collection.mutable.BitSet
+
+class MissingBooleanArrayBuilder {
+  private var len = 0
+  private val elements = new BitSet()
+  private val isMissing = new BitSet()
+
+  def addMissing() {
+    isMissing.add(len)
+    len += 1
+  }
+
+  def add(x: Boolean) {
+    elements.add(len)
+    len += 1
+  }
+
+  def length(): Int = len
+
+  def foreach(whenMissing: (Int) => Unit)(whenPresent: (Int, Boolean) => Unit) {
+    var i = 0
+    var j = 0
+    while (i < len) {
+      if (isMissing(i))
+        whenMissing(i)
+      else {
+        whenPresent(i, elements(j))
+        j += 1
+      }
+      i += 1
+    }
+  }
+
+  val typ = TArray(TBoolean())
+
+  private val rvb = new RegionValueBuilder()
+
+  def writeIntoRegion(region: Region): Long = {
+    rvb.set(region)
+    rvb.start(typ)
+    rvb.startArray(len)
+    var i = 0
+    while (i < len) {
+      if (isMissing(i))
+        rvb.setMissing()
+      else
+        rvb.addBoolean(elements(i))
+      i += 1
+    }
+    rvb.endArray()
+    rvb.end()
+  }
+}

--- a/src/main/scala/is/hail/utils/MissingDoubleArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingDoubleArrayBuilder.scala
@@ -14,8 +14,8 @@ class MissingDoubleArrayBuilder {
     len += 1
   }
 
-  def add(i: Double) {
-    elements += i
+  def add(x: Double) {
+    elements += x
     len += 1
   }
 

--- a/src/main/scala/is/hail/utils/MissingDoubleArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingDoubleArrayBuilder.scala
@@ -1,0 +1,57 @@
+package is.hail.utils
+
+import is.hail.expr._
+import is.hail.annotations._
+import scala.collection.mutable.BitSet
+
+class MissingDoubleArrayBuilder {
+  private var len = 0
+  private val elements = new ArrayBuilder[Double]()
+  private val isMissing = new BitSet()
+
+  def addMissing() {
+    isMissing.add(len)
+    len += 1
+  }
+
+  def add(i: Double) {
+    elements += i
+    len += 1
+  }
+
+  def length(): Int = len
+
+  def foreach(whenMissing: (Int) => Unit)(whenPresent: (Int, Double) => Unit) {
+    var i = 0
+    var j = 0
+    while (i < len) {
+      if (isMissing(i))
+        whenMissing(i)
+      else {
+        whenPresent(i, elements(j))
+        j += 1
+      }
+      i += 1
+    }
+  }
+
+  val typ = TArray(TFloat64())
+
+  private val rvb = new RegionValueBuilder()
+
+  def writeIntoRegion(region: Region): Long = {
+    rvb.set(region)
+    rvb.start(typ)
+    rvb.startArray(len)
+    var i = 0
+    while (i < len) {
+      if (isMissing(i))
+        rvb.setMissing()
+      else
+        rvb.addDouble(elements(i))
+      i += 1
+    }
+    rvb.endArray()
+    rvb.end()
+  }
+}

--- a/src/main/scala/is/hail/utils/MissingFloatArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingFloatArrayBuilder.scala
@@ -14,8 +14,8 @@ class MissingFloatArrayBuilder {
     len += 1
   }
 
-  def add(i: Float) {
-    elements += i
+  def add(x: Float) {
+    elements += x
     len += 1
   }
 

--- a/src/main/scala/is/hail/utils/MissingFloatArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingFloatArrayBuilder.scala
@@ -1,0 +1,57 @@
+package is.hail.utils
+
+import is.hail.expr._
+import is.hail.annotations._
+import scala.collection.mutable.BitSet
+
+class MissingFloatArrayBuilder {
+  private var len = 0
+  private val elements = new ArrayBuilder[Float]()
+  private val isMissing = new BitSet()
+
+  def addMissing() {
+    isMissing.add(len)
+    len += 1
+  }
+
+  def add(i: Float) {
+    elements += i
+    len += 1
+  }
+
+  def length(): Int = len
+
+  def foreach(whenMissing: (Int) => Unit)(whenPresent: (Int, Float) => Unit) {
+    var i = 0
+    var j = 0
+    while (i < len) {
+      if (isMissing(i))
+        whenMissing(i)
+      else {
+        whenPresent(i, elements(j))
+        j += 1
+      }
+      i += 1
+    }
+  }
+
+  val typ = TArray(TFloat32())
+
+  private val rvb = new RegionValueBuilder()
+
+  def writeIntoRegion(region: Region): Long = {
+    rvb.set(region)
+    rvb.start(typ)
+    rvb.startArray(len)
+    var i = 0
+    while (i < len) {
+      if (isMissing(i))
+        rvb.setMissing()
+      else
+        rvb.addFloat(elements(i))
+      i += 1
+    }
+    rvb.endArray()
+    rvb.end()
+  }
+}

--- a/src/main/scala/is/hail/utils/MissingIntArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingIntArrayBuilder.scala
@@ -1,0 +1,57 @@
+package is.hail.utils
+
+import is.hail.expr._
+import is.hail.annotations._
+import scala.collection.mutable.BitSet
+
+class MissingIntArrayBuilder {
+  private var len = 0
+  private val elements = new ArrayBuilder[Int]()
+  private val isMissing = new BitSet()
+
+  def addMissing() {
+    isMissing.add(len)
+    len += 1
+  }
+
+  def add(i: Int) {
+    elements += i
+    len += 1
+  }
+
+  def length(): Int = len
+
+  def foreach(whenMissing: (Int) => Unit)(whenPresent: (Int, Int) => Unit) {
+    var i = 0
+    var j = 0
+    while (i < len) {
+      if (isMissing(i))
+        whenMissing(i)
+      else {
+        whenPresent(i, elements(j))
+        j += 1
+      }
+      i += 1
+    }
+  }
+
+  val typ = TArray(TInt32())
+
+  private val rvb = new RegionValueBuilder()
+
+  def writeIntoRegion(region: Region): Long = {
+    rvb.set(region)
+    rvb.start(typ)
+    rvb.startArray(len)
+    var i = 0
+    while (i < len) {
+      if (isMissing(i))
+        rvb.setMissing()
+      else
+        rvb.addInt(elements(i))
+      i += 1
+    }
+    rvb.endArray()
+    rvb.end()
+  }
+}

--- a/src/main/scala/is/hail/utils/MissingIntArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingIntArrayBuilder.scala
@@ -14,8 +14,8 @@ class MissingIntArrayBuilder {
     len += 1
   }
 
-  def add(i: Int) {
-    elements += i
+  def add(x: Int) {
+    elements += x
     len += 1
   }
 

--- a/src/main/scala/is/hail/utils/MissingLongArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingLongArrayBuilder.scala
@@ -14,8 +14,8 @@ class MissingLongArrayBuilder {
     len += 1
   }
 
-  def add(i: Long) {
-    elements += i
+  def add(x: Long) {
+    elements += x
     len += 1
   }
 

--- a/src/main/scala/is/hail/utils/MissingLongArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingLongArrayBuilder.scala
@@ -1,0 +1,57 @@
+package is.hail.utils
+
+import is.hail.expr._
+import is.hail.annotations._
+import scala.collection.mutable.BitSet
+
+class MissingLongArrayBuilder {
+  private var len = 0
+  private val elements = new ArrayBuilder[Long]()
+  private val isMissing = new BitSet()
+
+  def addMissing() {
+    isMissing.add(len)
+    len += 1
+  }
+
+  def add(i: Long) {
+    elements += i
+    len += 1
+  }
+
+  def length(): Int = len
+
+  def foreach(whenMissing: (Int) => Unit)(whenPresent: (Int, Long) => Unit) {
+    var i = 0
+    var j = 0
+    while (i < len) {
+      if (isMissing(i))
+        whenMissing(i)
+      else {
+        whenPresent(i, elements(j))
+        j += 1
+      }
+      i += 1
+    }
+  }
+
+  val typ = TArray(TInt64())
+
+  private val rvb = new RegionValueBuilder()
+
+  def writeIntoRegion(region: Region): Long = {
+    rvb.set(region)
+    rvb.start(typ)
+    rvb.startArray(len)
+    var i = 0
+    while (i < len) {
+      if (isMissing(i))
+        rvb.setMissing()
+      else
+        rvb.addLong(elements(i))
+      i += 1
+    }
+    rvb.endArray()
+    rvb.end()
+  }
+}

--- a/src/test/scala/is/hail/annotations/RegionValueToScala.scala
+++ b/src/test/scala/is/hail/annotations/RegionValueToScala.scala
@@ -39,11 +39,9 @@ object RegionValueToScala {
   def loadArray[T : ClassTag](elementType: Type)(region: Region, aOff: Long): Array[T] = {
     val arrayType = TArray(elementType)
     val len = arrayType.loadLength(region, aOff)
-    println(s"rvts length $len")
     val a = new Array[T](len)
     var i = 0
     while (i < len) {
-      println(s"rvts $i")
       if (arrayType.isElementDefined(region, aOff, i))
         a(i) = load[T](elementType)(region, arrayType.loadElement(region, aOff, i))
       i += 1

--- a/src/test/scala/is/hail/annotations/RegionValueToScala.scala
+++ b/src/test/scala/is/hail/annotations/RegionValueToScala.scala
@@ -1,0 +1,53 @@
+package is.hail.annotations
+
+import is.hail.expr._
+
+import scala.reflect.ClassTag
+import scala.reflect.classTag
+
+object RegionValueToScala {
+  def classTagHail(t: Type): ClassTag[_] = t match {
+    case TBoolean(true) => classTag[Boolean]
+    case TBoolean(false) => classTag[java.lang.Boolean]
+    case TInt32(true) => classTag[Int]
+    case TInt32(false) => classTag[java.lang.Integer]
+    case TInt64(true) => classTag[Long]
+    case TInt64(false) => classTag[java.lang.Long]
+    case TFloat32(true) => classTag[Float]
+    case TFloat32(false) => classTag[java.lang.Float]
+    case TFloat64(true) => classTag[Double]
+    case TFloat64(false) => classTag[java.lang.Double]
+    case t => throw new RuntimeException(s"classTagHail does not handle $t")
+  }
+
+  def load[T: HailRep](region: Region, off: Long): T =
+    load(hailType[T])(region, off)
+
+  def load[T](t: Type)(region: Region, off: Long): T = t match {
+    case _: TBoolean => region.loadBoolean(off).asInstanceOf[T]
+    case _: TInt32 => region.loadInt(off).asInstanceOf[T]
+    case _: TInt64 => region.loadLong(off).asInstanceOf[T]
+    case _: TFloat32 => region.loadFloat(off).asInstanceOf[T]
+    case _: TFloat64 => region.loadDouble(off).asInstanceOf[T]
+    case t: TArray => loadArray(t.elementType)(region, off)(classTagHail(t.elementType)).asInstanceOf[T]
+    case t => throw new RuntimeException(s"load does not handle $t")
+  }
+
+  def loadArray[T : HailRep : ClassTag](region: Region, aOff: Long): Array[T] =
+    loadArray[T](hailType[T])(region, aOff)
+
+  def loadArray[T : ClassTag](elementType: Type)(region: Region, aOff: Long): Array[T] = {
+    val arrayType = TArray(elementType)
+    val len = arrayType.loadLength(region, aOff)
+    println(s"rvts length $len")
+    val a = new Array[T](len)
+    var i = 0
+    while (i < len) {
+      println(s"rvts $i")
+      if (arrayType.isElementDefined(region, aOff, i))
+        a(i) = load[T](elementType)(region, arrayType.loadElement(region, aOff, i))
+      i += 1
+    }
+    a
+  }
+}

--- a/src/test/scala/is/hail/expr/TableIRSuite.scala
+++ b/src/test/scala/is/hail/expr/TableIRSuite.scala
@@ -2,7 +2,6 @@ package is.hail.expr
 
 import is.hail.SparkSuite
 import is.hail.table.Table
-import is.hail.expr.ir
 import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 

--- a/src/test/scala/is/hail/expr/ir/ExtractAggregatorsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/ExtractAggregatorsSuite.scala
@@ -530,6 +530,6 @@ class ExtractAggregatorsSuite {
       region, t.loadField(region, hOff, binFrequencies))
     assert(binFrequenciesArray === Array[Long](3L, 0L, 1L, 0L, 0L))
     assert(region.loadLong(t.loadField(region, hOff, nLess)) === 1L)
-    assert(region.loadLong(t.loadField(region, hOff, nGreater)) === 1L)
+    assert(region.loadLong(t.loadField(region, hOff, nGreater)) === 2L)
   }
 }


### PR DESCRIPTION
@cseed @catoverdrive This is how we should do aggregators. I implemented several as examples. It's a bit repetitive, maybe `@specialized` can help here? I'm kind of afraid of it.

Some open issues:

 - if the result of an aggregator is missing, I can't write it into the region, maybe rewrite `result` in continuation-passing style with a missing and non missing continuation? (is that function call indirection worth avoiding an allocation of a `Some(offset)` per-aggrgator-result?)

 - how do I take a user supplied function, e.g. `takeBy`? I keep avoiding lambda-like constructs. Do I introduce a new binding form, like `ApplyUnaryFunAggOp`. I don't like this path, but I also think adding a `Lambda` IR that isn't a full-fledged lambda will make the compiler look annoying/ugly too. This issue is basically the continuation of me punting on how to handle lambdas.

 - How do y'all feel about me eliminating some type-specific aggregators that can be implemented in terms of other ones (see AggOp.scala)

If y'all are happy with this, I want to solve the missingness issue, and then farm out the last few (non-lambda-taking) aggregators to the team.