### PR TITLE
remove useIR

### DIFF
--- a/python/hail/context.py
+++ b/python/hail/context.py
@@ -21,12 +21,11 @@ class HailContext(object):
                       min_block_size=int,
                       branching_factor=int,
                       tmp_dir=nullable(str),
-                      default_reference=str,
-                      force_ir=bool)
+                      default_reference=str)
     def __init__(self, sc=None, app_name="Hail", master=None, local='local[*]',
                  log='hail.log', quiet=False, append=False,
                  min_block_size=1, branching_factor=50, tmp_dir=None,
-                 default_reference="GRCh37", force_ir=False):
+                 default_reference="GRCh37"):
 
         if Env._hc:
             raise FatalError('Hail has already been initialized, restart session '
@@ -51,7 +50,7 @@ class HailContext(object):
         # to be routed through Python separately.
         self._jhc = self._hail.HailContext.apply(
             jsc, app_name, joption(master), local, log, True, append,
-            min_block_size, branching_factor, tmp_dir, force_ir)
+            min_block_size, branching_factor, tmp_dir)
 
         self._jsc = self._jhc.sc()
         self.sc = sc if sc else SparkContext(gateway=self._gateway, jsc=self._jvm.JavaSparkContext(self._jsc))
@@ -119,12 +118,11 @@ class HailContext(object):
            min_block_size=int,
            branching_factor=int,
            tmp_dir=str,
-           default_reference=enumeration('GRCh37', 'GRCh38'),
-           force_ir=bool)
+           default_reference=enumeration('GRCh37', 'GRCh38'))
 def init(sc=None, app_name='Hail', master=None, local='local[*]',
              log='hail.log', quiet=False, append=False,
              min_block_size=1, branching_factor=50, tmp_dir='/tmp',
-             default_reference='GRCh37', force_ir=False):
+             default_reference='GRCh37'):
     """Initialize Hail and Spark.
 
     Parameters
@@ -157,7 +155,7 @@ def init(sc=None, app_name='Hail', master=None, local='local[*]',
     """
     HailContext(sc, app_name, master, local, log, quiet, append,
                 min_block_size, branching_factor, tmp_dir,
-                default_reference, force_ir)
+                default_reference)
 
 def stop():
     """Stop the currently running Hail session."""

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -147,8 +147,7 @@ object HailContext {
     append: Boolean = false,
     minBlockSize: Long = 1L,
     branchingFactor: Int = 50,
-    tmpDir: String = "/tmp",
-    forceIR: Boolean = false): HailContext = {
+    tmpDir: String = "/tmp"): HailContext = {
     require(theContext == null)
 
     val javaVersion = raw"(\d+)\.(\d+)\.(\d+).*".r
@@ -193,7 +192,7 @@ object HailContext {
 
     val sqlContext = new org.apache.spark.sql.SQLContext(sparkContext)
     val hailTempDir = TempDir.createTempDir(tmpDir, sparkContext.hadoopConfiguration)
-    val hc = new HailContext(sparkContext, sqlContext, hailTempDir, branchingFactor, forceIR)
+    val hc = new HailContext(sparkContext, sqlContext, hailTempDir, branchingFactor)
     sparkContext.uiWebUrl.foreach(ui => info(s"SparkUI: $ui"))
 
     info(s"Running Hail version ${ hc.version }")
@@ -269,8 +268,7 @@ object HailContext {
 class HailContext private(val sc: SparkContext,
   val sqlContext: SQLContext,
   val tmpDir: String,
-  val branchingFactor: Int,
-  val forceIR: Boolean) {
+  val branchingFactor: Int) {
   val hadoopConf: hadoop.conf.Configuration = sc.hadoopConfiguration
 
   def version: String = is.hail.HAIL_PRETTY_VERSION


### PR DESCRIPTION
I believe useIR is no longer necessary.  It was meant to handle copying large globals/col values (just fixed by https://github.com/hail-is/hail/pull/3660) and blowing out the JVM bytecode limit (long since fixed).  @tpoterba @catoverdrive am I missing anything else?