### PR TITLE
Teach IR to ArraySum

### DIFF
--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueArraySumAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueArraySumAggregator.scala
@@ -1,0 +1,125 @@
+package is.hail.annotations.aggregators
+
+import is.hail.annotations._
+import is.hail.expr.types._
+import is.hail.utils._
+
+class RegionValueArraySumLongAggregator extends RegionValueAggregator {
+  private var sum: Array[Long] = _
+  private[this] val t = TArray(TInt64())
+
+  def seqOp(region: Region, aoff: Long, missing: Boolean) {
+    if (!missing)
+      if (sum == null)
+        sum = Array.tabulate(t.loadLength(region, aoff)) { i =>
+          if (t.isElementDefined(region, aoff, i)) {
+            region.loadLong(t.loadElement(region, aoff, i))
+          } else 0L
+        }
+      else {
+        val len = t.loadLength(region, aoff)
+        if (len != sum.length)
+          fatal(
+            s"""cannot aggregate arrays of unequal length with `sum'
+               |Found conflicting arrays of size (${ sum.length }) and (${ len })""".stripMargin)
+        else {
+          var i = 0
+          while (i < len) {
+            if (t.isElementDefined(region, aoff, i)) {
+              sum(i) += region.loadLong(t.loadElement(region, aoff, i))
+            }
+            i += 1
+          }
+        }
+      }
+  }
+
+  def combOp(_that: RegionValueAggregator) {
+    val that = _that.asInstanceOf[RegionValueArraySumLongAggregator]
+    if (that.sum.length != sum.length)
+      fatal(
+        s"""cannot aggregate arrays of unequal length with `sum'
+               |Found conflicting arrays of size (${ sum.length })
+               |and (${ that.sum.length })""".stripMargin)
+    var i = 0
+    while (i < sum.length) {
+      sum(i) += that.sum(i)
+    }
+  }
+
+  def result(rvb: RegionValueBuilder) {
+    if (sum == null) {
+      rvb.setMissing()
+    } else {
+      rvb.startArray(sum.length)
+      sum.foreach(rvb.addLong)
+      rvb.endArray()
+    }
+  }
+
+  def copy(): RegionValueSumLongAggregator = new RegionValueSumLongAggregator()
+
+  def clear() {
+    sum = null
+  }
+}
+
+class RegionValueArraySumDoubleAggregator extends RegionValueAggregator {
+  private var sum: Array[Double] = _
+  private[this] val t = TArray(TInt64())
+
+  def seqOp(region: Region, aoff: Long, missing: Boolean) {
+    if (!missing)
+      if (sum == null)
+        sum = Array.tabulate(t.loadLength(region, aoff)) { i =>
+          if (t.isElementDefined(region, aoff, i)) {
+            region.loadDouble(t.loadElement(region, aoff, i))
+          } else 0
+        }
+      else {
+        val len = t.loadLength(region, aoff)
+        if (len != sum.length)
+          fatal(
+            s"""cannot aggregate arrays of unequal length with `sum'
+               |Found conflicting arrays of size (${ sum.length }) and (${ len })""".stripMargin)
+        else {
+          var i = 0
+          while (i < len) {
+            if (t.isElementDefined(region, aoff, i)) {
+              sum(i) += region.loadDouble(t.loadElement(region, aoff, i))
+            }
+            i += 1
+          }
+        }
+      }
+  }
+
+  def combOp(_that: RegionValueAggregator) {
+    val that = _that.asInstanceOf[RegionValueArraySumDoubleAggregator]
+    if (that.sum.length != sum.length)
+      fatal(
+        s"""cannot aggregate arrays of unequal length with `sum'
+               |Found conflicting arrays of size (${ sum.length })
+               |and (${ that.sum.length })""".stripMargin)
+    var i = 0
+    while (i < sum.length) {
+      sum(i) += that.sum(i)
+    }
+  }
+
+  def result(rvb: RegionValueBuilder) {
+    if (sum == null) {
+      rvb.setMissing()
+    } else {
+      rvb.startArray(sum.length)
+      sum.foreach(rvb.addDouble)
+      rvb.endArray()
+    }
+  }
+
+  def copy(): RegionValueSumDoubleAggregator = new RegionValueSumDoubleAggregator()
+
+  def clear() {
+    sum = null
+  }
+}

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueArraySumAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueArraySumAggregator.scala
@@ -21,7 +21,7 @@ class RegionValueArraySumLongAggregator extends RegionValueAggregator {
         if (len != sum.length)
           fatal(
             s"""cannot aggregate arrays of unequal length with `sum'
-               |Found conflicting arrays of size (${ sum.length }) and (${ len })""".stripMargin)
+               |Found conflicting arrays of size (${ sum.length }) and ($len)""".stripMargin)
         else {
           var i = 0
           while (i < len) {
@@ -81,7 +81,7 @@ class RegionValueArraySumDoubleAggregator extends RegionValueAggregator {
         if (len != sum.length)
           fatal(
             s"""cannot aggregate arrays of unequal length with `sum'
-               |Found conflicting arrays of size (${ sum.length }) and (${ len })""".stripMargin)
+               |Found conflicting arrays of size (${ sum.length }) and ($len)""".stripMargin)
         else {
           var i = 0
           while (i < len) {

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCallStatsAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCallStatsAggregator.scala
@@ -18,7 +18,7 @@ class RegionValueCallStatsAggregator extends RegionValueAggregator {
       combiner = new CallStatsCombiner(nAlleles)
   }
 
-  def seqOp(x: Call, missing: Boolean): Unit = {
+  def seqOp(region: Region, x: Call, missing: Boolean): Unit = {
     if (combiner != null && !missing)
       combiner.merge(x)
   }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCollectAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCollectAggregator.scala
@@ -6,7 +6,7 @@ import is.hail.utils._
 class RegionValueCollectBooleanAggregator extends RegionValueAggregator {
   private val ab = new MissingBooleanArrayBuilder()
 
-  def seqOp(b: Boolean, missing: Boolean) {
+  def seqOp(region: Region, b: Boolean, missing: Boolean) {
     if (missing)
       ab.addMissing()
     else
@@ -36,7 +36,7 @@ class RegionValueCollectBooleanAggregator extends RegionValueAggregator {
 class RegionValueCollectIntAggregator extends RegionValueAggregator {
   private val ab = new MissingIntArrayBuilder()
 
-  def seqOp(x: Int, missing: Boolean) {
+  def seqOp(region: Region, x: Int, missing: Boolean) {
     if (missing)
       ab.addMissing()
     else

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCountAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCountAggregator.scala
@@ -1,11 +1,11 @@
 package is.hail.annotations.aggregators
 
-import is.hail.annotations.RegionValueBuilder
+import is.hail.annotations._
 
 class RegionValueCountAggregator extends RegionValueAggregator {
   private var count: Long = 0
 
-  def seqOp(dummy: Int, missing: Boolean) {
+  def seqOp(region: Region, dummy: Int, missing: Boolean) {
     count += 1
   }
 

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueFractionAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueFractionAggregator.scala
@@ -6,7 +6,7 @@ class RegionValueFractionAggregator extends RegionValueAggregator {
   private var trues = 0L
   private var total = 0L
 
-  def seqOp(i: Boolean, missing: Boolean) {
+  def seqOp(region: Region, i: Boolean, missing: Boolean) {
     total += 1
     if (!missing && i)
       trues += 1

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueHistogramAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueHistogramAggregator.scala
@@ -25,7 +25,7 @@ class RegionValueHistogramAggregator(start: Double, end: Double, bins: Int) exte
 
   private val combiner = new HistogramCombiner(indices)
 
-  def seqOp(x: Double, missing: Boolean) {
+  def seqOp(region: Region, x: Double, missing: Boolean) {
     if (!missing)
       combiner.merge(x)
   }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueMaxAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueMaxAggregator.scala
@@ -6,7 +6,7 @@ class RegionValueMaxBooleanAggregator extends RegionValueAggregator {
   private var max: Boolean = false
   private var empty: Boolean = true
 
-  def seqOp(i: Boolean, missing: Boolean) {
+  def seqOp(region: Region, i: Boolean, missing: Boolean) {
     if (!missing && (i > max || empty)) {
       empty = false
       max = i
@@ -40,7 +40,7 @@ class RegionValueMaxIntAggregator extends RegionValueAggregator {
   private var max: Int = 0
   private var empty: Boolean = true
 
-  def seqOp(i: Int, missing: Boolean) {
+  def seqOp(region: Region, i: Int, missing: Boolean) {
     if (!missing && (i > max || empty)) {
       empty = false
       max = i
@@ -74,7 +74,7 @@ class RegionValueMaxLongAggregator extends RegionValueAggregator {
   private var max: Long = 0L
   private var empty: Boolean = true
 
-  def seqOp(i: Long, missing: Boolean) {
+  def seqOp(region: Region, i: Long, missing: Boolean) {
     if (!missing && (i > max || empty)) {
       empty = false
       max = i
@@ -108,7 +108,7 @@ class RegionValueMaxFloatAggregator extends RegionValueAggregator {
   private var max: Float = 0.0f
   private var empty: Boolean = true
 
-  def seqOp(i: Float, missing: Boolean) {
+  def seqOp(region: Region, i: Float, missing: Boolean) {
     if (!missing && (i > max || empty)) {
       empty = false
       max = i
@@ -142,7 +142,7 @@ class RegionValueMaxDoubleAggregator extends RegionValueAggregator {
   private var max: Double = 0.0
   private var empty: Boolean = true
 
-  def seqOp(i: Double, missing: Boolean) {
+  def seqOp(region: Region, i: Double, missing: Boolean) {
     if (!missing && (i > max || empty)) {
       empty = false
       max = i

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueMinAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueMinAggregator.scala
@@ -6,7 +6,7 @@ class RegionValueMinBooleanAggregator extends RegionValueAggregator {
   private var min: Boolean = false
   private var empty: Boolean = true
 
-  def seqOp(i: Boolean, missing: Boolean) {
+  def seqOp(region: Region, i: Boolean, missing: Boolean) {
     if (!missing && (i < min || empty)) {
       empty = false
       min = i
@@ -40,7 +40,7 @@ class RegionValueMinIntAggregator extends RegionValueAggregator {
   private var min: Int = 0
   private var empty: Boolean = true
 
-  def seqOp(i: Int, missing: Boolean) {
+  def seqOp(region: Region, i: Int, missing: Boolean) {
     if (!missing && (i < min || empty)) {
       empty = false
       min = i
@@ -74,7 +74,7 @@ class RegionValueMinLongAggregator extends RegionValueAggregator {
   private var min: Long = 0L
   private var empty: Boolean = true
 
-  def seqOp(i: Long, missing: Boolean) {
+  def seqOp(region: Region, i: Long, missing: Boolean) {
     if (!missing && (i < min || empty)) {
       empty = false
       min = i
@@ -108,7 +108,7 @@ class RegionValueMinFloatAggregator extends RegionValueAggregator {
   private var min: Float = 0.0f
   private var empty: Boolean = true
 
-  def seqOp(i: Float, missing: Boolean) {
+  def seqOp(region: Region, i: Float, missing: Boolean) {
     if (!missing && (i < min || empty)) {
       empty = false
       min = i
@@ -142,7 +142,7 @@ class RegionValueMinDoubleAggregator extends RegionValueAggregator {
   private var min: Double = 0.0
   private var empty: Boolean = true
 
-  def seqOp(i: Double, missing: Boolean) {
+  def seqOp(region: Region, i: Double, missing: Boolean) {
     if (!missing && (i < min || empty)) {
       empty = false
       min = i

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueProductAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueProductAggregator.scala
@@ -5,7 +5,7 @@ import is.hail.annotations._
 class RegionValueProductLongAggregator extends RegionValueAggregator {
   private var product: Long = 1L
 
-  def seqOp(l: Long, missing: Boolean) {
+  def seqOp(region: Region, l: Long, missing: Boolean) {
     if (!missing)
       product *= l
   }
@@ -28,7 +28,7 @@ class RegionValueProductLongAggregator extends RegionValueAggregator {
 class RegionValueProductDoubleAggregator extends RegionValueAggregator {
   private var product: Double = 1.0
 
-  def seqOp(d: Double, missing: Boolean) {
+  def seqOp(region: Region, d: Double, missing: Boolean) {
     if (!missing)
       product *= d
   }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueStatisticsAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueStatisticsAggregator.scala
@@ -18,7 +18,7 @@ object RegionValueStatisticsAggregator {
 class RegionValueStatisticsAggregator extends RegionValueAggregator {
   private var sc = new StatCounter()
 
-  def seqOp(x: Double, missing: Boolean) {
+  def seqOp(region: Region, x: Double, missing: Boolean) {
     if (!missing)
       sc.merge(x)
   }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueSumAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueSumAggregator.scala
@@ -5,7 +5,7 @@ import is.hail.annotations._
 class RegionValueSumLongAggregator extends RegionValueAggregator {
   private var sum: Long = 0L
 
-  def seqOp(l: Long, missing: Boolean) {
+  def seqOp(region: Region, l: Long, missing: Boolean) {
     if (!missing)
       sum += l
   }
@@ -28,7 +28,7 @@ class RegionValueSumLongAggregator extends RegionValueAggregator {
 class RegionValueSumDoubleAggregator extends RegionValueAggregator {
   private var sum: Double = 0.0
 
-  def seqOp(d: Double, missing: Boolean) {
+  def seqOp(region: Region, d: Double, missing: Boolean) {
     if (!missing)
       sum += d
   }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueTakeAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueTakeAggregator.scala
@@ -8,7 +8,7 @@ import is.hail.utils._
 class RegionValueTakeBooleanAggregator(n: Int) extends RegionValueAggregator {
   private val ab = new MissingBooleanArrayBuilder()
 
-  def seqOp(x: Boolean, missing: Boolean) {
+  def seqOp(region: Region, x: Boolean, missing: Boolean) {
     if (ab.length() < n)
       if (missing)
         ab.addMissing()
@@ -41,7 +41,7 @@ class RegionValueTakeBooleanAggregator(n: Int) extends RegionValueAggregator {
 class RegionValueTakeIntAggregator(n: Int) extends RegionValueAggregator {
   private val ab = new MissingIntArrayBuilder()
 
-  def seqOp(x: Int, missing: Boolean) {
+  def seqOp(region: Region, x: Int, missing: Boolean) {
     if (ab.length() < n)
       if (missing)
         ab.addMissing()
@@ -74,7 +74,7 @@ class RegionValueTakeIntAggregator(n: Int) extends RegionValueAggregator {
 class RegionValueTakeLongAggregator(n: Int) extends RegionValueAggregator {
   private val ab = new MissingLongArrayBuilder()
 
-  def seqOp(x: Long, missing: Boolean) {
+  def seqOp(region: Region, x: Long, missing: Boolean) {
     if (ab.length() < n)
       if (missing)
         ab.addMissing()
@@ -107,7 +107,7 @@ class RegionValueTakeLongAggregator(n: Int) extends RegionValueAggregator {
 class RegionValueTakeFloatAggregator(n: Int) extends RegionValueAggregator {
   private val ab = new MissingFloatArrayBuilder()
 
-  def seqOp(x: Float, missing: Boolean) {
+  def seqOp(region: Region, x: Float, missing: Boolean) {
     if (ab.length() < n)
       if (missing)
         ab.addMissing()
@@ -140,7 +140,7 @@ class RegionValueTakeFloatAggregator(n: Int) extends RegionValueAggregator {
 class RegionValueTakeDoubleAggregator(n: Int) extends RegionValueAggregator {
   private val ab = new MissingDoubleArrayBuilder()
 
-  def seqOp(x: Double, missing: Boolean) {
+  def seqOp(region: Region, x: Double, missing: Boolean) {
     if (ab.length() < n)
       if (missing)
         ab.addMissing()

--- a/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -5,7 +5,12 @@ import is.hail.asm4s._
 import is.hail.expr.types._
 import is.hail.utils._
 
-case class AggSignature(op: AggOp, inputType: Type, constructorArgs: Seq[Type], initOpArgs: Option[Seq[Type]])
+case class AggSignature(
+  op: AggOp,
+  inputType: Type,
+  constructorArgs: Seq[Type],
+  initOpArgs: Option[Seq[Type]]
+)
 
 sealed trait AggOp { }
 // nulary
@@ -70,6 +75,10 @@ object AggOp {
 
     case (Sum(), in: TInt64, Seq(), None) => CodeAggregator[RegionValueSumLongAggregator](in, TInt64())
     case (Sum(), in: TFloat64, Seq(), None) => CodeAggregator[RegionValueSumDoubleAggregator](in, TFloat64())
+    case (Sum(), in@TArray(TInt64(_), _), Seq(), None) =>
+      CodeAggregator[RegionValueArraySumLongAggregator](in, TArray(TInt64()))
+    case (Sum(), in@TArray(TFloat64(_), _), Seq(), None) =>
+      CodeAggregator[RegionValueArraySumDoubleAggregator](in, TArray(TFloat64()))
 
     case (Product(), in: TInt64, Seq(), None) => CodeAggregator[RegionValueProductLongAggregator](in, TInt64())
     case (Product(), in: TFloat64, Seq(), None) => CodeAggregator[RegionValueProductDoubleAggregator](in, TFloat64())

--- a/src/main/scala/is/hail/expr/ir/CodeAggregator.scala
+++ b/src/main/scala/is/hail/expr/ir/CodeAggregator.scala
@@ -26,12 +26,30 @@ case class CodeAggregator[Agg <: RegionValueAggregator : ClassTag : TypeInfo](
     Code.checkcast[Agg](rva).invoke("initOp", argTypes, args)(classTag[Unit])
   }
 
-  def seqOp(rva: Code[RegionValueAggregator], v: Code[_], mv: Code[Boolean]): Code[Unit] = {
+  def seqOp(region: Code[Region], rva: Code[RegionValueAggregator], v: Code[_], mv: Code[Boolean]): Code[Unit] = {
     TypeToIRIntermediateClassTag(in) match {
       case ct: ClassTag[t] =>
         mv.mux(
-          Code.checkcast[Agg](rva).invoke("seqOp", coerce[t](defaultValue(in)), true)(ct, classTag[Boolean], classTag[Unit]),
-          Code.checkcast[Agg](rva).invoke("seqOp", coerce[t](v), false)(ct, classTag[Boolean], classTag[Unit]))
+          Code.checkcast[Agg](rva).invoke(
+            "seqOp",
+            region,
+            coerce[t](defaultValue(in)),
+            true
+          )(classTag[Region],
+            ct,
+            classTag[Boolean],
+            classTag[Unit]
+          ),
+          Code.checkcast[Agg](rva).invoke(
+            "seqOp",
+            region,
+            coerce[t](v),
+            false
+          )(classTag[Region],
+            ct,
+            classTag[Boolean],
+            classTag[Unit]
+          ))
     }
   }
 

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -581,7 +581,7 @@ private class Emit(
           Code(codeI.setup, codeA.setup,
             codeI.m.mux(
               Code._empty,
-               agg.seqOp(aggregator(coerce[Int](codeI.v)), codeA.v, codeA.m))),
+               agg.seqOp(region, aggregator(coerce[Int](codeI.v)), codeA.v, codeA.m))),
           const(false),
           Code._empty)
 

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -325,6 +325,8 @@ object Interpret {
               case TInt64(_) => new SumAggregator[Long]()
               case TFloat32(_) => new SumAggregator[Float]()
               case TFloat64(_) => new SumAggregator[Double]()
+              case TArray(TInt64(_), _) => new SumArrayAggregator[Long]()
+              case TArray(TFloat64(_), _) => new SumArrayAggregator[Double]()
             }
           case Max() =>
             aggType match {

--- a/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
@@ -129,14 +129,7 @@ class AggregatorsSuite {
     val aggSig = AggSignature(Sum(), TArray(hailType[T]), FastSeq(), None)
     val aggregable = a.map(Row(_))
     assertEvalsTo(
-      ApplyAggOp(
-        SeqOp(
-          Ref("a", TArray(hailType[T])),
-          I32(0),
-          aggSig),
-        FastSeq(),
-        None,
-        aggSig),
+      ApplyAggOp(SeqOp(Ref("a", TArray(hailType[T])), I32(0), aggSig), FastSeq(), None, aggSig),
       (aggregable, TStruct("a" -> TArray(hailType[T]))),
       expected)
   }

--- a/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir
 
+import is.hail.expr._
 import is.hail.expr.types._
 import is.hail.TestUtils._
 import org.testng.annotations.Test
@@ -120,4 +121,95 @@ class AggregatorsSuite {
       (FastIndexedSeq(Row(1.0, 10.0), Row(10.0, 10.0), Row(null, 10.0)), TStruct("a" -> TFloat64(), "b" -> TFloat64())),
       110.0)
   }
+
+  private[this] def assertArraySumEvalsTo[T: HailRep](
+    a: IndexedSeq[Seq[T]],
+    expected: Seq[T]
+  ): Unit = {
+    val aggSig = AggSignature(Sum(), TArray(hailType[T]), FastSeq(), None)
+    val aggregable = a.map(Row(_))
+    assertEvalsTo(
+      ApplyAggOp(
+        SeqOp(
+          Ref("a", TArray(hailType[T])),
+          I32(0),
+          aggSig),
+        FastSeq(),
+        None,
+        aggSig),
+      (aggregable, TStruct("a" -> TArray(hailType[T]))),
+      expected)
+  }
+
+  @Test
+  def arraySumFloat64OnEmpty(): Unit =
+    assertArraySumEvalsTo[Double](
+      FastIndexedSeq(),
+      null
+    )
+
+  @Test
+  def arraySumFloat64OnSingletonMissing(): Unit =
+    assertArraySumEvalsTo[Double](
+      FastIndexedSeq(null),
+      null
+    )
+
+  @Test
+  def arraySumFloat64OnAllMissing(): Unit =
+    assertArraySumEvalsTo[Double](
+      FastIndexedSeq(null, null, null),
+      null
+    )
+
+  @Test
+  def arraySumInt64OnEmpty(): Unit =
+    assertArraySumEvalsTo[Long](
+      FastIndexedSeq(),
+      null
+    )
+
+  @Test
+  def arraySumInt64OnSingletonMissing(): Unit =
+    assertArraySumEvalsTo[Long](
+      FastIndexedSeq(null),
+      null
+    )
+
+  @Test
+  def arraySumInt64OnAllMissing(): Unit =
+    assertArraySumEvalsTo[Long](
+      FastIndexedSeq(null, null, null),
+      null
+    )
+
+  @Test
+  def arraySumFloat64OnSmallArray(): Unit =
+    assertArraySumEvalsTo(
+      FastIndexedSeq(
+        FastSeq(1.0, 2.0),
+        FastSeq(10.0, 20.0),
+        null),
+      FastSeq(11.0, 22.0)
+    )
+
+  @Test
+  def arraySumInt64OnSmallArray(): Unit =
+    assertArraySumEvalsTo(
+      FastIndexedSeq(
+        FastSeq(1L, 2L),
+        FastSeq(10L, 20L),
+        null),
+      FastSeq(11L, 22L)
+    )
+
+  @Test
+  def arraySumInt64FirstElementMissing(): Unit =
+    assertArraySumEvalsTo(
+      FastIndexedSeq(
+        null,
+        FastSeq(1L, 33L),
+        FastSeq(42L, 3L)),
+      FastSeq(43L, 36L)
+    )
 }


### PR DESCRIPTION
This teaches the IR how to compile `hl.agg.array_sum`, which it
previously could not compile. This is the first aggregator whose
input is a non-primitive value. I decided to generalize the seqOp
so that it accepts a Region argument and so that the element is
an IR "intermediate". An IR "intermediate" is a primitive value
or a `Long` offset for values of fundamental type Array or Binary.

cc: @armartin