### PR TITLE
Add BGEN File Row Index Row Field

### DIFF
--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -787,7 +787,7 @@ def grep(regex, path, max_count=100):
            reference_genome=nullable(reference_genome_type),
            contig_recoding=nullable(dictof(str, str)),
            skip_invalid_loci=bool,
-           _row_fields=sequenceof(enumeration('varid', 'rsid')))
+           _row_fields=sequenceof(enumeration('varid', 'rsid', 'file_row_idx')))
 def import_bgen(path,
                 entry_fields,
                 sample_file=None,
@@ -917,7 +917,7 @@ def import_bgen(path,
 
     jmt = Env.hc()._jhc.importBgens(jindexed_seq_args(path), joption(sample_file),
                                     'GT' in entry_set, 'GP' in entry_set, 'dosage' in entry_set,
-                                    'varid' in row_set, 'rsid' in row_set,
+                                    'varid' in row_set, 'rsid' in row_set, 'file_row_idx' in row_set,
                                     joption(min_partitions), joption(rg), joption(contig_recoding),
                                     skip_invalid_loci)
     return MatrixTable(jmt)

--- a/python/hail/tests/test_io.py
+++ b/python/hail/tests/test_io.py
@@ -545,6 +545,22 @@ class BGENTests(unittest.TestCase):
         self.assertTrue(
             default_row_fields.drop('varid', 'rsid')._same(no_row_fields))
 
+    def test_import_bgen_row_fields(self):
+        mt = hl.import_bgen(resource('example.8bits.bgen'),
+                            entry_fields=['dosage'],
+                            contig_recoding={'01': '1'},
+                            reference_genome='GRCh37',
+                            _row_fields=['rsid', 'file_row_idx'])
+        self.assertEqual(mt.file_row_idx.take(10), [99, 0, 100, 1, 101, 2, 102, 3, 103, 4])
+
+        # the rsids are numbered 2 to 200 and corresond to the order of the
+        # variants in the file (the loci are out of order in this file)
+        #
+        # the rsids look like: "RSID_99"
+        rsids = mt.rsid.collect()
+        self.assertEqual(mt.file_row_idx.collect(),
+                         [int(rsid[5:]) - 2 for rsid in rsids])
+
 
 class GENTests(unittest.TestCase):
     def test_import_gen(self):

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -299,11 +299,12 @@ class HailContext private(val sc: SparkContext,
     includeDosage: Boolean,
     includeLid: Boolean,
     includeRsid: Boolean,
+    includeFileRowIdx: Boolean = false,
     nPartitions: Option[Int] = None,
     rg: Option[ReferenceGenome] = Some(ReferenceGenome.defaultReference),
     contigRecoding: Option[Map[String, String]] = None,
     skipInvalidLoci: Boolean = false): MatrixTable = {
-    importBgens(List(file), sampleFile, includeGT, includeGP, includeDosage, includeLid, includeRsid,
+    importBgens(List(file), sampleFile, includeGT, includeGP, includeDosage, includeLid, includeRsid, includeFileRowIdx,
       nPartitions, rg, contigRecoding, skipInvalidLoci)
   }
 
@@ -314,6 +315,7 @@ class HailContext private(val sc: SparkContext,
     includeDosage: Boolean = false,
     includeLid: Boolean = true,
     includeRsid: Boolean = true,
+    includeFileRowIdx: Boolean = false,
     nPartitions: Option[Int] = None,
     rg: Option[ReferenceGenome] = Some(ReferenceGenome.defaultReference),
     contigRecoding: Option[Map[String, String]] = None,
@@ -336,7 +338,7 @@ class HailContext private(val sc: SparkContext,
 
     rg.foreach(ref => contigRecoding.foreach(ref.validateContigRemap))
 
-    LoadBgen.load(this, inputs, sampleFile, includeGT, includeGP, includeDosage, includeLid, includeRsid,
+    LoadBgen.load(this, inputs, sampleFile, includeGT, includeGP, includeDosage, includeLid, includeRsid, includeFileRowIdx,
       nPartitions, rg, contigRecoding.getOrElse(Map.empty[String, String]), skipInvalidLoci)
   }
 

--- a/src/main/scala/is/hail/io/bgen/BgenRecord.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenRecord.scala
@@ -14,10 +14,12 @@ class BgenRecordV12 (
   includeLid: Boolean,
   includeRsid: Boolean,
   bfis: HadoopFSDataBinaryReader,
-  end: Long
+  end: Long,
+  partitionsFirstFileRowIndex: Long
 ) {
   private[this] var rsid: String = _
   private[this] var lid: String = _
+  private[this] var fileRowIdx: Long = partitionsFirstFileRowIndex - 1
   private[this] var contig: String = _
   private[this] var position: Int = _
   private[this] var alleles: Array[String] = _
@@ -34,12 +36,16 @@ class BgenRecordV12 (
 
   def getLid: String = lid
 
+  def getFileRowIdx: Long = fileRowIdx
+
   private[this] def includeAnyEntryFields =
     includeGT || includeGP || includeDosage
 
   def advance(): Boolean = {
     if (bfis.getPosition >= end)
       return false
+
+    fileRowIdx += 1
 
     if (includeLid)
       lid = bfis.readLengthAndString(2)

--- a/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -56,7 +56,6 @@ object LoadBgen {
     hadoop.setBoolean("includeDosage", includeDosage)
     hadoop.setBoolean("includeLid", includeLid)
     hadoop.setBoolean("includeRsid", includeRsid)
-    hadoop.setBoolean("includeFileRowIdx", includeFileRowIdx)
 
     val sc = hc.sc
     val results = files.map { file =>

--- a/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -88,15 +88,12 @@ object LoadBgen {
     info(s"Number of samples in BGEN files: $nSamples")
     info(s"Number of variants across all BGEN files: $nVariants")
 
-    val lidType = TString()
-    val rsidType = TString()
-    val fileRowIdxType = TInt64()
     val rowFields = Array(
       (true, "locus" -> TLocus.schemaFromRG(rg)),
       (true, "alleles" -> TArray(TString())),
-      (includeRsid, "rsid" -> rsidType),
-      (includeLid, "varid" -> lidType),
-      (includeFileRowIdx, "file_row_idx" -> fileRowIdxType))
+      (includeRsid, "rsid" -> TString()),
+      (includeLid, "varid" -> TString()),
+      (includeFileRowIdx, "file_row_idx" -> TInt64()))
       .withFilter(_._1).map(_._2)
 
     val signature = TStruct(rowFields:_*)
@@ -184,11 +181,11 @@ object LoadBgen {
           rvb.endArray()
 
           if (includeRsid)
-            rvb.addAnnotation(rsidType, record.getRsid)
+            rvb.addString(record.getRsid)
           if (includeLid)
-            rvb.addAnnotation(lidType, record.getLid)
+            rvb.addString(record.getLid)
           if (includeFileRowIdx)
-            rvb.addAnnotation(fileRowIdxType, record.getFileRowIdx)
+            rvb.addLong(record.getFileRowIdx)
           record.getValue(rvb) // gs
 
           rvb.endStruct()

--- a/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -35,6 +35,7 @@ object LoadBgen {
     includeDosage: Boolean,
     includeLid: Boolean,
     includeRsid: Boolean,
+    includeFileRowIdx: Boolean,
     nPartitions: Option[Int] = None,
     rg: Option[ReferenceGenome] = Some(ReferenceGenome.defaultReference),
     contigRecoding: Map[String, String] = Map.empty[String, String],
@@ -55,6 +56,7 @@ object LoadBgen {
     hadoop.setBoolean("includeDosage", includeDosage)
     hadoop.setBoolean("includeLid", includeLid)
     hadoop.setBoolean("includeRsid", includeRsid)
+    hadoop.setBoolean("includeFileRowIdx", includeFileRowIdx)
 
     val sc = hc.sc
     val results = files.map { file =>
@@ -88,11 +90,13 @@ object LoadBgen {
 
     val lidType = TString()
     val rsidType = TString()
+    val fileRowIdxType = TInt64()
     val rowFields = Array(
       (true, "locus" -> TLocus.schemaFromRG(rg)),
       (true, "alleles" -> TArray(TString())),
       (includeRsid, "rsid" -> rsidType),
-      (includeLid, "varid" -> lidType))
+      (includeLid, "varid" -> lidType),
+      (includeFileRowIdx, "file_row_idx" -> fileRowIdxType))
       .withFilter(_._1).map(_._2)
 
     val signature = TStruct(rowFields:_*)
@@ -183,6 +187,8 @@ object LoadBgen {
             rvb.addAnnotation(rsidType, record.getRsid)
           if (includeLid)
             rvb.addAnnotation(lidType, record.getLid)
+          if (includeFileRowIdx)
+            rvb.addAnnotation(fileRowIdxType, record.getFileRowIdx)
           record.getValue(rvb) // gs
 
           rvb.endStruct()


### PR DESCRIPTION
This builds on top of #3779 and will merge clean once that it's in. Please review after #3779 merges.

This adds a row field that is the index of the variant _in the original file_. This might not be the same as the locus ordered position. In particular, our 8bit test file has variants ordered by RSID, which is not the same ordering as the file ordering.

The next file will add a filter on file row indices. Then, finally, we can use all this in combination to generate a list of file row indices to keep and dramatically increase filtering speed.


```python
In [1]: import hail as hl
   ...: 
   ...: mt = hl.import_bgen('/Users/dking/projects/hail/src/test/resources/example.8bits.bgen',
   ...:                     entry_fields=['dosage'],
   ...:                     contig_recoding={'01': '1'},
   ...:                     reference_genome='GRCh37',
   ...:                     _row_fields=['varid', 'rsid', 'file_row_idx'])
   ...: 
   ...: mt.rows().show()
```
```
+---------------+------------+----------+-----------+--------------+
| locus         | alleles    | rsid     | varid     | file_row_idx |
+---------------+------------+----------+-----------+--------------+
| locus<GRCh37> | array<str> | str      | str       |        int64 |
+---------------+------------+----------+-----------+--------------+
| 1:1001        | ["A","G"]  | RSID_101 | SNPID_101 |           99 |
| 1:2000        | ["A","G"]  | RSID_2   | SNPID_2   |            0 |
| 1:2001        | ["A","G"]  | RSID_102 | SNPID_102 |          100 |
| 1:3000        | ["A","G"]  | RSID_3   | SNPID_3   |            1 |
| 1:3001        | ["A","G"]  | RSID_103 | SNPID_103 |          101 |
| 1:4000        | ["A","G"]  | RSID_4   | SNPID_4   |            2 |
| 1:4001        | ["A","G"]  | RSID_104 | SNPID_104 |          102 |
| 1:5000        | ["A","G"]  | RSID_5   | SNPID_5   |            3 |
| 1:5001        | ["A","G"]  | RSID_105 | SNPID_105 |          103 |
| 1:6000        | ["A","G"]  | RSID_6   | SNPID_6   |            4 |
+---------------+------------+----------+-----------+--------------+
```