### PR TITLE
Ordered tables

### DIFF
--- a/python/hail/expr/expressions/base_expression.py
+++ b/python/hail/expr/expressions/base_expression.py
@@ -605,7 +605,8 @@ class Expression(object):
         elif len(axes) == 1:
             if isinstance(source, hail.Table):
                 df = source
-                df = df.select(*filter(lambda f: f != name, df.key), **{name: self})
+                keys = filter(lambda f: f != name, df.key) if df.key else []
+                df = df.select(*keys, **{name: self})
                 return df.select_globals()
             else:
                 assert isinstance(source, hail.MatrixTable)

--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -2268,6 +2268,7 @@ class MatrixTable(ExprContainer):
         if row_exprs:
             row_struct = self.row.annotate(**row_exprs)
             analyze("MatrixTable.annotate_rows", row_struct, self._row_indices)
+            hql = row_struct._ast.to_hql()
             jmt = jmt.selectRows(row_struct._ast.to_hql())
         if col_exprs:
             col_struct = self.col.annotate(**col_exprs)
@@ -2849,7 +2850,7 @@ class MatrixTable(ExprContainer):
                 partition_key = [partition_key]
             if len(partition_key) == 0:
                 raise ValueError('partition_key must not be empty')
-            elif list(table.key)[:len(partition_key)] != partition_key:
+            elif table.key is None or list(table.key)[:len(partition_key)] != partition_key:
                 raise ValueError('partition_key must be a prefix of table key')
         jmt = scala_object(Env.hail().variant, 'MatrixTable').fromRowsTable(table._jt, partition_key)
         return MatrixTable(jmt)

