### PR TITLE
fix import docs and change how reference is handled

### DIFF
--- a/python/hail/context.py
+++ b/python/hail/context.py
@@ -137,7 +137,11 @@ def get_reference(name):
     :class:`.GenomeReference`
     """
     from hail import GenomeReference
-    return GenomeReference._references.get(
-        name,
-        GenomeReference._from_java(Env.hail().variant.GenomeReference.getReference(name))
-    )
+
+    if name == "default":
+        return default_reference()
+    else:
+        return GenomeReference._references.get(
+            name,
+            GenomeReference._from_java(Env.hail().variant.GenomeReference.getReference(name))
+        )

--- a/python/hail/context.py
+++ b/python/hail/context.py
@@ -132,6 +132,8 @@ def default_reference():
 def get_reference(name):
     """Return the reference genome corresponding to `name`.
 
+    If `name` is ``default``, return the reference from :func:`.default_reference`.
+
     Returns
     -------
     :class:`.GenomeReference`

--- a/python/hail/expr/functions.py
+++ b/python/hail/expr/functions.py
@@ -1,8 +1,8 @@
 from hail.typecheck import *
 from hail.expr.expression import *
 from hail.expr.ast import *
-from hail.genetics import Locus, Call, GenomeReference
-from hail.context import get_reference
+# from hail.genetics import Locus, Call, GenomeReference
+from hail.genetics.genomeref import reference_genome_type
 
 std_len = len
 std_str = str
@@ -642,7 +642,7 @@ def index(structs, identifier):
 
 
 @typecheck(contig=expr_str, pos=expr_int32,
-           reference_genome=oneof(transformed((std_str, lambda x: get_reference(x))), GenomeReference))
+           reference_genome=reference_genome_type)
 def locus(contig, pos, reference_genome='default'):
     """Construct a locus expression from a chromosome and position.
 
@@ -675,7 +675,7 @@ def locus(contig, pos, reference_genome='default'):
 
 
 @typecheck(s=expr_str,
-           reference_genome=oneof(transformed((std_str, lambda x: get_reference(x))), GenomeReference))
+           reference_genome=reference_genome_type)
 def parse_locus(s, reference_genome='default'):
     """Construct a locus expression by parsing a string or string expression.
 
@@ -708,7 +708,7 @@ def parse_locus(s, reference_genome='default'):
 
 
 @typecheck(s=expr_str,
-           reference_genome=oneof(transformed((std_str, lambda x: get_reference(x))), GenomeReference))
+           reference_genome=reference_genome_type)
 def parse_variant(s, reference_genome='default'):
     """Construct a struct with a locus and alleles by parsing a string.
 
@@ -841,7 +841,7 @@ def interval(start, end):
 
 
 @typecheck(s=expr_str,
-           reference_genome=oneof(transformed((std_str, lambda x: get_reference(x))), GenomeReference))
+           reference_genome=reference_genome_type)
 def parse_interval(s, reference_genome='default'):
     """Construct an interval expression by parsing a string or string expression.
 

--- a/python/hail/expr/functions.py
+++ b/python/hail/expr/functions.py
@@ -641,7 +641,8 @@ def index(structs, identifier):
                           structs._indices, structs._aggregations, structs._joins, structs._refs)
 
 
-@typecheck(contig=expr_str, pos=expr_int32, reference_genome=oneof(str, GenomeReference))
+@typecheck(contig=expr_str, pos=expr_int32,
+           reference_genome=oneof(transformed((std_str, lambda x: get_reference(x))), GenomeReference))
 def locus(contig, pos, reference_genome='default'):
     """Construct a locus expression from a chromosome and position.
 
@@ -659,7 +660,7 @@ def locus(contig, pos, reference_genome='default'):
     pos : int or :class:`.Expression` of type :class:`.TInt32`
         Base position along the chromosome.
     reference_genome : :obj:`str` or :class:`.GenomeReference`
-        Reference genome to use. ``default`` is :func:`~hail.default_reference`.
+        Reference genome to use.
 
     Returns
     -------
@@ -668,15 +669,13 @@ def locus(contig, pos, reference_genome='default'):
     contig = to_expr(contig)
     pos = to_expr(pos)
 
-    if isinstance(reference_genome, std_str):
-        reference_genome = get_reference(reference_genome)
-
     indices, aggregations, joins, refs = unify_all(contig, pos)
     return construct_expr(ApplyMethod('Locus({})'.format(reference_genome.name), contig._ast, pos._ast),
                           tlocus(reference_genome), indices, aggregations, joins, refs)
 
 
-@typecheck(s=expr_str, reference_genome=oneof(str, GenomeReference))
+@typecheck(s=expr_str,
+           reference_genome=oneof(transformed((std_str, lambda x: get_reference(x))), GenomeReference))
 def parse_locus(s, reference_genome='default'):
     """Construct a locus expression by parsing a string or string expression.
 
@@ -697,22 +696,19 @@ def parse_locus(s, reference_genome='default'):
     s : str or :class:`.StringExpression`
         String to parse.
     reference_genome : :obj:`str` or :class:`.GenomeReference`
-        Reference genome to use. ``default`` is :func:`~hail.default_reference`.
+        Reference genome to use.
 
     Returns
     -------
     :class:`.LocusExpression`
     """
     s = to_expr(s)
-
-    if isinstance(reference_genome, std_str):
-        reference_genome = get_reference(reference_genome)
-
     return construct_expr(ApplyMethod('Locus({})'.format(reference_genome.name), s._ast), tlocus(reference_genome),
                           s._indices, s._aggregations, s._joins, s._refs)
 
 
-@typecheck(s=expr_str, reference_genome=oneof(str, GenomeReference))
+@typecheck(s=expr_str,
+           reference_genome=oneof(transformed((std_str, lambda x: get_reference(x))), GenomeReference))
 def parse_variant(s, reference_genome='default'):
     """Construct a struct with a locus and alleles by parsing a string.
 
@@ -736,7 +732,7 @@ def parse_variant(s, reference_genome='default'):
     s : :class:`.StringExpression`
         String to parse.
     reference_genome: :obj:`str` or :class:`.GenomeReference`
-        Reference genome to use. ``default`` is :func:`~hail.default_reference`.
+        Reference genome to use.
 
     Returns
     -------
@@ -744,10 +740,6 @@ def parse_variant(s, reference_genome='default'):
         Struct with fields `locus` and `alleles`.
     """
     s = to_expr(s)
-
-    if isinstance(reference_genome, std_str):
-        reference_genome = get_reference(reference_genome)
-
     t = tstruct(['locus', 'alleles'], [tlocus(reference_genome), tarray(tstr)])
     return construct_expr(ApplyMethod('LocusAlleles({})'.format(reference_genome.name), s._ast), t,
                           s._indices, s._aggregations, s._joins, s._refs)
@@ -832,8 +824,6 @@ def interval(start, end):
         Starting locus (inclusive).
     end : :class:`.hail.genetics.Locus` or :class:`.LocusExpression`
         End locus (exclusive).
-    reference_genome : :class:`.GenomeReference` (optional)
-        Reference genome to use (uses :meth:`.default_reference` if not passed).
 
     Returns
     -------
@@ -850,7 +840,8 @@ def interval(start, end):
         indices, aggregations, joins, refs)
 
 
-@typecheck(s=expr_str, reference_genome=oneof(str, GenomeReference))
+@typecheck(s=expr_str,
+           reference_genome=oneof(transformed((std_str, lambda x: get_reference(x))), GenomeReference))
 def parse_interval(s, reference_genome='default'):
     """Construct an interval expression by parsing a string or string expression.
 
@@ -876,17 +867,13 @@ def parse_interval(s, reference_genome='default'):
     s : str or :class:`.StringExpression`
         String to parse.
     reference_genome : :obj:`str` or :class:`.hail.genetics.GenomeReference`
-        Reference genome to use. ``default`` is :func:`~hail.default_reference`.
+        Reference genome to use.
 
     Returns
     -------
     :class:`.IntervalExpression`
     """
     s = to_expr(s)
-
-    if isinstance(reference_genome, std_str):
-        reference_genome = get_reference(reference_genome)
-
     return construct_expr(
         ApplyMethod('LocusInterval({})'.format(reference_genome.name), s._ast), tinterval(tlocus(reference_genome)),
         s._indices, s._aggregations, s._joins, s._refs)

--- a/python/hail/expr/types.py
+++ b/python/hail/expr/types.py
@@ -771,15 +771,14 @@ class TLocus(Type):
     Parameters
     ----------
     reference_genome: :class:`.GenomeReference` or :obj:`str`
-        Reference genome to use. Default is
-        :meth:`hail.default_reference`.
+        Reference genome to use. ``default`` is :func:`~hail.default_reference`.
     """
 
-    @typecheck_method(reference_genome=nullable(oneof(genetics.GenomeReference, str)))
-    def __init__(self, reference_genome=None):
-        if reference_genome is not None:
-            if not isinstance(reference_genome, genetics.GenomeReference):
-                reference_genome = hl.get_reference(reference_genome)
+    @typecheck_method(reference_genome=oneof(genetics.GenomeReference, str))
+    def __init__(self, reference_genome='default'):
+        if isinstance(reference_genome, str):
+            reference_genome = hl.get_reference(reference_genome)
+
         self._rg = reference_genome
         self._get_jtype = lambda: scala_object(Env.hail().expr.types, 'TLocus').apply(self.reference_genome._jrep,
                                                                                       False)

--- a/python/hail/expr/types.py
+++ b/python/hail/expr/types.py
@@ -771,16 +771,13 @@ class TLocus(Type):
     Parameters
     ----------
     reference_genome: :class:`.GenomeReference` or :obj:`str`
-        Reference genome to use. ``default`` is :func:`~hail.default_reference`.
+        Reference genome to use.
     """
 
-    @typecheck_method(reference_genome=oneof(genetics.GenomeReference, str))
+    @typecheck_method(reference_genome=oneof(transformed((str, lambda x: hl.get_reference(x))), genetics.GenomeReference))
     def __init__(self, reference_genome='default'):
-        if isinstance(reference_genome, str):
-            reference_genome = hl.get_reference(reference_genome)
-
         self._rg = reference_genome
-        self._get_jtype = lambda: scala_object(Env.hail().expr.types, 'TLocus').apply(self.reference_genome._jrep,
+        self._get_jtype = lambda: scala_object(Env.hail().expr.types, 'TLocus').apply(self._rg._jrep,
                                                                                       False)
         super(TLocus, self).__init__()
 

--- a/python/hail/expr/types.py
+++ b/python/hail/expr/types.py
@@ -5,6 +5,7 @@ from hail.history import *
 from hail.typecheck import *
 from hail.utils import Struct
 from hail.utils.java import scala_object, jset, jindexed_seq, Env, jarray_to_list, escape_parsable
+from hail.genetics.genomeref import reference_genome_type
 from hail import genetics
 from hail.expr.type_parsing import type_grammar, type_node_visitor
 
@@ -774,7 +775,7 @@ class TLocus(Type):
         Reference genome to use.
     """
 
