### PR TITLE
Support expressions in typecheck more naturally

### DIFF
--- a/python/hail/api1/dataset.py
+++ b/python/hail/api1/dataset.py
@@ -2635,7 +2635,7 @@ g = let newgt = gtIndex(oldToNew[gtj(g.GT)], oldToNew[gtk(g.GT)]) and
 
     @handle_py4j
     @record_method
-    @typecheck(datasets=tupleof(vds_type))
+    @typecheck(datasets=vds_type)
     def union(*datasets):
         """Take the union of datasets vertically (include all variants).
 

--- a/python/hail/api1/keytable.py
+++ b/python/hail/api1/keytable.py
@@ -1051,7 +1051,7 @@ class KeyTable(HistoryMixin):
 
     @handle_py4j
     @record_method
-    @typecheck_method(cols=tupleof(oneof(strlike, Ascending, Descending)))
+    @typecheck_method(cols=oneof(strlike, Ascending, Descending))
     def order_by(self, *cols):
         """Sort by the specified columns.  Missing values are sorted after non-missing values.  Sort by the first column, then the second, etc.
 
@@ -1326,7 +1326,7 @@ class KeyTable(HistoryMixin):
 
     @handle_py4j
     @record_method
-    @typecheck_method(kts=tupleof(kt_type))
+    @typecheck_method(kts=kt_type)
     def union(self, *kts):
         """Union the rows of multiple tables.
 
@@ -1642,7 +1642,7 @@ class KeyTable(HistoryMixin):
     @handle_py4j
     @record_method
     @typecheck_method(dest=strlike,
-                      columns=tupleof(strlike))
+                      columns=strlike)
     def group(self, dest, *columns):
         """Combines columns into a single struct column.
 

--- a/python/hail/api2/matrixtable.py
+++ b/python/hail/api2/matrixtable.py
@@ -885,7 +885,7 @@ class MatrixTable(object):
         return cleanup(m)
 
     @handle_py4j
-    @typecheck_method(exprs=tupleof(oneof(strlike, Expression)))
+    @typecheck_method(exprs=oneof(strlike, Expression))
     def drop(self, *exprs):
         """Drop fields.
 
@@ -1037,7 +1037,7 @@ class MatrixTable(object):
 
         Keep columns where `pheno.isCase` is ``True`` and `pheno.age` is larger than 50:
 
-        >>> dataset_result = dataset.filter_cols(dataset.pheno.isCase & dataset.pheno.age > 50, keep=True)
+        >>> dataset_result = dataset.filter_cols(dataset.pheno.isCase & (dataset.pheno.age > 50), keep=True)
 
         Remove rows where `sample_qc.gqMean` is less than 20:
 
@@ -1886,7 +1886,7 @@ class MatrixTable(object):
             error('Analysis exception: {}'.format(msg))
             raise ExpressionException(msg)
 
-    @typecheck_method(exprs=tupleof(Expression))
+    @typecheck_method(exprs=Expression)
     def _process_joins(self, *exprs):
 
         all_uids = []

--- a/python/hail/api2/table.py
+++ b/python/hail/api2/table.py
@@ -184,7 +184,6 @@ class GroupedTable(TableTemplate):
         return self
 
     @handle_py4j
-    @typecheck_method(named_exprs=dictof(strlike, anytype))
     def aggregate(self, **named_exprs):
         """Aggregate by group, used after :meth:`Table.group_by`.
 
@@ -392,7 +391,7 @@ class Table(TableTemplate):
                 schema._jtype, wrap_to_list(key), joption(num_partitions)))
 
     @handle_py4j
-    @typecheck_method(keys=tupleof(strlike))
+    @typecheck_method(keys=strlike)
     def key_by(self, *keys):
         """Change which columns are keys.
 
@@ -514,7 +513,6 @@ class Table(TableTemplate):
         return cleanup(Table(base._jt.selectGlobal(strs)))
 
     @handle_py4j
-    @typecheck_method(named_exprs=dictof(strlike, anytype))
     def annotate(self, **named_exprs):
         """Add new columns.
 
@@ -600,8 +598,8 @@ class Table(TableTemplate):
         return cleanup(Table(base._jt.filter(expr._ast.to_hql(), keep)))
 
     @handle_py4j
-    @typecheck_method(exprs=tupleof(oneof(Expression, strlike)),
-                      named_exprs=dictof(strlike, anytype))
+    @typecheck_method(exprs=oneof(Expression, strlike),
+                      named_exprs=anytype)
     def select(self, *exprs, **named_exprs):
         """Select existing fields or create new fields by name, dropping the rest.
 
@@ -702,7 +700,7 @@ class Table(TableTemplate):
         return cleanup(Table(base._jt.select(strs, False)))
 
     @handle_py4j
-    @typecheck_method(exprs=tupleof(oneof(strlike, Expression)))
+    @typecheck_method(exprs=oneof(strlike, Expression))
     def drop(self, *exprs):
         """Drop fields from the table.
 
@@ -804,8 +802,6 @@ class Table(TableTemplate):
 
         self._jt.export(output, types_file, header, Env.hail().utils.ExportType.getExportType(parallel))
 
-    @typecheck_method(exprs=tupleof(anytype),
-                      named_exprs=dictof(strlike, anytype))
     def group_by(self, *exprs, **named_exprs):
         """Group by a new set of keys for use with :meth:`GroupedTable.aggregate`.
 
@@ -1120,7 +1116,7 @@ class Table(TableTemplate):
 
         return construct_expr(GlobalJoinReference(uid), self.global_schema, joins=(Join(joiner, [uid]),))
 
-    @typecheck_method(exprs=tupleof(Expression))
+    @typecheck_method(exprs=Expression)
     def _process_joins(self, *exprs):
         # ordered to support nested joins
         original_key = self.key
@@ -1359,7 +1355,7 @@ class Table(TableTemplate):
         return Table(self._jt.indexed(name))
 
     @handle_py4j
-    @typecheck_method(tables=tupleof(table_type))
+    @typecheck_method(tables=table_type)
     def union(self, *tables):
         """Union the rows of multiple tables.
 
