### PR TITLE
add EmitFunctionBuilder to store environment stuff for Emit

### DIFF
--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -652,8 +652,8 @@ trait Settable[T] {
 
 class LazyFieldRef[T: TypeInfo](fb: FunctionBuilder[_], name: String, setup: Code[T]) extends Settable[T] {
 
-  val value: ClassFieldRef[T] = fb.newField[T](name)
-  val present: ClassFieldRef[Boolean] = fb.newField[Boolean](s"${name}_present")
+  private[this] val value: ClassFieldRef[T] = fb.newField[T](name)
+  private[this] val present: ClassFieldRef[Boolean] = fb.newField[Boolean](s"${name}_present")
 
   def load(): Code[T] =
     Code(present.mux(Code._empty[Unit], Code(value := setup, present := true)), value)

--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -650,6 +650,18 @@ trait Settable[T] {
   def :=(rhs: Code[T]): Code[Unit] = store(rhs)
 }
 
+class LazyFieldRef[T: TypeInfo](fb: FunctionBuilder[_], name: String, setup: Code[T]) extends Settable[T] {
+
+  val value: ClassFieldRef[T] = fb.newField[T](name)
+  val present: ClassFieldRef[Boolean] = fb.newField[Boolean](s"${name}_present")
+
+  def load(): Code[T] =
+    Code(present.mux(Code._empty[Unit], Code(value := setup, present := true)), value)
+
+  def store(rhs: Code[T]): Code[Unit] =
+    throw new UnsupportedOperationException("cannot store new value into LazyFieldRef!")
+}
+
 class ClassFieldRef[T: TypeInfo](fb: FunctionBuilder[_], name: String) extends Settable[T] {
   val desc: String = typeInfo[T].name
   val node: FieldNode = new FieldNode(ACC_PUBLIC, name, desc, null, null)

--- a/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -99,6 +99,10 @@ class MethodBuilder(val fb: FunctionBuilder[_], val mname: String, val parameter
 
   def newField[T: TypeInfo](name: String = null): ClassFieldRef[T] = fb.newField[T](name)
 
+  def newLazyField[T: TypeInfo](setup: Code[T]): LazyFieldRef[T] = newLazyField("")(setup)
+
+  def newLazyField[T: TypeInfo](name: String)(setup: Code[T]): LazyFieldRef[T] = fb.newLazyField(name)(setup)
+
   def getArg[T](i: Int)(implicit tti: TypeInfo[T]): LocalRef[T] = {
     assert(i >= 0)
     assert(i < layout.length)
@@ -167,8 +171,8 @@ class Method5Builder[A, B, C, D, E, R](fb: FunctionBuilder[_], mname: String)
   def apply(a:Code[A], b: Code[B], c: Code[C], d: Code[D], e: Code[E]): Code[R] = invoke(a, b, c, d, e).asInstanceOf[Code[R]]
 }
 
-class FunctionBuilder[F >: Null](parameterTypeInfo: Array[MaybeGenericTypeInfo[_]], returnTypeInfo: MaybeGenericTypeInfo[_],
-  packageName: String = "is/hail/codegen/generated")(implicit interfaceTi: TypeInfo[F]) {
+class FunctionBuilder[F >: Null](val parameterTypeInfo: Array[MaybeGenericTypeInfo[_]], val returnTypeInfo: MaybeGenericTypeInfo[_],
+  val packageName: String = "is/hail/codegen/generated")(implicit interfaceTi: TypeInfo[F]) {
 
   import FunctionBuilder._
 
@@ -218,6 +222,11 @@ class FunctionBuilder[F >: Null](parameterTypeInfo: Array[MaybeGenericTypeInfo[_
 
   def newField[T: TypeInfo](name: String = null): ClassFieldRef[T] =
     new ClassFieldRef[T](this, s"field${cn.fields.size()}${ if (name == null) "" else s"_$name" }")
+
+  def newLazyField[T: TypeInfo](setup: Code[T]): LazyFieldRef[T] = newLazyField("")(setup)
+
+  def newLazyField[T: TypeInfo](name: String)(setup: Code[T]): LazyFieldRef[T] =
+    new LazyFieldRef[T](this, s"field${cn.fields.size()}_$name", setup)
 
   def allocLocal[T](name: String = null)(implicit tti: TypeInfo[T]): Int = apply_method.allocLocal[T](name)
 

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -19,7 +19,7 @@ object Compile {
           FastSeq[GenericTypeInfo[_]](GenericTypeInfo()(typeToTypeInfo(t)), GenericTypeInfo[Boolean]())
         }.toArray
 
-    val fb = new FunctionBuilder[F](argTypeInfo, GenericTypeInfo[R]())
+    val fb = new EmitFunctionBuilder[F](argTypeInfo, GenericTypeInfo[R]())
 
     var ir = body
     val env = args
@@ -68,20 +68,11 @@ object Compile {
     typ2: Type,
     body: IR
   ): (Type, () => AsmFunction7[Region, T0, Boolean, T1, Boolean, T2, Boolean, R]) = {
-    assert(TypeToIRIntermediateClassTag(typ0) == classTag[T0])
-    assert(TypeToIRIntermediateClassTag(typ1) == classTag[T1])
-    assert(TypeToIRIntermediateClassTag(typ2) == classTag[T2])
-    val fb = FunctionBuilder.functionBuilder[Region, T0, Boolean, T1, Boolean, T2, Boolean, R]
-    var e = body
-    val env = new Env[IR]()
-      .bind(name0, In(0, typ0))
-      .bind(name1, In(1, typ1))
-      .bind(name2, In(2, typ2))
-    e = Subst(e, env)
-    Infer(e)
-    assert(TypeToIRIntermediateClassTag(e.typ) == classTag[R])
-    Emit(e, fb)
-    (e.typ, fb.result())
+    apply[AsmFunction7[Region, T0, Boolean, T1, Boolean, T2, Boolean, R], R](FastSeq(
+      (name0, typ0, classTag[T0]),
+      (name1, typ1, classTag[T1]),
+      (name2, typ2, classTag[T2])
+    ), body)
   }
 
   def apply[
@@ -142,7 +133,7 @@ object CompileWithAggregators {
         }
 
     val (rvAggs, seqOps) = aggregators.zipWithIndex.map { case ((ir, agg), i) =>
-      val fb = new FunctionBuilder[F1](f1TypeInfo, GenericTypeInfo[Unit]())
+      val fb = new EmitFunctionBuilder[F1](f1TypeInfo, GenericTypeInfo[Unit]())
       Emit(ir, fb, 2, aggType)
       (agg, fb.result())
     }.unzip

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -16,23 +16,23 @@ object Emit {
 
   type F = (Code[Boolean], Code[_]) => Code[Unit]
 
-  private[ir] def toCode(ir: IR, fb: FunctionBuilder[_], nSpecialArguments: Int): EmitTriplet = {
+  private[ir] def toCode(ir: IR, fb: EmitFunctionBuilder[_], nSpecialArguments: Int): EmitTriplet = {
     emit(ir, fb, Env.empty, None, nSpecialArguments)
   }
 
-  def apply(ir: IR, fb: FunctionBuilder[_]) {
+  def apply(ir: IR, fb: EmitFunctionBuilder[_]) {
     apply(ir, fb, None, 1)
   }
 
-  def apply(ir: IR, fb: FunctionBuilder[_], nSpecialArguments: Int) {
+  def apply(ir: IR, fb: EmitFunctionBuilder[_], nSpecialArguments: Int) {
     apply(ir, fb, None, nSpecialArguments)
   }
 
-  def apply(ir: IR, fb: FunctionBuilder[_], nSpecialArguments: Int, tAggIn: TAggregable) {
+  def apply(ir: IR, fb: EmitFunctionBuilder[_], nSpecialArguments: Int, tAggIn: TAggregable) {
     apply(ir, fb, Some(tAggIn), nSpecialArguments)
   }
 
-  private def apply(ir: IR, fb: FunctionBuilder[_], tAggIn: Option[TAggregable], nSpecialArguments: Int) {
+  private def apply(ir: IR, fb: EmitFunctionBuilder[_], tAggIn: Option[TAggregable], nSpecialArguments: Int) {
     val triplet = emit(ir, fb, Env.empty, tAggIn, nSpecialArguments)
     typeToTypeInfo(ir.typ) match {
       case ti: TypeInfo[t] =>
@@ -44,7 +44,7 @@ object Emit {
 
   private def emit(
     ir: IR,
-    fb: FunctionBuilder[_],
+    fb: EmitFunctionBuilder[_],
     env: E,
     tAggIn: Option[TAggregable],
     nSpecialArguments: Int): EmitTriplet = {

--- a/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -1,0 +1,21 @@
+package is.hail.expr.ir
+
+import is.hail.asm4s._
+import is.hail.variant.ReferenceGenome
+
+import scala.collection.mutable
+
+class EmitFunctionBuilder[F >: Null](
+  parameterTypeInfo: Array[MaybeGenericTypeInfo[_]],
+  returnTypeInfo: MaybeGenericTypeInfo[_],
+  packageName: String = "is/hail/codegen/generated"
+)(implicit interfaceTi: TypeInfo[F]) extends FunctionBuilder[F](parameterTypeInfo, returnTypeInfo, packageName) {
+
+  private[this] val rgMap: mutable.Map[ReferenceGenome, Code[ReferenceGenome]] =
+    mutable.Map[ReferenceGenome, Code[ReferenceGenome]]()
+
+  def numReferenceGenomes: Int = rgMap.size
+
+  def getReferenceGenome(rg: ReferenceGenome): Code[ReferenceGenome] =
+    rgMap.getOrElseUpdate(rg, newLazyField[ReferenceGenome](rg.codeSetup))
+}

--- a/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -50,7 +50,8 @@ object ExtractAggregators {
 
   private def newAggregator(ir: ApplyAggOp): RegionValueAggregator = ir match {
     case x@ApplyAggOp(a, op, args, typ) =>
-      val constfb = FunctionBuilder.functionBuilder[Region, RegionValueAggregator]
+      val constfb =
+        new EmitFunctionBuilder[AsmFunction1[Region, RegionValueAggregator]](Array(GenericTypeInfo[Region]()), GenericTypeInfo[RegionValueAggregator]())
       val codeArgs = args.map(Emit.toCode(_, constfb, 1))
       constfb.emit(Code(
         Code(codeArgs.map(_.setup):_*),

--- a/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
+++ b/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
@@ -406,4 +406,17 @@ class ASM4SSuite extends TestNGSuite {
     assert(readField[Long](1, 2L, true) == 2L)
     assert(readField[Boolean](1, 2L, true))
   }
+
+  @Test def lazyFieldEvaluatesOnce(): Unit = {
+    val fb = FunctionBuilder.functionBuilder[Int]
+    val v2 = fb.newField[Int]
+    val v1 = fb.newLazyField(v2 + 1)
+
+    fb.emit(v2 := 0)
+    fb.emit(v2 := v1)
+    fb.emit(v2 := v1)
+    fb.emit(v1)
+
+    assert(fb.result()()() == 1)
+  }
 }

--- a/src/test/scala/is/hail/expr/ir/CompileSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/CompileSuite.scala
@@ -11,13 +11,17 @@ import org.testng.annotations.Test
 import org.scalatest._
 import Matchers._
 import is.hail.expr.ir.functions.IRFunctionRegistry
+import is.hail.variant.ReferenceGenome
 import org.apache.spark.sql.Row
 
 class CompileSuite {
-  def doit(ir: IR, fb: FunctionBuilder[_]) {
+  def doit(ir: IR, fb: EmitFunctionBuilder[_]) {
     Infer(ir)
     Emit(ir, fb)
   }
+
+  def emitFromFB[F >: Null : TypeInfo](fb: FunctionBuilder[F]) =
+    new EmitFunctionBuilder[F](fb.parameterTypeInfo, fb.returnTypeInfo, fb.packageName)
 
   @Test
   def mean() {
@@ -28,7 +32,7 @@ class CompileSuite {
             ApplyBinaryPrimOp(Add(), Ref("sum"), Ref("v"))),
           Cast(ArrayLen(Ref("x")), TFloat64())))
 
-    val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Double]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Long, Boolean, Double])
     doit(meanIr, fb)
     val f = fb.result(Some(new PrintWriter(System.out)))()
     def run(a: Array[Double]): Double = {
@@ -50,7 +54,7 @@ class CompileSuite {
         ApplyBinaryPrimOp(Add(),
           Ref("foo"), Cast(I32(1), TFloat64())))
 
-    val fb = FunctionBuilder.functionBuilder[Region, Double]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Double])
     doit(letAddIr, fb)
     val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
     val mb = Region()
@@ -64,7 +68,7 @@ class CompileSuite {
         ArrayFold(Ref("in"), I32(0), "count", "v",
           ApplyBinaryPrimOp(Add(), Ref("count"), I32(1))))
 
-    val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Int]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Long, Boolean, Int])
     doit(letAddIr, fb)
     val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
 
@@ -87,7 +91,7 @@ class CompileSuite {
         ArrayFold(Ref("in"), F64(0), "sum", "v",
           ApplyBinaryPrimOp(Add(), Ref("sum"), Ref("v"))))
 
-    val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Double]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Long, Boolean, Double])
     doit(letAddIr, fb)
     val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
 
@@ -112,7 +116,7 @@ class CompileSuite {
         ArrayFold(Ref("in"), I32(0), "count", "v",
           ApplyBinaryPrimOp(Add(), Ref("count"), If(IsNA(Ref("v")), I32(0), I32(1)))))
 
-    val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Int]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Long, Boolean, Int])
     doit(letAddIr, fb)
     val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
 
@@ -135,7 +139,7 @@ class CompileSuite {
     val sumIr =
       ArrayFold(In(0, TArray(TFloat64())), F64(0), "sum", "v",
         ApplyBinaryPrimOp(Add(), Ref("sum"), If(IsNA(Ref("v")), F64(0.0), Ref("v"))))
-    val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Double]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Long, Boolean, Double])
     doit(sumIr, fb)
     val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
 
@@ -164,7 +168,7 @@ class CompileSuite {
               ApplyBinaryPrimOp(Add(), Ref("sum"), If(IsNA(Ref("v")), F64(0.0), Ref("v")))),
             ApplyBinaryPrimOp(FloatingPointDivide(), Ref("sum"), Cast(Ref("nonMissing"), TFloat64())))))
 
-    val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Double]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Long, Boolean, Double])
     doit(letAddIr, fb)
     val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
 
@@ -244,7 +248,7 @@ class CompileSuite {
       Let("mean", F64(42.0),
         ArrayMap(In(0, TArray(TFloat64())), "v",
           If(IsNA(Ref("v")), Ref("mean"), Ref("v"))))
-    val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Long]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Long, Boolean, Long])
     doit(replaceMissingIr, fb)
     val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
     def run(a: Array[java.lang.Double]): Array[java.lang.Double] = {
@@ -282,7 +286,7 @@ class CompileSuite {
               ArrayMap(Ref("in"), "v",
                 If(IsNA(Ref("v")), Ref("mean"), Ref("v")))))))
 
