### PR TITLE
IR for chisq, fet, ctt, hwe with simpler chisq implementation

### DIFF
--- a/python/hail/tests/test_api.py
+++ b/python/hail/tests/test_api.py
@@ -4,6 +4,8 @@ Unit tests for Hail.
 import pandas as pd
 import unittest
 import random
+import math
+
 import hail as hl
 import hail.expr.aggregators as agg
 from hail.utils.java import Env, scala_object
@@ -1471,10 +1473,13 @@ class MatrixTableTests(unittest.TestCase):
                     (2, ['A', 'G'], 0.25, 0.5),
                     (3, ['T', 'C'], 0.5357142857142857, 0.21428571428571427),
                     (4, ['T', 'A'], 0.5714285714285714,0.6571428571428573),
-                    (5, ['G', 'A'], 0.3333333333333333, 0.5),
-                    (6, ['T', 'C'], hl.null(hl.tfloat64), 0.5)]],
+                    (5, ['G', 'A'], 0.3333333333333333, 0.5)]],
                                         key=['locus', 'alleles'])
-        self.assertTrue(rt._same(expected))
+        self.assertTrue(rt.filter(rt.locus.position != 6)._same(expected))
+
+        rt6 = rt.filter(rt.locus.position == 6).collect()[0]
+        self.assertEqual(rt6['p_hwe'], 0.5)
+        self.assertTrue(math.isnan(rt6['r_expected_het_freq']))
 
     def test_hw_p_and_agg_agree(self):
         mt = hl.import_vcf(resource('sample.vcf'))

--- a/python/hail/tests/test_expr.py
+++ b/python/hail/tests/test_expr.py
@@ -1,8 +1,9 @@
 import unittest
+import math
 
 import hail as hl
 import hail.expr.aggregators as agg
-from hail.expr import dtype, coercer_from_dtype
+from hail.expr import coercer_from_dtype
 from hail.expr.types import *
 from .utils import startTestHailContext, stopTestHailContext, resource
 
@@ -1567,3 +1568,39 @@ class Tests(unittest.TestCase):
 
     def test_uniroot(self):
         self.assertAlmostEqual(hl.uniroot(lambda x: x - 1, 0, 3).value, 1)
+
+    def test_chisq(self):
+        res = hl.chisq(0, 0, 0, 0).value
+        self.assertTrue(math.isnan(res['p_value']))
+        self.assertTrue(math.isnan(res['odds_ratio']))
+
+        res = hl.chisq(51, 43, 22, 92).value
+        self.assertAlmostEqual(res['p_value'] / 1.462626e-7, 1.0, places=4)
+        self.assertAlmostEqual(res['odds_ratio'], 4.95983087)
+
+    def test_fisher_exact_test(self):
+        res = hl.fisher_exact_test(0, 0, 0, 0).value
+        self.assertTrue(math.isnan(res['p_value']))
+        self.assertTrue(math.isnan(res['odds_ratio']))
+        self.assertTrue(math.isnan(res['ci_95_lower']))
+        self.assertTrue(math.isnan(res['ci_95_upper']))
+
+        res = hl.fisher_exact_test(51, 43, 22, 92).value
+        self.assertAlmostEqual(res['p_value'] / 2.1565e-7, 1.0, places=4)
+        self.assertAlmostEqual(res['odds_ratio'], 4.91805817)
+        self.assertAlmostEqual(res['ci_95_lower'], 2.56593733)
+        self.assertAlmostEqual(res['ci_95_upper'], 9.67792963)
+
+    def test_ctt(self):
+        res = hl.ctt(51, 43, 22, 92, 22).value
+        self.assertAlmostEqual(res['p_value'] / 1.462626e-7, 1.0, places=4)
+        self.assertAlmostEqual(res['odds_ratio'], 4.95983087)
+
+        res = hl.ctt(51, 43, 22, 92, 23).value
+        self.assertAlmostEqual(res['p_value'] / 2.1565e-7, 1.0, places=4)
+        self.assertAlmostEqual(res['odds_ratio'], 4.91805817)
+
+    def test_hardy_weinberg_p(self):
+        res = hl.hardy_weinberg_p(1, 2, 1).value
+        self.assertAlmostEqual(res['p_hwe'], 0.65714285)
+        self.assertAlmostEqual(res['r_expected_het_freq'], 0.57142857)

