### PR TITLE
add some dict functions to IR

### DIFF
--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -953,7 +953,7 @@ case class ApplyMethod(posn: Position, lhs: AST, method: String, args: Array[AST
                 val v = ir.genUID()
                 ir.ArrayFold(ir.ToArray(a), ir.True(), v, name, ir.ApplySpecial("&&", FastSeq(ir.Ref(v, TBoolean()), b)))
               case (_: TDict, "mapValues") =>
-                val newName = ir.Ref(name, types.coerce[TContainer](a.typ).elementType)
+                val newName = ir.Ref(name, -types.coerce[TContainer](a.typ).elementType)
                 val value = ir.Subst(b, ir.Env.empty.bind(name -> ir.GetField(newName, "value")))
                 ir.ToDict(
                   ir.ArrayMap(

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -952,6 +952,17 @@ case class ApplyMethod(posn: Position, lhs: AST, method: String, args: Array[AST
               case (_: TSet, "forall") =>
                 val v = ir.genUID()
                 ir.ArrayFold(ir.ToArray(a), ir.True(), v, name, ir.ApplySpecial("&&", FastSeq(ir.Ref(v, TBoolean()), b)))
+              case (_: TDict, "mapValues") =>
+                val newName = ir.Ref(name, types.coerce[TContainer](a.typ).elementType)
+                val value = ir.Subst(b, ir.Env.empty.bind(name -> ir.GetField(newName, "value")))
+                ir.ToDict(
+                  ir.ArrayMap(
+                    ir.ToArray(a),
+                    name,
+                    ir.MakeStruct(Seq(
+                      "key" -> ir.GetField(newName, "key"),
+                      "value" -> value))))
+
               case (_: TArray, "groupBy") =>
                 ir.GroupByKey(ir.ArrayMap(a, name, ir.MakeTuple(FastSeq(b, ir.Ref(name, types.coerce[TContainer](a.typ).elementType)))))
               case (_: TSet, "groupBy") =>

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -827,13 +827,6 @@ object FunctionRegistry {
   register("Call", { (s: String) => Call.parse(s) })(stringHr, callHr)
   register("UnphasedDiploidGtIndexCall", { (gt: Int) => Call2.fromUnphasedDiploidGtIndex(gt) })(int32Hr, callHr)
 
-  register("Dict", { (keys: IndexedSeq[Annotation], values: IndexedSeq[Annotation]) =>
-    if (keys.length != values.length)
-      fatal(s"mismatch between length of keys (${ keys.length }) and values (${ values.length })")
-    keys.zip(values).toMap
-  })(arrayHr(TTHr), arrayHr(TUHr), dictHr(TTHr, TUHr))
-
-
   val tuple2Hr = new HailRep[Annotation] {
     override def typ: Type = TTuple(TTHr.typ, TUHr.typ)
   }

--- a/src/main/scala/is/hail/expr/ir/functions/DictFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/DictFunctions.scala
@@ -62,24 +62,6 @@ object DictFunctions extends RegistryFunctions {
 
     registerIR("dict", TArray(TTuple(tv("key"), tv("value"))))(ToDict)
 
-    registerIR("Dict", TArray(tv("key")), TArray(tv("value"))) { (k, v) =>
-      val keys = Ref(genUID(), k.typ)
-      val values = Ref(genUID(), v.typ)
-      val i = Ref(genUID(), TInt32())
-      val typ = TDict(
-        types.coerce[TArray](k.typ).elementType,
-        types.coerce[TArray](v.typ).elementType)
-
-      Let(keys.name, k,
-        Let(values.name, v,
-          If(ArrayLen(keys).cne(ArrayLen(values)),
-            Die("Keys and values arrays must have same length in Dict(keys, values).", typ),
-            ToDict(ArrayMap(
-              ArrayRange(0, ArrayLen(keys), 1),
-              i.name,
-              MakeTuple(Seq(ArrayRef(keys, i), ArrayRef(values, i))))))))
-    }
-
     registerIR("keys", tdict) { d =>
       val elt = Ref(genUID(), -types.coerce[TContainer](d.typ).elementType)
       ArrayMap(ToArray(d), elt.name, GetField(elt, "key"))

--- a/src/test/scala/is/hail/expr/ir/DictFunctionsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/DictFunctionsSuite.scala
@@ -66,14 +66,6 @@ class DictFunctionsSuite extends TestNGSuite {
     Array(null, null, null))
 
   @Test(dataProvider = "keysAndValues")
-  def dictFromTwoArrays(
-    a: Seq[(Integer, Integer)],
-    keys: IndexedSeq[Integer],
-    values: IndexedSeq[Integer]) {
-    assertEvalsTo(invoke("Dict", toIRArray(keys), toIRArray(values)), tuplesToMap(a))
-  }
-
-  @Test(dataProvider = "keysAndValues")
   def keySet(a: Seq[(Integer, Integer)],
     keys: IndexedSeq[Integer],
     values: IndexedSeq[Integer]) {

--- a/src/test/scala/is/hail/expr/ir/DictFunctionsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/DictFunctionsSuite.scala
@@ -2,10 +2,13 @@ package is.hail.expr.ir
 
 import is.hail.TestUtils._
 import is.hail.expr.ir.TestUtils._
+import org.apache.spark.sql.Row
 import org.testng.annotations.{DataProvider, Test}
 import org.scalatest.testng.TestNGSuite
 
 class DictFunctionsSuite extends TestNGSuite {
+  def tuplesToMap(a: Seq[(Integer, Integer)]): Map[Integer, Integer] =
+    Option(a).map(_.filter(_ != null).toMap).orNull
 
   @DataProvider(name = "basic")
   def basicData(): Array[Array[Any]] = Array(
@@ -17,11 +20,14 @@ class DictFunctionsSuite extends TestNGSuite {
   )
 
   @Test(dataProvider = "basic")
-  def toDict(a: Seq[(Integer, Integer)]) {
-    assertEvalsTo(invoke("toDict", toIRPairArray(a)),
-      Option(a).map(_.filter(_ != null).toMap).orNull)
-    assertEvalsTo(toIRDict(a),
-      Option(a).map(_.filter(_ != null).toMap).orNull)
+  def dictFromArray(a: Seq[(Integer, Integer)]) {
+    assertEvalsTo(invoke("dict", toIRPairArray(a)), tuplesToMap(a))
+    assertEvalsTo(toIRDict(a), tuplesToMap(a))
+  }
+
+  @Test(dataProvider = "basic")
+  def dictFromSet(a: Seq[(Integer, Integer)]) {
+    assertEvalsTo(invoke("dict", ToSet(toIRPairArray(a))), tuplesToMap(a))
   }
 
   @Test(dataProvider = "basic")
@@ -34,5 +40,58 @@ class DictFunctionsSuite extends TestNGSuite {
   def isEmpty(a: Seq[(Integer, Integer)]) {
     assertEvalsTo(invoke("isEmpty", toIRDict(a)),
       Option(a).map(_.forall(_ == null)).orNull)
+  }
+
+  @DataProvider(name = "dictToArray")
+  def dictToArrayData(): Array[Array[Any]] = Array(
+    Array(Seq(1 -> 3, 2 -> 7), IndexedSeq(Row(1, 3), Row(2, 7))),
+    Array(Seq(1 -> 3, 2 -> null, null, (null, 1), 3 -> 7),
+      IndexedSeq(Row(1, 3), Row(2, null), Row(3, 7), Row(null, 1))),
+    Array(Seq(), IndexedSeq()),
+    Array(Seq(null), IndexedSeq()),
+    Array(null, null))
+
+  @Test(dataProvider = "dictToArray")
+  def dictToArray(a: Seq[(Integer, Integer)], expected: (IndexedSeq[Row])) {
+    assertEvalsTo(invoke("dictToArray", toIRDict(a)), expected)
+  }
+
+  @DataProvider(name = "keysAndValues")
+  def keysAndValuesData(): Array[Array[Any]] = Array(
+    Array(Seq(1 -> 3, 2 -> 7), IndexedSeq(1, 2), IndexedSeq(3, 7)),
+    Array(Seq(1 -> 3, 2 -> null, null, (null, 1), 3 -> 7),
+      IndexedSeq(1, 2, 3, null), IndexedSeq(3, null, 7, 1)),
+    Array(Seq(), IndexedSeq(), IndexedSeq()),
+    Array(Seq(null), IndexedSeq(), IndexedSeq()),
+    Array(null, null, null))
+
+  @Test(dataProvider = "keysAndValues")
+  def dictFromTwoArrays(
+    a: Seq[(Integer, Integer)],
+    keys: IndexedSeq[Integer],
+    values: IndexedSeq[Integer]) {
+    assertEvalsTo(invoke("Dict", toIRArray(keys), toIRArray(values)), tuplesToMap(a))
+  }
+
+  @Test(dataProvider = "keysAndValues")
+  def keySet(a: Seq[(Integer, Integer)],
+    keys: IndexedSeq[Integer],
+    values: IndexedSeq[Integer]) {
+    assertEvalsTo(invoke("keySet", toIRDict(a)),
+      Option(keys).map(_.toSet).orNull)
+  }
+
+  @Test(dataProvider = "keysAndValues")
+  def keys(a: Seq[(Integer, Integer)],
+    keys: IndexedSeq[Integer],
+    values: IndexedSeq[Integer]) {
+    assertEvalsTo(invoke("keys", toIRDict(a)), keys)
+  }
+
+  @Test(dataProvider = "keysAndValues")
+  def values(a: Seq[(Integer, Integer)],
+    keys: IndexedSeq[Integer],
+    values: IndexedSeq[Integer]) {
+    assertEvalsTo(invoke("values", toIRDict(a)), values)
   }
 }

--- a/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -865,9 +865,6 @@ class ExprSuite extends SparkSuite {
       eval("str(1) == 1")
     }
 
-    assert(eval("Dict([1,2,3], [1,2,3])").contains(Map(1 -> 1, 2 -> 2, 3 -> 3)))
-    assert(eval("""Dict(["foo", "bar"], [1,2])""").contains(Map("foo" -> 1, "bar" -> 2)))
-
     assert(eval("isnan(0/0)").contains(true))
     assert(eval("isnan(0d)").contains(false))
     assert(eval("isnan(NA: Float32)").isEmpty)


### PR DESCRIPTION
I removed `toDict` (well, renamed it to `dict`) since it doesn't appear to be used anywhere (the function is in the current function registry as `dict`).