### PR TITLE
LD prune optimization & question

### DIFF
--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -2951,9 +2951,8 @@ def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256):
     check_entry_indexed('ld_prune/call_expr', call_expr)
     mt = matrix_table_source('ld_prune/call_expr', call_expr)
 
-    mt = require_row_key_variant(mt, 'ld_prune')
-    mt = require_partition_key_locus(mt, 'ld_prune')
-    mt = require_biallelic(mt, 'ld_prune')
+    require_row_key_variant(mt, 'ld_prune')
+    require_partition_key_locus(mt, 'ld_prune')
 
     #  FIXME: remove once select_entries on a field is free
     if call_expr in mt._fields_inverse:
@@ -2962,7 +2961,7 @@ def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256):
         field = Env.get_uid()
         mt = mt.select_entries(**{field: call_expr})
 
-    sites_only_table = _local_ld_prune(mt, field, r2, bp_window_size, memory_per_core)
+    sites_only_table = _local_ld_prune(require_biallelic(mt, 'ld_prune'), field, r2, bp_window_size, memory_per_core)
 
     sites_path = new_temp_file()
     sites_only_table.write(sites_path, overwrite=True)
@@ -2987,7 +2986,7 @@ def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256):
                 * locally_pruned_ds.centered_length_sd_reciprocal, 0))
 
     # BlockMatrix.from_entry_expr writes to disk
-    block_matrix = BlockMatrix.from_entry_expr(normalized_mean_imputed_genotype_expr, block_size=1024)
+    block_matrix = BlockMatrix.from_entry_expr(normalized_mean_imputed_genotype_expr)
     correlation_matrix = (block_matrix @ block_matrix.T)
 
     locally_pruned_rows = locally_pruned_ds.rows()


### PR DESCRIPTION
@maccum without checks on the requirements, it could be that `mt` is not partitioned by locus in which case LocalLDPrune wouldn't do much and this would be a bug because the `correlation_matrix` and `locally_pruned_rows` would not align:

```
    block_matrix = BlockMatrix.from_entry_expr(normalized_mean_imputed_genotype_expr, block_size=1024)
    correlation_matrix = (block_matrix @ block_matrix.T)

    locally_pruned_rows = locally_pruned_ds.rows()
    locally_pruned_rows = locally_pruned_rows.key_by(contig=locally_pruned_rows.locus.contig)
    locally_pruned_rows = locally_pruned_rows.select(pos=locally_pruned_rows.locus.position)
    entries = correlation_matrix._filtered_entries_table(locally_pruned_rows, bp_window_size, False)
```

I'm still worried about the following. By changing the key (and partition_key) to `contig=locally_pruned_rows.locus.contig`, the execute code for keyBy below will repartition and resort. I believe the resorting won't actually reorder the key equals the partition key, so each resulting partition is de facto sorted. But what guarantee do we have that groups or rows from different original partitions overlapping the contig aren't re-ordered?

```
  def execute(hc: HailContext): TableValue = {
    val tv = child.execute(hc)
    val rvd = if (sort) {
      def resort: OrderedRVD = {
        val orvdType = new OrderedRVDType(keys.take(nPartitionKeys), keys, typ.rowType)
        OrderedRVD.coerce(orvdType, tv.rvd, None, None)
      }

      tv.rvd match {
        case ordered: OrderedRVD =>
          if (ordered.typ.key.startsWith(keys)
            && ordered.typ.partitionKey.length == nPartitionKeys)
            ordered.copy(typ = ordered.typ.copy(key = keys))
          else resort
        case _: UnpartitionedRVD =>
          resort
      }
...
```

Then in UpperIndexBounds, we do `tbl.groupByKey("positions")`. Our implementation of groupByKey should be fine w.r.t. preserving key (group / contig) order. But later:
```
    val relativeUpperIndexBounds = groupPositionsByKey(tbl).map(positions => {
      scala.util.Sorting.quickSort(positions)
      computeUpperIndexBounds(positions, radius)
    })
```
If these positions aren't already sorted, wouldn't changing their order screw up the alignment with the block matrix? (I think they happen to be sorted because we re-keyed from locus to contig to get here).

I think if we verify that the positions are sorted, rather than sorting the positions, then we guarantee the right behavior of this function with respect to not re-ordering rows (at least up to switching rows with the same position, but that doesn't matter for determining the range bounds). What do you think?