@@ -1735,7 +1731,7 @@ class Table(TableTemplate):
         return Table(self._jt.flatten())
 
     @handle_py4j
-    @typecheck_method(exprs=tupleof(oneof(strlike, Expression, Ascending, Descending)))
+    @typecheck_method(exprs=oneof(strlike, Expression, Ascending, Descending))
     def order_by(self, *exprs):
         """Sort by the specified columns.
 

--- a/python/hail/expr/aggregators.py
+++ b/python/hail/expr/aggregators.py
@@ -15,7 +15,7 @@ def _to_agg(x):
         return Aggregable(ast, x._type, x._indices, x._aggregations, x._joins)
 
 
-@typecheck(name=strlike, aggregable=Aggregable, ret_type=Type, args=tupleof(anytype))
+@typecheck(name=strlike, aggregable=Aggregable, ret_type=Type, args=anytype)
 def _agg_func(name, aggregable, ret_type, *args):
     args = [to_expr(a) for a in args]
     indices, aggregations, joins = unify_all(aggregable, *args)

--- a/python/hail/expr/ast.py
+++ b/python/hail/expr/ast.py
@@ -4,7 +4,7 @@ asttype = lazy()
 
 
 class AST(object):
-    @typecheck_method(children=tupleof(asttype))
+    @typecheck_method(children=asttype)
     def __init__(self, *children):
         self.children = children
 
@@ -78,7 +78,7 @@ class Select(AST):
 
 
 class ApplyMethod(AST):
-    @typecheck_method(method=strlike, args=tupleof(AST))
+    @typecheck_method(method=strlike, args=AST)
     def __init__(self, method, *args):
         self.method = method
         self.args = args
@@ -89,7 +89,7 @@ class ApplyMethod(AST):
 
 
 class ClassMethod(AST):
-    @typecheck_method(method=strlike, callee=AST, args=tupleof(AST))
+    @typecheck_method(method=strlike, callee=AST, args=AST)
     def __init__(self, method, callee, *args):
         self.method = method
         self.callee = callee
@@ -101,7 +101,7 @@ class ClassMethod(AST):
 
 
 class LambdaClassMethod(AST):
-    @typecheck_method(method=strlike, lambda_var=strlike, callee=AST, rhs=AST, args=tupleof(AST))
+    @typecheck_method(method=strlike, lambda_var=strlike, callee=AST, rhs=AST, args=AST)
     def __init__(self, method, lambda_var, callee, rhs, *args):
         self.method = method
         self.lambda_var = lambda_var
@@ -161,7 +161,7 @@ class StructDeclaration(AST):
 
 
 class StructOp(AST):
-    @typecheck_method(operation=strlike, parent=AST, keys=tupleof(strlike))
+    @typecheck_method(operation=strlike, parent=AST, keys=strlike)
     def __init__(self, operation, parent, *keys):
         self.operation = operation
         self.parent = parent

--- a/python/hail/expr/expression.py
+++ b/python/hail/expr/expression.py
@@ -4,7 +4,7 @@ from hail.expr.ast import *
 from hail.expr.types import *
 from hail.utils.java import *
 from hail.genetics import Locus, Variant, Interval, Call, AltAllele
-
+from hail.typecheck import *
 
 def to_expr(e):
     if isinstance(e, Expression):
@@ -125,33 +125,33 @@ _lazy_interval = lazy()
 _lazy_call = lazy()
 _lazy_expr = lazy()
 
-expr_int32 = transformed({_lazy_int32: identity,
-                          integral: to_expr})
-expr_numeric = transformed({_lazy_numeric: identity,
-                            integral: to_expr,
-                            float: to_expr})
-expr_list = transformed({list: to_expr,
-                         _lazy_array: identity})
-expr_set = transformed({set: to_expr,
-                        _lazy_set: identity})
-expr_bool = transformed({bool: to_expr,
-                         _lazy_bool: identity})
-expr_struct = transformed({Struct: to_expr,
-                           _lazy_struct: identity})
-expr_str = transformed({strlike: to_expr,
-                        _lazy_string: identity})
-expr_variant = transformed({Variant: to_expr,
-                            _lazy_variant: identity})
-expr_locus = transformed({Locus: to_expr,
-                          _lazy_locus: identity})
-expr_altallele = transformed({AltAllele: to_expr,
-                              _lazy_altallele: identity})
-expr_interval = transformed({Interval: to_expr,
-                             _lazy_interval: identity})
-expr_call = transformed({Call: to_expr,
-                         _lazy_call: identity})
-expr_any = transformed({_lazy_expr: identity,
-                        anytype: to_expr})
+expr_int32 = transformed((_lazy_int32, identity),
+                         (integral, to_expr))
+expr_numeric = transformed((_lazy_numeric, identity),
+                           (integral, to_expr),
+                           (float, to_expr))
+expr_list = transformed((list, to_expr),
+                        (_lazy_array, identity))
+expr_set = transformed((set, to_expr),
+                       (_lazy_set, identity))
+expr_bool = transformed((bool, to_expr),
+                        (_lazy_bool, identity))
+expr_struct = transformed((Struct, to_expr),
+                          (_lazy_struct, identity))
+expr_str = transformed((strlike, to_expr),
+                       (_lazy_string, identity))
+expr_variant = transformed((Variant, to_expr),
+                           (_lazy_variant, identity))
+expr_locus = transformed((Locus, to_expr),
+                         (_lazy_locus, identity))
+expr_altallele = transformed((AltAllele, to_expr),
+                             (_lazy_altallele, identity))
+expr_interval = transformed((Interval, to_expr),
+                            (_lazy_interval, identity))
+expr_call = transformed((Call, to_expr),
+                        (_lazy_call, identity))
+expr_any = transformed((_lazy_expr, identity),
+                       (anytype, to_expr))
 
 
 class Indices(object):

--- a/python/hail/expr/expression.py
+++ b/python/hail/expr/expression.py
@@ -1018,7 +1018,6 @@ class ArrayNumericExpression(ArrayExpression, CollectionNumericExpression):
             return TArray(TInt32())
 
         else:
-            print('HERE HERE HERE: %s %s' % (type(self), type(other)))
             raise NotImplementedError('''Error in return type for numeric conversion.
                 self = {}
                 other = {}'''.format(type(self), type(other)))

--- a/python/hail/expr/expression.py
+++ b/python/hail/expr/expression.py
@@ -834,7 +834,7 @@ class ArrayExpression(CollectionExpression):
         else:
             raise NotImplementedError
 
-    @typecheck_method(x=expr_any)
+    @typecheck_method(item=expr_any)
     def contains(self, item):
         """Returns a boolean indicating whether `item` is found in the array.
 

