### PR TITLE
bug fix in emit

### DIFF
--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -405,7 +405,6 @@ private class Emit(
               .map { case (name, v) => name -> (v.typ, emit(v)) }: _*)
             val appendInit = fields.filter { case (name, _) => !oldtype.hasField(name) }
               .map { case (_, v) => (v.typ, emit(v)) }
-            val initializers = fields.map { case (_, v) => (v.typ, emit(v)) }
             val srvb = new StagedRegionValueBuilder(fb, x.typ)
             present(Code(
               srvb.start(init = true),
@@ -764,7 +763,6 @@ private class Emit(
 
       case _ =>
         val t: TArray = coerce[TArray](ir.typ)
-        val srvb = new StagedRegionValueBuilder(fb, t)
         val i = fb.newLocal[Int]("i")
         val len = fb.newLocal[Int]("len")
         val aoff = fb.newLocal[Long]("aoff")
@@ -774,7 +772,6 @@ private class Emit(
           len := t.loadLength(region, aoff))
         ArrayIteratorTriplet(calcLength, Some(len.load()), { continuation: F =>
           EmitArrayTriplet(codeV.setup, Some(codeV.m), Code(
-            srvb.start(len, init = true),
             i := 0,
             Code.whileLoop(i < len,
               continuation(t.isElementMissing(region, aoff, i),

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -590,7 +590,7 @@ private class Emit(
                 len := tArray.loadLength(region, arr),
                 Code.whileLoop(i < len,
                   continuation(
-                    region.loadIRIntermediate(tArray.elementType)(tArray.loadElement(region, arr, i)),
+                    region.loadIRIntermediate(tArray.elementType)(tArray.elementOffsetInRegion(region, arr, i)),
                     tArray.isElementMissing(region, arr, i)),
                   i ++))))
         }
@@ -778,7 +778,7 @@ private class Emit(
             i := 0,
             Code.whileLoop(i < len,
               continuation(t.isElementMissing(region, aoff, i),
-                region.loadIRIntermediate(t.elementType)(t.loadElement(region, aoff, i))),
+                region.loadIRIntermediate(t.elementType)(t.elementOffsetInRegion(region, aoff, i))),
               i := i + 1)))
         })
     }


### PR DESCRIPTION
loadIRIntermediate load binary and array, so it must be passed the element, but the element offset.

It probably shouldn't do that but this was a quicker fix.