### PR TITLE
add missing docs for ld_prune and impute_sex

### DIFF
--- a/python/hail/docs/conf.py
+++ b/python/hail/docs/conf.py
@@ -42,7 +42,7 @@ extensions = [
     'sphinx.ext.autosummary',
     'nbsphinx',
     'IPython.sphinxext.ipython_console_highlighting', # https://github.com/spatialaudio/nbsphinx/issues/24#issuecomment-187172022 and https://github.com/ContinuumIO/anaconda-issues/issues/1430
-    'sphinxcontrib.napoleon'
+    'sphinx.ext.napoleon'
 ]
 
 mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML'

--- a/python/hail/docs/doctest_setup.py
+++ b/python/hail/docs/doctest_setup.py
@@ -15,18 +15,25 @@ for f in files:
 
 ds = hl.import_vcf('data/sample.vcf.bgz')
 ds = ds.sample_rows(0.03)
-ds = ds.annotate_rows(useInKinship=hl.rand_bool(0.9), panel_maf=0.1, anno1=5, anno2=0, consequence="LOF", gene="A",
+ds = ds.annotate_rows(use_in_kinship=hl.rand_bool(0.9),
+                      panel_maf=0.1,
+                      anno1=5,
+                      anno2=0,
+                      consequence="LOF",
+                      gene="A",
                       score=5.0)
-ds = ds.annotate_rows(aIndex=1)
+ds = ds.annotate_rows(a_index=1)
 ds = hl.sample_qc(hl.variant_qc(ds))
-ds = ds.annotate_cols(isCase=True,
-                      pheno=hl.Struct(isCase=hl.rand_bool(0.5),
-                                      isFemale=hl.rand_bool(0.5),
+ds = ds.annotate_cols(is_case=True,
+                      pheno=hl.Struct(is_case=hl.rand_bool(0.5),
+                                      is_female=hl.rand_bool(0.5),
                                       age=hl.rand_norm(65, 10),
                                       height=hl.rand_norm(70, 10),
-                                      bloodPressure=hl.rand_norm(120, 20),
-                                      cohortName="cohort1"),
-                      cov=hl.Struct(PC1=hl.rand_norm(0, 1)), cov1=hl.rand_norm(0, 1), cov2=hl.rand_norm(0, 1))
+                                      blood_pressure=hl.rand_norm(120, 20),
+                                      cohort_name="cohort1"),
+                      cov=hl.Struct(PC1=hl.rand_norm(0, 1)),
+                      cov1=hl.rand_norm(0, 1),
+                      cov2=hl.rand_norm(0, 1))
 
 ds = ds.annotate_rows(gene=['TTN'])
 ds = ds.annotate_cols(cohorts=['1kg'], pop='EAS')

--- a/python/hail/docs/methods/genetics.rst
+++ b/python/hail/docs/methods/genetics.rst
@@ -10,11 +10,13 @@ Genetics
 
     balding_nichols_model
     concordance
-    FilterAlleles
     filter_intervals
+    FilterAlleles
     grm
     hwe_normalized_pca
     ibd
+    impute_sex
+    ld_prune
     mendel_errors
     min_rep
     nirvana
@@ -22,8 +24,8 @@ Genetics
     rrm
     sample_qc
     skat
-    SplitMulti
     split_multi_hts
+    SplitMulti
     tdt
     trio_matrix
     variant_qc
@@ -32,11 +34,13 @@ Genetics
 
 .. autofunction:: balding_nichols_model
 .. autofunction:: concordance
-.. autoclass:: FilterAlleles
 .. autofunction:: filter_intervals
+.. autoclass:: FilterAlleles
 .. autofunction:: grm
 .. autofunction:: hwe_normalized_pca
 .. autofunction:: ibd
+.. autofunction:: impute_sex
+.. autofunction:: ld_prune
 .. autofunction:: mendel_errors
 .. autofunction:: min_rep
 .. autofunction:: nirvana
@@ -44,8 +48,8 @@ Genetics
 .. autofunction:: rrm
 .. autofunction:: sample_qc
 .. autofunction:: skat
-.. autoclass:: SplitMulti
 .. autofunction:: split_multi_hts
+.. autoclass:: SplitMulti
 .. autofunction:: tdt
 .. autofunction:: trio_matrix
 .. autofunction:: variant_qc

--- a/python/hail/docs/methods/index.rst
+++ b/python/hail/docs/methods/index.rst
@@ -50,11 +50,13 @@ Methods
 
     balding_nichols_model
     concordance
-    FilterAlleles
     filter_intervals
+    FilterAlleles
     grm
     hwe_normalized_pca
     ibd
+    impute_sex
+    ld_prune
     mendel_errors
     min_rep
     nirvana
@@ -62,8 +64,8 @@ Methods
     rrm
     sample_qc
     skat
-    SplitMulti
     split_multi_hts
+    SplitMulti
     tdt
     trio_matrix
     variant_qc

--- a/python/hail/environment.yml
+++ b/python/hail/environment.yml
@@ -1,13 +1,13 @@
 name: hail
 dependencies:
-  - python=3.6
-  - Sphinx=1.5.4
-  - sphinxcontrib
-  - conda-forge::nbsphinx
-  - conda-forge::sphinx_rtd_theme
-  - decorator
-  - numpy
-  - pandas
-  - matplotlib
-  - seaborn
-  - parsimonious
+- python=3.6
+- Sphinx=1.5.4
+- sphinxcontrib
+- conda-forge::nbsphinx
+- conda-forge::sphinx_rtd_theme
+- decorator
+- numpy
+- pandas
+- matplotlib
+- seaborn
+- parsimonious

--- a/python/hail/environment.yml
+++ b/python/hail/environment.yml
@@ -1,7 +1,8 @@
 name: hail
 dependencies:
   - python=3.6
-  - Sphinx
+  - Sphinx=1.5.4
+  - sphinxcontrib
   - conda-forge::nbsphinx
   - conda-forge::sphinx_rtd_theme
   - decorator

--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -867,8 +867,12 @@ class MatrixTable(object):
         --------
         Select existing fields and compute a new one:
 
-        >>> dataset_result = dataset.select_rows(dataset.locus, dataset.alleles, dataset.variant_qc.gq_mean,
-        ...                                      highQualityCases = agg.count_where((dataset.GQ > 20) & (dataset.isCase)))
+        >>> dataset_result = dataset.select_rows(
+        ...    dataset.locus,
+        ...    dataset.alleles,
+        ...    dataset.variant_qc.gq_mean,
+        ...    high_quality_cases = agg.count_where((dataset.GQ > 20) &
+        ...                                         dataset.is_case))
 
         Notes
         -----
@@ -932,9 +936,10 @@ class MatrixTable(object):
         --------
         Select existing fields and compute a new one:
 
-        >>> dataset_result = dataset.select_cols(dataset.sample_qc,
-        ...                                      dataset.pheno.age,
-        ...                                      isCohort1 = dataset.pheno.cohortName == 'Cohort1')
+        >>> dataset_result = dataset.select_cols(
+        ...     dataset.sample_qc,
+        ...     dataset.pheno.age,
+        ...     isCohort1 = dataset.pheno.cohort_name == 'Cohort1')
 
         Notes
         -----
@@ -1230,13 +1235,17 @@ class MatrixTable(object):
         Examples
         --------
 
-        Keep columns where `pheno.isCase` is ``True`` and `pheno.age` is larger than 50:
+        Keep columns where `pheno.is_case` is ``True`` and `pheno.age` is larger
+        than 50:
 
-        >>> dataset_result = dataset.filter_cols(dataset.pheno.isCase & (dataset.pheno.age > 50), keep=True)
+        >>> dataset_result = dataset.filter_cols(dataset.pheno.is_case &
+        ...                                      (dataset.pheno.age > 50),
+        ...                                      keep=True)
 
         Remove rows where `sample_qc.gq_mean` is less than 20:
 
-        >>> dataset_result = dataset.filter_cols(dataset.sample_qc.gq_mean < 20, keep=False)
+        >>> dataset_result = dataset.filter_cols(dataset.sample_qc.gq_mean < 20,
+        ...                                      keep=False)
 
         Notes
         -----
@@ -1477,8 +1486,9 @@ class MatrixTable(object):
 
         .. doctest::
 
-            >>> dataset.aggregate_cols(Struct(fraction_female=agg.fraction(dataset.pheno.isFemale),
-            ...                               case_ratio=agg.count_where(dataset.isCase) / agg.count()))
+            >>> dataset.aggregate_cols(
+            ...    Struct(fraction_female=agg.fraction(dataset.pheno.is_female),
+            ...           case_ratio=agg.count_where(dataset.is_case) / agg.count()))
             Struct(fraction_female=0.5102222, case_ratio=0.35156)
 
         Notes
@@ -1490,8 +1500,9 @@ class MatrixTable(object):
         the following:
 
         >>> cols_table = dataset.cols()
-        >>> cols_table.aggregate(Struct(fraction_female=agg.fraction(cols_table.pheno.isFemale),
-        ...                             case_ratio=agg.count_where(cols_table.isCase) / agg.count()))
+        >>> cols_table.aggregate(
+        ...     Struct(fraction_female=agg.fraction(cols_table.pheno.is_female),
+        ...            case_ratio=agg.count_where(cols_table.is_case) / agg.count()))
 
         Note
         ----

--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -44,9 +44,9 @@ def export_gen(dataset, output, precision=4):
     Import genotype probability data, filter variants based on INFO score, and
     export data to a GEN and SAMPLE file:
 
-    >>> ds = hl.import_gen('data/example.gen', sample_file='data/example.sample')
-    >>> ds = ds.filter_rows(agg.info_score(ds.GP).score >= 0.9) # doctest: +SKIP
-    >>> hl.export_gen(ds, 'output/infoscore_filtered')
+    >>> example_ds = hl.import_gen('data/example.gen', sample_file='data/example.sample')
+    >>> example_ds = example_ds.filter_rows(agg.info_score(example_ds.GP).score >= 0.9) # doctest: +SKIP
+    >>> hl.export_gen(example_ds, 'output/infoscore_filtered')
 
     Notes
     -----

--- a/python/hail/methods/misc.py
+++ b/python/hail/methods/misc.py
@@ -34,8 +34,8 @@ def maximal_independent_set(i, j, keep=True, tie_breaker=None):
     >>> pairs = pc_rel.filter(pc_rel['kin'] > 0.125).select('i', 'j')
     >>> samples = dataset.cols()
     >>> pairs_with_case = pairs.select(
-    ...     i=hl.Struct(id=pairs.i, is_case=samples[pairs.i].isCase),
-    ...     j=hl.Struct(id=pairs.j, is_case=samples[pairs.j].isCase))
+    ...     i=hl.Struct(id=pairs.i, is_case=samples[pairs.i].is_case),
+    ...     j=hl.Struct(id=pairs.j, is_case=samples[pairs.j].is_case))
     >>> def tie_breaker(l, r):
     ...     return hl.cond(l.is_case & ~r.is_case, -1,
     ...                    hl.cond(~l.is_case & r.is_case, 1, 0))

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -243,7 +243,7 @@ def linreg(dataset, ys, x, covariates=[], root='linreg', block_size=16):
     --------
 
     >>> dataset_result = hl.linreg(dataset, [dataset.pheno.height], dataset.GT.num_alt_alleles(),
-    ...                                 covariates=[dataset.pheno.age, dataset.pheno.is_female])
+    ...                            covariates=[dataset.pheno.age, dataset.pheno.is_female])
 
     Warning
     -------
