### PR TITLE
added IR parser (2)

### DIFF
--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -385,7 +385,7 @@ object Parser extends JavaTokenParsers {
             return Failure(s"unterminated $what", r)
           val c = r.first
           r = r.rest
-          if (c == '"')
+          if (c == delim)
             continue = false
           else {
             sb += c

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -404,31 +404,6 @@ object Parser extends JavaTokenParsers {
       }
     }
 
-  /*
-  def quotedLiteral(delim: Char, what: String): Parser[String] =
-    withPos(s"$delim(?:[^$delim\\\\]|\\\\.)*$delim".r) ^^ { s =>
-      try {
-        unescapeString(s.x.substring(1, s.x.length - 1))
-      } catch {
-        case e: Exception =>
-          val toSearch = s.x.substring(1, s.x.length - 1)
-          """\\[^\\"bfnrt'"`]""".r.findFirstMatchIn(toSearch) match {
-            case Some(m) =>
-              // + 1 for the opening "
-              ParserUtils.error(advancePosition(s.pos, m.start + 1),
-                s"""invalid escape character in $what: ${ m.matched }""")
-
-            case None =>
-              // For safety.  Should never happen.
-              ParserUtils.error(s.pos, s"invalid $what")
-          }
-
-      }
-    } | withPos(s"$delim([^$delim\\\\]|\\\\.)*\\z".r) ^^ { s =>
-      ParserUtils.error(s.pos, s"unterminated $what")
-    }
-    */
-
   def backtickLiteral: Parser[String] = quotedLiteral('`', "backtick identifier")
 
   override def stringLiteral: Parser[String] =
@@ -641,13 +616,13 @@ object Parser extends JavaTokenParsers {
         _.toDouble
       }
 
-  def int32_literal_opt: Parser[Option[Int]] = int32_literal ^^ { x => Some(x) } | "None" ^^ { _ => None }
+  def int32_literal_opt: Parser[Option[Int]] = int32_literal ^^ { Some(_) } | "None" ^^ { _ => None }
 
   def int64_literals: Parser[IndexedSeq[Long]] = "(" ~> rep(int64_literal) <~ ")" ^^ {
     _.toFastIndexedSeq
   }
 
-  def int64_literals_opt: Parser[Option[IndexedSeq[Long]]] = int64_literals ^^ { x => Some(x) } | "None" ^^ { _ => None }
+  def int64_literals_opt: Parser[Option[IndexedSeq[Long]]] = int64_literals ^^ { Some(_) } | "None" ^^ { _ => None }
 
   def string_literal: Parser[String] = stringLiteral
 

--- a/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -152,7 +152,7 @@ object MatrixIR {
 abstract sealed class MatrixIR extends BaseIR {
   def typ: MatrixType
 
-  def partitionCounts: Option[Array[Long]] = None
+  def partitionCounts: Option[IndexedSeq[Long]] = None
 
   def execute(hc: HailContext): MatrixValue
 }
@@ -273,7 +273,16 @@ case class MatrixNativeReader(path: String, spec: MatrixTableSpec) extends Matri
   }
 }
 
