### PR TITLE
Resolves a performance problem with _to_table that caused a re-scan

### DIFF
--- a/python/hail/expr/expressions/base_expression.py
+++ b/python/hail/expr/expressions/base_expression.py
@@ -648,12 +648,25 @@ class Expression(object):
             else:
                 assert isinstance(source, hail.MatrixTable)
                 if self._indices == source._row_indices:
-                    source = source.select_rows(*filter(lambda x: x != name, source.row_key), **{name: self})
-                    return source.rows().select_globals()
+                    if self in source._fields_inverse:
+                        assert source[name] is self
+                        if name in source.row_key:
+                            m = source.select_rows(*source.row_key)
+                        else:
+                            m = source.select_rows(*source.row_key, name)
+                    else:
+                        m = source.select_rows(*source.row_key, **{name: self})
+                    return m.rows().select_globals()
                 else:
-                    assert self._indices == source._col_indices
-                    source = source.select_cols(*filter(lambda f: f != name, source.col_key), **{name: self})
-                    return source.cols().select_globals()
+                    if self in source._fields_inverse:
+                        assert source[name] is self
+                        if name in source.col_key:
+                            m = source.select_cols(*source.col_key)
+                        else:
+                            return source.select_cols(*source.col_key, name)
+                    else:
+                        return source.select_cols(*source.col_key, **{name: self})
+                    return m.cols().select_globals()
         else:
             assert len(axes) == 2
             assert isinstance(source, hail.MatrixTable)

--- a/python/hail/expr/expressions/base_expression.py
+++ b/python/hail/expr/expressions/base_expression.py
@@ -648,22 +648,24 @@ class Expression(object):
             else:
                 assert isinstance(source, hail.MatrixTable)
                 if self._indices == source._row_indices:
-                    if self in source._fields_inverse:
-                        assert source[name] is self
-                        if name in source.row_key:
+                    field_name = source._fields_inverse.get(self)
+                    if field_name is not None:
+                        if field_name in source.row_key:
                             m = source.select_rows(*source.row_key)
                         else:
-                            m = source.select_rows(*source.row_key, name)
+                            m = source.select_rows(*source.row_key, field_name)
+                        m = m.rename({field_name: name})
                     else:
                         m = source.select_rows(*source.row_key, **{name: self})
                     return m.rows().select_globals()
                 else:
-                    if self in source._fields_inverse:
-                        assert source[name] is self
-                        if name in source.col_key:
+                    field_name = source._fields_inverse.get(self)
+                    if field_name is not None:
+                        if field_name in source.col_key:
                             m = source.select_cols(*source.col_key)
                         else:
-                            return source.select_cols(*source.col_key, name)
+                            m = source.select_cols(*source.col_key, field_name)
+                        m = m.rename({field_name: name})
                     else:
                         return source.select_cols(*source.col_key, **{name: self})
                     return m.cols().select_globals()

--- a/python/hail/expr/expressions/base_expression.py
+++ b/python/hail/expr/expressions/base_expression.py
@@ -667,7 +667,7 @@ class Expression(object):
                             m = source.select_cols(*source.col_key, field_name)
                         m = m.rename({field_name: name})
                     else:
-                        return source.select_cols(*source.col_key, **{name: self})
+                        m = source.select_cols(*source.col_key, **{name: self})
                     return m.cols().select_globals()
         else:
             assert len(axes) == 2

--- a/python/hail/tests/test_api.py
+++ b/python/hail/tests/test_api.py
@@ -876,15 +876,14 @@ class MatrixTests(unittest.TestCase):
     def test_to_table_on_various_fields(self):
         mt = self.get_vds()
 
-        mt.row.take(1)
-        mt.row_key.take(1)
-        mt['locus'].take(1)
-        mt['s'].take(1)
-        mt.annotate_cols(foo=5).foo.take(1)
-        mt.GQ.take(1)
-
-        mt.locus.contig.take(1)
-        mt.s[0].take(1)
+        self.assertEqual(mt.row.take(1), mt.rows().take(1))
+        self.assertEqual(mt.row_key.take(1), mt.rows().select(*mt.row_key).take(1))
+        self.assertEqual(mt['locus'].take(1), [mt.rows().select('locus').take(1)[0].locus])
+        self.assertEqual(mt['s'].take(1), [mt.cols().select('s').take(1)[0].s])
+        self.assertEqual(mt.annotate_cols(foo=5).foo.take(1), [5])
+        self.assertEqual(mt.GQ.take(1), [mt.entries().select('GQ').take(1)[0]['GQ']])
+        self.assertEqual(mt.locus.contig.take(1), [mt.rows().select('locus').take(1)[0].locus.contig])
+        self.assertEqual(mt['s'][0].take(1), [mt.cols().select('s').take(1)[0].s[0]])
 
 
 

--- a/python/hail/tests/test_api.py
+++ b/python/hail/tests/test_api.py
@@ -883,6 +883,9 @@ class MatrixTests(unittest.TestCase):
         mt.annotate_cols(foo=5).foo.take(1)
         mt.GQ.take(1)
 
+        mt.locus.contig.take(1)
+        mt.s[0].take(1)
+
 
 
 class GroupedMatrixTests(unittest.TestCase):

--- a/python/hail/tests/test_api.py
+++ b/python/hail/tests/test_api.py
@@ -873,6 +873,17 @@ class MatrixTests(unittest.TestCase):
         entries = ds.entries()
         self.assertTrue(entries.all((entries.col_idx * entries.row_idx) % 4 == 0))
 
+    def test_to_table_on_various_fields(self):
+        mt = self.get_vds()
+
+        mt.row.take(1)
+        mt.row_key.take(1)
+        mt['locus'].take(1)
+        mt['s'].take(1)
+        mt.annotate_cols(foo=5).foo.take(1)
+        mt.GQ.take(1)
+
+
 
 class GroupedMatrixTests(unittest.TestCase):
 


### PR DESCRIPTION
of the entire MatrixTable if the field is a row key.