### PR TITLE
Context rdd coalesce and shuffle

### DIFF
--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -456,7 +456,7 @@ object OrderedRVD {
     rdd: RDD[RegionValue]
   ): RDD[RegionValue] = getKeys(
     typ,
-    ContextRDD.weaken(rdd, RVDContext.default _)).run
+    ContextRDD.weaken(rdd)).run
 
   def getPartitionKeyInfo(
     typ: OrderedRVDType,
@@ -492,7 +492,7 @@ object OrderedRVD {
     keys: RDD[RegionValue]
   ): Array[OrderedRVPartitionInfo] = getPartitionKeyInfo(
     typ,
-    ContextRDD.weaken(keys, RVDContext.default _))
+    ContextRDD.weaken(keys))
 
   def coerce(
     typ: OrderedRVDType,
@@ -660,7 +660,7 @@ object OrderedRVD {
     partitioner: OrderedRVDPartitioner,
     rdd: RDD[RegionValue]
   ): OrderedRVD =
-    shuffle(typ, partitioner, ContextRDD.weaken(rdd, RVDContext.default _))
+    shuffle(typ, partitioner, ContextRDD.weaken(rdd))
 
   def shuffle(
     typ: OrderedRVDType,
@@ -763,7 +763,7 @@ object OrderedRVD {
     typ: OrderedRVDType,
     partitioner: OrderedRVDPartitioner,
     rdd: RDD[RegionValue]
-  ): OrderedRVD = apply(typ, partitioner, ContextRDD.weaken(rdd, RVDContext.default _))
+  ): OrderedRVD = apply(typ, partitioner, ContextRDD.weaken(rdd))
 
   def apply(
     typ: OrderedRVDType,

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -456,7 +456,7 @@ object OrderedRVD {
     rdd: RDD[RegionValue]
   ): RDD[RegionValue] = getKeys(
     typ,
-    ContextRDD.weaken[RVDContext](rdd, RVDContext.default _)).run
+    ContextRDD.weaken(rdd, RVDContext.default _)).run
 
   def getPartitionKeyInfo(
     typ: OrderedRVDType,

--- a/src/main/scala/is/hail/rvd/UnpartitionedRVD.scala
+++ b/src/main/scala/is/hail/rvd/UnpartitionedRVD.scala
@@ -58,9 +58,7 @@ class UnpartitionedRVD(val rowType: TStruct, val crdd: ContextRDD[RVDContext, Re
   }
 
   def coalesce(maxPartitions: Int, shuffle: Boolean): UnpartitionedRVD =
-    new UnpartitionedRVD(
-      rowType,
-      ContextRDD.weaken(rdd.coalesce(maxPartitions, shuffle = shuffle)))
+    new UnpartitionedRVD(rowType, crdd.coalesce(maxPartitions, shuffle = shuffle))
 
   def constrainToOrderedPartitioner(
     ordType: OrderedRVDType,
@@ -72,7 +70,7 @@ class UnpartitionedRVD(val rowType: TStruct, val crdd: ContextRDD[RVDContext, Re
     val localRowType = rowType
     val pkOrdering = ordType.pkType.ordering
     val rangeTree = newPartitioner.rangeTree
-    val filtered = rdd.mapPartitions { it =>
+    val filtered = crdd.mapPartitions { it =>
       val ur = new UnsafeRow(localRowType, null, 0)
       val key = new KeyedRow(ur, ordType.pkRowFieldIdx)
       it.filter { rv =>

--- a/src/main/scala/is/hail/sparkextras/ContextPairRDDFunctions.scala
+++ b/src/main/scala/is/hail/sparkextras/ContextPairRDDFunctions.scala
@@ -1,0 +1,18 @@
+package is.hail.sparkextras
+
+import org.apache.spark._
+import org.apache.spark.rdd._
+
+import scala.reflect.ClassTag
+
+class ContextPairRDDFunctions[C <: AutoCloseable, K: ClassTag, V: ClassTag](
+  crdd: ContextRDD[C, (K, V)]
+) {
+  def shuffle(p: Partitioner, o: Ordering[K]): ContextRDD[C, (K, V)] =
+    // NB: the run marks the end of a context lifetime, the next context
+    // lifetime starts after the shuffle (and potentially on a different machine
+    // than the one that owned the previous lifetime)
+    ContextRDD.weaken(
+      new ShuffledRDD[K, V, V](crdd.run, p).setKeyOrdering(o),
+      crdd.mkc)
+}

--- a/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -157,6 +157,15 @@ class ContextRDD[C <: AutoCloseable, T: ClassTag](
     onRDD(rdd => new AdjustedPartitionsRDD(rdd, contextIgnorantAdjustments))
   }
 
+  def coalesce(numPartitions: Int, shuffle: Boolean = false): ContextRDD[C, T] =
+    // NB: the run marks the end of a context lifetime, the next one starts
+    // after the coalesce/shuffle
+    ContextRDD.weaken(run.coalesce(numPartitions, shuffle), mkc)
+
+  def sparkContext: SparkContext = rdd.sparkContext
+
+  def getNumPartitions: Int = rdd.getNumPartitions
+
   private[this] def onRDD(
     f: RDD[C => Iterator[T]] => RDD[C => Iterator[T]]
   ): ContextRDD[C, T] = new ContextRDD(f(rdd), mkc)

--- a/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -159,8 +159,11 @@ class ContextRDD[C <: AutoCloseable, T: ClassTag](
 
   def coalesce(numPartitions: Int, shuffle: Boolean = false): ContextRDD[C, T] =
     // NB: the run marks the end of a context lifetime, the next one starts
-    // after the coalesce/shuffle
-    ContextRDD.weaken(run.coalesce(numPartitions, shuffle), mkc)
+    // after the shuffle
+    if (shuffle)
+      ContextRDD.weaken(run.coalesce(numPartitions, shuffle), mkc)
+    else
+      onRDD(_.coalesce(numPartitions, shuffle))
 
   def sparkContext: SparkContext = rdd.sparkContext
 

--- a/src/main/scala/is/hail/utils/richUtils/Implicits.scala
+++ b/src/main/scala/is/hail/utils/richUtils/Implicits.scala
@@ -6,6 +6,7 @@ import breeze.linalg.DenseMatrix
 import is.hail.annotations.{Region, RegionValue, JoinedRegionValue}
 import is.hail.asm4s.Code
 import is.hail.io.RichRDDRegionValue
+import is.hail.sparkextras._
 import is.hail.utils.{ArrayBuilder, HailIterator, JSONWriter, MultiArray2, Truncatable, WithContext}
 import org.apache.hadoop
 import org.apache.spark.SparkContext
@@ -121,4 +122,6 @@ trait Implicits {
   implicit def toRichCodeRegion(r: Code[Region]): RichCodeRegion = new RichCodeRegion(r)
 
   implicit def toRichPartialKleisliOptionFunction[A, B](x: PartialFunction[A, Option[B]]): RichPartialKleisliOptionFunction[A, B] = new RichPartialKleisliOptionFunction(x)
+
+  implicit def toContextPairRDDFunctions[C <: AutoCloseable, K: ClassTag, V: ClassTag](x: ContextRDD[C, (K, V)]): ContextPairRDDFunctions[C, K, V] = new ContextPairRDDFunctions(x)
 }


### PR DESCRIPTION
cc: @cseed

Adds coalesce and shuffle. They're not particularly interesting. I just implemented them in terms of the underlying RDD. They use `run` which demarcates the end of a memory-lifetime. The end of a memory-lifetime means, if regions were off-heap, I could free the region. When RegionValues become non-serializable, I'll have to come back here and add serialize/deserialize steps. I'll probably do that at the RVD level (since that's where serialization and deserialization are meaningful concepts).