### PR TITLE
fast-path import_bgen with no entry fields

### DIFF
--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -818,10 +818,6 @@ def import_bgen(path,
 
     rg = reference_genome._jrep if reference_genome else None
 
-    if not entry_fields:
-        raise FatalError("import_bgen: entry_fields must be non-empty."
-                         "\n    Options: 'GT', 'GP', 'dosage'.")
-
     entry_set = set(entry_fields)
     bad_entry_fields = list(entry_set - {'GT', 'GP', 'dosage'})
 

--- a/python/hail/tests/test_methods.py
+++ b/python/hail/tests/test_methods.py
@@ -1536,6 +1536,16 @@ class Tests(unittest.TestCase):
         self.assertEqual(bgen.entry.dtype, hl.tstruct(GT=hl.tcall, GP=hl.tarray(hl.tfloat64), dosage=hl.tfloat64))
         self.assertEqual(bgen.locus.dtype, hl.tlocus('GRCh37'))
 
+    def test_import_bgen_no_entry_fields(self):
+        hl.index_bgen(resource('example.v11.bgen'))
+
+        bgen = hl.import_bgen(resource('example.v11.bgen'),
+                              entry_fields=[],
+                              sample_file=resource('example.sample'),
+                              contig_recoding={'01': '1'},
+                              reference_genome='GRCh37')
+        bgen._jvds.typecheck()
+
     def test_import_bgen_no_reference_specified(self):
         bgen = hl.import_bgen(resource('example.10bits.bgen'),
                               entry_fields=['GT', 'GP', 'dosage'],

--- a/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -132,6 +132,8 @@ object LoadBgen {
       }
     }))
 
+    val loadEntries = entryFields.length > 0
+
     val rdd2 = sc.union(results.map(_.rdd.mapPartitions { it =>
       val region = Region()
       val rvb = new RegionValueBuilder(region)
@@ -158,7 +160,18 @@ object LoadBgen {
         rvb.endArray()
         rvb.addAnnotation(rowType.types(2), va.get(0))
         rvb.addAnnotation(rowType.types(3), va.get(1))
-        record.getValue(rvb) // gs
+        if (loadEntries)
+          record.getValue(rvb) // gs
+        else {
+          rvb.startArray(nSamples)
+          var j = 0
+          while (j < nSamples) {
+            rvb.startStruct()
+            rvb.endStruct()
+            j += 1
+          }
+          rvb.endArray()
+        }
         rvb.endStruct()
 
         rv.setOffset(rvb.end())


### PR DESCRIPTION
Expands the interface to permit importing with no entry fields (previously was error)