### PR TITLE
MT.count returns (n_rows, n_cols)

### DIFF
--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -1761,18 +1761,18 @@ class MatrixTable(object):
         return self._jvds.numCols()
 
     def count(self):
-        """Count the number of columns and rows in the matrix.
+        """Count the number of rows and columns in the matrix.
 
         Examples
         --------
         .. doctest::
 
-            >>> dataset.count_cols()
+            >>> dataset.count()
 
         Returns
         -------
         :obj:`int`, :obj:`int`
-            Number of cols, number of rows.
+            Number of rows, number of cols.
         """
         r = self._jvds.count()
         return r._1(), r._2()

--- a/python/hail/tests.py
+++ b/python/hail/tests.py
@@ -333,6 +333,9 @@ class MatrixTests(unittest.TestCase):
     def get_vds(self, min_partitions=None):
         return hl.import_vcf(test_file("sample.vcf"), min_partitions=min_partitions)
 
+    def test_range_count(self):
+        self.assertEqual(hl.utils.range_matrix_table(7, 13).count(), (7, 13))
+
     def test_row_key_field_show_runs(self):
         ds = self.get_vds()
         ds.locus.show()

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1451,7 +1451,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     orderedRVDLeftJoinDistinctAndInsert(rightRVD, root, product = false)
   }
 
-  def count(): (Long, Long) = (numCols, countRows())
+  def count(): (Long, Long) = (countRows(), numCols)
 
   def countRows(): Long = partitionCounts().sum
 

--- a/src/test/scala/is/hail/variant/vsm/GroupBySuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/GroupBySuite.scala
@@ -16,22 +16,22 @@ class GroupBySuite extends SparkSuite {
 
   @Test def testGroupSamplesBy() {
     val vds = hc.importVCF("src/test/resources/sample.vcf").annotateSamplesExpr("AC = AGG.map(g => g.GT.nNonRefAlleles()).sum()")
-    val vds2 = vds.groupSamplesBy("AC = sa.AC", "max = AGG.map(g => g.GT.nNonRefAlleles()).max()").count()
+    vds.groupSamplesBy("AC = sa.AC", "max = AGG.map(g => g.GT.nNonRefAlleles()).max()").count()
   }
 
   @Test def testGroupSamplesStruct() {
     val vds = hc.importVCF("src/test/resources/sample.vcf").annotateSamplesExpr("foo = {str1: 1, str2: \"bar\"}")
-    val vds2 = vds.groupSamplesBy("foo = sa.foo", "max = AGG.map(g => g.GT.nNonRefAlleles()).max()").count()
+    vds.groupSamplesBy("foo = sa.foo", "max = AGG.map(g => g.GT.nNonRefAlleles()).max()").count()
   }
 
   @Test def testGroupVariantsBy() {
     val vds = hc.importVCF("src/test/resources/sample.vcf").annotateRowsExpr("AC = AGG.map(g => g.GT.nNonRefAlleles()).sum()")
-    val vds2 = vds.groupRowsBy("AC = va.AC", "max = AGG.map(g => g.GT.nNonRefAlleles()).max()").count()
+    vds.groupRowsBy("AC = va.AC", "max = AGG.map(g => g.GT.nNonRefAlleles()).max()").count()
   }
 
   @Test def testGroupVariantsStruct() {
     val vds = hc.importVCF("src/test/resources/sample.vcf").annotateRowsExpr("AC = {str1: \"foo\", str2: 1}")
-    val vds2 = vds.groupRowsBy("AC = va.AC", "max = AGG.map(g => g.GT.nNonRefAlleles()).max()").count()
+    vds.groupRowsBy("AC = va.AC", "max = AGG.map(g => g.GT.nNonRefAlleles()).max()").count()
   }
 
   // FIXME this test is broken, @tpoterba has fixed in a separate branch


### PR DESCRIPTION
the other way was clearly backwards