### PR TITLE
rv-ified concordance

### DIFF
--- a/python/hail/api1/dataset.py
+++ b/python/hail/api1/dataset.py
@@ -1161,12 +1161,24 @@ in { GT: newgt, AD: newad, DP: g.DP, GQ: newgq, PL: newpl }
 
         **Notes**
 
-        This method computes the genotype call concordance between two bialellic variant datasets.
-        It performs an inner join on samples (only samples in both datasets will be considered), and an outer join
-        on variants. If a variant is only in one dataset, then each genotype is treated as "no data" in the other.
-        This method returns a tuple of three objects: a nested list of list of int with global concordance
-        summary statistics, a key table with sample concordance statistics, and a key table with variant concordance
-        statistics.
+        This method computes the genotype call concordance between two
+        bialellic variant datasets.  It requires unique sample IDs and
+        performs an inner join on samples (only samples in both
+        datasets will be considered).
+
+        It performs an ordered zip join of the variants.  That means
+        the variants of each dataset are sorted, with duplicate
+        variants appearing in some random relative order, and then
+        zipped together.  When a variant appears a different number of
+        times between the two datasets, the dataset with the fewer
+        number of instances is padded with "no data".  For example, if
+        a variant is only in one dataset, then each genotype is
+        treated as "no data" in the other.
+
+        This method returns a tuple of three objects: a nested list of
+        list of int with global concordance summary statistics, a key
+        table with sample concordance statistics, and a key table with
+        variant concordance statistics.
 
         **Using the global summary result**
 

--- a/python/hail/api1/dataset.py
+++ b/python/hail/api1/dataset.py
@@ -1162,7 +1162,7 @@ in { GT: newgt, AD: newad, DP: g.DP, GQ: newgq, PL: newpl }
         **Notes**
 
         This method computes the genotype call concordance between two
-        bialellic variant datasets.  It requires unique sample IDs and
+        biallelic variant datasets.  It requires unique sample IDs and
         performs an inner join on samples (only samples in both
         datasets will be considered).
 
@@ -2360,7 +2360,7 @@ g = let newgt = gtIndex(oldToNew[gtj(g.GT)], oldToNew[gtk(g.GT)]) and
 
         **Notes**
 
-        The genetic relationship matrix (GRM) :math:`G` encodes genetic correlation between each pair of samples. It is defined by :math:`G = MM^T` where :math:`M` is a standardized version of the genotype matrix, computed as follows. Let :math:`C` be the :math:`n \\times m` matrix of raw genotypes in the variant dataset, with rows indexed by :math:`n` samples and columns indexed by :math:`m` bialellic autosomal variants; :math:`C_{ij}` is the number of alternate alleles of variant :math:`j` carried by sample :math:`i`, which can be 0, 1, 2, or missing. For each variant :math:`j`, the sample alternate allele frequency :math:`p_j` is computed as half the mean of the non-missing entries of column :math:`j`. Entries of :math:`M` are then mean-centered and variance-normalized as
+        The genetic relationship matrix (GRM) :math:`G` encodes genetic correlation between each pair of samples. It is defined by :math:`G = MM^T` where :math:`M` is a standardized version of the genotype matrix, computed as follows. Let :math:`C` be the :math:`n \\times m` matrix of raw genotypes in the variant dataset, with rows indexed by :math:`n` samples and columns indexed by :math:`m` biallelic autosomal variants; :math:`C_{ij}` is the number of alternate alleles of variant :math:`j` carried by sample :math:`i`, which can be 0, 1, 2, or missing. For each variant :math:`j`, the sample alternate allele frequency :math:`p_j` is computed as half the mean of the non-missing entries of column :math:`j`. Entries of :math:`M` are then mean-centered and variance-normalized as
 
         .. math::
 
@@ -4427,7 +4427,7 @@ g = let newgt = gtIndex(oldToNew[gtj(g.GT)], oldToNew[gtk(g.GT)]) and
         **Notes**
 
         The Realized Relationship Matrix is defined as follows. Consider the :math:`n \\times m` matrix :math:`C` of raw genotypes, with rows indexed by :math:`n` samples and
