### PR TITLE
RowMatrix.readBlockMatrix with RowPartitioner

### DIFF
--- a/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
@@ -281,15 +281,18 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   /**
     * Writes the matrix {@code m} to a Hadoop sequence file at location {@code uri}.
     **/
-  def write(uri: String) {
+  def write(uri: String, forceRowMajor: Boolean = false) {
     val hadoop = blocks.sparkContext.hadoopConfiguration
     hadoop.mkDir(uri)
 
     def writeBlock(i: Int, it: Iterator[((Int, Int), BDM[Double])], os: OutputStream): Int = {
       assert(it.hasNext)
-      val (_, bdm) = it.next()
+      var bdm = it.next()._2
       assert(!it.hasNext)
-
+ 
+      if (forceRowMajor)
+        bdm = bdm.forceRowMajor()
+      
       val dos = new DataOutputStream(os)
       bdm.write(dos)
       dos.close()

--- a/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
@@ -279,7 +279,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   }
 
   /**
-    * Writes the matrix {@code m} to a Hadoop sequence file at location {@code uri}.
+    * Write {@code this} to a Hadoop sequence file at location {@code uri}.
     **/
   def write(uri: String, forceRowMajor: Boolean = false) {
     val hadoop = blocks.sparkContext.hadoopConfiguration

--- a/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
@@ -1031,7 +1031,7 @@ class WriteBlocksRDD(path: String,
     val firstRowInBlock = blockRow.toLong * blockSize
     val nRowsInBlock = gp.blockRowNRows(blockRow)
 
-    val dosArray = Array.tabulate(gp.nBlockCols) { blockCol =>
+    val dosPerBlockCol = Array.tabulate(gp.nBlockCols) { blockCol =>
       val nColsInBlock = gp.blockColNCols(blockCol)
 
       val is = gp.coordinatesBlock(blockRow, blockCol).toString
@@ -1087,7 +1087,7 @@ class WriteBlocksRDD(path: String,
             sampleIndex += 1
             j += 1
           }
-          dosArray(blockCol).write(bytes, 0, n << 3)
+          dosPerBlockCol(blockCol).write(bytes, 0, n << 3)
 
           blockCol += 1
         }
@@ -1095,7 +1095,7 @@ class WriteBlocksRDD(path: String,
       }
     }
 
-    dosArray.foreach(_.close())
+    dosPerBlockCol.foreach(_.close())
 
     Iterator.single(gp.nBlockCols) // number of blocks written
   }

--- a/src/main/scala/is/hail/distributedmatrix/RowMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/RowMatrix.scala
@@ -47,13 +47,13 @@ object RowMatrix {
     val gp = readGridPartitioner(hc, uri)
     val partitionCounts = computePartitionCounts(partSize, gp.nRows)
         
-    RowMatrix(new ReadBlocksAsRowsRDD(uri, hc.sc, partitionCounts, gp), gp.nCols.toInt, gp.nRows, partitionCounts)    
+    RowMatrix(hc, new ReadBlocksAsRowsRDD(uri, hc.sc, partitionCounts, gp), gp.nCols.toInt, gp.nRows, partitionCounts)    
   }
   
   def readBlockMatrix(hc: HailContext, uri: String, partitionCounts: Array[Long]): RowMatrix = {
     val gp = readGridPartitioner(hc, uri)
     
-    RowMatrix(new ReadBlocksAsRowsRDD(uri, hc.sc, partitionCounts, gp), gp.nCols.toInt, gp.nRows, partitionCounts)
+    RowMatrix(hc, new ReadBlocksAsRowsRDD(uri, hc.sc, partitionCounts, gp), gp.nCols.toInt, gp.nRows, partitionCounts)
   }
 }
 

--- a/src/main/scala/is/hail/distributedmatrix/RowMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/RowMatrix.scala
@@ -252,5 +252,5 @@ class ReadBlocksAsRowsRDD(path: String,
     }
   }
   
-  @transient override val partitioner: Option[Partitioner] = Some(RowPartitioner.fromPartitionStarts(partitionStarts))
+  @transient override val partitioner: Option[Partitioner] = Some(RowPartitioner(partitionStarts))
 }

--- a/src/main/scala/is/hail/distributedmatrix/RowMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/RowMatrix.scala
@@ -1,8 +1,15 @@
 package is.hail.distributedmatrix
 
+import java.io.DataInputStream
+
+import breeze.linalg.DenseMatrix
 import is.hail.HailContext
+import is.hail.annotations.Memory
 import is.hail.utils._