--- a/python/hail/expr/expression.py
+++ b/python/hail/expr/expression.py
@@ -1630,7 +1630,7 @@ class DictExpression(Expression):
         """
         return self._method("contains", TBoolean(), k)
 
-    @typecheck_method(item=expr_any)
+    @typecheck_method(k=expr_any)
     def get(self, k):
         """Returns the value associated with key `k`, or missing if that key is not present.
 

--- a/python/hail/expr/expression.py
+++ b/python/hail/expr/expression.py
@@ -6,68 +6,6 @@ from hail.utils.java import *
 from hail.genetics import Locus, Variant, Interval, Call, AltAllele
 
 
-class Indices(object):
-    @typecheck_method(source=anytype, axes=setof(strlike))
-    def __init__(self, source=None, axes=set()):
-        self.source = source
-        self.axes = axes
-
-    def __eq__(self, other):
-        return isinstance(other, Indices) and self.source is other.source and self.axes == other.axes
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
-    @staticmethod
-    def unify(*indices):
-        axes = set()
-        src = None
-        for ind in indices:
-            if src is None:
-                src = ind.source
-            else:
-                if ind.source is not None and ind.source is not src:
-                    raise ExpressionException('Cannot unify_all operations between {} and {}'.format(
-                        repr(src), repr(ind.source)))
-
-            intersection = axes.intersection(ind.axes)
-            left = axes - intersection
-            right = ind.axes - intersection
-            if right:
-                for i in left:
-                    info('broadcasting index {} along axes [{}]'.format(i, ', '.join(right)))
-            if left:
-                for i in right:
-                    info('broadcasting index {} along axes [{}]'.format(i, ', '.join(left)))
-
-            axes = axes.union(ind.axes)
-
-        return Indices(src, axes)
-
-
-class Aggregation(object):
-    def __init__(self, indices):
-        self.indices = indices
-
-
-class Join(object):
-    def __init__(self, join_function, temp_vars):
-        self.join_function = join_function
-        self.temp_vars = temp_vars
-
-
-@typecheck(ast=AST, type=Type, indices=Indices, aggregations=tupleof(Aggregation), joins=tupleof(Join))
-def construct_expr(ast, type, indices=Indices(), aggregations=(), joins=()):
-    if isinstance(type, TArray) and type.element_type.__class__ in elt_typ_to_array_expr:
-        return elt_typ_to_array_expr[type.element_type.__class__](ast, type, indices, aggregations, joins)
-    elif isinstance(type, TSet) and type.element_type.__class__ in elt_typ_to_set_expr:
-        return elt_typ_to_set_expr[type.element_type.__class__](ast, type, indices, aggregations, joins)
-    elif type.__class__ in typ_to_expr:
-        return typ_to_expr[type.__class__](ast, type, indices, aggregations, joins)
-    else:
-        raise NotImplementedError(type)
-
-
 def to_expr(e):
     if isinstance(e, Expression):
         return e
@@ -173,9 +111,109 @@ def to_expr(e):
         raise ValueError("Cannot implicitly capture value `{}' with type `{}'.".format(e, e.__class__))
 
 
-@decorator
-def args_to_expr(func, *args):
-    return func(*(to_expr(a) for a in args))
+_lazy_int32 = lazy()
+_lazy_numeric = lazy()
+_lazy_array = lazy()
+_lazy_set = lazy()
+_lazy_bool = lazy()
+_lazy_struct = lazy()
+_lazy_string = lazy()
+_lazy_variant = lazy()
+_lazy_locus = lazy()
+_lazy_altallele = lazy()
+_lazy_interval = lazy()
+_lazy_call = lazy()
+_lazy_expr = lazy()
+
+expr_int32 = transformed({_lazy_int32: identity,
+                          integral: to_expr})
+expr_numeric = transformed({_lazy_numeric: identity,
+                            integral: to_expr,
+                            float: to_expr})
+expr_list = transformed({list: to_expr,
+                         _lazy_array: identity})
+expr_set = transformed({set: to_expr,
+                        _lazy_set: identity})
+expr_bool = transformed({bool: to_expr,
+                         _lazy_bool: identity})
+expr_struct = transformed({Struct: to_expr,
+                           _lazy_struct: identity})
+expr_str = transformed({strlike: to_expr,
+                        _lazy_string: identity})
+expr_variant = transformed({Variant: to_expr,
+                            _lazy_variant: identity})
+expr_locus = transformed({Locus: to_expr,
+                          _lazy_locus: identity})
+expr_altallele = transformed({AltAllele: to_expr,
+                              _lazy_altallele: identity})
+expr_interval = transformed({Interval: to_expr,
+                             _lazy_interval: identity})
+expr_call = transformed({Call: to_expr,
+                         _lazy_call: identity})
+expr_any = transformed({_lazy_expr: identity,
+                        anytype: to_expr})
+
+
+class Indices(object):
+    @typecheck_method(source=anytype, axes=setof(strlike))
+    def __init__(self, source=None, axes=set()):
+        self.source = source
+        self.axes = axes
+
+    def __eq__(self, other):
+        return isinstance(other, Indices) and self.source is other.source and self.axes == other.axes
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    @staticmethod
+    def unify(*indices):
+        axes = set()
+        src = None
+        for ind in indices:
+            if src is None:
+                src = ind.source
+            else:
+                if ind.source is not None and ind.source is not src:
+                    raise ExpressionException('Cannot unify_all operations between {} and {}'.format(
+                        repr(src), repr(ind.source)))
+
+            intersection = axes.intersection(ind.axes)
+            left = axes - intersection
+            right = ind.axes - intersection
+            if right:
+                for i in left:
+                    info('broadcasting index {} along axes [{}]'.format(i, ', '.join(right)))
+            if left:
+                for i in right:
+                    info('broadcasting index {} along axes [{}]'.format(i, ', '.join(left)))
+
+            axes = axes.union(ind.axes)
+
+        return Indices(src, axes)
+
+
+class Aggregation(object):
+    def __init__(self, indices):
+        self.indices = indices
+
+
+class Join(object):
+    def __init__(self, join_function, temp_vars):
+        self.join_function = join_function
+        self.temp_vars = temp_vars
+
+
+@typecheck(ast=AST, type=Type, indices=Indices, aggregations=tupleof(Aggregation), joins=tupleof(Join))
+def construct_expr(ast, type, indices=Indices(), aggregations=(), joins=()):
+    if isinstance(type, TArray) and type.element_type.__class__ in elt_typ_to_array_expr:
+        return elt_typ_to_array_expr[type.element_type.__class__](ast, type, indices, aggregations, joins)
+    elif isinstance(type, TSet) and type.element_type.__class__ in elt_typ_to_set_expr:
+        return elt_typ_to_set_expr[type.element_type.__class__](ast, type, indices, aggregations, joins)
+    elif type.__class__ in typ_to_expr:
+        return typ_to_expr[type.__class__](ast, type, indices, aggregations, joins)
+    else:
+        raise NotImplementedError(type)
 
 
 def unify_all(*exprs):
