### PR TITLE
Type.codeOrdering can compare across types

### DIFF
--- a/src/main/scala/is/hail/annotations/CodeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/CodeOrdering.scala
@@ -20,31 +20,31 @@ object CodeOrdering {
 
   type F[R] = (Code[Region], (Code[Boolean], Code[_]), Code[Region], (Code[Boolean], Code[_])) => Code[R]
 
-  def rowOrdering(t: TBaseStruct, mb: EmitMethodBuilder): CodeOrdering = new CodeOrdering {
+  def rowOrdering(t1: TBaseStruct, t2: TBaseStruct, mb: EmitMethodBuilder): CodeOrdering = new CodeOrdering {
     type T = Long
-
-    val orderings: Array[CodeOrdering] = t.types.map(_.codeOrdering(mb))
+    val orderings: Array[CodeOrdering] = t1.types.zip(t2.types).map{ case (t1, t2) => t1.codeOrdering(mb, t2) }
 
     val m1: LocalRef[Boolean] = mb.newLocal[Boolean]
     val m2: LocalRef[Boolean] = mb.newLocal[Boolean]
 
-    val v1s: Array[LocalRef[_]] = t.types.map(tf => mb.newLocal(ir.typeToTypeInfo(tf)))
-    val v2s: Array[LocalRef[_]] = t.types.map(tf => mb.newLocal(ir.typeToTypeInfo(tf)))
+    val v1s: Array[LocalRef[_]] = t1.types.map(tf => mb.newLocal(ir.typeToTypeInfo(tf)))
+    val v2s: Array[LocalRef[_]] = t2.types.map(tf => mb.newLocal(ir.typeToTypeInfo(tf)))
 
     def setup(i: Int)(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long], missingGreatest: Boolean): Code[Unit] = {
-      val tf = t.types(i)
+      val tf1 = t1.types(i)
+      val tf2 = t2.types(i)
       Code(
-        m1 := t.isFieldMissing(rx, x, i),
-        m2 := t.isFieldMissing(ry, y, i),
-        v1s(i).storeAny(m1.mux(ir.defaultValue(tf), rx.loadIRIntermediate(tf)(t.fieldOffset(x, i)))),
-        v2s(i).storeAny(m2.mux(ir.defaultValue(tf), ry.loadIRIntermediate(tf)(t.fieldOffset(y, i)))))
+        m1 := t1.isFieldMissing(rx, x, i),
+        m2 := t2.isFieldMissing(ry, y, i),
+        v1s(i).storeAny(m1.mux(ir.defaultValue(tf1), rx.loadIRIntermediate(tf1)(t1.fieldOffset(x, i)))),
+        v2s(i).storeAny(m2.mux(ir.defaultValue(tf2), ry.loadIRIntermediate(tf2)(t2.fieldOffset(y, i)))))
     }
 
     override def compareNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long], missingGreatest: Boolean): Code[Int] = {
       val cmp = mb.newLocal[Int]
 
-      val c = Array.tabulate(t.size) { i =>
-        val mbcmp = mb.getCodeOrdering[Int](t.types(i), CodeOrdering.compare, missingGreatest)
+      val c = Array.tabulate(t1.size) { i =>
+        val mbcmp = mb.getCodeOrdering[Int](t1.types(i), t2.types(i), CodeOrdering.compare, missingGreatest)
         Code(setup(i)(rx, x, ry, y, missingGreatest),
           mbcmp(rx, (m1, v1s(i)), ry, (m2, v2s(i))))
       }.foldRight[Code[Int]](cmp.load()) { (ci, cont) => cmp.ceq(0).mux(Code(cmp := ci, cont), cmp) }
@@ -53,81 +53,81 @@ object CodeOrdering {
     }
 
     override def ltNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long], missingGreatest: Boolean): Code[Boolean] = {
-      Array.tabulate(t.size) { i =>
-        val mblt = mb.getCodeOrdering[Boolean](t.types(i), CodeOrdering.lt, missingGreatest)
-        val mbequiv = mb.getCodeOrdering[Boolean](t.types(i), CodeOrdering.equiv, missingGreatest)
+      Array.tabulate(t1.size) { i =>
+        val mblt = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.lt, missingGreatest)
+        val mbequiv = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.equiv, missingGreatest)
         (Code(setup(i)(rx, x, ry, y, missingGreatest), mblt(rx, (m1, v1s(i)), ry, (m2, v2s(i)))),
-            mbequiv(rx, (m1, v1s(i)), ry, (m2, v2s(i))))
+          mbequiv(rx, (m1, v1s(i)), ry, (m2, v2s(i))))
       }.foldRight[Code[Boolean]](false) { case ((clt, ceq), cont) => clt || (ceq && cont) }
     }
 
     override def lteqNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long], missingGreatest: Boolean): Code[Boolean] = {
-      Array.tabulate(t.size) { i =>
-        val mblteq = mb.getCodeOrdering[Boolean](t.types(i), CodeOrdering.lteq, missingGreatest)
-        val mbequiv = mb.getCodeOrdering[Boolean](t.types(i), CodeOrdering.equiv, missingGreatest)
+      Array.tabulate(t1.size) { i =>
+        val mblteq = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.lteq, missingGreatest)
+        val mbequiv = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.equiv, missingGreatest)
         (Code(setup(i)(rx, x, ry, y, missingGreatest), mblteq(rx, (m1, v1s(i)), ry, (m2, v2s(i)))),
           mbequiv(rx, (m1, v1s(i)), ry, (m2, v2s(i))))
       }.foldRight[Code[Boolean]](true) { case ((clteq, ceq), cont) => clteq && (!ceq || cont) }
     }
 
     override def gtNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long], missingGreatest: Boolean): Code[Boolean] = {
-      Array.tabulate(t.size) { i =>
-        val mbgt = mb.getCodeOrdering[Boolean](t.types(i), CodeOrdering.gt, missingGreatest)
-        val mbequiv = mb.getCodeOrdering[Boolean](t.types(i), CodeOrdering.equiv, missingGreatest)
+      Array.tabulate(t1.size) { i =>
+        val mbgt = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.gt, missingGreatest)
+        val mbequiv = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.equiv, missingGreatest)
         (Code(setup(i)(rx, x, ry, y, missingGreatest), mbgt(rx, (m1, v1s(i)), ry, (m2, v2s(i)))),
           mbequiv(rx, (m1, v1s(i)), ry, (m2, v2s(i))))
       }.foldRight[Code[Boolean]](false) { case ((cgt, ceq), cont) => cgt || (ceq && cont) }
     }
 
     override def gteqNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long], missingGreatest: Boolean): Code[Boolean] = {
-      Array.tabulate(t.size) { i =>
-        val mbgteq = mb.getCodeOrdering[Boolean](t.types(i), CodeOrdering.gteq, missingGreatest)
-        val mbequiv = mb.getCodeOrdering[Boolean](t.types(i), CodeOrdering.equiv, missingGreatest)
+      Array.tabulate(t1.size) { i =>
+        val mbgteq = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.gteq, missingGreatest)
+        val mbequiv = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.equiv, missingGreatest)
         (Code(setup(i)(rx, x, ry, y, missingGreatest), mbgteq(rx, (m1, v1s(i)), ry, (m2, v2s(i)))),
           mbequiv(rx, (m1, v1s(i)), ry, (m2, v2s(i))))
       }.foldRight[Code[Boolean]](true) { case ((cgteq, ceq), cont) => cgteq && (!ceq || cont) }
     }
 
     override def equivNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long], missingGreatest: Boolean): Code[Boolean] = {
-      Array.tabulate(t.size) { i =>
-        val mbequiv = mb.getCodeOrdering[Boolean](t.types(i), CodeOrdering.equiv, missingGreatest)
+      Array.tabulate(t1.size) { i =>
+        val mbequiv = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.equiv, missingGreatest)
         Code(setup(i)(rx, x, ry, y, missingGreatest),
           mbequiv(rx, (m1, v1s(i)), ry, (m2, v2s(i))))
       }.foldRight[Code[Boolean]](const(true))(_ && _)
     }
   }
 
