### PR TITLE
clean up IR function registry code

### DIFF
--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -12,10 +12,10 @@ import scala.collection.mutable
 object IRFunctionRegistry {
 
   val irRegistry: mutable.MultiMap[String, (Seq[Type], Seq[IR] => IR)] =
-    new mutable.HashMap[String, (Seq[Type], Seq[IR] => IR)] with mutable.MultiMap[String, (Seq[Type], Seq[IR] => IR)]
+    new mutable.HashMap[String, mutable.Set[(Seq[Type], Seq[IR] => IR)]] with mutable.MultiMap[String, (Seq[Type], Seq[IR] => IR)]
 
   val codeRegistry: mutable.MultiMap[String, (Seq[Type], IRFunction)] =
-    new mutable.HashMap[String, (Seq[Type], IRFunction)] with mutable.MultiMap[String, (Seq[Type], IRFunction)]
+    new mutable.HashMap[String, mutable.Set[(Seq[Type], IRFunction)]] with mutable.MultiMap[String, (Seq[Type], IRFunction)]
 
   def addIRFunction(f: IRFunction): Unit =
     codeRegistry.addBinding(f.name, (f.argTypes, f))

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -33,7 +33,7 @@ object IRFunctionRegistry {
       }.toSeq match {
         case Seq() => None
         case Seq((_, f)) => Some(f)
-        case _ => fatal(s"Multiple functions found that satisfy $name$args.")
+        case _ => fatal(s"Multiple functions found that satisfy $name(${ args.mkString(",") }).")
       }
     }
   }
@@ -59,7 +59,7 @@ object IRFunctionRegistry {
       case (None, None) => None
       case (None, Some(x)) => Some(x)
       case (Some(x), None) => Some(x)
-      case _ => fatal(s"Multiple methods found that satisfy $name$args.")
+      case _ => fatal(s"Multiple methods found that satisfy $name(${ args.mkString(",") }).")
     }
   }
 


### PR DESCRIPTION
use MultiMap instead of `Map[String, Seq[]]` and pull out duplicate code between `lookupFunction` and `lookupConversion`.