### PR TITLE
rewrite annotate_rows in terms of select_rows

### DIFF
--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -1250,10 +1250,9 @@ class MatrixTable(ExprContainer):
             new_global_fields = [f for f in m.globals if f not in fields_to_drop]
             m = m.select_globals(*new_global_fields)
 
-        row_fields = [x for x in fields_to_drop if self._fields[x]._indices == self._row_indices]
+        row_fields = [field for field in fields_to_drop if self._fields[field]._indices == self._row_indices]
         if row_fields:
-            # need to drop row fields
-            m = MatrixTable(m._jvds.dropRows(row_fields))
+            m = m._select_entries("MatrixTable.drop_rows", m.entry.drop(*row_fields))
 
         if any(self._fields[field]._indices == self._col_indices for field in fields_to_drop):
             # need to drop col fields
@@ -2584,7 +2583,7 @@ class MatrixTable(ExprContainer):
     @typecheck_method(caller=str, s=expr_struct())
     def _select_rows(self, caller, s):
         base, cleanup = self._process_joins(s)
-        analyze(caller, s, self._row_indices)
+        analyze(caller, s, self._row_indices, {self._col_axis})
         return cleanup(MatrixTable(base._jvds.selectRows(s._ast.to_hql())))
 
     @typecheck(datasets=matrix_table_type)

--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -1252,7 +1252,7 @@ class MatrixTable(ExprContainer):
 
         row_fields = [field for field in fields_to_drop if self._fields[field]._indices == self._row_indices]
         if row_fields:
-            m = m._select_rows("MatrixTable.drop_rows", m.rows.drop(*row_fields))
+            m = m._select_rows("MatrixTable.drop_rows", m.row.drop(*row_fields))
 
         if any(self._fields[field]._indices == self._col_indices for field in fields_to_drop):
             # need to drop col fields
@@ -2193,7 +2193,7 @@ class MatrixTable(ExprContainer):
         if row_exprs:
             row_struct = self.row.annotate(**row_exprs)
             analyze("MatrixTable.annotate_rows", row_struct, self._row_indices)
-            jmt = jmt.selectEntries(row_struct._ast.to_hql())
+            jmt = jmt.selectRows(row_struct._ast.to_hql())
         if col_exprs:
             col_strs = []
             for k, v in col_exprs.items():

--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -1252,7 +1252,7 @@ class MatrixTable(ExprContainer):
 
         row_fields = [field for field in fields_to_drop if self._fields[field]._indices == self._row_indices]
         if row_fields:
-            m = m._select_entries("MatrixTable.drop_rows", m.entry.drop(*row_fields))
+            m = m._select_rows("MatrixTable.drop_rows", m.entry.drop(*row_fields))
 
         if any(self._fields[field]._indices == self._col_indices for field in fields_to_drop):
             # need to drop col fields

--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -825,16 +825,12 @@ class MatrixTable(ExprContainer):
         :class:`.MatrixTable`
             Matrix table with new row-indexed field(s).
         """
-        exprs = []
         named_exprs = {k: to_expr(v) for k, v in named_exprs.items()}
-        base, cleanup = self._process_joins(*named_exprs.values())
 
         for k, v in named_exprs.items():
-            analyze('MatrixTable.annotate_rows', v, self._row_indices, {self._col_axis})
-            exprs.append('{k} = {v}'.format(k=escape_id(k), v=v._ast.to_hql()))
             check_collisions(self._fields, k, self._row_indices)
-        m = MatrixTable(base._jvds.annotateRowsExpr(",\n".join(exprs)))
-        return cleanup(m)
+
+        return self._select_rows("MatrixTable.annotate_rows", self.row.annotate(**named_exprs))
 
     def annotate_cols(self, **named_exprs) -> 'MatrixTable':
         """Create new column-indexed fields by name.
@@ -1050,29 +1046,23 @@ class MatrixTable(ExprContainer):
         :class:`.MatrixTable`
             MatrixTable with specified row fields.
         """
-        exprs = [to_expr(e) if not isinstance(e, str) else self[e] for e in exprs]
-        named_exprs = {k: to_expr(v) for k, v in named_exprs.items()}
-        strs = []
-        all_exprs = []
-        base, cleanup = self._process_joins(*itertools.chain(exprs, named_exprs.values()))
 
-        ids = []
+        exprs = [self[e] if not isinstance(e, Expression) else e for e in exprs]
+        named_exprs = {k: to_expr(v) for k, v in named_exprs.items()}
+        assignments = OrderedDict()
+
         for e in exprs:
-            all_exprs.append(e)
-            analyze('MatrixTable.select_rows', e, self._row_indices, {self._col_axis})
             if e._ast.search(lambda ast: not isinstance(ast, TopLevelReference) and not isinstance(ast, Select)):
-                raise ExpressionException("method 'select_rows' expects keyword arguments for complex expressions")
-            strs.append(e._ast.to_hql())
-            ids.append(e._ast.name)
+                raise ExpressionException("method 'select' expects keyword arguments for complex expressions")
+            assert isinstance(e._ast, Select)
+            assignments[e._ast.name] = e
+
         for k, e in named_exprs.items():
-            all_exprs.append(e)
-            analyze('MatrixTable.select_rows', e, self._row_indices, {self._col_axis})
             check_collisions(self._fields, k, self._row_indices)
-            strs.append('{} = {}'.format(escape_id(k), e._ast.to_hql()))
-            ids.append(k)
-        check_field_uniqueness(ids)
-        m = MatrixTable(base._jvds.selectRows(strs))
-        return cleanup(m)
+            assignments[k] = e
+
+        check_field_uniqueness(assignments.keys())
+        return self._select_rows('Table.select_rows', hl.struct(**assignments))
 
     def select_cols(self, *exprs, **named_exprs) -> 'MatrixTable':
         """Select existing column fields or create new fields by name, dropping the rest.
