### PR TITLE
Concordance, SplitMulti, diploid/unphased warnings

### DIFF
--- a/python/hail/docs/_templates/req_unphased_diploid_gt.rst
+++ b/python/hail/docs/_templates/req_unphased_diploid_gt.rst
@@ -1,0 +1,5 @@
+.. note::
+
+    Requires the dataset to contain only diploid and unphased genotype calls.
+    Use :func:`.call` to recode genotype calls or :func:`.null` to set genotype
+    calls to missing.

--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -121,10 +121,9 @@ def export_plink(dataset, output, call=None, fam_id=None, ind_id=None, pat_id=No
     BED, BIM and FAM files.
 
     .. include:: ../_templates/req_tvariant_w_struct_locus.rst
-
     .. include:: ../_templates/req_tstring.rst
-
     .. include:: ../_templates/req_biallelic.rst
+    .. include:: ../_templates/req_unphased_diploid_gt.rst
 
     Examples
     --------

--- a/python/hail/methods/qc.py
+++ b/python/hail/methods/qc.py
@@ -97,6 +97,7 @@ def variant_qc(dataset, name='variant_qc') -> MatrixTable:
 
     .. include:: ../_templates/req_biallelic.rst
     .. include:: ../_templates/req_tvariant.rst
+    .. include:: ../_templates/req_unphased_diploid_gt.rst
 
     Examples
     --------
@@ -174,6 +175,8 @@ def concordance(left, right) -> Tuple[List[List[int]], Table, Table]:
 
     .. include:: ../_templates/req_biallelic.rst
 
+    .. include:: ../_templates/req_unphased_diploid_gt.rst
+
     .. testsetup::
 
         dataset2 = dataset
@@ -193,7 +196,8 @@ def concordance(left, right) -> Tuple[List[List[int]], Table, Table]:
     This method computes the genotype call concordance (from the entry
     field **GT**) between two biallelic variant datasets.  It requires
     unique sample IDs and performs an inner join on samples (only
-    samples in both datasets will be considered).
+    samples in both datasets will be considered). In addition, all genotype
+    calls must be **diploid** and **unphased**.
 
     It performs an ordered zip join of the variants.  That means the
     variants of each dataset are sorted, with duplicate variants

--- a/src/main/scala/is/hail/methods/CalculateConcordance.scala
+++ b/src/main/scala/is/hail/methods/CalculateConcordance.scala
@@ -131,15 +131,23 @@ object CalculateConcordance {
             rview.setGenotype(leftToRightBc.value(li))
           comb(li).merge(
             if (lrv != null) {
-              if (lview.hasGT)
-                Call.unphasedDiploidGtIndex(lview.getGT) + 2
+              if (lview.hasGT) {
+                val gt = Call.unphasedDiploidGtIndex(lview.getGT)
+                if (gt > 2)
+                  fatal(s"'concordance' requires biallelic genotype calls. Found ${ Call.toString(lview.getGT) }.")
+                gt + 2
+              }
               else
                 1
             } else
               0,
             if (rrv != null) {
-              if (rview.hasGT)
-                Call.unphasedDiploidGtIndex(rview.getGT) + 2
+              if (rview.hasGT) {
+                val gt = Call.unphasedDiploidGtIndex(rview.getGT)
+                if (gt > 2)
+                  fatal(s"'concordance' requires biallelic genotype calls. Found ${ Call.toString(rview.getGT) }.")
+                gt + 2
+              }
               else
                 1
             } else


### PR DESCRIPTION
I purposefully left off the warning for `call_stats` because the requirement will be removed with #3496.