### PR TITLE
lmm2 test improvements and h_sq_standard_error

### DIFF
--- a/python/test/test_hail/methods/test_statgen.py
+++ b/python/test/test_hail/methods/test_statgen.py
@@ -1236,43 +1236,6 @@ class Tests(unittest.TestCase):
         assert lmm_vs_numpy_p_value[10] < 1e-12  # 10 least p-values
         assert lmm_vs_numpy_p_value[-1] < 1e-8   # all p-values
 
-        # compare LinearMixedModel and LinearMixedRegression
-        y_bc = hl.literal(list(y.reshape(n_samples)))
-        cov1_bc = hl.literal(list(x[:, 1]))
-        cov2_bc = hl.literal(list(x[:, 2]))
-
-        mt = mt.annotate_cols(y = y_bc[mt.sample_idx],
-                              cov1 = cov1_bc[mt.sample_idx],
-                              cov2 = cov2_bc[mt.sample_idx])
-        mt = mt.annotate_cols(s = hl.str(mt.sample_idx)).key_cols_by('s')
-
-        mt_markers = mt.filter_rows(mt.locus.position > n_variants - n_orig_markers)
-        rrm = hl.realized_relationship_matrix(mt_markers.GT)
-        mt_lmr = hl.linear_mixed_regression(rrm, mt.y,
-                                            mt.GT.n_alt_alleles(),
-                                            [mt.cov1, mt.cov2],
-                                            n_eigenvectors=n_eigenvectors)
-
-        delta = mt_lmr.lmmreg_global.delta.value
-        assert np.isclose(delta, 1 / model.gamma)
-
-        ht_lmr = mt_lmr.rows()
-        df_lmr = ht_lmr.select(beta = ht_lmr.lmmreg.beta,
-                               sigma_sq = ht_lmr.lmmreg.sigma_g_squared,
-                               chi_sq = ht_lmr.lmmreg.chi_sq_stat,
-                               p_value = ht_lmr.lmmreg.p_value).to_pandas()
-
-        na_lmr = df_lmr.isna().any(axis=1)
-
-        assert na_lmr.sum() <= 10
-        assert np.logical_xor(na_numpy, na_lmm).sum() <= 5
-        mask = ~(na_lmm | na_lmr)
-
-        lmm_vs_lmr_p_value = np.sort(np.abs(df_lmm['p_value'][mask] - df_lmr['p_value'][mask]))
-
-        assert lmm_vs_lmr_p_value[10] < 1e-7  # 10 least p-values
-        assert lmm_vs_lmr_p_value[-1] < 2e-3  # all p-values
-
     def test_linear_mixed_model_full_rank(self):
         seed = 0
         n_populations = 8
@@ -1353,38 +1316,144 @@ class Tests(unittest.TestCase):
         assert lmm_vs_numpy_p_value[10] < 1e-12  # 10 least p-values
         assert lmm_vs_numpy_p_value[-1] < 1e-8  # all p-values
 
-        # compare LinearMixedModel and LinearMixedRegression
-        y_bc = hl.literal(list(y.reshape(n_samples)))
-        cov1_bc = hl.literal(list(x[:, 1]))
-        cov2_bc = hl.literal(list(x[:, 2]))
+    def test_linear_mixed_model_fastlmm(self):
+        # FastLMM Test data is from all.bed, all.bim, all.fam, cov.txt, pheno_10_causals.txt:
+        #   https://github.com/MicrosoftGenomics/FaST-LMM/tree/master/tests/datasets/synth
+        #
+        # Data is filtered to chromosome 1,3 and samples 0-124,375-499 (2000 variants and 250 samples)
+        #
+        # Results are computed with single_snp (with LOCO) as in:
+        #   https://github.com/MicrosoftGenomics/FaST-LMM/blob/master/doc/ipynb/FaST-LMM.ipynb
 
-        mt = mt.annotate_cols(y = y_bc[mt.sample_idx],
-                              cov1 = cov1_bc[mt.sample_idx],
-                              cov2 = cov2_bc[mt.sample_idx])
-        mt = mt.annotate_cols(s = hl.str(mt.sample_idx)).key_cols_by('s')
+        n, m = 250, 1000  # per chromosome
 
