### PR TITLE
More index btree array position tests

### DIFF
--- a/src/main/scala/is/hail/io/IndexBTree.scala
+++ b/src/main/scala/is/hail/io/IndexBTree.scala
@@ -139,10 +139,8 @@ class IndexBTree(indexFileName: String, hConf: Configuration, branchingFactor: I
 
     if (currentDepth == maxDepth) {
       val (bytePosition, value) = searchLastBlock()
-      val leadingElements =
-        if (currentDepth == 1) 0L
-        else math.pow(branchingFactor, currentDepth - 1).toLong
-      (bytePosition / 8 - leadingElements, value)
+      val leadingBytes = getOffset(currentDepth)
+      ((bytePosition - leadingBytes) / 8, value)
     } else {
       val matchPosition = searchBlock()
       val blockIndex = (matchPosition - getOffset(currentDepth)) / 8

--- a/src/test/scala/is/hail/io/IndexBTreeSuite.scala
+++ b/src/test/scala/is/hail/io/IndexBTreeSuite.scala
@@ -153,7 +153,58 @@ class IndexBTreeSuite extends SparkSuite {
     val branchingFactor = 1024
     IndexBTree.write(v, f, hadoopConf, branchingFactor = branchingFactor)
     val bt = new IndexBTree(f, hadoopConf, branchingFactor = branchingFactor)
-    // assert(bt.queryArrayPositionAndFileOffset(sqr(1024)+1) == Some(1024, sqr(1025)))
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1022)) == Some(1022, sqr(1022)))
 
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1022)+1) == Some(1023, sqr(1023)))
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1023)-1) == Some(1023, sqr(1023)))
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1023)) == Some(1023, sqr(1023)))
+
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1023)+1) == Some(1024, sqr(1024)))
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1024)-1) == Some(1024, sqr(1024)))
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1024)) == Some(1024, sqr(1024)))
+
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1024)+1) == Some(1025, sqr(1025)))
+
+    assert(bt.queryArrayPositionAndFileOffset(0) == Some(0, sqr(0)))
+    assert(bt.queryArrayPositionAndFileOffset(1) == Some(1, sqr(1)))
+    assert(bt.queryArrayPositionAndFileOffset(2) == Some(2, sqr(2)))
+    assert(bt.queryArrayPositionAndFileOffset(3) == Some(2, sqr(2)))
+    assert(bt.queryArrayPositionAndFileOffset(4) == Some(2, sqr(2)))
+    assert(bt.queryArrayPositionAndFileOffset(5) == Some(3, sqr(3)))
+  }
+
+  @Test def queryArrayPositionAndFileOffsetIsCorrectThreeLevelsArray() {
+    def sqr(x: Long) = x * x
+    val f = tmpDir.createTempFile(prefix = "btree")
+    val v = Array.tabulate(1024*1024+1)(x => sqr(x))
+    val branchingFactor = 1024
+    IndexBTree.write(v, f, hadoopConf, branchingFactor = branchingFactor)
+    val bt = new IndexBTree(f, hadoopConf, branchingFactor = branchingFactor)
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1022)) == Some(1022, sqr(1022)))
+
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1022)+1) == Some(1023, sqr(1023)))
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1023)-1) == Some(1023, sqr(1023)))
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1023)) == Some(1023, sqr(1023)))
+
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1023)+1) == Some(1024, sqr(1024)))
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1024)-1) == Some(1024, sqr(1024)))
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1024)) == Some(1024, sqr(1024)))
+
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1024)+1) == Some(1025, sqr(1025)))
+
+    assert(bt.queryArrayPositionAndFileOffset(0) == Some(0, sqr(0)))
+    assert(bt.queryArrayPositionAndFileOffset(1) == Some(1, sqr(1)))
+    assert(bt.queryArrayPositionAndFileOffset(2) == Some(2, sqr(2)))
+    assert(bt.queryArrayPositionAndFileOffset(3) == Some(2, sqr(2)))
+    assert(bt.queryArrayPositionAndFileOffset(4) == Some(2, sqr(2)))
+    assert(bt.queryArrayPositionAndFileOffset(5) == Some(3, sqr(3)))
+
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1024*1024-1)) == Some(1024*1024-1, sqr(1024*1024-1)))
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1024*1024-1)+1) == Some(1024*1024, sqr(1024*1024)))
+
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1024*1024)) == Some(1024*1024, sqr(1024*1024)))
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1024*1024)-1) == Some(1024*1024, sqr(1024*1024)))
+
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1024*1024)+1) == None)
   }
 }

