### PR TITLE
generalize BaldingNichols to PritchardStephensDonnally

### DIFF
--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -1301,7 +1301,7 @@ def hwe_normalized_pca(dataset, k=10, compute_loadings=False, as_array=False):
     :math:`i` and :math:`j` of :math:`M`; in terms of :math:`C` it is
 
     .. math::
-    
+
       \frac{1}{m}\sum_{l\in\mathcal{C}_i\cap\mathcal{C}_j}\frac{(C_{il}-2p_l)(C_{jl} - 2p_l)}{2p_l(1-p_l)}
 
     where :math:`\mathcal{C}_i = \{l \mid C_{il} \text{ is non-missing}\}`. In
@@ -1323,7 +1323,7 @@ def hwe_normalized_pca(dataset, k=10, compute_loadings=False, as_array=False):
     Parameters
     ----------
     dataset : :class:`.MatrixTable`
-        Dataset.
+        Matrix table with entry-indexed ``GT`` field of type :py:data:`.tcall`.
     k : :obj:`int`
         Number of principal components.
     compute_loadings : :obj:`bool`
@@ -1379,7 +1379,7 @@ def pca(entry_expr, k=10, compute_loadings=False, as_array=False):
     1s encoding missingness of genotype calls.
 
     >>> eigenvalues, scores, _ = hl.pca(hl.int(hl.is_defined(dataset.GT)),
-    ...                                      k=2)
+    ...                                 k=2)
 
     Warning
     -------
@@ -1438,8 +1438,6 @@ def pca(entry_expr, k=10, compute_loadings=False, as_array=False):
 
     Parameters
     ----------
-    dataset : :class:`.MatrixTable`
-        Dataset.
     entry_expr : :class:`.Expression`
         Numeric expression for matrix entries.
     k : :obj:`int`
@@ -2258,10 +2256,11 @@ def realized_relationship_matrix(call_expr):
            fst=nullable(listof(numeric)),
            af_dist=oneof(UniformDist, BetaDist, TruncatedBetaDist),
            seed=int,
-           reference_genome=reference_genome_type)
+           reference_genome=reference_genome_type,
+           mixture=bool)
 def balding_nichols_model(n_populations, n_samples, n_variants, n_partitions=None,
                           pop_dist=None, fst=None, af_dist=UniformDist(0.1, 0.9),
-                          seed=0, reference_genome='default'):
+                          seed=0, reference_genome='default', mixture=False):
     r"""Generate a matrix table of variants, samples, and genotypes using the
     Balding-Nichols model.
 
@@ -2324,7 +2323,7 @@ def balding_nichols_model(n_populations, n_samples, n_variants, n_partitions=Non
     population allele frequencies by :math:`p_{k, m}`, and diploid, unphased
     genotype calls by :math:`g_{n, m}` (0, 1, and 2 correspond to homozygous
     reference, heterozygous, and homozygous variant, respectively).
-    
+
     The generative model is then given by:
 
     .. math::
@@ -2354,6 +2353,7 @@ def balding_nichols_model(n_populations, n_samples, n_variants, n_partitions=Non
     - `ancestral_af_dist` (:class:`.tstruct`) -- Description of the ancestral allele
       frequency distribution.
     - `seed` (:py:data:`.tint32`) -- Random seed.
+    - `mixture` (:py:data:`.tbool`) -- Value of `mixture` parameter.
 
     Row fields:
 
@@ -2397,6 +2397,12 @@ def balding_nichols_model(n_populations, n_samples, n_variants, n_partitions=Non
         Random seed.
     reference_genome : :obj:`str` or :class:`.ReferenceGenome`
         Reference genome to use.
+    mixture : :obj:`bool`
+        Treat `pop_dist` as the parameters of a Dirichlet distribution,
+        as in the Prichard-Stevens-Donnelly model. This feature is
+        EXPERIMENTAL and currently undocumented and untested.
+        If ``True``, the type of `pop` is :class:`.tarray` of
+        :py:data:`.tfloat64` and the value is the mixture proportions.
 
     Returns
     -------
@@ -2420,7 +2426,8 @@ def balding_nichols_model(n_populations, n_samples, n_variants, n_partitions=Non
                                             jvm_fst_opt,
                                             af_dist._jrep(),
                                             seed,
-                                            reference_genome._jrep)
+                                            reference_genome._jrep,
+                                            mixture)
     return MatrixTable(jmt)
 
 

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -603,8 +603,9 @@ class HailContext private(val sc: SparkContext,
     fst: Option[Array[Double]] = None,
     afDist: Distribution = UniformDist(0.1, 0.9),
     seed: Int = 0,
-    rg: ReferenceGenome = ReferenceGenome.defaultReference): MatrixTable =
-    BaldingNicholsModel(this, populations, samples, variants, popDist, fst, seed, nPartitions, afDist, rg)
+    rg: ReferenceGenome = ReferenceGenome.defaultReference,
+    mixture: Boolean = false): MatrixTable =
+    BaldingNicholsModel(this, populations, samples, variants, popDist, fst, seed, nPartitions, afDist, rg, mixture)
 
   def genDataset(): MatrixTable = VSMSubgen.realistic.gen(this).sample()
 

--- a/src/test/scala/is/hail/stats/BaldingNicholsModelSuite.scala
+++ b/src/test/scala/is/hail/stats/BaldingNicholsModelSuite.scala
@@ -2,7 +2,7 @@ package is.hail.stats
 
 import breeze.stats._
 import is.hail.SparkSuite
-import is.hail.variant.{Call, Locus, Variant}
+import is.hail.variant.{Call, Variant}
 import is.hail.testUtils._
 import org.apache.spark.sql.Row
 import org.testng.Assert.assertEquals


### PR DESCRIPTION
A simple but powerful extension requested by @alexb-3 and Christina to allow for synthetic genotypes with very general and realistic-looking PCA plots with [redacted]. Alex pointed out that BaldingNichols is special case of PritchardStephensDonnelly in a degenerate sense, just as one-hot encoded `Categorical(p_1,...,p_k)` is the distributional limit of `Dirichlet(a * p_1,..., a * p_k)` as `a` goes to 0. So the substantive changes took about 10 lines.

It's turned on by the `mixture` parameter which defaults to False and is marked as experimental. `True` means treat `pop_dist` as the parameters of Dirichlet rather than Categorical. @alexb-3 , it'd be great if you and Christina could experiment with it and extend the documentation accordingly. Once we have that, I'll add tests and remove "experimental". The plots below are already quite convincing.

```
import hail as hl
import matplotlib.pyplot as plt

mt = hl.balding_nichols_model(3, 500, 50, pop_dist=[0.01, 0.02, 0.05], fst=[.2, .3, .5])
_, pcs, _ = hl.hwe_normalized_pca(mt, 3)
plt.scatter(pcs.PC1.collect(), pcs.PC2.collect())
```

![ex0](https://user-images.githubusercontent.com/3201642/37743475-a470a372-2d40-11e8-894c-5ed0d74f3d14.png)

```
mt = hl.balding_nichols_model(3, 500, 50, pop_dist=[0.01, 0.02, 0.05], fst=[.2, .3, .5], mixture=True)
```

![ex1](https://user-images.githubusercontent.com/3201642/37743104-decf0da8-2d3e-11e8-8d43-3e36f194fa8e.png)

```
mt = hl.balding_nichols_model(3, 500, 50, pop_dist=[0.1, 0.2, 0.5], fst=[.2, .3, .5], mixture=True)
```

![ex2](https://user-images.githubusercontent.com/3201642/37743108-e2e4cfe0-2d3e-11e8-9860-724de2c6611c.png)