### PR TITLE
relax ld_prune to run on phased GT

### DIFF
--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -1601,15 +1601,15 @@ def pc_relate(call_expr, min_individual_maf, *, k=None, scores_expr=None,
     situation and the related situation of admixed individuals.
 
     PC-Relate slightly modifies the usual estimator for relatedness:
-    occurences of population allele frequency are replaced with an
+    occurrences of population allele frequency are replaced with an
     "individual-specific allele frequency". This modification allows the
     method to correctly weight an allele according to an individual's unique
     ancestry profile.
 
     The "individual-specific allele frequency" at a given genetic locus is
-    modeled by PC-Relate as a linear function of their first ``k`` principal
-    component coordinates. As such, the efficacy of this method rests on two
-    assumptions:
+    modeled by PC-Relate as a linear function of a sample's first ``k``
+    principal component coordinates. As such, the efficacy of this method
+    rests on two assumptions:
 
      - an individual's first ``k`` principal component coordinates fully
        describe their allele-frequency-relevant ancestry, and
@@ -1694,6 +1694,8 @@ def pc_relate(call_expr, min_individual_maf, *, k=None, scores_expr=None,
 
       \\widehat{k^{(1)}_{ij}} :=
         1 - \\widehat{k^{(2)}_{ij}} - \\widehat{k^{(0)}_{ij}}
+
+    Note that, even if present, phase information is ignored by this method.
 
     The PC-Relate method is described in "Model-free Estimation of Recent
     Genetic Relatedness". Conomos MP, Reiner AP, Weir BS, Thornton TA. in
@@ -2902,9 +2904,9 @@ def filter_alleles_hts(mt: MatrixTable,
 @typecheck(mt=MatrixTable,
            call_field=str,
            r2=numeric,
-           window=int,
+           bp_window_size=int,
            memory_per_core=int)
-def _local_ld_prune(mt, call_field, r2=0.2, window=1000000, memory_per_core=256):
+def _local_ld_prune(mt, call_field, r2=0.2, bp_window_size=1000000, memory_per_core=256):
     bytes_per_core = memory_per_core * 1024 * 1024
     fraction_memory_to_use = 0.25
     variant_byte_overhead = 50
@@ -2918,19 +2920,19 @@ def _local_ld_prune(mt, call_field, r2=0.2, window=1000000, memory_per_core=256)
     max_queue_size = int(max(1.0, math.ceil(memory_available_per_core / bytes_per_variant)))
 
     sites_only_table = Table(Env.hail().methods.LocalLDPrune.apply(
-        require_biallelic(mt, 'ld_prune')._jvds, call_field, float(r2), window, max_queue_size))
+        require_biallelic(mt, 'ld_prune')._jvds, call_field, float(r2), bp_window_size, max_queue_size))
 
     return sites_only_table
 
 
 @typecheck(call_expr=expr_call,
            r2=numeric,
-           window=int,
+           bp_window_size=int,
            memory_per_core=int)
-def ld_prune(call_expr, r2=0.2, window=1000000, memory_per_core=256):
+def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256):
     """Prune variants in linkage disequilibrium.
 
-    .. include:: ../_templates/req_unphased_diploid_gt.rst
+    .. include:: ../_templates/req_diploid_gt.rst
 
     .. include:: ../_templates/req_biallelic.rst
 
@@ -2938,26 +2940,35 @@ def ld_prune(call_expr, r2=0.2, window=1000000, memory_per_core=256):
 
     Notes
     -----
+    This method removes variants in linkage disequilibrium to ensure that
+    the squared Pearson correlation coefficient :math:`r^2` of any pair of
+    variants at most `window_size` base pairs apart is less than or
+    equal to `r2`. Each variant is represented as a vector over samples
+    with elements given by the (mean-imputed) number of alternate alleles.
+    In particular, even if present, **phase information is currently ignored**.
 
-    This method prunes variants in linkage disequilibrium in two stages. The first stage
-    is a local pruning step, which prunes variants in the same partition. The parallelism
-    in this step will be affected by the number of partitions in the dataset, as well as
-    the memory per core, which is used to calculate a queue size for the local prune.
+    The method proceeds in two stages. The first stage is a local pruning step,
+    which prunes variants in the same partition. The parallelism in this step
+    will be affected by the number of partitions in the dataset, as well as
+    the memory per core, which is used to calculate a queue size for local
+    pruning.
 
-    The second stage is a global pruning step which makes use of a correlation matrix
-    across all remaining variants. In the global pruning step, correlated variants are
-    passed to a method that computes a maximal independent set of those variants.
+    The second stage is a global pruning step which computes the correlation
+    matrix across all remaining variants. In the global pruning step, correlated
+    variants are passed to a method that computes a maximal independent set of
+    those variants.
 
     Parameters
     ----------
     call_expr : :class:`.CallExpression`
-        Entry-indexed call expression on a matrix table with row-indexed variants and column-indexed samples.
+        Entry-indexed call expression on a matrix table with row-indexed
+        variants and column-indexed samples.
     r2 : :obj:`float`
-        correlation threshold (exclusive) above which variants are removed
-    window : :obj:`int`
-        distance in kilobases; correlation between variants further apart is not considered in pruning
+        Squared correlation threshold.
+    bp_window_size: :obj:`int`
+        Window size in base pairs.
     memory_per_core : :obj:`int`
-        memory in MB per core for local pruning
+        Memory in MB per core for local pruning.
 
     Returns
     -------
@@ -2974,7 +2985,7 @@ def ld_prune(call_expr, r2=0.2, window=1000000, memory_per_core=256):
         field = Env.get_uid()
         mt = mt.select_entries(**{field: call_expr})
 
-    sites_only_table = _local_ld_prune(mt, field, r2, window, memory_per_core)
+    sites_only_table = _local_ld_prune(mt, field, r2, bp_window_size, memory_per_core)
 
     sites_path = new_temp_file()
     sites_only_table.write(sites_path, overwrite=True)
@@ -3005,7 +3016,7 @@ def ld_prune(call_expr, r2=0.2, window=1000000, memory_per_core=256):
     locally_pruned_rows = locally_pruned_ds.rows()
     locally_pruned_rows = locally_pruned_rows.key_by(contig=locally_pruned_rows.locus.contig)
     locally_pruned_rows = locally_pruned_rows.select(pos=locally_pruned_rows.locus.position)
-    entries = correlation_matrix._filtered_entries_table(locally_pruned_rows, window, False)
+    entries = correlation_matrix._filtered_entries_table(locally_pruned_rows, bp_window_size, False)
 
     entries = entries.filter((entries.entry ** 2 >= r2) & (entries.i != entries.j) & (entries.i < entries.j))
 
@@ -3013,7 +3024,7 @@ def ld_prune(call_expr, r2=0.2, window=1000000, memory_per_core=256):
     entries = entries.annotate(locus_i=index_table[entries.i].locus, locus_j=index_table[entries.j].locus)
 
     entries = entries.filter((entries.locus_i.contig == entries.locus_j.contig)
-                             & ((hl.abs(entries.locus_i.position - entries.locus_j.position)) <= window))
+                             & ((hl.abs(entries.locus_i.position - entries.locus_j.position)) <= bp_window_size))
 
     entries_path = new_temp_file()
     entries.write(entries_path, overwrite=True)

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -2940,12 +2940,12 @@ def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256):
 
     Notes
     -----
-    This method removes variants in linkage disequilibrium to ensure that
-    the squared Pearson correlation coefficient :math:`r^2` of any pair of
-    variants at most `window_size` base pairs apart is less than or
-    equal to `r2`. Each variant is represented as a vector over samples
-    with elements given by the (mean-imputed) number of alternate alleles.
-    In particular, even if present, **phase information is currently ignored**.
+    This method finds a maximal subset of variants in (windowed) linkage
+    disequilibrium: the squared Pearson correlation coefficient :math:`r^2` of
+    any pair of resulting variants at most `window_size` base pairs apart is
+    strictly less than `r2`. Each variant is represented as a vector over
+    samples with elements given by the (mean-imputed) number of alternate
+    alleles. In particular, even if present, **phase information is ignored**.
 
     The method proceeds in two stages. The first stage is a local pruning step,
     which prunes variants in the same partition. The parallelism in this step
@@ -2964,7 +2964,7 @@ def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256):
         Entry-indexed call expression on a matrix table with row-indexed
         variants and column-indexed samples.
     r2 : :obj:`float`
-        Squared correlation threshold.
+        Squared correlation threshold (exclusive upper bound).
     bp_window_size: :obj:`int`
         Window size in base pairs.
     memory_per_core : :obj:`int`
@@ -2973,7 +2973,7 @@ def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256):
     Returns
     -------
     :class:`.Table`
-        Table of variants after pruning.
+        Table of variants in linkage disequilibrium.
     """
     check_entry_indexed('ld_prune/call_expr', call_expr)
     mt = matrix_table_source('ld_prune/call_expr', call_expr)

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -2940,12 +2940,12 @@ def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256):
 
     Notes
     -----