-    val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Long]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Long, Boolean, Long])
     doit(meanImputeIr, fb)
     val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
     def run(a: Array[java.lang.Double]): Array[java.lang.Double] = {
@@ -320,7 +324,7 @@ class CompileSuite {
     val roff = addStruct(region,
       "x", 5.0,
       "scope", scopeStruct, addStruct(region, "foo", 7))
-    val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Long, Boolean, Double]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Long, Boolean, Long, Boolean, Double])
     doit(ir, fb)
     val f = fb.result()()
     assert(f(region, loff, false, roff, false) === 8.0)
@@ -333,7 +337,7 @@ class CompileSuite {
     val ir = InsertFields(In(0, t), Array(("1", I32(532)), ("2", F64(3.2)), ("3", I64(533))))
     val region = Region()
     val off = addStruct[IndexedSeq[Double]](region, "0", IndexedSeq(3.0, 5.0, 7.0))
-    val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Long]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Long, Boolean, Long])
     doit(ir, fb)
     val f = fb.result()()
     checkRegion(region, f(region, off, false), ir.typ,
@@ -352,7 +356,7 @@ class CompileSuite {
     val off1 = addStruct(region, "a", IndexedSeq(1, 2, 3))
     val off = addStruct(region, "0", IndexedSeq(3.0, 5.0, 7.0), "1", TStruct("a" -> TArray(TInt32())), off1)
 
-    val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Long]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Long, Boolean, Long])
     doit(ir, fb)
     val f = fb.result()()
     val noff = f(region, off, false)