-    @typecheck_method(reference_genome=oneof(transformed((str, lambda x: hl.get_reference(x))), genetics.GenomeReference))
+    @typecheck_method(reference_genome=reference_genome_type)
     def __init__(self, reference_genome='default'):
         self._rg = reference_genome
         self._get_jtype = lambda: scala_object(Env.hail().expr.types, 'TLocus').apply(self._rg._jrep,

--- a/python/hail/genetics/genomeref.py
+++ b/python/hail/genetics/genomeref.py
@@ -8,7 +8,7 @@ class GenomeReference(HistoryMixin):
     """An object that represents a `reference genome <https://en.wikipedia.org/wiki/Reference_genome>`__.
 
     :param str name: Name of reference. Must be unique and not one of Hail's
-    predefined references "GRCh37", "GRCh38", and "default".
+        predefined references "GRCh37", "GRCh38", and "default".
 
     :param contigs: Contig names.
     :type contigs: list of str

--- a/python/hail/genetics/genomeref.py
+++ b/python/hail/genetics/genomeref.py
@@ -7,7 +7,8 @@ from hail.utils.java import handle_py4j, jiterable_to_list, Env
 class GenomeReference(HistoryMixin):
     """An object that represents a `reference genome <https://en.wikipedia.org/wiki/Reference_genome>`__.
 
-    :param str name: Name of reference. Must be unique and not one of Hail's predefined references "GRCh37" and "GRCh38".
+    :param str name: Name of reference. Must be unique and not one of Hail's
+    predefined references "GRCh37", "GRCh38", and "default".
 
     :param contigs: Contig names.
     :type contigs: list of str

--- a/python/hail/genetics/genomeref.py
+++ b/python/hail/genetics/genomeref.py
@@ -2,6 +2,8 @@ from hail.history import *
 from hail.typecheck import *
 from hail.utils import wrap_to_list
 from hail.utils.java import handle_py4j, jiterable_to_list, Env
+from hail.typecheck import oneof, transformed
+import hail as hl
 
 
 class GenomeReference(HistoryMixin):
@@ -306,3 +308,5 @@ class GenomeReference(HistoryMixin):
     @handle_py4j
     def _check_interval(self, interval_jrep):
         self._jrep.checkInterval(interval_jrep)
+
+reference_genome_type = oneof(transformed((str, lambda x: hl.get_reference(x))), GenomeReference)

--- a/python/hail/genetics/interval.py
+++ b/python/hail/genetics/interval.py
@@ -1,4 +1,4 @@
-from hail.genetics.genomeref import GenomeReference
+from hail.genetics.genomeref import GenomeReference, reference_genome_type
 from hail.genetics.locus import Locus
 from hail.history import *
 from hail.typecheck import *
@@ -65,7 +65,7 @@ class Interval(HistoryMixin):
     @handle_py4j
     @record_classmethod
     @typecheck_method(string=str,
-                      reference_genome=oneof(transformed((str, lambda x: hl.get_reference(x))), GenomeReference))
+                      reference_genome=reference_genome_type)
     def parse(cls, string, reference_genome='default'):
         """Parses a genomic interval from string representation.
 

--- a/python/hail/genetics/interval.py
+++ b/python/hail/genetics/interval.py
@@ -3,6 +3,7 @@ from hail.genetics.locus import Locus
 from hail.history import *
 from hail.typecheck import *
 from hail.utils.java import *
+import hail as hl
 
 interval_type = lazy()
 
@@ -64,7 +65,7 @@ class Interval(HistoryMixin):
     @handle_py4j
     @record_classmethod
     @typecheck_method(string=str,
-                      reference_genome=oneof(str, GenomeReference))
+                      reference_genome=oneof(transformed((str, lambda x: hl.get_reference(x))), GenomeReference))
     def parse(cls, string, reference_genome='default'):
         """Parses a genomic interval from string representation.
 
@@ -105,18 +106,12 @@ class Interval(HistoryMixin):
         string : :obj:`str`
             String to parse.
         reference_genome : :obj:`str` or :class:`.GenomeReference`
-            Reference genome to use. ``default`` is :class:`~hail.default_reference`.
+            Reference genome to use.
 
         Returns
         -------
         :class:`.Interval`
         """
-
-        from hail import default_reference, get_reference
-        if reference_genome == 'default':
-            reference_genome = default_reference()
-        elif isinstance(reference_genome, str):
-            reference_genome = get_reference(reference_genome)
 
         jrep = scala_object(Env.hail().variant, 'Locus').parseInterval(string, reference_genome._jrep)
         return Interval._from_java(jrep, reference_genome)

--- a/python/hail/genetics/locus.py
+++ b/python/hail/genetics/locus.py
@@ -1,4 +1,4 @@
-from hail.genetics.genomeref import GenomeReference
+from hail.genetics.genomeref import GenomeReference, reference_genome_type
 from hail.history import *
 from hail.typecheck import *
 from hail.utils.java import scala_object, handle_py4j, Env
@@ -19,7 +19,7 @@ class Locus(HistoryMixin):
     @record_init
     @typecheck_method(contig=oneof(str, int),
                       position=int,
-                      reference_genome=oneof(transformed((str, lambda x: hl.get_reference(x))), GenomeReference))
+                      reference_genome=reference_genome_type)
     def __init__(self, contig, position, reference_genome='default'):
         if isinstance(contig, int):
             contig = str(contig)
@@ -61,7 +61,7 @@ class Locus(HistoryMixin):
     @handle_py4j
     @record_classmethod
     @typecheck_method(string=str,
-                      reference_genome=oneof(transformed((str, lambda x: hl.get_reference(x))), GenomeReference))
+                      reference_genome=reference_genome_type)
     def parse(cls, string, reference_genome='default'):
         """Parses a locus object from a CHR:POS string.
 

--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -318,7 +318,7 @@ def export_vcf(dataset, output, append_to_header=None, parallel=None, metadata=N
 
 @handle_py4j
 @typecheck(path=str,
-           reference_genome=nullable(oneof(str, GenomeReference)))
+           reference_genome=nullable(oneof(transformed((str, lambda x: get_reference(x))), GenomeReference)))
 def import_interval_list(path, reference_genome='default'):
     """Import an interval list as a :class:`.Table`.
 
@@ -373,16 +373,13 @@ def import_interval_list(path, reference_genome='default'):
         Path to file.
 
     reference_genome : :obj:`str` or :class:`.GenomeReference`, optional
-        Reference genome to use. ``default`` is :func:`~hail.default_reference`.
+        Reference genome to use.
 
     Returns
     -------
     :class:`.Table`
         Interval-keyed table.
     """
-
-    if isinstance(reference_genome, str):
-        reference_genome = get_reference(reference_genome)
     rg = reference_genome._jrep if reference_genome else None
 
     t = Env.hail().table.Table.importIntervalList(Env.hc()._jhc, path, joption(rg))
@@ -391,7 +388,7 @@ def import_interval_list(path, reference_genome='default'):
 
 @handle_py4j
 @typecheck(path=str,
-           reference_genome=nullable(oneof(str, GenomeReference)))
+           reference_genome=nullable(oneof(transformed((str, lambda x: get_reference(x))), GenomeReference)))
 def import_bed(path, reference_genome='default'):
     """Import a UCSC .bed file as a :class:`.Table`.
 
@@ -454,7 +451,7 @@ def import_bed(path, reference_genome='default'):
         Path to .bed file.
 
     reference_genome : :obj:`str` or :class:`.GenomeReference`, optional
-        Reference genome to use. ``default`` is :func:`~hail.default_reference`.
+        Reference genome to use.
 
     Returns
     -------
@@ -474,10 +471,6 @@ def import_bed(path, reference_genome='default'):
     # >>> bed = hl.import_bed('data/file2.bed')
     # >>> vds_result = vds.annotate_rows(cnvID = bed[vds.locus])
 
-    from hail import get_reference
-
-    if isinstance(reference_genome, str):
-        reference_genome = get_reference(reference_genome)
     rg = reference_genome._jrep if reference_genome else None
 
     jt = Env.hail().table.Table.importBED(Env.hc()._jhc, path, joption(rg))
@@ -595,7 +588,7 @@ def grep(regex, path, max_count=100):
            sample_file=nullable(str),
            entry_fields=listof(str),
            min_partitions=nullable(int),
-           reference_genome=nullable(oneof(str, GenomeReference)),
+           reference_genome=nullable(oneof(transformed((str, lambda x: get_reference(x))), GenomeReference)),
            contig_recoding=nullable(dictof(str, str)),
            tolerance=numeric)
 def import_bgen(path, entry_fields, sample_file=None,
@@ -694,7 +687,7 @@ def import_bgen(path, entry_fields, sample_file=None,
     min_partitions : :obj:`int`, optional
         Number of partitions.
     reference_genome : :obj:`str` or :class:`.GenomeReference`, optional
-        Reference genome to use. ``default`` is :func:`~hail.default_reference`.
+        Reference genome to use.
     contig_recoding : :obj:`dict` of :obj:`str` to :obj:`str`, optional
         Dict of old contig name to new contig name. The new contig name must be
         in the reference genome given by `reference_genome`.
@@ -707,8 +700,6 @@ def import_bgen(path, entry_fields, sample_file=None,
     :class:`.MatrixTable`
     """
 
-    if isinstance(reference_genome, str):
-        reference_genome = get_reference(reference_genome)
     rg = reference_genome._jrep if reference_genome else None
 
     if not entry_fields:
@@ -738,7 +729,7 @@ def import_bgen(path, entry_fields, sample_file=None,
            tolerance=numeric,
            min_partitions=nullable(int),
            chromosome=nullable(str),
-           reference_genome=nullable(oneof(str, GenomeReference)),
+           reference_genome=nullable(oneof(transformed((str, lambda x: get_reference(x))), GenomeReference)),
            contig_recoding=nullable(dictof(str, str)))
 def import_gen(path, sample_file=None, tolerance=0.2, min_partitions=None, chromosome=None,
                reference_genome='default', contig_recoding=None):
