### PR TITLE
deforest filter, map, range, arrayfold

### DIFF
--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -2048,11 +2048,10 @@ def split_multi_hts(ds, keep_star=False, left_aligned=False):
         AD=hl.or_missing(hl.is_defined(ds.AD),
                          [hl.sum(ds.AD) - ds.AD[sm.a_index()], ds.AD[sm.a_index()]]),
         DP=ds.DP,
-        PL=pl,
-        GQ=hl.gq_from_pl(pl)
+        GQ=hl.gq_from_pl(pl),
+        PL=pl
     )
-    split = sm.result()
-    return split#.annotate_entries(GQ=hl.gq_from_pl(split.PL))
+    return sm.result()
 
 
 @typecheck(dataset=MatrixTable)

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -2048,10 +2048,11 @@ def split_multi_hts(ds, keep_star=False, left_aligned=False):
         AD=hl.or_missing(hl.is_defined(ds.AD),
                          [hl.sum(ds.AD) - ds.AD[sm.a_index()], ds.AD[sm.a_index()]]),
         DP=ds.DP,
-        PL=pl
+        PL=pl,
+        GQ=hl.gq_from_pl(pl)
     )
     split = sm.result()
-    return split.annotate_entries(GQ=hl.gq_from_pl(split.PL))
+    return split#.annotate_entries(GQ=hl.gq_from_pl(split.PL))
 
 
 @typecheck(dataset=MatrixTable)

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -6,12 +6,10 @@ import is.hail.annotations.aggregators._
 import is.hail.expr.ir.functions.IRFunction
 import is.hail.expr.types._
 import is.hail.utils._
-import org.objectweb.asm.tree._
 
 import scala.collection.mutable
 import scala.language.existentials
 import scala.language.postfixOps
