### PR TITLE
generic intervals 2: add extended ordering

### DIFF
--- a/src/main/scala/is/hail/annotations/ExtendedOrdering.scala
+++ b/src/main/scala/is/hail/annotations/ExtendedOrdering.scala
@@ -1,0 +1,312 @@
+package is.hail.annotations
+
+import is.hail.utils._
+import org.apache.spark.sql.Row
+
+object ExtendedOrdering {
+  def extendToNull[S](ord: Ordering[S]): ExtendedOrdering = {
+    new ExtendedOrdering {
+      def compareNonnull(x: T, y: T, missingGreatest: Boolean): Int = ord.compare(x.asInstanceOf[S], y.asInstanceOf[S])
+
+      override def ltNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = ord.lt(x.asInstanceOf[S], y.asInstanceOf[S])
+
+      override def lteqNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = ord.lteq(x.asInstanceOf[S], y.asInstanceOf[S])
+
+      override def gtNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = ord.gt(x.asInstanceOf[S], y.asInstanceOf[S])
+
+      override def gteqNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = ord.gteq(x.asInstanceOf[S], y.asInstanceOf[S])
+
+      override def equivNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = ord.equiv(x.asInstanceOf[S], y.asInstanceOf[S])
+
+      override def minNonnull(x: T, y: T, missingGreatest: Boolean): T = ord.min(x.asInstanceOf[S], y.asInstanceOf[S])
+
+      override def maxNonnull(x: T, y: T, missingGreatest: Boolean): T = ord.max(x.asInstanceOf[S], y.asInstanceOf[S])
+    }
+  }
+
+  def iterableOrdering[T](ord: ExtendedOrdering): ExtendedOrdering =
+    new ExtendedOrdering {
+      def compareNonnull(x: T, y: T, missingGreatest: Boolean): Int = {
+        val xit = x.asInstanceOf[Iterable[T]].iterator
+        val yit = y.asInstanceOf[Iterable[T]].iterator
+
+        while (xit.hasNext && yit.hasNext) {
+          val c = ord.compare(xit.next(), yit.next(), missingGreatest)
+          if (c != 0)
+            return c
+        }
+
+        java.lang.Boolean.compare(xit.hasNext, yit.hasNext)
+      }
+    }
+
+  def sortArrayOrdering(ord: ExtendedOrdering): ExtendedOrdering =
+    new ExtendedOrdering {
+      private val itOrd = iterableOrdering(ord)
+      
+      def compareNonnull(x: T, y: T, missingGreatest: Boolean): Int = {
+        val ax = x.asInstanceOf[Array[T]]
+        val ay = y.asInstanceOf[Array[T]]
+
+        val scalaOrd = ord.toOrdering(missingGreatest)
+        itOrd.compareNonnull(ax.sorted(scalaOrd).toFastIndexedSeq, ay.sorted(scalaOrd).toFastIndexedSeq, missingGreatest)
+      }
+    }
+
+  def setOrdering(ord: ExtendedOrdering): ExtendedOrdering =
+    new ExtendedOrdering {
+      private val saOrd = sortArrayOrdering(ord)
+
+      def compareNonnull(x: T, y: T, missingGreatest: Boolean): Int = {
+        val ix = x.asInstanceOf[Iterable[T]]
+        val iy = y.asInstanceOf[Iterable[T]]
+        
+        val scalaOrd = ord.toOrdering(missingGreatest)
+        saOrd.compareNonnull(ix.toArray.sorted(scalaOrd), iy.toArray.sorted(scalaOrd), missingGreatest)
+      }
+    }
+
+  def mapOrdering(ord: ExtendedOrdering): ExtendedOrdering =
+    new ExtendedOrdering {
+      private val saOrd = sortArrayOrdering(ord)
+
+      def compareNonnull(x: T, y: T, missingGreatest: Boolean): Int = {
+        val mx = x.asInstanceOf[Map[_,  _]]
+        val my = y.asInstanceOf[Map[_,  _]]
+        
+        saOrd.compareNonnull(
+          mx.toArray.map { case (k, v) => Row(k, v): T },
+          my.toArray.map { case (k, v) => Row(k, v): T },
+          missingGreatest)
+      }
+    }
+
+  def rowOrdering(fieldOrd: Array[ExtendedOrdering]): ExtendedOrdering =
+    new ExtendedOrdering {
+      def compareNonnull(x: T, y: T, missingGreatest: Boolean): Int = {
+        val rx = x.asInstanceOf[Row]
+        val ry = y.asInstanceOf[Row]
+        
+        var i = 0
+        while (i < fieldOrd.length) {
+          val c = fieldOrd(i).compare(rx.get(i), ry.get(i), missingGreatest)
+          if (c != 0)
+            return c
+          i += 1
+        }
+
+        // equal
+        0
+      }
+    }
+}
+
+abstract class ExtendedOrdering extends Serializable {
+  outer =>
+  
+  type T = Any
+  
+  def compareNonnull(x: T, y: T, missingGreatest: Boolean): Int
+
+  def ltNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = compareNonnull(x, y, missingGreatest) < 0
+
+  def lteqNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = compareNonnull(x, y, missingGreatest) <= 0
+
+  def gtNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = compareNonnull(x, y, missingGreatest) > 0
+
+  def gteqNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = compareNonnull(x, y, missingGreatest) >= 0
+
+  def equivNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = compareNonnull(x, y, missingGreatest) == 0
+
+  def minNonnull(x: T, y: T, missingGreatest: Boolean): T = {
+    if (ltNonnull(x, y, missingGreatest))
+      x
+    else
+      y
+  }
+
+  def maxNonnull(x: T, y: T, missingGreatest: Boolean): T = {
+    if (gtNonnull(x, y, missingGreatest))
+      x
+    else
+      y
+  }
+
+  def compare(x: T, y: T, missingGreatest: Boolean): Int = {
+    if (y == null) {
+      if (x == null)
+        0
+      else if (missingGreatest) -1 else 1
+    } else {
+      if (x == null)
+        if (missingGreatest) 1 else -1
+      else
+        compareNonnull(x, y, missingGreatest)
+    }
+  }
+
+  def lt(x: T, y: T, missingGreatest: Boolean): Boolean = {
+    if (y == null) {
+      if (x == null)
+        false
+      else
+        missingGreatest
+    } else {
+      if (x == null)
+        !missingGreatest
+      else
+        ltNonnull(x, y, missingGreatest)
+    }
+  }
+
+  def lteq(x: T, y: T, missingGreatest: Boolean): Boolean = {
+    if (y == null) {
+      if (x == null)
+        true
+      else
+        missingGreatest
+    } else {
+      if (x == null)
+        !missingGreatest
+      else
+        lteqNonnull(x, y, missingGreatest)
+    }
+  }
+
+  def gt(x: T, y: T, missingGreatest: Boolean): Boolean = {
+    if (y == null) {
+      if (x == null)
+        false
+      else
+        !missingGreatest
+    } else {
+      if (x == null)
+        missingGreatest
+      else
+        gtNonnull(x, y, missingGreatest)
+    }
+  }
+
+  def gteq(x: T, y: T, missingGreatest: Boolean): Boolean = {
+    if (y == null) {
+      if (x == null)
+        true
+      else
+        !missingGreatest
+    } else {
+      if (x == null)
+        missingGreatest
+      else
+        gteqNonnull(x, y, missingGreatest)
+    }
+  }
+  
+  def equiv(x: T, y: T, missingGreatest: Boolean): Boolean = {
+    if (y == null) {
+      if (x == null)
+        true
+      else
+        false
+    } else {
+      if (x == null)
+        false
+      else
+        equivNonnull(x, y, missingGreatest)
+    }
+  }
+
+  def min(x: T, y: T, missingGreatest: Boolean): T = {
+    if (y == null) {
+      if (missingGreatest) x else y
+    } else {
+      if (x == null)
+        if (missingGreatest) y else x
+      else
+        minNonnull(x, y, missingGreatest)
+    }
+  }
+
+  def max(x: T, y: T, missingGreatest: Boolean): T = {
+    if (y == null) {
+      if (missingGreatest) y else x
+    } else {
+      if (x == null)
+        if (missingGreatest) x else y
+      else
+        maxNonnull(x, y, missingGreatest)
+    }
+  }
+
+  def compare(x: T, y: T): Int = compare(x, y, missingGreatest = true)
+
+  def lt(x: T, y: T): Boolean = lt(x, y, missingGreatest = true)
+
+  def lteq(x: T, y: T): Boolean = lteq(x, y, missingGreatest = true)
+
+  def gt(x: T, y: T): Boolean = gt(x, y, missingGreatest = true)
+
+  def gteq(x: T, y: T): Boolean = gteq(x, y, missingGreatest = true)
+
+  def equiv(x: T, y: T): Boolean = equiv(x, y, missingGreatest = true)
+
+  def min(x: T, y: T): T = min(x, y, missingGreatest = true)
+
+  def max(x: T, y: T): T = max(x, y, missingGreatest = true)
+
+  // reverses the sense of the non-null comparison only
+  def reverse: ExtendedOrdering = new ExtendedOrdering {
+    override def reverse: ExtendedOrdering = outer
+
+    def compareNonnull(x: T, y: T, missingGreatest: Boolean): Int = outer.compareNonnull(y, x, missingGreatest)
+
+    override def ltNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = outer.ltNonnull(y, x, missingGreatest)
+
+    override def lteqNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = outer.lteqNonnull(y, x, missingGreatest)
+
+    override def gtNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = outer.gtNonnull(y, x, missingGreatest)
+
+    override def gteqNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = outer.gteqNonnull(y, x, missingGreatest)
+
+    override def equivNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = outer.equivNonnull(y, x, missingGreatest)
+
+    override def minNonnull(x: T, y: T, missingGreatest: Boolean): T = outer.maxNonnull(x, y, missingGreatest)
+
+    override def maxNonnull(x: T, y: T, missingGreatest: Boolean): T = outer.minNonnull(x, y, missingGreatest)
+  }
+
+  def toOrdering: Ordering[T] = new Ordering[T] {
+    def compare(x: T, y: T): Int = outer.compare(x, y)
+
+    override def lt(x: T, y: T): Boolean = outer.lt(x, y)
+
+    override def lteq(x: T, y: T): Boolean = outer.lteq(x, y)
+
+    override def gt(x: T, y: T): Boolean = outer.gt(x, y)
+
+    override def gteq(x: T, y: T): Boolean = outer.gteq(x, y)
+
+    override def equiv(x: T, y: T): Boolean = outer.equiv(x, y)
+
+    override def min(x: T, y: T): T = outer.min(x, y)
+
+    override def max(x: T, y: T): T = outer.max(x, y)
+  }
+
+  def toOrdering(missingGreatest: Boolean): Ordering[T] = new Ordering[T] {
+    def compare(x: T, y: T): Int = outer.compare(x, y, missingGreatest)
+
+    override def lt(x: T, y: T): Boolean = outer.lt(x, y, missingGreatest)
+
+    override def lteq(x: T, y: T): Boolean = outer.lteq(x, y, missingGreatest)
+
+    override def gt(x: T, y: T): Boolean = outer.gt(x, y, missingGreatest)
+
+    override def gteq(x: T, y: T): Boolean = outer.gteq(x, y, missingGreatest)
+
+    override def equiv(x: T, y: T): Boolean = outer.equiv(x, y, missingGreatest)
+
+    override def min(x: T, y: T): T = outer.min(x, y, missingGreatest)
+
+    override def max(x: T, y: T): T = outer.max(x, y, missingGreatest)    
+  }
+}

