### PR TITLE
Added ir.Optimize

### DIFF
--- a/python/hail/expr/types.py
+++ b/python/hail/expr/types.py
@@ -15,6 +15,7 @@ __all__ = [
     'HailType',
     'hail_type',
     'is_container',
+    'is_compound',
     'is_numeric',
     'is_primitive',
     'types_match',

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -25,6 +25,7 @@ object Compile {
       .zipWithIndex
       .foldLeft(Env.empty[IR]) { case (e, ((n, t, _), i)) => e.bind(n, In(i, t)) }
 
+    ir = Optimize(ir)
     ir = Subst(ir, env)
     Infer(ir)
     assert(TypeToIRIntermediateClassTag(ir.typ) == classTag[R])

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -25,7 +25,6 @@ object Compile {
       .zipWithIndex
       .foldLeft(Env.empty[IR]) { case (e, ((n, t, _), i)) => e.bind(n, In(i, t)) }
 
-    ir = Optimize(ir)
     ir = Subst(ir, env)
     Infer(ir)
     assert(TypeToIRIntermediateClassTag(ir.typ) == classTag[R])

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -14,18 +14,22 @@ object Interpret {
 
   def apply[T](ir: IR): T = apply(ir, Env.empty[(Any, Type)], IndexedSeq(), None).asInstanceOf[T]
 
-  def apply[T](ir: IR,
+  def apply[T](ir0: IR,
     env: Env[(Any, Type)],
     args: IndexedSeq[(Any, Type)],
     agg: Option[Agg]): T = {
 
-    log.info("interpret:\n" + Pretty(ir))
 
     val (typeEnv, valueEnv) = env.m.foldLeft((Env.empty[Type], Env.empty[Any])) {
       case ((e1, e2), (k, (value, t))) => (e1.bind(k, t), e2.bind(k, value))
     }
 
+    var ir = ir0
+    ir = Optimize(ir)
     Infer(ir, agg.map(_._1), typeEnv)
+
+    log.info("interpret:\n" + Pretty(ir))
+
     interpret(ir, valueEnv, args, agg.orNull).asInstanceOf[T]
   }
 

--- a/src/main/scala/is/hail/expr/ir/Optimize.scala
+++ b/src/main/scala/is/hail/expr/ir/Optimize.scala
@@ -1,0 +1,52 @@
+package is.hail.expr.ir
+
+import is.hail.expr._
+
+object Optimize {
+  private def optimize(ir: BaseIR): BaseIR = {
+    RewriteBottomUp(ir, {
+      // optimize TableIR
+      case TableFilter(t, True()) => t
+
+      case TableFilter(TableRead(path, spec, _), False() | NA(_)) =>
+        TableRead(path, spec, dropRows = true)
+
+      case TableFilter(TableFilter(t, p1), p2) =>
+        TableFilter(t,
+          ApplySpecial("&&", Array(p1, p2)))
+
+      // optimize MatrixIR
+
+      // Equivalent rewrites for the new Filter{Cols,Rows}IR
+      case FilterRowsIR(MatrixRead(path, spec, dropSamples, _), False() | NA(_)) =>
+        MatrixRead(path, spec, dropSamples, dropRows = true)
+
+      case FilterColsIR(MatrixRead(path, spec, dropVariants, _), False() | NA(_)) =>
+        MatrixRead(path, spec, dropCols = true, dropVariants)
+
+      // Keep all rows/cols = do nothing
+      case FilterRowsIR(m, True()) => m
+
+      case FilterColsIR(m, True()) => m
+
+      // Push FilterRowsIR into FilterColsIR
+      case FilterRowsIR(FilterColsIR(m, colPred), rowPred) =>
+        FilterColsIR(FilterRowsIR(m, rowPred), colPred)
+
+      // Combine multiple filters into one
+      case FilterRowsIR(FilterRowsIR(m, pred1), pred2) =>
+        FilterRowsIR(m,
+          ApplySpecial("&&", Array(pred1, pred2)))
+
+      case FilterColsIR(FilterColsIR(m, pred1), pred2) =>
+        FilterColsIR(m,
+          ApplySpecial("&&", Array(pred1, pred2)))
+    })
+  }
+
+  def apply(ir: TableIR): TableIR = optimize(ir).asInstanceOf[TableIR]
+
+  def apply(ir: MatrixIR): MatrixIR = optimize(ir).asInstanceOf[MatrixIR]
+
+  def apply(ir: IR): IR = optimize(ir).asInstanceOf[IR]
+}

--- a/src/main/scala/is/hail/expr/ir/RewriteBottomUp.scala
+++ b/src/main/scala/is/hail/expr/ir/RewriteBottomUp.scala
@@ -1,0 +1,27 @@
+package is.hail.expr.ir
+
+import is.hail.expr._
+
+object RewriteBottomUp {
+  def apply(ir: BaseIR, rule: PartialFunction[BaseIR, BaseIR]): BaseIR = {
+    def rewrite(ast: BaseIR): BaseIR = {
+      val newChildren = ast.children.map(rewrite)
+
+      // only recons if necessary
+      val rewritten =
+        if ((ast.children, newChildren).zipped.forall(_ eq _))
+          ast
+        else
+          ast.copy(newChildren)
+
+      rule.lift(rewritten) match {
+        case Some(newAST) if newAST != rewritten =>
+          rewrite(newAST)
+        case None =>
+          rewritten
+      }
+    }
+
+    rewrite(ir)
+  }
+}

--- a/src/main/scala/is/hail/expr/ir/RewriteTopDown.scala
+++ b/src/main/scala/is/hail/expr/ir/RewriteTopDown.scala
@@ -1,0 +1,22 @@
+package is.hail.expr.ir
+
+import is.hail.expr._
+
+object RewriteTopDown {
+  def rewriteTopDown(ast: BaseIR, rule: PartialFunction[BaseIR, BaseIR]): BaseIR = {
+    def rewrite(ast: BaseIR): BaseIR = {
+      rule.lift(ast) match {
+        case Some(newAST) if newAST != ast =>
+          rewrite(newAST)
+        case None =>
+          val newChildren = ast.children.map(rewrite)
+          if ((ast.children, newChildren).zipped.forall(_ eq _))
+            ast
+          else
+            ast.copy(newChildren)
+      }
+    }
+
+    rewrite(ast)
+  }
+}

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -165,7 +165,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
   }
 
   lazy val value: TableValue = {
-    val opt = TableIR.optimize(tir)
+    val opt = ir.Optimize(tir)
 
     log.info("in Table.value: execute:\n" + ir.Pretty(opt))
 

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -562,7 +562,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     .toArray
 
   lazy val value: MatrixValue = {
-    val opt = MatrixIR.optimize(ast)
+    val opt = ir.Optimize(ast)
 
     log.info("in MatrixTable.value: execute:\n" + ir.Pretty(opt))
 


### PR DESCRIPTION
Mostly code reorg.  Also:

moved rewriters to ir objects
call Optimize before intepreting
removed Filter{Rows, Cols} rules (non-IR), those should get folded back into the MT methods like other AST-based rules
re-enabled Fitler{Rows, Cols}IR fusion rules since logical and/or is back
