### PR TITLE
Improve valuesSimilar for _same

### DIFF
--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -2546,9 +2546,10 @@ class MatrixTable(ExprContainer):
         return MatrixTable(self._jvds.indexCols(name))
 
     @typecheck_method(other=matrix_table_type,
-                      tolerance=numeric)
-    def _same(self, other, tolerance=1e-6):
-        return self._jvds.same(other._jvds, tolerance)
+                      tolerance=numeric,
+                      absolute=bool)
+    def _same(self, other, tolerance=1e-6, absolute=False):
+        return self._jvds.same(other._jvds, tolerance, absolute)
 
     @typecheck_method(caller=str, s=expr_struct())
     def _select_entries(self, caller, s):

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -2200,9 +2200,9 @@ class Table(ExprContainer):
         """
         return Table.from_spark(Env.sql_context().createDataFrame(df), key)
 
-    @typecheck_method(other=table_type, tolerance=nullable(numeric))
-    def _same(self, other, tolerance=1e-6):
-        return self._jt.same(other._jt, tolerance)
+    @typecheck_method(other=table_type, tolerance=nullable(numeric), absolute=bool)
+    def _same(self, other, tolerance=1e-6, absolute=False):
+        return self._jt.same(other._jt, tolerance, absolute)
 
     def collect_by_key(self, name: str= 'values') -> 'Table':
         """Collect values for each unique key into an array.

--- a/python/hail/tests/test_methods.py
+++ b/python/hail/tests/test_methods.py
@@ -479,10 +479,10 @@ class Tests(unittest.TestCase):
         hkin = hl.pc_relate(mt.GT, 0.00, k=2).cache()
         rkin = self._R_pc_relate(mt, 0.00).cache()
 
-        self.assertTrue(rkin.select("i", "j", "kin")._same(hkin.select("i", "j", "kin"), tolerance=1e-3))
-        self.assertTrue(rkin.select("i", "j", "ibd0")._same(hkin.select("i", "j", "ibd0"), tolerance=1e-2))
-        self.assertTrue(rkin.select("i", "j", "ibd1")._same(hkin.select("i", "j", "ibd1"), tolerance=2e-2))
-        self.assertTrue(rkin.select("i", "j", "ibd2")._same(hkin.select("i", "j", "ibd2"), tolerance=1e-2))
+        self.assertTrue(rkin.select("i", "j", "kin")._same(hkin.select("i", "j", "kin"), tolerance=1e-3, absolute=True))
+        self.assertTrue(rkin.select("i", "j", "ibd0")._same(hkin.select("i", "j", "ibd0"), tolerance=1e-2, absolute=True))
+        self.assertTrue(rkin.select("i", "j", "ibd1")._same(hkin.select("i", "j", "ibd1"), tolerance=2e-2, absolute=True))
+        self.assertTrue(rkin.select("i", "j", "ibd2")._same(hkin.select("i", "j", "ibd2"), tolerance=1e-2, absolute=True))
 
     def test_pcrelate_paths(self):
         mt = hl.balding_nichols_model(3, 50, 100)

--- a/src/main/scala/is/hail/expr/types/TBaseStruct.scala
+++ b/src/main/scala/is/hail/expr/types/TBaseStruct.scala
@@ -102,12 +102,12 @@ abstract class TBaseStruct extends Type {
           Gen.uniformSequence(types.map(t => t.genValue)).map(a => Annotation(a: _*)))
   }
 
-  override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double): Boolean =
+  override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean): Boolean =
     a1 == a2 || (a1 != null && a2 != null
       && types.zip(a1.asInstanceOf[Row].toSeq).zip(a2.asInstanceOf[Row].toSeq)
       .forall {
         case ((t, x1), x2) =>
-          t.valuesSimilar(x1, x2, tolerance)
+          t.valuesSimilar(x1, x2, tolerance, absolute)
       })
 
   override def scalaClassTag: ClassTag[Row] = classTag[Row]

--- a/src/main/scala/is/hail/expr/types/TDict.scala
+++ b/src/main/scala/is/hail/expr/types/TDict.scala
@@ -62,11 +62,11 @@ final case class TDict(keyType: Type, valueType: Type, override val required: Bo
   override def genNonmissingValue: Gen[Annotation] =
     Gen.buildableOf2[Map](Gen.zip(keyType.genValue, valueType.genValue))
 
-  override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double): Boolean =
+  override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean): Boolean =
     a1 == a2 || (a1 != null && a2 != null &&
       a1.asInstanceOf[Map[Any, _]].outerJoin(a2.asInstanceOf[Map[Any, _]])
         .forall { case (_, (o1, o2)) =>
-          o1.liftedZip(o2).exists { case (v1, v2) => valueType.valuesSimilar(v1, v2, tolerance) }
+          o1.liftedZip(o2).exists { case (v1, v2) => valueType.valuesSimilar(v1, v2, tolerance, absolute) }
         })
 
   override def desc: String =