@@ -2202,12 +2192,9 @@ class MatrixTable(ExprContainer):
         base, cleanup = self._process_joins(*all_exprs)
         jmt = base._jvds
         if row_exprs:
-            row_strs = []
-            for k, v in row_exprs.items():
-                analyze('MatrixTable.annotate_rows', v, self._row_indices, {self._col_axis})
-                row_strs.append('{k} = {v}'.format(k=escape_id(k), v=v._ast.to_hql()))
-                check_collisions(self._fields, k, self._row_indices)
-                jmt = jmt.annotateRowsExpr(",\n".join(row_strs))
+            row_struct = self.row.annotate(**row_exprs)
+            analyze("MatrixTable.annotate_rows", row_struct, self._row_indices)
+            jmt = jmt.selectEntries(row_struct._ast.to_hql())
         if col_exprs:
             col_strs = []
             for k, v in col_exprs.items():
@@ -2593,6 +2580,12 @@ class MatrixTable(ExprContainer):
         base, cleanup = self._process_joins(s)
         analyze(caller, s, self._entry_indices)
         return cleanup(MatrixTable(base._jvds.selectEntries(s._ast.to_hql())))
+
+    @typecheck_method(caller=str, s=expr_struct())
+    def _select_rows(self, caller, s):
+        base, cleanup = self._process_joins(s)
+        analyze(caller, s, self._row_indices)
+        return cleanup(MatrixTable(base._jvds.selectRows(s._ast.to_hql())))
 
     @typecheck(datasets=matrix_table_type)
     def union_rows(*datasets: 'MatrixTable') -> 'MatrixTable':

--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -1252,7 +1252,7 @@ class MatrixTable(ExprContainer):
 
         row_fields = [field for field in fields_to_drop if self._fields[field]._indices == self._row_indices]
         if row_fields:
-            m = m._select_rows("MatrixTable.drop_rows", m.entry.drop(*row_fields))
+            m = m._select_rows("MatrixTable.drop_rows", m.rows.drop(*row_fields))
 
         if any(self._fields[field]._indices == self._col_indices for field in fields_to_drop):
             # need to drop col fields

--- a/python/hail/methods/qc.py
+++ b/python/hail/methods/qc.py
@@ -544,7 +544,8 @@ def vep(dataset, config, block_size=1000, name='vep', csq=False):
     """
 
     require_row_key_variant(dataset, 'vep')
-    return MatrixTable(Env.hail().methods.VEP.apply(dataset._jvds, config, 'va.`{}`'.format(name), csq, block_size))
+    mt = MatrixTable(Env.hail().methods.VEP.apply(dataset._jvds, config, 'va.`{}`'.format(name), csq, block_size))
+    return mt.annotate_rows(vep=mt['vep']['vep'])
 
 
 @typecheck(dataset=MatrixTable,
@@ -805,4 +806,5 @@ def nirvana(dataset, config, block_size=500000, name='nirvana'):
     """
 
     require_row_key_variant(dataset, 'nirvana')
-    return MatrixTable(Env.hail().methods.Nirvana.apply(dataset._jvds, config, block_size, 'va.`{}`'.format(name)))
+    mt = MatrixTable(Env.hail().methods.Nirvana.apply(dataset._jvds, config, block_size, 'va.`{}`'.format(name)))
+    return mt.annotate_rows(nirvana=mt['nirvana']['nirvana'])

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -1216,10 +1216,10 @@ class Table(ExprContainer):
                         vt = vt.annotate(values=hl.index(vt.values, k_uid))
 
                         jl = left._jvds.annotateRowsTable(vt._jt, uid, False)
