### PR TITLE
Safe, On-Heap Annotations

### DIFF
--- a/src/main/scala/is/hail/annotations/Annotation.scala
+++ b/src/main/scala/is/hail/annotations/Annotation.scala
@@ -119,80 +119,22 @@ object Annotation {
   def safeFromRegionValue(t: Type, rv: RegionValue): Annotation =
     safeFromRegionValue(t, rv.region, rv.offset)
 
-  def safeFromRegionValue(t: Type, region: Region, offset: Long): Annotation = t match {
-    case _: TBoolean =>
-      region.loadBoolean(offset)
-    case _: TInt32 | _: TCall => region.loadInt(offset)
-    case _: TInt64 => region.loadLong(offset)
-    case _: TFloat32 => region.loadFloat(offset)
-    case _: TFloat64 => region.loadDouble(offset)
-    case t: TArray =>
-      safeFromArrayRegionValue(t, region, offset)
-    case t: TSet =>
-      safeFromArrayRegionValue(t, region, offset).toSet
-    case _: TString => UnsafeRow.readString(region, offset)
-    case _: TBinary => UnsafeRow.readBinary(region, offset)
-    case td: TDict =>
-      val a = safeFromArrayRegionValue(td, region, offset)
-      a.map(r => r.asInstanceOf[Row]).map(r => (r.get(0), r.get(1))).toMap
-    case t: TBaseStruct =>
-      safeFromBaseStructRegionValue(t, region, offset)
-    case t: TLocus =>
-      UnsafeRow.readLocus(region, offset, t.rg)
-    case t: TInterval =>
-      val ft = t.fundamentalType.asInstanceOf[TStruct]
-      val start: Annotation =
-        if (ft.isFieldDefined(region, offset, 0))
-          safeFromRegionValue(t.pointType, region, ft.loadField(region, offset, 0))
-        else
-          null
-      val end =
-        if (ft.isFieldDefined(region, offset, 1))
-          safeFromRegionValue(t.pointType, region, ft.loadField(region, offset, 1))
-        else
-          null
-      val includesStart = safeFromRegionValue(
-        TBooleanRequired,
-        region,
-        ft.loadField(region, offset, 2)).asInstanceOf[Boolean]
-      val includesEnd = safeFromRegionValue(
-        TBooleanRequired,
-        region,
-        ft.loadField(region, offset, 3)).asInstanceOf[Boolean]
-      Interval(start, end, includesStart, includesEnd)
-  }
+  def safeFromRegionValue(t: Type, region: Region, offset: Long): Annotation =
+    Annotation.copy(t, UnsafeRow.read(t, region, offset))
 
   def safeFromArrayRegionValue(
     t: TContainer,
     region: Region,
     offset: Long
-  ): IndexedSeq[Annotation] = {
-    val length = t.loadLength(region, offset)
-    val a = new Array[Annotation](length)
-    var i = 0
-    while (i < length) {
-      a(i) =
-        safeFromRegionValue(
-          t.elementType,
-          region,
-          t.loadElement(region, offset, length, i))
-      i += 1
-    }
-    a.toFastIndexedSeq
-  }
+  ): IndexedSeq[Annotation] =
+    Annotation.copy(t, UnsafeRow.readArray(t, region, offset))
+      .asInstanceOf[IndexedSeq[Annotation]]
 
   def safeFromBaseStructRegionValue(
     t: TBaseStruct,
     region: Region,
     offset: Long
   ): Row =
-    Row(t.fields.map(f =>
-      if (t.isFieldDefined(region, offset, f.index))
-        safeFromRegionValue(
-          f.typ,
-          region,
-          t.loadField(region, offset, f.index))
-      else
-        null
-    ).toArray: _*)
+    Annotation.copy(t, UnsafeRow.readBaseStruct(t, region, offset))
+      .asInstanceOf[Row]
 }

--- a/src/main/scala/is/hail/annotations/Annotation.scala
+++ b/src/main/scala/is/hail/annotations/Annotation.scala
@@ -115,26 +115,4 @@ object Annotation {
       case _ => true
     })
   }
-
-  def safeFromRegionValue(t: Type, rv: RegionValue): Annotation =
-    safeFromRegionValue(t, rv.region, rv.offset)
-
-  def safeFromRegionValue(t: Type, region: Region, offset: Long): Annotation =
-    Annotation.copy(t, UnsafeRow.read(t, region, offset))
-
-  def safeFromArrayRegionValue(
-    t: TContainer,
-    region: Region,
-    offset: Long
-  ): IndexedSeq[Annotation] =
-    Annotation.copy(t, UnsafeRow.readArray(t, region, offset))
-      .asInstanceOf[IndexedSeq[Annotation]]
-
-  def safeFromBaseStructRegionValue(
-    t: TBaseStruct,
-    region: Region,
-    offset: Long
-  ): Row =
-    Annotation.copy(t, UnsafeRow.readBaseStruct(t, region, offset))
-      .asInstanceOf[Row]
 }

--- a/src/main/scala/is/hail/annotations/Annotation.scala
+++ b/src/main/scala/is/hail/annotations/Annotation.scala
@@ -115,4 +115,84 @@ object Annotation {
       case _ => true
     })
   }
