### PR TITLE
added some more stuff to the function registry

### DIFF
--- a/python/hail/tests/test_methods.py
+++ b/python/hail/tests/test_methods.py
@@ -802,6 +802,7 @@ class Tests(unittest.TestCase):
 
         bad = (tdt_tab.filter(hl.is_nan(tdt_tab.p_value), keep=False)
             .join(truth.filter(hl.is_nan(truth.Pval), keep=False), how='outer'))
+        bad.describe()
 
         bad = bad.filter(~(
                 (bad.t == bad.T) &

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueAggregator.scala
@@ -4,8 +4,6 @@ import is.hail.annotations._
 import is.hail.expr.types._
 
 trait RegionValueAggregator extends Serializable {
-  def seqOp(region: Region, off: Long, missing: Boolean): Unit
-
   def combOp(agg2: RegionValueAggregator): Unit
 
   def result(rvb: RegionValueBuilder)

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCountAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCountAggregator.scala
@@ -1,0 +1,25 @@
+package is.hail.annotations.aggregators
+
+import is.hail.annotations.{Region, RegionValueBuilder}
+
+class RegionValueCountAggregator extends RegionValueAggregator {
+  private var count: Long = 0
+
+  def seqOp(offset: Long, missing: Boolean) {
+    count += 1
+  }
+
+  def seqOp(region: Region, off: Long, missing: Boolean) {
+    count += 1
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    count += agg2.asInstanceOf[RegionValueCountAggregator].count
+  }
+
+  def result(rvb: RegionValueBuilder) {
+    rvb.addLong(count)
+  }
+
+  def copy(): RegionValueCountAggregator = new RegionValueCountAggregator()
+}

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCountAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCountAggregator.scala
@@ -1,15 +1,11 @@
 package is.hail.annotations.aggregators
 
-import is.hail.annotations.{Region, RegionValueBuilder}
+import is.hail.annotations.RegionValueBuilder
 
 class RegionValueCountAggregator extends RegionValueAggregator {
   private var count: Long = 0
 
-  def seqOp(offset: Long, missing: Boolean) {
-    count += 1
-  }
-
-  def seqOp(region: Region, off: Long, missing: Boolean) {
+  def seqOp(dummy: Int, missing: Boolean) {
     count += 1
   }
 

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -986,8 +986,8 @@ object FunctionRegistry {
 
   register("qpois", { (p: Double, lambda: Double, lowerTail: Boolean, logP: Boolean) => qpois(p, lambda, lowerTail, logP) })
 
-  register("pchisqtail", { (x: Double, df: Double) => chiSquaredTail(df, x) })
-  register("qchisqtail", { (p: Double, df: Double) => inverseChiSquaredTail(df, p) })
+  register("pchisqtail", { (x: Double, df: Double) => chiSquaredTail(x, df) })
+  register("qchisqtail", { (p: Double, df: Double) => inverseChiSquaredTail(p, df) })
 
   register("!", (a: Boolean) => !a)
 

--- a/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -17,6 +17,8 @@ final case class Sum() extends AggOp { }
 final case class Max() extends AggOp { }
 // final case class Min() extends AggOp { }
 
+final case class Count() extends AggOp { }
+
 // unary
 final case class Take() extends AggOp { }
 
@@ -72,6 +74,7 @@ object AggOp {
     case (Max(), in: TFloat32, Seq()) => CodeAggregator[RegionValueMaxFloatAggregator](in, TFloat32())
     case (Max(), in: TFloat64, Seq()) => CodeAggregator[RegionValueMaxDoubleAggregator](in, TFloat64())
     // case (Min(), _: T) =>
+    case (Count(), in, Seq()) => CodeAggregator[RegionValueCountAggregator](in, TInt64())
     case (Take(), in: TBoolean, args@Seq(_: TInt32)) => CodeAggregator[RegionValueTakeBooleanAggregator](in, TArray(in), classOf[Int])
     case (Take(), in: TInt32, args@Seq(_: TInt32)) => CodeAggregator[RegionValueTakeIntAggregator](in, TArray(in), classOf[Int])
     case (Take(), in: TInt64, args@Seq(_: TInt32)) => CodeAggregator[RegionValueTakeLongAggregator](in, TArray(in), classOf[Int])

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -775,15 +775,9 @@ private class Emit(
 
       case _ =>
         val t: TArray = coerce[TArray](ir.typ)
-<<<<<<< c501f4eb26f6729875d721b85a97771469c20c40
         val i = mb.newLocal[Int]("i")
         val len = mb.newLocal[Int]("len")
         val aoff = mb.newLocal[Long]("aoff")
-=======
-        val i = fb.newLocal[Int]("i")
-        val len = fb.newLocal[Int]("len")
-        val aoff = fb.newLocal[Long]("aoff")
->>>>>>> nuked some dead code
         val codeV = emit(ir, env)
         val calcLength = Code(
           aoff := coerce[Long](codeV.v),

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -775,9 +775,15 @@ private class Emit(
 
       case _ =>
         val t: TArray = coerce[TArray](ir.typ)
+<<<<<<< c501f4eb26f6729875d721b85a97771469c20c40
         val i = mb.newLocal[Int]("i")
         val len = mb.newLocal[Int]("len")
         val aoff = mb.newLocal[Long]("aoff")
+=======
+        val i = fb.newLocal[Int]("i")
+        val len = fb.newLocal[Int]("len")
+        val aoff = fb.newLocal[Long]("aoff")
+>>>>>>> nuked some dead code
         val codeV = emit(ir, env)
         val calcLength = Code(
           aoff := coerce[Long](codeV.v),

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -56,7 +56,9 @@ object IRFunctionRegistry {
     }
 
     (validIR, validMethods) match {
-      case (None, None) => None
+      case (None, None) =>
+        log.fatal(s"no IRFunction found for $name(${ args.mkString(", ") })")
+        None
       case (None, Some(x)) => Some(x)
       case (Some(x), None) => Some(x)
       case _ => fatal(s"Multiple methods found that satisfy $name(${ args.mkString(",") }).")

--- a/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
@@ -32,6 +32,10 @@ object MathFunctions extends RegistryFunctions {
 
   def isnan(d: Double): Boolean = d.isNaN
 
+  def pcoin(p: Double): Boolean = math.random < p
+
+  def runif(min: Double, max: Double): Double = min + (max - min) * math.random
+
   def registerAll() {
     val thisClass = getClass
     val mathPackageClass = Class.forName("scala.math.package$")
@@ -64,6 +68,21 @@ object MathFunctions extends RegistryFunctions {
 
     registerScalaFunction("rpois", TFloat64(), TFloat64())(statsPackageClass, "rpois")
     // other rpois returns an array
+
+    registerScalaFunction("dpois", TFloat64(), TFloat64(), TFloat64())(statsPackageClass, "dpois")
+    registerScalaFunction("dpois", TFloat64(), TFloat64(), TBoolean(), TFloat64())(statsPackageClass, "dpois")
+
+    registerScalaFunction("ppois", TFloat64(), TFloat64(), TFloat64())(statsPackageClass, "ppois")
+    registerScalaFunction("ppois", TFloat64(), TFloat64(), TBoolean(), TBoolean(), TFloat64())(statsPackageClass, "ppois")
+
+    registerScalaFunction("qpois", TFloat64(), TFloat64(), TInt32())(statsPackageClass, "qpois")
+    registerScalaFunction("qpois", TFloat64(), TFloat64(), TBoolean(), TBoolean(), TInt32())(statsPackageClass, "qpois")
+
+    registerScalaFunction("pchisqtail", TFloat64(), TFloat64(), TFloat64())(statsPackageClass, "chiSquaredTail")
+    registerScalaFunction("qchisqtail", TFloat64(), TFloat64(), TFloat64())(statsPackageClass, "inverseChiSquaredTail")
+
+    registerScalaFunction("pcoin", TFloat64(), TBoolean())(thisClass, "pcoin")
+    registerScalaFunction("runif", TFloat64(), TFloat64(), TFloat64())(thisClass, "runif")
 
     registerScalaFunction("floor", TFloat32(), TFloat32())(thisClass, "floor")
     registerScalaFunction("floor", TFloat64(), TFloat64())(thisClass, "floor")

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -30,7 +30,7 @@ object UtilFunctions extends RegistryFunctions {
 
     registerIR("count", TAggregable(tv("T"))) { agg =>
       val uid = genUID()
-      ApplyAggOp(AggMap(agg, uid, MakeStruct(Seq())), Count(), Seq())
+      ApplyAggOp(AggMap(agg, uid, I32(0)), Count(), Seq())
     }
 
     registerIR("min", TArray(tnum("T"))) { a =>

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -18,22 +18,92 @@ object UtilFunctions extends RegistryFunctions {
       ArrayFold(a, zero, "sum", "v", If(IsNA(Ref("v")), Ref("sum"), ApplyBinaryPrimOp(Add(), Ref("sum"), Ref("v"))))
     }
 
+
     registerIR("sum", TAggregable(tnum("T")))(ApplyAggOp(_, Sum(), FastSeq()))
 
+    registerIR("product", TArray(tnum("T"))) { a =>
+      val product = genUID()
+      val v = genUID()
+      val one = Literal(1, coerce[TArray](a.typ).elementType)
+      ArrayFold(a, one, product, v, If(IsNA(Ref(v)), Ref(product), ApplyBinaryPrimOp(Multiply(), Ref(product), Ref(v))))
+    }
+
+    registerIR("count", TAggregable(tv("T"))) { agg =>
+      val uid = genUID()
+      ApplyAggOp(AggMap(agg, uid, MakeStruct(Seq())), Count(), Seq())
+    }
+
     registerIR("min", TArray(tnum("T"))) { a =>
-      val body = If(IsNA(Ref("min")),
-        Ref("value"),
-        If(IsNA(Ref("value")),
-          Ref("min"),
-          If(ApplyBinaryPrimOp(LT(), Ref("min"), Ref("value")), Ref("min"), Ref("value"))))
-      ArrayFold(a, NA(tnum("T").t), "min", "value", body)
+      val min = genUID()
+      val value = genUID()
+      val body = If(IsNA(Ref(min)),
+        Ref(value),
+        If(IsNA(Ref(value)),
+          Ref(min),
+          If(ApplyBinaryPrimOp(LT(), Ref(value), Ref(min)), Ref(value), Ref(min))))
+      ArrayFold(a, NA(tnum("T").t), min, value, body)
+    }
+
+    registerIR("max", TArray(tnum("T"))) { a =>
+      val max = genUID()
+      val value = genUID()
+      val body = If(IsNA(Ref(max)),
+        Ref(value),
+        If(IsNA(Ref(value)),
+          Ref(max),
+          If(ApplyBinaryPrimOp(GT(), Ref(value), Ref(max)), Ref(value), Ref(max))))
+      ArrayFold(a, NA(tnum("T").t), max, value, body)
     }
 
     registerIR("isDefined", tv("T")) { a => ApplyUnaryPrimOp(Bang(), IsNA(a)) }
+    registerIR("isMissing", tv("T")) { a => IsNA(a) }
 
     registerIR("[]", TArray(tv("T")), TInt32()) { (a, i) => ArrayRef(a, i) }
 
+    registerIR("[:]", TArray(tv("T"))) { (a) => a }
+
+    registerIR("[*:]", TArray(tv("T")), TInt32()) { (a, i) =>
+      val idx = genUID()
+      ArrayMap(
+        ArrayRange(If(ApplyBinaryPrimOp(LT(), i, I32(0)),
+          ApplyBinaryPrimOp(Add(), ArrayLen(a), i),
+          i),
+          ArrayLen(a),
+          I32(1)),
+        idx,
+        ArrayRef(a, Ref(idx)))
+    }
+
+    registerIR("[:*]", TArray(tv("T")), TInt32()) { (a, i) =>
+      val idx = genUID()
+      ArrayMap(
+        ArrayRange(I32(0),
+          If(ApplyBinaryPrimOp(LT(), i, I32(0)),
+            ApplyBinaryPrimOp(Add(), ArrayLen(a), i),
+            i),
+          I32(1)),
+        idx,
+        ArrayRef(a, Ref(idx)))
+    }
+
+    registerIR("[*:*]", TArray(tv("T")), TInt32(), TInt32()) { (a, i, j) =>
+      val idx = genUID()
+      ArrayMap(
+        ArrayRange(
+          If(ApplyBinaryPrimOp(LT(), i, I32(0)),
+            ApplyBinaryPrimOp(Add(), ArrayLen(a), i),
+            i),
+          If(ApplyBinaryPrimOp(LT(), j, I32(0)),
+            ApplyBinaryPrimOp(Add(), ArrayLen(a), j),
+            j),
+          I32(1)),
+        idx,
+        ArrayRef(a, Ref(idx)))
+    }
+
     registerIR("[]", tv("T", _.isInstanceOf[TTuple]), TInt32()) { (a, i) => GetTupleElement(a, i.asInstanceOf[I32].x) }
+
+    registerIR("[:]", TString()) { (a) => a }
 
     registerIR("range", TInt32(), TInt32(), TInt32())(ArrayRange)
 

--- a/src/main/scala/is/hail/expr/ir/package.scala
+++ b/src/main/scala/is/hail/expr/ir/package.scala
@@ -5,6 +5,14 @@ import is.hail.asm4s._
 import is.hail.expr.types._
 
 package object ir {
+  var uidCounter: Long = 0
+
+  def genUID(): String = {
+    val uid = s"__iruid_$uidCounter"
+    uidCounter += 1
+    uid
+  }
+
   def typeToTypeInfo(t: Type): TypeInfo[_] = t.fundamentalType match {
     case _: TInt32 => typeInfo[Int]
     case _: TInt64 => typeInfo[Long]

--- a/src/main/scala/is/hail/methods/LinearMixedRegression.scala
+++ b/src/main/scala/is/hail/methods/LinearMixedRegression.scala
@@ -231,7 +231,7 @@ class FullRankScalerLMM(
     val b: Double = xQty / xQtx
     val s2 = invDf * (yQty - xQty * b)
     val chi2 = n * (logNullS2 - math.log(s2))
-    val p = chiSquaredTail(1, chi2)
+    val p = chiSquaredTail(chi2, 1)
 
     rvb.startStruct()
     rvb.addDouble(b)
@@ -291,7 +291,7 @@ class LowRankScalerLMM(con: LMMConstants, delta: Double, logNullS2: Double, useM
     val b = CdC \ Cdy
     val s2 = invDf * (ydy - (Cdy dot b))
     val chi2 = n * (logNullS2 - math.log(s2))
-    val p = chiSquaredTail(1, chi2)
+    val p = chiSquaredTail(chi2, 1)
 
     rvb.startStruct()
     rvb.addDouble(b(0))

--- a/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
+++ b/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
@@ -91,7 +91,7 @@ object LikelihoodRatioTest extends LogisticRegressionTest {
     val lrStats =
       if (fit.converged) {
         val chi2 = 2 * (fit.logLkhd - nullFit.logLkhd)
-        val p = chiSquaredTail(m - m0, chi2)
+        val p = chiSquaredTail(chi2, m - m0)
 
         Some(LikelihoodRatioStats(fit.b, chi2, p))
       } else
@@ -134,7 +134,7 @@ object FirthTest extends LogisticRegressionTest {
       val firthStats =
         if (fitFirth.converged) {
           val chi2 = 2 * (fitFirth.logLkhd - nullFitFirth.logLkhd)
-          val p = chiSquaredTail(m - m0, chi2)
+          val p = chiSquaredTail(chi2, m - m0)
 
           Some(FirthStats(fitFirth.b, chi2, p))
         } else
@@ -189,7 +189,7 @@ object ScoreTest extends LogisticRegressionTest {
         fisher(r1, r1) := X1.t * (X1(::, *) *:* (mu *:* (1d - mu)))
 
         val chi2 = score dot (fisher \ score)
-        val p = chiSquaredTail(m - m0, chi2)
+        val p = chiSquaredTail(chi2, m - m0)
 
         Some(ScoreStats(chi2, p))
       } catch {

--- a/src/main/scala/is/hail/stats/package.scala
+++ b/src/main/scala/is/hail/stats/package.scala
@@ -281,10 +281,10 @@ package object stats {
   def qnorm(p: Double): Double = Normal.quantile(p, 0, 1, true, false)
 
   // Returns the p for which p = Prob(Z^2 > x) with Z^2 a chi-squared RV with df degrees of freedom
-  def chiSquaredTail(df: Double, x: Double): Double = ChiSquare.cumulative(x, df, false, false)
+  def chiSquaredTail(x: Double, df: Double): Double = ChiSquare.cumulative(x, df, false, false)
 
   // Returns the x for which p = Prob(Z^2 > x) with Z^2 a chi-squared RV with df degrees of freedom
-  def inverseChiSquaredTail(df: Double, p: Double): Double = ChiSquare.quantile(p, df, false, false)
+  def inverseChiSquaredTail(p: Double, df: Double): Double = ChiSquare.quantile(p, df, false, false)
 
   def dbeta(x: Double, a: Double, b: Double): Double = Beta.density(x, a, b, false)
 
@@ -292,15 +292,21 @@ package object stats {
 
   def rpois(n: Int, lambda: Double): IndexedSeq[Double] = new Poisson(lambda).random(n)
 
-  def dpois(x: Double, lambda: Double, logP: Boolean = false): Double = new Poisson(lambda).density(x, logP)
+  def dpois(x: Double, lambda: Double, logP: Boolean): Double = new Poisson(lambda).density(x, logP)
 
-  def ppois(x: Double, lambda: Double, lowerTail: Boolean = true, logP: Boolean = false): Double = new Poisson(lambda).cumulative(x, lowerTail, logP)
+  def dpois(x: Double, lambda: Double): Double = dpois(x, lambda, logP = false)
 
-  def qpois(x: Double, lambda: Double, lowerTail: Boolean = true, logP: Boolean = false): Int = {
+  def ppois(x: Double, lambda: Double, lowerTail: Boolean, logP: Boolean): Double = new Poisson(lambda).cumulative(x, lowerTail, logP)
+
+  def ppois(x: Double, lambda: Double): Double = ppois(x, lambda, lowerTail = true, logP = false)
+
+  def qpois(x: Double, lambda: Double, lowerTail: Boolean, logP: Boolean): Int = {
     val result = new Poisson(lambda).quantile(x, lowerTail, logP)
     assert(result.isValidInt, s"qpois result is not a valid int. Found $result.")
     result.toInt
   }
+
+  def qpois(x: Double, lambda: Double): Int = qpois(x, lambda, lowerTail = true, logP = false)
 
   def binomTest(nSuccess: Int, n: Int, p: Double, alternative: String): Double = {
     val kind = alternative match {

--- a/src/test/scala/is/hail/methods/LinearMixedRegressionSuite.scala
+++ b/src/test/scala/is/hail/methods/LinearMixedRegressionSuite.scala
@@ -95,7 +95,7 @@ class LinearMixedRegressionSuite extends SparkSuite {
       val res = norm(yc - xCc * beta)
       val sg2 = (res * res) / (n - c)
       val chi2 = n * (model.logNullS2 - math.log(sg2))
-      val pval = chiSquaredTail(1d, chi2)
+      val pval = chiSquaredTail(chi2, 1d)
       
       (beta(0), sg2, chi2, pval)
     }

--- a/src/test/scala/is/hail/stats/StatsSuite.scala
+++ b/src/test/scala/is/hail/stats/StatsSuite.scala
@@ -12,26 +12,26 @@ class StatsSuite extends SparkSuite {
 
   @Test def chiSquaredTailTest() {
     val chiSq1 = new ChiSquaredDistribution(1)
-    assert(D_==(chiSquaredTail(1,1d), 1 - chiSq1.cumulativeProbability(1d)))
-    assert(D_==(chiSquaredTail(1,5.52341d), 1 - chiSq1.cumulativeProbability(5.52341d)))
+    assert(D_==(chiSquaredTail(1d,1), 1 - chiSq1.cumulativeProbability(1d)))
+    assert(D_==(chiSquaredTail(5.52341d,1), 1 - chiSq1.cumulativeProbability(5.52341d)))
 
     val chiSq2 = new ChiSquaredDistribution(2)
-    assert(D_==(chiSquaredTail(2, 1), 1 - chiSq2.cumulativeProbability(1)))
-    assert(D_==(chiSquaredTail(2, 5.52341), 1 - chiSq2.cumulativeProbability(5.52341)))
+    assert(D_==(chiSquaredTail(1, 2), 1 - chiSq2.cumulativeProbability(1)))
+    assert(D_==(chiSquaredTail(5.52341, 2), 1 - chiSq2.cumulativeProbability(5.52341)))
 
     val chiSq5 = new ChiSquaredDistribution(5.2)
-    assert(D_==(chiSquaredTail(5.2, 1), 1 - chiSq5.cumulativeProbability(1)))
-    assert(D_==(chiSquaredTail(5.2, 5.52341), 1 - chiSq5.cumulativeProbability(5.52341)))
+    assert(D_==(chiSquaredTail(1, 5.2), 1 - chiSq5.cumulativeProbability(1)))
+    assert(D_==(chiSquaredTail(5.52341, 5.2), 1 - chiSq5.cumulativeProbability(5.52341)))
 
-    assert(D_==(inverseChiSquaredTail(1.0, .1), chiSq1.inverseCumulativeProbability(1 - .1)))
-    assert(D_==(inverseChiSquaredTail(1.0, .0001), chiSq1.inverseCumulativeProbability(1 - .0001)))
+    assert(D_==(inverseChiSquaredTail(.1, 1.0), chiSq1.inverseCumulativeProbability(1 - .1)))
+    assert(D_==(inverseChiSquaredTail(.0001, 1.0), chiSq1.inverseCumulativeProbability(1 - .0001)))
 
     val a = List(.0000000001, .5, .9999999999, 1.0)
-    a.foreach(p => assert(D_==(chiSquaredTail(1.0, inverseChiSquaredTail(1.0, p)), p)))
+    a.foreach(p => assert(D_==(chiSquaredTail(inverseChiSquaredTail(p, 1.0), 1.0), p)))
 
     // compare with R
-    assert(math.abs(chiSquaredTail(1, 400) - 5.507248e-89) < 1e-93)
-    assert(D_==(inverseChiSquaredTail(1, 5.507248e-89), 400))
+    assert(math.abs(chiSquaredTail(400, 1) - 5.507248e-89) < 1e-93)
+    assert(D_==(inverseChiSquaredTail(5.507248e-89, 1), 400))
   }
 
   @Test def normalTest() {
@@ -69,15 +69,15 @@ class StatsSuite extends SparkSuite {
     // compare with R
     assert(D_==(dpois(5, 10), 0.03783327))
     assert(qpois(0.3, 10) == 8)
-    assert(qpois(0.3, 10, lowerTail = false) == 12)
+    assert(qpois(0.3, 10, lowerTail = false, logP = false) == 12)
     assert(D_==(ppois(5, 10), 0.06708596))
-    assert(D_==(ppois(5, 10, lowerTail = false), 0.932914))
+    assert(D_==(ppois(5, 10, lowerTail = false, logP = false), 0.932914))
     assert(rpois(5) >= 0)
 
     assert(qpois(ppois(5, 10), 10) == 5)
-    assert(qpois(ppois(5, 10, lowerTail = false), 10, lowerTail = false) == 5)
+    assert(qpois(ppois(5, 10, lowerTail = false, logP = false), 10, lowerTail = false, logP = false) == 5)
 
-    assert(ppois(30, 1, lowerTail = false) > 0)
+    assert(ppois(30, 1, lowerTail = false, logP = false) > 0)
   }
 
   @Test def betaTest() {


### PR DESCRIPTION
swapped the (inverse) chi squared tail paramters to match the order in the function registry

added ir.genUID to generate unique IDs.  There are other places it should probably be used.  In the long term, we should just use Longs instead of strings, but keep strings for informational purposes.