### PR TITLE
sets, dicts, and sorted arrays in IR

### DIFF
--- a/src/main/scala/is/hail/annotations/CodeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/CodeOrdering.scala
@@ -25,10 +25,15 @@ case class CodeOrdering(t: Type, missingGreatest: Boolean) {
     Code.invokeStatic[java.lang.Long, Long, Long, Int]("compare", v1, v2)
 
   private[this] def floatCompare(v1: Code[Float], v2: Code[Float]): Code[Int] =
-    Code.invokeStatic[java.lang.Float, Float, Float, Int]("compare", v1, v2)
+    v1.ceq(v2).mux(0, Code.invokeStatic[java.lang.Float, Float, Float, Int]("compare", v1, v2))
 
   private[this] def doubleCompare(v1: Code[Double], v2: Code[Double]): Code[Int] =
-    Code.invokeStatic[java.lang.Double, Double, Double, Int]("compare", v1, v2)
+    v1.ceq(v2).mux(0, Code.invokeStatic[java.lang.Double, Double, Double, Int]("compare", v1, v2))
+
+  def compare(m1: Code[Boolean], v1: Code[_], m2: Code[Boolean], v2: Code[_])(mb: EmitMethodBuilder): Code[Int] = {
+    val m = mb.newLocal[Boolean]
+    Code(m := m1, m.cne(m2).mux(if (missingGreatest) m.mux(1, -1) else m.mux(-1, 1), m.mux(0, compare(mb, v1, v2))))
+  }
 
   def compare(mb: EmitMethodBuilder, v1: Code[_], v2: Code[_]): Code[Int] = {
     t match {

--- a/src/main/scala/is/hail/annotations/CodeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/CodeOrdering.scala
@@ -31,13 +31,9 @@ case class CodeOrdering(t: Type, missingGreatest: Boolean) {
     Code.invokeStatic[java.lang.Double, Double, Double, Int]("compare", v1, v2)
 
   def compare(mb: EmitMethodBuilder, v1: Code[_], v2: Code[_]): Code[Int] = {
-    val trep = t match {
-      case tc: ComplexType => tc.representation
-      case _ => t
-    }
-    trep match {
+    t match {
       case _: TBoolean => booleanCompare(asm4s.coerce[Boolean](v1), asm4s.coerce[Boolean](v2))
-      case _: TInt32 => intCompare(asm4s.coerce[Int](v1), asm4s.coerce[Int](v2))
+      case _: TInt32 | _: TCall => intCompare(asm4s.coerce[Int](v1), asm4s.coerce[Int](v2))
       case _: TInt64 => longCompare(asm4s.coerce[Long](v1), asm4s.coerce[Long](v2))
       case _: TFloat32 => floatCompare(asm4s.coerce[Float](v1), asm4s.coerce[Float](v2))
       case _: TFloat64 => doubleCompare(asm4s.coerce[Double](v1), asm4s.coerce[Double](v2))

--- a/src/main/scala/is/hail/annotations/CodeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/CodeOrdering.scala
@@ -30,8 +30,10 @@ case class CodeOrdering(t: Type, missingGreatest: Boolean) {
   private[this] def doubleCompare(v1: Code[Double], v2: Code[Double]): Code[Int] =
     v1.ceq(v2).mux(0, Code.invokeStatic[java.lang.Double, Double, Double, Int]("compare", v1, v2))
 
-  def compare(m1: Code[Boolean], v1: Code[_], m2: Code[Boolean], v2: Code[_])(mb: EmitMethodBuilder): Code[Int] = {
+  def compare(mb: EmitMethodBuilder, x1: (Code[Boolean], Code[_]), x2: (Code[Boolean], Code[_])): Code[Int] = {
     val m = mb.newLocal[Boolean]
+    val (m1, v1) = x1
+    val (m2, v2) = x2
     Code(m := m1, m.cne(m2).mux(if (missingGreatest) m.mux(1, -1) else m.mux(-1, 1), m.mux(0, compare(mb, v1, v2))))
   }
 

--- a/src/main/scala/is/hail/annotations/CodeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/CodeOrdering.scala
@@ -4,7 +4,7 @@ import java.io.PrintStream
 
 import is.hail.asm4s
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitMethodBuilder, EmitTriplet}
+import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.expr.types._
 import is.hail.utils._
 import is.hail.expr.types.coerce

--- a/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -59,9 +59,9 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: Type, var
       case _: TBaseStruct => start(true)
       case _: TBinary =>
         assert(pOffset == null)
-        startOffset.store(endOffset)
+        startOffset := endOffset
       case _ =>
-        startOffset.store(region.allocate(typ.alignment, typ.byteSize))
+        startOffset := region.allocate(typ.alignment, typ.byteSize)
     }
   }
 
@@ -114,7 +114,8 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: Type, var
       boff := region.appendInt(bytes.length()),
       toUnit(region.appendBytes(bytes)),
       typ.fundamentalType match {
-        case _: TBinary => _empty
+        case _: TBinary =>
+          startOffset := boff
         case _ =>
           region.storeAddress(currentOffset, boff)
       })

--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -412,6 +412,8 @@ class CodeBoolean(val lhs: Code[Boolean]) extends AnyVal {
 
   // on the JVM Booleans are represented as Ints
   def toI: Code[Int] = lhs.asInstanceOf[Code[Int]]
+
+  def toS: Code[String] = lhs.mux("true", "false")
 }
 
 class CodeInt(val lhs: Code[Int]) extends AnyVal {
@@ -513,6 +515,8 @@ class CodeLong(val lhs: Code[Long]) extends AnyVal {
   def toF: Code[Float] = Code(lhs, new InsnNode(L2F))
 
   def toD: Code[Double] = Code(lhs, new InsnNode(L2D))
+
+  def toS: Code[String] = Code.invokeStatic[java.lang.Long, Long, String]("toString", lhs)
 }
 
 class CodeFloat(val lhs: Code[Float]) extends AnyVal {
@@ -545,6 +549,8 @@ class CodeFloat(val lhs: Code[Float]) extends AnyVal {
   def toF: Code[Float] = lhs
 
   def toD: Code[Double] = Code(lhs, new InsnNode(F2D))
+
+  def toS: Code[String] = Code.invokeStatic[java.lang.Float, Float, String]("toString", lhs)
 }
 
 class CodeDouble(val lhs: Code[Double]) extends AnyVal {
@@ -577,6 +583,8 @@ class CodeDouble(val lhs: Code[Double]) extends AnyVal {
   def toF: Code[Float] = Code(lhs, new InsnNode(D2F))
 
   def toD: Code[Double] = lhs
+
+  def toS: Code[String] = Code.invokeStatic[java.lang.Double, Double, String]("toString", lhs)
 }
 
 class CodeString(val lhs: Code[String]) extends AnyVal {

--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -689,6 +689,8 @@ trait Settable[T] {
   def store(rhs: Code[T]): Code[Unit]
 
   def :=(rhs: Code[T]): Code[Unit] = store(rhs)
+
+  def storeAny(rhs: Code[_]): Code[Unit] = store(coerce[T](rhs))
 }
 
 class LazyFieldRef[T: TypeInfo](fb: FunctionBuilder[_], name: String, setup: Code[T]) extends Settable[T] {

--- a/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -126,7 +126,6 @@ class MethodBuilder(val fb: FunctionBuilder[_], val mname: String, val parameter
     l.foreach(mn.instructions.add _)
     mn.instructions.add(new InsnNode(returnTypeInfo.returnOp))
     mn.instructions.add(end)
-    println(mname)
   }
 
   def invoke(args: Code[_]*) = {
@@ -236,7 +235,6 @@ class FunctionBuilder[F >: Null](val parameterTypeInfo: Array[MaybeGenericTypeIn
     newMethod(Array[TypeInfo[_]](typeInfo[A], typeInfo[B], typeInfo[C], typeInfo[D], typeInfo[E]), typeInfo[R])
 
   def classAsBytes(print: Option[PrintWriter] = None): Array[Byte] = {
-    println(methods.map(_.mname).mkString(","))
     apply_method.close()
     methods.toArray.foreach { m => m.close() }
 

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -297,7 +297,7 @@ case class Const(posn: Position, value: Any, t: Type) extends AST(posn) {
     case (t: TFloat32, x: Float) => Some(ir.F32(x))
     case (t: TFloat64, x: Double) => Some(ir.F64(x))
     case (t: TBoolean, x: Boolean) => Some(if (x) ir.True() else ir.False())
-    case (t: TString, x: String) => None
+    case (t: TString, x: String) => Some(ir.Str(x))
     case (t, null) => Some(ir.NA(t))
     case _ => throw new RuntimeException(s"Unrecognized constant of type $t: $value")
   }

--- a/src/main/scala/is/hail/expr/ir/ArraySorter.scala
+++ b/src/main/scala/is/hail/expr/ir/ArraySorter.scala
@@ -1,0 +1,68 @@
+package is.hail.expr.ir
+
+import is.hail.annotations.{CodeOrdering, Region}
+import is.hail.expr.types._
+import is.hail.asm4s._
+import is.hail.utils._
+
+object ArraySorter {
+  def apply(mb: EmitMethodBuilder, typ: Type, array: Code[Long]): ArraySorter = {
+
+  }
+
+
+}
+
+class ArraySorter(mb: EmitMethodBuilder, array: StagedArrayBuilder) {
+  val typ: Type = array.elt
+  val ti: TypeInfo[_] = typeToTypeInfo(typ)
+  val ord: CodeOrdering = CodeOrdering(typ, missingGreatest = true)
+
+  def sort(): Code[Unit] = {
+
+    val sort = mb.fb.newMethod[Region, Int, Int, Int]
+    val region = sort.getArg[Region](1)
+    val start = sort.getArg[Int](2)
+    val end = sort.getArg[Int](3)
+
+    val pi: LocalRef[Int] = sort.newLocal[Int]
+    val i: LocalRef[Int] = sort.newLocal[Int]
+
+    val m1: LocalRef[Boolean] = sort.newLocal[Boolean]
+    val v1: LocalRef[_] = sort.newLocal(ti)
+
+    def loadPivot(start: Code[Int], end: Code[Int]): Code[Unit] = {
+      pi := end
+    }
+
+    def lt(m1: Code[Boolean], v1: Code[_], m2: Code[Boolean], v2: Code[_]): Code[Boolean] = {
+      m1.mux(false, m2.mux(true, ord.compare(mb, v1, v2) < 0))
+    }
+
+    def swap(i: Code[Int], j: Code[Int]): Code[Unit] = {
+      Code(
+        m1 := array.isMissing(i),
+        v1.storeAny(array(i)),
+        array.setMissing(i, array.isMissing(j)),
+        array.isMissing(i).mux(Code._empty, array.update(i, array(j))),
+        array.setMissing(j, m1),
+        m1.mux(Code._empty, array.update(j, v1)))
+    }
+
+    sort.emit(Code(
+      loadPivot(start, end),
+      i := start,
+      Code.whileLoop(i < pi,
+        lt(array.isMissing(pi), array(pi), array.isMissing(i), array(i)).mux(
+          Code(
+            i.ceq(pi - 1).mux(
+              Code(swap(i, pi), i += 1),
+              Code(swap(pi, pi - 1), swap(i, pi))),
+            pi += -1),
+          i += 1)),
+      (start < pi - 2).mux(sort.invoke(region, start, pi - 1), Code._empty),
+      (pi + 2 < end).mux(sort.invoke(region, pi + 1, end), Code._empty)))
+
+    sort.invoke(mb.getArg[Region](1), 0, array.size - 1)
+  }
+}

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -30,6 +30,8 @@ object Children {
       Array(x)
     case MakeArray(args, typ) =>
       args.toIndexedSeq
+    case ArraySort(a) =>
+      Array(a)
     case ArrayRef(a, i, typ) =>
       Array(a, i)
     case ArrayLen(a) =>

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -40,6 +40,8 @@ object Children {
       Array(a)
     case Set(a) =>
       Array(a)
+    case Dict(a) =>
+      Array(a)
     case ArrayMap(a, name, body, elementTyp) =>
       Array(a, body)
     case ArrayFilter(a, name, cond) =>

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -30,14 +30,16 @@ object Children {
       Array(x)
     case MakeArray(args, typ) =>
       args.toIndexedSeq
-    case ArraySort(a) =>
-      Array(a)
     case ArrayRef(a, i, typ) =>
       Array(a, i)
     case ArrayLen(a) =>
       Array(a)
     case ArrayRange(start, stop, step) =>
       Array(start, stop, step)
+    case ArraySort(a) =>
+      Array(a)
+    case Set(a) =>
+      Array(a)
     case ArrayMap(a, name, body, elementTyp) =>
       Array(a, body)
     case ArrayFilter(a, name, cond) =>

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -10,6 +10,7 @@ object Children {
     case I64(x) => none
     case F32(x) => none
     case F64(x) => none
+    case Str(x) => none
     case True() => none
     case False() => none
     case Cast(v, typ) =>

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -40,6 +40,9 @@ object Copy {
       case MakeArray(args, typ) =>
         assert(args.length == newChildren.length)
         MakeArray(newChildren.map(_.asInstanceOf[IR]), typ)
+      case ArraySort(_) =>
+        val IndexedSeq(a: IR) = newChildren
+        ArraySort(a)
       case ArrayRef(_, _, typ) =>
         val IndexedSeq(a: IR, i: IR) = newChildren
         ArrayRef(a, i, typ)

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -55,6 +55,9 @@ object Copy {
       case Set(_) =>
         val IndexedSeq(a: IR) = newChildren
         Set(a)
+      case Dict(_) =>
+        val IndexedSeq(a: IR) = newChildren
+        Dict(a)
       case ArrayMap(_, name, _, elementTyp) =>
         val IndexedSeq(a: IR, body: IR) = newChildren
         ArrayMap(a, name, body, elementTyp)

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -40,9 +40,6 @@ object Copy {
       case MakeArray(args, typ) =>
         assert(args.length == newChildren.length)
         MakeArray(newChildren.map(_.asInstanceOf[IR]), typ)
-      case ArraySort(_) =>
-        val IndexedSeq(a: IR) = newChildren
-        ArraySort(a)
       case ArrayRef(_, _, typ) =>
         val IndexedSeq(a: IR, i: IR) = newChildren
         ArrayRef(a, i, typ)
@@ -52,6 +49,12 @@ object Copy {
       case ArrayRange(_, _, _) =>
         val IndexedSeq(start: IR, stop: IR, step: IR) = newChildren
         ArrayRange(start, stop, step)
+      case ArraySort(_) =>
+        val IndexedSeq(a: IR) = newChildren
+        ArraySort(a)
+      case Set(_) =>
+        val IndexedSeq(a: IR) = newChildren
+        Set(a)
       case ArrayMap(_, name, _, elementTyp) =>
         val IndexedSeq(a: IR, body: IR) = newChildren
         ArrayMap(a, name, body, elementTyp)

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -13,6 +13,7 @@ object Copy {
       case I64(_) => same
       case F32(_) => same
       case F64(_) => same
+      case Str(_) => same
       case True() => same
       case False() => same
       case Cast(_, typ) =>

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -192,8 +192,7 @@ private class Emit(
       case F64(x) =>
         present(const(x))
       case Str(x) =>
-        val srvb = new StagedRegionValueBuilder(mb, TString())
-        present(Code(srvb.start(), srvb.addString(const(x)), srvb.end()))
+        present(region.appendString(const(x)))
       case True() =>
         present(const(true))
       case False() =>

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -347,7 +347,7 @@ private class Emit(
             sorter.toRegion()))
         }
       case Dict(a) =>
-        if (a.typ.isInstanceOf[TSet] || a.typ.isInstanceOf[TDict]) {
+        if (a.typ.isInstanceOf[TDict]) {
           emit(a)
         } else {
           val atyp = coerce[TArray](a.typ)

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -270,6 +270,8 @@ private class Emit(
         }
         present(Code(srvb.start(args.size, init = true), wrapToMethod(args, env)(addElts), srvb.offset))
 
+      case ArraySort(a) =>
+
       case ArrayRef(a, i, typ) =>
         val ti = typeToTypeInfo(typ)
         val tarray = coerce[TArray](a.typ)

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -324,7 +324,7 @@ private class Emit(
           sorter.sort(),
           sorter.toRegion()))
       case Set(a) =>
-        if (a.typ.isInstanceOf[TSet] || a.typ.isInstanceOf[TDict]) {
+        if (a.typ.isInstanceOf[TSet]) {
           emit(a)
         } else {
           val atyp = coerce[TArray](a.typ)

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -270,25 +270,6 @@ private class Emit(
         }
         present(Code(srvb.start(args.size, init = true), wrapToMethod(args, env)(addElts), srvb.offset))
 
-      case ArraySort(a) =>
-        val atyp = coerce[TArray](a.typ)
-
-        val aout = emitArrayIterator(ir)
-        val vab = new StagedArrayBuilder(atyp.elementType, mb, 16)
-        val sorter = new ArraySorter(mb, vab)
-
-        val cont = { (m: Code[Boolean], v: Code[_]) =>
-          m.mux(vab.addMissing(), vab.add(v))
-        }
-
-        val processArrayElts = aout.arrayEmitter(cont)
-        EmitTriplet(processArrayElts.setup, processArrayElts.m.getOrElse(const(false)), Code(
-          vab.clear,
-          aout.calcLength,
-          processArrayElts.addElements,
-          sorter.sort(),
-          sorter.toRegion()))
-
       case ArrayRef(a, i, typ) =>
         val ti = typeToTypeInfo(typ)
         val tarray = coerce[TArray](a.typ)
@@ -323,6 +304,46 @@ private class Emit(
       case ArrayLen(a) =>
         val codeA = emit(a)
         EmitTriplet(codeA.setup, codeA.m, TContainer.loadLength(region, coerce[Long](codeA.v)))
+
+      case ArraySort(a) =>
+        val atyp = coerce[TArray](a.typ)
+
+        val aout = emitArrayIterator(ir)
+        val vab = new StagedArrayBuilder(atyp.elementType, mb, 16)
+        val sorter = new ArraySorter(mb, vab)
+
+        val cont = { (m: Code[Boolean], v: Code[_]) =>
+          m.mux(vab.addMissing(), vab.add(v))
+        }
+
+        val processArrayElts = aout.arrayEmitter(cont)
+        EmitTriplet(processArrayElts.setup, processArrayElts.m.getOrElse(const(false)), Code(
+          vab.clear,
+          aout.calcLength,
+          processArrayElts.addElements,
+          sorter.sort(),
+          sorter.toRegion()))
+
+
+      case Set(a) =>
+        val atyp = coerce[TArray](a.typ)
+
+        val aout = emitArrayIterator(a)
+        val vab = new StagedArrayBuilder(atyp.elementType, mb, 16)
+        val sorter = new ArraySorter(mb, vab)
+
+        val cont = { (m: Code[Boolean], v: Code[_]) =>
+          m.mux(vab.addMissing(), vab.add(v))
+        }
+
+        val processArrayElts = aout.arrayEmitter(cont)
+        EmitTriplet(processArrayElts.setup, processArrayElts.m.getOrElse(const(false)), Code(
+          vab.clear,
+          aout.calcLength,
+          processArrayElts.addElements,
+          sorter.sort(),
+          sorter.distinctFromSorted(),
+          sorter.toRegion()))
 
       case _: ArrayMap | _: ArrayFilter | _: ArrayRange | _: ArrayFlatMap =>
         val elt = coerce[TArray](ir.typ).elementType

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -189,6 +189,9 @@ private class Emit(
         present(const(x))
       case F64(x) =>
         present(const(x))
+      case Str(x) =>
+        val srvb = new StagedRegionValueBuilder(mb, TString())
+        present(Code(srvb.start(), srvb.addString(const(x)), srvb.end()))
       case True() =>
         present(const(true))
       case False() =>

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -52,7 +52,9 @@ object Emit {
   }
 }
 
-case class EmitTriplet(setup: Code[Unit], m: Code[Boolean], v: Code[_])
+case class EmitTriplet(setup: Code[Unit], m: Code[Boolean], v: Code[_]) {
+  def value[T]: Code[T] = coerce[T](v)
+}
 
 case class EmitArrayTriplet(setup: Code[Unit], m: Option[Code[Boolean]], addElements: Code[Unit])
 
@@ -237,7 +239,7 @@ private class Emit(
         val setup = Code(
           codeV.setup,
           mx := codeV.m,
-          x := codeV.v,
+          x := mx.mux(defaultValue(value.typ), codeV.v),
           codeBody.setup)
 
         EmitTriplet(setup, codeBody.m, codeBody.v)

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -62,7 +62,7 @@ case class ArrayIteratorTriplet(calcLength: Code[Unit], length: Option[Code[Int]
 }
 
 private class Emit(
-  mb: MethodBuilder,
+  mb: EmitMethodBuilder,
   tAggInOpt: Option[TAggregable],
   nSpecialArguments: Int) {
 
@@ -85,12 +85,12 @@ private class Emit(
     ab.result()
   }
 
-  val methods: mutable.Map[String, Seq[(Seq[Type], MethodBuilder)]] = mutable.Map().withDefaultValue(FastSeq())
+  val methods: mutable.Map[String, Seq[(Seq[Type], EmitMethodBuilder)]] = mutable.Map().withDefaultValue(FastSeq())
 
   import Emit.E
   import Emit.F
 
-  private def wrapToMethod(irs: Seq[IR], env: E)(useValues: (MethodBuilder, Type, EmitTriplet) => Code[Unit]): Code[Unit] = {
+  private def wrapToMethod(irs: Seq[IR], env: E)(useValues: (EmitMethodBuilder, Type, EmitTriplet) => Code[Unit]): Code[Unit] = {
     def wrapCodeChunks(items: Seq[_], isIR: Boolean = false): Code[Unit] = {
       val sizes: Seq[Int] = if (isIR) irs.map(_.size * opSize) else Array.fill(items.size)(5)
       val chunkBounds = getChunkBounds(sizes)
@@ -261,7 +261,7 @@ private class Emit(
       case MakeArray(args, typ) =>
         val srvb = new StagedRegionValueBuilder(mb, typ)
         val addElement = srvb.addIRIntermediate(typ.elementType)
-        val addElts = { (newMB: MethodBuilder, t: Type, v: EmitTriplet) =>
+        val addElts = { (newMB: EmitMethodBuilder, t: Type, v: EmitTriplet) =>
           Code(
             v.setup,
             v.m.mux(srvb.setMissing(), addElement(v.v)),
@@ -411,7 +411,7 @@ private class Emit(
 
       case x@MakeStruct(fields, _) =>
         val srvb = new StagedRegionValueBuilder(mb, x.typ)
-        val addFields = { (newMB: MethodBuilder, t: Type, v: EmitTriplet) =>
+        val addFields = { (newMB: EmitMethodBuilder, t: Type, v: EmitTriplet) =>
           Code(
             v.setup,
             v.m.mux(srvb.setMissing(), srvb.addIRIntermediate(t)(v.v)),
@@ -481,7 +481,7 @@ private class Emit(
 
       case x@MakeTuple(fields, _) =>
         val srvb = new StagedRegionValueBuilder(mb, x.typ)
-        val addFields = { (newMB: MethodBuilder, t: Type, v: EmitTriplet) =>
+        val addFields = { (newMB: EmitMethodBuilder, t: Type, v: EmitTriplet) =>
           Code(
             v.setup,
             v.m.mux(srvb.setMissing(), srvb.addIRIntermediate(t)(v.v)),

--- a/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -34,7 +34,7 @@ object EmitFunctionBuilder {
 }
 
 class EmitMethodBuilder(
-  fb: EmitFunctionBuilder[_],
+  override val fb: EmitFunctionBuilder[_],
   mname: String,
   parameterTypeInfo: Array[TypeInfo[_]],
   returnTypeInfo: TypeInfo[_]

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -57,6 +57,7 @@ final case class ApplyBinaryPrimOp(op: BinaryOp, l: IR, r: IR, var typ: Type = n
 final case class ApplyUnaryPrimOp(op: UnaryOp, x: IR, var typ: Type = null) extends IR
 
 final case class MakeArray(args: Seq[IR], var typ: TArray = null) extends IR
+final case class ArraySort(a: IR) extends IR { def typ: TArray = coerce[TArray](a.typ) }
 final case class ArrayRef(a: IR, i: IR, var typ: Type = null) extends IR
 final case class ArrayLen(a: IR) extends IR { val typ = TInt32() }
 final case class ArrayRange(start: IR, stop: IR, step: IR) extends IR { val typ: TArray = TArray(TInt32()) }

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -65,7 +65,7 @@ final case class ArraySort(a: IR) extends IR { def typ: TArray = coerce[TArray](
 final case class Set(a: IR) extends IR { def typ: TSet = TSet(coerce[TContainer](a.typ).elementType) }
 final case class Dict(a: IR) extends IR {
   def typ: TDict = {
-    val etype = coerce[TBaseStruct](coerce[TContainer](a.typ).elementType)
+    val etype = coerce[TBaseStruct](coerce[TArray](a.typ).elementType)
     TDict(etype.types(0), etype.types(1))
   }
 }

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -57,10 +57,13 @@ final case class ApplyBinaryPrimOp(op: BinaryOp, l: IR, r: IR, var typ: Type = n
 final case class ApplyUnaryPrimOp(op: UnaryOp, x: IR, var typ: Type = null) extends IR
 
 final case class MakeArray(args: Seq[IR], var typ: TArray = null) extends IR
-final case class ArraySort(a: IR) extends IR { def typ: TArray = coerce[TArray](a.typ) }
 final case class ArrayRef(a: IR, i: IR, var typ: Type = null) extends IR
 final case class ArrayLen(a: IR) extends IR { val typ = TInt32() }
 final case class ArrayRange(start: IR, stop: IR, step: IR) extends IR { val typ: TArray = TArray(TInt32()) }
+
+final case class ArraySort(a: IR) extends IR { def typ: TArray = coerce[TArray](a.typ) }
+final case class Set(a: IR) extends IR { def typ: TSet = TSet(coerce[TContainer](a.typ).elementType) }
+
 final case class ArrayMap(a: IR, name: String, body: IR, var elementTyp: Type = null) extends IR { def typ: TArray = TArray(elementTyp) }
 final case class ArrayFilter(a: IR, name: String, cond: IR) extends IR { def typ: TArray = coerce[TArray](a.typ) }
 final case class ArrayFlatMap(a: IR, name: String, body: IR) extends IR { def typ: TArray = coerce[TArray](body.typ) }

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -63,6 +63,12 @@ final case class ArrayRange(start: IR, stop: IR, step: IR) extends IR { val typ:
 
 final case class ArraySort(a: IR) extends IR { def typ: TArray = coerce[TArray](a.typ) }
 final case class Set(a: IR) extends IR { def typ: TSet = TSet(coerce[TContainer](a.typ).elementType) }
+final case class Dict(a: IR) extends IR {
+  def typ: TDict = {
+    val etype = coerce[TBaseStruct](coerce[TContainer](a.typ).elementType)
+    TDict(etype.types(0), etype.types(1))
+  }
+}
 
 final case class ArrayMap(a: IR, name: String, body: IR, var elementTyp: Type = null) extends IR { def typ: TArray = TArray(elementTyp) }
 final case class ArrayFilter(a: IR, name: String, cond: IR) extends IR { def typ: TArray = coerce[TArray](a.typ) }

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -62,7 +62,7 @@ final case class ArrayLen(a: IR) extends IR { val typ = TInt32() }
 final case class ArrayRange(start: IR, stop: IR, step: IR) extends IR { val typ: TArray = TArray(TInt32()) }
 
 final case class ArraySort(a: IR) extends IR { def typ: TArray = coerce[TArray](a.typ) }
-final case class Set(a: IR) extends IR { def typ: TSet = TSet(coerce[TContainer](a.typ).elementType) }
+final case class Set(a: IR) extends IR { def typ: TSet = TSet(coerce[TArray](a.typ).elementType) }
 final case class Dict(a: IR) extends IR {
   def typ: TDict = {
     val etype = coerce[TBaseStruct](coerce[TArray](a.typ).elementType)

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -29,6 +29,7 @@ object Literal {
       case _: TFloat32 => F32(x.asInstanceOf[Float])
       case _: TFloat64 => F64(x.asInstanceOf[Double])
       case _: TBoolean => if (x.asInstanceOf[Boolean]) True() else False()
+      case _: TString => Str(x.asInstanceOf[String])
       case _ => throw new RuntimeException("Unsupported literal type")
     }
   }
@@ -38,6 +39,7 @@ final case class I32(x: Int) extends IR { val typ = TInt32() }
 final case class I64(x: Long) extends IR { val typ = TInt64() }
 final case class F32(x: Float) extends IR { val typ = TFloat32() }
 final case class F64(x: Double) extends IR { val typ = TFloat64() }
+final case class Str(x: String) extends IR { val typ = TString() }
 final case class True() extends IR { val typ = TBoolean() }
 final case class False() extends IR { val typ = TBoolean() }
 

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -79,7 +79,7 @@ object Infer {
         assert(a.typ.isInstanceOf[TContainer])
       case x@Dict(a) =>
         infer(a)
-        assert(a.typ.isInstanceOf[TContainer])
+        assert(a.typ.isInstanceOf[TArray])
         assert(coerce[TBaseStruct](coerce[TContainer](a.typ).elementType).size == 2)
       case x@ArrayMap(a, name, body, _) =>
         infer(a)

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -76,7 +76,7 @@ object Infer {
         assert(a.typ.isInstanceOf[TArray])
       case x@Set(a) =>
         infer(a)
-        assert(a.typ.isInstanceOf[TContainer])
+        assert(a.typ.isInstanceOf[TArray])
       case x@Dict(a) =>
         infer(a)
         assert(a.typ.isInstanceOf[TArray])

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -56,6 +56,9 @@ object Infer {
           args.map(_.typ).zipWithIndex.tail.foreach { case (x, i) => assert(x.isOfType(t), s"at position $i type mismatch: $t $x") }
           x.typ = TArray(t)
         }
+      case x@ArraySort(a) =>
+        infer(a)
+        assert(a.typ.isInstanceOf[TArray])
       case x@ArrayRef(a, i, _) =>
         infer(a)
         infer(i)

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -56,9 +56,6 @@ object Infer {
           args.map(_.typ).zipWithIndex.tail.foreach { case (x, i) => assert(x.isOfType(t), s"at position $i type mismatch: $t $x") }
           x.typ = TArray(t)
         }
-      case x@ArraySort(a) =>
-        infer(a)
-        assert(a.typ.isInstanceOf[TArray])
       case x@ArrayRef(a, i, _) =>
         infer(a)
         infer(i)
@@ -74,6 +71,12 @@ object Infer {
         assert(a.typ.isOfType(TInt32()))
         assert(b.typ.isOfType(TInt32()))
         assert(c.typ.isOfType(TInt32()))
+      case x@ArraySort(a) =>
+        infer(a)
+        assert(a.typ.isInstanceOf[TArray])
+      case x@Set(a) =>
+        infer(a)
+        assert(a.typ.isInstanceOf[TContainer])
       case x@ArrayMap(a, name, body, _) =>
         infer(a)
         val tarray = coerce[TArray](a.typ)

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -77,6 +77,10 @@ object Infer {
       case x@Set(a) =>
         infer(a)
         assert(a.typ.isInstanceOf[TContainer])
+      case x@Dict(a) =>
+        infer(a)
+        assert(a.typ.isInstanceOf[TContainer])
+        assert(coerce[TBaseStruct](coerce[TContainer](a.typ).elementType).size == 2)
       case x@ArrayMap(a, name, body, _) =>
         infer(a)
         val tarray = coerce[TArray](a.typ)

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -13,6 +13,7 @@ object Infer {
       case I64(x) =>
       case F32(x) =>
       case F64(x) =>
+      case Str(x) =>
       case True() =>
       case False() =>
 

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -162,12 +162,14 @@ object Infer {
       case x@Apply(fn, args, impl) =>
         args.foreach(infer(_))
         if (impl == null)
-          x.implementation = (IRFunctionRegistry.lookupFunction(fn, args.map(_.typ)).get).asInstanceOf[IRFunctionWithoutMissingness]
-        assert(args.map(_.typ).zip(x.implementation.argTypes).forall {case (i, j) => j.unify(i)})
+          x.implementation = IRFunctionRegistry.lookupFunction(fn, args.map(_.typ)).get.asInstanceOf[IRFunctionWithoutMissingness]
+        x.implementation.argTypes.foreach(_.clear())
+        assert(args.map(_.typ).zip(x.implementation.argTypes).forall { case (i, j) => j.unify(i) })
       case x@ApplySpecial(fn, args, impl) =>
         args.foreach(infer(_))
         if (impl == null)
-          x.implementation = (IRFunctionRegistry.lookupFunction(fn, args.map(_.typ)).get).asInstanceOf[IRFunctionWithMissingness]
+          x.implementation = IRFunctionRegistry.lookupFunction(fn, args.map(_.typ)).get.asInstanceOf[IRFunctionWithMissingness]
+        x.implementation.argTypes.foreach(_.clear())
         assert(args.map(_.typ).zip(x.implementation.argTypes).forall {case (i, j) => j.unify(i)})
       case x@TableAggregate(child, query, _) =>
         infer(query, tAgg = Some(child.typ.tAgg), env = child.typ.aggEnv)

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -180,12 +180,6 @@ object Interpret {
             }
         }
       case MakeArray(elements, _) => elements.map(interpret(_, env, args, agg)).toIndexedSeq
-      case ArraySort(a) =>
-        val aValue = interpret(a, env, args, agg)
-        if (aValue == null)
-          null
-        else
-          aValue.asInstanceOf[IndexedSeq[Any]].sorted(a.typ.ordering.toOrdering)
       case ArrayRef(a, i, _) =>
         val aValue = interpret(a, env, args, agg)
         val iValue = interpret(i, env, args, agg)
@@ -207,6 +201,24 @@ object Interpret {
           null
         else
           startValue.asInstanceOf[Int] until stopValue.asInstanceOf[Int] by stepValue.asInstanceOf[Int]
+      case ArraySort(a) =>
+        val aValue = interpret(a, env, args, agg)
+        if (aValue == null)
+          null
+        else
+          aValue.asInstanceOf[IndexedSeq[Any]].sorted(a.typ.ordering.toOrdering)
+      case Set(a) =>
+        val aValue = interpret(a, env, args, agg)
+        if (aValue == null)
+          null
+        else
+          aValue.asInstanceOf[IndexedSeq[Any]].toSet
+      case Dict(a) =>
+        val aValue = interpret(a, env, args, agg)
+        if (aValue == null)
+          null
+        else
+          aValue.asInstanceOf[IndexedSeq[Row]].filter(_ != null).map{ case Row(k, v) => (k, v) }.toMap
       case ArrayMap(a, name, body, _) =>
         val aValue = interpret(a, env, args, agg)
         if (aValue == null)

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -180,6 +180,12 @@ object Interpret {
             }
         }
       case MakeArray(elements, _) => elements.map(interpret(_, env, args, agg)).toIndexedSeq
+      case ArraySort(a) =>
+        val aValue = interpret(a, env, args, agg)
+        if (aValue == null)
+          null
+        else
+          aValue.asInstanceOf[IndexedSeq[Any]].sorted(a.typ.ordering.toOrdering)
       case ArrayRef(a, i, _) =>
         val aValue = interpret(a, env, args, agg)
         val iValue = interpret(i, env, args, agg)

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -39,6 +39,7 @@ object Interpret {
       case I64(x) => x
       case F32(x) => x
       case F64(x) => x
+      case Str(x) => x
       case True() => true
       case False() => false
       case Cast(v, t) =>

--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -46,6 +46,7 @@ object Pretty {
             case I64(x) => x.toString
             case F32(x) => x.toString
             case F64(x) => x.toString
+            case Str(x) => x
             case Cast(_, typ) => typ.toString
             case NA(typ) => typ.toString
             case Let(name, _, _, _) => name

--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -46,7 +46,7 @@ object Pretty {
             case I64(x) => x.toString
             case F32(x) => x.toString
             case F64(x) => x.toString
-            case Str(x) => x
+            case Str(x) => s"'$x'"
             case Cast(_, typ) => typ.toString
             case NA(typ) => typ.toString
             case Let(name, _, _, _) => name

--- a/src/main/scala/is/hail/expr/ir/Recur.scala
+++ b/src/main/scala/is/hail/expr/ir/Recur.scala
@@ -1,48 +1,8 @@
 package is.hail.expr.ir
 
 object Recur {
-  def apply(f: IR => IR)(ir: IR): IR = ir match {
-    case I32(x) => ir
-    case I64(x) => ir
-    case F32(x) => ir
-    case F64(x) => ir
-    case True() => ir
-    case False() => ir
-    case Cast(v, typ) => Cast(f(v), typ)
-    case NA(typ) => ir
-    case IsNA(value) => IsNA(f(value))
-    case If(cond, cnsq, altr, typ) => If(f(cond), f(cnsq), f(altr), typ)
-    case Let(name, value, body, typ) => Let(name, f(value), f(body), typ)
-    case Ref(name, typ) => ir
-    case ApplyBinaryPrimOp(op, l, r, typ) => ApplyBinaryPrimOp(op, f(l), f(r), typ)
-    case ApplyUnaryPrimOp(op, x, typ) => ApplyUnaryPrimOp(op, f(x), typ)
-    case MakeArray(args, typ) => MakeArray(args map f, typ)
-    case ArrayRef(a, i, typ) => ArrayRef(f(a), f(i), typ)
-    case ArrayLen(a) => ArrayLen(f(a))
-    case ArrayRange(start, stop, step) => ArrayRange(f(start), f(stop), f(step))
-    case ArrayMap(a, name, body, elementTyp) => ArrayMap(f(a), name, f(body), elementTyp)
-    case ArrayFilter(a, name, cond) => ArrayFilter(f(a), name, f(cond))
-    case ArrayFlatMap(a, name, body) => ArrayFlatMap(f(a), name, f(body))
-    case ArrayFold(a, zero, accumName, valueName, body, typ) => ArrayFold(f(a), f(zero), accumName, valueName, f(body), typ)
-    case MakeStruct(fields, _) => MakeStruct(fields map { case (n, a) => (n, f(a)) })
-    case InsertFields(old, fields, _) => InsertFields(f(old), fields map { case (n, a) => (n, f(a)) })
-    case GetField(o, name, typ) => GetField(f(o), name, typ)
-    case AggIn(typ) => ir
-    case AggMap(a, name, body, typ) => AggMap(f(a), name, f(body), typ)
-    case AggFilter(a, name, body, typ) => AggFilter(f(a), name, f(body), typ)
-    case AggFlatMap(a, name, body, typ) => AggFlatMap(f(a), name, f(body), typ)
-    case ApplyAggOp(a, op, args, typ) => ApplyAggOp(f(a), op, args.map(f), typ)
-    case MakeTuple(elts, typ) => MakeTuple(elts.map(f), typ)
-    case GetTupleElement(tup, idx, typ) => GetTupleElement(f(tup), idx, typ)
-    case In(i, typ) => ir
-    case Die(message) => ir
-    case Apply(fn, args, impl) => Apply(fn, args.map(f), impl)
-    case ApplySpecial(fn, args, impl) => ApplySpecial(fn, args.map(f), impl)
-    // from MatrixIR
-    case MatrixWrite(_, _, _, _) => ir
-    // from TableIR
-    case TableCount(_) => ir
-    case TableAggregate(child, query, typ) => TableAggregate(child, query, typ)
-    case TableWrite(_, _, _, _) => ir
-  }
+  def apply(f: IR => IR)(ir: IR): IR = Copy(ir, Children(ir).map {
+    case c: IR => f(c)
+    case c => c
+  }).asInstanceOf[IR]
 }

--- a/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
+++ b/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
@@ -91,21 +91,15 @@ sealed abstract class MissingArrayBuilder[T](initialCapacity: Int) {
     missing(i)
   }
 
-  def enlargeMissing(newCapacity: Int) {
-    val newmissing = new Array[Boolean](newCapacity)
-    Array.copy(missing, 0, newmissing, 0, size_)
-    missing = newmissing
-  }
-
   def ensureCapacity(n: Int): Unit
 
   def add(x: T): Unit
 
   def update(i: Int, x: T): Unit
 
-  def setMissing(i: Int): Unit = {
+  def setMissing(i: Int, m: Boolean): Unit = {
     require(i >= 0 && i < size)
-    missing(i) = true
+    missing(i) = m
   }
 
   def addMissing() {
@@ -131,7 +125,9 @@ class ByteArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder[Byte](i
       val newb = new Array[Byte](newCapacity)
       Array.copy(b, 0, newb, 0, size_)
       b = newb
-      enlargeMissing(n)
+      val newmissing = new Array[Boolean](newCapacity)
+      Array.copy(missing, 0, newmissing, 0, size_)
+      missing = newmissing
     }
   }
 
@@ -163,7 +159,9 @@ class IntArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder[Int](ini
       val newb = new Array[Int](newCapacity)
       Array.copy(b, 0, newb, 0, size_)
       b = newb
-      enlargeMissing(n)
+      val newmissing = new Array[Boolean](newCapacity)
+      Array.copy(missing, 0, newmissing, 0, size_)
+      missing = newmissing
     }
   }
 
@@ -195,7 +193,9 @@ class LongArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder[Long](i
       val newb = new Array[Long](newCapacity)
       Array.copy(b, 0, newb, 0, size_)
       b = newb
-      enlargeMissing(n)
+      val newmissing = new Array[Boolean](newCapacity)
+      Array.copy(missing, 0, newmissing, 0, size_)
+      missing = newmissing
     }
   }
 
@@ -227,7 +227,9 @@ class FloatArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder[Float]
       val newb = new Array[Float](newCapacity)
       Array.copy(b, 0, newb, 0, size_)
       b = newb
-      enlargeMissing(n)
+      val newmissing = new Array[Boolean](newCapacity)
+      Array.copy(missing, 0, newmissing, 0, size_)
+      missing = newmissing
     }
   }
 
@@ -259,7 +261,9 @@ class DoubleArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder[Doubl
       val newb = new Array[Double](newCapacity)
       Array.copy(b, 0, newb, 0, size_)
       b = newb
-      enlargeMissing(n)
+      val newmissing = new Array[Boolean](newCapacity)
+      Array.copy(missing, 0, newmissing, 0, size_)
+      missing = newmissing
     }
   }
 
@@ -291,7 +295,9 @@ class BooleanArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder[Bool
       val newb = new Array[Boolean](newCapacity)
       Array.copy(b, 0, newb, 0, size_)
       b = newb
-      enlargeMissing(n)
+      val newmissing = new Array[Boolean](newCapacity)
+      Array.copy(missing, 0, newmissing, 0, size_)
+      missing = newmissing
     }
   }
 

--- a/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
+++ b/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
@@ -111,7 +111,7 @@ sealed abstract class MissingArrayBuilder[T](initialCapacity: Int) {
   }
 
   def setSize(n: Int) {
-    require(n >= 0 && n < size)
+    require(n >= 0 && n <= size)
     size_ = n
   }
 

--- a/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
+++ b/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
@@ -74,6 +74,8 @@ class StagedArrayBuilder(val elt: Type, mb: MethodBuilder, len: Code[Int]) {
 
   def size: Code[Int] = wrapArgs[Int]("size")
 
+  def setSize(n: Code[Int]): Code[Unit] = wrapArgs[Int, Unit]("setSize", n)
+
   def clear: Code[Unit] = wrapArgs[Unit]("clear")
 }
 
@@ -106,6 +108,11 @@ sealed abstract class MissingArrayBuilder[T](initialCapacity: Int) {
     ensureCapacity(size_ + 1)
     missing(size_) = true
     size_ += 1
+  }
+
+  def setSize(n: Int) {
+    require(n >= 0 && n < size)
+    size_ = n
   }
 
   def clear() {  size_ = 0 }

--- a/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
+++ b/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
@@ -3,38 +3,27 @@ package is.hail.expr.ir
 import is.hail.asm4s._
 import is.hail.expr.types.Type
 
-class StagedArrayBuilder(elt: Type, mb: MethodBuilder) {
+import scala.reflect.ClassTag
+
+class StagedArrayBuilder(val elt: Type, mb: MethodBuilder, len: Code[Int]) {
 
   val ti = typeToTypeInfo(elt)
 
   val ref: Settable[Any] = coerce[Any](ti match {
-    case BooleanInfo => mb.newLocal[BooleanArrayBuilder]("zab")
-    case IntInfo => mb.newLocal[IntArrayBuilder]("iab")
-    case LongInfo => mb.newLocal[LongArrayBuilder]("jab")
-    case FloatInfo => mb.newLocal[FloatArrayBuilder]("fab")
-    case DoubleInfo => mb.newLocal[DoubleArrayBuilder]("dab")
+    case BooleanInfo => mb.newLazyField[BooleanArrayBuilder]("zab")(Code.newInstance[BooleanArrayBuilder, Int](len))
+    case IntInfo => mb.newLazyField[IntArrayBuilder]("iab")(Code.newInstance[IntArrayBuilder, Int](len))
+    case LongInfo => mb.newLazyField[LongArrayBuilder]("jab")(Code.newInstance[LongArrayBuilder, Int](len))
+    case FloatInfo => mb.newLazyField[FloatArrayBuilder]("fab")(Code.newInstance[FloatArrayBuilder, Int](len))
+    case DoubleInfo => mb.newLazyField[DoubleArrayBuilder]("dab")(Code.newInstance[DoubleArrayBuilder, Int](len))
     case ti => throw new RuntimeException(s"unsupported type found: $elt whose type info is $ti")
   })
 
-  def create(len: Code[Int]): Code[Unit] = {
-    ref := {
-      ti match {
-        case BooleanInfo => Code.newInstance[BooleanArrayBuilder, Int](len)
-        case IntInfo => Code.newInstance[IntArrayBuilder, Int](len)
-        case LongInfo => Code.newInstance[LongArrayBuilder, Int](len)
-        case FloatInfo => Code.newInstance[FloatArrayBuilder, Int](len)
-        case DoubleInfo => Code.newInstance[DoubleArrayBuilder, Int](len)
-        case ti => throw new RuntimeException(s"unsupported type found: $elt whose type info is $ti")
-      }
-    }
-  }
-
-  def add(i: Code[_]): Code[Unit] = ti match {
-    case BooleanInfo => coerce[BooleanArrayBuilder](ref).invoke[Boolean, Unit]("add", coerce[Boolean](i))
-    case IntInfo => coerce[IntArrayBuilder](ref).invoke[Int, Unit]("add", coerce[Int](i))
-    case LongInfo => coerce[LongArrayBuilder](ref).invoke[Long, Unit]("add", coerce[Long](i))
-    case FloatInfo => coerce[FloatArrayBuilder](ref).invoke[Float, Unit]("add", coerce[Float](i))
-    case DoubleInfo => coerce[DoubleArrayBuilder](ref).invoke[Double, Unit]("add", coerce[Double](i))
+  def add(x: Code[_]): Code[Unit] = ti match {
+    case BooleanInfo => coerce[BooleanArrayBuilder](ref).invoke[Boolean, Unit]("add", coerce[Boolean](x))
+    case IntInfo => coerce[IntArrayBuilder](ref).invoke[Int, Unit]("add", coerce[Int](x))
+    case LongInfo => coerce[LongArrayBuilder](ref).invoke[Long, Unit]("add", coerce[Long](x))
+    case FloatInfo => coerce[FloatArrayBuilder](ref).invoke[Float, Unit]("add", coerce[Float](x))
+    case DoubleInfo => coerce[DoubleArrayBuilder](ref).invoke[Double, Unit]("add", coerce[Double](x))
   }
 
   def apply(i: Code[Int]): Code[_] = ti match {
@@ -45,192 +34,277 @@ class StagedArrayBuilder(elt: Type, mb: MethodBuilder) {
     case DoubleInfo => coerce[DoubleArrayBuilder](ref).invoke[Int, Double]("apply", i)
   }
 
-  def size: Code[Int] = ti match {
-    case BooleanInfo => coerce[BooleanArrayBuilder](ref).invoke[Int]("size")
-    case IntInfo => coerce[IntArrayBuilder](ref).invoke[Int]("size")
-    case LongInfo => coerce[LongArrayBuilder](ref).invoke[Int]("size")
-    case FloatInfo => coerce[FloatArrayBuilder](ref).invoke[Int]("size")
-    case DoubleInfo => coerce[DoubleArrayBuilder](ref).invoke[Int]("size")
+  def update(i: Code[Int], x: Code[_]): Code[Unit] = ti match {
+    case BooleanInfo => coerce[BooleanArrayBuilder](ref).invoke[Int, Boolean, Unit]("update", i, coerce[Boolean](x))
+    case IntInfo => coerce[IntArrayBuilder](ref).invoke[Int, Int, Unit]("update", i, coerce[Int](x))
+    case LongInfo => coerce[LongArrayBuilder](ref).invoke[Int, Long, Unit]("update", i, coerce[Long](x))
+    case FloatInfo => coerce[FloatArrayBuilder](ref).invoke[Int, Float, Unit]("update", i, coerce[Float](x))
+    case DoubleInfo => coerce[DoubleArrayBuilder](ref).invoke[Int, Double, Unit]("update", i, coerce[Double](x))
   }
 
-  def clear: Code[Unit] = ti match {
-    case BooleanInfo => coerce[BooleanArrayBuilder](ref).invoke[Unit]("clear")
-    case IntInfo => coerce[IntArrayBuilder](ref).invoke[Unit]("clear")
-    case LongInfo => coerce[LongArrayBuilder](ref).invoke[Unit]("clear")
-    case FloatInfo => coerce[FloatArrayBuilder](ref).invoke[Unit]("clear")
-    case DoubleInfo => coerce[DoubleArrayBuilder](ref).invoke[Unit]("clear")
+  private def wrapArgs[A1: ClassTag, A2: ClassTag, R: ClassTag](method: String, a1: Code[A1], a2: Code[A2]): Code[R] = ti match {
+    case BooleanInfo => coerce[BooleanArrayBuilder](ref).invoke[A1, A2, R](method, a1, a2)
+    case IntInfo => coerce[IntArrayBuilder](ref).invoke[A1, A2, R](method, a1, a2)
+    case LongInfo => coerce[LongArrayBuilder](ref).invoke[A1, A2, R](method, a1, a2)
+    case FloatInfo => coerce[FloatArrayBuilder](ref).invoke[A1, A2, R](method, a1, a2)
+    case DoubleInfo => coerce[DoubleArrayBuilder](ref).invoke[A1, A2, R](method, a1, a2)
   }
 
+  private def wrapArgs[A1: ClassTag, R: ClassTag](method: String, a1: Code[A1]): Code[R] = ti match {
+    case BooleanInfo => coerce[BooleanArrayBuilder](ref).invoke[A1, R](method, a1)
+    case IntInfo => coerce[IntArrayBuilder](ref).invoke[A1, R](method, a1)
+    case LongInfo => coerce[LongArrayBuilder](ref).invoke[A1, R](method, a1)
+    case FloatInfo => coerce[FloatArrayBuilder](ref).invoke[A1, R](method, a1)
+    case DoubleInfo => coerce[DoubleArrayBuilder](ref).invoke[A1, R](method, a1)
+  }
+
+  private def wrapArgs[R: ClassTag](method: String): Code[R] = ti match {
+    case BooleanInfo => coerce[BooleanArrayBuilder](ref).invoke[R](method)
+    case IntInfo => coerce[IntArrayBuilder](ref).invoke[R](method)
+    case LongInfo => coerce[LongArrayBuilder](ref).invoke[R](method)
+    case FloatInfo => coerce[FloatArrayBuilder](ref).invoke[R](method)
+    case DoubleInfo => coerce[DoubleArrayBuilder](ref).invoke[R](method)
+  }
+
+  def addMissing(): Code[Unit] = wrapArgs[Unit]("addMissing")
+
+  def isMissing(i: Code[Int]): Code[Boolean] = wrapArgs[Int, Boolean]("isMissing", i)
+
+  def setMissing(i: Code[Int], m: Code[Boolean]): Code[Unit] = wrapArgs[Int, Boolean, Unit]("setMissing", i, m)
+
+  def size: Code[Int] = wrapArgs[Int]("size")
+
+  def clear: Code[Unit] = wrapArgs[Unit]("clear")
 }
 
-class ByteArrayBuilder(initialCapacity: Int) {
-  private var b: Array[Byte] = new Array[Byte](initialCapacity)
-  private var size_ : Int = 0
+sealed abstract class MissingArrayBuilder[T](initialCapacity: Int) {
+
+  var missing: Array[Boolean] = new Array[Boolean](initialCapacity)
+  var size_ : Int = 0
 
   def size: Int = size_
+
+  def apply(i: Int): T
+
+  def isMissing(i: Int): Boolean = {
+    require(i >= 0 && i < size)
+    missing(i)
+  }
+
+  def enlargeMissing(newCapacity: Int) {
+    val newmissing = new Array[Boolean](newCapacity)
+    Array.copy(missing, 0, newmissing, 0, size_)
+    missing = newmissing
+  }
+
+  def ensureCapacity(n: Int): Unit
+
+  def add(x: T): Unit
+
+  def update(i: Int, x: T): Unit
+
+  def setMissing(i: Int): Unit = {
+    require(i >= 0 && i < size)
+    missing(i) = true
+  }
+
+  def addMissing() {
+    ensureCapacity(size_ + 1)
+    missing(size_) = true
+    size_ += 1
+  }
+
+  def clear() {  size_ = 0 }
+}
+
+class ByteArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder[Byte](initialCapacity) {
+  private var b: Array[Byte] = new Array[Byte](initialCapacity)
 
   def apply(i: Int): Byte = {
     require(i >= 0 && i < size)
     b(i)
   }
 
-  def ensureCapacity(n: Int) {
+  def ensureCapacity(n: Int): Unit = {
     if (b.length < n) {
       val newCapacity = (b.length * 2).max(n)
       val newb = new Array[Byte](newCapacity)
       Array.copy(b, 0, newb, 0, size_)
       b = newb
+      enlargeMissing(n)
     }
   }
 
-  def add(x: Byte) {
+  def add(x: Byte): Unit = {
     ensureCapacity(size_ + 1)
     b(size_) = x
+    missing(size_) = false
     size_ += 1
+  }
+
+  def update(i: Int, x: Byte): Unit = {
+    require(i >= 0 && i < size)
+    b(i) = x
+    missing(i) = false
   }
 }
 
-class IntArrayBuilder(initialCapacity: Int) {
+class IntArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder[Int](initialCapacity) {
   private var b: Array[Int] = new Array[Int](initialCapacity)
-  private var size_ : Int = 0
-
-  def size: Int = size_
 
   def apply(i: Int): Int = {
     require(i >= 0 && i < size)
     b(i)
   }
 
-  def ensureCapacity(n: Int) {
+  def ensureCapacity(n: Int): Unit = {
     if (b.length < n) {
       val newCapacity = (b.length * 2).max(n)
       val newb = new Array[Int](newCapacity)
       Array.copy(b, 0, newb, 0, size_)
       b = newb
+      enlargeMissing(n)
     }
   }
 
-  def add(x: Int) {
+  def add(x: Int): Unit = {
     ensureCapacity(size_ + 1)
     b(size_) = x
+    missing(size_) = false
     size_ += 1
   }
 
-  def clear() {  size_ = 0 }
+  def update(i: Int, x: Int): Unit = {
+    require(i >= 0 && i < size)
+    b(i) = x
+    missing(i) = false
+  }
 }
 
-class LongArrayBuilder(initialCapacity: Int) {
+class LongArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder[Long](initialCapacity) {
   private var b: Array[Long] = new Array[Long](initialCapacity)
-  private var size_ : Int = 0
-
-  def size: Int = size_
 
   def apply(i: Int): Long = {
     require(i >= 0 && i < size)
     b(i)
   }
 
-  def ensureCapacity(n: Int) {
+  def ensureCapacity(n: Int): Unit = {
     if (b.length < n) {
       val newCapacity = (b.length * 2).max(n)
       val newb = new Array[Long](newCapacity)
       Array.copy(b, 0, newb, 0, size_)
       b = newb
+      enlargeMissing(n)
     }
   }
 
-  def add(x: Long) {
+  def add(x: Long): Unit = {
     ensureCapacity(size_ + 1)
     b(size_) = x
+    missing(size_) = false
     size_ += 1
   }
 
-  def clear() {  size_ = 0 }
+  def update(i: Int, x: Long): Unit = {
+    require(i >= 0 && i < size)
+    b(i) = x
+    missing(i) = false
+  }
 }
 
-class FloatArrayBuilder(initialCapacity: Int) {
+class FloatArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder[Float](initialCapacity) {
   private var b: Array[Float] = new Array[Float](initialCapacity)
-  private var size_ : Int = 0
-
-  def size: Int = size_
 
   def apply(i: Int): Float = {
     require(i >= 0 && i < size)
     b(i)
   }
 
-  def ensureCapacity(n: Int) {
+  def ensureCapacity(n: Int): Unit = {
     if (b.length < n) {
       val newCapacity = (b.length * 2).max(n)
       val newb = new Array[Float](newCapacity)
       Array.copy(b, 0, newb, 0, size_)
       b = newb
+      enlargeMissing(n)
     }
   }
 
-  def add(x: Float) {
+  def add(x: Float): Unit = {
     ensureCapacity(size_ + 1)
     b(size_) = x
+    missing(size_) = false
     size_ += 1
   }
 
-  def clear() {  size_ = 0 }
+  def update(i: Int, x: Float): Unit = {
+    require(i >= 0 && i < size)
+    b(i) = x
+    missing(i) = false
+  }
 }
 
-class DoubleArrayBuilder(initialCapacity: Int) {
+class DoubleArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder[Double](initialCapacity) {
   private var b: Array[Double] = new Array[Double](initialCapacity)
-  private var size_ : Int = 0
-
-  def size: Int = size_
 
   def apply(i: Int): Double = {
     require(i >= 0 && i < size)
     b(i)
   }
 
-  def ensureCapacity(n: Int) {
+  def ensureCapacity(n: Int): Unit = {
     if (b.length < n) {
       val newCapacity = (b.length * 2).max(n)
       val newb = new Array[Double](newCapacity)
       Array.copy(b, 0, newb, 0, size_)
       b = newb
+      enlargeMissing(n)
     }
   }
 
-  def add(x: Double) {
+  def add(x: Double): Unit = {
     ensureCapacity(size_ + 1)
     b(size_) = x
+    missing(size_) = false
     size_ += 1
   }
 
-  def clear() {  size_ = 0 }
+  def update(i: Int, x: Double): Unit = {
+    require(i >= 0 && i < size)
+    b(i) = x
+    missing(i) = false
+  }
 }
 
-class BooleanArrayBuilder(initialCapacity: Int) {
+class BooleanArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder[Boolean](initialCapacity) {
   private var b: Array[Boolean] = new Array[Boolean](initialCapacity)
-  private var size_ : Int = 0
-
-  def size: Int = size_
 
   def apply(i: Int): Boolean = {
     require(i >= 0 && i < size)
     b(i)
   }
 
-  def ensureCapacity(n: Int) {
+  def ensureCapacity(n: Int): Unit = {
     if (b.length < n) {
       val newCapacity = (b.length * 2).max(n)
       val newb = new Array[Boolean](newCapacity)
       Array.copy(b, 0, newb, 0, size_)
       b = newb
+      enlargeMissing(n)
     }
   }
 
-  def add(x: Boolean) {
+  def add(x: Boolean): Unit = {
     ensureCapacity(size_ + 1)
     b(size_) = x
+    missing(size_) = false
     size_ += 1
   }
 
-  def clear() {  size_ = 0 }
+  def update(i: Int, x: Boolean): Unit = {
+    require(i >= 0 && i < size)
+    b(i) = x
+    missing(i) = false
+  }
 }

--- a/src/main/scala/is/hail/expr/ir/TypeToIRIntermediateClassTag.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeToIRIntermediateClassTag.scala
@@ -11,6 +11,6 @@ object TypeToIRIntermediateClassTag {
     case _: TInt64 => classTag[Long]
     case _: TFloat32 => classTag[Float]
     case _: TFloat64 => classTag[Double]
-    case _: TBaseStruct | _: TArray => classTag[Long]
+    case _: TBaseStruct | _: TArray | _: TBinary => classTag[Long]
   }
 }

--- a/src/main/scala/is/hail/expr/ir/functions/CallFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/CallFunctions.scala
@@ -10,7 +10,5 @@ object CallFunctions extends RegistryFunctions {
     registerScalaFunction("downcode", TCall(), TInt32(), TCall())(Call.getClass, "downcode")
     registerScalaFunction("UnphasedDiploidGtIndexCall", TInt32(), TCall())(Call2.getClass, "fromUnphasedDiploidGtIndex")
     registerScalaFunction("isNonRef", TCall(), TBoolean())(Call.getClass, "isNonRef")
-
-    registerCode("==", TCall(), TCall(), TBoolean()) { (_, a: Code[Int], b: Code[Int]) => a.ceq(b) }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -89,7 +89,7 @@ abstract class RegistryFunctions {
   def tnum(name: String): TVariable =
     tv(name, _.isInstanceOf[TNumeric])
 
-  def registerCode(mname: String, aTypes: Array[Type], rType: Type)(impl: (MethodBuilder, Array[Code[_]]) => Code[_]) {
+  def registerCode(mname: String, aTypes: Array[Type], rType: Type)(impl: (EmitMethodBuilder, Array[Code[_]]) => Code[_]) {
     IRFunctionRegistry.addIRFunction(new IRFunctionWithoutMissingness {
       override val name: String = mname
 
@@ -97,11 +97,11 @@ abstract class RegistryFunctions {
 
       override val returnType: Type = rType
 
-      override def apply(mb: MethodBuilder, args: Code[_]*): Code[_] = impl(mb, args.toArray)
+      override def apply(mb: EmitMethodBuilder, args: Code[_]*): Code[_] = impl(mb, args.toArray)
     })
   }
 
-  def registerCodeWithMissingness(mname: String, aTypes: Array[Type], rType: Type)(impl: (MethodBuilder, Array[EmitTriplet]) => EmitTriplet) {
+  def registerCodeWithMissingness(mname: String, aTypes: Array[Type], rType: Type)(impl: (EmitMethodBuilder, Array[EmitTriplet]) => EmitTriplet) {
     IRFunctionRegistry.addIRFunction(new IRFunctionWithMissingness {
       override val name: String = mname
 
@@ -109,7 +109,7 @@ abstract class RegistryFunctions {
 
       override val returnType: Type = rType
 
-      override def apply(mb: MethodBuilder, args: EmitTriplet*): EmitTriplet = impl(mb, args.toArray)
+      override def apply(mb: EmitMethodBuilder, args: EmitTriplet*): EmitTriplet = impl(mb, args.toArray)
     })
   }
 
@@ -137,26 +137,26 @@ abstract class RegistryFunctions {
     IRFunctionRegistry.addIR(mname, argTypes, f)
   }
 
-  def registerCode(mname: String, rt: Type)(impl: MethodBuilder => Code[_]): Unit =
+  def registerCode(mname: String, rt: Type)(impl: EmitMethodBuilder => Code[_]): Unit =
     registerCode(mname, Array[Type](), rt) { case (mb, Array()) => impl(mb) }
 
-  def registerCode[T1: TypeInfo](mname: String, mt1: Type, rt: Type)(impl: (MethodBuilder, Code[T1]) => Code[_]): Unit =
+  def registerCode[T1: TypeInfo](mname: String, mt1: Type, rt: Type)(impl: (EmitMethodBuilder, Code[T1]) => Code[_]): Unit =
     registerCode(mname, Array(mt1), rt) { case (mb, Array(a1)) => impl(mb, coerce[T1](a1)) }
 
-  def registerCode[T1: TypeInfo, T2: TypeInfo](mname: String, mt1: Type, mt2: Type, rt: Type)(impl: (MethodBuilder, Code[T1], Code[T2]) => Code[_]): Unit =
+  def registerCode[T1: TypeInfo, T2: TypeInfo](mname: String, mt1: Type, mt2: Type, rt: Type)(impl: (EmitMethodBuilder, Code[T1], Code[T2]) => Code[_]): Unit =
     registerCode(mname, Array(mt1, mt2), rt) { case (mb, Array(a1, a2)) => impl(mb, coerce[T1](a1), coerce[T2](a2)) }
 
   def registerCode[T1: TypeInfo, T2: TypeInfo, T3: TypeInfo](mname: String, mt1: Type, mt2: Type, mt3: Type, rt: Type)
-    (impl: (MethodBuilder, Code[_], Code[_], Code[_]) => Code[_]): Unit =
+    (impl: (EmitMethodBuilder, Code[_], Code[_], Code[_]) => Code[_]): Unit =
     registerCode(mname, Array(mt1, mt2, mt3), rt) { case (mb, Array(a1, a2, a3)) => impl(mb, coerce[T1](a1), coerce[T2](a2), coerce[T3](a3)) }
 
-  def registerCodeWithMissingness(mname: String, rt: Type)(impl: MethodBuilder => EmitTriplet): Unit =
+  def registerCodeWithMissingness(mname: String, rt: Type)(impl: EmitMethodBuilder => EmitTriplet): Unit =
     registerCodeWithMissingness(mname, Array[Type](), rt) { case (mb, Array()) => impl(mb) }
 
-  def registerCodeWithMissingness(mname: String, mt1: Type, rt: Type)(impl: (MethodBuilder, EmitTriplet) => EmitTriplet): Unit =
+  def registerCodeWithMissingness(mname: String, mt1: Type, rt: Type)(impl: (EmitMethodBuilder, EmitTriplet) => EmitTriplet): Unit =
     registerCodeWithMissingness(mname, Array(mt1), rt) { case (mb, Array(a1)) => impl(mb, a1) }
 
-  def registerCodeWithMissingness(mname: String, mt1: Type, mt2: Type, rt: Type)(impl: (MethodBuilder, EmitTriplet, EmitTriplet) => EmitTriplet): Unit =
+  def registerCodeWithMissingness(mname: String, mt1: Type, mt2: Type, rt: Type)(impl: (EmitMethodBuilder, EmitTriplet, EmitTriplet) => EmitTriplet): Unit =
     registerCodeWithMissingness(mname, Array(mt1, mt2), rt) { case (mb, Array(a1, a2)) => impl(mb, a1, a2) }
 
   def registerIR(mname: String)(f: () => IR): Unit =
@@ -177,9 +177,9 @@ sealed abstract class IRFunction {
 
   def argTypes: Seq[Type]
 
-  def apply(mb: MethodBuilder, args: EmitTriplet*): EmitTriplet
+  def apply(mb: EmitMethodBuilder, args: EmitTriplet*): EmitTriplet
 
-  def getAsMethod(fb: FunctionBuilder[_], args: Type*): MethodBuilder = ???
+  def getAsMethod(fb: EmitFunctionBuilder[_], args: Type*): EmitMethodBuilder = ???
 
   def returnType: Type
 
@@ -192,9 +192,9 @@ abstract class IRFunctionWithoutMissingness extends IRFunction {
 
   def argTypes: Seq[Type]
 
-  def apply(mb: MethodBuilder, args: Code[_]*): Code[_]
+  def apply(mb: EmitMethodBuilder, args: Code[_]*): Code[_]
 
-  def apply(mb: MethodBuilder, args: EmitTriplet*): EmitTriplet = {
+  def apply(mb: EmitMethodBuilder, args: EmitTriplet*): EmitTriplet = {
     val setup = args.map(_.setup)
     val missing = args.map(_.m).reduce(_ || _)
     val value = apply(mb, args.map(_.v): _*)
@@ -202,7 +202,7 @@ abstract class IRFunctionWithoutMissingness extends IRFunction {
     EmitTriplet(setup, missing, value)
   }
 
-  override def getAsMethod(fb: FunctionBuilder[_], args: Type*): MethodBuilder = {
+  override def getAsMethod(fb: EmitFunctionBuilder[_], args: Type*): EmitMethodBuilder = {
     argTypes.foreach(_.clear())
     (argTypes, args).zipped.foreach(_.unify(_))
     val ts = argTypes.map(t => typeToTypeInfo(t.subst()))
@@ -221,7 +221,7 @@ abstract class IRFunctionWithMissingness extends IRFunction {
 
   def argTypes: Seq[Type]
 
-  def apply(mb: MethodBuilder, args: EmitTriplet*): EmitTriplet
+  def apply(mb: EmitMethodBuilder, args: EmitTriplet*): EmitTriplet
 
   def returnType: Type
 

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -140,15 +140,14 @@ abstract class RegistryFunctions {
   def registerCode(mname: String, rt: Type)(impl: EmitMethodBuilder => Code[_]): Unit =
     registerCode(mname, Array[Type](), rt) { case (mb, Array()) => impl(mb) }
 
-  def registerCode[T1: TypeInfo](mname: String, mt1: Type, rt: Type)(impl: (EmitMethodBuilder, Code[T1]) => Code[_]): Unit =
-    registerCode(mname, Array(mt1), rt) { case (mb, Array(a1)) => impl(mb, coerce[T1](a1)) }
+  def registerCode(mname: String, mt1: Type, rt: Type)(impl: (EmitMethodBuilder, Code[_]) => Code[_]): Unit =
+    registerCode(mname, Array(mt1), rt) { case (mb, Array(a1)) => impl(mb, a1) }
 
-  def registerCode[T1: TypeInfo, T2: TypeInfo](mname: String, mt1: Type, mt2: Type, rt: Type)(impl: (EmitMethodBuilder, Code[T1], Code[T2]) => Code[_]): Unit =
-    registerCode(mname, Array(mt1, mt2), rt) { case (mb, Array(a1, a2)) => impl(mb, coerce[T1](a1), coerce[T2](a2)) }
+  def registerCode(mname: String, mt1: Type, mt2: Type, rt: Type)(impl: (EmitMethodBuilder, Code[_], Code[_]) => Code[_]): Unit =
+    registerCode(mname, Array(mt1, mt2), rt) { case (mb, Array(a1, a2)) => impl(mb, a1, a2) }
 
-  def registerCode[T1: TypeInfo, T2: TypeInfo, T3: TypeInfo](mname: String, mt1: Type, mt2: Type, mt3: Type, rt: Type)
-    (impl: (EmitMethodBuilder, Code[_], Code[_], Code[_]) => Code[_]): Unit =
-    registerCode(mname, Array(mt1, mt2, mt3), rt) { case (mb, Array(a1, a2, a3)) => impl(mb, coerce[T1](a1), coerce[T2](a2), coerce[T3](a3)) }
+  def registerCode(mname: String, mt1: Type, mt2: Type, mt3: Type, rt: Type)(impl: (EmitMethodBuilder, Code[_], Code[_], Code[_]) => Code[_]): Unit =
+    registerCode(mname, Array(mt1, mt2, mt3), rt) { case (mb, Array(a1, a2, a3)) => impl(mb, a1, a2, a3) }
 
   def registerCodeWithMissingness(mname: String, rt: Type)(impl: EmitMethodBuilder => EmitTriplet): Unit =
     registerCodeWithMissingness(mname, Array[Type](), rt) { case (mb, Array()) => impl(mb) }

--- a/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -8,7 +8,7 @@ import is.hail.utils._
 object GenotypeFunctions extends RegistryFunctions {
 
   def registerAll() {
-    registerCode("gqFromPL", TArray(tv("N", _.isInstanceOf[TInt32])), TInt32()) { (mb, pl: Code[Long]) =>
+    registerCode("gqFromPL", TArray(tv("N", _.isInstanceOf[TInt32])), TInt32()) { case (mb, pl: Code[Long]) =>
       val region = mb.getArg[Region](1).load()
       val tPL = TArray(tv("N").t)
       val m = mb.newLocal[Int]("m")

--- a/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
@@ -57,7 +57,8 @@ object MathFunctions extends RegistryFunctions {
     registerScalaFunction("**", TFloat64(), TFloat64(), TFloat64())(mathPackageClass, "pow")
     registerScalaFunction("gamma", TFloat64(), TFloat64())(thisClass, "gamma")
 
-    registerScalaFunction("binomTest", TInt32(), TInt32(), TFloat64(), TString(), TFloat64())(statsPackageClass, "binomTest")
+    // FIXME: This needs to do string conversion.
+    // registerScalaFunction("binomTest", TInt32(), TInt32(), TFloat64(), TString(), TFloat64())(statsPackageClass, "binomTest")
 
     registerScalaFunction("dbeta", TFloat64(), TFloat64(), TFloat64(), TFloat64())(statsPackageClass, "dbeta")
 

--- a/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -17,8 +17,7 @@ object StringFunctions extends RegistryFunctions {
   }
 
   private[this] def convertFromString(mb: EmitMethodBuilder, v: Code[String]): Code[Long] = {
-    val srvb = new StagedRegionValueBuilder(mb, TString())
-    Code(srvb.start(), srvb.addString(v), srvb.end())
+    mb.getArg[Region](1).load().appendString(v)
   }
 
   private[this] def registerWrappedStringScalaFunction(mname: String, argTypes: Array[Type], rType: Type)(cls: Class[_], method: String) {

--- a/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -1,9 +1,54 @@
 package is.hail.expr.ir.functions
 
+import is.hail.annotations.{Region, StagedRegionValueBuilder}
+import is.hail.asm4s
+import is.hail.asm4s._
+import is.hail.expr.ir
+import is.hail.expr.ir.{EmitMethodBuilder, EmitTriplet, TypeToIRIntermediateClassTag}
 import is.hail.expr.types._
 import is.hail.utils._
 
+import scala.reflect.{ClassTag, classTag}
+
 object StringFunctions extends RegistryFunctions {
+
+  private[this] def wrapToString(mb: EmitMethodBuilder, v: Code[Long]): Code[String] = {
+    Code.invokeScalaObject[Region, Long, String](TString.getClass, "loadString", mb.getArg[Region](1), v)
+  }
+
+  private[this] def convertFromString(mb: EmitMethodBuilder, v: Code[String]): Code[Long] = {
+    val srvb = new StagedRegionValueBuilder(mb, TString())
+    Code(srvb.start(), srvb.addString(v), srvb.end())
+  }
+
+  private[this] def registerWrappedStringScalaFunction(mname: String, argTypes: Array[Type], rType: Type)(cls: Class[_], method: String) {
+    def ct(typ: Type): ClassTag[_] = typ match {
+      case _: TString => classTag[String]
+      case t => TypeToIRIntermediateClassTag(t)
+    }
+
+    def conversion(mb: EmitMethodBuilder, typ: Type, v: Code[_]): Code[_] = (typ, v) match {
+        case (_: TString, v2: Code[Long]) => wrapToString(mb, v2)
+        case (_, v2) => v2
+    }
+
+    def convertBack(mb: EmitMethodBuilder, v: Code[_]): Code[_] = rType match {
+      case _: TString => convertFromString(mb, asm4s.coerce[String](v))
+      case t => v
+    }
+
+    registerCode(mname, argTypes, rType) { (mb, args) =>
+      val cts = argTypes.map(ct(_).runtimeClass)
+      val out = Code.invokeScalaObject(cls, method, cts, argTypes.zip(args).map { case (t, a) => conversion(mb, t, a) } )(ct(rType))
+      convertBack(mb, out)
+    }
+  }
+
+  def registerWrappedStringScalaFunction(mname: String, a1: Type, rType: Type)(cls: Class[_], method: String): Unit =
+    registerWrappedStringScalaFunction(mname, Array(a1), rType)(cls, method)
+
+  def registerWrappedStringScalaFunction(mname: String, a1: Type, a2: Type, rType: Type)(cls: Class[_], method: String): Unit =
+    registerWrappedStringScalaFunction(mname, Array(a1, a2), rType)(cls, method)
 
   def upper(s: String): String = s.toUpperCase
 
@@ -17,16 +62,48 @@ object StringFunctions extends RegistryFunctions {
 
   def endswith(s: String, t: String): Boolean = s.endsWith(t)
 
-  def firstMatchIn(s: String, regex: String): IndexedSeq[String] = regex.r.findFirstMatchIn(s).map(_.subgroups.toArray.toFastIndexedSeq).orNull
+  def firstMatchIn(s: String, regex: String): IndexedSeq[String] = {
+    regex.r.findFirstMatchIn(s).map(_.subgroups.toArray.toFastIndexedSeq).orNull
+  }
 
   def registerAll(): Unit = {
     val thisClass = getClass
-    registerScalaFunction("upper", TString(), TString())(thisClass, "upper")
-    registerScalaFunction("lower", TString(), TString())(thisClass, "lower")
-    registerScalaFunction("strip", TString(), TString())(thisClass, "strip")
-    registerScalaFunction("contains", TString(), TString(), TBoolean())(thisClass, "contains")
-    registerScalaFunction("startswith", TString(), TString(), TBoolean())(thisClass, "startswith")
-    registerScalaFunction("endswith", TString(), TString(), TBoolean())(thisClass, "endswith")
-    registerScalaFunction("firstMatchIn", TString(), TString(), TArray(TString()))(thisClass, "firstMatchIn")
+    registerWrappedStringScalaFunction("upper", TString(), TString())(thisClass, "upper")
+    registerWrappedStringScalaFunction("lower", TString(), TString())(thisClass, "lower")
+    registerWrappedStringScalaFunction("strip", TString(), TString())(thisClass, "strip")
+    registerWrappedStringScalaFunction("contains", TString(), TString(), TBoolean())(thisClass, "contains")
+    registerWrappedStringScalaFunction("startswith", TString(), TString(), TBoolean())(thisClass, "startswith")
+    registerWrappedStringScalaFunction("endswith", TString(), TString(), TBoolean())(thisClass, "endswith")
+
+    registerCodeWithMissingness("firstMatchIn", TString(), TString(), TArray(TString())) { (mb: EmitMethodBuilder, s: EmitTriplet, r: EmitTriplet) =>
+      val out: LocalRef[IndexedSeq[String]] = mb.newLocal[IndexedSeq[String]]
+      val nout = new CodeNullable[IndexedSeq[String]](out)
+
+      val srvb: StagedRegionValueBuilder = new StagedRegionValueBuilder(mb, TArray(TString()))
+      val len: LocalRef[Int] = mb.newLocal[Int]
+      val elt: LocalRef[String] = mb.newLocal[String]
+      val nelt = new CodeNullable[String](elt)
+
+      val setup = Code(s.setup, r.setup)
+      val missing = s.m || r.m || Code(
+        out := Code.invokeScalaObject[String, String, IndexedSeq[String]](thisClass,
+          "firstMatchIn", wrapToString(mb, s.value[Long]), wrapToString(mb, r.value[Long])),
+        nout.isNull)
+      val value =
+        nout.ifNull(
+          ir.defaultValue(TArray(TString())),
+          Code(
+            len := out.invoke[Int]("size"),
+            srvb.start(len),
+            Code.whileLoop(srvb.arrayIdx < len,
+              elt := out.invoke[Int, String]("apply", srvb.arrayIdx),
+              nelt.ifNull(
+                srvb.setMissing(),
+                srvb.addString(elt)),
+              srvb.advance()),
+            srvb.end()))
+
+      EmitTriplet(setup, missing, value)
+    }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -11,7 +11,7 @@ import is.hail.asm4s
 object UtilFunctions extends RegistryFunctions {
 
   def registerAll() {
-    registerCode("triangle", TInt32(), TInt32()) { (_, n: Code[Int]) => n * (n + 1) / 2 }
+    registerCode("triangle", TInt32(), TInt32()) { case (_, n: Code[Int]) => n * (n + 1) / 2 }
 
     registerIR("size", TArray(tv("T")))(ArrayLen)
 
@@ -118,56 +118,14 @@ object UtilFunctions extends RegistryFunctions {
       InsertFields(s, annotations.asInstanceOf[MakeStruct].fields)
     }
 
-    registerCodeWithMissingness("==", tv("T"), tv("T"), TBoolean()) { (mb, v1, v2) =>
-      val tactual = tv("T").t match {
-        case tc: ComplexType => tc.representation
-        case t => t
-      }
-      val comparison = (tactual, v1.v, v2.v) match {
-        case (_: TBoolean, x1: Code[Boolean], x2: Code[Boolean]) => x1.ceq(x2)
-        case (_: TInt32, x1: Code[Int], x2: Code[Int]) => x1.ceq(x2)
-        case (_: TInt64, x1: Code[Long], x2: Code[Long]) => x1.ceq(x2)
-        case (_: TFloat32, x1: Code[Float], x2: Code[Float]) => x1.ceq(x2)
-        case (_: TFloat64, x1: Code[Double], x2: Code[Double]) => x1.ceq(x2)
-        case (t, o1: Code[Long], o2: Code[Long]) =>
-          val ord = CodeOrdering(t, missingGreatest = true)
-          ord.compare(mb, mb.getArg[Region](1), o1, mb.getArg[Region](1), o2).ceq(0)
-        case (t, x1, x2) =>
-          throw new UnsupportedOperationException(s"can't compare things of type $t with classes ${ x1.getClass } and ${ x2.getClass }")
-      }
-
-      val setup = Code(v1.setup, v2.setup)
-      val v1m = mb.newLocal[Boolean]
-      val vout = Code(
-        v1m := v1.m,
-        v1m.cne(v2.m).mux(const(false), v1m.mux(const(true), comparison)))
-      EmitTriplet(setup, const(false), vout)
+    registerCode("==", tv("T"), tv("T"), TBoolean()) { (mb, v1, v2) =>
+      val ord = CodeOrdering(tv("T").t, missingGreatest = true)
+      ord.compare(mb, v1, v2).ceq(0)
     }
 
-    registerCodeWithMissingness("!=", tv("T"), tv("T"), TBoolean()) { (mb, v1, v2) =>
-      val tactual = tv("T").t match {
-        case tc: ComplexType => tc.representation
-        case t => t
-      }
-      val comparison = (tactual, v1.v, v2.v) match {
-        case (_: TBoolean, x1: Code[Boolean], x2: Code[Boolean]) => x1.cne(x2)
-        case (_: TInt32, x1: Code[Int], x2: Code[Int]) => x1.cne(x2)
-        case (_: TInt64, x1: Code[Long], x2: Code[Long]) => x1.cne(x2)
-        case (_: TFloat32, x1: Code[Float], x2: Code[Float]) => x1.cne(x2)
-        case (_: TFloat64, x1: Code[Double], x2: Code[Double]) => x1.cne(x2)
-        case (t, o1: Code[Long], o2: Code[Long]) =>
-          val ord = CodeOrdering(t, missingGreatest = true)
-          ord.compare(mb, mb.getArg[Region](1), o1, mb.getArg[Region](1), o2).cne(0)
-        case (t, x1, x2) =>
-          throw new UnsupportedOperationException(s"can't compare things of type $t with classes ${ x1.getClass } and ${ x2.getClass }")
-      }
-
-      val setup = Code(v1.setup, v2.setup)
-      val v1m = mb.newLocal[Boolean]
-      val vout = Code(
-        v1m := v1.m,
-        v1m.cne(v2.m).mux(const(true), v1m.mux(const(false), comparison)))
-      EmitTriplet(setup, const(false), vout)
+    registerCode("!=", tv("T"), tv("T"), TBoolean()) { (mb, v1, v2) =>
+      val ord = CodeOrdering(tv("T").t, missingGreatest = true)
+      ord.compare(mb, v1, v2).cne(0)
     }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -127,5 +127,25 @@ object UtilFunctions extends RegistryFunctions {
       val ord = CodeOrdering(tv("T").t, missingGreatest = true)
       ord.compare(mb, v1, v2).cne(0)
     }
+
+    registerCode("<=", tv("T"), tv("T"), TBoolean()) { (mb, v1, v2) =>
+      val ord = CodeOrdering(tv("T").t, missingGreatest = true)
+      ord.compare(mb, v1, v2) <= 0
+    }
+
+    registerCode(">=", tv("T"), tv("T"), TBoolean()) { (mb, v1, v2) =>
+      val ord = CodeOrdering(tv("T").t, missingGreatest = true)
+      ord.compare(mb, v1, v2) >= 0
+    }
+
+    registerCode("<", tv("T"), tv("T"), TBoolean()) { (mb, v1, v2) =>
+      val ord = CodeOrdering(tv("T").t, missingGreatest = true)
+      ord.compare(mb, v1, v2) < 0
+    }
+
+    registerCode(">", tv("T"), tv("T"), TBoolean()) { (mb, v1, v2) =>
+      val ord = CodeOrdering(tv("T").t, missingGreatest = true)
+      ord.compare(mb, v1, v2) > 0
+    }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -1,10 +1,12 @@
 package is.hail.expr.ir.functions
 
+import is.hail.annotations.{CodeOrdering, Region}
 import is.hail.asm4s._
 import is.hail.expr.ir._
 import is.hail.expr.types._
 import is.hail.utils._
 import is.hail.expr.types.coerce
+import is.hail.asm4s
 
 object UtilFunctions extends RegistryFunctions {
 
@@ -114,6 +116,58 @@ object UtilFunctions extends RegistryFunctions {
 
     registerIR("annotate", tv("T", _.isInstanceOf[TStruct]), tv("U", _.isInstanceOf[TStruct])) { (s, annotations) =>
       InsertFields(s, annotations.asInstanceOf[MakeStruct].fields)
+    }
+
+    registerCodeWithMissingness("==", tv("T"), tv("T"), TBoolean()) { (mb, v1, v2) =>
+      val tactual = tv("T").t match {
+        case tc: ComplexType => tc.representation
+        case t => t
+      }
+      val comparison = (tactual, v1.v, v2.v) match {
+        case (_: TBoolean, x1: Code[Boolean], x2: Code[Boolean]) => x1.ceq(x2)
+        case (_: TInt32, x1: Code[Int], x2: Code[Int]) => x1.ceq(x2)
+        case (_: TInt64, x1: Code[Long], x2: Code[Long]) => x1.ceq(x2)
+        case (_: TFloat32, x1: Code[Float], x2: Code[Float]) => x1.ceq(x2)
+        case (_: TFloat64, x1: Code[Double], x2: Code[Double]) => x1.ceq(x2)
+        case (t, o1: Code[Long], o2: Code[Long]) =>
+          val ord = CodeOrdering(t, missingGreatest = true)
+          ord.compare(mb, mb.getArg[Region](1), o1, mb.getArg[Region](1), o2).ceq(0)
+        case (t, x1, x2) =>
+          throw new UnsupportedOperationException(s"can't compare things of type $t with classes ${ x1.getClass } and ${ x2.getClass }")
+      }
+
+      val setup = Code(v1.setup, v2.setup)
+      val v1m = mb.newLocal[Boolean]
+      val vout = Code(
+        v1m := v1.m,
+        v1m.cne(v2.m).mux(const(false), v1m.mux(const(true), comparison)))
+      EmitTriplet(setup, const(false), vout)
+    }
+
+    registerCodeWithMissingness("!=", tv("T"), tv("T"), TBoolean()) { (mb, v1, v2) =>
+      val tactual = tv("T").t match {
+        case tc: ComplexType => tc.representation
+        case t => t
+      }
+      val comparison = (tactual, v1.v, v2.v) match {
+        case (_: TBoolean, x1: Code[Boolean], x2: Code[Boolean]) => x1.cne(x2)
+        case (_: TInt32, x1: Code[Int], x2: Code[Int]) => x1.cne(x2)
+        case (_: TInt64, x1: Code[Long], x2: Code[Long]) => x1.cne(x2)
+        case (_: TFloat32, x1: Code[Float], x2: Code[Float]) => x1.cne(x2)
+        case (_: TFloat64, x1: Code[Double], x2: Code[Double]) => x1.cne(x2)
+        case (t, o1: Code[Long], o2: Code[Long]) =>
+          val ord = CodeOrdering(t, missingGreatest = true)
+          ord.compare(mb, mb.getArg[Region](1), o1, mb.getArg[Region](1), o2).cne(0)
+        case (t, x1, x2) =>
+          throw new UnsupportedOperationException(s"can't compare things of type $t with classes ${ x1.getClass } and ${ x2.getClass }")
+      }
+
+      val setup = Code(v1.setup, v2.setup)
+      val v1m = mb.newLocal[Boolean]
+      val vout = Code(
+        v1m := v1.m,
+        v1m.cne(v2.m).mux(const(true), v1m.mux(const(false), comparison)))
+      EmitTriplet(setup, const(false), vout)
     }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir.functions
 
-import is.hail.annotations.{CodeOrdering, Region}
+import is.hail.annotations.CodeOrdering
 import is.hail.asm4s._
 import is.hail.expr.ir._
 import is.hail.expr.types._

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -16,11 +16,16 @@ object UtilFunctions extends RegistryFunctions {
     registerIR("size", TArray(tv("T")))(ArrayLen)
 
     registerIR("sum", TArray(tnum("T"))) { a =>
+      val sum = genUID()
+      val v = genUID()
       val zero = Literal(0, coerce[TArray](a.typ).elementType)
-      ArrayFold(a, zero, "sum", "v", If(IsNA(Ref("v")), Ref("sum"), ApplyBinaryPrimOp(Add(), Ref("sum"), Ref("v"))))
+      ArrayFold(a, zero, sum, v, If(IsNA(Ref(v)), Ref(sum), ApplyBinaryPrimOp(Add(), Ref(sum), Ref(v))))
     }
 
-    registerIR("*", TArray(tnum("T")), tv("T")){ (a, c) => ArrayMap(a, "imul", ApplyBinaryPrimOp(Multiply(), Ref("imul"), c)) }
+    registerIR("*", TArray(tnum("T")), tv("T")){ (a, c) =>
+      val imul = genUID()
+      ArrayMap(a, imul, ApplyBinaryPrimOp(Multiply(), Ref(imul), c))
+    }
 
     registerIR("sum", TAggregable(tnum("T")))(ApplyAggOp(_, Sum(), FastSeq()))
 

--- a/src/main/scala/is/hail/expr/ir/package.scala
+++ b/src/main/scala/is/hail/expr/ir/package.scala
@@ -36,12 +36,13 @@ package object ir {
 
   // Build consistent expression for a filter-condition with keep polarity,
   // using Let to manage missing-ness.
-  def filterPredicateWithKeep(irPred: ir.IR, keep: Boolean, letName: String): ir.IR = {
-    ir.Let(letName,
+  def filterPredicateWithKeep(irPred: ir.IR, keep: Boolean): ir.IR = {
+    val pred = genUID()
+    ir.Let(pred,
       if (keep) irPred else ir.ApplyUnaryPrimOp(ir.Bang(), irPred),
-      ir.If(ir.IsNA(ir.Ref(letName)),
+      ir.If(ir.IsNA(ir.Ref(pred)),
         ir.False(),
-        ir.Ref(letName)))
+        ir.Ref(pred)))
   }
 
   private[ir] def coerce[T](c: Code[_]): Code[T] = asm4s.coerce(c)

--- a/src/main/scala/is/hail/expr/types/TFloat32.scala
+++ b/src/main/scala/is/hail/expr/types/TFloat32.scala
@@ -42,12 +42,20 @@ class TFloat32(override val required: Boolean) extends TNumeric {
 
   override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering = new UnsafeOrdering {
     def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
-      java.lang.Float.compare(r1.loadFloat(o1), r2.loadFloat(o2))
+      val f1 = r1.loadFloat(o1)
+      val f2 = r2.loadFloat(o2)
+      if (f1 == f2) 0 else java.lang.Float.compare(f1, f2)
     }
   }
 
   val ordering: ExtendedOrdering =
-    ExtendedOrdering.extendToNull(implicitly[Ordering[Float]])
+    new ExtendedOrdering {
+      def compareNonnull(x: T, y: T, missingGreatest: Boolean): Int = {
+        val fx = x.asInstanceOf[Float]
+        val fy = y.asInstanceOf[Float]
+        if (fx == fy) 0 else java.lang.Float.compare(fx, fy)
+      }
+    }
 
   override def byteSize: Long = 4
 }

--- a/src/main/scala/is/hail/expr/types/TFloat64.scala
+++ b/src/main/scala/is/hail/expr/types/TFloat64.scala
@@ -43,12 +43,20 @@ class TFloat64(override val required: Boolean) extends TNumeric {
 
   override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering = new UnsafeOrdering {
     def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
-      java.lang.Double.compare(r1.loadDouble(o1), r2.loadDouble(o2))
+      val d1 = r1.loadDouble(o1)
+      val d2 = r2.loadDouble(o2)
+      if (d1 == d2) 0 else java.lang.Double.compare(d1, d2)
     }
   }
 
   val ordering: ExtendedOrdering =
-    ExtendedOrdering.extendToNull(implicitly[Ordering[Double]])
+    new ExtendedOrdering {
+      def compareNonnull(x: T, y: T, missingGreatest: Boolean): Int = {
+        val dx = x.asInstanceOf[Double]
+        val dy = y.asInstanceOf[Double]
+        if (dx == dy) 0 else java.lang.Double.compare(dx, dy)
+      }
+    }
 
   override def byteSize: Long = 8
 }

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -458,7 +458,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
     pred match {
       case Some(irPred) =>
         new Table(hc,
-          TableFilter(tir, ir.filterPredicateWithKeep(irPred, keep, "filter_pred"))
+          TableFilter(tir, ir.filterPredicateWithKeep(irPred, keep))
         )
       case None =>
         log.warn(s"Table.filter found no AST to IR conversion: ${ PrettyAST(filterAST) }")

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1282,7 +1282,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     pred match {
       case Some(irPred) =>
         new MatrixTable(hc,
-          FilterColsIR(ast, ir.filterPredicateWithKeep(irPred, keep, "filterCols_pred"))
+          FilterColsIR(ast, ir.filterPredicateWithKeep(irPred, keep))
         )
       case None =>
         log.info(s"filterCols: No AST to IR conversion. Fallback for predicate ${ PrettyAST(filterAST) }")
@@ -1314,7 +1314,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     pred match {
       case Some(irPred) =>
         new MatrixTable(hc,
-          FilterRowsIR(ast, ir.filterPredicateWithKeep(irPred, keep, "filterRows_pred"))
+          FilterRowsIR(ast, ir.filterPredicateWithKeep(irPred, keep))
         )
       case _ =>
         log.info(s"filterRows: No AST to IR conversion. Fallback for predicate ${ PrettyAST(filterAST) }")
@@ -2189,7 +2189,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     val filterAST = Parser.parseToAST(filterExpr, ec)
     filterAST.toIR() match {
       case Some(x) if useIR(entryAxis, filterAST) =>
-        copyAST(MatrixFilterEntries(ast, ir.filterPredicateWithKeep(x, keep, "filterEntriesPred")))
+        copyAST(MatrixFilterEntries(ast, ir.filterPredicateWithKeep(x, keep)))
 
       case _ =>
         log.warn(s"filter_entries found no AST to IR conversion: ${ PrettyAST(filterAST) }")

--- a/src/test/scala/is/hail/expr/ir/CompileSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/CompileSuite.scala
@@ -639,4 +639,18 @@ class CompileSuite {
     val expected = grch37.isValidContig("X") && grch37.isValidContig("Y") && grch38.isValidContig("X")
     assert(fb.result()()("X", "Y") == expected)
   }
+
+  @Test
+  def testStringConstantWorks() {
+    val ir = Str("hello")
+
+    val fb = EmitFunctionBuilder[Region, Long]
+    doit(ir, fb)
+    val f = fb.result()()
+
+    val region = Region()
+    val off = f(region)
+    assert(TString.loadString(region, off) == "hello")
+
+  }
 }

--- a/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -30,8 +30,8 @@ object TestRegisterFunctions extends RegistryFunctions {
     registerJavaStaticFunction("compare", TInt32(), TInt32(), TInt32())(classOf[java.lang.Integer], "compare")
     registerScalaFunction("foobar1", TInt32())(ScalaTestObject.getClass, "testFunction")
     registerScalaFunction("foobar2", TInt32())(ScalaTestCompanion.getClass, "testFunction")
-    registerCode("testCodeUnification", tnum("x"), tv("x", _.isInstanceOf[TInt32]), tv("x")){ (_, a: Code[Int], b: Code[Int]) => a + b }
-    registerCode("testCodeUnification2", tv("x"), tv("x")){ (_, a: Code[Long]) => a }
+    registerCode("testCodeUnification", tnum("x"), tv("x", _.isInstanceOf[TInt32]), tv("x")){ case (_, a: Code[Int], b: Code[Int]) => a + b }
+    registerCode("testCodeUnification2", tv("x"), tv("x")){ case (_, a: Code[Long]) => a }
   }
 }
 

--- a/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -5,9 +5,9 @@ import is.hail.check.{Gen, Prop}
 import is.hail.asm4s._
 import is.hail.expr.ir._
 import is.hail.expr.types._
-import is.hail.utils.Interval
-import org.apache.spark.sql.Row
 import org.testng.annotations.Test
+import is.hail.utils._
+import org.apache.spark.sql.Row
 
 class OrderingSuite {
 
@@ -32,6 +32,53 @@ class OrderingSuite {
       fb.emit(stagedOrdering.compare(fb.apply_method, fb.getArg[Region](1), fb.getArg[Long](2), fb.getArg[Region](1), fb.getArg[Long](3)))
       val f = fb.result()()
       f(region, v1, v2) == compare
+    }
+    p.check()
+  }
+
+  @Test def testEqualityInEmitFunction() {
+    val compareGen = Type.genArb.flatMap(t => Gen.zip(Gen.const(t), t.genNonmissingValue, t.genNonmissingValue))
+    val p = Prop.forAll(compareGen) { case (t, a1, a2) =>
+
+      val ttup = TTuple(t)
+      val region = Region()
+      val rvb = new RegionValueBuilder(region)
+
+      rvb.start(ttup)
+      rvb.addAnnotation(ttup, Row(a1))
+      val tup1 = rvb.end()
+
+      rvb.start(ttup)
+      rvb.addAnnotation(ttup, Row(a2))
+      val tup2 = rvb.end()
+
+      val v1 = ttup.loadField(region, tup1, 0)
+      val v2 = ttup.loadField(region, tup2, 0)
+
+      val compare = t.unsafeOrdering(true).compare(region, v1, region, v2)
+
+      val ir = ApplySpecial("==", FastSeq(GetTupleElement(In(0, ttup), 0), GetTupleElement(In(1, ttup), 0)))
+      val irfb = EmitFunctionBuilder[Region, Long, Boolean, Long, Boolean, Boolean]
+
+      Infer(ir)
+      Emit(ir, irfb)
+
+      val irf = irfb.result()()
+      assert(irf(region, tup1, false, tup2, false) == (compare == 0))
+      assert(irf(region, tup1, false, tup1, false))
+      assert(irf(region, tup2, false, tup2, false))
+
+      val ir2 = ApplySpecial("!=", FastSeq(GetTupleElement(In(0, TTuple(t)), 0), GetTupleElement(In(1, TTuple(t)), 0)))
+      val irfb2 = EmitFunctionBuilder[Region, Long, Boolean, Long, Boolean, Boolean]
+
+      Infer(ir2)
+      Emit(ir2, irfb2)
+
+      val irf2 = irfb2.result()()
+      assert(irf2(region, tup1, false, tup2, false) == (compare != 0))
+      assert(!irf2(region, tup1, false, tup1, false))
+      assert(!irf2(region, tup2, false, tup2, false))
+      true
     }
     p.check()
   }

--- a/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -57,7 +57,7 @@ class OrderingSuite {
 
       val compare = t.unsafeOrdering(true).compare(region, v1, region, v2)
 
-      val ir = ApplySpecial("==", FastSeq(GetTupleElement(In(0, ttup), 0), GetTupleElement(In(1, ttup), 0)))
+      val ir = Apply("==", FastSeq(GetTupleElement(In(0, ttup), 0), GetTupleElement(In(1, ttup), 0)))
       val irfb = EmitFunctionBuilder[Region, Long, Boolean, Long, Boolean, Boolean]
 
       Infer(ir)
@@ -68,7 +68,7 @@ class OrderingSuite {
       assert(irf(region, tup1, false, tup1, false))
       assert(irf(region, tup2, false, tup2, false))
 
-      val ir2 = ApplySpecial("!=", FastSeq(GetTupleElement(In(0, TTuple(t)), 0), GetTupleElement(In(1, TTuple(t)), 0)))
+      val ir2 = Apply("!=", FastSeq(GetTupleElement(In(0, TTuple(t)), 0), GetTupleElement(In(1, TTuple(t)), 0)))
       val irfb2 = EmitFunctionBuilder[Region, Long, Boolean, Long, Boolean, Boolean]
 
       Infer(ir2)

--- a/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -5,9 +5,9 @@ import is.hail.check.{Gen, Prop}
 import is.hail.asm4s._
 import is.hail.expr.ir._
 import is.hail.expr.types._
-import org.testng.annotations.Test
 import is.hail.utils._
 import org.apache.spark.sql.Row
+import org.testng.annotations.Test
 
 class OrderingSuite {
 


### PR DESCRIPTION
adds ArraySort, Set, Dict nodes to IR. 

Sets and dicts are stored as sorted arrays in the region; Sets keep all distinct values and dicts keep all distinct keys (with non-guaranteed value if multiple items have the same key) where the (key, value) tuple isn't missing.

Map, Filter, FlatMap, Fold still need to be expanded for sets and dicts.

Builds on #3388.