-                        key_expr = '{uid} = va.{uid}.values.get({{ {es} }})'.format(uid=uid, es=','.join(
+                        key_expr = 'annotate(va, {{uid}: va.{uid}.values.get({{ {es} }})})'.format(uid=uid, es=','.join(
                             '{}: {}'.format(u, e._ast.to_hql()) for u, e in
                             zip(uids, exprs)))
-                        jl = jl.annotateRowsExpr(key_expr)
+                        jl = jl.selectRows(key_expr)
                         return MatrixTable(jl)
 
                     return construct_expr(Select(TopLevelReference('va', src._row_indices), uid),

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -1216,10 +1216,10 @@ class Table(ExprContainer):
                         vt = vt.annotate(values=hl.index(vt.values, k_uid))
 
                         jl = left._jvds.annotateRowsTable(vt._jt, uid, False)
-                        key_expr = 'annotate(va, {{uid}: va.{uid}.values.get({{ {es} }})})'.format(uid=uid, es=','.join(
+                        key_expr = '{uid}: va.{uid}.values.get({{ {es} }})'.format(uid=uid, es=','.join(
                             '{}: {}'.format(u, e._ast.to_hql()) for u, e in
                             zip(uids, exprs)))
-                        jl = jl.selectRows(key_expr)
+                        jl = jl.selectRows('annotate(va, {'+key_expr+"})")
                         return MatrixTable(jl)
 
                     return construct_expr(Select(TopLevelReference('va', src._row_indices), uid),

--- a/src/main/scala/is/hail/methods/Nirvana.scala
+++ b/src/main/scala/is/hail/methods/Nirvana.scala
@@ -346,7 +346,6 @@ object Nirvana {
       })
 
     vds.orderedRVDLeftJoinDistinctAndInsert(nirvanaRVD, "nirvana", product = false)
-      .annotateRowsExpr("nirvana = va.nirvana.nirvana")
   }
 
   def apply(vsm: MatrixTable, config: String, blockSize: Int = 500000, root: String): MatrixTable =

--- a/src/main/scala/is/hail/methods/VEP.scala
+++ b/src/main/scala/is/hail/methods/VEP.scala
@@ -356,7 +356,6 @@ object VEP {
     info(s"vep: annotated ${ annotations.count() } variants")
 
     vsm.orderedRVDLeftJoinDistinctAndInsert(vepRVD, "vep", product = false)
-      .annotateRowsExpr("vep = va.vep.vep")
   }
 
   def apply(vsm: MatrixTable, config: String, root: String = "va.vep", csq: Boolean = false, blockSize: Int = 1000): MatrixTable =

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1124,7 +1124,6 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     val ec = rowEC
 
     val rowsAST = Parser.parseToAST(expr, ec)
-    assert(rowsAST.`type`.isInstanceOf[TStruct])
 
     val newRowType = coerce[TStruct](rowsAST.`type`)
     val namesSet = newRowType.fieldNames.toSet

--- a/src/test/scala/is/hail/io/ImportBgenSuite.scala
+++ b/src/test/scala/is/hail/io/ImportBgenSuite.scala
@@ -229,8 +229,8 @@ class ImportBgenSuite extends SparkSuite {
     val vds = hc.importBgen("src/test/resources/example.v11.bgen", Some("src/test/resources/example.sample"),
       includeGT = true, includeGP = true, includeDosage = false, contigRecoding = contigRecoding)
 
-    assert(vds.annotateRowsExpr("cr1 = AGG.fraction(g => isDefined(g.GT))")
-      .annotateRowsExpr("cr2 = AGG.fraction(g => isDefined(g.GT))")
+    assert(vds.annotateRowsExpr(("cr1", "AGG.fraction(g => isDefined(g.GT))"))
+      .annotateRowsExpr(("cr2", "AGG.fraction(g => isDefined(g.GT))"))
       .rowsTable()
       .forall("row.cr1 == row.cr2"))
   }

--- a/src/test/scala/is/hail/io/ImportMatrixSuite.scala
+++ b/src/test/scala/is/hail/io/ImportMatrixSuite.scala
@@ -35,7 +35,8 @@ class ImportMatrixSuite extends SparkSuite {
     tGen = (t: Type, v: Annotation) => t.genNonmissingValue)
 
   def reKeyRows(vsm: MatrixTable): MatrixTable = {
-    vsm.indexRows("row_id").keyRowsBy(Array("row_id"), Array("row_id")).selectRows("va.row_id" +: vsm.rowType.fieldNames.map("va."+_): _*)
+    val newFieldNames = "row_id" +: vsm.rowType.fieldNames
+    vsm.indexRows("row_id").keyRowsBy(Array("row_id"), Array("row_id")).selectRows(s"{${ newFieldNames.map(n => s"$n: va.$n").mkString(",") }}")
   }
 
   def reKeyCols(vsm: MatrixTable): MatrixTable = {

--- a/src/test/scala/is/hail/methods/AggregatorSuite.scala
+++ b/src/test/scala/is/hail/methods/AggregatorSuite.scala
@@ -23,7 +23,8 @@ class AggregatorSuite extends SparkSuite {
         """{callrate: AGG.fraction(g => isDefined(g.GT)),
           |AC: AGG.map(g => g.GT.nNonRefAlleles()).sum(),
           |AF: AGG.map(g => g.GT.nNonRefAlleles().toFloat64).stats().sum / AGG.filter(g => isDefined(g.GT)).count().toFloat64 / 2.0,
-          |gqstats: AGG.map(g => g.GQ.toFloat64).stats(), test.gqhetstats = AGG.filter(g => g.GT.isHet()).map(g => g.GQ.toFloat64).stats()}
+          |gqstats: AGG.map(g => g.GQ.toFloat64).stats(),
+          |gqhetstats: AGG.filter(g => g.GT.isHet()).map(g => g.GQ.toFloat64).stats()}
           """.stripMargin,
         "lowGqGts" -> "AGG.filter(g => g.GQ < 60).collect()")
 

--- a/src/test/scala/is/hail/methods/AnnotateSuite.scala
+++ b/src/test/scala/is/hail/methods/AnnotateSuite.scala
@@ -116,9 +116,9 @@ class AnnotateSuite extends SparkSuite {
     val vds = TestUtils.splitMultiHTS(hc.importVCF("src/test/resources/sample.vcf"))
       .cache()
 
-    val bed1r = vds.annotateRowsTable(BedAnnotator(hc, "src/test/resources/example1.bed"), root = "test").annotateRowsExpr("test = isDefined(va.test)")
-    val bed2r = vds.annotateRowsTable(BedAnnotator(hc, "src/test/resources/example2.bed"), root = "test").annotateRowsExpr("test = va.test.target")
-    val bed3r = vds.annotateRowsTable(BedAnnotator(hc, "src/test/resources/example3.bed"), root = "test").annotateRowsExpr("test = va.test.target")
+    val bed1r = vds.annotateRowsTable(BedAnnotator(hc, "src/test/resources/example1.bed"), root = "test").annotateRowsExpr("test" -> "isDefined(va.test)")
+    val bed2r = vds.annotateRowsTable(BedAnnotator(hc, "src/test/resources/example2.bed"), root = "test").annotateRowsExpr("test" -> "va.test.target")
+    val bed3r = vds.annotateRowsTable(BedAnnotator(hc, "src/test/resources/example3.bed"), root = "test").annotateRowsExpr("test" -> "va.test.target")
 
     val q1 = bed1r.queryVA("va.test")._2
     val q2 = bed2r.queryVA("va.test")._2
@@ -161,10 +161,10 @@ class AnnotateSuite extends SparkSuite {
 
     val int1r = vds.annotateRowsTable(IntervalList.read(hc,
       "src/test/resources/exampleAnnotation1.interval_list"), "test")
-        .annotateRowsExpr("test = isDefined(va.test)")
+        .annotateRowsExpr("test" -> "isDefined(va.test)")
     val int2r = vds.annotateRowsTable(
       IntervalList.read(hc, "src/test/resources/exampleAnnotation2.interval_list"), "test")
-        .annotateRowsExpr("test = va.test.target")
+        .annotateRowsExpr("test" -> "va.test.target")
 
     assert(int1r.same(bed1r))
     assert(int2r.same(bed2r))
@@ -238,35 +238,35 @@ class AnnotateSuite extends SparkSuite {
     val kt1 = hc.importTable(tmpf1, separator = "\\s+", impute = true)
       .annotate("locus = Locus(str(row.Chr), row.Pos), alleles = [row.Ref, row.Alt]")
       .keyBy("locus", "alleles")
-    val fmt1 = vds.annotateRowsTable(kt1, "table").annotateRowsExpr("table = {Anno1: va.table.Anno1, Anno2: va.table.Anno2}")
+    val fmt1 = vds.annotateRowsTable(kt1, "table").annotateRowsExpr("table" -> "{Anno1: va.table.Anno1, Anno2: va.table.Anno2}")
 
     val fmt2 = vds.annotateRowsTable(hc.importTable(tmpf2, separator = "\\s+", impute = true,
       commentChar = Some("#"))
       .annotate("locus = Locus(str(row.Chr), row.Pos), alleles = [row.Ref, row.Alt]")
       .keyBy("locus", "alleles"),
-      "table").annotateRowsExpr("table = {Anno1: va.table.Anno1, Anno2: va.table.Anno2}")
+      "table").annotateRowsExpr("table" -> "{Anno1: va.table.Anno1, Anno2: va.table.Anno2}")
 
     val fmt3 = vds.annotateRowsTable(hc.importTable(tmpf3,
       commentChar = Some("#"), separator = "\\s+", noHeader = true, impute = true)
       .annotate("locus = Locus(str(row.f0), row.f1), alleles = [row.f2, row.f3]")
       .keyBy("locus", "alleles"),
-      "table").annotateRowsExpr("table = {Anno1: va.table.f4, Anno2: va.table.f5}")
+      "table").annotateRowsExpr("table" -> "{Anno1: va.table.f4, Anno2: va.table.f5}")
 
     val fmt4 = vds.annotateRowsTable(hc.importTable(tmpf4, separator = ",", noHeader = true, impute = true)
       .annotate("locus = Locus(str(row.f0), row.f1), alleles = [row.f2, row.f3]")
       .keyBy("locus", "alleles"),
-      "table").annotateRowsExpr("table = {Anno1: va.table.f4, Anno2: va.table.f5}")
+      "table").annotateRowsExpr("table" -> "{Anno1: va.table.f4, Anno2: va.table.f5}")
 
     val fmt5 = vds.annotateRowsTable(hc.importTable(tmpf5, separator = "\\s+", impute = true, missing = ".")
       .annotate("locus = Locus(str(row.Chr), row.Pos), alleles = [row.Ref, row.Alt]")
       .keyBy("locus", "alleles"),
-      "table").annotateRowsExpr("table = {Anno1: va.table.Anno1, Anno2: va.table.Anno2}")
+      "table").annotateRowsExpr("table" -> "{Anno1: va.table.Anno1, Anno2: va.table.Anno2}")
 
     val fmt6 = vds.annotateRowsTable(hc.importTable(tmpf6,
       noHeader = true, impute = true, separator = ",", commentChar = Some("!"))
       .annotate("locus = Locus(str(row.f0), row.f1), alleles = [row.f2, row.f3]")
       .keyBy("locus", "alleles"),
-      "table").annotateRowsExpr("table = {Anno1: va.table.f5, Anno2: va.table.f7}")
+      "table").annotateRowsExpr("table" -> "{Anno1: va.table.f5, Anno2: va.table.f7}")
 
     val vds1 = fmt1.cache()
 
@@ -285,14 +285,14 @@ class AnnotateSuite extends SparkSuite {
       .annotate("locus = Locus(row.Chromosome, row.Position.toInt32())")
       .keyBy("locus")
 
-    val byPosition = vds.annotateRowsTable(kt, "stuff").annotateRowsExpr("stuff = {Rand1: va.stuff.Rand1, Rand2: va.stuff.Rand2}")
+    val byPosition = vds.annotateRowsTable(kt, "stuff").annotateRowsExpr("stuff" -> "{Rand1: va.stuff.Rand1, Rand2: va.stuff.Rand2}")
 
     val kt2 = hc.importTable("src/test/resources/sample2_va_nomulti.tsv",
       types = Map("Rand1" -> TFloat64(), "Rand2" -> TFloat64()))
       .annotate("loc = Locus(row.Chromosome, row.Position.toInt32()), alleles = [row.Ref, row.Alt]")
       .keyBy("loc", "alleles")
     val byVariant = vds.annotateRowsTable(kt2,
-      "stuff").annotateRowsExpr("stuff = {Rand1: va.stuff.Rand1, Rand2: va.stuff.Rand2}")
+      "stuff").annotateRowsExpr("stuff" -> "{Rand1: va.stuff.Rand1, Rand2: va.stuff.Rand2}")
 
     assert(byPosition.same(byVariant))
   }

--- a/src/test/scala/is/hail/methods/ConcordanceSuite.scala
+++ b/src/test/scala/is/hail/methods/ConcordanceSuite.scala
@@ -46,8 +46,8 @@ class ConcordanceSuite extends SparkSuite {
         .keyBy("locus", "alleles"))
     }
   } yield (vds1, vds2.annotateRowsTable(newVariantMapping, "newVariant")
-      .annotateRowsExpr("locus = va.newVariant.locus2, " +
-        "alleles = va.newVariant.alleles2")
+      .annotateRowsExpr("locus" -> "va.newVariant.locus2",
+        "alleles" -> "va.newVariant.alleles2")
       .copy2(colValues = newIds2.map(Annotation(_)), colType = TStruct("s" -> TString())))
 
   // FIXME use SnpSift when it's fixed

--- a/src/test/scala/is/hail/methods/LinearRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearRegressionSuite.scala
@@ -379,7 +379,7 @@ class LinearRegressionSuite extends SparkSuite {
                  |standard_error: [va.linreg.standard_error[$i]],
                  |t_stat: [va.linreg.t_stat[$i]],
                  |p_value: [va.linreg.p_value[$i]]
-                 |}""".stripMargin),
+                 |})""".stripMargin),
           root = "mlinreg").annotateRowsExpr("mlinreg" -> "va.mlinreg.linreg")
 
       val (t, q) = result.queryVA("va.linreg")

