### PR TITLE
Expose RVDContext in RVD.treeAggregate

### DIFF
--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -1022,44 +1022,50 @@ case class MatrixMapCols(child: MatrixIR, newCol: IR) extends MatrixIR {
       rvAggsMA(i, j) = rvAggs(j).copy()
     }
 
-    val aggResults = if (seqOps.nonEmpty) {
-      prev.rvd.treeAggregate[MultiArray2[RegionValueAggregator]](rvAggsMA)({ (rvaggs, rv) =>
-        val rvb = new RegionValueBuilder()
-        val region = rv.region
-        val oldRow = rv.offset
+    type RVAggArray = MultiArray2[RegionValueAggregator]
 
-        rvb.set(region)
-        rvb.start(localGlobalsType)
-        rvb.addAnnotation(localGlobalsType, globalsBc.value)
-        val globals = rvb.end()
+    def seqOp(ctx: RVDContext, rvaggs: RVAggArray, rv: RegionValue): RVAggArray = {
+      val rvb = ctx.rvb
+      val region = ctx.region
+      val oldRow = rv.offset
 
-        rvb.start(localColsType)
-        rvb.addAnnotation(localColsType, colValuesBc.value)
-        val cols = rvb.end()
+      rvb.set(region)
+      rvb.start(localGlobalsType)
+      rvb.addAnnotation(localGlobalsType, globalsBc.value)
+      val globals = rvb.end()
 
-        val entriesOff = localRowType.loadField(region, oldRow, entriesIdx)
+      rvb.start(localColsType)
+      rvb.addAnnotation(localColsType, colValuesBc.value)
+      val cols = rvb.end()
 
-        var i = 0
-        while (i < localNCols) {
-          val eMissing = localEntriesType.isElementMissing(region, entriesOff, i)
-          val eOff = localEntriesType.elementOffset(entriesOff, localNCols, i)
-          val colMissing = localColsType.isElementMissing(region, cols, i)
-          assert(!colMissing)
-          val colOff = localColsType.elementOffset(cols, localNCols, i)
+      val entriesOff = localRowType.loadField(region, oldRow, entriesIdx)
 
-          var j = 0
-          while (j < seqOps.length) {
-            seqOps(j)()(region, rvaggs(i, j), oldRow, false, globals, false, oldRow, false, eOff, eMissing, colOff, colMissing)
-            j += 1
-          }
-          i += 1
+      var i = 0
+      while (i < localNCols) {
+        val eMissing = localEntriesType.isElementMissing(region, entriesOff, i)
+        val eOff = localEntriesType.elementOffset(entriesOff, localNCols, i)
+        val colMissing = localColsType.isElementMissing(region, cols, i)
+        assert(!colMissing)
+        val colOff = localColsType.elementOffset(cols, localNCols, i)
+
+        var j = 0
+        while (j < seqOps.length) {
+          seqOps(j)()(region, rvaggs(i, j), oldRow, false, globals, false, oldRow, false, eOff, eMissing, colOff, colMissing)
+          j += 1
         }
+        i += 1
+      }
 
-        rvaggs
-      }, { (rvAggs1, rvAggs2) =>
-        rvAggs1.zip(rvAggs2).foreach { case (rvAgg1, rvAgg2) => rvAgg1.combOp(rvAgg2) }
-        rvAggs1
-      }, depth = depth)
+      rvaggs
+    }
+
+    def combOp(ctx: RVDContext, rvAggs1: RVAggArray, rvAggs2: RVAggArray): RVAggArray = {
+      rvAggs1.zip(rvAggs2).foreach { case (rvAgg1, rvAgg2) => rvAgg1.combOp(rvAgg2) }
+      rvAggs1
+    }
+
+    val aggResults = if (seqOps.nonEmpty) {
+      prev.rvd.treeAggregate[RVAggArray](rvAggsMA, seqOp _, combOp _, depth = depth)
     } else
       MultiArray2.fill[RegionValueAggregator](localNCols, 0)(null)
 

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -1024,7 +1024,7 @@ case class MatrixMapCols(child: MatrixIR, newCol: IR) extends MatrixIR {
 
     type RVAggArray = MultiArray2[RegionValueAggregator]
 
-    def seqOp(ctx: RVDContext, rvaggs: RVAggArray, rv: RegionValue): RVAggArray = {
+    val seqOp = (ctx: RVDContext, rvaggs: RVAggArray, rv: RegionValue) => {
       val rvb = ctx.rvb
       val region = ctx.region
       val oldRow = rv.offset
@@ -1059,13 +1059,13 @@ case class MatrixMapCols(child: MatrixIR, newCol: IR) extends MatrixIR {
       rvaggs
     }
 
-    def combOp(ctx: RVDContext, rvAggs1: RVAggArray, rvAggs2: RVAggArray): RVAggArray = {
+    val combOp = (ctx: RVDContext, rvAggs1: RVAggArray, rvAggs2: RVAggArray) => {
       rvAggs1.zip(rvAggs2).foreach { case (rvAgg1, rvAgg2) => rvAgg1.combOp(rvAgg2) }
       rvAggs1
     }
 
     val aggResults = if (seqOps.nonEmpty) {
-      prev.rvd.treeAggregate[RVAggArray](rvAggsMA, seqOp _, combOp _, depth = depth)
+      prev.rvd.treeAggregate[RVAggArray](rvAggsMA, seqOp, combOp, depth = depth)
     } else
       MultiArray2.fill[RegionValueAggregator](localNCols, 0)(null)
 

--- a/src/main/scala/is/hail/methods/Aggregators.scala
+++ b/src/main/scala/is/hail/methods/Aggregators.scala
@@ -159,10 +159,10 @@ object Aggregators {
     val fullRowType = value.typ.rvRowType
     val localEntriesIndex = value.typ.entriesIdx
 
-    def seqOp(
+    val seqOp = (
       arr: MultiArray2[Aggregator],
       rv: RegionValue
-    ): MultiArray2[Aggregator] = {
+    ) => {
       val fullRow = new UnsafeRow(fullRowType, rv)
 
       localA(0) = globalsBc.value
@@ -191,10 +191,10 @@ object Aggregators {
       arr
     }
 
-    def combOp(
+    val combOp = (
       arr1: MultiArray2[Aggregator],
       arr2: MultiArray2[Aggregator]
-    ): MultiArray2[Aggregator] = {
+    ) => {
       for (i <- 0 until nCols; j <- 0 until nAggregations) {
         val a1 = arr1(i, j)
         a1.combOp(arr2(i, j).asInstanceOf[a1.type])
@@ -203,7 +203,7 @@ object Aggregators {
     }
 
     val result = value.rvd
-      .treeAggregate(baseArray, seqOp _, combOp _, depth = depth)
+      .treeAggregate(baseArray, seqOp, combOp, depth = depth)
 
     Some((i: Int) => {
       for (j <- 0 until nAggregations) {

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -168,17 +168,38 @@ trait RVD {
     newPartitioner: OrderedRVDPartitioner
   ): OrderedRVD
 
-  def treeAggregate[U: ClassTag](zeroValue: U)(
+  def treeAggregate[U: ClassTag](
+    zeroValue: U,
+    seqOp: (U, RegionValue) => U,
+    combOp: (U, U) => U
+  ): U = treeAggregate(
+    zeroValue,
+    seqOp,
+    combOp,
+    treeAggDepth(HailContext.get, rdd.getNumPartitions))
+
+  def treeAggregate[U: ClassTag](
+    zeroValue: U,
     seqOp: (U, RegionValue) => U,
     combOp: (U, U) => U,
-    depth: Int = treeAggDepth(HailContext.get, rdd.getNumPartitions)
+    depth: Int
   ): U = crdd.treeAggregate(zeroValue, seqOp, combOp, depth)
 
   def treeAggregate[U: ClassTag](
     zeroValue: U,
     seqOp: (RVDContext, U, RegionValue) => U,
+    combOp: (RVDContext, U, U) => U
+  ): U = treeAggregate(
+    zeroValue,
+    seqOp,
+    combOp,
+    treeAggDepth(HailContext.get, rdd.getNumPartitions))
+
+  def treeAggregate[U: ClassTag](
+    zeroValue: U,
+    seqOp: (RVDContext, U, RegionValue) => U,
     combOp: (RVDContext, U, U) => U,
-    depth: Int = treeAggDepth(HailContext.get, rdd.getNumPartitions)
+    depth: Int
   ): U = crdd.ctreeAggregate[U, U](
     zeroValue,
     seqOp,

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -174,6 +174,19 @@ trait RVD {
     depth: Int = treeAggDepth(HailContext.get, rdd.getNumPartitions)
   ): U = crdd.treeAggregate(zeroValue, seqOp, combOp, depth)
 
+  def treeAggregate[U: ClassTag](
+    zeroValue: U,
+    seqOp: (RVDContext, U, RegionValue) => U,
+    combOp: (RVDContext, U, U) => U,
+    depth: Int = treeAggDepth(HailContext.get, rdd.getNumPartitions)
+  ): U = crdd.ctreeAggregate[U, U](
+    zeroValue,
+    seqOp,
+    combOp,
+    x => x,
+    (_, x) => x,
+    depth)
+
   def aggregate[U: ClassTag](
     zeroValue: U
   )(seqOp: (U, RegionValue) => U,

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1695,7 +1695,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
         })
 
         val result = rvd
-          .treeAggregate(zVal)(seqOp, combOp, depth = treeAggDepth(hc, nPartitions))
+          .treeAggregate(zVal, seqOp, combOp, depth = treeAggDepth(hc, nPartitions))
         resOp(result)
 
         (f(), t)


### PR DESCRIPTION
Unfortunately, this killed the type inference (🤷‍♀️ Scala). That made the functions kind of unwieldy in-line, so I made them inner-method-definitions instead and added a type alias for `MultiArray2[RegionValueAggregator]`.

The RVB will be allocated once per aggregated partition.