### PR TITLE
Hail2 rrm

### DIFF
--- a/python/hail/api1/dataset.py
+++ b/python/hail/api1/dataset.py
@@ -2390,7 +2390,7 @@ g = let newgt = gtIndex(oldToNew[gtj(g.GT)], oldToNew[gtk(g.GT)]) and
 
         f = new_temp_file(suffix="bm")
 
-        vds._jvds.writeBlockMatrix(f, normalized_genotype_expr, BlockMatrix.default_block_size())
+        vds._jvds.writeBlockMatrix(f, normalized_genotype_expr)
         vds.unpersist()
 
         bm = BlockMatrix.read(f)
@@ -4469,7 +4469,7 @@ g = let newgt = gtIndex(oldToNew[gtj(g.GT)], oldToNew[gtk(g.GT)]) and
 
         f = new_temp_file(suffix="bm")
 
-        vds._jvds.writeBlockMatrix(f, normalized_genotype_expr, BlockMatrix.default_block_size())
+        vds._jvds.writeBlockMatrix(f, normalized_genotype_expr)
         vds.unpersist()
 
         bm = BlockMatrix.read(f)

--- a/python/hail/api1/dataset.py
+++ b/python/hail/api1/dataset.py
@@ -2390,7 +2390,7 @@ g = let newgt = gtIndex(oldToNew[gtj(g.GT)], oldToNew[gtk(g.GT)]) and
 
         f = new_temp_file(suffix="bm")
 
-        vds._jvds.writeBlockMatrix(f, normalized_genotype_expr)
+        vds._jvds.writeBlockMatrix(f, normalized_genotype_expr, BlockMatrix.default_block_size())
         vds.unpersist()
 
         bm = BlockMatrix.read(f)
@@ -4469,7 +4469,7 @@ g = let newgt = gtIndex(oldToNew[gtj(g.GT)], oldToNew[gtk(g.GT)]) and
 
         f = new_temp_file(suffix="bm")
 
-        vds._jvds.writeBlockMatrix(f, normalized_genotype_expr)
+        vds._jvds.writeBlockMatrix(f, normalized_genotype_expr, BlockMatrix.default_block_size())
         vds.unpersist()
 
         bm = BlockMatrix.read(f)

--- a/python/hail/docs/methods/index.rst
+++ b/python/hail/docs/methods/index.rst
@@ -13,6 +13,7 @@ Methods
     hail.methods.ld_matrix
     hail.methods.trio_matrix
     hail.methods.grm
+    hail.methods.rrm
     hail.methods.ibd
     hail.methods.pca
     hail.methods.hwe_normalized_pca
@@ -39,6 +40,7 @@ Methods
 .. autofunction:: hail.methods.ld_matrix
 .. autofunction:: hail.methods.trio_matrix
 .. autofunction:: hail.methods.grm
+.. autofunction:: hail.methods.rrm
 .. autofunction:: hail.methods.ibd
 .. autofunction:: hail.methods.pca
 .. autofunction:: hail.methods.hwe_normalized_pca

--- a/python/hail/linalg/matrix.py
+++ b/python/hail/linalg/matrix.py
@@ -1,5 +1,5 @@
 from hail.utils import new_temp_file, storage_level
-from hail.utils.java import Env, handle_py4j, scala_object, jarray
+from hail.utils.java import Env, handle_py4j, scala_object, jarray, numpy_from_breeze
 from hail.typecheck import *
 from hail.api2 import MatrixTable
 from hail.expr.expression import expr_numeric, to_expr, analyze
@@ -112,10 +112,7 @@ class BlockMatrix(object):
 
     @handle_py4j
     def to_numpy_matrix(self):
-        b = Env.jutils().doubleBDMToBytes(self._jbm.toLocalMatrix())
-        rows, cols = unpack('II', b[:8])
-        data = np.fromstring(bytes(b[8:]), dtype='f8')
-        return np.reshape(data, (cols, rows)).T
+        return numpy_from_breeze(self._jbm.toLocalMatrix())
 
     @handle_py4j
     @typecheck_method(i=numeric)

--- a/python/hail/linalg/matrix.py
+++ b/python/hail/linalg/matrix.py
@@ -114,8 +114,8 @@ class BlockMatrix(object):
     def to_local_matrix(self):
         b = Env.jutils().doubleBDMToBytes(self._jbm.toLocalMatrix())
         rows, cols = unpack('<II', b[:8])
