### PR TITLE
Add Region.scoped

### DIFF
--- a/src/main/scala/is/hail/annotations/Region.scala
+++ b/src/main/scala/is/hail/annotations/Region.scala
@@ -12,6 +12,9 @@ object Region {
   def apply(sizeHint: Long = 128): Region = {
     new Region(new Array[Byte](sizeHint.toInt))
   }
+
+  def scoped[T](f: Region => T): T =
+    using(Region())(f)
 }
 
 final class Region(


### PR DESCRIPTION
Long term goal is for all allocations of `Region` to come through either `RVDContext` or `Region.scoped`. Forthcoming PRs will start making this conversion.