### PR TITLE
made interval generic on the JVM side

### DIFF
--- a/src/main/scala/is/hail/annotations/Annotation.scala
+++ b/src/main/scala/is/hail/annotations/Annotation.scala
@@ -77,10 +77,11 @@ object Annotation {
 
         case _: TAltAllele => a.asInstanceOf[AltAllele].toRow
 
-        case _: TInterval =>
-          val i = a.asInstanceOf[Interval[Locus]]
-          Annotation(i.start.toRow,
-            i.end.toRow)
+        case TInterval(pointType, _) =>
+          val i = a.asInstanceOf[Interval]
+          Annotation(
+            expandAnnotation(i.start, pointType),
+            expandAnnotation(i.end, pointType))
 
         // including TChar, TSample
         case _ => a

--- a/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
+++ b/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
@@ -491,7 +491,7 @@ class RegionValueBuilder(var region: Region) {
           endStruct()
 
         case t: TInterval =>
-          val i = a.asInstanceOf[Interval[Annotation]]
+          val i = a.asInstanceOf[Interval]
           startStruct()
           addAnnotation(t.pointType, i.start)
           addAnnotation(t.pointType, i.end)

--- a/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -222,7 +222,7 @@ object UnsafeRow {
             read(x.pointType, region, ft.loadField(region, offset, 1))
           else
             null
-        Interval[Annotation](start, end)(x.pointType.ordering.toOrdering)
+        Interval(start, end)
     }
   }
 }

