### PR TITLE
Fraction Aggregator + AggregatorFunctions

### DIFF
--- a/python/hail/expr/aggregators.py
+++ b/python/hail/expr/aggregators.py
@@ -670,13 +670,8 @@ def fraction(predicate) -> Float64Expression:
     :class:`.Expression` of type :py:data:`.tfloat64`
         Fraction of records where `predicate` is ``True``.
     """
-    if predicate._aggregations:
-        raise ExpressionException('Cannot aggregate an already-aggregated expression')
 
-    uid = Env.get_uid()
-    ast = LambdaClassMethod('fraction', uid, predicate._ast, VariableReference(uid))
-    return construct_expr(ast, tfloat64, Indices(source=predicate._indices.source),
-                          predicate._aggregations.push(Aggregation(predicate)))
+    return _agg_func('fraction', predicate, tfloat64)
 
 @typecheck(expr=agg_expr(expr_call))
 def hardy_weinberg(expr) -> StructExpression:

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -1333,6 +1333,8 @@ object FunctionRegistry {
       def typ = InbreedingCombiner.signature
     })
 
+  registerAggregator[Boolean, java.lang.Double]("fraction", () => new FractionAggregator(x => x))
+
   registerLambdaAggregator[Any, (Any) => Any, java.lang.Double]("fraction", (f: (Any) => Any) => new FractionAggregator(f)
   )(aggregableHr(TTHr), unaryHr(TTHr, boxedboolHr), boxedFloat64Hr)
 

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -1333,7 +1333,9 @@ object FunctionRegistry {
       def typ = InbreedingCombiner.signature
     })
 
-  registerAggregator[Boolean, java.lang.Double]("fraction", () => new FractionAggregator(x => x))
+  registerAggregator[Boolean, java.lang.Double](
+    "fraction", () => new FractionAggregator(x => x)
+  )(aggregableHr(boolHr), boxedFloat64Hr)
 
   registerLambdaAggregator[Any, (Any) => Any, java.lang.Double]("fraction", (f: (Any) => Any) => new FractionAggregator(f)
   )(aggregableHr(TTHr), unaryHr(TTHr, boxedboolHr), boxedFloat64Hr)

--- a/src/main/scala/is/hail/expr/ir/functions/AggregatorFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/AggregatorFunctions.scala
@@ -1,0 +1,38 @@
+package is.hail.expr.ir.functions
+
+import is.hail.annotations.{CodeOrdering, Region}
+import is.hail.asm4s
+import is.hail.asm4s._
+import is.hail.expr.ir._
+import is.hail.expr.types._
+import is.hail.utils._
+import is.hail.expr.types.coerce
+
+object AggregatorFunctions extends RegistryFunctions {
+
+  def registerAll() {
+    registerIR("sum", TAggregable(TInt64()))(ApplyAggOp(_, Sum(), FastSeq()))
+    registerIR("sum", TAggregable(TFloat64()))(ApplyAggOp(_, Sum(), FastSeq()))
+
+    registerIR("product", TAggregable(TInt64()))(ApplyAggOp(_, Product(), FastSeq()))
+    registerIR("product", TAggregable(TFloat64()))(ApplyAggOp(_, Product(), FastSeq()))
+
+    registerIR("max", TAggregable(tnum("T")))(ApplyAggOp(_, Max(), FastSeq()))
+
+    registerIR("min", TAggregable(tnum("T")))(ApplyAggOp(_, Min(), FastSeq()))
+
+    registerIR("count", TAggregable(tv("T"))) { agg =>
+      ApplyAggOp(AggMap(agg, "_", I32(0)), Count(), FastSeq())
+    }
+
+    registerIR("fraction", TAggregable(TBoolean())) { agg =>
+      ApplyAggOp(agg, Fraction(), FastSeq())
+    }
+
+    registerIR("hist",
+      TAggregable(TFloat64()), TFloat64(), TFloat64(), TInt32()
+    ) { (agg, start, end, nbins) =>
+      ApplyAggOp(agg, Histogram(), FastSeq(start, end, nbins))
+    }
+  }
+}

--- a/src/main/scala/is/hail/expr/ir/functions/AggregatorFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/AggregatorFunctions.scala
@@ -9,7 +9,6 @@ import is.hail.utils._
 import is.hail.expr.types.coerce
 
 object AggregatorFunctions extends RegistryFunctions {
-
   def registerAll() {
     registerIR("sum", TAggregable(TInt64()))(ApplyAggOp(_, Sum(), FastSeq()))
     registerIR("sum", TAggregable(TFloat64()))(ApplyAggOp(_, Sum(), FastSeq()))

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -81,13 +81,16 @@ object IRFunctionRegistry {
     }
   }
 
-  SetFunctions.registerAll()
-  CallFunctions.registerAll()
-  GenotypeFunctions.registerAll()
-  MathFunctions.registerAll()
-  ArrayFunctions.registerAll()
-  UtilFunctions.registerAll()
-  StringFunctions.registerAll()
+  Array(
+      AggregatorFunctions
+    , ArrayFunctions
+    , CallFunctions
+    , GenotypeFunctions
+    , MathFunctions
+    , SetFunctions
+    , StringFunctions
+    , UtilFunctions
+  ).map(_.registerAll())
 }
 
 abstract class RegistryFunctions {


### PR DESCRIPTION
Creating an AggregatorFunctions to be tidy and clean and not put all the things in one place.

Added `fraction` as an aggregator on bools.

Changed the python api to not create an lambda things, just call `fraction` on the aggregable. Had to add a shim in the AST FunctionRegistry to support that.