### PR TITLE
Add Keys and KeyedBlockMatrix

### DIFF
--- a/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
@@ -594,16 +594,15 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       nRows, nCols)
   }
     
-  // rowsToKeep is an array of distinct row indices
-  def filterRows(rowsToKeep: Array[Long]): BlockMatrix = this.transpose().filterCols(rowsToKeep).transpose()
+  // keep is an array of distinct indices
+  def filterRows(keep: Array[Long]): BlockMatrix = this.transpose().filterCols(keep).transpose()
 
-  // colsToKeep is an array of distinct col indices  
-  def filterCols(colsToKeep: Array[Long]): BlockMatrix =
-    new BlockMatrix(new BlockMatrixFilterColsRDD(this, colsToKeep.sorted), blockSize, nRows, colsToKeep.length)
+  def filterCols(keep: Array[Long]): BlockMatrix =
+    new BlockMatrix(new BlockMatrixFilterColsRDD(this, keep.sorted), blockSize, nRows, keep.length)
   
-  def filter(rowsToKeep: Array[Long], colsToKeep: Array[Long]): BlockMatrix =
-    new BlockMatrix(new BlockMatrixFilterRDD(this, rowsToKeep.sorted, colsToKeep.sorted),
-      blockSize, rowsToKeep.length, colsToKeep.length)
+  def filter(keepRows: Array[Long], keepCols: Array[Long]): BlockMatrix =
+    new BlockMatrix(new BlockMatrixFilterRDD(this, keepRows.sorted, keepCols.sorted),
+      blockSize, keepRows.length, keepCols.length)
 }
 
 case class BlockMatrixFilterRDDPartition(index: Int,
@@ -613,7 +612,7 @@ case class BlockMatrixFilterRDDPartition(index: Int,
 object BlockMatrixFilterRDD {
   // allBlockColRanges(newBlockCol) has elements of the form (blockCol, startIndices, endIndices) with blockCol increasing
   //   startIndices.zip(endIndices) gives all column-index ranges in blockCol to be copied to ranges in newBlockCol
-  def computeAllBlockColRanges(colsToKeep: Array[Long],
+  def computeAllBlockColRanges(keep: Array[Long],
     gp: GridPartitioner,
     newGP: GridPartitioner): Array[Array[(Int, Array[Int], Array[Int])]] = {
     
@@ -622,7 +621,7 @@ object BlockMatrixFilterRDD {
     val startIndices = new ArrayBuilder[Int]()
     val endIndices = new ArrayBuilder[Int]()
 
-    colsToKeep
+    keep
       .grouped(blockSize)
       .zipWithIndex
       .map { case (colsInNewBlock, newBlockCol) =>
@@ -660,28 +659,28 @@ object BlockMatrixFilterRDD {
       }.toArray
   }
   
-  def computeAllBlockRowRanges(rowsToKeep: Array[Long],
+  def computeAllBlockRowRanges(keep: Array[Long],
     gp: GridPartitioner,
     newGP: GridPartitioner): Array[Array[(Int, Array[Int], Array[Int])]] = {
 
-    computeAllBlockColRanges(rowsToKeep, gp.transpose, newGP.transpose)
+    computeAllBlockColRanges(keep, gp.transpose, newGP.transpose)
   }
 }
 
-private class BlockMatrixFilterRDD(dm: BlockMatrix, rowsToKeep: Array[Long], colsToKeep: Array[Long])
+private class BlockMatrixFilterRDD(dm: BlockMatrix, keepRows: Array[Long], keepCols: Array[Long])
   extends RDD[((Int, Int), BDM[Double])](dm.blocks.sparkContext, Nil) {
-  require(rowsToKeep.nonEmpty && rowsToKeep.isIncreasing && rowsToKeep.head >= 0 && rowsToKeep.last < dm.nRows)
-  require(colsToKeep.nonEmpty && colsToKeep.isIncreasing && colsToKeep.head >= 0 && colsToKeep.last < dm.nCols)
+  require(keepRows.nonEmpty && keepRows.isIncreasing && keepRows.head >= 0 && keepRows.last < dm.nRows)
+  require(keepCols.nonEmpty && keepCols.isIncreasing && keepCols.head >= 0 && keepCols.last < dm.nCols)
   
   private val gp = dm.partitioner
   private val blockSize = gp.blockSize
-  private val newGP = GridPartitioner(blockSize, rowsToKeep.length, colsToKeep.length)
+  private val newGP = GridPartitioner(blockSize, keepRows.length, keepCols.length)
       
   private val allBlockRowRanges: Array[Array[(Int, Array[Int], Array[Int])]] =
-    BlockMatrixFilterRDD.computeAllBlockRowRanges(rowsToKeep, gp, newGP)  
+    BlockMatrixFilterRDD.computeAllBlockRowRanges(keepRows, gp, newGP)  
   
   private val allBlockColRanges: Array[Array[(Int, Array[Int], Array[Int])]] =
-    BlockMatrixFilterRDD.computeAllBlockColRanges(colsToKeep, gp, newGP)
+    BlockMatrixFilterRDD.computeAllBlockColRanges(keepCols, gp, newGP)
 
   protected def getPartitions: Array[Partition] =
     Array.tabulate(newGP.numPartitions) { pi => 
@@ -756,16 +755,16 @@ private class BlockMatrixFilterRDD(dm: BlockMatrix, rowsToKeep: Array[Long], col
 
 case class BlockMatrixFilterColsRDDPartition(index: Int, blockColRanges: Array[(Int, Array[Int], Array[Int])]) extends Partition
 
-private class BlockMatrixFilterColsRDD(dm: BlockMatrix, colsToKeep: Array[Long])
+private class BlockMatrixFilterColsRDD(dm: BlockMatrix, keep: Array[Long])
   extends RDD[((Int, Int), BDM[Double])](dm.blocks.sparkContext, Nil) {
-  require(colsToKeep.nonEmpty && colsToKeep.isIncreasing && colsToKeep.head >= 0 && colsToKeep.last < dm.nCols)
+  require(keep.nonEmpty && keep.isIncreasing && keep.head >= 0 && keep.last < dm.nCols)
   
   private val gp = dm.partitioner
   private val blockSize = gp.blockSize
-  private val newGP = GridPartitioner(blockSize, gp.nRows, colsToKeep.length)
+  private val newGP = GridPartitioner(blockSize, gp.nRows, keep.length)
   
   private val allBlockColRanges: Array[Array[(Int, Array[Int], Array[Int])]] =
-    BlockMatrixFilterRDD.computeAllBlockColRanges(colsToKeep, gp, newGP)
+    BlockMatrixFilterRDD.computeAllBlockColRanges(keep, gp, newGP)
 
   protected def getPartitions: Array[Partition] =
     Array.tabulate(newGP.numPartitions) { pi => 

--- a/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/BlockMatrix.scala
@@ -593,15 +593,14 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       .map { case (i, a) => IndexedRow(i, new DenseVector(a)) },
       nRows, nCols)
   }
-    
-  // keep is an array of distinct indices
+  
   def filterRows(keep: Array[Long]): BlockMatrix = this.transpose().filterCols(keep).transpose()
 
   def filterCols(keep: Array[Long]): BlockMatrix =
-    new BlockMatrix(new BlockMatrixFilterColsRDD(this, keep.sorted), blockSize, nRows, keep.length)
+    new BlockMatrix(new BlockMatrixFilterColsRDD(this, keep), blockSize, nRows, keep.length)
   
   def filter(keepRows: Array[Long], keepCols: Array[Long]): BlockMatrix =
-    new BlockMatrix(new BlockMatrixFilterRDD(this, keepRows.sorted, keepCols.sorted),
+    new BlockMatrix(new BlockMatrixFilterRDD(this, keepRows, keepCols),
       blockSize, keepRows.length, keepCols.length)
 }
 
@@ -1042,7 +1041,6 @@ class WriteBlocksRDD(path: String,
 
   def compute(split: Partition, context: TaskContext): Iterator[Int] = {
     val blockRow = split.index
-    val firstRowInBlock = blockRow.toLong * blockSize
     val nRowsInBlock = gp.blockRowNRows(blockRow)
 
     val dosPerBlockCol = Array.tabulate(gp.nBlockCols) { blockCol =>

--- a/src/main/scala/is/hail/distributedmatrix/KeyedBlockMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/KeyedBlockMatrix.scala
@@ -137,7 +137,7 @@ class KeyedBlockMatrix(val bm: BlockMatrix, val rowKeys: Option[Keys], val colKe
   def filterRows(keep: Array[Int]): KeyedBlockMatrix =
     new KeyedBlockMatrix(
       bm.filterRows(keep.map(_.toLong)),
-      rowKeys.map(_.filter(keep, check = false)),
+      rowKeys.map(_.filter(keep)),
       colKeys)
 
   def filterCols(pred: Annotation => Boolean): KeyedBlockMatrix =
@@ -153,7 +153,7 @@ class KeyedBlockMatrix(val bm: BlockMatrix, val rowKeys: Option[Keys], val colKe
       new KeyedBlockMatrix(
         bm.filterCols(keep.map(_.toLong)),
         rowKeys,
-        colKeys.map(_.filter(keep, check = false)))
+        colKeys.map(_.filter(keep)))
 
   def filter(rowPred: Annotation => Boolean, colPred: Annotation => Boolean): KeyedBlockMatrix =
     (rowKeys, colKeys) match {
@@ -172,8 +172,8 @@ class KeyedBlockMatrix(val bm: BlockMatrix, val rowKeys: Option[Keys], val colKe
   def filter(keepRows: Array[Int], keepCols: Array[Int]): KeyedBlockMatrix =
         new KeyedBlockMatrix(
           bm.filter(keepRows.map(_.toLong), keepCols.map(_.toLong)),
-          rowKeys.map(_.filter(keepRows, check = false)),
-          colKeys.map(_.filter(keepCols, check = false)))
+          rowKeys.map(_.filter(keepRows)),
+          colKeys.map(_.filter(keepCols)))
   
   def write(uri: String, forceRowMajor: Boolean = false) {
     val sc = bm.blocks.sparkContext

--- a/src/main/scala/is/hail/distributedmatrix/KeyedBlockMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/KeyedBlockMatrix.scala
@@ -33,8 +33,8 @@ object KeyedBlockMatrix {
 }
 
 class KeyedBlockMatrix(val bm: BlockMatrix, val rowKeys: Option[Keys], val colKeys: Option[Keys]) extends Serializable {
-  require(rowKeys.forall(_.length == bm.nRows))
-  require(colKeys.forall(_.length == bm.nCols))
+  require(rowKeys.forall(_.length == bm.nRows), "Differing number of row keys and rows.")
+  require(colKeys.forall(_.length == bm.nCols), "Differing number of col keys and cols.")
   
   def copy(bm: BlockMatrix = bm,
     rowKeys: Option[Keys] = rowKeys,
@@ -45,15 +45,19 @@ class KeyedBlockMatrix(val bm: BlockMatrix, val rowKeys: Option[Keys], val colKe
   def persist(storageLevel: StorageLevel): KeyedBlockMatrix = copy(bm.persist(storageLevel))
   
   def setRowKeys(keys: Keys): KeyedBlockMatrix = {
-    if (keys.length != bm.nRows)
-      fatal(s"Differing number of keys and rows: $keys.length, ${bm.nRows}")    
+    if (bm.nRows > Int.MaxValue)
+      fatal(s"Cannot set row keys on a matrix with more than ${Int.MaxValue} rows. Found ${bm.nRows} rows")
+    else if (keys.length != bm.nRows)
+      fatal(s"Differing number of row keys and rows: $keys.length, ${bm.nRows}")    
 
     copy(rowKeys = Some(keys))
   }
   
   def setColKeys(keys: Keys): KeyedBlockMatrix = {
-    if (keys.length != bm.nCols)
-      fatal(s"Differing number of keys and cols: ${keys.length}, ${bm.nCols}")    
+    if (bm.nRows > Int.MaxValue)
+      fatal(s"Cannot set col keys on a matrix with more than ${Int.MaxValue} cols. Found ${bm.nCols} cols")
+    else if (keys.length != bm.nCols)
+      fatal(s"Differing number of col keys and cols: ${keys.length}, ${bm.nCols}")    
 
     copy(colKeys = Some(keys))
   }

--- a/src/main/scala/is/hail/distributedmatrix/KeyedBlockMatrix.scala
+++ b/src/main/scala/is/hail/distributedmatrix/KeyedBlockMatrix.scala
@@ -1,0 +1,240 @@
+package is.hail.distributedmatrix
+
+import is.hail.HailContext
+import is.hail.annotations.Annotation
+import is.hail.expr.{JSONAnnotationImpex, Parser}
+import is.hail.expr.types.Type
+import is.hail.utils._
+import org.apache.spark.SparkContext
+import org.apache.spark.storage.StorageLevel
+import org.json4s.jackson.Serialization
+import org.json4s.{JArray, JValue}
+import org.json4s.jackson.JsonMethods.parse
+
+case class KeysImpex(typeStr: String, valuesJ: JValue)
+
+object Keys {
+  def unify(left: Option[Keys], right: Option[Keys], msg: String): Option[Keys] = {
+    (left, right) match {
+      case (Some(l), Some(r)) =>
+        l.assertSame(r, msg)
+        left
+      case (Some(_), _) => left
+      case _ => right
+    }
+  }
+  
+  def read(sc: SparkContext, uri: String): Keys = {
+    val KeysImpex(typeStr, JArray(arr)) =  sc.hadoopConfiguration.readTextFile(uri)(in =>
+      try {
+        val json = parse(in)
+        json.extract[KeysImpex]
+      } catch {
+        case e: Exception => fatal(
+          s"""corrupt or outdated matrix key data.
+             |  Recreate with current version of Hail.
+             |  Detailed exception:
+             |  ${ e.getMessage }""".stripMargin)
+      })
+    
+    val typ = Parser.parseType(typeStr)
+    val values = arr.map(JSONAnnotationImpex.importAnnotation(_, typ)).toArray
+    
+    new Keys(typ, values)
+  }
+}
+
+class Keys(val typ: Type, val values: Array[Annotation]) {
+  def length: Int = values.length
+  
+  def assertSame(that: Keys, msg: String = "") {
+    if (typ != that.typ)
+      fatal(msg + s"Keys have different types: $typ, ${ that.typ }")
+
+    if (length != that.length)
+      fatal(msg + s"Differing number of keys: $length, ${ that.length }")
+
+    var i = 0
+    while (i < length) {
+      if (values(i) != that.values(i))
+        fatal(msg + s"Key mismatch at index $i: ${typ.str(values(i))}, ${typ.str(that.values(i))}")
+      i += 1
+    }
+  }
+  
+  def filter(pred: Annotation => Boolean): Keys = new Keys(typ, values.filter(pred))
+  
+  // keep must be sorted, strictly increasing, in [0, length)
+  def filter(keep: Array[Int]): Keys = new Keys(typ, keep.map(values))
+  
+  def filterAndIndex(pred: Annotation => Boolean): (Keys, Array[Int]) = {
+    val (newValues, indices) = values.zipWithIndex.filter(pred).unzip
+    (new Keys(typ, newValues), indices)
+  }
+  
+  def write(sc: SparkContext, uri: String) {
+    val typeStr = typ.toPrettyString(compact = true)
+    val valuesJ = JArray(values.map(typ.toJSON).toList)
+
+    sc.hadoopConfiguration.writeTextFile(uri)(out => Serialization.write(KeysImpex(typeStr, valuesJ), out))
+  }
+}
+
+object KeyedBlockMatrix {
+  def from(bm: BlockMatrix): KeyedBlockMatrix =
+    new KeyedBlockMatrix(bm, None, None)
+  
+  def read(hc: HailContext, uri: String): KeyedBlockMatrix = {
+    val hadoop = hc.hadoopConf
+    
+    val rowFile = uri + "/rowkeys"
+    val rowKeys =
+      if (hadoop.exists(rowFile))
+        Some(Keys.read(hc.sc, rowFile))
+      else
+        None
+    
+    val colFile = uri + "/colkeys"
+    val colKeys =
+      if (hadoop.exists(colFile))
+        Some(Keys.read(hc.sc, colFile))
+      else
+        None
+
+    val bm = BlockMatrix.read(hc, uri + "/blockmatrix")
+
+    new KeyedBlockMatrix(bm, rowKeys, colKeys)
+  }
+}
+
+class KeyedBlockMatrix(val bm: BlockMatrix, val rowKeys: Option[Keys], val colKeys: Option[Keys]) extends Serializable {
+  require(rowKeys.forall(_.length == bm.nRows))
+  require(colKeys.forall(_.length == bm.nCols))
+  
+  def copy(bm: BlockMatrix = bm,
+    rowKeys: Option[Keys] = rowKeys,
+    colKeys: Option[Keys] = colKeys): KeyedBlockMatrix = new KeyedBlockMatrix(bm, rowKeys, colKeys)
+
+  def cache(): KeyedBlockMatrix = copy(bm.cache())
+  
+  def persist(storageLevel: StorageLevel): KeyedBlockMatrix = copy(bm.persist(storageLevel))
+  
+  def setRowKeys(keys: Keys): KeyedBlockMatrix = {
+    if (keys.length != bm.nRows)
+      fatal(s"Differing number of keys and rows: $keys.length, ${bm.nRows}")    
+
+    copy(rowKeys = Some(keys))
+  }
+  
+  def setColKeys(keys: Keys): KeyedBlockMatrix = {
+    if (keys.length != bm.nCols)
+      fatal(s"Differing number of keys and cows: $keys.length, ${bm.nCols}")    
+
+    copy(colKeys = Some(keys))
+  }
+  
+  def dropRowKeys(): KeyedBlockMatrix = copy(rowKeys = None)
+
+  def dropColKeys(): KeyedBlockMatrix = copy(colKeys = None)
+  
+  def unifyRowKeys(that: KeyedBlockMatrix): Option[Keys] = Keys.unify(rowKeys, that.rowKeys, "Inconsistent row keys. ")
+  
+  def unifyColKeys(that: KeyedBlockMatrix): Option[Keys] = Keys.unify(colKeys, that.colKeys, "Inconsistent col keys. ")
+  
+  def add(that: KeyedBlockMatrix): KeyedBlockMatrix =
+    new KeyedBlockMatrix(bm.add(that.bm), unifyRowKeys(that), unifyColKeys(that))
+  
+  def subtract(that: KeyedBlockMatrix): KeyedBlockMatrix =
+      new KeyedBlockMatrix(bm.subtract(that.bm), unifyRowKeys(that), unifyColKeys(that))
+
+
+  def multiply(that: KeyedBlockMatrix): KeyedBlockMatrix = {
+    Keys.unify(colKeys, that.rowKeys, "Column keys on left do not match row keys on right. ")
+    new KeyedBlockMatrix(bm.multiply(that.bm), rowKeys, that.colKeys)
+  }
+
+  def multiply(bm: BlockMatrix): KeyedBlockMatrix = multiply(KeyedBlockMatrix.from(bm))
+
+  def scalarAdd(i: Double): KeyedBlockMatrix = copy(bm.scalarAdd(i))
+  
+  def scalarSubtract(i: Double): KeyedBlockMatrix = copy(bm.scalarSubtract(i))
+  
+  def scalarMultiply(i: Double): KeyedBlockMatrix = copy(bm.scalarMultiply(i))
+
+  def scalarDivide(i: Double): KeyedBlockMatrix = copy(bm.scalarDivide(i))
+
+  def pointwiseMultiply(that: KeyedBlockMatrix): KeyedBlockMatrix =
+    new KeyedBlockMatrix(bm.pointwiseMultiply(that.bm), unifyRowKeys(that), unifyColKeys(that))
+
+  def pointwiseDivide(that: KeyedBlockMatrix): KeyedBlockMatrix =
+    new KeyedBlockMatrix(bm.pointwiseDivide(that.bm), unifyRowKeys(that), unifyColKeys(that))
+    
+  def vectorAddToEveryRow(v: Array[Double]): KeyedBlockMatrix = copy(bm.vectorAddToEveryRow(v))
+
+  def vectorAddToEveryColumn(v: Array[Double]): KeyedBlockMatrix = copy(bm.vectorAddToEveryColumn(v))
+
+  def vectorPointwiseMultiplyEveryRow(v: Array[Double]): KeyedBlockMatrix = copy(bm.vectorPointwiseMultiplyEveryRow(v))
+
+  def vectorPointwiseMultiplyEveryColumn(v: Array[Double]): KeyedBlockMatrix = copy(bm.vectorPointwiseMultiplyEveryColumn(v))
+  
+  def transpose(): KeyedBlockMatrix = new KeyedBlockMatrix(bm.transpose(), colKeys, rowKeys)
+
+  def filterRows(pred: Annotation => Boolean): KeyedBlockMatrix =
+    rowKeys match {
+      case Some(rk) =>
+        val (newRK, keep) = rk.filterAndIndex(pred)
+        new KeyedBlockMatrix(bm.filterRows(keep.map(_.toLong)), Some(newRK), colKeys)
+      case None =>
+        fatal("Cannot filter rows using predicate: no row keys")
+    }
+  
+  def filterRows(keep: Array[Int]): KeyedBlockMatrix =
+    new KeyedBlockMatrix(
+      bm.filterRows(keep.map(_.toLong)),
+      rowKeys.map(_.filter(keep)),
+      colKeys)
+
+  def filterCols(pred: Annotation => Boolean): KeyedBlockMatrix =
+    colKeys match {
+      case Some(ck) =>
+        val (newCK, keep) = ck.filterAndIndex(pred)
+        new KeyedBlockMatrix(bm.filterCols(keep.map(_.toLong)), rowKeys, Some(newCK))
+      case None =>
+        fatal("Cannot filter rows using predicate: no col keys")
+    }
+  
+  def filterCols(keep: Array[Int]): KeyedBlockMatrix =
+      new KeyedBlockMatrix(
+        bm.filterCols(keep.map(_.toLong)),
+        rowKeys,
+        colKeys.map(_.filter(keep)))
+
+  def filter(rowPred: Annotation => Boolean, colPred: Annotation => Boolean): KeyedBlockMatrix =
+    (rowKeys, colKeys) match {
+      case (Some(rk), Some(ck)) =>
+        val (newRK, keepRows) = rk.filterAndIndex(rowPred)
+        val (newCK, keepCols) = ck.filterAndIndex(colPred)
+        new KeyedBlockMatrix(
+          bm.filter(keepRows.map(_.toLong), keepCols.map(_.toLong)),
+          Some(newRK),
+          Some(newCK))
+      case (None, Some(_)) => fatal("Cannot filter predicate: no row keys")
+      case (Some(_), None) => fatal("Cannot filter using predicate: no col keys")
+      case _ => fatal("Cannot filter using predicates: no row keys, no col keys")
+    }
+  
+  def filter(keepRows: Array[Int], keepCols: Array[Int]): KeyedBlockMatrix =
+        new KeyedBlockMatrix(
+          bm.filter(keepRows.map(_.toLong), keepCols.map(_.toLong)),
+          rowKeys.map(_.filter(keepRows)),
+          colKeys.map(_.filter(keepCols)))
+  
+  def write(uri: String, forceRowMajor: Boolean = false) {
+    val sc = bm.blocks.sparkContext
+    sc.hadoopConfiguration.mkDir(uri)
+
+    rowKeys.foreach(_.write(sc, uri + "/rowkeys"))
+    colKeys.foreach(_.write(sc, uri + "/colkeys"))
+    bm.write(uri + "/blockmatrix", forceRowMajor)
+  }
+}

--- a/src/main/scala/is/hail/distributedmatrix/Keys.scala
+++ b/src/main/scala/is/hail/distributedmatrix/Keys.scala
@@ -1,0 +1,83 @@
+package is.hail.distributedmatrix
+
+import is.hail.annotations.Annotation
+import is.hail.expr.{JSONAnnotationImpex, Parser}
+import is.hail.expr.types.Type
+import is.hail.utils._
+import org.apache.spark.SparkContext
+import org.json4s.jackson.Serialization
+import org.json4s.{JArray, JValue}
+import org.json4s.jackson.JsonMethods.parse
+
+case class KeysImpex(typeStr: String, valuesJ: JValue)
+
+object Keys {
+  def unify(left: Option[Keys], right: Option[Keys], msg: String): Option[Keys] = {
+    (left, right) match {
+      case (Some(l), Some(r)) =>
+        l.assertSame(r, msg)
+        left
+      case (Some(_), _) => left
+      case _ => right
+    }
+  }
+  
+  def read(sc: SparkContext, uri: String): Keys = {
+    val KeysImpex(typeStr, JArray(arr)) =  sc.hadoopConfiguration.readTextFile(uri)(in =>
+      try {
+        val json = parse(in)
+        json.extract[KeysImpex]
+      } catch {
+        case e: Exception => fatal(
+          s"""corrupt or outdated matrix key data.
+             |  Recreate with current version of Hail.
+             |  Detailed exception:
+             |  ${ e.getMessage }""".stripMargin)
+      })
+    
+    val typ = Parser.parseType(typeStr)
+    val values = arr.map(JSONAnnotationImpex.importAnnotation(_, typ)).toArray
+    
+    new Keys(typ, values)
+  }
+}
+
+class Keys(val typ: Type, val values: Array[Annotation]) {
+  def length: Int = values.length
+  
+  def assertSame(that: Keys, msg: String = "") {
+    if (typ != that.typ)
+      fatal(msg + "Keys have different types: " +
+        s"${typ.toPrettyString(compact = true)}, ${ that.typ.toPrettyString(compact = true) }")
+
+    if (values.length != that.values.length)
+      fatal(msg + s"Differing number of keys: $length, ${ that.length }")
+
+    var i = 0
+    while (i < length) {
+      if (values(i) != that.values(i))
+        fatal(msg + s"Key mismatch at index $i: ${typ.str(values(i))}, ${typ.str(that.values(i))}")
+      i += 1
+    }
+  }
+  
+  def filter(pred: Annotation => Boolean): Keys = new Keys(typ, values.filter(pred))
+  
+  def filter(keep: Array[Int], check: Boolean = true): Keys = {
+    if (check)
+      require(keep.isEmpty || (keep.isIncreasing && keep.head >= 0 && keep.last < length))
+    new Keys(typ, keep.map(values))
+  }
+  
+  def filterAndIndex(pred: Annotation => Boolean): (Keys, Array[Int]) = {
+    val (newValues, indices) = values.zipWithIndex.filter(vi => pred(vi._1)).unzip
+    (new Keys(typ, newValues), indices)
+  }
+  
+  def write(sc: SparkContext, uri: String) {
+    val typeStr = typ.toPrettyString(compact = true)
+    val valuesJ = JArray(values.map(typ.toJSON).toList)
+
+    sc.hadoopConfiguration.writeTextFile(uri)(out => Serialization.write(KeysImpex(typeStr, valuesJ), out))
+  }
+}

--- a/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/BlockMatrixSuite.scala
@@ -700,17 +700,17 @@ class BlockMatrixSuite extends SparkSuite {
     } {
       val bm = BlockMatrix.from(sc, lm, blockSize)      
       for {
-        rowsToKeep <- Seq(
+        keepRows <- Seq(
           Array(1),
           Array(0, 3, 4, 5, 7),
           Array(0, 1, 2, 3, 4, 5, 6, 7, 8))  
-        colsToKeep <- Seq(
+        keepCols <- Seq(
           Array(2),
           Array(1, 4, 5, 7, 8, 9),
           Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))  
       } {
-        val filteredViaBlock = bm.filter(rowsToKeep.map(_.toLong), colsToKeep.map(_.toLong)).toLocalMatrix()
-        val filteredViaBreeze = lm(rowsToKeep.toIndexedSeq, colsToKeep.toIndexedSeq).copy
+        val filteredViaBlock = bm.filter(keepRows.map(_.toLong), keepCols.map(_.toLong)).toLocalMatrix()
+        val filteredViaBreeze = lm(keepRows.toIndexedSeq, keepCols.toIndexedSeq).copy
         
         assert(filteredViaBlock === filteredViaBreeze)
       }

--- a/src/test/scala/is/hail/distributedmatrix/KeyedBlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/KeyedBlockMatrixSuite.scala
@@ -1,0 +1,118 @@
+package is.hail.distributedmatrix
+
+import is.hail.SparkSuite
+import is.hail.annotations.Annotation
+import is.hail.check.Gen
+import is.hail.check.Prop._
+import is.hail.expr.types._
+import breeze.linalg.{DenseMatrix => BDM}
+import org.testng.annotations.Test
+
+class KeyedBlockMatrixSuite extends SparkSuite {
+  def assertSame(left: KeyedBlockMatrix, right: KeyedBlockMatrix) {
+    (left.rowKeys, right.rowKeys) match {
+      case (Some(lrk), Some(rrk)) => lrk.assertSame(rrk)
+      case (None, None) =>
+      case _ => assert(false)
+    }
+
+    (left.colKeys, right.colKeys) match {
+      case (Some(lck), Some(rck)) => lck.assertSame(rck)
+      case (None, None) =>
+      case _ => assert(false)
+    }
+    
+    assert(left.bm.toLocalMatrix() === right.bm.toLocalMatrix())
+  }
+  
+  val genKeys: Gen[Keys] = for {
+      t <- Type.genArb
+      v <- TArray(t).genNonmissingValue
+    } yield new Keys(t, v.asInstanceOf[IndexedSeq[Annotation]].toArray)
+  
+  @Test
+  def writeReadKeys() {
+    val p = forAll(genKeys) { keys =>
+      val f = tmpDir.createTempFile()
+      keys.write(sc, f)
+      keys.assertSame(Keys.read(sc, f))
+      true
+    }
+    
+    p.check()
+  }
+  
+  @Test
+  def writeReadKBM() {
+    val nRows = 9
+    val nCols = 10
+    val lm = Gen.denseMatrix[Double](9, 10).sample()
+    val bm = BlockMatrix.from(sc, lm, 3)    
+    val rk = new Keys(TInt32(), (0 until nRows).toArray)
+    val ck = new Keys(TString(), (0 until nCols).map(_.toString).toArray)
+    
+    for {
+      rowKeys <- Seq(Some(rk), None)
+      colKeys <- Seq(Some(ck), None)
+    } {
+      val file = tmpDir.createTempFile("test")
+      val kbm = new KeyedBlockMatrix(bm, rowKeys, colKeys)
+      kbm.write(file)
+      assertSame(kbm, KeyedBlockMatrix.read(hc, file))
+    }
+  }
+
+  def fromLocal(lm: BDM[Double], blockSize: Int = 3): KeyedBlockMatrix = {
+    val bm = BlockMatrix.from(sc, lm, blockSize)
+    val rowKeys = Some(new Keys(TInt32(), (0 until lm.rows).toArray))
+    val colKeys = Some(new Keys(TString(), (0 until lm.cols).map(_.toString).toArray))
+    new KeyedBlockMatrix(bm, rowKeys, colKeys)
+  }  
+  
+  @Test
+  def testOps() {
+    val nRows = 9
+    val nCols = 10
+    val kbm = fromLocal(Gen.denseMatrix[Double](nRows, nCols).sample())
+    val zeros = fromLocal(BDM.zeros[Double](nRows, nCols))
+    val ones = fromLocal(BDM.ones[Double](nRows, nCols))
+    val idLeft = fromLocal(BDM.eye[Double](nRows))
+    val idRight = fromLocal(BDM.eye[Double](nCols))
+    val keepRows = (0 until nRows).toArray
+    val keepCols = (0 until nCols).toArray
+    val file = tmpDir.createTempFile("test")
+    kbm.write(file)
+    
+    for {
+      kbm0 <- Seq(
+        KeyedBlockMatrix.read(hc, file),
+        kbm.add(zeros),
+        kbm.subtract(zeros),
+        kbm.multiply(idRight.dropRowKeys()).setColKeys(kbm.colKeys.get),
+        idLeft.setRowKeys(kbm.rowKeys.get).dropColKeys().multiply(kbm),
+        kbm.scalarAdd(0),
+        kbm.scalarSubtract(0),
+        kbm.scalarMultiply(1),
+        kbm.scalarDivide(1),
+        kbm.pointwiseMultiply(ones),
+        kbm.pointwiseDivide(ones),
+        kbm.vectorAddToEveryRow(Array.fill[Double](nCols)(0)),
+        kbm.vectorAddToEveryColumn(Array.fill[Double](nRows)(0)),
+        kbm.vectorPointwiseMultiplyEveryRow(Array.fill[Double](nCols)(1)),
+        kbm.vectorPointwiseMultiplyEveryColumn(Array.fill[Double](nRows)(1)),
+        kbm.transpose().transpose(),
+        kbm.filterRows(_ => true),
+        kbm.filterRows(keepRows),
+        kbm.filterCols(_ => true),
+        kbm.filterCols(keepCols),
+        kbm.filter(_ => true, _ => true),
+        kbm.filter(keepRows, keepCols),
+        kbm.cache(),
+        kbm.dropRowKeys().setRowKeys(kbm.rowKeys.get),
+        kbm.dropColKeys().setColKeys(kbm.colKeys.get)
+      )
+    } {
+      assertSame(kbm, kbm0)
+    }
+  }
+}

--- a/src/test/scala/is/hail/distributedmatrix/KeysSuite.scala
+++ b/src/test/scala/is/hail/distributedmatrix/KeysSuite.scala
@@ -1,0 +1,60 @@
+package is.hail.distributedmatrix
+
+import is.hail.annotations.Annotation
+import is.hail.check.Gen
+import is.hail.check.Prop._
+import is.hail.expr.types._
+import is.hail.{SparkSuite, TestUtils}
+import org.testng.annotations.Test
+
+class KeysSuite extends SparkSuite {  
+  val genKeys: Gen[Keys] = for {
+      t <- Type.genArb
+      v <- TArray(t).genNonmissingValue
+    } yield new Keys(t, v.asInstanceOf[IndexedSeq[Annotation]].toArray)
+  
+  @Test
+  def writeReadKeys() {
+    val p = forAll(genKeys) { keys =>
+      val f = tmpDir.createTempFile()
+      keys.write(sc, f)
+      keys.assertSame(Keys.read(sc, f))
+      true
+    }
+    
+    p.check()
+  }
+
+  @Test
+  def testFatals() {
+    val k1 = new Keys(TInt32(), Array(0, 1))
+    val k2 = new Keys(TString(), Array("a", "b"))
+    val k3 = new Keys(TInt32(), Array(0, 1, 2))
+    val k4 = new Keys(TInt32(), Array(0, 2))
+    
+    TestUtils.interceptFatal("Keys have different types: Int32, String") {
+      k1.assertSame(k2)
+    }
+    
+    TestUtils.interceptFatal("Differing number of keys: 2, 3") {
+      k1.assertSame(k3)
+    }
+    
+    TestUtils.interceptFatal("Key mismatch at index 1: 1, 2") {
+      k1.assertSame(k4)
+    }
+  }
+  
+  @Test
+  def filter() {
+    val k1 = new Keys(TString(), Array("a", "bc", "d"))
+    val k2 = new Keys(TString(), Array("a", "d"))
+    
+    k1.filter(_.asInstanceOf[String].length < 2).assertSame(k2)
+    k1.filter(Array(0, 2)).assertSame(k2)
+    
+    val (k3, ind) = k1.filterAndIndex(_.asInstanceOf[String].length < 2)
+    k2.assertSame(k3)
+    assert(Array(0, 2).sameElements(ind))
+  }
+}


### PR DESCRIPTION
KeyedBlockMatrix is a BlockMatrix with optional row and column Keys. I chose to make them optional when considering the need to constantly check key agreement. Here if both operands have row keys in a binary operation like add, then the keys are checked for agreement. The result has rowKeys iff at least one operand has rowKeys (and they agree). Similar rules apply to column keys and other operations where sensible. When promoting a BlockMatrix to a KeyedBlockMatrix, the keys are set to None. A BlockMatrix can be promoted to a KeyedBlockMatrix even if it's dimensions exceed Int.MaxValue; the simple rule is that you can't set keys on a dimension that is too large. This is convenient if you have a matrix where one dimension is huge but you still want keys on the other dimension.

Checking keys helps ensure correctness, and I think the ability to set/drop keys on keyed matrices should be useful for linear algebra where a matrix operand comes un-keyed or you don't care about the keys on that operand.  This key persistence is also natural when thinking about operations that add (unkeyed) scalars or vectors to keyed matrices (We'd later add optionally-keyed vectors as well, where keys are checked in vector addition, matrix/vector mult, vectorAddToEveryRow, etc). Keys are stored and checked on master, so for large dimensions users may want to rekey with simpler keys, via a map on the python side or with just indices.

For simplicity, and since there's basically no additional overhead using an unkeyed KeyedBlockMatrix versus its underlying BlockMatrix, I think we should consider only having (optionally) keyed matrices exposed on the Python side (so a Python BlockMatrix is a Scala KeyedBlockMatrix, and you can do linear algebra numpy-style by just having no keys set). I plan to add writeKeyedBlockMatrix to MatrixTable in next step, with parameters to on whether to retain the keys (e.g., key_rows = true). On the Python side, this could then replace write_block_matrix rather than being in addition to it. Later, LocalMatrix and RowMatrix would follow the same pattern of optionally keyed versions in Scala, with a common Matrix and KeyedMatrix abstraction. And in Python users would just have Matrix backed by KeyedMatrix on the Scala side.

PS. In the filters, I switched to names keepRows and keepCols in KeyedBlockMatrix instead of rowsToKeep and colsToKeep, so the changes in BlockMatrix and BlockMatrixSuite are just renaming for consistency (as well as removing one unused line).