### PR TITLE
IR types are always available

### DIFF
--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -352,7 +352,7 @@ case class Select(posn: Position, lhs: AST, rhs: String) extends AST(posn, lhs) 
     s <- lhs.toIR(agg)
     t <- someIf(lhs.`type`.isInstanceOf[TStruct], lhs.`type`.asInstanceOf[TStruct])
     f <- t.selfField(rhs)
-  } yield ir.GetField(s, rhs, f.typ)
+  } yield ir.GetField(s, rhs)
 }
 
 case class ArrayConstructor(posn: Position, elements: Array[AST]) extends AST(posn, elements) {
@@ -703,11 +703,11 @@ case class Apply(posn: Position, fn: String, args: Array[AST]) extends AST(posn,
       case IndexedSeq((xt, x)) => for {
         op <- ir.UnaryOp.fromString.lift(fn)
         t <- ir.UnaryOp.returnTypeOption(op, xt)
-      } yield ir.ApplyUnaryPrimOp(op, x, t)
+      } yield ir.ApplyUnaryPrimOp(op, x)
       case IndexedSeq((xt, x), (yt, y)) => for {
         op <- ir.BinaryOp.fromString.lift(fn)
         t <- ir.BinaryOp.returnTypeOption(op, xt, yt)
-      } yield ir.ApplyBinaryPrimOp(op, x, y, t)
+      } yield ir.ApplyBinaryPrimOp(op, x, y)
     }
 
   private[this] def tryIRConversion(agg: Option[String]): Option[IR] =
