### PR TITLE
move annotate(struct1, struct2) to IR

### DIFF
--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -660,11 +660,11 @@ case class Apply(posn: Position, fn: String, args: Array[AST]) extends AST(posn,
       } yield ir.ApplyBinaryPrimOp(op, x, y, t)
     }
 
-  def tryIRConversion(agg: Option[String]): Option[IR] =
+  private[this] def tryIRConversion(agg: Option[String]): Option[IR] =
     for {
       irArgs <- anyFailAllFail(args.map(_.toIR(agg)))
       ir <- tryPrimOpConversion(args.map(_.`type`).zip(irArgs)).orElse(
-        IRFunctionRegistry.lookupFunction(fn, args.map(_.`type`))
+        IRFunctionRegistry.lookupConversion(fn, args.map(_.`type`))
           .map { irf => irf(irArgs) })
     } yield ir
 

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -41,5 +41,9 @@ object UtilFunctions extends RegistryFunctions {
     registerIR("range", TInt32(), TInt32())(ArrayRange(_, _, I32(1)))
 
     registerIR("range", TInt32())(ArrayRange(I32(0), _, I32(1)))
+
+    registerIR("annotate", tv("T", _.isInstanceOf[TStruct]), tv("U", _.isInstanceOf[TStruct])) { (s, annotations) =>
+      InsertFields(s, annotations.asInstanceOf[MakeStruct].fields)
+    }
   }
 }


### PR DESCRIPTION
this moves the struct-level annotate that's in the AST (which calls `tstruct1.annotate(tstruct2)`) This will allow the python struct-level annotate operation to pass through the IR when able.