### PR TITLE
 Improved FastSeq, FastIndexedSeq.

### DIFF
--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -316,7 +316,7 @@ case class Select(posn: Position, lhs: AST, rhs: String) extends AST(posn, lhs) 
                |    ${ t.fields.map(x => s"${ prettyIdentifier(x.name) }: ${ x.typ }").mkString("\n    ") }""".stripMargin)
         }
 
-      case (t, name) => FunctionRegistry.lookupFieldReturnType(t, Seq(), name)
+      case (t, name) => FunctionRegistry.lookupFieldReturnType(t, FastSeq(), name)
         .valueOr {
           case FunctionRegistry.NotFound(name, typ, _) =>
             parseError(s"""`$t' has no field or method `$rhs'""".stripMargin)
@@ -326,7 +326,7 @@ case class Select(posn: Position, lhs: AST, rhs: String) extends AST(posn, lhs) 
   }
 
   def compileAggregator(): CMCodeCPS[AnyRef] =
-    FunctionRegistry.callAggregatorTransformation(lhs.`type`, Seq(), rhs)(lhs, Seq())
+    FunctionRegistry.callAggregatorTransformation(lhs.`type`, FastSeq(), rhs)(lhs, FastSeq())
 
   def compile() = (lhs.`type`: @unchecked) match {
     case t: TStruct =>
@@ -337,7 +337,7 @@ case class Select(posn: Position, lhs: AST, rhs: String) extends AST(posn, lhs) 
     case t =>
       val localPos = posn
 
-      FunctionRegistry.lookupField(t, Seq(), rhs)(lhs, Seq())
+      FunctionRegistry.lookupField(t, FastSeq(), rhs)(lhs, FastSeq())
         .valueOr {
           case FunctionRegistry.NotFound(name, typ, _) =>
             ParserUtils.error(localPos,

--- a/src/main/scala/is/hail/expr/HailRep.scala
+++ b/src/main/scala/is/hail/expr/HailRep.scala
@@ -1,7 +1,7 @@
 package is.hail.expr
 
 import is.hail.expr.types._
-import is.hail.utils.Interval
+import is.hail.utils._
 import is.hail.variant.{Call, RGBase, Locus}
 
 trait HailRep[T] { self =>
@@ -79,7 +79,7 @@ trait HailRepFunctions {
   }
 
   implicit def unaryHr[T, U](implicit hrt: HailRep[T], hru: HailRep[U]) = new HailRep[(Any) => Any] {
-    def typ = TFunction(Seq(hrt.typ), hru.typ)
+    def typ = TFunction(FastSeq(hrt.typ), hru.typ)
   }
 
   def aggregableHr[T](implicit hrt: HailRep[T]) = new HailRep[T] {

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -4,6 +4,7 @@ import is.hail.annotations._
 import is.hail.annotations.aggregators.RegionValueAggregator
 import is.hail.asm4s._
 import is.hail.expr.types._
+import is.hail.utils.FastSeq
 
 import scala.reflect.{ClassTag, classTag}
 
@@ -15,7 +16,7 @@ object Compile {
     val argTypeInfo: Array[MaybeGenericTypeInfo[_]] =
       GenericTypeInfo[Region]() +:
         args.flatMap { case (_, t, _) =>
-          Seq[GenericTypeInfo[_]](GenericTypeInfo()(typeToTypeInfo(t)), GenericTypeInfo[Boolean]())
+          FastSeq[GenericTypeInfo[_]](GenericTypeInfo()(typeToTypeInfo(t)), GenericTypeInfo[Boolean]())
         }.toArray
 
     val fb = new FunctionBuilder[F](argTypeInfo, GenericTypeInfo[R]())
@@ -33,7 +34,7 @@ object Compile {
   }
 
   def apply[R: TypeInfo : ClassTag](body: IR): (Type, () => AsmFunction1[Region, R]) = {
-    apply[AsmFunction1[Region, R], R](Seq(), body)
+    apply[AsmFunction1[Region, R], R](FastSeq[(String, Type, ClassTag[_])](), body)
   }
 
   def apply[T0 : ClassTag, R: TypeInfo : ClassTag](
@@ -41,7 +42,7 @@ object Compile {
     typ0: Type,
     body: IR): (Type, () => AsmFunction3[Region, T0, Boolean, R]) = {
 
-    apply[AsmFunction3[Region, T0, Boolean, R], R](Seq((name0, typ0, classTag[T0])), body)
+    apply[AsmFunction3[Region, T0, Boolean, R], R](FastSeq((name0, typ0, classTag[T0])), body)
   }
 
   def apply[T0 : ClassTag, T1 : ClassTag, R: TypeInfo : ClassTag](
@@ -51,7 +52,7 @@ object Compile {
     typ1: Type,
     body: IR): (Type, () => AsmFunction5[Region, T0, Boolean, T1, Boolean, R]) = {
 
-    apply[AsmFunction5[Region, T0, Boolean, T1, Boolean, R], R](Seq((name0, typ0, classTag[T0]), (name1, typ1, classTag[T1])), body)
+    apply[AsmFunction5[Region, T0, Boolean, T1, Boolean, R], R](FastSeq((name0, typ0, classTag[T0]), (name1, typ1, classTag[T1])), body)
   }
 
   def apply[
@@ -100,7 +101,7 @@ object Compile {
     body: IR
   ): (Type, () => AsmFunction13[Region, T0, Boolean, T1, Boolean, T2, Boolean, T3, Boolean, T4, Boolean, T5, Boolean, R]) = {
 
-    apply[AsmFunction13[Region, T0, Boolean, T1, Boolean, T2, Boolean, T3, Boolean, T4, Boolean, T5, Boolean, R], R](Seq(
+    apply[AsmFunction13[Region, T0, Boolean, T1, Boolean, T2, Boolean, T3, Boolean, T4, Boolean, T5, Boolean, R], R](FastSeq(
       (name0, typ0, classTag[T0]),
       (name1, typ1, classTag[T1]),
       (name2, typ2, classTag[T2]),
@@ -170,7 +171,7 @@ object CompileWithAggregators {
 
     assert(TypeToIRIntermediateClassTag(aggTyp) == classTag[TAGG])
 
-    val args = Seq((name0, typ0, classTag[T0]))
+    val args = FastSeq((name0, typ0, classTag[T0]))
 
     val scope = aggTyp.symTab
     assert(scope.size == 2)
@@ -209,7 +210,7 @@ object CompileWithAggregators {
 
     assert(TypeToIRIntermediateClassTag(aggTyp) == classTag[TAGG])
 
-    val args = Seq(
+    val args = FastSeq(
       (name0, typ0, classTag[T0]),
       (name1, typ1, classTag[T1]))
 

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -68,7 +68,7 @@ private class Emit(
   tAggInOpt: Option[TAggregable],
   nSpecialArguments: Int) {
 
-  val methods: mutable.Map[String, Seq[(Seq[Type], MethodBuilder)]] = mutable.Map().withDefaultValue(Seq())
+  val methods: mutable.Map[String, Seq[(Seq[Type], MethodBuilder)]] = mutable.Map().withDefaultValue(FastSeq())
 
   import Emit.E
   import Emit.F

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -12,7 +12,7 @@ object Interpret {
   type AggElement = (Any, Env[Any])
   type Agg = (TAggregable, IndexedSeq[AggElement])
 
-  def apply[T](ir: IR): T = apply(ir, Env.empty[(Any, Type)], IndexedSeq(), None).asInstanceOf[T]
+  def apply[T](ir: IR): T = apply(ir, Env.empty[(Any, Type)], FastIndexedSeq(), None).asInstanceOf[T]
 
   def apply[T](ir: IR,
     env: Env[(Any, Type)],

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir.functions
 import is.hail.asm4s._
 import is.hail.expr.ir._
 import is.hail.expr.types._
+import is.hail.utils._
 import is.hail.expr.types.coerce
 
 object UtilFunctions extends RegistryFunctions {
@@ -17,7 +18,7 @@ object UtilFunctions extends RegistryFunctions {
       ArrayFold(a, zero, "sum", "v", If(IsNA(Ref("v")), Ref("sum"), ApplyBinaryPrimOp(Add(), Ref("sum"), Ref("v"))))
     }
 
-    registerIR("sum", TAggregable(tnum("T")))(ApplyAggOp(_, Sum(), Seq()))
+    registerIR("sum", TAggregable(tnum("T")))(ApplyAggOp(_, Sum(), FastSeq()))
 
     registerIR("min", TArray(tnum("T"))) { a =>
       val body = If(IsNA(Ref("min")),

--- a/src/main/scala/is/hail/expr/types/TAggregableVariable.scala
+++ b/src/main/scala/is/hail/expr/types/TAggregableVariable.scala
@@ -2,6 +2,7 @@ package is.hail.expr.types
 
 import is.hail.annotations._
 import is.hail.expr._
+import is.hail.utils._
 
 import scala.reflect.ClassTag
 
@@ -12,7 +13,7 @@ final case class TAggregableVariable(elementType: Type, st: Box[SymbolTable]) ex
 
   override def isRealizable = false
 
-  override def children = Seq(elementType)
+  override def children = FastSeq(elementType)
 
   def _typeCheck(a: Any): Boolean =
     throw new RuntimeException("TAggregableVariable is not realizable")

--- a/src/main/scala/is/hail/expr/types/TContainer.scala
+++ b/src/main/scala/is/hail/expr/types/TContainer.scala
@@ -21,7 +21,7 @@ abstract class TContainer extends Type {
 
   def contentsAlignment: Long
 
-  override def children = Seq(elementType)
+  override def children = FastSeq(elementType)
 
   final def loadLength(region: Region, aoff: Long): Int =
     TContainer.loadLength(region, aoff)

--- a/src/main/scala/is/hail/expr/types/TDict.scala
+++ b/src/main/scala/is/hail/expr/types/TDict.scala
@@ -22,7 +22,7 @@ final case class TDict(keyType: Type, valueType: Type, override val required: Bo
     case _ => false
   }
 
-  override def children = Seq(keyType, valueType)
+  override def children = FastSeq(keyType, valueType)
 
   override def unify(concrete: Type): Boolean = {
     concrete match {

--- a/src/main/scala/is/hail/expr/types/TInterval.scala
+++ b/src/main/scala/is/hail/expr/types/TInterval.scala
@@ -8,7 +8,7 @@ import scala.reflect.{ClassTag, classTag}
 
 
 case class TInterval(pointType: Type, override val required: Boolean = false) extends ComplexType {
-  override def children = Seq(pointType)
+  override def children = FastSeq(pointType)
 
   def _toPretty = s"""Interval[$pointType]"""
 

--- a/src/main/scala/is/hail/expr/types/Type.scala
+++ b/src/main/scala/is/hail/expr/types/Type.scala
@@ -128,7 +128,7 @@ object Type {
 abstract class Type extends BaseType with Serializable {
   self =>
 
-  def children: Seq[Type] = Seq()
+  def children: Seq[Type] = FastSeq()
 
   def clear(): Unit = children.foreach(_.clear())
 

--- a/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -281,7 +281,7 @@ object LoadBgen {
       .map(_.toInt)
       .toSeq
 
-    if (magicNumber != Seq(0, 0, 0, 0) && magicNumber != Seq(98, 103, 101, 110))
+    if (magicNumber != FastSeq(0, 0, 0, 0) && magicNumber != FastSeq(98, 103, 101, 110))
       fatal(s"expected magic number [0000] or [bgen], got [${ magicNumber.mkString }]")
 
     if (headerLength > 20)

--- a/src/main/scala/is/hail/io/gen/LoadGen.scala
+++ b/src/main/scala/is/hail/io/gen/LoadGen.scala
@@ -49,7 +49,7 @@ object LoadGen {
 
     val recodedContig = contigRecoding.getOrElse(chr, chr)
     val locus = Locus.annotation(recodedContig, start.toInt, rg)
-    val alleles = Array(ref, alt).toFastIndexedSeq
+    val alleles = FastIndexedSeq(ref, alt)
 
     val gp = arr.drop(6 - chrCol).map {
       _.toDouble

--- a/src/main/scala/is/hail/methods/LinearMixedRegression.scala
+++ b/src/main/scala/is/hail/methods/LinearMixedRegression.scala
@@ -437,7 +437,7 @@ object DiagLMM {
 
       val h2Lkhd = h2LogLkhd.map(ll => math.exp(ll - maxLogLkhd))
       val h2LkhdSum = h2Lkhd.sum
-      val h2NormLkhd = IndexedSeq(Double.NaN) ++ h2Lkhd.map(_ / h2LkhdSum) ++ IndexedSeq(Double.NaN)
+      val h2NormLkhd = FastIndexedSeq(Double.NaN) ++ h2Lkhd.map(_ / h2LkhdSum) ++ FastIndexedSeq(Double.NaN)
 
       (FastMath.exp(maxlogDelta), GlobalFitLMM(maxLogLkhd, gridLogLkhd, sigmaH2, h2NormLkhd))
     }

--- a/src/main/scala/is/hail/methods/Nirvana.scala
+++ b/src/main/scala/is/hail/methods/Nirvana.scala
@@ -222,7 +222,7 @@ object Nirvana {
   }
 
   def annotate(vds: MatrixTable, config: String, blockSize: Int, root: String = "va.nirvana"): MatrixTable = {
-    assert(vds.rowKey == IndexedSeq("locus", "alleles"))
+    assert(vds.rowKey == FastIndexedSeq("locus", "alleles"))
     val parsedRoot = Parser.parseAnnotationRoot(root, Annotation.ROW_HEAD)
 
     val properties = try {

--- a/src/main/scala/is/hail/methods/VEP.scala
+++ b/src/main/scala/is/hail/methods/VEP.scala
@@ -173,7 +173,7 @@ object VEP {
 
   def annotate(vsm: MatrixTable, config: String, root: String = "va.vep", csq: Boolean,
     blockSize: Int): MatrixTable = {
-    assert(vsm.rowKey == IndexedSeq("locus", "alleles"))
+    assert(vsm.rowKey == FastIndexedSeq("locus", "alleles"))
 
     val parsedRoot = Parser.parseAnnotationRoot(root, Annotation.ROW_HEAD)
 

--- a/src/main/scala/is/hail/rvd/OrderedRVDPartitioner.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVDPartitioner.scala
@@ -69,7 +69,7 @@ class OrderedRVDPartitioner(
         rangeTree.queryValues(pkType.ordering, row)
       case interval: Interval =>
         if (!rangeTree.probablyOverlaps(pkType.ordering, interval))
-          Seq.empty[Int]
+          FastSeq.empty[Int]
         else {
           val startRange = getPartitionRange(interval.start)
           val start = if (startRange.nonEmpty)
@@ -112,14 +112,14 @@ class OrderedRVDPartitioner(
     if (newRange.isEmpty)
       return this
     if (range.isEmpty)
-      return copy(rangeBounds = IndexedSeq(newRange.get))
+      return copy(rangeBounds = FastIndexedSeq(newRange.get))
     val newStart = pkType.ordering.min(range.get.start, Annotation.copy(pkType, newRange.get.start))
     val newEnd = pkType.ordering.max(range.get.end, Annotation.copy(pkType, newRange.get.end))
     val newRangeBounds =
       rangeBounds match {
-        case IndexedSeq(x) => IndexedSeq(Interval(newStart, newEnd, true, true))
+        case IndexedSeq(x) => FastIndexedSeq(Interval(newStart, newEnd, true, true))
         case IndexedSeq(x1, x2) =>
-          IndexedSeq(x1.copy(start = newStart, includesStart = true),
+          FastIndexedSeq(x1.copy(start = newStart, includesStart = true),
             x2.copy(end = newEnd, includesEnd = true))
         case _ =>
           rangeBounds.head.copy(start = newStart, includesStart = true)  +:

--- a/src/main/scala/is/hail/sparkextras/AdjustedPartitionsRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/AdjustedPartitionsRDD.scala
@@ -1,5 +1,6 @@
 package is.hail.sparkextras
 
+import is.hail.utils._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{Dependency, NarrowDependency, Partition, TaskContext}
 
@@ -32,8 +33,8 @@ class AdjustedPartitionsRDD[T](@transient var prev: RDD[T],
       }
   }
 
-  override def getDependencies: Seq[Dependency[_]] = Seq(new NarrowDependency[T](prev) {
-    override def getParents(partitionId: Int): Seq[Int] = adjustments(partitionId).map(_.index).toSeq
+  override def getDependencies: Seq[Dependency[_]] = FastSeq(new NarrowDependency[T](prev) {
+    override def getParents(partitionId: Int): Seq[Int] = adjustments(partitionId).map(_.index).toFastSeq
   })
 
   override def clearDependencies() {
@@ -58,6 +59,6 @@ class AdjustedPartitionsRDD[T](@transient var prev: RDD[T],
     val m = locationAvail.values.max
     locationAvail.filter(_._2 == m)
       .keys
-      .toSeq
+      .toFastSeq
   }
 }

--- a/src/main/scala/is/hail/sparkextras/BlockedRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/BlockedRDD.scala
@@ -1,5 +1,6 @@
 package is.hail.sparkextras
 
+import is.hail.utils._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{Dependency, NarrowDependency, Partition, TaskContext}
 
@@ -37,7 +38,7 @@ class BlockedRDD[T](@transient var prev: RDD[T],
   }
 
   override def getDependencies: Seq[Dependency[_]] = {
-    Seq(new NarrowDependency(prev) {
+    FastSeq(new NarrowDependency(prev) {
       def getParents(id: Int): Seq[Int] =
         partitions(id).asInstanceOf[BlockedRDDPartition].range
     })
@@ -58,11 +59,11 @@ class BlockedRDD[T](@transient var prev: RDD[T],
       .mapValues(_.length)
 
     if (locationAvail.isEmpty)
-      return Seq.empty
+      return FastSeq.empty[String]
 
     val m = locationAvail.values.max
     locationAvail.filter(_._2 == m)
       .keys
-      .toSeq
+      .toFastSeq
   }
 }

--- a/src/main/scala/is/hail/sparkextras/ReorderedPartitionsRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/ReorderedPartitionsRDD.scala
@@ -1,5 +1,6 @@
 package is.hail.sparkextras
 
+import is.hail.utils.FastSeq
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{Dependency, NarrowDependency, Partition, TaskContext}
 
@@ -24,8 +25,8 @@ class ReorderedPartitionsRDD[T](@transient var prev: RDD[T], @transient val oldI
     parent.compute(split.asInstanceOf[ReorderedPartitionsRDDPartition].oldPartition, context)
   }
 
-  override def getDependencies: Seq[Dependency[_]] = Seq(new NarrowDependency[T](prev) {
-    override def getParents(partitionId: Int): Seq[Int] = Seq(oldIndices(partitionId))
+  override def getDependencies: Seq[Dependency[_]] = FastSeq(new NarrowDependency[T](prev) {
+    override def getParents(partitionId: Int): Seq[Int] = FastSeq(oldIndices(partitionId))
   })
 
   override def clearDependencies() {

--- a/src/main/scala/is/hail/sparkextras/RepartitionedOrderedRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/RepartitionedOrderedRDD.scala
@@ -61,7 +61,7 @@ class RepartitionedOrderedRDD(
 
   val dependency = new OrderedDependency(oldPartitionerBc, newPartitionerBc, prevRDD)
 
-  override def getDependencies: Seq[Dependency[_]] = Seq(dependency)
+  override def getDependencies: Seq[Dependency[_]] = FastSeq(dependency)
 }
 
 class OrderedDependency(oldPartitionerBc: Broadcast[OrderedRVDPartitioner], newPartitionerBc: Broadcast[OrderedRVDPartitioner], rdd: RDD[RegionValue])
@@ -78,7 +78,7 @@ class OrderedDependency(oldPartitionerBc: Broadcast[OrderedRVDPartitioner], newP
 
   override def getParents(partitionId: Int): Seq[Int] = {
     val partBounds =
-      newPartitioner.rangeBounds(partitionId).asInstanceOf[Interval]
+      newPartitioner.rangeBounds(partitionId)
     oldPartitioner.getPartitionRange(partBounds)
   }
 }

--- a/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
+++ b/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
@@ -5,6 +5,7 @@ import breeze.numerics._
 import is.hail.annotations.Annotation
 import is.hail.expr._
 import is.hail.expr.types._
+import is.hail.utils.FastSeq
 
 object LogisticRegressionTest {
   val tests = Map("wald" -> WaldTest, "lrt" -> LikelihoodRatioTest, "score" -> ScoreTest, "firth" -> FirthTest)
@@ -66,7 +67,7 @@ object WaldTest extends LogisticRegressionTest {
 }
 
 case class WaldStats(b: DenseVector[Double], se: DenseVector[Double], z: DenseVector[Double], p: DenseVector[Double]) extends LogisticRegressionStats {
-  def toAnnotations: Seq[Annotation] = Seq(b(-1), se(-1), z(-1), p(-1))
+  def toAnnotations: Seq[Annotation] = FastSeq(b(-1), se(-1), z(-1), p(-1))
 }
 
 
@@ -103,7 +104,7 @@ object LikelihoodRatioTest extends LogisticRegressionTest {
 
 
 case class LikelihoodRatioStats(b: DenseVector[Double], chi2: Double, p: Double) extends LogisticRegressionStats {
-  def toAnnotations: Seq[Annotation] = Seq(b(-1), chi2, p)
+  def toAnnotations: Seq[Annotation] = FastSeq(b(-1), chi2, p)
 }
 
 
@@ -147,7 +148,7 @@ object FirthTest extends LogisticRegressionTest {
 
 
 case class FirthStats(b: DenseVector[Double], chi2: Double, p: Double) extends LogisticRegressionStats {
-  def toAnnotations: Seq[Annotation] = Seq(b(-1), chi2, p)
+  def toAnnotations: Seq[Annotation] = FastSeq(b(-1), chi2, p)
 }
 
 
@@ -203,7 +204,7 @@ object ScoreTest extends LogisticRegressionTest {
 
 
 case class ScoreStats(chi2: Double, p: Double) extends LogisticRegressionStats {
-  def toAnnotations: Seq[Annotation] = Seq(chi2, p)
+  def toAnnotations: Seq[Annotation] = FastSeq(chi2, p)
 }
 
 

--- a/src/main/scala/is/hail/stats/package.scala
+++ b/src/main/scala/is/hail/stats/package.scala
@@ -340,7 +340,7 @@ package object stats {
 
     val rdd = hc.sc.parallelize(
       (0 until callMat.cols).map { j =>
-        (Annotation(Locus("1", j + 1), Array("A", "C").toFastIndexedSeq),
+        (Annotation(Locus("1", j + 1), FastIndexedSeq("A", "C")),
           (0 until callMat.rows).map { i =>
             Genotype(callMat(i, j))
           }: Iterable[Annotation])
@@ -374,7 +374,7 @@ package object stats {
 
     val rdd = hc.sc.parallelize(
       (0 until gpMat.cols).map { j =>
-        (Annotation(Locus("1", j + 1), Array("A", "C").toFastIndexedSeq),
+        (Annotation(Locus("1", j + 1), FastIndexedSeq("A", "C")),
           (0 until gpMat.rows).map { i =>
             Row(gpMat(i, j): IndexedSeq[Annotation])
           }: Iterable[Annotation])

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -52,7 +52,7 @@ object Table {
       case Some(parts) => hc.sc.parallelize(range, numSlices = parts)
       case None => hc.sc.parallelize(range)
     }
-    Table(hc, rdd, TStruct(name -> TInt32()), IndexedSeq(name))
+    Table(hc, rdd, TStruct(name -> TInt32()), FastIndexedSeq(name))
   }
 
   def fromDF(hc: HailContext, df: DataFrame, key: java.util.ArrayList[String]): Table = {
@@ -337,7 +337,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
     Parser.parseToAST(expr, ec).toIR(Some("AGG")) match {
       case Some(convertedIR) =>
         val t = ir.TableAggregate(tir, convertedIR)
-        (ir.Interpret(t, ir.Env.empty, IndexedSeq(), None), t.typ)
+        (ir.Interpret(t, ir.Env.empty, FastIndexedSeq(), None), t.typ)
       case None =>
         val (t, f) = Parser.parseExpr(expr, ec)
         val (zVals, seqOp, combOp, resultOp) = Aggregators.makeFunctions[Annotation](ec, {

--- a/src/main/scala/is/hail/utils/FastIndexedSeq.scala
+++ b/src/main/scala/is/hail/utils/FastIndexedSeq.scala
@@ -9,6 +9,7 @@ object FastIndexedSeq {
   def apply[T](args: T*)(implicit tct: ClassTag[T]): IndexedSeq[T] = {
     args match {
       case args: mutable.WrappedArray[T] => args
+      case args: mutable.ArrayBuffer[T] => args
       case _ => args.toArray[T]
     }
   }

--- a/src/main/scala/is/hail/utils/FastIndexedSeq.scala
+++ b/src/main/scala/is/hail/utils/FastIndexedSeq.scala
@@ -6,6 +6,10 @@ import scala.reflect.ClassTag
 object FastIndexedSeq {
   def empty[T](implicit tct: ClassTag[T]): IndexedSeq[T] = FastIndexedSeq()
 
-  def apply[T](args: T*)(implicit tct: ClassTag[T]): IndexedSeq[T] =
-    args.asInstanceOf[mutable.WrappedArray[T]]
+  def apply[T](args: T*)(implicit tct: ClassTag[T]): IndexedSeq[T] = {
+    args match {
+      case args: mutable.WrappedArray[T] => args
+      case _ => args.toArray[T]
+    }
+  }
 }

--- a/src/main/scala/is/hail/utils/FastIndexedSeq.scala
+++ b/src/main/scala/is/hail/utils/FastIndexedSeq.scala
@@ -1,0 +1,11 @@
+package is.hail.utils
+
+import scala.collection.mutable
+import scala.reflect.ClassTag
+
+object FastIndexedSeq {
+  def empty[T](implicit tct: ClassTag[T]): IndexedSeq[T] = FastIndexedSeq()
+
+  def apply[T](args: T*)(implicit tct: ClassTag[T]): IndexedSeq[T] =
+    args.asInstanceOf[mutable.WrappedArray[T]]
+}

--- a/src/main/scala/is/hail/utils/FastSeq.scala
+++ b/src/main/scala/is/hail/utils/FastSeq.scala
@@ -1,0 +1,13 @@
+package is.hail.utils
+
+import scala.collection.mutable
+import scala.reflect.ClassTag
+
+object FastSeq {
+  def empty[T](implicit tct: ClassTag[T]): Seq[T] = FastSeq()
+
+  def apply[T](args: T*)(implicit tct: ClassTag[T]): Seq[T] = {
+    assert(args.isInstanceOf[mutable.WrappedArray[_]])
+    args
+  }
+}

--- a/src/main/scala/is/hail/utils/FastSeq.scala
+++ b/src/main/scala/is/hail/utils/FastSeq.scala
@@ -9,6 +9,7 @@ object FastSeq {
   def apply[T](args: T*)(implicit tct: ClassTag[T]): Seq[T] = {
     args match {
       case args: mutable.WrappedArray[T] => args
+      case args: mutable.ArrayBuffer[T] => args
       case _ => args.toArray[T]
     }
   }

--- a/src/main/scala/is/hail/utils/FastSeq.scala
+++ b/src/main/scala/is/hail/utils/FastSeq.scala
@@ -7,7 +7,9 @@ object FastSeq {
   def empty[T](implicit tct: ClassTag[T]): Seq[T] = FastSeq()
 
   def apply[T](args: T*)(implicit tct: ClassTag[T]): Seq[T] = {
-    assert(args.isInstanceOf[mutable.WrappedArray[_]])
-    args
+    args match {
+      case args: mutable.WrappedArray[T] => args
+      case _ => args.toArray[T]
+    }
   }
 }

--- a/src/main/scala/is/hail/utils/richUtils/RichArray.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichArray.scala
@@ -36,6 +36,4 @@ object RichArray {
 
 class RichArray[T](val a: Array[T]) extends AnyVal {
   def index: Map[T, Int] = a.zipWithIndex.toMap
-
-  def toFastIndexedSeq: IndexedSeq[T] = a
 }

--- a/src/main/scala/is/hail/utils/richUtils/RichIterable.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichIterable.scala
@@ -165,10 +165,9 @@ class RichIterable[T](val i: Iterable[T]) extends Serializable {
 
   def toFastIndexedSeq(implicit tct: ClassTag[T]): IndexedSeq[T] = {
     i match {
-      case s: mutable.WrappedArray[T] =>
-        s
-      case _ =>
-        i.toArray[T]
+      case i: mutable.WrappedArray[T] => i
+      case i: mutable.ArrayBuffer[T] => i
+      case _ => i.toArray[T]
     }
   }
 }

--- a/src/main/scala/is/hail/utils/richUtils/RichIterable.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichIterable.scala
@@ -5,6 +5,7 @@ import java.io.Serializable
 import is.hail.utils._
 
 import scala.collection.{TraversableOnce, mutable}
+import scala.reflect.ClassTag
 
 class RichIterable[T](val i: Iterable[T]) extends Serializable {
   def lazyMap[S](f: (T) => S): Iterable[S] = new Iterable[S] with Serializable {
@@ -158,5 +159,16 @@ class RichIterable[T](val i: Iterable[T]) extends Serializable {
     i.foreach { elem => m.updateValue(elem, 0, _ + 1) }
 
     m.toMap
+  }
+
+  def toFastSeq(implicit tct: ClassTag[T]): Seq[T] = toFastIndexedSeq
+
+  def toFastIndexedSeq(implicit tct: ClassTag[T]): IndexedSeq[T] = {
+    i match {
+      case s: mutable.WrappedArray[T] =>
+        s
+      case _ =>
+        i.toArray[T]
+    }
   }
 }

--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -106,8 +106,8 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
       "values not sorted or not in range [0, number of partitions)")
     val parentPartitions = r.partitions
 
-    new RDD[T](r.sparkContext, Seq(new NarrowDependency[T](r) {
-      def getParents(partitionId: Int): Seq[Int] = Seq(keep(partitionId))
+    new RDD[T](r.sparkContext, FastSeq(new NarrowDependency[T](r) {
+      def getParents(partitionId: Int): Seq[Int] = FastSeq(keep(partitionId))
     })) {
       def getPartitions: Array[Partition] = keep.indices.map { i =>
         SubsetRDDPartition(i, parentPartitions(keep(i)))

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -815,7 +815,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     val keyedRDD = kt.keyedRDD()
       .filter { case (k, v) => k.toSeq.forall(_ != null) }
 
-    val nullValue: IndexedSeq[Annotation] = if (product) IndexedSeq() else null
+    val nullValue: IndexedSeq[Annotation] = if (product) FastIndexedSeq() else null
 
     if (vdsKey != null) {
       val keyEC = EvalContext(Map("sa" -> (0, colType)))

--- a/src/test/scala/is/hail/expr/AstToIrSuite.scala
+++ b/src/test/scala/is/hail/expr/AstToIrSuite.scala
@@ -2,6 +2,7 @@ package is.hail.expr
 
 import is.hail.expr.ir._
 import is.hail.expr.types._
+import is.hail.utils.FastSeq
 import org.testng.annotations.Test
 import org.scalatest.testng.TestNGSuite
 
@@ -22,12 +23,12 @@ class ASTToIRSuite extends TestNGSuite {
       "3.0" -> F64(3.0),
       "true" -> True(),
       "false" -> False(),
-      "{}" -> MakeStruct(Seq()),
-      "{a : 1}" -> MakeStruct(Seq(("a", I32(1)))),
-      "{a: 1, b: 2}" -> MakeStruct(Seq(
+      "{}" -> MakeStruct(FastSeq()),
+      "{a : 1}" -> MakeStruct(FastSeq(("a", I32(1)))),
+      "{a: 1, b: 2}" -> MakeStruct(FastSeq(
         ("a", I32(1)), ("b", I32(2)))),
-      "[1, 2]" -> MakeArray(Seq(I32(1), I32(2)), TArray(TInt32())),
-      "[42.0]" -> MakeArray(Seq(F64(42.0)), TArray(TFloat64()))
+      "[1, 2]" -> MakeArray(FastSeq(I32(1), I32(2)), TArray(TInt32())),
+      "[42.0]" -> MakeArray(FastSeq(F64(42.0)), TArray(TFloat64()))
     )
     } {
       assert(toIR(in).contains(out),
@@ -40,13 +41,13 @@ class ASTToIRSuite extends TestNGSuite {
     for {(in, out) <- Array(
       "{a: 1, b: 2}.a" ->
         GetField(
-          MakeStruct(Seq(
+          MakeStruct(FastSeq(
             ("a", I32(1)), ("b", I32(2)))),
           "a",
           TInt32()),
       "{a: 1, b: 2}.b" ->
         GetField(
-          MakeStruct(Seq(
+          MakeStruct(FastSeq(
             ("a", I32(1)), ("b", I32(2)))),
           "b",
           TInt32())
@@ -110,24 +111,24 @@ class ASTToIRSuite extends TestNGSuite {
   @Test
   def aggs() { for { (in, out) <- Array(
     "aggregable.sum()" ->
-      ApplyAggOp(AggIn(), Sum(), Seq()),
+      ApplyAggOp(AggIn(), Sum(), FastSeq()),
     "aggregable.map(x => x * 5).sum()" ->
       ApplyAggOp(
         AggMap(AggIn(), "x", ApplyBinaryPrimOp(Multiply(), Ref("x"), I32(5))),
-        Sum(), Seq(), TInt32()),
+        Sum(), FastSeq(), TInt32()),
     "aggregable.map(x => x * something).sum()" ->
       ApplyAggOp(
         AggMap(AggIn(), "x", ApplyBinaryPrimOp(Multiply(), Ref("x"), Ref("something"))),
-        Sum(), Seq()),
+        Sum(), FastSeq()),
     "aggregable.filter(x => x > 2).sum()" ->
       ApplyAggOp(
         AggFilter(AggIn(), "x", ApplyBinaryPrimOp(GT(), Ref("x"), I32(2))),
-        Sum(), Seq()),
+        Sum(), FastSeq()),
     "aggregable.flatMap(x => [x * 5]).sum()" ->
       ApplyAggOp(
         AggFlatMap(AggIn(), "x",
-          MakeArray(Seq(ApplyBinaryPrimOp(Multiply(), Ref("x") ,I32(5))))),
-        Sum(), Seq())
+          MakeArray(FastSeq(ApplyBinaryPrimOp(Multiply(), Ref("x") ,I32(5))))),
+        Sum(), FastSeq())
   )
   } {
     val tAgg = TAggregable(TInt32())

--- a/src/test/scala/is/hail/io/ExportVCFSuite.scala
+++ b/src/test/scala/is/hail/io/ExportVCFSuite.scala
@@ -46,7 +46,7 @@ class ExportVCFSuite extends SparkSuite {
       Source.fromInputStream(s)
         .getLines()
         .filter(line => !line.isEmpty && line(0) != '#')
-        .map(line => line.split("\t")).take(5).map(a => Annotation(Locus(a(0), a(1).toInt), Array(a(3), a(4)).toFastIndexedSeq)).toArray
+        .map(line => line.split("\t")).take(5).map(a => Annotation(Locus(a(0), a(1).toInt), FastIndexedSeq(a(3), a(4)))).toArray
     }.isSorted)
   }
 

--- a/src/test/scala/is/hail/utils/TestRDDBuilder.scala
+++ b/src/test/scala/is/hail/utils/TestRDDBuilder.scala
@@ -97,7 +97,7 @@ object TestRDDBuilder {
 
     // create array of (Variant, gq[Int], dp[Int])
     val variantArray = (0 until nVariants).map(i =>
-      (Locus("1", i + 1), Array(defaultRef, defaultAlt).toFastIndexedSeq,
+      (Locus("1", i + 1), FastIndexedSeq(defaultRef, defaultAlt),
         (callArray.map(_ (i)),
           gqArray.map(_ (i)),
           dpArray.map(_ (i)))))


### PR DESCRIPTION
Added FastSeq, FastIndexedSeq constructors.
.toFastSeq, toFastIndexedSeq now work on Iterable[T], not just array.

Mapping WrappedArrays returns ArrayBuffers.  I think this is forced by the Iterable/Seq interface, since map cannot take a ClassTag for new element type.

```
scala> Seq(1, 2, 3)
res0: Seq[Int] = List(1, 2, 3)

scala> val a = Seq(1, 2, 3)
a: Seq[Int] = List(1, 2, 3)

scala> val b: Seq[Int] = Array(1, 2, 3)
b: Seq[Int] = WrappedArray(1, 2, 3)

scala> a.map(_ + 1)
res1: Seq[Int] = List(2, 3, 4)

scala> b.map(_ + 1)
res2: Seq[Int] = ArrayBuffer(2, 3, 4)
```
