### PR TITLE
Expose RowMatrix in Python

### DIFF
--- a/python/hail/__init__.py
+++ b/python/hail/__init__.py
@@ -28,6 +28,7 @@ from .genetics import *
 from . import genetics as genetics
 from .methods import *
 from . import methods as methods
+from . import linalg as linalg
 from hail.expr import aggregators as agg
 from hail.utils import Struct, Interval, hadoop_copy, hadoop_open
 
@@ -49,7 +50,8 @@ __all__ = ['init',
            'Interval',
            'agg',
            'genetics',
-           'methods']
+           'methods',
+           'linalg']
 
 
 __all__.extend(genetics.__all__)

--- a/python/hail/docs/linalg/index.rst
+++ b/python/hail/docs/linalg/index.rst
@@ -18,3 +18,4 @@ to maintain compatibility.
     :template: class.rst
 
     BlockMatrix
+    RowMatrix

--- a/python/hail/linalg/__init__.py
+++ b/python/hail/linalg/__init__.py
@@ -1,3 +1,5 @@
 from .blockmatrix import BlockMatrix
+from .rowmatrix import RowMatrix
 
-__all__ = ['BlockMatrix']
+__all__ = ['BlockMatrix',
+           'RowMatrix']

--- a/python/hail/linalg/blockmatrix.py
+++ b/python/hail/linalg/blockmatrix.py
@@ -380,8 +380,8 @@ class BlockMatrix(object):
         Examples
         --------
         >>> mt = hl.balding_nichols_model(3, 25, 50)
-        >>> bm = BlockMatrix.write_from_entry_expr(mt.GT.n_alt_alleles(),
-        ...                                        'output/model.bm')
+        >>> BlockMatrix.write_from_entry_expr(mt.GT.n_alt_alleles(),
+        ...                                   'output/model.bm')
 
         Notes
         -----
@@ -917,6 +917,8 @@ class BlockMatrix(object):
         at least a few partitions per core. Setting the partition size
         to an exact (rather than approximate) divisor or multiple of the
         block size reduces superfluous shuffling of data.
+
+        See also :meth:`.RowMatrix.read_from_block_matrix`.
 
         Parameters
         ----------

--- a/python/hail/linalg/blockmatrix.py
+++ b/python/hail/linalg/blockmatrix.py
@@ -1,8 +1,10 @@
+import hail as hl
 from hail.utils import new_temp_file, new_local_temp_file, local_path_uri, storage_level
 from hail.utils.java import Env, jarray, joption
 from hail.typecheck import *
 from hail.table import Table
 from hail.expr.expressions import expr_float64, matrix_table_source, check_entry_indexed
+from hail.linalg import RowMatrix
 import numpy as np
 from enum import IntEnum
 
@@ -230,10 +232,16 @@ class BlockMatrix(object):
     def from_entry_expr(cls, entry_expr, block_size=None):
         """Create a block matrix using a matrix table entry expression.
 
+        Examples
+        --------
+        >>> mt = hl.balding_nichols_model(3, 25, 50)
+        >>> bm = BlockMatrix.from_entry_expr(mt.GT.n_alt_alleles())
+
         Parameters
         ----------
         entry_expr: :class:`.Float64Expression`
             Entry expression for numeric matrix entries.
+            All values must be non-missing.
         block_size: :obj:`int`, optional
             Block size. Default given by :meth:`.BlockMatrix.default_block_size`.
 
@@ -370,14 +378,23 @@ class BlockMatrix(object):
     def write_from_entry_expr(entry_expr, path, block_size=None):
         """Writes a block matrix from a matrix table entry expression.
 
+        Examples
+        --------
+        >>> mt = hl.balding_nichols_model(3, 25, 50)
+        >>> bm = BlockMatrix.write_from_entry_expr(mt.GT.n_alt_alleles(),
+        ...                                        'output/model.bm')
+
         Notes
         -----
+        If any values are missing, an error message is returned.
+
         The resulting file can be loaded with :meth:`BlockMatrix.read`.
 
         Parameters
         ----------
         entry_expr: :class:`.Float64Expression`
             Entry expression for numeric matrix entries.
+            All values must be non-missing.
         path: :obj:`str`
             Path for output.
         block_size: :obj:`int`, optional
@@ -386,9 +403,9 @@ class BlockMatrix(object):
         if not block_size:
             block_size = BlockMatrix.default_block_size()
 