-  def iterableOrdering(t: TArray, mb: EmitMethodBuilder): CodeOrdering = new CodeOrdering {
+  def iterableOrdering(t1: TArray, t2: TArray, mb: EmitMethodBuilder): CodeOrdering = new CodeOrdering {
     type T = Long
     val lord: CodeOrdering = TInt32().codeOrdering(mb)
-    val ord: CodeOrdering = t.elementType.codeOrdering(mb)
+    val ord: CodeOrdering = t1.elementType.codeOrdering(mb, t2.elementType)
     val len1: LocalRef[Int] = mb.newLocal[Int]
     val len2: LocalRef[Int] = mb.newLocal[Int]
     val lim: LocalRef[Int] = mb.newLocal[Int]
     val i: LocalRef[Int] = mb.newLocal[Int]
     val m1: LocalRef[Boolean] = mb.newLocal[Boolean]
-    val v1: LocalRef[ord.T] = mb.newLocal(ir.typeToTypeInfo(t.elementType)).asInstanceOf[LocalRef[ord.T]]
+    val v1: LocalRef[ord.T] = mb.newLocal(ir.typeToTypeInfo(t1.elementType)).asInstanceOf[LocalRef[ord.T]]
     val m2: LocalRef[Boolean] = mb.newLocal[Boolean]
-    val v2: LocalRef[ord.T] = mb.newLocal(ir.typeToTypeInfo(t.elementType)).asInstanceOf[LocalRef[ord.T]]
+    val v2: LocalRef[ord.T] = mb.newLocal(ir.typeToTypeInfo(t2.elementType)).asInstanceOf[LocalRef[ord.T]]
     val eq: LocalRef[Boolean] = mb.newLocal[Boolean]
 
     def loop(cmp: Code[Unit], loopCond: Code[Boolean])
       (rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Unit] = {
       Code(
         i := 0,
-        len1 := t.loadLength(rx, x),
-        len2 := t.loadLength(ry, y),
+        len1 := t1.loadLength(rx, x),
+        len2 := t2.loadLength(ry, y),
         lim := (len1 < len2).mux(len1, len2),
         Code.whileLoop(loopCond && i < lim,
-          m1 := t.isElementMissing(rx, x, i),
-          v1.storeAny(rx.loadIRIntermediate(t.elementType)(t.elementOffset(x, len1, i))),
-          m2 := t.isElementMissing(ry, y, i),
-          v2.storeAny(ry.loadIRIntermediate(t.elementType)(t.elementOffset(y, len2, i))),
+          m1 := t1.isElementMissing(rx, x, i),
+          v1.storeAny(rx.loadIRIntermediate(t1.elementType)(t1.elementOffset(x, len1, i))),
+          m2 := t2.isElementMissing(ry, y, i),
+          v2.storeAny(ry.loadIRIntermediate(t2.elementType)(t2.elementOffset(y, len2, i))),
           cmp, i += 1))
     }
 
     override def compareNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long], missingGreatest: Boolean): Code[Int] = {
-      val mbcmp = mb.getCodeOrdering[Int](t.elementType, CodeOrdering.compare, missingGreatest)
+      val mbcmp = mb.getCodeOrdering[Int](t1.elementType, t2.elementType, CodeOrdering.compare, missingGreatest)
       val cmp = mb.newLocal[Int]
 
       Code(cmp := 0,
@@ -138,8 +138,8 @@ object CodeOrdering {
     }
 
     override def ltNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long], missingGreatest: Boolean): Code[Boolean] = {
-      val mblt = mb.getCodeOrdering[Boolean](t.elementType, CodeOrdering.lt, missingGreatest)
-      val mbequiv = mb.getCodeOrdering[Boolean](t.elementType, CodeOrdering.equiv, missingGreatest)
+      val mblt = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.lt, missingGreatest)
+      val mbequiv = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.equiv, missingGreatest)
       val lt = mb.newLocal[Boolean]
       val lcmp = Code(
         lt := mblt(rx, (m1, v1), ry, (m2, v2)),
@@ -151,8 +151,8 @@ object CodeOrdering {
     }
 
     override def lteqNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long], missingGreatest: Boolean): Code[Boolean] = {
-      val mblteq = mb.getCodeOrdering[Boolean](t.elementType, CodeOrdering.lteq, missingGreatest)
-      val mbequiv = mb.getCodeOrdering[Boolean](t.elementType, CodeOrdering.equiv, missingGreatest)
+      val mblteq = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.lteq, missingGreatest)
+      val mbequiv = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.equiv, missingGreatest)
 
       val lteq = mb.newLocal[Boolean]
       val lcmp = Code(
@@ -165,8 +165,8 @@ object CodeOrdering {
     }
 
     override def gtNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long], missingGreatest: Boolean): Code[Boolean] = {
-      val mbgt = mb.getCodeOrdering[Boolean](t.elementType, CodeOrdering.gt, missingGreatest)
-      val mbequiv = mb.getCodeOrdering[Boolean](t.elementType, CodeOrdering.equiv, missingGreatest)
+      val mbgt = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.gt, missingGreatest)
+      val mbequiv = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.equiv, missingGreatest)
       val gt = mb.newLocal[Boolean]
       val lcmp = Code(
         gt := mbgt(rx, (m1, v1), ry, (m2, v2)),
@@ -180,8 +180,8 @@ object CodeOrdering {
     }
 
     override def gteqNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long], missingGreatest: Boolean): Code[Boolean] = {
-      val mbgteq = mb.getCodeOrdering[Boolean](t.elementType, CodeOrdering.gteq, missingGreatest)
-      val mbequiv = mb.getCodeOrdering[Boolean](t.elementType, CodeOrdering.equiv, missingGreatest)
+      val mbgteq = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.gteq, missingGreatest)
+      val mbequiv = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.equiv, missingGreatest)
 
       val gteq = mb.newLocal[Boolean]
       val lcmp = Code(
@@ -195,7 +195,7 @@ object CodeOrdering {
     }
 
     override def equivNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long], missingGreatest: Boolean): Code[Boolean] = {
-      val mbequiv = mb.getCodeOrdering[Boolean](t.elementType, CodeOrdering.equiv, missingGreatest)
+      val mbequiv = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.equiv, missingGreatest)
       val lcmp = eq := mbequiv(rx, (m1, v1), ry, (m2, v2))
       Code(eq := true,
         loop(lcmp, eq)(rx, x, ry, y),
@@ -203,114 +203,113 @@ object CodeOrdering {
     }
   }
 