-        mt_markers = mt.filter_rows(mt.locus.position > n_variants - n_orig_markers)
-        rrm = hl.realized_relationship_matrix(mt_markers.GT)
-        mt_lmr = hl.linear_mixed_regression(rrm, mt.y,
-                                            mt.GT.n_alt_alleles(),
-                                            [mt.cov1, mt.cov2])
+        x_table = hl.import_table(resource('fastlmmCov.txt'), no_header=True, impute=True).key_by('f1')
+        y_table = hl.import_table(resource('fastlmmPheno.txt'), no_header=True, impute=True, delimiter=' ').key_by('f1')
 
-        delta = mt_lmr.lmmreg_global.delta.value
-        assert np.isclose(delta, 1 / model.gamma)
+        mt = hl.import_plink(bed=resource('fastlmmTest.bed'),
+                             bim=resource('fastlmmTest.bim'),
+                             fam=resource('fastlmmTest.fam'),
+                             reference_genome=None)
+        mt = mt.annotate_cols(x=x_table[mt.col_key].f2)
+        mt = mt.annotate_cols(y=y_table[mt.col_key].f2).cache()
 
-        ht_lmr = mt_lmr.rows()
-        df_lmr = ht_lmr.select(beta = ht_lmr.lmmreg.beta,
-                               sigma_sq = ht_lmr.lmmreg.sigma_g_squared,
-                               chi_sq = ht_lmr.lmmreg.chi_sq_stat,
-                               p_value = ht_lmr.lmmreg.p_value).to_pandas()
+        x = np.array([np.ones(n), mt.x.collect()]).T
+        y = np.array(mt.y.collect())
 
-        na_lmr = df_lmr.isna().any(axis=1)
+        mt_chr1 = mt.filter_rows(mt.locus.contig == '1')
+        mt_chr3 = mt.filter_rows(mt.locus.contig == '3')
 
-        assert na_lmr.sum() <= 20
-        assert np.logical_xor(na_numpy, na_lmm).sum() <= 10
-        mask = ~(na_lmm | na_lmr)
+        # testing chrom 1 for h2, betas, p-values
+        h2_fastlmm = 0.14276125
+        h2_std_error = 0.13770773  # FIXME migrate additional check
+        beta_fastlmm = [0.012202061, 0.037718282, -0.033572693, 0.29171541, -0.045644170]
 
-        lmm_vs_lmr_p_value = np.sort(np.abs(df_lmm['p_value'][mask] - df_lmr['p_value'][mask]))
+        # FastLMM p-values do not agree to high precision because FastLMM regresses
+        # out x from each SNP first and does an F(1, dof)-test on (beta / se)^2
+        # (a t(dof)-test), whereas Hail does LRT on chi_sq (a z-test).
+        # We verify below that Hail's p-values remain fixed going forward.
+        # fastlmm = [0.84650294, 0.57865098, 0.59050998, 1.6649473e-06, 0.46892059]
+        pval_hail = [0.84543084, 0.57596760, 0.58788517, 1.4057279e-06, 0.46578204]
 
