### PR TITLE
add scala functions that parse IR instead of AST

### DIFF
--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -660,20 +660,18 @@ object Parser extends JavaTokenParsers {
   def ir_agg_op: Parser[ir.AggOp] =
     ir_identifier ^^ { x => ir.AggOp.fromString(x) }
 
-  def ir_children: Parser[IndexedSeq[ir.IR]] = rep(ir_value_expr) ^^ {
-    _.toFastIndexedSeq
-  }
+  def ir_children(ref_map: Map[String, (String, Type)] = Map.empty): Parser[IndexedSeq[ir.IR]] =
+    rep(ir_value_expr(ref_map)) ^^ { _.toFastIndexedSeq }
 
   def table_ir_children: Parser[IndexedSeq[ir.TableIR]] = rep(table_ir) ^^ {
     _.toFastIndexedSeq
   }
 
-  def ir_value_exprs: Parser[IndexedSeq[ir.IR]] = "(" ~> rep(ir_value_expr) <~ ")" ^^ {
-    _.toFastIndexedSeq
-  }
+  def ir_value_exprs(ref_map: Map[String, (String, Type)] = Map.empty): Parser[IndexedSeq[ir.IR]] =
+    "(" ~> rep(ir_value_expr(ref_map)) <~ ")" ^^ { _.toFastIndexedSeq }
 
-  def ir_value_exprs_opt: Parser[Option[IndexedSeq[ir.IR]]] =
-    ir_value_exprs ^^ { xs => Some(xs) } |
+  def ir_value_exprs_opt(ref_map: Map[String, (String, Type)] = Map.empty): Parser[Option[IndexedSeq[ir.IR]]] =
+    ir_value_exprs(ref_map) ^^ { xs => Some(xs) } |
       "None" ^^ { _ => None }
 
   def matrix_type_expr_opt: Parser[Option[MatrixType]] = matrix_type_expr ^^ {
@@ -689,18 +687,17 @@ object Parser extends JavaTokenParsers {
       AggSignature(op, ctorArgTypes, initOpArgTypes, seqOpArgTypes)
     }
 
-  def ir_named_value_exprs: Parser[Seq[(String, ir.IR)]] = rep(ir_named_value_expr)
+  def ir_named_value_exprs(ref_map: Map[String, (String, Type)] = Map.empty): Parser[Seq[(String, ir.IR)]] = rep(ir_named_value_expr(ref_map))
 
-  def ir_named_value_expr: Parser[(String, ir.IR)] =
-    "(" ~> ir_identifier ~ ir_value_expr <~ ")" ^^ { case n ~ x => (n, x) }
+  def ir_named_value_expr(ref_map: Map[String, (String, Type)] = Map.empty): Parser[(String, ir.IR)] =
+    "(" ~> ir_identifier ~ ir_value_expr(ref_map) <~ ")" ^^ { case n ~ x => (n, x) }
 
   def ir_opt[T](p: Parser[T]): Parser[Option[T]] = p ^^ { Some(_) } | "None" ^^ { _ => None }
 
-  def ir_value_expr: Parser[ir.IR] = "(" ~> ir_value_expr_1 <~ ")"
+  def ir_value_expr(ref_map: Map[String, (String, Type)] = Map.empty): Parser[ir.IR] = "(" ~> ir_value_expr_1(ref_map) <~ ")"
 
-  def ir_value_expr: Parser[ir.IR] = "(" ~> ir_value_expr_1 <~ ")"
-
-  def ir_value_expr_1: Parser[ir.IR] = {
+  def ir_value_expr_1(ref_map: Map[String, (String, Type)] = Map.empty): Parser[ir.IR] = {
+    def expr_with_map: Parser[ir.IR] = ir_value_expr(ref_map)
     "I32" ~> int32_literal ^^ { x => ir.I32(x) } |
       "I64" ~> int64_literal ^^ { x => ir.I64(x) } |
       "F32" ~> float32_literal ^^ { x => ir.F32(x) } |
@@ -709,48 +706,50 @@ object Parser extends JavaTokenParsers {
       "True" ^^ { x => ir.True() } |
       "False" ^^ { x => ir.False() } |
       "Void" ^^ { x => ir.Void() } |
-      "Cast" ~> type_expr ~ ir_value_expr ^^ { case t ~ v => ir.Cast(v, t) } |
+      "Cast" ~> type_expr ~ expr_with_map ^^ { case t ~ v => ir.Cast(v, t) } |
       "NA" ~> type_expr ^^ { t => ir.NA(t) } |
-      "IsNA" ~> ir_value_expr ^^ { value => ir.IsNA(value) } |
-      "If" ~> ir_value_expr ~ ir_value_expr ~ ir_value_expr ^^ { case cond ~ consq ~ altr => ir.If(cond, consq, altr) } |
-      "Let" ~> ir_identifier ~ ir_value_expr ~ ir_value_expr ^^ { case name ~ value ~ body => ir.Let(name, value, body) } |
+      "IsNA" ~> expr_with_map ^^ { value => ir.IsNA(value) } |
+      "If" ~> expr_with_map ~ expr_with_map ~ expr_with_map ^^ { case cond ~ consq ~ altr => ir.If(cond, consq, altr) } |
+      "Let" ~> ir_identifier ~ expr_with_map ~ expr_with_map ^^ { case name ~ value ~ body => ir.Let(name, value, body) } |
       "Ref" ~> type_expr ~ ir_identifier ^^ { case t ~ name => ir.Ref(name, t) } |
-      "Ref" ~> ir_identifier ^^ { name => ir.Ref(name, null) } |
-      "ApplyBinaryPrimOp" ~> ir_binary_op ~ ir_value_expr ~ ir_value_expr ^^ { case op ~ l ~ r => ir.ApplyBinaryPrimOp(op, l, r) } |
-      "ApplyUnaryPrimOp" ~> ir_unary_op ~ ir_value_expr ^^ { case op ~ x => ir.ApplyUnaryPrimOp(op, x) } |
-      "ApplyComparisonOp" ~> ir_comparison_op ~ ir_value_expr ~ ir_value_expr ^^ { case op ~ l ~ r => ir.ApplyComparisonOp(op, l, r) } |
-      "MakeArray" ~> type_expr ~ ir_children ^^ { case t ~ args => ir.MakeArray(args, t.asInstanceOf[TArray]) } |
-      "ArrayRef" ~> ir_value_expr ~ ir_value_expr ^^ { case a ~ i => ir.ArrayRef(a, i) } |
-      "ArrayLen" ~> ir_value_expr ^^ { a => ir.ArrayLen(a) } |
-      "ArrayRange" ~> ir_value_expr ~ ir_value_expr ~ ir_value_expr ^^ { case start ~ stop ~ step => ir.ArrayRange(start, stop, step) } |
-      "ArraySort" ~> boolean_literal ~ ir_value_expr ~ ir_value_expr ^^ { case onKey ~ a ~ ascending => ir.ArraySort(a, ascending, onKey) } |
-      "ToSet" ~> ir_value_expr ^^ { a => ir.ToSet(a) } |
-      "ToDict" ~> ir_value_expr ^^ { a => ir.ToDict(a) } |
-      "ToArray" ~> ir_value_expr ^^ { a => ir.ToArray(a) } |
-      "LowerBoundOnOrderedCollection" ~> boolean_literal ~ ir_value_expr ~ ir_value_expr ^^ { case onKey ~ col ~ elem => ir.LowerBoundOnOrderedCollection(col, elem, onKey) } |
-      "GroupByKey" ~> ir_value_expr ^^ { a => ir.GroupByKey(a) } |
-      "ArrayMap" ~> ir_identifier ~ ir_value_expr ~ ir_value_expr ^^ { case name ~ a ~ body => ir.ArrayMap(a, name, body) } |
-      "ArrayFilter" ~> ir_identifier ~ ir_value_expr ~ ir_value_expr ^^ { case name ~ a ~ body => ir.ArrayFilter(a, name, body) } |
-      "ArrayFlatMap" ~> ir_identifier ~ ir_value_expr ~ ir_value_expr ^^ { case name ~ a ~ body => ir.ArrayFlatMap(a, name, body) } |
-      "ArrayFold" ~> ir_identifier ~ ir_identifier ~ ir_value_expr ~ ir_value_expr ~ ir_value_expr ^^ { case accumName ~ valueName ~ a ~ zero ~ body => ir.ArrayFold(a, zero, accumName, valueName, body) } |
-      "ArrayFor" ~> ir_identifier ~ ir_value_expr ~ ir_value_expr ^^ { case name ~ a ~ body => ir.ArrayFor(a, name, body) } |
-      "ApplyAggOp" ~> agg_signature ~ ir_value_expr ~ ir_value_exprs ~ ir_value_exprs_opt ^^ { case aggSig ~ a ~ ctorArgs ~ initOpArgs => ir.ApplyAggOp(a, ctorArgs, initOpArgs, aggSig) } |
-      "ApplyScanOp" ~> agg_signature ~ ir_value_expr ~ ir_value_exprs ~ ir_value_exprs_opt ^^ { case aggSig ~ a ~ ctorArgs ~ initOpArgs => ir.ApplyScanOp(a, ctorArgs, initOpArgs, aggSig) } |
-      "InitOp" ~> agg_signature ~ ir_value_expr ~ ir_value_exprs ^^ { case aggSig ~ i ~ args => ir.InitOp(i, args, aggSig) } |
-      "SeqOp" ~> agg_signature ~ ir_value_expr ~ ir_value_exprs ^^ { case aggSig ~ i ~ args => ir.SeqOp(i, args, aggSig) } |
-      "Begin" ~> ir_children ^^ { xs => ir.Begin(xs) } |
-      "MakeStruct" ~> ir_named_value_exprs ^^ { fields => ir.MakeStruct(fields) } |
-      "SelectFields" ~> ir_identifiers ~ ir_value_expr ^^ { case fields ~ old => ir.SelectFields(old, fields) } |
-      "InsertFields" ~> ir_value_expr ~ ir_named_value_exprs ^^ { case old ~ fields => ir.InsertFields(old, fields) } |
-      "GetField" ~> ir_identifier ~ ir_value_expr ^^ { case name ~ o => ir.GetField(o, name) } |
-      "MakeTuple" ~> ir_children ^^ { xs => ir.MakeTuple(xs) } |
-      "GetTupleElement" ~> int32_literal ~ ir_value_expr ^^ { case idx ~ o => ir.GetTupleElement(o, idx) } |
-      "StringSlice" ~> ir_value_expr ~ ir_value_expr ~ ir_value_expr ^^ { case s ~ start ~ end => ir.StringSlice(s, start, end) } |
-      "StringLength" ~> ir_value_expr ^^ { s => ir.StringLength(s) } |
+      "Ref" ~> ir_identifier ^^ { id =>
+        val (name, typ) = ref_map(id)
+        ir.Ref(name, typ) } |
+      "ApplyBinaryPrimOp" ~> ir_binary_op ~ expr_with_map ~ expr_with_map ^^ { case op ~ l ~ r => ir.ApplyBinaryPrimOp(op, l, r) } |
+      "ApplyUnaryPrimOp" ~> ir_unary_op ~ expr_with_map ^^ { case op ~ x => ir.ApplyUnaryPrimOp(op, x) } |
+      "ApplyComparisonOp" ~> ir_comparison_op ~ expr_with_map ~ expr_with_map ^^ { case op ~ l ~ r => ir.ApplyComparisonOp(op, l, r) } |
+      "MakeArray" ~> type_expr ~ ir_children(ref_map) ^^ { case t ~ args => ir.MakeArray(args, t.asInstanceOf[TArray]) } |
+      "ArrayRef" ~> expr_with_map  ~ expr_with_map ^^ { case a ~ i => ir.ArrayRef(a, i) } |
+      "ArrayLen" ~> expr_with_map ^^ { a => ir.ArrayLen(a) } |
+      "ArrayRange" ~> expr_with_map  ~ expr_with_map ~ expr_with_map  ^^ { case start ~ stop ~ step => ir.ArrayRange(start, stop, step) } |
+      "ArraySort" ~> boolean_literal ~ expr_with_map ~ expr_with_map ^^ { case onKey ~ a ~ ascending => ir.ArraySort(a, ascending, onKey) } |
+      "ToSet" ~> expr_with_map ^^ { a => ir.ToSet(a) } |
+      "ToDict" ~> expr_with_map ^^ { a => ir.ToDict(a) } |
+      "ToArray" ~> expr_with_map ^^ { a => ir.ToArray(a) } |
+      "LowerBoundOnOrderedCollection" ~> boolean_literal ~ expr_with_map ~ expr_with_map ^^ { case onKey ~ col ~ elem => ir.LowerBoundOnOrderedCollection(col, elem, onKey) } |
+      "GroupByKey" ~> expr_with_map ^^ { a => ir.GroupByKey(a) } |
+      "ArrayMap" ~> ir_identifier ~ expr_with_map ~ expr_with_map ^^ { case name ~ a ~ body => ir.ArrayMap(a, name, body) } |
+      "ArrayFilter" ~> ir_identifier ~ expr_with_map ~ expr_with_map ^^ { case name ~ a ~ body => ir.ArrayFilter(a, name, body) } |
+      "ArrayFlatMap" ~> ir_identifier ~ expr_with_map ~ expr_with_map ^^ { case name ~ a ~ body => ir.ArrayFlatMap(a, name, body) } |
+      "ArrayFold" ~> ir_identifier ~ ir_identifier ~ expr_with_map ~ expr_with_map ~ expr_with_map ^^ { case accumName ~ valueName ~ a ~ zero ~ body => ir.ArrayFold(a, zero, accumName, valueName, body) } |
+      "ArrayFor" ~> ir_identifier ~ expr_with_map ~ expr_with_map ^^ { case name ~ a ~ body => ir.ArrayFor(a, name, body) } |
+      "ApplyAggOp" ~> agg_signature ~ expr_with_map ~ ir_value_exprs(ref_map) ~ ir_value_exprs_opt(ref_map) ^^ { case aggSig ~ a ~ ctorArgs ~ initOpArgs => ir.ApplyAggOp(a, ctorArgs, initOpArgs, aggSig) } |
+      "ApplyScanOp" ~> agg_signature ~ expr_with_map ~ ir_value_exprs(ref_map) ~ ir_value_exprs_opt(ref_map) ^^ { case aggSig ~ a ~ ctorArgs ~ initOpArgs => ir.ApplyScanOp(a, ctorArgs, initOpArgs, aggSig) } |
+      "InitOp" ~> agg_signature ~ expr_with_map ~ ir_value_exprs(ref_map) ^^ { case aggSig ~ i ~ args => ir.InitOp(i, args, aggSig) } |
+      "SeqOp" ~> agg_signature ~ expr_with_map ~ ir_value_exprs(ref_map) ^^ { case aggSig ~ i ~ args => ir.SeqOp(i, args, aggSig) } |
+      "Begin" ~> ir_children(ref_map) ^^ { xs => ir.Begin(xs) } |
+      "MakeStruct" ~> ir_named_value_exprs(ref_map) ^^ { fields => ir.MakeStruct(fields) } |
+      "SelectFields" ~> ir_identifiers ~ expr_with_map ^^ { case fields ~ old => ir.SelectFields(old, fields) } |
+      "InsertFields" ~> expr_with_map ~ ir_named_value_exprs(ref_map) ^^ { case old ~ fields => ir.InsertFields(old, fields) } |
+      "GetField" ~> ir_identifier ~ expr_with_map ^^ { case name ~ o => ir.GetField(o, name) } |
+      "MakeTuple" ~> ir_children(ref_map) ^^ { xs => ir.MakeTuple(xs) } |
+      "GetTupleElement" ~> int32_literal ~ expr_with_map ^^ { case idx ~ o => ir.GetTupleElement(o, idx) } |
+      "StringSlice" ~> expr_with_map ~ expr_with_map ~ expr_with_map ^^ { case s ~ start ~ end => ir.StringSlice(s, start, end) } |
+      "StringLength" ~> expr_with_map ^^ { s => ir.StringLength(s) } |
       "In" ~> type_expr ~ int32_literal ^^ { case t ~ i => ir.In(i, t) } |
       "Die" ~> type_expr ~ string_literal ^^ { case t ~ message => ir.Die(message, t) } |
-      ("ApplyIR" | "ApplySpecial" | "Apply") ~> ir_identifier ~ ir_children ^^ { case function ~ args => ir.invoke(function, args: _*) } |
-      "Uniroot" ~> ir_identifier ~ ir_value_expr ~ ir_value_expr ~ ir_value_expr ^^ { case name ~ f ~ min ~ max => ir.Uniroot(name, f, min, max) }
+      ("ApplyIR" | "ApplySpecial" | "Apply") ~> ir_identifier ~ ir_children(ref_map) ^^ { case function ~ args => ir.invoke(function, args: _*) } |
+      "Uniroot" ~> ir_identifier ~ expr_with_map ~ expr_with_map ~ expr_with_map ^^ { case name ~ f ~ min ~ max => ir.Uniroot(name, f, min, max) }
   }
 
 
@@ -773,22 +772,22 @@ object Parser extends JavaTokenParsers {
         ir.TableKeyBy(child, key, nPartKeys, sort)
       } |
       "TableDistinct" ~> table_ir ^^ { t => ir.TableDistinct(t) } |
-      "TableFilter" ~> table_ir ~ ir_value_expr ^^ { case child ~ pred => ir.TableFilter(child, pred) } |
+      "TableFilter" ~> table_ir ~ ir_value_expr() ^^ { case child ~ pred => ir.TableFilter(child, pred) } |
       "TableRead" ~> string_literal ~ boolean_literal ~ ir_opt(table_type_expr) ^^ { case path ~ dropRows ~ typ =>
         TableIR.read(HailContext.get, path, dropRows, typ)
       } |
       "MatrixColsTable" ~> matrix_ir ^^ { child => ir.MatrixColsTable(child) } |
       "MatrixRowsTable" ~> matrix_ir ^^ { child => ir.MatrixRowsTable(child) } |
       "MatrixEntriesTable" ~> matrix_ir ^^ { child => ir.MatrixEntriesTable(child) } |
-      "TableAggregateByKey" ~> table_ir ~ ir_value_expr ^^ { case child ~ expr => ir.TableAggregateByKey(child, expr) } |
+      "TableAggregateByKey" ~> table_ir ~ ir_value_expr() ^^ { case child ~ expr => ir.TableAggregateByKey(child, expr) } |
       "TableJoin" ~> ir_identifier ~ table_ir ~ table_ir ^^ { case joinType ~ left ~ right => ir.TableJoin(left, right, joinType) } |
       "TableParallelize" ~> table_type_expr ~ ir_value ~ int32_literal_opt ^^ { case typ ~ ((rowsType, rows)) ~ nPartitions =>
         ir.TableParallelize(typ, rows.asInstanceOf[IndexedSeq[Row]], nPartitions)
       } |
-      "TableMapRows" ~> string_literals_opt ~ int32_literal_opt ~ table_ir ~ ir_value_expr ^^ { case newKey ~ preservedKeyFields ~ child ~ newRow =>
+      "TableMapRows" ~> string_literals_opt ~ int32_literal_opt ~ table_ir ~ ir_value_expr() ^^ { case newKey ~ preservedKeyFields ~ child ~ newRow =>
         ir.TableMapRows(child, newRow, newKey, preservedKeyFields)
       } |
-      "TableMapGlobals" ~> ir_value ~ table_ir ~ ir_value_expr ^^ { case ((t, v)) ~ child ~ newRow =>
+      "TableMapGlobals" ~> ir_value ~ table_ir ~ ir_value_expr() ^^ { case ((t, v)) ~ child ~ newRow =>
         ir.TableMapGlobals(child, newRow,
           BroadcastRow(v.asInstanceOf[Row], t.asInstanceOf[TBaseStruct], HailContext.get.sc))
       } |
@@ -806,24 +805,24 @@ object Parser extends JavaTokenParsers {
   def matrix_ir: Parser[ir.MatrixIR] = "(" ~> matrix_ir_1 <~ ")"
 
   def matrix_ir_1: Parser[ir.MatrixIR] =
-    "MatrixFilterCols" ~> matrix_ir ~ ir_value_expr ^^ { case child ~ pred => ir.MatrixFilterCols(child, pred) } |
-      "MatrixFilterRows" ~> matrix_ir ~ ir_value_expr ^^ { case child ~ pred => ir.MatrixFilterRows(child, pred) } |
-      "MatrixFilterEntries" ~> matrix_ir ~ ir_value_expr ^^ { case child ~ pred => ir.MatrixFilterEntries(child, pred) } |
-      "MatrixMapCols" ~> string_literals_opt ~ matrix_ir ~ ir_value_expr ^^ { case newKey ~ child ~ newCol => ir.MatrixMapCols(child, newCol, newKey) } |
-      "MatrixMapRows" ~> string_literals_opt ~ string_literals_opt ~ matrix_ir ~ ir_value_expr ^^ { case newKey ~ newPartitionKey ~ child ~ newCol =>
+    "MatrixFilterCols" ~> matrix_ir ~ ir_value_expr() ^^ { case child ~ pred => ir.MatrixFilterCols(child, pred) } |
+      "MatrixFilterRows" ~> matrix_ir ~ ir_value_expr() ^^ { case child ~ pred => ir.MatrixFilterRows(child, pred) } |
+      "MatrixFilterEntries" ~> matrix_ir ~ ir_value_expr() ^^ { case child ~ pred => ir.MatrixFilterEntries(child, pred) } |
+      "MatrixMapCols" ~> string_literals_opt ~ matrix_ir ~ ir_value_expr() ^^ { case newKey ~ child ~ newCol => ir.MatrixMapCols(child, newCol, newKey) } |
+      "MatrixMapRows" ~> string_literals_opt ~ string_literals_opt ~ matrix_ir ~ ir_value_expr() ^^ { case newKey ~ newPartitionKey ~ child ~ newCol =>
         val newKPK = ((newKey, newPartitionKey): @unchecked) match {
           case (Some(k), Some(pk)) => Some((k, pk))
           case (None, None) => None
         }
         ir.MatrixMapRows(child, newCol, newKPK)
       } |
-      "MatrixMapEntries" ~> matrix_ir ~ ir_value_expr ^^ { case child ~ newEntries => ir.MatrixMapEntries(child, newEntries) } |
-      "MatrixMapGlobals" ~> matrix_ir ~ ir_value_expr ~ ir_value ^^ { case child ~ newGlobals ~ ((t, v)) =>
+      "MatrixMapEntries" ~> matrix_ir ~ ir_value_expr() ^^ { case child ~ newEntries => ir.MatrixMapEntries(child, newEntries) } |
+      "MatrixMapGlobals" ~> matrix_ir ~ ir_value_expr() ~ ir_value ^^ { case child ~ newGlobals ~ ((t, v)) =>
         ir.MatrixMapGlobals(child, newGlobals,
           BroadcastRow(v.asInstanceOf[Row], t.asInstanceOf[TBaseStruct], HailContext.get.sc))
       } |
-      "MatrixAggregateColsByKey" ~> matrix_ir ~ ir_value_expr ^^ { case child ~ agg => ir.MatrixAggregateColsByKey(child, agg) } |
-      "MatrixAggregateRowsByKey" ~> matrix_ir ~ ir_value_expr ^^ { case child ~ agg => ir.MatrixAggregateRowsByKey(child, agg) } |
+      "MatrixAggregateColsByKey" ~> matrix_ir ~ ir_value_expr() ^^ { case child ~ agg => ir.MatrixAggregateColsByKey(child, agg) } |
+      "MatrixAggregateRowsByKey" ~> matrix_ir ~ ir_value_expr() ^^ { case child ~ agg => ir.MatrixAggregateRowsByKey(child, agg) } |
       "MatrixRead" ~> matrix_type_expr_opt ~ boolean_literal ~ boolean_literal ~ string_literal ^^ {
         case typ ~ dropCols ~ dropRows ~ readerStr =>
           implicit val formats = ir.MatrixReader.formats
@@ -834,18 +833,10 @@ object Parser extends JavaTokenParsers {
       "MatrixChooseCols" ~> int32_literals ~ matrix_ir ^^ { case oldIndices ~ child => ir.MatrixChooseCols(child, oldIndices) } |
       "MatrixCollectColsByKey" ~> matrix_ir ^^ { child => ir.MatrixCollectColsByKey(child) }
 
-  def parse_value_ir(s: String): IR = parse(ir_value_expr, s)
+  def parse_value_ir(s: String, ref_map: Map[String, (String, Type)] = Map.empty): IR = parse(ir_value_expr(ref_map), s)
 
-  def parse_value_ir(s: String, ref_map: Map[String, (String, Type)]): IR = {
-    def add_type(node: IR): IR = node match {
-      case ir.Ref(name, null) =>
-        val (newName, typ) = ref_map(name)
-        ir.Ref(newName, typ)
-      case _ =>
-        ir.Recur(add_type)(node)
-    }
-    add_type(parse(ir_value_expr, s))
-  }
+  def parse_named_value_irs(s: String, ref_map: Map[String, (String, Type)] = Map.empty): Array[(String, IR)] =
+    parse(ir_named_value_exprs(ref_map), s).toArray
 
   def parse_table_ir(s: String): TableIR = parse(table_ir, s)
 

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -698,7 +698,9 @@ object Parser extends JavaTokenParsers {
 
   def ir_value_expr: Parser[ir.IR] = "(" ~> ir_value_expr_1 <~ ")"
 
-  def ir_value_expr_1: Parser[ir.IR] =
+  def ir_value_expr: Parser[ir.IR] = "(" ~> ir_value_expr_1 <~ ")"
+
+  def ir_value_expr_1: Parser[ir.IR] = {
     "I32" ~> int32_literal ^^ { x => ir.I32(x) } |
       "I64" ~> int64_literal ^^ { x => ir.I64(x) } |
       "F32" ~> float32_literal ^^ { x => ir.F32(x) } |
@@ -713,6 +715,7 @@ object Parser extends JavaTokenParsers {
       "If" ~> ir_value_expr ~ ir_value_expr ~ ir_value_expr ^^ { case cond ~ consq ~ altr => ir.If(cond, consq, altr) } |
       "Let" ~> ir_identifier ~ ir_value_expr ~ ir_value_expr ^^ { case name ~ value ~ body => ir.Let(name, value, body) } |
       "Ref" ~> type_expr ~ ir_identifier ^^ { case t ~ name => ir.Ref(name, t) } |
+      "Ref" ~> ir_identifier ^^ { name => ir.Ref(name, null) } |
       "ApplyBinaryPrimOp" ~> ir_binary_op ~ ir_value_expr ~ ir_value_expr ^^ { case op ~ l ~ r => ir.ApplyBinaryPrimOp(op, l, r) } |
       "ApplyUnaryPrimOp" ~> ir_unary_op ~ ir_value_expr ^^ { case op ~ x => ir.ApplyUnaryPrimOp(op, x) } |
       "ApplyComparisonOp" ~> ir_comparison_op ~ ir_value_expr ~ ir_value_expr ^^ { case op ~ l ~ r => ir.ApplyComparisonOp(op, l, r) } |
@@ -748,6 +751,8 @@ object Parser extends JavaTokenParsers {
       "Die" ~> type_expr ~ string_literal ^^ { case t ~ message => ir.Die(message, t) } |
       ("ApplyIR" | "ApplySpecial" | "Apply") ~> ir_identifier ~ ir_children ^^ { case function ~ args => ir.invoke(function, args: _*) } |
       "Uniroot" ~> ir_identifier ~ ir_value_expr ~ ir_value_expr ~ ir_value_expr ^^ { case name ~ f ~ min ~ max => ir.Uniroot(name, f, min, max) }
+  }
+
 
   def ir_value: Parser[(Type, Any)] = type_expr ~ string_literal ^^ { case t ~ vJSONStr =>
     val vJSON = JsonMethods.parse(vJSONStr)
@@ -830,6 +835,17 @@ object Parser extends JavaTokenParsers {
       "MatrixCollectColsByKey" ~> matrix_ir ^^ { child => ir.MatrixCollectColsByKey(child) }
 
   def parse_value_ir(s: String): IR = parse(ir_value_expr, s)
+
+  def parse_value_ir(s: String, ref_map: Map[String, (String, Type)]): IR = {
+    def add_type(node: IR): IR = node match {
+      case ir.Ref(name, null) =>
+        val (newName, typ) = ref_map(name)
+        ir.Ref(newName, typ)
+      case _ =>
+        ir.Recur(add_type)(node)
+    }
+    add_type(parse(ir_value_expr, s))
+  }
 
   def parse_table_ir(s: String): TableIR = parse(table_ir, s)
 

--- a/src/main/scala/is/hail/expr/types/MatrixType.scala
+++ b/src/main/scala/is/hail/expr/types/MatrixType.scala
@@ -126,6 +126,13 @@ case class MatrixType(
       "g" -> (3, entryType)))
   }
 
+  def refMap: Map[String, (String, Type)] = Map(
+    "global" -> ("global", globalType),
+    "va" -> ("va", rvRowType),
+    "sa" -> ("sa", colType),
+    "g" -> ("g", entryType),
+    "AGG" -> ("g", entryType))
+
   def pretty(sb: StringBuilder, indent0: Int = 0, compact: Boolean = false) {
     var indent = indent0
 

--- a/src/main/scala/is/hail/expr/types/TableType.scala
+++ b/src/main/scala/is/hail/expr/types/TableType.scala
@@ -30,6 +30,12 @@ case class TableType(rowType: TStruct, key: Option[IndexedSeq[String]], globalTy
     .bind("global" -> globalType)
     .bind("AGG" -> tAgg)
 
+  def refMap: Map[String, (String, Type)] = Map(
+    "global" -> ("global", globalType),
+    "row" -> ("row", rowType),
+    "AGG" -> ("row", rowType)
+  )
+
   def keyType: Option[TStruct] = key.map(key => rowType.select(key.toArray)._1)
   val keyFieldIdx: Option[Array[Int]] = key.map(_.toArray.map(rowType.fieldIdx))
   def valueType: TStruct = rowType.filterSet(keyOrEmpty.toSet, include = false)._1

--- a/src/main/scala/is/hail/methods/IBD.scala
+++ b/src/main/scala/is/hail/methods/IBD.scala
@@ -344,30 +344,25 @@ object IBD {
     }
   }
 
-  private[methods] def generateComputeMaf(vds: MatrixTable,
-    computeMafExpr: String): (RegionValue) => Double = {
-
-    val mafSymbolTable = Map("va" -> (0, vds.rowType))
-    val mafEc = EvalContext(mafSymbolTable)
-    val mafAst = Parser.parseToAST(computeMafExpr, mafEc)
+  private[methods] def generateComputeMaf(vds: MatrixTable, computeMafExpr: String): (RegionValue) => Double = {
+    val refMap = Map("va" -> ("va", vds.rowType))
+    val ir = Parser.parse_value_ir(computeMafExpr, refMap)
+    // The expression may need a cast to Double
+    val ir1 = if (ir.typ.isInstanceOf[TFloat64]) ir else Cast(ir, TFloat64())
 
     val rowKeysF = vds.rowKeysF
     val localRowType = vds.rowType
 
-    val computeMafFromRV = mafAst.toIR() match {
-      case ToIRSuccess(ir0) =>
-        // The expression may need a cast to Double
-        val ir1 = if (ir0.typ.isInstanceOf[TFloat64]) ir0 else Cast(ir0, TFloat64())
-        val (rtyp, irThunk) = ir.Compile[Long, Long, Double](
-          "va", localRowType,
-          "_dummyA", localRowType,
-          ir1
-        )
-        (rv: RegionValue) => {
-          val result: java.lang.Double = irThunk()(rv.region, rv.offset, false, 0, true)
-          result
-        }
-    }
+    val (rtyp, irThunk) = Compile[Long, Long, Double](
+      "va", localRowType,
+      "_dummyA", localRowType,
+      ir1
+    )
+
+    val computeMafFromRV = { rv: RegionValue =>
+        val result: java.lang.Double = irThunk()(rv.region, rv.offset, false, 0, true)
+        result
+      }
 
     (rv: RegionValue) => {
       val maf = computeMafFromRV(rv)

--- a/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/src/main/scala/is/hail/methods/PCRelate.scala
@@ -78,6 +78,16 @@ object PCRelate {
 
     val result = new PCRelate(maf, blockSize, statistics, defaultStorageLevel)(hc, blockedG, pcs)
 
+    val irFields = Array(
+      "i" -> "(Apply `[]` (GetField sample_ids (Ref global)) (GetField i (Ref row)))",
+      "j" -> "(Apply `[]` (GetField sample_ids (Ref global)) (GetField j (Ref row)))",
+      "kin" -> "(GetField kin (Ref row))",
+      "ibd0" -> "(GetField ibd0 (Ref row))",
+      "ibd1" -> "(GetField ibd1 (Ref row))",
+      "ibd2" -> "(GetField ibd2 (Ref row))"
+    ).map { case (name, expr) => s"($name $expr)" }
+    val irExpr = s"(MakeStruct ${irFields.mkString(" ")})"
+
     Table(vds.hc, toRowRdd(result, blockSize, minKinship, statistics), sig, Some(keys))
       .annotateGlobal(sampleIds.toFastIndexedSeq, TArray(TString()), "sample_ids")
       .select("{i: global.sample_ids[row.i], j: global.sample_ids[row.j], kin: row.kin, ibd0: row.ibd0, ibd1: row.ibd1, ibd2: row.ibd2}",

--- a/src/main/scala/is/hail/methods/SplitMulti.scala
+++ b/src/main/scala/is/hail/methods/SplitMulti.scala
@@ -11,23 +11,6 @@ import is.hail.utils._
 import is.hail.variant._
 import org.apache.spark.sql.Row
 
-class ExprAnnotator(val ec: EvalContext, t: TStruct, expr: String, head: Option[String]) extends Serializable {
-  private val asts = Parser.parseAnnotationExprsToAST(expr, ec, head)
-
-  private val inserters = new Array[Inserter](asts.length)
-  val newT: TStruct = {
-    var newT = t
-    var i = 0
-    while (i < asts.length) {
-      val (newSig, ins) = newT.structInsert(asts(i)._2.`type`, List(asts(i)._1))
-      inserters(i) = ins
-      newT = newSig
-      i += 1
-    }
-    newT
-  }
-}
-
 class SplitMultiRowIR(rowIRs: Array[(String, IR)], entryIRs: Array[(String, IR)], oldMatrixType: MatrixType) {
   val oldRowIR = Ref("va", oldMatrixType.rvRowType)
   val newEntries = ArrayMap(GetField(In(3, oldMatrixType.rvRowType), MatrixType.entriesIdentifier), "g", InsertFields(Ref("g", oldMatrixType.entryType), entryIRs))
@@ -65,19 +48,17 @@ class SplitMultiPartitionContextIR(
   removeLeftAligned: Boolean,
   removeMoving: Boolean,
   verifyLeftAligned: Boolean
-) extends SplitMultiPartitionContext(
-  keepStar,
-  nSamples,
-  globalAnnotation,
-  matrixType,
-  oldRVRowType,
-  newRVRowType,
-  ctx,
-  sortAlleles,
-  removeLeftAligned,
-  removeMoving,
-  verifyLeftAligned
 ) {
+
+  val splitRegion = ctx.region
+  val locusIndex = oldRVRowType.fieldIdx("locus")
+  var fullRow = new UnsafeRow(matrixType.rvRowType)
+  var prevLocus: Locus = null
+  val rvv = new RegionValueVariant(matrixType.rvRowType)
+  val rvb = new RegionValueBuilder()
+  val splitrv = RegionValue()
+  val locusAllelesOrdering = matrixType.rowKeyStruct.ordering
+
   private val allelesType = matrixType.rowType.fieldByName("alleles").typ
   private val locusType = matrixType.rowType.fieldByName("locus").typ
   val f = rowF()
@@ -112,32 +93,6 @@ class SplitMultiPartitionContextIR(
       splitrv
     }
   }
-}
-
-abstract class SplitMultiPartitionContext(
-  keepStar: Boolean,
-  nSamples: Int,
-  globalAnnotation: Annotation,
-  matrixType: MatrixType,
-  oldRVRowType: TStruct,
-  newRVRowType: TStruct,
-  val ctx: RVDContext,
-  sortAlleles: Boolean,
-  removeLeftAligned: Boolean,
-  removeMoving: Boolean,
-  verifyLeftAligned: Boolean
-) extends Serializable {
-
-  val splitRegion = ctx.region
-  val locusIndex = oldRVRowType.fieldIdx("locus")
-  var fullRow = new UnsafeRow(matrixType.rvRowType)
-  var prevLocus: Locus = null
-  val rvv = new RegionValueVariant(matrixType.rvRowType)
-  val rvb = new RegionValueBuilder()
-  val splitrv = RegionValue()
-  val locusAllelesOrdering = matrixType.rowKeyStruct.ordering
-
-  def constructSplitRow(splitVariants: Iterator[(Locus, IndexedSeq[String], Int)], rv: RegionValue, wasSplit: Boolean): Iterator[RegionValue]
 
   def splitRow(rv: RegionValue): Iterator[RegionValue] = {
     require(!(removeMoving && verifyLeftAligned))
@@ -197,43 +152,6 @@ abstract class SplitMultiPartitionContext(
 object SplitMulti {
 
   def apply(vsm: MatrixTable, variantExpr: String, genotypeExpr: String, keepStar: Boolean = false, leftAligned: Boolean = false): MatrixTable = {
-    val vEC = EvalContext(Map(
-      "global" -> (0, vsm.globalType),
-      "newLocus" -> (1, vsm.rowKeyStruct.types(0)),
-      "newAlleles" -> (2, vsm.rowKeyStruct.types(1)),
-      "va" -> (3, vsm.rvRowType),
-      "aIndex" -> (4, TInt32()),
-      "wasSplit" -> (5, TBoolean())))
-
-    val gEC = EvalContext(Map(
-      "global" -> (0, vsm.globalType),
-      "newLocus" -> (1, vsm.rowKeyStruct.types(0)),
-      "newAlleles" -> (2, vsm.rowKeyStruct.types(1)),
-      "va" -> (3, vsm.rvRowType),
-      "aIndex" -> (4, TInt32()),
-      "wasSplit" -> (5, TBoolean()),
-      "g" -> (6, vsm.entryType)))
-    val gAnnotator = new ExprAnnotator(gEC, vsm.entryType, genotypeExpr, Some(Annotation.ENTRY_HEAD))
-
-    val rowASTs = Parser.parseAnnotationExprsToAST(variantExpr, vEC, Some("va"))
-    val entryASTs = Parser.parseAnnotationExprsToAST(genotypeExpr, gEC, Some("g"))
-
-    val rowIRs = rowASTs.flatMap { case (name, ast) =>
-      for (ir <- ast.toIROpt()) yield {
-        (name, ir)
-      }
-    }
-    val entryIRs = entryASTs.flatMap { case (name, ast) =>
-      for (ir <- ast.toIROpt()) yield {
-        (name, ir)
-      }
-    }
-
-    val splitmulti = new SplitMulti(vsm, rowIRs, entryIRs, keepStar, leftAligned)
-    splitmulti.split()
-  }
-
-  def IR(vsm: MatrixTable, variantExpr: Array[(String, String)], genotypeExpr: Array[(String, String)], keepStar: Boolean = false, leftAligned: Boolean = false): MatrixTable = {
     val refMap = Map(
       "global" -> ("global", vsm.globalType),
       "newLocus" -> ("newLocus", vsm.rowKeyStruct.types(0)),
@@ -243,8 +161,9 @@ object SplitMulti {
       "wasSplit" -> ("wasSplit", TBoolean()),
       "g" -> ("g", vsm.entryType))
 
-    def extractIR(elt: (String, String)): (String, IR) = elt._1 -> Parser.parse_value_ir(elt._2, refMap)
-    val splitmulti = new SplitMulti(vsm, variantExpr.map(extractIR), genotypeExpr.map(extractIR), keepStar, leftAligned)
+    val variantIRs = Parser.parse_named_value_irs(variantExpr, refMap)
+    val genotypeIRs = Parser.parse_named_value_irs(genotypeExpr, refMap)
+    val splitmulti = new SplitMulti(vsm, variantIRs, genotypeIRs, keepStar, leftAligned)
     splitmulti.split()
   }
 

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -422,6 +422,9 @@ class Table(val hc: HailContext, val tir: TableIR) {
     }
   }
 
+  def aggregateIR(expr: String): (Any, Type) =
+    aggregate(Parser.parse_value_ir(expr, typ.refMap))
+
   def aggregate(query: IR): (Any, Type) = {
     val t = ir.TableAggregate(tir, query)
     (ir.Interpret(t, ir.Env.empty, FastIndexedSeq(), None), t.typ)
@@ -455,6 +458,11 @@ class Table(val hc: HailContext, val tir: TableIR) {
     }
   }
 
+  def selectGlobalIR(expr: String): Table = {
+    val ir = Parser.parse_value_ir(expr, typ.refMap)
+    new Table(hc, TableMapGlobals(tir, ir, BroadcastRow(Row(), TStruct(), hc.sc)))
+  }
+
   def filter(cond: String, keep: Boolean): Table = {
     val ec = rowEvalContext()
     var filterAST = Parser.parseToAST(cond, ec)
@@ -465,6 +473,12 @@ class Table(val hc: HailContext, val tir: TableIR) {
           TableFilter(tir, ir.filterPredicateWithKeep(irPred, keep))
         )
     }
+  }
+
+  def filterIR(cond: String, keep: Boolean): Table = {
+    var irPred = Parser.parse_value_ir(cond, typ.refMap)
+    new Table(hc,
+      TableFilter(tir, ir.filterPredicateWithKeep(irPred, keep)))
   }
 
   def head(n: Long): Table = {
@@ -513,6 +527,11 @@ class Table(val hc: HailContext, val tir: TableIR) {
       case Some(ir) =>
         new Table(hc, TableMapRows(tir, ir, newKey, preservedKeyFields))
     }
+  }
+
+  def selectIR(expr: String, newKey: Option[IndexedSeq[String]], preservedKeyFields: Option[Int]): Table = {
+    val ir = Parser.parse_value_ir(expr, typ.refMap)
+    new Table(hc, TableMapRows(tir, ir, newKey, preservedKeyFields))
   }
 
   def join(other: Table, joinType: String): Table =
@@ -722,6 +741,11 @@ class Table(val hc: HailContext, val tir: TableIR) {
       case Some(x) =>
         new Table(hc, TableAggregateByKey(tir, x))
     }
+  }
+
+  def aggregateByKeyIR(expr: String, nPartitions: Option[Int] = None): Table = {
+    val x = Parser.parse_value_ir(expr, typ.refMap)
+    new Table(hc, TableAggregateByKey(tir, x))
   }
 
   def expandTypes(): Table = {

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -581,6 +581,11 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     }
   }
 
+  def aggregateColsByKeyIR(aggExpr: String): MatrixTable = {
+    val aggIR = Parser.parse_value_ir(aggExpr, matrixType.refMap)
+    new MatrixTable(hc, MatrixAggregateColsByKey(ast, aggIR))
+  }
+
   def aggregateRowsByKey(expr: String, oldAggExpr: String): MatrixTable = {
     val ec = colEC
 
@@ -591,6 +596,12 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
       case Some(x) =>
         new MatrixTable(hc, MatrixAggregateRowsByKey(ast, x))
     }
+  }
+
+  def aggregateRowsByKeyIR(expr: String): MatrixTable = {
+    log.info(expr)
+    val rowsIR = Parser.parse_value_ir(expr, matrixType.refMap)
+    new MatrixTable(hc, MatrixAggregateRowsByKey(ast, rowsIR))
   }
 
   def annotateGlobal(a: Annotation, t: Type, name: String): MatrixTable = {
@@ -852,6 +863,11 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     }
   }
 
+  def selectGlobalsIR(expr: String): MatrixTable = {
+    val globalIR = Parser.parse_value_ir(expr, matrixType.refMap)
+    new MatrixTable(hc, MatrixMapGlobals(ast, globalIR, BroadcastRow(Row(), TStruct(), hc.sc)))
+  }
+
   def selectCols(expr: String, newKey: java.util.ArrayList[String]): MatrixTable =
     selectCols(expr, Option(newKey).map(_.asScala.toFastIndexedSeq))
 
@@ -864,6 +880,12 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
       case Some(x) =>
         new MatrixTable(hc, MatrixMapCols(ast, x, newKey))
     }
+  }
+
+  def selectColsIR(expr: String, newKey: Option[IndexedSeq[String]]): MatrixTable = {
+    val colsAST = Parser.parse_value_ir(expr, matrixType.refMap)
+    val newColKey = newKey.getOrElse(colKey)
+    new MatrixTable(hc, MatrixMapCols(ast, x, newKey))
   }
 
   def selectRows(expr: String, newKey: java.util.ArrayList[java.util.ArrayList[String]]): MatrixTable = {
@@ -882,6 +904,11 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     }
   }
 
+  def selectRowsIR(expr: String, newKey: Option[(IndexedSeq[String], IndexedSeq[String])]): MatrixTable = {
+    val rowsIR = Parser.parse_value_ir(expr, matrixType.refMap)
+    new MatrixTable(hc, MatrixMapRows(ast, rowsIR, newKey))
+  }
+
   def selectEntries(expr: String): MatrixTable = {
     val ec = entryEC
 
@@ -892,6 +919,11 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
       case Some(ir) =>
         new MatrixTable(hc, MatrixMapEntries(ast, ir))
     }
+  }
+
+  def selectEntriesIR(expr: String): MatrixTable = {
+    val ir = Parser.parse_value_ir(expr, matrixType.refMap)
+    new MatrixTable(hc, MatrixMapEntries(ast, ir))
   }
 
   def nPartitions: Int = rvd.getNumPartitions
@@ -1021,6 +1053,12 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     }
   }
 
+  def filterColsExprIR(filterExpr: String, keep: Boolean = true): MatrixTable = {
+    var irPred = Parser.parse_value_ir(filterExpr, matrixType.refMap)
+    new MatrixTable(hc,
+      MatrixFilterCols(ast, ir.filterPredicateWithKeep(irPred, keep)))
+  }
+
   def filterColsList(samples: java.util.ArrayList[Annotation], keep: Boolean): MatrixTable =
     filterColsList(samples.asScala.toSet, keep)
 
@@ -1037,6 +1075,12 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
         new MatrixTable(hc,
           MatrixFilterRows(ast, ir.filterPredicateWithKeep(irPred, keep)))
     }
+  }
+
+  def filterRowsExprIR(filterExpr: String, keep: Boolean = true): MatrixTable = {
+    var irPred = Parser.parse_value_ir(filterExpr, matrixType.refMap)
+    new MatrixTable(hc,
+      MatrixFilterRows(ast, ir.filterPredicateWithKeep(irPred, keep)))
   }
 
   def sparkContext: SparkContext = hc.sc
@@ -1322,6 +1366,20 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     }
   }
 
+  def aggregateEntriesIR(expr: String): (Annotation, Type) = {
+    val queryAST = Parser.parse_value_ir(expr, matrixType.refMap)
+    val et = entriesTable()
+
+    val entriesRowType = et.typ.rowType
+    val aggEnv = new ir.Env[ir.IR].bind(
+      "g" -> ir.SelectFields(ir.Ref("row", entriesRowType), entryType.fieldNames),
+      "va" -> ir.SelectFields(ir.Ref("row", entriesRowType), rowType.fieldNames),
+      "sa" -> ir.SelectFields(ir.Ref("row", entriesRowType), colType.fieldNames))
+
+    val sqir = ir.Subst(qir.unwrap, ir.Env.empty, aggEnv)
+    et.aggregate(sqir)
+  }
+
   def aggregateCols(expr: String): (Annotation, Type) = {
     val aggregationST = Map(
       "global" -> (0, globalType),
@@ -1342,6 +1400,14 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     }
   }
 
+  def aggregateColsIR(expr: String): (Annotation, Type) = {
+    val qir = Parser.parse_value_ir(expr, matrixType.refMap)
+    val ct = colsTable()
+    val aggEnv = new ir.Env[ir.IR].bind("sa" -> ir.Ref("row", ct.typ.rowType))
+    val sqir = ir.Subst(qir.unwrap, ir.Env.empty, aggEnv)
+    ct.aggregate(sqir)
+  }
+
   def aggregateRows(expr: String): (Annotation, Type) = {
     val aggregationST = Map(
       "global" -> (0, globalType),
@@ -1359,6 +1425,14 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
         val sqir = ir.Subst(qir.unwrap, ir.Env.empty, aggEnv)
         rt.aggregate(sqir)
     }
+  }
+
+  def aggregateRowsIR(expr: String): (Annotation, Type) = {
+    val qir = Parser.parse_value_ir(expr, matrixType.refMap)
+    val rt = rowsTable()
+    val aggEnv = new ir.Env[ir.IR].bind("va" -> ir.Ref("row", rt.typ.rowType))
+    val sqir = ir.Subst(qir.unwrap, ir.Env.empty, aggEnv)
+    rt.aggregate(sqir)
   }
 
   def chooseCols(oldIndices: java.util.ArrayList[Int]): MatrixTable =
@@ -1711,6 +1785,11 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
       case Some(x) =>
         copyAST(MatrixFilterEntries(ast, ir.filterPredicateWithKeep(x, keep)))
     }
+  }
+
+  def filterEntriesIR(filterExpr: String, keep: Boolean = true): MatrixTable = {
+    val filterIR = Parser.parse_value_ir(filterExpr, matrixType.refMap)
+    new MatrixTable(hc, MatrixFilterEntries(ast, ir.filterPredicateWithKeep(filterIR, keep)))
   }
 
   def write(path: String, overwrite: Boolean = false, stageLocally: Boolean = false, codecSpecJSONStr: String = null) {

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -883,9 +883,9 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
   def selectColsIR(expr: String, newKey: Option[IndexedSeq[String]]): MatrixTable = {
-    val colsAST = Parser.parse_value_ir(expr, matrixType.refMap)
+    val ir = Parser.parse_value_ir(expr, matrixType.refMap)
     val newColKey = newKey.getOrElse(colKey)
-    new MatrixTable(hc, MatrixMapCols(ast, x, newKey))
+    new MatrixTable(hc, MatrixMapCols(ast, ir, newKey))
   }
 
   def selectRows(expr: String, newKey: java.util.ArrayList[java.util.ArrayList[String]]): MatrixTable = {
@@ -1367,7 +1367,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
   def aggregateEntriesIR(expr: String): (Annotation, Type) = {
-    val queryAST = Parser.parse_value_ir(expr, matrixType.refMap)
+    val qir = Parser.parse_value_ir(expr, matrixType.refMap)
     val et = entriesTable()
 
     val entriesRowType = et.typ.rowType

--- a/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -479,7 +479,7 @@ class IRSuite extends SparkSuite {
   @Test(dataProvider = "valueIRs")
   def testValueIRParser(x: IR) {
     val s = Pretty(x)
-    val x2 = Parser.parse(Parser.ir_value_expr, s)
+    val x2 = Parser.parse(Parser.ir_value_expr(), s)
     assert(x2 == x)
   }
 

--- a/src/test/scala/is/hail/methods/IBDSuite.scala
+++ b/src/test/scala/is/hail/methods/IBDSuite.scala
@@ -162,7 +162,7 @@ class IBDSuite extends SparkSuite {
     val vds = hc.importVCF("src/test/resources/sample.vcf")
     val vds2 = vds.selectRows("annotate(va, { `dummy_maf`: 0.08 })", None)
 
-    val us = IBD.toRDD(IBD(vds2, computeMafExpr = Some("va.dummy_maf"))).collect().toMap
+    val us = IBD.toRDD(IBD(vds2, computeMafExpr = Some("(GetField dummy_maf (Ref va))"))).collect().toMap
     val plink = runPlinkIBD(vds, maf = Some(0.08))
 
     mapSameElements(us, plink,


### PR DESCRIPTION
currently shouldn't do much, except in IBD tests and PCRelate, which now construct IR strings to parse instead of expr. Mostly just separating this out from the python-side changes (in a forthcoming PR), and making sure I didn't break all the scala tests.