### PR TITLE
Block matrix explode

### DIFF
--- a/python/hail/linalg/matrix.py
+++ b/python/hail/linalg/matrix.py
@@ -2,9 +2,12 @@ from hail.utils import new_temp_file, storage_level
 from hail.utils.java import Env, handle_py4j, scala_object, jarray, numpy_from_breeze
 from hail.typecheck import *
 from hail.matrixtable import MatrixTable
+from hail.table import Table
 from hail.expr.expression import expr_numeric, to_expr, analyze
+import numpy as np
 
 block_matrix_type = lazy()
+
 
 class BlockMatrix(object):
 
@@ -19,6 +22,42 @@ class BlockMatrix(object):
         hc = Env.hc()
         return cls(Env.hail().distributedmatrix.BlockMatrix.read(
             hc._jhc, path))
+
+    @staticmethod
+    @handle_py4j
+    def _from_numpy_matrix(numpy_matrix, block_size):
+        """Create a block matrix from a NumPy matrix.
+
+        Notes
+        -----
+
+        This method is useful for creating small block matrices when writing tests. It is not
+        efficient for large matrices.
+
+        Parameters
+        ----------
+        numpy_matrix : NumPy matrix
+
+        Returns
+        -------
+        :class:`.BlockMatrix`
+        """
+        # convert to float64 to ensure that jarray method below works
+        numpy_matrix = numpy_matrix.astype(np.float64)
+        num_rows, num_cols = numpy_matrix.shape[0:2]
+        sc = Env.hc()._jsc
+        # np.ravel() exports row major by default
+        data = jarray(Env.jvm().double, np.ravel(numpy_matrix))
+        # breeze is column major
+        is_transpose = True
+
+        block_matrix_constructor = getattr(Env.hail().distributedmatrix.BlockMatrix, "from")
+        breeze_matrix_constructor = getattr(Env.hail().utils.richUtils.RichDenseMatrixDouble, 'from')
+
+        return BlockMatrix(
+            block_matrix_constructor(sc,
+                                     breeze_matrix_constructor(num_rows, num_cols, data, is_transpose),
+                                     block_size))
 
     @classmethod
     @handle_py4j
@@ -46,7 +85,7 @@ class BlockMatrix(object):
     def random(num_rows, num_cols, block_size, seed=0, gaussian=False):
         hc = Env.hc()
         return BlockMatrix(scala_object(Env.hail().distributedmatrix, 'BlockMatrix').random(
-                hc._jhc, num_rows, num_cols, block_size, seed, gaussian))
+            hc._jhc, num_rows, num_cols, block_size, seed, gaussian))
 
     def __init__(self, jbm):
         self._jbm = jbm
@@ -80,13 +119,13 @@ class BlockMatrix(object):
     @typecheck_method(rows_to_keep=listof(integral))
     def filter_rows(self, rows_to_keep):
         return BlockMatrix(self._jbm.filterRows(jarray(Env.jvm().long, rows_to_keep)))
-    
+
     @handle_py4j
     @typecheck_method(rows_to_keep=listof(integral),
                       cols_to_keep=listof(integral))
     def filter(self, rows_to_keep, cols_to_keep):
         return BlockMatrix(self._jbm.filter(jarray(Env.jvm().long, rows_to_keep),
-                             jarray(Env.jvm().long, cols_to_keep)))
+                                            jarray(Env.jvm().long, cols_to_keep)))
 
     @property
     @handle_py4j
@@ -122,6 +161,41 @@ class BlockMatrix(object):
     def dot(self, that):
         return BlockMatrix(self._jbm.multiply(that._jbm))
 
+    def entries_table(self):
+        """Returns a table with the coordinates and numeric value of each block matrix entry.
+
+        Examples
+        --------
+
+        >>> from hail.linalg import BlockMatrix
+        >>> import numpy as np
+        >>> block_matrix = BlockMatrix._from_numpy_matrix(np.matrix([[5, 7], [2, 8]]), 2)
+        >>> entries_table = block_matrix.entries_table()
+        >>> entries_table.show()
+        +--------+--------+-------------+
+        |      i |      j |       entry |
+        +--------+--------+-------------+
+        | !Int64 | !Int64 |    !Float64 |
+        +--------+--------+-------------+
+        |      0 |      0 | 5.00000e+00 |
+        |      0 |      1 | 7.00000e+00 |
+        |      1 |      0 | 2.00000e+00 |
+        |      1 |      1 | 8.00000e+00 |
+        +--------+--------+-------------+
+
+        Warning
+        -------
+        The resulting table may be filtered, aggregated, and queried, but should only be
+        directly exported to disk if the block matrix is very small.
+
+        Returns
+        -------
+        :class:`.Table`
+            Table with a row for each entry.
+        """
+        hc = Env.hc()
+        return Table(self._jbm.entriesTable(hc._jhc))
+
     @handle_py4j
     @typecheck_method(i=numeric)
     def __mul__(self, i):