@@ -813,7 +804,7 @@ def import_gen(path, sample_file=None, tolerance=0.2, min_partitions=None, chrom
     chromosome : :obj:`str`, optional
         Chromosome if not included in the GEN file
     reference_genome : :obj:`str` or :class:`.GenomeReference`, optional
-        Reference genome to use. ``default`` is :func:`~hail.default_reference`.
+        Reference genome to use.
     contig_recoding : :obj:`dict` of :obj:`str` to :obj:`str`, optional
         Dict of old contig name to new contig name. The new contig name must be
         in the reference genome given by `reference_genome`.
@@ -823,8 +814,6 @@ def import_gen(path, sample_file=None, tolerance=0.2, min_partitions=None, chrom
     :class:`.MatrixTable`
     """
 
-    if isinstance(reference_genome, str):
-        reference_genome = get_reference(reference_genome)
     rg = reference_genome._jrep if reference_genome else None
 
     if contig_recoding:
@@ -1147,7 +1136,7 @@ def import_matrix_table(paths, row_fields={}, key=[], entry_type=tint32, missing
            missing=str,
            quant_pheno=bool,
            a2_reference=bool,
-           reference_genome=nullable(oneof(GenomeReference, str)),
+           reference_genome=nullable(oneof(transformed((str, lambda x: get_reference(x))), GenomeReference)),
            contig_recoding=nullable(dictof(str, str)))
 def import_plink(bed, bim, fam,
                  min_partitions=None,
@@ -1250,7 +1239,7 @@ def import_plink(bed, bim, fam,
         as the reference allele.
 
     reference_genome : :obj:`str` or :class:`.GenomeReference`, optional
-        Reference genome to use. ``default`` is :func:`~hail.default_reference`.
+        Reference genome to use.
 
     contig_recoding : :obj:`dict` of :obj:`str` to :obj:`str`, optional
         Dict of old contig name to new contig name. The new contig name must be
@@ -1261,8 +1250,6 @@ def import_plink(bed, bim, fam,
     :class:`.MatrixTable`
     """
 
-    if isinstance(reference_genome, str):
-        reference_genome = get_reference(reference_genome)
     rg = reference_genome._jrep if reference_genome else None
 
     if contig_recoding:
@@ -1361,7 +1348,7 @@ def get_vcf_metadata(path):
            min_partitions=nullable(int),
            drop_samples=bool,
            call_fields=oneof(str, listof(str)),
-           reference_genome=nullable(oneof(str, GenomeReference)),
+           reference_genome=nullable(oneof(transformed((str, lambda x: get_reference(x))), GenomeReference)),
            contig_recoding=nullable(dictof(str, str)))
 def import_vcf(path, force=False, force_bgz=False, header_file=None, min_partitions=None,
                drop_samples=False, call_fields=[], reference_genome='default', contig_recoding=None):
@@ -1466,7 +1453,7 @@ def import_vcf(path, force=False, force_bgz=False, header_file=None, min_partiti
         List of FORMAT fields to load as :class:`.TCall`. "GT" is loaded as
         a call automatically.
     reference_genome: :obj:`str` or :class:`.GenomeReference`, optional
-        Reference genome to use. ``default`` is :func:`~hail.default_reference`.
+        Reference genome to use.
     contig_recoding: :obj:`dict` of (:obj:`str`, :obj:`str`)
         Mapping from contig name in VCF to contig name in loaded dataset.
         All contigs must be present in the `reference_genome`, so this is
@@ -1477,8 +1464,6 @@ def import_vcf(path, force=False, force_bgz=False, header_file=None, min_partiti
     :class:`.MatrixTable`
     """
 
-    if isinstance(reference_genome, str):
-        reference_genome = get_reference(reference_genome)
     rg = reference_genome._jrep if reference_genome else None
 
     if contig_recoding:

--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -6,9 +6,8 @@ from hail.matrixtable import MatrixTable
 from hail.table import Table
 from hail.expr.types import *
 from hail.expr.expression import analyze, expr_any
-from hail.genetics import GenomeReference
+from hail.genetics.genomeref import reference_genome_type
 from hail.methods.misc import require_biallelic
-from hail.context import get_reference
 
 
 @handle_py4j
@@ -318,7 +317,7 @@ def export_vcf(dataset, output, append_to_header=None, parallel=None, metadata=N
 
 @handle_py4j
 @typecheck(path=str,
-           reference_genome=nullable(oneof(transformed((str, lambda x: get_reference(x))), GenomeReference)))
+           reference_genome=nullable(reference_genome_type))
 def import_interval_list(path, reference_genome='default'):
     """Import an interval list as a :class:`.Table`.
 
@@ -388,7 +387,7 @@ def import_interval_list(path, reference_genome='default'):
 
 @handle_py4j
 @typecheck(path=str,
-           reference_genome=nullable(oneof(transformed((str, lambda x: get_reference(x))), GenomeReference)))
+           reference_genome=nullable(reference_genome_type))
 def import_bed(path, reference_genome='default'):
     """Import a UCSC .bed file as a :class:`.Table`.
 
@@ -588,7 +587,7 @@ def grep(regex, path, max_count=100):
            sample_file=nullable(str),
            entry_fields=listof(str),
            min_partitions=nullable(int),
-           reference_genome=nullable(oneof(transformed((str, lambda x: get_reference(x))), GenomeReference)),
+           reference_genome=nullable(reference_genome_type),
            contig_recoding=nullable(dictof(str, str)),
            tolerance=numeric)
 def import_bgen(path, entry_fields, sample_file=None,
@@ -729,7 +728,7 @@ def import_bgen(path, entry_fields, sample_file=None,
            tolerance=numeric,
            min_partitions=nullable(int),
            chromosome=nullable(str),
-           reference_genome=nullable(oneof(transformed((str, lambda x: get_reference(x))), GenomeReference)),
+           reference_genome=nullable(reference_genome_type),
            contig_recoding=nullable(dictof(str, str)))
 def import_gen(path, sample_file=None, tolerance=0.2, min_partitions=None, chromosome=None,
                reference_genome='default', contig_recoding=None):
@@ -1136,7 +1135,7 @@ def import_matrix_table(paths, row_fields={}, key=[], entry_type=tint32, missing
            missing=str,
            quant_pheno=bool,
            a2_reference=bool,
-           reference_genome=nullable(oneof(transformed((str, lambda x: get_reference(x))), GenomeReference)),
+           reference_genome=nullable(reference_genome_type),
            contig_recoding=nullable(dictof(str, str)))
 def import_plink(bed, bim, fam,
                  min_partitions=None,
@@ -1348,7 +1347,7 @@ def get_vcf_metadata(path):
            min_partitions=nullable(int),
            drop_samples=bool,
            call_fields=oneof(str, listof(str)),
-           reference_genome=nullable(oneof(transformed((str, lambda x: get_reference(x))), GenomeReference)),
+           reference_genome=nullable(reference_genome_type),
            contig_recoding=nullable(dictof(str, str)))
 def import_vcf(path, force=False, force_bgz=False, header_file=None, min_partitions=None,
                drop_samples=False, call_fields=[], reference_genome='default', contig_recoding=None):

--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -8,6 +8,7 @@ from hail.expr.types import *
 from hail.expr.expression import analyze, expr_any
 from hail.genetics import GenomeReference
 from hail.methods.misc import require_biallelic
+from hail.context import get_reference
 
 
 @handle_py4j
@@ -317,8 +318,8 @@ def export_vcf(dataset, output, append_to_header=None, parallel=None, metadata=N
 
 @handle_py4j
 @typecheck(path=str,
-           reference_genome=nullable(GenomeReference))
-def import_interval_list(path, reference_genome=None):
+           reference_genome=nullable(oneof(str, GenomeReference)))
+def import_interval_list(path, reference_genome='default'):
     """Import an interval list as a :class:`.Table`.
 
     Examples
@@ -339,13 +340,17 @@ def import_interval_list(path, reference_genome=None):
     A file in either of the first two formats produces a table with one
     field:
 
-     - **interval** (*Interval*), key field
+    - **interval** (:class:`.TInterval`) - Row key. Genomic interval. If
+      `reference_genome` is defined, the point type of the interval will be
+      :class:`.TLocus` parameterized by the `reference_genome`. Otherwise,
+      the point type is a :class:`.TStruct` with two fields: `contig` with
+      type :class:`.TString` and `position` with type :class:`.TInt32`.
 
     A file in the third format (with a "target" column) produces a table with two
     fields:
 
-     - **interval** (*Interval*), key field
-     - **target** (*String*)
+     - **interval** (:class:`.TInterval`) - Row key. Same schema as above.
+     - **target** (:class:`.TString`)
 
     Note
     ----
@@ -367,8 +372,8 @@ def import_interval_list(path, reference_genome=None):
     path : :obj:`str`
         Path to file.
 
-    reference_genome : :class:`.GenomeReference`
-        Reference genome to use. Default is :func:`~hail.default_reference`.
+    reference_genome : :obj:`str` or :class:`.GenomeReference`, optional
+        Reference genome to use. ``default`` is :func:`~hail.default_reference`.
 
     Returns
     -------
@@ -376,16 +381,18 @@ def import_interval_list(path, reference_genome=None):
         Interval-keyed table.
     """
 
-    from hail import default_reference
-    rg = reference_genome if reference_genome else default_reference()
-    t = Env.hail().table.Table.importIntervalList(Env.hc()._jhc, path, rg._jrep)
+    if isinstance(reference_genome, str):
+        reference_genome = get_reference(reference_genome)
+    rg = reference_genome._jrep if reference_genome else None
+
+    t = Env.hail().table.Table.importIntervalList(Env.hc()._jhc, path, joption(rg))
     return Table(t)
 
 
 @handle_py4j
 @typecheck(path=str,
-           reference_genome=nullable(GenomeReference))
-def import_bed(path, reference_genome=None):
+           reference_genome=nullable(oneof(str, GenomeReference)))
+def import_bed(path, reference_genome='default'):
     """Import a UCSC .bed file as a :class:`.Table`.
 
     Examples
@@ -419,12 +426,16 @@ def import_bed(path, reference_genome=None):
     the .bed file has only three fields (`chrom`, `chromStart`, and
     `chromEnd`), then the produced table has only one column:
 
-        - **interval** (*Interval*) - Genomic interval.
+        - **interval** (:class:`.TInterval`) - Row key. Genomic interval. If
+          `reference_genome` is defined, the point type of the interval will be
+          :class:`.TLocus` parameterized by the `reference_genome`. Otherwise,
+          the point type is a :class:`.TStruct` with two fields: `contig` with
+          type :class:`.TString` and `position` with type :class:`.TInt32`.
 
     If the .bed file has four or more columns, then Hail will store the fourth
     column as a field in the table:
 
-        - **interval** (*Interval*) - Genomic interval.
+        - **interval** (*Interval*) - Row key. Genomic interval. Same schema as above.
         - **target** (*String*) - Fourth column of .bed file.
 
     `UCSC bed files <https://genome.ucsc.edu/FAQ/FAQformat.html#format1>`__ can
@@ -442,8 +453,8 @@ def import_bed(path, reference_genome=None):
     path : :obj:`str`
         Path to .bed file.
 
-    reference_genome : :class:`.GenomeReference`
-        Reference genome to use. Default is :func:`~hail.default_reference`.
+    reference_genome : :obj:`str` or :class:`.GenomeReference`, optional
+        Reference genome to use. ``default`` is :func:`~hail.default_reference`.
 
     Returns
     -------
@@ -463,10 +474,13 @@ def import_bed(path, reference_genome=None):
     # >>> bed = hl.import_bed('data/file2.bed')
     # >>> vds_result = vds.annotate_rows(cnvID = bed[vds.locus])
 
-    from hail import default_reference
-    rg = reference_genome if reference_genome else default_reference()
+    from hail import get_reference
 
-    jt = Env.hail().table.Table.importBED(Env.hc()._jhc, path, rg._jrep)
+    if isinstance(reference_genome, str):
+        reference_genome = get_reference(reference_genome)
+    rg = reference_genome._jrep if reference_genome else None
+
+    jt = Env.hail().table.Table.importBED(Env.hc()._jhc, path, joption(rg))
     return Table(jt)
 
 
@@ -581,11 +595,11 @@ def grep(regex, path, max_count=100):
            sample_file=nullable(str),
            entry_fields=listof(str),
            min_partitions=nullable(int),
-           reference_genome=nullable(GenomeReference),
+           reference_genome=nullable(oneof(str, GenomeReference)),
            contig_recoding=nullable(dictof(str, str)),
            tolerance=numeric)
 def import_bgen(path, entry_fields, sample_file=None,
-                min_partitions=None, reference_genome=None,
+                min_partitions=None, reference_genome='default',
                 contig_recoding=None, tolerance=0.2):
     """Import BGEN file(s) as a :class:`.MatrixTable`.
 
@@ -630,10 +644,15 @@ def import_bgen(path, entry_fields, sample_file=None,
 
     **Row Fields**
 
-    - `v` (:class:`.TVariant`) -- Row key. This is the variant created from the
-      chromosome, position, reference allele (A allele in the v1.1 spec and
-      first allele in the v1.2 spec), and alternate alleles in each variant
-      identifying block.
+    - `locus` (:class:`.TLocus` or :class:`.TStruct`) -- Row key. The chromosome
+      and position. If `reference_genome` is defined, the type will be
+      :class:`.TLocus` parameterized by `reference_genome`. Otherwise, the type
+      will be a :class:`.TStruct` with two fields: `contig` with type
+      :class:`.TString` and `position` with type :class:`.TInt32`.
+    - `alleles` (:class:`.TArray` of :class:`.TString`) -- Row key. An array
+      containing the alleles of the variant. The reference allele (A allele in
+      the v1.1 spec and first allele in the v1.2 spec) is the first element in
+      the array.
     - `varid` (:class:`.TString`) -- The variant identifier. The third field in
       each variant identifying block.
     - `rsid` (:class:`.TString`) -- The rsID for the variant. The fifth field in
@@ -674,9 +693,8 @@ def import_bgen(path, entry_fields, sample_file=None,
         samples in the file must match the number in the BGEN file(s).
     min_partitions : :obj:`int`, optional
         Number of partitions.
-    reference_genome : :class:`.GenomeReference`, optional
-        Reference genome to use. Default is :func:`~hail.default_reference`
-        The row key will have type ``TVariant(reference_genome)``.
+    reference_genome : :obj:`str` or :class:`.GenomeReference`, optional
+        Reference genome to use. ``default`` is :func:`~hail.default_reference`.
     contig_recoding : :obj:`dict` of :obj:`str` to :obj:`str`, optional
         Dict of old contig name to new contig name. The new contig name must be
         in the reference genome given by `reference_genome`.
@@ -689,8 +707,9 @@ def import_bgen(path, entry_fields, sample_file=None,
     :class:`.MatrixTable`
     """
 
-    from hail import default_reference
-    rg = reference_genome if reference_genome else default_reference()
+    if isinstance(reference_genome, str):
+        reference_genome = get_reference(reference_genome)
+    rg = reference_genome._jrep if reference_genome else None
 
     if not entry_fields:
         raise FatalError("import_bgen: entry_fields must be non-empty."
@@ -709,7 +728,7 @@ def import_bgen(path, entry_fields, sample_file=None,
 
     jmt = Env.hc()._jhc.importBgens(jindexed_seq_args(path), joption(sample_file),
                                     'GT' in entry_set, 'GP' in entry_set, 'dosage' in entry_set,
-                                    joption(min_partitions), rg._jrep, joption(contig_recoding), tolerance)
+                                    joption(min_partitions), joption(rg), joption(contig_recoding), tolerance)
     return MatrixTable(jmt)
 
 
@@ -719,10 +738,10 @@ def import_bgen(path, entry_fields, sample_file=None,
            tolerance=numeric,
            min_partitions=nullable(int),
            chromosome=nullable(str),
-           reference_genome=nullable(GenomeReference),
+           reference_genome=nullable(oneof(str, GenomeReference)),
            contig_recoding=nullable(dictof(str, str)))
-def import_gen(path, sample_file=None, tolerance=0.2, min_partitions=None, chromosome=None, reference_genome=None,
-               contig_recoding=None):
+def import_gen(path, sample_file=None, tolerance=0.2, min_partitions=None, chromosome=None,
+               reference_genome='default', contig_recoding=None):
     """
     Import GEN file(s) as a :class:`.MatrixTable`.
 
@@ -752,11 +771,18 @@ def import_gen(path, sample_file=None, tolerance=0.2, min_partitions=None, chrom
 
     **Row Fields**
 
-    - `v` (:class:`.TVariant`) -- Row key. This is the variant created from the
-      contig (1st column if present, otherwise given by `chromosome`), position
-      (3rd column if chromosome is not present), reference allele (4th column if
-      chromosome is not present), and alternate allele (5th column if chromosome
-      is not present).
+    - `locus` (:class:`.TLocus` or :class:`.TStruct`) -- Row key. The genomic
+      location consisting of the chromosome (1st column if present, otherwise
+      given by `chromosome`) and position (3rd column if `chromosome` is not
+      defined). If `reference_genome` is defined, the type will be
+      :class:`.TLocus` parameterized by `reference_genome`. Otherwise, the type
+      will be a :class:`.TStruct` with two fields: `contig` with type
+      :class:`.TString` and `position` with type :class:`.TInt32`.
+    - `alleles` (:class:`.TArray` of :class:`.TString`) -- Row key. An array
+      containing the alleles of the variant. The reference allele (4th column if
+      `chromosome` is not defined) is the first element of the array and the
+      alternate allele (5th column if `chromosome` is not defined) is the second
+      element.
     - `varid` (:class:`.TString`) -- The variant identifier. 2nd column of GEN
       file if chromosome present, otherwise 1st column.
     - `rsid` (:class:`.TString`) -- The rsID. 3rd column of GEN file if
@@ -786,9 +812,8 @@ def import_gen(path, sample_file=None, tolerance=0.2, min_partitions=None, chrom
         Number of partitions.
     chromosome : :obj:`str`, optional
         Chromosome if not included in the GEN file
-    reference_genome : :class:`.GenomeReference`
-        Reference genome to use. Default is :func:`~hail.default_reference`
-        The row key will have type ``TVariant(reference_genome)``.
+    reference_genome : :obj:`str` or :class:`.GenomeReference`, optional
+        Reference genome to use. ``default`` is :func:`~hail.default_reference`.
     contig_recoding : :obj:`dict` of :obj:`str` to :obj:`str`, optional
         Dict of old contig name to new contig name. The new contig name must be
         in the reference genome given by `reference_genome`.
@@ -798,14 +823,15 @@ def import_gen(path, sample_file=None, tolerance=0.2, min_partitions=None, chrom
     :class:`.MatrixTable`
     """
 
-    from hail import default_reference
-    rg = reference_genome if reference_genome else default_reference()
+    if isinstance(reference_genome, str):
+        reference_genome = get_reference(reference_genome)
+    rg = reference_genome._jrep if reference_genome else None
 
     if contig_recoding:
         contig_recoding = tdict(tstr, tstr)._convert_to_j(contig_recoding)
 
     jmt = Env.hc()._jhc.importGens(jindexed_seq_args(path), sample_file, joption(chromosome), joption(min_partitions),
-                                   tolerance, rg._jrep, joption(contig_recoding))
+                                   tolerance, joption(rg), joption(contig_recoding))
     return MatrixTable(jmt)
 
 
@@ -819,10 +845,9 @@ def import_gen(path, sample_file=None, tolerance=0.2, min_partitions=None, chrom
            delimiter=str,
            missing=str,
            types=dictof(str, Type),
-           quote=nullable(char),
-           reference_genome=nullable(GenomeReference))
+           quote=nullable(char))
 def import_table(paths, key=[], min_partitions=None, impute=False, no_header=False,
-                 comment=None, delimiter="\t", missing="NA", types={}, quote=None, reference_genome=None):
+                 comment=None, delimiter="\t", missing="NA", types={}, quote=None):
     """Import delimited text file (text table) as :class:`.Table`.
 
     The resulting :class:`.Table` will have no key fields. Use
@@ -966,9 +991,6 @@ def import_table(paths, key=[], min_partitions=None, impute=False, no_header=Fal
         Dictionary defining field types.
     quote: :obj:`str` or :obj:`None`
         Quote character.
-    reference_genome: :class:`.GenomeReference`
-        Reference genome to use when imputing Variant or Locus fields. Default
-        is :func:`~hail.default_reference`
 
     Returns
     -------
@@ -978,11 +1000,8 @@ def import_table(paths, key=[], min_partitions=None, impute=False, no_header=Fal
     paths = wrap_to_list(paths)
     jtypes = {k: v._jtype for k, v in types.items()}
 
-    from hail import default_reference
-    rg = reference_genome if reference_genome else default_reference()
-
     jt = Env.hc()._jhc.importTable(paths, key, min_partitions, jtypes, comment, delimiter, missing,
-                                   no_header, impute, quote, rg._jrep)
+                                   no_header, impute, quote)
     return Table(jt)
 
 @handle_py4j
@@ -1128,21 +1147,19 @@ def import_matrix_table(paths, row_fields={}, key=[], entry_type=tint32, missing
            missing=str,
            quant_pheno=bool,
            a2_reference=bool,
-           reference_genome=nullable(GenomeReference),
-           contig_recoding=nullable(dictof(str, str)),
-           drop_chr0=bool)
+           reference_genome=nullable(oneof(GenomeReference, str)),
+           contig_recoding=nullable(dictof(str, str)))
 def import_plink(bed, bim, fam,
                  min_partitions=None,
                  delimiter='\\\\s+',
                  missing='NA',
                  quant_pheno=False,
                  a2_reference=True,
-                 reference_genome=None,
+                 reference_genome='default',
                  contig_recoding={'23': 'X',
                                   '24': 'Y',
                                   '25': 'X',
-                                  '26': 'MT'},
-                 drop_chr0=False):
+                                  '26': 'MT'}):
     """Import a PLINK dataset (BED, BIM, FAM) as a :class:`.MatrixTable`.
 
     Examples
