### PR TITLE
Table select/annotate/rename/drop changes

### DIFF
--- a/python/hail/expr/expressions/base_expression.py
+++ b/python/hail/expr/expressions/base_expression.py
@@ -227,7 +227,7 @@ def unify_all(*exprs) -> Tuple[Indices, LinkedList, LinkedList]:
         sources = defaultdict(lambda: [])
         for e in exprs:
             from .expression_utils import get_refs
-            for name, inds in get_refs(e, *e._aggregations.exprs):
+            for name, inds in get_refs(e, *[e for a in e._aggregations for e in a._exprs]):
                 sources[inds.source].append(str(name))
         raise ExpressionException("Cannot combine expressions from different source objects."
                                   "\n    Found fields from {n} objects:{fields}".format(

--- a/python/hail/expr/expressions/indices.py
+++ b/python/hail/expr/expressions/indices.py
@@ -44,8 +44,12 @@ class Aggregation(object):
 
 
 class Join(object):
+    _idx = 0
+
     def __init__(self, join_function, temp_vars, uid, exprs):
         self.join_function = join_function
         self.temp_vars = temp_vars
         self.uid = uid
         self.exprs = exprs
+        self.idx = Join._idx
+        Join._idx += 1

--- a/python/hail/expr/expressions/typed_expressions.py
+++ b/python/hail/expr/expressions/typed_expressions.py
@@ -1246,7 +1246,7 @@ class StructExpression(Mapping, Expression):
                 types.append(t)
 
         result_type = tstruct(**dict(zip(names, types)))
-        indices, aggregations, joins = unify_all(self, kwargs_struct)
+        indices, aggregations, joins = unify_all(kwargs_struct)
 
         return construct_expr(ApplyMethod('annotate', self._ast, kwargs_struct._ast), result_type,
                               indices, aggregations, joins)

--- a/python/hail/expr/functions.py
+++ b/python/hail/expr/functions.py
@@ -143,7 +143,6 @@ def literal(x: Any, dtype: Optional[Union[HailType, str]] = None) -> Expression:
 def cond(condition: BooleanExpression,
          consequent: Expression,
          alternate: Expression,
-         *,
          missing_false: bool = False) -> Expression:
     """Expression for an if/else statement; tests a condition and returns one of two options based on the result.
 

--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -2261,7 +2261,7 @@ class MatrixTable(ExprContainer):
         used_uids = set()
 
         for e in exprs:
-            for j in list(e._joins)[::-1]:
+            for j in sorted(list(e._joins), key = lambda j: j.idx): # Make sure joins happen in order
                 if j.uid not in used_uids:
                     left = j.join_function(left)
                     all_uids.extend(j.temp_vars)

--- a/python/hail/tests/test_expr.py
+++ b/python/hail/tests/test_expr.py
@@ -980,6 +980,7 @@ class Tests(unittest.TestCase):
         a1 = [1,2,3]
         a2 = ['a', 'b']
         a3 = [[1]]
+
         self.assertEqual(hl.eval_expr(hl.zip(a1, a2)), [(1, 'a'), (2, 'b')])
         self.assertEqual(hl.eval_expr(hl.zip(a1, a2, fill_missing=True)), [(1, 'a'), (2, 'b'), (3, None)])
 

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -716,7 +716,8 @@ case class ApplyMethod(posn: Position, lhs: AST, method: String, args: Array[AST
         `type` = FunctionRegistry.lookupMethodReturnType(it, funType +: rest.map(_.`type`), method)
           .valueOr(x => parseError(x.message))
 
-      case (tt: TTuple, "[]", Array(Const(_, v, t))) =>
+      case (tt: TTuple, "[]", Array(idxAST@Const(_, v, t))) =>
+        idxAST.typecheck(ec)
         val idx = v.asInstanceOf[Int]
         assert(idx >= 0 && idx < tt.size)
         `type` = tt.types(idx)

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -134,28 +134,7 @@ object Parser extends JavaTokenParsers {
     }
     (names, types, () => fs.map(_()))
   }
-
-  def parseSelectExprsToAST(codes: Array[String], ec: EvalContext): (Array[Either[String, List[String]]], Array[AST]) = {
-    val names = new Array[Either[String, List[String]]](codes.length)
-    val asts = new Array[AST](codes.length)
-    codes.indices.foreach { i =>
-      val code = codes(i)
-      annotationIdentifier.parseOpt(code) match {
-        case Some(ids) =>
-          val ast = expr.parse(code)
-          assert(ids.nonEmpty)
-          names(i) = Right(ids)
-          asts(i) = ast
-        case None =>
-          val (name, ast) = named_expr(identifier).parse(code)
-          names(i) = Left(name)
-          asts(i) = ast
-      }
-    }
-    asts.foreach { _.typecheck(ec) }
-    (names, asts)
-  }
-
+  
   def parseAnnotationExprs(code: String, ec: EvalContext, expectedHead: Option[String]): (
     Array[List[String]], Array[Type], () => Array[Any]) = {
 

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -495,19 +495,19 @@ case class TableFilter(child: TableIR, pred: IR) extends TableIR {
   }
 }
 
-case class TableAnnotate(child: TableIR, paths: IndexedSeq[String], preds: IndexedSeq[IR]) extends TableIR {
-  val children: IndexedSeq[BaseIR] = Array(child) ++ preds
-
-  private val newIR: IR = InsertFields(In(0, child.typ.rowType), paths.zip(preds))
+case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
+  val children: IndexedSeq[BaseIR] = Array(child, newRow)
 
   val typ: TableType = {
-    Infer(newIR, None, child.typ.env)
-    child.typ.copy(rowType = newIR.typ.asInstanceOf[TStruct])
+    Infer(newRow, None, child.typ.env)
+    val newRowType = newRow.typ.asInstanceOf[TStruct]
+    val newKey = child.typ.key.filter(newRowType.fieldIdx.contains)
+    child.typ.copy(rowType = newRowType, key = newKey)
   }
 
-  def copy(newChildren: IndexedSeq[BaseIR]): TableAnnotate = {
-    assert(newChildren.length == children.length)
-    TableAnnotate(newChildren(0).asInstanceOf[TableIR], paths, newChildren.tail.asInstanceOf[IndexedSeq[IR]])
+  def copy(newChildren: IndexedSeq[BaseIR]): TableMapRows = {
+    assert(newChildren.length == 2)
+    TableMapRows(newChildren(0).asInstanceOf[TableIR], newChildren(1).asInstanceOf[IR])
   }
 
   def execute(hc: HailContext): TableValue = {
@@ -515,7 +515,7 @@ case class TableAnnotate(child: TableIR, paths: IndexedSeq[String], preds: Index
     val (rTyp, f) = ir.Compile[Long, Long, Long](
       "row", child.typ.rowType,
       "global", child.typ.globalType,
-      newIR)
+      newRow)
     assert(rTyp == typ.rowType)
     val globalsBc = tv.globals.broadcast
     val gType = typ.globalType
@@ -537,4 +537,3 @@ case class TableAnnotate(child: TableIR, paths: IndexedSeq[String], preds: Index
       })
   }
 }
-

--- a/src/main/scala/is/hail/expr/types/TStruct.scala
+++ b/src/main/scala/is/hail/expr/types/TStruct.scala
@@ -392,6 +392,15 @@ final case class TStruct(fields: IndexedSeq[Field], override val required: Boole
     newStruct -> annotator
   }
 
+  def rename(m: Map[String, String]): TStruct = {
+    val newFieldsBuilder = new ArrayBuilder[(String, Type)]()
+    fields.foreach { fd =>
+      val n = fd.name
+      newFieldsBuilder += (m.getOrElse(n, n), fd.typ)
+    }
+    TStruct(newFieldsBuilder.result(): _*)
+  }
+
   def filter(set: Set[String], include: Boolean = true): (TStruct, Deleter) = {
     val notFound = set.filter(name => selfField(name).isEmpty).map(prettyIdentifier)
     if (notFound.nonEmpty)

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1564,8 +1564,8 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
   def localizeEntries(entriesFieldName: String): Table = {
-    new Table(hc, TableLiteral(TableValue(TableType(rvRowType, rowKey, globalType), globals, rvd)))
-      .rename(Map(MatrixType.entriesIdentifier -> entriesFieldName), Map.empty[String, String])
+    val m = Map(MatrixType.entriesIdentifier -> entriesFieldName)
+    new Table(hc, TableLiteral(TableValue(TableType(rvRowType.rename(m), rowKey, globalType), globals, rvd)))
   }
 
   def annotateEntriesExpr(expr: String): MatrixTable = {

--- a/src/test/scala/is/hail/expr/TableIRSuite.scala
+++ b/src/test/scala/is/hail/expr/TableIRSuite.scala
@@ -7,41 +7,28 @@ import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
 class TableIRSuite extends SparkSuite {
-
-  @Test def testFilter() {
+  def getKT: Table = {
     val data = Array(Array("Sample1", 9, 5), Array("Sample2", 3, 5), Array("Sample3", 2, 5), Array("Sample4", 1, 5))
     val rdd = sc.parallelize(data.map(Row.fromSeq(_)))
     val signature = TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32()))
     val keyNames = Array("Sample")
 
     val kt = Table(hc, rdd, signature, keyNames)
+    kt.typeCheck()
+    kt
+  }
+
+  @Test def testFilter() {
+    val kt = getKT
     val kt2 = new Table(hc, TableFilter(kt.tir,
       ir.ApplyBinaryPrimOp(ir.EQ(), ir.GetField(ir.Ref("row"), "field1"), ir.I32(3))))
     assert(kt2.count() == 1)
   }
 
   @Test def testFilterGlobals() {
-    val data = Array(Array("Sample1", 9, 5), Array("Sample2", 3, 5), Array("Sample3", 2, 5), Array("Sample4", 1, 5))
-    val rdd = sc.parallelize(data.map(Row.fromSeq(_)))
-    val signature = TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32()))
-    val keyNames = Array("Sample")
-
-    val kt = Table(hc, rdd, signature, keyNames).annotateGlobalExpr("g = 3")
+    val kt = getKT.annotateGlobalExpr("g = 3")
     val kt2 = new Table(hc, TableFilter(kt.tir,
       ir.ApplyBinaryPrimOp(ir.EQ(), ir.GetField(ir.Ref("row"), "field1"), ir.GetField(ir.Ref("global"), "g"))))
     assert(kt2.count() == 1)
-  }
-
-  @Test def testAnnotate() {
-    val data = Array(Array("Sample1", 9, 5), Array("Sample2", 3, 5), Array("Sample3", 2, 5), Array("Sample4", 1, 5))
-    val rdd = sc.parallelize(data.map(Row.fromSeq(_)))
-    val signature = TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32()))
-    val keyNames = Array("Sample")
-
-    val kt = Table(hc, rdd, signature, keyNames)
-    val kt2 = new Table(hc, TableAnnotate(kt.tir,
-      IndexedSeq("dummy", "a", "field1"),
-      IndexedSeq(ir.I32(0), ir.GetField(ir.Ref("row"), "field1"), ir.GetField(ir.Ref("row"), "field2"))))
-    assert(kt2.select("row.Sample", "field1 = row.a", "field2 = row.field1").same(kt))
   }
 }

--- a/src/test/scala/is/hail/expr/ir/CompileSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/CompileSuite.scala
@@ -509,6 +509,7 @@ class CompileSuite {
     doit(ir, fb)
     val f = fb.result()()
     region.clear()
+
     val a1actual = Array(1, 2)
     val a2actual = Array("a", "b")
     val rvb = new RegionValueBuilder(region)

--- a/src/test/scala/is/hail/io/ImportPlinkSuite.scala
+++ b/src/test/scala/is/hail/io/ImportPlinkSuite.scala
@@ -82,35 +82,32 @@ class ImportPlinkSuite extends SparkSuite {
       .rowsTable()
       .select(
         "row.rsid",
-        "row.alleles",
-        "row.variant_qc.n_not_called",
-        "row.variant_qc.n_hom_ref",
-        "row.variant_qc.n_het",
-        "row.variant_qc.n_hom_var")
-      .rename(Map("alleles" -> "vA1", "n_not_called" -> "nNotCalledA1",
-        "n_hom_ref" -> "nHomRefA1", "n_het" -> "nHetA1", "n_hom_var" -> "nHomVarA1"), Map.empty[String, String])
+        "alleles_a1 = row.alleles",
+        "n_not_called_a1 = row.variant_qc.n_not_called",
+        "n_hom_ref_a1 = row.variant_qc.n_hom_ref",
+        "n_het_a1 = row.variant_qc.n_het",
+        "n_hom_var_a1 = row.variant_qc.n_hom_var")
       .keyBy("rsid")
 
     val a2kt = VariantQC(a2ref, "variant_qc")
       .rowsTable()
       .select(
         "row.rsid",
-        "row.alleles",
-        "row.variant_qc.n_not_called",
-        "row.variant_qc.n_hom_ref",
-        "row.variant_qc.n_het",
-        "row.variant_qc.n_hom_var")
-      .rename(Map("alleles" -> "vA2", "n_not_called" -> "nNotCalledA2",
-        "n_hom_ref" -> "nHomRefA2", "n_het" -> "nHetA2", "n_hom_var" -> "nHomVarA2"), Map.empty[String, String])
+        "alleles_a2 = row.alleles",
+        "n_not_called_a2 = row.variant_qc.n_not_called",
+        "n_hom_ref_a2 = row.variant_qc.n_hom_ref",
+        "n_het_a2 = row.variant_qc.n_het",
+        "n_hom_var_a2 = row.variant_qc.n_hom_var")
       .keyBy("rsid")
 
     val joined = a1kt.join(a2kt, "outer")
 
-    assert(joined.forall("row.vA1[0] == row.vA2[1] && " +
-      "row.vA1[1] == row.vA2[0] && " +
-      "row.nNotCalledA1 == row.nNotCalledA2 && " +
-      "row.nHetA1 == row.nHetA2 && " +
-      "row.nHomRefA1 == row.nHomVarA2 && " +
-      "row.nHomVarA1 == row.nHomRefA2"))
+    assert(joined.forall(
+      "row.alleles_a1[0] == row.alleles_a2[1] && " +
+      "row.alleles_a1[1] == row.alleles_a2[0] && " +
+      "row.n_not_called_a1 == row.n_not_called_a2 && " +
+      "row.n_het_a1 == row.n_het_a2 && " +
+      "row.n_hom_ref_a1 == row.n_hom_var_a2 && " +
+      "row.n_hom_var_a1 == row.n_hom_ref_a2"))
   }
 }

--- a/src/test/scala/is/hail/io/ImportPlinkSuite.scala
+++ b/src/test/scala/is/hail/io/ImportPlinkSuite.scala
@@ -80,34 +80,34 @@ class ImportPlinkSuite extends SparkSuite {
 
     val a1kt = VariantQC(a1ref, "variant_qc")
       .rowsTable()
-      .select(
+      .select(Array(
         "row.rsid",
         "alleles_a1 = row.alleles",
         "n_not_called_a1 = row.variant_qc.n_not_called",
         "n_hom_ref_a1 = row.variant_qc.n_hom_ref",
         "n_het_a1 = row.variant_qc.n_het",
-        "n_hom_var_a1 = row.variant_qc.n_hom_var")
+        "n_hom_var_a1 = row.variant_qc.n_hom_var"))
       .keyBy("rsid")
 
     val a2kt = VariantQC(a2ref, "variant_qc")
       .rowsTable()
-      .select(
+      .select(Array(
         "row.rsid",
         "alleles_a2 = row.alleles",
         "n_not_called_a2 = row.variant_qc.n_not_called",
         "n_hom_ref_a2 = row.variant_qc.n_hom_ref",
         "n_het_a2 = row.variant_qc.n_het",
-        "n_hom_var_a2 = row.variant_qc.n_hom_var")
+        "n_hom_var_a2 = row.variant_qc.n_hom_var"))
       .keyBy("rsid")
 
     val joined = a1kt.join(a2kt, "outer")
 
     assert(joined.forall(
       "row.alleles_a1[0] == row.alleles_a2[1] && " +
-      "row.alleles_a1[1] == row.alleles_a2[0] && " +
-      "row.n_not_called_a1 == row.n_not_called_a2 && " +
-      "row.n_het_a1 == row.n_het_a2 && " +
-      "row.n_hom_ref_a1 == row.n_hom_var_a2 && " +
-      "row.n_hom_var_a1 == row.n_hom_ref_a2"))
+        "row.alleles_a1[1] == row.alleles_a2[0] && " +
+        "row.n_not_called_a1 == row.n_not_called_a2 && " +
+        "row.n_het_a1 == row.n_het_a2 && " +
+        "row.n_hom_ref_a1 == row.n_hom_var_a2 && " +
+        "row.n_hom_var_a1 == row.n_hom_ref_a2"))
   }
 }

--- a/src/test/scala/is/hail/methods/ExportSuite.scala
+++ b/src/test/scala/is/hail/methods/ExportSuite.scala
@@ -16,7 +16,7 @@ class ExportSuite extends SparkSuite {
     vds = SampleQC(vds)
 
     val out = tmpDir.createTempFile("out", ".tsv")
-    vds.colsTable().select("Sample = row.s",
+    vds.colsTable().select(Array("Sample = row.s",
     "row.qc.call_rate",
     "row.qc.n_called",
     "row.qc.n_not_called",
@@ -37,7 +37,7 @@ class ExportSuite extends SparkSuite {
     "row.qc.n_non_ref",
     "row.qc.r_ti_tv",
     "row.qc.r_het_hom_var",
-    "row.qc.r_insertion_deletion").export(out)
+    "row.qc.r_insertion_deletion")).export(out)
 
     val sb = new StringBuilder()
     sb.tsvAppend(Array(1, 2, 3, 4, 5))
@@ -86,7 +86,7 @@ class ExportSuite extends SparkSuite {
 
     // verify exports localSamples
     val f = tmpDir.createTempFile("samples", ".tsv")
-    vds.colsTable().select("row.s").export(f, header = false)
+    vds.colsTable().select(Array("row.s")).export(f, header = false)
     assert(sc.textFile(f).count() == 1)
   }
 
@@ -96,9 +96,9 @@ class ExportSuite extends SparkSuite {
     val f3 = tmpDir.createTempFile("samples", ".tsv")
 
     val vds = TestUtils.splitMultiHTS(hc.importVCF("src/test/resources/sample.vcf"))
-    vds.colsTable().select("`S.A.M.P.L.E.ID` = row.s").export(f)
-    vds.colsTable().select("`$$$I_HEARD_YOU_LIKE!_WEIRD~^_CHARS****` = row.s", "ANOTHERTHING = row.s").export(f2)
-    vds.colsTable().select("`I have some spaces and tabs\\there` = row.s", "`more weird stuff here` = row.s").export(f3)
+    vds.colsTable().select(Array("`S.A.M.P.L.E.ID` = row.s")).export(f)
+    vds.colsTable().select(Array("`$$$I_HEARD_YOU_LIKE!_WEIRD~^_CHARS****` = row.s", "ANOTHERTHING = row.s")).export(f2)
+    vds.colsTable().select(Array("`I have some spaces and tabs\\there` = row.s", "`more weird stuff here` = row.s")).export(f3)
     hadoopConf.readFile(f) { reader =>
       val lines = Source.fromInputStream(reader)
         .getLines()
@@ -125,7 +125,7 @@ class ExportSuite extends SparkSuite {
     vds = SampleQC(vds)
     vds
       .colsTable()
-      .select("computation = 5 * (if (row.qc.call_rate < .95) 0 else 1)")
+      .select(Array("computation = 5 * (if (row.qc.call_rate < .95) 0 else 1)"))
       .export(f)
   }
 }

--- a/src/test/scala/is/hail/methods/SelectSuite.scala
+++ b/src/test/scala/is/hail/methods/SelectSuite.scala
@@ -2,6 +2,7 @@ package is.hail.methods
 
 import is.hail.SparkSuite
 import org.testng.annotations.Test
+import is.hail.testUtils._
 
 class SelectSuite extends SparkSuite {
   @Test def testRows() {

--- a/src/test/scala/is/hail/methods/SelectSuite.scala
+++ b/src/test/scala/is/hail/methods/SelectSuite.scala
@@ -11,7 +11,7 @@ class SelectSuite extends SparkSuite {
 
     val t1 = vds.selectRows("va.locus", "va.alleles", "va.info.AC", "AF = va.info.AF", "foo2 = AGG.count()").rowsTable()
 
-    val t2 = vds.rowsTable().select("row.locus", "row.alleles", "row.info.AC", "AF = row.info.AF", "foo2 = row.foo")
+    val t2 = vds.rowsTable().select(Array("row.locus", "row.alleles", "row.info.AC", "AF = row.info.AF", "foo2 = row.foo"))
 
     assert(t1.same(t2))
   }
@@ -28,7 +28,7 @@ class SelectSuite extends SparkSuite {
 
     val t1 = vds.selectCols("sa.s", "sa.bar.baz", "foo2 = AGG.count()").colsTable()
 
-    val t2 = vds.colsTable().select("row.s", "row.bar.baz", "foo2 = row.foo")
+    val t2 = vds.colsTable().select(Array("row.s", "row.bar.baz", "foo2 = row.foo"))
 
     assert(t1.same(t2))
   }

--- a/src/test/scala/is/hail/methods/TableSuite.scala
+++ b/src/test/scala/is/hail/methods/TableSuite.scala
@@ -263,23 +263,23 @@ class TableSuite extends SparkSuite {
     val kt = Table(hc, rdd, signature, keyNames)
     kt.typeCheck()
 
-    val select1 = kt.select("row.field1").keyBy("field1")
+    val select1 = kt.select(Array("row.field1")).keyBy("field1")
     assert((select1.key sameElements Array("field1")) && (select1.fieldNames sameElements Array("field1")))
 
-    val select2 = kt.select("row.Sample", "row.field2", "row.field1").keyBy("Sample")
+    val select2 = kt.select(Array("row.Sample", "row.field2", "row.field1")).keyBy("Sample")
     assert((select2.key sameElements Array("Sample")) && (select2.fieldNames sameElements Array("Sample", "field2", "field1")))
 
-    val select3 = kt.select("row.field2", "row.field1", "row.Sample").keyBy()
+    val select3 = kt.select(Array("row.field2", "row.field1", "row.Sample")).keyBy()
     assert((select3.key sameElements Array.empty[String]) && (select3.fieldNames sameElements Array("field2", "field1", "Sample")))
 
-    val select4 = kt.select()
+    val select4 = kt.select(Array.empty[String])
     assert((select4.key sameElements Array.empty[String]) && (select4.fieldNames sameElements Array.empty[String]))
 
     for (select <- Array(select1, select2, select3, select4)) {
       select.export(tmpDir.createTempFile("select", "tsv"))
     }
 
-    TestUtils.interceptFatal("Invalid key")(kt.select().keyBy("Sample"))
+    TestUtils.interceptFatal("Invalid key")(kt.select(Array.empty[String]).keyBy("Sample"))
   }
 
   @Test def testExplode() {
@@ -314,7 +314,7 @@ class TableSuite extends SparkSuite {
       .rowsTable()
       .expandTypes()
       .flatten()
-      .select("row.`info.MQRankSum`")
+      .select(Array("row.`info.MQRankSum`"))
       .copy2(globalSignature = TStruct.empty())
 
     val df = kt.toDF(sqlContext)
@@ -422,7 +422,7 @@ class TableSuite extends SparkSuite {
 
     val gkt = kt.aggregate("index = row.index", "x = AGG.map(r => global.dict.get(r.index)).collect()[0]")
     assert(gkt.exists("row.x == \"bar\""))
-    assert(kt.select("baz = global.dict.get(row.index)").exists("row.baz == \"bar\""))
+    assert(kt.select(Array("baz = global.dict.get(row.index)")).exists("row.baz == \"bar\""))
 
     val tmpPath = tmpDir.createTempFile(extension = "kt")
     kt.write(tmpPath)
@@ -477,5 +477,4 @@ class TableSuite extends SparkSuite {
     val expectedSets = List(Set("A", "C", "E", "G"), Set("A", "C", "E", "H")).map(set => set.map(str => (str, true)))
     assert(expectedSets.contains(mis))
   }
-
 }

--- a/src/test/scala/is/hail/testUtils/RichTable.scala
+++ b/src/test/scala/is/hail/testUtils/RichTable.scala
@@ -1,8 +1,12 @@
 package is.hail.testUtils
 
+import is.hail.annotations.Inserter
 import is.hail.expr._
+import is.hail.expr.ir.{InsertFields, MakeStruct, Ref}
+import is.hail.expr.types.TStruct
 import is.hail.table.Table
 import is.hail.utils._
+import org.apache.spark.sql.Row
 
 class RichTable(ht: Table) {
   def forall(code: String): Boolean = {
@@ -36,4 +40,100 @@ class RichTable(ht: Table) {
     }
   }
 
+  def rename(rowUpdateMap: Map[String, String], globalUpdateMap: Map[String, String]): Table = {
+    select(ht.fieldNames.map(n => s"${ rowUpdateMap.getOrElse(n, n) } = row.$n"): _*)
+      .keyBy(ht.key.map(k => rowUpdateMap.getOrElse(k, k)))
+      .selectGlobal(ht.globalSignature.fieldNames.map(n => s"${ globalUpdateMap.getOrElse(n, n) } = global.$n"): _*)
+  }
+
+  def select(exprs: Array[String]): Table = {
+    val ec = ht.rowEvalContext()
+
+    val (paths, asts) = Parser.parseSelectExprsToAST(exprs, ec)
+
+    val insertionPaths = paths.map {
+      case Left(name) => name
+      case Right(path) => path.last
+    }
+
+    val overlappingPaths = paths.counter().filter { case (n, i) => i != 1 }.keys
+
+    if (overlappingPaths.nonEmpty)
+      fatal(s"Found ${ overlappingPaths.size } ${ plural(overlappingPaths.size, "selected field name") } that are duplicated.\n" +
+        "Overlapping fields:\n  " +
+        s"@1", overlappingPaths.truncatable("\n  "))
+
+    val irs = asts.flatMap { x => x.typecheck(ec); x.toIR() }
+
+    if (irs.length != asts.length || ht.globalSignature.size != 0) {
+      val (_, types, f) = Parser.parseSelectExprs(exprs, ec)
+
+      val inserterBuilder = new ArrayBuilder[Inserter]()
+
+      val finalSignature = (insertionPaths, types).zipped.foldLeft(TStruct()) { case (vs, (p, sig)) =>
+        val (s: TStruct, i) = vs.insert(sig, p)
+        inserterBuilder += i
+        s
+      }
+
+      val inserters = inserterBuilder.result()
+      val globalsBc = globals.broadcast
+
+      val annotF: Row => Row = { r =>
+        ec.setAll(globalsBc.value, r)
+
+        f().zip(inserters)
+          .foldLeft(Row()) { case (a1, (v, inserter)) =>
+            inserter(a1, v).asInstanceOf[Row]
+          }
+      }
+
+      val newKey = ht.key.filter(insertionPaths.toSet)
+
+      ht.copy(rdd = ht.rdd.map(annotF), signature = finalSignature, key = newKey)
+    } else {
+      new Table(ht.hc, TableMapRows(ht.tir, MakeStruct(insertionPaths.zip(irs))))
+    }
+  }
+
+  def select(names: String*): Table = select(names.toArray)
+
+  def annotate(code: String): Table = {
+    val ec = ht.rowEvalContext()
+
+    val (paths, asts) = Parser.parseAnnotationExprsToAST(code, ec).unzip
+    if (paths.length == 0)
+      return ht
+
+    val irs = asts.flatMap { _.toIR() }
+
+    if (irs.length != asts.length || ht.globalSignature.size != 0) {
+      val (paths, types, f) = Parser.parseAnnotationExprs(code, ec, None)
+
+      val inserterBuilder = new ArrayBuilder[Inserter]()
+
+      val finalSignature = (paths, types).zipped.foldLeft(ht.signature) { case (vs, (ids, sig)) =>
+        val (s: TStruct, i) = vs.insert(sig, ids)
+        inserterBuilder += i
+        s
+      }
+
+      val inserters = inserterBuilder.result()
+      val globalsBc = globals.broadcast
+
+      val annotF: Row => Row = { r =>
+        ec.setAll(globalsBc.value, r)
+
+        f().zip(inserters)
+          .foldLeft(r) { case (a1, (v, inserter)) =>
+            inserter(a1, v).asInstanceOf[Row]
+          }
+      }
+
+      ht.copy(rdd = ht.rdd.map(annotF), signature = finalSignature, key = ht.key)
+    } else {
+      val newIR = InsertFields(Ref("row"), paths.zip(irs))
+      new Table(ht.hc, TableMapRows(ht.tir, newIR))
+    }
+  }
 }

--- a/src/test/scala/is/hail/variant/vsm/GroupBySuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/GroupBySuite.scala
@@ -97,8 +97,8 @@ class GroupBySuite extends SparkSuite {
       .annotateColsExpr("pheno = sa.pheno.Pheno")
 
     val resultsVSM = vdsGrouped.linreg(Array("sa.pheno"), "g.sum", covExpr = Array("sa.cov.Cov1", "sa.cov.Cov2"))
-    val linregMap = resultsVSM.rowsTable().select("row.genes", "row.linreg.beta",
-      "row.linreg.standard_error", "row.linreg.t_stat", "row.linreg.p_value")
+    val linregMap = resultsVSM.rowsTable().select(Array("row.genes", "row.linreg.beta",
+      "row.linreg.standard_error", "row.linreg.t_stat", "row.linreg.p_value"))
       .rdd.map { r => (r.getAs[String](0), (1 to 4).map{ i => Double.box(r.getAs[IndexedSeq[Double]](i)(0)) }) }
       .collect()
       .toMap

--- a/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -56,7 +56,7 @@ class PartitioningSuite extends SparkSuite {
   @Test def testHintPartitionerAdjustedCorrectly() {
     val mt = MatrixTable.fromRowsTable(Table.range(hc, 100, "idx", partitions=Some(6)))
     val t = Table.range(hc, 205, "idx", partitions=Some(6))
-      .select("tidx = 200 - row.idx")
+      .select(Array("tidx = 200 - row.idx"))
       .keyBy("tidx")
     mt.annotateRowsTable(t, "foo").forceCountRows()
   }

--- a/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
@@ -158,7 +158,7 @@ class VSMSuite extends SparkSuite {
         .writeBlockMatrix(dirname, "x", blockSize)
 
       val data = mt.entriesTable()
-          .select("x = row.GT.nNonRefAlleles().toFloat64 + row.rowIdx.toFloat64 + row.colIdx.toFloat64 + 1.0")
+          .select(Array("x = row.GT.nNonRefAlleles().toFloat64 + row.rowIdx.toFloat64 + row.colIdx.toFloat64 + 1.0"))
           .collect()
           .map(_.getAs[Double](0))
 


### PR DESCRIPTION
- TableMapRows IR (takes a Struct IR as an argument)
- Removed TableAnnotate
- select can output an IR
- Rewrote annotate and rename in Python to utilize select
- Removed annotate, rename, and drop from the Scala Table interface
- Moved annotate and rename to RichTable for Scala tests
- added some additional python tests