### PR TITLE
changed blockMap2 from join to zipPartitions

### DIFF
--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -253,7 +253,7 @@ class PCRelate(maf: Double, blockSize: Int) extends Serializable {
         g - mu * 2.0
     } (g, mu)
 
-    val stddev = variance.map(math.sqrt)
+    val stddev = variance.sqrt()
 
     (gram(centeredG) /:/ gram(stddev)) / 4.0
   }

--- a/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
@@ -10,8 +10,7 @@ import is.hail.utils._
 import org.json4s.jackson
 
 object RichDenseMatrixDouble {
-  // assumes zero offset and minimal majorStride
-  // caller must close
+  // assumes data isCompact, caller must close
   def read(is: InputStream, bufferSpec: BufferSpec): DenseMatrix[Double] = {
     val in = bufferSpec.buildInputBuffer(is)
     

--- a/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
@@ -788,9 +788,9 @@ class BlockMatrixSuite extends SparkSuite {
   
   @Test
   def testPowSqrt(): Unit = {
-    val lm = new BDM[Double](2, 3, Array(0.0, 1.0, 4.0, 9.0, 16.0, 25.0, 36.0))
+    val lm = new BDM[Double](2, 3, Array(0.0, 1.0, 4.0, 9.0, 16.0, 25.0))
     val bm = BlockMatrix.fromBreezeMatrix(sc, lm, blockSize = 2)
-    val expected = new BDM[Double](2, 3, Array(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0))
+    val expected = new BDM[Double](2, 3, Array(0.0, 1.0, 2.0, 3.0, 4.0, 5.0))
     
     TestUtils.assertMatrixEqualityDouble(bm.pow(0.0).toBreezeMatrix(), BDM.fill(2, 3)(1.0))
     TestUtils.assertMatrixEqualityDouble(bm.pow(0.5).toBreezeMatrix(), expected)


### PR DESCRIPTION
Also changed `assertCompatibleLocalMatrix` to used `isCompact`, which is the intended condition. The current one doesn't rule out extra trailing values in data.