### PR TITLE
make filter_cols aggregations happen in python

### DIFF
--- a/src/main/scala/is/hail/expr/Relational.scala
+++ b/src/main/scala/is/hail/expr/Relational.scala
@@ -650,9 +650,8 @@ case class FilterColsIR(
     val (rTyp, predCompiledFunc) = ir.Compile[Long, Long, Boolean](
       "global", typ.globalType,
       "sa", typ.colType,
-      pred
-    )
-    // Note that we don't yet support IR aggregators
+      pred)
+
     val p = (sa: Annotation, i: Int) => {
       Region.scoped { colRegion =>
         // FIXME: it would be nice to only load the globals once per matrix

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1280,14 +1280,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   def filterColsExpr(filterExpr: String, keep: Boolean = true): MatrixTable = {
     var filterAST = Parser.expr.parse(filterExpr)
     filterAST.typecheck(matrixType.colEC)
-    var pred = filterAST.toIROpt(Some("AGG" -> "g"))
-    pred match {
-      case Some(irPred) if ContainsAgg(irPred) =>
-        // FIXME: the IR path doesn't yet support aggs
-        log.info("filterCols: predicate contains aggs - not yet supported in IR")
-        pred = None
-      case _ =>
-    }
+    val pred = filterAST.toIROpt(Some("AGG" -> "g"))
     pred match {
       case Some(irPred) =>
         new MatrixTable(hc,


### PR DESCRIPTION
@cseed @tpoterba I couldn't think of a great way to figure out how to handle aggregations more generally in python, so I currently just have it setting a boolean field for the filter. This seemed more straightforward than adding aggregations to the FilterCols IR node, but maybe it's wrong/bad in a way that I hadn't thought of?