### PR TITLE
GridPartitioner functions for overlapping blocks

### DIFF
--- a/src/main/scala/is/hail/linalg/GridPartitioner.scala
+++ b/src/main/scala/is/hail/linalg/GridPartitioner.scala
@@ -1,6 +1,5 @@
 package is.hail.linalg
 
-import is.hail.utils.ArrayBuilder
 import org.apache.spark.Partitioner
 
 case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long) extends Partitioner {

--- a/src/main/scala/is/hail/linalg/GridPartitioner.scala
+++ b/src/main/scala/is/hail/linalg/GridPartitioner.scala
@@ -1,5 +1,6 @@
 package is.hail.linalg
 
+import is.hail.utils.ArrayBuilder
 import org.apache.spark.Partitioner
 
 case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long) extends Partitioner {
@@ -39,4 +40,81 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long) extends Par
   }
   
   def transpose: GridPartitioner = GridPartitioner(this.blockSize, this.nCols, this.nRows)
+  
+  // returns all blocks intersecting the diagonal band consisting of all entries
+  //   with -lowerBandwidth <= (colIndex - rowIndex) <= upperBandwidth
+  def bandedBlocks(lowerBandwidth: Long, upperBandwidth: Long): Array[Int] = {
+    require(lowerBandwidth >= 0 && upperBandwidth >= 0)
+    
+    val lowerBlockBandwidth = blockIndex(lowerBandwidth + blockSize - 1)
+    val upperBlockBandwidth = blockIndex(upperBandwidth + blockSize - 1)
+
+    val blocks = new ArrayBuilder[Int]
+    
+    var j = 0
+    while (j < nBlockCols) {
+      val offset = j * nBlockRows
+      var i = (j - upperBlockBandwidth) max 0
+      while (i <= ((j + lowerBlockBandwidth) min (nBlockRows - 1))) {
+        blocks += offset + i
+        i += 1
+      }
+      j += 1
+    }
+    
+    blocks.result()
+  }
+  
+  // returns all blocks intersecting the rectangle [firstRow, lastRow] x [firstCol, lastCol]
+  def rectangularBlocks(firstRow: Long, lastRow: Long, firstCol: Long, lastCol: Long): Array[Int] = {
+    require(firstRow >= 0 && firstRow <= lastRow && lastRow <= nRows)
+    require(firstCol >= 0 && firstCol <= lastCol && lastCol <= nCols)
+    
+    val firstBlockRow = blockIndex(firstRow)
+    val lastBlockRow = blockIndex(lastRow)
+    val firstBlockCol = blockIndex(firstCol)
+    val lastBlockCol = blockIndex(lastCol)
+
+    val blocks = new Array[Int]((lastBlockRow - firstBlockRow + 1) * (lastBlockCol - firstBlockCol + 1))
+    
+    var k = 0
+    var j = firstBlockCol
+    while (j <= lastBlockCol) {
+      val offset = j * nBlockRows
+      var i = firstBlockRow
+      while (i <= lastBlockRow) {
+        blocks(k) = offset + i
+        k += 1
+        i += 1
+      }
+      j += 1
+    }
+    
+    blocks
+  }
+
+  // returns all blocks intersecting the union of rectangles
+  def rectangularBlocks(rectangles: Array[Array[Long]]): Array[Int] = {
+    val keep = new Array[Boolean](numPartitions)
+    
+    rectangles.foreach { r =>
+      assert(r.length == 4)
+      val rBlocks = rectangularBlocks(r(0), r(1), r(2), r(3))
+      var i = 0
+      while (i < rBlocks.length) {
+        keep(rBlocks(i)) = true
+        i += 1
+      }
+    }
+    
+    val blocks = new ArrayBuilder[Int]()
+    var block = 0
+    while (block < numPartitions) {
+      if (keep(block))
+        blocks += block
+      block += 1
+    }
+    
+    blocks.result()
+  }
 }

--- a/src/test/scala/is/hail/linalg/GridPartitionerSuite.scala
+++ b/src/test/scala/is/hail/linalg/GridPartitionerSuite.scala
@@ -2,7 +2,6 @@ package is.hail.linalg
 
 import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.Test