-case class MatrixRangeReader(typ: MatrixType, nRows: Int, nCols: Int, nPartitions: Option[Int]) extends MatrixReader {
+case class MatrixRangeReader(nRows: Int, nCols: Int, nPartitions: Option[Int]) extends MatrixReader {
+  val typ: MatrixType = MatrixType.fromParts(
+    globalType = TStruct.empty(),
+    colKey = Array("col_idx"),
+    colType = TStruct("col_idx" -> TInt32()),
+    rowPartitionKey = Array("row_idx"),
+    rowKey = Array("row_idx"),
+    rowType = TStruct("row_idx" -> TInt32()),
+    entryType = TStruct.empty())
+
   def apply(mr: MatrixRead): MatrixValue = {
     assert(mr.typ == typ)
 
@@ -341,7 +350,7 @@ case class MatrixRangeReader(typ: MatrixType, nRows: Int, nCols: Int, nPartition
 
 case class MatrixRead(
   typ: MatrixType,
-  override val partitionCounts: Option[Array[Long]],
+  override val partitionCounts: Option[IndexedSeq[Long]],
   dropCols: Boolean,
   dropRows: Boolean,
   reader: MatrixReader) extends MatrixIR {
@@ -523,7 +532,7 @@ case class ChooseCols(child: MatrixIR, oldIndices: Array[Int]) extends MatrixIR 
 
   val (typ, colsF) = MatrixIR.chooseColsWithArray(child.typ)
 
-  override def partitionCounts: Option[Array[Long]] = child.partitionCounts
+  override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
 
   def execute(hc: HailContext): MatrixValue = {
     val prev = child.execute(hc)
@@ -995,7 +1004,7 @@ case class MatrixMapEntries(child: MatrixIR, newEntries: IR) extends MatrixIR {
   val typ: MatrixType =
     child.typ.copy(rvRowType = newRow.typ)
 
-  override def partitionCounts: Option[Array[Long]] = child.partitionCounts
+  override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
 
   def execute(hc: HailContext): MatrixValue = {
     val prev = child.execute(hc)
@@ -1059,7 +1068,7 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR, newKey: Option[(IndexedSeq
     child.typ.copy(rvRowType = newRVRow.typ, rowKey = newRowKey, rowPartitionKey = newPartitionKey)
   }
 
-  override def partitionCounts: Option[Array[Long]] = child.partitionCounts
+  override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
 
   def execute(hc: HailContext): MatrixValue = {
     val prev = child.execute(hc)
@@ -1180,7 +1189,7 @@ case class MatrixMapCols(child: MatrixIR, newCol: IR, newKey: Option[IndexedSeq[
     child.typ.copy(colKey = newColKey, colType = newColType)
   }
 
-  override def partitionCounts: Option[Array[Long]] = child.partitionCounts
+  override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
 
   def execute(hc: HailContext): MatrixValue = {
     val prev = child.execute(hc)
@@ -1391,7 +1400,7 @@ case class MatrixMapGlobals(child: MatrixIR, newRow: IR, value: BroadcastRow) ex
     MatrixMapGlobals(newChildren(0).asInstanceOf[MatrixIR], newChildren(1).asInstanceOf[IR], value)
   }
 
-  override def partitionCounts: Option[Array[Long]] = child.partitionCounts
+  override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
 
   def execute(hc: HailContext): MatrixValue = {
     val prev = child.execute(hc)

--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -1,6 +1,10 @@
 package is.hail.expr.ir
 
+import is.hail.expr.JSONAnnotationImpex
+import is.hail.expr.types.TArray
 import is.hail.utils._
+import is.hail.variant.RelationalSpec
+import org.json4s.jackson.{JsonMethods, Serialization}
 
 object Pretty {
   def prettyStringLiteral(s: String): String =
@@ -23,6 +27,29 @@ object Pretty {
     sb.append(aggSig.seqOpArgs.map(_.parsableString()).mkString(" (", " ", ")"))
     sb += ')'
     sb.result()
+  }
+
+  def prettyIntOpt(x: Option[Int]): String = x.map(_.toString).getOrElse("None")
+
+  def prettyLongs(x: IndexedSeq[Long]): String = x.mkString("(", " ", ")")
+
+  def prettyLongsOpt(x: Option[IndexedSeq[Long]]): String =
+    x.map(prettyLongs).getOrElse("None")
+
+  def prettyIdentifiers(x: IndexedSeq[String]): String = x.map(prettyIdentifier).mkString("(", " ", ")")
+
+  def prettyIdentifiersOpt(x: Option[IndexedSeq[String]]): String = x.map(prettyIdentifiers).getOrElse("None")
+
+  def prettyMatrixReader(reader: MatrixReader): String = {
+    reader match {
+      case reader: MatrixNativeReader =>
+        import RelationalSpec.formats
+        val specJSONStr = Serialization.write(reader.spec)
+        "(MatrixNativeReader " + prettyStringLiteral(reader.path) + " " +
+        prettyStringLiteral(specJSONStr) + ")"
+      case reader: MatrixRangeReader =>
+        s"(MatrixRangeReader ${ reader.nCols } ${ reader.nRows } ${ prettyIntOpt(reader.nPartitions) })"
+    }
   }
 
   def apply(ir: BaseIR): String = {
@@ -144,7 +171,11 @@ object Pretty {
             case Die(message, typ) => typ.parsableString() + " " + prettyStringLiteral(message)
             case Uniroot(name, _, _, _) => prettyIdentifier(name)
             case MatrixRead(typ, partitionCounts, dropCols, dropRows, reader) =>
-              s"$typ partition_counts=${ partitionCounts.map(_.mkString(",")).getOrElse("None") } ${ if (dropRows) "drop_rows" else "" }${ if (dropCols) "drop_cols" else "" }"
+              typ.parsableString() + " " +
+              prettyLongsOpt(partitionCounts) + " " +
+                prettyBooleanLiteral(dropCols) + " " +
+                prettyBooleanLiteral(dropRows) + " " +
+                prettyMatrixReader(reader)
             case TableImport(paths, _, _) =>
               if (paths.length == 1)
                 paths.head
@@ -160,11 +191,13 @@ object Pretty {
 
                 ""
               }
-            case TableRead(path, _, typ, dropRows) =>
-              if (dropRows)
-                s"${ StringEscapeUtils.escapeString(path) } drop_rows"
-              else
-                path
+            case TableRead(path, spec, typ, dropRows) =>
+              implicit val formats = RelationalSpec.formats
+              val specJSONStr = Serialization.write(spec)
+              prettyStringLiteral(path) + " " +
+                prettyStringLiteral(specJSONStr) + " " +
+                typ.parsableString() + " " +
+                prettyBooleanLiteral(dropRows)
             case TableWrite(_, path, overwrite, _) =>
               if (overwrite)
                 s"${ StringEscapeUtils.escapeString(path) } overwrite"
@@ -185,6 +218,28 @@ object Pretty {
               }(sb += '\n')
 
               ""
+            case TableKeyBy(_, keys, nPartitionKeys, sort) =>
+              keys.map(prettyIdentifier).mkString("(", " ", ")") + " " +
+                (nPartitionKeys match {
+                  case Some(n) => n.toString
+                  case None => "None"
+                }) + " " +
+                prettyBooleanLiteral(sort)
+            case TableRange(n, nPartitions) => s"$n $nPartitions"
+            case TableJoin(_, _, joinType) => joinType
+            case TableMapRows(_, _, newKey, preservedKeyFields) =>
+              prettyIdentifiersOpt(newKey) + " " + prettyIntOpt(preservedKeyFields)
+            case TableExplode(_, field) => field
+            case TableParallelize(typ, rows, nPartitions) =>
+              val valueType = TArray(typ.rowType)
+              typ.parsableString() + " " + valueType.parsableString() + " " +
+                prettyStringLiteral(
+                  JsonMethods.compact(JSONAnnotationImpex.exportAnnotation(rows, valueType))) + " " +
+                prettyIntOpt(nPartitions)
+            case TableMapGlobals(_, _, value) =>
+              value.t.parsableString() + " " +
+                prettyStringLiteral(
+                  JsonMethods.compact(JSONAnnotationImpex.exportAnnotation(value.value, value.t)))
             case _ => ""
           }
 

--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -46,7 +46,7 @@ object Pretty {
         import RelationalSpec.formats
         val specJSONStr = Serialization.write(reader.spec)
         "(MatrixNativeReader " + prettyStringLiteral(reader.path) + " " +
-        prettyStringLiteral(specJSONStr) + ")"
+          prettyStringLiteral(specJSONStr) + ")"
       case reader: MatrixRangeReader =>
         s"(MatrixRangeReader ${ reader.nCols } ${ reader.nRows } ${ prettyIntOpt(reader.nPartitions) })"
     }
@@ -172,7 +172,7 @@ object Pretty {
             case Uniroot(name, _, _, _) => prettyIdentifier(name)
             case MatrixRead(typ, partitionCounts, dropCols, dropRows, reader) =>
               typ.parsableString() + " " +
-              prettyLongsOpt(partitionCounts) + " " +
+                prettyLongsOpt(partitionCounts) + " " +
                 prettyBooleanLiteral(dropCols) + " " +
                 prettyBooleanLiteral(dropRows) + " " +
                 prettyMatrixReader(reader)
@@ -219,11 +219,8 @@ object Pretty {
 
               ""
             case TableKeyBy(_, keys, nPartitionKeys, sort) =>
-              keys.map(prettyIdentifier).mkString("(", " ", ")") + " " +
-                (nPartitionKeys match {
-                  case Some(n) => n.toString
-                  case None => "None"
-                }) + " " +
+              prettyIdentifiers(keys) + " " +
+                prettyIntOpt(nPartitionKeys) + " " +
                 prettyBooleanLiteral(sort)
             case TableRange(n, nPartitions) => s"$n $nPartitions"
             case TableJoin(_, _, joinType) => joinType

--- a/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -431,7 +431,6 @@ class IRSuite extends SparkSuite {
   @Test(dataProvider = "tableIRs")
   def testTableIRParser(x: TableIR) {
     val s = Pretty(x)
-    println(s)
     val x2 = Parser.parse(Parser.table_ir, s)
     assert(x2 == x)
   }


### PR DESCRIPTION
Builds on https://github.com/hail-is/hail/pull/3852 to avoid a conflict nightmare.  You probably don't want to reivew until that goes in.

This adds TableIR parser.  TableImport is missing because handling the import options requires a bit more work.  Tested by pretty printing/parsing example TableIR and verifying the result is the same.  Also added (most of the) MatrixIR parser, but it is untested, that will come in part (3).

Had to change some Array => IndexedSeq in various places to get proper equality.

Rewrote Parser.quotedLiteral to avoid JVM stack depth limits when parsing non-small string literals.