### PR TITLE
Parallel option for export PLINK

### DIFF
--- a/python/hail/dataset.py
+++ b/python/hail/dataset.py
@@ -1413,8 +1413,9 @@ class VariantDataset(object):
     @handle_py4j
     @requireTGenotype
     @typecheck_method(output=strlike,
-                      fam_expr=strlike)
-    def export_plink(self, output, fam_expr='id = s'):
+                      fam_expr=strlike,
+                      parallel=bool)
+    def export_plink(self, output, fam_expr='id = s', parallel=False):
         """Export variant dataset as `PLINK2 <https://www.cog-genomics.org/plink2/formats>`__ BED, BIM and FAM.
 
         .. include:: requireTGenotype.rst
@@ -1470,9 +1471,11 @@ class VariantDataset(object):
         :param str output: Output file base.  Will write BED, BIM, and FAM files.
 
         :param str fam_expr: Expression for FAM file fields.
+
+        :param bool parallel: If true, return a set of BED and BIM files (one per partition) rather than serially concatenating these files.
         """
 
-        self._jvdf.exportPlink(output, fam_expr)
+        self._jvdf.exportPlink(output, fam_expr, parallel)
 
     @handle_py4j
     @typecheck_method(output=strlike,

--- a/src/main/scala/is/hail/io/hadoop/BytesOnlyWritable.scala
+++ b/src/main/scala/is/hail/io/hadoop/BytesOnlyWritable.scala
@@ -1,15 +1,23 @@
 package is.hail.io.hadoop
 
-import java.io.DataOutput
+import java.io.{DataOutput, DataInput}
 
-import org.apache.hadoop.io.BytesWritable
+import org.apache.hadoop.io.Writable
 
-class BytesOnlyWritable(var bytes: Array[Byte])
-  extends BytesWritable(bytes, bytes.length) {
+class BytesOnlyWritable(var bytes: Array[Byte]) extends Writable {
 
-  def this() = this(Array.empty[Byte])
+  def this() = this(null)
+
+  def set(bytes: Array[Byte]) {
+    this.bytes = bytes
+  }
 
   override def write(out: DataOutput) {
-    out.write(super.getBytes, 0, super.getLength)
+    assert(bytes != null)
+    out.write(bytes, 0, bytes.length)
+  }
+
+  override def readFields(in: DataInput) {
+    throw new UnsupportedOperationException()
   }
 }

--- a/src/main/scala/is/hail/utils/ExportType.scala
+++ b/src/main/scala/is/hail/utils/ExportType.scala
@@ -1,0 +1,16 @@
+package is.hail.utils
+
+object ExportType {
+  val CONCATENATED = 0
+  val PARALLEL_SEPARATE_HEADER = 1
+  val PARALLEL_HEADER_IN_SHARD = 2
+
+  def getExportType(typ: String): Int = {
+    typ match {
+      case null => CONCATENATED
+      case "separate_header" => PARALLEL_SEPARATE_HEADER
+      case "header_per_shard" => PARALLEL_HEADER_IN_SHARD
+      case _ => fatal(s"Unknown export type: `$typ'")
+    }
+  }
+}

--- a/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
@@ -154,7 +154,7 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
     }
   }
 