-import is.hail.utils._
 
 class GridPartitionerSuite extends TestNGSuite {
 

--- a/src/test/scala/is/hail/linalg/GridPartitionerSuite.scala
+++ b/src/test/scala/is/hail/linalg/GridPartitionerSuite.scala
@@ -2,6 +2,7 @@ package is.hail.linalg
 
 import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.Test
+import is.hail.utils._
 
 class GridPartitionerSuite extends TestNGSuite {
 
@@ -100,7 +101,7 @@ class GridPartitionerSuite extends TestNGSuite {
       assert(gp.rectangularBlocks(Array(
         Array(9, 10, 9, 10), Array(10, 19, 10, 29), Array(0, 0, 20, 20), Array(20, 20, 20, 30)))
         sameElements Array(0, 1, 3, 4, 6, 7, 8, 11))
-      
+
       assert(gp.rectangularBlocks(0, 20, 0, 30) sameElements (0 until 12))
     }
   }

--- a/src/test/scala/is/hail/linalg/GridPartitionerSuite.scala
+++ b/src/test/scala/is/hail/linalg/GridPartitionerSuite.scala
@@ -47,4 +47,61 @@ class GridPartitionerSuite extends TestNGSuite {
       (1, 2) -> 5
     )
   }
+
+  @Test
+  def bandedBlocksTest() {
+    // 0  3  6  9
+    // 1  4  7 10
+    // 2  5  8 11
+    val gp1 = GridPartitioner(10, 30, 40)
+    val gp2 = GridPartitioner(10, 21, 31)
+
+    for (gp <- Seq(gp1, gp2)) {
+      assert(gp.bandedBlocks(0, 0) sameElements Array(0, 4, 8))
+
+      assert(gp.bandedBlocks(1, 0) sameElements Array(0, 1, 4, 5, 8))
+      assert(gp.bandedBlocks(1, 0) sameElements gp.bandedBlocks(10, 0))
+
+      assert(gp.bandedBlocks(0, 1) sameElements Array(0, 3, 4, 7, 8, 11))
+      assert(gp.bandedBlocks(0, 1) sameElements gp.bandedBlocks(0, 10))
+
+      assert(gp.bandedBlocks(1, 1) sameElements Array(0, 1, 3, 4, 5, 7, 8, 11))
+      assert(gp.bandedBlocks(1, 1) sameElements gp.bandedBlocks(10, 10))
+
+      assert(gp.bandedBlocks(11, 0) sameElements Array(0, 1, 2, 4, 5, 8))
+
+      assert(gp.bandedBlocks(0, 11) sameElements Array(0, 3, 4, 6, 7, 8, 10, 11))
+      assert(gp.bandedBlocks(0, 20) sameElements gp.bandedBlocks(0, 11))
+      assert(gp.bandedBlocks(0, 21) sameElements Array(0, 3, 4, 6, 7, 8, 9, 10, 11))
+
+      assert(gp.bandedBlocks(1000, 1000) sameElements (0 until 12))
+    }
+  }
+  
+  @Test
+  def rectangularBlocksTest() {
+    // 0  3  6  9
+    // 1  4  7 10
+    // 2  5  8 11
+    val gp1 = GridPartitioner(10, 30, 40)
+    val gp2 = GridPartitioner(10, 21, 31)
+
+    for (gp <- Seq(gp1, gp2)) {
+      assert(gp.rectangularBlocks(0, 0, 0, 0) sameElements Array(0))
+      assert(gp.rectangularBlocks(Array(Array(0, 0, 0, 0))) sameElements Array(0))
+
+      assert(gp.rectangularBlocks(0, 9, 0, 9) sameElements Array(0))
+
+      assert(gp.rectangularBlocks(9, 10, 9, 10) sameElements Array(0, 1, 3, 4))
+      assert(gp.rectangularBlocks(Array(Array(9, 10, 9, 10))) sameElements Array(0, 1, 3, 4))
+      
+      assert(gp.rectangularBlocks(10, 19, 10, 29) sameElements Array(4, 7))
+
+      assert(gp.rectangularBlocks(Array(
+        Array(9, 10, 9, 10), Array(10, 19, 10, 29), Array(0, 0, 20, 20), Array(20, 20, 20, 30)))
+        sameElements Array(0, 1, 3, 4, 6, 7, 8, 11))
+      
+      assert(gp.rectangularBlocks(0, 20, 0, 30) sameElements (0 until 12))
+    }
+  }
 }


### PR DESCRIPTION
I'm keeping my LD extension branch separate until we add a proper sparse block matrix implementation, but I pulled out these functions on GridPartitioner since (i) they're some of the logic we'll need to make sparse block matrix useful and (ii) Meredith just built a step to compute variant windows in LDPrune, which can then be combined with this logic as part of her optimization strategy to not compute unneeded blocks.