### PR TITLE
add ApplySpecial to handle IRFunctions with missingness treatment

### DIFF
--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -76,5 +76,7 @@ object Children {
       none
     case Apply(_, args, _) =>
       args.toIndexedSeq
+    case ApplySpecial(_, args, _) =>
+      args.toIndexedSeq
   }
 }

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -30,8 +30,6 @@ object Children {
       Array(x)
     case MakeArray(args, typ) =>
       args.toIndexedSeq
-    case MakeArrayN(len, elementType) =>
-      Array(len)
     case ArrayRef(a, i, typ) =>
       Array(a, i)
     case ArrayMissingnessRef(a, i) =>

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -103,6 +103,8 @@ object Copy {
         same
       case Apply(fn, args, impl) =>
         Apply(fn, children, impl)
+      case ApplySpecial(fn, args, impl) =>
+        ApplySpecial(fn, children, impl)
     }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -43,9 +43,6 @@ object Copy {
       case MakeArray(args, typ) =>
         assert(args.length == children.length)
         MakeArray(children, typ)
-      case MakeArrayN(_, elementType) =>
-        val IndexedSeq(len) = children
-        MakeArrayN(len, elementType)
       case ArrayRef(_, _, typ) =>
         val IndexedSeq(a, i) = children
         ArrayRef(a, i, typ)

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -497,27 +497,24 @@ private class Emit(
       case Die(m) =>
         present(Code._throw(Code.newInstance[RuntimeException, String](m)))
       case Apply(fn, args, impl) =>
-        impl match {
-          case _: IRFunctionWithoutMissingness =>
-            val existing =
-              methods(fn).filter { case (argt, _) => argt.zip(args.map(_.typ)).forall { case (t1, t2) => t1 isOfType t2 } } match {
-                case Seq(f) =>
-                  f._2
-                case Seq() =>
-                  val methodbuilder = impl.getAsMethod(fb, args.map(_.typ): _*)
-                  methods.update(fn, methods(fn) :+ (args.map(_.typ), methodbuilder))
-                  methodbuilder
-              }
-            val codeArgs = args.map(emit(_))
-            val vars = args.map { a => coerce[Any](fb.newLocal()(typeToTypeInfo(a.typ))) }
-            val ins = vars.zip(codeArgs.map(_.v)).map { case (l, i) => l := i }
-            val setup = coerce[Unit](Code(codeArgs.map(_.setup): _*))
-            val missing = if (codeArgs.isEmpty) const(false) else codeArgs.map(_.m).reduce(_ || _)
-            val value = Code(ins :+ existing.invoke(fb.getArg[Region](1).load() +: vars.map { a => a.load() }: _*): _*)
-            EmitTriplet(setup, missing, value)
-          case _: IRFunctionWithMissingness =>
-            impl.apply(fb.apply_method, args.map(emit(_)): _*)
-        }
+        val existing =
+          methods(fn).filter { case (argt, _) => argt.zip(args.map(_.typ)).forall { case (t1, t2) => t1 isOfType t2 } } match {
+            case Seq(f) =>
+              f._2
+            case Seq() =>
+              val methodbuilder = impl.getAsMethod(fb, args.map(_.typ): _*)
+              methods.update(fn, methods(fn) :+ (args.map(_.typ), methodbuilder))
+              methodbuilder
+          }
+        val codeArgs = args.map(emit(_))
+        val vars = args.map { a => coerce[Any](fb.newLocal()(typeToTypeInfo(a.typ))) }
+        val ins = vars.zip(codeArgs.map(_.v)).map { case (l, i) => l := i }
+        val setup = coerce[Unit](Code(codeArgs.map(_.setup): _*))
+        val missing = if (codeArgs.isEmpty) const(false) else codeArgs.map(_.m).reduce(_ || _)
+        val value = Code(ins :+ existing.invoke(fb.getArg[Region](1).load() +: vars.map { a => a.load() }: _*): _*)
+        EmitTriplet(setup, missing, value)
+      case ApplySpecial(fn, args, impl) =>
+        impl.apply(fb.apply_method, args.map(emit(_)): _*)
     }
   }
 

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -497,7 +497,7 @@ private class Emit(
       case Die(m) =>
         present(Code._throw(Code.newInstance[RuntimeException, String](m)))
       case Apply(fn, args, impl) =>
-        val existing =
+        val meth =
           methods(fn).filter { case (argt, _) => argt.zip(args.map(_.typ)).forall { case (t1, t2) => t1 isOfType t2 } } match {
             case Seq(f) =>
               f._2
@@ -511,7 +511,7 @@ private class Emit(
         val ins = vars.zip(codeArgs.map(_.v)).map { case (l, i) => l := i }
         val setup = coerce[Unit](Code(codeArgs.map(_.setup): _*))
         val missing = if (codeArgs.isEmpty) const(false) else codeArgs.map(_.m).reduce(_ || _)
-        val value = Code(ins :+ existing.invoke(fb.getArg[Region](1).load() +: vars.map { a => a.load() }: _*): _*)
+        val value = Code(ins :+ meth.invoke(fb.getArg[Region](1).load() +: vars.map { a => a.load() }: _*): _*)
         EmitTriplet(setup, missing, value)
       case ApplySpecial(fn, args, impl) =>
         impl.apply(fb.apply_method, args.map(emit(_)): _*)

--- a/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -52,11 +52,11 @@ object ExtractAggregators {
   private def newAggregator(ir: ApplyAggOp): RegionValueAggregator = ir match {
     case x@ApplyAggOp(a, op, args, typ) =>
       val constfb = FunctionBuilder.functionBuilder[Region, RegionValueAggregator]
-      val (doargs, margs, vargs) = args.map(Emit.toCode(_, constfb, 1)).unzip3
+      val codeArgs = args.map(Emit.toCode(_, constfb, 1))
       constfb.emit(Code(
-        Code(doargs:_*),
+        Code(codeArgs.map(_.setup):_*),
         AggOp.get(op, x.inputType, args.map(_.typ))
-          .stagedNew(vargs.toArray, margs.toArray)))
+          .stagedNew(codeArgs.map(_.v).toArray, codeArgs.map(_.m).toArray)))
       constfb.result()()(Region())
   }
 }

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.expr.types._
 import is.hail.expr.BaseIR
-import is.hail.expr.ir.functions.{IRFunction, IRFunctionWithMissingness, IRFunctionWithoutMissingness}
+import is.hail.expr.ir.functions.IRFunction
 
 sealed trait IR extends BaseIR {
   def typ: Type

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.expr.types._
 import is.hail.expr.BaseIR
-import is.hail.expr.ir.functions.IRFunction
+import is.hail.expr.ir.functions.{IRFunction, IRFunctionWithMissingness, IRFunctionWithoutMissingness}
 
 sealed trait IR extends BaseIR {
   def typ: Type
@@ -83,4 +83,5 @@ final case class InMissingness(i: Int) extends IR { val typ: Type = TBoolean() }
 // FIXME: should be type any
 final case class Die(message: String) extends IR { val typ = TVoid }
 
-final case class Apply(function: String, args: Seq[IR], var implementation: IRFunction = null) extends IR { def typ = implementation.returnType }
+final case class Apply(function: String, args: Seq[IR], var implementation: IRFunctionWithoutMissingness = null) extends IR { def typ = implementation.returnType }
+final case class ApplySpecial(function: String, args: Seq[IR], var implementation: IRFunctionWithMissingness = null) extends IR { def typ = implementation.returnType }

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -51,7 +51,6 @@ final case class ApplyBinaryPrimOp(op: BinaryOp, l: IR, r: IR, var typ: Type = n
 final case class ApplyUnaryPrimOp(op: UnaryOp, x: IR, var typ: Type = null) extends IR
 
 final case class MakeArray(args: Seq[IR], var typ: TArray = null) extends IR
-final case class MakeArrayN(len: IR, elementType: Type) extends IR { def typ: TArray = TArray(elementType) }
 final case class ArrayRef(a: IR, i: IR, var typ: Type = null) extends IR
 final case class ArrayMissingnessRef(a: IR, i: IR) extends IR { val typ: Type = TBoolean() }
 final case class ArrayLen(a: IR) extends IR { val typ = TInt32() }

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.expr.types._
 import is.hail.expr.BaseIR
-import is.hail.expr.ir.functions.IRFunction
+import is.hail.expr.ir.functions.{IRFunction, IRFunctionWithMissingness, IRFunctionWithoutMissingness}
 
 sealed trait IR extends BaseIR {
   def typ: Type

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -59,10 +59,6 @@ object Infer {
           args.map(_.typ).zipWithIndex.tail.foreach { case (x, i) => assert(x.isOfType(t), s"at position $i type mismatch: $t $x") }
           x.typ = TArray(t)
         }
-      case MakeArrayN(len, typ) =>
-        infer(len)
-        assert(len.typ.isOfType(TInt32()))
-        assert(typ != null)
       case x@ArrayRef(a, i, _) =>
         infer(a)
         infer(i)

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -173,7 +173,6 @@ object Infer {
       case Die(msg) =>
       case x@Apply(fn, args, impl) =>
         args.foreach(infer(_))
-        println(IRFunctionRegistry.lookupFunction(fn, args.map(_.typ)).get.getClass())
         if (impl == null)
           x.implementation = (IRFunctionRegistry.lookupFunction(fn, args.map(_.typ)).get).asInstanceOf[IRFunctionWithoutMissingness]
         assert(args.map(_.typ).zip(x.implementation.argTypes).forall {case (i, j) => j.unify(i)})

--- a/src/main/scala/is/hail/expr/ir/Recur.scala
+++ b/src/main/scala/is/hail/expr/ir/Recur.scala
@@ -41,5 +41,6 @@ object Recur {
     case InMissingness(i) => ir
     case Die(message) => ir
     case Apply(fn, args, impl) => Apply(fn, args.map(f), impl)
+    case ApplySpecial(fn, args, impl) => ApplySpecial(fn, args.map(f), impl)
   }
 }

--- a/src/main/scala/is/hail/expr/ir/Recur.scala
+++ b/src/main/scala/is/hail/expr/ir/Recur.scala
@@ -18,7 +18,6 @@ object Recur {
     case ApplyBinaryPrimOp(op, l, r, typ) => ApplyBinaryPrimOp(op, f(l), f(r), typ)
     case ApplyUnaryPrimOp(op, x, typ) => ApplyUnaryPrimOp(op, f(x), typ)
     case MakeArray(args, typ) => MakeArray(args map f, typ)
-    case MakeArrayN(len, elementType) => MakeArrayN(f(len), elementType)
     case ArrayRef(a, i, typ) => ArrayRef(f(a), f(i), typ)
     case ArrayMissingnessRef(a, i) => ArrayMissingnessRef(f(a), f(i))
     case ArrayLen(a) => ArrayLen(f(a))

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -59,7 +59,11 @@ object IRFunctionRegistry {
     }
 
     val validMethods = validIR ++ lookupFunction(name, args).map { f =>
-      { args: Seq[IR] => Apply(name, args, f) }
+      { args: Seq[IR] =>
+        f match {
+          case irf: IRFunctionWithoutMissingness => Apply(name, args, irf)
+          case irf: IRFunctionWithMissingness => ApplySpecial(name, args, irf)
+        } }
     }
 
     validMethods match {

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -222,7 +222,6 @@ abstract class IRFunctionWithoutMissingness extends IRFunction {
   def returnType: Type
 
   override def toString: String = s"$name(${ argTypes.mkString(", ") }): $returnType"
-
 }
 
 abstract class IRFunctionWithMissingness extends IRFunction {
@@ -235,5 +234,4 @@ abstract class IRFunctionWithMissingness extends IRFunction {
   def returnType: Type
 
   override def toString: String = s"$name(${ argTypes.mkString(", ") }): $returnType"
-
 }

--- a/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
@@ -1,9 +1,10 @@
 package is.hail.expr.ir.functions
 
+import is.hail.asm4s.Code
 import is.hail.expr.ir._
 import is.hail.expr.types._
-import is.hail.stats
 import org.apache.commons.math3.special.Gamma
+import is.hail.expr.ir.coerce
 
 object MathFunctions extends RegistryFunctions {
 
@@ -79,5 +80,21 @@ object MathFunctions extends RegistryFunctions {
     registerJavaStaticFunction("%", TInt64(), TInt32(), TInt64())(jMathClass, "floorMod")
 
     registerScalaFunction("isnan", TFloat64(), TBoolean())(thisClass, "isnan")
+
+    registerCodeWithMissingness("&&", TBoolean(), TBoolean(), TBoolean()) { (_, l, r) =>
+      EmitTriplet(
+        Code(l.setup, r.setup),
+        l.m || (coerce[Boolean](l.v) && r.m),
+        coerce[Boolean](l.v) && coerce[Boolean](r.v)
+      )
+    }
+
+    registerCodeWithMissingness("||", TBoolean(), TBoolean(), TBoolean()) { (_, l, r) =>
+      EmitTriplet(
+        Code(l.setup, r.setup),
+        l.m || (!coerce[Boolean](l.v) && r.m),
+        coerce[Boolean](l.v) || coerce[Boolean](r.v)
+      )
+    }
   }
 }

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -433,8 +433,10 @@ class Table(val hc: HailContext, val tir: TableIR) {
 
     ast.toIR() match {
       case Some(ir) =>
+        println("Table.select using IR")
         new Table(hc, TableMapRows(tir, ir))
       case None =>
+        println("Table.select using AST")
         val (t, f) = Parser.parseExpr(expr, ec)
         val newSignature = t.asInstanceOf[TStruct]
         val globalsBc = globals.broadcast

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -433,10 +433,8 @@ class Table(val hc: HailContext, val tir: TableIR) {
 
     ast.toIR() match {
       case Some(ir) =>
-        println("Table.select using IR")
         new Table(hc, TableMapRows(tir, ir))
       case None =>
-        println("Table.select using AST")
         val (t, f) = Parser.parseExpr(expr, ec)
         val newSignature = t.asInstanceOf[TStruct]
         val globalsBc = globals.broadcast

--- a/src/test/scala/is/hail/expr/ir/CompileSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/CompileSuite.scala
@@ -572,8 +572,8 @@ class CompileSuite {
   def testShortCircuitBooleans() {
     val tin = TArray(TBoolean())
     val tout = TTuple(TBoolean())
-    val irAnd = MakeTuple(Seq(Apply("&&", Seq(ArrayRef(In(0, tin), I32(0)), ArrayRef(In(0, tin), I32(1))))))
-    val irOr = MakeTuple(Seq(Apply("||", Seq(ArrayRef(In(0, tin), I32(0)), ArrayRef(In(0, tin), I32(1))))))
+    val irAnd = MakeTuple(Seq(ApplySpecial("&&", Seq(ArrayRef(In(0, tin), I32(0)), ArrayRef(In(0, tin), I32(1))))))
+    val irOr = MakeTuple(Seq(ApplySpecial("||", Seq(ArrayRef(In(0, tin), I32(0)), ArrayRef(In(0, tin), I32(1))))))
 
     val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Long]
     doit(irAnd, fb)


### PR DESCRIPTION
This allows us to write functions for the IR that handle missingness specially, in cases where we don't necessarily want the behavior where any missing argument implies that the entire function result is considered missing. I implemented `&&` and `||` using this in order to test.

I also refactored the return from Emit.emit to a case class `EmitTriplet` to make it easier to talk about them in other contexts.

cc @cseed @danking 