### PR TITLE
Safer scans

### DIFF
--- a/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -1200,7 +1200,6 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR, newKey: Option[(IndexedSeq
         }
       } else Array.fill(prev.rvd.getNumPartitions)(Array.empty[RegionValueAggregator])
 
-
     val mapPartitionF = {(i: Int, ctx: RVDContext, it: Iterator[RegionValue]) =>
       val partitionAggs = scanAggsPerPartition(i)
       val rvb = new RegionValueBuilder()

--- a/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -463,6 +463,7 @@ case class TableMapRows(child: TableIR, newRow: IR, newKey: Option[IndexedSeq[St
         val globals = rvb.end()
         it.foreach { rv =>
           scanSeqOps()(rv.region, scanAggs, globals, false, rv.offset, false)
+          ctx.region.clear()
         }
         scanAggs
       }.scanLeft(scanAggs) { (a1, a2) =>

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -371,9 +371,9 @@ trait RVD {
     }.collect()
 
   def collectPerPartition[T : ClassTag](f: (RVDContext, Iterator[RegionValue]) => T): Array[T] =
-    clearingRun(crdd.cmapPartitions{ (ctx, it) =>
+    crdd.cmapPartitions { (ctx, it) =>
       Iterator.single(f(ctx, it))
-    }).collect()
+    }.collect()
 
   protected def persistRVRDD(level: StorageLevel): PersistedRVRDD = {
     val localRowType = rowType


### PR DESCRIPTION
Fixes #3920

I'm a bit dubious on `collectPerPartitions` because it can only be safely used if there's a `ctx.region.clear` in the right spot. This should avoid some issues that caitlin was experiencing.

The root issue is that `clearingRun` clears once per item, but, after the `cmapPartitions` there is only one item per partition. That item was produced by iterating through every element (with `it.foreach`) and accumulating some state. When `it.foreach` is finished, the entire partition will be in memory. On sufficiently large datasets, YARN will kill the executors for exceeding memory limits. We previously observed these errors coming from Java, but now that the regions are in native code, there are no JVM limits, the memory usage is instead noticed by YARN at the container-level.

The fix is to clear after we are finished with each row, i.e. before the lambda passed to `foreach` returns.