-        columns indexed by the :math:`m` bialellic autosomal variants; :math:`C_{ij}` is the number of alternate alleles of variant :math:`j` carried by sample :math:`i`, which
+        columns indexed by the :math:`m` biallelic autosomal variants; :math:`C_{ij}` is the number of alternate alleles of variant :math:`j` carried by sample :math:`i`, which
         can be 0, 1, 2, or missing. For each variant :math:`j`, the sample alternate allele frequency :math:`p_j` is computed as half the mean of the non-missing entries of column
         :math:`j`. Entries of :math:`M` are then mean-centered and variance-normalized as
 

--- a/python/hail/methods/qc.py
+++ b/python/hail/methods/qc.py
@@ -194,16 +194,23 @@ def concordance(left, right):
     Notes
     -----
 
-    This method computes the genotype call concordance (from the entry field
-    **GT**) between two biallelic datasets. It performs an inner join on column
-    keys (only column keys in both datasets will be considered), and an outer
-    join on row keys. If a column key is duplicated in the right dataset, the
-    column joined with the left dataset will be randomly chosen. If a row key is
-    only in one dataset, then each genotype is treated as "no data" in the
-    other. This method returns a tuple of three objects: a nested list of list
-    of int with global concordance summary statistics, a table with concordance
-    statistics per column key, and a table with concordance statistics per row
-    key.
+    This method computes the genotype call concordance (from the entry
+    field **GT**) between two biallelic variant datasets.  It requires
+    unique sample IDs and performs an inner join on samples (only
+    samples in both datasets will be considered).
+
+    It performs an ordered zip join of the variants.  That means the
+    variants of each dataset are sorted, with duplicate variants
+    appearing in some random relative order, and then zipped together.
+    When a variant appears a different number of times between the two
+    datasets, the dataset with the fewer number of instances is padded
+    with "no data".  For example, if a variant is only in one dataset,
+    then each genotype is treated as "no data" in the other.
+
+    This method returns a tuple of three objects: a nested list of
+    list of int with global concordance summary statistics, a table
+    with concordance statistics per column key, and a table with
+    concordance statistics per row key.
 
     **Using the global summary result**
 
@@ -271,6 +278,7 @@ def concordance(left, right):
     (list of list of int, :class:`.Table`, :class:`.Table`)
         The global concordance statistics, a table with concordance statistics
         per column key, and a table with concordance statistics per row key.
+
     """
 
     left = require_biallelic(left, "concordance, left")

--- a/src/main/scala/is/hail/methods/CalculateConcordance.scala
+++ b/src/main/scala/is/hail/methods/CalculateConcordance.scala
@@ -1,5 +1,6 @@
 package is.hail.methods
 
+import is.hail.annotations.UnsafeRow
 import is.hail.expr.types._
 import is.hail.table.Table
 import is.hail.utils._
@@ -14,16 +15,8 @@ class ConcordanceCombiner extends Serializable {
   // 5x5 square matrix indexed by [NoData, NoCall, HomRef, Het, HomVar] on each axis
   val mapping = MultiArray2.fill(5, 5)(0L)
 
-  def mergeBoth(left: Int, right: Int) {
-    mapping(left + 2, right + 2) += 1
-  }
-
-  def mergeLeft(left: Int) {
-    mapping(left + 2, 0) += 1
-  }
-
-  def mergeRight(right: Int) {
-    mapping(0, right + 2) += 1
+  def merge(left: Int, right: Int) {
+    mapping(left, right) += 1
   }
 
   def merge(other: ConcordanceCombiner): ConcordanceCombiner = {
@@ -73,8 +66,8 @@ object CalculateConcordance {
 
     if (left.vSignature != right.vSignature)
       fatal(s"""Cannot compute concordance for datasets with different reference genomes:
