### PR TITLE
group_by_rows(...).aggregate(...) in the IR

### DIFF
--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -349,8 +349,8 @@ class GroupedMatrixTable(ExprContainer):
             pk = {k: self._row_keys[k] for k in self._partition_key}
             rest_of_key = {k: self._row_keys[k] for k in self._row_keys.keys() if k not in self._partition_key}
             base = MatrixTable(
-                base._key_rows_by("GroupedMatrixTable.group_rows_by", pk, rest_of_key)._jvds.aggregateRowsByKey(
-                    ',\n'.join(strs)))
+                base._key_rows_by("GroupedMatrixTable.group_rows_by", pk, rest_of_key)
+                ._jvds.aggregateRowsByKey(self.row.annotate(**named_exprs), ',\n'.join(strs)))
         else:
             raise ValueError("GroupedMatrixTable cannot be aggregated if no groupings are specified.")
 

--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -350,7 +350,7 @@ class GroupedMatrixTable(ExprContainer):
             rest_of_key = {k: self._row_keys[k] for k in self._row_keys.keys() if k not in self._partition_key}
             base = MatrixTable(
                 base._key_rows_by("GroupedMatrixTable.group_rows_by", pk, rest_of_key)
-                ._jvds.aggregateRowsByKey(self.row.annotate(**named_exprs), ',\n'.join(strs)))
+                ._jvds.aggregateRowsByKey(hl.struct(**named_exprs)._ast.to_hql(), ',\n'.join(strs)))
         else:
             raise ValueError("GroupedMatrixTable cannot be aggregated if no groupings are specified.")
 

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -717,16 +717,6 @@ case class MatrixAggregateRowsByKey(child: MatrixIR, expr: IR) extends MatrixIR 
       MatrixAggregateRowsByKey(child, expr)
   }
 
-  private[this] val tAggElt: Type = child.typ.entryType
-  // FIXME: this should come from the MatrixType
-  private[this] val aggSymTab = Map(
-    "global" -> (0, child.typ.globalType),
-    "va" -> (1, child.typ.rvRowType),
-    "g" -> (2, child.typ.entryType),
-    "sa" -> (3, child.typ.colType))
-
-  private[this] val tAgg = TAggregable(tAggElt, aggSymTab)
-
   val typ: MatrixType = child.typ.copyParts(
     rowType = child.typ.orvdType.kType,
     // FIXME: how on earth is this supposed to work, expr doesn't know its

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -810,7 +810,6 @@ case class MatrixAggregateRowsByKey(child: MatrixIR, expr: IR) extends MatrixIR 
     val globalsBc = prev.globals.broadcast
     val newRVD = prev.rvd.boundary.mapPartitionsPreservesPartitioning(typ.orvdType, { (ctx, it) =>
       val partRVB = new RegionValueBuilder()
-      val newRV = RegionValue()
 
       val partRegion = ctx.freshContext.region
 

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -211,4 +211,40 @@ object CompileWithAggregators {
       AsmFunction7[Region, Long, Boolean, T0, Boolean, T1, Boolean, R],
       R](args, aggArgs, body, transformInitOp, transformSeqOp)
   }
+
+  def apply[
+    T0: ClassTag,
+    TAGG: ClassTag,
+    S0: ClassTag,
+    S1: ClassTag,
+    S2: ClassTag,
+    R: TypeInfo : ClassTag
+  ](name0: String, typ0: Type,
+    aggName: String, aggTyp: TAggregable,
+    aggName0: String, aggType0: Type,
+    aggName1: String, aggType1: Type,
+    aggName2: String, aggType2: Type,
+    body: IR,
+    transformAggIR: (Int, IR) => IR
+  ): (Array[RegionValueAggregator],
+    () => AsmFunction10[Region, Array[RegionValueAggregator], TAGG, Boolean, S0, Boolean, S1, Boolean, S2, Boolean, Unit],
+    Type,
+    () => AsmFunction5[Region, Long, Boolean, T0, Boolean, R],
+    Type) = {
+
+    assert(TypeToIRIntermediateClassTag(aggTyp) == classTag[TAGG])
+
+    val args = FastSeq(
+      (name0, typ0, classTag[T0]))
+
+    val aggArgs = FastSeq(
+      (aggName, aggTyp.elementType, classTag[TAGG]),
+      (aggName0, aggType0, classTag[S0]),
+      (aggName1, aggType1, classTag[S1]),
+      (aggName2, aggType2, classTag[S2]))
+
+    apply[AsmFunction10[Region, Array[RegionValueAggregator], TAGG, Boolean, S0, Boolean, S1, Boolean, S2, Boolean, Unit],
+      AsmFunction5[Region, Long, Boolean, T0, Boolean, R],
+      R](aggName, aggTyp, args, aggArgs, body, transformAggIR)
+  }
 }

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -223,6 +223,7 @@ object CompileWithAggregators {
     aggName1: String, aggType1: Type,
     aggName2: String, aggType2: Type,
     body: IR,
+    transformInitOp: (Int, IR) => IR,
     transformAggIR: (Int, IR) => IR
   ): (Array[RegionValueAggregator],
     () => AsmFunction4[Region, Array[RegionValueAggregator], T0, Boolean, Unit],
@@ -242,6 +243,6 @@ object CompileWithAggregators {
       AsmFunction4[Region, Array[RegionValueAggregator], T0, Boolean, Unit],
       AsmFunction8[Region, Array[RegionValueAggregator], S0, Boolean, S1, Boolean, S2, Boolean, Unit],
       AsmFunction5[Region, Long, Boolean, T0, Boolean, R],
-      R](args, aggArgs, body, transformAggIR)
+      R](args, aggArgs, body, transformInitOp, transformAggIR)
   }
 }

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -214,37 +214,34 @@ object CompileWithAggregators {
 
   def apply[
     T0: ClassTag,
-    TAGG: ClassTag,
     S0: ClassTag,
     S1: ClassTag,
     S2: ClassTag,
     R: TypeInfo : ClassTag
   ](name0: String, typ0: Type,
-    aggName: String, aggTyp: TAggregable,
     aggName0: String, aggType0: Type,
     aggName1: String, aggType1: Type,
     aggName2: String, aggType2: Type,
     body: IR,
     transformAggIR: (Int, IR) => IR
   ): (Array[RegionValueAggregator],
-    () => AsmFunction10[Region, Array[RegionValueAggregator], TAGG, Boolean, S0, Boolean, S1, Boolean, S2, Boolean, Unit],
+    () => AsmFunction4[Region, Array[RegionValueAggregator], T0, Boolean, Unit],
+    () => AsmFunction8[Region, Array[RegionValueAggregator], S0, Boolean, S1, Boolean, S2, Boolean, Unit],
     Type,
     () => AsmFunction5[Region, Long, Boolean, T0, Boolean, R],
     Type) = {
-
-    assert(TypeToIRIntermediateClassTag(aggTyp) == classTag[TAGG])
-
     val args = FastSeq(
       (name0, typ0, classTag[T0]))
 
     val aggArgs = FastSeq(
-      (aggName, aggTyp.elementType, classTag[TAGG]),
       (aggName0, aggType0, classTag[S0]),
       (aggName1, aggType1, classTag[S1]),
       (aggName2, aggType2, classTag[S2]))
 
-    apply[AsmFunction10[Region, Array[RegionValueAggregator], TAGG, Boolean, S0, Boolean, S1, Boolean, S2, Boolean, Unit],
+    apply[
+      AsmFunction4[Region, Array[RegionValueAggregator], T0, Boolean, Unit],
+      AsmFunction8[Region, Array[RegionValueAggregator], S0, Boolean, S1, Boolean, S2, Boolean, Unit],
       AsmFunction5[Region, Long, Boolean, T0, Boolean, R],
-      R](aggName, aggTyp, args, aggArgs, body, transformAggIR)
+      R](args, aggArgs, body, transformAggIR)
   }
 }

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -810,14 +810,14 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     log.info(expr)
     val rowsAST = Parser.parseToAST(expr, ec)
 
