### PR TITLE
Keyed RV Aggregator

### DIFF
--- a/src/main/scala/is/hail/annotations/aggregators/KeyedRegionValueAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/KeyedRegionValueAggregator.scala
@@ -1,0 +1,47 @@
+package is.hail.annotations.aggregators
+
+import is.hail.annotations.RegionValueBuilder
+import is.hail.expr.types.Type
+
+import scala.collection.mutable
+
+case class KeyedRegionValueAggregator[Agg <: RegionValueAggregator](
+  rvAgg: Agg,
+  keyTyp: Type,
+  aggTyp: Type,
+  resultTyp: Type) extends RegionValueAggregator {
+
+  val m = mutable.Map.empty[Any, Agg] // this can't be private for reflection to work
+
+  override def copy(): RegionValueAggregator = {
+    KeyedRegionValueAggregator(rvAgg, keyTyp, aggTyp, resultTyp)
+  }
+
+  override def combOp(agg2: RegionValueAggregator): Unit = {
+    val m2 = agg2.asInstanceOf[KeyedRegionValueAggregator[Agg]].m
+    m2.foreach { case (k, v2) =>
+      m(k) = m.get(k) match {
+        case Some(v) =>
+          v.combOp(v2)
+          v
+        case None =>
+          v2
+      }
+    }
+  }
+
+  override def result(rvb: RegionValueBuilder): Unit = {
+    rvb.startArray(m.size)
+    m.foreach { case (group, rvagg) =>
+      rvb.startStruct()
+      rvb.addAnnotation(keyTyp, group)
+      rvagg.result(rvb)
+      rvb.endStruct()
+    }
+    rvb.endArray()
+  }
+
+  override def clear(): Unit = {
+    m.clear()
+  }
+}

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCallStatsAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCallStatsAggregator.scala
@@ -1,9 +1,8 @@
 package is.hail.annotations.aggregators
 
 import is.hail.annotations.{Region, RegionValueBuilder}
-import is.hail.expr.types.{TArray, TString, TStruct}
+import is.hail.expr.types.TStruct
 import is.hail.stats.{CallStats, CallStatsCombiner}