@@ -130,6 +204,7 @@ class BlockMatrix(object):
     @handle_py4j
     @typecheck_method(i=numeric)
     def __div__(self, i):
-        return self * (1./i)
+        return self * (1. / i)
+
 
 block_matrix_type.set(BlockMatrix)

--- a/python/hail/methods/tests.py
+++ b/python/hail/methods/tests.py
@@ -39,7 +39,7 @@ class Tests(unittest.TestCase):
             threshold_string = "{} {}".format("--min {}".format(min) if min else "",
                                               "--max {}".format(max) if max else "")
 
-            plink_command = "plink --double-id --allow-extra-chr --vcf {} --genome full --out {} {}"\
+            plink_command = "plink --double-id --allow-extra-chr --vcf {} --genome full --out {} {}" \
                 .format(utils.get_URI(vcf),
                         utils.get_URI(plinkpath),
                         threshold_string)
@@ -91,17 +91,17 @@ class Tests(unittest.TestCase):
         dataset = methods.import_vcf(test_file('regressionLinear.vcf'))
 
         phenos = methods.import_table(test_file('regressionLinear.pheno'),
-                                 types={'Pheno': TFloat64()},
-                                 key='Sample')
+                                      types={'Pheno': TFloat64()},
+                                      key='Sample')
         covs = methods.import_table(test_file('regressionLinear.cov'),
-                               types={'Cov1': TFloat64(), 'Cov2': TFloat64()},
-                               key='Sample')
+                                    types={'Cov1': TFloat64(), 'Cov2': TFloat64()},
+                                    key='Sample')
 
-        dataset = dataset.annotate_cols(pheno=phenos[dataset.s], cov = covs[dataset.s])
+        dataset = dataset.annotate_cols(pheno=phenos[dataset.s], cov=covs[dataset.s])
         dataset = methods.linreg(dataset,
-                         ys=dataset.pheno,
-                         x=dataset.GT.num_alt_alleles(),
-                         covariates=[dataset.cov.Cov1, dataset.cov.Cov2 + 1 - 1])
+                                 ys=dataset.pheno,
+                                 x=dataset.GT.num_alt_alleles(),
+                                 covariates=[dataset.cov.Cov1, dataset.cov.Cov2 + 1 - 1])
 
         dataset.count_rows()
 
@@ -110,7 +110,7 @@ class Tests(unittest.TestCase):
         fam_table = methods.import_fam(test_file('triomatrix.fam'))
 
         dataset = methods.import_vcf(test_file('triomatrix.vcf'))
-        dataset = dataset.annotate_cols(fam = fam_table[dataset.s])
+        dataset = dataset.annotate_cols(fam=fam_table[dataset.s])
 
         tm = methods.trio_matrix(dataset, ped, complete_trios=True)
 
@@ -135,9 +135,9 @@ class Tests(unittest.TestCase):
         def load_rel(ns, path):
             rel = np.zeros((ns, ns))
             with hadoop_read(path) as f:
-                for i,l in enumerate(f):
-                    for j,n in enumerate(map(float, l.strip().split('\t'))):
-                        rel[i,j] = n
+                for i, l in enumerate(f):
+                    for j, n in enumerate(map(float, l.strip().split('\t'))):
+                        rel[i, j] = n
                     self.assertEqual(j, i)
                 self.assertEqual(i, ns - 1)
             return rel
@@ -149,7 +149,7 @@ class Tests(unittest.TestCase):
                 for l in f:
                     row = l.strip().split('\t')
                     self.assertEqual(int(row[2]), nv)
-                    m[int(row[0])-1, int(row[1])-1] = float(row[3])
+                    m[int(row[0]) - 1, int(row[1]) - 1] = float(row[3])
                     i += 1
 
                 self.assertEqual(i, ns * (ns + 1) / 2)
