### PR TITLE
Table.index no shuffle

### DIFF
--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -74,7 +74,7 @@ class OrderedRVD(
     OrderedRVD(
       typ.copy(rowType = newRowType.asInstanceOf[TStruct]),
       partitioner,
-      crdd = crdd
+      crdd = newCRDD
     )
   }
 

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -67,6 +67,30 @@ class OrderedRVD(
   def sample(withReplacement: Boolean, p: Double, seed: Long): OrderedRVD =
     OrderedRVD(typ, partitioner, crdd.sample(withReplacement, p, seed))
 
+  def zipWithIndex(name: String): OrderedRVD = {
+    assert(!typ.key.contains(name))
+    val (newRowType, ins) = typ.rowType.unsafeStructInsert(TInt64(), List(name))
+
+    val a = sparkContext.broadcast(countPerPartition().scanLeft(0L)(_ + _))
+
+    OrderedRVD(
+      typ.copy(rowType = newRowType.asInstanceOf[TStruct]),
+      partitioner,
+      crdd = crdd.cmapPartitionsWithIndex({ (i, ctx, it) =>
+        val rv2 = RegionValue()
+        val rvb = ctx.rvb
+        var index = a.value(i)
+        it.zipWithIndex.map { case (rv, i) =>
+          rvb.start(newRowType)
+          ins(rv.region, rv.offset, rvb, () => rvb.addLong(index))
+          index += 1
+          rv2.set(rvb.region, rvb.end())
+          rv2
+        }
+      }, preservesPartitioning=true)
+    )
+  }
+
   def persist(level: StorageLevel): OrderedRVD = {
     val PersistedRVRDD(persistedRDD, iterationRDD) = persistRVRDD(level)
     new OrderedRVD(typ, partitioner, iterationRDD) {

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -401,6 +401,8 @@ trait RVD {
 
   def sample(withReplacement: Boolean, p: Double, seed: Long): RVD
 
+  def zipWithIndex(name: String): RVD
+
   protected def rvdSpec(codecSpec: CodecSpec, partFiles: Array[String]): RVDSpec
 
   final def write(path: String, codecSpec: CodecSpec): Array[Long] = {

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -414,7 +414,7 @@ trait RVD {
       val rv2 = RegionValue()
       val rvb = ctx.rvb
       var index = a.value(i)
-      it.zipWithIndex.map { case (rv, i) =>
+      it.map { rv =>
         rvb.start(newRowType)
         ins(rv.region, rv.offset, rvb, () => rvb.addLong(index))
         index += 1

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -5,7 +5,7 @@ import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, InputStream, Outpu
 import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.expr.JSONAnnotationImpex
-import is.hail.expr.types.{TArray, TInterval, TStruct, TStructSerializer}
+import is.hail.expr.types._
 import is.hail.sparkextras._
 import is.hail.io._
 import is.hail.utils._
@@ -402,6 +402,28 @@ trait RVD {
   def sample(withReplacement: Boolean, p: Double, seed: Long): RVD
 
   def zipWithIndex(name: String): RVD
+
+  private[rvd] def zipWithIndexCRDD(
+    name: String
+  ): (TStruct, ContextRDD[RVDContext, RegionValue]) = {
+    val (newRowType, ins) = rowType.unsafeStructInsert(TInt64(), List(name))
+
+    val a = sparkContext.broadcast(countPerPartition().scanLeft(0L)(_ + _))
+
+    val newCRDD = crdd.cmapPartitionsWithIndex({ (i, ctx, it) =>
+      val rv2 = RegionValue()
+      val rvb = ctx.rvb
+      var index = a.value(i)
+      it.zipWithIndex.map { case (rv, i) =>
+        rvb.start(newRowType)
+        ins(rv.region, rv.offset, rvb, () => rvb.addLong(index))
+        index += 1
+        rv2.set(rvb.region, rvb.end())
+        rv2
+      }
+    }, preservesPartitioning=true)
+    (newRowType, newCRDD)
+  }
 
   protected def rvdSpec(codecSpec: CodecSpec, partFiles: Array[String]): RVDSpec
 

--- a/src/main/scala/is/hail/rvd/UnpartitionedRVD.scala
+++ b/src/main/scala/is/hail/rvd/UnpartitionedRVD.scala
@@ -50,24 +50,11 @@ class UnpartitionedRVD(val rowType: TStruct, val crdd: ContextRDD[RVDContext, Re
     new UnpartitionedRVD(rowType, crdd.sample(withReplacement, p, seed))
 
   def zipWithIndex(name: String): UnpartitionedRVD = {
-    val (newRowType, ins) = rowType.unsafeStructInsert(TInt64(), List(name))
-
-    val a = sparkContext.broadcast(countPerPartition().scanLeft(0L)(_ + _))
+    val (newRowType, newCRDD) = zipWithIndexCRDD(name)
 
     new UnpartitionedRVD(
-      rowType = newRowType.asInstanceOf[TStruct],
-      crdd = crdd.cmapPartitionsWithIndex({ (i, ctx, it) =>
-        val rv2 = RegionValue()
-        val rvb = ctx.rvb
-        var index = a.value(i)
-        it.zipWithIndex.map { case (rv, i) =>
-          rvb.start(newRowType)
-          ins(rv.region, rv.offset, rvb, () => rvb.addLong(index))
-          index += 1
-          rv2.set(rvb.region, rvb.end())
-          rv2
-        }
-      }, preservesPartitioning=true)
+      rowType = newRowType,
+      crdd = crdd
     )
   }
 

--- a/src/main/scala/is/hail/rvd/UnpartitionedRVD.scala
+++ b/src/main/scala/is/hail/rvd/UnpartitionedRVD.scala
@@ -54,7 +54,7 @@ class UnpartitionedRVD(val rowType: TStruct, val crdd: ContextRDD[RVDContext, Re
 
     new UnpartitionedRVD(
       rowType = newRowType,
-      crdd = crdd
+      crdd = newCRDD
     )
   }
 

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -976,13 +976,8 @@ class Table(val hc: HailContext, val tir: TableIR) {
   def index(name: String): Table = {
     if (fieldNames.contains(name))
       fatal(s"name collision: cannot index table, because column '$name' already exists")
-
-    val (newSignature, ins) = signature.insert(TInt64(), name)
-
-    // FIXME: should use RVD, need zipWithIndex
-    val newRDD = rdd.zipWithIndex().map { case (r, ind) => ins(r, ind).asInstanceOf[Row] }
-
-    copy(signature = newSignature.asInstanceOf[TStruct], rdd = newRDD)
+    val newRvd = rvd.zipWithIndex(name)
+    copy2(signature = newRvd.rowType, rvd = newRvd)
   }
 
   def show(n: Int = 10, truncate: Option[Int] = None, printTypes: Boolean = true, maxWidth: Int = 100): Unit = {

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -2500,29 +2500,10 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
   def indexRows(name: String): MatrixTable = {
-    val (newRVType, inserter) = rvRowType.unsafeStructInsert(TInt64(), List(name))
-
-    val partStarts = partitionStarts()
-    val newMatrixType = matrixType.copy(rvRowType = newRVType)
-    val indexedRVD = rvd.boundary.mapPartitionsWithIndexPreservesPartitioning(newMatrixType.orvdType, { (i, ctx, it) =>
-      val region2 = ctx.region
-      val rv2 = RegionValue(region2)
-      val rv2b = ctx.rvb
-
-      var idx = partStarts(i)
-
-      it.map { rv =>
-        rv2b.start(newRVType)
-
-        inserter(rv.region, rv.offset, rv2b,
-          () => rv2b.addLong(idx))
-
-        idx += 1
-        rv2.setOffset(rv2b.end())
-        rv2
-      }
-    })
-    copyMT(matrixType = newMatrixType, rvd = indexedRVD)
+    val indexedRVD = rvd.zipWithIndex(name)
+    copyMT(
+      matrixType = matrixType.copy(rvRowType = indexedRVD.typ.rowType),
+      rvd = indexedRVD)
   }
 
   def indexCols(name: String): MatrixTable = {


### PR DESCRIPTION
The old `Table.index` used the `RDD` route which forced a shuffle because all partitioning information was lost. I exposed `zipWithIndex` on `RVD` and used it in both MatrixTable and Table.