### PR TITLE
Use RVDContext in MatrixRead zip

### DIFF
--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -408,42 +408,25 @@ case class MatrixRead(
         } else {
           val entriesRVD = spec.entriesComponent.read(hc, path)
           val entriesRowType = entriesRVD.rowType
-          rowsRVD.zipPartitionsPreservesPartitioning(
-            typ.orvdType,
-            entriesRVD
-          ) { case (it1, it2) =>
-            val rvb = new RegionValueBuilder()
-
-            new Iterator[RegionValue] {
-              def hasNext: Boolean = {
-                val hn = it1.hasNext
-                assert(hn == it2.hasNext)
-                hn
-              }
-
-              def next(): RegionValue = {
-                val rv1 = it1.next()
-                val rv2 = it2.next()
-                val region = rv2.region
-                rvb.set(region)
-                rvb.start(fullRowType)
-                rvb.startStruct()
-                var i = 0
-                while (i < localEntriesIndex) {
-                  rvb.addField(rowType, rv1, i)
-                  i += 1
-                }
-                rvb.addField(entriesRowType, rv2, 0)
-                i += 1
-                while (i < fullRowType.size) {
-                  rvb.addField(rowType, rv1, i - 1)
-                  i += 1
-                }
-                rvb.endStruct()
-                rv2.set(region, rvb.end())
-                rv2
-              }
+          rowsRVD.zip(typ.orvdType, entriesRVD) { (ctx, rv1, rv2) =>
+            val rvb = ctx.rvb
+            val region = ctx.region
+            rvb.start(fullRowType)
+            rvb.startStruct()
+            var i = 0
+            while (i < localEntriesIndex) {
+              rvb.addField(rowType, rv1, i)
+              i += 1
+             }
+            rvb.addField(entriesRowType, rv2, 0)
+            i += 1
+            while (i < fullRowType.size) {
+              rvb.addField(rowType, rv1, i - 1)
+              i += 1
             }
+            rvb.endStruct()
+            rv2.set(region, rvb.end())
+            rv2
           }
         }
       }

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -384,6 +384,16 @@ class OrderedRVD(
       partitioner,
       this.rdd.zipPartitions(that.rdd, preservesPartitioning = true)(zipper))
 
+  def zip(
+    newTyp: OrderedRVDType,
+    that: RVD
+  )(zipper: (RVDContext, RegionValue, RegionValue) => RegionValue
+  ): OrderedRVD =
+    OrderedRVD(
+      newTyp,
+      partitioner,
+      this.crdd.czip(that.crdd, preservesPartitioning = true)(zipper))
+
   def writeRowsSplit(
     path: String,
     t: MatrixType,


### PR DESCRIPTION
This Region will get cleared by consumers.

I introduced the zip primitive which is a safer way to
zip two RVDs because it does not rely on the user correctly
clearing the regions used by the left and right hand sides
of the zip.

cc: @cseed