### PR TITLE
Add option to stage Table/MatrixTable writes locally before copying to final storage location

### DIFF
--- a/python/hail/linalg/blockmatrix.py
+++ b/python/hail/linalg/blockmatrix.py
@@ -511,8 +511,9 @@ class BlockMatrix(object):
         return self._jbm.toBreezeMatrix().apply(0, 0)
 
     @typecheck_method(path=str,
-                      force_row_major=bool)
-    def write(self, path, force_row_major=False):
+                      force_row_major=bool,
+                      stage_locally=bool)
+    def write(self, path, force_row_major=False, stage_locally=False):
         """Writes the block matrix.
 
         Parameters
@@ -523,8 +524,11 @@ class BlockMatrix(object):
             If ``True``, transform blocks in column-major format
             to row-major format before writing.
             If ``False``, write blocks in their current format.
+        stage_locally: :obj:`bool`
+            If ``True``, major output will be written to temporary local storage
+            before being copied to ``output``.
         """
-        self._jbm.write(path, force_row_major)
+        self._jbm.write(path, force_row_major, stage_locally)
 
     @staticmethod
     @typecheck(entry_expr=expr_float64,

--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -2090,7 +2090,8 @@ class MatrixTable(ExprContainer):
     @typecheck_method(output=str,
                       overwrite=bool,
                       _codec_spec=nullable(str))
-    def write(self, output: str, overwrite: bool = False, _codec_spec: Optional[str] = None):
+    def write(self, output: str, overwrite: bool = False, stage_locally: bool = False,
+              _codec_spec: Optional[str] = None):
         """Write to disk.
 
         Examples
@@ -2110,7 +2111,7 @@ class MatrixTable(ExprContainer):
             If ``True``, overwrite an existing file at the destination.
         """
 
-        self._jvds.write(output, overwrite, _codec_spec)
+        self._jvds.write(output, overwrite, stage_locally, _codec_spec)
 
     def globals_table(self) -> Table:
         """Returns a table with a single row with the globals of the matrix table.

--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -2108,6 +2108,9 @@ class MatrixTable(ExprContainer):
         ----------
         output : str
             Path at which to write.
+        stage_locally: bool
+            If ``True``, major output will be written to temporary local storage
+            before being copied to ``output``
         overwrite : bool
             If ``True``, overwrite an existing file at the destination.
         """

--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -2089,6 +2089,7 @@ class MatrixTable(ExprContainer):
 
     @typecheck_method(output=str,
                       overwrite=bool,
+                      stage_locally=bool,
                       _codec_spec=nullable(str))
     def write(self, output: str, overwrite: bool = False, stage_locally: bool = False,
               _codec_spec: Optional[str] = None):

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -1161,6 +1161,9 @@ class Table(ExprContainer):
         ----------
         output : str
             Path at which to write.
+        stage_locally: bool
+            If ``True``, major output will be written to temporary local storage
+            before being copied to ``output``.
         overwrite : bool
             If ``True``, overwrite an existing file at the destination.
         """

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -1142,8 +1142,10 @@ class Table(ExprContainer):
 
     @typecheck_method(output=str,
                       overwrite=bool,
+                      stage_locally=bool,
                       _codec_spec=nullable(str))
-    def write(self, output, overwrite=False, _codec_spec=None):
+    def write(self, output: str, overwrite = False, stage_locally: bool = False,
+              _codec_spec: Optional[str] = None):
         """Write to disk.
 
         Examples
@@ -1163,7 +1165,7 @@ class Table(ExprContainer):
             If ``True``, overwrite an existing file at the destination.
         """
 
-        self._jt.write(output, overwrite, _codec_spec)
+        self._jt.write(output, overwrite, stage_locally, _codec_spec)
 
     @typecheck_method(n=int, width=int, truncate=nullable(int), types=bool)
     def show(self, n=10, width=90, truncate=None, types=True):

--- a/python/test/test_hail/linalg/test_linalg.py
+++ b/python/test/test_hail/linalg/test_linalg.py
@@ -742,3 +742,12 @@ class Tests(unittest.TestCase):
             contig_cum_len=[0, 1, 1, 3, 5, 6, 7])
 
         self.assertEqual(res, [0, 0, 2, 2, 4, 6])
+
+    def test_stage_locally(self):
+        nd = np.arange(0, 80, dtype=float).reshape(8, 10)
+        rects = [[0, 1, 0, 1], [4, 5, 7, 8]]
+        bm_uri = new_temp_file()
+        BlockMatrix.from_numpy(nd, block_size=3).write(bm_uri, stage_locally=True)
+
+        bm = BlockMatrix.read(bm_uri)
+        self._assert_eq(nd, bm)

--- a/python/test/test_hail/linalg/test_linalg.py
+++ b/python/test/test_hail/linalg/test_linalg.py
@@ -745,7 +745,6 @@ class Tests(unittest.TestCase):
 
     def test_stage_locally(self):
         nd = np.arange(0, 80, dtype=float).reshape(8, 10)
-        rects = [[0, 1, 0, 1], [4, 5, 7, 8]]
         bm_uri = new_temp_file()
         BlockMatrix.from_numpy(nd, block_size=3).write(bm_uri, stage_locally=True)
 

--- a/python/test/test_hail/matrixtable/test_matrix_table.py
+++ b/python/test/test_hail/matrixtable/test_matrix_table.py
@@ -818,3 +818,11 @@ class Tests(unittest.TestCase):
                                     mt.stats.homozygote_count[1]))
         rt = mt.rows()
         self.assertTrue(rt.all(rt.hw == rt.hw2))
+
+    def test_write_stage_locally(self):
+        mt = self.get_vds()
+        f = new_temp_file(suffix='mt')
+        mt.write(f, stage_locally=True)
+
+        mt2 = hl.read_matrix_table(f)
+        self.assertTrue(mt._same(mt2))

--- a/python/test/test_hail/table/test_table.py
+++ b/python/test/test_hail/table/test_table.py
@@ -551,6 +551,6 @@ class Tests(unittest.TestCase):
     def test_write_stage_locally(self):
         t = hl.utils.range_table(5)
         f = new_temp_file(suffix='ht')
-        t.write(f, stage_locally=true)
+        t.write(f, stage_locally=True)
         t2 = hl.read_table(f)
         self.assertTrue(t._same(t2))

--- a/python/test/test_hail/table/test_table.py
+++ b/python/test/test_hail/table/test_table.py
@@ -5,6 +5,7 @@ import pyspark.sql
 
 import hail as hl
 import hail.expr.aggregators as agg
+from hail.utils import new_temp_file
 from hail.utils.java import Env
 from ..helpers import *
 
@@ -546,3 +547,10 @@ class Tests(unittest.TestCase):
         t = t.explode('a')
         self.assertEqual(set(t.collect()),
                          {hl.struct(idx=0, a='a').value, hl.struct(idx=0, a='b').value, hl.struct(idx=0, a='c').value})
+
+    def test_write_stage_locally(self):
+        t = hl.utils.range_table(5)
+        f = new_temp_file(suffix='ht')
+        t.write(f, stage_locally=true)
+        t2 = hl.read_table(f)
+        self.assertTrue(t._same(t2))

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -104,7 +104,7 @@ object Children {
     // from TableIR
     case TableCount(child) => IndexedSeq(child)
     case TableAggregate(child, query) => IndexedSeq(child, query)
-    case TableWrite(child, _, _, _) => IndexedSeq(child)
+    case TableWrite(child, _, _, _, _) => IndexedSeq(child)
     case TableExport(child, _, _, _, _) => IndexedSeq(child)
   }
 }

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -144,9 +144,9 @@ object Copy {
       case TableAggregate(_, _) =>
         val IndexedSeq(child: TableIR, query: IR) = newChildren
         TableAggregate(child, query)
-      case TableWrite(_, path, overwrite, codecSpecJSONStr) =>
+      case TableWrite(_, path, overwrite, stageLocally, codecSpecJSONStr) =>
         val IndexedSeq(child: TableIR) = newChildren
-        TableWrite(child, path, overwrite, codecSpecJSONStr)
+        TableWrite(child, path, overwrite, stageLocally, codecSpecJSONStr)
       case TableExport(_, path, typesFile, header, exportType) =>
         val IndexedSeq(child: TableIR) = newChildren
         TableExport(child, path, typesFile, header, exportType)

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -205,6 +205,7 @@ final case class TableWrite(
   child: TableIR,
   path: String,
   overwrite: Boolean = true,
+  stageLocally: Boolean = false,
   codecSpecJSONStr: String = null) extends IR {
   val typ: Type = TVoid
 }

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -565,10 +565,10 @@ object Interpret {
       case MatrixWrite(child, f) =>
         val mv = child.execute(HailContext.get)
         f(mv)
-      case TableWrite(child, path, overwrite, codecSpecJSONStr) =>
+      case TableWrite(child, path, overwrite, stageLocally, codecSpecJSONStr) =>
         val hc = HailContext.get
         val tableValue = child.execute(hc)
-        tableValue.write(path, overwrite, codecSpecJSONStr)
+        tableValue.write(path, overwrite, stageLocally, codecSpecJSONStr)
       case TableExport(child, path, typesFile, header, exportType) =>
         val hc = HailContext.get
         val tableValue = child.execute(hc)

--- a/src/main/scala/is/hail/expr/ir/MatrixValue.scala
+++ b/src/main/scala/is/hail/expr/ir/MatrixValue.scala
@@ -79,7 +79,7 @@ case class MatrixValue(
       hadoopConf.writeTextFile(path + "/_SUCCESS")(out => ())
     }
 
-    def write(path: String, overwrite: Boolean = false, codecSpecJSONStr: String = null): Unit = {
+    def write(path: String, overwrite: Boolean = false, stageLocally: Boolean = false, codecSpecJSONStr: String = null) = {
       val hc = HailContext.get
       val hadoopConf = hc.hadoopConf
 
@@ -98,7 +98,7 @@ case class MatrixValue(
 
       hc.hadoopConf.mkDir(path)
 
-      val partitionCounts = rvd.writeRowsSplit(path, typ, codecSpec)
+      val partitionCounts = rvd.writeRowsSplit(path, typ, codecSpec, stageLocally)
 
       val globalsPath = path + "/globals"
       hadoopConf.mkDir(globalsPath)

--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -214,7 +214,7 @@ object Pretty {
                   "None"
                 else
                   typ.parsableString())
-            case TableWrite(_, path, overwrite, _) =>
+            case TableWrite(_, path, overwrite, _, _) =>
               if (overwrite)
                 s"${ StringEscapeUtils.escapeString(path) } overwrite"
               else

--- a/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -54,7 +54,7 @@ case class TableValue(typ: TableType, globals: BroadcastRow, rvd: RVD) {
     }))
   }
 
-  def write(path: String, overwrite: Boolean, codecSpecJSONStr: String) {
+  def write(path: String, overwrite: Boolean, stageLocally: Boolean, codecSpecJSONStr: String) {
     val hc = HailContext.get
 
     val codecSpec =

--- a/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -76,7 +76,7 @@ case class TableValue(typ: TableType, globals: BroadcastRow, rvd: RVD) {
     hc.hadoopConf.mkDir(globalsPath)
     RVD.writeLocalUnpartitioned(hc, globalsPath, typ.globalType, codecSpec, Array(globals.value))
 
-    val partitionCounts = enforceOrderingRVD.write(path + "/rows", codecSpec)
+    val partitionCounts = enforceOrderingRVD.write(path + "/rows", stageLocally, codecSpec)
 
     val referencesPath = path + "/references"
     hc.hadoopConf.mkDir(referencesPath)

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -237,7 +237,7 @@ object TypeCheck {
               env.bind(n, t)
           }))
         assert(x.typ == query.typ)
-      case TableWrite(_, _, _, _) =>
+      case TableWrite(_, _, _, _, _) =>
       case TableExport(_, _, _, _, _) =>
       case TableCount(_) =>
     }

--- a/src/main/scala/is/hail/io/RowStore.scala
+++ b/src/main/scala/is/hail/io/RowStore.scala
@@ -1090,8 +1090,8 @@ object RichContextRDDRegionValue {
 }
 
 class RichContextRDDRegionValue(val crdd: ContextRDD[RVDContext, RegionValue]) extends AnyVal {
-  def writeRows(path: String, t: TStruct, codecSpec: CodecSpec): (Array[String], Array[Long]) = {
-    crdd.writePartitions(path, RichContextRDDRegionValue.writeRowsPartition(codecSpec.buildEncoder(t)))
+  def writeRows(path: String, t: TStruct, stageLocally: Boolean, codecSpec: CodecSpec): (Array[String], Array[Long]) = {
+    crdd.writePartitions(path, stageLocally, RichContextRDDRegionValue.writeRowsPartition(codecSpec.buildEncoder(t)))
   }
 
   def writeRowsSplit(

--- a/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -694,7 +694,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     result
   }
 
-  def write(uri: String, forceRowMajor: Boolean = false) {
+  def write(uri: String, forceRowMajor: Boolean = false, stageLocally: Boolean = false) {
     val hadoop = blocks.sparkContext.hadoopConfiguration
     hadoop.mkDir(uri)
 
@@ -709,7 +709,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       1
     }
 
-    val (partFiles, _) = blocks.writePartitions(uri, writeBlock)
+    val (partFiles, _) = blocks.writePartitions(uri, stageLocally, writeBlock)
 
     hadoop.writeDataFile(uri + metadataRelativePath) { os =>
       implicit val formats = defaultJSONFormats

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -461,8 +461,9 @@ class OrderedRVD(
   def writeRowsSplit(
     path: String,
     t: MatrixType,
-    codecSpec: CodecSpec
-  ): Array[Long] = crdd.writeRowsSplit(path, t, codecSpec, partitioner)
+    codecSpec: CodecSpec,
+    stageLocally: Boolean
+  ): Array[Long] = crdd.writeRowsSplit(path, t, codecSpec, partitioner, stageLocally)
 
   override def toUnpartitionedRVD: UnpartitionedRVD =
     new UnpartitionedRVD(typ.rowType, crdd)

--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -435,8 +435,8 @@ trait RVD {
 
   protected def rvdSpec(codecSpec: CodecSpec, partFiles: Array[String]): RVDSpec
 
-  final def write(path: String, codecSpec: CodecSpec): Array[Long] = {
-    val (partFiles, partitionCounts) = crdd.writeRows(path, rowType, codecSpec)
+  final def write(path: String, stageLocally: Boolean, codecSpec: CodecSpec): Array[Long] = {
+    val (partFiles, partitionCounts) = crdd.writeRows(path, rowType, stageLocally, codecSpec)
     rvdSpec(codecSpec, partFiles).write(sparkContext.hadoopConfiguration, path)
     partitionCounts
   }

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -794,8 +794,8 @@ class Table(val hc: HailContext, val tir: TableIR) {
   }
 
 
-  def write(path: String, overwrite: Boolean = false, codecSpecJSONStr: String = null) {
-    ir.Interpret(ir.TableWrite(tir, path, overwrite, codecSpecJSONStr))
+  def write(path: String, overwrite: Boolean = false, stageLocally: Boolean = false, codecSpecJSONStr: String = null) {
+    ir.Interpret(ir.TableWrite(tir, path, overwrite, stageLocally, codecSpecJSONStr))
   }
 
   def cache(): Table = persist("MEMORY_ONLY")

--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -227,5 +227,6 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
   ): (Array[String], Array[Long]) =
     ContextRDD.weaken[RVDContext](r).writePartitions(
       path,
+      false,
       (_, it, os) => write(it, os))
 }

--- a/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -221,12 +221,14 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
       .subsetPartitions((0 to idxLast).toArray)
   }
 
-  def writePartitions(path: String,
+  def writePartitions(
+    path: String,
+    stageLocally: Boolean,
     write: (Iterator[T], OutputStream) => Long
   )(implicit tct: ClassTag[T]
   ): (Array[String], Array[Long]) =
     ContextRDD.weaken[RVDContext](r).writePartitions(
       path,
-      false,
+      stageLocally,
       (_, it, os) => write(it, os))
 }

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -1712,8 +1712,8 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     }
   }
 
-  def write(path: String, overwrite: Boolean = false, codecSpecJSONStr: String = null) {
-    ir.Interpret(ir.MatrixWrite(ast, _.write(path, overwrite, codecSpecJSONStr)))
+  def write(path: String, overwrite: Boolean = false, stageLocally: Boolean = false, codecSpecJSONStr: String = null) {
+    ir.Interpret(ir.MatrixWrite(ast, _.write(path, overwrite, stageLocally, codecSpecJSONStr)))
   }
 
   def exportPlink(path: String) {


### PR DESCRIPTION
If the option is set, then writeRowsSplit for MatrixTable and writePartitions for Table
first write much of their output to tempfiles before copying it to the final destination.