### PR TITLE
Add row_fields import_bgen parameter

### DIFF
--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -841,7 +841,7 @@ def import_bgen(path,
     **Row Fields**
 
     Between two and four row fields are created. The `locus` and `alleles` are
-    always included. `row_fields` determines if `varid` and `rsid` are alos
+    always included. `row_fields` determines if `varid` and `rsid` are also
     included. For best performance, only include fields necessary for your
     analysis.
 

--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -786,14 +786,16 @@ def grep(regex, path, max_count=100):
            min_partitions=nullable(int),
            reference_genome=nullable(reference_genome_type),
            contig_recoding=nullable(dictof(str, str)),
-           skip_invalid_loci=bool)
+           skip_invalid_loci=bool,
+           row_fields=sequenceof(enumeration('varid', 'rsid')))
 def import_bgen(path,
                 entry_fields,
                 sample_file=None,
                 min_partitions=None,
                 reference_genome='default',
                 contig_recoding=None,
-                skip_invalid_loci=False) -> MatrixTable:
+                skip_invalid_loci=False,
+                row_fields=['varid', 'rsid']) -> MatrixTable:
     """Import BGEN file(s) as a :class:`.MatrixTable`.
 
     Examples
@@ -837,6 +839,11 @@ def import_bgen(path,
       exists; else IDs are assigned from `_0`, `_1`, to `_N`.
 
     **Row Fields**
+
+    Between two and four row fields are created. The `locus` and `alleles` are
+    always included. `row_fields` determines if `varid` and `rsid` are alos
+    included. For best performance, only include fields necessary for your
+    analysis.
 
     - `locus` (:class:`.tlocus` or :class:`.tstruct`) -- Row key. The chromosome
       and position. If `reference_genome` is defined, the type will be
@@ -890,6 +897,9 @@ def import_bgen(path,
         in the reference genome given by `reference_genome`.
     skip_invalid_loci : :obj:`bool`
         If ``True``, skip loci that are not consistent with `reference_genome`.
+    row_fields : :obj:`list` of :obj:`str`
+        List of non-key row fields to create.
+        Options: ``'varid'``, ``'rsid'``
 
     Returns
     -------
@@ -906,6 +916,7 @@ def import_bgen(path,
 
     jmt = Env.hc()._jhc.importBgens(jindexed_seq_args(path), joption(sample_file),
                                     'GT' in entry_set, 'GP' in entry_set, 'dosage' in entry_set,
+                                    'varid' in row_set, 'rsid' in row_set,
                                     joption(min_partitions), joption(rg), joption(contig_recoding),
                                     skip_invalid_loci)
     return MatrixTable(jmt)

--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -910,6 +910,7 @@ def import_bgen(path,
     rg = reference_genome._jrep if reference_genome else None
 
     entry_set = set(entry_fields)
+    row_set = set(row_fields)
 
     if contig_recoding:
         contig_recoding = tdict(tstr, tstr)._convert_to_j(contig_recoding)

--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -787,7 +787,7 @@ def grep(regex, path, max_count=100):
            reference_genome=nullable(reference_genome_type),
            contig_recoding=nullable(dictof(str, str)),
            skip_invalid_loci=bool,
-           row_fields=sequenceof(enumeration('varid', 'rsid')))
+           _row_fields=sequenceof(enumeration('varid', 'rsid')))
 def import_bgen(path,
                 entry_fields,
                 sample_file=None,
@@ -795,7 +795,7 @@ def import_bgen(path,
                 reference_genome='default',
                 contig_recoding=None,
                 skip_invalid_loci=False,
-                row_fields=['varid', 'rsid']) -> MatrixTable:
+                _row_fields=['varid', 'rsid']) -> MatrixTable:
     """Import BGEN file(s) as a :class:`.MatrixTable`.
 
     Examples
