### PR TITLE
remove function registry warning for failed conversion

### DIFF
--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -73,7 +73,6 @@ object IRFunctionRegistry {
 
     (validIR, validMethods) match {
       case (None, None) =>
-        log.warn(s"no IRFunction found for $name(${ args.mkString(", ") })")
         None
       case (None, Some(x)) => Some(x)
       case (Some(x), None) => Some(x)


### PR DESCRIPTION
Now that all the warnings are happening in toIR, and Apply.toIR checks all three possible conversions to make sure that only one of them converts properly, these warnings are both extraneous and misleading.