### PR TITLE
Simplify GeneralRDD

### DIFF
--- a/src/main/scala/is/hail/sparkextras/GeneralRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/GeneralRDD.scala
@@ -5,25 +5,28 @@ import org.apache.spark.rdd.RDD
 
 import scala.reflect.ClassTag
 
-case class GeneralRDDPartition[T](index: Int, partitionInputs: Array[(Int, Partition)], f: (Array[Iterator[T]]) => Iterator[T]) extends Partition
+case class GeneralRDDPartition[T](index: Int, partitionInputs: Array[(Int, Partition)]) extends Partition
 
 class GeneralRDD[T](@transient var sc: SparkContext,
   var rdds: Array[RDD[T]],
-  var inputs: Array[(Array[(Int, Int)], (Array[Iterator[T]] => Iterator[T]))])(implicit tct: ClassTag[T]) extends RDD[T](sc, Nil) {
+  var inputs: Array[Array[(Int, Int)]])(implicit tct: ClassTag[T]) extends RDD[Array[Iterator[T]]](sc, Nil) {
 
   override def getPartitions: Array[Partition] = {
     // Do not call getPartitions here!
     val parentPartitions = rdds.zipWithIndex.map { case (rdd, i) => (i, rdd.partitions) }.toMap
     inputs.zipWithIndex.map { case (input, i) =>
-      val partitionInputs = input._1.map { case (rddIndex, partitionIndex) => (rddIndex, parentPartitions(rddIndex)(partitionIndex)) }
-      new GeneralRDDPartition[T](i, partitionInputs, input._2)
+      val partitionInputs = input.map { case (rddIndex, partitionIndex) => (rddIndex, parentPartitions(rddIndex)(partitionIndex)) }
+      new GeneralRDDPartition[T](i, partitionInputs)
     }
   }
 
-  override def compute(split: Partition, context: TaskContext): Iterator[T] = {
+  override def compute(
+    split: Partition,
+    context: TaskContext
+  ): Iterator[Array[Iterator[T]]] = {
     // Do not call partitions or getPartitions here!
     val gp = split.asInstanceOf[GeneralRDDPartition[T]]
-    gp.f(gp.partitionInputs.map { case (rddIndex, partition) =>
+    Iterator.single(gp.partitionInputs.map { case (rddIndex, partition) =>
       val rdd = rdds(rddIndex)
       rdd.iterator(partition, context)
     })
@@ -32,7 +35,7 @@ class GeneralRDD[T](@transient var sc: SparkContext,
   override def getDependencies: Seq[Dependency[_]] = {
     inputs
       .zipWithIndex
-      .flatMap { case (input, i) => input._1.map { case (rddIndex, partitionIndex) => (rddIndex, partitionIndex, i) } }
+      .flatMap { case (input, i) => input.map { case (rddIndex, partitionIndex) => (rddIndex, partitionIndex, i) } }
       .groupBy(_._1)
       .map { case (rddIndex, x) =>
         new NarrowDependency[T](rdds(rddIndex)) {

--- a/src/main/scala/is/hail/sparkextras/GeneralRDD.scala
+++ b/src/main/scala/is/hail/sparkextras/GeneralRDD.scala
@@ -5,19 +5,25 @@ import org.apache.spark.rdd.RDD
 
 import scala.reflect.ClassTag
 
-case class GeneralRDDPartition[T](index: Int, partitionInputs: Array[(Int, Partition)]) extends Partition
+case class GeneralRDDPartition(
+  partitionInputs: Array[(Int, Partition)],
+  index: Int
+) extends Partition
 
-class GeneralRDD[T](@transient var sc: SparkContext,
-  var rdds: Array[RDD[T]],
-  var inputs: Array[Array[(Int, Int)]])(implicit tct: ClassTag[T]) extends RDD[Array[Iterator[T]]](sc, Nil) {
+class GeneralRDD[T: ClassTag](
+  sc: SparkContext,
+  rdds: Array[RDD[T]],
+  inputs: Array[Array[(Int, Int)]]
+) extends RDD[Array[Iterator[T]]](sc, Nil) {
 
   override def getPartitions: Array[Partition] = {
     // Do not call getPartitions here!
-    val parentPartitions = rdds.zipWithIndex.map { case (rdd, i) => (i, rdd.partitions) }.toMap
-    inputs.zipWithIndex.map { case (input, i) =>
-      val partitionInputs = input.map { case (rddIndex, partitionIndex) => (rddIndex, parentPartitions(rddIndex)(partitionIndex)) }
-      new GeneralRDDPartition[T](i, partitionInputs)
-    }
+    val parentPartitions = rdds.map(_.partitions)
+
+    inputs.map { _.map { case (rddIndex, partitionIndex) =>
+      (rddIndex, parentPartitions(rddIndex)(partitionIndex)) }
+    } .zipWithIndex
+      .map { case (x, i) => new GeneralRDDPartition(x, i) }
   }
 
   override def compute(
@@ -25,24 +31,22 @@ class GeneralRDD[T](@transient var sc: SparkContext,
     context: TaskContext
   ): Iterator[Array[Iterator[T]]] = {
     // Do not call partitions or getPartitions here!
-    val gp = split.asInstanceOf[GeneralRDDPartition[T]]
-    Iterator.single(gp.partitionInputs.map { case (rddIndex, partition) =>
-      val rdd = rdds(rddIndex)
-      rdd.iterator(partition, context)
-    })
+    val gp = split.asInstanceOf[GeneralRDDPartition]
+    Iterator.single(
+      gp.partitionInputs.map { case (rddIndex, partition) =>
+        rdds(rddIndex).iterator(partition, context) } )
   }
 
   override def getDependencies: Seq[Dependency[_]] = {
     inputs
       .zipWithIndex
-      .flatMap { case (input, i) => input.map { case (rddIndex, partitionIndex) => (rddIndex, partitionIndex, i) } }
+      .flatMap { case (input, i) =>
+        input.map { case (rddIndex, partitionIndex) => (rddIndex, partitionIndex, i) } }
       .groupBy(_._1)
       .map { case (rddIndex, x) =>
         new NarrowDependency[T](rdds(rddIndex)) {
           override def getParents(partitionId: Int): Seq[Int] =
-            x.filter {
-              partitionId == _._3
-            }.map(_._2)
+            x.filter(partitionId == _._3).map(_._2)
         }
       }.toSeq
   }


### PR DESCRIPTION
I made a couple formatting changes, so if you want functional changes only narrow the diff to the first commit.

The key change is that the `GeneralRDD` now contains a singleton iterator containing the array of parent iterators. Anywhere we previously had

```
new GeneralRDD(..., Array((..., f))
```
we transform it to
```
new GeneralRDD(..., Array((...)))
  .flatMap(f)
```
We didn't previously take advantage of having distinct functions for different partitions. If that functionality became necessary we could `mapPartitionsWithIndex` and lookup the relevant function in an array.

I want to use this change in the spicy meatball (cc: @cseed) so that I can convert to a `ContextRDD` before calling `flatMap`.