--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -945,7 +945,7 @@ def import_gen(path,
 
 
 @typecheck(paths=oneof(str, sequenceof(str)),
-           key=oneof(str, sequenceof(str)),
+           key=nullable(oneof(str, sequenceof(str))),
            min_partitions=nullable(int),
            impute=bool,
            no_header=bool,
@@ -956,7 +956,7 @@ def import_gen(path,
            quote=nullable(char),
            skip_blank_lines=bool)
 def import_table(paths,
-                 key=(),
+                 key=None,
                  min_partitions=None,
                  impute=False,
                  no_header=False,
@@ -1125,7 +1125,7 @@ def import_table(paths,
     -------
     :class:`.Table`
     """
-    key = wrap_to_list(key)
+    key = wrap_to_list(key) if key else None
     paths = wrap_to_list(paths)
     jtypes = {k: v._jtype for k, v in types.items()}
     comment = wrap_to_list(comment)

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -295,7 +295,7 @@ class Table(ExprContainer):
                                    indices=self._row_indices)
 
         self._key = hail.struct(
-            **{k: self._row[k] for k in jiterable_to_list(jt.key())})
+            **{k: self._row[k] for k in jiterable_to_list(jt.keyOrNull())})
 
         for k, v in itertools.chain(self._globals.items(),
                                     self._row.items()):

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -294,8 +294,12 @@ class Table(ExprContainer):
         self._row = construct_expr(TopLevelReference('row', self._row_indices), self._row_type,
                                    indices=self._row_indices)
 
-        self._key = hail.struct(
-            **{k: self._row[k] for k in jiterable_to_list(jt.keyOrNull())})
+        opt_key = from_option(jt.key())
+        if opt_key is None:
+            self._key = None
+        else:
+            self._key = hail.struct(
+                **{k: self._row[k] for k in jiterable_to_list(opt_key)})
 
         for k, v in itertools.chain(self._globals.items(),
                                     self._row.items()):
@@ -322,7 +326,7 @@ class Table(ExprContainer):
             return self.index(*exprs)
 
     @property
-    def key(self) -> StructExpression:
+    def key(self) -> Optional[StructExpression]:
         """Row key struct.
 
         Examples
@@ -387,17 +391,19 @@ class Table(ExprContainer):
     @classmethod
     @typecheck_method(rows=anytype,
                       schema=nullable(tstruct),
-                      key=oneof(str, sequenceof(str)),
+                      key=nullable(oneof(str, sequenceof(str))),
                       n_partitions=nullable(int))
-    def parallelize(cls, rows, schema=None, key=(), n_partitions=None):
+    def parallelize(cls, rows, schema=None, key=None, n_partitions=None):
         rows = to_expr(rows, hl.tarray(schema) if schema is not None else None)
+        if key is not None:
+            key = wrap_to_list(key)
         if not isinstance(rows.dtype.element_type, tstruct):
             raise TypeError("'parallelize' expects an array with element type 'struct', found '{}'"
                             .format(rows.dtype))
         return Table(
             Env.hail().table.Table.parallelize(
                 Env.hc()._jhc, rows.dtype._to_json(rows.value),
-                rows.dtype.element_type._jtype, wrap_to_list(key), joption(n_partitions)))
+                rows.dtype.element_type._jtype, joption(key), joption(n_partitions)))
 
     @typecheck_method(keys=oneof(str, Expression))
     def key_by(self, *keys) -> 'Table':
@@ -1099,6 +1105,8 @@ class Table(ExprContainer):
 
     def index(self, *exprs):
         exprs = tuple(exprs)
+        if self.key is None:
+            raise TypeError('Cannot index an unkeyed table')
         if not len(exprs) > 0:
             raise ValueError('Require at least one expression to index')
         non_exprs = list(filter(lambda e: not isinstance(e, Expression), exprs))
@@ -1275,7 +1283,7 @@ class Table(ExprContainer):
 
     def _process_joins(self, *exprs):
         # ordered to support nested joins
-        original_key = list(self.key)
+        original_key = list(self.key) if self.key else None
 
         all_uids = []
         left = self
@@ -1288,7 +1296,7 @@ class Table(ExprContainer):
                     all_uids.extend(j.temp_vars)
                     used_uids.add(j.uid)
 
-        if left is not self:
+        if left is not self and original_key is not None:
             left = left.key_by(*original_key)
 
         def cleanup(table):
@@ -1706,6 +1714,8 @@ class Table(ExprContainer):
             Joined table.
 
         """
+        if self.key is None or right.key is None:
+            raise TypeError("'join' requires keyed tables")
         left_key_types = list(self.key.dtype.values())
         right_key_types = list(right.key.dtype.values())
         if not left_key_types == right_key_types:
@@ -1806,10 +1816,10 @@ class Table(ExprContainer):
 
         table = self
         if row_map:
-            remapped_key = [row_map.get(k, k) for k in table.key.keys()]
-            table = (table
-                     .select(**{row_map.get(k, k): v for k, v in table.row.items()})
-                     .key_by(*remapped_key))
+            remapped_key = [row_map.get(k, k) for k in table.key.keys()] if table.key else None
+            table = table.select(**{row_map.get(k, k): v for k, v in table.row.items()})
+            if remapped_key:
+                table = table.key_by(*remapped_key)
         if global_map:
             table = table.select_globals(**{global_map.get(k, k): v for k, v in table.globals.items()})
         return table
@@ -2143,8 +2153,8 @@ class Table(ExprContainer):
 
     @staticmethod
     @typecheck(df=pyspark.sql.DataFrame,
-               key=oneof(str, sequenceof(str)))
-    def from_spark(df, key=[]):
+               key=nullable(oneof(str, sequenceof(str))))
+    def from_spark(df, key=None):
         """Convert PySpark SQL DataFrame to a table.
 
         Examples
@@ -2184,7 +2194,8 @@ class Table(ExprContainer):
         :class:`.Table`
             Table constructed from the Spark SQL DataFrame.
         """
-        return Table(Env.hail().table.Table.fromDF(Env.hc()._jhc, df._jdf, wrap_to_list(key)))
+        key = wrap_to_list(key) if key else None
+        return Table(Env.hail().table.Table.fromDF(Env.hc()._jhc, df._jdf, key))
 
     @typecheck_method(flatten=bool)
     def to_spark(self, flatten=True):

--- a/python/hail/tests/test_api.py
+++ b/python/hail/tests/test_api.py
@@ -336,7 +336,7 @@ class TableTests(unittest.TestCase):
 
         t1 = kt.select(kt.a, kt.e)
         self.assertEqual(list(t1.row), ['a', 'e'])
-        self.assertEqual(list(t1.key), [])
+        self.assertEqual(t1.key, None)
 
         t2 = kt.key_by('d', 'e')
         t2 = t2.select(*[t2.a, t2.e])
@@ -349,7 +349,7 @@ class TableTests(unittest.TestCase):
         # select no fields
         s = kt.select()
         self.assertEqual(list(s.row), [])
-        self.assertEqual(list(s.key), [])
+        self.assertEqual(s.key, None)
 
     def test_errors(self):
         schema = hl.tstruct(status=hl.tint32, gt=hl.tcall, qPheno=hl.tint32)
@@ -444,13 +444,13 @@ class TableTests(unittest.TestCase):
 
         ktd = kt.drop('idx', 'foo')
         self.assertEqual(list(ktd.row), ['sq', 'bar'])
-        self.assertEqual(list(ktd.key), [])
+        self.assertEqual(ktd.key, None)
 
         self.assertEqual(list(kt.drop(kt['idx'], kt['foo']).row), ['sq', 'bar'])
 
         d = kt.drop(*list(kt.row))
         self.assertEqual(list(d.row), [])
-        self.assertEqual(list(d.key), [])
+        self.assertEqual(d.key, None)
 
         self.assertTrue(kt.drop()._same(kt))
         self.assertTrue(kt.drop(*list(kt.row))._same(kt.select()))

--- a/python/hail/utils/java.py
+++ b/python/hail/utils/java.py
@@ -125,7 +125,7 @@ def jset_args(x):
 
 
 def jiterable_to_list(it):
-    if it:
+    if it is not None:
         return list(Env.jutils().iterableToArrayList(it))
     else:
         return None

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -446,12 +446,8 @@ class HailContext private(val sc: SparkContext,
       fatal(s"Arguments referred to no files: '${ inputs.mkString(",") }'")
 
     TextTableReader.read(this)(files, types, comment, separator, missing,
-      noHeader,
-      impute,
-      nPartitions.getOrElse(sc.defaultMinPartitions),
-      quote,
-      keyNames,
-      skipBlankLines)
+      noHeader, impute, nPartitions.getOrElse(sc.defaultMinPartitions), quote,
+      keyNames, skipBlankLines)
   }
 
   def importPlink(bed: String, bim: String, fam: String,

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -411,7 +411,7 @@ class HailContext private(val sc: SparkContext,
     skipBlankLines: Boolean
   ): Table = importTables(inputs.asScala,
     Option(keyNames).map(_.asScala.toIndexedSeq),
-    Option(nPartitions), types.asScala.toMap, comment.asScala.toArray,
+    if (nPartitions == null) None else Some(nPartitions), types.asScala.toMap, comment.asScala.toArray,
     separator, missing, noHeader, impute, quote, skipBlankLines)
 
   def importTable(input: String,

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -408,11 +408,14 @@ class HailContext private(val sc: SparkContext,
     noHeader: Boolean,
     impute: Boolean,
     quote: java.lang.Character,
-    skipBlankLines: Boolean): Table = importTables(inputs.asScala, keyNames.asScala.toArray, if (nPartitions == null) None else Some(nPartitions),
-    types.asScala.toMap, comment.asScala.toArray, separator, missing, noHeader, impute, quote, skipBlankLines)
+    skipBlankLines: Boolean
+  ): Table = importTables(inputs.asScala,
+    Option(keyNames).map(_.asScala.toIndexedSeq),
+    Option(nPartitions), types.asScala.toMap, comment.asScala.toArray,
+    separator, missing, noHeader, impute, quote, skipBlankLines)
 
   def importTable(input: String,
-    keyNames: Array[String] = Array.empty[String],
+    keyNames: Option[IndexedSeq[String]] = None,
     nPartitions: Option[Int] = None,
     types: Map[String, Type] = Map.empty[String, Type],
     comment: Array[String] = Array.empty[String],
@@ -421,12 +424,12 @@ class HailContext private(val sc: SparkContext,
     noHeader: Boolean = false,
     impute: Boolean = false,
     quote: java.lang.Character = null,
-    skipBlankLines: Boolean = false): Table = {
-    importTables(List(input), keyNames, nPartitions, types, comment, separator, missing, noHeader, impute, quote, skipBlankLines)
-  }
+    skipBlankLines: Boolean = false
+  ): Table = importTables(List(input), keyNames, nPartitions, types, comment,
+    separator, missing, noHeader, impute, quote, skipBlankLines)
 
   def importTables(inputs: Seq[String],
-    keyNames: Array[String] = Array.empty[String],
+    keyNames: Option[IndexedSeq[String]] = None,
     nPartitions: Option[Int] = None,
     types: Map[String, Type] = Map.empty[String, Type],
     comment: Array[String] = Array.empty[String],
@@ -443,7 +446,12 @@ class HailContext private(val sc: SparkContext,
       fatal(s"Arguments referred to no files: '${ inputs.mkString(",") }'")
 
     TextTableReader.read(this)(files, types, comment, separator, missing,
-      noHeader, impute, nPartitions.getOrElse(sc.defaultMinPartitions), quote, keyNames, skipBlankLines)
+      noHeader,
+      impute,
+      nPartitions.getOrElse(sc.defaultMinPartitions),
+      quote,
+      keyNames,
+      skipBlankLines)
   }
 
   def importPlink(bed: String, bim: String, fam: String,

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -558,9 +558,9 @@ object Parser extends JavaTokenParsers {
 
   def table_type_expr: Parser[TableType] =
     (("Table" ~ "{" ~ "global" ~ ":") ~> struct_expr) ~
-      (("," ~ "key" ~ ":") ~> key) ~
+      (("," ~ "key" ~ ":") ~> ("none" ^^ { _ => None } | key ^^ { key => Some(key.toIndexedSeq) })) ~
       (("," ~ "row" ~ ":") ~> struct_expr <~ "}") ^^ { case globalType ~ key ~ rowType =>
-      TableType(rowType, Some(key), globalType)
+      TableType(rowType, key, globalType)
     }
 
   def matrix_type_expr: Parser[MatrixType] =

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -560,7 +560,7 @@ object Parser extends JavaTokenParsers {
     (("Table" ~ "{" ~ "global" ~ ":") ~> struct_expr) ~
       (("," ~ "key" ~ ":") ~> key) ~
       (("," ~ "row" ~ ":") ~> struct_expr <~ "}") ^^ { case globalType ~ key ~ rowType =>
-      TableType(rowType, key, globalType)
+      TableType(rowType, Some(key), globalType)
     }
 
   def matrix_type_expr: Parser[MatrixType] =

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -1413,9 +1413,9 @@ case class TableFilter(child: TableIR, pred: IR) extends TableIR {
 }
 
 case class TableJoin(left: TableIR, right: TableIR, joinType: String) extends TableIR {
-  require(left.typ.keyType.exists(leftKey =>
-    right.typ.keyType.exists(rightKey =>
-      leftKey isIsomorphicTo rightKey)))
+  require(left.typ.keyType.zip(right.typ.keyType).exists { case (leftKey, rightKey) =>
+    leftKey isIsomorphicTo rightKey
+  })
 
   val children: IndexedSeq[BaseIR] = Array(left, right)
 

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -1520,7 +1520,8 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
 
   val typ: TableType = {
     val newRowType = newRow.typ.asInstanceOf[TStruct]
-    val newKey = child.typ.key.map(_.filter(newRowType.fieldIdx.contains))
+    var newKey = child.typ.key.map(_.filter(newRowType.fieldIdx.contains))
+    if (newKey.exists(_.isEmpty)) newKey = None
     child.typ.copy(rowType = newRowType, key = newKey)
   }
 
@@ -1540,22 +1541,27 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
     assert(rTyp == typ.rowType)
     val globalsBc = tv.globals.broadcast
     val gType = typ.globalType
+    val newRVD = tv.rvd.mapPartitions(typ.rowType) { it =>
+      val globalRV = RegionValue()
+      val globalRVb = new RegionValueBuilder()
+      val rv2 = RegionValue()
+      val newRow = f()
+      it.map { rv =>
+        globalRVb.set(rv.region)
+        globalRVb.start(gType)
+        globalRVb.addAnnotation(gType, globalsBc.value)
+        globalRV.set(rv.region, globalRVb.end())
+        rv2.set(rv.region, newRow(rv.region, rv.offset, false, globalRV.offset, false))
+        rv2
+      }
+    }
     TableValue(typ,
       tv.globals,
-      tv.rvd.mapPartitions(typ.rowType) { it =>
-        val globalRV = RegionValue()
-        val globalRVb = new RegionValueBuilder()
-        val rv2 = RegionValue()
-        val newRow = f()
-        it.map { rv =>
-          globalRVb.set(rv.region)
-          globalRVb.start(gType)
-          globalRVb.addAnnotation(gType, globalsBc.value)
-          globalRV.set(rv.region, globalRVb.end())
-          rv2.set(rv.region, newRow(rv.region, rv.offset, false, globalRV.offset, false))
-          rv2
-        }
-      })
+      typ.key match {
+        case Some(_) => newRVD
+        case None => newRVD.toUnpartitionedRVD
+      }
+      )
   }
 }
 

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -1132,6 +1132,7 @@ case class MatrixMapGlobals(child: MatrixIR, newRow: IR, value: BroadcastRow) ex
 }
 
 case class TableValue(typ: TableType, globals: BroadcastRow, rvd: RVD) {
+  require(typ.rowType == rvd.rowType)
   def rdd: RDD[Row] =
     rvd.toRows
 

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -84,7 +84,7 @@ case class MatrixValue(
       FileFormat.version.rep,
       hc.version,
       "../references",
-      TableType(typ.globalType, Array.empty[String], TStruct.empty()),
+      TableType(typ.globalType, None, TStruct.empty()),
       Map("globals" -> RVDComponentSpec("globals"),
         "rows" -> RVDComponentSpec("rows"),
         "partition_counts" -> PartitionCountsComponentSpec(partitionCounts)))
@@ -1359,7 +1359,7 @@ case class TableRange(n: Int, nPartitions: Int) extends TableIR {
 
   val typ: TableType = TableType(
     TStruct("idx" -> TInt32()),
-    Array("idx"),
+    Some(Array("idx")),
     TStruct.empty())
 
   def execute(hc: HailContext): TableValue = {
@@ -1413,11 +1413,13 @@ case class TableFilter(child: TableIR, pred: IR) extends TableIR {
 }
 
 case class TableJoin(left: TableIR, right: TableIR, joinType: String) extends TableIR {
-  require(left.typ.keyType isIsomorphicTo right.typ.keyType)
+  require(left.typ.keyType.exists(leftKey =>
+    right.typ.keyType.exists(rightKey =>
+      leftKey isIsomorphicTo rightKey)))
 
   val children: IndexedSeq[BaseIR] = Array(left, right)
 
-  private val joinedFields = left.typ.keyType.fields ++
+  private val joinedFields = left.typ.keyType.get.fields ++
     left.typ.valueType.fields ++
     right.typ.valueType.fields
   private val preNames = joinedFields.map(_.name).toArray
@@ -1442,8 +1444,8 @@ case class TableJoin(left: TableIR, right: TableIR, joinType: String) extends Ta
     val rightTV = right.execute(hc)
     val leftRowType = left.typ.rowType
     val rightRowType = right.typ.rowType
-    val leftKeyFieldIdx = left.typ.keyFieldIdx
-    val rightKeyFieldIdx = right.typ.keyFieldIdx
+    val leftKeyFieldIdx = left.typ.keyFieldIdx.get
+    val rightKeyFieldIdx = right.typ.keyFieldIdx.get
     val leftValueFieldIdx = left.typ.valueFieldIdx
     val rightValueFieldIdx = right.typ.valueFieldIdx
     val localNewRowType = newRowType
@@ -1490,14 +1492,14 @@ case class TableJoin(left: TableIR, right: TableIR, joinType: String) extends Ta
       case ordered: OrderedRVD => ordered
       case unordered =>
         OrderedRVD.coerce(
-          new OrderedRVDType(left.typ.key.toArray, left.typ.key.toArray, leftRowType),
+          new OrderedRVDType(left.typ.key.get.toArray, left.typ.key.get.toArray, leftRowType),
           unordered)
     }
     val rightORVD = rightTV.rvd match {
       case ordered: OrderedRVD => ordered
       case unordered =>
         val ordType =
-          new OrderedRVDType(right.typ.key.toArray, right.typ.key.toArray, rightRowType)
+          new OrderedRVDType(right.typ.key.get.toArray, right.typ.key.get.toArray, rightRowType)
         if (joinType == "left" || joinType == "inner")
           unordered.constrainToOrderedPartitioner(ordType, leftORVD.partitioner)
         else
@@ -1518,7 +1520,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
 
   val typ: TableType = {
     val newRowType = newRow.typ.asInstanceOf[TStruct]
-    val newKey = child.typ.key.filter(newRowType.fieldIdx.contains)
+    val newKey = child.typ.key.map(_.filter(newRowType.fieldIdx.contains))
     child.typ.copy(rowType = newRowType, key = newKey)
   }
 
@@ -1656,6 +1658,8 @@ case class TableExplode(child: TableIR, column: String) extends TableIR {
 case class TableUnion(children: IndexedSeq[TableIR]) extends TableIR {
   assert(children.length > 0)
   assert(children.tail.forall(_.typ == children(0).typ))
+  assert((children(0).typ.key.isEmpty && children.tail.forall(_.typ.key.isEmpty)) ||
+    children.tail.forall(_.typ.key.exists(_ == children(0).typ.key.get)))
 
   def copy(newChildren: IndexedSeq[BaseIR]): TableUnion = {
     TableUnion(newChildren.map(_.asInstanceOf[TableIR]))

--- a/src/main/scala/is/hail/expr/types/MatrixType.scala
+++ b/src/main/scala/is/hail/expr/types/MatrixType.scala
@@ -67,16 +67,16 @@ case class MatrixType(
   val colValueFieldIdx: Array[Int] = colValueStruct.fieldNames.map(colType.fieldIdx)
 
   val colsTableType: TableType =
-    if (colKey.isEmpty)
-      TableType(colType, None, globalType)
-    else
-      TableType(colType, Some(colKey), globalType)
+    TableType(
+      colType,
+      if (colKey.isEmpty) None else Some(colKey),
+      globalType)
 
   val rowsTableType: TableType =
-    if(rowKey.isEmpty)
-      TableType(rowType, None, globalType)
-    else
-      TableType(rowType, Some(rowKey), globalType)
+    TableType(
+      rowType,
+      if (rowKey.isEmpty) None else Some(rowKey),
+      globalType)
 
   def orvdType: OrderedRVDType = {
     new OrderedRVDType(rowPartitionKey.toArray,

--- a/src/main/scala/is/hail/expr/types/MatrixType.scala
+++ b/src/main/scala/is/hail/expr/types/MatrixType.scala
@@ -66,9 +66,17 @@ case class MatrixType(
   def extractColValue: Annotation => Annotation = colType.filter(colKey.toSet, include = false)._2
   val colValueFieldIdx: Array[Int] = colValueStruct.fieldNames.map(colType.fieldIdx)
 
-  val colsTableType: TableType = TableType(colType, colKey, globalType)
+  val colsTableType: TableType =
+    if (colKey.isEmpty)
+      TableType(colType, None, globalType)
+    else
+      TableType(colType, Some(colKey), globalType)
 
-  val rowsTableType: TableType = TableType(rowType, rowKey, globalType)
+  val rowsTableType: TableType =
+    if(rowKey.isEmpty)
+      TableType(rowType, None, globalType)
+    else
+      TableType(rowType, Some(rowKey), globalType)
 
   def orvdType: OrderedRVDType = {
     new OrderedRVDType(rowPartitionKey.toArray,

--- a/src/main/scala/is/hail/expr/types/TableType.scala
+++ b/src/main/scala/is/hail/expr/types/TableType.scala
@@ -13,6 +13,7 @@ class TableTypeSerializer extends CustomSerializer[TableType](format => (
 case class TableType(rowType: TStruct, key: Option[IndexedSeq[String]], globalType: TStruct) extends BaseType {
 
   val keyOrEmpty: IndexedSeq[String] = key.getOrElse(IndexedSeq.empty)
+  val keyOrNull: IndexedSeq[String] = key.orNull
 
   def env: Env[Type] = {
     Env.empty[Type]

--- a/src/main/scala/is/hail/expr/types/TableType.scala
+++ b/src/main/scala/is/hail/expr/types/TableType.scala
@@ -10,7 +10,10 @@ class TableTypeSerializer extends CustomSerializer[TableType](format => (
   { case JString(s) => Parser.parseTableType(s) },
   { case tt: TableType => JString(tt.toString) }))
 
-case class TableType(rowType: TStruct, key: IndexedSeq[String], globalType: TStruct) extends BaseType {
+case class TableType(rowType: TStruct, key: Option[IndexedSeq[String]], globalType: TStruct) extends BaseType {
+
+  val keyOrEmpty: IndexedSeq[String] = key.getOrElse(IndexedSeq.empty)
+
   def env: Env[Type] = {
     Env.empty[Type]
       .bind(("global", globalType))
@@ -26,11 +29,11 @@ case class TableType(rowType: TStruct, key: IndexedSeq[String], globalType: TStr
     .bind("global" -> globalType)
     .bind("AGG" -> tAgg)
 
-  def keyType: TStruct = rowType.select(key.toArray)._1
-  val keyFieldIdx: Array[Int] = key.toArray.map(rowType.fieldIdx)
-  def valueType: TStruct = rowType.filter(key.toSet, include = false)._1
+  def keyType: Option[TStruct] = key.map(key => rowType.select(key.toArray)._1)
+  val keyFieldIdx: Option[Array[Int]] = key.map(_.toArray.map(rowType.fieldIdx))
+  def valueType: TStruct = rowType.filter(keyOrEmpty.toSet, include = false)._1
   val valueFieldIdx: Array[Int] =
-    rowType.fields.filter(f => !key.contains(f.name)).map(_.index).toArray
+    rowType.fields.filter(f => !keyOrEmpty.contains(f.name)).map(_.index).toArray
 
   def pretty(sb: StringBuilder, indent0: Int = 0, compact: Boolean = false) {
     var indent = indent0
@@ -53,9 +56,14 @@ case class TableType(rowType: TStruct, key: IndexedSeq[String], globalType: TStr
     sb += ','
     newline()
 
-    sb.append(s"key:$space[")
-    key.foreachBetween(k => sb.append(prettyIdentifier(k)))(sb.append(s",$space"))
-    sb += ']'
+    key match {
+      case Some(key) =>
+        sb.append(s"key:$space[")
+        key.foreachBetween(k => sb.append(prettyIdentifier(k)))(sb.append(s",$space"))
+        sb += ']'
+      case None =>
+        sb.append(s"key:${space}none")
+    }
     sb += ','
     newline()
 

--- a/src/main/scala/is/hail/io/annotators/IntervalList.scala
+++ b/src/main/scala/is/hail/io/annotators/IntervalList.scala
@@ -77,6 +77,6 @@ object IntervalList {
         }.value
       }
 
-    Table(hc, rdd, schema, Array("interval"))
+    Table(hc, rdd, schema, Some(IndexedSeq("interval")))
   }
 }

--- a/src/main/scala/is/hail/methods/CalculateConcordance.scala
+++ b/src/main/scala/is/hail/methods/CalculateConcordance.scala
@@ -222,7 +222,7 @@ object CalculateConcordance {
 
     val sampleKT = Table(left.hc, sampleRDD, sampleSchema, Some(left.colKey))
 
-    val variantKT = Table(left.hc, variantCRDD, variantSchema, Some(left.rowKey))
+    val variantKT = Table(left.hc, variantCRDD, variantSchema, Some(left.rowKey), sort = true)
 
     (global.toAnnotation, sampleKT, variantKT)
   }

--- a/src/main/scala/is/hail/methods/CalculateConcordance.scala
+++ b/src/main/scala/is/hail/methods/CalculateConcordance.scala
@@ -220,9 +220,9 @@ object CalculateConcordance {
     val sampleRDD = left.hc.sc.parallelize(leftFiltered.stringSampleIds.zip(sampleResults)
       .map { case (id, comb) => Row(id, comb.nDiscordant, comb.toAnnotation) })
 
-    val sampleKT = Table(left.hc, sampleRDD, sampleSchema, left.colKey)
+    val sampleKT = Table(left.hc, sampleRDD, sampleSchema, Some(left.colKey))
 
-    val variantKT = Table(left.hc, variantCRDD, variantSchema, left.rowKey)
+    val variantKT = Table(left.hc, variantCRDD, variantSchema, Some(left.rowKey))
 
     (global.toAnnotation, sampleKT, variantKT)
   }

--- a/src/main/scala/is/hail/methods/IBD.scala
+++ b/src/main/scala/is/hail/methods/IBD.scala
@@ -315,7 +315,7 @@ object IBD {
     val sampleIds = vds.stringSampleIds
 
     val ktRdd2 = computeIBDMatrix(vds, computeMaf, min, max, sampleIds, bounded)
-    new Table(vds.hc, ktRdd2, ibdSignature, Some(Array("i", "j")))
+    new Table(vds.hc, ktRdd2, ibdSignature, Some(IndexedSeq("i", "j")))
   }
 
   private val (ibdSignature, ibdMerger) = TStruct(("i", TString()), ("j", TString())).merge(ExtendedIBDInfo.signature)

--- a/src/main/scala/is/hail/methods/IBD.scala
+++ b/src/main/scala/is/hail/methods/IBD.scala
@@ -322,7 +322,7 @@ object IBD {
 
   def toKeyTable(sc: HailContext, ibdMatrix: RDD[((Annotation, Annotation), ExtendedIBDInfo)]): Table = {
     val ktRdd = ibdMatrix.map { case ((i, j), eibd) => ibdMerger(Annotation(i, j), eibd.toAnnotation).asInstanceOf[Row] }
-    Table(sc, ktRdd, ibdSignature, Array("i", "j"))
+    Table(sc, ktRdd, ibdSignature, Some(IndexedSeq("i", "j")))
   }
 
   def toRDD(kt: Table): RDD[((Annotation, Annotation), ExtendedIBDInfo)] = {

--- a/src/main/scala/is/hail/methods/IBD.scala
+++ b/src/main/scala/is/hail/methods/IBD.scala
@@ -315,7 +315,7 @@ object IBD {
     val sampleIds = vds.stringSampleIds
 
     val ktRdd2 = computeIBDMatrix(vds, computeMaf, min, max, sampleIds, bounded)
-    new Table(vds.hc, ktRdd2, ibdSignature, Array("i", "j"))
+    new Table(vds.hc, ktRdd2, ibdSignature, Some(Array("i", "j")))
   }
 
   private val (ibdSignature, ibdMerger) = TStruct(("i", TString()), ("j", TString())).merge(ExtendedIBDInfo.signature)

--- a/src/main/scala/is/hail/methods/PCA.scala
+++ b/src/main/scala/is/hail/methods/PCA.scala
@@ -51,7 +51,7 @@ object PCA {
         rv
       }
     }
-    new Table(hc, scoresRDD, rowType, vsm.colKey)
+    new Table(hc, scoresRDD, rowType, Some(vsm.colKey))
   }
 
   // returns (eigenvalues, sample scores, optional variant loadings)
@@ -121,7 +121,7 @@ object PCA {
           rv
         }
       }
-      new Table(vsm.hc, rdd, rowType, vsm.rowKey)
+      new Table(vsm.hc, rdd, rowType, Some(vsm.rowKey))
     })
 
     val data =

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -60,7 +60,7 @@ object PCRelate {
     
     val result = new PCRelate(maf, blockSize, statistics, defaultStorageLevel)(hc, blockedG, pcs)
 
-    Table(hc, toRowRdd(result, blockSize, minKinship, statistics), sig, Some(keys))
+    Table(hc, toRowRdd(result, blockSize, minKinship, statistics), sig, Some(keys.toIndexedSeq))
   }
 
   private[methods] def apply(hc: HailContext,
@@ -78,7 +78,7 @@ object PCRelate {
 
     val result = new PCRelate(maf, blockSize, statistics, defaultStorageLevel)(hc, blockedG, pcs)
 
-    Table(vds.hc, toRowRdd(result, blockSize, minKinship, statistics), sig, Some(keys))
+    Table(vds.hc, toRowRdd(result, blockSize, minKinship, statistics), sig, Some(keys.toIndexedSeq))
       .annotateGlobal(sampleIds.toFastIndexedSeq, TArray(TString()), "sample_ids")
       .select("{i: global.sample_ids[row.i], j: global.sample_ids[row.j], kin: row.kin, ibd0: row.ibd0, ibd1: row.ibd1, ibd2: row.ibd2}") 
   }

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -42,7 +42,7 @@ object PCRelate {
       ("ibd1", TFloat64()),
       ("ibd2", TFloat64()))
 
-  private val keys = Array("i", "j")
+  private val keys = IndexedSeq("i", "j")
 
   def apply(
     hc: HailContext,
@@ -60,7 +60,7 @@ object PCRelate {
     
     val result = new PCRelate(maf, blockSize, statistics, defaultStorageLevel)(hc, blockedG, pcs)
 
-    Table(hc, toRowRdd(result, blockSize, minKinship, statistics), sig, keys)
+    Table(hc, toRowRdd(result, blockSize, minKinship, statistics), sig, Some(keys))
   }
 
   private[methods] def apply(hc: HailContext,
@@ -78,7 +78,7 @@ object PCRelate {
 
     val result = new PCRelate(maf, blockSize, statistics, defaultStorageLevel)(hc, blockedG, pcs)
 
-    Table(vds.hc, toRowRdd(result, blockSize, minKinship, statistics), sig, keys)
+    Table(vds.hc, toRowRdd(result, blockSize, minKinship, statistics), sig, Some(keys))
       .annotateGlobal(sampleIds.toFastIndexedSeq, TArray(TString()), "sample_ids")
       .select("{i: global.sample_ids[row.i], j: global.sample_ids[row.j], kin: row.kin, ibd0: row.ibd0, ibd1: row.ibd1, ibd2: row.ibd2}") 
   }

--- a/src/main/scala/is/hail/methods/Skat.scala
+++ b/src/main/scala/is/hail/methods/Skat.scala
@@ -195,7 +195,7 @@ object Skat {
       ("p_value", TFloat64()),
       ("fault", TInt32()))
 
-    Table(vsm.hc, skatRdd, skatSignature, Array("key"))
+    Table(vsm.hc, skatRdd, skatSignature, Some(IndexedSeq("key")))
   }
 
   def computeKeyGsWeightRdd(vsm: MatrixTable,

--- a/src/main/scala/is/hail/rvd/KeyedOrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/KeyedOrderedRVD.scala
@@ -64,8 +64,9 @@ class KeyedOrderedRVD(val rvd: OrderedRVD, val key: Array[String]) {
     val rekeyedRTyp = new OrderedRVDType(right.typ.partitionKey, right.key, right.typ.rowType)
 
     val newPartitioner = this.rvd.partitioner
-    val repartitionedRight =
-      right.rvd.constrainToOrderedPartitioner(right.typ, newPartitioner)
+    val repartitionedRight = right.rvd.constrainToOrderedPartitioner(
+      right.typ.copy(partitionKey = right.typ.key.take(newPartitioner.partitionKey.length)),
+      newPartitioner)
     val compute: (OrderedRVIterator, OrderedRVIterator) => Iterator[JoinedRegionValue] =
       (joinType: @unchecked) match {
         case "inner" => _.innerJoinDistinct(_)

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -387,6 +387,9 @@ class OrderedRVD(
     t: MatrixType,
     codecSpec: CodecSpec
   ): Array[Long] = crdd.writeRowsSplit(path, t, codecSpec, partitioner)
+
+  def toUnpartitionedRVD: UnpartitionedRVD =
+    new UnpartitionedRVD(typ.rowType, crdd)
 }
 
 object OrderedRVD {

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -92,8 +92,6 @@ class OrderedRVD(
     require(ordType.rowType == typ.rowType)
     require(ordType.kType isPrefixOf typ.kType)
     require(newPartitioner.pkType isIsomorphicTo ordType.pkType)
-    // Should remove this requirement in the future
-    require(typ.pkType isPrefixOf ordType.pkType)
 
     new OrderedRVD(
       typ = ordType,

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -388,7 +388,7 @@ class OrderedRVD(
     codecSpec: CodecSpec
   ): Array[Long] = crdd.writeRowsSplit(path, t, codecSpec, partitioner)
 
-  def toUnpartitionedRVD: UnpartitionedRVD =
+  override def toUnpartitionedRVD: UnpartitionedRVD =
     new UnpartitionedRVD(typ.rowType, crdd)
 }
 

--- a/src/main/scala/is/hail/rvd/OrderedRVDPartitioner.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVDPartitioner.scala
@@ -34,6 +34,21 @@ class OrderedRVDPartitioner(
       (rangeBounds(i), i)
     })
 
+  def coarsenedPKRangeTree(newPK: Int): IntervalTree[Int] = {
+    val (newPKType, getNewPK) = kType.select(partitionKey.take(newPK))
+    IntervalTree.fromSorted(
+      newPKType.ordering,
+      Array.tabulate[(Interval, Int)](numPartitions) { i =>
+        (Interval(
+          getNewPK(rangeBounds(i).start.asInstanceOf[Row]),
+          getNewPK(rangeBounds(i).end.asInstanceOf[Row]),
+          includesStart = true,
+          includesEnd = true),
+        i)
+      }
+    )
+  }
+
   def range: Option[Interval] = rangeTree.root.map(_.range)
 
   /**

--- a/src/main/scala/is/hail/rvd/OrderedRVDPartitioner.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVDPartitioner.scala
@@ -35,7 +35,7 @@ class OrderedRVDPartitioner(
     })
 
   def coarsenedPKRangeTree(newPK: Int): IntervalTree[Int] = {
-    val (newPKType, getNewPK) = kType.select(partitionKey.take(newPK))
+    val (newPKType, getNewPK) = pkType.select(partitionKey.take(newPK))
     IntervalTree.fromSorted(
       newPKType.ordering,
       Array.tabulate[(Interval, Int)](numPartitions) { i =>

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -251,4 +251,6 @@ trait RVD {
     val localRowType = rowType
     crdd.map { rv => SafeRow(localRowType, rv.region, rv.offset) }.run
   }
+
+  def toUnpartitionedRVD: UnpartitionedRVD
 }

--- a/src/main/scala/is/hail/rvd/UnpartitionedRVD.scala
+++ b/src/main/scala/is/hail/rvd/UnpartitionedRVD.scala
@@ -75,4 +75,6 @@ class UnpartitionedRVD(val rowType: TStruct, val crdd: ContextRDD[RVDContext, Re
 
     OrderedRVD.shuffle(ordType, newPartitioner, filtered)
   }
+
+  override def toUnpartitionedRVD: UnpartitionedRVD = this
 }

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -187,21 +187,20 @@ class Table(val hc: HailContext, val tir: TableIR) {
     hc: HailContext,
     crdd: ContextRDD[RVDContext, RegionValue],
     signature: TStruct,
-    key: IndexedSeq[String],
+    key: Option[IndexedSeq[String]],
     globalSignature: TStruct,
     globals: Row
   ) = this(hc,
     TableLiteral(
       TableValue(
-        TableType(signature, Some(key), globalSignature),
+        TableType(signature, key, globalSignature),
         BroadcastRow(globals, globalSignature, hc.sc),
         new UnpartitionedRVD(signature, crdd))))
 
-  // FIXME
   def this(hc: HailContext,
     rdd: RDD[RegionValue],
     signature: TStruct,
-    key: IndexedSeq[String],
+    key: Option[IndexedSeq[String]],
     globalSignature: TStruct,
     globals: Row
   ) = this(
@@ -232,14 +231,14 @@ class Table(val hc: HailContext, val tir: TableIR) {
     hc: HailContext,
     rdd: RDD[RegionValue],
     signature: TStruct,
-    key: IndexedSeq[String]
+    key: Option[IndexedSeq[String]]
   ) = this(hc, rdd, signature, key, TStruct.empty(), Row.empty)
 
   def this(
     hc: HailContext,
     rdd: RDD[RegionValue],
     signature: TStruct
-  ) = this(hc, rdd, signature, Array.empty[String])
+  ) = this(hc, rdd, signature, None)
 
   lazy val TableValue(ktType, globals, rvd) = value
 

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -52,12 +52,12 @@ object Table {
     new Table(hc, TableRange(n, nPartitions.getOrElse(hc.sc.defaultParallelism)))
 
   def fromDF(hc: HailContext, df: DataFrame, key: java.util.ArrayList[String]): Table = {
-    fromDF(hc, df, key.asScala.toArray.toFastIndexedSeq)
+    fromDF(hc, df, Option(key.asScala.toArray.toFastIndexedSeq))
   }
 
-  def fromDF(hc: HailContext, df: DataFrame, key: IndexedSeq[String] = Array.empty[String]): Table = {
+  def fromDF(hc: HailContext, df: DataFrame, key: Option[IndexedSeq[String]] = None): Table = {
     val signature = SparkAnnotationImpex.importType(df.schema).asInstanceOf[TStruct]
-    Table(hc, df.rdd, signature, Some(key))
+    Table(hc, df.rdd, signature, key)
   }
 
   def read(hc: HailContext, path: String): Table = {

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -85,11 +85,6 @@ object Table {
     parallelize(hc, parsedRows, signature, Some(key), nPartitions)
   }
 
-//  def parallelize(hc: HailContext, rows: IndexedSeq[Row], signature: TStruct,
-//    key: IndexedSeq[String], nPartitions: Option[Int]): Table = {
-//    val typ = TableType(signature, Some(key.toArray.toFastIndexedSeq), TStruct())
-//    new Table(hc, TableParallelize(typ, rows, nPartitions))
-//  }
   def parallelize(hc: HailContext, rows: IndexedSeq[Row], signature: TStruct,
     key: Option[IndexedSeq[String]], nPartitions: Option[Int]): Table = {
     val typ = TableType(signature, key.map(_.toArray.toFastIndexedSeq), TStruct())

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -355,7 +355,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
            |""".stripMargin)
       false
     } else if (key.isDefined != other.key.isDefined ||
-               (key.isDefined && key.get.toSeq != other.key.get.toSeq)) {
+               (key.isDefined && key.get != other.key.get)) {
       info(
         s"""different keys:
             | left: ${ key.map(_.mkString(", ")).getOrElse("none") }
@@ -376,7 +376,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
            | right: ${ other.globals.value }
            |""".stripMargin)
       false
-    } else {
+    } else if (key.isDefined) {
       keyedRDD().groupByKey().fullOuterJoin(other.keyedRDD().groupByKey()).forall { case (k, (v1, v2)) =>
         (v1, v2) match {
           case (None, None) => true
@@ -395,6 +395,9 @@ class Table(val hc: HailContext, val tir: TableIR) {
             false
         }
       }
+    } else {
+      assert(key.isEmpty)
+      ???
     }
   }
 

