### PR TITLE
Fix AbstractBinaryReader.readLong and add test for it

### DIFF
--- a/src/main/scala/is/hail/io/AbstractBinaryReader.scala
+++ b/src/main/scala/is/hail/io/AbstractBinaryReader.scala
@@ -28,8 +28,14 @@ abstract class AbstractBinaryReader {
   }
 
   def readLong(): Long =
-    (read() & 0xff) | ((read() & 0xff) << 8) | ((read() & 0xff) << 16) | ((read() & 0xff) << 24) |
-      ((read() & 0xff) << 32) | ((read() & 0xff) << 40) | ((read() & 0xff) << 48) | ((read() & 0xff) << 56)
+    (read() & 0xff).asInstanceOf[Long] |
+  ((read() & 0xff).asInstanceOf[Long] << 8) |
+  ((read() & 0xff).asInstanceOf[Long] << 16) |
+  ((read() & 0xff).asInstanceOf[Long] << 24) |
+  ((read() & 0xff).asInstanceOf[Long] << 32) |
+  ((read() & 0xff).asInstanceOf[Long] << 40) |
+  ((read() & 0xff).asInstanceOf[Long] << 48) |
+  ((read() & 0xff).asInstanceOf[Long] << 56)
 
   def readInt(): Int =
     (read() & 0xff) | ((read() & 0xff) << 8) | ((read() & 0xff) << 16) | ((read() & 0xff) << 24)

--- a/src/test/scala/is/hail/io/ByteArrayReaderSuite.scala
+++ b/src/test/scala/is/hail/io/ByteArrayReaderSuite.scala
@@ -15,6 +15,13 @@ class ByteArrayReaderSuite extends TestNGSuite {
   def readLongReadsALong2() {
     val a = Array(0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8)
       .map(_.toByte)
+    assert(new ByteArrayReader(a).readLong() == 0xf8f7f6f5f4f3f2f1L)
+  }
+
+  @Test
+  def readLongReadsALong3() {
+    val a = Array(0xf8, 0xf7, 0xf6, 0xf5, 0xf4, 0xf3, 0xf2, 0xf1)
+      .map(_.toByte)
     assert(new ByteArrayReader(a).readLong() == 0xf1f2f3f4f5f6f7f8L)
   }
 }

--- a/src/test/scala/is/hail/io/ByteArrayReaderSuite.scala
+++ b/src/test/scala/is/hail/io/ByteArrayReaderSuite.scala
@@ -1,0 +1,20 @@
+package is.hail.io
+
+import org.testng.annotations.Test
+import org.scalatest.testng.TestNGSuite
+
+class ByteArrayReaderSuite extends TestNGSuite {
+  @Test
+  def readLongReadsALong() {
+    val a = Array(0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff)
+      .map(_.toByte)
+    assert(new ByteArrayReader(a).readLong() == -1L)
+  }
+
+  @Test
+  def readLongReadsALong2() {
+    val a = Array(0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8)
+      .map(_.toByte)
+    assert(new ByteArrayReader(a).readLong() == 0xf1f2f3f4f5f6f7f8L)
+  }
+}


### PR DESCRIPTION
I discovered this while working on BGEN things. 