### PR TITLE
Port locus functions to ir registry

### DIFF
--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -85,11 +85,12 @@ object IRFunctionRegistry {
     CallFunctions,
     DictFunctions,
     GenotypeFunctions,
+    LocusFunctions,
     MathFunctions,
     SetFunctions,
     StringFunctions,
     UtilFunctions
-  ).map(_.registerAll())
+  ).foreach(_.registerAll())
 }
 
 abstract class RegistryFunctions {

--- a/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -1,24 +1,55 @@
 package is.hail.expr.ir.functions
 
+import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.types._
 import is.hail.expr.types
 import is.hail.asm4s
 import is.hail.expr.ir.EmitMethodBuilder
-import is.hail.variant.Locus
+import is.hail.variant.{Locus, RGBase, RGVariable, ReferenceGenome}
+import is.hail.expr.ir._
+import is.hail.utils.FastSeq
 
 object LocusFunctions extends RegistryFunctions {
 
   def getLocus(mb: EmitMethodBuilder, locus: Code[Long], typeString: String): Code[Locus] = {
     val tlocus = types.coerce[TLocus](tv(typeString).t)
-    asm4s.coerce[Locus](wrapArg(mb, tlocus)(locus))
+    Code.checkcast[Locus](wrapArg(mb, tlocus)(locus).asInstanceOf[Code[AnyRef]])
+  }
+
+  def registerLocusCode(methodName: String): Unit = {
+    registerCode(methodName, tv("T", _.isInstanceOf[TLocus]), TBoolean()) {
+      case (mb: EmitMethodBuilder, locus: Code[Long]) =>
+        val locusObject = getLocus(mb, locus, "T")
+        val tlocus = types.coerce[TLocus](tv("T").t)
+        val rg = tlocus.rg.asInstanceOf[ReferenceGenome]
+
+        val codeRG = mb.getReferenceGenome(rg)
+        unwrapReturn(mb, TBoolean())(locusObject.invoke[RGBase, Boolean](methodName, codeRG))
+    }
   }
 
   def registerAll() {
     registerCode("contig", tv("T", _.isInstanceOf[TLocus]), TString()) {
       case (mb, locus: Code[Long]) =>
-        val locusObject = getLocus(mb, locus, "T")
-        unwrapReturn(mb, TString())(locusObject.invoke[String]("contig"))
+        val region = mb.getArg[Region](1).load()
+        val tlocus = types.coerce[TLocus](tv("T").t)
+        tlocus.contig(region, locus)
     }
+
+    registerCode("position", tv("T", _.isInstanceOf[TLocus]), TInt32()) {
+      case (mb, locus: Code[Long]) =>
+        val region = mb.getArg[Region](1).load()
+        val tlocus = types.coerce[TLocus](tv("T").t)
+        tlocus.position(region, locus)
+    }
+
+    registerLocusCode("isAutosomalOrPseudoAutosomal")
+    registerLocusCode("isAutosomal")
+    registerLocusCode("inYNonPar")
+    registerLocusCode("inXPar")
+    registerLocusCode("isMitochondrial")
+    registerLocusCode("inXNonPar")
+    registerLocusCode("inYPar")
   }
 }

--- a/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -1,0 +1,24 @@
+package is.hail.expr.ir.functions
+
+import is.hail.asm4s._
+import is.hail.expr.types._
+import is.hail.expr.types
+import is.hail.asm4s
+import is.hail.expr.ir.EmitMethodBuilder
+import is.hail.variant.Locus
+
+object LocusFunctions extends RegistryFunctions {
+
+  def getLocus(mb: EmitMethodBuilder, locus: Code[Long], typeString: String): Code[Locus] = {
+    val tlocus = types.coerce[TLocus](tv(typeString).t)
+    asm4s.coerce[Locus](wrapArg(mb, tlocus)(locus))
+  }
+
+  def registerAll() {
+    registerCode("contig", tv("T", _.isInstanceOf[TLocus]), TString()) {
+      case (mb, locus: Code[Long]) =>
+        val locusObject = getLocus(mb, locus, "T")
+        unwrapReturn(mb, TString())(locusObject.invoke[String]("contig"))
+    }
+  }
+}

--- a/src/main/scala/is/hail/expr/types/TLocus.scala
+++ b/src/main/scala/is/hail/expr/types/TLocus.scala
@@ -101,4 +101,8 @@ case class TLocus(rg: RGBase, override val required: Boolean = false) extends Co
   override def clear(): Unit = rg.clear()
 
   override def subst() = rg.subst().locusType
+  
+  def contig(region: Code[Region], off: Code[Long]): Code[Long] = representation.loadField(region, off, 0)
+  
+  def position(region: Code[Region], off: Code[Long]): Code[Int] = region.loadInt(representation.loadField(region, off, 1))
 }

--- a/src/test/scala/is/hail/expr/ir/LocusFunctionsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/LocusFunctionsSuite.scala
@@ -1,0 +1,55 @@
+package is.hail.expr.ir
+
+import is.hail.TestUtils.assertEvalsTo
+import is.hail.utils.FastSeq
+import is.hail.variant.{Locus, ReferenceGenome}
+import org.testng.annotations.Test
+import org.scalatest.testng.TestNGSuite
+
+class LocusFunctionsSuite extends TestNGSuite {
+
+  val grch38: ReferenceGenome = ReferenceGenome.GRCh38
+
+  val locusIR: Apply = {
+    val fn = grch38.wrapFunctionName("Locus")
+    Apply(fn, FastSeq(Str("chr22"), I32(1)))
+  }
+
+  val locus = Locus("chr22", 1, grch38)
+
+  @Test def contig() {
+    assertEvalsTo(invoke("contig", locusIR), locus.contig)
+  }
+
+  @Test def position() {
+    assertEvalsTo(invoke("position", locusIR), locus.position)
+  }
+
+  @Test def isAutosomalOrPseudoAutosomal() {
+    assertEvalsTo(invoke("isAutosomalOrPseudoAutosomal", locusIR), locus.isAutosomalOrPseudoAutosomal(grch38))
+  }
+
+  @Test def isAutosomal() {
+    assertEvalsTo(invoke("isAutosomal", locusIR), locus.isAutosomal(grch38))
+  }
+
+  @Test def inYNonPar() {
+    assertEvalsTo(invoke("inYNonPar", locusIR), locus.inYNonPar(grch38))
+  }
+
+  @Test def inXPar() {
+    assertEvalsTo(invoke("inXPar", locusIR), locus.inXPar(grch38))
+  }
+
+  @Test def isMitochondrial() {
+    assertEvalsTo(invoke("isMitochondrial", locusIR), locus.isMitochondrial(grch38))
+  }
+
+  @Test def inXNonPar() {
+    assertEvalsTo(invoke("inXNonPar", locusIR), locus.inXNonPar(grch38))
+  }
+
+  @Test def inYPar() {
+    assertEvalsTo(invoke("inYPar", locusIR), locus.inYPar(grch38))
+  }
+}


### PR DESCRIPTION
move these to IR function registry: 

isAutosomalOrPseudoAutosomal(locus<RGVariable>):bool
isAutosomal(locus<RGVariable>):bool
inYNonPar(locus<RGVariable>):bool
inXPar(locus<RGVariable>):bool
isMitochondrial(locus<RGVariable>):bool
inXNonPar(locus<RGVariable>):bool
contig(locus<RGVariable>):str
position(locus<RGVariable>):int32
inYPar(locus<RGVariable>):bool

I have a couple more to do that aren't locus ones, which I'll PR separately.