### PR TITLE
add set functions

### DIFF
--- a/python/hail/tests/test_expr.py
+++ b/python/hail/tests/test_expr.py
@@ -1376,3 +1376,28 @@ class Tests(unittest.TestCase):
         assert_min_reps_to(['GCTAA', 'GCAAA', 'G'], ['GCTAA', 'GCAAA', 'G'])
         assert_min_reps_to(['GCTAA', 'GCAAA', 'GCCAA'], ['T', 'A', 'C'], pos_change=2)
         assert_min_reps_to(['GCTAA', 'GCAAA', 'GCCAA', '*'], ['T', 'A', 'C', '*'], pos_change=2)
+
+    def assert_evals_to(self, e, v):
+        self.assertEqual(e.value, v)
+
+    def test_set_functions(self):
+        s = hl.set([1, 3, 7])
+        t = hl.set([3, 8])
+        self.assert_evals_to(s, set([1, 3, 7]))
+
+        self.assert_evals_to(s.add(3), set([1, 3, 7]))
+        self.assert_evals_to(s.add(4), set([1, 3, 4, 7]))
+
+        self.assert_evals_to(s.remove(3), set([1, 7]))
+        self.assert_evals_to(s.remove(4), set([1, 3, 7]))
+
+        self.assert_evals_to(s.contains(3), True)
+        self.assert_evals_to(s.contains(4), False)
+
+        self.assert_evals_to(s.difference(t), set([1, 7]))
+        self.assert_evals_to(s.intersection(t), set([3]))
+
+        self.assert_evals_to(s.is_subset(hl.set([1, 3, 4, 7])), True)
+        self.assert_evals_to(s.is_subset(hl.set([1, 3])), False)
+
+        self.assert_evals_to(s.union(t), set([1, 3, 7, 8]))

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -869,6 +869,10 @@ case class ApplyMethod(posn: Position, lhs: AST, method: String, args: Array[AST
               case (_: TArray, "map") => ir.ArrayMap(a, name, b)
               case (_: TArray, "filter") => ir.ArrayFilter(a, name, b)
               case (_: TArray, "flatMap") => ir.ArrayFlatMap(a, name, b)
+              case (_: TSet, "flatMap") =>
+                ir.ToSet(
+                  ir.ArrayFlatMap(ir.ToArray(a), name,
+                      ir.ToArray(b)))
               case (_: TArray, "exists") =>
                 val v = ir.genUID()
                 ir.ArrayFold(a, ir.False(), v, name, ir.ApplySpecial("||", FastSeq(ir.Ref(v, TBoolean()), b)))

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -254,7 +254,6 @@ private class Emit(
         val codeR = emit(r)
         EmitTriplet(Code(codeL.setup, codeR.setup),
           codeL.m || codeR.m,
-
           BinaryOp.emit(op, l.typ, r.typ, codeL.v, codeR.v))
       case ApplyUnaryPrimOp(op, x) =>
         val typ = ir.typ
@@ -816,14 +815,14 @@ private class Emit(
         val filterCont = { (cont: F, m: Code[Boolean], v: Code[_]) =>
           Code(
             xmv := m,
-            xmv.mux(
-              Code._empty,
-              Code(
-                xvv := v,
-                codeCond.setup,
-                (codeCond.m || !coerce[Boolean](codeCond.v)).mux(
-                  Code._empty,
-                  cont(false, xvv)))))
+            xvv := xmv.mux(
+              defaultValue(x.typ.elementType),
+              v),
+            Code(
+              codeCond.setup,
+              (codeCond.m || !coerce[Boolean](codeCond.v)).mux(
+                Code._empty,
+                cont(xmv, xvv))))
         }
         emitArrayIterator(a).copy(length = None).wrapContinuation(filterCont)
 

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -168,7 +168,7 @@ final case class ApplySpecial(function: String, args: Seq[IR]) extends IR {
     implementation.unify(argTypes)
     implementation.returnType.subst()
   }
-
+  
   def isDeterministic: Boolean = implementation.isDeterministic
 }
 

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -34,7 +34,9 @@ object IRFunctionRegistry {
     codeRegistry.remove(name)
 
   private def lookupInRegistry[T](reg: mutable.MultiMap[String, T], name: String, args: Seq[Type], cond: (T, Seq[Type]) => Boolean): Option[T] = {
-    reg.lift(name).map { fs => fs.filter(t => cond(t, args)).toSeq }.getOrElse(FastSeq()) match {
+    reg.lift(name).map { fs =>
+      println(fs)
+      fs.filter(t => cond(t, args)).toSeq }.getOrElse(FastSeq()) match {
       case Seq() => None
       case Seq(f) => Some(f)
       case _ => fatal(s"Multiple functions found that satisfy $name(${ args.mkString(",") }).")
@@ -87,6 +89,7 @@ object IRFunctionRegistry {
   ArrayFunctions.registerAll()
   UtilFunctions.registerAll()
   StringFunctions.registerAll()
+  SetFunctions.registerAll()
 }
 
 abstract class RegistryFunctions {
@@ -188,6 +191,7 @@ abstract class RegistryFunctions {
     registerJavaStaticFunction(mname, types.init.toArray, types.last)(cls, method, isDeterministic)
 
   def registerIR(mname: String, argTypes: Array[Type])(f: Seq[IR] => IR) {
+    println(mname, argTypes.toFastSeq)
     IRFunctionRegistry.addIR(mname, argTypes, f)
   }
 

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -81,12 +81,6 @@ object IRFunctionRegistry {
     }
   }
 
-  def invoke(name: String, args: Seq[IR]): IR = {
-    lookupConversion(name, args.map(_.typ)) match {
-      case Some(f) => f(args)
-    }
-  }
-
   SetFunctions.registerAll()
   CallFunctions.registerAll()
   GenotypeFunctions.registerAll()

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -34,9 +34,7 @@ object IRFunctionRegistry {
     codeRegistry.remove(name)
 
   private def lookupInRegistry[T](reg: mutable.MultiMap[String, T], name: String, args: Seq[Type], cond: (T, Seq[Type]) => Boolean): Option[T] = {
-    reg.lift(name).map { fs =>
-      println(fs)
-      fs.filter(t => cond(t, args)).toSeq }.getOrElse(FastSeq()) match {
+    reg.lift(name).map { fs => fs.filter(t => cond(t, args)).toSeq }.getOrElse(FastSeq()) match {
       case Seq() => None
       case Seq(f) => Some(f)
       case _ => fatal(s"Multiple functions found that satisfy $name(${ args.mkString(",") }).")
@@ -83,13 +81,19 @@ object IRFunctionRegistry {
     }
   }
 
+  def invoke(name: String, args: Seq[IR]): IR = {
+    lookupConversion(name, args.map(_.typ)) match {
+      case Some(f) => f(args)
+    }
+  }
+
+  SetFunctions.registerAll()
   CallFunctions.registerAll()
   GenotypeFunctions.registerAll()
   MathFunctions.registerAll()
   ArrayFunctions.registerAll()
   UtilFunctions.registerAll()
   StringFunctions.registerAll()
-  SetFunctions.registerAll()
 }
 
 abstract class RegistryFunctions {
@@ -191,7 +195,6 @@ abstract class RegistryFunctions {
     registerJavaStaticFunction(mname, types.init.toArray, types.last)(cls, method, isDeterministic)
 
   def registerIR(mname: String, argTypes: Array[Type])(f: Seq[IR] => IR) {
-    println(mname, argTypes.toFastSeq)
     IRFunctionRegistry.addIR(mname, argTypes, f)
   }
 

--- a/src/main/scala/is/hail/expr/ir/functions/SetFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/SetFunctions.scala
@@ -10,16 +10,6 @@ object SetFunctions extends RegistryFunctions {
       ToSet(a)
     }
 
-    registerIR("contains", TSet(tv("T")), tv("T")) { case (s, v) =>
-      val t = v.typ
-      val x = genUID()
-      val accum = genUID()
-
-      ArrayFold(ToArray(s), False(), accum, x,
-        ApplySpecial("||",
-          FastSeq(Ref(accum, TBoolean()), ApplyBinaryPrimOp(EQ(), v, Ref(x, t)))))
-    }
-
     registerIR("remove", TSet(tv("T")), tv("T")) { case (s, v) =>
       val t = v.typ
       val x = genUID()
@@ -55,7 +45,7 @@ object SetFunctions extends RegistryFunctions {
       val x = genUID()
       ToSet(
         ArrayFilter(ToArray(s1), x,
-          IRFunctionRegistry.invoke("contains", FastSeq(s2, Ref(x, t)))))
+          SetContains(s2, Ref(x, t))))
     }
 
     registerIR("difference", TSet(tv("T")), TSet(tv("T"))) { case (s1, s2) =>
@@ -63,7 +53,7 @@ object SetFunctions extends RegistryFunctions {
       val x = genUID()
       ToSet(
         ArrayFilter(ToArray(s1), x,
-          ApplyUnaryPrimOp(Bang(), IRFunctionRegistry.invoke("contains", FastSeq(s2, Ref(x, t))))))
+          ApplyUnaryPrimOp(Bang(), SetContains(s2, Ref(x, t)))))
     }
 
     registerIR("isSubset", TSet(tv("T")), TSet(tv("T"))) { case (s, w) =>
@@ -73,7 +63,7 @@ object SetFunctions extends RegistryFunctions {
       ArrayFold(ToArray(s), True(), a, x,
         // FIXME short circuit
         ApplySpecial("&&",
-          FastSeq(Ref(a, TBoolean()), IRFunctionRegistry.invoke("contains", FastSeq(w, Ref(x, t))))))
+          FastSeq(Ref(a, TBoolean()), SetContains(w, Ref(x, t)))))
     }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/functions/SetFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/SetFunctions.scala
@@ -1,0 +1,62 @@
+package is.hail.expr.ir.functions
+
+import is.hail.expr.ir._
+import is.hail.expr.types.{TArray, TBoolean, TSet}
+import is.hail.utils.FastSeq
+
+object SetFunctions extends RegistryFunctions {
+  def registerAll() {
+    registerIR("toSet", TArray(tv("T"))) { a =>
+      ToSet(a)
+    }
+
+    registerIR("contains", TSet(tv("T")), tv("T")) { case (s, v) =>
+      val t = v.typ
+      val x = genUID()
+      val accum = genUID()
+
+      ArrayFold(ToArray(s), False(), accum, x,
+        ApplySpecial("||",
+          FastSeq(Ref(accum, TBoolean()), ApplyBinaryPrimOp(EQ(), v, Ref(x, t)))))
+    }
+
+    registerIR("remove", TSet(tv("T")), tv("T")) { case (s, v) =>
+      val t = v.typ
+      val x = genUID()
+      ToSet(
+        ArrayFilter(
+          ToArray(s),
+          x,
+          ApplyBinaryPrimOp(NEQ(), Ref(x, t), v)))
+    }
+
+    registerIR("add", TSet(tv("T")), tv("T")) { case (s, v) =>
+      val t = v.typ
+      val x = genUID()
+      ToSet(
+        ArrayFlatMap(
+          MakeArray(FastSeq(ToArray(s), MakeArray(FastSeq(v), TArray(t))), TArray(TArray(t))),
+          x,
+          Ref(x, TArray(t))))
+    }
+
+    registerIR("isSubset", TSet(tv("T")), TSet(tv("T"))) { case (s, w) =>
+      val t = -s.typ.asInstanceOf[TSet].elementType
+
+      val a = genUID()
+      val x = genUID()
+
+      val args = FastSeq(w, Ref(x, t))
+      println(args, args.map(_.typ))
+
+      ArrayFold(ToArray(s), True(), a, x,
+        // FIXME short circuit
+        ApplySpecial("&&",
+          FastSeq(Ref(a, TBoolean()), Apply("contains", args))))
+    }
+
+    // union(set<T>,set<T>):set<T>
+    // intersection(set<T>,set<T>):set<T>
+    // difference(set<T>,set<T>):set<T>
+  }
+}

--- a/src/main/scala/is/hail/expr/ir/functions/SetFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/SetFunctions.scala
@@ -21,7 +21,7 @@ object SetFunctions extends RegistryFunctions {
         ArrayFilter(
           ToArray(s),
           x,
-          ApplyBinaryPrimOp(NEQ(), Ref(x, t), v)))
+          ApplyUnaryPrimOp(Bang(), nonstrictEQ(Ref(x, t), v))))
     }
 
     registerIR("add", TSet(tv("T")), tv("T")) { case (s, v) =>

--- a/src/main/scala/is/hail/expr/ir/functions/SetFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/SetFunctions.scala
@@ -10,6 +10,10 @@ object SetFunctions extends RegistryFunctions {
       ToSet(a)
     }
 
+    registerIR("contains", TSet(tv("T")), tv("T")) { case (s, v) =>
+      SetContains(s, v)
+    }
+
     registerIR("remove", TSet(tv("T")), tv("T")) { case (s, v) =>
       val t = v.typ
       val x = genUID()

--- a/src/main/scala/is/hail/expr/ir/package.scala
+++ b/src/main/scala/is/hail/expr/ir/package.scala
@@ -2,6 +2,7 @@ package is.hail.expr
 
 import is.hail.asm4s
 import is.hail.asm4s._
+import is.hail.expr.ir.functions.IRFunctionRegistry
 import is.hail.expr.types._
 
 package object ir {
@@ -53,8 +54,11 @@ package object ir {
 
   private[ir] def coerce[T](ti: TypeInfo[_]): TypeInfo[T] = ti.asInstanceOf[TypeInfo[T]]
 
-  private[ir] def coerce[T <: Type](x: Type): T = {
-    import is.hail.expr.types
-    types.coerce[T](x)
+  private[ir] def coerce[T <: Type](x: Type): T = types.coerce[T](x)
+
+  def invoke(name: String, args: IR*): IR = {
+    IRFunctionRegistry.lookupConversion(name, args.map(_.typ)) match {
+      case Some(f) => f(args)
+    }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/package.scala
+++ b/src/main/scala/is/hail/expr/ir/package.scala
@@ -61,4 +61,19 @@ package object ir {
       case Some(f) => f(args)
     }
   }
+
+  def nonstrictEQ(l: IR, r: IR): IR = {
+    // FIXME better as a (non-strict) BinaryOp?
+    assert(l.typ == r.typ)
+    val t = l.typ
+    val lv = genUID()
+    val rv = genUID()
+    Let(lv, l,
+      Let(rv, r,
+        If(IsNA(Ref(lv, t)),
+          IsNA(Ref(rv, t)),
+          If(IsNA(Ref(rv, t)),
+            False(),
+            ApplyBinaryPrimOp(EQ(), Ref(lv, t), Ref(rv, t))))))
+  }
 }

--- a/src/main/scala/is/hail/utils/FastSeq.scala
+++ b/src/main/scala/is/hail/utils/FastSeq.scala
@@ -4,9 +4,9 @@ import scala.collection.mutable
 import scala.reflect.ClassTag
 
 object FastSeq {
-  def empty[T](implicit tct: ClassTag[T]): Seq[T] = FastSeq()
+  def empty[T](implicit tct: ClassTag[T]): IndexedSeq[T] = FastSeq()
 
-  def apply[T](args: T*)(implicit tct: ClassTag[T]): Seq[T] = {
+  def apply[T](args: T*)(implicit tct: ClassTag[T]): IndexedSeq[T] = {
     args match {
       case args: mutable.WrappedArray[T] => args
       case args: mutable.ArrayBuffer[T] => args

--- a/src/test/scala/is/hail/TestUtils.scala
+++ b/src/test/scala/is/hail/TestUtils.scala
@@ -4,8 +4,9 @@ import java.net.URI
 import java.nio.file.{Files, Paths}
 
 import breeze.linalg.{DenseMatrix, Matrix, Vector}
-import is.hail.annotations.Annotation
-import is.hail.expr.types.{TFloat64, TString}
+import is.hail.annotations.{Annotation, Region, RegionValueBuilder, SafeRow}
+import is.hail.expr.ir._
+import is.hail.expr.types._
 import is.hail.linalg.BlockMatrix
 import is.hail.methods.{KinshipMatrix, SplitMulti}
 import is.hail.table.Table
@@ -252,5 +253,61 @@ object TestUtils {
       "varid" -> """let l = va.locus and a = va.alleles in [l.contig, str(l.position), a[0], a[1]].mkString(":")""",
       "rsid" -> "\".\"")
       .exportGen(path, precision)
+
+  def eval(x: IR): Any = {
+    eval(x, FastSeq.empty)
+  }
+
+  def eval(x: IR, env: Env[(Any, Type)]): Any = {
+    val (substEnv, args) = env.m.toFastSeq
+      .zipWithIndex
+      .foldLeft((Env.empty[IR], FastSeq.empty[(Any, Type)])) { case ((e, xs), ((n, (v, t)), i)) => (e.bind(n, In(i, t)), xs :+  (v, t)) }
+    eval(Subst(x, substEnv), args)
+  }
+
+  def eval(x: IR, args: IndexedSeq[(Any, Type)]): Any = {
+    val i = Interpret[Any](x, Env.empty[(Any, Type)], args, None)
+
+    val i2 = Interpret[Any](x, Env.empty[(Any, Type)], args, None, optimize = false)
+    assert(i == i2)
+
+    // verify compiler and interpreter agree
+    val argsVar = genUID()
+    val argsType = TTuple(args.map(_._2): _*)
+    val resultType = TTuple(x.typ)
+
+    def rewrite(x: IR): IR = {
+      x match {
+        case In(i, t) =>
+          GetTupleElement(Ref(argsVar, argsType), i)
+        case _ =>
+          Recur(rewrite)(x)
+      }
+    }
+
+    val (resultType2, f) = Compile[Long, Long]("args", argsType, MakeTuple(FastSeq(x)))
+    assert(resultType2 == resultType)
+
+    val c = Region.scoped { region =>
+      val rvb = new RegionValueBuilder(region)
+      rvb.start(argsType)
+      rvb.startTuple()
+      args.foreach { case (v, t) =>
+          rvb.addAnnotation(t, v)
+      }
+      rvb.endTuple()
+      val argsOff = rvb.end()
+
+      val resultOff = f()(region, argsOff, false)
+      SafeRow(resultType.asInstanceOf[TBaseStruct], region, resultOff).get(0)
+    }
+
+    assert(i == c)
+
+    i
+  }
+
+  def assertEvalsTo(x: IR, expected: Any) {
+    assert(eval(x) == expected)
   }
 }

--- a/src/test/scala/is/hail/TestUtils.scala
+++ b/src/test/scala/is/hail/TestUtils.scala
@@ -256,7 +256,7 @@ object TestUtils {
   }
 
   def eval(x: IR): Any = {
-    eval(x, FastSeq.empty)
+    eval(x, FastSeq())
   }
 
   def eval(x: IR, env: Env[(Any, Type)]): Any = {
@@ -286,7 +286,7 @@ object TestUtils {
       }
     }
 
-    val (resultType2, f) = Compile[Long, Long]("args", argsType, MakeTuple(FastSeq(x)))
+    val (resultType2, f) = Compile[Long, Long]("args", argsType, MakeTuple(FastSeq(rewrite(x))))
     assert(resultType2 == resultType)
 
     val c = Region.scoped { region =>

--- a/src/test/scala/is/hail/TestUtils.scala
+++ b/src/test/scala/is/hail/TestUtils.scala
@@ -250,9 +250,10 @@ object TestUtils {
   def exportGen(mt: MatrixTable, path: String, precision: Int): Unit = {
     mt.selectCols(""" {id1: sa.s, id2: sa.s, missing: 0.toFloat64} """, Some(FastIndexedSeq()))
       .annotateRowsExpr(
-      "varid" -> """let l = va.locus and a = va.alleles in [l.contig, str(l.position), a[0], a[1]].mkString(":")""",
-      "rsid" -> "\".\"")
+        "varid" -> """let l = va.locus and a = va.alleles in [l.contig, str(l.position), a[0], a[1]].mkString(":")""",
+        "rsid" -> "\".\"")
       .exportGen(path, precision)
+  }
 
   def eval(x: IR): Any = {
     eval(x, FastSeq.empty)

--- a/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -7,13 +7,12 @@ import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.expr.ir.functions.{IRFunctionRegistry, RegistryFunctions}
 import is.hail.expr.types._
+import is.hail.TestUtils._
 import org.testng.annotations.Test
 import is.hail.expr.{EvalContext, Parser}
 import is.hail.table.Table
 import is.hail.utils.FastSeq
 import is.hail.variant.Call2
-
-import scala.reflect.ClassTag
 
 object ScalaTestObject {
   def testFunction(): Int = 1
@@ -148,5 +147,32 @@ class FunctionSuite extends SparkSuite {
     val ir = lookup("UnphasedDiploidGtIndexCall", TInt32())(In(0, TInt32()))
     val f = toF[Int, Int](ir)
     assert(f(region, 0, false) == Call2.fromUnphasedDiploidGtIndex(0))
+  }
+
+  @Test
+  def testSetFunctions() {
+    val a = MakeArray(Seq(I32(1), I32(3), I32(7)), TArray(TInt32()))
+    val s = ToSet(a)
+    val t = ToSet(MakeArray(Seq(I32(3), I32(8)), TArray(TInt32())))
+
+    assertEvalsTo(s, Set(1, 3, 7))
+
+    assertEvalsTo(invoke("toSet", a), Set(1, 3, 7))
+
+    assertEvalsTo(invoke("contains", s, I32(3)), true)
+    assertEvalsTo(invoke("contains", s, I32(4)), false)
+
+    assertEvalsTo(invoke("remove", s, I32(3)), Set(1, 7))
+    assertEvalsTo(invoke("remove", s, I32(4)), Set(1, 3, 7))
+
+    assertEvalsTo(invoke("add", s, I32(3)), Set(1, 3, 7))
+    assertEvalsTo(invoke("add", s, I32(4)), Set(1, 3, 4, 7))
+
+    assertEvalsTo(invoke("isSubset", s, invoke("add", s, I32(4))), true)
+    assertEvalsTo(invoke("isSubset", s, invoke("remove", s, I32(3))), false)
+
+    assertEvalsTo(invoke("union", s, t), Set(1, 3, 7, 8))
+    assertEvalsTo(invoke("intersection", s, t), Set(3))
+    assertEvalsTo(invoke("difference", s, t), Set(1, 7))
   }
 }

--- a/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -148,31 +148,4 @@ class FunctionSuite extends SparkSuite {
     val f = toF[Int, Int](ir)
     assert(f(region, 0, false) == Call2.fromUnphasedDiploidGtIndex(0))
   }
-
-  @Test
-  def testSetFunctions() {
-    val a = MakeArray(Seq(I32(1), I32(3), I32(7)), TArray(TInt32()))
-    val s = ToSet(a)
-    val t = ToSet(MakeArray(Seq(I32(3), I32(8)), TArray(TInt32())))
-
-    assertEvalsTo(s, Set(1, 3, 7))
-
-    assertEvalsTo(invoke("toSet", a), Set(1, 3, 7))
-
-    assertEvalsTo(invoke("contains", s, I32(3)), true)
-    assertEvalsTo(invoke("contains", s, I32(4)), false)
-
-    assertEvalsTo(invoke("remove", s, I32(3)), Set(1, 7))
-    assertEvalsTo(invoke("remove", s, I32(4)), Set(1, 3, 7))
-
-    assertEvalsTo(invoke("add", s, I32(3)), Set(1, 3, 7))
-    assertEvalsTo(invoke("add", s, I32(4)), Set(1, 3, 4, 7))
-
-    assertEvalsTo(invoke("isSubset", s, invoke("add", s, I32(4))), true)
-    assertEvalsTo(invoke("isSubset", s, invoke("remove", s, I32(3))), false)
-
-    assertEvalsTo(invoke("union", s, t), Set(1, 3, 7, 8))
-    assertEvalsTo(invoke("intersection", s, t), Set(3))
-    assertEvalsTo(invoke("difference", s, t), Set(1, 7))
-  }
 }

--- a/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.expr.types._
 import is.hail.TestUtils._
-
+import is.hail.utils.FastIndexedSeq
 import org.testng.annotations.Test
 import org.scalatest.testng.TestNGSuite
 
@@ -11,5 +11,24 @@ class IRSuite extends TestNGSuite {
     assertEvalsTo(nonstrictEQ(NA(TInt32()), NA(TInt32())), true)
     assertEvalsTo(nonstrictEQ(I32(5), I32(5)), true)
     assertEvalsTo(nonstrictEQ(NA(TInt32()), I32(5)), false)
+  }
+
+  @Test def testArrayFilter() {
+    val naa = NA(TArray(TInt32()))
+        val a = MakeArray(Seq(I32(3), NA(TInt32()), I32(7)), TArray(TInt32()))
+
+    assertEvalsTo(ArrayFilter(naa, "x", True()), null)
+
+    assertEvalsTo(ArrayFilter(a, "x", NA(TBoolean())), FastIndexedSeq())
+    assertEvalsTo(ArrayFilter(a, "x", False()), FastIndexedSeq())
+    assertEvalsTo(ArrayFilter(a, "x", True()), FastIndexedSeq(3, null, 7))
+
+    assertEvalsTo(ArrayFilter(a, "x",
+      IsNA(Ref("x", TInt32()))), FastIndexedSeq(null))
+    assertEvalsTo(ArrayFilter(a, "x",
+      ApplyUnaryPrimOp(Bang(), IsNA(Ref("x", TInt32())))), FastIndexedSeq(3, 7))
+
+    assertEvalsTo(ArrayFilter(a, "x",
+      ApplyBinaryPrimOp(LT(), Ref("x", TInt32()), I32(6))), FastIndexedSeq(3))
   }
 }

--- a/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1,0 +1,15 @@
+package is.hail.expr.ir
+
+import is.hail.expr.types._
+import is.hail.TestUtils._
+
+import org.testng.annotations.Test
+import org.scalatest.testng.TestNGSuite
+
+class IRSuite extends TestNGSuite {
+  @Test def testNonstrictEQ() {
+    assertEvalsTo(nonstrictEQ(NA(TInt32()), NA(TInt32())), true)
+    assertEvalsTo(nonstrictEQ(I32(5), I32(5)), true)
+    assertEvalsTo(nonstrictEQ(NA(TInt32()), I32(5)), false)
+  }
+}

--- a/src/test/scala/is/hail/expr/ir/SetFunctionsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/SetFunctionsSuite.scala
@@ -1,0 +1,72 @@
+package is.hail.expr.ir
+
+import is.hail.expr.types._
+import is.hail.TestUtils._
+
+import org.testng.annotations.Test
+import org.scalatest.testng.TestNGSuite
+
+class SetFunctionsSuite extends TestNGSuite {
+  val naa = NA(TArray(TInt32()))
+  val a0 = MakeArray(Seq(I32(3), I32(7)), TArray(TInt32()))
+  val s0 = ToSet(a0)
+  val a = MakeArray(Seq(I32(3), NA(TInt32()), I32(7)), TArray(TInt32()))
+  val s = ToSet(a)
+  val nas = NA(TSet(TInt32()))
+  val t = ToSet(MakeArray(Seq(I32(3), I32(8)), TArray(TInt32())))
+  val t2 = ToSet(MakeArray(Seq(I32(3), I32(8), NA(TInt32())), TArray(TInt32())))
+
+  @Test def toSet() {
+    assertEvalsTo(s0, Set(3, 7))
+    assertEvalsTo(s, Set(null, 3, 7))
+    assertEvalsTo(nas, null)
+    assertEvalsTo(ToSet(naa), null)
+    assertEvalsTo(invoke("toSet", a0), Set(3, 7))
+    assertEvalsTo(invoke("toSet", a), Set(null, 3, 7))
+    assertEvalsTo(invoke("toSet", naa), null)
+  }
+
+  @Test def contains() {
+    assertEvalsTo(invoke("contains", s, I32(3)), true)
+    assertEvalsTo(invoke("contains", s, I32(4)), false)
+    assertEvalsTo(invoke("contains", s, NA(TInt32())), true)
+    assertEvalsTo(invoke("contains", s0, NA(TInt32())), false)
+  }
+
+  @Test def remove() {
+    assertEvalsTo(invoke("remove", s, I32(3)), Set(null, 7))
+    assertEvalsTo(invoke("remove", s, I32(4)), Set(null, 3, 7))
+    assertEvalsTo(invoke("remove", s, NA(TInt32())), Set(3, 7))
+    assertEvalsTo(invoke("remove", s0, NA(TInt32())), Set(3, 7))
+  }
+
+  @Test def add() {
+    assertEvalsTo(invoke("add", s, I32(3)), Set(null, 3, 7))
+    assertEvalsTo(invoke("add", s, I32(4)), Set(null, 3, 4, 7))
+    assertEvalsTo(invoke("add", s, I32(4)), Set(null, 3, 4, 7))
+    assertEvalsTo(invoke("add", s, NA(TInt32())), Set(null, 3, 7))
+    assertEvalsTo(invoke("add", s0, NA(TInt32())), Set(null, 3, 7))
+  }
+
+  @Test def isSubset() {
+    assertEvalsTo(invoke("isSubset", s, invoke("add", s, I32(4))), true)
+    assertEvalsTo(invoke("isSubset", s0, invoke("add", s0, NA(TInt32()))), true)
+    assertEvalsTo(invoke("isSubset", s, invoke("remove", s, I32(3))), false)
+    assertEvalsTo(invoke("isSubset", s, invoke("remove", s, NA(TInt32()))), false)
+  }
+
+  @Test def union() {
+    assertEvalsTo(invoke("union", s, t), Set(null, 3, 7, 8))
+    assertEvalsTo(invoke("union", s0, t2), Set(null, 3, 7, 8))
+  }
+
+  @Test def intersection() {
+    assertEvalsTo(invoke("intersection", s, t), Set(3))
+    assertEvalsTo(invoke("intersection", s, t2), Set(null, 3))
+  }
+
+  @Test def difference() {
+    assertEvalsTo(invoke("difference", s, t), Set(null, 7))
+    assertEvalsTo(invoke("difference", s, t2), Set(7))
+  }
+}

--- a/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
@@ -5,14 +5,12 @@ import is.hail.annotations._
 import is.hail.check.Prop._
 import is.hail.check.Parameters
 import is.hail.linalg.BlockMatrix
-import is.hail.expr.types._
 import is.hail.utils._
 import is.hail.testUtils._
 import is.hail.variant._
 import is.hail.{SparkSuite, TestUtils}
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics
 import org.apache.commons.math3.stat.regression.SimpleRegression
-import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
 import scala.language.postfixOps


### PR DESCRIPTION
Added the straightforward implementations to get them in the IRFunctionRegistry.  They are not optimal from the computational complexity perspective (e.g. union is n log m instead of n + m).  I will improve them in a separate PR.