--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -189,6 +189,14 @@ object Code {
     implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2], a3ct: ClassTag[A3], a4ct: ClassTag[A4], sct: ClassTag[S]): Code[S] =
     invokeScalaObject[S](cls, method, Array[Class[_]](a1ct.runtimeClass, a2ct.runtimeClass, a3ct.runtimeClass, a4ct.runtimeClass), Array(a1, a2, a3, a4))
 
+  def invokeScalaObject[A1, A2, A3, A4, A5, S](
+    cls: Class[_], method: String, a1: Code[A1], a2: Code[A2], a3: Code[A3], a4: Code[A4], a5: Code[A5])(
+    implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2], a3ct: ClassTag[A3], a4ct: ClassTag[A4], a5ct: ClassTag[A5], sct: ClassTag[S]
+  ): Code[S] =
+    invokeScalaObject[S](
+      cls, method, Array[Class[_]](
+        a1ct.runtimeClass, a2ct.runtimeClass, a3ct.runtimeClass, a4ct.runtimeClass, a5ct.runtimeClass), Array(a1, a2, a3, a4, a5))
+
   def invokeScalaObject[A1, A2, A3, A4, A5, A6, S](
     cls: Class[_], method: String, a1: Code[A1], a2: Code[A2], a3: Code[A3], a4: Code[A4], a5: Code[A5], a6: Code[A6])(
     implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2], a3ct: ClassTag[A3], a4ct: ClassTag[A4], a5ct: ClassTag[A5], a6ct: ClassTag[A6], sct: ClassTag[S]

--- a/src/main/scala/is/hail/expr/FunctionRegistry.scala
+++ b/src/main/scala/is/hail/expr/FunctionRegistry.scala
@@ -16,7 +16,6 @@ import scala.collection.generic.Growable
 import scala.collection.mutable
 import scala.language.higherKinds
 import scala.reflect.ClassTag
-import org.apache.commons.math3.stat.inference.ChiSquareTest
 import org.apache.commons.math3.special.Gamma
 import org.apache.spark.sql.Row
 import org.json4s.jackson.JsonMethods
