### PR TITLE
update conda env for python 3

### DIFF
--- a/python/hail/environment.yml
+++ b/python/hail/environment.yml
@@ -1,6 +1,6 @@
 name: hail
 dependencies:
-  - python=2.7
+  - python=3.5
   - Sphinx=1.5.4
   - conda-forge::nbsphinx=0.2.13
   - conda-forge::sphinx_rtd_theme=0.2.4

--- a/python/hail/environment.yml
+++ b/python/hail/environment.yml
@@ -1,12 +1,11 @@
 name: hail
 dependencies:
-  - python=3.5
-  - Sphinx=1.5.4
-  - conda-forge::nbsphinx=0.2.13
-  - conda-forge::sphinx_rtd_theme=0.2.4
-  - decorator=4.0.10
-  - ipython-notebook=4.0.4
-  - numpy=1.11.1
-  - pandas=0.20.2
-  - matplotlib=2.0.2
-  - seaborn=0.7.1
+  - python=3.6
+  - Sphinx
+  - conda-forge::nbsphinx
+  - conda-forge::sphinx_rtd_theme
+  - decorator
+  - numpy
+  - pandas
+  - matplotlib
+  - seaborn


### PR DESCRIPTION
NB: we cannot use python 3.6 because ipython-notebook hasn't been updated yet.