@@ -377,7 +381,7 @@ class CompileSuite {
     val roff = addStruct(region,
       "0", 5.0,
       "scope", scopeStruct, addStruct(region, "foo", 7))
-    val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Long, Boolean, Long]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Long, Boolean, Long, Boolean, Long])
     doit(ir, fb)
     val f = fb.result()()
     val outOff = f(region, loff, false, roff, false)
@@ -391,7 +395,7 @@ class CompileSuite {
     val tRange = TArray(TInt32())
     val ir = ArrayRange(In(0, TInt32()), In(1, TInt32()), In(2, TInt32()))
     val region = Region()
-    val fb = FunctionBuilder.functionBuilder[Region, Int, Boolean, Int, Boolean, Int, Boolean, Long]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Int, Boolean, Int, Boolean, Int, Boolean, Long])
     doit(ir, fb)
     val f = fb.result()()
     for {
@@ -423,7 +427,7 @@ class CompileSuite {
     val t = TArray(TInt32())
     val ir = ArrayFilter(ArrayRange(I32(0), In(0, TInt32()), I32(1)), "x", ApplyBinaryPrimOp(LT(), Ref("x"), In(1, TInt32())))
     val region = Region()
-    val fb = FunctionBuilder.functionBuilder[Region, Int, Boolean, Int, Boolean, Long]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Int, Boolean, Int, Boolean, Long])
     doit(ir, fb)
     val f = fb.result()()
     for {
@@ -442,7 +446,7 @@ class CompileSuite {
     val t = TArray(TInt32())
     val ir = ArrayFilter(In(0, t), "x", ApplyBinaryPrimOp(EQ(), Ref("x"), In(1, TInt32())))
     val region = Region()
-    val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Int, Boolean, Long]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Long, Boolean, Int, Boolean, Long])
     doit(ir, fb)
     val f = fb.result(Some(new java.io.PrintWriter(System.out)))()
     for {
@@ -474,7 +478,7 @@ class CompileSuite {
     val range = ArrayRange(I32(0), min(Seq(MakeArray(Seq(ArrayLen(a1), ArrayLen(a2))))), I32(1))
     val ir = ArrayMap(range, "i", MakeTuple(Seq(ArrayRef(a1, Ref("i")), ArrayRef(a2, Ref("i")))))
     val region = Region()
-    val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Long, Boolean, Long]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Long, Boolean, Long, Boolean, Long])
     doit(ir, fb)
     val f = fb.result()()
     region.clear()
