### PR TITLE
First use of RVDContext's region

### DIFF
--- a/src/main/scala/is/hail/io/RowStore.scala
+++ b/src/main/scala/is/hail/io/RowStore.scala
@@ -719,7 +719,7 @@ object RichContextRDDRegionValue {
     it.foreach { rv =>
       en.writeByte(1)
       en.writeRegionValue(t, rv.region, rv.offset)
-      ctx.reset()
+      ctx.region.clear()
       rowCount += 1
     }
 

--- a/src/main/scala/is/hail/io/RowStore.scala
+++ b/src/main/scala/is/hail/io/RowStore.scala
@@ -4,7 +4,7 @@ import is.hail.annotations._
 import is.hail.expr.JSONAnnotationImpex
 import is.hail.expr.types._
 import is.hail.io.compress.LZ4Utils
-import is.hail.rvd.{OrderedRVDPartitioner, OrderedRVDSpec, RVDSpec, UnpartitionedRVDSpec}
+import is.hail.rvd.{OrderedRVDPartitioner, OrderedRVDSpec, RVDContext, RVDSpec, UnpartitionedRVDSpec}
 import is.hail.sparkextras.ContextRDD
 import is.hail.utils._
 import org.apache.spark.rdd.RDD
@@ -712,13 +712,14 @@ final class PackEncoder(out: OutputBuffer) extends Encoder {
 }
 
 object RichContextRDDRegionValue {
-  def writeRowsPartition(t: TStruct, codecSpec: CodecSpec)(i: Int, it: Iterator[RegionValue], os: OutputStream): Long = {
+  def writeRowsPartition(t: TStruct, codecSpec: CodecSpec)(ctx: RVDContext, it: Iterator[RegionValue], os: OutputStream): Long = {
     val en = codecSpec.buildEncoder(os)
     var rowCount = 0L
 
     it.foreach { rv =>
       en.writeByte(1)
       en.writeRegionValue(t, rv.region, rv.offset)
+      ctx.reset()
       rowCount += 1
     }
 
@@ -730,7 +731,7 @@ object RichContextRDDRegionValue {
   }
 }
 
-class RichContextRDDRegionValue[C <: AutoCloseable](val crdd: ContextRDD[C, RegionValue]) extends AnyVal {
+class RichContextRDDRegionValue(val crdd: ContextRDD[RVDContext, RegionValue]) extends AnyVal {
   def writeRows(path: String, t: TStruct, codecSpec: CodecSpec): (Array[String], Array[Long]) = {
     crdd.writePartitions(path, RichContextRDDRegionValue.writeRowsPartition(t, codecSpec))
   }

--- a/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -5,7 +5,8 @@ import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.expr.types._
 import is.hail.io.{VCFAttributes, VCFMetadata}
-import is.hail.rvd.OrderedRVD
+import is.hail.rvd.{OrderedRVD, RVDContext}
+import is.hail.sparkextras.ContextRDD
 import is.hail.utils._
 import is.hail.variant._
 import org.apache.hadoop
@@ -711,12 +712,18 @@ object LoadVCF {
   }
 
   // parses the Variant (key), leaves the rest to f
-  def parseLines[C](makeContext: () => C)(f: (C, VCFLine, RegionValueBuilder) => Unit)(
-    lines: RDD[WithContext[String]], t: Type, rg: Option[ReferenceGenome], contigRecoding: Map[String, String]): RDD[RegionValue] = {
-    lines.mapPartitions { it =>
+  def parseLines[C](
+    makeContext: () => C
+  )(f: (C, VCFLine, RegionValueBuilder) => Unit
+  )(lines: ContextRDD[RVDContext, WithContext[String]],
+    t: Type,
+    rg: Option[ReferenceGenome],
+    contigRecoding: Map[String, String]
+  ): ContextRDD[RVDContext, RegionValue] = {
+    lines.cmapPartitions { (ctx, it) =>
       new Iterator[RegionValue] {
-        val region = Region()
-        val rvb = new RegionValueBuilder(region)
+        val region = ctx.region
+        val rvb = ctx.rvb
         val rv = RegionValue(region)
 
         val context: C = makeContext()
@@ -729,7 +736,6 @@ object LoadVCF {
             val line = lwc.value
             try {
               val vcfLine = new VCFLine(line)
-              region.clear()
               rvb.start(t)
               rvb.startStruct()
               present = vcfLine.parseAddVariant(rvb, rg, contigRecoding)
@@ -845,7 +851,7 @@ object LoadVCF {
 
     val headerLinesBc = sc.broadcast(headerLines1)
 
-    val lines = sc.textFilesLines(files, nPartitions.getOrElse(sc.defaultMinPartitions))
+    val lines = ContextRDD.textFilesLines[RVDContext](sc, files, nPartitions)
 
     val matrixType: MatrixType = MatrixType.fromParts(
       TStruct.empty(true),
@@ -895,7 +901,7 @@ object LoadVCF {
         }
         rvb.endArray()
       }(lines, rowType, rg, contigRecoding),
-      Some(justVariants), None)
+      justVariants)
 
     new MatrixTable(hc,
       matrixType,

--- a/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -246,7 +246,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     val hadoop = blocks.sparkContext.hadoopConfiguration
     hadoop.mkDir(uri)
 
-    def writeBlock(i: Int, it: Iterator[((Int, Int), BDM[Double])], os: OutputStream): Int = {
+    def writeBlock(it: Iterator[((Int, Int), BDM[Double])], os: OutputStream): Int = {
       assert(it.hasNext)
       val bdm = it.next()._2
       assert(!it.hasNext)

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -29,8 +29,6 @@ class OrderedRVD(
     rdd: RDD[RegionValue]
   ) = this(typ, partitioner, ContextRDD.weaken[RVDContext](rdd))
 
-  val rdd = crdd.run
-
   def rowType: TStruct = typ.rowType
 
   def updateType(newTyp: OrderedRVDType): OrderedRVD =

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -670,7 +670,7 @@ object OrderedRVD {
 
   def adjustBoundsAndShuffle(
     typ: OrderedRVDType,
-      partitioner: OrderedRVDPartitioner,
+    partitioner: OrderedRVDPartitioner,
     rdd: RDD[RegionValue]
   ): OrderedRVD = adjustBoundsAndShuffle(
     typ,

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -140,7 +140,7 @@ trait RVD {
 
   def crdd: ContextRDD[RVDContext, RegionValue]
 
-  def rdd: RDD[RegionValue] =  crdd.run
+  def rdd: RDD[RegionValue] = crdd.run
 
   def sparkContext: SparkContext = crdd.sparkContext
 

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -137,7 +137,7 @@ trait RVD {
 
   def crdd: ContextRDD[RVDContext, RegionValue]
 
-  def rdd: RDD[RegionValue]
+  def rdd: RDD[RegionValue] =  crdd.run
 
   def sparkContext: SparkContext = crdd.sparkContext
 

--- a/src/main/scala/is/hail/rvd/RVDContext.scala
+++ b/src/main/scala/is/hail/rvd/RVDContext.scala
@@ -28,10 +28,6 @@ class RVDContext(r: Region) extends AutoCloseable {
   private[this] val theRvb = new RegionValueBuilder(r)
   def rvb = theRvb
 
-  def reset(): Unit = {
-    r.clear()
-  }
-
   // frees the memory associated with this context
   def close(): Unit = {
     var e: Exception = null

--- a/src/main/scala/is/hail/rvd/UnpartitionedRVD.scala
+++ b/src/main/scala/is/hail/rvd/UnpartitionedRVD.scala
@@ -20,8 +20,6 @@ class UnpartitionedRVD(val rowType: TStruct, val crdd: ContextRDD[RVDContext, Re
   def this(rowType: TStruct, rdd: RDD[RegionValue]) =
     this(rowType, ContextRDD.weaken[RVDContext](rdd))
 
-  val rdd = crdd.run
-
   def filter(f: (RegionValue) => Boolean): UnpartitionedRVD = new UnpartitionedRVD(rowType, crdd.filter(f))
 
   def persist(level: StorageLevel): UnpartitionedRVD = {

--- a/src/main/scala/is/hail/utils/richUtils/Implicits.scala
+++ b/src/main/scala/is/hail/utils/richUtils/Implicits.scala
@@ -5,7 +5,8 @@ import java.io.InputStream
 import breeze.linalg.DenseMatrix
 import is.hail.annotations.{JoinedRegionValue, Region, RegionValue}
 import is.hail.asm4s.Code
-import is.hail.io.{RichContextRDDRegionValue}
+import is.hail.io.RichContextRDDRegionValue
+import is.hail.rvd.RVDContext
 import is.hail.sparkextras._
 import is.hail.utils.{ArrayBuilder, HailIterator, JSONWriter, MultiArray2, Truncatable, WithContext}
 import org.apache.hadoop
@@ -73,7 +74,7 @@ trait Implicits {
 
   implicit def toRichRDD[T](r: RDD[T])(implicit tct: ClassTag[T]): RichRDD[T] = new RichRDD(r)
 
-  implicit def toRichContextRDDRegionValue[C <: AutoCloseable](r: ContextRDD[C, RegionValue]): RichContextRDDRegionValue[C] = new RichContextRDDRegionValue(r)
+  implicit def toRichContextRDDRegionValue(r: ContextRDD[RVDContext, RegionValue]): RichContextRDDRegionValue = new RichContextRDDRegionValue(r)
 
   implicit def toRichRDDByteArray(r: RDD[Array[Byte]]): RichRDDByteArray = new RichRDDByteArray(r)
 
@@ -111,5 +112,5 @@ trait Implicits {
 
   implicit def toContextPairRDDFunctions[C <: AutoCloseable, K: ClassTag, V: ClassTag](x: ContextRDD[C, (K, V)]): ContextPairRDDFunctions[C, K, V] = new ContextPairRDDFunctions(x)
 
-  implicit def toRichContextRDD[C <: AutoCloseable, T: ClassTag](x: ContextRDD[C, T]): RichContextRDD[C, T] = new RichContextRDD(x)
+  implicit def toRichContextRDD[T: ClassTag](x: ContextRDD[RVDContext, T]): RichContextRDD[T] = new RichContextRDD(x)
 }

--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -2,6 +2,7 @@ package is.hail.utils.richUtils
 
 import java.io.OutputStream
 
+import is.hail.rvd.RVDContext
 import is.hail.sparkextras._
 import is.hail.utils._
 import org.apache.commons.lang3.StringUtils
@@ -183,9 +184,12 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
   }
 
   def writePartitions(path: String,
-    write: (Int, Iterator[T], OutputStream) => Long,
+    write: (Iterator[T], OutputStream) => Long,
     remapPartitions: Option[(Array[Int], Int)] = None
   )(implicit tct: ClassTag[T]
   ): (Array[String], Array[Long]) =
-    ContextRDD.weaken[TrivialContext](r).writePartitions(path, write, remapPartitions)
+    ContextRDD.weaken[RVDContext](r).writePartitions(
+      path,
+      (_, it, os) => write(it, os),
+      remapPartitions)
 }


### PR DESCRIPTION
I could not re-open [the old PR](https://github.com/hail-is/hail/pull/3392) because I force-pushed after a rebase.

---

We want all allocations of `Region` to be controlled with a `using` or within a `RVDContext` (which will be appropriately closed). When we have achieved this, we can move the `Region` off-heap which provides a number of benefits including the use of raw-pointers in our Hail Object Representation as well as allocation free communication with other languages.

This PR makes `LoadVCF` and `HailContext.readRows` use the regions in the `RVDContext`. Note that the _consumer_ is responsible for clearing the region when they're done with the current values. This is why `writePartitions` now includes `ctx.clear()`. Moreover, _producers_ must _not_ clear the region.

These changes are tested by our whole infrastructure, but in particular, `is.hail.annotations.AnnotationsSuite.testReadWrite` exercises a lot of this.

NB: We no longer clear the region between each read of a row. This means we could blow memory if we don't clear in the consumer. The other consumers are: aggregations, collects, shuffles, and joins. The tests pass though, so I guess I'm not too concerned for now. Once this is merged, I'll follow swiftly with uses of the RVDContext's region else where in our infrastructure.

cc: @cseed 

---

I also included a couple miscellaneous clean ups like unifying `OrderedRVD.rdd` and `UnpartitionedRVD.rdd` as well as adding a use of `Region.scoped` in `HailContext`.