-        assert lmm_vs_lmr_p_value[10] < 1e-7  # 10 least p-values
-        assert lmm_vs_lmr_p_value[-1] < 2e-3  # all p-values
+        gamma_fastlmm = h2_fastlmm / (1 - h2_fastlmm)
+
+        g = BlockMatrix.from_entry_expr(mt_chr1.GT.n_alt_alleles()).to_numpy().T
+        g_std = self._standardize_cols(g)
+
+        # full rank
+        k = (g_std @ g_std.T) * (n / m)
+        s, u = np.linalg.eigh(k)
+        p = u.T
+        model = hl.LinearMixedModel(p @ y, p @ x, s)
+        model.fit()
+
+        assert np.isclose(model.h_sq, h2_fastlmm)
+        assert np.isclose(model.h_sq_standard_error, h2_std_error)
+
+        mt3_chr3_5var = mt_chr3.filter_rows(mt_chr3.locus.position < 2005)
+        a = BlockMatrix.from_entry_expr(mt3_chr3_5var.GT.n_alt_alleles()).to_numpy().T
+
+        # FastLMM standardizes each variant to have mean 0 and variance 1.
+        a = self._standardize_cols(a) * np.sqrt(n)
+        pa = p @ a
+
+        model.fit(log_gamma=np.log(gamma_fastlmm))
+
+        res = model.fit_alternatives_numpy(pa).to_pandas()
+
+        assert np.allclose(res['beta'], beta_fastlmm)
+        assert np.allclose(res['p_value'], pval_hail)
+
+        pa_t_path = utils.new_temp_file(suffix='bm')
+        BlockMatrix.from_numpy(pa.T).write(pa_t_path, force_row_major=True)
+
+        res = model.fit_alternatives(pa_t_path).to_pandas()
+
+        assert np.allclose(res['beta'], beta_fastlmm)
+        assert np.allclose(res['p_value'], pval_hail)
+
+        # low rank
+        l = g_std.T @ g_std
+        sl, v = np.linalg.eigh(l)
+        n_eigenvectors = int(np.sum(sl > 1e-10))
+        assert n_eigenvectors < n
+        sl = sl[-n_eigenvectors:]
+        v = v[:, -n_eigenvectors:]
+        s = sl * (n / m)
+        p = (g_std @ (v / np.sqrt(sl))).T
+        model = hl.LinearMixedModel(p @ y, p @ x, s, y, x)
+        model.fit()
+
+        assert np.isclose(model.h_sq, h2_fastlmm)
+        assert np.isclose(model.h_sq_standard_error, h2_std_error)
+
+        model.fit(log_gamma=np.log(gamma_fastlmm))
+
+        pa = p @ a
+        res = model.fit_alternatives_numpy(pa, a).to_pandas()
+
+        assert np.allclose(res['beta'], beta_fastlmm)
+        assert np.allclose(res['p_value'], pval_hail)
+
+        a_t_path = utils.new_temp_file(suffix='bm')
+        BlockMatrix.from_numpy(a.T).write(a_t_path, force_row_major=True)
+
+        pa_t_path = utils.new_temp_file(suffix='bm')
+        BlockMatrix.from_numpy(pa.T).write(pa_t_path, force_row_major=True)
+
+        res = model.fit_alternatives(pa_t_path, a_t_path).to_pandas()
+
+        assert np.allclose(res['beta'], beta_fastlmm)
+        assert np.allclose(res['p_value'], pval_hail)
+
+        # testing chrom 3 for h2
+        h2_fastlmm = 0.36733240
+        h2_std_error = 0.17409641  # FIXME migrate additional check
+
+        g = BlockMatrix.from_entry_expr(mt_chr3.GT.n_alt_alleles()).to_numpy().T
+        g_std = self._standardize_cols(g)
+
+        # full rank
+        k = (g_std @ g_std.T) * (n / m)
+        s, u = np.linalg.eigh(k)
+        p = u.T
+        model = hl.LinearMixedModel(p @ y, p @ x, s)
+        model.fit()
+
+        assert np.isclose(model.h_sq, h2_fastlmm)
+        assert np.isclose(model.h_sq_standard_error, h2_std_error)
+
+        # low rank
+        l = g_std.T @ g_std
+        sl, v = np.linalg.eigh(l)
+        n_eigenvectors = int(np.sum(sl > 1e-10))
+        assert n_eigenvectors < n
+        sl = sl[-n_eigenvectors:]
+        v = v[:, -n_eigenvectors:]
+        s = sl * (n / m)
+        p = (g_std @ (v / np.sqrt(sl))).T
+        model = hl.LinearMixedModel(p @ y, p @ x, s, y, x)
+        model.fit()
+
+        assert np.isclose(model.h_sq, h2_fastlmm)
+        assert np.isclose(model.h_sq_standard_error, h2_std_error)


### PR DESCRIPTION
- removed dependencies of lmm tests on linear_mixed_regression
- added test against fast_lmm
- added h_sq_standard_error feature from linear_mixed_regression

Toward goal of deleting linear_mixed_regression and its Scala / suites ASAP, as well as the KinshipMatrix class