-import scala.reflect.ClassTag
 
 object Emit {
   type E = Env[(TypeInfo[_], Code[Boolean], Code[_])]

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -14,6 +14,8 @@ import scala.language.postfixOps
 object Emit {
   type E = Env[(TypeInfo[_], Code[Boolean], Code[_])]
 
+  type F = (Code[Boolean], Code[_]) => Code[Unit]
+
   private[ir] def toCode(ir: IR, fb: FunctionBuilder[_], nSpecialArguments: Int): (Code[Unit], Code[Boolean], Code[_]) = {
     emit(ir, fb, Env.empty, new StagedBitSet(fb), None, nSpecialArguments)
   }
@@ -32,10 +34,11 @@ object Emit {
 
   private def apply(ir: IR, fb: FunctionBuilder[_], tAggIn: Option[TAggregable], nSpecialArguments: Int) {
     val (dov, mv, vv) = emit(ir, fb, Env.empty, new StagedBitSet(fb), tAggIn, nSpecialArguments)
-    typeToTypeInfo(ir.typ) match { case ti: TypeInfo[t] =>
-      fb.emit(Code(dov, mv.mux(
-        Code._throw(Code.newInstance[RuntimeException, String]("cannot return empty")),
-        coerce[t](vv))))
+    typeToTypeInfo(ir.typ) match {
+      case ti: TypeInfo[t] =>
+        fb.emit(Code(dov, mv.mux(
+          Code._throw(Code.newInstance[RuntimeException, String]("cannot return empty")),
+          coerce[t](vv))))
     }
   }
 
@@ -55,10 +58,11 @@ private class Emit(
   mb: StagedBitSet,
   tAggInOpt: Option[TAggregable],
   nSpecialArguments: Int) {
-  
+
   val methods: mutable.Map[IRFunction, MethodBuilder] = mutable.Map()
 
   import Emit.E
+  import Emit.F
 
   /**
     * Invariants of the Returned Triplet
@@ -77,36 +81,39 @@ private class Emit(
     * -------------------
     *
     * {@code In(i)} occupies two argument slots, one for the value and one for a
-    * missing bit. The value for {@code In(0)} is passed as argument
-    * {@code nSpecialArguments + 1}. The missingness bit is the subsequent
-    * argument. In general, the value for {@code In(i)} appears at
-    * {@code nSpecialArguments + 1 + 2 * i}.
+    * missing bit. The value for {@code  In(0)} is passed as argument
+    * {@code  nSpecialArguments + 1}. The missingness bit is the subsequent
+    * argument. In general, the value for {@code  In(i)} appears at
+    * {@code  nSpecialArguments + 1 + 2 * i}.
     *
-    * There must always be at least one special argument: a {@code Region} in
+    * There must always be at least one special argument: a {@code  Region} in
     * which the IR can allocate memory.
     *
     * Aggregating expressions must have at least two special arguments. As with
-    * all expressions, the first argument must be a {@code Region}. The second
-    * argument is the {@code RegionValueAggregator} that implements the
-    * functionality of the (unique) {@code AggOp} in the expression. Note that
+    * all expressions, the first argument must be a {@code  Region}. The second
+    * argument is the {@code  RegionValueAggregator} that implements the
+    * functionality of the (unique) {@code  AggOp} in the expression. Note that
     * the special arguments do not appear in pairs, i.e., they may not be
     * missing.
     *
     * An aggregating expression additionally has an element argument and a
     * number of "scope" argmuents following the special arguments. The type of
-    * the element is {@code tAggIn.elementType}. The number and types of the
-    * scope arguments are defined by the symbol table of {@code tAggIn}. The
+    * the element is {@code  tAggIn.elementType}. The number and types of the
+    * scope arguments are defined by the symbol table of {@code  tAggIn}. The
     * element argument and the scope arguments, unlike special arguments, appear
     * in pairs of a value and a missingness bit. Moreover, the element argument
     * must appear first.
     *
     **/
   private def emit(ir: IR, env: E): (Code[Unit], Code[Boolean], Code[_]) = {
+
     def emit(ir: IR, env: E = env): (Code[Unit], Code[Boolean], Code[_]) =
       this.emit(ir, env)
+
     def emitAgg(ir: IR, env: E = env)(k: (Code[_], Code[Boolean]) => Code[Unit]): Code[Unit] =
       this.emitAgg(ir, aggEnv)(k)
-    def emitArrayIterator(ir: IR, env: E = env)(c: (Code[Boolean], Code[_]) => Code[Unit]) = this.emitArrayIterator(ir, env)(c)
+
+    def emitArrayIterator(ir: IR, env: E = env) = this.emitArrayIterator(ir, env)
 
     val region = fb.getArg[Region](1).load()
     lazy val aggregator = {
@@ -266,69 +273,61 @@ private class Emit(
       case ArrayLen(a) =>
         val (doa, ma, va) = emit(a)
         (doa, ma, TContainer.loadLength(region, coerce[Long](va)))
-      case x@ArrayRange(startir, stopir, stepir) =>
-        val srvb = new StagedRegionValueBuilder(fb, x.typ)
-        val (d, m, v) = Array(emit(startir), emit(stopir), emit(stepir)).unzip3
-        val start = fb.newLocal[Int]("ar_start")
-        val stop = fb.newLocal[Int]("ar_stop")
-        val step = fb.newLocal[Int]("ar_step")
 
-        val i = fb.newLocal[Int]("ar_i")
-        val len = fb.newLocal[Int]("ar_len")
-        val llen = fb.newLocal[Long]("ar_llen")
-        (coerce[Unit](Code(d: _*)), m.reduce(_ || _), Code(
-          start := coerce[Int](v(0)),
-          stop := coerce[Int](v(1)),
-          step := coerce[Int](v(2)),
-          step.ceq(0).mux(
-            Code._fatal("Array range cannot have step size 0."),
-            Code._empty[Unit]),
-          llen := start.ceq(stop).mux(0L,
-            (step < 0).mux(
-              (start.toL - stop.toL - 1L) / (-step).toL + 1L,
-              (stop.toL - start.toL - 1L) / step.toL + 1L)),
-          (llen > const(Int.MaxValue.toLong)).mux(
-            Code._fatal("Array range cannot have more than MAXINT elements."),
-            len := (llen < 0L).mux(0L, llen).toI),
-          srvb.start(len, init = true),
-          i := 0,
-          Code.whileLoop(i < len,
-            srvb.addInt(start),
-            srvb.advance(),
-            i := i + 1,
-            start := start + step),
-          srvb.offset))
-
-      case _: ArrayMap | _: ArrayFilter =>
+      case _: ArrayMap | _: ArrayFilter | _: ArrayRange =>
 
         val elt = coerce[TArray](ir.typ).elementType
-        val len = fb.newLocal[Int]
-        val i = fb.newLocal[Int]
         val srvb = new StagedRegionValueBuilder(fb, ir.typ)
-        val mab = new StagedArrayBuilder(TBoolean(), fb.apply_method)
-        val vab = new StagedArrayBuilder(elt, fb.apply_method)
 
-        val cont = { (m: Code[Boolean], v: Code[_]) =>
-          coerce[Unit](Code(mab.add(m), vab.add(v)))
+        val (calcLength, optLength, f) = emitArrayIterator(ir)
+        optLength match {
+          case Some(len) =>
+            val cont = { (m: Code[Boolean], v: Code[_]) =>
+              coerce[Unit](
+                Code(
+                  m.mux(
+                    srvb.setMissing(),
+                    srvb.addIRIntermediate(elt)(v)),
+                  srvb.advance()))
+            }
+            val (d, m, addElts) = f(cont)
+            (d, m, Code(
+              calcLength,
+              srvb.start(len, init = true),
+              addElts,
+              srvb.offset
+            ))
+
+          case None =>
+            val len = fb.newLocal[Int]
+            val i = fb.newLocal[Int]
+            val mab = new StagedArrayBuilder(TBoolean(), fb.apply_method)
+            val vab = new StagedArrayBuilder(elt, fb.apply_method)
+            fb.emit(mab.create(16))
+            fb.emit(vab.create(16))
+
+            val cont = { (m: Code[Boolean], v: Code[_]) =>
+              coerce[Unit](Code(mab.add(m), vab.add(v)))
+            }
+
+            val (d, m, popAB) = f(cont)
+            (d, m, Code(
+              mab.clear,
+              vab.clear,
+              calcLength,
+              popAB,
+              len := mab.size,
+              srvb.start(len, init = true),
+              i := 0,
+              Code.whileLoop(i < len,
+                coerce[Boolean](mab(i)).mux(
+                  srvb.setMissing(),
+                  srvb.addIRIntermediate(elt)(vab(i))),
+                i := i + 1,
+                srvb.advance()),
+              srvb.offset
+            ))
         }
-
-        val (d, m, popAB) = emitArrayIterator(ir)(cont)
-
-        (d, m, Code(
-          mab.create(16),
-          vab.create(16),
-          popAB,
-          len := mab.size,
-          srvb.start(len, init=true),
-          i := 0,
-          Code.whileLoop(i < len,
-            coerce[Boolean](mab(i)).mux(
-              srvb.setMissing(),
-              srvb.addIRIntermediate(elt)(vab(i))),
-            i := i + 1,
-            srvb.advance()),
-          srvb.offset
-        ))
 
       case ArrayFold(a, zero, name1, name2, body, typ) =>
         val tarray = coerce[TArray](a.typ)
@@ -347,6 +346,8 @@ private class Emit(
         val (dozero, mzero, vzero) = emit(zero)
         val (dobody, mbody, vbody) = emit(body, env = bodyenv)
 
+        val (calcLength, _, f) = emitArrayIterator(a)
+
         val cont = { (m: Code[Boolean], v: Code[_]) =>
           Code(
             xmv := m,
@@ -356,7 +357,7 @@ private class Emit(
             xvout := xmout.mux(defaultValue(typ), vbody))
         }
 
-        val (doa, ma, va) = emitArrayIterator(a)(cont)
+        val (doa, ma, va) = f(cont)
 
         (Code(
           doa,
@@ -368,6 +369,7 @@ private class Emit(
               dozero,
               xmout := mzero,
               xvout := xmout.mux(defaultValue(typ), vzero),
+              calcLength,
               va,
               xmout)),
           xvout := xmout.mux(defaultValue(typ), xvout)
@@ -386,7 +388,8 @@ private class Emit(
             Code(
               dov,
               mv.mux(srvb.setMissing(), srvb.addIRIntermediate(t)(vv)),
-              srvb.advance()) }: _*),
+              srvb.advance())
+          }: _*),
           srvb.offset))
       case x@InsertFields(old, fields, _) =>
         old.typ match {
@@ -426,7 +429,8 @@ private class Emit(
                 Code(
                   dov,
                   mv.mux(srvb.setMissing(), srvb.addIRIntermediate(t)(vv)),
-                  srvb.advance()) }: _*),
+                  srvb.advance())
+              }: _*),
               srvb.offset))
           case _ =>
             val newIR = MakeStruct(fields)
@@ -462,7 +466,8 @@ private class Emit(
             Code(
               dov,
               mv.mux(srvb.setMissing(), srvb.addIRIntermediate(t)(vv)),
-              srvb.advance()) }: _*),
+              srvb.advance())
+          }: _*),
           srvb.offset))
       case GetTupleElement(o, idx, _) =>
         val t = coerce[TTuple](o.typ)
