### PR TITLE
SelectCols in IR

### DIFF
--- a/python/hail/tests/test_api.py
+++ b/python/hail/tests/test_api.py
@@ -698,6 +698,17 @@ class MatrixTests(unittest.TestCase):
 
         assert(mt_entries.all(mt_entries.bc == mt_entries.foo))
 
+    def test_select_cols(self):
+        mt = hl.utils.range_matrix_table(3, 5, n_partitions=4)
+        mt = mt.annotate_entries(e=mt.col_idx * mt.row_idx)
+        mt = mt.annotate_globals(g=1)
+        mt = mt.annotate_cols(sum=agg.sum(mt.e + mt.col_idx + mt.row_idx + mt.g) + mt.col_idx + mt.g,
+                              count=agg.count_where(mt.e % 2 == 0),
+                              foo=agg.count(mt.e))
+
+        result = convert_struct_to_dict(mt.cols().collect()[-2])
+        self.assertEqual(result, {'col_idx': 3, 'sum': 28, 'count': 2, 'foo': 3})
+
     def test_drop(self):
         vds = self.get_vds()
         vds = vds.annotate_globals(foo=5)

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -1032,6 +1032,7 @@ case class MatrixMapCols(child: MatrixIR, newCol: IR) extends MatrixIR {
           val eMissing = localEntriesType.isElementMissing(region, entriesOff, i)
           val eOff = localEntriesType.elementOffset(entriesOff, localNCols, i)
           val colMissing = localColsType.isElementMissing(region, cols, i)
+          assert(!colMissing)
           val colOff = localColsType.elementOffset(cols, localNCols, i)
 
           var j = 0

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -650,8 +650,6 @@ case class FilterRows(
       prev.rvd.sparkContext, prev.typ, prev.globals, prev.colValues, ec)
 
     val fullRowType = prev.typ.rvRowType
-    val localRowType = prev.typ.rowType
-    val localEntriesIndex = prev.typ.entriesIdx
 
     val localGlobals = prev.globals.broadcast
 
@@ -752,13 +750,13 @@ case class CollectColsByKey(child: MatrixIR) extends MatrixIR {
   }
 }
 