--- a/src/main/scala/is/hail/utils/TextTableReader.scala
+++ b/src/main/scala/is/hail/utils/TextTableReader.scala
@@ -152,7 +152,6 @@ object TextTableReader {
     }.toArray
   }
 
-  // FIXME
   def read(hc: HailContext)(files: Array[String],
     types: Map[String, Type] = Map.empty[String, Type],
     comment: Array[String] = Array.empty[String],
@@ -162,7 +161,7 @@ object TextTableReader {
     impute: Boolean = false,
     nPartitions: Int = hc.sc.defaultMinPartitions,
     quote: java.lang.Character = null,
-    keyNames: Array[String] = Array.empty[String],
+    keyNames: Option[IndexedSeq[String]] = None,
     skipBlankLines: Boolean = false): Table = {
 
     require(files.nonEmpty)
@@ -245,7 +244,7 @@ object TextTableReader {
 
     info(sb.result())
 
-    val ttyp = TableType(TStruct(namesAndTypes: _*), Some(keyNames), TStruct())
+    val ttyp = TableType(TStruct(namesAndTypes: _*), keyNames, TStruct())
     val readerOpts = TableReaderOptions(nPartitions, commentStartsWith, commentRegexes, separator, missing, noHeader, header, quote, skipBlankLines)
     new Table(hc, TableImport(files, ttyp, readerOpts))
   }

--- a/src/main/scala/is/hail/utils/TextTableReader.scala
+++ b/src/main/scala/is/hail/utils/TextTableReader.scala
@@ -152,6 +152,7 @@ object TextTableReader {
     }.toArray
   }
 
+  // FIXME
   def read(hc: HailContext)(files: Array[String],
     types: Map[String, Type] = Map.empty[String, Type],
     comment: Array[String] = Array.empty[String],
@@ -244,7 +245,7 @@ object TextTableReader {
 
     info(sb.result())
 
-    val ttyp = TableType(TStruct(namesAndTypes: _*), keyNames, TStruct())
+    val ttyp = TableType(TStruct(namesAndTypes: _*), Some(keyNames), TStruct())
     val readerOpts = TableReaderOptions(nPartitions, commentStartsWith, commentRegexes, separator, missing, noHeader, header, quote, skipBlankLines)
     new Table(hc, TableImport(files, ttyp, readerOpts))
   }

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1253,10 +1253,11 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
   def localizeEntries(entriesFieldName: String): Table = {
     val m = Map(MatrixType.entriesIdentifier -> entriesFieldName)
+    val newRowType = rvRowType.rename(m)
     new Table(hc, TableLiteral(TableValue(
-      TableType(rvRowType.rename(m), Some(rowKey), globalType),
+      TableType(newRowType, Some(rowKey), globalType),
       globals,
-      rvd)))
+      rvd.copy(typ = rvd.typ.copy(rowType = newRowType)))))
   }
 
   def filterCols(p: (Annotation, Int) => Boolean): MatrixTable = {

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -831,7 +831,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
   private def annotateRowsIntervalTable(kt: Table, root: String, product: Boolean): MatrixTable = {
-    assert(!kt.key.isEmpty)
+    assert(kt.key.isDefined)
     assert(rowPartitionKeyTypes.length == 1)
     assert(kt.keySignature.get.size == 1)
     assert(kt.keySignature.get.types(0) == TInterval(rowPartitionKeyTypes(0)))
@@ -914,7 +914,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
   def annotateRowsTable(kt: Table, root: String, product: Boolean = false): MatrixTable = {
-    assert(!kt.key.isEmpty)
+    assert(kt.key.isDefined)
     assert(!rowKey.contains(root))
 
     val keyTypes = kt.keyFields.get.map(_.typ)

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -923,8 +923,8 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
         case ordered: OrderedRVD => ordered
         case unordered =>
           val ordType = new OrderedRVDType(
-            kt.key.get.toArray,
             kt.key.get.toArray.take(rowPartitionKey.length),
+            kt.key.get.toArray,
             kt.signature)
           unordered.constrainToOrderedPartitioner(ordType, rvd.partitioner)
       }

--- a/src/test/scala/is/hail/expr/TableIRSuite.scala
+++ b/src/test/scala/is/hail/expr/TableIRSuite.scala
@@ -11,9 +11,9 @@ class TableIRSuite extends SparkSuite {
     val data = Array(Array("Sample1", 9, 5), Array("Sample2", 3, 5), Array("Sample3", 2, 5), Array("Sample4", 1, 5))
     val rdd = sc.parallelize(data.map(Row.fromSeq(_)))
     val signature = TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32()))
-    val keyNames = Array("Sample")
+    val keyNames = IndexedSeq("Sample")
 
-    val kt = Table(hc, rdd, signature, keyNames)
+    val kt = Table(hc, rdd, signature, Some(keyNames))
     kt.typeCheck()
     kt
   }

