### PR TITLE
ORVDPartitioner.range -> Option[Interval]

### DIFF
--- a/python/hail/tests/test_api.py
+++ b/python/hail/tests/test_api.py
@@ -387,6 +387,11 @@ class TableTests(unittest.TestCase):
         kt2 = kt2.annotate_globals(kt_foo=kt[:].foo)
         self.assertEqual(kt2.globals.kt_foo.value, 5)
 
+    def test_join_with_empty(self):
+        kt = hl.utils.range_table(10)
+        kt2 = ht.head(0)
+        kt.annotate(foo = hl.is_defined(kt2[ht.idx]))
+
     def test_join_with_key(self):
         ht = hl.utils.range_table(10)
         ht1 = ht.annotate(foo = 5)

--- a/python/hail/tests/test_api.py
+++ b/python/hail/tests/test_api.py
@@ -389,8 +389,8 @@ class TableTests(unittest.TestCase):
 
     def test_join_with_empty(self):
         kt = hl.utils.range_table(10)
-        kt2 = ht.head(0)
-        kt.annotate(foo = hl.is_defined(kt2[ht.idx]))
+        kt2 = kt.head(0)
+        kt.annotate(foo = hl.is_defined(kt2[kt.idx]))
 
     def test_join_with_key(self):
         ht = hl.utils.range_table(10)

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -610,7 +610,7 @@ object OrderedRVD {
     val min = new UnsafeRow(pkType, pkis.map(_.min).min(pkOrdUnsafe))
     val max = new UnsafeRow(pkType, pkis.map(_.max).max(pkOrdUnsafe))
 
-    shuffle(typ, partitioner.enlargeToRange(Some(Interval(min, max, true, true))), rdd)
+    shuffle(typ, partitioner.enlargeToRange(Interval(min, max, true, true)), rdd)
   }
 
   def shuffle(

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -610,7 +610,7 @@ object OrderedRVD {
     val min = new UnsafeRow(pkType, pkis.map(_.min).min(pkOrdUnsafe))
     val max = new UnsafeRow(pkType, pkis.map(_.max).max(pkOrdUnsafe))
 
-    shuffle(typ, partitioner.enlargeToRange(Interval(min, max, true, true)), rdd)
+    shuffle(typ, partitioner.enlargeToRange(Some(Interval(min, max, true, true))), rdd)
   }
 
   def shuffle(

--- a/src/main/scala/is/hail/rvd/OrderedRVDPartitioner.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVDPartitioner.scala
@@ -46,10 +46,11 @@ class OrderedRVDPartitioner(
     * partition.
     */
   def getPartitionPK(row: Any): Int = {
+    require(rangeBounds.nonEmpty)
     val part = rangeTree.queryValues(pkType.ordering, row)
     part match {
       case Array() =>
-        if (range.forall(_.isAbovePosition(pkType.ordering, row)))
+        if (range.get.isAbovePosition(pkType.ordering, row))
           0
         else {
           assert(range.get.isBelowPosition(pkType.ordering, row))

--- a/src/main/scala/is/hail/rvd/OrderedRVDPartitioner.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVDPartitioner.scala
@@ -103,6 +103,9 @@ class OrderedRVDPartitioner(
     new OrderedRVDPartitioner(partitionKey, kType, rangeBounds)
   }
 
+  def enlargeToRange(newRange: Interval): OrderedRVDPartitioner =
+    enlargeToRange(Some(newRange))
+
   // FIXME Make work if newRange has different point type than pkType
   def enlargeToRange(newRange: Option[Interval]): OrderedRVDPartitioner = {
     if (newRange.isEmpty)

--- a/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -79,7 +79,7 @@ class PartitioningSuite extends SparkSuite {
     mt.rvd.orderedJoinDistinct(OrderedRVD.empty(hc.sc, orvdType), "inner", _.map(_._1), orvdType).count()
   }
 
-  @Test def testEmptyLeftRDDOrderedJoin() {
+  @Test def testEmptyRDDOrderedJoin() {
     val mt = MatrixTable.fromRowsTable(Table.range(hc, 100, "idx", partitions=Some(6)))
     val orvdType = mt.matrixType.orvdType
 

--- a/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -78,4 +78,17 @@ class PartitioningSuite extends SparkSuite {
     mt.rvd.orderedJoinDistinct(OrderedRVD.empty(hc.sc, orvdType), "left", _.map(_._1), orvdType).count()
     mt.rvd.orderedJoinDistinct(OrderedRVD.empty(hc.sc, orvdType), "inner", _.map(_._1), orvdType).count()
   }
+
+  @Test def testEmptyLeftRDDOrderedJoin() {
+    val mt = MatrixTable.fromRowsTable(Table.range(hc, 100, "idx", partitions=Some(6)))
+    val orvdType = mt.matrixType.orvdType
+
+    val nonEmptyRVD = mt.rvd
+    val emptyRVD = OrderedRVD.empty(hc.sc, orvdType)
+
+    emptyRVD.orderedJoin(nonEmptyRVD, "left", _.map(_._1), orvdType).count()
+    emptyRVD.orderedJoin(nonEmptyRVD, "inner", _.map(_._1), orvdType).count()
+    nonEmptyRVD.orderedJoin(emptyRVD, "left", _.map(_._1), orvdType).count()
+    nonEmptyRVD.orderedJoin(emptyRVD, "inner", _.map(_._1), orvdType).count()
+  }
 }


### PR DESCRIPTION
Where None denotes a partitioner for an empty RVD.

Fixes #3244.

cc @patrick-schultz do you think this is ok?