### PR TITLE
correlation between rows of matrix table

### DIFF
--- a/python/hail/docs/methods/index.rst
+++ b/python/hail/docs/methods/index.rst
@@ -41,7 +41,7 @@ Methods
     linear_regression
     logistic_regression
     pca
-    correlation
+    row_correlation
 
 
 .. rubric:: Genetics

--- a/python/hail/docs/methods/index.rst
+++ b/python/hail/docs/methods/index.rst
@@ -41,6 +41,7 @@ Methods
     linear_regression
     logistic_regression
     pca
+    correlation
 
 
 .. rubric:: Genetics

--- a/python/hail/docs/methods/stats.rst
+++ b/python/hail/docs/methods/stats.rst
@@ -8,11 +8,13 @@ Statistics
 
 .. autosummary::
 
+    correlation
     linear_regression
     logistic_regression
     LinearMixedModel
     pca
 
+.. autofunction:: correlation
 .. autofunction:: linear_regression
 .. autofunction:: logistic_regression
 .. autoclass:: LinearMixedModel

--- a/python/hail/docs/methods/stats.rst
+++ b/python/hail/docs/methods/stats.rst
@@ -8,13 +8,13 @@ Statistics
 
 .. autosummary::
 
-    correlation
+    row_correlation
     linear_regression
     logistic_regression
     LinearMixedModel
     pca
 
-.. autofunction:: correlation
+.. autofunction:: row_correlation
 .. autofunction:: linear_regression
 .. autofunction:: logistic_regression
 .. autoclass:: LinearMixedModel