+
+  def safeFromRegionValue(t: Type, rv: RegionValue): Annotation =
+    safeFromRegionValue(t, rv.region, rv.offset)
+
+  def safeFromRegionValue(t: Type, region: Region, offset: Long): Annotation = t match {
+    case _: TBoolean =>
+      region.loadBoolean(offset)
+    case _: TInt32 | _: TCall => region.loadInt(offset)
+    case _: TInt64 => region.loadLong(offset)
+    case _: TFloat32 => region.loadFloat(offset)
+    case _: TFloat64 => region.loadDouble(offset)
+    case t: TArray =>
+      safeFromArrayRegionValue(t, region, offset)
+    case t: TSet =>
+      safeFromArrayRegionValue(t, region, offset).toSet
+    case _: TString => UnsafeRow.readString(region, offset)
+    case _: TBinary => UnsafeRow.readBinary(region, offset)
+    case td: TDict =>
+      val a = safeFromArrayRegionValue(td, region, offset)
+      a.map(r => r.asInstanceOf[Row]).map(r => (r.get(0), r.get(1))).toMap
+    case t: TBaseStruct =>
+      safeFromBaseStructRegionValue(t, region, offset)
+    case t: TLocus =>
+      UnsafeRow.readLocus(region, offset, t.rg)
+    case t: TInterval =>
+      val ft = t.fundamentalType.asInstanceOf[TStruct]
+      val start: Annotation =
+        if (ft.isFieldDefined(region, offset, 0))
+          safeFromRegionValue(t.pointType, region, ft.loadField(region, offset, 0))
+        else
+          null
+      val end =
+        if (ft.isFieldDefined(region, offset, 1))
+          safeFromRegionValue(t.pointType, region, ft.loadField(region, offset, 1))
+        else
+          null
+      val includesStart = safeFromRegionValue(
+        TBooleanRequired,
+        region,
+        ft.loadField(region, offset, 2)).asInstanceOf[Boolean]
+      val includesEnd = safeFromRegionValue(
+        TBooleanRequired,
+        region,
+        ft.loadField(region, offset, 3)).asInstanceOf[Boolean]
+      Interval(start, end, includesStart, includesEnd)
+  }
+
+  def safeFromArrayRegionValue(
+    t: TContainer,
+    region: Region,
+    offset: Long
+  ): IndexedSeq[Annotation] = {
+    val length = t.loadLength(region, offset)
+    val a = new Array[Annotation](length)
+    var i = 0
+    while (i < length) {
+      a(i) =
+        safeFromRegionValue(
+          t.elementType,
+          region,
+          t.loadElement(region, offset, length, i))
+      i += 1
+    }
+    a.toFastIndexedSeq
+  }
+
+  def safeFromBaseStructRegionValue(
+    t: TBaseStruct,
+    region: Region,
+    offset: Long
+  ): Row =
+    Row(t.fields.map(f =>
+      if (t.isFieldDefined(region, offset, f.index))
+        safeFromRegionValue(
+          f.typ,
+          region,
+          t.loadField(region, offset, f.index))
+      else
+        null
+    ).toArray: _*)
 }

--- a/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -224,12 +224,12 @@ object SafeRow {
     Annotation.copy(t, UnsafeRow.read(t, region, off))
 
   def read(t: Type, rv: RegionValue): Annotation =
-    read(t, rv.region, rv.off)
+    read(t, rv.region, rv.offset)
 }
 
 object SafeIndexedSeq {
   def apply(t: TArray, region: Region, off: Long): IndexedSeq[Annotation] =
-    Annotation.copy(new UnsafeIndexedSeq(t, region, off))
+    Annotation.copy(t, new UnsafeIndexedSeq(t, region, off))
       .asInstanceOf[IndexedSeq[Annotation]]
 
   def apply(t: TArray, rv: RegionValue): IndexedSeq[Annotation] =

--- a/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -219,6 +219,21 @@ object SafeRow {
   }
 
   def apply(t: TBaseStruct, rv: RegionValue): Row = SafeRow(t, rv.region, rv.offset)
+
+  def read(t: Type, region: Region, off: Long): Annotation =
+    Annotation.copy(t, UnsafeRow.read(t, region, off))
+
+  def read(t: Type, rv: RegionValue): Annotation =
+    read(t, rv.region, rv.off)
+}
+
+object SafeIndexedSeq {
+  def apply(t: TArray, region: Region, off: Long): IndexedSeq[Annotation] =
+    Annotation.copy(new UnsafeIndexedSeq(t, region, off))
+      .asInstanceOf[IndexedSeq[Annotation]]
+
+  def apply(t: TArray, rv: RegionValue): IndexedSeq[Annotation] =
+    apply(t, rv.region, rv.offset)
 }
 
 class KeyedRow(var row: Row, keyFields: Array[Int]) extends Row {


### PR DESCRIPTION
RegionValue and Region are going off-heap, so where we use `Annotation` we will need to start using something not based on `Region`s.

This PR is just for the implementation. A follow up PR will spread it throughout the code-base wherever we need GC'd `Annotation`. My hope is that this is quite limited. For over-the-network communication, we should use the `is.hail.io` `RowStore.scala` stuff. If the memory-lifetime of the object is known, we can use a region that is explicitly `close`d.

cc: @cseed