### PR TITLE
port ibd to api2

### DIFF
--- a/python/hail/api1/dataset.py
+++ b/python/hail/api1/dataset.py
@@ -2560,7 +2560,12 @@ g = let newgt = gtIndex(oldToNew[gtj(g.GT)], oldToNew[gtk(g.GT)]) and
 
         """
 
-        return KeyTable(self.hc, self._jvds.ibd(joption(maf), bounded, joption(min), joption(max)))
+        return KeyTable(self.hc,
+                        Env.hail().methods.IBD.apply(self._jvds,
+                                                     joption(maf),
+                                                     bounded,
+                                                     joption(min),
+                                                     joption(max)))
 
     @handle_py4j
     @require_biallelic

--- a/python/hail/docs/methods/index.rst
+++ b/python/hail/docs/methods/index.rst
@@ -13,6 +13,7 @@ Methods
     hail.methods.ld_matrix
     hail.methods.trio_matrix
     hail.methods.grm
+    hail.methods.ibd
     hail.methods.pca
     hail.methods.hwe_normalized_pca
     hail.methods.rename_duplicates
@@ -36,6 +37,7 @@ Methods
 .. autofunction:: hail.methods.ld_matrix
 .. autofunction:: hail.methods.trio_matrix
 .. autofunction:: hail.methods.grm
+.. autofunction:: hail.methods.ibd
 .. autofunction:: hail.methods.pca
 .. autofunction:: hail.methods.hwe_normalized_pca
 .. autofunction:: hail.methods.rename_duplicates

--- a/python/hail/methods/__init__.py
+++ b/python/hail/methods/__init__.py
@@ -1,12 +1,13 @@
 from .family_methods import trio_matrix, mendel_errors
 from .io import export_cassandra, export_gen, export_solr, export_vcf, import_interval_list, import_bed, import_fam
-from .statgen import linreg, sample_rows, ld_matrix, grm, pca, hwe_normalized_pca, split_multi_hts
+from .statgen import linreg, sample_rows, ibd, ld_matrix, grm, pca, hwe_normalized_pca, split_multi_hts
 from .qc import sample_qc, variant_qc, vep, concordance, nirvana
 from .misc import rename_duplicates
 
 __all__ = ['trio_matrix',
            'linreg',
            'sample_rows',
+           'ibd',
            'ld_matrix',
            'sample_qc',
            'variant_qc',

--- a/python/hail/methods/family_methods.py
+++ b/python/hail/methods/family_methods.py
@@ -58,7 +58,6 @@ def trio_matrix(dataset, pedigree, complete_trios=False):
                        .annotateGenotypesExpr('g = {proband_entry: g.proband, father_entry: g.father, mother_entry: g.mother}'))
 
 @handle_py4j
-@require_biallelic
 @typecheck(dataset=MatrixTable,
            pedigree=Pedigree)
 def mendel_errors(dataset, pedigree):
@@ -224,6 +223,6 @@ def mendel_errors(dataset, pedigree):
         Four tables as detailed in notes with Mendel error statistics.
     """
 
-    kts = dataset._jvds.mendelErrors(pedigree._jrep)
+    kts = require_biallelic(dataset, 'mendel_errors')._jvds.mendelErrors(pedigree._jrep)
     return Table(kts._1()), Table(kts._2()), \
            Table(kts._3()), Table(kts._4())

