### PR TITLE
Make TableMapRows/select preserve key order

### DIFF
--- a/python/hail/expr/expressions/base_expression.py
+++ b/python/hail/expr/expressions/base_expression.py
@@ -762,7 +762,7 @@ class Expression(object):
         """
         uid = Env.get_uid()
         t = self._to_table(uid)
-        return [r[uid] for r in t._select("collect", hl.struct(), hl.struct(**{uid: t[uid]})).collect()]
+        return [r[uid] for r in t._select("collect", None, hl.struct(**{uid: t[uid]})).collect()]
 
     @property
     def value(self):

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -417,7 +417,7 @@ class Table(ExprContainer):
         jt = base._jt
         if self.key is not None and preserved_key != list(self.key.keys()):
             jt = jt.keyBy(preserved_key)
-        jt = jt.select(row._ast.to_hql(), preserved_key_new)
+        jt = jt.select(row._ast.to_hql(), preserved_key_new, preserved_key.length if preserved_key else None)
         if new_key != preserved_key_new:
             jt = jt.keyBy(new_key)
         t = cleanup(Table(jt))

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -380,23 +380,47 @@ class Table(ExprContainer):
     def _force_count(self):
         return self._jt.forceCount()
 
-    @typecheck_method(caller=str, key_struct=nullable(expr_struct()), value_struct=nullable(expr_struct()))
-    def _select(self, caller, key_struct=None, value_struct=None):
-        if key_struct is None:
+    @typecheck_method(caller=str, key_struct=oneof(nullable(expr_struct()), exactly("default")), value_struct=nullable(expr_struct()))
+    def _select(self, caller, key_struct="default", value_struct=None):
+        def is_copy(ast, name):
+            return (isinstance(ast, Select) and
+                ast.name == name and
+                isinstance(ast.parent, TopLevelReference) and
+                ast.parent.name == 'row' and
+                ast.parent.indices.source is self
+                )
+        if isinstance(key_struct, str):
             assert value_struct is not None
-            new_key = None
+            preserved_key = preserved_key_new = new_key = list(self.key.keys()) if self.key is not None else None
             row = hl.bind(lambda v: self.key.annotate(**v), value_struct) if self.key else value_struct
-        else:
+        elif key_struct is not None:
+            if self.key is None:
+                preserved_key_pairs = []
+            else:
+                preserved_key_pairs = list(map(lambda pair: (pair[1]._ast.name, pair[0]),
+                    itertools.takewhile(
+                        lambda pair: is_copy(pair[1]._ast, pair[2]),
+                        zip(key_struct.keys(), key_struct.values(), self.key.keys()))))
+            (preserved_key, preserved_key_new) = (list(k) for k in zip(*preserved_key_pairs)) if preserved_key_pairs != [] else (None, None)
             new_key = list(key_struct.keys())
             if value_struct is None:
                 row = hl.bind(lambda k: self.row.annotate(**k), key_struct)
             else:
                 row = hl.bind(lambda k, v: hl.struct(**k, **v), key_struct, value_struct)
+        else:
+            preserved_key = preserved_key_new = new_key = None
+            row = value_struct if value_struct is not None else hl.struct()
 
         base, cleanup = self._process_joins(row)
         analyze(caller, row, self._row_indices)
 
-        t = cleanup(Table(base._jt.select(row._ast.to_hql(), new_key)))
+        jt = base._jt
+        if self.key is not None and preserved_key != list(self.key.keys()):
+            jt = jt.keyBy(preserved_key)
+        jt = jt.select(row._ast.to_hql(), preserved_key_new)
+        if new_key != preserved_key_new:
+            jt = jt.keyBy(new_key)
+        t = cleanup(Table(jt))
         return t
 
     @typecheck_method(caller=str, s=expr_struct())
@@ -1972,7 +1996,7 @@ class Table(ExprContainer):
             new_keys = {row_key_map.get(k, k): v for k, v in table.key.items()} if table.key else None
             new_values = {row_value_map.get(k, k): v for k, v in table.row_value.items()}
             table = table._select("Table.rename",
-                                  key_struct=hl.struct(**new_keys) if new_keys else None,
+                                  key_struct=hl.struct(**new_keys) if new_keys else "default",
                                   value_struct=hl.struct(**new_values))
         if global_map:
             table = table.select_globals(**{global_map.get(k, k): v for k, v in table.globals.items()})

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -415,9 +415,9 @@ class Table(ExprContainer):
         analyze(caller, row, self._row_indices)
 
         jt = base._jt
-        if self.key is not None and preserved_key != list(self.key.keys()):
+        if self.key is not None and preserved_key != list(self.key):
             jt = jt.keyBy(preserved_key)
-        jt = jt.select(row._ast.to_hql(), preserved_key_new, preserved_key.length if preserved_key else None)
+        jt = jt.select(row._ast.to_hql(), preserved_key_new, len(preserved_key) if preserved_key else None)
         if new_key != preserved_key_new:
             jt = jt.keyBy(new_key)
         t = cleanup(Table(jt))
@@ -1313,7 +1313,7 @@ class Table(ExprContainer):
             def joiner(left):
                 left = Table(left._jt.select(ApplyMethod('annotate',
                                                          left._row._ast,
-                                                         hl.struct(**dict(zip(uids, exprs)))._ast).to_hql(), None)).key_by(*uids)
+                                                         hl.struct(**dict(zip(uids, exprs)))._ast).to_hql(), None, None)).key_by(*uids)
                 left = Table(left._jt.join(right.distinct()._jt, 'left'))
                 return left
 

--- a/python/hail/tests/test_api.py
+++ b/python/hail/tests/test_api.py
@@ -512,7 +512,7 @@ class TableTests(unittest.TestCase):
         kt = hl.utils.range_table(10)
         kt = kt.annotate_globals(foo=5, fi=3)
         kt = kt.annotate(bar=45, baz=32).key_by('bar')
-        renamed = kt.rename({'foo': 'foo2', 'bar' : 'bar2'})
+        renamed = kt.rename({'foo': 'foo2', 'bar': 'bar2'})
         renamed.count()
 
         self.assertEqual(list(renamed.key), ['bar2'])

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -465,7 +465,7 @@ class HailContext private(val sc: SparkContext,
     forceBGZip(forceBGZ) {
       TextTableReader.read(this)(files, types, comment, separator, missing,
         noHeader, impute, nPartitions.getOrElse(sc.defaultMinPartitions), quote,
-        keyNames, skipBlankLines)
+        skipBlankLines).keyBy(keyNames.map(_.toArray), sort = false)
     }
   }
 

--- a/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -126,7 +126,7 @@ object Simplify {
 
       case TableCount(TableMapGlobals(child, _, _)) => TableCount(child)
 
-      case TableCount(TableMapRows(child, _, _)) => TableCount(child)
+      case TableCount(TableMapRows(child, _, _, _)) => TableCount(child)
 
       case TableCount(TableUnion(children)) =>
         children.map(TableCount).reduce[IR](ApplyBinaryPrimOp(Add(), _, _))

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -81,7 +81,7 @@ object PCRelate {
     Table(vds.hc, toRowRdd(result, blockSize, minKinship, statistics), sig, Some(keys))
       .annotateGlobal(sampleIds.toFastIndexedSeq, TArray(TString()), "sample_ids")
       .select("{i: global.sample_ids[row.i], j: global.sample_ids[row.j], kin: row.kin, ibd0: row.ibd0, ibd1: row.ibd1, ibd2: row.ibd2}",
-        Some(keys.toFastIndexedSeq))
+        Some(keys.toFastIndexedSeq), Some(0))
   }
 
   // FIXME move matrix formation to Python

--- a/src/main/scala/is/hail/rvd/OrderedRVPartitionInfo.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVPartitionInfo.scala
@@ -75,7 +75,7 @@ object OrderedRVPartitionInfo {
         if (i < sampleSize)
           samples(i) = WritableRegionValue(typ.pkType, f, localctx.freshRegion)
         else {
-          val j = rng.nextInt(i)
+          val j = if (i > 0) rng.nextInt(i) else 0
           if (j < sampleSize)
             samples(j).set(f)
         }

--- a/src/main/scala/is/hail/utils/TextTableReader.scala
+++ b/src/main/scala/is/hail/utils/TextTableReader.scala
@@ -164,7 +164,6 @@ object TextTableReader {
     impute: Boolean = false,
     nPartitions: Int = hc.sc.defaultMinPartitions,
     quote: java.lang.Character = null,
-    keyNames: Option[IndexedSeq[String]] = None,
     skipBlankLines: Boolean = false): Table = {
 
     require(files.nonEmpty)
@@ -249,7 +248,7 @@ object TextTableReader {
 
     info(sb.result())
 
-    val ttyp = TableType(TStruct(namesAndTypes: _*), keyNames, TStruct())
+    val ttyp = TableType(TStruct(namesAndTypes: _*), None, TStruct())
     val readerOpts = TableReaderOptions(nPartitions, commentStartsWith, commentRegexes,
       separator, missing, noHeader, header, quote, skipBlankLines, namesAndTypes.indices.toArray,
       ttyp.rowType.size)

--- a/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
+++ b/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
@@ -788,7 +788,7 @@ class BlockMatrixSuite extends SparkSuite {
     val expectedTable = Table.parallelize(hc, expectedRows, TStruct("i" -> TInt64(), "j" -> TInt64()),
       None, None)
 
-    assert(entriesTable.unkey().select("{i: row.i, j: row.j}", None).same(expectedTable))
+    assert(entriesTable.unkey().select("{i: row.i, j: row.j}", None, None).same(expectedTable))
   }
   
   def filteredEquals(bm1: BlockMatrix, bm2: BlockMatrix): Boolean =

--- a/src/test/scala/is/hail/testUtils/RichTable.scala
+++ b/src/test/scala/is/hail/testUtils/RichTable.scala
@@ -90,10 +90,10 @@ class RichTable(ht: Table) {
   }
 
   def keyByExpr(exprs: (String, String)*): Table =
-    ht.select(s"annotate(row, {${ exprs.map { case (n, e) => s"${ prettyIdentifier(n) }: $e" }.mkString(",") }})", Some(exprs.map(_._1).toIndexedSeq))
+    ht.select(s"annotate(row, {${ exprs.map { case (n, e) => s"${ prettyIdentifier(n) }: $e" }.mkString(",") }})", Some(exprs.map(_._1).toIndexedSeq), None)
 
   def annotate(exprs: (String, String)*): Table =
-    ht.select(s"annotate(row, {${ exprs.map { case (n, e) => s"${ prettyIdentifier(n) }: $e" }.mkString(",") }})", None)
+    ht.select(s"annotate(row, {${ exprs.map { case (n, e) => s"${ prettyIdentifier(n) }: $e" }.mkString(",") }})", ht.key, ht.key.map(_.length))
 
   def selectGlobal(fields: Array[String]): Table = {
     val ec = EvalContext("global" -> ht.globalSignature)

--- a/src/test/scala/is/hail/utils/TextTableSuite.scala
+++ b/src/test/scala/is/hail/utils/TextTableSuite.scala
@@ -97,7 +97,7 @@ class TextTableSuite extends SparkSuite {
     val tbl = TextTableReader.read(hc)(Array(file), impute = true)
     val tir = tbl.tir.asInstanceOf[TableImport]
     
-    val selectOneCol = tbl.select("{Gene: row.Gene}", None)
+    val selectOneCol = tbl.select("{Gene: row.Gene}", None, None)
     val irSelectOneCol = new Table(hc, TableImport(
       tir.paths,
       selectOneCol.typ,
@@ -105,7 +105,7 @@ class TextTableSuite extends SparkSuite {
     ))
     assert(selectOneCol.same(irSelectOneCol))
 
-    val selectTwoCols = tbl.select("{Chromosome: row.Chromosome, Rand2: row.Rand2}", None)
+    val selectTwoCols = tbl.select("{Chromosome: row.Chromosome, Rand2: row.Rand2}", None, None)
     val irSelectTwoCols = new Table(hc, TableImport(
       tir.paths,
       selectTwoCols.typ,


### PR DESCRIPTION
This PR changes the semantics of TableMapRows in the IR and Table.select. They are now required to preserve the key ordering. In other words, applying TableMapRows to an ordered table can produce an ordered table without shuffling. I put an assert to verify that the produced OrderedRVD is really ordered, but that might be too expensive an assertion.

Before, `newKey = None` meant "keep the old key", but that left no room to ask for the result to be unkeyed. Now `newKey` is just the key of the resulting table.

If any partition key fields are modified, then even if the ordering is preserved, the result will need to be scanned to update the partition bounds. To avoid this scan when unnecessary, I added the `preservedKeyFields` parameter, which is the length of the prefix of key fields which are not modified. Thus, if the number of partition keys of the underlying OrderedRVD is less than or equal to `preservedKeyFields`, the partition bounds will remain valid. This feels pretty clunky, and I welcome better ideas. In particular, is there a way to compute this from the `newRow` IR? That's what I did on the Python side in `_select`, but it wasn't obvious to me how to do the same with the Scala IR.