### PR TITLE
Use ResettableContext in ContextRDD

### DIFF
--- a/src/main/scala/is/hail/io/RowStore.scala
+++ b/src/main/scala/is/hail/io/RowStore.scala
@@ -5,7 +5,7 @@ import is.hail.expr.JSONAnnotationImpex
 import is.hail.expr.types._
 import is.hail.io.compress.LZ4Utils
 import is.hail.rvd.{OrderedRVDPartitioner, OrderedRVDSpec, RVDSpec, UnpartitionedRVDSpec}
-import is.hail.sparkextras.ContextRDD
+import is.hail.sparkextras.{ContextRDD, ResettableContext}
 import is.hail.utils._
 import org.apache.spark.rdd.RDD
 import org.json4s.{Extraction, JValue}
@@ -730,7 +730,7 @@ object RichContextRDDRegionValue {
   }
 }
 
-class RichContextRDDRegionValue[C <: AutoCloseable](val crdd: ContextRDD[C, RegionValue]) extends AnyVal {
+class RichContextRDDRegionValue[C <: ResettableContext](val crdd: ContextRDD[C, RegionValue]) extends AnyVal {
   def writeRows(path: String, t: TStruct, codecSpec: CodecSpec): (Array[String], Array[Long]) = {
     crdd.writePartitions(path, RichContextRDDRegionValue.writeRowsPartition(t, codecSpec))
   }

--- a/src/main/scala/is/hail/sparkextras/ContextPairRDDFunctions.scala
+++ b/src/main/scala/is/hail/sparkextras/ContextPairRDDFunctions.scala
@@ -5,7 +5,7 @@ import org.apache.spark.rdd._
 
 import scala.reflect.ClassTag
 
-class ContextPairRDDFunctions[C <: AutoCloseable, K: ClassTag, V: ClassTag](
+class ContextPairRDDFunctions[C <: ResettableContext, K: ClassTag, V: ClassTag](
   crdd: ContextRDD[C, (K, V)]
 ) {
   def shuffle(p: Partitioner, o: Ordering[K]): ContextRDD[C, (K, V)] =

--- a/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -94,10 +94,10 @@ class ContextRDD[C <: ResettableContext, T: ClassTag](
   def collect(): Array[T] =
     run.collect()
 
-  // WARNING: this resets the context, when this method is called, the value of
+  // WARNING: This resets the context. When this method is called, the value of
   // type `T` must already be "stable" i.e. not dependent on the region
   private[this] def decontextualize(c: C, it: Iterator[C => Iterator[T]]): Iterator[T] =
-    new SetupIterator(it.flatMap(_(c)), c.reset _)
+    new SetupIterator(it.flatMap(_(c)), c.reset)
 
   def run[U >: T : ClassTag]: RDD[U] =
     rdd.mapPartitions { part => using(mkc()) { cc => decontextualize(cc, part) } }
@@ -107,10 +107,10 @@ class ContextRDD[C <: ResettableContext, T: ClassTag](
   ): Iterator[C => Iterator[U]] = Iterator.single(f)
 
   def map[U: ClassTag](f: T => U): ContextRDD[C, U] =
-    mapPartitions(_.map(f), true)
+    mapPartitions(_.map(f), preservesPartitioning = true)
 
   def filter(f: T => Boolean): ContextRDD[C, T] =
-    mapPartitions(_.filter(f), true)
+    mapPartitions(_.filter(f), preservesPartitioning = true)
 
   def flatMap[U: ClassTag](f: T => TraversableOnce[U]): ContextRDD[C, U] =
     mapPartitions(_.flatMap(f))

--- a/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -104,7 +104,7 @@ class ContextRDD[C <: ResettableContext, T: ClassTag](
   // WARNING: this resets the context, when this method is called, the value of
   // type `T` must already be "stable" i.e. not dependent on the region
   private[this] def decontextualize(c: C, it: Iterator[C => Iterator[T]]): Iterator[T] =
-    new SetupIterator(it.flatMap(_(c)), () => c.reset())
+    new SetupIterator(it.flatMap(_(c)), c.reset _)
 
   def map[U: ClassTag](f: T => U): ContextRDD[C, U] =
     mapPartitions(_.map(f), true)

--- a/src/main/scala/is/hail/sparkextras/TrivialContext.scala
+++ b/src/main/scala/is/hail/sparkextras/TrivialContext.scala
@@ -1,5 +1,7 @@
 package is.hail.sparkextras
 
-object TrivialContextInstance extends AutoCloseable {
+object TrivialContextInstance extends ResettableContext {
   def close(): Unit = ()
+
+  def reset(): Unit = ()
 }

--- a/src/main/scala/is/hail/utils/SetupIterator.scala
+++ b/src/main/scala/is/hail/utils/SetupIterator.scala
@@ -1,0 +1,20 @@
+package is.hail.utils
+
+class SetupIterator[T](it: Iterator[T], setup: () => Unit) extends Iterator[T] {
+  private[this] var needsSetup = true
+
+  def hasNext: Boolean = {
+    if (needsSetup) {
+      setup()
+      needsSetup = false
+    }
+    it.hasNext
+  }
+
+  def next(): T = {
+    if (needsSetup)
+      setup()
+    needsSetup = true
+    it.next()
+  }
+}

--- a/src/main/scala/is/hail/utils/richUtils/Implicits.scala
+++ b/src/main/scala/is/hail/utils/richUtils/Implicits.scala
@@ -123,7 +123,7 @@ trait Implicits {
 
   implicit def toRichPartialKleisliOptionFunction[A, B](x: PartialFunction[A, Option[B]]): RichPartialKleisliOptionFunction[A, B] = new RichPartialKleisliOptionFunction(x)
 
-  implicit def toContextPairRDDFunctions[C <: AutoCloseable, K: ClassTag, V: ClassTag](x: ContextRDD[C, (K, V)]): ContextPairRDDFunctions[C, K, V] = new ContextPairRDDFunctions(x)
+  implicit def toContextPairRDDFunctions[C <: ResettableContext, K: ClassTag, V: ClassTag](x: ContextRDD[C, (K, V)]): ContextPairRDDFunctions[C, K, V] = new ContextPairRDDFunctions(x)
 
-  implicit def toRichContextRDD[C <: AutoCloseable, T: ClassTag](x: ContextRDD[C, T]): RichContextRDD[C, T] = new RichContextRDD(x)
+  implicit def toRichContextRDD[C <: ResettableContext, T: ClassTag](x: ContextRDD[C, T]): RichContextRDD[C, T] = new RichContextRDD(x)
 }

--- a/src/main/scala/is/hail/utils/richUtils/Implicits.scala
+++ b/src/main/scala/is/hail/utils/richUtils/Implicits.scala
@@ -83,7 +83,7 @@ trait Implicits {
 
   implicit def toRichRDD[T](r: RDD[T])(implicit tct: ClassTag[T]): RichRDD[T] = new RichRDD(r)
 
-  implicit def toRichContextRDDRegionValue[C <: AutoCloseable](r: ContextRDD[C, RegionValue]): RichContextRDDRegionValue[C] = new RichContextRDDRegionValue(r)
+  implicit def toRichContextRDDRegionValue[C <: ResettableContext](r: ContextRDD[C, RegionValue]): RichContextRDDRegionValue[C] = new RichContextRDDRegionValue(r)
 
   implicit def toRichRDDByteArray(r: RDD[Array[Byte]]): RichRDDByteArray = new RichRDDByteArray(r)
 

--- a/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
@@ -9,7 +9,7 @@ import is.hail.sparkextras._
 
 import scala.reflect.ClassTag
 
-class RichContextRDD[C <: AutoCloseable, T: ClassTag](crdd: ContextRDD[C, T]) {
+class RichContextRDD[C <: ResettableContext, T: ClassTag](crdd: ContextRDD[C, T]) {
   def writePartitions(path: String,
     write: (Int, Iterator[T], OutputStream) => Long,
     remapPartitions: Option[(Array[Int], Int)] = None): (Array[String], Array[Long]) = {


### PR DESCRIPTION
Now we use `ResettableContext` in the `ContextRDD` to reset the context _in-between_ calls to `next`.

Currently, no method uses the context's region, so all values are "stable". Subsequent PR's will start using the context's region and will thus need to ensure that values are "stabilized" (copied out of the context's region and into a fresh region, encoded, or converted to `Annotation`s).