### PR TITLE
move `sample_variants` to api2 as `sample_rows`

### DIFF
--- a/python/hail/docs/methods/index.rst
+++ b/python/hail/docs/methods/index.rst
@@ -7,6 +7,7 @@ Methods
 .. autosummary::
 
     hail.methods.linreg
+    hail.methods.sample_rows
     hail.methods.sample_qc
     hail.methods.variant_qc
     hail.methods.ld_matrix
@@ -17,6 +18,7 @@ Methods
     hail.methods.split_multi_hts
 
 .. autofunction:: hail.methods.linreg
+.. autofunction:: hail.methods.sample_rows
 .. autofunction:: hail.methods.sample_qc
 .. autofunction:: hail.methods.variant_qc
 .. autofunction:: hail.methods.ld_matrix

--- a/python/hail/methods/__init__.py
+++ b/python/hail/methods/__init__.py
@@ -1,10 +1,11 @@
 from .family_methods import trio_matrix
-from .statgen import linreg, ld_matrix, pca, hwe_normalized_pca, split_multi_hts
+from .statgen import linreg, sample_rows, ld_matrix, pca, hwe_normalized_pca, split_multi_hts
 from .qc import sample_qc, variant_qc
 from .misc import rename_duplicates
 
 __all__ = ['trio_matrix',
            'linreg',
+           'sample_rows',
            'ld_matrix',
            'sample_qc',
            'variant_qc',

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -367,7 +367,7 @@ def sample_rows(dataset, fraction, seed=1):
     Notes
     -----
 
-    This method may not sample exactly ``(fraction * n_variants)`` rows from
+    This method may not sample exactly ``(fraction * n_rows)`` rows from
     the dataset.
 
     Parameters

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -362,7 +362,7 @@ def sample_rows(dataset, fraction, seed=1):
     Examples
     --------
 
-    >>> small_dataset = sample_rows(dataset, 0.01)
+    >>> small_dataset = methods.sample_rows(dataset, 0.01)
 
     Notes
     -----
@@ -385,7 +385,7 @@ def sample_rows(dataset, fraction, seed=1):
         Downsampled matrix table.
     """
 
-    return MatrixTable(dataset.hc, dataset._jvds.sampleVariants(fraction, seed))
+    return MatrixTable(dataset._jvds.sampleVariants(fraction, seed))
 
 @handle_py4j
 @typecheck(ds=MatrixTable,

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -353,6 +353,41 @@ def pca(entry_expr, k=10, compute_loadings=False, as_array=False):
     return (jiterable_to_list(r._1()), scores, loadings)
 
 @handle_py4j
+@typecheck(dataset=MatrixTable,
+           fraction=numeric,
+           seed=integral)
+def sample_rows(dataset, fraction, seed=1):
+    """Downsample rows to a given fraction of the dataset.
+
+    Examples
+    --------
+
+    >>> small_dataset = sample_rows(dataset, 0.01)
+
+    Notes
+    -----
+
+    This method may not sample exactly ``(fraction * n_variants)`` rows from
+    the dataset.
+
+    Parameters
+    ----------
+    dataset : :class:`.MatrixTable`
+        Dataset to sample from.
+    fraction : :obj:`float`
+        (Expected) fraction of rows to keep.
+    seed : :obj:`int`
+        Random seed.
+
+    Returns
+    ------
+    :class:`.MatrixTable`
+        Downsampled matrix table.
+    """
+
+    return MatrixTable(dataset.hc, dataset._jvds.sampleVariants(fraction, seed))
+
+@handle_py4j
 @typecheck(ds=MatrixTable,
            keep_star=bool,
            left_aligned=bool)


### PR DESCRIPTION
I couldn't find any tests of `sample_variants` in either the Python or Scala suites, nor could I think of any good tests. But it's such a direct interface to `RDD.sample`, that seems okay to me. I can add tests if anyone has suggestions.