### PR TITLE
minor decode optimization

### DIFF
--- a/src/main/scala/is/hail/io/RowStore.scala
+++ b/src/main/scala/is/hail/io/RowStore.scala
@@ -535,13 +535,11 @@ final class PackDecoder(in: InputBuffer) extends Decoder {
     val elemsOff = aoff + t.elementsOffset(length)
     val elemSize = t.elementByteSize
 
-    if (t.elementType.isInstanceOf[TInt32]) { // fast path
+    if (t.elementType.isInstanceOf[TInt32] && t.elementType.required) { // fast path
       var i = 0
       while (i < length) {
-        if (t.isElementDefined(region, aoff, i)) {
-          val off = elemsOff + i * elemSize
-          region.storeInt(off, in.readInt())
-        }
+        val off = elemsOff + i * elemSize
+        region.storeInt(off, in.readInt())
         i += 1
       }
     } else {
@@ -556,6 +554,7 @@ final class PackDecoder(in: InputBuffer) extends Decoder {
               region.storeAddress(off, aoff)
             case _: TBoolean => region.storeByte(off, in.readBoolean().toByte)
             case _: TInt64 => region.storeLong(off, in.readLong())
+            case _: TInt32 => region.storeInt(off, in.readInt())
             case _: TFloat32 => region.storeFloat(off, in.readFloat())
             case _: TFloat64 => region.storeDouble(off, in.readDouble())
             case _: TBinary => readBinary(region, off)

--- a/src/main/scala/is/hail/io/RowStore.scala
+++ b/src/main/scala/is/hail/io/RowStore.scala
@@ -535,7 +535,7 @@ final class PackDecoder(in: InputBuffer) extends Decoder {
     val elemsOff = aoff + t.elementsOffset(length)
     val elemSize = t.elementByteSize
 
-    if (t.elementType.isInstanceOf[TInt32] && t.elementType.required) { // fast path
+    if (t.elementType == TInt32Required) { // fast path
       var i = 0
       while (i < length) {
         val off = elemsOff + i * elemSize


### PR DESCRIPTION
Only fast-path required arrays (e.g. in AD, PL).  Gives minor (7%) decode speedup on a shard of gnomad (51.5s => 47.5s):

```
mt = hl.read_matrix_table('gnomad.mt')
mt = mt.drop_cols()
mt.write('freq.mt', overwrite=True)
```