@@ -45,8 +44,6 @@ object FunctionRegistry {
   type Err[T] = Either[LookupError, T]
 
   private val registry = mutable.HashMap[String, Seq[(TypeTag, Fun)]]().withDefaultValue(Seq.empty)
-
-  private val chisq = new ChiSquareTest()
 
   private def lookup(name: String, typ: TypeTag, rtTypConcrete: Option[Type] = None): Err[Fun] = {
 
@@ -874,69 +871,24 @@ object FunctionRegistry {
     (x: Annotation, y: Annotation, includesStart: Boolean, includesEnd: Boolean) => Interval(x, y, includesStart, includesEnd)
   })(TTHr, TTHr, boolHr, boolHr, intervalHr(TTHr))
 
-  val hweStruct = TStruct("r_expected_het_freq" -> TFloat64(), "p_hwe" -> TFloat64())
-
   registerAnn("hwe", hweStruct, { (nHomRef: Int, nHet: Int, nHomVar: Int) =>
-    if (nHomRef < 0 || nHet < 0 || nHomVar < 0)
-      fatal(s"got invalid (negative) argument to function `hwe': hwe($nHomRef, $nHet, $nHomVar)")
-    val n = nHomRef + nHet + nHomVar
-    val nAB = nHet
-    val nA = nAB + 2 * nHomRef.min(nHomVar)
-
-    val LH = LeveneHaldane(n, nA)
-    Annotation(divOption(LH.getNumericalMean, n).orNull, LH.exactMidP(nAB))
+    val res = hweTest(nHomRef, nHet, nHomVar)
+    Annotation(res(0), res(1))
   })
 
-  def chisqTest(c1: Int, c2: Int, c3: Int, c4: Int): (Option[Double], Option[Double]) = {
-
-    var or: Option[Double] = None
-    var chisqp: Option[Double] = None
-
-    if (Array(c1, c2, c3, c4).sum > 0) {
-      if (c1 > 0 && c3 == 0)
-        or = Option(Double.PositiveInfinity)
-      else if (c3 > 0 && c1 == 0)
-        or = Option(Double.NegativeInfinity)
-      else if ((c1 > 0 && c2 > 0 && c3 > 0 && c4 > 0))
-        or = Option((c1 * c4) / (c2 * c3).toDouble)
-      chisqp = Option(chisq.chiSquareTest(Array(Array(c1, c2), Array(c3, c4))))
-    }
-
-    (chisqp, or)
-  }
-
-
-  val chisqStruct = TStruct("p_value" -> TFloat64(), "odds_ratio" -> TFloat64())
-  registerAnn("chisq", chisqStruct, { (c1: Int, c2: Int, c3: Int, c4: Int) =>
-    if (c1 < 0 || c2 < 0 || c3 < 0 || c4 < 0)
-      fatal(s"got invalid argument to function `chisq': chisq($c1, $c2, $c3, $c4)")
-
-    val res = chisqTest(c1, c2, c3, c4)
-    Annotation(res._1.orNull, res._2.orNull)
+  registerAnn("chisq", chisqStruct, { (a: Int, b: Int, c: Int, d: Int) =>
+    val res = chisqTest(a, b, c, d)
+    Annotation(res(0), res(1))
   })
 
-  registerAnn("ctt", chisqStruct, { (c1: Int, c2: Int, c3: Int, c4: Int, minCellCount: Int) =>
-    if (c1 < 0 || c2 < 0 || c3 < 0 || c4 < 0)
-      fatal(s"got invalid argument to function `ctTest': ctTest($c1, $c2, $c3, $c4)")
-
-    if (Array(c1, c2, c3, c4).exists(_ < minCellCount)) {
-      val fet = FisherExactTest(c1, c2, c3, c4)
-      Annotation(fet(0).orNull, fet(1).orNull)
-    } else {
-      val res = chisqTest(c1, c2, c3, c4)
-      Annotation(res._1.orNull, res._2.orNull)
-    }
-
+  registerAnn("ctt", chisqStruct, { (a: Int, b: Int, c: Int, d: Int, minCellCount: Int) =>
+    val ctt = contingencyTableTest(a, b, c, d, minCellCount)
+    Annotation(ctt(0), ctt(1))
   })
 
-  val fetStruct = TStruct("p_value" -> TFloat64(), "odds_ratio" -> TFloat64(),
-    "ci_95_lower" -> TFloat64(), "ci_95_upper" -> TFloat64())
-
-  registerAnn("fet", fetStruct, { (c1: Int, c2: Int, c3: Int, c4: Int) =>
-    if (c1 < 0 || c2 < 0 || c3 < 0 || c4 < 0)
-      fatal(s"got invalid argument to function `fet': fet($c1, $c2, $c3, $c4)")
-    val fet = FisherExactTest(c1, c2, c3, c4)
-    Annotation(fet(0).orNull, fet(1).orNull, fet(2).orNull, fet(3).orNull)
+  registerAnn("fet", fetStruct, { (a: Int, b: Int, c: Int, d: Int) =>
+    val fet = fisherExactTest(a, b, c, d)
+    Annotation(fet(0), fet(1), fet(2), fet(3))
   })
 
   register("binomTest", { (x: Int, n: Int, p: Double, alternative: Int) => binomTest(x, n, p, alternative)

--- a/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -285,8 +285,29 @@ abstract class RegistryFunctions {
       case (mb, Array(a1: Code[A1] @unchecked, a2: Code[A2] @unchecked, a3: Code[A3] @unchecked)) => impl(mb, a1, a2, a3)
     }
 
-  def registerCode[A1, A2, A3](mname: String, mt1: Type, mt2: Type, mt3: Type, rt: Type)(impl: (EmitMethodBuilder, Code[A1], Code[A2], Code[A3]) => Code[_]): Unit =
+  def registerCode[A1, A2, A3](mname: String, mt1: Type, mt2: Type, mt3: Type, rt: Type)
+    (impl: (EmitMethodBuilder, Code[A1], Code[A2], Code[A3]) => Code[_]): Unit =
     registerCode(mname, mt1, mt2, mt3, rt, isDeterministic = true)(impl)
+
+  def registerCode[A1, A2, A3, A4](mname: String, mt1: Type, mt2: Type, mt3: Type, mt4: Type, rt: Type)
+    (impl: (EmitMethodBuilder, Code[A1], Code[A2], Code[A3], Code[A4]) => Code[_]): Unit =
+    registerCode(mname, mt1, mt2, mt3, mt4, rt, isDeterministic = true)(impl)
+
+  def registerCode[A1, A2, A3, A4](mname: String, mt1: Type, mt2: Type, mt3: Type, mt4: Type, rt: Type, isDeterministic: Boolean)
+    (impl: (EmitMethodBuilder, Code[A1], Code[A2], Code[A3], Code[A4]) => Code[_]): Unit =
+    registerCode(mname, Array(mt1, mt2, mt3, mt4), rt, isDeterministic) {
+      case (mb, Array(a1: Code[A1] @unchecked, a2: Code[A2] @unchecked, a3: Code[A3] @unchecked, a4: Code[A4] @unchecked)) => impl(mb, a1, a2, a3, a4)
+    }
+
+  def registerCode[A1, A2, A3, A4, A5](mname: String, mt1: Type, mt2: Type, mt3: Type, mt4: Type, mt5: Type, rt: Type)
+    (impl: (EmitMethodBuilder, Code[A1], Code[A2], Code[A3], Code[A4], Code[A5]) => Code[_]): Unit =
+    registerCode(mname, mt1, mt2, mt3, mt4, mt5, rt, isDeterministic = true)(impl)
+
+  def registerCode[A1, A2, A3, A4, A5](mname: String, mt1: Type, mt2: Type, mt3: Type, mt4: Type, mt5: Type, rt: Type, isDeterministic: Boolean)
+    (impl: (EmitMethodBuilder, Code[A1], Code[A2], Code[A3], Code[A4], Code[A5]) => Code[_]): Unit =
+    registerCode(mname, Array(mt1, mt2, mt3, mt4, mt5), rt, isDeterministic) {
+      case (mb, Array(a1: Code[A1] @unchecked, a2: Code[A2] @unchecked, a3: Code[A3] @unchecked, a4: Code[A4] @unchecked, a5: Code[A5] @unchecked)) => impl(mb, a1, a2, a3, a4, a5)
+    }
 
   def registerCodeWithMissingness(mname: String, rt: Type, isDeterministic: Boolean)(impl: EmitMethodBuilder => EmitTriplet): Unit =
     registerCodeWithMissingness(mname, Array[Type](), rt, isDeterministic) { case (mb, Array()) => impl(mb) }

--- a/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
@@ -5,7 +5,7 @@ import is.hail.asm4s.{AsmFunction3, Code}
 import is.hail.expr.ir._
 import is.hail.expr.types._
 import org.apache.commons.math3.special.Gamma
-import is.hail.stats.{uniroot, entropy}
+import is.hail.stats.{uniroot, entropy, chisqStruct, fetStruct, hweStruct}
 
 import is.hail.utils.fatal
 
@@ -113,8 +113,8 @@ object MathFunctions extends RegistryFunctions {
 
     registerScalaFunction("rpois", TFloat64(), TFloat64())(statsPackageClass, "rpois", isDeterministic = false)
     registerCode("rpois", TInt32(), TFloat64(), TArray(TFloat64()), isDeterministic = false){ (mb, n, lambda) => 
+      val res = mb.newLocal[Array[Double]]
       val srvb = new StagedRegionValueBuilder(mb, TArray(TFloat64()))
-      val res = srvb.mb.newLocal[Array[Double]]
       Code(
         res := Code.invokeScalaObject[Int, Double, Array[Double]](statsPackageClass, "rpois", n, lambda),
         srvb.start(res.length()),
@@ -161,5 +161,65 @@ object MathFunctions extends RegistryFunctions {
     registerJavaStaticFunction("sign", TFloat64(), TFloat64())(jMathClass, "signum")
 
     registerWrappedScalaFunction("entropy", TString(), TFloat64())(thisClass, "irentropy")
+
+    registerCode("fet", TInt32(), TInt32(), TInt32(), TInt32(), fetStruct){ case (mb, a, b, c, d) =>
+      val res = mb.newLocal[Array[Double]]
+      val srvb = new StagedRegionValueBuilder(mb, fetStruct)
+      Code(
+        res := Code.invokeScalaObject[Int, Int, Int, Int, Array[Double]](statsPackageClass, "fisherExactTest", a, b, c, d),
+        srvb.start(),
+        srvb.addDouble(res(0)),
+        srvb.advance(),
+        srvb.addDouble(res(1)),
+        srvb.advance(),
+        srvb.addDouble(res(2)),
+        srvb.advance(),
+        srvb.addDouble(res(3)),
+        srvb.advance(),
+        srvb.offset
+      )
+    }
+    
+    registerCode("chisq", TInt32(), TInt32(), TInt32(), TInt32(), chisqStruct){ case (mb, a, b, c, d) =>
+      val res = mb.newLocal[Array[Double]]
+      val srvb = new StagedRegionValueBuilder(mb, chisqStruct)
+      Code(
+        res := Code.invokeScalaObject[Int, Int, Int, Int, Array[Double]](statsPackageClass, "chisqTest", a, b, c, d),
+        srvb.start(),
+        srvb.addDouble(res(0)),
+        srvb.advance(),
+        srvb.addDouble(res(1)),
+        srvb.advance(),
+        srvb.offset
+      )
+    }
+
+    registerCode("ctt", TInt32(), TInt32(), TInt32(), TInt32(), TInt32(), chisqStruct){ case (mb, a, b, c, d, min_cell_count) =>
+      val res = mb.newLocal[Array[Double]]
+      val srvb = new StagedRegionValueBuilder(mb, chisqStruct)
+      Code(
+        res := Code.invokeScalaObject[Int, Int, Int, Int, Int, Array[Double]](statsPackageClass, "contingencyTableTest", a, b, c, d, min_cell_count),
+        srvb.start(),
+        srvb.addDouble(res(0)),
+        srvb.advance(),
+        srvb.addDouble(res(1)),
+        srvb.advance(),
+        srvb.offset
+      )
+    }
+
+    registerCode("hwe", TInt32(), TInt32(), TInt32(), hweStruct){ case (mb, nHomRef, nHet, nHomVar) =>
+      val res = mb.newLocal[Array[Double]]
+      val srvb = new StagedRegionValueBuilder(mb, hweStruct)
+      Code(
+        res := Code.invokeScalaObject[Int, Int, Int, Array[Double]](statsPackageClass, "hweTest", nHomRef, nHet, nHomVar),
+        srvb.start(),
+        srvb.addDouble(res(0)),
+        srvb.advance(),
+        srvb.addDouble(res(1)),
+        srvb.advance(),
+        srvb.offset
+      )
+    }
   }
 }

--- a/src/main/scala/is/hail/methods/VariantQC.scala
+++ b/src/main/scala/is/hail/methods/VariantQC.scala
@@ -47,6 +47,7 @@ final class VariantQCCombiner {
     val nA = nAB + 2 * math.min(nHomRef, nHomVar)
 
     val LH = LeveneHaldane(nCalled, nA)
+    val hweHetFreq = LH.getNumericalMean / n
     val hweP = LH.exactMidP(nAB)
 
     rvb.startStruct() // qc
@@ -99,12 +100,7 @@ final class VariantQCCombiner {
     else
       rvb.setMissing()
 
-    // rExpectedHetFreq
-    if (nCalled != 0)
-      rvb.addDouble(LH.getNumericalMean / nCalled)
-    else
-      rvb.setMissing()
-
+    rvb.addDouble(hweHetFreq)
     rvb.addDouble(hweP)
     rvb.endStruct()
   }

--- a/src/main/scala/is/hail/stats/HWECombiner.scala
+++ b/src/main/scala/is/hail/stats/HWECombiner.scala
@@ -44,20 +44,12 @@ class HWECombiner extends Serializable {
 
   def lh = LeveneHaldane(n, nA)
 
-  def asAnnotation: Annotation = Annotation(divOption(lh.getNumericalMean, n).orNull, lh.exactMidP(nHet))
+  def asAnnotation: Annotation = Annotation(lh.getNumericalMean / n, lh.exactMidP(nHet))
 
   def result(rvb: RegionValueBuilder) {
     rvb.startStruct()
-
-    val rExpHetFreq = divNull(lh.getNumericalMean, n)
-    if (rExpHetFreq == null)
-      rvb.setMissing()
-    else
-      rvb.addDouble(rExpHetFreq)
-
-    val p = lh.exactMidP(nHet)
-    rvb.addDouble(p)
-
+    rvb.addDouble(lh.getNumericalMean / n)
+    rvb.addDouble(lh.exactMidP(nHet))
     rvb.endStruct()
   }
 

--- a/src/main/scala/is/hail/utils/package.scala
+++ b/src/main/scala/is/hail/utils/package.scala
@@ -185,6 +185,16 @@ package object utils extends Logging
   def D_>=(a: Double, b: Double, tolerance: Double = defaultTolerance): Boolean =
     (a == b) || a - b >= -D_epsilon(a, b, tolerance)
 
+  def D0_==(x: Double, y: Double, tolerance: Double = defaultTolerance): Boolean =
+    if (x.isNaN)
+      y.isNaN
+    else if (x.isPosInfinity)
+      y.isPosInfinity
+    else if (x.isNegInfinity)
+      y.isNegInfinity
+    else
+      D_==(x, y, tolerance)
+
   def flushDouble(a: Double): Double =
     if (math.abs(a) < java.lang.Double.MIN_NORMAL) 0.0 else a
 

--- a/src/test/scala/is/hail/expr/ir/MathFunctionsSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/MathFunctionsSuite.scala
@@ -1,9 +1,12 @@
 package is.hail.expr.ir
 
 import is.hail.expr.types._
+import is.hail.utils._
 import is.hail.TestUtils._
+import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 import org.scalatest.testng.TestNGSuite
+
 
 class MathFunctionsSuite extends TestNGSuite {
 
@@ -93,5 +96,60 @@ class MathFunctionsSuite extends TestNGSuite {
     assertEvalsTo(
       Uniroot("x", Ref("x", tfloat), NA(tfloat), F64(0)),
       null)
+  }
+
+  @Test def chisq() {
+    def check(a: Int, b: Int, c: Int, d: Int, pValue: Double, oddsRatio: Double) {
+      val r = eval(invoke("chisq", a, b, c, d)).asInstanceOf[Row]
+      assert(D0_==(pValue, r.getDouble(0)))
+      assert(D0_==(oddsRatio, r.getDouble(1)))
+    }
+        
+    check(0, 0, 0, 0, Double.NaN, Double.NaN)
+    check(0, 1, 1, 1, 0.38647623077123266, 0.0)
+    check(1, 0, 1, 1, 0.38647623077123266, Double.PositiveInfinity)
+    check(1, 1, 0, 1, 0.38647623077123266, Double.PositiveInfinity)
+    check(1, 1, 1, 0, 0.38647623077123266, 0.0)
+    check(10, 10, 10, 10, 1.0, 1.0)
+    check(51, 43, 22, 92, 1.462626e-7, (51.0 * 92) / (22 * 43))
+  }
+
+  @Test def fet() {
+    def check(a: Int, b: Int, c: Int, d: Int, pValue: Double, oddsRatio: Double, confLower: Double, confUpper: Double) {
+      val r = eval(invoke("fet", a, b, c, d)).asInstanceOf[Row]
+      println(r)
+      assert(D0_==(pValue, r.getDouble(0)))
+      assert(D0_==(oddsRatio, r.getDouble(1)))
+      assert(D0_==(confLower, r.getDouble(2)))
+      assert(D0_==(confUpper, r.getDouble(3)))
+    }
+    
+    check(0, 0, 0, 0, Double.NaN, Double.NaN, Double.NaN, Double.NaN)
+    check(10, 10, 10, 10, 1.0, 1.0, 0.243858, 4.100748)
+    check(51, 43, 22, 92, 2.1565e-7, 4.918058, 2.565937, 9.677930)
+  }
+  
+ @Test def ctt() {
+    def check(a: Int, b: Int, c: Int, d: Int, minCellCount: Int, pValue: Double, oddsRatio: Double) {
+      val r = eval(invoke("ctt", a, b, c, d, minCellCount)).asInstanceOf[Row]
+      assert(D0_==(pValue, r.getDouble(0)))
+      assert(D0_==(oddsRatio, r.getDouble(1)))
+    }
+
+    check(51, 43, 22, 92, 22, 1.462626e-7, 4.95983087)
+    check(51, 43, 22, 92, 23, 2.1565e-7, 4.91805817)
+  }
+  
+ @Test def hwe() {
+    def check(nHomRef: Int, nHet: Int, nHomVar: Int, pValue: Double, expectedHetFreq: Double) {
+      val r = eval(invoke("hwe", nHomRef, nHet, nHomVar)).asInstanceOf[Row]
+      assert(D0_==(pValue, r.getDouble(0)))
+      assert(D0_==(expectedHetFreq, r.getDouble(1)))
+    }
+
+    check(0, 0, 0, Double.NaN, 0.5)
+    check(1, 2, 1, 0.57142857, 0.65714285)
+    check(0, 1, 0, 1.0, 0.5)
+    check(100, 200, 100, 0.50062578, 0.96016808)
   }
 }


### PR DESCRIPTION
- ir for chisq, fet, ctt, hwe
- using nan instead of missing
- direct implementation of chisq

This is first half of closed #3825, leaving all python docs and interface as is.

To cross-check, I used R and https://www.cog-genomics.org/software/stats