### PR TITLE
Add expr functions testing contigs/loci/intervals are valid for a RG

### DIFF
--- a/python/hail/docs/functions/genetics.rst
+++ b/python/hail/docs/functions/genetics.rst
@@ -25,6 +25,9 @@ Genetics functions
     is_star
     is_complex
     is_strand_ambiguous
+    is_valid_contig
+    is_valid_locus
+    is_valid_locus_interval
     allele_type
     pl_dosage
     gp_dosage
@@ -50,6 +53,9 @@ Genetics functions
 .. autofunction:: is_star
 .. autofunction:: is_complex
 .. autofunction:: is_strand_ambiguous
+.. autofunction:: is_valid_contig
+.. autofunction:: is_valid_locus
+.. autofunction:: is_valid_locus_interval
 .. autofunction:: allele_type
 .. autofunction:: pl_dosage
 .. autofunction:: gp_dosage

--- a/python/hail/docs/functions/genetics.rst
+++ b/python/hail/docs/functions/genetics.rst
@@ -27,7 +27,6 @@ Genetics functions
     is_strand_ambiguous
     is_valid_contig
     is_valid_locus
-    is_valid_locus_interval
     allele_type
     pl_dosage
     gp_dosage
@@ -55,7 +54,6 @@ Genetics functions
 .. autofunction:: is_strand_ambiguous
 .. autofunction:: is_valid_contig
 .. autofunction:: is_valid_locus
-.. autofunction:: is_valid_locus_interval
 .. autofunction:: allele_type
 .. autofunction:: pl_dosage
 .. autofunction:: gp_dosage

--- a/python/hail/docs/functions/index.rst
+++ b/python/hail/docs/functions/index.rst
@@ -167,6 +167,9 @@ These functions are exposed at the top level of the module, e.g. ``hl.case``.
     is_indel
     is_star
     is_complex
+    is_valid_contig
+    is_valid_locus
+    is_valid_locus_interval
     allele_type
     pl_dosage
     gp_dosage

--- a/python/hail/docs/functions/index.rst
+++ b/python/hail/docs/functions/index.rst
@@ -169,7 +169,6 @@ These functions are exposed at the top level of the module, e.g. ``hl.case``.
     is_complex
     is_valid_contig
     is_valid_locus
-    is_valid_locus_interval
     allele_type
     pl_dosage
     gp_dosage

--- a/python/hail/expr/__init__.py
+++ b/python/hail/expr/__init__.py
@@ -126,6 +126,5 @@ __all__ = ['HailType',
            'get_sequence',
            'builders',
            'is_valid_contig',
-           'is_valid_locus',
-           'is_valid_locus_interval'
+           'is_valid_locus'
            ]

--- a/python/hail/expr/__init__.py
+++ b/python/hail/expr/__init__.py
@@ -125,4 +125,7 @@ __all__ = ['HailType',
            'bool',
            'get_sequence',
            'builders',
+           'is_valid_contig',
+           'is_valid_locus',
+           'is_valid_locus_interval'
            ]

--- a/python/hail/expr/expressions/typed_expressions.py
+++ b/python/hail/expr/expressions/typed_expressions.py
@@ -2711,7 +2711,7 @@ class LocusExpression(Expression):
         rg = self.dtype.reference_genome
         if not rg.has_sequence():
             raise TypeError("Reference genome '{}' does not have a sequence loaded. Use 'add_sequence' to load the sequence from a FASTA file.".format(rg.name))
-        return hl.get_sequence(rg, self.contig, self.position, before, after)
+        return hl.get_sequence(self.contig, self.position, before, after, rg)
 
 
 class IntervalExpression(Expression):

--- a/python/hail/expr/functions.py
+++ b/python/hail/expr/functions.py
@@ -3494,3 +3494,111 @@ def get_sequence(reference_genome, contig, position, before=0, after=0) -> Strin
         raise TypeError("Reference genome '{}' does not have a sequence loaded. Use 'add_sequence' to load the sequence from a FASTA file.".format(reference_genome.name))
     return _func("getReferenceSequence({})".format(reference_genome.name), tstr,
                  contig, position, before, after)