@@ -1168,7 +1185,15 @@ def import_plink(bed, bim, fam,
 
     * Row fields:
 
-        * `v` (:class:`.TVariant`) -- Variant (key field).
+        * `locus` (:class:`.TLocus` or :class:`.TStruct`) -- Row key. The
+          chromosome and position. If `reference_genome` is defined, the type
+          will be :class:`.TLocus` parameterized by `reference_genome`.
+          Otherwise, the type will be a :class:`.TStruct` with two fields:
+          `contig` with type :class:`.TString` and `position` with type
+          :class:`.TInt32`.
+        * `alleles` (:class:`.TArray` of :class:`.TString`) -- Row key. An
+          array containing the alleles of the variant. The reference allele (A2
+          if `a2_reference` is ``True``) is the first element in the array.
         * `rsid` (:class:`.TString`) -- Column 2 in the BIM file.
 
     * Column fields:
@@ -1224,23 +1249,21 @@ def import_plink(bed, bim, fam,
         If True, A2 is treated as the reference allele. If False, A1 is treated
         as the reference allele.
 
-    reference_genome : :class:`.GenomeReference`
-        Reference genome to use. Default is
-        :class:`~.HailContext.default_reference`.
+    reference_genome : :obj:`str` or :class:`.GenomeReference`, optional
+        Reference genome to use. ``default`` is :func:`~hail.default_reference`.
 
     contig_recoding : :obj:`dict` of :obj:`str` to :obj:`str`, optional
         Dict of old contig name to new contig name. The new contig name must be
         in the reference genome given by ``reference_genome``.
-
-    drop_chr0 : :obj:`bool`
-        If true, do not include variants with contig == "0".
 
     Returns
     -------
     :class:`.MatrixTable`
     """
 
-    rg = reference_genome if reference_genome else Env.hc().default_reference
+    if isinstance(reference_genome, str):
+        reference_genome = get_reference(reference_genome)
+    rg = reference_genome._jrep if reference_genome else None
 
     if contig_recoding:
         contig_recoding = tdict(tstr,
@@ -1248,8 +1271,8 @@ def import_plink(bed, bim, fam,
 
     jmt = Env.hc()._jhc.importPlink(bed, bim, fam, joption(min_partitions),
                                     delimiter, missing, quant_pheno,
-                                    a2_reference, rg._jrep,
-                                    joption(contig_recoding), drop_chr0)
+                                    a2_reference, joption(rg),
+                                    joption(contig_recoding))
 
     return MatrixTable(jmt)
 
@@ -1338,10 +1361,10 @@ def get_vcf_metadata(path):
            min_partitions=nullable(int),
            drop_samples=bool,
            call_fields=oneof(str, listof(str)),
-           reference_genome=nullable(GenomeReference),
+           reference_genome=nullable(oneof(str, GenomeReference)),
            contig_recoding=nullable(dictof(str, str)))
 def import_vcf(path, force=False, force_bgz=False, header_file=None, min_partitions=None,
-               drop_samples=False, call_fields=[], reference_genome=None, contig_recoding=None):
+               drop_samples=False, call_fields=[], reference_genome='default', contig_recoding=None):
     """Import VCF file(s) as a :class:`.MatrixTable`.
 
     Examples
@@ -1395,8 +1418,16 @@ def import_vcf(path, force=False, force_bgz=False, header_file=None, min_partiti
 
     **Row Fields**
 
-    - `v` (:class:`.TVariant`) -- Row key. This is the variant created from the CHROM,
-      POS, REF, and ALT fields.
+    - `locus` (:class:`.TLocus` or :class:`.TStruct`) -- Row key. The
+      chromosome (CHROM field) and position (POS field). If `reference_genome`
+      is defined, the type will be :class:`.TLocus` parameterized by
+      `reference_genome`. Otherwise, the type will be a :class:`.TStruct` with
+      two fields: `contig` with type :class:`.TString` and `position` with type
+      :class:`.TInt32`.
+    - `alleles` (:class:`.TArray` of :class:`.TString`) -- Row key. An array
+      containing the alleles of the variant. The reference allele (REF field) is
+      the first element in the array and the alternate alleles (ALT field) are
+      the subsequent elements.
     - `filters` (:class:`.TSet` of :class:`.TString`) -- Set containing all filters applied to a
       variant.
     - `rsid` (:class:`.TString`) -- rsID of the variant.
@@ -1434,9 +1465,8 @@ def import_vcf(path, force=False, force_bgz=False, header_file=None, min_partiti
     call_fields : :obj:`list` of :obj:`str`
         List of FORMAT fields to load as :class:`.TCall`. "GT" is loaded as
         a call automatically.
-    reference_genome: :class:`.GenomeReference`, optional
-        Reference genome to use. If ``None``, then the
-        :func:`~hail.default_reference` is used.
+    reference_genome: :obj:`str` or :class:`.GenomeReference`, optional
+        Reference genome to use. ``default`` is :func:`~hail.default_reference`.
     contig_recoding: :obj:`dict` of (:obj:`str`, :obj:`str`)
         Mapping from contig name in VCF to contig name in loaded dataset.
         All contigs must be present in the `reference_genome`, so this is
@@ -1446,15 +1476,17 @@ def import_vcf(path, force=False, force_bgz=False, header_file=None, min_partiti
     -------
     :class:`.MatrixTable`
     """
-    from hail import default_reference
-    rg = reference_genome if reference_genome else default_reference()
+
+    if isinstance(reference_genome, str):
+        reference_genome = get_reference(reference_genome)
+    rg = reference_genome._jrep if reference_genome else None
 
     if contig_recoding:
         contig_recoding = tdict(tstr, tstr)._convert_to_j(contig_recoding)
 
     jmt = Env.hc()._jhc.importVCFs(jindexed_seq_args(path), force, force_bgz, joption(header_file),
-                                   joption(min_partitions), drop_samples, jset_args(call_fields), rg._jrep,
-                                   joption(contig_recoding))
+                                   joption(min_partitions), drop_samples, jset_args(call_fields),
+                                   joption(rg), joption(contig_recoding))
 
     return MatrixTable(jmt)
 

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -2267,7 +2267,7 @@ def rrm(call_expr):
            fst=nullable(listof(numeric)),
            af_dist=oneof(UniformDist, BetaDist, TruncatedBetaDist),
            seed=int,
-           reference_genome=oneof(str, GenomeReference))
+           reference_genome=oneof(transformed((str, lambda x: get_reference(x))), GenomeReference))
 def balding_nichols_model(num_populations, num_samples, num_variants, num_partitions=None,
                           pop_dist=None, fst=None, af_dist=UniformDist(0.1, 0.9),
                           seed=0, reference_genome='default'):
@@ -2405,7 +2405,7 @@ def balding_nichols_model(num_populations, num_samples, num_variants, num_partit
     seed : :obj:`int`
         Random seed.
     reference_genome : :obj:`str` or :class:`.GenomeReference`
-        Reference genome to use. ``default`` is :class:`~.HailContext.default_reference`.
+        Reference genome to use.
 
     Returns
     -------
@@ -2422,9 +2422,6 @@ def balding_nichols_model(num_populations, num_samples, num_variants, num_partit
         jvm_fst_opt = joption(fst)
     else:
         jvm_fst_opt = joption(jarray(Env.jvm().double, fst))
-
-    if isinstance(reference_genome, str):
-        reference_genome = get_reference(reference_genome)
 
     jmt = Env.hc()._jhc.baldingNicholsModel(num_populations, num_samples, num_variants,
                                             joption(num_partitions),

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -4,6 +4,7 @@ from hail.matrixtable import MatrixTable
 from hail.table import Table
 from hail.expr.expression import *
 from hail.genetics import KinshipMatrix, GenomeReference
+from hail.genetics.genomeref import reference_genome_type
 from hail.linalg import BlockMatrix
 from hail.typecheck import *
 from hail.utils import wrap_to_list, new_temp_file, info
@@ -11,7 +12,6 @@ from hail.utils.java import handle_py4j, joption, jarray
 from hail.utils.misc import check_collisions
 from hail.methods.misc import require_biallelic, require_variant
 from hail.stats import UniformDist, BetaDist, TruncatedBetaDist
-from hail.context import get_reference
 import itertools
 
 
@@ -2267,7 +2267,7 @@ def rrm(call_expr):
            fst=nullable(listof(numeric)),
            af_dist=oneof(UniformDist, BetaDist, TruncatedBetaDist),
            seed=int,
-           reference_genome=oneof(transformed((str, lambda x: get_reference(x))), GenomeReference))
+           reference_genome=reference_genome_type)
 def balding_nichols_model(num_populations, num_samples, num_variants, num_partitions=None,
                           pop_dist=None, fst=None, af_dist=UniformDist(0.1, 0.9),
                           seed=0, reference_genome='default'):

--- a/python/hail/typecheck/check.py
+++ b/python/hail/typecheck/check.py
@@ -346,8 +346,10 @@ def setof(t):
 def dictof(k, v):
     return DictChecker(only(k), only(v))
 
+
 def func_spec(n, tc):
     return FunctionChecker(n, only(tc))
+
 
 def transformed(*tcs):
     fs = []

--- a/src/main/scala/is/hail/expr/types/TLocus.scala
+++ b/src/main/scala/is/hail/expr/types/TLocus.scala
@@ -15,6 +15,11 @@ object TLocus {
       "position" -> +TInt32())
     rep.setRequired(required).asInstanceOf[TStruct]
   }
+
+  def schemaFromGR(gr: Option[GenomeReference], required: Boolean = false): Type = gr match {
+    case Some(ref) => TLocus(ref)
+    case None => TLocus.representation(required)
+  }
 }
 
 case class TLocus(gr: GRBase, override val required: Boolean = false) extends ComplexType {

--- a/src/main/scala/is/hail/io/annotators/BedAnnotator.scala
+++ b/src/main/scala/is/hail/io/annotators/BedAnnotator.scala
@@ -64,17 +64,7 @@ object BedAnnotator {
           val start = spl(1).toInt + 1
           val end = spl(2).toInt + 1
 
-          val startLocus = gr match {
-            case Some(ref) => Locus(chrom, start, ref)
-            case None => Annotation(chrom, start)
-          }
-
-          val endLocus = gr match {
-            case Some(ref) => Locus(chrom, end, ref)
-            case None => Annotation(chrom, end)
-          }
-
-          val interval = Interval(startLocus, endLocus, true, false)
+          val interval = Interval(Locus(chrom, start, gr), Locus(chrom, end, gr), true, false)
 
           if (hasTarget)
             Row(interval, spl(3))

--- a/src/main/scala/is/hail/io/annotators/BedAnnotator.scala
+++ b/src/main/scala/is/hail/io/annotators/BedAnnotator.scala
@@ -1,14 +1,16 @@
 package is.hail.io.annotators
 
 import is.hail.HailContext
+import is.hail.annotations.Annotation
 import is.hail.expr.types._
+import is.hail.io.vcf.LoadVCF
 import is.hail.table.Table
 import is.hail.utils.{Interval, _}
 import is.hail.variant._
 import org.apache.spark.sql.Row
 
 object BedAnnotator {
-  def apply(hc: HailContext, filename: String, gr: GenomeReference = GenomeReference.defaultReference): Table = {
+  def apply(hc: HailContext, filename: String, gr: Option[GenomeReference] = Some(GenomeReference.defaultReference)): Table = {
     // this annotator reads files in the UCSC BED spec defined here: https://genome.ucsc.edu/FAQ/FAQformat.html#format1
 
     val hasTarget = hc.hadoopConf.readLines(filename) { lines =>
@@ -37,12 +39,14 @@ object BedAnnotator {
 
     val expectedLength = if (hasTarget) 4 else 3
 
-    val schema = if (hasTarget)
-      TStruct("interval" -> TInterval(TLocus(gr)), "target" -> TString())
-    else
-      TStruct("interval" -> TInterval(TLocus(gr)))
+    val locusSchema = TLocus.schemaFromGR(gr)
 
-    implicit val ord = TInterval(gr.locusType).ordering
+    val schema = if (hasTarget)
+      TStruct("interval" -> TInterval(locusSchema), "target" -> TString())
+    else
+      TStruct("interval" -> TInterval(locusSchema))
+
+    implicit val ord = TInterval(locusSchema).ordering
 
     val rdd = hc.sc.textFileLines(filename)
       .filter(line =>
@@ -59,7 +63,18 @@ object BedAnnotator {
           // transform BED 0-based coordinates to Hail/VCF 1-based coordinates
           val start = spl(1).toInt + 1
           val end = spl(2).toInt + 1
-          val interval = Interval(Locus(chrom, start), Locus(chrom, end), true, false)
+
+          val startLocus = gr match {
+            case Some(ref) => Locus(chrom, start, ref)
+            case None => Annotation(chrom, start)
+          }
+
+          val endLocus = gr match {
+            case Some(ref) => Locus(chrom, end, ref)
+            case None => Annotation(chrom, end)
+          }
+
+          val interval = Interval(startLocus, endLocus, true, false)
 
           if (hasTarget)
             Row(interval, spl(3))

--- a/src/main/scala/is/hail/io/annotators/IntervalList.scala
+++ b/src/main/scala/is/hail/io/annotators/IntervalList.scala
@@ -50,24 +50,16 @@ object IntervalList {
             val split = line.split("\\s+")
             split match {
               case Array(contig, start, end, dir, target) =>
-                val interval = gr match {
-                  case Some(ref) => Interval(Locus(contig, start.toInt, ref), Locus(contig, end.toInt, ref),
-                    includeStart = true, includeEnd = true)
-                  case None => Interval(Annotation(contig, start.toInt), Annotation(contig, end.toInt),
-                    includeStart = true, includeEnd = true)
-                }
+                val interval = Interval(Locus(contig, start.toInt, gr), Locus(contig, end.toInt, gr),
+                  includeStart = true, includeEnd = true)
                 Row(interval, target)
               case arr => fatal(s"expected 5 fields, but found ${ arr.length }")
             }
           } else {
             line match {
               case intervalRegex(contig, start, end) =>
-                val interval = gr match {
-                  case Some(ref) => Interval(Locus(contig, start.toInt, ref), Locus(contig, end.toInt, ref),
-                    includeStart = true, includeEnd = true)
-                  case None => Interval(Annotation(contig, start.toInt), Annotation(contig, end.toInt),
-                    includeStart = true, includeEnd = true)
-                }
+                val interval = Interval(Locus(contig, start.toInt, gr), Locus(contig, end.toInt, gr),
+                  includeStart = true, includeEnd = true)
                 Row(interval)
               case _ => fatal("invalid interval")
             }

--- a/src/main/scala/is/hail/io/annotators/IntervalList.scala
+++ b/src/main/scala/is/hail/io/annotators/IntervalList.scala
@@ -1,6 +1,7 @@
 package is.hail.io.annotators
 
 import is.hail.HailContext
+import is.hail.annotations.Annotation
 import is.hail.expr.types._
 import is.hail.table.Table
 import is.hail.utils.{Interval, _}
@@ -12,7 +13,7 @@ object IntervalList {
 
   val intervalRegex = """([^:]*)[:\t](\d+)[\-\t](\d+)""".r
 
-  def read(hc: HailContext, filename: String, gr: GenomeReference = GenomeReference.defaultReference): Table = {
+  def read(hc: HailContext, filename: String, gr: Option[GenomeReference] = Some(GenomeReference.defaultReference)): Table = {
     val hasValue = hc.hadoopConf.readLines(filename) {
       lines =>
         val skipHeader = lines.filter(l => !l.value.isEmpty && l.value(0) != '@')
@@ -32,12 +33,14 @@ object IntervalList {
         }.value
     }
 
+    val locusSchema = TLocus.schemaFromGR(gr)
+    
     val schema = if (hasValue)
-      TStruct("interval" -> TInterval(TLocus(gr)), "target" -> TString())
+      TStruct("interval" -> TInterval(locusSchema), "target" -> TString())
     else
-      TStruct("interval" -> TInterval(TLocus(gr)))
+      TStruct("interval" -> TInterval(locusSchema))
 
-    implicit val ord = gr.locusType.ordering
+    implicit val ord = locusSchema.ordering
 
     val rdd = hc.sc.textFileLines(filename)
       .filter(l => !l.value.isEmpty && l.value(0) != '@')
@@ -47,14 +50,25 @@ object IntervalList {
             val split = line.split("\\s+")
             split match {
               case Array(contig, start, end, dir, target) =>
-                val interval = Interval(Locus(contig, start.toInt), Locus(contig, end.toInt), includeStart = true, includeEnd = true)
+                val interval = gr match {
+                  case Some(ref) => Interval(Locus(contig, start.toInt, ref), Locus(contig, end.toInt, ref),
+                    includeStart = true, includeEnd = true)
+                  case None => Interval(Annotation(contig, start.toInt), Annotation(contig, end.toInt),
+                    includeStart = true, includeEnd = true)
+                }
                 Row(interval, target)
               case arr => fatal(s"expected 5 fields, but found ${ arr.length }")
             }
           } else {
             line match {
-              case intervalRegex(contig, startStr, endStr) =>
-                Row(Interval(Locus(contig, startStr.toInt), Locus(contig, endStr.toInt), includeStart = true, includeEnd = true))
+              case intervalRegex(contig, start, end) =>
+                val interval = gr match {
+                  case Some(ref) => Interval(Locus(contig, start.toInt, ref), Locus(contig, end.toInt, ref),
+                    includeStart = true, includeEnd = true)
+                  case None => Interval(Annotation(contig, start.toInt), Annotation(contig, end.toInt),
+                    includeStart = true, includeEnd = true)
+                }
+                Row(interval)
               case _ => fatal("invalid interval")
             }
           }

--- a/src/main/scala/is/hail/io/bgen/BgenRecord.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenRecord.scala
@@ -5,7 +5,7 @@ import is.hail.io.{ByteArrayReader, KeySerializedValueRecord}
 import is.hail.utils._
 import is.hail.variant.{Call2, Genotype, Variant}
 
-abstract class BgenRecord extends KeySerializedValueRecord[Variant] {
+abstract class BgenRecord extends KeySerializedValueRecord[(String, Int, Array[String])] {
   var ann: Annotation = _
 
   def setAnnotation(ann: Annotation) {

--- a/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -154,16 +154,8 @@ object LoadBgen {
         region.clear()
         rvb.start(rowType)
         rvb.startStruct()
+        rvb.addAnnotation(kType.types(0), Locus(contigRecoded, pos, gr))
 
-        gr match {
-          case Some(gr) =>
-            rvb.addAnnotation(kType.types(0), Locus(contigRecoded, pos, gr))
-          case None =>
-            rvb.startStruct()
-            rvb.addString(contigRecoded)
-            rvb.addInt(pos)
-            rvb.endStruct()
-        }
         val nAlleles = alleles.length
         rvb.startArray(nAlleles)
         var i = 0

--- a/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -28,7 +28,7 @@ object LoadBgen {
     includeGP: Boolean,
     includeDosage: Boolean,
     nPartitions: Option[Int] = None,
-    gr: GenomeReference = GenomeReference.defaultReference,
+    gr: Option[GenomeReference] = Some(GenomeReference.defaultReference),
     contigRecoding: Map[String, String] = Map.empty[String, String],
     tolerance: Double): MatrixTable = {
     
@@ -80,7 +80,7 @@ object LoadBgen {
     info(s"Number of samples in BGEN files: $nSamples")
     info(s"Number of variants across all BGEN files: $nVariants")
 
-    val signature = TStruct("locus" -> TLocus(gr),
+    val signature = TStruct("locus" -> TLocus.schemaFromGR(gr),
       "alleles" -> TArray(TString()),
       "rsid" -> TString(),
       "varid" -> TString())
@@ -109,15 +109,30 @@ object LoadBgen {
       val rv = RegionValue(region)
 
       it.map { case (_, record) =>
-        val v = record.getKey
-        val vRecoded = v.copy(contig = contigRecoding.getOrElse(v.contig, v.contig))
-        gr.checkVariant(vRecoded)
+        val (contig, pos, alleles) = record.getKey
+        val contigRecoded = contigRecoding.getOrElse(contig, contig)
 
         region.clear()
         rvb.start(kType)
         rvb.startStruct()
-        rvb.addAnnotation(kType.types(0), vRecoded.locus) // locus/pk
-        rvb.addAnnotation(kType.types(1), IndexedSeq(vRecoded.ref, vRecoded.alt))
+
+        gr match {
+          case Some(gr) =>
+            rvb.addAnnotation(kType.types(0), Locus(contigRecoded, pos, gr))
+          case None =>
+            rvb.startStruct()
+            rvb.addString(contigRecoded)
+            rvb.addInt(pos)
+            rvb.endStruct()
+        }
+        val nAlleles = alleles.length
+        rvb.startArray(nAlleles)
+        var i = 0
+        while (i < nAlleles) {
+          rvb.addString(alleles(i))
+          i += 1
+        }
+        rvb.endArray()
         rvb.endStruct()
 
         rv.setOffset(rvb.end())
@@ -131,17 +146,32 @@ object LoadBgen {
       val rv = RegionValue(region)
 
       it.map { case (_, record) =>
-        val v = record.getKey
+        val (contig, pos, alleles) = record.getKey
         val va = record.getAnnotation.asInstanceOf[Row]
 
-        val vRecoded = v.copy(contig = contigRecoding.getOrElse(v.contig, v.contig))
-        gr.checkVariant(vRecoded)
+        val contigRecoded = contigRecoding.getOrElse(contig, contig)
 
         region.clear()
         rvb.start(rowType)
         rvb.startStruct()
-        rvb.addAnnotation(rowType.types(0), vRecoded.locus)
-        rvb.addAnnotation(kType.types(1), IndexedSeq(vRecoded.ref, vRecoded.alt))
+
+        gr match {
+          case Some(gr) =>
+            rvb.addAnnotation(kType.types(0), Locus(contigRecoded, pos, gr))
+          case None =>
+            rvb.startStruct()
+            rvb.addString(contigRecoded)
+            rvb.addInt(pos)
+            rvb.endStruct()
+        }
+        val nAlleles = alleles.length
+        rvb.startArray(nAlleles)
+        var i = 0
+        while (i < nAlleles) {
+          rvb.addString(alleles(i))
+          i += 1
+        }
+        rvb.endArray()
         rvb.addAnnotation(rowType.types(2), va.get(0))
         rvb.addAnnotation(rowType.types(3), va.get(1))
         record.getValue(rvb) // gs

--- a/src/main/scala/is/hail/io/gen/LoadGen.scala
+++ b/src/main/scala/is/hail/io/gen/LoadGen.scala
@@ -48,10 +48,7 @@ object LoadGen {
     val alt = arr(5 - chrCol)
 
     val recodedContig = contigRecoding.getOrElse(chr, chr)
-    val locus = gr match {
-      case Some(gr) => Locus(recodedContig, start.toInt, gr)
-      case None => Annotation(recodedContig, start.toInt)
-    }
+    val locus = Locus(recodedContig, start.toInt, gr)
     val alleles = Array(ref, alt).toFastIndexedSeq
 
     val gp = arr.drop(6 - chrCol).map {

--- a/src/main/scala/is/hail/io/gen/LoadGen.scala
+++ b/src/main/scala/is/hail/io/gen/LoadGen.scala
@@ -13,7 +13,7 @@ import scala.collection.mutable
 case class GenResult(file: String, nSamples: Int, nVariants: Int, rdd: RDD[(Annotation, Iterable[Annotation])])
 
 object LoadGen {
-  def apply(genFile: String, sampleFile: String, sc: SparkContext, gr: GenomeReference,
+  def apply(genFile: String, sampleFile: String, sc: SparkContext, gr: Option[GenomeReference],
     nPartitions: Option[Int] = None, tolerance: Double = 0.02,
     chromosome: Option[String] = None, contigRecoding: Map[String, String] = Map.empty[String, String]): GenResult = {
 
@@ -34,7 +34,7 @@ object LoadGen {
 
   def readGenLine(line: String, nSamples: Int,
     tolerance: Double,
-    gr: GenomeReference,
+    gr: Option[GenomeReference],
     chromosome: Option[String] = None,
     contigRecoding: Map[String, String] = Map.empty[String, String]): (Annotation, Iterable[Annotation]) = {
 
@@ -48,10 +48,12 @@ object LoadGen {
     val alt = arr(5 - chrCol)
 
     val recodedContig = contigRecoding.getOrElse(chr, chr)
-    val locus = Locus(recodedContig, start.toInt, gr)
+    val locus = gr match {
+      case Some(gr) => Locus(recodedContig, start.toInt, gr)
+      case None => Annotation(recodedContig, start.toInt)
+    }
     val alleles = Array(ref, alt).toFastIndexedSeq
 
-    val nGenotypes = 3
     val gp = arr.drop(6 - chrCol).map {
       _.toDouble
     }

--- a/src/main/scala/is/hail/io/plink/LoadPlink.scala
+++ b/src/main/scala/is/hail/io/plink/LoadPlink.scala
@@ -149,15 +149,7 @@ object LoadPlink {
         region.clear()
         rvb.start(kType)
         rvb.startStruct()
-        gr match {
-          case Some(gr) =>
-            rvb.addAnnotation(kType.types(0), Locus(contig, pos, gr))
-          case None =>
-            rvb.startStruct()
-            rvb.addString(contig)
-            rvb.addInt(pos)
-            rvb.endStruct()
-        }
+        rvb.addAnnotation(kType.types(0), Locus(contig, pos, gr))
         rvb.startArray(2)
         rvb.addString(ref)
         rvb.addString(alt)
@@ -180,15 +172,7 @@ object LoadPlink {
         region.clear()
         rvb.start(rvRowType)
         rvb.startStruct()
-        gr match {
-          case Some(gr) =>
-            rvb.addAnnotation(kType.types(0), Locus(contig, pos, gr))
-          case None =>
-            rvb.startStruct()
-            rvb.addString(contig)
-            rvb.addInt(pos)
-            rvb.endStruct()
-        }
+        rvb.addAnnotation(kType.types(0), Locus(contig, pos, gr))
         rvb.startArray(2)
         rvb.addString(ref)
         rvb.addString(alt)

--- a/src/main/scala/is/hail/io/plink/LoadPlink.scala
+++ b/src/main/scala/is/hail/io/plink/LoadPlink.scala
@@ -7,7 +7,7 @@ import is.hail.io.vcf.LoadVCF
 import is.hail.rvd.OrderedRVD
 import is.hail.utils.StringEscapeUtils._
 import is.hail.utils._
-import is.hail.variant._
+import is.hail.variant.{Locus, _}
 import org.apache.hadoop
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.LongWritable
@@ -23,16 +23,15 @@ object LoadPlink {
   def expectedBedSize(nSamples: Int, nVariants: Long): Long = 3 + nVariants * ((nSamples + 3) / 4)
 
   private def parseBim(bimPath: String, hConf: Configuration, a2Reference: Boolean = true,
-    contigRecoding: Map[String, String] = Map.empty[String, String]): Array[(Variant, String)] = {
+    contigRecoding: Map[String, String] = Map.empty[String, String]): Array[(String, Int, String, String, String)] = {
     hConf.readLines(bimPath)(_.map(_.map { line =>
       line.split("\\s+") match {
         case Array(contig, rsId, morganPos, bpPos, allele1, allele2) =>
           val recodedContig = contigRecoding.getOrElse(contig, contig)
-
           if (a2Reference)
-            (Variant(recodedContig, bpPos.toInt, allele2, allele1), rsId)
+            (recodedContig, bpPos.toInt, allele2, allele1, rsId)
           else
-            (Variant(recodedContig, bpPos.toInt, allele1, allele2), rsId)
+            (recodedContig, bpPos.toInt, allele1, allele2, rsId)
 
         case other => fatal(s"Invalid .bim line.  Expected 6 fields, found ${ other.length } ${ plural(other.length, "field") }")
       }
@@ -113,11 +112,10 @@ object LoadPlink {
     bedPath: String,
     sampleAnnotations: IndexedSeq[Annotation],
     sampleAnnotationSignature: TStruct,
-    variants: Array[(Variant, String)],
+    variants: Array[(String, Int, String, String, String)],
     nPartitions: Option[Int] = None,
     a2Reference: Boolean = true,
-    gr: GenomeReference = GenomeReference.defaultReference,
-    dropChr0: Boolean = false): MatrixTable = {
+    gr: Option[GenomeReference] = Some(GenomeReference.defaultReference)): MatrixTable = {
 
     val sc = hc.sc
     val nSamples = sampleAnnotations.length
@@ -132,7 +130,7 @@ object LoadPlink {
       globalType = TStruct.empty(),
       colKey = Array("s"),
       colType = sampleAnnotationSignature,
-      rowType = TStruct("locus" -> TLocus(gr), "alleles" -> TArray(TString()), "rsid" -> TString()),
+      rowType = TStruct("locus" -> TLocus.schemaFromGR(gr), "alleles" -> TArray(TString()), "rsid" -> TString()),
       rowKey = Array("locus", "alleles"),
       rowPartitionKey = Array("locus"),
       entryType = TStruct(required = true, "GT" -> TCall()))
@@ -145,25 +143,29 @@ object LoadPlink {
       val rvb = new RegionValueBuilder(region)
       val rv = RegionValue(region)
 
-      it.flatMap { case (_, record) =>
-        val (v, _) = variantsBc.value(record.getKey)
+      it.map { case (_, record) =>
+        val (contig, pos, ref, alt, rsid) = variantsBc.value(record.getKey)
 
-        if (dropChr0 && v.contig == "0")
-          None
-        else {
-          region.clear()
-          rvb.start(kType)
-          rvb.startStruct()
-          rvb.addAnnotation(kType.types(0), v.locus) // locus/pk
-          rvb.startArray(2)
-          rvb.addString(v.ref)
-          rvb.addString(v.alt)
-          rvb.endArray()
-          rvb.endStruct()
-
-          rv.setOffset(rvb.end())
-          Some(rv)
+        region.clear()
+        rvb.start(kType)
+        rvb.startStruct()
+        gr match {
+          case Some(gr) =>
+            rvb.addAnnotation(kType.types(0), Locus(contig, pos, gr))
+          case None =>
+            rvb.startStruct()
+            rvb.addString(contig)
+            rvb.addInt(pos)
+            rvb.endStruct()
         }
+        rvb.startArray(2)
+        rvb.addString(ref)
+        rvb.addString(alt)
+        rvb.endArray()
+        rvb.endStruct()
+
+        rv.setOffset(rvb.end())
+        rv
       }
     }
 
@@ -172,24 +174,31 @@ object LoadPlink {
       val rvb = new RegionValueBuilder(region)
       val rv = RegionValue(region)
 
-      it.flatMap { case (_, record) =>
-        val (v, rsid) = variantsBc.value(record.getKey)
+      it.map { case (_, record) =>
+        val (contig, pos, ref, alt, rsid) = variantsBc.value(record.getKey)
 
-        if (dropChr0 && v.contig == "0")
-          None
-        else {
-          region.clear()
-          rvb.start(rvRowType)
-          rvb.startStruct()
-          rvb.addAnnotation(rvRowType.types(0), v.locus) // locus/pk
-          rvb.addAnnotation(rvRowType.types(1), IndexedSeq(v.ref, v.alt))
-          rvb.addAnnotation(rvRowType.types(2), rsid)
-          record.getValue(rvb)
-          rvb.endStruct()
-
-          rv.setOffset(rvb.end())
-          Some(rv)
+        region.clear()
+        rvb.start(rvRowType)
+        rvb.startStruct()
+        gr match {
+          case Some(gr) =>
+            rvb.addAnnotation(kType.types(0), Locus(contig, pos, gr))
+          case None =>
+            rvb.startStruct()
+            rvb.addString(contig)
+            rvb.addInt(pos)
+            rvb.endStruct()
         }
+        rvb.startArray(2)
+        rvb.addString(ref)
+        rvb.addString(alt)
+        rvb.endArray()
+        rvb.addAnnotation(rvRowType.types(2), rsid)
+        record.getValue(rvb)
+        rvb.endStruct()
+
+        rv.setOffset(rvb.end())
+        rv
       }
     }
 
@@ -200,8 +209,8 @@ object LoadPlink {
   }
 
   def apply(hc: HailContext, bedPath: String, bimPath: String, famPath: String, ffConfig: FamFileConfig,
-    nPartitions: Option[Int] = None, a2Reference: Boolean = true, gr: GenomeReference = GenomeReference.defaultReference,
-    contigRecoding: Map[String, String] = Map.empty[String, String], dropChr0: Boolean = false): MatrixTable = {
+    nPartitions: Option[Int] = None, a2Reference: Boolean = true, gr: Option[GenomeReference] = Some(GenomeReference.defaultReference),
+    contigRecoding: Map[String, String] = Map.empty[String, String]): MatrixTable = {
     val (sampleInfo, signature) = parseFam(famPath, ffConfig, hc.hadoopConf)
 
     val nameMap = Map("id" -> "s")
@@ -238,7 +247,7 @@ object LoadPlink {
     if (bedSize < nPartitions.getOrElse(hc.sc.defaultMinPartitions))
       fatal(s"The number of partitions requested (${ nPartitions.getOrElse(hc.sc.defaultMinPartitions) }) is greater than the file size ($bedSize)")
 
-    val vds = parseBed(hc, bedPath, sampleInfo, saSignature, variants, nPartitions, a2Reference, gr, dropChr0)
+    val vds = parseBed(hc, bedPath, sampleInfo, saSignature, variants, nPartitions, a2Reference, gr)
     vds
   }
 

--- a/src/main/scala/is/hail/io/vcf/LoadGDB.scala
+++ b/src/main/scala/is/hail/io/vcf/LoadGDB.scala
@@ -103,7 +103,7 @@ object LoadGDB {
                vcfHeaderPath: Option[String],
                nPartitions: Option[Int] = None,
                dropSamples: Boolean = false,
-               gr: GenomeReference = GenomeReference.defaultReference): MatrixTable = {
+               gr: Option[GenomeReference] = Some(GenomeReference.defaultReference)): MatrixTable = {
     val sc = hc.sc
 
     val codec = new htsjdk.variant.vcf.VCFCodec()
@@ -143,7 +143,7 @@ object LoadGDB {
     val (genotypeSignature, canonicalFlags, formatAttrs) = formatHeaderSignature(formatHeader, reader.callFields)
 
     val variantAnnotationSignatures = TStruct(
-      "locus" -> TLocus(gr),
+      "locus" -> TLocus.schemaFromGR(gr),
       "alleles" -> TArray(TString()),
       "rsid" -> TString(),
       "qual" -> TFloat64(),

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -93,12 +93,12 @@ object Table {
   }
 
   def importIntervalList(hc: HailContext, filename: String,
-    gr: GenomeReference = GenomeReference.defaultReference): Table = {
+    gr: Option[GenomeReference] = Some(GenomeReference.defaultReference)): Table = {
     IntervalList.read(hc, filename, gr)
   }
 
   def importBED(hc: HailContext, filename: String,
-    gr: GenomeReference = GenomeReference.defaultReference): Table = {
+    gr: Option[GenomeReference] = Some(GenomeReference.defaultReference)): Table = {
     BedAnnotator.apply(hc, filename, gr)
   }
 

--- a/src/main/scala/is/hail/utils/TextTableReader.scala
+++ b/src/main/scala/is/hail/utils/TextTableReader.scala
@@ -84,8 +84,7 @@ object TextTableReader {
   val intRegex = """^-?\d+$"""
 
   def imputeTypes(values: RDD[WithContext[String]], header: Array[String],
-    delimiter: String, missing: String, quote: java.lang.Character,
-    gr: GenomeReference = GenomeReference.defaultReference): Array[Option[Type]] = {
+    delimiter: String, missing: String, quote: java.lang.Character): Array[Option[Type]] = {
     val nFields = header.length
     val regexes = Array(booleanRegex, intRegex, doubleRegex).map(Pattern.compile)
 
@@ -143,8 +142,7 @@ object TextTableReader {
     noHeader: Boolean = false,
     impute: Boolean = false,
     nPartitions: Int = sc.defaultMinPartitions,
-    quote: java.lang.Character = null,
-    gr: GenomeReference = GenomeReference.defaultReference): (TStruct, RDD[WithContext[Row]]) = {
+    quote: java.lang.Character = null): (TStruct, RDD[WithContext[Row]]) = {
     require(files.nonEmpty)
 
     val firstFile = files.head
@@ -187,7 +185,7 @@ object TextTableReader {
         info("Reading table to impute column types")
 
         sb.append("Finished type imputation")
-        val imputedTypes = imputeTypes(rdd, columns, separator, missing, quote, gr)
+        val imputedTypes = imputeTypes(rdd, columns, separator, missing, quote)
         columns.zip(imputedTypes).map { case (name, imputedType) =>
           types.get(name) match {
             case Some(t) =>

--- a/src/main/scala/is/hail/variant/GenomeReference.scala
+++ b/src/main/scala/is/hail/variant/GenomeReference.scala
@@ -330,7 +330,7 @@ object GenomeReference {
   val GRCh37: GenomeReference = fromResource("reference/grch37.json")
   val GRCh38: GenomeReference = fromResource("reference/grch38.json")
   var defaultReference = GRCh37
-  val hailReferences = references.keySet
+  val hailReferences = references.keySet + "default"
 
   def addReference(gr: GenomeReference) {
     if (hasReference(gr.name))
@@ -348,7 +348,7 @@ object GenomeReference {
     }
   }
 
-  def hasReference(name: String): Boolean = references.contains(name)
+  def hasReference(name: String): Boolean = references.contains(name) || name == "default"
 
   def removeReference(name: String): Unit = {
     val nonBuiltInReferences = references.keySet -- hailReferences

--- a/src/main/scala/is/hail/variant/GenomeReference.scala
+++ b/src/main/scala/is/hail/variant/GenomeReference.scala
@@ -330,7 +330,8 @@ object GenomeReference {
   val GRCh37: GenomeReference = fromResource("reference/grch37.json")
   val GRCh38: GenomeReference = fromResource("reference/grch38.json")
   var defaultReference = GRCh37
-  val hailReferences = references.keySet + "default"
+  references += ("default" -> defaultReference)
+  val hailReferences = references.keySet
 
   def addReference(gr: GenomeReference) {
     if (hasReference(gr.name))
@@ -348,7 +349,7 @@ object GenomeReference {
     }
   }
 
-  def hasReference(name: String): Boolean = references.contains(name) || name == "default"
+  def hasReference(name: String): Boolean = references.contains(name)
 
   def removeReference(name: String): Unit = {
     val nonBuiltInReferences = references.keySet -- hailReferences

--- a/src/main/scala/is/hail/variant/Locus.scala
+++ b/src/main/scala/is/hail/variant/Locus.scala
@@ -1,7 +1,7 @@
 package is.hail.variant
 
+import is.hail.annotations.Annotation
 import is.hail.check.Gen
-import is.hail.expr.types.TInterval
 import is.hail.expr.Parser
 import is.hail.utils._
 import org.apache.spark.sql.Row
@@ -17,6 +17,13 @@ object Locus {
   def apply(contig: String, position: Int, gr: GRBase): Locus = {
     gr.checkLocus(contig, position)
     Locus(contig, position)
+  }
+
+  def apply(contig: String, position: Int, gr: Option[GenomeReference]): Annotation = {
+    gr match {
+      case Some(ref) => Locus(contig, position, ref)
+      case None => Annotation(contig, position)
+    }
   }
 
   def sparkSchema: StructType =

--- a/src/test/scala/is/hail/io/ExportVCFSuite.scala
+++ b/src/test/scala/is/hail/io/ExportVCFSuite.scala
@@ -55,9 +55,9 @@ class ExportVCFSuite extends SparkSuite {
       hadoopConf.delete(out, recursive = true)
       hadoopConf.delete(out2, recursive = true)
       ExportVCF(vds, out)
-      val vds2 = hc.importVCF(out, nPartitions = Some(nPar1), gr = vds.genomeReference)
+      val vds2 = hc.importVCF(out, nPartitions = Some(nPar1), gr = Some(vds.genomeReference))
       ExportVCF(vds, out2)
-      hc.importVCF(out2, nPartitions = Some(nPar2), gr = vds.genomeReference).same(vds2)
+      hc.importVCF(out2, nPartitions = Some(nPar2), gr = Some(vds.genomeReference)).same(vds2)
     }
 
     p.check()

--- a/src/test/scala/is/hail/io/ImportPlinkSuite.scala
+++ b/src/test/scala/is/hail/io/ImportPlinkSuite.scala
@@ -33,7 +33,7 @@ class ImportPlinkSuite extends SparkSuite {
 
         if (vds.numCols == 0) {
           TestUtils.interceptFatal("Empty .fam file") {
-            hc.importPlinkBFile(truthRoot, nPartitions = Some(nPartitions), gr = vds.genomeReference)
+            hc.importPlinkBFile(truthRoot, nPartitions = Some(nPartitions), gr = Some(vds.genomeReference))
           }
           true
         } else if (vds.countVariants() == 0) {
@@ -42,7 +42,7 @@ class ImportPlinkSuite extends SparkSuite {
           }
           true
         } else {
-          ExportPlink(hc.importPlinkBFile(truthRoot, nPartitions = Some(nPartitions), gr = vds.genomeReference),
+          ExportPlink(hc.importPlinkBFile(truthRoot, nPartitions = Some(nPartitions), gr = Some(vds.genomeReference)),
             testRoot)
 
           val localTruthRoot = tmpDir.createLocalTempFile("truth")
@@ -113,13 +113,5 @@ class ImportPlinkSuite extends SparkSuite {
       "row.nHetA1 == row.nHetA2 && " +
       "row.nHomRefA1 == row.nHomVarA2 && " +
       "row.nHomVarA1 == row.nHomRefA2"))
-  }
-
-  @Test def testDropChr0() {
-    val vds = VSMSubgen.plinkSafeBiallelic.copy(vGen = (t: Type) =>
-      VariantSubgen.biallelic.copy(contigGen = Contig.gen(Gen.const("0"))).gen).gen(hc).sample()
-    val outFile = tmpDir.createTempFile("plink_drop_chr0")
-    ExportPlink(vds, outFile)
-    assert(hc.importPlinkBFile(outFile, dropChr0 = true).countVariants() == 0)
   }
 }

--- a/src/test/scala/is/hail/io/ImportVCFSuite.scala
+++ b/src/test/scala/is/hail/io/ImportVCFSuite.scala
@@ -181,13 +181,13 @@ class ImportVCFSuite extends SparkSuite {
       val truth = {
         val f = tmpDir.createTempFile(extension="vcf")
         ExportVCF(vds, f)
-        hc.importVCF(f, gr = vds.genomeReference)
+        hc.importVCF(f, gr = Some(vds.genomeReference))
       }
 
       val actual = {
         val f = tmpDir.createTempFile(extension="vcf")
         ExportVCF(truth, f)
-        hc.importVCF(f, gr = vds.genomeReference)
+        hc.importVCF(f, gr = Some(vds.genomeReference))
       }
 
       truth.same(actual)

--- a/src/test/scala/is/hail/methods/LinearMixedRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearMixedRegressionSuite.scala
@@ -300,7 +300,8 @@ class LinearMixedRegressionSuite extends SparkSuite {
 
   lazy val vdsFastLMM = hc.importPlink(bed = "src/test/resources/fastlmmTest.bed",
     bim = "src/test/resources/fastlmmTest.bim",
-    fam = "src/test/resources/fastlmmTest.fam")
+    fam = "src/test/resources/fastlmmTest.fam",
+    gr = None)
     .annotateSamplesTable(covariates, root = "cov").annotateSamplesExpr("cov = sa.cov.f2")
     .annotateSamplesTable(phenotypes, root = "pheno").annotateSamplesExpr("pheno = sa.pheno.f2")
 


### PR DESCRIPTION
Previous behavior:
- `None` = default reference
 
Now:
- `default` = default reference

For import methods, `None` means don't convert to Locus(reference) and instead return a Struct with ["contig": String, "position": Int]. `None` is not valid for constructors, TLocus, and balding nichols.