### PR TITLE
Make OrderedRVDPartitioner non-serializable

### DIFF
--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -1291,8 +1291,10 @@ def import_plink(bed, bim, fam,
     return MatrixTable(jmt)
 
 
-@typecheck(path=oneof(str, listof(str)))
-def read_matrix_table(path):
+@typecheck(path=oneof(str, listof(str)),
+           _drop_cols=bool,
+           _drop_rows=bool)
+def read_matrix_table(path, _drop_cols=False, _drop_rows=False):
     """Read in a :class:`.MatrixTable` written with written with :meth:`.MatrixTable.write`
 
     Parameters
@@ -1304,7 +1306,7 @@ def read_matrix_table(path):
     -------
     :class:`.MatrixTable`
     """
-    return MatrixTable(Env.hc()._jhc.read(path, False, False))
+    return MatrixTable(Env.hc()._jhc.read(path, _drop_cols, _drop_rows))
 
 
 @typecheck(path=str)

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -532,6 +532,8 @@ object OrderedRVD {
   }
 
   def calculateKeyRanges(typ: OrderedRVDType, pkis: Array[OrderedRVPartitionInfo], nPartitions: Int): UnsafeIndexedSeq = {
+    assert(nPartitions > 0)
+
     val pkOrd = typ.pkOrd
     var keys = pkis
       .flatMap(_.samples)
@@ -540,27 +542,24 @@ object OrderedRVD {
     val min = pkis.map(_.min).min(pkOrd)
     val max = pkis.map(_.max).max(pkOrd)
 
-    keys = min +: keys :+ max
-
     val ab = new ArrayBuilder[RegionValue]()
-    var i = 0
-    while (i < keys.length) {
-      if (i == 0
-        || pkOrd.compare(keys(i - 1), keys(i)) != 0)
-        ab += keys(i)
+    ab += min
+    var i = 1
+    var start = 0
+    while (i < nPartitions && start < keys.length) {
+      var end = ((i.toDouble * keys.length) / nPartitions).toInt
+      if (start > end)
+        start = end
+      while (end < keys.length - 1
+        && pkOrd.compare(keys(end), keys(end + 1)) == 0)
+        end += 1
+      ab += keys(end)
+      start = end + 1
       i += 1
     }
-    keys = ab.result()
-
-    // FIXME weighted
-    val partitionMaxes =
-      if (keys.length <= nPartitions + 1)
-        keys
-      else {
-        val k = keys.length / nPartitions
-        assert(k > 0)
-        Array.tabulate(nPartitions)(i => keys(i * k)) :+ max
-      }
+    ab += max
+    val partitionMaxes = ab.result()
+    assert(partitionMaxes.length <= nPartitions + 1)
 
     OrderedRVDPartitioner.makeRangeBoundIntervals(typ.pkType, partitionMaxes)
   }
@@ -592,7 +591,6 @@ object OrderedRVD {
       partitioner.kType, UnsafeIndexedSeq(partitioner.rangeBoundsType, newRangeBounds))
 
     shuffle(typ, newPartitioner, rdd)
-
   }
 
   def shuffle(typ: OrderedRVDType,
@@ -602,10 +600,12 @@ object OrderedRVD {
       partitioner,
       new ShuffledRDD[RegionValue, RegionValue, RegionValue](
         rdd.mapPartitions { it =>
+          val wrv = WritableRegionValue(typ.rowType)
           val wkrv = WritableRegionValue(typ.kType)
           it.map { rv =>
+            wrv.set(rv)
             wkrv.setSelect(typ.rowType, typ.kRowFieldIdx, rv)
-            (wkrv.value, rv)
+            (wkrv.value, wrv.value)
           }
         },
         partitioner)

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -552,7 +552,7 @@ object OrderedRVD {
     while (i < nPartitions && start < keys.length) {
       var end = ((i.toDouble * keys.length) / nPartitions).toInt
       if (start > end)
-        start = end
+        end = start
       while (end < keys.length - 1
         && pkOrd.compare(keys(end), keys(end + 1)) == 0)
         end += 1

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -544,8 +544,11 @@ object OrderedRVD {
 
     val ab = new ArrayBuilder[RegionValue]()
     ab += min
-    var i = 1
     var start = 0
+    while (start < keys.length
+      && pkOrd.compare(min, keys(start)) == 0)
+      start += 1
+    var i = 1
     while (i < nPartitions && start < keys.length) {
       var end = ((i.toDouble * keys.length) / nPartitions).toInt
       if (start > end)
@@ -557,7 +560,8 @@ object OrderedRVD {
       start = end + 1
       i += 1
     }
-    ab += max
+    if (pkOrd.compare(ab.last, max) != 0)
+      ab += max
     val partitionMaxes = ab.result()
     assert(partitionMaxes.length <= nPartitions + 1)
 

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -562,10 +562,10 @@ object OrderedRVD {
     }
     if (pkOrd.compare(ab.last, max) != 0)
       ab += max
-    val partitionMaxes = ab.result()
-    assert(partitionMaxes.length <= nPartitions + 1)
+    val partitionEdges = ab.result()
+    assert(partitionEdges.length <= nPartitions + 1)
 
-    OrderedRVDPartitioner.makeRangeBoundIntervals(typ.pkType, partitionMaxes)
+    OrderedRVDPartitioner.makeRangeBoundIntervals(typ.pkType, partitionEdges)
   }
 
   def adjustBoundsAndShuffle(typ: OrderedRVDType,

--- a/src/main/scala/is/hail/utils/ArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/ArrayBuilder.scala
@@ -65,4 +65,9 @@ final class ArrayBuilder[@specialized T](initialCapacity: Int)(implicit tct: Cla
   }
 
   def underlying(): Array[T] = b
+
+  def last: T = {
+    assert(size_ > 0)
+    b(size_ - 1)
+  }
 }


### PR DESCRIPTION
This builds on: https://github.com/hail-is/hail/pull/3107

We were getting absolutely murdered by serializing the partitioner on every task.  I made OrderedRVDPartitioner not inherit from Spark Partitioner, non-serializable, and modified it to be broadcasted where needed.

There is a good chance this will speed up OrderedRVD shuffles as well, but I haven't timed.

Timing:

```
import hail as hl

mt = hl.read_matrix_table('gnomad.exomes.vds', _drop_cols=True)
mt = mt._filter_partitions(list(range(1000)))
mt._force_count_rows()
```

master: 1m15s
no_ser_ord_part: 9s

That's about 8x improvement.  This includes startup time so it's actually much better.
