### PR TITLE
Fixed PCA docs and caching

### DIFF
--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -1300,7 +1300,7 @@ def hwe_normalized_pca(dataset, k=10, compute_loadings=False, as_array=False):
     Notes
     -----
 
-    This is a specialization of :meth:`.pca` above for the common use case
+    This is a specialization of :func:`.pca` for the common use case
     of PCA in statistical genetics, that of projecting samples to a small
     number of ancestry coordinates. Variants that are all homozygous reference
     or all homozygous alternate are unnormalizable and removed before
@@ -1311,7 +1311,8 @@ def hwe_normalized_pca(dataset, k=10, compute_loadings=False, as_array=False):
     :math:`ij` entry of the GRM :math:`MM^T` is simply the dot product of rows
     :math:`i` and :math:`j` of :math:`M`; in terms of :math:`C` it is
 
-    .. math:
+    .. math::
+    
       \\frac{1}{m}\sum_{l\in\mathcal{C}_i\cap\mathcal{C}_j}\\frac{(C_{il}-2p_l)(C_{jl} - 2p_l)}{2p_l(1-p_l)
 
     where :math:`\mathcal{C}_i = \{l \mid C_{il} \\text{ is non-missing}\}`. In
@@ -1405,7 +1406,7 @@ def pca(entry_expr, k=10, compute_loadings=False, as_array=False):
 
     PCA is run on the columns of the numeric matrix obtained by evaluating
     `entry_expr` on each entry of the matrix table, or equivalently on the rows
-    of the **transposed** numeric matrix :math:`M`.
+    of the **transposed** numeric matrix :math:`M` referenced below.
 
     PCA computes the SVD
 

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -1393,8 +1393,11 @@ def pca(entry_expr, k=10, compute_loadings=False, as_array=False):
 
     Warning
     -------
-      This method does not automatically mean-center each column. If desired,
-      mean-centering should be incorporated in `entry_expr`.
+      This method does **not** automatically mean-center or normalize each column.
+      If desired, such transformations should be incorporated in `entry_expr`.
+
+      Hail will return an error if `entry_expr` evaluates to missing, NaN, or
+      infinity on any entry.
 
     Notes
     -----

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -1289,7 +1289,8 @@ def skat(dataset, key_expr, weight_expr, y, x, covariates=[], logistic=False,
            compute_loadings=bool,
            as_array=bool)
 def hwe_normalized_pca(dataset, k=10, compute_loadings=False, as_array=False):
-    """Run principal component analysis (PCA) on the Hardy-Weinberg-normalized call matrix.
+    """Run principal component analysis (PCA) on the Hardy-Weinberg-normalized
+    genotype call matrix.
 
     Examples
     --------
@@ -1298,8 +1299,36 @@ def hwe_normalized_pca(dataset, k=10, compute_loadings=False, as_array=False):
 
     Notes
     -----
-    Variants that are all homozygous reference or all homozygous alternate
-    are removed before evaluation.
+
+    This is a specialization of :meth:`.pca` above for the common use case
+    of PCA in statistical genetics, that of projecting samples to a small
+    number of ancestry coordinates. Variants that are all homozygous reference
+    or all homozygous alternate are unnormalizable and removed before
+    evaluation.
+
+    Users of PLINK/GCTA should be aware that Hail computes the GRM slightly
+    differently with regard to missing data. In Hail, the
+    :math:`ij` entry of the GRM :math:`MM^T` is simply the dot product of rows
+    :math:`i` and :math:`j` of :math:`M`; in terms of :math:`C` it is
+
+    .. math:
+      \\frac{1}{m}\sum_{l\in\mathcal{C}_i\cap\mathcal{C}_j}\\frac{(C_{il}-2p_l)(C_{jl} - 2p_l)}{2p_l(1-p_l)
+
+    where :math:`\mathcal{C}_i = \{l \mid C_{il} \\text{ is non-missing}\}`. In
+    PLINK/GCTA the denominator :math:`m` is replaced with the number of terms in
+    the sum :math:`\\lvert\mathcal{C}_i\cap\\mathcal{C}_j\\rvert`, i.e. the
+    number of variants where both samples have non-missing genotypes. While this
+    is arguably a better estimator of the true GRM (trading shrinkage for
+    noise), it has the drawback that one loses the clean interpretation of the
+    loadings and scores as features and projections
+
+    Separately, for the PCs PLINK/GCTA output the eigenvectors of the GRM, i.e.
+    the left singular vectors :math:`U_k` instead of the component scores
+    :math:`U_k S_k`. The scores have the advantage of representing true
+    projections of the data onto features with the variance of a score
+    reflecting the variance explained by the corresponding feature. In PC
+    bi-plots this amounts to a change in aspect ratio; for use of PCs as
+    covariates in regression it is immaterial.
 
     Parameters
     ----------
@@ -1349,18 +1378,30 @@ def hwe_normalized_pca(dataset, k=10, compute_loadings=False, as_array=False):
            compute_loadings=bool,
            as_array=bool)
 def pca(entry_expr, k=10, compute_loadings=False, as_array=False):
-    """Run principal Component Analysis (PCA) on a matrix table, using `entry_expr` as the numerical entry.
+    """Run principal component analysis (PCA) on numeric columns derived from a
+    matrix table.
 
     Examples
     --------
 
-    Compute the top 2 principal component scores and eigenvalues of the call missingness matrix.
+    For a matrix table with variant rows, sample columns, and genotype entries,
+    compute the top 2 PC sample scores and eigenvalues of the matrix of 0s and
+    1s encoding missingness of genotype calls.
 
     >>> eigenvalues, scores, _ = hl.pca(hl.is_defined(dataset.GT).to_int32(),
     ...                                      k=2)
 
+    Warning
+    -------
+      This method does not automatically mean-center each column. If desired,
+      mean-centering should be incorporated in `entry_expr`.
+
     Notes
     -----
+
+    PCA is run on the columns of the numeric matrix obtained by evaluating
+    `entry_expr` on each entry of the matrix table, or equivalently on the rows
+    of the **transposed** numeric matrix :math:`M`.
 
     PCA computes the SVD
 
@@ -1378,43 +1419,15 @@ def pca(entry_expr, k=10, compute_loadings=False, as_array=False):
     :math:`n \\times k`, :math:`k \\times k` and :math:`m \\times k`
     respectively.
 
-    From the perspective of the samples or rows of :math:`M` as data,
-    :math:`V_k` contains the variant loadings for the first :math:`k` PCs while
+    From the perspective of the rows of :math:`M` as samples (data points),
+    :math:`V_k` contains the loadings for the first :math:`k` PCs while
     :math:`MV_k = U_k S_k` contains the first :math:`k` PC scores of each
     sample. The loadings represent a new basis of features while the scores
-    represent the projected data on those features. The eigenvalues of the GRM
+    represent the projected data on those features. The eigenvalues of the Gramian
     :math:`MM^T` are the squares of the singular values :math:`s_1^2, s_2^2,
     \ldots`, which represent the variances carried by the respective PCs. By
     default, Hail only computes the loadings if the ``loadings`` parameter is
     specified.
-
-    Note
-    ----
-    In PLINK/GCTA the GRM is taken as the starting point and it is
-    computed slightly differently with regard to missing data. Here the
-    :math:`ij` entry of :math:`MM^T` is simply the dot product of rows :math:`i`
-    and :math:`j` of :math:`M`; in terms of :math:`C` it is
-
-    .. math::
-
-      \\frac{1}{m}\sum_{l\in\mathcal{C}_i\cap\mathcal{C}_j}\\frac{(C_{il}-2p_l)(C_{jl} - 2p_l)}{2p_l(1-p_l)}
-
-    where :math:`\mathcal{C}_i = \{l \mid C_{il} \\text{ is non-missing}\}`. In
-    PLINK/GCTA the denominator :math:`m` is replaced with the number of terms in
-    the sum :math:`\\lvert\mathcal{C}_i\cap\\mathcal{C}_j\\rvert`, i.e. the
-    number of variants where both samples have non-missing genotypes. While this
-    is arguably a better estimator of the true GRM (trading shrinkage for
-    noise), it has the drawback that one loses the clean interpretation of the
-    loadings and scores as features and projections.
-
-    Separately, for the PCs PLINK/GCTA output the eigenvectors of the GRM; even
-    ignoring the above discrepancy that means the left singular vectors
-    :math:`U_k` instead of the component scores :math:`U_k S_k`. While this is
-    just a matter of the scale on each PC, the scores have the advantage of
-    representing true projections of the data onto features with the variance of
-    a score reflecting the variance explained by the corresponding feature. (In
-    PC bi-plots this amounts to a change in aspect ratio; for use of PCs as
-    covariates in regression it is immaterial.)
 
     Scores are stored in a :class:`.Table` with the column keys of the matrix,
     and the following additional field:
@@ -1431,7 +1444,7 @@ def pca(entry_expr, k=10, compute_loadings=False, as_array=False):
 
      - **v**: Row key of the dataset.
 
-     - **pcaLoadings**: Row loadings (same type as the scores)
+     - **pcaLoadings**: Row loadings (same type as the scores).
 
     Parameters
     ----------

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -1289,7 +1289,7 @@ def skat(dataset, key_expr, weight_expr, y, x, covariates=[], logistic=False,
            compute_loadings=bool,
            as_array=bool)
 def hwe_normalized_pca(dataset, k=10, compute_loadings=False, as_array=False):
-    """Run principal component analysis (PCA) on the Hardy-Weinberg-normalized
+    r"""Run principal component analysis (PCA) on the Hardy-Weinberg-normalized
     genotype call matrix.
 
     Examples
@@ -1313,11 +1313,11 @@ def hwe_normalized_pca(dataset, k=10, compute_loadings=False, as_array=False):
 
     .. math::
     
-      \\frac{1}{m}\sum_{l\in\mathcal{C}_i\cap\mathcal{C}_j}\\frac{(C_{il}-2p_l)(C_{jl} - 2p_l)}{2p_l(1-p_l)
+      \frac{1}{m}\sum_{l\in\mathcal{C}_i\cap\mathcal{C}_j}\frac{(C_{il}-2p_l)(C_{jl} - 2p_l)}{2p_l(1-p_l)}
 
-    where :math:`\mathcal{C}_i = \{l \mid C_{il} \\text{ is non-missing}\}`. In
+    where :math:`\mathcal{C}_i = \{l \mid C_{il} \text{ is non-missing}\}`. In
     PLINK/GCTA the denominator :math:`m` is replaced with the number of terms in
-    the sum :math:`\\lvert\mathcal{C}_i\cap\\mathcal{C}_j\\rvert`, i.e. the
+    the sum :math:`\lvert\mathcal{C}_i\cap\mathcal{C}_j\rvert`, i.e. the
     number of variants where both samples have non-missing genotypes. While this
     is arguably a better estimator of the true GRM (trading shrinkage for
     noise), it has the drawback that one loses the clean interpretation of the
@@ -1380,7 +1380,7 @@ def hwe_normalized_pca(dataset, k=10, compute_loadings=False, as_array=False):
            compute_loadings=bool,
            as_array=bool)
 def pca(entry_expr, k=10, compute_loadings=False, as_array=False):
-    """Run principal component analysis (PCA) on numeric columns derived from a
+    r"""Run principal component analysis (PCA) on numeric columns derived from a
     matrix table.
 
     Examples
@@ -1421,7 +1421,7 @@ def pca(entry_expr, k=10, compute_loadings=False, as_array=False):
     Typically one computes only the first :math:`k` singular vectors and values,
     yielding the best rank :math:`k` approximation :math:`U_k S_k V_k^T` of
     :math:`M`; the truncations :math:`U_k`, :math:`S_k` and :math:`V_k` are
-    :math:`n \\times k`, :math:`k \\times k` and :math:`m \\times k`
+    :math:`n \times k`, :math:`k \times k` and :math:`m \times k`
     respectively.
 
     From the perspective of the rows of :math:`M` as samples (data points),

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -1350,8 +1350,9 @@ def hwe_normalized_pca(dataset, k=10, compute_loadings=False, as_array=False):
     dataset = require_biallelic(dataset, 'hwe_normalized_pca')
     dataset = dataset.annotate_rows(AC=agg.sum(dataset.GT.num_alt_alleles()),
                                     n_called=agg.count_where(hl.is_defined(dataset.GT)))
-    dataset = dataset.filter_rows((dataset.AC > 0) & (dataset.AC < 2 * dataset.n_called)).persist()
+    dataset = dataset.filter_rows((dataset.AC > 0) & (dataset.AC < 2 * dataset.n_called))
 
+    # once count_rows() adds partition_counts we can avoid annotating and filtering twice
     n_variants = dataset.count_rows()
     if n_variants == 0:
         raise FatalError(
@@ -1368,7 +1369,7 @@ def hwe_normalized_pca(dataset, k=10, compute_loadings=False, as_array=False):
                  k,
                  compute_loadings,
                  as_array)
-    dataset.unpersist()
+
     return result
 
 

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -2862,6 +2862,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) extends JoinAnnotator 
       }
     }
 