-        data = [[unpack('<d', b[24+8*(i*cols+j):32+8*(i*cols+j)])[0] for j in range(cols)] for i in range(rows)]
-        return np.array(data)
+        data = np.fromstring(bytes(b[24:]), dtype='<f8')
+        return np.reshape(data, (rows, cols))
 
     @handle_py4j
     @typecheck_method(i=numeric)
@@ -128,4 +128,3 @@ class BlockMatrix(object):
         return self * (1./i)
 
 block_matrix_type.set(BlockMatrix)
-

--- a/python/hail/linalg/matrix.py
+++ b/python/hail/linalg/matrix.py
@@ -111,11 +111,11 @@ class BlockMatrix(object):
         return BlockMatrix(self._jbm.unpersist())
 
     @handle_py4j
-    def to_local_matrix(self):
+    def to_numpy_matrix(self):
         b = Env.jutils().doubleBDMToBytes(self._jbm.toLocalMatrix())
-        rows, cols = unpack('<II', b[:8])
-        data = np.fromstring(bytes(b[24:]), dtype='<f8')
-        return np.reshape(data, (rows, cols))
+        rows, cols = unpack('II', b[:8])
+        data = np.fromstring(bytes(b[8:]), dtype='f8')
+        return np.reshape(data, (cols, rows)).T
 
     @handle_py4j
     @typecheck_method(i=numeric)

--- a/python/hail/methods/__init__.py
+++ b/python/hail/methods/__init__.py
@@ -1,6 +1,6 @@
 from .family_methods import trio_matrix, mendel_errors
 from .io import export_cassandra, export_gen, export_plink, export_solr, export_vcf, import_interval_list, import_bed, import_fam
-from .statgen import linreg, sample_rows, ibd, ld_matrix, grm, pca, hwe_normalized_pca, pc_relate, split_multi_hts
+from .statgen import linreg, sample_rows, ibd, ld_matrix, grm, rrm, pca, hwe_normalized_pca, pc_relate, split_multi_hts
 from .qc import sample_qc, variant_qc, vep, concordance, nirvana
 from .misc import rename_duplicates
 
@@ -12,6 +12,7 @@ __all__ = ['trio_matrix',
            'sample_qc',
            'variant_qc',
            'grm',
+           'rrm',
            'pca',
            'hwe_normalized_pca',
            'pc_relate',

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -9,6 +9,7 @@ from hail.utils.java import handle_py4j, joption
 from .misc import require_biallelic
 from hail.expr import functions
 import hail.expr.aggregators as agg
+from math import sqrt
 
 
 @handle_py4j
@@ -998,3 +999,106 @@ def grm(dataset):
                                       grm,
                                       [row.s for row in dataset.cols_table().select('s').collect()],
                                       n_variants)
