### PR TITLE
Fix BlockMatrix diagonal bug on non-square matrices

### DIFF
--- a/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -152,9 +152,6 @@ object BlockMatrix {
       def t: M =
         l.transpose()
 
-      def diag: Array[Double] =
-        l.diagonal()
-
       def *(r: M): M =
         l.multiply(r)
 
@@ -963,11 +960,12 @@ private class BlockMatrixDiagonalRDD(m: BlockMatrix)
     val result = new Array[Double](length)
     var i = 0
     while (i < partitionsLength) {
-      val a = diag(block(m, dmPartitions, dmPartitioner, context, i, i)).toArray
+      val lm = block(m, dmPartitions, dmPartitioner, context, i, i)
+      val size = math.min(lm.rows, lm.cols)
       var k = 0
       val offset = i * blockSize
-      while (k < a.length) {
-        result(offset + k) = a(k)
+      while (k < size) {
+        result(offset + k) = lm(k, k)
         k += 1
       }
       i += 1

--- a/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
@@ -332,7 +332,7 @@ class BlockMatrixSuite extends SparkSuite {
       9, 10, 11, 12,
       13, 14, 15, 16))
 
-    assert(m.diag.toSeq == Seq(1, 6, 11, 16))
+    assert(m.diagonal().toSeq == Seq(1, 6, 11, 16))
   }
 
   @Test
@@ -342,11 +342,11 @@ class BlockMatrixSuite extends SparkSuite {
       val diagonalLength = math.min(lm.rows, lm.cols)
       val diagonal = Array.tabulate(diagonalLength)(i => lm(i, i))
 
-      if (m.diag.toSeq == diagonal.toSeq)
+      if (m.diagonal().toSeq == diagonal.toSeq)
         true
       else {
         println(s"lm: $lm")
-        println(s"${ m.diag.toSeq } != ${ diagonal.toSeq }")
+        println(s"${ m.diagonal().toSeq } != ${ diagonal.toSeq }")
         false
       }
     }.check()

--- a/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
@@ -326,13 +326,16 @@ class BlockMatrixSuite extends SparkSuite {
 
   @Test
   def diagonalTestTiny() {
-    val m = toBM(4, 4, Array[Double](
+    val lm = toLM(3, 4, Array[Double](
       1, 2, 3, 4,
       5, 6, 7, 8,
-      9, 10, 11, 12,
-      13, 14, 15, 16))
+      9, 10, 11, 12))
+    
+    val m = toBM(lm, blockSize = 2)
 
-    assert(m.diagonal().toSeq == Seq(1, 6, 11, 16))
+    assert(m.diagonal().toSeq == Seq(1, 6, 11))
+    assert(m.t.diagonal().toSeq == Seq(1, 6, 11))
+    assert((m * m.t).diagonal().toSeq == Seq(30, 174, 446))
   }
 
   @Test


### PR DESCRIPTION
Breeze diag only works on square matrices, whereas BlockMatrix diagonal was written for arbitrary matrices, consistent with NumPy. Update avoids Breeze diag, tests non-square matrix with multiple blocks, and deletes shortened operator `diag` as unnecessary.