### PR TITLE
rv-ified VEP and Nirvana

### DIFF
--- a/src/main/scala/is/hail/methods/Nirvana.scala
+++ b/src/main/scala/is/hail/methods/Nirvana.scala
@@ -363,7 +363,7 @@ object Nirvana {
 
     val newMatrixType = vds.matrixType.copy(vaType = newVAType)
     val newRDD2 = vds.orderedRVDLeftJoinDistinctAndInsert(vds.rdd2, vepRVD,
-      newMatrixType.orderedRVType, product = false, 3, newVAType, inserter)
+      newMatrixType.orderedRVType, product = false, 2, newVAType, inserter)
 
     vds.copy2(rdd2 = newRDD2, vaSignature = newVAType)
   }

--- a/src/main/scala/is/hail/methods/Nirvana.scala
+++ b/src/main/scala/is/hail/methods/Nirvana.scala
@@ -3,9 +3,10 @@ package is.hail.methods
 import java.io.{FileInputStream, IOException}
 import java.util.Properties
 
-import is.hail.annotations.{Annotation, Querier}
+import is.hail.annotations._
 import is.hail.expr.types._
 import is.hail.expr.{JSONAnnotationImpex, Parser}
+import is.hail.rvd.{OrderedRVD, OrderedRVType}
 import is.hail.utils._
 import is.hail.variant.{Locus, MatrixTable, Variant}
 import org.apache.spark.storage.StorageLevel
@@ -327,18 +328,44 @@ object Nirvana {
 
     info(s"nirvana: annotated ${ annotations.count() } variants")
 
-    val (newVASignature, insertNirvana) = vds.vaSignature.insert(nirvanaSignature, parsedRoot)
+    val nirvanaOrderedRVType = new OrderedRVType(
+      Array("pk"), Array("pk", "v"),
+      TStruct(
+        "pk" -> vds.locusType,
+        "v" -> vds.vSignature,
+        "vep" -> nirvanaSignature))
 
-    val newRDD = vds.typedRDD[Locus, Variant]
-      .zipPartitions(annotations, preservesPartitioning = true) { case (left, right) =>
-        left.sortedLeftJoinDistinct(right)
-          .map { case (v, ((va, gs), vaNirvana)) =>
-            (v, (insertNirvana(va, vaNirvana.orNull), gs))
-          }
-      }
+    val nirvanaRowType = nirvanaOrderedRVType.rowType
+    val (t, pkProjection) = Type.partitionKeyProjection(vds.vSignature)
+    assert(t == vds.locusType)
 
-    vds.copyLegacy(rdd = newRDD,
-      vaSignature = newVASignature)
+    val vepRVD: OrderedRVD = OrderedRVD(
+      nirvanaOrderedRVType,
+      vds.rdd2.partitioner,
+      annotations.mapPartitions { it =>
+        val region = Region()
+        val rvb = new RegionValueBuilder(region)
+        val rv = RegionValue(region)
+
+        it.map { case (v, vep) =>
+          rvb.start(nirvanaRowType)
+          rvb.startStruct()
+          rvb.addAnnotation(nirvanaRowType.fieldType(0), pkProjection(v))
+          rvb.addAnnotation(nirvanaRowType.fieldType(1), v)
+          rvb.addAnnotation(nirvanaRowType.fieldType(2), vep)
+          rvb.endStruct()
+          rv.setOffset(rvb.end())
+
+          rv
+        }})
+
+    val (newVAType, inserter) = vds.vaSignature.insert(nirvanaSignature, parsedRoot)
+
+    val newMatrixType = vds.matrixType.copy(vaType = newVAType)
+    val newRDD2 = vds.orderedRVDLeftJoinDistinctAndInsert(vds.rdd2, vepRVD,
+      newMatrixType.orderedRVType, product = false, 3, newVAType, inserter)
+
+    vds.copy2(rdd2 = newRDD2, vaSignature = newVAType)
   }
 
   def apply(vsm: MatrixTable, config: String, blockSize: Int = 500000, root: String): MatrixTable =

--- a/src/main/scala/is/hail/methods/VEP.scala
+++ b/src/main/scala/is/hail/methods/VEP.scala
@@ -3,18 +3,18 @@ package is.hail.methods
 import java.io.{FileInputStream, IOException}
 import java.util.Properties
 
-import is.hail.annotations.Annotation
+import is.hail.annotations.{Annotation, Region, RegionValue, RegionValueBuilder}
 import is.hail.expr._
 import is.hail.expr.types._
+import is.hail.rvd.{OrderedRVD, OrderedRVType}
 import is.hail.utils._
