### PR TITLE
filter on BlockMatrix

### DIFF
--- a/python/hail/linalg/matrix.py
+++ b/python/hail/linalg/matrix.py
@@ -1,4 +1,4 @@
-from hail.utils.java import Env, handle_py4j, scala_object
+from hail.utils.java import Env, handle_py4j, scala_object, jarray
 from hail.typecheck import *
 
 block_matrix_type = lazy()
@@ -49,5 +49,25 @@ class BlockMatrix(object):
     def __mul__(self, that):
         return BlockMatrix(self.hc,
             self._jbm.multiply(that._jbm))
+
+    @handle_py4j
+    @typecheck_method(cols_to_keep=listof(integral))
+    def filter_cols(self, cols_to_keep):
+        return BlockMatrix(self.hc,
+            self._jbm.filterCols(jarray(Env.jvm().long, cols_to_keep)))
+
+    @handle_py4j
+    @typecheck_method(rows_to_keep=listof(integral))
+    def filter_rows(self, rows_to_keep):
+        return BlockMatrix(self.hc,
+            self._jbm.filterRows(jarray(Env.jvm().long, rows_to_keep)))
+    
+    @handle_py4j
+    @typecheck_method(rows_to_keep=listof(integral),
+                      cols_to_keep=listof(integral))
+    def filter(self, rows_to_keep, cols_to_keep):
+        return BlockMatrix(self.hc,
+            self._jbm.filter(jarray(Env.jvm().long, rows_to_keep),
+                             jarray(Env.jvm().long, cols_to_keep)))
 
 block_matrix_type.set(BlockMatrix)

--- a/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
@@ -576,12 +576,185 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   }
   
   // keep is an array of distinct column indices
-  def filterCols(keep: Array[Long]): BlockMatrix =
-    new BlockMatrix(new BlockMatrixFilterColsRDD(this, keep.sorted), blockSize, rows, keep.length)
+  def filter(rowsToKeep: Array[Long], colsToKeep: Array[Long]): BlockMatrix =
+    new BlockMatrix(new BlockMatrixFilterRDD(this, rowsToKeep.sorted, colsToKeep.sorted),
+      blockSize, rowsToKeep.length, colsToKeep.length)
   
   def filterRows(keep: Array[Long]): BlockMatrix = this.transpose().filterCols(keep).transpose()
+  
+  def filterCols(keep: Array[Long]): BlockMatrix =
+    new BlockMatrix(new BlockMatrixFilterColsRDD(this, keep.sorted), blockSize, rows, keep.length)
 }
 
