### PR TITLE
compile all seqops together

### DIFF
--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -921,7 +921,7 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR) extends MatrixIR {
 
         val entriesOff = localRowType.loadField(region, oldRow, entriesIdx)
 
-        val aggResultsOff = if (seqOps.nonEmpty) {
+        val aggResultsOff = if (rvAggs.nonEmpty) {
           val newRVAggs = rvAggs.map(_.copy())
 
           var i = 0
@@ -931,11 +931,7 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR) extends MatrixIR {
             val colMissing = localColsType.isElementMissing(region, cols, i)
             val colOff = localColsType.elementOffset(cols, localNCols, i)
 
-            var j = 0
-            while (j < seqOps.length) {
-              seqOps(j)()(region, newRVAggs(j), oldRow, false, globals, false, oldRow, false, eOff, eMissing, colOff, colMissing)
-              j += 1
-            }
+            seqOps()(region, newRVAggs, oldRow, false, globals, false, oldRow, false, eOff, eMissing, colOff, colMissing)
             i += 1
           }
           rvb.start(aggResultType)

--- a/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -44,13 +44,13 @@ final case class Histogram() extends AggOp { }
 
 object AggOp {
 
-  def get(op: AggOp, inputType: Type, argumentTypes: Seq[Type]): CodeAggregator[_] =
+  def get(op: AggOp, inputType: Type, argumentTypes: Seq[Type]): CodeAggregator[T] forSome { type T <: RegionValueAggregator } =
     m((op, inputType, argumentTypes)).getOrElse(incompatible(op, inputType, argumentTypes))
 
   def getType(op: AggOp, inputType: Type, argumentTypes: Seq[Type]): Type =
     m((op, inputType, argumentTypes)).getOrElse(incompatible(op, inputType, argumentTypes)).out
 
-  private val m: ((AggOp, Type, Seq[Type])) => Option[CodeAggregator[_]] = lift {
+  private val m: ((AggOp, Type, Seq[Type])) => Option[CodeAggregator[T] forSome { type T <: RegionValueAggregator }] = lift {
     case (Fraction(), in: TBoolean, Seq()) => CodeAggregator[RegionValueFractionAggregator](in, TFloat64())
     case (Statistics(), in: TFloat64, Seq()) => CodeAggregator[RegionValueStatisticsAggregator](in, RegionValueStatisticsAggregator.typ)
     case (Collect(), in: TBoolean, Seq()) => CodeAggregator[RegionValueCollectBooleanAggregator](in, TArray(TBoolean()))

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -55,6 +55,10 @@ object Children {
       Array(a, body)
     case AggFlatMap(a, name, body) =>
       Array(a, body)
+    case SeqOp(a, _, _) =>
+      Array(a)
+    case Begin(xs) =>
+      xs
     case ApplyAggOp(a, op, args) =>
       (a +: args).toIndexedSeq
     case GetField(o, name) =>

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -80,6 +80,11 @@ object Copy {
       case AggFlatMap(_, name, _) =>
         val IndexedSeq(a: IR, body: IR) = newChildren
         AggFlatMap(a, name, body)
+      case SeqOp(a, i, agg) =>
+        val IndexedSeq(newA: IR) = newChildren
+        SeqOp(newA, i, agg)
+      case Begin(xs) =>
+        Begin(newChildren.map(_.asInstanceOf[IR]))
       case ApplyAggOp(_, op, args) =>
         ApplyAggOp(newChildren.head.asInstanceOf[IR], op, newChildren.tail.map(_.asInstanceOf[IR]))
       case MakeTuple(_) =>

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -120,6 +120,7 @@ private class Emit(
           wrapCodeChunks(chunks)
       }
     }
+
     wrapCodeChunks(irs, true)
   }
 
@@ -134,7 +135,7 @@ private class Emit(
     *  3. guard the the evaluation of value by missingness
     *
     * JVM gotcha:
-    *  a variable must be initialized on all static code-paths prior to its use (ergo defaultValue)
+    * a variable must be initialized on all static code-paths prior to its use (ergo defaultValue)
     *
     * Argument Convention
     * -------------------
@@ -177,7 +178,7 @@ private class Emit(
     val region = mb.getArg[Region](1).load()
     lazy val aggregator = {
       assert(nSpecialArguments >= 2)
-      mb.getArg[RegionValueAggregator](2)
+      mb.getArg[Array[RegionValueAggregator]](2)
     }
 
     ir match {
@@ -408,9 +409,20 @@ private class Emit(
           xvout := xmout.mux(defaultValue(typ), xvout)
         ), xmout, xvout)
 
-      case x@ApplyAggOp(a, op, args) =>
-        val agg = AggOp.get(op, x.inputType, args.map(_.typ))
-        present(emitAgg(a)(agg.seqOp(aggregator, _, _)))
+      case SeqOp(a, i, agg) =>
+        EmitTriplet(
+          emitAgg(a)(agg.seqOp(aggregator(i), _, _)),
+          const(false),
+          Code._empty)
+
+      case Begin(xs) =>
+        EmitTriplet(
+          coerce[Unit](Code(xs.map { x =>
+            val codex = emit(x)
+            codex.setup
+          }: _*)),
+          const(false),
+          Code._empty)
 
       case x@MakeStruct(fields) =>
         val srvb = new StagedRegionValueBuilder(mb, x.typ)

--- a/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -10,11 +10,22 @@ import scala.language.{existentials, postfixOps}
 
 object ExtractAggregators {
 
-  private case class IRAgg(ref: Ref, applyAggOp: ApplyAggOp) { }
+  private case class IRAgg(ref: Ref, applyAggOp: ApplyAggOp) {}
 
-  def apply(ir: IR, tAggIn: TAggregable): (IR, TStruct, Array[(IR, RegionValueAggregator)]) = {
+  def apply(ir: IR, tAggIn: TAggregable): (IR, TStruct, IR, Array[RegionValueAggregator]) = {
     val (ir2, aggs) = extract(ir, tAggIn)
-    val rvas = aggs.map(_.applyAggOp).map(x => (x: IR, newAggregator(x)))
+    val aggir = Begin(
+      aggs.map(_.applyAggOp)
+        .zipWithIndex
+        .map { case (x, i) =>
+          val agg = AggOp.get(x.op, x.inputType, x.args.map(_.typ))
+          SeqOp(x.a, i, agg)
+        })
+
+    val rvas = aggs.map(_.applyAggOp)
+      .map { x =>
+        newAggregator(x)
+      }
 
     val fields = aggs.map(_.applyAggOp.typ).zipWithIndex.map { case (t, i) => i.toString -> t }
     val resultStruct = TStruct(fields: _*)
@@ -22,7 +33,7 @@ object ExtractAggregators {
     // struct's type is
     aggs.foreach(_.ref.typ = resultStruct)
 
-    (ir2, resultStruct, rvas)
+    (ir2, resultStruct, aggir, rvas)
   }
 
   private def extract(ir: IR, tAggIn: TAggregable): (IR, Array[IRAgg]) = {
@@ -33,6 +44,7 @@ object ExtractAggregators {
 
   private def extract(ir: IR, ab: ArrayBuilder[IRAgg], tAggIn: TAggregable): IR = {
     def extract(ir: IR): IR = this.extract(ir, ab, tAggIn)
+
     ir match {
       case Ref(name, typ) =>
         assert(typ.isRealizable)
@@ -53,7 +65,7 @@ object ExtractAggregators {
       val constfb = EmitFunctionBuilder[Region, RegionValueAggregator]
       val codeArgs = args.map(Emit.toCode(_, constfb, 1))
       constfb.emit(Code(
-        Code(codeArgs.map(_.setup):_*),
+        Code(codeArgs.map(_.setup): _*),
         AggOp.get(op, x.inputType, args.map(_.typ))
           .stagedNew(codeArgs.map(_.v).toArray, codeArgs.map(_.m).toArray)))
       constfb.result()()(Region())

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -1,9 +1,12 @@
 package is.hail.expr.ir
 
+import is.hail.annotations.aggregators.RegionValueAggregator
 import is.hail.expr.types._
 import is.hail.expr.{BaseIR, MatrixIR, TableIR}
 import is.hail.expr.ir.functions.{IRFunction, IRFunctionRegistry, IRFunctionWithMissingness, IRFunctionWithoutMissingness}
 import is.hail.utils.ExportType
+
+import scala.language.existentials
 
 sealed trait IR extends BaseIR {
   def typ: Type
@@ -87,6 +90,14 @@ final case class AggFilter(a: IR, name: String, body: IR) extends InferIR
 final case class AggFlatMap(a: IR, name: String, body: IR) extends InferIR
 final case class ApplyAggOp(a: IR, op: AggOp, args: Seq[IR]) extends InferIR {
   def inputType: Type = coerce[TAggregable](a.typ).elementType
+}
+
+final case class SeqOp(a: IR, i: Int, agg: CodeAggregator[T] forSome { type T <: RegionValueAggregator }) extends IR {
+  val typ = TVoid
+}
+
+final case class Begin(xs: IndexedSeq[IR]) extends IR {
+  val typ = TVoid
 }
 
 final case class MakeStruct(fields: Seq[(String, IR)]) extends InferIR

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -400,7 +400,7 @@ object Interpret {
 
         val value = child.execute(HailContext.get)
         val globalsBc = value.globals.broadcast
-        val aggResults = if (seqOps.nonEmpty) {
+        val aggResults = if (rvAggs.nonEmpty) {
           value.rvd.aggregate[Array[RegionValueAggregator]](rvAggs)({ case (rvaggs, rv) =>
             // add globals to region value
             val rowOffset = rv.offset
@@ -410,10 +410,9 @@ object Interpret {
             rvb.addAnnotation(localGlobalSignature, globalsBc.value)
             val globalsOffset = rvb.end()
 
-            rvaggs.zip(seqOps).foreach { case (rvagg, seqOp) =>
-              seqOp()(rv.region, rvagg, rowOffset, false, globalsOffset, false, rowOffset, false)
-            }
-            rvaggs
+            seqOps()(rv.region, rvAggs, rowOffset, false, globalsOffset, false, rowOffset, false)
+
+            rvAggs
           }, { (rvAggs1, rvAggs2) =>
             rvAggs1.zip(rvAggs2).foreach { case (rvAgg1, rvAgg2) => rvAgg1.combOp(rvAgg2) }
             rvAggs1

--- a/src/main/scala/is/hail/expr/ir/Recur.scala
+++ b/src/main/scala/is/hail/expr/ir/Recur.scala
@@ -31,6 +31,8 @@ object Recur {
     case AggMap(a, name, body) => AggMap(f(a), name, f(body))
     case AggFilter(a, name, body) => AggFilter(f(a), name, f(body))
     case AggFlatMap(a, name, body) => AggFlatMap(f(a), name, f(body))
+    case SeqOp(a, i, agg) => SeqOp(f(a), i, agg)
+    case Begin(xs) => Begin(xs.map(f))
     case ApplyAggOp(a, op, args) => ApplyAggOp(f(a), op, args.map(f))
     case MakeTuple(elts) => MakeTuple(elts.map(f))
     case GetTupleElement(tup, idx) => GetTupleElement(f(tup), idx)

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -124,6 +124,13 @@ object TypeCheck {
         val tagg2 = tagg.copy(elementType = tout.elementType)
         tagg2.symTab = tagg.symTab
         assert(x.typ == tagg2)
+      case x@SeqOp(a, _, _) =>
+        check(a)
+      case x@Begin(xs) =>
+        xs.foreach { x =>
+          check(x)
+          assert(x.typ == TVoid)
+        }
       case x@ApplyAggOp(a, op, args) =>
         val tAgg = coerce[TAggregable](a.typ)
         check(a)

--- a/src/main/scala/is/hail/expr/ir/package.scala
+++ b/src/main/scala/is/hail/expr/ir/package.scala
@@ -22,6 +22,7 @@ package object ir {
     case _: TBinary => typeInfo[Long]
     case _: TArray => typeInfo[Long]
     case _: TBaseStruct => typeInfo[Long]
+    case TVoid => typeInfo[Unit]
     case _ => throw new RuntimeException(s"unsupported type found, $t")
   }
 


### PR DESCRIPTION
This improves a benchmark variant of a pipeline of @konradjk with six aggregators by 24% (140.6s => 106.8s) on a shard of gnomAD.  The improvement will be larger with more aggregators.  This change compiles the seqOp for all aggregators together into a single function and eliminates a loop over aggregators where the aggregations are invoked (e.g. MatrixMapRows).

I added a SeqOp node that represents the call of a seqOp on a single region value aggregator.  This replaces ApplyAggOp when extracting aggregators.

I added a Begin node which just sequences collection of void-typed IRs.