--- a/src/main/scala/is/hail/expr/types/TFloat32.scala
+++ b/src/main/scala/is/hail/expr/types/TFloat32.scala
@@ -25,11 +25,13 @@ class TFloat32(override val required: Boolean) extends TNumeric {
 
   override def genNonmissingValue: Gen[Annotation] = arbitrary[Double].map(_.toFloat)
 
-  override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double): Boolean =
-    a1 == a2 || (a1 != null && a2 != null &&
-      (math.abs(a1.asInstanceOf[Float] - a2.asInstanceOf[Float]) <= tolerance ||
-        D_==(a1.asInstanceOf[Float], a2.asInstanceOf[Float], tolerance) ||
-        (a1.asInstanceOf[Double].isNaN && a2.asInstanceOf[Double].isNaN)))
+  override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean): Boolean =
+    a1 == a2 || (a1 != null && a2 != null && (
+      (if (absolute)
+        math.abs(a1.asInstanceOf[Float] - a2.asInstanceOf[Float]) <= tolerance
+      else
+        D_==(a1.asInstanceOf[Float], a2.asInstanceOf[Float], tolerance)
+        ) || (a1.asInstanceOf[Float].isNaN && a2.asInstanceOf[Float].isNaN)))
 
   override def scalaClassTag: ClassTag[java.lang.Float] = classTag[java.lang.Float]
 

--- a/src/main/scala/is/hail/expr/types/TFloat32.scala
+++ b/src/main/scala/is/hail/expr/types/TFloat32.scala
@@ -26,12 +26,17 @@ class TFloat32(override val required: Boolean) extends TNumeric {
   override def genNonmissingValue: Gen[Annotation] = arbitrary[Double].map(_.toFloat)
 
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean): Boolean =
-    a1 == a2 || (a1 != null && a2 != null && (
+    a1 == a2 || (a1 != null && a2 != null && {
+      val f1 = a1.asInstanceOf[Float]
+      val f2 = a2.asInstanceOf[Float]
+
       (if (absolute)
-        math.abs(a1.asInstanceOf[Float] - a2.asInstanceOf[Float]) <= tolerance
+        math.abs(f1 - f2) <= tolerance
       else
-        D_==(a1.asInstanceOf[Float], a2.asInstanceOf[Float], tolerance)
-        ) || (a1.asInstanceOf[Float].isNaN && a2.asInstanceOf[Float].isNaN)))
+        D_==(f1, f2, tolerance)) ||
+        (f1.isNaN && f2.isNaN) ||
+        (f1.isInfinite && f2.isInfinite && ((f1 > 0 && f2 > 0) || (f1 < 0 && f2 < 0)))
+    })
 
   override def scalaClassTag: ClassTag[java.lang.Float] = classTag[java.lang.Float]
 