@@ -485,7 +490,7 @@ private class Emit(
           fb.getArg[Boolean](normalArgumentPosition(i) + 1),
           fb.getArg(normalArgumentPosition(i))(typeToTypeInfo(typ)))
       case InMissingness(i) =>
-        present(fb.getArg[Boolean](i*2 + 3))
+        present(fb.getArg[Boolean](i * 2 + 3))
       case Die(m) =>
         present(Code._throw(Code.newInstance[RuntimeException, String](m)))
       case ApplyFunction(impl, args) =>
@@ -500,7 +505,7 @@ private class Emit(
         val (s, m, v) = args.map(emit(_)).unzip3
         val vars = args.map { a => coerce[Any](fb.newLocal()(typeToTypeInfo(a.typ))) }
         val ins = vars.zip(v).map { case (l, i) => l := i }
-        val setup = coerce[Unit](Code(s:_*))
+        val setup = coerce[Unit](Code(s: _*))
         val missing = if (m.isEmpty) const(false) else m.reduce(_ || _)
         val value = Code(ins :+ meth.invoke(fb.getArg[Region](1).load() +: vars.map { a => a.load() }: _*): _*)
         (setup, missing, value)
@@ -510,6 +515,7 @@ private class Emit(
   private def emitAgg(ir: IR, env: E)(continuation: (Code[_], Code[Boolean]) => Code[Unit]): Code[Unit] = {
     def emit(ir: IR, env: E = env): (Code[Unit], Code[Boolean], Code[_]) =
       this.emit(ir, env)
+
     def emitAgg(ir: IR)(continuation: (Code[_], Code[Boolean]) => Code[Unit]): Code[Unit] =
       this.emitAgg(ir, env)(continuation)
 
@@ -537,7 +543,8 @@ private class Emit(
             mx := mv,
             x := mx.mux(defaultValue(tElement), v),
             dobody,
-            continuation(vbody, mbody)) }
+            continuation(vbody, mbody))
+        }
       case AggFilter(a, name, body, typ) =>
         val tElement = coerce[TAggregable](a.typ).elementType
         val elementTi = typeToTypeInfo(tElement)