--- a/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
@@ -814,7 +814,7 @@ class BlockMatrixSuite extends SparkSuite {
     val rows = IndexedSeq[(String, Int)](("X", 5), ("X", 7), ("X", 13), ("X", 14), ("X", 17),
       ("X", 65), ("X", 70), ("X", 73), ("Y", 74), ("Y", 75), ("Y", 200), ("Y", 300))
       .map { case (contig, pos) => Row(contig, pos) }
-    val tbl = Table.parallelize(hc, rows, TStruct("contig" -> TString(), "pos" -> TInt32()), IndexedSeq[String](), None)
+    val tbl = Table.parallelize(hc, rows, TStruct("contig" -> TString(), "pos" -> TInt32()), None, None)
     
     val nRows = tbl.count().toInt
     val bm = BlockMatrix.fromBreezeMatrix(sc, BDM.zeros(nRows, nRows), blockSize = 1)
@@ -824,7 +824,7 @@ class BlockMatrixSuite extends SparkSuite {
     val expectedRows = IndexedSeq[(Long, Long)]((0, 1), (0, 2), (1, 2), (0, 3), (1, 3), (2, 3), (1, 4), (2, 4), (3, 4),
       (5, 6), (5, 7), (6, 7), (8, 9)).map { case (i, j) => Row(i, j) }
     val expectedTable = Table.parallelize(hc, expectedRows, TStruct("i" -> TInt64(), "j" -> TInt64()),
-      IndexedSeq[String](), None)
+      None, None)
 
     assert(entriesTable.select("{i: row.i, j: row.j}").same(expectedTable))
   }