@@ -502,7 +506,7 @@ class CompileSuite {
     val tRange = TArray(TInt32())
     val ir = ArrayFlatMap(ArrayRange(I32(0), In(0, TInt32()), I32(1)), "i", ArrayRange(I32(0), Ref("i"), I32(1)))
     val region = Region()
-    val fb = FunctionBuilder.functionBuilder[Region, Int, Boolean, Long]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Int, Boolean, Long])
     doit(ir, fb)
     val f = fb.result()()
     for {
@@ -524,11 +528,11 @@ class CompileSuite {
     val flatMapIR = ArrayFlatMap(inputIR, "i", If(filterCond(Ref("i")), MakeArray(Seq(Ref("i"))), MakeArray(Seq(), tRange)))
 
     val region = Region()
-    val fb1 = FunctionBuilder.functionBuilder[Region, Int, Boolean, Long]
+    val fb1 = emitFromFB(FunctionBuilder.functionBuilder[Region, Int, Boolean, Long])
     doit(flatMapIR, fb1)
     val f1 = fb1.result()()
 
-    val fb2 = FunctionBuilder.functionBuilder[Region, Int, Boolean, Long]
+    val fb2 = emitFromFB(FunctionBuilder.functionBuilder[Region, Int, Boolean, Long])
     doit(filterIR, fb2)
     val f2 = fb2.result()()
 
@@ -551,11 +555,11 @@ class CompileSuite {
     val irAnd = MakeTuple(Seq(ApplySpecial("&&", Seq(ArrayRef(In(0, tin), I32(0)), ArrayRef(In(0, tin), I32(1))))))
     val irOr = MakeTuple(Seq(ApplySpecial("||", Seq(ArrayRef(In(0, tin), I32(0)), ArrayRef(In(0, tin), I32(1))))))
 
-    val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Long]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Long, Boolean, Long])
     doit(irAnd, fb)
     val fAnd = fb.result()()
 
