### PR TITLE
rv-ify queryVariants

### DIFF
--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -4,10 +4,9 @@ import is.hail.expr.ir.IR
 import is.hail.asm4s.{Code, _}
 import is.hail.expr.types._
 import is.hail.utils.EitherIsAMonad._
-import is.hail.utils.{HailException, _}
+import is.hail.utils._
 import is.hail.variant.GenomeReference
 import org.apache.spark.sql.{Row, RowFactory}
-import org.json4s.jackson.JsonMethods
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer

--- a/src/test/scala/is/hail/methods/LinearMixedRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearMixedRegressionSuite.scala
@@ -7,6 +7,7 @@ import is.hail.annotations._
 import is.hail.expr.types._
 import is.hail.stats._
 import is.hail.utils._
+import is.hail.testUtils._
 import is.hail.variant.{MatrixTable, Variant}
 import is.hail.{SparkSuite, TestUtils}
 import org.testng.annotations.Test

--- a/src/test/scala/is/hail/methods/LinearRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearRegressionSuite.scala
@@ -6,6 +6,7 @@ import is.hail.annotations.Annotation
 import is.hail.expr.types._
 import is.hail.table.Table
 import is.hail.utils._
+import is.hail.testUtils._
 import is.hail.variant.Variant
 import org.testng.annotations.Test
 

--- a/src/test/scala/is/hail/methods/LogisticRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LogisticRegressionSuite.scala
@@ -5,6 +5,7 @@ import is.hail.annotations.{Annotation, Querier}
 import is.hail.expr.types._
 import is.hail.table.Table
 import is.hail.utils._
+import is.hail.testUtils._
 import is.hail.variant.Variant
 import org.testng.annotations.Test
 

--- a/src/test/scala/is/hail/stats/BaldingNicholsModelSuite.scala
+++ b/src/test/scala/is/hail/stats/BaldingNicholsModelSuite.scala
@@ -2,8 +2,8 @@ package is.hail.stats
 
 import breeze.stats._
 import is.hail.SparkSuite
-import is.hail.variant.{Genotype, Locus, Variant}
-import is.hail.variant.{Call, Genotype}
+import is.hail.variant.{Call, Locus, Variant}
+import is.hail.testUtils._
 import org.apache.spark.sql.Row
 import org.testng.Assert.assertEquals
 import org.testng.annotations.Test

--- a/src/test/scala/is/hail/stats/FisherExactTestSuite.scala
+++ b/src/test/scala/is/hail/stats/FisherExactTestSuite.scala
@@ -5,6 +5,8 @@ import is.hail.check.Gen._
 import is.hail.check.Prop._
 import is.hail.check.Properties
 import is.hail.utils._
+import is.hail.testUtils._
+import is.hail.variant.{Call, Genotype}
 import is.hail.variant.{MatrixTable, _}
 import org.testng.annotations.Test
 

--- a/src/test/scala/is/hail/stats/HWESuite.scala
+++ b/src/test/scala/is/hail/stats/HWESuite.scala
@@ -4,6 +4,7 @@ import is.hail.SparkSuite
 import is.hail.check._
 import is.hail.methods.{SplitMulti, VariantQC}
 import is.hail.utils._
+import is.hail.testUtils._
 import is.hail.variant._
 import org.apache.spark.sql.Row
 import org.testng.annotations.Test

--- a/src/test/scala/is/hail/utils/RichMatrixTable.scala
+++ b/src/test/scala/is/hail/utils/RichMatrixTable.scala
@@ -3,6 +3,7 @@ package is.hail.utils
 import is.hail.annotations.{Annotation, Inserter, Querier, UnsafeRow}
 import is.hail.expr.{EvalContext, Parser}
 import is.hail.expr.types._
+import is.hail.sparkextras.OrderedRDD
 import is.hail.variant.MatrixTable
 import org.apache.spark.rdd.RDD
 
@@ -76,4 +77,7 @@ class RichMatrixTable(vsm: MatrixTable) {
   def stringSampleIdsAndAnnotations: IndexedSeq[(Annotation, Annotation)] = vsm.stringSampleIds.zip(vsm.sampleAnnotations)
 
   def variants: RDD[Annotation] = vsm.rdd.keys
+
+  def variantsAndAnnotations: OrderedRDD[Annotation, Annotation, Annotation] =
+    vsm.rdd.mapValuesWithKey { case (v, (va, gs)) => va }
 }

--- a/src/test/scala/is/hail/variant/IntervalSuite.scala
+++ b/src/test/scala/is/hail/variant/IntervalSuite.scala
@@ -6,6 +6,7 @@ import is.hail.check.{Gen, Prop}
 import is.hail.expr.types._
 import is.hail.io.annotators.IntervalList
 import is.hail.utils._
+import is.hail.testUtils._
 import org.testng.annotations.Test
 
 class IntervalSuite extends SparkSuite {

--- a/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -3,6 +3,7 @@ package is.hail.variant.vsm
 import is.hail.SparkSuite
 import is.hail.check.{Gen, Prop}
 import is.hail.variant.{GenomeReference, VSMSubgen, MatrixTable}
+import is.hail.testUtils._
 import org.testng.annotations.Test
 
 class PartitioningSuite extends SparkSuite {


### PR DESCRIPTION
along the way, move rdd-based variantsAndAnnotations to tests code