-  def intervalOrdering(t: TInterval, mb: EmitMethodBuilder): CodeOrdering = new CodeOrdering {
+  def intervalOrdering(t1: TInterval, t2: TInterval, mb: EmitMethodBuilder): CodeOrdering = new CodeOrdering {
     type T = Long
-    val pti = ir.typeToTypeInfo(t.pointType)
+    val pti = ir.typeToTypeInfo(t1.pointType)
     val mp1: LocalRef[Boolean] = mb.newLocal[Boolean]
     val mp2: LocalRef[Boolean] = mb.newLocal[Boolean]
-    val p1: LocalRef[_] = mb.newLocal(ir.typeToTypeInfo(t.pointType))
-    val p2: LocalRef[_] = mb.newLocal(ir.typeToTypeInfo(t.pointType))
+    val p1: LocalRef[_] = mb.newLocal(ir.typeToTypeInfo(t1.pointType))
+    val p2: LocalRef[_] = mb.newLocal(ir.typeToTypeInfo(t2.pointType))
 
     def loadStart(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Unit] = {
       Code(
-        mp1 := !t.startDefined(rx, x),
-        mp2 := !t.startDefined(ry, y),
-        p1.storeAny(mp1.mux(ir.defaultValue(t.pointType), rx.loadIRIntermediate(t.pointType)(t.startOffset(x)))),
-        p2.storeAny(mp2.mux(ir.defaultValue(t.pointType), ry.loadIRIntermediate(t.pointType)(t.startOffset(y)))))
+        mp1 := !t1.startDefined(rx, x),
+        mp2 := !t2.startDefined(ry, y),
+        p1.storeAny(mp1.mux(ir.defaultValue(t1.pointType), rx.loadIRIntermediate(t1.pointType)(t1.startOffset(x)))),
+        p2.storeAny(mp2.mux(ir.defaultValue(t2.pointType), ry.loadIRIntermediate(t2.pointType)(t2.startOffset(y)))))
     }
 
     def loadEnd(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Unit] = {
       Code(
-        mp1 := !t.endDefined(rx, x),
-        mp2 := !t.endDefined(ry, y),
-        p1.storeAny(mp1.mux(ir.defaultValue(t.pointType), rx.loadIRIntermediate(t.pointType)(t.endOffset(x)))),
-        p2.storeAny(mp2.mux(ir.defaultValue(t.pointType), ry.loadIRIntermediate(t.pointType)(t.endOffset(y)))))
+        mp1 := !t1.endDefined(rx, x),
+        mp2 := !t2.endDefined(ry, y),
+        p1.storeAny(mp1.mux(ir.defaultValue(t1.pointType), rx.loadIRIntermediate(t1.pointType)(t1.endOffset(x)))),
+        p2.storeAny(mp2.mux(ir.defaultValue(t2.pointType), ry.loadIRIntermediate(t2.pointType)(t2.endOffset(y)))))
     }
 
     override def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] = {
-      val mbcmp = mb.getCodeOrdering[Int](t.pointType, CodeOrdering.compare, missingGreatest)
+      val mbcmp = mb.getCodeOrdering[Int](t1.pointType, t2.pointType, CodeOrdering.compare, missingGreatest)
 
       val cmp = mb.newLocal[Int]
       Code(loadStart(rx, x, ry, y),
         cmp := mbcmp(rx, (mp1, p1), ry, (mp2, p2)),
         cmp.ceq(0).mux(
-          Code(mp1 := t.includeStart(rx, x),
-          mp1.cne(t.includeStart(ry, y)).mux(
-            mp1.mux(-1, 1),
-            Code(
-              loadEnd(rx, x, ry, y),
-              cmp := mbcmp(rx, (mp1, p1), ry, (mp2, p2)),
-              cmp.ceq(0).mux(
-                Code(mp1 := t.includeEnd(rx, x),
-                  mp1.cne(t.includeEnd(ry, y)).mux(mp1.mux(1, -1), 0)),
-                cmp)))),
+          Code(mp1 := t1.includeStart(rx, x),
+            mp1.cne(t2.includeStart(ry, y)).mux(
+              mp1.mux(-1, 1),
+              Code(
+                loadEnd(rx, x, ry, y),
+                cmp := mbcmp(rx, (mp1, p1), ry, (mp2, p2)),
+                cmp.ceq(0).mux(
+                  Code(mp1 := t1.includeEnd(rx, x),
+                    mp1.cne(t2.includeEnd(ry, y)).mux(mp1.mux(1, -1), 0)),
+                  cmp)))),
           cmp))
     }
 
     override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] = {
-      val mbeq = mb.getCodeOrdering[Boolean](t.pointType, CodeOrdering.equiv, missingGreatest)
+      val mbeq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.equiv, missingGreatest)
 
       Code(loadStart(rx, x, ry, y), mbeq(rx, (mp1, p1), ry, (mp2, p2))) &&
-        t.includeStart(rx, x).ceq(t.includeStart(ry, y)) &&
+        t1.includeStart(rx, x).ceq(t2.includeStart(ry, y)) &&
         Code(loadEnd(rx, x, ry, y), mbeq(rx, (mp1, p1), ry, (mp2, p2))) &&
