### PR TITLE
ContextRDD Write Rows

### DIFF
--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -41,7 +41,7 @@ case class MatrixValue(
 
   def sparkContext: SparkContext = rvd.sparkContext
 
-  def nPartitions: Int = rvd.partitions.length
+  def nPartitions: Int = rvd.getNumPartitions
 
   def nCols: Int = colValues.value.length
 

--- a/src/main/scala/is/hail/io/RowStore.scala
+++ b/src/main/scala/is/hail/io/RowStore.scala
@@ -5,6 +5,7 @@ import is.hail.expr.JSONAnnotationImpex
 import is.hail.expr.types._
 import is.hail.io.compress.LZ4Utils
 import is.hail.rvd.{OrderedRVDPartitioner, OrderedRVDSpec, RVDSpec, UnpartitionedRVDSpec}
+import is.hail.sparkextras.ContextRDD
 import is.hail.utils._
 import org.apache.spark.rdd.RDD
 import org.json4s.{Extraction, JValue}
@@ -710,7 +711,7 @@ final class PackEncoder(out: OutputBuffer) extends Encoder {
   }
 }
 
-object RichRDDRegionValue {
+object RichContextRDDRegionValue {
   def writeRowsPartition(t: TStruct, codecSpec: CodecSpec)(i: Int, it: Iterator[RegionValue], os: OutputStream): Long = {
     val en = codecSpec.buildEncoder(os)
     var rowCount = 0L
@@ -729,13 +730,13 @@ object RichRDDRegionValue {
   }
 }
 
-class RichRDDRegionValue(val rdd: RDD[RegionValue]) extends AnyVal {
+class RichContextRDDRegionValue[C <: AutoCloseable](val crdd: ContextRDD[C, RegionValue]) extends AnyVal {
   def writeRows(path: String, t: TStruct, codecSpec: CodecSpec): (Array[String], Array[Long]) = {
-    rdd.writePartitions(path, RichRDDRegionValue.writeRowsPartition(t, codecSpec))
+    crdd.writePartitions(path, RichContextRDDRegionValue.writeRowsPartition(t, codecSpec))
   }
 
   def writeRowsSplit(path: String, t: MatrixType, codecSpec: CodecSpec, partitioner: OrderedRVDPartitioner): Array[Long] = {
-    val sc = rdd.sparkContext
+    val sc = crdd.sparkContext
     val hConf = sc.hadoopConfiguration
 
     hConf.mkDir(path + "/rows/rows/parts")
@@ -743,7 +744,7 @@ class RichRDDRegionValue(val rdd: RDD[RegionValue]) extends AnyVal {
 
     val sHConfBc = sc.broadcast(new SerializableHadoopConfiguration(hConf))
 
-    val nPartitions = rdd.getNumPartitions
+    val nPartitions = crdd.getNumPartitions
     val d = digitsNeeded(nPartitions)
 
     val fullRowType = t.rvRowType
@@ -753,7 +754,7 @@ class RichRDDRegionValue(val rdd: RDD[RegionValue]) extends AnyVal {
     val entriesRVType = TStruct(
       MatrixType.entriesIdentifier -> TArray(t.entryType))
 
-    val partFilePartitionCounts = rdd.mapPartitionsWithIndex { case (i, it) =>
+    val partFilePartitionCounts = crdd.mapPartitionsWithIndex { case (i, it) =>
       val hConf = sHConfBc.value.value
 
       val f = partFile(d, i, TaskContext.get)
@@ -802,8 +803,7 @@ class RichRDDRegionValue(val rdd: RDD[RegionValue]) extends AnyVal {
           }
         }
       }
-    }
-      .collect()
+    }.run.collect()
 
     val (partFiles, partitionCounts) = partFilePartitionCounts.unzip
 

--- a/src/main/scala/is/hail/io/RowStore.scala
+++ b/src/main/scala/is/hail/io/RowStore.scala
@@ -803,7 +803,7 @@ class RichContextRDDRegionValue[C <: AutoCloseable](val crdd: ContextRDD[C, Regi
           }
         }
       }
-    }.run.collect()
+    }.collect()
 
     val (partFiles, partitionCounts) = partFilePartitionCounts.unzip
 

--- a/src/main/scala/is/hail/methods/LDPrune.scala
+++ b/src/main/scala/is/hail/methods/LDPrune.scala
@@ -292,7 +292,7 @@ object LDPrune {
 
     val partitioner = inputRDD.partitioner
     val rangeBounds = partitioner.rangeBounds
-    val nPartitions = inputRDD.partitions.length
+    val nPartitions = inputRDD.getNumPartitions
 
     val localRowType = inputRDD.typ.rowType
 
@@ -469,7 +469,7 @@ object LDPrune {
     val ((rddLP1, nVariantsLP1, nPartitionsLP1), durationLP1) = time({
       val prunedRDD = pruneLocal(standardizedRDD, r2Threshold, windowSize, Option(maxQueueSize)).persist(StorageLevel.MEMORY_AND_DISK)
       val nVariantsKept = prunedRDD.count()
-      val nPartitions = prunedRDD.partitions.length
+      val nPartitions = prunedRDD.getNumPartitions
       assert(nVariantsKept >= 1)
       (prunedRDD, nVariantsKept, nPartitions)
     })
@@ -482,7 +482,7 @@ object LDPrune {
       rddLP1.unpersist()
       val prunedRDD = pruneLocal(repartRDD, r2Threshold, windowSize, None).persist(StorageLevel.MEMORY_AND_DISK)
       val nVariantsKept = prunedRDD.count()
-      val nPartitions = prunedRDD.partitions.length
+      val nPartitions = prunedRDD.getNumPartitions
       assert(nVariantsKept >= 1)
       repartRDD.unpersist()
       (prunedRDD, nVariantsKept, nPartitions)

--- a/src/main/scala/is/hail/methods/SampleQC.scala
+++ b/src/main/scala/is/hail/methods/SampleQC.scala
@@ -165,7 +165,7 @@ object SampleQC {
     val rvRowType = vsm.rvRowType
     val localEntriesIndex = vsm.entriesIndex
     val nSamples = vsm.numCols
-    if (vsm.rvd.partitions.nonEmpty)
+    if (vsm.rvd.getNumPartitions > 0)
       vsm.rvd
         .mapPartitions { it =>
           val view = HTSGenotypeView(rvRowType)

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -475,7 +475,7 @@ object OrderedRVD {
         Iterator(OrderedRVPartitionInfo(localType, samplesPerPartition, i, it, partitionSeed(i)))
       else
         Iterator()
-    }.run.collect()
+    }.collect()
 
     pkis.sortBy(_.min)(typ.pkType.ordering.toOrdering)
   }

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -238,7 +238,7 @@ class OrderedRVD(
       intervalsBc.value.contains(pkOrdering, pk)
     }
 
-    val nPartitions = partitions.length
+    val nPartitions = getNumPartitions
     if (nPartitions <= 1)
       return filter(pred)
 

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -355,16 +355,14 @@ class OrderedRVD(
     OrderedRVD(typ, newPartitioner, rdd.subsetPartitions(keep))
   }
 
-  def write(path: String, codecSpec: CodecSpec): Array[Long] = {
-    val (partFiles, partitionCounts) = rdd.writeRows(path, rowType, codecSpec)
-    val spec = OrderedRVDSpec(
+  override protected def rvdSpec(codecSpec: CodecSpec, partFiles: Array[String]): RVDSpec =
+    OrderedRVDSpec(
       typ,
       codecSpec,
       partFiles,
-      JSONAnnotationImpex.exportAnnotation(partitioner.rangeBounds, partitioner.rangeBoundsType))
-    spec.write(sparkContext.hadoopConfiguration, path)
-    partitionCounts
-  }
+      JSONAnnotationImpex.exportAnnotation(
+        partitioner.rangeBounds,
+        partitioner.rangeBoundsType))
 
   def zipPartitionsPreservesPartitioning[T: ClassTag](
     newTyp: OrderedRVDType,
@@ -390,7 +388,7 @@ class OrderedRVD(
     path: String,
     t: MatrixType,
     codecSpec: CodecSpec
-  ): Array[Long] = rdd.writeRowsSplit(path, t, codecSpec, partitioner)
+  ): Array[Long] = crdd.writeRowsSplit(path, t, codecSpec, partitioner)
 }
 
 object OrderedRVD {

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -151,16 +151,13 @@ trait RVD {
       it.map { rv => f(c, rv) }
     })
 
-  // FIXME: just make user call run
   def map[T](f: (RegionValue) => T)(implicit tct: ClassTag[T]): RDD[T] = crdd.map(f).run
 
   def mapPartitions(newRowType: TStruct)(f: (Iterator[RegionValue]) => Iterator[RegionValue]): RVD =
     new UnpartitionedRVD(newRowType, crdd.mapPartitions(f))
 
-  // FIXME: just make user call run
   def mapPartitionsWithIndex[T](f: (Int, Iterator[RegionValue]) => Iterator[T])(implicit tct: ClassTag[T]): RDD[T] = crdd.mapPartitionsWithIndex(f).run
 
-  // FIXME: just make user call run
   def mapPartitions[T](f: (Iterator[RegionValue]) => Iterator[T])(implicit tct: ClassTag[T]): RDD[T] = crdd.mapPartitions(f).run
 
   def constrainToOrderedPartitioner(

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -138,8 +138,6 @@ trait RVD {
 
   def getNumPartitions: Int = crdd.getNumPartitions
 
-  def partitions: Array[Partition] = crdd.partitions
-
   def filter(f: (RegionValue) => Boolean): RVD
 
   def map(newRowType: TStruct)(f: (RegionValue) => RegionValue): UnpartitionedRVD =

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -151,14 +151,14 @@ trait RVD {
       it.map { rv => f(c, rv) }
     })
 
-  def map[T](f: (RegionValue) => T)(implicit tct: ClassTag[T]): RDD[T] = crdd.map(f).run
+  def map[T](f: (RegionValue) => T)(implicit tct: ClassTag[T]): RDD[T] = rdd.map(f)
 
   def mapPartitions(newRowType: TStruct)(f: (Iterator[RegionValue]) => Iterator[RegionValue]): RVD =
     new UnpartitionedRVD(newRowType, crdd.mapPartitions(f))
 
-  def mapPartitionsWithIndex[T](f: (Int, Iterator[RegionValue]) => Iterator[T])(implicit tct: ClassTag[T]): RDD[T] = crdd.mapPartitionsWithIndex(f).run
+  def mapPartitionsWithIndex[T](f: (Int, Iterator[RegionValue]) => Iterator[T])(implicit tct: ClassTag[T]): RDD[T] = rdd.mapPartitionsWithIndex(f)
 
-  def mapPartitions[T](f: (Iterator[RegionValue]) => Iterator[T])(implicit tct: ClassTag[T]): RDD[T] = crdd.mapPartitions(f).run
+  def mapPartitions[T](f: (Iterator[RegionValue]) => Iterator[T])(implicit tct: ClassTag[T]): RDD[T] = rdd.mapPartitions(f)
 
   def constrainToOrderedPartitioner(
     ordType: OrderedRVDType,

--- a/src/main/scala/is/hail/rvd/UnpartitionedRVD.scala
+++ b/src/main/scala/is/hail/rvd/UnpartitionedRVD.scala
@@ -48,12 +48,8 @@ class UnpartitionedRVD(val rowType: TStruct, val crdd: ContextRDD[RVDContext, Re
   def sample(withReplacement: Boolean, p: Double, seed: Long): UnpartitionedRVD =
     new UnpartitionedRVD(rowType, crdd.sample(withReplacement, p, seed))
 
-  def write(path: String, codecSpec: CodecSpec): Array[Long] = {
-    val (partFiles, partitionCounts) = rdd.writeRows(path, rowType, codecSpec)
-    val spec = UnpartitionedRVDSpec(rowType, codecSpec, partFiles)
-    spec.write(sparkContext.hadoopConfiguration, path)
-    partitionCounts
-  }
+  override protected def rvdSpec(codecSpec: CodecSpec, partFiles: Array[String]): RVDSpec =
+    UnpartitionedRVDSpec(rowType, codecSpec, partFiles)
 
   def coalesce(maxPartitions: Int, shuffle: Boolean): UnpartitionedRVD =
     new UnpartitionedRVD(rowType, crdd.coalesce(maxPartitions, shuffle = shuffle))

--- a/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -60,7 +60,7 @@ object ContextRDD {
     def apply[T: ClassTag](
       rdd: RDD[T]
     )(implicit c: Pointed[C]
-     ): ContextRDD[C, T] = weaken(rdd, c.point _)
+    ): ContextRDD[C, T] = weaken(rdd, c.point _)
   }
   private[this] object weakenInstance extends Weaken[Nothing]
   def weaken[C <: AutoCloseable] = weakenInstance.asInstanceOf[Weaken[C]]

--- a/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -91,6 +91,9 @@ class ContextRDD[C <: AutoCloseable, T: ClassTag](
 ) extends Serializable {
   type ElementType = ContextRDD.ElementType[C, T]
 
+  def collect(): Array[T] =
+    run.collect()
+
   def run[U >: T : ClassTag]: RDD[U] =
     rdd.mapPartitions { part => using(mkc()) { cc => part.flatMap(_(cc)) } }
 

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -288,7 +288,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
 
   def nKeys: Int = key.length
 
-  def nPartitions: Int = rvd.partitions.length
+  def nPartitions: Int = rvd.getNumPartitions
 
   def keySignature: TStruct = {
     val (t, _) = signature.select(key.toArray)

--- a/src/main/scala/is/hail/utils/richUtils/Implicits.scala
+++ b/src/main/scala/is/hail/utils/richUtils/Implicits.scala
@@ -3,9 +3,9 @@ package is.hail.utils.richUtils
 import java.io.InputStream
 
 import breeze.linalg.DenseMatrix
-import is.hail.annotations.{Region, RegionValue, JoinedRegionValue}
+import is.hail.annotations.{JoinedRegionValue, Region, RegionValue}
 import is.hail.asm4s.Code
-import is.hail.io.RichRDDRegionValue
+import is.hail.io.{RichContextRDDRegionValue}
 import is.hail.sparkextras._
 import is.hail.utils.{ArrayBuilder, HailIterator, JSONWriter, MultiArray2, Truncatable, WithContext}
 import org.apache.hadoop
@@ -83,7 +83,7 @@ trait Implicits {
 
   implicit def toRichRDD[T](r: RDD[T])(implicit tct: ClassTag[T]): RichRDD[T] = new RichRDD(r)
 
-  implicit def toRichRDDRegionValue(r: RDD[RegionValue]): RichRDDRegionValue = new RichRDDRegionValue(r)
+  implicit def toRichContextRDDRegionValue[C <: AutoCloseable](r: ContextRDD[C, RegionValue]): RichContextRDDRegionValue[C] = new RichContextRDDRegionValue(r)
 
   implicit def toRichRDDByteArray(r: RDD[Array[Byte]]): RichRDDByteArray = new RichRDDByteArray(r)
 
@@ -124,4 +124,6 @@ trait Implicits {
   implicit def toRichPartialKleisliOptionFunction[A, B](x: PartialFunction[A, Option[B]]): RichPartialKleisliOptionFunction[A, B] = new RichPartialKleisliOptionFunction(x)
 
   implicit def toContextPairRDDFunctions[C <: AutoCloseable, K: ClassTag, V: ClassTag](x: ContextRDD[C, (K, V)]): ContextPairRDDFunctions[C, K, V] = new ContextPairRDDFunctions(x)
+
+  implicit def toRichContextRDD[C <: AutoCloseable, T: ClassTag](x: ContextRDD[C, T]): RichContextRDD[C, T] = new RichContextRDD(x)
 }

--- a/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
@@ -1,0 +1,54 @@
+package is.hail.utils.richUtils
+
+import java.io._
+
+import org.apache.commons.lang3.StringUtils
+import is.hail.utils._
+import is.hail.sparkextras._
+
+import scala.reflect.ClassTag
+
+class RichContextRDD[C <: AutoCloseable, T: ClassTag](crdd: ContextRDD[C, T]) {
+  def writePartitions(path: String,
+    write: (Int, Iterator[T], OutputStream) => Long,
+    remapPartitions: Option[(Array[Int], Int)] = None): (Array[String], Array[Long]) = {
+    val sc = crdd.sparkContext
+    val hadoopConf = sc.hadoopConfiguration
+
+    hadoopConf.mkDir(path + "/parts")
+
+    val sHadoopConfBc = sc.broadcast(new SerializableHadoopConfiguration(hadoopConf))
+
+    val nPartitionsToWrite = crdd.getNumPartitions
+
+    val (remap, nPartitions) = remapPartitions match {
+      case Some((map, n)) => (map.apply _, n)
+      case None => (identity[Int] _, nPartitionsToWrite)
+    }
+
+    val d = digitsNeeded(nPartitions)
+
+    val remapBc = sc.broadcast(remap)
+
+    val partFiles = Array.tabulate[String](nPartitions) { i =>
+      val is = i.toString
+      assert(is.length <= d)
+      "part-" + StringUtils.leftPad(is, d, "0")
+    }
+
+    val partitionCounts = crdd.mapPartitionsWithIndex { case (index, it) =>
+      val i = remapBc.value(index)
+      val filename = path + "/parts/" + partFile(d, i)
+      val os = sHadoopConfBc.value.value.unsafeWriter(filename)
+      Iterator.single(write(i, it, os))
+    }.run.collect()
+
+    val itemCount = partitionCounts.sum
+    assert(nPartitionsToWrite == partitionCounts.length)
+
+    info(s"wrote $itemCount ${ plural(itemCount, "item") } " +
+      s"in ${ nPartitionsToWrite } ${ plural(nPartitionsToWrite, "partition") }")
+
+    (partFiles, partitionCounts)
+  }
+}

--- a/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
@@ -38,7 +38,6 @@ class RichContextRDD[C <: AutoCloseable, T: ClassTag](crdd: ContextRDD[C, T]) {
       val os = sHadoopConfBc.value.value.unsafeWriter(filename)
       Iterator.single(f -> write(i, it, os))
     }
-      .run
       .collect()
       .unzip
 

--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -189,5 +189,5 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
     remapPartitions: Option[(Array[Int], Int)] = None
   )(implicit tct: ClassTag[T]
   ): (Array[String], Array[Long]) =
-    ContextRDD.weaken[TrivialContext, T](r).writePartitions(path, write, remapPartitions)
+    ContextRDD.weaken[TrivialContext](r).writePartitions(path, write, remapPartitions)
 }

--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -183,7 +183,9 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
     }, preservesPartitioning = true)
       .subsetPartitions((0 to idxLast).toArray)
   }
-  
+
+  // FIXME: somehow harmonize this with the RichContextRDD.writePartitions,
+  // since BlockMatrix will likely never use a ContextRDD
   def writePartitions(path: String,
     write: (Int, Iterator[T], OutputStream) => Long,
     remapPartitions: Option[(Array[Int], Int)] = None): (Array[String], Array[Long]) = {

--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -2,7 +2,7 @@ package is.hail.utils.richUtils
 
 import java.io.OutputStream
 
-import is.hail.sparkextras.ReorderedPartitionsRDD
+import is.hail.sparkextras._
 import is.hail.utils._
 import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop
@@ -183,4 +183,11 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
     }, preservesPartitioning = true)
       .subsetPartitions((0 to idxLast).toArray)
   }
+
+  def writePartitions(path: String,
+    write: (Int, Iterator[T], OutputStream) => Long,
+    remapPartitions: Option[(Array[Int], Int)] = None
+  )(implicit tct: ClassTag[T]
+  ): (Array[String], Array[Long]) =
+    ContextRDD.weaken[TrivialContext, T](r).writePartitions(path, write, remapPartitions)
 }

--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -183,46 +183,4 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
     }, preservesPartitioning = true)
       .subsetPartitions((0 to idxLast).toArray)
   }
