### PR TITLE
Typecheck2 : The Types Strike Back

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,6 +214,7 @@ task testPython(type: Exec, dependsOn: shadowJar) {
              'hail.tests.test_linalg',
              'hail.tests.test_methods',
              'hail.tests.test_typecheck',
+             'hail.tests.test_typecheck2',
              'hail.tests.test_utils'
      environment SPARK_HOME: sparkHome
      environment PYTHONPATH: '' + projectDir + '/python:' + sparkHome + '/python:' + sparkHome + '/python/lib/py4j-' + py4jVersion + '-src.zip'

--- a/python/hail/tests/test_typecheck2.py
+++ b/python/hail/tests/test_typecheck2.py
@@ -3,152 +3,68 @@ import unittest
 from typing import *
 
 
-def f_noargs():
-    pass
-
-
-def f_simple1(x: int):
-    typecheck(f_simple1)
-
-
-def f_simple2(x: str):
-    typecheck(f_simple2)
-
-
-def f_optional(x: Optional[str]):
-    typecheck(f_optional)
-
-
-def f_float(x: float):
-    typecheck(f_float)
-
-
-def f_union(x: Union[int, str]):
-    typecheck(f_union)
-
-
-def f_list(x: List):
-    typecheck(f_list)
-
-
-def f_list_int(x: List[int]):
-    typecheck(f_list_int)
-
-
-def f_sequence(x: Sequence):
-    typecheck(f_sequence)
-
-
-def f_sequence_float(x: Sequence[float]):
-    typecheck(f_sequence_float)
-
-
-def f_set(x: Set):
-    typecheck(f_set)
-
-
-def f_set_union(x: Set[Union[int, str]]):
-    typecheck(f_set_union)
-
-
-def f_frozenset(x: FrozenSet):
-    typecheck(f_frozenset)
-
-
-def f_frozenset_int(x: FrozenSet[int]):
-    typecheck(f_frozenset_int)
-
-
-def f_collection(x: Collection):
-    typecheck(f_collection)
-
-
-def f_collection_str(x: Collection[str]):
-    typecheck(f_collection_str)
-
-
-def f_tuple(x: Tuple):
-    typecheck(f_tuple)
-
-
-def f_tuple2(x: Tuple[Any, ...]):
-    typecheck(f_tuple2)
-
-
-def f_tuple_var(x: Tuple[int, ...]):
-    typecheck(f_tuple_var)
-
-
-def f_tuple_sized1(x: Tuple[int]):
-    typecheck(f_tuple_sized1)
-
-
-def f_tuple_sized2(x: Tuple[int, str, Union[str, int]]):
-    typecheck(f_tuple_sized2)
-
-
-def f_dict(x: Dict):
-    typecheck(f_dict)
-
-
-def f_dict_str_int(x: Dict[str, int]):
-    typecheck(f_dict_str_int)
-
-
-def f_mapping(x: Mapping):
-    typecheck(f_mapping)
-
-
-def f_mapping_str_int(x: Mapping[str, int]):
-    typecheck(f_mapping_str_int)
-
-
-def f_varargs(x: int, *xs: str):
-    typecheck(f_varargs)
-
-
-def f_varargs2(*xs: str):
-    typecheck(f_varargs2)
-
-
-def f_varargs3(x: int, *xs: Union[str, int]):
-    typecheck(f_varargs3)
-
-
-def f_kwargs(x: int, **xs: int):
-    typecheck(f_kwargs)
-
-
-def f_kwargs2(x: int, **xs: List[Union[str, int]]):
-    typecheck(f_kwargs2)
-
-
-def f_complicated(x: List[List[Set[Union[str, int]]]],
-                  y: Dict[Union[int, str], Sequence[Optional[int]]]):
-    typecheck(f_complicated)
-
-def f_callable(x: Callable[[int, str], str]):
-    typecheck(f_callable)
-
-
 class Tests(unittest.TestCase):
 
-    def test_successful_execution(self):
+    def test_noargs(self):
+        def f_noargs():
+            pass
+
         f_noargs()
 
-        f_simple1(1)
+    def test_simple(self):
+        def f_simple1(x: int):
+            typecheck(f_simple1)
 
+        def f_simple2(x: str):
+            typecheck(f_simple2)
+
+        f_simple1(1)
         f_simple2('a')
+
+        with self.assertRaises(TypeError):
+            f_simple1('1')
+        with self.assertRaises(TypeError):
+            f_simple2(1)
+        with self.assertRaises(TypeError):
+            f_simple2(None)
+
+    def test_optional(self):
+        def f_optional(x: Optional[str]):
+            typecheck(f_optional)
 
         f_optional('')
         f_optional('a')
         f_optional(None)
 
-        f_float(1.5)
+        with self.assertRaises(TypeError):
+            f_optional(1)
+
+    def test_float(self):
+        def f_float(x: float):
+            typecheck(f_float)
+
         f_float(1)
+        f_float(1.5)
+
+        with self.assertRaises(TypeError):
+            f_float([])
+
+    def test_union(self):
+        def f_union(x: Union[int, str]):
+            typecheck(f_union)
 
         f_union(1)
         f_union('1')
+
+        with self.assertRaises(TypeError):
+            f_union(1.2)
+
+    def test_list(self):
+        def f_list(x: List):
+            typecheck(f_list)
+
+        def f_list_int(x: List[int]):
+            typecheck(f_list_int)
 
         f_list([])
         f_list(['a'])
@@ -157,6 +73,24 @@ class Tests(unittest.TestCase):
         f_list_int([])
         f_list_int([1, 2, 3])
 
+        with self.assertRaises(TypeError):
+            f_list({})
+        with self.assertRaises(TypeError):
+            f_list(tuple([1, 2, 3]))
+        with self.assertRaises(TypeError):
+            f_list_int(['1'])
+        with self.assertRaises(TypeError):
+            f_list_int(tuple([]))
+        with self.assertRaises(TypeError):
+            f_list_int(tuple([1]))
+
+    def test_sequence(self):
+        def f_sequence(x: Sequence):
+            typecheck(f_sequence)
+
+        def f_sequence_float(x: Sequence[float]):
+            typecheck(f_sequence_float)
+
         f_sequence([])
         f_sequence(tuple())
 
@@ -164,6 +98,24 @@ class Tests(unittest.TestCase):
         f_sequence_float(tuple())
         f_sequence_float([1, 1.5, 2])
         f_sequence_float((1, 1.5, 2))
+
+        with self.assertRaises(TypeError):
+            f_sequence({})
+        with self.assertRaises(TypeError):
+            f_sequence(set([1, 2, 3]))
+        with self.assertRaises(TypeError):
+            f_sequence_float(['1'])
+        with self.assertRaises(TypeError):
+            f_sequence_float(set())
+        with self.assertRaises(TypeError):
+            f_sequence_float(tuple(['1']))
+
+    def test_set(self):
+        def f_set(x: Set):
+            typecheck(f_set)
+
+        def f_set_union(x: Set[Union[int, str]]):
+            typecheck(f_set_union)
 
         f_set(set())
         f_set({1, 2, 3})
@@ -174,11 +126,44 @@ class Tests(unittest.TestCase):
         f_set_union({'1', 1})
         f_set_union({1, 2, 3, 4})
 
+        with self.assertRaises(TypeError):
+            f_set([])
+        with self.assertRaises(TypeError):
+            f_set(())
+        with self.assertRaises(TypeError):
+            f_set(frozenset())
+        with self.assertRaises(TypeError):
+            f_set_union({1, 1.5})
+
+    def test_frozenset(self):
+        def f_frozenset(x: FrozenSet):
+            typecheck(f_frozenset)
+
+        def f_frozenset_int(x: FrozenSet[int]):
+            typecheck(f_frozenset_int)
+
         f_frozenset(frozenset())
         f_frozenset(frozenset([1, 2, 3]))
 
         f_frozenset_int(frozenset())
         f_frozenset_int(frozenset([1, 2, 3]))
+
+        with self.assertRaises(TypeError):
+            f_frozenset(set())
+        with self.assertRaises(TypeError):
+            f_frozenset([])
+        with self.assertRaises(TypeError):
+            f_frozenset_int(set())
+        with self.assertRaises(TypeError):
+            f_frozenset_int(frozenset(['1']))
+
+    def test_collection(self):
+        def f_collection(x: Collection):
+            typecheck(f_collection)
+
+        def f_collection_str(x: Collection[str]):
+            typecheck(f_collection_str)
+
         f_collection([])
         f_collection([x for x in []])
         f_collection([1, 2, 3])
@@ -189,6 +174,27 @@ class Tests(unittest.TestCase):
 
         f_collection_str([1, 2, 3])
         f_collection_str(tuple(x for x in [1, 2, 3]))
+
+        with self.assertRaises(TypeError):
+            f_collection(1)
+        with self.assertRaises(TypeError):
+            f_collection_str(1)
+
+    def test_tuple(self):
+        def f_tuple(x: Tuple):
+            typecheck(f_tuple)
+
+        def f_tuple2(x: Tuple[Any, ...]):
+            typecheck(f_tuple2)
+
+        def f_tuple_var(x: Tuple[int, ...]):
+            typecheck(f_tuple_var)
+
+        def f_tuple_sized1(x: Tuple[int]):
+            typecheck(f_tuple_sized1)
+
+        def f_tuple_sized2(x: Tuple[int, str, Union[str, int]]):
+            typecheck(f_tuple_sized2)
 
         f_tuple(tuple())
         f_tuple(tuple([1, 2, 3, 4]))
@@ -203,89 +209,6 @@ class Tests(unittest.TestCase):
         f_tuple_sized2((1, '1', 1))
         f_tuple_sized2((1, '1', '2'))
 
-        f_dict({})
-        f_dict({'1': 1})
-        f_dict({1: 1})
-
-        f_dict_str_int({})
-        f_dict_str_int({'1': 1})
-
-        f_mapping({})
-        f_mapping({'1': 1})
-        f_mapping({1: 1})
-
-        f_mapping_str_int({})
-        f_mapping_str_int({'1': 1})
-
-        f_varargs(1)
-        f_varargs(1, '1')
-        f_varargs(1, '1', '2', '3')
-
-        f_varargs2()
-        f_varargs2('1', '2')
-        f_varargs2(*['1'])
-
-        f_varargs3(1)
-        f_varargs3(1, 1)
-        f_varargs3(1, '1')
-        f_varargs3(1, '1', 1, '2', 2)
-
-        f_kwargs(1, xx=1, y=2, **{'foo bar baz': 1})
-        f_kwargs2(1, xx=[1], y=[], **{'foo bar baz': ['1', 1]})
-
-        f_callable(lambda x, y: x + y)
-
-    def test_errors(self):
-        with self.assertRaises(TypeError):
-            f_simple1('1')
-        with self.assertRaises(TypeError):
-            f_simple2(1)
-        with self.assertRaises(TypeError):
-            f_simple2(None)
-        with self.assertRaises(TypeError):
-            f_float([])
-        with self.assertRaises(TypeError):
-            f_union(1.2)
-        with self.assertRaises(TypeError):
-            f_list({})
-        with self.assertRaises(TypeError):
-            f_list(tuple([1, 2, 3]))
-        with self.assertRaises(TypeError):
-            f_list_int(['1'])
-        with self.assertRaises(TypeError):
-            f_list_int(tuple([]))
-        with self.assertRaises(TypeError):
-            f_list_int(tuple([1]))
-        with self.assertRaises(TypeError):
-            f_sequence({})
-        with self.assertRaises(TypeError):
-            f_sequence(set([1, 2, 3]))
-        with self.assertRaises(TypeError):
-            f_sequence_float(['1'])
-        with self.assertRaises(TypeError):
-            f_sequence_float(set())
-        with self.assertRaises(TypeError):
-            f_sequence_float(tuple(['1']))
-        with self.assertRaises(TypeError):
-            f_set([])
-        with self.assertRaises(TypeError):
-            f_set(())
-        with self.assertRaises(TypeError):
-            f_set(frozenset())
-        with self.assertRaises(TypeError):
-            f_set_union({1, 1.5})
-        with self.assertRaises(TypeError):
-            f_frozenset(set())
-        with self.assertRaises(TypeError):
-            f_frozenset([])
-        with self.assertRaises(TypeError):
-            f_frozenset_int(set())
-        with self.assertRaises(TypeError):
-            f_frozenset_int(frozenset(['1']))
-        with self.assertRaises(TypeError):
-            f_collection(1)
-        with self.assertRaises(TypeError):
-            f_collection_str(1)
         with self.assertRaises(TypeError):
             f_tuple([])
         with self.assertRaises(TypeError):
@@ -304,6 +227,21 @@ class Tests(unittest.TestCase):
             f_tuple_sized2(1, '1')
         with self.assertRaises(TypeError):
             f_tuple_sized2(1, '1', '1')
+
+    def test_dict(self):
+        def f_dict(x: Dict):
+            typecheck(f_dict)
+
+        def f_dict_str_int(x: Dict[str, int]):
+            typecheck(f_dict_str_int)
+
+        f_dict({})
+        f_dict({'1': 1})
+        f_dict({1: 1})
+
+        f_dict_str_int({})
+        f_dict_str_int({'1': 1})
+
         with self.assertRaises(TypeError):
             f_dict([])
         with self.assertRaises(TypeError):
@@ -312,6 +250,21 @@ class Tests(unittest.TestCase):
             f_dict_str_int({1: 1})
         with self.assertRaises(TypeError):
             f_dict_str_int({'1': '1'})
+
+    def test_mapping(self):
+        def f_mapping(x: Mapping):
+            typecheck(f_mapping)
+
+        def f_mapping_str_int(x: Mapping[str, int]):
+            typecheck(f_mapping_str_int)
+
+        f_mapping({})
+        f_mapping({'1': 1})
+        f_mapping({1: 1})
+
+        f_mapping_str_int({})
+        f_mapping_str_int({'1': 1})
+
         with self.assertRaises(TypeError):
             f_mapping([])
         with self.assertRaises(TypeError):
@@ -320,6 +273,17 @@ class Tests(unittest.TestCase):
             f_mapping_str_int({1: 1})
         with self.assertRaises(TypeError):
             f_mapping_str_int({'1': '1'})
+
+    def test_varargs(self):
+        def f_varargs(x: int, *xs: str):
+            typecheck(f_varargs)
+
+        def f_varargs2(*xs: str):
+            typecheck(f_varargs2)
+
+        def f_varargs3(x: int, *xs: Union[str, int]):
+            typecheck(f_varargs3)
+
         with self.assertRaises(TypeError):
             f_varargs('1')
         with self.assertRaises(TypeError):
@@ -332,6 +296,30 @@ class Tests(unittest.TestCase):
             f_varargs3('1')
         with self.assertRaises(TypeError):
             f_varargs3(1, 1.5)
+
+        f_varargs(1)
+        f_varargs(1, '1')
+        f_varargs(1, '1', '2', '3')
+
+        f_varargs2()
+        f_varargs2('1', '2')
+        f_varargs2(*['1'])
+
+        f_varargs3(1)
+        f_varargs3(1, 1)
+        f_varargs3(1, '1')
+        f_varargs3(1, '1', 1, '2', 2)
+
+    def test_kwargs(self):
+        def f_kwargs(x: int, **xs: int):
+            typecheck(f_kwargs)
+
+        def f_kwargs2(x: int, **xs: List[Union[str, int]]):
+            typecheck(f_kwargs2)
+
+        f_kwargs(1, xx=1, y=2, **{'foo bar baz': 1})
+        f_kwargs2(1, xx=[1], y=[], **{'foo bar baz': ['1', 1]})
+
         with self.assertRaises(TypeError):
             f_kwargs('1')
         with self.assertRaises(TypeError):
@@ -342,8 +330,13 @@ class Tests(unittest.TestCase):
             f_kwargs2('1')
         with self.assertRaises(TypeError):
             f_kwargs2(1, x=[], y=[1.5])
-        with self.assertRaises(TypeError):
-            f_complicated([[{1, '1'}]], {'1': [1, None, '1']})
+
+    def test_callable(self):
+        def f_callable(x: Callable[[int, str], str]):
+            typecheck(f_callable)
+
+        f_callable(lambda x, y: x + y)
+
         with self.assertRaises(TypeError):
             f_callable(lambda x: x)
         with self.assertRaises(TypeError):
@@ -351,12 +344,24 @@ class Tests(unittest.TestCase):
         with self.assertRaises(TypeError):
             def f(*xs):
                 pass
+
             f_callable(f)
         with self.assertRaises(TypeError):
             def f(x, y, *, z=5):
                 pass
+
             f_callable(f)
         with self.assertRaises(TypeError):
             def f(x, y, **kw):
                 pass
+
             f_callable(f)
+
+    def test_complicated(self):
+        def f_complicated(x: List[List[Set[Union[str, int]]]],
+                          y: Dict[Union[int, str], Sequence[Optional[int]]]):
+            typecheck(f_complicated)
+
+        f_complicated([[{1, 2}]], {'s': [None, 1]})
+        with self.assertRaises(TypeError):
+            f_complicated([[{1, '1'}]], {'1': [1, None, '1']})

--- a/python/hail/tests/test_typecheck2.py
+++ b/python/hail/tests/test_typecheck2.py
@@ -7,7 +7,7 @@ class Tests(unittest.TestCase):
 
     def test_noargs(self):
         def f_noargs():
-            pass
+            typecheck(f_noargs)
 
         f_noargs()
 
@@ -172,13 +172,15 @@ class Tests(unittest.TestCase):
         f_collection({}.keys())
         f_collection({}.items())
 
-        f_collection_str([1, 2, 3])
-        f_collection_str(tuple(x for x in [1, 2, 3]))
+        f_collection_str(['1', '2', '3'])
+        f_collection_str(tuple(str(x) for x in [1, 2, 3]))
 
         with self.assertRaises(TypeError):
             f_collection(1)
         with self.assertRaises(TypeError):
             f_collection_str(1)
+        with self.assertRaises(TypeError):
+            f_collection_str([1, 2, 3])
 
     def test_tuple(self):
         def f_tuple(x: Tuple):

--- a/python/hail/tests/test_typecheck2.py
+++ b/python/hail/tests/test_typecheck2.py
@@ -1,0 +1,362 @@
+from hail.typecheck2 import typecheck
+import unittest
+from typing import *
+
+
+def f_noargs():
+    pass
+
+
+def f_simple1(x: int):
+    typecheck(f_simple1)
+
+
+def f_simple2(x: str):
+    typecheck(f_simple2)
+
+
+def f_optional(x: Optional[str]):
+    typecheck(f_optional)
+
+
+def f_float(x: float):
+    typecheck(f_float)
+
+
+def f_union(x: Union[int, str]):
+    typecheck(f_union)
+
+
+def f_list(x: List):
+    typecheck(f_list)
+
+
+def f_list_int(x: List[int]):
+    typecheck(f_list_int)
+
+
+def f_sequence(x: Sequence):
+    typecheck(f_sequence)
+
+
+def f_sequence_float(x: Sequence[float]):
+    typecheck(f_sequence_float)
+
+
+def f_set(x: Set):
+    typecheck(f_set)
+
+
+def f_set_union(x: Set[Union[int, str]]):
+    typecheck(f_set_union)
+
+
+def f_frozenset(x: FrozenSet):
+    typecheck(f_frozenset)
+
+
+def f_frozenset_int(x: FrozenSet[int]):
+    typecheck(f_frozenset_int)
+
+
+def f_collection(x: Collection):
+    typecheck(f_collection)
+
+
+def f_collection_str(x: Collection[str]):
+    typecheck(f_collection_str)
+
+
+def f_tuple(x: Tuple):
+    typecheck(f_tuple)
+
+
+def f_tuple2(x: Tuple[Any, ...]):
+    typecheck(f_tuple2)
+
+
+def f_tuple_var(x: Tuple[int, ...]):
+    typecheck(f_tuple_var)
+
+
+def f_tuple_sized1(x: Tuple[int]):
+    typecheck(f_tuple_sized1)
+
+
+def f_tuple_sized2(x: Tuple[int, str, Union[str, int]]):
+    typecheck(f_tuple_sized2)
+
+
+def f_dict(x: Dict):
+    typecheck(f_dict)
+
+
+def f_dict_str_int(x: Dict[str, int]):
+    typecheck(f_dict_str_int)
+
+
+def f_mapping(x: Mapping):
+    typecheck(f_mapping)
+
+
+def f_mapping_str_int(x: Mapping[str, int]):
+    typecheck(f_mapping_str_int)
+
+
+def f_varargs(x: int, *xs: str):
+    typecheck(f_varargs)
+
+
+def f_varargs2(*xs: str):
+    typecheck(f_varargs2)
+
+
+def f_varargs3(x: int, *xs: Union[str, int]):
+    typecheck(f_varargs3)
+
+
+def f_kwargs(x: int, **xs: int):
+    typecheck(f_kwargs)
+
+
+def f_kwargs2(x: int, **xs: List[Union[str, int]]):
+    typecheck(f_kwargs2)
+
+
+def f_complicated(x: List[List[Set[Union[str, int]]]],
+                  y: Dict[Union[int, str], Sequence[Optional[int]]]):
+    typecheck(f_complicated)
+
+def f_callable(x: Callable[[int, str], str]):
+    typecheck(f_callable)
+
+
+class Tests(unittest.TestCase):
+
+    def test_successful_execution(self):
+        f_noargs()
+
+        f_simple1(1)
+
+        f_simple2('a')
+
+        f_optional('')
+        f_optional('a')
+        f_optional(None)
+
+        f_float(1.5)
+        f_float(1)
+
+        f_union(1)
+        f_union('1')
+
+        f_list([])
+        f_list(['a'])
+        f_list(['a', 1, None])
+
+        f_list_int([])
+        f_list_int([1, 2, 3])
+
+        f_sequence([])
+        f_sequence(tuple())
+
+        f_sequence_float([])
+        f_sequence_float(tuple())
+        f_sequence_float([1, 1.5, 2])
+        f_sequence_float((1, 1.5, 2))
+
+        f_set(set())
+        f_set({1, 2, 3})
+        f_set({1, 'a', None})
+
+        f_set_union(set())
+        f_set_union({'1'})
+        f_set_union({'1', 1})
+        f_set_union({1, 2, 3, 4})
+
+        f_frozenset(frozenset())
+        f_frozenset(frozenset([1, 2, 3]))
+
+        f_frozenset_int(frozenset())
+        f_frozenset_int(frozenset([1, 2, 3]))
+        f_collection([])
+        f_collection([x for x in []])
+        f_collection([1, 2, 3])
+        f_collection({1, 2, 3})
+        f_collection({})
+        f_collection({}.keys())
+        f_collection({}.items())
+
+        f_collection_str([1, 2, 3])
+        f_collection_str(tuple(x for x in [1, 2, 3]))
+
+        f_tuple(tuple())
+        f_tuple(tuple([1, 2, 3, 4]))
+        f_tuple(tuple([1, 2, 3, '4']))
+
+        f_tuple2(tuple())
+        f_tuple2(tuple([1, 2, 3, 4]))
+        f_tuple2(tuple([1, 2, 3, '4']))
+
+        f_tuple_sized1(tuple([1]))
+
+        f_tuple_sized2((1, '1', 1))
+        f_tuple_sized2((1, '1', '2'))
+
+        f_dict({})
+        f_dict({'1': 1})
+        f_dict({1: 1})
+
+        f_dict_str_int({})
+        f_dict_str_int({'1': 1})
+
+        f_mapping({})
+        f_mapping({'1': 1})
+        f_mapping({1: 1})
+
+        f_mapping_str_int({})
+        f_mapping_str_int({'1': 1})
+
+        f_varargs(1)
+        f_varargs(1, '1')
+        f_varargs(1, '1', '2', '3')
+
+        f_varargs2()
+        f_varargs2('1', '2')
+        f_varargs2(*['1'])
+
+        f_varargs3(1)
+        f_varargs3(1, 1)
+        f_varargs3(1, '1')
+        f_varargs3(1, '1', 1, '2', 2)
+
+        f_kwargs(1, xx=1, y=2, **{'foo bar baz': 1})
+        f_kwargs2(1, xx=[1], y=[], **{'foo bar baz': ['1', 1]})
+
+        f_callable(lambda x, y: x + y)
+
+    def test_errors(self):
+        with self.assertRaises(TypeError):
+            f_simple1('1')
+        with self.assertRaises(TypeError):
+            f_simple2(1)
+        with self.assertRaises(TypeError):
+            f_simple2(None)
+        with self.assertRaises(TypeError):
+            f_float([])
+        with self.assertRaises(TypeError):
+            f_union(1.2)
+        with self.assertRaises(TypeError):
+            f_list({})
+        with self.assertRaises(TypeError):
+            f_list(tuple([1, 2, 3]))
+        with self.assertRaises(TypeError):
+            f_list_int(['1'])
+        with self.assertRaises(TypeError):
+            f_list_int(tuple([]))
+        with self.assertRaises(TypeError):
+            f_list_int(tuple([1]))
+        with self.assertRaises(TypeError):
+            f_sequence({})
+        with self.assertRaises(TypeError):
+            f_sequence(set([1, 2, 3]))
+        with self.assertRaises(TypeError):
+            f_sequence_float(['1'])
+        with self.assertRaises(TypeError):
+            f_sequence_float(set())
+        with self.assertRaises(TypeError):
+            f_sequence_float(tuple(['1']))
+        with self.assertRaises(TypeError):
+            f_set([])
+        with self.assertRaises(TypeError):
+            f_set(())
+        with self.assertRaises(TypeError):
+            f_set(frozenset())
+        with self.assertRaises(TypeError):
+            f_set_union({1, 1.5})
+        with self.assertRaises(TypeError):
+            f_frozenset(set())
+        with self.assertRaises(TypeError):
+            f_frozenset([])
+        with self.assertRaises(TypeError):
+            f_frozenset_int(set())
+        with self.assertRaises(TypeError):
+            f_frozenset_int(frozenset(['1']))
+        with self.assertRaises(TypeError):
+            f_collection(1)
+        with self.assertRaises(TypeError):
+            f_collection_str(1)
+        with self.assertRaises(TypeError):
+            f_tuple([])
+        with self.assertRaises(TypeError):
+            f_tuple2([])
+        with self.assertRaises(TypeError):
+            f_tuple_sized1(())
+        with self.assertRaises(TypeError):
+            f_tuple_sized1(tuple([1, 2]))
+        with self.assertRaises(TypeError):
+            f_tuple_sized1(tuple([1, 2, 3]))
+        with self.assertRaises(TypeError):
+            f_tuple_sized1(tuple(['1']))
+        with self.assertRaises(TypeError):
+            f_tuple_sized2(1, 1, 1.5)
+        with self.assertRaises(TypeError):
+            f_tuple_sized2(1, '1')
+        with self.assertRaises(TypeError):
+            f_tuple_sized2(1, '1', '1')
+        with self.assertRaises(TypeError):
+            f_dict([])
+        with self.assertRaises(TypeError):
+            f_dict(set())
+        with self.assertRaises(TypeError):
+            f_dict_str_int({1: 1})
+        with self.assertRaises(TypeError):
+            f_dict_str_int({'1': '1'})
+        with self.assertRaises(TypeError):
+            f_mapping([])
+        with self.assertRaises(TypeError):
+            f_mapping(set())
+        with self.assertRaises(TypeError):
+            f_mapping_str_int({1: 1})
+        with self.assertRaises(TypeError):
+            f_mapping_str_int({'1': '1'})
+        with self.assertRaises(TypeError):
+            f_varargs('1')
+        with self.assertRaises(TypeError):
+            f_varargs(1, 1)
+        with self.assertRaises(TypeError):
+            f_varargs2(1)
+        with self.assertRaises(TypeError):
+            f_varargs2('1', 1, '1')
+        with self.assertRaises(TypeError):
+            f_varargs3('1')
+        with self.assertRaises(TypeError):
+            f_varargs3(1, 1.5)
+        with self.assertRaises(TypeError):
+            f_kwargs('1')
+        with self.assertRaises(TypeError):
+            f_kwargs(y='s')
+        with self.assertRaises(TypeError):
+            f_kwargs(y=1, z=2, bad=1.5)
+        with self.assertRaises(TypeError):
+            f_kwargs2('1')
+        with self.assertRaises(TypeError):
+            f_kwargs2(1, x=[], y=[1.5])
+        with self.assertRaises(TypeError):
+            f_complicated([[{1, '1'}]], {'1': [1, None, '1']})
+        with self.assertRaises(TypeError):
+            f_callable(lambda x: x)
+        with self.assertRaises(TypeError):
+            f_callable(lambda x, y, z: x)
+        with self.assertRaises(TypeError):
+            def f(*xs):
+                pass
+            f_callable(f)
+        with self.assertRaises(TypeError):
+            def f(x, y, *, z=5):
+                pass
+            f_callable(f)
+        with self.assertRaises(TypeError):
+            def f(x, y, **kw):
+                pass
+            f_callable(f)

--- a/python/hail/typecheck2/__init__.py
+++ b/python/hail/typecheck2/__init__.py
@@ -1,0 +1,8 @@
+from .check import typecheck, register_conversion
+__all__ = ['typecheck',
+           'register_conversion']
+
+__doc__ = """
+Heavily inspired by typeguard: 
+    https://github.com/agronholm/typeguard/
+"""

--- a/python/hail/typecheck2/check.py
+++ b/python/hail/typecheck2/check.py
@@ -1,0 +1,316 @@
+import sys
+import inspect
+from typing import *
+import collections
+import itertools
+
+implicit_conversions: Dict[type, Set[type]] = {}
+
+warned_for: Set[type] = set()
+
+
+def qualified_name(t):
+    return qualified_type(type(t))
+
+
+def qualified_type(t):
+    module = t.__module__
+    if module == 'builtins':
+        return t.__name__
+    elif module == 'typing':
+        return str(t).replace('typing.', '')  # HACKY HACK
+    else:
+        return t.__qualname__
+
+
+class TypeCheckFailure(Exception):
+    __slots__ = ['msg']
+
+    def __init__(self, msg: str):
+        self.msg = msg
+
+
+def get_spec(f) -> inspect.FullArgSpec:
+    if hasattr(f, '__memo'):
+        return f.__memo
+    else:
+        signature = inspect.getfullargspec(f)
+        f.__memo = signature
+        return signature
+
+
+def typecheck(f: Callable):
+    """Typecheck a function's arguments against its type annotations.
+
+    Examples
+    --------
+    >>> def f(i: int, s: str) -> str:
+    ...     typecheck(f)
+    ...     return i * s
+
+    Notes
+    -----
+    Functions should call this function with themselves as an argument. This
+    is required to look up the function signature without hacking around in
+    the garbage collector and frames too deeply.
+
+    Not all types in :mod:`typing` are supported at this time.
+
+    Parameters
+    ----------
+    f
+        Function to check.
+
+    Raises
+    ------
+    TypeError
+    """
+    frame = inspect.currentframe().f_back
+    args = frame.f_locals
+    spec = get_spec(f)
+    for arg_name in itertools.chain(spec.args, spec.kwonlyargs):
+        t = spec.annotations.get(arg_name)
+        if t is not None:
+            check_t(args[arg_name], t, f"argument {repr(arg_name)} of {f.__qualname__}")
+    if spec.varargs:
+        t = spec.annotations.get(spec.varargs)
+        if t is not None:
+            varargs = args[spec.varargs]
+            assert isinstance(varargs, tuple)
+            for i, value in enumerate(varargs):
+                check_t(value, t, f"element {i} of argument {repr(spec.varargs)} of {f.__qualname__}")
+    if spec.varkw:
+        t = spec.annotations.get(spec.varkw)
+        if t is not None:
+            varkw = args[spec.varkw]
+            assert isinstance(varkw, collections.Mapping)
+            for name, value in varkw.items():
+                check_t(value, t, f"keyword argument {repr(name)} of {f.__qualname__}")
+
+
+def register_conversion(from_type: type, to_type: type) -> None:
+    """Register a recognized conversion from type to type.
+
+    Examples
+    --------
+    >>> register_conversion(int, float)
+
+    Notes
+    -----
+    The only self-initialized conversion is from int to float.
+
+    Parameters
+    ----------
+    from_type : type
+    to_type : type
+    """
+    if to_type not in implicit_conversions:
+        implicit_conversions[to_type] = {from_type}
+    else:
+        implicit_conversions[to_type].add(from_type)
+
+
+def check_union(arg, t, context: str) -> None:
+    cast(t, Union)
+    union_params = t.__args__
+
+    for t_ in union_params:
+        try:
+            _check_t(arg, t_, context)
+            return
+        except TypeCheckFailure:
+            pass
+
+    options = ', '.join(qualified_type(t_) for t_ in union_params)
+    raise TypeCheckFailure(f"expected ({options}); found '{qualified_name(arg)}' at {context}: {repr(arg)}")
+
+
+def _check_collection(arg: collections.Collection, element_type, context: str, indexed: bool) -> None:
+    if indexed:
+        for i, v in enumerate(arg):
+            _check_t(v, element_type, f'element {i} of {context}')
+    else:
+        for v in arg:
+            _check_t(v, element_type, f'element of {context}')
+
+
+def check_list(arg, t, context: str) -> None:
+    cast(t, List)
+    if not isinstance(arg, list):
+        raise TypeCheckFailure(f"expected 'list', found '{qualified_name(arg)}' at {context}: {repr(arg)}")
+
+    if t is List:
+        return
+    element_type = getattr(t, '__args__', t.__parameters__)[0]
+    _check_collection(arg, element_type, context, indexed=True)
+
+
+def check_sequence(arg, t, context: str) -> None:
+    cast(t, Sequence)
+    if not isinstance(arg, collections.Sequence):
+        raise TypeCheckFailure(f"expected 'Sequence', found '{qualified_name(arg)}' at {context}: {repr(arg)}")
+
+    if t is Sequence:
+        return
+    element_type = getattr(t, '__args__', t.__parameters__)[0]
+    _check_collection(arg, element_type, context, indexed=True)
+
+
+def check_set(arg, t, context: str) -> None:
+    cast(t, Set)
+    if not isinstance(arg, set):
+        raise TypeCheckFailure(f"expected 'set', found '{qualified_name(arg)}' at {context}: {repr(arg)}")
+
+    if t is Set:
+        return
+    element_type = getattr(t, '__args__', t.__parameters__)[0]
+    _check_collection(arg, element_type, context, indexed=False)
+
+
+def check_frozenset(arg, t, context: str) -> None:
+    cast(t, FrozenSet)
+    if not isinstance(arg, frozenset):
+        raise TypeCheckFailure(f"expected 'frozenset', found '{qualified_name(arg)}' at {context}: {repr(arg)}")
+
+    if t is FrozenSet:
+        return
+    element_type = getattr(t, '__args__', t.__parameters__)[0]
+    _check_collection(arg, element_type, context, indexed=False)
+
+
+def _check_mapping(arg: collections.Mapping, key_type, value_type, context: str) -> None:
+    for k, v in arg.items():
+        _check_t(k, key_type, f'key of {context}')
+        _check_t(v, value_type, f'value for key {repr(k)} of {context}')
+
+
+def check_dict(arg, t, context: str) -> None:
+    cast(t, Dict)
+    if not isinstance(arg, dict):
+        raise TypeCheckFailure(f"expected 'dict', found '{qualified_name(arg)}' at {context}: {repr(arg)}")
+
+    if t is Dict:
+        return
+    key_type, value_type = getattr(t, '__args__', t.__parameters__)
+    _check_mapping(arg, key_type, value_type, context)
+
+
+def check_mapping(arg, t, context: str) -> None:
+    cast(t, Mapping)
+    if not isinstance(arg, collections.Mapping):
+        raise TypeCheckFailure(f"expected 'Mapping', found '{qualified_name(arg)}' at {context}: {repr(arg)}")
+
+    if t is Mapping:
+        return
+    key_type, value_type = getattr(t, '__args__', t.__parameters__)
+    _check_mapping(arg, key_type, value_type, context)
+
+
+def check_tuple(arg, t, context: str) -> None:
+    cast(t, Tuple)
+    if not isinstance(arg, tuple):
+        raise TypeCheckFailure(f"expected 'tuple', found '{qualified_name(arg)}' at {context}: {repr(arg)}")
+
+    if t is Tuple:
+        return
+    types = t.__args__
+    if types[-1] is Ellipsis:
+        # variable-length tuple
+        element_type = types[0]
+        _check_collection(arg, element_type, context, indexed=True)
+    else:
+        if len(arg) != len(types):
+            types_str = ', '.join(map(qualified_type, types))
+            raise TypeCheckFailure(f"expected tuple with {len(types)} elements of types {types_str}, "
+                                   f"found {len(arg)} elements at {context}")
+        for i, element in enumerate(arg):
+            _check_t(element, types[i], f"element{i} of {context}")
+
+
+def check_callable(arg, t, context: str) -> None:
+    cast(t, Callable)
+    if not callable(arg):
+        raise TypeCheckFailure(f'expected callable {qualified_type(t)}, found not callable at {context}')
+    if t is Callable:
+        return
+
+    if isinstance(t.__args__, tuple):
+        argument_types = t.__args__[:-1]
+        check_args = argument_types != (Ellipsis,)
+
+        if check_args:
+            signature = inspect.signature(arg)
+
+            parameter_types = list(p.kind for p in signature.parameters.values())
+            if any(kind == inspect.Parameter.KEYWORD_ONLY for kind in parameter_types):
+                raise TypeCheckFailure(f"found keyword-only arguments on callable signature at {context}")
+            elif any(kind == inspect.Parameter.VAR_POSITIONAL for kind in parameter_types):
+                raise TypeCheckFailure(f"found variable-length args on callable signature at {context}")
+            elif any(kind == inspect.Parameter.VAR_KEYWORD for kind in parameter_types):
+                raise TypeCheckFailure(f"found variable keyword arguments on callable signature at {context}")
+            elif len(parameter_types) != len(argument_types):
+                raise TypeCheckFailure(f"expected {len(argument_types)}-parameter callable, "
+                                       f"found {len(parameter_types)}-parameter callable at {context}")
+
+
+def check_collection(arg, t, context: str) -> None:
+    if not isinstance(arg, collections.Collection):
+        raise TypeCheckFailure(f"expected 'Collection', found '{qualified_name(arg)}' at {context}: {repr(arg)}")
+    if t is Collection:
+        return
+    else:
+        # can't type check the iterator currently
+        return
+
+
+def check_t(arg, t, context: str) -> None:
+    # the following motif is used to squelch the original (deeply recursive)
+    # stack trace
+    _e: TypeCheckFailure = None
+    try:
+        _check_t(arg, t, context)
+    except TypeCheckFailure as e:
+        _e = e
+    finally:
+        if _e:
+            raise TypeError(_e.msg)
+
+
+known_checkers = {
+    Union: check_union,
+    Dict: check_dict,
+    Mapping: check_mapping,
+    Sequence: check_sequence,
+    Set: check_set,
+    FrozenSet: check_frozenset,
+    List: check_list,
+    Tuple: check_tuple,
+    Collection: check_collection,
+    Callable: check_callable
+}
+
+
+def _check_t(arg, t, context: str) -> None:
+    if t is Any:
+        return
+
+    # typing.Type subtypes have the '__origin__' attribute set
+    typing_type = getattr(t, '__origin__', None)
+    if typing_type is not None:
+        f = known_checkers.get(typing_type)
+        if f:
+            f(arg, t, context)
+        else:
+            if typing_type not in warned_for:
+                sys.stderr.write(f"WARN: typecheck: type '{typing_type}' is not currently supported\n")
+                warned_for.add(typing_type)
+    else:
+        assert isinstance(t, type)
+        if not isinstance(arg, t):
+            if t not in implicit_conversions or all(
+                    not isinstance(arg, compatible_type) for compatible_type in implicit_conversions[t]):
+                raise TypeCheckFailure(f"expected type '{qualified_type(t)}', "
+                                       f"found '{qualified_type(type(arg))}' at {context}: {repr(arg)}")
+
+
+register_conversion(int, float)

--- a/python/hail/typecheck2/check.py
+++ b/python/hail/typecheck2/check.py
@@ -260,8 +260,7 @@ def check_collection(arg, t, context: str) -> None:
     if t is Collection:
         return
     else:
-        # can't type check the iterator currently
-        return
+        return _check_collection(arg, t.__args__[0], context, indexed=False)
 
 
 def check_t(arg, t, context: str) -> None:


### PR DESCRIPTION
(This wasn't a random assignment, so feel free to remove yourself and I'll assign someone else)

I've implemented a type checker that uses type annotations and a minor amount of frame hacking to check type signatures.

The register_conversion mechanic can be used to do the following:
```
register_conversion(Int32Expression, Int64Expression)
```
and so on. I'm leaning towards that rather than fully documenting an Int64ExpressionType which is `Union[Int32ExpressionType, Int64Expression]` where `Int32ExpressionType = Union[int, Int32Expression]`.

Happy to do either, though!