### PR TITLE
Fix Type Error When PAR is Empty

### DIFF
--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -215,7 +215,10 @@ def impute_sex(call, aaf_threshold=0.0, include_par=False, female_threshold=0.2,
                              hl.map(lambda x_contig: hl.parse_locus_interval(x_contig, rg), rg.x_contigs),
                              keep=True)
     if not include_par:
-        mt = hl.filter_intervals(mt, rg.par, keep=False)
+        interval_type = hl.tarray(hl.tinterval(hl.tlocus(rg)))
+        mt = hl.filter_intervals(mt,
+                                 hl.literal(rg.par, interval_type),
+                                 keep=False)
 
     mt = mt.filter_rows((mt[aaf] > aaf_threshold) & (mt[aaf] < (1 - aaf_threshold)))
     mt = mt.annotate_cols(ib=agg.inbreeding(mt.call, mt[aaf]))


### PR DESCRIPTION
Hail should not signal an error if the PAR is empty. This change provides an explicit type to the PAR before handing it to filter_intervals. 

@tpoterba assigning you because I want to make sure I'm doing this right.