### PR TITLE
Use Encoder/Decoder in RVD.persist

### DIFF
--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -45,7 +45,7 @@ object RVDSpec {
       val f = path + "/parts/" + p
       val in = hConf.unsafeReader(f)
       HailContext.readRowsPartition(rowType, codecSpec)(0, in)
-        .map { rv => SafeRow(rowType, rv.region, rv.offset) }
+        .map(rv => SafeRow(rowType, rv.region, rv.offset))
     }.toFastIndexedSeq
   }
 }

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -45,11 +45,7 @@ object RVDSpec {
       val f = path + "/parts/" + p
       val in = hConf.unsafeReader(f)
       HailContext.readRowsPartition(rowType, codecSpec)(0, in)
-        .map { rv =>
-        val r = SafeRow(rowType, rv.region, rv.offset)
-        ctx.region.clear()
-        r
-      }
+        .map { rv => SafeRow(rowType, rv.region, rv.offset) }
     }.toFastIndexedSeq
   }
 }

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -205,6 +205,7 @@ trait RVD {
           val region = Region()
           val rv2 = RegionValue(region)
           it.map { bytes =>
+            region.clear()
             using(new ByteArrayInputStream(bytes)) { bais =>
               val dec = persistCodec.buildDecoder(bais)
               rv2.setOffset(dec.readRegionValue(localRowType, region))

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -44,13 +44,11 @@ object RVDSpec {
     partFiles.flatMap { p =>
       val f = path + "/parts/" + p
       val in = hConf.unsafeReader(f)
-      using(RVDContext.default) { ctx =>
-        HailContext.readRowsPartition(rowType, codecSpec)(ctx, in)
-          .map { rv =>
-            val r = SafeRow(rowType, rv.region, rv.offset)
-            ctx.region.clear()
-            r
-          }
+      HailContext.readRowsPartition(rowType, codecSpec)(0, in)
+        .map { rv =>
+        val r = SafeRow(rowType, rv.region, rv.offset)
+        ctx.region.clear()
+        r
       }
     }.toFastIndexedSeq
   }

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -187,7 +187,10 @@ trait RVD {
   protected def persistRVRDD(level: StorageLevel): PersistedRVRDD = {
     val localRowType = rowType
 
-    val persistCodec = CodecSpec.default
+    val persistCodec =
+      new PackCodecSpec(
+        new BlockingBufferSpec(32 * 1024,
+          new StreamBlockBufferSpec))
 
     // copy, persist region values
     val persistedRDD = rdd.mapPartitions { it =>


### PR DESCRIPTION
I also included a little change to use `Region.scoped` for writing a local `IndexedSeq[Annotation]`. In general, we cannot move Region off-heap until all the allocations of Regions are matched with `Region.close()`.

We don't use the context's region yet in the persist. I'll introduce that in a later pull request. This just avoids serializing regions and region values, which will soon become off-heap, non-serializable values.