@@ -197,7 +235,7 @@ def is_numeric(t):
     return t.__class__ in __numeric_types
 
 
-@typecheck(types=tupleof(Type))
+@typecheck(types=Type)
 def convert_numeric_typ(*types):
     priority_map = {t: p for t, p in zip(__numeric_types, range(len(__numeric_types)))}
     priority = 0
@@ -624,7 +662,6 @@ class CollectionExpression(Expression):
         return self._method("size", TInt32())
 
 
-
 class CollectionNumericExpression(CollectionExpression):
     """Expression of type :class:`hail.expr.types.TArray` or :class:`hail.expr.types.TSet` with numeric element type.
 
@@ -728,7 +765,7 @@ class CollectionNumericExpression(CollectionExpression):
         """
         return self._method("product",
                             TInt64() if isinstance(self._type.element_type, TInt32) or
-                                        isinstance(self._type.element_type, TInt64) else TFloat64)
+                                        isinstance(self._type.element_type, TInt64) else TFloat64())
 
     def sum(self):
         """Returns the sum of all elements in the collection.
@@ -757,7 +794,6 @@ class ArrayExpression(CollectionExpression):
 
     >>> a = functions.capture(['Alice', 'Bob', 'Charlie'])
     """
-
     def __getitem__(self, item):
         """Index into or slice the array.
 
@@ -832,6 +868,7 @@ class ArrayExpression(CollectionExpression):
         item = to_expr(item)
         return self.exists(lambda x: x == item)
 
+    @typecheck_method(x=expr_any)
     def append(self, x):
         """Append an element to the array and return the result.
 
@@ -854,6 +891,7 @@ class ArrayExpression(CollectionExpression):
         """
         return self._method("append", self._type, x)
 
+    @typecheck_method(a=expr_list)
     def extend(self, a):
         """Concatenate two arrays and return the result.
 
@@ -934,6 +972,7 @@ class ArrayNumericExpression(ArrayExpression, CollectionNumericExpression):
     >>> a2 = functions.capture([1, -1, 1, -1, 1, -1])
 
     """
+
     def _bin_op_ret_typ(self, other):
         if isinstance(self, ArrayNumericExpression) and isinstance(other, float):
             return TArray(TFloat64())
@@ -979,6 +1018,7 @@ class ArrayNumericExpression(ArrayExpression, CollectionNumericExpression):
             return TArray(TInt32())
 
         else:
+            print('HERE HERE HERE: %s %s' % (type(self), type(other)))
             raise NotImplementedError('''Error in return type for numeric conversion.
                 self = {}
                 other = {}'''.format(type(self), type(other)))
@@ -1260,7 +1300,7 @@ class SetExpression(CollectionExpression):
     >>> s1 = functions.capture({1, 2, 3})
     >>> s2 = functions.capture({1, 3, 5})
     """
-
+    @typecheck_method(x=expr_any)
     def add(self, x):
         """Returns a new set including `x`.
 
@@ -1283,6 +1323,7 @@ class SetExpression(CollectionExpression):
         """
         return self._method("add", self._type, x)
 
+    @typecheck_method(x=expr_any)
     def remove(self, x):
         """Returns a new set excluding `x`.
 
@@ -1305,6 +1346,7 @@ class SetExpression(CollectionExpression):
         """
         return self._method("remove", self._type, x)
 
+    @typecheck_method(x=expr_any)
     def contains(self, x):
         """Returns ``True`` if `x` is in the set.
 
@@ -1330,6 +1372,7 @@ class SetExpression(CollectionExpression):
         """
         return self._method("contains", TBoolean(), x)
 
+    @typecheck_method(s=expr_set)
     def difference(self, s):
         """Return the set of elements in the set that are not present in set `s`.
 
@@ -1355,6 +1398,7 @@ class SetExpression(CollectionExpression):
         """
         return self._method("difference", self._type, s)
 
+    @typecheck_method(s=expr_set)
     def intersection(self, s):
         """Return the intersection of the set and set `s`.
 
@@ -1377,6 +1421,7 @@ class SetExpression(CollectionExpression):
         """
         return self._method("intersection", self._type, s)
 
