### PR TITLE
ld_prune: add MAF preference in MIS, other improvements

### DIFF
--- a/python/hail/expr/functions.py
+++ b/python/hail/expr/functions.py
@@ -2735,7 +2735,7 @@ def signum(x):
 
     Returns
     -------
-    :class:`.NumericExpression` or :class:`.ArrayNumericExpression`.
+    :class:`.Int32Expression` or :class:`.ArrayNumericExpression`.
     """
     if isinstance(x.dtype, tarray):
         return map(signum, x)

--- a/python/hail/linalg/blockmatrix.py
+++ b/python/hail/linalg/blockmatrix.py
@@ -1405,12 +1405,12 @@ class BlockMatrix(object):
             raise ValueError(f'axis must be None, 0, or 1: found {axis}')
 
     def entries(self):
-        """Returns a table with the coordinates and numeric value of each block matrix entry.
+        """Returns a table with the indices and value of each block matrix entry.
 
         Examples
         --------
         >>> import numpy as np
-        >>> block_matrix = BlockMatrix.from_numpy(np.matrix([[5, 7], [2, 8]]), 2)
+        >>> block_matrix = BlockMatrix.from_numpy(np.array([[5, 7], [2, 8]]), 2)
         >>> entries_table = block_matrix.entries()
         >>> entries_table.show()
         +-------+-------+-------------+
@@ -1424,10 +1424,21 @@ class BlockMatrix(object):
         |     1 |     1 | 8.00000e+00 |
         +-------+-------+-------------+
 
-        Warning
-        -------
+        Notes
+        -----
         The resulting table may be filtered, aggregated, and queried, but should only be
         directly exported to disk if the block matrix is very small.
+
+        For block-sparse matrices, only realized blocks are included. To force inclusion
+        of zeroes in dropped blocks, apply :meth:`densify` first.
+
+        The resulting table has the following fields:
+
+        - **i** (:py:data:`.tint64`, key field) -- Row index.
+
+        - **j** (:py:data:`.tint64`, key field) -- Column index.
+
+        - **entry** (:py:data:`.tfloat64`) -- Value of entry.
 
         Returns
         -------

--- a/python/hail/methods/misc.py
+++ b/python/hail/methods/misc.py
@@ -20,19 +20,20 @@ def maximal_independent_set(i, j, keep=True, tie_breaker=None) -> Table:
 
     Examples
     --------
-    Run PC-relate and compute pairs of individuals:
+    Run PC-relate and compute pairs of closely related individuals:
 
     >>> pc_rel = hl.pc_relate(dataset.GT, 0.001, k=2, statistics='kin')
     >>> pairs = pc_rel.filter(pc_rel['kin'] > 0.125)
 
     Starting from the above pairs, prune individuals from a dataset until no
-    close relationships remain with respect to a PC-Relate measure of kinship:
+    close relationships remain:
 
     >>> related_samples_to_remove = hl.maximal_independent_set(pairs.i, pairs.j, False)
-    >>> result = dataset.filter_cols(hl.is_defined(related_samples_to_remove[dataset.col_key]), keep=False)
+    >>> result = dataset.filter_cols(
+    ...     hl.is_defined(related_samples_to_remove[dataset.col_key]), keep=False)
 
-    Starting from the above pairs, prune individuals from a dataset,
-    preferring to keep cases over controls:
+    Starting from the above pairs, prune individuals from a dataset until no
+    close relationships remain, preferring to keep cases over controls:
 
     >>> samples = dataset.cols()
     >>> pairs_with_case = pairs.key_by(
@@ -163,6 +164,7 @@ def require_row_key_variant(dataset, method):
                          "'alleles' (type 'array<str>')\n"
                          "  Found:{}".format(method, ''.join(
             "\n    '{}': {}".format(k, str(dataset[k].dtype)) for k in dataset.row_key)))
+
 
 def require_row_key_variant_w_struct_locus(dataset, method):
     if (list(dataset.row_key) != ['locus', 'alleles'] or

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -3040,7 +3040,7 @@ def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256, kee
                              info_j=locally_pruned_info[entries.j])
 
     entries = entries.filter((entries.info_i.locus.contig == entries.info_j.locus.contig)
-                             & (entries.info_i.locus.position - entries.info_j.locus.position <= bp_window_size))
+                             & (entries.info_j.locus.position - entries.info_i.locus.position <= bp_window_size))
 
     entries_path = new_temp_file()
     entries.write(entries_path, overwrite=True)

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -294,7 +294,7 @@ def linear_regression(y, x, covariates=(), root='linreg', block_size=16) -> Matr
     3.2 of `The Elements of Statistical Learning, 2nd Edition
     <http://statweb.stanford.edu/~tibs/ElemStatLearn/printings/ESLII_print10.pdf>`__.
     See equation 3.12 for the t-statistic which follows the t-distribution with
-    :math:`n - k - 2` degrees of freedom, under the null hypothesis of no
+    :math:`n - k - 2` degrees of freedom, under the null hypothesis of nogi
     effect, with :math:`n` samples and :math:`k` covariates in addition to
     ``x`` and the intercept.
 
@@ -2896,12 +2896,14 @@ def _local_ld_prune(mt, call_field, r2=0.2, bp_window_size=1000000, memory_per_c
     variant_byte_overhead = 50
     genotypes_per_pack = 32
     n_samples = mt.count_cols()
-    min_memory_per_core = math.ceil((1 / fraction_memory_to_use) * 8 * n_samples + variant_byte_overhead)
-    if bytes_per_core < min_memory_per_core:
-        raise ValueError("memory per core must be greater than {} MB".format(min_memory_per_core * 1024 * 1024))
+    min_bytes_per_core = math.ceil((1 / fraction_memory_to_use) * 8 * n_samples + variant_byte_overhead)
+    if bytes_per_core < min_bytes_per_core:
+        raise ValueError("memory_per_core must be greater than {} MB".format(min_bytes_per_core // (1024 * 1024)))
     bytes_per_variant = math.ceil(8 * n_samples / genotypes_per_pack) + variant_byte_overhead
-    memory_available_per_core = bytes_per_core * fraction_memory_to_use
-    max_queue_size = int(max(1.0, math.ceil(memory_available_per_core / bytes_per_variant)))
+    bytes_available_per_core = bytes_per_core * fraction_memory_to_use
+    max_queue_size = int(max(1.0, math.ceil(bytes_available_per_core / bytes_per_variant)))
+
+    info(f'ld_prune: running local pruning stage with max queue size of {max_queue_size} variants')
 
     sites_only_table = Table(Env.hail().methods.LocalLDPrune.apply(
         mt._jvds, call_field, float(r2), bp_window_size, max_queue_size))
@@ -2941,10 +2943,10 @@ def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256, kee
       this stage. Minor allele frequency is not taken into account. The
       parallelism is the number of matrix table partitions.
 
-    - The second, "global correlation" stage uses block matrix multiplication
-      to compute correlation between each pair of remaining variants within
-      `bp_window_size` base pairs, and then forms a graph of correlated
-      variants. The parallelism of writing the locally-pruned matrix
+    - The second, "global correlation" stage uses block-sparse matrix
+      multiplication to compute correlation between each pair of remaining
+      variants within `bp_window_size` base pairs, and then forms a graph of
+      correlated variants. The parallelism of writing the locally-pruned matrix
       table as a block matrix is ``n_locally_pruned_variants / block_size``.
 
     - The third, "global pruning" stage applies :func:`.maximal_independent_set`

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -294,7 +294,7 @@ def linear_regression(y, x, covariates=(), root='linreg', block_size=16) -> Matr
     3.2 of `The Elements of Statistical Learning, 2nd Edition
     <http://statweb.stanford.edu/~tibs/ElemStatLearn/printings/ESLII_print10.pdf>`__.
     See equation 3.12 for the t-statistic which follows the t-distribution with
-    :math:`n - k - 2` degrees of freedom, under the null hypothesis of nogi
+    :math:`n - k - 2` degrees of freedom, under the null hypothesis of no
     effect, with :math:`n` samples and :math:`k` covariates in addition to
     ``x`` and the intercept.
 
@@ -3014,10 +3014,8 @@ def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256, kee
     locally_pruned_table = hl.read_table(locally_pruned_table_path)
 
     locally_pruned_ds_path = new_temp_file()
-    mt = mt.annotate_rows(
-        mean=locally_pruned_table[mt.row_key].mean,
-        centered_length_rec=locally_pruned_table[mt.row_key].centered_length_rec)
-    (mt.filter_rows(hl.is_defined(mt.mean))
+    mt = mt.annotate_rows(info=locally_pruned_table[mt.row_key])
+    (mt.filter_rows(hl.is_defined(mt.info))
         .write(locally_pruned_ds_path, overwrite=True))
     locally_pruned_ds = hl.read_matrix_table(locally_pruned_ds_path)
 
@@ -3025,7 +3023,7 @@ def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256, kee
     info(f'ld_prune: local pruning stage retained {n_locally_pruned_variants} variants')
 
     standardized_mean_imputed_gt_expr = hl.or_else(
-        (locally_pruned_ds[field].n_alt_alleles() - locally_pruned_ds.mean) * locally_pruned_ds.centered_length_rec,
+        (locally_pruned_ds[field].n_alt_alleles() - locally_pruned_ds.info.mean) * locally_pruned_ds.info.centered_length_rec,
         0.0)
 
     std_gt_bm = BlockMatrix.from_entry_expr(standardized_mean_imputed_gt_expr, block_size)

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -2931,14 +2931,15 @@ def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256, kee
     base pairs apart is strictly less than `r2`. Each variant is represented as
     a vector over samples with elements given by the (mean-imputed) number of
     alternate alleles. In particular, even if present, **phase information is
-    ignored**. 
+    ignored**.
 
     The method prunes variants in linkage disequilibrium in three stages.
 
     - The first, "local pruning" stage prunes correlated variants within each
       partition, using a local variant queue whose size is determined by
       `memory_per_core`. A larger queue may facilitate more local pruning in
-      this stage. The parallelism is the number of partitions in the dataset.
+      this stage. Minor allele frequency is not taken into account. The
+      parallelism is the number of matrix table partitions.
 
     - The second, "global correlation" stage uses block matrix multiplication
       to compute correlation between each pair of remaining variants within
@@ -2949,9 +2950,8 @@ def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256, kee
     - The third, "global pruning" stage applies :func:`.maximal_independent_set`
       to prune variants from this graph until no edges remain. This algorithm
       iteratively removes the variant with the highest vertex degree. If
-      `keep_higher_maf` is true, then in the case of multiple variants of
-      highest degree, the algorithm will remove the variant with lowest minor
-      allele frequency.
+      `keep_higher_maf` is true, then in the case of a tie for highest degree,
+      the variant with lowest minor allele frequency is removed.
 
     If you encounter a Hadoop write/replication error, consider:
 
@@ -2978,9 +2978,8 @@ def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256, kee
     memory_per_core : :obj:`int`
         Memory in MB per core for local pruning queue.
     keep_higher_maf: :obj:`int`
-        If ``True``, break ties at each step of global pruning
-        stage by preferring to keep variants with higher minor
-        allele frequency.
+        If ``True``, break ties at each step of the global pruning stage by
+        preferring to keep variants with higher minor allele frequency.
     block_size: :obj:`int`, optional
         Block size for block matrices in the second stage.
         Default given by :meth:`.BlockMatrix.default_block_size`.
@@ -3008,7 +3007,8 @@ def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256, kee
 
     locally_pruned_table_path = new_temp_file()
     (_local_ld_prune(require_biallelic(mt, 'ld_prune'), field, r2, bp_window_size, memory_per_core)
-         .write(locally_pruned_table_path, overwrite=True))
+        .add_index()
+        .write(locally_pruned_table_path, overwrite=True))
     locally_pruned_table = hl.read_table(locally_pruned_table_path)
 
     locally_pruned_ds_path = new_temp_file()
@@ -3022,10 +3022,9 @@ def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256, kee
     n_locally_pruned_variants = locally_pruned_ds.count_rows()
     info(f'ld_prune: local pruning stage retained {n_locally_pruned_variants} variants')
 
-    standardized_mean_imputed_gt_expr = (
-        hl.cond(hl.is_defined(locally_pruned_ds[field]),
-                (locally_pruned_ds[field].n_alt_alleles() - locally_pruned_ds.mean)
-                * locally_pruned_ds.centered_length_rec, 0.0))
+    standardized_mean_imputed_gt_expr = hl.or_else(
+        (locally_pruned_ds[field].n_alt_alleles() - locally_pruned_ds.mean) * locally_pruned_ds.centered_length_rec,
+        0.0)
 
     std_gt_bm = BlockMatrix.from_entry_expr(standardized_mean_imputed_gt_expr, block_size)
 
@@ -3035,17 +3034,16 @@ def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256, kee
     entries = (std_gt_bm @ std_gt_bm.T)._filtered_entries_table(locally_pruned_positions, bp_window_size, False)
     entries = entries.filter((entries.entry ** 2 >= r2) & (entries.i < entries.j))
 
-    index_table = locally_pruned_table.add_index().key_by('idx').select('locus', 'mean')
-    entries = entries.annotate(locus_i=index_table[entries.i].locus,
-                               mean_i=index_table[entries.i].mean,
-                               locus_j=index_table[entries.j].locus,
-                               mean_j=index_table[entries.j].mean)
+    locally_pruned_info = locally_pruned_table.key_by('idx').select('locus', 'mean')
 
-    entries = entries.filter((entries.locus_i.contig == entries.locus_j.contig)
-                             & (entries.locus_j.position - entries.locus_i.position <= bp_window_size))
+    entries = entries.select(info_i=locally_pruned_info[entries.i],
+                             info_j=locally_pruned_info[entries.j])
+
+    entries = entries.filter((entries.info_i.locus.contig == entries.info_j.locus.contig)
+                             & (entries.info_i.locus.position - entries.info_j.locus.position <= bp_window_size))
 
     entries_path = new_temp_file()
-    entries.drop('entry', 'locus_i', 'locus_j').write(entries_path, overwrite=True)
+    entries.write(entries_path, overwrite=True)
     entries = hl.read_table(entries_path)
 
     n_edges = entries.count()
@@ -3055,9 +3053,9 @@ def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256, kee
     if keep_higher_maf:
         entries = entries.key_by(
             i=hl.struct(idx=entries.i,
-                        twice_maf=hl.cond(entries.mean_i <= 1.0, entries.mean_i, 2.0 - entries.mean_i)),
+                        twice_maf=hl.min(entries.info_i.mean, 2.0 - entries.info_i.mean)),
             j=hl.struct(idx=entries.j,
-                        twice_maf=hl.cond(entries.mean_j <= 1.0, entries.mean_j, 2.0 - entries.mean_j)))
+                        twice_maf=hl.min(entries.info_j.mean, 2.0 - entries.info_j.mean)))
 
         def tie_breaker(l, r):
             return hl.cond(l.twice_maf > r.twice_maf,
@@ -3070,8 +3068,6 @@ def ld_prune(call_expr, r2=0.2, bp_window_size=1000000, memory_per_core=256, kee
         variants_to_remove = variants_to_remove.key_by(variants_to_remove.node.idx)
     else:
         variants_to_remove = maximal_independent_set(entries.i, entries.j, keep=False)
-
-    locally_pruned_table = locally_pruned_table.add_index()
 
     return locally_pruned_table.filter(
         hl.is_defined(variants_to_remove[locally_pruned_table.idx]), keep=False).select()

--- a/python/hail/tests/test_methods.py
+++ b/python/hail/tests/test_methods.py
@@ -1618,8 +1618,8 @@ class Tests(unittest.TestCase):
         window_filter = (hl.abs(entries.locus_i.position - entries.locus_j.position)) <= 1000000
         identical_filter = entries.i != entries.j
 
-        assert (entries.filter(
-            (entries['entry'] >= 0.2) & (contig_filter) & (window_filter) & (identical_filter)).count() == 0)
+        self.assertEqual(entries.filter(
+            (entries['entry'] >= 0.2) & (contig_filter) & (window_filter) & (identical_filter)).count(), 0)
 
     def test_ld_prune_inputs(self):
         ds = hl.split_multi_hts(hl.import_vcf(resource('sample.vcf')))
@@ -1635,13 +1635,13 @@ class Tests(unittest.TestCase):
     def test_ld_prune_identical_variants(self):
         ds = hl.import_vcf(resource('ldprune2.vcf'), min_partitions=2)
         pruned_table = hl.ld_prune(ds.GT)
-        assert (pruned_table.count() == 1)
+        self.assertEqual(pruned_table.count(), 1)
 
     def test_ld_prune_call_expression(self):
         ds = hl.import_vcf(resource("ldprune2.vcf"), min_partitions=2)
         ds = ds.select_entries(foo=ds.GT)
         pruned_table = hl.ld_prune(ds.foo)
-        assert (pruned_table.count() == 1)
+        self.assertEqual(pruned_table.count(), 1)
 
     def test_entries(self):
         n_rows, n_cols = 5, 3

--- a/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -1188,7 +1188,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
         }
     }
 
-    new Table(hc, entriesRDD, rvRowType)
+    new Table(hc, entriesRDD, rvRowType, Some(Array("i", "j")))
   }
 
   // positions is an ordered table with one value field of type int32, which will be grouped by key field(s) if present

--- a/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -1190,9 +1190,9 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
 
     new Table(hc, entriesRDD, rvRowType, Some(Array("i", "j")))
   }
-
-  // positions is an ordered table with one value field of type int32, which will be grouped by key field(s) if present
-  /* returns the entry table of the block matrix, filtered to pairs (i, j) such that i <= j, key[i] == key[j], 
+  
+  /* positions is an ordered table with one value field of type int32, which will be grouped by key field(s) if present.
+  returns the entry table of the block matrix, filtered to pairs (i, j) such that i <= j, key[i] == key[j], 
   and position[j] - position[i] <= radius. If includeDiagonal=false, require i < j rather than i <= j.*/
   def filteredEntriesTable(positions: Table, radius: Int, includeDiagonal: Boolean): Table = {
     val blocksToKeep = UpperIndexBounds.computeCoverByUpperTriangularBlocks(positions, gp, radius, includeDiagonal)

--- a/src/main/scala/is/hail/methods/LocalLDPrune.scala
+++ b/src/main/scala/is/hail/methods/LocalLDPrune.scala
@@ -284,10 +284,8 @@ object LocalLDPrune {
     if (maxQueueSize < 1)
       fatal(s"Maximum queue size must be positive. Found `$maxQueueSize'.")
 
-    val (nVariantsInitial, nPartitionsInitial, nSamples) = (mt.countRows(), mt.nPartitions, mt.numCols)
-
-    info(s"Running LD prune with nSamples=$nSamples, nVariants=$nVariantsInitial, nPartitions=$nPartitionsInitial, and maxQueueSize=$maxQueueSize.")
-
+    val nSamples = mt.numCols
+    
     val fullRowType = mt.rvRowType
 
     val locusIndex = mt.rowType.fieldIdx("locus")

--- a/src/main/scala/is/hail/methods/LocalLDPrune.scala
+++ b/src/main/scala/is/hail/methods/LocalLDPrune.scala
@@ -14,7 +14,7 @@ object BitPackedVectorView {
   val bpvElementSize = TInt64Required.byteSize
 
   def rvRowType(locusType: Type, allelesType: Type): TStruct = TStruct("locus" -> locusType, "alleles" -> allelesType,
-    "bpv" -> TArray(TInt64Required), "nSamples" -> TInt32Required, "mean" -> TFloat64Required, "centered_length_sd_reciprocal" -> TFloat64Required)
+    "bpv" -> TArray(TInt64Required), "nSamples" -> TInt32Required, "mean" -> TFloat64Required, "centered_length_rec" -> TFloat64Required)
 }
 
 class BitPackedVectorView(rvRowType: TStruct) {
@@ -27,7 +27,7 @@ class BitPackedVectorView(rvRowType: TStruct) {
   private var bpvElementOffset: Long = _
   private var nSamplesOffset: Long = _
   private var meanOffset: Long = _
-  private var sdOffset: Long = _
+  private var centeredLengthRecOffset: Long = _
 
   def setRegion(mb: Region, offset: Long) {
     this.m = mb
@@ -36,7 +36,7 @@ class BitPackedVectorView(rvRowType: TStruct) {
     bpvElementOffset = TArray(TInt64Required).elementOffset(bpvOffset, bpvLength, 0)
     nSamplesOffset = rvRowType.loadField(m, offset, rvRowType.fieldIdx("nSamples"))
     meanOffset = rvRowType.loadField(m, offset, rvRowType.fieldIdx("mean"))
-    sdOffset = rvRowType.loadField(m, offset, rvRowType.fieldIdx("centered_length_sd_reciprocal"))
+    centeredLengthRecOffset = rvRowType.loadField(m, offset, rvRowType.fieldIdx("centered_length_rec"))
 
     vView.setRegion(m, offset)
   }
@@ -60,7 +60,7 @@ class BitPackedVectorView(rvRowType: TStruct) {
 
   def getMean: Double = m.loadDouble(meanOffset)
 
-  def getStdDevRecip: Double = m.loadDouble(sdOffset)
+  def getCenteredLengthRec: Double = m.loadDouble(centeredLengthRecOffset)
 }
 
 object LocalLDPrune {
@@ -168,14 +168,13 @@ object LocalLDPrune {
       false
     } else {
       val gtMean = gtSum.toDouble / nPresent
-      val gtMeanAll = (gtSum + nMissing * gtMean) / nSamples
-      val gtMeanSqAll = (gtSumSq + nMissing * gtMean * gtMean) / nSamples
-      // this is 1 / (sqrt(n) * standard deviation)
-      val gtLengthCenteredStdDevRecip = 1d / math.sqrt((gtMeanSqAll - gtMeanAll * gtMeanAll) * nSamples)
+      val gtSumAll = gtSum + nMissing * gtMean
+      val gtSumSqAll = gtSumSq + nMissing * gtMean * gtMean
+      val gtCenteredLengthRec = 1d / math.sqrt(gtSumSqAll - (gtSumAll * gtSumAll / nSamples))
 
       rvb.addInt(nSamples)
       rvb.addDouble(gtMean)
-      rvb.addDouble(gtLengthCenteredStdDevRecip)
+      rvb.addDouble(gtCenteredLengthRec)
       true
     }
   }
@@ -186,8 +185,8 @@ object LocalLDPrune {
     val N = x.getNSamples
     val meanX = x.getMean
     val meanY = y.getMean
-    val stdDevRecX = x.getStdDevRecip
-    val stdDevRecY = y.getStdDevRecip
+    val centeredLengthRecX = x.getCenteredLengthRec
+    val centeredLengthRecY = y.getCenteredLengthRec
 
     var XbarYbarCount = 0
     var XbarCount = 0
@@ -213,7 +212,8 @@ object LocalLDPrune {
       pack += 1
     }
 
-    stdDevRecX * stdDevRecY * ((xySum + XbarCount * meanX + YbarCount * meanY + XbarYbarCount * meanX * meanY) - N * meanX * meanY)
+    centeredLengthRecX * centeredLengthRecY *
+      ((xySum + XbarCount * meanX + YbarCount * meanY + XbarYbarCount * meanX * meanY) - N * meanX * meanY)
   }
 
   def computeR2(x: BitPackedVectorView, y: BitPackedVectorView): Double = {
@@ -327,7 +327,7 @@ object LocalLDPrune {
     val rvdLP = pruneLocal(standardizedRDD, r2Threshold, windowSize, Some(maxQueueSize))
 
     val tableType = TableType(
-      rowType = mt.rowKeyStruct ++ TStruct("mean" -> TFloat64Required, "centered_length_sd_reciprocal" -> TFloat64Required),
+      rowType = mt.rowKeyStruct ++ TStruct("mean" -> TFloat64Required, "centered_length_rec" -> TFloat64Required),
       key = Some(mt.rowKey), globalType = TStruct.empty())
 
     val sitesOnly = rvdLP.mapPartitionsPreservesPartitioning(
@@ -342,7 +342,7 @@ object LocalLDPrune {
           rvb.set(region)
           rvb.start(tableType.rowType)
           rvb.startStruct()
-          rvb.addFields(bpvType, rv, Array("locus", "alleles", "mean", "centered_length_sd_reciprocal")
+          rvb.addFields(bpvType, rv, Array("locus", "alleles", "mean", "centered_length_rec")
             .map(field => bpvType.fieldIdx(field)))
           rvb.endStruct()
           newRV.setOffset(rvb.end())

--- a/src/main/scala/is/hail/methods/UpperIndexBounds.scala
+++ b/src/main/scala/is/hail/methods/UpperIndexBounds.scala
@@ -23,7 +23,7 @@ object UpperIndexBounds {
   // positions is non-decreasing, radius is non-negative
   // for each index i, compute the largest j such that positions[k]-positions[i] <= radius
   // for all k in [i, j)
-  // FIXME: do in Python or add to expression language, then replace UpperIndexBounds with Python sparsify_row_intervals
+  // FIXME: do in Python or add to expression language, then do block filtering with sparsify_row_intervals
   def computeUpperIndexBounds(positions: Array[Int], radius: Int): Array[Int] = {
     val n = positions.length
     val bounds = new Array[Int](n)

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -970,7 +970,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
     copy2(rvd = rvd.sample(withReplacement = false, p, seed))
   }
 
-  def index(name: String = "index"): Table = {
+  def index(name: String): Table = {
     if (fieldNames.contains(name))
       fatal(s"name collision: cannot index table, because column '$name' already exists")
 

--- a/src/test/scala/is/hail/methods/LocalLDPruneSuite.scala
+++ b/src/test/scala/is/hail/methods/LocalLDPruneSuite.scala
@@ -109,7 +109,7 @@ object LocalLDPruneSuite {
   def toBitPackedVector(calls: Array[BoxedCall]): Option[BitPackedVector] = {
     val nSamples = calls.length
     toBitPackedVectorView(convertCallsToGs(calls), nSamples).map { bpvv =>
-      BitPackedVector((0 until bpvv.getNPacks).map(bpvv.getPack).toArray, bpvv.getNSamples, bpvv.getMean, bpvv.getStdDevRecip)
+      BitPackedVector((0 until bpvv.getNPacks).map(bpvv.getPack).toArray, bpvv.getNSamples, bpvv.getMean, bpvv.getCenteredLengthRec)
     }
   }
 


### PR DESCRIPTION
- added `keep_higher_maf` option (`true` by default) to `ld_prune` to prefer to keep higher MAF variants in the global (MIS) stage.
- improved the `ld_prune` flow to reduce duplicated work
- set BlockMatrix.entries to set `i` and `j` as key fields and improved its doc
- corrected references to standard deviation that are actually n times standard deviation, i.e. centered length
- switched `computeCoverByUpperTriangularBlocks` to use the newer`rowIntervalsBlocks` rather than `rectanglesBlocks` directly

I've tested `keep_higher_maf` in notebooks, will add a test of MAF soon and then assign.

@danking rather than:
```
        def tie_breaker(l, r):
            return hl.cond(l.twice_maf > r.twice_maf,
                           -1,
                           hl.cond(l.twice_maf < r.twice_maf,
                                   1,
                                   0))
```
I'd prefer:
```
        def tie_breaker(l, r):
            return hl.signum(r.twice_maf - l.twice_maf)
```
I'm having trouble figuring out why the latter throws the error below. Your `tie_breaker` code looks like it should work with Int32Expressions. Any idea what's going on?
```
FatalError: ClassCastException: java.lang.Long cannot be cast to org.apache.spark.sql.Row

Java stack trace:
java.lang.ClassCastException: java.lang.Long cannot be cast to org.apache.spark.sql.Row
	at is.hail.codegen.generated.C46.apply(Unknown Source)
	at is.hail.codegen.generated.C46.apply(Unknown Source)
	at is.hail.expr.CM$$anonfun$runWithDelayedValues$1.apply(CM.scala:84)
	at is.hail.expr.CM$$anonfun$runWithDelayedValues$1.apply(CM.scala:82)
	at is.hail.expr.Parser$$anonfun$is$hail$expr$Parser$$evalNoTypeCheck$1.apply(Parser.scala:64)
	at is.hail.expr.Parser$$anonfun$parseTypedExpr$1.apply(Parser.scala:102)
	at scala.Function0$class.apply$mcJ$sp(Function0.scala:34)
	at scala.runtime.AbstractFunction0.apply$mcJ$sp(AbstractFunction0.scala:12)
	at is.hail.utils.Graph$$anonfun$2$$anonfun$apply$4.apply(Graph.scala:81)
	at is.hail.utils.Graph$$anonfun$2$$anonfun$apply$4.apply(Graph.scala:79)
	at is.hail.utils.BinaryHeap.isLeftFavoredTie(BinaryHeap.scala:16)
	at is.hail.utils.BinaryHeap.is$hail$utils$BinaryHeap$$bubbleUp(BinaryHeap.scala:161)
	at is.hail.utils.BinaryHeap.insert(BinaryHeap.scala:40)
	at is.hail.utils.Graph$$anonfun$maximalIndependentSet$1.apply(Graph.scala:101)
	at is.hail.utils.Graph$$anonfun$maximalIndependentSet$1.apply(Graph.scala:100)
	at scala.collection.mutable.HashMap$$anonfun$foreach$1.apply(HashMap.scala:99)
	at scala.collection.mutable.HashMap$$anonfun$foreach$1.apply(HashMap.scala:99)
	at scala.collection.mutable.HashTable$class.foreachEntry(HashTable.scala:230)
	at scala.collection.mutable.HashMap.foreachEntry(HashMap.scala:40)
	at scala.collection.mutable.HashMap.foreach(HashMap.scala:99)
	at is.hail.utils.Graph$.maximalIndependentSet(Graph.scala:100)
	at is.hail.utils.Graph$.maximalIndependentSet(Graph.scala:86)
	at is.hail.utils.Graph.maximalIndependentSet(Graph.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
	at py4j.Gateway.invoke(Gateway.java:280)
	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
	at py4j.commands.CallCommand.execute(CallCommand.java:79)
	at py4j.GatewayConnection.run(GatewayConnection.java:214)
	at java.lang.Thread.run(Thread.java:745)
```