### PR TITLE
reuse same RDD

### DIFF
--- a/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -891,7 +891,7 @@ object LoadVCF {
     val justVariants = parseLines(
       () => ()
     )((c, l, rvb) => ()
-    )(ContextRDD.textFilesLines[RVDContext](sc, files, nPartitions),
+    )(lines,
       kType,
       rg,
       contigRecoding,


### PR DESCRIPTION
fixes Christina's bug

With enough partitions, it's somewhat likely that the `fastKeys` will end up with different partition ordering from the full rows, I guess.

cc: @tpoterba 