### PR TITLE
Improve simplify

### DIFF
--- a/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -1,0 +1,17 @@
+package is.hail.expr.ir
+
+object Binds {
+  def apply(x: IR): Set[String] = {
+    x match {
+      case Let(n, _, _) => Set(n)
+      case ArrayMap(_, n, _) => Set(n)
+      case ArrayFlatMap(_, n, _) => Set(n)
+      case ArrayFilter(_, n, _) => Set(n)
+      case ArrayFold(_, _, accumName, valueName, _) => Set(accumName, valueName)
+      case AggMap(_, n, _) => Set(n)
+      case AggFlatMap(_, n, _) => Set(n)
+      case AggFilter(_, n, _) => Set(n)
+      case _ => Set.empty[String]
+    }
+  }
+}

--- a/src/main/scala/is/hail/expr/ir/FoldConstants.scala
+++ b/src/main/scala/is/hail/expr/ir/FoldConstants.scala
@@ -15,9 +15,6 @@ object FoldConstants {
           throw new MatchError(ir)
 
         ir match {
-          case If(NA(_), _, _) =>
-            NA(ir.typ)
-
           case ApplyUnaryPrimOp(_, _) |
                ApplyBinaryPrimOp(_, _, _) |
                Apply(_, _) |

--- a/src/main/scala/is/hail/expr/ir/Mentions.scala
+++ b/src/main/scala/is/hail/expr/ir/Mentions.scala
@@ -1,0 +1,17 @@
+package is.hail.expr.ir
+
+object Mentions {
+  def apply(x: IR, v: String): Boolean = {
+    x match {
+      case Ref(n, _) => v == n
+      case _ =>
+        if (Binds(x).contains(v))
+          false
+        else
+          Children(x).exists {
+            case c: IR => Mentions(c, v)
+            case _ => false
+          }
+    }
+  }
+}

--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -59,6 +59,10 @@ object Pretty {
             case ArrayFilter(_, name, _) => name
             case ArrayFlatMap(_, name, _) => name
             case ArrayFold(_, _, accumName, valueName, _) => s"$accumName $valueName"
+            case AggMap(_, name, _) => name
+            case AggFilter(_, name, _) => name
+            case AggFlatMap(_, name, _) => name
+            case ApplyAggOp(_, op, _) => op.getClass.getName.split("\\.").last
             case Apply(function, _) => function
             case ApplySpecial(function, _) => function
             case In(i, _) => i.toString
@@ -117,9 +121,9 @@ object Pretty {
             sb += '\n'
             children.foreachBetween(c => pretty(c, depth + 2))(sb += '\n')
           }
-
-          sb += ')'
       }
+
+      sb += ')'
     }
 
     pretty(ir, 0)

--- a/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -26,6 +26,14 @@ object Simplify {
       case ArrayFilter(a, _, True()) => a
 
       case AggFilter(a, _, True()) => a
+        
+      case Let(n, v, b) if !Mentions(b, n) => b
+
+      case AggFilter(AggMap(a, n1, b), n2, p) if !Mentions(p, n2) =>
+        AggMap(AggFilter(a, n2, p), n1, b)
+
+      case AggMap(AggMap(a, n1, b1), n2, b2) =>
+        AggMap(a, n1, Let(n2, b1, b2))
 
       case GetField(MakeStruct(fields), name) =>
         val (_, x) = fields.find { case (n, _) => n == name }.get

--- a/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -34,8 +34,7 @@ object Simplify {
       // optimize IR
 
       // propagate NA
-      case x: IR
-        if isStrict(x) && Children(x).exists(_.isInstanceOf[NA]) =>
+      case x: IR if isStrict(x) && Children(x).exists(_.isInstanceOf[NA]) =>
         NA(x.typ)
 
       case x@If(NA(_), _, _) => NA(x.typ)
@@ -54,7 +53,6 @@ object Simplify {
 
       case Let(n1, v, Ref(n2, _)) if n1 == n2 => v
 
-      // If(NA, ...) handled by FoldConstants
       case If(True(), x, _) => x
       case If(False(), _, x) => x
 

--- a/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -4,9 +4,51 @@ import is.hail.utils._
 import is.hail.expr.{BaseIR, FilterColsIR, FilterRowsIR, MatrixRead, TableFilter, TableRead}
 
 object Simplify {
+  private[this] def isStrict(x: IR): Boolean = {
+    x match {
+      case _: Apply |
+        _: ApplyUnaryPrimOp |
+        _: ApplyBinaryPrimOp |
+        _: ArrayRange |
+        _: ArrayRef |
+        _: ArrayLen |
+        _: GetField |
+        _: GetTupleElement => true
+      case _ => false
+    }
+  }
+
+  def isDefinitelyDefined(x: IR): Boolean = {
+    case _: MakeArray |
+      _: MakeStruct |
+      _: MakeTuple |
+      _: IsNA |
+      _: I32 | _: I64 | _: F32 | _: F64 | True() | False() => true
+    case _ => false
+  }
+
   def apply(ir: BaseIR): BaseIR = {
     RewriteBottomUp(ir, matchErrorToNone {
-      // optimze IR
+      // optimize IR
+
+      // propagate NA
+      case x: IR
+        if isStrict(x) && Children(x).exists(_.isInstanceOf[NA]) =>
+        NA(x.typ)
+
+      case x@If(NA(_), _, _) => NA(x.typ)
+
+      case x@ArrayMap(NA(_), _, _) => NA(x.typ)
+
+      case x@ArrayFlatMap(NA(_), _, _) => NA(x.typ)
+
+      case x@ArrayFilter(NA(_), _, _) => NA(x.typ)
+
+      case x@ArrayFold(NA(_), _, _, _, _) => NA(x.typ)
+
+      case IsNA(NA(_)) => True()
+
+      case IsNA(x) if isDefinitelyDefined(x) => False()
 
       case Let(n1, v, Ref(n2, _)) if n1 == n2 => v
 
@@ -34,6 +76,9 @@ object Simplify {
 
       case AggMap(AggMap(a, n1, b1), n2, b2) =>
         AggMap(a, n1, Let(n2, b1, b2))
+
+      case ArrayMap(ArrayMap(a, n1, b1), n2, b2) =>
+        ArrayMap(a, n1, Let(n2, b1, b2))
 
       case GetField(MakeStruct(fields), name) =>
         val (_, x) = fields.find { case (n, _) => n == name }.get

--- a/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -18,13 +18,15 @@ object Simplify {
     }
   }
 
-  def isDefinitelyDefined(x: IR): Boolean = {
-    case _: MakeArray |
-      _: MakeStruct |
-      _: MakeTuple |
-      _: IsNA |
-      _: I32 | _: I64 | _: F32 | _: F64 | True() | False() => true
-    case _ => false
+  private[this] def isDefinitelyDefined(x: IR): Boolean = {
+    x match {
+      case _: MakeArray |
+           _: MakeStruct |
+           _: MakeTuple |
+           _: IsNA |
+           _: I32 | _: I64 | _: F32 | _: F64 | True() | False() => true
+      case _ => false
+    }
   }
 
   def apply(ir: BaseIR): BaseIR = {


### PR DESCRIPTION
remove unused let
push aggfilter into aggmap (if possible)
fuse aggmaps
Added ir.Binds (list of variables bound by an IR)
Added ir.Mentions (whether a variable is free in an IR)
propagate NA where strict
fuse ArrayMaps

Also improved ir.Pretty (more headers, was missing some closing parens).

This cleans up most of the small IR opportunities I've seen in @konradjk's scripts, although probably won't make a huge difference (except maybe pushing AggFilter into AggMap).