+case class BlockMatrixFilterRDDPartition(index: Int,
+  blockRowRanges: Array[(Int, Array[Int], Array[Int])],
+  blockColRanges: Array[(Int, Array[Int], Array[Int])]) extends Partition
+
+private class BlockMatrixFilterRDD(dm: BlockMatrix, rowsToKeep: Array[Long], colsToKeep: Array[Long])
+  extends RDD[((Int, Int), BDM[Double])](dm.blocks.sparkContext, Nil) {
+  require(rowsToKeep.nonEmpty && rowsToKeep.isIncreasing && rowsToKeep.head >= 0 && rowsToKeep.last < dm.rows)
+  require(colsToKeep.nonEmpty && colsToKeep.isIncreasing && colsToKeep.head >= 0 && colsToKeep.last < dm.cols)
+  
+  private val gp = dm.partitioner
+  private val blockSize = gp.blockSize
+  private val newGP = GridPartitioner(blockSize, rowsToKeep.length, colsToKeep.length)
+  
+  // allBlockRowRanges(newBlockRow) has elements of the form (blockRow, startIndices, endIndices) with blockRow increasing
+  //   startIndices.zip(endIndices) gives all row-index ranges in blockRow to be copied to ranges in newBlockRow
+  private val allBlockRowRanges: Array[Array[(Int, Array[Int], Array[Int])]] = {
+    val ab = new ArrayBuilder[(Int, Array[Int], Array[Int])]()
+    val startIndices = new ArrayBuilder[Int]()
+    val endIndices = new ArrayBuilder[Int]()
+
+    rowsToKeep
+      .grouped(blockSize)
+      .zipWithIndex
+      .map { case (rowsInNewBlock, newBlockRow) =>
+        ab.clear()
+
+        val newBlockNRows = newGP.blockRowNRows(newBlockRow)
+
+        var j = 0 // start index in newBlockRow
+        var k = 0 // end index in newBlockRow
+        while (j < newBlockNRows) {
+          startIndices.clear()
+          endIndices.clear()
+
+          var startRow = rowsInNewBlock(j)
+          val blockRow = (startRow / blockSize).toInt
+          val finalRowInBlockRow = blockRow * blockSize + gp.blockRowNRows(blockRow)
+
+          while (j < newBlockNRows && rowsInNewBlock(j) < finalRowInBlockRow) { // compute ranges for this blockRow
+            val startRow = rowsInNewBlock(j)
+            val startRowIndex = (startRow % blockSize).toInt // start index in blockRow
+            startIndices += startRowIndex
+
+            var endRow = startRow + 1
+            var k = j + 1
+            while (k < newBlockNRows && rowsInNewBlock(k) == endRow && endRow < finalRowInBlockRow) { // extend range
+              endRow += 1
+              k += 1
+            }
+            endIndices += ((endRow - 1) % blockSize + 1).toInt // end index in blockRow
+            j = k
+          }
+          ab += (blockRow, startIndices.result(), endIndices.result())
+        }
+        ab.result()
+      }.toArray
+  }
+  
+  // allBlockColRanges(newBlockCol) has elements of the form (blockCol, startIndices, endIndices) with blockCol increasing
+  //   startIndices.zip(endIndices) gives all column-index ranges in blockCol to be copied to ranges in newBlockCol
+  private val allBlockColRanges: Array[Array[(Int, Array[Int], Array[Int])]] = {
+    val ab = new ArrayBuilder[(Int, Array[Int], Array[Int])]()
+    val startIndices = new ArrayBuilder[Int]()
+    val endIndices = new ArrayBuilder[Int]()
+
+    colsToKeep
+      .grouped(blockSize)
+      .zipWithIndex
+      .map { case (colsInNewBlock, newBlockCol) =>
+        ab.clear()
+
+        val newBlockNCols = newGP.blockColNCols(newBlockCol)
+
+        var j = 0 // start index in newBlockCol
+        var k = 0 // end index in newBlockCol
+        while (j < newBlockNCols) {
+          startIndices.clear()
+          endIndices.clear()
+          
+          var startCol = colsInNewBlock(j)
+          val blockCol = (startCol / blockSize).toInt
+          val finalColInBlockCol = blockCol * blockSize + gp.blockColNCols(blockCol)
+
+          while (j < newBlockNCols && colsInNewBlock(j) < finalColInBlockCol) { // compute ranges for this blockCol
+            val startCol = colsInNewBlock(j)
+            val startColIndex = (startCol % blockSize).toInt // start index in blockCol
+            startIndices += startColIndex
+
+            var endCol = startCol + 1
+            var k = j + 1
+            while (k < newBlockNCols && colsInNewBlock(k) == endCol && endCol < finalColInBlockCol) { // extend range
+              endCol += 1
+              k += 1
+            }
+            endIndices += ((endCol - 1) % blockSize + 1).toInt  // end index in blockCol
+            j = k
+          }
+          ab += (blockCol, startIndices.result(), endIndices.result())
+        }
+        ab.result()
+      }.toArray
+  }
+
+  protected def getPartitions: Array[Partition] =
+    Array.tabulate(newGP.numPartitions) { pi => 
+      BlockMatrixFilterRDDPartition(pi,
+        allBlockRowRanges(newGP.blockBlockRow(pi)),
+        allBlockColRanges(newGP.blockBlockCol(pi)))
+    }
+  
+  override def getDependencies: Seq[Dependency[_]] = Array[Dependency[_]](
+    new NarrowDependency(dm.blocks) {
+      def getParents(partitionId: Int): Seq[Int] = {
+        val (newBlockRow, newBlockCol) = newGP.blockCoordinates(partitionId)
+
+        for {
+          blockRow <- allBlockRowRanges(newBlockRow).map(_._1)
+          blockCol <- allBlockColRanges(newBlockCol).map(_._1)
+        } yield gp.coordinatesBlock(blockRow, blockCol)
+      }
+    })
+  
+  def compute(split: Partition, context: TaskContext): Iterator[((Int, Int), BDM[Double])] = {
+    val (newBlockRow, newBlockCol) = newGP.blockCoordinates(split.index)
+    val (newBlockNRows, newBlockNCols) = newGP.blockDims(split.index)
+    val newBlock = BDM.zeros[Double](newBlockNRows, newBlockNCols)
+    
+    val part = split.asInstanceOf[BlockMatrixFilterRDDPartition]
+    
+    var jCol = 0
+    var kCol = 0
+    part.blockColRanges.foreach { case (blockCol, colStartIndices, colEndIndices) =>
+      var colRangeIndex = 0
+      while (colRangeIndex < colStartIndices.length) {
+        val siCol = colStartIndices(colRangeIndex)
+        val eiCol = colEndIndices(colRangeIndex)
+        kCol = jCol + eiCol - siCol
+
+        var jRow = 0
+        var kRow = 0
+        part.blockRowRanges.foreach { case (blockRow, rowStartIndices, rowEndIndices) =>
+          val parentPI = gp.coordinatesBlock(blockRow, blockCol)
+          val (_, block) = dm.blocks.iterator(dm.blocks.partitions(parentPI), context).next()
+          
+          var rowRangeIndex = 0
+          while (rowRangeIndex < rowStartIndices.length) {
+            val siRow = rowStartIndices(rowRangeIndex)
+            val eiRow = rowEndIndices(rowRangeIndex)
+            kRow = jRow + eiRow - siRow
+            
+            newBlock(jRow until kRow, jCol until kCol) := block(siRow until eiRow, siCol until eiCol)
+
+            jRow = kRow
+            rowRangeIndex += 1
+          }
+        }
+        assert(jRow == newBlockNRows)
+        
+        jCol = kCol
+        colRangeIndex += 1
+      }
+    }
+    assert(jCol == newBlockNCols)
+    
+    Iterator.single(((newBlockRow, newBlockCol), newBlock))
+  }
+  
+  @transient override val partitioner: Option[Partitioner] = Some(newGP)
+}
 
 case class BlockMatrixFilterColsRDDPartition(index: Int, blockColRanges: Array[(Int, Array[Int], Array[Int])]) extends Partition
 
