### PR TITLE
rv-ified fromTable.

### DIFF
--- a/python/hail/api1/dataset.py
+++ b/python/hail/api1/dataset.py
@@ -78,7 +78,7 @@ class VariantDataset(HistoryMixin):
         :return: Sites-only variant dataset.
         :rtype: :py:class:`.VariantDataset`
         """
-        jvds = scala_object(Env.hail().variant, 'MatrixTable').fromKeyTable(table._jkt)
+        jvds = scala_object(Env.hail().variant, 'MatrixTable').fromTable(table._jkt)
         return VariantDataset(table.hc, jvds)
 
     @property

--- a/src/test/scala/is/hail/methods/AnnotateSuite.scala
+++ b/src/test/scala/is/hail/methods/AnnotateSuite.scala
@@ -260,7 +260,7 @@ class AnnotateSuite extends SparkSuite {
 
     // tsv
     val importTSVFile = tmpDir.createTempFile("variantAnnotationsTSV", ".vds")
-    vds = MatrixTable.fromKeyTable(hc.importTable("src/test/resources/variantAnnotations.tsv",
+    vds = MatrixTable.fromTable(hc.importTable("src/test/resources/variantAnnotations.tsv",
       impute = true, types = Map("Chromosome" -> TString()))
       .annotate("v = Variant(Chromosome, Position, Ref, Alt)")
       .keyBy("v"))
@@ -299,7 +299,7 @@ class AnnotateSuite extends SparkSuite {
       .annotate("""v = Variant(f0.contig, f0.start, f0.ref, f0.alt.split("/"))""")
       .keyBy("v")
 
-    vds = MatrixTable.fromKeyTable(kt2)
+    vds = MatrixTable.fromTable(kt2)
       .annotateVariantsExpr("va = va.f0")
       .filterVariantsExpr("v.isBiallelic")
     vds.write(importJSONFile)

--- a/src/test/scala/is/hail/vds/JoinSuite.scala
+++ b/src/test/scala/is/hail/vds/JoinSuite.scala
@@ -56,11 +56,11 @@ class JoinSuite extends SparkSuite {
 
     val leftKt = Table(hc, sc.parallelize(leftVariants.map(Row(_))), TStruct("v" -> TVariant(GenomeReference.GRCh37))).keyBy("v")
     leftKt.typeCheck()
-    val left = MatrixTable.fromKeyTable(leftKt)
+    val left = MatrixTable.fromTable(leftKt)
 
     val rightKt = Table(hc, sc.parallelize(rightVariants.map(Row(_))), TStruct("v" -> TVariant(GenomeReference.GRCh37))).keyBy("v")
     rightKt.typeCheck()
-    val right = MatrixTable.fromKeyTable(rightKt)
+    val right = MatrixTable.fromTable(rightKt)
 
     val localRowType = left.rowType
 


### PR DESCRIPTION
renamed fromKeyTable => fromTable.
made generic (single key until we have compound keys in MT)

The two FIXMEs will use infrastructure from other, pending PRs.  To avoid stacking, I'll rebase one side or the other depending on which goes in first.