### PR TITLE
Allow Firth to bypass non-converged MLE

### DIFF
--- a/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -49,7 +49,7 @@ object LogisticRegression {
         nullFit = LogisticRegressionFit(nullModel.bInterceptOnly(),
           None, None, 0, nullFit.nIter, exploded = nullFit.exploded, converged = false)
       else
-        fatal("Failed to fit logistic regression null model (MLE with covariates only): " + (
+        fatal("Failed to fit logistic regression null model (standard MLE with covariates only): " + (
           if (nullFit.exploded)
             s"exploded at Newton iteration ${ nullFit.nIter }"
           else

--- a/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -42,14 +42,18 @@ object LogisticRegression {
     info(s"Running $test logistic regression on $n samples with $k ${ plural(k, "covariate") } including intercept...")
 
     val nullModel = new LogisticRegressionModel(cov, y)
-    val nullFit = nullModel.fit()
+    var nullFit = nullModel.fit()
 
     if (!nullFit.converged)
-      fatal("Failed to fit logistic regression null model (MLE with covariates only): " + (
-        if (nullFit.exploded)
-          s"exploded at Newton iteration ${ nullFit.nIter }"
-        else
-          "Newton iteration failed to converge"))
+      if (logRegTest == FirthTest)
+        nullFit = LogisticRegressionFit(nullModel.bInterceptOnly(),
+          None, None, 0, nullFit.nIter, exploded = nullFit.exploded, converged = false)
+      else
+        fatal("Failed to fit logistic regression null model (MLE with covariates only): " + (
+          if (nullFit.exploded)
+            s"exploded at Newton iteration ${ nullFit.nIter }"
+          else
+            "Newton iteration failed to converge"))
 
     val sc = vds.sparkContext
     val sampleMaskBc = sc.broadcast(sampleMask)

--- a/src/test/scala/is/hail/methods/LogisticRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LogisticRegressionSuite.scala
@@ -340,7 +340,7 @@ class LogisticRegressionSuite extends SparkSuite {
     assert(qChi2(a(v10)) == null)
   }
 
-  @Test def waldEpactsTest() {
+  @Test def epactsTest() {
 
     val covariates = hc.importTable("src/test/resources/regressionLogisticEpacts.cov",
       types = Map("PC1" -> TDouble, "PC2" -> TDouble), missing = "0").keyBy("IND_ID")
@@ -375,7 +375,7 @@ class LogisticRegressionSuite extends SparkSuite {
 
     val a = vds.variantsAndAnnotations.collect().toMap
 
-    // Comparing to output of b.wald, b.lrt, and b.score in EPACTS
+    // Comparing to output of b.wald, b.lrt, b.firth, and b.score in EPACTS
     // for five 1KG project variants with no missing genotypes
     // http://genome.sph.umich.edu/wiki/EPACTS#Single_Variant_Tests
 

--- a/src/test/scala/is/hail/stats/LogisticRegressionModelSuite.scala
+++ b/src/test/scala/is/hail/stats/LogisticRegressionModelSuite.scala
@@ -239,4 +239,17 @@ class LogisticRegressionModelSuite extends SparkSuite {
     assert(D_==(firthFit.logLkhd, firthLogLkhdR, tol))
     assert(D_==(firthStats.p, firthPValR, tol))
   }
+  
+  @Test def firthSeparationTest() {
+    val y = DenseVector(0d, 0d, 0d, 1d, 1d, 1d)
+    val X = y.asDenseMatrix.t
+
+    val nullModel = new LogisticRegressionModel(X, y) // separation => MLE does not exist
+    var nullFit = nullModel.fit()
+    assert(!nullFit.converged)
+        
+    nullFit = LogisticRegressionFit(nullModel.bInterceptOnly(),
+          None, None, 0, nullFit.nIter, exploded = nullFit.exploded, converged = false)
+    assert(FirthTest.test(X, y, nullFit).stats.isDefined) // firth penalized MLE still exists
+  }
 }


### PR DESCRIPTION
This addresses a user issue whereby adding an indicator covariate that only varied in controls caused Firth to fail. Currently the standard logistic MLE is computed even for Firth regression so this beta can be used to initialize the Firth per-variant models. But if the data has a (quasi-)separated coordinate, the standard MLE may not converge, throwing an error before the Firth models are fit. With the changes in this PR, if the MLE does not converge, Firth falls back to initializing with the intercept-only estimate.