+    @typecheck_method(s=expr_set)
     def is_subset(self, s):
         """Returns ``True`` if every element is contained in set `s`.
 
@@ -1402,6 +1447,7 @@ class SetExpression(CollectionExpression):
         """
         return self._method("isSubset", TBoolean(), s)
 
+    @typecheck_method(s=expr_set)
     def union(self, s):
         """Return the union of the set and set `s`.
 
@@ -1471,6 +1517,7 @@ class SetStringExpression(SetExpression):
 
     >>> s = functions.capture({'Alice', 'Bob', 'Charles'})
     """
+    @typecheck_method(delimiter=expr_str)
     def mkstring(self, delimiter):
         """Joins the elements of the set into a single string delimited by `delimiter`.
 
@@ -1530,6 +1577,7 @@ class DictExpression(Expression):
         self._key_typ = self._type.key_type
         self._value_typ = self._type.value_type
 
+    @typecheck_method(item=expr_any)
     def __getitem__(self, item):
         """Get the value associated with key `item`.
 
@@ -1557,6 +1605,7 @@ class DictExpression(Expression):
         """
         return self._index(self._value_typ, item)
 
+    @typecheck_method(item=expr_any)
     def contains(self, k):
         """Returns whether a given key is present in the dictionary.
 
@@ -1582,6 +1631,7 @@ class DictExpression(Expression):
         """
         return self._method("contains", TBoolean(), k)
 
+    @typecheck_method(item=expr_any)
     def get(self, k):
         """Returns the value associated with key `k`, or missing if that key is not present.
 
@@ -1779,6 +1829,7 @@ class StructExpression(Expression):
 
 class AtomicExpression(Expression):
     """Abstract base class for numeric and logical types."""
+
     def to_float64(self):
         """Convert to a 64-bit floating point expression.
 
@@ -1835,10 +1886,12 @@ class BooleanExpression(AtomicExpression):
         None
 
     """
+
     def _bin_op_logical(self, name, other):
         other = to_expr(other)
         return self._bin_op(name, other, TBoolean())
 
+    @typecheck_method(other=expr_bool)
     def __and__(self, other):
         """Return ``True`` if the left and right arguments are ``True``.
 
@@ -1981,6 +2034,7 @@ class NumericExpression(AtomicExpression):
         ret_typ = self._bin_op_ret_typ(other)
         return self._bin_op_reverse(name, other, ret_typ)
 
+    @typecheck_method(other=expr_numeric)
     def __lt__(self, other):
         """Less-than comparison.
 
@@ -2003,6 +2057,7 @@ class NumericExpression(AtomicExpression):
         """
         return self._bin_op("<", other, TBoolean())
 
+    @typecheck_method(other=expr_numeric)
     def __le__(self, other):
         """Less-than-or-equals comparison.
 
@@ -2025,6 +2080,7 @@ class NumericExpression(AtomicExpression):
         """
         return self._bin_op("<=", other, TBoolean())
 
+    @typecheck_method(other=expr_numeric)
     def __gt__(self, other):
         """Greater-than comparison.
 
@@ -2047,6 +2103,7 @@ class NumericExpression(AtomicExpression):
         """
         return self._bin_op(">", other, TBoolean())
 
+    @typecheck_method(other=expr_numeric)
     def __ge__(self, other):
         """Greater-than-or-equals comparison.
 
@@ -2296,6 +2353,7 @@ class NumericExpression(AtomicExpression):
         """
         return self._method("abs", self._type)
 
+    @typecheck_method(other=expr_numeric)
     def max(self, other):
         """Returns the maximum value between the callee and `other`.
 
@@ -2312,6 +2370,7 @@ class NumericExpression(AtomicExpression):
         assert (isinstance(other, self.__class__))
         return self._method("max", self._type, other)
 
+    @typecheck_method(other=expr_numeric)
     def min(self, other):
         """Returns the minumum value between the callee and `other`.
 
@@ -2354,6 +2413,7 @@ class StringExpression(AtomicExpression):
 
     >>> s = functions.capture('The quick brown fox')
     """
+    @typecheck_method(item=oneof(slice, expr_int32))
     def __getitem__(self, item):
         """Slice or index into the string.
 
@@ -2430,6 +2490,7 @@ class StringExpression(AtomicExpression):
         """
         return self._method("length", TInt32())
 
+    @typecheck_method(pattern1=expr_str, pattern2=expr_str)
     def replace(self, pattern1, pattern2):
         """Replace substrings matching `pattern1` with `pattern2` using regex.
 
@@ -2456,6 +2517,7 @@ class StringExpression(AtomicExpression):
         """
         return self._method("replace", TString(), pattern1, pattern2)
 
+    @typecheck_method(delim=expr_str, n=nullable(expr_int32))
     def split(self, delim, n=None):
         """Returns an array of strings generated by splitting the string at `delim`.
 
@@ -2713,6 +2775,7 @@ class CallExpression(Expression):
         """
         return self._method("nNonRefAlleles", TInt32())
 
+    @typecheck_method(v=expr_variant)
     def one_hot_alleles(self, v):
         """Returns an array containing the summed one-hot encoding of the two alleles.
 
@@ -2742,6 +2805,7 @@ class CallExpression(Expression):
         """
         return self._method("oneHotAlleles", TArray(TInt32()), v)
 
+    @typecheck_method(v=expr_variant)
     def one_hot_genotype(self, v):
         """Returns the triangle number of the genotype one-hot encoded into an integer array.
 
@@ -2818,7 +2882,7 @@ class IntervalExpression(Expression):
 
     >>> interval = functions.capture(Interval.parse('X:1M-2M'))
     """
-    @typecheck_method(locus=oneof(LocusExpression, Locus))
+    @typecheck_method(locus=expr_locus)
     def contains(self, locus):
         """Tests whether a locus is contained in the interval.
 
@@ -3100,7 +3164,6 @@ class VariantExpression(Expression):
 
     >>> variant = functions.capture(Variant('16', 123055, 'A', 'C'))
     """