-    This method finds a maximal subset of variants in (windowed) linkage
-    disequilibrium: the squared Pearson correlation coefficient :math:`r^2` of
-    any pair of resulting variants at most `window_size` base pairs apart is
-    strictly less than `r2`. Each variant is represented as a vector over
-    samples with elements given by the (mean-imputed) number of alternate
-    alleles. In particular, even if present, **phase information is ignored**.
+    This method finds a maximal subset of variants such that the squared
+    Pearson correlation coefficient :math:`r^2` of any pair at most
+    `window_size` base pairs apart is strictly less than `r2`. Each variant is
+    represented as a vector over samples with elements given by the
+    (mean-imputed) number of alternate alleles. In particular, even if present,
+    **phase information is ignored**.
 
     The method proceeds in two stages. The first stage is a local pruning step,
     which prunes variants in the same partition. The parallelism in this step
@@ -2966,14 +2966,14 @@ def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256):
     r2 : :obj:`float`
         Squared correlation threshold (exclusive upper bound).
     bp_window_size: :obj:`int`
-        Window size in base pairs.
+        Window size in base pairs (inclusive upper bound).
     memory_per_core : :obj:`int`
         Memory in MB per core for local pruning.
 
     Returns
     -------
     :class:`.Table`
-        Table of variants in linkage disequilibrium.
+        Table of a maximal independent set of variants.
     """
     check_entry_indexed('ld_prune/call_expr', call_expr)
     mt = matrix_table_source('ld_prune/call_expr', call_expr)

--- a/python/hail/tests/test_methods.py
+++ b/python/hail/tests/test_methods.py
@@ -1520,7 +1520,7 @@ class Tests(unittest.TestCase):
 
     def test_ld_prune(self):
         ds = hl.split_multi_hts(hl.import_vcf(resource('sample.vcf')))
-        pruned_table = hl.ld_prune(ds.GT, r2=0.2, window=1000000)
+        pruned_table = hl.ld_prune(ds.GT, r2=0.2, bp_window_size=1000000)
 
         filtered_ds = (ds.filter_rows(hl.is_defined(pruned_table[(ds.locus, ds.alleles)])))
         filtered_ds = filtered_ds.annotate_rows(stats=agg.stats(filtered_ds.GT.n_alt_alleles()))
@@ -1548,11 +1548,11 @@ class Tests(unittest.TestCase):
 
     def test_ld_prune_inputs(self):
         ds = hl.split_multi_hts(hl.import_vcf(resource('sample.vcf')))
-        self.assertRaises(ValueError, lambda: hl.ld_prune(ds.GT, r2=0.2, window=1000000, memory_per_core=0))
+        self.assertRaises(ValueError, lambda: hl.ld_prune(ds.GT, r2=0.2, bp_window_size=1000000, memory_per_core=0))
 
     def test_ld_prune_no_prune(self):
         ds = hl.split_multi_hts(hl.import_vcf(resource('sample.vcf')))
-        pruned_table = hl.ld_prune(ds.GT, r2=1, window=0)
+        pruned_table = hl.ld_prune(ds.GT, r2=1, bp_window_size=0)
         expected_ds = ds.filter_rows(
             agg.collect_as_set(agg.filter(hl.is_defined(ds['GT']), ds.GT)).size() > 1, keep=True)
         assert (pruned_table.count() == expected_ds.count_rows())

--- a/src/main/scala/is/hail/methods/LocalLDPrune.scala
+++ b/src/main/scala/is/hail/methods/LocalLDPrune.scala
@@ -131,7 +131,7 @@ object LocalLDPrune {
     var i = 0
     while (i < nSamples) {
       hcView.setGenotype(i)
-      val gt = if (hcView.hasGT) Call.unphasedDiploidGtIndex(hcView.getGT) else -1
+      val gt = if (hcView.hasGT) Call.nNonRefAlleles(hcView.getGT) else -1
 
       pack = pack | ((gt & 3).toLong << packOffset)
 


### PR DESCRIPTION
Proposed change for `ld_prune` motivated by user difficulty importing and pruning 1kg. As we don't have near-term plans for a version that exploits phasing, I think it's best to make this runnable regardless of phasing, while documenting that the algorithm ignores phasing. I've added this description, fixed a doc bug (unit is bases, not kilobases) and changed the parameter `window` to `bp_window_size`, which is consistent with `window_by_locus` and I think clearer. (I'll note it on our breaking changes dev post).

If we add a method that incorporates phasing in 0.2 lifetime, it can be a separate method or we can add a parameter `use_phasing` with default value `False`. (actually, it should be a separate method since r^2 correlation won't be the right measure for that).