### PR TITLE
don't re-parse reference genome in emitted code

### DIFF
--- a/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -44,8 +44,6 @@ class EmitMethodBuilder(
   returnTypeInfo: TypeInfo[_]
 ) extends MethodBuilder(fb, mname, parameterTypeInfo, returnTypeInfo) {
 
-  def numReferenceGenomes: Int = fb.numReferenceGenomes
-
   def getReferenceGenome(rg: ReferenceGenome): Code[ReferenceGenome] =
     fb.getReferenceGenome(rg)
 
@@ -63,21 +61,15 @@ class EmitFunctionBuilder[F >: Null](
   packageName: String = "is/hail/codegen/generated"
 )(implicit interfaceTi: TypeInfo[F]) extends FunctionBuilder[F](parameterTypeInfo, returnTypeInfo, packageName) {
 
-  private[this] val rgMap: mutable.Map[ReferenceGenome, Code[ReferenceGenome]] =
-    mutable.Map[ReferenceGenome, Code[ReferenceGenome]]()
-
   private[this] val typMap: mutable.Map[Type, Code[Type]] =
     mutable.Map[Type, Code[Type]]()
 
   private[this] val compareMap: mutable.Map[(Type, CodeOrdering.Op, Boolean), CodeOrdering.F[_]] =
     mutable.Map[(Type, CodeOrdering.Op, Boolean), CodeOrdering.F[_]]()
 
-  def numReferenceGenomes: Int = rgMap.size
-
   def getReferenceGenome(rg: ReferenceGenome): Code[ReferenceGenome] =
-    rgMap.getOrElseUpdate(rg, newLazyField[ReferenceGenome](
       Code.invokeScalaObject[String, ReferenceGenome](
-        ReferenceGenome.getClass, "getReference", const(rg.name))))
+        ReferenceGenome.getClass, "getReference", const(rg.name))
 
   def numTypes: Int = typMap.size
 

--- a/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -75,7 +75,9 @@ class EmitFunctionBuilder[F >: Null](
   def numReferenceGenomes: Int = rgMap.size
 
   def getReferenceGenome(rg: ReferenceGenome): Code[ReferenceGenome] =
-    rgMap.getOrElseUpdate(rg, newLazyField[ReferenceGenome](rg.codeSetup))
+    rgMap.getOrElseUpdate(rg, newLazyField[ReferenceGenome](
+      Code.invokeScalaObject[String, ReferenceGenome](
+        ReferenceGenome.getClass, "getReference", const(rg.name))))
 
   def numTypes: Int = typMap.size
 

--- a/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -456,19 +456,6 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
     implicit val formats: Formats = defaultJSONFormats
     Serialization.write(jrg)
   }
-
-  def codeSetup: Code[ReferenceGenome] = {
-    val json = toJSONString
-    val chunkSize = (1 << 16) - 1
-    val nChunks = (json.length() - 1) / chunkSize + 1
-    assert(nChunks > 0)
-
-    val chunks = Array.tabulate(nChunks){ i => json.slice(i * chunkSize, (i + 1) * chunkSize) }
-    val stringAssembler =
-      chunks.tail.foldLeft[Code[String]](chunks.head) { (c, s) => c.invoke[String, String]("concat", s) }
-
-    Code.invokeScalaObject[String, ReferenceGenome](ReferenceGenome.getClass(), "parse", stringAssembler)
-  }
 }
 
 object ReferenceGenome {
@@ -526,11 +513,6 @@ object ReferenceGenome {
   def read(is: InputStream): ReferenceGenome = {
     implicit val formats = defaultJSONFormats
     JsonMethods.parse(is).extract[JSONExtractReferenceGenome].toReferenceGenome
-  }
-
-  def parse(str: String): ReferenceGenome = {
-    implicit val formats = defaultJSONFormats
-    JsonMethods.parse(str).extract[JSONExtractReferenceGenome].toReferenceGenome
   }
 
   def fromResource(file: String): ReferenceGenome = {

--- a/src/test/scala/is/hail/variant/ReferenceGenomeSuite.scala
+++ b/src/test/scala/is/hail/variant/ReferenceGenomeSuite.scala
@@ -5,6 +5,7 @@ import java.io.FileNotFoundException
 import is.hail.asm4s.FunctionBuilder
 import is.hail.check.Prop._
 import is.hail.check.Properties
+import is.hail.expr.ir.EmitFunctionBuilder
 import is.hail.expr.types.{TInterval, TLocus, TStruct}
 import is.hail.io.reference.FASTAReader
 import is.hail.table.Table
@@ -300,9 +301,9 @@ class ReferenceGenomeSuite extends SparkSuite {
 
   @Test def testSerializeOnFB() {
     val grch38 = ReferenceGenome.GRCh38
-    val fb = FunctionBuilder.functionBuilder[String, Boolean]
+    val fb = EmitFunctionBuilder[String, Boolean]
 
-    val rgfield = fb.newLazyField(grch38.codeSetup)
+    val rgfield = fb.getReferenceGenome(grch38)
     fb.emit(rgfield.invoke[String, Boolean]("isValidContig", fb.getArg[String](1)))
 
     val f = fb.result()()

--- a/src/test/scala/is/hail/variant/ReferenceGenomeSuite.scala
+++ b/src/test/scala/is/hail/variant/ReferenceGenomeSuite.scala
@@ -298,15 +298,4 @@ class ReferenceGenomeSuite extends SparkSuite {
       .forall("row.base == row.baseComputed"))
     ReferenceGenome.removeReference(rg2.name)
   }
-
-  @Test def testSerializeOnFB() {
-    val grch38 = ReferenceGenome.GRCh38
-    val fb = EmitFunctionBuilder[String, Boolean]
-
-    val rgfield = fb.getReferenceGenome(grch38)
-    fb.emit(rgfield.invoke[String, Boolean]("isValidContig", fb.getArg[String](1)))
-
-    val f = fb.result()()
-    assert(f("X") == grch38.isValidContig("X"))
-  }
 }


### PR DESCRIPTION
if they're already getting serialized and sent to the workers, there's no need to re-parse. Oops.