### PR TITLE
remove sample_rows from methods/misc

### DIFF
--- a/python/hail/docs/methods/index.rst
+++ b/python/hail/docs/methods/index.rst
@@ -74,4 +74,3 @@ Methods
 
     maximal_independent_set
     rename_duplicates
-    sample_rows

--- a/python/hail/docs/methods/misc.rst
+++ b/python/hail/docs/methods/misc.rst
@@ -10,8 +10,6 @@ Miscellaneous
 
     maximal_independent_set
     rename_duplicates
-    sample_rows
 
 .. autofunction:: maximal_independent_set
 .. autofunction:: rename_duplicates
-.. autofunction:: sample_rows

--- a/python/hail/methods/__init__.py
+++ b/python/hail/methods/__init__.py
@@ -2,7 +2,7 @@ from .family_methods import trio_matrix, mendel_errors, tdt
 from .impex import export_cassandra, export_gen, export_plink, export_solr, export_vcf, \
     import_interval_list, import_bed, import_fam, grep, import_bgen, import_gen, import_table, \
     import_plink, read_matrix_table, read_table, get_vcf_metadata, import_vcf, index_bgen
-from .statgen import linreg, logreg, lmmreg, skat, sample_rows, ibd, impute_sex, \
+from .statgen import linreg, logreg, lmmreg, skat, ibd, impute_sex, \
     grm, rrm, pca, hwe_normalized_pca, pc_relate, SplitMulti, \
     split_multi_hts, balding_nichols_model, FilterAlleles, ld_prune, min_rep
 from .qc import sample_qc, variant_qc, vep, concordance, nirvana
@@ -14,7 +14,6 @@ __all__ = ['trio_matrix',
            'logreg',
            'lmmreg',
            'skat',
-           'sample_rows',
            'ibd',
            'impute_sex',
            'sample_qc',

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -1747,43 +1747,6 @@ def pc_relate(dataset, k, maf, block_size=512, min_kinship=-float("inf"), statis
                    min_kinship,
                    intstatistics))
 
-
-@handle_py4j
-@typecheck(dataset=MatrixTable,
-           fraction=numeric,
-           seed=integral)
-def sample_rows(dataset, fraction, seed=1):
-    """Downsample rows to a given fraction of the dataset.
-
-    Examples
-    --------
-
-    >>> small_dataset = hl.sample_rows(dataset, 0.01)
-
-    Notes
-    -----
-
-    This method may not sample exactly ``(fraction * n_rows)`` rows from
-    the dataset.
-
-    Parameters
-    ----------
-    dataset : :class:`.MatrixTable`
-        Dataset to sample from.
-    fraction : :obj:`float`
-        (Expected) fraction of rows to keep.
-    seed : :obj:`int`
-        Random seed.
-
-    Returns
-    ------
-    :class:`.MatrixTable`
-        Downsampled matrix table.
-    """
-
-    return MatrixTable(dataset._jvds.sampleVariants(fraction, seed))
-
-
 class SplitMulti(object):
     """Split multiallelic variants.
 


### PR DESCRIPTION
@tpoterba any reason not to remove this?

We already have sample_rows on MatrixTable and sample of Table.