### PR TITLE
MapEntries IR; use in annotate.

### DIFF
--- a/python/hail/tests/utils.py
+++ b/python/hail/tests/utils.py
@@ -4,7 +4,7 @@ import hail
 
 
 def startTestHailContext():
-    hail.init(master='local[2]', min_block_size=0)
+    hail.init(master='local[2]', min_block_size=0, quiet=True)
 
 
 def stopTestHailContext():

--- a/python/hail/tests/utils.py
+++ b/python/hail/tests/utils.py
@@ -4,7 +4,7 @@ import hail
 
 
 def startTestHailContext():
-    hail.init(master='local[2]', min_block_size=0, quiet=True)
+    hail.init(master='local[2]', min_block_size=0)
 
 
 def stopTestHailContext():

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -403,7 +403,7 @@ case class MapEntries(child: MatrixIR, newEntries: IR) extends MatrixIR {
       .bind("va", child.typ.rvRowType)
       .bind("sa", TArray(child.typ.colType))
     )
-    child.typ.copy(rvRowType=newRow.typ)
+    child.typ.copy(rvRowType = newRow.typ)
   }
 
   def execute(hc: HailContext): MatrixValue = {

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -409,17 +409,17 @@ case class MapEntries(child: MatrixIR, newEntries: IR) extends MatrixIR {
   def execute(hc: HailContext): MatrixValue = {
     val prev = child.execute(hc)
 
-    val (rTyp, f) = ir.Compile[Long, Long, Long, Long](
-      "global", child.typ.globalType,
-      "va", child.typ.rvRowType,
-      "sa", child.typ.colType,
-      newRow)
-    assert(rTyp == typ.rvRowType)
-
     val localGlobalsType = typ.globalType
     val localColsType = TArray(typ.colType)
     val colValuesBc = prev.colValuesBc
     val globalsBc = prev.globals.broadcast
+
+    val (rTyp, f) = ir.Compile[Long, Long, Long, Long](
+      "global", localGlobalsType,
+      "va", prev.typ.rvRowType,
+      "sa", localColsType,
+      newRow)
+    assert(rTyp == typ.rvRowType)
 
     val newRVD = prev.rvd.mapPartitionsPreservesPartitioning(typ.orvdType) { it =>
       val rvb = new RegionValueBuilder()

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -61,7 +61,7 @@ object Compile {
     val env = new Env[IR]()
       .bind(name0, In(0, typ0))
       .bind(name1, In(1, typ1))
-      .bind(name1, In(2, typ2))
+      .bind(name2, In(2, typ2))
     e = Subst(e, env)
     Infer(e)
     assert(TypeToIRIntermediateClassTag(e.typ) == classTag[R])

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -45,6 +45,30 @@ object Compile {
     apply[AsmFunction5[Region, T0, Boolean, T1, Boolean, R], R](Seq((name0, typ0, classTag[T0]), (name1, typ1, classTag[T1])), body)
   }
 
+  def apply[T0: TypeInfo : ClassTag, T1: TypeInfo : ClassTag, T2: TypeInfo : ClassTag, R: TypeInfo : ClassTag](
+    name0: String,
+    typ0: Type,
+    name1: String,
+    typ1: Type,
+    name2: String,
+    typ2: Type,
+    body: IR): (Type, () => AsmFunction7[Region, T0, Boolean, T1, Boolean, T2, Boolean, R]) = {
+    assert(TypeToIRIntermediateClassTag(typ0) == classTag[T0])
+    assert(TypeToIRIntermediateClassTag(typ1) == classTag[T1])
+    assert(TypeToIRIntermediateClassTag(typ2) == classTag[T2])
+    val fb = FunctionBuilder.functionBuilder[Region, T0, Boolean, T1, Boolean, T2, Boolean, R]
+    var e = body
+    val env = new Env[IR]()
+      .bind(name0, In(0, typ0))
+      .bind(name1, In(1, typ1))
+      .bind(name1, In(2, typ2))
+    e = Subst(e, env)
+    Infer(e)
+    assert(TypeToIRIntermediateClassTag(e.typ) == classTag[R])
+    Emit(e, fb)
+    (e.typ, fb.result())
+  }
+
   def apply[T0: TypeInfo : ClassTag, T1: TypeInfo : ClassTag, T2: TypeInfo : ClassTag,
   T3: TypeInfo : ClassTag, T4: TypeInfo : ClassTag, T5: TypeInfo : ClassTag,
   R: TypeInfo : ClassTag](

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -151,7 +151,7 @@ object Infer {
       case x@GetField(o, name, _) =>
         infer(o)
         val t = coerce[TStruct](o.typ)
-        assert(t.index(name).nonEmpty)
+        assert(t.index(name).nonEmpty, s"$name not in $t")
         x.typ = -t.field(name).typ
       case GetFieldMissingness(o, name) =>
         infer(o)

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1583,11 +1583,12 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
     val irs = asts.flatMap { case (f, a) => a.toIR().map((f, _)) }
 
-//    if (irs.length == asts.length) {
-//      val newEntries = ir.InsertFields(ir.Ref("g"), irs)
-//
-//      new MatrixTable(hc, MapEntries(ast, newEntries))
-//    } else {
+    val colValuesIsSmall = colType.size == 1 && colType.types.head.isOfType(TString())
+    if (irs.length == asts.length && colValuesIsSmall) {
+      val newEntries = ir.InsertFields(ir.Ref("g"), irs)
+
+      new MatrixTable(hc, MapEntries(ast, newEntries))
+    } else {
 
       val (paths, types, f) = Parser.parseAnnotationExprs(expr, ec, Some(Annotation.ENTRY_HEAD))
 
@@ -1632,7 +1633,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
         }
         rvb.endArray()
       })
-//    }
+    }
   }
 
   def filterCols(p: (Annotation, Int) => Boolean): MatrixTable = {

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -4,6 +4,7 @@ import is.hail.annotations._
 import is.hail.check.Gen
 import is.hail.linalg._
 import is.hail.expr._
+import is.hail.expr.ir
 import is.hail.methods._
 import is.hail.rvd._
 import is.hail.table.{Table, TableSpec}
@@ -1578,49 +1579,61 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
     val globalsBc = globals.broadcast
 
-    val (paths, types, f) = Parser.parseAnnotationExprs(expr, ec, Some(Annotation.ENTRY_HEAD))
+    val asts = Parser.parseAnnotationExprsToAST(expr, ec, Some(Annotation.ENTRY_HEAD))
 
-    val inserterBuilder = new ArrayBuilder[Inserter]()
-    val newEntryType = (paths, types).zipped.foldLeft(entryType) { case (gsig, (ids, signature)) =>
-      val (s, i) = gsig.structInsert(signature, ids)
-      inserterBuilder += i
-      s
-    }
-    val inserters = inserterBuilder.result()
+    val irs = asts.flatMap { case (f, a) => a.toIR().map((f, _)) }
 
-    val localNSamples = numCols
-    val fullRowType = rvRowType
-    val localColValuesBc = colValuesBc
-    val localEntriesIndex = entriesIndex
+    if (irs.length == asts.length) {
+      val newEntries = ir.InsertFields(ir.Ref("g"), irs)
 
-    insertEntries(() => {
-      val fullRow = new UnsafeRow(fullRowType)
-      val row = fullRow.deleteField(localEntriesIndex)
-      (fullRow, row)
-    })(newEntryType, { case ((fullRow, row), rv, rvb) =>
-      fullRow.set(rv)
-      val entries = fullRow.getAs[IndexedSeq[Annotation]](localEntriesIndex)
+      new MatrixTable(hc, MapEntries(ast, newEntries))
+    } else {
+      info("No IR conversion found for annotate_entries. Falling back to AST.")
 
-      rvb.startArray(localNSamples)
+      val (paths, types, f) = Parser.parseAnnotationExprs(expr, ec, Some(Annotation.ENTRY_HEAD))
 
-      var i = 0
-      while (i < localNSamples) {
-        val entry = entries(i)
-        ec.setAll(row,
-          localColValuesBc.value(i),
-          entry,
-          globalsBc.value)
-
-        val newEntry = f().zip(inserters)
-          .foldLeft(entry) { case (ga, (a, inserter)) =>
-            inserter(ga, a)
-          }
-        rvb.addAnnotation(newEntryType, newEntry)
-
-        i += 1
+      val inserterBuilder = new ArrayBuilder[Inserter]()
+      val newEntryType = (paths, types).zipped.foldLeft(entryType) { case (gsig, (ids, signature)) =>
+        val (s, i) = gsig.structInsert(signature, ids)
+        inserterBuilder += i
+        s
       }
-      rvb.endArray()
-    })
+      val inserters = inserterBuilder.result()
+
+      val localNSamples = numCols
+      val fullRowType = rvRowType
+      val localColValuesBc = colValuesBc
+      val localEntriesIndex = entriesIndex
+
+      insertEntries(() => {
+        val fullRow = new UnsafeRow(fullRowType)
+        val row = fullRow.deleteField(localEntriesIndex)
+        (fullRow, row)
+      })(newEntryType, { case ((fullRow, row), rv, rvb) =>
+        fullRow.set(rv)
+        val entries = fullRow.getAs[IndexedSeq[Annotation]](localEntriesIndex)
+
+        rvb.startArray(localNSamples)
+
+        var i = 0
+        while (i < localNSamples) {
+          val entry = entries(i)
+          ec.setAll(row,
+            localColValuesBc.value(i),
+            entry,
+            globalsBc.value)
+
+          val newEntry = f().zip(inserters)
+            .foldLeft(entry) { case (ga, (a, inserter)) =>
+              inserter(ga, a)
+            }
+          rvb.addAnnotation(newEntryType, newEntry)
+
+          i += 1
+        }
+        rvb.endArray()
+      })
+    }
   }
 
   def filterCols(p: (Annotation, Int) => Boolean): MatrixTable = {

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1583,12 +1583,11 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
     val irs = asts.flatMap { case (f, a) => a.toIR().map((f, _)) }
 
-    if (irs.length == asts.length) {
-      val newEntries = ir.InsertFields(ir.Ref("g"), irs)
-
-      new MatrixTable(hc, MapEntries(ast, newEntries))
-    } else {
-      info("No IR conversion found for annotate_entries. Falling back to AST.")
+//    if (irs.length == asts.length) {
+//      val newEntries = ir.InsertFields(ir.Ref("g"), irs)
+//
+//      new MatrixTable(hc, MapEntries(ast, newEntries))
+//    } else {
 
       val (paths, types, f) = Parser.parseAnnotationExprs(expr, ec, Some(Annotation.ENTRY_HEAD))
 
@@ -1633,7 +1632,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
         }
         rvb.endArray()
       })
-    }
+//    }
   }
 
   def filterCols(p: (Annotation, Int) => Boolean): MatrixTable = {

--- a/src/test/scala/is/hail/io/ExportVCFSuite.scala
+++ b/src/test/scala/is/hail/io/ExportVCFSuite.scala
@@ -210,13 +210,13 @@ class ExportVCFSuite extends SparkSuite {
 
     TestUtils.interceptFatal("Invalid type for format field 'BOOL'. Found 'bool'.") {
       ExportVCF(vds
-        .annotateEntriesExpr("g = {BOOL: true}"),
+        .annotateEntriesExpr("g.BOOL = true"),
         out)
     }
 
     TestUtils.interceptFatal("Invalid type for format field 'AA'.") {
       ExportVCF(vds
-        .annotateEntriesExpr("g = {AA: [[0]]}"),
+        .annotateEntriesExpr("g.AA = [[0]]"),
         out)
     }
   }


### PR DESCRIPTION
I'm going to merge select/drop/annotate on the scala side in a separate PR. For now annotateEntriesExpr uses the IR path if possible for testing.