### PR TITLE
ContextRDD and its Basic Usage in RVD

### DIFF
--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -27,7 +27,7 @@ class OrderedRVD(
     typ: OrderedRVDType,
     partitioner: OrderedRVDPartitioner,
     rdd: RDD[RegionValue]
-  ) = this(typ, partitioner, ContextRDD.weaken(rdd, RVDContext.default _))
+  ) = this(typ, partitioner, ContextRDD.weaken(rdd))
 
   val rdd = crdd.run
 
@@ -100,7 +100,7 @@ class OrderedRVD(
     new OrderedRVD(
       typ = ordType,
       partitioner = newPartitioner,
-      crdd = ContextRDD.weaken(RepartitionedOrderedRDD(this, newPartitioner), RVDContext.default _))
+      crdd = ContextRDD.weaken(RepartitionedOrderedRDD(this, newPartitioner))
   }
 
   def keyBy(key: Array[String] = typ.key): KeyedOrderedRVD =
@@ -738,7 +738,7 @@ object OrderedRVD {
     new OrderedRVD(
       typ,
       partitioner,
-      ContextRDD.weaken(rdd, RVDContext.default _)
+      ContextRDD.weaken(rdd)
         .mapPartitionsWithIndex { case (i, it) =>
           val prevK = WritableRegionValue(typ.kType)
           val prevPK = WritableRegionValue(typ.pkType)

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -19,8 +19,11 @@ import scala.reflect.ClassTag
 class OrderedRVD(
   val typ: OrderedRVDType,
   val partitioner: OrderedRVDPartitioner,
-  val rdd: RDD[RegionValue]) extends RVD {
+  val crdd: ContextRDD[RVDContext, RegionValue]) extends RVD {
   self =>
+
+  val rdd = crdd.run
+
   def rowType: TStruct = typ.rowType
 
   def updateType(newTyp: OrderedRVDType): OrderedRVD =

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -100,7 +100,7 @@ class OrderedRVD(
     new OrderedRVD(
       typ = ordType,
       partitioner = newPartitioner,
-      crdd = ContextRDD.weaken(RepartitionedOrderedRDD(this, newPartitioner))
+      crdd = ContextRDD.weaken(RepartitionedOrderedRDD(this, newPartitioner)))
   }
 
   def keyBy(key: Array[String] = typ.key): KeyedOrderedRVD =

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -19,8 +19,15 @@ import scala.reflect.ClassTag
 class OrderedRVD(
   val typ: OrderedRVDType,
   val partitioner: OrderedRVDPartitioner,
-  val crdd: ContextRDD[RVDContext, RegionValue]) extends RVD {
+  val crdd: ContextRDD[RVDContext, RegionValue]
+) extends RVD {
   self =>
+
+  def this(
+    typ: OrderedRVDType,
+    partitioner: OrderedRVDPartitioner,
+    rdd: RDD[RegionValue]
+  ) = this(typ, partitioner, ContextRDD.weaken(rdd, RVDContext.default _))
 
   val rdd = crdd.run
 
@@ -93,7 +100,7 @@ class OrderedRVD(
     new OrderedRVD(
       typ = ordType,
       partitioner = newPartitioner,
-      rdd = RepartitionedOrderedRDD(this, newPartitioner))
+      crdd = ContextRDD.weaken(RepartitionedOrderedRDD(this, newPartitioner), RVDContext.default _))
   }
 
   def keyBy(key: Array[String] = typ.key): KeyedOrderedRVD =

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -67,7 +67,9 @@ case class UnpartitionedRVDSpec(
   codecSpec: CodecSpec,
   partFiles: Array[String]) extends RVDSpec {
   def read(hc: HailContext, path: String): UnpartitionedRVD =
-    new UnpartitionedRVD(rowType, hc.readRows(path, rowType, codecSpec, partFiles))
+    new UnpartitionedRVD(
+      rowType,
+      hc.readRows(path, rowType, codecSpec, partFiles))
 
   def readLocal(hc: HailContext, path: String): IndexedSeq[Row] =
     RVDSpec.readLocal(hc, path, rowType, codecSpec, partFiles)
@@ -92,7 +94,7 @@ case class OrderedRVDSpec(
 
 case class PersistedRVRDD(
   persistedRDD: RDD[RegionValue],
-  iterationRDD: RDD[RegionValue])
+  iterationRDD: ContextRDD[RVDContext, RegionValue])
 
 object RVD {
   def writeLocalUnpartitioned(hc: HailContext, path: String, rowType: TStruct, codecSpec: CodecSpec, rows: IndexedSeq[Annotation]): Array[Long] = {
@@ -121,6 +123,8 @@ trait RVD {
   self =>
   def rowType: TStruct
 
+  def crdd: ContextRDD[RVDContext, RegionValue]
+
   def rdd: RDD[RegionValue]
 
   def sparkContext: SparkContext = rdd.sparkContext
@@ -131,17 +135,19 @@ trait RVD {
 
   def filter(f: (RegionValue) => Boolean): RVD
 
-  def map(newRowType: TStruct)(f: (RegionValue) => RegionValue): UnpartitionedRVD = new UnpartitionedRVD(newRowType, rdd.map(f))
+  def map(newRowType: TStruct)(f: (RegionValue) => RegionValue): UnpartitionedRVD =
+    new UnpartitionedRVD(newRowType, crdd.map(f))
 
   def mapWithContext[C](newRowType: TStruct)(makeContext: () => C)(f: (C, RegionValue) => RegionValue): UnpartitionedRVD =
-    new UnpartitionedRVD(newRowType, rdd.mapPartitions { it =>
+    new UnpartitionedRVD(newRowType, crdd.mapPartitions { it =>
       val c = makeContext()
       it.map { rv => f(c, rv) }
     })
 
   def map[T](f: (RegionValue) => T)(implicit tct: ClassTag[T]): RDD[T] = rdd.map(f)
 
-  def mapPartitions(newRowType: TStruct)(f: (Iterator[RegionValue]) => Iterator[RegionValue]): RVD = new UnpartitionedRVD(newRowType, rdd.mapPartitions(f))
+  def mapPartitions(newRowType: TStruct)(f: (Iterator[RegionValue]) => Iterator[RegionValue]): RVD =
+    new UnpartitionedRVD(newRowType, crdd.mapPartitions(f))
 
   def mapPartitionsWithIndex[T](f: (Int, Iterator[RegionValue]) => Iterator[T])(implicit tct: ClassTag[T]): RDD[T] = rdd.mapPartitionsWithIndex(f)
 
@@ -184,7 +190,7 @@ trait RVD {
       .persist(level)
 
     PersistedRVRDD(persistedRDD,
-      persistedRDD
+      ContextRDD.weaken(persistedRDD, RVDContext.default _)
         .mapPartitions { it =>
           val region = Region()
           val rv2 = RegionValue(region)

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -190,7 +190,7 @@ trait RVD {
       .persist(level)
 
     PersistedRVRDD(persistedRDD,
-      ContextRDD.weaken(persistedRDD, RVDContext.default _)
+      ContextRDD.weaken(persistedRDD)
         .mapPartitions { it =>
           val region = Region()
           val rv2 = RegionValue(region)

--- a/src/main/scala/is/hail/rvd/RVDContext.scala
+++ b/src/main/scala/is/hail/rvd/RVDContext.scala
@@ -16,5 +16,5 @@ class RVDContext(r: Region) extends AutoCloseable {
   def partitionRegion: Region = r // lifetime: partition
 
   // frees the memory associated with this context
-  def close: Unit = ()
+  def close(): Unit = ()
 }

--- a/src/main/scala/is/hail/rvd/RVDContext.scala
+++ b/src/main/scala/is/hail/rvd/RVDContext.scala
@@ -1,0 +1,28 @@
+package is.hail.rvd
+
+import is.hail.annotations.Region
+
+object RVDContext {
+  def default: RVDContext = SimpleRVDContext(Region())
+
+  def fromRegion(region: Region): RVDContext = SimpleRVDContext(region)
+}
+
+// NB: must be *Auto*Closeable because calling close twice is undefined behavior
+// (see AutoCloseable javadoc)
+trait RVDContext extends AutoCloseable {
+  def region: Region // lifetime: element
+
+  def partitionRegion: Region // lifetime: partition
+
+  // frees the memory associated with this context
+  def close: Unit
+}
+
+case class SimpleRVDContext(region: Region) extends RVDContext {
+  val partitionRegion = region
+
+  def close {
+    region.close()
+  }
+}

--- a/src/main/scala/is/hail/rvd/RVDContext.scala
+++ b/src/main/scala/is/hail/rvd/RVDContext.scala
@@ -3,25 +3,18 @@ package is.hail.rvd
 import is.hail.annotations.Region
 
 object RVDContext {
-  def default: RVDContext = SimpleRVDContext(Region())
+  def default: RVDContext = new RVDContext(Region())
 
-  def fromRegion(region: Region): RVDContext = SimpleRVDContext(region)
+  def fromRegion(region: Region): RVDContext = new RVDContext(region)
 }
 
 // NB: must be *Auto*Closeable because calling close twice is undefined behavior
 // (see AutoCloseable javadoc)
-trait RVDContext extends AutoCloseable {
-  def region: Region // lifetime: element
+class RVDContext(r: Region) extends AutoCloseable {
+  def region: Region = r // lifetime: element
 
-  def partitionRegion: Region // lifetime: partition
+  def partitionRegion: Region = r // lifetime: partition
 
   // frees the memory associated with this context
-  def close: Unit
-}
-
-case class SimpleRVDContext(region: Region) extends RVDContext {
-  val partitionRegion = region
-
-  def close {
-  }
+  def close: Unit = ()
 }

--- a/src/main/scala/is/hail/rvd/RVDContext.scala
+++ b/src/main/scala/is/hail/rvd/RVDContext.scala
@@ -23,6 +23,5 @@ case class SimpleRVDContext(region: Region) extends RVDContext {
   val partitionRegion = region
 
   def close {
-    region.close()
   }
 }

--- a/src/main/scala/is/hail/rvd/UnpartitionedRVD.scala
+++ b/src/main/scala/is/hail/rvd/UnpartitionedRVD.scala
@@ -11,14 +11,14 @@ import org.apache.spark.storage.StorageLevel
 
 object UnpartitionedRVD {
   def empty(sc: SparkContext, rowType: TStruct): UnpartitionedRVD =
-    new UnpartitionedRVD(rowType, ContextRDD.empty[RegionValue](sc, RVDContext.default _))
+    new UnpartitionedRVD(rowType, ContextRDD.empty[RVDContext, RegionValue](sc))
 }
 
 class UnpartitionedRVD(val rowType: TStruct, val crdd: ContextRDD[RVDContext, RegionValue]) extends RVD {
   self =>
 
   def this(rowType: TStruct, rdd: RDD[RegionValue]) =
-    this(rowType, ContextRDD.weaken(rdd, RVDContext.default _))
+    this(rowType, ContextRDD.weaken(rdd))
 
   val rdd = crdd.run
 
@@ -48,7 +48,7 @@ class UnpartitionedRVD(val rowType: TStruct, val crdd: ContextRDD[RVDContext, Re
   def sample(withReplacement: Boolean, p: Double, seed: Long): UnpartitionedRVD =
     new UnpartitionedRVD(
       rowType,
-      ContextRDD.weaken(rdd.sample(withReplacement, p, seed), RVDContext.default _))
+      ContextRDD.weaken(rdd.sample(withReplacement, p, seed)))
 
   def write(path: String, codecSpec: CodecSpec): Array[Long] = {
     val (partFiles, partitionCounts) = rdd.writeRows(path, rowType, codecSpec)
@@ -61,8 +61,7 @@ class UnpartitionedRVD(val rowType: TStruct, val crdd: ContextRDD[RVDContext, Re
     new UnpartitionedRVD(
       rowType,
       ContextRDD.weaken(
-        rdd.coalesce(maxPartitions, shuffle = shuffle),
-        RVDContext.default _))
+        rdd.coalesce(maxPartitions, shuffle = shuffle)))
 
   def constrainToOrderedPartitioner(
     ordType: OrderedRVDType,

--- a/src/main/scala/is/hail/rvd/UnpartitionedRVD.scala
+++ b/src/main/scala/is/hail/rvd/UnpartitionedRVD.scala
@@ -2,6 +2,7 @@ package is.hail.rvd
 
 import is.hail.annotations.{KeyedRow, RegionValue, UnsafeRow}
 import is.hail.expr.types.TStruct
+import is.hail.sparkextras._
 import is.hail.io.CodecSpec
 import is.hail.utils._
 import org.apache.spark.SparkContext
@@ -9,13 +10,19 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
 
 object UnpartitionedRVD {
-  def empty(sc: SparkContext, rowType: TStruct): UnpartitionedRVD = new UnpartitionedRVD(rowType, sc.emptyRDD[RegionValue])
+  def empty(sc: SparkContext, rowType: TStruct): UnpartitionedRVD =
+    new UnpartitionedRVD(rowType, ContextRDD.empty[RegionValue](sc, RVDContext.default _))
 }
 
-class UnpartitionedRVD(val rowType: TStruct, val rdd: RDD[RegionValue]) extends RVD {
+class UnpartitionedRVD(val rowType: TStruct, val crdd: ContextRDD[RVDContext, RegionValue]) extends RVD {
   self =>
 
-  def filter(f: (RegionValue) => Boolean): UnpartitionedRVD = new UnpartitionedRVD(rowType, rdd.filter(f))
+  def this(rowType: TStruct, rdd: RDD[RegionValue]) =
+    this(rowType, ContextRDD.weaken(rdd, RVDContext.default _))
+
+  val rdd = crdd.run
+
+  def filter(f: (RegionValue) => Boolean): UnpartitionedRVD = new UnpartitionedRVD(rowType, crdd.filter(f))
 
   def persist(level: StorageLevel): UnpartitionedRVD = {
     val PersistedRVRDD(persistedRDD, iterationRDD) = persistRVRDD(level)
@@ -39,7 +46,9 @@ class UnpartitionedRVD(val rowType: TStruct, val rdd: RDD[RegionValue]) extends 
   }
 
   def sample(withReplacement: Boolean, p: Double, seed: Long): UnpartitionedRVD =
-    new UnpartitionedRVD(rowType, rdd.sample(withReplacement, p, seed))
+    new UnpartitionedRVD(
+      rowType,
+      ContextRDD.weaken(rdd.sample(withReplacement, p, seed), RVDContext.default _))
 
   def write(path: String, codecSpec: CodecSpec): Array[Long] = {
     val (partFiles, partitionCounts) = rdd.writeRows(path, rowType, codecSpec)
@@ -48,7 +57,12 @@ class UnpartitionedRVD(val rowType: TStruct, val rdd: RDD[RegionValue]) extends 
     partitionCounts
   }
 
-  def coalesce(maxPartitions: Int, shuffle: Boolean): UnpartitionedRVD = new UnpartitionedRVD(rowType, rdd.coalesce(maxPartitions, shuffle = shuffle))
+  def coalesce(maxPartitions: Int, shuffle: Boolean): UnpartitionedRVD =
+    new UnpartitionedRVD(
+      rowType,
+      ContextRDD.weaken(
+        rdd.coalesce(maxPartitions, shuffle = shuffle),
+        RVDContext.default _))
 
   def constrainToOrderedPartitioner(
     ordType: OrderedRVDType,

--- a/src/main/scala/is/hail/rvd/UnpartitionedRVD.scala
+++ b/src/main/scala/is/hail/rvd/UnpartitionedRVD.scala
@@ -60,8 +60,7 @@ class UnpartitionedRVD(val rowType: TStruct, val crdd: ContextRDD[RVDContext, Re
   def coalesce(maxPartitions: Int, shuffle: Boolean): UnpartitionedRVD =
     new UnpartitionedRVD(
       rowType,
-      ContextRDD.weaken(
-        rdd.coalesce(maxPartitions, shuffle = shuffle)))
+      ContextRDD.weaken(rdd.coalesce(maxPartitions, shuffle = shuffle)))
 
   def constrainToOrderedPartitioner(
     ordType: OrderedRVDType,

--- a/src/main/scala/is/hail/rvd/package.scala
+++ b/src/main/scala/is/hail/rvd/package.scala
@@ -3,7 +3,8 @@ package is.hail
 import is.hail.utils._
 
 package object rvd {
-  implicit object RVDContextIsPointed extends Pointed[RVDContext] {
+  implicit object RVDContextIsPointed
+      extends Pointed[RVDContext] with Serializable {
     def point: RVDContext = RVDContext.default
   }
 }

--- a/src/main/scala/is/hail/rvd/package.scala
+++ b/src/main/scala/is/hail/rvd/package.scala
@@ -1,0 +1,9 @@
+package is.hail
+
+import is.hail.utils._
+
+package object rvd {
+  implicit object RVDContextIsPointed extends Pointed[RVDContext] {
+    def point: RVDContext = RVDContext.default
+  }
+}

--- a/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -16,6 +16,17 @@ object ContextRDD {
   ): ContextRDD[C, T] =
     new ContextRDD(sc.emptyRDD[C => Iterator[T]], mkc)
 
+  // this one weird trick permits the caller to specify T without C
+  sealed trait Empty[T] {
+    def apply[C <: AutoCloseable](
+      sc: SparkContext,
+      mkc: () => C
+    )(implicit tct: ClassTag[T]): ContextRDD[C, T] =
+      empty[C, T](sc, mkc)
+  }
+  private[this] object emptyInstance extends Empty[Nothing]
+  def empty[T] = emptyInstance.asInstanceOf[Empty[T]]
+
   def union[C <: AutoCloseable, T: ClassTag](
     sc: SparkContext,
     xs: Seq[ContextRDD[C, T]]

--- a/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -68,7 +68,7 @@ class ContextRDD[C <: AutoCloseable, T: ClassTag](
   val mkc: () => C
 ) extends Serializable {
   def run: RDD[T] =
-    rdd.mapPartitions { part => using(mkc()) { cc => part.flatMap(_(cc)).toArray.iterator } }
+    rdd.mapPartitions { part => using(mkc()) { cc => part.flatMap(_(cc)) } }
 
   private[this] def inCtx[U: ClassTag](f: C => Iterator[U])
       : Iterator[C => Iterator[U]] =

--- a/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -1,0 +1,229 @@
+package is.hail.sparkextras
+
+import is.hail.io._
+import is.hail.expr.types._
+import is.hail.utils._
+
+import org.apache.spark._
+import org.apache.spark.rdd._
+import org.apache.spark.storage._
+import scala.reflect.ClassTag
+
+object ContextRDD {
+  def empty[C <: AutoCloseable, T: ClassTag](sc: SparkContext): ContextRDD[C, T] =
+    new ContextRDD(sc.emptyRDD[C => Iterator[T]])
+
+  def union[C <: AutoCloseable, T: ClassTag]
+    (sc: SparkContext, xs: Seq[ContextRDD[C, T]])
+      : ContextRDD[C, T] =
+    new ContextRDD(sc.union(xs.map(_.rdd)))
+
+  // def weaken[C, T: ClassTag](rdd: RDD[T]): ContextRDD[C, T] =
+  //   new ContextRDD(rdd.mapPartitions(it => Iterator.single((ctx: C) => it)))
+
+  // this one weird trick permits the caller to specify C without T
+  sealed trait Weaken[C <: AutoCloseable] {
+    def apply[T: ClassTag](rdd: RDD[T]): ContextRDD[C, T] =
+      new ContextRDD(rdd.mapPartitions(it => Iterator.single((ctx: C) => it)))
+  }
+  private[this] object weakenInstance extends Weaken[Nothing]
+  def weaken[C <: AutoCloseable] = weakenInstance.asInstanceOf[Weaken[C]]
+
+  type ElementType[C, T] = C => Iterator[T]
+}
+
+// FIXME: Subclassing seems super dangerous, did I actually implement the
+// interace right?!?! Also: I want `map` to work on `T` not on the literal
+// elements of the RDD (i.e. `C => Iterator[T]`).
+class ContextRDD[C <: AutoCloseable, T: ClassTag](val rdd: RDD[C => Iterator[T]])
+    extends Serializable {
+  // FIXME: is this the right choice? Should I broadcast c? Should there be a
+  // new one per useCtx? Probably need a method that constructs a context
+  // FIXME: I probably need to reset the region per record??
+  def run(c: () => C): RDD[T] =
+    rdd.mapPartitions { part => using(c()) { cc => part.flatMap(_(cc)).toArray.iterator } }
+
+  def collect(c: () => C): Array[T] = run(c).collect()
+
+  private[this] def inCtx[U: ClassTag](f: C => Iterator[U])
+      : Iterator[C => Iterator[U]] =
+    Iterator.single { (ctx: C) => f(ctx) }
+
+  private[this] def withoutContext[U: ClassTag](f: Iterator[T] => Iterator[U])
+      : ContextRDD[C, U] =
+    new ContextRDD(rdd.map(_.andThen(f)))
+
+  def map[U: ClassTag](f: T => U): ContextRDD[C, U] =
+    withoutContext(_.map(f))
+
+  def filter(f: T => Boolean): ContextRDD[C, T] =
+    withoutContext(_.filter(f))
+
+  def flatMap[U: ClassTag](f: T => TraversableOnce[U]): ContextRDD[C, U] =
+    withoutContext(_.flatMap(f))
+
+  def mapPartitions[U: ClassTag]
+    (f: Iterator[T] => Iterator[U], preservesPartitioning: Boolean = false)
+      : ContextRDD[C, U] =
+    cmapPartitions((_, part) => f(part), preservesPartitioning)
+
+  def mapPartitionsWithIndex[U: ClassTag](f: (Int, Iterator[T]) => Iterator[U])
+      : ContextRDD[C, U] =
+    cmapPartitionsWithIndex((i, _, part) => f(i, part))
+
+  // context is shared
+  def zipPartitions[U: ClassTag, V: ClassTag]
+    (that: ContextRDD[C, U], preservesPartitioning: Boolean = false)
+    (f: (Iterator[T], Iterator[U]) => Iterator[V])
+      : ContextRDD[C, V] =
+    czipPartitions[U, V](that, preservesPartitioning)((_, l, r) => f(l, r))
+
+  // FIXME: should this even exist? Where am I cleaning up the context?
+  def treeAggregate[U: ClassTag](c: () => C)(zero: U)
+    (seqOp: (U, T) => U,combOp: (U, U) => U, depth: Int = 2): U =
+    rdd.treeAggregate(zero)(
+      // FIXME: shouldn't this be per-partition?? Should I ensure there's one
+      // iterator per partition?
+      { (u, useCtx) => useCtx(c()).foldLeft(u)(seqOp)},
+      combOp,
+      depth)
+
+  // FIXME: is this just treeAggregate with depth = 1?
+  def aggregate[U: ClassTag](c: () => C)(zero: U)
+    (seqOp: (U, T) => U,combOp: (U, U) => U): U =
+    rdd.aggregate(zero)(
+      // FIXME: shouldn't this be per-partition?? Should I ensure there's one
+      // iterator per partition?
+      { (u, useCtx) => useCtx(c()).foldLeft(u)(seqOp)},
+      combOp)
+
+  def aggregateByKey[U: ClassTag, K: ClassTag, V: ClassTag]
+    (zero: U)(seqOp: (U, V) => U,combOp: (U, U) => U)
+    (implicit ev: T =:= (K, V))
+      : ContextRDD[C, (K, U)] =
+    // FIXME: how do I do this
+    ???
+
+  def summarizePartitions[U: ClassTag](c: () => C)(f: Iterator[T] => U): Array[U] =
+    run(c).mapPartitions(f.andThen(Iterator.single)).collect()
+
+  def find(f: T => Boolean): Option[T] = filter(f).take(1) match {
+    case Array(elem) => Some(elem)
+    case _ => None
+  }
+
+  def take(i: Int): Array[T] =
+    ??? // FIXME: I shouldn't need a context to do this
+
+  private[this] def withContext[U: ClassTag](f: (C, Iterator[T]) => Iterator[U])
+      : ContextRDD[C, U] =
+    new ContextRDD(rdd.map(useCtx => ctx => f(ctx, useCtx(ctx))))
+
+  def cmap[U: ClassTag](f: (C, T) => U): ContextRDD[C, U] =
+    withContext((c, it) => it.map(f(c,_)))
+
+  def cfilter(f: (C, T) => Boolean): ContextRDD[C, T] =
+    withContext((c, it) => it.filter(f(c,_)))
+
+  def cflatMap[U: ClassTag](f: (C, T) => TraversableOnce[U]): ContextRDD[C, U] =
+    withContext((c, it) => it.flatMap(f(c,_)))
+
+  def cmapPartitions[U: ClassTag]
+    (f: (C, Iterator[T]) => Iterator[U], preservesPartitioning: Boolean = false)
+      : ContextRDD[C, U] =
+    new ContextRDD(rdd.mapPartitions(
+      part => inCtx(ctx => f(ctx, part.flatMap(_(ctx)))),
+      preservesPartitioning))
+
+  def cmapPartitionsWithIndex[U: ClassTag](f: (Int, C, Iterator[T]) => Iterator[U])
+      : ContextRDD[C, U] =
+    new ContextRDD(rdd.mapPartitionsWithIndex(
+      (i, part) => inCtx(ctx => f(i, ctx, part.flatMap(_(ctx))))))
+
+  def czipPartitions[U: ClassTag, V: ClassTag]
+    (that: ContextRDD[C, U], preservesPartitioning: Boolean = false)
+    (f: (C, Iterator[T], Iterator[U]) => Iterator[V])
+      : ContextRDD[C, V] =
+    new ContextRDD(rdd.zipPartitions(that.rdd, preservesPartitioning)(
+      (l, r) => inCtx(ctx => f(ctx, l.flatMap(_(ctx)), r.flatMap(_(ctx))))))
+
+  def sample(c: () => C)(withReplacement: Boolean, p: Double, seed: Long)
+      : ContextRDD[C, T] =
+    ContextRDD.weaken(run(c).sample(withReplacement, p, seed))
+
+  // delagate to Spark
+
+  // WTF SPARK? Two methods for the same thing?
+  def sparkContext: SparkContext = rdd.sparkContext
+  def context: SparkContext = rdd.context
+
+  def getNumPartitions: Int = rdd.getNumPartitions
+
+  def partitions: Array[Partition] = rdd.partitions
+
+  def partitioner: Option[Partitioner] = rdd.partitioner
+
+  def persist(level: StorageLevel): ContextRDD[C, T] =
+    onRdd(_.persist)
+
+  def unpersist(): ContextRDD[C, T] =
+    onRdd(_.unpersist())
+
+  def getStorageLevel: StorageLevel = rdd.getStorageLevel
+
+  def coalesce(maxPartitions: Int, shuffle: Boolean): ContextRDD[C, T] =
+    onRdd(_.coalesce(maxPartitions, shuffle))
+
+  def preferredLocations(p: Partition): Seq[String] =
+    rdd.preferredLocations(p)
+
+  def subsetPartitions(keptPartitionIndices: Array[Int]): ContextRDD[C, T] =
+    onRdd(_.subsetPartitions(keptPartitionIndices))
+
+  def head(c: () => C)(n: Long): ContextRDD[C, T] =
+    // FIXME: do I really need a context to do head? This doesn't seem
+    // necessary. I think I just need to pull the thread on RichRDD.head
+    ContextRDD.weaken(run(c).head(n))
+
+  def reorderPartitions(oldIndices: Array[Int]): ContextRDD[C, T] =
+    onRdd(_.reorderPartitions(oldIndices))
+
+  def adjustPartitions(adjustments: IndexedSeq[Array[Adjustment[T]]])
+      : ContextRDD[C, T] = {
+    def contextIgnorantPartitionFunction(f: Iterator[T] => Iterator[T])
+        : Iterator[C => Iterator[T]] => Iterator[C => Iterator[T]] =
+      it => inCtx(ctx => f(it.flatMap(useCtx => useCtx(ctx))))
+    def contextIgnorantAdjustment(a: Adjustment[T]): Adjustment[C => Iterator[T]] =
+      new Adjustment(a.index, contextIgnorantPartitionFunction(a.f))
+    val contextIgnorantAdjustments =
+      adjustments.map(as => as.map(a => contextIgnorantAdjustment(a)))
+    onRdd(rdd => new AdjustedPartitionsRDD(rdd, contextIgnorantAdjustments))
+  }
+
+  def partitionBy[K: ClassTag, V: ClassTag](partitioner: Partitioner)
+    (implicit ev: (K, V) =:= T): ContextRDD[C, T] =
+    // FIXME: this actually inserts a map step that shouldn't be necessary
+    // probably need PairContextRDDFunctions
+    /// map(ev(_)).onRdd(_.partitionBy(partitioner))
+    // FIXME: Actually, wtf, how do I do this? I need a new RDD I think
+    ???
+
+  def values[K: ClassTag, V: ClassTag](implicit ev: (K, V) =:= T)
+      : ContextRDD[C, V] =
+    // FIXME scala is actually super dumb and doesn't let me go from T to (K, V)
+    // using ev /shrug
+    ???
+    // map(???.apply(_)._2)
+
+  def iterator(partition: Partition, context: TaskContext): Iterator[C => Iterator[T]] =
+    rdd.iterator(partition, context)
+
+  // FIXME: this seems like a dangerous method, I should suck all functionality
+  // into my interface and this should be private. I think only use is
+  // BlockedRDD in OrderedRVD; should I just implement that here instead?
+  def onRdd(f: RDD[C => Iterator[T]] => RDD[C => Iterator[T]]): ContextRDD[C, T] =
+    new ContextRDD(f(rdd))
+
+  // FIXME: I should define cache and use it smartly rather than run'ing. go
+  // look for all run's followed by cache and fix them
+}

--- a/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -50,16 +50,6 @@ object ContextRDD {
   ): ContextRDD[C, T] =
     new ContextRDD(rdd.mapPartitions(it => Iterator.single((ctx: C) => it)), mkc)
 
-  // this one weird trick permits the caller to specify C without T
-  sealed trait Weaken[C <: AutoCloseable] {
-    def apply[T: ClassTag](rdd: RDD[T], mkc: () => C): ContextRDD[C, T] =
-      new ContextRDD(
-        rdd.mapPartitions(it => Iterator.single((ctx: C) => it)),
-        mkc)
-  }
-  private[this] object weakenInstance extends Weaken[Nothing]
-  def weaken[C <: AutoCloseable] = weakenInstance.asInstanceOf[Weaken[C]]
-
   type ElementType[C, T] = C => Iterator[T]
 }
 

--- a/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -32,9 +32,7 @@ object ContextRDD {
   def union[C <: AutoCloseable : Pointed, T: ClassTag](
     sc: SparkContext,
     xs: Seq[ContextRDD[C, T]]
-  ): ContextRDD[C, T] = {
-    union(sc, xs, point[C])
-  }
+  ): ContextRDD[C, T] = union(sc, xs, point[C])
 
   def union[C <: AutoCloseable, T: ClassTag](
     sc: SparkContext,
@@ -106,13 +104,13 @@ class ContextRDD[C <: AutoCloseable, T: ClassTag](
     new ContextRDD(rdd.map(useCtx => ctx => f(ctx, useCtx(ctx))), mkc)
 
   def cmap[U: ClassTag](f: (C, T) => U): ContextRDD[C, U] =
-    withContext((c, it) => it.map(f(c,_)))
+    withContext((c, it) => it.map(f(c, _)))
 
   def cfilter(f: (C, T) => Boolean): ContextRDD[C, T] =
-    withContext((c, it) => it.filter(f(c,_)))
+    withContext((c, it) => it.filter(f(c, _)))
 
   def cflatMap[U: ClassTag](f: (C, T) => TraversableOnce[U]): ContextRDD[C, U] =
-    withContext((c, it) => it.flatMap(f(c,_)))
+    withContext((c, it) => it.flatMap(f(c, _)))
 
   def cmapPartitions[U: ClassTag](
     f: (C, Iterator[T]) => Iterator[U],
@@ -153,7 +151,7 @@ class ContextRDD[C <: AutoCloseable, T: ClassTag](
     ): Iterator[C => Iterator[T]] => Iterator[C => Iterator[T]] =
       it => inCtx(ctx => f(it.flatMap(useCtx => useCtx(ctx))))
     def contextIgnorantAdjustment(a: Adjustment[T]): Adjustment[C => Iterator[T]] =
-      new Adjustment(a.index, contextIgnorantPartitionFunction(a.f))
+      Adjustment(a.index, contextIgnorantPartitionFunction(a.f))
     val contextIgnorantAdjustments =
       adjustments.map(as => as.map(a => contextIgnorantAdjustment(a)))
     onRDD(rdd => new AdjustedPartitionsRDD(rdd, contextIgnorantAdjustments))

--- a/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -1,12 +1,9 @@
 package is.hail.sparkextras
 
-import is.hail.io._
-import is.hail.expr.types._
 import is.hail.utils._
-
 import org.apache.spark._
 import org.apache.spark.rdd._
-import org.apache.spark.storage._
+
 import scala.reflect.ClassTag
 
 object ContextRDD {

--- a/src/main/scala/is/hail/sparkextras/RepartitionedOrderedRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/RepartitionedOrderedRDD.scala
@@ -8,6 +8,8 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 
+// FIXME(DK): Gotta update this for contextrdd
+
 /**
   * Repartition prev to comply with newPartitioner, using narrow dependencies.
   * Assumes new key type is a prefix of old key type, so no reordering is

--- a/src/main/scala/is/hail/utils/Pointed.scala
+++ b/src/main/scala/is/hail/utils/Pointed.scala
@@ -1,0 +1,5 @@
+package is.hail.utils
+
+trait Pointed[T] {
+  def point: T
+}

--- a/src/main/scala/is/hail/utils/package.scala
+++ b/src/main/scala/is/hail/utils/package.scala
@@ -571,7 +571,7 @@ package object utils extends Logging
   def optMatch[T, S](a: T)(pf : PartialFunction[T, S]): Option[S] = lift(pf)(a)
 
 
-  def using[R <: Closeable, T](r: R)(consume: (R) => T): T = {
+  def using[R <: AutoCloseable, T](r: R)(consume: (R) => T): T = {
     try {
       consume(r)
     } finally {

--- a/src/main/scala/is/hail/utils/package.scala
+++ b/src/main/scala/is/hail/utils/package.scala
@@ -578,6 +578,8 @@ package object utils extends Logging
       r.close()
     }
   }
+
+  def point[T]()(implicit t: Pointed[T]): T = t.point
 }
 
 // FIXME: probably resolved in 3.6 https://github.com/json4s/json4s/commit/fc96a92e1aa3e9e3f97e2e91f94907fdfff6010d


### PR DESCRIPTION
cc: @cseed, @patrick-schultz, @catoverdrive 

A `ContextRDD[C, T]` is an `RDD[C => Iterator[T]]` and captures the idea that a computation needs a context. I did not inherit from RDD so that `map` and friends can be implemented as if this was an `RDD[T]`. To access the context, one uses `cmap` and friends.

The lifetime of a context corresponds roughly to the dynamic extent of an `RDD` computation happening on a single worker node. In particular, a context always ends before a `shuffle` or other network communication happens. One may explicitly end a `ContextRDD`'s context lifetime by calling `ContextRDD.run` which produces an `RDD[T]`.

Generally the partitions of a `ContextRDD[C, T]` need only contain one element, but (I believe) I have written `ContextRDD[C, T]` to also handle many `C => Iterator[T]` functions inside a single partition.

Most operations on `RVD` do not use the `crdd` yet. I have a growing local stack of branches in which more of these operations are implemented. I am only holding them back because stacked PRs have proven unwieldy.

Finally, I added `RVDContext`, which is not fleshed out. It will need to carry at least a region. We might also want it to carry a random seed. Unless you have severe issues with it, I think it's best to treat it as a placeholder for something that will later adopt its name.