### PR TITLE
Uniroot is strict in min and max test

### DIFF
--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -521,7 +521,10 @@ object Interpret {
         val f = { x: Double => interpret(fn, env.bind(functionid, x), args, agg).asInstanceOf[Double] }
         val min = interpret(minIR, env, args, agg)
         val max = interpret(maxIR, env, args, agg)
-        stats.uniroot(f, min.asInstanceOf[Double], max.asInstanceOf[Double]).orNull
+        if (min == null || max == null)
+          null
+        else
+          stats.uniroot(f, min.asInstanceOf[Double], max.asInstanceOf[Double]).orNull
 
       case TableCount(child) =>
         child.partitionCounts

--- a/src/test/scala/is/hail/expr/ir/MathFunctionsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/MathFunctionsSuite.scala
@@ -84,6 +84,7 @@ class MathFunctionsSuite extends TestNGSuite {
     assertEvalsTo(invoke("entropy", Str("aa")), 0.0)
     assertEvalsTo(invoke("entropy", Str("ac")), 1.0)
     assertEvalsTo(invoke("entropy", Str("accctg")), 1.7924812503605778)
+  }
 
   @Test def unirootIsStrictInMinAndMax() {
     assertEvalsTo(

--- a/src/test/scala/is/hail/expr/ir/MathFunctionsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/MathFunctionsSuite.scala
@@ -38,7 +38,7 @@ class MathFunctionsSuite extends TestNGSuite {
 
     assertEvalsTo(ir, -3.0)
   }
-  
+
   @Test def rpois() {
     val res0 = eval(invoke("rpois", I32(5), F64(1)))
     assert(TArray(TFloat64()).typeCheck(res0))
@@ -47,20 +47,20 @@ class MathFunctionsSuite extends TestNGSuite {
     assert(res.forall(_ >= 0))
     assert(res.forall(x => x == x.floor))
   }
-  
+
   @Test def isnan() {
     assertEvalsTo(invoke("isnan", F32(0)), false)
     assertEvalsTo(invoke("isnan", F32(Float.NaN)), true)
-    
+
     assertEvalsTo(invoke("isnan", F64(0)), false)
     assertEvalsTo(invoke("isnan", F64(Double.NaN)), true)
   }
-  
+
   @Test def sign() {
     assertEvalsTo(invoke("sign", I32(2)), 1)
     assertEvalsTo(invoke("sign", I32(0)), 0)
     assertEvalsTo(invoke("sign", I32(-2)), -1)
-    
+
     assertEvalsTo(invoke("sign", I64(2)), 1l)
     assertEvalsTo(invoke("sign", I64(0)), 0l)
     assertEvalsTo(invoke("sign", I64(-2)), -1l)
@@ -68,14 +68,14 @@ class MathFunctionsSuite extends TestNGSuite {
     assertEvalsTo(invoke("sign", F32(2)), 1.0f)
     assertEvalsTo(invoke("sign", F32(0)), 0.0f)
     assertEvalsTo(invoke("sign", F32(-2)), -1.0f)
-    
+
     assertEvalsTo(invoke("sign", F64(2)), 1.0)
     assertEvalsTo(invoke("sign", F64(0)), 0.0)
     assertEvalsTo(invoke("sign", F64(-2)), -1.0)
 
     assert(eval(invoke("sign", F64(Double.NaN))).asInstanceOf[Double].isNaN)
     assertEvalsTo(invoke("sign", F64(Double.PositiveInfinity)), 1.0)
-    assertEvalsTo(invoke("sign", F64(Double.NegativeInfinity)), -1.0)    
+    assertEvalsTo(invoke("sign", F64(Double.NegativeInfinity)), -1.0)
   }
 
   @Test def entropy() {
@@ -84,5 +84,13 @@ class MathFunctionsSuite extends TestNGSuite {
     assertEvalsTo(invoke("entropy", Str("aa")), 0.0)
     assertEvalsTo(invoke("entropy", Str("ac")), 1.0)
     assertEvalsTo(invoke("entropy", Str("accctg")), 1.7924812503605778)
+
+  @Test def unirootIsStrictInMinAndMax() {
+    assertEvalsTo(
+      Uniroot("x", Ref("x", tfloat), F64(-6), NA(tfloat)),
+      null)
+    assertEvalsTo(
+      Uniroot("x", Ref("x", tfloat), NA(tfloat), F64(0)),
+      null)
   }
 }


### PR DESCRIPTION
I forget why I added this, but I came across something in
Uniroot that either was not or made me think that Uniroot
was not strict in max and min, so I added a test.