### PR TITLE
Split CodeNullable from CodeObject

### DIFF
--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueSumAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueSumAggregator.scala
@@ -9,7 +9,7 @@ import is.hail.expr.RegionValueAggregator
 import scala.reflect.ClassTag
 
 object RegionValueSumAggregator {
-  private def seqOp[Agg >: Null : ClassTag : TypeInfo, T : ClassTag](t: Type): (Code[RegionValueAggregator], Code[_], Code[Boolean]) => Code[Unit] =
+  private def seqOp[Agg <: RegionValueAggregator : ClassTag : TypeInfo, T : ClassTag](t: Type): (Code[RegionValueAggregator], Code[_], Code[Boolean]) => Code[Unit] =
   { (rva: Code[RegionValueAggregator], v: Code[_], mv: Code[Boolean]) =>
     mv.mux(
       Code.checkcast[Agg](rva).invoke[T, Boolean, Unit]("seqOp", coerce[T](defaultValue(t)), true),

--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -686,7 +686,7 @@ class FieldRef[T, S](f: Field)(implicit tct: ClassTag[T], sti: TypeInfo[S]) {
     }
 }
 
-class CodeObject[T >: Null](val lhs: Code[T])(implicit tct: ClassTag[T], tti: TypeInfo[T]) {
+class CodeObject[T <: AnyRef : ClassTag](val lhs: Code[T]) {
   def get[S](field: String)(implicit sct: ClassTag[S], sti: TypeInfo[S]): Code[S] =
     FieldRef[T, S](field).get(lhs)
 
@@ -715,7 +715,9 @@ class CodeObject[T >: Null](val lhs: Code[T])(implicit tct: ClassTag[T], tti: Ty
   def invoke[A1, A2, A3, A4, S](method: String, a1: Code[A1], a2: Code[A2], a3: Code[A3], a4: Code[A4])
     (implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2], a3ct: ClassTag[A3], a4ct: ClassTag[A4], sct: ClassTag[S]): Code[S] =
     invoke[S](method, Array[Class[_]](a1ct.runtimeClass, a2ct.runtimeClass, a3ct.runtimeClass, a4ct.runtimeClass), Array[Code[_]](a1, a2, a3, a4))
+}
 
+class CodeNullable[T >: Null : TypeInfo](val lhs: Code[T]) {
   def ifNull[T](cnullcase: Code[T], cnonnullcase: Code[T]): Code[T] =
     new Code[T] {
       def emit(il: Growable[AbstractInsnNode]): Unit = {

--- a/src/main/scala/is/hail/asm4s/package.scala
+++ b/src/main/scala/is/hail/asm4s/package.scala
@@ -201,8 +201,11 @@ package object asm4s {
 
   implicit def toCodeArray[T](c: Code[Array[T]])(implicit tti: TypeInfo[T]): CodeArray[T] = new CodeArray(c)
 
-  implicit def toCodeObject[T >: Null](c: Code[T])(implicit tti: TypeInfo[T], tct: ClassTag[T]): CodeObject[T] =
+  implicit def toCodeObject[T <: AnyRef : ClassTag](c: Code[T]): CodeObject[T] =
     new CodeObject(c)
+
+  implicit def toCodeNullable[T >: Null : TypeInfo](c: Code[T]): CodeNullable[T] =
+    new CodeNullable(c)
 
   implicit def toCode[T](insn: => AbstractInsnNode): Code[T] = new Code[T] {
     def emit(il: Growable[AbstractInsnNode]): Unit = {
@@ -229,7 +232,9 @@ package object asm4s {
 
   implicit def toCodeBoolean(f: LocalRef[Boolean]): CodeBoolean = new CodeBoolean(f.load())
 
-  implicit def toCodeObject[T >: Null](f: LocalRef[T])(implicit tti: TypeInfo[T], tct: ClassTag[T]): CodeObject[T] = new CodeObject[T](f.load())
+  implicit def toCodeObject[T <: AnyRef : ClassTag](f: LocalRef[T]): CodeObject[T] = new CodeObject[T](f.load())
+
+  implicit def toCodeNullable[T >: Null : TypeInfo](f: LocalRef[T]): CodeNullable[T] = new CodeNullable[T](f.load())
 
   implicit def toLocalRefInt(f: LocalRef[Int]): LocalRefInt = new LocalRefInt(f)
 


### PR DESCRIPTION
The AnyRef bound is necessary for the ability to reflectively
invoke methods. The Null bound is necessary for operations that
return null as a value of that type.

Unfortunately AnyRef does not imply a Null lower bound. This
PR resolves this issue by formally divorcing the two notions.
Most types will staisfy both bounds enabling the use of
either implicit. I actually am not aware of what types do not
satisfy both bounds.