### PR TITLE
BlockMatrix fill, sum over axis

### DIFF
--- a/python/hail/linalg/blockmatrix.py
+++ b/python/hail/linalg/blockmatrix.py
@@ -48,8 +48,6 @@ class BlockMatrix(object):
 
     .. include:: ../_templates/experimental.rst
 
-    Notes
-    -----
     A block matrix is a distributed analogue of a two-dimensional
     `NumPy ndarray
     <https://docs.scipy.org/doc/numpy/reference/arrays.ndarray.html>`__ with
@@ -177,7 +175,9 @@ class BlockMatrix(object):
 
     These following methods always result in a block-dense matrix:
 
-    - Addition and subtraction of a scalar or broadcasted vector.
+    - :meth:`fill`
+
+    - Addition or subtraction of a scalar or broadcasted vector.
 
     - Matrix multiplication, ``@``.
 
@@ -187,7 +187,7 @@ class BlockMatrix(object):
     The following methods fail if any operand is block-sparse, but can be forced
     by first applying :meth:`densify`.
 
-    - Division between two block matrices.
+    - Element-wise division between two block matrices.
 
     - Multiplication by a scalar or broadcasted vector which includes an
       infinite or ``nan`` value.
@@ -197,7 +197,7 @@ class BlockMatrix(object):
 
     - Division of a scalar or broadcasted vector by a block matrix.
 
-    - Exponentiation by a negative exponent.
+    - Element-wise exponentiation by a negative exponent.
 
     - Natural logarithm, :meth:`log`.
     """
@@ -349,6 +349,10 @@ class BlockMatrix(object):
         Do not use this method if you want to store a copy of the resulting
         block matrix. Instead, use :meth:`write_from_entry_expr` followed by
         :meth:`BlockMatrix.read`.
+
+        If a pipelined transformation significantly downsamples the rows of the
+        underlying matrix table, then repartitioning the matrix table ahead of
+        this method will greatly improve its performance.
 
         The method will fail if any values are missing. To be clear, special
         float values like ``NaN`` are not missing values.
@@ -539,8 +543,12 @@ class BlockMatrix(object):
         ...                                   'output/model.bm')
 
         Notes
-        -----        
+        -----
         The resulting file can be loaded with :meth:`BlockMatrix.read`.
+
+        If a pipelined transformation significantly downsamples the rows of the
+        underlying matrix table, then repartitioning the matrix table ahead of
+        this method will greatly improve its performance.
 
         The method will fail if any values are missing. To be clear, special
         float values like ``NaN`` are not missing values.

--- a/python/hail/linalg/blockmatrix.py
+++ b/python/hail/linalg/blockmatrix.py
@@ -172,6 +172,9 @@ class BlockMatrix(object):
 
     - :meth:`abs` and :meth:`sqrt` preserve the realized blocks.
 
+    - :meth:`sum` along an axis realizes those blocks for which at least one
+      block summand is realized.
+
     These following methods always result in a block-dense matrix:
 
     - Addition and subtraction of a scalar or broadcasted vector.
@@ -343,7 +346,12 @@ class BlockMatrix(object):
 
         Notes
         -----
-        If any values are missing, an error message is returned.
+        Do not use this method if you want to store a copy of the resulting
+        block matrix. Instead, use :meth:`write_from_entry_expr` followed by
+        :meth:`BlockMatrix.read`.
+
+        The method will fail if any values are missing. To be clear, special
+        float values like ``NaN`` are not missing values.
 
         Parameters
         ----------
@@ -397,6 +405,39 @@ class BlockMatrix(object):
         if not block_size:
             block_size = BlockMatrix.default_block_size()
         return cls(Env.hail().linalg.BlockMatrix.random(Env.hc()._jhc, n_rows, n_cols, block_size, seed, uniform))
+
+    @classmethod
+    @typecheck_method(n_rows=int,
+                      n_cols=int,
+                      value=float,
+                      block_size=nullable(int))
+    def fill(cls, n_rows, n_cols, value, block_size=None):
+        """Creates a block matrix with all elements the same value.
+
+        Examples
+        --------
+        Create a block matrix with 10 rows, 20 columns, and all elements equal to ``1.0``:
+
+        >>> bm = BlockMatrix.fill(10, 20, 1.0)
+
+        Parameters
+        ----------
+        n_rows: :obj:`int`
+            Number of rows.
+        n_cols: :obj:`int`
+            Number of columns.
+        value: :obj:`float`
+            Value of all elements.
+        block_size: :obj:`int`, optional
+            Block size. Default given by :meth:`default_block_size`.
+
+        Returns
+        -------
+        :class:`.BlockMatrix`
+        """
+        if not block_size:
+            block_size = BlockMatrix.default_block_size()
+        return cls(Env.hail().linalg.BlockMatrix.fill(Env.hc()._jhc, n_rows, n_cols, value, block_size))
 
     @classmethod
     @typecheck_method(n_rows=int,
@@ -498,10 +539,11 @@ class BlockMatrix(object):
         ...                                   'output/model.bm')
 
         Notes
-        -----
-        If any values are missing, an error message is returned.
-
+        -----        
         The resulting file can be loaded with :meth:`BlockMatrix.read`.
+
+        The method will fail if any values are missing. To be clear, special
+        float values like ``NaN`` are not missing values.
 
         Parameters
         ----------
@@ -968,7 +1010,7 @@ class BlockMatrix(object):
         -------
         :obj:`bool`
         """
-        return self._jbm.gp().maybeSparse().isDefined()
+        return self._jbm.gp().maybeBlocks().isDefined()
 
     @property
     def T(self):
