### PR TITLE
Fix Aggregable IR FlatMap

### DIFF
--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -850,7 +850,7 @@ case class ApplyMethod(posn: Position, lhs: AST, method: String, args: Array[AST
           rx <- lhs.toAggIR(agg, { lhsx =>
             val t = -lhsx.typ.asInstanceOf[TContainer].elementType
             val v = ir.genUID()
-            ir.ArrayFor(ir.Let(name, lhsx, bodyx),
+            ir.ArrayFor(ir.ToArray(ir.Let(name, lhsx, bodyx)),
               v,
               cont(ir.Ref(v, t)))
           })


### PR DESCRIPTION
I ran into an error on another branch where ArrayFor doesn't work if the object being aggregated is a Set. I'm assuming here the ToArray is free for all container objects.