@@ -665,6 +838,7 @@ private class BlockMatrixFilterColsRDD(dm: BlockMatrix, colsToKeep: Array[Long])
       .foreach { case (blockCol, startIndices, endIndices) =>
         val parentPI = gp.coordinatesBlock(blockRow, blockCol)
         val (_, block) = dm.blocks.iterator(dm.blocks.partitions(parentPI), context).next()
+        
         var colRangeIndex = 0
         while (colRangeIndex < startIndices.length) {
           val si = startIndices(colRangeIndex)
@@ -678,7 +852,7 @@ private class BlockMatrixFilterColsRDD(dm: BlockMatrix, colsToKeep: Array[Long])
         }
       }
     assert(j == newBlockNCols)
-    
+        
     Iterator.single(((blockRow, newBlockCol), newBlock))
   }
   

--- a/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
@@ -574,6 +574,25 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       .map { case (i, a) => IndexedRow(i, new DenseVector(a)) },
       rows, cols)
   }
+  
+  def filterCols(keep: Array[Long]): BlockMatrix = {
+    if (keep.isEmpty) {
+      fatal("error filtering columns: at least one column must remain")
+    }
+    
+    scala.util.Sorting.quickSort(keep)
+    assert(keep.sortedAreDistinct() && keep.head >= 0 && keep.last < rows) // require distinct?
+    
+    
+    
+    this
+  }
+}
+
+case class BlockMatrixFilterRDDPartition(index: Int) extends Partition // add fields
+
+private class BlockMatrixFilterRDD(dm: BlockMatrix, keep: Array[Long]) extends RDD(dm.blocks.sparkContext, Nil) {
+  
 }
 
 case class BlockMatrixTransposeRDDPartition(index: Int, prevPartition: Partition) extends Partition

--- a/src/main/scala/is/hail/utils/richUtils/RichIterable.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichIterable.scala
@@ -133,18 +133,6 @@ class RichIterable[T](val i: Iterable[T]) extends Serializable {
     true
   }
 
