### PR TITLE
Added RegionValueAggregator.clear.

### DIFF
--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueAggregator.scala
@@ -9,4 +9,6 @@ trait RegionValueAggregator extends Serializable {
   def result(rvb: RegionValueBuilder)
 
   def copy(): RegionValueAggregator
+
+  def clear(): Unit
 }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCollectAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCollectAggregator.scala
@@ -1,10 +1,7 @@
 package is.hail.annotations.aggregators
 
-import is.hail.expr._
 import is.hail.annotations._
 import is.hail.utils._
-
-import scala.collection.mutable.BitSet
 
 class RegionValueCollectBooleanAggregator extends RegionValueAggregator {
   private val ab = new MissingBooleanArrayBuilder()
@@ -30,6 +27,10 @@ class RegionValueCollectBooleanAggregator extends RegionValueAggregator {
   }
 
   def copy(): RegionValueCollectBooleanAggregator = new RegionValueCollectBooleanAggregator()
+
+  def clear() {
+    ab.clear()
+  }
 }
 
 class RegionValueCollectIntAggregator extends RegionValueAggregator {
@@ -56,4 +57,8 @@ class RegionValueCollectIntAggregator extends RegionValueAggregator {
   }
 
   def copy(): RegionValueCollectIntAggregator = new RegionValueCollectIntAggregator()
+
+  def clear() {
+    ab.clear()
+  }
 }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCountAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCountAggregator.scala
@@ -18,4 +18,8 @@ class RegionValueCountAggregator extends RegionValueAggregator {
   }
 
   def copy(): RegionValueCountAggregator = new RegionValueCountAggregator()
+
+  def clear() {
+    count = 0
+  }
 }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueFractionAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueFractionAggregator.scala
@@ -26,4 +26,9 @@ class RegionValueFractionAggregator extends RegionValueAggregator {
   }
 
   def copy() = new RegionValueFractionAggregator()
+
+  def clear() {
+    trues = 0L
+    total = 0L
+  }
 }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueHistogramAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueHistogramAggregator.scala
@@ -50,4 +50,8 @@ class RegionValueHistogramAggregator(start: Double, end: Double, bins: Int) exte
   }
 
   def copy() = new RegionValueHistogramAggregator(start, end, bins)
+
+  def clear() {
+    combiner.clear()
+  }
 }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueMaxIntAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueMaxIntAggregator.scala
@@ -26,6 +26,11 @@ class RegionValueMaxBooleanAggregator extends RegionValueAggregator {
   }
 
   def copy(): RegionValueMaxBooleanAggregator = new RegionValueMaxBooleanAggregator()
+
+  def clear() {
+    max = false
+    found = false
+  }
 }
 
 class RegionValueMaxIntAggregator extends RegionValueAggregator {
@@ -52,6 +57,11 @@ class RegionValueMaxIntAggregator extends RegionValueAggregator {
   }
 
   def copy(): RegionValueMaxIntAggregator = new RegionValueMaxIntAggregator()
+
+  def clear() {
+    max = 0
+    found = false
+  }
 }
 
 class RegionValueMaxLongAggregator extends RegionValueAggregator {
@@ -78,6 +88,11 @@ class RegionValueMaxLongAggregator extends RegionValueAggregator {
   }
 
   def copy(): RegionValueMaxLongAggregator = new RegionValueMaxLongAggregator()
+
+  def clear() {
+    max = 0L
+    found = false
+  }
 }
 
 class RegionValueMaxFloatAggregator extends RegionValueAggregator {
@@ -104,6 +119,11 @@ class RegionValueMaxFloatAggregator extends RegionValueAggregator {
   }
 
   def copy(): RegionValueMaxFloatAggregator = new RegionValueMaxFloatAggregator()
+
+  def clear() {
+    max = 0.0f
+    found = false
+  }
 }
 
 class RegionValueMaxDoubleAggregator extends RegionValueAggregator {
@@ -130,4 +150,9 @@ class RegionValueMaxDoubleAggregator extends RegionValueAggregator {
   }
 
   def copy(): RegionValueMaxDoubleAggregator = new RegionValueMaxDoubleAggregator()
+
+  def clear() {
+    max = 0.0
+    found = false
+  }
 }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueStatisticsAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueStatisticsAggregator.scala
