### PR TITLE
BGEN File-Read-Level Filtering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,6 +159,7 @@ dependencies {
     testCompile 'org.scalatest:scalatest_' + scalaMajorVersion + ':2.2.4'
 
     compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
+    compile group: 'commons-codec', name: 'commons-codec', version: '1.11'
 }
 
 task(checkSettings) << {
@@ -291,6 +292,7 @@ shadowJar {
         include(dependency('net.sourceforge.jdistlib:jdistlib:.*'))
 
         include(dependency('org.apache.commons.commons-math3:3.6.1'))
+        include(dependency('commons-codec:commons-codec:.*'))
     }
 }
 
@@ -350,6 +352,7 @@ task shadowTestJar(type: ShadowJar) {
         include(dependency('net.java.dev.jna:jna:.*'))
         include(dependency('net.sourceforge.jdistlib:jdistlib:.*'))
         include(dependency('org.apache.commons.commons-math3:3.6.1'))
+        include(dependency('commons-codec:commons-codec:.*'))
     }
 }
 

--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -787,7 +787,8 @@ def grep(regex, path, max_count=100):
            reference_genome=nullable(reference_genome_type),
            contig_recoding=nullable(dictof(str, str)),
            skip_invalid_loci=bool,
-           _row_fields=sequenceof(enumeration('varid', 'rsid', 'file_row_idx')))
+           _row_fields=sequenceof(enumeration('varid', 'rsid', 'file_row_idx')),
+           _variants_per_file=dictof(str, sequenceof(int)))
 def import_bgen(path,
                 entry_fields,
                 sample_file=None,
@@ -795,7 +796,8 @@ def import_bgen(path,
                 reference_genome='default',
                 contig_recoding=None,
                 skip_invalid_loci=False,
-                _row_fields=['varid', 'rsid']) -> MatrixTable:
+                _row_fields=['varid', 'rsid'],
+                _variants_per_file={}) -> MatrixTable:
     """Import BGEN file(s) as a :class:`.MatrixTable`.
 
     Examples
@@ -919,7 +921,7 @@ def import_bgen(path,
                                     'GT' in entry_set, 'GP' in entry_set, 'dosage' in entry_set,
                                     'varid' in row_set, 'rsid' in row_set, 'file_row_idx' in row_set,
                                     joption(min_partitions), joption(rg), joption(contig_recoding),
-                                    skip_invalid_loci)
+                                    skip_invalid_loci, tdict(tstr, tarray(tint32))._convert_to_j(_variants_per_file)))
     return MatrixTable(jmt)
 
 

--- a/python/hail/methods/impex.py
+++ b/python/hail/methods/impex.py
@@ -921,7 +921,7 @@ def import_bgen(path,
                                     'GT' in entry_set, 'GP' in entry_set, 'dosage' in entry_set,
                                     'varid' in row_set, 'rsid' in row_set, 'file_row_idx' in row_set,
                                     joption(min_partitions), joption(rg), joption(contig_recoding),
-                                    skip_invalid_loci, tdict(tstr, tarray(tint32))._convert_to_j(_variants_per_file)))
+                                    skip_invalid_loci, tdict(tstr, tarray(tint32))._convert_to_j(_variants_per_file))
     return MatrixTable(jmt)
 
 

--- a/python/hail/tests/test_io.py
+++ b/python/hail/tests/test_io.py
@@ -567,7 +567,7 @@ class BGENTests(unittest.TestCase):
                                 ['GT'],
                                 contig_recoding={'01': '1'},
                                 reference_genome=None,
-                                row_fields=['file_row_idx'],
+                                _row_fields=['file_row_idx'],
                                 # FIXME use: os.path.abspath
                                 _variants_per_file={ 'file:' + '/Users/dking/projects/hail/src/test/resources/' + ('example.8bits.bgen') : desired_variant_indexes})
         print({ 'file:' + resource('example.8bits.bgen') : desired_variant_indexes})
@@ -578,7 +578,7 @@ class BGENTests(unittest.TestCase):
                                     ['GT'],
                                     contig_recoding={'01': '1'},
                                     reference_genome=None,
-                                    row_fields=['file_row_idx'])
+                                    _row_fields=['file_row_idx'])
         self.assertEqual(everything.count(), (199, 500))
 
         everything.rows().show()

--- a/python/hail/tests/test_io.py
+++ b/python/hail/tests/test_io.py
@@ -568,6 +568,7 @@ class BGENTests(unittest.TestCase):
                                 ['GT'],
                                 contig_recoding={'01': '1'},
                                 reference_genome=None,
+                                min_partitions=10,
                                 _row_fields=['file_row_idx'],
                                 _variants_per_file={ 'file:' + os.path.abspath(resource('example.8bits.bgen')) : desired_variant_indexes})
         print({ 'file:' + resource('example.8bits.bgen') : desired_variant_indexes})
@@ -581,16 +582,8 @@ class BGENTests(unittest.TestCase):
                                     _row_fields=['file_row_idx'])
         self.assertEqual(everything.count(), (199, 500))
 
-        everything.rows().show()
-
         expected = everything.filter_rows(
             hl.set(desired_variant_indexes).contains(hl.int32(everything.file_row_idx)))
-
-        actual.rows().show()
-        expected.rows().show(20)
-
-        print("actual size " + str(actual.count()))
-        print("expected size " + str(expected.count()))
 
         self.assertTrue(expected._same(actual))
         self.assertEqual((hl.str(actual.locus.contig) + ":" + hl.str(actual.locus.position)).collect(),

--- a/python/hail/tests/test_io.py
+++ b/python/hail/tests/test_io.py
@@ -570,8 +570,7 @@ class BGENTests(unittest.TestCase):
                                 reference_genome=None,
                                 min_partitions=10,
                                 _row_fields=['file_row_idx'],
-                                _variants_per_file={ 'file:' + os.path.abspath(resource('example.8bits.bgen')) : desired_variant_indexes})
-        print({ 'file:' + resource('example.8bits.bgen') : desired_variant_indexes})
+                                _variants_per_file={ resource('example.8bits.bgen') : desired_variant_indexes})
         # doing the expected import_bgen second catches the case where the
         # hadoop configuraiton is polluted with old data from the
         # _variants_per_file

--- a/python/hail/tests/test_io.py
+++ b/python/hail/tests/test_io.py
@@ -2,6 +2,7 @@ import hail as hl
 from .utils import resource, doctest_resource, startTestHailContext, stopTestHailContext
 from hail.utils import new_temp_file, FatalError, run_command, uri_path
 import unittest
+import os
 
 setUpModule = startTestHailContext
 tearDownModule = stopTestHailContext
@@ -568,8 +569,7 @@ class BGENTests(unittest.TestCase):
                                 contig_recoding={'01': '1'},
                                 reference_genome=None,
                                 _row_fields=['file_row_idx'],
-                                # FIXME use: os.path.abspath
-                                _variants_per_file={ 'file:' + '/Users/dking/projects/hail/src/test/resources/' + ('example.8bits.bgen') : desired_variant_indexes})
+                                _variants_per_file={ 'file:' + os.path.abspath(resources('example.8bits.bgen')) : desired_variant_indexes})
         print({ 'file:' + resource('example.8bits.bgen') : desired_variant_indexes})
         # doing the expected import_bgen second catches the case where the
         # hadoop configuraiton is polluted with old data from the

--- a/python/hail/tests/test_io.py
+++ b/python/hail/tests/test_io.py
@@ -569,7 +569,7 @@ class BGENTests(unittest.TestCase):
                                 contig_recoding={'01': '1'},
                                 reference_genome=None,
                                 _row_fields=['file_row_idx'],
-                                _variants_per_file={ 'file:' + os.path.abspath(resources('example.8bits.bgen')) : desired_variant_indexes})
+                                _variants_per_file={ 'file:' + os.path.abspath(resource('example.8bits.bgen')) : desired_variant_indexes})
         print({ 'file:' + resource('example.8bits.bgen') : desired_variant_indexes})
         # doing the expected import_bgen second catches the case where the
         # hadoop configuraiton is polluted with old data from the

--- a/python/hail/tests/test_io.py
+++ b/python/hail/tests/test_io.py
@@ -561,6 +561,42 @@ class BGENTests(unittest.TestCase):
         self.assertEqual(mt.file_row_idx.collect(),
                          [int(rsid[5:]) - 2 for rsid in rsids])
 
+    def test_import_bgen_variant_filtering(self):
+        desired_variant_indexes = [1,2,3,5,7,9,11,13,17,198]
+        actual = hl.import_bgen(resource('example.8bits.bgen'),
+                                ['GT'],
+                                contig_recoding={'01': '1'},
+                                reference_genome=None,
+                                row_fields=['file_row_idx'],
+                                # FIXME use: os.path.abspath
+                                _variants_per_file={ 'file:' + '/Users/dking/projects/hail/src/test/resources/' + ('example.8bits.bgen') : desired_variant_indexes})
+        print({ 'file:' + resource('example.8bits.bgen') : desired_variant_indexes})
+        # doing the expected import_bgen second catches the case where the
+        # hadoop configuraiton is polluted with old data from the
+        # _variants_per_file
+        everything = hl.import_bgen(resource('example.8bits.bgen'),
+                                    ['GT'],
+                                    contig_recoding={'01': '1'},
+                                    reference_genome=None,
+                                    row_fields=['file_row_idx'])
+        self.assertEqual(everything.count(), (199, 500))
+
+        everything.rows().show()
+
+        expected = everything.filter_rows(
+            hl.set(desired_variant_indexes).contains(hl.int32(everything.file_row_idx)))
+
+        actual.rows().show()
+        expected.rows().show(20)
+
+        print("actual size " + str(actual.count()))
+        print("expected size " + str(expected.count()))
+
+        self.assertTrue(expected._same(actual))
+        self.assertEqual((hl.str(actual.locus.contig) + ":" + hl.str(actual.locus.position)).collect(),
+                         ['1:3000', '1:4000', '1:5000', '1:7000', '1:9000',
+                          '1:11000', '1:13000', '1:15000', '1:19000', '1:100001'])
+
 
 class GENTests(unittest.TestCase):
     def test_import_gen(self):

--- a/src/main/scala/is/hail/HailContext.scala
+++ b/src/main/scala/is/hail/HailContext.scala
@@ -303,9 +303,11 @@ class HailContext private(val sc: SparkContext,
     nPartitions: Option[Int] = None,
     rg: Option[ReferenceGenome] = Some(ReferenceGenome.defaultReference),
     contigRecoding: Option[Map[String, String]] = None,
-    skipInvalidLoci: Boolean = false): MatrixTable = {
+    skipInvalidLoci: Boolean = false,
+    includedVariantsPerFile: Map[String, Seq[Int]] = Map.empty[String, Seq[Int]]
+  ): MatrixTable = {
     importBgens(List(file), sampleFile, includeGT, includeGP, includeDosage, includeLid, includeRsid, includeFileRowIdx,
-      nPartitions, rg, contigRecoding, skipInvalidLoci)
+      nPartitions, rg, contigRecoding, skipInvalidLoci, includedVariantsPerFile)
   }
 
   def importBgens(files: Seq[String],
@@ -319,7 +321,9 @@ class HailContext private(val sc: SparkContext,
     nPartitions: Option[Int] = None,
     rg: Option[ReferenceGenome] = Some(ReferenceGenome.defaultReference),
     contigRecoding: Option[Map[String, String]] = None,
-    skipInvalidLoci: Boolean = false): MatrixTable = {
+    skipInvalidLoci: Boolean = false,
+    includedVariantsPerFile: Map[String, Seq[Int]] = Map.empty[String, Seq[Int]]
+  ): MatrixTable = {
 
     val inputs = hadoopConf.globAll(files).flatMap { file =>
       if (!file.endsWith(".bgen"))
@@ -339,7 +343,7 @@ class HailContext private(val sc: SparkContext,
     rg.foreach(ref => contigRecoding.foreach(ref.validateContigRemap))
 
     LoadBgen.load(this, inputs, sampleFile, includeGT, includeGP, includeDosage, includeLid, includeRsid, includeFileRowIdx,
-      nPartitions, rg, contigRecoding.getOrElse(Map.empty[String, String]), skipInvalidLoci)
+      nPartitions, rg, contigRecoding.getOrElse(Map.empty[String, String]), skipInvalidLoci, includedVariantsPerFile)
   }
 
   def importGen(file: String,

--- a/src/main/scala/is/hail/io/IndexBTree.scala
+++ b/src/main/scala/is/hail/io/IndexBTree.scala
@@ -9,10 +9,10 @@ import org.apache.hadoop.fs._
 import scala.collection.mutable
 
 object IndexBTree {
-  private[io] def calcDepth(numBtreeElements: Long, branchingFactor: Int): Int = {
+  private[io] def calcDepth(internalAndExternalNodeCount: Long, branchingFactor: Int): Int = {
     var depth = 1
     var maximumTreeSize = branchingFactor.toLong
-    while (numBtreeElements > maximumTreeSize) {
+    while (internalAndExternalNodeCount > maximumTreeSize) {
       assert(depth <= 6) // 1024^7 > Long.MaxValue
       maximumTreeSize = maximumTreeSize * branchingFactor + branchingFactor
       depth += 1

--- a/src/main/scala/is/hail/io/IndexBTree.scala
+++ b/src/main/scala/is/hail/io/IndexBTree.scala
@@ -1,5 +1,6 @@
 package is.hail.io
 
+import java.io.Closeable
 import java.util.Arrays
 import is.hail.utils._
 import org.apache.hadoop.conf.Configuration
@@ -76,7 +77,7 @@ object IndexBTree {
     btreeLayers(arr, branchingFactor).map(_.mkString("[", " ", "]")).mkString("(BTREE\n", "\n", "\n)")
 }
 
-class IndexBTree(indexFileName: String, hConf: Configuration, branchingFactor: Int = 1024) {
+class IndexBTree(indexFileName: String, hConf: Configuration, branchingFactor: Int = 1024) extends Closeable {
   val maxDepth = calcDepth()
   private val fs = try {
     hConf.fileSystem(indexFileName).open(new Path(indexFileName))

--- a/src/main/scala/is/hail/io/IndexBTree.scala
+++ b/src/main/scala/is/hail/io/IndexBTree.scala
@@ -219,7 +219,7 @@ class OnDiskBTreeIndexToValue(
   }
 
   private[this] val layers = numLayers(hConf.getFileSize(path) / 8)
-  private[this] val junk = leadingElements(layers - 1)
+  private[this] val junk = leadingElements(layers)
   private[this] var fs = try {
     log.info("reading index file: " + path)
     hConf.fileSystem(path).open(new Path(path))
@@ -237,6 +237,7 @@ class OnDiskBTreeIndexToValue(
       Arrays.sort(indices)
       fs.seek((junk + indices(0)) * 8)
       a(0) = fs.readLong()
+      assert(a(0) != -1, "0")
       var i = 1
       while (i < indices.length) {
         if (indices(i) == indices(i - 1)) {
@@ -246,6 +247,7 @@ class OnDiskBTreeIndexToValue(
           assert(jump >= 0)
           fs.skipBytes(jump)
           a(i) = fs.readLong()
+          assert(a(i) != -1, s"$i")
         }
         i += 1
       }

--- a/src/main/scala/is/hail/io/IndexBTree.scala
+++ b/src/main/scala/is/hail/io/IndexBTree.scala
@@ -9,6 +9,17 @@ import org.apache.hadoop.fs._
 import scala.collection.mutable
 
 object IndexBTree {
+  private[io] def calcDepth(numBtreeElements: Long, branchingFactor: Int): Int = {
+    var depth = 1
+    var maximumTreeSize = branchingFactor.toLong
+    while (numBtreeElements > maximumTreeSize) {
+      assert(depth <= 6) // 1024^7 > Long.MaxValue
+      maximumTreeSize = maximumTreeSize * branchingFactor + branchingFactor
+      depth += 1
+    }
+    depth
+  }
+
   private[io] def calcDepth(arr: Array[Long], branchingFactor: Int) =
     //max necessary for array of length 1 becomes depth=0
     math.max(1, (math.log10(arr.length) / math.log10(branchingFactor)).ceil.toInt)
@@ -87,14 +98,8 @@ class IndexBTree(indexFileName: String, hConf: Configuration, branchingFactor: I
 
   def close() = fs.close()
 
-  def calcDepth(): Int = {
-    val numBtreeElements = hConf.getFileSize(indexFileName) / 8
-    var depth = 1
-    while (numBtreeElements > math.pow(branchingFactor, depth).toInt) {
-      depth += 1
-    }
-    depth
-  }
+  def calcDepth(): Int =
+    IndexBTree.calcDepth(hConf.getFileSize(indexFileName) / 8, branchingFactor)
 
   private def getOffset(depth: Int): Long = {
     (1 until depth).map(math.pow(branchingFactor, _).toLong * 8).sum
@@ -201,12 +206,8 @@ class OnDiskBTreeIndexToValue(
   hConf: Configuration,
   branchingFactor: Int = 1024
 ) extends AutoCloseable {
-  private[this] def numLayers(size: Long): Int = {
-    if (size <= branchingFactor)
-      1
-    else
-      (math.log(size) / math.log(branchingFactor)).floor.toInt
-  }
+  private[this] def numLayers(size: Long): Int =
+    IndexBTree.calcDepth(size, branchingFactor)
 
   private[this] def leadingElements(layer: Int): Long = {
     var i = 0
@@ -219,7 +220,7 @@ class OnDiskBTreeIndexToValue(
   }
 
   private[this] val layers = numLayers(hConf.getFileSize(path) / 8)
-  private[this] val junk = leadingElements(layers)
+  private[this] val junk = leadingElements(layers - 1)
   private[this] var fs = try {
     log.info("reading index file: " + path)
     hConf.fileSystem(path).open(new Path(path))
@@ -237,7 +238,7 @@ class OnDiskBTreeIndexToValue(
       Arrays.sort(indices)
       fs.seek((junk + indices(0)) * 8)
       a(0) = fs.readLong()
-      assert(a(0) != -1, "0")
+      assert(a(0) != -1)
       var i = 1
       while (i < indices.length) {
         if (indices(i) == indices(i - 1)) {
@@ -247,7 +248,7 @@ class OnDiskBTreeIndexToValue(
           assert(jump >= 0)
           fs.skipBytes(jump)
           a(i) = fs.readLong()
-          assert(a(i) != -1, s"$i")
+          assert(a(i) != -1)
         }
         i += 1
       }

--- a/src/main/scala/is/hail/io/IndexedBinaryBlockReader.scala
+++ b/src/main/scala/is/hail/io/IndexedBinaryBlockReader.scala
@@ -39,8 +39,6 @@ abstract class IndexedBinaryBlockReader[T](job: Configuration, split: FileSplit)
     new HadoopFSDataBinaryReader(fs.open(file))
   }
 
-  def seekToFirstBlockInSplit(start: Long): Unit
-
   def createKey(): LongWritable = new LongWritable()
 
   def createValue(): T

--- a/src/main/scala/is/hail/io/bgen/BgenBlockReader.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenBlockReader.scala
@@ -7,37 +7,39 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.LongWritable
 import org.apache.hadoop.mapred.FileSplit
 
-class BgenBlockReaderV12(job: Configuration, split: FileSplit) extends IndexedBinaryBlockReader[BgenRecordV12](job, split) {
-  val file = split.getPath
-  val bState = LoadBgen.readState(bfis)
-  val indexPath = file + ".idx"
-  val btree = new IndexBTree(indexPath, job)
+class BgenBlockReaderV12(
+  job: Configuration,
+  split: BgenV12InputSplit
+) extends IndexedBinaryBlockReader[BgenRecordV12](job, split.fileSplit) {
+  private[this] val file = split.getPath
+  private[this] val bState = LoadBgen.readState(bfis)
+  private[this] val indexPath = file + ".idx"
 
-  val includeGT = job.get("includeGT").toBoolean
-  val includeGP = job.get("includeGP").toBoolean
-  val includeDosage = job.get("includeDosage").toBoolean
-  val includeLid = job.get("includeLid").toBoolean
-  val includeRsid = job.get("includeRsid").toBoolean
-
+  private[this] val includeGT = job.get("includeGT").toBoolean
+  private[this] val includeGP = job.get("includeGP").toBoolean
+  private[this] val includeDosage = job.get("includeDosage").toBoolean
+  private[this] val includeLid = job.get("includeLid").toBoolean
+  private[this] val includeRsid = job.get("includeRsid").toBoolean
   private[bgen] var partitionFirstFileRowIdx: Long = _
 
-  seekToFirstBlockInSplit(split.getStart)
-
-  def seekToFirstBlockInSplit(start: Long) {
-    btree.queryArrayPositionAndFileOffset(start) match {
-      case Some((arrayPosition, byteOffset)) =>
-        partitionFirstFileRowIdx = arrayPosition
-        pos = byteOffset
-      case None =>
-        pos = end
+  using(new IndexBTree(indexPath, job)) { btree =>
+    if (split.hasFilter) {
+      pos = split.keptPositions(0)
+    } else {
+      btree.queryArrayPositionAndFileOffset(split.getStart) match {
+        case Some((arrayPosition, byteOffset)) =>
+          partitionFirstFileRowIdx = arrayPosition
+          pos = byteOffset
+        case None =>
+          pos = end
+      }
     }
-
-    btree.close()
-    bfis.seek(pos)
   }
 
+  bfis.seek(pos)
+
   override def createValue(): BgenRecordV12 =
-    new BgenRecordV12(bState.compressed, bState.nSamples, includeGT, includeGP, includeDosage, includeLid, includeRsid, bfis, end, partitionFirstFileRowIdx)
+    new BgenRecordV12(bState.compressed, bState.nSamples, includeGT, includeGP, includeDosage, includeLid, includeRsid, bfis, end, partitionFirstFileRowIdx, split)
 
   override def next(key: LongWritable, value: BgenRecordV12): Boolean = {
     value.advance()

--- a/src/main/scala/is/hail/io/bgen/BgenBlockReader.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenBlockReader.scala
@@ -20,7 +20,7 @@ class BgenBlockReaderV12(
   private[this] val includeDosage = job.get("includeDosage").toBoolean
   private[this] val includeLid = job.get("includeLid").toBoolean
   private[this] val includeRsid = job.get("includeRsid").toBoolean
-  private[bgen] var partitionFirstFileRowIdx: Long = _
+  private[this] var partitionFirstFileRowIdx: Long = _
 
   using(new IndexBTree(indexPath, job)) { btree =>
     if (split.hasFilter) {

--- a/src/main/scala/is/hail/io/bgen/BgenInputFormat.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenInputFormat.scala
@@ -52,7 +52,7 @@ class BgenV12InputSplit(
   require(keptIndices == null && keptPositions == null ||
     keptIndices.length == keptPositions.length)
   def this() = this(null, null, null)
-  def hasFilter: Boolean = keptIndices == null
+  def hasFilter: Boolean = keptIndices != null
   def getPath(): Path = fileSplit.getPath()
   def getStart(): Long = fileSplit.getStart()
   def getLength(): Long = fileSplit.getLength()

--- a/src/main/scala/is/hail/io/bgen/BgenInputFormat.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenInputFormat.scala
@@ -2,6 +2,7 @@ package is.hail.io.bgen
 
 import is.hail.utils._
 import is.hail.io._
+import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.LongWritable
 import org.apache.hadoop.mapred._
 
@@ -51,6 +52,9 @@ class BgenV12InputSplit(
   require(keptIndices == null && keptPositions == null ||
     keptIndices.length == keptPositions.length)
   def this() = this(null, null, null)
+  def hasFilter: Boolean = keptIndices == null
+  def getPath(): Path = fileSplit.getPath()
+  def getStart(): Long = fileSplit.getStart()
   def getLength(): Long = fileSplit.getLength()
   def getLocations(): Array[String] = fileSplit.getLocations()
   def readFields(in: java.io.DataInput): Unit = {

--- a/src/main/scala/is/hail/io/bgen/BgenInputFormat.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenInputFormat.scala
@@ -24,7 +24,6 @@ class BgenInputFormatV12 extends IndexedBinaryInputFormat[BgenRecordV12] {
         positions != null && indices != null)
       if (positions != null) {
         val decodedPositions = LoadBgen.decodeLongs(positions)
-        log.info(s"variant filters found for $path: ${decodedPositions.mkString("[", ",", "]")}")
         val (keptIndices, keptPositions) = LoadBgen.decodeInts(indices).zip(decodedPositions)
           .filter { case (_, x) =>
             split.getStart <= x && x < split.getStart + split.getLength

--- a/src/main/scala/is/hail/io/bgen/BgenInputFormat.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenInputFormat.scala
@@ -1,6 +1,7 @@
 package is.hail.io.bgen
 
-import is.hail.io.IndexedBinaryInputFormat
+import is.hail.utils._
+import is.hail.io._
 import org.apache.hadoop.io.LongWritable
 import org.apache.hadoop.mapred._
 
@@ -8,6 +9,95 @@ class BgenInputFormatV12 extends IndexedBinaryInputFormat[BgenRecordV12] {
   override def getRecordReader(split: InputSplit, job: JobConf, reporter: Reporter): RecordReader[LongWritable,
     BgenRecordV12] = {
     reporter.setStatus(split.toString)
-    new BgenBlockReaderV12(job, split.asInstanceOf[FileSplit])
+    new BgenBlockReaderV12(job, split.asInstanceOf[BgenV12InputSplit])
   }
+
+  override def getSplits(job: JobConf, numSplits: Int): Array[InputSplit] = {
+    val splits = super.getSplits(job, numSplits)
+    splits.flatMap { x =>
+      val split = x.asInstanceOf[FileSplit]
+      val path = split.getPath
+      val positions = job.get(LoadBgen.includedVariantsPositionsHadoopPrefix + path)
+      val indices = job.get(LoadBgen.includedVariantsIndicesHadoopPrefix + path)
+      assert(positions == null && indices == null ||
+        positions != null && indices != null)
+      if (positions != null) {
+        val decodedPositions = LoadBgen.decodeLongs(positions)
+        log.info(s"variant filters found for $path: ${decodedPositions.mkString("[", ",", "]")}")
+        val (keptIndices, keptPositions) = LoadBgen.decodeInts(indices).zip(decodedPositions)
+          .filter { case (_, x) =>
+            split.getStart <= x && x < split.getStart + split.getLength
+        } .unzip
+
+        log.info(s"kept ${keptPositions.length} for split $x")
+
+        if (keptPositions.isEmpty)
+          None
+        else
+          Some(new BgenV12InputSplit(split, keptIndices, keptPositions))
+      } else {
+        log.info(s"no variant filters found for $path")
+        Some(new BgenV12InputSplit(split, null, null))
+      }
+    }
+  }
+}
+
+class BgenV12InputSplit(
+  var fileSplit: FileSplit,
+  var keptIndices: Array[Int],
+  var keptPositions: Array[Long]
+) extends InputSplit {
+  require(keptIndices == null && keptPositions == null ||
+    keptIndices.length == keptPositions.length)
+  def this() = this(null, null, null)
+  def getLength(): Long = fileSplit.getLength()
+  def getLocations(): Array[String] = fileSplit.getLocations()
+  def readFields(in: java.io.DataInput): Unit = {
+    fileSplit = new FileSplit(new org.apache.hadoop.mapreduce.lib.input.FileSplit())
+    fileSplit.readFields(in)
+    val indicesLen = in.readInt()
+    if (indicesLen != -1) {
+      var i = 0
+      keptIndices = new Array[Int](indicesLen)
+      while (i < indicesLen) {
+        keptIndices(i) = in.readInt()
+        i += 1
+      }
+    }
+    val positionsLen = in.readInt()
+    if (positionsLen != -1) {
+      var i = 0
+      keptPositions = new Array[Long](positionsLen)
+      while (i < positionsLen) {
+        keptPositions(i) = in.readLong()
+        i += 1
+      }
+    }
+  }
+  def write(out: java.io.DataOutput): Unit = {
+    fileSplit.write(out)
+    if (keptIndices == null)
+      out.writeInt(-1)
+    else {
+      out.writeInt(keptIndices.length)
+      var i = 0
+      while (i < keptIndices.length) {
+        out.writeInt(keptIndices(i))
+        i += 1
+      }
+    }
+    if (keptPositions == null)
+      out.writeInt(-1)
+    else {
+      out.writeInt(keptPositions.length)
+      var i = 0
+      while (i < keptPositions.length) {
+        out.writeLong(keptPositions(i))
+        i += 1
+      }
+    }
+  }
+  override def toString(): String =
+    s"BgenV12InputSplit($fileSplit, $keptPositions)"
 }

--- a/src/main/scala/is/hail/io/bgen/BgenRecord.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenRecord.scala
@@ -47,7 +47,11 @@ class BgenRecordV12 (
     if (bfis.getPosition >= end)
       return false
 
-    fileRowIdx += 1
+    if (split.hasFilter) {
+      fileRowIdx = split.keptIndices(filterIndex)
+    } else {
+      fileRowIdx += 1
+    }
 
     if (includeLid)
       lid = bfis.readLengthAndString(2)

--- a/src/main/scala/is/hail/io/bgen/BgenRecord.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenRecord.scala
@@ -15,7 +15,8 @@ class BgenRecordV12 (
   includeRsid: Boolean,
   bfis: HadoopFSDataBinaryReader,
   end: Long,
-  partitionsFirstFileRowIndex: Long
+  partitionsFirstFileRowIndex: Long,
+  split: BgenV12InputSplit
 ) {
   private[this] var rsid: String = _
   private[this] var lid: String = _
@@ -25,6 +26,7 @@ class BgenRecordV12 (
   private[this] var alleles: Array[String] = _
   private[this] var data: Array[Byte] = _
   private[this] var dataSize: Int = 0
+  private[this] var filterIndex = 0
 
   def getContig: String = contig
 
@@ -139,6 +141,11 @@ class BgenRecordV12 (
                  |match the expected size `$nExpectedBytesProbs'.""".stripMargin)
     } else {
       bfis.skipBytes(dataSize)
+    }
+
+    if (split.hasFilter) {
+      filterIndex += 1
+      bfis.seek(split.keptPositions(filterIndex))
     }
 
     return true

