### PR TITLE
edit ld_prune to take CallExpression

### DIFF
--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -2904,7 +2904,7 @@ def filter_alleles_hts(mt: MatrixTable,
            window=int,
            memory_per_core=int)
 def _local_ld_prune(call_expr, r2=0.2, window=1000000, memory_per_core=256):
-    mt = matrix_table_source('_local_ld_prune/call_expr', call_expr)
+    mt = matrix_table_source('_local_ld_prune/call_expr', call_expr).select_entries(call_expr)
     bytes_per_core = memory_per_core * 1024 * 1024
     fraction_memory_to_use = 0.25
     variant_byte_overhead = 50
@@ -2951,7 +2951,7 @@ def ld_prune(call_expr, r2=0.2, window=1000000, memory_per_core=256):
     Parameters
     ----------
     call_expr : :class:`.CallExpression`
-        Entry-indexed call expression on a matrix table with row-indexed variants and column-indexed samples.
+        Entry-indexed genotype call expression on a matrix table with row-indexed variants and column-indexed samples.
     r2 : :obj:`float`
         correlation threshold (exclusive) above which variants are removed
     window : :obj:`int`

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -2898,16 +2898,18 @@ def filter_alleles_hts(mt: MatrixTable,
             GQ=hl.gq_from_pl(newPL),
             PL=newPL).drop('__old_to_new_no_na')
 
-@typecheck(ds=MatrixTable,
+
+@typecheck(call_expr=expr_call,
            r2=numeric,
            window=int,
-           memory_per_core=int)  
-def _local_ld_prune(ds, r2=0.2, window=1000000, memory_per_core=256):
+           memory_per_core=int)
+def _local_ld_prune(call_expr, r2=0.2, window=1000000, memory_per_core=256):
+    mt = matrix_table_source('_local_ld_prune/call_expr', call_expr)
     bytes_per_core = memory_per_core * 1024 * 1024
     fraction_memory_to_use = 0.25
     variant_byte_overhead = 50
     genotypes_per_pack = 32
-    n_samples = ds.count_cols()
+    n_samples = mt.count_cols()
     min_memory_per_core = math.ceil((1 / fraction_memory_to_use) * 8 * n_samples + variant_byte_overhead)
     if bytes_per_core < min_memory_per_core:
         raise ValueError("memory per core must be greater than {} MB".format(min_memory_per_core * 1024 * 1024))
@@ -2916,18 +2918,23 @@ def _local_ld_prune(ds, r2=0.2, window=1000000, memory_per_core=256):
     max_queue_size = int(max(1.0, math.ceil(memory_available_per_core / bytes_per_variant)))
 
     sites_only_table = Table(Env.hail().methods.LocalLDPrune.apply(
-        require_biallelic(ds, 'ld_prune')._jvds, float(r2), window, max_queue_size))
+        require_biallelic(mt, 'ld_prune')._jvds, float(r2), window, max_queue_size))
 
     return sites_only_table
 
