### PR TITLE
fix optimizer to clean up mt.field.show()

### DIFF
--- a/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -1,14 +1,20 @@
 package is.hail.expr.ir
 
 object Binds {
-  def apply(x: IR): Set[String] = {
+  def apply(x: IR, v: String, i: Int): Boolean = {
     x match {
-      case Let(n, _, _) => Set(n)
-      case ArrayMap(_, n, _) => Set(n)
-      case ArrayFlatMap(_, n, _) => Set(n)
-      case ArrayFilter(_, n, _) => Set(n)
-      case ArrayFold(_, _, accumName, valueName, _) => Set(accumName, valueName)
-      case _ => Set.empty[String]
+      case Let(n, _, _) =>
+        v == n && i == 1
+      case ArrayMap(_, n, _) =>
+        v == n && i == 1
+      case ArrayFlatMap(_, n, _) =>
+        v == n && i == 1
+      case ArrayFilter(_, n, _) =>
+        v == n && i == 1
+      case ArrayFold(_, _, accumName, valueName, _) =>
+        (v == accumName || v == valueName) && i == 2
+      case _ =>
+        false
     }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -40,6 +40,8 @@ object Compile {
     val fb = new EmitFunctionBuilder[F](argTypeInfo, GenericTypeInfo[R]())
 
     var ir = body
+    ir = Optimize(ir)
+
     val env = args
       .zipWithIndex
       .foldLeft(Env.empty[IR]) { case (e, ((n, t, _), i)) => e.bind(n, In(i, t)) }

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -734,49 +734,52 @@ private class Emit(
 
 
       case x@InsertFields(old, fields) =>
-        old.typ match {
-          case oldtype: TStruct =>
-            val codeOld = emit(old)
-            val xo = mb.newLocal[Long]
-            val xmo = mb.newLocal[Boolean]()
-            val updateInit = Map(fields.filter { case (name, _) => oldtype.hasField(name) }
-              .map { case (name, v) => name -> (v.typ, emit(v)) }: _*)
-            val appendInit = fields.filter { case (name, _) => !oldtype.hasField(name) }
-              .map { case (_, v) => (v.typ, emit(v)) }
-            val srvb = new StagedRegionValueBuilder(mb, x.typ)
-            present(Code(
-              srvb.start(init = true),
-              Code(
-                codeOld.setup,
-                xmo := codeOld.m,
-                xo := coerce[Long](xmo.mux(defaultValue(oldtype), codeOld.v)),
-                Code(oldtype.fields.map { f =>
-                  updateInit.get(f.name) match {
-                    case Some((t, EmitTriplet(dov, mv, vv))) =>
-                      Code(
-                        dov,
-                        mv.mux(srvb.setMissing(), srvb.addIRIntermediate(t)(vv)),
-                        srvb.advance())
-                    case None =>
-                      Code(
-                        (xmo || oldtype.isFieldMissing(region, xo, f.index)).mux(
-                          srvb.setMissing(),
-                          srvb.addIRIntermediate(f.typ)(region.loadIRIntermediate(f.typ)(oldtype.fieldOffset(xo, f.index)))
-                        ),
-                        srvb.advance())
-                  }
-                }: _*)),
-              Code(appendInit.map { case (t, EmitTriplet(setup, mv, vv)) =>
+        if (fields.isEmpty)
+          emit(old)
+        else
+          old.typ match {
+            case oldtype: TStruct =>
+              val codeOld = emit(old)
+              val xo = mb.newLocal[Long]
+              val xmo = mb.newLocal[Boolean]()
+              val updateInit = Map(fields.filter { case (name, _) => oldtype.hasField(name) }
+                .map { case (name, v) => name -> (v.typ, emit(v)) }: _*)
+              val appendInit = fields.filter { case (name, _) => !oldtype.hasField(name) }
+                .map { case (_, v) => (v.typ, emit(v)) }
+              val srvb = new StagedRegionValueBuilder(mb, x.typ)
+              present(Code(
+                srvb.start(init = true),
                 Code(
-                  setup,
-                  mv.mux(srvb.setMissing(), srvb.addIRIntermediate(t)(vv)),
-                  srvb.advance())
-              }: _*),
-              srvb.offset))
-          case _ =>
-            val newIR = MakeStruct(fields)
-            emit(newIR)
-        }
+                  codeOld.setup,
+                  xmo := codeOld.m,
+                  xo := coerce[Long](xmo.mux(defaultValue(oldtype), codeOld.v)),
+                  Code(oldtype.fields.map { f =>
+                    updateInit.get(f.name) match {
+                      case Some((t, EmitTriplet(dov, mv, vv))) =>
+                        Code(
+                          dov,
+                          mv.mux(srvb.setMissing(), srvb.addIRIntermediate(t)(vv)),
+                          srvb.advance())
+                      case None =>
+                        Code(
+                          (xmo || oldtype.isFieldMissing(region, xo, f.index)).mux(
+                            srvb.setMissing(),
+                            srvb.addIRIntermediate(f.typ)(region.loadIRIntermediate(f.typ)(oldtype.fieldOffset(xo, f.index)))
+                          ),
+                          srvb.advance())
+                    }
+                  }: _*)),
+                Code(appendInit.map { case (t, EmitTriplet(setup, mv, vv)) =>
+                  Code(
+                    setup,
+                    mv.mux(srvb.setMissing(), srvb.addIRIntermediate(t)(vv)),
+                    srvb.advance())
+                }: _*),
+                srvb.offset))
+            case _ =>
+              val newIR = MakeStruct(fields)
+              emit(newIR)
+          }
 
       case GetField(o, name) =>
         val t = coerce[TStruct](o.typ)
@@ -937,10 +940,11 @@ private class Emit(
     }
   }
 
-  private def getAsDependentFunction[A1 : TypeInfo, R : TypeInfo](
+  private def getAsDependentFunction[A1: TypeInfo, R: TypeInfo](
     ir: IR, argname: String, env: Emit.E, fb: EmitFunctionBuilder[_], errorMsg: String
   ): DependentFunction[AsmFunction3[Region, A1, Boolean, R]] = {
     var ids = Set[String]()
+
     def getReferenced: IR => IR = {
       case Ref(id, typ) if id == argname =>
         In(0, typ)
@@ -1001,8 +1005,8 @@ private class Emit(
             Code._fatal("Array range cannot have step size 0."),
             Code._empty[Unit]),
           llen := (step < 0).mux(
-              (start <= stop).mux(0L, (start.toL - stop.toL - 1L) / (-step).toL + 1L),
-              (start >= stop).mux(0L, (stop.toL - start.toL - 1L) / step.toL + 1L)),
+            (start <= stop).mux(0L, (start.toL - stop.toL - 1L) / (-step).toL + 1L),
+            (start >= stop).mux(0L, (stop.toL - start.toL - 1L) / step.toL + 1L)),
           (llen > const(Int.MaxValue.toLong)).mux(
             Code._fatal("Array range cannot have more than MAXINT elements."),
             len := (llen < 0L).mux(0L, llen).toI)

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -27,7 +27,6 @@ object Interpret {
 
     var ir = ir0.unwrap
     if (optimize) {
-      log.info("interpret: PRE-OPT\n" + Pretty(ir))
       ir = Optimize(ir)
       TypeCheck(ir, typeEnv, agg.map { agg =>
         agg._2.fields.foldLeft(Env.empty[Type]) { case (env, f) =>

--- a/src/main/scala/is/hail/expr/ir/Mentions.scala
+++ b/src/main/scala/is/hail/expr/ir/Mentions.scala
@@ -13,14 +13,15 @@ object CountMentions {
         else
           0
       case _ =>
-        if (Binds(x).contains(v))
-          0
-        else
-          Children(x).iterator.map {
-            case c: IR => CountMentions(c, v)
-            case _ => 0
-          }
-            .sum
+        Children(x).iterator.zipWithIndex.map {
+          case (c: IR, i) =>
+            if (Binds(x, v, i))
+              0
+            else
+              CountMentions(c, v)
+          case _ => 0
+        }
+          .sum
     }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/Mentions.scala
+++ b/src/main/scala/is/hail/expr/ir/Mentions.scala
@@ -1,17 +1,26 @@
 package is.hail.expr.ir
 
 object Mentions {
-  def apply(x: IR, v: String): Boolean = {
+  def apply(x: IR, v: String): Boolean = CountMentions(x, v) > 0
+}
+
+object CountMentions {
+  def apply(x: IR, v: String): Int = {
     x match {
-      case Ref(n, _) => v == n
+      case Ref(n, _) =>
+        if (v == n)
+          1
+        else
+          0
       case _ =>
         if (Binds(x).contains(v))
-          false
+          0
         else
-          Children(x).exists {
-            case c: IR => Mentions(c, v)
-            case _ => false
+          Children(x).iterator.map {
+            case c: IR => CountMentions(c, v)
+            case _ => 0
           }
+            .sum
     }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/Optimize.scala
+++ b/src/main/scala/is/hail/expr/ir/Optimize.scala
@@ -1,15 +1,20 @@
 package is.hail.expr.ir
 
-import is.hail.expr._
+import is.hail.utils._
 
 object Optimize {
   private def optimize(ir0: BaseIR): BaseIR = {
+    log.info("optimize: before:\n" + Pretty(ir0))
+
     var ir = ir0
     ir = FoldConstants(ir)
     ir = Simplify(ir)
     ir = PruneDeadFields(ir)
 
     assert(ir.typ == ir0.typ, s"optimization changed type!\n  before: ${ir0.typ}\n  after:  ${ir.typ}")
+
+    log.info("optimize: after:\n" + Pretty(ir))
+
     ir
   }
 

--- a/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -32,6 +32,18 @@ object Simplify {
     }
   }
 
+  private[this] def areFieldSelects(fields: Seq[(String, IR)]): Boolean = {
+    assert(fields.nonEmpty)
+    fields.head match {
+      case (_, GetField(s1, _)) =>
+        fields.forall {
+          case (f1, GetField(s2, f2)) if f1 == f2 && s1 == s2 => true
+          case _ => false
+        }
+      case _ => false
+    }
+  }
+
   def apply(ir: BaseIR): BaseIR = {
     RewriteBottomUp(ir, matchErrorToNone {
       // optimize IR
@@ -71,6 +83,13 @@ object Simplify {
       case ArrayFilter(a, _, True()) => a
 
       case Let(n, v, b) if !Mentions(b, n) => b
+
+      case Let(n, v, b) if CountMentions(b, n) == 1 =>
+        Subst(b, Env.empty[IR].bind(n, v))
+
+      case Let(_, _, Begin(Seq())) => Begin(FastIndexedSeq())
+
+      case ArrayFor(_, _, Begin(Seq())) => Begin(FastIndexedSeq())
 
       case ArrayFold(ArrayMap(a, n1, b), zero, accumName, valueName, body) => ArrayFold(a, zero, accumName, n1, Let(valueName, b, body))
 
@@ -120,6 +139,9 @@ object Simplify {
 
       case GetTupleElement(MakeTuple(xs), idx) => xs(idx)
 
+      case ApplyIR("annotate", Seq(s1, MakeStruct(Seq())), _) =>
+        s1
+
       // optimize TableIR
       case TableFilter(t, True()) => t
 
@@ -152,6 +174,14 @@ object Simplify {
       case TableCount(TableRange(n, _)) => I64(n)
 
       case TableCount(TableParallelize(_, rows, _)) => I64(rows.length)
+
+      case ApplyIR("annotate", Seq(s, MakeStruct(fields)), _) =>
+        InsertFields(s, fields)
+
+      case MakeStruct(fields) if fields.nonEmpty && areFieldSelects(fields) =>
+        val (_, GetField(s, _)) = fields(0)
+
+        SelectFields(s, fields.map(_._1))
 
         // flatten unions
       case TableUnion(children) if children.exists(_.isInstanceOf[TableUnion]) =>

--- a/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -183,6 +183,9 @@ object Simplify {
 
         SelectFields(s, fields.map(_._1))
 
+      case SelectFields(SelectFields(old, _), fields) =>
+        SelectFields(old, fields)
+
         // flatten unions
       case TableUnion(children) if children.exists(_.isInstanceOf[TableUnion]) =>
         TableUnion(children.flatMap {

--- a/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -178,11 +178,6 @@ object Simplify {
       case ApplyIR("annotate", Seq(s, MakeStruct(fields)), _) =>
         InsertFields(s, fields)
 
-      case MakeStruct(fields) if fields.nonEmpty && areFieldSelects(fields) =>
-        val (_, GetField(s, _)) = fields(0)
-
-        SelectFields(s, fields.map(_._1))
-
       case SelectFields(SelectFields(old, _), fields) =>
         SelectFields(old, fields)
 

--- a/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -31,13 +31,13 @@ object UtilFunctions extends RegistryFunctions {
 
     registerIR("range", TInt32())(ArrayRange(I32(0), _, I32(1)))
 
-    registerIR("annotate", tv("T", _.isInstanceOf[TStruct]), tv("U", _.isInstanceOf[TStruct])) { (s, annotations) =>
-      annotations match {
+    registerIR("annotate", tv("T", _.isInstanceOf[TStruct]), tv("U", _.isInstanceOf[TStruct])) { (s, s2) =>
+      s2 match {
         case s2: MakeStruct => InsertFields(s, s2.fields)
         case s2 =>
-          val styp = coerce[TStruct](s2.typ)
-          val struct = Ref(genUID(), styp)
-          Let(struct.name, s2, InsertFields(s, styp.fieldNames.map { n => n -> GetField(struct, n) } ))
+          val s2typ = coerce[TStruct](s2.typ)
+          val s2id = genUID()
+          Let(s2id, s2, InsertFields(s, s2typ.fieldNames.map { n => n -> GetField(Ref(s2id, s2typ), n) }))
       }
     }
 

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -211,10 +211,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
   def typ: TableType = tir.typ
   
   lazy val value: TableValue = {
-    log.info("in Table.value: pre-opt:\n" + ir.Pretty(tir))
     val opt = ir.Optimize(tir)
-    log.info("in Table.value: post-opt:\n" + ir.Pretty(opt))
-
     opt.execute(hc)
   }
 

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -494,11 +494,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     .toArray
 
   lazy val value: MatrixValue = {
-    log.info(s"MatrixValue: Pre-Opt:\n${Pretty(ast)}")
     val opt = ir.Optimize(ast)
-
-    log.info("in MatrixTable.value: execute:\n" + ir.Pretty(opt))
-
     val v = opt.execute(hc)
     assert(v.rvd.typ == matrixType.orvdType, s"\n${ v.rvd.typ }\n${ matrixType.orvdType }")
     v

--- a/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -258,6 +258,52 @@ class IRSuite extends SparkSuite {
     assertFatal(ArrayRange(I32(0), I32(5), I32(0)), "step size")
   }
 
+  @Test def testInsertFields() {
+    val s = TStruct("a" -> TInt64(), "b" -> TString())
+
+    assertEvalsTo(
+      InsertFields(
+        NA(s),
+        Seq()),
+      null)
+
+    assertEvalsTo(
+      InsertFields(
+        NA(s),
+        Seq("a" -> I64(5))),
+      Row(5L, null))
+
+    assertEvalsTo(
+      InsertFields(
+        NA(s),
+        Seq("c" -> F64(3.2))),
+      Row(null, null, 3.2))
+
+    assertEvalsTo(
+      InsertFields(
+        NA(s),
+        Seq("c" -> NA(TFloat64()))),
+      Row(null, null, null))
+
+    assertEvalsTo(
+      InsertFields(
+        MakeStruct(Seq("a" -> NA(TInt64()), "b" -> Str("abc"))),
+        Seq()),
+      Row(null, "abc"))
+
+    assertEvalsTo(
+      InsertFields(
+        MakeStruct(Seq("a" -> NA(TInt64()), "b" -> Str("abc"))),
+        Seq("a" -> I64(5))),
+      Row(5L, "abc"))
+
+    assertEvalsTo(
+      InsertFields(
+        MakeStruct(Seq("a" -> NA(TInt64()), "b" -> Str("abc"))),
+        Seq("c" -> F64(3.2))),
+      Row(null, "abc", 3.2))
+  }
+
   @Test def testTableCount() {
     assertEvalsTo(TableCount(TableRange(0, 4)), 0L)
     assertEvalsTo(TableCount(TableRange(7, 4)), 7L)


### PR DESCRIPTION
Improved the optimizer so the IR generated for:

```
mt = hl.import_vcf('sample.vcf')
mt.info.CCC.show()
```

is reasonable.

Run optimizer in compile, so we optimize (transformed) agg and seq ops.

Simplify runs:
 - propagate Begins up if possible
 - inline single-use Lets
 - (Apply annotate ...) => InsertFields if possible
 - Turn MakeStruct of a bunch of FieldRefs into InsertFields

The optimizer now turns this:

```
(TableMapGlobals Struct{} "{}"
  (MatrixRowsTable
    (MatrixMapRows None None
      (MatrixRead None False False ...)
      (Let __uid_1
        (MakeStruct
          (<expr>
            (GetField CCC
              (GetField info
                (Ref ... va)))))
        (ApplyIR annotate
          (MakeStruct
            (locus
              (GetField locus
                (Ref ... va)))
            (alleles
              (GetField alleles
                (Ref ... va))))
          (MakeStruct
            (<expr>
              (GetField `<expr>`
                (Ref Struct{`<expr>`:Int32} __uid_1))))))))
  (MakeStruct))
```

I shit you not, that's literally what's generated by:

```
import hail as hl
mt = hl.import_vcf('sample.vcf')
mt.info.CCC.show()
```

into:

```
(TableMapGlobals Struct{} "{}"
  (MatrixRowsTable
    (MatrixMapRows None None
      (MatrixRead ... False False ...)
      (InsertFields
        (SelectFields (locus alleles)
          (Ref ... va))
        (<expr>
          (GetField CCC
            (GetField info
              (Ref ... va)))))))
  (MakeStruct))
```

The only thing that's missing is to push the MatrixRowsTable into the MatrixMapRows.  @tpoterba, I thought you had code for this?  What happened?