+
+@typecheck(reference_genome=reference_genome_type,
+           contig=expr_str)
+def is_valid_contig(reference_genome, contig) -> BooleanExpression:
+    """Returns True if `contig` is a valid contig name in `reference_genome`.
+
+    Examples
+    --------
+
+    .. doctest::
+
+        >>> hl.is_valid_contig('GRCh37', '1')
+        True
+
+        >>> hl.is_valid_contig('GRCh37', 'chr1')
+        False
+
+    Parameters
+    ----------
+    reference_genome : :obj:`str` or :class:`.ReferenceGenome`
+        Reference genome to use.
+    contig : :class:`.Expression` of type :py:data:`.tstr`
+        Contig name to test.
+
+    Returns
+    -------
+    :class:`.Expression` of type :py:data:`.tbool`
+    """
+    return _func("isValidContig({})".format(reference_genome.name), tbool, contig)
+
+@typecheck(reference_genome=reference_genome_type,
+           contig=expr_str,
+           position=expr_int32)
+def is_valid_locus(reference_genome, contig, position) -> BooleanExpression:
+    """Returns True if `contig` and `position` is a valid site in `reference_genome`.
+
+    Examples
+    --------
+
+    .. doctest::
+
+        >>> hl.is_valid_locus('GRCh37', '1', 324254)
+        True
+
+        >>> hl.is_valid_locus('GRCh37', 'chr1', 324254)
+        False
+
+    Parameters
+    ----------
+    reference_genome : :obj:`str` or :class:`.ReferenceGenome`
+        Reference genome to use.
+    contig : :class:`.Expression` of type :py:data:`.tstr`
+        Contig name to test.
+    position : :class:`.Expression` of type :py:data:`.tint`
+        Position to test.
+
+    Returns
+    -------
+    :class:`.Expression` of type :py:data:`.tbool`
+    """
+    return _func("isValidLocus({})".format(reference_genome.name), tbool, contig, position)
+
+@typecheck(reference_genome=reference_genome_type,
+           start_contig=expr_str,
+           start_position=expr_int32,
+           end_contig=expr_str,
+           end_position=expr_int32,
+           includes_start=expr_bool,
+           includes_end=expr_bool)
+def is_valid_locus_interval(reference_genome, start_contig, start_position,
+                            end_contig, end_position, includes_start, includes_end) -> BooleanExpression:
+    """Returns True if the inputs compose a valid interval in `reference_genome`.
+
+    Examples
+    --------
+
+    .. doctest::
+
+        >>> hl.is_valid_locus_interval('GRCh37', '1', 1, '1', 249250622, true, false)
+        True
+
+        >>> hl.is_valid_locus_interval('GRCh37', '1', 0, '1', 249250622, true, true)
+        False
+
+    Parameters
+    ----------
+    reference_genome : :obj:`str` or :class:`.ReferenceGenome`
+        Reference genome to use.
+    start_contig : :class:`.Expression` of type :py:data:`.tstr`
+        Start contig name to test.
+    start_position : :class:`.Expression` of type :py:data:`.tint`
+        Start position to test.
+    end_contig : :class:`.Expression` of type :py:data:`.tstr`
+        End contig name to test.
+    end_position : :class:`.Expression` of type :py:data:`.tint`
+        End position to test.
+    includes_start : :class:`.Expression` of type :py:data:`.tbool`
+        If ``True``, interval includes the start.
+    includes_end : :class:`.Expression` of type :py:data:`.tbool`
+        If ``True``, interval includes the end.
+
+    Returns
+    -------
+    :class:`.Expression` of type :py:data:`.tbool`
+    """
+    return _func("isValidLocusInterval({})".format(reference_genome.name), tbool,
+                 start_contig, start_position, end_contig, end_position,
+                 includes_start, includes_end)

