### PR TITLE
make MatrixTable.unpersist return itself

### DIFF
--- a/python/hail/api2/matrixtable.py
+++ b/python/hail/api2/matrixtable.py
@@ -2208,8 +2208,7 @@ class MatrixTable(object):
         :class:`MatrixTable`
             Unpersisted dataset.
         """
-        self._jvds.unpersist()
-        return self
+        return MatrixTable(self._jvds.unpersist())
 
     @handle_py4j
     @typecheck_method(other=matrix_table_type,

--- a/python/hail/api2/matrixtable.py
+++ b/python/hail/api2/matrixtable.py
@@ -2209,6 +2209,7 @@ class MatrixTable(object):
             Unpersisted dataset.
         """
         self._jvds.unpersist()
+        return self
 
     @handle_py4j
     @typecheck_method(other=matrix_table_type,


### PR DESCRIPTION
@tpoterba I'm not entirely sure this is the correct thing to do (rather than make it return nothing) because it does still mutate the original dataset. I don't really think anyone will get tripped up by this, but it feels a little silly. What do you think?