--- a/src/test/scala/is/hail/methods/PCASuite.scala
+++ b/src/test/scala/is/hail/methods/PCASuite.scala
@@ -55,8 +55,11 @@ class PCASuite extends SparkSuite {
 
     val structT = TStruct("_PC1" -> TFloat64(), "_PC2" -> TFloat64(), "_PC3" -> TFloat64())
     val truth = Table.parallelize(hc, pyLoadings,
-      TStruct("locus" -> TLocus(ReferenceGenome.defaultReference), "alleles" -> TArray(TString())) ++ structT,
-      Array("locus", "alleles"), None)
+      TStruct("locus" -> TLocus(ReferenceGenome.defaultReference),
+              "alleles" -> TArray(TString())
+      ) ++ structT,
+      Some(IndexedSeq("locus", "alleles")),
+      None)
     truth.typeCheck()
 
     assert(truth.join(loadings.get, "outer").forall(

--- a/src/test/scala/is/hail/methods/SkatSuite.scala
+++ b/src/test/scala/is/hail/methods/SkatSuite.scala
@@ -189,10 +189,17 @@ class SkatSuite extends SparkSuite {
 
     hailKT.typeCheck()
 
-    val resultHail = hailKT.rdd.collect()
+    var resultHail = hailKT.rdd.collect()
 
-    val resultsR = skatInR(vds, "gene", "weight", "pheno",
+    var resultsR = skatInR(vds, "gene", "weight", "pheno",
       Array("Cov1", "Cov2"), logistic, useDosages)
+    if (useBN) {
+      resultHail.sortBy(_.getAs[Int](0))
+      resultsR.sortBy(_.getAs[Int](0))
+    } else {
+      resultHail = resultHail.sortBy(_.getAs[String](0))
+      resultsR = resultsR.sortBy(_.getAs[String](0))
+    }
 
     var i = 0
     while (i < resultsR.length) {

--- a/src/test/scala/is/hail/methods/TableSuite.scala
+++ b/src/test/scala/is/hail/methods/TableSuite.scala
@@ -59,8 +59,8 @@ class TableSuite extends SparkSuite {
     val importedData = sc.hadoopConfiguration.readLines(inputFile)(_.map(_.value).toIndexedSeq)
     val exportedData = sc.hadoopConfiguration.readLines(outputFile)(_.map(_.value).toIndexedSeq)
 
-    intercept[HailException] {
-      hc.importTable(inputFile).keyBy(List("Sample", "Status", "BadKeyName"))
+    intercept[AssertionError] {
+      hc.importTable(inputFile).keyBy("Sample", "Status", "BadKeyName")
     }
 
     assert(importedData == exportedData)
@@ -190,7 +190,7 @@ class TableSuite extends SparkSuite {
     val outputFile = tmpDir.createTempFile("join", "tsv")
     ktLeftJoin.export(outputFile)
 
-    val noNull = ktLeft.filter("isDefined(row.qPhen) && isDefined(row.Status)", keep = true).keyBy(List("Sample", "Status"))
+    val noNull = ktLeft.filter("isDefined(row.qPhen) && isDefined(row.Status)", keep = true).keyBy("Sample", "Status")
     assert(noNull.join(noNull.rename(Map("qPhen" -> "qPhen_"), Map()), "outer").rdd.forall { r => !r.toSeq.contains(null) })
   }
 

--- a/src/test/scala/is/hail/methods/TableSuite.scala
+++ b/src/test/scala/is/hail/methods/TableSuite.scala
@@ -290,13 +290,17 @@ class TableSuite extends SparkSuite {
     val result2 = Array(Array("Sample1", 9, 5), Array("Sample1", 1, 5), Array("Sample2", 3, 5), Array("Sample3", 2, 5),
       Array("Sample3", 3, 5), Array("Sample3", 4, 5))
     val resRDD2 = sc.parallelize(result2.map(Row.fromSeq(_)))
-    val ktResult2 = Table(hc, resRDD2, TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32())), key = Some(IndexedSeq("Sample")))
+    val ktResult2 = Table(hc, resRDD2,
+      TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32())),
+      key = Some(IndexedSeq("Sample")))
     ktResult2.typeCheck()
 
     val result3 = Array(Array("Sample1", 9, 5), Array("Sample1", 10, 5), Array("Sample1", 9, 6), Array("Sample1", 10, 6),
       Array("Sample1", 1, 5), Array("Sample1", 1, 6), Array("Sample2", 3, 5), Array("Sample2", 3, 3))
     val resRDD3 = sc.parallelize(result3.map(Row.fromSeq(_)))
-    val ktResult3 = Table(hc, resRDD3, TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32())), key = Some(IndexedSeq("Sample")))
+    val ktResult3 = Table(hc, resRDD3,
+      TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32())),
+      key = Some(IndexedSeq("Sample")))
     ktResult3.typeCheck()
 
     assert(ktResult2.same(kt2.explode(Array("field1"))))