--- a/python/hail/expr/functions.py
+++ b/python/hail/expr/functions.py
@@ -3572,10 +3572,10 @@ def is_valid_locus_interval(reference_genome, start_contig, start_position,
 
     .. doctest::
 
-        >>> hl.is_valid_locus_interval('GRCh37', '1', 1, '1', 249250622, true, false)
+        >>> hl.is_valid_locus_interval('GRCh37', '1', 1, '1', 249250622, True, False)
         True
 
-        >>> hl.is_valid_locus_interval('GRCh37', '1', 0, '1', 249250622, true, true)
+        >>> hl.is_valid_locus_interval('GRCh37', '1', 0, '1', 249250622, True, True)
         False
 
     Parameters

--- a/python/hail/expr/functions.py
+++ b/python/hail/expr/functions.py
@@ -3458,7 +3458,7 @@ def get_sequence(reference_genome, contig, position, before=0, after=0) -> Strin
     .. doctest::
         :options: +SKIP
 
-        >>> hl.get_sequence('GRCh37', '1', 45323)
+        >>> hl.eval_expr(hl.get_sequence('GRCh37', '1', 45323))
         "T"
 
     Notes
@@ -3498,18 +3498,16 @@ def get_sequence(reference_genome, contig, position, before=0, after=0) -> Strin
 @typecheck(reference_genome=reference_genome_type,
            contig=expr_str)
 def is_valid_contig(reference_genome, contig) -> BooleanExpression:
-    """Returns True if `contig` is a valid contig name in `reference_genome`.
+    """Returns ``True`` if `contig` is a valid contig name in `reference_genome`.
 
     Examples
     --------
 
-    .. doctest::
+    >>> hl.eval_expr(hl.is_valid_contig('GRCh37', '1'))
+    True
 
-        >>> hl.is_valid_contig('GRCh37', '1')
-        True
-
-        >>> hl.is_valid_contig('GRCh37', 'chr1')
-        False
+    >>> hl.eval_expr(hl.is_valid_contig('GRCh37', 'chr1'))
+    False
 
     Parameters
     ----------
@@ -3528,18 +3526,16 @@ def is_valid_contig(reference_genome, contig) -> BooleanExpression:
            contig=expr_str,
            position=expr_int32)
 def is_valid_locus(reference_genome, contig, position) -> BooleanExpression:
-    """Returns True if `contig` and `position` is a valid site in `reference_genome`.
+    """Returns ``True`` if `contig` and `position` is a valid site in `reference_genome`.
 
     Examples
     --------
 
-    .. doctest::
+    >>> hl.eval_expr(hl.is_valid_locus('GRCh37', '1', 324254))
+    True
 
-        >>> hl.is_valid_locus('GRCh37', '1', 324254)
-        True
-
-        >>> hl.is_valid_locus('GRCh37', 'chr1', 324254)
-        False
+    >>> hl.eval_expr(hl.is_valid_locus('GRCh37', 'chr1', 324254))
+    False
 
     Parameters
     ----------
@@ -3555,50 +3551,3 @@ def is_valid_locus(reference_genome, contig, position) -> BooleanExpression:
     :class:`.Expression` of type :py:data:`.tbool`
     """
     return _func("isValidLocus({})".format(reference_genome.name), tbool, contig, position)
-
-@typecheck(reference_genome=reference_genome_type,
-           start_contig=expr_str,
-           start_position=expr_int32,
-           end_contig=expr_str,
-           end_position=expr_int32,
-           includes_start=expr_bool,
-           includes_end=expr_bool)
-def is_valid_locus_interval(reference_genome, start_contig, start_position,
-                            end_contig, end_position, includes_start, includes_end) -> BooleanExpression:
-    """Returns True if the inputs compose a valid interval in `reference_genome`.
-
-    Examples
-    --------
-
-    .. doctest::
-
-        >>> hl.is_valid_locus_interval('GRCh37', '1', 1, '1', 249250622, True, False)
-        True
-
-        >>> hl.is_valid_locus_interval('GRCh37', '1', 0, '1', 249250622, True, True)
-        False
-
-    Parameters
-    ----------
-    reference_genome : :obj:`str` or :class:`.ReferenceGenome`
-        Reference genome to use.
-    start_contig : :class:`.Expression` of type :py:data:`.tstr`
-        Start contig name to test.
-    start_position : :class:`.Expression` of type :py:data:`.tint`
-        Start position to test.
-    end_contig : :class:`.Expression` of type :py:data:`.tstr`
-        End contig name to test.
-    end_position : :class:`.Expression` of type :py:data:`.tint`
-        End position to test.
-    includes_start : :class:`.Expression` of type :py:data:`.tbool`
-        If ``True``, interval includes the start.
-    includes_end : :class:`.Expression` of type :py:data:`.tbool`
-        If ``True``, interval includes the end.
-
-    Returns
-    -------
-    :class:`.Expression` of type :py:data:`.tbool`
-    """
-    return _func("isValidLocusInterval({})".format(reference_genome.name), tbool,
-                 start_contig, start_position, end_contig, end_position,
-                 includes_start, includes_end)

--- a/python/hail/expr/functions.py
+++ b/python/hail/expr/functions.py
@@ -3442,12 +3442,12 @@ def bool(x) -> BooleanExpression:
         return x._method("toBoolean", tbool)
 
 
-@typecheck(reference_genome=reference_genome_type,
-           contig=expr_str,
+@typecheck(contig=expr_str,
            position=expr_int32,
            before=expr_int32,
-           after=expr_int32)
-def get_sequence(reference_genome, contig, position, before=0, after=0) -> StringExpression:
+           after=expr_int32,
+           reference_genome=reference_genome_type)
+def get_sequence(contig, position, before=0, after=0, reference_genome='default') -> StringExpression:
     """Return the reference sequence at a given locus.
 
     Examples