-        t.includeEnd(rx, x).ceq(t.includeEnd(ry, y))
+        t1.includeEnd(rx, x).ceq(t2.includeEnd(ry, y))
     }
 
     override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] = {
-      val mblt = mb.getCodeOrdering[Boolean](t.pointType, CodeOrdering.lt, missingGreatest)
-      val mbeq = mb.getCodeOrdering[Boolean](t.pointType, CodeOrdering.equiv, missingGreatest)
+      val mblt = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.lt, missingGreatest)
+      val mbeq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.equiv, missingGreatest)
 
       Code(loadStart(rx, x, ry, y), mblt(rx, (mp1, p1), ry, (mp2, p2))) || (
         mbeq(rx, (mp1, p1), ry, (mp2, p2)) && (
-          Code(mp1 := t.includeStart(rx, x), mp2 := t.includeStart(ry, y), mp1 && !mp2) || (mp1.ceq(mp2) && (
+          Code(mp1 := t1.includeStart(rx, x), mp2 := t2.includeStart(ry, y), mp1 && !mp2) || (mp1.ceq(mp2) && (
             Code(loadEnd(rx, x, ry, y), mblt(rx, (mp1, p1), ry, (mp2, p2))) || (
               mbeq(rx, (mp1, p1), ry, (mp2, p2)) &&
-              !t.includeEnd(rx, x) && t.includeEnd(ry, y))))))
+                !t1.includeEnd(rx, x) && t2.includeEnd(ry, y))))))
     }
 
     override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] = {
-      val mblteq = mb.getCodeOrdering[Boolean](t.pointType, CodeOrdering.lteq, missingGreatest)
-      val mbeq = mb.getCodeOrdering[Boolean](t.pointType, CodeOrdering.equiv, missingGreatest)
+      val mblteq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.lteq, missingGreatest)
+      val mbeq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.equiv, missingGreatest)
 
       Code(loadStart(rx, x, ry, y), mblteq(rx, (mp1, p1), ry, (mp2, p2))) && (
         !mbeq(rx, (mp1, p1), ry, (mp2, p2)) || ( // if not equal, then lt
-          Code(mp1 := t.includeStart(rx, x), mp2 := t.includeStart(ry, y), mp1 && !mp2) || (mp1.ceq(mp2) && (
+          Code(mp1 := t1.includeStart(rx, x), mp2 := t2.includeStart(ry, y), mp1 && !mp2) || (mp1.ceq(mp2) && (
             Code(loadEnd(rx, x, ry, y), mblteq(rx, (mp1, p1), ry, (mp2, p2))) && (
               !mbeq(rx, (mp1, p1), ry, (mp2, p2)) ||
-                !t.includeEnd(rx, x) || t.includeEnd(ry, y))))))
+                !t1.includeEnd(rx, x) || t2.includeEnd(ry, y))))))
     }
 
     override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] = {
-      val mbgt = mb.getCodeOrdering[Boolean](t.pointType, CodeOrdering.gt, missingGreatest)
-      val mbeq = mb.getCodeOrdering[Boolean](t.pointType, CodeOrdering.equiv, missingGreatest)
+      val mbgt = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.gt, missingGreatest)
+      val mbeq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.equiv, missingGreatest)
 
       Code(loadStart(rx, x, ry, y), mbgt(rx, (mp1, p1), ry, (mp2, p2))) || (
         mbeq(rx, (mp1, p1), ry, (mp2, p2)) && (
-          Code(mp1 := t.includeStart(rx, x), mp2 := t.includeStart(ry, y), !mp1 && mp2) || (mp1.ceq(mp2) && (
+          Code(mp1 := t1.includeStart(rx, x), mp2 := t2.includeStart(ry, y), !mp1 && mp2) || (mp1.ceq(mp2) && (
             Code(loadEnd(rx, x, ry, y), mbgt(rx, (mp1, p1), ry, (mp2, p2))) || (
               mbeq(rx, (mp1, p1), ry, (mp2, p2)) &&
-                t.includeEnd(rx, x) && !t.includeEnd(ry, y))))))
+                t1.includeEnd(rx, x) && !t2.includeEnd(ry, y))))))
     }
 
     override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] = {
-      val mbgteq = mb.getCodeOrdering[Boolean](t.pointType, CodeOrdering.gteq, missingGreatest)
-      val mbeq = mb.getCodeOrdering[Boolean](t.pointType, CodeOrdering.equiv, missingGreatest)
+      val mbgteq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.gteq, missingGreatest)
+      val mbeq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.equiv, missingGreatest)
 
       Code(loadStart(rx, x, ry, y), mbgteq(rx, (mp1, p1), ry, (mp2, p2))) && (
         !mbeq(rx, (mp1, p1), ry, (mp2, p2)) || ( // if not equal, then lt
-          Code(mp1 := t.includeStart(rx, x), mp2 := t.includeStart(ry, y), !mp1 && mp2) || (mp1.ceq(mp2) && (
+          Code(mp1 := t1.includeStart(rx, x), mp2 := t2.includeStart(ry, y), !mp1 && mp2) || (mp1.ceq(mp2) && (
             Code(loadEnd(rx, x, ry, y), mbgteq(rx, (mp1, p1), ry, (mp2, p2))) && (
               !mbeq(rx, (mp1, p1), ry, (mp2, p2)) ||
-                t.includeEnd(rx, x) || !t.includeEnd(ry, y))))))
+                t1.includeEnd(rx, x) || !t2.includeEnd(ry, y))))))
     }
   }
 
-  def mapOrdering(t: TDict, mb: EmitMethodBuilder): CodeOrdering = {
-    iterableOrdering(TArray(t.elementType, t.required), mb)
-  }
+  def mapOrdering(t1: TDict, t2: TDict, mb: EmitMethodBuilder): CodeOrdering =
+    iterableOrdering(TArray(t1.elementType, t1.required), TArray(t2.elementType, t2.required), mb)
 
-  def setOrdering(t: TSet, mb: EmitMethodBuilder): CodeOrdering =
-    iterableOrdering(TArray(t.elementType, t.required), mb)
+  def setOrdering(t1: TSet, t2: TSet, mb: EmitMethodBuilder): CodeOrdering =
+    iterableOrdering(TArray(t1.elementType, t1.required), TArray(t2.elementType, t2.required), mb)
 
 }
 

