### PR TITLE
parallelize BlockMatrix diagonal

### DIFF
--- a/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -927,7 +927,7 @@ private class BlockMatrixTransposeRDD(dm: BlockMatrix)
 }
 
 private class BlockMatrixDiagonalRDD(m: BlockMatrix)
-  extends RDD[Array[Double]](m.blocks.sparkContext, Nil) {
+  extends RDD[Double](m.blocks.sparkContext, Nil) {
 
   import BlockMatrix.block
 
@@ -946,16 +946,16 @@ private class BlockMatrixDiagonalRDD(m: BlockMatrix)
       def getParents(partitionId: Int): Seq[Int] = Array(gp.coordinatesBlock(partitionId, partitionId))
     })
 
-  def compute(split: Partition, context: TaskContext): Iterator[Array[Double]] = {
+  def compute(split: Partition, context: TaskContext): Iterator[Double] = {
     val i = split.index
     val lm = block(m, parts, gp, context, i, i)
-    Iterator.single(Array.tabulate(math.min(lm.rows, lm.cols))(k => lm(k, k)))
+    (0 until math.min(lm.rows, lm.cols)).iterator.map(k => lm(k, k))
   }
 
   protected def getPartitions: Array[Partition] = Array.tabulate(nDiagBlocks)(IntPartition)
 
   def toArray: Array[Double] = {
-    val diag = this.collect().flatten
+    val diag = this.collect()
     assert(diag.length == nDiagElements)
     diag
   }

--- a/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -955,7 +955,7 @@ private class BlockMatrixDiagonalRDD(m: BlockMatrix)
   protected def getPartitions: Array[Partition] = Array.tabulate(nDiagBlocks)(IntPartition)
 
   def toArray: Array[Double] = {
-    val diag = this.collect()
+    val diag = collect()
     assert(diag.length == nDiagElements)
     diag
   }


### PR DESCRIPTION
@konradjk is getting bogged down by the single-core implementation of BlockMatrix diagonal. This implementation pulls out the diagonal of each diagonal block in parallel, and then collects and flattens the result.