### PR TITLE
Fix #3475: Expression error gets output in stacktrace

### DIFF
--- a/python/hail/expr/expressions/base_expression.py
+++ b/python/hail/expr/expressions/base_expression.py
@@ -56,7 +56,7 @@ def impute_type(x):
         return ttuple(*(impute_type(element) for element in x))
     elif isinstance(x, list):
         if len(x) == 0:
-            raise ExpressionException('Cannot impute type of empty list.')
+            raise ExpressionException("Cannot impute type of empty list. Use 'hl.empty_array' to create an empty array.")
         ts = {impute_type(element) for element in x}
         unified_type = unify_types_limited(*ts)
         if not unified_type:
@@ -65,7 +65,7 @@ def impute_type(x):
         return tarray(unified_type)
     elif isinstance(x, set):
         if len(x) == 0:
-            raise ExpressionException('Cannot impute type of empty set.')
+            raise ExpressionException("Cannot impute type of empty set. Use 'hl.empty_set' to create an empty set.")
         ts = {impute_type(element) for element in x}
         unified_type = unify_types_limited(*ts)
         if not unified_type:
@@ -74,7 +74,7 @@ def impute_type(x):
         return tset(unified_type)
     elif isinstance(x, dict):
         if len(x) == 0:
-            raise ExpressionException('Cannot impute type of empty dict.')
+            raise ExpressionException("Cannot impute type of empty dict. Use 'hl.empty_dict' to create an empty dict.")
         kts = {impute_type(element) for element in x.keys()}
         vts = {impute_type(element) for element in x.values()}
         unified_key_type = unify_types_limited(*kts)

--- a/python/hail/typecheck/check.py
+++ b/python/hail/typecheck/check.py
@@ -425,7 +425,7 @@ def check_all(f, args, kwargs, checks, is_method):
         try:
             arg_ = tc.check(arg, name, argname)
             args_.append(arg_)
-        except TypecheckFailure:
+        except TypecheckFailure as e:
             if i < len(named_args):
                 raise TypeError("{fname}: parameter '{argname}': "
                                 "expected {expected}, found {found}".format(
@@ -433,7 +433,7 @@ def check_all(f, args, kwargs, checks, is_method):
                     argname=argname,
                     expected=tc.expects(),
                     found=tc.format(arg)
-                )) from None
+                )) from e
             else:
                 raise TypeError("{fname}: parameter '*{argname}' (arg {idx} of {tot}): "
                                 "expected {expected}, found {found}".format(
@@ -443,7 +443,7 @@ def check_all(f, args, kwargs, checks, is_method):
                     tot=len(pos_args) - len(named_args),
                     expected=tc.expects(),
                     found=tc.format(arg)
-                )) from None
+                )) from e
 
     kwargs_ = {}
 


### PR DESCRIPTION
The stack trace looks like this now:

```
Error
Traceback (most recent call last):
  File "/Users/jigold/hail/python/hail/expr/expressions/expression_typecheck.py", line 73, in check
    return self.coerce(to_expr(x))
  File "/Users/jigold/hail/python/hail/expr/expressions/base_expression.py", line 101, in to_expr
    dtype = impute_type(e)
  File "/Users/jigold/hail/python/hail/expr/expressions/base_expression.py", line 59, in impute_type
    raise ExpressionException("Cannot impute type of empty list. Use 'hl.empty_array' to create an empty array.")
hail.expr.expressions.base_expression.ExpressionException: Cannot impute type of empty list. Use 'hl.empty_array' to create an empty array.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/jigold/hail/python/hail/typecheck/check.py", line 426, in check_all
    arg_ = tc.check(arg, name, argname)
  File "/Users/jigold/hail/python/hail/expr/expressions/expression_typecheck.py", line 75, in check
    raise TypecheckFailure from e
hail.typecheck.check.TypecheckFailure

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/jigold/hail/python/hail/tests/test_expr.py", line 1085, in test_empty_collection_error_msg
    self.assertRaisesRegex(hl.expr.ExpressionException, "Cannot impute type of empty list.", hl.array([]))
  File "<decorator-gen-420>", line 2, in array
  File "/Users/jigold/hail/python/hail/typecheck/check.py", line 494, in _typecheck
    args_, kwargs_ = check_all(__orig_func__, args, kwargs, checkers, is_method=False)
  File "/Users/jigold/hail/python/hail/typecheck/check.py", line 436, in check_all
    )) from e
TypeError: array: parameter 'collection': expected expression of type set<any> or array<any> or dict<('any', 'any')>, found list: []
```