### PR TITLE
remove Serializable from OrderedRVD

### DIFF
--- a/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -1064,7 +1064,7 @@ case class WriteBlocksRDDPartition(index: Int, start: Int, skip: Int, end: Int) 
 }
 
 class WriteBlocksRDD(path: String,
-  rvd: RVD,
+  rdd: RDD[RegionValue],
   sc: SparkContext,
   matrixType: MatrixType,
   parentPartStarts: Array[Long],
@@ -1073,7 +1073,7 @@ class WriteBlocksRDD(path: String,
 
   require(gp.nRows == parentPartStarts.last)
 
-  private val parentParts = rvd.partitions
+  private val parentParts = rdd.partitions
   private val blockSize = gp.blockSize
 
   private val d = digitsNeeded(gp.numPartitions)
@@ -1081,7 +1081,7 @@ class WriteBlocksRDD(path: String,
 
   override def getDependencies: Seq[Dependency[_]] =
     Array[Dependency[_]](
-      new NarrowDependency(rvd.rdd) {
+      new NarrowDependency(rdd) {
         def getParents(partitionId: Int): Seq[Int] =
           partitions(partitionId).asInstanceOf[WriteBlocksRDDPartition].range
       }
@@ -1154,7 +1154,7 @@ class WriteBlocksRDD(path: String,
     val writeBlocksPart = split.asInstanceOf[WriteBlocksRDDPartition]
     val start = writeBlocksPart.start
     writeBlocksPart.range.foreach { pi =>
-      val it = rvd.rdd.iterator(parentParts(pi), context)
+      val it = rdd.iterator(parentParts(pi), context)
 
       if (pi == start) {
         var j = 0

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -94,7 +94,7 @@ class OrderedRVD(
     new OrderedRVD(
       typ = ordType,
       partitioner = newPartitioner,
-      rdd = RepartitionedOrderedRDD2(this, newPartitioner))
+      rdd = RepartitionedOrderedRDD(this, newPartitioner))
   }
 
   def keyBy(key: Array[String] = typ.key): KeyedOrderedRVD =

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -94,7 +94,7 @@ class OrderedRVD(
     new OrderedRVD(
       typ = ordType,
       partitioner = newPartitioner,
-      rdd = new RepartitionedOrderedRDD2(this, newPartitioner))
+      rdd = RepartitionedOrderedRDD2(this, newPartitioner))
   }
 
   def keyBy(key: Array[String] = typ.key): KeyedOrderedRVD =

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -19,7 +19,7 @@ import scala.reflect.ClassTag
 class OrderedRVD(
   val typ: OrderedRVDType,
   val partitioner: OrderedRVDPartitioner,
-  val rdd: RDD[RegionValue]) extends RVD with Serializable {
+  val rdd: RDD[RegionValue]) extends RVD {
   self =>
   def rowType: TStruct = typ.rowType
 

--- a/src/main/scala/is/hail/sparkextras/RepartitionedOrderedRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/RepartitionedOrderedRDD.scala
@@ -13,13 +13,13 @@ import org.apache.spark.sql.Row
   * needed. No assumption should need to be made about partition keys, but currently
   * assumes old partition key type is a prefix of the new partition key type.
   */
-object RepartitionedOrderedRDD2 {
-  def apply(prev: OrderedRVD, newPartitioner: OrderedRVDPartitioner): RepartitionedOrderedRDD2 = {
-    new RepartitionedOrderedRDD2(prev.rdd, prev.typ, prev.partitioner, newPartitioner)
+object RepartitionedOrderedRDD {
+  def apply(prev: OrderedRVD, newPartitioner: OrderedRVDPartitioner): RepartitionedOrderedRDD = {
+    new RepartitionedOrderedRDD(prev.rdd, prev.typ, prev.partitioner, newPartitioner)
   }
 }
 
-class RepartitionedOrderedRDD2(
+class RepartitionedOrderedRDD(
     prevRDD: RDD[RegionValue],
     typ: OrderedRVDType,
     oldPartitioner: OrderedRVDPartitioner,

--- a/src/main/scala/is/hail/sparkextras/RepartitionedOrderedRDD2.scala
+++ b/src/main/scala/is/hail/sparkextras/RepartitionedOrderedRDD2.scala
@@ -15,15 +15,14 @@ import org.apache.spark.sql.Row
   */
 object RepartitionedOrderedRDD2 {
   def apply(prev: OrderedRVD, newPartitioner: OrderedRVDPartitioner): RepartitionedOrderedRDD2 = {
-    val dep = new OrderedDependency(prev.partitioner, newPartitioner, prev.rdd)
-    new RepartitionedOrderedRDD2(prev.rdd, prev.typ, dep, newPartitioner)
+    new RepartitionedOrderedRDD2(prev.rdd, prev.typ, prev.partitioner, newPartitioner)
   }
 }
 
 class RepartitionedOrderedRDD2(
     prevRDD: RDD[RegionValue],
     typ: OrderedRVDType,
-    dependency: OrderedDependency,
+    oldPartitioner: OrderedRVDPartitioner,
     newPartitioner: OrderedRVDPartitioner)
   extends RDD[RegionValue](prevRDD.sparkContext, Nil) { // Nil since we implement getDependencies
 
@@ -49,6 +48,8 @@ class RepartitionedOrderedRDD2(
       }
     OrderedRVIterator(typ, it).restrictToPKInterval(ordPartition.range)
   }
+
+  val dependency = new OrderedDependency(oldPartitioner, newPartitioner, prevRDD)
 
   override def getDependencies: Seq[Dependency[_]] = Seq(dependency)
 }

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -2893,7 +2893,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     hadoop.mkDir(dirname + "/parts")
     val gp = GridPartitioner(blockSize, nRows, localNCols)
     val blockCount =
-      new WriteBlocksRDD(dirname, rvd, sparkContext, matrixType, partStarts, entryField, gp)
+      new WriteBlocksRDD(dirname, rvd.rdd, sparkContext, matrixType, partStarts, entryField, gp)
         .reduce(_ + _)
 
     assert(blockCount == gp.numPartitions)


### PR DESCRIPTION
Basically just exploded the RepartitionedOrderedRDD2 interface so that the individual (serializable) parts could be passed in separately. 

The next step is to make the partitioner unserializable, so I'll change this again when I do that to broadcast the partitioner where needed.