### PR TITLE
Added InitOp IR, RegionValueCallStatsAggregator

### DIFF
--- a/python/hail/expr/aggregators.py
+++ b/python/hail/expr/aggregators.py
@@ -970,7 +970,7 @@ def call_stats(expr, alleles) -> StructExpression:
     alleles = to_expr(alleles)
     uid = Env.get_uid()
 
-    ast = LambdaClassMethod('callStats', uid, expr._ast, alleles._ast)
+    ast = LambdaClassMethod('callStats', uid, expr._ast, alleles._ast) # FIXME: This should be _agg_func once the AST is gone
     indices, aggregations, joins = unify_all(expr, alleles)
 
     if aggregations:

--- a/python/hail/expr/aggregators.py
+++ b/python/hail/expr/aggregators.py
@@ -922,22 +922,22 @@ def call_stats(expr, alleles) -> StructExpression:
 
         >>> dataset_result = dataset.annotate_rows(gt_stats = agg.call_stats(dataset.GT, dataset.alleles))
         >>> dataset_result.rows().key_by('locus').select('gt_stats').show()
-        +---------------+--------------+----------------+-------------+
-        | locus         | gt_stats.AC  | gt_stats.AF    | gt_stats.AN |
-        +---------------+--------------+----------------+-------------+
-        | locus<GRCh37> | array<int32> | array<float64> |       int32 |
-        +---------------+--------------+----------------+-------------+
-        | 20:10019093   | [111,89]     | [0.555,0.445]  |         200 |
-        | 20:10026348   | [198,2]      | [0.99,0.01]    |         200 |
-        | 20:10026357   | [166,34]     | [0.83,0.17]    |         200 |
-        | 20:10030188   | [166,34]     | [0.83,0.17]    |         200 |
-        | 20:10030452   | [170,30]     | [0.85,0.15]    |         200 |
-        | 20:10030508   | [199,1]      | [0.995,0.005]  |         200 |
-        | 20:10030573   | [198,2]      | [0.99,0.01]    |         200 |
-        | 20:10032413   | [166,34]     | [0.83,0.17]    |         200 |
-        | 20:10036107   | [187,13]     | [0.935,0.065]  |         200 |
-        | 20:10036141   | [192,8]      | [0.96,0.04]    |         200 |
-        +---------------+--------------+----------------+-------------+
+        +---------------+--------------+----------------+-------------+---------------------------+
+        | locus         | gt_stats.AC  | gt_stats.AF    | gt_stats.AN | gt_stats.homozygote_count |
+        +---------------+--------------+----------------+-------------+---------------------------+
+        | locus<GRCh37> | array<int32> | array<float64> |       int32 | array<int32>              |
+        +---------------+--------------+----------------+-------------+---------------------------+
+        | 20:10579373   | [199,1]      | [0.995,0.005]  |         200 | [99,0]                    |
+        | 20:13695607   | [177,23]     | [0.885,0.115]  |         200 | [77,0]                    |
+        | 20:13698129   | [198,2]      | [0.99,0.01]    |         200 | [98,0]                    |
+        | 20:14306896   | [142,58]     | [0.71,0.29]    |         200 | [51,9]                    |
+        | 20:14306953   | [121,79]     | [0.605,0.395]  |         200 | [38,17]                   |
+        | 20:15948325   | [172,2]      | [0.989,0.012]  |         174 | [85,0]                    |
+        | 20:15948326   | [174,8]      | [0.956,0.043]  |         182 | [83,0]                    |
+        | 20:17479423   | [199,1]      | [0.995,0.005]  |         200 | [99,0]                    |
+        | 20:17600357   | [79,121]     | [0.395,0.605]  |         200 | [24,45]                   |
+        | 20:17640833   | [193,3]      | [0.985,0.015]  |         196 | [95,0]                    |
+        +---------------+--------------+----------------+-------------+---------------------------+
 
     Notes
     -----
@@ -952,6 +952,8 @@ def call_stats(expr, alleles) -> StructExpression:
        element for each allele, including the reference.
      - `AN` (:py:data:`.tint32`) - Allele number. The total number of called
        alleles, or the number of non-missing calls * 2.
+     - `homozygote_count` (:class:`.tarray` of :py:data:`.tint32`) - Homozygote
+       genotype counts for each allele, including the reference.
 
     Parameters
     ----------
@@ -963,7 +965,7 @@ def call_stats(expr, alleles) -> StructExpression:
     Returns
     -------
     :class:`.StructExpression`
