### PR TITLE
fix implicit joins inside select/transmute

### DIFF
--- a/python/hail/api2/matrixtable.py
+++ b/python/hail/api2/matrixtable.py
@@ -1919,7 +1919,8 @@ class MatrixTable(object):
                 all_uids.extend(j.temp_vars)
 
         def cleanup(matrix):
-            return matrix.drop(*all_uids)
+            remaining_uids = [uid for uid in all_uids if uid in matrix._fields]
+            return matrix.drop(*remaining_uids)
 
         return left, cleanup
 

--- a/python/hail/api2/table.py
+++ b/python/hail/api2/table.py
@@ -1221,7 +1221,8 @@ class Table(TableTemplate):
             left = left.key_by(*original_key)
 
         def cleanup(table):
-            return table.drop(*all_uids)
+            remaining_uids = [uid for uid in all_uids if uid in table._fields]
+            return table.drop(*remaining_uids)
 
         return left, cleanup
 

--- a/python/hail/api2/tests.py
+++ b/python/hail/api2/tests.py
@@ -295,6 +295,9 @@ class TableTests(unittest.TestCase):
         ktr = kt.annotate(e=kt4[kt3[kt2[kt1[kt.a].b].c].d].e)
         self.assertTrue(ktr.aggregate(result=agg.collect(ktr.e)).result == ['quam'])
 
+        ktr = kt.select(e=kt4[kt3[kt2[kt1[kt.a].b].c].d].e)
+        self.assertTrue(ktr.aggregate(result=agg.collect(ktr.e)).result == ['quam'])
+
         self.assertEqual(kt.filter(kt4[kt3[kt2[kt1[kt.a].b].c].d].e == 'quam').count(), 1)
 
         m = hc.import_vcf('src/test/resources/sample.vcf')


### PR DESCRIPTION
Select and transmute can remove uid fields after an implicit join, but cleanup was trying to remove all uids.