### PR TITLE
Small c++ build system tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ python/**/*.pyc
 python/hail/docs/_build/*
 src/main/c/libsimdpp-2.0-rc2.tar.gz
 src/main/c/libsimdpp-2.0-rc2
+src/main/c/headers
+src/main/c/lib/**/*.so
 target
 src/main/resources/build-info.properties
 src/test/resources/example.v11.bgen.idx

--- a/src/main/c/Makefile
+++ b/src/main/c/Makefile
@@ -105,6 +105,6 @@ libsimdpp-2.0-rc2: libsimdpp-2.0-rc2.tar.gz
 	tar -xzf libsimdpp-2.0-rc2.tar.gz
 
 $(shared_library): libsimdpp-2.0-rc2 ${OBJECTS}
-	mkdir -p $(basename $(shared_library))
+	mkdir -p $(dir $(shared_library))
 	${CXX} ${LIBFLAGS} ${LIBDIRS} ${CXXFLAGS} ${OBJECTS} -o $@ 
 


### PR DESCRIPTION
Adds ignore for the header sentinel file, linux (and technically other OSes) built shared object. Also replaces `basename` with `dir` to not create an extra empty directory during compilation.