### PR TITLE
moved numeric conversions to python

### DIFF
--- a/python/hail/expr/aggregators.py
+++ b/python/hail/expr/aggregators.py
@@ -586,6 +586,7 @@ def stats(expr):
     agg = _to_agg(expr)
     if not is_numeric(agg._type):
         raise TypeError("'stats' expects a numeric argument, found '{}'".format(agg._type))
+    agg = Expression._promote_numeric(agg, tfloat64)
     return _agg_func('stats', agg, tstruct(mean=tfloat64,
                                            stdev=tfloat64,
                                            min=tfloat64,
@@ -1004,7 +1005,7 @@ def call_stats(expr, alleles):
     return construct_expr(ast, t, Indices(source=indices.source),
                           aggregations.push(Aggregation(agg, alleles)), joins)
 
-@typecheck(expr=oneof(Aggregable, expr_numeric), start=numeric, end=numeric, bins=numeric)
+@typecheck(expr=oneof(Aggregable, expr_numeric), start=expr_float64, end=expr_float64, bins=expr_int32)
 def hist(expr, start, end, bins):
     """Compute binned counts of a numeric expression.
 
@@ -1053,8 +1054,9 @@ def hist(expr, start, end, bins):
     agg = _to_agg(expr)
     if not is_numeric(agg._type):
         raise TypeError("'hist' expects argument 'expr' to be a numeric type, found '{}'".format(agg._type))
+    agg = Expression._promote_numeric(agg, tfloat64)
     t = tstruct(bin_edges=tarray(tfloat64),
                 bin_freq=tarray(tint64),
-                nLess=tint64,
+                n_less=tint64,
                 n_larger=tint64)
     return _agg_func('hist', agg, t, start, end, bins)

--- a/python/hail/expr/aggregators.py
+++ b/python/hail/expr/aggregators.py
@@ -630,6 +630,7 @@ def product(expr):
     agg = _to_agg(expr)
     if not is_numeric(agg._type):
         raise TypeError("'product' expects a numeric argument, found '{}'".format(agg._type))
+    agg = Expression._promote_numeric(agg, tfloat64)
     return _agg_func('product', agg, agg._type)
 
 @typecheck(predicate=oneof(Aggregable, expr_bool))

--- a/python/hail/expr/expressions/base_expression.py
+++ b/python/hail/expr/expressions/base_expression.py
@@ -417,6 +417,12 @@ class Expression(object):
                 expr = hail.map(lambda x: promote_scalar(x, typ.element_type), expr)
             else:
                 expr = promote_scalar(expr, typ.element_type)
+        elif isinstance(expr, expressions.Aggregable):
+            uid = Env._get_uid()
+            ref = expressions.construct_expr(Reference(uid), expr._type, expr._indices, expr._aggregations, expr._joins, expr._refs)
+            promoted = promote_scalar(ref, typ)
+            ast = LambdaClassMethod('map', uid, expr._ast, promoted._ast)
+            expr = expressions.Aggregable(ast, promoted.dtype, expr._indices, expr._aggregations, expr._joins, expr._refs)
         else:
             expr = promote_scalar(expr, typ)
         return expr

--- a/python/hail/expr/expressions/base_expression.py
+++ b/python/hail/expr/expressions/base_expression.py
@@ -419,10 +419,10 @@ class Expression(object):
                 expr = promote_scalar(expr, typ.element_type)
         elif isinstance(expr, expressions.Aggregable):
             uid = Env.get_uid()
-            ref = expressions.construct_expr(Reference(uid), expr._type, expr._indices, expr._aggregations, expr._joins, expr._refs)
+            ref = expressions.construct_expr(TopLevelReference(uid, expr._indices), expr._type, expr._indices, expr._aggregations, expr._joins)
             promoted = promote_scalar(ref, typ)
             ast = LambdaClassMethod('map', uid, expr._ast, promoted._ast)
-            expr = expressions.Aggregable(ast, promoted.dtype, expr._indices, expr._aggregations, expr._joins, expr._refs)
+            expr = expressions.Aggregable(ast, promoted.dtype, expr._indices, expr._aggregations, expr._joins)
         else:
             expr = promote_scalar(expr, typ)
         return expr

--- a/python/hail/expr/expressions/base_expression.py
+++ b/python/hail/expr/expressions/base_expression.py
@@ -418,7 +418,7 @@ class Expression(object):
             else:
                 expr = promote_scalar(expr, typ.element_type)
         elif isinstance(expr, expressions.Aggregable):
-            uid = Env._get_uid()
+            uid = Env.get_uid()
             ref = expressions.construct_expr(Reference(uid), expr._type, expr._indices, expr._aggregations, expr._joins, expr._refs)
             promoted = promote_scalar(ref, typ)
             ast = LambdaClassMethod('map', uid, expr._ast, promoted._ast)

--- a/python/hail/expr/expressions/expression_typecheck.py
+++ b/python/hail/expr/expressions/expression_typecheck.py
@@ -132,10 +132,8 @@ class Float64Checker(ExpressionTypechecker):
         return dtype == hl.tfloat64
 
     def cast_from(self, dtype: HailType) -> Callable[[Expression], Expression]:
-        if dtype == hl.tint32 or dtype == hl.tint64 or dtype == hl.tfloat64 or dtype == hl.tbool:
-            return hl.float64
-        else:
-            raise AssertionError
+        assert dtype == hl.tbool or dtype == hl.tint32 or dtype == hl.tint64 or dtype == hl.tfloat32
+        return hl.float64
 
 
 class BoolChecker(ExpressionTypechecker):

--- a/python/hail/expr/functions.py
+++ b/python/hail/expr/functions.py
@@ -2589,7 +2589,7 @@ def max(*exprs: Union[CollectionExpression, Num_T]) -> Num_T:
                             "  Found {} arguments with types '{}'".format(builtins.len(exprs), ', '.join(
                 "'{}'".format(e.dtype) for e in exprs)))
         ret_t = unify_types(*(e.dtype for e in exprs))
-        exprs = tuple(e._promote_numeric(e, ret_t) for e in exprs)
+        exprs = tuple(e._promote_numeric(ret_t) for e in exprs)
         if builtins.len(exprs) == 2:
             return exprs[0]._method('max', ret_t, exprs[1])
         else:
@@ -2643,7 +2643,7 @@ def min(*exprs: Union[CollectionExpression, Num_T]) -> Num_T:
                             "  Found {} arguments with types '{}'".format(builtins.len(exprs), ', '.join(
                 "'{}'".format(e.dtype) for e in exprs)))
         ret_t = unify_types(*(e.dtype for e in exprs))
-        exprs = tuple(e._promote_numeric(e, ret_t) for e in exprs)
+        exprs = tuple(e._promote_numeric(ret_t) for e in exprs)
         if builtins.len(exprs) == 2:
             return exprs[0]._method('min', ret_t, exprs[1])
         else:

--- a/python/hail/expr/functions.py
+++ b/python/hail/expr/functions.py
@@ -453,7 +453,7 @@ def dict(collection: Union[Mapping, DictExpression, SetExpression, ArrayExpressi
         return collection
 
 
-@typecheck(x=expr_numeric, a=expr_numeric, b=expr_numeric)
+@typecheck(x=expr_float64, a=expr_float64, b=expr_float64)
 def dbeta(x: Float64Expression, a: Float64Expression, b: Float64Expression) -> Float64Expression:
     """
     Returns the probability density at `x` of a `beta distribution
@@ -482,7 +482,7 @@ def dbeta(x: Float64Expression, a: Float64Expression, b: Float64Expression) -> F
     return _func("dbeta", tfloat64, x, a, b)
 
 
-@typecheck(x=expr_numeric, lamb=expr_numeric, log_p=expr_bool)
+@typecheck(x=expr_float64, lamb=expr_float64, log_p=expr_bool)
 def dpois(x: Float64Expression, lamb: Float64Expression, log_p: BooleanExpression = False) -> Float64Expression:
     """Compute the (log) probability density at x of a Poisson distribution with rate parameter `lamb`.
 
@@ -510,7 +510,7 @@ def dpois(x: Float64Expression, lamb: Float64Expression, log_p: BooleanExpressio
     return _func("dpois", tfloat64, x, lamb, log_p)
 
 
-@typecheck(x=expr_numeric)
+@typecheck(x=expr_float64)
 def exp(x: Float64Expression) -> Float64Expression:
     """Computes `e` raised to the power `x`.
 
@@ -585,7 +585,7 @@ def fisher_exact_test(c1: Int32Expression,
     return _func("fet", ret_type, c1, c2, c3, c4)
 
 
-@typecheck(x=expr_numeric)
+@typecheck(x=oneof(expr_float32, expr_float64))
 def floor(x: NumericExpression) -> NumericExpression:
     """The largest integral value that is less than or equal to `x`.
 
@@ -600,10 +600,10 @@ def floor(x: NumericExpression) -> NumericExpression:
     -------
     :obj:`.Float64Expression`
     """
-    return _func("floor", unify_types(x.dtype, tfloat32), x)
+    return _func("floor", x.dtype, x)
 
 
-@typecheck(x=expr_numeric)
+@typecheck(x=oneof(expr_float32, expr_float64))
 def ceil(x: NumericExpression) -> NumericExpression:
     """The smallest integral value that is greater than or equal to `x`.
 
@@ -618,7 +618,7 @@ def ceil(x: NumericExpression) -> NumericExpression:
     -------
     :obj:`.Float64Expression`
     """
-    return _func("ceil", unify_types(x.dtype, tfloat32), x)
+    return _func("ceil", x.dtype, x)
 
 
 @typecheck(n_hom_ref=expr_int32, n_het=expr_int32, n_hom_var=expr_int32)
@@ -1154,7 +1154,7 @@ def is_missing(expression: Expression) -> BooleanExpression:
     return _func("isMissing", tbool, expression)
 
 
-@typecheck(x=expr_numeric)
+@typecheck(x=oneof(expr_float32, expr_float64))
 def is_nan(x: NumericExpression) -> BooleanExpression:
     """Returns ``True`` if the argument is ``NaN`` (not a number).
 
@@ -1217,7 +1217,7 @@ def json(x: Expression) -> StringExpression:
     return _func("json", tstr, x)
 
 
-@typecheck(x=expr_numeric, base=nullable(expr_numeric))
+@typecheck(x=expr_float64, base=nullable(expr_float64))
 def log(x: Float64Expression, base: Optional[Float64Expression] = None) -> Float64Expression:
     """Take the logarithm of the `x` with base `base`.
 
@@ -1254,7 +1254,7 @@ def log(x: Float64Expression, base: Optional[Float64Expression] = None) -> Float
         return _func("log", tfloat64, x)
 
 
-@typecheck(x=expr_numeric)
+@typecheck(x=expr_float64)
 def log10(x: Float64Expression) -> Float64Expression:
     """Take the logarithm of the `x` with base 10.
 
@@ -1338,7 +1338,7 @@ def or_missing(predicate: BooleanExpression, value: Expression):
     return _func("orMissing", value._type, predicate, value)
 
 
-@typecheck(x=expr_int32, n=expr_int32, p=expr_numeric,
+@typecheck(x=expr_int32, n=expr_int32, p=expr_float64,
            alternative=enumeration("two.sided", "greater", "less"))
 def binom_test(x: Int32Expression, n: Int32Expression, p: Float64Expression, alternative: str) -> Float64Expression:
     """Performs a binomial test on `p` given `x` successes in `n` trials.
@@ -1379,7 +1379,7 @@ def binom_test(x: Int32Expression, n: Int32Expression, p: Float64Expression, alt
     return _func("binomTest", tfloat64, x, n, p, to_expr(alternative))
 
 
-@typecheck(x=expr_numeric, df=expr_numeric)
+@typecheck(x=expr_float64, df=expr_float64)
 def pchisqtail(x: Float64Expression, df: Float64Expression) -> Float64Expression:
     """Returns the probability under the right-tail starting at x for a chi-squared
     distribution with df degrees of freedom.
@@ -1404,7 +1404,7 @@ def pchisqtail(x: Float64Expression, df: Float64Expression) -> Float64Expression
     return _func("pchisqtail", tfloat64, x, df)
 
 
-@typecheck(x=expr_numeric)
+@typecheck(x=expr_float64)
 def pnorm(x: Float64Expression) -> Float64Expression:
     """The cumulative probability function of a standard normal distribution.
 
@@ -1436,7 +1436,7 @@ def pnorm(x: Float64Expression) -> Float64Expression:
     return _func("pnorm", tfloat64, x)
 
 
-@typecheck(x=expr_numeric, lamb=expr_numeric, lower_tail=expr_bool, log_p=expr_bool)
+@typecheck(x=expr_float64, lamb=expr_float64, lower_tail=expr_bool, log_p=expr_bool)
 def ppois(x: Float64Expression,
           lamb: Float64Expression,
           lower_tail: BooleanExpression = True,
@@ -1474,7 +1474,7 @@ def ppois(x: Float64Expression,
     return _func("ppois", tfloat64, x, lamb, lower_tail, log_p)
 
 
-@typecheck(p=expr_numeric, df=expr_numeric)
+@typecheck(p=expr_float64, df=expr_float64)
 def qchisqtail(p: Float64Expression, df: Float64Expression) -> Float64Expression:
     """Inverts :meth:`.pchisqtail`.
 
@@ -1504,7 +1504,7 @@ def qchisqtail(p: Float64Expression, df: Float64Expression) -> Float64Expression
     return _func("qchisqtail", tfloat64, p, df)
 
 
-@typecheck(p=expr_numeric)
+@typecheck(p=expr_float64)
 def qnorm(p: Float64Expression) -> Float64Expression:
     """Inverts :meth:`.pnorm`.
 
@@ -1532,7 +1532,7 @@ def qnorm(p: Float64Expression) -> Float64Expression:
     return _func("qnorm", tfloat64, p)
 
 
-@typecheck(p=expr_numeric, lamb=expr_numeric, lower_tail=expr_bool, log_p=expr_bool)
+@typecheck(p=expr_float64, lamb=expr_float64, lower_tail=expr_bool, log_p=expr_bool)
 def qpois(p: Float64Expression,
           lamb: Float64Expression,
           lower_tail: BooleanExpression = True,
@@ -1602,7 +1602,7 @@ def range(start: Int32Expression, stop: Int32Expression, step: Int32Expression =
     return _func("range", tarray(tint32), start, stop, step)
 
 
-@typecheck(p=expr_numeric)
+@typecheck(p=expr_float64)
 def rand_bool(p: Float64Expression) -> BooleanExpression:
     """Returns ``True`` with probability `p` (RNG).
 
@@ -1633,7 +1633,7 @@ def rand_bool(p: Float64Expression) -> BooleanExpression:
     return _func("pcoin", tbool, p)
 
 
-@typecheck(mean=expr_numeric, sd=expr_numeric)
+@typecheck(mean=expr_float64, sd=expr_float64)
 def rand_norm(mean: Float64Expression = 0, sd: Float64Expression = 1) -> Float64Expression:
     """Samples from a normal distribution with mean `mean` and standard deviation `sd` (RNG).
 
@@ -1667,7 +1667,7 @@ def rand_norm(mean: Float64Expression = 0, sd: Float64Expression = 1) -> Float64
     return _func("rnorm", tfloat64, mean, sd)
 
 
-@typecheck(lamb=expr_numeric)
+@typecheck(lamb=expr_float64)
 def rand_pois(lamb: Float64Expression) -> Float64Expression:
     """Samples from a Poisson distribution with rate parameter `lamb` (RNG).
 
@@ -1699,7 +1699,7 @@ def rand_pois(lamb: Float64Expression) -> Float64Expression:
     return _func("rpois", tfloat64, lamb)
 
 
-@typecheck(min=expr_numeric, max=expr_numeric)
+@typecheck(min=expr_float64, max=expr_float64)
 def rand_unif(min: Float64Expression, max: Float64Expression) -> Float64Expression:
     """Returns a random floating-point number uniformly drawn from the interval [`min`, `max`].
 
@@ -1733,7 +1733,7 @@ def rand_unif(min: Float64Expression, max: Float64Expression) -> Float64Expressi
     return _func("runif", tfloat64, min, max)
 
 
-@typecheck(x=expr_numeric)
+@typecheck(x=expr_float64)
 def sqrt(x: Float64Expression) -> Float64Expression:
     """Returns the square root of `x`.
 
@@ -2589,6 +2589,7 @@ def max(*exprs: Union[CollectionExpression, Num_T]) -> Num_T:
                             "  Found {} arguments with types '{}'".format(builtins.len(exprs), ', '.join(
                 "'{}'".format(e.dtype) for e in exprs)))
         ret_t = unify_types(*(e.dtype for e in exprs))
+        exprs = tuple(e._promote_numeric(e, ret_t) for e in exprs)
         if builtins.len(exprs) == 2:
             return exprs[0]._method('max', ret_t, exprs[1])
         else:
@@ -2642,6 +2643,7 @@ def min(*exprs: Union[CollectionExpression, Num_T]) -> Num_T:
                             "  Found {} arguments with types '{}'".format(builtins.len(exprs), ', '.join(
                 "'{}'".format(e.dtype) for e in exprs)))
         ret_t = unify_types(*(e.dtype for e in exprs))
+        exprs = tuple(e._promote_numeric(e, ret_t) for e in exprs)
         if builtins.len(exprs) == 2:
             return exprs[0]._method('min', ret_t, exprs[1])
         else:

--- a/python/hail/expr/types.py
+++ b/python/hail/expr/types.py
@@ -172,6 +172,13 @@ class HailType(object):
     def _convert_from_json(self, x):
         return x
 
+    def _scalar_type(self):
+        if isinstance(self, tarray):
+            return self.element_type
+        else:
+            assert is_numeric(self)
+            return self
+
 
 hail_type = oneof(HailType, transformed((str, dtype)))
 

--- a/python/hail/tests/test_api.py
+++ b/python/hail/tests/test_api.py
@@ -1117,8 +1117,6 @@ class ColumnTests(unittest.TestCase):
                     'x30': False, 'x31': True, 'x32': False,
                     'x33': False, 'x34': False, 'x35': False, 'x36': True}
 
-        self.maxDiff = 2000
-
         for k, v in expected.items():
             if isinstance(v, float):
                 self.assertAlmostEqual(v, result[k], msg=k)

--- a/src/main/scala/is/hail/expr/Fun.scala
+++ b/src/main/scala/is/hail/expr/Fun.scala
@@ -9,8 +9,6 @@ sealed trait Fun {
   def retType: Type
 
   def subst(): Fun
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun
 }
 
 case class Transformation[T, U](f: T => U, fcode: Code[T] => CM[Code[U]]) extends (T => U) {
@@ -25,9 +23,6 @@ case class UnaryDependentFunCode[T, U](retType: Type, code: () => Code[T] => CM[
 
   def subst() =
     throw new UnsupportedOperationException("must captureType first")
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun =
-    throw new UnsupportedOperationException("must captureType first")
 }
 
 case class UnaryDependentFun[T, U](retType: Type, code: () => T => U) extends Fun {
@@ -38,22 +33,12 @@ case class UnaryDependentFun[T, U](retType: Type, code: () => T => U) extends Fu
 
   def subst() =
     throw new UnsupportedOperationException("must captureType first")
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun =
-    throw new UnsupportedOperationException("must captureType first")
 }
 
 case class UnaryFunCode[T, U](retType: Type, code: Code[T] => CM[Code[U]]) extends Fun with (Code[T] => CM[Code[U]]) {
   def apply(ct: Code[T]): CM[Code[U]] = code(ct)
 
   def subst() = UnaryFunCode[T, U](retType.subst(), code)
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = {
-    require(transformations.length == 1)
-
-    UnaryFunCode[Any, Any](retType, (a: Code[Any]) =>
-      transformations(0).fcode(a).flatMap(ct => code(ct.asInstanceOf[Code[T]])))
-  }
 }
 
 case class BinarySpecialCode[T, U, V](retType: Type, code: (Code[T], Code[U]) => CM[Code[V]])
@@ -61,25 +46,12 @@ case class BinarySpecialCode[T, U, V](retType: Type, code: (Code[T], Code[U]) =>
   def apply(t: Code[T], u: Code[U]): CM[Code[V]] = code(t, u)
 
   def subst() = BinarySpecialCode(retType.subst(), code)
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = ???
 }
 
 case class BinaryFunCode[T, U, V](retType: Type, code: (Code[T], Code[U]) => CM[Code[V]]) extends Fun with Serializable with ((Code[T], Code[U]) => CM[Code[V]]) {
   def apply(t: Code[T], u: Code[U]): CM[Code[V]] = code(t, u)
 
   def subst() = BinaryFunCode(retType.subst(), code)
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = {
-    require(transformations.length == 2)
-
-    BinaryFunCode[Any, Any, Any](retType, { (a, b) => for (
-      ct <- transformations(0).fcode(a);
-      cu <- transformations(1).fcode(b);
-      ret <- code(ct.asInstanceOf[Code[T]], cu.asInstanceOf[Code[U]])
-    ) yield ret
-    })
-  }
 }
 
 case class BinaryDependentFun[T, U, V](retType: Type, code: () => (T, U) => V) extends Fun {
@@ -90,25 +62,14 @@ case class BinaryDependentFun[T, U, V](retType: Type, code: () => (T, U) => V) e
 
   def subst() =
     throw new UnsupportedOperationException("must captureType first")
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun =
-    throw new UnsupportedOperationException("must captureType first")
 }
 
 case class Arity0Aggregator[T, U](retType: Type, ctor: () => TypedAggregator[U]) extends Fun {
   def subst() = Arity0Aggregator[T, U](retType.subst(), ctor)
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = {
-    assert(transformations.length == 1)
-
-    Arity0Aggregator[T, U](retType, () => new TransformedAggregator(ctor(), transformations(0).f))
-  }
 }
 
 case class Arity0DependentAggregator[T, U](retType: Type, ctor: () => (() => TypedAggregator[U])) extends Fun {
   def subst() = Arity0Aggregator[T, U](retType.subst(), ctor())
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = ???
 }
 
 class TransformedAggregator[T](val prev: TypedAggregator[T], transform: (Any) => Any) extends TypedAggregator[T] {
@@ -123,92 +84,44 @@ class TransformedAggregator[T](val prev: TypedAggregator[T], transform: (Any) =>
 
 case class Arity1Aggregator[T, U, V](retType: Type, ctor: (U) => TypedAggregator[V]) extends Fun {
   def subst() = Arity1Aggregator[T, U, V](retType.subst(), ctor)
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = {
-    assert(transformations.length == 2)
-
-    Arity1Aggregator[T, U, V](retType, { (u) =>
-      new TransformedAggregator(ctor(
-        transformations(1).f(u).asInstanceOf[U]),
-        transformations(0).f)
-    })
-  }
 }
 
 case class Arity1DependentAggregator[T, U, V](retType: Type, ctor: () => ((U) => TypedAggregator[V])) extends Fun {
   def subst() = Arity1Aggregator[T, U, V](retType.subst(), ctor())
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = ???
 }
 
 case class Arity3Aggregator[T, U, V, W, X](retType: Type, ctor: (U, V, W) => TypedAggregator[X]) extends Fun {
   def subst() = Arity3Aggregator[T, U, V, W, X](retType.subst(), ctor)
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = {
-    assert(transformations.length == 4)
-
-    Arity3Aggregator[T, U, V, W, X](retType, { (u, v, w) =>
-      new TransformedAggregator(ctor(
-        transformations(1).f(u).asInstanceOf[U],
-        transformations(2).f(v).asInstanceOf[V],
-        transformations(3).f(w).asInstanceOf[W]),
-        transformations(0).f)
-    })
-  }
 }
 
 case class UnaryLambdaAggregator[T, U, V](retType: Type, ctor: ((Any) => Any) => TypedAggregator[V]) extends Fun {
   def subst() = UnaryLambdaAggregator[T, U, V](retType.subst(), ctor)
-
-  // conversion can't apply to function type
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = ???
 }
 
 case class BinaryLambdaAggregator[T, U, V, W](retType: Type, ctor: ((Any) => Any, V) => TypedAggregator[W]) extends Fun {
   def subst() = BinaryLambdaAggregator[T, U, V, W](retType.subst(), ctor)
-
-  // conversion can't apply to function type
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = ???
 }
 
 case class BinaryDependentLambdaAggregator[T, U, V, W](retType: Type, ctor: () => (((Any) => Any, V) => TypedAggregator[W])) extends Fun {
   def subst() = BinaryLambdaAggregator[T, U, V, W](retType.subst(), ctor())
-
-  // conversion can't apply to function type
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = ???
 }
 
 case class UnaryFun[T, U](retType: Type, f: (T) => U) extends Fun with Serializable with ((T) => U) {
   def apply(t: T): U = f(t)
 
   def subst() = UnaryFun(retType.subst(), f)
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = {
-    require(transformations.length == 1)
-
-    UnaryFun[Any, Any](retType, (a: Any) => f(transformations(0).f(a).asInstanceOf[T]))
-  }
 }
 
 case class UnarySpecial[T, U](retType: Type, f: (() => Any) => U) extends Fun with Serializable with ((() => Any) => U) {
   def apply(t: () => Any): U = f(t)
 
   def subst() = UnarySpecial(retType.subst(), f)
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = ???
 }
 
 case class BinaryFun[T, U, V](retType: Type, f: (T, U) => V) extends Fun with Serializable with ((T, U) => V) {
   def apply(t: T, u: U): V = f(t, u)
 
   def subst() = BinaryFun(retType.subst(), f)
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = {
-    require(transformations.length == 2)
-
-    BinaryFun[Any, Any, Any](retType, (a, b) => f(transformations(0).f(a).asInstanceOf[T],
-      transformations(1).f(b).asInstanceOf[U]))
-  }
 }
 
 case class BinarySpecial[T, U, V](retType: Type, f: (() => Any, () => Any) => V)
@@ -216,8 +129,6 @@ case class BinarySpecial[T, U, V](retType: Type, f: (() => Any, () => Any) => V)
   def apply(t: () => Any, u: () => Any): V = f(t, u)
 
   def subst() = BinarySpecial(retType.subst(), f)
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = ???
 }
 
 case class BinaryLambdaFun[T, U, V](retType: Type, f: (T, (Any) => Any) => V)
@@ -225,9 +136,6 @@ case class BinaryLambdaFun[T, U, V](retType: Type, f: (T, (Any) => Any) => V)
   def apply(t: T, u: (Any) => Any): V = f(t, u)
 
   def subst() = BinaryLambdaFun(retType.subst(), f)
-
-  // conversion can't apply to function type
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = ???
 }
 
 case class Arity3LambdaMethod[T, U, V, W](retType: Type, f: (T, (Any) => Any, V) => W)
@@ -235,16 +143,6 @@ case class Arity3LambdaMethod[T, U, V, W](retType: Type, f: (T, (Any) => Any, V)
   def apply(t: T, u: (Any) => Any, v: V): W = f(t, u, v)
 
   def subst() = Arity3LambdaMethod(retType.subst(), f)
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = {
-    require(transformations.length == 3)
-
-    Arity3LambdaMethod[Any, Any, Any, Any](retType, (t, u, v) =>
-      f(transformations(0).f(t).asInstanceOf[T],
-        // conversion can't apply to function type
-        u,
-        transformations(2).f(v).asInstanceOf[V]))
-  }
 }
 
 case class Arity3LambdaFun[T, U, V, W](retType: Type, f: ((Any) => Any, U, V) => W)
@@ -252,15 +150,6 @@ case class Arity3LambdaFun[T, U, V, W](retType: Type, f: ((Any) => Any, U, V) =>
   def apply(t: (Any) => Any, u: U, v: V): W = f(t, u, v)
 
   def subst() = Arity3LambdaFun(retType.subst(), f)
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = {
-    require(transformations.length == 3)
-
-    Arity3LambdaFun[Any, Any, Any, Any](retType, (t, u, v) =>
-      f(t, // conversion can't apply to function type
-        transformations(1).f(u).asInstanceOf[U],
-        transformations(2).f(v).asInstanceOf[V]))
-  }
 }
 
 case class BinaryLambdaAggregatorTransformer[T, U, V](retType: Type, f: (CPS[Any], (Any) => Any) => CPS[V],
@@ -269,23 +158,12 @@ case class BinaryLambdaAggregatorTransformer[T, U, V](retType: Type, f: (CPS[Any
   def apply(t: CPS[Any], u: (Any) => Any): CPS[V] = f(t, u)
 
   def subst() = BinaryLambdaAggregatorTransformer(retType.subst(), f, fcode)
-
-  // conversion can't apply to function type
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = ???
 }
 
 case class Arity3Fun[T, U, V, W](retType: Type, f: (T, U, V) => W) extends Fun with Serializable with ((T, U, V) => W) {
   def apply(t: T, u: U, v: V): W = f(t, u, v)
 
   def subst() = Arity3Fun(retType.subst(), f)
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = {
-    require(transformations.length == 3)
-
-    Arity3Fun[Any, Any, Any, Any](retType, (a, b, c) => f(transformations(0).f(a).asInstanceOf[T],
-      transformations(1).f(b).asInstanceOf[U],
-      transformations(2).f(c).asInstanceOf[V]))
-  }
 }
 
 case class Arity3Special[T, U, V, W](retType: Type, f: (() => Any, () => Any, () => Any) => W)
@@ -293,8 +171,6 @@ case class Arity3Special[T, U, V, W](retType: Type, f: (() => Any, () => Any, ()
   def apply(t: () => Any, u: () => Any, v: () => Any): W = f(t, u, v)
 
   def subst() = Arity3Special(retType.subst(), f)
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = ???
 }
 
 case class Arity3DependentFun[T, U, V, W](retType: Type, code: () => (T, U, V) => W) extends Fun {
@@ -305,24 +181,12 @@ case class Arity3DependentFun[T, U, V, W](retType: Type, code: () => (T, U, V) =
 
   def subst() =
     throw new UnsupportedOperationException("must captureType first")
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun =
-    throw new UnsupportedOperationException("must captureType first")
 }
 
 case class Arity4Fun[T, U, V, W, X](retType: Type, f: (T, U, V, W) => X) extends Fun with Serializable with ((T, U, V, W) => X) {
   def apply(t: T, u: U, v: V, w: W): X = f(t, u, v, w)
 
   def subst() = Arity4Fun(retType.subst(), f)
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = {
-    require(transformations.length == 4)
-
-    Arity4Fun[Any, Any, Any, Any, Any](retType, (a, b, c, d) => f(transformations(0).f(a).asInstanceOf[T],
-      transformations(1).f(b).asInstanceOf[U],
-      transformations(2).f(c).asInstanceOf[V],
-      transformations(3).f(d).asInstanceOf[W]))
-  }
 }
 
 case class Arity4DependentFun[T, U, V, W, X](retType: Type, code: () => (T, U, V, W) => X) extends Fun {
@@ -333,25 +197,12 @@ case class Arity4DependentFun[T, U, V, W, X](retType: Type, code: () => (T, U, V
 
   def subst() =
     throw new UnsupportedOperationException("must captureType first")
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun =
-    throw new UnsupportedOperationException("must captureType first")
 }
 
 case class Arity5Fun[T, U, V, W, X, Y](retType: Type, f: (T, U, V, W, X) => Y) extends Fun with Serializable with ((T, U, V, W, X) => Y) {
   def apply(t: T, u: U, v: V, w: W, x:X): Y = f(t, u, v, w, x)
 
   def subst() = Arity5Fun(retType.subst(), f)
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = {
-    require(transformations.length == 5)
-
-    Arity5Fun[Any, Any, Any, Any, Any, Any](retType, (a, b, c, d, e) => f(transformations(0).f(a).asInstanceOf[T],
-      transformations(1).f(b).asInstanceOf[U],
-      transformations(2).f(c).asInstanceOf[V],
-      transformations(3).f(d).asInstanceOf[W],
-      transformations(4).f(e).asInstanceOf[X]))
-  }
 }
 
 case class Arity5DependentFun[T, U, V, W, X, Y](retType: Type, code: () => (T, U, V, W, X) => Y) extends Fun {
@@ -362,9 +213,6 @@ case class Arity5DependentFun[T, U, V, W, X, Y](retType: Type, code: () => (T, U
 
   def subst() =
     throw new UnsupportedOperationException("must captureType first")
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun =
-    throw new UnsupportedOperationException("must captureType first")
 }
 
 case class Arity6Special[T, U, V, W, X, Y, Z](retType: Type, f: (() => Any, () => Any, () => Any, () => Any, () => Any, () => Any) => Z)
@@ -372,6 +220,4 @@ case class Arity6Special[T, U, V, W, X, Y, Z](retType: Type, f: (() => Any, () =
   def apply(t: () => Any, u: () => Any, v: () => Any, w: () => Any, x: () => Any, y: () => Any): Z = f(t, u, v, w, x, y)
 
   def subst() = Arity6Special(retType.subst(), f)
-
-  def convertArgs(transformations: Array[Transformation[Any, Any]]): Fun = ???
 }

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -2121,7 +2121,8 @@ object FunctionRegistry {
   register("~", (s: String, t: String) => s.r.findFirstIn(t).isDefined)
 
   register("isnan", (d: Double) => d.isNaN)
-
+  register("isnan", (f: Float) => f.isNaN)
+  
   registerSpecial("isMissing", (g: () => Any) => g() == null)(TTHr, boolHr)
   registerSpecial("isDefined", (g: () => Any) => g() != null)(TTHr, boolHr)
 

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -432,6 +432,10 @@ object Parser extends JavaTokenParsers {
     withPos("f64#" ~> """-?\d+(\.\d+)?[eE][+-]?\d+""".r) ^^ (r => Const(r.pos, r.x.toDouble, TFloat64())) |
       withPos("f32#" ~> """-?\d*(\.\d+)?""".r) ^^ (r => Const(r.pos, r.x.toFloat, TFloat32())) |
       withPos("f64#" ~> """-?\d*(\.\d+)?""".r) ^^ (r => Const(r.pos, r.x.toDouble, TFloat64())) |
+      withPos("""-?\d+(\.\d+)?[eE][+-]?\d+[fF]""".r) ^^ (r => Const(r.pos, r.x.toFloat, TFloat32())) |
+      withPos("""-?\d*\.\d+[fF]""".r) ^^ (r => Const(r.pos, r.x.toFloat, TFloat32())) |
+      withPos("""-?\d+[fF]""".r) ^^ (r => Const(r.pos, r.x.toFloat, TFloat32())) |
+      withPos("""-?\d+[dD]""".r) ^^ (r => Const(r.pos, r.x.toDouble, TFloat64())) |
       withPos("""-?\d+(\.\d+)?[eE][+-]?\d+[dD]?""".r) ^^ (r => Const(r.pos, r.x.toDouble, TFloat64())) |
       withPos("""-?\d*\.\d+[dD]?""".r) ^^ (r => Const(r.pos, r.x.toDouble, TFloat64())) |
       withPos("i64#" ~> wholeNumber) ^^ (r => Const(r.pos, r.x.toLong, TInt64())) |

--- a/src/test/scala/is/hail/expr/AstToIrSuite.scala
+++ b/src/test/scala/is/hail/expr/AstToIrSuite.scala
@@ -136,36 +136,4 @@ class ASTToIRSuite extends TestNGSuite {
       s"expected '$in' to parse and convert into $out, but got ${toIR(in)}")
   }
   }
-
-  @Test
-  def aggs() {
-    for {(in, out) <- Array(
-      "aggregable.sum()" ->
-        ApplyAggOp(AggIn(), Sum(), Seq()),
-      "aggregable.map(x => x * 5).sum()" ->
-        ApplyAggOp(
-          AggMap(AggIn(), "x", ApplyBinaryPrimOp(Multiply(), Ref("x"), I32(5))),
-          Sum(), Seq(), TInt32()),
-      "aggregable.map(x => x * something).sum()" ->
-        ApplyAggOp(
-          AggMap(AggIn(), "x", ApplyBinaryPrimOp(Multiply(), Ref("x"), Ref("something"))),
-          Sum(), Seq()),
-      "aggregable.filter(x => x > 2).sum()" ->
-        ApplyAggOp(
-          AggFilter(AggIn(), "x", ApplyBinaryPrimOp(GT(), Ref("x"), I32(2))),
-          Sum(), Seq()),
-      "aggregable.flatMap(x => [x * 5]).sum()" ->
-        ApplyAggOp(
-          AggFlatMap(AggIn(), "x",
-            MakeArray(Seq(ApplyBinaryPrimOp(Multiply(), Ref("x"), I32(5))))),
-          Sum(), Seq())
-    )
-    } {
-      val tAgg = TAggregable(TInt32())
-      tAgg.symTab = Map("something" -> (0, TInt32(): Type))
-      Infer(out, Some(tAgg))
-      assert(toIR(in).contains(out),
-        s"expected '$in' to parse and convert into $out, but got ${ toIR(in) }")
-    }
-  }
 }

--- a/src/test/scala/is/hail/io/ExportVCFSuite.scala
+++ b/src/test/scala/is/hail/io/ExportVCFSuite.scala
@@ -124,7 +124,7 @@ class ExportVCFSuite extends SparkSuite {
     val out = tmpDir.createTempFile("out", "vcf")
     ExportVCF(vds
       .annotateRowsExpr("info.AC_pass = AGG.filter(g => g.GQ >= 20 && g.DP >= 10 && " +
-        "(!g.GT.isHet() || ( (g.AD[1]/g.AD.sum()) >= 0.2 ) )).count()"),
+        "(!g.GT.isHet() || ( (g.AD[1]/g.AD.sum()).toFloat64 >= 0.2 ) )).count()"),
       out)
 
     hadoopConf.readFile(out) { in =>

--- a/src/test/scala/is/hail/methods/AnnotateGlobalSuite.scala
+++ b/src/test/scala/is/hail/methods/AnnotateGlobalSuite.scala
@@ -17,8 +17,8 @@ class AnnotateGlobalSuite extends SparkSuite {
     vds = SampleQC(vds)
 
     val (afDist, _) = vds.queryRows("AGG.map(v => va.qc.AF).stats()")
-    val (singStats, _) = vds.queryCols("AGG.filter(sa => sa.qc.n_singleton > 2).count()")
-    val (acDist, _) = vds.queryRows("AGG.map(v => va.qc.AC).stats()")
+    val (singStats, _) = vds.queryCols("AGG.filter(sa => sa.qc.n_singleton > 2L).count()")
+    val (acDist, _) = vds.queryRows("AGG.map(v => va.qc.AC.toFloat64).stats()")
     val (crStats, _) = vds.queryCols("AGG.map(s => sa.qc.call_rate).stats()")
 
     val qSingleton = vds.querySA("sa.qc.n_singleton")._2

--- a/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -164,12 +164,12 @@ class ExprSuite extends SparkSuite {
       (t, Option(f()).map(_.asInstanceOf[T]))
     }
 
-    assert(D_==(eval[Double]("gamma(5)").get, 24))
+    assert(D_==(eval[Double]("gamma(5.0)").get, 24))
     assert(D_==(eval[Double]("gamma(0.5)").get, 1.7724538509055159)) // python: math.gamma(0.5)
 
     // uniroot (default) tolerance is ~1.22e-4
-    assert(D_==(eval[Double]("uniroot(x => x*x + 3*x - 4, 0, 2)").get, 1, tolerance = 1e-4))
-    assert(D_==(eval[Double]("uniroot(x => x*x + 3*x - 4, -5, -1)").get, -4, tolerance = 1e-4))
+    assert(D_==(eval[Double]("uniroot(x => x*x + 3.0*x - 4.0, 0.0, 2.0)").get, 1, tolerance = 1e-4))
+    assert(D_==(eval[Double]("uniroot(x => x*x + 3.0*x - 4.0, -5.0, -1.0)").get, -4, tolerance = 1e-4))
 
     assert(eval[Int]("is.toInt32()").contains(-37))
 
@@ -182,10 +182,7 @@ class ExprSuite extends SparkSuite {
     assert(eval[Boolean]("gs.het.isHomRef()").contains(false))
     assert(eval[Boolean]("!gs.het.isHomRef()").contains(true))
 
-    assert(eval[Boolean]("1 / 2 == 0.5").contains(true))
     assert(eval[Boolean]("1.0 / 2.0 == 0.5").contains(true))
-    assert(eval[Boolean]("1 / 2.0 == 0.5").contains(true))
-    assert(eval[Boolean]("1.0 / 2 == 0.5").contains(true))
 
     assert(eval[Boolean]("0 % 1 == 0").contains(true))
     assert(eval[Boolean]("0 % -1 == 0").contains(true))
@@ -223,10 +220,10 @@ class ExprSuite extends SparkSuite {
 
     assert(eval[Float]("0 / 0").forall(_.isNaN))
     assert(eval[Double]("0.0 / 0.0").forall(_.isNaN))
-    assert(eval[Float]("0 / 0 + 1").forall(_.isNaN))
-    assert(eval[Double]("0.0 / 0.0 + 1").forall(_.isNaN))
-    assert(eval[Float]("0 / 0 * 1").forall(_.isNaN))
-    assert(eval[Double]("0.0 / 0.0 * 1").forall(_.isNaN))
+    assert(eval[Float]("0 / 0 + 1f").forall(_.isNaN))
+    assert(eval[Double]("0.0 / 0.0 + 1d").forall(_.isNaN))
+    assert(eval[Float]("0 / 0 * 1f").forall(_.isNaN))
+    assert(eval[Double]("0.0 / 0.0 * 1d").forall(_.isNaN))
     assert(eval[Float]("1 / 0").contains(Float.PositiveInfinity))
     assert(eval[Double]("1.0 / 0.0").contains(Double.PositiveInfinity))
     assert(eval[Float]("-1 / 0").contains(Float.NegativeInfinity))
@@ -234,8 +231,8 @@ class ExprSuite extends SparkSuite {
     // NB: the -0 is parsed as the zero integer, which is converted to +0.0
     assert(eval[Float]("1 / -0").contains(Float.PositiveInfinity))
     assert(eval[Double]("1.0 / -0.0").contains(Double.NegativeInfinity))
-    assert(eval[Float]("0/0 * 1/0").forall(_.isNaN))
-    assert(eval[Double]("0.0/0.0 * 1.0/0.0").forall(_.isNaN))
+    assert(eval[Float]("(0/0) * (1/0)").forall(_.isNaN))
+    assert(eval[Double]("(0.0/0.0) * (1.0/0.0)").forall(_.isNaN))
     for {x <- Array("-1.0/0.0", "-1.0", "0.0", "1.0", "1.0/0.0")} {
       assert(eval[Boolean](s"0.0/0.0 < $x").contains(false))
       assert(eval[Boolean](s"0.0/0.0 <= $x").contains(false))
@@ -674,38 +671,33 @@ class ExprSuite extends SparkSuite {
     TestUtils.interceptFatal("""invalid escape character.*backtick identifier.*\\i""")(eval[String](""" let `bad\identifier` = 0 in 0 """))
     TestUtils.interceptFatal("""unterminated backtick identifier""")(eval[String](""" let `bad\identifier = 0 in 0 """))
 
-    assert(D_==(eval[Double]("log(56.toInt64())").get, math.log(56)))
+    assert(D_==(eval[Double]("log(56.toFloat64)").get, math.log(56)))
     assert(D_==(eval[Double]("exp(5.6)").get, math.exp(5.6)))
     assert(D_==(eval[Double]("log10(5.6)").get, math.log10(5.6)))
-    assert(D_==(eval[Double]("log10(5.6)").get, eval[Double]("log(5.6, 10)").get))
+    assert(D_==(eval[Double]("log10(5.6)").get, eval[Double]("log(5.6, 10.0)").get))
     assert(D_==(eval[Double]("log(5.6, 3.2)").get, 1.481120576298196))
     assert(D_==(eval[Double]("sqrt(5.6)").get, math.sqrt(5.6)))
-    assert(D_==(eval[Double]("pow(2, 3)").get, 8.0))
+    assert(D_==(eval[Double]("pow(2.0, 3.0)").get, 8.0))
 
     assert(eval[IndexedSeq[_]]("""[1,2,3] + [2,3,4] """).contains(IndexedSeq(3, 5, 7)))
     assert(eval[IndexedSeq[_]]("""[1,2,3] - [2,3,4] """).contains(IndexedSeq(-1, -1, -1)))
     assert(eval[IndexedSeq[_]]("""[1,2,3] / [2,3,4] """).contains(IndexedSeq(.5, 2f / 3f, .75)))
     assert(eval[IndexedSeq[_]]("""1 / [2,3,4] """).contains(IndexedSeq(1f / 2f, 1f / 3f, 1.0 / 4.0)))
     assert(eval[IndexedSeq[_]]("""[2,3,4] / 2""").contains(IndexedSeq(1.0, 1.5, 2.0)))
-    assert(eval[IndexedSeq[_]]("""[2,3,4] * 2.0""").contains(IndexedSeq(4.0, 6.0, 8.0)))
-    assert(eval[IndexedSeq[_]]("""[2,NA: Int,4] * 2.0""").contains(IndexedSeq(4.0, null, 8.0)))
+    assert(eval[IndexedSeq[_]]("""[2.0,3.0,4.0] * 2.0""").contains(IndexedSeq(4.0, 6.0, 8.0)))
+    assert(eval[IndexedSeq[_]]("""[2.0,NA: Float64,4.0] * 2.0""").contains(IndexedSeq(4.0, null, 8.0)))
     assert(eval[IndexedSeq[_]]("""[2,NA: Int,4] * [2,NA: Int,4]""").contains(IndexedSeq(4.0, null, 16.0)))
-    assert(eval[IndexedSeq[_]]("""[2,NA: Int,4] + 2.0""").contains(IndexedSeq(4.0, null, 6.0)))
+    assert(eval[IndexedSeq[_]]("""[2.0,NA: Float64,4.0] + 2.0""").contains(IndexedSeq(4.0, null, 6.0)))
     assert(eval[IndexedSeq[_]]("""[2,NA: Int,4] + [2,NA: Int,4]""").contains(IndexedSeq(4.0, null, 8.0)))
-    assert(eval[IndexedSeq[_]]("""[2,NA: Int,4] - 2.0""").contains(IndexedSeq(0.0, null, 2.0)))
+    assert(eval[IndexedSeq[_]]("""[2.0,NA: Float64,4.0] - 2.0""").contains(IndexedSeq(0.0, null, 2.0)))
     assert(eval[IndexedSeq[_]]("""[2,NA: Int,4] - [2,NA: Int,4]""").contains(IndexedSeq(0.0, null, 0.0)))
-    assert(eval[IndexedSeq[_]]("""[2,NA: Int,4] / 2.0""").contains(IndexedSeq(1.0, null, 2.0)))
+    assert(eval[IndexedSeq[_]]("""[2.0,NA: Float64,4.0] / 2.0""").contains(IndexedSeq(1.0, null, 2.0)))
     assert(eval[IndexedSeq[_]]("""[2,NA: Int,4] / [2,NA: Int,4]""").contains(IndexedSeq(1.0, null, 1.0)))
 
     // tests for issue #1204
-    assert(eval[IndexedSeq[_]]("""([2,3,4] / 2) / 2""").contains(IndexedSeq(0.5, 0.75, 1.0)))
-    assert(eval[IndexedSeq[_]]("""([2,3,4] / 2L) / 2""").contains(IndexedSeq(0.5, 0.75, 1.0)))
-    assert(eval[IndexedSeq[_]]("""([2,3,4] / 2.0) / 2""").contains(IndexedSeq(0.5, 0.75, 1.0)))
-    assert(eval[IndexedSeq[_]]("""([2L,3L,4L] / 2) / 2""").contains(IndexedSeq(0.5, 0.75, 1.0)))
-    assert(eval[IndexedSeq[_]]("""([2L,3L,4L] / 2L) / 2""").contains(IndexedSeq(0.5, 0.75, 1.0)))
-    assert(eval[IndexedSeq[_]]("""([2L,3L,4L] / 2.0) / 2""").contains(IndexedSeq(0.5, 0.75, 1.0)))
-    assert(eval[IndexedSeq[_]]("""([2.0,3.0,4.0] / 2) / 2""").contains(IndexedSeq(0.5, 0.75, 1.0)))
-    assert(eval[IndexedSeq[_]]("""([2.0,3.0,4.0] / 2.0) / 2""").contains(IndexedSeq(0.5, 0.75, 1.0)))
+    assert(eval[IndexedSeq[_]]("""([2,3,4] / 2) / 2f""").contains(IndexedSeq(0.5, 0.75, 1.0)))
+    assert(eval[IndexedSeq[_]]("""([2L,3L,4L] / 2L) / 2f""").contains(IndexedSeq(0.5, 0.75, 1.0)))
+    assert(eval[IndexedSeq[_]]("""([2.0,3.0,4.0] / 2.0) / 2.0""").contains(IndexedSeq(0.5, 0.75, 1.0)))
 
     TestUtils.interceptFatal("""Cannot apply operation \+ to arrays of unequal length""") {
       eval[IndexedSeq[Int]]("""[1] + [2,3,4] """)
@@ -736,12 +728,9 @@ class ExprSuite extends SparkSuite {
 
     assert(eval[Boolean]("pcoin(2.0)").contains(true))
     assert(eval[Boolean]("pcoin(-1.0)").contains(false))
-    assert(eval[Boolean]("pcoin(2.0.toFloat32())").contains(true))
-    assert(eval[Boolean]("pcoin(-1.0.toFloat32())").contains(false))
 
     assert(eval[Boolean]("runif(2.0, 3.0) > -1.0").contains(true))
     assert(eval[Boolean]("runif(2.0, 3.0) < 3.0").contains(true))
-    assert(eval[Boolean]("runif(2, 3) < 3.0").contains(true))
 
     assert(eval[Boolean]("rnorm(2.0, 4.0).abs() > -1.0").contains(true))
 
@@ -749,19 +738,19 @@ class ExprSuite extends SparkSuite {
     assert(D_==(eval[Double]("qnorm(pnorm(0.5))").get, 0.5))
     assert(D_==(eval[Double]("qnorm(pnorm(-0.5))").get, -0.5))
 
-    assert(D_==(eval[Double]("qchisqtail(pchisqtail(0.5,1),1)").get, 0.5))
-    assert(D_==(eval[Double]("pchisqtail(qchisqtail(0.5,1),1)").get, 0.5))
+    assert(D_==(eval[Double]("qchisqtail(pchisqtail(0.5,1.0),1.0)").get, 0.5))
+    assert(D_==(eval[Double]("pchisqtail(qchisqtail(0.5,1.0),1.0)").get, 0.5))
 
-    assert(eval[Boolean]("rpois(5) >= 0").contains(true))
-    assert(eval[Boolean]("rpois(5, 5).length == 5").contains(true))
-    assert(D_==(eval[Double]("dpois(5, 5)").get, 0.1754674))
-    assert(D_==(eval[Double]("dpois(5, 5, true)").get, -1.740302))
-    assert(D_==(eval[Double]("ppois(5, 5)").get, 0.6159607))
-    assert(D_==(eval[Double]("ppois(5, 5, true, true)").get, -0.4845722))
-    assert(D_==(eval[Double]("ppois(5, 5, false, false)").get, 0.3840393))
-    assert(D_==(eval[Int]("qpois(0.4, 5)").get, 4))
-    assert(D_==(eval[Int]("qpois(log(0.4), 5, true, true)").get, 4))
-    assert(D_==(eval[Int]("qpois(0.4, 5, false, false)").get, 5))
+    assert(eval[Boolean]("rpois(5.0) >= 0d").contains(true))
+    assert(eval[Boolean]("rpois(5, 5.0).length == 5").contains(true))
+    assert(D_==(eval[Double]("dpois(5.0, 5.0)").get, 0.1754674))
+    assert(D_==(eval[Double]("dpois(5.0, 5.0, true)").get, -1.740302))
+    assert(D_==(eval[Double]("ppois(5.0, 5.0)").get, 0.6159607))
+    assert(D_==(eval[Double]("ppois(5.0, 5.0, true, true)").get, -0.4845722))
+    assert(D_==(eval[Double]("ppois(5.0, 5.0, false, false)").get, 0.3840393))
+    assert(D_==(eval[Int]("qpois(0.4, 5.0)").get, 4))
+    assert(D_==(eval[Int]("qpois(log(0.4), 5.0, true, true)").get, 4))
+    assert(D_==(eval[Int]("qpois(0.4, 5.0, false, false)").get, 5))
 
     assert(eval[Any]("if (true) NA: Float64 else 0.0").isEmpty)
 
@@ -898,14 +887,14 @@ class ExprSuite extends SparkSuite {
       assert(t.isOfType(TFloat64()))
       assert(r.contains(4))
 
-      val (t2, r2) = evalWithType("2 ** 3.0")
+      val (t2, r2) = evalWithType("2d ** 3.0")
       assert(t2.isOfType(TFloat64()))
       assert(r2.contains(8.0))
 
       assert(eval("3.123 ** 5.123") == eval("pow(3.123, 5.123)"))
-      assert(eval("5 * 2 ** 2").contains(20))
+      assert(eval("5d * 2 ** 2").contains(20))
       assert(eval("-2**2").contains(-4))
-      assert(eval("2**3**2").contains(64))
+      assert(eval("2**3**2d").contains(64))
       assert(eval("(-2)**2").contains(4))
       assert(eval("-2 ** -2").contains(-0.25))
     }
@@ -927,32 +916,8 @@ class ExprSuite extends SparkSuite {
     assert(eval("""Dict(["foo", "bar"], [1,2])""").contains(Map("foo" -> 1, "bar" -> 2)))
 
     assert(eval("isnan(0/0)").contains(true))
-    assert(eval("isnan(0)").contains(false))
-    assert(eval("isnan(NA: Int)").isEmpty)
-
-    // Test numeric promotion rules
-    assert(evalWithType[Any]("1.toFloat32() + 1.toInt32()") == TFloat32Optional -> Some(2.0f))
-    assert(evalWithType[Any]("1.toFloat32() * 1.toInt32()") == TFloat32Optional -> Some(1.0f))
-    assert(evalWithType[Any]("1.toFloat32() - 1.toInt32()") == TFloat32Optional -> Some(0.0f))
-    assert(evalWithType[Any]("1.toFloat32() / 1.toInt32()") == TFloat32Optional -> Some(1.0f))
-
-    assert(evalWithType[Any]("1.toFloat32() + 1.toInt64()") == TFloat32Optional -> Some(2.0f))
-    assert(evalWithType[Any]("1.toFloat32() * 1.toInt64()") == TFloat32Optional -> Some(1.0f))
-    assert(evalWithType[Any]("1.toFloat32() - 1.toInt64()") == TFloat32Optional -> Some(0.0f))
-    assert(evalWithType[Any]("1.toFloat32() / 1.toInt64()") == TFloat32Optional -> Some(1.0f))
-
-    assert(evalWithType[Any]("[1.toFloat32()] + [1.toInt32()]") == TArray(TFloat32Optional) -> Some(IndexedSeq(2.0f)))
-    assert(evalWithType[Any]("[1.toFloat32()] * [1.toInt32()]") == TArray(TFloat32Optional) -> Some(IndexedSeq(1.0f)))
-    assert(evalWithType[Any]("[1.toFloat32()] - [1.toInt32()]") == TArray(TFloat32Optional) -> Some(IndexedSeq(0.0f)))
-    assert(evalWithType[Any]("[1.toFloat32()] / [1.toInt32()]") == TArray(TFloat32Optional) -> Some(IndexedSeq(1.0f)))
-
-    assert(evalWithType[Any]("[1.toFloat32()] + [1.toInt64()]") == TArray(TFloat32Optional) -> Some(IndexedSeq(2.0f)))
-    assert(evalWithType[Any]("[1.toFloat32()] * [1.toInt64()]") == TArray(TFloat32Optional) -> Some(IndexedSeq(1.0f)))
-    assert(evalWithType[Any]("[1.toFloat32()] - [1.toInt64()]") == TArray(TFloat32Optional) -> Some(IndexedSeq(0.0f)))
-    assert(evalWithType[Any]("[1.toFloat32()] / [1.toInt64()]") == TArray(TFloat32Optional) -> Some(IndexedSeq(1.0f)))
-
-    assert(evalWithType[Any]("1.toInt64() / 1.toInt64()") == TFloat32Optional -> Some(1.0f))
-    assert(evalWithType[Any]("[1.toInt64()] / [1.toInt64()]") == TArray(TFloat32Optional) -> Some(IndexedSeq(1.0f)))
+    assert(eval("isnan(0d)").contains(false))
+    assert(eval("isnan(NA: Float32)").isEmpty)
   }
 
   @Test def testParseTypes() {

--- a/src/test/scala/is/hail/methods/FilterSuite.scala
+++ b/src/test/scala/is/hail/methods/FilterSuite.scala
@@ -59,7 +59,7 @@ class FilterSuite extends SparkSuite {
 
     assert(vds2.filterEntries("g.AD[0] < 30").entriesTable().count() == 3)
 
-    assert(vds2.filterEntries("g.AD[1].toFloat64() / g.DP > 0.05f")
+    assert(vds2.filterEntries("g.AD[1] / g.DP > 0.05f")
         .entriesTable()
         .count() == 3)
 

--- a/src/test/scala/is/hail/methods/FilterSuite.scala
+++ b/src/test/scala/is/hail/methods/FilterSuite.scala
@@ -1,7 +1,7 @@
 package is.hail.methods
 
 import is.hail.testUtils._
-import is.hail.SparkSuite
+import is.hail.{SparkSuite, TestUtils}
 import org.testng.annotations.Test
 
 class FilterSuite extends SparkSuite {

--- a/src/test/scala/is/hail/methods/FilterSuite.scala
+++ b/src/test/scala/is/hail/methods/FilterSuite.scala
@@ -1,12 +1,7 @@
 package is.hail.methods
 
-import is.hail.annotations.Annotation
-import is.hail.expr._
-import is.hail.expr.types._
-import is.hail.io.annotators.IntervalList
-import is.hail.utils._
 import is.hail.testUtils._
-import is.hail.{SparkSuite, TestUtils}
+import is.hail.SparkSuite
 import org.testng.annotations.Test
 
 class FilterSuite extends SparkSuite {
@@ -32,9 +27,9 @@ class FilterSuite extends SparkSuite {
 
     assert(sQcVds.filterColsExpr("sa.qc.n_called == 337").numCols == 17)
 
-    assert(sQcVds.filterColsExpr("sa.qc.dp_mean > 60").numCols == 6)
+    assert(sQcVds.filterColsExpr("sa.qc.dp_mean > 60d").numCols == 6)
 
-    assert(sQcVds.filterColsExpr("if (\"^C1048\" ~ sa.s) {sa.qc.r_ti_tv > 3.5 && sa.qc.n_singleton < 10000000} else sa.qc.r_ti_tv > 3")
+    assert(sQcVds.filterColsExpr("if (\"^C1048\" ~ sa.s) {sa.qc.r_ti_tv > 3.5 && sa.qc.n_singleton < 10000000L} else sa.qc.r_ti_tv > 3d")
       .numCols == 16)
 
     val vQcVds = VariantQC(vds)
@@ -43,9 +38,9 @@ class FilterSuite extends SparkSuite {
 
     assert(vQcVds.filterRowsExpr("va.qc.n_hom_var > 0 && va.qc.n_het > 0").countRows() == 104)
 
-    assert(vQcVds.filterRowsExpr("va.qc.r_het_hom_var > 0").countRows() == 104)
+    assert(vQcVds.filterRowsExpr("va.qc.r_het_hom_var > 0d").countRows() == 104)
 
-    assert(vQcVds.filterRowsExpr("va.qc.r_het_hom_var >= 0").countRows() == 117)
+    assert(vQcVds.filterRowsExpr("va.qc.r_het_hom_var >= 0d").countRows() == 117)
 
     assert(vQcVds.filterRowsExpr("isMissing(va.qc.r_het_hom_var)", keep = false).countRows() == 117)
 
@@ -55,7 +50,7 @@ class FilterSuite extends SparkSuite {
     assert(!highGQ.entriesTable().exists("row.GQ < 20"))
     assert(highGQ.entriesTable().count() == 30889)
 
-    val highGQorMidQGAndLowFS = vds.filterEntries("g.GQ < 20 || (g.GQ < 30 && va.info.FS > 30)", keep = false)
+    val highGQorMidQGAndLowFS = vds.filterEntries("g.GQ < 20 || (g.GQ < 30 && va.info.FS > 30d)", keep = false)
       .expand()
       .collect()
 
@@ -64,7 +59,7 @@ class FilterSuite extends SparkSuite {
 
     assert(vds2.filterEntries("g.AD[0] < 30").entriesTable().count() == 3)
 
-    assert(vds2.filterEntries("g.AD[1].toFloat64() / g.DP > 0.05")
+    assert(vds2.filterEntries("g.AD[1].toFloat64() / g.DP > 0.05f")
         .entriesTable()
         .count() == 3)
 

--- a/src/test/scala/is/hail/methods/LinearMixedRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearMixedRegressionSuite.scala
@@ -428,7 +428,7 @@ class LinearMixedRegressionSuite extends SparkSuite {
       .annotateColsTable(covariates, root = "cov")
       .annotateColsTable(phenotypes, root = "pheno")
       .annotateColsExpr("""culprit = AGG.filter(g => va.locus.contig == "1" && va.locus.position == 1 && va.alleles == ["C", "T"]).map(g => g.GT.nNonRefAlleles()).collect()[0]""")
-      .annotateColsExpr("pheno.PhenoLMM = (1 + 0.1 * sa.cov.Cov1 * sa.cov.Cov2) * sa.culprit")
+      .annotateColsExpr("pheno.PhenoLMM = (1d + 0.1 * sa.cov.Cov1 * sa.cov.Cov2) * sa.culprit.toFloat64")
 
     val vdsKinship = vdsAssoc.filterRowsExpr("va.locus.position < 4")
 
@@ -491,7 +491,7 @@ class LinearMixedRegressionSuite extends SparkSuite {
   lazy val vdsSmall = vdsFromCallMatrix(hc)(TestUtils.unphasedDiploidGtIndicesToBoxedCall(smallMat))
     .annotateColsExpr("culprit = AGG.filter(g => va.locus.position == 2).map(g => g.GT.nNonRefAlleles()).collect()[0]")
     .annotateGlobal(randomNorms, TArray(TFloat64()), "randNorms")
-    .annotateColsExpr("pheno = sa.culprit + global.randNorms[sa.s.toInt32()]")
+    .annotateColsExpr("pheno = sa.culprit.toFloat64 + global.randNorms[sa.s.toInt32()]")
 
   lazy val vdsSmallRRM = ComputeRRM(vdsSmall)
   

--- a/src/test/scala/is/hail/methods/LinearRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearRegressionSuite.scala
@@ -38,7 +38,7 @@ class LinearRegressionSuite extends SparkSuite {
     val vds = hc.importVCF("src/test/resources/regressionLinear.vcf")
       .annotateColsTable(covariates, root = "cov")
       .annotateColsTable(phenotypes, root = "pheno")
-      .linreg(Array("sa.pheno.Pheno"), "g.GT.nNonRefAlleles()", Array("sa.cov.Cov1", "sa.cov.Cov2 + 1 - 1"))
+      .linreg(Array("sa.pheno.Pheno"), "g.GT.nNonRefAlleles()", Array("sa.cov.Cov1", "sa.cov.Cov2"))
     
     val a = vds.variantsAndAnnotations.collect().toMap
 
@@ -102,7 +102,7 @@ class LinearRegressionSuite extends SparkSuite {
     val vds = hc.importVCF("src/test/resources/regressionLinear.vcf")
       .annotateColsTable(covariates, root = "cov")
       .annotateColsTable(phenotypes, root = "pheno")
-      .linreg(Array("sa.pheno.Pheno"), "plDosage(g.PL)", Array("sa.cov.Cov1", "sa.cov.Cov2 + 1 - 1"))
+      .linreg(Array("sa.pheno.Pheno"), "plDosage(g.PL)", Array("sa.cov.Cov1", "sa.cov.Cov2"))
 
     val qBeta = vds.queryVA("va.linreg.beta")._2
     val qSe = vds.queryVA("va.linreg.standard_error")._2
@@ -159,7 +159,7 @@ class LinearRegressionSuite extends SparkSuite {
     val vds = hc.importGen("src/test/resources/regressionLinear.gen", "src/test/resources/regressionLinear.sample")
       .annotateColsTable(covariates, root = "cov")
       .annotateColsTable(phenotypes, root = "pheno")
-      .linreg(Array("sa.pheno.Pheno"), "dosage(g.GP)", Array("sa.cov.Cov1", "sa.cov.Cov2 + 1 - 1"))
+      .linreg(Array("sa.pheno.Pheno"), "dosage(g.GP)", Array("sa.cov.Cov1", "sa.cov.Cov2"))
 
     val qBeta = vds.queryVA("va.linreg.beta")._2
     val qSe = vds.queryVA("va.linreg.standard_error")._2

--- a/src/test/scala/is/hail/methods/PCASuite.scala
+++ b/src/test/scala/is/hail/methods/PCASuite.scala
@@ -14,9 +14,9 @@ object PCASuite {
     asArray: Boolean = false): (IndexedSeq[Double], DenseMatrix[Double], Option[Table]) = {
 
     val prePCA = vsm.annotateRowsExpr("AC = AGG.map(g => g.GT.nNonRefAlleles()).sum(), nCalled = AGG.filter(g => isDefined(g.GT)).count()")
-      .filterRowsExpr("va.AC > 0 && va.AC < 2 * va.nCalled").persist()
+      .filterRowsExpr("va.AC > 0 && va.AC.toInt64 < 2L * va.nCalled").persist()
     val nVariants = prePCA.countRows()
-    val expr = s"let mean = va.AC / va.nCalled in if (isDefined(g.GT)) (g.GT.nNonRefAlleles() - mean) / sqrt(mean * (2 - mean) * $nVariants / 2) else 0"
+    val expr = s"let mean = va.AC.toFloat64 / va.nCalled.toFloat64 in if (isDefined(g.GT)) (g.GT.nNonRefAlleles().toFloat64 - mean) / sqrt(mean * (2d - mean) * ${ nVariants }d / 2d) else 0d"
     
     PCA(prePCA, expr, k, computeLoadings, asArray)
   }

--- a/src/test/scala/is/hail/methods/SkatSuite.scala
+++ b/src/test/scala/is/hail/methods/SkatSuite.scala
@@ -168,7 +168,7 @@ class SkatSuite extends SparkSuite {
       .annotateRowsExpr("gene = va.locus.position % 3") // three genes
       .annotateRowsExpr("AF = AGG.map(g => g.GT).callStats(GT => va.alleles).AF")
       .annotateRowsExpr("weight = let af = if (va.AF[0] <= va.AF[1]) va.AF[0] else va.AF[1] in " +
-        "dbeta(af, 1.0, 25.0)**2")
+        "dbeta(af, 1.0, 25.0)**2d")
   }
 
   def hailVsRTest(useBN: Boolean = false, useDosages: Boolean = false, logistic: Boolean = false,

--- a/src/test/scala/is/hail/methods/TableSuite.scala
+++ b/src/test/scala/is/hail/methods/TableSuite.scala
@@ -86,7 +86,7 @@ class TableSuite extends SparkSuite {
   @Test def testAnnotate() {
     val inputFile = "src/test/resources/sampleAnnotations.tsv"
     val kt1 = hc.importTable(inputFile, impute = true).keyBy("Sample")
-    val kt2 = kt1.annotate("""qPhen2 = pow(row.qPhen, 2), NotStatus = row.Status == "CASE", X = row.qPhen == 5""")
+    val kt2 = kt1.annotate("""qPhen2 = pow(row.qPhen.toFloat64, 2d), NotStatus = row.Status == "CASE", X = row.qPhen == 5""")
     val kt3 = kt2.annotate("")
     val kt4 = kt3.select(kt3.fieldNames.map(n => s"row.$n")).keyBy("qPhen", "NotStatus")
 
@@ -383,7 +383,7 @@ class TableSuite extends SparkSuite {
     val statComb = localData.flatMap { ld => ld.qPhen }
       .aggregate(new StatCounter())({ case (sc, i) => sc.merge(i) }, { case (sc1, sc2) => sc1.merge(sc2) })
 
-    val Array(ktMean, ktStDev) = kt.query(Array("AGG.map(r => r.qPhen).stats().mean", "AGG.map(r => r.qPhen).stats().stdev")).map(_._1)
+    val Array(ktMean, ktStDev) = kt.query(Array("AGG.map(r => r.qPhen.toFloat64).stats().mean", "AGG.map(r => r.qPhen.toFloat64).stats().stdev")).map(_._1)
 
     assert(D_==(ktMean.asInstanceOf[Double], statComb.mean))
     assert(D_==(ktStDev.asInstanceOf[Double], statComb.stdev))

--- a/src/test/scala/is/hail/stats/FisherExactTestSuite.scala
+++ b/src/test/scala/is/hail/stats/FisherExactTestSuite.scala
@@ -101,16 +101,16 @@ class FisherExactTestSuite extends SparkSuite {
           .annotateColsExpr("pheno = sa.pheno.Pheno1")
           .annotateRowsExpr(
             """macCase = AGG.filter(g => sa.pheno == "ADHD" && g.GT.isHet()).count() +
-              |2 * AGG.filter(g => sa.pheno == "ADHD" && g.GT.isHomVar()).count()""".stripMargin)
+              |2L * AGG.filter(g => sa.pheno == "ADHD" && g.GT.isHomVar()).count()""".stripMargin)
           .annotateRowsExpr(
             """majCase = AGG.filter(g => sa.pheno == "ADHD" && g.GT.isHet()).count() +
-              |2 * AGG.filter(g => sa.pheno == "ADHD" && g.GT.isHomRef()).count()""".stripMargin)
+              |2L * AGG.filter(g => sa.pheno == "ADHD" && g.GT.isHomRef()).count()""".stripMargin)
           .annotateRowsExpr(
             """macControl = AGG.filter(g => sa.pheno == "Control" && g.GT.isHet()).count() +
-              |2 * AGG.filter(g => sa.pheno == "ADHD" && g.GT.isHomVar()).count()""".stripMargin)
+              |2L * AGG.filter(g => sa.pheno == "ADHD" && g.GT.isHomVar()).count()""".stripMargin)
           .annotateRowsExpr(
             """majControl = AGG.filter(g => sa.pheno == "Control" && g.GT.isHet()).count() +
-              |2 * AGG.filter(g => sa.pheno == "ADHD" && g.GT.isHomRef()).count()""".stripMargin)
+              |2L * AGG.filter(g => sa.pheno == "ADHD" && g.GT.isHomRef()).count()""".stripMargin)
           .annotateRowsExpr(
             """fet = fet(va.macCase.toInt32(), va.majCase.toInt32(), va.macControl.toInt32(), va.majControl.toInt32())""")
 

--- a/src/test/scala/is/hail/stats/InbreedingCoefficientSuite.scala
+++ b/src/test/scala/is/hail/stats/InbreedingCoefficientSuite.scala
@@ -42,7 +42,7 @@ class InbreedingCoefficientSuite extends SparkSuite {
       forAll(plinkSafeBiallelicVDS) { case (vds: MatrixTable) =>
 
         val vds2 = VariantQC(vds)
-          .filterRowsExpr("va.qc.AC > 1 && va.qc.AF >= 1e-8 && va.qc.n_called * 2 - va.qc.AC > 1 && va.qc.AF <= 1 - 1e-8")
+          .filterRowsExpr("va.qc.AC > 1 && va.qc.AF >= 1e-8 && va.qc.n_called * 2 - va.qc.AC > 1 && va.qc.AF <= 1d - 1e-8")
 
         if (vds2.numCols < 5 || vds2.countRows() < 5) {
           true

--- a/src/test/scala/is/hail/variant/vsm/GroupBySuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/GroupBySuite.scala
@@ -93,7 +93,7 @@ class GroupBySuite extends SparkSuite {
 
     val vdsGrouped = vds.explodeRows("va.genes")
       .keyRowsBy(Array("genes"), Array("genes"))
-      .aggregateRowsByKey("sum = AGG.map(g => va.weight * g.GT.nNonRefAlleles()).sum()")
+      .aggregateRowsByKey("sum = AGG.map(g => va.weight * g.GT.nNonRefAlleles().toFloat64).sum()")
       .annotateColsExpr("pheno = sa.pheno.Pheno")
 
     val resultsVSM = vdsGrouped.linreg(Array("sa.pheno"), "g.sum", covExpr = Array("sa.cov.Cov1", "sa.cov.Cov2"))

--- a/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
@@ -125,7 +125,7 @@ class VSMSuite extends SparkSuite {
 
   @Test def testQueryGenotypes() {
     val vds = hc.importVCF("src/test/resources/sample.vcf.bgz")
-    vds.queryEntries("AGG.map(g => g.GQ).hist(0, 100, 100)")
+    vds.queryEntries("AGG.map(g => g.GQ.toFloat64).hist(0d, 100d, 100)")
   }
 
   @Test def testReorderSamples() {
@@ -154,11 +154,11 @@ class VSMSuite extends SparkSuite {
         .indexRows("rowIdx")
         .indexCols("colIdx")
       
-      mt.selectEntries("x = g.GT.nNonRefAlleles() + va.rowIdx + sa.colIdx + 1")
+      mt.selectEntries("x = g.GT.nNonRefAlleles().toInt64 + va.rowIdx + sa.colIdx.toInt64 + 1L")
         .writeBlockMatrix(dirname, "x", blockSize)
 
       val data = mt.entriesTable()
-          .select("x = row.GT.nNonRefAlleles() + row.rowIdx + row.colIdx + 1.0")
+          .select("x = row.GT.nNonRefAlleles().toFloat64 + row.rowIdx.toFloat64 + row.colIdx.toFloat64 + 1.0")
           .collect()
           .map(_.getAs[Double](0))
 


### PR DESCRIPTION
Remove conversions from the function registry.  They are now inserted by Python and explicit in the expression language.

This should simplify lots of stuff on the back end.