--- a/src/main/scala/is/hail/expr/types/TFloat64.scala
+++ b/src/main/scala/is/hail/expr/types/TFloat64.scala
@@ -28,8 +28,8 @@ class TFloat64(override val required: Boolean) extends TNumeric {
 
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean): Boolean =
     a1 == a2 || (a1 != null && a2 != null && {
-      val f1 = a1.asInstanceOf[Float]
-      val f2 = a2.asInstanceOf[Float]
+      val f1 = a1.asInstanceOf[Double]
+      val f2 = a2.asInstanceOf[Double]
 
       (if (absolute)
         math.abs(f1 - f2) <= tolerance

--- a/src/main/scala/is/hail/expr/types/TFloat64.scala
+++ b/src/main/scala/is/hail/expr/types/TFloat64.scala
@@ -26,11 +26,13 @@ class TFloat64(override val required: Boolean) extends TNumeric {
 
   override def genNonmissingValue: Gen[Annotation] = arbitrary[Double]
 
-  override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double): Boolean =
-    a1 == a2 || (a1 != null && a2 != null &&
-      (math.abs(a1.asInstanceOf[Double] - a2.asInstanceOf[Double]) <= tolerance ||
-        D_==(a1.asInstanceOf[Double], a2.asInstanceOf[Double], tolerance) ||
-        (a1.asInstanceOf[Double].isNaN && a2.asInstanceOf[Double].isNaN)))
+  override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean): Boolean =
+    a1 == a2 || (a1 != null && a2 != null && (
+      (if (absolute)
+        math.abs(a1.asInstanceOf[Double] - a2.asInstanceOf[Double]) <= tolerance
+      else
+        D_==(a1.asInstanceOf[Double], a2.asInstanceOf[Double], tolerance)
+        ) || (a1.asInstanceOf[Double].isNaN && a2.asInstanceOf[Double].isNaN)))
 
   override def scalaClassTag: ClassTag[java.lang.Double] = classTag[java.lang.Double]
 

--- a/src/main/scala/is/hail/expr/types/TFloat64.scala
+++ b/src/main/scala/is/hail/expr/types/TFloat64.scala
@@ -27,12 +27,17 @@ class TFloat64(override val required: Boolean) extends TNumeric {
   override def genNonmissingValue: Gen[Annotation] = arbitrary[Double]
 
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean): Boolean =
-    a1 == a2 || (a1 != null && a2 != null && (
+    a1 == a2 || (a1 != null && a2 != null && {
+      val f1 = a1.asInstanceOf[Float]
+      val f2 = a2.asInstanceOf[Float]
+
       (if (absolute)
-        math.abs(a1.asInstanceOf[Double] - a2.asInstanceOf[Double]) <= tolerance
+        math.abs(f1 - f2) <= tolerance
       else
-        D_==(a1.asInstanceOf[Double], a2.asInstanceOf[Double], tolerance)
-        ) || (a1.asInstanceOf[Double].isNaN && a2.asInstanceOf[Double].isNaN)))
+        D_==(f1, f2, tolerance)) ||
+        (f1.isNaN && f2.isNaN) ||
+        (f1.isInfinite && f2.isInfinite && ((f1 > 0 && f2 > 0) || (f1 < 0 && f2 < 0)))
+    })
 
   override def scalaClassTag: ClassTag[java.lang.Double] = classTag[java.lang.Double]
 

--- a/src/main/scala/is/hail/expr/types/TIterable.scala
+++ b/src/main/scala/is/hail/expr/types/TIterable.scala
@@ -3,9 +3,9 @@ package is.hail.expr.types
 import is.hail.annotations._
 
 abstract class TIterable extends TContainer {
-  override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double): Boolean =
+  override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean): Boolean =
     a1 == a2 || (a1 != null && a2 != null
       && (a1.asInstanceOf[Iterable[_]].size == a2.asInstanceOf[Iterable[_]].size)
       && a1.asInstanceOf[Iterable[_]].zip(a2.asInstanceOf[Iterable[_]])
-      .forall { case (e1, e2) => elementType.valuesSimilar(e1, e2, tolerance) })
+      .forall { case (e1, e2) => elementType.valuesSimilar(e1, e2, tolerance, absolute) })
 }

--- a/src/main/scala/is/hail/expr/types/Type.scala
+++ b/src/main/scala/is/hail/expr/types/Type.scala
@@ -243,7 +243,7 @@ abstract class Type extends BaseType with Serializable {
   def isRealizable: Boolean = children.forall(_.isRealizable)
 
   /* compare values for equality, but compare Float and Double values by the absolute value of their difference is within tolerance or with D_== */
-  def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double = utils.defaultTolerance): Boolean = a1 == a2
+  def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double = utils.defaultTolerance, absolute: Boolean = false): Boolean = a1 == a2
 
   def scalaClassTag: ClassTag[_ <: AnyRef]
 

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -112,7 +112,7 @@ object Table {
     ))
   }
 
