### PR TITLE
change schema of block matrix's entries table to all optional types

### DIFF
--- a/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -613,7 +613,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
 
 
   def entriesTable(hc: HailContext): Table = {
-    val rvRowType = TStruct("i" -> TInt64Required, "j" -> TInt64Required, "entry" -> TFloat64Required)
+    val rvRowType = TStruct("i" -> TInt64Optional, "j" -> TInt64Optional, "entry" -> TFloat64Optional)
     val entriesRDD = blocks.flatMap { case ((blockRow, blockCol), block) =>
       val rowOffset = blockRow * blockSize.toLong
       val colOffset = blockCol * blockSize.toLong

--- a/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
@@ -8,7 +8,7 @@ import is.hail.check.Prop._
 import is.hail.check.Gen._
 import is.hail.check._
 import is.hail.linalg.BlockMatrix.ops._
-import is.hail.expr.types.{TFloat64Required, TInt64Required, TStruct}
+import is.hail.expr.types._
 import is.hail.utils._
 import org.testng.annotations.Test
 
@@ -776,7 +776,7 @@ class BlockMatrixSuite extends SparkSuite {
     val data = (0 until 90).map(_.toDouble).toArray
     val lm = new BDM[Double](9, 10, data)
     val expectedEntries = data.map(x => ((x % 9).toLong, (x / 9).toLong, x)).toSet
-    val expectedSignature = TStruct("i" -> TInt64Required, "j" -> TInt64Required, "entry" -> TFloat64Required)
+    val expectedSignature = TStruct("i" -> TInt64Optional, "j" -> TInt64Optional, "entry" -> TFloat64Optional)
 
     for {blockSize <- Seq(1, 4, 10)} {
       val entriesTable = toBM(lm, blockSize).entriesTable(hc)


### PR DESCRIPTION
* change schema of block matrix's entries table to all optional types

The entriesTable method I wrote for block matrix has a row schema with required types. Due to an issue with joins when requiredness doesn't match, I can't easily join this table with other tables unless I change the schema. I'd like to be able to join this table with other tables for LD Prune, so I'd like to change the schema to get rid of the requiredness.