@@ -178,11 +178,11 @@ class Tests(unittest.TestCase):
         dataset = self.get_dataset()
         n_samples = dataset.count_cols()
         dataset = dataset.annotate_rows(AC=agg.sum(dataset.GT.num_alt_alleles()),
-                              n_called=agg.count_where(functions.is_defined(dataset.GT)))
+                                        n_called=agg.count_where(functions.is_defined(dataset.GT)))
         dataset = dataset.filter_rows((dataset.AC > 0) & (dataset.AC < 2 * dataset.n_called))
         dataset = dataset.filter_rows(dataset.n_called == n_samples).persist()
 
-        methods.export_plink(dataset, b_file, id = dataset.s)
+        methods.export_plink(dataset, b_file, id=dataset.s)
 
         sample_ids = [row.s for row in dataset.cols_table().select('s').collect()]
         n_variants = dataset.count_rows()
@@ -202,8 +202,8 @@ class Tests(unittest.TestCase):
         grm.export_rel(rel_file)
         self.assertEqual(load_id_file(rel_id_file), sample_ids)
         self.assertTrue(np.allclose(load_rel(n_samples, p_file + ".rel"),
-                           load_rel(n_samples, rel_file),
-                           atol=tolerance))
+                                    load_rel(n_samples, rel_file),
+                                    atol=tolerance))
 
         ############
         ### gcta-grm
@@ -215,8 +215,8 @@ class Tests(unittest.TestCase):
 
         grm.export_gcta_grm(grm_file)
         self.assertTrue(np.allclose(load_grm(n_samples, n_variants, p_file + ".grm.gz"),
-                           load_grm(n_samples, n_variants, grm_file),
-                           atol=tolerance))
+                                    load_grm(n_samples, n_variants, grm_file),
+                                    atol=tolerance))
 
         ############
         ### gcta-grm-bin