-@typecheck(ds=MatrixTable,
+
+@typecheck(call_expr=expr_call,
            r2=numeric,
            window=int,
            memory_per_core=int)
-def ld_prune(ds, r2=0.2, window=1000000, memory_per_core=256):
+def ld_prune(call_expr, r2=0.2, window=1000000, memory_per_core=256):
     """Prune variants in linkage disequilibrium.
 
     .. include:: ../_templates/req_unphased_diploid_gt.rst
+
+    .. include:: ../_templates/req_biallelic.rst
+
+    .. include:: ../_templates/req_tvariant.rst
 
     Notes
     -----
@@ -2943,8 +2950,8 @@ def ld_prune(ds, r2=0.2, window=1000000, memory_per_core=256):
 
     Parameters
     ----------
-    ds : :class:`.MatrixTable`
-        dataset to prune
+    call_expr : :class:`.CallExpression`
+        Entry-indexed call expression on a matrix table with row-indexed variants and column-indexed samples.
     r2 : :obj:`float`
         correlation threshold (exclusive) above which variants are removed
     window : :obj:`int`
@@ -2957,13 +2964,14 @@ def ld_prune(ds, r2=0.2, window=1000000, memory_per_core=256):
     :class:`.Table`
         Table of variants after pruning.
     """
-    sites_only_table = _local_ld_prune(ds, r2, window, memory_per_core)
+    sites_only_table = _local_ld_prune(call_expr, r2, window, memory_per_core)
 
     sites_path = new_temp_file()
     sites_only_table.write(sites_path, overwrite=True)
     sites_only_table = hl.read_table(sites_path)
 
-    locally_pruned_ds = ds.annotate_rows(pruned=sites_only_table[ds.row_key])
+    mt = matrix_table_source('ld_prune/call_expr', call_expr)
+    locally_pruned_ds = mt.annotate_rows(pruned=sites_only_table[mt.row_key])
     locally_pruned_ds = locally_pruned_ds.filter_rows(hl.is_defined(locally_pruned_ds.pruned))
 
     locally_pruned_ds = (locally_pruned_ds.annotate_rows(

--- a/python/hail/tests/test_methods.py
+++ b/python/hail/tests/test_methods.py
@@ -1562,6 +1562,12 @@ class Tests(unittest.TestCase):
         pruned_table = hl.ld_prune(ds.GT)
         assert (pruned_table.count() == 1)
 
+    def test_ld_prune_call_expression(self):
+        ds = hl.import_vcf("src/test/resources/ldprune2.vcf", min_partitions=2)
+        ds = ds.select_entries(foo=ds.GT)
+        pruned_table = hl.ld_prune(ds.foo)
+        assert (pruned_table.count() == 1)
+
     def test_entries_table(self):
         n_rows, n_cols = 5, 3
         rows = [{'i': i, 'j': j, 'entry': float(i + j)} for i in range(n_rows) for j in range(n_cols)]

--- a/python/hail/tests/test_methods.py
+++ b/python/hail/tests/test_methods.py
@@ -1520,7 +1520,7 @@ class Tests(unittest.TestCase):
 
     def test_ld_prune(self):
         ds = hl.split_multi_hts(hl.import_vcf(resource('sample.vcf')))
-        pruned_table = hl.ld_prune(ds, r2=0.2, window=1000000)
+        pruned_table = hl.ld_prune(ds.GT, r2=0.2, window=1000000)
 
         filtered_ds = (ds.filter_rows(hl.is_defined(pruned_table[(ds.locus, ds.alleles)])))
         filtered_ds = filtered_ds.annotate_rows(stats=agg.stats(filtered_ds.GT.n_alt_alleles()))
@@ -1548,18 +1548,18 @@ class Tests(unittest.TestCase):
 
     def test_ld_prune_inputs(self):
         ds = hl.split_multi_hts(hl.import_vcf(resource('sample.vcf')))
-        self.assertRaises(ValueError, lambda: hl.ld_prune(ds, r2=0.2, window=1000000, memory_per_core=0))
+        self.assertRaises(ValueError, lambda: hl.ld_prune(ds.GT, r2=0.2, window=1000000, memory_per_core=0))
 
     def test_ld_prune_no_prune(self):
         ds = hl.split_multi_hts(hl.import_vcf(resource('sample.vcf')))
-        pruned_table = hl.ld_prune(ds, r2=1, window=0)
+        pruned_table = hl.ld_prune(ds.GT, r2=1, window=0)
         expected_ds = ds.filter_rows(
             agg.collect_as_set(agg.filter(hl.is_defined(ds['GT']), ds.GT)).size() > 1, keep=True)
         assert (pruned_table.count() == expected_ds.count_rows())
 
     def test_ld_prune_identical_variants(self):
         ds = hl.import_vcf(resource('ldprune2.vcf'), min_partitions=2)
-        pruned_table = hl.ld_prune(ds)
+        pruned_table = hl.ld_prune(ds.GT)
         assert (pruned_table.count() == 1)
 
     def test_entries_table(self):

--- a/src/main/scala/is/hail/methods/LocalLDPrune.scala
+++ b/src/main/scala/is/hail/methods/LocalLDPrune.scala
@@ -266,7 +266,7 @@ object LocalLDPrune {
     }
   }
 
-  def apply(mt: MatrixTable, r2Threshold: Double = 0.2, windowSize: Int = 1000000, maxQueueSize: Int): Table = {
+  def apply(mt: MatrixTable, callField: String = "GT", r2Threshold: Double = 0.2, windowSize: Int = 1000000, maxQueueSize: Int): Table = {
 
     mt.requireRowKeyVariant("ld_prune")
 
@@ -294,7 +294,7 @@ object LocalLDPrune {
 
     val standardizedRDD = mt.rvd
       .mapPartitionsPreservesPartitioning(new OrderedRVDType(typ.partitionKey, typ.key, bpvType))({ it =>
-        val hcView = HardCallView(fullRowType)
+        val hcView = new HardCallView(fullRowType, callField)
         val region = Region()
         val rvb = new RegionValueBuilder(region)
         val newRV = RegionValue(region)


### PR DESCRIPTION
edit ld_prune to take a CallExpression instead of a matrix table, as well as some doc edits

will post to this [dev thread](http://discuss.hail.is/t/log-of-breaking-changes-in-0-2-beta/454/3) when it goes through