### PR TITLE
speed up global, col value copy in MatrixMapRows

### DIFF
--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -894,17 +894,29 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR) extends MatrixIR {
       val newRV = RegionValue()
       val rowF = f()
 
+      val partRegion = Region()
+
+      rvb.set(partRegion)
+      rvb.start(localGlobalsType)
+      rvb.addAnnotation(localGlobalsType, globalsBc.value)
+      val partGlobalsOff = rvb.end()
+
+      rvb.start(localColsType)
+      rvb.addAnnotation(localColsType, colValuesBc.value)
+      val partColsOff = rvb.end()
+
       it.map { rv =>
         val region = rv.region
         val oldRow = rv.offset
 
         rvb.set(region)
         rvb.start(localGlobalsType)
-        rvb.addAnnotation(localGlobalsType, globalsBc.value)
+        rvb.addRegionValue(localGlobalsType, partRegion, partGlobalsOff)
         val globals = rvb.end()
 
+        rvb.set(region)
         rvb.start(localColsType)
-        rvb.addAnnotation(localColsType, colValuesBc.value)
+        rvb.addRegionValue(localColsType, partRegion, partColsOff)
         val cols = rvb.end()
 
         val entriesOff = localRowType.loadField(region, oldRow, entriesIdx)


### PR DESCRIPTION
Converting annotations to region values is quite slow, and while @danking's changes are pending, we're currently doing it once per (matrix) row in MatrixMapRows.  This copies the annotations to region values once per partition (at the cost of an extra region value copy) but then the copy into the per-row region is MUCH faster.  Saw something like 40% speedup (which will be even higher once @danking's off-heap changes go in and there is no copy at all.)