### PR TITLE
fix using rows table of matrix table

### DIFF
--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -412,14 +412,14 @@ class OrderedRVD(
   def zipPartitions(
     newTyp: OrderedRVDType,
     newPartitioner: OrderedRVDPartitioner,
-    that: OrderedRVD
+    that: RVD
   )(zipper: (RVDContext, Iterator[RegionValue], Iterator[RegionValue]) => Iterator[RegionValue]
   ): OrderedRVD = zipPartitions(newTyp, newPartitioner, that, false)(zipper)
 
   def zipPartitions(
     newTyp: OrderedRVDType,
     newPartitioner: OrderedRVDPartitioner,
-    that: OrderedRVD,
+    that: RVD,
     preservesPartitioning: Boolean
   )(zipper: (RVDContext, Iterator[RegionValue], Iterator[RegionValue]) => Iterator[RegionValue]
   ): OrderedRVD = OrderedRVD(
@@ -428,12 +428,12 @@ class OrderedRVD(
     boundary.crdd.czipPartitions(that.boundary.crdd, preservesPartitioning)(zipper))
 
   def zipPartitions[T: ClassTag](
-    that: OrderedRVD
+    that: RVD
   )(zipper: (RVDContext, Iterator[RegionValue], Iterator[RegionValue]) => Iterator[T]
   ): ContextRDD[RVDContext, T] = zipPartitions(that, false)(zipper)
 
   def zipPartitions[T: ClassTag](
-    that: OrderedRVD,
+    that: RVD,
     preservesPartitioning: Boolean
   )(zipper: (RVDContext, Iterator[RegionValue], Iterator[RegionValue]) => Iterator[T]
   ): ContextRDD[RVDContext, T] =

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -183,9 +183,9 @@ object MatrixTable {
             val entriesRVD = spec.entriesComponent.read(hc, path)
             val entriesRowType = entriesRVD.rowType
             rowsRVD.zipPartitions(typ.orvdType, rowsRVD.partitioner, entriesRVD, preservesPartitioning = true) { (ctx, it1, it2) =>
-              val rv3 = RegionValue()
               val rvb = ctx.rvb
               val region = ctx.region
+              val rv3 = RegionValue(region)
               new Iterator[RegionValue] {
                 def hasNext = {
                   val hn1 = it1.hasNext
@@ -212,7 +212,7 @@ object MatrixTable {
                     i += 1
                   }
                   rvb.endStruct()
-                  rv3.set(region, rvb.end())
+                  rv3.setOffset(rvb.end())
                   rv3
                 }
               }

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -182,7 +182,7 @@ object MatrixTable {
           } else {
             val entriesRVD = spec.entriesComponent.read(hc, path)
             val entriesRowType = entriesRVD.rowType
-            rowsRVD.zip(typ.orvdType, entriesRVD) { (ctx, rv1, rv2) =>
+            rowsRVD.boundary.zip(typ.orvdType, entriesRVD.boundary) { (ctx, rv1, rv2) =>
               val rvb = ctx.rvb
               val region = ctx.region
               rvb.start(fullRowType)

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -182,25 +182,40 @@ object MatrixTable {
           } else {
             val entriesRVD = spec.entriesComponent.read(hc, path)
             val entriesRowType = entriesRVD.rowType
-            rowsRVD.boundary.zip(typ.orvdType, entriesRVD.boundary) { (ctx, rv1, rv2) =>
+            rowsRVD.zipPartitions(typ.orvdType, rowsRVD.partitioner, entriesRVD, preservesPartitioning = true) { (ctx, it1, it2) =>
+              val rv3 = RegionValue()
               val rvb = ctx.rvb
               val region = ctx.region
-              rvb.start(fullRowType)
-              rvb.startStruct()
-              var i = 0
-              while (i < localEntriesIndex) {
-                rvb.addField(rowType, rv1, i)
-                i += 1
+              new Iterator[RegionValue] {
+                def hasNext = {
+                  val hn1 = it1.hasNext
+                  val hn2 = it2.hasNext
+                  assert(hn1 == hn2)
+                  hn1
+                }
+
+                def next(): RegionValue = {
+                  val rv1 = it1.next()
+                  val rv2 = it2.next()
+
+                  rvb.start(fullRowType)
+                  rvb.startStruct()
+                  var i = 0
+                  while (i < localEntriesIndex) {
+                    rvb.addField(rowType, rv1, i)
+                    i += 1
+                  }
+                  rvb.addField(entriesRowType, rv2, 0)
+                  i += 1
+                  while (i < fullRowType.size) {
+                    rvb.addField(rowType, rv1, i - 1)
+                    i += 1
+                  }
+                  rvb.endStruct()
+                  rv3.set(region, rvb.end())
+                  rv3
+                }
               }
-              rvb.addField(entriesRowType, rv2, 0)
-              i += 1
-              while (i < fullRowType.size) {
-                rvb.addField(rowType, rv1, i - 1)
-                i += 1
-              }
-              rvb.endStruct()
-              rv2.set(region, rvb.end())
-              rv2
             }
           }
         }


### PR DESCRIPTION
It seems that as long as we are copying the rows and the
entries into a combined RVD--rather than placing pointers
to the two, previously read, data structures--we need to
separate the regions used for each source and for the
combined data structure.

cc: @konradjk @catoverdrive 