-import is.hail.utils.ArrayBuilder
 import is.hail.variant.Call
 
 object RegionValueCallStatsAggregator {
@@ -39,7 +38,11 @@ class RegionValueCallStatsAggregator extends RegionValueAggregator {
       rvb.setMissing()
   }
 
-  def copy() = new RegionValueCallStatsAggregator()
+  def copy() = {
+    val rva = new RegionValueCallStatsAggregator()
+    rva.combiner = combiner.copy()
+    rva
+  }
 
   def clear() {
     combiner = null

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -743,13 +743,13 @@ case class MatrixAggregateRowsByKey(child: MatrixIR, expr: IR) extends MatrixIR 
 
         def rewrite(x: IR): IR = {
           x match {
-            case InitOp(i, args, aggSig) =>
+            case InitOp(i, args, aggSig, k) =>
               InitOp(
                 ir.ApplyBinaryPrimOp(ir.Add(),
                   ir.ApplyBinaryPrimOp(ir.Multiply(), ir.Ref(colIdx, TInt32()), ir.I32(nAggs)),
                   i),
                 args,
-                aggSig)
+                aggSig, k)
             case _ =>
               ir.Recur(rewrite)(x)
           }
@@ -765,12 +765,12 @@ case class MatrixAggregateRowsByKey(child: MatrixIR, expr: IR) extends MatrixIR 
 
         def rewrite(x: IR): IR = {
           x match {
-            case SeqOp(a, i, agg) =>
+            case SeqOp(a, i, agg, k) =>
               SeqOp(a,
                 ir.ApplyBinaryPrimOp(ir.Add(),
                   ir.ApplyBinaryPrimOp(ir.Multiply(), ir.Ref(colIdx, TInt32()), ir.I32(nAggs)),
                   i),
-                agg)
+                agg, k)
             case _ =>
               ir.Recur(rewrite)(x)
           }
@@ -985,7 +985,7 @@ case class MatrixAggregateColsByKey(child: MatrixIR, aggIR: IR) extends MatrixIR
 
       def rewrite(x: IR): IR = {
         x match {
-          case InitOp(i, args, aggSig) =>
+          case InitOp(i, args, aggSig, k) =>
             InitOp(ir.ApplyBinaryPrimOp(ir.Add(),
               ir.ApplyBinaryPrimOp(
                 ir.Multiply(),
@@ -993,7 +993,7 @@ case class MatrixAggregateColsByKey(child: MatrixIR, aggIR: IR) extends MatrixIR
                 ir.I32(nAggs)),
               i),
               args,
-              aggSig)
+              aggSig, k)
           case _ =>
             ir.Recur(rewrite)(x)
         }
@@ -1010,7 +1010,7 @@ case class MatrixAggregateColsByKey(child: MatrixIR, aggIR: IR) extends MatrixIR
 
       def rewrite(x: IR): IR = {
         x match {
-          case SeqOp(a, i, aggSig) =>
+          case SeqOp(a, i, aggSig, k) =>
             SeqOp(a,
               ir.ApplyBinaryPrimOp(ir.Add(),
                 ir.ApplyBinaryPrimOp(
@@ -1018,7 +1018,7 @@ case class MatrixAggregateColsByKey(child: MatrixIR, aggIR: IR) extends MatrixIR
                   ir.ArrayRef(ir.Ref("newColumnIndices", newColumnIndicesType), ir.Ref(colIdx, TInt32())),
                   ir.I32(nAggs)),
                 i),
-              aggSig)
+              aggSig, k)
           case _ =>
             ir.Recur(rewrite)(x)
         }
@@ -1428,13 +1428,13 @@ case class MatrixMapCols(child: MatrixIR, newCol: IR, newKey: Option[IndexedSeq[
 
       def rewrite(x: IR): IR = {
         x match {
-          case InitOp(i, args, aggSig) =>
+          case InitOp(i, args, aggSig, k) =>
             InitOp(
               ir.ApplyBinaryPrimOp(ir.Add(),
                 ir.ApplyBinaryPrimOp(ir.Multiply(), ir.Ref(colIdx, TInt32()), ir.I32(nAggs)),
                 i),
               args,
-              aggSig)
+              aggSig, k)
           case _ =>
             ir.Recur(rewrite)(x)
         }
@@ -1451,12 +1451,12 @@ case class MatrixMapCols(child: MatrixIR, newCol: IR, newKey: Option[IndexedSeq[
 
       def rewrite(x: IR): IR = {
         x match {
-          case SeqOp(a, i, aggSig) =>
+          case SeqOp(a, i, aggSig, k) =>
             SeqOp(a,
               ir.ApplyBinaryPrimOp(ir.Add(),
                 ir.ApplyBinaryPrimOp(ir.Multiply(), ir.Ref(colIdx, TInt32()), ir.I32(nAggs)),
                 i),
-              aggSig)
+              aggSig, k)
           case _ =>
             ir.Recur(rewrite)(x)
         }

--- a/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -57,6 +57,8 @@ object AggOp {
 
   def getType(aggSig: AggSignature): Type = getOption(aggSig).getOrElse(incompatible(aggSig)).out
 
+  def getKeyedType(aggSig: AggSignature, keyType: Type): Type = TDict(keyType, getType(aggSig))
+
   def getOption(aggSig: AggSignature): Option[CodeAggregator[T] forSome { type T <: RegionValueAggregator }] =
     getOption(aggSig.op, aggSig.inputType, aggSig.constructorArgs, aggSig.initOpArgs)
 

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -68,10 +68,16 @@ object Children {
       Array(old)
     case InsertFields(old, fields) =>
       (old +: fields.map(_._2)).toIndexedSeq
-    case InitOp(i, args, aggSig) =>
-      i +: args
-    case SeqOp(a, i, _) =>
-      Array(a, i)
+    case InitOp(i, args, aggSig, k) =>
+      k match {
+        case Some(key) => i +: args :+ key
+        case None => i +: args
+      }
+    case x@SeqOp(a, i, _, k) =>
+      k match {
+        case Some(key) => Array(a, i, key)
+        case None => Array(a, i)
+      }
     case Begin(xs) =>
       xs
     case ApplyAggOp(a, constructorArgs, initOpArgs, aggSig) =>

--- a/src/main/scala/is/hail/expr/ir/CodeAggregator.scala
+++ b/src/main/scala/is/hail/expr/ir/CodeAggregator.scala
@@ -1,10 +1,11 @@
 package is.hail.expr.ir
 
-import is.hail.annotations.Region
+import is.hail.annotations.{Region, UnsafeRow}
 import is.hail.annotations.aggregators._
 import is.hail.asm4s._
 import is.hail.expr.types._
 
+import scala.collection.mutable
 import scala.reflect.ClassTag
 import scala.reflect.classTag
 
@@ -53,11 +54,80 @@ case class CodeAggregator[Agg <: RegionValueAggregator : ClassTag : TypeInfo](
     }
   }
 
+  def toKeyedAggregator(keyType: Type): KeyedCodeAggregator[Agg] =
+    KeyedCodeAggregator[Agg](keyType, in, out, initOpArgTypes)
+
   def stagedNew(v: Array[Code[_]], m: Array[Code[Boolean]]): Code[Agg] = {
     assert(v.length == m.length)
     val anyArgMissing = m.fold[Code[Boolean]](false)(_ | _)
     anyArgMissing.mux(
       Code._throw(Code.newInstance[RuntimeException, String]("Aggregators must have non missing constructor arguments")),
       Code.newInstance[Agg](constrArgTypes, v))
+  }
+}
+
+case class KeyedCodeAggregator[Agg <: RegionValueAggregator : ClassTag : TypeInfo](keyType: Type, inType: Type, outType: Type,
+                               initOpArgTypes: Option[Array[Class[_]]] = None) {
+
+  def initOp(krva: Code[RegionValueAggregator], vs: Array[Code[_]], ms: Array[Code[Boolean]]): Code[Unit] = {
+    assert(initOpArgTypes.isDefined && vs.length == ms.length)
+    val argTypes = initOpArgTypes.get.flatMap[Class[_], Array[Class[_]]](Array(_, classOf[Boolean]))
+    val args = vs.zip(ms).flatMap { case (v, m) => Array(v, m) }
+    val krvAgg = Code.checkcast[KeyedRegionValueAggregator[Agg]](krva)
+    krvAgg.invoke[Agg]("rvAgg").invoke("initOp", argTypes, args)(classTag[Unit])
+  }
+
+  def seqOp(region: Code[Region], krva: Code[RegionValueAggregator], k: Code[_], mk: Code[Boolean], v: Code[_], mv: Code[Boolean]): Code[Unit] = {
+
+    val krvAgg = Code.checkcast[KeyedRegionValueAggregator[Agg]](krva)
+
+    def wrapArg(arg: Code[_]): Code[_] = keyType match {
+      case _: TBoolean => Code.boxBoolean(coerce[Boolean](arg))
+      case _: TInt32 => Code.boxInt(coerce[Int](arg))
+      case _: TInt64 => Code.boxLong(coerce[Long](arg))
+      case _: TFloat32 => Code.boxFloat(coerce[Float](arg))
+      case _: TFloat64 => Code.boxDouble(coerce[Double](arg))
+      case _: TString =>
+        Code.invokeScalaObject[Region, Long, String](
+          TString.getClass, "loadString",
+          region, coerce[Long](arg))
+      case _ =>
+        Code.invokeScalaObject[Type, Region, Long, Any](
+          UnsafeRow.getClass, "read",
+          krvAgg.invoke[Type]("keyType"), region, coerce[Long](arg))
+    }
+
+    val key = mk.mux(Code._null[Any], wrapArg(k))
+    val m =  krvAgg.invoke[mutable.Map[Any, Agg]]("m")
+
+    val rva = Code(m.invoke[Any, Boolean]("contains", key).mux(
+        Code._empty,
+        m.invoke[Any, Any, Unit]("update", key, Code.checkcast[Agg](krvAgg.invoke[RegionValueAggregator]("rvAgg")).invoke[Agg]("copy"))),
+      m.invoke("apply", key))
+
+    TypeToIRIntermediateClassTag(inType) match {
+      case ct: ClassTag[t] =>
+        mv.mux(
+          Code.checkcast[Agg](rva).invoke(
+            "seqOp",
+            region,
+            coerce[t](defaultValue(inType)),
+            true
+          )(classTag[Region],
+            ct,
+            classTag[Boolean],
+            classTag[Unit]
+          ),
+          Code.checkcast[Agg](rva).invoke(
+            "seqOp",
+            region,
+            coerce[t](v),
+            false
+          )(classTag[Region],
+            ct,
+            classTag[Boolean],
+            classTag[Unit]
+          ))
+    }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -98,11 +98,19 @@ object Copy {
       case GetField(_, name) =>
         val IndexedSeq(o: IR) = newChildren
         GetField(o, name)
-      case InitOp(_, _, aggSig) =>
-        InitOp(newChildren.head.asInstanceOf[IR], newChildren.tail.map(_.asInstanceOf[IR]), aggSig)
-      case SeqOp(_, _, aggSig) =>
-        val IndexedSeq(a: IR, i: IR) = newChildren
-        SeqOp(a, i, aggSig)
+      case x@InitOp(_, _, aggSig, _) =>
+        if (x.isKeyed)
+          InitOp(newChildren.head.asInstanceOf[IR], newChildren.tail.dropRight(1).map(_.asInstanceOf[IR]), aggSig, Some(newChildren.last.asInstanceOf[IR]))
+        else
+          InitOp(newChildren.head.asInstanceOf[IR], newChildren.tail.map(_.asInstanceOf[IR]), aggSig, None)
+      case x@SeqOp(_, _, aggSig, _) =>
+        if (x.isKeyed) {
+          val IndexedSeq(a: IR, i: IR, k: IR) = newChildren
+          SeqOp(a, i, aggSig, Some(k))
+        } else {
+          val IndexedSeq(a: IR, i: IR) = newChildren
+          SeqOp(a, i, aggSig, None)
+        }
       case Begin(_) =>
         Begin(newChildren.map(_.asInstanceOf[IR]))
       case x@ApplyAggOp(_, _, initOpArgs, aggSig) =>

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -121,11 +121,15 @@ final case class ApplyAggOp(a: IR, constructorArgs: IndexedSeq[IR], initOpArgs: 
   def inputType: Type = aggSig.inputType
 }
 
-final case class InitOp(i: IR, args: IndexedSeq[IR], aggSig: AggSignature) extends IR {
+final case class InitOp(i: IR, args: IndexedSeq[IR], aggSig: AggSignature, k: Option[IR] = None) extends IR {
   val typ = TVoid
+
+  def isKeyed: Boolean = k.isDefined
 }
-final case class SeqOp(a: IR, i: IR, aggSig: AggSignature) extends IR {
+final case class SeqOp(a: IR, i: IR, aggSig: AggSignature, k: Option[IR] = None) extends IR {
   val typ = TVoid
+
+  def isKeyed: Boolean = k.isDefined
 }
 
 final case class Begin(xs: IndexedSeq[IR]) extends IR {

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -45,7 +45,12 @@ object Infer {
         assert(body.typ == zero.typ)
         zero.typ
       case ApplyAggOp(a, constructorArgs, initOpArgs, aggSig) =>
-        AggOp.getType(aggSig)
+        a match {
+          case SeqOp(_, _, _, k) => k match {
+            case Some(key) => TDict(key.typ, AggOp.getType(aggSig))
+            case None => AggOp.getType(aggSig)
+          }
+        }
       case MakeStruct(fields) =>
         TStruct(fields.map { case (name, a) =>
           (name, a.typ)

--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -61,7 +61,8 @@ object Pretty {
             case ArrayFlatMap(_, name, _) => name
             case ArrayFold(_, _, accumName, valueName, _) => s"$accumName $valueName"
             case ApplyAggOp(_, _, _, aggSig) => aggSig.op.getClass.getName.split("\\.").last
-            case SeqOp(_, _, aggSig) => aggSig.op.getClass.getName.split("\\.").last
+            case SeqOp(_, _, aggSig, _) => aggSig.op.getClass.getName.split("\\.").last
+            case InitOp(_, _, aggSig, _) => aggSig.op.getClass.getName.split("\\.").last
             case ArrayFor(_, valueName, _) => s"$valueName"
             case ApplyIR(function, _, _) => function
             case Apply(function, _) => function

--- a/src/main/scala/is/hail/methods/Aggregators.scala
+++ b/src/main/scala/is/hail/methods/Aggregators.scala
@@ -10,6 +10,7 @@ import is.hail.stats._
 import is.hail.utils._
 import is.hail.variant._
 import org.apache.spark.SparkContext
+import org.apache.spark.sql.Row
 import org.apache.spark.util.StatCounter
 
 import scala.collection.mutable
@@ -808,4 +809,38 @@ class TakeByAggregator[T](var t: Type, var f: (Any) => Any, var n: Int)(implicit
     val elems = ois.readObject().asInstanceOf[Array[(Any, Any)]]
     _state = mutable.PriorityQueue[(Any, Any)](elems: _*)(ord)
   }
+}
+
+class KeyedAggregator[T, K](aggregator: TypedAggregator[T], t: Type) extends TypedAggregator[Map[Any, T]] {
+  private val m = mutable.Map[Any, TypedAggregator[T]]()
+
+  def result = m.map { case (k, v) => (k, v.result) }.toMap
+
+  def seqOp(x: Any) {
+    val cx = Annotation.copy(t, x).asInstanceOf[Row]
+
+    if (cx != null)
+      seqOp(cx.get(0), cx.get(1))
+    else
+      seqOp(null, null)
+  }
+
+  private def seqOp(x: Any, key: Any) {
+    val agg = m.getOrElseUpdate(key, aggregator.copy())
+    agg.seqOp(x)
+  }
+
+  def combOp(agg2: this.type) {
+    agg2.m.foreach { case (k, v2) =>
+      m(k) = m.get(k) match {
+        case Some(v) =>
+          v.combOp(v2.asInstanceOf[v.type])
+          v
+        case None =>
+          v2
+      }
+    }
+  }
+
+  def copy() = new KeyedAggregator(aggregator, t)
 }

--- a/src/main/scala/is/hail/stats/CallStatsCombiner.scala
+++ b/src/main/scala/is/hail/stats/CallStatsCombiner.scala
@@ -58,7 +58,7 @@ class CallStatsCombiner(val nAlleles: Int) extends Serializable {
     CallStats(alleleCount, alleleFrequency, alleleNumber, homozygoteCount)
   }
 
-  def result(rvb: RegionValueBuilder): Unit = {
+  def result(rvb: RegionValueBuilder) {
     val cstats = result()
     rvb.startStruct()
 
@@ -86,4 +86,6 @@ class CallStatsCombiner(val nAlleles: Int) extends Serializable {
     rvb.endArray()
     rvb.endStruct()
   }
+
+  def copy(): CallStatsCombiner = new CallStatsCombiner(nAlleles)
 }

--- a/src/main/scala/is/hail/utils/MissingLongArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingLongArrayBuilder.scala
@@ -37,8 +37,6 @@ class MissingLongArrayBuilder {
 
   val typ = TArray(TInt64())
 
-  private val rvb = new RegionValueBuilder()
-
   def write(rvb: RegionValueBuilder) {
     rvb.startArray(len)
     var i = 0


### PR DESCRIPTION
@cseed This is the IR infrastructure needed for the `groupBy` aggregator. I wrote tests by adding a `KeyedAggregator` so we can use the interpreter. I don't think it is trivial to incorporate `groupBy` into the AST / Parser. Since we're going to rip out the AST soon anyways, I decided to leave the code where it's at and expose it in Python once we can build IRs in Python.