-    val fb2 = FunctionBuilder.functionBuilder[Region, Long, Boolean, Long]
+    val fb2 = emitFromFB(FunctionBuilder.functionBuilder[Region, Long, Boolean, Long])
     doit(irOr, fb2)
     val fOr = fb2.result()()
 
@@ -599,7 +603,7 @@ class CompileSuite {
       else
         MakeStruct((0 until n).map(i => s"foo$i" -> GetField(in, s"field$i")))
 
-      val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, Long]
+      val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Long, Boolean, Long])
       doit(ir, fb)
       val f = fb.result(print)()
 
@@ -617,5 +621,25 @@ class CompileSuite {
     testStructN(5)
     testStructN(5000)
     testStructN(20000, hardCoded=true)
+  }
+
+  @Test def testEmitFunctionBuilderWithReferenceGenome() {
+    val grch37 = ReferenceGenome.GRCh37
+    val grch38 = ReferenceGenome.GRCh38
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[String, String, Boolean])
+    val v1 = fb.newLocal[Boolean]
+    val v2 = fb.newLocal[Boolean]
+    val v3 = fb.newLocal[Boolean]
+
+    val isValid1 = fb.getReferenceGenome(grch37).invoke[String, Boolean]("isValidContig", fb.getArg[String](1))
+    val isValid2 = fb.getReferenceGenome(grch37).invoke[String, Boolean]("isValidContig", fb.getArg[String](2))
+    assert(fb.numReferenceGenomes == 1)
+
+    val isValid3 = fb.getReferenceGenome(grch38).invoke[String, Boolean]("isValidContig", fb.getArg[String](1))
+    assert(fb.numReferenceGenomes == 2)
+
+    fb.emit(Code(v1 := isValid1, v2 := isValid2, v3 := isValid3, v1 && v2 && v3))
+    val expected = grch37.isValidContig("X") && grch37.isValidContig("Y") && grch38.isValidContig("X")
+    assert(fb.result()()("X", "Y") == expected)
   }
 }

