### PR TITLE
Unique part files

### DIFF
--- a/src/main/scala/is/hail/io/RowStore.scala
+++ b/src/main/scala/is/hail/io/RowStore.scala
@@ -756,10 +756,7 @@ class RichRDDRegionValue(val rdd: RDD[RegionValue]) extends AnyVal {
     val partFilePartitionCounts = rdd.mapPartitionsWithIndex { case (i, it) =>
       val hConf = sHConfBc.value.value
 
-      val rng = new java.security.SecureRandom()
-      val fileUUID = new java.util.UUID(rng.nextLong(), rng.nextLong())
-      val ctx = TaskContext.get
-      val f = partFile(d, i) + s"-${ ctx.stageId() }-${ ctx.partitionId() }-${ ctx.attemptNumber() }-${ fileUUID }"
+      val f = partFile(d, i, TaskContext.get)
 
       val rowsPartPath = path + "/rows/rows/parts/" + f
       hConf.writeFile(rowsPartPath) { rowsOS =>

--- a/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -1101,17 +1101,13 @@ class WriteBlocksRDD(path: String,
   def compute(split: Partition, context: TaskContext): Iterator[(Int, String)] = {
     val blockRow = split.index
     val nRowsInBlock = gp.blockRowNRows(blockRow)
-
-    val rng = new java.security.SecureRandom()
     val ctx = TaskContext.get
 
     val (blockPartFiles, outPerBlockCol) = Array.tabulate(gp.nBlockCols) { blockCol =>
       val nColsInBlock = gp.blockColNCols(blockCol)
 
       val i = gp.coordinatesBlock(blockRow, blockCol)
-
-      val fileUUID = new java.util.UUID(rng.nextLong(), rng.nextLong())
-      val f = partFile(d, i) + s"-${ ctx.stageId() }-${ ctx.partitionId() }-${ ctx.attemptNumber() }-${ fileUUID }"
+      val f = partFile(d, i, ctx)
       val filename = path + "/parts/" + f
 
       val os = sHadoopBc.value.value.unsafeWriter(filename)

--- a/src/main/scala/is/hail/linalg/RowMatrix.scala
+++ b/src/main/scala/is/hail/linalg/RowMatrix.scala
@@ -24,7 +24,7 @@ object RowMatrix {
     if (!hadoop.exists(uri + "/_SUCCESS"))
       fatal("Write failed: no success indicator found")
     
-    val BlockMatrixMetadata(blockSize, nRows, nCols) =
+    val BlockMatrixMetadata(blockSize, nRows, nCols, _) =
       hadoop.readTextFile(uri + BlockMatrix.metadataRelativePath) { isr  =>
         implicit val formats = defaultJSONFormats
         jackson.Serialization.read[BlockMatrixMetadata](isr)

--- a/src/main/scala/is/hail/utils/package.scala
+++ b/src/main/scala/is/hail/utils/package.scala
@@ -12,7 +12,7 @@ import org.apache.hadoop.fs.PathIOException
 import org.apache.hadoop.mapred.FileSplit
 import org.apache.hadoop.mapreduce.lib.input.{FileSplit => NewFileSplit}
 import org.apache.log4j.Level
-import org.apache.spark.Partition
+import org.apache.spark.{Partition, TaskContext}
 import org.json4s.JsonAST.JArray
 import org.json4s.jackson.Serialization
 import org.json4s.reflect.TypeInfo
@@ -535,6 +535,12 @@ package object utils extends Logging
     val is = i.toString
     assert(is.length <= d)
     "part-" + StringUtils.leftPad(is, d, "0")
+  }
+
+  def partFile(d: Int, i: Int, ctx: TaskContext): String = {
+    val rng = new java.security.SecureRandom()
+    val fileUUID = new java.util.UUID(rng.nextLong(), rng.nextLong())
+    s"${ partFile(i, d) }-${ ctx.stageId() }-${ ctx.partitionId() }-${ ctx.attemptNumber() }-$fileUUID"
   }
 
   def mangle(strs: Array[String], formatter: Int => String = "_%d".format(_)): (Array[String], Array[(String, String)]) = {

--- a/src/main/scala/is/hail/utils/package.scala
+++ b/src/main/scala/is/hail/utils/package.scala
@@ -540,7 +540,7 @@ package object utils extends Logging
   def partFile(d: Int, i: Int, ctx: TaskContext): String = {
     val rng = new java.security.SecureRandom()
     val fileUUID = new java.util.UUID(rng.nextLong(), rng.nextLong())
-    s"${ partFile(i, d) }-${ ctx.stageId() }-${ ctx.partitionId() }-${ ctx.attemptNumber() }-$fileUUID"
+    s"${ partFile(d, i) }-${ ctx.stageId() }-${ ctx.partitionId() }-${ ctx.attemptNumber() }-$fileUUID"
   }
 
   def mangle(strs: Array[String], formatter: Int => String = "_%d".format(_)): (Array[String], Array[(String, String)]) = {

--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -207,12 +207,7 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
 
     val (partFiles, partitionCounts) = r.mapPartitionsWithIndex { case (index, it) =>
       val i = remapBc.value(index)
-
-      val rng = new java.security.SecureRandom()
-      val fileUUID = new java.util.UUID(rng.nextLong(), rng.nextLong())
-      val ctx = TaskContext.get
-      val f = partFile(d, i) + s"-${ ctx.stageId() }-${ ctx.partitionId() }-${ ctx.attemptNumber() }-${ fileUUID }"
-
+      val f = partFile(d, i, TaskContext.get)
       val filename = path + "/parts/" + f
       val os = sHadoopConfBc.value.value.unsafeWriter(filename)
       Iterator.single(f -> write(i, it, os))

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -360,27 +360,27 @@ case class VSMSubgen(
 
   def gen(hc: HailContext): Gen[MatrixTable] =
     for (size <- Gen.size;
-    (l, w) <- Gen.squareOfAreaAtMostSize.resize((size / 3 / 10) * 8);
+      (l, w) <- Gen.squareOfAreaAtMostSize.resize((size / 3 / 10) * 8);
 
-    vSig <- vSigGen.resize(3);
-    vaSig <- vaSigGen.map(t => t.deepOptional().asInstanceOf[TStruct]).resize(3);
-    sSig <- sSigGen.resize(3);
-    saSig <- saSigGen.map(t => t.deepOptional().asInstanceOf[TStruct]).resize(3);
-    globalSig <- globalSigGen.resize(5);
-    tSig <- tSigGen.map(t => t.structOptional().asInstanceOf[TStruct]).resize(3);
-    global <- globalGen(globalSig).resize(25);
-    nPartitions <- Gen.choose(1, 10);
+      vSig <- vSigGen.resize(3);
+      vaSig <- vaSigGen.map(t => t.deepOptional().asInstanceOf[TStruct]).resize(3);
+      sSig <- sSigGen.resize(3);
+      saSig <- saSigGen.map(t => t.deepOptional().asInstanceOf[TStruct]).resize(3);
+      globalSig <- globalSigGen.resize(5);
+      tSig <- tSigGen.map(t => t.structOptional().asInstanceOf[TStruct]).resize(3);
+      global <- globalGen(globalSig).resize(25);
+      nPartitions <- Gen.choose(1, 10);
 
-    sampleIds <- Gen.buildableOfN[Array](w, sGen(sSig).resize(3))
-      .map(ids => ids.distinct);
-    nSamples = sampleIds.length;
-    saValues <- Gen.buildableOfN[Array](nSamples, saGen(saSig).resize(5));
-    rows <- Gen.buildableOfN[Array](l,
-      for (
-        v <- vGen(vSig).resize(3);
-        va <- vaGen(vaSig).resize(5);
-        ts <- Gen.buildableOfN[Array](nSamples, tGen(tSig, v).resize(3)))
-        yield (v, (va, ts: Iterable[Annotation]))))
+      sampleIds <- Gen.buildableOfN[Array](w, sGen(sSig).resize(3))
+        .map(ids => ids.distinct);
+      nSamples = sampleIds.length;
+      saValues <- Gen.buildableOfN[Array](nSamples, saGen(saSig).resize(5));
+      rows <- Gen.buildableOfN[Array](l,
+        for (
+          v <- vGen(vSig).resize(3);
+          va <- vaGen(vaSig).resize(5);
+          ts <- Gen.buildableOfN[Array](nSamples, tGen(tSig, v).resize(3)))
+          yield (v, (va, ts: Iterable[Annotation]))))
       yield {
         assert(sampleIds.forall(_ != null))
         val (finalSASig, sIns) = saSig.structInsert(sSig, List("s"))
@@ -977,9 +977,9 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
       right.typ.valueType
 
     val rightRVD = if (product)
-        right.groupByKey(" !!! values !!! ")
-      else
-        right
+      right.groupByKey(" !!! values !!! ")
+    else
+      right
 
     val (newRVType, ins) = rvRowType.unsafeStructInsert(valueType, List(root))
 
@@ -1985,19 +1985,19 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
     val fieldMapRows = oldToNewRows.asScala
     assert(fieldMapRows.keys.forall(k => matrixType.rowType.fieldNames.contains(k)),
-      s"[${fieldMapRows.keys.mkString(", ")}], expected [${ matrixType.rowType.fieldNames.mkString(", ") }]")
+      s"[${ fieldMapRows.keys.mkString(", ") }], expected [${ matrixType.rowType.fieldNames.mkString(", ") }]")
 
     val fieldMapCols = oldToNewCols.asScala
     assert(fieldMapCols.keys.forall(k => matrixType.colType.fieldNames.contains(k)),
-      s"[${fieldMapCols.keys.mkString(", ")}], expected [${ matrixType.colType.fieldNames.mkString(", ") }]")
+      s"[${ fieldMapCols.keys.mkString(", ") }], expected [${ matrixType.colType.fieldNames.mkString(", ") }]")
 
     val fieldMapEntries = oldToNewEntries.asScala
     assert(fieldMapEntries.keys.forall(k => matrixType.entryType.fieldNames.contains(k)),
-      s"[${fieldMapEntries.keys.mkString(", ")}], expected [${ matrixType.entryType.fieldNames.mkString(", ") }]")
+      s"[${ fieldMapEntries.keys.mkString(", ") }], expected [${ matrixType.entryType.fieldNames.mkString(", ") }]")
 
     val fieldMapGlobals = oldToNewGlobals.asScala
     assert(fieldMapGlobals.keys.forall(k => matrixType.globalType.fieldNames.contains(k)),
-      s"[${fieldMapGlobals.keys.mkString(", ")}], expected [${ matrixType.globalType.fieldNames.mkString(", ") }]")
+      s"[${ fieldMapGlobals.keys.mkString(", ") }], expected [${ matrixType.globalType.fieldNames.mkString(", ") }]")
 
     val (newColKey, newColType) = if (fieldMapCols.isEmpty) (colKey, colType) else {
       val newFieldNames = colType.fieldNames.map { n => fieldMapCols.getOrElse(n, n) }
@@ -2014,10 +2014,10 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
       val newPK = rowPartitionKey.map { f => fieldMapRows.getOrElse(f, f) }
       val newKey = rowKey.map { f => fieldMapRows.getOrElse(f, f) }
       val newRVRowType = TStruct(rvRowType.required, rvRowType.fields.map { f =>
-          f.name match {
-            case x@MatrixType.entriesIdentifier => (x, TArray(newEntryType, f.typ.required))
-            case x => (fieldMapRows.getOrElse(x, x), f.typ)
-          }
+        f.name match {
+          case x@MatrixType.entriesIdentifier => (x, TArray(newEntryType, f.typ.required))
+          case x => (fieldMapRows.getOrElse(x, x), f.typ)
+        }
       }: _*)
       (newPK, newKey, newRVRowType)
     }
@@ -2872,20 +2872,24 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     val hadoop = sparkContext.hadoopConfiguration
     hadoop.mkDir(dirname)
 
+    // write blocks
+    hadoop.mkDir(dirname + "/parts")
+    val gp = GridPartitioner(blockSize, nRows, localNCols)
+    val blockPartFiles =
+      new WriteBlocksRDD(dirname, rvd.rdd, sparkContext, matrixType, partStarts, entryField, gp)
+      .collect()
+
+    val blockCount = blockPartFiles.length
+    val partFiles = new Array[String](blockCount)
+    blockPartFiles.foreach { case (i, f) => partFiles(i) = f }
+
     // write metadata
     hadoop.writeDataFile(dirname + BlockMatrix.metadataRelativePath) { os =>
       implicit val formats = defaultJSONFormats
       jackson.Serialization.write(
-        BlockMatrixMetadata(blockSize, nRows, localNCols),
+        BlockMatrixMetadata(blockSize, nRows, localNCols, partFiles),
         os)
     }
-
-    // write blocks
-    hadoop.mkDir(dirname + "/parts")
-    val gp = GridPartitioner(blockSize, nRows, localNCols)
-    val blockCount =
-      new WriteBlocksRDD(dirname, rvd.rdd, sparkContext, matrixType, partStarts, entryField, gp)
-        .reduce(_ + _)
 
     assert(blockCount == gp.numPartitions)
     info(s"Wrote all $blockCount blocks of $nRows x $localNCols matrix with block size $blockSize.")


### PR DESCRIPTION
I think it is possible for two partitions, either through speculation or a network partition between the master and a worker, to try to write the same file.  This leads to Bad Problems(tm).  In this change, each write task attempt creates a unique part file path name (part-NNN-taskID-partitionID-attemptNumber-UUID) and writes that.  These path files (collected from the successful tasks) are collected and stored in the relevant metadata.

Note, this is a breaking change for the matrix file format which should be OK since it is marked as experimental.