### PR TITLE
improved BlockMatrix.from(lm), added lm.writeBlockMatrix, defaultBlockSize=4096

### DIFF
--- a/src/main/scala/is/hail/utils/package.scala
+++ b/src/main/scala/is/hail/utils/package.scala
@@ -46,7 +46,7 @@ package object utils extends Logging
     }
   }
 
-  def plural(n: Int, sing: String, plur: String = null): String =
+  def plural(n: Long, sing: String, plur: String = null): String =
     if (n == 1)
       sing
     else if (plur == null)

--- a/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
@@ -3,8 +3,12 @@ package is.hail.utils.richUtils
 import java.io.{DataInputStream, DataOutputStream}
 
 import breeze.linalg.DenseMatrix
+import is.hail.HailContext
 import is.hail.annotations.Memory
-import is.hail.utils.ArrayBuilder
+import is.hail.distributedmatrix.{BlockMatrix, BlockMatrixMetadata, GridPartitioner}
+import is.hail.utils._
+import org.apache.commons.lang3.StringUtils
+import org.json4s.jackson
 
 object RichDenseMatrixDouble {  
   // copies n doubles as bytes from data to dos
@@ -56,6 +60,10 @@ object RichDenseMatrixDouble {
     
     new DenseMatrix[Double](rows, cols, data,
       offset = 0, majorStride = if (isTranspose) cols else rows, isTranspose = isTranspose)
+  }
+  
+  def read(hc: HailContext, path: String): DenseMatrix[Double] = {
+    hc.hadoopConf.readDataFile(path)(read)
   }
 }
 
@@ -128,4 +136,43 @@ class RichDenseMatrixDouble(val m: DenseMatrix[Double]) extends AnyVal {
       m
     else
       new DenseMatrix(m.rows, m.cols, m.t.toArray, 0, m.cols, isTranspose = true)
+  
+  def write(hc: HailContext, path: String) {
+    hc.hadoopConf.writeDataFile(path)(write)
+  }
+  
+  def writeBlockMatrix(hc: HailContext, path: String, blockSize: Int, forceRowMajor: Boolean = false) {
+    val hadoop = hc.hadoopConf
+    hadoop.mkDir(path)
+
+    hadoop.writeDataFile(path + BlockMatrix.metadataRelativePath) { os =>
+      jackson.Serialization.write(
+        BlockMatrixMetadata(blockSize, m.rows, m.cols),
+        os)
+    }
+
+    val gp = GridPartitioner(blockSize, m.rows, m.cols)    
+    val nParts = gp.numPartitions
+    val d = digitsNeeded(nParts)
+
+    (0 until nParts).par.foreach { pi =>
+      val pis = StringUtils.leftPad(pi.toString, d, "0")
+      val filename = path + "/parts/part-" + pis
+      
+      val (i, j) = gp.blockCoordinates(pi)
+      val (blockNRows, blockNCols) = gp.blockDims(pi)
+      val iOffset = i * blockSize
+      val jOffset = j * blockSize      
+      var block = m(iOffset until iOffset + blockNRows, jOffset until jOffset + blockNCols)
+    
+      if (forceRowMajor)
+        block.forceRowMajor().write(hc, filename)
+      else
+        block.copy.write(hc, filename)
+    }
+
+    info(s"wrote $nParts ${ plural(nParts, "item") } in $nParts ${ plural(nParts, "partition") }")
+
+    hadoop.writeTextFile(path + "/_SUCCESS")(out => ())
+  }
 }

--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -209,7 +209,8 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
       .collect()
 
     val itemCount = partitionCounts.sum
-    info(s"wrote ${ partitionCounts.sum } items in $nPartitions partitions")
+    info(s"wrote $itemCount ${ plural(itemCount, "item") } " +
+      s"in $nPartitions ${ plural(nPartitions, "partition") }")
     
     partitionCounts
   }


### PR DESCRIPTION
I've changed BlockMatrix.from(lm: BDM[Double]) so that each executor is transmitted only the blocks it needs (~num_blocks/num_executors) rather than all of them: "[TorrentBroadcast](https://jaceklaskowski.gitbooks.io/mastering-apache-spark/spark-TorrentBroadcast.html) uses a BitTorrent-like protocol for block distribution (that only happens when tasks access broadcast variables on executors)."

In another branch, I've verified on GCP that distributing and then localizing a 10k x 10k matrix is twice as fast (about 15s vs 30s). Distributing and then writing a 25k by 25k matrix (5GB) with 10+2 standard 8-core workers takes about 30s with the new method but fails for every partition with the old method (months ago I believe I sometimes got the old method to work at this scale using high mem. It's needed for LMM). Note the matrix only has 49 partitions at the new default blockSize so I had more cores than needed for the experiment.

I've also added a method to write a local matrix as a block matrix. I use ParRange to parallelize writing from master. Writing and then reading should be the safest way to distribute a big local matrix at the beginning of complex pipelines, and I think it avoids some of the memory overhead associated with broadcast.