-  private def copyMergeList(srcFileStatuses: Array[FileStatus], destFilename: String, deleteSource: Boolean = true) {
+  def copyMergeList(srcFileStatuses: Array[FileStatus], destFilename: String, deleteSource: Boolean = true) {
     val destPath = new hadoop.fs.Path(destFilename)
     val destFS = fileSystem(destFilename)
 
@@ -208,6 +208,18 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
         assert(s.endsWith(ext))
         s.dropRight(ext.length)
       }.getOrElse(s)
+  }
+
+  def getCodec(s: String): String = {
+    val path = new org.apache.hadoop.fs.Path(s)
+
+    Option(new CompressionCodecFactory(hConf)
+      .getCodec(path))
+      .map { codec =>
+        val ext = codec.getDefaultExtension
+        assert(s.endsWith(ext))
+        s.takeRight(ext.length)
+      }.getOrElse("")
   }
 
   def writeObjectFile[T](filename: String)(f: (ObjectOutputStream) => T): T = {

--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -29,6 +29,16 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
   }.fold(false)(_ || _)
 
   def writeTable(filename: String, tmpDir: String, header: Option[String] = None, parallelWrite: Boolean = false) {
+    val exportType =
+      if (parallelWrite)
+        ExportType.PARALLEL_HEADER_IN_SHARD
+      else
+        ExportType.CONCATENATED
+
+    writeTable(filename, tmpDir, header, exportType)
+  }
+
+  def writeTable(filename: String, tmpDir: String, header: Option[String], exportType: Int) {
     val hConf = r.sparkContext.hadoopConfiguration
 
     val codecFactory = new CompressionCodecFactory(hConf)
@@ -37,23 +47,30 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
     hConf.delete(filename, recursive = true) // overwriting by default
 
     val parallelOutputPath =
-      if (parallelWrite) {
-        filename
-      } else
+      if (exportType == ExportType.CONCATENATED)
         hConf.getTemporaryFile(tmpDir)
+      else
+        filename
 
     val rWithHeader = header.map { h =>
-      if (r.partitions.length == 0)
+      if (r.getNumPartitions == 0 && exportType != ExportType.PARALLEL_SEPARATE_HEADER)
         r.sparkContext.parallelize(List(h), numSlices = 1)
-      else if (parallelWrite)
-        r.mapPartitions { it => Iterator(h) ++ it }
-      else
-        r.mapPartitionsWithIndex { case (i, it) =>
-          if (i == 0)
-            Iterator(h) ++ it
-          else
-            it
+      else {
+        exportType match {
+          case ExportType.CONCATENATED =>
+            r.mapPartitionsWithIndex { case (i, it) =>
+              if (i == 0)
+                Iterator(h) ++ it
+              else
+                it
+            }
+          case ExportType.PARALLEL_SEPARATE_HEADER =>
+            r
+          case ExportType.PARALLEL_HEADER_IN_SHARD =>
+            r.mapPartitions { it => Iterator(h) ++ it }
+          case _ => fatal(s"Unknown export type: $exportType")
         }
+      }
     }.getOrElse(r)
 
     codec match {
@@ -61,10 +78,20 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
       case None => rWithHeader.saveAsTextFile(parallelOutputPath)
     }
 
+    if (exportType == ExportType.PARALLEL_SEPARATE_HEADER) {
+      val headerExt = hConf.getCodec(filename)
+      hConf.writeTextFile(parallelOutputPath + "/header" + headerExt) { out =>
+        header.foreach { h =>
+          out.write(h)
+          out.write('\n')
+        }
+      }
+    }
+
     if (!hConf.exists(parallelOutputPath + "/_SUCCESS"))
       fatal("write failed: no success indicator found")
 
-    if (!parallelWrite) {
+    if (exportType == ExportType.CONCATENATED) {
       hConf.copyMerge(parallelOutputPath, filename, hasHeader = false)
     }
   }

--- a/src/main/scala/is/hail/variant/VariantDataset.scala
+++ b/src/main/scala/is/hail/variant/VariantDataset.scala
@@ -320,7 +320,7 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
     vds.exportGenotypes(path, expr, typeFile, filterF, parallel)
   }
 
-  def exportPlink(path: String, famExpr: String = "id = s") {
+  def exportPlink(path: String, famExpr: String = "id = s", parallel: Boolean = false) {
     requireSplit("export plink")
     vds.requireSampleTString("export plink")
 
@@ -392,10 +392,10 @@ class VariantDatasetFunctions(private val vds: VariantSampleMatrix[Genotype]) ex
       .persist(StorageLevel.MEMORY_AND_DISK)
 
     plinkRDD.map { case (v, bed) => bed }
-      .saveFromByteArrays(path + ".bed", vds.hc.tmpDir, header = Some(bedHeader))
+      .saveFromByteArrays(path + ".bed", vds.hc.tmpDir, header = Some(bedHeader), parallelWrite = parallel)
 
     plinkRDD.map { case (v, bed) => ExportBedBimFam.makeBimRow(v) }
-      .writeTable(path + ".bim", vds.hc.tmpDir)
+      .writeTable(path + ".bim", vds.hc.tmpDir, parallelWrite = parallel)
 
     plinkRDD.unpersist()
 

--- a/src/test/scala/is/hail/utils/RichRDDSuite.scala
+++ b/src/test/scala/is/hail/utils/RichRDDSuite.scala
@@ -1,0 +1,76 @@
+package is.hail.utils
+
+import is.hail.SparkSuite
+import org.testng.annotations.Test
+
+class RichRDDSuite extends SparkSuite {
+  @Test def binaryParallelWrite() {
+    def readBytes(file: String): Array[Byte] = hadoopConf.readFile(file) { dis =>
+      val buffer = new Array[Byte](32)
+      val size = dis.read(buffer)
+      buffer.take(size)
+    }
+
+    val header = Array[Byte](108, 27, 1, 91)
+    val data = Array(Array[Byte](1, 19, 23, 127, -1), Array[Byte](23, 4, 15, -2, 1))
+    val r = sc.parallelize(data, numSlices = 2)
+    assert(r.getNumPartitions == 2)
+
+    val notParallelWrite = tmpDir.createTempFile("notParallelWrite")
+    r.saveFromByteArrays(notParallelWrite, tmpDir.createTempFile("notParallelWrite_tmp"), Some(header),
+      deleteTmpFiles = true, exportType = ExportType.CONCATENATED)
+
+    assert(readBytes(notParallelWrite) sameElements (header ++: data.flatten))
+
+    val parallelWrite = tmpDir.createTempFile("parallelWrite")
+    r.saveFromByteArrays(parallelWrite, tmpDir.createTempFile("parallelWrite_tmp"), Some(header),
+      deleteTmpFiles = true, exportType = ExportType.PARALLEL_HEADER_IN_SHARD)
+
+    assert(readBytes(parallelWrite + "/part-00000") sameElements header ++ data(0))
+    assert(readBytes(parallelWrite + "/part-00001") sameElements header ++ data(1))
+
+    val parallelWriteHeader = tmpDir.createTempFile("parallelWriteHeader")
+    r.saveFromByteArrays(parallelWriteHeader, tmpDir.createTempFile("parallelHeaderWrite_tmp"), Some(header),
+      deleteTmpFiles = true, exportType = ExportType.PARALLEL_SEPARATE_HEADER)
+
+    assert(readBytes(parallelWriteHeader + "/header") sameElements header)
+    assert(readBytes(parallelWriteHeader + "/part-00000") sameElements data(0))
+    assert(readBytes(parallelWriteHeader + "/part-00001") sameElements data(1))
+  }
+
+  @Test def parallelWrite() {
+    def read(file: String): Array[String] = hc.hadoopConf.readLines(file)(_.map(_.value).toArray)
+
+    val header = "my header is awesome!"
+    val data = Array("the cat jumped over the moon.", "all creatures great and small")
+    val r = sc.parallelize(data, numSlices = 2)
+    assert(r.getNumPartitions == 2)
+
+    val concatenated = tmpDir.createTempFile("concatenated")
+    r.writeTable(concatenated, tmpDir.createTempFile("concatenated"), Some(header), exportType = ExportType.CONCATENATED)
+
+    assert(read(concatenated) sameElements (header +: data))
+
+    val shardHeaders = tmpDir.createTempFile("shardHeader")
+    r.writeTable(shardHeaders, tmpDir.createTempFile("shardHeader"), Some(header), exportType = ExportType.PARALLEL_HEADER_IN_SHARD)
+
+    assert(read(shardHeaders + "/part-00000") sameElements header +: Array(data(0)))
+    assert(read(shardHeaders + "/part-00001") sameElements header +: Array(data(1)))
+
+    val separateHeader = tmpDir.createTempFile("separateHeader", ".gz")
+    r.writeTable(separateHeader, tmpDir.createTempFile("separateHeader"), Some(header), exportType = ExportType.PARALLEL_SEPARATE_HEADER)
+
+    assert(read(separateHeader + "/header.gz") sameElements Array(header))
+    assert(read(separateHeader + "/part-00000.gz") sameElements Array(data(0)))
+    assert(read(separateHeader + "/part-00001.gz") sameElements Array(data(1)))
+
+
+    val merged = tmpDir.createTempFile("merged", ".gz")
+    val mergeList = Array(separateHeader + "/header.gz",
+      separateHeader + "/part-00000.gz",
+      separateHeader + "/part-00001.gz").flatMap(hadoopConf.glob)
+    hadoopConf.copyMergeList(mergeList, merged, deleteSource = false)
+
+    assert(read(merged) sameElements read(concatenated))
+  }
+}


### PR DESCRIPTION
- I ported over the parallel write changes from 0.2 to 0.1. However, I left the interface of parallel being a Boolean where False = concatenate and True = parallel with a header per shard.
- This is a combination of previous PRs: #2265, #2263, #2354, #2587, #2630 
- Addresses #2245 for @maryhaas