### PR TITLE
* changed signature of maximal_independent_set method

### DIFF
--- a/python/hail/methods/misc.py
+++ b/python/hail/methods/misc.py
@@ -12,8 +12,8 @@ from hail.expr.ast import Reference
            j=Expression,
            keep=bool,
            tie_breaker=nullable(func_spec(2, expr_numeric)))
-def maximal_independent_set(i, j, keep, tie_breaker=None):
-    """Return a Table containing the vertices in a near
+def maximal_independent_set(i, j, keep=True, tie_breaker=None):
+    """Return a table containing the vertices in a near
     `maximal independent set <https://en.wikipedia.org/wiki/Maximal_independent_set>`_
     of an undirected graph whose edges are given by a two-column table.
 
@@ -88,27 +88,26 @@ def maximal_independent_set(i, j, keep, tie_breaker=None):
         Expression to compute one endpoint of an edge.
     j : :class:`.Expression`
         Expression to compute another endpoint of an edge.
-    keep : boolean
-        Boolean specifying whether to return vertices in set, or outside of set.
+    keep : :obj:`bool`
+        If ``True``, return vertices in set. If ``False``, return vertices removed.
     tie_breaker : function
         Function used to order nodes with equal degree.
 
     Returns
     -------
-    :class:`Table` filtered to the rows that belong in the approximate maximal independent set,
-    or the rows that belong in the complement of this set, if keep is False.
+    :class:`.Table`
     """
     if i.dtype != j.dtype:
-        raise ValueError("Expects arguments `i` and `j` to have same type. "
+        raise ValueError("'maximal_independent_set' expects arguments `i` and `j` to have same type. "
                          "Found {} and {}.".format(i.dtype, j.dtype))
     source = i._indices.source
     if not isinstance(source, Table):
-        raise ValueError("Expects an expression of 'Table', found {}".format(
+        raise ValueError("'maximal_independent_set' expects an expression of 'Table'. Found {}".format(
             "expression of '{}'".format(
                 source.__class__) if source is not None else 'scalar expression'))
     if i._indices.source != j._indices.source:
         raise ValueError(
-            "Expects arguments `i` and `j` to be expressions of the same Table. "
+            "'maximal_independent_set' expects arguments `i` and `j` to be expressions of the same Table. "
             "Found\n{}\n{}".format(i, j))
 
     node_t = i.dtype

--- a/python/hail/methods/tests.py
+++ b/python/hail/methods/tests.py
@@ -10,7 +10,6 @@ from hail.utils.misc import test_file, doctest_file
 from hail.linalg import BlockMatrix
 from math import sqrt
 
-
 def setUpModule():
     hl.init(master='local[2]', min_block_size=0)
 
@@ -526,21 +525,16 @@ class Tests(unittest.TestCase):
     def test_maximal_independent_set(self):
         # prefer to remove nodes with higher index
         t = hl.utils.range_table(10)
-        graph = t.select(i=t.idx.to_int64(), j=(t.idx + 10).to_int64(), bad_type=t.idx.to_float32())
+        graph = t.select(i=hl.int64(t.idx), j=hl.int64(t.idx + 10), bad_type=hl.float32(t.idx))
 
-        rows = [{'row_data': 'foo' + str(v)} for v in range(20)]
-        schema = hl.TStruct(['row_data'], [hl.TString()])
-        nodes = hl.Table.parallelize(rows, schema).index()
-
-        mis_table = hl.maximal_independent_set(nodes.idx, graph.i, graph.j, lambda l, r: l - r)
-        mis = [row['idx'] for row in mis_table.collect()]
+        mis_table = hl.maximal_independent_set(graph.i, graph.j, True, lambda l, r: l - r)
+        mis = [row['node'] for row in mis_table.collect()]
         self.assertEqual(sorted(mis), list(range(0, 10)))
-        self.assertEqual(mis_table.schema, nodes.schema)
+        self.assertEqual(mis_table.schema, hl.tstruct(node=hl.tint64))
 
-        self.assertRaises(ValueError, lambda: hl.maximal_independent_set(hl.capture(1), graph.i, graph.j))
-        self.assertRaises(ValueError, lambda: hl.maximal_independent_set(nodes.idx, graph.i, graph.bad_type))
-        self.assertRaises(ValueError, lambda: hl.maximal_independent_set(nodes.idx, graph.i, nodes.row_data))
-        self.assertRaises(ValueError, lambda: hl.maximal_independent_set(nodes.idx, hl.capture(1), hl.capture(2)))
+        self.assertRaises(ValueError, lambda: hl.maximal_independent_set(graph.i, graph.bad_type, True))
+        self.assertRaises(ValueError, lambda: hl.maximal_independent_set(graph.i, hl.utils.range_table(10).idx, True))
+        self.assertRaises(ValueError, lambda: hl.maximal_independent_set(hl.capture(1), hl.capture(2), True))
 
     def test_filter_alleles(self):
         # poor man's Gen

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -373,11 +373,15 @@ class Table(val hc: HailContext, val ir: TableIR) {
       globalSignature = finalType)
   }
 
-  def selectGlobal(exprs: java.util.ArrayList[String]): Table = {
+  def selectGlobal(fields: java.util.ArrayList[String]): Table = {
+    selectGlobal(fields.asScala.toArray: _*)
+  }
+
+  def selectGlobal(fields: String*): Table = {
     val ec = EvalContext("global" -> globalSignature)
     ec.set(0, globals)
 
-    val (paths, types, f) = Parser.parseSelectExprs(exprs.asScala.toArray, ec)
+    val (paths, types, f) = Parser.parseSelectExprs(fields.toArray, ec)
 
     val names = paths.map {
       case Left(n) => n
@@ -1184,7 +1188,7 @@ class Table(val hc: HailContext, val ir: TableIR) {
     copy(signature = newSignature.asInstanceOf[TStruct], rdd = newRDD)
   }
 
-  def maximalIndependentSet(iExpr: String, jExpr: String, tieBreakerExpr: Option[String] = None): Array[Any] = {
+  def maximalIndependentSet(iExpr: String, jExpr: String, tieBreakerExpr: Option[String]): Array[Any] = {
     val ec = rowEvalContext()
 
     val (iType, iThunk) = Parser.parseExpr(iExpr, ec)
@@ -1196,7 +1200,7 @@ class Table(val hc: HailContext, val ir: TableIR) {
     val tieBreakerEc = EvalContext("l" -> iType, "r" -> iType)
 
     val maybeTieBreaker = tieBreakerExpr.map { e =>
-      val tieBreakerThunk = Parser.parseTypedExpr[Int](e, tieBreakerEc)
+      val tieBreakerThunk = Parser.parseTypedExpr[Long](e, tieBreakerEc)
 
       (l: Any, r: Any) => {
         tieBreakerEc.setAll(l, r)
@@ -1213,6 +1217,27 @@ class Table(val hc: HailContext, val ir: TableIR) {
       warn(s"over 400,000 edges are in the graph; maximal_independent_set may run out of memory")
 
     Graph.maximalIndependentSet(edgeRdd.collect(), maybeTieBreaker)
+  }
+
+  def maximalIndependentSet(nodes: Table, nodeExpr: String, iExpr: String, jExpr: String,
+    maybeTieBreaker: Option[String] = None): Table = {
+
+    val (iType, _) = Parser.parseExpr(iExpr, rowEvalContext())
+    val (nodeType, _) = Parser.parseExpr(nodeExpr, nodes.rowEvalContext())
+
+    if (iType != nodeType) {
+      fatal(s"type of node in nodes table must match type of $iExpr in edges table, but type of" +
+        s" `$nodeExpr` is $nodeType, while type of $iExpr is $iType")
+    }
+
+    val relatedNodes = this.annotate("nodes = [" + iExpr + "," + jExpr + "]").select("row.nodes").explode("nodes").rdd
+      .mapPartitions(it => it.map(row => row.get(0))).collectAsSet()
+    val relatedNodesToKeep = this.maximalIndependentSet(iExpr, jExpr, maybeTieBreaker).toSet
+    val relatedNodesToRemove = relatedNodes -- relatedNodesToKeep
+
+    nodes.annotateGlobal(relatedNodesToRemove.toSet, TSet(iType), "relatedNodesToRemove")
+      .filter(s"global.relatedNodesToRemove.contains($nodeExpr)", keep = false)
+      .selectGlobal(nodes.globalSignature.fieldNames: _*)
   }
 
   def show(n: Int = 10, truncate: Option[Int] = None, printTypes: Boolean = true, maxWidth: Int = 100): Unit = {

--- a/src/main/scala/is/hail/utils/BinaryHeap.scala
+++ b/src/main/scala/is/hail/utils/BinaryHeap.scala
@@ -3,7 +3,7 @@ package is.hail.utils
 import scala.collection.mutable
 import scala.reflect.ClassTag
 
-class BinaryHeap[@specialized T: ClassTag](minimumCapacity: Int = 32, maybeTieBreaker: (T, T) => Int = null) {
+class BinaryHeap[@specialized T: ClassTag](minimumCapacity: Int = 32, maybeTieBreaker: (T, T) => Long = null) {
   private var ts: Array[T] = new Array[T](minimumCapacity)
   private var ranks: Array[Long] = new Array[Long](minimumCapacity)
   private val m: mutable.Map[T, Int] = new mutable.HashMap()
@@ -15,6 +15,7 @@ class BinaryHeap[@specialized T: ClassTag](minimumCapacity: Int = 32, maybeTieBr
   def size: Int = next
 
   def isEmpty: Boolean = next == 0
+
   def nonEmpty: Boolean = next != 0
 
   override def toString(): String =

--- a/src/main/scala/is/hail/utils/Graph.scala
+++ b/src/main/scala/is/hail/utils/Graph.scala
@@ -1,5 +1,6 @@
 package is.hail.utils
 
+
 import scala.collection.mutable
 import scala.reflect.ClassTag
 
@@ -31,11 +32,11 @@ object Graph {
     maximalIndependentSet(mkGraph(edges))
   }
 
-  def maximalIndependentSet[T: ClassTag](edges: Array[(T, T)], tieBreaker: (T, T) => Int): Array[T] = {
+  def maximalIndependentSet[T: ClassTag](edges: Array[(T, T)], tieBreaker: (T, T) => Long): Array[T] = {
     maximalIndependentSet(mkGraph(edges), Some(tieBreaker))
   }
 
-  def maximalIndependentSet[T: ClassTag](g: mutable.MultiMap[T, T], maybeTieBreaker: Option[(T, T) => Int] = None): Array[T] = {
+  def maximalIndependentSet[T: ClassTag](g: mutable.MultiMap[T, T], maybeTieBreaker: Option[(T, T) => Long] = None): Array[T] = {
     val verticesByDegree = new BinaryHeap[T](maybeTieBreaker = maybeTieBreaker.orNull)
 
     g.foreach { case (v, neighbors) =>
@@ -53,5 +54,4 @@ object Graph {
 
     verticesByDegree.toArray
   }
-
 }


### PR DESCRIPTION
to accept a table of vertices and return a filtered table.

* changed BinaryHeap's tiebreaker function to return
a Long, which matches data type of indices returned by
Table.index()

* added selectGlobal method to Table which takes String*