-import is.hail.variant.{Locus, MatrixTable, Variant}
+import is.hail.variant.{MatrixTable, Variant}
 import org.apache.spark.sql.Row
 import org.apache.spark.storage.StorageLevel
 import org.json4s.jackson.JsonMethods
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-import scala.reflect.ClassTag
 
 object VEP {
 
@@ -391,22 +391,48 @@ object VEP {
       }
       .persist(StorageLevel.MEMORY_AND_DISK)
 
+    val vepType: Type = if (csq) TArray(TString()) else vepSignature
+
+    val vepOrderedRVType = new OrderedRVType(
+      Array("pk"), Array("pk", "v"),
+      TStruct(
+        "pk" -> vsm.locusType,
+        "v" -> vsm.vSignature,
+        "vep" -> vepType))
+
+    val vepRowType = vepOrderedRVType.rowType
+    val (t, pkProjection) = Type.partitionKeyProjection(vsm.vSignature)
+    assert(t == vsm.locusType)
+
+    val vepRVD: OrderedRVD = OrderedRVD(
+      vepOrderedRVType,
+      vsm.rdd2.partitioner,
+      annotations.mapPartitions { it =>
+        val region = Region()
+        val rvb = new RegionValueBuilder(region)
+        val rv = RegionValue(region)
+
+        it.map { case (v, vep) =>
+          rvb.start(vepRowType)
+          rvb.startStruct()
+          rvb.addAnnotation(vepRowType.fieldType(0), pkProjection(v))
+          rvb.addAnnotation(vepRowType.fieldType(1), v)
+          rvb.addAnnotation(vepRowType.fieldType(2), vep)
+          rvb.endStruct()
+          rv.setOffset(rvb.end())
+
+          rv
+      }})
+
     info(s"vep: annotated ${ annotations.count() } variants")
 
-    val (newVASignature, insertVEP) = vsm.vaSignature.insert(if (csq) TArray(TString()) else vepSignature, parsedRoot)
+    val (newVAType, inserter) = vsm.vaSignature.insert(vepType, parsedRoot)
 
-    implicit val variantOrd = vsm.genomeReference.variantOrdering
+    val newMatrixType = vsm.matrixType.copy(vaType = newVAType)
+    val newRDD2 = vsm.orderedRVDLeftJoinDistinctAndInsert(vsm.rdd2, vepRVD,
+      newMatrixType.orderedRVType, product = false, 3, newVAType, inserter)
 
-    val newRDD = vsm.typedRDD[Locus, Variant]
-      .zipPartitions(annotations, preservesPartitioning = true) { case (left, right) =>
-        left.sortedLeftJoinDistinct(right)
-          .map { case (v, ((va, gs), a)) => (v, (insertVEP(va, a.orNull), gs)) }
-      }
-
-    (csq, newVASignature) match {
-      case (true, t: TStruct) => vsm.copyLegacy(rdd = newRDD)
-      case _ => vsm.copyLegacy(rdd = newRDD, vaSignature = newVASignature)
-    }
+    vsm.copy2(rdd2 = newRDD2, vaSignature = newVAType)
   }
 
   def apply(vsm: MatrixTable, config: String, root: String = "va.vep", csq: Boolean = false, blockSize: Int = 1000): MatrixTable =

--- a/src/main/scala/is/hail/methods/VEP.scala
+++ b/src/main/scala/is/hail/methods/VEP.scala
@@ -430,7 +430,7 @@ object VEP {
 
     val newMatrixType = vsm.matrixType.copy(vaType = newVAType)
     val newRDD2 = vsm.orderedRVDLeftJoinDistinctAndInsert(vsm.rdd2, vepRVD,
-      newMatrixType.orderedRVType, product = false, 3, newVAType, inserter)
+      newMatrixType.orderedRVType, product = false, 2, newVAType, inserter)
 
     vsm.copy2(rdd2 = newRDD2, vaSignature = newVAType)
   }

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -890,7 +890,7 @@ class MatrixTable(val hc: HailContext, val metadata: VSMMetadata,
     root: String, expr: String, product: Boolean): MatrixTable =
     annotateVariantsTable(kt, if (vdsKey != null) vdsKey.asScala else null, root, expr, product)
 
-  private def orderedRVDLeftJoinDistinctAndInsert(
+  def orderedRVDLeftJoinDistinctAndInsert(
     lrvd: OrderedRVD,
     rrvd: OrderedRVD,
     newOrderedRVType: OrderedRVType, product: Boolean, valueIdx: Int, newVAType: Type, inserter: Inserter): OrderedRVD = {


### PR DESCRIPTION
Builds on: https://github.com/hail-is/hail/pull/2711 (genericintervals7)

You probably want to wait until that goes in to review.

@konradjk Unfortunately, we don't have automated tests for VEP yet.  I'm bump the priority on that to make changing VEP safer, but in the mean time, can I ask you to run this on a small example to make sure we didn't break anything?  Thanks!

@jbloom22 Can you do the same for Nirvana?
