### PR TITLE
Make the version length coming from error messages consistent

### DIFF
--- a/src/main/scala/is/hail/package.scala
+++ b/src/main/scala/is/hail/package.scala
@@ -45,6 +45,6 @@ package object hail {
   val HAIL_VERSION = HailBuildInfo.hail_version
 
   // FIXME: probably should use tags or something to choose English name
-  val HAIL_PRETTY_VERSION = HAIL_VERSION + "-" + HAIL_REVISION.substring(0, 7)
+  val HAIL_PRETTY_VERSION = HAIL_VERSION + "-" + HAIL_REVISION.substring(0, 12)
 
 }


### PR DESCRIPTION
with the version of deployed jars / zips / distros