-  def sortedAreDistinct(): Boolean = {
-    if (i.nonEmpty) {
-      var last = i.head
-      for (x <- i.tail)
-        if (x == last)
-          return false
-        else
-          last = x
-    }
-    true
-  }
-  
   def duplicates(): Set[T] = {
     val dups = mutable.HashSet[T]()
     val seen = mutable.HashSet[T]()

--- a/src/main/scala/is/hail/utils/richUtils/RichIterable.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichIterable.scala
@@ -133,6 +133,18 @@ class RichIterable[T](val i: Iterable[T]) extends Serializable {
     true
   }
 
+  def sortedAreDistinct(): Boolean = {
+    if (i.nonEmpty) {
+      var last = i.head
+      for (x <- i.tail)
+        if (x == last)
+          return false
+        else
+          last = x
+    }
+    true
+  }
+  
   def duplicates(): Set[T] = {
     val dups = mutable.HashSet[T]()
     val seen = mutable.HashSet[T]()

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -599,20 +599,19 @@ class BlockMatrixSuite extends SparkSuite {
   
   @Test
   def filterBlockMatrix() {
-    val lm = new BDM[Double](10, 10, (0 until 100).map(_.toDouble).toArray)
+    val lm = new BDM[Double](9, 10, (0 until 90).map(_.toDouble).toArray)
 
-    for { blockSize <- Seq(1, 2, 3, 10, 11)
+    for { blockSize <- Seq(1, 2, 3, 5, 10, 11)
     } {
       val bm = BlockMatrix.from(sc, lm, blockSize)      
       for { keep <- Seq(
         Array(0),
         Array(1),
         Array(9),
+        Array(0, 3, 4, 5, 7),
         Array(1, 4, 5, 7, 8, 9),
         Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
       } {
-        println()
-        println(blockSize, keep.toIndexedSeq)
         val filteredViaBlock = bm.filterCols(keep.map(_.toLong)).toLocalMatrix()
         val filteredViaBreeze = lm(::, keep.toIndexedSeq).copy
         

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -619,4 +619,25 @@ class BlockMatrixSuite extends SparkSuite {
       }
     }
   }
+  
+  @Test
+  def filterBlockMatrixTranspose() {
+    val lm = new BDM[Double](9, 10, (0 until 90).map(_.toDouble).toArray)
+    val lmt = lm.t
+
+    for { blockSize <- Seq(2, 3)
+    } {
+      val bm = BlockMatrix.from(sc, lm, blockSize).transpose()   
+      for { keep <- Seq(
+        Array(0),
+        Array(1, 4, 5, 7, 8),
+        Array(0, 1, 2, 3, 4, 5, 6, 7, 8))
+      } {
+        val filteredViaBlock = bm.filterCols(keep.map(_.toLong)).toLocalMatrix()
+        val filteredViaBreeze = lmt(::, keep.toIndexedSeq).copy
+        
+        assert(filteredViaBlock === filteredViaBreeze)
+      }
+    }
+  }
 }

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -596,4 +596,13 @@ class BlockMatrixSuite extends SparkSuite {
     
     assert(lm === lm2)
   }
+  
+  @Test
+  def filterBlockMatrix() {
+    val bm = BlockMatrix.random(hc, 10, 10, 8)
+    
+    val keep = Array(2, 4, 7)
+    
+    bm.filterCols(keep)
+  }
 }

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -608,13 +608,14 @@ class BlockMatrixSuite extends SparkSuite {
         Array(0),
         Array(1),
         Array(9),
-        Array(0, 1, 4, 5),
-        Array(4, 5, 6, 7, 8),
+        Array(1, 4, 5, 7, 8, 9),
         Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
       } {
+        println()
+        println(blockSize, keep.toIndexedSeq)
         val filteredViaBlock = bm.filterCols(keep.map(_.toLong)).toLocalMatrix()
         val filteredViaBreeze = lm(::, keep.toIndexedSeq).copy
-  
+        
         assert(filteredViaBlock === filteredViaBreeze)
       }
     }

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -598,7 +598,7 @@ class BlockMatrixSuite extends SparkSuite {
   }
   
   @Test
-  def filterBlockMatrix() {
+  def filterBlockMatrixCols() {
     val lm = new BDM[Double](9, 10, (0 until 90).map(_.toDouble).toArray)
 
     for { blockSize <- Seq(1, 2, 3, 5, 10, 11)
@@ -621,7 +621,7 @@ class BlockMatrixSuite extends SparkSuite {
   }
   
   @Test
-  def filterBlockMatrixTranspose() {
+  def filterBlockMatrixColsTranspose() {
     val lm = new BDM[Double](9, 10, (0 until 90).map(_.toDouble).toArray)
     val lmt = lm.t
 

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -599,10 +599,24 @@ class BlockMatrixSuite extends SparkSuite {
   
   @Test
   def filterBlockMatrix() {
-    val bm = BlockMatrix.random(hc, 10, 10, 8)
-    
-    val keep = Array(2, 4, 7)
-    
-    bm.filterCols(keep)
+    val lm = new BDM[Double](10, 10, (0 until 100).map(_.toDouble).toArray)
+
+    for { blockSize <- Seq(1, 2, 3, 10, 11)
+    } {
+      val bm = BlockMatrix.from(sc, lm, blockSize)      
+      for { keep <- Seq(
+        Array(0),
+        Array(1),
+        Array(9),
+        Array(0, 1, 4, 5),
+        Array(4, 5, 6, 7, 8),
+        Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
+      } {
+        val filteredViaBlock = bm.filterCols(keep.map(_.toLong)).toLocalMatrix()
+        val filteredViaBreeze = lm(::, keep.toIndexedSeq).copy
+  
+        assert(filteredViaBlock === filteredViaBreeze)
+      }
+    }
   }
 }

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -640,4 +640,24 @@ class BlockMatrixSuite extends SparkSuite {
       }
     }
   }
+  
+  @Test
+  def filterBlockMatrixRows() {
+    val lm = new BDM[Double](9, 10, (0 until 90).map(_.toDouble).toArray)
+    
+    for { blockSize <- Seq(2, 3)
+    } {
+      val bm = BlockMatrix.from(sc, lm, blockSize) 
+      for { keep <- Seq(
+        Array(0),
+        Array(1, 4, 5, 7, 8),
+        Array(0, 1, 2, 3, 4, 5, 6, 7, 8))
+      } {
+        val filteredViaBlock = bm.filterRows(keep.map(_.toLong)).toLocalMatrix()
+        val filteredViaBreeze = lm(keep.toIndexedSeq, ::).copy
+        
+        assert(filteredViaBlock === filteredViaBreeze)
+      }
+    }
+  }
 }


### PR DESCRIPTION
This adds filter, filterCols, and filterRows to BlockMatrix, en route to moving kinship and LD matrix to from IRM to BlockMatrix. For example, filtering out rows/columns from a kinship matrix (e.g. to remove samples with missing covariate data); or filtering an LD matrix (e.g. to perform Leave-One-Chromosome-Out LMM analysis).

Since the number of tasks equals the number of resulting partitions (blocks), these functions are suited to filtering out a small to medium subset (say, throwing out a few rows and columns, or half of the rows and columns) and may fail when filtering all but a small number of rows and columns due to all the blocks being sent to one executor. In the latter case, one can do better by writing the result of filterCols, then reading and applying filterRows.

Testing locally, on a 16384 * 16384 matrix (block size 4096, 16 partitions, 128MB each), when only filtering columns (or rows), filterCols (or filterRows) tends to be faster than filter (likely due to less copying), and filterCols tends to be a bit faster than filterRows (which I think is due to lack of transpose and esp. better striding). When filtering both columns and rows, filter tends to be fastest but filter_columns followed by filter_rows is often comparable. It may be that the cost of an additional copy in the first step is offset by smaller strides resulting better caching in the second step.

For example, filtering out every 31st row and column:
```
filter
[9.550655126571655, 9.62321400642395]
filterCols.filterRows
[12.190248966217041, 12.07064700126648]
filterRows.filterCols
[14.239542007446289, 15.601837158203125]
```
Filtering out every row and column with 0.5 probability, resulting in 4 partitions:
```
filter
[4.625396966934204, 4.427164077758789, 4.435616970062256]
filterCols.filterRows
[4.647814035415649, 4.610292911529541, 4.655405044555664]
filterRows.filterCols
[4.866307973861694, 5.073392868041992, 5.470307111740112]
```

On GCP, with 32 core highmem master and 176 cores (2 workers + 20 prempt, 8 core standard), reading and writing a 100k by 100k matrix M with 4096 block size (625 partitions, each 128MB, 80GB total) takes about 25s. Even with this 3.5 to 1 ratio of partitions to cores, there is a lot of volatility running the same operations multiple times. I've documented some experiments below, the main conclusion is that these functions should work well for the use cases above and while those are being developed and we experiment more on real data, I think it makes sense to include all three: filterCols, filterRows (implemented via filterCols and transpose), and filter.

```
from hail import *
from hail.linalg import *
import timeit
from random import randint

hc = HailContext(log='/hail/hail.log')

def time(name, f, number=1, repeat=3):
    print('running:', name)
    d = timeit.repeat(f, number=number, repeat=repeat)
    print(name, d)

size = 100000
block_size = 4096
mod = 31
alll = range(0, size)

keep = filter(lambda i: i % mod != 0, alll)
keepS = filter(lambda i: i % mod == 0, alll)
keepR = filter(lambda i: randint(0,1) == 0, alll)

pathC = 'gs://jbloom/block_filter/C.bm'
pathCfilt = 'gs://jbloom/block_filter/Cfilt.bm'

# 29s
def writeC():
    BlockMatrix.random(size, size, block_size).write(pathC)

# 25s
def readwrite():
    BlockMatrix.read('gs://jbloom/block_filter/C.bm').write(pathC)

## keep all
# ('filtnone', [50.187114000320435, 37.279563903808594, 39.105873823165894])
# ('filtnone2', [42.968636989593506, 90.15687894821167, 53.434531927108765])
# ('filtnone3', [38.40539002418518, 106.12774705886841, 51.939454078674316])
def filtnone():
    C = BlockMatrix.read(pathC)
    C.filter(alll, alll).write(pathCfilt)
def filtnone2():
    C = BlockMatrix.read(pathC)
    C.filter_rows(alll).filter_cols(alll).write(pathCfilt)
def filtnone3():
    C = BlockMatrix.read(pathC)
    C.filter_cols(alll).filter_rows(alll).write(pathCfilt)

## remove each row and col with .5 prob
# ('filtR', [38.61059308052063, 35.43895888328552, 57.82970595359802])
# ('filt2R', [37.06329607963562, 34.83527898788452, 37.52358818054199])
# ('filt3R', [34.79560899734497, 35.761980056762695, 78.56368398666382])
def filtR():
    C = BlockMatrix.read(pathC)
    C.filter(keepR, keepR).write(pathCfilt)
def filt2R():
    C = BlockMatrix.read(pathC)
    C.filter_rows(keepR).filter_cols(keepR).write(pathCfilt)
def filt3R():
    C = BlockMatrix.read(pathC)
    C.filter_cols(keepR).filter_rows(keepR).write(pathCfilt)

## keep 30/31 rows and cols (i % 31 != 0)
# ('filt', [57.02336001396179, 54.873445987701416, 53.126954078674316])
# ('filt2', [58.207281827926636, 60.20579814910889, 57.53346490859985])
# ('filt3', [108.86680817604065, 71.24583005905151, 55.10001802444458])
def filt():
    C = BlockMatrix.read(pathC)
    C.filter(keep, keep).write(pathCfilt)
def filt2():
    C = BlockMatrix.read(pathC)
    C.filter_rows(keep).filter_cols(keep).write(pathCfilt)
def filt3():
    C = BlockMatrix.read(pathC)
    C.filter_cols(keep).filter_rows(keep).write(pathCfilt)

## keep 30/31 cols and all rows (or vice versa)
# ('filt_cols', [57.32737994194031, 33.26124596595764, 33.395057916641235])
# ('filt_rows', [49.38128685951233, 47.55074596405029, 100.86482095718384])
# ('filt_cols2', [42.00072693824768, 45.933130979537964, 41.59523010253906])
# ('filt_rows2', [41.70167016983032, 41.66839098930359, 60.907771825790405])
def filt_cols():
    C = BlockMatrix.read(pathC)
    C.filter_cols(keep).write(pathCfilt)
def filt_rows():
    C = BlockMatrix.read(pathC)
    C.filter_rows(keep).write(pathCfilt)
def filt_cols2():
    C = BlockMatrix.read(pathC)
    C.filter(alll, keep).write(pathCfilt)
def filt_rows2():
    C = BlockMatrix.read(pathC)
    C.filter(keep, alll).write(pathCfilt)

## keep 30/31 cols and 1/31 rows (only 24 partitions result => only 24 cores uses)
# ('filtDS', [136.84060502052307, 134.0212321281433, 134.53289103507996])
# ('filt2DS', [147.68482112884521, 149.9198350906372, 115.02943587303162])
# ('filt3DS', [91.42765092849731, 93.03190994262695, 105.57131218910217])
def filtDS():
    C = BlockMatrix.read(pathC)
    C.filter(keep, keepS).write(pathCfilt)
def filt2DS():
    C = BlockMatrix.read(pathC)
    C.filter_rows(keep).filter_cols(keepS).write(pathCfilt)
def filt3DS():
    C = BlockMatrix.read(pathC)
    C.filter_cols(keepS).filter_rows(keep).write(pathCfilt)
```
  
  