### PR TITLE
fix CodeOrdering to differentiate between `compare` and `equiv`

### DIFF
--- a/src/main/scala/is/hail/annotations/CodeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/CodeOrdering.scala
@@ -17,6 +17,8 @@ object CodeOrdering {
   val gt: Op = 4
   val gteq: Op = 5
 
+  type F[R] = (Code[Region], (Code[Boolean], Code[_]), Code[Region], (Code[Boolean], Code[_])) => Code[R]
+
   def rowOrdering(t: TBaseStruct, mb: EmitMethodBuilder): CodeOrdering = new CodeOrdering {
     type T = Long
 

--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -412,6 +412,8 @@ class CodeBoolean(val lhs: Code[Boolean]) extends AnyVal {
 
   // on the JVM Booleans are represented as Ints
   def toI: Code[Int] = lhs.asInstanceOf[Code[Int]]
+
+  def toS: Code[String] = lhs.mux(const("true"), const("false"))
 }
 
 class CodeInt(val lhs: Code[Int]) extends AnyVal {
@@ -689,6 +691,8 @@ trait Settable[T] {
   def store(rhs: Code[T]): Code[Unit]
 
   def :=(rhs: Code[T]): Code[Unit] = store(rhs)
+
+  def storeAny(rhs: Code[_]): Code[Unit] = store(coerce[T](rhs))
 }
 
 class LazyFieldRef[T: TypeInfo](fb: FunctionBuilder[_], name: String, setup: Code[T]) extends Settable[T] {

--- a/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -251,7 +251,7 @@ class FunctionBuilder[F >: Null](val parameterTypeInfo: Array[MaybeGenericTypeIn
         val cwNoFrames = new ClassWriter(ClassWriter.COMPUTE_MAXS)
         val sw2 = new StringWriter()
         cn.accept(cwNoFrames)
-//        CheckClassAdapter.verify(new ClassReader(cwNoFrames.toByteArray), false, new PrintWriter(sw2))
+        CheckClassAdapter.verify(new ClassReader(cwNoFrames.toByteArray), false, new PrintWriter(sw2))
 
         if (sw2.toString().length() != 0) {
           System.err.println("Verify Output 2 for " + name + ":")

--- a/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -251,7 +251,7 @@ class FunctionBuilder[F >: Null](val parameterTypeInfo: Array[MaybeGenericTypeIn
         val cwNoFrames = new ClassWriter(ClassWriter.COMPUTE_MAXS)
         val sw2 = new StringWriter()
         cn.accept(cwNoFrames)
-        CheckClassAdapter.verify(new ClassReader(cwNoFrames.toByteArray), false, new PrintWriter(sw2))
+//        CheckClassAdapter.verify(new ClassReader(cwNoFrames.toByteArray), false, new PrintWriter(sw2))
 
         if (sw2.toString().length() != 0) {
           System.err.println("Verify Output 2 for " + name + ":")

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -710,7 +710,7 @@ case class Apply(posn: Position, fn: String, args: Array[AST]) extends AST(posn,
     for {
       irArgs <- anyFailAllFail(args.map(_.toIR(agg)))
       ir <- tryPrimOpConversion(args.map(_.`type`).zip(irArgs)).orElse(
-        IRFunctionRegistry.lookupConversion(fn, args.map(_.`type`))
+        IRFunctionRegistry.lookupConversion(fn, irArgs.map(_.typ))
           .map { irf => irf(irArgs) })
     } yield ir
 
@@ -840,7 +840,7 @@ case class ApplyMethod(posn: Position, lhs: AST, method: String, args: Array[AST
       case _ =>
         for {
           irs <- anyFailAllFail((lhs +: args).map(_.toIR(agg)))
-          ir <- IRFunctionRegistry.lookupConversion(method, (lhs +: args).map(_.`type`))
+          ir <- IRFunctionRegistry.lookupConversion(method, irs.map(_.typ))
               .map { irf => irf(irs) }
         } yield ir
     }

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -519,8 +519,7 @@ private class Emit(
         present(Code._throw(Code.newInstance[RuntimeException, String](m)))
       case ir@Apply(fn, args) =>
         val impl = ir.implementation
-        impl.argTypes.foreach(_.clear())
-        val unified = args.map(_.typ).zip(impl.argTypes).forall { case (i, j) => j.unify(i) }
+        val unified = impl.unify(args.map(_.typ))
         assert(unified)
 
         val meth =
@@ -541,7 +540,7 @@ private class Emit(
         EmitTriplet(setup, missing, value)
       case x@ApplySpecial(_, args) =>
         x.implementation.argTypes.foreach(_.clear())
-        val unified = args.map(_.typ).zip(x.implementation.argTypes).forall { case (i, j) => j.unify(i) }
+        val unified = x.implementation.unify(args.map(_.typ))
         assert(unified)
         x.implementation.apply(mb, args.map(emit(_)): _*)
     }

--- a/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -1,6 +1,9 @@
 package is.hail.expr.ir
 
+import is.hail.annotations.{CodeOrdering, Region}
+import is.hail.asm4s
 import is.hail.asm4s._
+import is.hail.expr.types.Type
 import is.hail.variant.ReferenceGenome
 import org.objectweb.asm.tree.AbstractInsnNode
 
@@ -44,6 +47,9 @@ class EmitMethodBuilder(
 
   def getReferenceGenome(rg: ReferenceGenome): Code[ReferenceGenome] =
     fb.getReferenceGenome(rg)
+
+  def getCodeOrdering[T](t: Type, op: CodeOrdering.Op, missingGreatest: Boolean): fb.OrdF[T] =
+    fb.getCodeOrdering[T](t, op, missingGreatest)
 }
 
 class EmitFunctionBuilder[F >: Null](
@@ -55,10 +61,44 @@ class EmitFunctionBuilder[F >: Null](
   private[this] val rgMap: mutable.Map[ReferenceGenome, Code[ReferenceGenome]] =
     mutable.Map[ReferenceGenome, Code[ReferenceGenome]]()
 
+  type OrdF[T] = (Code[Region], (Code[Boolean], Code[_]), Code[Region], (Code[Boolean], Code[_])) => Code[T]
+  private[this] val compareMap: mutable.Map[(Type, CodeOrdering.Op, Boolean), OrdF[_]] =
+    mutable.Map[(Type, CodeOrdering.Op, Boolean), OrdF[_]]()
+
   def numReferenceGenomes: Int = rgMap.size
 
   def getReferenceGenome(rg: ReferenceGenome): Code[ReferenceGenome] =
     rgMap.getOrElseUpdate(rg, newLazyField[ReferenceGenome](rg.codeSetup))
+
+  def getCodeOrdering[T](t: Type, op: CodeOrdering.Op, missingGreatest: Boolean): OrdF[T] = {
+    val f = compareMap.getOrElseUpdate((t, op, missingGreatest), {
+      val ti = typeToTypeInfo(t)
+      val rt = if (op == CodeOrdering.compare) typeInfo[Int] else typeInfo[Boolean]
+      val newMB = newMethod(Array[TypeInfo[_]](typeInfo[Region], typeInfo[Boolean], ti, typeInfo[Region], typeInfo[Boolean], ti), rt)
+      val ord = t.codeOrdering(newMB)
+      val r1 = newMB.getArg[Region](1)
+      val r2 = newMB.getArg[Region](4)
+      val m1 = newMB.getArg[Boolean](2)
+      val v1 = newMB.getArg(3)(ti)
+      val m2 = newMB.getArg[Boolean](5)
+      val v2 = newMB.getArg(6)(ti)
+      val c: Code[_] = op match {
+        case CodeOrdering.compare => ord.compare(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)), missingGreatest)
+        case CodeOrdering.equiv => ord.equiv(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)), missingGreatest)
+        case CodeOrdering.lt => ord.lt(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)), missingGreatest)
+        case CodeOrdering.lteq => ord.lteq(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)), missingGreatest)
+        case CodeOrdering.gt => ord.gt(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)), missingGreatest)
+        case CodeOrdering.gteq => ord.gteq(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)), missingGreatest)
+      }
+      newMB.emit(c)
+      val f = { (rx: Code[Region], x: (Code[Boolean], Code[_]), ry: Code[Region], y: (Code[Boolean], Code[_])) =>
+        newMB.invoke(rx, x._1, x._2, ry, y._1, y._2)
+      }
+      f
+    })
+    (r1: Code[Region], v1: (Code[Boolean], Code[_]), r2: Code[Region], v2: (Code[Boolean], Code[_])) => coerce[T](f(r1, v1, r2, v2))
+  }
+
 
   override val apply_method: EmitMethodBuilder = {
     val m = new EmitMethodBuilder(this, "apply", parameterTypeInfo.map(_.base), returnTypeInfo.base)

--- a/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -48,7 +48,7 @@ class EmitMethodBuilder(
   def getReferenceGenome(rg: ReferenceGenome): Code[ReferenceGenome] =
     fb.getReferenceGenome(rg)
 
-  def getCodeOrdering[T](t: Type, op: CodeOrdering.Op, missingGreatest: Boolean): fb.OrdF[T] =
+  def getCodeOrdering[T](t: Type, op: CodeOrdering.Op, missingGreatest: Boolean): CodeOrdering.F[T] =
     fb.getCodeOrdering[T](t, op, missingGreatest)
 }
 
@@ -61,16 +61,15 @@ class EmitFunctionBuilder[F >: Null](
   private[this] val rgMap: mutable.Map[ReferenceGenome, Code[ReferenceGenome]] =
     mutable.Map[ReferenceGenome, Code[ReferenceGenome]]()
 
-  type OrdF[T] = (Code[Region], (Code[Boolean], Code[_]), Code[Region], (Code[Boolean], Code[_])) => Code[T]
-  private[this] val compareMap: mutable.Map[(Type, CodeOrdering.Op, Boolean), OrdF[_]] =
-    mutable.Map[(Type, CodeOrdering.Op, Boolean), OrdF[_]]()
+  private[this] val compareMap: mutable.Map[(Type, CodeOrdering.Op, Boolean), CodeOrdering.F[_]] =
+    mutable.Map[(Type, CodeOrdering.Op, Boolean), CodeOrdering.F[_]]()
 
   def numReferenceGenomes: Int = rgMap.size
 
   def getReferenceGenome(rg: ReferenceGenome): Code[ReferenceGenome] =
     rgMap.getOrElseUpdate(rg, newLazyField[ReferenceGenome](rg.codeSetup))
 
-  def getCodeOrdering[T](t: Type, op: CodeOrdering.Op, missingGreatest: Boolean): OrdF[T] = {
+  def getCodeOrdering[T](t: Type, op: CodeOrdering.Op, missingGreatest: Boolean): CodeOrdering.F[T] = {
     val f = compareMap.getOrElseUpdate((t, op, missingGreatest), {
       val ti = typeToTypeInfo(t)
       val rt = if (op == CodeOrdering.compare) typeInfo[Int] else typeInfo[Boolean]

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -113,11 +113,7 @@ final case class Apply(function: String, args: Seq[IR]) extends IR {
   def typ: Type = {
     // convert all arg types before unifying
     val argTypes = args.map(_.typ)
-    implementation.argTypes.foreach(_.clear())
-    argTypes.zip(implementation.argTypes).foreach { case (i, j) =>
-      val u = j.unify(i)
-      assert(u)
-    }
+    implementation.unify(argTypes)
     implementation.returnType.subst()
   }
 
@@ -130,11 +126,7 @@ final case class ApplySpecial(function: String, args: Seq[IR]) extends IR {
 
   def typ: Type = {
     val argTypes = args.map(_.typ)
-    implementation.argTypes.foreach(_.clear())
-    argTypes.zip(implementation.argTypes).foreach { case (i, j) =>
-      val u = j.unify(i)
-      assert(u)
-    }
+    implementation.unify(argTypes)
     implementation.returnType.subst()
   }
 

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -113,8 +113,8 @@ final case class Apply(function: String, args: Seq[IR]) extends IR {
   def typ: Type = {
     // convert all arg types before unifying
     val argTypes = args.map(_.typ)
+    implementation.argTypes.foreach(_.clear())
     argTypes.zip(implementation.argTypes).foreach { case (i, j) =>
-      j.clear()
       val u = j.unify(i)
       assert(u)
     }
@@ -130,8 +130,8 @@ final case class ApplySpecial(function: String, args: Seq[IR]) extends IR {
 
   def typ: Type = {
     val argTypes = args.map(_.typ)
+    implementation.argTypes.foreach(_.clear())
     argTypes.zip(implementation.argTypes).foreach { case (i, j) =>
-      j.clear()
       val u = j.unify(i)
       assert(u)
     }

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -167,10 +167,12 @@ object TypeCheck {
       case x@Apply(fn, args) =>
         val impl = x.implementation
         args.foreach(check(_))
+        x.implementation.argTypes.foreach(_.clear())
         assert(args.map(_.typ).zip(x.implementation.argTypes).forall { case (i, j) => j.unify(i) })
       case x@ApplySpecial(fn, args) =>
         val impl = x.implementation
         args.foreach(check(_))
+        x.implementation.argTypes.foreach(_.clear())
         assert(args.map(_.typ).zip(x.implementation.argTypes).forall { case (i, j) => j.unify(i) })
       case MatrixWrite(_, _, _, _) =>
       case x@TableAggregate(child, query) =>

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -167,13 +167,11 @@ object TypeCheck {
       case x@Apply(fn, args) =>
         val impl = x.implementation
         args.foreach(check(_))
-        x.implementation.argTypes.foreach(_.clear())
-        assert(args.map(_.typ).zip(x.implementation.argTypes).forall { case (i, j) => j.unify(i) })
+        assert(x.implementation.unify(args.map(_.typ)))
       case x@ApplySpecial(fn, args) =>
         val impl = x.implementation
         args.foreach(check(_))
-        x.implementation.argTypes.foreach(_.clear())
-        assert(args.map(_.typ).zip(x.implementation.argTypes).forall { case (i, j) => j.unify(i) })
+        assert(x.implementation.unify(args.map(_.typ)))
       case MatrixWrite(_, _, _, _) =>
       case x@TableAggregate(child, query) =>
         check(query, tAgg = Some(child.typ.tAgg), env = child.typ.aggEnv)

--- a/src/main/scala/is/hail/expr/ir/functions/CallFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/CallFunctions.scala
@@ -11,8 +11,6 @@ object CallFunctions extends RegistryFunctions {
     registerScalaFunction("downcode", TCall(), TInt32(), TCall())(Call.getClass, "downcode")
     registerScalaFunction("UnphasedDiploidGtIndexCall", TInt32(), TCall())(Call2.getClass, "fromUnphasedDiploidGtIndex")
 
-    registerCode("==", TCall(), TCall(), TBoolean()) { case (_, a: Code[Int], b: Code[Int]) => a.ceq(b) }
-
     val qualities = Array("isPhased", "isHomRef", "isHet",
       "isHomVar", "isNonRef", "isHetNonRef", "isHetRef")
     for (q <- qualities) registerScalaFunction(q, TCall(), TBoolean())(Call.getClass, q)

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -14,37 +14,34 @@ object IRFunctionRegistry {
   val irRegistry: mutable.MultiMap[String, (Seq[Type], Seq[IR] => IR)] =
     new mutable.HashMap[String, mutable.Set[(Seq[Type], Seq[IR] => IR)]] with mutable.MultiMap[String, (Seq[Type], Seq[IR] => IR)]
 
-  val codeRegistry: mutable.MultiMap[String, (Seq[Type], IRFunction)] =
-    new mutable.HashMap[String, mutable.Set[(Seq[Type], IRFunction)]] with mutable.MultiMap[String, (Seq[Type], IRFunction)]
+  val codeRegistry: mutable.MultiMap[String, IRFunction] =
+    new mutable.HashMap[String, mutable.Set[IRFunction]] with mutable.MultiMap[String, IRFunction]
 
   def addIRFunction(f: IRFunction): Unit =
-    codeRegistry.addBinding(f.name, (f.argTypes, f))
+    codeRegistry.addBinding(f.name, f)
 
   def addIR(name: String, types: Seq[Type], f: Seq[IR] => IR): Unit =
     irRegistry.addBinding(name, (types, f))
 
-  private def lookupInRegistry[T](reg: mutable.MultiMap[String, (Seq[Type], T)], name: String, args: Seq[Type]): Option[T] = {
-    reg.lift(name).flatMap { fs =>
-      fs.filter { case (ts, _) =>
-        ts.length == args.length && {
-          ts.foreach(_.clear())
-          (ts, args).zipped.forall(_.unify(_))
-        }
-      }.toSeq match {
-        case Seq() => None
-        case Seq((_, f)) => Some(f)
-        case _ => fatal(s"Multiple functions found that satisfy $name(${ args.mkString(",") }).")
-      }
+  private def lookupInRegistry[T](reg: mutable.MultiMap[String, T], name: String, args: Seq[Type], cond: (T, Seq[Type]) => Boolean): Option[T] = {
+    reg.lift(name).map { fs => fs.filter(t => cond(t, args)).toSeq }.getOrElse(FastSeq()) match {
+      case Seq() => None
+      case Seq((_, f)) => Some(f)
+      case _ => fatal(s"Multiple functions found that satisfy $name(${ args.mkString(",") }).")
     }
   }
 
   def lookupFunction(name: String, args: Seq[Type]): Option[IRFunction] =
-    lookupInRegistry(codeRegistry, name, args)
+    lookupInRegistry(codeRegistry, name, args, (f: IRFunction, ts: Seq[Type]) => f.unify(ts))
 
   def lookupConversion(name: String, args: Seq[Type]): Option[Seq[IR] => IR] = {
-    assert(args.forall(_ != null))
-
-    val validIR = lookupInRegistry(irRegistry, name, args)
+    val findIR = { case ((ts: Seq[Type], ir: IR), t2s: Seq[Type]) =>
+      ts.length == args.length && {
+        ts.foreach(_.clear())
+        (ts, args).zipped.forall(_.unify(_))
+      }
+    }
+    val validIR = lookupInRegistry(irRegistry, name, args, findIR).map(_._2)
 
     val validMethods = lookupFunction(name, args).map { f =>
       { irArgs: Seq[IR] =>
@@ -212,6 +209,11 @@ sealed abstract class IRFunction {
 
   def isDeterministic: Boolean
 
+  def unify(concrete: Seq[Type]): Boolean = {
+    require(argTypes.length == concrete.length)
+    argTypes.foreach(_.clear())
+    argTypes.zip(concrete).forall { case (i, j) => i.unify(j) }
+  }
 }
 
 abstract class IRFunctionWithoutMissingness extends IRFunction {
@@ -230,8 +232,7 @@ abstract class IRFunctionWithoutMissingness extends IRFunction {
   }
 
   override def getAsMethod(fb: EmitFunctionBuilder[_], args: Type*): EmitMethodBuilder = {
-    argTypes.foreach(_.clear())
-    (argTypes, args).zipped.foreach(_.unify(_))
+    unify(args)
     val ts = argTypes.map(t => typeToTypeInfo(t.subst()))
     val methodbuilder = fb.newMethod((typeInfo[Region] +: ts).toArray, typeToTypeInfo(returnType))
     methodbuilder.emit(apply(methodbuilder, ts.zipWithIndex.map { case (a, i) => methodbuilder.getArg(i + 2)(a).load() }: _*))

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -212,9 +212,10 @@ sealed abstract class IRFunction {
   def isDeterministic: Boolean
 
   def unify(concrete: Seq[Type]): Boolean = {
-    require(argTypes.length == concrete.length)
-    argTypes.foreach(_.clear())
-    argTypes.zip(concrete).forall { case (i, j) => i.unify(j) }
+    argTypes.length == concrete.length && {
+      argTypes.foreach(_.clear())
+      argTypes.zip(concrete).forall { case (i, j) => i.unify(j) }
+    }
   }
 }
 

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir.functions
 
+import is.hail.annotations.{CodeOrdering, Region}
 import is.hail.asm4s._
 import is.hail.expr.ir._
 import is.hail.expr.types._
@@ -128,6 +129,27 @@ object UtilFunctions extends RegistryFunctions {
 
     registerIR("annotate", tv("T", _.isInstanceOf[TStruct]), tv("U", _.isInstanceOf[TStruct])) { (s, annotations) =>
       InsertFields(s, annotations.asInstanceOf[MakeStruct].fields)
+    }
+
+    val compareOps = Array(
+      ("==", CodeOrdering.equiv),
+      ("<", CodeOrdering.lt),
+      ("<=", CodeOrdering.lteq),
+      (">", CodeOrdering.gt),
+      (">=", CodeOrdering.gteq))
+    for ((sym, op) <- compareOps) {
+      registerCodeWithMissingness(sym, tv("T"), tv("T"), TBoolean()) { case (mb, a, b) =>
+        val t = tv("T").t
+        val cop = mb.getCodeOrdering[Boolean](t, op, missingGreatest = true)
+        val am = mb.newLocal[Boolean]
+        val bm = mb.newLocal[Boolean]
+        val av = mb.newLocal(typeToTypeInfo(t))
+        val bv = mb.newLocal(typeToTypeInfo(t))
+        val v = Code(
+          am := a.m, bm := b.m, av := a.v, bv := b.v,
+          cop(mb.getArg[Region](1), (am, av), mb.getArg[Region](1), (bm, bv)))
+        EmitTriplet(Code(a.setup, b.setup), const(false), v)
+      }
     }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -146,7 +146,7 @@ object UtilFunctions extends RegistryFunctions {
         val av = mb.newLocal(typeToTypeInfo(t))
         val bv = mb.newLocal(typeToTypeInfo(t))
         val v = Code(
-          am := a.m, bm := b.m, av := a.v, bv := b.v,
+          am := a.m, bm := b.m, av.storeAny(a.v), bv.storeAny(b.v),
           cop(mb.getArg[Region](1), (am, av), mb.getArg[Region](1), (bm, bv)))
         EmitTriplet(Code(a.setup, b.setup), const(false), v)
       }

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -151,5 +151,7 @@ object UtilFunctions extends RegistryFunctions {
         EmitTriplet(Code(a.setup, b.setup), const(false), v)
       }
     }
+
+    registerIR("!=", tv("T"), tv("T")) { case (a, b) => ApplyUnaryPrimOp(Bang(), ApplySpecial("==", FastSeq(a, b))) }
   }
 }

--- a/src/main/scala/is/hail/expr/types/TAggregable.scala
+++ b/src/main/scala/is/hail/expr/types/TAggregable.scala
@@ -2,6 +2,7 @@ package is.hail.expr.types
 
 import is.hail.annotations._
 import is.hail.expr._
+import is.hail.expr.ir.EmitMethodBuilder
 
 import scala.reflect.ClassTag
 
@@ -51,4 +52,6 @@ final case class TAggregable(elementType: Type, override val required: Boolean =
   override def scalaClassTag: ClassTag[_ <: AnyRef] = elementType.scalaClassTag
 
   val ordering: ExtendedOrdering = null
+
+  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = null
 }

--- a/src/main/scala/is/hail/expr/types/TAggregableVariable.scala
+++ b/src/main/scala/is/hail/expr/types/TAggregableVariable.scala
@@ -2,6 +2,7 @@ package is.hail.expr.types
 
 import is.hail.annotations._
 import is.hail.expr._
+import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.utils._
 
 import scala.reflect.ClassTag
@@ -42,4 +43,6 @@ final case class TAggregableVariable(elementType: Type, st: Box[SymbolTable]) ex
   override def scalaClassTag: ClassTag[AnyRef] = throw new RuntimeException("TAggregableVariable is not realizable")
 
   val ordering: ExtendedOrdering = null
+
+  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = null
 }

--- a/src/main/scala/is/hail/expr/types/TArray.scala
+++ b/src/main/scala/is/hail/expr/types/TArray.scala
@@ -2,6 +2,7 @@ package is.hail.expr.types
 
 import is.hail.annotations.{UnsafeUtils, _}
 import is.hail.check.Gen
+import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.utils._
 import org.json4s.jackson.JsonMethods
 
@@ -56,6 +57,9 @@ final case class TArray(elementType: Type, override val required: Boolean = fals
 
   val ordering: ExtendedOrdering =
     ExtendedOrdering.iterableOrdering(elementType.ordering)
+
+  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering =
+    CodeOrdering.iterableOrdering(this, mb)
 
   override def desc: String =
     """

--- a/src/main/scala/is/hail/expr/types/TBaseStruct.scala
+++ b/src/main/scala/is/hail/expr/types/TBaseStruct.scala
@@ -3,6 +3,7 @@ package is.hail.expr.types
 import is.hail.annotations._
 import is.hail.asm4s.{Code, _}
 import is.hail.check.Gen
+import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.utils._
 import org.apache.spark.sql.Row
 import org.json4s.jackson.JsonMethods

--- a/src/main/scala/is/hail/expr/types/TBinary.scala
+++ b/src/main/scala/is/hail/expr/types/TBinary.scala
@@ -1,9 +1,11 @@
 package is.hail.expr.types
 
+import is.hail.annotations.CodeOrdering
 import is.hail.annotations.{Region, UnsafeOrdering, _}
 import is.hail.asm4s._
 import is.hail.check.Arbitrary._
 import is.hail.check.Gen
+import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.utils._
 
 import scala.reflect.{ClassTag, _}
@@ -46,6 +48,30 @@ class TBinary(override val required: Boolean) extends Type {
 
   val ordering: ExtendedOrdering =
     ExtendedOrdering.extendToNull(Ordering.Iterable[Byte])
+
+  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = new CodeOrdering {
+    type T = Long
+    def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] = {
+      val l1 = mb.newLocal[Int]
+      val l2 = mb.newLocal[Int]
+      val lim = mb.newLocal[Int]
+      val i = mb.newLocal[Int]
+      val cmp = mb.newLocal[Int]
+
+      Code(
+        l1 := TBinary.loadLength(rx, x),
+        l2 := TBinary.loadLength(ry, y),
+        lim := (l1 < l2).mux(l1, l2),
+        i := 0,
+        cmp := 0,
+        Code.whileLoop(cmp.ceq(0) && i < lim,
+          cmp := Code.invokeStatic[java.lang.Byte, Byte, Byte, Int]("compare",
+            rx.loadByte(TBinary.bytesOffset(x) + i.toL),
+            ry.loadByte(TBinary.bytesOffset(y) + i.toL)),
+          i += 1),
+        cmp.ceq(0).mux(Code.invokeStatic[java.lang.Integer, Int, Int, Int]("compare", l1, l2), cmp))
+    }
+  }
 
   override def byteSize: Long = 8
 }

--- a/src/main/scala/is/hail/expr/types/TBoolean.scala
+++ b/src/main/scala/is/hail/expr/types/TBoolean.scala
@@ -1,8 +1,10 @@
 package is.hail.expr.types
 
 import is.hail.annotations.{Region, UnsafeOrdering, _}
+import is.hail.asm4s.Code
 import is.hail.check.Arbitrary._
 import is.hail.check.Gen
+import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.utils._
 
 import scala.reflect.{ClassTag, _}
@@ -33,6 +35,12 @@ class TBoolean(override val required: Boolean) extends Type {
 
   val ordering: ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Boolean]])
+
+  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = new CodeOrdering {
+    type T = Boolean
+    def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] =
+      Code.invokeStatic[java.lang.Boolean, Boolean, Boolean, Int]("compare", x, y)
+  }
 
   override def byteSize: Long = 1
 }

--- a/src/main/scala/is/hail/expr/types/TCall.scala
+++ b/src/main/scala/is/hail/expr/types/TCall.scala
@@ -2,6 +2,7 @@ package is.hail.expr.types
 
 import is.hail.annotations._
 import is.hail.check.Gen
+import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.utils._
 import is.hail.variant.Call
 
@@ -30,6 +31,8 @@ class TCall(override val required: Boolean) extends ComplexType {
 
   val ordering: ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Int]])
+
+  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = TInt32().codeOrdering(mb)
 }
 
 object TCall {

--- a/src/main/scala/is/hail/expr/types/TDict.scala
+++ b/src/main/scala/is/hail/expr/types/TDict.scala
@@ -2,6 +2,7 @@ package is.hail.expr.types
 
 import is.hail.annotations.{UnsafeUtils, _}
 import is.hail.check.Gen
+import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.utils._
 import org.apache.spark.sql.Row
 import org.json4s.jackson.JsonMethods
@@ -78,4 +79,7 @@ final case class TDict(keyType: Type, valueType: Type, override val required: Bo
 
   val ordering: ExtendedOrdering =
     ExtendedOrdering.mapOrdering(elementType.ordering)
+
+  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering =
+    CodeOrdering.mapOrdering(this, mb)
 }

--- a/src/main/scala/is/hail/expr/types/TFloat64.scala
+++ b/src/main/scala/is/hail/expr/types/TFloat64.scala
@@ -1,9 +1,11 @@
 package is.hail.expr.types
 
-import is.hail.annotations.{Region, UnsafeOrdering, _}
+import is.hail.annotations._
+import is.hail.asm4s.Code
 import is.hail.check.Arbitrary._
 import is.hail.check.Gen
 import is.hail.expr.DoubleNumericConversion
+import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.utils._
 
 import scala.reflect.{ClassTag, _}
@@ -49,6 +51,27 @@ class TFloat64(override val required: Boolean) extends TNumeric {
 
   val ordering: ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Double]])
+
+  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = new CodeOrdering {
+    type T = Double
+    def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] =
+      Code.invokeStatic[java.lang.Double, Double, Double, Int]("compare", x, y)
+
+    override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      x < y
+
+    override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      x <= y
+
+    override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      x > y
+
+    override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      x >= y
+
+    override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      x.ceq(y)
+  }
 
   override def byteSize: Long = 8
 }

--- a/src/main/scala/is/hail/expr/types/TFunction.scala
+++ b/src/main/scala/is/hail/expr/types/TFunction.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.types
 
 import is.hail.annotations._
+import is.hail.expr.ir.EmitMethodBuilder
 
 import scala.reflect.ClassTag
 
@@ -34,4 +35,6 @@ final case class TFunction(paramTypes: Seq[Type], returnType: Type) extends Type
   override def scalaClassTag: ClassTag[AnyRef] = throw new RuntimeException("TFunction is not realizable")
 
   val ordering: ExtendedOrdering = null
+
+  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = null
 }

--- a/src/main/scala/is/hail/expr/types/TInt64.scala
+++ b/src/main/scala/is/hail/expr/types/TInt64.scala
@@ -1,9 +1,11 @@
 package is.hail.expr.types
 
 import is.hail.annotations.{Region, UnsafeOrdering, _}
+import is.hail.asm4s.Code
 import is.hail.check.Arbitrary._
 import is.hail.check.Gen
 import is.hail.expr.LongNumericConversion
+import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.utils._
 
 import scala.reflect.{ClassTag, _}
@@ -33,6 +35,27 @@ class TInt64(override val required: Boolean) extends TIntegral {
 
   val ordering: ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Long]])
+
+  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = new CodeOrdering {
+    type T = Long
+    def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] =
+        Code.invokeStatic[java.lang.Long, Long, Long, Int]("compare", x, y)
+
+    override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+        x < y
+
+    override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+        x <= y
+
+    override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+        x > y
+
+    override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+        x >= y
+
+    override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+        x.ceq(y)
+    }
 
   override def byteSize: Long = 8
 }

--- a/src/main/scala/is/hail/expr/types/TInterval.scala
+++ b/src/main/scala/is/hail/expr/types/TInterval.scala
@@ -1,8 +1,10 @@
 package is.hail.expr.types
 
+import is.hail.annotations.CodeOrdering
 import is.hail.annotations._
 import is.hail.asm4s.Code
 import is.hail.check.Gen
+import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.utils._
 
 import scala.reflect.{ClassTag, classTag}
@@ -36,6 +38,9 @@ case class TInterval(pointType: Type, override val required: Boolean = false) ex
   override def scalaClassTag: ClassTag[Interval] = classTag[Interval]
 
   val ordering: ExtendedOrdering = Interval.ordering(pointType.ordering, startPrimary=true)
+
+  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering =
+    CodeOrdering.intervalOrdering(this, mb)
 
   override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering =
     new UnsafeOrdering {
@@ -80,6 +85,10 @@ case class TInterval(pointType: Type, override val required: Boolean = false) ex
   }
 
   override def subst() = TInterval(pointType.subst())
+
+  def startOffset(off: Code[Long]): Code[Long] = representation.fieldOffset(off, 0)
+
+  def endOffset(off: Code[Long]): Code[Long] = representation.fieldOffset(off, 1)
 
   def loadStart(region: Region, off: Long): Long = representation.loadField(region, off, 0)
 

--- a/src/main/scala/is/hail/expr/types/TSet.scala
+++ b/src/main/scala/is/hail/expr/types/TSet.scala
@@ -2,6 +2,7 @@ package is.hail.expr.types
 
 import is.hail.annotations.{UnsafeUtils, _}
 import is.hail.check.Gen
+import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.utils._
 import org.json4s.jackson.JsonMethods
 
@@ -45,6 +46,9 @@ final case class TSet(elementType: Type, override val required: Boolean = false)
 
   val ordering: ExtendedOrdering =
     ExtendedOrdering.setOrdering(elementType.ordering)
+
+  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering =
+    CodeOrdering.setOrdering(this, mb)
 
   override def str(a: Annotation): String = JsonMethods.compact(toJSON(a))
 

--- a/src/main/scala/is/hail/expr/types/TString.scala
+++ b/src/main/scala/is/hail/expr/types/TString.scala
@@ -1,8 +1,10 @@
 package is.hail.expr.types
 
+import is.hail.annotations.CodeOrdering
 import is.hail.annotations.{UnsafeOrdering, _}
 import is.hail.check.Arbitrary._
 import is.hail.check.Gen
+import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.utils._
 
 import scala.reflect.{ClassTag, _}
@@ -31,6 +33,7 @@ class TString(override val required: Boolean) extends Type {
 
   override def fundamentalType: Type = TBinary(required)
 
+  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = TBinary(required).codeOrdering(mb)
 }
 
 object TString {

--- a/src/main/scala/is/hail/expr/types/TStruct.scala
+++ b/src/main/scala/is/hail/expr/types/TStruct.scala
@@ -2,6 +2,7 @@ package is.hail.expr.types
 
 import is.hail.annotations.{Annotation, AnnotationPathException, _}
 import is.hail.asm4s.{Code, _}
+import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.expr.{EvalContext, HailRep, Parser}
 import is.hail.utils._
 import org.apache.spark.sql.Row
@@ -71,6 +72,8 @@ final case class TStruct(fields: IndexedSeq[Field], override val required: Boole
   override val alignment: Long = TBaseStruct.alignment(types)
 
   val ordering: ExtendedOrdering = TBaseStruct.getOrdering(types)
+
+  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = CodeOrdering.rowOrdering(this, mb)
 
   def fieldByName(name: String): Field = fields(fieldIdx(name))
 

--- a/src/main/scala/is/hail/expr/types/TTuple.scala
+++ b/src/main/scala/is/hail/expr/types/TTuple.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.types
 
-import is.hail.annotations.ExtendedOrdering
+import is.hail.annotations.{CodeOrdering, ExtendedOrdering}
+import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.utils._
 
 import scala.collection.JavaConverters._
@@ -28,6 +29,8 @@ final case class TTuple(_types: IndexedSeq[Type], override val required: Boolean
   val fields: IndexedSeq[Field] = types.zipWithIndex.map { case (t, i) => Field(s"$i", t, i) }
 
   val ordering: ExtendedOrdering = TBaseStruct.getOrdering(types)
+
+  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = CodeOrdering.rowOrdering(this, mb)
 
   val size: Int = types.length
 

--- a/src/main/scala/is/hail/expr/types/TVariable.scala
+++ b/src/main/scala/is/hail/expr/types/TVariable.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.types
 
 import is.hail.annotations._
+import is.hail.expr.ir.EmitMethodBuilder
 
 import scala.reflect.ClassTag
 
@@ -34,4 +35,6 @@ final case class TVariable(name: String, cond: (Type) => Boolean = { _ => true }
   override def scalaClassTag: ClassTag[AnyRef] = throw new RuntimeException("TVariable is not realizable")
 
   val ordering: ExtendedOrdering = null
+
+  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = null
 }

--- a/src/main/scala/is/hail/expr/types/TVoid.scala
+++ b/src/main/scala/is/hail/expr/types/TVoid.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.types
 
-import is.hail.annotations.ExtendedOrdering
+import is.hail.annotations.{CodeOrdering, ExtendedOrdering}
+import is.hail.expr.ir.EmitMethodBuilder
 
 case object TVoid extends Type {
   override val required = true
@@ -14,4 +15,6 @@ case object TVoid extends Type {
   override def _typeCheck(a: Any): Boolean = throw new UnsupportedOperationException("No elements of Void")
 
   override def isRealizable = false
+
+  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = null
 }

--- a/src/main/scala/is/hail/expr/types/Type.scala
+++ b/src/main/scala/is/hail/expr/types/Type.scala
@@ -2,6 +2,7 @@ package is.hail.expr.types
 
 import is.hail.annotations._
 import is.hail.check.{Arbitrary, Gen}
+import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.expr.{JSONAnnotationImpex, Parser, SparkAnnotationImpex}
 import is.hail.utils
 import is.hail.utils._
@@ -250,6 +251,8 @@ abstract class Type extends BaseType with Serializable {
   def canCompare(other: Type): Boolean = this == other
 
   val ordering: ExtendedOrdering
+
+  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering
 
   def jsonReader: JSONReader[Annotation] = new JSONReader[Annotation] {
     def fromJSON(a: JValue): Annotation = JSONAnnotationImpex.importAnnotation(a, self)

--- a/src/main/scala/is/hail/utils/richUtils/RichCodeRegion.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichCodeRegion.scala
@@ -87,6 +87,15 @@ class RichCodeRegion(val region: Code[Region]) extends AnyVal {
     case _: TBaseStruct => off => off
   }
 
+  def getIRIntermediate(typ: Type): Code[Long] => Code[_] = typ.fundamentalType match {
+    case _: TBoolean => loadBoolean
+    case _: TInt32 => loadInt
+    case _: TInt64 => loadLong
+    case _: TFloat32 => loadFloat
+    case _: TFloat64 => loadDouble
+    case _ => off => off
+  }
+
   def setBit(byteOff: Code[Long], bitOff: Code[Long]): Code[Unit] = {
     region.invoke[Long, Long, Unit]("setBit", byteOff, bitOff)
   }

--- a/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -1,17 +1,46 @@
 package is.hail.expr.ir
 
-import is.hail.annotations.{CodeOrdering, Region, RegionValueBuilder}
+import is.hail.annotations.{Region, RegionValueBuilder, SafeIndexedSeq}
 import is.hail.check.{Gen, Prop}
 import is.hail.asm4s._
 import is.hail.expr.ir._
 import is.hail.expr.types._
-import is.hail.utils.Interval
+import is.hail.utils._
 import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
 class OrderingSuite {
 
-  @Test def testRandomAgainstUnsafe() {
+  def recursiveSize(t: Type): Int = {
+    val inner = t match {
+      case ti: TInterval => recursiveSize(ti.pointType)
+      case tc: TContainer => recursiveSize(tc.elementType)
+      case tbs: TBaseStruct =>
+        tbs.types.map{ t => recursiveSize(t) }.sum
+      case _ => 0
+    }
+    inner + 1
+  }
+
+  def getStagedOrderingFunction[T: TypeInfo](t: Type, comp: String): AsmFunction3[Region, Long, Long, T] = {
+    val fb = EmitFunctionBuilder[Region, Long, Long, T]
+    val stagedOrdering = t.codeOrdering(fb.apply_method)
+    val cregion: Code[Region] = fb.getArg[Region](1)
+    val cv1 = coerce[stagedOrdering.T](cregion.getIRIntermediate(t)(fb.getArg[Long](2)))
+    val cv2 = coerce[stagedOrdering.T](cregion.getIRIntermediate(t)(fb.getArg[Long](3)))
+    comp match {
+      case "compare" => fb.emit(stagedOrdering.compare(cregion, (const(false), cv1), cregion, (const(false), cv2)))
+      case "equiv" => fb.emit(stagedOrdering.equiv(cregion, (const(false), cv1), cregion, (const(false), cv2)))
+      case "lt" => fb.emit(stagedOrdering.lt(cregion, (const(false), cv1), cregion, (const(false), cv2)))
+      case "lteq" => fb.emit(stagedOrdering.lteq(cregion, (const(false), cv1), cregion, (const(false), cv2)))
+      case "gt" => fb.emit(stagedOrdering.gt(cregion, (const(false), cv1), cregion, (const(false), cv2)))
+      case "gteq" => fb.emit(stagedOrdering.gteq(cregion, (const(false), cv1), cregion, (const(false), cv2)))
+    }
+
+    fb.result()()
+  }
+
+  @Test def testRandomOpsAgainstExtended() {
     val compareGen = Type.genArb.flatMap(t => Gen.zip(Gen.const(t), t.genNonmissingValue, t.genNonmissingValue))
     val p = Prop.forAll(compareGen) { case (t, a1, a2) =>
       val region = Region()
@@ -25,13 +54,39 @@ class OrderingSuite {
       rvb.addAnnotation(t, a2)
       val v2 = rvb.end()
 
-      val compare = t.unsafeOrdering(true).compare(region, v1, region, v2)
-      val fb = new EmitFunctionBuilder[AsmFunction3[Region, Long, Long, Int]](Array(GenericTypeInfo[Region](), GenericTypeInfo[Long](), GenericTypeInfo[Long]()), GenericTypeInfo[Int]())
-      val stagedOrdering = new CodeOrdering(t, true)
+      val compare = java.lang.Integer.signum(t.ordering.compare(a1, a2))
+      val fcompare = getStagedOrderingFunction[Int](t, "compare")
+      val result = java.lang.Integer.signum(fcompare(region, v1, v2))
 
-      fb.emit(stagedOrdering.compare(fb.apply_method, fb.getArg[Region](1), fb.getArg[Long](2), fb.getArg[Region](1), fb.getArg[Long](3)))
-      val f = fb.result()()
-      f(region, v1, v2) == compare
+      assert(result == compare, s"compare expected: $compare vs $result")
+
+
+      val equiv = t.ordering.equiv(a1, a2)
+      val fequiv = getStagedOrderingFunction[Boolean](t, "equiv")
+
+      assert(fequiv(region, v1, v2) == equiv, s"equiv expected: $equiv")
+
+      val lt = t.ordering.lt(a1, a2)
+      val flt = getStagedOrderingFunction[Boolean](t, "lt")
+
+      assert(flt(region, v1, v2) == lt, s"lt expected: $lt")
+
+      val lteq = t.ordering.lteq(a1, a2)
+      val flteq = getStagedOrderingFunction[Boolean](t, "lteq")
+
+      assert(flteq(region, v1, v2) == lteq, s"lteq expected: $lteq")
+
+      val gt = t.ordering.gt(a1, a2)
+      val fgt = getStagedOrderingFunction[Boolean](t, "gt")
+
+      assert(fgt(region, v1, v2) == gt, s"gt expected: $gt")
+
+      val gteq = t.ordering.gteq(a1, a2)
+      val fgteq = getStagedOrderingFunction[Boolean](t, "gteq")
+
+      assert(fgteq(region, v1, v2) == gteq, s"gteq expected: $gteq")
+
+      true
     }
     p.check()
   }

--- a/src/test/scala/is/hail/methods/FilterSuite.scala
+++ b/src/test/scala/is/hail/methods/FilterSuite.scala
@@ -18,10 +18,9 @@ class FilterSuite extends SparkSuite {
 
     assert(vds.filterRowsExpr("""va.filters.contains("VQSRTrancheSNP99.60to99.80")""").countRows() == 3)
 
-    // FIXME: rsid of "." should be treated as missing value
-    assert(vds.filterRowsExpr("""va.rsid != "."""").countRows() == 258)
+    assert(vds.filterRowsExpr("""isDefined(va.rsid)""").countRows() == 258)
 
-    assert(vds.filterRowsExpr("""va.rsid == "."""", keep = false).countRows() == 258)
+    assert(vds.filterRowsExpr("""isMissing(va.rsid)""", keep = false).countRows() == 258)
 
     val sQcVds = SampleQC(vds)
 


### PR DESCRIPTION
@cseed @danking it's a lot of lines of code, but I couldn't really figure out how to cut down on the boilerplate. Suggestions welcome.