--- a/src/test/scala/is/hail/methods/TableSuite.scala
+++ b/src/test/scala/is/hail/methods/TableSuite.scala
@@ -273,13 +273,13 @@ class TableSuite extends SparkSuite {
     assert(select3.key.isEmpty && (select3.fieldNames sameElements Array("field2", "field1", "Sample")))
 
     val select4 = kt.select(Array.empty[String])
-    assert((select4.key.get sameElements Array.empty[String]) && (select4.fieldNames sameElements Array.empty[String]))
+    assert(select4.key.isEmpty && (select4.fieldNames sameElements Array.empty[String]))
 
     for (select <- Array(select1, select2, select3, select4)) {
       select.export(tmpDir.createTempFile("select", "tsv"))
     }
 
-    TestUtils.interceptFatal("Invalid key")(kt.select(Array.empty[String]).keyBy("Sample"))
+    intercept[Throwable](kt.select(Array.empty[String]).keyBy("Sample"))
   }
 
   @Test def testExplode() {
@@ -338,7 +338,7 @@ class TableSuite extends SparkSuite {
     val df = kt
       .expandTypes()
       .toDF(sqlContext)
-    val kt2 = Table.fromDF(hc, df, key = Array("locus", "alleles"))
+    val kt2 = Table.fromDF(hc, df, key = Some(IndexedSeq("locus", "alleles")))
     assert(kt2.same(kt))
   }
 

--- a/src/test/scala/is/hail/methods/UpperIndexBoundsSuite.scala
+++ b/src/test/scala/is/hail/methods/UpperIndexBoundsSuite.scala
@@ -14,7 +14,7 @@ class UpperIndexBoundsSuite extends SparkSuite {
     val rows = IndexedSeq[(String, Int)](("X", 5), ("X", 7), ("X", 13), ("X", 14), ("X", 17),
       ("X", 65), ("X", 70), ("X", 73), ("Y", 74), ("Y", 75), ("Y", 200), ("Y", 300))
       .map { case (contig, pos) => Row(contig, pos) }
-    Table.parallelize(hc, rows, TStruct("contig" -> TString(), "pos" -> TInt32()), IndexedSeq[String](), None)
+    Table.parallelize(hc, rows, TStruct("contig" -> TString(), "pos" -> TInt32()), None, None)
   }
 
   @Test def testGroupPositionsByContig() {

--- a/src/test/scala/is/hail/testUtils/RichTable.scala
+++ b/src/test/scala/is/hail/testUtils/RichTable.scala
@@ -42,7 +42,7 @@ class RichTable(ht: Table) {
 
   def rename(rowUpdateMap: Map[String, String], globalUpdateMap: Map[String, String]): Table = {
     select(ht.fieldNames.map(n => s"${ rowUpdateMap.getOrElse(n, n) } = row.$n"))
-      .keyBy(ht.key.map(k => rowUpdateMap.getOrElse(k, k)))
+      .keyBy(ht.key.map(k => rowUpdateMap.getOrElse(k, k)).toArray)
       .selectGlobal(ht.globalSignature.fieldNames.map(n => s"${ globalUpdateMap.getOrElse(n, n) } = global.$n"))
   }
 

--- a/src/test/scala/is/hail/testUtils/RichTable.scala
+++ b/src/test/scala/is/hail/testUtils/RichTable.scala
@@ -83,7 +83,8 @@ class RichTable(ht: Table) {
         }
     }
 
-    val newKey = ht.key.map(_.filter(insertionPaths.toSet))
+    var newKey = ht.key.map(_.filter(insertionPaths.toSet))
+    if (newKey.exists(_.isEmpty)) newKey = None
 
     ht.copy(rdd = ht.rdd.map(annotF), signature = finalSignature, key = newKey)
   }

--- a/src/test/scala/is/hail/testUtils/RichTable.scala
+++ b/src/test/scala/is/hail/testUtils/RichTable.scala
@@ -42,7 +42,7 @@ class RichTable(ht: Table) {
 
   def rename(rowUpdateMap: Map[String, String], globalUpdateMap: Map[String, String]): Table = {
     select(ht.fieldNames.map(n => s"${ rowUpdateMap.getOrElse(n, n) } = row.$n"))
-      .keyBy(ht.key.map(k => rowUpdateMap.getOrElse(k, k)).toArray)
+      .keyBy(ht.key.map(_.map(k => rowUpdateMap.getOrElse(k, k)).toArray))
       .selectGlobal(ht.globalSignature.fieldNames.map(n => s"${ globalUpdateMap.getOrElse(n, n) } = global.$n"))
   }
 
@@ -83,7 +83,7 @@ class RichTable(ht: Table) {
         }
     }
 
-    val newKey = ht.key.filter(insertionPaths.toSet)
+    val newKey = ht.key.map(_.filter(insertionPaths.toSet))
 
     ht.copy(rdd = ht.rdd.map(annotF), signature = finalSignature, key = newKey)
   }
