### PR TITLE
Table partition counts ir

### DIFF
--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -100,7 +100,7 @@ object Children {
     // from MatrixIR
     case MatrixWrite(child, _) => IndexedSeq(child)
     // from TableIR
-    case TableCount(child) => IndexedSeq(child)
+    case TablePartitionCounts(child) => IndexedSeq(child)
     case TableAggregate(child, query) => IndexedSeq(child, query)
     case TableWrite(child, _, _, _) => IndexedSeq(child)
     case TableExport(child, _, _, _, _) => IndexedSeq(child)

--- a/src/main/scala/is/hail/expr/ir/Compilable.scala
+++ b/src/main/scala/is/hail/expr/ir/Compilable.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir
 object Compilable {
   def apply(ir: IR): Boolean = {
     ir match {
-      case _: TableCount => false
+      case _: TablePartitionCounts => false
       case _: TableAggregate => false
       case _: TableWrite => false
       case _: TableExport  => false

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -131,9 +131,9 @@ object Copy {
         val IndexedSeq(child: MatrixIR) = newChildren
         MatrixWrite(child, f)
       // from TableIR
-      case TableCount(_) =>
+      case TablePartitionCounts(_) =>
         val IndexedSeq(child: TableIR) = newChildren
-        TableCount(child)
+        TablePartitionCounts(child)
       case TableAggregate(_, _) =>
         val IndexedSeq(child: TableIR, query: IR) = newChildren
         TableAggregate(child, query)

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -186,7 +186,7 @@ final case class ApplySpecial(function: String, args: Seq[IR]) extends IR {
 
 final case class Uniroot(argname: String, function: IR, min: IR, max: IR) extends IR { val typ: Type = TFloat64() }
 
-final case class TableCount(child: TableIR) extends IR { val typ: Type = TInt64() }
+final case class TablePartitionCounts(child: TableIR) extends IR { val typ: Type = TArray(TInt64()) }
 final case class TableAggregate(child: TableIR, query: IR) extends InferIR
 final case class TableWrite(
   child: TableIR,

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -556,10 +556,9 @@ object Interpret {
         else
           stats.uniroot(f, min.asInstanceOf[Double], max.asInstanceOf[Double]).orNull
 
-      case TableCount(child) =>
-        child.partitionCounts
-          .map(_.sum)
-          .getOrElse(child.execute(HailContext.get).rvd.count())
+      case TablePartitionCounts(child) =>
+        child._partitionCounts
+          .getOrElse(child.execute(HailContext.get).rvd.countPerPartition(): IndexedSeq[Long])
       case MatrixWrite(child, f) =>
         val mv = child.execute(HailContext.get)
         f(mv)

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -557,7 +557,7 @@ object Interpret {
           stats.uniroot(f, min.asInstanceOf[Double], max.asInstanceOf[Double]).orNull
 
       case TablePartitionCounts(child) =>
-        child._fastPartitionCounts
+        child.fastPartitionCounts
           .getOrElse(child.execute(HailContext.get).rvd.countPerPartition(): IndexedSeq[Long])
       case MatrixWrite(child, f) =>
         val mv = child.execute(HailContext.get)

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -557,7 +557,7 @@ object Interpret {
           stats.uniroot(f, min.asInstanceOf[Double], max.asInstanceOf[Double]).orNull
 
       case TablePartitionCounts(child) =>
-        child._partitionCounts
+        child._fastPartitionCounts
           .getOrElse(child.execute(HailContext.get).rvd.countPerPartition(): IndexedSeq[Long])
       case MatrixWrite(child, f) =>
         val mv = child.execute(HailContext.get)

--- a/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -538,7 +538,7 @@ object PruneDeadFields {
             .zipWithIndex
             .map { case (t, i) => if (i == idx) requestedType else minimal(t) }: _*)
         memoizeValueIR(o, tupleDep, memo)
-      case TableCount(child) =>
+      case TablePartitionCounts(child) =>
         memoizeTableIR(child, minimal(child.typ), memo)
         Env.empty[(Type, Type)]
       case TableAggregate(child, query) =>

--- a/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -130,20 +130,16 @@ object Simplify {
         TableFilter(t,
           ApplySpecial("&&", Array(p1, p2)))
 
-      case TableCount(TableMapGlobals(child, _, _)) => TableCount(child)
+      case TablePartitionCounts(TableMapGlobals(child, _, _)) => TablePartitionCounts(child)
 
-      case TableCount(TableMapRows(child, _, _, _)) => TableCount(child)
+      case TablePartitionCounts(TableMapRows(child, _, _, _)) => TablePartitionCounts(child)
 
-      case TableCount(TableUnion(children)) =>
-        children.map(TableCount).reduce[IR](ApplyBinaryPrimOp(Add(), _, _))
+      case TablePartitionCounts(TableUnion(children)) =>
+        children.map(TablePartitionCounts).reduce[IR](ApplyBinaryPrimOp(Add(), _, _))
 
-      case TableCount(TableKeyBy(child, _, _, _)) => TableCount(child)
+      case TablePartitionCounts(TableKeyBy(child, _, _, _)) => TablePartitionCounts(child)
 
-      case TableCount(TableUnkey(child)) => TableCount(child)
-
-      case TableCount(TableRange(n, _)) => I64(n)
-
-      case TableCount(TableParallelize(_, rows, _)) => I64(rows.length)
+      case TablePartitionCounts(TableUnkey(child)) => TablePartitionCounts(child)
 
         // flatten unions
       case TableUnion(children) if children.exists(_.isInstanceOf[TableUnion]) =>

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -232,7 +232,7 @@ object TypeCheck {
         assert(x.typ == query.typ)
       case TableWrite(_, _, _, _) =>
       case TableExport(_, _, _, _, _) =>
-      case TableCount(_) =>
+      case TablePartitionCounts(_) =>
     }
   }
 }

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -289,14 +289,9 @@ class Table(val hc: HailContext, val tir: TableIR) {
 
   def fieldNames: Array[String] = fields.map(_.name)
 
-  def partitionCounts(): IndexedSeq[Long] = {
-    tir.partitionCounts match {
-      case Some(counts) => counts
-      case None => rvd.countPerPartition()
-    }
-  }
+  def partitionCounts(): IndexedSeq[Long] = tir.partitionCounts
 
-  def count(): Long = ir.Interpret[Long](ir.TableCount(tir))
+  def count(): Long = tir.count()
 
   def forceCount(): Long = rvd.count()
 

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -514,12 +514,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
   lazy val MatrixValue(_, globals, colValues, rvd) = value
 
-  def partitionCounts(): Array[Long] = {
-    ast._partitionCounts match {
-      case Some(counts) => counts.toArray
-      case None => rvd.countPerPartition()
-    }
-  }
+  def partitionCounts(): Array[Long] = ast.partitionCounts.toArray
 
   // length nPartitions + 1, first element 0, last element rvd count
   def partitionStarts(): Array[Long] = partitionCounts().scanLeft(0L)(_ + _)

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -515,7 +515,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   lazy val MatrixValue(_, globals, colValues, rvd) = value
 
   def partitionCounts(): Array[Long] = {
-    ast.partitionCounts match {
+    ast._partitionCounts match {
       case Some(counts) => counts.toArray
       case None => rvd.countPerPartition()
     }
@@ -909,9 +909,9 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
   def count(): (Long, Long) = (countRows(), countCols())
 
-  def countRows(): Long = Interpret(TableCount(MatrixRowsTable(ast)))
+  def countRows(): Long = ast.rowCount
 
-  def countCols(): Long = ast.columnCount.map(_.toLong).getOrElse(Interpret[Long](TableCount(MatrixColsTable(ast))))
+  def countCols(): Long = ast.columnCount
 
   def forceCountRows(): Long = rvd.count()
 

--- a/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -258,8 +258,8 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testTableCount() {
-    assertEvalsTo(TableCount(TableRange(0, 4)), 0L)
-    assertEvalsTo(TableCount(TableRange(7, 4)), 7L)
+    assertEvalsTo(TablePartitionCounts(TableRange(0, 4)), FastIndexedSeq())
+    assertEvalsTo(TablePartitionCounts(TableRange(7, 4)), FastIndexedSeq(2L, 2L, 2L, 1L))
   }
 
   @Test def testGroupByKey() {

--- a/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -426,7 +426,7 @@ class PruneSuite extends SparkSuite {
   }
 
   @Test def testTableCountMemo() {
-    checkMemo(TableCount(tab), TInt64(), Array(subsetTable(tab.typ)))
+    checkMemo(TablePartitionCounts(tab), TInt64(), Array(subsetTable(tab.typ)))
   }
 
   @Test def testTableAggregateMemo() {

--- a/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -426,7 +426,7 @@ class PruneSuite extends SparkSuite {
   }
 
   @Test def testTableCountMemo() {
-    checkMemo(TablePartitionCounts(tab), TInt64(), Array(subsetTable(tab.typ)))
+    checkMemo(TablePartitionCounts(tab), TArray(TInt64()), Array(subsetTable(tab.typ)))
   }
 
   @Test def testTableAggregateMemo() {


### PR DESCRIPTION
@tpoterba this builds on your recent PR https://github.com/hail-is/hail/pull/3882

partition counts are computed through Interpret on demand and memoized in the IR.  fastPartitionCounts means get the partition counts if you have them (either because the IR know their partition counts, or they were previously computed by counting the RVD partitions).  partitionCounts means compute (and memoize) if they aren't available the fast way.

I think this is now optimal except that MatrixTable.count potentially runs things twice.  We might be able to fix this with a MatrixLet in the case you're calling MatrixTable.count().

Next Table.index/MatrixTable.indexRows should use partitionCounts instead of zipWithIndex because computing the partition counts via the optimizer will potentially be much faster.