+
+@handle_py4j
+@typecheck(call_expr=CallExpression)
+def rrm(call_expr):
+    """Computes the Realized Relationship Matrix (RRM).
+
+    .. include:: ../_templates/req_tvariant.rst
+
+    .. include:: ../_templates/req_biallelic.rst
+
+    Examples
+    --------
+
+    >>> kinship_matrix = methods.rrm(dataset['GT'])
+
+    Notes
+    -----
+
+    The Realized Relationship Matrix is defined as follows. Consider the
+    :math:`n \\times m` matrix :math:`C` of raw genotypes, with rows indexed by
+    :math:`n` samples and columns indexed by the :math:`m` bialellic autosomal
+    variants; :math:`C_{ij}` is the number of alternate alleles of variant
+    :math:`j` carried by sample :math:`i`, which can be 0, 1, 2, or missing. For
+    each variant :math:`j`, the sample alternate allele frequency :math:`p_j` is
+    computed as half the mean of the non-missing entries of column :math:`j`.
+    Entries of :math:`M` are then mean-centered and variance-normalized as
+
+    .. math::
+
+        M_{ij} =
+          \\frac{C_{ij}-2p_j}
+                {\sqrt{\\frac{m}{n} \\sum_{k=1}^n (C_{ij}-2p_j)^2}},
+
+    with :math:`M_{ij} = 0` for :math:`C_{ij}` missing (i.e. mean genotype
+    imputation). This scaling normalizes each variant column to have empirical
+    variance :math:`1/m`, which gives each sample row approximately unit total
+    variance (assuming linkage equilibrium) and yields the :math:`n \\times n`
+    sample correlation or realized relationship matrix (RRM) :math:`K` as simply
+
+    .. math::
+
+        K = MM^T
+
+    Note that the only difference between the Realized Relationship Matrix and
+    the Genetic Relationship Matrix (GRM) used in :func:`.methods.grm` is the
+    variant (column) normalization: where RRM uses empirical variance, GRM uses
+    expected variance under Hardy-Weinberg Equilibrium.
+
+
+    Parameters
+    ----------
+    call_expr : :class:`.CallExpression`
+        Expression on a :class:`.MatrixTable` that gives the genotype call.
+
+    Returns
+        :return: Realized Relationship Matrix for all samples.
+        :rtype: :class:`.KinshipMatrix`
+        """
+    source = call_expr._indices.source
+    if not isinstance(source, MatrixTable):
+        raise ValueError("Expect an expression of 'MatrixTable', found {}".format(
+            "expression of '{}'".format(source.__class__) if source is not None else 'scalar expression'))
+    dataset = source
+    base, _ = dataset._process_joins(call_expr)
+    analyze('rrm', call_expr, dataset._entry_indices)
+
+    dataset = require_biallelic(dataset, 'rrm')
+
+    call_expr._indices = dataset._entry_indices
+    gt_expr = call_expr.num_alt_alleles()
+    dataset = dataset.annotate_rows(AC=agg.sum(gt_expr),
+                                    ACsq=agg.sum(gt_expr * gt_expr),
+                                    n_called=agg.count_where(functions.is_defined(call_expr)))
+    dataset = dataset.filter_rows((dataset.AC > 0) &
+                                  (dataset.AC < 2 * dataset.n_called) &
+                                  ((dataset.AC != dataset.n_called) |
+                                   (dataset.ACsq != dataset.n_called)))
+
+    n_samples = dataset.count_cols()
+    n_variants = dataset.count_rows()
+    if n_variants == 0:
+        raise FatalError("Cannot run RRM: found 0 variants after filtering out monomorphic sites.")
+    info("Computing RRM using {} variants.".format(n_variants))
+
+    call_expr._indices = dataset._entry_indices
+    gt_expr = call_expr.num_alt_alleles()
+    normalized_genotype_expr = functions.bind(
+        dataset.AC / dataset.n_called,
+        lambda mean_gt: functions.bind(
+            functions.sqrt((dataset.ACsq +
+                            (n_samples - dataset.n_called) * mean_gt ** 2) /
+                           n_samples - mean_gt ** 2),
+            lambda stddev: functions.cond(functions.is_defined(call_expr),
+                                          (gt_expr - mean_gt) / stddev, 0)))
+
+    bm = BlockMatrix.from_matrix_table(normalized_genotype_expr)
+    dataset.unpersist()
+    rrm = bm.T.dot(bm) / n_variants
+
+    return KinshipMatrix._from_block_matrix(dataset.colkey_schema,
+                                            rrm,
+                                            [row.s for row in dataset.cols_table().select('s').collect()],
+                                            n_variants)

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -1005,8 +1005,6 @@ def grm(dataset):
 def rrm(call_expr):
     """Computes the Realized Relationship Matrix (RRM).
 
-    .. include:: ../_templates/req_tvariant.rst
-
     .. include:: ../_templates/req_biallelic.rst
 
     Examples

--- a/python/hail/methods/tests.py
+++ b/python/hail/methods/tests.py
@@ -255,17 +255,13 @@ class Tests(unittest.TestCase):
                                                 m1,
                                                 fst=(k * [fst]),
                                                 seed=seed,
-                                                num_partitions=4,
-                                                af_dist=UniformDist(0.1, 0.9)).to_hail2()
+                                                num_partitions=4).to_hail2()
 
-        def to_int_python(ds):
-            return BlockMatrix.from_matrix_table(ds['GT'].num_alt_alleles()).to_local_matrix()
-
-        def manual_calculation(ds):
-            ds = to_int_python(ds)
+        def direct_calculation(ds):
+            ds = BlockMatrix.from_matrix_table(ds['GT'].num_alt_alleles()).to_numpy_matrix()
 
             # filter out constant rows
-            isconst = lambda r: any([all([gt == c for gt in r]) for c in range(3)])
+            isconst = lambda r: any([all([(gt < c + .01) and (gt > c - .01) for gt in r]) for c in range(3)])
             ds = ds[[not isconst(row) for row in ds]]
 
             nvariants, nsamples = ds.shape
@@ -294,7 +290,7 @@ class Tests(unittest.TestCase):
 
             return np.array(data)
 
-        manual = manual_calculation(dataset)
+        manual = direct_calculation(dataset)
         rrm = hail_calculation(dataset)
 
         self.assertTrue(np.allclose(manual, rrm))

--- a/python/hail/methods/tests.py
+++ b/python/hail/methods/tests.py
@@ -295,26 +295,9 @@ class Tests(unittest.TestCase):
 
             return np.array(data)
 
-        def from_api1(ds):
-            ds = ds.to_hail1()
-            rrm = ds.rrm()
-            fn = utils.new_temp_file(suffix='.tsv')
-            rrm.export_tsv(fn)
-            data = []
-            with open(utils.get_URI(fn)) as f:
-                f.readline()
-                for line in f:
-                    row = line.strip().split()
-                    data.append(map(float, row))
-
-            return np.array(data)
-
         manual = manual_calculation(dataset)
         rrm = hail_calculation(dataset)
-        rrm1 = from_api1(dataset)
 
-        self.assertTrue(np.allclose(manual, rrm1))
-        self.assertTrue(np.allclose(rrm1, rrm))
         self.assertTrue(np.allclose(manual, rrm))
 
 

--- a/python/hail/methods/tests.py
+++ b/python/hail/methods/tests.py
@@ -11,7 +11,6 @@ from hail.expr.expression import ExpressionException
 from hail.utils.misc import test_file
 from hail.linalg import BlockMatrix
 from math import sqrt
->>>>>>> first pass at rrm
 
 hc = None
 

--- a/python/hail/methods/tests.py
+++ b/python/hail/methods/tests.py
@@ -294,25 +294,10 @@ class Tests(unittest.TestCase):
 
             return np.array(data)
 
-        def api1(ds):
-            rrm = ds.to_hail1().rrm()
-            fn = utils.new_temp_file(suffix='.tsv')
-            rrm.export_tsv(fn)
-            data = []
-            with open(utils.get_URI(fn)) as f:
-                f.readline()
-                for line in f:
-                    row = line.strip().split()
-                    data.append(map(float, row))
-
-            return np.array(data)
-
         manual = manual_calculation(dataset)
         rrm = hail_calculation(dataset)
-        rrm1 = api1(dataset)
 
         self.assertTrue(np.allclose(manual, rrm))
-        self.assertTrue(np.allclose(manual, rrm1))
 
 
     def test_pca(self):

--- a/python/hail/methods/tests.py
+++ b/python/hail/methods/tests.py
@@ -9,7 +9,6 @@ from struct import unpack
 import hail.utils as utils
 from hail.expr.expression import ExpressionException
 from hail.utils.misc import test_file
-from hail.stats import UniformDist
 from hail.linalg import BlockMatrix
 from math import sqrt
 >>>>>>> first pass at rrm
@@ -259,6 +258,8 @@ class Tests(unittest.TestCase):
 
         def direct_calculation(ds):
             ds = BlockMatrix.from_matrix_table(ds['GT'].num_alt_alleles()).to_numpy_matrix()
+            print(ds.shape)
+            print(ds)
 
             # filter out constant rows
             isconst = lambda r: any([all([(gt < c + .01) and (gt > c - .01) for gt in r]) for c in range(3)])

--- a/python/hail/methods/tests.py
+++ b/python/hail/methods/tests.py
@@ -271,7 +271,6 @@ class Tests(unittest.TestCase):
             nvariants, nsamples = ds.shape
             sumgt = lambda r: sum([i for i in r if i >= 0])
             sumsq = lambda r: sum([i**2 for i in r if i >= 0])
-            print(np.array([[sumgt(r), sumsq(r)] for r in ds]))
 
             mean = [sumgt(row) / nsamples for row in ds]
             stddev = [sqrt(sumsq(row) / nsamples - mean[i] ** 2)
@@ -295,10 +294,25 @@ class Tests(unittest.TestCase):
 
             return np.array(data)
 
+        def api1(ds):
+            rrm = ds.to_hail1().rrm()
+            fn = utils.new_temp_file(suffix='.tsv')
+            rrm.export_tsv(fn)
+            data = []
+            with open(utils.get_URI(fn)) as f:
+                f.readline()
+                for line in f:
+                    row = line.strip().split()
+                    data.append(map(float, row))
+
+            return np.array(data)
+
         manual = manual_calculation(dataset)
         rrm = hail_calculation(dataset)
+        rrm1 = api1(dataset)
 
         self.assertTrue(np.allclose(manual, rrm))
+        self.assertTrue(np.allclose(manual, rrm1))
 
 
     def test_pca(self):

--- a/python/hail/methods/tests.py
+++ b/python/hail/methods/tests.py
@@ -258,8 +258,6 @@ class Tests(unittest.TestCase):
 
         def direct_calculation(ds):
             ds = BlockMatrix.from_matrix_table(ds['GT'].num_alt_alleles()).to_numpy_matrix()
-            print(ds.shape)
-            print(ds)
 
             # filter out constant rows
             isconst = lambda r: any([all([(gt < c + .01) and (gt > c - .01) for gt in r]) for c in range(3)])

--- a/python/hail/utils/java.py
+++ b/python/hail/utils/java.py
@@ -127,11 +127,19 @@ def numpy_from_breeze(bdm):
     if bdm.majorStride() != expected_stride:
         raise ValueError("Expected major stride of Breeze matrix to be {}, found {}"
                          .format(expected_stride, bdm.majorStride()))
-    if cols * rows > 0x7ffff:
+    if cols * rows > 0x7ffffff:
         raise ValueError("rows * cols must be smaller than {}, found {} by {} matrix"
-                         .format(0x7ffff, rows, cols))
+                         .format(0x7ffffff, rows, cols))
 
-    b = Env.jutils().bdmToBytes(bdm)
+    if cols * rows <= 0x7ffff:
+        b = Env.jutils().bdmGetBytes(bdm, 0, cols * rows)
+    else:
+        b = bytearray()
+        i = 0
+        while (i < rows * cols):
+            n = min(0x7ffff, rows * cols - i)
+            b.append(Env.jutils().bdmGetBytes(bdm, i, n))
+            i += n
     data = np.fromstring(bytes(b), dtype='f8')
     return np.reshape(data, (cols, rows)).T if bdm.isTranspose else np.reshape(data, (rows, cols))
 

--- a/python/hail/utils/java.py
+++ b/python/hail/utils/java.py
@@ -6,6 +6,7 @@ from threading import Thread
 import py4j
 from pyspark.sql.utils import CapturedException
 from decorator import decorator
+import numpy as np
 
 
 class FatalError(Exception):
@@ -114,6 +115,25 @@ def jiterable_to_list(it):
 
 def jarray_to_list(a):
     return list(a) if a else None
+
+def numpy_from_breeze(bdm):
+    isT = bdm.isTranspose()
+    rows, cols = bdm.rows(), bdm.cols()
+
+    if bdm.offset() != 0:
+        raise ValueError("Expected offset of Breeze matrix to be 0, found {}"
+                         .format(bdm.offset()))
+    expected_stride = cols if isT else rows
+    if bdm.majorStride() != expected_stride:
+        raise ValueError("Expected major stride of Breeze matrix to be {}, found {}"
+                         .format(expected_stride, bdm.majorStride()))
+    if cols * rows > 0x7ffff:
+        raise ValueError("rows * cols must be smaller than {}, found {} by {} matrix"
+                         .format(0x7ffff, rows, cols))
+
+    b = Env.jutils().bdmToBytes(bdm)
+    data = np.fromstring(bytes(b), dtype='f8')
+    return np.reshape(data, (cols, rows)).T if bdm.isTranspose else np.reshape(data, (rows, cols))
 
 
 class Log4jLogger:

--- a/src/main/scala/is/hail/stats/ComputeRRM.scala
+++ b/src/main/scala/is/hail/stats/ComputeRRM.scala
@@ -34,10 +34,6 @@ object ComputeRRM {
   def apply(vds: MatrixTable, forceBlock: Boolean = false, forceGramian: Boolean = false): KinshipMatrix = {
     info(s"rrm: Computing Realized Relationship Matrix...")
 
-    def scaleMatrix(matrix: Matrix, scalar: Double): Matrix = {
-      Matrices.dense(matrix.numRows, matrix.numCols, matrix.toArray.map(_ * scalar))
-    }
-
     val useBlock = (forceBlock, forceGramian) match {
       case (false, false) => vds.nSamples > 3000 // for small matrices, computeGramian fits in memory and runs faster than BlockMatrix product
       case (true, true) => fatal("Cannot force both Block and Gramian")

--- a/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -27,14 +27,13 @@ trait Py4jUtils {
     list
   }
 
-  // FIXME: Currently this can only send much less than the limit of
-  // BlockMatrix.toLocalMatrix. That's probably fine.
-  def doubleBDMToBytes(mat: BDM[Double]): Array[Byte] = {
-    // assumes matrix is written as written by BlockMatrix
-    val buf = new Array[Byte](8 + 8 * mat.rows * mat.cols)
-    Memory.storeInt(buf, 0, mat.rows)
-    Memory.storeInt(buf, 4, mat.cols)
-    Memory.memcpy(buf, 8, mat.data, 0, 8*mat.rows*mat.cols)
+  // FIXME: Currently this needs 8 * r * c < int.max.
+  def bdmToBytes(bdm: BDM[Double]): Array[Byte] = {
+    assert(8 * bdm.rows * bdm.cols < Integer.MAX_VALUE)
+    assert(bdm.offset == 0)
+    assert(bdm.majorStride == (if (bdm.isTranspose) bdm.cols else bdm.rows))
+    val buf = new Array[Byte](8 * bdm.rows * bdm.cols)
+    Memory.memcpy(buf, 0, bdm.data, 0, 8 * bdm.rows * bdm.cols)
     buf
   }
 

--- a/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -26,13 +26,13 @@ trait Py4jUtils {
       list.add(elem)
     list
   }
-  
+
   def bdmGetBytes(bdm: BDM[Double], start: Int, n: Int): Array[Byte] = {
-    assert(8L * n < Integer.MAX_VALUE.toLong)
+    assert(8L * n < Integer.MAX_VALUE)
     assert(bdm.offset == 0)
     assert(bdm.majorStride == (if (bdm.isTranspose) bdm.cols else bdm.rows))
     val buf = new Array[Byte](8 * n)
-    Memory.memcpy(buf, 0, bdm.data, 8 * start, 8 * n)
+    Memory.memcpy(buf, 0, bdm.data, start, n)
     buf
   }
 

--- a/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -26,14 +26,13 @@ trait Py4jUtils {
       list.add(elem)
     list
   }
-
-  // FIXME: Currently this needs 8 * r * c < int.max.
-  def bdmToBytes(bdm: BDM[Double]): Array[Byte] = {
-    assert(8 * bdm.rows * bdm.cols < Integer.MAX_VALUE)
+  
+  def bdmGetBytes(bdm: BDM[Double], start: Int, n: Int): Array[Byte] = {
+    assert(8L * n < Integer.MAX_VALUE.toLong)
     assert(bdm.offset == 0)
     assert(bdm.majorStride == (if (bdm.isTranspose) bdm.cols else bdm.rows))
-    val buf = new Array[Byte](8 * bdm.rows * bdm.cols)
-    Memory.memcpy(buf, 0, bdm.data, 0, 8 * bdm.rows * bdm.cols)
+    val buf = new Array[Byte](8 * n)
+    Memory.memcpy(buf, 0, bdm.data, 8 * start, 8 * n)
     buf
   }
 

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -2801,7 +2801,7 @@ class MatrixTable(val hc: HailContext, val metadata: VSMMetadata,
     (irm, optionVariants)
   }
 
-  def writeBlockMatrix(dirname: String, expr: String, blockSize: Int): Unit = {
+  def writeBlockMatrix(dirname: String, expr: String, blockSize: Int = BlockMatrix.defaultBlockSize): Unit = {
     val partStarts = partitionStarts()
     assert(partStarts.length == rdd2.getNumPartitions + 1)
 


### PR DESCRIPTION
@jbloom22 I put in a rough version of a Python `BlockMatrix.to_local_matrix()`. It won't do super large matrices---it can only accommodate `MAXINT / 8 - 3` entries---but I needed something like this for testing. I was looking at maybe removing `ComputeRRM` from Scala, but it looks like a lot of the lmmreg tests are using it, so I didn't touch it for now; do you know how easy that is work around?