### PR TITLE
SplitMulti globals region

### DIFF
--- a/src/main/scala/is/hail/methods/SplitMulti.scala
+++ b/src/main/scala/is/hail/methods/SplitMulti.scala
@@ -92,19 +92,18 @@ class SplitMultiPartitionContextIR(
   private val allelesType = matrixType.rowType.fieldByName("alleles").typ
   private val locusType = matrixType.rowType.fieldByName("locus").typ
   val f = rowF()
-  // private[this] val partitionRegion = ctx.freshRegion
+  private[this] val partitionRegion = ctx.freshRegion
 
-  // rvb.set(partitionRegion)
-  // rvb.start(matrixType.globalType)
-  // rvb.addAnnotation(matrixType.globalType, globalAnnotation)
-  // private[this] val partitionWideGlobals = rvb.end()
+  rvb.set(partitionRegion)
+  rvb.start(matrixType.globalType)
+  rvb.addAnnotation(matrixType.globalType, globalAnnotation)
+  private[this] val partitionWideGlobals = rvb.end()
 
   def constructSplitRow(splitVariants: Iterator[(Locus, IndexedSeq[String], Int)], rv: RegionValue, wasSplit: Boolean): Iterator[RegionValue] = {
     splitVariants.map { case (newLocus, newAlleles, aIndex) =>
       rvb.set(splitRegion)
       rvb.start(matrixType.globalType)
-      // rvb.addRegionValue(matrixType.globalType, partitionRegion, partitionWideGlobals)
-      rvb.addAnnotation(matrixType.globalType, globalAnnotation)
+      rvb.addRegionValue(matrixType.globalType, partitionRegion, partitionWideGlobals)
       val globals = rvb.end()
 
       rvb.start(matrixType.rvRowType)

--- a/src/main/scala/is/hail/methods/SplitMulti.scala
+++ b/src/main/scala/is/hail/methods/SplitMulti.scala
@@ -67,20 +67,42 @@ class SplitMultiPartitionContextIR(
   keepStar: Boolean,
   nSamples: Int, globalAnnotation: Annotation, matrixType: MatrixType,
   rowF: () => AsmFunction13[Region, Long, Boolean, Long, Boolean, Long, Boolean, Long, Boolean, Int, Boolean, Boolean, Boolean, Long],
+  oldRVRowType: TStruct,
   newRVRowType: TStruct,
-  region: Region
-) extends
-  SplitMultiPartitionContext(keepStar, nSamples, globalAnnotation, matrixType, newRVRowType, region) {
-
+  ctx: RVDContext,
+  sortAlleles: Boolean,
+  removeLeftAligned: Boolean,
+  removeMoving: Boolean,
+  verifyLeftAligned: Boolean
+) extends SplitMultiPartitionContext(
+  keepStar,
+  nSamples,
+  globalAnnotation,
+  matrixType,
+  oldRVRowType,
+  newRVRowType,
+  ctx,
+  sortAlleles,
+  removeLeftAligned,
+  removeMoving,
+  verifyLeftAligned
+) {
   private val allelesType = matrixType.rowType.fieldByName("alleles").typ
   private val locusType = matrixType.rowType.fieldByName("locus").typ
   val f = rowF()
+  private[this] val partitionRegion = ctx.freshRegion
+
+  rvb.set(partitionRegion)
+  rvb.start(matrixType.globalType)
+  rvb.addAnnotation(matrixType.globalType, globalAnnotation)
+  private[this] val partitionWideGlobals = rvb.end()
+
 
   def constructSplitRow(splitVariants: Iterator[(Locus, IndexedSeq[String], Int)], rv: RegionValue, wasSplit: Boolean): Iterator[RegionValue] = {
     splitVariants.map { case (newLocus, newAlleles, aIndex) =>
       rvb.set(splitRegion)
       rvb.start(matrixType.globalType)
-      rvb.addAnnotation(matrixType.globalType, globalAnnotation)
+      rvb.addRegionValue(matrixType.globalType, partitionRegion, partitionWideGlobals)
       val globals = rvb.end()
 
       rvb.start(matrixType.rvRowType)
@@ -109,11 +131,26 @@ class SplitMultiPartitionContextAST(
   matrixType: MatrixType,
   vAnnotator: ExprAnnotator,
   gAnnotator: ExprAnnotator,
+  oldRVRowType: TStruct,
   newRVRowType: TStruct,
-  region: Region
-) extends
-  SplitMultiPartitionContext(keepStar, nSamples, globalAnnotation, matrixType, newRVRowType, region) {
-
+  ctx: RVDContext,
+  sortAlleles: Boolean,
+  removeLeftAligned: Boolean,
+  removeMoving: Boolean,
+  verifyLeftAligned: Boolean
+) extends SplitMultiPartitionContext(
+  keepStar,
+  nSamples,
+  globalAnnotation,
+  matrixType,
+  oldRVRowType,
+  newRVRowType,
+  ctx,
+  sortAlleles,
+  removeLeftAligned,
+  removeMoving,
+  verifyLeftAligned
+) {
   val (t1, locusInserter) = vAnnotator.newT.insert(matrixType.rowType.fieldByName("locus").typ, "locus")
   assert(t1 == vAnnotator.newT)
   val (t2, allelesInserter) = vAnnotator.newT.insert(matrixType.rowType.fieldByName("alleles").typ, "alleles")
@@ -156,16 +193,22 @@ class SplitMultiPartitionContextAST(
   }
 }
 
-
 abstract class SplitMultiPartitionContext(
   keepStar: Boolean,
   nSamples: Int,
   globalAnnotation: Annotation,
   matrixType: MatrixType,
+  oldRVRowType: TStruct,
   newRVRowType: TStruct,
-  val splitRegion: Region
+  val ctx: RVDContext,
+  sortAlleles: Boolean,
+  removeLeftAligned: Boolean,
+  removeMoving: Boolean,
+  verifyLeftAligned: Boolean
 ) extends Serializable {
 
+  val splitRegion = ctx.region
+  val locusIndex = oldRVRowType.fieldIdx("locus")
   var fullRow = new UnsafeRow(matrixType.rvRowType)
   var prevLocus: Locus = null
   val rvv = new RegionValueVariant(matrixType.rvRowType)
@@ -175,7 +218,7 @@ abstract class SplitMultiPartitionContext(
 
   def constructSplitRow(splitVariants: Iterator[(Locus, IndexedSeq[String], Int)], rv: RegionValue, wasSplit: Boolean): Iterator[RegionValue]
 
-  def splitRow(rv: RegionValue, sortAlleles: Boolean, removeLeftAligned: Boolean, removeMoving: Boolean, verifyLeftAligned: Boolean): Iterator[RegionValue] = {
+  def splitRow(rv: RegionValue): Iterator[RegionValue] = {
     require(!(removeMoving && verifyLeftAligned))
     fullRow.set(rv)
     rvv.setRegion(rv)
@@ -219,8 +262,13 @@ abstract class SplitMultiPartitionContext(
 
     val nAlleles = 1 + alts.length
     val nGenotypes = VariantMethods.nGenotypes(nAlleles)
-    constructSplitRow(splitVariants.iterator, rv, wasSplit)
+    val it = constructSplitRow(splitVariants.iterator, rv, wasSplit)
+    prevLocus = fullRow.getAs[Locus](locusIndex)
+    it
   }
+
+  def splitPartition(it: Iterator[RegionValue]): Iterator[RegionValue] =
+    it.flatMap(splitRow)
 }
 
 object SplitMulti {
@@ -290,7 +338,7 @@ class SplitMulti(vsm: MatrixTable, variantExpr: String, genotypeExpr: String, ke
     val localKeepStar = keepStar
     val globalsBc = vsm.globals.broadcast
     val localNSamples = vsm.numCols
-    val localRowType = vsm.rvRowType
+    val oldRVRowType = vsm.rvRowType
     val localMatrixType = vsm.matrixType
     val localVAnnotator = vAnnotator
     val localGAnnotator = gAnnotator
@@ -298,23 +346,16 @@ class SplitMulti(vsm: MatrixTable, variantExpr: String, genotypeExpr: String, ke
 
     val newRowType = newMatrixType.rvRowType
 
-    val locusIndex = localRowType.fieldIdx("locus")
-
     val makeContext = if (useAST) {
-      (region: Region) => new SplitMultiPartitionContextAST(localKeepStar, localNSamples, globalsBc.value,
-        localMatrixType, localVAnnotator, localGAnnotator, newRowType, region)
+      (ctx: RVDContext) => new SplitMultiPartitionContextAST(localKeepStar, localNSamples, globalsBc.value,
+        localMatrixType, localVAnnotator, localGAnnotator, oldRVRowType, newRowType, ctx, sortAlleles, removeLeftAligned, removeMoving, verifyLeftAligned)
     } else {
-      (region: Region) => new SplitMultiPartitionContextIR(localKeepStar, localNSamples, globalsBc.value,
-        localMatrixType, localSplitRow, newRowType, region)
+      (ctx: RVDContext) => new SplitMultiPartitionContextIR(localKeepStar, localNSamples, globalsBc.value,
+        localMatrixType, localSplitRow, oldRVRowType, newRowType, ctx, sortAlleles, removeLeftAligned, removeMoving, verifyLeftAligned)
     }
 
     vsm.rvd.boundary.mapPartitions(newRowType, { (ctx, it) =>
-      val splitMultiContext = makeContext(ctx.region)
-      it.flatMap { rv =>
-        val splitit = splitMultiContext.splitRow(rv, sortAlleles, removeLeftAligned, removeMoving, verifyLeftAligned)
-        splitMultiContext.prevLocus = splitMultiContext.fullRow.getAs[Locus](locusIndex)
-        splitit
-      }
+      makeContext(ctx).splitPartition(it)
     })
   }
 

--- a/src/main/scala/is/hail/methods/SplitMulti.scala
+++ b/src/main/scala/is/hail/methods/SplitMulti.scala
@@ -209,8 +209,8 @@ abstract class SplitMultiPartitionContext(
   verifyLeftAligned: Boolean
 ) extends Serializable {
 
-  // val splitRegion = ctx.region
-  // val locusIndex = oldRVRowType.fieldIdx("locus")
+  val splitRegion = ctx.region
+  val locusIndex = oldRVRowType.fieldIdx("locus")
   var fullRow = new UnsafeRow(matrixType.rvRowType)
   var prevLocus: Locus = null
   val rvv = new RegionValueVariant(matrixType.rvRowType)

--- a/src/test/scala/is/hail/io/SplitSuite.scala
+++ b/src/test/scala/is/hail/io/SplitSuite.scala
@@ -31,7 +31,9 @@ class SplitSuite extends SparkSuite {
           }
       }.collect().toSet
 
-      method1 == method2
+      assert(method1 == method2,
+        s"\n\n${method2 -- method1}\n${method1 -- method2}\n$method1\n\n$method2")
+      true
     }
   }
 

--- a/src/test/scala/is/hail/io/SplitSuite.scala
+++ b/src/test/scala/is/hail/io/SplitSuite.scala
@@ -31,9 +31,7 @@ class SplitSuite extends SparkSuite {
           }
       }.collect().toSet
 
-      assert(method1 == method2,
-        s"\n\n${method2 -- method1}\n${method1 -- method2}\n$method1\n\n$method2")
-      true
+      method1 == method2
     }
   }
 


### PR DESCRIPTION
This prevents importing from Annotation multiple times.

I also did some minor clean up of the structure of the class
while I made this change.

I saw about a 10 second improvement (out of 2.5 minutes) on

```
In [1]: import hail as hl
In [2]: hl.init()
In [3]: %%time 
   ...: hl.split_multi_hts(hl.read_matrix_table('/Users/dking/projects/hail-data/profile.mt').select_entries('GT', 'AD', 'DP', 'GQ', 'PL'))._force_count_rows()
```