--- a/src/main/scala/is/hail/annotations/CodeOrdering.scala
+++ b/src/main/scala/is/hail/annotations/CodeOrdering.scala
@@ -22,7 +22,6 @@ object CodeOrdering {
 
   def rowOrdering(t1: TBaseStruct, t2: TBaseStruct, mb: EmitMethodBuilder): CodeOrdering = new CodeOrdering {
     type T = Long
-    val orderings: Array[CodeOrdering] = t1.types.zip(t2.types).map{ case (t1, t2) => t1.codeOrdering(mb, t2) }
 
     val m1: LocalRef[Boolean] = mb.newLocal[Boolean]
     val m2: LocalRef[Boolean] = mb.newLocal[Boolean]

--- a/src/main/scala/is/hail/expr/ir/ComparisonOp.scala
+++ b/src/main/scala/is/hail/expr/ir/ComparisonOp.scala
@@ -8,55 +8,64 @@ import is.hail.utils.lift
 object ComparisonOp {
 
   private def checkCompatible[T](lt: Type, rt: Type): Unit =
-    if (lt.fundamentalType != rt.fundamentalType)
+    if (!lt.isOfType(rt))
       throw new RuntimeException(s"Cannot compare types $lt and $rt")
 
   // FIXME: this needs to happen for now because CodeOrdering can't compare across types.
   private def comparable(lt: Type, rt: Type): Boolean =
-    lt.fundamentalType == rt.fundamentalType
+    lt isOfType rt
 
   val fromStringAndTypes: PartialFunction[(String, Type, Type), ComparisonOp] = {
     case ("==", t1, t2) if comparable(t1, t2) =>
       checkCompatible(t1, t2)
-      EQ(t1)
+      EQ(t1, t2)
     case ("!=", t1, t2) if comparable(t1, t2) =>
       checkCompatible(t1, t2)
-      NEQ(t1)
+      NEQ(t1, t2)
     case (">=", t1, t2) if comparable(t1, t2) =>
       checkCompatible(t1, t2)
-      GTEQ(t1)
+      GTEQ(t1, t2)
     case ("<=", t1, t2) if comparable(t1, t2) =>
       checkCompatible(t1, t2)
-      LTEQ(t1)
+      LTEQ(t1, t2)
     case (">", t1, t2) if comparable(t1, t2) =>
       checkCompatible(t1, t2)
-      GT(t1)
+      GT(t1, t2)
     case ("<", t1, t2) if comparable(t1, t2) =>
       checkCompatible(t1, t2)
-      LT(t1)
+      LT(t1, t2)
   }
 }
 
 sealed trait ComparisonOp {
-  def typ: Type
+  def t1: Type
+  def t2: Type
   def op: CodeOrdering.Op
   val strict: Boolean = true
   def codeOrdering(mb: EmitMethodBuilder): CodeOrdering.F[Boolean] = {
-    mb.getCodeOrdering[Boolean](typ, op, missingGreatest = true)
+    mb.getCodeOrdering[Boolean](t1, t2, op, missingGreatest = true)
   }
 }
 
-case class GT(typ: Type) extends ComparisonOp { val op: CodeOrdering.Op = CodeOrdering.gt }
-case class GTEQ(typ: Type) extends ComparisonOp { val op: CodeOrdering.Op = CodeOrdering.gteq }
-case class LTEQ(typ: Type) extends ComparisonOp { val op: CodeOrdering.Op = CodeOrdering.lteq }
-case class LT(typ: Type) extends ComparisonOp { val op: CodeOrdering.Op = CodeOrdering.lt }
-case class EQ(typ: Type) extends ComparisonOp { val op: CodeOrdering.Op = CodeOrdering.equiv }
-case class NEQ(typ: Type) extends ComparisonOp { val op: CodeOrdering.Op = CodeOrdering.neq }
-case class EQWithNA(typ: Type) extends ComparisonOp {
+case class GT(t1: Type, t2: Type) extends ComparisonOp { val op: CodeOrdering.Op = CodeOrdering.gt }
+object GT { def apply(typ: Type): GT = GT(typ, typ) }
+case class GTEQ(t1: Type, t2: Type) extends ComparisonOp { val op: CodeOrdering.Op = CodeOrdering.gteq }
+object GTEQ { def apply(typ: Type): GTEQ = GTEQ(typ, typ) }
+case class LTEQ(t1: Type, t2: Type) extends ComparisonOp { val op: CodeOrdering.Op = CodeOrdering.lteq }
+object LTEQ { def apply(typ: Type): LTEQ = LTEQ(typ, typ) }
+case class LT(t1: Type, t2: Type) extends ComparisonOp { val op: CodeOrdering.Op = CodeOrdering.lt }
+object LT { def apply(typ: Type): LT = LT(typ, typ) }
+case class EQ(t1: Type, t2: Type) extends ComparisonOp { val op: CodeOrdering.Op = CodeOrdering.equiv }
+object EQ { def apply(typ: Type): EQ = EQ(typ, typ) }
+case class NEQ(t1: Type, t2: Type) extends ComparisonOp { val op: CodeOrdering.Op = CodeOrdering.neq }
+object NEQ { def apply(typ: Type): NEQ = NEQ(typ, typ) }
+case class EQWithNA(t1: Type, t2: Type) extends ComparisonOp {
   val op: CodeOrdering.Op = CodeOrdering.equiv
   override val strict: Boolean = false
 }
-case class NEQWithNA(typ: Type) extends ComparisonOp {
+object EQWithNA { def apply(typ: Type): EQWithNA = EQWithNA(typ, typ) }
+case class NEQWithNA(t1: Type, t2: Type) extends ComparisonOp {
   val op: CodeOrdering.Op = CodeOrdering.neq
   override val strict: Boolean = false
 }
+object NEQWithNA { def apply(typ: Type): NEQWithNA = NEQWithNA(typ, typ) }

--- a/src/main/scala/is/hail/expr/ir/ComparisonOp.scala
+++ b/src/main/scala/is/hail/expr/ir/ComparisonOp.scala
@@ -11,27 +11,23 @@ object ComparisonOp {
     if (!lt.isOfType(rt))
       throw new RuntimeException(s"Cannot compare types $lt and $rt")
 
-  // FIXME: this needs to happen for now because CodeOrdering can't compare across types.
-  private def comparable(lt: Type, rt: Type): Boolean =
-    lt isOfType rt
-
   val fromStringAndTypes: PartialFunction[(String, Type, Type), ComparisonOp] = {
-    case ("==", t1, t2) if comparable(t1, t2) =>
+    case ("==", t1, t2) =>
       checkCompatible(t1, t2)
       EQ(t1, t2)
-    case ("!=", t1, t2) if comparable(t1, t2) =>
+    case ("!=", t1, t2) =>
       checkCompatible(t1, t2)
       NEQ(t1, t2)
-    case (">=", t1, t2) if comparable(t1, t2) =>
+    case (">=", t1, t2) =>
       checkCompatible(t1, t2)
       GTEQ(t1, t2)
-    case ("<=", t1, t2) if comparable(t1, t2) =>
+    case ("<=", t1, t2) =>
       checkCompatible(t1, t2)
       LTEQ(t1, t2)
-    case (">", t1, t2) if comparable(t1, t2) =>
+    case (">", t1, t2) =>
       checkCompatible(t1, t2)
       GT(t1, t2)
-    case ("<", t1, t2) if comparable(t1, t2) =>
+    case ("<", t1, t2) =>
       checkCompatible(t1, t2)
       LT(t1, t2)
   }

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -231,10 +231,10 @@ class PrimitiveIR(val self: IR) extends AnyVal {
   def unary_-(): IR = ApplyUnaryPrimOp(Negate(), self)
   def unary_!(): IR = ApplyUnaryPrimOp(Bang(), self)
 
-  def ceq(other: IR): IR = ApplyComparisonOp(EQWithNA(self.typ), self, other)
-  def cne(other: IR): IR = ApplyComparisonOp(NEQWithNA(self.typ), self, other)
-  def <(other: IR): IR = ApplyComparisonOp(LT(self.typ), self, other)
-  def >(other: IR): IR = ApplyComparisonOp(GT(self.typ), self, other)
-  def <=(other: IR): IR = ApplyComparisonOp(LTEQ(self.typ), self, other)
-  def >=(other: IR): IR = ApplyComparisonOp(GTEQ(self.typ), self, other)
+  def ceq(other: IR): IR = ApplyComparisonOp(EQWithNA(self.typ, other.typ), self, other)
+  def cne(other: IR): IR = ApplyComparisonOp(NEQWithNA(self.typ, other.typ), self, other)
+  def <(other: IR): IR = ApplyComparisonOp(LT(self.typ, other.typ), self, other)
+  def >(other: IR): IR = ApplyComparisonOp(GT(self.typ, other.typ), self, other)
+  def <=(other: IR): IR = ApplyComparisonOp(LTEQ(self.typ, other.typ), self, other)
+  def >=(other: IR): IR = ApplyComparisonOp(GTEQ(self.typ, other.typ), self, other)
 }

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -17,7 +17,7 @@ object Infer {
       case ApplyUnaryPrimOp(op, v) =>
         UnaryOp.getReturnType(op, v.typ)
       case ApplyComparisonOp(op, l, r) =>
-        assert(l.typ == r.typ)
+        assert(l.typ isOfType r.typ, s"${l.typ.parsableString()} vs ${r.typ.parsableString()}")
         TBoolean()
       case ArrayRef(a, i) =>
         assert(i.typ.isOfType(TInt32()))

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -167,12 +167,12 @@ object Interpret {
           null
         else
           op match {
-            case EQ(_) | EQWithNA(_) => lValue == rValue
-            case NEQ(_) | NEQWithNA(_) => lValue != rValue
-            case LT(t) => t.ordering.lt(lValue, rValue)
-            case GT(t) => t.ordering.gt(lValue, rValue)
-            case LTEQ(t) => t.ordering.lteq(lValue, rValue)
-            case GTEQ(t) => t.ordering.gteq(lValue, rValue)
+            case EQ(_, _) | EQWithNA(_, _) => lValue == rValue
+            case NEQ(_, _) | NEQWithNA(_, _) => lValue != rValue
+            case LT(t, _) => t.ordering.lt(lValue, rValue)
+            case GT(t, _) => t.ordering.gt(lValue, rValue)
+            case LTEQ(t, _) => t.ordering.lteq(lValue, rValue)
+            case GTEQ(t, _) => t.ordering.gteq(lValue, rValue)
           }
 
       case MakeArray(elements, _) => elements.map(interpret(_, env, args, agg)).toIndexedSeq

--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -53,7 +53,7 @@ object Pretty {
             case Ref(name, _) => name
             case ApplyBinaryPrimOp(op, _, _) => op.getClass.getName.split("\\.").last
             case ApplyUnaryPrimOp(op, _) => op.getClass.getName.split("\\.").last
-            case ApplyComparisonOp(op, _, _) => s"${ op.getClass.getSimpleName }(${ op.typ })"
+            case ApplyComparisonOp(op, _, _) => s"${ op.getClass.getSimpleName }(${ op.t1 })"
             case GetField(_, name) => name
             case GetTupleElement(_, idx) => idx.toString
             case ArrayMap(_, name, _) => name

--- a/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -25,8 +25,8 @@ object Simplify {
            _: MakeStruct |
            _: MakeTuple |
            _: IsNA |
-           ApplyComparisonOp(EQWithNA(_), _, _) |
-           ApplyComparisonOp(NEQWithNA(_), _, _) |
+           ApplyComparisonOp(EQWithNA(_, _), _, _) |
+           ApplyComparisonOp(NEQWithNA(_, _), _, _) |
            _: I32 | _: I64 | _: F32 | _: F64 | True() | False() => true
       case _ => false
     }

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -56,8 +56,8 @@ object TypeCheck {
       case x@ApplyComparisonOp(op, l, r) =>
         check(l)
         check(r)
-        assert(l.typ.fundamentalType == r.typ.fundamentalType)
-        assert(op.typ.fundamentalType == l.typ.fundamentalType)
+        assert(op.t1.fundamentalType == l.typ.fundamentalType)
+        assert(op.t2.fundamentalType == r.typ.fundamentalType)
         assert(x.typ == TBoolean())
       case x@MakeArray(args, typ) =>
         if (args.length == 0)

--- a/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -206,9 +206,9 @@ object ArrayFunctions extends RegistryFunctions {
         ), "midx")
     }
 
-    registerIR("argmin", TArray(tv("T")))(argF(_, LT))
+    registerIR("argmin", TArray(tv("T")))(argF(_, LT(_)))
 
-    registerIR("argmax", TArray(tv("T")))(argF(_, GT))
+    registerIR("argmax", TArray(tv("T")))(argF(_, GT(_)))
 
     def uniqueIndex(a: IR, op: (Type) => ComparisonOp): IR = {
       val t = -coerce[TArray](a.typ).elementType
@@ -246,9 +246,9 @@ object ArrayFunctions extends RegistryFunctions {
         NA(TInt32())))
     }
 
-    registerIR("uniqueMinIndex", TArray(tv("T")))(uniqueIndex(_, LT))
+    registerIR("uniqueMinIndex", TArray(tv("T")))(uniqueIndex(_, LT(_)))
 
-    registerIR("uniqueMaxIndex", TArray(tv("T")))(uniqueIndex(_, GT))
+    registerIR("uniqueMaxIndex", TArray(tv("T")))(uniqueIndex(_, GT(_)))
 
     registerIR("[]", TArray(tv("T")), TInt32()) { (a, i) =>
       ArrayRef(

--- a/src/main/scala/is/hail/expr/types/TAggregable.scala
+++ b/src/main/scala/is/hail/expr/types/TAggregable.scala
@@ -49,5 +49,5 @@ final case class TAggregable(elementType: Type, override val required: Boolean =
 
   val ordering: ExtendedOrdering = null
 
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = null
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = null
 }

--- a/src/main/scala/is/hail/expr/types/TAggregableVariable.scala
+++ b/src/main/scala/is/hail/expr/types/TAggregableVariable.scala
@@ -42,5 +42,5 @@ final case class TAggregableVariable(elementType: Type, st: Box[SymbolTable]) ex
 
   val ordering: ExtendedOrdering = null
 
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = null
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = null
 }

--- a/src/main/scala/is/hail/expr/types/TArray.scala
+++ b/src/main/scala/is/hail/expr/types/TArray.scala
@@ -57,9 +57,11 @@ final case class TArray(elementType: Type, override val required: Boolean = fals
 
   val ordering: ExtendedOrdering =
     ExtendedOrdering.iterableOrdering(elementType.ordering)
-  
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering =
-    CodeOrdering.iterableOrdering(this, mb)
+
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = {
+    assert(this isOfType other)
+    CodeOrdering.iterableOrdering(this, other.asInstanceOf[TArray], mb)
+  }
 
   override def scalaClassTag: ClassTag[IndexedSeq[AnyRef]] = classTag[IndexedSeq[AnyRef]]
 }

--- a/src/main/scala/is/hail/expr/types/TBoolean.scala
+++ b/src/main/scala/is/hail/expr/types/TBoolean.scala
@@ -36,10 +36,14 @@ class TBoolean(override val required: Boolean) extends Type {
   val ordering: ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Boolean]])
 
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = new CodeOrdering {
-    type T = Boolean
-    def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] =
-      Code.invokeStatic[java.lang.Boolean, Boolean, Boolean, Int]("compare", x, y)
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = {
+    assert(other isOfType this)
+    new CodeOrdering {
+      type T = Boolean
+
+      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] =
+        Code.invokeStatic[java.lang.Boolean, Boolean, Boolean, Int]("compare", x, y)
+    }
   }
 
   override def byteSize: Long = 1

--- a/src/main/scala/is/hail/expr/types/TCall.scala
+++ b/src/main/scala/is/hail/expr/types/TCall.scala
@@ -30,7 +30,10 @@ class TCall(override val required: Boolean) extends ComplexType {
   val ordering: ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Int]])
 
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = TInt32().codeOrdering(mb)
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = {
+    assert(other isOfType this)
+    TInt32().codeOrdering(mb)
+  }
 }
 
 object TCall {

--- a/src/main/scala/is/hail/expr/types/TDict.scala
+++ b/src/main/scala/is/hail/expr/types/TDict.scala
@@ -75,6 +75,8 @@ final case class TDict(keyType: Type, valueType: Type, override val required: Bo
   val ordering: ExtendedOrdering =
     ExtendedOrdering.mapOrdering(elementType.ordering)
 
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering =
-    CodeOrdering.mapOrdering(this, mb)
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = {
+    assert(other isOfType this)
+    CodeOrdering.mapOrdering(this, other.asInstanceOf[TDict], mb)
+  }
 }

--- a/src/main/scala/is/hail/expr/types/TFloat32.scala
+++ b/src/main/scala/is/hail/expr/types/TFloat32.scala
@@ -51,25 +51,29 @@ class TFloat32(override val required: Boolean) extends TNumeric {
   val ordering: ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Float]])
 
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = new CodeOrdering {
-    type T = Float
-    def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] =
-      Code.invokeStatic[java.lang.Float, Float, Float, Int]("compare", x, y)
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = {
+    assert(other isOfType this)
+    new CodeOrdering {
+      type T = Float
 
-    override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
-      x < y
+      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] =
+        Code.invokeStatic[java.lang.Float, Float, Float, Int]("compare", x, y)
 
-    override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
-      x <= y
+      override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+        x < y
 
-    override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
-      x > y
+      override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+        x <= y
 
-    override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
-      x >= y
+      override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+        x > y
 
-    override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
-      x.ceq(y)
+      override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+        x >= y
+
+      override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+        x.ceq(y)
+    }
   }
 
   override def byteSize: Long = 4

