### PR TITLE
use rvd in expandTypes

### DIFF
--- a/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -217,6 +217,8 @@ object SafeRow {
   def apply(t: TBaseStruct, region: Region, off: Long): Row = {
     Annotation.copy(t, new UnsafeRow(t, region, off)).asInstanceOf[Row]
   }
+
+  def apply(t: TBaseStruct, rv: RegionValue): Row = SafeRow(t, rv.region, rv.offset)
 }
 
 class KeyedRow(var row: Row, keyFields: Array[Int]) extends Row {

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -2,7 +2,7 @@ package is.hail.rvd
 
 import is.hail.HailContext
 import is.hail.annotations._
-import is.hail.expr.{JSONAnnotationImpex, Parser}
+import is.hail.expr.JSONAnnotationImpex
 import is.hail.expr.types.{TArray, TInterval, TStruct, TStructSerializer}
 import is.hail.sparkextras._
 import is.hail.io._
@@ -12,7 +12,7 @@ import org.apache.spark.{Partition, SparkContext}
 import org.apache.spark.rdd.{AggregateWithContext, RDD}
 import org.apache.spark.sql.Row
 import org.apache.spark.storage.StorageLevel
-import org.json4s.{CustomSerializer, DefaultFormats, Formats, JValue, ShortTypeHints}
+import org.json4s.{DefaultFormats, Formats, JValue, ShortTypeHints}
 import org.json4s.jackson.{JsonMethods, Serialization}
 
 import scala.reflect.ClassTag

--- a/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -997,10 +997,6 @@ class ExprSuite extends SparkSuite {
       property("table") = forAll(g.filter { case (t, a) => !t.isOfType(TFloat64()) && a != null }.resize(10)) { case (t, a) =>
         TableAnnotationImpex.importAnnotation(TableAnnotationImpex.exportAnnotation(a, t), t) == a
       }
-
-      property("spark") = forAll(g) { case (t, a) =>
-        SparkAnnotationImpex.importAnnotation(SparkAnnotationImpex.exportAnnotation(a, t), t) == a
-      }
     }
 
     Spec.check()


### PR DESCRIPTION
removed AnnotationImpex
removed some dead code from SparkAnnotationImpex
Table.toDF now requires expandTypes to have been run (will fail with match error in SparkAnnotationImpex.exportType)
Handle tuple in Spark conversion (convert to struct)