### PR TITLE
minor import_bgen optimizations

### DIFF
--- a/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -87,8 +87,8 @@ object LoadBgen {
 
     val entryFields = Array(
       (includeGT, "GT" -> TCall()),
-      (includeGP, "GP" -> TArray(TFloat64())),
-      (includeDosage, "dosage" -> TFloat64()))
+      (includeGP, "GP" -> +TArray(+TFloat64())),
+      (includeDosage, "dosage" -> +TFloat64()))
       .withFilter(_._1).map(_._2)
 
     val matrixType: MatrixType = MatrixType.fromParts(


### PR DESCRIPTION
adding requiredness seemed to speed up import with GP by about 5%.  The GT stuff was smaller, maybe in the noise.