@@ -827,9 +827,9 @@ case class ApplyMethod(posn: Position, lhs: AST, method: String, args: Array[AST
           a <- lhs.toIR(agg)
           b <- body.toIR(agg)
           result <- optMatch((t, m)) {
-            case (_: TAggregable, "map") => ir.AggMap(a, name, b, `type`.asInstanceOf[TAggregable])
-            case (_: TAggregable, "filter") => ir.AggFilter(a, name, b, `type`.asInstanceOf[TAggregable])
-            case (_: TAggregable, "flatMap") => ir.AggFlatMap(a, name, b, `type`.asInstanceOf[TAggregable])
+            case (_: TAggregable, "map") => ir.AggMap(a, name, b)
+            case (_: TAggregable, "filter") => ir.AggFilter(a, name, b)
+            case (_: TAggregable, "flatMap") => ir.AggFlatMap(a, name, b)
             case (_: TArray, "map") => ir.ArrayMap(a, name, b)
             case (_: TArray, "filter") => ir.ArrayFilter(a, name, b)
             case (_: TArray, "flatMap") => ir.ArrayFlatMap(a, name, b)
@@ -931,7 +931,7 @@ case class If(pos: Position, cond: AST, thenTree: AST, elseTree: AST)
     condition <- cond.toIR(agg)
     consequent <- thenTree.toIR(agg)
     alternate <- elseTree.toIR(agg)
-  } yield ir.If(condition, consequent, alternate, `type`)
+  } yield ir.If(condition, consequent, alternate)
 }
 
 // PrettyAST(ast) gives a pretty-print of an AST tree

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -844,9 +844,6 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR) extends MatrixIR {
   val tAgg = TAggregable(tAggElt, aggSymTab)
 
   val typ: MatrixType = {
-    println("prevRVRowType", child.typ.rvRowType)
-    println("newRVRow", Pretty(newRVRow))
-    println("newRVRow.typ", newRVRow.typ)
     val newRVRowSet = newRVRow.typ.fieldNames.toSet
     val newRowKey = child.typ.rowKey.filter(newRVRowSet.contains)
     val newPartitionKey = child.typ.rowPartitionKey.filter(newRVRowSet.contains)

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -689,7 +689,6 @@ case class FilterRowsIR(
     val prev = child.execute(hc)
     assert(child.typ == prev.typ)
 
-    println(Pretty(pred))
     val (rTyp, predCompiledFunc) = ir.Compile[Long, Long, Boolean](
       "va", typ.rvRowType,
       "global", typ.globalType,

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -207,10 +207,10 @@ object MatrixIR {
     val keepType = TArray(+TInt32())
     val (rTyp, makeF) = ir.Compile[Long, Long, Long]("row", rowType,
       "keep", keepType,
-      body = InsertFields(ir.Ref("row"), Seq((MatrixType.entriesIdentifier,
-        ir.ArrayMap(ir.Ref("keep"), "i",
+      body = InsertFields(ir.Ref("row", rowType), Seq((MatrixType.entriesIdentifier,
+        ir.ArrayMap(ir.Ref("keep", keepType), "i",
           ir.ArrayRef(ir.GetField(ir.In(0, rowType), MatrixType.entriesIdentifier),
-            ir.Ref("i")))))))
+            ir.Ref("i", TInt32())))))))
     assert(rTyp.isOfType(rowType))
 
     val newMatrixType = typ.copy(rvRowType = coerce[TStruct](rTyp))
@@ -659,11 +659,10 @@ case class FilterRows(
 
     val filteredRDD = prev.rvd.mapPartitionsPreservesPartitioning(prev.typ.orvdType) { it =>
       val fullRow = new UnsafeRow(fullRowType)
-      val row = fullRow.deleteField(localEntriesIndex)
       it.filter { rv =>
         fullRow.set(rv)
         ec.set(0, localGlobals.value)
-        ec.set(1, row)
+        ec.set(1, fullRow)
         aggregatorOption.foreach(_ (rv))
         f() == true
       }
@@ -688,18 +687,18 @@ case class FilterRowsIR(
 
   def execute(hc: HailContext): MatrixValue = {
     val prev = child.execute(hc)
+    assert(child.typ == prev.typ)
 
+    println(Pretty(pred))
     val (rTyp, predCompiledFunc) = ir.Compile[Long, Long, Boolean](
       "va", typ.rvRowType,
       "global", typ.globalType,
-      pred
-    )
+      pred)
 
     // Note that we don't yet support IR aggregators
     //
     // Everything used inside the Spark iteration must be serializable,
     // so we pick out precisely what is needed.
-    //
     val fullRowType = prev.typ.rvRowType
     val localRowType = prev.typ.rowType
     val localEntriesIndex = prev.typ.entriesIdx
@@ -766,22 +765,19 @@ case class MapEntries(child: MatrixIR, newEntries: IR) extends MatrixIR {
   }
 
   val newRow = {
-    val arrayLength = ArrayLen(GetField(Ref("va"), MatrixType.entriesIdentifier))
+    val vaType = child.typ.rvRowType
+    val saType = TArray(child.typ.colType)
+
+    val arrayLength = ArrayLen(GetField(Ref("va", vaType), MatrixType.entriesIdentifier))
     val idxEnv = new Env[IR]()
-      .bind("g", ArrayRef(GetField(Ref("va"), MatrixType.entriesIdentifier), Ref("i")))
-      .bind("sa", ArrayRef(Ref("sa"), Ref("i")))
+      .bind("g", ArrayRef(GetField(Ref("va", vaType), MatrixType.entriesIdentifier), Ref("i", TInt32())))
+      .bind("sa", ArrayRef(Ref("sa", saType), Ref("i", TInt32())))
     val entries = ArrayMap(ArrayRange(I32(0), arrayLength, I32(1)), "i", Subst(newEntries, idxEnv))
-    InsertFields(Ref("va"), Seq((MatrixType.entriesIdentifier, entries)))
+    InsertFields(Ref("va", vaType), Seq((MatrixType.entriesIdentifier, entries)))
   }
 
-  val typ: MatrixType = {
-    Infer(newRow, None, new Env[Type]()
-      .bind("global", child.typ.globalType)
-      .bind("va", child.typ.rvRowType)
-      .bind("sa", TArray(child.typ.colType))
-    )
+  val typ: MatrixType =
     child.typ.copy(rvRowType = newRow.typ)
-  }
 
   override def partitionCounts: Option[Array[Long]] = child.partitionCounts
 
@@ -836,7 +832,8 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR) extends MatrixIR {
     MatrixMapRows(newChildren(0).asInstanceOf[MatrixIR], newChildren(1).asInstanceOf[IR])
   }
 
-  val newRVRow = InsertFields(newRow, Seq(MatrixType.entriesIdentifier -> GetField(Ref("va"), MatrixType.entriesIdentifier)))
+  val newRVRow = InsertFields(newRow, Seq(
+    MatrixType.entriesIdentifier -> GetField(Ref("va", child.typ.rvRowType), MatrixType.entriesIdentifier)))
 
   val tAggElt: Type = child.typ.entryType
   val aggSymTab = Map(
@@ -848,11 +845,9 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR) extends MatrixIR {
   val tAgg = TAggregable(tAggElt, aggSymTab)
 
   val typ: MatrixType = {
-    Infer(newRVRow, Some(tAgg), new Env[Type]()
-      .bind("global", child.typ.globalType)
-      .bind("va", child.typ.rvRowType)
-      .bind("AGG", tAgg)
-    )
+    println("prevRVRowType", child.typ.rvRowType)
+    println("newRVRow", Pretty(newRVRow))
+    println("newRVRow.typ", newRVRow.typ)
     val newRVRowSet = newRVRow.typ.fieldNames.toSet
     val newRowKey = child.typ.rowKey.filter(newRVRowSet.contains)
     val newPartitionKey = child.typ.rowPartitionKey.filter(newRVRowSet.contains)
@@ -865,7 +860,7 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR) extends MatrixIR {
     fields.exists { case (name, ir) =>
       typ.rowKey.contains(name) && (
         ir match {
-          case GetField(Ref("va", _), n, _) => n != name
+          case GetField(Ref("va", _), n) => n != name
           case _ => true
         })
     }
@@ -873,15 +868,16 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR) extends MatrixIR {
   val touchesKeys: Boolean = (typ.rowKey != child.typ.rowKey) ||
     (typ.rowPartitionKey != child.typ.rowPartitionKey) || (
     newRow match {
-      case MakeStruct(fields, _) =>
+      case MakeStruct(fields) =>
         makeStructChangesKeys(fields)
-      case InsertFields(MakeStruct(fields, _), toIns, _) =>
+      case InsertFields(MakeStruct(fields), toIns) =>
         makeStructChangesKeys(fields) || toIns.map(_._1).toSet.intersect(typ.rowKey.toSet).nonEmpty
       case _ => true
     })
 
   def execute(hc: HailContext): MatrixValue = {
     val prev = child.execute(hc)
+    assert(prev.typ == child.typ)
 
     val localRowType = prev.typ.rvRowType
     val localEntriesType = prev.typ.entryArrayType
@@ -971,13 +967,8 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR) extends MatrixIR {
 case class MatrixMapGlobals(child: MatrixIR, newRow: IR, value: BroadcastRow) extends MatrixIR {
   val children: IndexedSeq[BaseIR] = Array(child, newRow)
 
-  val typ: MatrixType = {
-    Infer(newRow, None, new Env[Type]()
-      .bind("global", child.typ.globalType)
-      .bind("value", value.t)
-    )
+  val typ: MatrixType =
     child.typ.copy(globalType = newRow.typ.asInstanceOf[TStruct])
-  }
 
   def copy(newChildren: IndexedSeq[BaseIR]): MatrixMapGlobals = {
     assert(newChildren.length == 2)
@@ -1394,7 +1385,6 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
   val children: IndexedSeq[BaseIR] = Array(child, newRow)
 
   val typ: TableType = {
-    Infer(newRow, None, child.typ.env)
     val newRowType = newRow.typ.asInstanceOf[TStruct]
     val newKey = child.typ.key.filter(newRowType.fieldIdx.contains)
     child.typ.copy(rowType = newRowType, key = newKey)
@@ -1438,10 +1428,8 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
 case class TableMapGlobals(child: TableIR, newRow: IR, value: BroadcastRow) extends TableIR {
   val children: IndexedSeq[BaseIR] = Array(child, newRow)
 
-  val typ: TableType = {
-    Infer(newRow, None, child.typ.env.bind("value", value.t))
+  val typ: TableType =
     child.typ.copy(globalType = newRow.typ.asInstanceOf[TStruct])
-  }
 
   def copy(newChildren: IndexedSeq[BaseIR]): TableMapGlobals = {
     assert(newChildren.length == 2)
@@ -1493,18 +1481,20 @@ case class TableExplode(child: TableIR, column: String) extends TableIR {
   def execute(hc: HailContext): TableValue = {
     val prev = child.execute(hc)
 
-    val (_, isMissingF) = ir.Compile[Long, Boolean]("row", child.typ.rowType,
-      ir.IsNA(ir.GetField(Ref("row"), column)))
+    val childRowType = child.typ.rowType
 
-    val (_, lengthF) = ir.Compile[Long, Int]("row", child.typ.rowType,
-      ir.ArrayLen(ir.GetField(Ref("row"), column)))
+    val (_, isMissingF) = ir.Compile[Long, Boolean]("row", childRowType,
+      ir.IsNA(ir.GetField(Ref("row", childRowType), column)))
 
-    val (resultType, explodeF) = ir.Compile[Long, Int, Long]("row", child.typ.rowType,
+    val (_, lengthF) = ir.Compile[Long, Int]("row", childRowType,
+      ir.ArrayLen(ir.GetField(Ref("row", childRowType), column)))
+
+    val (resultType, explodeF) = ir.Compile[Long, Int, Long]("row", childRowType,
       "i", TInt32(),
-      ir.InsertFields(Ref("row"),
+      ir.InsertFields(Ref("row", childRowType),
         Array(column -> ir.ArrayRef(
-          ir.GetField(ir.Ref("row"), column),
-          ir.Ref("i")))))
+          ir.GetField(ir.Ref("row", childRowType), column),
+          ir.Ref("i", TInt32())))))
     assert(resultType == typ.rowType)
 
     TableValue(typ, prev.globals,

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -17,65 +17,65 @@ object Children {
     case NA(typ) => none
     case IsNA(value) =>
       Array(value)
-    case If(cond, cnsq, altr, typ) =>
+    case If(cond, cnsq, altr) =>
       Array(cond, cnsq, altr)
-    case Let(name, value, body, typ) =>
+    case Let(name, value, body) =>
       Array(value, body)
     case Ref(name, typ) =>
       none
-    case ApplyBinaryPrimOp(op, l, r, typ) =>
+    case ApplyBinaryPrimOp(op, l, r) =>
       Array(l, r)
-    case ApplyUnaryPrimOp(op, x, typ) =>
+    case ApplyUnaryPrimOp(op, x) =>
       Array(x)
     case MakeArray(args, typ) =>
       args.toIndexedSeq
-    case ArrayRef(a, i, typ) =>
+    case ArrayRef(a, i) =>
       Array(a, i)
     case ArrayLen(a) =>
       Array(a)
     case ArrayRange(start, stop, step) =>
       Array(start, stop, step)
-    case ArrayMap(a, name, body, elementTyp) =>
+    case ArrayMap(a, name, body) =>
       Array(a, body)
     case ArrayFilter(a, name, cond) =>
       Array(a, cond)
     case ArrayFlatMap(a, name, body) =>
       Array(a, body)
-    case ArrayFold(a, zero, accumName, valueName, body, typ) =>
+    case ArrayFold(a, zero, accumName, valueName, body) =>
       Array(a, zero, body)
-    case MakeStruct(fields, _) =>
+    case MakeStruct(fields) =>
       fields.map(_._2).toIndexedSeq
-    case InsertFields(old, fields, _) =>
+    case InsertFields(old, fields) =>
       (old +: fields.map(_._2)).toIndexedSeq
     case AggIn(_) =>
       none
-    case AggMap(a, _, body, _) =>
+    case AggMap(a, _, body) =>
       Array(a, body)
-    case AggFilter(a, name, body, typ) =>
+    case AggFilter(a, name, body) =>
       Array(a, body)
-    case AggFlatMap(a, name, body, typ) =>
+    case AggFlatMap(a, name, body) =>
       Array(a, body)
-    case ApplyAggOp(a, op, args, _) =>
+    case ApplyAggOp(a, op, args) =>
       (a +: args).toIndexedSeq
-    case GetField(o, name, typ) =>
+    case GetField(o, name) =>
       Array(o)
-    case MakeTuple(types, _) =>
+    case MakeTuple(types) =>
       types.toIndexedSeq
-    case GetTupleElement(o, idx, _) =>
+    case GetTupleElement(o, idx) =>
       Array(o)
     case In(i, typ) =>
       none
     case Die(message) =>
       none
-    case Apply(_, args, _) =>
+    case Apply(_, args) =>
       args.toIndexedSeq
-    case ApplySpecial(_, args, _) =>
+    case ApplySpecial(_, args) =>
       args.toIndexedSeq
     // from MatrixIR
     case MatrixWrite(child, _, _, _) => IndexedSeq(child)
     // from TableIR
     case TableCount(child) => IndexedSeq(child)
-    case TableAggregate(child, query, _) => IndexedSeq(child, query)
+    case TableAggregate(child, query) => IndexedSeq(child, query)
     case TableWrite(child, _, _, _) => IndexedSeq(child)
     case TableExport(child, _, _, _, _) => IndexedSeq(child)
   }

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -137,8 +137,6 @@ object CompileWithAggregators {
     }.unzip
 
     val args2 = ("AGGR", aggResultType, classTag[Long]) +: args
-    println("body", Pretty(body))
-    println("postAggIR", Pretty(postAggIR))
     val (t, f) = Compile[F2, R](args2, postAggIR)
     (rvAggs, seqOps, aggResultType, f, t)
   }

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -27,7 +27,6 @@ object Compile {
       .foldLeft(Env.empty[IR]) { case (e, ((n, t, _), i)) => e.bind(n, In(i, t)) }
 
     ir = Subst(ir, env)
-    Infer(ir)
     assert(TypeToIRIntermediateClassTag(ir.typ) == classTag[R])
     Emit(ir, fb)
     (ir.typ, fb.result())
@@ -121,7 +120,6 @@ object CompileWithAggregators {
       .foldLeft(Env.empty[IR]) { case (e, ((n, t, _), i)) => e.bind(n, In(i, t)) }
 
     val ir = Subst(body, env)
-    Infer(ir, Some(aggType))
 
     val (postAggIR, aggResultType, aggregators) = ExtractAggregators(ir, aggType)
 
@@ -139,6 +137,8 @@ object CompileWithAggregators {
     }.unzip
 
     val args2 = ("AGGR", aggResultType, classTag[Long]) +: args
+    println("body", Pretty(body))
+    println("postAggIR", Pretty(postAggIR))
     val (t, f) = Compile[F2, R](args2, postAggIR)
     (rvAggs, seqOps, aggResultType, f, t)
   }

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -22,79 +22,79 @@ object Copy {
       case IsNA(value) =>
         val IndexedSeq(value: IR) = newChildren
         IsNA(value)
-      case If(_, _, _, typ) =>
+      case If(_, _, _) =>
         val IndexedSeq(cond: IR, cnsq: IR, altr: IR) = newChildren
-        If(cond, cnsq, altr, typ)
-      case Let(name, _, _, typ) =>
+        If(cond, cnsq, altr)
+      case Let(name, _, _) =>
         val IndexedSeq(value: IR, body: IR) = newChildren
-        Let(name, value, body, typ)
+        Let(name, value, body)
       case Ref(_, _) =>
         same
-      case ApplyBinaryPrimOp(op, _, _, typ) =>
+      case ApplyBinaryPrimOp(op, _, _) =>
         val IndexedSeq(l: IR, r: IR) = newChildren
-        ApplyBinaryPrimOp(op, l, r, typ)
-      case ApplyUnaryPrimOp(op, _, typ) =>
+        ApplyBinaryPrimOp(op, l, r)
+      case ApplyUnaryPrimOp(op, _) =>
         val IndexedSeq(x: IR) = newChildren
-        ApplyUnaryPrimOp(op, x, typ)
+        ApplyUnaryPrimOp(op, x)
       case MakeArray(args, typ) =>
         assert(args.length == newChildren.length)
         MakeArray(newChildren.map(_.asInstanceOf[IR]), typ)
-      case ArrayRef(_, _, typ) =>
+      case ArrayRef(_, _) =>
         val IndexedSeq(a: IR, i: IR) = newChildren
-        ArrayRef(a, i, typ)
+        ArrayRef(a, i)
       case ArrayLen(_) =>
         val IndexedSeq(a: IR) = newChildren
         ArrayLen(a)
       case ArrayRange(_, _, _) =>
         val IndexedSeq(start: IR, stop: IR, step: IR) = newChildren
         ArrayRange(start, stop, step)
-      case ArrayMap(_, name, _, elementTyp) =>
+      case ArrayMap(_, name, _) =>
         val IndexedSeq(a: IR, body: IR) = newChildren
-        ArrayMap(a, name, body, elementTyp)
+        ArrayMap(a, name, body)
       case ArrayFilter(_, name, _) =>
         val IndexedSeq(a: IR, cond: IR) = newChildren
         ArrayFilter(a, name, cond)
       case ArrayFlatMap(_, name, _) =>
         val IndexedSeq(a: IR, body: IR) = newChildren
         ArrayFlatMap(a, name, body)
-      case ArrayFold(_, _, accumName, valueName, _, typ) =>
+      case ArrayFold(_, _, accumName, valueName, _) =>
         val IndexedSeq(a: IR, zero: IR, body: IR) = newChildren
-        ArrayFold(a, zero, accumName, valueName, body, typ)
-      case MakeStruct(fields, _) =>
+        ArrayFold(a, zero, accumName, valueName, body)
+      case MakeStruct(fields) =>
         assert(fields.length == newChildren.length)
         MakeStruct(fields.zip(newChildren).map { case ((n, _), a) => (n, a.asInstanceOf[IR]) })
-      case InsertFields(_, fields, typ) =>
+      case InsertFields(_, fields) =>
         assert(newChildren.length == fields.length + 1)
         InsertFields(newChildren.head.asInstanceOf[IR], fields.zip(newChildren.tail).map { case ((n, _), a) => (n, a.asInstanceOf[IR]) })
-      case GetField(_, name, typ) =>
+      case GetField(_, name) =>
         val IndexedSeq(o: IR) = newChildren
-        GetField(o, name, typ)
+        GetField(o, name)
       case AggIn(_) =>
         same
-      case AggMap(_, name, _, typ) =>
+      case AggMap(_, name, _) =>
         val IndexedSeq(a: IR, body: IR) = newChildren
-        AggMap(a, name, body, typ)
-      case AggFilter(_, name, _, typ) =>
+        AggMap(a, name, body)
+      case AggFilter(_, name, _) =>
         val IndexedSeq(a: IR, body: IR) = newChildren
-        AggFilter(a, name, body, typ)
-      case AggFlatMap(_, name, _, typ) =>
+        AggFilter(a, name, body)
+      case AggFlatMap(_, name, _) =>
         val IndexedSeq(a: IR, body: IR) = newChildren
-        AggFlatMap(a, name, body, typ)
-      case ApplyAggOp(_, op, args, typ) =>
-        ApplyAggOp(newChildren.head.asInstanceOf[IR], op, newChildren.tail.map(_.asInstanceOf[IR]), typ)
-      case MakeTuple(_, typ) =>
-        MakeTuple(newChildren.map(_.asInstanceOf[IR]), typ)
-      case GetTupleElement(_, idx, typ) =>
+        AggFlatMap(a, name, body)
+      case ApplyAggOp(_, op, args) =>
+        ApplyAggOp(newChildren.head.asInstanceOf[IR], op, newChildren.tail.map(_.asInstanceOf[IR]))
+      case MakeTuple(_) =>
+        MakeTuple(newChildren.map(_.asInstanceOf[IR]))
+      case GetTupleElement(_, idx) =>
         val IndexedSeq(o: IR) = newChildren
-        GetTupleElement(o, idx, typ)
+        GetTupleElement(o, idx)
       case In(_, _) =>
         same
       case Die(message) =>
         same
-      case Apply(fn, args, impl) =>
-        Apply(fn, newChildren.map(_.asInstanceOf[IR]), impl)
-      case ApplySpecial(fn, args, impl) =>
-        ApplySpecial(fn, newChildren.map(_.asInstanceOf[IR]), impl)
+      case Apply(fn, args) =>
+        Apply(fn, newChildren.map(_.asInstanceOf[IR]))
+      case ApplySpecial(fn, args) =>
+        ApplySpecial(fn, newChildren.map(_.asInstanceOf[IR]))
       // from MatrixIR
       case MatrixWrite(_, path, overwrite, codecSpecJSONStr) =>
         val IndexedSeq(child: MatrixIR) = newChildren
@@ -103,7 +103,7 @@ object Copy {
       case TableCount(_) =>
         val IndexedSeq(child: TableIR) = newChildren
         TableCount(child)
-      case TableAggregate(_, _, typ) =>
+      case TableAggregate(_, _) =>
         val IndexedSeq(child: TableIR, query: IR) = newChildren
         TableAggregate(child, query)
       case TableWrite(_, path, overwrite, codecSpecJSONStr) =>

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -47,7 +47,7 @@ object Emit {
     env: E,
     tAggIn: Option[TAggregable],
     nSpecialArguments: Int): EmitTriplet = {
-    TypeCheck(ir)
+    TypeCheck(ir, tAggIn)
     new Emit(fb.apply_method, tAggIn, nSpecialArguments).emit(ir, env)
   }
 }

--- a/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -43,13 +43,13 @@ object ExtractAggregators {
         val ref = Ref("AGGR", null)
         ab += IRAgg(ref, x)
 
-        GetField(ref, (ab.length - 1).toString, x.typ)
+        GetField(ref, (ab.length - 1).toString)
       case _ => Recur(extract)(ir)
     }
   }
 
   private def newAggregator(ir: ApplyAggOp): RegionValueAggregator = ir match {
-    case x@ApplyAggOp(a, op, args, typ) =>
+    case x@ApplyAggOp(a, op, args) =>
       val constfb = EmitFunctionBuilder[Region, RegionValueAggregator]
       val codeArgs = args.map(Emit.toCode(_, constfb, 1))
       constfb.emit(Code(

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.expr.types._
 import is.hail.expr.{BaseIR, MatrixIR, TableIR}
-import is.hail.expr.ir.functions.{IRFunction, IRFunctionWithMissingness, IRFunctionWithoutMissingness}
+import is.hail.expr.ir.functions.{IRFunction, IRFunctionRegistry, IRFunctionWithMissingness, IRFunctionWithoutMissingness}
 import is.hail.utils.ExportType
 
 sealed trait IR extends BaseIR {
@@ -35,6 +35,16 @@ object Literal {
   }
 }
 
+trait InferIR extends IR {
+  var _typ: Type = null
+
+  def typ: Type = {
+    if (_typ == null)
+      _typ = Infer(this)
+    _typ
+  }
+}
+
 final case class I32(x: Int) extends IR { val typ = TInt32() }
 final case class I64(x: Long) extends IR { val typ = TInt64() }
 final case class F32(x: Float) extends IR { val typ = TFloat32() }
@@ -47,48 +57,68 @@ final case class Cast(v: IR, typ: Type) extends IR
 final case class NA(typ: Type) extends IR
 final case class IsNA(value: IR) extends IR { val typ = TBoolean() }
 
-final case class If(cond: IR, cnsq: IR, altr: IR, var typ: Type = null) extends IR
+final case class If(cond: IR, cnsq: IR, altr: IR) extends InferIR
 
-final case class Let(name: String, value: IR, body: IR, var typ: Type = null) extends IR
-final case class Ref(name: String, var typ: Type = null) extends IR
+final case class Let(name: String, value: IR, body: IR) extends InferIR
+final case class Ref(name: String, var typ: Type) extends IR
 
-final case class ApplyBinaryPrimOp(op: BinaryOp, l: IR, r: IR, var typ: Type = null) extends IR
-final case class ApplyUnaryPrimOp(op: UnaryOp, x: IR, var typ: Type = null) extends IR
+final case class ApplyBinaryPrimOp(op: BinaryOp, l: IR, r: IR) extends InferIR
+final case class ApplyUnaryPrimOp(op: UnaryOp, x: IR) extends InferIR
 
-final case class MakeArray(args: Seq[IR], var typ: TArray = null) extends IR
-final case class ArrayRef(a: IR, i: IR, var typ: Type = null) extends IR
+final case class MakeArray(args: Seq[IR], typ: TArray) extends IR
+final case class ArrayRef(a: IR, i: IR) extends InferIR
 final case class ArrayLen(a: IR) extends IR { val typ = TInt32() }
 final case class ArrayRange(start: IR, stop: IR, step: IR) extends IR { val typ: TArray = TArray(TInt32()) }
-final case class ArrayMap(a: IR, name: String, body: IR, var elementTyp: Type = null) extends IR { def typ: TArray = TArray(elementTyp) }
-final case class ArrayFilter(a: IR, name: String, cond: IR) extends IR { def typ: TArray = coerce[TArray](a.typ) }
-final case class ArrayFlatMap(a: IR, name: String, body: IR) extends IR { def typ: TArray = coerce[TArray](body.typ) }
-final case class ArrayFold(a: IR, zero: IR, accumName: String, valueName: String, body: IR, var typ: Type = null) extends IR
+final case class ArrayMap(a: IR, name: String, body: IR) extends InferIR {
+  override def typ: TArray = coerce[TArray](super.typ)
+  def elementTyp: Type = typ.elementType
+}
+final case class ArrayFilter(a: IR, name: String, cond: IR) extends InferIR {
+  override def typ: TArray = super.typ.asInstanceOf[TArray]
+}
+final case class ArrayFlatMap(a: IR, name: String, body: IR) extends InferIR {
+  override def typ: TArray = coerce[TArray](super.typ)
+}
+final case class ArrayFold(a: IR, zero: IR, accumName: String, valueName: String, body: IR) extends InferIR
 
-final case class AggIn(var typ: TAggregable = null) extends IR
-final case class AggMap(a: IR, name: String, body: IR, var typ: TAggregable = null) extends IR
-final case class AggFilter(a: IR, name: String, body: IR, var typ: TAggregable = null) extends IR
-final case class AggFlatMap(a: IR, name: String, body: IR, var typ: TAggregable = null) extends IR
-final case class ApplyAggOp(a: IR, op: AggOp, args: Seq[IR], var typ: Type = null) extends IR {
+final case class AggIn(var typ: TAggregable) extends IR
+final case class AggMap(a: IR, name: String, body: IR) extends InferIR
+final case class AggFilter(a: IR, name: String, body: IR) extends InferIR
+final case class AggFlatMap(a: IR, name: String, body: IR) extends InferIR
+final case class ApplyAggOp(a: IR, op: AggOp, args: Seq[IR]) extends InferIR {
   def inputType: Type = coerce[TAggregable](a.typ).elementType
 }
 
-final case class MakeStruct(fields: Seq[(String, IR)], var typ: TStruct = null) extends IR
-final case class InsertFields(old: IR, fields: Seq[(String, IR)], var typ: TStruct = null) extends IR
+final case class MakeStruct(fields: Seq[(String, IR)]) extends InferIR
 
-final case class GetField(o: IR, name: String, var typ: Type = null) extends IR
+final case class InsertFields(old: IR, fields: Seq[(String, IR)]) extends InferIR {
+  override def typ: TStruct = coerce[TStruct](super.typ)
+}
 
-final case class MakeTuple(types: Seq[IR], var typ: TTuple = null) extends IR
-final case class GetTupleElement(o: IR, idx: Int, var typ: Type = null) extends IR
+final case class GetField(o: IR, name: String) extends InferIR
 
-final case class In(i: Int, var typ: Type) extends IR
+final case class MakeTuple(types: Seq[IR]) extends InferIR
+final case class GetTupleElement(o: IR, idx: Int) extends InferIR
+
+final case class In(i: Int, typ: Type) extends IR
 // FIXME: should be type any
 final case class Die(message: String) extends IR { val typ = TVoid }
 
-final case class Apply(function: String, args: Seq[IR], var implementation: IRFunctionWithoutMissingness = null) extends IR { def typ = implementation.returnType }
-final case class ApplySpecial(function: String, args: Seq[IR], var implementation: IRFunctionWithMissingness = null) extends IR { def typ = implementation.returnType }
+final case class Apply(function: String, args: Seq[IR]) extends IR {
+  val implementation: IRFunctionWithoutMissingness =
+    IRFunctionRegistry.lookupFunction(function, args.map(_.typ)).get.asInstanceOf[IRFunctionWithoutMissingness]
+
+  def typ: Type = implementation.returnType
+}
+final case class ApplySpecial(function: String, args: Seq[IR]) extends IR {
+  val implementation: IRFunctionWithMissingness =
+    IRFunctionRegistry.lookupFunction(function, args.map(_.typ)).get.asInstanceOf[IRFunctionWithMissingness]
+
+  def typ: Type = implementation.returnType
+}
 
 final case class TableCount(child: TableIR) extends IR { val typ: Type = TInt64() }
-final case class TableAggregate(child: TableIR, query: IR, var typ: Type = null) extends IR
+final case class TableAggregate(child: TableIR, query: IR) extends InferIR
 final case class TableWrite(
   child: TableIR,
   path: String,

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -1,138 +1,49 @@
 package is.hail.expr.ir
 
-import is.hail.expr.ir.functions.{IRFunctionRegistry, IRFunctionWithMissingness, IRFunctionWithoutMissingness}
 import is.hail.expr.types._
 
 object Infer {
-  def apply(ir: IR, tAgg: Option[TAggregable] = None) { apply(ir, tAgg, new Env[Type]()) }
-
-  def apply(ir: IR, tAgg: Option[TAggregable], env: Env[Type]) {
-    def infer(ir: IR, tAgg: Option[TAggregable] = tAgg, env: Env[Type] = env) { apply(ir, tAgg, env) }
+  def apply(ir: IR): Type = {
     ir match {
-      case I32(x) =>
-      case I64(x) =>
-      case F32(x) =>
-      case F64(x) =>
-      case True() =>
-      case False() =>
-
-      case Cast(v, typ) =>
-        infer(v)
-        assert(Casts.valid(v.typ, typ))
-
-      case NA(t) =>
-        assert(t != null)
-      case IsNA(v) =>
-        infer(v)
-
-      case x@If(cond, cnsq, altr, _) =>
-        infer(cond)
-        infer(cnsq)
-        infer(altr)
+      case x@If(cond, cnsq, altr) =>
         assert(cond.typ.isOfType(TBoolean()))
-        assert(cnsq.typ == altr.typ, s"${cnsq.typ}, ${altr.typ}, $cond")
-        x.typ = cnsq.typ
+        assert(cnsq.typ == altr.typ, s"${ cnsq.typ }, ${ altr.typ }, $cond")
+        cnsq.typ
 
-      case x@Let(name, value, body, _) =>
-        infer(value)
-        infer(body, env = env.bind(name, value.typ))
-        x.typ = body.typ
-      case x@Ref(_, _) =>
-        x.typ = env.lookup(x)
-      case x@ApplyBinaryPrimOp(op, l, r, _) =>
-        infer(l)
-        infer(r)
-        x.typ = BinaryOp.getReturnType(op, l.typ, r.typ)
-      case x@ApplyUnaryPrimOp(op, v, _) =>
-        infer(v)
-        x.typ = UnaryOp.getReturnType(op, v.typ)
-      case x@MakeArray(args, typ) =>
-        if (args.length == 0)
-          assert(typ != null)
-        else {
-          args.foreach(infer(_))
-          val t = args.head.typ
-          args.map(_.typ).zipWithIndex.tail.foreach { case (x, i) => assert(x.isOfType(t), s"at position $i type mismatch: $t $x") }
-          x.typ = TArray(t)
-        }
-      case x@ArrayRef(a, i, _) =>
-        infer(a)
-        infer(i)
+      case x@Let(name, value, body) =>
+        body.typ
+      case x@ApplyBinaryPrimOp(op, l, r) =>
+        BinaryOp.getReturnType(op, l.typ, r.typ)
+      case x@ApplyUnaryPrimOp(op, v) =>
+        UnaryOp.getReturnType(op, v.typ)
+      case x@ArrayRef(a, i) =>
         assert(i.typ.isOfType(TInt32()))
-        x.typ = -coerce[TArray](a.typ).elementType
-      case ArrayLen(a) =>
-        infer(a)
-        assert(a.typ.isInstanceOf[TArray])
-      case x@ArrayRange(a, b, c) =>
-        infer(a)
-        infer(b)
-        infer(c)
-        assert(a.typ.isOfType(TInt32()))
-        assert(b.typ.isOfType(TInt32()))
-        assert(c.typ.isOfType(TInt32()))
-      case x@ArrayMap(a, name, body, _) =>
-        infer(a)
-        val tarray = coerce[TArray](a.typ)
-        infer(body, env = env.bind(name, tarray.elementType))
-        x.elementTyp = body.typ
+        -coerce[TArray](a.typ).elementType
+      case x@ArrayMap(a, name, body) =>
+        TArray(-body.typ)
       case x@ArrayFilter(a, name, cond) =>
-        infer(a)
-        val tarray = coerce[TArray](a.typ)
-        infer(cond, env = env.bind(name, tarray.elementType))
-        assert(cond.typ.isOfType(TBoolean()))
+        a.typ
       case x@ArrayFlatMap(a, name, body) =>
-        infer(a)
-        val tarray = coerce[TArray](a.typ)
-        infer(body, env = env.bind(name, tarray.elementType))
-        assert(body.typ.isInstanceOf[TArray])
-      case x@ArrayFold(a, zero, accumName, valueName, body, _) =>
-        infer(a)
-        val tarray = coerce[TArray](a.typ)
-        infer(zero)
-        infer(body, env = env.bind(accumName -> zero.typ, valueName -> tarray.elementType))
+        TArray(coerce[TContainer](body.typ).elementType)
+      case x@ArrayFold(a, zero, accumName, valueName, body) =>
         assert(body.typ == zero.typ)
-        x.typ = zero.typ
-      case x@AggIn(typ) =>
-        (tAgg, typ) match {
-          case (Some(t), null) => x.typ = t
-          case (Some(t), t2) => assert(t == t2)
-          case (None, _) => throw new RuntimeException("must provide type of aggregable to Infer")
-        }
-      case x@AggMap(a, name, body, _) =>
-        infer(a)
+        zero.typ
+      case x@AggMap(a, name, body) =>
+        coerce[TAggregable](a.typ).copy(elementType = body.typ)
+      case x@AggFilter(a, name, body) =>
+        a.typ
+      case x@AggFlatMap(a, name, body) =>
         val tagg = coerce[TAggregable](a.typ)
-        infer(body, env = aggScope(tagg).bind(name, tagg.elementType))
-        val tagg2 = tagg.copy(elementType = body.typ)
-        tagg2.symTab = tagg.symTab
-        x.typ = tagg2
-      case x@AggFilter(a, name, body, typ) =>
-        infer(a)
-        val tagg = coerce[TAggregable](a.typ)
-        infer(body, env = aggScope(tagg).bind(name, tagg.elementType))
-        assert(body.typ.isInstanceOf[TBoolean])
-        x.typ = tagg
-      case x@AggFlatMap(a, name, body, typ) =>
-        infer(a)
-        val tagg = coerce[TAggregable](a.typ)
-        infer(body, env = aggScope(tagg).bind(name, tagg.elementType))
-        val tout = coerce[TArray](body.typ)
-        val tagg2 = tagg.copy(elementType = tout.elementType)
-        tagg2.symTab = tagg.symTab
-        x.typ = tagg2
-      case x@ApplyAggOp(a, op, args, _) =>
-        infer(a)
-        args.foreach(infer(_))
+        tagg.copy(elementType = coerce[TContainer](body.typ).elementType)
+      case x@ApplyAggOp(a, op, args) =>
         val tAgg = coerce[TAggregable](a.typ)
-        x.typ = AggOp.getType(op, tAgg.elementType, args.map(_.typ))
-      case x@MakeStruct(fields, _) =>
-        fields.foreach { case (name, a) => infer(a) }
-        x.typ = TStruct(fields.map { case (name, a) =>
+        AggOp.getType(op, tAgg.elementType, args.map(_.typ))
+      case x@MakeStruct(fields) =>
+        TStruct(fields.map { case (name, a) =>
           (name, a.typ)
         }: _*)
-      case x@InsertFields(old, fields, _) =>
-        infer(old)
-        fields.foreach { case (name, a) => infer(a) }
-        x.typ = fields.foldLeft(old.typ){ case (t, (name, a)) =>
+      case x@InsertFields(old, fields) =>
+        fields.foldLeft(old.typ) { case (t, (name, a)) =>
           t match {
             case t2: TStruct =>
               t2.selfField(name) match {
@@ -142,42 +53,18 @@ object Infer {
             case _ => TStruct(name -> a.typ)
           }
         }.asInstanceOf[TStruct]
-      case x@GetField(o, name, _) =>
-        infer(o)
+      case x@GetField(o, name) =>
         val t = coerce[TStruct](o.typ)
         assert(t.index(name).nonEmpty, s"$name not in $t")
-        x.typ = -t.field(name).typ
-      case x@MakeTuple(types, _) =>
-        types.foreach { a => infer(a) }
-        x.typ = TTuple(types.map(_.typ): _*)
-      case x@GetTupleElement(o, idx, _) =>
-        infer(o)
+        -t.field(name).typ
+      case x@MakeTuple(types) =>
+        TTuple(types.map(_.typ): _*)
+      case x@GetTupleElement(o, idx) =>
         val t = coerce[TTuple](o.typ)
         assert(idx >= 0 && idx < t.size)
-        x.typ = -t.types(idx)
-      case In(i, typ) =>
-        assert(typ != null)
-      case Die(msg) =>
-      case x@Apply(fn, args, impl) =>
-        args.foreach(infer(_))
-        if (impl == null)
-          x.implementation = (IRFunctionRegistry.lookupFunction(fn, args.map(_.typ)).get).asInstanceOf[IRFunctionWithoutMissingness]
-        assert(args.map(_.typ).zip(x.implementation.argTypes).forall {case (i, j) => j.unify(i)})
-      case x@ApplySpecial(fn, args, impl) =>
-        args.foreach(infer(_))
-        if (impl == null)
-          x.implementation = (IRFunctionRegistry.lookupFunction(fn, args.map(_.typ)).get).asInstanceOf[IRFunctionWithMissingness]
-        assert(args.map(_.typ).zip(x.implementation.argTypes).forall {case (i, j) => j.unify(i)})
-      case x@TableAggregate(child, query, _) =>
-        infer(query, tAgg = Some(child.typ.tAgg), env = child.typ.aggEnv)
-        x.typ = query.typ
-      case MatrixWrite(_, _, _, _) =>
-      case TableWrite(_, _, _, _) =>
-      case TableExport(_, _, _, _, _) =>
-      case TableCount(_) =>
+        -t.types(idx)
+      case x@TableAggregate(child, query) =>
+        query.typ
     }
   }
-
-  private def aggScope(t: TAggregable): Env[Type] =
-    Env.empty.bind(t.bindings:_*)
 }

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -29,12 +29,17 @@ object Infer {
         assert(body.typ == zero.typ)
         zero.typ
       case x@AggMap(a, name, body) =>
-        coerce[TAggregable](a.typ).copy(elementType = body.typ)
+        val tagg = coerce[TAggregable](a.typ)
+        val tagg2 = tagg.copy(elementType = body.typ)
+        tagg2.symTab = tagg.symTab
+        tagg2
       case x@AggFilter(a, name, body) =>
         a.typ
       case x@AggFlatMap(a, name, body) =>
         val tagg = coerce[TAggregable](a.typ)
-        tagg.copy(elementType = coerce[TContainer](body.typ).elementType)
+        val tagg2 = tagg.copy(elementType = coerce[TContainer](body.typ).elementType)
+        tagg2.symTab = tagg.symTab
+        tagg2
       case x@ApplyAggOp(a, op, args) =>
         val tAgg = coerce[TAggregable](a.typ)
         AggOp.getType(op, tAgg.elementType, args.map(_.typ))

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -26,10 +26,10 @@ object Interpret {
 
     var ir = ir0
     ir = Optimize(ir)
-    Infer(ir, agg.map(_._1), typeEnv)
 
     log.info("interpret:\n" + Pretty(ir))
 
+    TypeCheck(ir, agg.map(_._1), typeEnv)
     interpret(ir, valueEnv, args, agg.orNull).asInstanceOf[T]
   }
 
@@ -66,7 +66,7 @@ object Interpret {
           }
       case NA(_) => null
       case IsNA(value) => interpret(value, env, args, agg) == null
-      case If(cond, cnsq, altr, _) =>
+      case If(cond, cnsq, altr) =>
         val condValue = interpret(cond, env, args, agg)
         if (condValue == null)
           null
@@ -74,11 +74,11 @@ object Interpret {
           interpret(cnsq, env, args, agg)
         else
           interpret(altr, env, args, agg)
-      case Let(name, value, body, _) =>
+      case Let(name, value, body) =>
         val valueValue = interpret(value, env, args, agg)
         interpret(body, env.bind(name, valueValue), args, agg)
       case Ref(name, _) => env.lookup(name)
-      case ApplyBinaryPrimOp(op, l, r, _) =>
+      case ApplyBinaryPrimOp(op, l, r) =>
         val lValue = interpret(l, env, args, agg)
         val rValue = interpret(r, env, args, agg)
         if (lValue == null || rValue == null)
@@ -155,7 +155,7 @@ object Interpret {
                 case NEQ() => lValue != rValue
               }
           }
-      case ApplyUnaryPrimOp(op, x, _) =>
+      case ApplyUnaryPrimOp(op, x) =>
         op match {
           case Bang() =>
             assert(x.typ.isOfType(TBoolean()))
@@ -179,7 +179,7 @@ object Interpret {
             }
         }
       case MakeArray(elements, _) => elements.map(interpret(_, env, args, agg)).toIndexedSeq
-      case ArrayRef(a, i, _) =>
+      case ArrayRef(a, i) =>
         val aValue = interpret(a, env, args, agg)
         val iValue = interpret(i, env, args, agg)
         if (aValue == null || iValue == null)
@@ -200,7 +200,7 @@ object Interpret {
           null
         else
           startValue.asInstanceOf[Int] until stopValue.asInstanceOf[Int] by stepValue.asInstanceOf[Int]
-      case ArrayMap(a, name, body, _) =>
+      case ArrayMap(a, name, body) =>
         val aValue = interpret(a, env, args, agg)
         if (aValue == null)
           null
@@ -232,7 +232,7 @@ object Interpret {
               None
           }
         }
-      case ArrayFold(a, zero, accumName, valueName, body, _) =>
+      case ArrayFold(a, zero, accumName, valueName, body) =>
         val aValue = interpret(a, env, args, agg)
         if (aValue == null)
           null
@@ -243,7 +243,7 @@ object Interpret {
           }
           zeroValue
         }
-      case x@ApplyAggOp(a, op, aggArgs, _) =>
+      case x@ApplyAggOp(a, op, aggArgs) =>
         val aValue = interpretAgg(a, agg._2)
         val aggType = a.typ.asInstanceOf[TAggregable].elementType
         assert(aValue != null)
@@ -292,9 +292,9 @@ object Interpret {
             aggregator.seqOp(element)
         }
         aggregator.result
-      case MakeStruct(fields, _) =>
+      case MakeStruct(fields) =>
         Row.fromSeq(fields.map { case (name, fieldIR) => interpret(fieldIR, env, args, agg) })
-      case InsertFields(old, fields, _) =>
+      case InsertFields(old, fields) =>
         var struct = interpret(old, env, args, agg)
         var t = old.typ
         fields.foreach { case (name, body) =>
@@ -303,7 +303,7 @@ object Interpret {
           struct = ins(struct, interpret(body, env, args, agg))
         }
         struct
-      case GetField(o, name, _) =>
+      case GetField(o, name) =>
         val oValue = interpret(o, env, args, agg)
         if (oValue == null)
           null
@@ -312,9 +312,9 @@ object Interpret {
           val fieldIndex = oType.fieldIdx(name)
           oValue.asInstanceOf[Row].get(fieldIndex)
         }
-      case MakeTuple(types, _) =>
+      case MakeTuple(types) =>
         Row.fromSeq(types.map(x => interpret(x, env, args, agg)))
-      case GetTupleElement(o, idx, _) =>
+      case GetTupleElement(o, idx) =>
         val oValue = interpret(o, env, args, agg)
         if (oValue == null)
           null
@@ -322,11 +322,13 @@ object Interpret {
           oValue.asInstanceOf[Row].get(idx)
       case In(i, _) => args(i)
       case Die(message) => fatal(message)
-      case Apply(function, functionArgs, implementation) =>
+      case ir@Apply(function, functionArgs) =>
+
         val argTuple = TTuple(functionArgs.map(_.typ): _*)
         val (_, makeFunction) = Compile[Long, Long]("in", argTuple, MakeTuple(List(Apply(function,
-          (0 until argTuple.size)
-            .map(i => GetTupleElement(Ref("in"), i))))))
+          functionArgs.zipWithIndex.map { case (x, i) =>
+            GetTupleElement(Ref("in", x.typ), i)
+          }))))
 
         val f = makeFunction()
         Region.scoped { region =>
@@ -342,14 +344,15 @@ object Interpret {
           val offset = rvb.end()
 
           val resultOffset = f(region, offset, false)
-          SafeRow(TTuple(implementation.returnType), region, resultOffset)
+          SafeRow(TTuple(ir.implementation.returnType), region, resultOffset)
             .get(0)
         }
-      case ApplySpecial(function, functionArgs, implementation) =>
+      case ir@ApplySpecial(function, functionArgs) =>
         val argTuple = TTuple(functionArgs.map(_.typ): _*)
         val (_, makeFunction) = Compile[Long, Long]("in", argTuple, MakeTuple(List(ApplySpecial(function,
-          (0 until argTuple.size)
-            .map(i => GetTupleElement(Ref("in"), i))))))
+          functionArgs.zipWithIndex.map { case (x, i) =>
+            GetTupleElement(Ref("in", x.typ), i)
+          }))))
 
         val f = makeFunction()
         Region.scoped { region =>
@@ -364,10 +367,16 @@ object Interpret {
           rvb.endTuple()
           val offset = rvb.end()
 
+<<<<<<< 4f7adbde257a638e515641814f26436ab43a0306
           val resultOffset = f(region, offset, false)
           SafeRow(TTuple(implementation.returnType), region, resultOffset)
             .get(0)
         }
+=======
+        val resultOffset = f(region, offset, false)
+        val ur = new UnsafeRow(TTuple(ir.implementation.returnType), region, resultOffset)
+        ur.get(0)
+>>>>>>> wip
       case TableCount(child) =>
         child.partitionCounts
           .map(_.sum)
@@ -379,11 +388,15 @@ object Interpret {
         val hc = HailContext.get
         val tableValue = child.execute(hc)
         tableValue.write(path, overwrite, codecSpecJSONStr)
+<<<<<<< 4f7adbde257a638e515641814f26436ab43a0306
       case TableExport(child, path, typesFile, header, exportType) =>
         val hc = HailContext.get
         val tableValue = child.execute(hc)
         tableValue.export(path, typesFile, header, exportType)
       case TableAggregate(child, query, _) =>
+=======
+      case TableAggregate(child, query) =>
+>>>>>>> wip
         val localGlobalSignature = child.typ.globalType
         val tAgg = child.typ.aggEnv.lookup("AGG").asInstanceOf[TAggregable]
 
@@ -442,18 +455,18 @@ object Interpret {
       case AggIn(_) =>
         assert(agg != null)
         agg
-      case AggMap(a, name, body, t) =>
+      case AggMap(a, name, body) =>
         interpretAgg(a, agg)
           .map { case (element, env) =>
             interpret(body, env.bind(name, element), null, null) -> env
           }
-      case AggFilter(a, name, body, _) =>
+      case AggFilter(a, name, body) =>
         interpretAgg(a, agg)
           .filter { case (element, env) =>
             // casting to boolean treats null as false
             interpret(body, env.bind(name, element), null, null).asInstanceOf[Boolean]
           }
-      case AggFlatMap(a, name, body, _) =>
+      case AggFlatMap(a, name, body) =>
         interpretAgg(a, agg)
           .flatMap { case (element, env) =>
             interpret(body, env.bind(name, element), null, null)

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -367,16 +367,10 @@ object Interpret {
           rvb.endTuple()
           val offset = rvb.end()
 
-<<<<<<< 4f7adbde257a638e515641814f26436ab43a0306
           val resultOffset = f(region, offset, false)
-          SafeRow(TTuple(implementation.returnType), region, resultOffset)
+          SafeRow(TTuple(ir.implementation.returnType), region, resultOffset)
             .get(0)
         }
-=======
-        val resultOffset = f(region, offset, false)
-        val ur = new UnsafeRow(TTuple(ir.implementation.returnType), region, resultOffset)
-        ur.get(0)
->>>>>>> wip
       case TableCount(child) =>
         child.partitionCounts
           .map(_.sum)
@@ -388,15 +382,11 @@ object Interpret {
         val hc = HailContext.get
         val tableValue = child.execute(hc)
         tableValue.write(path, overwrite, codecSpecJSONStr)
-<<<<<<< 4f7adbde257a638e515641814f26436ab43a0306
       case TableExport(child, path, typesFile, header, exportType) =>
         val hc = HailContext.get
         val tableValue = child.execute(hc)
         tableValue.export(path, typesFile, header, exportType)
-      case TableAggregate(child, query, _) =>
-=======
       case TableAggregate(child, query) =>
->>>>>>> wip
         val localGlobalSignature = child.typ.globalType
         val tAgg = child.typ.aggEnv.lookup("AGG").asInstanceOf[TAggregable]
 

--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -14,7 +14,7 @@ object Pretty {
       sb.append(ir.getClass.getName.split("\\.").last)
 
       ir match {
-        case MakeStruct(fields, _) =>
+        case MakeStruct(fields) =>
           if (fields.nonEmpty) {
             sb += '\n'
             fields.foreachBetween { case (n, a) =>
@@ -26,7 +26,7 @@ object Pretty {
               sb += ')'
             }(sb += '\n')
           }
-        case InsertFields(old, fields, _) =>
+        case InsertFields(old, fields) =>
           sb += '\n'
           pretty(old, depth + 2)
           if (fields.nonEmpty) {
@@ -48,19 +48,19 @@ object Pretty {
             case F64(x) => x.toString
             case Cast(_, typ) => typ.toString
             case NA(typ) => typ.toString
-            case Let(name, _, _, _) => name
+            case Let(name, _, _) => name
             case Ref(name, _) => name
-            case ApplyBinaryPrimOp(op, _, _, _) => op.getClass.getName.split("\\.").last
-            case ApplyUnaryPrimOp(op, _, _) => op.getClass.getName.split("\\.").last
-            case ArrayRef(_, i, _) => i.toString
-            case GetField(_, name, _) => name
-            case GetTupleElement(_, idx, _) => idx.toString
-            case ArrayMap(_, name, _, _) => name
+            case ApplyBinaryPrimOp(op, _, _) => op.getClass.getName.split("\\.").last
+            case ApplyUnaryPrimOp(op, _) => op.getClass.getName.split("\\.").last
+            case ArrayRef(_, i) => i.toString
+            case GetField(_, name) => name
+            case GetTupleElement(_, idx) => idx.toString
+            case ArrayMap(_, name, _) => name
             case ArrayFilter(_, name, _) => name
             case ArrayFlatMap(_, name, _) => name
-            case ArrayFold(_, _, accumName, valueName, _, _) => s"$accumName $valueName"
-            case Apply(function, _, _) => function
-            case ApplySpecial(function, _, _) => function
+            case ArrayFold(_, _, accumName, valueName, _) => s"$accumName $valueName"
+            case Apply(function, _) => function
+            case ApplySpecial(function, _) => function
             case In(i, _) => i.toString
             case MatrixRead(path, _, dropCols, dropRows) =>
               s"${ StringEscapeUtils.escapeString(path) }${ if (dropRows) "drop_rows" else "" }${ if (dropCols) "drop_cols" else "" }"

--- a/src/main/scala/is/hail/expr/ir/Recur.scala
+++ b/src/main/scala/is/hail/expr/ir/Recur.scala
@@ -11,38 +11,38 @@ object Recur {
     case Cast(v, typ) => Cast(f(v), typ)
     case NA(typ) => ir
     case IsNA(value) => IsNA(f(value))
-    case If(cond, cnsq, altr, typ) => If(f(cond), f(cnsq), f(altr), typ)
-    case Let(name, value, body, typ) => Let(name, f(value), f(body), typ)
+    case If(cond, cnsq, altr) => If(f(cond), f(cnsq), f(altr))
+    case Let(name, value, body) => Let(name, f(value), f(body))
     case Ref(name, typ) => ir
-    case ApplyBinaryPrimOp(op, l, r, typ) => ApplyBinaryPrimOp(op, f(l), f(r), typ)
-    case ApplyUnaryPrimOp(op, x, typ) => ApplyUnaryPrimOp(op, f(x), typ)
+    case ApplyBinaryPrimOp(op, l, r) => ApplyBinaryPrimOp(op, f(l), f(r))
+    case ApplyUnaryPrimOp(op, x) => ApplyUnaryPrimOp(op, f(x))
     case MakeArray(args, typ) => MakeArray(args map f, typ)
-    case ArrayRef(a, i, typ) => ArrayRef(f(a), f(i), typ)
+    case ArrayRef(a, i) => ArrayRef(f(a), f(i))
     case ArrayLen(a) => ArrayLen(f(a))
     case ArrayRange(start, stop, step) => ArrayRange(f(start), f(stop), f(step))
-    case ArrayMap(a, name, body, elementTyp) => ArrayMap(f(a), name, f(body), elementTyp)
+    case ArrayMap(a, name, body) => ArrayMap(f(a), name, f(body))
     case ArrayFilter(a, name, cond) => ArrayFilter(f(a), name, f(cond))
     case ArrayFlatMap(a, name, body) => ArrayFlatMap(f(a), name, f(body))
-    case ArrayFold(a, zero, accumName, valueName, body, typ) => ArrayFold(f(a), f(zero), accumName, valueName, f(body), typ)
-    case MakeStruct(fields, _) => MakeStruct(fields map { case (n, a) => (n, f(a)) })
-    case InsertFields(old, fields, _) => InsertFields(f(old), fields map { case (n, a) => (n, f(a)) })
-    case GetField(o, name, typ) => GetField(f(o), name, typ)
+    case ArrayFold(a, zero, accumName, valueName, body) => ArrayFold(f(a), f(zero), accumName, valueName, f(body))
+    case MakeStruct(fields) => MakeStruct(fields map { case (n, a) => (n, f(a)) })
+    case InsertFields(old, fields) => InsertFields(f(old), fields map { case (n, a) => (n, f(a)) })
+    case GetField(o, name) => GetField(f(o), name)
     case AggIn(typ) => ir
-    case AggMap(a, name, body, typ) => AggMap(f(a), name, f(body), typ)
-    case AggFilter(a, name, body, typ) => AggFilter(f(a), name, f(body), typ)
-    case AggFlatMap(a, name, body, typ) => AggFlatMap(f(a), name, f(body), typ)
-    case ApplyAggOp(a, op, args, typ) => ApplyAggOp(f(a), op, args.map(f), typ)
-    case MakeTuple(elts, typ) => MakeTuple(elts.map(f), typ)
-    case GetTupleElement(tup, idx, typ) => GetTupleElement(f(tup), idx, typ)
+    case AggMap(a, name, body) => AggMap(f(a), name, f(body))
+    case AggFilter(a, name, body) => AggFilter(f(a), name, f(body))
+    case AggFlatMap(a, name, body) => AggFlatMap(f(a), name, f(body))
+    case ApplyAggOp(a, op, args) => ApplyAggOp(f(a), op, args.map(f))
+    case MakeTuple(elts) => MakeTuple(elts.map(f))
+    case GetTupleElement(tup, idx) => GetTupleElement(f(tup), idx)
     case In(i, typ) => ir
     case Die(message) => ir
-    case Apply(fn, args, impl) => Apply(fn, args.map(f), impl)
-    case ApplySpecial(fn, args, impl) => ApplySpecial(fn, args.map(f), impl)
+    case Apply(fn, args) => Apply(fn, args.map(f))
+    case ApplySpecial(fn, args) => ApplySpecial(fn, args.map(f))
     // from MatrixIR
     case MatrixWrite(_, _, _, _) => ir
     // from TableIR
     case TableCount(_) => ir
-    case TableAggregate(child, query, typ) => TableAggregate(child, f(query), typ)
+    case TableAggregate(child, query) => TableAggregate(child, f(query))
     case TableWrite(_, _, _, _) => ir
     case TableExport(_, _, _, _, _) => ir
   }

--- a/src/main/scala/is/hail/expr/ir/Subst.scala
+++ b/src/main/scala/is/hail/expr/ir/Subst.scala
@@ -11,8 +11,6 @@ object Subst {
     e match {
       case x@Ref(name, typ) =>
         val s = env.lookupOption(name).getOrElse(x)
-        println(Pretty(x))
-        println(Pretty(s))
         assert(s.typ == x.typ, s"$name: ${ x.typ.parsableString() }, ${ s.typ.parsableString() }")
         s
       case Let(name, v, body) =>

--- a/src/main/scala/is/hail/expr/ir/Subst.scala
+++ b/src/main/scala/is/hail/expr/ir/Subst.scala
@@ -10,9 +10,7 @@ object Subst {
 
     e match {
       case x@Ref(name, typ) =>
-        val s = env.lookupOption(name).getOrElse(x)
-        assert(s.typ == x.typ, s"$name: ${ x.typ.parsableString() }, ${ s.typ.parsableString() }")
-        s
+        env.lookupOption(name).getOrElse(x)
       case x@AggIn(typ) =>
         aggTyp.map(AggIn).getOrElse(x)
       case Let(name, v, body) =>

--- a/src/main/scala/is/hail/expr/ir/Subst.scala
+++ b/src/main/scala/is/hail/expr/ir/Subst.scala
@@ -3,10 +3,10 @@ package is.hail.expr.ir
 import is.hail.expr.types.TAggregable
 
 object Subst {
-  def apply(e: IR): IR = apply(e, Env.empty)
-
-  def apply(e: IR, env: Env[IR]): IR = {
-    def subst(e: IR, env: Env[IR] = env): IR = apply(e, env)
+  def apply(e: IR): IR = apply(e, Env.empty, Env.empty, None)
+  def apply(e: IR, env: Env[IR]): IR = apply(e, env, Env.empty, None)
+  def apply(e: IR, env: Env[IR], aggEnv: Env[IR], aggTyp: Option[TAggregable]): IR = {
+    def subst(e: IR, env: Env[IR] = env, aggEnv: Env[IR] = aggEnv, aggTyp: Option[TAggregable] = aggTyp): IR = apply(e, env, aggEnv, aggTyp)
 
     e match {
       case x@Ref(name, typ) =>
@@ -25,7 +25,7 @@ object Subst {
         ArrayFold(subst(a), subst(zero), accumName, valueName, subst(body, env.delete(accumName).delete(valueName)))
       case ApplyAggOp(a, op, args) =>
         val substitutedArgs = args.map(arg => Recur(subst(_))(arg))
-        ApplyAggOp(subst(a, aggEnv, Env.empty), op, substitutedArgs, typ)
+        ApplyAggOp(subst(a, aggEnv, Env.empty), op, substitutedArgs)
       case _ =>
         Recur(subst(_))(e)
     }

--- a/src/main/scala/is/hail/expr/ir/Subst.scala
+++ b/src/main/scala/is/hail/expr/ir/Subst.scala
@@ -3,26 +3,29 @@ package is.hail.expr.ir
 import is.hail.expr.types.TAggregable
 
 object Subst {
-  def apply(e: IR): IR = apply(e, Env.empty, Env.empty, None)
-  def apply(e: IR, env: Env[IR]): IR = apply(e, env, Env.empty, None)
-  def apply(e: IR, env: Env[IR], aggEnv: Env[IR], aggTyp: Option[TAggregable]): IR = {
-    def subst(e: IR, env: Env[IR] = env, aggEnv: Env[IR] = aggEnv, aggTyp: Option[TAggregable] = aggTyp): IR = apply(e, env, aggEnv, aggTyp)
+  def apply(e: IR): IR = apply(e, Env.empty)
+
+  def apply(e: IR, env: Env[IR]): IR = {
+    def subst(e: IR, env: Env[IR] = env): IR = apply(e, env)
+
     e match {
-      case x@Ref(name, _) =>
-        env.lookupOption(name).getOrElse(x)
-      case x@AggIn(typ) =>
-        aggTyp.map(AggIn).getOrElse(x)
-      case Let(name, v, body, _) =>
+      case x@Ref(name, typ) =>
+        val s = env.lookupOption(name).getOrElse(x)
+        println(Pretty(x))
+        println(Pretty(s))
+        assert(s.typ == x.typ, s"$name: ${ x.typ.parsableString() }, ${ s.typ.parsableString() }")
+        s
+      case Let(name, v, body) =>
         Let(name, subst(v), subst(body, env.delete(name)))
-      case ArrayMap(a, name, body, _) =>
+      case ArrayMap(a, name, body) =>
         ArrayMap(subst(a), name, subst(body, env.delete(name)))
       case ArrayFilter(a, name, cond) =>
         ArrayFilter(subst(a), name, subst(cond, env.delete(name)))
       case ArrayFlatMap(a, name, body) =>
         ArrayFlatMap(subst(a), name, subst(body, env.delete(name)))
-      case ArrayFold(a, zero, accumName, valueName, body, _) =>
+      case ArrayFold(a, zero, accumName, valueName, body) =>
         ArrayFold(subst(a), subst(zero), accumName, valueName, subst(body, env.delete(accumName).delete(valueName)))
-      case ApplyAggOp(a, op, args, typ) =>
+      case ApplyAggOp(a, op, args) =>
         val substitutedArgs = args.map(arg => Recur(subst(_))(arg))
         ApplyAggOp(subst(a, aggEnv, Env.empty), op, substitutedArgs, typ)
       case _ =>

--- a/src/main/scala/is/hail/expr/ir/Subst.scala
+++ b/src/main/scala/is/hail/expr/ir/Subst.scala
@@ -13,6 +13,8 @@ object Subst {
         val s = env.lookupOption(name).getOrElse(x)
         assert(s.typ == x.typ, s"$name: ${ x.typ.parsableString() }, ${ s.typ.parsableString() }")
         s
+      case x@AggIn(typ) =>
+        aggTyp.map(AggIn).getOrElse(x)
       case Let(name, v, body) =>
         Let(name, subst(v), subst(body, env.delete(name)))
       case ArrayMap(a, name, body) =>

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -125,9 +125,9 @@ object TypeCheck {
         tagg2.symTab = tagg.symTab
         assert(x.typ == tagg2)
       case x@ApplyAggOp(a, op, args) =>
+        val tAgg = coerce[TAggregable](a.typ)
         check(a)
         args.foreach(check(_))
-        val tAgg = coerce[TAggregable](a.typ)
         assert(x.typ == AggOp.getType(op, tAgg.elementType, args.map(_.typ)))
       case x@MakeStruct(fields) =>
         fields.foreach { case (name, a) => check(a) }
@@ -171,6 +171,7 @@ object TypeCheck {
         val impl = x.implementation
         args.foreach(check(_))
         assert(args.map(_.typ).zip(x.implementation.argTypes).forall { case (i, j) => j.unify(i) })
+      case MatrixWrite(_, _, _, _) =>
       case x@TableAggregate(child, query) =>
         check(query, tAgg = Some(child.typ.tAgg), env = child.typ.aggEnv)
         assert(x.typ == query.typ)

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -176,6 +176,7 @@ object TypeCheck {
         check(query, tAgg = Some(child.typ.tAgg), env = child.typ.aggEnv)
         assert(x.typ == query.typ)
       case TableWrite(_, _, _, _) =>
+      case TableExport(_, _, _, _, _) =>
       case TableCount(_) =>
     }
   }

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -101,7 +101,7 @@ object TypeCheck {
         (tAgg, typ) match {
           case (Some(t), null) => x.typ = t
           case (Some(t), t2) => assert(t == t2)
-          case (None, _) => throw new RuntimeException("must provide type of aggregable to Infer")
+          case (None, _) => throw new RuntimeException("must provide type of aggregable to TypeCheck")
         }
       case x@AggMap(a, name, body) =>
         check(a)

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -1,0 +1,183 @@
+package is.hail.expr.ir
+
+import is.hail.expr.types._
+
+object TypeCheck {
+  def apply(ir: IR, tAgg: Option[TAggregable] = None) {
+    apply(ir, tAgg, new Env[Type]())
+  }
+
+  def apply(ir: IR, tAgg: Option[TAggregable], env: Env[Type]) {
+    def check(ir: IR, tAgg: Option[TAggregable] = tAgg, env: Env[Type] = env) {
+      apply(ir, tAgg, env)
+    }
+
+    ir match {
+      case I32(x) =>
+      case I64(x) =>
+      case F32(x) =>
+      case F64(x) =>
+      case True() =>
+      case False() =>
+
+      case Cast(v, typ) =>
+        check(v)
+        assert(Casts.valid(v.typ, typ))
+
+      case NA(t) =>
+        assert(t != null)
+      case IsNA(v) =>
+        check(v)
+
+      case x@If(cond, cnsq, altr) =>
+        check(cond)
+        check(cnsq)
+        check(altr)
+        assert(cond.typ.isOfType(TBoolean()))
+        assert(cnsq.typ == altr.typ, s"${ cnsq.typ }, ${ altr.typ }, $cond")
+        assert(x.typ == cnsq.typ)
+
+      case x@Let(name, value, body) =>
+        check(value)
+        check(body, env = env.bind(name, value.typ))
+        assert(x.typ == body.typ)
+      case x@Ref(_, _) =>
+        assert(x.typ == env.lookup(x))
+      case x@ApplyBinaryPrimOp(op, l, r) =>
+        check(l)
+        check(r)
+        assert(x.typ == BinaryOp.getReturnType(op, l.typ, r.typ))
+      case x@ApplyUnaryPrimOp(op, v) =>
+        check(v)
+        assert(x.typ == UnaryOp.getReturnType(op, v.typ))
+      case x@MakeArray(args, typ) =>
+        if (args.length == 0)
+          assert(typ != null)
+        else {
+          args.foreach(check(_))
+          val t = args.head.typ
+          args.map(_.typ).zipWithIndex.tail.foreach { case (x, i) => assert(x.isOfType(t), s"at position $i type mismatch: $t $x") }
+          assert(x.typ == TArray(t))
+        }
+      case x@ArrayRef(a, i) =>
+        check(a)
+        check(i)
+        assert(i.typ.isOfType(TInt32()))
+        assert(x.typ == -coerce[TArray](a.typ).elementType)
+      case ArrayLen(a) =>
+        check(a)
+        assert(a.typ.isInstanceOf[TArray])
+      case x@ArrayRange(a, b, c) =>
+        check(a)
+        check(b)
+        check(c)
+        assert(a.typ.isOfType(TInt32()))
+        assert(b.typ.isOfType(TInt32()))
+        assert(c.typ.isOfType(TInt32()))
+      case x@ArrayMap(a, name, body) =>
+        check(a)
+        val tarray = coerce[TArray](a.typ)
+        check(body, env = env.bind(name, -tarray.elementType))
+        assert(x.elementTyp == body.typ)
+      case x@ArrayFilter(a, name, cond) =>
+        check(a)
+        val tarray = coerce[TArray](a.typ)
+        check(cond, env = env.bind(name, tarray.elementType))
+        assert(cond.typ.isOfType(TBoolean()))
+      case x@ArrayFlatMap(a, name, body) =>
+        check(a)
+        val tarray = coerce[TArray](a.typ)
+        check(body, env = env.bind(name, tarray.elementType))
+        assert(body.typ.isInstanceOf[TArray])
+      case x@ArrayFold(a, zero, accumName, valueName, body) =>
+        check(a)
+        val tarray = coerce[TArray](a.typ)
+        check(zero)
+        check(body, env = env.bind(accumName -> zero.typ, valueName -> tarray.elementType))
+        assert(body.typ == zero.typ)
+        assert(x.typ == zero.typ)
+      case x@AggIn(typ) =>
+        (tAgg, typ) match {
+          case (Some(t), null) => x.typ = t
+          case (Some(t), t2) => assert(t == t2)
+          case (None, _) => throw new RuntimeException("must provide type of aggregable to Infer")
+        }
+      case x@AggMap(a, name, body) =>
+        check(a)
+        val tagg = coerce[TAggregable](a.typ)
+        check(body, env = aggScope(tagg).bind(name, tagg.elementType))
+        val tagg2 = tagg.copy(elementType = body.typ)
+        tagg2.symTab = tagg.symTab
+        assert(x.typ == tagg2)
+      case x@AggFilter(a, name, body) =>
+        check(a)
+        val tagg = coerce[TAggregable](a.typ)
+        check(body, env = aggScope(tagg).bind(name, tagg.elementType))
+        assert(body.typ.isInstanceOf[TBoolean])
+        assert(x.typ == tagg)
+      case x@AggFlatMap(a, name, body) =>
+        check(a)
+        val tagg = coerce[TAggregable](a.typ)
+        check(body, env = aggScope(tagg).bind(name, tagg.elementType))
+        val tout = coerce[TArray](body.typ)
+        val tagg2 = tagg.copy(elementType = tout.elementType)
+        tagg2.symTab = tagg.symTab
+        assert(x.typ == tagg2)
+      case x@ApplyAggOp(a, op, args) =>
+        check(a)
+        args.foreach(check(_))
+        val tAgg = coerce[TAggregable](a.typ)
+        assert(x.typ == AggOp.getType(op, tAgg.elementType, args.map(_.typ)))
+      case x@MakeStruct(fields) =>
+        fields.foreach { case (name, a) => check(a) }
+        assert(x.typ == TStruct(fields.map { case (name, a) =>
+          (name, a.typ)
+        }: _*))
+      case x@InsertFields(old, fields) =>
+        check(old)
+        fields.foreach { case (name, a) => check(a) }
+        assert(x.typ == fields.foldLeft(old.typ) { case (t, (name, a)) =>
+          t match {
+            case t2: TStruct =>
+              t2.selfField(name) match {
+                case Some(f2) => t2.updateKey(name, f2.index, a.typ)
+                case None => t2.appendKey(name, a.typ)
+              }
+            case _ => TStruct(name -> a.typ)
+          }
+        }.asInstanceOf[TStruct])
+      case x@GetField(o, name) =>
+        check(o)
+        val t = coerce[TStruct](o.typ)
+        assert(t.index(name).nonEmpty, s"$name not in $t")
+        assert(x.typ == -t.field(name).typ)
+      case x@MakeTuple(types) =>
+        types.foreach { a => check(a) }
+        assert(x.typ == TTuple(types.map(_.typ): _*))
+      case x@GetTupleElement(o, idx) =>
+        check(o)
+        val t = coerce[TTuple](o.typ)
+        assert(idx >= 0 && idx < t.size)
+        assert(x.typ == -t.types(idx))
+      case In(i, typ) =>
+        assert(typ != null)
+      case Die(msg) =>
+      case x@Apply(fn, args) =>
+        val impl = x.implementation
+        args.foreach(check(_))
+        assert(args.map(_.typ).zip(x.implementation.argTypes).forall { case (i, j) => j.unify(i) })
+      case x@ApplySpecial(fn, args) =>
+        val impl = x.implementation
+        args.foreach(check(_))
+        assert(args.map(_.typ).zip(x.implementation.argTypes).forall { case (i, j) => j.unify(i) })
+      case x@TableAggregate(child, query) =>
+        check(query, tAgg = Some(child.typ.tAgg), env = child.typ.aggEnv)
+        assert(x.typ == query.typ)
+      case TableWrite(_, _, _, _) =>
+      case TableCount(_) =>
+    }
+  }
+
+  private def aggScope(t: TAggregable): Env[Type] =
+    Env.empty.bind(t.bindings: _*)
+}

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -41,8 +41,9 @@ object TypeCheck {
         check(value)
         check(body, env = env.bind(name, value.typ))
         assert(x.typ == body.typ)
-      case x@Ref(_, _) =>
-        assert(x.typ == env.lookup(x))
+      case x@Ref(name, _) =>
+        val expected = env.lookup(x)
+        assert(x.typ == expected, s"$name ${ x.typ.parsableString() } ${ expected.parsableString() }")
       case x@ApplyBinaryPrimOp(op, l, r) =>
         check(l)
         check(r)
@@ -93,7 +94,7 @@ object TypeCheck {
         check(a)
         val tarray = coerce[TArray](a.typ)
         check(zero)
-        check(body, env = env.bind(accumName -> zero.typ, valueName -> tarray.elementType))
+        check(body, env = env.bind(accumName -> zero.typ, valueName -> -tarray.elementType))
         assert(body.typ == zero.typ)
         assert(x.typ == zero.typ)
       case x@AggIn(typ) =>

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -49,8 +49,8 @@ object IRFunctionRegistry {
     val validMethods = lookupFunction(name, args).map { f =>
       { irArgs: Seq[IR] =>
         f match {
-          case irf: IRFunctionWithoutMissingness => Apply(name, irArgs, irf)
-          case irf: IRFunctionWithMissingness => ApplySpecial(name, irArgs, irf)
+          case irf: IRFunctionWithoutMissingness => Apply(name, irArgs)
+          case irf: IRFunctionWithMissingness => ApplySpecial(name, irArgs)
         }
       }
     }

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -14,8 +14,9 @@ object UtilFunctions extends RegistryFunctions {
     registerIR("size", TArray(tv("T")))(ArrayLen)
 
     registerIR("sum", TArray(tnum("T"))) { a =>
-      val zero = Literal(0, coerce[TArray](a.typ).elementType)
-      ArrayFold(a, zero, "sum", "v", If(IsNA(Ref("v")), Ref("sum"), ApplyBinaryPrimOp(Add(), Ref("sum"), Ref("v"))))
+      val t = coerce[TArray](a.typ).elementType
+      val zero = Literal(0, t)
+      ArrayFold(a, zero, "sum", "v", If(IsNA(Ref("v", t)), Ref("sum", t), ApplyBinaryPrimOp(Add(), Ref("sum", t), Ref("v", t))))
     }
 
     registerIR("*", TArray(tnum("T")), tv("T")){ (a, c) => ArrayMap(a, "imul", ApplyBinaryPrimOp(Multiply(), Ref("imul"), c)) }

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -14,7 +14,7 @@ object UtilFunctions extends RegistryFunctions {
     registerIR("size", TArray(tv("T")))(ArrayLen)
 
     registerIR("sum", TArray(tnum("T"))) { a =>
-      val t = coerce[TArray](a.typ).elementType
+      val t = -coerce[TArray](a.typ).elementType
       val zero = Literal(0, t)
       ArrayFold(a, zero, "sum", "v", If(IsNA(Ref("v", t)), Ref("sum", t), ApplyBinaryPrimOp(Add(), Ref("sum", t), Ref("v", t))))
     }

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -19,15 +19,18 @@ object UtilFunctions extends RegistryFunctions {
       ArrayFold(a, zero, "sum", "v", If(IsNA(Ref("v", t)), Ref("sum", t), ApplyBinaryPrimOp(Add(), Ref("sum", t), Ref("v", t))))
     }
 
-    registerIR("*", TArray(tnum("T")), tv("T")){ (a, c) => ArrayMap(a, "imul", ApplyBinaryPrimOp(Multiply(), Ref("imul"), c)) }
+    registerIR("*", TArray(tnum("T")), tv("T")){ (a, c) =>
+      ArrayMap(a, "imul", ApplyBinaryPrimOp(Multiply(), Ref("imul", c.typ), c))
+    }
 
     registerIR("sum", TAggregable(tnum("T")))(ApplyAggOp(_, Sum(), FastSeq()))
 
     registerIR("product", TArray(tnum("T"))) { a =>
+      val t = -coerce[TArray](a.typ).elementType
       val product = genUID()
       val v = genUID()
       val one = Literal(1, coerce[TArray](a.typ).elementType)
-      ArrayFold(a, one, product, v, If(IsNA(Ref(v)), Ref(product), ApplyBinaryPrimOp(Multiply(), Ref(product), Ref(v))))
+      ArrayFold(a, one, product, v, If(IsNA(Ref(v, t)), Ref(product, t), ApplyBinaryPrimOp(Multiply(), Ref(product, t), Ref(v, t))))
     }
 
     registerIR("count", TAggregable(tv("T"))) { agg =>
@@ -36,24 +39,26 @@ object UtilFunctions extends RegistryFunctions {
     }
 
     registerIR("min", TArray(tnum("T"))) { a =>
+      val t = -coerce[TArray](a.typ).elementType
       val min = genUID()
       val value = genUID()
-      val body = If(IsNA(Ref(min)),
-        Ref(value),
-        If(IsNA(Ref(value)),
-          Ref(min),
-          If(ApplyBinaryPrimOp(LT(), Ref(value), Ref(min)), Ref(value), Ref(min))))
+      val body = If(IsNA(Ref(min, t)),
+        Ref(value, t),
+        If(IsNA(Ref(value, t)),
+          Ref(min, t),
+          If(ApplyBinaryPrimOp(LT(), Ref(value, t), Ref(min, t)), Ref(value, t), Ref(min, t))))
       ArrayFold(a, NA(tnum("T").t), min, value, body)
     }
 
     registerIR("max", TArray(tnum("T"))) { a =>
+      val t = -coerce[TArray](a.typ).elementType
       val max = genUID()
       val value = genUID()
-      val body = If(IsNA(Ref(max)),
-        Ref(value),
-        If(IsNA(Ref(value)),
-          Ref(max),
-          If(ApplyBinaryPrimOp(GT(), Ref(value), Ref(max)), Ref(value), Ref(max))))
+      val body = If(IsNA(Ref(max, t)),
+        Ref(value, t),
+        If(IsNA(Ref(value, t)),
+          Ref(max, t),
+          If(ApplyBinaryPrimOp(GT(), Ref(value, t), Ref(max, t)), Ref(value, t), Ref(max, t))))
       ArrayFold(a, NA(tnum("T").t), max, value, body)
     }
 
@@ -73,7 +78,7 @@ object UtilFunctions extends RegistryFunctions {
           ArrayLen(a),
           I32(1)),
         idx,
-        ArrayRef(a, Ref(idx)))
+        ArrayRef(a, Ref(idx, TInt32())))
     }
 
     registerIR("[:*]", TArray(tv("T")), TInt32()) { (a, i) =>
@@ -85,7 +90,7 @@ object UtilFunctions extends RegistryFunctions {
             i),
           I32(1)),
         idx,
-        ArrayRef(a, Ref(idx)))
+        ArrayRef(a, Ref(idx, TInt32())))
     }
 
     registerIR("[*:*]", TArray(tv("T")), TInt32(), TInt32()) { (a, i, j) =>
@@ -100,7 +105,7 @@ object UtilFunctions extends RegistryFunctions {
             j),
           I32(1)),
         idx,
-        ArrayRef(a, Ref(idx)))
+        ArrayRef(a, Ref(idx, TInt32())))
     }
 
     registerIR("[]", tv("T", _.isInstanceOf[TTuple]), TInt32()) { (a, i) => GetTupleElement(a, i.asInstanceOf[I32].x) }

--- a/src/main/scala/is/hail/expr/ir/package.scala
+++ b/src/main/scala/is/hail/expr/ir/package.scala
@@ -39,9 +39,9 @@ package object ir {
   def filterPredicateWithKeep(irPred: ir.IR, keep: Boolean, letName: String): ir.IR = {
     ir.Let(letName,
       if (keep) irPred else ir.ApplyUnaryPrimOp(ir.Bang(), irPred),
-      ir.If(ir.IsNA(ir.Ref(letName)),
+      ir.If(ir.IsNA(ir.Ref(letName, TBoolean())),
         ir.False(),
-        ir.Ref(letName)))
+        ir.Ref(letName, TBoolean())))
   }
 
   private[ir] def coerce[T](c: Code[_]): Code[T] = asm4s.coerce(c)

--- a/src/main/scala/is/hail/expr/types/MatrixType.scala
+++ b/src/main/scala/is/hail/expr/types/MatrixType.scala
@@ -83,7 +83,7 @@ case class MatrixType(
       "global" -> (0, globalType),
       "sa" -> (1, colType),
       "g" -> (2, entryType),
-      "va" -> (3, rowType))
+      "va" -> (3, rvRowType))
     EvalContext(Map(
       "global" -> (0, globalType),
       "sa" -> (1, colType),
@@ -93,19 +93,19 @@ case class MatrixType(
   def rowEC: EvalContext = {
     val aggregationST = Map(
       "global" -> (0, globalType),
-      "va" -> (1, rowType),
+      "va" -> (1, rvRowType),
       "g" -> (2, entryType),
       "sa" -> (3, colType))
     EvalContext(Map(
       "global" -> (0, globalType),
-      "va" -> (1, rowType),
+      "va" -> (1, rvRowType),
       "AGG" -> (2, TAggregable(entryType, aggregationST))))
   }
 
   def genotypeEC: EvalContext = {
     EvalContext(Map(
       "global" -> (0, globalType),
-      "va" -> (1, rowType),
+      "va" -> (1, rvRowType),
       "sa" -> (2, colType),
       "g" -> (3, entryType)))
   }

--- a/src/main/scala/is/hail/expr/types/TStruct.scala
+++ b/src/main/scala/is/hail/expr/types/TStruct.scala
@@ -288,7 +288,7 @@ final case class TStruct(fields: IndexedSeq[Field], override val required: Boole
     TStruct(newFields)
   }
 
-  def deleteKey(key: String, index: Int): Type = {
+  def deleteKey(key: String, index: Int): TStruct = {
     assert(fieldIdx.contains(key))
     if (fields.length == 1)
       TStruct.empty()

--- a/src/main/scala/is/hail/io/RowStore.scala
+++ b/src/main/scala/is/hail/io/RowStore.scala
@@ -774,11 +774,12 @@ class RichContextRDDRegionValue[C <: AutoCloseable](val crdd: ContextRDD[C, Regi
 
               it.foreach { rv =>
                 fullRow.set(rv)
+                val row = fullRow.deleteField(localEntriesIndex)
 
                 val region = rv.region
                 rvb.set(region)
                 rvb.start(rowsRVType)
-                rvb.addAnnotation(rowsRVType, fullRow)
+                rvb.addAnnotation(rowsRVType, row)
 
                 rowsEN.writeByte(1)
                 rowsEN.writeRegionValue(rowsRVType, region, rvb.end())

--- a/src/main/scala/is/hail/io/RowStore.scala
+++ b/src/main/scala/is/hail/io/RowStore.scala
@@ -774,12 +774,11 @@ class RichContextRDDRegionValue[C <: AutoCloseable](val crdd: ContextRDD[C, Regi
 
               it.foreach { rv =>
                 fullRow.set(rv)
-                val row = fullRow.deleteField(localEntriesIndex)
 
                 val region = rv.region
                 rvb.set(region)
                 rvb.start(rowsRVType)
-                rvb.addAnnotation(rowsRVType, row)
+                rvb.addAnnotation(rowsRVType, fullRow)
 
                 rowsEN.writeByte(1)
                 rowsEN.writeRegionValue(rowsRVType, region, rvb.end())

--- a/src/main/scala/is/hail/methods/Aggregators.scala
+++ b/src/main/scala/is/hail/methods/Aggregators.scala
@@ -43,7 +43,6 @@ object Aggregators {
 
     { (rv: RegionValue) =>
       val fullRow = new UnsafeRow(fullRowType, rv)
-      val row = fullRow.deleteField(localEntriesIndex)
 
       val aggs = MultiArray2.fill[Aggregator](nKeys, aggregations.size)(null)
       var nk = 0
@@ -56,7 +55,7 @@ object Aggregators {
         nk += 1
       }
       localA(0) = globalsBc.value
-      localA(1) = row
+      localA(1) = fullRow
       val is = fullRow.getAs[IndexedSeq[Annotation]](localEntriesIndex)
 
       var i = 0
@@ -106,12 +105,11 @@ object Aggregators {
     Some({ (rv: RegionValue) =>
 
       val fullRow = new UnsafeRow(fullRowType, rv)
-      val row = fullRow.deleteField(localEntriesIndex)
 
       val aggs = aggregations.map { case (_, _, agg0) => agg0.copy() }
 
       ec.set(0, globalsBc.value)
-      ec.set(1, row)
+      ec.set(1, fullRow)
 
       val is = fullRow.getAs[IndexedSeq[Annotation]](localEntriesIndex)
       var i = 0
@@ -163,10 +161,9 @@ object Aggregators {
 
     val result = value.rvd.treeAggregate(baseArray)({ case (arr, rv) =>
       val fullRow = new UnsafeRow(fullRowType, rv)
-      val row = fullRow.deleteField(localEntriesIndex)
 
       localA(0) = globalsBc.value
-      localA(3) = row
+      localA(3) = fullRow
 
       val gs = fullRow.getAs[IndexedSeq[Annotation]](localEntriesIndex)
 
@@ -233,7 +230,6 @@ object Aggregators {
 
     val seqOp = (ma: MultiArray2[Aggregator], rv: RegionValue) => {
       val fullRow = new UnsafeRow(fullRowType, rv)
-      val row = fullRow.deleteField(localEntriesIndex)
 
       val is = fullRow.getAs[IndexedSeq[Annotation]](localEntriesIndex)
 
@@ -242,7 +238,7 @@ object Aggregators {
         ec.setAll(globalsBc.value,
           localColValuesBc.value(i),
           is(i),
-          row)
+          fullRow)
 
         var j = 0
         while (j < nAggregations) {

--- a/src/main/scala/is/hail/methods/FilterAlleles.scala
+++ b/src/main/scala/is/hail/methods/FilterAlleles.scala
@@ -103,7 +103,6 @@ object FilterAlleles {
       rdd.mapPartitions(newRVType) { it =>
         var prevLocus: Locus = null
         val fullRow = new UnsafeRow(fullRowType)
-        val row = fullRow.deleteField(localEntriesIndex)
         val rvv = new RegionValueVariant(fullRowType)
 
         it.flatMap { rv =>
@@ -115,7 +114,7 @@ object FilterAlleles {
 
           val gs = fullRow.getAs[IndexedSeq[Annotation]](localEntriesIndex)
 
-          filterAllelesInVariant(rvv.locus(), rvv.alleles(), row)
+          filterAllelesInVariant(rvv.locus(), rvv.alleles(), fullRow)
             .flatMap { case (newLocus, newAlleles, newToOld, oldToNew) =>
               val isLeftAligned = (prevLocus == null || prevLocus != newLocus) &&
                 newLocus == rvv.locus
@@ -133,8 +132,8 @@ object FilterAlleles {
                 rvb.start(newRVType)
                 rvb.startStruct()
 
-                vAnnotator.ec.setAll(globalsBc.value, row, newLocus, newAlleles, oldToNew, newToOld)
-                var newVA = vAnnotator.insert(row)
+                vAnnotator.ec.setAll(globalsBc.value, fullRow, newLocus, newAlleles, oldToNew, newToOld)
+                var newVA = vAnnotator.insert(fullRow)
                 newVA = insertLocus(newVA, newLocus)
                 newVA = insertAlleles(newVA, newAlleles)
                 val newRow = newVA.asInstanceOf[Row]
@@ -146,7 +145,7 @@ object FilterAlleles {
                   i += 1
                 }
 
-                gAnnotator.ec.setAll(globalsBc.value, row, newLocus, newAlleles, oldToNew, newToOld)
+                gAnnotator.ec.setAll(globalsBc.value, fullRow, newLocus, newAlleles, oldToNew, newToOld)
 
                 rvb.startArray(localNSamples) // gs
                 var k = 0

--- a/src/main/scala/is/hail/methods/FilterAlleles.scala
+++ b/src/main/scala/is/hail/methods/FilterAlleles.scala
@@ -40,7 +40,7 @@ object FilterAlleles {
       "sa" -> (6, vsm.colType),
       "g" -> (7, vsm.entryType)))
 
-    val vAnnotator = new ExprAnnotator(vEC, vsm.rowType, variantExpr, Some(Annotation.ROW_HEAD))
+    val vAnnotator = new ExprAnnotator(vEC, vsm.rvRowType, variantExpr, Some(Annotation.ROW_HEAD))
     val gAnnotator = new ExprAnnotator(gEC, vsm.entryType, genotypeExpr, Some(Annotation.ENTRY_HEAD))
 
     val (t1, insertLocus) = vAnnotator.newT.insert(locusType, "locus")
@@ -51,8 +51,12 @@ object FilterAlleles {
     val globalsBc = vsm.globals.broadcast
     val localNSamples = vsm.numCols
 
+    val newRowEntriesIdx = vAnnotator.newT.fieldIdx.get(MatrixType.entriesIdentifier)
+    val newRowType = newRowEntriesIdx.map(i => vAnnotator.newT.deleteKey(MatrixType.entriesIdentifier, i))
+      .getOrElse(vAnnotator.newT)
+
     val newEntryType = gAnnotator.newT
-    val newMatrixType = vsm.matrixType.copyParts(rowType = vAnnotator.newT, entryType = newEntryType)
+    val newMatrixType = vsm.matrixType.copyParts(rowType = newRowType, entryType = newEntryType)
 
     def filter(rdd: RVD,
       removeLeftAligned: Boolean, removeMoving: Boolean, verifyLeftAligned: Boolean): RVD = {
@@ -137,11 +141,11 @@ object FilterAlleles {
                 newVA = insertLocus(newVA, newLocus)
                 newVA = insertAlleles(newVA, newAlleles)
                 val newRow = newVA.asInstanceOf[Row]
-                assert(newRow.length == newRVType.size - 1)
 
                 var i = 0
-                while (i < newRVType.size - 1) {
-                  rvb.addAnnotation(newRVType.types(i), newRow.get(i))
+                while (i < vAnnotator.newT.size) {
+                  if (newRowEntriesIdx.forall(_ != i))
+                    rvb.addAnnotation(vAnnotator.newT.types(i), newRow.get(i))
                   i += 1
                 }
 

--- a/src/main/scala/is/hail/methods/Skat.scala
+++ b/src/main/scala/is/hail/methods/Skat.scala
@@ -225,8 +225,9 @@ object Skat {
     
     (vsm.rvd.rdd.flatMap { rv =>
       val fullRow = new UnsafeRow(fullRowType, rv)
+      val row = fullRow.deleteField(entryArrayIdx)
 
-      (Option(keyQuerier(fullRow)), Option(weightQuerier(fullRow)).map(_.asInstanceOf[Double])) match {
+      (Option(keyQuerier(row)), Option(weightQuerier(row)).map(_.asInstanceOf[Double])) match {
         case (Some(key), Some(w)) =>
           if (w < 0)
             fatal(s"Variant weights must be non-negative, got $w")

--- a/src/main/scala/is/hail/methods/Skat.scala
+++ b/src/main/scala/is/hail/methods/Skat.scala
@@ -225,9 +225,8 @@ object Skat {
     
     (vsm.rvd.rdd.flatMap { rv =>
       val fullRow = new UnsafeRow(fullRowType, rv)
-      val row = fullRow.deleteField(entryArrayIdx)
 
-      (Option(keyQuerier(row)), Option(weightQuerier(row)).map(_.asInstanceOf[Double])) match {
+      (Option(keyQuerier(fullRow)), Option(weightQuerier(fullRow)).map(_.asInstanceOf[Double])) match {
         case (Some(key), Some(w)) =>
           if (w < 0)
             fatal(s"Variant weights must be non-negative, got $w")

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -422,9 +422,10 @@ class Table(val hc: HailContext, val tir: TableIR) {
   }
 
   def annotateGlobal(a: Annotation, t: Type, name: String): Table = {
-    val value = BroadcastRow(Row(a), TStruct(name -> t), hc.sc)
+    val at = TStruct(name -> t)
+    val value = BroadcastRow(Row(a), at, hc.sc)
     new Table(hc, TableMapGlobals(tir,
-      ir.InsertFields(ir.Ref("global", tir.typ.globalType), FastSeq(name -> ir.GetField(ir.Ref(s"value", t), name))), value))
+      ir.InsertFields(ir.Ref("global", tir.typ.globalType), FastSeq(name -> ir.GetField(ir.Ref(s"value", at), name))), value))
   }
 
   def annotateGlobalJSON(s: String, t: Type, name: String): Table = {

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1052,7 +1052,11 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
               true
           })
 
-        val newMatrixType = matrixType.copyParts(rowType = newRowType, rowKey = newRowKey, rowPartitionKey = newPartitionKey)
+        val newEntriesIndex = newRowType.fieldIdx(MatrixType.entriesIdentifier)
+        val newMatrixType = matrixType.copyParts(
+          rowType = newRowType.deleteKey(MatrixType.entriesIdentifier, entriesIndex),
+          rowKey = newRowKey,
+          rowPartitionKey = newPartitionKey)
         val fullRowType = rvRowType
         val localEntriesIndex = entriesIndex
         val newRVType = newMatrixType.rvRowType
@@ -1077,7 +1081,8 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
             rvb.startStruct()
             var i = 0
             while (i < newRowType.size) {
-              rvb.addAnnotation(newRowType.types(i), results(i))
+              if (i != newEntriesIndex)
+                rvb.addAnnotation(newRowType.types(i), results(i))
               i += 1
             }
             rvb.addField(fullRowType, rv, localEntriesIndex)

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1950,7 +1950,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
       "global" -> (0, globalType),
       "sa" -> (1, colType),
       "g" -> (2, entryType),
-      "va" -> (3, rowType))
+      "va" -> (3, rvRowType))
     EvalContext(Map(
       "global" -> (0, globalType),
       "sa" -> (1, colType),
@@ -2048,7 +2048,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
   def entryEC: EvalContext = EvalContext(Map(
     "global" -> (0, globalType),
-    "va" -> (1, rowType),
+    "va" -> (1, rvRowType),
     "sa" -> (2, colType),
     "g" -> (3, entryType)))
 

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -2181,7 +2181,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
   def filterEntries(filterExpr: String, keep: Boolean = true): MatrixTable = {
     val symTab = Map(
-      "va" -> (0, rowType),
+      "va" -> (0, rvRowType),
       "sa" -> (1, colType),
       "g" -> (2, entryType),
       "global" -> (3, globalType))

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -701,9 +701,10 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
   def annotateGlobal(a: Annotation, t: Type, name: String): MatrixTable = {
-    val value = BroadcastRow(Row(a), TStruct(name -> t), hc.sc)
+    val at = TStruct(name -> t)
+    val value = BroadcastRow(Row(a), at, hc.sc)
     new MatrixTable(hc, MatrixMapGlobals(ast,
-      ir.InsertFields(ir.Ref("global", ast.typ.globalType), FastSeq(name -> ir.GetField(ir.Ref(s"value", t), name))), value))
+      ir.InsertFields(ir.Ref("global", ast.typ.globalType), FastSeq(name -> ir.GetField(ir.Ref(s"value", at), name))), value))
   }
 
   def annotateGlobalJSON(s: String, t: Type, name: String): MatrixTable = {

--- a/src/test/scala/is/hail/expr/TableIRSuite.scala
+++ b/src/test/scala/is/hail/expr/TableIRSuite.scala
@@ -21,14 +21,14 @@ class TableIRSuite extends SparkSuite {
   @Test def testFilter() {
     val kt = getKT
     val kt2 = new Table(hc, TableFilter(kt.tir,
-      ir.ApplyBinaryPrimOp(ir.EQ(), ir.GetField(ir.Ref("row"), "field1"), ir.I32(3))))
+      ir.ApplyBinaryPrimOp(ir.EQ(), ir.GetField(ir.Ref("row", kt.typ.rowType), "field1"), ir.I32(3))))
     assert(kt2.count() == 1)
   }
 
   @Test def testFilterGlobals() {
     val kt = getKT.selectGlobal("{g: 3}")
     val kt2 = new Table(hc, TableFilter(kt.tir,
-      ir.ApplyBinaryPrimOp(ir.EQ(), ir.GetField(ir.Ref("row"), "field1"), ir.GetField(ir.Ref("global"), "g"))))
+      ir.ApplyBinaryPrimOp(ir.EQ(), ir.GetField(ir.Ref("row", kt.typ.rowType), "field1"), ir.GetField(ir.Ref("global", kt.typ.globalType), "g"))))
     assert(kt2.count() == 1)
   }
 }

--- a/src/test/scala/is/hail/expr/ir/CompileSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/CompileSuite.scala
@@ -16,18 +16,18 @@ import org.apache.spark.sql.Row
 
 class CompileSuite {
   def doit(ir: IR, fb: EmitFunctionBuilder[_]) {
-    Infer(ir)
     Emit(ir, fb)
   }
 
   @Test
   def mean() {
+    val tarrf64 = TArray(TFloat64())
     val meanIr =
-      Let("x", In(0, TArray(TFloat64())),
+      Let("x", In(0, tarrf64),
         ApplyBinaryPrimOp(FloatingPointDivide(),
-          ArrayFold(Ref("x"), F64(0.0), "sum", "v",
-            ApplyBinaryPrimOp(Add(), Ref("sum"), Ref("v"))),
-          Cast(ArrayLen(Ref("x")), TFloat64())))
+          ArrayFold(Ref("x", tarrf64), F64(0.0), "sum", "v",
+            ApplyBinaryPrimOp(Add(), Ref("sum", TFloat64()), Ref("v", TFloat64()))),
+          Cast(ArrayLen(Ref("x", tarrf64)), TFloat64())))
 
     val fb = EmitFunctionBuilder[Region, Long, Boolean, Double]
     doit(meanIr, fb)
@@ -49,7 +49,7 @@ class CompileSuite {
     val letAddIr =
       Let("foo", F64(0),
         ApplyBinaryPrimOp(Add(),
-          Ref("foo"), Cast(I32(1), TFloat64())))
+          Ref("foo", TFloat64()), Cast(I32(1), TFloat64())))
 
     val fb = EmitFunctionBuilder[Region, Double]
     doit(letAddIr, fb)
@@ -60,10 +60,11 @@ class CompileSuite {
 
   @Test
   def count() {
+    val tarrf64 = TArray(TFloat64())
     val letAddIr =
-      Let("in", In(0, TArray(TFloat64())),
-        ArrayFold(Ref("in"), I32(0), "count", "v",
-          ApplyBinaryPrimOp(Add(), Ref("count"), I32(1))))
+      Let("in", In(0, tarrf64),
+        ArrayFold(Ref("in", tarrf64), I32(0), "count", "v",
+          ApplyBinaryPrimOp(Add(), Ref("count", TInt32()), I32(1))))
 
     val fb = EmitFunctionBuilder[Region, Long, Boolean, Int]
     doit(letAddIr, fb)
@@ -83,10 +84,11 @@ class CompileSuite {
 
   @Test
   def sum() {
+    val tarrf64 = TArray(TFloat64())
     val letAddIr =
-      Let("in", In(0, TArray(TFloat64())),
-        ArrayFold(Ref("in"), F64(0), "sum", "v",
-          ApplyBinaryPrimOp(Add(), Ref("sum"), Ref("v"))))
+      Let("in", In(0, tarrf64),
+        ArrayFold(Ref("in", tarrf64), F64(0), "sum", "v",
+          ApplyBinaryPrimOp(Add(), Ref("sum", TFloat64()), Ref("v", TFloat64()))))
 
     val fb = EmitFunctionBuilder[Region, Long, Boolean, Double]
     doit(letAddIr, fb)
@@ -108,10 +110,11 @@ class CompileSuite {
 
   @Test
   def countNonMissing() {
+    val tin = TArray(TFloat64())
     val letAddIr =
-      Let("in", In(0, TArray(TFloat64())),
-        ArrayFold(Ref("in"), I32(0), "count", "v",
-          ApplyBinaryPrimOp(Add(), Ref("count"), If(IsNA(Ref("v")), I32(0), I32(1)))))
+      Let("in", In(0, tin),
+        ArrayFold(Ref("in", tin), I32(0), "count", "v",
+          ApplyBinaryPrimOp(Add(), Ref("count", TInt32()), If(IsNA(Ref("v", TFloat64())), I32(0), I32(1)))))
 
     val fb = EmitFunctionBuilder[Region, Long, Boolean, Int]
     doit(letAddIr, fb)
@@ -133,10 +136,17 @@ class CompileSuite {
 
   @Test
   def nonMissingSum() {
+    val tin = TArray(TFloat64())
     val sumIr =
+<<<<<<< 202c883a2f4a51a12106db58fcdf61033a9d8107
       ArrayFold(In(0, TArray(TFloat64())), F64(0), "sum", "v",
         ApplyBinaryPrimOp(Add(), Ref("sum"), If(IsNA(Ref("v")), F64(0.0), Ref("v"))))
     val fb = EmitFunctionBuilder[Region, Long, Boolean, Double]
+=======
+      ArrayFold(In(0, tin), F64(0), "sum", "v",
+        ApplyBinaryPrimOp(Add(), Ref("sum", TFloat64()), If(IsNA(Ref("v", TFloat64())), F64(0.0), Ref("v", TFloat64()))))
+    val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Double]
+>>>>>>> wip
     doit(sumIr, fb)
     val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
 
@@ -155,15 +165,16 @@ class CompileSuite {
 
   @Test
   def nonMissingMean() {
+    val tin = TArray(TFloat64())
     val letAddIr =
-      Let("in", In(0, TArray(TFloat64())),
+      Let("in", In(0, tin),
         Let("nonMissing",
-          ArrayFold(Ref("in"), I32(0), "count", "v",
-            ApplyBinaryPrimOp(Add(), Ref("count"), If(IsNA(Ref("v")), I32(0), I32(1)))),
+          ArrayFold(Ref("in", tin), I32(0), "count", "v",
+            ApplyBinaryPrimOp(Add(), Ref("count", TInt32()), If(IsNA(Ref("v", TFloat64())), I32(0), I32(1)))),
           Let("sum",
-            ArrayFold(Ref("in"), F64(0), "sum", "v",
-              ApplyBinaryPrimOp(Add(), Ref("sum"), If(IsNA(Ref("v")), F64(0.0), Ref("v")))),
-            ApplyBinaryPrimOp(FloatingPointDivide(), Ref("sum"), Cast(Ref("nonMissing"), TFloat64())))))
+            ArrayFold(Ref("in", tin), F64(0), "sum", "v",
+              ApplyBinaryPrimOp(Add(), Ref("sum", TFloat64()), If(IsNA(Ref("v", TFloat64())), F64(0.0), Ref("v", TFloat64())))),
+            ApplyBinaryPrimOp(FloatingPointDivide(), Ref("sum", TFloat64()), Cast(Ref("nonMissing", TInt32()), TFloat64())))))
 
     val fb = EmitFunctionBuilder[Region, Long, Boolean, Double]
     doit(letAddIr, fb)
@@ -244,8 +255,13 @@ class CompileSuite {
     val replaceMissingIr =
       Let("mean", F64(42.0),
         ArrayMap(In(0, TArray(TFloat64())), "v",
+<<<<<<< 202c883a2f4a51a12106db58fcdf61033a9d8107
           If(IsNA(Ref("v")), Ref("mean"), Ref("v"))))
     val fb = EmitFunctionBuilder[Region, Long, Boolean, Long]
+=======
+          If(IsNA(Ref("v", TFloat64())), Ref("mean", TFloat64()), Ref("v", TFloat64()))))
+    val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Long]
+>>>>>>> wip
     doit(replaceMissingIr, fb)
     val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
     def run(a: Array[java.lang.Double]): Array[java.lang.Double] = {
@@ -270,18 +286,19 @@ class CompileSuite {
 
   @Test
   def meanImpute() {
+    val tin = TArray(TFloat64())
     val meanImputeIr =
-      Let("in", In(0, TArray(TFloat64())),
+      Let("in", In(0, tin),
         Let("nonMissing",
-          ArrayFold(Ref("in"), I32(0), "count", "v",
-            ApplyBinaryPrimOp(Add(), Ref("count"), If(IsNA(Ref("v")), I32(0), I32(1)))),
+          ArrayFold(Ref("in", tin), I32(0), "count", "v",
+            ApplyBinaryPrimOp(Add(), Ref("count", TInt32()), If(IsNA(Ref("v", TFloat64())), I32(0), I32(1)))),
           Let("sum",
-            ArrayFold(Ref("in"), F64(0), "sum", "v",
-              ApplyBinaryPrimOp(Add(), Ref("sum"), If(IsNA(Ref("v")), F64(0.0), Ref("v")))),
+            ArrayFold(Ref("in", tin), F64(0), "sum", "v",
+              ApplyBinaryPrimOp(Add(), Ref("sum", TFloat64()), If(IsNA(Ref("v", TFloat64())), F64(0.0), Ref("v", TFloat64())))),
             Let("mean",
-              ApplyBinaryPrimOp(FloatingPointDivide(), Ref("sum"), Cast(Ref("nonMissing"), TFloat64())),
-              ArrayMap(Ref("in"), "v",
-                If(IsNA(Ref("v")), Ref("mean"), Ref("v")))))))
+              ApplyBinaryPrimOp(FloatingPointDivide(), Ref("sum", TFloat64()), Cast(Ref("nonMissing", TInt32()), TFloat64())),
+              ArrayMap(Ref("in", tin), "v",
+                If(IsNA(Ref("v", TFloat64())), Ref("mean", TFloat64()), Ref("v", TFloat64())))))))
 
     val fb = EmitFunctionBuilder[Region, Long, Boolean, Long]
     doit(meanImputeIr, fb)
@@ -422,7 +439,7 @@ class CompileSuite {
   @Test
   def testArrayFilterCutoff() {
     val t = TArray(TInt32())
-    val ir = ArrayFilter(ArrayRange(I32(0), In(0, TInt32()), I32(1)), "x", ApplyBinaryPrimOp(LT(), Ref("x"), In(1, TInt32())))
+    val ir = ArrayFilter(ArrayRange(I32(0), In(0, TInt32()), I32(1)), "x", ApplyBinaryPrimOp(LT(), Ref("x", TInt32()), In(1, TInt32())))
     val region = Region()
     val fb = EmitFunctionBuilder[Region, Int, Boolean, Int, Boolean, Long]
     doit(ir, fb)
@@ -441,7 +458,7 @@ class CompileSuite {
   @Test
   def testArrayFilterElement() {
     val t = TArray(TInt32())
-    val ir = ArrayFilter(In(0, t), "x", ApplyBinaryPrimOp(EQ(), Ref("x"), In(1, TInt32())))
+    val ir = ArrayFilter(In(0, t), "x", ApplyBinaryPrimOp(EQ(), Ref("x", TInt32()), In(1, TInt32())))
     val region = Region()
     val fb = EmitFunctionBuilder[Region, Long, Boolean, Int, Boolean, Long]
     doit(ir, fb)
@@ -472,8 +489,8 @@ class CompileSuite {
     val a1 = In(0, TArray(TInt32()))
     val a2 = In(1, TArray(TString()))
     val min = IRFunctionRegistry.lookupConversion("min", Seq(TArray(TInt32()))).get
-    val range = ArrayRange(I32(0), min(Seq(MakeArray(Seq(ArrayLen(a1), ArrayLen(a2))))), I32(1))
-    val ir = ArrayMap(range, "i", MakeTuple(Seq(ArrayRef(a1, Ref("i")), ArrayRef(a2, Ref("i")))))
+    val range = ArrayRange(I32(0), min(Seq(MakeArray(Seq(ArrayLen(a1), ArrayLen(a2)), TArray(TInt32())))), I32(1))
+    val ir = ArrayMap(range, "i", MakeTuple(Seq(ArrayRef(a1, Ref("i", TInt32())), ArrayRef(a2, Ref("i", TInt32())))))
     val region = Region()
     val fb = EmitFunctionBuilder[Region, Long, Boolean, Long, Boolean, Long]
     doit(ir, fb)
@@ -501,7 +518,7 @@ class CompileSuite {
 
   def testArrayFlatMap() {
     val tRange = TArray(TInt32())
-    val ir = ArrayFlatMap(ArrayRange(I32(0), In(0, TInt32()), I32(1)), "i", ArrayRange(I32(0), Ref("i"), I32(1)))
+    val ir = ArrayFlatMap(ArrayRange(I32(0), In(0, TInt32()), I32(1)), "i", ArrayRange(I32(0), Ref("i", TInt32()), I32(1)))
     val region = Region()
     val fb = EmitFunctionBuilder[Region, Int, Boolean, Long]
     doit(ir, fb)
@@ -521,8 +538,8 @@ class CompileSuite {
     val tRange = TArray(TInt32())
     val inputIR = ArrayRange(I32(0), In(0, TInt32()), I32(1))
     val filterCond = { x: IR => ApplyBinaryPrimOp(EQ(), x, I32(1)) }
-    val filterIR = ArrayFilter(inputIR, "i", filterCond(Ref("i")))
-    val flatMapIR = ArrayFlatMap(inputIR, "i", If(filterCond(Ref("i")), MakeArray(Seq(Ref("i"))), MakeArray(Seq(), tRange)))
+    val filterIR = ArrayFilter(inputIR, "i", filterCond(Ref("i", TInt32())))
+    val flatMapIR = ArrayFlatMap(inputIR, "i", If(filterCond(Ref("i", TInt32())), MakeArray(Seq(Ref("i", TInt32())), TArray(TInt32())), MakeArray(Seq(), tRange)))
 
     val region = Region()
     val fb1 = EmitFunctionBuilder[Region, Int, Boolean, Long]

--- a/src/test/scala/is/hail/expr/ir/CompileSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/CompileSuite.scala
@@ -138,15 +138,9 @@ class CompileSuite {
   def nonMissingSum() {
     val tin = TArray(TFloat64())
     val sumIr =
-<<<<<<< 202c883a2f4a51a12106db58fcdf61033a9d8107
       ArrayFold(In(0, TArray(TFloat64())), F64(0), "sum", "v",
-        ApplyBinaryPrimOp(Add(), Ref("sum"), If(IsNA(Ref("v")), F64(0.0), Ref("v"))))
-    val fb = EmitFunctionBuilder[Region, Long, Boolean, Double]
-=======
-      ArrayFold(In(0, tin), F64(0), "sum", "v",
         ApplyBinaryPrimOp(Add(), Ref("sum", TFloat64()), If(IsNA(Ref("v", TFloat64())), F64(0.0), Ref("v", TFloat64()))))
-    val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Double]
->>>>>>> wip
+    val fb = EmitFunctionBuilder[Region, Long, Boolean, Double]
     doit(sumIr, fb)
     val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
 
@@ -255,13 +249,8 @@ class CompileSuite {
     val replaceMissingIr =
       Let("mean", F64(42.0),
         ArrayMap(In(0, TArray(TFloat64())), "v",
-<<<<<<< 202c883a2f4a51a12106db58fcdf61033a9d8107
-          If(IsNA(Ref("v")), Ref("mean"), Ref("v"))))
-    val fb = EmitFunctionBuilder[Region, Long, Boolean, Long]
-=======
           If(IsNA(Ref("v", TFloat64())), Ref("mean", TFloat64()), Ref("v", TFloat64()))))
-    val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Long]
->>>>>>> wip
+    val fb = EmitFunctionBuilder[Region, Long, Boolean, Long]
     doit(replaceMissingIr, fb)
     val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
     def run(a: Array[java.lang.Double]): Array[java.lang.Double] = {

--- a/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -48,14 +48,12 @@ class FunctionSuite {
   def fromHailString(hql: String): IR = Parser.parseToAST(hql, ec).toIR().get
 
   def toF[R: TypeInfo](ir: IR): AsmFunction1[Region, R] = {
-    Infer(ir)
     val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, R])
     Emit(ir, fb)
     fb.result(Some(new PrintWriter(System.out)))()
   }
 
   def toF[A: TypeInfo, R: TypeInfo](ir: IR): AsmFunction3[Region, A, Boolean, R] = {
-    Infer(ir)
     val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, A, Boolean, R])
     Emit(ir, fb)
     fb.result(Some(new PrintWriter(System.out)))()

--- a/src/test/scala/is/hail/expr/ir/InterpretSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/InterpretSuite.scala
@@ -22,7 +22,7 @@ class InterpretSuite {
   private val t = True()
   private val f = False()
 
-  private val arr = MakeArray(List(I32(1), I32(5), I32(2), NA(TInt32())))
+  private val arr = MakeArray(List(I32(1), I32(5), I32(2), NA(TInt32())), TArray(TInt32()))
 
   private val struct = MakeStruct(List("a" -> i32, "b" -> f32, "c" -> ArrayRange(I32(0), I32(5), I32(1))))
 
@@ -211,7 +211,7 @@ class InterpretSuite {
   }
 
   @Test def testLet() {
-    check(Let("foo", i64, ApplyBinaryPrimOp(Add(), f64, Cast(Ref("foo"), TFloat64()))))
+    check(Let("foo", i64, ApplyBinaryPrimOp(Add(), f64, Cast(Ref("foo", TInt64()), TFloat64()))))
   }
 
   @Test def testMakeArray() {
@@ -233,20 +233,20 @@ class InterpretSuite {
   }
 
   @Test def testArrayMap() {
-    check(ArrayMap(arr, "foo", ApplyBinaryPrimOp(Multiply(), Ref("foo"), Ref("foo"))))
+    check(ArrayMap(arr, "foo", ApplyBinaryPrimOp(Multiply(), Ref("foo", TInt32()), Ref("foo", TInt32()))))
   }
 
   @Test def testArrayFilter() {
-    check(ArrayFilter(arr, "foo", ApplyBinaryPrimOp(LT(), Ref("foo"), I32(2))))
-    check(ArrayFilter(arr, "foo", ApplyBinaryPrimOp(LT(), Ref("foo"), NA(TInt32()))))
+    check(ArrayFilter(arr, "foo", ApplyBinaryPrimOp(LT(), Ref("foo", TInt32()), I32(2))))
+    check(ArrayFilter(arr, "foo", ApplyBinaryPrimOp(LT(), Ref("foo", TInt32()), NA(TInt32()))))
   }
 
   @Test def testArrayFlatMap() {
-    check(ArrayFlatMap(arr, "foo", ArrayRange(I32(-1), Ref("foo"), I32(1))))
+    check(ArrayFlatMap(arr, "foo", ArrayRange(I32(-1), Ref("foo", TInt32()), I32(1))))
   }
 
   @Test def testArrayFold() {
-    check(ArrayFold(arr, I32(0), "sum", "element", ApplyBinaryPrimOp(Add(), Ref("sum"), Ref("element"))))
+    check(ArrayFold(arr, I32(0), "sum", "element", ApplyBinaryPrimOp(Add(), Ref("sum", TInt32()), Ref("element", TInt32()))))
   }
 
   @Test def testMakeStruct() {
@@ -290,7 +290,7 @@ class InterpretSuite {
       15 -> Env.empty[Any].bind("a" -> 30)
     )
 
-    val result = Interpret(ApplyAggOp(AggFilter(AggIn(), "x", ApplyBinaryPrimOp(LT(), Ref("a"), I32(21))),
+    val result = Interpret(ApplyAggOp(AggFilter(AggIn(aggT), "x", ApplyBinaryPrimOp(LT(), Ref("a", TInt32()), I32(21))),
       Sum(), List()), env, IndexedSeq(), Some(agg))
     assert(result == 15)
   }

--- a/src/test/scala/is/hail/testUtils/RichMatrixTable.scala
+++ b/src/test/scala/is/hail/testUtils/RichMatrixTable.scala
@@ -88,7 +88,6 @@ class RichMatrixTable(vsm: MatrixTable) {
     val localRowType = vsm.rowType
     val rowKeyF = vsm.rowKeysF
     vsm.rvd.rdd.map { rv =>
-      val unsafeFullRow = new UnsafeRow(fullRowType, rv)
       val fullRow = SafeRow(fullRowType, rv.region, rv.offset)
       val row = fullRow.deleteField(localEntriesIndex)
       (rowKeyF(fullRow), (row, fullRow.getAs[IndexedSeq[Any]](localEntriesIndex)))


### PR DESCRIPTION
This probably needs a little cleanup.

What's this for?  Well, in another branch I have a bunch of IR rewrite optimizations.  Those rewrite rules (1) want to test types (e.g. eliminate a cast of a type to itself), and they (2) also want to create new IRs which therefore need well-formed types.  Calculating all the intermediate types explicitly (or calling Infer) everywhere both seem like non-starters.

Therefore, I changed the IR nodes to compute their own types.  I repurposed Infer, but it is no longer recursive.

This meant that In, InAgg and Ref needed to carry their types, becuase, in the old, Infer-based way, they were dependent on the environment to type themselves, but that's no longer possible.

I also repurposed Infer as a recursive type checker.

This created two subtle problems: (1) the IR code uses rvRowType everywhere in stead of rowType (so it can reuse pointers to the full row) and (2) toIR needs to set the Ref type from the symbol table, but the symbol table strips out all missing bits, so the types on Ref terms disagreed with the actual values flowing around.

I resolved this in two ways: (1) va now refers to the full rvRowType in all eval contexts, everywhere.  (This is closer to the existing IR behavior.)  (2) the symbol table no longer strips missingness, but it is stripped by Ref when the symbol is referenced.  Ref also records the unstripped type which is used by toIR.

The sooner we can kill AST, the better.