@@ -550,7 +557,8 @@ private class Emit(
             x := mx.mux(defaultValue(tElement), v),
             dobody,
             // missing is false
-            (!mbody && coerce[Boolean](vbody)).mux(continuation(x, mx), Code._empty)) }
+            (!mbody && coerce[Boolean](vbody)).mux(continuation(x, mx), Code._empty))
+        }
       case AggFlatMap(a, name, body, typ) =>
         val tA = coerce[TAggregable](a.typ)
         val tElement = tA.elementType
@@ -577,7 +585,8 @@ private class Emit(
                   continuation(
                     region.loadIRIntermediate(tArray.elementType)(tArray.loadElement(region, arr, i)),
                     tArray.isElementMissing(region, arr, i)),
-                  i ++)))) }
+                  i ++))))
+        }
       case _: ApplyAggOp =>
         throw new RuntimeException(s"No nested aggregations allowed: $ir")
       case In(_, _) | InMissingness(_) =>
@@ -587,10 +596,11 @@ private class Emit(
     }
   }
 
-  private def emitArrayIterator(ir: IR, env: E)(continuation: (Code[Boolean], Code[_]) => Code[Unit]): (Code[Unit], Code[Boolean], Code[Unit]) = {
+  private def emitArrayIterator(ir: IR, env: E): (Code[Unit], Option[Code[Int]], F => (Code[Unit], Code[Boolean], Code[Unit])) = {
+
     def emit(ir: IR, env: E = env) = this.emit(ir, env)
 
-    def emitArrayIterator(ir: IR, env: E = env)(c: (Code[Boolean], Code[_]) => Code[Unit]) = this.emitArrayIterator(ir, env)(c)
+    def emitArrayIterator(ir: IR, env: E = env) = this.emitArrayIterator(ir, env)
 
     val region = fb.getArg[Region](1).load()
 
@@ -604,7 +614,8 @@ private class Emit(
         val i = fb.newLocal[Int]("ar_i")
         val len = fb.newLocal[Int]("ar_len")
         val llen = fb.newLocal[Long]("ar_llen")
-        (coerce[Unit](Code(d: _*)), m.reduce(_ || _), Code(
+
+        val calcLength = Code(
           start := coerce[Int](v(0)),
           stop := coerce[Int](v(1)),
           step := coerce[Int](v(2)),
@@ -617,12 +628,17 @@ private class Emit(
               (stop.toL - start.toL - 1L) / step.toL + 1L)),
           (llen > const(Int.MaxValue.toLong)).mux(
             Code._fatal("Array range cannot have more than MAXINT elements."),
-            len := (llen < 0L).mux(0L, llen).toI),
-          i := 0,
-          Code.whileLoop(i < len,
-            continuation(false, i),
-            i := i + 1,
-            start := start + step)))
+            len := (llen < 0L).mux(0L, llen).toI)
+        )
+
+        (calcLength ,Some(len.load()), { continuation: F =>
+          (coerce[Unit](Code(d: _*)), m.reduce(_ || _), Code(
+            i := 0,
+            Code.whileLoop(i < len,
+              continuation(false, start),
+              i := i + 1,
+              start := start + step)))
+        })
       case x@ArrayFilter(a, name, condition) =>
         val elementTypeInfoA = coerce[Any](typeToTypeInfo(x.typ.elementType))
         val xmv = mb.newBit()
@@ -630,16 +646,17 @@ private class Emit(
         val condenv = env.bind(name -> (elementTypeInfoA, xmv, xvv))
         val (docond, mcond, vcond) = emit(condition, condenv)
 
-        val filterCont = {(m: Code[Boolean], v: Code[_]) =>
+        val filterCont = { (cont: F, m: Code[Boolean], v: Code[_]) =>
           Code(
             xmv := m,
             xvv := v,
             docond,
             (xmv || mcond || !coerce[Boolean](vcond)).mux(
               Code._empty,
-              continuation(false, xvv)))
+              cont(false, xvv)))
         }
-        emitArrayIterator(a)(filterCont)
+        val (cl, _, f) = emitArrayIterator(a)
+        (cl, None, { cont: F => f(filterCont(cont, _, _)) })
 
       case x@ArrayMap(a, name, body, _) =>
         val elementTypeInfoA = coerce[Any](typeToTypeInfo(x.typ.elementType))
@@ -647,14 +664,15 @@ private class Emit(
         val xvv = fb.newLocal(name)(elementTypeInfoA)
         val bodyenv = env.bind(name -> (elementTypeInfoA, xmv, xvv))
         val (dobody, mbody, vbody) = emit(body, bodyenv)
-        val mapCont = {(m: Code[Boolean], v: Code[_]) =>
+        val mapCont = { (continuation: F, m: Code[Boolean], v: Code[_]) =>
           Code(
             xmv := m,
             xvv := v,
             dobody,
             continuation(mbody, vbody))
         }
-        emitArrayIterator(a)(mapCont)
+        val (cl, l, f) = emitArrayIterator(a)
+        (cl, l, { cont: F => f(mapCont(cont, _, _)) })
 
       case _ =>
         val t: TArray = coerce[TArray](ir.typ)
@@ -663,15 +681,18 @@ private class Emit(
         val len = fb.newLocal[Int]("len")
         val aoff = fb.newLocal[Long]("aoff")
         val (setup, m, v) = emit(ir, env)
-        (setup, m, Code(
+        val calcLength = Code(
           aoff := coerce[Long](v),
-          len := t.loadLength(region, aoff),
-          srvb.start(len, init = true),
-          i := 0,
-          Code.whileLoop(i < len,
-            continuation(t.isElementMissing(region, aoff, i),
-              region.loadIRIntermediate(t.elementType)(t.loadElement(region, aoff, i))),
-            i := i + 1)))
+    len := t.loadLength(region, aoff))
+        (calcLength, Some(len.load()), { continuation: F =>
+          (setup, m, Code(
+            srvb.start(len, init = true),
+            i := 0,
+            Code.whileLoop(i < len,
+              continuation(t.isElementMissing(region, aoff, i),
+                region.loadIRIntermediate(t.elementType)(t.loadElement(region, aoff, i))),
+              i := i + 1)))
+        })
     }
   }
 
@@ -681,10 +702,12 @@ private class Emit(
   private lazy val aggEnv: E = {
     val scopeOffset = nSpecialArguments + 2 // element and element missingness
     Env.empty.bind(tAggInOpt.get.bindings.zipWithIndex
-      .map { case ((n, t), i) => n -> ((
-        typeToTypeInfo(t),
-        fb.getArg[Boolean](scopeOffset + i*2 + 2).load(),
-        fb.getArg(scopeOffset + i*2 + 1)(typeToTypeInfo(t)).load())) }: _*)
+      .map {
+        case ((n, t), i) => n -> ((
+          typeToTypeInfo(t),
+          fb.getArg[Boolean](scopeOffset + i * 2 + 2).load(),
+          fb.getArg(scopeOffset + i * 2 + 1)(typeToTypeInfo(t)).load()))
+      }: _*)
   }
 
   private def normalArgumentPosition(idx: Int): Int = {

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -659,7 +659,7 @@ private class Emit(
         (cl, None, { cont: F => f(filterCont(cont, _, _)) })
 
       case x@ArrayMap(a, name, body, _) =>
-        val elementTypeInfoA = coerce[Any](typeToTypeInfo(x.typ.elementType))
+        val elementTypeInfoA = coerce[Any](typeToTypeInfo(coerce[TArray](a.typ).elementType))
         val xmv = mb.newBit()
         val xvv = fb.newLocal(name)(elementTypeInfoA)
         val bodyenv = env.bind(name -> (elementTypeInfoA, xmv, xvv))

--- a/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
+++ b/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
@@ -53,6 +53,14 @@ class StagedArrayBuilder(elt: Type, mb: MethodBuilder) {
     case DoubleInfo => coerce[DoubleArrayBuilder](ref).invoke[Int]("size")
   }
 
+  def clear: Code[Unit] = ti match {
+    case BooleanInfo => coerce[BooleanArrayBuilder](ref).invoke[Unit]("clear")
+    case IntInfo => coerce[IntArrayBuilder](ref).invoke[Unit]("clear")
+    case LongInfo => coerce[LongArrayBuilder](ref).invoke[Unit]("clear")
+    case FloatInfo => coerce[FloatArrayBuilder](ref).invoke[Unit]("clear")
+    case DoubleInfo => coerce[DoubleArrayBuilder](ref).invoke[Unit]("clear")
+  }
+
 }
 
 class ByteArrayBuilder(initialCapacity: Int) {
@@ -107,6 +115,8 @@ class IntArrayBuilder(initialCapacity: Int) {
     b(size_) = x
     size_ += 1
   }
+
+  def clear() {  size_ = 0 }
 }
 
 class LongArrayBuilder(initialCapacity: Int) {
@@ -134,6 +144,8 @@ class LongArrayBuilder(initialCapacity: Int) {
     b(size_) = x
     size_ += 1
   }
+
+  def clear() {  size_ = 0 }
 }
 
 class FloatArrayBuilder(initialCapacity: Int) {
@@ -161,6 +173,8 @@ class FloatArrayBuilder(initialCapacity: Int) {
     b(size_) = x
     size_ += 1
   }
+
+  def clear() {  size_ = 0 }
 }
 
 class DoubleArrayBuilder(initialCapacity: Int) {
@@ -188,6 +202,8 @@ class DoubleArrayBuilder(initialCapacity: Int) {
     b(size_) = x
     size_ += 1
   }
+
+  def clear() {  size_ = 0 }
 }
 
 class BooleanArrayBuilder(initialCapacity: Int) {
@@ -215,4 +231,6 @@ class BooleanArrayBuilder(initialCapacity: Int) {
     b(size_) = x
     size_ += 1
   }
+
+  def clear() {  size_ = 0 }
 }

--- a/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
+++ b/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
@@ -1,0 +1,220 @@
+package is.hail.expr.ir
+
+import is.hail.asm4s._
+import is.hail.expr.types.Type
+
+object StagedArrayBuilder {
+  def newLocalRef(elt: Type, mb: MethodBuilder): LocalRef[_] = typeToTypeInfo(elt) match {
+    case BooleanInfo => mb.newLocal[BooleanArrayBuilder]("zab")
+    case IntInfo => mb.newLocal[IntArrayBuilder]("iab")
+    case LongInfo => mb.newLocal[LongArrayBuilder]("jab")
+    case FloatInfo => mb.newLocal[FloatArrayBuilder]("fab")
+    case DoubleInfo => mb.newLocal[DoubleArrayBuilder]("dab")
+    case ti => throw new RuntimeException(s"unsupported type found: $elt whose type info is $ti")
+  }
+
+  def getNewInstance(elt: Type, len: Code[Int]): Code[_] = typeToTypeInfo(elt) match {
+    case BooleanInfo => Code.newInstance[BooleanArrayBuilder, Int](len)
+    case IntInfo => Code.newInstance[IntArrayBuilder, Int](len)
+    case LongInfo => Code.newInstance[LongArrayBuilder, Int](len)
+    case FloatInfo => Code.newInstance[FloatArrayBuilder, Int](len)
+    case DoubleInfo => Code.newInstance[DoubleArrayBuilder, Int](len)
+    case ti => throw new RuntimeException(s"unsupported type found: $elt whose type info is $ti")
+  }
+}
+
+class StagedArrayBuilder(elt: Type, mb: MethodBuilder) {
+
+  val ti = typeToTypeInfo(elt)
+
+  val ref: LocalRef[Any] = coerce[Any](StagedArrayBuilder.newLocalRef(elt, mb))
+
+  def create(len: Code[Int]): Code[Unit] = ref := StagedArrayBuilder.getNewInstance(elt, len)
+
+  def add(i: Code[_]): Code[Unit] = ti match {
+    case BooleanInfo => coerce[BooleanArrayBuilder](ref).invoke[Boolean, Unit]("add", coerce[Boolean](i))
+    case IntInfo => coerce[IntArrayBuilder](ref).invoke[Int, Unit]("add", coerce[Int](i))
+    case LongInfo => coerce[LongArrayBuilder](ref).invoke[Long, Unit]("add", coerce[Long](i))
+    case FloatInfo => coerce[FloatArrayBuilder](ref).invoke[Float, Unit]("add", coerce[Float](i))
+    case DoubleInfo => coerce[DoubleArrayBuilder](ref).invoke[Double, Unit]("add", coerce[Double](i))
+  }
+
+  def apply(i: Code[Int]): Code[_] = ti match {
+    case BooleanInfo => coerce[BooleanArrayBuilder](ref).invoke[Int, Boolean]("apply", i)
+    case IntInfo => coerce[IntArrayBuilder](ref).invoke[Int, Int]("apply", i)
+    case LongInfo => coerce[LongArrayBuilder](ref).invoke[Int, Long]("apply", i)
+    case FloatInfo => coerce[FloatArrayBuilder](ref).invoke[Int, Float]("apply", i)
+    case DoubleInfo => coerce[DoubleArrayBuilder](ref).invoke[Int, Double]("apply", i)
+  }
+
+  def size: Code[Int] = ti match {
+    case BooleanInfo => coerce[BooleanArrayBuilder](ref).invoke[Int]("size")
+    case IntInfo => coerce[IntArrayBuilder](ref).invoke[Int]("size")
+    case LongInfo => coerce[LongArrayBuilder](ref).invoke[Int]("size")
+    case FloatInfo => coerce[FloatArrayBuilder](ref).invoke[Int]("size")
+    case DoubleInfo => coerce[DoubleArrayBuilder](ref).invoke[Int]("size")
+  }
+
+}
+
+class ByteArrayBuilder(initialCapacity: Int) {
+  private var b: Array[Byte] = new Array[Byte](initialCapacity)
+  private var size_ : Int = 0
+
+  def size: Int = size_
+
+  def apply(i: Int): Byte = {
+    require(i >= 0 && i < size)
+    b(i)
+  }
+
+  def ensureCapacity(n: Int) {
+    if (b.length < n) {
+      val newCapacity = (b.length * 2).max(n)
+      val newb = new Array[Byte](newCapacity)
+      Array.copy(b, 0, newb, 0, size_)
+      b = newb
+    }
+  }
+
+  def add(x: Byte) {
+    ensureCapacity(size_ + 1)
+    b(size_) = x
+    size_ += 1
+  }
+}
+
+class IntArrayBuilder(initialCapacity: Int) {
+  private var b: Array[Int] = new Array[Int](initialCapacity)
+  private var size_ : Int = 0
+
+  def size: Int = size_
+
+  def apply(i: Int): Int = {
+    require(i >= 0 && i < size)
+    b(i)
+  }
+
+  def ensureCapacity(n: Int) {
+    if (b.length < n) {
+      val newCapacity = (b.length * 2).max(n)
+      val newb = new Array[Int](newCapacity)
+      Array.copy(b, 0, newb, 0, size_)
+      b = newb
+    }
+  }
+
+  def add(x: Int) {
+    ensureCapacity(size_ + 1)
+    b(size_) = x
+    size_ += 1
+  }
+}
+
+class LongArrayBuilder(initialCapacity: Int) {
+  private var b: Array[Long] = new Array[Long](initialCapacity)
+  private var size_ : Int = 0
+
+  def size: Int = size_
+
+  def apply(i: Int): Long = {
+    require(i >= 0 && i < size)
+    b(i)
+  }
+
+  def ensureCapacity(n: Int) {
+    if (b.length < n) {
+      val newCapacity = (b.length * 2).max(n)
+      val newb = new Array[Long](newCapacity)
+      Array.copy(b, 0, newb, 0, size_)
+      b = newb
+    }
+  }
+
+  def add(x: Long) {
+    ensureCapacity(size_ + 1)
+    b(size_) = x
+    size_ += 1
+  }
+}
+
+class FloatArrayBuilder(initialCapacity: Int) {
+  private var b: Array[Float] = new Array[Float](initialCapacity)
+  private var size_ : Int = 0
+
+  def size: Int = size_
+
+  def apply(i: Int): Float = {
+    require(i >= 0 && i < size)
+    b(i)
+  }
+
+  def ensureCapacity(n: Int) {
+    if (b.length < n) {
+      val newCapacity = (b.length * 2).max(n)
+      val newb = new Array[Float](newCapacity)
+      Array.copy(b, 0, newb, 0, size_)
+      b = newb
+    }
+  }
+
+  def add(x: Float) {
+    ensureCapacity(size_ + 1)
+    b(size_) = x
+    size_ += 1
+  }
+}
+
+class DoubleArrayBuilder(initialCapacity: Int) {
+  private var b: Array[Double] = new Array[Double](initialCapacity)
+  private var size_ : Int = 0
+
+  def size: Int = size_
+
+  def apply(i: Int): Double = {
+    require(i >= 0 && i < size)
+    b(i)
+  }
+
+  def ensureCapacity(n: Int) {
+    if (b.length < n) {
+      val newCapacity = (b.length * 2).max(n)
+      val newb = new Array[Double](newCapacity)
+      Array.copy(b, 0, newb, 0, size_)
+      b = newb
+    }
+  }
+
+  def add(x: Double) {
+    ensureCapacity(size_ + 1)
+    b(size_) = x
+    size_ += 1
+  }
+}
+
+class BooleanArrayBuilder(initialCapacity: Int) {
+  private var b: Array[Boolean] = new Array[Boolean](initialCapacity)
+  private var size_ : Int = 0
+
+  def size: Int = size_
+
+  def apply(i: Int): Boolean = {
+    require(i >= 0 && i < size)
+    b(i)
+  }
+
+  def ensureCapacity(n: Int) {
+    if (b.length < n) {
+      val newCapacity = (b.length * 2).max(n)
+      val newb = new Array[Boolean](newCapacity)
+      Array.copy(b, 0, newb, 0, size_)
+      b = newb
+    }
+  }
+
+  def add(x: Boolean) {
+    ensureCapacity(size_ + 1)
+    b(size_) = x
+    size_ += 1
+  }
+}


### PR DESCRIPTION
GQ as expr means adding it on after the splitmulti calculation as an annotate_entries which still goes through the AST.

```
profile.vcf.bgz

non-deforested, gq inline: ~50s
non-deforested, gq as expr: ~45s
deforested, gq as expr: ~36s
deforested, gq inline: ~26s
```