### PR TITLE
fixed matrix computed key join bug

### DIFF
--- a/python/hail/api1/tests.py
+++ b/python/hail/api1/tests.py
@@ -250,8 +250,6 @@ class ContextTests(unittest.TestCase):
                   .annotate("v2 = v")
                   .key_by(["v", "v2"]))
 
-            dataset.annotate_variants_table(kt, root='va.foo', vds_key=["v", "v"])
-
             self.assertEqual(kt.query('v.fraction(x => x == v2)'), 1.0)
 
             dataset.genotypes_table()
@@ -454,7 +452,6 @@ class ContextTests(unittest.TestCase):
         kt = (sample2.variants_table()
               .annotate("v2 = v")
               .key_by(["v", "v2"]))
-        sample2.annotate_variants_table(kt, root="va.foo", vds_key=["v", "v"])
 
         self.assertEqual(kt.query('v.fraction(x => x == v2)'), 1.0)
 

--- a/python/hail/api2/matrixtable.py
+++ b/python/hail/api2/matrixtable.py
@@ -1769,7 +1769,7 @@ class MatrixTable(object):
                     MatrixTable(left._jvds.annotateVariantsVDS(right._jvds, jsome('{}.{}'.format(prefix, uid)),
                                                                jnone())))
             elif indices == src._row_indices:
-                return self.rows_table()[expr]
+                return self.rows_table().view_join_rows(expr)
             elif indices == src._col_indices:
                 prefix = 'sa'
                 joiner = lambda left: (
@@ -1828,7 +1828,7 @@ class MatrixTable(object):
                                                                 [expr._ast.to_hql()],
                                                                 '{}.{}'.format(prefix, uid), None, False)))
             elif indices == src._row_indices:
-                return self.rows_table()[expr]
+                return self.cols_table().view_join_rows(expr)
             else:
                 # FIXME: implement entry-based join in the expression language
                 raise NotImplementedError('MatrixTable.view_join_cols join with indices {}'.format(indices))

--- a/python/hail/api2/matrixtable.py
+++ b/python/hail/api2/matrixtable.py
@@ -1769,11 +1769,7 @@ class MatrixTable(object):
                     MatrixTable(left._jvds.annotateVariantsVDS(right._jvds, jsome('{}.{}'.format(prefix, uid)),
                                                                jnone())))
             elif indices == src._row_indices:
-                prefix = 'va'
-                joiner = lambda left: (
-                    MatrixTable(left._jvds.annotateVariantsTable(right._jvds.variantsKT(),
-                                                                 [expr._ast.to_hql()],
-                                                                 '{}.{}'.format(prefix, uid), None, False)))
+                return self.rows_table()[expr]
             elif indices == src._col_indices:
                 prefix = 'sa'
                 joiner = lambda left: (
@@ -1832,11 +1828,7 @@ class MatrixTable(object):
                                                                 [expr._ast.to_hql()],
                                                                 '{}.{}'.format(prefix, uid), None, False)))
             elif indices == src._row_indices:
-                prefix = 'va'
-                joiner = lambda left: (
-                    MatrixTable(left._jvds.annotateVariantsTable(right._jvds.samplesKT(),
-                                                                 [expr._ast.to_hql()],
-                                                                 '{}.{}'.format(prefix, uid), None, False)))
+                return self.rows_table()[expr]
             else:
                 # FIXME: implement entry-based join in the expression language
                 raise NotImplementedError('MatrixTable.view_join_cols join with indices {}'.format(indices))


### PR DESCRIPTION
Fixes https://github.com/hail-is/hail/issues/2802

fixed a bug where a matrix with duplicated row keys would join incorrectly witha table via a computed key (vds_key)
added test for this case
moved the vds_key logic and tests to python in api2
removed vds_key from api1