### PR TITLE
Fix unsafe ordering

### DIFF
--- a/src/main/scala/is/hail/expr/types/TBaseStruct.scala
+++ b/src/main/scala/is/hail/expr/types/TBaseStruct.scala
@@ -112,18 +112,25 @@ abstract class TBaseStruct extends Type {
 
   override def scalaClassTag: ClassTag[Row] = classTag[Row]
 
-  override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering = {
-    val fieldOrderings = types.map(_.unsafeOrdering(missingGreatest))
+  override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering =
+    unsafeOrdering(this, missingGreatest)
+
+  override def unsafeOrdering(rightType: Type, missingGreatest: Boolean): UnsafeOrdering = {
+    require(this.isOfType(rightType))
+
+    val right = rightType.asInstanceOf[TBaseStruct]
+    val fieldOrderings: Array[UnsafeOrdering] =
+      types.zip(right.types).map { case (l, r) => l.unsafeOrdering(r, missingGreatest)}
 
     new UnsafeOrdering {
       def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
         var i = 0
         while (i < types.length) {
           val leftDefined = isFieldDefined(r1, o1, i)
-          val rightDefined = isFieldDefined(r2, o2, i)
+          val rightDefined = right.isFieldDefined(r2, o2, i)
 
           if (leftDefined && rightDefined) {
-            val c = fieldOrderings(i).compare(r1, loadField(r1, o1, i), r2, loadField(r2, o2, i))
+            val c = fieldOrderings(i).compare(r1, loadField(r1, o1, i), r2, right.loadField(r2, o2, i))
             if (c != 0)
               return c
           } else if (leftDefined != rightDefined) {

--- a/src/main/scala/is/hail/expr/types/TContainer.scala
+++ b/src/main/scala/is/hail/expr/types/TContainer.scala
@@ -159,22 +159,30 @@ abstract class TContainer extends Type {
     )
   }
 
-  override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering = {
-    val eltOrd = elementType.unsafeOrdering(missingGreatest)
+  override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering =
+    unsafeOrdering(this, missingGreatest)
+
+  override def unsafeOrdering(rightType: Type, missingGreatest: Boolean): UnsafeOrdering = {
+    require(this.isOfType(rightType))
+
+    val right = rightType.asInstanceOf[TContainer]
+    val eltOrd = elementType.unsafeOrdering(
+      right.elementType,
+      missingGreatest)
 
     new UnsafeOrdering {
       override def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
         val length1 = loadLength(r1, o1)
-        val length2 = loadLength(r2, o2)
+        val length2 = right.loadLength(r2, o2)
 
         var i = 0
         while (i < math.min(length1, length2)) {
           val leftDefined = isElementDefined(r1, o1, i)
-          val rightDefined = isElementDefined(r2, o2, i)
+          val rightDefined = right.isElementDefined(r2, o2, i)
 
           if (leftDefined && rightDefined) {
             val eOff1 = loadElement(r1, o1, length1, i)
-            val eOff2 = loadElement(r2, o2, length2, i)
+            val eOff2 = right.loadElement(r2, o2, length2, i)
             val c = eltOrd.compare(r1, eOff1, r2, eOff2)
             if (c != 0)
               return c

--- a/src/main/scala/is/hail/expr/types/Type.scala
+++ b/src/main/scala/is/hail/expr/types/Type.scala
@@ -152,12 +152,16 @@ abstract class Type extends BaseType with Serializable {
       }
   }
 
-  def unsafeOrdering(missingGreatest: Boolean = false): UnsafeOrdering = ???
+  def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering = ???
 
-  def unsafeOrdering(rightType: Type, missingGreatest: Boolean = false): UnsafeOrdering = {
+  def unsafeOrdering(): UnsafeOrdering = unsafeOrdering(false)
+
+  def unsafeOrdering(rightType: Type, missingGreatest: Boolean): UnsafeOrdering = {
     require(this.isOfType(rightType))
     unsafeOrdering(missingGreatest)
   }
+
+  def unsafeOrdering(rightType: Type): UnsafeOrdering = unsafeOrdering(rightType, false)
 
   def getOption(fields: String*): Option[Type] = getOption(fields.toList)
 

--- a/src/main/scala/is/hail/expr/types/Type.scala
+++ b/src/main/scala/is/hail/expr/types/Type.scala
@@ -154,6 +154,11 @@ abstract class Type extends BaseType with Serializable {
 
   def unsafeOrdering(missingGreatest: Boolean = false): UnsafeOrdering = ???
 
+  def unsafeOrdering(rightType: Type, missingGreatest: Boolean = false): UnsafeOrdering = {
+    require(this.isOfType(rightType))
+    unsafeOrdering(missingGreatest)
+  }
+
   def getOption(fields: String*): Option[Type] = getOption(fields.toList)
 
   def getOption(path: List[String]): Option[Type] = {

--- a/src/main/scala/is/hail/rvd/OrderedRVDType.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVDType.scala
@@ -127,11 +127,13 @@ object OrderedRVDType {
     t2: TStruct, fields2: Array[Int]): UnsafeOrdering = {
     require(fields1.length == fields2.length)
     require((fields1, fields2).zipped.forall { case (f1, f2) =>
-      t1.types(f1) == t2.types(f2)
+      t1.types(f1) isOfType t2.types(f2)
     })
 
     val nFields = fields1.length
-    val fieldOrderings = fields1.map(f1 => t1.types(f1).unsafeOrdering(missingGreatest = true))
+    val fieldOrderings = Range(0, nFields).map { i =>
+      t1.types(fields1(i)).unsafeOrdering(t2.types(fields2(i)), missingGreatest = true)
+    }.toArray
 
     new UnsafeOrdering {
       def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {


### PR DESCRIPTION
@maccum ran into a problem where a join was failing because the two tables had different requiredness in their key fields. This should resolve the problem, by adding an overload `Type.unsafeOrdering` which takes a `rightType: Type`, requiring that `this isOfType rightType`, but allowing them to have different requiredness. 