-        check_entry_indexed('write_from_entry_expr/entry_expr', entry_expr)
+        check_entry_indexed('BlockMatrix.write_from_entry_expr/entry_expr', entry_expr)
 
-        mt = matrix_table_source('write_from_entry_expr/entry_expr', entry_expr)
+        mt = matrix_table_source('BlockMatrix.write_from_entry_expr/entry_expr', entry_expr)
 
         #  FIXME: remove once select_entries on a field is free
         if entry_expr in mt._fields_inverse:
@@ -876,6 +893,47 @@ class BlockMatrix(object):
             Table with a row for each entry.
         """
         return Table(self._jbm.entriesTable(Env.hc()._jhc))
+
+    @classmethod
+    @typecheck_method(partition_size=int)
+    def to_row_matrix(self, partition_size):
+        """Creates a row matrix from a block matrix.
+
+        Examples
+        --------
+        >>> bm = BlockMatrix.random(3, 3)
+        >>> rm = bm.to_row_matrix(2)
+
+        Notes
+        -----
+        The number of partitions in the resulting row matrix equals
+        the ceiling of ``n_rows / partition_size``.
+
+        For example, consider a block matrix with :math:`10^6` rows,
+        :math:`10^5` columns, and block size :math:`2^{12}` (4096). 
+        A partition size of :math:`2^{10}` (1024) will result
+        in a row matrix with 977 partitions. with all but the last partition
+        containing 1024 full rows, e.g. 781 MB of 8-byte floats.
+
+        For good parallelism and load balancing, it's good practice to have
+        at least a few partitions per core. Setting the partition size
+        to an exact (rather than approximate) divisor or multiple of the
+        block size reduces superfluous shuffling of data.
+
+        Parameters
+        ----------
+        partition_size: :obj:`int`
+            Number of rows to group per partition.
+
+        Returns
+        -------
+        :class:`RowMatrix`
+        """
+
+        path = new_temp_file()
+        self.write(path, force_row_major=True)
+
+        return RowMatrix.read_from_block_matrix(path, partition_size)
 
 
 block_matrix_type.set(BlockMatrix)

--- a/python/hail/linalg/blockmatrix.py
+++ b/python/hail/linalg/blockmatrix.py
@@ -4,7 +4,6 @@ from hail.utils.java import Env, jarray, joption
 from hail.typecheck import *
 from hail.table import Table
 from hail.expr.expressions import expr_float64, matrix_table_source, check_entry_indexed
-from hail.linalg import RowMatrix
 import numpy as np
 from enum import IntEnum
 
@@ -894,7 +893,6 @@ class BlockMatrix(object):
         """
         return Table(self._jbm.entriesTable(Env.hc()._jhc))
 