--- a/src/main/scala/is/hail/expr/types/TFloat64.scala
+++ b/src/main/scala/is/hail/expr/types/TFloat64.scala
@@ -52,25 +52,29 @@ class TFloat64(override val required: Boolean) extends TNumeric {
   val ordering: ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Double]])
 
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = new CodeOrdering {
-    type T = Double
-    def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] =
-      Code.invokeStatic[java.lang.Double, Double, Double, Int]("compare", x, y)
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = {
+    assert(other isOfType this)
+    new CodeOrdering {
+      type T = Double
 
-    override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
-      x < y
+      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] =
+        Code.invokeStatic[java.lang.Double, Double, Double, Int]("compare", x, y)
 
-    override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
-      x <= y
+      override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+        x < y
 
-    override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
-      x > y
+      override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+        x <= y
 
-    override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
-      x >= y
+      override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+        x > y
 
-    override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
-      x.ceq(y)
+      override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+        x >= y
+
+      override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+        x.ceq(y)
+    }
   }
 
   override def byteSize: Long = 8

--- a/src/main/scala/is/hail/expr/types/TFunction.scala
+++ b/src/main/scala/is/hail/expr/types/TFunction.scala
@@ -36,5 +36,5 @@ final case class TFunction(paramTypes: Seq[Type], returnType: Type) extends Type
 
   val ordering: ExtendedOrdering = null
 
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = null
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = null
 }

