### PR TITLE
wrap more things in their own methods to get around function size limits

### DIFF
--- a/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -150,7 +150,7 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: Type, var
       case t: TBaseStruct =>
         staticIdx += 1
         if (staticIdx < t.size)
-          elementsOffset := startOffset + t.byteOffsets(staticIdx)
+          elementsOffset := elementsOffset + (t.byteOffsets(staticIdx) - t.byteOffsets(staticIdx - 1))
         else _empty
     }
   }

--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -647,7 +647,7 @@ trait Settable[T] {
   def :=(rhs: Code[T]): Code[Unit] = store(rhs)
 }
 
-class ClassFieldRef[T](fb: FunctionBuilder[_], name: String)(implicit tti: TypeInfo[T]) extends Settable[T] {
+class ClassFieldRef[T: TypeInfo](fb: FunctionBuilder[_], name: String) extends Settable[T] {
   val desc: String = typeInfo[T].name
   val node: FieldNode = new FieldNode(ACC_PUBLIC, name, desc, null, null)
 

--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -647,7 +647,7 @@ trait Settable[T] {
   def :=(rhs: Code[T]): Code[Unit] = store(rhs)
 }
 
-class ClassFieldRef[T: TypeInfo](fb: FunctionBuilder[_], name: String) extends Settable[T] {
+class ClassFieldRef[T](fb: FunctionBuilder[_], name: String)(implicit tti: TypeInfo[T]) extends Settable[T] {
   val desc: String = typeInfo[T].name
   val node: FieldNode = new FieldNode(ACC_PUBLIC, name, desc, null, null)
 

--- a/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -95,7 +95,7 @@ class MethodBuilder(val fb: FunctionBuilder[_], val mname: String, val parameter
   def newLocal[T](name: String = null)(implicit tti: TypeInfo[T]): LocalRef[T] =
     new LocalRef[T](allocLocal[T](name))
 
-  def newField[T: TypeInfo](implicit tti: TypeInfo[T]): ClassFieldRef[T] = newField[T]()
+  def newField[T](implicit tti: TypeInfo[T]): ClassFieldRef[T] = newField[T]()(tti)
 
   def newField[T](name: String = null)(implicit tti: TypeInfo[T]): ClassFieldRef[T] = fb.newField[T](name)
 

--- a/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -217,7 +217,7 @@ class FunctionBuilder[F >: Null](parameterTypeInfo: Array[MaybeGenericTypeInfo[_
   def newField[T](implicit tti: TypeInfo[T]): ClassFieldRef[T] = newField()
 
   def newField[T](name: String = null)(implicit tti: TypeInfo[T]): ClassFieldRef[T] =
-    new ClassFieldRef[T](this, if (name == null) s"field${cn.fields.size()}" else name)
+    new ClassFieldRef[T](this, s"field${cn.fields.size()}${ if (name == null) "" else s"_$name" }")
 
   def allocLocal[T](name: String = null)(implicit tti: TypeInfo[T]): Int = apply_method.allocLocal[T](name)
 

--- a/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -61,7 +61,7 @@ object FunctionBuilder {
     new FunctionBuilder(Array(GenericTypeInfo[A], GenericTypeInfo[B], GenericTypeInfo[C], GenericTypeInfo[D], GenericTypeInfo[E], GenericTypeInfo[F], GenericTypeInfo[G]), GenericTypeInfo[R])
 }
 
-class MethodBuilder(val fb: FunctionBuilder[_], mname: String, parameterTypeInfo: Array[TypeInfo[_]], returnTypeInfo: TypeInfo[_]) {
+class MethodBuilder(val fb: FunctionBuilder[_], val mname: String, val parameterTypeInfo: Array[TypeInfo[_]], val returnTypeInfo: TypeInfo[_]) {
 
   def descriptor: String = s"(${ parameterTypeInfo.map(_.name).mkString })${ returnTypeInfo.name }"
 
@@ -73,6 +73,7 @@ class MethodBuilder(val fb: FunctionBuilder[_], mname: String, parameterTypeInfo
   val layout: Array[Int] = 0 +: (parameterTypeInfo.scanLeft(1) { case (prev, gti) => prev + gti.slots })
   val argIndex: Array[Int] = layout.init
   var locals: Int = layout.last
+  private val localBitSet = new LocalBitSet(this)
 
   def allocLocal[T](name: String = null)(implicit tti: TypeInfo[T]): Int = {
     val i = locals
@@ -84,15 +85,19 @@ class MethodBuilder(val fb: FunctionBuilder[_], mname: String, parameterTypeInfo
     i
   }
 
+  def newLocalBit(): SettableBit = localBitSet.newBit()
+
+  def newClassBit(): SettableBit = fb.classBitSet.newBit(this)
+
   def newLocal[T](implicit tti: TypeInfo[T]): LocalRef[T] =
     newLocal()
 
   def newLocal[T](name: String = null)(implicit tti: TypeInfo[T]): LocalRef[T] =
     new LocalRef[T](allocLocal[T](name))
 
-  def newField[T: TypeInfo]: ClassFieldRef[T] = newField[T]()
+  def newField[T: TypeInfo](implicit tti: TypeInfo[T]): ClassFieldRef[T] = newField[T]()
 
-  def newField[T: TypeInfo](name: String = null): ClassFieldRef[T] = fb.newField[T](name)
+  def newField[T](name: String = null)(implicit tti: TypeInfo[T]): ClassFieldRef[T] = fb.newField[T](name)
 
   def getArg[T](i: Int)(implicit tti: TypeInfo[T]): LocalRef[T] = {
     assert(i >= 0)
@@ -203,9 +208,15 @@ class FunctionBuilder[F >: Null](parameterTypeInfo: Array[MaybeGenericTypeInfo[_
     )
   }
 
-  def newField[T: TypeInfo]: ClassFieldRef[T] = newField()
+  val classBitSet = new ClassBitSet(this)
 
-  def newField[T: TypeInfo](name: String = null): ClassFieldRef[T] =
+  def newLocalBit(): SettableBit = apply_method.newLocalBit()
+
+  def newClassBit(): SettableBit = classBitSet.newBit(apply_method)
+
+  def newField[T](implicit tti: TypeInfo[T]): ClassFieldRef[T] = newField()
+
+  def newField[T](name: String = null)(implicit tti: TypeInfo[T]): ClassFieldRef[T] =
     new ClassFieldRef[T](this, if (name == null) s"field${cn.fields.size()}" else name)
 
   def allocLocal[T](name: String = null)(implicit tti: TypeInfo[T]): Int = apply_method.allocLocal[T](name)
@@ -232,7 +243,6 @@ class FunctionBuilder[F >: Null](parameterTypeInfo: Array[MaybeGenericTypeInfo[_
     mb
   }
 
-
   def newMethod[A: TypeInfo, R: TypeInfo] = {
     val mb = new Method1Builder[A, R](this, s"method${ methods.size }")
     methods.append(mb)
@@ -244,7 +254,6 @@ class FunctionBuilder[F >: Null](parameterTypeInfo: Array[MaybeGenericTypeInfo[_
     methods.append(mb)
     mb
   }
-
 
   def newMethod[A: TypeInfo, B: TypeInfo, C: TypeInfo, R: TypeInfo] = {
     val mb = new Method3Builder[A, B, C, R](this, s"method${ methods.size }")

--- a/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -95,9 +95,9 @@ class MethodBuilder(val fb: FunctionBuilder[_], val mname: String, val parameter
   def newLocal[T](name: String = null)(implicit tti: TypeInfo[T]): LocalRef[T] =
     new LocalRef[T](allocLocal[T](name))
 
-  def newField[T](implicit tti: TypeInfo[T]): ClassFieldRef[T] = newField[T]()(tti)
+  def newField[T: TypeInfo]: ClassFieldRef[T] = newField[T]()
 
-  def newField[T](name: String = null)(implicit tti: TypeInfo[T]): ClassFieldRef[T] = fb.newField[T](name)
+  def newField[T: TypeInfo](name: String = null): ClassFieldRef[T] = fb.newField[T](name)
 
   def getArg[T](i: Int)(implicit tti: TypeInfo[T]): LocalRef[T] = {
     assert(i >= 0)
@@ -214,9 +214,9 @@ class FunctionBuilder[F >: Null](parameterTypeInfo: Array[MaybeGenericTypeInfo[_
 
   def newClassBit(): SettableBit = classBitSet.newBit(apply_method)
 
-  def newField[T](implicit tti: TypeInfo[T]): ClassFieldRef[T] = newField()
+  def newField[T: TypeInfo]: ClassFieldRef[T] = newField()
 
-  def newField[T](name: String = null)(implicit tti: TypeInfo[T]): ClassFieldRef[T] =
+  def newField[T: TypeInfo](name: String = null): ClassFieldRef[T] =
     new ClassFieldRef[T](this, s"field${cn.fields.size()}${ if (name == null) "" else s"_$name" }")
 
   def allocLocal[T](name: String = null)(implicit tti: TypeInfo[T]): Int = apply_method.allocLocal[T](name)

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -251,7 +251,6 @@ private class Emit(
         EmitTriplet(codeA.setup, codeA.m, TContainer.loadLength(region, coerce[Long](codeA.v)))
 
       case _: ArrayMap | _: ArrayFilter | _: ArrayRange | _: ArrayFlatMap =>
-
         val elt = coerce[TArray](ir.typ).elementType
         val srvb = new StagedRegionValueBuilder(fb, ir.typ)
 

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -81,7 +81,7 @@ private class Emit(
       for (ir <- irs) yield {
         val EmitTriplet(setup, m, v) = emitWrapper.emit(ir, env)
         val missing = newMB.newClassBit()
-        val value = newMB.newField()(typeToTypeInfo(ir.typ))
+        val value = newMB.newField()(typeToTypeInfo(ir.typ)).asInstanceOf[Settable[Any]]
         mb.emit(setup)
         mb.emit(missing := m)
         mb.emit(value := missing.mux(defaultValue(ir.typ), v))

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -273,7 +273,7 @@ private class Emit(
             v.m.mux(srvb.setMissing(), addElement(v.v)),
             srvb.advance())
         }
-        present(Code(srvb.start(init = true), treeWrapToMethod(args, env)(addElts), srvb.offset))
+        present(Code(srvb.start(args.size, init = true), treeWrapToMethod(args, env)(addElts), srvb.offset))
 
       case ArrayRef(a, i, typ) =>
         val ti = typeToTypeInfo(typ)

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -71,7 +71,6 @@ private class Emit(
 
   def chunkIRs(irs: Seq[IR]): Array[Seq[IR]] = {
     val chunkBounds = getChunkBounds(irs.map(_.size * opSize))
-    println(chunkBounds.mkString(","))
     Array.tabulate(chunkBounds.length - 1)(i => irs.slice(chunkBounds(i), chunkBounds(i + 1)))
   }
 
@@ -80,13 +79,10 @@ private class Emit(
     val ab = new ArrayBuilder[Int]()
     ab += 0
     sizes.zipWithIndex.foreach { case (size, i) =>
-      if (total + size <= maxBytecodeSizeTarget)
+      if (total == 0 || total + size <= maxBytecodeSizeTarget)
         total += size
       else {
-        if (total == 0)
-          total += size
-        else
-          ab += i
+        ab += i
         total = 0
       }
     }
@@ -118,7 +114,6 @@ private class Emit(
         coerce[Unit](Code(code: _*))
       else {
         val chunkBounds = getChunkBounds(Array.fill(code.size)(opSize))
-        println(chunkBounds.mkString(","))
         val chunks = chunkBounds.zip(chunkBounds.tail).map { case (start, end) =>
           val c = code.slice(start, end)
           val newMB = mb.fb.newMethod(mb.parameterTypeInfo, typeInfo[Unit])

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -12,6 +12,13 @@ sealed trait IR extends BaseIR {
 
   override def copy(newChildren: IndexedSeq[BaseIR]): BaseIR =
     Copy(this, newChildren)
+
+  def size: Int = 1 + children.map {
+      case x: IR => x.size
+      case _ => 1
+    }.sum
+
+  def estimatedBytecode: Int = size * 20
 }
 
 object Literal {

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -17,8 +17,6 @@ sealed trait IR extends BaseIR {
       case x: IR => x.size
       case _ => 1
     }.sum
-
-  def estimatedBytecode: Int = size * 20
 }
 
 object Literal {

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -15,7 +15,7 @@ sealed trait IR extends BaseIR {
 
   def size: Int = 1 + children.map {
       case x: IR => x.size
-      case _ => 1
+      case _ => 0
     }.sum
 }
 

--- a/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
+++ b/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
@@ -7,7 +7,7 @@ class StagedArrayBuilder(elt: Type, mb: MethodBuilder) {
 
   val ti = typeToTypeInfo(elt)
 
-  val ref: LocalRef[Any] = coerce[Any](ti match {
+  val ref: Settable[Any] = coerce[Any](ti match {
     case BooleanInfo => mb.newLocal[BooleanArrayBuilder]("zab")
     case IntInfo => mb.newLocal[IntArrayBuilder]("iab")
     case LongInfo => mb.newLocal[LongArrayBuilder]("jab")

--- a/src/main/scala/is/hail/expr/ir/package.scala
+++ b/src/main/scala/is/hail/expr/ir/package.scala
@@ -38,7 +38,7 @@ package object ir {
 
   private[ir] def coerce[T](c: Code[_]): Code[T] = asm4s.coerce(c)
 
-  private[ir] def coerce[T](lr: Settable[_]): LocalRef[T] = lr.asInstanceOf[LocalRef[T]]
+  private[ir] def coerce[T](lr: Settable[_]): Settable[T] = lr.asInstanceOf[Settable[T]]
 
   private[ir] def coerce[T](ti: TypeInfo[_]): TypeInfo[T] = ti.asInstanceOf[TypeInfo[T]]
 

--- a/src/main/scala/is/hail/expr/ir/package.scala
+++ b/src/main/scala/is/hail/expr/ir/package.scala
@@ -38,7 +38,7 @@ package object ir {
 
   private[ir] def coerce[T](c: Code[_]): Code[T] = asm4s.coerce(c)
 
-  private[ir] def coerce[T](lr: LocalRef[_]): LocalRef[T] = lr.asInstanceOf[LocalRef[T]]
+  private[ir] def coerce[T](lr: Settable[_]): LocalRef[T] = lr.asInstanceOf[LocalRef[T]]
 
   private[ir] def coerce[T](ti: TypeInfo[_]): TypeInfo[T] = ti.asInstanceOf[TypeInfo[T]]
 

--- a/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
+++ b/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
@@ -381,7 +381,6 @@ class ASM4SSuite extends TestNGSuite {
   }
 
   @Test def checkClassFieldsFromMethod(): Unit = {
-
     def readField[T: TypeInfo](arg1: Int, arg2: Long, arg3: Boolean): T = {
       val fb = FunctionBuilder.functionBuilder[Int, Long, Boolean, T]
       val mb = fb.newMethod[Int, Long, Boolean, T]

--- a/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
+++ b/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
@@ -379,4 +379,32 @@ class ASM4SSuite extends TestNGSuite {
     assert(readField[Long](1, 2L, true) == 2L)
     assert(readField[Boolean](1, 2L, true))
   }
+
+  @Test def checkClassFieldsFromMethod(): Unit = {
+
+    def readField[T: TypeInfo](arg1: Int, arg2: Long, arg3: Boolean): T = {
+      val fb = FunctionBuilder.functionBuilder[Int, Long, Boolean, T]
+      val mb = fb.newMethod[Int, Long, Boolean, T]
+      val intField = fb.newField[Int]
+      val longField = fb.newField[Long]
+      val booleanField = fb.newField[Boolean]
+      val c = Code(
+        intField.store(fb.getArg[Int](1)),
+        longField.store(fb.getArg[Long](2)),
+        booleanField.store(fb.getArg[Boolean](3)))
+
+      typeInfo[T] match {
+        case IntInfo => mb.emit(Code(c, intField.load()))
+        case LongInfo => mb.emit(Code(c, longField.load()))
+        case BooleanInfo => mb.emit(Code(c, booleanField.load()))
+      }
+      fb.emit(mb.invoke(fb.getArg[Int](1), fb.getArg[Long](2), fb.getArg[Boolean](3)))
+      val f = fb.result()()
+      f(arg1, arg2, arg3)
+    }
+
+    assert(readField[Int](1, 2L, true) == 1)
+    assert(readField[Long](1, 2L, true) == 2L)
+    assert(readField[Boolean](1, 2L, true))
+  }
 }

--- a/src/test/scala/is/hail/asm4s/StagedBitSetSuite.scala
+++ b/src/test/scala/is/hail/asm4s/StagedBitSetSuite.scala
@@ -10,7 +10,7 @@ import is.hail.asm4s.FunctionBuilder._
 class StagedBitSetSuite extends TestNGSuite {
   def withOneBit(f : SettableBit => Code[Boolean]): Boolean = {
     val fb = functionBuilder[Boolean]
-    val bs = new StagedBitSet(fb)
+    val bs = new LocalBitSet(fb)
     val x = bs.newBit()
     fb.emit(f(x))
     fb.result()()()
@@ -18,7 +18,7 @@ class StagedBitSetSuite extends TestNGSuite {
 
   def withTwoBits(f : (SettableBit, SettableBit) => Code[Boolean]): Boolean = {
     val fb = functionBuilder[Boolean]
-    val bs = new StagedBitSet(fb)
+    val bs = new LocalBitSet(fb)
     val x = bs.newBit()
     val y = bs.newBit()
     fb.emit(f(x, y))
@@ -27,7 +27,7 @@ class StagedBitSetSuite extends TestNGSuite {
 
   def withNBits(n: Int)(f: Array[SettableBit] => Code[Boolean]): Boolean = {
     val fb = functionBuilder[Boolean]
-    val bs = new StagedBitSet(fb)
+    val bs = new LocalBitSet(fb)
     val x = Array.tabulate(n)(i => bs.newBit())
     fb.emit(f(x))
     fb.result()()()

--- a/src/test/scala/is/hail/expr/ir/CompileSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/CompileSuite.scala
@@ -591,14 +591,17 @@ class CompileSuite {
     val region = Region()
     val rvb = new RegionValueBuilder(region)
 
-    def testStructN(n: Int) {
+    def testStructN(n: Int, hardCoded: Boolean = false, print: Option[PrintWriter] = None) {
       val tin = TStruct((0 until n).map(i => s"field$i" -> TInt32()): _*)
       val in = In(0, tin)
-      val ir = MakeStruct((0 until n).map(i => s"foo$i" -> GetField(in, s"field$i")))
+      val ir = if (hardCoded)
+        MakeStruct((0 until n).map(i => s"foo$i" -> I32(n)))
+      else
+        MakeStruct((0 until n).map(i => s"foo$i" -> GetField(in, s"field$i")))
 
       val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Long]
       doit(ir, fb)
-      val f = fb.result()()
+      val f = fb.result(print)()
 
       region.clear()
       val input = Row(Array.fill(n)(n): _*)
@@ -613,7 +616,6 @@ class CompileSuite {
 
     testStructN(5)
     testStructN(5000)
-
-    // FIXME: testStructN(20000) hits the Class file size limit!
+    testStructN(20000, hardCoded=true)
   }
 }

--- a/src/test/scala/is/hail/expr/ir/CompileSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/CompileSuite.scala
@@ -16,7 +16,6 @@ import org.apache.spark.sql.Row
 class CompileSuite {
   def doit(ir: IR, fb: FunctionBuilder[_]) {
     Infer(ir)
-    println(ir)
     Emit(ir, fb)
   }
 
@@ -613,6 +612,8 @@ class CompileSuite {
     }
 
     testStructN(5)
-    testStructN(500)
+    testStructN(5000)
+
+    // FIXME: testStructN(20000) hits the Class file size limit!
   }
 }

--- a/src/test/scala/is/hail/expr/ir/CompileSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/CompileSuite.scala
@@ -613,5 +613,6 @@ class CompileSuite {
     }
 
     testStructN(5)
+    testStructN(500)
   }
 }


### PR DESCRIPTION
fyi @cseed 

All of the auxilliary methods have the same arguments as the original emitted function, to preserve the behavior of In and aggregator stuff without change.

Any IR that binds a new environment variable (`Let`, `Map`, etc.) now stores those values on a class field so that other methods don't have to worry about whether or not there exist such values in scope.

That's basically the only change I made to the structure of Emit; `MakeArray`, `MakeStruct`, and `MakeTuple` now check how big their fields/elements are. I'm a little worried we'll start hitting the class size limit; turning up one of the tests really far already hits it.