### PR TITLE
Remove Unnecessary KeyBy's

### DIFF
--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -1291,7 +1291,7 @@ class Table(ExprContainer):
                 analyze('Table.index', e, src._row_indices)
 
             is_key = src.key is not None and len(exprs) == len(src.key) and all(
-                expr is key_field for expr, key_field in zip(exprs, self.key.values()))
+                expr is key_field for expr, key_field in zip(exprs, src.key.values()))
             is_interval = (len(self.key) == 1
                            and isinstance(self.key[0].dtype, hl.tinterval)
                            and exprs[0].dtype == self.key[0].dtype.point_type)


### PR DESCRIPTION
The `self` here is the left-hand side of a join. This expression is checking if the right-hand side of the join needs to be re-keyed. Obviously the left-hand side's keys will never be reference equal to the right-hand side's keys.