### PR TITLE
join bugfix

### DIFF
--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -1409,7 +1409,6 @@ class Table(ExprContainer):
                                   .key_cols_by(*uids)
                                   .cols()
                                   .select(index_uid)
-                                  .distinct()
                                   .join(self, 'inner')
                                   .key_by(index_uid)
                                   .drop(*uids))

--- a/python/hail/tests/test_api.py
+++ b/python/hail/tests/test_api.py
@@ -416,6 +416,12 @@ class TableTests(unittest.TestCase):
         m3 = m.annotate_rows(qual2=m.index_rows(m.row_key).qual)
         self.assertTrue(m3.filter_rows(m3.qual != m3.qual2).count_rows() == 0)
 
+        kt5 = hl.utils.range_table(1).annotate(key='C1589').key_by('key')
+        m4 = m.annotate_cols(foo=m.s[:5])
+        m4 = m4.annotate_cols(idx=kt5[m4.foo].idx)
+        self.assertTrue(m4.filter_cols(hl.is_defined(m4.idx)).count_cols() ==
+                        m.filter_cols(m.s[:5]=='C1589').count_cols())
+
         kt = hl.utils.range_table(1)
         kt = kt.annotate_globals(foo=5)
         self.assertEqual(kt.foo.value, 5)

--- a/python/hail/tests/test_api.py
+++ b/python/hail/tests/test_api.py
@@ -419,8 +419,9 @@ class TableTests(unittest.TestCase):
         kt5 = hl.utils.range_table(1).annotate(key='C1589').key_by('key')
         m4 = m.annotate_cols(foo=m.s[:5])
         m4 = m4.annotate_cols(idx=kt5[m4.foo].idx)
-        self.assertTrue(m4.filter_cols(hl.is_defined(m4.idx)).count_cols() ==
-                        m.filter_cols(m.s[:5]=='C1589').count_cols())
+        n_C1589 = m.filter_cols(m.s[:5] == 'C1589').count_cols()
+        self.assertTrue(n_C1589 > 1)
+        self.assertEqual(m4.filter_cols(hl.is_defined(m4.idx)).count_cols(), n_C1589)
 
         kt = hl.utils.range_table(1)
         kt = kt.annotate_globals(foo=5)


### PR DESCRIPTION
Indexing a table by a non-unique matrixtable field was broken (only joined with one row per distinct value). For example, in the test I added, `m4.filter_cols(hl.is_defined(m4.idx)).count_cols()` previously returned 1, now returns 9.