### PR TITLE
Improve LDPruneSuite timing

### DIFF
--- a/src/test/scala/is/hail/methods/LDPruneSuite.scala
+++ b/src/test/scala/is/hail/methods/LDPruneSuite.scala
@@ -110,6 +110,7 @@ object LDPruneSuite {
 class LDPruneSuite extends SparkSuite {
   val bytesPerCoreMB = 256
   val nCores = 4
+  val vds = TestUtils.splitMultiHTS(hc.importVCF("src/test/resources/sample.vcf.bgz", nPartitions = Option(10)))
 
   def toC2(i: Int): BoxedCall = if (i == -1) null else Call2.fromUnphasedDiploidGtIndex(i)
 
@@ -213,10 +214,6 @@ class LDPruneSuite extends SparkSuite {
   }
 
   object Spec extends Properties("LDPrune") {
-    val compGen = for (r2: Double <- Gen.choose(0.5, 1.0);
-    windowSize: Int <- Gen.choose(0, 5000);
-    nPartitions: Int <- Gen.choose(5, 10)) yield (r2, windowSize, nPartitions)
-
     val vectorGen = for (nSamples: Int <- Gen.choose(1, 1000);
       v1: Array[BoxedCall] <- Gen.buildableOfN[Array](nSamples, Gen.choose(-1, 2).map(toC2));
       v2: Array[BoxedCall] <- Gen.buildableOfN[Array](nSamples, Gen.choose(-1, 2).map(toC2))
@@ -264,13 +261,6 @@ class LDPruneSuite extends SparkSuite {
           case _ => true
         }
       }
-
-    property("uncorrelated") =
-      forAll(compGen) { case (r2: Double, windowSize: Int, nPartitions: Int) =>
-        val vds = TestUtils.splitMultiHTS(hc.importVCF("src/test/resources/sample.vcf.bgz", nPartitions = Option(nPartitions)))
-        val prunedVds = LDPrune(vds, nCores, r2, windowSize, bytesPerCoreMB)
-        isUncorrelated(prunedVds, r2, windowSize)
-      }
   }
 
   @Test def testRandom() {
@@ -278,8 +268,6 @@ class LDPruneSuite extends SparkSuite {
   }
 
   @Test def testInputs() {
-    def vds = TestUtils.splitMultiHTS(hc.importVCF("src/test/resources/sample.vcf.bgz", nPartitions = Option(10)))
-
     // memory per core requirement
     intercept[HailException](LDPrune(vds, nCores, r2Threshold = 0.2, windowSize = 1000, memoryPerCoreMB = 0))
 
@@ -309,15 +297,12 @@ class LDPruneSuite extends SparkSuite {
     }
   }
 
-  @Test def testWindow() {
-    val vds = TestUtils.splitMultiHTS(hc.importVCF("src/test/resources/sample.vcf.bgz"))
-    val prunedVds = LDPrune(vds, nCores, r2Threshold = 0.2, windowSize = 100000, memoryPerCoreMB = 200)
-    assert(isUncorrelated(prunedVds, 0.2, 1000))
+  @Test def testLargerInput() {
+    val prunedVds = LDPrune(vds, nCores, r2Threshold = 0.2, windowSize = 1000000, memoryPerCoreMB = 200)
+    assert(isUncorrelated(prunedVds, 0.2, 1000000))
   }
 
   @Test def testNoPrune() {
-    val vds = TestUtils.splitMultiHTS(hc.importVCF("src/test/resources/sample.vcf.bgz"))
-    val nSamples = vds.numCols
     val filteredVDS = vds.filterRowsExpr("AGG.filter(g => isDefined(g.GT)).map(_ => g.GT).collectAsSet().size() > 1")
     val prunedVDS = LDPrune(filteredVDS, nCores, r2Threshold = 1, windowSize = 0, memoryPerCoreMB = 200)
     assert(prunedVDS.countRows() == filteredVDS.countRows())


### PR DESCRIPTION
With 1 core on my local computer, it went from 49.832s to 10.254s with this change. I removed the random test (count=10) of pruning `sample.vcf` with random partition numbers, window size, and r2 threshold. This is replaced with one test with default parameters (R^2 = 0.2, window size = 1MB). I also moved the vcf import as a class value so it wasn't being reimported for each test.