### PR TITLE
remove direct encoder

### DIFF
--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -20,8 +20,8 @@ object RVDSpec {
   implicit val formats: Formats = new DefaultFormats() {
     override val typeHints = ShortTypeHints(List(
       classOf[RVDSpec], classOf[UnpartitionedRVDSpec], classOf[OrderedRVDSpec],
-      classOf[CodecSpec], classOf[DirectCodecSpec], classOf[PackCodecSpec],
-      classOf[BlockBufferSpec], classOf[LZ4BlockBufferSpec], classOf[StreamBlockBufferSpec],
+      classOf[CodecSpec], classOf[PackCodecSpec], classOf[BlockBufferSpec],
+      classOf[LZ4BlockBufferSpec], classOf[StreamBlockBufferSpec],
       classOf[BufferSpec], classOf[LEB128BufferSpec], classOf[BlockingBufferSpec]))
     override val typeHintFieldName = "name"
   } +


### PR DESCRIPTION
DirectEncoder is not currently used and will not work
with the forthcoming off-heap Region PR.