### PR TITLE
add dict[key], remove dict.get without default from Scala

### DIFF
--- a/src/main/scala/is/hail/expr/ir/functions/DictFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/DictFunctions.scala
@@ -42,6 +42,7 @@ object DictFunctions extends RegistryFunctions {
     registerIR("get", tdict, tv("key"), tv("value"))(get)
     registerIR("get", tdict, tv("key")) { (d, k) =>
       get(d, k, NA(types.coerce[TDict](d.typ).valueType))
+    }
 
     registerIR("[]", tdict, tv("key")) { (d, k) =>
       val vtype = types.coerce[TBaseStruct](types.coerce[TContainer](d.typ).elementType).types(1)

--- a/src/main/scala/is/hail/expr/ir/functions/DictFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/DictFunctions.scala
@@ -21,7 +21,7 @@ object DictFunctions extends RegistryFunctions {
       LowerBoundOnOrderedCollection(dict, key, onKey=true),
       If(IsNA(dict),
         NA(default.typ),
-        If(ApplyComparisonOp(EQWithNA(key.typ), GetField(ArrayRef(ToArray(dict), i), "key"), key),
+        If(ApplyComparisonOp(EQ(key.typ), GetField(ArrayRef(ToArray(dict), i), "key"), key),
           GetField(ArrayRef(ToArray(dict), i), "value"),
           default)))
   }

--- a/src/main/scala/is/hail/expr/ir/functions/DictFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/DictFunctions.scala
@@ -40,9 +40,13 @@ object DictFunctions extends RegistryFunctions {
     registerIR("contains", tdict, tv("key"))(contains)
 
     registerIR("get", tdict, tv("key"), tv("value"))(get)
-
     registerIR("get", tdict, tv("key")) { (d, k) =>
       get(d, k, NA(types.coerce[TDict](d.typ).valueType))
+
+    registerIR("[]", tdict, tv("key")) { (d, k) =>
+      val vtype = types.coerce[TBaseStruct](types.coerce[TContainer](d.typ).elementType).types(1)
+      val errormsg = "Key not found in dictionary."
+      get(d, k, Die(errormsg, vtype))
     }
 
     registerIR("dictToArray", tdict) { d =>

--- a/src/test/scala/is/hail/expr/ir/DictFunctionsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/DictFunctionsSuite.scala
@@ -90,18 +90,18 @@ class DictFunctionsSuite extends TestNGSuite {
   }
 
   @Test def dictGet() {
-    val d = IRDict((1, 3), (2, 7), (null, 1), (3, null))
+    val d = IRDict((1, 3), (2, 7), (3, null))
     val na = NA(TInt32())
     assertEvalsTo(invoke("get", NA(TDict(TInt32(), TInt32())), 1, na), null)
     assertEvalsTo(invoke("get", d, 1, na), 3)
     assertEvalsTo(invoke("get", d, 2, 50), 7)
-    assertEvalsTo(invoke("get", d, na, 50), 1)
+    assertEvalsTo(invoke("get", d, na, 50), null)
     assertEvalsTo(invoke("get", d, 3, 50), null)
     assertEvalsTo(invoke("get", d, 100, 50), 50)
     assertEvalsTo(invoke("get", d, 100, na), null)
 
     assertEvalsTo(invoke("[]", d, 1), 3)
-    assertEvalsTo(invoke("[]", d, na), 1)
+    assertEvalsTo(invoke("[]", d, na), null)
     assertEvalsTo(invoke("[]", d, 3), null)
     assertFatal(invoke("[]", d, 100), "dictionary")
   }

--- a/src/test/scala/is/hail/expr/ir/DictFunctionsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/DictFunctionsSuite.scala
@@ -1,7 +1,9 @@
 package is.hail.expr.ir
 
+import is.hail.utils._
 import is.hail.TestUtils._
 import is.hail.expr.ir.TestUtils._
+import is.hail.expr.types.{TDict, TInt32}
 import org.apache.spark.sql.Row
 import org.testng.annotations.{DataProvider, Test}
 import org.scalatest.testng.TestNGSuite
@@ -85,5 +87,22 @@ class DictFunctionsSuite extends TestNGSuite {
     keys: IndexedSeq[Integer],
     values: IndexedSeq[Integer]) {
     assertEvalsTo(invoke("values", toIRDict(a)), values)
+  }
+
+  @Test def dictGet() {
+    val d = IRDict((1, 3), (2, 7), (null, 1), (3, null))
+    val na = NA(TInt32())
+    assertEvalsTo(invoke("get", NA(TDict(TInt32(), TInt32())), 1, na), null)
+    assertEvalsTo(invoke("get", d, 1, na), 3)
+    assertEvalsTo(invoke("get", d, 2, 50), 7)
+    assertEvalsTo(invoke("get", d, na, 50), 1)
+    assertEvalsTo(invoke("get", d, 3, 50), null)
+    assertEvalsTo(invoke("get", d, 100, 50), 50)
+    assertEvalsTo(invoke("get", d, 100, na), null)
+
+    assertEvalsTo(invoke("[]", d, 1), 3)
+    assertEvalsTo(invoke("[]", d, na), 1)
+    assertEvalsTo(invoke("[]", d, 3), null)
+    assertFatal(invoke("[]", d, 100), "dictionary")
   }
 }

--- a/src/test/scala/is/hail/expr/ir/DictFunctionsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/DictFunctionsSuite.scala
@@ -95,14 +95,15 @@ class DictFunctionsSuite extends TestNGSuite {
     assertEvalsTo(invoke("get", NA(TDict(TInt32(), TInt32())), 1, na), null)
     assertEvalsTo(invoke("get", d, 1, na), 3)
     assertEvalsTo(invoke("get", d, 2, 50), 7)
-    assertEvalsTo(invoke("get", d, na, 50), null)
     assertEvalsTo(invoke("get", d, 3, 50), null)
     assertEvalsTo(invoke("get", d, 100, 50), 50)
     assertEvalsTo(invoke("get", d, 100, na), null)
 
     assertEvalsTo(invoke("[]", d, 1), 3)
-    assertEvalsTo(invoke("[]", d, na), null)
     assertEvalsTo(invoke("[]", d, 3), null)
     assertFatal(invoke("[]", d, 100), "dictionary")
+
+    assertEvalsTo(invoke("get", d, na, 50), null)
+    assertEvalsTo(invoke("[]", d, na), null)
   }
 }

--- a/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -186,22 +186,6 @@ class IRSuite extends TestNGSuite {
       false)
   }
 
-  @Test def testDictGet() {
-    val t = TDict(TInt32(), TString())
-    assertEvalsTo(invoke("get", NA(t), I32(2)), null)
-
-    val d = Map(1 -> "a", 2 -> null, (null, "c"))
-    assertEvalsTo(invoke("get", In(0, t), NA(TInt32())),
-      FastIndexedSeq((d, t)),
-      "c")
-    assertEvalsTo(invoke("get", In(0, t), I32(2)),
-      FastIndexedSeq((d, t)),
-      null)
-    assertEvalsTo(invoke("get", In(0, t), I32(0)),
-      FastIndexedSeq((d, t)),
-      null)
-  }
-
   @Test def testArrayMap() {
     val naa = NA(TArray(TInt32()))
     val a = MakeArray(Seq(I32(3), NA(TInt32()), I32(7)), TArray(TInt32()))

--- a/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -242,7 +242,7 @@ class OrderingSuite extends TestNGSuite {
   @Test def testDictGetOnRandomDict() {
     val compareGen = Gen.zip(Type.genArb, Type.genArb).flatMap {
       case (k, v) =>
-        Gen.zip(Gen.const(TDict(k, v)), TDict(k, v).genNonmissingValue, k.genValue)
+        Gen.zip(Gen.const(TDict(k, v)), TDict(k, v).genNonmissingValue, k.genNonmissingValue)
     }
     val p = Prop.forAll(compareGen) { case (tdict: TDict, dict: Map[Any, Any] @unchecked, testKey1) =>
       val telt = coerce[TBaseStruct](tdict.elementType)

--- a/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -4,6 +4,8 @@ import is.hail.annotations._
 import is.hail.check.{Gen, Prop}
 import is.hail.asm4s._
 import is.hail.expr.types._
+import is.hail.expr.ir.TestUtils._
+import is.hail.TestUtils._
 import is.hail.utils._
 import org.apache.spark.sql.Row
 import org.scalatest.testng.TestNGSuite
@@ -245,24 +247,20 @@ class OrderingSuite extends TestNGSuite {
         Gen.zip(Gen.const(TDict(k, v)), TDict(k, v).genNonmissingValue, k.genNonmissingValue)
     }
     val p = Prop.forAll(compareGen) { case (tdict: TDict, dict: Map[Any, Any] @unchecked, testKey1) =>
-      val telt = coerce[TBaseStruct](tdict.elementType)
+      assertEvalsTo(invoke("get", In(0, tdict), In(1, -tdict.keyType)),
+        IndexedSeq(dict -> tdict,
+          testKey1 -> -tdict.keyType),
+        dict.getOrElse(testKey1, null))
 
-      val ir = { irs: Seq[IR] => invoke("get", irs(0), irs(1)) }
-      val dictgetF = getCompiledFunction(ir, tdict, tdict.keyType, -tdict.valueType)
-
-      Region.scoped { region =>
-        if (dict.nonEmpty) {
-          val testKey2 = dict.keys.toSeq.head
-          val expected2 = dict(testKey2)
-          val actual2 = dictgetF(region, Seq(dict, testKey2))
-          assert(expected2 == actual2)
-        }
-
-        val expected1 = dict.getOrElse(testKey1, null)
-        val actual1 = dictgetF(region, Seq(dict, testKey1))
-
-        expected1 == actual1
+      if (dict.nonEmpty) {
+        val testKey2 = dict.keys.toSeq.head
+        val expected2 = if (testKey2 == null) null else dict(testKey2)
+        assertEvalsTo(invoke("get", In(0, tdict), In(1, -tdict.keyType)),
+          IndexedSeq(dict -> tdict,
+            testKey2 -> -tdict.keyType),
+          expected2)
       }
+      true
     }
     p.check()
   }


### PR DESCRIPTION
(actually, I put `dict.get(key)` back in since it's used in python join stuff also.)