### PR TITLE
add IR nodes for SetContains, DictContains, DictGet

### DIFF
--- a/src/main/scala/is/hail/expr/ir/BinarySearch.scala
+++ b/src/main/scala/is/hail/expr/ir/BinarySearch.scala
@@ -1,0 +1,77 @@
+package is.hail.expr.ir
+
+import is.hail.annotations.{CodeOrdering, Region}
+import is.hail.asm4s._
+import is.hail.expr.types._
+import is.hail.utils._
+
+class BinarySearch(mb: EmitMethodBuilder, typ: TContainer, keyOnly: Boolean) {
+
+  val elt: Type = typ.elementType
+  val ti: TypeInfo[_] = typeToTypeInfo(elt)
+
+  val (compare: CodeOrdering.F[Int], equiv: CodeOrdering.F[Boolean], findElt: EmitMethodBuilder, t: Type) = if (keyOnly) {
+    val ttype = coerce[TBaseStruct](elt)
+    require(ttype.size == 2)
+    val kt = ttype.types(0)
+    val findMB = mb.fb.newMethod(Array[TypeInfo[_]](typeInfo[Region], typeInfo[Long], typeInfo[Boolean], typeToTypeInfo(kt)), typeInfo[Int])
+    val mk2l = findMB.newLocal[Boolean]
+    val mk2l1 = mb.newLocal[Boolean]
+
+    val comp: CodeOrdering.F[Int] = {
+      case (r1: Code[Region], (mk1: Code[Boolean], k1: Code[_]), r2: Code[Region], (m2: Code[Boolean], v2: Code[Long])) =>
+        val mk2 = Code(mk2l := m2 || ttype.isFieldMissing(r2, v2, 0), mk2l)
+        val k2 = mk2l.mux(defaultValue(kt), r2.loadIRIntermediate(kt)(ttype.fieldOffset(v2, 0)))
+        findMB.getCodeOrdering[Int](kt, CodeOrdering.compare, missingGreatest = true)(r1, (mk1, k1), r2, (mk2, k2))
+    }
+    val ceq: CodeOrdering.F[Boolean] = {
+      case (r1: Code[Region], (mk1: Code[Boolean], k1: Code[_]), r2: Code[Region], (m2: Code[Boolean], v2: Code[Long])) =>
+        val mk2 = Code(mk2l1 := m2 || ttype.isFieldMissing(r2, v2, 0), mk2l1)
+        val k2 = mk2l1.mux(defaultValue(kt), r2.loadIRIntermediate(kt)(ttype.fieldOffset(v2, 0)))
+        mb.getCodeOrdering[Boolean](kt, CodeOrdering.equiv, missingGreatest = true)(r1, (mk1, k1), r2, (mk2, k2))
+    }
+    (comp, ceq, findMB, kt)
+  } else
+    (mb.getCodeOrdering[Int](elt, CodeOrdering.compare, missingGreatest = true),
+      mb.getCodeOrdering[Boolean](elt, CodeOrdering.equiv, missingGreatest = true),
+      mb.fb.newMethod(Array[TypeInfo[_]](typeInfo[Region], typeInfo[Long], typeInfo[Boolean], typeToTypeInfo(elt)), typeInfo[Int]), elt)
+
+  private[this] val region = findElt.getArg[Region](1).load()
+  private[this] val array = findElt.getArg[Long](2)
+  private[this] val m = findElt.getArg[Boolean](3)
+  private[this] val e = findElt.getArg(4)(typeToTypeInfo(t))
+  private[this] val len = findElt.newLocal[Int]
+  private[this] val i = findElt.newLocal[Int]
+  private[this] val low = findElt.newLocal[Int]
+  private[this] val high = findElt.newLocal[Int]
+
+  def cmp(i: Code[Int]): Code[Int] =
+    compare(region, (m, e),
+      region, (typ.isElementMissing(region, array, i),
+        region.loadIRIntermediate(elt)(typ.elementOffset(array, len, i))))
+
+  // return smallest i such that elem <= array(i)
+  findElt.emit(Code(
+    len := typ.loadLength(region, array),
+    low := 0,
+    high := len - 1,
+    Code.whileLoop(low < high,
+      i := (low + high) / 2,
+      (cmp(i) <= 0).mux(
+        high := i,
+        low := i + 1)),
+    low))
+
+  def getClosestIndex(array: Code[Long], m: Code[Boolean], v: Code[_]): Code[Int] = {
+    val region = mb.getArg[Region](1).load()
+    findElt.invoke(region, array, m, v)
+  }
+
+  def isIndexEqual(array: Code[Long], i: Code[Int], m: Code[Boolean], v: Code[_]): Code[Boolean] = {
+    val region = mb.getArg[Region](1).load()
+    val len = typ.loadLength(region, array)
+    !len.ceq(0) && equiv(region, (m, v), region,
+      (typ.isElementMissing(region, array, i),
+        region.loadIRIntermediate(elt)(typ.elementOffset(array, len, i))))
+  }
+}

