### PR TITLE
Some logging and an alloc improvement to Region

### DIFF
--- a/src/main/scala/is/hail/annotations/Region.scala
+++ b/src/main/scala/is/hail/annotations/Region.scala
@@ -155,9 +155,9 @@ final class Region private (
 
   private def allocate(n: Long): Long = {
     assert(n >= 0)
-    if (n > blockSize) {
+    if (n > blockSize / 2) {
       // FIXME: is this guaranteed to be aligned to anything?
-      log.info(s"Allocating a large region $n")
+      log.info(s"Allocating a large block $n, currently have ${bigBlocks.length} large blocks")
       val mem = Memory.malloc(n)
       bigBlocks += mem
       mem
@@ -167,7 +167,7 @@ final class Region private (
         // FIXME: is this guaranteed to be aligned to anything?
         activeBlock += 1
         val mem = if (activeBlock == blocks.length) {
-          log.info(s"Allocating a new region, $end $n $capacity")
+          log.info(s"Allocating a new block, $end $n $capacity, currently have ${blocks.length} blocks")
           val temp = Memory.malloc(blockSize)
           blocks += temp
           temp
@@ -366,6 +366,7 @@ final class Region private (
   }
 
   def close(): Unit = {
+    log.info(s"Freeing all blocks. ${blocks.length} ${bigBlocks.length}")
     blocks.result().foreach(Memory.free)
     bigBlocks.result().foreach(Memory.free)
   }


### PR DESCRIPTION
I found this logging helpful but not noisy. The blockSize change
is inspired by @rcownie. It means that things that take half or more of the block will get a custom block, rather than possibly having a block half-occupied with something big and not have a lot of room for new stuff. (At least, that's my understanding of the rational)