-
-  // FIXME: somehow harmonize this with the RichContextRDD.writePartitions,
-  // since BlockMatrix will likely never use a ContextRDD
-  def writePartitions(path: String,
-    write: (Int, Iterator[T], OutputStream) => Long,
-    remapPartitions: Option[(Array[Int], Int)] = None): (Array[String], Array[Long]) = {
-    val sc = r.sparkContext
-    val hadoopConf = sc.hadoopConfiguration
-    
-    hadoopConf.mkDir(path + "/parts")
-    
-    val sHadoopConfBc = sc.broadcast(new SerializableHadoopConfiguration(hadoopConf))
-
-    val nPartitionsToWrite = r.getNumPartitions
-    
-    val (remap, nPartitions) = remapPartitions match {
-      case Some((map, n)) => (map.apply _, n)
-      case None => (identity[Int] _, nPartitionsToWrite)
-    }
-    
-    val d = digitsNeeded(nPartitions)
-    
-    val remapBc = sc.broadcast(remap)
-
-    val (partFiles, partitionCounts) = r.mapPartitionsWithIndex { case (index, it) =>
-      val i = remapBc.value(index)
-      val f = partFile(d, i, TaskContext.get)
-      val filename = path + "/parts/" + f
-      val os = sHadoopConfBc.value.value.unsafeWriter(filename)
-      Iterator.single(f -> write(i, it, os))
-    }
-      .collect()
-      .unzip
-        
-    val itemCount = partitionCounts.sum
-    assert(nPartitionsToWrite == partitionCounts.length)
-
-    info(s"wrote $itemCount ${ plural(itemCount, "item") } " +
-      s"in ${ nPartitionsToWrite } ${ plural(nPartitionsToWrite, "partition") }")
-    
-    (partFiles, partitionCounts)
-  }
 }

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -889,7 +889,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
           Iterator()
       }
 
-    val nParts = rvd.partitions.length
+    val nParts = rvd.getNumPartitions
     val zipRDD = partitionKeyedIntervals.partitionBy(new Partitioner {
       def getPartition(key: Any): Int = key.asInstanceOf[Int]
 
@@ -1134,7 +1134,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     }
   }
 
-  def nPartitions: Int = rvd.partitions.length
+  def nPartitions: Int = rvd.getNumPartitions
 
   def annotateRowsVDS(right: MatrixTable, root: String): MatrixTable =
     orderedRVDLeftJoinDistinctAndInsert(right.value.rowsRVD(), root, product = false)


### PR DESCRIPTION
An unfortunately large set of changes to enable `writeRows` on a `ContextRDD`.

I took the chance to do a wee bit of refactoring between the write methods of `UnpartitionedRVD` and `OrderedRVD`.