-
     def alt(self):
         """Returns the alternate allele string.
 
@@ -3545,7 +3608,7 @@ def analyze(expr, expected_indices, aggregation_axes, scoped_variables=None):
         raise errors[0]
 
 
-@args_to_expr
+@typecheck(expression=expr_any)
 def eval_expr(expression):
     """Evaluate a Hail expression, returning the result.
 
@@ -3578,7 +3641,7 @@ def eval_expr(expression):
     return eval_expr_typed(expression)[0]
 
 
-@args_to_expr
+@typecheck(expression=expr_any)
 def eval_expr_typed(expression):
     """Evaluate a Hail expression, returning the result and the type of the result.
 
@@ -3614,13 +3677,17 @@ def eval_expr_typed(expression):
     r, t = Env.hc().eval_expr_typed(expression._ast.to_hql())
     return r, t
 
-expr_int32 = oneof(Int32Expression, int)
-expr_numeric = oneof(Float32Expression, Float64Expression, Int64Expression, float, expr_int32)
-expr_list = oneof(list, ArrayExpression)
-expr_set = oneof(set, SetExpression)
-expr_bool = oneof(bool, BooleanExpression)
-expr_struct = oneof(Struct, StructExpression)
-expr_str = oneof(strlike, StringExpression)
-expr_variant = oneof(Variant, VariantExpression)
-expr_locus = oneof(Locus, LocusExpression)
-expr_call = oneof(Call, CallExpression)
+
+_lazy_int32.set(Int32Expression)
+_lazy_numeric.set(NumericExpression)
+_lazy_array.set(ArrayExpression)
+_lazy_set.set(SetExpression)
+_lazy_bool.set(BooleanExpression)
+_lazy_struct.set(StructExpression)
+_lazy_string.set(StringExpression)
+_lazy_variant.set(VariantExpression)
+_lazy_locus.set(LocusExpression)
+_lazy_altallele.set(AltAlleleExpression)
+_lazy_interval.set(IntervalExpression)
+_lazy_call.set(CallExpression)
+_lazy_expr.set(Expression)

--- a/python/hail/expr/expression.py
+++ b/python/hail/expr/expression.py
@@ -834,6 +834,7 @@ class ArrayExpression(CollectionExpression):
         else:
             raise NotImplementedError
 
+    @typecheck_method(x=expr_any)
     def contains(self, item):
         """Returns a boolean indicating whether `item` is found in the array.
 
@@ -865,7 +866,6 @@ class ArrayExpression(CollectionExpression):
         :py:class:`BooleanExpression`
             ``True`` if the element is found in the array, ``False`` otherwise.
         """
-        item = to_expr(item)
         return self.exists(lambda x: x == item)
 
     @typecheck_method(x=expr_any)
@@ -1604,7 +1604,7 @@ class DictExpression(Expression):
         """
         return self._index(self._value_typ, item)
 
-    @typecheck_method(item=expr_any)
+    @typecheck_method(k=expr_any)
     def contains(self, k):
         """Returns whether a given key is present in the dictionary.
 

--- a/python/hail/expr/functions.py
+++ b/python/hail/expr/functions.py
@@ -123,8 +123,7 @@ def broadcast(x):
     return construct_expr(GlobalJoinReference(uid), expr._type, joins=(Join(joiner, [uid]),))
 
 
-@typecheck(predicate=expr_bool, then_case=anytype, else_case=anytype)
-@args_to_expr
+@typecheck(predicate=expr_bool, then_case=expr_any, else_case=expr_any)
 def cond(predicate, then_case, else_case):
     """Expression for an if/else statement; tests a predicate and returns one of two options based on the result.
 
@@ -233,7 +232,6 @@ def bind(expr, f):
     return construct_expr(ast, lambda_result._type, indices, aggregations, joins)
 
 
-@args_to_expr
 @typecheck(c1=expr_int32, c2=expr_int32, c3=expr_int32, c4=expr_int32)
 def chisq(c1, c2, c3, c4):
     """Calculates p-value (Chi-square approximation) and odds ratio for a 2x2 table.
@@ -270,7 +268,6 @@ def chisq(c1, c2, c3, c4):
     return _func("chisq", ret_type, c1, c2, c3, c4)
 
 
-@args_to_expr
 @typecheck(left=expr_variant, right=expr_variant)
 def combine_variants(left, right):
     """Combines the alleles of two variants at the same locus to form a new variant.
@@ -301,7 +298,6 @@ def combine_variants(left, right):
 
 
 @typecheck(c1=expr_int32, c2=expr_int32, c3=expr_int32, c4=expr_int32, min_cell_count=expr_int32)
-@args_to_expr
 def ctt(c1, c2, c3, c4, min_cell_count):
     """Calculates p-value and odds ratio for 2x2 table.
 
@@ -345,7 +341,6 @@ def ctt(c1, c2, c3, c4, min_cell_count):
 
 
 @typecheck(keys=expr_list, values=expr_list)
-@args_to_expr
 def Dict(keys, values):
     """Creates a dictionary from a list of keys and a list of values.
 
@@ -380,7 +375,6 @@ def Dict(keys, values):
 
 
 @typecheck(x=expr_numeric, lamb=expr_numeric, log_p=expr_bool)
-@args_to_expr
 def dpois(x, lamb, log_p=False):
     """Compute the (log) probability density at x of a Poisson distribution with rate parameter `lamb`.
 
@@ -408,7 +402,7 @@ def dpois(x, lamb, log_p=False):
     return _func("dpois", TFloat64(), x, lamb, log_p)
 
 
-@typecheck(s=oneof(Struct, StructExpression), identifiers=tupleof(expr_str))
+@typecheck(s=oneof(Struct, StructExpression), identifiers=strlike)
 def drop(s, *identifiers):
     s = to_expr(s)
     ret_type = s._type._drop(*identifiers)
@@ -417,7 +411,6 @@ def drop(s, *identifiers):
 
 
 @typecheck(x=expr_numeric)
-@args_to_expr
 def exp(x):
     """Computes `e` raised to the power `x`.
 
