### PR TITLE
Eliminate some but not all uses of RVD.rdd

### DIFF
--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -85,6 +85,8 @@ case class MatrixValue(
   colValues: IndexedSeq[Annotation],
   rvd: OrderedRVD) {
 
+  assert(rvd.typ == typ.orvdType)
+
   def sparkContext: SparkContext = rvd.sparkContext
 
   def nPartitions: Int = rvd.partitions.length
@@ -223,6 +225,7 @@ case class MatrixRead(
         val localEntriesIndex = typ.entriesIdx
 
         val rowsRVD = spec.rowsComponent.read(hc, path).asInstanceOf[OrderedRVD]
+        assert(rowsRVD.typ == typ.orvdType)
         if (dropCols) {
           rowsRVD.mapPartitionsPreservesPartitioning(typ.orvdType) { it =>
             var rv2b = new RegionValueBuilder()
@@ -252,9 +255,6 @@ case class MatrixRead(
         } else {
           val entriesRVD = spec.entriesComponent.read(hc, path)
           val entriesRowType = entriesRVD.rowType
-          // FIXME: DK added this assert when refactoring, but should this just
-          // always be true? Is this assert necessary?
-          assert(rowsRVD.typ == typ.orvdType)
           rowsRVD.zipPartitions(entriesRVD) { case (it1, it2) =>
             val rvb = new RegionValueBuilder()
 

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -643,7 +643,7 @@ case class TableJoin(left: TableIR, right: TableIR, joinType: String) extends Ta
     val leftORVD = leftTV.rvd match {
       case ordered: OrderedRVD => ordered
       case unordered =>
-        OrderedRVD(
+        OrderedRVD.coerce(
           new OrderedRVDType(left.typ.key.toArray, left.typ.key.toArray, leftRowType),
           unordered.rdd,
           None,
@@ -657,7 +657,7 @@ case class TableJoin(left: TableIR, right: TableIR, joinType: String) extends Ta
         if (joinType == "left" || joinType == "inner")
           unordered.constrainToOrderedPartitioner(ordType, leftORVD.partitioner)
         else
-          OrderedRVD(ordType, unordered.rdd, None, Some(leftORVD.partitioner))
+          OrderedRVD.coerce(ordType, unordered.rdd, None, Some(leftORVD.partitioner))
     }
     val joinedRVD = leftORVD.orderedJoin(
       rightORVD,

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -250,7 +250,7 @@ case class MatrixRead(
             }
           }
         } else {
-          val entriesRVD = spec.entriesComponent.read(hc, path).asInstanceOf[OrderedRVD]
+          val entriesRVD = spec.entriesComponent.read(hc, path)
           val entriesRowType = entriesRVD.rowType
           // FIXME: DK added this assert when refactoring, but should this just
           // always be true? Is this assert necessary?

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -254,7 +254,10 @@ case class MatrixRead(
         } else {
           val entriesRVD = spec.entriesComponent.read(hc, path)
           val entriesRowType = entriesRVD.rowType
-          rowsRVD.zipPartitions(typ.orvdType, entriesRVD) { case (it1, it2) =>
+          rowsRVD.zipPartitionsPreservesPartitioning(
+            typ.orvdType,
+            entriesRVD
+          ) { case (it1, it2) =>
             val rvb = new RegionValueBuilder()
 
             new Iterator[RegionValue] {

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -452,7 +452,7 @@ case class MapEntries(child: MatrixIR, newEntries: IR) extends MatrixIR {
 
 case class TableValue(typ: TableType, globals: BroadcastValue, rvd: RVD) {
   def rdd: RDD[Row] =
-    rvd.toUnsafeRows
+    rvd.toRows
 
   def filter(p: (RegionValue, RegionValue) => Boolean): TableValue = {
     val globalType = typ.globalType

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -225,7 +225,6 @@ case class MatrixRead(
         val localEntriesIndex = typ.entriesIdx
 
         val rowsRVD = spec.rowsComponent.read(hc, path).asInstanceOf[OrderedRVD]
-        assert(rowsRVD.typ == typ.orvdType)
         if (dropCols) {
           rowsRVD.mapPartitionsPreservesPartitioning(typ.orvdType) { it =>
             var rv2b = new RegionValueBuilder()
@@ -255,7 +254,7 @@ case class MatrixRead(
         } else {
           val entriesRVD = spec.entriesComponent.read(hc, path)
           val entriesRowType = entriesRVD.rowType
-          rowsRVD.zipPartitions(entriesRVD) { case (it1, it2) =>
+          rowsRVD.zipPartitions(typ.orvdType, entriesRVD) { case (it1, it2) =>
             val rvb = new RegionValueBuilder()
 
             new Iterator[RegionValue] {

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -250,44 +250,45 @@ case class MatrixRead(
             }
           }
         } else {
-          val entriesRVD = spec.entriesComponent.read(hc, path)
+          val entriesRVD = spec.entriesComponent.read(hc, path).asInstanceOf[OrderedRVD]
           val entriesRowType = entriesRVD.rowType
-          OrderedRVD(typ.orvdType,
-            rowsRVD.partitioner,
-            rowsRVD.rdd.zipPartitions(entriesRVD.rdd) { case (it1, it2) =>
-              val rvb = new RegionValueBuilder()
+          // FIXME: DK added this assert when refactoring, but should this just
+          // always be true? Is this assert necessary?
+          assert(rowsRVD.typ == typ.orvdType)
+          rowsRVD.zipPartitions(entriesRVD) { case (it1, it2) =>
+            val rvb = new RegionValueBuilder()
 
-              new Iterator[RegionValue] {
-                def hasNext: Boolean = {
-                  val hn = it1.hasNext
-                  assert(hn == it2.hasNext)
-                  hn
-                }
-
-                def next(): RegionValue = {
-                  val rv1 = it1.next()
-                  val rv2 = it2.next()
-                  val region = rv2.region
-                  rvb.set(region)
-                  rvb.start(fullRowType)
-                  rvb.startStruct()
-                  var i = 0
-                  while (i < localEntriesIndex) {
-                    rvb.addField(fullRowType, rv1, i)
-                    i += 1
-                  }
-                  rvb.addField(entriesRowType, rv2, 0)
-                  i += 1
-                  while (i < fullRowType.size) {
-                    rvb.addField(fullRowType, rv1, i - 1)
-                    i += 1
-                  }
-                  rvb.endStruct()
-                  rv2.set(region, rvb.end())
-                  rv2
-                }
+            new Iterator[RegionValue] {
+              def hasNext: Boolean = {
+                val hn = it1.hasNext
+                assert(hn == it2.hasNext)
+                hn
               }
-            })
+
+              def next(): RegionValue = {
+                val rv1 = it1.next()
+                val rv2 = it2.next()
+                val region = rv2.region
+                rvb.set(region)
+                rvb.start(fullRowType)
+                rvb.startStruct()
+                var i = 0
+                while (i < localEntriesIndex) {
+                  rvb.addField(fullRowType, rv1, i)
+                  i += 1
+                }
+                rvb.addField(entriesRowType, rv2, 0)
+                i += 1
+                while (i < fullRowType.size) {
+                  rvb.addField(fullRowType, rv1, i - 1)
+                  i += 1
+                }
+                rvb.endStruct()
+                rv2.set(region, rvb.end())
+                rv2
+              }
+            }
+          }
         }
       }
 
@@ -450,10 +451,8 @@ case class MapEntries(child: MatrixIR, newEntries: IR) extends MatrixIR {
 }
 
 case class TableValue(typ: TableType, globals: BroadcastValue, rvd: RVD) {
-  def rdd: RDD[Row] = {
-    val localRowType = typ.rowType
-    rvd.rdd.map { rv => new UnsafeRow(localRowType, rv.region.copy(), rv.offset) }
-  }
+  def rdd: RDD[Row] =
+    rvd.toUnsafeRows
 
   def filter(p: (RegionValue, RegionValue) => Boolean): TableValue = {
     val globalType = typ.globalType

--- a/src/main/scala/is/hail/io/LoadMatrix.scala
+++ b/src/main/scala/is/hail/io/LoadMatrix.scala
@@ -392,7 +392,7 @@ object LoadMatrix {
       val (partitioner, keepPartitions) = makePartitionerFromCounts(partitionCounts, matrixType.orvdType.pkType)
       OrderedRVD(matrixType.orvdType, partitioner, rdd.subsetPartitions(keepPartitions))
     } else
-      OrderedRVD(matrixType.orvdType, rdd, None, None)
+      OrderedRVD.coerce(matrixType.orvdType, rdd, None, None)
 
     new MatrixTable(hc,
       matrixType,

--- a/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -169,7 +169,7 @@ object LoadBgen {
     new MatrixTable(hc, matrixType,
       BroadcastValue(Annotation.empty, matrixType.globalType, sc),
       sampleIds.map(x => Annotation(x)),
-      OrderedRVD(matrixType.orvdType, rdd2, Some(fastKeys), None))
+      OrderedRVD.coerce(matrixType.orvdType, rdd2, Some(fastKeys), None))
   }
 
   def index(hConf: org.apache.hadoop.conf.Configuration, file: String) {

--- a/src/main/scala/is/hail/io/plink/LoadPlink.scala
+++ b/src/main/scala/is/hail/io/plink/LoadPlink.scala
@@ -189,7 +189,7 @@ object LoadPlink {
     new MatrixTable(hc, matrixType,
       BroadcastValue(Annotation.empty, matrixType.globalType, sc),
       sampleAnnotations,
-      OrderedRVD(matrixType.orvdType, rdd2, Some(fastKeys), None))
+      OrderedRVD.coerce(matrixType.orvdType, rdd2, Some(fastKeys), None))
   }
 
   def apply(hc: HailContext, bedPath: String, bimPath: String, famPath: String, ffConfig: FamFileConfig,

--- a/src/main/scala/is/hail/io/vcf/LoadGDB.scala
+++ b/src/main/scala/is/hail/io/vcf/LoadGDB.scala
@@ -190,6 +190,6 @@ object LoadGDB {
     new MatrixTable(hc, matrixType,
       BroadcastValue(Annotation.empty, matrixType.globalType, sc),
       sampleIds.map(x => Annotation(x)),
-      OrderedRVD(matrixType.orvdType, hc.sc.parallelize(records), None, None))
+      OrderedRVD.coerce(matrixType.orvdType, hc.sc.parallelize(records), None, None))
   }
 }

--- a/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -841,7 +841,7 @@ object LoadVCF {
     // nothing after the key
     val justVariants = parseLines(() => ())((c, l, rvb) => ())(lines, kType, rg, contigRecoding)
 
-    val rdd = OrderedRVD(
+    val rdd = OrderedRVD.coerce(
       matrixType.orvdType,
       parseLines { () =>
         new ParseLineContext(genotypeSignature, new BufferedLineIterator(headerLinesBc.value.iterator.buffered))

--- a/src/main/scala/is/hail/methods/FilterAlleles.scala
+++ b/src/main/scala/is/hail/methods/FilterAlleles.scala
@@ -54,8 +54,8 @@ object FilterAlleles {
     val newEntryType = gAnnotator.newT
     val newMatrixType = vsm.matrixType.copyParts(rowType = vAnnotator.newT, entryType = newEntryType)
 
-    def filter(rdd: RVD,
-      removeLeftAligned: Boolean, removeMoving: Boolean, verifyLeftAligned: Boolean): RVD = {
+    def filter(rdd: OrderedRVD,
+      removeLeftAligned: Boolean, removeMoving: Boolean, verifyLeftAligned: Boolean): OrderedRVD = {
 
       def filterAllelesInVariant(v: Variant, va: Annotation): Option[(Variant, IndexedSeq[Int], IndexedSeq[Int])] = {
         var alive = 0
@@ -176,7 +176,6 @@ object FilterAlleles {
           removeLeftAligned = false,
           removeMoving = false,
           verifyLeftAligned = true)
-          .assertOrdered(newMatrixType.orvdType, vsm.rvd.partitioner)
       } else {
         val leftAlignedVariants =
           filter(
@@ -184,7 +183,6 @@ object FilterAlleles {
             removeLeftAligned = false,
             removeMoving = true,
             verifyLeftAligned = false)
-            .assertOrdered(newMatrixType.orvdType, vsm.rvd.partitioner)
 
         val movingVariants =
           filter(
@@ -192,7 +190,6 @@ object FilterAlleles {
             removeLeftAligned = true,
             removeMoving = false,
             verifyLeftAligned = false)
-            .assertOrdered(newMatrixType.orvdType, vsm.rvd.partitioner)
 
         leftAlignedVariants.partitionSortedUnion(movingVariants)
       }

--- a/src/main/scala/is/hail/methods/FilterAlleles.scala
+++ b/src/main/scala/is/hail/methods/FilterAlleles.scala
@@ -171,17 +171,28 @@ object FilterAlleles {
 
     val newRDD2: OrderedRVD =
       if (leftAligned) {
-        OrderedRVD(newMatrixType.orvdType,
-          vsm.rvd.partitioner,
-          filter(vsm.rvd, removeLeftAligned = false, removeMoving = false, verifyLeftAligned = true))
+        filter(
+          vsm.rvd,
+          removeLeftAligned = false,
+          removeMoving = false,
+          verifyLeftAligned = true)
+          .assertOrdered(newMatrixType.orvdType, vsm.rvd.partitioner)
       } else {
-        val leftAlignedVariants = OrderedRVD(newMatrixType.orvdType,
-          vsm.rvd.partitioner,
-          filter(vsm.rvd, removeLeftAligned = false, removeMoving = true, verifyLeftAligned = false))
+        val leftAlignedVariants =
+          filter(
+            vsm.rvd,
+            removeLeftAligned = false,
+            removeMoving = true,
+            verifyLeftAligned = false)
+            .assertOrdered(newMatrixType.orvdType, vsm.rvd.partitioner)
 
-        val movingVariants = OrderedRVD.shuffle(newMatrixType.orvdType,
-          vsm.rvd.partitioner,
-          filter(vsm.rvd, removeLeftAligned = true, removeMoving = false, verifyLeftAligned = false))
+        val movingVariants =
+          filter(
+            vsm.rvd,
+            removeLeftAligned = true,
+            removeMoving = false,
+            verifyLeftAligned = false)
+            .assertOrdered(newMatrixType.orvdType, vsm.rvd.partitioner)
 
         leftAlignedVariants.partitionSortedUnion(movingVariants)
       }

--- a/src/main/scala/is/hail/methods/FilterAlleles.scala
+++ b/src/main/scala/is/hail/methods/FilterAlleles.scala
@@ -171,32 +171,17 @@ object FilterAlleles {
 
     val newRDD2: OrderedRVD =
       if (leftAligned) {
-        OrderedRVD.coerce(
-          newMatrixType.orvdType,
-          filter(
-            vsm.rvd,
-            removeLeftAligned = false,
-            removeMoving = false,
-            verifyLeftAligned = true))
+        OrderedRVD(newMatrixType.orvdType,
+          vsm.rvd.partitioner,
+          filter(vsm.rvd, removeLeftAligned = false, removeMoving = false, verifyLeftAligned = true))
       } else {
-        val leftAlignedVariants =
-          OrderedRVD.coerce(
-            newMatrixType.orvdType,
-            filter(
-              vsm.rvd,
-              removeLeftAligned = false,
-              removeMoving = true,
-              verifyLeftAligned = false))
+        val leftAlignedVariants = OrderedRVD(newMatrixType.orvdType,
+          vsm.rvd.partitioner,
+          filter(vsm.rvd, removeLeftAligned = false, removeMoving = true, verifyLeftAligned = false))
 
-        val movingVariants =
-          OrderedRVD.shuffle(
-            newMatrixType.orvdType,
-            vsm.rvd.partitioner,
-            filter(
-              vsm.rvd,
-              removeLeftAligned = true,
-              removeMoving = false,
-              verifyLeftAligned = false))
+        val movingVariants = OrderedRVD.shuffle(newMatrixType.orvdType,
+          vsm.rvd.partitioner,
+          filter(vsm.rvd, removeLeftAligned = true, removeMoving = false, verifyLeftAligned = false))
 
         leftAlignedVariants.partitionSortedUnion(movingVariants)
       }

--- a/src/main/scala/is/hail/methods/FilterAlleles.scala
+++ b/src/main/scala/is/hail/methods/FilterAlleles.scala
@@ -99,7 +99,7 @@ object FilterAlleles {
 
       val localSampleAnnotationsBc = vsm.colValuesBc
 
-      rdd.mapPartitions(newRVType) { it =>
+      rdd.mapPartitionsPreservesPartitioning(newRVType) { it =>
         var prevLocus: Locus = null
         val fullRow = new UnsafeRow(fullRowType)
         val row = fullRow.deleteField(localEntriesIndex)

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -377,7 +377,7 @@ class OrderedRVD(
   def zipPartitionsPreservesPartitioning[T: ClassTag](
     newTyp: OrderedRVDType, that: RDD[T]
   )(zipper: (Iterator[RegionValue], Iterator[T]) => Iterator[RegionValue]
-  ) : OrderedRVD =
+  ): OrderedRVD =
     OrderedRVD(
       newTyp,
       partitioner,

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -56,13 +56,6 @@ class OrderedRVD(
       partitioner,
       rdd.mapPartitions(f))
 
-  def zipPartitionsPreservesPartitioning[T](newTyp: OrderedRVDType, rdd2: RDD[T])(f: (Iterator[RegionValue], Iterator[T]) => Iterator[RegionValue])(implicit tct: ClassTag[T]): OrderedRVD =
-    OrderedRVD(newTyp,
-      partitioner,
-      rdd.zipPartitions(rdd2) { case (it, it2) =>
-        f(it, it2)
-      })
-
   override def filter(p: (RegionValue) => Boolean): OrderedRVD =
     OrderedRVD(typ,
       partitioner,

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -51,14 +51,6 @@ class OrderedRVD(
       partitioner,
       rdd.mapPartitionsWithIndex(f))
 
-  def mapPartitionsPreservesPartitioning(
-    rowTyp: TStruct
-  )(f: (Iterator[RegionValue]) => Iterator[RegionValue]
-  ): OrderedRVD =
-    OrderedRVD(typ.copy(rowType = rowTyp),
-      partitioner,
-      rdd.mapPartitions(f))
-
   def mapPartitionsPreservesPartitioning(newTyp: OrderedRVDType)(f: (Iterator[RegionValue]) => Iterator[RegionValue]): OrderedRVD =
     OrderedRVD(newTyp,
       partitioner,
@@ -625,6 +617,12 @@ object OrderedRVD {
 
     shuffle(typ, partitioner.enlargeToRange(Interval(min, max, true, true)), rdd)
   }
+
+  def shuffle(
+    typ: OrderedRVDType,
+    partitioner: OrderedRVDPartitioner,
+    rvd: RVD
+  ): OrderedRVD = shuffle(typ, partitioner, rvd.rdd)
 
   def shuffle(typ: OrderedRVDType,
     partitioner: OrderedRVDPartitioner,

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -367,7 +367,8 @@ class OrderedRVD(
   }
 
   def zipPartitionsPreservesPartitioning[T: ClassTag](
-    newTyp: OrderedRVDType, that: RDD[T]
+    newTyp: OrderedRVDType,
+    that: RDD[T]
   )(zipper: (Iterator[RegionValue], Iterator[T]) => Iterator[RegionValue]
   ): OrderedRVD =
     OrderedRVD(
@@ -375,17 +376,21 @@ class OrderedRVD(
       partitioner,
       this.rdd.zipPartitions(that, preservesPartitioning = true)(zipper))
 
-  def zipPartitionsPreservesPartitioning(newTyp: OrderedRVDType, that: RVD)
-    (zipper: (Iterator[RegionValue], Iterator[RegionValue]) => Iterator[RegionValue])
-      : OrderedRVD =
+  def zipPartitionsPreservesPartitioning(
+    newTyp: OrderedRVDType,
+    that: RVD
+  )(zipper: (Iterator[RegionValue], Iterator[RegionValue]) => Iterator[RegionValue]
+  ): OrderedRVD =
     OrderedRVD(
       newTyp,
       partitioner,
       this.rdd.zipPartitions(that.rdd, preservesPartitioning = true)(zipper))
 
-  def writeRowsSplit(path: String, t: MatrixType, codecSpec: CodecSpec)
-      : Array[Long] =
-    rdd.writeRowsSplit(path, t, codecSpec, partitioner)
+  def writeRowsSplit(
+    path: String,
+    t: MatrixType,
+    codecSpec: CodecSpec
+  ): Array[Long] = rdd.writeRowsSplit(path, t, codecSpec, partitioner)
 }
 
 object OrderedRVD {

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -468,12 +468,50 @@ object OrderedRVD {
     pkis.sortBy(_.min)(typ.pkOrd)
   }
 
-  def coerce(typ: OrderedRVDType,
+  def coerce(
+    typ: OrderedRVDType,
+    rvd: RVD
+  ): OrderedRVD = coerce(typ, rvd, None, None)
+
+  def coerce(
+    typ: OrderedRVDType,
+    rvd: RVD,
+    fastKeys: Option[RDD[RegionValue]],
+    hintPartitioner: Option[OrderedRVDPartitioner]
+  ): OrderedRVD = coerce(typ, rvd.rdd, fastKeys, hintPartitioner)
+
+  def coerce(
+    typ: OrderedRVDType,
+    rdd: RDD[RegionValue]
+  ): OrderedRVD = coerce(typ, rdd, None, None)
+
+  def coerce(
+    typ: OrderedRVDType,
+    rdd: RDD[RegionValue],
+    fastKeys: RDD[RegionValue]
+  ): OrderedRVD = coerce(typ, rdd, Some(fastKeys), None)
+
+  def coerce(
+    typ: OrderedRVDType,
+    rdd: RDD[RegionValue],
+    hintPartitioner: OrderedRVDPartitioner
+  ): OrderedRVD = coerce(typ, rdd, None, Some(hintPartitioner))
+
+  def coerce(
+    typ: OrderedRVDType,
+    rdd: RDD[RegionValue],
+    fastKeys: RDD[RegionValue],
+    hintPartitioner: OrderedRVDPartitioner
+  ): OrderedRVD = coerce(typ, rdd, Some(fastKeys), Some(hintPartitioner))
+
+  def coerce(
+    typ: OrderedRVDType,
     // rdd: RDD[RegionValue[rowType]]
     rdd: RDD[RegionValue],
     // fastKeys: Option[RDD[RegionValue[kType]]]
-    fastKeys: Option[RDD[RegionValue]] = None,
-    hintPartitioner: Option[OrderedRVDPartitioner] = None): OrderedRVD = {
+    fastKeys: Option[RDD[RegionValue]],
+    hintPartitioner: Option[OrderedRVDPartitioner]
+  ): OrderedRVD = {
     val sc = rdd.sparkContext
 
     if (rdd.partitions.isEmpty)

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -51,6 +51,13 @@ class OrderedRVD(
       partitioner,
       rdd.mapPartitionsWithIndex(f))
 
+  def mapPartitionsPreservesPartitioning(rowTyp: TStruct)
+    (f: (Iterator[RegionValue]) => Iterator[RegionValue])
+      : OrderedRVD =
+    OrderedRVD(typ.copy(rowType = rowTyp),
+      partitioner,
+      rdd.mapPartitions(f))
+
   def mapPartitionsPreservesPartitioning(newTyp: OrderedRVDType)(f: (Iterator[RegionValue]) => Iterator[RegionValue]): OrderedRVD =
     OrderedRVD(newTyp,
       partitioner,

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -392,11 +392,7 @@ object OrderedRVD {
 
   // FIXME: delete this, it's just a wrapper around coerce
   def apply(typ: OrderedRVDType,
-    // rdd: RDD[RegionValue[rowType]]
-    rdd: RDD[RegionValue],
-    // fastKeys: Option[RDD[RegionValue[kType]]]
-    fastKeys: Option[RDD[RegionValue]] = None,
-    hintPartitioner: Option[OrderedRVDPartitioner] = None): OrderedRVD =
+    rdd: RDD[RegionValue], fastKeys: Option[RDD[RegionValue]], hintPartitioner: Option[OrderedRVDPartitioner]): OrderedRVD =
     coerce(typ, rdd, fastKeys, hintPartitioner)
 
   /**

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -498,7 +498,7 @@ object OrderedRVD {
 
       val reorderedPartitionsRDD = rdd.reorderPartitions(pkis.map(_.partitionIndex))
       val adjustedRDD = new AdjustedPartitionsRDD(reorderedPartitionsRDD, adjustedPartitions)
-        (adjSortedness: @unchecked) match {
+      (adjSortedness: @unchecked) match {
         case OrderedRVPartitionInfo.KSORTED =>
           info("Coerced sorted dataset")
           OrderedRVD(typ,

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -373,28 +373,22 @@ class OrderedRVD(
     partitionCounts
   }
 
-  def zipPartitions(newTyp: OrderedRVDType, that: RVD)
+  def zipPartitionsPreservesPartitioning[T: ClassTag](
+    newTyp: OrderedRVDType, that: RDD[T]
+  )(zipper: (Iterator[RegionValue], Iterator[T]) => Iterator[RegionValue]
+  ) : OrderedRVD =
+    OrderedRVD(
+      newTyp,
+      partitioner,
+      this.rdd.zipPartitions(that, preservesPartitioning = true)(zipper))
+
+  def zipPartitionsPreservesPartitioning(newTyp: OrderedRVDType, that: RVD)
     (zipper: (Iterator[RegionValue], Iterator[RegionValue]) => Iterator[RegionValue])
-      : OrderedRVD =
-    zipPartitions(newTyp, that, false)(zipper)
-
-  def zipPartitions(newTyp: OrderedRVDType, that: RVD, preservesPartitioning: Boolean)
-    (zipper: (Iterator[RegionValue], Iterator[RegionValue]) => Iterator[RegionValue])
-      : OrderedRVD =
-    zipPartitions(newTyp, that.rdd, preservesPartitioning)(zipper)
-
-  def zipPartitions[T: ClassTag](newTyp: OrderedRVDType, that: RDD[T])
-    (zipper: (Iterator[RegionValue], Iterator[T]) => Iterator[RegionValue])
-      : OrderedRVD =
-    zipPartitions(newTyp, that, false)(zipper)
-
-  def zipPartitions[T: ClassTag](newTyp: OrderedRVDType, that: RDD[T], preservesPartitioning: Boolean)
-    (zipper: (Iterator[RegionValue], Iterator[T]) => Iterator[RegionValue])
       : OrderedRVD =
     OrderedRVD(
       newTyp,
       partitioner,
-      this.rdd.zipPartitions(that, preservesPartitioning)(zipper))
+      this.rdd.zipPartitions(that.rdd, preservesPartitioning = true)(zipper))
 
   def writeRowsSplit(path: String, t: MatrixType, codecSpec: CodecSpec)
       : Array[Long] =

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -369,7 +369,7 @@ class OrderedRVD(
   def zipPartitions(newTyp: OrderedRVDType, that: RVD)
     (zipper: (Iterator[RegionValue], Iterator[RegionValue]) => Iterator[RegionValue])
       : OrderedRVD =
-    zipPartitions(newTyp, that, true)(zipper)
+    zipPartitions(newTyp, that, false)(zipper)
 
   def zipPartitions(newTyp: OrderedRVDType, that: RVD, preservesPartitioning: Boolean)
     (zipper: (Iterator[RegionValue], Iterator[RegionValue]) => Iterator[RegionValue])
@@ -379,7 +379,7 @@ class OrderedRVD(
   def zipPartitions[T: ClassTag](newTyp: OrderedRVDType, that: RDD[T])
     (zipper: (Iterator[RegionValue], Iterator[T]) => Iterator[RegionValue])
       : OrderedRVD =
-    zipPartitions(newTyp, that, true)(zipper)
+    zipPartitions(newTyp, that, false)(zipper)
 
   def zipPartitions[T: ClassTag](newTyp: OrderedRVDType, that: RDD[T], preservesPartitioning: Boolean)
     (zipper: (Iterator[RegionValue], Iterator[T]) => Iterator[RegionValue])
@@ -400,11 +400,6 @@ object OrderedRVD {
       OrderedRVDPartitioner.empty(typ),
       sc.emptyRDD[RegionValue])
   }
-
-  // FIXME: delete this, it's just a wrapper around coerce
-  def apply(typ: OrderedRVDType,
-    rdd: RDD[RegionValue], fastKeys: Option[RDD[RegionValue]], hintPartitioner: Option[OrderedRVDPartitioner]): OrderedRVD =
-    coerce(typ, rdd, fastKeys, hintPartitioner)
 
   /**
     * Precondition: the iterator it is PK-sorted.  We lazily K-sort each block
@@ -725,7 +720,7 @@ object OrderedRVD {
     require(rvds.length > 1)
     val first = rvds(0)
     val sc = first.sparkContext
-    OrderedRVD(
+    OrderedRVD.coerce(
       first.typ,
       sc.union(rvds.map(_.rdd)),
       None,

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -23,21 +23,6 @@ class OrderedRVD(
   self =>
   def rowType: TStruct = typ.rowType
 
-  // should be totally generic, permitting any number of keys, but that requires more work
-  def downcastToPK(): OrderedRVD = {
-    val newType = new OrderedRVDType(partitionKey = typ.partitionKey,
-      key = typ.partitionKey,
-      rowType = rowType)
-    OrderedRVD(newType, partitioner, rdd)
-  }
-
-  def upcast(castKeys: Array[String]): OrderedRVD = {
-    val newType = new OrderedRVDType(partitionKey = typ.partitionKey,
-      key = typ.key ++ castKeys,
-      rowType = rowType)
-    OrderedRVD(newType, partitioner, rdd)
-  }
-
   def updateType(newTyp: OrderedRVDType): OrderedRVD =
     OrderedRVD(newTyp, partitioner, rdd)
 

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -714,6 +714,12 @@ object OrderedRVD {
     (adjustmentsBuffer, rangeBounds, adjSortedness)
   }
 
+  def apply(
+    typ: OrderedRVDType,
+    partitioner: OrderedRVDPartitioner,
+    rvd: RVD
+  ): OrderedRVD = apply(typ, partitioner, rvd.rdd)
+
   def apply(typ: OrderedRVDType,
     partitioner: OrderedRVDPartitioner,
     rdd: RDD[RegionValue]): OrderedRVD = {

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -366,26 +366,26 @@ class OrderedRVD(
     partitionCounts
   }
 
-  def zipPartitions(that: RVD)
+  def zipPartitions(newTyp: OrderedRVDType, that: RVD)
     (zipper: (Iterator[RegionValue], Iterator[RegionValue]) => Iterator[RegionValue])
       : OrderedRVD =
-    zipPartitions(that, true)(zipper)
+    zipPartitions(newTyp, that, true)(zipper)
 
-  def zipPartitions(that: RVD, preservesPartitioning: Boolean)
+  def zipPartitions(newTyp: OrderedRVDType, that: RVD, preservesPartitioning: Boolean)
     (zipper: (Iterator[RegionValue], Iterator[RegionValue]) => Iterator[RegionValue])
       : OrderedRVD =
-    zipPartitions(that.rdd, preservesPartitioning)(zipper)
+    zipPartitions(newTyp, that.rdd, preservesPartitioning)(zipper)
 
-  def zipPartitions[T: ClassTag](that: RDD[T])
+  def zipPartitions[T: ClassTag](newTyp: OrderedRVDType, that: RDD[T])
     (zipper: (Iterator[RegionValue], Iterator[T]) => Iterator[RegionValue])
       : OrderedRVD =
-    zipPartitions(that, true)(zipper)
+    zipPartitions(newTyp, that, true)(zipper)
 
-  def zipPartitions[T: ClassTag](that: RDD[T], preservesPartitioning: Boolean)
+  def zipPartitions[T: ClassTag](newTyp: OrderedRVDType, that: RDD[T], preservesPartitioning: Boolean)
     (zipper: (Iterator[RegionValue], Iterator[T]) => Iterator[RegionValue])
       : OrderedRVD =
     OrderedRVD(
-      typ,
+      newTyp,
       partitioner,
       this.rdd.zipPartitions(that, preservesPartitioning)(zipper))
 

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -354,26 +354,40 @@ class OrderedRVD(
     spec.write(sparkContext.hadoopConfiguration, path)
     partitionCounts
   }
+
+  def zipPartitions(that: OrderedRVD)
+    (zipper: (Iterator[RegionValue], Iterator[RegionValue]) => Iterator[RegionValue])
+      : OrderedRVD =
+    zipPartitions(that, true)(zipper)
+
+  def zipPartitions(that: OrderedRVD, preservesPartitioning: Boolean)
+    (zipper: (Iterator[RegionValue], Iterator[RegionValue]) => Iterator[RegionValue])
+      : OrderedRVD =
+    zipPartitions(that.rdd, preservesPartitioning)(zipper)
+
+  def zipPartitions[T: ClassTag](that: RDD[T])
+    (zipper: (Iterator[RegionValue], Iterator[T]) => Iterator[RegionValue])
+      : OrderedRVD =
+    zipPartitions(that, true)(zipper)
+
+  def zipPartitions[T: ClassTag](that: RDD[T], preservesPartitioning: Boolean)
+    (zipper: (Iterator[RegionValue], Iterator[T]) => Iterator[RegionValue])
+      : OrderedRVD =
+    OrderedRVD(
+      typ,
+      partitioner,
+      this.rdd.zipPartitions(that, preservesPartitioning)(zipper))
+
+  def writeRowsSplit(path: String, t: MatrixType, codecSpec: CodecSpec)
+      : Array[Long] =
+    rdd.writeRowsSplit(path, t, codecSpec, partitioner)
 }
 
 object OrderedRVD {
-  type CoercionMethod = Int
-
-  final val ORDERED_PARTITIONER: CoercionMethod = 0
-  final val AS_IS: CoercionMethod = 1
-  final val LOCAL_SORT: CoercionMethod = 2
-  final val SHUFFLE: CoercionMethod = 3
-
   def empty(sc: SparkContext, typ: OrderedRVDType): OrderedRVD = {
     OrderedRVD(typ,
       OrderedRVDPartitioner.empty(typ),
       sc.emptyRDD[RegionValue])
-  }
-
-  def apply(typ: OrderedRVDType,
-    rdd: RDD[RegionValue], fastKeys: Option[RDD[RegionValue]], hintPartitioner: Option[OrderedRVDPartitioner]): OrderedRVD = {
-    val (_, orderedRVD) = coerce(typ, rdd, fastKeys, hintPartitioner)
-    orderedRVD
   }
 
   /**
@@ -443,71 +457,6 @@ object OrderedRVD {
     pkis.sortBy(_.min)(typ.pkOrd)
   }
 
-  def coerce(typ: OrderedRVDType,
-    // rdd: RDD[RegionValue[rowType]]
-    rdd: RDD[RegionValue],
-    // fastKeys: Option[RDD[RegionValue[kType]]]
-    fastKeys: Option[RDD[RegionValue]] = None,
-    hintPartitioner: Option[OrderedRVDPartitioner] = None): (CoercionMethod, OrderedRVD) = {
-    val sc = rdd.sparkContext
-
-    if (rdd.partitions.isEmpty)
-      return (ORDERED_PARTITIONER, empty(sc, typ))
-
-    // keys: RDD[RegionValue[kType]]
-    val keys = fastKeys.getOrElse(getKeys(typ, rdd))
-
-    val pkis = getPartitionKeyInfo(typ, keys)
-
-    if (pkis.isEmpty)
-      return (AS_IS, empty(sc, typ))
-
-    val partitionsSorted = (pkis, pkis.tail).zipped.forall { case (p, pnext) =>
-      val r = typ.pkOrd.lteq(p.max, pnext.min)
-      if (!r)
-        log.info(s"not sorted: p = $p, pnext = $pnext")
-      r
-    }
-
-    val sortedness = pkis.map(_.sortedness).min
-    if (partitionsSorted && sortedness >= OrderedRVPartitionInfo.TSORTED) {
-      val (adjustedPartitions, rangeBounds, adjSortedness) = rangesAndAdjustments(typ, pkis, sortedness)
-
-      val partitioner = new OrderedRVDPartitioner(typ.partitionKey,
-        typ.kType,
-        rangeBounds)
-
-      val reorderedPartitionsRDD = rdd.reorderPartitions(pkis.map(_.partitionIndex))
-      val adjustedRDD = new AdjustedPartitionsRDD(reorderedPartitionsRDD, adjustedPartitions)
-      (adjSortedness: @unchecked) match {
-        case OrderedRVPartitionInfo.KSORTED =>
-          info("Coerced sorted dataset")
-          (AS_IS, OrderedRVD(typ,
-            partitioner,
-            adjustedRDD))
-
-        case OrderedRVPartitionInfo.TSORTED =>
-          info("Coerced almost-sorted dataset")
-          (LOCAL_SORT, OrderedRVD(typ,
-            partitioner,
-            adjustedRDD.mapPartitions { it =>
-              localKeySort(typ, it)
-            }))
-      }
-    } else {
-      info("Ordering unsorted dataset with network shuffle")
-      val orvd = hintPartitioner
-        .filter(_.numPartitions >= rdd.partitions.length)
-        .map(adjustBoundsAndShuffle(typ, _, rdd))
-        .getOrElse {
-          val ranges = calculateKeyRanges(typ, pkis, rdd.getNumPartitions)
-          val p = new OrderedRVDPartitioner(typ.partitionKey, typ.kType, ranges)
-          shuffle(typ, p, rdd)
-        }
-      (SHUFFLE, orvd)
-    }
-  }
-
   def calculateKeyRanges(typ: OrderedRVDType, pkis: Array[OrderedRVPartitionInfo], nPartitions: Int): UnsafeIndexedSeq = {
     assert(nPartitions > 0)
 
@@ -562,6 +511,79 @@ object OrderedRVD {
     shuffle(typ, partitioner.enlargeToRange(Interval(min, max, true, true)), rdd)
   }
 
+  // FIXME: delete eventually, only here to keep changes small for this PR
+  def apply(typ: OrderedRVDType,
+    // rdd: RDD[RegionValue[rowType]]
+    rdd: RDD[RegionValue],
+    // fastKeys: Option[RDD[RegionValue[kType]]]
+    fastKeys: Option[RDD[RegionValue]] = None,
+    hintPartitioner: Option[OrderedRVDPartitioner] = None): OrderedRVD =
+    coerce(typ, rdd, fastKeys, hintPartitioner)
+
+  def coerce(typ: OrderedRVDType,
+    // rdd: RDD[RegionValue[rowType]]
+    rdd: RDD[RegionValue],
+    // fastKeys: Option[RDD[RegionValue[kType]]]
+    fastKeys: Option[RDD[RegionValue]] = None,
+    hintPartitioner: Option[OrderedRVDPartitioner] = None): OrderedRVD = {
+    val sc = rdd.sparkContext
+
+    if (rdd.partitions.isEmpty)
+      return empty(sc, typ)
+
+    // keys: RDD[RegionValue[kType]]
+    val keys = fastKeys.getOrElse(getKeys(typ, rdd))
+
+    val pkis = getPartitionKeyInfo(typ, keys)
+
+    if (pkis.isEmpty)
+      return empty(sc, typ)
+
+    val partitionsSorted = (pkis, pkis.tail).zipped.forall { case (p, pnext) =>
+      val r = typ.pkOrd.lteq(p.max, pnext.min)
+      if (!r)
+        log.info(s"not sorted: p = $p, pnext = $pnext")
+      r
+    }
+
+    val sortedness = pkis.map(_.sortedness).min
+    if (partitionsSorted && sortedness >= OrderedRVPartitionInfo.TSORTED) {
+      val (adjustedPartitions, rangeBounds, adjSortedness) = rangesAndAdjustments(typ, pkis, sortedness)
+
+      val partitioner = new OrderedRVDPartitioner(typ.partitionKey,
+        typ.kType,
+        rangeBounds)
+
+      val reorderedPartitionsRDD = rdd.reorderPartitions(pkis.map(_.partitionIndex))
+      val adjustedRDD = new AdjustedPartitionsRDD(reorderedPartitionsRDD, adjustedPartitions)
+        (adjSortedness: @unchecked) match {
+        case OrderedRVPartitionInfo.KSORTED =>
+          info("Coerced sorted dataset")
+          OrderedRVD(typ,
+            partitioner,
+            adjustedRDD)
+
+        case OrderedRVPartitionInfo.TSORTED =>
+          info("Coerced almost-sorted dataset")
+          OrderedRVD(typ,
+            partitioner,
+            adjustedRDD.mapPartitions { it =>
+              localKeySort(typ, it)
+            })
+      }
+    } else {
+      info("Ordering unsorted dataset with network shuffle")
+      hintPartitioner
+        .filter(_.numPartitions >= rdd.partitions.length)
+        .map(adjustBoundsAndShuffle(typ, _, rdd))
+        .getOrElse {
+        val ranges = calculateKeyRanges(typ, pkis, rdd.getNumPartitions)
+        val p = new OrderedRVDPartitioner(typ.partitionKey, typ.kType, ranges)
+        shuffle(typ, p, rdd)
+      }
+    }
+  }
+
   def shuffle(typ: OrderedRVDType,
     partitioner: OrderedRVDPartitioner,
     rdd: RDD[RegionValue]): OrderedRVD = {
@@ -586,9 +608,6 @@ object OrderedRVD {
           }
         })
   }
-
-  def shuffle(typ: OrderedRVDType, partitioner: OrderedRVDPartitioner, rvd: RVD): OrderedRVD =
-    shuffle(typ, partitioner, rvd.rdd)
 
   def rangesAndAdjustments(typ: OrderedRVDType,
     sortedKeyInfo: Array[OrderedRVPartitionInfo],
@@ -695,8 +714,14 @@ object OrderedRVD {
     })
   }
 
-  def apply(typ: OrderedRVDType, partitioner: OrderedRVDPartitioner, rvd: RVD): OrderedRVD = {
-    assert(typ.rowType == rvd.rowType)
-    apply(typ, partitioner, rvd.rdd)
+  def union(rvds: Array[OrderedRVD]): OrderedRVD = {
+    require(rvds.length > 1)
+    val first = rvds(0)
+    val sc = first.sparkContext
+    OrderedRVD(
+      first.typ,
+      sc.union(rvds.map(_.rdd)),
+      None,
+      None)
   }
 }

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -38,7 +38,7 @@ class OrderedRVD(
     OrderedRVD(newType, partitioner, rdd)
   }
 
-  def unsafeChangeType(newTyp: OrderedRVDType): OrderedRVD =
+  def updateType(newTyp: OrderedRVDType): OrderedRVD =
     OrderedRVD(newTyp, partitioner, rdd)
 
   def mapPreservesPartitioning(newTyp: OrderedRVDType)(f: (RegionValue) => RegionValue): OrderedRVD =

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -51,9 +51,10 @@ class OrderedRVD(
       partitioner,
       rdd.mapPartitionsWithIndex(f))
 
-  def mapPartitionsPreservesPartitioning(rowTyp: TStruct)
-    (f: (Iterator[RegionValue]) => Iterator[RegionValue])
-      : OrderedRVD =
+  def mapPartitionsPreservesPartitioning(
+    rowTyp: TStruct
+  )(f: (Iterator[RegionValue]) => Iterator[RegionValue]
+  ): OrderedRVD =
     OrderedRVD(typ.copy(rowType = rowTyp),
       partitioner,
       rdd.mapPartitions(f))

--- a/src/main/scala/is/hail/rvd/OrderedRVDType.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVDType.scala
@@ -118,7 +118,7 @@ class OrderedRVDType(
     partitionKey: Array[String] = partitionKey,
     key: Array[String] = key,
     rowType: TStruct = rowType
-  ) : OrderedRVDType = new OrderedRVDType(partitionKey, key, rowType)
+  ): OrderedRVDType = new OrderedRVDType(partitionKey, key, rowType)
 }
 
 object OrderedRVDType {

--- a/src/main/scala/is/hail/rvd/OrderedRVDType.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVDType.scala
@@ -113,6 +113,12 @@ class OrderedRVDType(
     sb += '}'
     sb.result()
   }
+
+  def copy(
+    partitionKey: Array[String] = partitionKey,
+    key: Array[String] = key,
+    rowType: TStruct = rowType
+  ) : OrderedRVDType = new OrderedRVDType(partitionKey, key, rowType)
 }
 
 object OrderedRVDType {

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -211,16 +211,6 @@ trait RVD {
 
   def write(path: String, codecSpec: CodecSpec): Array[Long]
 
-  def shuffle(typ: OrderedRVDType, partitioner: OrderedRVDPartitioner): OrderedRVD = {
-    assert(typ.rowType == rowType)
-    OrderedRVD.shuffle(typ, partitioner, rdd)
-  }
-
-  def assertOrdered(typ: OrderedRVDType, partitioner: OrderedRVDPartitioner): OrderedRVD = {
-    assert(typ.rowType == rowType)
-    OrderedRVD(typ, partitioner, rdd)
-  }
-
   def toRows: RDD[Row] = {
     val localRowType = rowType
     rdd.map { rv => new UnsafeRow(localRowType, rv.region.copy(), rv.offset) }

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -215,11 +215,4 @@ trait RVD {
     val localRowType = rowType
     rdd.map { rv => new UnsafeRow(localRowType, rv.region.copy(), rv.offset) }
   }
-
-  def coerceOrdered(
-    typ: OrderedRVDType,
-    // fastKeys: Option[RDD[RegionValue[kType]]]
-    fastKeys: Option[RDD[RegionValue]] = None,
-    hintPartitioner: Option[OrderedRVDPartitioner] = None
-  ): OrderedRVD = OrderedRVD.coerce(typ, rdd, fastKeys, hintPartitioner)
 }

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -4,6 +4,7 @@ import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.expr.{JSONAnnotationImpex, Parser}
 import is.hail.expr.types.{TArray, TInterval, TStruct, TStructSerializer}
+import is.hail.sparkextras._
 import is.hail.io._
 import is.hail.utils._
 import org.apache.hadoop
@@ -209,4 +210,26 @@ trait RVD {
   def sample(withReplacement: Boolean, p: Double, seed: Long): RVD
 
   def write(path: String, codecSpec: CodecSpec): Array[Long]
+
+  def shuffle(typ: OrderedRVDType, partitioner: OrderedRVDPartitioner): OrderedRVD = {
+    assert(typ.rowType == rowType)
+    OrderedRVD.shuffle(typ, partitioner, rdd)
+  }
+
+  def assertOrdered(typ: OrderedRVDType, partitioner: OrderedRVDPartitioner): OrderedRVD = {
+    assert(typ.rowType == rowType)
+    OrderedRVD(typ, partitioner, rdd)
+  }
+
+  def toUnsafeRows: RDD[Row] = {
+    val localRowType = rowType
+    rdd.map { rv => new UnsafeRow(localRowType, rv.region.copy(), rv.offset) }
+  }
+
+  def coerceOrdered(
+    typ: OrderedRVDType,
+    // fastKeys: Option[RDD[RegionValue[kType]]]
+    fastKeys: Option[RDD[RegionValue]] = None,
+    hintPartitioner: Option[OrderedRVDPartitioner] = None
+  ): OrderedRVD = OrderedRVD.coerce(typ, rdd, fastKeys, hintPartitioner)
 }

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -221,7 +221,7 @@ trait RVD {
     OrderedRVD(typ, partitioner, rdd)
   }
 
-  def toUnsafeRows: RDD[Row] = {
+  def toRows: RDD[Row] = {
     val localRowType = rowType
     rdd.map { rv => new UnsafeRow(localRowType, rv.region.copy(), rv.offset) }
   }

--- a/src/main/scala/is/hail/stats/BaldingNicholsModel.scala
+++ b/src/main/scala/is/hail/stats/BaldingNicholsModel.scala
@@ -216,7 +216,7 @@ object BaldingNicholsModel {
         Array.tabulate(N)(i => Annotation(i, popOfSample_n(0, i).toInt))
 
     // FIXME: should use fast keys
-    val ordrdd = OrderedRVD(matrixType.orvdType, rdd, None, None)
+    val ordrdd = OrderedRVD.coerce(matrixType.orvdType, rdd, None, None)
 
     new MatrixTable(hc,
       matrixType,

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -602,7 +602,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
     }
 
     val ordType = new OrderedRVDType(partitionKeys, rowKeys ++ Array(INDEX_UID), rowEntryStruct)
-    val ordered = OrderedRVD(ordType, rowEntryRVD.rdd, None, None)
+    val ordered = rowEntryRVD.coerceOrdered(ordType, None, None)
 
     val matrixType: MatrixType = MatrixType.fromParts(
       globalSignature,
@@ -1144,6 +1144,6 @@ class Table(val hc: HailContext, val tir: TableIR) {
   def toOrderedRVD(hintPartitioner: Option[OrderedRVDPartitioner], partitionKeys: Int): OrderedRVD = {
     val orderedKTType = new OrderedRVDType(key.take(partitionKeys).toArray, key.toArray, signature)
     assert(hintPartitioner.forall(p => p.pkType.types.sameElements(orderedKTType.pkType.types)))
-    OrderedRVD(orderedKTType, rvd.rdd, None, hintPartitioner)
+    rvd.coerceOrdered(orderedKTType, None, hintPartitioner)
   }
 }

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -602,7 +602,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
     }
 
     val ordType = new OrderedRVDType(partitionKeys, rowKeys ++ Array(INDEX_UID), rowEntryStruct)
-    val ordered = rowEntryRVD.coerceOrdered(ordType, None, None)
+    val ordered = OrderedRVD.coerce(ordType, rowEntryRVD)
 
     val matrixType: MatrixType = MatrixType.fromParts(
       globalSignature,
@@ -1144,6 +1144,6 @@ class Table(val hc: HailContext, val tir: TableIR) {
   def toOrderedRVD(hintPartitioner: Option[OrderedRVDPartitioner], partitionKeys: Int): OrderedRVD = {
     val orderedKTType = new OrderedRVDType(key.take(partitionKeys).toArray, key.toArray, signature)
     assert(hintPartitioner.forall(p => p.pkType.types.sameElements(orderedKTType.pkType.types)))
-    rvd.coerceOrdered(orderedKTType, None, hintPartitioner)
+    OrderedRVD.coerce(orderedKTType, rvd, None, hintPartitioner)
   }
 }

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -569,7 +569,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
       rowPartitionKey = partitionKeys)
 
     copyMT(matrixType = newMatrixType,
-      rvd = rvd.coerceOrdered(newMatrixType.orvdType, None, None))
+      rvd = OrderedRVD.coerce(newMatrixType.orvdType, rvd))
   }
 
   def keyColsBy(keys: java.util.ArrayList[String]): MatrixTable = keyColsBy(keys.asScala: _*)
@@ -1368,7 +1368,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   def nPartitions: Int = rvd.partitions.length
 
   def annotateRowsVDS(right: MatrixTable, root: String): MatrixTable =
-    orderedRVDLeftJoinDistinctAndInsert(right.rowFieldsRVD, root, product = false
+    orderedRVDLeftJoinDistinctAndInsert(right.rowFieldsRVD, root, product = false)
 
   def count(): (Long, Long) = (countRows(), numCols)
 
@@ -2305,7 +2305,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
       Array.empty[String])
   }
 
-  private[this] def rowFieldsRVD: OrderedRVD = {
+  private def rowFieldsRVD: OrderedRVD = {
     val localRowType = rowType
     val fullRowType = rvRowType
     val localEntriesIndex = entriesIndex

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1076,8 +1076,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     val newMatrixType = matrixType.copy(rvRowType = newRVType)
     val newRVD = rvd.zipPartitions(
       newMatrixType.orvdType,
-      zipRDD,
-      preservesPartitioning = true
+      zipRDD
     ) { case (it, intervals) =>
       val intervalAnnotations: Array[(Interval, Any)] =
         intervals.map { rv =>

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1073,7 +1073,12 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
     val localRVRowType = rvRowType
     val pkIndex = rvRowType.fieldIdx(rowPartitionKey(0))
-    val newRDD = rvd.zipPartitions(zipRDD, preservesPartitioning = true) { case (it, intervals) =>
+    val newMatrixType = matrixType.copy(rvRowType = newRVType)
+    val newRDD = rvd.zipPartitions(
+      newMatrixType.orvdType,
+      zipRDD,
+      preservesPartitioning = true
+    ) { case (it, intervals) =>
       val intervalAnnotations: Array[(Interval, Any)] =
         intervals.map { rv =>
           val ur = new UnsafeRow(ktSignature, rv)
@@ -1110,8 +1115,6 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
         rv2
       }
     }
-
-    val newMatrixType = matrixType.copy(rvRowType = newRVType)
 
     val newRVD = newRDD.assertOrdered(
       newMatrixType.orvdType,

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -2044,7 +2044,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     val newRVD = if (fieldMapRows.isEmpty) rvd else {
       val newType = newMatrixType.orvdType
       val newPartitioner = rvd.partitioner.withKType(pk.toArray, newType.kType)
-      rvd.unsafeChangeType(newType)
+      rvd.updateType(newType)
     }
 
     new MatrixTable(hc, newMatrixType, globals, colValues, newRVD)

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1113,10 +1113,9 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
     val newMatrixType = matrixType.copy(rvRowType = newRVType)
 
-    val newRVD = OrderedRVD(
+    val newRVD = newRDD.assertOrdered(
       newMatrixType.orvdType,
-      rvd.partitioner,
-      newRDD)
+      rvd.partitioner)
 
     copyMT(rvd = newRVD, matrixType = newMatrixType)
   }

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -2044,7 +2044,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     val newRVD = if (fieldMapRows.isEmpty) rvd else {
       val newType = newMatrixType.orvdType
       val newPartitioner = rvd.partitioner.withKType(pk.toArray, newType.kType)
-      rvd.assertOrdered(newType, newPartitioner)
+      rvd.unsafeChangeType(newType)
     }
 
     new MatrixTable(hc, newMatrixType, globals, colValues, newRVD)

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -303,15 +303,8 @@ object MatrixTable {
   def unionRows(datasets: Array[MatrixTable]): MatrixTable = {
     require(datasets.length >= 2)
     val first = datasets(0)
-    val sc = first.sparkContext
-
     checkDatasetSchemasCompatible(datasets)
-
-    first.copyMT(
-      rvd = OrderedRVD(
-        first.rvd.typ,
-        sc.union(datasets.map(_.rvd.rdd)),
-        None, None))
+    first.copyMT(rvd = OrderedRVD.union(datasets.map(_.rvd)))
   }
 
   def fromRowsTable(kt: Table, partitionKey: java.util.ArrayList[String] = null): MatrixTable = {
@@ -576,7 +569,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
       rowPartitionKey = partitionKeys)
 
     copyMT(matrixType = newMatrixType,
-      rvd = OrderedRVD(newMatrixType.orvdType, rvd.rdd, None, None))
+      rvd = rvd.coerceOrdered(newMatrixType.orvdType, None, None))
   }
 
   def keyColsBy(keys: java.util.ArrayList[String]): MatrixTable = keyColsBy(keys.asScala: _*)
@@ -1080,7 +1073,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
     val localRVRowType = rvRowType
     val pkIndex = rvRowType.fieldIdx(rowPartitionKey(0))
-    val newRDD = rvd.rdd.zipPartitions(zipRDD, preservesPartitioning = true) { case (it, intervals) =>
+    val newRDD = rvd.zipPartitions(zipRDD, preservesPartitioning = true) { case (it, intervals) =>
       val intervalAnnotations: Array[(Interval, Any)] =
         intervals.map { rv =>
           val ur = new UnsafeRow(ktSignature, rv)
@@ -1380,7 +1373,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     // need to strip entries!
     // FIXME: HACK
     val rTyp = new OrderedRVDType(right.rowPartitionKey.toArray, right.rowKey.toArray, right.rowType)
-    val rightRVD = OrderedRVD(rTyp, right.rvd.partitioner, right.rowsTable().rvd)
+    val rightRVD = right.rowsTable().rvd.assertOrdered(rTyp, right.rvd.partitioner)
     orderedRVDLeftJoinDistinctAndInsert(rightRVD, root, product = false)
   }
 
@@ -2052,7 +2045,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     val newRVD = if (fieldMapRows.isEmpty) rvd else {
       val newType = newMatrixType.orvdType
       val newPartitioner = rvd.partitioner.withKType(pk.toArray, newType.kType)
-      OrderedRVD(newType, newPartitioner, rvd.rdd)
+      rvd.assertOrdered(newType, newPartitioner)
     }
 
     new MatrixTable(hc, newMatrixType, globals, colValues, newRVD)
@@ -2558,7 +2551,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
     hc.hadoopConf.mkDir(path)
 
-    val partitionCounts = rvd.rdd.writeRowsSplit(path, matrixType, codecSpec, rvd.partitioner)
+    val partitionCounts = rvd.writeRowsSplit(path, matrixType, codecSpec)
 
     val globalsPath = path + "/globals"
     hadoopConf.mkDir(globalsPath)

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1074,7 +1074,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     val localRVRowType = rvRowType
     val pkIndex = rvRowType.fieldIdx(rowPartitionKey(0))
     val newMatrixType = matrixType.copy(rvRowType = newRVType)
-    val newRVD = rvd.zipPartitions(
+    val newRVD = rvd.zipPartitionsPreservesPartitioning(
       newMatrixType.orvdType,
       zipRDD
     ) { case (it, intervals) =>


### PR DESCRIPTION
This change anticipates the ContextRDD change wherein `RVD.rdd` will not
be an RDD. Moreover, enforcing an abstraction barrier at the level of
`RVD` will ease changes to the implementation of `RVD`.

There are two remaining types of calls that I cannot eliminate:

 - uses in BlockMatrix and OrderedRDD2: these two classes are building
   new RDDs based on the RVD's rdd, these classes should be considered
   within the implementation of the RVD abstraction. Because these two
   classes are outside of `is.hail.rvd`, I cannot enforce an access
   modifier on `RVD.rdd`.

 - uses by methods:

   - LDPrune: it seems we need a "GeneralRVD"

   - Skat: it seems like some of this could be moved to python actually;
     but there is some matrix math that cannot be moved until the expr
     lang has efficient small-matrix ops

   - MatrixTable.same: I could probably move this if I re-implemented
     forall in terms of RVD.aggregate?

   - MatrixTable.annotateRowsIntervalTable: really not sure about this
     one, this seems like a performance optimization that purposely
     reaches through the abstraction to do Smart Things