--- a/src/main/scala/is/hail/io/bgen/BgenRecord.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenRecord.scala
@@ -152,8 +152,10 @@ class BgenRecordV12 (
     }
 
     if (split.hasFilter) {
-      // skip to next variant
-      bfis.seek(split.keptPositions(filterIndex))
+      if (filterIndex < split.keptIndices.length) {
+        // skip to next variant
+        bfis.seek(split.keptPositions(filterIndex))
+      }
     }
 
     return true

--- a/src/main/scala/is/hail/io/bgen/BgenRecord.scala
+++ b/src/main/scala/is/hail/io/bgen/BgenRecord.scala
@@ -44,13 +44,17 @@ class BgenRecordV12 (
     includeGT || includeGP || includeDosage
 
   def advance(): Boolean = {
-    if (bfis.getPosition >= end)
-      return false
-
     if (split.hasFilter) {
-      fileRowIdx = split.keptIndices(filterIndex)
+      if (filterIndex < split.keptIndices.length) {
+        fileRowIdx = split.keptIndices(filterIndex)
+        filterIndex += 1
+      } else
+        return false
     } else {
-      fileRowIdx += 1
+      if (bfis.getPosition < end)
+        fileRowIdx += 1
+      else
+        return false
     }
 
     if (includeLid)
@@ -148,7 +152,7 @@ class BgenRecordV12 (
     }
 
     if (split.hasFilter) {
-      filterIndex += 1
+      // skip to next variant
       bfis.seek(split.keptPositions(filterIndex))
     }
 

--- a/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -349,4 +349,66 @@ object LoadBgen {
     val hasIds = (flags >> 31 & 1) != 0
     BgenHeader(isCompressed, nSamples, nVariants, headerLength, dataStart, hasIds, version)
   }
+
+  private[bgen] def encodeInts(a: Array[Int]): String = {
+    val b = new Array[Byte](a.length*4)
+    var i = 0
+    while (i < a.length) {
+      b(4*i) = (a(i) & 0xff).asInstanceOf[Byte]
+      b(4*i+1) = ((a(i) >>> 8) & 0xff).asInstanceOf[Byte]
+      b(4*i+2) = ((a(i) >>> 16) & 0xff).asInstanceOf[Byte]
+      b(4*i+3) = ((a(i) >>> 24) & 0xff).asInstanceOf[Byte]
+      i += 1
+    }
+    Base64.encodeBase64String(b)
+  }
+
+  private[bgen] def decodeInts(a: String): Array[Int] = {
+    val b = Base64.decodeBase64(a)
+    val c = new Array[Int](b.length/4)
+    var i = 0
+    while (i < c.length) {
+      c(i) = ((b(i*4+3) & 0xff).asInstanceOf[Int] << 24) |
+             ((b(i*4+2) & 0xff).asInstanceOf[Int] << 16) |
+             ((b(i*4+1) & 0xff).asInstanceOf[Int] << 8) |
+             (b(i*4).asInstanceOf[Int] & 0xff)
+      i += 1
+    }
+    c
+  }
+
+  private[bgen] def encodeLongs(a: Array[Long]): String = {
+    val b = new Array[Byte](a.length*8)
+    var i = 0
+    while (i < a.length) {
+      b(8*i) = (a(i) & 0xff).asInstanceOf[Byte]
+      b(8*i+1) = ((a(i) >>> 8) & 0xff).asInstanceOf[Byte]
+      b(8*i+2) = ((a(i) >>> 16) & 0xff).asInstanceOf[Byte]
+      b(8*i+3) = ((a(i) >>> 24) & 0xff).asInstanceOf[Byte]
+      b(8*i+4) = ((a(i) >>> 32) & 0xff).asInstanceOf[Byte]
+      b(8*i+5) = ((a(i) >>> 40) & 0xff).asInstanceOf[Byte]
+      b(8*i+6) = ((a(i) >>> 48) & 0xff).asInstanceOf[Byte]
+      b(8*i+7) = ((a(i) >>> 56) & 0xff).asInstanceOf[Byte]
+      i += 1
+    }
+    Base64.encodeBase64String(b)
+  }
+
+  private[bgen] def decodeLongs(a: String): Array[Long] = {
+    val b = Base64.decodeBase64(a)
+    val c = new Array[Long](b.length/8)
+    var i = 0
+    while (i < c.length) {
+      c(i) = ((b(i*8+7) & 0xff).asInstanceOf[Long] << 56) |
+             ((b(i*8+6) & 0xff).asInstanceOf[Long] << 48) |
+             ((b(i*8+5) & 0xff).asInstanceOf[Long] << 40) |
+             ((b(i*8+4) & 0xff).asInstanceOf[Long] << 32) |
+             ((b(i*8+3) & 0xff).asInstanceOf[Long] << 24) |
+             ((b(i*8+2) & 0xff).asInstanceOf[Long] << 16) |
+             ((b(i*8+1) & 0xff).asInstanceOf[Long] << 8) |
+             (b(i*8).asInstanceOf[Long] & 0xff)
+      i += 1
+    }
+    c
+  }
 }

--- a/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -9,6 +9,7 @@ import is.hail.rvd.{OrderedRVD, RVDContext}
 import is.hail.sparkextras.ContextRDD
 import is.hail.utils._
 import is.hail.variant._
+import org.apache.commons.codec.binary.Base64
 import org.apache.hadoop.io.LongWritable
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row

--- a/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -4,7 +4,7 @@ import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.expr.types._
 import is.hail.io.vcf.LoadVCF
-import is.hail.io.{HadoopFSDataBinaryReader, IndexBTree}
+import is.hail.io._
 import is.hail.rvd.{OrderedRVD, RVDContext}
 import is.hail.sparkextras.ContextRDD
 import is.hail.utils._

--- a/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -93,13 +93,13 @@ object LoadBgen {
     if (unequalSamples.length > 0)
       fatal(
         s"""The following BGEN files did not contain the expected number of samples $nSamples:
-           |  ${ unequalSamples.map(x => s"""(${ x._2 } ${ x._1 }""").mkString("\n  ") }""".stripMargin)
+            |  ${ unequalSamples.map(x => s"""(${ x._2 } ${ x._1 }""").mkString("\n  ") }""".stripMargin)
 
     val noVariants = results.filter(_.nVariants == 0).map(_.file)
     if (noVariants.length > 0)
       fatal(
         s"""The following BGEN files did not contain at least 1 variant:
-           |  ${ noVariants.mkString("\n  ") })""".stripMargin)
+            |  ${ noVariants.mkString("\n  ") })""".stripMargin)
 
     val nVariants = results.map(_.nVariants).sum
 
@@ -115,7 +115,7 @@ object LoadBgen {
       (includeFileRowIdx, "file_row_idx" -> TInt64()))
       .withFilter(_._1).map(_._2)
 
-    val signature = TStruct(rowFields:_*)
+    val signature = TStruct(rowFields: _*)
 
     val entryFields = Array(
       (includeGT, "GT" -> TCall()),
@@ -352,13 +352,13 @@ object LoadBgen {
   }
 
   private[bgen] def encodeInts(a: Array[Int]): String = {
-    val b = new Array[Byte](a.length*4)
+    val b = new Array[Byte](a.length * 4)
     var i = 0
     while (i < a.length) {
-      b(4*i) = (a(i) & 0xff).asInstanceOf[Byte]
-      b(4*i+1) = ((a(i) >>> 8) & 0xff).asInstanceOf[Byte]
-      b(4*i+2) = ((a(i) >>> 16) & 0xff).asInstanceOf[Byte]
-      b(4*i+3) = ((a(i) >>> 24) & 0xff).asInstanceOf[Byte]
+      b(4 * i) = (a(i) & 0xff).asInstanceOf[Byte]
+      b(4 * i + 1) = ((a(i) >>> 8) & 0xff).asInstanceOf[Byte]
+      b(4 * i + 2) = ((a(i) >>> 16) & 0xff).asInstanceOf[Byte]
+      b(4 * i + 3) = ((a(i) >>> 24) & 0xff).asInstanceOf[Byte]
       i += 1
     }
     Base64.encodeBase64String(b)
@@ -366,30 +366,31 @@ object LoadBgen {
 
   private[bgen] def decodeInts(a: String): Array[Int] = {
     val b = Base64.decodeBase64(a)
-    val c = new Array[Int](b.length/4)
+    val c = new Array[Int](b.length / 4)
     var i = 0
     while (i < c.length) {
-      c(i) = ((b(i*4+3) & 0xff).asInstanceOf[Int] << 24) |
-             ((b(i*4+2) & 0xff).asInstanceOf[Int] << 16) |
-             ((b(i*4+1) & 0xff).asInstanceOf[Int] << 8) |
-             (b(i*4).asInstanceOf[Int] & 0xff)
+      c(i) =
+        ((b(i * 4 + 3) & 0xff).asInstanceOf[Int] << 24) |
+        ((b(i * 4 + 2) & 0xff).asInstanceOf[Int] << 16) |
+        ((b(i * 4 + 1) & 0xff).asInstanceOf[Int] << 8) |
+        (b(i * 4).asInstanceOf[Int] & 0xff)
       i += 1
     }
     c
   }
 
   private[bgen] def encodeLongs(a: Array[Long]): String = {
-    val b = new Array[Byte](a.length*8)
+    val b = new Array[Byte](a.length * 8)
     var i = 0
     while (i < a.length) {
-      b(8*i) = (a(i) & 0xff).asInstanceOf[Byte]
-      b(8*i+1) = ((a(i) >>> 8) & 0xff).asInstanceOf[Byte]
-      b(8*i+2) = ((a(i) >>> 16) & 0xff).asInstanceOf[Byte]
-      b(8*i+3) = ((a(i) >>> 24) & 0xff).asInstanceOf[Byte]
-      b(8*i+4) = ((a(i) >>> 32) & 0xff).asInstanceOf[Byte]
-      b(8*i+5) = ((a(i) >>> 40) & 0xff).asInstanceOf[Byte]
-      b(8*i+6) = ((a(i) >>> 48) & 0xff).asInstanceOf[Byte]
-      b(8*i+7) = ((a(i) >>> 56) & 0xff).asInstanceOf[Byte]
+      b(8 * i) = (a(i) & 0xff).asInstanceOf[Byte]
+      b(8 * i + 1) = ((a(i) >>> 8) & 0xff).asInstanceOf[Byte]
+      b(8 * i + 2) = ((a(i) >>> 16) & 0xff).asInstanceOf[Byte]
+      b(8 * i + 3) = ((a(i) >>> 24) & 0xff).asInstanceOf[Byte]
+      b(8 * i + 4) = ((a(i) >>> 32) & 0xff).asInstanceOf[Byte]
+      b(8 * i + 5) = ((a(i) >>> 40) & 0xff).asInstanceOf[Byte]
+      b(8 * i + 6) = ((a(i) >>> 48) & 0xff).asInstanceOf[Byte]
+      b(8 * i + 7) = ((a(i) >>> 56) & 0xff).asInstanceOf[Byte]
       i += 1
     }
     Base64.encodeBase64String(b)
@@ -397,17 +398,18 @@ object LoadBgen {
 
   private[bgen] def decodeLongs(a: String): Array[Long] = {
     val b = Base64.decodeBase64(a)
-    val c = new Array[Long](b.length/8)
+    val c = new Array[Long](b.length / 8)
     var i = 0
     while (i < c.length) {
-      c(i) = ((b(i*8+7) & 0xff).asInstanceOf[Long] << 56) |
-             ((b(i*8+6) & 0xff).asInstanceOf[Long] << 48) |
-             ((b(i*8+5) & 0xff).asInstanceOf[Long] << 40) |
-             ((b(i*8+4) & 0xff).asInstanceOf[Long] << 32) |
-             ((b(i*8+3) & 0xff).asInstanceOf[Long] << 24) |
-             ((b(i*8+2) & 0xff).asInstanceOf[Long] << 16) |
-             ((b(i*8+1) & 0xff).asInstanceOf[Long] << 8) |
-             (b(i*8).asInstanceOf[Long] & 0xff)
+      c(i) =
+        ((b(i * 8 + 7) & 0xff).asInstanceOf[Long] << 56) |
+        ((b(i * 8 + 6) & 0xff).asInstanceOf[Long] << 48) |
+        ((b(i * 8 + 5) & 0xff).asInstanceOf[Long] << 40) |
+        ((b(i * 8 + 4) & 0xff).asInstanceOf[Long] << 32) |
+        ((b(i * 8 + 3) & 0xff).asInstanceOf[Long] << 24) |
+        ((b(i * 8 + 2) & 0xff).asInstanceOf[Long] << 16) |
+        ((b(i * 8 + 1) & 0xff).asInstanceOf[Long] << 8) |
+        (b(i * 8).asInstanceOf[Long] & 0xff)
       i += 1
     }
     c

--- a/src/main/scala/is/hail/utils/package.scala
+++ b/src/main/scala/is/hail/utils/package.scala
@@ -613,6 +613,23 @@ package object utils extends Logging
     else
       s
   }
+
+  def toMapIfUnique[K, K2, V](
+    kvs: Traversable[(K, V)]
+  )(keyBy: K => K2
+  ): Either[Map[K2, Traversable[K]], Map[K2, V]] = {
+    val grouped = kvs.groupBy(x => keyBy(x._1))
+
+    val dupes = grouped.filter { case (k, m) => m.size != 1 }
+
+    if (dupes.nonEmpty) {
+      Left(dupes.map { case (k, m) => k -> m.map(_._1) })
+    } else {
+      Right(grouped
+        .map { case (k, m) => k -> m.map(_._2).head }
+        .toMap)
+    }
+  }
 }
 
 // FIXME: probably resolved in 3.6 https://github.com/json4s/json4s/commit/fc96a92e1aa3e9e3f97e2e91f94907fdfff6010d

--- a/src/test/scala/is/hail/io/IndexBTreeSuite.scala
+++ b/src/test/scala/is/hail/io/IndexBTreeSuite.scala
@@ -256,4 +256,24 @@ class IndexBTreeSuite extends SparkSuite {
       true
     }.check()
   }
+
+
+  @Test def onDiskBTreeIndexToValueThreeLayers() {
+    val longs = Array.tabulate(1024*1024*1024)(x => x.toLong)
+    val indices = Array.tabulate(1024*1024)(x => x * 1024)
+    val f = tmpDir.createTempFile()
+    try {
+      IndexBTree.write(longs, f, hadoopConf)
+      val bt = new OnDiskBTreeIndexToValue(f, hadoopConf)
+      val actual = bt.positionOfVariants(indices.toArray)
+      val expected = indices.sorted.map(longs)
+      assert(actual sameElements expected,
+        s"${actual.toSeq} not same elements as expected ${expected.toSeq}")
+    } catch {
+      case t: Throwable =>
+        throw new RuntimeException(
+          "exception while checking BTree: " + IndexBTree.toString(longs),
+          t)
+    }
+  }
 }

--- a/src/test/scala/is/hail/utils/UtilsSuite.scala
+++ b/src/test/scala/is/hail/utils/UtilsSuite.scala
@@ -207,4 +207,22 @@ class UtilsSuite extends SparkSuite {
     assert(c4.toSeq == Seq("a", "b", "c", "aD", "aDD", "cD", "aDDD"))
     assert(diff2.toSeq == Seq("a" -> "aD", "a" -> "aDD", "c" -> "cD", "a" -> "aDDD"))
   }
+
+  @Test def toMapUniqueEmpty() {
+    assert(toMapIfUnique(Seq[(Int, Int)]())(x => x % 2) == Right(Map()))
+  }
+
+  @Test def toMapUniqueSingleton() {
+    assert(toMapIfUnique(Seq(1 -> 2))(x => x % 2) == Right(Map(1 -> 2)))
+  }
+
+  @Test def toMapUniqueSmallNoDupe() {
+    assert(toMapIfUnique(Seq(1 -> 2, 3 -> 6, 10 -> 2))(x => x % 5) ==
+      Right(Map(1 -> 2, 3 -> 6, 0 -> 2)))
+  }
+
+  @Test def toMapUniqueSmallDupes() {
+    assert(toMapIfUnique(Seq(1 -> 2, 6 -> 6, 10 -> 2))(x => x % 5) ==
+      Left(Map(1 -> Seq(1, 6))))
+  }
 }


### PR DESCRIPTION
Finally add BGEN filtering at the level of bytes. We add a non-public, non-documented `_variants_per_file` argument that lists the variants to keep by their on-disk indices. It's a pretty groady interface, but it works with the current infrastructure and provides a _massive_ improvement. We go from decoding all the variants in the BGEN to decoding only those relevant to the computation at hand. In the case of Caitlin's PRS scoring method, that's about 1% or less of the original variant set.

It's a bit janky. The file paths need to be the fully qualified ones that are seen by the hadoop reader. So `file:/full/path/to/file.bgen` or `gs://full/path/to/bgen.file`, which is annoying. I don't have any better way to generically uniquely identify files though.

---
### Calc Depth Bug

I also had to fix a bug in the indices. Neither my `OnDiskBTreeIndexToValue` nor the existing `IndexBTree` correctly calculated the sizes of the given trees. Recall that a b-tree is a series of layers. Layer 0 is at most `branchingFactor` in size. Layer i is at most `branchingFactor ^ (i+1)` in size. The total size of the b-tree is the sum of the layer sizes. Here's a few max sizes for a branchingFactor of 1024:

 - 1 layer tree: 1024
 - 2 layer tree: 1024^2 + 1024
 - 3 layer tree: 1024^3 + 1024^2 + 1024

If you look carefully at the old `calcDepth` method, it incorrectly concludes that fully populated 3 layer trees have four layers because they have more than 1024^3 total (internal+leaf) elements. This issue rears it's head on an exponentially small number of trees (at depth `i`, the number of leaf elements must lie in `[1024^i-1024^(i-1), 1024^i]`. This discrepancy is what lead to my confusion for the last few days. It shows up quite quickly with very small branching factors (e.g. 3) but with a large branching factor (the default of 1024 and what all the tests were written against) it's fairly rare.

---
### Summary of Changes

 - add `_variants_per_file` which is a map from absolute file paths to lists of variants (identified by their in-file index) to keep
 - a test for `_variants_per_file`
 - a fixed `calcDepth` which is now used by both index classes
 - a set of tests for `calcDepth`
 - some clean up in `BgenBlockReader`: use `private[this]` for things that are truly private fields (otherwise they're accessed through `invokevirtual`) and use `using` to manage resources
 - teach `BgenInputFormat` to produce splits that describe which variants to keep
 - modify `BgenRecord` to use variant filtering information in file splits
 - add some groady code to ship variant filter lists through the hadoop configuration