### PR TITLE
generalize wrapToMethod

### DIFF
--- a/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -115,7 +115,7 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: Type, var
   def addDouble(v: Code[Double]): Code[Unit] = region.storeDouble(currentOffset, v)
 
   def allocateBinary(n: Code[Int]): Code[Long] = {
-    val boff = mb.newLocal[Long]
+    val boff = mb.newField[Long]
     Code(
       boff := TBinary.allocate(region, n),
       region.storeInt(boff, n),
@@ -128,7 +128,7 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: Type, var
   }
 
   def addBinary(bytes: Code[Array[Byte]]): Code[Unit] = {
-    val boff = mb.newLocal[Long]
+    val boff = mb.newField[Long]
     Code(
       boff := region.appendInt(bytes.length()),
       toUnit(region.appendBytes(bytes)),
@@ -146,7 +146,7 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: Type, var
 
   def addArray(t: TArray, f: (StagedRegionValueBuilder => Code[Unit])): Code[Unit] = f(new StagedRegionValueBuilder(mb, t, this))
 
-  def addBaseStruct(t: TBaseStruct, f: (StagedRegionValueBuilder => Code[Unit]), init: LocalRef[Boolean] = null): Code[Unit] = f(new StagedRegionValueBuilder(mb, t, this))
+  def addBaseStruct(t: TBaseStruct, f: (StagedRegionValueBuilder => Code[Unit])): Code[Unit] = f(new StagedRegionValueBuilder(mb, t, this))
 
   def addIRIntermediate(t: Type): (Code[_]) => Code[Unit] = t.fundamentalType match {
     case _: TBoolean => v => addBoolean(v.asInstanceOf[Code[Boolean]])

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -55,12 +55,22 @@ case class ArrayIteratorTriplet(calcLength: Code[Unit], length: Option[Code[Int]
     copy(calcLength = calcLength, length = length, arrayEmitter = { cont: Emit.F => arrayEmitter(contMap(cont, _, _)) })
 }
 
-private class Emit(
-  mb: EmitMethodBuilder,
-  nSpecialArguments: Int) {
+abstract class MethodBuilderLike[M <: MethodBuilderLike[M]] {
+  type MB <: MethodBuilder
 
+  def mb: MB
+
+  def newMethod(paramInfo: Array[TypeInfo[_]], returnInfo: TypeInfo[_]): M
+}
+
+abstract class EstimableEmitter[M <: MethodBuilderLike[M]] {
+  def emit(mb: M): Code[Unit]
+
+  def estimatedSize: Int
+}
+
+object EmitUtils {
   private val maxBytecodeSizeTarget: Int = 4096
-  private val opSize: Int = 20
 
   def getChunkBounds(sizes: Seq[Int]): Array[Int] = {
     var total = 0
@@ -70,51 +80,76 @@ private class Emit(
       if (total == 0 || total + size <= maxBytecodeSizeTarget)
         total += size
       else {
-        ab += i
-        total = 0
+        ab += (i - 1)
+        total = size
       }
     }
     ab += sizes.size
     ab.result()
   }
 
+  def wrapToMethod[T, M <: MethodBuilderLike[M]](items: Seq[EstimableEmitter[M]], mbLike: M): Code[Unit] = {
+    if (items.isEmpty)
+      return Code._empty
+
+    val sizes = items.map(_.estimatedSize)
+    if (sizes.sum < 100)
+      return coerce[Unit](Code(items.map(_.emit(mbLike)): _*))
+
+    val chunkBounds = getChunkBounds(sizes)
+    assert(chunkBounds(0) == 0 && chunkBounds.last == sizes.length)
+
+    val chunks = chunkBounds.zip(chunkBounds.tail).map { case (start, end) =>
+      assert(start < end)
+      val newMBLike = mbLike.newMethod(mbLike.mb.parameterTypeInfo, typeInfo[Unit])
+      val c = items.slice(start, end)
+      newMBLike.mb.emit(Code(c.map(_.emit(newMBLike)): _*))
+      new EstimableEmitter[M] {
+        def estimatedSize: Int = 5
+
+        def emit(mbLike: M): Code[Unit] = {
+          val args = mbLike.mb.parameterTypeInfo.zipWithIndex.map { case (ti, i) => mbLike.mb.getArg(i + 1)(ti).load() }
+          coerce[Unit](newMBLike.mb.invoke(args: _*))
+        }
+      }
+    }
+    wrapToMethod(chunks, mbLike)
+  }
+}
+
+private class Emit(
+  val mb: EmitMethodBuilder,
+  val nSpecialArguments: Int) {
+
   val methods: mutable.Map[String, Seq[(Seq[Type], EmitMethodBuilder)]] = mutable.Map().withDefaultValue(FastSeq())
 
   import Emit.E
   import Emit.F
 
+  class EmitMethodBuilderLike(val emit: Emit) extends MethodBuilderLike[EmitMethodBuilderLike] {
+    type MB = EmitMethodBuilder
+
+    def mb: MB = emit.mb
+
+    def newMethod(paramInfo: Array[TypeInfo[_]], returnInfo: TypeInfo[_]): EmitMethodBuilderLike = {
+      val newMB = emit.mb.fb.newMethod(paramInfo, returnInfo)
+      val newEmitter = new Emit(newMB, emit.nSpecialArguments)
+      new EmitMethodBuilderLike(newEmitter)
+    }
+  }
+
   private def wrapToMethod(irs: Seq[IR], env: E)(useValues: (EmitMethodBuilder, Type, EmitTriplet) => Code[Unit]): Code[Unit] = {
-    def wrapCodeChunks(items: Seq[_], isIR: Boolean = false): Code[Unit] = {
-      val sizes: Seq[Int] = if (isIR) irs.map(_.size * opSize) else Array.fill(items.size)(5)
-      val chunkBounds = getChunkBounds(sizes)
-      chunkBounds match {
-        case Array(start, end) =>
-          if (isIR) {
-            val c = for (ir: IR <- items.asInstanceOf[Seq[IR]]) yield
-              useValues(mb, ir.typ, emit(ir, env))
-            coerce[Unit](Code(c: _*))
-          } else
-            coerce[Unit](Code(items.asInstanceOf[Seq[Code[Unit]]]: _*))
-        case _ =>
-          val chunks = chunkBounds.zip(chunkBounds.tail).map { case (start, end) =>
-            val newMB = mb.fb.newMethod(mb.parameterTypeInfo, typeInfo[Unit])
-            val c = {
-              if (isIR) {
-                val emitWrapper = new Emit(newMB, nSpecialArguments)
-                for (ir: IR <- items.asInstanceOf[Seq[IR]].slice(start, end)) yield
-                  useValues(newMB, ir.typ, emitWrapper.emit(ir, env))
-              } else
-                items.asInstanceOf[Seq[Code[Unit]]].slice(start, end)
-            }
-            newMB.emit(Code(c: _*))
-            val args = mb.parameterTypeInfo.zipWithIndex.map { case (ti, i) => mb.getArg(i + 1)(ti).load() }
-            coerce[Unit](newMB.invoke(args: _*))
-          }
-          wrapCodeChunks(chunks)
+    val opSize: Int = 20
+    val items = irs.map { ir =>
+      new EstimableEmitter[EmitMethodBuilderLike] {
+        def estimatedSize: Int = ir.size * opSize
+
+        def emit(mbLike: EmitMethodBuilderLike): Code[Unit] =
+          useValues(mbLike.mb, ir.typ, mbLike.emit.emit(ir, env))
       }
     }
 
-    wrapCodeChunks(irs, true)
+    EmitUtils.wrapToMethod(items, new EmitMethodBuilderLike(this))
   }
 
   /**

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -73,14 +73,14 @@ object EmitUtils {
   private val maxBytecodeSizeTarget: Int = 4096
 
   def getChunkBounds(sizes: Seq[Int]): Array[Int] = {
-    var total = 0
     val ab = new ArrayBuilder[Int]()
     ab += 0
-    sizes.zipWithIndex.foreach { case (size, i) =>
-      if (total == 0 || total + size <= maxBytecodeSizeTarget)
+    var total = sizes.head
+    sizes.zipWithIndex.tail.foreach { case (size, i) =>
+      if (total + size <= maxBytecodeSizeTarget)
         total += size
       else {
-        ab += (i - 1)
+        ab += i
         total = size
       }
     }

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -105,12 +105,12 @@ object EmitUtils {
       val c = items.slice(start, end)
       newMBLike.mb.emit(Code(c.map(_.emit(newMBLike)): _*))
       new EstimableEmitter[M] {
-        def estimatedSize: Int = 5
-
         def emit(mbLike: M): Code[Unit] = {
           val args = mbLike.mb.parameterTypeInfo.zipWithIndex.map { case (ti, i) => mbLike.mb.getArg(i + 1)(ti).load() }
           coerce[Unit](newMBLike.mb.invoke(args: _*))
         }
+
+        def estimatedSize: Int = 5
       }
     }
     wrapToMethod(chunks, mbLike)

--- a/src/main/scala/is/hail/io/RowStore.scala
+++ b/src/main/scala/is/hail/io/RowStore.scala
@@ -13,6 +13,7 @@ import org.json4s.jackson.JsonMethods
 import java.io.{Closeable, InputStream, OutputStream, PrintWriter}
 
 import is.hail.asm4s._
+import is.hail.expr.ir.{EmitUtils, EstimableEmitter, MethodBuilderLike}
 import is.hail.utils.richUtils.ByteTrackingOutputStream
 import org.apache.spark.{ExposedMetrics, TaskContext}
 
@@ -574,7 +575,26 @@ trait Decoder extends Closeable {
   def readByte(): Byte
 }
 
+class MethodBuilderSelfLike(val mb: MethodBuilder) extends MethodBuilderLike[MethodBuilderSelfLike] {
+  type MB = MethodBuilder
+
+  def newMethod(paramInfo: Array[TypeInfo[_]], returnInfo: TypeInfo[_]): MethodBuilderSelfLike =
+    new MethodBuilderSelfLike(mb.fb.newMethod(paramInfo, returnInfo))
+}
+
 object EmitPackDecoder {
+  self =>
+
+  type Emitter = EstimableEmitter[MethodBuilderSelfLike]
+
+  def emitTypeSize(t: Type): Int = {
+    t match {
+      case t: TArray => 20 + emitTypeSize(t.elementType)
+      case t: TStruct => 100
+      case _ => 20
+    }
+  }
+
   def emitBinary(
     t: TBinary,
     mb: MethodBuilder,
@@ -597,16 +617,14 @@ object EmitPackDecoder {
     srvb: StagedRegionValueBuilder): Code[Unit] = {
     val region = srvb.region
 
-    val off = mb.newLocal[Long]
-    val moff = mb.newLocal[Long]
+    val moff = mb.newField[Long]
 
     val initCode = Code(
       srvb.start(init = true),
-      off := srvb.offset,
       moff := region.allocate(const(1), const(t.nMissingBytes)),
       in.readBytes(region, moff, t.nMissingBytes))
 
-    val fieldCode = new Array[Code[Unit]](t.size)
+    val fieldEmitters = new Array[Emitter](t.size)
 
     assert(t.isInstanceOf[TTuple] || t.isInstanceOf[TStruct])
 
@@ -614,37 +632,52 @@ object EmitPackDecoder {
     var j = 0
     while (i < t.size) {
       val f = t.fields(i)
-      fieldCode(i) =
+      fieldEmitters(i) =
         if (t.isInstanceOf[TTuple] ||
           (j < requestedType.size && requestedType.fields(j).name == f.name)) {
           val rf = requestedType.fields(j)
           assert(f.typ.required == rf.typ.required)
           j += 1
-          val readElement = emit(f.typ, rf.typ, mb, in, srvb)
-          Code(
-            if (f.typ.required)
-              readElement
-            else {
-              region.loadBit(moff, const(t.missingIdx(i))).mux(
-                srvb.setMissing(),
-                readElement)
-            },
-            srvb.advance())
+
+          new Emitter {
+            def emit(mbLike: MethodBuilderSelfLike): Code[Unit] = {
+              val readElement = self.emit(f.typ, rf.typ, mbLike.mb, in, srvb)
+              Code(
+                if (f.typ.required)
+                  readElement
+                else {
+                  region.loadBit(moff, const(t.missingIdx(f.index))).mux(
+                    srvb.setMissing(),
+                    readElement)
+                },
+                srvb.advance())
+            }
+
+            def estimatedSize: Int = emitTypeSize(f.typ)
+          }
         } else {
-          val skipField = skip(f.typ, mb, in, region)
-          if (f.typ.required)
-            skipField
-          else {
-            region.loadBit(moff, const(t.missingIdx(i))).mux(
-              Code._empty,
-              skipField)
+          new Emitter {
+            def emit(mbLike: MethodBuilderSelfLike): Code[Unit] = {
+              val skipField = skip(f.typ, mbLike.mb, in, region)
+              if (f.typ.required)
+                skipField
+              else {
+                region.loadBit(moff, const(t.missingIdx(f.index))).mux(
+                  Code._empty,
+                  skipField)
+              }
+            }
+
+            def estimatedSize: Int = emitTypeSize(f.typ)
           }
         }
       i += 1
     }
     assert(j == requestedType.size)
 
-    Code(initCode, Code(fieldCode: _*), Code._empty)
+    Code(initCode,
+      EmitUtils.wrapToMethod(fieldEmitters, new MethodBuilderSelfLike(mb)),
+      Code._empty)
   }
 
   def emitArray(
@@ -683,20 +716,28 @@ object EmitPackDecoder {
   }
 
   def skipBaseStruct(t: TBaseStruct, mb: MethodBuilder, in: Code[InputBuffer], region: Code[Region]): Code[Unit] = {
-    val moff = mb.newLocal[Long]
+    val moff = mb.newField[Long]
+
+    val fieldEmitters = t.fields.map { f =>
+      new Emitter {
+        def emit(mbLike: MethodBuilderSelfLike): Code[Unit] = {
+          val skipField = skip(f.typ, mbLike.mb, in, region)
+          if (f.typ.required)
+            skipField
+          else
+            region.loadBit(moff, const(t.missingIdx(f.index))).mux(
+              Code._empty,
+              skipField)
+        }
+
+        def estimatedSize: Int = emitTypeSize(f.typ)
+      }
+    }
+
     Code(
       moff := region.allocate(const(1), const(t.nMissingBytes)),
       in.readBytes(region, moff, t.nMissingBytes),
-      Code(t.fields.map { f =>
-        val skipField = skip(f.typ, mb, in, region)
-        if (f.typ.required)
-          skipField
-        else
-          region.loadBit(moff, const(t.missingIdx(f.index))).mux(
-            Code._empty,
-            skipField)
-      }: _*),
-      Code._empty)
+      EmitUtils.wrapToMethod(fieldEmitters, new MethodBuilderSelfLike(mb)))
   }
 
   def skipArray(t: TArray,
@@ -717,8 +758,6 @@ object EmitPackDecoder {
     } else {
       val moff = mb.newLocal[Long]
       val nMissing = mb.newLocal[Int]
-      val m = mb.newLocal[Int]
-      val n = mb.newLocal[Int]
       Code(
         length := in.readInt(),
         nMissing := ((length + 7) >>> 3),
@@ -784,14 +823,14 @@ object EmitPackDecoder {
   def apply(t: Type, requestedType: Type): () => AsmFunction2[Region, InputBuffer, Long] = {
     val fb = new Function2Builder[Region, InputBuffer, Long]
     val mb = fb.apply_method
-    val region = fb.arg2
-    val srvb = new StagedRegionValueBuilder(fb, requestedType)
+    val in = mb.getArg[InputBuffer](2).load()
+    val srvb = new StagedRegionValueBuilder(mb, requestedType)
 
     var c = t.fundamentalType match {
       case t: TBaseStruct =>
-        emitBaseStruct(t, requestedType.fundamentalType.asInstanceOf[TBaseStruct], mb, region, srvb)
+        emitBaseStruct(t, requestedType.fundamentalType.asInstanceOf[TBaseStruct], mb, in, srvb)
       case t: TArray =>
-        emitArray(t, requestedType.fundamentalType.asInstanceOf[TArray], mb, region, srvb)
+        emitArray(t, requestedType.fundamentalType.asInstanceOf[TArray], mb, in, srvb)
     }
 
     mb.emit(Code(

--- a/src/main/scala/is/hail/io/RowStore.scala
+++ b/src/main/scala/is/hail/io/RowStore.scala
@@ -589,7 +589,7 @@ object EmitPackDecoder {
 
   def emitTypeSize(t: Type): Int = {
     t match {
-      case t: TArray => 20 + emitTypeSize(t.elementType)
+      case t: TArray => 120 + emitTypeSize(t.elementType)
       case t: TStruct => 100
       case _ => 20
     }


### PR DESCRIPTION
I need to use in decoder builder which doesn't currently chunk struct construction, will use there after https://github.com/hail-is/hail/pull/3667 goes in to avoid conflicts.

This introduces 1 change in behavior: code with estimated size > 100 will be put out in its own method, even it fits in one block.  If I read it correctly, the old code would put any amount of code inline up to the method limit target, so several medium-sized structs would potentially blow out the method bytecode limit.

Also fixed a bug in getChunkBounds where items on the boundary weren't counted in the size.