@@ -113,7 +113,7 @@ class RichTable(ht: Table) {
         }
     }
 
-    ht.copy(rdd = ht.rdd.map(annotF), signature = finalSignature, key = ht.key)
+    ht.copy(rdd = ht.rdd.map(annotF), signature = finalSignature)
   }
 
   def selectGlobal(fields: Array[String]): Table = {

--- a/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -65,7 +65,7 @@ class PartitioningSuite extends SparkSuite {
     val mt = MatrixTable.fromRowsTable(Table.range(hc, 100, nPartitions=Some(6)))
     val t = new Table(hc,
       TableLiteral(TableValue(
-        TableType(TStruct("tidx"->TInt32()), Array("tidx"), TStruct.empty()),
+        TableType(TStruct("tidx"->TInt32()), Some(IndexedSeq("tidx")), TStruct.empty()),
         BroadcastRow(Row.empty, TStruct.empty(), sc),
         UnpartitionedRVD.empty(sc, TStruct("tidx"->TInt32())))))
     mt.annotateRowsTable(t, "foo").forceCountRows()


### PR DESCRIPTION
This PR is incomplete. The goals are:
* Make the key on `Table` and `TableType` `Option`al.
* Make `Table.keyBy` produce an `OrderedRVD` backed `Table`. When setting `key = None`, the table has an `UnpartitionedRVD`.
* Make `RepartionedOrderedRVD` handle the case where the new partitioner has shorter partition keys than the old partitioner.

Some things I know still need to be done:
* Fix `Table.same` to handle the case where the tables are unkeyed. This is currently causing tests `testKeyTableToDF` and `testSame` in `TableSuite` to fail.
* Make `Table.keyBy` smarter. In some cases, no sorting needs to be done, or maybe only local sorting.
* Add tests checking that writing then reading back an `OrderedRVD` backed table remains so, and that writing and reading can handle the `key = None` case.
