### PR TITLE
RV Aggregator: Inbreeding

### DIFF
--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueInbreedingAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueInbreedingAggregator.scala
@@ -1,0 +1,47 @@
+package is.hail.annotations.aggregators
+
+import is.hail.annotations.{Region, RegionValueBuilder}
+import is.hail.stats.InbreedingCombiner
+import is.hail.variant.Call
+
+object RegionValueInbreedingAggregator {
+  def typ = InbreedingCombiner.signature
+}
+
+class RegionValueInbreedingAggregator extends RegionValueAggregator {
+  var combiner: InbreedingCombiner = _
+
+  def initOp(af: Double, missing: Boolean) {
+    if (!missing) {
+      combiner = new InbreedingCombiner(af)
+    }
+  }
+
+  def seqOp(region: Region, c: Call, missing: Boolean) {
+    if (combiner != null && !missing) {
+      combiner.merge(c)
+    }
+  }
+
+  override def combOp(agg2: RegionValueAggregator) {
+    val other = agg2.asInstanceOf[RegionValueInbreedingAggregator]
+    if (other.combiner != null) {
+      if (combiner == null)
+        combiner = new InbreedingCombiner(other.combiner.af)
+      combiner.merge(other.combiner)
+    }
+  }
+
+  override def result(rvb: RegionValueBuilder) {
+    if (combiner != null)
+      combiner.result(rvb)
+    else
+      rvb.setMissing()
+  }
+
+  override def copy(): RegionValueAggregator = new RegionValueInbreedingAggregator()
+
+  override def clear() {
+    combiner = null
+  }
+}

--- a/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -36,6 +36,7 @@ final case class Histogram() extends AggOp { }
 // what to do about CallStats
 final case class CallStats() extends AggOp { }
 // what to do about InbreedingAggregator
+final case class Inbreeding() extends AggOp { }
 
 // exists === map(p).sum, needs short-circuiting aggs
 // forall === map(p).product, needs short-circuiting aggs
@@ -110,6 +111,9 @@ object AggOp {
 
     case (CallStats(), in: TCall, Seq(), initOpArgs@Some(Seq(_: TInt32))) =>
       CodeAggregator[RegionValueCallStatsAggregator](in, RegionValueCallStatsAggregator.typ, initOpArgTypes = Some(Array(classOf[Int])))
+
+    case (Inbreeding(), in: TCall, Seq(), initOpArgs@Some(Seq(_: TFloat64))) =>
+      CodeAggregator[RegionValueInbreedingAggregator](in, RegionValueInbreedingAggregator.typ, initOpArgTypes = Some(Array(classOf[Double])))
   }
 
   private def incompatible(aggSig: AggSignature): Nothing = {
@@ -130,5 +134,6 @@ object AggOp {
     case "take" => Take()
     case "hist" => Histogram()
     case "callStats" => CallStats()
+    case "inbreeding" => Inbreeding()
   }
 }

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -328,6 +328,10 @@ object Interpret {
             assert(aggType == TCall())
             val nAlleles = interpret(initOpArgs.get(0))
             new CallStatsAggregator(_ => nAlleles)
+          case Inbreeding() =>
+            assert(aggType == TCall())
+            val af = interpret(initOpArgs.get(0))
+            new InbreedingAggregator(_ => af)
           case Collect() => new CollectAggregator(aggType)
           case Fraction() =>
             assert(aggType == TBoolean())

--- a/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
@@ -51,6 +51,13 @@ class AggregatorsSuite {
       initOpArgs = Some(FastIndexedSeq(I32(3))))
   }
 
+  @Test def inbreeding() {
+    runAggregator(Inbreeding(), TCall(),
+      FastIndexedSeq(Call2(0, 0), Call2(0, 1), Call2(0, 1), null, Call2(1, 1)),
+      Row(-1.7777777, 4L, 3.28, 2L),
+      initOpArgs = Some(FastIndexedSeq(F64(0.1))))
+  }
+
   // FIXME Max Boolean not supported by old-style MaxAggregator
 
   @Test def maxInt32() {

--- a/src/test/scala/is/hail/stats/InbreedingCoefficientSuite.scala
+++ b/src/test/scala/is/hail/stats/InbreedingCoefficientSuite.scala
@@ -110,7 +110,7 @@ class InbreedingCoefficientSuite extends SparkSuite {
   }
 
   @Test def signatureIsCorrect() {
-    assert(InbreedingCombiner.signature.typeCheck((new InbreedingCombiner()).asAnnotation))
+    assert(InbreedingCombiner.signature.typeCheck(new InbreedingCombiner(0.4).asAnnotation))
   }
 }
 


### PR DESCRIPTION
This aggregator is very similar to RegionValueCallStatsAggregator where it requires an initOp. The original aggregator is implemented in the is.hail.methods.Aggregators.scala.