-        Struct expression with fields `AC`, `AF`, and `AN`.
+        Struct expression with fields `AC`, `AF`, `AN`, and `homozygote_count`.
     """
     alleles = to_expr(alleles)
     uid = Env.get_uid()
@@ -978,7 +980,8 @@ def call_stats(expr, alleles) -> StructExpression:
     _check_agg_bindings(alleles)
     t = tstruct(AC=tarray(tint32),
                 AF=tarray(tfloat64),
-                AN=tint32)
+                AN=tint32,
+                homozygote_count=tarray(tint32))
 
     return construct_expr(ast, t, Indices(source=indices.source),
                           aggregations.push(Aggregation(expr, alleles)), joins)

--- a/python/hail/tests/test_api.py
+++ b/python/hail/tests/test_api.py
@@ -266,7 +266,7 @@ class TableTests(unittest.TestCase):
         expected = {u'status': 0,
                     u'x13': {u'n_called': 2, u'expected_homs': 1.64, u'f_stat': -1.777777777777777,
                              u'observed_homs': 1},
-                    u'x14': {u'AC': [3, 1], u'AF': [0.75, 0.25], u'AN': 4},
+                    u'x14': {u'AC': [3, 1], u'AF': [0.75, 0.25], u'AN': 4, u'homozygote_count': [1, 0]},
                     u'x15': {u'a': 5, u'c': {u'banana': u'apple'}, u'b': u'foo'},
                     u'x10': {u'min': 3.0, u'max': 13.0, u'sum': 16.0, u'stdev': 5.0, u'n': 2, u'mean': 8.0},
                     u'x8': 1, u'x9': 0.0, u'x16': u'apple',

--- a/python/hail/tests/test_expr.py
+++ b/python/hail/tests/test_expr.py
@@ -1267,6 +1267,24 @@ class Tests(unittest.TestCase):
         self.assertFalse(hl.is_valid_locus('1', 249250622, 'GRCh37').value)
         self.assertFalse(hl.is_valid_locus('chr1', 2645, 'GRCh37').value)
 
+    def test_call_stats(self):
+        t = (hl.utils.range_table(5, 3)
+             .annotate(GT = hl.call(0, 1))
+             .annotate_globals(alleles=["A", "T"]))
+
+        self.assertTrue(t.aggregate(agg.call_stats(t.GT, t.alleles)) == hl.Struct(AC=[5, 5], AF=[0.5, 0.5], AN=10)) # Tests table.aggregate initOp
+
+        mt = (hl.utils.range_matrix_table(10, 5, 3)
+              .annotate_entries(GT=hl.call(0, 1))
+              .annotate_rows(alleles=["A", "T"])
+              .annotate_globals(alleles2=["G", "C"]))
+
+        row_agg = mt.annotate_rows(call_stats=agg.call_stats(mt.GT, mt.alleles)).rows() # Tests MatrixMapRows initOp
+        col_agg = mt.annotate_cols(call_stats=agg.call_stats(mt.GT, mt.alleles2)).cols() # Tests MatrixMapCols initOp
+
+        self.assertTrue(row_agg.all(row_agg.call_stats == hl.struct(AC=[5, 5], AF=[0.5, 0.5], AN=10)))
+        self.assertTrue(col_agg.all(col_agg.call_stats == hl.struct(AC=[10, 10], AF=[0.5, 0.5], AN=20)))
+
     def test_mendel_error_code(self):
         locus_auto = hl.Locus('2', 20000000)
         locus_x_par = hl.get_reference('default').par[0].start

--- a/python/hail/tests/test_expr.py
+++ b/python/hail/tests/test_expr.py
@@ -1272,9 +1272,10 @@ class Tests(unittest.TestCase):
              .annotate(GT = hl.call(0, 1))
              .annotate_globals(alleles=["A", "T"]))
 
-        self.assertTrue(t.aggregate(agg.call_stats(t.GT, t.alleles)) == hl.Struct(AC=[5, 5], AF=[0.5, 0.5], AN=10)) # Tests table.aggregate initOp
+        self.assertTrue(t.aggregate(agg.call_stats(t.GT, t.alleles)) ==
+                        hl.Struct(AC=[5, 5], AF=[0.5, 0.5], AN=10, homozygote_count=[0, 0])) # Tests table.aggregate initOp
 
-        mt = (hl.utils.range_matrix_table(10, 5, 3)
+        mt = (hl.utils.range_matrix_table(10, 5, 5)
               .annotate_entries(GT=hl.call(0, 1))
               .annotate_rows(alleles=["A", "T"])
               .annotate_globals(alleles2=["G", "C"]))
@@ -1282,8 +1283,10 @@ class Tests(unittest.TestCase):
         row_agg = mt.annotate_rows(call_stats=agg.call_stats(mt.GT, mt.alleles)).rows() # Tests MatrixMapRows initOp
         col_agg = mt.annotate_cols(call_stats=agg.call_stats(mt.GT, mt.alleles2)).cols() # Tests MatrixMapCols initOp
 
-        self.assertTrue(row_agg.all(row_agg.call_stats == hl.struct(AC=[5, 5], AF=[0.5, 0.5], AN=10)))
-        self.assertTrue(col_agg.all(col_agg.call_stats == hl.struct(AC=[10, 10], AF=[0.5, 0.5], AN=20)))
+        self.assertTrue(row_agg.all(row_agg.call_stats ==
+                                    hl.struct(AC=[5, 5], AF=[0.5, 0.5], AN=10, homozygote_count=[0, 0])))
+        self.assertTrue(col_agg.all(col_agg.call_stats ==
+                                    hl.struct(AC=[10, 10], AF=[0.5, 0.5], AN=20, homozygote_count=[0, 0])))
 
     def test_mendel_error_code(self):
         locus_auto = hl.Locus('2', 20000000)

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCallStatsAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCallStatsAggregator.scala
@@ -45,21 +45,7 @@ class RegionValueCallStatsAggregator extends RegionValueAggregator {
 
   def result(rvb: RegionValueBuilder): Unit = {
     if (combiner != null) {
-      val r = combiner.result()
-      rvb.startStruct()
-      rvb.startArray(r.alleleCount.length)
-      r.alleleCount.foreach(rvb.addInt _)
-      rvb.endArray()
-      r.alleleFrequency match {
-        case Some(af) =>
-          rvb.startArray(af.length)
-          af.foreach(rvb.addDouble _)
-          rvb.endArray()
-        case None =>
-          rvb.setMissing()
-      }
-      rvb.addInt(r.alleleNumber)
-      rvb.endStruct()
+      combiner.result(rvb)
     } else
       rvb.setMissing()
   }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCallStatsAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCallStatsAggregator.scala
@@ -1,0 +1,73 @@
+package is.hail.annotations.aggregators
+
+import is.hail.annotations.{Region, RegionValueBuilder}
+import is.hail.expr.types.{TArray, TString, TStruct}
+import is.hail.stats.{CallStats, CallStatsCombiner}
+import is.hail.utils.ArrayBuilder
+import is.hail.variant.Call
+
+object RegionValueCallStatsAggregator {
+  val allelesTyp = TArray(TString())
+  val typ: TStruct = CallStats.schema
+}
+
+class RegionValueCallStatsAggregator extends RegionValueAggregator {
+  private var combiner: CallStatsCombiner = _
+  private var alleles: Array[String] = _
+
+  def initOp(region: Region, offset: Long, missing: Boolean): Unit = {
+    if (!missing) {
+      val l = RegionValueCallStatsAggregator.allelesTyp.loadLength(region, offset)
+      alleles = new Array[String](l)
+      var i = 0
+      while (i < l) {
+        assert(RegionValueCallStatsAggregator.allelesTyp.isElementDefined(region, offset, i))
+        alleles(i) = TString.loadString(region, RegionValueCallStatsAggregator.allelesTyp.loadElement(region, offset, i))
+        i += 1
+      }
+      combiner = new CallStatsCombiner(alleles)
+    }
+  }
+
+  def seqOp(x: Call, missing: Boolean): Unit = {
+    if (combiner != null && !missing)
+      combiner.merge(x)
+  }
+
+  def combOp(agg2: RegionValueAggregator): Unit = {
+    val other = agg2.asInstanceOf[RegionValueCallStatsAggregator]
+    if (other.combiner != null) {
+      if (combiner == null)
+        combiner = new CallStatsCombiner(other.combiner.alleles)
+    }
+    combiner.merge(other.combiner)
+  }
+
+  def result(rvb: RegionValueBuilder): Unit = {
+    if (combiner != null) {
+      val r = combiner.result()
+      rvb.startStruct()
+      rvb.startArray(r.alleleCount.length)
+      r.alleleCount.foreach(rvb.addInt _)
+      rvb.endArray()
+      r.alleleFrequency match {
+        case Some(af) =>
+          rvb.startArray(af.length)
+          af.foreach(rvb.addDouble _)
+          rvb.endArray()
+        case None =>
+          rvb.setMissing()
+      }
+      rvb.addInt(r.alleleNumber)
+      rvb.endStruct()
+    } else
+      rvb.setMissing()
+  }
+
+  def copy() = new RegionValueCallStatsAggregator()
+
+  def clear() {
+    combiner = null
+    alleles = null
+  }
+}

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCallStatsAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCallStatsAggregator.scala
@@ -7,26 +7,15 @@ import is.hail.utils.ArrayBuilder
 import is.hail.variant.Call
 
 object RegionValueCallStatsAggregator {
-  val allelesTyp = TArray(TString())
   val typ: TStruct = CallStats.schema
 }
 
 class RegionValueCallStatsAggregator extends RegionValueAggregator {
   private var combiner: CallStatsCombiner = _
-  private var alleles: Array[String] = _
 
-  def initOp(region: Region, offset: Long, missing: Boolean): Unit = {
-    if (!missing) {
-      val l = RegionValueCallStatsAggregator.allelesTyp.loadLength(region, offset)
-      alleles = new Array[String](l)
-      var i = 0
-      while (i < l) {
-        assert(RegionValueCallStatsAggregator.allelesTyp.isElementDefined(region, offset, i))
-        alleles(i) = TString.loadString(region, RegionValueCallStatsAggregator.allelesTyp.loadElement(region, offset, i))
-        i += 1
-      }
-      combiner = new CallStatsCombiner(alleles)
-    }
+  def initOp(nAlleles: Int, missing: Boolean): Unit = {
+    if (!missing)
+      combiner = new CallStatsCombiner(nAlleles)
   }
 
   def seqOp(x: Call, missing: Boolean): Unit = {
@@ -38,7 +27,7 @@ class RegionValueCallStatsAggregator extends RegionValueAggregator {
     val other = agg2.asInstanceOf[RegionValueCallStatsAggregator]
     if (other.combiner != null) {
       if (combiner == null)
-        combiner = new CallStatsCombiner(other.combiner.alleles)
+        combiner = new CallStatsCombiner(other.combiner.nAlleles)
     }
     combiner.merge(other.combiner)
   }
@@ -54,6 +43,5 @@ class RegionValueCallStatsAggregator extends RegionValueAggregator {
 
   def clear() {
     combiner = null
-    alleles = null
   }
 }

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -856,6 +856,7 @@ case class ApplyMethod(posn: Position, lhs: AST, method: String, args: Array[AST
               case (_: TAggregable, "map") => ir.AggMap(a, name, b)
               case (_: TAggregable, "filter") => ir.AggFilter(a, name, b)
               case (_: TAggregable, "flatMap") => ir.AggFlatMap(a, name, b)
+              case (_: TAggregable, "callStats") => ir.ApplyAggOp(a, ir.CallStats(), FastSeq(), Some(FastSeq(b)))
               case (_: TArray, "map") => ir.ArrayMap(a, name, b)
               case (_: TArray, "filter") => ir.ArrayFilter(a, name, b)
               case (_: TArray, "flatMap") => ir.ArrayFlatMap(a, name, b)

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -1327,7 +1327,7 @@ object FunctionRegistry {
   })
 
   registerLambdaAggregator[Call, (Any) => Any, Any]("callStats", (vf: (Any) => Any) => new CallStatsAggregator(vf)
-  )(aggregableHr(callHr), unaryHr(callHr, arrayHr(stringHr)), new HailRep[Any] {
+  )(aggregableHr(callHr), unaryHr(callHr, int32Hr), new HailRep[Any] {
       def typ = CallStats.schema
     })
 

--- a/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -52,7 +52,7 @@ object AggOp {
     m((op, inputType, constructorTypes, initOpTypes)).getOrElse(incompatible(op, inputType, constructorTypes, initOpTypes)).out
 
   private val m: ((AggOp, Type, Seq[Type], Option[Seq[Type]])) => Option[CodeAggregator[T] forSome { type T <: RegionValueAggregator }] = lift {
-    case (Fraction(), in: TBoolean, Seq(), None) => CodeAggregator[RegionValueFractionAggregator](in, TArray(TFloat64()))
+    case (Fraction(), in: TBoolean, Seq(), None) => CodeAggregator[RegionValueFractionAggregator](in, TFloat64())
     case (Statistics(), in: TFloat64, Seq(), None) => CodeAggregator[RegionValueStatisticsAggregator](in, RegionValueStatisticsAggregator.typ)
     case (Collect(), in: TBoolean, Seq(), None) => CodeAggregator[RegionValueCollectBooleanAggregator](in, TArray(TBoolean()))
     case (Collect(), in: TInt32, Seq(), None) => CodeAggregator[RegionValueCollectIntAggregator](in, TArray(TInt32()))

--- a/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -95,8 +95,8 @@ object AggOp {
     case (Histogram(), in: TFloat64, constArgs@Seq(_: TFloat64, _: TFloat64, _: TInt32), None) =>
       CodeAggregator[RegionValueHistogramAggregator](in, RegionValueHistogramAggregator.typ, constrArgTypes = Array(classOf[Double], classOf[Double], classOf[Int]))
 
-    case (CallStats(), in: TCall, Seq(), initOpArgs@Some(Seq(TArray(_: TString, _)))) =>
-      CodeAggregator[RegionValueCallStatsAggregator](in, RegionValueCallStatsAggregator.typ, initOpArgTypes = Some(Array(classOf[Long])))
+    case (CallStats(), in: TCall, Seq(), initOpArgs@Some(Seq(_: TInt32))) =>
+      CodeAggregator[RegionValueCallStatsAggregator](in, RegionValueCallStatsAggregator.typ, initOpArgTypes = Some(Array(classOf[Int])))
   }
 
   private def incompatible(op: AggOp, inputType: Type, constTypes: Seq[Type], initOpTypes: Option[Seq[Type]]): Nothing = {

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.expr.BaseIR
+import is.hail.utils.FastSeq
 
 object Children {
   private def none: IndexedSeq[BaseIR] = Array.empty[BaseIR]
@@ -73,12 +74,14 @@ object Children {
       Array(a, body)
     case AggFlatMap(a, name, body) =>
       Array(a, body)
+    case InitOp(i, _, args) =>
+      i +: args.toIndexedSeq
     case SeqOp(a, i, _) =>
       Array(a, i)
     case Begin(xs) =>
       xs
-    case ApplyAggOp(a, op, args) =>
-      (a +: args).toIndexedSeq
+    case ApplyAggOp(a, op, constructorArgs, initOpArgs) =>
+      (a +: constructorArgs ++: initOpArgs.getOrElse(FastSeq())).toIndexedSeq
     case GetField(o, name) =>
       Array(o)
     case MakeTuple(types) =>

--- a/src/main/scala/is/hail/expr/ir/CodeAggregator.scala
+++ b/src/main/scala/is/hail/expr/ir/CodeAggregator.scala
@@ -19,10 +19,10 @@ case class CodeAggregator[Agg <: RegionValueAggregator : ClassTag : TypeInfo](
   constrArgTypes: Array[Class[_]] = Array.empty[Class[_]],
   initOpArgTypes: Option[Array[Class[_]]] = None) {
 
-  def initOp(rva: Code[RegionValueAggregator], region: Code[Region], vs: Array[Code[_]], ms: Array[Code[Boolean]]): Code[Unit] = {
+  def initOp(rva: Code[RegionValueAggregator], vs: Array[Code[_]], ms: Array[Code[Boolean]]): Code[Unit] = {
     assert(initOpArgTypes.isDefined && vs.length == ms.length)
-    val argTypes = classOf[Region] +: initOpArgTypes.get.flatMap[Class[_], Array[Class[_]]](Array(_, classOf[Boolean]))
-    val args = region +: vs.zip(ms).flatMap { case (v, m) => Array(v, m) }
+    val argTypes = initOpArgTypes.get.flatMap[Class[_], Array[Class[_]]](Array(_, classOf[Boolean]))
+    val args = vs.zip(ms).flatMap { case (v, m) => Array(v, m) }
     Code.checkcast[Agg](rva).invoke("initOp", argTypes, args)(classTag[Unit])
   }
 

--- a/src/main/scala/is/hail/expr/ir/CodeAggregator.scala
+++ b/src/main/scala/is/hail/expr/ir/CodeAggregator.scala
@@ -1,21 +1,31 @@
 package is.hail.expr.ir
 
-import is.hail.annotations._
+import is.hail.annotations.Region
 import is.hail.annotations.aggregators._
 import is.hail.asm4s._
 import is.hail.expr.types._
-import is.hail.expr.{HailRep, hailType}
 
 import scala.reflect.ClassTag
 import scala.reflect.classTag
 
 /**
   * Pair the aggregator with a staged seqOp that calls the non-generic seqOp
-  * method and handles missingness correctly
-  *
+  * method and handles missingness correctly. If an initOp exists, the arguments
+  * have already had missingness handled.
   **/
-case class CodeAggregator[Agg <: RegionValueAggregator : ClassTag : TypeInfo]
-  (in: Type, out: Type, constructorArgumentTypes: Class[_]*) {
+case class CodeAggregator[Agg <: RegionValueAggregator : ClassTag : TypeInfo](
+  in: Type,
+  out: Type,
+  constrArgTypes: Array[Class[_]] = Array.empty[Class[_]],
+  initOpArgTypes: Option[Array[Class[_]]] = None) {
+
+  def initOp(rva: Code[RegionValueAggregator], region: Code[Region], vs: Array[Code[_]], ms: Array[Code[Boolean]]): Code[Unit] = {
+    assert(initOpArgTypes.isDefined && vs.length == ms.length)
+    val argTypes = classOf[Region] +: initOpArgTypes.get.flatMap[Class[_], Array[Class[_]]](Array(_, classOf[Boolean]))
+    val args = region +: vs.zip(ms).flatMap { case (v, m) => Array(v, m) }
+    Code.checkcast[Agg](rva).invoke("initOp", argTypes, args)(classTag[Unit])
+  }
+
   def seqOp(rva: Code[RegionValueAggregator], v: Code[_], mv: Code[Boolean]): Code[Unit] = {
     TypeToIRIntermediateClassTag(in) match {
       case ct: ClassTag[t] =>
@@ -26,9 +36,10 @@ case class CodeAggregator[Agg <: RegionValueAggregator : ClassTag : TypeInfo]
   }
 
   def stagedNew(v: Array[Code[_]], m: Array[Code[Boolean]]): Code[Agg] = {
+    assert(v.length == m.length)
     val anyArgMissing = m.fold[Code[Boolean]](false)(_ | _)
     anyArgMissing.mux(
-      Code._throw(Code.newInstance[RuntimeException, String]("Aggregators must have non missing arguments")),
-      Code.newInstance[Agg](constructorArgumentTypes.toArray, v))
+      Code._throw(Code.newInstance[RuntimeException, String]("Aggregators must have non missing constructor arguments")),
+      Code.newInstance[Agg](constrArgTypes, v))
   }
 }

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -106,13 +106,20 @@ object Copy {
       case AggFlatMap(_, name, _) =>
         val IndexedSeq(a: IR, body: IR) = newChildren
         AggFlatMap(a, name, body)
+      case InitOp(_, agg, _) =>
+        InitOp(newChildren.head.asInstanceOf[IR], agg, newChildren.tail.map(_.asInstanceOf[IR]))
       case SeqOp(_, _, agg) =>
         val IndexedSeq(a: IR, i: IR) = newChildren
         SeqOp(a, i, agg)
       case Begin(_) =>
         Begin(newChildren.map(_.asInstanceOf[IR]))
-      case ApplyAggOp(_, op, _) =>
-        ApplyAggOp(newChildren.head.asInstanceOf[IR], op, newChildren.tail.map(_.asInstanceOf[IR]))
+      case x@ApplyAggOp(_, op, _, _) =>
+        val args = newChildren.tail.map(_.asInstanceOf[IR])
+        ApplyAggOp(
+          newChildren.head.asInstanceOf[IR],
+          op,
+          args.take(x.nConstructorArgs),
+          if (x.hasInitOp) Some(args.drop(x.nConstructorArgs)) else None)
       case MakeTuple(_) =>
         MakeTuple(newChildren.map(_.asInstanceOf[IR]))
       case GetTupleElement(_, idx) =>

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -524,8 +524,6 @@ private class Emit(
         val argsm = Array.fill[ClassFieldRef[Boolean]](nArgs)(mb.newField[Boolean]())
         val argsv = (0 until nArgs).map(i => mb.newField(typeToTypeInfo(args(i).typ))).toArray
 
-        val region = mb.getArg[Region](1).load()
-
         val codeI = emit(i)
         val codeA = args.map(ir => emit(ir))
 

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -546,7 +546,6 @@ private class Emit(
               Code._empty,
               agg.initOp(
                 aggregator(coerce[Int](codeI.v)),
-                region,
                 argsv.map(Code(_)),
                 argsm.map(Code(_).asInstanceOf[Code[Boolean]])))),
           const(false),

--- a/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -11,7 +11,7 @@ import scala.language.{existentials, postfixOps}
 object ExtractAggregators {
 
   private case class IRAgg(ref: Ref, applyAggOp: ApplyAggOp) {}
-  
+
   def apply(ir: IR, tAggIn: TAggregable): (IR, TStruct, IR, IR, Array[RegionValueAggregator]) = {
     val (ir2, aggs) = extract(ir.unwrap, tAggIn)
 

--- a/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -11,16 +11,19 @@ import scala.language.{existentials, postfixOps}
 object ExtractAggregators {
 
   private case class IRAgg(ref: Ref, applyAggOp: ApplyAggOp) {}
-
-  def apply(ir: IR, tAggIn: TAggregable): (IR, TStruct, IR, Array[RegionValueAggregator]) = {
+  
+  def apply(ir: IR, tAggIn: TAggregable): (IR, TStruct, IR, IR, Array[RegionValueAggregator]) = {
     val (ir2, aggs) = extract(ir.unwrap, tAggIn)
-    val aggir = Begin(
-      aggs.map(_.applyAggOp)
+
+    val (initOps, seqOps) = aggs.map(_.applyAggOp)
         .zipWithIndex
         .map { case (x, i) =>
-          val agg = AggOp.get(x.op, x.inputType, x.args.map(_.typ))
-          SeqOp(x.a, I32(i), agg)
-        })
+          val agg = AggOp.get(x.op, x.inputType, x.constructorArgs.map(_.typ), x.initOpArgs.map(_.map(_.typ)))
+          (x.initOpArgs.map(args => InitOp(I32(i), agg, args)), SeqOp(x.a, I32(i), agg))
+        }.unzip
+
+    val seqOpIR = Begin(seqOps)
+    val initOpIR = Begin(initOps.flatten[InitOp])
 
     val rvas = aggs.map(_.applyAggOp)
       .map { x =>
@@ -33,7 +36,7 @@ object ExtractAggregators {
     // struct's type is
     aggs.foreach(_.ref.typ = resultStruct)
 
-    (ir2, resultStruct, aggir, rvas)
+    (ir2, resultStruct, initOpIR, seqOpIR, rvas)
   }
 
   private def extract(ir: IR, tAggIn: TAggregable): (IR, Array[IRAgg]) = {
@@ -61,13 +64,13 @@ object ExtractAggregators {
   }
 
   private def newAggregator(ir: ApplyAggOp): RegionValueAggregator = ir match {
-    case x@ApplyAggOp(a, op, args) =>
+    case x@ApplyAggOp(a, op, constructorArgs, initOpArgs) =>
       val constfb = EmitFunctionBuilder[Region, RegionValueAggregator]
-      val codeArgs = args.map(Emit.toCode(_, constfb, 1))
+      val codeConstructorArgs = constructorArgs.map(Emit.toCode(_, constfb, 1))
       constfb.emit(Code(
-        Code(codeArgs.map(_.setup): _*),
-        AggOp.get(op, x.inputType, args.map(_.typ))
-          .stagedNew(codeArgs.map(_.v).toArray, codeArgs.map(_.m).toArray)))
+        Code(codeConstructorArgs.map(_.setup): _*),
+        AggOp.get(op, x.inputType, constructorArgs.map(_.typ), initOpArgs.map(_.map(_.typ)))
+          .stagedNew(codeConstructorArgs.map(_.v).toArray, codeConstructorArgs.map(_.m).toArray)))
       Region.scoped(constfb.result()()(_))
   }
 }

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -112,10 +112,16 @@ final case class AggIn(var typ: TAggregable) extends IR
 final case class AggMap(a: IR, name: String, body: IR) extends InferIR
 final case class AggFilter(a: IR, name: String, body: IR) extends InferIR
 final case class AggFlatMap(a: IR, name: String, body: IR) extends InferIR
-final case class ApplyAggOp(a: IR, op: AggOp, args: Seq[IR]) extends InferIR {
+final case class ApplyAggOp(a: IR, op: AggOp, constructorArgs: Seq[IR] = Seq.empty[IR], initOpArgs: Option[Seq[IR]] = None) extends InferIR {
+  val nConstructorArgs = constructorArgs.length
+  val hasInitOp = initOpArgs.isDefined
+
   def inputType: Type = coerce[TAggregable](a.typ).elementType
 }
 
+final case class InitOp(i: IR, agg: CodeAggregator[T] forSome { type T <: RegionValueAggregator }, args: Seq[IR]) extends IR {
+  val typ = TVoid
+}
 final case class SeqOp(a: IR, i: IR, agg: CodeAggregator[T] forSome { type T <: RegionValueAggregator }) extends IR {
   val typ = TVoid
 }

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -51,9 +51,9 @@ object Infer {
         val tagg2 = tagg.copy(elementType = coerce[TContainer](body.typ).elementType)
         tagg2.symTab = tagg.symTab
         tagg2
-      case x@ApplyAggOp(a, op, args) =>
+      case x@ApplyAggOp(a, op, constructorArgs, initOpArgs) =>
         val tAgg = coerce[TAggregable](a.typ)
-        AggOp.getType(op, tAgg.elementType, args.map(_.typ))
+        AggOp.getType(op, tAgg.elementType, constructorArgs.map(_.typ), initOpArgs.map(_.map(_.typ)))
       case x@MakeStruct(fields) =>
         TStruct(fields.map { case (name, a) =>
           (name, a.typ)

--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -63,7 +63,7 @@ object Pretty {
             case AggMap(_, name, _) => name
             case AggFilter(_, name, _) => name
             case AggFlatMap(_, name, _) => name
-            case ApplyAggOp(_, op, _) => op.getClass.getName.split("\\.").last
+            case ApplyAggOp(_, op, _, _) => op.getClass.getName.split("\\.").last
             case ArrayFor(_, valueName, _) => s"$valueName"
             case ApplyIR(function, _, _) => function
             case Apply(function, _) => function

--- a/src/main/scala/is/hail/expr/ir/Subst.scala
+++ b/src/main/scala/is/hail/expr/ir/Subst.scala
@@ -25,9 +25,9 @@ object Subst {
         ArrayFold(subst(a), subst(zero), accumName, valueName, subst(body, env.delete(accumName).delete(valueName)))
       case ArrayFor(a, valueName, body) =>
         ArrayFor(subst(a), valueName, subst(body, env.delete(valueName)))
-      case ApplyAggOp(a, op, args) =>
-        val substitutedArgs = args.map(arg => Recur(subst(_))(arg))
-        ApplyAggOp(subst(a, aggEnv, Env.empty), op, substitutedArgs)
+      case ApplyAggOp(a, op, constructorArgs, initOpArgs) =>
+        val substConstructorArgs = constructorArgs.map(arg => Recur(subst(_))(arg))
+        ApplyAggOp(subst(a, aggEnv, Env.empty), op, substConstructorArgs, initOpArgs) // Cannot subst the initOpArgs because there is an extra element (AGG) in env
       case _ =>
         Recur(subst(_))(e)
     }

--- a/src/main/scala/is/hail/expr/ir/functions/CallFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/CallFunctions.scala
@@ -10,6 +10,7 @@ object CallFunctions extends RegistryFunctions {
   def registerAll() {
     registerScalaFunction("downcode", TCall(), TInt32(), TCall())(Call.getClass, "downcode")
     registerScalaFunction("UnphasedDiploidGtIndexCall", TInt32(), TCall())(Call2.getClass, "fromUnphasedDiploidGtIndex")
+    registerScalaFunction("Call", TInt32(), TInt32(), TBoolean(), TCall())(Call2.getClass, "apply")
 
     val qualities = Array("isPhased", "isHomRef", "isHet",
       "isHomVar", "isNonRef", "isHetNonRef", "isHetRef")

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -33,7 +33,11 @@ object UtilFunctions extends RegistryFunctions {
     }
 
     registerIR("hist", TAggregable(TFloat64()), TFloat64(), TFloat64(), TInt32()){ (agg, start, end, nbins) =>
-      ApplyAggOp(agg, Histogram(), FastSeq(start, end, nbins))
+      ApplyAggOp(agg, Histogram(), constructorArgs = FastSeq(start, end, nbins))
+    }
+
+    registerIR("callStats", TAggregable(TCall()), TArray(TString())){ (agg, alleles) =>
+      ApplyAggOp(agg, Histogram(), initOpArgs = Some(FastSeq(alleles)))
     }
 
     registerIR("isDefined", tv("T")) { a => ApplyUnaryPrimOp(Bang(), IsNA(a)) }

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -36,8 +36,8 @@ object UtilFunctions extends RegistryFunctions {
       ApplyAggOp(agg, Histogram(), constructorArgs = FastSeq(start, end, nbins))
     }
 
-    registerIR("callStats", TAggregable(TCall()), TArray(TString())){ (agg, alleles) =>
-      ApplyAggOp(agg, Histogram(), initOpArgs = Some(FastSeq(alleles)))
+    registerIR("callStats", TAggregable(TCall()), TInt32()){ (agg, nAlleles) =>
+      ApplyAggOp(agg, CallStats(), initOpArgs = Some(FastSeq(nAlleles)))
     }
 
     registerIR("isDefined", tv("T")) { a => ApplyUnaryPrimOp(Bang(), IsNA(a)) }

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -17,20 +17,19 @@ object UtilFunctions extends RegistryFunctions {
 
     registerCode("triangle", TInt32(), TInt32()) { case (_, n: Code[Int]) => (n * (n + 1)) / 2 }
 
+    registerIR("sum", TAggregable(TInt64()))(ApplyAggOp(_, Sum()))
+    registerIR("sum", TAggregable(TFloat64()))(ApplyAggOp(_, Sum()))
 
-    registerIR("sum", TAggregable(TInt64()))(ApplyAggOp(_, Sum(), FastSeq()))
-    registerIR("sum", TAggregable(TFloat64()))(ApplyAggOp(_, Sum(), FastSeq()))
+    registerIR("product", TAggregable(TInt64()))(ApplyAggOp(_, Product()))
+    registerIR("product", TAggregable(TFloat64()))(ApplyAggOp(_, Product()))
 
-    registerIR("product", TAggregable(TInt64()))(ApplyAggOp(_, Product(), FastSeq()))
-    registerIR("product", TAggregable(TFloat64()))(ApplyAggOp(_, Product(), FastSeq()))
+    registerIR("max", TAggregable(tnum("T")))(ApplyAggOp(_, Max()))
 
-    registerIR("max", TAggregable(tnum("T")))(ApplyAggOp(_, Max(), FastSeq()))
-
-    registerIR("min", TAggregable(tnum("T")))(ApplyAggOp(_, Min(), FastSeq()))
+    registerIR("min", TAggregable(tnum("T")))(ApplyAggOp(_, Min()))
 
     registerIR("count", TAggregable(tv("T"))) { agg =>
       val uid = genUID()
-      ApplyAggOp(AggMap(agg, uid, I32(0)), Count(), Seq())
+      ApplyAggOp(AggMap(agg, uid, I32(0)), Count())
     }
 
     registerIR("hist", TAggregable(TFloat64()), TFloat64(), TFloat64(), TInt32()){ (agg, start, end, nbins) =>

--- a/src/main/scala/is/hail/methods/Aggregators.scala
+++ b/src/main/scala/is/hail/methods/Aggregators.scala
@@ -673,7 +673,7 @@ class MinAggregator[T, BoxedT >: Null](implicit ev: NumericPair[T, BoxedT], ct: 
   def copy() = new MinAggregator[T, BoxedT]()
 }
 
-class CallStatsAggregator(allelesF: (Any) => Any)
+class CallStatsAggregator(nAllelesF: (Any) => Any)
   extends TypedAggregator[Annotation] {
 
   var first = true
@@ -689,9 +689,9 @@ class CallStatsAggregator(allelesF: (Any) => Any)
     if (first) {
       first = false
 
-      val alleles = allelesF(x)
-      if (alleles != null)
-        combiner = new CallStatsCombiner(alleles.asInstanceOf[IndexedSeq[String]])
+      val nAlleles = nAllelesF(x)
+      if (nAlleles != null)
+        combiner = new CallStatsCombiner(nAlleles.asInstanceOf[Int])
     }
 
     if (combiner != null && x != null)
@@ -701,12 +701,12 @@ class CallStatsAggregator(allelesF: (Any) => Any)
   def combOp(agg2: this.type) {
     if (agg2.combiner != null) {
       if (combiner == null)
-        combiner = new CallStatsCombiner(agg2.combiner.alleles)
+        combiner = new CallStatsCombiner(agg2.combiner.nAlleles)
       combiner.merge(agg2.combiner)
     }
   }
 
-  def copy() = new CallStatsAggregator(allelesF)
+  def copy() = new CallStatsAggregator(nAllelesF)
 }
 
 class InbreedingAggregator(getAF: (Call) => Any) extends TypedAggregator[Annotation] {

--- a/src/main/scala/is/hail/stats/CallStatsCombiner.scala
+++ b/src/main/scala/is/hail/stats/CallStatsCombiner.scala
@@ -20,9 +20,9 @@ case class CallStats(alleleCount: IndexedSeq[Int], alleleFrequency: Option[Index
   def asAnnotation: Annotation = Annotation(alleleCount, alleleFrequency.orNull, alleleNumber, homCount)
 }
 
-class CallStatsCombiner(val alleles: IndexedSeq[String]) extends Serializable {
-  val alleleCount = new Array[Int](alleles.length)
-  val homozygoteCount = new Array[Int](alleles.length)
+class CallStatsCombiner(val nAlleles: Int) extends Serializable {
+  val alleleCount = new Array[Int](nAlleles)
+  val homozygoteCount = new Array[Int](nAlleles)
 
   def merge(c: Call): CallStatsCombiner = {
     val p = Call.allelePair(c)

--- a/src/main/scala/is/hail/stats/CallStatsCombiner.scala
+++ b/src/main/scala/is/hail/stats/CallStatsCombiner.scala
@@ -1,6 +1,6 @@
 package is.hail.stats
 
-import is.hail.annotations.Annotation
+import is.hail.annotations.{Annotation, RegionValueBuilder}
 import is.hail.expr.types._
 import is.hail.utils._
 import is.hail.variant.{Call, VariantMethods}
@@ -9,27 +9,33 @@ object CallStats {
   def schema = TStruct(
     "AC" -> TArray(TInt32()),
     "AF" -> TArray(TFloat64()),
-    "AN" -> TInt32())
+    "AN" -> TInt32(),
+    "homozygote_count" -> TArray(TInt32()))
 }
 
-case class CallStats(alleleCount: IndexedSeq[Int], alleleFrequency: Option[IndexedSeq[Double]], alleleNumber: Int) {
+case class CallStats(alleleCount: IndexedSeq[Int], alleleFrequency: Option[IndexedSeq[Double]], alleleNumber: Int,
+  homCount: IndexedSeq[Int]) {
   require(alleleFrequency.forall(f => D_==(f.sum, 1d)), s"AF did not sum to 1: $this")
-
-  def asAnnotation: Annotation = Annotation(alleleCount, alleleFrequency.orNull, alleleNumber)
+  require(homCount.sum >= 0 && homCount.sum <= alleleNumber.toDouble / 2)
+  def asAnnotation: Annotation = Annotation(alleleCount, alleleFrequency.orNull, alleleNumber, homCount)
 }
 
 class CallStatsCombiner(val alleles: IndexedSeq[String]) extends Serializable {
   val alleleCount = new Array[Int](alleles.length)
+  val homozygoteCount = new Array[Int](alleles.length)
 
   def merge(c: Call): CallStatsCombiner = {
     val p = Call.allelePair(c)
     alleleCount(p.j) += 1
     alleleCount(p.k) += 1
+    if (p.j == p.k)
+      homozygoteCount(p.j) += 1
     this
   }
 
   def merge(that: CallStatsCombiner): CallStatsCombiner = {
     alleleCount.indices.foreach { i => alleleCount(i) += that.alleleCount(i) }
+    homozygoteCount.indices.foreach { i => homozygoteCount(i) += that.homozygoteCount(i) }
     this
   }
 
@@ -40,6 +46,35 @@ class CallStatsCombiner(val alleles: IndexedSeq[String]) extends Serializable {
         None
       else
         Some(alleleCount.map(_.toDouble / alleleNumber): IndexedSeq[Double])
-    CallStats(alleleCount, alleleFrequency, alleleNumber)
+    CallStats(alleleCount, alleleFrequency, alleleNumber, homozygoteCount)
+  }
+
+  def result(rvb: RegionValueBuilder): Unit = {
+    val cstats = result()
+    rvb.startStruct()
+
+    // AC
+    rvb.startArray(cstats.alleleCount.length)
+    cstats.alleleCount.foreach(rvb.addInt _)
+    rvb.endArray()
+
+    // AF
+    cstats.alleleFrequency match {
+      case Some(af) =>
+        rvb.startArray(af.length)
+        af.foreach(rvb.addDouble _)
+        rvb.endArray()
+      case None =>
+        rvb.setMissing()
+    }
+
+    // AN
+    rvb.addInt(cstats.alleleNumber)
+
+    // homozygote_count
+    rvb.startArray(cstats.homCount.length)
+    cstats.homCount.foreach(rvb.addInt _)
+    rvb.endArray()
+    rvb.endStruct()
   }
 }

--- a/src/test/scala/is/hail/expr/AstToIrSuite.scala
+++ b/src/test/scala/is/hail/expr/AstToIrSuite.scala
@@ -113,20 +113,20 @@ class ASTToIRSuite extends TestNGSuite {
       "aggregable.map(x => x * i64#5).sum()" ->
         ApplyAggOp(
           AggMap(AggIn(tAgg), "x", ApplyBinaryPrimOp(Multiply(), Ref("x", TInt64()), I64(5))),
-          Sum(), Seq()),
+          Sum()),
       "aggregable.map(x => x * something).sum()" ->
         ApplyAggOp(
           AggMap(AggIn(tAgg), "x", ApplyBinaryPrimOp(Multiply(), Ref("x", TInt64()), Ref("something", TInt64()))),
-          Sum(), Seq()),
+          Sum()),
       "aggregable.filter(x => x > i64#2).sum()" ->
         ApplyAggOp(
           AggFilter(AggIn(tAgg), "x", ApplyBinaryPrimOp(GT(), Ref("x", TInt64()), I64(2))),
-          Sum(), Seq()),
+          Sum()),
       "aggregable.flatMap(x => [x * i64#5]).sum()" ->
         ApplyAggOp(
           AggFlatMap(AggIn(tAgg), "x",
             MakeArray(Seq(ApplyBinaryPrimOp(Multiply(), Ref("x", TInt64()), I64(5))), TArray(TInt64()))),
-          Sum(), Seq())
+          Sum())
     )
     } {
       val converted = toIR(in)

--- a/src/test/scala/is/hail/expr/ir/InterpretSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/InterpretSuite.scala
@@ -291,7 +291,7 @@ class InterpretSuite {
     )
 
     val result = Interpret(ApplyAggOp(AggFilter(AggIn(aggT), "x", ApplyBinaryPrimOp(LT(), Ref("a", TInt32()), I32(21))),
-      Sum(), List()), env, IndexedSeq(), Some(agg))
+      Sum()), env, IndexedSeq(), Some(agg))
     assert(result == 15)
   }
 }

--- a/src/test/scala/is/hail/methods/AggregatorSuite.scala
+++ b/src/test/scala/is/hail/methods/AggregatorSuite.scala
@@ -189,7 +189,7 @@ class AggregatorSuite extends SparkSuite {
   @Test def testCallStats() {
     val vds = hc.importVCF("src/test/resources/sample2.vcf").cache()
       .annotateRowsExpr(
-        "callStats" -> "AGG.map(g => g.GT).callStats(g => va.alleles)",
+        "callStats" -> "AGG.map(g => g.GT).callStats(g => va.alleles.length)",
           "AC" -> "AGG.map(g => g.GT.oneHotAlleles(va.alleles)).sum()",
           "AN" -> "AGG.filter(g => isDefined(g.GT)).count() * 2L")
       .annotateRowsExpr("AF" -> "va.AC.map(x => x.toFloat64) / va.AN.toFloat64()")

--- a/src/test/scala/is/hail/methods/SkatSuite.scala
+++ b/src/test/scala/is/hail/methods/SkatSuite.scala
@@ -168,7 +168,7 @@ class SkatSuite extends SparkSuite {
       .annotateSamplesF(TFloat64(), List("cov", "Cov2"), s => cov2Array(s.asInstanceOf[String].toInt))
       .annotateSamplesF(TFloat64(), List("pheno"), s => phenoArray(s.asInstanceOf[String].toInt))
       .annotateRowsExpr("gene" -> "va.locus.position % 3") // three genes
-      .annotateRowsExpr("AF" -> "AGG.map(g => g.GT).callStats(GT => va.alleles).AF")
+      .annotateRowsExpr("AF" -> "AGG.map(g => g.GT).callStats(GT => va.alleles.length).AF")
       .annotateRowsExpr("weight" -> ("let af = if (va.AF[0] <= va.AF[1]) va.AF[0] else va.AF[1] in " +
         "dbeta(af, 1.0, 25.0)**2d")).cache()
   }


### PR DESCRIPTION
For aggregation, there is now an `InitOp` which is a companion to a `SeqOp`. The `InitOp` IR will emit an `initOp` function on the `RegionValueAggregator` if it exists (not `None` as defined by the `ApplyAggOp`). The `initOp` function must have the region as the first argument followed by pairs of offsets and missing values. The `InitOpIR` gets compiled with `args` rather than `aggArgs` (scope is different from `SeqOp`) as it doesn't execute in the scope of the aggregable.