@@ -1309,6 +1351,50 @@ class BlockMatrix(object):
         :class:`numpy.ndarray`
         """
         return _ndarray_from_jarray(self._jbm.diagonal())
+
+    @typecheck_method(axis=nullable(int))
+    def sum(self, axis=None):
+        """Sums array elements over one or both axes.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> nd = np.array([[ 1.0,  2.0,  3.0],
+        ...                [ 4.0,  5.0,  6.0]])
+        >>> bm = BlockMatrix.from_numpy(nd)
+        >>> bm.sum()
+        21.0
+
+        >>> bm.sum(axis=0).to_numpy()
+        array([[5., 7., 9.]])
+
+        >>> bm.sum(axis=1).to_numpy()
+        array([[ 6.],
+               [15.]])
+
+        Parameters
+        ----------
+        axis: :obj:`int`, optional
+            Axis over which to sum.
+            By default, sum all elements.
+            If ``0``, sum over rows.
+            If ``1``, sum over columns.
+
+        Returns
+        -------
+        :obj:`float` or :class:`BlockMatrix`
+            If None, returns a float.
+            If ``0``, returns a block matrix with a single row.
+            If ``1``, returns a block matrix with a single column.
+        """
+        if axis is None:
+            return self._jbm.sum()
+        elif axis == 0:
+            return BlockMatrix(self._jbm.rowSum())
+        elif axis == 1:
+            return BlockMatrix(self._jbm.colSum())
+        else:
+            raise ValueError(f'axis must be None, 0, or 1: found {axis}')
 
     def entries(self):
         """Returns a table with the coordinates and numeric value of each block matrix entry.

--- a/python/hail/tests/test_linalg.py
+++ b/python/hail/tests/test_linalg.py
@@ -354,20 +354,19 @@ class Tests(unittest.TestCase):
 
     def test_fill(self):
         nd = np.ones((3, 5))
-
         bm = BlockMatrix.fill(3, 5, 1.0)
-        self.assertTrue(bm.block_size == BlockMatrix.default_block_size())
-        self.assertTrue(np.array_equal(bm.to_numpy(), nd))
-
         bm2 = BlockMatrix.fill(3, 5, 1.0, block_size=2)
+
+        self.assertTrue(bm.block_size == BlockMatrix.default_block_size())
         self.assertTrue(bm2.block_size == 2)
-        self.assertTrue(np.array_equal(bm2.to_numpy(), nd))
+        self._assert_eq(bm, nd)
+        self._assert_eq(bm2, nd)
 
     def test_sum(self):
         def sums_agree(bm, nd):
             self.assertAlmostEqual(bm.sum(), np.sum(nd))
-            self.assertTrue(np.allclose(bm.sum(axis=0).to_numpy(), np.sum(nd, axis=0, keepdims=True)))
-            self.assertTrue(np.allclose(bm.sum(axis=1).to_numpy(), np.sum(nd, axis=1, keepdims=True)))
+            self._assert_close(bm.sum(axis=0), np.sum(nd, axis=0, keepdims=True))
+            self._assert_close(bm.sum(axis=1), np.sum(nd, axis=1, keepdims=True))
 
         nd = np.random.normal(size=(11, 13))
         bm = BlockMatrix.from_numpy(nd, block_size=3)

--- a/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
@@ -136,7 +136,7 @@ class RichDenseMatrixDouble(val m: BDM[Double]) extends AnyVal {
     hadoop.writeDataFile(path + BlockMatrix.metadataRelativePath) { os =>
       implicit val formats = defaultJSONFormats
       jackson.Serialization.write(
-        BlockMatrixMetadata(blockSize, m.rows, m.cols, gp.maybeSparse, partFiles),
+        BlockMatrixMetadata(blockSize, m.rows, m.cols, gp.maybeBlocks, partFiles),
         os)
     }
 

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -2490,7 +2490,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     hadoop.writeDataFile(dirname + BlockMatrix.metadataRelativePath) { os =>
       implicit val formats = defaultJSONFormats
       jackson.Serialization.write(
-        BlockMatrixMetadata(blockSize, nRows, localNCols, gp.maybeSparse, partFiles),
+        BlockMatrixMetadata(blockSize, nRows, localNCols, gp.maybeBlocks, partFiles),
         os)
     }
 


### PR DESCRIPTION
Added to Python BlockMatrix:
- `fill` w/ test
- `sum` w/ test (useful for LD scores among other things)

Added to Scala BlockMatrix:
- `fill`
- `apply` to factor out common motif in `fromBreezeMatrix`, `random`, `fill`
- `sum`, `rowSum`, `colSum` via `reduce`, `rowReduce`, `colReduce`

Added `maybeBlockRows` and `maybeBlockCols` to GridPartitioner, and changed `maybeSparse` to the more descriptive `maybeBlocks` to match.

Regarding the implementations of `sum`, `rowSum`, `colSum`: I tested Breeze op `sum(a(::, *))` against Breeze matrix multiplication by a vector of ones at the block level, and found the latter to be four times faster on laptop (17s vs 4.5s for 1000 iterations).

```
  @Test  
  def sum() {
    val a = BDM.rand[Double](4096, 4096)
    printTime {
      var i = 0
      while (i < 1000) {
        //val c = breeze.linalg.sum(a(*, ::))
        val b = BDV.ones[Double](4096)
        val c = a * b
        i += 1
      }
    }
  }
```

However, I didn't implement `sum` over (say) rows using distributed multiply because the parallelism would be reduced from the number of blocks to the number of blockCols.

Two other small changes:
- added a suggestion in the `from_entry_expr` doc based on seeing a user make this mistake.
- changed `random` to multiply the partition index by a large prime so that consecutive seeds don't produce the same blocks shifted over.