--- a/src/main/scala/is/hail/expr/types/TInt32.scala
+++ b/src/main/scala/is/hail/expr/types/TInt32.scala
@@ -36,9 +36,11 @@ class TInt32(override val required: Boolean) extends TIntegral {
   val ordering: ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Int]])
 
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering =
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = {
+    assert(other isOfType this)
     new CodeOrdering {
       type T = Int
+
       def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] =
         Code.invokeStatic[java.lang.Integer, Int, Int, Int]("compare", x, y)
 
@@ -57,6 +59,7 @@ class TInt32(override val required: Boolean) extends TIntegral {
       override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
         x.ceq(y)
     }
+  }
 
   override def byteSize: Long = 4
 }

--- a/src/main/scala/is/hail/expr/types/TInt64.scala
+++ b/src/main/scala/is/hail/expr/types/TInt64.scala
@@ -36,26 +36,30 @@ class TInt64(override val required: Boolean) extends TIntegral {
   val ordering: ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Long]])
 
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = new CodeOrdering {
-    type T = Long
-    def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] =
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = {
+    assert(other isOfType this)
+    new CodeOrdering {
+      type T = Long
+
+      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] =
         Code.invokeStatic[java.lang.Long, Long, Long, Int]("compare", x, y)
 
-    override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
         x < y
 
-    override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
         x <= y
 
-    override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
         x > y
 
-    override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
         x >= y
 
-    override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
         x.ceq(y)
     }
+  }
 
   override def byteSize: Long = 8
 }

--- a/src/main/scala/is/hail/expr/types/TInterval.scala
+++ b/src/main/scala/is/hail/expr/types/TInterval.scala
@@ -37,8 +37,11 @@ case class TInterval(pointType: Type, override val required: Boolean = false) ex
 
   val ordering: ExtendedOrdering = Interval.ordering(pointType.ordering, startPrimary=true)
 
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering =
-    CodeOrdering.intervalOrdering(this, mb)
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = {
+    assert(other isOfType this)
+    CodeOrdering.intervalOrdering(this, other.asInstanceOf[TInterval], mb)
+  }
+
 
   override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering =
     new UnsafeOrdering {

--- a/src/main/scala/is/hail/expr/types/TLocus.scala
+++ b/src/main/scala/is/hail/expr/types/TLocus.scala
@@ -64,28 +64,31 @@ case class TLocus(rg: RGBase, override val required: Boolean = false) extends Co
     }
   }
 
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = new CodeOrdering {
-    type T = Long
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = {
+    assert(other isOfType this)
+    new CodeOrdering {
+      type T = Long
 
-    override def compareNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long], missingGreatest: Boolean): Code[Int] = {
-      val cmp = mb.newLocal[Int]
+      override def compareNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long], missingGreatest: Boolean): Code[Int] = {
+        val cmp = mb.newLocal[Int]
 
-      val c1 = representation.loadField(rx, x, 0)
-      val c2 = representation.loadField(ry, y, 0)
+        val c1 = representation.loadField(rx, x, 0)
+        val c2 = representation.loadField(ry, y, 0)
 
-      val s1 = Code.invokeScalaObject[Region, Long, String](TString.getClass, "loadString", rx, c1)
-      val s2 = Code.invokeScalaObject[Region, Long, String](TString.getClass, "loadString", ry, c2)
+        val s1 = Code.invokeScalaObject[Region, Long, String](TString.getClass, "loadString", rx, c1)
+        val s2 = Code.invokeScalaObject[Region, Long, String](TString.getClass, "loadString", ry, c2)
 
-      val p1 = rx.loadInt(representation.fieldOffset(x, 1))
-      val p2 = ry.loadInt(representation.fieldOffset(y, 1))
+        val p1 = rx.loadInt(representation.fieldOffset(x, 1))
+        val p2 = ry.loadInt(representation.fieldOffset(y, 1))
 
-      val codeRG = mb.getReferenceGenome(rg.asInstanceOf[ReferenceGenome])
+        val codeRG = mb.getReferenceGenome(rg.asInstanceOf[ReferenceGenome])
 
-      Code(
-        cmp := codeRG.invoke[String, String, Int]("compare", s1, s2),
-        cmp.ceq(0).mux(
-          Code.invokeStatic[java.lang.Integer, Int, Int, Int]("compare", p1, p2),
-          cmp))
+        Code(
+          cmp := codeRG.invoke[String, String, Int]("compare", s1, s2),
+          cmp.ceq(0).mux(
+            Code.invokeStatic[java.lang.Integer, Int, Int, Int]("compare", p1, p2),
+            cmp))
+      }
     }
   }
 