@@ -230,11 +230,20 @@ class Tests(unittest.TestCase):
         grm.export_gcta_grm_bin(grm_bin_file, grm_nbin_file)
 
         self.assertTrue(np.allclose(load_bin(n_samples, p_file + ".grm.bin"),
-                           load_bin(n_samples, grm_bin_file),
-                           atol=tolerance))
+                                    load_bin(n_samples, grm_bin_file),
+                                    atol=tolerance))
         self.assertTrue(np.allclose(load_bin(n_samples, p_file + ".grm.N.bin"),
-                           load_bin(n_samples, grm_nbin_file),
-                           atol=tolerance))
+                                    load_bin(n_samples, grm_nbin_file),
+                                    atol=tolerance))
+
+    def test_block_matrix_from_numpy_matrix(self):
+        numpy_matrix = np.matrix([[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [10, 11, 12, 13, 14]])
+
+        for block_size in [1, 2, 5, 1024]:
+            block_matrix = BlockMatrix._from_numpy_matrix(numpy_matrix, block_size)
+            assert (block_matrix.num_rows == 3)
+            assert (block_matrix.num_cols == 5)
+            assert (block_matrix.to_numpy_matrix() == numpy_matrix).all()
 
     def test_rrm(self):
         seed = 0
@@ -259,16 +268,16 @@ class Tests(unittest.TestCase):
 
             nvariants, nsamples = ds.shape
             sumgt = lambda r: sum([i for i in r if i >= 0])
-            sumsq = lambda r: sum([i**2 for i in r if i >= 0])
+            sumsq = lambda r: sum([i ** 2 for i in r if i >= 0])
 
             mean = [sumgt(row) / nsamples for row in ds]
             stddev = [sqrt(sumsq(row) / nsamples - mean[i] ** 2)
                       for i, row in enumerate(ds)]
 
-            mat = np.array([[(g-mean[i])/stddev[i] for g in row] for i, row in enumerate(ds)])
+            mat = np.array([[(g - mean[i]) / stddev[i] for g in row] for i, row in enumerate(ds)])
 
             rrm = mat.T.dot(mat) / nvariants
-            
+
             return rrm
 
         def hail_calculation(ds):
@@ -311,7 +320,7 @@ class Tests(unittest.TestCase):
         t.count()
 
     def test_rename_duplicates(self):
-        dataset = self.get_dataset() # FIXME - want to rename samples with same id
+        dataset = self.get_dataset()  # FIXME - want to rename samples with same id
         renamed_ids = methods.rename_duplicates(dataset).cols_table().select('s').collect()
         self.assertTrue(len(set(renamed_ids)), len(renamed_ids))
 
@@ -319,13 +328,14 @@ class Tests(unittest.TestCase):
         ds1 = methods.import_vcf(test_file('split_test.vcf'))
         ds1 = methods.split_multi_hts(ds1)
         ds2 = methods.import_vcf(test_file('split_test_b.vcf'))
-        self.assertEqual(ds1.aggregate_entries(foo = agg.product((ds1.wasSplit == (ds1.v.start != 1180)).to_int32())).foo, 1)
-        ds1 = ds1.drop('wasSplit','aIndex')
+        self.assertEqual(ds1.aggregate_entries(foo=agg.product((ds1.wasSplit == (ds1.v.start != 1180)).to_int32())).foo,
+                         1)
+        ds1 = ds1.drop('wasSplit', 'aIndex')
         # required python3
         # self.assertTrue(ds1._same(ds2))
 
         ds = self.get_dataset()
-        ds = ds.annotate_entries(X = ds.GT)
+        ds = ds.annotate_entries(X=ds.GT)
         self.assertRaisesRegexp(utils.FatalError,
                                 "split_multi_hts: entry schema must be the HTS genotype schema",
                                 methods.split_multi_hts,
@@ -410,25 +420,26 @@ class Tests(unittest.TestCase):
 
     def test_export_plink(self):
         ds = self.get_dataset()
-        
-        methods.export_plink(ds, '/tmp/plink_example', id = ds.s)
-        
-        methods.export_plink(ds, '/tmp/plink_example2', id = ds.s, fam_id = ds.s, pat_id = "nope",
-                             mat_id = "nada", is_female = True, is_case = False)
-        
-        methods.export_plink(ds, '/tmp/plink_example3', id = ds.s, fam_id = ds.s, pat_id = "nope",
-                             mat_id = "nada", is_female = True, quant_pheno = ds.s.length().to_float64())
-        
-        self.assertRaises(ValueError, lambda: methods.export_plink(ds, '/tmp/plink_example', is_case = True, quant_pheno = 0.0))
-        
-        self.assertRaises(ValueError, lambda: methods.export_plink(ds, '/tmp/plink_example', foo = 0.0))
-        
-        self.assertRaises(TypeError, lambda: methods.export_plink(ds, '/tmp/plink_example', is_case = 0.0))
-        
+
+        methods.export_plink(ds, '/tmp/plink_example', id=ds.s)
+
+        methods.export_plink(ds, '/tmp/plink_example2', id=ds.s, fam_id=ds.s, pat_id="nope",
+                             mat_id="nada", is_female=True, is_case=False)
+
+        methods.export_plink(ds, '/tmp/plink_example3', id=ds.s, fam_id=ds.s, pat_id="nope",
+                             mat_id="nada", is_female=True, quant_pheno=ds.s.length().to_float64())
+
+        self.assertRaises(ValueError,
+                          lambda: methods.export_plink(ds, '/tmp/plink_example', is_case=True, quant_pheno=0.0))
+
+        self.assertRaises(ValueError, lambda: methods.export_plink(ds, '/tmp/plink_example', foo=0.0))
+
+        self.assertRaises(TypeError, lambda: methods.export_plink(ds, '/tmp/plink_example', is_case=0.0))
+
         # FIXME still resolving: these should throw an error due to unexpected row / entry indicies, still looking into why a more cryptic error is being thrown
         # self.assertRaises(ExpressionException, lambda: methods.export_plink(ds, '/tmp/plink_example', id = ds.v.contig))
         # self.assertRaises(ExpressionException, lambda: methods.export_plink(ds, '/tmp/plink_example', id = ds.GT))
-        
+
     def test_tdt(self):
         pedigree = Pedigree.read(test_file('tdt.fam'))
         tdt_tab = (methods.tdt(
@@ -440,21 +451,21 @@ class Tests(unittest.TestCase):
             types={'POSITION': TInt32(), 'T': TInt32(), 'U': TInt32(),
                    'Chi2': TFloat64(), 'Pval': TFloat64()})
         truth = (truth
-            .transmute(v = functions.variant(truth.CHROM, truth.POSITION, truth.REF, [truth.ALT]))
+            .transmute(v=functions.variant(truth.CHROM, truth.POSITION, truth.REF, [truth.ALT]))
             .key_by('v'))
-        
+
         if tdt_tab.count() != truth.count():
-           self.fail('Result has {} rows but should have {} rows'.format(tdt_tab.count(), truth.count()))
+            self.fail('Result has {} rows but should have {} rows'.format(tdt_tab.count(), truth.count()))
 
         bad = (tdt_tab.filter(functions.is_nan(tdt_tab.pval), keep=False)
             .join(truth.filter(functions.is_nan(truth.Pval), keep=False), how='outer'))
-        
+
         bad = bad.filter(~(
-            (bad.t == bad.T) &
-            (bad.u == bad.U) &
-            ((bad.chi2 - bad.Chi2).abs() < 0.001) &
-            ((bad.pval - bad.Pval).abs() < 0.001)))
-        
+                (bad.t == bad.T) &
+                (bad.u == bad.U) &
+                ((bad.chi2 - bad.Chi2).abs() < 0.001) &
+                ((bad.pval - bad.Pval).abs() < 0.001)))
+
         if bad.count() != 0:
             bad.order_by(asc(bad.v)).show()
             self.fail('Found rows in violation of the predicate (see show output)')
@@ -462,7 +473,7 @@ class Tests(unittest.TestCase):
     def test_maximal_independent_set(self):
         # prefer to remove nodes with higher index
         t = Table.range(10)
-        graph = t.select(i = t.idx, j = t.idx + 10)
+        graph = t.select(i=t.idx, j=t.idx + 10)
         mis = methods.maximal_independent_set(graph.i, graph.j, lambda l, r: l - r)
         self.assertEqual(sorted(mis), range(0, 10))
 
@@ -475,12 +486,12 @@ class Tests(unittest.TestCase):
             ds = methods.import_vcf(path)
             self.assertEqual(
                 methods.FilterAlleles(functions.range(0, ds.v.num_alt_alleles()).map(lambda i: False))
-                .filter()
-                .count_rows(), 0)
+                    .filter()
+                    .count_rows(), 0)
             self.assertEqual(
                 methods.FilterAlleles(functions.range(0, ds.v.num_alt_alleles()).map(lambda i: True))
-                .filter()
-                .count_rows(), ds.count_rows())
+                    .filter()
+                    .count_rows(), ds.count_rows())
 
     def test_filter_alleles2(self):
         # 1 variant: A:T,G