@@ -440,7 +433,6 @@ def exp(x):
 
 
 @typecheck(c1=expr_int32, c2=expr_int32, c3=expr_int32, c4=expr_int32)
-@args_to_expr
 def fisher_exact_test(c1, c2, c3, c4):
     """Calculates the p-value, odds ratio, and 95% confidence interval with Fisher's exact test for a 2x2 table.
 
@@ -485,7 +477,6 @@ def fisher_exact_test(c1, c2, c3, c4):
 
 
 @typecheck(j=expr_int32, k=expr_int32)
-@args_to_expr
 def gt_index(j, k):
     """Convert from `j`/`k` pair to call index (the triangular number).
 
@@ -519,7 +510,6 @@ def gt_index(j, k):
 
 
 @typecheck(num_hom_ref=expr_int32, num_het=expr_int32, num_hom_var=expr_int32)
-@args_to_expr
 def hardy_weinberg_p(num_hom_ref, num_het, num_hom_var):
     """Compute Hardy-Weinberg Equilbrium p-value and heterozygosity ratio.
 
@@ -795,8 +785,7 @@ def parse_variant(s, reference_genome=None):
     return construct_expr(ApplyMethod('Variant({})'.format(reference_genome.name), s._ast),
                           TVariant(reference_genome), s._indices, s._aggregations, s._joins)
 
-
-@args_to_expr
+@typecheck(i=expr_int32)
 def call(i):
     """Construct a call expression from an integer or integer expression.
 
@@ -825,8 +814,7 @@ def call(i):
     return CallExpression(ApplyMethod('Call', i._ast), TCall(), i._indices, i._aggregations, i._joins)
 
 
-@args_to_expr
-@typecheck(expression=anytype)
+@typecheck(expression=expr_any)
 def is_defined(expression):
     """Returns ``True`` if the argument is not missing.
 
@@ -856,8 +844,7 @@ def is_defined(expression):
     return _func("isDefined", TBoolean(), expression)
 
 
-@args_to_expr
-@typecheck(expression=anytype)
+@typecheck(expression=expr_any)
 def is_missing(expression):
     """Returns ``True`` if the argument is missing.
 
@@ -887,7 +874,6 @@ def is_missing(expression):
     return _func("isMissing", TBoolean(), expression)
 
 
-@args_to_expr
 @typecheck(x=expr_numeric)
 def is_nan(x):
     """Returns ``True`` if the argument is ``NaN`` (not a number).
@@ -924,8 +910,7 @@ def is_nan(x):
     return _func("isnan", TBoolean(), x)
 
 
-@args_to_expr
-@typecheck(x=anytype)
+@typecheck(x=expr_any)
 def json(x):
     """Convert an expression to a JSON string expression.
 
@@ -989,7 +974,6 @@ def log(x, base=None):
         return _func("log", TFloat64(), x)
 
 
-@args_to_expr
 @typecheck(x=expr_numeric)
 def log10(x):
     """Take the logarithm of the `x` with base 10.
@@ -1015,7 +999,6 @@ def log10(x):
     return _func("log10", TFloat64(), x)
 
 
-@args_to_expr
 @typecheck(b=expr_bool)
 def logical_not(b):
     """Negates a boolean.
@@ -1049,15 +1032,13 @@ def logical_not(b):
     return _func("!", TBoolean(), b)
 
 
-@typecheck(s1=StructExpression, s2=StructExpression)
-@args_to_expr
+@typecheck(s1=expr_struct, s2=expr_struct)
 def merge(s1, s2):
     ret_type = s1._type._merge(s2._type)
     return _func("merge", ret_type, s1, s2)
 
 
-@typecheck(a=anytype, b=anytype)
-@args_to_expr
+@typecheck(a=expr_any, b=expr_any)
 def or_else(a, b):
     """If `a` is missing, return `b`.
 
@@ -1085,8 +1066,7 @@ def or_else(a, b):
     return _func("orElse", a._type, a, b)
 
 
-@args_to_expr
-@typecheck(predicate=expr_bool, value=anytype)
+@typecheck(predicate=expr_bool, value=expr_any)
 def or_missing(predicate, value):
     """Returns `value` if `predicate` is ``True``, otherwise returns missing.
 
@@ -1115,7 +1095,6 @@ def or_missing(predicate, value):
 
 @typecheck(x=expr_int32, n=expr_int32, p=expr_numeric,
            alternative=enumeration("two.sided", "greater", "less"))
-@args_to_expr
 def binom_test(x, n, p, alternative):
     """Performs a binomial test on `p` given `x` successes in `n` trials.
 
@@ -1155,7 +1134,6 @@ def binom_test(x, n, p, alternative):
     return _func("binomTest", TFloat64(), x, n, p, alternative)
 
 @typecheck(x=expr_numeric, df=expr_numeric)
-@args_to_expr
 def pchisqtail(x, df):
     """Returns the probability under the right-tail starting at x for a chi-squared
     distribution with df degrees of freedom.
@@ -1181,7 +1159,6 @@ def pchisqtail(x, df):
 
 
 @typecheck(x=expr_numeric)
-@args_to_expr
 def pnorm(x):
     """The cumulative probability function of a standard normal distribution.
 
@@ -1214,7 +1191,6 @@ def pnorm(x):
 
 
 @typecheck(x=expr_numeric, lamb=expr_numeric, lower_tail=expr_bool, log_p=expr_bool)
-@args_to_expr
 def ppois(x, lamb, lower_tail=True, log_p=False):
     """The cumulative probability function of a Poisson distribution.
 
@@ -1250,7 +1226,6 @@ def ppois(x, lamb, lower_tail=True, log_p=False):
 
 
 @typecheck(p=expr_numeric, df=expr_numeric)
