### PR TITLE
Use class loader from asm4s instead of System

### DIFF
--- a/src/main/scala/is/hail/asm4s/package.scala
+++ b/src/main/scala/is/hail/asm4s/package.scala
@@ -164,7 +164,7 @@ package object asm4s {
     def newArray() = new TypeInsnNode(ANEWARRAY, iname)
   }
 
-  object HailClassLoader extends ClassLoader {
+  object HailClassLoader extends ClassLoader(this.getClass.getClassLoader) {
     def loadOrDefineClass(name: String, b: Array[Byte]): Class[_] = {
       getClassLoadingLock(name).synchronized {
         try {


### PR DESCRIPTION
This lets me run tests in SBT. SBT sets up a class loader that it
uses to load freshly compiled test clases and execute tests. This
makes the code-compile-test loop less time consuming.

I will check it against a cluster to ensure that it does not
introduce new class loader issues when code is shipped.