### PR TITLE
Actually Fix getPartitionKeyInfo

### DIFF
--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -546,7 +546,7 @@ object OrderedRVD {
 
     val pkis = keys.cmapPartitionsWithIndex { (i, ctx, it) =>
       val out = if (it.hasNext)
-        Iterator(OrderedRVPartitionInfo(localType, samplesPerPartition, i, it, partitionSeed(i)))
+        Iterator(OrderedRVPartitionInfo(localType, samplesPerPartition, i, it, partitionSeed(i), ctx))
       else
         Iterator()
       out


### PR DESCRIPTION
I am not sure why I thought my previous fix fixed anything. I was
not clearing the correct region. This fix clears the region
appropriately, i.e., clears it whenever it is finished with
a value from the producers region.