@@ -516,6 +527,20 @@ class Tests(unittest.TestCase):
             methods.import_vcf(test_file('sample.vcf')))
         methods.ld_prune(ds, 8).count_rows()
 
+    def test_entries_table(self):
+        num_rows, num_cols = 5, 3
+        rows = [{'i': i, 'j': j, 'entry': float(i + j)} for i in range(num_rows) for j in range(num_cols)]
+        schema = TStruct(['i', 'j', 'entry'], [TInt64(required=True), TInt64(required=True), TFloat64(required=True)])
+        table = Table.parallelize(rows, schema)
+        numpy_matrix = np.reshape(map(lambda row: row['entry'], rows), (num_rows, num_cols))
+
+        for block_size in [1, 2, 1024]:
+            block_matrix = BlockMatrix._from_numpy_matrix(numpy_matrix, block_size)
+            entries_table = block_matrix.entries_table()
+            self.assertEqual(entries_table.count(), num_cols * num_rows)
+            self.assertEqual(entries_table.num_columns, 3)
+            self.assertTrue(table._same(entries_table))
+
     def test_min_rep(self):
         # FIXME actually test
         ds = self.get_dataset()
@@ -530,10 +555,10 @@ class Tests(unittest.TestCase):
         from hail.stats import TruncatedBetaDist
 
         ds = methods.balding_nichols_model(2, 20, 25, 3,
-                 pop_dist=[1.0, 2.0],
-                 fst=[.02, .06],
-                 af_dist=TruncatedBetaDist(a=0.01, b=2.0, min=0.05, max=0.95),
-                 seed=1)
+                                           pop_dist=[1.0, 2.0],
+                                           fst=[.02, .06],
+                                           af_dist=TruncatedBetaDist(a=0.01, b=2.0, min=0.05, max=0.95),
+                                           seed=1)
 
         self.assertEqual(ds.count_cols(), 20)
         self.assertEqual(ds.count_rows(), 25)
