### PR TITLE
Make Caitlin's BGEN PRS Pipeline Fast

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,6 +159,7 @@ dependencies {
     testCompile 'org.scalatest:scalatest_' + scalaMajorVersion + ':2.2.4'
 
     compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
+    compile group: 'commons-codec', name: 'commons-codec', version: '1.11'
 }
 
 task(checkSettings) << {
@@ -291,6 +292,7 @@ shadowJar {
         include(dependency('net.sourceforge.jdistlib:jdistlib:.*'))
 
         include(dependency('org.apache.commons.commons-math3:3.6.1'))
+        include(dependency('commons-codec:commons-codec:.*'))
     }
 }
 
@@ -350,6 +352,7 @@ task shadowTestJar(type: ShadowJar) {
         include(dependency('net.java.dev.jna:jna:.*'))
         include(dependency('net.sourceforge.jdistlib:jdistlib:.*'))
         include(dependency('org.apache.commons.commons-math3:3.6.1'))
+        include(dependency('commons-codec:commons-codec:.*'))
     }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,7 @@ lazy val root = (project in file(".")).
         , "net.sourceforge.jdistlib" % "jdistlib" % "0.4.5"
         , "org.apache.commons" % "commons-math3" % "3.6.1"
         , "org.testng" % "testng" % "6.8.21" % Test
+        , "commons-codec" % "commons-codec" % "1.11"
     ),
     assemblyShadeRules in assembly := Seq(
       ShadeRule

--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -788,7 +788,9 @@ def grep(regex, path, max_count=100):
            contig_recoding=nullable(dictof(str, str)),
            tolerance=numeric,
            skip_invalid_loci=bool,
-           _variants_per_file=dictof(str, sequenceof(int)))
+           _variants_per_file=dictof(str, sequenceof(int)),
+           _include_lid=bool,
+           _include_rsid=bool)
 def import_bgen(path,
                 entry_fields,
                 sample_file=None,
@@ -797,7 +799,9 @@ def import_bgen(path,
                 contig_recoding=None,
                 tolerance=0.2,
                 skip_invalid_loci=False,
-                _variants_per_file={}) -> MatrixTable:
+                _variants_per_file={},
+                _include_lid=True,
+                _include_rsid=True) -> MatrixTable:
     """Import BGEN file(s) as a :class:`.MatrixTable`.
 
     Examples
@@ -915,10 +919,9 @@ def import_bgen(path,
         contig_recoding = tdict(tstr, tstr)._convert_to_j(contig_recoding)
 
     jmt = Env.hc()._jhc.importBgens(jindexed_seq_args(path), joption(sample_file),
-                                    'GT' in entry_set, 'GP' in entry_set, 'dosage' in entry_set,
-                                    joption(min_partitions), joption(rg), joption(contig_recoding),
-                                    tolerance, skip_invalid_loci,
-                                    tdict(tstr, tarray(tint32))._convert_to_j(_variants_per_file))
+                                    'GT' in entry_set, 'GP' in entry_set, 'dosage' in entry_set, _include_lid, _include_rsid,
+                                    joption(min_partitions), joption(rg), joption(contig_recoding), tolerance,
+                                    skip_invalid_loci, tdict(tstr, tarray(tint32))._convert_to_j(_variants_per_file))
     return MatrixTable(jmt)
 
 

--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -782,15 +782,14 @@ def grep(regex, path, max_count=100):
 
 @typecheck(path=oneof(str, sequenceof(str)),
            sample_file=nullable(str),
-           entry_fields=sequenceof(str),
+           entry_fields=enumeration('GT', 'GP', 'dosage'),
            min_partitions=nullable(int),
            reference_genome=nullable(reference_genome_type),
            contig_recoding=nullable(dictof(str, str)),
            tolerance=numeric,
            skip_invalid_loci=bool,
-           _variants_per_file=dictof(str, sequenceof(int)),
-           _include_lid=bool,
-           _include_rsid=bool)
+           row_fields=enumeration('varid', 'rsid'),
+           _variants_per_file=dictof(str, sequenceof(int)))
 def import_bgen(path,
                 entry_fields,
                 sample_file=None,
@@ -799,9 +798,8 @@ def import_bgen(path,
                 contig_recoding=None,
                 tolerance=0.2,
                 skip_invalid_loci=False,
-                _variants_per_file={},
-                _include_lid=True,
-                _include_rsid=True) -> MatrixTable:
+                row_fields=['varid', 'rsid'],
+                _variants_per_file={}) -> MatrixTable:
     """Import BGEN file(s) as a :class:`.MatrixTable`.
 
     Examples
