### PR TITLE
linear_regression ys => y, return scalar annotations when y is not list

### DIFF
--- a/python/hail/docs/tutorials/01-genome-wide-association-study.ipynb
+++ b/python/hail/docs/tutorials/01-genome-wide-association-study.ipynb
@@ -787,7 +787,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gwas = hl.linear_regression(ys=common_ds.CaffeineConsumption, x=common_ds.GT.n_alt_alleles())\n",
+    "gwas = hl.linear_regression(y=common_ds.CaffeineConsumption, x=common_ds.GT.n_alt_alleles())\n",
     "gwas.row.describe()"
    ]
   },
@@ -830,7 +830,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qqplot(gwas.linreg.p_value[0].collect())"
+    "qqplot(gwas.linreg.p_value.collect())"
    ]
   },
   {
@@ -928,10 +928,10 @@
     "cds = common_ds.annotate_cols(pca = pca_scores[common_ds.s])\n",
     "\n",
     "linear_regression_results = hl.linear_regression(\n",
-    "    ys=cds.CaffeineConsumption, x=cds.GT.n_alt_alleles(),\n",
+    "    y=cds.CaffeineConsumption, x=cds.GT.n_alt_alleles(),\n",
     "    covariates=[cds.isFemale, cds.pca.scores[0], cds.pca.scores[1], cds.pca.scores[2]])\n",
     "\n",
-    "pvals = linear_regression_results.linreg.p_value[0].collect()"
+    "pvals = linear_regression_results.linreg.p_value.collect()"
    ]
   },
   {
@@ -972,10 +972,10 @@
    "outputs": [],
    "source": [
     "linear_regression_results = hl.linear_regression(\n",
-    "    ys=cds.CaffeineConsumption, x=plDosage(cds.PL),\n",
+    "    y=cds.CaffeineConsumption, x=plDosage(cds.PL),\n",
     "    covariates=[cds.isFemale, cds.pca.scores[0], cds.pca.scores[1], cds.pca.scores[2]])\n",
     "\n",
-    "pvals = linear_regression_results.linreg.p_value[0].collect()"
+    "pvals = linear_regression_results.linreg.p_value.collect()"
    ]
   },
   {
@@ -1100,9 +1100,9 @@
     "\n",
     "cds = common_ds.annotate_cols(pca = pca_scores[common_ds.s])\n",
     "linear_regression_results = hl.linear_regression(\n",
-    "    ys=cds.CaffeineConsumption, x=cds.GT.n_alt_alleles(),\n",
+    "    y=cds.CaffeineConsumption, x=cds.GT.n_alt_alleles(),\n",
     "    covariates=[cds.isFemale, cds.pca.scores[0], cds.pca.scores[1], cds.pca.scores[2]])\n",
-    "pvals = linear_regression_results.linreg.p_value[0].collect()"
+    "pvals = linear_regression_results.linreg.p_value.collect()"
    ]
   },
   {

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -321,8 +321,6 @@ def linear_regression(y, x, covariates=[], root='linreg', block_size=16) -> Matr
 
     y_is_list = isinstance(y, list)
 
-    print(y, y_is_list)
-
     all_exprs = []
     y = wrap_to_list(y)
     for e in y:

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -229,19 +229,20 @@ def impute_sex(call, aaf_threshold=0.0, include_par=False, female_threshold=0.2,
     return kt
 
 
-@typecheck(ys=oneof(expr_float64, sequenceof(expr_float64)),
+@typecheck(y=oneof(expr_float64, sequenceof(expr_float64)),
            x=expr_float64,
            covariates=sequenceof(expr_float64),
            root=str,
            block_size=int)
-def linear_regression(ys, x, covariates=[], root='linreg', block_size=16) -> MatrixTable:
+def linear_regression(y, x, covariates=[], root='linreg', block_size=16) -> MatrixTable:
     """For each row, test an input variable for association with
     response variables using linear regression.
 
     Examples
     --------
 
-    >>> dataset_result = hl.linear_regression(ys=dataset.pheno.height, x=dataset.GT.n_alt_alleles(),
+    >>> dataset_result = hl.linear_regression(y=dataset.pheno.height,
+    ...                                       x=dataset.GT.n_alt_alleles(),
     ...                                       covariates=[dataset.pheno.age, dataset.pheno.is_female])
 
     Warning
@@ -253,22 +254,24 @@ def linear_regression(ys, x, covariates=[], root='linreg', block_size=16) -> Mat
 
     Notes
     -----
-    With the default root, the following row-indexed fields are added. The
-    indexing of the array fields corresponds to that of `ys`.
+    With the default root and `y` a single expression, the following row-indexed
+    fields are added.
 
-    - **linreg.n_complete_samples** (:py:data:`.tint32`) -- Number of columns used.
+    - **linreg.n** (:py:data:`.tint32`) -- Number of columns used.
     - **linreg.sum_x** (:py:data:`.tfloat64`) -- Sum of input values `x`.
-    - **linreg.y_transpose_x** (:class:`.tarray` of :py:data:`.tfloat64`) -- Array of
-      dot products of each response vector `y` with the input vector `x`.
-    - **linreg.beta** (:class:`.tarray` of :py:data:`.tfloat64`) -- Array of
-      fit effect coefficients of `x`, :math:`\hat\\beta_1` below.
-    - **linreg.standard_error** (:class:`.tarray` of :py:data:`.tfloat64`) -- Array of
-      estimated standard errors, :math:`\widehat{\mathrm{se}}_1`.
-    - **linreg.t_stat** (:class:`.tarray` of :py:data:`.tfloat64`) -- Array
-      of :math:`t`-statistics, equal to
+    - **linreg.y_transpose_x** (:py:data:`.tfloat64`) -- Dot product of response
+      vector `y` with the input vector `x`.
+    - **linreg.beta** (:py:data:`.tfloat64`) --
+      Fit effect coefficient of `x`, :math:`\hat\\beta_1` below.
+    - **linreg.standard_error** (:py:data:`.tfloat64`) --
+      Estimated standard error, :math:`\widehat{\mathrm{se}}_1`.
+    - **linreg.t_stat** (:py:data:`.tfloat64`) -- :math:`t`-statistic, equal to
       :math:`\hat\\beta_1 / \widehat{\mathrm{se}}_1`.
-    - **linreg.p_value** (:class:`.tarray` of :py:data:`.tfloat64`) -- array
-      of :math:`p`-values.
+    - **linreg.p_value** (:py:data:`.tfloat64`) -- :math:`p`-value.
+
+    If `y` is a list of expressions, then the last five fields instead have type
+    :py:data:`.tarray` of :py:data:`.tfloat64`, with corresponding indexing of
+    the list and each array.
 
     In the statistical genetics example above, the input variable `x` encodes
     genotype as the number of alternate alleles (0, 1, or 2). For each variant
@@ -296,7 +299,7 @@ def linear_regression(ys, x, covariates=[], root='linreg', block_size=16) -> Mat
 
     Parameters
     ----------
-    ys : :class:`.Float64Expression` or :obj:`list` of :class:`.Float64Expression`
+    y : :class:`.Float64Expression` or :obj:`list` of :class:`.Float64Expression`
         One or more column-indexed response expressions.
     x : :class:`.Float64Expression`
         Entry-indexed expression for input variable.
@@ -316,11 +319,15 @@ def linear_regression(ys, x, covariates=[], root='linreg', block_size=16) -> Mat
     mt = matrix_table_source('linear_regression/x', x)
     check_entry_indexed('linear_regression/x', x)
 
+    y_is_list = isinstance(y, list)
+
+    print(y, y_is_list)
+
     all_exprs = []
-    ys = wrap_to_list(ys)
-    for e in ys:
+    y = wrap_to_list(y)
+    for e in y:
         all_exprs.append(e)
-        analyze('linear_regression/ys', e, mt._col_indices)
+        analyze('linear_regression/y', e, mt._col_indices)
     for e in covariates:
         all_exprs.append(e)
         analyze('linear_regression/covariates', e, mt._col_indices)
@@ -337,14 +344,22 @@ def linear_regression(ys, x, covariates=[], root='linreg', block_size=16) -> Mat
     base, cleanup = mt._process_joins(*all_exprs)
 
     jm = base._jvds.linreg(
-        jarray(Env.jvm().java.lang.String, [y._ast.to_hql() for y in ys]),
+        jarray(Env.jvm().java.lang.String, [yi._ast.to_hql() for yi in y]),
         x_field,
         jarray(Env.jvm().java.lang.String, [cov._ast.to_hql() for cov in covariates]),
         root,
         block_size
     )
 
-    return cleanup(MatrixTable(jm)).drop(*fields_to_drop)
+    mt_result = cleanup(MatrixTable(jm)).drop(*fields_to_drop)
+
+    if not y_is_list:
+        fields = ['y_transpose_x', 'beta', 'standard_error', 't_stat', 'p_value']
+        linreg = mt_result[root]
+        mt_result = mt_result.annotate_rows(
+            **{root: linreg.annotate(**{f: linreg[f][0] for f in fields})})
+
+    return mt_result
 
 
 @typecheck(test=enumeration('wald', 'lrt', 'score', 'firth'),

--- a/src/main/scala/is/hail/methods/LinearRegression.scala
+++ b/src/main/scala/is/hail/methods/LinearRegression.scala
@@ -11,8 +11,8 @@ import net.sourceforge.jdistlib.T
 
 object LinearRegression {
   def schema = TStruct(
-    ("n_complete_samples", TInt32()),
-    ("AC", TFloat64()),
+    ("n", TInt32()),
+    ("sum_x", TFloat64()),
     ("y_transpose_x", TArray(TFloat64())),
     ("beta", TArray(TFloat64())),
     ("standard_error", TArray(TFloat64())),
@@ -20,10 +20,10 @@ object LinearRegression {
     ("p_value", TArray(TFloat64())))
 
   def apply(vsm: MatrixTable,
-    ysExpr: Array[String], xField: String, covExpr: Array[String], root: String, rowBlockSize: Int
+    yExpr: Array[String], xField: String, covExpr: Array[String], root: String, rowBlockSize: Int
   ): MatrixTable = {
 
-    val (y, cov, completeColIdx) = RegressionUtils.getPhenosCovCompleteSamples(vsm, ysExpr, covExpr)
+    val (y, cov, completeColIdx) = RegressionUtils.getPhenosCovCompleteSamples(vsm, yExpr, covExpr)
 
     val n = y.rows // n_complete_samples
     val k = cov.cols // nCovariates

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -2479,8 +2479,8 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     hadoopConf.writeTextFile(path + "/_SUCCESS")(out => ())
   }
 
-  def linreg(ysExpr: Array[String], xField: String, covExpr: Array[String] = Array.empty[String], root: String = "linreg", rowBlockSize: Int = 16): MatrixTable = {
-    LinearRegression(this, ysExpr, xField, covExpr, root, rowBlockSize)
+  def linreg(yExpr: Array[String], xField: String, covExpr: Array[String] = Array.empty[String], root: String = "linreg", rowBlockSize: Int = 16): MatrixTable = {
+    LinearRegression(this, yExpr, xField, covExpr, root, rowBlockSize)
   }
 
   def logreg(test: String,


### PR DESCRIPTION
- changed behavior of `linear_regression` to parallel that of the other stats method when an expression is passed for `y`. When `y` is a list of expressions (even a list of one expression), the the five phenotype-dependent annotations are still array of float64.
- expanded `test_linreg` to test that all the interfaces work as expected
- changed `n_complete_samples` to just `n` since we may introduce an option to subset rather than impute per variant (which would cause n to change per variant) and I don't want to overload the notion of complete_sample to depend on the mode. I also think `n` is clear in linear regression context as the number of data points used, and in any case it's documented as the number of columns used.
- fixed a bug whereby `sum_x` was still `AC` on the Scala side.