### PR TITLE
add ApplyIR to wrap ir => ir conversions in function registry

### DIFF
--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -83,6 +83,8 @@ object Children {
       none
     case Die(message) =>
       none
+    case ApplyIR(_, args, _) =>
+      args.toIndexedSeq
     case Apply(_, args) =>
       args.toIndexedSeq
     case ApplySpecial(_, args) =>

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -52,13 +52,7 @@ object Compile {
       .zipWithIndex
       .foldLeft(Env.empty[IR]) { case (e, ((n, t, _), i)) => e.bind(n, In(i, t)) }
 
-    def unwrap: IR => IR = {
-      case node: ApplyIR => Recur(unwrap)(node.explicitNode)
-      case node => Recur(unwrap)(node)
-    }
-
     ir = Subst(ir, env)
-    ir = unwrap(ir)
     assert(TypeToIRIntermediateClassTag(ir.typ) == classTag[R])
     Emit(ir, fb, tAggIn, if (tAggIn.isDefined) 2 else 1)
     (ir.typ, fb.result())
@@ -153,12 +147,7 @@ object CompileWithAggregators {
     val env = ((aggName, aggType, TypeToIRIntermediateClassTag(aggType)) +: args).zipWithIndex
       .foldLeft(Env.empty[IR]) { case (e, ((n, t, _), i)) => e.bind(n, In(i, t)) }
 
-    def unwrap: IR => IR = {
-      case node: ApplyIR => Recur(unwrap)(node.explicitNode)
-      case node => Recur(unwrap)(node)
-    }
-
-    val ir = unwrap(Subst(body, env))
+    val ir = Subst(body, env)
 
     val (postAggIR, aggResultType, aggIR, rvAggs) = ExtractAggregators(ir, aggType)
     val nAggs = rvAggs.length

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -113,6 +113,8 @@ object Copy {
         same
       case Die(message) =>
         same
+      case ApplyIR(fn, args, conversion) =>
+        ApplyIR(fn, newChildren.map(_.asInstanceOf[IR]), conversion)
       case Apply(fn, args) =>
         Apply(fn, newChildren.map(_.asInstanceOf[IR]))
       case ApplySpecial(fn, args) =>

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -572,6 +572,8 @@ private class Emit(
           mb.getArg(normalArgumentPosition(i))(typeToTypeInfo(typ)))
       case Die(m) =>
         present(Code._throw(Code.newInstance[RuntimeException, String](m)))
+      case ir@ApplyIR(fn, args, conversion) =>
+        emit(ir.explicitNode)
       case ir@Apply(fn, args) =>
         val impl = ir.implementation
         val unified = impl.unify(args.map(_.typ))

--- a/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -13,11 +13,7 @@ object ExtractAggregators {
   private case class IRAgg(ref: Ref, applyAggOp: ApplyAggOp) {}
 
   def apply(ir: IR, tAggIn: TAggregable): (IR, TStruct, IR, Array[RegionValueAggregator]) = {
-    def unwrap: IR => IR = {
-      case node: ApplyIR => Recur(unwrap)(node.explicitNode)
-      case node => Recur(unwrap)(node)
-    }
-    val (ir2, aggs) = extract(unwrap(ir), tAggIn)
+    val (ir2, aggs) = extract(ir.unwrap, tAggIn)
     val aggir = Begin(
       aggs.map(_.applyAggOp)
         .zipWithIndex

--- a/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -13,7 +13,11 @@ object ExtractAggregators {
   private case class IRAgg(ref: Ref, applyAggOp: ApplyAggOp) {}
 
   def apply(ir: IR, tAggIn: TAggregable): (IR, TStruct, IR, Array[RegionValueAggregator]) = {
-    val (ir2, aggs) = extract(ir, tAggIn)
+    def unwrap: IR => IR = {
+      case node: ApplyIR => Recur(unwrap)(node.explicitNode)
+      case node => Recur(unwrap)(node)
+    }
+    val (ir2, aggs) = extract(unwrap(ir), tAggIn)
     val aggir = Begin(
       aggs.map(_.applyAggOp)
         .zipWithIndex

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -128,6 +128,12 @@ final case class In(i: Int, typ: Type) extends IR
 // FIXME: should be type any
 final case class Die(message: String) extends IR { val typ = TVoid }
 
+final case class ApplyIR(function: String, args: Seq[IR], conversion: Seq[IR] => IR) extends IR {
+  val explicitNode: IR = conversion(args)
+
+  def typ: Type = explicitNode.typ
+}
+
 final case class Apply(function: String, args: Seq[IR]) extends IR {
   val implementation: IRFunctionWithoutMissingness =
     IRFunctionRegistry.lookupFunction(function, args.map(_.typ)).get.asInstanceOf[IRFunctionWithoutMissingness]

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -21,6 +21,13 @@ sealed trait IR extends BaseIR {
       case x: IR => x.size
       case _ => 0
     }.sum
+
+  private[this] def _unwrap: IR => IR = {
+    case node: ApplyIR => Recur(_unwrap)(node.explicitNode)
+    case node => Recur(_unwrap)(node)
+  }
+
+  def unwrap: IR = _unwrap(this)
 }
 
 object Literal {

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -353,6 +353,8 @@ object Interpret {
           oValue.asInstanceOf[Row].get(idx)
       case In(i, _) => args(i)
       case Die(message) => fatal(message)
+      case ir@ApplyIR(function, functionArgs, conversion) =>
+        interpret(ir.explicitNode, env, args, agg)
       case ir@Apply(function, functionArgs) =>
 
         val argTuple = TTuple(functionArgs.map(_.typ): _*)

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -26,11 +26,7 @@ object Interpret {
       case ((e1, e2), (k, (value, t))) => (e1.bind(k, t), e2.bind(k, value))
     }
 
-    def unwrap: IR => IR = {
-      case node: ApplyIR => Recur(unwrap)(node.explicitNode)
-      case node => Recur(unwrap)(node)
-    }
-    var ir = unwrap(ir0)
+    var ir = ir0.unwrap
     if (optimize)
       ir = Optimize(ir)
     TypeCheck(ir, agg.map(_._1), typeEnv)

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -26,7 +26,11 @@ object Interpret {
       case ((e1, e2), (k, (value, t))) => (e1.bind(k, t), e2.bind(k, value))
     }
 
-    var ir = ir0
+    def unwrap: IR => IR = {
+      case node: ApplyIR => Recur(unwrap)(node.explicitNode)
+      case node => Recur(unwrap)(node)
+    }
+    var ir = unwrap(ir0)
     if (optimize)
       ir = Optimize(ir)
     TypeCheck(ir, agg.map(_._1), typeEnv)

--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -65,6 +65,7 @@ object Pretty {
             case AggFlatMap(_, name, _) => name
             case ApplyAggOp(_, op, _) => op.getClass.getName.split("\\.").last
             case ArrayFor(_, valueName, _) => s"$valueName"
+            case ApplyIR(function, _, _) => function
             case Apply(function, _) => function
             case ApplySpecial(function, _) => function
             case In(i, _) => i.toString

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -191,6 +191,8 @@ object TypeCheck {
       case In(i, typ) =>
         assert(typ != null)
       case Die(msg) =>
+      case x@ApplyIR(fn, args, conversion) =>
+        check(x.explicitNode)
       case x@Apply(fn, args) =>
         val impl = x.implementation
         args.foreach(check(_))

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -45,7 +45,7 @@ object IRFunctionRegistry {
     }
     val validIR = lookupInRegistry[Conversion](irRegistry, name, args, findIR).map {
       case (_, conversion) =>
-        ApplyIR(name, _, conversion)
+        { irs: Seq[IR] => ApplyIR(name, irs, conversion) }
     }
 
     val validMethods = lookupFunction(name, args).map { f =>

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -43,7 +43,10 @@ object IRFunctionRegistry {
         (ts, t2s).zipped.forall(_.unify(_))
       }
     }
-    val validIR = lookupInRegistry[Conversion](irRegistry, name, args, findIR).map(_._2)
+    val validIR = lookupInRegistry[Conversion](irRegistry, name, args, findIR).map {
+      case (_, conversion) =>
+        ApplyIR(name, _, conversion)
+    }
 
     val validMethods = lookupFunction(name, args).map { f =>
       { irArgs: Seq[IR] =>

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -45,7 +45,12 @@ object IRFunctionRegistry {
     }
     val validIR = lookupInRegistry[Conversion](irRegistry, name, args, findIR).map {
       case (_, conversion) =>
-        { irs: Seq[IR] => ApplyIR(name, irs, conversion) }
+        { irs: Seq[IR] =>
+          if (args.forall(!_.isInstanceOf[TAggregable]))
+            ApplyIR(name, irs, conversion)
+          else
+            conversion(irs)
+        }
     }
 
     val validMethods = lookupFunction(name, args).map { f =>

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1759,7 +1759,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
           "va" -> ir.Ref("row", entriesRowType),
           "sa" -> ir.Ref("row", entriesRowType))
 
-        val sqir = ir.Subst(qir, ir.Env.empty, aggEnv, Some(et.aggType()))
+        val sqir = ir.Subst(qir.unwrap, ir.Env.empty, aggEnv, Some(et.aggType()))
         et.aggregate(sqir)
       case _ =>
         log.warn(s"aggregateEntries found no AST to IR conversion: ${ PrettyAST(queryAST) }")
@@ -1820,7 +1820,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
       case Some(qir) if useIR(colAxis, queryAST) =>
         val ct = colsTable()
         val aggEnv = new ir.Env[ir.IR].bind("sa" -> ir.Ref("row", ct.typ.rowType))
-        val sqir = ir.Subst(qir, ir.Env.empty, aggEnv, Some(ct.aggType()))
+        val sqir = ir.Subst(qir.unwrap, ir.Env.empty, aggEnv, Some(ct.aggType()))
         ct.aggregate(sqir)
       case _ =>
         val (t, f) = Parser.parseExpr(expr, ec)
@@ -1854,7 +1854,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
       case Some(qir) if useIR(rowAxis, qAST) =>
         val rt = rowsTable()
         val aggEnv = new ir.Env[ir.IR].bind("va" -> ir.Ref("row", rt.typ.rowType))
-        val sqir = ir.Subst(qir, ir.Env.empty, aggEnv, Some(rt.aggType()))
+        val sqir = ir.Subst(qir.unwrap, ir.Env.empty, aggEnv, Some(rt.aggType()))
         rt.aggregate(sqir)
       case _ =>
         log.warn(s"aggregate_rows found no AST to IR conversion: ${ PrettyAST(qAST) }")

--- a/src/test/scala/is/hail/expr/AstToIrSuite.scala
+++ b/src/test/scala/is/hail/expr/AstToIrSuite.scala
@@ -12,7 +12,13 @@ class ASTToIRSuite extends TestNGSuite {
       "aggregable" -> (0, TAggregable(TInt64(),
         Map("agg" -> (0, TInt64()),
           "something" -> (1, TInt64())))))))
-    ast.toIR(Some("aggregable"))
+
+    def unwrap: IR => IR = {
+      case node: ApplyIR => Recur(unwrap)(node.explicitNode)
+      case node => Recur(unwrap)(node)
+    }
+
+    ast.toIR(Some("aggregable")).map(unwrap)
   }
 
   @Test

--- a/src/test/scala/is/hail/expr/AstToIrSuite.scala
+++ b/src/test/scala/is/hail/expr/AstToIrSuite.scala
@@ -13,12 +13,7 @@ class ASTToIRSuite extends TestNGSuite {
         Map("agg" -> (0, TInt64()),
           "something" -> (1, TInt64())))))))
 
-    def unwrap: IR => IR = {
-      case node: ApplyIR => Recur(unwrap)(node.explicitNode)
-      case node => Recur(unwrap)(node)
-    }
-
-    ast.toIR(Some("aggregable")).map(unwrap)
+    ast.toIR(Some("aggregable")).map(_.unwrap)
   }
 
   @Test

--- a/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -2,12 +2,15 @@ package is.hail.expr.ir
 
 import java.io.PrintWriter
 
+import is.hail.SparkSuite
 import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.expr.ir.functions.{IRFunctionRegistry, RegistryFunctions}
 import is.hail.expr.types._
 import org.testng.annotations.Test
-import is.hail.expr.{EvalContext, FunType, Parser}
+import is.hail.expr.{EvalContext, Parser}
+import is.hail.table.Table
+import is.hail.utils.FastSeq
 import is.hail.variant.Call2
 
 import scala.reflect.ClassTag
@@ -28,6 +31,9 @@ class ScalaTestCompanion {
 object TestRegisterFunctions extends RegistryFunctions {
   def registerAll() {
     registerIR("addone", TInt32())(ApplyBinaryPrimOp(Add(), _, I32(1)))
+    registerIR("sumaggregator32", TAggregable(TInt32())) { ir =>
+      ApplyAggOp(AggMap(ir, "__i", Cast(Ref("__i", TInt32()), TInt64())), Sum(), FastSeq())
+    }
     registerJavaStaticFunction("compare", TInt32(), TInt32(), TInt32())(classOf[java.lang.Integer], "compare")
     registerScalaFunction("foobar1", TInt32())(ScalaTestObject.getClass, "testFunction")
     registerScalaFunction("foobar2", TInt32())(ScalaTestCompanion.getClass, "testFunction")
@@ -36,7 +42,7 @@ object TestRegisterFunctions extends RegistryFunctions {
   }
 }
 
-class FunctionSuite {
+class FunctionSuite extends SparkSuite {
 
   val ec = EvalContext()
   val region = Region()
@@ -95,6 +101,18 @@ class FunctionSuite {
     val f = toF[Int, Int](ir)
     val actual = f(region, 5, false)
     assert(actual == 6)
+  }
+
+  @Test
+  def testAggregatorConversion() {
+    val t = Table.range(hc, 10)
+
+    val tagg = TAggregable(t.signature)
+    val idxField = AggMap(AggIn(tagg), "row", GetField(Ref("row", t.signature), "idx"))
+    val ir = lookup("sumaggregator32", TAggregable(TInt32()))(idxField)
+
+    val actual = Interpret[Long](TableAggregate(t.tir, ir))
+    assert(actual == 45)
   }
 
   @Test

--- a/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -27,7 +27,7 @@ class ScalaTestCompanion {
 
 object TestRegisterFunctions extends RegistryFunctions {
   def registerAll() {
-    registerIR("testIR", TInt32())(ApplyBinaryPrimOp(Add(), _, I32(1)))
+    registerIR("addone", TInt32())(ApplyBinaryPrimOp(Add(), _, I32(1)))
     registerJavaStaticFunction("compare", TInt32(), TInt32(), TInt32())(classOf[java.lang.Integer], "compare")
     registerScalaFunction("foobar1", TInt32())(ScalaTestObject.getClass, "testFunction")
     registerScalaFunction("foobar2", TInt32())(ScalaTestCompanion.getClass, "testFunction")
@@ -90,8 +90,8 @@ class FunctionSuite {
   }
 
   @Test
-  def testIR() {
-    val ir = lookup("testIR", TInt32())(In(0, TInt32()))
+  def testIRConversion() {
+    val ir = lookup("addone", TInt32())(In(0, TInt32()))
     val f = toF[Int, Int](ir)
     val actual = f(region, 5, false)
     assert(actual == 6)

--- a/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -27,6 +27,7 @@ class ScalaTestCompanion {
 
 object TestRegisterFunctions extends RegistryFunctions {
   def registerAll() {
+    registerIR("testIR", TInt32())(ApplyBinaryPrimOp(Add(), _, I32(1)))
     registerJavaStaticFunction("compare", TInt32(), TInt32(), TInt32())(classOf[java.lang.Integer], "compare")
     registerScalaFunction("foobar1", TInt32())(ScalaTestObject.getClass, "testFunction")
     registerScalaFunction("foobar2", TInt32())(ScalaTestCompanion.getClass, "testFunction")
@@ -86,6 +87,14 @@ class FunctionSuite {
     val f = toF[Int](ir)
     val actual = f(region)
     assert(actual == 1)
+  }
+
+  @Test
+  def testIR() {
+    val ir = lookup("testIR", TInt32())(In(0, TInt32()))
+    val f = toF[Int, Int](ir)
+    val actual = f(region, 5, false)
+    assert(actual == 6)
   }
 
   @Test


### PR DESCRIPTION
@cseed @tpoterba 

this was my solution to wrapping the `registerIR` calls to the function registry as one unit. The `fn` tag at the beginning is more or less just a tag on what the function name was.

If this looks ok, maybe we can just expose the ability to create and register these from python (maybe with uids as function names for distinctness) to wrap things like `alt_allele` and other things where the IR gets big and explody.