-    rowsAST.toIROpt(Some("AGG")) match {
+    rowsAST.toIROpt(Some("AGG" -> "g")) match {
       case Some(x) if useIR(this.rowAxis, rowsAST) =>
         new MatrixTable(hc, MatrixAggregateRowsByKey(ast, x))
 
       case _ =>
         log.warn(s"group_rows_by(...).aggregate() found no AST to IR conversion: ${ PrettyAST(rowsAST) }")
 
-        val ColFunctions(zero, seqOp, resultOp, newEntryType) = Aggregators.makeColFunctions(this, aggExpr)
+        val ColFunctions(zero, seqOp, resultOp, newEntryType) = Aggregators.makeColFunctions(this, oldAggExpr)
         val newRowType = matrixType.orvdType.kType
         val newMatrixType = MatrixType.fromParts(globalType, colKey, colType,
           rowPartitionKey, rowKey, newRowType, newEntryType)

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -805,7 +805,6 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
   def aggregateRowsByKey(aggExpr: String): MatrixTable = {
-
     val ColFunctions(zero, seqOp, resultOp, newEntryType) = Aggregators.makeColFunctions(this, aggExpr)
     val newRowType = matrixType.orvdType.kType
     val newMatrixType = MatrixType.fromParts(globalType, colKey, colType,

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -810,7 +810,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     log.info(expr)
     val rowsAST = Parser.parseToAST(expr, ec)
 
-    rowsAST.toIR(Some("AGG")) match {
+    rowsAST.toIROpt(Some("AGG")) match {
       case Some(x) if useIR(this.rowAxis, rowsAST) =>
         new MatrixTable(hc, MatrixAggregateRowsByKey(ast, x))
 


### PR DESCRIPTION
Created a Relational IR for `mt.group_by_rows(...).aggregate(...)`.

I've never done this before so I just copied and massaged `MatrixMapRows`. It seems a lot longer than I anticipated. Two of the `GroupBySuite` tests exercise this path. The other two use non-IR features. When more things are put into the expr IR, they'll start exercising this path too.