@@ -553,32 +578,32 @@ class Tests(unittest.TestCase):
         ds2 = methods.import_vcf(test_file('sample2.vcf'))
 
         covariatesSkat = (methods
-                          .import_table(test_file("skat.cov"), impute=True)
-                          .key_by("Sample"))
+            .import_table(test_file("skat.cov"), impute=True)
+            .key_by("Sample"))
 
         phenotypesSkat = (methods.import_table(test_file("skat.pheno"),
                                                types={"Pheno": TFloat64()},
                                                missing="0")
-                          .key_by("Sample"))
+            .key_by("Sample"))
 
         intervalsSkat = (methods
-                         .import_interval_list(test_file("skat.interval_list")))
+            .import_interval_list(test_file("skat.interval_list")))
 
         weightsSkat = (methods.import_table(test_file("skat.weights"),
                                             types={"locus": TLocus(),
                                                    "weight": TFloat64()})
-                              .key_by("locus"))
+            .key_by("locus"))
 
         ds = methods.split_multi_hts(ds2)
-        ds = ds.annotate_rows(gene = intervalsSkat[ds.v],
-                              weight = weightsSkat[ds.v].weight)
-        ds = ds.annotate_cols(pheno = phenotypesSkat[ds.s],
-                                 cov = covariatesSkat[ds.s])
-        ds = ds.annotate_cols(pheno = functions.cond(ds.pheno == 1.0,
-            False,
-            functions.cond(ds.pheno == 2.0,
-                           True,
-                           functions.null(TBoolean()))))
+        ds = ds.annotate_rows(gene=intervalsSkat[ds.v],
+                              weight=weightsSkat[ds.v].weight)
+        ds = ds.annotate_cols(pheno=phenotypesSkat[ds.s],
+                              cov=covariatesSkat[ds.s])
+        ds = ds.annotate_cols(pheno=functions.cond(ds.pheno == 1.0,
+                                                   False,
+                                                   functions.cond(ds.pheno == 2.0,
+                                                                  True,
+                                                                  functions.null(TBoolean()))))
 
         methods.skat(ds,
                      key_expr=ds.gene,

--- a/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
@@ -10,7 +10,7 @@ import is.hail.utils._
 import org.apache.commons.lang3.StringUtils
 import org.json4s.jackson
 
-object RichDenseMatrixDouble {  
+object RichDenseMatrixDouble {
   // copies n doubles as bytes from data to dos
   def writeDoubles(dos: DataOutputStream, data: Array[Double], n: Int) {
     assert(n <= data.length)
@@ -21,7 +21,7 @@ object RichDenseMatrixDouble {
     var off = 0
     while (nLeft > 0) {
       val nCopy = math.min(nLeft, bufSize)
-      
+
       Memory.memcpy(buf, 0, data, off, nCopy)
       dos.write(buf, 0, nCopy << 3)
 
@@ -40,7 +40,7 @@ object RichDenseMatrixDouble {
     var off = 0
     while (nLeft > 0) {
       val nCopy = math.min(nLeft, bufSize)
-      
+
       dis.readFully(buf, 0, nCopy << 3)
       Memory.memcpy(data, off, buf, 0, nCopy)
 
@@ -48,7 +48,7 @@ object RichDenseMatrixDouble {
       nLeft -= nCopy
     }
   }
-  
+
   // assumes zero offset and minimal majorStride 
   def read(dis: DataInputStream): DenseMatrix[Double] = {
     val rows = dis.readInt()
@@ -57,13 +57,18 @@ object RichDenseMatrixDouble {
 
     val data = new Array[Double](rows * cols)
     readDoubles(dis, data, data.length)
-    
+
     new DenseMatrix[Double](rows, cols, data,
       offset = 0, majorStride = if (isTranspose) cols else rows, isTranspose = isTranspose)
   }
   
   def read(hc: HailContext, path: String): DenseMatrix[Double] = {
     hc.hadoopConf.readDataFile(path)(read)
+  }
+
+  def from(nRows: Int, nCols: Int, data: Array[Double], isTranspose: Boolean = false): DenseMatrix[Double] = {
+    return new DenseMatrix[Double](rows = nRows, cols = nCols, data = data,
+      offset = 0, majorStride = nCols, isTranspose = isTranspose)
   }
 }
 


### PR DESCRIPTION
Added methods to melt a BlockMatrix into a Table with the format: [row index, column index, entry]. Added method to make a Block Matrix from a numpy matrix in python, for testing the melt() method.