### PR TITLE
Remove ContextRDD.partitionRegion

### DIFF
--- a/src/main/scala/is/hail/rvd/RVDContext.scala
+++ b/src/main/scala/is/hail/rvd/RVDContext.scala
@@ -26,8 +26,6 @@ class RVDContext(r: Region) extends ResettableContext {
 
   def region: Region = r // lifetime: element
 
-  def partitionRegion: Region = r // lifetime: partition
-
   private[this] val theRvb = new RegionValueBuilder(r)
   def rvb = theRvb
 


### PR DESCRIPTION
This isn't used and doesn't work right now. Perhaps we will bring it back in the future when we find a need for it.