### PR TITLE
add comparison ops to ir function registry

### DIFF
--- a/src/main/scala/is/hail/annotations/CodeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/CodeOrdering.scala
@@ -31,13 +31,9 @@ case class CodeOrdering(t: Type, missingGreatest: Boolean) {
     Code.invokeStatic[java.lang.Double, Double, Double, Int]("compare", v1, v2)
 
   def compare(mb: EmitMethodBuilder, v1: Code[_], v2: Code[_]): Code[Int] = {
-    val trep = t match {
-      case tc: ComplexType => tc.representation
-      case _ => t
-    }
-    trep match {
+    t match {
       case _: TBoolean => booleanCompare(asm4s.coerce[Boolean](v1), asm4s.coerce[Boolean](v2))
-      case _: TInt32 => intCompare(asm4s.coerce[Int](v1), asm4s.coerce[Int](v2))
+      case _: TInt32 | _: TCall => intCompare(asm4s.coerce[Int](v1), asm4s.coerce[Int](v2))
       case _: TInt64 => longCompare(asm4s.coerce[Long](v1), asm4s.coerce[Long](v2))
       case _: TFloat32 => floatCompare(asm4s.coerce[Float](v1), asm4s.coerce[Float](v2))
       case _: TFloat64 => doubleCompare(asm4s.coerce[Double](v1), asm4s.coerce[Double](v2))

--- a/src/main/scala/is/hail/annotations/CodeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/CodeOrdering.scala
@@ -4,7 +4,7 @@ import java.io.PrintStream
 
 import is.hail.asm4s
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitMethodBuilder, EmitTriplet}
+import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.expr.types._
 import is.hail.utils._
 import is.hail.expr.types.coerce

--- a/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -59,9 +59,9 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: Type, var
       case _: TBaseStruct => start(true)
       case _: TBinary =>
         assert(pOffset == null)
-        startOffset.store(endOffset)
+        startOffset := endOffset
       case _ =>
-        startOffset.store(region.allocate(typ.alignment, typ.byteSize))
+        startOffset := region.allocate(typ.alignment, typ.byteSize)
     }
   }
 
@@ -114,7 +114,8 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: Type, var
       boff := region.appendInt(bytes.length()),
       toUnit(region.appendBytes(bytes)),
       typ.fundamentalType match {
-        case _: TBinary => _empty
+        case _: TBinary =>
+          startOffset := boff
         case _ =>
           region.storeAddress(currentOffset, boff)
       })

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -297,7 +297,7 @@ case class Const(posn: Position, value: Any, t: Type) extends AST(posn) {
     case (t: TFloat32, x: Float) => Some(ir.F32(x))
     case (t: TFloat64, x: Double) => Some(ir.F64(x))
     case (t: TBoolean, x: Boolean) => Some(if (x) ir.True() else ir.False())
-    case (t: TString, x: String) => None
+    case (t: TString, x: String) => Some(ir.Str(x))
     case (t, null) => Some(ir.NA(t))
     case _ => throw new RuntimeException(s"Unrecognized constant of type $t: $value")
   }

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -10,6 +10,7 @@ object Children {
     case I64(x) => none
     case F32(x) => none
     case F64(x) => none
+    case Str(x) => none
     case True() => none
     case False() => none
     case Cast(v, typ) =>

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -13,6 +13,7 @@ object Copy {
       case I64(_) => same
       case F32(_) => same
       case F64(_) => same
+      case Str(_) => same
       case True() => same
       case False() => same
       case Cast(_, typ) =>

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -192,8 +192,7 @@ private class Emit(
       case F64(x) =>
         present(const(x))
       case Str(x) =>
-        val srvb = new StagedRegionValueBuilder(mb, TString())
-        present(Code(srvb.start(), srvb.addString(const(x)), srvb.end()))
+        present(region.appendString(const(x)))
       case True() =>
         present(const(true))
       case False() =>

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -189,6 +189,9 @@ private class Emit(
         present(const(x))
       case F64(x) =>
         present(const(x))
+      case Str(x) =>
+        val srvb = new StagedRegionValueBuilder(mb, TString())
+        present(Code(srvb.start(), srvb.addString(const(x)), srvb.end()))
       case True() =>
         present(const(true))
       case False() =>

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -52,7 +52,9 @@ object Emit {
   }
 }
 
-case class EmitTriplet(setup: Code[Unit], m: Code[Boolean], v: Code[_])
+case class EmitTriplet(setup: Code[Unit], m: Code[Boolean], v: Code[_]) {
+  def value[T]: Code[T] = coerce[T](v)
+}
 
 case class EmitArrayTriplet(setup: Code[Unit], m: Option[Code[Boolean]], addElements: Code[Unit])
 
@@ -237,7 +239,7 @@ private class Emit(
         val setup = Code(
           codeV.setup,
           mx := codeV.m,
-          x := codeV.v,
+          x := mx.mux(defaultValue(value.typ), codeV.v),
           codeBody.setup)
 
         EmitTriplet(setup, codeBody.m, codeBody.v)

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -3,7 +3,6 @@ package is.hail.expr.ir
 import is.hail.asm4s._
 import is.hail.annotations._
 import is.hail.annotations.aggregators._
-import is.hail.expr.ir.functions.{IRFunction, IRFunctionWithMissingness, IRFunctionWithoutMissingness}
 import is.hail.expr.types._
 import is.hail.utils._
 

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -62,7 +62,7 @@ case class ArrayIteratorTriplet(calcLength: Code[Unit], length: Option[Code[Int]
 }
 
 private class Emit(
-  mb: MethodBuilder,
+  mb: EmitMethodBuilder,
   tAggInOpt: Option[TAggregable],
   nSpecialArguments: Int) {
 
@@ -85,12 +85,12 @@ private class Emit(
     ab.result()
   }
 
-  val methods: mutable.Map[String, Seq[(Seq[Type], MethodBuilder)]] = mutable.Map().withDefaultValue(FastSeq())
+  val methods: mutable.Map[String, Seq[(Seq[Type], EmitMethodBuilder)]] = mutable.Map().withDefaultValue(FastSeq())
 
   import Emit.E
   import Emit.F
 
-  private def wrapToMethod(irs: Seq[IR], env: E)(useValues: (MethodBuilder, Type, EmitTriplet) => Code[Unit]): Code[Unit] = {
+  private def wrapToMethod(irs: Seq[IR], env: E)(useValues: (EmitMethodBuilder, Type, EmitTriplet) => Code[Unit]): Code[Unit] = {
     def wrapCodeChunks(items: Seq[_], isIR: Boolean = false): Code[Unit] = {
       val sizes: Seq[Int] = if (isIR) irs.map(_.size * opSize) else Array.fill(items.size)(5)
       val chunkBounds = getChunkBounds(sizes)
@@ -261,7 +261,7 @@ private class Emit(
       case MakeArray(args, typ) =>
         val srvb = new StagedRegionValueBuilder(mb, typ)
         val addElement = srvb.addIRIntermediate(typ.elementType)
-        val addElts = { (newMB: MethodBuilder, t: Type, v: EmitTriplet) =>
+        val addElts = { (newMB: EmitMethodBuilder, t: Type, v: EmitTriplet) =>
           Code(
             v.setup,
             v.m.mux(srvb.setMissing(), addElement(v.v)),
@@ -411,7 +411,7 @@ private class Emit(
 
       case x@MakeStruct(fields, _) =>
         val srvb = new StagedRegionValueBuilder(mb, x.typ)
-        val addFields = { (newMB: MethodBuilder, t: Type, v: EmitTriplet) =>
+        val addFields = { (newMB: EmitMethodBuilder, t: Type, v: EmitTriplet) =>
           Code(
             v.setup,
             v.m.mux(srvb.setMissing(), srvb.addIRIntermediate(t)(v.v)),
@@ -481,7 +481,7 @@ private class Emit(
 
       case x@MakeTuple(fields, _) =>
         val srvb = new StagedRegionValueBuilder(mb, x.typ)
-        val addFields = { (newMB: MethodBuilder, t: Type, v: EmitTriplet) =>
+        val addFields = { (newMB: EmitMethodBuilder, t: Type, v: EmitTriplet) =>
           Code(
             v.setup,
             v.m.mux(srvb.setMissing(), srvb.addIRIntermediate(t)(v.v)),

--- a/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -34,7 +34,7 @@ object EmitFunctionBuilder {
 }
 
 class EmitMethodBuilder(
-  fb: EmitFunctionBuilder[_],
+  override val fb: EmitFunctionBuilder[_],
   mname: String,
   parameterTypeInfo: Array[TypeInfo[_]],
   returnTypeInfo: TypeInfo[_]

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -30,6 +30,7 @@ object Literal {
       case _: TFloat32 => F32(x.asInstanceOf[Float])
       case _: TFloat64 => F64(x.asInstanceOf[Double])
       case _: TBoolean => if (x.asInstanceOf[Boolean]) True() else False()
+      case _: TString => Str(x.asInstanceOf[String])
       case _ => throw new RuntimeException("Unsupported literal type")
     }
   }
@@ -39,6 +40,7 @@ final case class I32(x: Int) extends IR { val typ = TInt32() }
 final case class I64(x: Long) extends IR { val typ = TInt64() }
 final case class F32(x: Float) extends IR { val typ = TFloat32() }
 final case class F64(x: Double) extends IR { val typ = TFloat64() }
+final case class Str(x: String) extends IR { val typ = TString() }
 final case class True() extends IR { val typ = TBoolean() }
 final case class False() extends IR { val typ = TBoolean() }
 

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -13,6 +13,7 @@ object Infer {
       case I64(x) =>
       case F32(x) =>
       case F64(x) =>
+      case Str(x) =>
       case True() =>
       case False() =>
 

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -162,12 +162,14 @@ object Infer {
       case x@Apply(fn, args, impl) =>
         args.foreach(infer(_))
         if (impl == null)
-          x.implementation = (IRFunctionRegistry.lookupFunction(fn, args.map(_.typ)).get).asInstanceOf[IRFunctionWithoutMissingness]
-        assert(args.map(_.typ).zip(x.implementation.argTypes).forall {case (i, j) => j.unify(i)})
+          x.implementation = IRFunctionRegistry.lookupFunction(fn, args.map(_.typ)).get.asInstanceOf[IRFunctionWithoutMissingness]
+        x.implementation.argTypes.foreach(_.clear())
+        assert(args.map(_.typ).zip(x.implementation.argTypes).forall { case (i, j) => j.unify(i) })
       case x@ApplySpecial(fn, args, impl) =>
         args.foreach(infer(_))
         if (impl == null)
-          x.implementation = (IRFunctionRegistry.lookupFunction(fn, args.map(_.typ)).get).asInstanceOf[IRFunctionWithMissingness]
+          x.implementation = IRFunctionRegistry.lookupFunction(fn, args.map(_.typ)).get.asInstanceOf[IRFunctionWithMissingness]
+        x.implementation.argTypes.foreach(_.clear())
         assert(args.map(_.typ).zip(x.implementation.argTypes).forall {case (i, j) => j.unify(i)})
       case x@TableAggregate(child, query, _) =>
         infer(query, tAgg = Some(child.typ.tAgg), env = child.typ.aggEnv)

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -39,6 +39,7 @@ object Interpret {
       case I64(x) => x
       case F32(x) => x
       case F64(x) => x
+      case Str(x) => x
       case True() => true
       case False() => false
       case Cast(v, t) =>

--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -46,6 +46,7 @@ object Pretty {
             case I64(x) => x.toString
             case F32(x) => x.toString
             case F64(x) => x.toString
+            case Str(x) => x
             case Cast(_, typ) => typ.toString
             case NA(typ) => typ.toString
             case Let(name, _, _, _) => name

--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -46,7 +46,7 @@ object Pretty {
             case I64(x) => x.toString
             case F32(x) => x.toString
             case F64(x) => x.toString
-            case Str(x) => x
+            case Str(x) => s"'$x'"
             case Cast(_, typ) => typ.toString
             case NA(typ) => typ.toString
             case Let(name, _, _, _) => name

--- a/src/main/scala/is/hail/expr/ir/Recur.scala
+++ b/src/main/scala/is/hail/expr/ir/Recur.scala
@@ -1,49 +1,8 @@
 package is.hail.expr.ir
 
 object Recur {
-  def apply(f: IR => IR)(ir: IR): IR = ir match {
-    case I32(x) => ir
-    case I64(x) => ir
-    case F32(x) => ir
-    case F64(x) => ir
-    case True() => ir
-    case False() => ir
-    case Cast(v, typ) => Cast(f(v), typ)
-    case NA(typ) => ir
-    case IsNA(value) => IsNA(f(value))
-    case If(cond, cnsq, altr, typ) => If(f(cond), f(cnsq), f(altr), typ)
-    case Let(name, value, body, typ) => Let(name, f(value), f(body), typ)
-    case Ref(name, typ) => ir
-    case ApplyBinaryPrimOp(op, l, r, typ) => ApplyBinaryPrimOp(op, f(l), f(r), typ)
-    case ApplyUnaryPrimOp(op, x, typ) => ApplyUnaryPrimOp(op, f(x), typ)
-    case MakeArray(args, typ) => MakeArray(args map f, typ)
-    case ArrayRef(a, i, typ) => ArrayRef(f(a), f(i), typ)
-    case ArrayLen(a) => ArrayLen(f(a))
-    case ArrayRange(start, stop, step) => ArrayRange(f(start), f(stop), f(step))
-    case ArrayMap(a, name, body, elementTyp) => ArrayMap(f(a), name, f(body), elementTyp)
-    case ArrayFilter(a, name, cond) => ArrayFilter(f(a), name, f(cond))
-    case ArrayFlatMap(a, name, body) => ArrayFlatMap(f(a), name, f(body))
-    case ArrayFold(a, zero, accumName, valueName, body, typ) => ArrayFold(f(a), f(zero), accumName, valueName, f(body), typ)
-    case MakeStruct(fields, _) => MakeStruct(fields map { case (n, a) => (n, f(a)) })
-    case InsertFields(old, fields, _) => InsertFields(f(old), fields map { case (n, a) => (n, f(a)) })
-    case GetField(o, name, typ) => GetField(f(o), name, typ)
-    case AggIn(typ) => ir
-    case AggMap(a, name, body, typ) => AggMap(f(a), name, f(body), typ)
-    case AggFilter(a, name, body, typ) => AggFilter(f(a), name, f(body), typ)
-    case AggFlatMap(a, name, body, typ) => AggFlatMap(f(a), name, f(body), typ)
-    case ApplyAggOp(a, op, args, typ) => ApplyAggOp(f(a), op, args.map(f), typ)
-    case MakeTuple(elts, typ) => MakeTuple(elts.map(f), typ)
-    case GetTupleElement(tup, idx, typ) => GetTupleElement(f(tup), idx, typ)
-    case In(i, typ) => ir
-    case Die(message) => ir
-    case Apply(fn, args, impl) => Apply(fn, args.map(f), impl)
-    case ApplySpecial(fn, args, impl) => ApplySpecial(fn, args.map(f), impl)
-    // from MatrixIR
-    case MatrixWrite(_, _, _, _) => ir
-    // from TableIR
-    case TableCount(_) => ir
-    case TableAggregate(child, query, typ) => TableAggregate(child, f(query), typ)
-    case TableWrite(_, _, _, _) => ir
-    case TableExport(_, _, _, _, _) => ir
-  }
+  def apply(f: IR => IR)(ir: IR): IR = Copy(ir, Children(ir).map {
+    case c: IR => f(c)
+    case c => c
+  }).asInstanceOf[IR]
 }

--- a/src/main/scala/is/hail/expr/ir/TypeToIRIntermediateClassTag.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeToIRIntermediateClassTag.scala
@@ -11,6 +11,6 @@ object TypeToIRIntermediateClassTag {
     case _: TInt64 => classTag[Long]
     case _: TFloat32 => classTag[Float]
     case _: TFloat64 => classTag[Double]
-    case _: TBaseStruct | _: TArray => classTag[Long]
+    case _: TBaseStruct | _: TArray | _: TBinary => classTag[Long]
   }
 }

--- a/src/main/scala/is/hail/expr/ir/functions/CallFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/CallFunctions.scala
@@ -10,7 +10,5 @@ object CallFunctions extends RegistryFunctions {
     registerScalaFunction("downcode", TCall(), TInt32(), TCall())(Call.getClass, "downcode")
     registerScalaFunction("UnphasedDiploidGtIndexCall", TInt32(), TCall())(Call2.getClass, "fromUnphasedDiploidGtIndex")
     registerScalaFunction("isNonRef", TCall(), TBoolean())(Call.getClass, "isNonRef")
-
-    registerCode("==", TCall(), TCall(), TBoolean()) { (_, a: Code[Int], b: Code[Int]) => a.ceq(b) }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -89,7 +89,7 @@ abstract class RegistryFunctions {
   def tnum(name: String): TVariable =
     tv(name, _.isInstanceOf[TNumeric])
 
-  def registerCode(mname: String, aTypes: Array[Type], rType: Type)(impl: (MethodBuilder, Array[Code[_]]) => Code[_]) {
+  def registerCode(mname: String, aTypes: Array[Type], rType: Type)(impl: (EmitMethodBuilder, Array[Code[_]]) => Code[_]) {
     IRFunctionRegistry.addIRFunction(new IRFunctionWithoutMissingness {
       override val name: String = mname
 
@@ -97,11 +97,11 @@ abstract class RegistryFunctions {
 
       override val returnType: Type = rType
 
-      override def apply(mb: MethodBuilder, args: Code[_]*): Code[_] = impl(mb, args.toArray)
+      override def apply(mb: EmitMethodBuilder, args: Code[_]*): Code[_] = impl(mb, args.toArray)
     })
   }
 
-  def registerCodeWithMissingness(mname: String, aTypes: Array[Type], rType: Type)(impl: (MethodBuilder, Array[EmitTriplet]) => EmitTriplet) {
+  def registerCodeWithMissingness(mname: String, aTypes: Array[Type], rType: Type)(impl: (EmitMethodBuilder, Array[EmitTriplet]) => EmitTriplet) {
     IRFunctionRegistry.addIRFunction(new IRFunctionWithMissingness {
       override val name: String = mname
 
@@ -109,7 +109,7 @@ abstract class RegistryFunctions {
 
       override val returnType: Type = rType
 
-      override def apply(mb: MethodBuilder, args: EmitTriplet*): EmitTriplet = impl(mb, args.toArray)
+      override def apply(mb: EmitMethodBuilder, args: EmitTriplet*): EmitTriplet = impl(mb, args.toArray)
     })
   }
 
@@ -137,26 +137,26 @@ abstract class RegistryFunctions {
     IRFunctionRegistry.addIR(mname, argTypes, f)
   }
 
-  def registerCode(mname: String, rt: Type)(impl: MethodBuilder => Code[_]): Unit =
+  def registerCode(mname: String, rt: Type)(impl: EmitMethodBuilder => Code[_]): Unit =
     registerCode(mname, Array[Type](), rt) { case (mb, Array()) => impl(mb) }
 
-  def registerCode[T1: TypeInfo](mname: String, mt1: Type, rt: Type)(impl: (MethodBuilder, Code[T1]) => Code[_]): Unit =
+  def registerCode[T1: TypeInfo](mname: String, mt1: Type, rt: Type)(impl: (EmitMethodBuilder, Code[T1]) => Code[_]): Unit =
     registerCode(mname, Array(mt1), rt) { case (mb, Array(a1)) => impl(mb, coerce[T1](a1)) }
 
-  def registerCode[T1: TypeInfo, T2: TypeInfo](mname: String, mt1: Type, mt2: Type, rt: Type)(impl: (MethodBuilder, Code[T1], Code[T2]) => Code[_]): Unit =
+  def registerCode[T1: TypeInfo, T2: TypeInfo](mname: String, mt1: Type, mt2: Type, rt: Type)(impl: (EmitMethodBuilder, Code[T1], Code[T2]) => Code[_]): Unit =
     registerCode(mname, Array(mt1, mt2), rt) { case (mb, Array(a1, a2)) => impl(mb, coerce[T1](a1), coerce[T2](a2)) }
 
   def registerCode[T1: TypeInfo, T2: TypeInfo, T3: TypeInfo](mname: String, mt1: Type, mt2: Type, mt3: Type, rt: Type)
-    (impl: (MethodBuilder, Code[_], Code[_], Code[_]) => Code[_]): Unit =
+    (impl: (EmitMethodBuilder, Code[_], Code[_], Code[_]) => Code[_]): Unit =
     registerCode(mname, Array(mt1, mt2, mt3), rt) { case (mb, Array(a1, a2, a3)) => impl(mb, coerce[T1](a1), coerce[T2](a2), coerce[T3](a3)) }
 
-  def registerCodeWithMissingness(mname: String, rt: Type)(impl: MethodBuilder => EmitTriplet): Unit =
+  def registerCodeWithMissingness(mname: String, rt: Type)(impl: EmitMethodBuilder => EmitTriplet): Unit =
     registerCodeWithMissingness(mname, Array[Type](), rt) { case (mb, Array()) => impl(mb) }
 
-  def registerCodeWithMissingness(mname: String, mt1: Type, rt: Type)(impl: (MethodBuilder, EmitTriplet) => EmitTriplet): Unit =
+  def registerCodeWithMissingness(mname: String, mt1: Type, rt: Type)(impl: (EmitMethodBuilder, EmitTriplet) => EmitTriplet): Unit =
     registerCodeWithMissingness(mname, Array(mt1), rt) { case (mb, Array(a1)) => impl(mb, a1) }
 
-  def registerCodeWithMissingness(mname: String, mt1: Type, mt2: Type, rt: Type)(impl: (MethodBuilder, EmitTriplet, EmitTriplet) => EmitTriplet): Unit =
+  def registerCodeWithMissingness(mname: String, mt1: Type, mt2: Type, rt: Type)(impl: (EmitMethodBuilder, EmitTriplet, EmitTriplet) => EmitTriplet): Unit =
     registerCodeWithMissingness(mname, Array(mt1, mt2), rt) { case (mb, Array(a1, a2)) => impl(mb, a1, a2) }
 
   def registerIR(mname: String)(f: () => IR): Unit =
@@ -177,9 +177,9 @@ sealed abstract class IRFunction {
 
   def argTypes: Seq[Type]
 
-  def apply(mb: MethodBuilder, args: EmitTriplet*): EmitTriplet
+  def apply(mb: EmitMethodBuilder, args: EmitTriplet*): EmitTriplet
 
-  def getAsMethod(fb: FunctionBuilder[_], args: Type*): MethodBuilder = ???
+  def getAsMethod(fb: EmitFunctionBuilder[_], args: Type*): EmitMethodBuilder = ???
 
   def returnType: Type
 
@@ -192,9 +192,9 @@ abstract class IRFunctionWithoutMissingness extends IRFunction {
 
   def argTypes: Seq[Type]
 
-  def apply(mb: MethodBuilder, args: Code[_]*): Code[_]
+  def apply(mb: EmitMethodBuilder, args: Code[_]*): Code[_]
 
-  def apply(mb: MethodBuilder, args: EmitTriplet*): EmitTriplet = {
+  def apply(mb: EmitMethodBuilder, args: EmitTriplet*): EmitTriplet = {
     val setup = args.map(_.setup)
     val missing = args.map(_.m).reduce(_ || _)
     val value = apply(mb, args.map(_.v): _*)
@@ -202,7 +202,7 @@ abstract class IRFunctionWithoutMissingness extends IRFunction {
     EmitTriplet(setup, missing, value)
   }
 
-  override def getAsMethod(fb: FunctionBuilder[_], args: Type*): MethodBuilder = {
+  override def getAsMethod(fb: EmitFunctionBuilder[_], args: Type*): EmitMethodBuilder = {
     argTypes.foreach(_.clear())
     (argTypes, args).zipped.foreach(_.unify(_))
     val ts = argTypes.map(t => typeToTypeInfo(t.subst()))
@@ -221,7 +221,7 @@ abstract class IRFunctionWithMissingness extends IRFunction {
 
   def argTypes: Seq[Type]
 
-  def apply(mb: MethodBuilder, args: EmitTriplet*): EmitTriplet
+  def apply(mb: EmitMethodBuilder, args: EmitTriplet*): EmitTriplet
 
   def returnType: Type
 

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -140,15 +140,14 @@ abstract class RegistryFunctions {
   def registerCode(mname: String, rt: Type)(impl: EmitMethodBuilder => Code[_]): Unit =
     registerCode(mname, Array[Type](), rt) { case (mb, Array()) => impl(mb) }
 
-  def registerCode[T1: TypeInfo](mname: String, mt1: Type, rt: Type)(impl: (EmitMethodBuilder, Code[T1]) => Code[_]): Unit =
-    registerCode(mname, Array(mt1), rt) { case (mb, Array(a1)) => impl(mb, coerce[T1](a1)) }
+  def registerCode(mname: String, mt1: Type, rt: Type)(impl: (EmitMethodBuilder, Code[_]) => Code[_]): Unit =
+    registerCode(mname, Array(mt1), rt) { case (mb, Array(a1)) => impl(mb, a1) }
 
-  def registerCode[T1: TypeInfo, T2: TypeInfo](mname: String, mt1: Type, mt2: Type, rt: Type)(impl: (EmitMethodBuilder, Code[T1], Code[T2]) => Code[_]): Unit =
-    registerCode(mname, Array(mt1, mt2), rt) { case (mb, Array(a1, a2)) => impl(mb, coerce[T1](a1), coerce[T2](a2)) }
+  def registerCode(mname: String, mt1: Type, mt2: Type, rt: Type)(impl: (EmitMethodBuilder, Code[_], Code[_]) => Code[_]): Unit =
+    registerCode(mname, Array(mt1, mt2), rt) { case (mb, Array(a1, a2)) => impl(mb, a1, a2) }
 
-  def registerCode[T1: TypeInfo, T2: TypeInfo, T3: TypeInfo](mname: String, mt1: Type, mt2: Type, mt3: Type, rt: Type)
-    (impl: (EmitMethodBuilder, Code[_], Code[_], Code[_]) => Code[_]): Unit =
-    registerCode(mname, Array(mt1, mt2, mt3), rt) { case (mb, Array(a1, a2, a3)) => impl(mb, coerce[T1](a1), coerce[T2](a2), coerce[T3](a3)) }
+  def registerCode(mname: String, mt1: Type, mt2: Type, mt3: Type, rt: Type)(impl: (EmitMethodBuilder, Code[_], Code[_], Code[_]) => Code[_]): Unit =
+    registerCode(mname, Array(mt1, mt2, mt3), rt) { case (mb, Array(a1, a2, a3)) => impl(mb, a1, a2, a3) }
 
   def registerCodeWithMissingness(mname: String, rt: Type)(impl: EmitMethodBuilder => EmitTriplet): Unit =
     registerCodeWithMissingness(mname, Array[Type](), rt) { case (mb, Array()) => impl(mb) }

--- a/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -8,7 +8,7 @@ import is.hail.utils._
 object GenotypeFunctions extends RegistryFunctions {
 
   def registerAll() {
-    registerCode("gqFromPL", TArray(tv("N", _.isInstanceOf[TInt32])), TInt32()) { (mb, pl: Code[Long]) =>
+    registerCode("gqFromPL", TArray(tv("N", _.isInstanceOf[TInt32])), TInt32()) { case (mb, pl: Code[Long]) =>
       val region = mb.getArg[Region](1).load()
       val tPL = TArray(tv("N").t)
       val m = mb.newLocal[Int]("m")

--- a/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
@@ -57,7 +57,8 @@ object MathFunctions extends RegistryFunctions {
     registerScalaFunction("**", TFloat64(), TFloat64(), TFloat64())(mathPackageClass, "pow")
     registerScalaFunction("gamma", TFloat64(), TFloat64())(thisClass, "gamma")
 
-    registerScalaFunction("binomTest", TInt32(), TInt32(), TFloat64(), TString(), TFloat64())(statsPackageClass, "binomTest")
+    // FIXME: This needs to do string conversion.
+    // registerScalaFunction("binomTest", TInt32(), TInt32(), TFloat64(), TString(), TFloat64())(statsPackageClass, "binomTest")
 
     registerScalaFunction("dbeta", TFloat64(), TFloat64(), TFloat64(), TFloat64())(statsPackageClass, "dbeta")
 

--- a/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -17,8 +17,7 @@ object StringFunctions extends RegistryFunctions {
   }
 
   private[this] def convertFromString(mb: EmitMethodBuilder, v: Code[String]): Code[Long] = {
-    val srvb = new StagedRegionValueBuilder(mb, TString())
-    Code(srvb.start(), srvb.addString(v), srvb.end())
+    mb.getArg[Region](1).load().appendString(v)
   }
 
   private[this] def registerWrappedStringScalaFunction(mname: String, argTypes: Array[Type], rType: Type)(cls: Class[_], method: String) {

--- a/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -26,7 +26,7 @@ object StringFunctions extends RegistryFunctions {
       case t => TypeToIRIntermediateClassTag(t)
     }
 
-    def conversion(mb: EmitMethodBuilder, typ: Type, v: Code[_]): Code[_] = (typ, v) match {
+    def convertToString(mb: EmitMethodBuilder, typ: Type, v: Code[_]): Code[_] = (typ, v) match {
         case (_: TString, v2: Code[Long]) => wrapToString(mb, v2)
         case (_, v2) => v2
     }
@@ -38,7 +38,7 @@ object StringFunctions extends RegistryFunctions {
 
     registerCode(mname, argTypes, rType) { (mb, args) =>
       val cts = argTypes.map(ct(_).runtimeClass)
-      val out = Code.invokeScalaObject(cls, method, cts, argTypes.zip(args).map { case (t, a) => conversion(mb, t, a) } )(ct(rType))
+      val out = Code.invokeScalaObject(cls, method, cts, argTypes.zip(args).map { case (t, a) => convertToString(mb, t, a) } )(ct(rType))
       convertBack(mb, out)
     }
   }

--- a/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -1,9 +1,54 @@
 package is.hail.expr.ir.functions
 
+import is.hail.annotations.{Region, StagedRegionValueBuilder}
+import is.hail.asm4s
+import is.hail.asm4s._
+import is.hail.expr.ir
+import is.hail.expr.ir.{EmitMethodBuilder, EmitTriplet, TypeToIRIntermediateClassTag}
 import is.hail.expr.types._
 import is.hail.utils._
 
+import scala.reflect.{ClassTag, classTag}
+
 object StringFunctions extends RegistryFunctions {
+
+  private[this] def wrapToString(mb: EmitMethodBuilder, v: Code[Long]): Code[String] = {
+    Code.invokeScalaObject[Region, Long, String](TString.getClass, "loadString", mb.getArg[Region](1), v)
+  }
+
+  private[this] def convertFromString(mb: EmitMethodBuilder, v: Code[String]): Code[Long] = {
+    val srvb = new StagedRegionValueBuilder(mb, TString())
+    Code(srvb.start(), srvb.addString(v), srvb.end())
+  }
+
+  private[this] def registerWrappedStringScalaFunction(mname: String, argTypes: Array[Type], rType: Type)(cls: Class[_], method: String) {
+    def ct(typ: Type): ClassTag[_] = typ match {
+      case _: TString => classTag[String]
+      case t => TypeToIRIntermediateClassTag(t)
+    }
+
+    def conversion(mb: EmitMethodBuilder, typ: Type, v: Code[_]): Code[_] = (typ, v) match {
+        case (_: TString, v2: Code[Long]) => wrapToString(mb, v2)
+        case (_, v2) => v2
+    }
+
+    def convertBack(mb: EmitMethodBuilder, v: Code[_]): Code[_] = rType match {
+      case _: TString => convertFromString(mb, asm4s.coerce[String](v))
+      case t => v
+    }
+
+    registerCode(mname, argTypes, rType) { (mb, args) =>
+      val cts = argTypes.map(ct(_).runtimeClass)
+      val out = Code.invokeScalaObject(cls, method, cts, argTypes.zip(args).map { case (t, a) => conversion(mb, t, a) } )(ct(rType))
+      convertBack(mb, out)
+    }
+  }
+
+  def registerWrappedStringScalaFunction(mname: String, a1: Type, rType: Type)(cls: Class[_], method: String): Unit =
+    registerWrappedStringScalaFunction(mname, Array(a1), rType)(cls, method)
+
+  def registerWrappedStringScalaFunction(mname: String, a1: Type, a2: Type, rType: Type)(cls: Class[_], method: String): Unit =
+    registerWrappedStringScalaFunction(mname, Array(a1, a2), rType)(cls, method)
 
   def upper(s: String): String = s.toUpperCase
 
@@ -17,16 +62,48 @@ object StringFunctions extends RegistryFunctions {
 
   def endswith(s: String, t: String): Boolean = s.endsWith(t)
 
-  def firstMatchIn(s: String, regex: String): IndexedSeq[String] = regex.r.findFirstMatchIn(s).map(_.subgroups.toArray.toFastIndexedSeq).orNull
+  def firstMatchIn(s: String, regex: String): IndexedSeq[String] = {
+    regex.r.findFirstMatchIn(s).map(_.subgroups.toArray.toFastIndexedSeq).orNull
+  }
 
   def registerAll(): Unit = {
     val thisClass = getClass
-    registerScalaFunction("upper", TString(), TString())(thisClass, "upper")
-    registerScalaFunction("lower", TString(), TString())(thisClass, "lower")
-    registerScalaFunction("strip", TString(), TString())(thisClass, "strip")
-    registerScalaFunction("contains", TString(), TString(), TBoolean())(thisClass, "contains")
-    registerScalaFunction("startswith", TString(), TString(), TBoolean())(thisClass, "startswith")
-    registerScalaFunction("endswith", TString(), TString(), TBoolean())(thisClass, "endswith")
-    registerScalaFunction("firstMatchIn", TString(), TString(), TArray(TString()))(thisClass, "firstMatchIn")
+    registerWrappedStringScalaFunction("upper", TString(), TString())(thisClass, "upper")
+    registerWrappedStringScalaFunction("lower", TString(), TString())(thisClass, "lower")
+    registerWrappedStringScalaFunction("strip", TString(), TString())(thisClass, "strip")
+    registerWrappedStringScalaFunction("contains", TString(), TString(), TBoolean())(thisClass, "contains")
+    registerWrappedStringScalaFunction("startswith", TString(), TString(), TBoolean())(thisClass, "startswith")
+    registerWrappedStringScalaFunction("endswith", TString(), TString(), TBoolean())(thisClass, "endswith")
+
+    registerCodeWithMissingness("firstMatchIn", TString(), TString(), TArray(TString())) { (mb: EmitMethodBuilder, s: EmitTriplet, r: EmitTriplet) =>
+      val out: LocalRef[IndexedSeq[String]] = mb.newLocal[IndexedSeq[String]]
+      val nout = new CodeNullable[IndexedSeq[String]](out)
+
+      val srvb: StagedRegionValueBuilder = new StagedRegionValueBuilder(mb, TArray(TString()))
+      val len: LocalRef[Int] = mb.newLocal[Int]
+      val elt: LocalRef[String] = mb.newLocal[String]
+      val nelt = new CodeNullable[String](elt)
+
+      val setup = Code(s.setup, r.setup)
+      val missing = s.m || r.m || Code(
+        out := Code.invokeScalaObject[String, String, IndexedSeq[String]](thisClass,
+          "firstMatchIn", wrapToString(mb, s.value[Long]), wrapToString(mb, r.value[Long])),
+        nout.isNull)
+      val value =
+        nout.ifNull(
+          ir.defaultValue(TArray(TString())),
+          Code(
+            len := out.invoke[Int]("size"),
+            srvb.start(len),
+            Code.whileLoop(srvb.arrayIdx < len,
+              elt := out.invoke[Int, String]("apply", srvb.arrayIdx),
+              nelt.ifNull(
+                srvb.setMissing(),
+                srvb.addString(elt)),
+              srvb.advance()),
+            srvb.end()))
+
+      EmitTriplet(setup, missing, value)
+    }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -11,7 +11,7 @@ import is.hail.asm4s
 object UtilFunctions extends RegistryFunctions {
 
   def registerAll() {
-    registerCode("triangle", TInt32(), TInt32()) { (_, n: Code[Int]) => n * (n + 1) / 2 }
+    registerCode("triangle", TInt32(), TInt32()) { case (_, n: Code[Int]) => n * (n + 1) / 2 }
 
     registerIR("size", TArray(tv("T")))(ArrayLen)
 
@@ -118,56 +118,14 @@ object UtilFunctions extends RegistryFunctions {
       InsertFields(s, annotations.asInstanceOf[MakeStruct].fields)
     }
 
-    registerCodeWithMissingness("==", tv("T"), tv("T"), TBoolean()) { (mb, v1, v2) =>
-      val tactual = tv("T").t match {
-        case tc: ComplexType => tc.representation
-        case t => t
-      }
-      val comparison = (tactual, v1.v, v2.v) match {
-        case (_: TBoolean, x1: Code[Boolean], x2: Code[Boolean]) => x1.ceq(x2)
-        case (_: TInt32, x1: Code[Int], x2: Code[Int]) => x1.ceq(x2)
-        case (_: TInt64, x1: Code[Long], x2: Code[Long]) => x1.ceq(x2)
-        case (_: TFloat32, x1: Code[Float], x2: Code[Float]) => x1.ceq(x2)
-        case (_: TFloat64, x1: Code[Double], x2: Code[Double]) => x1.ceq(x2)
-        case (t, o1: Code[Long], o2: Code[Long]) =>
-          val ord = CodeOrdering(t, missingGreatest = true)
-          ord.compare(mb, mb.getArg[Region](1), o1, mb.getArg[Region](1), o2).ceq(0)
-        case (t, x1, x2) =>
-          throw new UnsupportedOperationException(s"can't compare things of type $t with classes ${ x1.getClass } and ${ x2.getClass }")
-      }
-
-      val setup = Code(v1.setup, v2.setup)
-      val v1m = mb.newLocal[Boolean]
-      val vout = Code(
-        v1m := v1.m,
-        v1m.cne(v2.m).mux(const(false), v1m.mux(const(true), comparison)))
-      EmitTriplet(setup, const(false), vout)
+    registerCode("==", tv("T"), tv("T"), TBoolean()) { (mb, v1, v2) =>
+      val ord = CodeOrdering(tv("T").t, missingGreatest = true)
+      ord.compare(mb, v1, v2).ceq(0)
     }
 
-    registerCodeWithMissingness("!=", tv("T"), tv("T"), TBoolean()) { (mb, v1, v2) =>
-      val tactual = tv("T").t match {
-        case tc: ComplexType => tc.representation
-        case t => t
-      }
-      val comparison = (tactual, v1.v, v2.v) match {
-        case (_: TBoolean, x1: Code[Boolean], x2: Code[Boolean]) => x1.cne(x2)
-        case (_: TInt32, x1: Code[Int], x2: Code[Int]) => x1.cne(x2)
-        case (_: TInt64, x1: Code[Long], x2: Code[Long]) => x1.cne(x2)
-        case (_: TFloat32, x1: Code[Float], x2: Code[Float]) => x1.cne(x2)
-        case (_: TFloat64, x1: Code[Double], x2: Code[Double]) => x1.cne(x2)
-        case (t, o1: Code[Long], o2: Code[Long]) =>
-          val ord = CodeOrdering(t, missingGreatest = true)
-          ord.compare(mb, mb.getArg[Region](1), o1, mb.getArg[Region](1), o2).cne(0)
-        case (t, x1, x2) =>
-          throw new UnsupportedOperationException(s"can't compare things of type $t with classes ${ x1.getClass } and ${ x2.getClass }")
-      }
-
-      val setup = Code(v1.setup, v2.setup)
-      val v1m = mb.newLocal[Boolean]
-      val vout = Code(
-        v1m := v1.m,
-        v1m.cne(v2.m).mux(const(true), v1m.mux(const(false), comparison)))
-      EmitTriplet(setup, const(false), vout)
+    registerCode("!=", tv("T"), tv("T"), TBoolean()) { (mb, v1, v2) =>
+      val ord = CodeOrdering(tv("T").t, missingGreatest = true)
+      ord.compare(mb, v1, v2).cne(0)
     }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -127,5 +127,25 @@ object UtilFunctions extends RegistryFunctions {
       val ord = CodeOrdering(tv("T").t, missingGreatest = true)
       ord.compare(mb, v1, v2).cne(0)
     }
+
+    registerCode("<=", tv("T"), tv("T"), TBoolean()) { (mb, v1, v2) =>
+      val ord = CodeOrdering(tv("T").t, missingGreatest = true)
+      ord.compare(mb, v1, v2) <= 0
+    }
+
+    registerCode(">=", tv("T"), tv("T"), TBoolean()) { (mb, v1, v2) =>
+      val ord = CodeOrdering(tv("T").t, missingGreatest = true)
+      ord.compare(mb, v1, v2) >= 0
+    }
+
+    registerCode("<", tv("T"), tv("T"), TBoolean()) { (mb, v1, v2) =>
+      val ord = CodeOrdering(tv("T").t, missingGreatest = true)
+      ord.compare(mb, v1, v2) < 0
+    }
+
+    registerCode(">", tv("T"), tv("T"), TBoolean()) { (mb, v1, v2) =>
+      val ord = CodeOrdering(tv("T").t, missingGreatest = true)
+      ord.compare(mb, v1, v2) > 0
+    }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -1,10 +1,12 @@
 package is.hail.expr.ir.functions
 
+import is.hail.annotations.{CodeOrdering, Region}
 import is.hail.asm4s._
 import is.hail.expr.ir._
 import is.hail.expr.types._
 import is.hail.utils._
 import is.hail.expr.types.coerce
+import is.hail.asm4s
 
 object UtilFunctions extends RegistryFunctions {
 
@@ -114,6 +116,58 @@ object UtilFunctions extends RegistryFunctions {
 
     registerIR("annotate", tv("T", _.isInstanceOf[TStruct]), tv("U", _.isInstanceOf[TStruct])) { (s, annotations) =>
       InsertFields(s, annotations.asInstanceOf[MakeStruct].fields)
+    }
+
+    registerCodeWithMissingness("==", tv("T"), tv("T"), TBoolean()) { (mb, v1, v2) =>
+      val tactual = tv("T").t match {
+        case tc: ComplexType => tc.representation
+        case t => t
+      }
+      val comparison = (tactual, v1.v, v2.v) match {
+        case (_: TBoolean, x1: Code[Boolean], x2: Code[Boolean]) => x1.ceq(x2)
+        case (_: TInt32, x1: Code[Int], x2: Code[Int]) => x1.ceq(x2)
+        case (_: TInt64, x1: Code[Long], x2: Code[Long]) => x1.ceq(x2)
+        case (_: TFloat32, x1: Code[Float], x2: Code[Float]) => x1.ceq(x2)
+        case (_: TFloat64, x1: Code[Double], x2: Code[Double]) => x1.ceq(x2)
+        case (t, o1: Code[Long], o2: Code[Long]) =>
+          val ord = CodeOrdering(t, missingGreatest = true)
+          ord.compare(mb, mb.getArg[Region](1), o1, mb.getArg[Region](1), o2).ceq(0)
+        case (t, x1, x2) =>
+          throw new UnsupportedOperationException(s"can't compare things of type $t with classes ${ x1.getClass } and ${ x2.getClass }")
+      }
+
+      val setup = Code(v1.setup, v2.setup)
+      val v1m = mb.newLocal[Boolean]
+      val vout = Code(
+        v1m := v1.m,
+        v1m.cne(v2.m).mux(const(false), v1m.mux(const(true), comparison)))
+      EmitTriplet(setup, const(false), vout)
+    }
+
+    registerCodeWithMissingness("!=", tv("T"), tv("T"), TBoolean()) { (mb, v1, v2) =>
+      val tactual = tv("T").t match {
+        case tc: ComplexType => tc.representation
+        case t => t
+      }
+      val comparison = (tactual, v1.v, v2.v) match {
+        case (_: TBoolean, x1: Code[Boolean], x2: Code[Boolean]) => x1.cne(x2)
+        case (_: TInt32, x1: Code[Int], x2: Code[Int]) => x1.cne(x2)
+        case (_: TInt64, x1: Code[Long], x2: Code[Long]) => x1.cne(x2)
+        case (_: TFloat32, x1: Code[Float], x2: Code[Float]) => x1.cne(x2)
+        case (_: TFloat64, x1: Code[Double], x2: Code[Double]) => x1.cne(x2)
+        case (t, o1: Code[Long], o2: Code[Long]) =>
+          val ord = CodeOrdering(t, missingGreatest = true)
+          ord.compare(mb, mb.getArg[Region](1), o1, mb.getArg[Region](1), o2).cne(0)
+        case (t, x1, x2) =>
+          throw new UnsupportedOperationException(s"can't compare things of type $t with classes ${ x1.getClass } and ${ x2.getClass }")
+      }
+
+      val setup = Code(v1.setup, v2.setup)
+      val v1m = mb.newLocal[Boolean]
+      val vout = Code(
+        v1m := v1.m,
+        v1m.cne(v2.m).mux(const(true), v1m.mux(const(false), comparison)))
+      EmitTriplet(setup, const(false), vout)
     }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir.functions
 
-import is.hail.annotations.{CodeOrdering, Region}
+import is.hail.annotations.CodeOrdering
 import is.hail.asm4s._
 import is.hail.expr.ir._
 import is.hail.expr.types._

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -16,11 +16,16 @@ object UtilFunctions extends RegistryFunctions {
     registerIR("size", TArray(tv("T")))(ArrayLen)
 
     registerIR("sum", TArray(tnum("T"))) { a =>
+      val sum = genUID()
+      val v = genUID()
       val zero = Literal(0, coerce[TArray](a.typ).elementType)
-      ArrayFold(a, zero, "sum", "v", If(IsNA(Ref("v")), Ref("sum"), ApplyBinaryPrimOp(Add(), Ref("sum"), Ref("v"))))
+      ArrayFold(a, zero, sum, v, If(IsNA(Ref(v)), Ref(sum), ApplyBinaryPrimOp(Add(), Ref(sum), Ref(v))))
     }
 
-    registerIR("*", TArray(tnum("T")), tv("T")){ (a, c) => ArrayMap(a, "imul", ApplyBinaryPrimOp(Multiply(), Ref("imul"), c)) }
+    registerIR("*", TArray(tnum("T")), tv("T")){ (a, c) =>
+      val imul = genUID()
+      ArrayMap(a, imul, ApplyBinaryPrimOp(Multiply(), Ref(imul), c))
+    }
 
     registerIR("sum", TAggregable(tnum("T")))(ApplyAggOp(_, Sum(), FastSeq()))
 

--- a/src/main/scala/is/hail/expr/ir/package.scala
+++ b/src/main/scala/is/hail/expr/ir/package.scala
@@ -36,12 +36,13 @@ package object ir {
 
   // Build consistent expression for a filter-condition with keep polarity,
   // using Let to manage missing-ness.
-  def filterPredicateWithKeep(irPred: ir.IR, keep: Boolean, letName: String): ir.IR = {
-    ir.Let(letName,
+  def filterPredicateWithKeep(irPred: ir.IR, keep: Boolean): ir.IR = {
+    val pred = genUID()
+    ir.Let(pred,
       if (keep) irPred else ir.ApplyUnaryPrimOp(ir.Bang(), irPred),
-      ir.If(ir.IsNA(ir.Ref(letName)),
+      ir.If(ir.IsNA(ir.Ref(pred)),
         ir.False(),
-        ir.Ref(letName)))
+        ir.Ref(pred)))
   }
 
   private[ir] def coerce[T](c: Code[_]): Code[T] = asm4s.coerce(c)

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -458,7 +458,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
     pred match {
       case Some(irPred) =>
         new Table(hc,
-          TableFilter(tir, ir.filterPredicateWithKeep(irPred, keep, "filter_pred"))
+          TableFilter(tir, ir.filterPredicateWithKeep(irPred, keep))
         )
       case None =>
         log.warn(s"Table.filter found no AST to IR conversion: ${ PrettyAST(filterAST) }")

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1284,7 +1284,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     pred match {
       case Some(irPred) =>
         new MatrixTable(hc,
-          FilterColsIR(ast, ir.filterPredicateWithKeep(irPred, keep, "filterCols_pred"))
+          FilterColsIR(ast, ir.filterPredicateWithKeep(irPred, keep))
         )
       case None =>
         log.info(s"filterCols: No AST to IR conversion. Fallback for predicate ${ PrettyAST(filterAST) }")
@@ -1316,7 +1316,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     pred match {
       case Some(irPred) =>
         new MatrixTable(hc,
-          FilterRowsIR(ast, ir.filterPredicateWithKeep(irPred, keep, "filterRows_pred"))
+          FilterRowsIR(ast, ir.filterPredicateWithKeep(irPred, keep))
         )
       case _ =>
         log.info(s"filterRows: No AST to IR conversion. Fallback for predicate ${ PrettyAST(filterAST) }")
@@ -2185,7 +2185,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     val filterAST = Parser.parseToAST(filterExpr, ec)
     filterAST.toIR() match {
       case Some(x) if useIR(entryAxis, filterAST) =>
-        copyAST(MatrixFilterEntries(ast, ir.filterPredicateWithKeep(x, keep, "filterEntriesPred")))
+        copyAST(MatrixFilterEntries(ast, ir.filterPredicateWithKeep(x, keep)))
 
       case _ =>
         log.warn(s"filter_entries found no AST to IR conversion: ${ PrettyAST(filterAST) }")

--- a/src/test/scala/is/hail/expr/ir/CompileSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/CompileSuite.scala
@@ -651,6 +651,5 @@ class CompileSuite {
     val region = Region()
     val off = f(region)
     assert(TString.loadString(region, off) == "hello")
-
   }
 }

--- a/src/test/scala/is/hail/expr/ir/CompileSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/CompileSuite.scala
@@ -639,4 +639,18 @@ class CompileSuite {
     val expected = grch37.isValidContig("X") && grch37.isValidContig("Y") && grch38.isValidContig("X")
     assert(fb.result()()("X", "Y") == expected)
   }
+
+  @Test
+  def testStringConstantWorks() {
+    val ir = Str("hello")
+
+    val fb = EmitFunctionBuilder[Region, Long]
+    doit(ir, fb)
+    val f = fb.result()()
+
+    val region = Region()
+    val off = f(region)
+    assert(TString.loadString(region, off) == "hello")
+
+  }
 }

--- a/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -30,8 +30,8 @@ object TestRegisterFunctions extends RegistryFunctions {
     registerJavaStaticFunction("compare", TInt32(), TInt32(), TInt32())(classOf[java.lang.Integer], "compare")
     registerScalaFunction("foobar1", TInt32())(ScalaTestObject.getClass, "testFunction")
     registerScalaFunction("foobar2", TInt32())(ScalaTestCompanion.getClass, "testFunction")
-    registerCode("testCodeUnification", tnum("x"), tv("x", _.isInstanceOf[TInt32]), tv("x")){ (_, a: Code[Int], b: Code[Int]) => a + b }
-    registerCode("testCodeUnification2", tv("x"), tv("x")){ (_, a: Code[Long]) => a }
+    registerCode("testCodeUnification", tnum("x"), tv("x", _.isInstanceOf[TInt32]), tv("x")){ case (_, a: Code[Int], b: Code[Int]) => a + b }
+    registerCode("testCodeUnification2", tv("x"), tv("x")){ case (_, a: Code[Long]) => a }
   }
 }
 

--- a/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -5,9 +5,9 @@ import is.hail.check.{Gen, Prop}
 import is.hail.asm4s._
 import is.hail.expr.ir._
 import is.hail.expr.types._
-import is.hail.utils.Interval
-import org.apache.spark.sql.Row
 import org.testng.annotations.Test
+import is.hail.utils._
+import org.apache.spark.sql.Row
 
 class OrderingSuite {
 
@@ -32,6 +32,53 @@ class OrderingSuite {
       fb.emit(stagedOrdering.compare(fb.apply_method, fb.getArg[Region](1), fb.getArg[Long](2), fb.getArg[Region](1), fb.getArg[Long](3)))
       val f = fb.result()()
       f(region, v1, v2) == compare
+    }
+    p.check()
+  }
+
+  @Test def testEqualityInEmitFunction() {
+    val compareGen = Type.genArb.flatMap(t => Gen.zip(Gen.const(t), t.genNonmissingValue, t.genNonmissingValue))
+    val p = Prop.forAll(compareGen) { case (t, a1, a2) =>
+
+      val ttup = TTuple(t)
+      val region = Region()
+      val rvb = new RegionValueBuilder(region)
+
+      rvb.start(ttup)
+      rvb.addAnnotation(ttup, Row(a1))
+      val tup1 = rvb.end()
+
+      rvb.start(ttup)
+      rvb.addAnnotation(ttup, Row(a2))
+      val tup2 = rvb.end()
+
+      val v1 = ttup.loadField(region, tup1, 0)
+      val v2 = ttup.loadField(region, tup2, 0)
+
+      val compare = t.unsafeOrdering(true).compare(region, v1, region, v2)
+
+      val ir = ApplySpecial("==", FastSeq(GetTupleElement(In(0, ttup), 0), GetTupleElement(In(1, ttup), 0)))
+      val irfb = EmitFunctionBuilder[Region, Long, Boolean, Long, Boolean, Boolean]
+
+      Infer(ir)
+      Emit(ir, irfb)
+
+      val irf = irfb.result()()
+      assert(irf(region, tup1, false, tup2, false) == (compare == 0))
+      assert(irf(region, tup1, false, tup1, false))
+      assert(irf(region, tup2, false, tup2, false))
+
+      val ir2 = ApplySpecial("!=", FastSeq(GetTupleElement(In(0, TTuple(t)), 0), GetTupleElement(In(1, TTuple(t)), 0)))
+      val irfb2 = EmitFunctionBuilder[Region, Long, Boolean, Long, Boolean, Boolean]
+
+      Infer(ir2)
+      Emit(ir2, irfb2)
+
+      val irf2 = irfb2.result()()
+      assert(irf2(region, tup1, false, tup2, false) == (compare != 0))
+      assert(!irf2(region, tup1, false, tup1, false))
+      assert(!irf2(region, tup2, false, tup2, false))
+      true
     }
     p.check()
   }

--- a/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -57,7 +57,7 @@ class OrderingSuite {
 
       val compare = t.unsafeOrdering(true).compare(region, v1, region, v2)
 
-      val ir = ApplySpecial("==", FastSeq(GetTupleElement(In(0, ttup), 0), GetTupleElement(In(1, ttup), 0)))
+      val ir = Apply("==", FastSeq(GetTupleElement(In(0, ttup), 0), GetTupleElement(In(1, ttup), 0)))
       val irfb = EmitFunctionBuilder[Region, Long, Boolean, Long, Boolean, Boolean]
 
       Infer(ir)
@@ -68,7 +68,7 @@ class OrderingSuite {
       assert(irf(region, tup1, false, tup1, false))
       assert(irf(region, tup2, false, tup2, false))
 
-      val ir2 = ApplySpecial("!=", FastSeq(GetTupleElement(In(0, TTuple(t)), 0), GetTupleElement(In(1, TTuple(t)), 0)))
+      val ir2 = Apply("!=", FastSeq(GetTupleElement(In(0, TTuple(t)), 0), GetTupleElement(In(1, TTuple(t)), 0)))
       val irfb2 = EmitFunctionBuilder[Region, Long, Boolean, Long, Boolean, Boolean]
 
       Infer(ir2)

--- a/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -5,9 +5,9 @@ import is.hail.check.{Gen, Prop}
 import is.hail.asm4s._
 import is.hail.expr.ir._
 import is.hail.expr.types._
-import org.testng.annotations.Test
 import is.hail.utils._
 import org.apache.spark.sql.Row
+import org.testng.annotations.Test
 
 class OrderingSuite {
 


### PR DESCRIPTION
uses CodeOrdering to implement staged comparison operations for IR code.

also adds a string constant IR node.