--- a/src/test/scala/is/hail/methods/LinearRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearRegressionSuite.scala
@@ -372,15 +372,15 @@ class LinearRegressionSuite extends SparkSuite {
           inputVDS.linreg(Array("sa.pheno.Pheno", "sa.pheno.Pheno"),
             if (d) "plDosage(g.PL)" else "g.GT.nNonRefAlleles().toFloat64",
             Array("sa.cov.Cov1", "sa.cov.Cov2"))
-            .annotateRowsExpr(
-              s"""
-                 |linreg.y_transpose_x = [va.linreg.y_transpose_x[$i]],
-                 |linreg.beta = [va.linreg.beta[$i]],
-                 |linreg.standard_error = [va.linreg.standard_error[$i]],
-                 |linreg.t_stat = [va.linreg.t_stat[$i]],
-                 |linreg.p_value = [va.linreg.p_value[$i]]
-                 |""".stripMargin),
-          root = "mlinreg").annotateRowsExpr("mlinreg = va.mlinreg.linreg")
+            .annotateRowsExpr("linreg" ->
+              s"""annotate(va.linreg, {
+                 |y_transpose_x: [va.linreg.y_transpose_x[$i]],
+                 |beta: [va.linreg.beta[$i]],
+                 |standard_error: [va.linreg.standard_error[$i]],
+                 |t_stat: [va.linreg.t_stat[$i]],
+                 |p_value: [va.linreg.p_value[$i]]
+                 |}""".stripMargin),
+          root = "mlinreg").annotateRowsExpr("mlinreg" -> "va.mlinreg.linreg")
 
       val (t, q) = result.queryVA("va.linreg")
       val (mt, mq) = result.queryVA("va.mlinreg")

