### PR TITLE
Off Heap Region Prep

### DIFF
--- a/src/main/scala/is/hail/annotations/Region.scala
+++ b/src/main/scala/is/hail/annotations/Region.scala
@@ -260,10 +260,6 @@ final class Region(
     end = 0
   }
 
-  def copy(): Region = {
-    new Region(util.Arrays.copyOf(mem, end.toInt), end)
-  }
-
   override def write(kryo: Kryo, output: Output) {
     output.writeLong(end)
 

--- a/src/main/scala/is/hail/annotations/Region.scala
+++ b/src/main/scala/is/hail/annotations/Region.scala
@@ -260,15 +260,6 @@ final class Region(
     end = 0
   }
 
-  def setFrom(from: Region) {
-    if (from.end > capacity) {
-      val newLength = math.max((capacity * 3) / 2, from.end)
-      mem = new Array[Byte](newLength.toInt)
-    }
-    Memory.memcpy(mem, 0, from.mem, 0, from.end)
-    end = from.end
-  }
-
   def copy(): Region = {
     new Region(util.Arrays.copyOf(mem, end.toInt), end)
   }

--- a/src/main/scala/is/hail/annotations/RegionValue.scala
+++ b/src/main/scala/is/hail/annotations/RegionValue.scala
@@ -35,9 +35,6 @@ final class RegionValue(
 
   def pretty(t: Type): String = region.pretty(t, offset)
 
-  def copy(): RegionValue = RegionValue(region.copy(), offset)
-
-
   private def writeObject(s: ObjectOutputStream): Unit = {
     throw new NotImplementedException()
   }

--- a/src/main/scala/is/hail/rvd/OrderedRVPartitionInfo.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVPartitionInfo.scala
@@ -27,7 +27,8 @@ object OrderedRVPartitionInfo {
     sampleSize: Int,
     partitionIndex: Int,
     it: Iterator[RegionValue],
-    seed: Int
+    seed: Int,
+    ctx: RVDContext
   ): OrderedRVPartitionInfo = {
     using(RVDContext.default) { ctx =>
       val minF = WritableRegionValue(typ.pkType, ctx.freshRegion)

--- a/src/main/scala/is/hail/rvd/OrderedRVPartitionInfo.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVPartitionInfo.scala
@@ -27,8 +27,7 @@ object OrderedRVPartitionInfo {
     sampleSize: Int,
     partitionIndex: Int,
     it: Iterator[RegionValue],
-    seed: Int,
-    ctx: RVDContext
+    seed: Int
   ): OrderedRVPartitionInfo = {
     using(RVDContext.default) { ctx =>
       val minF = WritableRegionValue(typ.pkType, ctx.freshRegion)

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -641,11 +641,8 @@ class Table(val hc: HailContext, val tir: TableIR) {
     val localColData = rvd.mapPartitions { it =>
       val ur = new UnsafeRow(fullRowType)
       it.map { rv =>
-        val rvCopy = rv.copy()
-        ur.set(rvCopy)
-
-        val colKey = Row.fromSeq(colKeyIndices.map(ur.get))
-        val colValues = Row.fromSeq(colValueIndices.map(ur.get))
+        val colKey = SafeRow.selectFields(fullRowType, rv)(colKeyIndices)
+        val colValues = SafeRow.selectFields(fullRowType, rv)(colValueIndices)
         colKey -> colValues
       }
     }.reduceByKey({ case (l, _) => l }) // poor man's distinctByKey


### PR DESCRIPTION
Will merge cleanly when https://github.com/hail-is/hail/pull/3560 lands.

I needed to remove `RegionValue.copy` and `Region.copy` because they necessarily create regions that aren't managed by an `RVDContext`.

`RegionValue.copy` is only used in three places. 

 - `Table.toMatrixTable`: Here, I took the somewhat inefficient choice of creating `SafeRow`s. If `toMatrixTable` is a performance bottleneck, we might want to reconsider this. It's not totally obvious how to do this. I think I'd need to explicitly serialize/deserialize these values and modify `reduceByKey` to explicitly provide the `RVDContext`. Anyway, this works and I don't think it's _that_ slow. (I guess I should check that)

 - `OrderedRVD.localKeySort` & `LocalLDPrune.pruneLocal`: in both cases we need keep a handful of region values around per-partition. This does not lend itself to region-based-allocation. I solve this with two copies and a fresh region per value. Putting a value into `localKeySort`'s queue requires copying it into a fresh region. Taking a value out of the queue requires copying it into the consumer's region and closing/freeing the region it was living in. There fresh region is alive as long as the value is in the queue.

I had to modify `RVDContext` to track `Region`s that get closed early. This seems a bit inefficient. Maybe I should track children as a `Set`?

cc: @cseed