+    // caching is critical before use in computeSVD in PCA
     new IndexedRowMatrix(indexedRows.cache(), partStarts.last, numCols)
   }
 

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -2848,7 +2848,11 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) extends JoinAnnotator 
           ec.set(3, entries(k))
           a(k) = f() match {
             case null => fatal(s"Entry expr must be non-missing. Found missing value for col $k and row ${ localRKF(row) }")
-            case t => t.toDouble
+            case t =>
+              val td = t.toDouble
+              if (td.isNaN || td.isInfinite)
+                fatal(s"Entry expr cannot be NaN or infinite. Found ${ if (td.isNaN) "NaN" else "infinite" } value for col $k and row ${ localRKF(row) }")
+              td
           }
           k += 1
         }

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -2847,11 +2847,11 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) extends JoinAnnotator 
           ec.set(2, localSampleAnnotationsBc.value(k))
           ec.set(3, entries(k))
           a(k) = f() match {
-            case null => fatal(s"Entry expr must be non-missing. Found missing value for col $k and row ${ localRKF(row) }")
+            case null => fatal(s"entry_expr must be non-missing. Found missing value for col $k and row ${ localRKF(row) }")
             case t =>
               val td = t.toDouble
               if (td.isNaN || td.isInfinite)
-                fatal(s"Entry expr cannot be NaN or infinite. Found ${ if (td.isNaN) "NaN" else "infinite" } value for col $k and row ${ localRKF(row) }")
+                fatal(s"entry_expr cannot be NaN or infinite. Found ${ if (td.isNaN) "NaN" else "infinite" } value for col $k and row ${ localRKF(row) }")
               td
           }
           k += 1
@@ -2862,7 +2862,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) extends JoinAnnotator 
       }
     }
 
-    new IndexedRowMatrix(indexedRows, partStarts.last, numCols)
+    new IndexedRowMatrix(indexedRows.cache(), partStarts.last, numCols)
   }
 
   def collectRowKeys(): Keys = {


### PR DESCRIPTION
Still not the ideal (M as transpose is confusing and we should probably automatically mean-center), but at least the docs are now correct.