### PR TITLE
Refactor AggSignature

### DIFF
--- a/src/main/scala/is/hail/annotations/aggregators/RegionValueCountAggregator.scala
+++ b/src/main/scala/is/hail/annotations/aggregators/RegionValueCountAggregator.scala
@@ -5,7 +5,7 @@ import is.hail.annotations._
 class RegionValueCountAggregator extends RegionValueAggregator {
   private var count: Long = 0
 
-  def seqOp(region: Region, dummy: Int, missing: Boolean) {
+  def seqOp(region: Region) {
     count += 1
   }
 

--- a/src/main/scala/is/hail/expr/AST.scala
+++ b/src/main/scala/is/hail/expr/AST.scala
@@ -524,10 +524,9 @@ case class ApplyMethodAST(posn: Position, lhs: AST, method: String, args: Array[
           bodyx <- body.toIR()
           initOpArgs = Some(FastIndexedSeq(bodyx))
           aggSig = AggSignature(op,
-            -t.elementType,
             FastIndexedSeq(),
             initOpArgs.map(_.map(_.typ)),
-            FastIndexedSeq())
+            FastIndexedSeq(-t.elementType))
           ca <- fromOption(
             this,
             "no CodeAggregator",
@@ -544,10 +543,9 @@ case class ApplyMethodAST(posn: Position, lhs: AST, method: String, args: Array[
           bodyx <- body.toIR()
           seqOpArgs = FastIndexedSeq(bodyx)
           aggSig = AggSignature(op,
-            -t.elementType,
             FastIndexedSeq(),
             None,
-            seqOpArgs.map(_.typ))
+            -t.elementType +: seqOpArgs.map(_.typ))
           ca <- fromOption(
             this,
             "no CodeAggregator",
@@ -564,10 +562,9 @@ case class ApplyMethodAST(posn: Position, lhs: AST, method: String, args: Array[
           nx <- n.toIR()
           bodyx <- body.toIR()
           aggSig = AggSignature(op,
-            -t.elementType,
             FastIndexedSeq(nx.typ),
             None,
-            FastIndexedSeq(bodyx.typ))
+            FastIndexedSeq(-t.elementType, bodyx.typ))
           ca <- fromOption(
             this,
             "no CodeAggregator",
@@ -583,10 +580,9 @@ case class ApplyMethodAST(posn: Position, lhs: AST, method: String, args: Array[
             AggOp.fromString.lift(method))
           bodyx <- body.toIR()
           aggSig = AggSignature(op,
-            bodyx.typ,
             FastIndexedSeq(),
             None,
-            FastIndexedSeq())
+            FastIndexedSeq(bodyx.typ))
           ca <- fromOption(
             this,
             "no CodeAggregator",
@@ -602,13 +598,12 @@ case class ApplyMethodAST(posn: Position, lhs: AST, method: String, args: Array[
             AggOp.fromString.lift(method))
           constructorArgs <- all(args.map(_.toIR(agg))).map(_.toFastIndexedSeq)
           aggSig = AggSignature(op,
-            if (method == "count")
-              TInt32()
-            else
-              -t.elementType,
             constructorArgs.map(_.typ),
             None,
-            FastIndexedSeq())
+            FastIndexedSeq(if (method == "count")
+              TInt32()
+            else
+              -t.elementType))
           ca <- fromOption(
             this,
             "no CodeAggregator",

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -673,8 +673,8 @@ object Parser extends JavaTokenParsers {
   def type_exprs_opt: Parser[Option[Seq[Type]]] = type_exprs ^^ { ts => Some(ts) } | "None" ^^ { _ => None }
 
   def agg_signature: Parser[AggSignature] =
-    "(" ~> ir_agg_op ~ type_expr ~ type_exprs ~ type_exprs_opt ~ type_exprs <~ ")" ^^ { case op ~ inputType ~ ctorArgTypes ~ initOpArgTypes ~ seqOpArgTypes =>
-      AggSignature(op, inputType, ctorArgTypes, initOpArgTypes, seqOpArgTypes)
+    "(" ~> ir_agg_op ~ type_exprs ~ type_exprs_opt ~ type_exprs <~ ")" ^^ { case op ~ ctorArgTypes ~ initOpArgTypes ~ seqOpArgTypes =>
+      AggSignature(op, ctorArgTypes, initOpArgTypes, seqOpArgTypes)
     }
 
   def ir_named_value_exprs: Parser[Seq[(String, ir.IR)]] = rep(ir_named_value_expr)

--- a/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -11,11 +11,7 @@ case class AggSignature(
   op: AggOp,
   constructorArgs: Seq[Type],
   initOpArgs: Option[Seq[Type]],
-  seqOpArgs: Seq[Type]) {
-  assert(seqOpArgs.nonEmpty)
-
-  def inputType: Type = seqOpArgs.head
-}
+  seqOpArgs: Seq[Type])
 
 sealed trait AggOp { }
 // nulary
@@ -125,14 +121,7 @@ object AggOp {
     case (Min(), Seq(), None, Seq(_: TFloat32)) => CodeAggregator[RegionValueMinFloatAggregator](TFloat32(), seqOpArgTypes = Array(classOf[Float]))
     case (Min(), Seq(), None, Seq(_: TFloat64)) => CodeAggregator[RegionValueMinDoubleAggregator](TFloat64(), seqOpArgTypes = Array(classOf[Double]))
 
-    case (Count(), Seq(), None, Seq(in)) => in match {
-      case _: TBoolean => CodeAggregator[RegionValueCountAggregator](TInt64(), seqOpArgTypes = Array(classOf[Boolean]))
-      case _: TInt32 | _: TCall => CodeAggregator[RegionValueCountAggregator](TInt64(), seqOpArgTypes = Array(classOf[Int]))
-      case _: TInt64 => CodeAggregator[RegionValueCountAggregator](TInt64(), seqOpArgTypes = Array(classOf[Long]))
-      case _: TFloat32 => CodeAggregator[RegionValueCountAggregator](TInt64(), seqOpArgTypes = Array(classOf[Float]))
-      case _: TFloat64 => CodeAggregator[RegionValueCountAggregator](TInt64(), seqOpArgTypes = Array(classOf[Double]))
-      case _ => CodeAggregator[RegionValueCountAggregator](TInt64(), seqOpArgTypes = Array(classOf[Long]))
-    }
+    case (Count(), Seq(), None, Seq()) => CodeAggregator[RegionValueCountAggregator](TInt64(), seqOpArgTypes = Array())
 
     case (Counter(), Seq(), None, Seq(in)) => in match {
       case _: TBoolean => CodeAggregator[RegionValueCounterBooleanAggregator](TDict(in, TInt64()), seqOpArgTypes = Array(classOf[Boolean]))

--- a/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -9,11 +9,13 @@ import scala.reflect.ClassTag
 
 case class AggSignature(
   op: AggOp,
-  inputType: Type,
   constructorArgs: Seq[Type],
   initOpArgs: Option[Seq[Type]],
-  seqOpArgs: Seq[Type]
-)
+  seqOpArgs: Seq[Type]) {
+  assert(seqOpArgs.nonEmpty)
+
+  def inputType: Type = seqOpArgs.head
+}
 
 sealed trait AggOp { }
 // nulary
@@ -65,140 +67,161 @@ object AggOp {
   def getType(aggSig: AggSignature): Type = getOption(aggSig).getOrElse(incompatible(aggSig)).out
 
   def getOption(aggSig: AggSignature): Option[CodeAggregator[T] forSome { type T <: RegionValueAggregator }] =
-    getOption(aggSig.op, aggSig.inputType, aggSig.constructorArgs, aggSig.initOpArgs, aggSig.seqOpArgs)
+    getOption(aggSig.op, aggSig.constructorArgs, aggSig.initOpArgs, aggSig.seqOpArgs)
 
-  val getOption: ((AggOp, Type, Seq[Type], Option[Seq[Type]], Seq[Type])) => Option[CodeAggregator[T] forSome { type T <: RegionValueAggregator }] = lift {
-    case (Fraction(), in: TBoolean, Seq(), None, Seq()) => CodeAggregator[RegionValueFractionAggregator](in, TFloat64())
+  val getOption: ((AggOp, Seq[Type], Option[Seq[Type]], Seq[Type])) => Option[CodeAggregator[T] forSome { type T <: RegionValueAggregator }] = lift {
+    case (Fraction(), Seq(), None, Seq(_: TBoolean)) =>
+      CodeAggregator[RegionValueFractionAggregator](TFloat64(), seqOpArgTypes = Array(classOf[Boolean]))
 
-    case (Statistics(), in: TFloat64, Seq(), None, Seq()) => CodeAggregator[RegionValueStatisticsAggregator](in, RegionValueStatisticsAggregator.typ)
+    case (Statistics(), Seq(), None, Seq(_: TFloat64)) =>
+      CodeAggregator[RegionValueStatisticsAggregator](RegionValueStatisticsAggregator.typ, seqOpArgTypes = Array(classOf[Double]))
 
-    case (Collect(), in, Seq(), None, Seq()) => in match {
-      case _: TBoolean => CodeAggregator[RegionValueCollectBooleanAggregator](in, TArray(in))
-      case _: TInt32 | _: TCall => CodeAggregator[RegionValueCollectIntAggregator](in, TArray(in))
-      case _: TInt64 => CodeAggregator[RegionValueCollectLongAggregator](in, TArray(in))
-      case _: TFloat32 => CodeAggregator[RegionValueCollectFloatAggregator](in, TArray(in))
-      case _: TFloat64 => CodeAggregator[RegionValueCollectDoubleAggregator](in, TArray(in))
-      case _ => CodeAggregator[RegionValueCollectAnnotationAggregator](in, TArray(in), constrArgTypes = Array(classOf[Type]))
+    case (Collect(), Seq(), None, Seq(in)) => in match {
+      case _: TBoolean => CodeAggregator[RegionValueCollectBooleanAggregator](TArray(in), seqOpArgTypes = Array(classOf[Boolean]))
+      case _: TInt32 | _: TCall => CodeAggregator[RegionValueCollectIntAggregator](TArray(in), seqOpArgTypes = Array(classOf[Int]))
+      case _: TInt64 => CodeAggregator[RegionValueCollectLongAggregator](TArray(in), seqOpArgTypes = Array(classOf[Long]))
+      case _: TFloat32 => CodeAggregator[RegionValueCollectFloatAggregator](TArray(in), seqOpArgTypes = Array(classOf[Float]))
+      case _: TFloat64 => CodeAggregator[RegionValueCollectDoubleAggregator](TArray(in), seqOpArgTypes = Array(classOf[Double]))
+      case _ => CodeAggregator[RegionValueCollectAnnotationAggregator](TArray(in), constrArgTypes = Array(classOf[Type]), seqOpArgTypes = Array(classOf[Long]))
     }
 
-    case (InfoScore(), in@TArray(TFloat64(_), _), Seq(), None, Seq()) => CodeAggregator[RegionValueInfoScoreAggregator](in, RegionValueInfoScoreAggregator.typ)
-      
-    case (Sum(), in: TInt64, Seq(), None, Seq()) => CodeAggregator[RegionValueSumLongAggregator](in, TInt64())
-    case (Sum(), in: TFloat64, Seq(), None, Seq()) => CodeAggregator[RegionValueSumDoubleAggregator](in, TFloat64())
-    case (Sum(), in@TArray(TInt64(_), _), Seq(), None, Seq()) =>
-      CodeAggregator[RegionValueArraySumLongAggregator](in, TArray(TInt64()))
+    case (InfoScore(), Seq(), None, Seq(TArray(TFloat64(_), _))) =>
+      CodeAggregator[RegionValueInfoScoreAggregator](RegionValueInfoScoreAggregator.typ, seqOpArgTypes = Array(classOf[Long]))
 
-    case (CollectAsSet(), in, Seq(), None, Seq()) =>
+    case (Sum(), Seq(), None, Seq(_: TInt64)) => CodeAggregator[RegionValueSumLongAggregator](TInt64(), seqOpArgTypes = Array(classOf[Long]))
+    case (Sum(), Seq(), None, Seq(_: TFloat64)) => CodeAggregator[RegionValueSumDoubleAggregator](TFloat64(), seqOpArgTypes = Array(classOf[Double]))
+    case (Sum(), Seq(), None, Seq(TArray(TInt64(_), _))) =>
+      CodeAggregator[RegionValueArraySumLongAggregator](TArray(TInt64()), seqOpArgTypes = Array(classOf[Long]))
+
+    case (CollectAsSet(), Seq(), None, Seq(in)) =>
       in match {
-        case _: TBoolean => CodeAggregator[RegionValueCollectAsSetBooleanAggregator](in, TSet(TBoolean()))
-        case _: TInt32 | _: TCall => CodeAggregator[RegionValueCollectAsSetIntAggregator](in, TSet(in))
-        case _: TInt64 => CodeAggregator[RegionValueCollectAsSetLongAggregator](in, TSet(TInt64()))
-        case _: TFloat32 => CodeAggregator[RegionValueCollectAsSetFloatAggregator](in, TSet(TFloat32()))
-        case _: TFloat64 => CodeAggregator[RegionValueCollectAsSetDoubleAggregator](in, TSet(TFloat64()))
-        case _ => CodeAggregator[RegionValueCollectAsSetAnnotationAggregator](in, TSet(in), constrArgTypes = Array(classOf[Type]))
+        case _: TBoolean => CodeAggregator[RegionValueCollectAsSetBooleanAggregator](TSet(TBoolean()), seqOpArgTypes = Array(classOf[Boolean]))
+        case _: TInt32 | _: TCall => CodeAggregator[RegionValueCollectAsSetIntAggregator](TSet(in), seqOpArgTypes = Array(classOf[Int]))
+        case _: TInt64 => CodeAggregator[RegionValueCollectAsSetLongAggregator](TSet(TInt64()), seqOpArgTypes = Array(classOf[Long]))
+        case _: TFloat32 => CodeAggregator[RegionValueCollectAsSetFloatAggregator](TSet(TFloat32()), seqOpArgTypes = Array(classOf[Float]))
+        case _: TFloat64 => CodeAggregator[RegionValueCollectAsSetDoubleAggregator](TSet(TFloat64()), seqOpArgTypes = Array(classOf[Double]))
+        case _ => CodeAggregator[RegionValueCollectAsSetAnnotationAggregator](TSet(in), constrArgTypes = Array(classOf[Type]), seqOpArgTypes = Array(classOf[Long]))
       }
-    case (Sum(), in@TArray(TFloat64(_), _), Seq(), None, Seq()) =>
-      CodeAggregator[RegionValueArraySumDoubleAggregator](in, TArray(TFloat64()))
 
-    case (Product(), in: TInt64, Seq(), None, Seq()) => CodeAggregator[RegionValueProductLongAggregator](in, TInt64())
-    case (Product(), in: TFloat64, Seq(), None, Seq()) => CodeAggregator[RegionValueProductDoubleAggregator](in, TFloat64())
+    case (Sum(), Seq(), None, Seq(TArray(TFloat64(_), _))) =>
+      CodeAggregator[RegionValueArraySumDoubleAggregator](TArray(TFloat64()), seqOpArgTypes = Array(classOf[Long]))
 
-    case (HardyWeinberg(), in: TCall, Seq(), None, Seq()) => CodeAggregator[RegionValueHardyWeinbergAggregator](in, RegionValueHardyWeinbergAggregator.typ)
+    case (Product(), Seq(), None, Seq(_: TInt64)) => CodeAggregator[RegionValueProductLongAggregator](TInt64(), seqOpArgTypes = Array(classOf[Long]))
+    case (Product(), Seq(), None, Seq(_: TFloat64)) => CodeAggregator[RegionValueProductDoubleAggregator](TFloat64(), seqOpArgTypes = Array(classOf[Double]))
 
-    case (Max(), in: TBoolean, Seq(), None, Seq()) => CodeAggregator[RegionValueMaxBooleanAggregator](in, TBoolean())
-    case (Max(), in: TInt32, Seq(), None, Seq()) => CodeAggregator[RegionValueMaxIntAggregator](in, TInt32())
-    case (Max(), in: TInt64, Seq(), None, Seq()) => CodeAggregator[RegionValueMaxLongAggregator](in, TInt64())
-    case (Max(), in: TFloat32, Seq(), None, Seq()) => CodeAggregator[RegionValueMaxFloatAggregator](in, TFloat32())
-    case (Max(), in: TFloat64, Seq(), None, Seq()) => CodeAggregator[RegionValueMaxDoubleAggregator](in, TFloat64())
+    case (HardyWeinberg(), Seq(), None, Seq(_: TCall)) => CodeAggregator[RegionValueHardyWeinbergAggregator](
+      RegionValueHardyWeinbergAggregator.typ,
+      seqOpArgTypes = Array(classOf[Int]))
 
-    case (Min(), in: TBoolean, Seq(), None, Seq()) => CodeAggregator[RegionValueMinBooleanAggregator](in, TBoolean())
-    case (Min(), in: TInt32, Seq(), None, Seq()) => CodeAggregator[RegionValueMinIntAggregator](in, TInt32())
-    case (Min(), in: TInt64, Seq(), None, Seq()) => CodeAggregator[RegionValueMinLongAggregator](in, TInt64())
-    case (Min(), in: TFloat32, Seq(), None, Seq()) => CodeAggregator[RegionValueMinFloatAggregator](in, TFloat32())
-    case (Min(), in: TFloat64, Seq(), None, Seq()) => CodeAggregator[RegionValueMinDoubleAggregator](in, TFloat64())
+    case (Max(), Seq(), None, Seq(_: TBoolean)) => CodeAggregator[RegionValueMaxBooleanAggregator](TBoolean(), seqOpArgTypes = Array(classOf[Boolean]))
+    case (Max(), Seq(), None, Seq(_: TInt32)) => CodeAggregator[RegionValueMaxIntAggregator](TInt32(), seqOpArgTypes = Array(classOf[Int]))
+    case (Max(), Seq(), None, Seq(_: TInt64)) => CodeAggregator[RegionValueMaxLongAggregator](TInt64(), seqOpArgTypes = Array(classOf[Long]))
+    case (Max(), Seq(), None, Seq(_: TFloat32)) => CodeAggregator[RegionValueMaxFloatAggregator](TFloat32(), seqOpArgTypes = Array(classOf[Float]))
+    case (Max(), Seq(), None, Seq(_: TFloat64)) => CodeAggregator[RegionValueMaxDoubleAggregator](TFloat64(), seqOpArgTypes = Array(classOf[Double]))
 
-    case (Count(), in, Seq(), None, Seq()) => CodeAggregator[RegionValueCountAggregator](in, TInt64())
+    case (Min(), Seq(), None, Seq(_: TBoolean)) => CodeAggregator[RegionValueMinBooleanAggregator](TBoolean(), seqOpArgTypes = Array(classOf[Boolean]))
+    case (Min(), Seq(), None, Seq(_: TInt32)) => CodeAggregator[RegionValueMinIntAggregator](TInt32(), seqOpArgTypes = Array(classOf[Int]))
+    case (Min(), Seq(), None, Seq(_: TInt64)) => CodeAggregator[RegionValueMinLongAggregator](TInt64(), seqOpArgTypes = Array(classOf[Long]))
+    case (Min(), Seq(), None, Seq(_: TFloat32)) => CodeAggregator[RegionValueMinFloatAggregator](TFloat32(), seqOpArgTypes = Array(classOf[Float]))
+    case (Min(), Seq(), None, Seq(_: TFloat64)) => CodeAggregator[RegionValueMinDoubleAggregator](TFloat64(), seqOpArgTypes = Array(classOf[Double]))
 
-    case (Counter(), in, Seq(), None, Seq()) => in match {
-      case _: TBoolean => CodeAggregator[RegionValueCounterBooleanAggregator](in, TDict(in, TInt64()))
-      case _: TInt32 | _: TCall => CodeAggregator[RegionValueCounterIntAggregator](in, TDict(in, TInt64()), constrArgTypes = Array(classOf[Type]))
-      case _: TInt64 => CodeAggregator[RegionValueCounterLongAggregator](in, TDict(in, TInt64()), constrArgTypes = Array(classOf[Type]))
-      case _: TFloat32 => CodeAggregator[RegionValueCounterFloatAggregator](in, TDict(in, TInt64()), constrArgTypes = Array(classOf[Type]))
-      case _: TFloat64 => CodeAggregator[RegionValueCounterDoubleAggregator](in, TDict(in, TInt64()), constrArgTypes = Array(classOf[Type]))
-      case _ => CodeAggregator[RegionValueCounterAnnotationAggregator](in, TDict(in, TInt64()), constrArgTypes = Array(classOf[Type]))
+    case (Count(), Seq(), None, Seq(in)) => in match {
+      case _: TBoolean => CodeAggregator[RegionValueCountAggregator](TInt64(), seqOpArgTypes = Array(classOf[Boolean]))
+      case _: TInt32 | _: TCall => CodeAggregator[RegionValueCountAggregator](TInt64(), seqOpArgTypes = Array(classOf[Int]))
+      case _: TInt64 => CodeAggregator[RegionValueCountAggregator](TInt64(), seqOpArgTypes = Array(classOf[Long]))
+      case _: TFloat32 => CodeAggregator[RegionValueCountAggregator](TInt64(), seqOpArgTypes = Array(classOf[Float]))
+      case _: TFloat64 => CodeAggregator[RegionValueCountAggregator](TInt64(), seqOpArgTypes = Array(classOf[Double]))
+      case _ => CodeAggregator[RegionValueCountAggregator](TInt64(), seqOpArgTypes = Array(classOf[Long]))
     }
 
-    case (Take(), in, constArgs@Seq(_: TInt32), None, Seq()) => in match {
-      case _: TBoolean => CodeAggregator[RegionValueTakeBooleanAggregator](in, TArray(in), constrArgTypes = Array(classOf[Int]))
-      case _: TInt32 | _: TCall => CodeAggregator[RegionValueTakeIntAggregator](in, TArray(in), constrArgTypes = Array(classOf[Int]))
-      case _: TInt64 => CodeAggregator[RegionValueTakeLongAggregator](in, TArray(in), constrArgTypes = Array(classOf[Int]))
-      case _: TFloat32 => CodeAggregator[RegionValueTakeFloatAggregator](in, TArray(in), constrArgTypes = Array(classOf[Int]))
-      case _: TFloat64 => CodeAggregator[RegionValueTakeDoubleAggregator](in, TArray(in), constrArgTypes = Array(classOf[Int]))
-      case _ => CodeAggregator[RegionValueTakeAnnotationAggregator](in, TArray(in), constrArgTypes = Array(classOf[Int], classOf[Type]))
+    case (Counter(), Seq(), None, Seq(in)) => in match {
+      case _: TBoolean => CodeAggregator[RegionValueCounterBooleanAggregator](TDict(in, TInt64()), seqOpArgTypes = Array(classOf[Boolean]))
+      case _: TInt32 | _: TCall => CodeAggregator[RegionValueCounterIntAggregator](TDict(in, TInt64()), constrArgTypes = Array(classOf[Type]), seqOpArgTypes = Array(classOf[Int]))
+      case _: TInt64 => CodeAggregator[RegionValueCounterLongAggregator](TDict(in, TInt64()), constrArgTypes = Array(classOf[Type]), seqOpArgTypes = Array(classOf[Long]))
+      case _: TFloat32 => CodeAggregator[RegionValueCounterFloatAggregator](TDict(in, TInt64()), constrArgTypes = Array(classOf[Type]), seqOpArgTypes = Array(classOf[Float]))
+      case _: TFloat64 => CodeAggregator[RegionValueCounterDoubleAggregator](TDict(in, TInt64()), constrArgTypes = Array(classOf[Type]), seqOpArgTypes = Array(classOf[Double]))
+      case _ => CodeAggregator[RegionValueCounterAnnotationAggregator](TDict(in, TInt64()), constrArgTypes = Array(classOf[Type]), seqOpArgTypes = Array(classOf[Long]))
     }
 
-    case (TakeBy(), in, constArgs@Seq(_: TInt32), None, Seq(key)) =>
-      def tbCodeAgg[T <: RegionValueTakeByAggregator](seqOpArg: Class[_])(implicit ct: ClassTag[T]) =
-        new CodeAggregator[T](in, TArray(in), constrArgTypes = Array(classOf[Int], classOf[Type], classOf[Type]), seqOpArgTypes = Array(seqOpArg))
+    case (Take(), constArgs@Seq(_: TInt32), None, Seq(in)) => in match {
+      case _: TBoolean => CodeAggregator[RegionValueTakeBooleanAggregator](TArray(in), constrArgTypes = Array(classOf[Int]), seqOpArgTypes = Array(classOf[Boolean]))
+      case _: TInt32 | _: TCall => CodeAggregator[RegionValueTakeIntAggregator](TArray(in), constrArgTypes = Array(classOf[Int]), seqOpArgTypes = Array(classOf[Int]))
+      case _: TInt64 => CodeAggregator[RegionValueTakeLongAggregator](TArray(in), constrArgTypes = Array(classOf[Int]), seqOpArgTypes = Array(classOf[Long]))
+      case _: TFloat32 => CodeAggregator[RegionValueTakeFloatAggregator](TArray(in), constrArgTypes = Array(classOf[Int]), seqOpArgTypes = Array(classOf[Float]))
+      case _: TFloat64 => CodeAggregator[RegionValueTakeDoubleAggregator](TArray(in), constrArgTypes = Array(classOf[Int]), seqOpArgTypes = Array(classOf[Double]))
+      case _ => CodeAggregator[RegionValueTakeAnnotationAggregator](TArray(in), constrArgTypes = Array(classOf[Int], classOf[Type]), seqOpArgTypes = Array(classOf[Long]))
+    }
+
+    case (TakeBy(), constArgs@Seq(_: TInt32), None, Seq(in, key)) =>
+      def tbCodeAgg[T <: RegionValueTakeByAggregator](seqOpArgs: Class[_]*)(implicit ct: ClassTag[T]) =
+        new CodeAggregator[T](TArray(in), constrArgTypes = Array(classOf[Int], classOf[Type], classOf[Type]), seqOpArgTypes = seqOpArgs.toArray)
       
       (in, key) match {
-        case (_: TBoolean, _: TBoolean) => tbCodeAgg[RegionValueTakeByBooleanBooleanAggregator](classOf[Boolean])
-        case (_: TBoolean, _: TInt32 | _: TCall) => tbCodeAgg[RegionValueTakeByBooleanIntAggregator](classOf[Int])
-        case (_: TBoolean, _: TInt64) => tbCodeAgg[RegionValueTakeByBooleanLongAggregator](classOf[Long])
-        case (_: TBoolean, _: TFloat32) => tbCodeAgg[RegionValueTakeByBooleanFloatAggregator](classOf[Float])
-        case (_: TBoolean, _: TFloat64) => tbCodeAgg[RegionValueTakeByBooleanDoubleAggregator](classOf[Double])
-        case (_: TBoolean, _) => tbCodeAgg[RegionValueTakeByBooleanAnnotationAggregator](classOf[Long])
+        case (_: TBoolean, _: TBoolean) => tbCodeAgg[RegionValueTakeByBooleanBooleanAggregator](classOf[Boolean], classOf[Boolean])
+        case (_: TBoolean, _: TInt32 | _: TCall) => tbCodeAgg[RegionValueTakeByBooleanIntAggregator](classOf[Boolean], classOf[Int])
+        case (_: TBoolean, _: TInt64) => tbCodeAgg[RegionValueTakeByBooleanLongAggregator](classOf[Boolean], classOf[Long])
+        case (_: TBoolean, _: TFloat32) => tbCodeAgg[RegionValueTakeByBooleanFloatAggregator](classOf[Boolean], classOf[Float])
+        case (_: TBoolean, _: TFloat64) => tbCodeAgg[RegionValueTakeByBooleanDoubleAggregator](classOf[Boolean], classOf[Double])
+        case (_: TBoolean, _) => tbCodeAgg[RegionValueTakeByBooleanAnnotationAggregator](classOf[Boolean], classOf[Long])
 
-        case (_: TInt32 | _: TCall, _: TBoolean) => tbCodeAgg[RegionValueTakeByIntBooleanAggregator](classOf[Boolean])
-        case (_: TInt32 | _: TCall, _: TInt32 | _: TCall) => tbCodeAgg[RegionValueTakeByIntIntAggregator](classOf[Int])
-        case (_: TInt32 | _: TCall, _: TInt64) => tbCodeAgg[RegionValueTakeByIntLongAggregator](classOf[Long])
-        case (_: TInt32 | _: TCall, _: TFloat32) => tbCodeAgg[RegionValueTakeByIntFloatAggregator](classOf[Float])
-        case (_: TInt32 | _: TCall, _: TFloat64) => tbCodeAgg[RegionValueTakeByIntDoubleAggregator](classOf[Double])
-        case (_: TInt32 | _: TCall, _) => tbCodeAgg[RegionValueTakeByIntAnnotationAggregator](classOf[Long])
+        case (_: TInt32 | _: TCall, _: TBoolean) => tbCodeAgg[RegionValueTakeByIntBooleanAggregator](classOf[Int], classOf[Boolean])
+        case (_: TInt32 | _: TCall, _: TInt32 | _: TCall) => tbCodeAgg[RegionValueTakeByIntIntAggregator](classOf[Int], classOf[Int])
+        case (_: TInt32 | _: TCall, _: TInt64) => tbCodeAgg[RegionValueTakeByIntLongAggregator](classOf[Int], classOf[Long])
+        case (_: TInt32 | _: TCall, _: TFloat32) => tbCodeAgg[RegionValueTakeByIntFloatAggregator](classOf[Int], classOf[Float])
+        case (_: TInt32 | _: TCall, _: TFloat64) => tbCodeAgg[RegionValueTakeByIntDoubleAggregator](classOf[Int], classOf[Double])
+        case (_: TInt32 | _: TCall, _) => tbCodeAgg[RegionValueTakeByIntAnnotationAggregator](classOf[Int], classOf[Long])
 
-        case (_: TInt64, _: TBoolean) => tbCodeAgg[RegionValueTakeByLongBooleanAggregator](classOf[Boolean])
-        case (_: TInt64, _: TInt32 | _: TCall) => tbCodeAgg[RegionValueTakeByLongIntAggregator](classOf[Int])
-        case (_: TInt64, _: TInt64) => tbCodeAgg[RegionValueTakeByLongLongAggregator](classOf[Long])
-        case (_: TInt64, _: TFloat32) => tbCodeAgg[RegionValueTakeByLongFloatAggregator](classOf[Float])
-        case (_: TInt64, _: TFloat64) => tbCodeAgg[RegionValueTakeByLongDoubleAggregator](classOf[Double])
-        case (_: TInt64, _) => tbCodeAgg[RegionValueTakeByLongAnnotationAggregator](classOf[Long])
+        case (_: TInt64, _: TBoolean) => tbCodeAgg[RegionValueTakeByLongBooleanAggregator](classOf[Long], classOf[Boolean])
+        case (_: TInt64, _: TInt32 | _: TCall) => tbCodeAgg[RegionValueTakeByLongIntAggregator](classOf[Long], classOf[Int])
+        case (_: TInt64, _: TInt64) => tbCodeAgg[RegionValueTakeByLongLongAggregator](classOf[Long], classOf[Long])
+        case (_: TInt64, _: TFloat32) => tbCodeAgg[RegionValueTakeByLongFloatAggregator](classOf[Long], classOf[Float])
+        case (_: TInt64, _: TFloat64) => tbCodeAgg[RegionValueTakeByLongDoubleAggregator](classOf[Long], classOf[Double])
+        case (_: TInt64, _) => tbCodeAgg[RegionValueTakeByLongAnnotationAggregator](classOf[Long], classOf[Long])
 
-        case (_: TFloat32, _: TBoolean) => tbCodeAgg[RegionValueTakeByFloatBooleanAggregator](classOf[Boolean])
-        case (_: TFloat32, _: TInt32 | _: TCall) => tbCodeAgg[RegionValueTakeByFloatIntAggregator](classOf[Int])
-        case (_: TFloat32, _: TInt64) => tbCodeAgg[RegionValueTakeByFloatLongAggregator](classOf[Long])
-        case (_: TFloat32, _: TFloat32) => tbCodeAgg[RegionValueTakeByFloatFloatAggregator](classOf[Float])
-        case (_: TFloat32, _: TFloat64) => tbCodeAgg[RegionValueTakeByFloatDoubleAggregator](classOf[Double])
-        case (_: TFloat32, _) => tbCodeAgg[RegionValueTakeByFloatAnnotationAggregator](classOf[Long])
+        case (_: TFloat32, _: TBoolean) => tbCodeAgg[RegionValueTakeByFloatBooleanAggregator](classOf[Float], classOf[Boolean])
+        case (_: TFloat32, _: TInt32 | _: TCall) => tbCodeAgg[RegionValueTakeByFloatIntAggregator](classOf[Float], classOf[Int])
+        case (_: TFloat32, _: TInt64) => tbCodeAgg[RegionValueTakeByFloatLongAggregator](classOf[Float], classOf[Long])
+        case (_: TFloat32, _: TFloat32) => tbCodeAgg[RegionValueTakeByFloatFloatAggregator](classOf[Float], classOf[Float])
+        case (_: TFloat32, _: TFloat64) => tbCodeAgg[RegionValueTakeByFloatDoubleAggregator](classOf[Float], classOf[Double])
+        case (_: TFloat32, _) => tbCodeAgg[RegionValueTakeByFloatAnnotationAggregator](classOf[Float], classOf[Long])
 
-        case (_: TFloat64, _: TBoolean) => tbCodeAgg[RegionValueTakeByDoubleBooleanAggregator](classOf[Boolean])
-        case (_: TFloat64, _: TInt32 | _: TCall) => tbCodeAgg[RegionValueTakeByDoubleIntAggregator](classOf[Int])
-        case (_: TFloat64, _: TInt64) => tbCodeAgg[RegionValueTakeByDoubleLongAggregator](classOf[Long])
-        case (_: TFloat64, _: TFloat32) => tbCodeAgg[RegionValueTakeByDoubleFloatAggregator](classOf[Float])
-        case (_: TFloat64, _: TFloat64) => tbCodeAgg[RegionValueTakeByDoubleDoubleAggregator](classOf[Double])
-        case (_: TFloat64, _) => tbCodeAgg[RegionValueTakeByDoubleAnnotationAggregator](classOf[Long])
+        case (_: TFloat64, _: TBoolean) => tbCodeAgg[RegionValueTakeByDoubleBooleanAggregator](classOf[Double], classOf[Boolean])
+        case (_: TFloat64, _: TInt32 | _: TCall) => tbCodeAgg[RegionValueTakeByDoubleIntAggregator](classOf[Double], classOf[Int])
+        case (_: TFloat64, _: TInt64) => tbCodeAgg[RegionValueTakeByDoubleLongAggregator](classOf[Double], classOf[Long])
+        case (_: TFloat64, _: TFloat32) => tbCodeAgg[RegionValueTakeByDoubleFloatAggregator](classOf[Double], classOf[Float])
+        case (_: TFloat64, _: TFloat64) => tbCodeAgg[RegionValueTakeByDoubleDoubleAggregator](classOf[Double], classOf[Double])
+        case (_: TFloat64, _) => tbCodeAgg[RegionValueTakeByDoubleAnnotationAggregator](classOf[Double], classOf[Long])
 
-        case (_, _: TBoolean) => tbCodeAgg[RegionValueTakeByAnnotationBooleanAggregator](classOf[Boolean])
-        case (_, _: TInt32 | _: TCall) => tbCodeAgg[RegionValueTakeByAnnotationIntAggregator](classOf[Int])
-        case (_, _: TInt64) => tbCodeAgg[RegionValueTakeByAnnotationLongAggregator](classOf[Long])
-        case (_, _: TFloat32) => tbCodeAgg[RegionValueTakeByAnnotationFloatAggregator](classOf[Float])
-        case (_, _: TFloat64) => tbCodeAgg[RegionValueTakeByAnnotationDoubleAggregator](classOf[Double])
-        case (_, _) => tbCodeAgg[RegionValueTakeByAnnotationAnnotationAggregator](classOf[Long])
+        case (_, _: TBoolean) => tbCodeAgg[RegionValueTakeByAnnotationBooleanAggregator](classOf[Long], classOf[Boolean])
+        case (_, _: TInt32 | _: TCall) => tbCodeAgg[RegionValueTakeByAnnotationIntAggregator](classOf[Long], classOf[Int])
+        case (_, _: TInt64) => tbCodeAgg[RegionValueTakeByAnnotationLongAggregator](classOf[Long], classOf[Long])
+        case (_, _: TFloat32) => tbCodeAgg[RegionValueTakeByAnnotationFloatAggregator](classOf[Long], classOf[Float])
+        case (_, _: TFloat64) => tbCodeAgg[RegionValueTakeByAnnotationDoubleAggregator](classOf[Long], classOf[Double])
+        case (_, _) => tbCodeAgg[RegionValueTakeByAnnotationAnnotationAggregator](classOf[Long], classOf[Long])
       }
 
-    case (Histogram(), in: TFloat64, constArgs@Seq(_: TFloat64, _: TFloat64, _: TInt32), None, Seq()) =>
-      CodeAggregator[RegionValueHistogramAggregator](in, RegionValueHistogramAggregator.typ, constrArgTypes = Array(classOf[Double], classOf[Double], classOf[Int]))
+    case (Histogram(), constArgs@Seq(_: TFloat64, _: TFloat64, _: TInt32), None, Seq(_: TFloat64)) =>
+      CodeAggregator[RegionValueHistogramAggregator](
+        RegionValueHistogramAggregator.typ,
+        constrArgTypes = Array(classOf[Double], classOf[Double], classOf[Int]),
+        seqOpArgTypes = Array(classOf[Double]))
 
-    case (CallStats(), in: TCall, Seq(), initOpArgs@Some(Seq(_: TInt32)), Seq()) =>
-      CodeAggregator[RegionValueCallStatsAggregator](in, RegionValueCallStatsAggregator.typ, initOpArgTypes = Some(Array(classOf[Int])))
+    case (CallStats(), Seq(), initOpArgs@Some(Seq(_: TInt32)), Seq(_: TCall)) =>
+      CodeAggregator[RegionValueCallStatsAggregator](
+        RegionValueCallStatsAggregator.typ,
+        initOpArgTypes = Some(Array(classOf[Int])),
+        seqOpArgTypes = Array(classOf[Int]))
 
-    case (Inbreeding(), in: TCall, Seq(), None, seqOpArgs@Seq(_: TFloat64)) =>
-      CodeAggregator[RegionValueInbreedingAggregator](in, RegionValueInbreedingAggregator.typ, seqOpArgTypes = Array(classOf[Double]))
+    case (Inbreeding(), Seq(), None, seqOpArgs@Seq(_: TCall, _: TFloat64)) =>
+      CodeAggregator[RegionValueInbreedingAggregator](
+        RegionValueInbreedingAggregator.typ,
+        seqOpArgTypes = Array(classOf[Int], classOf[Double]))
   }
 
   private def incompatible(aggSig: AggSignature): Nothing = {
-    throw new RuntimeException(s"no aggregator named ${ aggSig.op } taking arguments ([${ aggSig.constructorArgs.mkString(", ") }]" +
-      s", ${ if (aggSig.initOpArgs.isEmpty) "None" else "[" + aggSig.initOpArgs.get.mkString(", ") + "]" }) " +
-      s"operating on aggregables of type ${ aggSig.inputType }")
+    throw new RuntimeException(s"no aggregator named ${ aggSig.op } taking constructor arguments [${ aggSig.constructorArgs.mkString(", ") }] " +
+      s"initOp arguments ${ if (aggSig.initOpArgs.isEmpty) "None" else "[" + aggSig.initOpArgs.get.mkString(", ") + "]" } " +
+      s"and seqOp arguments [${ aggSig.seqOpArgs.mkString(", ")}]")
   }
 
   val fromString: PartialFunction[String, AggOp] = {

--- a/src/main/scala/is/hail/expr/ir/CodeAggregator.scala
+++ b/src/main/scala/is/hail/expr/ir/CodeAggregator.scala
@@ -9,16 +9,16 @@ import scala.reflect.ClassTag
 import scala.reflect.classTag
 
 /**
-  * Pair the aggregator with a staged seqOp that calls the non-generic seqOp
-  * method and handles missingness correctly. If an initOp exists, the arguments
-  * have already had missingness handled.
+  * Pair the aggregator with a staged seqOp that calls the non-generic seqOp and initOp
+  * methods. Missingness is handled by Emit.
   **/
 case class CodeAggregator[Agg <: RegionValueAggregator : ClassTag : TypeInfo](
-  in: Type,
   out: Type,
   constrArgTypes: Array[Class[_]] = Array.empty[Class[_]],
   initOpArgTypes: Option[Array[Class[_]]] = None,
-  seqOpArgTypes: Array[Class[_]] = Array.empty[Class[_]]) {
+  seqOpArgTypes: Array[Class[_]]) {
+
+  assert(seqOpArgTypes.nonEmpty)
 
   def initOp(rva: Code[RegionValueAggregator], vs: Array[Code[_]], ms: Array[Code[Boolean]]): Code[Unit] = {
     assert(initOpArgTypes.isDefined && vs.length == ms.length)
@@ -31,9 +31,7 @@ case class CodeAggregator[Agg <: RegionValueAggregator : ClassTag : TypeInfo](
     assert(vs.length == ms.length)
     val argTypes = seqOpArgTypes.flatMap[Class[_], Array[Class[_]]](Array(_, classOf[Boolean]))
     val args = vs.zip(ms).flatMap { case (v, m) => Array(v, m) }
-    Code.checkcast[Agg](rva).invoke("seqOp", Array(classOf[Region],
-      TypeToIRIntermediateClassTag(in).runtimeClass, classOf[Boolean]) ++ argTypes,
-      Array(region) ++ args)(classTag[Unit])
+    Code.checkcast[Agg](rva).invoke("seqOp", Array(classOf[Region]) ++ argTypes, Array(region) ++ args)(classTag[Unit])
   }
 
   def stagedNew(v: Array[Code[_]], m: Array[Code[Boolean]]): Code[Agg] = {

--- a/src/main/scala/is/hail/expr/ir/CodeAggregator.scala
+++ b/src/main/scala/is/hail/expr/ir/CodeAggregator.scala
@@ -16,9 +16,7 @@ case class CodeAggregator[Agg <: RegionValueAggregator : ClassTag : TypeInfo](
   out: Type,
   constrArgTypes: Array[Class[_]] = Array.empty[Class[_]],
   initOpArgTypes: Option[Array[Class[_]]] = None,
-  seqOpArgTypes: Array[Class[_]]) {
-
-  assert(seqOpArgTypes.nonEmpty)
+  seqOpArgTypes: Array[Class[_]] = Array.empty[Class[_]]) {
 
   def initOp(rva: Code[RegionValueAggregator], vs: Array[Code[_]], ms: Array[Code[Boolean]]): Code[Unit] = {
     assert(initOpArgTypes.isDefined && vs.length == ms.length)

--- a/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -75,13 +75,13 @@ object ExtractAggregators {
       var codeConstructorArgs = constructorArgs.map(Emit.toCode(_, fb, 1))
 
       aggSig match {
-        case AggSignature(Collect() | Take() | CollectAsSet(), t@(_: TBoolean | _: TInt32 | _: TInt64 | _: TFloat32 | _: TFloat64 | _: TCall), _, _, _) =>
-        case AggSignature(Collect() | Take() | CollectAsSet(), t, _, _, _) =>
+        case AggSignature(Collect() | Take() | CollectAsSet(), _, _, Seq(t@(_: TBoolean | _: TInt32 | _: TInt64 | _: TFloat32 | _: TFloat64 | _: TCall))) =>
+        case AggSignature(Collect() | Take() | CollectAsSet(), _, _, Seq(t)) =>
           codeConstructorArgs ++= FastIndexedSeq(EmitTriplet(Code._empty, const(false), fb.getType(t)))
-        case AggSignature(Counter(), t@(_: TBoolean), _, _, _) =>
-        case AggSignature(Counter(), t, _, _, _) =>
+        case AggSignature(Counter(), _, _, Seq(t@(_: TBoolean))) =>
+        case AggSignature(Counter(), _, _, Seq(t)) =>
           codeConstructorArgs = FastIndexedSeq(EmitTriplet(Code._empty, const(false), fb.getType(t)))
-        case AggSignature(TakeBy(), aggType, _, _, Seq(keyType)) =>
+        case AggSignature(TakeBy(), _, _, Seq(aggType, keyType)) =>
           codeConstructorArgs ++= FastIndexedSeq(EmitTriplet(Code._empty, const(false), fb.getType(aggType)),
             EmitTriplet(Code._empty, const(false), fb.getType(keyType)))
         case _ =>

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -116,8 +116,6 @@ final case class ApplyAggOp(a: IR, constructorArgs: IndexedSeq[IR], initOpArgs: 
   def hasInitOp = initOpArgs.isDefined
 
   def op: AggOp = aggSig.op
-
-  def inputType: Type = aggSig.inputType
 }
 
 final case class InitOp(i: IR, args: IndexedSeq[IR], aggSig: AggSignature) extends IR {

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -345,34 +345,34 @@ object Interpret {
             aggregator.get.seqOp(interpret(a))
         }
       case x@ApplyAggOp(a, constructorArgs, initOpArgs, aggSig) =>
-        val seqOpArgs = aggSig.seqOpArgs
+        val seqOpArgTypes = aggSig.seqOpArgs
         assert(AggOp.getType(aggSig) == x.typ)
         val aggregator = aggSig.op match {
           case CallStats() =>
-            assert(seqOpArgs == FastIndexedSeq(TCall()))
+            assert(seqOpArgTypes == FastIndexedSeq(TCall()))
             val nAlleles = interpret(initOpArgs.get(0))
             new CallStatsAggregator(_ => nAlleles)
           case Inbreeding() =>
-            assert(seqOpArgs == FastIndexedSeq(TCall(), TFloat64()))
+            assert(seqOpArgTypes == FastIndexedSeq(TCall(), TFloat64()))
             new InbreedingAggregator(null)
           case HardyWeinberg() =>
-            assert(seqOpArgs == FastIndexedSeq(TCall()))
+            assert(seqOpArgTypes == FastIndexedSeq(TCall()))
             new HWEAggregator()
           case Count() => new CountAggregator()
           case Collect() =>
-            val IndexedSeq(aggType) = seqOpArgs
+            val IndexedSeq(aggType) = seqOpArgTypes
             new CollectAggregator(aggType)
           case Counter() =>
-            val IndexedSeq(aggType) = seqOpArgs
+            val IndexedSeq(aggType) = seqOpArgTypes
             new CounterAggregator(aggType)
           case CollectAsSet() =>
-            val IndexedSeq(aggType) = seqOpArgs
+            val IndexedSeq(aggType) = seqOpArgTypes
             new CollectSetAggregator(aggType)
           case Fraction() =>
-            assert(seqOpArgs == FastIndexedSeq(TBoolean()))
+            assert(seqOpArgTypes == FastIndexedSeq(TBoolean()))
             new FractionAggregator(a => a)
           case Sum() =>
-            val IndexedSeq(aggType) = seqOpArgs
+            val IndexedSeq(aggType) = seqOpArgTypes
             aggType match {
               case TInt64(_) => new SumAggregator[Long]()
               case TFloat64(_) => new SumAggregator[Double]()
@@ -380,13 +380,13 @@ object Interpret {
               case TArray(TFloat64(_), _) => new SumArrayAggregator[Double]()
             }
           case Product() =>
-            val IndexedSeq(aggType) = seqOpArgs
+            val IndexedSeq(aggType) = seqOpArgTypes
             aggType match {
               case TInt64(_) => new ProductAggregator[Long]()
               case TFloat64(_) => new ProductAggregator[Double]()
             }
           case Min() =>
-            val IndexedSeq(aggType) = seqOpArgs
+            val IndexedSeq(aggType) = seqOpArgTypes
             aggType match {
               case TInt32(_) => new MinAggregator[Int, java.lang.Integer]()
               case TInt64(_) => new MinAggregator[Long, java.lang.Long]()
@@ -394,7 +394,7 @@ object Interpret {
               case TFloat64(_) => new MinAggregator[Double, java.lang.Double]()
             }
           case Max() =>
-            val IndexedSeq(aggType) = seqOpArgs
+            val IndexedSeq(aggType) = seqOpArgTypes
             aggType match {
               case TInt32(_) => new MaxAggregator[Int, java.lang.Integer]()
               case TInt64(_) => new MaxAggregator[Long, java.lang.Long]()
@@ -403,12 +403,12 @@ object Interpret {
             }
           case Take() =>
             val IndexedSeq(n) = constructorArgs
-            val IndexedSeq(aggType) = seqOpArgs
+            val IndexedSeq(aggType) = seqOpArgTypes
             val nValue = interpret(n, Env.empty[Any], null, null).asInstanceOf[Int]
             new TakeAggregator(aggType, nValue)
           case TakeBy() =>
             val IndexedSeq(n) = constructorArgs
-            val IndexedSeq(aggType) = seqOpArgs
+            val IndexedSeq(aggType, _) = seqOpArgTypes
             val nValue = interpret(n, Env.empty[Any], null, null).asInstanceOf[Int]
             val seqOps = Extract(a, _.isInstanceOf[SeqOp]).map(_.asInstanceOf[SeqOp])
             assert(seqOps.length == 1)

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -353,7 +353,7 @@ object Interpret {
             val nAlleles = interpret(initOpArgs.get(0))
             new CallStatsAggregator(_ => nAlleles)
           case Inbreeding() =>
-            assert(seqOpArgs == FastIndexedSeq(TCall()))
+            assert(seqOpArgs == FastIndexedSeq(TCall(), TFloat64()))
             new InbreedingAggregator(null)
           case HardyWeinberg() =>
             assert(seqOpArgs == FastIndexedSeq(TCall()))

--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -21,7 +21,6 @@ object Pretty {
     sb += '('
     sb.append(prettyClass(aggSig.op))
     sb += ' '
-    sb.append(aggSig.inputType.parsableString())
     sb.append(aggSig.constructorArgs.map(_.parsableString()).mkString(" (", " ", ")"))
     sb.append(aggSig.initOpArgs.map(_.map(_.parsableString()).mkString(" (", " ", ")")).getOrElse(" None"))
     sb.append(aggSig.seqOpArgs.map(_.parsableString()).mkString(" (", " ", ")"))

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -137,14 +137,15 @@ object TypeCheck {
         val tarray = coerce[TArray](a.typ)
         check(body, env = env.bind(valueName -> -tarray.elementType))
         assert(body.typ == TVoid)
-      case x@InitOp(i, args, _) =>
+      case x@InitOp(i, args, aggSig) =>
         args.foreach(check(_))
         check(i)
+        assert(Some(args.map(_.typ)) == aggSig.initOpArgs)
         assert(i.typ.isInstanceOf[TInt32])
       case x@SeqOp(i, args, aggSig) =>
         check(i)
         args.foreach(check(_))
-        assert(args.head.typ == aggSig.inputType)
+        assert(args.map(_.typ) == aggSig.seqOpArgs)
         assert(i.typ.isInstanceOf[TInt32])
       case x@Begin(xs) =>
         xs.foreach { x =>

--- a/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -31,7 +31,7 @@ object TestRegisterFunctions extends RegistryFunctions {
   def registerAll() {
     registerIR("addone", TInt32())(ApplyBinaryPrimOp(Add(), _, I32(1)))
     registerIR("sumaggregator32", TAggregable(TInt32())) { ir =>
-      val aggSig = AggSignature(Sum(), TInt64(), FastSeq(), None, FastSeq())
+      val aggSig = AggSignature(Sum(), FastSeq(), None, FastSeq(TInt64()))
       ApplyAggOp(SeqOp(I32(0), FastSeq(Cast(ir, TInt64())), aggSig), FastSeq(), None, aggSig)
     }
     registerJavaStaticFunction("compare", TInt32(), TInt32(), TInt32())(classOf[java.lang.Integer], "compare")

--- a/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -309,13 +309,13 @@ class IRSuite extends SparkSuite {
 
     val call = Ref("call", TCall())
 
-    val collectSig = AggSignature(Collect(), TInt32(), Seq(), None, Seq())
+    val collectSig = AggSignature(Collect(), Seq(), None, Seq(TInt32()))
 
-    val callStatsSig = AggSignature(CallStats(), TCall(), Seq(), Some(Seq(TInt32())), Seq())
+    val callStatsSig = AggSignature(CallStats(), Seq(), Some(Seq(TInt32())), Seq(TCall()))
 
-    val histSig = AggSignature(Histogram(), TFloat64(), Seq(TFloat64(), TFloat64(), TInt32()), None, Seq())
+    val histSig = AggSignature(Histogram(), Seq(TFloat64(), TFloat64(), TInt32()), None, Seq(TFloat64()))
 
-    val takeBySig = AggSignature(TakeBy(), TFloat64(), Seq(TInt32()), None, Seq(TInt32()))
+    val takeBySig = AggSignature(TakeBy(), Seq(TInt32()), None, Seq(TFloat64(), TInt32()))
 
     val irs = Array(
       i, I64(5), F32(3.14f), F64(3.14), str, True(), False(), Void(),

--- a/src/test/scala/is/hail/expr/ir/InterpretSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/InterpretSuite.scala
@@ -282,7 +282,7 @@ class InterpretSuite {
   @Test def testAggregator() {
     val agg = (FastIndexedSeq(Row(5), Row(10), Row(15)),
       TStruct("a" -> TInt32()))
-    val aggSig = AggSignature(Sum(), TInt64(), FastSeq(), None, FastSeq())
+    val aggSig = AggSignature(Sum(), FastSeq(), None, FastSeq(TInt64()))
     assertEvalsTo(ApplyAggOp(
       If(ApplyComparisonOp(LT(TInt32()), Ref("a", TInt32()), I32(11)),
         SeqOp(I32(0), FastSeq(Cast(Ref("a", TInt32()), TInt64())), aggSig),


### PR DESCRIPTION
The goal of this PR is to move the inputType of the AggSignature into the seqOpArgs to make it more general. For now, the first seqOpArgument is always the aggregable. However, when I add Keyed AggOps, the first argument will be the key and the second argument will be the aggregable.