@@ -16,7 +16,7 @@ object RegionValueStatisticsAggregator {
 }
 
 class RegionValueStatisticsAggregator extends RegionValueAggregator {
-  private val sc = new StatCounter()
+  private var sc = new StatCounter()
 
   def seqOp(x: Double, missing: Boolean) {
     if (!missing)
@@ -43,4 +43,8 @@ class RegionValueStatisticsAggregator extends RegionValueAggregator {
   }
 
   def copy() = new RegionValueStatisticsAggregator()
+
+  def clear() {
+    sc = new StatCounter()
+  }
 }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueSumAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueSumAggregator.scala
@@ -19,6 +19,10 @@ class RegionValueSumBooleanAggregator extends RegionValueAggregator {
   }
 
   def copy(): RegionValueSumBooleanAggregator = new RegionValueSumBooleanAggregator()
+
+  def clear() {
+    sum = false
+  }
 }
 
 class RegionValueSumIntAggregator extends RegionValueAggregator {
@@ -38,6 +42,10 @@ class RegionValueSumIntAggregator extends RegionValueAggregator {
   }
 
   def copy(): RegionValueSumIntAggregator = new RegionValueSumIntAggregator()
+
+  def clear() {
+    sum = 0
+  }
 }
 
 class RegionValueSumLongAggregator extends RegionValueAggregator {
@@ -57,6 +65,10 @@ class RegionValueSumLongAggregator extends RegionValueAggregator {
   }
 
   def copy(): RegionValueSumLongAggregator = new RegionValueSumLongAggregator()
+
+  def clear() {
+    sum = 0L
+  }
 }
 
 class RegionValueSumFloatAggregator extends RegionValueAggregator {
@@ -76,6 +88,10 @@ class RegionValueSumFloatAggregator extends RegionValueAggregator {
   }
 
   def copy(): RegionValueSumFloatAggregator = new RegionValueSumFloatAggregator()
+
+  def clear() {
+    sum = 0.0f
+  }
 }
 
 class RegionValueSumDoubleAggregator extends RegionValueAggregator {
@@ -95,4 +111,8 @@ class RegionValueSumDoubleAggregator extends RegionValueAggregator {
   }
 
   def copy(): RegionValueSumDoubleAggregator = new RegionValueSumDoubleAggregator()
+
+  def clear() {
+    sum = 0.0
+  }
 }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueTakeAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueTakeAggregator.scala
@@ -32,6 +32,10 @@ class RegionValueTakeBooleanAggregator(n: Int) extends RegionValueAggregator {
   }
 
   def copy(): RegionValueTakeBooleanAggregator = new RegionValueTakeBooleanAggregator(n)