+import org.apache.commons.lang3.StringUtils
+import org.apache.spark.{Partition, Partitioner, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
+import org.json4s.jackson
 
 object RowMatrix {
   def apply(hc: HailContext, rows: RDD[(Long, Array[Double])], nCols: Int): RowMatrix =
@@ -13,6 +20,41 @@ object RowMatrix {
   
   def apply(hc: HailContext, rows: RDD[(Long, Array[Double])], nCols: Int, nRows: Long, partitionCounts: Array[Long]): RowMatrix =
     new RowMatrix(hc, rows, nCols, Some(nRows), Some(partitionCounts))
+    
+  def readGridPartitioner(hc: HailContext, uri: String): GridPartitioner = {
+    val hadoop = hc.hadoopConf
+    
+    if (!hadoop.exists(uri + "/_SUCCESS"))
+      fatal("Write failed: no success indicator found")
+    
+    val BlockMatrixMetadata(blockSize, nRows, nCols) =
+      hadoop.readTextFile(uri + BlockMatrix.metadataRelativePath) { isr  =>
+        jackson.Serialization.read[BlockMatrixMetadata](isr)
+      }
+    
+    GridPartitioner(blockSize, nRows, nCols)
+  }
+
+  def computePartitionCounts(partSize: Long, nRows: Long): Array[Long] = {
+    val nParts = ((nRows - 1) / partSize).toInt + 1
+    val partitionCounts = Array.fill[Long](nParts)(partSize)
+    partitionCounts(nParts - 1) = nRows - partSize * (nParts - 1)
+    
+    partitionCounts
+  }
+  
+  def readBlockMatrix(hc: HailContext, uri: String, partSize: Int): RowMatrix = {
+    val gp = readGridPartitioner(hc, uri)
+    val partitionCounts = computePartitionCounts(partSize, gp.nRows)
+        
+    RowMatrix(new ReadBlocksAsRowsRDD(uri, hc.sc, partitionCounts, gp), gp.nCols.toInt, gp.nRows, partitionCounts)    
+  }
+  
+  def readBlockMatrix(hc: HailContext, uri: String, partitionCounts: Array[Long]): RowMatrix = {
+    val gp = readGridPartitioner(hc, uri)
+    
+    RowMatrix(new ReadBlocksAsRowsRDD(uri, hc.sc, partitionCounts, gp), gp.nCols.toInt, gp.nRows, partitionCounts)
+  }
 }
 
 class RowMatrix(val hc: HailContext,
@@ -40,6 +82,20 @@ class RowMatrix(val hc: HailContext,
   // length nPartitions + 1, first element 0, last element rdd2 count
   def partitionStarts(): Array[Long] = partitionCounts().scanLeft(0L)(_ + _)
     
+  def toLocalMatrix(): DenseMatrix[Double] = {
+    // if _nRows is defined, check that it's a valid Int
+    require(_nRows.forall(_ <= Int.MaxValue), "The number of rows of this matrix should be less than or equal to " +
+        s"Int.MaxValue. Currently numRows: ${ _nRows.get }")
+    
+    val a = rows.map(_._2).collect() // fails if nRows > Int.MaxValue
+    val nRowsInt = a.length
+    
+    require(nRowsInt * nCols.toLong <= Int.MaxValue, "The length of the values array must be " +
+      s"less than or equal to Int.MaxValue. Currently rows * cols: ${ nRowsInt * nCols.toLong }")    
+    
+    new DenseMatrix[Double](nRowsInt, nCols, a.flatten, 0, nCols, isTranspose = true)
+  }
+  
   def export(path: String, columnDelimiter: String, header: Option[String], exportType: Int) {
     val localNCols = nCols
     exportDelimitedRowSlices(path, columnDelimiter, header, exportType, _ => 0, _ => localNCols)
@@ -105,4 +161,96 @@ class RowMatrix(val hc: HailContext,
       }.filter(_.nonEmpty)
     }.writeTable(path, hc.tmpDir, header, exportType)
   }
+}
+
+// [`start`, `end`) is the row range of partition
+case class ReadBlocksAsRowsRDDPartition(index: Int, start: Long, end: Long) extends Partition
+
+class ReadBlocksAsRowsRDD(path: String,
+  sc: SparkContext,
+  partitionCounts: Array[Long],
+  gp: GridPartitioner) extends RDD[(Long, Array[Double])](sc, Nil) {
+  
+  private val partitionStarts = partitionCounts.scanLeft(0L)(_ + _)
+  
+  if (partitionStarts.last != gp.nRows)
+    fatal(s"Error reading BlockMatrix as RowMatrix: expected ${partitionStarts.last} rows in RowMatrix, but found ${gp.nRows} rows in BlockMatrix")
+
+  if (gp.nCols > Int.MaxValue)
+      fatal(s"Cannot read BlockMatrix with ${gp.nCols} > Int.MaxValue columns as a RowMatrix")
+  
+  private val nCols = gp.nCols.toInt
+  private val nBlockCols = gp.nBlockCols
+  private val blockSize = gp.blockSize
+
+  private val d = digitsNeeded(gp.numPartitions)
+  private val sHadoopBc = sc.broadcast(new SerializableHadoopConfiguration(sc.hadoopConfiguration))
+
+  protected def getPartitions: Array[Partition] = Array.tabulate(partitionStarts.length - 1)(pi => 
+    ReadBlocksAsRowsRDDPartition(pi, partitionStarts(pi), partitionStarts(pi + 1)))
+
+  def compute(split: Partition, context: TaskContext): Iterator[(Long, Array[Double])] = {
+    val ReadBlocksAsRowsRDDPartition(_, start, end) = split.asInstanceOf[ReadBlocksAsRowsRDDPartition]
+
+    var disArray = new Array[DataInputStream](nBlockCols)
+    val buf = new Array[Byte](blockSize << 3)
+
+    var i = start
+
+    new Iterator[(Long, Array[Double])] {
+      def hasNext: Boolean = i < end
+
+      def next(): (Long, Array[Double]) = {
+        if (i == start || i % blockSize == 0) {
+          val blockRow = (i / blockSize).toInt
+          val nRowsInBlock = gp.blockRowNRows(blockRow)
+          
+          disArray = Array.tabulate(gp.nBlockCols) { blockCol =>
+            val is = gp.coordinatesBlock(blockRow, blockCol).toString
+            assert(is.length <= d)
+            val pis = StringUtils.leftPad(is, d, "0")
+            val filename = path + "/parts/part-" + pis
+
+            val dis = new DataInputStream(sHadoopBc.value.value.unsafeReader(filename))
+
+            val nColsInBlock = gp.blockColNCols(blockCol)
+
+            assert(dis.readInt() == nRowsInBlock)
+            assert(dis.readInt() == nColsInBlock)
+            if (!dis.readBoolean())
+              fatal("BlockMatrix must be stored row major on disk in order to be read as a RowMatrix")
+
+            if (i == start) {
+              val skip = (start % blockSize).toInt * (nColsInBlock << 3)
+              assert(skip == dis.skipBytes(skip)) // FIXME: can we seek?
+            }
+
+            dis
+          }
+        }
+
+        val row = new Array[Double](nCols)
+        var offset = 0
+        var blockCol = 0
+        while (blockCol < nBlockCols) {
+          val n = gp.blockColNCols(blockCol)
+          
+          disArray(blockCol).readFully(buf, 0, n << 3)
+          Memory.memcpy(row, offset, buf, 0, n)
+          
+          offset += n
+          blockCol += 1
+        }
+        val iRow = (i, row)
+        i += 1
+        
+        if (i % blockSize == 0 || i == end)
+          disArray.foreach(_.close())
+        
+        iRow
+      }
+    }
+  }
+  
+  @transient override val partitioner: Option[Partitioner] = Some(RowPartitioner.fromPartitionStarts(partitionStarts))
 }

--- a/src/main/scala/is/hail/distributedmatrix/RowPartitioner.scala
+++ b/src/main/scala/is/hail/distributedmatrix/RowPartitioner.scala
@@ -1,12 +1,40 @@
 package is.hail.distributedmatrix
 
-import is.hail.utils.BinarySearch
 import org.apache.spark.Partitioner
+
+object RowPartitioner {
+  /**
+    * a represents a partitioning of the (mathematical) integers into intervals
+    * with interval j given by [a(j), a(j+1)).
+    *
+    * -infty   -1    a(0)   0   a(1)   1         len-2   a(len-1)   len-1   infty
+    *    (-----------)[---------)[-------- ... ------------)[-----------------)  
+    *  
+    * a must be non-decreasing; repeated values correspond to empty intervals.
+    *
+    * Returns interval containing key:
+    *      -1 iff a is empty or key < a(0)
+    *       j iff a(j) <= key < a(j + 1)
+    *   len-1 iff a(len - 1) < key
+    **/
+  def findInterval(a: Array[Long], key: Long): Int = {
+    var lo = 0
+    var hi = a.length - 1
+    while (lo <= hi) {
+      val mid = (lo + hi) >>> 1
+      if (key < a(mid))
+        hi = mid - 1
+      else
+        lo = mid + 1
+    }
+    lo - 1
+  }
+}
 
 case class RowPartitioner(partitionStarts: Array[Long]) extends Partitioner {
   override val numPartitions: Int = partitionStarts.length - 1
 
   override def getPartition(key: Any): Int = key match {
-    case i: Long => BinarySearch.binarySearchInterval(partitionStarts, i)
+    case i: Long => RowPartitioner.findInterval(partitionStarts, i)
   }
 }

--- a/src/main/scala/is/hail/distributedmatrix/RowPartitioner.scala
+++ b/src/main/scala/is/hail/distributedmatrix/RowPartitioner.scala
@@ -1,36 +1,12 @@
 package is.hail.distributedmatrix
 
+import is.hail.utils.BinarySearch
 import org.apache.spark.Partitioner
 
 case class RowPartitioner(partitionStarts: Array[Long]) extends Partitioner {
   override val numPartitions: Int = partitionStarts.length - 1
 
   override def getPartition(key: Any): Int = key match {
-    case i: Long => binarySearchBefore(partitionStarts, i)
-  }
-  
-  // a is increasing and may contain duplicate values
-  //   returns j - 1 where j is the first index with a(j) < elem
-  def binarySearchBefore(a: Array[Long], elem: Long): Int = {
-    var low = 1
-    var high = a.length - 1
-    assert(elem >= a(0) && elem < a(high))
-    
-    while (low <= high) {
-      val mid = (low + high) >>> 1
-      val midVal = a(mid)
-      
-      if (midVal < elem)
-        low = mid + 1
-      else if (midVal > elem)
-        high = mid - 1
-      else {
-        var mid0 = mid
-        while (mid0 < a.length - 2 && a(mid0) == a(mid0 + 1))
-          mid0 += 1
-        return mid0
-      }
-    }
-    low - 1
+    case i: Long => BinarySearch.binarySearchInterval(partitionStarts, i)
   }
 }

--- a/src/main/scala/is/hail/distributedmatrix/RowPartitioner.scala
+++ b/src/main/scala/is/hail/distributedmatrix/RowPartitioner.scala
@@ -1,0 +1,46 @@
+package is.hail.distributedmatrix
+
+import java.util
+
+import org.apache.spark.Partitioner
+
+object RowPartitioner {
+  def rangeBoundsFromStarts(partitionStarts: Array[Long]): Array[Long] = {
+    val rangeBounds = new Array[Long](partitionStarts.length - 2)
+    var pi = 0
+    while (pi < partitionStarts.length - 2) {
+      rangeBounds(pi) = partitionStarts(pi + 1) - 1
+      pi += 1
+    }
+    rangeBounds
+  }
+
+  def fromPartitionStarts(partitionStarts: Array[Long]): RowPartitioner = {
+    RowPartitioner(rangeBoundsFromStarts(partitionStarts))
+  }
+}
+
+case class RowPartitioner(rangeBounds: Array[Long]) extends Partitioner {
+  override val numPartitions: Int = rangeBounds.length + 1
+
+  override def getPartition(key: Any): Int = key match {
+    case i: Long =>
+      var pi = 0
+      if (rangeBounds.length < 128) {
+        while (pi < rangeBounds.length && i > rangeBounds(pi)) {
+          pi += 1
+        }
+      } else {
+        pi = util.Arrays.binarySearch(rangeBounds, i)
+        if (pi < 0) {
+          // found no match, returned -[insertion point] - 1
+          pi = -(pi + 1)
+        } else if (pi < rangeBounds.length) {
+          // found a match, decrement to first match to precede empty partitions
+          while (pi > 0 && rangeBounds(pi) == rangeBounds(pi - 1))
+            pi -= 1
+        }
+      }
+      pi
+  }
+}

--- a/src/main/scala/is/hail/distributedmatrix/RowPartitioner.scala
+++ b/src/main/scala/is/hail/distributedmatrix/RowPartitioner.scala
@@ -17,7 +17,7 @@ case class RowPartitioner(partitionStarts: Array[Long]) extends Partitioner {
     assert(elem >= a(0) && elem < a(high))
     
     while (low <= high) {
-      var mid = (low + high) >>> 1
+      val mid = (low + high) >>> 1
       val midVal = a(mid)
       
       if (midVal < elem)
@@ -25,9 +25,10 @@ case class RowPartitioner(partitionStarts: Array[Long]) extends Partitioner {
       else if (midVal > elem)
         high = mid - 1
       else {
-        while (mid < a.length - 2 && a(mid) == a(mid + 1))
-          mid += 1
-        return mid
+        var mid0 = mid
+        while (mid0 < a.length - 2 && a(mid0) == a(mid0 + 1))
+          mid0 += 1
+        return mid0
       }
     }
     low - 1

--- a/src/main/scala/is/hail/rvd/OrderedRVPartitioner.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVPartitioner.scala
@@ -4,7 +4,6 @@ import is.hail.annotations._
 import is.hail.expr.types._
 import is.hail.expr.{JSONAnnotationImpex, Parser}
 import is.hail.utils._
-import is.hail.sparkextras.BinarySearch
 import org.apache.spark.{Partitioner, SparkContext}
 import org.json4s.JsonAST._
 

--- a/src/main/scala/is/hail/sparkextras/OrderedRDD2.scala
+++ b/src/main/scala/is/hail/sparkextras/OrderedRDD2.scala
@@ -6,39 +6,6 @@ import is.hail.utils._
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
 
-object BinarySearch {
-  // return smallest elem such that key <= elem
-  def binarySearch(length: Int,
-    // key.compare(elem)
-    compare: (Int) => Int): Int = {
-    assert(length > 0)
-
-    var low = 0
-    var high = length - 1
-    while (low < high) {
-      val mid = (low + high) / 2
-      assert(mid >= low && mid < high)
-
-      // key <= elem
-      if (compare(mid) <= 0) {
-        high = mid
-      } else {
-        low = mid + 1
-      }
-    }
-    assert(low == high)
-    assert(low >= 0 && low < length)
-
-    // key <= low
-    assert(compare(low) <= 0 || low == length - 1)
-    // low == 0 || (low - 1) > key
-    assert(low == 0
-      || compare(low - 1) > 0)
-
-    low
-  }
-}
-
 class OrderedDependency2(left: OrderedRVD, right: OrderedRVD) extends NarrowDependency[RegionValue](right.rdd) {
   override def getParents(partitionId: Int): Seq[Int] =
     OrderedDependency2.getDependencies(left.partitioner, right.partitioner)(partitionId)

--- a/src/main/scala/is/hail/utils/BinarySearch.scala
+++ b/src/main/scala/is/hail/utils/BinarySearch.scala
@@ -1,0 +1,51 @@
+package is.hail.utils
+
+object BinarySearch {
+  // return smallest elem such that key <= elem
+  def binarySearch(length: Int,
+    // key.compare(elem)
+    compare: (Int) => Int): Int = {
+    assert(length > 0)
+
+    var low = 0
+    var high = length - 1
+    while (low < high) {
+      val mid = (low + high) / 2
+      assert(mid >= low && mid < high)
+
+      // key <= elem
+      if (compare(mid) <= 0) {
+        high = mid
+      } else {
+        low = mid + 1
+      }
+    }
+    assert(low == high)
+    assert(low >= 0 && low < length)
+
+    // key <= low
+    assert(compare(low) <= 0 || low == length - 1)
+    // low == 0 || (low - 1) > key
+    assert(low == 0
+      || compare(low - 1) > 0)
+
+    low
+  }
+  
+  // a is increasing and may contain duplicate values. Returns:
+  //      -1 iff a is empty or key < a(0)
+  //       j iff a(j) <= key < a(j + 1)
+  //   len-1 iff a(len - 1) < key
+  def binarySearchInterval(a: Array[Long], key: Long): Int = {
+    var low = 0
+    var high = a.length - 1
+    while (low <= high) {
+      val mid = (low + high) >>> 1
+      if (key < a(mid))
+        high = mid - 1
+      else
+        low = mid + 1
+    }
+    low - 1
+  }
+}

--- a/src/main/scala/is/hail/utils/BinarySearch.scala
+++ b/src/main/scala/is/hail/utils/BinarySearch.scala
@@ -31,21 +31,4 @@ object BinarySearch {
 
     low
   }
-  
-  // a is increasing and may contain duplicate values. Returns:
-  //      -1 iff a is empty or key < a(0)
-  //       j iff a(j) <= key < a(j + 1)
-  //   len-1 iff a(len - 1) < key
-  def binarySearchInterval(a: Array[Long], key: Long): Int = {
-    var low = 0
-    var high = a.length - 1
-    while (low <= high) {
-      val mid = (low + high) >>> 1
-      if (key < a(mid))
-        high = mid - 1
-      else
-        low = mid + 1
-    }
-    low - 1
-  }
 }

--- a/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
@@ -122,4 +122,10 @@ class RichDenseMatrixDouble(val m: DenseMatrix[Double]) extends AnyVal {
     
     RichDenseMatrixDouble.writeDoubles(dos, m.data, m.data.length)
   }
+  
+  def forceRowMajor(): DenseMatrix[Double] =
+    if (m.isTranspose)
+      m
+    else
+      new DenseMatrix(m.rows, m.cols, m.t.toArray, 0, m.cols, isTranspose = true)
 }

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -374,6 +374,10 @@ class BlockMatrixSuite extends SparkSuite {
     val fname = tmpDir.createTempFile("test")
     m.write(fname)
     assert(m.toLocalMatrix() == BlockMatrix.read(hc, fname).toLocalMatrix())
+    
+    val fname2 = tmpDir.createTempFile("test2")
+    m.write(fname2, forceRowMajor = true)
+    assert(m.toLocalMatrix() == BlockMatrix.read(hc, fname2).toLocalMatrix())
   }
 
   @Test
@@ -387,6 +391,10 @@ class BlockMatrixSuite extends SparkSuite {
     val fname = tmpDir.createTempFile("test")
     m.t.write(fname)
     assert(m.t.toLocalMatrix() == BlockMatrix.read(hc, fname).toLocalMatrix())
+    
+    val fname2 = tmpDir.createTempFile("test2")
+    m.t.write(fname2, forceRowMajor = true)
+    assert(m.t.toLocalMatrix() == BlockMatrix.read(hc, fname2).toLocalMatrix())    
   }
 
   @Test

--- a/src/test/scala/is/hail/distributedmatrix/RowMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/RowMatrixSuite.scala
@@ -2,6 +2,7 @@ package is.hail.distributedmatrix
   
 import breeze.linalg.DenseMatrix
 import is.hail.SparkSuite
+import is.hail.check.{Gen, Prop}
 import is.hail.utils._
 import org.testng.annotations.Test
 
@@ -53,13 +54,11 @@ class RowMatrixSuite extends SparkSuite {
     assert(rowMatrixFromBlock.toLocalMatrix() == localMatrix)
   }
   
-  @Test def readBlock() {
-    val fname = tmpDir.createTempFile("test")
-    val r = scala.util.Random
-    r.setSeed(0)
-    
-    val lm = DenseMatrix.fill[Double](9, 10)(r.nextDouble())
-    
+  @Test
+  def readBlock() {
+    val fname = tmpDir.createTempFile("test")    
+    val lm = Gen.denseMatrix[Double](9, 10).sample()
+
     for {
       blockSize <- Seq(1, 2, 3, 4, 6, 7, 9, 10)
       partSize <- Seq(1, 2, 4, 9, 11)

--- a/src/test/scala/is/hail/distributedmatrix/RowMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/RowMatrixSuite.scala
@@ -5,7 +5,6 @@ import is.hail.SparkSuite
 import is.hail.utils._
 import org.testng.annotations.Test
 
-
 class RowMatrixSuite extends SparkSuite {
   private def rowArrayToRowMatrix(a: Array[Array[Double]]): RowMatrix = {
     require(a.length > 0)

--- a/src/test/scala/is/hail/distributedmatrix/RowMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/RowMatrixSuite.scala
@@ -23,7 +23,7 @@ class RowMatrixSuite extends SparkSuite {
   }
   
   @Test
-  def local() {
+  def localizeRowMatrix() {
     val fname = tmpDir.createTempFile("test")
     
     val rowArrays = Array(

--- a/src/test/scala/is/hail/distributedmatrix/RowPartitionerSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/RowPartitionerSuite.scala
@@ -51,11 +51,9 @@ class RowPartitionerSuite extends TestNGSuite {
   @Test
   def testRelationshipToBinarySearch() {
     val a = Array[Long](0, 0, 0, 4, 5, 5, 8, 10, 10)
-    val len0 = a.length - 1
     
-    assert((0 until len0).forall(key =>
+    assert((0 until a.length - 1).forall(key =>
       RowPartitioner.findInterval(a, key) == 
-        BinarySearch.binarySearch(len0, j => math.signum(key + 1 - a(j + 1)).toInt)))
+        BinarySearch.binarySearch(a.length - 1, j => math.signum(key + 1 - a(j + 1)).toInt)))
   }
-
 }

--- a/src/test/scala/is/hail/distributedmatrix/RowPartitionerSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/RowPartitionerSuite.scala
@@ -1,0 +1,45 @@
+package is.hail.distributedmatrix
+
+import org.scalatest.testng.TestNGSuite
+import org.testng.annotations.Test
+
+class RowPartitionerSuite extends TestNGSuite {
+
+  @Test
+  def testSmall() {
+    val partitionStarts = Array[Long](0, 4, 5, 10)
+    val rangeBounds = Array[Long](3, 4)
+    assert(RowPartitioner.rangeBoundsFromStarts(partitionStarts).sameElements(rangeBounds))
+
+    val partitionCounts = Array(4, 1, 5)
+    val keyPart = partitionCounts.zipWithIndex.flatMap{ case (count, pi) => Array.fill(count)(pi) }
+    val rp = new RowPartitioner(rangeBounds)
+    assert(rp.numPartitions == 3)    
+    assert((0 until 10).forall(i => keyPart(i) == rp.getPartition(i.toLong)))
+  }
+  
+  @Test
+  def testBig() {
+    val partitionStarts = Array.tabulate(151)(i => 2 * i.toLong)  
+    partitionStarts(10) -= 2
+    partitionStarts(20) -= 1
+    partitionStarts(30) += 1
+    partitionStarts(40) += 2
+    
+    val rangeBounds = Array.tabulate(149)(i => 2 * i.toLong + 1)
+    rangeBounds(9) -= 2
+    rangeBounds(19) -= 1
+    rangeBounds(29) += 1
+    rangeBounds(39) += 2
+    
+    assert(RowPartitioner.rangeBoundsFromStarts(partitionStarts).sameElements(rangeBounds))
+    
+    val nParts = partitionStarts.length - 1
+    val partitionCounts = Array.tabulate(nParts)(pi => (partitionStarts(pi + 1) - partitionStarts(pi)).toInt)
+    val keyPart = partitionCounts.zipWithIndex.flatMap{ case (count, pi) => Array.fill(count)(pi) }    
+
+    val rp = RowPartitioner.fromPartitionStarts(partitionStarts)
+    assert(rp.numPartitions == nParts)
+    assert((0 until 300).forall(i => keyPart(i) == rp.getPartition(i.toLong)))
+  }
+}

--- a/src/test/scala/is/hail/distributedmatrix/RowPartitionerSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/RowPartitionerSuite.scala
@@ -6,7 +6,7 @@ import org.testng.annotations.Test
 class RowPartitionerSuite extends TestNGSuite {
 
   @Test
-  def testSmall() {
+  def test() {
     val partitionStarts = Array[Long](0, 4, 5, 10)
     val partitionCounts = Array(4, 1, 5)
     val keyPart = partitionCounts.zipWithIndex.flatMap{ case (count, pi) => Array.fill(count)(pi) }
@@ -17,30 +17,13 @@ class RowPartitionerSuite extends TestNGSuite {
   }
   
   @Test
-  def testSmallWithEmptyPartitions() {
-    val partitionStarts = Array[Long](0, 0, 0, 4, 5, 5, 10, 10)
-    val partitionCounts = Array(0, 0, 4, 1, 0, 5, 0)
+  def testWithEmptyPartitions() {
+    val partitionStarts = Array[Long](0, 0, 0, 4, 5, 5, 8, 10, 10)
+    val partitionCounts = Array(0, 0, 4, 1, 0, 3, 2, 0)
     val keyPart = partitionCounts.zipWithIndex.flatMap{ case (count, pi) => Array.fill(count)(pi) }
-  
-    val rp = RowPartitioner(partitionStarts)
-    assert(rp.numPartitions == 7)
-    assert((0 until 10).forall(i => keyPart(i) == rp.getPartition(i.toLong)))
-  }
-  
-  @Test
-  def testBig() {
-    val partitionStarts = Array.tabulate(151)(i => 2 * i.toLong)  
-    partitionStarts(10) -= 2
-    partitionStarts(20) -= 1
-    partitionStarts(30) += 1
-    partitionStarts(40) += 2
     
-    val nParts = partitionStarts.length - 1
-    val partitionCounts = Array.tabulate(nParts)(pi => (partitionStarts(pi + 1) - partitionStarts(pi)).toInt)
-    val keyPart = partitionCounts.zipWithIndex.flatMap{ case (count, pi) => Array.fill(count)(pi) }    
-
     val rp = RowPartitioner(partitionStarts)
-    assert(rp.numPartitions == nParts)    
-    assert((0 until 300).forall(i => keyPart(i) == rp.getPartition(i.toLong)))
+    assert(rp.numPartitions == 8)   
+    assert((0 until 10).forall(i => keyPart(i) == rp.getPartition(i.toLong)))
   }
 }

--- a/src/test/scala/is/hail/distributedmatrix/RowPartitionerSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/RowPartitionerSuite.scala
@@ -1,29 +1,61 @@
 package is.hail.distributedmatrix
 
+import is.hail.check.Arbitrary.arbitrary
+import is.hail.check.{Gen, Prop}
+import is.hail.utils.BinarySearch
 import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.Test
 
 class RowPartitionerSuite extends TestNGSuite {
-
   @Test
-  def test() {
-    val partitionStarts = Array[Long](0, 4, 5, 10)
-    val partitionCounts = Array(4, 1, 5)
-    val keyPart = partitionCounts.zipWithIndex.flatMap{ case (count, pi) => Array.fill(count)(pi) }
-  
-    val rp = RowPartitioner(partitionStarts)
-    assert(rp.numPartitions == 3)
-    assert((0 until 10).forall(i => keyPart(i) == rp.getPartition(i.toLong)))
-  }
-  
-  @Test
-  def testWithEmptyPartitions() {
+  def testGetPartition() {
     val partitionStarts = Array[Long](0, 0, 0, 4, 5, 5, 8, 10, 10)
     val partitionCounts = Array(0, 0, 4, 1, 0, 3, 2, 0)
-    val keyPart = partitionCounts.zipWithIndex.flatMap{ case (count, pi) => Array.fill(count)(pi) }
-    
+    val keyPart = partitionCounts.zipWithIndex.flatMap { case (count, pi) => Array.fill(count)(pi) }
+
     val rp = RowPartitioner(partitionStarts)
-    assert(rp.numPartitions == 8)   
+    assert(rp.numPartitions == 8)
     assert((0 until 10).forall(i => keyPart(i) == rp.getPartition(i.toLong)))
   }
+  
+  @Test def testFindInterval() {
+    def naiveFindInterval(a: Array[Long], key: Long): Int = {  
+      if (a.length == 0 || key < a(0))
+        -1
+      else if (key >= a(a.length - 1))
+        a.length - 1
+      else {
+        var j = 0
+        while (!(a(j) <= key && key < a(j + 1)))
+          j += 1
+        j
+      }
+    }
+
+    val moreKeys = Array(Long.MinValue, -1000L, -1L, 0L, 1L, 1000L, Long.MaxValue)
+    
+    val g = for {
+      a0 <- Gen.buildableOf[Array](arbitrary[Long])
+      a = a0.sorted
+    } yield {
+      val len = a.length
+      for {key <- a ++ moreKeys} {
+        if (key > a(0) && key < a(len - 1))
+          assert(RowPartitioner.findInterval(a, key) == naiveFindInterval(a, key))
+      }
+      true
+    }
+    Prop.forAll(g).check()
+  }
+  
+  @Test
+  def testRelationshipToBinarySearch() {
+    val a = Array[Long](0, 0, 0, 4, 5, 5, 8, 10, 10)
+    val len0 = a.length - 1
+    
+    assert((0 until len0).forall(key =>
+      RowPartitioner.findInterval(a, key) == 
+        BinarySearch.binarySearch(len0, j => math.signum(key + 1 - a(j + 1)).toInt)))
+  }
+
 }

--- a/src/test/scala/is/hail/utils/UtilsSuite.scala
+++ b/src/test/scala/is/hail/utils/UtilsSuite.scala
@@ -3,7 +3,8 @@ package is.hail.utils
 import is.hail.SparkSuite
 import is.hail.check.Arbitrary._
 import is.hail.check.{Gen, Prop}
-import is.hail.sparkextras.{BinarySearch, OrderedRDD}
+import is.hail.distributedmatrix.RowPartitioner
+import is.hail.sparkextras.OrderedRDD
 import is.hail.utils.richUtils.RichHadoopConfiguration
 import is.hail.variant._
 import org.apache.spark.storage.StorageLevel
@@ -316,6 +317,47 @@ class UtilsSuite extends SparkSuite {
 
       BinarySearch.binarySearch(a.length, i => v.compare(s(i)))
 
+      true
+    }
+    Prop.forAll(g).check()
+  }
+  
+  
+  @Test
+  def testBinarySearchIntervalSmall() {
+    val a = Array[Long](0, 0, 0, 4, 5, 5, 10, 10)
+    val counts = Array(0, 0, 4, 1, 0, 5, 0)
+    val keyIndex = counts.zipWithIndex.flatMap{ case (count, j) => Array.fill(count)(j) }
+    
+    assert(BinarySearch.binarySearchInterval(a, -1) == -1)
+    assert((0 until 10).forall(i => BinarySearch.binarySearchInterval(a, i) == keyIndex(i)))
+    assert(BinarySearch.binarySearchInterval(a, 10) == a.length - 1)
+  }
+  
+  @Test def testBinarySearchInterval() {
+    def naiveBinarySearchInterval(a: Array[Long], key: Long): Int = {  
+      if (a.length == 0 || key < a(0))
+        -1
+      else if (key >= a(a.length - 1))
+        a.length - 1
+      else {
+        var j = 0
+        while (!(a(j) <= key && key < a(j + 1)))
+          j += 1
+        j
+      }
+    }
+
+    val moreKeys = Array(Long.MinValue, -1000L, -1L, 0L, 1L, 1000L, Long.MaxValue)
+        
+    val g = for {
+      a0 <- Gen.buildableOf[Array](arbitrary[Long])
+      a = a0.sorted
+    } yield {
+      val len = a.length
+      for {key <- a ++ moreKeys} {
+        assert(BinarySearch.binarySearchInterval(a, key) == naiveBinarySearchInterval(a, key))
+      }
       true
     }
     Prop.forAll(g).check()

--- a/src/test/scala/is/hail/utils/UtilsSuite.scala
+++ b/src/test/scala/is/hail/utils/UtilsSuite.scala
@@ -321,45 +321,4 @@ class UtilsSuite extends SparkSuite {
     }
     Prop.forAll(g).check()
   }
-  
-  
-  @Test
-  def testBinarySearchIntervalSmall() {
-    val a = Array[Long](0, 0, 0, 4, 5, 5, 10, 10)
-    val counts = Array(0, 0, 4, 1, 0, 5, 0)
-    val keyIndex = counts.zipWithIndex.flatMap{ case (count, j) => Array.fill(count)(j) }
-    
-    assert(BinarySearch.binarySearchInterval(a, -1) == -1)
-    assert((0 until 10).forall(i => BinarySearch.binarySearchInterval(a, i) == keyIndex(i)))
-    assert(BinarySearch.binarySearchInterval(a, 10) == a.length - 1)
-  }
-  
-  @Test def testBinarySearchInterval() {
-    def naiveBinarySearchInterval(a: Array[Long], key: Long): Int = {  
-      if (a.length == 0 || key < a(0))
-        -1
-      else if (key >= a(a.length - 1))
-        a.length - 1
-      else {
-        var j = 0
-        while (!(a(j) <= key && key < a(j + 1)))
-          j += 1
-        j
-      }
-    }
-
-    val moreKeys = Array(Long.MinValue, -1000L, -1L, 0L, 1L, 1000L, Long.MaxValue)
-        
-    val g = for {
-      a0 <- Gen.buildableOf[Array](arbitrary[Long])
-      a = a0.sorted
-    } yield {
-      val len = a.length
-      for {key <- a ++ moreKeys} {
-        assert(BinarySearch.binarySearchInterval(a, key) == naiveBinarySearchInterval(a, key))
-      }
-      true
-    }
-    Prop.forAll(g).check()
-  }
 }

--- a/src/test/scala/is/hail/utils/UtilsSuite.scala
+++ b/src/test/scala/is/hail/utils/UtilsSuite.scala
@@ -3,7 +3,6 @@ package is.hail.utils
 import is.hail.SparkSuite
 import is.hail.check.Arbitrary._
 import is.hail.check.{Gen, Prop}
-import is.hail.distributedmatrix.RowPartitioner
 import is.hail.sparkextras.OrderedRDD
 import is.hail.utils.richUtils.RichHadoopConfiguration
 import is.hail.variant._


### PR DESCRIPTION
Depends on (and includes changes in) #2661

This PR adds:
RowPartitioner and RowPartitionerSuite
RowMatrix.readBlockMatrix and tests in RowMatrixSuite
forceRowMajor parameter to BlockMatrix.write, included in tests
forceRowMajor to richDenseMatrixDouble

Currently I use skipBytes (which reads and throws away) to advance the DataInputStream. @cseed do you have advice on how to use seek instead?
  