### PR TITLE
ReferenceGenome-dependent constructors in the function registry

### DIFF
--- a/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -31,7 +31,7 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: Type, var
   private var elementsOffset: ClassFieldRef[Long] = _
   private val startOffset: ClassFieldRef[Long] = mb.newField[Long]
 
-  typ match {
+  typ.fundamentalType match {
     case t: TBaseStruct => elementsOffset = mb.newField[Long]
     case t: TArray =>
       elementsOffset = mb.newField[Long]

--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -184,6 +184,14 @@ object Code {
   def invokeScalaObject[A1, A2, A3, S](cls: Class[_], method: String, a1: Code[A1], a2: Code[A2], a3: Code[A3])(implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2], a3ct: ClassTag[A3], sct: ClassTag[S]): Code[S] =
     invokeScalaObject[S](cls, method, Array[Class[_]](a1ct.runtimeClass, a2ct.runtimeClass, a3ct.runtimeClass), Array(a1, a2, a3))
 
+  def invokeScalaObject[A1, A2, A3, A4, A5, A6, S](
+    cls: Class[_], method: String, a1: Code[A1], a2: Code[A2], a3: Code[A3], a4: Code[A4], a5: Code[A5], a6: Code[A6])(
+    implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2], a3ct: ClassTag[A3], a4ct: ClassTag[A4], a5ct: ClassTag[A5], a6ct: ClassTag[A5], sct: ClassTag[S]
+  ): Code[S] =
+    invokeScalaObject[S](
+      cls, method, Array[Class[_]](
+        a1ct.runtimeClass, a2ct.runtimeClass, a3ct.runtimeClass, a4ct.runtimeClass, a5ct.runtimeClass, a6ct.runtimeClass), Array(a1, a2, a3, a4, a5, a6))
+
   def invokeStatic[S](cls: Class[_], method: String, parameterTypes: Array[Class[_]], args: Array[Code[_]])(implicit sct: ClassTag[S]): Code[S] = {
     val m = Invokeable.lookupMethod(cls, method, parameterTypes)(sct)
     assert(m.isStatic)

--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -186,7 +186,7 @@ object Code {
 
   def invokeScalaObject[A1, A2, A3, A4, A5, A6, S](
     cls: Class[_], method: String, a1: Code[A1], a2: Code[A2], a3: Code[A3], a4: Code[A4], a5: Code[A5], a6: Code[A6])(
-    implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2], a3ct: ClassTag[A3], a4ct: ClassTag[A4], a5ct: ClassTag[A5], a6ct: ClassTag[A5], sct: ClassTag[S]
+    implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2], a3ct: ClassTag[A3], a4ct: ClassTag[A4], a5ct: ClassTag[A5], a6ct: ClassTag[A6], sct: ClassTag[S]
   ): Code[S] =
     invokeScalaObject[S](
       cls, method, Array[Class[_]](

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -30,10 +30,8 @@ object IRFunctionRegistry {
     codeRegistry.removeBinding(name, toRemove.head)
   }
 
-  def removeIRFunction(name: String): Unit = {
-    val toRemove = codeRegistry(name).toArray
-    toRemove.foreach(codeRegistry.removeBinding(name, _))
-  }
+  def removeIRFunction(name: String): Unit =
+    codeRegistry.remove(name)
 
   private def lookupInRegistry[T](reg: mutable.MultiMap[String, T], name: String, args: Seq[Type], cond: (T, Seq[Type]) => Boolean): Option[T] = {
     reg.lift(name).map { fs => fs.filter(t => cond(t, args)).toSeq }.getOrElse(FastSeq()) match {

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -32,8 +32,7 @@ object IRFunctionRegistry {
 
   def removeIRFunction(name: String): Unit = {
     val toRemove = codeRegistry(name).toArray
-    assert(toRemove.length == 1)
-    codeRegistry.removeBinding(name, toRemove.head)
+    toRemove.foreach(codeRegistry.removeBinding(name, _))
   }
 
   private def lookupInRegistry[T](reg: mutable.MultiMap[String, T], name: String, args: Seq[Type], cond: (T, Seq[Type]) => Boolean): Option[T] = {

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -23,6 +23,19 @@ object IRFunctionRegistry {
   def addIR(name: String, types: Seq[Type], f: Seq[IR] => IR): Unit =
     irRegistry.addBinding(name, (types, f))
 
+  def removeIRFunction(name: String, args: Seq[Type]): Unit = {
+    val functions = codeRegistry(name)
+    val toRemove = functions.filter(_.unify(args)).toArray
+    assert(toRemove.length == 1)
+    codeRegistry.removeBinding(name, toRemove.head)
+  }
+
+  def removeIRFunction(name: String): Unit = {
+    val toRemove = codeRegistry(name).toArray
+    assert(toRemove.length == 1)
+    codeRegistry.removeBinding(name, toRemove.head)
+  }
+
   private def lookupInRegistry[T](reg: mutable.MultiMap[String, T], name: String, args: Seq[Type], cond: (T, Seq[Type]) => Boolean): Option[T] = {
     reg.lift(name).map { fs => fs.filter(t => cond(t, args)).toSeq }.getOrElse(FastSeq()) match {
       case Seq() => None

--- a/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
@@ -1,0 +1,182 @@
+package is.hail.expr.ir.functions
+
+import is.hail.annotations.StagedRegionValueBuilder
+import is.hail.asm4s
+import is.hail.asm4s._
+import is.hail.expr.ir.EmitMethodBuilder
+import is.hail.expr.types
+import is.hail.expr.types._
+import is.hail.utils.Interval
+import is.hail.variant.{Locus, ReferenceGenome, VariantMethods}
+
+class ReferenceGenomeFunctions(rg: ReferenceGenome) extends RegistryFunctions {
+
+  def rgCode(mb: EmitMethodBuilder): Code[ReferenceGenome] = mb.getReferenceGenome(rg)
+
+  def emitLocus(mb: EmitMethodBuilder, locus: Code[Locus]): Code[Long] = {
+    val srvb = new StagedRegionValueBuilder(mb, TLocus(rg))
+    Code(
+      srvb.start(),
+      srvb.addString(locus.get[String]("contig")),
+      srvb.advance(),
+      srvb.addInt(locus.get[Int]("position")),
+      srvb.advance(),
+      srvb.offset)
+  }
+
+  def emitVariant(mb: EmitMethodBuilder, variant: Code[(Locus, IndexedSeq[String])]): Code[Long] = {
+    val vlocal = mb.newLocal[(Locus, IndexedSeq[String])]
+    val alocal = mb.newLocal[IndexedSeq[String]]
+    val len = mb.newLocal[Int]
+    val srvb = new StagedRegionValueBuilder(mb, tvariant)
+    val addAlleles = { srvb: StagedRegionValueBuilder =>
+      Code(
+        srvb.start(len),
+        Code.whileLoop(srvb.arrayIdx < len,
+          srvb.addString(alocal.invoke[Int, String]("apply", srvb.arrayIdx)),
+          srvb.advance()))
+    }
+
+    Code(
+      vlocal := variant,
+      alocal := vlocal.get("_2"),
+      len := alocal.invoke[Int]("size"),
+      srvb.start(),
+      emitLocus(mb, vlocal.get("_1")),
+      srvb.advance(),
+      srvb.addArray(talleles, addAlleles),
+      srvb.advance(),
+      srvb.offset)
+  }
+
+  def emitInterval(mb: EmitMethodBuilder, interval: Code[Interval]): Code[Long] = {
+    val ilocal = mb.newLocal[Interval]
+    val plocal = mb.newLocal[Locus]
+    val srvb = new StagedRegionValueBuilder(mb, tinterval)
+
+    asm4s.coerce[Long](Code(
+      ilocal := interval,
+      srvb.start(),
+      emitLocus(mb, Code.checkcast[Locus](ilocal.get[java.lang.Object]("start"))),
+      srvb.advance(),
+      emitLocus(mb, Code.checkcast[Locus](ilocal.get[java.lang.Object]("end"))),
+      srvb.advance(),
+      srvb.addBoolean(ilocal.get[Boolean]("includesStart")),
+      srvb.advance(),
+      srvb.addBoolean(ilocal.get[Boolean]("includesEnd")),
+      srvb.advance(),
+      srvb.offset))
+  }
+
+  var registered: Set[String] = Set[String]()
+
+  val tlocus = TLocus(rg)
+  val talleles = TArray(TString())
+  val tvariant = TStruct("locus" -> tlocus, "alleles" -> talleles)
+  val tinterval = TInterval(tlocus)
+
+  def removeRegisteredFunctions(): Unit =
+    registered.foreach(IRFunctionRegistry.removeIRFunction)
+
+  def registerRGCode(
+    mname: String, args: Array[Type], rt: Type, isDeterministic: Boolean)(
+    impl: (EmitMethodBuilder, Array[Code[_]]) => Code[_]
+  ): Unit = {
+    val newName = rg.wrapFunctionName(mname)
+    registered += newName
+    registerCode(newName, args, rt, isDeterministic)(impl)
+  }
+
+  def registerRGCode(
+    mname: String, arg1: Type, rt: Type, isDeterministic: Boolean)(
+    impl: (EmitMethodBuilder, Code[_]) => Code[_]
+  ): Unit =
+    registerRGCode(mname, Array[Type](arg1), rt, isDeterministic) { case (mb, Array()) => impl(mb) }
+
+  def registerRGCode(
+    mname: String, arg1: Type, rt: Type)(
+    impl: (EmitMethodBuilder, Code[_]) => Code[_]
+  ): Unit = registerRGCode(mname, arg1, rt, isDeterministic = true)(impl)
+
+  def registerRGCode(
+    mname: String, arg1: Type, arg2: Type, rt: Type, isDeterministic: Boolean)(
+    impl: (EmitMethodBuilder, Code[_], Code[_]) => Code[_]
+  ): Unit =
+    registerRGCode(mname, Array[Type](arg1, arg2), rt, isDeterministic) { case (mb, Array()) => impl(mb) }
+
+  def registerRGCode(
+    mname: String, arg1: Type, arg2: Type, rt: Type)(
+    impl: (EmitMethodBuilder, Code[_], Code[_]) => Code[_]
+  ): Unit = registerRGCode(mname, arg1, arg2, rt, isDeterministic = true)(impl)
+
+  def registerRGCode(
+    mname: String, arg1: Type, arg2: Type, arg3: Type, arg4: Type, arg5: Type, rt: Type, isDeterministic: Boolean)(
+    impl: (EmitMethodBuilder, Code[_], Code[_], Code[_], Code[_], Code[_]) => Code[_]
+  ): Unit =
+    registerRGCode(mname, Array[Type](arg1, arg2, arg3, arg4, arg5), rt, isDeterministic) { case (mb, Array()) => impl(mb) }
+
+  def registerRGCode(
+    mname: String, arg1: Type, arg2: Type, arg3: Type, arg4: Type, arg5: Type, rt: Type)(
+    impl: (EmitMethodBuilder, Code[_], Code[_], Code[_], Code[_], Code[_]) => Code[_]
+  ): Unit = registerRGCode(mname, arg1, arg2, arg3, arg4, arg5, rt, isDeterministic = true)(impl)
+
+  def registerAll() {
+
+    val locusClass = Locus.getClass
+
+    registerRGCode("Locus", TString(), TLocus(rg)) {
+      case (mb, locusoff: Code[Long]) =>
+        val slocus = asm4s.coerce[String](wrapArg(mb, TString())(locusoff))
+        val locus = Code
+          .invokeScalaObject[String, ReferenceGenome, Locus](
+          locusClass, "parse", slocus, rgCode(mb))
+        emitLocus(mb, locus)
+    }
+
+    registerRGCode("Locus", TString(), TInt32(), TLocus(rg)) {
+      case (mb, contig: Code[Long], pos: Code[Int]) =>
+        val scontig = asm4s.coerce[String](wrapArg(mb, TString())(contig))
+        val locus = Code
+          .invokeScalaObject[String, Int, ReferenceGenome, Locus](
+          locusClass, "apply", scontig, pos, rgCode(mb))
+        emitLocus(mb, locus)
+    }
+
+    registerRGCode("LocusAlleles", TString(), tvariant) {
+      case (mb, variantoff: Code[Long]) =>
+        val svar = asm4s.coerce[String](wrapArg(mb, TString())(variantoff))
+        val variant = Code
+          .invokeScalaObject[String, ReferenceGenome, (Locus, IndexedSeq[String])](
+          VariantMethods.getClass, "parse", svar, rgCode(mb))
+        emitVariant(mb, variant)
+    }
+
+
+    registerRGCode("LocusInterval", TString(), tinterval) {
+      case (mb, variantoff: Code[Long]) =>
+        val svar = asm4s.coerce[String](wrapArg(mb, TString())(variantoff))
+        val variant = Code
+          .invokeScalaObject[String, ReferenceGenome, (Locus, IndexedSeq[String])](
+          VariantMethods.getClass, "parse", svar, rgCode(mb))
+        emitVariant(mb, variant)
+    }
+
+    registerRGCode("LocusInterval", TString(), tinterval) {
+      case (mb, ioff: Code[Long]) =>
+        val sinterval = asm4s.coerce[String](wrapArg(mb, TString())(ioff))
+        val interval = Code
+          .invokeScalaObject[String, ReferenceGenome, Interval](
+          locusClass, "parseInterval", sinterval, rgCode(mb))
+        emitInterval(mb, interval)
+    }
+
+    registerRGCode("LocusInterval", TString(), TInt32(), TInt32(), TBoolean(), TBoolean(), tinterval) {
+      case (mb, locoff: Code[Long], pos1: Code[Int], pos2: Code[Int], include1: Code[Boolean], include2: Code[Boolean]) =>
+        val sloc = asm4s.coerce[String](wrapArg(mb, TString())(locoff))
+        val interval = Code
+          .invokeScalaObject[String, Int, Int, Boolean, Boolean, ReferenceGenome, Interval](
+          locusClass, "makeInterval", sloc, pos1, pos2, include1, include2, rgCode(mb))
+        emitInterval(mb, interval)
+    }
+  }
+}

--- a/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
@@ -62,13 +62,16 @@ class ReferenceGenomeFunctions(rg: ReferenceGenome) extends RegistryFunctions {
     val ilocal = mb.newLocal[Interval]
     val plocal = mb.newLocal[Locus]
     val srvb = new StagedRegionValueBuilder(mb, tinterval)
+    val addLocus = { (srvb: StagedRegionValueBuilder, point: String) =>
+      emitLocus(srvb, Code.checkcast[Locus](ilocal.invoke[java.lang.Object](point)))
+    }
 
     asm4s.coerce[Long](Code(
       ilocal := interval,
       srvb.start(),
-      emitLocus(mb, Code.checkcast[Locus](ilocal.invoke[java.lang.Object]("start"))),
+      srvb.addBaseStruct(types.coerce[TBaseStruct](tlocus.fundamentalType), addLocus(_, "start")),
       srvb.advance(),
-      emitLocus(mb, Code.checkcast[Locus](ilocal.invoke[java.lang.Object]("end"))),
+      srvb.addBaseStruct(types.coerce[TBaseStruct](tlocus.fundamentalType), addLocus(_, "end")),
       srvb.advance(),
       srvb.addBoolean(ilocal.invoke[Boolean]("includesStart")),
       srvb.advance(),

--- a/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
@@ -149,11 +149,15 @@ class ReferenceGenomeFunctions(rg: ReferenceGenome) extends RegistryFunctions {
 
     registerRGCode("Locus", TString(), TInt32(), TLocus(rg)) {
       case (mb, contig: Code[Long], pos: Code[Int]) =>
+        val srvb = new StagedRegionValueBuilder(mb, tlocus)
         val scontig = asm4s.coerce[String](wrapArg(mb, TString())(contig))
-        val locus = Code
-          .invokeScalaObject[String, Int, RGBase, Locus](
-          locusClass, "apply", scontig, pos, rgCode(mb))
-        emitLocus(mb, locus)
+        Code(
+          rgCode(mb).invoke[String, Int, Unit]("checkLocus", scontig, pos),
+          srvb.start(),
+          srvb.addIRIntermediate(TString())(contig),
+          srvb.advance(),
+          srvb.addInt(pos),
+          srvb.offset)
     }
 
     registerRGCode("LocusAlleles", TString(), tvariant) {

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -4,7 +4,7 @@ import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.expr._
 import is.hail.expr.ir
-import is.hail.expr.ir.{IR, Pretty}
+import is.hail.expr.ir.IR
 import is.hail.expr.types._
 import is.hail.io.plink.{FamFileConfig, LoadPlink}
 import is.hail.methods.Aggregators

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -4,7 +4,7 @@ import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.expr._
 import is.hail.expr.ir
-import is.hail.expr.ir.IR
+import is.hail.expr.ir.{IR, Pretty}
 import is.hail.expr.types._
 import is.hail.io.plink.{FamFileConfig, LoadPlink}
 import is.hail.methods.Aggregators


### PR DESCRIPTION
cc @jigold I'm pretty sure this works, but I'd appreciate a look just in case. 

There's a set of tests in ReferenceGenomeSuite.testConstructors to test the functions, including one with a fake reference. I didn't add any more tests because those are now running through IR (I checked). But I can move the tests to python if desired.