-@args_to_expr
 def qchisqtail(p, df):
     """Inverts :py:meth:`hail.expr.functions.pchisqtail`.
 
@@ -1281,7 +1256,6 @@ def qchisqtail(p, df):
 
 
 @typecheck(p=expr_numeric)
-@args_to_expr
 def qnorm(p):
     """Inverts :py:meth:`hail.expr.functions.pnorm`.
 
@@ -1310,7 +1284,6 @@ def qnorm(p):
 
 
 @typecheck(p=expr_numeric, lamb=expr_numeric, lower_tail=expr_bool, log_p=expr_bool)
-@args_to_expr
 def qpois(p, lamb, lower_tail=True, log_p=False):
     """Inverts :py:meth:`hail.expr.functions.ppois`.
 
@@ -1344,7 +1317,6 @@ def qpois(p, lamb, lower_tail=True, log_p=False):
 
 
 @typecheck(start=expr_int32, stop=expr_int32, step=expr_int32)
-@args_to_expr
 def range(start, stop, step=1):
     """Returns an array of integers from `start` to `stop` by `step`.
 
@@ -1379,7 +1351,6 @@ def range(start, stop, step=1):
 
 
 @typecheck(p=expr_numeric)
-@args_to_expr
 def rand_bool(p):
     """Returns ``True`` with probability `p` (RNG).
 
@@ -1411,7 +1382,6 @@ def rand_bool(p):
 
 
 @typecheck(mean=expr_numeric, sd=expr_numeric)
-@args_to_expr
 def rand_norm(mean=0, sd=1):
     """Samples from a normal distribution with mean `mean` and standard deviation `sd` (RNG).
 
@@ -1445,7 +1415,6 @@ def rand_norm(mean=0, sd=1):
     return _func("rnorm", TFloat64(), mean, sd)
 
 
-@args_to_expr
 @typecheck(lamb=expr_numeric)
 def rand_pois(lamb):
     """Samples from a Poisson distribution with rate parameter `lamb` (RNG).
@@ -1478,7 +1447,6 @@ def rand_pois(lamb):
     return _func("rpois", TFloat64(), lamb)
 
 
-@args_to_expr
 @typecheck(min=expr_numeric, max=expr_numeric)
 def rand_unif(min, max):
     """Returns a random floating-point number uniformly drawn from the interval [`min`, `max`].
@@ -1513,7 +1481,7 @@ def rand_unif(min, max):
     return _func("runif", TFloat64(), min, max)
 
 
-@typecheck(s=oneof(Struct, StructExpression), identifiers=tupleof(expr_str))
+@typecheck(s=oneof(Struct, StructExpression), identifiers=strlike)
 def select(s, *identifiers):
     s = to_expr(s)
     ret_type = s._type._select(*identifiers)
@@ -1521,7 +1489,6 @@ def select(s, *identifiers):
 
 
 @typecheck(x=expr_numeric)
-@args_to_expr
 def sqrt(x):
     """Returns the square root of `x`.
 
@@ -1548,8 +1515,7 @@ def sqrt(x):
     return _func("sqrt", TFloat64(), x)
 
 
-@typecheck(x=anytype)
-@args_to_expr
+@typecheck(x=expr_any)
 def to_str(x):
     """Returns the string representation of `x`.
 

--- a/python/hail/typecheck/__init__.py
+++ b/python/hail/typecheck/__init__.py
@@ -16,4 +16,6 @@ __all__ = ['typecheck',
            'numeric',
            'char',
            'lazy',
-           'enumeration']
+           'enumeration',
+           'identity',
+           'transformed']

--- a/python/hail/typecheck/check.py
+++ b/python/hail/typecheck/check.py
@@ -144,7 +144,7 @@ class SizedTupleChecker(TypeChecker):
         super(SizedTupleChecker, self).__init__()
 
     def check(self, x):
-        if not isinstance(x, tuple):
+        if not (isinstance(x, tuple) and len(x) == len(self.ec)):
             raise TypecheckFailure
         x_ = []
         for tc, elt in zip(self.ec, x):
@@ -236,7 +236,7 @@ class ExactlyTypeChecker(TypeChecker):
 class CoercionChecker(MultipleTypeChecker):
     """Type checker that performs argument transformations.
 
-    The `fs` argument should be a varargs of 2-tuples which contain a
+    The `fs` argument should be a varargs of 2-tuples that each contain a
     TypeChecker and a lambda function, e.g.:
 
     ((only(int), lambda x: x * 2),
@@ -362,7 +362,6 @@ def check_all(f, args, kwargs, checks, is_method):
                 msg += 'function parameters with no defined type: %s' % unmatched_sig
             raise RuntimeError('%s: invalid typecheck signature: %s' % (name, msg))
 
-    # if f has varargs, tuple any unnamed args and pass that as a regular argument to the checker
     for i in range(len(pos_args)):
         arg = pos_args[i]
         argname = named_args[i] if i < len(named_args) else spec.varargs

--- a/python/hail/typecheck/tests.py
+++ b/python/hail/typecheck/tests.py
@@ -228,8 +228,10 @@ class ContextTests(unittest.TestCase):
 
     def test_coercion(self):
 
-        @typecheck(a=transformed({integral: lambda x: 'int', strlike: lambda x: 'str'}),
-                   b=listof(dictof(strlike, transformed({integral: lambda x: 'int', strlike: lambda x: 'str'}))))
+        @typecheck(a=transformed((integral, lambda x: 'int'),
+                                 (strlike, lambda x: 'str')),
+                   b=listof(dictof(strlike, transformed((integral, lambda x: 'int'),
+                                                        (strlike, lambda x: 'str')))))
         def foo(a, b):
             return a, b
 


### PR DESCRIPTION
This involves a rework of the varargs/kwargs typecheck semantics:

old:
```
@typecheck(args=tupleof(int), kwargs=dictof(str, int))
def f(*args, **kwargs):
```

new:
```
@typecheck(args=int, kwargs=int)
def f(*args, **kwargs):
```