### PR TITLE
ContextRDD Changes for forthcoming things

### DIFF
--- a/src/main/scala/is/hail/sparkextras/ContextPairRDDFunctions.scala
+++ b/src/main/scala/is/hail/sparkextras/ContextPairRDDFunctions.scala
@@ -15,4 +15,12 @@ class ContextPairRDDFunctions[C <: AutoCloseable, K: ClassTag, V: ClassTag](
     ContextRDD.weaken(
       new ShuffledRDD[K, V, V](crdd.run, p).setKeyOrdering(o),
       crdd.mkc)
+
+  def partitionBy(p: Partitioner): ContextRDD[C, (K, V)] =
+    if (crdd.partitioner.contains(p)) crdd
+    else ContextRDD.weaken(
+      new ShuffledRDD[K, V, V](crdd.run, p),
+      crdd.mkc)
+
+  def values: ContextRDD[C, V] = crdd.map(_._2)
 }

--- a/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -324,8 +324,8 @@ class ContextRDD[C <: AutoCloseable, T: ClassTag](
     }
   }
 
-  // FIXME: this method is easy to use wrong because it shares the context
-  // between both producers and the consumer
+  // WARNING: this method is easy to use wrong because it shares the context
+  // between the two producers and the one consumer
   def zipPartitions[U: ClassTag, V: ClassTag](
     that: ContextRDD[C, U],
     preservesPartitioning: Boolean = false
@@ -333,8 +333,8 @@ class ContextRDD[C <: AutoCloseable, T: ClassTag](
   ): ContextRDD[C, V] =
     czipPartitions[U, V](that, preservesPartitioning)((_, l, r) => f(l, r))
 
-  // FIXME: this method is easy to use wrong because it shares the context
-  // between both producers and the consumer
+  // WARNING: this method is easy to use wrong because it shares the context
+  // between the two producers and the one consumer
   def czipPartitions[U: ClassTag, V: ClassTag](
     that: ContextRDD[C, U],
     preservesPartitioning: Boolean = false


### PR DESCRIPTION
Added:

 - `textFilesLines` to go directly form array of file names to ContextRDD of strings

 - `parallelize` with an `Option[Int]` (in addition to an overloaded version with an int parameter having a default value)

 - moved `run` to the top since it's super important

 - eliminated two useless methods

 - colocated `zipPartitions` with other zip-like methods

 - added some `*AndContext*` methods that let the API user decide what context to give to the producer of values

The AndContext methods are useful for these two situations:

 - One input value becomes multiple output values. We want to clear the input region separately from clearing the output region.

 - A zipPartitions / join where there are two inputs, we might want to use the same region for both inputs, but use a new region for the output. We might also want to use three distinct regions. All of these options are enabled by `czipPartitionsAndContext`