-case class MapEntries(child: MatrixIR, newEntries: IR) extends MatrixIR {
+case class MatrixMapEntries(child: MatrixIR, newEntries: IR) extends MatrixIR {
 
   def children: IndexedSeq[BaseIR] = Array(child, newEntries)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): MapEntries = {
+  def copy(newChildren: IndexedSeq[BaseIR]): MatrixMapEntries = {
     assert(newChildren.length == 2)
-    MapEntries(newChildren(0).asInstanceOf[MatrixIR], newChildren(1).asInstanceOf[IR])
+    MatrixMapEntries(newChildren(0).asInstanceOf[MatrixIR], newChildren(1).asInstanceOf[IR])
   }
 
   val newRow = {
@@ -876,8 +874,8 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR) extends MatrixIR {
     val localRowType = prev.typ.rvRowType
     val localEntriesType = prev.typ.entryArrayType
     val entriesIdx = prev.typ.entriesIdx
-    val localGlobalsType = typ.globalType
-    val localColsType = TArray(typ.colType)
+    val localGlobalsType = prev.typ.globalType
+    val localColsType = TArray(prev.typ.colType)
     val localNCols = prev.nCols
     val colValuesBc = prev.colValues.broadcast
     val globalsBc = prev.globals.broadcast
@@ -955,6 +953,133 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR) extends MatrixIR {
       val newRVD = prev.rvd.mapPartitionsPreservesPartitioning(typ.orvdType)(mapPartitionF)
       prev.copy(typ = typ, rvd = newRVD)
     }
+  }
+}
+
+case class MatrixMapCols(child: MatrixIR, newCol: IR) extends MatrixIR {
+  def children: IndexedSeq[BaseIR] = Array(child, newCol)
+
+  def copy(newChildren: IndexedSeq[BaseIR]): MatrixMapCols = {
+    assert(newChildren.length == 2)
+    MatrixMapCols(newChildren(0).asInstanceOf[MatrixIR], newChildren(1).asInstanceOf[IR])
+  }
+
+  val tAggElt: Type = child.typ.entryType
+  val aggSymTab = Map(
+    "global" -> (0, child.typ.globalType),
+    "va" -> (1, child.typ.rvRowType),
+    "g" -> (2, child.typ.entryType),
+    "sa" -> (3, child.typ.colType))
+
+  val tAgg = TAggregable(tAggElt, aggSymTab)
+
+  val typ: MatrixType = {
+    val newColType = newCol.typ.asInstanceOf[TStruct]
+    val newColNames = newColType.fieldNames.toSet
+    val newColKey = child.typ.colKey.filter(newColNames.contains)
+    child.typ.copy(colKey = newColKey, colType = newColType)
+  }
+
+  override def partitionCounts: Option[Array[Long]] = child.partitionCounts
+
+  def execute(hc: HailContext): MatrixValue = {
+    val prev = child.execute(hc)
+    assert(prev.typ == child.typ)
+
+    val localRowType = prev.typ.rvRowType
+    val localEntriesType = prev.typ.entryArrayType
+    val entriesIdx = prev.typ.entriesIdx
+    val localGlobalsType = prev.typ.globalType
+    val localColsType = TArray(prev.typ.colType)
+    val localNCols = prev.nCols
+    val colValuesBc = prev.colValues.broadcast
+    val globalsBc = prev.globals.broadcast
+
+    val (rvAggs, seqOps, aggResultType, f, rTyp) = ir.CompileWithAggregators[Long, Long, Long, Long, Long, Long, Long, Long](
+      "AGG", tAgg,
+      "global", localGlobalsType,
+      "sa", prev.typ.colType,
+      newCol)
+    assert(rTyp == typ.colType, s"$rTyp, ${ typ.colType }")
+
+    val depth = treeAggDepth(hc, prev.nPartitions)
+    val nAggs = seqOps.length
+
+    val rvAggsMA = MultiArray2.fill[RegionValueAggregator](localNCols, nAggs)(null)
+    for (i <- 0 until localNCols; j <- 0 until nAggs) {
+      rvAggsMA(i, j) = rvAggs(j).copy()
+    }
+
+    val aggResults = if (seqOps.nonEmpty) {
+      prev.rvd.treeAggregate[MultiArray2[RegionValueAggregator]](rvAggsMA)({ (rvaggs, rv) =>
+        val rvb = new RegionValueBuilder()
+        val region = rv.region
+        val oldRow = rv.offset
+
+        rvb.set(region)
+        rvb.start(localGlobalsType)
+        rvb.addAnnotation(localGlobalsType, globalsBc.value)
+        val globals = rvb.end()
+
+        rvb.start(localColsType)
+        rvb.addAnnotation(localColsType, colValuesBc.value)
+        val cols = rvb.end()
+
+        val entriesOff = localRowType.loadField(region, oldRow, entriesIdx)
+
+        var i = 0
+        while (i < localNCols) {
+          val eMissing = localEntriesType.isElementMissing(region, entriesOff, i)
+          val eOff = localEntriesType.elementOffset(entriesOff, localNCols, i)
+          val colMissing = localColsType.isElementMissing(region, cols, i)
+          val colOff = localColsType.elementOffset(cols, localNCols, i)
+
+          var j = 0
+          while (j < seqOps.length) {
+            seqOps(j)()(region, rvaggs(i, j), oldRow, false, globals, false, oldRow, false, eOff, eMissing, colOff, colMissing)
+            j += 1
+          }
+          i += 1
+        }
+
+        rvaggs
+      }, { (rvAggs1, rvAggs2) =>
+        rvAggs1.zip(rvAggs2).foreach { case (rvAgg1, rvAgg2) => rvAgg1.combOp(rvAgg2) }
+        rvAggs1
+      }, depth = depth)
+    } else
+      MultiArray2.fill[RegionValueAggregator](localNCols, 0)(null)
+
+    val prevColType = prev.typ.colType
+    val rvb = new RegionValueBuilder()
+
+    val mapF = (a: Annotation, i: Int) => {
+      Region.scoped { region =>
+        rvb.set(region)
+
+        rvb.start(aggResultType)
+        rvb.startStruct()
+        aggResults.row(i).foreach(_.result(rvb))
+        rvb.endStruct()
+        val aggResultsOffset = rvb.end()
+
+        rvb.start(localGlobalsType)
+        rvb.addAnnotation(localGlobalsType, globalsBc.value)
+        val globalRVoffset = rvb.end()
+
+        val colRVb = new RegionValueBuilder(region)
+        colRVb.start(prevColType)
+        colRVb.addAnnotation(prevColType, a)
+        val colRVoffset = colRVb.end()
+
+        val resultOffset = f()(region, aggResultsOffset, false, globalRVoffset, false, colRVoffset, false)
+
+        SafeRow(coerce[TStruct](rTyp), region, resultOffset)
+      }
+    }
+
+    val newColValues = BroadcastIndexedSeq(colValuesBc.value.zipWithIndex.map { case (a, i) => mapF(a, i) }, TArray(typ.colType), hc.sc)
+    prev.copy(typ = typ, colValues = newColValues)
   }
 }
 

--- a/src/main/scala/is/hail/utils/MultiArray2.scala
+++ b/src/main/scala/is/hail/utils/MultiArray2.scala
@@ -71,5 +71,8 @@ class MultiArray2[T](val n1: Int,
 object MultiArray2 {
   def fill[T](n1: Int, n2: Int)(elem: => T)(implicit tct: ClassTag[T]): MultiArray2[T] =
     new MultiArray2[T](n1, n2, Array.fill[T](n1 * n2)(elem))
+
+  def empty[T](implicit tct: ClassTag[T]): MultiArray2[T] =
+    new MultiArray2[T](0, 0, Array.empty[T](tct))
 }
 

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -962,7 +962,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
         new MatrixTable(hc, MatrixMapCols(ast, x))
 
       case _ =>
-        log.warn(s"select_rows found no AST to IR conversion: ${ PrettyAST(colsAST) }")
+        log.warn(s"select_cols found no AST to IR conversion: ${ PrettyAST(colsAST) }")
         val (t, f) = Parser.parseExpr(expr, ec)
 
         val newColType = coerce[TStruct](t)


### PR DESCRIPTION
`RegionValueBuilder` isn't serializable. Therefore, I had to initialize it for each seqop in `treeAggregate`. Is there a way to avoid this? @danking 