### PR TITLE
Add deepCopy to RegionValueAggregator

### DIFF
--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueAggregator.scala
@@ -9,9 +9,9 @@ trait RegionValueAggregator extends Serializable {
 
   def result(rvb: RegionValueBuilder)
 
-  def copy(): RegionValueAggregator
+  def newInstance(): RegionValueAggregator
 
-  def deepCopy(): RegionValueAggregator
+  def copy(): RegionValueAggregator
 
   def clear(): Unit
 }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueAggregator.scala
@@ -11,5 +11,7 @@ trait RegionValueAggregator extends Serializable {
 
   def copy(): RegionValueAggregator
 
+  def deepCopy(): RegionValueAggregator
+
   def clear(): Unit
 }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueArraySumAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueArraySumAggregator.scala
@@ -62,9 +62,9 @@ class RegionValueArraySumLongAggregator extends RegionValueAggregator {
     }
   }
 
-  def copy(): RegionValueArraySumLongAggregator = new RegionValueArraySumLongAggregator()
+  def newInstance(): RegionValueArraySumLongAggregator = new RegionValueArraySumLongAggregator()
 
-  def deepCopy(): RegionValueArraySumLongAggregator = {
+  def copy(): RegionValueArraySumLongAggregator = {
     val rva = new RegionValueArraySumLongAggregator()
     rva.sum = sum.clone()
     rva
@@ -133,9 +133,9 @@ class RegionValueArraySumDoubleAggregator extends RegionValueAggregator {
     }
   }
 
-  def copy(): RegionValueArraySumDoubleAggregator = new RegionValueArraySumDoubleAggregator()
+  def newInstance(): RegionValueArraySumDoubleAggregator = new RegionValueArraySumDoubleAggregator()
 
-  def deepCopy(): RegionValueArraySumDoubleAggregator = {
+  def copy(): RegionValueArraySumDoubleAggregator = {
     val rva = new RegionValueArraySumDoubleAggregator()
     rva.sum = sum.clone()
     rva

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueArraySumAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueArraySumAggregator.scala
@@ -64,6 +64,12 @@ class RegionValueArraySumLongAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueArraySumLongAggregator = new RegionValueArraySumLongAggregator()
 
+  def deepCopy(): RegionValueArraySumLongAggregator = {
+    val rva = new RegionValueArraySumLongAggregator()
+    rva.sum = sum.clone()
+    rva
+  }
+
   def clear() {
     sum = null
   }
@@ -128,6 +134,12 @@ class RegionValueArraySumDoubleAggregator extends RegionValueAggregator {
   }
 
   def copy(): RegionValueArraySumDoubleAggregator = new RegionValueArraySumDoubleAggregator()
+
+  def deepCopy(): RegionValueArraySumDoubleAggregator = {
+    val rva = new RegionValueArraySumDoubleAggregator()
+    rva.sum = sum.clone()
+    rva
+  }
 
   def clear() {
     sum = null

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCallStatsAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCallStatsAggregator.scala
@@ -38,7 +38,13 @@ class RegionValueCallStatsAggregator extends RegionValueAggregator {
       rvb.setMissing()
   }
 
-  def copy() = new RegionValueCallStatsAggregator()
+  def copy(): RegionValueCallStatsAggregator = new RegionValueCallStatsAggregator()
+
+  def deepCopy() = {
+    val rva = new RegionValueCallStatsAggregator()
+    rva.combiner = combiner.copy()
+    rva
+  }
 
   def clear() {
     combiner = null

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCallStatsAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCallStatsAggregator.scala
@@ -38,9 +38,9 @@ class RegionValueCallStatsAggregator extends RegionValueAggregator {
       rvb.setMissing()
   }
 
-  def copy(): RegionValueCallStatsAggregator = new RegionValueCallStatsAggregator()
+  def newInstance(): RegionValueCallStatsAggregator = new RegionValueCallStatsAggregator()
 
-  def deepCopy() = {
+  def copy() = {
     val rva = new RegionValueCallStatsAggregator()
     rva.combiner = combiner.copy()
     rva

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCollectAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCollectAggregator.scala
@@ -27,9 +27,9 @@ class RegionValueCollectBooleanAggregator extends RegionValueAggregator {
     ab.write(rvb)
   }
 
-  def copy(): RegionValueCollectBooleanAggregator = new RegionValueCollectBooleanAggregator()
+  def newInstance(): RegionValueCollectBooleanAggregator = new RegionValueCollectBooleanAggregator()
 
-  def deepCopy(): RegionValueCollectBooleanAggregator = {
+  def copy(): RegionValueCollectBooleanAggregator = {
     val rva = new RegionValueCollectBooleanAggregator()
     rva.ab = ab.clone()
     rva
@@ -63,9 +63,9 @@ class RegionValueCollectIntAggregator extends RegionValueAggregator {
     ab.write(rvb)
   }
 
-  def copy(): RegionValueCollectIntAggregator = new RegionValueCollectIntAggregator()
+  def newInstance(): RegionValueCollectIntAggregator = new RegionValueCollectIntAggregator()
 
-  def deepCopy(): RegionValueCollectIntAggregator = {
+  def copy(): RegionValueCollectIntAggregator = {
     val rva = new RegionValueCollectIntAggregator()
     rva.ab = ab.clone()
     rva
@@ -99,9 +99,9 @@ class RegionValueCollectLongAggregator extends RegionValueAggregator {
     ab.write(rvb)
   }
 
-  def copy(): RegionValueCollectLongAggregator = new RegionValueCollectLongAggregator()
+  def newInstance(): RegionValueCollectLongAggregator = new RegionValueCollectLongAggregator()
 
-  def deepCopy(): RegionValueCollectLongAggregator = {
+  def copy(): RegionValueCollectLongAggregator = {
     val rva = new RegionValueCollectLongAggregator()
     rva.ab = ab.clone()
     rva
@@ -135,9 +135,9 @@ class RegionValueCollectFloatAggregator extends RegionValueAggregator {
     ab.write(rvb)
   }
 
-  def copy(): RegionValueCollectFloatAggregator = new RegionValueCollectFloatAggregator()
+  def newInstance(): RegionValueCollectFloatAggregator = new RegionValueCollectFloatAggregator()
 
-  def deepCopy(): RegionValueCollectFloatAggregator = {
+  def copy(): RegionValueCollectFloatAggregator = {
     val rva = new RegionValueCollectFloatAggregator()
     rva.ab = ab.clone()
     rva
@@ -171,9 +171,9 @@ class RegionValueCollectDoubleAggregator extends RegionValueAggregator {
     ab.write(rvb)
   }
 
-  def copy(): RegionValueCollectDoubleAggregator = new RegionValueCollectDoubleAggregator()
+  def newInstance(): RegionValueCollectDoubleAggregator = new RegionValueCollectDoubleAggregator()
 
-  def deepCopy(): RegionValueCollectDoubleAggregator = {
+  def copy(): RegionValueCollectDoubleAggregator = {
     val rva = new RegionValueCollectDoubleAggregator()
     rva.ab = ab.clone()
     rva
@@ -207,9 +207,9 @@ class RegionValueCollectAnnotationAggregator(t: Type) extends RegionValueAggrega
     ab.write(rvb, t)
   }
 
-  def copy(): RegionValueCollectAnnotationAggregator = new RegionValueCollectAnnotationAggregator(t)
+  def newInstance(): RegionValueCollectAnnotationAggregator = new RegionValueCollectAnnotationAggregator(t)
 
-  def deepCopy(): RegionValueCollectAnnotationAggregator = {
+  def copy(): RegionValueCollectAnnotationAggregator = {
     val rva = new RegionValueCollectAnnotationAggregator(t)
     rva.ab = ab.clone()
     rva

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCollectAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCollectAggregator.scala
@@ -5,7 +5,7 @@ import is.hail.expr.types.{TBaseStruct, Type}
 import is.hail.utils._
 
 class RegionValueCollectBooleanAggregator extends RegionValueAggregator {
-  private val ab = new MissingBooleanArrayBuilder()
+  private var ab = new MissingBooleanArrayBuilder()
 
   def seqOp(region: Region, b: Boolean, missing: Boolean) {
     if (missing)
@@ -29,13 +29,19 @@ class RegionValueCollectBooleanAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueCollectBooleanAggregator = new RegionValueCollectBooleanAggregator()
 
+  def deepCopy(): RegionValueCollectBooleanAggregator = {
+    val rva = new RegionValueCollectBooleanAggregator()
+    rva.ab = ab.clone()
+    rva
+  }
+
   def clear() {
     ab.clear()
   }
 }
 
 class RegionValueCollectIntAggregator extends RegionValueAggregator {
-  private val ab = new MissingIntArrayBuilder()
+  private var ab = new MissingIntArrayBuilder()
 
   def seqOp(region: Region, x: Int, missing: Boolean) {
     if (missing)
@@ -59,13 +65,19 @@ class RegionValueCollectIntAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueCollectIntAggregator = new RegionValueCollectIntAggregator()
 
+  def deepCopy(): RegionValueCollectIntAggregator = {
+    val rva = new RegionValueCollectIntAggregator()
+    rva.ab = ab.clone()
+    rva
+  }
+
   def clear() {
     ab.clear()
   }
 }
 
 class RegionValueCollectLongAggregator extends RegionValueAggregator {
-  private val ab = new MissingLongArrayBuilder()
+  private var ab = new MissingLongArrayBuilder()
 
   def seqOp(region: Region, x: Long, missing: Boolean) {
     if (missing)
@@ -89,13 +101,19 @@ class RegionValueCollectLongAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueCollectLongAggregator = new RegionValueCollectLongAggregator()
 
+  def deepCopy(): RegionValueCollectLongAggregator = {
+    val rva = new RegionValueCollectLongAggregator()
+    rva.ab = ab.clone()
+    rva
+  }
+
   def clear() {
     ab.clear()
   }
 }
 
 class RegionValueCollectFloatAggregator extends RegionValueAggregator {
-  private val ab = new MissingFloatArrayBuilder()
+  private var ab = new MissingFloatArrayBuilder()
 
   def seqOp(region: Region, x: Float, missing: Boolean) {
     if (missing)
@@ -119,13 +137,19 @@ class RegionValueCollectFloatAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueCollectFloatAggregator = new RegionValueCollectFloatAggregator()
 
+  def deepCopy(): RegionValueCollectFloatAggregator = {
+    val rva = new RegionValueCollectFloatAggregator()
+    rva.ab = ab.clone()
+    rva
+  }
+
   def clear() {
     ab.clear()
   }
 }
 
 class RegionValueCollectDoubleAggregator extends RegionValueAggregator {
-  private val ab = new MissingDoubleArrayBuilder()
+  private var ab = new MissingDoubleArrayBuilder()
 
   def seqOp(region: Region, x: Double, missing: Boolean) {
     if (missing)
@@ -149,13 +173,19 @@ class RegionValueCollectDoubleAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueCollectDoubleAggregator = new RegionValueCollectDoubleAggregator()
 
+  def deepCopy(): RegionValueCollectDoubleAggregator = {
+    val rva = new RegionValueCollectDoubleAggregator()
+    rva.ab = ab.clone()
+    rva
+  }
+
   def clear() {
     ab.clear()
   }
 }
 
 class RegionValueCollectAnnotationAggregator(t: Type) extends RegionValueAggregator {
-  private val ab = new MissingAnnotationArrayBuilder()
+  private var ab = new MissingAnnotationArrayBuilder()
 
   def seqOp(region: Region, offset: Long, missing: Boolean) {
     if (missing)
@@ -178,6 +208,12 @@ class RegionValueCollectAnnotationAggregator(t: Type) extends RegionValueAggrega
   }
 
   def copy(): RegionValueCollectAnnotationAggregator = new RegionValueCollectAnnotationAggregator(t)
+
+  def deepCopy(): RegionValueCollectAnnotationAggregator = {
+    val rva = new RegionValueCollectAnnotationAggregator(t)
+    rva.ab = ab.clone()
+    rva
+  }
 
   def clear() {
     ab.clear()

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCollectAsSetAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCollectAsSetAggregator.scala
@@ -43,7 +43,9 @@ class RegionValueCollectAsSetBooleanAggregator extends RegionValueAggregator {
 
   override def deepCopy(): RegionValueCollectAsSetBooleanAggregator = {
     val rva = new RegionValueCollectAsSetBooleanAggregator()
-    rva.values = values.clone()
+    rva.hasTrue = hasTrue
+    rva.hasFalse = hasFalse
+    rva.hasMissing = hasMissing
     rva
   }
 

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCollectAsSetAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCollectAsSetAggregator.scala
@@ -39,9 +39,9 @@ class RegionValueCollectAsSetBooleanAggregator extends RegionValueAggregator {
     rvb.endArray()
   }
 
-  def copy(): RegionValueCollectAsSetBooleanAggregator = new RegionValueCollectAsSetBooleanAggregator()
+  def newInstance(): RegionValueCollectAsSetBooleanAggregator = new RegionValueCollectAsSetBooleanAggregator()
 
-  override def deepCopy(): RegionValueCollectAsSetBooleanAggregator = {
+  override def copy(): RegionValueCollectAsSetBooleanAggregator = {
     val rva = new RegionValueCollectAsSetBooleanAggregator()
     rva.hasTrue = hasTrue
     rva.hasFalse = hasFalse
@@ -83,9 +83,9 @@ class RegionValueCollectAsSetIntAggregator extends RegionValueAggregator {
     rvb.endArray()
   }
 
-  def copy(): RegionValueCollectAsSetIntAggregator = new RegionValueCollectAsSetIntAggregator()
+  def newInstance(): RegionValueCollectAsSetIntAggregator = new RegionValueCollectAsSetIntAggregator()
 
-  override def deepCopy(): RegionValueCollectAsSetIntAggregator = {
+  override def copy(): RegionValueCollectAsSetIntAggregator = {
     val rva = new RegionValueCollectAsSetIntAggregator()
     rva.values = values.clone()
     rva
@@ -124,9 +124,9 @@ class RegionValueCollectAsSetLongAggregator extends RegionValueAggregator {
     rvb.endArray()
   }
 
-  def copy(): RegionValueCollectAsSetLongAggregator = new RegionValueCollectAsSetLongAggregator()
+  def newInstance(): RegionValueCollectAsSetLongAggregator = new RegionValueCollectAsSetLongAggregator()
 
-  override def deepCopy(): RegionValueCollectAsSetLongAggregator = {
+  override def copy(): RegionValueCollectAsSetLongAggregator = {
     val rva = new RegionValueCollectAsSetLongAggregator()
     rva.values = values.clone()
     rva
@@ -165,9 +165,9 @@ class RegionValueCollectAsSetFloatAggregator extends RegionValueAggregator {
     rvb.endArray()
   }
 
-  def copy(): RegionValueCollectAsSetFloatAggregator = new RegionValueCollectAsSetFloatAggregator()
+  def newInstance(): RegionValueCollectAsSetFloatAggregator = new RegionValueCollectAsSetFloatAggregator()
 
-  override def deepCopy(): RegionValueCollectAsSetFloatAggregator = {
+  override def copy(): RegionValueCollectAsSetFloatAggregator = {
     val rva = new RegionValueCollectAsSetFloatAggregator()
     rva.values = values.clone()
     rva
@@ -206,9 +206,9 @@ class RegionValueCollectAsSetDoubleAggregator extends RegionValueAggregator {
     rvb.endArray()
   }
 
-  def copy(): RegionValueCollectAsSetDoubleAggregator = new RegionValueCollectAsSetDoubleAggregator()
+  def newInstance(): RegionValueCollectAsSetDoubleAggregator = new RegionValueCollectAsSetDoubleAggregator()
 
-  override def deepCopy(): RegionValueCollectAsSetDoubleAggregator = {
+  override def copy(): RegionValueCollectAsSetDoubleAggregator = {
     val rva = new RegionValueCollectAsSetDoubleAggregator()
     rva.values = values.clone()
     rva
@@ -239,9 +239,9 @@ class RegionValueCollectAsSetAnnotationAggregator(val typ: Type) extends RegionV
     rvb.addAnnotation(TSet(typ), values.toSet)
   }
 
-  def copy(): RegionValueCollectAsSetAnnotationAggregator = new RegionValueCollectAsSetAnnotationAggregator(typ)
+  def newInstance(): RegionValueCollectAsSetAnnotationAggregator = new RegionValueCollectAsSetAnnotationAggregator(typ)
 
-  override def deepCopy(): RegionValueCollectAsSetAnnotationAggregator = {
+  override def copy(): RegionValueCollectAsSetAnnotationAggregator = {
     val rva = new RegionValueCollectAsSetAnnotationAggregator(typ)
     rva.values = values.clone()
     rva

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCollectAsSetAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCollectAsSetAggregator.scala
@@ -41,6 +41,12 @@ class RegionValueCollectAsSetBooleanAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueCollectAsSetBooleanAggregator = new RegionValueCollectAsSetBooleanAggregator()
 
+  override def deepCopy(): RegionValueCollectAsSetBooleanAggregator = {
+    val rva = new RegionValueCollectAsSetBooleanAggregator()
+    rva.values = values.clone()
+    rva
+  }
+
   def clear() {
     hasTrue = false
     hasFalse = false
@@ -49,7 +55,7 @@ class RegionValueCollectAsSetBooleanAggregator extends RegionValueAggregator {
 }
 
 class RegionValueCollectAsSetIntAggregator extends RegionValueAggregator {
-  private val values = mutable.Set[Int]()
+  private var values = mutable.Set[Int]()
   private var hasMissing = false
 
   def seqOp(region: Region, x: Int, missing: Boolean) {
@@ -77,6 +83,12 @@ class RegionValueCollectAsSetIntAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueCollectAsSetIntAggregator = new RegionValueCollectAsSetIntAggregator()
 
+  override def deepCopy(): RegionValueCollectAsSetIntAggregator = {
+    val rva = new RegionValueCollectAsSetIntAggregator()
+    rva.values = values.clone()
+    rva
+  }
+
   def clear() {
     values.clear()
     hasMissing = false
@@ -84,7 +96,7 @@ class RegionValueCollectAsSetIntAggregator extends RegionValueAggregator {
 }
 
 class RegionValueCollectAsSetLongAggregator extends RegionValueAggregator {
-  private val values = mutable.Set[Long]()
+  private var values = mutable.Set[Long]()
   private var hasMissing = false
 
   def seqOp(region: Region, x: Long, missing: Boolean) {
@@ -112,6 +124,12 @@ class RegionValueCollectAsSetLongAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueCollectAsSetLongAggregator = new RegionValueCollectAsSetLongAggregator()
 
+  override def deepCopy(): RegionValueCollectAsSetLongAggregator = {
+    val rva = new RegionValueCollectAsSetLongAggregator()
+    rva.values = values.clone()
+    rva
+  }
+
   def clear() {
     values.clear()
     hasMissing = false
@@ -119,7 +137,7 @@ class RegionValueCollectAsSetLongAggregator extends RegionValueAggregator {
 }
 
 class RegionValueCollectAsSetFloatAggregator extends RegionValueAggregator {
-  private val values = mutable.Set[Float]()
+  private var values = mutable.Set[Float]()
   private var hasMissing = false
 
   def seqOp(region: Region, x: Float, missing: Boolean) {
@@ -147,6 +165,12 @@ class RegionValueCollectAsSetFloatAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueCollectAsSetFloatAggregator = new RegionValueCollectAsSetFloatAggregator()
 
+  override def deepCopy(): RegionValueCollectAsSetFloatAggregator = {
+    val rva = new RegionValueCollectAsSetFloatAggregator()
+    rva.values = values.clone()
+    rva
+  }
+
   def clear() {
     values.clear()
     hasMissing = false
@@ -154,7 +178,7 @@ class RegionValueCollectAsSetFloatAggregator extends RegionValueAggregator {
 }
 
 class RegionValueCollectAsSetDoubleAggregator extends RegionValueAggregator {
-  private val values = mutable.Set[Double]()
+  private var values = mutable.Set[Double]()
   private var hasMissing = false
 
   def seqOp(region: Region, x: Double, missing: Boolean) {
@@ -182,6 +206,12 @@ class RegionValueCollectAsSetDoubleAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueCollectAsSetDoubleAggregator = new RegionValueCollectAsSetDoubleAggregator()
 
+  override def deepCopy(): RegionValueCollectAsSetDoubleAggregator = {
+    val rva = new RegionValueCollectAsSetDoubleAggregator()
+    rva.values = values.clone()
+    rva
+  }
+
   def clear() {
     values.clear()
     hasMissing = false
@@ -189,7 +219,7 @@ class RegionValueCollectAsSetDoubleAggregator extends RegionValueAggregator {
 }
 
 class RegionValueCollectAsSetAnnotationAggregator(val typ: Type) extends RegionValueAggregator {
-  private val values = mutable.Set[Any]()
+  private var values = mutable.Set[Any]()
 
   def seqOp(region: Region, offset: Long, missing: Boolean) {
     if (missing)
@@ -208,6 +238,12 @@ class RegionValueCollectAsSetAnnotationAggregator(val typ: Type) extends RegionV
   }
 
   def copy(): RegionValueCollectAsSetAnnotationAggregator = new RegionValueCollectAsSetAnnotationAggregator(typ)
+
+  override def deepCopy(): RegionValueCollectAsSetAnnotationAggregator = {
+    val rva = new RegionValueCollectAsSetAnnotationAggregator(typ)
+    rva.values = values.clone()
+    rva
+  }
 
   def clear() {
     values.clear()

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCountAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCountAggregator.scala
@@ -19,6 +19,12 @@ class RegionValueCountAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueCountAggregator = new RegionValueCountAggregator()
 
+  def deepCopy: RegionValueCountAggregator = {
+    val rva = new RegionValueCountAggregator()
+    rva.count = count
+    rva
+  }
+
   def clear() {
     count = 0
   }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCountAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCountAggregator.scala
@@ -17,9 +17,9 @@ class RegionValueCountAggregator extends RegionValueAggregator {
     rvb.addLong(count)
   }
 
-  def copy(): RegionValueCountAggregator = new RegionValueCountAggregator()
+  def newInstance(): RegionValueCountAggregator = new RegionValueCountAggregator()
 
-  def deepCopy: RegionValueCountAggregator = {
+  def copy: RegionValueCountAggregator = {
     val rva = new RegionValueCountAggregator()
     rva.count = count
     rva

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCounterAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCounterAggregator.scala
@@ -34,9 +34,9 @@ class RegionValueCounterAggregator(t: Type) extends RegionValueAggregator {
     rvb.endArray()
   }
 
-  override def copy(): RegionValueCounterAggregator = new RegionValueCounterAggregator(t)
+  override def newInstance(): RegionValueCounterAggregator = new RegionValueCounterAggregator(t)
 
-  override def deepCopy(): RegionValueCounterAggregator = {
+  override def copy(): RegionValueCounterAggregator = {
     val rva = new RegionValueCounterAggregator(t)
     rva.m = m.clone()
     rva
@@ -95,9 +95,9 @@ class RegionValueCounterBooleanAggregator extends RegionValueAggregator {
     rvb.endArray()
   }
 
-  override def copy(): RegionValueCounterBooleanAggregator = new RegionValueCounterBooleanAggregator()
+  override def newInstance(): RegionValueCounterBooleanAggregator = new RegionValueCounterBooleanAggregator()
 
-  override def deepCopy(): RegionValueCounterBooleanAggregator = {
+  override def copy(): RegionValueCounterBooleanAggregator = {
     val rva = new RegionValueCounterBooleanAggregator()
     rva.nTrue = nTrue
     rva.nFalse = nFalse
@@ -117,9 +117,9 @@ class RegionValueCounterIntAggregator(t: Type) extends RegionValueCounterAggrega
     seqOp(if (missing) null else x)
   }
 
-  override def copy(): RegionValueCounterIntAggregator = new RegionValueCounterIntAggregator(t)
+  override def newInstance(): RegionValueCounterIntAggregator = new RegionValueCounterIntAggregator(t)
 
-  override def deepCopy(): RegionValueCounterIntAggregator = {
+  override def copy(): RegionValueCounterIntAggregator = {
     val rva = new RegionValueCounterIntAggregator(t)
     rva.m = m.clone()
     rva
@@ -131,9 +131,9 @@ class RegionValueCounterLongAggregator(t: Type) extends RegionValueCounterAggreg
     seqOp(if (missing) null else x)
   }
 
-  override def copy(): RegionValueCounterLongAggregator = new RegionValueCounterLongAggregator(t)
+  override def newInstance(): RegionValueCounterLongAggregator = new RegionValueCounterLongAggregator(t)
 
-  override def deepCopy(): RegionValueCounterLongAggregator = {
+  override def copy(): RegionValueCounterLongAggregator = {
     val rva = new RegionValueCounterLongAggregator(t)
     rva.m = m.clone()
     rva
@@ -145,9 +145,9 @@ class RegionValueCounterFloatAggregator(t: Type) extends RegionValueCounterAggre
     seqOp(if (missing) null else x)
   }
 
-  override def copy(): RegionValueCounterFloatAggregator = new RegionValueCounterFloatAggregator(t)
+  override def newInstance(): RegionValueCounterFloatAggregator = new RegionValueCounterFloatAggregator(t)
 
-  override def deepCopy(): RegionValueCounterFloatAggregator = {
+  override def copy(): RegionValueCounterFloatAggregator = {
     val rva = new RegionValueCounterFloatAggregator(t)
     rva.m = m.clone()
     rva
@@ -159,9 +159,9 @@ class RegionValueCounterDoubleAggregator(t: Type) extends RegionValueCounterAggr
     seqOp(if (missing) null else x)
   }
 
-  override def copy(): RegionValueCounterDoubleAggregator = new RegionValueCounterDoubleAggregator(t)
+  override def newInstance(): RegionValueCounterDoubleAggregator = new RegionValueCounterDoubleAggregator(t)
 
-  override def deepCopy(): RegionValueCounterDoubleAggregator = {
+  override def copy(): RegionValueCounterDoubleAggregator = {
     val rva = new RegionValueCounterDoubleAggregator(t)
     rva.m = m.clone()
     rva
@@ -173,9 +173,9 @@ class RegionValueCounterAnnotationAggregator(t: Type) extends RegionValueCounter
     seqOp(if (missing) null else SafeRow.read(t, region, offset))
   }
 
-  override def copy(): RegionValueCounterAnnotationAggregator = new RegionValueCounterAnnotationAggregator(t)
+  override def newInstance(): RegionValueCounterAnnotationAggregator = new RegionValueCounterAnnotationAggregator(t)
 
-  override def deepCopy(): RegionValueCounterAnnotationAggregator = {
+  override def copy(): RegionValueCounterAnnotationAggregator = {
     val rva = new RegionValueCounterAnnotationAggregator(t)
     rva.m = m.clone()
     rva

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCounterAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCounterAggregator.scala
@@ -7,7 +7,7 @@ import is.hail.utils._
 import scala.collection.mutable
 
 class RegionValueCounterAggregator(t: Type) extends RegionValueAggregator {
-  val m = mutable.Map[Any, Long]()
+  var m = mutable.Map[Any, Long]()
 
   def seqOp(a: Any) {
     m.updateValue(a, 0L, _ + 1L)
@@ -35,6 +35,12 @@ class RegionValueCounterAggregator(t: Type) extends RegionValueAggregator {
   }
 
   override def copy(): RegionValueCounterAggregator = new RegionValueCounterAggregator(t)
+
+  override def deepCopy(): RegionValueCounterAggregator = {
+    val rva = new RegionValueCounterAggregator(t)
+    rva.m = m.clone()
+    rva
+  }
 
   override def clear() {
     m.clear()
@@ -91,6 +97,14 @@ class RegionValueCounterBooleanAggregator extends RegionValueAggregator {
 
   override def copy(): RegionValueCounterBooleanAggregator = new RegionValueCounterBooleanAggregator()
 
+  override def deepCopy(): RegionValueCounterBooleanAggregator = {
+    val rva = new RegionValueCounterBooleanAggregator()
+    rva.nTrue = nTrue
+    rva.nFalse = nFalse
+    rva.nMissing = nMissing
+    rva
+  }
+
   override def clear() {
     nTrue = 0L
     nFalse = 0L
@@ -104,6 +118,12 @@ class RegionValueCounterIntAggregator(t: Type) extends RegionValueCounterAggrega
   }
 
   override def copy(): RegionValueCounterIntAggregator = new RegionValueCounterIntAggregator(t)
+
+  override def deepCopy(): RegionValueCounterIntAggregator = {
+    val rva = new RegionValueCounterIntAggregator(t)
+    rva.m = m.clone()
+    rva
+  }
 }
 
 class RegionValueCounterLongAggregator(t: Type) extends RegionValueCounterAggregator(t) {
@@ -112,6 +132,12 @@ class RegionValueCounterLongAggregator(t: Type) extends RegionValueCounterAggreg
   }
 
   override def copy(): RegionValueCounterLongAggregator = new RegionValueCounterLongAggregator(t)
+
+  override def deepCopy(): RegionValueCounterLongAggregator = {
+    val rva = new RegionValueCounterLongAggregator(t)
+    rva.m = m.clone()
+    rva
+  }
 }
 
 class RegionValueCounterFloatAggregator(t: Type) extends RegionValueCounterAggregator(t) {
@@ -120,6 +146,12 @@ class RegionValueCounterFloatAggregator(t: Type) extends RegionValueCounterAggre
   }
 
   override def copy(): RegionValueCounterFloatAggregator = new RegionValueCounterFloatAggregator(t)
+
+  override def deepCopy(): RegionValueCounterFloatAggregator = {
+    val rva = new RegionValueCounterFloatAggregator(t)
+    rva.m = m.clone()
+    rva
+  }
 }
 
 class RegionValueCounterDoubleAggregator(t: Type) extends RegionValueCounterAggregator(t) {
@@ -128,6 +160,12 @@ class RegionValueCounterDoubleAggregator(t: Type) extends RegionValueCounterAggr
   }
 
   override def copy(): RegionValueCounterDoubleAggregator = new RegionValueCounterDoubleAggregator(t)
+
+  override def deepCopy(): RegionValueCounterDoubleAggregator = {
+    val rva = new RegionValueCounterDoubleAggregator(t)
+    rva.m = m.clone()
+    rva
+  }
 }
 
 class RegionValueCounterAnnotationAggregator(t: Type) extends RegionValueCounterAggregator(t) {
@@ -136,4 +174,10 @@ class RegionValueCounterAnnotationAggregator(t: Type) extends RegionValueCounter
   }
 
   override def copy(): RegionValueCounterAnnotationAggregator = new RegionValueCounterAnnotationAggregator(t)
+
+  override def deepCopy(): RegionValueCounterAnnotationAggregator = {
+    val rva = new RegionValueCounterAnnotationAggregator(t)
+    rva.m = m.clone()
+    rva
+  }
 }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueFractionAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueFractionAggregator.scala
@@ -27,6 +27,13 @@ class RegionValueFractionAggregator extends RegionValueAggregator {
 
   def copy() = new RegionValueFractionAggregator()
 
+  override def deepCopy(): RegionValueFractionAggregator = {
+    val rva = new RegionValueFractionAggregator()
+    rva.trues = trues
+    rva.total = total
+    rva
+  }
+
   def clear() {
     trues = 0L
     total = 0L

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueFractionAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueFractionAggregator.scala
@@ -25,9 +25,9 @@ class RegionValueFractionAggregator extends RegionValueAggregator {
     total += other.total
   }
 
-  def copy() = new RegionValueFractionAggregator()
+  def newInstance() = new RegionValueFractionAggregator()
 
-  override def deepCopy(): RegionValueFractionAggregator = {
+  override def copy(): RegionValueFractionAggregator = {
     val rva = new RegionValueFractionAggregator()
     rva.trues = trues
     rva.total = total

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueHardyWeinbergAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueHardyWeinbergAggregator.scala
@@ -27,6 +27,12 @@ class RegionValueHardyWeinbergAggregator extends RegionValueAggregator {
 
   override def copy(): RegionValueHardyWeinbergAggregator = new RegionValueHardyWeinbergAggregator()
 
+  override def deepCopy(): RegionValueHardyWeinbergAggregator = {
+    val rva = new RegionValueHardyWeinbergAggregator()
+    rva.combiner = combiner.copy()
+    rva
+  }
+
   override def clear() {
     combiner.clear()
   }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueHardyWeinbergAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueHardyWeinbergAggregator.scala
@@ -25,9 +25,9 @@ class RegionValueHardyWeinbergAggregator extends RegionValueAggregator {
     combiner.result(rvb)
   }
 
-  override def copy(): RegionValueHardyWeinbergAggregator = new RegionValueHardyWeinbergAggregator()
+  override def newInstance(): RegionValueHardyWeinbergAggregator = new RegionValueHardyWeinbergAggregator()
 
-  override def deepCopy(): RegionValueHardyWeinbergAggregator = {
+  override def copy(): RegionValueHardyWeinbergAggregator = {
     val rva = new RegionValueHardyWeinbergAggregator()
     rva.combiner = combiner.copy()
     rva

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueHistogramAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueHistogramAggregator.scala
@@ -23,7 +23,7 @@ class RegionValueHistogramAggregator(start: Double, end: Double, bins: Int) exte
 
   private val indices = Array.tabulate(bins + 1)(i => start + i * binSize)
 
-  private val combiner = new HistogramCombiner(indices)
+  private var combiner = new HistogramCombiner(indices)
 
   def seqOp(region: Region, x: Double, missing: Boolean) {
     if (!missing)
@@ -48,6 +48,12 @@ class RegionValueHistogramAggregator(start: Double, end: Double, bins: Int) exte
   }
 
   def copy() = new RegionValueHistogramAggregator(start, end, bins)
+
+  override def deepCopy(): RegionValueHistogramAggregator = {
+    val rva = new RegionValueHistogramAggregator(start, end, bins)
+    rva.combiner = combiner.copy()
+    rva
+  }
 
   def clear() {
     combiner.clear()

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueHistogramAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueHistogramAggregator.scala
@@ -47,9 +47,9 @@ class RegionValueHistogramAggregator(start: Double, end: Double, bins: Int) exte
     rvb.endStruct()
   }
 
-  def copy() = new RegionValueHistogramAggregator(start, end, bins)
+  def newInstance() = new RegionValueHistogramAggregator(start, end, bins)
 
-  override def deepCopy(): RegionValueHistogramAggregator = {
+  override def copy(): RegionValueHistogramAggregator = {
     val rva = new RegionValueHistogramAggregator(start, end, bins)
     rva.combiner = combiner.copy()
     rva

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueInbreedingAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueInbreedingAggregator.scala
@@ -35,6 +35,12 @@ class RegionValueInbreedingAggregator extends RegionValueAggregator {
 
   override def copy(): RegionValueInbreedingAggregator = new RegionValueInbreedingAggregator()
 
+  override def deepCopy(): RegionValueInbreedingAggregator = {
+    val rva = new RegionValueInbreedingAggregator()
+    rva.combiner = combiner.copy()
+    rva
+  }
+
   override def clear() {
     combiner.clear()
   }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueInbreedingAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueInbreedingAggregator.scala
@@ -33,9 +33,9 @@ class RegionValueInbreedingAggregator extends RegionValueAggregator {
       rvb.setMissing()
   }
 
-  override def copy(): RegionValueInbreedingAggregator = new RegionValueInbreedingAggregator()
+  override def newInstance(): RegionValueInbreedingAggregator = new RegionValueInbreedingAggregator()
 
-  override def deepCopy(): RegionValueInbreedingAggregator = {
+  override def copy(): RegionValueInbreedingAggregator = {
     val rva = new RegionValueInbreedingAggregator()
     rva.combiner = combiner.copy()
     rva

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueInfoScoreAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueInfoScoreAggregator.scala
@@ -26,6 +26,12 @@ class RegionValueInfoScoreAggregator extends RegionValueAggregator {
 
   override def copy(): RegionValueAggregator = new RegionValueInfoScoreAggregator()
 
+  override def deepCopy(): RegionValueInfoScoreAggregator = {
+    val rva = new RegionValueInfoScoreAggregator()
+    rva.combiner = combiner.copy()
+    rva
+  }
+
   override def clear() {
     combiner.clear()
   }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueInfoScoreAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueInfoScoreAggregator.scala
@@ -24,9 +24,9 @@ class RegionValueInfoScoreAggregator extends RegionValueAggregator {
     combiner.result(rvb)
   }
 
-  override def copy(): RegionValueAggregator = new RegionValueInfoScoreAggregator()
+  override def newInstance(): RegionValueAggregator = new RegionValueInfoScoreAggregator()
 
-  override def deepCopy(): RegionValueInfoScoreAggregator = {
+  override def copy(): RegionValueInfoScoreAggregator = {
     val rva = new RegionValueInfoScoreAggregator()
     rva.combiner = combiner.copy()
     rva

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueMaxAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueMaxAggregator.scala
@@ -29,6 +29,13 @@ class RegionValueMaxBooleanAggregator extends RegionValueAggregator {
   }
 
   def copy(): RegionValueMaxBooleanAggregator = new RegionValueMaxBooleanAggregator()
+  
+  def deepCopy(): RegionValueMaxBooleanAggregator = {
+    val rva = new RegionValueMaxBooleanAggregator()
+    rva.max = max
+    rva.empty = empty
+    rva
+  }
 
   def clear() {
     max = false
@@ -64,6 +71,13 @@ class RegionValueMaxIntAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueMaxIntAggregator = new RegionValueMaxIntAggregator()
 
+  def deepCopy(): RegionValueMaxIntAggregator = {
+    val rva = new RegionValueMaxIntAggregator()
+    rva.max = max
+    rva.empty = empty
+    rva
+  }
+  
   def clear() {
     max = 0
     empty = true
@@ -98,6 +112,13 @@ class RegionValueMaxLongAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueMaxLongAggregator = new RegionValueMaxLongAggregator()
 
+  def deepCopy(): RegionValueMaxLongAggregator = {
+    val rva = new RegionValueMaxLongAggregator()
+    rva.max = max
+    rva.empty = empty
+    rva
+  }
+  
   def clear() {
     max = 0L
     empty = true
@@ -132,6 +153,13 @@ class RegionValueMaxFloatAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueMaxFloatAggregator = new RegionValueMaxFloatAggregator()
 
+  def deepCopy(): RegionValueMaxFloatAggregator = {
+    val rva = new RegionValueMaxFloatAggregator()
+    rva.max = max
+    rva.empty = empty
+    rva
+  }
+  
   def clear() {
     max = 0.0f
     empty = true
@@ -166,6 +194,13 @@ class RegionValueMaxDoubleAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueMaxDoubleAggregator = new RegionValueMaxDoubleAggregator()
 
+  def deepCopy(): RegionValueMaxDoubleAggregator = {
+    val rva = new RegionValueMaxDoubleAggregator()
+    rva.max = max
+    rva.empty = empty
+    rva
+  }
+  
   def clear() {
     max = 0.0
     empty = true

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueMaxAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueMaxAggregator.scala
@@ -28,9 +28,9 @@ class RegionValueMaxBooleanAggregator extends RegionValueAggregator {
       rvb.addBoolean(max)
   }
 
-  def copy(): RegionValueMaxBooleanAggregator = new RegionValueMaxBooleanAggregator()
+  def newInstance(): RegionValueMaxBooleanAggregator = new RegionValueMaxBooleanAggregator()
   
-  def deepCopy(): RegionValueMaxBooleanAggregator = {
+  def copy(): RegionValueMaxBooleanAggregator = {
     val rva = new RegionValueMaxBooleanAggregator()
     rva.max = max
     rva.empty = empty
@@ -69,9 +69,9 @@ class RegionValueMaxIntAggregator extends RegionValueAggregator {
       rvb.addInt(max)
   }
 
-  def copy(): RegionValueMaxIntAggregator = new RegionValueMaxIntAggregator()
+  def newInstance(): RegionValueMaxIntAggregator = new RegionValueMaxIntAggregator()
 
-  def deepCopy(): RegionValueMaxIntAggregator = {
+  def copy(): RegionValueMaxIntAggregator = {
     val rva = new RegionValueMaxIntAggregator()
     rva.max = max
     rva.empty = empty
@@ -110,9 +110,9 @@ class RegionValueMaxLongAggregator extends RegionValueAggregator {
       rvb.addLong(max)
   }
 
-  def copy(): RegionValueMaxLongAggregator = new RegionValueMaxLongAggregator()
+  def newInstance(): RegionValueMaxLongAggregator = new RegionValueMaxLongAggregator()
 
-  def deepCopy(): RegionValueMaxLongAggregator = {
+  def copy(): RegionValueMaxLongAggregator = {
     val rva = new RegionValueMaxLongAggregator()
     rva.max = max
     rva.empty = empty
@@ -151,9 +151,9 @@ class RegionValueMaxFloatAggregator extends RegionValueAggregator {
       rvb.addFloat(max)
   }
 
-  def copy(): RegionValueMaxFloatAggregator = new RegionValueMaxFloatAggregator()
+  def newInstance(): RegionValueMaxFloatAggregator = new RegionValueMaxFloatAggregator()
 
-  def deepCopy(): RegionValueMaxFloatAggregator = {
+  def copy(): RegionValueMaxFloatAggregator = {
     val rva = new RegionValueMaxFloatAggregator()
     rva.max = max
     rva.empty = empty
@@ -192,9 +192,9 @@ class RegionValueMaxDoubleAggregator extends RegionValueAggregator {
       rvb.addDouble(max)
   }
 
-  def copy(): RegionValueMaxDoubleAggregator = new RegionValueMaxDoubleAggregator()
+  def newInstance(): RegionValueMaxDoubleAggregator = new RegionValueMaxDoubleAggregator()
 
-  def deepCopy(): RegionValueMaxDoubleAggregator = {
+  def copy(): RegionValueMaxDoubleAggregator = {
     val rva = new RegionValueMaxDoubleAggregator()
     rva.max = max
     rva.empty = empty

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueMinAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueMinAggregator.scala
@@ -28,9 +28,9 @@ class RegionValueMinBooleanAggregator extends RegionValueAggregator {
       rvb.addBoolean(min)
   }
 
-  def copy(): RegionValueMinBooleanAggregator = new RegionValueMinBooleanAggregator()
+  def newInstance(): RegionValueMinBooleanAggregator = new RegionValueMinBooleanAggregator()
 
-  def deepCopy(): RegionValueMinBooleanAggregator = {
+  def copy(): RegionValueMinBooleanAggregator = {
     val rva = new RegionValueMinBooleanAggregator()
     rva.min = min
     rva.empty = empty
@@ -69,9 +69,9 @@ class RegionValueMinIntAggregator extends RegionValueAggregator {
       rvb.addInt(min)
   }
 
-  def copy(): RegionValueMinIntAggregator = new RegionValueMinIntAggregator()
+  def newInstance(): RegionValueMinIntAggregator = new RegionValueMinIntAggregator()
 
-  def deepCopy(): RegionValueMinIntAggregator = {
+  def copy(): RegionValueMinIntAggregator = {
     val rva = new RegionValueMinIntAggregator()
     rva.min = min
     rva.empty = empty
@@ -110,9 +110,9 @@ class RegionValueMinLongAggregator extends RegionValueAggregator {
       rvb.addLong(min)
   }
 
-  def copy(): RegionValueMinLongAggregator = new RegionValueMinLongAggregator()
+  def newInstance(): RegionValueMinLongAggregator = new RegionValueMinLongAggregator()
 
-  def deepCopy(): RegionValueMinLongAggregator = {
+  def copy(): RegionValueMinLongAggregator = {
     val rva = new RegionValueMinLongAggregator()
     rva.min = min
     rva.empty = empty
@@ -151,9 +151,9 @@ class RegionValueMinFloatAggregator extends RegionValueAggregator {
       rvb.addFloat(min)
   }
 
-  def copy(): RegionValueMinFloatAggregator = new RegionValueMinFloatAggregator()
+  def newInstance(): RegionValueMinFloatAggregator = new RegionValueMinFloatAggregator()
   
-  def deepCopy(): RegionValueMinFloatAggregator = {
+  def copy(): RegionValueMinFloatAggregator = {
     val rva = new RegionValueMinFloatAggregator()
     rva.min = min
     rva.empty = empty
@@ -192,9 +192,9 @@ class RegionValueMinDoubleAggregator extends RegionValueAggregator {
       rvb.addDouble(min)
   }
 
-  def copy(): RegionValueMinDoubleAggregator = new RegionValueMinDoubleAggregator()
+  def newInstance(): RegionValueMinDoubleAggregator = new RegionValueMinDoubleAggregator()
 
-  def deepCopy(): RegionValueMinDoubleAggregator = {
+  def copy(): RegionValueMinDoubleAggregator = {
     val rva = new RegionValueMinDoubleAggregator()
     rva.min = min
     rva.empty = empty

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueMinAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueMinAggregator.scala
@@ -30,6 +30,13 @@ class RegionValueMinBooleanAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueMinBooleanAggregator = new RegionValueMinBooleanAggregator()
 
+  def deepCopy(): RegionValueMinBooleanAggregator = {
+    val rva = new RegionValueMinBooleanAggregator()
+    rva.min = min
+    rva.empty = empty
+    rva
+  }
+  
   def clear() {
     min = false
     empty = true
@@ -64,6 +71,13 @@ class RegionValueMinIntAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueMinIntAggregator = new RegionValueMinIntAggregator()
 
+  def deepCopy(): RegionValueMinIntAggregator = {
+    val rva = new RegionValueMinIntAggregator()
+    rva.min = min
+    rva.empty = empty
+    rva
+  }
+  
   def clear() {
     min = 0
     empty = true
@@ -98,6 +112,13 @@ class RegionValueMinLongAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueMinLongAggregator = new RegionValueMinLongAggregator()
 
+  def deepCopy(): RegionValueMinLongAggregator = {
+    val rva = new RegionValueMinLongAggregator()
+    rva.min = min
+    rva.empty = empty
+    rva
+  }
+  
   def clear() {
     min = 0L
     empty = true
@@ -131,7 +152,14 @@ class RegionValueMinFloatAggregator extends RegionValueAggregator {
   }
 
   def copy(): RegionValueMinFloatAggregator = new RegionValueMinFloatAggregator()
-
+  
+  def deepCopy(): RegionValueMinFloatAggregator = {
+    val rva = new RegionValueMinFloatAggregator()
+    rva.min = min
+    rva.empty = empty
+    rva
+  }
+  
   def clear() {
     min = 0.0f
     empty = true
@@ -166,6 +194,13 @@ class RegionValueMinDoubleAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueMinDoubleAggregator = new RegionValueMinDoubleAggregator()
 
+  def deepCopy(): RegionValueMinDoubleAggregator = {
+    val rva = new RegionValueMinDoubleAggregator()
+    rva.min = min
+    rva.empty = empty
+    rva
+  }
+  
   def clear() {
     min = 0.0
     empty = true

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueProductAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueProductAggregator.scala
@@ -20,6 +20,12 @@ class RegionValueProductLongAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueProductLongAggregator = new RegionValueProductLongAggregator()
 
+  def deepCopy(): RegionValueProductLongAggregator = {
+    val rva = new RegionValueProductLongAggregator()
+    rva.product = product
+    rva
+  }
+
   def clear() {
     product = 1L
   }
@@ -42,6 +48,12 @@ class RegionValueProductDoubleAggregator extends RegionValueAggregator {
   }
 
   def copy(): RegionValueProductDoubleAggregator = new RegionValueProductDoubleAggregator()
+
+  def deepCopy(): RegionValueProductDoubleAggregator = {
+    val rva = new RegionValueProductDoubleAggregator()
+    rva.product = product
+    rva
+  }
 
   def clear() {
     product = 1.0

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueProductAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueProductAggregator.scala
@@ -18,9 +18,9 @@ class RegionValueProductLongAggregator extends RegionValueAggregator {
     rvb.addLong(product)
   }
 
-  def copy(): RegionValueProductLongAggregator = new RegionValueProductLongAggregator()
+  def newInstance(): RegionValueProductLongAggregator = new RegionValueProductLongAggregator()
 
-  def deepCopy(): RegionValueProductLongAggregator = {
+  def copy(): RegionValueProductLongAggregator = {
     val rva = new RegionValueProductLongAggregator()
     rva.product = product
     rva
@@ -47,9 +47,9 @@ class RegionValueProductDoubleAggregator extends RegionValueAggregator {
     rvb.addDouble(product)
   }
 
-  def copy(): RegionValueProductDoubleAggregator = new RegionValueProductDoubleAggregator()
+  def newInstance(): RegionValueProductDoubleAggregator = new RegionValueProductDoubleAggregator()
 
-  def deepCopy(): RegionValueProductDoubleAggregator = {
+  def copy(): RegionValueProductDoubleAggregator = {
     val rva = new RegionValueProductDoubleAggregator()
     rva.product = product
     rva

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueStatisticsAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueStatisticsAggregator.scala
@@ -44,6 +44,12 @@ class RegionValueStatisticsAggregator extends RegionValueAggregator {
 
   def copy() = new RegionValueStatisticsAggregator()
 
+  def deepCopy(): RegionValueStatisticsAggregator = {
+    val rva = new RegionValueStatisticsAggregator()
+    rva.sc = sc.copy()
+    rva
+  }
+
   def clear() {
     sc = new StatCounter()
   }

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueStatisticsAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueStatisticsAggregator.scala
@@ -42,9 +42,9 @@ class RegionValueStatisticsAggregator extends RegionValueAggregator {
     }
   }
 
-  def copy() = new RegionValueStatisticsAggregator()
+  def newInstance() = new RegionValueStatisticsAggregator()
 
-  def deepCopy(): RegionValueStatisticsAggregator = {
+  def copy(): RegionValueStatisticsAggregator = {
     val rva = new RegionValueStatisticsAggregator()
     rva.sc = sc.copy()
     rva

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueSumAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueSumAggregator.scala
@@ -20,6 +20,12 @@ class RegionValueSumLongAggregator extends RegionValueAggregator {
 
   def copy(): RegionValueSumLongAggregator = new RegionValueSumLongAggregator()
 
+  def deepCopy(): RegionValueSumLongAggregator = {
+    val rva = new RegionValueSumLongAggregator()
+    rva.sum = sum
+    rva
+  }
+
   def clear() {
     sum = 0L
   }
@@ -42,6 +48,12 @@ class RegionValueSumDoubleAggregator extends RegionValueAggregator {
   }
 
   def copy(): RegionValueSumDoubleAggregator = new RegionValueSumDoubleAggregator()
+
+  def deepCopy(): RegionValueSumDoubleAggregator = {
+    val rva = new RegionValueSumDoubleAggregator()
+    rva.sum = sum
+    rva
+  }
 
   def clear() {
     sum = 0.0

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueSumAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueSumAggregator.scala
@@ -18,9 +18,9 @@ class RegionValueSumLongAggregator extends RegionValueAggregator {
     rvb.addLong(sum)
   }
 
-  def copy(): RegionValueSumLongAggregator = new RegionValueSumLongAggregator()
+  def newInstance(): RegionValueSumLongAggregator = new RegionValueSumLongAggregator()
 
-  def deepCopy(): RegionValueSumLongAggregator = {
+  def copy(): RegionValueSumLongAggregator = {
     val rva = new RegionValueSumLongAggregator()
     rva.sum = sum
     rva
@@ -47,9 +47,9 @@ class RegionValueSumDoubleAggregator extends RegionValueAggregator {
     rvb.addDouble(sum)
   }
 
-  def copy(): RegionValueSumDoubleAggregator = new RegionValueSumDoubleAggregator()
+  def newInstance(): RegionValueSumDoubleAggregator = new RegionValueSumDoubleAggregator()
 
-  def deepCopy(): RegionValueSumDoubleAggregator = {
+  def copy(): RegionValueSumDoubleAggregator = {
     val rva = new RegionValueSumDoubleAggregator()
     rva.sum = sum
     rva

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueTakeAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueTakeAggregator.scala
@@ -32,9 +32,9 @@ class RegionValueTakeBooleanAggregator(n: Int) extends RegionValueAggregator {
     ab.write(rvb)
   }
 
-  def copy(): RegionValueTakeBooleanAggregator = new RegionValueTakeBooleanAggregator(n)
+  def newInstance(): RegionValueTakeBooleanAggregator = new RegionValueTakeBooleanAggregator(n)
 
-  def deepCopy(): RegionValueTakeBooleanAggregator = {
+  def copy(): RegionValueTakeBooleanAggregator = {
     val rva = new RegionValueTakeBooleanAggregator(n)
     rva.ab = ab.clone()
     rva
@@ -71,9 +71,9 @@ class RegionValueTakeIntAggregator(n: Int) extends RegionValueAggregator {
     ab.write(rvb)
   }
 
-  def copy(): RegionValueTakeIntAggregator = new RegionValueTakeIntAggregator(n)
+  def newInstance(): RegionValueTakeIntAggregator = new RegionValueTakeIntAggregator(n)
 
-  def deepCopy(): RegionValueTakeIntAggregator = {
+  def copy(): RegionValueTakeIntAggregator = {
     val rva = new RegionValueTakeIntAggregator(n)
     rva.ab = ab.clone()
     rva
@@ -110,9 +110,9 @@ class RegionValueTakeLongAggregator(n: Int) extends RegionValueAggregator {
     ab.write(rvb)
   }
 
-  def copy(): RegionValueTakeLongAggregator = new RegionValueTakeLongAggregator(n)
+  def newInstance(): RegionValueTakeLongAggregator = new RegionValueTakeLongAggregator(n)
 
-  def deepCopy(): RegionValueTakeLongAggregator = {
+  def copy(): RegionValueTakeLongAggregator = {
     val rva = new RegionValueTakeLongAggregator(n)
     rva.ab = ab.clone()
     rva
@@ -149,9 +149,9 @@ class RegionValueTakeFloatAggregator(n: Int) extends RegionValueAggregator {
     ab.write(rvb)
   }
 
-  def copy(): RegionValueTakeFloatAggregator = new RegionValueTakeFloatAggregator(n)
+  def newInstance(): RegionValueTakeFloatAggregator = new RegionValueTakeFloatAggregator(n)
 
-  def deepCopy(): RegionValueTakeFloatAggregator = {
+  def copy(): RegionValueTakeFloatAggregator = {
     val rva = new RegionValueTakeFloatAggregator(n)
     rva.ab = ab.clone()
     rva
@@ -188,9 +188,9 @@ class RegionValueTakeDoubleAggregator(n: Int) extends RegionValueAggregator {
     ab.write(rvb)
   }
 
-  def copy(): RegionValueTakeDoubleAggregator = new RegionValueTakeDoubleAggregator(n)
+  def newInstance(): RegionValueTakeDoubleAggregator = new RegionValueTakeDoubleAggregator(n)
 
-  def deepCopy(): RegionValueTakeDoubleAggregator = {
+  def copy(): RegionValueTakeDoubleAggregator = {
     val rva = new RegionValueTakeDoubleAggregator(n)
     rva.ab = ab.clone()
     rva
@@ -227,9 +227,9 @@ class RegionValueTakeAnnotationAggregator(n: Int, t: Type) extends RegionValueAg
     ab.write(rvb, t)
   }
 
-  def copy(): RegionValueTakeAnnotationAggregator = new RegionValueTakeAnnotationAggregator(n, t)
+  def newInstance(): RegionValueTakeAnnotationAggregator = new RegionValueTakeAnnotationAggregator(n, t)
 
-  def deepCopy(): RegionValueTakeAnnotationAggregator = {
+  def copy(): RegionValueTakeAnnotationAggregator = {
     val rva = new RegionValueTakeAnnotationAggregator(n, t)
     rva.ab = ab.clone()
     rva

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueTakeAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueTakeAggregator.scala
@@ -7,7 +7,7 @@ import is.hail.expr.types.Type
 import is.hail.utils._
 
 class RegionValueTakeBooleanAggregator(n: Int) extends RegionValueAggregator {
-  private val ab = new MissingBooleanArrayBuilder()
+  private var ab = new MissingBooleanArrayBuilder()
 
   def seqOp(region: Region, x: Boolean, missing: Boolean) {
     if (ab.length() < n)
@@ -34,13 +34,19 @@ class RegionValueTakeBooleanAggregator(n: Int) extends RegionValueAggregator {
 
   def copy(): RegionValueTakeBooleanAggregator = new RegionValueTakeBooleanAggregator(n)
 
+  def deepCopy(): RegionValueTakeBooleanAggregator = {
+    val rva = new RegionValueTakeBooleanAggregator(n)
+    rva.ab = ab.clone()
+    rva
+  }
+
   def clear() {
     ab.clear()
   }
 }
 
 class RegionValueTakeIntAggregator(n: Int) extends RegionValueAggregator {
-  private val ab = new MissingIntArrayBuilder()
+  private var ab = new MissingIntArrayBuilder()
 
   def seqOp(region: Region, x: Int, missing: Boolean) {
     if (ab.length() < n)
@@ -67,13 +73,19 @@ class RegionValueTakeIntAggregator(n: Int) extends RegionValueAggregator {
 
   def copy(): RegionValueTakeIntAggregator = new RegionValueTakeIntAggregator(n)
 
+  def deepCopy(): RegionValueTakeIntAggregator = {
+    val rva = new RegionValueTakeIntAggregator(n)
+    rva.ab = ab.clone()
+    rva
+  }
+
   def clear() {
     ab.clear()
   }
 }
 
 class RegionValueTakeLongAggregator(n: Int) extends RegionValueAggregator {
-  private val ab = new MissingLongArrayBuilder()
+  private var ab = new MissingLongArrayBuilder()
 
   def seqOp(region: Region, x: Long, missing: Boolean) {
     if (ab.length() < n)
@@ -100,13 +112,19 @@ class RegionValueTakeLongAggregator(n: Int) extends RegionValueAggregator {
 
   def copy(): RegionValueTakeLongAggregator = new RegionValueTakeLongAggregator(n)
 
+  def deepCopy(): RegionValueTakeLongAggregator = {
+    val rva = new RegionValueTakeLongAggregator(n)
+    rva.ab = ab.clone()
+    rva
+  }
+
   def clear() {
     ab.clear()
   }
 }
 
 class RegionValueTakeFloatAggregator(n: Int) extends RegionValueAggregator {
-  private val ab = new MissingFloatArrayBuilder()
+  private var ab = new MissingFloatArrayBuilder()
 
   def seqOp(region: Region, x: Float, missing: Boolean) {
     if (ab.length() < n)
@@ -133,13 +151,19 @@ class RegionValueTakeFloatAggregator(n: Int) extends RegionValueAggregator {
 
   def copy(): RegionValueTakeFloatAggregator = new RegionValueTakeFloatAggregator(n)
 
+  def deepCopy(): RegionValueTakeFloatAggregator = {
+    val rva = new RegionValueTakeFloatAggregator(n)
+    rva.ab = ab.clone()
+    rva
+  }
+
   def clear() {
     ab.clear()
   }
 }
 
 class RegionValueTakeDoubleAggregator(n: Int) extends RegionValueAggregator {
-  private val ab = new MissingDoubleArrayBuilder()
+  private var ab = new MissingDoubleArrayBuilder()
 
   def seqOp(region: Region, x: Double, missing: Boolean) {
     if (ab.length() < n)
@@ -166,13 +190,19 @@ class RegionValueTakeDoubleAggregator(n: Int) extends RegionValueAggregator {
 
   def copy(): RegionValueTakeDoubleAggregator = new RegionValueTakeDoubleAggregator(n)
 
+  def deepCopy(): RegionValueTakeDoubleAggregator = {
+    val rva = new RegionValueTakeDoubleAggregator(n)
+    rva.ab = ab.clone()
+    rva
+  }
+
   def clear() {
     ab.clear()
   }
 }
 
 class RegionValueTakeAnnotationAggregator(n: Int, t: Type) extends RegionValueAggregator {
-  private val ab = new MissingAnnotationArrayBuilder()
+  private var ab = new MissingAnnotationArrayBuilder()
 
   def seqOp(region: Region, offset: Long, missing: Boolean) {
     if (ab.length() < n)
@@ -198,6 +228,12 @@ class RegionValueTakeAnnotationAggregator(n: Int, t: Type) extends RegionValueAg
   }
 
   def copy(): RegionValueTakeAnnotationAggregator = new RegionValueTakeAnnotationAggregator(n, t)
+
+  def deepCopy(): RegionValueTakeAnnotationAggregator = {
+    val rva = new RegionValueTakeAnnotationAggregator(n, t)
+    rva.ab = ab.clone()
+    rva
+  }
 
   def clear() {
     ab.clear()

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueTakeByAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueTakeByAggregator.scala
@@ -34,9 +34,9 @@ class RegionValueTakeByAggregator(n: Int, aggType: Type, keyType: Type) extends 
     rvb.endArray()
   }
 
-  override def copy(): RegionValueTakeByAggregator = new RegionValueTakeByAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByAggregator = new RegionValueTakeByAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByAggregator = {
+  override def copy(): RegionValueTakeByAggregator = {
     val rva = new RegionValueTakeByAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -52,9 +52,9 @@ class RegionValueTakeByBooleanBooleanAggregator(n: Int, aggType: Type, keyType: 
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByBooleanBooleanAggregator = new RegionValueTakeByBooleanBooleanAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByBooleanBooleanAggregator = new RegionValueTakeByBooleanBooleanAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByBooleanBooleanAggregator = {
+  override def copy(): RegionValueTakeByBooleanBooleanAggregator = {
     val rva = new RegionValueTakeByBooleanBooleanAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -66,9 +66,9 @@ class RegionValueTakeByBooleanIntAggregator(n: Int, aggType: Type, keyType: Type
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByBooleanIntAggregator = new RegionValueTakeByBooleanIntAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByBooleanIntAggregator = new RegionValueTakeByBooleanIntAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByBooleanIntAggregator = {
+  override def copy(): RegionValueTakeByBooleanIntAggregator = {
     val rva = new RegionValueTakeByBooleanIntAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -80,9 +80,9 @@ class RegionValueTakeByBooleanLongAggregator(n: Int, aggType: Type, keyType: Typ
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByBooleanLongAggregator = new RegionValueTakeByBooleanLongAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByBooleanLongAggregator = new RegionValueTakeByBooleanLongAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByBooleanLongAggregator = {
+  override def copy(): RegionValueTakeByBooleanLongAggregator = {
     val rva = new RegionValueTakeByBooleanLongAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -94,9 +94,9 @@ class RegionValueTakeByBooleanFloatAggregator(n: Int, aggType: Type, keyType: Ty
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByBooleanFloatAggregator = new RegionValueTakeByBooleanFloatAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByBooleanFloatAggregator = new RegionValueTakeByBooleanFloatAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByBooleanFloatAggregator = {
+  override def copy(): RegionValueTakeByBooleanFloatAggregator = {
     val rva = new RegionValueTakeByBooleanFloatAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -108,9 +108,9 @@ class RegionValueTakeByBooleanDoubleAggregator(n: Int, aggType: Type, keyType: T
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByBooleanDoubleAggregator = new RegionValueTakeByBooleanDoubleAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByBooleanDoubleAggregator = new RegionValueTakeByBooleanDoubleAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByBooleanDoubleAggregator = {
+  override def copy(): RegionValueTakeByBooleanDoubleAggregator = {
     val rva = new RegionValueTakeByBooleanDoubleAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -122,9 +122,9 @@ class RegionValueTakeByBooleanAnnotationAggregator(n: Int, aggType: Type, keyTyp
     seqOp(if (xm) null else x, if (km) null else SafeRow.read(keyType, region, k))
   }
 
-  override def copy(): RegionValueTakeByBooleanAnnotationAggregator = new RegionValueTakeByBooleanAnnotationAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByBooleanAnnotationAggregator = new RegionValueTakeByBooleanAnnotationAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByBooleanAnnotationAggregator = {
+  override def copy(): RegionValueTakeByBooleanAnnotationAggregator = {
     val rva = new RegionValueTakeByBooleanAnnotationAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -136,9 +136,9 @@ class RegionValueTakeByIntBooleanAggregator(n: Int, aggType: Type, keyType: Type
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByIntBooleanAggregator = new RegionValueTakeByIntBooleanAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByIntBooleanAggregator = new RegionValueTakeByIntBooleanAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByIntBooleanAggregator = {
+  override def copy(): RegionValueTakeByIntBooleanAggregator = {
     val rva = new RegionValueTakeByIntBooleanAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -150,9 +150,9 @@ class RegionValueTakeByIntIntAggregator(n: Int, aggType: Type, keyType: Type) ex
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByIntIntAggregator = new RegionValueTakeByIntIntAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByIntIntAggregator = new RegionValueTakeByIntIntAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByIntIntAggregator = {
+  override def copy(): RegionValueTakeByIntIntAggregator = {
     val rva = new RegionValueTakeByIntIntAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -164,9 +164,9 @@ class RegionValueTakeByIntLongAggregator(n: Int, aggType: Type, keyType: Type) e
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByIntLongAggregator = new RegionValueTakeByIntLongAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByIntLongAggregator = new RegionValueTakeByIntLongAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByIntLongAggregator = {
+  override def copy(): RegionValueTakeByIntLongAggregator = {
     val rva = new RegionValueTakeByIntLongAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -178,9 +178,9 @@ class RegionValueTakeByIntFloatAggregator(n: Int, aggType: Type, keyType: Type) 
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByIntFloatAggregator = new RegionValueTakeByIntFloatAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByIntFloatAggregator = new RegionValueTakeByIntFloatAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByIntFloatAggregator = {
+  override def copy(): RegionValueTakeByIntFloatAggregator = {
     val rva = new RegionValueTakeByIntFloatAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -192,9 +192,9 @@ class RegionValueTakeByIntDoubleAggregator(n: Int, aggType: Type, keyType: Type)
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByIntDoubleAggregator = new RegionValueTakeByIntDoubleAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByIntDoubleAggregator = new RegionValueTakeByIntDoubleAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByIntDoubleAggregator = {
+  override def copy(): RegionValueTakeByIntDoubleAggregator = {
     val rva = new RegionValueTakeByIntDoubleAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -206,9 +206,9 @@ class RegionValueTakeByIntAnnotationAggregator(n: Int, aggType: Type, keyType: T
     seqOp(if (xm) null else x, if (km) null else SafeRow.read(keyType, region, k))
   }
 
-  override def copy(): RegionValueTakeByIntAnnotationAggregator = new RegionValueTakeByIntAnnotationAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByIntAnnotationAggregator = new RegionValueTakeByIntAnnotationAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByIntAnnotationAggregator = {
+  override def copy(): RegionValueTakeByIntAnnotationAggregator = {
     val rva = new RegionValueTakeByIntAnnotationAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -220,9 +220,9 @@ class RegionValueTakeByLongBooleanAggregator(n: Int, aggType: Type, keyType: Typ
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByLongBooleanAggregator = new RegionValueTakeByLongBooleanAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByLongBooleanAggregator = new RegionValueTakeByLongBooleanAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByLongBooleanAggregator = {
+  override def copy(): RegionValueTakeByLongBooleanAggregator = {
     val rva = new RegionValueTakeByLongBooleanAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -234,9 +234,9 @@ class RegionValueTakeByLongIntAggregator(n: Int, aggType: Type, keyType: Type) e
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByLongIntAggregator = new RegionValueTakeByLongIntAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByLongIntAggregator = new RegionValueTakeByLongIntAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByLongIntAggregator = {
+  override def copy(): RegionValueTakeByLongIntAggregator = {
     val rva = new RegionValueTakeByLongIntAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -248,9 +248,9 @@ class RegionValueTakeByLongLongAggregator(n: Int, aggType: Type, keyType: Type) 
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByLongLongAggregator = new RegionValueTakeByLongLongAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByLongLongAggregator = new RegionValueTakeByLongLongAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByLongLongAggregator = {
+  override def copy(): RegionValueTakeByLongLongAggregator = {
     val rva = new RegionValueTakeByLongLongAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -262,9 +262,9 @@ class RegionValueTakeByLongFloatAggregator(n: Int, aggType: Type, keyType: Type)
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByLongFloatAggregator = new RegionValueTakeByLongFloatAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByLongFloatAggregator = new RegionValueTakeByLongFloatAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByLongFloatAggregator = {
+  override def copy(): RegionValueTakeByLongFloatAggregator = {
     val rva = new RegionValueTakeByLongFloatAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -276,9 +276,9 @@ class RegionValueTakeByLongDoubleAggregator(n: Int, aggType: Type, keyType: Type
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByLongDoubleAggregator = new RegionValueTakeByLongDoubleAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByLongDoubleAggregator = new RegionValueTakeByLongDoubleAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByLongDoubleAggregator = {
+  override def copy(): RegionValueTakeByLongDoubleAggregator = {
     val rva = new RegionValueTakeByLongDoubleAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -290,9 +290,9 @@ class RegionValueTakeByLongAnnotationAggregator(n: Int, aggType: Type, keyType: 
     seqOp(if (xm) null else x, if (km) null else SafeRow.read(keyType, region, k))
   }
 
-  override def copy(): RegionValueTakeByLongAnnotationAggregator = new RegionValueTakeByLongAnnotationAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByLongAnnotationAggregator = new RegionValueTakeByLongAnnotationAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByLongAnnotationAggregator = {
+  override def copy(): RegionValueTakeByLongAnnotationAggregator = {
     val rva = new RegionValueTakeByLongAnnotationAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -304,9 +304,9 @@ class RegionValueTakeByFloatBooleanAggregator(n: Int, aggType: Type, keyType: Ty
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByFloatBooleanAggregator = new RegionValueTakeByFloatBooleanAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByFloatBooleanAggregator = new RegionValueTakeByFloatBooleanAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByFloatBooleanAggregator = {
+  override def copy(): RegionValueTakeByFloatBooleanAggregator = {
     val rva = new RegionValueTakeByFloatBooleanAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -318,9 +318,9 @@ class RegionValueTakeByFloatIntAggregator(n: Int, aggType: Type, keyType: Type) 
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByFloatIntAggregator = new RegionValueTakeByFloatIntAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByFloatIntAggregator = new RegionValueTakeByFloatIntAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByFloatIntAggregator = {
+  override def copy(): RegionValueTakeByFloatIntAggregator = {
     val rva = new RegionValueTakeByFloatIntAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -332,9 +332,9 @@ class RegionValueTakeByFloatLongAggregator(n: Int, aggType: Type, keyType: Type)
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByFloatLongAggregator = new RegionValueTakeByFloatLongAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByFloatLongAggregator = new RegionValueTakeByFloatLongAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByFloatLongAggregator = {
+  override def copy(): RegionValueTakeByFloatLongAggregator = {
     val rva = new RegionValueTakeByFloatLongAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -346,9 +346,9 @@ class RegionValueTakeByFloatFloatAggregator(n: Int, aggType: Type, keyType: Type
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByFloatFloatAggregator = new RegionValueTakeByFloatFloatAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByFloatFloatAggregator = new RegionValueTakeByFloatFloatAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByFloatFloatAggregator = {
+  override def copy(): RegionValueTakeByFloatFloatAggregator = {
     val rva = new RegionValueTakeByFloatFloatAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -360,9 +360,9 @@ class RegionValueTakeByFloatDoubleAggregator(n: Int, aggType: Type, keyType: Typ
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByFloatDoubleAggregator = new RegionValueTakeByFloatDoubleAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByFloatDoubleAggregator = new RegionValueTakeByFloatDoubleAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByFloatDoubleAggregator = {
+  override def copy(): RegionValueTakeByFloatDoubleAggregator = {
     val rva = new RegionValueTakeByFloatDoubleAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -374,9 +374,9 @@ class RegionValueTakeByFloatAnnotationAggregator(n: Int, aggType: Type, keyType:
     seqOp(if (xm) null else x, if (km) null else SafeRow.read(keyType, region, k))
   }
 
-  override def copy(): RegionValueTakeByFloatAnnotationAggregator = new RegionValueTakeByFloatAnnotationAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByFloatAnnotationAggregator = new RegionValueTakeByFloatAnnotationAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByFloatAnnotationAggregator = {
+  override def copy(): RegionValueTakeByFloatAnnotationAggregator = {
     val rva = new RegionValueTakeByFloatAnnotationAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -388,9 +388,9 @@ class RegionValueTakeByDoubleBooleanAggregator(n: Int, aggType: Type, keyType: T
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByDoubleBooleanAggregator = new RegionValueTakeByDoubleBooleanAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByDoubleBooleanAggregator = new RegionValueTakeByDoubleBooleanAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByDoubleBooleanAggregator = {
+  override def copy(): RegionValueTakeByDoubleBooleanAggregator = {
     val rva = new RegionValueTakeByDoubleBooleanAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -402,9 +402,9 @@ class RegionValueTakeByDoubleIntAggregator(n: Int, aggType: Type, keyType: Type)
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByDoubleIntAggregator = new RegionValueTakeByDoubleIntAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByDoubleIntAggregator = new RegionValueTakeByDoubleIntAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByDoubleIntAggregator = {
+  override def copy(): RegionValueTakeByDoubleIntAggregator = {
     val rva = new RegionValueTakeByDoubleIntAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -416,9 +416,9 @@ class RegionValueTakeByDoubleLongAggregator(n: Int, aggType: Type, keyType: Type
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByDoubleLongAggregator = new RegionValueTakeByDoubleLongAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByDoubleLongAggregator = new RegionValueTakeByDoubleLongAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByDoubleLongAggregator = {
+  override def copy(): RegionValueTakeByDoubleLongAggregator = {
     val rva = new RegionValueTakeByDoubleLongAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -430,9 +430,9 @@ class RegionValueTakeByDoubleFloatAggregator(n: Int, aggType: Type, keyType: Typ
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByDoubleFloatAggregator = new RegionValueTakeByDoubleFloatAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByDoubleFloatAggregator = new RegionValueTakeByDoubleFloatAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByDoubleFloatAggregator = {
+  override def copy(): RegionValueTakeByDoubleFloatAggregator = {
     val rva = new RegionValueTakeByDoubleFloatAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -444,9 +444,9 @@ class RegionValueTakeByDoubleDoubleAggregator(n: Int, aggType: Type, keyType: Ty
     seqOp(if (xm) null else x, if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByDoubleDoubleAggregator = new RegionValueTakeByDoubleDoubleAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByDoubleDoubleAggregator = new RegionValueTakeByDoubleDoubleAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByDoubleDoubleAggregator = {
+  override def copy(): RegionValueTakeByDoubleDoubleAggregator = {
     val rva = new RegionValueTakeByDoubleDoubleAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -458,9 +458,9 @@ class RegionValueTakeByDoubleAnnotationAggregator(n: Int, aggType: Type, keyType
     seqOp(if (xm) null else x, if (km) null else SafeRow.read(keyType, region, k))
   }
 
-  override def copy(): RegionValueTakeByDoubleAnnotationAggregator = new RegionValueTakeByDoubleAnnotationAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByDoubleAnnotationAggregator = new RegionValueTakeByDoubleAnnotationAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByDoubleAnnotationAggregator = {
+  override def copy(): RegionValueTakeByDoubleAnnotationAggregator = {
     val rva = new RegionValueTakeByDoubleAnnotationAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -472,9 +472,9 @@ class RegionValueTakeByAnnotationBooleanAggregator(n: Int, aggType: Type, keyTyp
     seqOp(if (xm) null else SafeRow.read(aggType, region, x), if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByAnnotationBooleanAggregator = new RegionValueTakeByAnnotationBooleanAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByAnnotationBooleanAggregator = new RegionValueTakeByAnnotationBooleanAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByAnnotationBooleanAggregator = {
+  override def copy(): RegionValueTakeByAnnotationBooleanAggregator = {
     val rva = new RegionValueTakeByAnnotationBooleanAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -486,9 +486,9 @@ class RegionValueTakeByAnnotationIntAggregator(n: Int, aggType: Type, keyType: T
     seqOp(if (xm) null else SafeRow.read(aggType, region, x), if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByAnnotationIntAggregator = new RegionValueTakeByAnnotationIntAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByAnnotationIntAggregator = new RegionValueTakeByAnnotationIntAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByAnnotationIntAggregator = {
+  override def copy(): RegionValueTakeByAnnotationIntAggregator = {
     val rva = new RegionValueTakeByAnnotationIntAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -500,9 +500,9 @@ class RegionValueTakeByAnnotationLongAggregator(n: Int, aggType: Type, keyType: 
     seqOp(if (xm) null else SafeRow.read(aggType, region, x), if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByAnnotationLongAggregator = new RegionValueTakeByAnnotationLongAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByAnnotationLongAggregator = new RegionValueTakeByAnnotationLongAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByAnnotationLongAggregator = {
+  override def copy(): RegionValueTakeByAnnotationLongAggregator = {
     val rva = new RegionValueTakeByAnnotationLongAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -514,9 +514,9 @@ class RegionValueTakeByAnnotationFloatAggregator(n: Int, aggType: Type, keyType:
     seqOp(if (xm) null else SafeRow.read(aggType, region, x), if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByAnnotationFloatAggregator = new RegionValueTakeByAnnotationFloatAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByAnnotationFloatAggregator = new RegionValueTakeByAnnotationFloatAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByAnnotationFloatAggregator = {
+  override def copy(): RegionValueTakeByAnnotationFloatAggregator = {
     val rva = new RegionValueTakeByAnnotationFloatAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -528,9 +528,9 @@ class RegionValueTakeByAnnotationDoubleAggregator(n: Int, aggType: Type, keyType
     seqOp(if (xm) null else SafeRow.read(aggType, region, x), if (km) null else k)
   }
 
-  override def copy(): RegionValueTakeByAnnotationDoubleAggregator = new RegionValueTakeByAnnotationDoubleAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByAnnotationDoubleAggregator = new RegionValueTakeByAnnotationDoubleAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByAnnotationDoubleAggregator = {
+  override def copy(): RegionValueTakeByAnnotationDoubleAggregator = {
     val rva = new RegionValueTakeByAnnotationDoubleAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva
@@ -542,9 +542,9 @@ class RegionValueTakeByAnnotationAnnotationAggregator(n: Int, aggType: Type, key
     seqOp(if (xm) null else SafeRow.read(aggType, region, x), if (km) null else SafeRow.read(keyType, region, k))
   }
 
-  override def copy(): RegionValueTakeByAnnotationAnnotationAggregator = new RegionValueTakeByAnnotationAnnotationAggregator(n, aggType, keyType)
+  override def newInstance(): RegionValueTakeByAnnotationAnnotationAggregator = new RegionValueTakeByAnnotationAnnotationAggregator(n, aggType, keyType)
 
-  override def deepCopy(): RegionValueTakeByAnnotationAnnotationAggregator = {
+  override def copy(): RegionValueTakeByAnnotationAnnotationAggregator = {
     val rva = new RegionValueTakeByAnnotationAnnotationAggregator(n, aggType, keyType)
     rva._state = _state.clone()
     rva

--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueTakeByAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueTakeByAggregator.scala
@@ -36,6 +36,12 @@ class RegionValueTakeByAggregator(n: Int, aggType: Type, keyType: Type) extends 
 
   override def copy(): RegionValueTakeByAggregator = new RegionValueTakeByAggregator(n, aggType, keyType)
 
+  override def deepCopy(): RegionValueTakeByAggregator = {
+    val rva = new RegionValueTakeByAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
+
   override def clear() {
     _state.clear()
   }
@@ -47,6 +53,12 @@ class RegionValueTakeByBooleanBooleanAggregator(n: Int, aggType: Type, keyType: 
   }
 
   override def copy(): RegionValueTakeByBooleanBooleanAggregator = new RegionValueTakeByBooleanBooleanAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByBooleanBooleanAggregator = {
+    val rva = new RegionValueTakeByBooleanBooleanAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByBooleanIntAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -55,6 +67,12 @@ class RegionValueTakeByBooleanIntAggregator(n: Int, aggType: Type, keyType: Type
   }
 
   override def copy(): RegionValueTakeByBooleanIntAggregator = new RegionValueTakeByBooleanIntAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByBooleanIntAggregator = {
+    val rva = new RegionValueTakeByBooleanIntAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByBooleanLongAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -63,6 +81,12 @@ class RegionValueTakeByBooleanLongAggregator(n: Int, aggType: Type, keyType: Typ
   }
 
   override def copy(): RegionValueTakeByBooleanLongAggregator = new RegionValueTakeByBooleanLongAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByBooleanLongAggregator = {
+    val rva = new RegionValueTakeByBooleanLongAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByBooleanFloatAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -71,6 +95,12 @@ class RegionValueTakeByBooleanFloatAggregator(n: Int, aggType: Type, keyType: Ty
   }
 
   override def copy(): RegionValueTakeByBooleanFloatAggregator = new RegionValueTakeByBooleanFloatAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByBooleanFloatAggregator = {
+    val rva = new RegionValueTakeByBooleanFloatAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByBooleanDoubleAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -79,6 +109,12 @@ class RegionValueTakeByBooleanDoubleAggregator(n: Int, aggType: Type, keyType: T
   }
 
   override def copy(): RegionValueTakeByBooleanDoubleAggregator = new RegionValueTakeByBooleanDoubleAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByBooleanDoubleAggregator = {
+    val rva = new RegionValueTakeByBooleanDoubleAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByBooleanAnnotationAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -87,6 +123,12 @@ class RegionValueTakeByBooleanAnnotationAggregator(n: Int, aggType: Type, keyTyp
   }
 
   override def copy(): RegionValueTakeByBooleanAnnotationAggregator = new RegionValueTakeByBooleanAnnotationAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByBooleanAnnotationAggregator = {
+    val rva = new RegionValueTakeByBooleanAnnotationAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByIntBooleanAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -95,6 +137,12 @@ class RegionValueTakeByIntBooleanAggregator(n: Int, aggType: Type, keyType: Type
   }
 
   override def copy(): RegionValueTakeByIntBooleanAggregator = new RegionValueTakeByIntBooleanAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByIntBooleanAggregator = {
+    val rva = new RegionValueTakeByIntBooleanAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByIntIntAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -103,6 +151,12 @@ class RegionValueTakeByIntIntAggregator(n: Int, aggType: Type, keyType: Type) ex
   }
 
   override def copy(): RegionValueTakeByIntIntAggregator = new RegionValueTakeByIntIntAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByIntIntAggregator = {
+    val rva = new RegionValueTakeByIntIntAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByIntLongAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -111,6 +165,12 @@ class RegionValueTakeByIntLongAggregator(n: Int, aggType: Type, keyType: Type) e
   }
 
   override def copy(): RegionValueTakeByIntLongAggregator = new RegionValueTakeByIntLongAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByIntLongAggregator = {
+    val rva = new RegionValueTakeByIntLongAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByIntFloatAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -119,6 +179,12 @@ class RegionValueTakeByIntFloatAggregator(n: Int, aggType: Type, keyType: Type) 
   }
 
   override def copy(): RegionValueTakeByIntFloatAggregator = new RegionValueTakeByIntFloatAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByIntFloatAggregator = {
+    val rva = new RegionValueTakeByIntFloatAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByIntDoubleAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -127,6 +193,12 @@ class RegionValueTakeByIntDoubleAggregator(n: Int, aggType: Type, keyType: Type)
   }
 
   override def copy(): RegionValueTakeByIntDoubleAggregator = new RegionValueTakeByIntDoubleAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByIntDoubleAggregator = {
+    val rva = new RegionValueTakeByIntDoubleAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByIntAnnotationAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -135,6 +207,12 @@ class RegionValueTakeByIntAnnotationAggregator(n: Int, aggType: Type, keyType: T
   }
 
   override def copy(): RegionValueTakeByIntAnnotationAggregator = new RegionValueTakeByIntAnnotationAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByIntAnnotationAggregator = {
+    val rva = new RegionValueTakeByIntAnnotationAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByLongBooleanAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -143,6 +221,12 @@ class RegionValueTakeByLongBooleanAggregator(n: Int, aggType: Type, keyType: Typ
   }
 
   override def copy(): RegionValueTakeByLongBooleanAggregator = new RegionValueTakeByLongBooleanAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByLongBooleanAggregator = {
+    val rva = new RegionValueTakeByLongBooleanAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByLongIntAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -151,6 +235,12 @@ class RegionValueTakeByLongIntAggregator(n: Int, aggType: Type, keyType: Type) e
   }
 
   override def copy(): RegionValueTakeByLongIntAggregator = new RegionValueTakeByLongIntAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByLongIntAggregator = {
+    val rva = new RegionValueTakeByLongIntAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByLongLongAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -159,6 +249,12 @@ class RegionValueTakeByLongLongAggregator(n: Int, aggType: Type, keyType: Type) 
   }
 
   override def copy(): RegionValueTakeByLongLongAggregator = new RegionValueTakeByLongLongAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByLongLongAggregator = {
+    val rva = new RegionValueTakeByLongLongAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByLongFloatAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -167,6 +263,12 @@ class RegionValueTakeByLongFloatAggregator(n: Int, aggType: Type, keyType: Type)
   }
 
   override def copy(): RegionValueTakeByLongFloatAggregator = new RegionValueTakeByLongFloatAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByLongFloatAggregator = {
+    val rva = new RegionValueTakeByLongFloatAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByLongDoubleAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -175,6 +277,12 @@ class RegionValueTakeByLongDoubleAggregator(n: Int, aggType: Type, keyType: Type
   }
 
   override def copy(): RegionValueTakeByLongDoubleAggregator = new RegionValueTakeByLongDoubleAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByLongDoubleAggregator = {
+    val rva = new RegionValueTakeByLongDoubleAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByLongAnnotationAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -183,6 +291,12 @@ class RegionValueTakeByLongAnnotationAggregator(n: Int, aggType: Type, keyType: 
   }
 
   override def copy(): RegionValueTakeByLongAnnotationAggregator = new RegionValueTakeByLongAnnotationAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByLongAnnotationAggregator = {
+    val rva = new RegionValueTakeByLongAnnotationAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByFloatBooleanAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -191,6 +305,12 @@ class RegionValueTakeByFloatBooleanAggregator(n: Int, aggType: Type, keyType: Ty
   }
 
   override def copy(): RegionValueTakeByFloatBooleanAggregator = new RegionValueTakeByFloatBooleanAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByFloatBooleanAggregator = {
+    val rva = new RegionValueTakeByFloatBooleanAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByFloatIntAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -199,6 +319,12 @@ class RegionValueTakeByFloatIntAggregator(n: Int, aggType: Type, keyType: Type) 
   }
 
   override def copy(): RegionValueTakeByFloatIntAggregator = new RegionValueTakeByFloatIntAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByFloatIntAggregator = {
+    val rva = new RegionValueTakeByFloatIntAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByFloatLongAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -207,6 +333,12 @@ class RegionValueTakeByFloatLongAggregator(n: Int, aggType: Type, keyType: Type)
   }
 
   override def copy(): RegionValueTakeByFloatLongAggregator = new RegionValueTakeByFloatLongAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByFloatLongAggregator = {
+    val rva = new RegionValueTakeByFloatLongAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByFloatFloatAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -215,6 +347,12 @@ class RegionValueTakeByFloatFloatAggregator(n: Int, aggType: Type, keyType: Type
   }
 
   override def copy(): RegionValueTakeByFloatFloatAggregator = new RegionValueTakeByFloatFloatAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByFloatFloatAggregator = {
+    val rva = new RegionValueTakeByFloatFloatAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByFloatDoubleAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -223,6 +361,12 @@ class RegionValueTakeByFloatDoubleAggregator(n: Int, aggType: Type, keyType: Typ
   }
 
   override def copy(): RegionValueTakeByFloatDoubleAggregator = new RegionValueTakeByFloatDoubleAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByFloatDoubleAggregator = {
+    val rva = new RegionValueTakeByFloatDoubleAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByFloatAnnotationAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -231,6 +375,12 @@ class RegionValueTakeByFloatAnnotationAggregator(n: Int, aggType: Type, keyType:
   }
 
   override def copy(): RegionValueTakeByFloatAnnotationAggregator = new RegionValueTakeByFloatAnnotationAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByFloatAnnotationAggregator = {
+    val rva = new RegionValueTakeByFloatAnnotationAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByDoubleBooleanAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -239,6 +389,12 @@ class RegionValueTakeByDoubleBooleanAggregator(n: Int, aggType: Type, keyType: T
   }
 
   override def copy(): RegionValueTakeByDoubleBooleanAggregator = new RegionValueTakeByDoubleBooleanAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByDoubleBooleanAggregator = {
+    val rva = new RegionValueTakeByDoubleBooleanAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByDoubleIntAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -247,6 +403,12 @@ class RegionValueTakeByDoubleIntAggregator(n: Int, aggType: Type, keyType: Type)
   }
 
   override def copy(): RegionValueTakeByDoubleIntAggregator = new RegionValueTakeByDoubleIntAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByDoubleIntAggregator = {
+    val rva = new RegionValueTakeByDoubleIntAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByDoubleLongAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -255,6 +417,12 @@ class RegionValueTakeByDoubleLongAggregator(n: Int, aggType: Type, keyType: Type
   }
 
   override def copy(): RegionValueTakeByDoubleLongAggregator = new RegionValueTakeByDoubleLongAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByDoubleLongAggregator = {
+    val rva = new RegionValueTakeByDoubleLongAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByDoubleFloatAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -263,6 +431,12 @@ class RegionValueTakeByDoubleFloatAggregator(n: Int, aggType: Type, keyType: Typ
   }
 
   override def copy(): RegionValueTakeByDoubleFloatAggregator = new RegionValueTakeByDoubleFloatAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByDoubleFloatAggregator = {
+    val rva = new RegionValueTakeByDoubleFloatAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByDoubleDoubleAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -271,6 +445,12 @@ class RegionValueTakeByDoubleDoubleAggregator(n: Int, aggType: Type, keyType: Ty
   }
 
   override def copy(): RegionValueTakeByDoubleDoubleAggregator = new RegionValueTakeByDoubleDoubleAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByDoubleDoubleAggregator = {
+    val rva = new RegionValueTakeByDoubleDoubleAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByDoubleAnnotationAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -279,6 +459,12 @@ class RegionValueTakeByDoubleAnnotationAggregator(n: Int, aggType: Type, keyType
   }
 
   override def copy(): RegionValueTakeByDoubleAnnotationAggregator = new RegionValueTakeByDoubleAnnotationAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByDoubleAnnotationAggregator = {
+    val rva = new RegionValueTakeByDoubleAnnotationAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByAnnotationBooleanAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -287,6 +473,12 @@ class RegionValueTakeByAnnotationBooleanAggregator(n: Int, aggType: Type, keyTyp
   }
 
   override def copy(): RegionValueTakeByAnnotationBooleanAggregator = new RegionValueTakeByAnnotationBooleanAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByAnnotationBooleanAggregator = {
+    val rva = new RegionValueTakeByAnnotationBooleanAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByAnnotationIntAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -295,6 +487,12 @@ class RegionValueTakeByAnnotationIntAggregator(n: Int, aggType: Type, keyType: T
   }
 
   override def copy(): RegionValueTakeByAnnotationIntAggregator = new RegionValueTakeByAnnotationIntAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByAnnotationIntAggregator = {
+    val rva = new RegionValueTakeByAnnotationIntAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByAnnotationLongAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -303,6 +501,12 @@ class RegionValueTakeByAnnotationLongAggregator(n: Int, aggType: Type, keyType: 
   }
 
   override def copy(): RegionValueTakeByAnnotationLongAggregator = new RegionValueTakeByAnnotationLongAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByAnnotationLongAggregator = {
+    val rva = new RegionValueTakeByAnnotationLongAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByAnnotationFloatAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -311,6 +515,12 @@ class RegionValueTakeByAnnotationFloatAggregator(n: Int, aggType: Type, keyType:
   }
 
   override def copy(): RegionValueTakeByAnnotationFloatAggregator = new RegionValueTakeByAnnotationFloatAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByAnnotationFloatAggregator = {
+    val rva = new RegionValueTakeByAnnotationFloatAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByAnnotationDoubleAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -319,6 +529,12 @@ class RegionValueTakeByAnnotationDoubleAggregator(n: Int, aggType: Type, keyType
   }
 
   override def copy(): RegionValueTakeByAnnotationDoubleAggregator = new RegionValueTakeByAnnotationDoubleAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByAnnotationDoubleAggregator = {
+    val rva = new RegionValueTakeByAnnotationDoubleAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }
 
 class RegionValueTakeByAnnotationAnnotationAggregator(n: Int, aggType: Type, keyType: Type) extends RegionValueTakeByAggregator(n, aggType, keyType) {
@@ -327,4 +543,10 @@ class RegionValueTakeByAnnotationAnnotationAggregator(n: Int, aggType: Type, key
   }
 
   override def copy(): RegionValueTakeByAnnotationAnnotationAggregator = new RegionValueTakeByAnnotationAnnotationAggregator(n, aggType, keyType)
+
+  override def deepCopy(): RegionValueTakeByAnnotationAnnotationAggregator = {
+    val rva = new RegionValueTakeByAnnotationAnnotationAggregator(n, aggType, keyType)
+    rva._state = _state.clone()
+    rva
+  }
 }

--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -822,7 +822,7 @@ case class MatrixAggregateRowsByKey(child: MatrixIR, expr: IR) extends MatrixIR 
           while (i < nCols) {
             var j = 0
             while (j < nAggs) {
-              colRVAggs(i * nAggs + j) = rvAggs(j).copy()
+              colRVAggs(i * nAggs + j) = rvAggs(j).newInstance()
               j += 1
             }
             i += 1
@@ -1025,7 +1025,7 @@ case class MatrixAggregateColsByKey(child: MatrixIR, aggIR: IR) extends MatrixIR
     while (i < nKeys) {
       var j = 0
       while (j < nAggs) {
-        colRVAggs(i * nAggs + j) = rvAggs(j).copy()
+        colRVAggs(i * nAggs + j) = rvAggs(j).newInstance()
         j += 1
       }
       i += 1
@@ -1444,7 +1444,7 @@ case class MatrixMapCols(child: MatrixIR, newCol: IR, newKey: Option[IndexedSeq[
     while (i < localNCols) {
       var j = 0
       while (j < nAggs) {
-        colRVAggs(i * nAggs + j) = rvAggs(j).copy()
+        colRVAggs(i * nAggs + j) = rvAggs(j).newInstance()
         j += 1
       }
       i += 1

--- a/src/main/scala/is/hail/stats/CallStatsCombiner.scala
+++ b/src/main/scala/is/hail/stats/CallStatsCombiner.scala
@@ -23,8 +23,8 @@ case class CallStats(alleleCount: IndexedSeq[Int], alleleFrequency: Option[Index
 }
 
 class CallStatsCombiner(val nAlleles: Int) extends Serializable {
-  val alleleCount = new Array[Int](nAlleles)
-  val homozygoteCount = new Array[Int](nAlleles)
+  var alleleCount = new Array[Int](nAlleles)
+  var homozygoteCount = new Array[Int](nAlleles)
 
   def merge(c: Call): CallStatsCombiner = {
     (Call.ploidy(c): @switch) match {
@@ -85,5 +85,12 @@ class CallStatsCombiner(val nAlleles: Int) extends Serializable {
     cstats.homCount.foreach(rvb.addInt _)
     rvb.endArray()
     rvb.endStruct()
+  }
+
+  def copy(): CallStatsCombiner = {
+    val c = new CallStatsCombiner(nAlleles)
+    c.alleleCount = alleleCount.clone()
+    c.homozygoteCount = homozygoteCount.clone()
+    c
   }
 }

--- a/src/main/scala/is/hail/stats/HistogramCombiner.scala
+++ b/src/main/scala/is/hail/stats/HistogramCombiner.scala
@@ -21,7 +21,7 @@ class HistogramCombiner(val indices: Array[Double]) extends Serializable {
 
   var nSmaller = 0L
   var nLarger = 0L
-  val frequency = Array.fill(indices.length - 1)(0L)
+  var frequency = Array.fill(indices.length - 1)(0L)
 
   def merge(d: Double): HistogramCombiner = {
     if (d < min)
@@ -62,5 +62,13 @@ class HistogramCombiner(val indices: Array[Double]) extends Serializable {
     nSmaller = 0L
     nLarger = 0L
     util.Arrays.fill(frequency, 0L)
+  }
+
+  def copy(): HistogramCombiner = {
+    val c = new HistogramCombiner(indices)
+    c.nSmaller = nSmaller
+    c.nLarger = nLarger
+    c.frequency = frequency.clone()
+    c
   }
 }

--- a/src/main/scala/is/hail/stats/InfoScoreCombiner.scala
+++ b/src/main/scala/is/hail/stats/InfoScoreCombiner.scala
@@ -111,4 +111,13 @@ class InfoScoreCombiner extends Serializable {
     totalDosage = 0d
     nIncluded = 0
   }
+
+  def copy(): InfoScoreCombiner = {
+    val c = new InfoScoreCombiner()
+    c.result = result
+    c.expectedAlleleCount = expectedAlleleCount
+    c.totalDosage = totalDosage
+    c.nIncluded = nIncluded
+    c
+  }
 }

--- a/src/main/scala/is/hail/utils/ArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/ArrayBuilder.scala
@@ -7,8 +7,8 @@ object ArrayBuilder {
 }
 
 final class ArrayBuilder[@specialized T](initialCapacity: Int)(implicit tct: ClassTag[T]) extends Serializable {
-  private var b: Array[T] = new Array[T](initialCapacity)
-  private var size_ : Int = 0
+  private[utils] var b: Array[T] = new Array[T](initialCapacity)
+  private[utils] var size_ : Int = 0
 
   def this()(implicit tct: ClassTag[T]) = this(ArrayBuilder.defaultInitialCapacity)
 
@@ -69,5 +69,12 @@ final class ArrayBuilder[@specialized T](initialCapacity: Int)(implicit tct: Cla
   def last: T = {
     assert(size_ > 0)
     b(size_ - 1)
+  }
+
+  override def clone(): ArrayBuilder[T] = {
+    val ab = new ArrayBuilder[T]()
+    ab.b = b.clone()
+    ab.size_ = size_
+    ab
   }
 }

--- a/src/main/scala/is/hail/utils/MissingAnnotationArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingAnnotationArrayBuilder.scala
@@ -5,10 +5,10 @@ import is.hail.expr.types.Type
 
 import scala.collection.mutable
 
-class MissingAnnotationArrayBuilder extends Serializable{
+class MissingAnnotationArrayBuilder extends Serializable {
   private var len = 0
-  private val elements = new ArrayBuilder[Annotation]()
-  private val isMissing = new mutable.BitSet()
+  private var elements = new ArrayBuilder[Annotation]()
+  private var isMissing = new mutable.BitSet()
 
   def addMissing() {
     isMissing.add(len)
@@ -56,5 +56,13 @@ class MissingAnnotationArrayBuilder extends Serializable{
     len = 0
     elements.clear()
     isMissing.clear()
+  }
+
+  override def clone(): MissingAnnotationArrayBuilder = {
+    val ab = new MissingAnnotationArrayBuilder()
+    ab.len = len
+    ab.elements = elements.clone()
+    ab.isMissing = isMissing.clone()
+    ab
   }
 }

--- a/src/main/scala/is/hail/utils/MissingBooleanArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingBooleanArrayBuilder.scala
@@ -4,10 +4,10 @@ import is.hail.expr.types._
 import is.hail.annotations._
 import scala.collection.mutable
 
-class MissingBooleanArrayBuilder {
+class MissingBooleanArrayBuilder extends Serializable {
   private var len = 0
-  private val elements = new mutable.BitSet()
-  private val isMissing = new mutable.BitSet()
+  private var elements = new mutable.BitSet()
+  private var isMissing = new mutable.BitSet()
 
   def addMissing() {
     isMissing.add(len)
@@ -52,5 +52,13 @@ class MissingBooleanArrayBuilder {
     len = 0
     elements.clear()
     isMissing.clear()
+  }
+
+  override def clone(): MissingBooleanArrayBuilder = {
+    val ab = new MissingBooleanArrayBuilder()
+    ab.len = len
+    ab.elements = elements.clone()
+    ab.isMissing = isMissing.clone()
+    ab
   }
 }

--- a/src/main/scala/is/hail/utils/MissingDoubleArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingDoubleArrayBuilder.scala
@@ -6,8 +6,8 @@ import scala.collection.mutable
 
 class MissingDoubleArrayBuilder extends Serializable {
   private var len = 0
-  private val elements = new ArrayBuilder[Double]()
-  private val isMissing = new mutable.BitSet()
+  private var elements = new ArrayBuilder[Double]()
+  private var isMissing = new mutable.BitSet()
 
   def addMissing() {
     isMissing.add(len)
@@ -57,5 +57,13 @@ class MissingDoubleArrayBuilder extends Serializable {
     len = 0
     elements.clear()
     isMissing.clear()
+  }
+
+  override def clone(): MissingDoubleArrayBuilder = {
+    val ab = new MissingDoubleArrayBuilder()
+    ab.len = len
+    ab.elements = elements.clone()
+    ab.isMissing = isMissing.clone()
+    ab
   }
 }

--- a/src/main/scala/is/hail/utils/MissingFloatArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingFloatArrayBuilder.scala
@@ -6,8 +6,8 @@ import scala.collection.mutable
 
 class MissingFloatArrayBuilder extends Serializable {
   private var len = 0
-  private val elements = new ArrayBuilder[Float]()
-  private val isMissing = new mutable.BitSet()
+  private var elements = new ArrayBuilder[Float]()
+  private var isMissing = new mutable.BitSet()
 
   def addMissing() {
     isMissing.add(len)
@@ -59,5 +59,13 @@ class MissingFloatArrayBuilder extends Serializable {
     len = 0
     elements.clear()
     isMissing.clear()
+  }
+
+  override def clone(): MissingFloatArrayBuilder = {
+    val ab = new MissingFloatArrayBuilder()
+    ab.len = len
+    ab.elements = elements.clone()
+    ab.isMissing = isMissing.clone()
+    ab
   }
 }

--- a/src/main/scala/is/hail/utils/MissingIntArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingIntArrayBuilder.scala
@@ -6,8 +6,8 @@ import scala.collection.mutable
 
 class MissingIntArrayBuilder extends Serializable {
   private var len = 0
-  private val elements = new ArrayBuilder[Int]()
-  private val isMissing = new mutable.BitSet()
+  private var elements = new ArrayBuilder[Int]()
+  private var isMissing = new mutable.BitSet()
 
   def addMissing() {
     isMissing.add(len)
@@ -57,5 +57,13 @@ class MissingIntArrayBuilder extends Serializable {
     len = 0
     elements.clear()
     isMissing.clear()
+  }
+
+  override def clone(): MissingIntArrayBuilder = {
+    val ab = new MissingIntArrayBuilder()
+    ab.len = len
+    ab.elements = elements.clone()
+    ab.isMissing = isMissing.clone()
+    ab
   }
 }

--- a/src/main/scala/is/hail/utils/MissingLongArrayBuilder.scala
+++ b/src/main/scala/is/hail/utils/MissingLongArrayBuilder.scala
@@ -6,8 +6,8 @@ import scala.collection.mutable
 
 class MissingLongArrayBuilder extends Serializable {
   private var len = 0
-  private val elements = new ArrayBuilder[Long]()
-  private val isMissing = new mutable.BitSet()
+  private var elements = new ArrayBuilder[Long]()
+  private var isMissing = new mutable.BitSet()
 
   def addMissing() {
     isMissing.add(len)
@@ -57,5 +57,13 @@ class MissingLongArrayBuilder extends Serializable {
     len = 0
     elements.clear()
     isMissing.clear()
+  }
+
+  override def clone(): MissingLongArrayBuilder = {
+    val ab = new MissingLongArrayBuilder()
+    ab.len = len
+    ab.elements = elements.clone()
+    ab.isMissing = isMissing.clone()
+    ab
   }
 }

--- a/src/test/scala/is/hail/TestUtils.scala
+++ b/src/test/scala/is/hail/TestUtils.scala
@@ -301,7 +301,7 @@ object TestUtils {
             i += 1
           }
 
-          val rvAggs2 = rvAggs.map(_.copy())
+          val rvAggs2 = rvAggs.map(_.newInstance())
           rvAggs2.foreach(_.clear())
           initOps()(region, rvAggs2, argsOff, false)
           while (i < aggElements.length) {


### PR DESCRIPTION
I will need deep copy for KeyedRegionValueAggregators. I only need deepCopy for aggregators with defined `initOp` methods (CallStats), but figured it would be better to add deepCopy to all aggregators so we have both types of copy. Feel free to push back on adding deep copy to all aggregators. I could change `Code.lookupMethod` to return an `Option[Invokeable[T, S]]` instead to test if `deepCopy` exists on the aggregator.