### PR TITLE
eagerly close linreg regoins

### DIFF
--- a/src/main/scala/is/hail/rvd/RVDContext.scala
+++ b/src/main/scala/is/hail/rvd/RVDContext.scala
@@ -11,9 +11,12 @@ object RVDContext {
 }
 
 class RVDContext(r: Region) extends AutoCloseable {
-  private[this] val children: mutable.ArrayBuffer[AutoCloseable] = new mutable.ArrayBuffer()
+  private[this] val children = new mutable.HashSet[AutoCloseable]()
 
-  private[this] def own(child: AutoCloseable): Unit = children += child
+  private[this] def own(child: AutoCloseable): Unit =
+    children += child
+  private[this] def disown(child: AutoCloseable): Unit =
+    assert(children.remove(child))
 
   own(r)
 
@@ -37,10 +40,9 @@ class RVDContext(r: Region) extends AutoCloseable {
   // frees the memory associated with this context
   def close(): Unit = {
     var e: Exception = null
-    var i = 0
-    while (i < children.size) {
+    children.foreach { child =>
       try {
-        children(i).close()
+        child.close()
       } catch {
         case e2: Exception =>
           if (e == null)
@@ -48,10 +50,14 @@ class RVDContext(r: Region) extends AutoCloseable {
           else
             e.addSuppressed(e2)
       }
-      i += 1
     }
 
     if (e != null)
       throw e
+  }
+
+  def closeChild(child: AutoCloseable) {
+    child.close()
+    disown(child)
   }
 }


### PR DESCRIPTION
No one has complained about this yet, but I suspect there's a lurking issue in `linreg`. On line 75 of LinearRegression.scala, we create a writable region value using a context managed region. This region will be kept alive (in the garbage collection sense) by the context until the end of the Task (which I believe is the end of processing one partition). As such, `linreg` will generate a bunch of garbage. We close the child as soon as we know it is no longer used, thus saving memory use, at the cost of copying the results.

In a future where we can reference-count regions then we could avoid the copy and simply return the writable region value. This future is not here yet.