### PR TITLE
avoid copying data when not reading genotypes

### DIFF
--- a/src/main/scala/is/hail/io/bgen/BgenBlockReader.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenBlockReader.scala
@@ -7,7 +7,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.LongWritable
 import org.apache.hadoop.mapred.FileSplit
 
-abstract class BgenBlockReader[T <: BgenRecord](job: Configuration, split: FileSplit) extends IndexedBinaryBlockReader[T](job, split) {
+abstract class BgenBlockReader(job: Configuration, split: FileSplit) extends IndexedBinaryBlockReader[BgenRecordV12](job, split) {
   val file = split.getPath
   val bState = LoadBgen.readState(bfis)
   val indexPath = file + ".idx"
@@ -19,7 +19,7 @@ abstract class BgenBlockReader[T <: BgenRecord](job: Configuration, split: FileS
 
   seekToFirstBlockInSplit(split.getStart)
 
-  override def createValue(): T
+  override def createValue(): BgenRecordV12
 
   def seekToFirstBlockInSplit(start: Long) {
     pos = btree.queryIndex(start) match {
@@ -31,62 +31,14 @@ abstract class BgenBlockReader[T <: BgenRecord](job: Configuration, split: FileS
     bfis.seek(pos)
   }
 
-  def next(key: LongWritable, value: T): Boolean
+  def next(key: LongWritable, value: BgenRecordV12): Boolean
 }
 
-class BgenBlockReaderV12(job: Configuration, split: FileSplit) extends BgenBlockReader[BgenRecordV12](job, split) {
+class BgenBlockReaderV12(job: Configuration, split: FileSplit) extends BgenBlockReader(job, split) {
   override def createValue(): BgenRecordV12 =
-    new BgenRecordV12(bState.compressed, bState.nSamples, includeGT, includeGP, includeDosage)
+    new BgenRecordV12(bState.compressed, bState.nSamples, includeGT, includeGP, includeDosage, bfis, end)
 
   override def next(key: LongWritable, value: BgenRecordV12): Boolean = {
-    if (pos >= end)
-      false
-    else {
-      val lid = bfis.readLengthAndString(2)
-      val rsid = bfis.readLengthAndString(2)
-      val chr = bfis.readLengthAndString(2)
-      val position = bfis.readInt()
-
-      val nAlleles = bfis.readShort()
-      if (nAlleles < 2)
-        fatal(s"Number of alleles must be greater than or equal to 2. Found $nAlleles alleles for variant '$lid'")
-      val alleles = new Array[String](nAlleles)
-
-      val ref = bfis.readLengthAndString(4)
-      alleles(0) = ref
-
-      var aIdx = 1
-      while (aIdx < nAlleles) {
-        alleles(aIdx) = bfis.readLengthAndString(4)
-        aIdx += 1
-      }
-
-      val recodedChr = chr match {
-        case "23" => "X"
-        case "24" => "Y"
-        case "25" => "X"
-        case "26" => "MT"
-        case x => x
-      }
-
-      val variantInfo = (recodedChr, position, alleles)
-
-      val dataSize = bfis.readInt()
-
-      val (uncompressedSize, bytesInput) =
-        if (bState.compressed)
-          (bfis.readInt(), bfis.readBytes(dataSize - 4))
-        else
-          (dataSize, bfis.readBytes(dataSize))
-
-      value.setKey(variantInfo)
-      value.setAnnotation(Annotation(rsid, lid))
-      value.setSerializedValue(bytesInput)
-      value.setExpectedDataSize(uncompressedSize)
-      value.setExpectedNumAlleles(nAlleles)
-
-      pos = bfis.getPosition
-      true
-    }
+    value.advance()
   }
 }

--- a/src/main/scala/is/hail/io/bgen/BgenRecord.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenRecord.scala
@@ -1,149 +1,203 @@
 package is.hail.io.bgen
 
 import is.hail.annotations._
-import is.hail.io.{ByteArrayReader, KeySerializedValueRecord}
+import is.hail.io._
 import is.hail.utils._
 import is.hail.variant.{Call2, Genotype}
 
-abstract class BgenRecord extends KeySerializedValueRecord[(String, Int, Array[String])] {
-  var ann: Annotation = _
+class BgenRecordV12 (
+  compressed: Boolean,
+  nSamples: Int,
+  includeGT: Boolean,
+  includeGP: Boolean,
+  includeDosage: Boolean,
+  bfis: HadoopFSDataBinaryReader,
+  end: Long
+) {
+  private[this] var rsid: String = _
+  private[this] var lid: String = _
+  private[this] var contig: String = _
+  private[this] var position: Int = _
+  private[this] var alleles: Array[String] = _
+  private[this] var data: Array[Byte] = _
+  private[this] var dataSize: Int = 0
 
-  def setAnnotation(ann: Annotation) {
-    this.ann = ann
-  }
+  def getContig: String = contig
 
-  def getAnnotation: Annotation = ann
+  def getPosition: Int = position
 
-  override def getValue(rvb: RegionValueBuilder): Unit
-}
+  def getAlleles: Array[String] = alleles
 
-class BgenRecordV12(compressed: Boolean, nSamples: Int,
-  includeGT: Boolean, includeGP: Boolean, includeDosage: Boolean) extends BgenRecord {
-  var expectedDataSize: Int = _
-  var expectedNumAlleles: Int = _
+  private[this] def includeAnyEntryFields =
+    includeGT || includeGP || includeDosage
 
-  def setExpectedDataSize(size: Int) {
-    this.expectedDataSize = size
-  }
+  def advance(): Boolean = {
+    if (bfis.getPosition >= end)
+      return false
 
-  def setExpectedNumAlleles(n: Int) {
-    this.expectedNumAlleles = n
-  }
+    lid = bfis.readLengthAndString(2)
+    rsid = bfis.readLengthAndString(2)
+    contig = bfis.readLengthAndString(2)
+    position = bfis.readInt()
 
-  override def getValue(rvb: RegionValueBuilder) {
-    require(input != null, "called getValue before serialized value was set")
-
-    val a = if (compressed) decompress(input, expectedDataSize) else input
-    val reader = new ByteArrayReader(a)
-
-    val nRow = reader.readInt()
-    if (nRow != nSamples)
-      fatal("row nSamples is not equal to header nSamples $nRow, $nSamples")
-
-    val nAlleles = reader.readShort()
-    if (nAlleles != expectedNumAlleles)
-      fatal(s"""Value for `nAlleles' in genotype probability data storage is
-               |not equal to value in variant identifying data. Expected
-               |$expectedNumAlleles but found $nAlleles.""".stripMargin)
+    val nAlleles = bfis.readShort()
     if (nAlleles != 2)
       fatal(s"Only biallelic variants supported, found variant with $nAlleles")
 
-    val minPloidy = reader.read()
-    val maxPloidy = reader.read()
+    alleles = new Array[String](nAlleles)
 
-    if (minPloidy != 2 || maxPloidy != 2)
-      fatal(s"Hail only supports diploid genotypes. Found min ploidy equals `$minPloidy' and max ploidy equals `$maxPloidy'.")
+    val ref = bfis.readLengthAndString(4)
+    alleles(0) = ref
 
-    var i = 0
-    while (i < nSamples) {
-      val ploidy = reader.read()
-      if ((ploidy & 0x3f) != 2)
-        fatal(s"Ploidy value must equal to 2. Found $ploidy.")
-      i += 1
+    var aIdx = 1
+    while (aIdx < nAlleles) {
+      alleles(aIdx) = bfis.readLengthAndString(4)
+      aIdx += 1
     }
-    if (i != nSamples)
-      fatal(s"Number of ploidy values `$i' does not equal the number of samples `$nSamples'.")
 
-    val phase = reader.read()
-    if (phase != 0 && phase != 1)
-      fatal(s"Value for phase must be 0 or 1. Found $phase.")
-    val isPhased = phase == 1
+    val recodedContig = contig match {
+      case "23" => "X"
+      case "24" => "Y"
+      case "25" => "X"
+      case "26" => "MT"
+      case x => x
+    }
 
-    if (isPhased)
-      fatal("Hail does not support phased genotypes.")
+    dataSize = bfis.readInt()
 
-    val nBitsPerProb = reader.read()
-    if (nBitsPerProb < 1 || nBitsPerProb > 32)
-      fatal(s"Value for nBits must be between 1 and 32 inclusive. Found $nBitsPerProb.")
-    if (nBitsPerProb != 8)
-      fatal(s"Only 8-bit probabilities supported, found $nBitsPerProb")
+    if (includeAnyEntryFields) {
+      data = if (compressed) {
+        val expectedDataSize = bfis.readInt()
+        val input = bfis.readBytes(dataSize - 4)
+        decompress(input, expectedDataSize)
+      } else {
+        bfis.readBytes(dataSize)
+      }
+      val reader = new ByteArrayReader(data)
 
-    val nGenotypes = triangle(nAlleles)
+      val nRow = reader.readInt()
+      if (nRow != nSamples)
+        fatal("row nSamples is not equal to header nSamples $nRow, $nSamples")
 
-    val nExpectedBytesProbs = (nSamples * (nGenotypes - 1) * nBitsPerProb + 7) / 8
-    if (reader.length != nExpectedBytesProbs + nSamples + 10)
-      fatal(s"""Number of uncompressed bytes `${ reader.length }' does not
-               |match the expected size `$nExpectedBytesProbs'.""".stripMargin)
+      val nAlleles2 = reader.readShort()
+      if (nAlleles == nAlleles2)
+        fatal(s"""Value for `nAlleles' in genotype probability data storage is
+                 |not equal to value in variant identifying data. Expected
+                 |$nAlleles but found $nAlleles2 at $lid.""".stripMargin)
 
+      val minPloidy = reader.read()
+      val maxPloidy = reader.read()
+
+      if (minPloidy != 2 || maxPloidy != 2)
+        fatal(s"Hail only supports diploid genotypes. Found min ploidy equals `$minPloidy' and max ploidy equals `$maxPloidy'.")
+
+      var i = 0
+      while (i < nSamples) {
+        val ploidy = reader.read()
+        if ((ploidy & 0x3f) != 2)
+          fatal(s"Ploidy value must equal to 2. Found $ploidy.")
+        i += 1
+      }
+
+      val phase = reader.read()
+      if (phase != 0 && phase != 1)
+        fatal(s"Value for phase must be 0 or 1. Found $phase.")
+      val isPhased = phase == 1
+
+      if (isPhased)
+        fatal("Hail does not support phased genotypes.")
+
+      val nBitsPerProb = reader.read()
+      if (nBitsPerProb < 1 || nBitsPerProb > 32)
+        fatal(s"Value for nBits must be between 1 and 32 inclusive. Found $nBitsPerProb.")
+      if (nBitsPerProb != 8)
+        fatal(s"Only 8-bit probabilities supported, found $nBitsPerProb")
+
+      val nGenotypes = triangle(nAlleles)
+
+      val nExpectedBytesProbs = (nSamples * (nGenotypes - 1) * nBitsPerProb + 7) / 8
+      if (reader.length != nExpectedBytesProbs + nSamples + 10)
+        fatal(s"""Number of uncompressed bytes `${ reader.length }' does not
+                 |match the expected size `$nExpectedBytesProbs'.""".stripMargin)
+    } else {
+      bfis.skipBytes(dataSize)
+    }
+
+    return true
+  }
+
+  def getValue(rvb: RegionValueBuilder) {
     rvb.startArray(nSamples) // gs
-    val c0 = Call2.fromUnphasedDiploidGtIndex(0)
-    val c1 = Call2.fromUnphasedDiploidGtIndex(1)
-    val c2 = Call2.fromUnphasedDiploidGtIndex(2)
+    if (includeAnyEntryFields) {
+      val c0 = Call2.fromUnphasedDiploidGtIndex(0)
+      val c1 = Call2.fromUnphasedDiploidGtIndex(1)
+      val c2 = Call2.fromUnphasedDiploidGtIndex(2)
 
-    i = 0
-    while (i < nSamples) {
-      val sampleMissing = (a(8 + i) & 0x80) != 0
-      if (sampleMissing)
-        rvb.setMissing()
-      else {
-        rvb.startStruct() // g
+      var i = 0
+      while (i < nSamples) {
+        val sampleMissing = (data(8 + i) & 0x80) != 0
+        if (sampleMissing)
+          rvb.setMissing()
+        else {
+          rvb.startStruct() // g
 
-        val off = nSamples + 10 + 2 * i
-        val d0 = a(off) & 0xff
-        val d1 = a(off + 1) & 0xff
-        val d2 = 255 - d0 - d1
+          val off = nSamples + 10 + 2 * i
+          val d0 = data(off) & 0xff
+          val d1 = data(off + 1) & 0xff
+          val d2 = 255 - d0 - d1
 
-        if (includeGT) {
-          if (d0 > d1) {
-            if (d0 > d2)
-              rvb.addInt(c0)
-            else if (d2 > d0)
-              rvb.addInt(c2)
-            else {
-              // d0 == d2
-              rvb.setMissing()
-            }
-          } else {
-            // d0 <= d1
-            if (d2 > d1)
-              rvb.addInt(c2)
-            else {
-              // d2 <= d1
-              if (d1 == d0 || d1 == d2)
+          if (includeGT) {
+            if (d0 > d1) {
+              if (d0 > d2)
+                rvb.addInt(c0)
+              else if (d2 > d0)
+                rvb.addInt(c2)
+              else {
+                // d0 == d2
                 rvb.setMissing()
-              else
-                rvb.addInt(c1)
+              }
+            } else {
+              // d0 <= d1
+              if (d2 > d1)
+                rvb.addInt(c2)
+              else {
+                // d2 <= d1
+                if (d1 == d0 || d1 == d2)
+                  rvb.setMissing()
+                else
+                  rvb.addInt(c1)
+              }
             }
           }
-        }
 
-        if (includeGP) {
-          rvb.startArray(3) // GP
-          rvb.addDouble(d0 / 255.0)
-          rvb.addDouble(d1 / 255.0)
-          rvb.addDouble(d2 / 255.0)
-          rvb.endArray()
-        }
+          if (includeGP) {
+            rvb.startArray(3) // GP
+            rvb.addDouble(d0 / 255.0)
+            rvb.addDouble(d1 / 255.0)
+            rvb.addDouble(d2 / 255.0)
+            rvb.endArray()
+          }
 
-        if (includeDosage) {
-          val dosage = (d1 + (d2 << 1)) / 255.0
-          rvb.addDouble(dosage)
-        }
+          if (includeDosage) {
+            val dosage = (d1 + (d2 << 1)) / 255.0
+            rvb.addDouble(dosage)
+          }
 
-        rvb.endStruct() // g
+          rvb.endStruct() // g
+        }
+        i += 1
       }
-      i += 1
+    } else {
+      var i = 0
+      while (i < nSamples) {
+        rvb.startStruct() // g
+        rvb.endStruct()
+        i += 1
+      }
     }
     rvb.endArray()
   }
+
+  def getAnnotation(): Annotation =
+    Annotation(rsid, lid)
 }

--- a/src/main/scala/is/hail/io/bgen/BgenRecord.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenRecord.scala
@@ -188,12 +188,8 @@ class BgenRecordV12 (
         i += 1
       }
     } else {
-      var i = 0
-      while (i < nSamples) {
-        rvb.startStruct() // g
-        rvb.endStruct()
-        i += 1
-      }
+      assert(rvb.currentType().byteSize == 0)
+      rvb.unsafeAdvance(nSamples)
     }
     rvb.endArray()
   }

--- a/src/main/scala/is/hail/io/bgen/BgenRecord.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenRecord.scala
@@ -80,7 +80,7 @@ class BgenRecordV12 (
         fatal("row nSamples is not equal to header nSamples $nRow, $nSamples")
 
       val nAlleles2 = reader.readShort()
-      if (nAlleles == nAlleles2)
+      if (nAlleles != nAlleles2)
         fatal(s"""Value for `nAlleles' in genotype probability data storage is
                  |not equal to value in variant identifying data. Expected
                  |$nAlleles but found $nAlleles2 at $lid.""".stripMargin)


### PR DESCRIPTION
@tpoterba you were in here recently for performance so your eyes are appreciated.

I simplified things a bit and localized almost all the parsing logic to `BgenRecord`. The contract for `advance` is that it is always called when `bfis` is pointing at the start of a record _or_ at or past the `end`. Advance will return the position to the start of a record or at or past the `end`. It returns true if there was a new record found. False otherwise.

I avoided a couple allocating patterns.

The rest of the diffs are copy pastes and some indentation changes.