### PR TITLE
rm broken set median IR function

### DIFF
--- a/src/main/scala/is/hail/expr/ir/functions/SetFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/SetFunctions.scala
@@ -116,38 +116,6 @@ object SetFunctions extends RegistryFunctions {
 
     registerIR("mean", TSet(tnum("T"))) { s => ArrayFunctions.mean(ToArray(s)) }
 
-    registerIR("median", TSet(tnum("T"))) { s =>
-      val t = s.typ.asInstanceOf[TSet].elementType
-      val a = genUID()
-      val size = genUID()
-      val lastIdx = genUID()
-      val midIdx = genUID()
-      val midIdx2 = genUID()
-
-      Let(a, ToArray(s),
-        Let(size, ArrayLen(Ref(a, TArray(t))),
-          If(ApplyComparisonOp(EQ(TInt32()), Ref(size, TInt32()), I32(0)),
-            NA(t),
-            If(ApplyComparisonOp(EQ(TInt32()), Ref(size, TInt32()), I32(1)),
-              ArrayRef(Ref(a, TArray(t)), I32(0)),
-              Let(lastIdx, ApplyBinaryPrimOp(Subtract(), Ref(size, TInt32()), I32(1)),
-                Let(lastIdx, If(
-                  IsNA(ArrayRef(Ref(a, TArray(t)), Ref(lastIdx, TInt32()))),
-                  ApplyBinaryPrimOp(Subtract(), Ref(lastIdx, TInt32()), I32(1)),
-                  Ref(lastIdx, TInt32())),
-                  Let(midIdx, ApplyBinaryPrimOp(RoundToNegInfDivide(), Ref(lastIdx, TInt32()), I32(2)),
-                    If(ApplyComparisonOp(EQ(TInt32()), Apply("%", FastSeq(Ref(lastIdx, TInt32()), I32(2))), I32(0)),
-                      ArrayRef(Ref(a, TArray(t)), Ref(midIdx, TInt32())), // odd number of non-missing elements
-                      Let(midIdx2, ApplyBinaryPrimOp(Add(), Ref(midIdx, TInt32()), I32(1)), // even number of non-missing elements
-                        ApplyBinaryPrimOp(
-                          RoundToNegInfDivide(),
-                          ApplyBinaryPrimOp(
-                            Add(),
-                            ArrayRef(Ref(a, TArray(t)), Ref(midIdx, TInt32())),
-                            ArrayRef(Ref(a, TArray(t)), Ref(midIdx2, TInt32()))),
-                          Cast(I32(2), t)))))))))))
-    }
-
     registerIR("flatten", TSet(tv("T"))) { s =>
       val elt = Ref(genUID(), types.coerce[TContainer](s.typ).elementType)
       ToSet(ArrayFlatMap(ToArray(s), elt.name, ToArray(elt)))

--- a/src/test/scala/is/hail/expr/ir/SetFunctionsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/SetFunctionsSuite.scala
@@ -101,6 +101,30 @@ class SetFunctionsSuite extends TestNGSuite {
     assertEvalsTo(invoke("product", nas), null)
   }
 
+  @Test def max() {
+    assertEvalsTo(invoke("max", IRSet(3, 7)), 7)
+    assertEvalsTo(invoke("max", IRSet(3, null, 7)), 7)
+    assertEvalsTo(invoke("max", IRSet()), null)
+    assertEvalsTo(invoke("max", IRSet(null)), null)
+    assertEvalsTo(invoke("max", nas), null)
+  }
+
+  @Test def min() {
+    assertEvalsTo(invoke("min", IRSet(3, 7)), 3)
+    assertEvalsTo(invoke("min", IRSet(3, null, 7)), 3)
+    assertEvalsTo(invoke("min", IRSet()), null)
+    assertEvalsTo(invoke("min", IRSet(null)), null)
+    assertEvalsTo(invoke("min", nas), null)
+  }
+
+  @Test def mean() {
+    assertEvalsTo(invoke("mean", IRSet(3, 7)), 5.0)
+    assertEvalsTo(invoke("mean", IRSet(3, null, 7)), 5.0)
+    assertEvalsTo(invoke("mean", IRSet()), null)
+    assertEvalsTo(invoke("mean", IRSet(null)), null)
+    assertEvalsTo(invoke("mean", nas), null)
+  }
+
   @Test def flatten() {
     val sets1 = FastSeq(IRSet(1, 5, 2), IRSet(6, 2), IRSet(), NA(TSet(TInt32())))
     val sets2 = FastSeq(IRSet(1, 5, 2), IRSet(6, 2), IRSet(), IRSet(null))


### PR DESCRIPTION
`median` for Sets doesn't work. I'm deleting for now and reimplementing in a separate PR.