### PR TITLE
make Apply and ApplySpecial work with ExtractAggregators

### DIFF
--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -146,7 +146,7 @@ final case class ApplyIR(function: String, args: Seq[IR], conversion: Seq[IR] =>
 }
 
 final case class Apply(function: String, args: Seq[IR]) extends IR {
-  val implementation: IRFunctionWithoutMissingness =
+  lazy val implementation: IRFunctionWithoutMissingness =
     IRFunctionRegistry.lookupFunction(function, args.map(_.typ)).get.asInstanceOf[IRFunctionWithoutMissingness]
 
   def typ: Type = {
@@ -160,7 +160,7 @@ final case class Apply(function: String, args: Seq[IR]) extends IR {
 }
 
 final case class ApplySpecial(function: String, args: Seq[IR]) extends IR {
-  val implementation: IRFunctionWithMissingness =
+  lazy val implementation: IRFunctionWithMissingness =
     IRFunctionRegistry.lookupFunction(function, args.map(_.typ)).get.asInstanceOf[IRFunctionWithMissingness]
 
   def typ: Type = {


### PR DESCRIPTION
ExtractAggregators uses a `Ref` with a null type (which is set before
returning to its callee) to avoid traversing the IR tree twice because
the type of the aggregation result is not known until all
the aggregations have been seen.

A non lazy call to `typ` will see the null type (and blow up with an
NPE) when an `ApplySpecial`/`Apply` IR node is copied to replace a
leaf IR aggregation node with a `Ref` to the aggregation result
struct.