-              |  left: ${left.vSignature.toPrettyString(compact = true)}
-              |  right: ${right.vSignature.toPrettyString(compact = true)}""")
+              |  left: ${ left.vSignature.toPrettyString(compact = true) }
+              |  right: ${ right.vSignature.toPrettyString(compact = true) }""")
 
     info(
       s"""Found ${ overlap.size } overlapping samples
@@ -101,46 +94,54 @@ object CalculateConcordance {
 
     assert(leftIds.toSet == overlap && rightIds.toSet == overlap)
 
-    val leftIdIndex = leftIds.zipWithIndex.toMap
-    val rightIdMapping = rightIds.map(leftIdIndex).toArray
-    val rightIdMappingBc = left.sparkContext.broadcast(rightIdMapping)
+    val rightIdIndex = rightIds.zipWithIndex.toMap
+    val leftToRight = leftIds.map(rightIdIndex).toArray
+    val leftToRightBc = left.sparkContext.broadcast(leftToRight)
 
-    val join = leftFiltered.typedRDD[Locus, Variant].orderedOuterJoinDistinct(rightFiltered.typedRDD[Locus, Variant])
+    val join = leftFiltered.rdd2.orderedZipJoin(rightFiltered.rdd2)
+
+    val leftRowType = leftFiltered.rowType
+    val rightRowType = rightFiltered.rowType
 
     val nSamples = leftIds.length
     val sampleResults = join.mapPartitions { it =>
-      val arr = Array.ofDim[Int](nSamples)
       val comb = Array.fill(nSamples)(new ConcordanceCombiner)
-      val rightMapping = rightIdMappingBc.value
+      val leftToRight = leftToRightBc.value
 
-      it.foreach { case (v, (v1, v2)) =>
-        ((v1, v2): @unchecked) match {
+      val lview = HardCallView(leftRowType)
+      val rview = HardCallView(rightRowType)
 
-          case (Some((_, leftGS)), Some((_, rightGS))) =>
-            var i = 0
-            rightGS.foreach { g =>
-              arr(rightMapping(i)) = Genotype.unboxedGT(g)
-              i += 1
-            }
-            assert(i == nSamples)
-            i = 0
-            leftGS.foreach { g =>
-              comb(i).mergeBoth(Genotype.unboxedGT(g), arr(i))
-              i += 1
-            }
-          case (None, Some((_, rightGS))) =>
-            var i = 0
-            rightGS.foreach { g =>
-              comb(rightMapping(i)).mergeRight(Genotype.unboxedGT(g))
-              i += 1
-            }
-            assert(i == nSamples)
-          case (Some((_, leftGS)), None) =>
-            var i = 0
-            leftGS.foreach { g =>
-              comb(i).mergeLeft(Genotype.unboxedGT(g))
-              i += 1
-            }
+      it.foreach { jrv =>
+        val lrv = jrv.rvLeft
+        val rrv = jrv.rvRight
+
+        if (lrv != null)
+          lview.setRegion(lrv)
+        if (rrv != null)
+          rview.setRegion(rrv)
+
+        var li = 0
+        while (li < nSamples) {
+          if (lrv != null)
+            lview.setGenotype(li)
+          if (rrv != null)
+            rview.setGenotype(leftToRight(li))
+          comb(li).merge(
+            if (lrv != null) {
+              if (lview.hasGT)
+                lview.getGT + 2
+              else
+                1
+            } else
+              0,
+            if (rrv != null) {
+              if (rview.hasGT)
+                rview.getGT + 2
+              else
+                1
+            } else
+              0)
+          li += 1
         }
       }
       Iterator(comb)
@@ -150,31 +151,56 @@ object CalculateConcordance {
     }
 
     val variantRDD = join.mapPartitions { it =>
-      val arr = Array.ofDim[Int](nSamples)
       val comb = new ConcordanceCombiner
-      val rightMapping = rightIdMappingBc.value
+      val rightToLeft = leftToRightBc.value
 
-      it.map { case (v, (value1, value2)) =>
+      val lur = new UnsafeRow(leftRowType)
+      val rur = new UnsafeRow(rightRowType)
+      val lview = HardCallView(leftRowType)
+      val rview = HardCallView(rightRowType)
+
+      it.map { jrv =>
         comb.reset()
-        ((value1, value2): @unchecked) match {
-          case (Some((_, leftGS)), Some((_, rightGS))) =>
-            var i = 0
-            rightGS.foreach { g =>
-              arr(rightMapping(i)) = Genotype.unboxedGT(g)
-              i += 1
-            }
-            assert(i == nSamples)
-            i = 0
-            leftGS.foreach { g =>
-              comb.mergeBoth(Genotype.unboxedGT(g), arr(i))
-              i += 1
-            }
-          case (None, Some((_, gs2))) =>
-            gs2.foreach { g =>
-              comb.mergeRight(Genotype.unboxedGT(g))
-            }
-          case (Some((_, gs1)), None) =>
-            gs1.foreach { g => comb.mergeLeft(Genotype.unboxedGT(g)) }
+
+        val lrv = jrv.rvLeft
+        val rrv = jrv.rvRight
+
+        val v =
+          if (lrv != null) {
+            lur.set(lrv)
+            lur.get(1)
+          } else {
+            rur.set(rrv)
+            rur.get(1)
+          }
+
+        if (lrv != null)
+          lview.setRegion(lrv)
+        if (rrv != null)
+          rview.setRegion(rrv)
+
+        var li = 0
+        while (li < nSamples) {
+          if (lrv != null)
+            lview.setGenotype(li)
+          if (rrv != null)
+            rview.setGenotype(leftToRight(li))
+          comb.merge(
+            if (lrv != null) {
+              if (lview.hasGT)
+                lview.getGT + 2
+              else
+                1
+            } else
+              0,
+            if (rrv != null) {
+              if (rview.hasGT)
+                rview.getGT + 2
+              else
+                1
+            } else
+              0)
+          li += 1
         }
         val r = Row(v, comb.nDiscordant, comb.toAnnotation)
         assert(variantSchema.typeCheck(r))

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -112,76 +112,7 @@ class OrderedRVD private(
     }
   }
 
-  def orderedZipJoin(right: OrderedRVD): RDD[JoinedRegionValue] = {
-    val leftTyp = typ
-    val rightTyp = right.typ
-
-    rdd.zipPartitions(right.rdd) { case (lit, rit) =>
-      new Iterator[JoinedRegionValue] {
-        private val lrKOrd = OrderedRVType.selectUnsafeOrdering(leftTyp.rowType, leftTyp.kRowFieldIdx, rightTyp.rowType, rightTyp.kRowFieldIdx)
-
-        val jrv = JoinedRegionValue()
-        var present: Boolean = false
-
-        var lrv: RegionValue = _
-        var rrv: RegionValue = _
-
-        def nextLeft() {
-          if (lrv == null && lit.hasNext)
-            lrv = lit.next()
-        }
-
-        def nextRight() {
-          if (rrv == null && rit.hasNext)
-            rrv = rit.next()
-        }
-
-        def hasNext: Boolean = {
-          if (!present) {
-            nextLeft()
-            nextRight()
-
-            var c = 0
-            if (lrv != null) {
-              if (rrv != null)
-                c = lrKOrd.compare(lrv, rrv)
-              else
-                -1
-            } else if (rrv != null)
-              1
-            else
-              return false
-
-            if (c == 0) {
-              jrv.rvLeft = lrv
-              jrv.rvRight = rrv
-              lrv = null
-              rrv = null
-            } else if (c < 0) {
-              jrv.rvLeft = lrv
-              lrv = null
-              jrv.rvRight = null
-            } else {
-              // c > 0
-              jrv.rvLeft = null
-              jrv.rvRight = rrv
-              rrv = null
-            }
-            present = true
-          }
-
-          present
-        }
-
-        def next(): JoinedRegionValue = {
-          if (!hasNext)
-            throw new NoSuchElementException("next on empty iterator")
-          present = false
-          jrv
-        }
-      }
-    }
-  }
+  def orderedZipJoin(right: OrderedRVD): RDD[JoinedRegionValue] = new OrderedZipJoinRDD(this, right)
 
   def partitionSortedUnion(rdd2: OrderedRVD): OrderedRVD = {
     assert(typ == rdd2.typ)

--- a/src/main/scala/is/hail/sparkextras/OrderedRDD2.scala
+++ b/src/main/scala/is/hail/sparkextras/OrderedRDD2.scala
@@ -1,10 +1,11 @@
 package is.hail.sparkextras
 
 import is.hail.annotations._
-import is.hail.rvd.{OrderedRVD, OrderedRVPartitioner}
+import is.hail.rvd.{OrderedRVD, OrderedRVPartitioner, OrderedRVType}
 import is.hail.utils._
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
 
 class OrderedDependency2(left: OrderedRVD, right: OrderedRVD) extends NarrowDependency[RegionValue](right.rdd) {
   override def getParents(partitionId: Int): Seq[Int] =
@@ -60,5 +61,114 @@ class OrderedJoinDistinctRDD2(left: OrderedRVD, right: OrderedRVD, joinType: Str
       case "left" => new OrderedLeftJoinDistinctIterator(left.typ, right.typ, leftIt, rightIt)
       case _ => fatal(s"Unknown join type `$joinType'. Choose from `inner' or `left'.")
     }
+  }
+}
+
+class OrderedZipJoinIterator(
+  leftTyp: OrderedRVType, rightTyp: OrderedRVType,
+  lit: Iterator[RegionValue], rit: Iterator[RegionValue])
+  extends Iterator[JoinedRegionValue] {
+
+  private val lrKOrd = OrderedRVType.selectUnsafeOrdering(leftTyp.rowType, leftTyp.kRowFieldIdx, rightTyp.rowType, rightTyp.kRowFieldIdx)
+
+  val jrv = JoinedRegionValue()
+  var present: Boolean = false
+
+  var lrv: RegionValue = _
+  var rrv: RegionValue = _
+
+  def nextLeft() {
+    if (lrv == null && lit.hasNext)
+      lrv = lit.next()
+  }
+
+  def nextRight() {
+    if (rrv == null && rit.hasNext)
+      rrv = rit.next()
+  }
+
+  def hasNext: Boolean = {
+    if (!present) {
+      nextLeft()
+      nextRight()
+
+      var c = 0
+      if (lrv != null) {
+        if (rrv != null)
+          c = lrKOrd.compare(lrv, rrv)
+        else
+          -1
+      } else if (rrv != null)
+        1
+      else {
+        assert(!lit.hasNext && !rit.hasNext)
+        return false
+      }
+
+      if (c == 0) {
+        jrv.rvLeft = lrv
+        jrv.rvRight = rrv
+        lrv = null
+        rrv = null
+      } else if (c < 0) {
+        jrv.rvLeft = lrv
+        lrv = null
+        jrv.rvRight = null
+      } else {
+        // c > 0
+        jrv.rvLeft = null
+        jrv.rvRight = rrv
+        rrv = null
+      }
+      present = true
+    }
+
+    present
+  }
+
+  def next(): JoinedRegionValue = {
+    if (!hasNext)
+      throw new NoSuchElementException("next on empty iterator")
+    present = false
+    jrv
+  }
+}
+
+case class OrderedZipJoinRDDPartition(index: Int, leftPartition: Partition, rightPartitions: Array[Partition]) extends Partition
+
+class OrderedZipJoinRDD(left: OrderedRVD, right: OrderedRVD)
+  extends RDD[JoinedRegionValue](left.sparkContext,
+    Seq[Dependency[_]](new OneToOneDependency(left.rdd),
+      new OrderedDependency2(left, right))) {
+  private val leftPartitionForRightRow = new OrderedRVPartitioner(
+    left.partitioner.numPartitions,
+    right.typ.partitionKey,
+    right.typ.rowType,
+    left.partitioner.rangeBounds)
+
+  override val partitioner: Option[Partitioner] = Some(left.partitioner)
+
+  def getPartitions: Array[Partition] = {
+    Array.tabulate[Partition](left.getNumPartitions)(i =>
+      OrderedZipJoinRDDPartition(i,
+        left.partitions(i),
+        OrderedDependency2.getDependencies(left.partitioner, right.partitioner)(i)
+          .map(right.partitions)
+          .toArray))
+  }
+
+  override def getPreferredLocations(split: Partition): Seq[String] = left.rdd.preferredLocations(split)
+
+  override def compute(split: Partition, context: TaskContext): Iterator[JoinedRegionValue] = {
+    val partition = split.asInstanceOf[OrderedZipJoinRDDPartition]
+    val index = partition.index
+
+    val leftIt = left.rdd.iterator(partition.leftPartition, context)
+    val rightIt = partition.rightPartitions.iterator.flatMap { p =>
+      right.rdd.iterator(p, context)
+    }
+      .filter { rrv =>leftPartitionForRightRow.getPartition(rrv) == index }
+
+    new OrderedZipJoinIterator(left.typ, right.typ, leftIt, rightIt)
   }
 }

--- a/src/main/scala/is/hail/sparkextras/OrderedRDD2.scala
+++ b/src/main/scala/is/hail/sparkextras/OrderedRDD2.scala
@@ -92,17 +92,18 @@ class OrderedZipJoinIterator(
       nextLeft()
       nextRight()
 
-      var c = 0
-      if (lrv != null) {
-        if (rrv != null)
-          c = lrKOrd.compare(lrv, rrv)
-        else
-          -1
-      } else if (rrv != null)
-        1
-      else {
-        assert(!lit.hasNext && !rit.hasNext)
-        return false
+      val c = {
+        if (lrv != null) {
+          if (rrv != null)
+            lrKOrd.compare(lrv, rrv)
+          else
+            -1
+        } else if (rrv != null)
+          1
+        else {
+          assert(!lit.hasNext && !rit.hasNext)
+          return false
+        }
       }
 
       if (c == 0) {
@@ -167,7 +168,7 @@ class OrderedZipJoinRDD(left: OrderedRVD, right: OrderedRVD)
     val rightIt = partition.rightPartitions.iterator.flatMap { p =>
       right.rdd.iterator(p, context)
     }
-      .filter { rrv =>leftPartitionForRightRow.getPartition(rrv) == index }
+      .filter { rrv => leftPartitionForRightRow.getPartition(rrv) == index }
 
     new OrderedZipJoinIterator(left.typ, right.typ, leftIt, rightIt)
   }

--- a/src/test/scala/is/hail/SparkSuite.scala
+++ b/src/test/scala/is/hail/SparkSuite.scala
@@ -9,7 +9,7 @@ import org.scalatest.testng.TestNGSuite
 object SparkSuite {
   lazy val hc = HailContext(master = Option(System.getProperty("hail.master")),
     appName = "Hail.TestNG",
-    local = "local[2]",
+    local = "local[1]",
     minBlockSize = 0)
 }
 

--- a/src/test/scala/is/hail/SparkSuite.scala
+++ b/src/test/scala/is/hail/SparkSuite.scala
@@ -9,7 +9,7 @@ import org.scalatest.testng.TestNGSuite
 object SparkSuite {
   lazy val hc = HailContext(master = Option(System.getProperty("hail.master")),
     appName = "Hail.TestNG",
-    local = "local[1]",
+    local = "local[2]",
     minBlockSize = 0)
 }
 

--- a/src/test/scala/is/hail/methods/ConcordanceSuite.scala
+++ b/src/test/scala/is/hail/methods/ConcordanceSuite.scala
@@ -67,12 +67,12 @@ class ConcordanceSuite extends SparkSuite {
   @Test def testCombiner() {
     val comb = new ConcordanceCombiner
 
-    comb.mergeBoth(-1, 1)
-    comb.mergeBoth(-1, 1)
-    comb.mergeBoth(-1, 1)
-    comb.mergeBoth(-1, 1)
-    comb.mergeRight(2)
-    comb.mergeLeft(0)
+    comb.merge(1, 3)
+    comb.merge(1, 3)
+    comb.merge(1, 3)
+    comb.merge(1, 3)
+    comb.merge(0, 4)
+    comb.merge(2, 0)
 
     assert(comb.toAnnotation == IndexedSeq(
       IndexedSeq(0L, 0L, 0L, 0L, 1L),
@@ -84,23 +84,23 @@ class ConcordanceSuite extends SparkSuite {
 
     val comb2 = new ConcordanceCombiner
 
-    comb2.mergeLeft(2)
-    comb2.mergeLeft(2)
-    comb2.mergeLeft(-1)
-    comb2.mergeLeft(-1)
-    comb2.mergeLeft(2)
-    comb2.mergeRight(0)
-    comb2.mergeRight(1)
-    comb2.mergeRight(1)
-    comb2.mergeBoth(1, 1)
-    comb2.mergeBoth(1, 1)
-    comb2.mergeBoth(-1, 1)
-    comb2.mergeBoth(-1, 1)
-    comb2.mergeBoth(1, -1)
-    comb2.mergeBoth(1, -1)
-    comb2.mergeBoth(2, -1)
-    comb2.mergeBoth(2, -1)
-    comb2.mergeBoth(2, -1)
+    comb2.merge(4, 0)
+    comb2.merge(4, 0)
+    comb2.merge(1, 0)
+    comb2.merge(1, 0)
+    comb2.merge(4, 0)
+    comb2.merge(0, 2)
+    comb2.merge(0, 3)
+    comb2.merge(0, 3)
+    comb2.merge(3, 3)
+    comb2.merge(3, 3)
+    comb2.merge(1, 3)
+    comb2.merge(1, 3)
+    comb2.merge(3, 1)
+    comb2.merge(3, 1)
+    comb2.merge(4, 1)
+    comb2.merge(4, 1)
+    comb2.merge(4, 1)
 
     assert(comb2.toAnnotation == IndexedSeq(
       IndexedSeq(0L, 0L, 1L, 2L, 0L),
@@ -126,13 +126,13 @@ class ConcordanceSuite extends SparkSuite {
       var n = 0
       values.foreach { case (i, j) =>
         if (i == -2)
-          comb.mergeRight(j)
+          comb.merge(0, j + 2)
         else if (j == -2)
-          comb.mergeLeft(i)
+          comb.merge(i + 2, 0)
         else {
           if (i >= 0 && j >= 0 && i != j)
             n += 1
-          comb.mergeBoth(i, j)
+          comb.merge(i + 2, j + 2)
         }
       }
       n == comb.nDiscordant
@@ -158,7 +158,7 @@ class ConcordanceSuite extends SparkSuite {
 
       val innerJoinSamples = innerJoin.map { case (k, v) => (k._2, v) }
         .aggregateByKey(new ConcordanceCombiner)({ case (comb, (g1, g2)) =>
-          comb.mergeBoth(Genotype.unboxedGT(g1), Genotype.unboxedGT(g2))
+          comb.merge(Genotype.unboxedGT(g1) + 2, Genotype.unboxedGT(g2) + 2)
           comb
         }, { case (comb1, comb2) => comb1.merge(comb2) })
         .map { case (s, comb) => (s, comb.toAnnotation.tail.map(_.tail)) }
@@ -166,7 +166,7 @@ class ConcordanceSuite extends SparkSuite {
 
       val innerJoinVariants = innerJoin.map { case (k, v) => (k._1, v) }
         .aggregateByKey(new ConcordanceCombiner)({ case (comb, (g1, g2)) =>
-          comb.mergeBoth(Genotype.unboxedGT(g1), Genotype.unboxedGT(g2))
+          comb.merge(Genotype.unboxedGT(g1) + 2, Genotype.unboxedGT(g2) + 2)
           comb
         }, { case (comb1, comb2) => comb1.merge(comb2) })
         .collectAsMap


### PR DESCRIPTION
I changed the semantics slightly.  Instead of using outerJoinDistinct,
since it really seems like the left and right sides should be treated
symmetrically, I used an "OrderedZipJoin".  This is like a sort and then
zip, except (1) only the same rows with the same key are zipped
together, and (2) if there are different number of rows with a given
key on the left and right, the side with the fewer rows is padding
with null rows.