--- a/src/main/scala/is/hail/expr/ir/BinarySearch.scala
+++ b/src/main/scala/is/hail/expr/ir/BinarySearch.scala
@@ -17,6 +17,8 @@ class BinarySearch(mb: EmitMethodBuilder, typ: TContainer, keyOnly: Boolean) {
     val findMB = mb.fb.newMethod(Array[TypeInfo[_]](typeInfo[Region], typeInfo[Long], typeInfo[Boolean], typeToTypeInfo(kt)), typeInfo[Int])
     val mk2l = findMB.newLocal[Boolean]
     val mk2l1 = mb.newLocal[Boolean]
+    val v2l = findMB.newLocal[Long]
+    val v2l1 = mb.newLocal[Long]
 
     val comp: CodeOrdering.F[Int] = {
       case (r1: Code[Region], (mk1: Code[Boolean], k1: Code[_]), r2: Code[Region], (m2: Code[Boolean], v2: Code[Long])) =>

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -45,6 +45,10 @@ object Children {
       Array(a)
     case ToArray(a) =>
       Array(a)
+    case SetContains(set, elem) =>
+      Array(set, elem)
+    case DictGet(dict, key) =>
+      Array(dict, key)
     case ArrayMap(a, name, body) =>
       Array(a, body)
     case ArrayFilter(a, name, cond) =>

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -47,6 +47,8 @@ object Children {
       Array(a)
     case SetContains(set, elem) =>
       Array(set, elem)
+    case DictContains(dict, key) =>
+      Array(dict, key)
     case DictGet(dict, key) =>
       Array(dict, key)
     case ArrayMap(a, name, body) =>

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -62,6 +62,12 @@ object Copy {
       case ToArray(_) =>
         val IndexedSeq(a: IR) = newChildren
         ToArray(a)
+      case SetContains(_, _) =>
+        val IndexedSeq(set: IR, elem: IR) = newChildren
+        SetContains(set, elem)
+      case DictGet(_, _) =>
+        val IndexedSeq(dict: IR, key: IR) = newChildren
+        DictGet(dict, key)
       case ArrayMap(_, name, _) =>
         val IndexedSeq(a: IR, body: IR) = newChildren
         ArrayMap(a, name, body)

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -65,6 +65,9 @@ object Copy {
       case SetContains(_, _) =>
         val IndexedSeq(set: IR, elem: IR) = newChildren
         SetContains(set, elem)
+      case DictContains(_, _) =>
+        val IndexedSeq(dict: IR, key: IR) = newChildren
+        DictContains(dict, key)
       case DictGet(_, _) =>
         val IndexedSeq(dict: IR, key: IR) = newChildren
         DictGet(dict, key)

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -328,6 +328,53 @@ private class Emit(
 
       case ToArray(a) =>
         emit(a)
+
+      case SetContains(set, elem) =>
+        val s = emit(set)
+        val e = emit(elem)
+        val bs = new BinarySearch(mb, coerce[TSet](set.typ), keyOnly = false)
+        val smx = mb.newLocal[Boolean]
+        val svx = mb.newLocal[Long]
+        val emx = mb.newLocal[Boolean]
+        val evx = mb.newLocal()(typeToTypeInfo(elem.typ))
+        val isIn = bs.isIndexEqual(svx, bs.getClosestIndex(svx, emx, evx), emx, evx)
+        EmitTriplet(
+          Code(s.setup, e.setup),
+          Code(smx := s.m, smx),
+          Code(smx || Code(svx := s.value[Long], emx := e.m, evx.storeAny(e.v), isIn)))
+
+      case x@DictGet(dict, key) =>
+        val dtype = coerce[TDict](dict.typ)
+        val d = emit(dict)
+        val k = emit(key)
+        val bs = new BinarySearch(mb, dtype, keyOnly = true)
+        val dmx = mb.newLocal[Boolean]
+        val dvx = mb.newLocal[Long]
+        val kmx = mb.newLocal[Boolean]
+        val kvx = mb.newLocal()(typeToTypeInfo(key.typ))
+        val i = mb.newLocal[Int]
+        val pair = mb.newLocal[Long]
+        val mx = mb.newLocal[Boolean]
+        val isEq = mb.newLocal[Boolean]
+        val elt = coerce[TBaseStruct](dtype.elementType)
+        val keyIn = Code(
+          dvx := d.value[Long],
+          kmx := k.m,
+          kmx.mux(Code._empty, kvx.storeAny(k.v)),
+          i := bs.getClosestIndex(dvx, kmx, kvx),
+          isEq := bs.isIndexEqual(dvx, i, kmx, kvx),
+          isEq)
+        val isMissing = Code(
+          pair := dtype.loadElement(region, dvx, i),
+          elt.isFieldMissing(region, pair, 1))
+        val getValue =
+          region.loadIRIntermediate(x.typ)(elt.fieldOffset(pair, 1))
+
+        EmitTriplet(
+          Code(d.setup, k.setup),
+          Code(mx := (Code(dmx := d.m, dvx := 0L, kmx := false, kvx.storeAny(defaultValue(key.typ)), i := -1, pair := 0L, dmx) || !keyIn || isMissing), const("mx: ").concat(mx.toS).println(), mx),
+          mx.mux(defaultValue(x.typ), getValue))
+
       case _: ArrayMap | _: ArrayFilter | _: ArrayRange | _: ArrayFlatMap =>
         val elt = coerce[TArray](ir.typ).elementType
         val srvb = new StagedRegionValueBuilder(mb, ir.typ)

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -372,15 +372,23 @@ private class Emit(
           i := bs.getClosestIndex(dvx, kmx, kvx),
           isEq := bs.isIndexEqual(dvx, i, kmx, kvx),
           isEq)
-        val isMissing = Code(
+        val isValueMissing = Code(
           pair := dtype.loadElement(region, dvx, i),
           elt.isFieldMissing(region, pair, 1))
         val getValue =
           region.loadIRIntermediate(x.typ)(elt.fieldOffset(pair, 1))
 
+        val setupDefaults = Code(
+          dmx := d.m,
+          dvx := 0L,
+          kmx := false,
+          kvx.storeAny(defaultValue(key.typ)),
+          i := -1,
+          pair := 0L)
+
         EmitTriplet(
           Code(d.setup, k.setup),
-          Code(mx := (Code(dmx := d.m, dvx := 0L, kmx := false, kvx.storeAny(defaultValue(key.typ)), i := -1, pair := 0L, dmx) || !keyIn || isMissing), const("mx: ").concat(mx.toS).println(), mx),
+          Code(setupDefaults, mx := (dmx || !keyIn || isValueMissing), mx),
           mx.mux(defaultValue(x.typ), getValue))
 
       case _: ArrayMap | _: ArrayFilter | _: ArrayRange | _: ArrayFlatMap =>

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -349,7 +349,10 @@ private class Emit(
         EmitTriplet(
           Code(s.setup, e.setup),
           Code(smx := s.m, smx),
-          Code(smx || Code(svx := s.value[Long], emx := e.m, evx.storeAny(e.v), isIn)))
+          Code(smx || Code(svx := s.value[Long],
+            emx := e.m,
+            evx.storeAny(emx.mux(defaultValue(elem.typ), e.v)),
+            isIn)))
 
       case x@DictGet(dict, key) =>
         val dtype = coerce[TDict](dict.typ)
@@ -389,7 +392,7 @@ private class Emit(
         EmitTriplet(
           Code(d.setup, k.setup),
           Code(setupDefaults, mx := (dmx || !keyIn || isValueMissing), mx),
-          mx.mux(defaultValue(x.typ), getValue))
+          getValue)
 
       case _: ArrayMap | _: ArrayFilter | _: ArrayRange | _: ArrayFlatMap =>
         val elt = coerce[TArray](ir.typ).elementType

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -329,10 +329,18 @@ private class Emit(
       case ToArray(a) =>
         emit(a)
 
-      case SetContains(set, elem) =>
+      case x@(_: SetContains | _: DictContains) =>
+        val (set, elem, bs) = x match {
+          case SetContains(set, elem) =>
+            val bs = new BinarySearch(mb, coerce[TSet](set.typ), keyOnly = false)
+            (set, elem, bs)
+          case DictContains(dict, key) =>
+            val bs = new BinarySearch(mb, coerce[TDict](dict.typ), keyOnly = true)
+            (dict, key, bs)
+        }
         val s = emit(set)
         val e = emit(elem)
-        val bs = new BinarySearch(mb, coerce[TSet](set.typ), keyOnly = false)
+
         val smx = mb.newLocal[Boolean]
         val svx = mb.newLocal[Long]
         val emx = mb.newLocal[Boolean]

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -349,7 +349,7 @@ private class Emit(
         EmitTriplet(
           Code(s.setup, e.setup),
           Code(smx := s.m, smx),
-          Code(smx || Code(svx := s.value[Long],
+          Code(Code(svx := s.value[Long],
             emx := e.m,
             evx.storeAny(emx.mux(defaultValue(elem.typ), e.v)),
             isIn)))
@@ -449,9 +449,9 @@ private class Emit(
         val tarray = coerce[TArray](a.typ)
         val tti = typeToTypeInfo(typ)
         val eti = typeToTypeInfo(tarray.elementType)
-        val xmv = mb.newField[Boolean]()
+        val xmv = mb.newField[Boolean](name2+"_missing")
         val xvv = coerce[Any](mb.newField(name2)(eti))
-        val xmout = mb.newField[Boolean]()
+        val xmout = mb.newField[Boolean](name1+"_missing")
         val xvout = coerce[Any](mb.newField(name1)(tti))
         val i = mb.newLocal[Int]("af_i")
         val len = mb.newLocal[Int]("af_len")

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -82,6 +82,7 @@ final case class ToDict(a: IR) extends InferIR
 final case class ToArray(a: IR) extends InferIR
 
 final case class SetContains(set: IR, elem: IR) extends IR { val typ: Type = TBoolean() }
+final case class DictContains(set: IR, elem: IR) extends IR { val typ: Type = TBoolean() }
 final case class DictGet(set: IR, key: IR) extends InferIR
 
 final case class ArrayMap(a: IR, name: String, body: IR) extends InferIR {

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -81,6 +81,9 @@ final case class ToSet(a: IR) extends InferIR
 final case class ToDict(a: IR) extends InferIR
 final case class ToArray(a: IR) extends InferIR
 
+final case class SetContains(set: IR, elem: IR) extends IR { val typ: Type = TBoolean() }
+final case class DictGet(set: IR, key: IR) extends InferIR
+
 final case class ArrayMap(a: IR, name: String, body: IR) extends InferIR {
   override def typ: TArray = coerce[TArray](super.typ)
   def elementTyp: Type = typ.elementType

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -28,6 +28,8 @@ object Infer {
         TDict(elt.types(0), elt.types(1))
       case x@ToArray(a) =>
         TArray(coerce[TContainer](a.typ).elementType)
+      case x@DictGet(dict, key) =>
+        -coerce[TDict](dict.typ).valueType
       case x@ArrayMap(a, name, body) =>
         TArray(-body.typ)
       case x@ArrayFilter(a, name, cond) =>

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -223,6 +223,42 @@ object Interpret {
           null
         else
           aValue.asInstanceOf[IndexedSeq[Row]].filter(_ != null).map{ case Row(k, v) => (k, v) }.toMap
+
+      case ToArray(c) =>
+        val cValue = interpret(c, env, args, agg)
+        if (cValue == null)
+          null
+        else
+          cValue match {
+            case s: Set[Any] => s.toIndexedSeq
+            case d: Map[Any, Any] => d.toIndexedSeq
+            case a => a
+          }
+
+      case SetContains(s, elem) =>
+        val sValue = interpret(s, env, args, agg)
+        val eValue = interpret(elem, env, args, agg)
+        if (sValue == null)
+          null
+        else
+          sValue.asInstanceOf[Set[Any]].contains(eValue)
+
+      case DictContains(d, key) =>
+        val dValue = interpret(d, env, args, agg)
+        val kValue = interpret(key, env, args, agg)
+        if (dValue == null)
+          null
+        else
+          dValue.asInstanceOf[Map[Any, Any]].contains(kValue)
+
+      case DictGet(d, key) =>
+        val dValue = interpret(d, env, args, agg)
+        val kValue = interpret(key, env, args, agg)
+        if (dValue == null)
+          null
+        else
+          dValue.asInstanceOf[Map[Any, Any]].getOrElse(kValue, null)
+
       case ArrayMap(a, name, body) =>
         val aValue = interpret(a, env, args, agg)
         if (aValue == null)

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -89,7 +89,7 @@ object TypeCheck {
         assert(coerce[TBaseStruct](coerce[TArray](a.typ).elementType).size == 2)
       case x@ToArray(a) =>
         check(a)
-        assert(a.typ.isInstanceOf[TArray])
+        assert(a.typ.isInstanceOf[TContainer])
       case x@SetContains(set, elem) =>
         check(set)
         check(elem)

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -95,6 +95,11 @@ object TypeCheck {
         check(elem)
         assert(set.typ.isInstanceOf[TSet])
         assert(-coerce[TSet](set.typ).elementType == elem.typ)
+      case x@DictContains(dict, key) =>
+        check(dict)
+        check(key)
+        assert(dict.typ.isInstanceOf[TDict])
+        assert(-coerce[TDict](dict.typ).keyType == key.typ)
       case x@DictGet(dict, key) =>
         check(dict)
         check(key)

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -90,6 +90,16 @@ object TypeCheck {
       case x@ToArray(a) =>
         check(a)
         assert(a.typ.isInstanceOf[TArray])
+      case x@SetContains(set, elem) =>
+        check(set)
+        check(elem)
+        assert(set.typ.isInstanceOf[TSet])
+        assert(-coerce[TSet](set.typ).elementType == elem.typ)
+      case x@DictGet(dict, key) =>
+        check(dict)
+        check(key)
+        assert(dict.typ.isInstanceOf[TDict])
+        assert(-coerce[TDict](dict.typ).keyType == key.typ)
       case x@ArrayMap(a, name, body) =>
         check(a)
         val tarray = coerce[TArray](a.typ)

--- a/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -348,12 +348,12 @@ class OrderingSuite {
     p.check()
   }
 
-  @Test def test() {
+  @Test def testContainsWithArrayFold() {
 
     val set1 = ToSet(MakeArray(Seq(I32(1), I32(4)), TArray(TInt32())))
     val set2 = ToSet(MakeArray(Seq(I32(9), I32(1), I32(4)), TArray(TInt32())))
     val ir =
-      ArrayFold(set1, True(), "accumulator", "setelt",
+      ArrayFold(ToArray(set1), True(), "accumulator", "setelt",
       ApplySpecial("&&",
         FastSeq(
           Ref("accumulator", TBoolean()),

--- a/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -350,30 +350,21 @@ class OrderingSuite {
 
   @Test def test() {
 
-    val irF: (IR, IR) => IR = { (set1: IR, set2: IR) => ArrayFold(ToArray(set1), True(), "accumulator", "setelt",
+    val set1 = ToSet(MakeArray(Seq(I32(1), I32(4)), TArray(TInt32())))
+    val set2 = ToSet(MakeArray(Seq(I32(9), I32(1), I32(4)), TArray(TInt32())))
+    val ir =
+      ArrayFold(set1, True(), "accumulator", "setelt",
       ApplySpecial("&&",
         FastSeq(
           Ref("accumulator", TBoolean()),
-          SetContains(set1, Ref("setelt", TInt32()))))) }
-    val set1 = Set(1, 4)
-    val set2 = Set(9, 1, 4)
+          SetContains(set2, Ref("setelt", TInt32())))))
 
-    val fb = EmitFunctionBuilder[Region, Long, Boolean, Long, Boolean, Boolean]
-    Emit(irF(In(0, TSet(TInt32())), In(1, TSet(TInt32()))), fb)
+    val fb = EmitFunctionBuilder[Region, Boolean]
+    Emit(ir, fb)
 
     val f = fb.result()()
     Region.scoped { region =>
-      val rvb = new RegionValueBuilder(region)
-
-      rvb.start(TSet(TInt32()))
-      rvb.addAnnotation(TSet(TInt32()), set1)
-      val o1 = rvb.end()
-
-      rvb.start(TSet(TInt32()))
-      rvb.addAnnotation(TSet(TInt32()), set2)
-      val o2 = rvb.end()
-
-      assert(f(region, o1, false, o2, false))
+      assert(f(region))
     }
   }
 }


### PR DESCRIPTION
Uses binary search on sorted array representation of sets and dicts. The binary search algorithm is just pulled from the old `is.hail.utils.BinarySearch` which was here:
https://github.com/hail-is/hail/pull/2895/files#diff-c4570442b21e7226350aeeae4e958dc9