@@ -362,7 +362,7 @@ def logreg(dataset, test, y, x, covariates=[], root='logreg'):
     >>> ds_result = hl.logreg(
     ...     dataset,
     ...     test='wald',
-    ...     y=dataset.pheno.isCase,
+    ...     y=dataset.pheno.is_case,
     ...     x=dataset.GT.num_alt_alleles(),
     ...     covariates=[dataset.pheno.age, dataset.pheno.is_female])
 
@@ -385,7 +385,7 @@ def logreg(dataset, test, y, x, covariates=[], root='logreg'):
 
     .. math::
 
-        \mathrm{Prob}(\mathrm{isCase}) =
+        \mathrm{Prob}(\mathrm{is_case}) =
             \mathrm{sigmoid}(\beta_0 + \beta_1 \, \mathrm{gt}
                             + \beta_2 \, \mathrm{age}
                             + \beta_3 \, \mathrm{is_female} + \varepsilon),
@@ -524,7 +524,7 @@ def logreg(dataset, test, y, x, covariates=[], root='logreg'):
         if (ds.is_female) ds.cov.age else (2 * ds.cov.age + 10)
 
     For Boolean covariate types, true is coded as 1 and false as 0. In
-    particular, for the sample annotation `fam.isCase` added by importing a FAM
+    particular, for the sample annotation `fam.is_case` added by importing a FAM
     file with case-control phenotype, case is 1 and control is 0.
 
     Hail's logistic regression tests correspond to the ``b.wald``, ``b.lrt``,
