### PR TITLE
More Information when toIR fails

### DIFF
--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -682,8 +682,8 @@ class HailContext private(val sc: SparkContext,
   def eval(expr: String): (Annotation, Type) = {
     val ec = EvalContext()
     val ast = Parser.parseToAST(expr, ec)
-    ast.toIR() match {
-      case ToIRSuccess(body) =>
+    ast.toIROpt() match {
+      case Some(body) =>
         Region.scoped { region =>
           val t = ast.`type`
           t match {
@@ -709,7 +709,7 @@ class HailContext private(val sc: SparkContext,
               (v2, t)
           }
         }
-      case ToIRFailure(_) =>
+      case None =>
         val (t, f) = Parser.eval(ast, ec)
         (f(), t)
     }

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -5,7 +5,7 @@ import java.util.Properties
 
 import is.hail.annotations._
 import is.hail.expr.types._
-import is.hail.expr.{EvalContext, Parser, ir}
+import is.hail.expr.{EvalContext, Parser, ir, ToIRSuccess, ToIRFailure}
 import is.hail.io.{CodecSpec, Decoder, LoadMatrix}
 import is.hail.io.bgen.LoadBgen
 import is.hail.io.gen.LoadGen
@@ -683,7 +683,7 @@ class HailContext private(val sc: SparkContext,
     val ec = EvalContext()
     val ast = Parser.parseToAST(expr, ec)
     ast.toIR() match {
-      case Some(body) =>
+      case ToIRSuccess(body) =>
         Region.scoped { region =>
           val t = ast.`type`
           t match {
@@ -709,7 +709,7 @@ class HailContext private(val sc: SparkContext,
               (v2, t)
           }
         }
-      case None =>
+      case ToIRFailure(_) =>
         val (t, f) = Parser.eval(ast, ec)
         (f(), t)
     }

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -870,10 +870,11 @@ case class ApplyMethod(posn: Position, lhs: AST, method: String, args: Array[AST
       case _ =>
         for {
           irs <- all((lhs +: args).map(_.toIR(agg)))
+          argTypes = irs.map(_.typ)
           ir <- fromOption(
             this,
-            s"no method $method on type ${lhs.`type`}",
-            IRFunctionRegistry.lookupConversion(method, irs.map(_.typ))
+            s"no method $method on type ${lhs.`type`} with arguments ${argTypes.tail}",
+            IRFunctionRegistry.lookupConversion(method, argTypes)
               .map { irf => irf(irs) })
         } yield ir
     }

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -979,7 +979,7 @@ case class If(pos: Position, cond: AST, thenTree: AST, elseTree: AST)
 
 // PrettyAST(ast) gives a pretty-print of an AST tree
 
-object  PrettyAST {
+object PrettyAST {
   def apply(rootAST: AST, depth: Int = 0, multiline: Boolean = true): String = {
     val sb = new StringBuilder()
 

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -404,7 +404,7 @@ case class ArrayConstructor(posn: Position, elements: Array[AST]) extends AST(po
   def toIR(agg: Option[String] = None): ToIRErr[IR] = for {
     irElements <- all(elements.map(_.toIR(agg)))
     elementTypes = elements.map(_.`type`).distinct
-    _ <- blameWhen(this, "elements must have same type, found: $elementTypes",  elementTypes.length != 1)
+    _ <- blameWhen(this, "array elements must have same type, found: $elementTypes",  elementTypes.length != 1)
   } yield ir.MakeArray(irElements, `type`.asInstanceOf[TArray])
 }
 

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -368,7 +368,7 @@ case class Select(posn: Position, lhs: AST, rhs: String) extends AST(posn, lhs) 
 
   def toIR(agg: Option[String] = None): ToIRErr[IR] = for {
     s <- lhs.toIR(agg)
-    t <- whenOfType[TStruct](this)
+    t <- whenOfType[TStruct](lhs)
     f <- fromOption(this, "$t must have field $rhs", t.selfField(rhs))
   } yield ir.GetField(s, rhs)
 }

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -735,7 +735,7 @@ case class Apply(posn: Position, fn: String, args: Array[AST]) extends AST(posn,
       irArgs <- all(args.map(_.toIR(agg)))
       ir <- fromOption(
         this,
-        "no function or primop found for $fn",
+        s"no function or primop found for $fn",
         tryPrimOpConversion(args.map(_.`type`).zip(irArgs)).orElse(
           IRFunctionRegistry.lookupConversion(fn, irArgs.map(_.typ))
             .map { irf => irf(irArgs) }))
@@ -851,7 +851,7 @@ case class ApplyMethod(posn: Position, lhs: AST, method: String, args: Array[AST
           b <- body.toIR(agg)
           result <- fromOption(
             this,
-            "no method $m on type $t",
+            s"no method $m on type $t",
             optMatch((t, m)) {
               case (_: TAggregable, "map") => ir.AggMap(a, name, b)
               case (_: TAggregable, "filter") => ir.AggFilter(a, name, b)
@@ -872,7 +872,7 @@ case class ApplyMethod(posn: Position, lhs: AST, method: String, args: Array[AST
           irs <- all((lhs +: args).map(_.toIR(agg)))
           ir <- fromOption(
             this,
-            "no method $m on type $t",
+            s"no method $method on type ${lhs.`type`}",
             IRFunctionRegistry.lookupConversion(method, irs.map(_.typ))
               .map { irf => irf(irs) })
         } yield ir

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -278,7 +278,7 @@ sealed abstract class AST(pos: Position, val subexprs: Array[AST] = Array.empty)
       val caller = context(0)
       val widerContextString = context.map("  " + _).mkString("\n")
       val reasons = fails.map { case (ir, message, context) =>
-        s"$message, $ir, $context"
+        s"$message, ${PrettyAST(ir, multiline=false)}, $context"
       }.map("  " + _).mkString("\n")
       log.warn(s"""[${caller} found no AST to IR conversion for:
                   |${ PrettyAST(this, 2) }
@@ -979,20 +979,25 @@ case class If(pos: Position, cond: AST, thenTree: AST, elseTree: AST)
 // PrettyAST(ast) gives a pretty-print of an AST tree
 
 object  PrettyAST {
-  def apply(rootAST: AST, depth: Int = 0): String = {
+  def apply(rootAST: AST, depth: Int = 0, multiline: Boolean = true): String = {
     val sb = new StringBuilder()
 
     def putDeepAST(ast: AST, depth: Int) {
-      sb.append("  " * depth)
+      if (multiline)
+        sb.append("  " * depth)
       val children = ast.subexprs
       sb.append(astToName(ast))
       if (children.length > 0) {
-        sb.append("(\n")
+        sb.append("(")
+        if (multiline)
+          sb.append("\n")
         children.foreach(putDeepAST(_, depth+1))
-        sb.append("  " * depth)
+        if (multiline)
+          sb.append("  " * depth)
         sb.append(")")
       }
-      if (depth > 0) sb.append("\n")
+      if (depth != 0)
+        if (multiline) sb.append("\n") else sb.append(" ")
     }
 
     putDeepAST(rootAST, depth)

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -368,7 +368,7 @@ case class Select(posn: Position, lhs: AST, rhs: String) extends AST(posn, lhs) 
 
   def toIR(agg: Option[String] = None): ToIRErr[IR] = for {
     s <- lhs.toIR(agg)
-    t <- whenOfType[TStruct](lhs)
+    t <- whenOfType[TStruct](this)
     f <- fromOption(this, "$t must have field $rhs", t.selfField(rhs))
   } yield ir.GetField(s, rhs)
 }

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -992,13 +992,19 @@ object PrettyAST {
         sb.append("(")
         if (multiline)
           sb.append("\n")
-        children.foreach(putDeepAST(_, depth+1))
+        var i = 0
+        while (i < children.length) {
+          putDeepAST(children(i), depth+1)
+
+          if (multiline) sb.append("\n")
+          else if (i + 1 != children.length)
+            sb.append(" ")
+          i += 1
+        }
         if (multiline)
           sb.append("  " * depth)
         sb.append(")")
       }
-      if (depth != 0)
-        if (multiline) sb.append("\n") else sb.append(" ")
     }
 
     putDeepAST(rootAST, depth)

--- a/src/main/scala/is/hail/expr/ToIRErr.scala
+++ b/src/main/scala/is/hail/expr/ToIRErr.scala
@@ -52,24 +52,6 @@ case class ToIRSuccess[T](value: T) extends ToIRErr[T] {
     ToIRSuccess(f(value))
   def flatMap[U](f: T => ToIRErr[U]): ToIRErr[U] =
     f(value)
-  // def filter(p: T => Boolean): ToIRErr[T] =
-  //   // heh, no IR to blame here
-  //   //
-  //   // better solution possible if Scala for notation allowed actions that return unit, a la:
-  //   // for {
-  //   //   x <- rhs.toIR
-  //   //   blameUnless(blamedIr, message, x.isInstanceOf[T])
-  //   // } yield x
-  //   //
-  //   // only current option is
-  //   //
-  //   // for {
-  //   //   x <- rhs.toIR
-  //   //   _ <- blameUnless(...)
-  //   // } yield x
-  //   //
-  //   if (p(value)) this
-  //   else ToIRErr.fail(null, null, ToIRErr.getCaller())
   def toOption: Option[T] = Some(value)
 }
 

--- a/src/main/scala/is/hail/expr/ToIRErr.scala
+++ b/src/main/scala/is/hail/expr/ToIRErr.scala
@@ -1,0 +1,73 @@
+package is.hail.expr
+
+import scala.reflect.{ClassTag, classTag}
+
+object ToIRErr {
+  def all[T](actions: Seq[ToIRErr[T]]): ToIRErr[Seq[T]] =
+    actions.foldLeft[ToIRErr[Seq[T]]](success(Seq[T]())) {
+      case (ToIRSuccess(xs), ToIRSuccess(x)) => success(x +: xs)
+      case (_: ToIRSuccess[_], f: ToIRFailure[_]) => f.as[Seq[T]]
+      case (f: ToIRFailure[_], _: ToIRSuccess[_]) => f
+      case (ToIRFailure(irs), ToIRFailure(moreIrs)) => fail(irs ++ moreIrs)
+    }
+  def all[T, U](a: ToIRErr[T], b: ToIRErr[U]): ToIRErr[(T, U)] =
+    (a, b) match {
+      case (ToIRSuccess(t), ToIRSuccess(u)) => success(t, u)
+      case (_: ToIRSuccess[_], f: ToIRFailure[_]) => f.as[(T, U)]
+      case (f: ToIRFailure[_], _: ToIRSuccess[_]) => f.as[(T, U)]
+      case (ToIRFailure(irs), ToIRFailure(moreIrs)) => fail(irs ++ moreIrs)
+    }
+  def success[T](t: T): ToIRErr[T] = ToIRSuccess(t)
+  def fail[T](ir: AST, message: String = null): ToIRErr[T] =
+    ToIRFailure(Seq((ir, message)))
+  def fail[T](irs: Seq[(AST, String)]): ToIRErr[T] = ToIRFailure(irs)
+  def whenOfType[T: ClassTag](a: AST): ToIRErr[T] =
+    a.`type` match {
+      case t: T => success(t)
+      case _ =>
+        fail(a, s"${a.`type`} should be a subtype of ${classTag[T].runtimeClass.getSimpleName}")
+    }
+  def fromOption[T](blame: AST, message: String, ot: Option[T]): ToIRErr[T] = ot match {
+    case Some(t) => success(t)
+    case None => fail(blame, message)
+  }
+}
+
+trait ToIRErr[T] {
+  def map[U](f: T => U): ToIRErr[U]
+  def flatMap[U](f: T => ToIRErr[U]): ToIRErr[U]
+  def filter(p: T => Boolean): ToIRErr[T]
+}
+
+case class ToIRSuccess[T](value: T) extends ToIRErr[T] {
+  def map[U](f: T => U): ToIRErr[U] =
+    ToIRSuccess(f(value))
+  def flatMap[U](f: T => ToIRErr[U]): ToIRErr[U] =
+    f(value)
+  def filter(p: T => Boolean): ToIRErr[T] =
+    // heh, no IR to blame here
+    //
+    // better solution possible if Scala for notation allowed actions that return unit, a la:
+    // for {
+    //   x <- rhs.toIR
+    //   blameUnless(blamedIr, message, x.isInstanceOf[T])
+    // } yield x
+    //
+    // only current option is
+    //
+    // for {
+    //   x <- rhs.toIR
+    //   _ <- blameUnless(...)
+    // } yield x
+    //
+    if (p(value)) this
+    else ToIRErr.fail(null, Thread.currentThread().getStackTrace()(2).toString())
+}
+
+case class ToIRFailure[T](incovertible: Seq[(AST, String)]) extends ToIRErr[T] {
+  // as is safe because this class contains no `T`s
+  def as[U]: ToIRErr[U] = this.asInstanceOf[ToIRErr[U]]
+  def map[U](f: T => U): ToIRErr[U] = as[U]
+  def flatMap[U](f: T => ToIRErr[U]): ToIRErr[U] = as[U]
+  def filter(p: T => Boolean): ToIRErr[T] = this
+}

--- a/src/main/scala/is/hail/expr/ToIRErr.scala
+++ b/src/main/scala/is/hail/expr/ToIRErr.scala
@@ -17,14 +17,16 @@ object ToIRErr {
       case (f: ToIRFailure[_], _: ToIRSuccess[_]) => f.as[(T, U)]
       case (ToIRFailure(irs), ToIRFailure(moreIrs)) => fail(irs ++ moreIrs)
     }
-  def success[T](t: T): ToIRErr[T] = ToIRSuccess(t)
+  def success[T](t: T): ToIRErr[T] =
+    ToIRSuccess(t)
   def fail[T](ir: AST): ToIRErr[T] =
     ToIRFailure(Seq((ir, null, getCaller())))
   def fail[T](ir: AST, message: String): ToIRErr[T] =
     ToIRFailure(Seq((ir, message, getCaller())))
   def fail[T](ir: AST, message: String, blame: StackTraceElement): ToIRErr[T] =
     ToIRFailure(Seq((ir, message, blame)))
-  def fail[T](irs: Seq[(AST, String, StackTraceElement)]): ToIRErr[T] = ToIRFailure(irs)
+  def fail[T](irs: Seq[(AST, String, StackTraceElement)]): ToIRErr[T] =
+    ToIRFailure(irs)
   def whenOfType[T: ClassTag](a: AST): ToIRErr[T] =
     a.`type` match {
       case t: T => success(t)
@@ -60,6 +62,5 @@ case class ToIRFailure[T](incovertible: Seq[(AST, String, StackTraceElement)]) e
   def as[U]: ToIRErr[U] = this.asInstanceOf[ToIRErr[U]]
   def map[U](f: T => U): ToIRErr[U] = as[U]
   def flatMap[U](f: T => ToIRErr[U]): ToIRErr[U] = as[U]
-  // def filter(p: T => Boolean): ToIRErr[T] = this
   def toOption: Option[T] = None
 }

--- a/src/main/scala/is/hail/expr/ToIRErr.scala
+++ b/src/main/scala/is/hail/expr/ToIRErr.scala
@@ -9,7 +9,7 @@ object ToIRErr {
       case (_: ToIRSuccess[_], f: ToIRFailure[_]) => f.as[Seq[T]]
       case (f: ToIRFailure[_], _: ToIRSuccess[_]) => f
       case (ToIRFailure(irs), ToIRFailure(moreIrs)) => fail(irs ++ moreIrs)
-    }
+    }.map(_.reverse)
   def all[T, U](a: ToIRErr[T], b: ToIRErr[U]): ToIRErr[(T, U)] =
     (a, b) match {
       case (ToIRSuccess(t), ToIRSuccess(u)) => success(t, u)
@@ -29,16 +29,16 @@ object ToIRErr {
     a.`type` match {
       case t: T => success(t)
       case _ =>
-        fail(a, s"${a.`type`} should be a subtype of ${classTag[T].runtimeClass.getSimpleName}")
+        fail(a, s"${a.`type`} should be a subtype of ${classTag[T].runtimeClass.getSimpleName}", getCaller())
     }
   def fromOption[T](blame: AST, message: String, ot: Option[T]): ToIRErr[T] = ot match {
     case Some(t) => success(t)
-    case None => fail(blame, message)
+    case None => fail(blame, message, getCaller())
   }
   def blameWhen(blame: AST, message: String, condition: Boolean): ToIRErr[Unit] =
-    if (condition) fail(blame, message) else success(())
+    if (condition) fail(blame, message, getCaller()) else success(())
   private[expr] def getCaller(): StackTraceElement =
-    Thread.currentThread().getStackTrace()(2)
+    Thread.currentThread().getStackTrace()(3)
 }
 
 trait ToIRErr[T] {

--- a/src/main/scala/is/hail/methods/SplitMulti.scala
+++ b/src/main/scala/is/hail/methods/SplitMulti.scala
@@ -267,12 +267,12 @@ class SplitMulti(vsm: MatrixTable, variantExpr: String, genotypeExpr: String, ke
   val entryASTs = Parser.parseAnnotationExprsToAST(genotypeExpr, gEC, Some("g"))
 
   val rowIRs = rowASTs.flatMap { case (name, ast) =>
-    for (ir <- ast.toIR()) yield {
+    for (ir <- ast.toIROpt()) yield {
       (name, ir)
     }
   }
   val entryIRs = entryASTs.flatMap { case (name, ast) =>
-    for (ir <- ast.toIR()) yield {
+    for (ir <- ast.toIROpt()) yield {
       (name, ir)
     }
   }

--- a/src/main/scala/is/hail/utils/Graph.scala
+++ b/src/main/scala/is/hail/utils/Graph.scala
@@ -47,7 +47,7 @@ object Graph {
 
     val tieBreakerF = tieBreaker.map { e =>
       val ast = Parser.parseToAST(e, tieBreakerEc)
-      ast.toIR() match {
+      ast.toIROpt() match {
         case Some(ir) =>
           val (t, f) = Compile[Long, Long, Long]("l", wrappedNodeType, "r", wrappedNodeType, MakeTuple(FastSeq(ir)))
           assert(t.isOfType(TTuple(TInt64())))

--- a/src/test/scala/is/hail/expr/AstToIrSuite.scala
+++ b/src/test/scala/is/hail/expr/AstToIrSuite.scala
@@ -13,7 +13,7 @@ class ASTToIRSuite extends TestNGSuite {
         Map("agg" -> (0, TInt64()),
           "something" -> (1, TInt64())))))))
 
-    ast.toIR(Some("aggregable")).map(_.unwrap)
+    ast.toIROptNoWarning(Some("aggregable")).map(_.unwrap)
   }
 
   @Test

--- a/src/test/scala/is/hail/expr/AstToIrSuite.scala
+++ b/src/test/scala/is/hail/expr/AstToIrSuite.scala
@@ -13,7 +13,7 @@ class ASTToIRSuite extends TestNGSuite {
         Map("agg" -> (0, TInt64()),
           "something" -> (1, TInt64())))))))
 
-    ast.toIROptNoWarning(Some("aggregable")).map(_.unwrap)
+    ast.toIROpt(Some("aggregable")).map(_.unwrap)
   }
 
   @Test

--- a/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -52,7 +52,8 @@ class FunctionSuite extends SparkSuite {
   def emitFromFB[F >: Null : TypeInfo](fb: FunctionBuilder[F]) =
     new EmitFunctionBuilder[F](fb.parameterTypeInfo, fb.returnTypeInfo, fb.packageName)
 
-  def fromHailString(hql: String): IR = Parser.parseToAST(hql, ec).toIR().get
+  def fromHailString(hql: String): IR =
+    Parser.parseToAST(hql, ec).toIROptNoWarning().get
 
   def toF[R: TypeInfo](ir: IR): AsmFunction1[Region, R] = {
     val fb = emitFromFB(FunctionBuilder.functionBuilder[Region, R])


### PR DESCRIPTION
Example:

```
2018-05-09 17:30:41 root: WARN: [is.hail.variant.MatrixTable.selectRows(MatrixTable.scala:1176) found no AST to IR conversion for:
    Apply[annotate](
      SymRef[va]
      StructConstructor(
        Select[toFloat64](
          Select[position](
            Select[locus](
              SymRef[va]
            )
          )
        )
      )
    )

due to the following errors:
  locus<GRCh37> should be a subtype of TStruct, Select[locus](SymRef[va] ), is.hail.expr.Select$$anonfun$toIR$1.apply(AST.scala:371)
in
  is.hail.variant.MatrixTable.selectRows(MatrixTable.scala:1176)
  is.hail.testUtils.RichMatrixTable.annotateRowsExpr(RichMatrixTable.scala:57)
  is.hail.variant.vsm.GroupBySuite.testLinregBurden(GroupBySuite.scala:107)
  sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
```

With multiple failures:

```
2018-05-09 17:43:03 root: WARN: [is.hail.variant.MatrixTable.aggregateRowsByKey(MatrixTable.scala:810) found no AST to IR conversion for:
    StructConstructor(
      ApplyMethod[sum](
        ApplyMethod[map](
          SymRef[AGG]
          Lambda[g](
            Apply[*](
              Select[weight](
                SymRef[va]
              )
              Select[toFloat64](
                ApplyMethod[nNonRefAlleles](
                  Select[GT](
                    SymRef[g]
                  )
                )
              )
            )
          )
        )
      )
    )

due to the following errors:
  float64 should be a subtype of TStruct, Select[weight](SymRef[va] ), is.hail.expr.Select$$anonfun$toIR$1.apply(AST.scala:371)
  call should be a subtype of TStruct, Select[GT](SymRef[g] ), is.hail.expr.Select$$anonfun$toIR$1.apply(AST.scala:371)
in
  is.hail.variant.MatrixTable.aggregateRowsByKey(MatrixTable.scala:810)
  is.hail.variant.vsm.GroupBySuite.testLinregBurden(GroupBySuite.scala:113)
  sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
  sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
```