--- a/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
+++ b/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
@@ -439,7 +439,7 @@ class RegionValueBuilder(var region: Region) {
         case TSet(elementType, _) =>
           val s = a.asInstanceOf[Set[Annotation]]
             .toArray
-            .sorted(elementType.ordering(true))
+            .sorted(elementType.ordering.toOrdering)
           startArray(s.length)
           s.foreach { x => addAnnotation(elementType, x) }
           endArray()
@@ -448,7 +448,7 @@ class RegionValueBuilder(var region: Region) {
           val m = a.asInstanceOf[Map[Annotation, Annotation]]
             .map { case (k, v) => Row(k, v) }
             .toArray
-            .sorted(td.elementType.ordering(true))
+            .sorted(td.elementType.ordering.toOrdering)
           startArray(m.length)
           m.foreach { case Row(k, v) =>
             startStruct()

--- a/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -222,7 +222,7 @@ object UnsafeRow {
             read(x.pointType, region, ft.loadField(region, offset, 1))
           else
             null
-        Interval[Annotation](start, end)(x.pointType.ordering(true))
+        Interval[Annotation](start, end)(x.pointType.ordering.toOrdering)
     }
   }
 }

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -440,7 +440,7 @@ case class GenomeReferenceDependentConstructor(posn: Position, fName: String, gr
   val rTyp = fName match {
     case "Variant" => gr.variant
     case "Locus" => gr.locus
-    case "LocusInterval" => gr.interval
+    case "LocusInterval" => TInterval(gr.locus)
     case _ => throw new UnsupportedOperationException
   }
 

--- a/src/main/scala/is/hail/expr/AnnotationImpex.scala
+++ b/src/main/scala/is/hail/expr/AnnotationImpex.scala
@@ -91,7 +91,7 @@ object SparkAnnotationImpex extends AnnotationImpex[DataType, Any] {
           Locus(r.getAs[String](0), r.getAs[Int](1))
         case x: TInterval =>
           val r = a.asInstanceOf[Row]
-          Interval(importAnnotation(r.get(0), x.pointType), importAnnotation(r.get(1), x.pointType))(x.pointType.ordering(true))
+          Interval(importAnnotation(r.get(0), x.pointType), importAnnotation(r.get(1), x.pointType))(x.pointType.ordering.toOrdering)
         case TStruct(fields, _) =>
           if (fields.isEmpty)
             if (a.asInstanceOf[Boolean]) Annotation.empty else null
@@ -382,7 +382,7 @@ object JSONAnnotationImpex extends AnnotationImpex[Type, JValue] {
         jv match {
           case JObject(List(("start", sjv), ("end", ejv))) =>
             Interval[Annotation](importAnnotation(sjv, pointType, parent + ".start"),
-              importAnnotation(ejv, pointType, parent + ".end"))(pointType.ordering(true))
+              importAnnotation(ejv, pointType, parent + ".end"))(pointType.ordering.toOrdering)
           case _ =>
             warn(s"Can't convert JSON value $jv to type $t at $parent.")
             null

--- a/src/main/scala/is/hail/expr/package.scala
+++ b/src/main/scala/is/hail/expr/package.scala
@@ -7,6 +7,7 @@ import is.hail.asm4s.Code
 
 package object expr extends HailRepFunctions {
   type SymbolTable = Map[String, (Int, Type)]
+
   def emptySymTab = Map.empty[String, (Int, Type)]
 
   def hailType[T: HailRep]: Type = implicitly[HailRep[T]].typ

--- a/src/main/scala/is/hail/expr/types/TAggregable.scala
+++ b/src/main/scala/is/hail/expr/types/TAggregable.scala
@@ -50,6 +50,5 @@ final case class TAggregable(elementType: Type, override val required: Boolean =
 
   override def scalaClassTag: ClassTag[_ <: AnyRef] = elementType.scalaClassTag
 
-  override def ordering(missingGreatest: Boolean): Ordering[Annotation] =
-    throw new RuntimeException("TAggregable is not realizable")
+  val ordering: ExtendedOrdering = null
 }

--- a/src/main/scala/is/hail/expr/types/TAggregableVariable.scala
+++ b/src/main/scala/is/hail/expr/types/TAggregableVariable.scala
@@ -40,6 +40,5 @@ final case class TAggregableVariable(elementType: Type, st: Box[SymbolTable]) ex
 
   override def scalaClassTag: ClassTag[AnyRef] = throw new RuntimeException("TAggregableVariable is not realizable")
 
-  override def ordering(missingGreatest: Boolean): Ordering[Annotation] =
-    throw new RuntimeException("TAggregableVariable is not realizable")
+  val ordering: ExtendedOrdering = null
 }

--- a/src/main/scala/is/hail/expr/types/TAltAllele.scala
+++ b/src/main/scala/is/hail/expr/types/TAltAllele.scala
@@ -21,9 +21,8 @@ class TAltAllele(override val required: Boolean) extends ComplexType {
 
   override def scalaClassTag: ClassTag[AltAllele] = classTag[AltAllele]
 
-  override def ordering(missingGreatest: Boolean): Ordering[Annotation] =
-    annotationOrdering(
-      extendOrderingToNull(missingGreatest)(implicitly[Ordering[AltAllele]]))
+  val ordering: ExtendedOrdering =
+    ExtendedOrdering.extendToNull(implicitly[Ordering[AltAllele]])
 
   val representation: TStruct = TAltAllele.representation(required)
 }

--- a/src/main/scala/is/hail/expr/types/TArray.scala
+++ b/src/main/scala/is/hail/expr/types/TArray.scala
@@ -49,9 +49,8 @@ final case class TArray(elementType: Type, override val required: Boolean = fals
   override def genNonmissingValue: Gen[Annotation] =
     Gen.buildableOf[Array](elementType.genValue).map(x => x: IndexedSeq[Annotation])
 
-  def ordering(missingGreatest: Boolean): Ordering[Annotation] =
-    annotationOrdering(extendOrderingToNull(missingGreatest)(
-      Ordering.Iterable(elementType.ordering(missingGreatest))))
+  val ordering: ExtendedOrdering =
+    ExtendedOrdering.iterableOrdering(elementType.ordering)
 
   override def desc: String =
     """

--- a/src/main/scala/is/hail/expr/types/TBinary.scala
+++ b/src/main/scala/is/hail/expr/types/TBinary.scala
@@ -8,6 +8,7 @@ import is.hail.utils._
 import scala.reflect.{ClassTag, _}
 
 case object TBinaryOptional extends TBinary(false)
+
 case object TBinaryRequired extends TBinary(true)
 
 class TBinary(override val required: Boolean) extends Type {
@@ -42,14 +43,8 @@ class TBinary(override val required: Boolean) extends Type {
     }
   }
 
-  def ordering(missingGreatest: Boolean): Ordering[Annotation] = {
-    val ord = Ordering.Iterable[Byte]
-
-    annotationOrdering(extendOrderingToNull(missingGreatest)(
-      new Ordering[Array[Byte]] {
-        def compare(a: Array[Byte], b: Array[Byte]): Int = ord.compare(a, b)
-      }))
-  }
+  val ordering: ExtendedOrdering =
+    ExtendedOrdering.extendToNull(Ordering.Iterable[Byte])
 
   override def byteSize: Long = 8
 }

--- a/src/main/scala/is/hail/expr/types/TBoolean.scala
+++ b/src/main/scala/is/hail/expr/types/TBoolean.scala
@@ -27,9 +27,8 @@ class TBoolean(override val required: Boolean) extends Type {
     }
   }
 
-  def ordering(missingGreatest: Boolean): Ordering[Annotation] =
-    annotationOrdering(
-      extendOrderingToNull(missingGreatest)(implicitly[Ordering[Boolean]]))
+  val ordering: ExtendedOrdering =
+    ExtendedOrdering.extendToNull(implicitly[Ordering[Boolean]])
 
   override def byteSize: Long = 1
 }

--- a/src/main/scala/is/hail/expr/types/TCall.scala
+++ b/src/main/scala/is/hail/expr/types/TCall.scala
@@ -23,9 +23,8 @@ class TCall(override val required: Boolean) extends ComplexType {
 
   override def scalaClassTag: ClassTag[java.lang.Integer] = classTag[java.lang.Integer]
 
-  override def ordering(missingGreatest: Boolean): Ordering[Annotation] =
-    annotationOrdering(
-      extendOrderingToNull(missingGreatest)(implicitly[Ordering[Int]]))
+  val ordering: ExtendedOrdering =
+    ExtendedOrdering.extendToNull(implicitly[Ordering[Int]])
 }
 
 object TCall {

--- a/src/main/scala/is/hail/expr/types/TDict.scala
+++ b/src/main/scala/is/hail/expr/types/TDict.scala
@@ -68,18 +68,6 @@ final case class TDict(keyType: Type, valueType: Type, override val required: Bo
 
   override def scalaClassTag: ClassTag[Map[_, _]] = classTag[Map[_, _]]
 
-  def ordering(missingGreatest: Boolean): Ordering[Annotation] = {
-    val elementSortOrd = elementType.ordering(true)
-    val itOrd = Ordering.Iterable(elementType.ordering(missingGreatest))
-    val dict = new Ordering[Map[Annotation, Annotation]] {
-      def compare(x: Map[Annotation, Annotation], y: Map[Annotation, Annotation]): Int = {
-        val s1 = x.toArray.map { case (k, v) => Row(k, v) }.sorted(elementSortOrd)
-        val s2 = y.toArray.map { case (k, v) => Row(k, v) }.sorted(elementSortOrd)
-
-        itOrd.compare(s1, s2)
-      }
-    }
-
-    annotationOrdering(extendOrderingToNull(missingGreatest)(dict))
-  }
+  val ordering: ExtendedOrdering =
+    ExtendedOrdering.mapOrdering(elementType.ordering)
 }

--- a/src/main/scala/is/hail/expr/types/TFloat32.scala
+++ b/src/main/scala/is/hail/expr/types/TFloat32.scala
@@ -35,9 +35,8 @@ class TFloat32(override val required: Boolean) extends TNumeric {
     }
   }
 
-  def ordering(missingGreatest: Boolean): Ordering[Annotation] =
-    annotationOrdering(
-      extendOrderingToNull(missingGreatest)(implicitly[Ordering[Float]]))
+  val ordering: ExtendedOrdering =
+    ExtendedOrdering.extendToNull(implicitly[Ordering[Float]])
 
   override def byteSize: Long = 4
 }

--- a/src/main/scala/is/hail/expr/types/TFloat64.scala
+++ b/src/main/scala/is/hail/expr/types/TFloat64.scala
@@ -35,9 +35,8 @@ class TFloat64(override val required: Boolean) extends TNumeric {
     }
   }
 
-  def ordering(missingGreatest: Boolean): Ordering[Annotation] =
-    annotationOrdering(
-      extendOrderingToNull(missingGreatest)(implicitly[Ordering[Double]]))
+  val ordering: ExtendedOrdering =
+    ExtendedOrdering.extendToNull(implicitly[Ordering[Double]])
 
   override def byteSize: Long = 8
 }

--- a/src/main/scala/is/hail/expr/types/TFunction.scala
+++ b/src/main/scala/is/hail/expr/types/TFunction.scala
@@ -33,6 +33,5 @@ final case class TFunction(paramTypes: Seq[Type], returnType: Type) extends Type
 
   override def scalaClassTag: ClassTag[AnyRef] = throw new RuntimeException("TFunction is not realizable")
 
-  override def ordering(missingGreatest: Boolean): Ordering[Annotation] =
-    throw new RuntimeException("TFunction is not realizable")
+  val ordering: ExtendedOrdering = null
 }

--- a/src/main/scala/is/hail/expr/types/TInt32.scala
+++ b/src/main/scala/is/hail/expr/types/TInt32.scala
@@ -28,9 +28,8 @@ class TInt32(override val required: Boolean) extends TIntegral {
     }
   }
 
-  def ordering(missingGreatest: Boolean): Ordering[Annotation] =
-    annotationOrdering(
-      extendOrderingToNull(missingGreatest)(implicitly[Ordering[Int]]))
+  val ordering: ExtendedOrdering =
+    ExtendedOrdering.extendToNull(implicitly[Ordering[Int]])
 
   override def byteSize: Long = 4
 }

--- a/src/main/scala/is/hail/expr/types/TInt64.scala
+++ b/src/main/scala/is/hail/expr/types/TInt64.scala
@@ -28,9 +28,8 @@ class TInt64(override val required: Boolean) extends TIntegral {
     }
   }
 
-  def ordering(missingGreatest: Boolean): Ordering[Annotation] =
-    annotationOrdering(
-      extendOrderingToNull(missingGreatest)(implicitly[Ordering[Long]]))
+  val ordering: ExtendedOrdering =
+    ExtendedOrdering.extendToNull(implicitly[Ordering[Long]])
 
   override def byteSize: Long = 8
 }

--- a/src/main/scala/is/hail/expr/types/TInterval.scala
+++ b/src/main/scala/is/hail/expr/types/TInterval.scala
@@ -1,10 +1,10 @@
 package is.hail.expr.types
 
-import is.hail.annotations.{Annotation, UnsafeOrdering}
+import is.hail.annotations.{Annotation, ExtendedOrdering, UnsafeOrdering}
 import is.hail.check.Gen
 import is.hail.utils._
 
-import scala.reflect.{classTag, ClassTag}
+import scala.reflect.{ClassTag, classTag}
 
 
 case class TInterval(pointType: Type, override val required: Boolean = false) extends ComplexType {
@@ -23,16 +23,14 @@ case class TInterval(pointType: Type, override val required: Boolean = false) ex
     pointType.typeCheck(i.start) && pointType.typeCheck(i.end)
   }
 
-  override def genNonmissingValue: Gen[Annotation] = Interval.gen(pointType.genValue)(pointType.ordering(true))
+  override def genNonmissingValue: Gen[Annotation] = Interval.gen(pointType.genValue)(pointType.ordering.toOrdering)
 
   override def desc: String = "An ``Interval[T]`` is a Hail data type representing a range over ordered values of type T."
 
   override def scalaClassTag: ClassTag[Interval[Annotation]] = classTag[Interval[Annotation]]
 
-  override def ordering(missingGreatest: Boolean): Ordering[Annotation] = {
-    annotationOrdering(
-      extendOrderingToNull(missingGreatest)(Interval.ordering[Annotation]))
-  }
+  val ordering: ExtendedOrdering =
+    ExtendedOrdering.extendToNull(Interval.ordering[Annotation])
 
   override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering = representation.unsafeOrdering(missingGreatest)
 

--- a/src/main/scala/is/hail/expr/types/TLocus.scala
+++ b/src/main/scala/is/hail/expr/types/TLocus.scala
@@ -28,9 +28,8 @@ case class TLocus(gr: GRBase, override val required: Boolean = false) extends Co
 
   override def scalaClassTag: ClassTag[Locus] = classTag[Locus]
 
-  override def ordering(missingGreatest: Boolean): Ordering[Annotation] =
-    annotationOrdering(
-      extendOrderingToNull(missingGreatest)(locusOrdering))
+  val ordering: ExtendedOrdering =
+    ExtendedOrdering.extendToNull(gr.locusOrdering)
 
   // FIXME: Remove when representation of contig/position is a naturally-ordered Long
   override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering = {

--- a/src/main/scala/is/hail/expr/types/TSet.scala
+++ b/src/main/scala/is/hail/expr/types/TSet.scala
@@ -37,20 +37,8 @@ final case class TSet(elementType: Type, override val required: Boolean = false)
     sb.append("]")
   }
 
-  def ordering(missingGreatest: Boolean): Ordering[Annotation] = {
-    val elementSortOrd = elementType.ordering(true)
-    val itOrd = Ordering.Iterable(elementType.ordering(missingGreatest))
-    val setOrdering = new Ordering[Set[Annotation]] {
-      def compare(x: Set[Annotation], y: Set[Annotation]): Int = {
-        val s1 = x.toArray.sorted(elementSortOrd)
-        val s2 = y.toArray.sorted(elementSortOrd)
-
-        itOrd.compare(s1, s2)
-      }
-    }
-
-    annotationOrdering(extendOrderingToNull(missingGreatest)(setOrdering))
-  }
+  val ordering: ExtendedOrdering =
+    ExtendedOrdering.setOrdering(elementType.ordering)
 
   override def str(a: Annotation): String = JsonMethods.compact(toJSON(a))
 

--- a/src/main/scala/is/hail/expr/types/TString.scala
+++ b/src/main/scala/is/hail/expr/types/TString.scala
@@ -21,9 +21,8 @@ class TString(override val required: Boolean) extends Type {
 
   override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering = TBinary(required).unsafeOrdering(missingGreatest)
 
-  def ordering(missingGreatest: Boolean): Ordering[Annotation] =
-    annotationOrdering(
-      extendOrderingToNull(missingGreatest)(implicitly[Ordering[String]]))
+  val ordering: ExtendedOrdering =
+    ExtendedOrdering.extendToNull(implicitly[Ordering[String]])
 
   override def byteSize: Long = 8
 

--- a/src/main/scala/is/hail/expr/types/TStruct.scala
+++ b/src/main/scala/is/hail/expr/types/TStruct.scala
@@ -27,7 +27,7 @@ object TStruct {
       required)
 
   def apply(args: (String, Type)*): TStruct =
-    apply(false, args:_*)
+    apply(false, args: _*)
 
   def apply(names: java.util.ArrayList[String], types: java.util.ArrayList[Type], required: Boolean): TStruct = {
     val sNames = names.asScala.toArray
@@ -553,26 +553,8 @@ final case class TStruct(fields: IndexedSeq[Field], override val required: Boole
 
   override def scalaClassTag: ClassTag[Row] = classTag[Row]
 
-  override def ordering(missingGreatest: Boolean): Ordering[Annotation] = {
-    val fieldOrderings = fields.map(f => f.typ.ordering(missingGreatest))
-
-    annotationOrdering(
-      extendOrderingToNull(missingGreatest)(new Ordering[Row] {
-        def compare(a: Row, b: Row): Int = {
-          var i = 0
-          while (i < a.size) {
-            val c = fieldOrderings(i).compare(a.get(i), b.get(i))
-            if (c != 0)
-              return c
-
-            i += 1
-          }
-
-          // equal
-          0
-        }
-      }))
-  }
+  val ordering: ExtendedOrdering =
+    ExtendedOrdering.rowOrdering(fields.map(_.typ.ordering).toArray)
 
   override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering = {
     val fieldOrderings = fields.map(_.typ.unsafeOrdering(missingGreatest)).toArray

--- a/src/main/scala/is/hail/expr/types/TVariable.scala
+++ b/src/main/scala/is/hail/expr/types/TVariable.scala
@@ -38,6 +38,5 @@ final case class TVariable(name: String, var t: Type = null) extends Type {
 
   override def scalaClassTag: ClassTag[AnyRef] = throw new RuntimeException("TVariable is not realizable")
 
-  override def ordering(missingGreatest: Boolean): Ordering[Annotation] =
-    throw new RuntimeException("TVariable is not realizable")
+  val ordering: ExtendedOrdering = null
 }

--- a/src/main/scala/is/hail/expr/types/TVariant.scala
+++ b/src/main/scala/is/hail/expr/types/TVariant.scala
@@ -41,18 +41,17 @@ case class TVariant(gr: GRBase, override val required: Boolean = false) extends 
 
   override def scalaClassTag: ClassTag[Variant] = classTag[Variant]
 
-  override def ordering(missingGreatest: Boolean): Ordering[Annotation] =
-    annotationOrdering(
-      extendOrderingToNull(missingGreatest)(variantOrdering))
+  val ordering: ExtendedOrdering =
+    ExtendedOrdering.extendToNull(gr.variantOrdering)
 
   override val partitionKey: Type = TLocus(gr)
 
   override def typedOrderedKey[PK, K]: OrderedKey[PK, K] = new OrderedKey[PK, K] {
     def project(key: K): PK = key.asInstanceOf[Variant].locus.asInstanceOf[PK]
 
-    val kOrd: Ordering[K] = ordering(missingGreatest = true).asInstanceOf[Ordering[K]]
+    val kOrd: Ordering[K] = ordering.toOrdering.asInstanceOf[Ordering[K]]
 
-    val pkOrd: Ordering[PK] = TLocus(gr).ordering(missingGreatest = true).asInstanceOf[Ordering[PK]]
+    val pkOrd: Ordering[PK] = TLocus(gr).ordering.toOrdering.asInstanceOf[Ordering[PK]]
 
     val kct: ClassTag[K] = classTag[Variant].asInstanceOf[ClassTag[K]]
 
@@ -62,9 +61,9 @@ case class TVariant(gr: GRBase, override val required: Boolean = false) extends 
   override def orderedKey: OrderedKey[Annotation, Annotation] = new OrderedKey[Annotation, Annotation] {
     def project(key: Annotation): Annotation = key.asInstanceOf[Variant].locus
 
-    val kOrd: Ordering[Annotation] = ordering(missingGreatest = true)
+    val kOrd: Ordering[Annotation] = ordering.toOrdering
 
-    val pkOrd: Ordering[Annotation] = TLocus(gr).ordering(missingGreatest = true)
+    val pkOrd: Ordering[Annotation] = TLocus(gr).ordering.toOrdering
 
     val kct: ClassTag[Annotation] = classTag[Annotation]
 

--- a/src/main/scala/is/hail/expr/types/TVoid.scala
+++ b/src/main/scala/is/hail/expr/types/TVoid.scala
@@ -1,11 +1,13 @@
 package is.hail.expr.types
 
+import is.hail.annotations.ExtendedOrdering
+
 case object TVoid extends Type {
   override val required = true
 
   override def _toString = "Void"
 
-  override def ordering(missingGreatest: Boolean): Ordering[is.hail.annotations.Annotation] = throw new UnsupportedOperationException("No ordering on Void")
+  val ordering: ExtendedOrdering = null
 
   override def scalaClassTag: scala.reflect.ClassTag[_ <: AnyRef] = throw new UnsupportedOperationException("No ClassTag for Void")
 

--- a/src/main/scala/is/hail/expr/types/Type.scala
+++ b/src/main/scala/is/hail/expr/types/Type.scala
@@ -232,16 +232,16 @@ abstract class Type extends BaseType with Serializable {
 
   def canCompare(other: Type): Boolean = this == other
 
-  def ordering(missingGreatest: Boolean): Ordering[Annotation]
+  val ordering: ExtendedOrdering
 
   val partitionKey: Type = this
 
   def typedOrderedKey[PK, K] = new OrderedKey[PK, K] {
     def project(key: K): PK = key.asInstanceOf[PK]
 
-    val kOrd: Ordering[K] = ordering(missingGreatest = true).asInstanceOf[Ordering[K]]
+    val kOrd: Ordering[K] = ordering.toOrdering.asInstanceOf[Ordering[K]]
 
-    val pkOrd: Ordering[PK] = ordering(missingGreatest = true).asInstanceOf[Ordering[PK]]
+    val pkOrd: Ordering[PK] = ordering.toOrdering.asInstanceOf[Ordering[PK]]
 
     val kct: ClassTag[K] = scalaClassTag.asInstanceOf[ClassTag[K]]
 
@@ -251,9 +251,9 @@ abstract class Type extends BaseType with Serializable {
   def orderedKey: OrderedKey[Annotation, Annotation] = new OrderedKey[Annotation, Annotation] {
     def project(key: Annotation): Annotation = key
 
-    val kOrd: Ordering[Annotation] = ordering(missingGreatest = true)
+    val kOrd: Ordering[Annotation] = ordering.toOrdering
 
-    val pkOrd: Ordering[Annotation] = ordering(missingGreatest = true)
+    val pkOrd: Ordering[Annotation] = ordering.toOrdering
 
     val kct: ClassTag[Annotation] = classTag[Annotation]
 

--- a/src/main/scala/is/hail/methods/Aggregators.scala
+++ b/src/main/scala/is/hail/methods/Aggregators.scala
@@ -3,7 +3,7 @@ package is.hail.methods
 import java.io.{ObjectInputStream, ObjectOutputStream}
 
 import is.hail.HailContext
-import is.hail.annotations.{Annotation, RegionValue, RegionValueBuilder, UnsafeRow}
+import is.hail.annotations._
 import is.hail.expr._
 import is.hail.table.TableLocalValue
 import is.hail.expr.types._
@@ -769,7 +769,7 @@ class TakeByAggregator[T](var t: Type, var f: (Any) => Any, var n: Int)(implicit
 
   def makeOrd(): Ordering[(Any, Any)] =
     if (tord != null)
-      extendOrderingToNull(true)(tord)
+      ExtendedOrdering.extendToNull(tord).toOrdering
         .on { case (e, k) => k.asInstanceOf[T] }
     else
       null

--- a/src/main/scala/is/hail/methods/FilterIntervals.scala
+++ b/src/main/scala/is/hail/methods/FilterIntervals.scala
@@ -14,7 +14,7 @@ object FilterIntervals {
   }
 
   def apply[T, U](vsm: MatrixTable, iList: IntervalTree[Locus, U], keep: Boolean): MatrixTable = {
-    implicit val locusOrd = vsm.matrixType.locusType.ordering(missingGreatest = true)
+    implicit val locusOrd = vsm.matrixType.locusType.ordering.toOrdering
 
     val ab = new ArrayBuilder[(Interval[Annotation], Annotation)]()
     iList.foreach { case (i, v) =>

--- a/src/main/scala/is/hail/rvd/OrderedRVPartitioner.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVPartitioner.scala
@@ -25,7 +25,7 @@ class OrderedRVPartitioner(
   val rangeBoundsType = TArray(pkType)
   assert(rangeBoundsType.typeCheck(rangeBounds))
 
-  val ordering: Ordering[Annotation] = pkType.ordering(missingGreatest = true)
+  val ordering: Ordering[Annotation] = pkType.ordering.toOrdering
   require(rangeBounds.isEmpty || rangeBounds.zip(rangeBounds.tail).forall { case (left, right) => ordering.compare(left, right) < 0 })
 
   def region: Region = rangeBounds.region

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -910,9 +910,7 @@ class Table(val hc: HailContext,
     val sortColIndexOrd = sortCols.map { case SortColumn(n, so) =>
       val i = signature.fieldIdx(n)
       val f = signature.fields(i)
-
-      val fo = f.typ.ordering(so == Ascending)
-
+      val fo = f.typ.ordering
       (i, if (so == Ascending) fo else fo.reverse)
     }
 

--- a/src/main/scala/is/hail/utils/package.scala
+++ b/src/main/scala/is/hail/utils/package.scala
@@ -214,32 +214,6 @@ package object utils extends Logging
 
   def uriPath(uri: String): String = new URI(uri).getPath
 
-  def annotationOrdering[T](ord: Ordering[T]): Ordering[Annotation] = {
-    new Ordering[Annotation] {
-      def compare(a: Annotation, b: Annotation): Int = ord.compare(a.asInstanceOf[T], b.asInstanceOf[T])
-    }
-  }
-
-  def extendOrderingToNull[T](missingGreatest: Boolean)(implicit ord: Ordering[T]): Ordering[T] = {
-    new Ordering[T] {
-      def compare(a: T, b: T): Int =
-        if (a == null) {
-          if (b == null)
-            0 // null, null
-          else {
-            // null, _
-            if (missingGreatest) 1 else -1
-          }
-        } else {
-          if (b == null) {
-            // _, null
-            if (missingGreatest) -1 else 1
-          } else
-            ord.compare(a, b)
-        }
-    }
-  }
-
   sealed trait FlattenOrNull[C[_] >: Null] {
     def apply[T >: Null](b: mutable.Builder[T, C[T]], it: Iterable[Iterable[T]]): C[T] = {
       for (elt <- it) {

--- a/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
+++ b/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
@@ -292,4 +292,27 @@ class AnnotationsSuite extends SparkSuite {
 
     assert(hc.readVDS(f).same(vds))
   }
+
+  @Test def testExtendedOrdering() {
+    val ord = ExtendedOrdering.extendToNull(implicitly[Ordering[Int]])
+    val rord = ord.reverse
+
+    assert(ord.lt(5, 7))
+    assert(ord.lt(5, null))
+    assert(ord.gt(null, 7))
+    assert(ord.equiv(3, 3))
+    assert(ord.equiv(null, null))
+    assert(ord.max(5, 7) == 7)
+    assert(ord.max(5, null) == null)
+    assert(ord.min(5, 7) == 5)
+    assert(ord.min(5, null) == 5)
+
+    assert(rord.gt(5, 7))
+    assert(rord.lt(5, null))
+    assert(rord.gt(null, 7))
+    assert(rord.max(5, 7) == 5)
+    assert(rord.max(5, null) == null)
+    assert(rord.min(5, 7) == 7)
+    assert(rord.min(5, null) == 5)
+  }
 }

--- a/src/test/scala/is/hail/annotations/UnsafeSuite.scala
+++ b/src/test/scala/is/hail/annotations/UnsafeSuite.scala
@@ -224,7 +224,7 @@ class UnsafeSuite extends SparkSuite {
     rvb2.addAnnotation(t, v2)
     val rv2 = RegionValue(region2, rvb2.end())
 
-    assert(math.signum(t.ordering(missingGreatest = true).compare(v1, v2)) ==
+    assert(math.signum(t.ordering.compare(v1, v2, missingGreatest = true)) ==
       math.signum(t.unsafeOrdering(missingGreatest = true).compare(rv, rv2)))
   }
 
@@ -259,11 +259,11 @@ class UnsafeSuite extends SparkSuite {
       val ur2 = new UnsafeRow(t, region2, offset2)
       assert(t.valuesSimilar(a2, ur2))
 
-      val ord = t.ordering(b)
+      val ord = t.ordering
       val uord = t.unsafeOrdering(b)
 
-      val c1 = ord.compare(a1, a2)
-      val c2 = ord.compare(ur1, ur2)
+      val c1 = ord.compare(a1, a2, b)
+      val c2 = ord.compare(ur1, ur2, b)
       val c3 = uord.compare(ur1.region, ur1.offset, ur2.region, ur2.offset)
 
       val p1 = math.signum(c1) == math.signum(c2)

--- a/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -1104,7 +1104,7 @@ class ExprSuite extends SparkSuite {
   }
 
   @Test def testOrdering() {
-    val intOrd = TInt32().ordering(true)
+    val intOrd = TInt32().ordering
 
     assert(intOrd.compare(-2, -2) == 0)
     assert(intOrd.compare(null, null) == 0)
@@ -1117,7 +1117,7 @@ class ExprSuite extends SparkSuite {
       b <- t.genValue) yield (t, a, b)
 
     val p = forAll(g) { case (t, a, b) =>
-      val ord = t.ordering(missingGreatest = true)
+      val ord = t.ordering
       ord.compare(a, b) == -ord.compare(b, a)
     }
     p.check()

--- a/src/test/scala/is/hail/variant/GenomeReferenceSuite.scala
+++ b/src/test/scala/is/hail/variant/GenomeReferenceSuite.scala
@@ -156,8 +156,8 @@ class GenomeReferenceSuite extends SparkSuite {
     ktann.signature.field("v3").typ == GenomeReference.GRCh37.variant &&
     ktann.signature.field("l1").typ == GenomeReference.GRCh38.locus &&
     ktann.signature.field("l2").typ == GenomeReference.GRCh37.locus &&
-    ktann.signature.field("i1").typ == GenomeReference.GRCh37.interval &&
-    ktann.signature.field("i2").typ == GenomeReference.GRCh38.interval)
+    ktann.signature.field("i1").typ == TInterval(GenomeReference.GRCh37.locus) &&
+    ktann.signature.field("i2").typ == TInterval(GenomeReference.GRCh38.locus))
 
     assert(ktann.forall("v1.inXPar() && v2.inXPar() && v3.isAutosomal() &&" +
       "l1.position == 100 && l2.position == 100 &&" +
@@ -167,7 +167,7 @@ class GenomeReferenceSuite extends SparkSuite {
     GenomeReference.addReference(gr)
     GenomeReference.setDefaultReference(gr)
     assert(kt.annotate("""v1 = Variant("chrX:156030895:A:T")""").signature.field("v1").typ == gr.variant)
-    assert(kt.annotate("""i1 = Interval(Locus(foo2)("1:100"), Locus(foo2)("1:104"))""").signature.field("i1").typ == gr.interval)
+    assert(kt.annotate("""i1 = Interval(Locus(foo2)("1:100"), Locus(foo2)("1:104"))""").signature.field("i1").typ == TInterval(gr.locus))
 
     GenomeReference.setDefaultReference(GenomeReference.GRCh37)
     GenomeReference.removeReference("foo2")


### PR DESCRIPTION
I want to make ordering a val instead of a def so it doesn't have to be recreated, but that means I need a way to pass missingGreatest as a parameter in compare.  Hence, ExtendedOrdering.  There are variants of compare, etc. that default missingGreatest = true since that is the default.  All the overrides are necessary because lt, etc. can't always be determined from compare (e.g. nan compares false with everything for all comparison operations).  This is used by a future PR for generic interval comparison.