### PR TITLE
have MatrixRowsTable preserve partitionCounts() information from MatrixIR

### DIFF
--- a/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -593,6 +593,8 @@ case class TableUnion(children: IndexedSeq[TableIR]) extends TableIR {
 case class MatrixRowsTable(child: MatrixIR) extends TableIR {
   val children: IndexedSeq[BaseIR] = Array(child)
 
+  override def partitionCounts: Option[Array[Long]] = child.partitionCounts
+
   def copy(newChildren: IndexedSeq[BaseIR]): MatrixRowsTable = {
     assert(newChildren.length == 1)
     MatrixRowsTable(newChildren(0).asInstanceOf[MatrixIR])


### PR DESCRIPTION
just realized that this one doesn't keep partitionCounts() information, either