@@ -845,6 +843,11 @@ def import_bgen(path,
       exists; else IDs are assigned from `_0`, `_1`, to `_N`.
 
     **Row Fields**
+
+    Between two and four row fields are created. The `locus` and `alleles` are
+    always included. `row_fields` determines if `varid` and `rsid` are alos
+    included. For best performance, only include fields necessary for your
+    analysis.
 
     - `locus` (:class:`.tlocus` or :class:`.tstruct`) -- Row key. The chromosome
       and position. If `reference_genome` is defined, the type will be
@@ -898,6 +901,9 @@ def import_bgen(path,
         in the reference genome given by `reference_genome`.
     skip_invalid_loci : :obj:`bool`
         If ``True``, skip loci that are not consistent with `reference_genome`.
+    row_fields : :obj:`list` of :obj:`str`
+        List of non-key row fields to create.
+        Options: ``'varid'``, ``'rsid'``
 
     Returns
     -------
@@ -908,18 +914,14 @@ def import_bgen(path,
     rg = reference_genome._jrep if reference_genome else None
 
     entry_set = set(entry_fields)
-    bad_entry_fields = list(entry_set - {'GT', 'GP', 'dosage'})
-
-    if bad_entry_fields:
-        word = plural('value', len(bad_entry_fields))
-        raise FatalError("import_bgen: found invalid {} {} in entry_fields."
-                         "\n    Options: 'GT', 'GP', 'dosage'.".format(word, bad_entry_fields))
+    row_set = set(row_fields)
 
     if contig_recoding:
         contig_recoding = tdict(tstr, tstr)._convert_to_j(contig_recoding)
 
     jmt = Env.hc()._jhc.importBgens(jindexed_seq_args(path), joption(sample_file),
-                                    'GT' in entry_set, 'GP' in entry_set, 'dosage' in entry_set, _include_lid, _include_rsid,
+                                    'GT' in entry_set, 'GP' in entry_set, 'dosage' in entry_set,
+                                    'varid' in row_set, 'rsid' in row_set,
                                     joption(min_partitions), joption(rg), joption(contig_recoding), tolerance,
                                     skip_invalid_loci, tdict(tstr, tarray(tint32))._convert_to_j(_variants_per_file))
     return MatrixTable(jmt)

--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -786,7 +786,6 @@ def grep(regex, path, max_count=100):
            min_partitions=nullable(int),
            reference_genome=nullable(reference_genome_type),
            contig_recoding=nullable(dictof(str, str)),
-           tolerance=numeric,
            skip_invalid_loci=bool,
            row_fields=sequenceof(enumeration('varid', 'rsid')),
            _variants_per_file=dictof(str, sequenceof(int)))
@@ -796,7 +795,6 @@ def import_bgen(path,
                 min_partitions=None,
                 reference_genome='default',
                 contig_recoding=None,
-                tolerance=0.2,
                 skip_invalid_loci=False,
                 row_fields=['varid', 'rsid'],
                 _variants_per_file={}) -> MatrixTable:
@@ -922,7 +920,7 @@ def import_bgen(path,
     jmt = Env.hc()._jhc.importBgens(jindexed_seq_args(path), joption(sample_file),
                                     'GT' in entry_set, 'GP' in entry_set, 'dosage' in entry_set,
                                     'varid' in row_set, 'rsid' in row_set,
-                                    joption(min_partitions), joption(rg), joption(contig_recoding), tolerance,
+                                    joption(min_partitions), joption(rg), joption(contig_recoding),
                                     skip_invalid_loci, tdict(tstr, tarray(tint32))._convert_to_j(_variants_per_file))
     return MatrixTable(jmt)
 

--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -786,14 +786,18 @@ def grep(regex, path, max_count=100):
            min_partitions=nullable(int),
            reference_genome=nullable(reference_genome_type),
            contig_recoding=nullable(dictof(str, str)),
-           skip_invalid_loci=bool)
+           tolerance=numeric,
+           skip_invalid_loci=bool,
+           _variants_per_file=dictof(str, sequenceof(int)))
 def import_bgen(path,
                 entry_fields,
                 sample_file=None,
                 min_partitions=None,
                 reference_genome='default',
                 contig_recoding=None,
-                skip_invalid_loci=False) -> MatrixTable:
+                tolerance=0.2,
+                skip_invalid_loci=False,
+                _variants_per_file={}) -> MatrixTable:
     """Import BGEN file(s) as a :class:`.MatrixTable`.
 
     Examples
@@ -913,7 +917,8 @@ def import_bgen(path,
     jmt = Env.hc()._jhc.importBgens(jindexed_seq_args(path), joption(sample_file),
                                     'GT' in entry_set, 'GP' in entry_set, 'dosage' in entry_set,
                                     joption(min_partitions), joption(rg), joption(contig_recoding),
-                                    skip_invalid_loci)
+                                    tolerance, skip_invalid_loci,
+                                    tdict(tstr, tarray(tint32))._convert_to_j(_variants_per_file))
     return MatrixTable(jmt)
 
 

--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -782,13 +782,13 @@ def grep(regex, path, max_count=100):
 
 @typecheck(path=oneof(str, sequenceof(str)),
            sample_file=nullable(str),
-           entry_fields=enumeration('GT', 'GP', 'dosage'),
+           entry_fields=sequenceof(enumeration('GT', 'GP', 'dosage')),
            min_partitions=nullable(int),
            reference_genome=nullable(reference_genome_type),
            contig_recoding=nullable(dictof(str, str)),
            tolerance=numeric,
            skip_invalid_loci=bool,
-           row_fields=enumeration('varid', 'rsid'),
+           row_fields=sequenceof(enumeration('varid', 'rsid')),
            _variants_per_file=dictof(str, sequenceof(int)))
 def import_bgen(path,
                 entry_fields,

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -315,7 +315,10 @@ class HailContext private(val sc: SparkContext,
     nPartitions: Option[Int] = None,
     rg: Option[ReferenceGenome] = Some(ReferenceGenome.defaultReference),
     contigRecoding: Option[Map[String, String]] = None,
-    skipInvalidLoci: Boolean = false): MatrixTable = {
+    tolerance: Double = 0.2,
+    skipInvalidLoci: Boolean = false,
+    includedVariantsPerFile: Map[String, Seq[Int]] = Map.empty[String, Seq[Int]]
+  ): MatrixTable = {
 
     val inputs = hadoopConf.globAll(files).flatMap { file =>
       if (!file.endsWith(".bgen"))
@@ -335,7 +338,8 @@ class HailContext private(val sc: SparkContext,
     rg.foreach(ref => contigRecoding.foreach(ref.validateContigRemap))
 
     LoadBgen.load(this, inputs, sampleFile, includeGT: Boolean, includeGP: Boolean, includeDosage: Boolean,
-      nPartitions, rg, contigRecoding.getOrElse(Map.empty[String, String]), skipInvalidLoci)
+      nPartitions, rg, contigRecoding.getOrElse(Map.empty[String, String]), tolerance, skipInvalidLoci,
+      includedVariantsPerFile)
   }
 
   def importGen(file: String,

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -299,12 +299,14 @@ class HailContext private(val sc: SparkContext,
     includeGT: Boolean,
     includeGP: Boolean,
     includeDosage: Boolean,
+    includeLid: Boolean,
+    includeRsid: Boolean,
     nPartitions: Option[Int] = None,
     rg: Option[ReferenceGenome] = Some(ReferenceGenome.defaultReference),
     contigRecoding: Option[Map[String, String]] = None,
     skipInvalidLoci: Boolean = false): MatrixTable = {
     importBgens(List(file), sampleFile, includeGT, includeGP, includeDosage, nPartitions, rg,
-      contigRecoding, skipInvalidLoci)
+      contigRecoding, tolerance, skipInvalidLoci)
   }
 
   def importBgens(files: Seq[String],
@@ -312,6 +314,8 @@ class HailContext private(val sc: SparkContext,
     includeGT: Boolean = true,
     includeGP: Boolean = true,
     includeDosage: Boolean = false,
+    includeLid: Boolean = true,
+    includeRsid: Boolean = true,
     nPartitions: Option[Int] = None,
     rg: Option[ReferenceGenome] = Some(ReferenceGenome.defaultReference),
     contigRecoding: Option[Map[String, String]] = None,
@@ -337,7 +341,7 @@ class HailContext private(val sc: SparkContext,
 
     rg.foreach(ref => contigRecoding.foreach(ref.validateContigRemap))
 
-    LoadBgen.load(this, inputs, sampleFile, includeGT: Boolean, includeGP: Boolean, includeDosage: Boolean,
+    LoadBgen.load(this, inputs, sampleFile, includeGT, includeGP, includeDosage, includeLid, includeRsid,
       nPartitions, rg, contigRecoding.getOrElse(Map.empty[String, String]), tolerance, skipInvalidLoci,
       includedVariantsPerFile)
   }

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -306,7 +306,7 @@ class HailContext private(val sc: SparkContext,
     contigRecoding: Option[Map[String, String]] = None,
     skipInvalidLoci: Boolean = false): MatrixTable = {
     importBgens(List(file), sampleFile, includeGT, includeGP, includeDosage, nPartitions, rg,
-      contigRecoding, tolerance, skipInvalidLoci)
+      contigRecoding, skipInvalidLoci)
   }
 
   def importBgens(files: Seq[String],
@@ -319,7 +319,6 @@ class HailContext private(val sc: SparkContext,
     nPartitions: Option[Int] = None,
     rg: Option[ReferenceGenome] = Some(ReferenceGenome.defaultReference),
     contigRecoding: Option[Map[String, String]] = None,
-    tolerance: Double = 0.2,
     skipInvalidLoci: Boolean = false,
     includedVariantsPerFile: Map[String, Seq[Int]] = Map.empty[String, Seq[Int]]
   ): MatrixTable = {
@@ -342,7 +341,7 @@ class HailContext private(val sc: SparkContext,
     rg.foreach(ref => contigRecoding.foreach(ref.validateContigRemap))
 
     LoadBgen.load(this, inputs, sampleFile, includeGT, includeGP, includeDosage, includeLid, includeRsid,
-      nPartitions, rg, contigRecoding.getOrElse(Map.empty[String, String]), tolerance, skipInvalidLoci,
+      nPartitions, rg, contigRecoding.getOrElse(Map.empty[String, String]), skipInvalidLoci,
       includedVariantsPerFile)
   }
 

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -305,8 +305,8 @@ class HailContext private(val sc: SparkContext,
     rg: Option[ReferenceGenome] = Some(ReferenceGenome.defaultReference),
     contigRecoding: Option[Map[String, String]] = None,
     skipInvalidLoci: Boolean = false): MatrixTable = {
-    importBgens(List(file), sampleFile, includeGT, includeGP, includeDosage, nPartitions, rg,
-      contigRecoding, skipInvalidLoci)
+    importBgens(List(file), sampleFile, includeGT, includeGP, includeDosage, includeLid, includeRsid,
+      nPartitions, rg, contigRecoding, skipInvalidLoci)
   }
 
   def importBgens(files: Seq[String],

--- a/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
+++ b/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
@@ -86,6 +86,11 @@ class RegionValueBuilder(var region: Region) {
       indexstk(0) = indexstk(0) + 1
   }
 
+  def unsafeAdvance(i: Int) {
+    if (indexstk.nonEmpty)
+      indexstk(0) = indexstk(0) + i
+  }
+
   def startBaseStruct(init: Boolean = true) {
     val t = currentType().asInstanceOf[TBaseStruct]
     if (typestk.isEmpty)

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -2065,6 +2065,7 @@ case class TableJoin(left: TableIR, right: TableIR, joinType: String) extends Ta
         rv
       }
     }
+    println(s"TableJoin: ${leftTV.rvd} ${rightTV.rvd} ${leftTV.rvd.crdd.rdd.toDebugString} ${rightTV.rvd.crdd.rdd.toDebugString}")
     val leftORVD = leftTV.rvd match {
       case ordered: OrderedRVD => ordered
       case unordered =>

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -2065,7 +2065,6 @@ case class TableJoin(left: TableIR, right: TableIR, joinType: String) extends Ta
         rv
       }
     }
-    println(s"TableJoin: ${leftTV.rvd} ${rightTV.rvd} ${leftTV.rvd.crdd.rdd.toDebugString} ${rightTV.rvd.crdd.rdd.toDebugString}")
     val leftORVD = leftTV.rvd match {
       case ordered: OrderedRVD => ordered
       case unordered =>

--- a/src/main/scala/is/hail/io/AbstractBinaryReader.scala
+++ b/src/main/scala/is/hail/io/AbstractBinaryReader.scala
@@ -54,5 +54,12 @@ abstract class AbstractBinaryReader {
     readString(length)
   }
 
+  def readLengthAndSkipString(lengthBytes: Int): String = {
+    require(lengthBytes == 2 || lengthBytes == 4)
+
+    val length = if (lengthBytes == 2) readShort() else readInt()
+    skipBytes(length)
+  }
+
   def skipBytes(lengthBytes: Long): Long
 }

--- a/src/main/scala/is/hail/io/AbstractBinaryReader.scala
+++ b/src/main/scala/is/hail/io/AbstractBinaryReader.scala
@@ -54,7 +54,7 @@ abstract class AbstractBinaryReader {
     readString(length)
   }
 
-  def readLengthAndSkipString(lengthBytes: Int): String = {
+  def readLengthAndSkipString(lengthBytes: Int): Unit = {
     require(lengthBytes == 2 || lengthBytes == 4)
 
     val length = if (lengthBytes == 2) readShort() else readInt()

--- a/src/main/scala/is/hail/io/bgen/BgenBlockReader.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenBlockReader.scala
@@ -72,7 +72,6 @@ class BgenBlockReaderV12(
       assert(nAlleles >= 2, s"Number of alleles must be greater than or equal to 2. Found $nAlleles alleles for variant '$lid' $i")
       val alleles = new Array[String](nAlleles)
 
-      assert(lid.length < 1000, s"very long lid ${split.fileSplit.getStart} $start ${bfis.getPosition} $i ${lid.take(10)}")
       val ref = bfis.readLengthAndString(4)
       alleles(0) = ref
 

--- a/src/main/scala/is/hail/io/bgen/BgenBlockReader.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenBlockReader.scala
@@ -82,7 +82,7 @@ class BgenBlockReaderV12(
 
       val nAlleles = bfis.readShort()
       if (!(nAlleles >= 2))
-        assert(false, s"Number of alleles must be greater than or equal to 2. Found $nAlleles alleles for variant $chr:$pos ($lid, $rsid) $i")
+        fatal(s"Number of alleles must be greater than or equal to 2. Found $nAlleles alleles for variant $chr:$pos ($lid, $rsid) $i")
       val alleles = new Array[String](nAlleles)
 
       val ref = bfis.readLengthAndString(4)

--- a/src/main/scala/is/hail/io/bgen/BgenBlockReader.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenBlockReader.scala
@@ -16,7 +16,6 @@ abstract class BgenBlockReader[T <: BgenRecord](job: Configuration, split: FileS
   val includeGT = job.get("includeGT").toBoolean
   val includeGP = job.get("includeGP").toBoolean
   val includeDosage = job.get("includeDosage").toBoolean
-  val nVariants = job.get("nVariants").toInt
   val includeLid = job.get("includeLid").toBoolean
   val includeRsid = job.get("includeRsid").toBoolean
 

--- a/src/main/scala/is/hail/io/bgen/BgenBlockReader.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenBlockReader.scala
@@ -69,7 +69,8 @@ class BgenBlockReaderV12(
       val position = bfis.readInt()
 
       val nAlleles = bfis.readShort()
-      assert(nAlleles >= 2, s"Number of alleles must be greater than or equal to 2. Found $nAlleles alleles for variant '$lid' $i")
+      if (!(nAlleles >= 2))
+        assert(false, s"Number of alleles must be greater than or equal to 2. Found $nAlleles alleles for variant $chr:$pos ($lid, $rsid) $i")
       val alleles = new Array[String](nAlleles)
 
       val ref = bfis.readLengthAndString(4)

--- a/src/main/scala/is/hail/io/bgen/BgenBlockReader.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenBlockReader.scala
@@ -105,19 +105,12 @@ class BgenBlockReaderV12(
 
       val dataSize = bfis.readInt()
 
-      val (uncompressedSize// , bytesInput
-      ) =
-        if (bState.compressed)
-          (bfis.readInt()// , bfis.readBytes(dataSize - 4)
-          )
-        else
-          (dataSize// , bfis.readBytes(dataSize)
-          )
+      val uncompressedSize =
+        if (bState.compressed) bfis.readInt() else dataSize
 
       value.setKey(variantInfo)
       if (includeLid || includeRsid)
         value.setAnnotation(Annotation(rsid, lid))
-      // value.setSerializedValue(bytesInput)
       value.dataSize = if (bState.compressed) dataSize - 4 else dataSize
       value.setExpectedDataSize(uncompressedSize)
       value.setExpectedNumAlleles(nAlleles)

--- a/src/main/scala/is/hail/io/bgen/BgenInputFormat.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenInputFormat.scala
@@ -1,6 +1,7 @@
 package is.hail.io.bgen
 
-import is.hail.io.IndexedBinaryInputFormat
+import is.hail.utils._
+import is.hail.io._
 import org.apache.hadoop.io.LongWritable
 import org.apache.hadoop.mapred._
 
@@ -8,6 +9,76 @@ class BgenInputFormatV12 extends IndexedBinaryInputFormat[BgenRecordV12] {
   override def getRecordReader(split: InputSplit, job: JobConf, reporter: Reporter): RecordReader[LongWritable,
     BgenRecordV12] = {
     reporter.setStatus(split.toString)
-    new BgenBlockReaderV12(job, split.asInstanceOf[FileSplit])
+    new BgenBlockReaderV12(job, split.asInstanceOf[BgenV12InputSplit])
   }
+
+  private[this] val indices = new java.util.concurrent.ConcurrentHashMap[String, IndexBTree2]()
+  private[this] def indexFor(indexPath: String, job: JobConf, nVariants: Int): IndexBTree2 =
+    indices.computeIfAbsent(
+      indexPath,
+      { (path: String) => new IndexBTree2(path, job, nVariants) })
+
+  override def getSplits(job: JobConf, numSplits: Int): Array[InputSplit] = {
+    val nVariants = job.get("nVariants").toInt
+    val splits = super.getSplits(job, numSplits)
+    splits.flatMap { x =>
+      val split = x.asInstanceOf[FileSplit]
+      val path = split.getPath
+      val indexPath = path + ".idx"
+      val index = indexFor(indexPath, job, nVariants)
+      val s = job.get("__"+path.toString.replaceAllLiterally("file:",""))
+      if (s != null) {
+        val keptPositions = LoadBgen.decodeInts(s)
+          .sorted
+          .map(index.positionOfVariant _)
+          .filter(x =>
+          split.getStart <= x && x < split.getStart + split.getLength)
+
+        if (keptPositions.isEmpty)
+          None
+        else
+          Some(new BgenV12InputSplit(split, keptPositions))
+      }
+      else {
+        Some(new BgenV12InputSplit(split, null))
+      }
+    }
+  }
+}
+
+class BgenV12InputSplit(
+  var fileSplit: FileSplit,
+  var keptPositions: Array[Long]
+) extends InputSplit {
+  def this() = this(null, null)
+  def getLength(): Long = fileSplit.getLength()
+  def getLocations(): Array[String] = fileSplit.getLocations()
+  def readFields(in: java.io.DataInput): Unit = {
+    fileSplit = new FileSplit(new org.apache.hadoop.mapreduce.lib.input.FileSplit())
+    fileSplit.readFields(in)
+    val len = in.readInt()
+    if (len != -1) {
+      var i = 0
+      keptPositions = new Array[Long](len)
+      while (i < len) {
+        keptPositions(i) = in.readLong()
+        i += 1
+      }
+    }
+  }
+  def write(out: java.io.DataOutput): Unit = {
+    fileSplit.write(out)
+    if (keptPositions == null)
+      out.writeInt(-1)
+    else {
+      out.writeInt(keptPositions.length)
+      var i = 0
+      while (i < keptPositions.length) {
+        out.writeLong(keptPositions(i))
+        i += 1
+      }
+    }
+  }
+  override def toString(): String =
+    s"BgenV12InputSplit($fileSplit, $keptPositions)"
 }

--- a/src/main/scala/is/hail/io/bgen/BgenRecord.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenRecord.scala
@@ -1,9 +1,12 @@
 package is.hail.io.bgen
 
+import com.google.common.io.LittleEndianDataInputStream
 import is.hail.annotations._
-import is.hail.io.{ByteArrayReader, KeySerializedValueRecord}
+import is.hail.expr.types.TStruct
+import is.hail.io.{ ByteArrayReader, HadoopFSDataBinaryReader, KeySerializedValueRecord }
 import is.hail.utils._
 import is.hail.variant.{Call2, Genotype}
+import java.util.zip.{ Inflater, InflaterInputStream }
 
 abstract class BgenRecord extends KeySerializedValueRecord[(String, Int, Array[String])] {
   var ann: Annotation = _
@@ -17,10 +20,41 @@ abstract class BgenRecord extends KeySerializedValueRecord[(String, Int, Array[S
   override def getValue(rvb: RegionValueBuilder): Unit
 }
 
-class BgenRecordV12(compressed: Boolean, nSamples: Int,
-  includeGT: Boolean, includeGP: Boolean, includeDosage: Boolean) extends BgenRecord {
+class BGen12ProbabilityArray(a: Array[Byte], nSamples: Int, nGenotypes: Int, nBitsPerProb: Int) {
+
+  def apply(s: Int, gi: Int): UInt = {
+    assert(s >= 0 && s < nSamples)
+    assert(gi >= 0 && gi < nGenotypes - 1)
+
+    val firstBit = (s * (nGenotypes - 1) + gi) * nBitsPerProb
+
+    var byteIndex = nSamples + 10 + (firstBit >> 3)
+    var r = (a(byteIndex) & 0xff) >>> (firstBit & 7)
+    var rBits = 8 - (firstBit & 7)
+    byteIndex += 1
+
+    while (rBits < nBitsPerProb) {
+      r |= ((a(byteIndex) & 0xff) << rBits)
+      byteIndex += 1
+      rBits += 8
+    }
+
+    // clear upper bits that might have garbage from last byte or
+    UInt.uintFromRep(r & ((1L << nBitsPerProb) - 1).toInt)
+  }
+}
+
+class BgenRecordV12(
+  compressed: Boolean,
+  nSamples: Int,
+  includeGT: Boolean,
+  includeGP: Boolean,
+  includeDosage: Boolean,
+  bfis: HadoopFSDataBinaryReader
+) extends BgenRecord {
   var expectedDataSize: Int = _
   var expectedNumAlleles: Int = _
+  var dataSize: Int = _
 
   def setExpectedDataSize(size: Int) {
     this.expectedDataSize = size
@@ -31,109 +65,149 @@ class BgenRecordV12(compressed: Boolean, nSamples: Int,
   }
 
   override def getValue(rvb: RegionValueBuilder) {
-    require(input != null, "called getValue before serialized value was set")
+    // require(input != null// , "called getValue before serialized value was set"
+    // )
 
-    val a = if (compressed) decompress(input, expectedDataSize) else input
-    val reader = new ByteArrayReader(a)
+    // val a = if (compressed) decompress(input, expectedDataSize) else input
+    // val reader = new ByteArrayReader(a)
 
-    val nRow = reader.readInt()
-    assert(nRow == nSamples, "row nSamples is not equal to header nSamples")
+    val start = bfis.fis.getPos
+    val expectedEnd = start + dataSize
 
-    val nAlleles = reader.readShort()
-    assert(nAlleles == expectedNumAlleles, s"Value for `nAlleles' in genotype probability data storage is not equal to value in variant identifying data. Expected $expectedNumAlleles but found $nAlleles.")
-    if (nAlleles != 2)
-      fatal(s"Only biallelic variants supported, found variant with $nAlleles")
+    if (rvb == null) {
+      bfis.fis.skipBytes(dataSize)
+    } else {
+      val uncompressedInput = if (compressed)
+        new InflaterInputStream(bfis.fis, new Inflater(), dataSize)
+      else
+        bfis.fis
 
-    val minPloidy = reader.read()
-    val maxPloidy = reader.read()
+      val reader =
+        new LittleEndianDataInputStream(uncompressedInput)
 
-    if (minPloidy != 2 || maxPloidy != 2)
-      fatal(s"Hail only supports diploid genotypes. Found min ploidy equals `$minPloidy' and max ploidy equals `$maxPloidy'.")
+      // val nRow = reader.readInt()
+      // assert(nRow == nSamples// , s"$nRow $nSamples"
+      // )
+      reader.skipBytes(4)
 
-    var i = 0
-    while (i < nSamples) {
-      val ploidy = reader.read()
-      assert((ploidy & 0x3f) == 2, s"Ploidy value must equal to 2. Found $ploidy.")
-      i += 1
-    }
-    assert(i == nSamples, s"Number of ploidy values `$i' does not equal the number of samples `$nSamples'.")
+      val nAlleles = reader.readShort()
+      // assert(nAlleles == expectedNumAlleles// , s"Value for `nAlleles' in genotype probability data storage is not equal to value in variant identifying data. Expected $expectedNumAlleles but found $nAlleles."
+      // )
+      if (nAlleles != 2)
+        fatal(s"Only biallelic variants supported, found variant with $nAlleles")
 
-    val phase = reader.read()
-    assert(phase == 0 || phase == 1, s"Value for phase must be 0 or 1. Found $phase.")
-    val isPhased = phase == 1
+      val minPloidy = reader.read()
+      val maxPloidy = reader.read()
 
-    if (isPhased)
-      fatal("Hail does not support phased genotypes.")
+      if (minPloidy != 2 || maxPloidy != 2)
+        fatal(s"Hail only supports diploid genotypes. Found min ploidy equals `$minPloidy' and max ploidy equals `$maxPloidy'.")
 
-    val nBitsPerProb = reader.read()
-    assert(nBitsPerProb >= 1 && nBitsPerProb <= 32, s"Value for nBits must be between 1 and 32 inclusive. Found $nBitsPerProb.")
-    if (nBitsPerProb != 8)
-      fatal(s"Only 8-bit probabilities supported, found $nBitsPerProb")
+      val sampleMissing = new Array[Byte](nSamples)
+      reader.readFully(sampleMissing)
 
-    val nGenotypes = triangle(nAlleles)
+      // var i = 0
+      // while (i < nSamples) {
+      //   val ploidyAndMissingness = reader.read()
+      //   // assert((ploidyAndMissingness & 0x3f) == 2// , s"Ploidy value must equal to 2. Found $ploidy."
+      //   // )
+      //   sampleMissing(i) = (ploidyAndMissingness & 0x80) == 1
+      //   i += 1
+      // }
+      // assert(i == nSamples// , s"Number of ploidy values `$i' does not equal the number of samples `$nSamples'."
+      // )
 
-    val nExpectedBytesProbs = (nSamples * (nGenotypes - 1) * nBitsPerProb + 7) / 8
-    assert(reader.length == nExpectedBytesProbs + nSamples + 10, s"Number of uncompressed bytes `${ reader.length }' does not match the expected size `$nExpectedBytesProbs'.")
+      val phase = reader.read()
+      assert(phase == 0 || phase == 1// , s"Value for phase must be 0 or 1. Found $phase."
+      )
+      val isPhased = phase == 1
 
-    rvb.startArray(nSamples) // gs
-    val c0 = Call2.fromUnphasedDiploidGtIndex(0)
-    val c1 = Call2.fromUnphasedDiploidGtIndex(1)
-    val c2 = Call2.fromUnphasedDiploidGtIndex(2)
+      if (isPhased)
+        fatal("Hail does not support phased genotypes.")
 
-    i = 0
-    while (i < nSamples) {
-      val sampleMissing = (a(8 + i) & 0x80) != 0
-      if (sampleMissing)
-        rvb.setMissing()
-      else {
-        rvb.startStruct() // g
+      val nBitsPerProb = reader.read()
+      assert(nBitsPerProb >= 1 && nBitsPerProb <= 32// , s"Value for nBits must be between 1 and 32 inclusive. Found $nBitsPerProb."
+      )
+      if (nBitsPerProb != 8)
+        fatal(s"Only 8-bit probabilities supported, found $nBitsPerProb")
 
-        val off = nSamples + 10 + 2 * i
-        val d0 = a(off) & 0xff
-        val d1 = a(off + 1) & 0xff
-        val d2 = 255 - d0 - d1
+      // val nGenotypes = triangle(nAlleles)
 
-        if (includeGT) {
-          if (d0 > d1) {
-            if (d0 > d2)
-              rvb.addInt(c0)
-            else if (d2 > d0)
-              rvb.addInt(c2)
-            else {
-              // d0 == d2
-              rvb.setMissing()
+      // val nExpectedBytesProbs = (nSamples * (nGenotypes - 1) * nBitsPerProb + 7) / 8
+      // assert(reader.length == nExpectedBytesProbs + nSamples + 10// , s"Number of uncompressed bytes `${ reader.length }' does not match the expected size `$nExpectedBytesProbs'."
+      // )
+
+      rvb.startArray(nSamples) // gs
+      if (!includeGT && !includeGP && !includeDosage) {
+        assert(rvb.currentType().asInstanceOf[TStruct].byteSize == 0)
+        rvb.unsafeAdvance(nSamples)
+        // FIXME: we should use the datasize to seek past the data rather than
+        // use the reader which will decompress all the bytes
+        // reader.skipBytes(nSamples * 2)
+        bfis.fis.seek(expectedEnd)
+      } else if (nBitsPerProb == 8 && nAlleles == 2) {
+        val c0 = Call2.fromUnphasedDiploidGtIndex(0)
+        val c1 = Call2.fromUnphasedDiploidGtIndex(1)
+        val c2 = Call2.fromUnphasedDiploidGtIndex(2)
+
+        var i = 0
+        while (i < nSamples) {
+          // val off = nSamples + 10 + 2 * i
+          val d0 = reader.read()
+          val d1 = reader.read()
+
+          if ((sampleMissing(i) & 0x80) == 1)
+            rvb.setMissing()
+          else {
+            val d2 = 255 - d0 - d1
+            rvb.startStruct() // g
+
+            if (includeGT) {
+              if (d0 > d1) {
+                if (d0 > d2)
+                  rvb.addInt(c0)
+                else if (d2 > d0)
+                  rvb.addInt(c2)
+                else {
+                  // d0 == d2
+                  rvb.setMissing()
+                }
+              } else {
+                // d0 <= d1
+                if (d2 > d1)
+                  rvb.addInt(c2)
+                else {
+                  // d2 <= d1
+                  if (d1 == d0 || d1 == d2)
+                    rvb.setMissing()
+                  else
+                    rvb.addInt(c1)
+                }
+              }
             }
-          } else {
-            // d0 <= d1
-            if (d2 > d1)
-              rvb.addInt(c2)
-            else {
-              // d2 <= d1
-              if (d1 == d0 || d1 == d2)
-                rvb.setMissing()
-              else
-                rvb.addInt(c1)
+
+            if (includeGP) {
+              rvb.startArray(3) // GP
+              rvb.addDouble(d0 / 255.0)
+              rvb.addDouble(d1 / 255.0)
+              rvb.addDouble(d2 / 255.0)
+              rvb.endArray()
             }
+
+            if (includeDosage) {
+              val dosage = (d1 + (d2 << 1)) / 255.0
+              rvb.addDouble(dosage)
+            }
+
+            rvb.endStruct() // g
           }
+          i += 1
         }
-
-        if (includeGP) {
-          rvb.startArray(3) // GP
-          rvb.addDouble(d0 / 255.0)
-          rvb.addDouble(d1 / 255.0)
-          rvb.addDouble(d2 / 255.0)
-          rvb.endArray()
-        }
-
-        if (includeDosage) {
-          val dosage = (d1 + (d2 << 1)) / 255.0
-          rvb.addDouble(dosage)
-        }
-
-        rvb.endStruct() // g
+        // FIXME: does it still overshoot now that I tell it how much data to buffer?
+        // the compressed reader will overshoot
+        bfis.fis.seek(expectedEnd)
       }
-      i += 1
+      // assert(expectedEnd == bfis.fis.getPos, s"expected $expectedEnd, but found ${bfis.fis.getPos}, record size: $dataSize")
+      rvb.endArray()
     }
-    rvb.endArray()
   }
 }

--- a/src/main/scala/is/hail/io/bgen/BgenRecord.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenRecord.scala
@@ -192,9 +192,6 @@ class BgenRecordV12(
           }
           i += 1
         }
-        // FIXME: does it still overshoot now that I tell it how much data to buffer?
-        // the compressed reader will overshoot
-        // bfis.fis.seek(expectedEnd)
       }
       rvb.endArray()
     }

--- a/src/main/scala/is/hail/io/bgen/BgenRecord.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenRecord.scala
@@ -54,7 +54,7 @@ class BgenRecordV12(
 ) extends BgenRecord {
   private[this] var expectedDataSize: Int = _
   private[this] var expectedNumAlleles: Int = _
-  private[this] var dataSize: Int = _
+  var dataSize: Int = _
   private[this] val inf = new Inflater()
 
   def setExpectedDataSize(size: Int) {

--- a/src/main/scala/is/hail/io/bgen/BgenRecord.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenRecord.scala
@@ -145,7 +145,10 @@ class BgenRecordV12(
           val d0 = bytes(off)
           val d1 = bytes(off + 1)
 
-          if ((bytes(8 + i) & 0x80) == 1)
+          if ((bytes(8 + i) & 0x3f) != 2)
+            fatal(s"Ploidy value must equal to 2. Found ${(bytes(8 + i) & 0x3f)}")
+
+          if ((bytes(8 + i) & 0x80) != 0)
             rvb.setMissing()
           else {
             val d2 = 255 - d0 - d1

--- a/src/main/scala/is/hail/io/bgen/BgenRecord.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenRecord.scala
@@ -92,7 +92,8 @@ class BgenRecordV12(
         inf.reset()
         inf.setInput(compressed)
         val decsize = inf.inflate(decompressed)
-        assert(decsize == expectedDataSize, s"$decsize, $expectedDataSize, ${inf.needsInput()} ${inf.needsDictionary()}")
+        if (decsize != expectedDataSize)
+          assert(false, s"$decsize, $expectedDataSize, ${inf.needsInput()} ${inf.needsDictionary()}")
         decompressed
       } else {
         val decompressed = new Array[Byte](dataSize)

--- a/src/main/scala/is/hail/io/bgen/BgenRecord.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenRecord.scala
@@ -142,8 +142,8 @@ class BgenRecordV12(
         var i = 0
         while (i < nSamples) {
           val off = nSamples + 10 + 2 * i
-          val d0 = bytes(off)
-          val d1 = bytes(off + 1)
+          val d0 = bytes(off) & 0xff
+          val d1 = bytes(off + 1) & 0xff
 
           if ((bytes(8 + i) & 0x3f) != 2)
             fatal(s"Ploidy value must equal to 2. Found ${(bytes(8 + i) & 0x3f)}")

--- a/src/main/scala/is/hail/io/bgen/BgenRecord.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenRecord.scala
@@ -45,16 +45,16 @@ class BGen12ProbabilityArray(a: Array[Byte], nSamples: Int, nGenotypes: Int, nBi
 }
 
 class BgenRecordV12(
-  compressed: Boolean,
+  isCompressed: Boolean,
   nSamples: Int,
   includeGT: Boolean,
   includeGP: Boolean,
   includeDosage: Boolean,
   bfis: HadoopFSDataBinaryReader
 ) extends BgenRecord {
-  var expectedDataSize: Int = _
-  var expectedNumAlleles: Int = _
-  var dataSize: Int = _
+  private[this] var expectedDataSize: Int = _
+  private[this] var expectedNumAlleles: Int = _
+  private[this] var dataSize: Int = _
   private[this] val inf = new Inflater()
 
   def setExpectedDataSize(size: Int) {
@@ -85,7 +85,7 @@ class BgenRecordV12(
       rvb.endArray()
       bfis.fis.skipBytes(dataSize)
     } else {
-      val bytes = if (compressed) {
+      val bytes = if (isCompressed) {
         val compressed = new Array[Byte](dataSize)
         bfis.fis.readFully(compressed)
         val decompressed = new Array[Byte](expectedDataSize)

--- a/src/main/scala/is/hail/io/bgen/BgenRecord.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenRecord.scala
@@ -79,8 +79,8 @@ class BgenRecordV12(
       bfis.fis.skipBytes(dataSize)
     } else if (!includeGT && !includeGP && !includeDosage) {
       // in this case, we don't even need to decompress anything
-      assert(rvb.currentType().asInstanceOf[TStruct].byteSize == 0)
       rvb.startArray(nSamples) // gs
+      assert(rvb.currentType().asInstanceOf[TStruct].byteSize == 0)
       rvb.unsafeAdvance(nSamples)
       rvb.endArray()
       bfis.fis.skipBytes(dataSize)
@@ -155,6 +155,7 @@ class BgenRecordV12(
       // assert(reader.length == nExpectedBytesProbs + nSamples + 10// , s"Number of uncompressed bytes `${ reader.length }' does not match the expected size `$nExpectedBytesProbs'."
       // )
 
+      rvb.startArray(nSamples) // gs
       if (nBitsPerProb == 8 && nAlleles == 2) {
         val c0 = Call2.fromUnphasedDiploidGtIndex(0)
         val c1 = Call2.fromUnphasedDiploidGtIndex(1)

--- a/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -37,7 +37,6 @@ object LoadBgen {
     nPartitions: Option[Int] = None,
     rg: Option[ReferenceGenome] = Some(ReferenceGenome.defaultReference),
     contigRecoding: Map[String, String] = Map.empty[String, String],
-    tolerance: Double,
     skipInvalidLoci: Boolean = false,
     includedVariantsPerFile: Map[String, Seq[Int]] = Map.empty[String, Seq[Int]]
   ): MatrixTable = {

--- a/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -121,6 +121,8 @@ object LoadBgen {
         val (contig, pos, alleles) = record.getKey
         val contigRecoded = contigRecoding.getOrElse(contig, contig)
 
+        record.getValue(null)
+
         if (skipInvalidLoci && !rg.forall(_.isValidLocus(contigRecoded, pos)))
           None
         else {
@@ -157,9 +159,10 @@ object LoadBgen {
 
         val contigRecoded = contigRecoding.getOrElse(contig, contig)
 
-        if (skipInvalidLoci && !rg.forall(_.isValidLocus(contigRecoded, pos)))
+        if (skipInvalidLoci && !rg.forall(_.isValidLocus(contigRecoded, pos))) {
+          record.getValue(null)
           None
-        else {
+        } else {
           rvb.start(rowType)
           rvb.startStruct()
           rvb.addAnnotation(kType.types(0), Locus.annotation(contigRecoded, pos, rg))
@@ -174,18 +177,14 @@ object LoadBgen {
           rvb.endArray()
           rvb.addAnnotation(rowType.types(2), va.get(0))
           rvb.addAnnotation(rowType.types(3), va.get(1))
-          if (loadEntries)
-            record.getValue(rvb) // gs
-          else {
-            rvb.startArray(nSamples)
-            var j = 0
-            while (j < nSamples) {
-              rvb.startStruct()
-              rvb.endStruct()
-              j += 1
-            }
-            rvb.endArray()
-          }
+          // if (loadEntries)
+          record.getValue(rvb) // gs
+          // else {
+          //   rvb.startArray(nSamples)
+          //   assert(rvb.currentType().asInstanceOf[TStruct].byteSize == 0)
+          //   rvb.unsafeAdvance(nSamples)
+          //   rvb.endArray()
+          // }
           rvb.endStruct()
 
           rv.setOffset(rvb.end())

--- a/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -63,8 +63,6 @@ object LoadBgen {
     val results = files.map { file =>
       val bState = readState(sc.hadoopConfiguration, file)
 
-      hadoop.setInt("nVariants", bState.nVariants)
-
       bState.version match {
         case 2 =>
           BgenResult(file, bState.nSamples, bState.nVariants,
@@ -129,6 +127,7 @@ object LoadBgen {
         val (contig, pos, alleles) = record.getKey
         val contigRecoded = contigRecoding.getOrElse(contig, contig)
 
+        // gotta call getValue to advance the stream, use null to do no work
         record.getValue(null)
 
         if (skipInvalidLoci && !rg.forall(_.isValidLocus(contigRecoded, pos)))
@@ -187,14 +186,7 @@ object LoadBgen {
             rvb.addAnnotation(rowType.types(2), va.get(0))
           if (includeLid)
             rvb.addAnnotation(rowType.types(3), va.get(1))
-          // if (loadEntries)
           record.getValue(rvb) // gs
-          // else {
-          //   rvb.startArray(nSamples)
-          //   assert(rvb.currentType().asInstanceOf[TStruct].byteSize == 0)
-          //   rvb.unsafeAdvance(nSamples)
-          //   rvb.endArray()
-          // }
           rvb.endStruct()
 
           rv.setOffset(rvb.end())

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -67,6 +67,30 @@ class OrderedRVD(
   def sample(withReplacement: Boolean, p: Double, seed: Long): OrderedRVD =
     OrderedRVD(typ, partitioner, crdd.sample(withReplacement, p, seed))
 
+  def zipWithIndex(name: String): OrderedRVD = {
+    assert(!typ.key.contains(name))
+    val (newRowType, ins) = typ.rowType.unsafeStructInsert(TInt64(), List(name))
+
+    val a = sparkContext.broadcast(countPerPartition().scanLeft(0L)(_ + _))
+
+    OrderedRVD(
+      typ.copy(rowType = newRowType.asInstanceOf[TStruct]),
+      partitioner,
+      crdd = crdd.cmapPartitionsWithIndex({ (i, ctx, it) =>
+        val rv2 = RegionValue()
+        val rvb = ctx.rvb
+        var index = a.value(i)
+        it.zipWithIndex.map { case (rv, i) =>
+          rvb.start(newRowType)
+          ins(rv.region, rv.offset, rvb, () => rvb.addLong(index))
+          index += 1
+          rv2.set(rvb.region, rvb.end())
+          rv2
+        }
+      }, preservesPartitioning=true)
+    )
+  }
+
   def persist(level: StorageLevel): OrderedRVD = {
     val PersistedRVRDD(persistedRDD, iterationRDD) = persistRVRDD(level)
     new OrderedRVD(typ, partitioner, iterationRDD) {

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -401,6 +401,8 @@ trait RVD {
 
   def sample(withReplacement: Boolean, p: Double, seed: Long): RVD
 
+  def zipWithIndex(name: String): RVD
+
   protected def rvdSpec(codecSpec: CodecSpec, partFiles: Array[String]): RVDSpec
 
   final def write(path: String, codecSpec: CodecSpec): Array[Long] = {

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -976,13 +976,8 @@ class Table(val hc: HailContext, val tir: TableIR) {
   def index(name: String): Table = {
     if (fieldNames.contains(name))
       fatal(s"name collision: cannot index table, because column '$name' already exists")
-
-    val (newSignature, ins) = signature.insert(TInt64(), name)
-
-    // FIXME: should use RVD, need zipWithIndex
-    val newRDD = rdd.zipWithIndex().map { case (r, ind) => ins(r, ind).asInstanceOf[Row] }
-
-    copy(signature = newSignature.asInstanceOf[TStruct], rdd = newRDD)
+    val newRvd = rvd.zipWithIndex(name)
+    copy2(signature = newRvd.rowType, rvd = newRvd)
   }
 
   def show(n: Int = 10, truncate: Option[Int] = None, printTypes: Boolean = true, maxWidth: Int = 100): Unit = {

--- a/src/main/scala/is/hail/utils/richUtils/Implicits.scala
+++ b/src/main/scala/is/hail/utils/richUtils/Implicits.scala
@@ -116,4 +116,10 @@ trait Implicits {
   implicit def toRichContextRDD[T: ClassTag](x: ContextRDD[RVDContext, T]): RichContextRDD[T] = new RichContextRDD(x)
 
   implicit def toRichCodeInputBuffer(in: Code[InputBuffer]): RichCodeInputBuffer = new RichCodeInputBuffer(in)
+
+  implicit def scalaLambdaToJavaLambda[T, U](
+    f: T => U
+  ): java.util.function.Function[T, U] = new java.util.function.Function[T, U]() {
+    def apply(t: T): U = f(t)
+  }
 }

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -2500,29 +2500,10 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
   def indexRows(name: String): MatrixTable = {
-    val (newRVType, inserter) = rvRowType.unsafeStructInsert(TInt64(), List(name))
-
-    val partStarts = partitionStarts()
-    val newMatrixType = matrixType.copy(rvRowType = newRVType)
-    val indexedRVD = rvd.boundary.mapPartitionsWithIndexPreservesPartitioning(newMatrixType.orvdType, { (i, ctx, it) =>
-      val region2 = ctx.region
-      val rv2 = RegionValue(region2)
-      val rv2b = ctx.rvb
-
-      var idx = partStarts(i)
-
-      it.map { rv =>
-        rv2b.start(newRVType)
-
-        inserter(rv.region, rv.offset, rv2b,
-          () => rv2b.addLong(idx))
-
-        idx += 1
-        rv2.setOffset(rv2b.end())
-        rv2
-      }
-    })
-    copyMT(matrixType = newMatrixType, rvd = indexedRVD)
+    val indexedRVD = rvd.zipWithIndex(name)
+    copyMT(
+      matrixType = matrixType.copy(rvRowType = indexedRVD.typ.rowType),
+      rvd = indexedRVD)
   }
 
   def indexCols(name: String): MatrixTable = {


### PR DESCRIPTION
This needs tests as well as I think I need to fix indexing (so I don't blow memory on the full genome), but I wanted to share what I've been up to with y'all. Also, caitlin can use this branch to run an analysis if it comes to that. I would also appreciate some feedback on the approach. It would be much more ideal to just make joins of variant tables against BGENs smarter, but I think the infrastructure necessary for that is big.

cc: @cseed

List of changes:

 - added `_variants_per_file` limits the loaded variants to variants at the given array of indexes (0-indexed, same order as on disk)

 - ~added `row_fields` which prevents reading and allocation of LID and RSID (also improved python-type-checking for `row_fields` and `entry_fields`)~ Moved to #3779 and #3778

 - ~fixed table-table joins to _not_ always coerce (thus computing partition keys of) the right-hand table~ Moved to #3723 

 - ~added a check that prevents globals and sample annotations copying when they're not used in the body of a MatrixMapCols~ Moved to #3751

 - ~fixed a bug in `IndexBTree` wherein if the number of elements was a multiple of 1024, an unnecessary 1024 elements were added to the end of the index file (which I believe breaks the reading process which expects the number of bytes to correspond to the size of the tree)~ Moved to #3750

 - ~added `IndexBTree2` which is just an in-memory list of the variant start positions. This is a fair bit of data. Chromosome 1 has about 250 million bases, so in the worst case this is 250 * 8 million bytes = 2 GB. It occurs to me that this is actually way to much data to load on the master node in general (since I just try to open the indexes for every file). I should switch this to a disk-based index.~ Made it disk-based, called it `OnDiskBTreeIndexToValue`  #3794

 - each hadoop `FileSplit` now contains a possibly null (indicating no filter) list of variants (by index) to keep, in practice this should be quite small

 - ~I changed several asserts to `if`'s with fatals, so as not to allocate strings~ Moved to #3771

 - ~We no longer copy the genotype data into a buffer in the block reader. This was forcing the `fastKeys` to do an unnecessary data copy~ Moved to #3783 (with some substantial refactoring so it doesn't look much like this PR anymore)

 - ~I changed the contract on BgenRecord to require that `getValue` is called to "consume" the record before the next record is taken~ Irrelevant thanks to #3783 's refactoring

 - ~`getValue(null)` just skips bytes (no copy, no decompression)~ Irrelevant thanks to #3783 's refactoring

 - ~I added `RegionValueBuilder.unsafeAdvance` which can be used when you're creating an array of empty structs but don't want to do all the unnecessary RVB bookkeeping work.~ Moved to #3773

 - ~I use `RegionValueBuilder.unsafeAdvance` to make loading a BGEN without entry fields very fast.~ Rolled into #3783

 - ~I fixed `Table.index` to not trigger a partition key info gathering~ Moved to #3774

I had to ship the arrays of filtered variant indices to the workers somehow, so I shipped them as base64 encoded arrays of bytes. It's pretty groady (and that's why I added the commons-codec library). I don't know how else to initialize record readers with hadoop.

Generally, I think the BGEN loading code could use a clean up, and I haven't done that here, if anything I've made it more complicated.

I also need to check that there are tests for or write tests for:

 - indexing tables doesn't cause an extra shuffle
 - ~the include lid and include raid flags~ included in #3779
 - the variant list flag
 - `getSplits`
 - the variant filtering code
 - ~loading a bgen with no entries~ exists: `BGENTests.test_import_bgen_no_entries`