### PR TITLE
ResettableContext

### DIFF
--- a/src/main/scala/is/hail/annotations/Region.scala
+++ b/src/main/scala/is/hail/annotations/Region.scala
@@ -14,7 +14,10 @@ object Region {
   }
 }
 
-final class Region(private var mem: Array[Byte], private var end: Long = 0) extends KryoSerializable with Serializable {
+final class Region(
+  private var mem: Array[Byte],
+  private var end: Long = 0
+) extends KryoSerializable with Serializable with AutoCloseable {
   def size: Long = end
 
   def capacity: Long = mem.length
@@ -369,4 +372,6 @@ final class Region(private var mem: Array[Byte], private var end: Long = 0) exte
     visit(t, off, v)
     v.result()
   }
+
+  def close(): Unit = ()
 }

--- a/src/main/scala/is/hail/rvd/RVDContext.scala
+++ b/src/main/scala/is/hail/rvd/RVDContext.scala
@@ -1,6 +1,9 @@
 package is.hail.rvd
 
-import is.hail.annotations.Region
+import is.hail.annotations.{Region, RegionValueBuilder}
+import is.hail.sparkextras.ResettableContext
+
+import scala.collection.mutable
 
 object RVDContext {
   def default: RVDContext = new RVDContext(Region())
@@ -10,11 +13,48 @@ object RVDContext {
 
 // NB: must be *Auto*Closeable because calling close twice is undefined behavior
 // (see AutoCloseable javadoc)
-class RVDContext(r: Region) extends AutoCloseable {
+class RVDContext(r: Region) extends ResettableContext {
+  private[this] val children: mutable.ArrayBuffer[AutoCloseable] = new mutable.ArrayBuffer()
+
+  private[this] def own(child: AutoCloseable): Unit = children += child
+
+  own(r)
+
+  def freshContext: RVDContext = {
+    val ctx = RVDContext.default
+    own(ctx)
+    ctx
+  }
+
   def region: Region = r // lifetime: element
 
   def partitionRegion: Region = r // lifetime: partition
 
+  private[this] val theRvb = new RegionValueBuilder(r)
+  def rvb = theRvb
+
+  def reset(): Unit = {
+    r.clear()
+  }
+
   // frees the memory associated with this context
-  def close(): Unit = ()
+  def close(): Unit = {
+    var e: Exception = null
+    var i = 0
+    while (i < children.size) {
+      try {
+        children(i).close()
+      } catch {
+        case e2: Exception =>
+          if (e == null)
+            e = e2
+          else
+            e.addSuppressed(e2)
+      }
+      i += 1
+    }
+
+    if (e != null)
+      throw e
+  }
 }

--- a/src/main/scala/is/hail/rvd/RVDContext.scala
+++ b/src/main/scala/is/hail/rvd/RVDContext.scala
@@ -11,8 +11,6 @@ object RVDContext {
   def fromRegion(region: Region): RVDContext = new RVDContext(region)
 }
 
-// NB: must be *Auto*Closeable because calling close twice is undefined behavior
-// (see AutoCloseable javadoc)
 class RVDContext(r: Region) extends ResettableContext {
   private[this] val children: mutable.ArrayBuffer[AutoCloseable] = new mutable.ArrayBuffer()
 

--- a/src/main/scala/is/hail/sparkextras/ResettableContext.scala
+++ b/src/main/scala/is/hail/sparkextras/ResettableContext.scala
@@ -1,0 +1,5 @@
+package is.hail.sparkextras
+
+trait ResettableContext extends AutoCloseable {
+  def reset(): Unit
+}


### PR DESCRIPTION
also add rvb to rvdcontext and give it children

Eventually `close` on `Region` will free off heap memory. For now, it does nothing.