@@ -3458,7 +3458,7 @@ def get_sequence(reference_genome, contig, position, before=0, after=0) -> Strin
     .. doctest::
         :options: +SKIP
 
-        >>> hl.eval_expr(hl.get_sequence('GRCh37', '1', 45323))
+        >>> hl.get_sequence('1', 45323, 'GRCh37').value
         "T"
 
     Notes
@@ -3472,8 +3472,6 @@ def get_sequence(reference_genome, contig, position, before=0, after=0) -> Strin
 
     Parameters
     ----------
-    reference_genome : :obj:`str` or :class:`.ReferenceGenome`
-        Reference genome to use. Must have a reference sequence available.
     contig : :class:`.Expression` of type :py:data:`.tstr`
         Locus contig.
     position : :class:`.Expression` of type :py:data:`.tint32`
@@ -3484,10 +3482,12 @@ def get_sequence(reference_genome, contig, position, before=0, after=0) -> Strin
     after : :class:`.Expression` of type :py:data:`.tint32`, optional
         Number of bases to include after the locus of interest. Truncates at
         contig boundary.
+    reference_genome : :obj:`str` or :class:`.ReferenceGenome`
+        Reference genome to use. Must have a reference sequence available.
 
     Returns
     -------
-    :class:`.Expression` of type :py:data:`.tstr`
+    :class:`.StringExpression`
     """
 
     if not reference_genome.has_sequence():
@@ -3495,59 +3495,54 @@ def get_sequence(reference_genome, contig, position, before=0, after=0) -> Strin
     return _func("getReferenceSequence({})".format(reference_genome.name), tstr,
                  contig, position, before, after)
 
-@typecheck(reference_genome=reference_genome_type,
-           contig=expr_str)
-def is_valid_contig(reference_genome, contig) -> BooleanExpression:
+@typecheck(contig=expr_str,
+           reference_genome=reference_genome_type)
+def is_valid_contig(contig, reference_genome='default') -> BooleanExpression:
     """Returns ``True`` if `contig` is a valid contig name in `reference_genome`.
 
     Examples
     --------
 
-    >>> hl.eval_expr(hl.is_valid_contig('GRCh37', '1'))
+    >>> hl.eval_expr(hl.is_valid_contig('1', 'GRCh37'))
     True
 
-    >>> hl.eval_expr(hl.is_valid_contig('GRCh37', 'chr1'))
+    >>> hl.eval_expr(hl.is_valid_contig('chr1', 'GRCh37'))
     False
 
     Parameters
     ----------
-    reference_genome : :obj:`str` or :class:`.ReferenceGenome`
-        Reference genome to use.
     contig : :class:`.Expression` of type :py:data:`.tstr`
-        Contig name to test.
+    reference_genome : :obj:`str` or :class:`.ReferenceGenome`
 
     Returns
     -------
-    :class:`.Expression` of type :py:data:`.tbool`
+    :class:`.BooleanExpression`
     """
     return _func("isValidContig({})".format(reference_genome.name), tbool, contig)
 
-@typecheck(reference_genome=reference_genome_type,
-           contig=expr_str,
-           position=expr_int32)
-def is_valid_locus(reference_genome, contig, position) -> BooleanExpression:
+@typecheck(contig=expr_str,
+           position=expr_int32,
+           reference_genome=reference_genome_type)
+def is_valid_locus(contig, position, reference_genome='default') -> BooleanExpression:
     """Returns ``True`` if `contig` and `position` is a valid site in `reference_genome`.
 
     Examples
     --------
 
-    >>> hl.eval_expr(hl.is_valid_locus('GRCh37', '1', 324254))
+    >>> hl.eval_expr(hl.is_valid_locus('1', 324254, 'GRCh37'))
     True
 
-    >>> hl.eval_expr(hl.is_valid_locus('GRCh37', 'chr1', 324254))
+    >>> hl.eval_expr(hl.is_valid_locus('chr1', 324254, 'GRCh37'))
     False
 
     Parameters
     ----------