+
+  def clear() {
+    ab.clear()
+  }
 }
 
 class RegionValueTakeIntAggregator(n: Int) extends RegionValueAggregator {
@@ -61,6 +65,10 @@ class RegionValueTakeIntAggregator(n: Int) extends RegionValueAggregator {
   }
 
   def copy(): RegionValueTakeIntAggregator = new RegionValueTakeIntAggregator(n)
+
+  def clear() {
+    ab.clear()
+  }
 }
 
 class RegionValueTakeLongAggregator(n: Int) extends RegionValueAggregator {
@@ -90,6 +98,10 @@ class RegionValueTakeLongAggregator(n: Int) extends RegionValueAggregator {
   }
 
   def copy(): RegionValueTakeLongAggregator = new RegionValueTakeLongAggregator(n)
+
+  def clear() {
+    ab.clear()
+  }
 }
 
 class RegionValueTakeFloatAggregator(n: Int) extends RegionValueAggregator {
@@ -119,6 +131,10 @@ class RegionValueTakeFloatAggregator(n: Int) extends RegionValueAggregator {
   }
 
   def copy(): RegionValueTakeFloatAggregator = new RegionValueTakeFloatAggregator(n)
+
+  def clear() {
+    ab.clear()
+  }
 }
 
 class RegionValueTakeDoubleAggregator(n: Int) extends RegionValueAggregator {
@@ -148,4 +164,8 @@ class RegionValueTakeDoubleAggregator(n: Int) extends RegionValueAggregator {
   }
 
   def copy(): RegionValueTakeDoubleAggregator = new RegionValueTakeDoubleAggregator(n)
+
+  def clear() {
+    ab.clear()
+  }
 }

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -976,16 +976,20 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR) extends MatrixIR {
         val cols = rvb.end()
 
         val aggResultsOff = if (rvAggs.nonEmpty) {
-          val newRVAggs = rvAggs.map(_.copy())
+          var j = 0
+          while (j < rvAggs.length) {
+            rvAggs(j).clear()
+            j += 1
+          }
 
-          seqOps()(region, newRVAggs, 0, true, globals, false, cols, false, oldRow, false)
+          seqOps()(region, rvAggs, 0, true, globals, false, cols, false, oldRow, false)
 
           rvb.start(aggResultType)
           rvb.startStruct()
 
-          var j = 0
-          while (j < newRVAggs.length) {
-            newRVAggs(j).result(rvb)
+          j = 0
+          while (j < rvAggs.length) {
+            rvAggs(j).result(rvb)
             j += 1
           }
           rvb.endStruct()

--- a/src/main/scala/is/hail/stats/HistogramCombiner.scala
+++ b/src/main/scala/is/hail/stats/HistogramCombiner.scala
@@ -1,5 +1,6 @@
 package is.hail.stats
 
+import java.util
 import java.util.Arrays.binarySearch
 
 import is.hail.annotations.Annotation
@@ -56,4 +57,10 @@ class HistogramCombiner(val indices: Array[Double]) extends Serializable {
   }
 
   def toAnnotation: Annotation = Annotation(indices: IndexedSeq[Double], frequency: IndexedSeq[Long], nLess, nGreater)
+
+  def clear() {
+    nLess = 0L
+    nGreater = 0L
+    util.Arrays.fill(frequency, 0L)
+  }
 }

--- a/src/main/scala/is/hail/utils/MissingBooleanArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingBooleanArrayBuilder.scala
@@ -2,12 +2,12 @@ package is.hail.utils
 
 import is.hail.expr.types._
 import is.hail.annotations._
-import scala.collection.mutable.BitSet
+import scala.collection.mutable
 
 class MissingBooleanArrayBuilder {
   private var len = 0
-  private val elements = new BitSet()
-  private val isMissing = new BitSet()
+  private val elements = new mutable.BitSet()
+  private val isMissing = new mutable.BitSet()
 
   def addMissing() {
     isMissing.add(len)
@@ -48,5 +48,11 @@ class MissingBooleanArrayBuilder {
       i += 1
     }
     rvb.endArray()
+  }
+
+  def clear() {
+    len = 0
+    elements.clear()
+    isMissing.clear()
   }
 }

--- a/src/main/scala/is/hail/utils/MissingDoubleArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingDoubleArrayBuilder.scala
@@ -2,12 +2,12 @@ package is.hail.utils
 
 import is.hail.expr.types._
 import is.hail.annotations._
-import scala.collection.mutable.BitSet
+import scala.collection.mutable
 
 class MissingDoubleArrayBuilder {
   private var len = 0
   private val elements = new ArrayBuilder[Double]()
-  private val isMissing = new BitSet()
+  private val isMissing = new mutable.BitSet()
 
   def addMissing() {
     isMissing.add(len)
@@ -48,5 +48,11 @@ class MissingDoubleArrayBuilder {
       i += 1
     }
     rvb.endArray()
+  }
+
+  def clear() {
+    len = 0
+    elements.clear()
+    isMissing.clear()
   }
 }

--- a/src/main/scala/is/hail/utils/MissingFloatArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingFloatArrayBuilder.scala
@@ -2,12 +2,12 @@ package is.hail.utils
 
 import is.hail.expr.types._
 import is.hail.annotations._
-import scala.collection.mutable.BitSet
+import scala.collection.mutable
 
 class MissingFloatArrayBuilder {
   private var len = 0
   private val elements = new ArrayBuilder[Float]()
-  private val isMissing = new BitSet()
+  private val isMissing = new mutable.BitSet()
 
   def addMissing() {
     isMissing.add(len)
@@ -50,5 +50,11 @@ class MissingFloatArrayBuilder {
       i += 1
     }
     rvb.endArray()
+  }
+
+  def clear() {
+    len = 0
+    elements.clear()
+    isMissing.clear()
   }
 }

--- a/src/main/scala/is/hail/utils/MissingIntArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingIntArrayBuilder.scala
@@ -2,12 +2,12 @@ package is.hail.utils
 
 import is.hail.expr.types._
 import is.hail.annotations._
-import scala.collection.mutable.BitSet
+import scala.collection.mutable
 
 class MissingIntArrayBuilder {
   private var len = 0
   private val elements = new ArrayBuilder[Int]()
-  private val isMissing = new BitSet()
+  private val isMissing = new mutable.BitSet()
 
   def addMissing() {
     isMissing.add(len)
@@ -48,5 +48,11 @@ class MissingIntArrayBuilder {
       i += 1
     }
     rvb.endArray()
+  }
+
+  def clear() {
+    len = 0
+    elements.clear()
+    isMissing.clear()
   }
 }

--- a/src/main/scala/is/hail/utils/MissingLongArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingLongArrayBuilder.scala
@@ -2,12 +2,12 @@ package is.hail.utils
 
 import is.hail.expr.types._
 import is.hail.annotations._
-import scala.collection.mutable.BitSet
+import scala.collection.mutable
 
 class MissingLongArrayBuilder {
   private var len = 0
   private val elements = new ArrayBuilder[Long]()
-  private val isMissing = new BitSet()
+  private val isMissing = new mutable.BitSet()
 
   def addMissing() {
     isMissing.add(len)
@@ -50,5 +50,11 @@ class MissingLongArrayBuilder {
       i += 1
     }
     rvb.endArray()
+  }
+
+  def clear() {
+    len = 0
+    elements.clear()
+    isMissing.clear()
   }
 }


### PR DESCRIPTION
Use in MatrixMapRows to avoid region value allocations.