-    @classmethod
     @typecheck_method(partition_size=int)
     def to_row_matrix(self, partition_size):
         """Creates a row matrix from a block matrix.
@@ -933,7 +931,7 @@ class BlockMatrix(object):
         path = new_temp_file()
         self.write(path, force_row_major=True)
 
-        return RowMatrix.read_from_block_matrix(path, partition_size)
+        return hl.linalg.RowMatrix.read_from_block_matrix(path, partition_size)
 
 
 block_matrix_type.set(BlockMatrix)

--- a/python/hail/linalg/rowmatrix.py
+++ b/python/hail/linalg/rowmatrix.py
@@ -1,0 +1,240 @@
+from hail.utils.java import Env, joption
+from hail.typecheck import *
+from hail.expr.expressions import expr_float64, matrix_table_source, check_entry_indexed
+import numpy as np
+
+row_matrix_type = lazy()
+
+
+class RowMatrix(object):
+    """Hail's row-distributed matrix of :py:data:`.tfloat64` elements.
+
+    .. include:: ../_templates/experimental.rst
+
+    Notes
+    -----
+    Row matrices must have fewer than ``2^31`` columns.
+
+    Under the hood, row matrices are partitioned into group of rows.
+    """
+
+    def __init__(self, jrm):
+        self._jrm = jrm
+
+    @property
+    def n_rows(self):
+        """Number of rows.
+
+        Returns
+        -------
+        :obj:`int`
+        """
+        return self._jrm.nRows()
+
+    @property
+    def n_cols(self):
+        """Number of columns.
+
+        Returns
+        -------
+        :obj:`int`
+        """
+        return self._jrm.nCols()
+
+    @property
+    def shape(self):
+        """Shape of matrix.
+
+        Returns
+        -------
+        (:obj:`int`, :obj:`int`)
+           Number of rows and number of columns.
+        """
+        return self.n_rows, self.n_cols
+
+    @classmethod
+    @typecheck_method(entry_expr=expr_float64)
+    def from_entry_expr(cls, entry_expr):
+        """Creates a row matrix using a matrix table entry expression.
+
+        Parameters
+        ----------
+        entry_expr: :class:`.Float64Expression`
+            Entry expression for numeric matrix entries.
+
+        Returns
+        -------
+        :class:`RowMatrix`
+        """
+
+        check_entry_indexed('write_from_entry_expr/entry_expr', entry_expr)
+
+        mt = matrix_table_source('write_from_entry_expr/entry_expr', entry_expr)
+
+        #  FIXME: remove once select_entries on a field is free
+        if entry_expr in mt._fields_inverse:
+            field = mt._fields_inverse[entry_expr]
+            jrm = mt._jvds.toRowMatrix(field)
+        else:
+            field = Env.get_uid()
+            jrm = mt.select_entries(**{field: entry_expr})._jvds.toRowMatrix(field)
+
+        return cls(jrm)
+
+    @classmethod
+    @typecheck_method(path=str, partition_size=int)
+    def read_block_matrix(cls, path, partition_size):
+        """Creates a row matrix from a stored block matrix.
+
+        Notes
+        -----
+        The number of partitions in the resulting row matrix will equal
+        the ceiling of ``n_rows / partition_size``.
+
+        Setting the partition size to an exact (rather than approximate)
+        divisor or multiple of the block size will reduce superfluous shuffling
+        of data.
+
+        Warning
+        -------
+        The block matrix must be stored in row-major format, as results from
+        :meth:`.BlockMatrix.write` with ``force_row_major=True`` and from
+        :meth:`.BlockMatrix.write_from_entry_expr`. Otherwise,
+        :meth:`read_block_matrix` will produce an error message.
+
+        Parameters
+        ----------
+        path: :obj:`str`
+            Path to block matrix.
+        partition_size: :obj:`int`
+            Number of rows to group per partition.
+        Returns
+        -------
+        :class:`RowMatrix`
+        """
+        jrm = Env.hail().linalg.RowMatrix.readBlockMatrix(Env.hc()._jhc, path, partition_size)
+
+        return cls(jrm)
+
+    @typecheck_method(path=str,
+                      column_delimiter=str,
+                      header=nullable(str),
+                      add_index=bool,
+                      parallel=nullable(enumeration('separate_header', 'header_per_shard')),
+                      entries=enumeration('full', 'lower', 'strict_lower', 'upper', 'strict_upper'))
+    def export(self, path, delimiter='\t', header=None, add_index=False, parallel=None, entries='full'):
+        """Exports row matrix as a delimited text file.
+
+        Examples
+        --------
+
+        >>> from hail.linalg import BlockMatrix
+        >>> nd = np.array([[1.0, 0.8, 0.7],
+        ...                [0.8, 1.0 ,0.3],
+        ...                [0.7, 0.3, 1.0]])
+        >>> BlockMatrix.from_numpy(nd).write('/output/bm')
+        >>> rm = RowMatrix.read_block_matrix('/output/bm')
+
+        Export the full matrix as a file with tab-separated values:
+
+        >>> rm.export('output/row_matrix.tsv')
+
+        Export the upper-triangle of the matrix as a file of
+        comma-separated values.
+
+        >>> rm.export('output/row_matrix.csv',
+        ...            delimiter=',',
+        ...            entries='upper')
+
+        Export the full matrix in parallel as a folder of files,
+        each with a header line for columns ``index``, ``A``, ``B``,
+        and ``C``. Every value line is tab-separated and prepended
+        by its absolute row index:
+
+        >>> rm.export('output/row_matrix',
+        ...            header='\t'.join(['index', 'A', 'B', 'C']),
+        ...            add_index=True,
+        ...            parallel='header_per_shard')
+
+        Notes
+        -----
+
+        Here is the full export with header and row index as one file:
+        .. code-block:: text
+            index,A,B,C
+            0   1.0 0.8 0.7
+            1   0.8 1.0 0.3
+            2   0.7 0.3 1.0
+
+        The five `entries` options are illustrated below.
+
+        Full:
+        .. code-block:: text
+            1.0 0.8 0.7
+            0.8 1.0 0.3
+            0.7 0.3 1.0
+
+        Lower triangle:
+        .. code-block:: text
+            1.0
+            0.8 1.0
+            0.7 0.3 1.0
+
+        Strict lower triangle:
+        .. code-block:: text
+            0.8
+            0.7 0.3
+
+        Upper triangle:
+        .. code-block:: text
+            1.0 0.8 0.7
+            1.0 0.3
+            1.0
+
+        Strict upper triangle:
+        .. code-block:: text
+            0.8 0.7
+            0.3
+
+        If `header` is ``None``, the `parallel` options ``'header_per_shard'`` and
+        ``'separate_header'`` are equivalent.
+
+        Parameters
+        ----------
+        path: :obj:`str`
+            Path for export.
+        delimiter: :obj:`str`
+            Column delimiter.
+        header: :obj:`str`, optional
+            If provided, header string is prepended before the first row of data.
+        add_index: :obj:`bool`
+            If true, add an initial column with the row index.
+        parallel: :obj:`str`, optional
+            If ``'header_per_shard'``, create a folder with one file per
+            partition, each with a header if provided.
+            If ``'separate_header'``, create a folder with one file per
+            partition without a header; write the header, if provided, in
+            a separate file.
+            If ``None``, serially concatenate the header and all partitions
+            into one file; export will be slower.
+        entries: :obj:`str
+            Describes which entries to export. One of:
+            ``'full'``, ``'lower'``, ``'strict_lower'``, ``'upper'``, ``'strict_upper'``.
+        """
+
+        export_type = Env.hail().utils.ExportType.getExportType(parallel)
+
+        if entries == 'full':
+            self._jrm.export(path, delimiter, joption(header), add_index, export_type)
+        elif entries == 'lower':
+            self._jrm.exportLowerTriangle(path, delimiter, joption(header), add_index, export_type)
+        elif entries == 'strict_lower':
+            self._jrm.exportStrictLowerTriangle(path, delimiter, joption(header), add_index, export_type)
+        elif entries == 'upper':
+            self._jrm.exportUpperTriangle(path, delimiter, joption(header), add_index, export_type)
+        else:
+            assert entries == 'strict_upper'
+            self._jrm.exportStrictUpperTriangle(path, delimiter, joption(header), add_index, export_type)
+
+
+row_matrix_type.set(RowMatrix)

--- a/python/hail/linalg/rowmatrix.py
+++ b/python/hail/linalg/rowmatrix.py
@@ -95,15 +95,18 @@ class RowMatrix(object):
 
         Examples
         --------
-        >>> from hail.linalg import RowMatrix
-        >>> rm = RowMatrix.read_from_block_matrix('output/bm',
+        >>> from hail.linalg import BlockMatrix, RowMatrix
+        >>> bm = BlockMatrix.random(3, 3).write('output/example.bm')
+        >>> rm = RowMatrix.read_from_block_matrix('output/example.bm',
         ...                                       partition_size=2)
 
         Notes
         -----
+
         The number of partitions in the resulting row matrix equals
         the ceiling of ``n_rows / partition_size``.
-        See :meth:`BlockMatrix.to_row_matrix` for more info.
+
+        See also :meth:`BlockMatrix.to_row_matrix`.
 
         Warning
         -------

--- a/python/hail/linalg/rowmatrix.py
+++ b/python/hail/linalg/rowmatrix.py
@@ -59,7 +59,7 @@ class RowMatrix(object):
 
         Examples
         --------
-
+        >>> from hail.linalg import RowMatrix
         >>> mt = hl.balding_nichols_model(3, 25, 50)
         >>> bm = RowMatrix.from_entry_expr(mt.GT.n_alt_alleles())
 
@@ -95,6 +95,7 @@ class RowMatrix(object):
 
         Examples
         --------
+        >>> from hail.linalg import RowMatrix
         >>> rm = RowMatrix.read_from_block_matrix('output/bm',
         ...                                       partition_size=2)
 

--- a/src/main/scala/is/hail/linalg/RowMatrix.scala
+++ b/src/main/scala/is/hail/linalg/RowMatrix.scala
@@ -16,7 +16,7 @@ object RowMatrix {
   
   def apply(hc: HailContext, rows: RDD[(Long, Array[Double])], nCols: Int, nRows: Long, partitionCounts: Array[Long]): RowMatrix =
     new RowMatrix(hc, rows, nCols, Some(nRows), Some(partitionCounts))
-    
+  
   def computePartitionCounts(partSize: Long, nRows: Long): Array[Long] = {
     val nParts = ((nRows - 1) / partSize).toInt + 1
     val partitionCounts = Array.fill[Long](nParts)(partSize)
@@ -92,7 +92,7 @@ class RowMatrix(val hc: HailContext,
     val localNCols = nCols
     exportDelimitedRowSlices(path, columnDelimiter, header, addIndex, exportType, i => math.min(i, localNCols.toLong).toInt, _ => localNCols)
   }  
-    
+  
   def exportStrictUpperTriangle(path: String, columnDelimiter: String, header: Option[String], addIndex: Boolean, exportType: Int) {
     val localNCols = nCols
     exportDelimitedRowSlices(path, columnDelimiter, header, addIndex, exportType, i => math.min(i + 1, localNCols.toLong).toInt, _ => localNCols)

--- a/src/main/scala/is/hail/linalg/RowMatrix.scala
+++ b/src/main/scala/is/hail/linalg/RowMatrix.scala
@@ -71,43 +71,48 @@ class RowMatrix(val hc: HailContext,
     new DenseMatrix[Double](nRowsInt, nCols, a.flatten, 0, nCols, isTranspose = true)
   }
   
-  def export(path: String, columnDelimiter: String, header: Option[String], exportType: Int) {
+  def export(path: String, columnDelimiter: String, header: Option[String], addIndex: Boolean, exportType: Int) {
     val localNCols = nCols
-    exportDelimitedRowSlices(path, columnDelimiter, header, exportType, _ => 0, _ => localNCols)
+    exportDelimitedRowSlices(path, columnDelimiter, header, addIndex, exportType, _ => 0, _ => localNCols)
   }
 
   // includes the diagonal
-  def exportLowerTriangle(path: String, columnDelimiter: String, header: Option[String], exportType: Int) {
+  def exportLowerTriangle(path: String, columnDelimiter: String, header: Option[String], addIndex: Boolean, exportType: Int) {
     val localNCols = nCols
-    exportDelimitedRowSlices(path, columnDelimiter, header, exportType, _ => 0, i => math.min(i + 1, localNCols.toLong).toInt)
+    exportDelimitedRowSlices(path, columnDelimiter, header, addIndex, exportType, _ => 0, i => math.min(i + 1, localNCols.toLong).toInt)
   }
 
-  def exportStrictLowerTriangle(path: String, columnDelimiter: String, header: Option[String], exportType: Int) {
+  def exportStrictLowerTriangle(path: String, columnDelimiter: String, header: Option[String], addIndex: Boolean, exportType: Int) {
     val localNCols = nCols
-    exportDelimitedRowSlices(path, columnDelimiter, header, exportType, _ => 0, i => math.min(i, localNCols.toLong).toInt)
+    exportDelimitedRowSlices(path, columnDelimiter, header, addIndex, exportType, _ => 0, i => math.min(i, localNCols.toLong).toInt)
   }
 
   // includes the diagonal
-  def exportUpperTriangle(path: String, columnDelimiter: String, header: Option[String], exportType: Int) {
+  def exportUpperTriangle(path: String, columnDelimiter: String, header: Option[String], addIndex: Boolean, exportType: Int) {
     val localNCols = nCols
-    exportDelimitedRowSlices(path, columnDelimiter, header, exportType, i => math.min(i, localNCols.toLong).toInt, _ => localNCols)
+    exportDelimitedRowSlices(path, columnDelimiter, header, addIndex, exportType, i => math.min(i, localNCols.toLong).toInt, _ => localNCols)
   }  
     
-  def exportStrictUpperTriangle(path: String, columnDelimiter: String, header: Option[String], exportType: Int) {
+  def exportStrictUpperTriangle(path: String, columnDelimiter: String, header: Option[String], addIndex: Boolean, exportType: Int) {
     val localNCols = nCols
-    exportDelimitedRowSlices(path, columnDelimiter, header, exportType, i => math.min(i + 1, localNCols.toLong).toInt, _ => localNCols)
+    exportDelimitedRowSlices(path, columnDelimiter, header, addIndex, exportType, i => math.min(i + 1, localNCols.toLong).toInt, _ => localNCols)
   }
   
   // convert elements in [start, end) of each array to a string, delimited by columnDelimiter, and export
   def exportDelimitedRowSlices(
     path: String, 
     columnDelimiter: String,
-    header: Option[String], 
+    header: Option[String],
+    addIndex: Boolean,
     exportType: Int, 
     start: (Long) => Int, 
     end: (Long) => Int) {
-    
+        
     genericExport(path, header, exportType, { (sb, i, v) =>
+      if (addIndex) {
+        sb.append(i)
+        sb.append(columnDelimiter)
+      }
       val l = start(i)
       val r = end(i)
       var j = l
@@ -168,8 +173,6 @@ class ReadBlocksAsRowsRDD(path: String,
     val ReadBlocksAsRowsRDDPartition(_, start, end) = split.asInstanceOf[ReadBlocksAsRowsRDDPartition]
 
     var inPerBlockCol = new Array[InputBuffer](nBlockCols)
-    val buf = new Array[Byte](blockSize << 3)
-
     var i = start
 
     new Iterator[(Long, Array[Double])] {

--- a/src/test/scala/is/hail/linalg/RowMatrixSuite.scala
+++ b/src/test/scala/is/hail/linalg/RowMatrixSuite.scala
@@ -91,24 +91,24 @@ class RowMatrixSuite extends SparkSuite {
       Array(7.0, 8.0, 9.0))
     val rowMatrix = rowArrayToRowMatrix(rowArrays)
 
-    exportImportAssert(rowMatrix.export(_, ",", header=None, exportType = ExportType.CONCATENATED),
+    exportImportAssert(rowMatrix.export(_, ",", header=None, addIndex = false, exportType = ExportType.CONCATENATED),
       rowArrays: _*)
 
-    exportImportAssert(rowMatrix.exportLowerTriangle(_, ",", header=None, exportType = ExportType.CONCATENATED),
+    exportImportAssert(rowMatrix.exportLowerTriangle(_, ",", header=None, addIndex = false, exportType = ExportType.CONCATENATED),
       Array(1.0),
       Array(4.0, 5.0),
       Array(7.0, 8.0, 9.0))
 
-    exportImportAssert(rowMatrix.exportStrictLowerTriangle(_, ",", header=None, exportType = ExportType.CONCATENATED),
+    exportImportAssert(rowMatrix.exportStrictLowerTriangle(_, ",", header=None, addIndex = false, exportType = ExportType.CONCATENATED),
       Array(4.0),
       Array(7.0, 8.0))
 
-    exportImportAssert(rowMatrix.exportUpperTriangle(_, ",", header=None, exportType = ExportType.CONCATENATED),
+    exportImportAssert(rowMatrix.exportUpperTriangle(_, ",", header=None, addIndex = false, exportType = ExportType.CONCATENATED),
       Array(1.0, 2.0, 3.0),
       Array(5.0, 6.0),
       Array(9.0))
 
-    exportImportAssert(rowMatrix.exportStrictUpperTriangle(_, ",", header=None, exportType = ExportType.CONCATENATED),
+    exportImportAssert(rowMatrix.exportStrictUpperTriangle(_, ",", header=None, addIndex = false, exportType = ExportType.CONCATENATED),
       Array(2.0, 3.0),
       Array(6.0))
   }
@@ -120,21 +120,21 @@ class RowMatrixSuite extends SparkSuite {
       Array(4.0, 5.0, 6.0))
     val rowMatrix = rowArrayToRowMatrix(rowArrays)
 
-    exportImportAssert(rowMatrix.export(_, ",", header=None, exportType = ExportType.CONCATENATED),
+    exportImportAssert(rowMatrix.export(_, ",", header=None, addIndex = false, exportType = ExportType.CONCATENATED),
       rowArrays: _*)
 
-    exportImportAssert(rowMatrix.exportLowerTriangle(_, ",", header=None, exportType = ExportType.CONCATENATED),
+    exportImportAssert(rowMatrix.exportLowerTriangle(_, ",", header=None, addIndex = false, exportType = ExportType.CONCATENATED),
       Array(1.0),
       Array(4.0, 5.0))
 
-    exportImportAssert(rowMatrix.exportStrictLowerTriangle(_, ",", header=None, exportType = ExportType.CONCATENATED),
+    exportImportAssert(rowMatrix.exportStrictLowerTriangle(_, ",", header=None, addIndex = false, exportType = ExportType.CONCATENATED),
       Array(4.0))
     
-    exportImportAssert(rowMatrix.exportUpperTriangle(_, ",", header=None, exportType = ExportType.CONCATENATED),
+    exportImportAssert(rowMatrix.exportUpperTriangle(_, ",", header=None, addIndex = false, exportType = ExportType.CONCATENATED),
       Array(1.0, 2.0, 3.0),
       Array(5.0, 6.0))
     
-    exportImportAssert(rowMatrix.exportStrictUpperTriangle(_, ",", header=None, exportType = ExportType.CONCATENATED),
+    exportImportAssert(rowMatrix.exportStrictUpperTriangle(_, ",", header=None, addIndex = false, exportType = ExportType.CONCATENATED),
       Array(2.0, 3.0),
       Array(6.0))
   }
@@ -147,23 +147,23 @@ class RowMatrixSuite extends SparkSuite {
       Array(7.0, 8.0))
     val rowMatrix = rowArrayToRowMatrix(rowArrays)
 
-    exportImportAssert(rowMatrix.export(_, ",", header=None, exportType = ExportType.CONCATENATED),
+    exportImportAssert(rowMatrix.export(_, ",", header=None, addIndex = false, exportType = ExportType.CONCATENATED),
       rowArrays: _*)
 
-    exportImportAssert(rowMatrix.exportLowerTriangle(_, ",", header=None, exportType = ExportType.CONCATENATED),
+    exportImportAssert(rowMatrix.exportLowerTriangle(_, ",", header=None, addIndex = false, exportType = ExportType.CONCATENATED),
       Array(1.0),
       Array(4.0, 5.0),
       Array(7.0, 8.0))
 
-    exportImportAssert(rowMatrix.exportStrictLowerTriangle(_, ",", header=None, exportType = ExportType.CONCATENATED),
+    exportImportAssert(rowMatrix.exportStrictLowerTriangle(_, ",", header=None, addIndex = false, exportType = ExportType.CONCATENATED),
       Array(4.0),
       Array(7.0, 8.0))
 
-    exportImportAssert(rowMatrix.exportUpperTriangle(_, ",", header=None, exportType = ExportType.CONCATENATED),
+    exportImportAssert(rowMatrix.exportUpperTriangle(_, ",", header=None, addIndex = false, exportType = ExportType.CONCATENATED),
       Array(1.0, 2.0),
       Array(5.0))
     
-    exportImportAssert(rowMatrix.exportStrictUpperTriangle(_, ",", header=None, exportType = ExportType.CONCATENATED),
+    exportImportAssert(rowMatrix.exportStrictUpperTriangle(_, ",", header=None, addIndex = false, exportType = ExportType.CONCATENATED),
       Array(2.0))
   }  
 
@@ -172,29 +172,29 @@ class RowMatrixSuite extends SparkSuite {
     val rowArrays: Array[Array[Double]] = Array.tabulate(20)( r => Array.tabulate(30)(c => 30 * c + r))
     val rowMatrix = rowArrayToRowMatrix(rowArrays)
     
-    exportImportAssert(rowMatrix.export(_, ",", header=None, exportType = ExportType.CONCATENATED),
+    exportImportAssert(rowMatrix.export(_, ",", header=None, addIndex = false, exportType = ExportType.CONCATENATED),
       rowArrays: _*)
 
-    exportImportAssert(rowMatrix.exportLowerTriangle(_, ",", header=None, exportType = ExportType.CONCATENATED),
+    exportImportAssert(rowMatrix.exportLowerTriangle(_, ",", header=None, addIndex = false, exportType = ExportType.CONCATENATED),
       rowArrays.zipWithIndex
         .map { case (a, i) =>
           a.zipWithIndex.filter { case (_, j) => j <= i }.map(_._1) }
         .toArray[Array[Double]]:_*)
         
-    exportImportAssert(rowMatrix.exportStrictLowerTriangle(_, ",", header=None, exportType = ExportType.CONCATENATED),
+    exportImportAssert(rowMatrix.exportStrictLowerTriangle(_, ",", header=None, addIndex = false, exportType = ExportType.CONCATENATED),
       rowArrays.zipWithIndex
         .map { case (a, i) =>
           a.zipWithIndex.filter { case (_, j) => j < i }.map(_._1) }
         .filter(_.nonEmpty)
         .toArray[Array[Double]]:_*)
 
-    exportImportAssert(rowMatrix.exportUpperTriangle(_, ",", header=None, exportType = ExportType.CONCATENATED),
+    exportImportAssert(rowMatrix.exportUpperTriangle(_, ",", header=None, addIndex = false, exportType = ExportType.CONCATENATED),
       rowArrays.zipWithIndex
         .map { case (a, i) =>
           a.zipWithIndex.filter { case (_, j) => j >= i }.map(_._1) }
         .toArray[Array[Double]]:_*)
 
-    exportImportAssert(rowMatrix.exportStrictUpperTriangle(_, ",", header=None, exportType = ExportType.CONCATENATED),
+    exportImportAssert(rowMatrix.exportStrictUpperTriangle(_, ",", header=None, addIndex = false, exportType = ExportType.CONCATENATED),
       rowArrays.zipWithIndex
         .map { case (a, i) =>
           a.zipWithIndex.filter { case (_, j) => j > i }.map(_._1) }

--- a/src/test/scala/is/hail/linalg/RowMatrixSuite.scala
+++ b/src/test/scala/is/hail/linalg/RowMatrixSuite.scala
@@ -7,12 +7,12 @@ import is.hail.utils._
 import org.testng.annotations.Test
 
 class RowMatrixSuite extends SparkSuite {
-  private def rowArrayToRowMatrix(a: Array[Array[Double]]): RowMatrix = {
+  private def rowArrayToRowMatrix(a: Array[Array[Double]], nPartitions: Int = sc.defaultParallelism): RowMatrix = {
     require(a.length > 0)
     val nRows = a.length
     val nCols = a(0).length
     
-    RowMatrix(hc, sc.parallelize(a.zipWithIndex.map { case (row, i) => (i.toLong, row) }), nCols, nRows)
+    RowMatrix(hc, sc.parallelize(a.zipWithIndex.map { case (row, i) => (i.toLong, row) }, nPartitions), nCols, nRows)
   }
   
   private def rowArrayToLocalMatrix(a: Array[Array[Double]]): DenseMatrix[Double] = {
@@ -89,7 +89,7 @@ class RowMatrixSuite extends SparkSuite {
       Array(1.0, 2.0, 3.0),
       Array(4.0, 5.0, 6.0),
       Array(7.0, 8.0, 9.0))
-    val rowMatrix = rowArrayToRowMatrix(rowArrays)
+    val rowMatrix = rowArrayToRowMatrix(rowArrays, nPartitions = 2)
 
     val rowArraysWithIndex = Array(
       Array(0.0, 1.0, 2.0, 3.0),

--- a/src/test/scala/is/hail/linalg/RowMatrixSuite.scala
+++ b/src/test/scala/is/hail/linalg/RowMatrixSuite.scala
@@ -2,7 +2,7 @@ package is.hail.linalg
   
 import breeze.linalg.DenseMatrix
 import is.hail.SparkSuite
-import is.hail.check.{Gen, Prop}
+import is.hail.check.Gen
 import is.hail.utils._
 import org.testng.annotations.Test
 
@@ -81,6 +81,23 @@ class RowMatrixSuite extends SparkSuite {
     val fname = tmpDir.createTempFile("test")
     export(fname)
     assert(readCSV(fname) === expected.toArray[Array[Double]])
+  }
+
+  @Test
+  def exportWithIndex() {
+    val rowArrays = Array(
+      Array(1.0, 2.0, 3.0),
+      Array(4.0, 5.0, 6.0),
+      Array(7.0, 8.0, 9.0))
+    val rowMatrix = rowArrayToRowMatrix(rowArrays)
+
+    val rowArraysWithIndex = Array(
+      Array(0.0, 1.0, 2.0, 3.0),
+      Array(1.0, 4.0, 5.0, 6.0),
+      Array(2.0, 7.0, 8.0, 9.0))
+
+    exportImportAssert(rowMatrix.export(_, ",", header = None, addIndex = true, exportType = ExportType.CONCATENATED),
+      rowArraysWithIndex: _*)
   }
 
   @Test


### PR DESCRIPTION
This PR begins to expose RowMatrix functions in Python.
- lots of docs
- fixed up parallel options in export
- added add_index option, useful for parallel export
- test of add_index

I broke this out from changes in sparse_block_matrix (v1 on its way, at which point I'll assign this and that) and lmm2. Three key uses for RowMatrix:
- BlockMatrix export
- class of inputs to per-variant LMM (see lmm2 branch)
- BlockMatrix to MatrixTable conversion (once I add RowMatrix.toMatrixTable)