### PR TITLE
fix warning in table ir suite

### DIFF
--- a/src/test/scala/is/hail/expr/TableIRSuite.scala
+++ b/src/test/scala/is/hail/expr/TableIRSuite.scala
@@ -2,7 +2,6 @@ package is.hail.expr
 
 import is.hail.SparkSuite
 import is.hail.table.Table
-import is.hail.expr.ir
 import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 


### PR DESCRIPTION
No need to import a sub-package. Sub-packages are implicitly imported.