-  def sameWithinTolerance(t: Type, l: Array[Row], r: Array[Row], tolerance: Double): Boolean = {
+  def sameWithinTolerance(t: Type, l: Array[Row], r: Array[Row], tolerance: Double, absolute: Boolean): Boolean = {
     val used = new Array[Boolean](r.length)
     var i = 0
     while (i < l.length) {
@@ -120,7 +120,7 @@ object Table {
       var matched = false
       var j = 0
       while (!matched && j < l.length && !used(j)) {
-        matched = t.valuesSimilar(li, r(j), tolerance)
+        matched = t.valuesSimilar(li, r(j), tolerance, absolute)
         if (matched)
           used(j) = true
         j += 1
@@ -257,7 +257,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
     rdd.map { r => (Row.fromSeq(keyIndices.map(r.get)), Row.fromSeq(valueIndices.map(r.get))) }
   }
 
-  def same(other: Table, tolerance: Double = defaultTolerance): Boolean = {
+  def same(other: Table, tolerance: Double = defaultTolerance, absolute: Boolean = false): Boolean = {
     val localValueSignature = valueSignature
 
     val globalSignatureOpt = globalSignature.deepOptional()
@@ -299,7 +299,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
             val res = if (r1.length != r2.length)
               false
             else r1.counter() == r2.counter() ||
-              Table.sameWithinTolerance(localValueSignature, r1, r2, tolerance)
+              Table.sameWithinTolerance(localValueSignature, r1, r2, tolerance, absolute)
             if (!res)
               info(s"SAME KEY, DIFFERENT VALUES: k=$k\n  left:\n    ${ r1.mkString("\n    ") }\n  right:\n    ${ r2.mkString("\n    ") }")
             res

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1818,7 +1818,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     copy2(colType = newSchema, colValues = colValues.copy(value = newAnnotations, t = TArray(newSchema)))
   }
 
-  def same(that: MatrixTable, tolerance: Double = utils.defaultTolerance): Boolean = {
+  def same(that: MatrixTable, tolerance: Double = utils.defaultTolerance, absolute: Boolean = false): Boolean = {
     var metadataSame = true
     if (rowType.deepOptional() != that.rowType.deepOptional()) {
       metadataSame = false
@@ -1848,14 +1848,14 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
            |  left:  ${ entryType.toString }
            |  right: ${ that.entryType.toString }""".stripMargin)
     }
-    if (!colValuesSimilar(that, tolerance)) {
+    if (!colValuesSimilar(that, tolerance, absolute)) {
       metadataSame = false
       println(
         s"""different sample annotations:
            |  left:  $colValues
            |  right: ${ that.colValues }""".stripMargin)
     }
-    if (!globalType.valuesSimilar(globals.value, that.globals.value)) {
+    if (!globalType.valuesSimilar(globals.value, that.globals.value, tolerance, absolute)) {
       metadataSame = false
       println(
         s"""different global annotation:
@@ -1901,7 +1901,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
           val row1 = fullRow1.deleteField(localLeftEntriesIndex)
           val row2 = fullRow2.deleteField(localRightEntriesIndex)
 
-          if (!localRowType.valuesSimilar(row1, row2, tolerance)) {
+          if (!localRowType.valuesSimilar(row1, row2, tolerance, absolute)) {
             println(
               s"""row fields not the same:
                  |  $row1
@@ -1914,7 +1914,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
           var i = 0
           while (partSame && i < gs1.length) {
-            if (!localEntryType.valuesSimilar(gs1(i), gs2(i), tolerance)) {
+            if (!localEntryType.valuesSimilar(gs1(i), gs2(i), tolerance, absolute)) {
               partSame = false
               println(
                 s"""different entry at row ${ localRKF(row1) }, col ${ localColKeys(i) }
@@ -1946,10 +1946,10 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
       "AGG" -> (2, TAggregable(entryType, aggregationST))))
   }
 
-  def colValuesSimilar(that: MatrixTable, tolerance: Double = utils.defaultTolerance): Boolean = {
+  def colValuesSimilar(that: MatrixTable, tolerance: Double = utils.defaultTolerance, absolute: Boolean = false): Boolean = {
     require(colType == that.colType, s"\n${ colType }\n${ that.colType }")
     colValues.value.zip(that.colValues.value)
-      .forall { case (s1, s2) => colType.valuesSimilar(s1, s2, tolerance)
+      .forall { case (s1, s2) => colType.valuesSimilar(s1, s2, tolerance, absolute)
       }
   }
 

--- a/src/test/scala/is/hail/io/ImportBgenSuite.scala
+++ b/src/test/scala/is/hail/io/ImportBgenSuite.scala
@@ -64,7 +64,7 @@ class ImportBgenSuite extends SparkSuite {
       hc.indexBgen(bgenFile)
       val bgenMT = hc.importBgen(bgenFile, sampleFile = Some(sampleFile), includeGT = true, includeGP = true,
         includeDosage = false, nPartitions = Some(10), contigRecoding = contigRecoding)
-      val isSame = genMT.same(bgenMT, tolerance)
+      val isSame = genMT.same(bgenMT, tolerance, absolute = true)
       hadoopConf.delete(bgenFile + ".idx", recursive = true)
       isSame
     })


### PR DESCRIPTION
Current behavior is it's testing both D_== and abs(d1 -d2) <= tolerance. Now `absolute=True` specifies use `abs(d1-d2)`. Behavior used to be D_== for everything until I changed it for the BGEN test. So `absolute=True` should only be in the BGEN tests.