### PR TITLE
make MatrixTable.group_by.aggregate_rows/cols work with implicit joins

### DIFF
--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -189,8 +189,7 @@ class GroupedTable(ExprContainer):
             analyze('GroupedTable.aggregate', v, self._parent._global_indices, {self._parent._row_axis})
             strs.append('{} = {}'.format(escape_id(k), v._ast.to_hql()))
 
-        base, cleanup = self._parent._process_joins(
-            *itertools.chain(group_exprs.values(), named_exprs.values()))
+        base, cleanup = self._parent._process_joins(*group_exprs.values(), *named_exprs.values())
 
         keyed_t = base._select_processed(hl.struct(**group_exprs))
 
@@ -421,9 +420,7 @@ class Table(ExprContainer):
             jt = jt.keyBy(new_key)
         return Table(jt)
 
-    def _make_row(self,
-                  key_struct=oneof(nullable(expr_struct()), exactly("default")),
-                  value_struct=nullable(expr_struct())):
+    def _make_row(self, key_struct, value_struct) -> Tuple[StructExpression, Optional[List[str]], Optional[List[str]], Optional[List[str]]]:
         def is_copy(ast, name):
             return (isinstance(ast, Select) and
                 ast.name == name and

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -89,6 +89,7 @@ class ExprContainer(object):
         self._fields = other._fields
         self._fields_inverse = other._fields_inverse
 
+
 class GroupedTable(ExprContainer):
     """Table grouped by row that can be aggregated into a new table.
 
@@ -104,9 +105,7 @@ class GroupedTable(ExprContainer):
 
         self._copy_fields_from(parent)
 
-
-    @typecheck_method(n=int)
-    def partition_hint(self, n) -> 'GroupedTable':
+    def partition_hint(self, n: int) -> 'GroupedTable':
         """Set the target number of partitions for aggregation.
 
         Examples
@@ -143,6 +142,7 @@ class GroupedTable(ExprContainer):
         self._npartitions = n
         return self
 
+    @typecheck_method(named_exprs=expr_any)
     def aggregate(self, **named_exprs):
         """Aggregate by group, used after :meth:`.Table.group_by`.
 
@@ -178,7 +178,6 @@ class GroupedTable(ExprContainer):
             raise ValueError('GroupedTable cannot be aggregated if no groupings are specified.')
 
         group_exprs = dict(self._groups)
-        named_exprs = {k: to_expr(v) for k, v in named_exprs.items()}
 
         if not named_exprs.keys().isdisjoint(group_exprs.keys()):
             intersection = set(named_exprs.keys()) & set(group_exprs.keys())

--- a/python/hail/tests/test_api.py
+++ b/python/hail/tests/test_api.py
@@ -686,7 +686,7 @@ class GroupedTableTests(unittest.TestCase):
         self.assertTrue(result._same(expected))
 
 
-class MatrixTests(unittest.TestCase):
+class MatrixTableTests(unittest.TestCase):
     def get_vds(self, min_partitions=None) -> hl.MatrixTable:
         return hl.import_vcf(resource("sample.vcf"), min_partitions=min_partitions)
 
@@ -1481,9 +1481,11 @@ class MatrixTests(unittest.TestCase):
         rt = mt.rows()
         self.assertTrue(rt.all(rt.hw == rt.hw2))
 
-class GroupedMatrixTests(unittest.TestCase):
 
-    def get_groupable_matrix(self):
+class GroupedMatrixTableTests(unittest.TestCase):
+
+    @staticmethod
+    def get_groupable_matrix():
         rt = hl.utils.range_matrix_table(n_rows=100, n_cols=20)
         rt = rt.annotate_globals(foo="foo")
         rt = rt.annotate_rows(group1=rt['row_idx'] % 6,
@@ -1524,7 +1526,6 @@ class GroupedMatrixTests(unittest.TestCase):
         self.assertRaises(ExpressionException, b.aggregate, group5=hl.agg.sum(mt['c']))
         self.assertRaises(ExpressionException, b.aggregate, foo=hl.agg.sum(mt['c']))
 
-
     def test_fields_work_correctly(self):
         mt = self.get_groupable_matrix()
         a = mt.group_rows_by(mt['group1']).aggregate(c=hl.agg.sum(mt['c']))
@@ -1555,6 +1556,52 @@ class GroupedMatrixTests(unittest.TestCase):
         self.assertEqual(b.count_cols(), 6)
         self.assertTrue('group5' in b.col_key)
 
+    def test_joins_work_correctly(self):
+        mt = hl.utils.range_matrix_table(4, 4)
+        mt = mt.annotate_globals(glob=5)
+
+        mt2 = hl.utils.range_matrix_table(4, 4)
+        mt2 = mt2.annotate_entries(x=mt2.row_idx + mt2.col_idx)
+        mt2 = mt2.annotate_rows(row_idx2=mt2.row_idx)
+        mt2 = mt2.annotate_cols(col_idx2=mt2.col_idx)
+
+        col_result = (mt.group_cols_by(group=mt2.cols()[mt.col_idx].col_idx2 < 2)
+                        .aggregate(sum=hl.agg.sum(mt2[mt.row_idx, mt.col_idx].x + mt.glob) + mt.glob - 15))
+
+        col_expected = (
+            hl.Table.parallelize(
+                [{'row_idx': 0, 'group': True, 'sum': 1},
+                 {'row_idx': 0, 'group': False, 'sum': 5},
+                 {'row_idx': 1, 'group': True, 'sum': 3},
+                 {'row_idx': 1, 'group': False, 'sum': 7},
+                 {'row_idx': 2, 'group': True, 'sum': 5},
+                 {'row_idx': 2, 'group': False, 'sum': 9},
+                 {'row_idx': 3, 'group': True, 'sum': 7},
+                 {'row_idx': 3, 'group': False, 'sum': 11}],
+                hl.tstruct(row_idx=hl.tint32, group=hl.tbool, sum=hl.tint64)
+            ).annotate_globals(glob=5).key_by('row_idx', 'group')
+        )
+
+        self.assertTrue(col_result.entries()._same(col_expected))
+
+        row_result = (mt.group_rows_by(group=mt2.rows()[mt.row_idx].row_idx2 < 2)
+                        .aggregate(sum=hl.agg.sum(mt2[mt.row_idx, mt.col_idx].x + mt.glob) + mt.glob - 15))
+
+        row_expected = (
+            hl.Table.parallelize(
+                [{'group': True, 'col_idx': 0, 'sum': 1},
+                 {'group': True, 'col_idx': 1, 'sum': 3},
+                 {'group': True, 'col_idx': 2, 'sum': 5},
+                 {'group': True, 'col_idx': 3, 'sum': 7},
+                 {'group': False, 'col_idx': 0, 'sum': 5},
+                 {'group': False, 'col_idx': 1, 'sum': 7},
+                 {'group': False, 'col_idx': 2, 'sum': 9},
+                 {'group': False, 'col_idx': 3, 'sum': 11}],
+                hl.tstruct(group=hl.tbool, col_idx=hl.tint32, sum=hl.tint64)
+            ).annotate_globals(glob=5).key_by('group', 'col_idx')
+        )
+
+        self.assertTrue(row_result.entries()._same(row_expected))
 
 
 class FunctionsTests(unittest.TestCase):


### PR DESCRIPTION
Joins were not being tested and fail with source mismatch if joins are present in both key and agg expressions. This fix is analogous to that on Table.group_by.aggregate in #3730, processing all joins at once, and not reprocessing later. I don't address here a deeper bug that throws a source error when processing more than one entry-indexed. I've made an issue #3763 