### PR TITLE
Nicer error for case/switch statements

### DIFF
--- a/python/hail/expr/expressions/base_expression.py
+++ b/python/hail/expr/expressions/base_expression.py
@@ -89,6 +89,9 @@ def impute_type(x):
         return tdict(unified_key_type, unified_value_type)
     elif x is None:
         raise ExpressionException("Hail cannot impute the type of 'None'")
+    elif isinstance(x, (hl.expr.builders.CaseBuilder, hl.expr.builders.SwitchBuilder)):
+        raise ExpressionException("'switch' and 'case' expressions must end with a call to either"
+                                  "'default' or 'or_missing'")
     else:
         raise ExpressionException("Hail cannot automatically impute type of {}: {}".format(type(x), x))
 


### PR DESCRIPTION
Prints a nice message if the user forgets default/or_missing

Fixes #3696