@@ -610,12 +610,12 @@ def lmmreg(ds, kinshipMatrix, y, x, covariates=[], global_root="lmmreg_global", 
         lmmreg_ds = hl.variant_qc(hl.split_multi_hts(hl.import_vcf('data/sample.vcf.bgz')))
         lmmreg_tsv = hl.import_table('data/example_lmmreg.tsv', 'Sample', impute=True)
         lmmreg_ds = lmmreg_ds.annotate_cols(**lmmreg_tsv[lmmreg_ds['s']])
-        lmmreg_ds = lmmreg_ds.annotate_rows(useInKinship = lmmreg_ds.variant_qc.AF > 0.05)
+        lmmreg_ds = lmmreg_ds.annotate_rows(use_in_kinship = lmmreg_ds.variant_qc.AF > 0.05)
         lmmreg_ds.write('data/example_lmmreg.vds', overwrite=True)
 
 
     >>> lmm_ds = hl.read_matrix_table("data/example_lmmreg.vds")
-    >>> kinship_matrix = hl.rrm(lmm_ds.filter_rows(lmm_ds.useInKinship)['GT'])
+    >>> kinship_matrix = hl.rrm(lmm_ds.filter_rows(lmm_ds.use_in_kinship)['GT'])
     >>> lmm_ds = hl.lmmreg(lmm_ds,
     ...                    kinship_matrix,
     ...                    lmm_ds.pheno,
@@ -625,7 +625,7 @@ def lmmreg(ds, kinshipMatrix, y, x, covariates=[], global_root="lmmreg_global", 
     Notes
     -----
     Suppose the variant dataset saved at :file:`data/example_lmmreg.vds` has a
-    Boolean variant-indexed field `useInKinship` and numeric or Boolean
+    Boolean variant-indexed field `use_in_kinship` and numeric or Boolean
     sample-indexed fields `pheno`, `cov1`, and `cov2`. Then the
     :func:`.lmmreg` function in the above example will execute the following
     four steps in order:
@@ -1987,11 +1987,12 @@ def split_multi_hts(ds, keep_star=False, left_aligned=False):
     Hail does not split fields in the info field. This means that if a
     multiallelic site with `info.AC` value ``[10, 2]`` is split, each split
     site will contain the same array ``[10, 2]``. The provided allele index
-    field `aIndex` can be used to select the value corresponding to the split
+    field `a_index` can be used to select the value corresponding to the split
     allele's position:
 
     >>> split_ds = hl.split_multi_hts(dataset)
-    >>> split_ds = split_ds.filter_rows(split_ds.info.AC[split_ds.aIndex - 1] < 10, keep = False)
+    >>> split_ds = split_ds.filter_rows(split_ds.info.AC[split_ds.a_index - 1] < 10,
+    ...                                 keep = False)
 
     VCFs split by Hail and exported to new VCFs may be
     incompatible with other tools, if action is not taken
@@ -2005,7 +2006,8 @@ def split_multi_hts(ds, keep_star=False, left_aligned=False):
     values. Here is an example:
 
     >>> split_ds = hl.split_multi_hts(dataset)
-    >>> split_ds = split_ds.annotate_rows(info = Struct(AC=split_ds.info.AC[split_ds.aIndex - 1], **split_ds.info)) # doctest: +SKIP
+    >>> split_ds = split_ds.annotate_rows(info = Struct(AC=split_ds.info.AC[split_ds.a_index - 1],
+    ...                                   **split_ds.info)) # doctest: +SKIP
     >>> hl.export_vcf(split_ds, 'output/export.vcf') # doctest: +SKIP
 
     The info field AC in *data/export.vcf* will have ``Number=1``.
@@ -2014,14 +2016,14 @@ def split_multi_hts(ds, keep_star=False, left_aligned=False):
 
     :func:`.split_multi_hts` adds the following fields:
 
-     - `wasSplit` (*Boolean*) -- ``True`` if this variant was originally
+     - `was_split` (*Boolean*) -- ``True`` if this variant was originally
        multiallelic, otherwise ``False``.
 
-     - `aIndex` (*Int*) -- The original index of this alternate allele in the
+     - `a_index` (*Int*) -- The original index of this alternate allele in the
        multiallelic representation (NB: 1 is the first alternate allele or the
        only alternate allele in a biallelic variant). For example, 1:100:A:T,C
-       splits into two variants: 1:100:A:T with ``aIndex = 1`` and 1:100:A:C
-       with ``aIndex = 2``.
+       splits into two variants: 1:100:A:T with ``a_index = 1`` and 1:100:A:C
+       with ``a_index = 2``.
 
     Parameters
     ----------

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -614,9 +614,13 @@ def lmmreg(ds, kinshipMatrix, y, x, covariates=[], global_root="lmmreg_global", 
         lmmreg_ds.write('data/example_lmmreg.vds', overwrite=True)
 
 
-    >>> ds = hl.read_matrix_table("data/example_lmmreg.vds")
-    >>> kinship_matrix = hl.rrm(ds.filter_rows(ds.useInKinship)['GT'])
-    >>> lmm_ds = hl.lmmreg(ds, kinship_matrix, ds.pheno, ds.GT.num_alt_alleles(), [ds.cov1, ds.cov2])
+    >>> lmm_ds = hl.read_matrix_table("data/example_lmmreg.vds")
+    >>> kinship_matrix = hl.rrm(lmm_ds.filter_rows(lmm_ds.useInKinship)['GT'])
+    >>> lmm_ds = hl.lmmreg(lmm_ds,
+    ...                    kinship_matrix,
+    ...                    lmm_ds.pheno,
+    ...                    lmm_ds.GT.num_alt_alleles(),
+    ...                    [lmm_ds.cov1, lmm_ds.cov2])
 
     Notes
     -----
@@ -1120,13 +1124,13 @@ def skat(dataset, key_expr, weight_expr, y, x, covariates=[], logistic=False,
         burden_ds = burden_ds.annotate_rows(gene = genekt[burden_ds.locus])
         burden_ds.write('data/example_burden.vds', overwrite=True)
 
-    >>> ds = hl.read_matrix_table('data/example_burden.vds')
-    >>> skat_table = hl.skat(ds,
-    ...                      key_expr=ds.gene,
-    ...                      weight_expr=ds.weight,
-    ...                      y=ds.burden.pheno,
-    ...                      x=ds.GT.num_alt_alleles(),
-    ...                      covariates=[ds.burden.cov1, ds.burden.cov2])
+    >>> burden_ds = hl.read_matrix_table('data/example_burden.vds')
+    >>> skat_table = hl.skat(burden_ds,
+    ...                      key_expr=burden_ds.gene,
+    ...                      weight_expr=burden_ds.weight,
+    ...                      y=burden_ds.burden.pheno,
+    ...                      x=burden_ds.GT.num_alt_alleles(),
+    ...                      covariates=[burden_ds.burden.cov1, burden_ds.burden.cov2])
 
     .. caution::
 
@@ -1986,8 +1990,8 @@ def split_multi_hts(ds, keep_star=False, left_aligned=False):
     field `aIndex` can be used to select the value corresponding to the split
     allele's position:
 
-    >>> ds = hl.split_multi_hts(dataset)
-    >>> ds = ds.filter_rows(ds.info.AC[ds.aIndex - 1] < 10, keep = False)
+    >>> split_ds = hl.split_multi_hts(dataset)
+    >>> split_ds = split_ds.filter_rows(split_ds.info.AC[split_ds.aIndex - 1] < 10, keep = False)
 
     VCFs split by Hail and exported to new VCFs may be
     incompatible with other tools, if action is not taken
@@ -2000,9 +2004,9 @@ def split_multi_hts(ds, keep_star=False, left_aligned=False):
     possible to use annotate_variants_expr to remap these
     values. Here is an example:
 
-    >>> ds = hl.split_multi_hts(dataset)
-    >>> ds = ds.annotate_rows(info = Struct(AC=ds.info.AC[ds.aIndex - 1], **ds.info)) # doctest: +SKIP
-    >>> hl.export_vcf(ds, 'output/export.vcf') # doctest: +SKIP
+    >>> split_ds = hl.split_multi_hts(dataset)
+    >>> split_ds = split_ds.annotate_rows(info = Struct(AC=split_ds.info.AC[split_ds.aIndex - 1], **split_ds.info)) # doctest: +SKIP
+    >>> hl.export_vcf(split_ds, 'output/export.vcf') # doctest: +SKIP
 
     The info field AC in *data/export.vcf* will have ``Number=1``.
 
@@ -2277,7 +2281,7 @@ def balding_nichols_model(num_populations, num_samples, num_variants, num_partit
     Generate a matrix table of genotypes with 1000 variants and 100 samples
     across 3 populations:
 
-    >>> ds = hl.balding_nichols_model(3, 100, 1000)
+    >>> bn_ds = hl.balding_nichols_model(3, 100, 1000)
 
     Generate a matrix table using 4 populations, 40 samples, 150 variants, 3
     partitions, population distribution ``[0.1, 0.2, 0.3, 0.4]``,
@@ -2287,7 +2291,7 @@ def balding_nichols_model(num_populations, num_samples, num_variants, num_partit
 
     >>> from hail.stats import TruncatedBetaDist
     >>>
-    >>> ds = hl.balding_nichols_model(4, 40, 150, 3,
+    >>> bn_ds = hl.balding_nichols_model(4, 40, 150, 3,
     ...          pop_dist=[0.1, 0.2, 0.3, 0.4],
     ...          fst=[.02, .06, .04, .12],
     ...          af_dist=TruncatedBetaDist(a=0.01, b=2.0, min=0.05, max=1.0),

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -123,7 +123,7 @@ def impute_sex(call, aaf_threshold=0.0, include_par=False, female_threshold=0.2,
     Remove samples where imputed sex does not equal reported sex:
 
     >>> imputed_sex = hl.impute_sex(ds.GT)
-    >>> ds.filter_cols(imputed_sex[ds.s].isFemale != ds.pheno.is_female)
+    >>> ds.filter_cols(imputed_sex[ds.s].is_female != ds.pheno.is_female)
 
     Notes
     -----
@@ -243,7 +243,7 @@ def linreg(dataset, ys, x, covariates=[], root='linreg', block_size=16):
     --------
 
     >>> dataset_result = hl.linreg(dataset, [dataset.pheno.height], dataset.GT.num_alt_alleles(),
-    ...                                 covariates=[dataset.pheno.age, dataset.pheno.isFemale])
+    ...                                 covariates=[dataset.pheno.age, dataset.pheno.is_female])
 
     Warning
     -------
@@ -278,11 +278,11 @@ def linreg(dataset, ys, x, covariates=[], root='linreg', block_size=16):
 
         \mathrm{height} = \\beta_0 + \\beta_1 \, \mathrm{genotype}
                           + \\beta_2 \, \mathrm{age}
-                          + \\beta_3 \, \mathrm{isFemale}
+                          + \\beta_3 \, \mathrm{is_female}
                           + \\varepsilon, \quad \\varepsilon
                         \sim \mathrm{N}(0, \sigma^2)
 
-    Boolean covariates like :math:`\mathrm{isFemale}` are encoded as 1 for true
+    Boolean covariates like :math:`\mathrm{is_female}` are encoded as 1 for true
     and 0 for false. The null model sets :math:`\\beta_1 = 0`.
 
     The standard least-squares linear regression model is derived in Section
@@ -364,7 +364,7 @@ def logreg(dataset, test, y, x, covariates=[], root='logreg'):
     ...     test='wald',
     ...     y=dataset.pheno.isCase,
     ...     x=dataset.GT.num_alt_alleles(),
-    ...     covariates=[dataset.pheno.age, dataset.pheno.isFemale])
+    ...     covariates=[dataset.pheno.age, dataset.pheno.is_female])
 
     Notes
     -----
@@ -388,13 +388,13 @@ def logreg(dataset, test, y, x, covariates=[], root='logreg'):
         \mathrm{Prob}(\mathrm{isCase}) =
             \mathrm{sigmoid}(\beta_0 + \beta_1 \, \mathrm{gt}
                             + \beta_2 \, \mathrm{age}
-                            + \beta_3 \, \mathrm{isFemale} + \varepsilon),
+                            + \beta_3 \, \mathrm{is_female} + \varepsilon),
         \quad
         \varepsilon \sim \mathrm{N}(0, \sigma^2)
 
     where :math:`\mathrm{sigmoid}` is the `sigmoid function`_, the genotype
     :math:`\mathrm{gt}` is coded as 0 for HomRef, 1 for Het, and 2 for
-    HomVar, and the Boolean covariate :math:`\mathrm{isFemale}` is coded as
+    HomVar, and the Boolean covariate :math:`\mathrm{is_female}` is coded as
     for true (female) and 0 for false (male). The null model sets
     :math:`\beta_1 = 0`.
 
@@ -521,7 +521,7 @@ def logreg(dataset, test, y, x, covariates=[], root='logreg'):
 
     .. code-block:: text
 
-        if (ds.isFemale) ds.cov.age else (2 * ds.cov.age + 10)
+        if (ds.is_female) ds.cov.age else (2 * ds.cov.age + 10)
 
     For Boolean covariate types, true is coded as 1 and false as 0. In
     particular, for the sample annotation `fam.isCase` added by importing a FAM

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -123,7 +123,7 @@ def impute_sex(call, aaf_threshold=0.0, include_par=False, female_threshold=0.2,
     Remove samples where imputed sex does not equal reported sex:
 
     >>> imputed_sex = hl.impute_sex(ds.GT)
-    >>> ds.filter_cols(imputed_sex[ds.s].isFemale != ds.pheno.isFemale)
+    >>> ds.filter_cols(imputed_sex[ds.s].isFemale != ds.pheno.is_female)
 
     Notes
     -----

--- a/python/hail/utils/misc.py
+++ b/python/hail/utils/misc.py
@@ -13,12 +13,12 @@ def range_matrix_table(n_rows, n_cols, n_partitions=None):
     --------
     .. doctest::
 
-        >>> ds = hl.utils.range_matrix_table(n_rows=100, n_cols=10)
+        >>> range_ds = hl.utils.range_matrix_table(n_rows=100, n_cols=10)
 
-        >>> ds.count_rows()
+        >>> range_ds.count_rows()
         100
 
-        >>> ds.count_cols()
+        >>> range_ds.count_cols()
         10
 
     Notes


### PR DESCRIPTION
I also reordered FilterAlleles and SplitMulti because in emacs `sort-lines` sorts using ASCII character index, so `A` comes after `_`. I think this will be an easier ordering to maintain, because it's the default ASCII ordering the most tools will use.