### PR TITLE
force a broader type, appeasing Scala's type system

### DIFF
--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -41,7 +41,7 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
       else
         filename
 
-    val rWithHeader = header.map { h =>
+    val rWithHeader: RDD[_] = header.map { h =>
       if (r.getNumPartitions == 0 && exportType != ExportType.PARALLEL_SEPARATE_HEADER)
         r.sparkContext.parallelize(List(h), numSlices = 1)
       else {


### PR DESCRIPTION
The type of this RDD is rather complicated because we prepend a String to
an RDD of a universally quantified variable.

`writeTextTable` works with any subtypes of AnyRef because it only requires
that the object defines `toString`. Ergo, we don't actually need to know
anything about the type parameter of the RDD. The explicit annotation
that I've added prevents Scala from inferring a complex type that cannot
be expressed without `forSome`. Such types trigger a warning from the
Scala compiler.