--- a/src/test/scala/is/hail/io/IndexBTreeSuite.scala
+++ b/src/test/scala/is/hail/io/IndexBTreeSuite.scala
@@ -163,7 +163,7 @@ class IndexBTreeSuite extends SparkSuite {
     assert(bt.queryArrayPositionAndFileOffset(sqr(1024)-1) == Some(1024, sqr(1024)))
     assert(bt.queryArrayPositionAndFileOffset(sqr(1024)) == Some(1024, sqr(1024)))
 
-    assert(bt.queryArrayPositionAndFileOffset(sqr(1024)+1) == Some(1025, sqr(1025)))
+    assert(bt.queryArrayPositionAndFileOffset(sqr(1024)+1) == None)
 
     assert(bt.queryArrayPositionAndFileOffset(0) == Some(0, sqr(0)))
     assert(bt.queryArrayPositionAndFileOffset(1) == Some(1, sqr(1)))

--- a/src/test/scala/is/hail/io/IndexBTreeSuite.scala
+++ b/src/test/scala/is/hail/io/IndexBTreeSuite.scala
@@ -128,13 +128,12 @@ class IndexBTreeSuite extends SparkSuite {
     assert(index.queryIndex(33).contains(33L))
   }
 
-  @Test def queryArrayPositionAndFileOffsetIsCorrect() {
+  @Test def queryArrayPositionAndFileOffsetIsCorrectSmallArray() {
     val f = tmpDir.createTempFile(prefix = "btree")
     val v = Array[Long](1, 2, 3, 40, 50, 60, 70)
     val branchingFactor = 1024
     IndexBTree.write(v, f, hadoopConf, branchingFactor = branchingFactor)
     val bt = new IndexBTree(f, hadoopConf, branchingFactor = branchingFactor)
-    assert(bt.queryIndex(1) == Some(1))
     assert(bt.queryArrayPositionAndFileOffset(1) == Some(0, 1))
     assert(bt.queryArrayPositionAndFileOffset(2) == Some(1, 2))
     assert(bt.queryArrayPositionAndFileOffset(3) == Some(2, 3))
@@ -145,5 +144,16 @@ class IndexBTreeSuite extends SparkSuite {
     assert(bt.queryArrayPositionAndFileOffset(65) == Some(6, 70))
     assert(bt.queryArrayPositionAndFileOffset(70) == Some(6, 70))
     assert(bt.queryArrayPositionAndFileOffset(71) == None)
+  }
+
+  @Test def queryArrayPositionAndFileOffsetIsCorrectTwoLevelsArray() {
+    def sqr(x: Long) = x * x
+    val f = tmpDir.createTempFile(prefix = "btree")
+    val v = Array.tabulate(1025)(x => sqr(x))
+    val branchingFactor = 1024
+    IndexBTree.write(v, f, hadoopConf, branchingFactor = branchingFactor)
+    val bt = new IndexBTree(f, hadoopConf, branchingFactor = branchingFactor)
+    // assert(bt.queryArrayPositionAndFileOffset(sqr(1024)+1) == Some(1024, sqr(1025)))
+
   }
 }


### PR DESCRIPTION
I knew I was missing tests of greater than two layers. Sure enough there were more bugs lurking. I think >3 layers won't find any new bugs given that there are basically three kinds of b-trees:

 - 1 layer: all leaf nodes, <=1024 elements
 - 2 layers: one internal/key layer, one leaf layer [1025, 1024^2] elements
 - n layers: n-1 internal/key layers, one leaf layer [1024^(n-1)+1, 1024^n] elements

The last case is the first case where we have to do two levels of internal layers. This traversal is defined inductively, so I suspect succeeding on 3 layers tests all the functionality of >3 layers.