--- a/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -139,7 +139,7 @@ object UnsafeRow {
     new String(readBinary(region, boff))
 
   def readLocus(region: Region, offset: Long, gr: GRBase): Locus = {
-    val ft = gr.locus.fundamentalType.asInstanceOf[TStruct]
+    val ft = gr.locusType.fundamentalType.asInstanceOf[TStruct]
     Locus(
       readString(region, ft.loadField(region, offset, 0)),
       region.loadInt(ft.loadField(region, offset, 1)))

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -438,9 +438,9 @@ case class StructConstructor(posn: Position, names: Array[String], elements: Arr
 case class GenomeReferenceDependentConstructor(posn: Position, fName: String, grName: String, args: Array[AST]) extends AST(posn, args) {
   val gr = GenomeReference.getReference(grName)
   val rTyp = fName match {
-    case "Variant" => gr.variant
-    case "Locus" => gr.locus
-    case "LocusInterval" => TInterval(gr.locus)
+    case "Variant" => gr.variantType
+    case "Locus" => gr.locusType
+    case "LocusInterval" => gr.intervalType
     case _ => throw new UnsupportedOperationException
   }
 

--- a/src/main/scala/is/hail/expr/AnnotationImpex.scala
+++ b/src/main/scala/is/hail/expr/AnnotationImpex.scala
@@ -91,7 +91,7 @@ object SparkAnnotationImpex extends AnnotationImpex[DataType, Any] {
           Locus(r.getAs[String](0), r.getAs[Int](1))
         case x: TInterval =>
           val r = a.asInstanceOf[Row]
-          Interval(importAnnotation(r.get(0), x.pointType), importAnnotation(r.get(1), x.pointType))(x.pointType.ordering.toOrdering)
+          Interval(importAnnotation(r.get(0), x.pointType), importAnnotation(r.get(1), x.pointType))
         case TStruct(fields, _) =>
           if (fields.isEmpty)
             if (a.asInstanceOf[Boolean]) Annotation.empty else null
@@ -170,7 +170,7 @@ object SparkAnnotationImpex extends AnnotationImpex[DataType, Any] {
           val l = a.asInstanceOf[Locus]
           Row(l.contig, l.position)
         case TInterval(pointType, _) =>
-          val i = a.asInstanceOf[Interval[_]]
+          val i = a.asInstanceOf[Interval]
           Row(exportAnnotation(i.start, pointType), exportAnnotation(i.end, pointType))
         case TStruct(fields, _) =>
           if (fields.isEmpty)
@@ -195,8 +195,6 @@ case class JSONExtractVariant(contig: String,
 }
 
 case class JSONExtractIntervalLocus(start: Locus, end: Locus) {
-  def toInterval(ord: Ordering[Locus]) = Interval(start, end)(ord)
-
   def toLocusTuple: (Locus, Locus) = (start, end)
 }
 
@@ -289,7 +287,7 @@ object JSONAnnotationImpex extends AnnotationImpex[Type, JValue] {
         case _: TAltAllele => a.asInstanceOf[AltAllele].toJSON
         case TVariant(_, _) => a.asInstanceOf[Variant].toJSON
         case TLocus(_, _) => a.asInstanceOf[Locus].toJSON
-        case TInterval(pointType, _) => a.asInstanceOf[Interval[Annotation]].toJSON(pointType.toJSON)
+        case TInterval(pointType, _) => a.asInstanceOf[Interval].toJSON(pointType.toJSON)
         case TStruct(fields, _) =>
           val row = a.asInstanceOf[Row]
           JObject(fields
@@ -381,8 +379,8 @@ object JSONAnnotationImpex extends AnnotationImpex[Type, JValue] {
       case (_, TInterval(pointType, _)) =>
         jv match {
           case JObject(List(("start", sjv), ("end", ejv))) =>
-            Interval[Annotation](importAnnotation(sjv, pointType, parent + ".start"),
-              importAnnotation(ejv, pointType, parent + ".end"))(pointType.ordering.toOrdering)
+            Interval(importAnnotation(sjv, pointType, parent + ".start"),
+              importAnnotation(ejv, pointType, parent + ".end"))
           case _ =>
             warn(s"Can't convert JSON value $jv to type $t at $parent.")
             null
@@ -420,9 +418,9 @@ object TableAnnotationImpex extends AnnotationImpex[Unit, String] {
         case it: TIterable => JsonMethods.compact(it.toJSON(a))
         case t: TStruct => JsonMethods.compact(t.toJSON(a))
         case TInterval(TLocus(gr, _), _) =>
-          val i = a.asInstanceOf[Interval[Locus]]
-          if (i.start.contig == i.end.contig)
-            s"${ i.start }-${ i.end.position }"
+          val i = a.asInstanceOf[Interval]
+          if (i.start.asInstanceOf[Locus].contig == i.end.asInstanceOf[Locus].contig)
+            s"${ i.start }-${ i.end.asInstanceOf[Locus].position }"
           else
             s"${ i.start }-${ i.end }"
         case _: TInterval =>

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -464,6 +464,11 @@ object FunctionRegistry {
     bind(name, MethodType(hrt.typ, hru.typ), BinaryFun[T, U, V](hrv.typ, impl), MetaData(Option(docstring), argNames))
   }
 
+  def registerMethodDependent[T, U, V](name: String, impl: () => (T, U) => V, docstring: String, argNames: (String, String)*)
+    (implicit hrt: HailRep[T], hru: HailRep[U], hrv: HailRep[V]) = {
+    bind(name, MethodType(hrt.typ, hru.typ), BinaryDependentFun[T, U, V](hrv.typ, impl), MetaData(Option(docstring), argNames))
+  }
+
   def registerMethodCode[T, U, V](name: String, impl: (Code[T], Code[U]) => CM[Code[V]], docstring: String, argNames: (String, String)*)
     (implicit hrt: HailRep[T], hru: HailRep[U], hrv: HailRep[V]) = {
     bind(name, MethodType(hrt.typ, hru.typ), BinaryFunCode[T, U, V](hrv.typ, impl), MetaData(Option(docstring), argNames))
@@ -790,8 +795,8 @@ object FunctionRegistry {
   }, "True if chromosome is not X, not Y, and not MT.")(variantHr(GR), boolHr)
   registerField("contig", { (x: Locus) => x.contig }, "String representation of contig.")(locusHr(GR), stringHr)
   registerField("position", { (x: Locus) => x.position }, "Chromosomal position.")(locusHr(GR), int32Hr)
-  registerField("start", { (x: Interval[Annotation]) => x.start }, "Start of the interval (inclusive).")(intervalHr(TTHr), TTHr)
-  registerField("end", { (x: Interval[Annotation]) => x.end }, "End of the interval (exclusive).")(intervalHr(TTHr), TTHr)
+  registerField("start", { (x: Interval) => x.start }, "Start of the interval (inclusive).")(intervalHr(TTHr), TTHr)
+  registerField("end", { (x: Interval) => x.end }, "End of the interval (exclusive).")(intervalHr(TTHr), TTHr)
   registerField("ref", { (x: AltAllele) => x.ref }, "Reference allele base sequence.")
   registerField("alt", { (x: AltAllele) => x.alt }, "Alternate allele base sequence.")
   registerMethod("isSNP", { (x: AltAllele) => x.isSNP }, "True if ``v.ref`` and ``v.alt`` are the same length and differ in one position.")
@@ -1092,7 +1097,7 @@ object FunctionRegistry {
     "pos" -> "SNP position or start of an indel.")(stringHr, int32Hr, locusHr(GR))
   registerDependent("Interval", () => {
     val t = TT.t
-    (x: Annotation, y: Annotation) => Interval(x, y)(t.ordering.toOrdering)
+    (x: Annotation, y: Annotation) => Interval(x, y)
   },
     """
     Construct an Interval object. Intervals are **left inclusive, right exclusive**.  This means that ``[chr1:1, chr1:3)`` contains ``chr1:1`` and ``chr1:2``.
@@ -1288,7 +1293,7 @@ object FunctionRegistry {
   registerDependent("LocusInterval", () => {
     val gr = GR.gr
     (chr: String, start: Int, end: Int) => {
-      implicit val locusOrdering = gr.locusOrdering
+      implicit val ord = TInterval(gr.locus).ordering
       Interval(Locus(chr, start), Locus(chr, end))
     }
   },
@@ -1585,7 +1590,10 @@ object FunctionRegistry {
     character frequency distribution.
     """)
 
-  registerMethod("contains", (interval: Interval[Annotation], point: Annotation) => interval.contains(point),
+  registerMethodDependent("contains", () => {
+    val pord = TT.t.ordering
+    (interval: Interval, point: Annotation) => interval.contains(pord, point)
+  },
     """
     Returns true if the ``point`` is contained in the interval.
 

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -1293,7 +1293,7 @@ object FunctionRegistry {
   registerDependent("LocusInterval", () => {
     val gr = GR.gr
     (chr: String, start: Int, end: Int) => {
-      implicit val ord = TInterval(gr.locus).ordering
+      implicit val ord = gr.intervalType.ordering
       Interval(Locus(chr, start), Locus(chr, end))
     }
   },

--- a/src/main/scala/is/hail/expr/HailRep.scala
+++ b/src/main/scala/is/hail/expr/HailRep.scala
@@ -70,7 +70,7 @@ trait HailRepFunctions {
     def typ = TAltAllele()
   }
 
-  implicit def intervalHr[T](implicit hrt: HailRep[T]) = new HailRep[Interval[T]] {
+  implicit def intervalHr[T](implicit hrt: HailRep[T]) = new HailRep[Interval] {
     def typ = TInterval(hrt.typ)
   }
 

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -545,7 +545,7 @@ object Parser extends JavaTokenParsers {
   def _type_expr: Parser[Type] =
     "Empty" ^^ { _ => TStruct.empty() } |
   // FIXME for backward compatability
-      "Interval" ~> ("(" ~> identifier <~ ")" ^^ { id => TInterval(GenomeReference.getReference(id).locus) } |
+      "Interval" ~> ("(" ~> identifier <~ ")" ^^ { id => TInterval(GenomeReference.getReference(id).locusType) } |
         "[" ~> type_expr <~ "]" ^^ { pointType => TInterval(pointType) }) |
       "Boolean" ^^ { _ => TBoolean() } |
       "Int32" ^^ { _ => TInt32() } |
@@ -556,8 +556,8 @@ object Parser extends JavaTokenParsers {
       "Float" ^^ { _ => TFloat64() } |
       "String" ^^ { _ => TString() } |
       "AltAllele" ^^ { _ => TAltAllele() } |
-      ("Variant" ~ "(") ~> identifier <~ ")" ^^ { id => GenomeReference.getReference(id).variant } |
-      ("Locus" ~ "(") ~> identifier <~ ")" ^^ { id => GenomeReference.getReference(id).locus } |
+      ("Variant" ~ "(") ~> identifier <~ ")" ^^ { id => GenomeReference.getReference(id).variantType } |
+      ("Locus" ~ "(") ~> identifier <~ ")" ^^ { id => GenomeReference.getReference(id).locusType } |
       "Call" ^^ { _ => TCall() } |
       ("Array" ~ "[") ~> type_expr <~ "]" ^^ { elementType => TArray(elementType) } |
       ("Set" ~ "[") ~> type_expr <~ "]" ^^ { elementType => TSet(elementType) } |

--- a/src/main/scala/is/hail/expr/types/TInterval.scala
+++ b/src/main/scala/is/hail/expr/types/TInterval.scala
@@ -18,19 +18,19 @@ case class TInterval(pointType: Type, override val required: Boolean = false) ex
     sb.append("]")
   }
 
-  def _typeCheck(a: Any): Boolean = a.isInstanceOf[Interval[_]] && {
-    val i = a.asInstanceOf[Interval[_]]
+  def _typeCheck(a: Any): Boolean = a.isInstanceOf[Interval] && {
+    val i = a.asInstanceOf[Interval]
     pointType.typeCheck(i.start) && pointType.typeCheck(i.end)
   }
 
-  override def genNonmissingValue: Gen[Annotation] = Interval.gen(pointType.genValue)(pointType.ordering.toOrdering)
+  override def genNonmissingValue: Gen[Annotation] = Interval.gen(pointType.ordering, pointType.genValue)
 
   override def desc: String = "An ``Interval[T]`` is a Hail data type representing a range over ordered values of type T."
 
-  override def scalaClassTag: ClassTag[Interval[Annotation]] = classTag[Interval[Annotation]]
+  override def scalaClassTag: ClassTag[Interval] = classTag[Interval]
 
   val ordering: ExtendedOrdering =
-    ExtendedOrdering.extendToNull(Interval.ordering[Annotation])
+    ExtendedOrdering.extendToNull(Interval.ordering(pointType.ordering))
 
   override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering = representation.unsafeOrdering(missingGreatest)
 

--- a/src/main/scala/is/hail/expr/types/TLocus.scala
+++ b/src/main/scala/is/hail/expr/types/TLocus.scala
@@ -65,5 +65,5 @@ case class TLocus(gr: GRBase, override val required: Boolean = false) extends Co
 
   override def clear(): Unit = gr.clear()
 
-  override def subst() = gr.subst().locus
+  override def subst() = gr.subst().locusType
 }

--- a/src/main/scala/is/hail/expr/types/TVariant.scala
+++ b/src/main/scala/is/hail/expr/types/TVariant.scala
@@ -113,5 +113,5 @@ case class TVariant(gr: GRBase, override val required: Boolean = false) extends 
 
   override def clear(): Unit = gr.clear()
 
-  override def subst() = gr.subst().variant
+  override def subst() = gr.subst().variantType
 }

--- a/src/main/scala/is/hail/io/annotators/BedAnnotator.scala
+++ b/src/main/scala/is/hail/io/annotators/BedAnnotator.scala
@@ -42,7 +42,7 @@ object BedAnnotator {
     else
       TStruct("interval" -> TInterval(TLocus(gr)))
 
-    implicit val locusOrd = gr.locusOrdering
+    implicit val ord = TInterval(gr.locus).ordering
 
     val rdd = hc.sc.textFileLines(filename)
       .filter(line =>

--- a/src/main/scala/is/hail/io/annotators/BedAnnotator.scala
+++ b/src/main/scala/is/hail/io/annotators/BedAnnotator.scala
@@ -42,7 +42,7 @@ object BedAnnotator {
     else
       TStruct("interval" -> TInterval(TLocus(gr)))
 
-    implicit val ord = TInterval(gr.locus).ordering
+    implicit val ord = TInterval(gr.locusType).ordering
 
     val rdd = hc.sc.textFileLines(filename)
       .filter(line =>

--- a/src/main/scala/is/hail/io/annotators/IntervalList.scala
+++ b/src/main/scala/is/hail/io/annotators/IntervalList.scala
@@ -37,7 +37,7 @@ object IntervalList {
     else
       TStruct("interval" -> TInterval(TLocus(gr)))
 
-    implicit val locusOrd = gr.locusOrdering
+    implicit val ord = gr.locus.ordering
 
     val rdd = hc.sc.textFileLines(filename)
       .filter(l => !l.value.isEmpty && l.value(0) != '@')

--- a/src/main/scala/is/hail/io/annotators/IntervalList.scala
+++ b/src/main/scala/is/hail/io/annotators/IntervalList.scala
@@ -37,7 +37,7 @@ object IntervalList {
     else
       TStruct("interval" -> TInterval(TLocus(gr)))
 
-    implicit val ord = gr.locus.ordering
+    implicit val ord = gr.locusType.ordering
 
     val rdd = hc.sc.textFileLines(filename)
       .filter(l => !l.value.isEmpty && l.value(0) != '@')

--- a/src/main/scala/is/hail/kryo/HailKryoRegistrator.scala
+++ b/src/main/scala/is/hail/kryo/HailKryoRegistrator.scala
@@ -12,9 +12,5 @@ class HailKryoRegistrator extends KryoRegistrator {
     kryo.register(classOf[UnsafeRow])
     kryo.register(classOf[UnsafeIndexedSeq])
     kryo.register(classOf[Region])
-
-    // work around https://github.com/EsotericSoftware/kryo/pull/342
-    // which is fixed in 4.0.0 but Spark ships with (shaded) 3.0.3
-    kryo.register(classOf[Interval[_]], new JavaSerializer())
   }
 }

--- a/src/main/scala/is/hail/methods/FilterIntervals.scala
+++ b/src/main/scala/is/hail/methods/FilterIntervals.scala
@@ -8,13 +8,13 @@ import scala.collection.JavaConverters._
 
 object FilterIntervals {
   def apply(vsm: MatrixTable, intervals: java.util.ArrayList[Interval], keep: Boolean): MatrixTable = {
-    val pord = vsm.genomeReference.locus.ordering
-    val iList = IntervalTree(vsm.genomeReference.locus.ordering, intervals.asScala.toArray)
+    val pord = vsm.genomeReference.locusType.ordering
+    val iList = IntervalTree(vsm.genomeReference.locusType.ordering, intervals.asScala.toArray)
     apply(vsm, iList, keep)
   }
 
   def apply[U](vsm: MatrixTable, iList: IntervalTree[U], keep: Boolean): MatrixTable = {
-    val pord = vsm.genomeReference.locus.ordering
+    val pord = vsm.genomeReference.locusType.ordering
 
     val ab = new ArrayBuilder[(Interval, Annotation)]()
     iList.foreach { case (i, v) =>

--- a/src/main/scala/is/hail/methods/ImputeSexPlink.scala
+++ b/src/main/scala/is/hail/methods/ImputeSexPlink.scala
@@ -14,12 +14,12 @@ object ImputeSexPlink {
 
     val gr = vsm.genomeReference
 
-    val xIntervals = IntervalTree(gr.locus.ordering,
+    val xIntervals = IntervalTree(gr.locusType.ordering,
       gr.xContigs.map(contig => Interval(Locus(contig, 0), Locus(contig, gr.contigLength(contig)))).toArray)
     vsm = FilterIntervals(vsm, xIntervals, keep = true)
 
     if (!includePar)
-      vsm = FilterIntervals(vsm, IntervalTree(gr.locus.ordering, gr.par), keep = false)
+      vsm = FilterIntervals(vsm, IntervalTree(gr.locusType.ordering, gr.par), keep = false)
 
     vsm = vsm.annotateVariantsExpr(
       s"va = ${ popFrequencyExpr.getOrElse("gs.map(g => g.GT.nNonRefAlleles).sum().toFloat64() / gs.filter(g => isDefined(g.GT)).count() / 2") }")

--- a/src/main/scala/is/hail/methods/ImputeSexPlink.scala
+++ b/src/main/scala/is/hail/methods/ImputeSexPlink.scala
@@ -13,13 +13,13 @@ object ImputeSexPlink {
     var vsm = in
 
     val gr = vsm.genomeReference
-    implicit val locusOrd = gr.locusOrdering
 
-    val xIntervals = IntervalTree(gr.xContigs.map(contig => Interval(Locus(contig, 0), Locus(contig, gr.contigLength(contig)))).toArray)
+    val xIntervals = IntervalTree(gr.locus.ordering,
+      gr.xContigs.map(contig => Interval(Locus(contig, 0), Locus(contig, gr.contigLength(contig)))).toArray)
     vsm = FilterIntervals(vsm, xIntervals, keep = true)
 
     if (!includePar)
-      vsm = FilterIntervals(vsm, IntervalTree(gr.par), keep = false)
+      vsm = FilterIntervals(vsm, IntervalTree(gr.locus.ordering, gr.par), keep = false)
 
     vsm = vsm.annotateVariantsExpr(
       s"va = ${ popFrequencyExpr.getOrElse("gs.map(g => g.GT.nNonRefAlleles).sum().toFloat64() / gs.filter(g => isDefined(g.GT)).count() / 2") }")

--- a/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -24,12 +24,12 @@ trait Py4jUtils {
   }
 
   def parseIntervalList(strs: java.util.ArrayList[String], gr: GenomeReference): IntervalTree[Unit] = {
-    IntervalTree(gr.locus.ordering, Locus.parseIntervals(strs.asScala.toArray, gr))
+    IntervalTree(gr.locusType.ordering, Locus.parseIntervals(strs.asScala.toArray, gr))
   }
 
 
   def makeIntervalList(intervals: java.util.ArrayList[Interval], gr: GenomeReference): IntervalTree[Unit] = {
-    IntervalTree(gr.locus.ordering, intervals.asScala.toArray)
+    IntervalTree(gr.locusType.ordering, intervals.asScala.toArray)
   }
 
   // we cannot construct an array because we don't have the class tag

--- a/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -23,15 +23,13 @@ trait Py4jUtils {
     list
   }
 
-  def parseIntervalList(strs: java.util.ArrayList[String], gr: GenomeReference): IntervalTree[Locus, Unit] = {
-    implicit val locusOrd = gr.locusOrdering
-    IntervalTree(Locus.parseIntervals(strs.asScala.toArray, gr))
+  def parseIntervalList(strs: java.util.ArrayList[String], gr: GenomeReference): IntervalTree[Unit] = {
+    IntervalTree(gr.locus.ordering, Locus.parseIntervals(strs.asScala.toArray, gr))
   }
 
 
-  def makeIntervalList(intervals: java.util.ArrayList[Interval[Locus]], gr: GenomeReference): IntervalTree[Locus, Unit] = {
-    implicit val locusOrd = gr.locusOrdering
-    IntervalTree(intervals.asScala.toArray)
+  def makeIntervalList(intervals: java.util.ArrayList[Interval], gr: GenomeReference): IntervalTree[Unit] = {
+    IntervalTree(gr.locus.ordering, intervals.asScala.toArray)
   }
 
   // we cannot construct an array because we don't have the class tag

--- a/src/main/scala/is/hail/variant/GenomeReference.scala
+++ b/src/main/scala/is/hail/variant/GenomeReference.scala
@@ -15,8 +15,8 @@ import scala.collection.mutable
 import scala.language.implicitConversions
 
 abstract class GRBase extends Serializable {
-  val variant: TVariant
-  val locus: TLocus
+  val variantType: TVariant
+  val locusType: TLocus
   val intervalType: TInterval
 
   def variantOrdering: Ordering[Variant]
@@ -127,9 +127,9 @@ case class GenomeReference(name: String, contigs: Array[String], lengths: Map[St
   }
 
   // must be constructed after orderings
-  val variant: TVariant = TVariant(this)
-  val locus: TLocus = TLocus(this)
-  val intervalType: TInterval = TInterval(locus)
+  val variantType: TVariant = TVariant(this)
+  val locusType: TLocus = TLocus(this)
+  val intervalType: TInterval = TInterval(locusType)
 
   val par = parInput.map { case (start, end) =>
     if (start.contig != end.contig)
@@ -167,9 +167,9 @@ case class GenomeReference(name: String, contigs: Array[String], lengths: Map[St
 
   def isMitochondrial(contig: String): Boolean = mtContigs.contains(contig)
 
-  def inXPar(l: Locus): Boolean = inX(l.contig) && par.exists(_.contains(locus.ordering, l))
+  def inXPar(l: Locus): Boolean = inX(l.contig) && par.exists(_.contains(locusType.ordering, l))
 
-  def inYPar(l: Locus): Boolean = inY(l.contig) && par.exists(_.contains(locus.ordering, l))
+  def inYPar(l: Locus): Boolean = inY(l.contig) && par.exists(_.contains(locusType.ordering, l))
 
   def compare(contig1: String, contig2: String): Int = GenomeReference.compare(contigsIndex, contig1, contig2)
 
@@ -363,9 +363,9 @@ object GenomeReference {
 }
 
 case class GRVariable(var gr: GRBase = null) extends GRBase {
-  val variant: TVariant = TVariant(this)
-  val locus: TLocus = TLocus(this)
-  val intervalType: TInterval = TInterval(locus)
+  val variantType: TVariant = TVariant(this)
+  val locusType: TLocus = TLocus(this)
+  val intervalType: TInterval = TInterval(locusType)
 
   override def toString = "?GR"
 

--- a/src/main/scala/is/hail/variant/GenomeReference.scala
+++ b/src/main/scala/is/hail/variant/GenomeReference.scala
@@ -4,8 +4,8 @@ import java.io.InputStream
 
 import is.hail.HailContext
 import is.hail.check.Gen
-import is.hail.expr.types.{TLocus, TVariant}
-import is.hail.expr.JSONExtractGenomeReference
+import is.hail.expr.types.{TInterval, TLocus, TVariant}
+import is.hail.expr.{JSONAnnotationImpex, JSONExtractGenomeReference}
 import is.hail.utils._
 import org.json4s._
 import org.json4s.jackson.{JsonMethods, Serialization}
@@ -17,6 +17,7 @@ import scala.language.implicitConversions
 abstract class GRBase extends Serializable {
   val variant: TVariant
   val locus: TLocus
+  val intervalType: TInterval
 
   def variantOrdering: Ordering[Variant]
 
@@ -128,6 +129,7 @@ case class GenomeReference(name: String, contigs: Array[String], lengths: Map[St
   // must be constructed after orderings
   val variant: TVariant = TVariant(this)
   val locus: TLocus = TLocus(this)
+  val intervalType: TInterval = TInterval(locus)
 
   val par = parInput.map { case (start, end) =>
     if (start.contig != end.contig)
@@ -165,9 +167,9 @@ case class GenomeReference(name: String, contigs: Array[String], lengths: Map[St
 
   def isMitochondrial(contig: String): Boolean = mtContigs.contains(contig)
 
-  def inXPar(locus: Locus): Boolean = inX(locus.contig) && par.exists(_.contains(locus))
+  def inXPar(l: Locus): Boolean = inX(l.contig) && par.exists(_.contains(locus.ordering, l))
 
-  def inYPar(locus: Locus): Boolean = inY(locus.contig) && par.exists(_.contains(locus))
+  def inYPar(l: Locus): Boolean = inY(l.contig) && par.exists(_.contains(locus.ordering, l))
 
   def compare(contig1: String, contig2: String): Int = GenomeReference.compare(contigsIndex, contig1, contig2)
 
@@ -181,7 +183,7 @@ case class GenomeReference(name: String, contigs: Array[String], lengths: Map[St
     ("xContigs", JArray(xContigs.map(JString(_)).toList)),
     ("yContigs", JArray(yContigs.map(JString(_)).toList)),
     ("mtContigs", JArray(mtContigs.map(JString(_)).toList)),
-    ("par", JArray(par.map(_.toJSON(_.toJSON)).toList))
+    ("par", JArray(par.map(i => JSONAnnotationImpex.exportAnnotation(i, intervalType)).toList))
   )
 
   def validateContigRemap(contigMapping: Map[String, String]) {
@@ -323,36 +325,25 @@ object GenomeReference {
     Integer.compare(l1.position, l2.position)
   }
 
-  def compare(contigsIndex: Map[String, Int], i1: Interval[Locus], i2: Interval[Locus]): Int = {
-    val c = compare(contigsIndex, i1.start, i2.start)
-    if (c != 0)
-      return c
-
-    compare(contigsIndex, i1.end, i2.end)
-  }
-
   def gen: Gen[GenomeReference] = for {
     name <- Gen.identifier
     nContigs <- Gen.choose(3, 50)
     contigs <- Gen.distinctBuildableOfN[Array](nContigs, Gen.identifier)
-    lengths <- Gen.distinctBuildableOfN[Array](nContigs, Gen.choose(1000000, 500000000))
+    lengths <- Gen.buildableOfN[Array](nContigs, Gen.choose(1000000, 500000000))
     contigsIndex = contigs.zip(lengths).toMap
     xContig <- Gen.oneOfSeq(contigs)
-    yContig <- Gen.oneOfSeq((contigs.toSet - xContig).toSeq)
-    mtContig <- Gen.oneOfSeq((contigs.toSet - xContig - yContig).toSeq)
-    locusOrd = new Ordering[Locus] {
-      def compare(x: Locus, y: Locus): Int = {
-        val c = Integer.compare(contigsIndex(x.contig), contigsIndex(y.contig))
-        if (c != 0)
-          return c
-
-        Integer.compare(x.position, y.position)
-      }
-    }
-    parX <- Gen.distinctBuildableOfN[Array](2, Interval.gen(Locus.gen(xContig, contigsIndex(xContig)))(locusOrd))
-    parY <- Gen.distinctBuildableOfN[Array](2, Interval.gen(Locus.gen(yContig, contigsIndex(yContig)))(locusOrd))
+    parXA <- Gen.choose(0, contigsIndex(xContig))
+    parXB <- Gen.choose(0, contigsIndex(xContig))
+    yContig <- Gen.oneOfSeq(contigs) if yContig != xContig
+    parYA <- Gen.choose(0, contigsIndex(yContig))
+    parYB <- Gen.choose(0, contigsIndex(yContig))
+    mtContig <- Gen.oneOfSeq(contigs) if mtContig != xContig && mtContig != yContig
   } yield GenomeReference(name, contigs, contigs.zip(lengths).toMap, Set(xContig), Set(yContig), Set(mtContig),
-    (parX ++ parY).map(i => (i.start, i.end)))
+    Array(
+      (Locus(xContig, math.min(parXA, parXB)),
+        Locus(xContig, math.max(parXA, parXB))),
+      (Locus(yContig, math.min(parYA, parYB)),
+        Locus(yContig, math.max(parYA, parYB)))))
 
   def apply(name: java.lang.String, contigs: java.util.ArrayList[String], lengths: java.util.HashMap[String, Int],
     xContigs: java.util.ArrayList[String], yContigs: java.util.ArrayList[String],
@@ -374,6 +365,7 @@ object GenomeReference {
 case class GRVariable(var gr: GRBase = null) extends GRBase {
   val variant: TVariant = TVariant(this)
   val locus: TLocus = TLocus(this)
+  val intervalType: TInterval = TInterval(locus)
 
   override def toString = "?GR"
 

--- a/src/main/scala/is/hail/variant/Locus.scala
+++ b/src/main/scala/is/hail/variant/Locus.scala
@@ -105,7 +105,7 @@ object Locus {
   def parseIntervals(arr: java.util.ArrayList[String], gr: GRBase): Array[Interval] = parseIntervals(arr.asScala.toArray, gr)
 
   def makeInterval(start: Locus, end: Locus, gr: GRBase): Interval = {
-    implicit val ord = TInterval(gr.locus).ordering
+    implicit val ord = TInterval(gr.locusType).ordering
     Interval(start, end)
   }
 }

--- a/src/main/scala/is/hail/variant/Locus.scala
+++ b/src/main/scala/is/hail/variant/Locus.scala
@@ -1,7 +1,7 @@
 package is.hail.variant
 
 import is.hail.check.Gen
-import is.hail.expr.types.TStruct
+import is.hail.expr.types.{TInterval, TStruct}
 import is.hail.sparkextras.OrderedKey
 import is.hail.utils._
 import org.apache.spark.sql.Row
@@ -25,9 +25,6 @@ object Locus {
     Locus(r.getAs[String](0), r.getInt(1))
   }
   
-  def intervalToRow(i: Interval[Locus]): Row =
-    Row(i.start.toRow, i.end.toRow)
-
   def gen(contigs: Seq[String]): Gen[Locus] =
     Gen.zip(Gen.oneOfSeq(contigs), Gen.posInt)
       .map { case (contig, pos) => Locus(contig, pos) }
@@ -53,26 +50,26 @@ object Locus {
   }
 
   object LocusIntervalParser extends JavaTokenParsers {
-    def parseInterval(input: String, gr: GRBase): Interval[Locus] = {
-      parseAll[Interval[Locus]](interval(gr), input) match {
+    // FIXME test against gr
+    def parseInterval(input: String, gr: GRBase): Interval = {
+      parseAll[Interval](locus_interval, input) match {
         case Success(r, _) => r
         case NoSuccess(msg, next) => fatal(s"invalid interval expression: `$input': $msg")
       }
     }
 
-    def interval(gr: GRBase): Parser[Interval[Locus]] = {
-      implicit val locusOrd = gr.locusOrdering
+    // FIXME make end correct
+    def locus_interval: Parser[Interval] = {
       locus ~ "-" ~ locus ^^ { case l1 ~ _ ~ l2 => Interval(l1, l2) } |
         locus ~ "-" ~ pos ^^ { case l1 ~ _ ~ p2 => Interval(l1, l1.copy(position = p2)) } |
         contig ~ "-" ~ contig ^^ { case c1 ~ _ ~ c2 => Interval(Locus(c1, 0), Locus(c2, Int.MaxValue)) } |
         contig ^^ { c => Interval(Locus(c, 0), Locus(c, Int.MaxValue)) }
     }
 
-    def locus: Parser[Locus] = {
-      contig ~ ":" ~ pos ^^ { case c ~ _ ~ p => Locus(c, p) }
-    }
+    def locus: Parser[Locus] =
+      (contig <~ ":") ~ pos ^^ { case c ~ p => Locus(c, p) }
 
-    def contig: Parser[String] = "\\w+".r
+    def contig: Parser[String] = "[^-:\\s]+".r
 
     def coerceInt(s: String): Int = try {
       s.toInt
@@ -101,14 +98,14 @@ object Locus {
     }
   }
 
-  def parseInterval(str: String, gr: GRBase): Interval[Locus] = LocusIntervalParser.parseInterval(str, gr)
+  def parseInterval(str: String, gr: GRBase): Interval = LocusIntervalParser.parseInterval(str, gr)
 
-  def parseIntervals(arr: Array[String], gr: GRBase): Array[Interval[Locus]] = arr.map(parseInterval(_, gr))
+  def parseIntervals(arr: Array[String], gr: GRBase): Array[Interval] = arr.map(parseInterval(_, gr))
 
-  def parseIntervals(arr: java.util.ArrayList[String], gr: GRBase): Array[Interval[Locus]] = parseIntervals(arr.asScala.toArray, gr)
+  def parseIntervals(arr: java.util.ArrayList[String], gr: GRBase): Array[Interval] = parseIntervals(arr.asScala.toArray, gr)
 
-  def makeInterval(start: Locus, end: Locus, gr: GRBase): Interval[Locus] = {
-    implicit val locusOrd = gr.locusOrdering
+  def makeInterval(start: Locus, end: Locus, gr: GRBase): Interval = {
+    implicit val ord = TInterval(gr.locus).ordering
     Interval(start, end)
   }
 }

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -915,7 +915,7 @@ class MatrixTable(val hc: HailContext, val metadata: VSMMetadata,
           annotateLoci(ord, finalType, inserter, product = product)
 
         case Array(TInterval(_, _)) if vSignature.isInstanceOf[TVariant] =>
-          val locusOrdering = genomeReference.locus.ordering
+          val locusOrdering = genomeReference.locusType.ordering
           val partBc = sparkContext.broadcast(rdd.orderedPartitioner)
           val partitionKeyedIntervals = keyedRDD
             .flatMap { case (k, v) =>
@@ -1371,7 +1371,7 @@ class MatrixTable(val hc: HailContext, val metadata: VSMMetadata,
           rdd.orderedPartitioner)
 
       case Array(TInterval(_, _)) if vSignature.isInstanceOf[TVariant] =>
-        val locusOrdering = genomeReference.locus.ordering
+        val locusOrdering = genomeReference.locusType.ordering
         val partBc = sparkContext.broadcast(rdd.orderedPartitioner)
         val intRDD = kt.keyedRDD()
           .map { case (k, _) => k.getAs[Interval](0) }

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -915,17 +915,17 @@ class MatrixTable(val hc: HailContext, val metadata: VSMMetadata,
           annotateLoci(ord, finalType, inserter, product = product)
 
         case Array(TInterval(_, _)) if vSignature.isInstanceOf[TVariant] =>
-          implicit val locusOrd = genomeReference.locusOrdering
+          val locusOrdering = genomeReference.locus.ordering
           val partBc = sparkContext.broadcast(rdd.orderedPartitioner)
           val partitionKeyedIntervals = keyedRDD
             .flatMap { case (k, v) =>
-              val interval = k.getAs[Interval[Locus]](0)
+              val interval = k.getAs[Interval](0)
               val start = partBc.value.getPartitionT(interval.start.asInstanceOf[Annotation])
               val end = partBc.value.getPartitionT(interval.end.asInstanceOf[Annotation])
               (start to end).view.map(i => (i, (interval, v)))
             }
 
-          type IntervalT = (Interval[Locus], Annotation)
+          type IntervalT = (Interval, Annotation)
           val nParts = rdd.partitions.length
           val zipRDD = partitionKeyedIntervals.partitionBy(new Partitioner {
             def getPartition(key: Any): Int = key.asInstanceOf[Int]
@@ -934,10 +934,10 @@ class MatrixTable(val hc: HailContext, val metadata: VSMMetadata,
           }).values
 
           val res = rdd.zipPartitions(zipRDD, preservesPartitioning = true) { case (it, intervals) =>
-            val iTree = IntervalTree.annotationTree[Locus, Annotation](intervals.toArray)
+            val iTree = IntervalTree.annotationTree(locusOrdering, intervals.toArray)
 
             it.map { case (v, (va, gs)) =>
-              val queries = iTree.queryValues(v.asInstanceOf[Variant].locus)
+              val queries = iTree.queryValues(locusOrdering, v.asInstanceOf[Variant].locus)
               val annot = if (product)
                 queries: IndexedSeq[Annotation]
               else
@@ -1371,10 +1371,10 @@ class MatrixTable(val hc: HailContext, val metadata: VSMMetadata,
           rdd.orderedPartitioner)
 
       case Array(TInterval(_, _)) if vSignature.isInstanceOf[TVariant] =>
-        implicit val locusOrd = genomeReference.locusOrdering
+        val locusOrdering = genomeReference.locus.ordering
         val partBc = sparkContext.broadcast(rdd.orderedPartitioner)
         val intRDD = kt.keyedRDD()
-          .map { case (k, _) => k.getAs[Interval[Locus]](0) }
+          .map { case (k, _) => k.getAs[Interval](0) }
           .filter(_ != null)
           .flatMap { interval =>
             val start = partBc.value.getPartitionT(interval.start.asInstanceOf[Annotation])
@@ -1399,8 +1399,8 @@ class MatrixTable(val hc: HailContext, val metadata: VSMMetadata,
 
           rdd.subsetPartitions(overlapPartitions)
             .zipPartitions(zipRDD, preservesPartitioning = true) { case (it, intervals) =>
-              val itree = IntervalTree.apply[Locus](intervals.toArray)
-              it.filter { case (v, _) => itree.contains(v.asInstanceOf[Variant].locus) }
+              val itree = IntervalTree.apply(locusOrdering, intervals.toArray)
+              it.filter { case (v, _) => itree.contains(locusOrdering, v.asInstanceOf[Variant].locus) }
             }
         } else {
           val zipRDD = intRDD.partitionBy(new Partitioner {
@@ -1410,8 +1410,8 @@ class MatrixTable(val hc: HailContext, val metadata: VSMMetadata,
           }).values
 
           rdd.zipPartitions(zipRDD, preservesPartitioning = true) { case (it, intervals) =>
-            val itree = IntervalTree.apply[Locus](intervals.toArray)
-            it.filter { case (v, _) => !itree.contains(v.asInstanceOf[Variant].locus) }
+            val itree = IntervalTree.apply(locusOrdering, intervals.toArray)
+            it.filter { case (v, _) => !itree.contains(locusOrdering, v.asInstanceOf[Variant].locus) }
           }
         }
 

--- a/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -688,14 +688,14 @@ class ExprSuite extends SparkSuite {
     assert(eval[Boolean]("""let l = Locus("1", 1) in Locus(str(l)) == l""").contains(true))
 
     implicit val locusOrd = GenomeReference.defaultReference.locusOrdering
-    assert(eval[Interval[Locus]]("""Interval(Locus("1", 1), Locus("2", 2))""").contains(Interval(Locus("1", 1), Locus("2", 2))))
+    assert(eval[Interval]("""Interval(Locus("1", 1), Locus("2", 2))""").contains(Interval(Locus("1", 1), Locus("2", 2))))
     assert(eval[Locus]("""Interval(Locus("1", 1), Locus("2", 2)).start""").contains(Locus("1", 1)))
     assert(eval[Locus]("""Interval(Locus("1", 1), Locus("2", 2)).end""").contains(Locus("2", 2)))
     assert(eval[Boolean]("""Interval(Locus("1", 1), Locus("1", 3)).contains(Locus("1", 2))""").contains(true))
     assert(eval[Boolean]("""Interval(Locus("1", 1), Locus("1", 3)).contains(Locus("2", 2))""").contains(false))
 
-    assert(eval[Interval[Locus]]("""LocusInterval(GRCh37)("1", 3, 5)""").contains(Interval(Locus("1", 3), Locus("1", 5))))
-    assert(eval[Interval[Locus]]("""LocusInterval(GRCh37)("1:3-5")""").contains(Interval(Locus("1", 3), Locus("1", 5))))
+    assert(eval[Interval]("""LocusInterval(GRCh37)("1", 3, 5)""").contains(Interval(Locus("1", 3), Locus("1", 5))))
+    assert(eval[Interval]("""LocusInterval(GRCh37)("1:3-5")""").contains(Interval(Locus("1", 3), Locus("1", 5))))
 
     assert(eval[Boolean]("Interval(-2, 9).contains(-3)").contains(false))
     assert(eval[Boolean]("Interval(-2, 9).contains(-2)").contains(true))

--- a/src/test/scala/is/hail/methods/LDPruneSuite.scala
+++ b/src/test/scala/is/hail/methods/LDPruneSuite.scala
@@ -40,8 +40,8 @@ case class BitPackedVector(gs: Array[Long], nSamples: Int, mean: Double, stdDevR
 
 object LDPruneSuite {
   val rowType = TStruct(
-    "pk" -> GenomeReference.GRCh37.locus,
-    "v" -> GenomeReference.GRCh37.variant,
+    "pk" -> GenomeReference.GRCh37.locusType,
+    "v" -> GenomeReference.GRCh37.variantType,
     "va" -> TStruct(),
     "gs" -> TArray(Genotype.htsGenotypeType)
   )

--- a/src/test/scala/is/hail/variant/GenomeReferenceSuite.scala
+++ b/src/test/scala/is/hail/variant/GenomeReferenceSuite.scala
@@ -151,13 +151,13 @@ class GenomeReferenceSuite extends SparkSuite {
     |v3 = Variant(GRCh37)("1", 3, "A", "T"), l1 = Locus(GRCh38)("1", 100), l2 = Locus(GRCh37)("1:100"),
     |i1 = LocusInterval(GRCh37)("1:5-10"), i2 = LocusInterval(GRCh38)("chrX", 156030890, 156030895)""".stripMargin)
 
-    assert(ktann.signature.field("v1").typ == GenomeReference.GRCh38.variant &&
-    ktann.signature.field("v2").typ == GenomeReference.GRCh37.variant &&
-    ktann.signature.field("v3").typ == GenomeReference.GRCh37.variant &&
-    ktann.signature.field("l1").typ == GenomeReference.GRCh38.locus &&
-    ktann.signature.field("l2").typ == GenomeReference.GRCh37.locus &&
-    ktann.signature.field("i1").typ == TInterval(GenomeReference.GRCh37.locus) &&
-    ktann.signature.field("i2").typ == TInterval(GenomeReference.GRCh38.locus))
+    assert(ktann.signature.field("v1").typ == GenomeReference.GRCh38.variantType &&
+    ktann.signature.field("v2").typ == GenomeReference.GRCh37.variantType &&
+    ktann.signature.field("v3").typ == GenomeReference.GRCh37.variantType &&
+    ktann.signature.field("l1").typ == GenomeReference.GRCh38.locusType &&
+    ktann.signature.field("l2").typ == GenomeReference.GRCh37.locusType &&
+    ktann.signature.field("i1").typ == TInterval(GenomeReference.GRCh37.locusType) &&
+    ktann.signature.field("i2").typ == TInterval(GenomeReference.GRCh38.locusType))
 
     assert(ktann.forall("v1.inXPar() && v2.inXPar() && v3.isAutosomal() &&" +
       "l1.position == 100 && l2.position == 100 &&" +
@@ -166,8 +166,8 @@ class GenomeReferenceSuite extends SparkSuite {
     val gr = GenomeReference("foo2", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5))
     GenomeReference.addReference(gr)
     GenomeReference.setDefaultReference(gr)
-    assert(kt.annotate("""v1 = Variant("chrX:156030895:A:T")""").signature.field("v1").typ == gr.variant)
-    assert(kt.annotate("""i1 = Interval(Locus(foo2)("1:100"), Locus(foo2)("1:104"))""").signature.field("i1").typ == TInterval(gr.locus))
+    assert(kt.annotate("""v1 = Variant("chrX:156030895:A:T")""").signature.field("v1").typ == gr.variantType)
+    assert(kt.annotate("""i1 = Interval(Locus(foo2)("1:100"), Locus(foo2)("1:104"))""").signature.field("i1").typ == TInterval(gr.locusType))
 
     GenomeReference.setDefaultReference(GenomeReference.GRCh37)
     GenomeReference.removeReference("foo2")

--- a/src/test/scala/is/hail/variant/IntervalSuite.scala
+++ b/src/test/scala/is/hail/variant/IntervalSuite.scala
@@ -10,7 +10,7 @@ import org.testng.annotations.Test
 
 class IntervalSuite extends SparkSuite {
   val gr = GenomeReference.GRCh37
-  val pord = gr.locus.ordering
+  val pord = gr.locusType.ordering
 
   def genomicInterval(contig: String, start: Int, end: Int): Interval =
     Interval(Locus(contig, start), Locus(contig, end))


### PR DESCRIPTION
Previous patches made the interval _type_ generic (e.g. Interval[T] instead of just Interval which implied interval of locus).  This patch makes the intervals themselves generic.  The interval doesn't carry the type (it's just a container for the start, end) so various interval operations need the ordering on the type that the interval is over to be passed in.  Then everything else is follows from this.

The next PR makes the intervals generic on the Python side.

Along the way, I allows intervals to be improper, e.g., [7, 5), which are effectively empty.  Note, intervals compare for equality if the endpoints are equal, so [7, 5) != [8, 5) even though they are both empty.