### PR TITLE
use new Expression.show, collect, etc. in tutorial

### DIFF
--- a/python/hail/docs/tutorials/hail-overview.ipynb
+++ b/python/hail/docs/tutorials/hail-overview.ipynb
@@ -12,9 +12,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import hail as hl\n",
@@ -34,9 +32,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -59,9 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# optional\n",
@@ -81,9 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
@@ -122,9 +114,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ds = hl.read_matrix_table('data/1kg.vds')"
@@ -149,9 +139,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "hl.summarize(ds).report()"
@@ -171,9 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ds.rows_table().select('locus', 'alleles').show(5)"
@@ -190,12 +176,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "ds.cols_table().select('s').show(5)"
+    "ds.s.show(5)"
    ]
   },
   {
@@ -211,12 +196,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
    "source": [
-    "ds.entries_table().select('DP','GT','AD','GQ','PL').take(5)"
+    "ds.entry.take(5)"
    ]
   },
   {
@@ -240,9 +224,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%sh\n",
@@ -259,9 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "table = (hl.import_table('data/1kg_annotations.txt', impute=True)\n",
@@ -280,7 +260,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -298,9 +277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pprint(table.schema)"
@@ -316,9 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "table.show(10, width=100)"
@@ -335,7 +310,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -353,9 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ds = ds.annotate_cols(**table[ds.s])"
@@ -365,7 +337,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -394,9 +365,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pprint(table.aggregate(agg.counter(table.SuperPopulation)))"
@@ -412,9 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pprint(table.aggregate(agg.stats(table.CaffeineConsumption)))"
@@ -430,9 +397,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "table.count()"
@@ -441,9 +406,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ds.count_cols()"
@@ -459,9 +422,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ds.aggregate_cols(agg.counter(ds.SuperPopulation))"
@@ -471,7 +432,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -493,9 +453,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "snp_counts = ds.aggregate_rows(agg.counter(hl.Struct(ref=ds.alleles[0], alt=ds.alleles[1])))\n",
@@ -512,9 +470,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from collections import Counter\n",
@@ -543,9 +499,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dp_hist = ds.aggregate_entries(agg.hist(ds.DP, 0, 30, 30))\n",
@@ -573,9 +527,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pprint(ds.col_schema)"
@@ -584,9 +536,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ds = hl.sample_qc(ds)"
@@ -595,9 +545,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pprint(ds.col_schema)"
@@ -615,9 +563,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df = ds.cols_table().to_pandas()"
@@ -626,9 +572,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df.head()"
@@ -644,9 +588,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plt.clf()\n",
@@ -676,9 +618,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plt.scatter(df[\"sample_qc.dpMean\"], df[\"sample_qc.callRate\"],\n",
@@ -700,7 +640,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -725,9 +664,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ds = ds.filter_cols((ds.sample_qc.dpMean >= 4) & (ds.sample_qc.callRate >= 0.97))\n",
@@ -746,9 +683,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "call_rate = ds.aggregate_entries(agg.fraction(hl.is_defined(ds.GT)))\n",
@@ -765,9 +700,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ab = ds.AD[1] / hl.sum(ds.AD)\n",
@@ -782,9 +715,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "post_qc_call_rate = ds.aggregate_entries(agg.fraction(hl.is_defined(ds.GT)))\n",
@@ -801,9 +732,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pprint(ds.row_schema)"
@@ -819,9 +748,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ds = hl.variant_qc(ds).cache()"
@@ -830,9 +757,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pprint(ds.row_schema)"
@@ -841,9 +766,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "variant_df = ds.rows_table().to_pandas()\n",
@@ -902,9 +825,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "common_ds = ds.filter_rows(ds.variant_qc.AF > 0.01)"
@@ -913,9 +834,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print('Samples: %d  Variants: %d' % (common_ds.count_cols(), common_ds.count_rows()))"
@@ -933,9 +852,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "gwas = hl.linreg(common_ds, common_ds.CaffeineConsumption, common_ds.GT.num_alt_alleles())\n",
@@ -952,9 +869,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def qqplot(pvals, xMax, yMax):\n",
@@ -981,12 +896,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "qqplot(gwas.aggregate_rows(agg.collect(gwas.linreg.pval[0])), 5, 6)"
+    "qqplot(gwas.linreg.pval[0].collect(), 5, 6)"
    ]
   },
   {
@@ -1007,9 +920,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pca_eigenvalues, pca_scores, _ = hl.hwe_normalized_pca(common_ds)"
@@ -1018,9 +929,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pprint(pca_eigenvalues)"
@@ -1029,9 +938,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pca_scores.show(5, width=100)"
@@ -1047,9 +954,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pca_table = pca_scores.join(common_ds.cols_table()).to_pandas()\n",
@@ -1076,9 +981,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "cds = common_ds.annotate_cols(pca = pca_scores[common_ds.s])\n",
@@ -1086,14 +989,13 @@
     "linreg_results = hl.linreg(cds, cds.CaffeineConsumption, cds.GT.num_alt_alleles(),\n",
     "                           covariates=[cds.pca.PC1, cds.pca.PC2, cds.pca.PC3, cds.isFemale])\n",
     "\n",
-    "pvals = linreg_results.aggregate_rows(agg.collect(linreg_results.linreg.pval[0]))"
+    "pvals = linreg_results.linreg.pval[0].collect()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -1104,9 +1006,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def plDosage(pl):\n",
@@ -1119,23 +1019,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "linreg_results = hl.linreg(cds, [cds.CaffeineConsumption], plDosage(cds.PL),\n",
     "                           covariates=[cds.pca.PC1, cds.pca.PC2, cds.pca.PC3, cds.isFemale])\n",
     "\n",
-    "pvals = linreg_results.aggregate_rows(agg.collect(linreg_results.linreg.pval[0]))"
+    "pvals = linreg_results.linreg.pval[0].collect()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "qqplot(pvals, 5, 6)"
@@ -1161,7 +1057,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -1174,9 +1069,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "results.show() "
@@ -1192,9 +1085,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "entries = entries.annotate(maf_bin = hl.cond(entries.info.AF[0]<0.01, \"< 1%\", \n",
@@ -1208,9 +1099,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "results2.show()"
@@ -1250,9 +1139,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "table = hl.import_table('data/1kg_annotations.txt', impute=True).key_by('Sample')\n",
@@ -1274,15 +1161,13 @@
     "cds = common_ds.annotate_cols(pca = pca_scores[common_ds.s])\n",
     "linreg_results = hl.linreg(cds, [cds.CaffeineConsumption], cds.GT.num_alt_alleles(),\n",
     "                           covariates=[cds.pca.PC1, cds.pca.PC2, cds.pca.PC3, cds.isFemale])\n",
-    "pvals = linreg_results.aggregate_rows(agg.collect(linreg_results.linreg.pval[0]))"
+    "pvals = linreg_results.linreg.pval[0].collect()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -1304,7 +1189,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/python/hail/expr/expression.py
+++ b/python/hail/expr/expression.py
@@ -679,7 +679,8 @@ class Expression(object):
         :obj:`list`
         """
         uid = Env._get_uid()
-        return [r[uid] for r in self._to_table(uid).collect()]
+        t = self._to_table(uid)
+        return t.aggregate(hl.agg.collect(t[uid]))
 
 class CollectionExpression(Expression):
     """Expression of type :class:`.TArray` or :class:`.TSet`

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -1415,7 +1415,7 @@ class Table(TableTemplate):
         :obj:`list` of :class:`.Struct`
             List of rows.
         """
-        return tarray(self.schema)._convert_to_py(self._jt.collect())
+        return [self.schema._convert_to_py(x) for x in self._jt.collect()]
 
     def describe(self):
         """Print information about the fields in the table."""

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -34,7 +34,7 @@ object PCRelate {
 
   def apply(vds: MatrixTable, k: Int, pcaScores: Table, maf: Double, blockSize: Int, minKinship: Double = PCRelate.defaultMinKinship, statistics: PCRelate.StatisticSubset = PCRelate.defaultStatisticSubset): Table = {
     val scoreArray = new Array[Double](vds.numCols * k)
-    val pcs = pcaScores.collect().asInstanceOf[IndexedSeq[UnsafeRow]]
+    val pcs = pcaScores.collect()
     var i = 0
     while (i < vds.numCols) {
       val row = pcs(i).getAs[IndexedSeq[Double]](1)

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -1051,7 +1051,7 @@ class Table(val hc: HailContext, val ir: TableIR) {
 
   def explode(columnNames: java.util.ArrayList[String]): Table = explode(columnNames.asScala.toArray)
 
-  def collect(): IndexedSeq[Row] = rdd.collect()
+  def collect(): Array[Row] = rdd.collect()
 
   def write(path: String, overwrite: Boolean = false, codecSpecJSONStr: String = null) {
     val codecSpec =
@@ -1234,7 +1234,7 @@ class Table(val hc: HailContext, val ir: TableIR) {
     else {
       val takeResult = take(n + 1)
       val hasMoreData = takeResult.length > n
-      (takeResult.take(n): IndexedSeq[Row]) -> hasMoreData
+      takeResult.take(n) -> hasMoreData
     }
 
     def convertType(t: Type, name: String, ab: ArrayBuilder[(String, String, Boolean)]) {

--- a/src/test/scala/is/hail/methods/AggregatorSuite.scala
+++ b/src/test/scala/is/hail/methods/AggregatorSuite.scala
@@ -139,12 +139,12 @@ class AggregatorSuite extends SparkSuite {
     val ktMax = Table(hc, rdd, signature)
       .aggregate("group = row.group", (0 until 11).map(i => s"s$i = rows.map(r => r.s$i).max()").mkString(","))
 
-    assert(ktMax.collect() == IndexedSeq(Row("a", 1, -1, 2, -1, -1, 1, 1, null, 1l, 1f, 1d)))
+    assert(ktMax.collect() sameElements Array(Row("a", 1, -1, 2, -1, -1, 1, 1, null, 1l, 1f, 1d)))
 
     val ktMin = Table(hc, rdd, signature)
       .aggregate("group = row.group", (0 until 11).map(i => s"s$i = rows.map(r => r.s$i).min()").mkString(","))
 
-    assert(ktMin.collect() == IndexedSeq(Row("a", -1, -2, 1, -2, -1, 1, 1, null, -1l, -1f, -1d)))
+    assert(ktMin.collect() sameElements Array(Row("a", -1, -2, 1, -2, -1, 1, 1, null, -1l, -1f, -1d)))
   }
 
   @Test def testProduct() {
@@ -159,7 +159,7 @@ class AggregatorSuite extends SparkSuite {
     val ktProduct = Table(hc, rdd, signature)
       .aggregate("group = row.group", ((0 until 11).map(i => s"s$i = rows.map(r => r.s$i).product()") :+ ("empty = rows.map(r => r.s10).filter(x => false).product()")).mkString(","))
 
-    assert(ktProduct.collect() == IndexedSeq(Row("a", 0l, 2l, 2l, 6l, -1l, -3l, 80l, 1l, 0l, -4d, 0d, 1d)))
+    assert(ktProduct.collect() sameElements Array(Row("a", 0l, 2l, 2l, 6l, -1l, -3l, 80l, 1l, 0l, -4d, 0d, 1d)))
 
   }
 

--- a/src/test/scala/is/hail/methods/AnnotateGlobalSuite.scala
+++ b/src/test/scala/is/hail/methods/AnnotateGlobalSuite.scala
@@ -77,7 +77,7 @@ class AnnotateGlobalSuite extends SparkSuite {
 
     val kt = hc.importTable(out1, impute = true)
     val vds = hc.importVCF("src/test/resources/sample.vcf")
-      .annotateGlobal(kt.collect(), TArray(kt.signature), "global.genes")
+      .annotateGlobal(kt.collect().toFastIndexedSeq, TArray(kt.signature), "global.genes")
 
     val (t, res) = vds.queryGlobal("global.genes")
 

--- a/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
@@ -160,8 +160,7 @@ class VSMSuite extends SparkSuite {
           .collect()
           .map(_.getAs[Double](0))
 
-
-      val lm = new DenseMatrix[Double](6, 9, data.asInstanceOf[IndexedSeq[Double]].toArray).t // data is row major
+      val lm = new DenseMatrix[Double](6, 9, data).t // data is row major
       
       assert(BlockMatrix.read(hc, dirname).toLocalMatrix() === lm)
     }
@@ -180,7 +179,7 @@ class VSMSuite extends SparkSuite {
       .select("x = row.GT.unphasedDiploidGtIndex() + row.rowIdx + 1 + row.colIdx.toFloat64()")
       .collect()
       .map(_.getAs[Double](0))
-    val lm = new DenseMatrix[Double](nSamples, nVariants, data.asInstanceOf[IndexedSeq[Double]].toArray).t // data is row major
+    val lm = new DenseMatrix[Double](nSamples, nVariants, data).t // data is row major
     val rowKeys = new Keys(TStruct("locus" -> TLocus(GenomeReference.defaultReference), "alleles" -> TArray(TString())),
       Array.tabulate(nVariants)(i => Row(Locus("1", i + 1), IndexedSeq("A", "C"))))
     val colKeys = new Keys(TStruct("s" -> TString()), Array.tabulate(nSamples)(s => Annotation(s.toString)))


### PR DESCRIPTION
Use Table.aggregate in Expression.collect since it is much faster
(doesn't convert row and unneeded keys to python)