--- a/python/hail/linalg/blockmatrix.py
+++ b/python/hail/linalg/blockmatrix.py
@@ -370,7 +370,7 @@ class BlockMatrix(object):
             Block size. Default given by :meth:`.BlockMatrix.default_block_size`.
         """
         path = new_temp_file()
-        cls.write_from_entry_expr(entry_expr, path, mean_impute, center, normalize, block_size=block_size)
+        cls.write_from_entry_expr(entry_expr, path, mean_impute, center, normalize, block_size)
         return cls.read(path)
 
     @classmethod
@@ -607,11 +607,10 @@ class BlockMatrix(object):
         check_entry_indexed('BlockMatrix.write_from_entry_expr', entry_expr)
         mt = matrix_table_source('BlockMatrix.write_from_entry_expr', entry_expr)
 
-        if not (mean_impute or center or normalize):
+        if (not (mean_impute or center or normalize)) and (entry_expr in mt._fields_inverse):
             #  FIXME: remove once select_entries on a field is free
-            if entry_expr in mt._fields_inverse:
-                field = mt._fields_inverse[entry_expr]
-                mt._jvds.writeBlockMatrix(path, field, block_size)
+            field = mt._fields_inverse[entry_expr]
+            mt._jvds.writeBlockMatrix(path, field, block_size)
         else:
             n_cols = mt.count_cols()
             mt = mt.select_entries(__x=entry_expr)

--- a/python/hail/methods/__init__.py
+++ b/python/hail/methods/__init__.py
@@ -6,7 +6,7 @@ from .impex import export_elasticsearch, export_gen, export_plink, export_vcf, \
 from .statgen import linear_regression, logistic_regression, skat, identity_by_descent, impute_sex, \
     genetic_relatedness_matrix, realized_relationship_matrix, pca, \
     hwe_normalized_pca, pc_relate, SplitMulti, filter_alleles, filter_alleles_hts, \
-    split_multi_hts, balding_nichols_model, ld_prune, correlation
+    split_multi_hts, balding_nichols_model, ld_prune, row_correlation
 from .qc import sample_qc, variant_qc, vep, concordance, nirvana, summarize_variants
 from .misc import rename_duplicates, maximal_independent_set, filter_intervals, window_by_locus
 from .linear_mixed_model import LinearMixedModel
@@ -60,5 +60,5 @@ __all__ = ['trio_matrix',
            'filter_alleles_hts',
            'LinearMixedModel',
            'summarize_variants',
-           'correlation'
+           'row_correlation'
            ]

--- a/python/hail/methods/__init__.py
+++ b/python/hail/methods/__init__.py
@@ -6,7 +6,7 @@ from .impex import export_elasticsearch, export_gen, export_plink, export_vcf, \
 from .statgen import linear_regression, logistic_regression, skat, identity_by_descent, impute_sex, \
     genetic_relatedness_matrix, realized_relationship_matrix, pca, \
     hwe_normalized_pca, pc_relate, SplitMulti, filter_alleles, filter_alleles_hts, \
-    split_multi_hts, balding_nichols_model, ld_prune
+    split_multi_hts, balding_nichols_model, ld_prune, correlation
 from .qc import sample_qc, variant_qc, vep, concordance, nirvana, summarize_variants
 from .misc import rename_duplicates, maximal_independent_set, filter_intervals, window_by_locus
 from .linear_mixed_model import LinearMixedModel
@@ -60,4 +60,5 @@ __all__ = ['trio_matrix',
            'filter_alleles_hts',
            'LinearMixedModel',
            'summarize_variants',
+           'correlation'
            ]

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -1821,8 +1821,7 @@ def correlation(entry_expr) -> BlockMatrix:
     ...         {'v': '1:3:C:G', 's': '3', 'GT': hl.Call([1, 1])},
     ...         {'v': '1:3:C:G', 's': '4', 'GT': hl.null(hl.tcall)}]
     >>> ht = hl.Table.parallelize(data, hl.dtype('struct{v: str, s: str, GT: call}'))
-    >>> ht = ht.transmute(**hl.parse_variant(ht.v))
-    >>> mt = ht.to_matrix_table(['locus', 'alleles'], ['s'], partition_key=['locus'])
+    >>> mt = ht.to_matrix_table(['v'], ['s'])
 
     Compute genotype correlation (linkage) between all pairs of variants:
 
@@ -1888,8 +1887,8 @@ def correlation(entry_expr) -> BlockMatrix:
                         __n_called=agg.count_where(hl.is_defined(mt.__x)))
     mt = mt.select_rows(__mean=mt.__sum / mt.__n_called,
                         __scaled_std_dev=hl.sqrt(mt.__sum_sq - (mt.__sum ** 2) / mt.__n_called))
-    normalized_gt = hl.or_else((mt.__x - mt.__mean) / mt.__scaled_std_dev, 0.0)
-    bm = BlockMatrix.from_entry_expr(normalized_gt)
+    normalized_x = hl.or_else((mt.__x - mt.__mean) / mt.__scaled_std_dev, 0.0)
+    bm = BlockMatrix.from_entry_expr(normalized_x)
 
     return bm @ bm.T
 

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -1799,6 +1799,101 @@ def realized_relationship_matrix(call_expr) -> BlockMatrix:
     return (bm.T @ bm) / (bm.n_rows / bm.n_cols)
 
 
+@typecheck(entry_expr=expr_float64)
+def correlation(entry_expr) -> BlockMatrix:
+    """Computes the correlation matrix between row vectors.
+
+    Examples
+    --------
+
+    Consider the following dataset with three variants and four samples:
+
+    >>> data = [{'v': '1:1:A:C', 's': '1', 'GT': hl.Call([0, 0])},
+    ...         {'v': '1:1:A:C', 's': '2', 'GT': hl.Call([0, 0])},
+    ...         {'v': '1:1:A:C', 's': '3', 'GT': hl.Call([0, 1])},
+    ...         {'v': '1:1:A:C', 's': '4', 'GT': hl.Call([1, 1])},
+    ...         {'v': '1:2:G:T', 's': '1', 'GT': hl.Call([0, 1])},
+    ...         {'v': '1:2:G:T', 's': '2', 'GT': hl.Call([1, 1])},
+    ...         {'v': '1:2:G:T', 's': '3', 'GT': hl.Call([0, 1])},
+    ...         {'v': '1:2:G:T', 's': '4', 'GT': hl.Call([0, 0])},
+    ...         {'v': '1:3:C:G', 's': '1', 'GT': hl.Call([0, 1])},
+    ...         {'v': '1:3:C:G', 's': '2', 'GT': hl.Call([0, 0])},
+    ...         {'v': '1:3:C:G', 's': '3', 'GT': hl.Call([1, 1])},
+    ...         {'v': '1:3:C:G', 's': '4', 'GT': hl.null(hl.tcall)}]
+    >>> ht = hl.Table.parallelize(data, hl.dtype('struct{v: str, s: str, GT: call}'))
+    >>> ht = ht.transmute(**hl.parse_variant(ht.v))
+    >>> mt = ht.to_matrix_table(['locus', 'alleles'], ['s'], partition_key=['locus'])
+
+    Compute genotype correlation (linkage) between all pairs of variants:
+
+    >>> ld_matrix = hl.correlation(mt.GT.n_alt_alleles())
+    >>> ld_matrix.to_numpy()
+    array([[ 1.        , -0.85280287,  0.42640143],
+           [-0.85280287,  1.        , -0.5       ],
+           [ 0.42640143, -0.5       ,  1.        ]])
+
+    Compute genotype correlation between consecutively-indexed variants:
+
+    >>> ld_matrix.sparsify_band(lower=0, upper=1).to_numpy()
+    array([[ 1.        , -0.85280287,  0.        ],
+           [ 0.        ,  1.        , -0.5       ],
+           [ 0.        ,  0.        ,  1.        ]])
+
+    Notes
+    -----
+    In this method, each row of entries is regarded as a vector with elements
+    defined by `entry_expr` and missing values mean-imputed per row.
+    The ``(i, j)`` element of the resulting block matrix is the correlation
+    between rows ``i`` and ``j`` (as 0-indexed by order in the matrix table;
+    see :meth:`add_row_index`).
+
+    The correlation of two vectors is defined as the
+    `Pearson correlation coeffecient <https://en.wikipedia.org/wiki/Pearson_correlation_coefficient>`__
+    between the corresponding empirical distributions of elements,
+    or equivalently as the cosine of the angle between the vectors.
+    In particular, all values are between ``-1.0`` and ``1.0``, with
+    the diagonal identically ``1.0``.
+
+    Warning
+    -------
+    Rows with a constant value (i.e., zero variance) will result `nan`
+    correlation values. To avoid this, first check that all rows vary or filter
+    out constant rows (for example, with the help of :func:`.aggregators.stats`).
+
+    Warning
+    -------
+    The resulting number of matrix elements is the square of the number of rows
+    in the matrix table, so computing the full matrix may be infeasible. For
+    example, ten million rows would produce 800TB of float64 values. The
+    block-sparse representation on BlockMatrix may be used to work efficiently
+    with regions of such matrices.
+
+    Parameters
+    ----------
+    entry_expr : :class:`.Float64Expression`
+        Entry-indexed numeric expression on matrix table.
+
+    Returns
+    -------
+    :class:`.BlockMatrix`
+        Correlation matrix between row vectors. Row and column indices
+        correspond to matrix table row index.
+    """
+    mt = matrix_table_source('correlation/entry_expr', entry_expr)
+    check_entry_indexed('correlation/entry_expr', entry_expr)
+
+    mt = mt.select_entries(__x=entry_expr)
+    mt = mt.select_rows(__sum=agg.sum(mt.__x),
+                        __sum_sq=agg.sum(mt.__x * mt.__x),
+                        __n_called=agg.count_where(hl.is_defined(mt.__x)))
+    mt = mt.select_rows(__mean=mt.__sum / mt.__n_called,
+                        __scaled_std_dev=hl.sqrt(mt.__sum_sq - (mt.__sum ** 2) / mt.__n_called))
+    normalized_gt = hl.or_else((mt.__x - mt.__mean) / mt.__scaled_std_dev, 0.0)
+    bm = BlockMatrix.from_entry_expr(normalized_gt)
+
+    return bm @ bm.T
+
+
 @typecheck(n_populations=int,
            n_samples=int,
            n_variants=int,

--- a/python/test/test_hail/linalg/test_linalg.py
+++ b/python/test/test_hail/linalg/test_linalg.py
@@ -43,33 +43,35 @@ class Tests(unittest.TestCase):
         self._assert_eq(a1, a4)
 
     def test_from_entry_expr_options(self):
-        def build_mt(x):
-            data = [{'v': 0, 's': 0, 'x': x[0]},
-                    {'v': 0, 's': 1, 'x': x[1]},
-                    {'v': 0, 's': 2, 'x': x[2]}]
+        def build_mt(a):
+            data = [{'v': 0, 's': 0, 'x': a[0]},
+                    {'v': 0, 's': 1, 'x': a[1]},
+                    {'v': 0, 's': 2, 'x': a[2]}]
             ht = hl.Table.parallelize(data, hl.dtype('struct{v: int32, s: int32, x: float64}'))
             mt = ht.to_matrix_table(['v'], ['s'])
             ids = mt.col_key[0].collect()
             return mt.choose_cols([ids.index(0), ids.index(1), ids.index(2)])
 
-        def check(mt, mean_impute, center, normalize, expected):
-            actual = np.squeeze(BlockMatrix.from_entry_expr(mt.x, mean_impute, center, normalize).to_numpy())
+        def check(expr, mean_impute, center, normalize, expected):
+            actual = np.squeeze(BlockMatrix.from_entry_expr(expr, mean_impute, center, normalize).to_numpy())
             assert np.allclose(actual, expected)
 
         a = np.array([0.0, 1.0, 2.0])
+
         mt = build_mt(a)
-        check(mt, False, False, False, a)
-        check(mt, False, True, False, a - 1.0)
-        check(mt, False, False, True, a / np.sqrt(5))
-        check(mt, False, True, True, (a - 1.0) / np.sqrt(2))
+        check(mt.x, False, False, False, a)
+        check(mt.x, False, True, False, a - 1.0)
+        check(mt.x, False, False, True, a / np.sqrt(5))
+        check(mt.x, False, True, True, (a - 1.0) / np.sqrt(2))
+        check(mt.x + 1 - 1, False, False, False, a)
 
         mt = build_mt([0.0, hl.null('float64'), 2.0])
+        check(mt.x, True, False, False, a)
+        check(mt.x, True, True, False, a - 1.0)
+        check(mt.x, True, False, True, a / np.sqrt(5))
+        check(mt.x, True, True, True, (a - 1.0) / np.sqrt(2))
         with self.assertRaises(Exception):
             BlockMatrix.from_entry_expr(mt.x)
-        check(mt, True, False, False, a)
-        check(mt, True, True, False, a - 1.0)
-        check(mt, True, False, True, a / np.sqrt(5))
-        check(mt, True, True, True, (a - 1.0) / np.sqrt(2))
 
     def test_to_from_numpy(self):
         n_rows = 10

--- a/python/test/test_hail/methods/test_statgen.py
+++ b/python/test/test_hail/methods/test_statgen.py
@@ -670,8 +670,7 @@ class Tests(unittest.TestCase):
                 {'v': '1:3:C:G', 's': '3', 'GT': hl.Call([1, 1])},
                 {'v': '1:3:C:G', 's': '4', 'GT': hl.null(hl.tcall)}]
         ht = hl.Table.parallelize(data, hl.dtype('struct{v: str, s: str, GT: call}'))
-        ht = ht.transmute(**hl.parse_variant(ht.v))
-        mt = ht.to_matrix_table(['locus', 'alleles'], ['s'], partition_key=['locus'])
+        mt = ht.to_matrix_table(['v'], ['s'])
 
         actual = hl.correlation(mt.GT.n_alt_alleles()).to_numpy()
         expected = np.array([[1., -0.85280287, 0.42640143],

--- a/python/test/test_hail/methods/test_statgen.py
+++ b/python/test/test_hail/methods/test_statgen.py
@@ -656,7 +656,7 @@ class Tests(unittest.TestCase):
         rrm = hl.realized_relationship_matrix(mt.GT).to_numpy()
         self.assertTrue(np.allclose(k, rrm))
 
-    def test_correlation_vs_hardcode(self):
+    def test_row_correlation_vs_hardcode(self):
         data = [{'v': '1:1:A:C', 's': '1', 'GT': hl.Call([0, 0])},
                 {'v': '1:1:A:C', 's': '2', 'GT': hl.Call([0, 0])},
                 {'v': '1:1:A:C', 's': '3', 'GT': hl.Call([0, 1])},
@@ -672,14 +672,14 @@ class Tests(unittest.TestCase):
         ht = hl.Table.parallelize(data, hl.dtype('struct{v: str, s: str, GT: call}'))
         mt = ht.to_matrix_table(['v'], ['s'])
 
-        actual = hl.correlation(mt.GT.n_alt_alleles()).to_numpy()
+        actual = hl.row_correlation(mt.GT.n_alt_alleles()).to_numpy()
         expected = np.array([[1., -0.85280287, 0.42640143],
                              [-0.85280287,  1., -0.5],
                              [0.42640143, -0.5, 1.]])
 
         self.assertTrue(np.allclose(actual, expected))
 
-    def test_correlation_vs_numpy(self):
+    def test_row_correlation_vs_numpy(self):
         n, m = 11, 10
         mt = hl.balding_nichols_model(3, n, m, fst=[.9, .9, .9], seed=0, n_partitions=2)
         mt = mt.annotate_rows(sd=agg.stats(mt.GT.n_alt_alleles()).stdev)
@@ -689,7 +689,7 @@ class Tests(unittest.TestCase):
         g_std = self._filter_and_standardize_cols(g)
         l = g_std.T @ g_std
 
-        cor = hl.correlation(mt.GT.n_alt_alleles()).to_numpy()
+        cor = hl.row_correlation(mt.GT.n_alt_alleles()).to_numpy()
 
         self.assertTrue(cor.shape[0] > 5 and cor.shape[0] == cor.shape[1])
         self.assertTrue(np.allclose(l, cor))


### PR DESCRIPTION
I next plan to add an `ld_matrix` function under methods/genetics that incorporates parameters for optional windowing and is implemented in a few lines using `locus_windows`, `correlation`, and `sparsify_row_intervals`. I may then add a more generic example here and put the ld_matrix examples there.