### PR TITLE
[0.1] Make Bgen12GenotypeIterator serializable.

### DIFF
--- a/src/main/scala/is/hail/io/bgen/BgenRecord.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenRecord.scala
@@ -97,7 +97,7 @@ class BGen12ProbabilityArray(a: Array[Byte], nSamples: Int, nGenotypes: Int, nBi
 final class Bgen12GenotypeIterator(a: Array[Byte],
   val nAlleles: Int,
   val nBitsPerProb: Int,
-  nSamples: Int) extends Iterable[Genotype] {
+  nSamples: Int) extends Iterable[Genotype] with Serializable {
   private val nGenotypes = triangle(nAlleles)
 
   private val totalProb = ((1L << nBitsPerProb) - 1).toUInt


### PR DESCRIPTION
It should be in case the BGEN is shuffled.