--- a/src/test/scala/is/hail/expr/ir/ExtractAggregatorsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/ExtractAggregatorsSuite.scala
@@ -14,6 +14,9 @@ import Matchers._
 
 class ExtractAggregatorsSuite {
 
+  def emitFromFB[F >: Null : TypeInfo](fb: FunctionBuilder[F]) =
+    new EmitFunctionBuilder[F](fb.parameterTypeInfo, fb.returnTypeInfo, fb.packageName)
+
   private def defaultValue(t: Type): Any = t match {
     case _: TBoolean => false
     case _: TInt32 => 0
@@ -56,7 +59,7 @@ class ExtractAggregatorsSuite {
     val (post, aggResultStruct, aggregators) = ExtractAggregators(ir, tAgg)
 
     val seqOps = aggregators.map { case (ir, agg) =>
-      val fb = FunctionBuilder.functionBuilder[Region, RegionValueAggregator, IN, Boolean, SCOPE0, Boolean, Unit]
+      val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, RegionValueAggregator, IN, Boolean, SCOPE0, Boolean, Unit])
       Emit(ir, fb, 2, tAgg)
 
       (agg, fb.result(Some(new java.io.PrintWriter(System.out)))())
@@ -84,7 +87,7 @@ class ExtractAggregatorsSuite {
   }
 
   private def compileStage0[R: TypeInfo](ir: IR): AsmFunction3[Region, Long, Boolean, R] = {
-    val fb = FunctionBuilder.functionBuilder[Region, Long, Boolean, R]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, Long, Boolean, R])
     // nb: inference is done by stage1
     Emit(ir, fb)
     fb.result()()

--- a/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -42,18 +42,21 @@ class FunctionSuite {
 
   TestRegisterFunctions.registerAll()
 
+  def emitFromFB[F >: Null : TypeInfo](fb: FunctionBuilder[F]) =
+    new EmitFunctionBuilder[F](fb.parameterTypeInfo, fb.returnTypeInfo, fb.packageName)
+
   def fromHailString(hql: String): IR = Parser.parseToAST(hql, ec).toIR().get
 
   def toF[R: TypeInfo](ir: IR): AsmFunction1[Region, R] = {
     Infer(ir)
-    val fb = FunctionBuilder.functionBuilder[Region, R]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, R])
     Emit(ir, fb)
     fb.result(Some(new PrintWriter(System.out)))()
   }
 
   def toF[A: TypeInfo, R: TypeInfo](ir: IR): AsmFunction3[Region, A, Boolean, R] = {
     Infer(ir)
-    val fb = FunctionBuilder.functionBuilder[Region, A, Boolean, R]
+    val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, A, Boolean, R])
     Emit(ir, fb)
     fb.result(Some(new PrintWriter(System.out)))()
   }

--- a/src/test/scala/is/hail/variant/ReferenceGenomeSuite.scala
+++ b/src/test/scala/is/hail/variant/ReferenceGenomeSuite.scala
@@ -301,9 +301,8 @@ class ReferenceGenomeSuite extends SparkSuite {
   @Test def testSerializeOnFB() {
     val grch38 = ReferenceGenome.GRCh38
     val fb = FunctionBuilder.functionBuilder[String, Boolean]
-    val (rgfield, load) = grch38.addAsField(fb)
 
-    fb.emit(load)
+    val rgfield = fb.newLazyField(grch38.codeSetup)
     fb.emit(rgfield.invoke[String, Boolean]("isValidContig", fb.getArg[String](1)))
 
     val f = fb.result()()


### PR DESCRIPTION
Currently just holds referenced ReferenceGenomes.

Also added lazy fields which act like Scala's `lazy val`.