### PR TITLE
add sortBy to IR conversion

### DIFF
--- a/python/hail/tests/test_expr.py
+++ b/python/hail/tests/test_expr.py
@@ -1235,6 +1235,13 @@ class Tests(unittest.TestCase):
         self.assertEqual(hl.eval_expr(hl.find(lambda x: x < 0, hl.set([1, 0, -4, 6]))), -4)
         self.assertEqual(hl.eval_expr(hl.find(lambda x: x < 0, hl.set([1, 0, 4, 6]))), None)
 
+    def test_sorted(self):
+        self.assertEqual(hl.eval_expr(hl.sorted([0, 1, 4, 3, 2], lambda x: x % 2)), [0, 4, 2, 1, 3])
+        self.assertEqual(hl.eval_expr(hl.sorted([0, 1, 4, 3, 2], lambda x: x % 2, reverse=True)), [1, 3, 0, 4, 2])
+
+        self.assertEqual(hl.eval_expr(hl.sorted([0, 1, 4, hl.null(tint), 3, 2], lambda x: x)), [0, 1, 2, 3, 4, None])
+        self.assertEqual(hl.eval_expr(hl.sorted([0, 1, 4, hl.null(tint), 3, 2], lambda x: x, reverse=True)), [None, 4, 3, 2, 1, 0])
+
     def test_bool_r_ops(self):
         self.assertTrue(hl.eval_expr(hl.literal(True) & True))
         self.assertTrue(hl.eval_expr(True & hl.literal(True)))

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -40,7 +40,7 @@ object Children {
       Array(a)
     case ArrayRange(start, stop, step) =>
       Array(start, stop, step)
-    case ArraySort(a, ascending) =>
+    case ArraySort(a, ascending, _) =>
       Array(a, ascending)
     case ToSet(a) =>
       Array(a)

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -48,9 +48,9 @@ object Copy {
       case ArrayRange(_, _, _) =>
         val IndexedSeq(start: IR, stop: IR, step: IR) = newChildren
         ArrayRange(start, stop, step)
-      case ArraySort(_, _) =>
+      case ArraySort(_, _, onKey) =>
         val IndexedSeq(a: IR, ascending: IR) = newChildren
-        ArraySort(a, ascending)
+        ArraySort(a, ascending, onKey)
       case ToSet(_) =>
         val IndexedSeq(a: IR) = newChildren
         ToSet(a)

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -370,7 +370,7 @@ private class Emit(
 
       case x@(_: ArraySort | _: ToSet | _: ToDict) =>
         val (a, ascending: IR, keyOnly) = x match {
-          case ArraySort(a, ascending) => (a, ascending, false)
+          case ArraySort(a, ascending, onKey) => (a, ascending, onKey)
           case ToSet(a) => (a, True(), false)
           case ToDict(a) => (a, True(), true)
         }

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -83,7 +83,7 @@ final case class ArrayRef(a: IR, i: IR) extends InferIR
 final case class ArrayLen(a: IR) extends IR { val typ = TInt32() }
 final case class ArrayRange(start: IR, stop: IR, step: IR) extends IR { val typ: TArray = TArray(TInt32()) }
 
-final case class ArraySort(a: IR, ascending: IR) extends InferIR
+final case class ArraySort(a: IR, ascending: IR, onKey: Boolean = false) extends InferIR
 final case class ToSet(a: IR) extends InferIR
 final case class ToDict(a: IR) extends InferIR
 final case class ToArray(a: IR) extends InferIR

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -22,7 +22,7 @@ object Infer {
       case ArrayRef(a, i) =>
         assert(i.typ.isOfType(TInt32()))
         -coerce[TArray](a.typ).elementType
-      case ArraySort(a, ascending) =>
+      case ArraySort(a, ascending, _) =>
         assert(ascending.typ.isOfType(TBoolean()))
         a.typ
       case ToSet(a) =>

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -205,7 +205,7 @@ object Interpret {
           null
         else
           startValue.asInstanceOf[Int] until stopValue.asInstanceOf[Int] by stepValue.asInstanceOf[Int]
-      case ArraySort(a, ascending) =>
+      case ArraySort(a, ascending, onKey) =>
         val aValue = interpret(a, env, args, agg)
         val ascendingValue = interpret(ascending, env, args, agg)
         if (aValue == null)
@@ -213,10 +213,10 @@ object Interpret {
         else {
           val ord =
             if (ascendingValue == null || ascendingValue.asInstanceOf[Boolean])
-              a.typ.asInstanceOf[TArray].elementType.ordering
+              a.typ.asInstanceOf[TArray].elementType.asInstanceOf[TBaseStruct].types(0).ordering
             else
-              a.typ.asInstanceOf[TArray].elementType.ordering.reverse
-          aValue.asInstanceOf[IndexedSeq[Any]].sorted(ord.toOrdering)
+              a.typ.asInstanceOf[TArray].elementType.asInstanceOf[TBaseStruct].types(0).ordering.reverse
+          aValue.asInstanceOf[IndexedSeq[Row]].sortBy(_.get(0))(ord.toOrdering)
         }
       case ToSet(a) =>
         val aValue = interpret(a, env, args, agg)

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -219,7 +219,10 @@ object Interpret {
               sortType.ordering
             else
               sortType.ordering.reverse
-          aValue.asInstanceOf[IndexedSeq[Row]].sortBy(_.get(0))(ord.toOrdering)
+          if (onKey)
+            aValue.asInstanceOf[IndexedSeq[Row]].sortBy(_.get(0))(ord.toOrdering)
+          else
+            aValue.asInstanceOf[IndexedSeq[Any]].sorted(ord.toOrdering)
         }
       case ToSet(a) =>
         val aValue = interpret(a, env, args, agg)

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -211,11 +211,14 @@ object Interpret {
         if (aValue == null)
           null
         else {
+          var sortType = a.typ.asInstanceOf[TArray].elementType
+          if (onKey)
+            sortType = sortType.asInstanceOf[TBaseStruct].types(0)
           val ord =
             if (ascendingValue == null || ascendingValue.asInstanceOf[Boolean])
-              a.typ.asInstanceOf[TArray].elementType.asInstanceOf[TBaseStruct].types(0).ordering
+              sortType.ordering
             else
-              a.typ.asInstanceOf[TArray].elementType.asInstanceOf[TBaseStruct].types(0).ordering.reverse
+              sortType.ordering.reverse
           aValue.asInstanceOf[IndexedSeq[Row]].sortBy(_.get(0))(ord.toOrdering)
         }
       case ToSet(a) =>

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -83,10 +83,11 @@ object TypeCheck {
         assert(a.typ.isOfType(TInt32()))
         assert(b.typ.isOfType(TInt32()))
         assert(c.typ.isOfType(TInt32()))
-      case x@ArraySort(a, ascending) =>
+      case x@ArraySort(a, ascending, onKey) =>
         check(a)
         check(ascending)
         assert(a.typ.isInstanceOf[TArray])
+        assert(!onKey || coerce[TArray](a.typ).elementType.isInstanceOf[TBaseStruct])
         assert(ascending.typ.isOfType(TBoolean()))
       case x@ToSet(a) =>
         check(a)

--- a/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -72,10 +72,10 @@ object ArrayFunctions extends RegistryFunctions {
 
     registerIR("isEmpty", TArray(tv("T")))(isEmpty)
 
-    registerIR("sort", TArray(tv("T")), TBoolean())(ArraySort)
+    registerIR("sort", TArray(tv("T")), TBoolean())(ArraySort(_, _, false))
 
     registerIR("sort", TArray(tv("T"))) { a =>
-      ArraySort(a, True())
+      ArraySort(a, True(), false)
     }
 
     registerIR("extend", TArray(tv("T")), TArray(tv("T")))(extend)

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1598,9 +1598,9 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
         val entriesRowType = et.typ.rowType
         val aggEnv = new ir.Env[ir.IR].bind(
-          "g" -> ir.Ref("row", entriesRowType),
-          "va" -> ir.Ref("row", entriesRowType),
-          "sa" -> ir.Ref("row", entriesRowType))
+          "g" -> ir.SelectFields(ir.Ref("row", entriesRowType), entryType.fieldNames),
+          "va" -> ir.SelectFields(ir.Ref("row", entriesRowType), rowType.fieldNames),
+          "sa" -> ir.SelectFields(ir.Ref("row", entriesRowType), colType.fieldNames))
 
         val sqir = ir.Subst(qir.unwrap, ir.Env.empty, aggEnv)
         et.aggregate(sqir)


### PR DESCRIPTION
I'm still not really sure how to test this properly since it's not in the IR function registry, but I checked that the tests in is.hail.methods.AggregatorSuite that rely on this are going through IR.