### PR TITLE
strike references to 2.1.0

### DIFF
--- a/python/hail/docs/getting_started.rst
+++ b/python/hail/docs/getting_started.rst
@@ -210,16 +210,16 @@ Building with other versions of Spark 2
 =======================================
 
 Hail should work with other versions of Spark 2.  To build against a
-different version, such as Spark 2.1.0, modify the above
+different version, such as Spark 2.2.0, modify the above
 instructions as follows:
 
  - Set the Spark version in the gradle command
 
    .. code-block:: text
 
-      $ ./gradlew -Dspark.version=2.1.0 shadowJar
+      $ ./gradlew -Dspark.version=2.2.0 shadowJar
 
- - ``SPARK_HOME`` should point to an installation of the desired version of Spark, such as *spark-2.1.0-bin-hadoop2.7*
+ - ``SPARK_HOME`` should point to an installation of the desired version of Spark, such as *spark-2.2.0-bin-hadoop2.7*
 
  - The version of the Py4J ZIP file in the hail alias must match the version in ``$SPARK_HOME/python/lib`` in your version of Spark.
 


### PR DESCRIPTION
Don't even give the impression that we might support 2.1.0.