--- a/python/hail/methods/io.py
+++ b/python/hail/methods/io.py
@@ -23,7 +23,6 @@ def export_cassandra(table, address, keyspace, table_name, block_size=100, rate=
     table._jkt.exportCassandra(address, keyspace, table_name, block_size, rate)
 
 @handle_py4j
-@require_biallelic
 @typecheck(dataset=MatrixTable,
            output=strlike,
            precision=integral)
@@ -76,7 +75,8 @@ def export_gen(dataset, output, precision=4):
     precision : :obj:`int`
         Number of digits to write after the decimal point.
     """
-    
+
+    dataset = require_biallelic(dataset, 'export_gen')
     try:
         gp = dataset['GP']
         if gp.dtype != TArray(TFloat64()) or gp._indices != dataset._entry_indices:

--- a/python/hail/methods/misc.py
+++ b/python/hail/methods/misc.py
@@ -1,16 +1,17 @@
 from decorator import decorator
 from hail.api2 import MatrixTable
 from hail.utils.java import Env, handle_py4j
-from hail.typecheck.check import typecheck
+from hail.typecheck.check import typecheck, strlike
 
-@decorator
-def require_biallelic(f, dataset, *args, **kwargs):
+@handle_py4j
+@typecheck(dataset=MatrixTable, method=strlike)
+def require_biallelic(dataset, method):
     from hail.expr.types import TVariant
     if not isinstance(dataset.rowkey_schema, TVariant):
         raise TypeError("Method '{}' requires the row key to be of type 'TVariant', found '{}'".format(
-            f.__name__, dataset.rowkey_schema))
-    dataset = MatrixTable(Env.hail().methods.VerifyBiallelic.apply(dataset._jvds, f.__name__))
-    return f(dataset, *args, **kwargs)
+            method, dataset.rowkey_schema))
+    dataset = MatrixTable(Env.hail().methods.VerifyBiallelic.apply(dataset._jvds, method))
+    return dataset
 
 @handle_py4j
 @typecheck(dataset=MatrixTable)

--- a/python/hail/methods/qc.py
+++ b/python/hail/methods/qc.py
@@ -273,7 +273,7 @@ def concordance(left, right):
         per column key, and a table with concordance statistics per row key.
     """
 
-    left = require_biallelic(right, "concordance, left")
+    left = require_biallelic(left, "concordance, left")
     right = require_biallelic(right, "concordance, right")
 
     r = Env.hail().methods.CalculateConcordance.apply(left._jvds, right._jvds)

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -14,7 +14,7 @@ import hail.expr.aggregators as agg
 @handle_py4j
 @require_biallelic
 @typecheck(dataset=MatrixTable,
-           maf=nullable(Expression),
+           maf=nullable(expr_numeric),
            bounded=bool,
            min=nullable(numeric),
            max=nullable(numeric))
@@ -29,13 +29,13 @@ def ibd(dataset, maf=None, bounded=True, min=None, max=None):
     --------
 
     To calculate a full IBD matrix, using minor allele frequencies computed
-    from the variant dataset itself:
+    from the dataset itself:
 
     >>> methods.ibd(dataset)
 
     To calculate an IBD matrix containing only pairs of samples with
     ``PI_HAT`` in :math:`[0.2, 0.9]`, using minor allele frequencies stored in
-    ``va.panel_maf``:
+    the row field ``panel_maf``:
 
     >>> methods.ibd(dataset, maf=dataset['panel_maf'], min=0.2, max=0.9)
 
@@ -55,7 +55,7 @@ def ibd(dataset, maf=None, bounded=True, min=None, max=None):
     String*`.
 
     Conceptually, the output is a symmetric, sample-by-sample matrix. The
-    output key table has the following form
+    output table has the following form
 
     .. code-block:: text
 
@@ -70,7 +70,7 @@ def ibd(dataset, maf=None, bounded=True, min=None, max=None):
     dataset : :class:`.MatrixTable`
         A variant-keyed :class:`.MatrixTable` containing genotype information.
 
-    maf : :class:`hail.expr.expression.Expression` or :obj:`None`
+    maf : numeric :class:`hail.expr.expression.Expression` or :obj:`None`
         (optional) expression on `dataset` for the minor allele frequency.
 
     bounded : :obj:`bool`
@@ -87,9 +87,8 @@ def ibd(dataset, maf=None, bounded=True, min=None, max=None):
 
     Return
     ------
-    :class:`.TableTable`
-        A table which maps pairs of samples to their IBD
-        statistics
+    :class:`.Table`
+        A table which maps pairs of samples to their IBD statistics
     """
 
     if maf:

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -91,7 +91,7 @@ def ibd(dataset, maf=None, bounded=True, min=None, max=None):
         A table which maps pairs of samples to their IBD statistics
     """
 
-    if maf:
+    if maf != None:
         analyze('ibd/maf', maf, dataset._row_indices)
         dataset, _ = dataset._process_joins(maf)
         maf = maf._ast.to_hql()

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -13,7 +13,7 @@ import hail.expr.aggregators as agg
 
 @handle_py4j
 @typecheck(dataset=MatrixTable,
-           maf=nullable(expr_numeric),
+           maf=nullable(oneof(Float32Expression, Float64Expression)),
            bounded=bool,
            min=nullable(numeric),
            max=nullable(numeric))
@@ -34,7 +34,7 @@ def ibd(dataset, maf=None, bounded=True, min=None, max=None):
 
     To calculate an IBD matrix containing only pairs of samples with
     ``PI_HAT`` in :math:`[0.2, 0.9]`, using minor allele frequencies stored in
-    the row field ``panel_maf``:
+    the row field `panel_maf`:
 
     >>> methods.ibd(dataset, maf=dataset['panel_maf'], min=0.2, max=0.9)
 
@@ -69,7 +69,7 @@ def ibd(dataset, maf=None, bounded=True, min=None, max=None):
     dataset : :class:`.MatrixTable`
         A variant-keyed :class:`.MatrixTable` containing genotype information.
 
-    maf : numeric :class:`hail.expr.expression.Expression` or :obj:`None`
+    maf : :class:`.Float32Expression`, :class:`.Float64Expression` or :obj:`None`
         (optional) expression on `dataset` for the minor allele frequency.
 
     bounded : :obj:`bool`

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -13,7 +13,6 @@ import hail.expr.aggregators as agg
 
 @handle_py4j
 @require_biallelic
-@record_method
 @typecheck(dataset=MatrixTable,
            maf=nullable(Expression),
            bounded=bool,
@@ -75,8 +74,8 @@ def ibd(dataset, maf=None, bounded=True, min=None, max=None):
         (optional) expression on `dataset` for the minor allele frequency.
 
     bounded : :obj:`bool`
-        Forces the estimations for `Z0``, ``Z1``, ``Z2``, and ``PI_HAT`` to take on
-        biologically meaningful values (in the range [0,1]).
+        Forces the estimations for `Z0``, ``Z1``, ``Z2``, and ``PI_HAT`` to take
+        on biologically meaningful values (in the range [0,1]).
 
     min : :obj:`float` or :obj:`None`
         Sample pairs with a ``PI_HAT`` below this value will
@@ -95,9 +94,14 @@ def ibd(dataset, maf=None, bounded=True, min=None, max=None):
 
     if maf:
         analyze('ibd/maf', maf, dataset._row_indices)
+        dataset, _ = dataset._process_joins(maf)
         maf = maf._ast.to_hql()
 
-    return Table(dataset._jvds.ibd(joption(maf), bounded, joption(min), joption(max)))
+    return Table(Env.hail().methods.IBD.apply(dataset._jvds,
+                                              joption(maf),
+                                              bounded,
+                                              joption(min),
+                                              joption(max)))
 
 @typecheck(dataset=MatrixTable,
            ys=oneof(Expression, listof(Expression)),

--- a/python/hail/methods/tests.py
+++ b/python/hail/methods/tests.py
@@ -84,6 +84,7 @@ class Tests(unittest.TestCase):
         compare(dataset, min=0.0, max=1.0)
         dataset = dataset.annotate_rows(dummy_maf=0.01)
         methods.ibd(dataset, dataset['dummy_maf'], min=0.0, max=1.0)
+        methods.ibd(dataset, dataset['dummy_maf'].to_float32(), min=0.0, max=1.0)
 
     def test_ld_matrix(self):
         dataset = self.get_dataset()

--- a/python/hail/methods/tests.py
+++ b/python/hail/methods/tests.py
@@ -66,9 +66,9 @@ class Tests(unittest.TestCase):
                                                  map(int, row[14:17]))
             return results
 
-        def compare(ds, maf=None, min=None, max=None):
+        def compare(ds, min=None, max=None):
             plink_results = plinkify(ds, min, max)
-            hail_results = methods.ibd(ds, maf, min=min, max=max).collect()
+            hail_results = methods.ibd(ds, min=min, max=max).collect()
 
             for row in hail_results:
                 key = (row.i, row.j)
@@ -81,9 +81,9 @@ class Tests(unittest.TestCase):
                 self.assertEqual(plink_results[key][1][2], row.ibs2)
 
         compare(dataset)
-        compare(dataset, min=0.0, min=1.0)
-        dataset = dataset.annotate_rows(dummy_maf=0.1)
-        compare(dataset, dataset['dummy_maf'], 0.0, 1.0)
+        compare(dataset, min=0.0, max=1.0)
+        dataset = dataset.annotate_rows(dummy_maf=0.01)
+        methods.ibd(dataset, dataset['dummy_maf'], min=0.0, max=1.0)
 
     def test_ld_matrix(self):
         dataset = self.get_dataset()

--- a/python/hail/methods/tests.py
+++ b/python/hail/methods/tests.py
@@ -10,7 +10,6 @@ import hail.utils as utils
 
 hc = None
 
-
 def setUpModule():
     global hc
     hc = HailContext()  # master = 'local[2]')
@@ -46,8 +45,8 @@ class Tests(unittest.TestCase):
 
             plink_command = "plink --double-id --allow-extra-chr --vcf {} --genome full --out {} {}"\
                 .format(utils.get_URI(vcf),
-                                                 utils.get_URI(plinkpath),
-                                                 threshold_string)
+                        utils.get_URI(plinkpath),
+                        threshold_string)
             result_file = utils.get_URI(plinkpath + ".genome")
 
             syscall(plink_command, shell=True)
@@ -67,9 +66,9 @@ class Tests(unittest.TestCase):
                                                  map(int, row[14:17]))
             return results
 
-        def compare(ds, min = None, max = None):
-            plink_results = plinkify(dataset, min, max)
-            hail_results = methods.ibd(dataset, min=min, max=max).collect()
+        def compare(ds, maf=None, min=None, max=None):
+            plink_results = plinkify(ds, min, max)
+            hail_results = methods.ibd(ds, maf, min=min, max=max).collect()
 
             for row in hail_results:
                 key = (row.i, row.j)
@@ -82,7 +81,9 @@ class Tests(unittest.TestCase):
                 self.assertEqual(plink_results[key][1][2], row.ibs2)
 
         compare(dataset)
-        compare(dataset, 0.0, 1.0)
+        compare(dataset, min=0.0, min=1.0)
+        dataset = dataset.annotate_rows(dummy_maf=0.1)
+        compare(dataset, dataset['dummy_maf'], 0.0, 1.0)
 
     def test_ld_matrix(self):
         dataset = self.get_dataset()

--- a/python/hail/utils/testutils.py
+++ b/python/hail/utils/testutils.py
@@ -1,4 +1,0 @@
-
-class PlinkCompare():
-
-    def

--- a/python/hail/utils/testutils.py
+++ b/python/hail/utils/testutils.py
@@ -1,0 +1,4 @@
+
+class PlinkCompare():
+
+    def

--- a/src/main/scala/is/hail/methods/IBD.scala
+++ b/src/main/scala/is/hail/methods/IBD.scala
@@ -8,6 +8,7 @@ import is.hail.expr.types._
 import is.hail.variant.{GenomeReference, Genotype, HardCallView, MatrixTable, Variant}
 import is.hail.methods.IBD.generateComputeMaf
 import is.hail.rvd.RVD
+import is.hail.stats.RegressionUtils
 import org.apache.spark.rdd.RDD
 import is.hail.utils._
 import org.apache.spark.sql.Row
@@ -346,7 +347,7 @@ object IBD {
 
     val mafSymbolTable = Map("v" -> (0, vds.vSignature), "va" -> (1, vds.vaSignature))
     val mafEc = EvalContext(mafSymbolTable)
-    val computeMafThunk = Parser.parseTypedExpr[java.lang.Double](computeMafExpr, mafEc)
+    val computeMafThunk = RegressionUtils.parseExprAsDouble(computeMafExpr, mafEc)
     val rowType = vds.rowType
 
     { (rv: RegionValue) =>

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1613,20 +1613,6 @@ class MatrixTable(val hc: HailContext, val metadata: VSMMetadata,
     copy2(rdd2 = rdd2.head(n))
   }
 
-  /**
-    *
-    * @param computeMafExpr An expression for the minor allele frequency of the current variant, `v', given
-    *                       the variant annotations `va'. If unspecified, MAF will be estimated from the dataset
-    * @param bounded        Allows the estimations for Z0, Z1, Z2, and PI_HAT to take on biologically-nonsense values
-    *                       (e.g. outside of [0,1]).
-    * @param minimum        Sample pairs with a PI_HAT below this value will not be included in the output. Must be in [0,1]
-    * @param maximum        Sample pairs with a PI_HAT above this value will not be included in the output. Must be in [0,1]
-    */
-  def ibd(computeMafExpr: Option[String] = None, bounded: Boolean = true,
-    minimum: Option[Double] = None, maximum: Option[Double] = None): Table = {
-    IBD(this, computeMafExpr, bounded, minimum, maximum)
-  }
-
   def insertSA(sig: Type, args: String*): (Type, Inserter) = insertSA(sig, args.toList)
 
   def insertSA(sig: Type, path: List[String]): (Type, Inserter) = saSignature.insert(sig, path)


### PR DESCRIPTION
I think IBD could/should maybe be rewritten to return a MatrixTable instead of a Table (the old format could be extracted pretty easily with `ibd.to_entries_table()`) but I haven't done that here yet.

Tim also suggested that methods where we're extracting a call could conceivably take a `CallExpression` instead of the dataset as the initial argument so we'd have e.g. `ibd(dataset['GT'])`.