### PR TITLE
Require variant for export vcf, nirvana, vep

### DIFF
--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -7,7 +7,7 @@ from hail.table import Table
 from hail.expr.types import *
 from hail.expr.expression import analyze, expr_any
 from hail.genetics.reference_genome import reference_genome_type
-from hail.methods.misc import require_biallelic
+from hail.methods.misc import require_biallelic, require_variant
 
 
 @handle_py4j
@@ -309,6 +309,7 @@ def export_vcf(dataset, output, append_to_header=None, parallel=None, metadata=N
 
     """
 
+    require_variant(dataset, 'export_vcf')
     typ = tdict(tstr, tdict(tstr, tdict(tstr, tstr)))
     Env.hail().io.vcf.ExportVCF.apply(dataset._jvds, output, joption(append_to_header),
                                       Env.hail().utils.ExportType.getExportType(parallel),

--- a/python/hail/methods/qc.py
+++ b/python/hail/methods/qc.py
@@ -2,7 +2,7 @@ from hail.typecheck import *
 from hail.utils.java import Env, handle_py4j
 from hail.matrixtable import MatrixTable
 from hail.table import Table
-from .misc import require_biallelic
+from .misc import require_biallelic, require_variant
 
 @handle_py4j
 @typecheck(dataset=MatrixTable, name=str)
@@ -539,6 +539,7 @@ def vep(dataset, config, block_size=1000, name='vep', csq=False):
         Dataset with new row-indexed field `name` containing VEP annotations.
     """
 
+    require_variant(dataset, 'vep')
     return MatrixTable(Env.hail().methods.VEP.apply(dataset._jvds, config, 'va.`{}`'.format(name), csq, block_size))
 
 
@@ -798,4 +799,5 @@ def nirvana(dataset, config, block_size=500000, name='nirvana'):
         Dataset with new row-indexed field `name` containing Nirvana annotations.
     """
 
+    require_variant(dataset, 'nirvana')
     return MatrixTable(Env.hail().methods.Nirvana.apply(dataset._jvds, config, block_size, 'va.`{}`'.format(name)))

--- a/src/main/scala/is/hail/methods/VEP.scala
+++ b/src/main/scala/is/hail/methods/VEP.scala
@@ -298,7 +298,7 @@ object VEP {
     val alleleNumIndex = if (csq) csqHeader.split("\\|").indexOf("ALLELE_NUM") else -1
 
     val localRowType = vsm.rvRowType
-    val localGR = vsm.referenceGenome
+    val localRG = vsm.referenceGenome
     val annotations = vsm.rvd
       .mapPartitions { it =>
         val pb = new ProcessBuilder(cmd.toList.asJava)
@@ -383,7 +383,7 @@ object VEP {
               }
 
             val r = kt.toArray
-              .sortBy(_._1)(localGR.variantOrdering)
+              .sortBy(_._1)(localRG.variantOrdering)
 
             val rc = proc.waitFor()
             if (rc != 0)


### PR DESCRIPTION
Other methods are already checked with require_biallelic which calls require_variant.
