### PR TITLE
Add Python type parser. Speed up Python API by ~3x with optimizations

### DIFF
--- a/python/hail/docs/expr/types.rst
+++ b/python/hail/docs/expr/types.rst
@@ -9,6 +9,7 @@ Types
 .. autosummary::
     :nosignatures:
 
+    dtype
     tint
     tint32
     tint64

--- a/python/hail/environment.yml
+++ b/python/hail/environment.yml
@@ -9,3 +9,4 @@ dependencies:
   - pandas
   - matplotlib
   - seaborn
+  - parsimonious

--- a/python/hail/expr/__init__.py
+++ b/python/hail/expr/__init__.py
@@ -2,8 +2,8 @@ import hail.expr.functions
 from .types import *
 from .expression import eval_expr, eval_expr_typed
 from .functions import *
-
 __all__ = ['Type',
+           'dtype',
            'tint',
            'tint32',
            'tint64',

--- a/python/hail/expr/expression.py
+++ b/python/hail/expr/expression.py
@@ -32,8 +32,6 @@ class Indices(object):
                 if ind.source is not None and ind.source is not src:
                     raise ExpressionException()
 
-            both = axes.intersection(ind.axes)
-
             axes = axes.union(ind.axes)
 
         return Indices(src, axes)
@@ -1854,7 +1852,7 @@ class StructExpression(Mapping, Expression):
         self._fields = OrderedDict()
 
         for fd in self._type.fields:
-            expr = construct_expr(Select(self._ast, fd.name), fd.typ, self._indices,
+            expr = construct_expr(Select(self._ast, fd.name), fd.dtype, self._indices,
                                   self._aggregations, self._joins, self._refs)
             self._set_field(fd.name, expr)
 
@@ -1947,13 +1945,13 @@ class StructExpression(Mapping, Expression):
         types = []
         for fd in self.dtype.fields:
             names.append(fd.name)
-            types.append(fd.typ)
+            types.append(fd.dtype)
         kwargs_struct = to_expr(Struct(**named_exprs))
 
         for fd in kwargs_struct.dtype.fields:
             if not fd.name in self._fields:
                 names.append(fd.name)
-                types.append(fd.typ)
+                types.append(fd.dtype)
 
         result_type = tstruct(names, types)
         indices, aggregations, joins, refs = unify_all(self, kwargs_struct)
@@ -2013,7 +2011,7 @@ class StructExpression(Mapping, Expression):
             if fd.name in select_name_set:
                 raise ExpressionException("Cannot select and assign '{}' in the same 'select' call".format(fd.name))
             names.append(fd.name)
-            types.append(fd.typ)
+            types.append(fd.dtype)
         result_type = tstruct(names, types)
 
         indices, joins, aggregations, refs = unify_all(self, kwargs_struct)
@@ -2056,7 +2054,7 @@ class StructExpression(Mapping, Expression):
         for fd in self.dtype.fields:
             if not fd.name in to_drop:
                 names.append(fd.name)
-                types.append(fd.typ)
+                types.append(fd.dtype)
         result_type = tstruct(names, types)
         return construct_expr(StructOp('drop', self._ast, *to_drop), result_type,
                               self._indices, self._joins, self._aggregations, self._refs)

--- a/python/hail/expr/functions.py
+++ b/python/hail/expr/functions.py
@@ -626,7 +626,7 @@ def index(structs, identifier):
                         .format(structs.dtype))
     structs = to_expr(structs)
     struct_type = structs._type.element_type
-    struct_fields = {fd.name: fd.typ for fd in struct_type.fields}
+    struct_fields = {fd.name: fd.dtype for fd in struct_type.fields}
 
     if identifier not in struct_fields:
         raise RuntimeError("`structs' does not have a field with identifier `{}'. " \

--- a/python/hail/expr/tests.py
+++ b/python/hail/expr/tests.py
@@ -4,6 +4,7 @@ import hail as hl
 from hail import Struct, Table, Locus
 import hail.expr.aggregators as agg
 from hail.expr.types import *
+from hail.expr import dtype
 
 
 def setUpModule():
@@ -14,87 +15,64 @@ def tearDownModule():
     hl.stop()
 
 
-class Tests(unittest.TestCase):
-    def test_types(self):
-        self.assertEqual(tint32, tint32)
-        self.assertEqual(tfloat64, tfloat64)
-        self.assertEqual(tarray(tfloat64), tarray(tfloat64))
-        self.assertNotEqual(tarray(tfloat64), tarray(tfloat32))
-        self.assertNotEqual(tset(tfloat64), tarray(tfloat64))
-        self.assertEqual(tset(tfloat64), tset(tfloat64))
-        self.assertEqual(tdict(tstr, tarray(tint32)), tdict(tstr, tarray(tint32)))
-        self.assertEqual(ttuple(tstr, tint), ttuple(tstr, tint))
-
-        some_random_types = [
+class TypeTests(unittest.TestCase):
+    def types_to_test(self):
+        return [
             tint32,
-            tstr,
+            tint64,
             tfloat32,
             tfloat64,
+            tstr,
             tbool,
-            tarray(tstr),
-            tset(tarray(tset(tbool))),
-            tdict(tstr, tint32),
-            tlocus(),
             tcall,
+            tinterval(tint32),
+            tdict(tstr, tint32),
+            tarray(tstr),
+            tset(tint64),
+            tlocus('GRCh37'),
+            tlocus('GRCh38'),
+            tstruct([], []),
+            tstruct(['x', 'y', 'z'], [tint32, tint64, tarray(tset(tstr))]),
+            tstruct(['weird field name 1',
+                     r"""this one ' has "" quotes and `` backticks```""",
+                     '!@#$%^&({['],
+                    [tint32, tint64, tarray(tset(tstr))]),
             tinterval(tlocus()),
             tset(tinterval(tlocus())),
             tstruct(['a', 'b', 'c'], [tint32, tint32, tarray(tstr)]),
             tstruct(['a', 'bb', 'c'], [tfloat64, tint32, tbool]),
             tstruct(['a', 'b'], [tint32, tint32]),
+            tstruct(['___', '_ . _'], [tint32, tint32]),
             ttuple(tstr, tint32)]
 
-        #  copy and reinitialize to check that two initializations produce equality (not reference equality)
-        some_random_types_cp = [
-            tint32,
-            tstr,
-            tfloat32,
-            tfloat64,
-            tbool,
-            tarray(tstr),
-            tset(tarray(tset(tbool))),
-            tdict(tstr, tint32),
-            tlocus(),
-            tcall,
-            tinterval(tlocus()),
-            tset(tinterval(tlocus())),
-            tstruct(['a', 'b', 'c'], [tint32, tint32, tarray(tstr)]),
-            tstruct(['a', 'bb', 'c'], [tfloat64, tint32, tbool]),
-            tstruct(['a', 'b'], [tint32, tint32]),
-            ttuple(tstr, tint32)]
+    def test_parser_roundtrip(self):
+        for t in self.types_to_test():
+            self.assertEqual(t, dtype(str(t)))
 
-        for i in range(len(some_random_types)):
-            for j in range(len(some_random_types)):
+    def test_eval_roundtrip(self):
+        for t in self.types_to_test():
+            self.assertEqual(t, eval(repr(t)))
+
+    def test_equality(self):
+        ts = self.types_to_test()
+        ts2 = self.types_to_test()  # reallocates the non-primitive types
+
+        for i in range(len(ts)):
+            for j in range(len(ts2)):
                 if (i == j):
-                    self.assertEqual(some_random_types[i], some_random_types_cp[j])
+                    self.assertEqual(ts[i], ts2[j])
                 else:
-                    self.assertNotEqual(some_random_types[i], some_random_types_cp[j])
+                    self.assertNotEqual(ts[i], ts2[j])
 
+    def test_jvm_roundtrip(self):
+        ts = self.types_to_test()
+        for t in ts:
+            rev_str = t._jtype.toPyString()
+            self.assertEqual(t, dtype(rev_str))
+
+class Tests(unittest.TestCase):
     def test_floating_point(self):
         self.assertEqual(hl.eval_expr(1.1e-15), 1.1e-15)
-
-    def test_repr(self):
-        tl = tlocus()
-        ti = tinterval(tlocus())
-        tc = tcall
-
-        ti32 = tint32
-        ti64 = tint64
-        tf32 = tfloat32
-        tf64 = tfloat64
-        ts = tstr
-        tb = tbool
-
-        tdict_ = tdict(tinterval(tlocus()), tfloat32)
-        tset_ = tarray(tlocus())
-        tarray_ = tarray(tstr)
-        tstruct_ = tstruct(['a', 'b'], [tbool, tarray(tstr)])
-        ttuple_ = ttuple(tstr, tint)
-
-        for typ in [tl, ti, tc,
-                    ti32, ti64, tf32, tf64, ts, tb,
-                    tdict_, tarray_, tset_, tstruct_,
-                    ttuple_]:
-            self.assertEqual(eval(repr(typ)), typ)
 
     def test_matches(self):
         self.assertEqual(hl.eval_expr('\d+'), '\d+')
@@ -127,13 +105,6 @@ class Tests(unittest.TestCase):
         self.assertEqual(r.gt6, 0.30)
         self.assertTrue(r.assert1)
         self.assertTrue(r.assert2)
-
-    def test_dtype(self):
-        i32 = hl.capture(5)
-        self.assertEqual(i32.dtype, tint32)
-
-        str_exp = hl.capture('5')
-        self.assertEqual(str_exp.dtype, tstr)
 
     def test_switch(self):
         x = hl.capture('1')
@@ -963,7 +934,7 @@ class Tests(unittest.TestCase):
     def test_array_methods(self):
         self.assertEqual(hl.eval_expr(hl.any(lambda x: x % 2 == 0, [1, 3, 5])), False)
         self.assertEqual(hl.eval_expr(hl.any(lambda x: x % 2 == 0, [1, 3, 5, 6])), True)
-        
+
         self.assertEqual(hl.eval_expr(hl.all(lambda x: x % 2 == 0, [1, 3, 5, 6])), False)
         self.assertEqual(hl.eval_expr(hl.all(lambda x: x % 2 == 0, [2, 6])), True)
 
@@ -987,7 +958,6 @@ class Tests(unittest.TestCase):
         self.assertEqual(hl.eval_expr(hl.group_by(lambda x: x % 2 == 0, [0, 1, 4, 6])), {True: [0, 4, 6], False: [1]})
 
         self.assertEqual(hl.eval_expr(hl.flatmap(lambda x: hl.range(0, x), [1, 2, 3])), [0, 0, 1, 0, 1, 2])
-
 
     def test_bool_r_ops(self):
         self.assertTrue(hl.eval_expr(hl.capture(True) & True))

--- a/python/hail/expr/tests.py
+++ b/python/hail/expr/tests.py
@@ -43,7 +43,9 @@ class TypeTests(unittest.TestCase):
             tstruct(['a', 'bb', 'c'], [tfloat64, tint32, tbool]),
             tstruct(['a', 'b'], [tint32, tint32]),
             tstruct(['___', '_ . _'], [tint32, tint32]),
-            ttuple(tstr, tint32)]
+            ttuple(tstr, tint32),
+            ttuple(tarray(tint32), tstr, tstr, tint32, tbool),
+            ttuple()]
 
     def test_parser_roundtrip(self):
         for t in self.types_to_test():

--- a/python/hail/expr/type_parsing.py
+++ b/python/hail/expr/type_parsing.py
@@ -4,7 +4,7 @@ from hail.utils.java import unescape_parsable
 
 type_grammar = Grammar(
     r"""
-    type = _ (array / set / dict / struct / interval / int64 / int32 / float32 / float64 / bool / str / call / str / locus) _
+    type = _ (array / set / dict / struct / tuple / interval / int64 / int32 / float32 / float64 / bool / str / call / str / locus) _
     int64 = "int64" / "tint64"
     int32 = "int32" / "tint32" / "int" / "tint"
     float32 = "float32" / "tfloat32"
@@ -84,13 +84,12 @@ class TypeConstructor(NodeVisitor):
             return hl.tstruct(names, types)
 
     def visit_tuple(self, node, visited_children):
-        ttuple, _, paren, maybe_types, paren = visited_children
+        ttuple, _, paren, [maybe_types], paren = visited_children
         if not maybe_types:
             return hl.ttuple()
         else:
-            [[first, rest]] = maybe_types
+            [first, rest] = maybe_types
             return hl.ttuple(first, *(t for comma, t in rest))
-
 
     def visit_fields(self, node, visited_children):
         first, rest = visited_children

--- a/python/hail/expr/type_parsing.py
+++ b/python/hail/expr/type_parsing.py
@@ -1,0 +1,116 @@
+from parsimonious import Grammar, NodeVisitor
+import hail as hl
+from hail.utils.java import unescape_parsable
+
+type_grammar = Grammar(
+    r"""
+    type = array / set / dict / struct / interval / int64 / int32 / float32 / float64 / bool / str / call / str / locus
+    int64 = "int64" / "tint64"
+    int32 = "int32" / "tint32" / "int" / "tint"
+    float32 = "float32" / "tfloat32"
+    float64 = "float64" / "tfloat64" / "tfloat" / "float"
+    bool = "tbool" / "bool"
+    call = "tcall" / "call"
+    str = "tstr" / "str"
+    locus = ("tlocus" / "locus") _ "[" _ identifier _ "]"
+    array = ("tarray" / "array") _ "<" _ type _ ">"
+    set = ("tset" / "set") _ "<" _ type _ ">"
+    dict = ("tdict" / "dict") _ "<" type  _ "," _ type ">"
+    struct = ("tstruct" / "struct") _ "{" _ fields? _ "}"
+    tuple = ("ttuple" / "tuple") _ "(" ((type ("," type)*) / _) ")"
+    fields = field _ ("," _ field)*
+    field = identifier _ ":" _ type
+    interval = ("tinterval" / "interval") _ "<" _ type _ ">"  
+    identifier = simple_identifier / escaped_identifier
+    simple_identifier = ~"[\w_]+"
+    escaped_identifier = "`" ~"([^`\\\\]|\\\\.)*" "`"
+    _ = ~"\s*"
+    """)
+
+
+class TypeConstructor(NodeVisitor):
+    def visit(self, node):
+        return super(TypeConstructor, self).visit(node)
+
+    def generic_visit(self, node, visited_children):
+        return visited_children
+
+    def visit_type(self, node, visited_children):
+        assert len(visited_children) == 1
+        return visited_children[0]
+
+    def visit_int64(self, node, visited_children):
+        return hl.tint64
+
+    def visit_int32(self, node, visited_children):
+        return hl.tint32
+
+    def visit_float64(self, node, visited_children):
+        return hl.tfloat64
+
+    def visit_float32(self, node, visited_children):
+        return hl.tfloat32
+
+    def visit_bool(self, node, visited_children):
+        return hl.tbool
+
+    def visit_call(self, node, visited_children):
+        return hl.tcall
+
+    def visit_str(self, node, visited_children):
+        return hl.tstr
+
+    def visit_locus(self, node, visited_children):
+        return hl.tlocus(visited_children[4])
+
+    def visit_genomeref(self, node, visited_children):
+        return node.text
+
+    def visit_array(self, node, visited_children):
+        return hl.tarray(visited_children[4])
+
+    def visit_set(self, node, visited_children):
+        return hl.tset(visited_children[4])
+
+    def visit_dict(self, node, visited_children):
+        return hl.tdict(visited_children[3], visited_children[7])
+
+    def visit_struct(self, node, visited_children):
+        maybe_fds = visited_children[4]
+        if not maybe_fds:
+            return hl.tstruct([], [])
+        else:
+            fds = maybe_fds[0]
+            names = [f[0] for f in fds]
+            types = [f[1] for f in fds]
+            return hl.tstruct(names, types)
+
+    def visit_tuple(self, node, visited_children):
+        ttuple, _, paren, maybe_types, paren = visited_children
+        if not maybe_types:
+            return hl.ttuple()
+        else:
+            [[first, rest]] = maybe_types
+            return hl.ttuple(first, *(t for comma, t in rest))
+
+
+    def visit_fields(self, node, visited_children):
+        return [visited_children[0]] + [x[2] for x in visited_children[2]]
+
+    def visit_field(self, node, visited_children):
+        return (visited_children[0], visited_children[-1])
+
+    def visit_interval(self, node, visited_children):
+        return hl.tinterval(visited_children[4])
+
+    def visit_identifier(self, node, visited_children):
+        return visited_children[0]
+
+    def visit_simple_identifier(self, node, visited_children):
+        return node.text
+
+    def visit_escaped_identifier(self, node, visited_children):
+        return unescape_parsable(node.text[1:-1])
+
+
+type_node_visitor = TypeConstructor()

--- a/python/hail/expr/type_parsing.py
+++ b/python/hail/expr/type_parsing.py
@@ -22,7 +22,7 @@ type_grammar = Grammar(
     field = identifier _ ":" _ type
     interval = ("tinterval" / "interval") _ "<" _ type _ ">"  
     identifier = simple_identifier / escaped_identifier
-    simple_identifier = ~"[\w_]+"
+    simple_identifier = ~"\w+"
     escaped_identifier = "`" ~"([^`\\\\]|\\\\.)*" "`"
     _ = ~"\s*"
     """)

--- a/python/hail/expr/types.py
+++ b/python/hail/expr/types.py
@@ -39,7 +39,7 @@ def dtype(type_str):
 
     .. code-block:: text
 
-        type = array / set / dict / struct / interval / int64 / int32 / float32 / float64 / bool / str / call / str / locus
+        type = _ (array / set / dict / struct / interval / int64 / int32 / float32 / float64 / bool / str / call / str / locus) _
         int64 = "int64" / "tint64"
         int32 = "int32" / "tint32" / "int" / "tint"
         float32 = "float32" / "tfloat32"
@@ -47,17 +47,17 @@ def dtype(type_str):
         bool = "tbool" / "bool"
         call = "tcall" / "call"
         str = "tstr" / "str"
-        locus = ("tlocus" / "locus") _ "[" _ identifier _ "]"
-        array = ("tarray" / "array") _ "<" _ type _ ">"
-        set = ("tset" / "set") _ "<" _ type _ ">"
-        dict = ("tdict" / "dict") _ "<" type  _ "," _ type ">"
-        struct = ("tstruct" / "struct") _ "{" _ fields? _ "}"
-        fields = field _ ("," _ field)*
-        field = identifier _ ":" _ type
-        interval = ("tinterval" / "interval") _ "<" _ type _ ">"
-        identifier = simple_identifier / escaped_identifier
+        locus = ("tlocus" / "locus") _ "[" identifier "]"
+        array = ("tarray" / "array") _ "<" type ">"
+        set = ("tset" / "set") _ "<" type ">"
+        dict = ("tdict" / "dict") _ "<" type "," type ">"
+        struct = ("tstruct" / "struct") _ "{" (fields / _) "}"
+        fields = field ("," field)*
+        field = identifier ":" type
+        interval = ("tinterval" / "interval") _ "<" type ">"
+        identifier = _ (simple_identifier / escaped_identifier) _
         simple_identifier = ~"\w+"
-        escaped_identifier = "`" ~"([^`\\\\]|\\\\.)*" "`"
+        escaped_identifier = ~"`([^`\\\\]|\\\\.)*`"
         _ = ~"\s*"
 
     Parameters

--- a/python/hail/expr/types.py
+++ b/python/hail/expr/types.py
@@ -4,23 +4,73 @@ import hail as hl
 from hail.history import *
 from hail.typecheck import *
 from hail.utils import Struct
-from hail.utils.java import scala_object, jset, jindexed_seq, Env, jarray_to_list
+from hail.utils.java import scala_object, jset, jindexed_seq, Env, jarray_to_list, escape_parsable
 from hail import genetics
+from hail.expr.type_parsing import type_grammar, type_node_visitor
 
 
-class TypeCheckError(Exception):
+def dtype(type_str):
+    r"""Parse a type from its string representation.
+
+    Examples
+    --------
+    .. doctest::
+
+        >>> hl.dtype('int')
+        dtype('int32')
+
+        >>> hl.dtype('float')
+        dtype('float64')
+
+        >>> hl.dtype('array<int32>')
+        dtype('array<int32>')
+
+        >>> hl.dtype('dict<str, bool>')
+        dtype('dict<str, bool>')
+
+        >>> hl.dtype('struct{a: int32, `field with spaces`: int64}')
+        dtype('struct{a: int32, `field with spaces`: int64}')
+
+    Notes
+    -----
+    This function is able to reverse ``str(t)`` on a :class:`.Type`.
+
+    The grammar is defined as follows:
+
+    .. code-block:: text
+
+        type = array / set / dict / struct / interval / int64 / int32 / float32 / float64 / bool / str / call / str / locus
+        int64 = "int64" / "tint64"
+        int32 = "int32" / "tint32" / "int" / "tint"
+        float32 = "float32" / "tfloat32"
+        float64 = "float64" / "tfloat64" / "tfloat" / "float"
+        bool = "tbool" / "bool"
+        call = "tcall" / "call"
+        str = "tstr" / "str"
+        locus = ("tlocus" / "locus") _ "[" _ identifier _ "]"
+        array = ("tarray" / "array") _ "<" _ type _ ">"
+        set = ("tset" / "set") _ "<" _ type _ ">"
+        dict = ("tdict" / "dict") _ "<" type  _ "," _ type ">"
+        struct = ("tstruct" / "struct") _ "{" _ fields? _ "}"
+        fields = field _ ("," _ field)*
+        field = identifier _ ":" _ type
+        interval = ("tinterval" / "interval") _ "<" _ type _ ">"
+        identifier = simple_identifier / escaped_identifier
+        simple_identifier = ~"[\w_]+"
+        escaped_identifier = "`" ~"([^`\\\\]|\\\\.)*" "`"
+        _ = ~"\s*"
+
+    Parameters
+    ----------
+    type_str : :obj:`str`
+        String representation of type.
+
+    Returns
+    -------
+    :class:`.Type`
     """
-    Error thrown at mismatch between expected and supplied python types.
-
-    :param str message: Error message
-    """
-
-    def __init__(self, message):
-        self.msg = message
-        super(TypeCheckError).__init__(TypeCheckError)
-
-    def __str__(self):
-        return self.msg
+    tree = type_grammar.parse(type_str)
+    return type_node_visitor.visit(tree)
 
 
 class Type(object):
@@ -57,7 +107,8 @@ class Type(object):
         super(Type, self).__init__()
 
     def __repr__(self):
-        return str(self)
+        s = str(self).replace("'", "\\'")
+        return "dtype('{}')".format(s)
 
     @property
     def _jtype(self):
@@ -65,9 +116,12 @@ class Type(object):
             self._cached_jtype = self._get_jtype()
         return self._cached_jtype
 
+    @abc.abstractmethod
+    def _eq(self, other):
+        return
+
     def __eq__(self, other):
-        # FIXME this is a bit weird
-        return isinstance(other, Type) and str(self) == str(other)
+        return isinstance(other, Type) and self._eq(other)
 
     @abc.abstractmethod
     def __str__(self):
@@ -87,32 +141,11 @@ class Type(object):
 
         :rtype: str
         """
-
         return self._jtype.toPrettyString(indent, False)
 
     @classmethod
     def _from_java(cls, jtype):
-        # FIXME string matching is pretty hacky
-        class_name = jtype.getClass().getCanonicalName()
-
-        if class_name in _intern_classes:
-            return _intern_classes[class_name]
-        elif class_name == 'is.hail.expr.types.TArray':
-            return TArray._from_java(jtype)
-        elif class_name == 'is.hail.expr.types.TSet':
-            return TSet._from_java(jtype)
-        elif class_name == 'is.hail.expr.types.TDict':
-            return TDict._from_java(jtype)
-        elif class_name == 'is.hail.expr.types.TStruct':
-            return TStruct._from_java(jtype)
-        elif class_name == 'is.hail.expr.types.TTuple':
-            return TTuple._from_java(jtype)
-        elif class_name == 'is.hail.expr.types.TLocus':
-            return TLocus._from_java(jtype)
-        elif class_name == 'is.hail.expr.types.TInterval':
-            return TInterval._from_java(jtype)
-        else:
-            raise TypeError("unknown type class: '%s'" % class_name)
+        return hl.dtype(jtype.toPyString())
 
     @abc.abstractmethod
     def _typecheck(self, annotation):
@@ -123,6 +156,7 @@ class Type(object):
         """
         return
 
+
 class TInt32(Type):
     """Hail type for signed 32-bit integers.
 
@@ -131,6 +165,7 @@ class TInt32(Type):
 
     In Python, these are represented as :obj:`int`.
     """
+
     def __init__(self):
         self._get_jtype = lambda: scala_object(Env.hail().expr.types, 'TInt32Optional')
         super(TInt32, self).__init__()
@@ -146,10 +181,13 @@ class TInt32(Type):
 
     def _typecheck(self, annotation):
         if annotation is not None and not isinstance(annotation, int):
-            raise TypeCheckError("TInt32 expected type 'int', but found type '%s'" % type(annotation))
+            raise TypeError("TInt32 expected type 'int', but found type '%s'" % type(annotation))
 
     def __str__(self):
-        return "TInt32()"
+        return "int32"
+
+    def _eq(self, other):
+        return isinstance(other, TInt32)
 
 
 class TInt64(Type):
@@ -172,10 +210,13 @@ class TInt64(Type):
 
     def _typecheck(self, annotation):
         if annotation and not isinstance(annotation, int):
-            raise TypeCheckError("TInt64 expected type 'int', but found type '%s'" % type(annotation))
+            raise TypeError("TInt64 expected type 'int', but found type '%s'" % type(annotation))
 
     def __str__(self):
-        return "TInt64()"
+        return "int64"
+
+    def _eq(self, other):
+        return isinstance(other, TInt64)
 
 
 class TFloat32(Type):
@@ -202,10 +243,13 @@ class TFloat32(Type):
 
     def _typecheck(self, annotation):
         if annotation is not None and not isinstance(annotation, float):
-            raise TypeCheckError("TFloat32 expected type 'float', but found type '%s'" % type(annotation))
+            raise TypeError("TFloat32 expected type 'float', but found type '%s'" % type(annotation))
 
     def __str__(self):
-        return "TFloat32()"
+        return "float32"
+
+    def _eq(self, other):
+        return isinstance(other, TFloat32)
 
 
 class TFloat64(Type):
@@ -229,10 +273,13 @@ class TFloat64(Type):
 
     def _typecheck(self, annotation):
         if annotation is not None and not isinstance(annotation, float):
-            raise TypeCheckError("TFloat64 expected type 'float', but found type '%s'" % type(annotation))
+            raise TypeError("TFloat64 expected type 'float', but found type '%s'" % type(annotation))
 
     def __str__(self):
-        return "TFloat64()"
+        return "float64"
+
+    def _eq(self, other):
+        return isinstance(other, TFloat64)
 
 
 class TString(Type):
@@ -253,10 +300,13 @@ class TString(Type):
 
     def _typecheck(self, annotation):
         if annotation and not isinstance(annotation, str):
-            raise TypeCheckError("TString expected type 'str', but found type '%s'" % type(annotation))
+            raise TypeError("TString expected type 'str', but found type '%s'" % type(annotation))
 
     def __str__(self):
-        return "TString()"
+        return "str"
+
+    def _eq(self, other):
+        return isinstance(other, TString)
 
 
 class TBoolean(Type):
@@ -277,10 +327,13 @@ class TBoolean(Type):
 
     def _typecheck(self, annotation):
         if annotation is not None and not isinstance(annotation, bool):
-            raise TypeCheckError("TBoolean expected type 'bool', but found type '%s'" % type(annotation))
+            raise TypeError("TBoolean expected type 'bool', but found type '%s'" % type(annotation))
 
     def __str__(self):
-        return "TBoolean()"
+        return "bool"
+
+    def _eq(self, other):
+        return isinstance(other, TBoolean)
 
 
 class TArray(Type):
@@ -299,6 +352,7 @@ class TArray(Type):
         Element type of array.
     """
 
+    @typecheck_method(element_type=Type)
     def __init__(self, element_type):
         self._get_jtype = lambda: scala_object(Env.hail().expr.types, 'TArray').apply(element_type._jtype, False)
         self._element_type = element_type
@@ -314,14 +368,6 @@ class TArray(Type):
             Element type.
         """
         return self._element_type
-
-    @classmethod
-    def _from_java(cls, jtype):
-        t = TArray.__new__(cls)
-        t._element_type = Type._from_java(jtype.elementType())
-        t._get_jtype = lambda: jtype
-        super(TArray, t).__init__()
-        return t
 
     def _convert_to_py(self, annotation):
         if annotation is not None:
@@ -341,12 +387,15 @@ class TArray(Type):
     def _typecheck(self, annotation):
         if annotation is not None:
             if not isinstance(annotation, list):
-                raise TypeCheckError("TArray expected type 'list', but found type '%s'" % type(annotation))
+                raise TypeError("TArray expected type 'list', but found type '%s'" % type(annotation))
             for elt in annotation:
                 self.element_type._typecheck(elt)
 
     def __str__(self):
-        return "TArray({})".format(self.element_type)
+        return "array<{}>".format(self.element_type)
+
+    def _eq(self, other):
+        return isinstance(other, TArray) and self.element_type == other.element_type
 
 
 class TSet(Type):
@@ -365,6 +414,7 @@ class TSet(Type):
         Element type of set.
     """
 
+    @typecheck_method(element_type=Type)
     def __init__(self, element_type):
         self._get_jtype = lambda: scala_object(Env.hail().expr.types, 'TSet').apply(element_type._jtype, False)
         self._element_type = element_type
@@ -380,14 +430,6 @@ class TSet(Type):
             Element type.
         """
         return self._element_type
-
-    @classmethod
-    def _from_java(cls, jtype):
-        t = TSet.__new__(cls)
-        t._element_type = Type._from_java(jtype.elementType())
-        t._get_jtype = lambda: jtype
-        super(TSet, t).__init__()
-        return t
 
     def _convert_to_py(self, annotation):
         if annotation is not None:
@@ -407,12 +449,15 @@ class TSet(Type):
     def _typecheck(self, annotation):
         if annotation is not None:
             if not isinstance(annotation, set):
-                raise TypeCheckError("TSet expected type 'set', but found type '%s'" % type(annotation))
+                raise TypeError("TSet expected type 'set', but found type '%s'" % type(annotation))
             for elt in annotation:
                 self.element_type._typecheck(elt)
 
     def __str__(self):
-        return "TSet({})".format(repr(self.element_type))
+        return "set<{}>".format(self.element_type)
+
+    def _eq(self, other):
+        return isinstance(other, TSet) and self.element_type == other.element_type
 
 
 class TDict(Type):
@@ -433,6 +478,7 @@ class TDict(Type):
         Value type.
     """
 
+    @typecheck_method(key_type=Type, value_type=Type)
     def __init__(self, key_type, value_type):
         self._get_jtype = lambda: scala_object(Env.hail().expr.types, 'TDict').apply(
             key_type._jtype, value_type._jtype, False)
@@ -462,15 +508,6 @@ class TDict(Type):
         """
         return self._value_type
 
-    @classmethod
-    def _from_java(cls, jtype):
-        t = TDict.__new__(cls)
-        t._key_type = Type._from_java(jtype.keyType())
-        t._value_type = Type._from_java(jtype.valueType())
-        t._get_jtype = lambda: jtype
-        super(TDict, t).__init__()
-        return t
-
     def _convert_to_py(self, annotation):
         if annotation is not None:
             lst = Env.jutils().iterableToArrayList(annotation)
@@ -492,13 +529,16 @@ class TDict(Type):
     def _typecheck(self, annotation):
         if annotation:
             if not isinstance(annotation, dict):
-                raise TypeCheckError("TDict expected type 'dict', but found type '%s'" % type(annotation))
+                raise TypeError("TDict expected type 'dict', but found type '%s'" % type(annotation))
             for k, v in annotation.items():
                 self.key_type._typecheck(k)
                 self.value_type._typecheck(v)
 
     def __str__(self):
-        return "TDict({}, {})".format(repr(self.key_type), repr(self.value_type))
+        return "dict<{}, {}>".format(self.key_type, self.value_type)
+
+    def _eq(self, other):
+        return isinstance(other, TDict) and self.key_type == other.key_type and self.value_type == other.value_type
 
 
 class Field(object):
@@ -520,7 +560,7 @@ class Field(object):
         return self._name
 
     @property
-    def typ(self):
+    def dtype(self):
         """Field type.
 
         Returns
@@ -529,6 +569,12 @@ class Field(object):
             Field type.
         """
         return self._typ
+
+    def __eq__(self, other):
+        return isinstance(other, Field) and self.name == other.name and self.dtype == other.dtype
+
+    def __hash__(self):
+        return 31 + hash(self.name) + hash(self.dtype)
 
 
 class TStruct(Type):
@@ -553,7 +599,7 @@ class TStruct(Type):
         self._get_jtype = lambda: scala_object(Env.hail().expr.types, 'TStruct').apply(names,
                                                                                        map(lambda t: t._jtype, types),
                                                                                        False)
-        self._fields = [Field(names[i], types[i]) for i in range(len(names))]
+        self._fields = tuple(Field(names[i], types[i]) for i in range(len(names)))
 
         super(TStruct, self).__init__()
 
@@ -563,7 +609,7 @@ class TStruct(Type):
 
         Returns
         -------
-        :obj:`list` of :class:`.Field`
+        :obj:`tuple` of :class:`.Field`
             Struct fields.
         """
         return self._fields
@@ -578,25 +624,13 @@ class TStruct(Type):
         :return: TStruct from input fields
         :rtype: :class:`.TStruct`
         """
-        return TStruct([f.name for f in fields], [f.typ for f in fields])
-
-    @classmethod
-    def _from_java(cls, jtype):
-        struct = TStruct.__new__(cls)
-        struct._init_from_java(jtype)
-        struct._get_jtype = lambda: jtype
-        super(TStruct, struct).__init__()
-        return struct
-
-    def _init_from_java(self, jtype):
-        jfields = Env.jutils().iterableToArrayList(jtype.fields())
-        self._fields = [Field(f.name(), Type._from_java(f.typ())) for f in jfields]
+        return TStruct([f.name for f in fields], [f.dtype for f in fields])
 
     def _convert_to_py(self, annotation):
         if annotation is not None:
             d = dict()
             for i, f in enumerate(self.fields):
-                d[f.name] = f.typ._convert_to_py(annotation.get(i))
+                d[f.name] = f.dtype._convert_to_py(annotation.get(i))
             return Struct(**d)
         else:
             return None
@@ -605,7 +639,7 @@ class TStruct(Type):
         if annotation is not None:
             return scala_object(Env.hail().annotations, 'Annotation').fromSeq(
                 Env.jutils().arrayListToISeq(
-                    [f.typ._convert_to_j(annotation.get(f.name)) for f in self.fields]
+                    [f.dtype._convert_to_j(annotation.get(f.name)) for f in self.fields]
                 )
             )
         else:
@@ -614,18 +648,20 @@ class TStruct(Type):
     def _typecheck(self, annotation):
         if annotation:
             if not isinstance(annotation, Struct):
-                raise TypeCheckError("TStruct expected type hail.genetics.Struct, but found '%s'" %
-                                     type(annotation))
+                raise TypeError("TStruct expected type hail.genetics.Struct, but found '%s'" %
+                                type(annotation))
             for f in self.fields:
                 if not (f.name in annotation):
-                    raise TypeCheckError("TStruct expected fields '%s', but found fields '%s'" %
-                                         ([f.name for f in self.fields], annotation._fields))
-                f.typ._typecheck((annotation[f.name]))
+                    raise TypeError("TStruct expected fields '%s', but found fields '%s'" %
+                                    ([f.name for f in self.fields], annotation._fields))
+                f.dtype._typecheck((annotation[f.name]))
 
     def __str__(self):
-        names = [str(fd.name) for fd in self.fields]
-        types = [fd.typ for fd in self.fields]
-        return "TStruct({}, {})".format(repr(list(names)), repr(list(types)))
+        return "struct{{{}}}".format(
+            ', '.join('{}: {}'.format(escape_parsable(fd.name), str(fd.dtype)) for fd in self.fields))
+
+    def _eq(self, other):
+        return isinstance(other, TStruct) and self.fields == other.fields
 
 
 class TTuple(Type):
@@ -656,18 +692,6 @@ class TTuple(Type):
         """
         return self._types
 
-    @classmethod
-    def _from_java(cls, jtype):
-        tup = TTuple.__new__(cls)
-        tup._init_from_java(jtype)
-        tup._get_jtype = lambda: jtype
-        super(TTuple, tup).__init__()
-        return tup
-
-    def _init_from_java(self, jtype):
-        jtypes = jarray_to_list(jtype.types())
-        self._types = [Type._from_java(t) for t in jtypes]
-
     def _convert_to_py(self, annotation):
         if annotation is not None:
             return tuple(t._convert_to_py(annotation.get(i)) for i, t in enumerate(self.types))
@@ -685,16 +709,16 @@ class TTuple(Type):
     def _typecheck(self, annotation):
         if annotation:
             if not isinstance(annotation, tuple):
-                raise TypeCheckError("ttuple expected tuple, but found '%s'" %
+                raise TypeError("ttuple expected tuple, but found '%s'" %
                                      type(annotation))
             if len(annotation) != len(self.types):
-                raise TypeCheckError("ttuple expected tuple of size '%i', but found '%s'" %
-                                     (len(self.types), annotation))
+                raise TypeError("%s expected tuple of size '%i', but found '%s'" %
+                                     (self, len(self.types), annotation))
             for i, t in enumerate(self.types):
                 t._typecheck((annotation[i]))
 
     def __str__(self):
-        return "TTuple({})".format(",".join([repr(t) for t in self.types]))
+        return "tuple({})".format(", ".join([str(t) for t in self.types]))
 
 
 class TCall(Type):
@@ -723,11 +747,14 @@ class TCall(Type):
 
     def _typecheck(self, annotation):
         if annotation is not None and not isinstance(annotation, genetics.Call):
-            raise TypeCheckError('TCall expected type hail.genetics.Call, but found %s' %
-                                 type(annotation))
+            raise TypeError('TCall expected type hail.genetics.Call, but found %s' %
+                            type(annotation))
 
     def __str__(self):
-        return "TCall()"
+        return "call"
+
+    def _eq(self, other):
+        return isinstance(other, TCall)
 
 
 class TLocus(Type):
@@ -752,14 +779,6 @@ class TLocus(Type):
                                                                                       False)
         super(TLocus, self).__init__()
 
-    @classmethod
-    def _from_java(cls, jtype):
-        l = TLocus.__new__(cls)
-        l._get_jtype = lambda: jtype
-        l._rg = genetics.GenomeReference._from_java(jtype.gr())
-        super(TLocus, l).__init__()
-        return l
-
     def _convert_to_py(self, annotation):
         if annotation is not None:
             return genetics.Locus._from_java(annotation, self._rg)
@@ -774,11 +793,14 @@ class TLocus(Type):
 
     def _typecheck(self, annotation):
         if annotation is not None and not isinstance(annotation, genetics.Locus):
-            raise TypeCheckError('TLocus expected type hail.genetics.Locus, but found %s' %
-                                 type(annotation))
+            raise TypeError('TLocus expected type hail.genetics.Locus, but found %s' %
+                            type(annotation))
 
     def __str__(self):
-        return "TLocus('{}')".format(self.reference_genome)
+        return "locus[{}]".format(escape_parsable(str(self.reference_genome)))
+
+    def _eq(self, other):
+        return isinstance(other, TLocus) and self.reference_genome == other.reference_genome
 
     @property
     def reference_genome(self):
@@ -811,7 +833,7 @@ class TInterval(Type):
 
     @typecheck_method(point_type=Type)
     def __init__(self, point_type):
-        self._get_jtype = lambda: scala_object(Env.hail().expr.types, 'TInterval').apply(self.point_type._jrep, False)
+        self._get_jtype = lambda: scala_object(Env.hail().expr.types, 'TInterval').apply(self.point_type._jtype, False)
         self._point_type = point_type
         super(TInterval, self).__init__()
 
@@ -825,14 +847,6 @@ class TInterval(Type):
             Interval point type.
         """
         return self._point_type
-
-    @classmethod
-    def _from_java(cls, jtype):
-        i = TInterval.__new__(cls)
-        i._point_type = Type._from_java(jtype.pointType())
-        i._get_jtype = lambda: jtype
-        super(TInterval, i).__init__()
-        return i
 
     def _convert_to_py(self, annotation):
         assert (isinstance(self._point_type, TLocus))
@@ -852,12 +866,14 @@ class TInterval(Type):
     def _typecheck(self, annotation):
         assert (isinstance(self._point_type, TLocus))
         if annotation is not None and not isinstance(annotation, genetics.Interval):
-            raise TypeCheckError('TInterval expected type hail.genetics.Interval, but found %s' %
-                                 type(annotation))
+            raise TypeError('TInterval expected type hail.genetics.Interval, but found %s' %
+                            type(annotation))
 
     def __str__(self):
-        return "TInterval({})".format(repr(self.point_type))
+        return "interval<{}>".format(str(self.point_type))
 
+    def _eq(self, other):
+        return isinstance(other, TInterval) and self.point_type == other.point_type
 
 
 tint32 = TInt32()
@@ -879,20 +895,6 @@ tinterval = TInterval
 
 _numeric_types = {tint32, tint64, tfloat32, tfloat64}
 
-_intern_classes = {'is.hail.expr.types.TInt32Optional$': tint32,
-                   'is.hail.expr.types.TInt32Required$': tint32,
-                   'is.hail.expr.types.TInt64Optional$': tint64,
-                   'is.hail.expr.types.TInt64Required$': tint64,
-                   'is.hail.expr.types.TFloat32Optional$': tfloat32,
-                   'is.hail.expr.types.TFloat32Required$': tfloat32,
-                   'is.hail.expr.types.TFloat64Optional$': tfloat64,
-                   'is.hail.expr.types.TFloat64Required$': tfloat64,
-                   'is.hail.expr.types.TBooleanOptional$': tbool,
-                   'is.hail.expr.types.TBooleanRequired$': tbool,
-                   'is.hail.expr.types.TStringOptional$': tstr,
-                   'is.hail.expr.types.TStringRequired$': tstr,
-                   'is.hail.expr.types.TCallOptional$': tcall,
-                   'is.hail.expr.types.TCallRequired$': tcall}
 
 @typecheck(t=Type)
 def is_numeric(t):

--- a/python/hail/expr/types.py
+++ b/python/hail/expr/types.py
@@ -56,7 +56,7 @@ def dtype(type_str):
         field = identifier _ ":" _ type
         interval = ("tinterval" / "interval") _ "<" _ type _ ">"
         identifier = simple_identifier / escaped_identifier
-        simple_identifier = ~"[\w_]+"
+        simple_identifier = ~"\w+"
         escaped_identifier = "`" ~"([^`\\\\]|\\\\.)*" "`"
         _ = ~"\s*"
 

--- a/python/hail/expr/types.py
+++ b/python/hail/expr/types.py
@@ -39,7 +39,7 @@ def dtype(type_str):
 
     .. code-block:: text
 
-        type = _ (array / set / dict / struct / interval / int64 / int32 / float32 / float64 / bool / str / call / str / locus) _
+        type = _ (array / set / dict / struct / tuple / interval / int64 / int32 / float32 / float64 / bool / str / call / str / locus) _
         int64 = "int64" / "tint64"
         int32 = "int32" / "tint32" / "int" / "tint"
         float32 = "float32" / "tfloat32"
@@ -52,6 +52,7 @@ def dtype(type_str):
         set = ("tset" / "set") _ "<" type ">"
         dict = ("tdict" / "dict") _ "<" type "," type ">"
         struct = ("tstruct" / "struct") _ "{" (fields / _) "}"
+        tuple = ("ttuple" / "tuple") _ "(" ((type ("," type)*) / _) ")"
         fields = field ("," field)*
         field = identifier ":" type
         interval = ("tinterval" / "interval") _ "<" type ">"
@@ -710,15 +711,20 @@ class TTuple(Type):
         if annotation:
             if not isinstance(annotation, tuple):
                 raise TypeError("ttuple expected tuple, but found '%s'" %
-                                     type(annotation))
+                                type(annotation))
             if len(annotation) != len(self.types):
                 raise TypeError("%s expected tuple of size '%i', but found '%s'" %
-                                     (self, len(self.types), annotation))
+                                (self, len(self.types), annotation))
             for i, t in enumerate(self.types):
                 t._typecheck((annotation[i]))
 
     def __str__(self):
         return "tuple({})".format(", ".join([str(t) for t in self.types]))
+
+    def _eq(self, other):
+        from operator import eq
+        return isinstance(other, TTuple) and len(self.types) == len(other.types) and all(
+            map(eq, self.types, other.types))
 
 
 class TCall(Type):

--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -1,3 +1,4 @@
+import hail
 from hail.expr.expression import *
 from hail.utils import storage_level
 from hail.utils.java import handle_py4j, escape_id
@@ -254,16 +255,16 @@ class MatrixTable(object):
         assert isinstance(self.entry_schema, TStruct), self.entry_schema
 
         for f in self.global_schema.fields:
-            self._set_field(f.name, construct_reference(f.name, f.typ, self._global_indices, prefix='global'))
+            self._set_field(f.name, construct_reference(f.name, f.dtype, self._global_indices, prefix='global'))
 
         for f in self.col_schema.fields:
-            self._set_field(f.name, construct_reference(f.name, f.typ, self._col_indices, prefix='sa'))
+            self._set_field(f.name, construct_reference(f.name, f.dtype, self._col_indices, prefix='sa'))
 
         for f in self.row_schema.fields:
-            self._set_field(f.name, construct_reference(f.name, f.typ, self._row_indices, prefix='va'))
+            self._set_field(f.name, construct_reference(f.name, f.dtype, self._row_indices, prefix='va'))
 
         for f in self.entry_schema.fields:
-            self._set_field(f.name, construct_reference(f.name, f.typ, self._entry_indices, prefix='g'))
+            self._set_field(f.name, construct_reference(f.name, f.dtype, self._entry_indices, prefix='g'))
 
     def _set_field(self, key, value):
         assert key not in self._fields, key
@@ -2008,7 +2009,6 @@ class MatrixTable(object):
         else:
             raise NotImplementedError('matrix.view_join_entries with {}'.format(src.__class__))
 
-    @typecheck_method(exprs=Expression)
     def _process_joins(self, *exprs):
 
         all_uids = []
@@ -2038,10 +2038,10 @@ class MatrixTable(object):
             global_fields = '\n    None'
         else:
             global_fields = ''.join("\n    '{name}': {type} ".format(
-                name=fd.name, type=format_type(fd.typ)) for fd in self.global_schema.fields)
+                name=fd.name, type=format_type(fd.dtype)) for fd in self.global_schema.fields)
 
         row_fields = ''.join("\n    '{name}': {type} ".format(
-            name=fd.name, type=format_type(fd.typ)) for fd in self.row_schema.fields)
+            name=fd.name, type=format_type(fd.dtype)) for fd in self.row_schema.fields)
 
         row_key = ''.join("\n    '{name}': {type} ".format(name=f, type=format_type(self[f].dtype))
                           for f in self.row_key) if self.row_key else '\n    None'
@@ -2049,7 +2049,7 @@ class MatrixTable(object):
                                 for f in self.partition_key) if self.partition_key else '\n    None'
 
         col_fields = ''.join("\n    '{name}': {type} ".format(
-            name=fd.name, type=format_type(fd.typ)) for fd in self.col_schema.fields)
+            name=fd.name, type=format_type(fd.dtype)) for fd in self.col_schema.fields)
 
         col_key = ''.join("\n    '{name}': {type} ".format(name=f, type=format_type(self[f].dtype))
                           for f in self.col_key) if self.col_key else '\n    None'
@@ -2058,7 +2058,7 @@ class MatrixTable(object):
             entry_fields = '\n    None'
         else:
             entry_fields = ''.join("\n    '{name}': {type} ".format(
-                name=fd.name, type=format_type(fd.typ)) for fd in self.entry_schema.fields)
+                name=fd.name, type=format_type(fd.dtype)) for fd in self.entry_schema.fields)
 
         s = '----------------------------------------\n' \
             'Global fields:{g}\n' \

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -310,10 +310,10 @@ class Table(TableTemplate):
         self._row_indices = Indices(axes={self._row_axis}, source=self)
 
         for fd in self.global_schema.fields:
-            self._set_field(fd.name, construct_reference(fd.name, fd.typ, self._global_indices, prefix='global'))
+            self._set_field(fd.name, construct_reference(fd.name, fd.dtype, self._global_indices, prefix='global'))
 
         for fd in self.schema.fields:
-            self._set_field(fd.name, construct_reference(fd.name, fd.typ, self._row_indices, prefix='row'))
+            self._set_field(fd.name, construct_reference(fd.name, fd.dtype, self._row_indices, prefix='row'))
 
     @typecheck_method(item=oneof(str, Expression, slice, tupleof(Expression)))
     def __getitem__(self, item):
@@ -1427,10 +1427,10 @@ class Table(TableTemplate):
             global_fields = '\n    None'
         else:
             global_fields = ''.join("\n    '{name}': {type} ".format(
-                name=fd.name, type=format_type(fd.typ)) for fd in self.global_schema.fields)
+                name=fd.name, type=format_type(fd.dtype)) for fd in self.global_schema.fields)
 
         row_fields = ''.join("\n    '{name}': {type} ".format(
-            name=fd.name, type=format_type(fd.typ)) for fd in self.schema.fields)
+            name=fd.name, type=format_type(fd.dtype)) for fd in self.schema.fields)
 
         row_key = ''.join("\n    '{name}': {type} ".format(name=f, type=format_type(self[f].dtype))
                           for f in self.key) if self.key else '\n    None'

--- a/python/hail/tests.py
+++ b/python/hail/tests.py
@@ -20,8 +20,8 @@ def tearDownModule():
 
 
 def schema_eq(x, y):
-    x_fds = dict([(fd.name, fd.typ) for fd in x.fields])
-    y_fds = dict([(fd.name, fd.typ) for fd in y.fields])
+    x_fds = dict([(fd.name, fd.dtype) for fd in x.fields])
+    y_fds = dict([(fd.name, fd.dtype) for fd in y.fields])
     return x_fds == y_fds
 
 
@@ -356,7 +356,7 @@ class MatrixTests(unittest.TestCase):
                                 x3=agg.count_where(True),
                                 x4=vds.info.AC + vds.foo)
 
-        expected_fields = [(fd.name, fd.typ) for fd in orig_variant_schema.fields] + \
+        expected_fields = [(fd.name, fd.dtype) for fd in orig_variant_schema.fields] + \
                           [('x1', hl.tint64),
                            ('x2', hl.tfloat64),
                            ('x3', hl.tint64),
@@ -890,7 +890,7 @@ class ColumnTests(unittest.TestCase):
                            'x5': hl.tarray(hl.tint32)}
 
         for fd in kt.schema.fields:
-            self.assertEqual(expected_schema[fd.name], fd.typ)
+            self.assertEqual(expected_schema[fd.name], fd.dtype)
 
     def test_constructors(self):
         rg = hl.GenomeReference("foo", ["1"], {"1": 100})
@@ -910,4 +910,4 @@ class ColumnTests(unittest.TestCase):
                            'l1': hl.tlocus(), 'l2': hl.tlocus(rg),
                            'i1': hl.tinterval(hl.tlocus(rg)), 'i2': hl.tinterval(hl.tlocus(rg))}
 
-        self.assertTrue(all([expected_schema[fd.name] == fd.typ for fd in kt.schema.fields]))
+        self.assertTrue(all([expected_schema[fd.name] == fd.dtype for fd in kt.schema.fields]))

--- a/python/hail/typecheck/check.py
+++ b/python/hail/typecheck/check.py
@@ -367,7 +367,10 @@ numeric = oneof(int, float)
 char = CharChecker()
 
 def check_all(f, args, kwargs, checks, is_method):
-    spec = inspect.getfullargspec(f)
+    if not hasattr(f, '_cached_spec'):
+        setattr(f, '_cached_spec', inspect.getfullargspec(f))
+
+    spec = f._cached_spec
     name = f.__name__
 
     args_ = []

--- a/python/hail/utils/java.py
+++ b/python/hail/utils/java.py
@@ -1,6 +1,7 @@
 import socketserver
 import socket
 import sys
+import re
 from threading import Thread
 
 import py4j
@@ -122,8 +123,24 @@ def jiterable_to_list(it):
     else:
         return None
 
+
 def escape_str(s):
     return Env.jutils().escapePyString(s)
+
+
+_parsable_str = re.compile(r'[\w_]+')
+
+
+def escape_parsable(s):
+    if _parsable_str.fullmatch(s):
+        return s
+    else:
+        return '`' + s.encode('unicode_escape').decode('utf-8').replace('`', '\\`') + '`'
+
+
+def unescape_parsable(s):
+    return bytes(s.replace('\\`', '`'), 'utf-8').decode('unicode_escape')
+
 
 def escape_id(s):
     return Env.jutils().escapeIdentifier(s)

--- a/src/main/scala/is/hail/expr/types/TArray.scala
+++ b/src/main/scala/is/hail/expr/types/TArray.scala
@@ -12,6 +12,11 @@ final case class TArray(elementType: Type, override val required: Boolean = fals
 
   val contentsAlignment: Long = elementType.alignment.max(4)
 
+  override def _toPyString(sb: StringBuilder): Unit = {
+    sb.append("array<")
+    elementType._toPyString(sb)
+    sb.append('>')
+  }
   override val fundamentalType: TArray = {
     if (elementType == elementType.fundamentalType)
       this

--- a/src/main/scala/is/hail/expr/types/TBoolean.scala
+++ b/src/main/scala/is/hail/expr/types/TBoolean.scala
@@ -13,6 +13,10 @@ case object TBooleanRequired extends TBoolean(true)
 class TBoolean(override val required: Boolean) extends Type {
   def _toString = "Boolean"
 
+  override def _toPyString(sb: StringBuilder): Unit = {
+    sb.append("bool")
+  }
+
   def _typeCheck(a: Any): Boolean = a.isInstanceOf[Boolean]
 
   def parse(s: String): Annotation = s.toBoolean

--- a/src/main/scala/is/hail/expr/types/TCall.scala
+++ b/src/main/scala/is/hail/expr/types/TCall.scala
@@ -13,6 +13,9 @@ case object TCallRequired extends TCall(true)
 class TCall(override val required: Boolean) extends ComplexType {
   def _toString = "Call"
 
+  override def _toPyString(sb: StringBuilder): Unit = {
+    sb.append("call")
+  }
   val representation: Type = TCall.representation(required)
 
   def _typeCheck(a: Any): Boolean = a.isInstanceOf[Int]

--- a/src/main/scala/is/hail/expr/types/TDict.scala
+++ b/src/main/scala/is/hail/expr/types/TDict.scala
@@ -35,6 +35,14 @@ final case class TDict(keyType: Type, valueType: Type, override val required: Bo
 
   def _toString = s"Dict[$keyType, $valueType]"
 
+  override def _toPyString(sb: StringBuilder): Unit = {
+    sb.append("dict<")
+    keyType._toPyString(sb)
+    sb.append(", ")
+    valueType._toPyString(sb)
+    sb.append('>')
+  }
+
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean = false) {
     sb.append("Dict[")
     keyType.pretty(sb, indent, compact)

--- a/src/main/scala/is/hail/expr/types/TFloat32.scala
+++ b/src/main/scala/is/hail/expr/types/TFloat32.scala
@@ -14,6 +14,9 @@ case object TFloat32Required extends TFloat32(true)
 class TFloat32(override val required: Boolean) extends TNumeric {
   def _toString = "Float32"
 
+  override def _toPyString(sb: StringBuilder): Unit = {
+    sb.append("float32")
+  }
   val conv = FloatNumericConversion
 
   def _typeCheck(a: Any): Boolean = a.isInstanceOf[Float]

--- a/src/main/scala/is/hail/expr/types/TFloat64.scala
+++ b/src/main/scala/is/hail/expr/types/TFloat64.scala
@@ -14,6 +14,10 @@ case object TFloat64Required extends TFloat64(true)
 class TFloat64(override val required: Boolean) extends TNumeric {
   override def _toString = "Float64"
 
+  override def _toPyString(sb: StringBuilder): Unit = {
+    sb.append("float64")
+  }
+
   val conv = DoubleNumericConversion
 
   def _typeCheck(a: Any): Boolean = a.isInstanceOf[Double]

--- a/src/main/scala/is/hail/expr/types/TInt32.scala
+++ b/src/main/scala/is/hail/expr/types/TInt32.scala
@@ -14,6 +14,9 @@ case object TInt32Required extends TInt32(true)
 class TInt32(override val required: Boolean) extends TIntegral {
   def _toString = "Int32"
 
+  override def _toPyString(sb: StringBuilder): Unit = {
+    sb.append("int32")
+  }
   val conv = IntNumericConversion
 
   def _typeCheck(a: Any): Boolean = a.isInstanceOf[Int]

--- a/src/main/scala/is/hail/expr/types/TInt64.scala
+++ b/src/main/scala/is/hail/expr/types/TInt64.scala
@@ -14,6 +14,9 @@ case object TInt64Required extends TInt64(true)
 class TInt64(override val required: Boolean) extends TIntegral {
   def _toString = "Int64"
 
+  override def _toPyString(sb: StringBuilder): Unit = {
+    sb.append("int64")
+  }
   val conv = LongNumericConversion
 
   def _typeCheck(a: Any): Boolean = a.isInstanceOf[Long]

--- a/src/main/scala/is/hail/expr/types/TInterval.scala
+++ b/src/main/scala/is/hail/expr/types/TInterval.scala
@@ -12,6 +12,11 @@ case class TInterval(pointType: Type, override val required: Boolean = false) ex
 
   def _toString = s"""Interval[$pointType]"""
 
+  override def _toPyString(sb: StringBuilder): Unit = {
+    sb.append("interval<")
+    pointType._toPyString(sb)
+    sb.append('>')
+  }
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean = false) {
     sb.append("Interval[")
     pointType.pretty(sb, indent, compact)

--- a/src/main/scala/is/hail/expr/types/TLocus.scala
+++ b/src/main/scala/is/hail/expr/types/TLocus.scala
@@ -20,6 +20,11 @@ object TLocus {
 case class TLocus(gr: GRBase, override val required: Boolean = false) extends ComplexType {
   def _toString = s"Locus($gr)"
 
+  override def _toPyString(sb: StringBuilder): Unit = {
+    sb.append("locus[")
+    sb.append(prettyIdentifier(gr.name))
+    sb.append(']')
+  }
   def _typeCheck(a: Any): Boolean = a.isInstanceOf[Locus]
 
   override def genNonmissingValue: Gen[Annotation] = Locus.gen(gr.asInstanceOf[GenomeReference])

--- a/src/main/scala/is/hail/expr/types/TSet.scala
+++ b/src/main/scala/is/hail/expr/types/TSet.scala
@@ -16,6 +16,12 @@ final case class TSet(elementType: Type, override val required: Boolean = false)
 
   def _toString = s"Set[$elementType]"
 
+  override def _toPyString(sb: StringBuilder): Unit = {
+    sb.append("set<")
+    elementType._toPyString(sb)
+    sb.append('>')
+  }
+
   override def canCompare(other: Type): Boolean = other match {
     case TSet(otherType, _) => elementType.canCompare(otherType)
     case _ => false

--- a/src/main/scala/is/hail/expr/types/TString.scala
+++ b/src/main/scala/is/hail/expr/types/TString.scala
@@ -13,6 +13,9 @@ case object TStringRequired extends TString(true)
 class TString(override val required: Boolean) extends Type {
   def _toString = "String"
 
+  override def _toPyString(sb: StringBuilder): Unit = {
+    sb.append("str")
+  }
   def _typeCheck(a: Any): Boolean = a.isInstanceOf[String]
 
   override def genNonmissingValue: Gen[Annotation] = arbitrary[String]

--- a/src/main/scala/is/hail/expr/types/TStruct.scala
+++ b/src/main/scala/is/hail/expr/types/TStruct.scala
@@ -550,6 +550,16 @@ final case class TStruct(fields: IndexedSeq[Field], override val required: Boole
     (TStruct(newFields.zipWithIndex.map { case (f, i) => f.copy(index = i) }), filterer)
   }
 
+  override def _toPyString(sb: StringBuilder): Unit = {
+    sb.append("struct{")
+    fields.foreachBetween({ field =>
+      sb.append(prettyIdentifier(field.name))
+      sb.append(": ")
+      field.typ._toPyString(sb)
+    }) { sb.append(", ")}
+    sb.append('}')
+  }
+
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean) {
     if (compact) {
       sb.append("Struct{")

--- a/src/main/scala/is/hail/expr/types/TTuple.scala
+++ b/src/main/scala/is/hail/expr/types/TTuple.scala
@@ -62,6 +62,15 @@ final case class TTuple(_types: IndexedSeq[Type], override val required: Boolean
     sb += ']'
   }
 
+  override def _toPyString(sb: StringBuilder): Unit = {
+    sb.append("tuple(")
+    fields.foreachBetween({ field =>
+      field.typ._toPyString(sb)
+    }) { sb.append(", ")}
+    sb.append(')')
+  }
+
+
   override val fundamentalType: TTuple = {
     val fundamentalFieldTypes = types.map(t => t.fundamentalType)
     if ((types, fundamentalFieldTypes).zipped

--- a/src/main/scala/is/hail/expr/types/Type.scala
+++ b/src/main/scala/is/hail/expr/types/Type.scala
@@ -210,6 +210,15 @@ abstract class Type extends BaseType with Serializable {
 
   def _toString: String
 
+  def toPyString: String = {
+    val sb = new StringBuilder
+    _toPyString(sb)
+    sb.result()
+  }
+
+  def _toPyString(sb: StringBuilder): Unit = ???
+
+
   def _pretty(sb: StringBuilder, indent: Int, compact: Boolean) {
     sb.append(_toString)
   }

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -1243,7 +1243,7 @@ class Table(val hc: HailContext, val ir: TableIR) {
           convertType(f.typ, if (name == null) f.name else name + "." + f.name, ab)
         }
         case _ =>
-          ab += (name, t.toString, t.isInstanceOf[TNumeric])
+          ab += (name, t.toPyString, t.isInstanceOf[TNumeric])
       }
     }
 


### PR DESCRIPTION
to the Type._from_java hotspot and the typecheck inspect hotspot.