@@ -841,9 +841,10 @@ def import_bgen(path,
     **Row Fields**
 
     Between two and four row fields are created. The `locus` and `alleles` are
-    always included. `row_fields` determines if `varid` and `rsid` are also
+    always included. `_row_fields` determines if `varid` and `rsid` are also
     included. For best performance, only include fields necessary for your
-    analysis.
+    analysis. NOTE: the `_row_fields` parameter is considered an experimental
+    feature and may be removed without warning.
 
     - `locus` (:class:`.tlocus` or :class:`.tstruct`) -- Row key. The chromosome
       and position. If `reference_genome` is defined, the type will be
@@ -897,20 +898,19 @@ def import_bgen(path,
         in the reference genome given by `reference_genome`.
     skip_invalid_loci : :obj:`bool`
         If ``True``, skip loci that are not consistent with `reference_genome`.
-    row_fields : :obj:`list` of :obj:`str`
+    _row_fields : :obj:`list` of :obj:`str`
         List of non-key row fields to create.
         Options: ``'varid'``, ``'rsid'``
 
     Returns
     -------
     :class:`.MatrixTable`
-
     """
 
     rg = reference_genome._jrep if reference_genome else None
 
     entry_set = set(entry_fields)
-    row_set = set(row_fields)
+    row_set = set(_row_fields)
 
     if contig_recoding:
         contig_recoding = tdict(tstr, tstr)._convert_to_j(contig_recoding)

--- a/python/hail/tests/test_io.py
+++ b/python/hail/tests/test_io.py
@@ -510,9 +510,9 @@ class BGENTests(unittest.TestCase):
                                             reference_genome='GRCh37')
         self.assertEqual(default_row_fields.row.dtype,
                          hl.tstruct(locus=hl.tlocus('GRCh37'),
-                                    alleles=hl.tarray(hl.tstring),
-                                    varid=hl.tstring,
-                                    rsid=hl.tstring))
+                                    alleles=hl.tarray(hl.tstr),
+                                    varid=hl.tstr,
+                                    rsid=hl.tstr))
         no_row_fields = hl.import_bgen(resource('example.8bits.bgen'),
                                        entry_fields=['dosage'],
                                        contig_recoding={'01': '1'},
@@ -520,7 +520,7 @@ class BGENTests(unittest.TestCase):
                                        row_fields=[])
         self.assertEqual(no_row_fields.row.dtype,
                          hl.tstruct(locus=hl.tlocus('GRCh37'),
-                                    alleles=hl.tarray(hl.tstring)))
+                                    alleles=hl.tarray(hl.tstr)))
         varid_only = hl.import_bgen(resource('example.8bits.bgen'),
                                     entry_fields=['dosage'],
                                     contig_recoding={'01': '1'},
@@ -528,8 +528,8 @@ class BGENTests(unittest.TestCase):
                                     row_fields=['varid'])
         self.assertEqual(varid_only.row.dtype,
                          hl.tstruct(locus=hl.tlocus('GRCh37'),
-                                    alleles=hl.tarray(hl.tstring),
-                                    varid=hl.tstring))
+                                    alleles=hl.tarray(hl.tstr),
+                                    varid=hl.tstr))
         rsid_only = hl.import_bgen(resource('example.8bits.bgen'),
                                    entry_fields=['dosage'],
                                    contig_recoding={'01': '1'},
@@ -537,8 +537,8 @@ class BGENTests(unittest.TestCase):
                                    row_fields=['rsid'])
         self.assertEqual(rsid_only.row.dtype,
                          hl.tstruct(locus=hl.tlocus('GRCh37'),
-                                    alleles=hl.tarray(hl.tstring),
-                                    varid=hl.tstring))
+                                    alleles=hl.tarray(hl.tstr),
+                                    varid=hl.tstr))
 
         self.assertTrue(default_row_fields.drop('varid')._same(rsid_only))
         self.assertTrue(default_row_fields.drop('rsid')._same(varid_only))

--- a/python/hail/tests/test_io.py
+++ b/python/hail/tests/test_io.py
@@ -511,8 +511,8 @@ class BGENTests(unittest.TestCase):
         self.assertEqual(default_row_fields.row.dtype,
                          hl.tstruct(locus=hl.tlocus('GRCh37'),
                                     alleles=hl.tarray(hl.tstr),
-                                    varid=hl.tstr,
-                                    rsid=hl.tstr))
+                                    rsid=hl.tstr,
+                                    varid=hl.tstr))
         no_row_fields = hl.import_bgen(resource('example.8bits.bgen'),
                                        entry_fields=['dosage'],
                                        contig_recoding={'01': '1'},
@@ -538,7 +538,7 @@ class BGENTests(unittest.TestCase):
         self.assertEqual(rsid_only.row.dtype,
                          hl.tstruct(locus=hl.tlocus('GRCh37'),
                                     alleles=hl.tarray(hl.tstr),
-                                    varid=hl.tstr))
+                                    rsid=hl.tstr))
 
         self.assertTrue(default_row_fields.drop('varid')._same(rsid_only))
         self.assertTrue(default_row_fields.drop('rsid')._same(varid_only))

--- a/python/hail/tests/test_io.py
+++ b/python/hail/tests/test_io.py
@@ -503,6 +503,48 @@ class BGENTests(unittest.TestCase):
             (hl.is_missing(et.dosage) & hl.is_missing(et.gp_dosage)) |
             (hl.abs(et.dosage - et.gp_dosage) < 1e-6)))
 
+    def test_import_bgen_row_fields(self):
+        default_row_fields = hl.import_bgen(resource('example.8bits.bgen'),
+                                            entry_fields=['dosage'],
+                                            contig_recoding={'01': '1'},
+                                            reference_genome='GRCh37')
+        self.assertEqual(default_row_fields.row.dtype,
+                         hl.tstruct(locus=hl.tlocus('GRCh37'),
+                                    alleles=hl.tarray(hl.tstring),
+                                    varid=hl.tstring,
+                                    rsid=hl.tstring))
+        no_row_fields = hl.import_bgen(resource('example.8bits.bgen'),
+                                       entry_fields=['dosage'],
+                                       contig_recoding={'01': '1'},
+                                       reference_genome='GRCh37',
+                                       row_fields=[])
+        self.assertEqual(no_row_fields.row.dtype,
+                         hl.tstruct(locus=hl.tlocus('GRCh37'),
+                                    alleles=hl.tarray(hl.tstring)))
+        varid_only = hl.import_bgen(resource('example.8bits.bgen'),
+                                    entry_fields=['dosage'],
+                                    contig_recoding={'01': '1'},
+                                    reference_genome='GRCh37',
+                                    row_fields=['varid'])
+        self.assertEqual(varid_only.row.dtype,
+                         hl.tstruct(locus=hl.tlocus('GRCh37'),
+                                    alleles=hl.tarray(hl.tstring),
+                                    varid=hl.tstring))
+        rsid_only = hl.import_bgen(resource('example.8bits.bgen'),
+                                   entry_fields=['dosage'],
+                                   contig_recoding={'01': '1'},
+                                   reference_genome='GRCh37',
+                                   row_fields=['rsid'])
+        self.assertEqual(rsid_only.row.dtype,
+                         hl.tstruct(locus=hl.tlocus('GRCh37'),
+                                    alleles=hl.tarray(hl.tstring),
+                                    varid=hl.tstring))
+
+        self.assertTrue(default_row_fields.drop('varid')._same(rsid_only))
+        self.assertTrue(default_row_fields.drop('rsid')._same(varid_only))
+        self.assertTrue(
+            default_row_fields.drop('varid', 'rsid')._same(no_row_fields))
+
 
 class GENTests(unittest.TestCase):
     def test_import_gen(self):

--- a/python/hail/tests/test_io.py
+++ b/python/hail/tests/test_io.py
@@ -517,7 +517,7 @@ class BGENTests(unittest.TestCase):
                                        entry_fields=['dosage'],
                                        contig_recoding={'01': '1'},
                                        reference_genome='GRCh37',
-                                       row_fields=[])
+                                       _row_fields=[])
         self.assertEqual(no_row_fields.row.dtype,
                          hl.tstruct(locus=hl.tlocus('GRCh37'),
                                     alleles=hl.tarray(hl.tstr)))
@@ -525,7 +525,7 @@ class BGENTests(unittest.TestCase):
                                     entry_fields=['dosage'],
                                     contig_recoding={'01': '1'},
                                     reference_genome='GRCh37',
-                                    row_fields=['varid'])
+                                    _row_fields=['varid'])
         self.assertEqual(varid_only.row.dtype,
                          hl.tstruct(locus=hl.tlocus('GRCh37'),
                                     alleles=hl.tarray(hl.tstr),
@@ -534,7 +534,7 @@ class BGENTests(unittest.TestCase):
                                    entry_fields=['dosage'],
                                    contig_recoding={'01': '1'},
                                    reference_genome='GRCh37',
-                                   row_fields=['rsid'])
+                                   _row_fields=['rsid'])
         self.assertEqual(rsid_only.row.dtype,
                          hl.tstruct(locus=hl.tlocus('GRCh37'),
                                     alleles=hl.tarray(hl.tstr),

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -297,12 +297,14 @@ class HailContext private(val sc: SparkContext,
     includeGT: Boolean,
     includeGP: Boolean,
     includeDosage: Boolean,
+    includeLid: Boolean,
+    includeRsid: Boolean,
     nPartitions: Option[Int] = None,
     rg: Option[ReferenceGenome] = Some(ReferenceGenome.defaultReference),
     contigRecoding: Option[Map[String, String]] = None,
     skipInvalidLoci: Boolean = false): MatrixTable = {
-    importBgens(List(file), sampleFile, includeGT, includeGP, includeDosage, nPartitions, rg,
-      contigRecoding, skipInvalidLoci)
+    importBgens(List(file), sampleFile, includeGT, includeGP, includeDosage, includeLid, includeRsid,
+      nPartitions, rg, contigRecoding, skipInvalidLoci)
   }
 
   def importBgens(files: Seq[String],
@@ -310,6 +312,8 @@ class HailContext private(val sc: SparkContext,
     includeGT: Boolean = true,
     includeGP: Boolean = true,
     includeDosage: Boolean = false,
+    includeLid: Boolean = true,
+    includeRsid: Boolean = true,
     nPartitions: Option[Int] = None,
     rg: Option[ReferenceGenome] = Some(ReferenceGenome.defaultReference),
     contigRecoding: Option[Map[String, String]] = None,
@@ -332,7 +336,7 @@ class HailContext private(val sc: SparkContext,
 
     rg.foreach(ref => contigRecoding.foreach(ref.validateContigRemap))
 
-    LoadBgen.load(this, inputs, sampleFile, includeGT: Boolean, includeGP: Boolean, includeDosage: Boolean,
+    LoadBgen.load(this, inputs, sampleFile, includeGT, includeGP, includeDosage, includeLid, includeRsid,
       nPartitions, rg, contigRecoding.getOrElse(Map.empty[String, String]), skipInvalidLoci)
   }
 

--- a/src/main/scala/is/hail/io/AbstractBinaryReader.scala
+++ b/src/main/scala/is/hail/io/AbstractBinaryReader.scala
@@ -54,5 +54,12 @@ abstract class AbstractBinaryReader {
     readString(length)
   }
 
+  def readLengthAndSkipString(lengthBytes: Int): Unit = {
+    require(lengthBytes == 2 || lengthBytes == 4)
+
+    val length = if (lengthBytes == 2) readShort() else readInt()
+    skipBytes(length)
+  }
+
   def skipBytes(lengthBytes: Long): Long
 }

--- a/src/main/scala/is/hail/io/bgen/BgenBlockReader.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenBlockReader.scala
@@ -16,6 +16,8 @@ abstract class BgenBlockReader(job: Configuration, split: FileSplit) extends Ind
   val includeGT = job.get("includeGT").toBoolean
   val includeGP = job.get("includeGP").toBoolean
   val includeDosage = job.get("includeDosage").toBoolean
+  val includeLid = job.get("includeLid").toBoolean
+  val includeRsid = job.get("includeRsid").toBoolean
 
   seekToFirstBlockInSplit(split.getStart)
 
@@ -36,7 +38,7 @@ abstract class BgenBlockReader(job: Configuration, split: FileSplit) extends Ind
 
 class BgenBlockReaderV12(job: Configuration, split: FileSplit) extends BgenBlockReader(job, split) {
   override def createValue(): BgenRecordV12 =
-    new BgenRecordV12(bState.compressed, bState.nSamples, includeGT, includeGP, includeDosage, bfis, end)
+    new BgenRecordV12(bState.compressed, bState.nSamples, includeGT, includeGP, includeDosage, includeLid, includeRsid, bfis, end)
 
   override def next(key: LongWritable, value: BgenRecordV12): Boolean = {
     value.advance()

--- a/src/main/scala/is/hail/io/bgen/BgenRecord.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenRecord.scala
@@ -11,6 +11,8 @@ class BgenRecordV12 (
   includeGT: Boolean,
   includeGP: Boolean,
   includeDosage: Boolean,
+  includeLid: Boolean,
+  includeRsid: Boolean,
   bfis: HadoopFSDataBinaryReader,
   end: Long
 ) {
@@ -28,6 +30,10 @@ class BgenRecordV12 (
 
   def getAlleles: Array[String] = alleles
 
+  def getRsid: String = rsid
+
+  def getLid: String = lid
+
   private[this] def includeAnyEntryFields =
     includeGT || includeGP || includeDosage
 
@@ -35,8 +41,14 @@ class BgenRecordV12 (
     if (bfis.getPosition >= end)
       return false
 
-    lid = bfis.readLengthAndString(2)
-    rsid = bfis.readLengthAndString(2)
+    if (includeLid)
+      lid = bfis.readLengthAndString(2)
+    else
+      bfis.readLengthAndSkipString(2)
+    if (includeRsid)
+      rsid = bfis.readLengthAndString(2)
+    else
+      bfis.readLengthAndSkipString(2)
     contig = bfis.readLengthAndString(2)
     position = bfis.readInt()
 

--- a/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -86,11 +86,13 @@ object LoadBgen {
     info(s"Number of samples in BGEN files: $nSamples")
     info(s"Number of variants across all BGEN files: $nVariants")
 
+    val lidType = TString()
+    val rsidType = TString()
     val rowFields = Array(
       (true, "locus" -> TLocus.schemaFromRG(rg)),
       (true, "alleles" -> TArray(TString())),
-      (includeRsid, "rsid" -> TString()),
-      (includeLid, "varid" -> TString()))
+      (includeRsid, "rsid" -> rsidType),
+      (includeLid, "varid" -> lidType))
       .withFilter(_._1).map(_._2)
 
     val signature = TStruct(rowFields:_*)
@@ -178,9 +180,9 @@ object LoadBgen {
           rvb.endArray()
 
           if (includeRsid)
-            rvb.addAnnotation(rowType.types(2), record.getRsid)
+            rvb.addAnnotation(rsidType, record.getRsid)
           if (includeLid)
-            rvb.addAnnotation(rowType.types(3), record.getLid)
+            rvb.addAnnotation(lidType, record.getLid)
           record.getValue(rvb) // gs
 
           rvb.endStruct()


### PR DESCRIPTION
This option controls parsing and loading of the `rsid` and `varid`
BGEN row fields. When (in a future PR) the reader does not decompress
the genotypes (nor decode them), these row field imports become
a substantial portion of the time necessary to load just the row
keys.

broken out from: https://github.com/hail-is/hail/pull/3727