### PR TITLE
ignore sbt build folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ python/**/*.pyc
 python/hail/docs/_build/*
 src/main/c/libsimdpp-2.0-rc2.tar.gz
 src/main/c/libsimdpp-2.0-rc2
+target


### PR DESCRIPTION
this folder is generated by sbt, so we should ignore it now that we have a `build.sbt`