### PR TITLE
remove RichTable.{select, selectGlobal}

### DIFF
--- a/src/test/scala/is/hail/methods/ExportSuite.scala
+++ b/src/test/scala/is/hail/methods/ExportSuite.scala
@@ -15,28 +15,28 @@ class ExportSuite extends SparkSuite {
     vds = SampleQC(vds)
 
     val out = tmpDir.createTempFile("out", ".tsv")
-    vds.colsTable().select(Array("Sample = row.s",
-    "row.qc.call_rate",
-    "row.qc.n_called",
-    "row.qc.n_not_called",
-    "row.qc.n_hom_ref",
-    "row.qc.n_het",
-    "row.qc.n_hom_var",
-    "row.qc.n_snp",
-    "row.qc.n_insertion",
-    "row.qc.n_deletion",
-    "row.qc.n_singleton",
-    "row.qc.n_transition",
-    "row.qc.n_transversion",
-    "row.qc.n_star",
-    "row.qc.dp_mean",
-    "row.qc.dp_stdev",
-    "row.qc.gq_mean",
-    "row.qc.gq_stdev",
-    "row.qc.n_non_ref",
-    "row.qc.r_ti_tv",
-    "row.qc.r_het_hom_var",
-    "row.qc.r_insertion_deletion")).export(out)
+    vds.colsTable().select(Array("{Sample: row.s",
+    "call_rate: row.qc.call_rate",
+    "n_called: row.qc.n_called",
+    "n_not_called: row.qc.n_not_called",
+    "n_hom_ref: row.qc.n_hom_ref",
+    "n_het: row.qc.n_het",
+    "n_hom_var: row.qc.n_hom_var",
+    "n_snp: row.qc.n_snp",
+    "n_insertion: row.qc.n_insertion",
+    "n_deletion: row.qc.n_deletion",
+    "n_singleton: row.qc.n_singleton",
+    "n_transition: row.qc.n_transition",
+    "n_transversion: row.qc.n_transversion",
+    "n_star: row.qc.n_star",
+    "dp_mean: row.qc.dp_mean",
+    "dp_stdev: row.qc.dp_stdev",
+    "gq_mean: row.qc.gq_mean",
+    "gq_stdev: row.qc.gq_stdev",
+    "n_non_ref: row.qc.n_non_ref",
+    "r_ti_tv: row.qc.r_ti_tv",
+    "r_het_hom_var: row.qc.r_het_hom_var",
+    "r_insertion_deletion: row.qc.r_insertion_deletion}").mkString(","), None, None).export(out)
 
     val sb = new StringBuilder()
     sb.tsvAppend(Array(1, 2, 3, 4, 5))
@@ -85,7 +85,7 @@ class ExportSuite extends SparkSuite {
 
     // verify exports localSamples
     val f = tmpDir.createTempFile("samples", ".tsv")
-    vds.colsTable().select(Array("row.s")).export(f, header = false)
+    vds.colsTable().select("{s: row.s}", None, None).export(f, header = false)
     assert(sc.textFile(f).count() == 1)
   }
 
@@ -95,9 +95,9 @@ class ExportSuite extends SparkSuite {
     val f3 = tmpDir.createTempFile("samples", ".tsv")
 
     val vds = hc.importVCF("src/test/resources/sample.vcf")
-    vds.colsTable().select(Array("`S.A.M.P.L.E.ID` = row.s")).export(f)
-    vds.colsTable().select(Array("`$$$I_HEARD_YOU_LIKE!_WEIRD~^_CHARS****` = row.s", "ANOTHERTHING = row.s")).export(f2)
-    vds.colsTable().select(Array("`I have some spaces and tabs\\there` = row.s", "`more weird stuff here` = row.s")).export(f3)
+    vds.colsTable().select("{`S.A.M.P.L.E.ID`: row.s}", None, None).export(f)
+    vds.colsTable().select("{`$$$I_HEARD_YOU_LIKE!_WEIRD~^_CHARS****`: row.s, ANOTHERTHING: row.s}", None, None).export(f2)
+    vds.colsTable().select("{`I have some spaces and tabs\\there`: row.s, `more weird stuff here`: row.s}", None, None).export(f3)
     hadoopConf.readFile(f) { reader =>
       val lines = Source.fromInputStream(reader)
         .getLines()
@@ -123,7 +123,7 @@ class ExportSuite extends SparkSuite {
     vds = SampleQC(vds)
     vds
       .colsTable()
-      .select(Array("computation = 5 * (if (row.qc.call_rate < .95) 0 else 1)"))
+      .select("{computation: 5 * (if (row.qc.call_rate < .95) 0 else 1)}", None, None)
       .export(f)
   }
 }

--- a/src/test/scala/is/hail/methods/SelectSuite.scala
+++ b/src/test/scala/is/hail/methods/SelectSuite.scala
@@ -3,6 +3,7 @@ package is.hail.methods
 import is.hail.SparkSuite
 import org.testng.annotations.Test
 import is.hail.testUtils._
+import is.hail.utils.FastIndexedSeq
 
 class SelectSuite extends SparkSuite {
   @Test def testRows() {
@@ -11,7 +12,8 @@ class SelectSuite extends SparkSuite {
 
     val t1 = vds.selectRows("{locus: va.locus, alleles: va.alleles, AC: va.info.AC, AF: va.info.AF, foo2: AGG.count()}", None).rowsTable()
 
-    val t2 = vds.rowsTable().select("{locus: row.locus, alleles: row.alleles, AC: row.info.AC, AF: row.info.AF, foo2: row.foo", None, None)
+    val t2 = vds.rowsTable().select("{locus: row.locus, alleles: row.alleles, AC: row.info.AC, AF: row.info.AF, foo2: row.foo}",
+      Some(FastIndexedSeq("locus", "alleles")), Some(2))
 
     assert(t1.same(t2))
   }
@@ -28,7 +30,7 @@ class SelectSuite extends SparkSuite {
 
     val t1 = vds.selectCols("{s: sa.s, baz: sa.bar.baz, foo2: AGG.count()}", None).colsTable()
 
-    val t2 = vds.colsTable().select("{s: row.s, baz: row.bar.baz, foo2: row.foo}", None, None)
+    val t2 = vds.colsTable().select("{s: row.s, baz: row.bar.baz, foo2: row.foo}", Option(FastIndexedSeq("s")), Option(1))
 
     assert(t1.same(t2))
   }

--- a/src/test/scala/is/hail/methods/SelectSuite.scala
+++ b/src/test/scala/is/hail/methods/SelectSuite.scala
@@ -11,7 +11,7 @@ class SelectSuite extends SparkSuite {
 
     val t1 = vds.selectRows("{locus: va.locus, alleles: va.alleles, AC: va.info.AC, AF: va.info.AF, foo2: AGG.count()}", None).rowsTable()
 
-    val t2 = vds.rowsTable().select(Array("row.locus", "row.alleles", "row.info.AC", "AF = row.info.AF", "foo2 = row.foo"))
+    val t2 = vds.rowsTable().select("{locus: row.locus, alleles: row.alleles, AC: row.info.AC, AF: row.info.AF, foo2: row.foo", None, None)
 
     assert(t1.same(t2))
   }
@@ -28,7 +28,7 @@ class SelectSuite extends SparkSuite {
 
     val t1 = vds.selectCols("{s: sa.s, baz: sa.bar.baz, foo2: AGG.count()}", None).colsTable()
 
-    val t2 = vds.colsTable().select(Array("row.s", "row.bar.baz", "foo2 = row.foo"))
+    val t2 = vds.colsTable().select("{s: row.s, baz: row.bar.baz, foo2: row.foo}", None, None)
 
     assert(t1.same(t2))
   }

--- a/src/test/scala/is/hail/methods/TableSuite.scala
+++ b/src/test/scala/is/hail/methods/TableSuite.scala
@@ -146,7 +146,7 @@ class TableSuite extends SparkSuite {
     kt2.export(outputFile)
   }
 
-  @Test def testFilter() = {
+  @Test def testFilter() {
     val data = Array(Array(5, 9, 0), Array(2, 3, 4), Array(1, 2, 3))
     val rdd = sc.parallelize(data.map(Row.fromSeq(_)))
     val signature = TStruct(("field1", TInt32()), ("field2", TInt32()), ("field3", TInt32()))
@@ -165,7 +165,7 @@ class TableSuite extends SparkSuite {
     kt5.export(outputFile)
   }
 
-  @Test def testJoin() = {
+  @Test def testJoin() {
     val inputFile1 = "src/test/resources/sampleAnnotations.tsv"
     val inputFile2 = "src/test/resources/sampleAnnotations2.tsv"
 
@@ -223,7 +223,7 @@ class TableSuite extends SparkSuite {
     assert(noNull.join(noNull.rename(Map("qPhen" -> "qPhen_"), Map()), "outer").rdd.forall { r => !r.toSeq.contains(null) })
   }
 
-  @Test def testJoinDiffKeyNames() = {
+  @Test def testJoinDiffKeyNames() {
     val inputFile1 = "src/test/resources/sampleAnnotations.tsv"
     val inputFile2 = "src/test/resources/sampleAnnotations2.tsv"
 

--- a/src/test/scala/is/hail/testUtils/RichTable.scala
+++ b/src/test/scala/is/hail/testUtils/RichTable.scala
@@ -41,52 +41,12 @@ class RichTable(ht: Table) {
   }
 
   def rename(rowUpdateMap: Map[String, String], globalUpdateMap: Map[String, String]): Table = {
-    select(ht.fieldNames.map(n => s"${ rowUpdateMap.getOrElse(n, n) } = row.$n"))
-      .keyBy(ht.key.map(_.map(k => rowUpdateMap.getOrElse(k, k)).toArray))
-      .selectGlobal(ht.globalSignature.fieldNames.map(n => s"${ globalUpdateMap.getOrElse(n, n) } = global.$n"))
-  }
-
-  def select(exprs: Array[String]): Table = {
-    val ec = ht.rowEvalContext()
-
-    val (paths, types, f) = Parser.parseSelectExprs(exprs, ec)
-
-    val insertionPaths = paths.map {
-      case Left(name) => name
-      case Right(path) => path.last
-    }
-
-    val overlappingPaths = paths.counter().filter { case (n, i) => i != 1 }.keys
-
-    if (overlappingPaths.nonEmpty)
-      fatal(s"Found ${ overlappingPaths.size } ${ plural(overlappingPaths.size, "selected field name") } that are duplicated.\n" +
-        "Overlapping fields:\n  " +
-        s"@1", overlappingPaths.truncatable("\n  "))
-
-    val inserterBuilder = new ArrayBuilder[Inserter]()
-
-    val finalSignature = (insertionPaths, types).zipped.foldLeft(TStruct()) { case (vs, (p, sig)) =>
-      val (s: TStruct, i) = vs.insert(sig, p)
-      inserterBuilder += i
-      s
-    }
-
-    val inserters = inserterBuilder.result()
-    val globalsBc = ht.globals.broadcast
-
-    val annotF: Row => Row = { r =>
-      ec.setAll(globalsBc.value, r)
-
-      f().zip(inserters)
-        .foldLeft(Row()) { case (a1, (v, inserter)) =>
-          inserter(a1, v).asInstanceOf[Row]
-        }
-    }
-
-    var newKey = ht.key.map(_.filter(insertionPaths.toSet))
-    if (newKey.exists(_.isEmpty)) newKey = None
-
-    ht.copy(rdd = ht.rdd.map(annotF), signature = finalSignature, key = newKey)
+    ht.select(
+      "{" + ht.fieldNames.map(n => s"${ rowUpdateMap.getOrElse(n, n) }: row.$n").mkString(",") + "}",
+      ht.key.map(_.map(k => rowUpdateMap.getOrElse(k, k)).toFastIndexedSeq),
+      ht.key.map(_.length))
+      .selectGlobal(
+        "{" + ht.globalSignature.fieldNames.map(n => s"${ globalUpdateMap.getOrElse(n, n) } = global.$n").mkString(",") + "}")
   }
 
   def keyByExpr(exprs: (String, String)*): Table =
@@ -94,40 +54,4 @@ class RichTable(ht: Table) {
 
   def annotate(exprs: (String, String)*): Table =
     ht.select(s"annotate(row, {${ exprs.map { case (n, e) => s"${ prettyIdentifier(n) }: $e" }.mkString(",") }})", ht.key, ht.key.map(_.length))
-
-  def selectGlobal(fields: Array[String]): Table = {
-    val ec = EvalContext("global" -> ht.globalSignature)
-    ec.set(0, ht.globals.value)
-
-    val (paths, types, f) = Parser.parseSelectExprs(fields, ec)
-
-    val names = paths.map {
-      case Left(n) => n
-      case Right(l) => l.last
-    }
-
-    val overlappingPaths = names.counter().filter { case (n, i) => i != 1 }.keys
-
-    if (overlappingPaths.nonEmpty)
-      fatal(s"Found ${ overlappingPaths.size } ${ plural(overlappingPaths.size, "selected field name") } that are duplicated.\n" +
-        "Overlapping fields:\n  " +
-        s"@1", overlappingPaths.truncatable("\n  "))
-
-    val inserterBuilder = new ArrayBuilder[Inserter]()
-
-    val finalSignature = (names, types).zipped.foldLeft(TStruct()) { case (vs, (p, sig)) =>
-      val (s: TStruct, i) = vs.insert(sig, p)
-      inserterBuilder += i
-      s
-    }
-
-    val inserters = inserterBuilder.result()
-
-    val newGlobal = f().zip(inserters)
-      .foldLeft(Row()) { case (a1, (v, inserter)) =>
-        inserter(a1, v).asInstanceOf[Row]
-      }
-
-    ht.copy2(globalSignature = finalSignature, globals = ht.globals.copy(value = newGlobal, t = finalSignature))
-  }
 }

--- a/src/test/scala/is/hail/variant/vsm/GroupBySuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/GroupBySuite.scala
@@ -185,8 +185,7 @@ class GroupBySuite extends SparkSuite {
       .annotateColsExpr("pheno" -> "sa.pheno.Pheno")
 
     val resultsVSM = vdsGrouped.linreg(Array("sa.pheno"), "sum", covExpr = Array("sa.cov.Cov1", "sa.cov.Cov2"))
-    val linregMap = resultsVSM.rowsTable().select(Array("row.genes", "row.linreg.beta",
-      "row.linreg.standard_error", "row.linreg.t_stat", "row.linreg.p_value"))
+    val linregMap = resultsVSM.rowsTable().select("{genes: row.genes, beta: row.linreg.beta, standard_error: row.linreg.standard_error, t_stat: row.linreg.t_stat, p_value: row.linreg.p_value}", None, None)
       .rdd.map { r => (r.getAs[String](0), (1 to 4).map { i => Double.box(r.getAs[IndexedSeq[Double]](i)(0)) }) }
       .collect()
       .toMap

--- a/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -56,7 +56,7 @@ class PartitioningSuite extends SparkSuite {
   @Test def testHintPartitionerAdjustedCorrectly() {
     val mt = MatrixTable.fromRowsTable(Table.range(hc, 100, nPartitions=Some(6)))
     val t = Table.range(hc, 205, nPartitions=Some(6))
-      .select(Array("tidx = 200 - row.idx"))
+      .select("{tidx: 200 - row.idx}", None, None)
       .keyBy("tidx")
     mt.annotateRowsTable(t, "foo").forceCountRows()
   }

--- a/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/VSMSuite.scala
@@ -156,7 +156,7 @@ class VSMSuite extends SparkSuite {
         .writeBlockMatrix(dirname, "x", blockSize)
 
       val data = mt.entriesTable()
-          .select(Array("x = row.GT.nNonRefAlleles().toFloat64 + row.rowIdx.toFloat64 + row.colIdx.toFloat64 + 1.0"))
+          .select("{x: row.GT.nNonRefAlleles().toFloat64 + row.rowIdx.toFloat64 + row.colIdx.toFloat64 + 1.0}", None, None)
           .collect()
           .map(_.getAs[Double](0))
 


### PR DESCRIPTION
They use the deprecated AST interface.   Rewrite in terms of Table interface.