### PR TITLE
Use partitionStarts in PCRelate.

### DIFF
--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1089,8 +1089,6 @@ class MatrixTable(val hc: HailContext, val metadata: VSMMetadata,
 
   def countVariants(): Long = partitionCounts().sum
 
-  def variants: RDD[Annotation] = rdd.keys
-
   def deduplicate(): MatrixTable =
     copy2(rdd2 = rdd2.mapPartitionsPreservesPartitioning(rdd2.typ)(
       SortedDistinctRowIterator.transformer(rdd2.typ)))

--- a/src/test/scala/is/hail/io/ImportGDBSuite.scala
+++ b/src/test/scala/is/hail/io/ImportGDBSuite.scala
@@ -3,6 +3,7 @@ package is.hail.io
 import is.hail.SparkSuite
 import is.hail.expr.types.TStruct
 import is.hail.io.vcf.{HtsjdkRecordReader, LoadGDB, LoadVCF}
+import is.hail.testUtils._
 import org.testng.annotations.Test
 
 class ImportGDBSuite extends SparkSuite {

--- a/src/test/scala/is/hail/methods/LDPruneSuite.scala
+++ b/src/test/scala/is/hail/methods/LDPruneSuite.scala
@@ -9,6 +9,7 @@ import is.hail.expr.types._
 import is.hail.stats.RegressionUtils
 import is.hail.variant._
 import is.hail.utils._
+import is.hail.testUtils._
 import org.testng.annotations.Test
 
 case class BitPackedVector(gs: Array[Long], nSamples: Int, mean: Double, stdDevRec: Double) {

--- a/src/test/scala/is/hail/methods/TableSuite.scala
+++ b/src/test/scala/is/hail/methods/TableSuite.scala
@@ -6,6 +6,7 @@ import is.hail.expr._
 import is.hail.expr.types._
 import is.hail.table.Table
 import is.hail.utils._
+import is.hail.testUtils._
 import org.apache.spark.sql.Row
 import org.apache.spark.util.StatCounter
 import org.testng.annotations.Test

--- a/src/test/scala/is/hail/stats/StatsSuite.scala
+++ b/src/test/scala/is/hail/stats/StatsSuite.scala
@@ -3,6 +3,7 @@ package is.hail.stats
 import breeze.linalg.DenseMatrix
 import is.hail.SparkSuite
 import is.hail.utils._
+import is.hail.testUtils._
 import is.hail.variant.{Genotype, Locus, Variant}
 import org.apache.commons.math3.distribution.{ChiSquaredDistribution, NormalDistribution}
 import org.testng.annotations.Test

--- a/src/test/scala/is/hail/utils/RichMatrixTable.scala
+++ b/src/test/scala/is/hail/utils/RichMatrixTable.scala
@@ -74,4 +74,6 @@ class RichMatrixTable(vsm: MatrixTable) {
   }
 
   def stringSampleIdsAndAnnotations: IndexedSeq[(Annotation, Annotation)] = vsm.stringSampleIds.zip(vsm.sampleAnnotations)
+
+  def variants: RDD[Annotation] = vsm.rdd.keys
 }

--- a/src/test/scala/is/hail/variant/vsm/ExplodeSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/ExplodeSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.variant.vsm
 
 import is.hail.SparkSuite
+import is.hail.testUtils._
 import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 

--- a/src/test/scala/is/hail/variant/vsm/GroupBySuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/GroupBySuite.scala
@@ -8,8 +8,8 @@ import is.hail.annotations.UnsafeRow
 import is.hail.check.Prop.forAll
 import is.hail.expr.types._
 import is.hail.utils._
+import is.hail.testUtils._
 import is.hail.variant.{MatrixTable, VSMSubgen}
-
 
 class GroupBySuite extends SparkSuite {
 

--- a/src/test/scala/is/hail/vds/FilterVariantsSuite.scala
+++ b/src/test/scala/is/hail/vds/FilterVariantsSuite.scala
@@ -2,10 +2,10 @@ package is.hail.vds
 
 import is.hail.SparkSuite
 import is.hail.annotations.Annotation
+import is.hail.testUtils._
 import is.hail.check.Arbitrary._
 import is.hail.check.Prop._
 import is.hail.check.{Gen, Prop}
-import is.hail.variant.Variant
 import org.testng.annotations.Test
 
 class FilterVariantsSuite extends SparkSuite {


### PR DESCRIPTION
Instead of building variant map (which is actually broken because variants are not necessarily unique!)
Move MT.variants to test code.  This eliminates another use of MT.rdd.