### PR TITLE
`wrapArg` and `unwrapReturn` to pull annotations from RV representation

### DIFF
--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -181,6 +181,9 @@ object Code {
   def invokeScalaObject[A1, A2, S](cls: Class[_], method: String, a1: Code[A1], a2: Code[A2])(implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2], sct: ClassTag[S]): Code[S] =
     invokeScalaObject[S](cls, method, Array[Class[_]](a1ct.runtimeClass, a2ct.runtimeClass), Array(a1, a2))
 
+  def invokeScalaObject[A1, A2, A3, S](cls: Class[_], method: String, a1: Code[A1], a2: Code[A2], a3: Code[A3])(implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2], a3ct: ClassTag[A3], sct: ClassTag[S]): Code[S] =
+    invokeScalaObject[S](cls, method, Array[Class[_]](a1ct.runtimeClass, a2ct.runtimeClass, a3ct.runtimeClass), Array(a1, a2, a3))
+
   def invokeStatic[S](cls: Class[_], method: String, parameterTypes: Array[Class[_]], args: Array[Code[_]])(implicit sct: ClassTag[S]): Code[S] = {
     val m = Invokeable.lookupMethod(cls, method, parameterTypes)(sct)
     assert(m.isStatic)

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -89,6 +89,7 @@ abstract class RegistryFunctions {
     tv(name, _.isInstanceOf[TNumeric])
 
   def wrapArg(mb: EmitMethodBuilder, t: Type): Code[_] => Code[_] = t match {
+    case _: TBoolean => { case c: Code[Boolean] => c }
     case _: TInt32 => { case c: Code[Int] => c }
     case _: TInt64 => { case c: Code[Long] => c }
     case _: TFloat32 => { case c: Code[Float] => c }
@@ -108,6 +109,7 @@ abstract class RegistryFunctions {
   }
 
   def unwrapReturn(mb: EmitMethodBuilder, t: Type): Code[_] => Code[_] = t match {
+    case _: TBoolean => { case c: Code[Boolean] => c }
     case _: TInt32 => { case c: Code[Int] => c }
     case _: TInt64 => { case c: Code[Long] => c }
     case _: TFloat32 => { case c: Code[Float] => c }
@@ -115,7 +117,6 @@ abstract class RegistryFunctions {
     case _: TString => { case c: Code[String] =>
       mb.getArg[Region](1).load().appendString(c)
     }
-    case _ => ???
   }
 
   def registerCode(mname: String, aTypes: Array[Type], rType: Type, isDet: Boolean)(impl: (EmitMethodBuilder, Array[Code[_]]) => Code[_]) {

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -93,6 +93,11 @@ abstract class RegistryFunctions {
     case _: TInt64 => { case c: Code[Long] => c }
     case _: TFloat32 => { case c: Code[Float] => c }
     case _: TFloat64 => { case c: Code[Double] => c }
+    case _: TString => { case c: Code[Long] =>
+      Code.invokeScalaObject[Region, Long, String](
+        TString.getClass, "loadString",
+        mb.getArg[Region](1), c)
+    }
     case t => {
       case c: Code[Long] =>
         Code.invokeScalaObject[Type, Region, Long, Any](

--- a/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -69,8 +69,8 @@ object StringFunctions extends RegistryFunctions {
       val missing = s.m || r.m || Code(
         out := Code.invokeScalaObject[String, String, IndexedSeq[String]](
           thisClass, "firstMatchIn",
-          coerce[String](wrapArg(mb, TString())(s.value[Long])),
-          coerce[String](wrapArg(mb, TString())(r.value[Long]))),
+          asm4s.coerce[String](wrapArg(mb, TString())(s.value[Long])),
+          asm4s.coerce[String](wrapArg(mb, TString())(r.value[Long]))),
         nout.isNull)
       val value =
         nout.ifNull(

--- a/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -12,34 +12,16 @@ import scala.reflect.{ClassTag, classTag}
 
 object StringFunctions extends RegistryFunctions {
 
-  private[this] def wrapToString(mb: EmitMethodBuilder, v: Code[Long]): Code[String] = {
-    Code.invokeScalaObject[Region, Long, String](TString.getClass, "loadString", mb.getArg[Region](1), v)
-  }
-
-  private[this] def convertFromString(mb: EmitMethodBuilder, v: Code[String]): Code[Long] = {
-    mb.getArg[Region](1).load().appendString(v)
-  }
-
   private[this] def registerWrappedStringScalaFunction(mname: String, argTypes: Array[Type], rType: Type)(cls: Class[_], method: String) {
     def ct(typ: Type): ClassTag[_] = typ match {
       case _: TString => classTag[String]
       case t => TypeToIRIntermediateClassTag(t)
     }
 
-    def convertToString(mb: EmitMethodBuilder, typ: Type, v: Code[_]): Code[_] = (typ, v) match {
-        case (_: TString, v2: Code[Long]) => wrapToString(mb, v2)
-        case (_, v2) => v2
-    }
-
-    def convertBack(mb: EmitMethodBuilder, v: Code[_]): Code[_] = rType match {
-      case _: TString => convertFromString(mb, asm4s.coerce[String](v))
-      case t => v
-    }
-
     registerCode(mname, argTypes, rType, isDet = true) { (mb, args) =>
       val cts = argTypes.map(ct(_).runtimeClass)
-      val out = Code.invokeScalaObject(cls, method, cts, argTypes.zip(args).map { case (t, a) => convertToString(mb, t, a) } )(ct(rType))
-      convertBack(mb, out)
+      val out = Code.invokeScalaObject(cls, method, cts, argTypes.zip(args).map { case (t, a) => wrapArg(mb, t)(a) } )(ct(rType))
+      unwrapReturn(mb, rType)(out)
     }
   }
 
@@ -85,8 +67,10 @@ object StringFunctions extends RegistryFunctions {
 
       val setup = Code(s.setup, r.setup)
       val missing = s.m || r.m || Code(
-        out := Code.invokeScalaObject[String, String, IndexedSeq[String]](thisClass,
-          "firstMatchIn", wrapToString(mb, s.value[Long]), wrapToString(mb, r.value[Long])),
+        out := Code.invokeScalaObject[String, String, IndexedSeq[String]](
+          thisClass, "firstMatchIn",
+          coerce[String](wrapArg(mb, TString())(s.value[Long])),
+          coerce[String](wrapArg(mb, TString())(r.value[Long]))),
         nout.isNull)
       val value =
         nout.ifNull(


### PR DESCRIPTION
This is to make it easier to port things to the FunctionRegistry.

This involves serializing the type, so it's not going to be especially efficient on most arbitrary objects, so i pulled strings out separately. It also doesn't deal with returning things that are arrays or structs or anything yet. (mostly just strings).

The type serializing is also included in this PR.

I moved the StringFunctions to use this so it should be moderately tested by the string function tests in python.

cc @tpoterba