--- a/src/test/scala/is/hail/methods/PCASuite.scala
+++ b/src/test/scala/is/hail/methods/PCASuite.scala
@@ -15,7 +15,7 @@ object PCASuite {
     asArray: Boolean = false): (IndexedSeq[Double], DenseMatrix[Double], Option[Table]) = {
 
     val prePCA = vsm.annotateRowsExpr(
-      "AC = AGG.map(g => g.GT.nNonRefAlleles()).sum(), nCalled = AGG.filter(g => isDefined(g.GT)).count()")
+      "AC" -> "AGG.map(g => g.GT.nNonRefAlleles()).sum()", "nCalled" -> "AGG.filter(g => isDefined(g.GT)).count()")
       .filterRowsExpr("va.AC > 0 && va.AC.toInt64 < 2L * va.nCalled").persist()
     val nVariants = prePCA.countRows()
     val expr = s"let mean = va.AC.toFloat64 / va.nCalled.toFloat64 in if (isDefined(g.GT)) (g.GT.nNonRefAlleles().toFloat64 - mean) / sqrt(mean * (2d - mean) * ${ nVariants }d / 2d) else 0d"

--- a/src/test/scala/is/hail/methods/SelectSuite.scala
+++ b/src/test/scala/is/hail/methods/SelectSuite.scala
@@ -7,9 +7,9 @@ import is.hail.testUtils._
 class SelectSuite extends SparkSuite {
   @Test def testRows() {
     val vds = hc.importVCF("src/test/resources/sample.vcf.bgz")
-      .annotateRowsExpr("foo = AGG.count()")
+      .annotateRowsExpr("foo" -> "AGG.count()")
 
-    val t1 = vds.selectRows("va.locus", "va.alleles", "va.info.AC", "AF = va.info.AF", "foo2 = AGG.count()").rowsTable()
+    val t1 = vds.selectRows("{locus: va.locus, alleles: va.alleles, AC: va.info.AC, AF: va.info.AF, foo2: AGG.count()}").rowsTable()
 
     val t2 = vds.rowsTable().select(Array("row.locus", "row.alleles", "row.info.AC", "AF = row.info.AF", "foo2 = row.foo"))
 
@@ -19,7 +19,7 @@ class SelectSuite extends SparkSuite {
   @Test def test_key_change_typechecks() {
     val vds = hc.importVCF("src/test/resources/sample.vcf.bgz")
 
-    vds.selectRows("va.alleles").typecheck()
+    vds.selectRows("{alleles: va.alleles}").typecheck()
   }
 
   @Test def testCols() {

--- a/src/test/scala/is/hail/methods/SkatSuite.scala
+++ b/src/test/scala/is/hail/methods/SkatSuite.scala
@@ -273,14 +273,14 @@ class SkatSuite extends SparkSuite {
     val kt = IntervalList.read(hc, "src/test/resources/skat2.interval_list")
     val vds = vds0
       .annotateRowsTable(kt, "key", product = true)
-      .annotateRowsExpr("key" -> "va.key.map(x => x.target).toSet(), weight = va.locus.position.toFloat64")
+      .annotateRowsExpr("key" -> "va.key.map(x => x.target).toSet()", "weight" -> "va.locus.position.toFloat64")
       .explodeRows("va.key")
       .annotateRowsExpr("key" -> "va.key.toInt32()")
     
     // annotations from expr
     val vds2 = vds0
       .annotateRowsExpr( // v1 -> {9, 1}, v2 -> {9, 0, 2}, v3 -> {9, 1, 2}
-        "key" -> "[9, va.locus.position % 2, va.locus.position // 2 + 1].toSet(), weight = va.locus.position.toFloat64")
+        "key" -> "[9, va.locus.position % 2, va.locus.position // 2 + 1].toSet()", "weight" -> "va.locus.position.toFloat64")
       .explodeRows("va.key") // 0 -> {v2}, 1 -> {v1, v3}, 2 -> {v2, v3}, 9 -> {v1, v2, v3}
     
     // table/explode and annotate/explode give same keys

--- a/src/test/scala/is/hail/stats/FisherExactTestSuite.scala
+++ b/src/test/scala/is/hail/stats/FisherExactTestSuite.scala
@@ -99,20 +99,20 @@ class FisherExactTestSuite extends SparkSuite {
 
         val vds2 = vds.annotateColsTable(hc.importTable(phenotypeFile).keyBy("Sample"), root = "pheno")
           .annotateColsExpr("pheno = sa.pheno.Pheno1")
-          .annotateRowsExpr(
-            """macCase = AGG.filter(g => sa.pheno == "ADHD" && g.GT.isHet()).count() +
+          .annotateRowsExpr("macCase" ->
+            """AGG.filter(g => sa.pheno == "ADHD" && g.GT.isHet()).count() +
               |2L * AGG.filter(g => sa.pheno == "ADHD" && g.GT.isHomVar()).count()""".stripMargin)
-          .annotateRowsExpr(
-            """majCase = AGG.filter(g => sa.pheno == "ADHD" && g.GT.isHet()).count() +
+          .annotateRowsExpr("majCase" ->
+            """AGG.filter(g => sa.pheno == "ADHD" && g.GT.isHet()).count() +
               |2L * AGG.filter(g => sa.pheno == "ADHD" && g.GT.isHomRef()).count()""".stripMargin)
-          .annotateRowsExpr(
-            """macControl = AGG.filter(g => sa.pheno == "Control" && g.GT.isHet()).count() +
+          .annotateRowsExpr("macControl" ->
+            """AGG.filter(g => sa.pheno == "Control" && g.GT.isHet()).count() +
               |2L * AGG.filter(g => sa.pheno == "ADHD" && g.GT.isHomVar()).count()""".stripMargin)
-          .annotateRowsExpr(
-            """majControl = AGG.filter(g => sa.pheno == "Control" && g.GT.isHet()).count() +
+          .annotateRowsExpr("majControl" ->
+            """AGG.filter(g => sa.pheno == "Control" && g.GT.isHet()).count() +
               |2L * AGG.filter(g => sa.pheno == "ADHD" && g.GT.isHomRef()).count()""".stripMargin)
-          .annotateRowsExpr(
-            """fet = fet(va.macCase.toInt32(), va.majCase.toInt32(), va.macControl.toInt32(), va.majControl.toInt32())""")
+          .annotateRowsExpr("fet" ->
+            """fet(va.macCase.toInt32(), va.majCase.toInt32(), va.macControl.toInt32(), va.majControl.toInt32())""")
 
 
         val (_, q1) = vds2.queryVA("va.macCase")

--- a/src/test/scala/is/hail/stats/HWESuite.scala
+++ b/src/test/scala/is/hail/stats/HWESuite.scala
@@ -34,8 +34,8 @@ class HWESuite extends SparkSuite {
       var vds2 = TestUtils.splitMultiHTS(vds)
       vds2 = VariantQC(vds2)
       vds2 = vds2
-        .annotateRowsExpr("hweExpr = hwe(va.qc.n_hom_ref, va.qc.n_het, va.qc.n_hom_var)")
-        .annotateRowsExpr("hweAgg = AGG.map(g => g.GT).hardyWeinberg()")
+        .annotateRowsExpr("hweExpr" -> "hwe(va.qc.n_hom_ref, va.qc.n_het, va.qc.n_hom_var)")
+        .annotateRowsExpr("hweAgg" -> "AGG.map(g => g.GT).hardyWeinberg()")
 
       val (_, q1) = vds2.queryVA("va.qc.r_expected_het_freq")
       val (_, q2) = vds2.queryVA("va.qc.p_hwe")

--- a/src/test/scala/is/hail/stats/InfoScoreSuite.scala
+++ b/src/test/scala/is/hail/stats/InfoScoreSuite.scala
@@ -12,7 +12,7 @@ class InfoScoreSuite extends SparkSuite {
     val truthResultFile = "src/test/resources/infoScoreTest.result"
 
     val vds = hc.importGen(genFile, sampleFile)
-      .annotateRowsExpr("""infoScore = AGG.map(g => g.GP).infoScore()""")
+      .annotateRowsExpr("infoScore" -> "AGG.map(g => g.GP).infoScore()")
 
     val truthResult = hadoopConf.readLines(truthResultFile)(_.map(_.map { line =>
       val Array(v, snpid, rsid, infoScore, nIncluded) = line.trim.split("\\s+")

--- a/src/test/scala/is/hail/utils/RichMatrixTable.scala
+++ b/src/test/scala/is/hail/utils/RichMatrixTable.scala
@@ -43,6 +43,9 @@ class RichMatrixTable(vsm: MatrixTable) {
     vsm.annotateCols(t, i) { case (_, i) => annotation(sampleIds(i)) }
   }
 
+  def annotateRowsExpr(exprs: (String, String)*): MatrixTable =
+    vsm.selectRows(s"annotate(va, {${ exprs.map { case (n, e) => s"`$n`: $e" }.mkString(",") }})")
+
   def annotateEntriesExpr(exprs: (String, String)*): MatrixTable =
     vsm.selectEntries(s"annotate(g, {${ exprs.map { case (n, e) => s"`$n`: $e" }.mkString(",") }})")
 

--- a/src/test/scala/is/hail/variant/LocusIntervalSuite.scala
+++ b/src/test/scala/is/hail/variant/LocusIntervalSuite.scala
@@ -58,7 +58,7 @@ class LocusIntervalSuite extends SparkSuite {
     }
 
     assert(vds.annotateRowsTable(IntervalList.read(hc, intervalFile), "foo", product = true)
-      .annotateRowsExpr("foo = va.foo.map(x => x.target)")
+      .annotateRowsExpr("foo" -> "va.foo.map(x => x.target)")
       .rowsTable().query("AGG.map(r => r.foo).collect()[0].toSet()")._1 == Set("THING1", "THING2", "THING3", "THING4", "THING5"))
   }
 
@@ -66,7 +66,7 @@ class LocusIntervalSuite extends SparkSuite {
     val vds = hc.importVCF("src/test/resources/sample2.vcf")
       .annotateRowsTable(IntervalList.read(hc, "src/test/resources/annotinterall.interval_list"),
         "annot", product = true)
-      .annotateRowsExpr("annot = va.annot.map(x => x.target)")
+      .annotateRowsExpr("annot" -> "va.annot.map(x => x.target)")
 
     val (t, q) = vds.queryVA("va.annot")
     assert(t == TArray(TString()))

--- a/src/test/scala/is/hail/variant/ReferenceGenomeSuite.scala
+++ b/src/test/scala/is/hail/variant/ReferenceGenomeSuite.scala
@@ -63,7 +63,7 @@ class ReferenceGenomeSuite extends SparkSuite {
     ReferenceGenome.addReference(rg)
 
     val vds = hc.importVCF("src/test/resources/sample.vcf")
-      .annotateRowsExpr("l = NA: Locus(foo), i = NA: Interval[Locus(foo)]")
+      .annotateRowsExpr("l" -> "NA: Locus(foo)", "i" -> "NA: Interval[Locus(foo)]")
 
     val vas = vds.rowType.asInstanceOf[TStruct]
 
@@ -218,7 +218,7 @@ class ReferenceGenomeSuite extends SparkSuite {
     val rg = ReferenceGenome("foo", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5))
     ReferenceGenome.addReference(rg)
     kt.annotate("""l1 = Locus(foo)("1:3")""").write(outKT)
-    vds.annotateRowsExpr("""l2 = Locus(foo)("1:3")""").write(outVDS)
+    vds.annotateRowsExpr("l2" -> """Locus(foo)("1:3")""").write(outVDS)
     ReferenceGenome.removeReference("foo")
 
     val rg2 = ReferenceGenome("foo", Array("1"), Map("1" -> 5))

--- a/src/test/scala/is/hail/variant/vsm/ExplodeSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/ExplodeSuite.scala
@@ -8,7 +8,7 @@ import org.testng.annotations.Test
 class ExplodeSuite extends SparkSuite {
   @Test def testExplode() {
     val vsm = hc.importVCF("src/test/resources/sample.vcf")
-      .annotateRowsExpr("foo = [1, 2, 2], bar = [1, 2, 2].toSet()")
+      .annotateRowsExpr("foo" -> "[1, 2, 2]", "bar" -> "[1, 2, 2].toSet()")
       .annotateColsExpr("foo = [1, 2, 2], bar = [1, 2, 2].toSet()")
         
     assert(vsm.explodeRows("va.foo").countRows() == vsm.countRows() * 3)
@@ -23,7 +23,7 @@ class ExplodeSuite extends SparkSuite {
 
   @Test def testExplodeUnwrap() {
     val vsm = hc.importVCF("src/test/resources/sample.vcf")
-      .annotateRowsExpr("foo = [1]")
+      .annotateRowsExpr("foo" -> "[1]")
       .annotateColsExpr("foo = [3]")
     
     val exploded = vsm.explodeRows("va.foo")
@@ -35,7 +35,7 @@ class ExplodeSuite extends SparkSuite {
 
   @Test def testNoElements() {
     val vsm = hc.importVCF("src/test/resources/sample.vcf")
-      .annotateRowsExpr("foo = NA: Array[Int32]")
+      .annotateRowsExpr("foo" -> "NA: Array[Int32]")
       .annotateColsExpr("foo = NA: Array[Int32]")
     
     val exploded = vsm.explodeRows("va.foo")

--- a/src/test/scala/is/hail/variant/vsm/GroupBySuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/GroupBySuite.scala
@@ -25,12 +25,12 @@ class GroupBySuite extends SparkSuite {
   }
 
   @Test def testGroupVariantsBy() {
-    val vds = hc.importVCF("src/test/resources/sample.vcf").annotateRowsExpr("AC = AGG.map(g => g.GT.nNonRefAlleles()).sum()")
+    val vds = hc.importVCF("src/test/resources/sample.vcf").annotateRowsExpr("AC" -> "AGG.map(g => g.GT.nNonRefAlleles()).sum()")
     val vds2 = vds.keyRowsBy(Array("AC"), Array("AC")).aggregateRowsByKey("max = AGG.map(g => g.GT.nNonRefAlleles()).max()").count()
   }
 
   @Test def testGroupVariantsStruct() {
-    val vds = hc.importVCF("src/test/resources/sample.vcf").annotateRowsExpr("AC = {str1: \"foo\", str2: 1}")
+    val vds = hc.importVCF("src/test/resources/sample.vcf").annotateRowsExpr("AC" -> "{str1: \"foo\", str2: 1}")
     val vds2 = vds.keyRowsBy(Array("AC"), Array("AC")).aggregateRowsByKey("max = AGG.map(g => g.GT.nNonRefAlleles()).max()").count()
   }
 
@@ -53,7 +53,7 @@ class GroupBySuite extends SparkSuite {
               "DP = AGG.collect()[0].DP, " +
               "GQ = AGG.collect()[0].GQ, " +
               "PL = AGG.collect()[0].PL")
-        assert(vsm.selectRows("va.locus", "va.alleles").same(grouped))
+        assert(vsm.selectRows("{locus: va.locus, alleles: va.alleles}").same(grouped))
       }
 
       val uniqueSamples = vsm.stringSampleIds.toSet
@@ -86,8 +86,8 @@ class GroupBySuite extends SparkSuite {
 
     val vds = hc.importVCF("src/test/resources/regressionLinear.vcf")
       .annotateRowsTable(intervals, root = "genes", product = true)
-      .annotateRowsExpr("genes = va.genes.map(x => x.target)")
-      .annotateRowsExpr("weight = va.locus.position.toFloat64")
+      .annotateRowsExpr("genes" -> "va.genes.map(x => x.target)")
+      .annotateRowsExpr("weight" -> "va.locus.position.toFloat64")
       .annotateColsTable(covariates, root = "cov")
       .annotateColsTable(phenotypes, root = "pheno")
 

--- a/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -38,7 +38,7 @@ class PartitioningSuite extends SparkSuite {
       orig.write(out)
       val problem = hc.readVDS(out)
 
-      hc.readVDS(out).annotateRowsExpr("va = va").countRows()
+      hc.readVDS(out).annotateRowsExpr("va" -> "va").countRows()
 
       // need to do 2 writes to ensure that the RDD is ordered
       hc.readVDS(out)

--- a/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
@@ -20,7 +20,7 @@ import scala.language.postfixOps
 class VSMSuite extends SparkSuite {
 
   @Test def testWriteRead() {
-    val p = forAll(MatrixTable.gen(hc, VSMSubgen.random).map(_.annotateRowsExpr("foo = 5"))) { vds =>
+    val p = forAll(MatrixTable.gen(hc, VSMSubgen.random).map(_.annotateRowsExpr("foo" -> "5"))) { vds =>
       ReferenceGenome.addReference(vds.referenceGenome)
       val f = tmpDir.createTempFile(extension = "vds")
       vds.write(f)
@@ -108,10 +108,10 @@ class VSMSuite extends SparkSuite {
 
   @Test def testAnnotateVariantsKeyTable() {
     forAll(MatrixTable.gen(hc, VSMSubgen.random)) { vds =>
-      val vds2 = vds.annotateRowsExpr("bar = va")
+      val vds2 = vds.annotateRowsExpr("bar" -> "va")
       val kt = vds2.rowsTable()
       val resultVds = vds2.annotateRowsTable(kt, "foo")
-        .annotateRowsExpr("foo = va.foo.bar")
+        .annotateRowsExpr("foo" -> "va.foo.bar")
       resultVds.typecheck()
       val result = resultVds.rdd.collect()
       val (_, getFoo) = resultVds.queryVA("va.foo")
@@ -135,9 +135,9 @@ class VSMSuite extends SparkSuite {
 
     val filteredVds = vds.filterColsList(origOrder.map(Annotation(_)).toSet)
       .indexCols("colIdx")
-      .annotateRowsExpr("origGenos = AGG.take(5)")
+      .annotateRowsExpr("origGenos" -> "AGG.take(5)")
     val reorderedVds = filteredVds.reorderCols(newOrder.map(Annotation(_)))
-      .annotateRowsExpr("newGenos = AGG.takeBy(g => sa.colIdx, 5)")
+      .annotateRowsExpr("newGenos" -> "AGG.takeBy(g => sa.colIdx, 5)")
 
     assert(reorderedVds.rowsTable().forall("row.origGenos == row.newGenos"))
     assert(vds.reorderCols(vds.colKeys).same(vds))


### PR DESCRIPTION
- annotateRowsExpr and dropRows(**exprs) have been removed from the Scala interface (annotateRowsExpr has been moved to testUtils)
- annotate_rows and drop_rows are rewritten in terms of select_rows in Python (following Table.select and MatrixTable.select_entries).