### PR TITLE
rename column => field everywhere in Table

### DIFF
--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -2346,7 +2346,7 @@ class MatrixTable(object):
 
         In order to combine two datasets, three requirements must be met:
 
-         - The column key must be identical, both in type, value, and ordering.
+         - The column keys must be identical, both in type, value, and ordering.
          - The row key schemas and row schemas must match.
          - The entry schemas must match.
 

--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -2346,7 +2346,7 @@ class MatrixTable(object):
 
         In order to combine two datasets, three requirements must be met:
 
-         - The column keys must be identical, both in type, value, and ordering.
+         - The column key must be identical, both in type, value, and ordering.
          - The row key schemas and row schemas must match.
          - The entry schemas must match.
 

--- a/python/hail/methods/tests.py
+++ b/python/hail/methods/tests.py
@@ -601,7 +601,7 @@ class Tests(unittest.TestCase):
             block_matrix = BlockMatrix._from_numpy_matrix(numpy_matrix, block_size)
             entries_table = block_matrix.entries()
             self.assertEqual(entries_table.count(), num_cols * num_rows)
-            self.assertEqual(entries_table.num_columns, 3)
+            self.assertEqual(entries_table.num_fields, 3)
             self.assertTrue(table._same(entries_table))
 
     def test_min_rep(self):

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -375,7 +375,7 @@ class Table(TableTemplate):
 
     @typecheck_method(keys=oneof(str, Expression))
     def key_by(self, *keys):
-        """Change which fields are keys.
+        """Change the key.
 
         Examples
         --------
@@ -388,7 +388,7 @@ class Table(TableTemplate):
 
         >>> table_result = table1.key_by(table1.C1)
 
-        Set to no keys:
+        Set to empty key:
 
         >>> table_result = table1.key_by()
 
@@ -400,7 +400,7 @@ class Table(TableTemplate):
         Returns
         -------
         :class:`.Table`
-            Table with new set of keys.
+            Table with a new key.
         """
         str_keys = []
         for k in keys:
@@ -896,7 +896,7 @@ class Table(TableTemplate):
         self._jt.export(output, types_file, header, Env.hail().utils.ExportType.getExportType(parallel))
 
     def group_by(self, *exprs, **named_exprs):
-        """Group by a new set of keys for use with :meth:`.GroupedTable.aggregate`.
+        """Group by a new key for use with :meth:`.GroupedTable.aggregate`.
 
         Examples
         --------
@@ -1311,7 +1311,7 @@ class Table(TableTemplate):
 
         Examples
         --------
-        Persist the key table to both memory and disk:
+        Persist the table to both memory and disk:
 
         >>> table = table.persist() # doctest: +SKIP
 
@@ -1665,8 +1665,9 @@ class Table(TableTemplate):
         rows will be joined where ``table1.a == table2.c`` and ``table1.b ==
         table2.d``).
 
-        The key field names and order from the left table are preserved, while
-        the key fields from the right table are not present in the result.
+        The key fields and order from the left table are preserved,
+        while the key fields from the right table are not present in
+        the result.
 
         Parameters
         ----------
@@ -1679,6 +1680,7 @@ class Table(TableTemplate):
         -------
         :class:`.Table`
             Joined table.
+
         """
 
         return Table(self._jt.join(right._jt, how))
@@ -1825,7 +1827,7 @@ class Table(TableTemplate):
                 }]
             }
 
-        and a single key field ``a``.  The result of flatten is
+        and a single key ``a``.  The result of flatten is
 
         .. code-block:: text
 
@@ -1838,7 +1840,7 @@ class Table(TableTemplate):
                 z: String
             }]
 
-        with key fields ``a.p`` and ``a.q``.
+        with key ``a.p`` and ``a.q``.
 
         Note, structures inside collections like arrays or sets will not be
         flattened.
@@ -2104,7 +2106,7 @@ class Table(TableTemplate):
     @typecheck_method(expand=bool,
                       flatten=bool)
     def to_spark(self, expand=True, flatten=True):
-        """Converts this key table to a Spark DataFrame.
+        """Converts this table to a Spark DataFrame.
 
         Parameters
         ----------

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -1827,7 +1827,7 @@ class Table(TableTemplate):
                 }]
             }
 
-        and a key ``a``.  The result of flatten is
+        and key ``a``.  The result of flatten is
 
         .. code-block:: text
 
@@ -1840,7 +1840,7 @@ class Table(TableTemplate):
                 z: String
             }]
 
-        with key ``a.p`` and ``a.q``.
+        with key ``a.p, a.q``.
 
         Note, structures inside collections like arrays or sets will not be
         flattened.

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -1827,7 +1827,7 @@ class Table(TableTemplate):
                 }]
             }
 
-        and a single key ``a``.  The result of flatten is
+        and a key ``a``.  The result of flatten is
 
         .. code-block:: text
 

--- a/python/hail/tests.py
+++ b/python/hail/tests.py
@@ -177,7 +177,7 @@ class TableTests(unittest.TestCase):
         df = df.transmute(h=df.a + df.b + df.c + df.g.y)
         r = df.select('h').collect()
 
-        self.assertEqual(df.columns, ['d', 'e', 'f', 'h'])
+        self.assertEqual(df.fields, ['d', 'e', 'f', 'h'])
         self.assertEqual(r, [hl.Struct(h=x) for x in [10, 20, None]])
 
     def test_select(self):
@@ -191,10 +191,10 @@ class TableTests(unittest.TestCase):
 
         kt = hl.Table.parallelize(rows, schema)
 
-        self.assertEqual(kt.select(kt.a, kt.e).columns, ['a', 'e'])
-        self.assertEqual(kt.select(*[kt.a, kt.e]).columns, ['a', 'e'])
-        self.assertEqual(kt.select(kt.a, foo=kt.a + kt.b - kt.c - kt.d).columns, ['a', 'foo'])
-        self.assertEqual(set(kt.select(kt.a, foo=kt.a + kt.b - kt.c - kt.d, **kt.g).columns), {'a', 'foo', 'x', 'y'})
+        self.assertEqual(kt.select(kt.a, kt.e).fields, ['a', 'e'])
+        self.assertEqual(kt.select(*[kt.a, kt.e]).fields, ['a', 'e'])
+        self.assertEqual(kt.select(kt.a, foo=kt.a + kt.b - kt.c - kt.d).fields, ['a', 'foo'])
+        self.assertEqual(set(kt.select(kt.a, foo=kt.a + kt.b - kt.c - kt.d, **kt.g).fields), {'a', 'foo', 'x', 'y'})
 
     def test_aggregate(self):
         schema = hl.tstruct.from_lists(['status', 'GT', 'qPheno'],
@@ -300,8 +300,8 @@ class TableTests(unittest.TestCase):
         kt = hl.utils.range_table(10)
         kt = kt.annotate(sq=kt.idx ** 2, foo='foo', bar='bar')
 
-        self.assertEqual(kt.drop('idx', 'foo').columns, ['sq', 'bar'])
-        self.assertEqual(kt.drop(kt['idx'], kt['foo']).columns, ['sq', 'bar'])
+        self.assertEqual(kt.drop('idx', 'foo').fields, ['sq', 'bar'])
+        self.assertEqual(kt.drop(kt['idx'], kt['foo']).fields, ['sq', 'bar'])
 
     def test_weird_names(self):
         df = hl.utils.range_table(10)


### PR DESCRIPTION
so we don't confuse column of table and column of matrixtable.