### PR TITLE
I brought back the staged decoder

### DIFF
--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -206,7 +206,7 @@ object HailContext {
       private val trackedIn = new ByteTrackingInputStream(in)
       private val dec =
         try {
-          codecSpec.buildDecoder(trackedIn)
+          codecSpec.buildDecoder(t, trackedIn)
         } catch {
           case e: Exception =>
             in.close()
@@ -227,7 +227,7 @@ object HailContext {
 
         try {
           region.clear()
-          rv.setOffset(dec.readRegionValue(t, region))
+          rv.setOffset(dec.readRegionValue(region))
           if (metrics != null) {
             ExposedMetrics.incrementRecord(metrics)
             ExposedMetrics.setBytes(metrics, trackedIn.bytesRead)

--- a/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -108,6 +108,19 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: Type, var
 
   def addDouble(v: Code[Double]): Code[Unit] = region.storeDouble(currentOffset, v)
 
+  def allocateBinary(n: Code[Int]): Code[Long] = {
+    val boff = mb.newLocal[Long]
+    Code(
+      boff := TBinary.allocate(region, n),
+      region.storeInt(boff, n),
+      typ.fundamentalType match {
+        case _: TBinary => _empty
+        case _ =>
+          region.storeAddress(currentOffset, boff)
+      },
+      boff)
+  }
+
   def addBinary(bytes: Code[Array[Byte]]): Code[Unit] = {
     val boff = mb.newLocal[Long]
     Code(
@@ -127,7 +140,7 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: Type, var
   def addArray(t: TArray, f: (StagedRegionValueBuilder => Code[Unit])): Code[Unit] = f(new StagedRegionValueBuilder(mb, t, this))
 
   def addBaseStruct(t: TBaseStruct, f: (StagedRegionValueBuilder => Code[Unit]), init: LocalRef[Boolean] = null): Code[Unit] = f(new StagedRegionValueBuilder(mb, t, this))
-  
+
   def addIRIntermediate(t: Type): (Code[_]) => Code[Unit] = t.fundamentalType match {
     case _: TBoolean => v => addBoolean(v.asInstanceOf[Code[Boolean]])
     case _: TInt32 => v => addInt(v.asInstanceOf[Code[Int]])

--- a/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -244,7 +244,7 @@ class FunctionBuilder[F >: Null](val parameterTypeInfo: Array[MaybeGenericTypeIn
     try {
       cn.accept(cw)
       bytes = cw.toByteArray
-      CheckClassAdapter.verify(new ClassReader(bytes), false, new PrintWriter(sw1))
+      // CheckClassAdapter.verify(new ClassReader(bytes), false, new PrintWriter(sw1))
     } catch {
       case e: Exception =>
         // if we fail with frames, try without frames for better error message

--- a/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -313,7 +313,7 @@ class FunctionBuilder[F >: Null](val parameterTypeInfo: Array[MaybeGenericTypeIn
   }
 }
 
-class Function2Builder[A1 >: Null : TypeInfo, A2 >: Null : TypeInfo, R >: Null : TypeInfo]
+class Function2Builder[A1 : TypeInfo, A2 : TypeInfo, R : TypeInfo]
   extends FunctionBuilder[AsmFunction2[A1, A2, R]](Array(GenericTypeInfo[A1], GenericTypeInfo[A2]), GenericTypeInfo[R]) {
 
   def arg1 = getArg[A1](1)

--- a/src/main/scala/is/hail/expr/types/TBinary.scala
+++ b/src/main/scala/is/hail/expr/types/TBinary.scala
@@ -59,6 +59,8 @@ object TBinary {
 
   def contentByteSize(length: Int): Long = 4 + length
 
+  def contentByteSize(length: Code[Int]): Code[Long] = (const(4) + length).toL
+
   def loadLength(region: Region, boff: Long): Int =
     region.loadInt(boff)
 
@@ -71,6 +73,10 @@ object TBinary {
 
   def allocate(region: Region, length: Int): Long = {
     region.allocate(contentAlignment, contentByteSize(length))
+  }
+
+  def allocate(region: Code[Region], length: Code[Int]): Code[Long] = {
+    region.allocate(const(contentAlignment), contentByteSize(length))
   }
 
 }

--- a/src/main/scala/is/hail/io/RowStore.scala
+++ b/src/main/scala/is/hail/io/RowStore.scala
@@ -537,7 +537,7 @@ object EmitPackDecoder {
     val initCode = Code(
       srvb.start(init = false),
       off := srvb.offset,
-      in.readBytes(srvb.region, off, const(t.nMissingBytes)))
+      in.readBytes(srvb.region, off, t.nMissingBytes))
 
     val fieldCode = (0 until t.size).map { i =>
       val ft = t.types(i)

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -196,8 +196,8 @@ trait RVD {
     val persistedRDD = rdd.mapPartitions { it =>
       it.map { rv =>
         using(new ByteArrayOutputStream()) { baos =>
-          using(persistCodec.buildEncoder(baos)) { enc =>
-            enc.writeRegionValue(localRowType, rv.region, rv.offset)
+          using(persistCodec.buildEncoder(localRowType, baos)) { enc =>
+            enc.writeRegionValue(rv.region, rv.offset)
             enc.flush()
             baos.toByteArray
           }
@@ -214,8 +214,8 @@ trait RVD {
           it.map { bytes =>
             region.clear()
             using(new ByteArrayInputStream(bytes)) { bais =>
-              using(persistCodec.buildDecoder(bais)) { dec =>
-                rv2.setOffset(dec.readRegionValue(localRowType, region))
+              using(persistCodec.buildDecoder(localRowType, bais)) { dec =>
+                rv2.setOffset(dec.readRegionValue(region))
                 rv2
               }
             }

--- a/src/main/scala/is/hail/utils/richUtils/Implicits.scala
+++ b/src/main/scala/is/hail/utils/richUtils/Implicits.scala
@@ -5,7 +5,7 @@ import java.io.InputStream
 import breeze.linalg.DenseMatrix
 import is.hail.annotations.{JoinedRegionValue, Region, RegionValue}
 import is.hail.asm4s.Code
-import is.hail.io.{RichContextRDDRegionValue}
+import is.hail.io.{InputBuffer, RichContextRDDRegionValue}
 import is.hail.sparkextras._
 import is.hail.utils.{ArrayBuilder, HailIterator, JSONWriter, MultiArray2, Truncatable, WithContext}
 import org.apache.hadoop
@@ -112,4 +112,6 @@ trait Implicits {
   implicit def toContextPairRDDFunctions[C <: AutoCloseable, K: ClassTag, V: ClassTag](x: ContextRDD[C, (K, V)]): ContextPairRDDFunctions[C, K, V] = new ContextPairRDDFunctions(x)
 
   implicit def toRichContextRDD[C <: AutoCloseable, T: ClassTag](x: ContextRDD[C, T]): RichContextRDD[C, T] = new RichContextRDD(x)
+
+  implicit def toRichCodeInputBuffer(in: Code[InputBuffer]): RichCodeInputBuffer = new RichCodeInputBuffer(in)
 }

--- a/src/main/scala/is/hail/utils/richUtils/RichCodeInputBuffer.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichCodeInputBuffer.scala
@@ -38,8 +38,12 @@ class RichCodeInputBuffer(in: Code[InputBuffer]) {
   def readBytes(toRegion: Code[Region], toOff: Code[Long], n: Int): Code[Unit] = {
     if (n == 0)
       Code._empty
-    else if (n == 1)
-      toRegion.storeByte(toOff, in.readByte())
+    else if (n < 5)
+      Code(
+        Code((0 until n).map(i =>
+          toRegion.storeByte(toOff + const(i), in.readByte())): _*),
+        // for type
+        Code._empty)
     else
       in.invoke[Region, Long, Int, Unit]("readBytes", toRegion, toOff, n)
   }

--- a/src/main/scala/is/hail/utils/richUtils/RichCodeInputBuffer.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichCodeInputBuffer.scala
@@ -36,38 +36,11 @@ class RichCodeInputBuffer(in: Code[InputBuffer]) {
   }
 
   def readBytes(toRegion: Code[Region], toOff: Code[Long], n: Int): Code[Unit] = {
-    var off = 0
-    var k = 0
-    while (off < n && k < 5) {
-      val r = n - off
-      if (4 >= 8)
-        off += 8
-      else if (r >= 4)
-        off += 4
-      else
-        off += 1
-      k += 1
-    }
-
-    if (off == n && k <= 4) {
-      var c = Code._empty[Unit]
-      off = 0
-      while (off < n) {
-        val r = n - off
-        if (r >= 8) {
-          c = Code(c, toRegion.storeLong(toOff + const(off), in.readLong()))
-          off += 8
-        } else if (r > 4) {
-          c = Code(c, toRegion.storeInt(toOff + const(off), in.readInt()))
-          off += 4
-        } else {
-          c = Code(c, toRegion.storeByte(toOff + const(off), in.readByte()))
-          off += 1
-        }
-      }
-
-      c
-    } else
+    if (n == 0)
+      Code._empty
+    else if (n == 1)
+      toRegion.storeByte(toOff, in.readByte())
+    else
       in.invoke[Region, Long, Int, Unit]("readBytes", toRegion, toOff, n)
   }
 

--- a/src/main/scala/is/hail/utils/richUtils/RichCodeInputBuffer.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichCodeInputBuffer.scala
@@ -3,7 +3,8 @@ package is.hail.utils.richUtils
 import is.hail.annotations.Region
 import is.hail.asm4s.Code
 import is.hail.io.InputBuffer
-
+import is.hail.utils._
+import is.hail.asm4s._
 
 class RichCodeInputBuffer(in: Code[InputBuffer]) {
   def readByte(): Code[Byte] = {
@@ -32,6 +33,42 @@ class RichCodeInputBuffer(in: Code[InputBuffer]) {
 
   def readBytes(toRegion: Code[Region], toOff: Code[Long], n: Code[Int]): Code[Unit] = {
     in.invoke[Region, Long, Int, Unit]("readBytes", toRegion, toOff, n)
+  }
+
+  def readBytes(toRegion: Code[Region], toOff: Code[Long], n: Int): Code[Unit] = {
+    var off = 0
+    var k = 0
+    while (off < n && k < 5) {
+      val r = n - off
+      if (4 >= 8)
+        off += 8
+      else if (r >= 4)
+        off += 4
+      else
+        off += 1
+      k += 1
+    }
+
+    if (off == n && k <= 4) {
+      var c = Code._empty[Unit]
+      off = 0
+      while (off < n) {
+        val r = n - off
+        if (r >= 8) {
+          c = Code(c, toRegion.storeLong(toOff + const(off), in.readLong()))
+          off += 8
+        } else if (r > 4) {
+          c = Code(c, toRegion.storeInt(toOff + const(off), in.readInt()))
+          off += 4
+        } else {
+          c = Code(c, toRegion.storeByte(toOff + const(off), in.readByte()))
+          off += 1
+        }
+      }
+
+      c
+    } else
+      in.invoke[Region, Long, Int, Unit]("readBytes", toRegion, toOff, n)
   }
 
   def skipBytes(n: Code[Int]): Code[Unit] = {

--- a/src/main/scala/is/hail/utils/richUtils/RichCodeInputBuffer.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichCodeInputBuffer.scala
@@ -1,0 +1,40 @@
+package is.hail.utils.richUtils
+
+import is.hail.annotations.Region
+import is.hail.asm4s.Code
+import is.hail.io.InputBuffer
+
+
+class RichCodeInputBuffer(in: Code[InputBuffer]) {
+  def readByte(): Code[Byte] = {
+    in.invoke[Byte]("readByte")
+  }
+
+  def readBoolean(): Code[Boolean] = {
+    in.invoke[Boolean]("readBoolean")
+  }
+
+  def readInt(): Code[Int] = {
+    in.invoke[Int]("readInt")
+  }
+
+  def readLong(): Code[Long] = {
+    in.invoke[Long]("readLong")
+  }
+
+  def readFloat(): Code[Float] = {
+    in.invoke[Float]("readFloat")
+  }
+
+  def readDouble(): Code[Double] = {
+    in.invoke[Double]("readDouble")
+  }
+
+  def readBytes(toRegion: Code[Region], toOff: Code[Long], n: Code[Int]): Code[Unit] = {
+    in.invoke[Region, Long, Int, Unit]("readBytes", toRegion, toOff, n)
+  }
+
+  def skipBytes(n: Code[Int]): Code[Unit] = {
+    in.invoke[Int, Unit]("skipBytes", n)
+  }
+}

--- a/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
+++ b/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
@@ -78,7 +78,6 @@ class AnnotationsSuite extends SparkSuite {
     assert(vds3.same(vds1))
   }
 
-
   @Test def testExtendedOrdering() {
     val ord = ExtendedOrdering.extendToNull(implicitly[Ordering[Int]])
     val rord = ord.reverse

--- a/src/test/scala/is/hail/annotations/UnsafeSuite.scala
+++ b/src/test/scala/is/hail/annotations/UnsafeSuite.scala
@@ -41,8 +41,6 @@ class UnsafeSuite extends SparkSuite {
 
         region2.clear()
         val ais = new ByteArrayInputStream(aos.toByteArray)
-
-        println(t)
         val dec = codecSpec.buildDecoder(t)(ais)
         val offset2 = dec.readRegionValue(region2)
         val ur2 = new UnsafeRow(t, region2, offset2)

--- a/src/test/scala/is/hail/annotations/UnsafeSuite.scala
+++ b/src/test/scala/is/hail/annotations/UnsafeSuite.scala
@@ -35,14 +35,14 @@ class UnsafeSuite extends SparkSuite {
         val ur = new UnsafeRow(t, region, offset)
 
         val aos = new ByteArrayOutputStream()
-        val en = codecSpec.buildEncoder(aos)
-        en.writeRegionValue(t, region, offset)
+        val en = codecSpec.buildEncoder(t, aos)
+        en.writeRegionValue(region, offset)
         en.flush()
 
         region2.clear()
         val ais = new ByteArrayInputStream(aos.toByteArray)
-        val dec = codecSpec.buildDecoder(ais)
-        val offset2 = dec.readRegionValue(t, region2)
+        val dec = codecSpec.buildDecoder(t, ais)
+        val offset2 = dec.readRegionValue(region2)
         val ur2 = new UnsafeRow(t, region2, offset2)
 
         assert(t.valuesSimilar(a, ur2))


### PR DESCRIPTION
13.7% improvement (47.3 => 40.8) over and above https://github.com/hail-is/hail/pull/3415.  Tested on a shard of gnomAD with:

```
mt = hl.read_matrix_table('gnomad.mt')
mt._force_count_rows()
```
