### PR TITLE
Fix bug preventing repartition(shuffle=True) with no rows

### DIFF
--- a/python/hail/tests/test_api.py
+++ b/python/hail/tests/test_api.py
@@ -839,6 +839,10 @@ class MatrixTests(unittest.TestCase):
         repart = vds.naive_coalesce(2)
         self.assertTrue(vds._same(repart))
 
+    def test_coalesce_with_no_rows(self):
+        mt = self.get_vds().filter_rows(False)
+        self.assertEqual(mt.repartition(1).count_rows(), 0)
+
     def test_unions(self):
         dataset = hl.import_vcf(resource('sample2.vcf'))
 

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -193,9 +193,12 @@ class OrderedRVD(
       return this
     if (shuffle) {
       val shuffled = stably(_.shuffleCoalesce(maxPartitions))
+      val pki = OrderedRVD.getPartitionKeyInfo(typ, OrderedRVD.getKeys(typ, shuffled))
+      if (pki.isEmpty)
+        return OrderedRVD.empty(sparkContext, typ)
       val ranges = OrderedRVD.calculateKeyRanges(
         typ,
-        OrderedRVD.getPartitionKeyInfo(typ, OrderedRVD.getKeys(typ, shuffled)),
+        pki,
         shuffled.getNumPartitions)
       OrderedRVD.shuffle(
         typ,


### PR DESCRIPTION
fixes #3515