### PR TITLE
parameterize en/decoder

### DIFF
--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -1758,6 +1758,10 @@ class MatrixTable(object):
         return self._jvds.countVariants()
 
     @handle_py4j
+    def _force_count_rows(self):
+        return self._jvds.forceCountRows()
+
+    @handle_py4j
     def count_cols(self):
         """Count the number of columns in the matrix.
 
@@ -1795,8 +1799,9 @@ class MatrixTable(object):
 
     @handle_py4j
     @typecheck_method(output=strlike,
-                      overwrite=bool)
-    def write(self, output, overwrite=False):
+                      overwrite=bool,
+                      _codec_spec=nullable(strlike))
+    def write(self, output, overwrite=False, _codec_spec=None):
         """Write to disk.
 
         Examples
@@ -1820,7 +1825,7 @@ class MatrixTable(object):
             If ``True``, overwrite an existing file at the destination.
         """
 
-        self._jvds.write(output, overwrite)
+        self._jvds.write(output, overwrite, _codec_spec)
 
     @handle_py4j
     def globals_table(self):

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -363,6 +363,10 @@ class Table(TableTemplate):
     def count(self):
         return self._jt.count()
 
+    @handle_py4j
+    def _force_count(self):
+        return self._jt.forceCount()
+
     @classmethod
     @handle_py4j
     @record_classmethod
@@ -1025,8 +1029,9 @@ class Table(TableTemplate):
 
     @handle_py4j
     @typecheck_method(output=strlike,
-                      overwrite=bool)
-    def write(self, output, overwrite=False):
+                      overwrite=bool,
+                      _codec_spec=nullable(strlike))
+    def write(self, output, overwrite=False, _codec_spec=None):
         """Write to disk.
 
         Examples
