### PR TITLE
fix BitPackedVectorView

### DIFF
--- a/src/main/scala/is/hail/methods/LDPrune.scala
+++ b/src/main/scala/is/hail/methods/LDPrune.scala
@@ -29,7 +29,6 @@ class BitPackedVectorView(rvRowType: TStruct) {
   private val sdIndex = 5
 
   private var m: Region = _
-  private var vOffset: Long = _
   private var bpvOffset: Long = _
   private var bpvLength: Int = _
   private var bpvEltOffset: Long = _
@@ -46,7 +45,7 @@ class BitPackedVectorView(rvRowType: TStruct) {
     meanOffset = rvRowType.loadField(m, offset, meanIndex)
     sdOffset = rvRowType.loadField(m, offset, sdIndex)
 
-    vView.setRegion(m, vOffset)
+    vView.setRegion(m, offset)
   }
 
   def setRegion(rv: RegionValue): Unit = setRegion(rv.region, rv.offset)


### PR DESCRIPTION
Previously it always assumed the variant struct started at offset zero, which is not true.