### PR TITLE
Make MatrixRead.f into a class

### DIFF
--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -82,7 +82,7 @@ object Pretty {
             case Apply(function, _) => function
             case ApplySpecial(function, _) => function
             case In(i, _) => i.toString
-            case MatrixRead(typ, partitionCounts, dropCols, dropRows, requestedType, _) =>
+            case MatrixRead(typ, partitionCounts, dropCols, dropRows, _) =>
               s"$typ partition_counts=${ partitionCounts.map(_.mkString(",")).getOrElse("None") } ${ if (dropRows) "drop_rows" else "" }${ if (dropCols) "drop_cols" else "" }"
             case TableImport(paths, _, _) =>
               if (paths.length == 1)

--- a/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -322,7 +322,7 @@ object PruneDeadFields {
         val irDep = memoizeAndGetDep(newRow, requestedType.globalType, child.typ, memo)
         // FIXME push down into value
         memoizeMatrixIR(child, unify(child.typ, requestedType.copy(globalType = irDep.globalType), irDep), memo)
-      case MatrixRead(_, _, _, _, _, _) =>
+      case MatrixRead(_, _, _, _, _) =>
       case MatrixLiteral(typ, value) =>
       case FilterCols(child, cond) =>
         memoizeMatrixIR(child, child.typ, memo)
@@ -599,8 +599,8 @@ object PruneDeadFields {
   def rebuild(mir: MatrixIR, memo: Memo[BaseType]): MatrixIR = {
     val dep = memo.lookup(mir).asInstanceOf[MatrixType]
     mir match {
-      case x@MatrixRead(typ, partitionCounts, dropCols, dropRows, _, f) =>
-        MatrixRead(typ, partitionCounts, dropCols, dropRows, dep, f)
+      case x@MatrixRead(typ, partitionCounts, dropCols, dropRows, reader) =>
+        MatrixRead(dep, partitionCounts, dropCols, dropRows, reader)
       case FilterColsIR(child, pred) =>
         val child2 = rebuild(child, memo)
         FilterColsIR(child2, rebuild(pred, child2.typ, memo))

--- a/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -155,18 +155,18 @@ object Simplify {
       // optimize MatrixIR
 
       // Equivalent rewrites for the new Filter{Cols,Rows}IR
-      case MatrixFilterRowsIR(MatrixRead(typ, partitionCounts, dropCols, _, requestedType, f), False() | NA(_)) =>
-        MatrixRead(typ, partitionCounts, dropCols, dropRows = true, requestedType, f)
+      case MatrixFilterRowsIR(MatrixRead(typ, partitionCounts, dropCols, _, reader), False() | NA(_)) =>
+        MatrixRead(typ, partitionCounts, dropCols, dropRows = true, reader)
 
-      case FilterColsIR(MatrixRead(typ, partitionCounts, _, dropRows, requestedType, f), False() | NA(_)) =>
-        MatrixRead(typ, partitionCounts, dropCols = true, dropRows, requestedType, f)
+      case FilterColsIR(MatrixRead(typ, partitionCounts, _, dropRows, reader), False() | NA(_)) =>
+        MatrixRead(typ, partitionCounts, dropCols = true, dropRows, reader)
 
       // Ignore column or row data that is immediately dropped
-      case MatrixRowsTable(MatrixRead(typ, partitionCounts, false, dropRows, requestedType, f)) =>
-        MatrixRowsTable(MatrixRead(typ, partitionCounts, dropCols = true, dropRows, requestedType, f))
+      case MatrixRowsTable(MatrixRead(typ, partitionCounts, false, dropRows, reader)) =>
+        MatrixRowsTable(MatrixRead(typ, partitionCounts, dropCols = true, dropRows, reader))
 
-      case MatrixColsTable(MatrixRead(typ, partitionCounts, dropCols, false, requestedType, f)) =>
-        MatrixColsTable(MatrixRead(typ, partitionCounts, dropCols, dropRows = true, requestedType, f))
+      case MatrixColsTable(MatrixRead(typ, partitionCounts, dropCols, false, reader)) =>
+        MatrixColsTable(MatrixRead(typ, partitionCounts, dropCols, dropRows = true, reader))
 
       // Keep all rows/cols = do nothing
       case MatrixFilterRowsIR(m, True()) => m


### PR DESCRIPTION
I needed to make the read function in MatrixRead into a class so I can print/parse as part of the work to replace AST with IR in the Python interface.

Also, push down required type into MT decoder.  I also use the compiler to build the function to add the entries to the row values (no RegionValueBuilder).