@@ -1050,7 +1055,7 @@ class Table(TableTemplate):
             If ``True``, overwrite an existing file at the destination.
         """
 
-        self._jt.write(output, overwrite)
+        self._jt.write(output, overwrite, _codec_spec)
 
     @handle_py4j
     @typecheck_method(n=integral, width=integral, truncate=nullable(integral), types=bool)

--- a/python/hail/tests.py
+++ b/python/hail/tests.py
@@ -8,6 +8,8 @@ import random
 import hail as hl
 import hail.expr.aggregators as agg
 from hail.utils.misc import test_file, new_temp_file
+import json
+
 
 
 def setUpModule():
@@ -643,6 +645,26 @@ class MatrixTests(unittest.TestCase):
         ds.write(f)
         t = hl.read_table(f + '/globals')
         self.assertTrue(ds.globals_table()._same(t))
+
+    def test_codecs_matrix(self):
+        from hail.utils.java import Env
+        codecs = Env.hail().io.CodecSpec.codecSpecs()
+        ds = self.get_vds()
+        temp = new_temp_file(suffix='hmt')
+        for codec in codecs:
+            ds.write(temp, overwrite=True, _codec_spec=codec.toString())
+            ds2 = methods.read_matrix(temp)
+            self.assertTrue(ds._same(ds2))
+
+    def test_codecs_table(self):
+        from hail.utils.java import Env
+        codecs = Env.hail().io.CodecSpec.codecSpecs()
+        rt = self.get_vds().rows_table()
+        temp = new_temp_file(suffix='ht')
+        for codec in codecs:
+            rt.write(temp, overwrite=True, _codec_spec=codec.toString())
+            rt2 = methods.read_matrix(temp)
+            self.assertTrue(rt._same(rt2))
 
 class FunctionsTests(unittest.TestCase):
     def test(self):

--- a/python/hail/tests.py
+++ b/python/hail/tests.py
@@ -643,7 +643,7 @@ class MatrixTests(unittest.TestCase):
         ds = ds.annotate_globals(x = 'foo')
         f = new_temp_file(suffix='vds')
         ds.write(f)
-        t = methods.read_table(f + '/rows')
+        t = hl.read_table(f + '/rows')
         self.assertTrue(ds.rows_table()._same(t))
 
     def test_read_stored_globals(self):
@@ -661,7 +661,7 @@ class MatrixTests(unittest.TestCase):
         temp = new_temp_file(suffix='hmt')
         for codec in codecs:
             ds.write(temp, overwrite=True, _codec_spec=codec.toString())
-            ds2 = methods.read_matrix_table(temp)
+            ds2 = hl.read_matrix_table(temp)
             self.assertTrue(ds._same(ds2))
 
     def test_codecs_table(self):
@@ -671,7 +671,7 @@ class MatrixTests(unittest.TestCase):
         temp = new_temp_file(suffix='ht')
         for codec in codecs:
             rt.write(temp, overwrite=True, _codec_spec=codec.toString())
-            rt2 = methods.read_table(temp)
+            rt2 = hl.read_table(temp)
             self.assertTrue(rt._same(rt2))
 
 class FunctionsTests(unittest.TestCase):

--- a/python/hail/tests.py
+++ b/python/hail/tests.py
@@ -638,6 +638,14 @@ class MatrixTests(unittest.TestCase):
         t = hl.read_table(f + '/cols')
         self.assertTrue(ds.cols_table()._same(t))
 
+    def test_read_stored_rows(self):
+        ds = self.get_vds()
+        ds = ds.annotate_globals(x = 'foo')
+        f = new_temp_file(suffix='vds')
+        ds.write(f)
+        t = methods.read_table(f + '/rows')
+        self.assertTrue(ds.rows_table()._same(t))
+
     def test_read_stored_globals(self):
         ds = self.get_vds()
         ds = ds.annotate_globals(x = 5, baz = 'foo')
@@ -653,7 +661,7 @@ class MatrixTests(unittest.TestCase):
         temp = new_temp_file(suffix='hmt')
         for codec in codecs:
             ds.write(temp, overwrite=True, _codec_spec=codec.toString())
-            ds2 = methods.read_matrix(temp)
+            ds2 = methods.read_matrix_table(temp)
             self.assertTrue(ds._same(ds2))
 
     def test_codecs_table(self):
@@ -663,7 +671,7 @@ class MatrixTests(unittest.TestCase):
         temp = new_temp_file(suffix='ht')
         for codec in codecs:
             rt.write(temp, overwrite=True, _codec_spec=codec.toString())
-            rt2 = methods.read_matrix(temp)
+            rt2 = methods.read_table(temp)
             self.assertTrue(rt._same(rt2))
 
 class FunctionsTests(unittest.TestCase):

--- a/python/hail/tests.py
+++ b/python/hail/tests.py
@@ -655,8 +655,8 @@ class MatrixTests(unittest.TestCase):
         self.assertTrue(ds.globals_table()._same(t))
 
     def test_codecs_matrix(self):
-        from hail.utils.java import Env
-        codecs = Env.hail().io.CodecSpec.codecSpecs()
+        from hail.utils.java import Env, scala_object
+        codecs = scala_object(Env.hail().io, 'CodecSpec').codecSpecs()
         ds = self.get_vds()
         temp = new_temp_file(suffix='hmt')
         for codec in codecs:
@@ -665,8 +665,8 @@ class MatrixTests(unittest.TestCase):
             self.assertTrue(ds._same(ds2))
 
     def test_codecs_table(self):
-        from hail.utils.java import Env
-        codecs = Env.hail().io.CodecSpec.codecSpecs()
+        from hail.utils.java import Env, scala_object
+        codecs = scala_object(Env.hail().io, 'CodecSpec').codecSpecs()
         rt = self.get_vds().rows_table()
         temp = new_temp_file(suffix='ht')
         for codec in codecs:

--- a/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -70,7 +70,7 @@ class UnsafeIndexedSeq(
     kryo.writeObject(output, t)
 
     val aos = new ArrayOutputStream()
-    val enc = new Encoder(new LZ4OutputBuffer(aos))
+    val enc = CodecSpec.default.buildEncoder(aos)
     enc.writeRegionValue(t, region, aoff)
     enc.flush()
 
@@ -82,7 +82,7 @@ class UnsafeIndexedSeq(
     out.writeObject(t)
 
     val aos = new ArrayOutputStream()
-    val enc = new Encoder(new LZ4OutputBuffer(aos))
+    val enc = CodecSpec.default.buildEncoder(aos)
     enc.writeRegionValue(t, region, aoff)
     enc.flush()
 
@@ -96,9 +96,7 @@ class UnsafeIndexedSeq(
     val smallInOff = input.readInt()
     val a = new Array[Byte](smallInOff)
     input.readFully(a, 0, smallInOff)
-    using(new Decoder(
-      new LZ4InputBuffer(
-        new ArrayInputStream(a)))) { dec =>
+    using(CodecSpec.default.buildDecoder(new ArrayInputStream(a))) { dec =>
 
       region = Region()
       aoff = dec.readRegionValue(t, region)
@@ -113,10 +111,7 @@ class UnsafeIndexedSeq(
     val smallInOff = in.readInt()
     val a = new Array[Byte](smallInOff)
     in.readFully(a, 0, smallInOff)
-    using(new Decoder(
-      new LZ4InputBuffer(
-        new ArrayInputStream(a)))) { dec =>
-
+    using(CodecSpec.default.buildDecoder(new ArrayInputStream(a))) { dec =>
       region = Region()
       aoff = dec.readRegionValue(t, region)
 
@@ -301,7 +296,7 @@ class UnsafeRow(var t: TStruct,
     kryo.writeObject(output, t)
 
     val aos = new ArrayOutputStream()
-    val enc = new Encoder(new LZ4OutputBuffer(aos))
+    val enc = CodecSpec.default.buildEncoder(aos)
     enc.writeRegionValue(t, region, offset)
     enc.flush()
 
@@ -313,7 +308,7 @@ class UnsafeRow(var t: TStruct,
     out.writeObject(t)
 
     val aos = new ArrayOutputStream()
-    val enc = new Encoder(new LZ4OutputBuffer(aos))
+    val enc = CodecSpec.default.buildEncoder(aos)
     enc.writeRegionValue(t, region, offset)
     enc.flush()
 
@@ -327,10 +322,7 @@ class UnsafeRow(var t: TStruct,
     val smallInOff = input.readInt()
     val a = new Array[Byte](smallInOff)
     input.readFully(a, 0, smallInOff)
-    using(new Decoder(
-      new LZ4InputBuffer(
-        new ArrayInputStream(a)))) { dec =>
-
+    using(CodecSpec.default.buildDecoder(new ArrayInputStream(a))) { dec =>
       region = Region()
       offset = dec.readRegionValue(t, region)
     }
@@ -342,9 +334,7 @@ class UnsafeRow(var t: TStruct,
     val smallInOff = in.readInt()
     val a = new Array[Byte](smallInOff)
     in.readFully(a, 0, smallInOff)
-    using(new Decoder(
-      new LZ4InputBuffer(
-        new ArrayInputStream(a)))) { dec =>
+    using(CodecSpec.default.buildDecoder(new ArrayInputStream(a))) { dec =>
       region = Region()
       offset = dec.readRegionValue(t, region)
     }

--- a/src/main/scala/is/hail/io/RowStore.scala
+++ b/src/main/scala/is/hail/io/RowStore.scala
@@ -9,6 +9,222 @@ import is.hail.rvd.{OrderedRVDPartitioner, OrderedRVDSpec, UnpartitionedRVDSpec}
 import is.hail.utils._
 import is.hail.variant.LZ4Utils
 import org.apache.spark.rdd.RDD
+import org.json4s.JValue
+import org.json4s.JsonAST.{JInt, JObject, JString}
+import org.json4s.jackson.JsonMethods
+
+object BufferSpec {
+  def extract(jv: JValue): BufferSpec = {
+    jv \ "name" match {
+      case JString("LEB128Buffer") =>
+        LEB128BufferSpec.extract(jv \ "args")
+      case JString("BlockingBuffer") =>
+        BlockingBufferSpec.extract(jv \ "args")
+    }
+  }
+}
+
+abstract class BufferSpec extends Serializable {
+  def buildInputBuffer(in: InputStream): InputBuffer
+
+  def buildOutputBuffer(out: OutputStream): OutputBuffer
+
+  def toJSON: JValue
+
+  override def toString: String = JsonMethods.compact(JsonMethods.render(toJSON))
+}
+
+object LEB128BufferSpec {
+  def extract(jv: JValue): LEB128BufferSpec = new LEB128BufferSpec(BufferSpec.extract(jv \ "child"))
+}
+
+final class LEB128BufferSpec(child: BufferSpec) extends BufferSpec {
+  def buildInputBuffer(in: InputStream): InputBuffer = new LEB128InputBuffer(child.buildInputBuffer(in))
+
+  def buildOutputBuffer(out: OutputStream): OutputBuffer = new LEB128OutputBuffer(child.buildOutputBuffer(out))
+
+  def toJSON: JValue = JObject("name" -> JString("LEB128Buffer"),
+    "args" -> JObject("child" -> child.toJSON))
+}
+
+object BlockingBufferSpec {
+  def extract(jv: JValue): BlockingBufferSpec = new BlockingBufferSpec(
+    jv \ "block_size" match {
+      case JInt(x) => x.toInt
+    },
+    BlockBufferSpec.extract(jv \ "child"))
+}
+
+final class BlockingBufferSpec(blockSize: Int, child: BlockBufferSpec) extends BufferSpec {
+  def buildInputBuffer(in: InputStream): InputBuffer = new BlockingInputBuffer(blockSize, child.buildInputBuffer(in))
+
+  def buildOutputBuffer(out: OutputStream): OutputBuffer = new BlockingOutputBuffer(blockSize, child.buildOutputBuffer(out))
+
+  def toJSON: JValue = JObject("name" -> JString("BlockingBuffer"),
+    "args" -> JObject("block_size" -> JInt(blockSize),
+      "child" -> child.toJSON))
+}
+
+object BlockBufferSpec {
+  def extract(jv: JValue): BlockBufferSpec = {
+    jv \ "name" match {
+      case JString("LZ4BlockBuffer") =>
+        LZ4BlockBufferSpec.extract(jv \ "args")
+      case JString("StreamBlockBuffer") =>
+        StreamBlockBufferSpec.extract(jv \ "args")
+    }
+  }
+}
+
+abstract class BlockBufferSpec extends Serializable {
+  def buildInputBuffer(in: InputStream): InputBlockBuffer
+
+  def buildOutputBuffer(out: OutputStream): OutputBlockBuffer
+
+  def toJSON: JValue
+
+  override def toString: String = JsonMethods.compact(JsonMethods.render(toJSON))
+}
+
+object LZ4BlockBufferSpec {
+  def extract(jv: JValue): LZ4BlockBufferSpec = new LZ4BlockBufferSpec(
+    jv \ "block_size" match {
+      case JInt(x) => x.toInt
+    },
+    BlockBufferSpec.extract(jv \ "child"))
+}
+
+final class LZ4BlockBufferSpec(blockSize: Int, child: BlockBufferSpec) extends BlockBufferSpec {
+  def buildInputBuffer(in: InputStream): InputBlockBuffer = new LZ4InputBlockBuffer(blockSize, child.buildInputBuffer(in))
+
+  def buildOutputBuffer(out: OutputStream): OutputBlockBuffer = new LZ4OutputBlockBuffer(blockSize, child.buildOutputBuffer(out))
+
+  def toJSON: JValue = JObject("name" -> JString("LZ4BlockBuffer"),
+    "args" -> JObject("block_size" -> JInt(blockSize),
+      "child" -> child.toJSON))
+}
+
+object StreamBlockBufferSpec {
+  def extract(jv: JValue): StreamBlockBufferSpec = new StreamBlockBufferSpec
+}
+
+final class StreamBlockBufferSpec extends BlockBufferSpec {
+  def buildInputBuffer(in: InputStream): InputBlockBuffer = new StreamBlockInputBuffer(in)
+
+  def buildOutputBuffer(out: OutputStream): OutputBlockBuffer = new StreamBlockOutputBuffer(out)
+
+  def toJSON: JValue = JObject("name" -> JString("StreamBlockBuffer"),
+    "args" -> JObject())
+}
+
+object CodecSpec {
+  val default: CodecSpec = new PackCodecSpec(
+    new LEB128BufferSpec(
+      new BlockingBufferSpec(32 * 1024,
+        new LZ4BlockBufferSpec(32 * 1024,
+          new StreamBlockBufferSpec))))
+
+  val blockSpecs:  Array[BufferSpec] = Array(
+    new BlockingBufferSpec(64 * 1024,
+      new StreamBlockBufferSpec),
+    new BlockingBufferSpec(32 * 1024,
+      new LZ4BlockBufferSpec(32 * 1024,
+        new StreamBlockBufferSpec)))
+
+  val bufferSpecs: Array[BufferSpec] = blockSpecs.flatMap { blockSpec =>
+    Array(blockSpec,
+      new LEB128BufferSpec(blockSpec))
+  }
+
+  val codecSpecs: Array[CodecSpec] = bufferSpecs.flatMap { bufferSpec =>
+    Array(new DirectCodecSpec(bufferSpec),
+      new PackCodecSpec(bufferSpec))
+  }
+
+  def extract(jv: JValue): CodecSpec = {
+    jv \ "name" match {
+      case JString("PackCodec") =>
+        PackCodecSpec.extract(jv \ "args")
+      case JString("DirectCodec") =>
+        DirectCodecSpec.extract(jv \ "args")
+    }
+  }
+}
+
+abstract class CodecSpec extends Serializable {
+  def buildEncoder(out: OutputStream): Encoder
+
+  def buildDecoder(in: InputStream): Decoder
+
+  def toJSON: JValue
+
+  override def toString: String = JsonMethods.compact(JsonMethods.render(toJSON))
+}
+
+object PackCodecSpec {
+  def extract(jv: JValue): PackCodecSpec = new PackCodecSpec(BufferSpec.extract(jv \ "child"))
+}
+
+final class PackCodecSpec(child: BufferSpec) extends CodecSpec {
+  def buildEncoder(out: OutputStream): Encoder = new PackEncoder(child.buildOutputBuffer(out))
+
+  def buildDecoder(in: InputStream): Decoder = new PackDecoder(child.buildInputBuffer(in))
+
+  def toJSON: JValue = JObject("name" -> JString("PackCodec"),
+    "args" -> JObject("child" -> child.toJSON))
+}
+
+object DirectCodecSpec {
+  def extract(jv: JValue): DirectCodecSpec = new DirectCodecSpec(BufferSpec.extract(jv \ "child"))
+}
+
+final class DirectCodecSpec(child: BufferSpec) extends CodecSpec {
+  def buildEncoder(out: OutputStream): Encoder = new DirectEncoder(child.buildOutputBuffer(out))
+
+  def buildDecoder(in: InputStream): Decoder = new DirectDecoder(child.buildInputBuffer(in))
+
+  def toJSON: JValue = JObject("name" -> JString("DirectCodec"),
+    "args" -> JObject("child" -> child.toJSON))
+}
+
+abstract class OutputBlockBuffer extends Closeable {
+  def writeBlock(buf: Array[Byte], len: Int): Unit
+}
+
+abstract class InputBlockBuffer extends Closeable {
+  def close(): Unit
+
+  def readBlock(buf: Array[Byte]): Int
+}
+
+final class StreamBlockOutputBuffer(out: OutputStream) extends OutputBlockBuffer {
+  private val lenBuf = new Array[Byte](4)
+
+  def close() {
+    out.close()
+  }
+
+  def writeBlock(buf: Array[Byte], len: Int): Unit = {
+    Memory.storeInt(lenBuf, 0, len)
+    out.write(lenBuf, 0, 4)
+    out.write(buf, 0, len)
+  }
+}
+
+class StreamBlockInputBuffer(in: InputStream) extends InputBlockBuffer {
+  private val lenBuf = new Array[Byte](4)
+
+  def close() {
+    in.close()
+  }
+
+  def readBlock(buf: Array[Byte]): Int = {
+    in.read(lenBuf, 0, 4)
+    val len = Memory.loadInt(lenBuf, 0)
+    in.read(buf, 0, len)
+    len
+  }
+}
 
 class ArrayInputStream(var a: Array[Byte], var end: Int) extends InputStream {
   var off: Int = 0
@@ -104,26 +320,65 @@ abstract class OutputBuffer extends Closeable {
   }
 }
 
-object LZ4Buffer {
-  final val blockSize: Int = 32 * 1024
+final class LEB128OutputBuffer(out: OutputBuffer) extends OutputBuffer {
+  def flush(): Unit = out.flush()
+
+  def close() {
+    out.close()
+  }
+
+  def writeByte(b: Byte): Unit = out.writeByte(b)
+
+  def writeInt(i: Int): Unit = {
+    var j = i
+    do {
+      var b = j & 0x7f
+      j >>>= 7
+      if (j != 0)
+        b |= 0x80
+      out.writeByte(b.toByte)
+    } while (j != 0)
+  }
+
+  def writeLong(l: Long): Unit = {
+    var j = l
+    do {
+      var b = j & 0x7f
+      j >>>= 7
+      if (j != 0)
+        b |= 0x80
+      out.writeByte(b.toByte)
+    } while (j != 0)
+  }
+
+  def writeFloat(f: Float): Unit = out.writeFloat(f)
+
+  def writeDouble(d: Double): Unit = out.writeDouble(d)
+
+  def writeBytes(region: Region, off: Long, n: Int): Unit = out.writeBytes(region, off, n)
 }
 
-class LZ4OutputBuffer(out: OutputStream) extends OutputBuffer {
-  val buf: Array[Byte] = new Array[Byte](LZ4Buffer.blockSize)
-  var off: Int = 0
+class LZ4OutputBlockBuffer(blockSize: Int, out: OutputBlockBuffer) extends OutputBlockBuffer {
+  private val comp = new Array[Byte](4 + LZ4Utils.maxCompressedLength(blockSize))
 
-  val comp = new Array[Byte](8 + LZ4Utils.maxCompressedLength(LZ4Buffer.blockSize))
+  def close() {
+    out.close()
+  }
+
+  def writeBlock(buf: Array[Byte], decompLen: Int): Unit = {
+    val compLen = LZ4Utils.compress(comp, 4, buf, decompLen)
+    Memory.storeInt(comp, 0, decompLen) // decompLen
+    out.writeBlock(comp, compLen + 4)
+  }
+}
+
+class BlockingOutputBuffer(blockSize: Int, out: OutputBlockBuffer) extends OutputBuffer {
+  private val buf: Array[Byte] = new Array[Byte](blockSize)
+  private var off: Int = 0
 
   private def writeBlock() {
-    if (off > 0) {
-      val compLen = LZ4Utils.compress(comp, 8, buf, off)
-      Memory.storeInt(comp, 0, compLen)
-      Memory.storeInt(comp, 4, off) // decompLen
-
-      out.write(comp, 0, 8 + compLen)
-
-      off = 0
-    }
+    out.writeBlock(buf, off)
+    off = 0
   }
 
   def flush() {
@@ -143,33 +398,17 @@ class LZ4OutputBuffer(out: OutputStream) extends OutputBuffer {
   }
 
   def writeInt(i: Int) {
-    if (off + 5 > buf.length)
+    if (off + 4 > buf.length)
       writeBlock()
-
-    var j = i
-    do {
-      var b = j & 0x7f
-      j >>>= 7
-      if (j != 0)
-        b |= 0x80
-      Memory.storeByte(buf, off, b.toByte)
-      off += 1
-    } while (j != 0)
+    Memory.storeInt(buf, off, i)
+    off += 4
   }
 
   def writeLong(l: Long) {
-    if (off + 10 > buf.length)
+    if (off + 8 > buf.length)
       writeBlock()
-
-    var j = l
-    do {
-      var b = j & 0x7f
-      j >>>= 7
-      if (j != 0)
-        b |= 0x80
-      Memory.storeByte(buf, off, b.toByte)
-      off += 1
-    } while (j != 0)
+    Memory.storeLong(buf, off, l)
+    off += 8
   }
 
   def writeFloat(f: Float) {
@@ -223,27 +462,71 @@ abstract class InputBuffer extends Closeable {
   def readBoolean(): Boolean = readByte() != 0
 }
 
-class LZ4InputBuffer(in: InputStream) extends InputBuffer {
-  private val buf = new Array[Byte](LZ4Buffer.blockSize)
+final class LEB128InputBuffer(in: InputBuffer) extends InputBuffer {
+  def close() {
+    in.close()
+  }
+
+  def readByte(): Byte = in.readByte()
+
+  def readInt(): Int = {
+    var b: Byte = readByte()
+    var x: Int = b & 0x7f
+    var shift: Int = 7
+    while ((b & 0x80) != 0) {
+      b = readByte()
+      x |= ((b & 0x7f) << shift)
+      shift += 7
+    }
+    x
+  }
+
+  def readLong(): Long = {
+    var b: Byte = readByte()
+    var x: Long = b & 0x7fL
+    var shift: Int = 7
+    while ((b & 0x80) != 0) {
+      b = readByte()
+      x |= ((b & 0x7fL) << shift)
+      shift += 7
+    }
+    x
+  }
+
+  def readFloat(): Float = in.readFloat()
+
+  def readDouble(): Double = in.readDouble()
+
+  def readBytes(toRegion: Region, toOff: Long, n: Int): Unit = in.readBytes(toRegion, toOff, n)
+}
+
+final class LZ4InputBlockBuffer(blockSize: Int, in: InputBlockBuffer) extends InputBlockBuffer {
+  private val comp = new Array[Byte](4 + LZ4Utils.maxCompressedLength(blockSize))
+
+  def close() {
+    in.close()
+  }
+
+  def readBlock(buf: Array[Byte]): Int = {
+    val blockLen = in.readBlock(comp)
+    val compLen = blockLen - 4
+    val decompLen = Memory.loadInt(comp, 0)
+
+    LZ4Utils.decompress(buf, 0, decompLen, comp, 4, compLen)
+
+    decompLen
+  }
+}
+
+class BlockingInputBuffer(blockSize: Int, in: InputBlockBuffer) extends InputBuffer {
+  private val buf = new Array[Byte](blockSize)
   private var end: Int = 0
   private var off: Int = 0
 
-  private val comp = new Array[Byte](8 + LZ4Utils.maxCompressedLength(LZ4Buffer.blockSize))
-
   private def readBlock() {
     assert(off == end)
-
-    // read the header
-    in.readFully(comp, 0, 4)
-    val compLen = Memory.loadInt(comp, 0)
-
-    in.readFully(comp, 4, 4 + compLen)
-    val decompLen = Memory.loadInt(comp, 4)
-
-    LZ4Utils.decompress(buf, 0, decompLen, comp, 8, compLen)
-
+    end = in.readBlock(buf)
     off = 0
-    end = decompLen
   }
 
   private def ensure(n: Int) {
@@ -264,37 +547,16 @@ class LZ4InputBuffer(in: InputStream) extends InputBuffer {
   }
 
   def readInt(): Int = {
-    ensure(1)
-
-    var b: Byte = Memory.loadByte(buf, off)
-    off += 1
-    var x: Int = b & 0x7f
-    var shift: Int = 7
-    while ((b & 0x80) != 0) {
-      b = Memory.loadByte(buf, off)
-      off += 1
-      x |= ((b & 0x7f) << shift)
-      shift += 7
-    }
-
-    x
+    ensure(4)
+    val i = Memory.loadInt(buf, off)
+    off += 4
+    i
   }
-
   def readLong(): Long = {
-    ensure(1)
-
-    var b: Byte = Memory.loadByte(buf, off)
-    off += 1
-    var x: Long = b & 0x7fL
-    var shift: Int = 7
-    while ((b & 0x80) != 0) {
-      b = Memory.loadByte(buf, off)
-      off += 1
-      x |= ((b & 0x7fL) << shift)
-      shift += 7
-    }
-
-    x
+    ensure(8)
+    val l  = Memory.loadLong(buf, off)
+    off += 8
+    l
   }
 
   def readFloat(): Float = {
@@ -329,7 +591,32 @@ class LZ4InputBuffer(in: InputStream) extends InputBuffer {
   }
 }
 
-final class Decoder(in: InputBuffer) extends Closeable {
+abstract class Decoder extends Closeable {
+  def close()
+
+  def readRegionValue(t: Type, region: Region): Long
+
+  def readByte(): Byte
+}
+
+final class DirectDecoder(in: InputBuffer) extends Decoder {
+  def close() {
+    in.close()
+  }
+
+  def readRegionValue(t: Type, region: Region): Long = {
+    val size = in.readInt()
+    val off = region.allocate(t.alignment, size)
+    assert(off == 0)
+    in.readBytes(region, 0, size)
+
+    in.readInt() // offset
+  }
+
+  def readByte(): Byte = in.readByte()
+}
+
+final class PackDecoder(in: InputBuffer) extends Decoder {
   def close() {
     in.close()
   }
@@ -431,7 +718,38 @@ final class Decoder(in: InputBuffer) extends Closeable {
   }
 }
 
-final class Encoder(out: OutputBuffer) extends Closeable {
+abstract class Encoder extends Closeable {
+  def flush(): Unit
+
+  def close(): Unit
+
+  def writeRegionValue(t: Type, region: Region, offset: Long): Unit
+
+  def writeByte(b: Byte): Unit
+}
+
+final class DirectEncoder(out: OutputBuffer) extends Encoder {
+  def flush() {
+    out.flush()
+  }
+
+  def close() {
+    out.close()
+  }
+
+  def writeRegionValue(t: Type, region: Region, offset: Long) {
+    assert(region.size <= Int.MaxValue)
+    out.writeInt(region.size.toInt)
+    out.writeBytes(region, 0, region.size.toInt)
+
+    assert(offset <= Int.MaxValue)
+    out.writeInt(offset.toInt)
+  }
+
+  def writeByte(b: Byte): Unit = out.writeByte(b)
+}
+
+final class PackEncoder(out: OutputBuffer) extends Encoder {
   def flush() {
     out.flush()
   }
@@ -526,8 +844,8 @@ final class Encoder(out: OutputBuffer) extends Closeable {
 }
 
 object RichRDDRegionValue {
-  def writeRowsPartition(t: TStruct)(i: Int, it: Iterator[RegionValue], os: OutputStream): Long = {
-    val en = new Encoder(new LZ4OutputBuffer(os))
+  def writeRowsPartition(t: TStruct, codecSpec: CodecSpec)(i: Int, it: Iterator[RegionValue], os: OutputStream): Long = {
+    val en = codecSpec.buildEncoder(os)
     var rowCount = 0L
 
     it.foreach { rv =>
@@ -545,11 +863,11 @@ object RichRDDRegionValue {
 }
 
 class RichRDDRegionValue(val rdd: RDD[RegionValue]) extends AnyVal {
-  def writeRows(path: String, t: TStruct): (Array[String], Array[Long]) = {
-    rdd.writePartitions(path, RichRDDRegionValue.writeRowsPartition(t))
+  def writeRows(path: String, t: TStruct, codecSpec: CodecSpec): (Array[String], Array[Long]) = {
+    rdd.writePartitions(path, RichRDDRegionValue.writeRowsPartition(t, codecSpec))
   }
 
-  def writeRowsSplit(path: String, t: MatrixType, partitioner: OrderedRVDPartitioner): Array[Long] = {
+  def writeRowsSplit(path: String, t: MatrixType, codecSpec: CodecSpec, partitioner: OrderedRVDPartitioner): Array[Long] = {
     val sc = rdd.sparkContext
     val hConf = sc.hadoopConfiguration
 
@@ -577,11 +895,11 @@ class RichRDDRegionValue(val rdd: RDD[RegionValue]) extends AnyVal {
 
       val rowsPartPath = path + "/rows/rows/parts/" + f
       hConf.writeFile(rowsPartPath) { rowsOS =>
-        using(new Encoder(new LZ4OutputBuffer(rowsOS))) { rowsEN =>
+        using(codecSpec.buildEncoder(rowsOS)) { rowsEN =>
 
           val entriesPartPath = path + "/entries/rows/parts/" + f
           hConf.writeFile(entriesPartPath) { entriesOS =>
-            using(new Encoder(new LZ4OutputBuffer(entriesOS))) { entriesEN =>
+            using(codecSpec.buildEncoder(entriesOS)) { entriesEN =>
 
               var rowCount = 0L
 
@@ -623,11 +941,12 @@ class RichRDDRegionValue(val rdd: RDD[RegionValue]) extends AnyVal {
       .collect()
 
     val rowsSpec = OrderedRVDSpec(t.rowORVDType,
+      codecSpec,
       partFiles,
       JSONAnnotationImpex.exportAnnotation(partitioner.rangeBounds, partitioner.rangeBoundsType))
     rowsSpec.write(hConf, path + "/rows/rows")
 
-    val entriesSpec = UnpartitionedRVDSpec(entriesRVType, partFiles)
+    val entriesSpec = UnpartitionedRVDSpec(entriesRVType, codecSpec, partFiles)
     entriesSpec.write(hConf, path + "/entries/rows")
 
     info(s"wrote ${ partitionCounts.sum } items in $nPartitions partitions")

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -5,6 +5,7 @@ import java.util
 import is.hail.annotations._
 import is.hail.expr.JSONAnnotationImpex
 import is.hail.expr.types._
+import is.hail.io.CodecSpec
 import is.hail.sparkextras._
 import is.hail.utils._
 import org.apache.spark.rdd.{RDD, ShuffledRDD}
@@ -414,10 +415,11 @@ class OrderedRVD private(
     OrderedRVD(typ, newPartitioner, rdd.subsetPartitions(keep))
   }
 
-  def write(path: String): Array[Long] = {
-    val (partFiles, partitionCounts) = rdd.writeRows(path, rowType)
+  def write(path: String, codecSpec: CodecSpec): Array[Long] = {
+    val (partFiles, partitionCounts) = rdd.writeRows(path, rowType, codecSpec)
     val spec = OrderedRVDSpec(
       typ,
+      codecSpec,
       partFiles,
       JSONAnnotationImpex.exportAnnotation(partitioner.rangeBounds, partitioner.rangeBoundsType))
     spec.write(sparkContext.hadoopConfiguration, path)

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -4,7 +4,7 @@ import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.expr.{JSONAnnotationImpex, Parser}
 import is.hail.expr.types.{TArray, TStruct, TStructSerializer}
-import is.hail.io.{CodecSpec, RichRDDRegionValue}
+import is.hail.io._
 import is.hail.utils._
 import org.apache.hadoop
 import org.apache.spark.{Partition, SparkContext}
@@ -19,7 +19,10 @@ import scala.reflect.ClassTag
 object RVDSpec {
   implicit val formats: Formats = new DefaultFormats() {
     override val typeHints = ShortTypeHints(List(
-      classOf[RVDSpec], classOf[UnpartitionedRVDSpec], classOf[OrderedRVDSpec]))
+      classOf[RVDSpec], classOf[UnpartitionedRVDSpec], classOf[OrderedRVDSpec],
+      classOf[CodecSpec], classOf[DirectCodecSpec], classOf[PackCodecSpec],
+      classOf[BlockBufferSpec], classOf[LZ4BlockBufferSpec], classOf[StreamBlockBufferSpec],
+      classOf[BufferSpec], classOf[LEB128BufferSpec], classOf[BlockingBufferSpec]))
     override val typeHintFieldName = "name" } +
     new TStructSerializer +
     new OrderedRVDTypeSerializer

--- a/src/main/scala/is/hail/rvd/UnpartitionedRVD.scala
+++ b/src/main/scala/is/hail/rvd/UnpartitionedRVD.scala
@@ -3,6 +3,7 @@ package is.hail.rvd
 import is.hail.annotations.RegionValue
 import is.hail.utils._
 import is.hail.expr.types.TStruct
+import is.hail.io.CodecSpec
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
@@ -40,9 +41,9 @@ class UnpartitionedRVD(val rowType: TStruct, val rdd: RDD[RegionValue]) extends 
   def sample(withReplacement: Boolean, p: Double, seed: Long): UnpartitionedRVD =
     new UnpartitionedRVD(rowType, rdd.sample(withReplacement, p, seed))
 
-  def write(path: String): Array[Long] = {
-    val (partFiles, partitionCounts) = rdd.writeRows(path, rowType)
-    val spec = UnpartitionedRVDSpec(rowType, partFiles)
+  def write(path: String, codecSpec: CodecSpec): Array[Long] = {
+    val (partFiles, partitionCounts) = rdd.writeRows(path, rowType, codecSpec)
+    val spec = UnpartitionedRVDSpec(rowType, codecSpec, partFiles)
     spec.write(sparkContext.hadoopConfiguration, path)
     partitionCounts
   }

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -1124,8 +1124,9 @@ class Table(val hc: HailContext, val ir: TableIR) {
   def write(path: String, overwrite: Boolean = false, codecSpecJSONStr: String = null) {
     val codecSpec =
       if (codecSpecJSONStr != null) {
+        implicit val formats = RVDSpec.formats
         val codecSpecJSON = JsonMethods.parse(codecSpecJSONStr)
-        CodecSpec.extract(codecSpecJSON)
+        codecSpecJSON.extract[CodecSpec]
       } else
         CodecSpec.default
 

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -2556,8 +2556,9 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   def write(path: String, overwrite: Boolean = false, codecSpecJSONStr: String = null): Unit = {
     val codecSpec =
       if (codecSpecJSONStr != null) {
+        implicit val formats = RVDSpec.formats
         val codecSpecJSON = parse(codecSpecJSONStr)
-        CodecSpec.extract(codecSpecJSON)
+        codecSpecJSON.extract[CodecSpec]
       } else
         CodecSpec.default
 

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -12,6 +12,7 @@ import is.hail.stats.RegressionUtils
 import is.hail.utils._
 import is.hail.{HailContext, utils}
 import is.hail.expr.types._
+import is.hail.io.CodecSpec
 import org.apache.hadoop
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix}
@@ -1389,6 +1390,8 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
   def countVariants(): Long = partitionCounts().sum
 
+  def forceCountRows(): Long = rvd.count()
+
   def deduplicate(): MatrixTable =
     copy2(rvd = rvd.mapPartitionsPreservesPartitioning(rvd.typ)(
       SortedDistinctRowIterator.transformer(rvd.typ)))
@@ -2516,8 +2519,8 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
 
-  def writeCols(path: String) {
-    val partitionCounts = RVD.writeLocalUnpartitioned(hc, path + "/rows", matrixType.colType, colValues)
+  def writeCols(path: String, codecSpec: CodecSpec) {
+    val partitionCounts = RVD.writeLocalUnpartitioned(hc, path + "/rows", matrixType.colType, codecSpec, colValues)
 
     val colsSpec = TableSpec(
       FileFormat.version.rep,
@@ -2532,10 +2535,10 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     hadoopConf.writeTextFile(path + "/_SUCCESS")(out => ())
   }
 
-  def writeGlobals(path: String) {
-    val partitionCounts = RVD.writeLocalUnpartitioned(hc, path + "/rows", matrixType.globalType, Array(globals))
+  def writeGlobals(path: String, codecSpec: CodecSpec) {
+    val partitionCounts = RVD.writeLocalUnpartitioned(hc, path + "/rows", matrixType.globalType, codecSpec, Array(globals))
 
-    RVD.writeLocalUnpartitioned(hc, path + "/globals", TStruct.empty(), Array[Annotation](Row()))
+    RVD.writeLocalUnpartitioned(hc, path + "/globals", TStruct.empty(), codecSpec, Array[Annotation](Row()))
 
     val globalsSpec = TableSpec(
       FileFormat.version.rep,
@@ -2550,7 +2553,14 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     hadoopConf.writeTextFile(path + "/_SUCCESS")(out => ())
   }
 
-  def write(path: String, overwrite: Boolean = false): Unit = {
+  def write(path: String, overwrite: Boolean = false, codecSpecJSONStr: String = null): Unit = {
+    val codecSpec =
+      if (codecSpecJSONStr != null) {
+        val codecSpecJSON = parse(codecSpecJSONStr)
+        CodecSpec.extract(codecSpecJSON)
+      } else
+        CodecSpec.default
+
     if (overwrite)
       hadoopConf.delete(path, recursive = true)
     else if (hadoopConf.exists(path))
@@ -2558,11 +2568,11 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
     hc.hadoopConf.mkDir(path)
 
-    val partitionCounts = rvd.rdd.writeRowsSplit(path, matrixType, rvd.partitioner)
+    val partitionCounts = rvd.rdd.writeRowsSplit(path, matrixType, codecSpec, rvd.partitioner)
 
     val globalsPath = path + "/globals"
     hadoopConf.mkDir(globalsPath)
-    writeGlobals(globalsPath)
+    writeGlobals(globalsPath, codecSpec)
 
     val rowsSpec = TableSpec(
       FileFormat.version.rep,
@@ -2589,7 +2599,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     hadoopConf.writeTextFile(path + "/entries/_SUCCESS")(out => ())
 
     hadoopConf.mkDir(path + "/cols")
-    writeCols(path + "/cols")
+    writeCols(path + "/cols", codecSpec)
 
     val refPath = path + "/references"
     hc.hadoopConf.mkDir(refPath)

--- a/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
+++ b/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
@@ -1,16 +1,12 @@
 package is.hail.annotations
 
 import is.hail.SparkSuite
-import is.hail.expr._
 import is.hail.expr.types._
-import is.hail.methods.SplitMulti
 import is.hail.utils._
 import is.hail.testUtils._
 import is.hail.variant.Variant
-import org.apache.spark.sql.types._
 import org.testng.annotations.Test
 
-import scala.collection.mutable
 import scala.language.implicitConversions
 
 /**

--- a/src/test/scala/is/hail/annotations/UnsafeSuite.scala
+++ b/src/test/scala/is/hail/annotations/UnsafeSuite.scala
@@ -27,10 +27,7 @@ class UnsafeSuite extends SparkSuite {
     val p = Prop.forAll(g) { case (t, a) =>
       t.typeCheck(a)
 
-      println("loop")
       CodecSpec.codecSpecs.foreach { codecSpec =>
-        println(JsonMethods.compact(JsonMethods.render(codecSpec.toJSON)))
-
         region.clear()
         rvb.start(t)
         rvb.addRow(t, a.asInstanceOf[Row])

--- a/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
@@ -3,23 +3,19 @@ package is.hail.variant.vsm
 import breeze.linalg.DenseMatrix
 import is.hail.annotations._
 import is.hail.check.Prop._
-import is.hail.check.{Gen, Parameters}
+import is.hail.check.Parameters
 import is.hail.distributedmatrix.{BlockMatrix, KeyedBlockMatrix, Keys}
 import is.hail.expr.types._
-import is.hail.table.Table
 import is.hail.utils._
 import is.hail.testUtils._
 import is.hail.variant._
 import is.hail.{SparkSuite, TestUtils}
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics
 import org.apache.commons.math3.stat.regression.SimpleRegression
-import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
-import scala.collection.mutable
 import scala.language.postfixOps
-import scala.util.Random
 
 class VSMSuite extends SparkSuite {
 


### PR DESCRIPTION
 - made decoder stuff modular/composable
 - CodecSpec, stored in RVDSpec (and hence in metadata) describes the en/decoding process
 - exposed to Python (private parameter in MT and Table.write)