-    reference_genome : :obj:`str` or :class:`.ReferenceGenome`
-        Reference genome to use.
     contig : :class:`.Expression` of type :py:data:`.tstr`
-        Contig name to test.
     position : :class:`.Expression` of type :py:data:`.tint`
-        Position to test.
+    reference_genome : :obj:`str` or :class:`.ReferenceGenome`
 
     Returns
     -------
-    :class:`.Expression` of type :py:data:`.tbool`
+    :class:`.BooleanExpression`
     """
     return _func("isValidLocus({})".format(reference_genome.name), tbool, contig, position)

--- a/python/hail/tests/test_expr.py
+++ b/python/hail/tests/test_expr.py
@@ -1157,11 +1157,12 @@ class Tests(unittest.TestCase):
         self.assertFalse(li.overlaps(li5).value)
 
     def test_reference_genome_fns(self):
-        self.assertTrue(hl.is_valid_contig('GRCh37', '1').value)
-        self.assertFalse(hl.is_valid_contig('GRCh37', 'chr1').value)
-        self.assertFalse(hl.is_valid_contig('GRCh38', '1').value)
-        self.assertTrue(hl.is_valid_contig('GRCh38', 'chr1').value)
+        self.assertTrue(hl.is_valid_contig('1', 'GRCh37').value)
+        self.assertFalse(hl.is_valid_contig('chr1', 'GRCh37').value)
+        self.assertFalse(hl.is_valid_contig('1', 'GRCh38').value)
+        self.assertTrue(hl.is_valid_contig('chr1', 'GRCh38').value)
 
-        self.assertTrue(hl.is_valid_locus('GRCh37', '1', 325423).value)
-        self.assertFalse(hl.is_valid_locus('GRCh37', '1', 0).value)
-        self.assertFalse(hl.is_valid_locus('GRCh37', '1', 249250622).value)
+        self.assertTrue(hl.is_valid_locus('1', 325423, 'GRCh37').value)
+        self.assertFalse(hl.is_valid_locus('1', 0, 'GRCh37').value)
+        self.assertFalse(hl.is_valid_locus('1', 249250622, 'GRCh37').value)
+        self.assertFalse(hl.is_valid_locus('chr1', 2645, 'GRCh37').value)

--- a/python/hail/tests/test_expr.py
+++ b/python/hail/tests/test_expr.py
@@ -1155,3 +1155,19 @@ class Tests(unittest.TestCase):
         self.assertTrue(li.overlaps(li4).value)
         self.assertFalse(li.overlaps(li3).value)
         self.assertFalse(li.overlaps(li5).value)
+
+    def test_reference_genome_fns(self):
+        self.assertTrue(hl.is_valid_contig('GRCh37', '1').value)
+        self.assertFalse(hl.is_valid_contig('GRCh37', 'chr1').value)
+        self.assertFalse(hl.is_valid_contig('GRCh38', '1').value)
+        self.assertTrue(hl.is_valid_contig('GRCh38', 'chr1').value)
+
+        self.assertTrue(hl.is_valid_locus('GRCh37', '1', 325423).value)
+        self.assertFalse(hl.is_valid_locus('GRCh37', '1', 0).value)
+        self.assertFalse(hl.is_valid_locus('GRCh37', '1', 249250622).value)
+
+        self.assertTrue(hl.is_valid_locus_interval('GRCh37', '1', 325423, '1', 249250622, True, False).value)
+        # self.assertTrue(hl.is_valid_locus_interval('GRCh37', '1', 0, '1', 249250622, False, False).value)
+        # self.assertFalse(hl.is_valid_locus_interval('GRCh37', '1', 0, '1', 249250622, True, False).value)
+        # self.assertFalse(hl.is_valid_locus_interval('GRCh37', '1', 0, '1', 249250622, False, True).value)
+        # self.assertFalse(hl.is_valid_locus_interval('GRCh37', '1', 0, '1', 249250622, True, True).value)

--- a/python/hail/tests/test_expr.py
+++ b/python/hail/tests/test_expr.py
@@ -1165,9 +1165,3 @@ class Tests(unittest.TestCase):
         self.assertTrue(hl.is_valid_locus('GRCh37', '1', 325423).value)
         self.assertFalse(hl.is_valid_locus('GRCh37', '1', 0).value)
         self.assertFalse(hl.is_valid_locus('GRCh37', '1', 249250622).value)
-
-        self.assertTrue(hl.is_valid_locus_interval('GRCh37', '1', 325423, '1', 249250622, True, False).value)
-        # self.assertTrue(hl.is_valid_locus_interval('GRCh37', '1', 0, '1', 249250622, False, False).value)
-        # self.assertFalse(hl.is_valid_locus_interval('GRCh37', '1', 0, '1', 249250622, True, False).value)
-        # self.assertFalse(hl.is_valid_locus_interval('GRCh37', '1', 0, '1', 249250622, False, True).value)
-        # self.assertFalse(hl.is_valid_locus_interval('GRCh37', '1', 0, '1', 249250622, True, True).value)

--- a/python/hail/tests/test_genetics.py
+++ b/python/hail/tests/test_genetics.py
@@ -134,7 +134,7 @@ class Tests(unittest.TestCase):
         self.assertTrue(gr4.x_contigs == ["a"])
 
         t = hl.import_table(resource("fake_reference.tsv"), impute=True)
-        self.assertTrue(t.all(hl.get_sequence(gr4, t.contig, t.pos) == t.base))
+        self.assertTrue(t.all(hl.get_sequence(t.contig, t.pos, reference_genome=gr4) == t.base))
 
         l = hl.locus("a", 7, gr4)
         self.assertTrue(l.sequence_context(before=3, after=3).value == "TTTCGAA")

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -209,23 +209,6 @@ object AST extends Positional {
           Code(std, dc.ifNull(Code._null,
             Code(ste, ec.ifNull(Code._null, gc)
             )))))))))
-
-  def evalComposeCodeM[T, U, V, W, X, Y](a: AST, b: AST, c: AST, d: AST, e: AST, f: AST)(g: (Code[T], Code[U], Code[V], Code[W], Code[X], Code[Y]) => CM[Code[AnyRef]]): CM[Code[AnyRef]] = for (
-    (sta, ac) <- CM.memoize(a.compile());
-    (stb, bc) <- CM.memoize(b.compile());
-    (stc, cc) <- CM.memoize(c.compile());
-    (std, dc) <- CM.memoize(d.compile());
-    (ste, ec) <- CM.memoize(e.compile());
-    (stf, fc) <- CM.memoize(f.compile());
-    gc <- g(ac.asInstanceOf[Code[T]], bc.asInstanceOf[Code[U]], cc.asInstanceOf[Code[V]], dc.asInstanceOf[Code[W]], ec.asInstanceOf[Code[X]], fc.asInstanceOf[Code[Y]])
-  ) yield
-    Code(sta, ac.ifNull(Code._null,
-      Code(stb, bc.ifNull(Code._null,
-        Code(stc, cc.ifNull(Code._null,
-          Code(std, dc.ifNull(Code._null,
-            Code(ste, ec.ifNull(Code._null,
-              Code(stf, fc.ifNull(Code._null, gc)
-            )))))))))))
 }
 
 case class Positioned[T](x: T) extends Positional
@@ -453,7 +436,7 @@ case class ReferenceGenomeDependentFunction(posn: Position, fName: String, grNam
     case "LocusInterval" => rg.intervalType
     case "LocusAlleles" => TStruct("locus" -> rg.locusType, "alleles" -> TArray(TString()))
     case "getReferenceSequence" => TString()
-    case "isValidContig" | "isValidLocus" | "isValidLocusInterval" => TBoolean()
+    case "isValidContig" | "isValidLocus" => TBoolean()
     case _ => throw new UnsupportedOperationException
   }
 
@@ -470,10 +453,6 @@ case class ReferenceGenomeDependentFunction(posn: Position, fName: String, grNam
       case "isValidLocus" =>
         (args.map(_.`type`): @unchecked) match {
           case Array(TString(_), TInt32(_)) =>
-        }
-      case "isValidLocusInterval" =>
-        (args.map(_.`type`): @unchecked) match {
-          case Array(TString(_), TInt32(_), TString(_), TInt32(_), TBoolean(_), TBoolean(_)) =>
         }
       case _ =>
     }
@@ -496,19 +475,16 @@ case class ReferenceGenomeDependentFunction(posn: Position, fName: String, grNam
     case "isValidContig" =>
       val localRG = rg
       val f: (String) => Boolean = { contig => localRG.isValidContig(contig) }
-      AST.evalComposeCodeM(args(0))(CM.invokePrimitive1(f.asInstanceOf[(AnyRef) => AnyRef]))
+      for {
+        b <- AST.evalComposeCodeM(args(0))(CM.invokePrimitive1(f.asInstanceOf[(AnyRef) => AnyRef]))
+      } yield Code.checkcast[java.lang.Boolean](b)
 
     case "isValidLocus" =>
       val localRG = rg
       val f: (String, Int) => Boolean = { (contig, pos) => localRG.isValidLocus(contig, pos) }
-      AST.evalComposeCodeM(args(0), args(1))(CM.invokePrimitive2(f.asInstanceOf[(AnyRef, AnyRef) => AnyRef]))
-
-    case "isValidLocusInterval" =>
-      val localRG = rg
-      val f: (String, Int, String, Int, Boolean, Boolean) => Boolean = { (startContig, startPos, endContig, endPos, includesStart, includesEnd) =>
-        localRG.isValidLocusInterval(startContig, startPos, endContig, endPos, includesStart, includesEnd)
-      }
-      AST.evalComposeCodeM(args(0), args(1), args(2), args(3), args(4), args(5))(CM.invokePrimitive6(f.asInstanceOf[(AnyRef, AnyRef, AnyRef, AnyRef, AnyRef, AnyRef) => AnyRef]))
+      for {
+        b <- AST.evalComposeCodeM(args(0), args(1))(CM.invokePrimitive2(f.asInstanceOf[(AnyRef, AnyRef) => AnyRef]))
+      } yield Code.checkcast[java.lang.Boolean](b)
 
     case _ => FunctionRegistry.call(fName, args, args.map(_.`type`).toSeq, Some(rTyp))
   }

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -648,7 +648,8 @@ object Parser extends JavaTokenParsers {
       "|-" ^^ { _ => Call0(phased = true) }
   }
   
-  def referenceGenomeDependentFunction: Parser[String] = "LocusInterval" | "LocusAlleles" | "Locus" | "getReferenceSequence"
+  def referenceGenomeDependentFunction: Parser[String] = "LocusInterval" | "LocusAlleles" | "Locus" |
+    "getReferenceSequence" | "isValidContig" | "isValidLocusInterval" | "isValidLocus"
 
   def intervalWithEndpoints[T](bounds: Parser[(T, T, Boolean, Boolean)]): Parser[Interval] = {
     val start = ("[" ^^^ true) | ("(" ^^^ false)

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -649,7 +649,7 @@ object Parser extends JavaTokenParsers {
   }
   
   def referenceGenomeDependentFunction: Parser[String] = "LocusInterval" | "LocusAlleles" | "Locus" |
-    "getReferenceSequence" | "isValidContig" | "isValidLocusInterval" | "isValidLocus"
+    "getReferenceSequence" | "isValidContig" | "isValidLocus"
 
   def intervalWithEndpoints[T](bounds: Parser[(T, T, Boolean, Boolean)]): Parser[Interval] = {
     val start = ("[" ^^^ true) | ("(" ^^^ false)

--- a/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -216,25 +216,29 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
 
   def isValidContig(contig: String): Boolean = contigsSet.contains(contig)
 
-  def isValidLocus(contig: String, pos: Int): Boolean = pos > 0 && pos <= contigLength(contig)
+  def isValidLocus(contig: String, pos: Int): Boolean = isValidContig(contig) && pos > 0 && pos <= contigLength(contig)
 
   def isValidLocus(l: Locus): Boolean = isValidLocus(l.contig, l.position)
-  
+
   def checkLocus(l: Locus): Unit = checkLocus(l.contig, l.position)
 
   def checkLocus(contig: String, pos: Int): Unit = {
-    if (!isValidContig(contig))
-      fatal(s"Invalid locus `$contig:$pos' found. Contig `$contig' is not in the reference genome `$name'.")
-    if (!isValidLocus(contig, pos))
-      fatal(s"Invalid locus `$contig:$pos' found. Position `$pos' is not within the range [1-${ contigLength(contig) }] for reference genome `$name'.")
+    if (!isValidLocus(contig, pos)) {
+      if (!isValidContig(contig))
+        fatal(s"Invalid locus `$contig:$pos' found. Contig `$contig' is not in the reference genome `$name'.")
+      else
+        fatal(s"Invalid locus `$contig:$pos' found. Position `$pos' is not within the range [1-${ contigLength(contig) }] for reference genome `$name'.")
+    }
   }
 
   def checkVariant(contig: String, start: Int, ref: String, alt: String): Unit = {
     val v = s"$contig:$start:$ref:$alt"
-    if (!isValidContig(contig))
-      fatal(s"Invalid variant `$v' found. Contig `$contig' is not in the reference genome `$name'.")
-    if (!isValidLocus(contig, start))
-      fatal(s"Invalid variant `$v' found. Start `$start' is not within the range [1-${ contigLength(contig) }] for reference genome `$name'.")
+    if (!isValidLocus(contig, start)) {
+      if (!isValidContig(contig))
+        fatal(s"Invalid variant `$v' found. Contig `$contig' is not in the reference genome `$name'.")
+      else
+        fatal(s"Invalid variant `$v' found. Start `$start' is not within the range [1-${ contigLength(contig) }] for reference genome `$name'.")
+    }
   }
 
   def checkVariant(contig: String, start: Int, ref: String, alts: Array[String]): Unit = checkVariant(contig, start, ref, alts.mkString(","))
@@ -245,14 +249,19 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
     val includesStart = i.includesStart
     val includesEnd = i.includesEnd
 
-    if (!isValidContig(start.contig))
-      fatal(s"Invalid interval `$i' found. Contig `${ start.contig }' is not in the reference genome `$name'.")
-    if (!isValidContig(end.contig))
-      fatal(s"Invalid interval `$i' found. Contig `${ end.contig }' is not in the reference genome `$name'.")
-    if (!isValidLocus(start.contig, if (includesStart) start.position else start.position + 1))
-      fatal(s"Invalid interval `$i' found. Start `$start' is not within the range [1-${ contigLength(start.contig) }] for reference genome `$name'.")
-    if (!isValidLocus(end.contig, if (includesEnd) end.position else end.position - 1))
-      fatal(s"Invalid interval `$i' found. End `$end' is not within the range [1-${ contigLength(end.contig) }] for reference genome `$name'.")
+    if (!isValidLocus(start.contig, if (includesStart) start.position else start.position + 1)) {
+      if (!isValidContig(start.contig))
+        fatal(s"Invalid interval `$i' found. Contig `${ start.contig }' is not in the reference genome `$name'.")
+      else
+        fatal(s"Invalid interval `$i' found. Start `$start' is not within the range [1-${ contigLength(start.contig) }] for reference genome `$name'.")
+    }
+
+    if (!isValidLocus(end.contig, if (includesEnd) end.position else end.position - 1)) {
+      if (!isValidContig(end.contig))
+        fatal(s"Invalid interval `$i' found. Contig `${ end.contig }' is not in the reference genome `$name'.")
+      else
+        fatal(s"Invalid interval `$i' found. End `$end' is not within the range [1-${ contigLength(end.contig) }] for reference genome `$name'.")
+    }
   }
 
   def normalizeLocusInterval(i: Interval): Interval = {

--- a/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -219,14 +219,7 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
   def isValidLocus(contig: String, pos: Int): Boolean = pos > 0 && pos <= contigLength(contig)
 
   def isValidLocus(l: Locus): Boolean = isValidLocus(l.contig, l.position)
-
-  def isValidLocusInterval(startContig: String, startPos: Int, endContig: String, endPos: Int, includesStart: Boolean, includesEnd: Boolean): Boolean = {
-    isValidContig(startContig) &&
-      isValidContig(endContig) &&
-      isValidLocus(startContig, if (includesStart) startPos else startPos + 1) &&
-      isValidLocus(endContig, if (includesEnd) endPos else endPos - 1)
-  }
-
+  
   def checkLocus(l: Locus): Unit = checkLocus(l.contig, l.position)
 
   def checkLocus(contig: String, pos: Int): Unit = {

--- a/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -220,6 +220,13 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
 
   def isValidLocus(l: Locus): Boolean = isValidLocus(l.contig, l.position)
 
+  def isValidLocusInterval(startContig: String, startPos: Int, endContig: String, endPos: Int, includesStart: Boolean, includesEnd: Boolean): Boolean = {
+    isValidContig(startContig) &&
+      isValidContig(endContig) &&
+      isValidLocus(startContig, if (includesStart) startPos else startPos + 1) &&
+      isValidLocus(endContig, if (includesEnd) endPos else endPos - 1)
+  }
+
   def checkLocus(l: Locus): Unit = checkLocus(l.contig, l.position)
 
   def checkLocus(contig: String, pos: Int): Unit = {


### PR DESCRIPTION
I thought these functions would be generally useful and I need them for a future PR reimplementing `import_bed` and `import_locus_intervals` in Python.