--- a/src/main/scala/is/hail/expr/types/TSet.scala
+++ b/src/main/scala/is/hail/expr/types/TSet.scala
@@ -47,8 +47,11 @@ final case class TSet(elementType: Type, override val required: Boolean = false)
   val ordering: ExtendedOrdering =
     ExtendedOrdering.setOrdering(elementType.ordering)
 
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering =
-    CodeOrdering.setOrdering(this, mb)
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = {
+    assert(other isOfType this)
+    CodeOrdering.setOrdering(this, other.asInstanceOf[TSet], mb)
+  }
+
 
   override def str(a: Annotation): String = JsonMethods.compact(toJSON(a))
 

--- a/src/main/scala/is/hail/expr/types/TString.scala
+++ b/src/main/scala/is/hail/expr/types/TString.scala
@@ -34,7 +34,10 @@ class TString(override val required: Boolean) extends Type {
 
   override def fundamentalType: Type = TBinary(required)
 
-  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = TBinary(required).codeOrdering(mb, TBinary(other.required))
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = {
+    assert(this isOfType other)
+    TBinary(required).codeOrdering(mb, TBinary(other.required))
+  }
 }
 
 object TString {

--- a/src/main/scala/is/hail/expr/types/TString.scala
+++ b/src/main/scala/is/hail/expr/types/TString.scala
@@ -34,7 +34,7 @@ class TString(override val required: Boolean) extends Type {
 
   override def fundamentalType: Type = TBinary(required)
 
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = TBinary(required).codeOrdering(mb)
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = TBinary(required).codeOrdering(mb, TBinary(other.required))
 }
 
 object TString {

--- a/src/main/scala/is/hail/expr/types/TStruct.scala
+++ b/src/main/scala/is/hail/expr/types/TStruct.scala
@@ -73,7 +73,10 @@ final case class TStruct(fields: IndexedSeq[Field], override val required: Boole
 
   val ordering: ExtendedOrdering = TBaseStruct.getOrdering(types)
 
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = CodeOrdering.rowOrdering(this, mb)
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = {
+    assert(other isOfType this)
+    CodeOrdering.rowOrdering(this, other.asInstanceOf[TStruct], mb)
+  }
 
   def fieldByName(name: String): Field = fields(fieldIdx(name))
 

--- a/src/main/scala/is/hail/expr/types/TTuple.scala
+++ b/src/main/scala/is/hail/expr/types/TTuple.scala
@@ -30,7 +30,10 @@ final case class TTuple(_types: IndexedSeq[Type], override val required: Boolean
 
   val ordering: ExtendedOrdering = TBaseStruct.getOrdering(types)
 
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = CodeOrdering.rowOrdering(this, mb)
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = {
+    assert(other isOfType this)
+    CodeOrdering.rowOrdering(this, other.asInstanceOf[TTuple], mb)
+  }
 
   val size: Int = types.length
 

--- a/src/main/scala/is/hail/expr/types/TVariable.scala
+++ b/src/main/scala/is/hail/expr/types/TVariable.scala
@@ -36,5 +36,5 @@ final case class TVariable(name: String, cond: (Type) => Boolean = { _ => true }
 
   val ordering: ExtendedOrdering = null
 
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = null
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = null
 }

--- a/src/main/scala/is/hail/expr/types/TVoid.scala
+++ b/src/main/scala/is/hail/expr/types/TVoid.scala
@@ -16,5 +16,5 @@ case object TVoid extends Type {
 
   override def isRealizable = false
 
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = null
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = null
 }

--- a/src/main/scala/is/hail/expr/types/Type.scala
+++ b/src/main/scala/is/hail/expr/types/Type.scala
@@ -250,7 +250,9 @@ abstract class Type extends BaseType with Serializable {
 
   val ordering: ExtendedOrdering
 
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering
+  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = codeOrdering(mb, this)
+
+  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering
 
   def jsonReader: JSONReader[Annotation] = new JSONReader[Annotation] {
     def fromJSON(a: JValue): Annotation = JSONAnnotationImpex.importAnnotation(a, self)
@@ -311,8 +313,8 @@ abstract class Type extends BaseType with Serializable {
       case TFloat64(_) => t == TFloat64Optional || t == TFloat64Required
       case TString(_) => t == TStringOptional || t == TStringRequired
       case TCall(_) => t == TCallOptional || t == TCallRequired
-      case t2: TLocus => t == t2 || t == +t2
-      case t2: TInterval => t == t2 || t == +t2
+      case t2: TLocus => t.isInstanceOf[TLocus] && t.asInstanceOf[TLocus].rg == t2.rg
+      case t2: TInterval => t.isInstanceOf[TInterval] && t.asInstanceOf[TInterval].pointType.isOfType(t2.pointType)
       case t2: TStruct =>
         t.isInstanceOf[TStruct] &&
           t.asInstanceOf[TStruct].size == t2.size &&

--- a/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -290,7 +290,8 @@ class IRSuite extends TestNGSuite {
     Array(Map(0L -> 5, 3L -> 20), TDict(+TInt64(), TInt32()), TDict(TInt64(), +TInt32())),
     Array(Interval(1, 2, includesStart = false, includesEnd = true), TInterval(+TInt32()), TInterval(TInt32())),
     Array(Row("foo", 0.0), TStruct("a" -> +TString(), "b" -> +TFloat64()), TStruct("a" -> TString(), "b" -> TFloat64())),
-    Array(Row("foo", 0.0), TTuple(TString(), +TFloat64()), TTuple(+TString(), +TFloat64()))
+    Array(Row("foo", 0.0), TTuple(TString(), +TFloat64()), TTuple(+TString(), +TFloat64())),
+    Array(Row(FastIndexedSeq("foo"), 0.0), TTuple(+TArray(TString()), +TFloat64()), TTuple(TArray(+TString()), +TFloat64()))
   )
 
   @Test(dataProvider="compareDifferentTypes")


### PR DESCRIPTION
This was preventing some of the python import_vcf tests from going through IR.