### PR TITLE
fix interval.start, interval.end

### DIFF
--- a/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
@@ -43,7 +43,7 @@ object IntervalFunctions extends RegistryFunctions {
         val region = getRegion(mb)
         val iv = mb.newLocal[Long]
         EmitTriplet(
-          interval.setup,
+          Code(interval.setup, iv.storeAny(defaultValue(tinterval))),
           interval.m || !Code(iv := interval.value[Long], tinterval.startDefined(region, iv)),
           region.loadIRIntermediate(tv("T").t)(tinterval.startOffset(iv))
         )
@@ -55,7 +55,7 @@ object IntervalFunctions extends RegistryFunctions {
         val region = getRegion(mb)
         val iv = mb.newLocal[Long]
         EmitTriplet(
-          interval.setup,
+          Code(interval.setup, iv.storeAny(defaultValue(tinterval))),
           interval.m || !Code(iv := interval.value[Long], tinterval.endDefined(region, iv)),
           region.loadIRIntermediate(tv("T").t)(tinterval.endOffset(iv))
         )

--- a/src/test/scala/is/hail/expr/ir/IntervalSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IntervalSuite.scala
@@ -39,6 +39,11 @@ class IntervalSuite extends TestNGSuite {
     assertEvalsTo(invoke("start", na), null)
   }
 
+  @Test def defaultValueCorrectlyStored() {
+    assertEvalsTo(If(GetTupleElement(invoke("start", i1), 0).ceq(1), true, false), true)
+    assertEvalsTo(If(GetTupleElement(invoke("end", i1), 0).ceq(2), true, false), true)
+  }
+
   @Test def end() {
     assertEvalsTo(invoke("end", i1), Row(2))
     assertEvalsTo(invoke("end", i2), null)


### PR DESCRIPTION
@cseed this fixes the bug that was caught by testConstructor in your branch, but it was distinct enough that I broke it out as a separate PR, if that's ok.