### PR TITLE
fix liftover functions to handle missing return

### DIFF
--- a/python/hail/tests/test_genetics.py
+++ b/python/hail/tests/test_genetics.py
@@ -196,7 +196,9 @@ class Tests(unittest.TestCase):
         ]
         schema = hl.tstruct(l37=hl.tlocus(grch37), l38=hl.tlocus(grch38))
         t = hl.Table.parallelize(rows, schema)
-        self.assertTrue(t.all(hl.liftover(t.l37, 'GRCh38') == t.l38))
+        self.assertTrue(t.all(hl.cond(hl.is_defined(t.l38),
+                                      hl.liftover(t.l37, 'GRCh38') == t.l38,
+                                      hl.is_missing(hl.liftover(t.l37, 'GRCh38')))))
 
         t = t.filter(hl.is_defined(t.l38))
         self.assertTrue(t.count() == 6)


### PR DESCRIPTION
before, a npe was being thrown because `liftoverLocus` would return a null Locus if it couldn't be lifted over.