### PR TITLE
DenseMatrix I/O moved to blocking buffer

### DIFF
--- a/src/main/scala/is/hail/io/RowStore.scala
+++ b/src/main/scala/is/hail/io/RowStore.scala
@@ -324,6 +324,8 @@ trait InputBuffer extends Closeable {
   def readDouble(): Double
 
   def readBytes(toRegion: Region, toOff: Long, n: Int): Unit
+  
+  def skipBytes(n: Int): Unit
 
   def readDoubles(to: Array[Double], off: Int, n: Int): Unit
 
@@ -369,6 +371,8 @@ final class LEB128InputBuffer(in: InputBuffer) extends InputBuffer {
 
   def readBytes(toRegion: Region, toOff: Long, n: Int): Unit = in.readBytes(toRegion, toOff, n)
 
+  def skipBytes(n: Int): Unit = in.skipBytes(n)
+  
   def readDoubles(to: Array[Double], toOff: Int, n: Int): Unit = in.readDoubles(to, toOff, n)
 }
 
@@ -457,6 +461,17 @@ final class BlockingInputBuffer(blockSize: Int, in: InputBlockBuffer) extends In
       assert(p > 0)
       toRegion.storeBytes(toOff, buf, off, p)
       toOff += p
+      n -= p
+      off += p
+    }
+  }
+  
+  def skipBytes(n0: Int) {
+    var n = n0
+    while (n > 0) {
+      if (end == off)
+        readBlock()
+      val p = math.min(end - off, n)
       n -= p
       off += p
     }

--- a/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -1110,7 +1110,6 @@ class WriteBlocksRDD(path: String,
       out.writeInt(nRowsInBlock)
       out.writeInt(nColsInBlock)
       out.writeBoolean(true) // transposed, stored row major
-      out.flush() // align block row with buffer
       
       out
     }
@@ -1162,10 +1161,7 @@ class WriteBlocksRDD(path: String,
       }
     }
 
-    outPerBlockCol.foreach { out =>
-      out.flush()
-      out.close()
-    }
+    outPerBlockCol.foreach(_.close())
 
     Iterator.single(gp.nBlockCols) // number of blocks written
   }

--- a/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
@@ -11,6 +11,7 @@ import org.json4s.jackson
 
 object RichDenseMatrixDouble {
   // assumes zero offset and minimal majorStride
+  // caller must close
   def read(is: InputStream, bufferSpec: BufferSpec): DenseMatrix[Double] = {
     val in = bufferSpec.buildInputBuffer(is)
     
@@ -98,6 +99,7 @@ class RichDenseMatrixDouble(val m: DenseMatrix[Double]) extends AnyVal {
       (m.toArray, false)
   }
 
+  // caller must close
   def write(os: OutputStream, forceRowMajor: Boolean, bufferSpec: BufferSpec) {
     val (data, isTranspose) = m.toCompactData(forceRowMajor)
     assert(data.length == m.rows * m.cols)
@@ -107,7 +109,6 @@ class RichDenseMatrixDouble(val m: DenseMatrix[Double]) extends AnyVal {
     out.writeInt(m.rows)
     out.writeInt(m.cols)
     out.writeBoolean(isTranspose)
-    out.flush() // align block row with buffer
     out.writeDoubles(data)
     out.flush()
   }

--- a/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
@@ -9,13 +9,10 @@ import is.hail.check.Gen._
 import is.hail.check._
 import is.hail.linalg.BlockMatrix.ops._
 import is.hail.expr.types.{TFloat64Required, TInt64Required, TStruct}
-import is.hail.table.Table
 import is.hail.utils._
 import is.hail.utils.richUtils.RichDenseMatrixDouble
 import org.testng.annotations.Test
 
-import scala.collection.JavaConverters._
-import scala.collection.mutable
 import scala.language.implicitConversions
 
 class BlockMatrixSuite extends SparkSuite {
@@ -598,8 +595,8 @@ class BlockMatrixSuite extends SparkSuite {
     val lm = BDM.rand[Double](256, 129) // 33024 doubles
     val fname = tmpDir.createTempFile("test")
 
-    lm.write(hc, fname)
-    val lm2 = RichDenseMatrixDouble.read(hc, fname)
+    lm.write(hc, fname, bufferSpec = BlockMatrix.bufferSpec)
+    val lm2 = RichDenseMatrixDouble.read(hc, fname, BlockMatrix.bufferSpec)
 
     assert(lm === lm2)
   }


### PR DESCRIPTION
I also added skipBytes for use with RowMatrix.readBlockMatrix

@cseed I still need to experiment on compression w.r.t. banded LD project, which should inform the choice of BDM BufferSpec further, but using the general infrastructure is clearly better than the one-off BDM buffers I'd written before. Is it reasonable to merge this to master (post review)?