### PR TITLE
removed action and simplified rrm and grm

### DIFF
--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -1694,9 +1694,6 @@ def genetic_relatedness_matrix(call_expr) -> BlockMatrix:
 
         G_{ik} = \\frac{1}{m} \\sum_{j=1}^m \\frac{(C_{ij}-2p_j)(C_{kj}-2p_j)}{2 p_j (1-p_j)}
 
-    Note that variants for which the alternate allele frequency is zero or one are not
-    normalizable, and therefore removed prior to calculating the GRM.
-
     This method drops variants with :math:`p_j = 0` or math:`p_j = 1` before
     computing kinship.
 


### PR DESCRIPTION
For rrm and grm, I've pushed overall rescaling to the faster block matrix side and thereby removed the action that counts the number of variants after filtering. The behavior is identical except that we no longer warn when constant variants are dropped, but I've clarified the behavior in the docs. In the unfathomable case that all variants are constant, the user will receive the error message `HailException: block matrix must have at least one row` when the BlockMatrix is being created.

For rrm, I've also simplified the filtering, as well as the expression algebra for std_dev from
```
hl.sqrt((mt.__ACsq + (n_samples - mt.__n_called) * mt.__mean_gt ** 2) / n_samples - mt.__mean_gt ** 2)
```
to
```
hl.sqrt(mt.__ACsq - (mt.__AC ** 2) / mt.__n_called)
```
with the added benefit of combining two annotates.