### PR TITLE
do full per-row aggregation inside the IR

### DIFF
--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCollectAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCollectAggregator.scala
@@ -16,10 +16,6 @@ class RegionValueCollectBooleanAggregator extends RegionValueAggregator {
       ab.add(b)
   }
 
-  def seqOp(region: Region, off: Long, missing: Boolean) {
-    seqOp(region.loadBoolean(off), missing)
-  }
-
   def combOp(agg2: RegionValueAggregator) {
     val other = agg2.asInstanceOf[RegionValueCollectBooleanAggregator]
     other.ab.foreach { _ =>
@@ -44,10 +40,6 @@ class RegionValueCollectIntAggregator extends RegionValueAggregator {
       ab.addMissing()
     else
       ab.add(x)
-  }
-
-  def seqOp(region: Region, off: Long, missing: Boolean) {
-    seqOp(region.loadInt(off), missing)
   }
 
   def combOp(agg2: RegionValueAggregator) {

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueFractionAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueFractionAggregator.scala
@@ -12,10 +12,6 @@ class RegionValueFractionAggregator extends RegionValueAggregator {
       trues += 1
   }
 
-  def seqOp(region: Region, off: Long, missing: Boolean) {
-    seqOp(region.loadBoolean(off), missing)
-  }
-
   def result(rvb: RegionValueBuilder) {
     if (total == 0)
       rvb.setMissing()

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueHistogramAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueHistogramAggregator.scala
@@ -32,10 +32,6 @@ class RegionValueHistogramAggregator(start: Double, end: Double, bins: Int) exte
       combiner.merge(x)
   }
 
-  def seqOp(region: Region, off: Long, missing: Boolean) {
-    seqOp(region.loadDouble(off), missing)
-  }
-
   def combOp(agg2: RegionValueAggregator) {
     combiner.merge(agg2.asInstanceOf[RegionValueHistogramAggregator].combiner)
   }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueMaxIntAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueMaxIntAggregator.scala
@@ -12,10 +12,6 @@ class RegionValueMaxBooleanAggregator extends RegionValueAggregator {
       max = i
   }
 
-  def seqOp(region: Region, off: Long, missing: Boolean) {
-    seqOp(region.loadBoolean(off), missing)
-  }
-
   def combOp(agg2: RegionValueAggregator) {
     val that = agg2.asInstanceOf[RegionValueMaxBooleanAggregator]
     if (that.max > max)
@@ -40,10 +36,6 @@ class RegionValueMaxIntAggregator extends RegionValueAggregator {
     found = true
     if (i > max)
       max = i
-  }
-
-  def seqOp(region: Region, off: Long, missing: Boolean) {
-    seqOp(region.loadInt(off), missing)
   }
 
   def combOp(agg2: RegionValueAggregator) {
@@ -72,10 +64,6 @@ class RegionValueMaxLongAggregator extends RegionValueAggregator {
       max = i
   }
 
-  def seqOp(region: Region, off: Long, missing: Boolean) {
-    seqOp(region.loadLong(off), missing)
-  }
-
   def combOp(agg2: RegionValueAggregator) {
     val that = agg2.asInstanceOf[RegionValueMaxLongAggregator]
     if (that.max > max)
@@ -102,10 +90,6 @@ class RegionValueMaxFloatAggregator extends RegionValueAggregator {
       max = i
   }
 
-  def seqOp(region: Region, off: Long, missing: Boolean) {
-    seqOp(region.loadFloat(off), missing)
-  }
-
   def combOp(agg2: RegionValueAggregator) {
     val that = agg2.asInstanceOf[RegionValueMaxFloatAggregator]
     if (that.max > max)
@@ -130,10 +114,6 @@ class RegionValueMaxDoubleAggregator extends RegionValueAggregator {
     found = true
     if (i > max)
       max = i
-  }
-
-  def seqOp(region: Region, off: Long, missing: Boolean) {
-    seqOp(region.loadDouble(off), missing)
   }
 
   def combOp(agg2: RegionValueAggregator) {

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueStatisticsAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueStatisticsAggregator.scala
@@ -23,10 +23,6 @@ class RegionValueStatisticsAggregator extends RegionValueAggregator {
       sc.merge(x)
   }
 
-  def seqOp(region: Region, off: Long, missing: Boolean) {
-    seqOp(region.loadDouble(off), missing)
-  }
-
   def combOp(agg2: RegionValueAggregator) {
     sc.merge(agg2.asInstanceOf[RegionValueStatisticsAggregator].sc)
   }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueSumAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueSumAggregator.scala
@@ -1,7 +1,5 @@
 package is.hail.annotations.aggregators
 
-import is.hail.asm4s._
-import is.hail.expr.types._
 import is.hail.annotations._
 
 class RegionValueSumBooleanAggregator extends RegionValueAggregator {
@@ -10,10 +8,6 @@ class RegionValueSumBooleanAggregator extends RegionValueAggregator {
   def seqOp(b: Boolean, missing: Boolean) {
     if (!missing)
       sum |= b
-  }
-
-  def seqOp(region: Region, off: Long, missing: Boolean) {
-    seqOp(region.loadBoolean(off), missing)
   }
 
   def combOp(agg2: RegionValueAggregator) {
@@ -35,10 +29,6 @@ class RegionValueSumIntAggregator extends RegionValueAggregator {
       sum += i
   }
 
-  def seqOp(region: Region, off: Long, missing: Boolean) {
-    seqOp(region.loadInt(off), missing)
-  }
-
   def combOp(agg2: RegionValueAggregator) {
     sum += agg2.asInstanceOf[RegionValueSumIntAggregator].sum
   }
@@ -56,10 +46,6 @@ class RegionValueSumLongAggregator extends RegionValueAggregator {
   def seqOp(l: Long, missing: Boolean) {
     if (!missing)
       sum += l
-  }
-
-  def seqOp(region: Region, off: Long, missing: Boolean) {
-    seqOp(region.loadLong(off), missing)
   }
 
   def combOp(agg2: RegionValueAggregator) {
@@ -81,10 +67,6 @@ class RegionValueSumFloatAggregator extends RegionValueAggregator {
       sum += f
   }
 
-  def seqOp(region: Region, off: Long, missing: Boolean) {
-    seqOp(region.loadFloat(off), missing)
-  }
-
   def combOp(agg2: RegionValueAggregator) {
     sum += agg2.asInstanceOf[RegionValueSumFloatAggregator].sum
   }
@@ -102,10 +84,6 @@ class RegionValueSumDoubleAggregator extends RegionValueAggregator {
   def seqOp(d: Double, missing: Boolean) {
     if (!missing)
       sum += d
-  }
-
-  def seqOp(region: Region, off: Long, missing: Boolean) {
-    seqOp(region.loadDouble(off), missing)
   }
 
   def combOp(agg2: RegionValueAggregator) {

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueTakeAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueTakeAggregator.scala
@@ -16,10 +16,6 @@ class RegionValueTakeBooleanAggregator(n: Int) extends RegionValueAggregator {
         ab.add(x)
   }
 
-  def seqOp(region: Region, off: Long, missing: Boolean) {
-    seqOp(region.loadBoolean(off), missing)
-  }
-
   def combOp(agg2: RegionValueAggregator) {
     val that = agg2.asInstanceOf[RegionValueTakeBooleanAggregator]
     that.ab.foreach { _ =>
@@ -47,10 +43,6 @@ class RegionValueTakeIntAggregator(n: Int) extends RegionValueAggregator {
         ab.addMissing()
       else
         ab.add(x)
-  }
-
-  def seqOp(region: Region, off: Long, missing: Boolean) {
-    seqOp(region.loadInt(off), missing)
   }
 
   def combOp(agg2: RegionValueAggregator) {
@@ -82,10 +74,6 @@ class RegionValueTakeLongAggregator(n: Int) extends RegionValueAggregator {
         ab.add(x)
   }
 
-  def seqOp(region: Region, off: Long, missing: Boolean) {
-    seqOp(region.loadLong(off), missing)
-  }
-
   def combOp(agg2: RegionValueAggregator) {
     val that = agg2.asInstanceOf[RegionValueTakeLongAggregator]
     that.ab.foreach { _ =>
@@ -115,10 +103,6 @@ class RegionValueTakeFloatAggregator(n: Int) extends RegionValueAggregator {
         ab.add(x)
   }
 
-  def seqOp(region: Region, off: Long, missing: Boolean) {
-    seqOp(region.loadFloat(off), missing)
-  }
-
   def combOp(agg2: RegionValueAggregator) {
     val that = agg2.asInstanceOf[RegionValueTakeFloatAggregator]
     that.ab.foreach { _ =>
@@ -146,10 +130,6 @@ class RegionValueTakeDoubleAggregator(n: Int) extends RegionValueAggregator {
         ab.addMissing()
       else
         ab.add(x)
-  }
-
-  def seqOp(region: Region, off: Long, missing: Boolean) {
-    seqOp(region.loadDouble(off), missing)
   }
 
   def combOp(agg2: RegionValueAggregator) {

--- a/src/main/scala/is/hail/asm4s/AsmFunction.scala
+++ b/src/main/scala/is/hail/asm4s/AsmFunction.scala
@@ -10,6 +10,7 @@ trait AsmFunction6[A,B,C,D,E,F,R] { def apply(a: A, b: B, c: C, d: D, e: E, f: F
 trait AsmFunction7[A,B,C,D,E,F,G,R] { def apply(a: A, b: B, c: C, d: D, e: E, f: F, g: G): R }
 trait AsmFunction8[A,B,C,D,E,F,G,H,R] { def apply(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H): R }
 trait AsmFunction9[A,B,C,D,E,F,G,H,I,R] { def apply(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I): R }
+trait AsmFunction10[A,B,C,D,E,F,G,H,I,J,R] { def apply(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J): R }
 trait AsmFunction12[T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,R] {
   def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12): R
 }

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -941,8 +941,6 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR) extends MatrixIR {
         rvb.addRegionValue(localColsType, partRegion, partColsOff)
         val cols = rvb.end()
 
-        val entriesOff = localRowType.loadField(region, oldRow, entriesIdx)
-
         val aggResultsOff = if (rvAggs.nonEmpty) {
           val newRVAggs = rvAggs.map(_.copy())
 
@@ -1086,8 +1084,6 @@ case class MatrixMapCols(child: MatrixIR, newCol: IR) extends MatrixIR {
         rvb.start(localColsType)
         rvb.addAnnotation(localColsType, colValuesBc.value)
         val cols = rvb.end()
-
-        val entriesOff = localRowType.loadField(region, oldRow, entriesIdx)
 
         seqOps()(region, colRVAggs, 0, true, globals, false, cols, false, oldRow, false)
 

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -890,12 +890,10 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR) extends MatrixIR {
       "colValues", colValuesType,
       "va", vaType,
       newRVRow, { (aggIR: IR) =>
-        ir.ArrayFold(
+        ir.ArrayFor(
           ir.ArrayRange(ir.I32(0), ir.I32(localNCols), ir.I32(1)),
-          ir.Void(),
-          "accum",
           "i",
-          ir.Let("sa", ir.ArrayRef(ir.Ref("colvalues", colValuesType), ir.Ref("i", TInt32())),
+          ir.Let("sa", ir.ArrayRef(ir.Ref("colValues", colValuesType), ir.Ref("i", TInt32())),
             ir.Let("g", ir.ArrayRef(
               ir.GetField(ir.Ref("va", vaType), MatrixType.entriesIdentifier),
               ir.Ref("i", TInt32())),

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -936,7 +936,7 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR) extends MatrixIR {
         val aggResultsOff = if (rvAggs.nonEmpty) {
           val newRVAggs = rvAggs.map(_.copy())
 
-          seqOps()(region, newRVAggs, 0, true, globals, false, oldRow, false, cols, false)
+          seqOps()(region, newRVAggs, 0, true, globals, false, cols, false, oldRow, false)
 
           rvb.start(aggResultType)
           rvb.startStruct()

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -919,7 +919,7 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR) extends MatrixIR {
 
         val entriesOff = localRowType.loadField(region, oldRow, entriesIdx)
 
-        val aggResultsOff = if (seqOps.nonEmpty) {
+        val aggResultsOff = if (rvAggs.nonEmpty) {
           val newRVAggs = rvAggs.map(_.copy())
 
           var i = 0
@@ -929,11 +929,7 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR) extends MatrixIR {
             val colMissing = localColsType.isElementMissing(region, cols, i)
             val colOff = localColsType.loadElement(region, cols, i)
 
-            var j = 0
-            while (j < seqOps.length) {
-              seqOps(j)()(region, newRVAggs(j), eOff, eMissing, globals, false, oldRow, false, eOff, eMissing, colOff, colMissing)
-              j += 1
-            }
+            seqOps()(region, newRVAggs, 0, eOff, eMissing, false, oldRow, false, eOff, eMissing, colOff, colMissing)
             i += 1
           }
           rvb.start(aggResultType)

--- a/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -44,13 +44,13 @@ final case class Histogram() extends AggOp { }
 
 object AggOp {
 
-  def get(op: AggOp, inputType: Type, argumentTypes: Seq[Type]): CodeAggregator[_] =
+  def get(op: AggOp, inputType: Type, argumentTypes: Seq[Type]): CodeAggregator[T] forSome { type T <: RegionValueAggregator } =
     m((op, inputType, argumentTypes)).getOrElse(incompatible(op, inputType, argumentTypes))
 
   def getType(op: AggOp, inputType: Type, argumentTypes: Seq[Type]): Type =
     m((op, inputType, argumentTypes)).getOrElse(incompatible(op, inputType, argumentTypes)).out
 
-  private val m: ((AggOp, Type, Seq[Type])) => Option[CodeAggregator[_]] = lift {
+  private val m: ((AggOp, Type, Seq[Type])) => Option[CodeAggregator[T] forSome { type T <: RegionValueAggregator }] = lift {
     case (Fraction(), in: TBoolean, Seq()) => CodeAggregator[RegionValueFractionAggregator](in, TFloat64())
     case (Statistics(), in: TFloat64, Seq()) => CodeAggregator[RegionValueStatisticsAggregator](in, RegionValueStatisticsAggregator.typ)
     case (Collect(), in: TBoolean, Seq()) => CodeAggregator[RegionValueCollectBooleanAggregator](in, TArray(TBoolean()))

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -59,8 +59,8 @@ object Children {
       Array(a, body)
     case AggFlatMap(a, name, body) =>
       Array(a, body)
-    case SeqOp(a, _, _) =>
-      Array(a)
+    case SeqOp(a, i, _) =>
+      Array(a, i)
     case Begin(xs) =>
       xs
     case ApplyAggOp(a, op, args) =>

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -13,6 +13,7 @@ object Children {
     case Str(x) => none
     case True() => none
     case False() => none
+    case Void() => none
     case Cast(v, typ) =>
       Array(v)
     case NA(typ) => none

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -56,6 +56,10 @@ object Children {
       Array(a, body)
     case AggFlatMap(a, name, body) =>
       Array(a, body)
+    case SeqOp(a, _, _) =>
+      Array(a)
+    case Begin(xs) =>
+      xs
     case ApplyAggOp(a, op, args) =>
       (a +: args).toIndexedSeq
     case GetField(o, name) =>

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -45,6 +45,8 @@ object Children {
       Array(a, body)
     case ArrayFold(a, zero, accumName, valueName, body) =>
       Array(a, zero, body)
+    case ArrayFor(a, valueName, body) =>
+      Array(a, body)
     case MakeStruct(fields) =>
       fields.map(_._2).toIndexedSeq
     case InsertFields(old, fields) =>

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -85,12 +85,12 @@ object Copy {
       case AggFlatMap(_, name, _) =>
         val IndexedSeq(a: IR, body: IR) = newChildren
         AggFlatMap(a, name, body)
-      case SeqOp(a, i, agg) =>
-        val IndexedSeq(newA: IR, newI: IR) = newChildren
-        SeqOp(newA, newI, agg)
-      case Begin(xs) =>
+      case SeqOp(_, _, agg) =>
+        val IndexedSeq(a: IR, i: IR) = newChildren
+        SeqOp(a, i, agg)
+      case Begin(_) =>
         Begin(newChildren.map(_.asInstanceOf[IR]))
-      case ApplyAggOp(_, op, args) =>
+      case ApplyAggOp(_, op, _) =>
         ApplyAggOp(newChildren.head.asInstanceOf[IR], op, newChildren.tail.map(_.asInstanceOf[IR]))
       case MakeTuple(_) =>
         MakeTuple(newChildren.map(_.asInstanceOf[IR]))

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -16,6 +16,7 @@ object Copy {
       case Str(_) => same
       case True() => same
       case False() => same
+      case Void() => same
       case Cast(_, typ) =>
         val IndexedSeq(v: IR) = newChildren
         Cast(v, typ)

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -81,6 +81,11 @@ object Copy {
       case AggFlatMap(_, name, _) =>
         val IndexedSeq(a: IR, body: IR) = newChildren
         AggFlatMap(a, name, body)
+      case SeqOp(a, i, agg) =>
+        val IndexedSeq(newA: IR) = newChildren
+        SeqOp(newA, i, agg)
+      case Begin(xs) =>
+        Begin(newChildren.map(_.asInstanceOf[IR]))
       case ApplyAggOp(_, op, args) =>
         ApplyAggOp(newChildren.head.asInstanceOf[IR], op, newChildren.tail.map(_.asInstanceOf[IR]))
       case MakeTuple(_) =>

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -62,6 +62,9 @@ object Copy {
       case ArrayFold(_, _, accumName, valueName, _) =>
         val IndexedSeq(a: IR, zero: IR, body: IR) = newChildren
         ArrayFold(a, zero, accumName, valueName, body)
+      case ArrayFor(_, valueName, _) =>
+        val IndexedSeq(a: IR, body: IR) = newChildren
+        ArrayFor(a, valueName, body)
       case MakeStruct(fields) =>
         assert(fields.length == newChildren.length)
         MakeStruct(fields.zip(newChildren).map { case ((n, _), a) => (n, a.asInstanceOf[IR]) })

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -86,8 +86,8 @@ object Copy {
         val IndexedSeq(a: IR, body: IR) = newChildren
         AggFlatMap(a, name, body)
       case SeqOp(a, i, agg) =>
-        val IndexedSeq(newA: IR) = newChildren
-        SeqOp(newA, i, agg)
+        val IndexedSeq(newA: IR, newI: IR) = newChildren
+        SeqOp(newA, newI, agg)
       case Begin(xs) =>
         Begin(newChildren.map(_.asInstanceOf[IR]))
       case ApplyAggOp(_, op, args) =>

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -198,6 +198,8 @@ private class Emit(
         present(const(true))
       case False() =>
         present(const(false))
+      case Void() =>
+        EmitTriplet(Code._empty, const(true), Code._empty)
 
       case Cast(v, typ) =>
         val codeV = emit(v)

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -196,7 +196,7 @@ private class Emit(
       case False() =>
         present(const(false))
       case Void() =>
-        EmitTriplet(Code._empty, const(true), Code._empty)
+        EmitTriplet(Code._empty, const(false), Code._empty)
 
       case Cast(v, typ) =>
         val codeV = emit(v)
@@ -433,7 +433,7 @@ private class Emit(
 
         val processAElts = aBase.arrayEmitter(cont)
 
-        EmitTriplet(processAElts.setup, const(true), Code._empty)
+        EmitTriplet(processAElts.setup, const(false), Code._empty)
 
       case SeqOp(a, i, agg) =>
         EmitTriplet(

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -136,6 +136,9 @@ private class Emit(
     *  2. evaluate precompute *on all static code-paths* leading to missingness or value
     *  3. guard the the evaluation of value by missingness
     *
+    *  Triplets returning values cannot have side-effects.  For void triplets, precompute
+    *  contains the side effect, missingness is false, and value is {@code Code._empty}.
+    *
     * JVM gotcha:
     * a variable must be initialized on all static code-paths prior to its use (ergo defaultValue)
     *
@@ -153,18 +156,13 @@ private class Emit(
     *
     * Aggregating expressions must have at least two special arguments. As with
     * all expressions, the first argument must be a {@code  Region}. The second
-    * argument is the {@code  RegionValueAggregator} that implements the
-    * functionality of the (unique) {@code  AggOp} in the expression. Note that
-    * the special arguments do not appear in pairs, i.e., they may not be
-    * missing.
+    * argument is the {@code  Array[RegionValueAggregator]} that is used by
+    * {@code SeqOp} to implement the aggregation. Note that the special arguments
+    * do not appear in pairs, i.e., they may not be missing.
     *
-    * An aggregating expression additionally has an element argument and a
-    * number of "scope" argmuents following the special arguments. The type of
-    * the element is {@code  tAggIn.elementType}. The number and types of the
-    * scope arguments are defined by the symbol table of {@code  tAggIn}. The
-    * element argument and the scope arguments, unlike special arguments, appear
-    * in pairs of a value and a missingness bit. Moreover, the element argument
-    * must appear first.
+    * When compiling an aggregation expression, {@code AggIn} refers to the first
+    * argument {@code In(0)} whose type must be of type
+    * {@code tAggIn.elementType}.  {@code tAggIn.symTab} is not used by Emit.
     *
     **/
   private def emit(ir: IR, env: E): EmitTriplet = {

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -419,11 +419,8 @@ private class Emit(
         val xvv = coerce[Any](mb.newField(valueName)(eti))
         val bodyenv = env.bind(
           valueName -> (eti, xmv.load(), xvv.load()))
-
         val codeB = emit(body, env = bodyenv)
-
         val aBase = emitArrayIterator(a)
-
         val cont = { (m: Code[Boolean], v: Code[_]) =>
           Code(
             xmv := m,
@@ -432,8 +429,15 @@ private class Emit(
         }
 
         val processAElts = aBase.arrayEmitter(cont)
-
-        EmitTriplet(processAElts.setup, const(false), Code._empty)
+        val ma = processAElts.m.getOrElse(const(false))
+        EmitTriplet(
+          Code(
+            processAElts.setup,
+            ma.mux(
+              Code._empty,
+              Code(aBase.calcLength, processAElts.addElements))),
+          const(false),
+          Code._empty)
 
       case SeqOp(a, i, agg) =>
         EmitTriplet(

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -440,17 +440,20 @@ private class Emit(
           Code._empty)
 
       case SeqOp(a, i, agg) =>
+        val codeI = emit(i)
         EmitTriplet(
-          emitAgg(a, env)(agg.seqOp(aggregator(i), _, _)),
+          Code(codeI.setup,
+            codeI.m.mux(
+              Code._empty,
+              emitAgg(a, env)(agg.seqOp(aggregator(coerce[Int](codeI.v)), _, _)))),
           const(false),
           Code._empty)
 
       case Begin(xs) =>
         EmitTriplet(
-          coerce[Unit](Code(xs.map { x =>
-            val codex = emit(x)
-            codex.setup
-          }: _*)),
+          wrapToMethod(xs, env) { case (_, t, code) =>
+            code.setup
+          },
           const(false),
           Code._empty)
 

--- a/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -19,7 +19,7 @@ object ExtractAggregators {
         .zipWithIndex
         .map { case (x, i) =>
           val agg = AggOp.get(x.op, x.inputType, x.args.map(_.typ))
-          SeqOp(x.a, i, agg)
+          SeqOp(x.a, I32(i), agg)
         })
 
     val rvas = aggs.map(_.applyAggOp)

--- a/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -10,11 +10,22 @@ import scala.language.{existentials, postfixOps}
 
 object ExtractAggregators {
 
-  private case class IRAgg(ref: Ref, applyAggOp: ApplyAggOp) { }
+  private case class IRAgg(ref: Ref, applyAggOp: ApplyAggOp) {}
 
-  def apply(ir: IR, tAggIn: TAggregable): (IR, TStruct, Array[(IR, RegionValueAggregator)]) = {
+  def apply(ir: IR, tAggIn: TAggregable): (IR, TStruct, IR, Array[RegionValueAggregator]) = {
     val (ir2, aggs) = extract(ir, tAggIn)
-    val rvas = aggs.map(_.applyAggOp).map(x => (x: IR, newAggregator(x)))
+    val aggir = Begin(
+      aggs.map(_.applyAggOp)
+        .zipWithIndex
+        .map { case (x, i) =>
+          val agg = AggOp.get(x.op, x.inputType, x.args.map(_.typ))
+          SeqOp(x.a, i, agg)
+        })
+
+    val rvas = aggs.map(_.applyAggOp)
+      .map { x =>
+        newAggregator(x)
+      }
 
     val fields = aggs.map(_.applyAggOp.typ).zipWithIndex.map { case (t, i) => i.toString -> t }
     val resultStruct = TStruct(fields: _*)
@@ -22,7 +33,7 @@ object ExtractAggregators {
     // struct's type is
     aggs.foreach(_.ref.typ = resultStruct)
 
-    (ir2, resultStruct, rvas)
+    (ir2, resultStruct, aggir, rvas)
   }
 
   private def extract(ir: IR, tAggIn: TAggregable): (IR, Array[IRAgg]) = {
@@ -33,6 +44,7 @@ object ExtractAggregators {
 
   private def extract(ir: IR, ab: ArrayBuilder[IRAgg], tAggIn: TAggregable): IR = {
     def extract(ir: IR): IR = this.extract(ir, ab, tAggIn)
+
     ir match {
       case Ref(name, typ) =>
         assert(typ.isRealizable)
@@ -53,7 +65,7 @@ object ExtractAggregators {
       val constfb = EmitFunctionBuilder[Region, RegionValueAggregator]
       val codeArgs = args.map(Emit.toCode(_, constfb, 1))
       constfb.emit(Code(
-        Code(codeArgs.map(_.setup):_*),
+        Code(codeArgs.map(_.setup): _*),
         AggOp.get(op, x.inputType, args.map(_.typ))
           .stagedNew(codeArgs.map(_.v).toArray, codeArgs.map(_.m).toArray)))
       constfb.result()()(Region())

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -56,6 +56,7 @@ final case class F64(x: Double) extends IR { val typ = TFloat64() }
 final case class Str(x: String) extends IR { val typ = TString() }
 final case class True() extends IR { val typ = TBoolean() }
 final case class False() extends IR { val typ = TBoolean() }
+final case class Void() extends IR { val typ = TVoid }
 
 final case class Cast(v: IR, typ: Type) extends IR
 

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -87,6 +87,10 @@ final case class ArrayFlatMap(a: IR, name: String, body: IR) extends InferIR {
 }
 final case class ArrayFold(a: IR, zero: IR, accumName: String, valueName: String, body: IR) extends InferIR
 
+final case class ArrayFor(a: IR, valueName: String, body: IR) extends IR {
+  val typ = TVoid
+}
+
 final case class AggIn(var typ: TAggregable) extends IR
 final case class AggMap(a: IR, name: String, body: IR) extends InferIR
 final case class AggFilter(a: IR, name: String, body: IR) extends InferIR

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -99,7 +99,7 @@ final case class ApplyAggOp(a: IR, op: AggOp, args: Seq[IR]) extends InferIR {
   def inputType: Type = coerce[TAggregable](a.typ).elementType
 }
 
-final case class SeqOp(a: IR, i: Int, agg: CodeAggregator[T] forSome { type T <: RegionValueAggregator }) extends IR {
+final case class SeqOp(a: IR, i: IR, agg: CodeAggregator[T] forSome { type T <: RegionValueAggregator }) extends IR {
   val typ = TVoid
 }
 

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -1,9 +1,12 @@
 package is.hail.expr.ir
 
+import is.hail.annotations.aggregators.RegionValueAggregator
 import is.hail.expr.types._
 import is.hail.expr.{BaseIR, MatrixIR, TableIR}
 import is.hail.expr.ir.functions.{IRFunction, IRFunctionRegistry, IRFunctionWithMissingness, IRFunctionWithoutMissingness}
 import is.hail.utils.ExportType
+
+import scala.language.existentials
 
 sealed trait IR extends BaseIR {
   def typ: Type
@@ -89,6 +92,14 @@ final case class AggFilter(a: IR, name: String, body: IR) extends InferIR
 final case class AggFlatMap(a: IR, name: String, body: IR) extends InferIR
 final case class ApplyAggOp(a: IR, op: AggOp, args: Seq[IR]) extends InferIR {
   def inputType: Type = coerce[TAggregable](a.typ).elementType
+}
+
+final case class SeqOp(a: IR, i: Int, agg: CodeAggregator[T] forSome { type T <: RegionValueAggregator }) extends IR {
+  val typ = TVoid
+}
+
+final case class Begin(xs: IndexedSeq[IR]) extends IR {
+  val typ = TVoid
 }
 
 final case class MakeStruct(fields: Seq[(String, IR)]) extends InferIR

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -45,6 +45,7 @@ object Interpret {
       case Str(x) => x
       case True() => true
       case False() => false
+      case Void() => ()
       case Cast(v, t) =>
         val vValue = interpret(v, env, args, agg)
         if (vValue == null)

--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -64,6 +64,7 @@ object Pretty {
             case AggFilter(_, name, _) => name
             case AggFlatMap(_, name, _) => name
             case ApplyAggOp(_, op, _) => op.getClass.getName.split("\\.").last
+            case ArrayFor(_, valueName, _) => s"$valueName"
             case Apply(function, _) => function
             case ApplySpecial(function, _) => function
             case In(i, _) => i.toString

--- a/src/main/scala/is/hail/expr/ir/Recur.scala
+++ b/src/main/scala/is/hail/expr/ir/Recur.scala
@@ -1,8 +1,59 @@
 package is.hail.expr.ir
 
 object Recur {
+<<<<<<< da22eb32264d1a628647697185ee222c20734739
   def apply(f: IR => IR)(ir: IR): IR = Copy(ir, Children(ir).map {
     case c: IR => f(c)
     case c => c
   }).asInstanceOf[IR]
+=======
+  def apply(f: IR => IR)(ir: IR): IR = ir match {
+    case I32(x) => ir
+    case I64(x) => ir
+    case F32(x) => ir
+    case F64(x) => ir
+    case True() => ir
+    case False() => ir
+    case Void() => ir
+    case Cast(v, typ) => Cast(f(v), typ)
+    case NA(typ) => ir
+    case IsNA(value) => IsNA(f(value))
+    case If(cond, cnsq, altr) => If(f(cond), f(cnsq), f(altr))
+    case Let(name, value, body) => Let(name, f(value), f(body))
+    case Ref(name, typ) => ir
+    case ApplyBinaryPrimOp(op, l, r) => ApplyBinaryPrimOp(op, f(l), f(r))
+    case ApplyUnaryPrimOp(op, x) => ApplyUnaryPrimOp(op, f(x))
+    case MakeArray(args, typ) => MakeArray(args map f, typ)
+    case ArrayRef(a, i) => ArrayRef(f(a), f(i))
+    case ArrayLen(a) => ArrayLen(f(a))
+    case ArrayRange(start, stop, step) => ArrayRange(f(start), f(stop), f(step))
+    case ArrayMap(a, name, body) => ArrayMap(f(a), name, f(body))
+    case ArrayFilter(a, name, cond) => ArrayFilter(f(a), name, f(cond))
+    case ArrayFlatMap(a, name, body) => ArrayFlatMap(f(a), name, f(body))
+    case ArrayFold(a, zero, accumName, valueName, body) => ArrayFold(f(a), f(zero), accumName, valueName, f(body))
+    case MakeStruct(fields) => MakeStruct(fields map { case (n, a) => (n, f(a)) })
+    case InsertFields(old, fields) => InsertFields(f(old), fields map { case (n, a) => (n, f(a)) })
+    case GetField(o, name) => GetField(f(o), name)
+    case AggIn(typ) => ir
+    case AggMap(a, name, body) => AggMap(f(a), name, f(body))
+    case AggFilter(a, name, body) => AggFilter(f(a), name, f(body))
+    case AggFlatMap(a, name, body) => AggFlatMap(f(a), name, f(body))
+    case SeqOp(a, i, agg) => SeqOp(f(a), i, agg)
+    case Begin(xs) => Begin(xs.map(f))
+    case ApplyAggOp(a, op, args) => ApplyAggOp(f(a), op, args.map(f))
+    case MakeTuple(elts) => MakeTuple(elts.map(f))
+    case GetTupleElement(tup, idx) => GetTupleElement(f(tup), idx)
+    case In(i, typ) => ir
+    case Die(message) => ir
+    case Apply(fn, args) => Apply(fn, args.map(f))
+    case ApplySpecial(fn, args) => ApplySpecial(fn, args.map(f))
+    // from MatrixIR
+    case MatrixWrite(_, _, _, _) => ir
+    // from TableIR
+    case TableCount(_) => ir
+    case TableAggregate(child, query) => TableAggregate(child, f(query))
+    case TableWrite(_, _, _, _) => ir
+    case TableExport(_, _, _, _, _) => ir
+  }
+>>>>>>> loop over columns in IR in MatrixMapRows
 }

--- a/src/main/scala/is/hail/expr/ir/Recur.scala
+++ b/src/main/scala/is/hail/expr/ir/Recur.scala
@@ -39,7 +39,7 @@ object Recur {
     case AggMap(a, name, body) => AggMap(f(a), name, f(body))
     case AggFilter(a, name, body) => AggFilter(f(a), name, f(body))
     case AggFlatMap(a, name, body) => AggFlatMap(f(a), name, f(body))
-    case SeqOp(a, i, agg) => SeqOp(f(a), i, agg)
+    case SeqOp(a, i, agg) => SeqOp(f(a), f(i), agg)
     case Begin(xs) => Begin(xs.map(f))
     case ApplyAggOp(a, op, args) => ApplyAggOp(f(a), op, args.map(f))
     case MakeTuple(elts) => MakeTuple(elts.map(f))

--- a/src/main/scala/is/hail/expr/ir/Recur.scala
+++ b/src/main/scala/is/hail/expr/ir/Recur.scala
@@ -1,60 +1,8 @@
 package is.hail.expr.ir
 
 object Recur {
-<<<<<<< da22eb32264d1a628647697185ee222c20734739
   def apply(f: IR => IR)(ir: IR): IR = Copy(ir, Children(ir).map {
     case c: IR => f(c)
     case c => c
   }).asInstanceOf[IR]
-=======
-  def apply(f: IR => IR)(ir: IR): IR = ir match {
-    case I32(x) => ir
-    case I64(x) => ir
-    case F32(x) => ir
-    case F64(x) => ir
-    case True() => ir
-    case False() => ir
-    case Void() => ir
-    case Cast(v, typ) => Cast(f(v), typ)
-    case NA(typ) => ir
-    case IsNA(value) => IsNA(f(value))
-    case If(cond, cnsq, altr) => If(f(cond), f(cnsq), f(altr))
-    case Let(name, value, body) => Let(name, f(value), f(body))
-    case Ref(name, typ) => ir
-    case ApplyBinaryPrimOp(op, l, r) => ApplyBinaryPrimOp(op, f(l), f(r))
-    case ApplyUnaryPrimOp(op, x) => ApplyUnaryPrimOp(op, f(x))
-    case MakeArray(args, typ) => MakeArray(args map f, typ)
-    case ArrayRef(a, i) => ArrayRef(f(a), f(i))
-    case ArrayLen(a) => ArrayLen(f(a))
-    case ArrayRange(start, stop, step) => ArrayRange(f(start), f(stop), f(step))
-    case ArrayMap(a, name, body) => ArrayMap(f(a), name, f(body))
-    case ArrayFilter(a, name, cond) => ArrayFilter(f(a), name, f(cond))
-    case ArrayFlatMap(a, name, body) => ArrayFlatMap(f(a), name, f(body))
-    case ArrayFold(a, zero, accumName, valueName, body) => ArrayFold(f(a), f(zero), accumName, valueName, f(body))
-    case ArrayFor(a, valueName, body) => ArrayFor(f(a), valueName, f(body))
-    case MakeStruct(fields) => MakeStruct(fields map { case (n, a) => (n, f(a)) })
-    case InsertFields(old, fields) => InsertFields(f(old), fields map { case (n, a) => (n, f(a)) })
-    case GetField(o, name) => GetField(f(o), name)
-    case AggIn(typ) => ir
-    case AggMap(a, name, body) => AggMap(f(a), name, f(body))
-    case AggFilter(a, name, body) => AggFilter(f(a), name, f(body))
-    case AggFlatMap(a, name, body) => AggFlatMap(f(a), name, f(body))
-    case SeqOp(a, i, agg) => SeqOp(f(a), f(i), agg)
-    case Begin(xs) => Begin(xs.map(f))
-    case ApplyAggOp(a, op, args) => ApplyAggOp(f(a), op, args.map(f))
-    case MakeTuple(elts) => MakeTuple(elts.map(f))
-    case GetTupleElement(tup, idx) => GetTupleElement(f(tup), idx)
-    case In(i, typ) => ir
-    case Die(message) => ir
-    case Apply(fn, args) => Apply(fn, args.map(f))
-    case ApplySpecial(fn, args) => ApplySpecial(fn, args.map(f))
-    // from MatrixIR
-    case MatrixWrite(_, _, _, _) => ir
-    // from TableIR
-    case TableCount(_) => ir
-    case TableAggregate(child, query) => TableAggregate(child, f(query))
-    case TableWrite(_, _, _, _) => ir
-    case TableExport(_, _, _, _, _) => ir
-  }
->>>>>>> loop over columns in IR in MatrixMapRows
 }

--- a/src/main/scala/is/hail/expr/ir/Recur.scala
+++ b/src/main/scala/is/hail/expr/ir/Recur.scala
@@ -31,6 +31,7 @@ object Recur {
     case ArrayFilter(a, name, cond) => ArrayFilter(f(a), name, f(cond))
     case ArrayFlatMap(a, name, body) => ArrayFlatMap(f(a), name, f(body))
     case ArrayFold(a, zero, accumName, valueName, body) => ArrayFold(f(a), f(zero), accumName, valueName, f(body))
+    case ArrayFor(a, valueName, body) => ArrayFor(f(a), valueName, f(body))
     case MakeStruct(fields) => MakeStruct(fields map { case (n, a) => (n, f(a)) })
     case InsertFields(old, fields) => InsertFields(f(old), fields map { case (n, a) => (n, f(a)) })
     case GetField(o, name) => GetField(f(o), name)

--- a/src/main/scala/is/hail/expr/ir/Subst.scala
+++ b/src/main/scala/is/hail/expr/ir/Subst.scala
@@ -23,6 +23,8 @@ object Subst {
         ArrayFlatMap(subst(a), name, subst(body, env.delete(name)))
       case ArrayFold(a, zero, accumName, valueName, body) =>
         ArrayFold(subst(a), subst(zero), accumName, valueName, subst(body, env.delete(accumName).delete(valueName)))
+      case ArrayFor(a, valueName, body) =>
+        ArrayFor(subst(a), valueName, subst(body, env.delete(valueName)))
       case ApplyAggOp(a, op, args) =>
         val substitutedArgs = args.map(arg => Recur(subst(_))(arg))
         ApplyAggOp(subst(a, aggEnv, Env.empty), op, substitutedArgs)

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -19,7 +19,11 @@ object TypeCheck {
       case F64(x) =>
       case True() =>
       case False() =>
+<<<<<<< da22eb32264d1a628647697185ee222c20734739
       case Str(x) =>
+=======
+      case Void() =>
+>>>>>>> loop over columns in IR in MatrixMapRows
 
       case Cast(v, typ) =>
         check(v)

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -102,6 +102,10 @@ object TypeCheck {
         check(body, env = env.bind(accumName -> zero.typ, valueName -> -tarray.elementType))
         assert(body.typ == zero.typ)
         assert(x.typ == zero.typ)
+      case x@ArrayFor(a, valueName, body) =>
+        check(a)
+        val tarray = coerce[TArray](a.typ)
+        check(body, env = env.bind(valueName -> -tarray.elementType))
       case x@AggIn(typ) =>
         (tAgg, typ) match {
           case (Some(t), null) => x.typ = t

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -133,8 +133,10 @@ object TypeCheck {
         val tagg2 = tagg.copy(elementType = tout.elementType)
         tagg2.symTab = tagg.symTab
         assert(x.typ == tagg2)
-      case x@SeqOp(a, _, _) =>
+      case x@SeqOp(a, i, _) =>
         check(a)
+        check(i)
+        assert(i.typ.isInstanceOf[TInt32])
       case x@Begin(xs) =>
         xs.foreach { x =>
           check(x)

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -19,11 +19,8 @@ object TypeCheck {
       case F64(x) =>
       case True() =>
       case False() =>
-<<<<<<< da22eb32264d1a628647697185ee222c20734739
       case Str(x) =>
-=======
       case Void() =>
->>>>>>> loop over columns in IR in MatrixMapRows
 
       case Cast(v, typ) =>
         check(v)

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -125,6 +125,13 @@ object TypeCheck {
         val tagg2 = tagg.copy(elementType = tout.elementType)
         tagg2.symTab = tagg.symTab
         assert(x.typ == tagg2)
+      case x@SeqOp(a, _, _) =>
+        check(a)
+      case x@Begin(xs) =>
+        xs.foreach { x =>
+          check(x)
+          assert(x.typ == TVoid)
+        }
       case x@ApplyAggOp(a, op, args) =>
         val tAgg = coerce[TAggregable](a.typ)
         check(a)

--- a/src/main/scala/is/hail/expr/ir/TypeToIRIntermediateClassTag.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeToIRIntermediateClassTag.scala
@@ -6,6 +6,7 @@ import scala.reflect.{ClassTag, classTag}
 
 object TypeToIRIntermediateClassTag {
   def apply(t: Type): ClassTag[_] = t.fundamentalType match {
+    case TVoid => classTag[Unit]
     case _: TBoolean => classTag[Boolean]
     case _: TInt32 => classTag[Int]
     case _: TInt64 => classTag[Long]

--- a/src/main/scala/is/hail/expr/ir/package.scala
+++ b/src/main/scala/is/hail/expr/ir/package.scala
@@ -27,6 +27,7 @@ package object ir {
   }
 
   def defaultValue(t: Type): Code[_] = typeToTypeInfo(t) match {
+    case UnitInfo => Code._empty[Unit]
     case BooleanInfo => false
     case IntInfo => 0
     case LongInfo => 0L

--- a/src/main/scala/is/hail/expr/ir/package.scala
+++ b/src/main/scala/is/hail/expr/ir/package.scala
@@ -22,6 +22,7 @@ package object ir {
     case _: TBinary => typeInfo[Long]
     case _: TArray => typeInfo[Long]
     case _: TBaseStruct => typeInfo[Long]
+    case TVoid => typeInfo[Unit]
     case _ => throw new RuntimeException(s"unsupported type found, $t")
   }
 

--- a/src/test/scala/is/hail/expr/ir/ExtractAggregatorsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/ExtractAggregatorsSuite.scala
@@ -56,9 +56,13 @@ class ExtractAggregatorsSuite {
 
     val seqOps = {
       val fb = EmitFunctionBuilder[Region, Array[RegionValueAggregator], IN, Boolean, SCOPE0, Boolean, Unit]
-      Emit(aggIR, fb, 2, tAgg)
 
-      fb.result(Some(new java.io.PrintWriter(System.out)))()
+      val s = Subst(aggIR, Env.empty[IR].bind("scope0", In(1, hailType[SCOPE0])))
+      Emit(s, fb, 2, tAgg)
+
+      fb.result(
+        // Some(new java.io.PrintWriter(System.out))
+      )()
     }
 
     val tArray = TArray(hailType[IN])
@@ -87,8 +91,8 @@ class ExtractAggregatorsSuite {
     fb.result()()
   }
 
-  private def run[IN : HailRep : TypeInfo, SCOPE0 : HailRep : TypeInfo, R : TypeInfo]
-    (region: Region, ir: IR, aOff: Long, scope0: Int => SCOPE0): R = {
+  private def run[IN : HailRep : TypeInfo, SCOPE0 : HailRep : TypeInfo, R : TypeInfo](
+    region: Region, ir: IR, aOff: Long, scope0: Int => SCOPE0): R = {
     val (post, ret) = runStage1[IN, SCOPE0](region, ir, aOff, scope0)
     val f = compileStage0[R](post)
     f(region, ret, false)

--- a/src/test/scala/is/hail/methods/AggregatorSuite.scala
+++ b/src/test/scala/is/hail/methods/AggregatorSuite.scala
@@ -244,7 +244,7 @@ class AggregatorSuite extends SparkSuite {
       } yield {
         val s1 = vds.stringSampleIds(0)
         assert(vds.aggregateCols(s"""AGG.map(r => if (r.s == "$s1") (NA : String) else r.s).map(x => 1).sum()""")._1 == vds.numCols)
-        assert(vds.aggregateCols("AGG.map(id => 1).sum()")._1 == vds.numCols)
+        assert(vds.aggregateCols("AGG.filter(r => true).map(id => 1).sum()")._1 == vds.numCols)
         assert(vds.aggregateCols("AGG.filter(r => false).map(id => 1).sum()")._1 == 0)
         assert(vds.aggregateCols("AGG.flatMap(g => [1]).sum()")._1 == vds.numCols)
         assert(vds.aggregateCols("AGG.flatMap(g => [0][:0]).sum()")._1 == 0)

--- a/src/test/scala/is/hail/methods/AggregatorSuite.scala
+++ b/src/test/scala/is/hail/methods/AggregatorSuite.scala
@@ -244,7 +244,7 @@ class AggregatorSuite extends SparkSuite {
       } yield {
         val s1 = vds.stringSampleIds(0)
         assert(vds.aggregateCols(s"""AGG.map(r => if (r.s == "$s1") (NA : String) else r.s).map(x => 1).sum()""")._1 == vds.numCols)
-        assert(vds.aggregateCols("AGG.filter(r => true).map(id => 1).sum()")._1 == vds.numCols)
+        assert(vds.aggregateCols("AGG.map(id => 1).sum()")._1 == vds.numCols)
         assert(vds.aggregateCols("AGG.filter(r => false).map(id => 1).sum()")._1 == 0)
         assert(vds.aggregateCols("AGG.flatMap(g => [1]).sum()")._1 == vds.numCols)
         assert(vds.aggregateCols("AGG.flatMap(g => [0][:0]).sum()")._1 == 0)


### PR DESCRIPTION
Previously, MatrixMapRows was calling into an IR-generated function for each element.  Now we aggregate the entire row from within Python.  On a 6-aggregator benchmark on a shard of gnomAD, this improved things about 50% (1m59 => 1m02).

Some notable changes:
 - I added a Begin for sequencing void-type IR,
 - I added ArrayFor for looping over arrays (@danking)
 - I added a SeqOp that represents calling the RegionValueAggregator in seqOp in the IR after extracting aggregators, it holds the index of the aggregator to call seqsOp on, since there might be multiple,
 - added Void literal (which I didn't end up using, but I left it in for now),
 - TAggreable symbol table is no longer used in compiling the extracted aggregators.  The arguments need to specified explicitly and otherwise it is just another function (but takes an extra special argument, the array of RVAggregators),

This suggests some additional improvements/simplifications to the aggregator interface that I will write up on the dev forum.