### PR TITLE
add 'or_error' case to CaseBuilder

### DIFF
--- a/python/hail/expr/builders.py
+++ b/python/hail/expr/builders.py
@@ -225,8 +225,7 @@ class CaseBuilder(ConditionalBuilder):
         -------
         Missingness is treated similarly to :func:`.cond`. Missingness is
         **not** treated as ``False``. A `condition` that evaluates to missing
-        will return a missing result, not proceed to the next
-        :meth:`~.CaseBuilder.when` or :meth:`~.CaseBuilder.default`. Always
+        will return a missing result, not proceed to the next case. Always
         test missingness first in a :class:`.CaseBuilder`.
 
         Parameters

--- a/python/test/test_hail/expr/test_expr.py
+++ b/python/test/test_hail/expr/test_expr.py
@@ -379,6 +379,9 @@ class Tests(unittest.TestCase):
         self.assertEqual(hl.case().when(hl.null(hl.tbool), 1).default(2).value, None)
         self.assertEqual(hl.case(missing_false=True).when(hl.null(hl.tbool), 1).default(2).value, 2)
 
+        error_case = hl.case().when(False, 1).or_error("foo")
+        self.assertRaises(hl.utils.java.FatalError, lambda: hl.eval_expr(error_case))
+
     def test_struct_ops(self):
         s = hl.struct(f1=1, f2=2, f3=3)
 


### PR DESCRIPTION
it felt a little weird to directly define a hail function that's like "throw an error of the specified type", so I added it as an option to `hl.case()`, but I could break it out explicitly if that would be better.