### PR TITLE
filter_intervals now works on tables

### DIFF
--- a/python/hail/methods/misc.py
+++ b/python/hail/methods/misc.py
@@ -1,3 +1,5 @@
+from typing import *
+
 import hail as hl
 from hail.expr.expressions import *
 from hail.expr.types import *

--- a/python/hail/methods/misc.py
+++ b/python/hail/methods/misc.py
@@ -244,7 +244,7 @@ def rename_duplicates(dataset, name='unique_id') -> MatrixTable:
     return MatrixTable(dataset._jvds.renameDuplicates(name))
 
 
-@typecheck(ds=MatrixTable,
+@typecheck(ds=oneof(Table, MatrixTable),
            intervals=expr_array(expr_interval(expr_any)),
            keep=bool)
 def filter_intervals(ds, intervals, keep=True) -> MatrixTable:
@@ -274,13 +274,13 @@ def filter_intervals(ds, intervals, keep=True) -> MatrixTable:
 
     Parameters
     ----------
-    ds : :class:`.MatrixTable`
-        Dataset.
+    ds : :class:`.MatrixTable` or :class:`.Table`
+        Dataset to filter.
     intervals : :class:`.ArrayExpression` of type :py:data:`.tinterval`
-        Intervals to filter on. If there is only one row partition key, the
-        point type of the interval can be the type of the first partition key.
-        Otherwise, the interval point type must be a :class:`.Struct` matching
-        the row partition key schema.
+        Intervals to filter on.  The point type of the interval must
+        be a prefix of the partition key (when filtering a matrix
+        table) or the key (when filtering a table), or equal to the
+        first field of the key.
     keep : :obj:`bool`
         If ``True``, keep only rows that fall within any interval in `intervals`.
         If ``False``, keep only rows that fall outside all intervals in
@@ -288,19 +288,36 @@ def filter_intervals(ds, intervals, keep=True) -> MatrixTable:
 
     Returns
     -------
-    :class:`.MatrixTable`
+    :class:`.MatrixTable` or :class:`.Table`
+
     """
 
-    n_pk = len(ds.partition_key)
-    pk_type = ds.partition_key.dtype
+    if isinstance(ds, MatrixTable):
+        n_pk = len(ds.partition_key)
+        pk_type = ds.partition_key.dtype
+    else:
+        assert isinstance(ds, Table)
+        if ds.key is None:
+            raise TypeError("cannot filter intervals of an unkeyed Table")
+        n_pk = len(ds.key)
+        pk_type = ds.key.dtype
+
     point_type = intervals.dtype.element_type.point_type
 
-    if point_type == pk_type:
-        needs_wrapper = False
-    elif n_pk == 1 and point_type == ds.partition_key[0].dtype:
+    def is_struct_prefix(partial, full):
+        if list(partial) != list(full)[:len(partial)]:
+            return False
+        for k, v in partial.items():
+            if full[k] != v:
+                return False
+        return True
+
+    if point_type == pk_type[0]:
         needs_wrapper = True
+    elif isinstance(pk_type, tstruct) and is_struct_prefix(point_type, pk_type):
+        needs_wrapper = False
     else:
-        raise TypeError("The point type does not match the row partition key type of the dataset ('{}', '{}')".format(repr(point_type), repr(pk_type)))
+        raise TypeError("The point type is incompatible with key type of the dataset ('{}', '{}')".format(repr(point_type), repr(pk_type)))
 
     def wrap_input(interval):
         if interval is None:
@@ -314,8 +331,13 @@ def filter_intervals(ds, intervals, keep=True) -> MatrixTable:
             return interval
 
     intervals = [wrap_input(x)._jrep for x in intervals.value]
-    jmt = Env.hail().methods.FilterIntervals.apply(ds._jvds, intervals, keep)
-    return MatrixTable(jmt)
+    if isinstance(ds, MatrixTable):
+        jmt = Env.hail().methods.MatrixFilterIntervals.apply(ds._jvds, intervals, keep)
+        return MatrixTable(jmt)
+    else:
+        jt = Env.hail().methods.TableFilterIntervals.apply(ds._jt, intervals, keep)
+        return Table(jt)
+
 
 @typecheck(mt=MatrixTable, bp_window_size=int)
 def window_by_locus(mt: MatrixTable, bp_window_size: int) -> MatrixTable:

--- a/python/hail/methods/misc.py
+++ b/python/hail/methods/misc.py
@@ -247,7 +247,7 @@ def rename_duplicates(dataset, name='unique_id') -> MatrixTable:
 @typecheck(ds=oneof(Table, MatrixTable),
            intervals=expr_array(expr_interval(expr_any)),
            keep=bool)
-def filter_intervals(ds, intervals, keep=True) -> MatrixTable:
+def filter_intervals(ds, intervals, keep=True) -> Union[Table, MatrixTable]:
     """Filter rows with a list of intervals.
 
     Examples
@@ -314,7 +314,7 @@ def filter_intervals(ds, intervals, keep=True) -> MatrixTable:
 
     if point_type == pk_type[0]:
         needs_wrapper = True
-    elif isinstance(pk_type, tstruct) and is_struct_prefix(point_type, pk_type):
+    elif isinstance(point_type, tstruct) and is_struct_prefix(point_type, pk_type):
         needs_wrapper = False
     else:
         raise TypeError("The point type is incompatible with key type of the dataset ('{}', '{}')".format(repr(point_type), repr(pk_type)))

--- a/python/test/hail/methods/test_misc.py
+++ b/python/test/hail/methods/test_misc.py
@@ -97,7 +97,7 @@ class Tests(unittest.TestCase):
         self.assertTrue(mis.all(mis.node.is_case))
         self.assertTrue(set([row.id for row in mis.select(mis.node.id).collect()]) in expected_sets)
 
-    def test_filter_intervals(self):
+    def test_matrix_filter_intervals(self):
         ds = hl.import_vcf(resource('sample.vcf'), min_partitions=20)
 
         self.assertEqual(
@@ -118,6 +118,28 @@ class Tests(unittest.TestCase):
         intervals = [hl.parse_locus_interval('[20:10019093-10026348]').value,
                      hl.parse_locus_interval('[20:17705793-17716416]').value]
         self.assertEqual(hl.filter_intervals(ds, intervals).count_rows(), 4)
+
+    def test_table_filter_intervals(self):
+        ds = hl.import_vcf(resource('sample.vcf'), min_partitions=20).rows()
+
+        self.assertEqual(
+            hl.filter_intervals(ds, [hl.parse_locus_interval('20:10639222-10644705')]).count(), 3)
+
+        intervals = [hl.parse_locus_interval('20:10639222-10644700'),
+                     hl.parse_locus_interval('20:10644700-10644705')]
+        self.assertEqual(hl.filter_intervals(ds, intervals).count(), 3)
+
+        intervals = hl.array([hl.parse_locus_interval('20:10639222-10644700'),
+                              hl.parse_locus_interval('20:10644700-10644705')])
+        self.assertEqual(hl.filter_intervals(ds, intervals).count(), 3)
+
+        intervals = hl.array([hl.parse_locus_interval('20:10639222-10644700').value,
+                              hl.parse_locus_interval('20:10644700-10644705')])
+        self.assertEqual(hl.filter_intervals(ds, intervals).count(), 3)
+
+        intervals = [hl.parse_locus_interval('[20:10019093-10026348]').value,
+                     hl.parse_locus_interval('[20:17705793-17716416]').value]
+        self.assertEqual(hl.filter_intervals(ds, intervals).count(), 4)
 
     def test_filter_intervals_compound_partition_key(self):
         ds = hl.import_vcf(resource('sample.vcf'), min_partitions=20)

--- a/src/main/scala/is/hail/methods/FilterIntervals.scala
+++ b/src/main/scala/is/hail/methods/FilterIntervals.scala
@@ -1,36 +1,32 @@
 package is.hail.methods
 
-import is.hail.annotations.{UnsafeRow, WritableRegionValue}
+import is.hail.rvd.{OrderedRVD, OrderedRVDType}
+import is.hail.table.Table
 import is.hail.utils.{Interval, IntervalTree}
 import is.hail.variant.MatrixTable
-import org.apache.spark.sql.Row
 
 import scala.collection.JavaConverters._
 
-object FilterIntervals {
-  def apply(vsm: MatrixTable, intervals: java.util.ArrayList[Interval], keep: Boolean): MatrixTable = {
-    val iList = IntervalTree(vsm.rvd.typ.pkType.ordering, intervals.asScala.toArray)
-    apply(vsm, iList, keep)
+object MatrixFilterIntervals {
+  def apply(mt: MatrixTable, jintervals: java.util.ArrayList[Interval], keep: Boolean): MatrixTable = {
+    val intervals = IntervalTree(mt.rvd.typ.pkType.ordering, jintervals.asScala.toArray)
+    mt.copy2(rvd = mt.rvd.filterIntervals(intervals, keep))
   }
+}
 
-  def apply[U](vsm: MatrixTable, intervals: IntervalTree[U], keep: Boolean): MatrixTable = {
-    if (keep) {
-      vsm.copy2(rvd = vsm.rvd.filterIntervals(intervals))
-    } else {
-      val intervalsBc = vsm.sparkContext.broadcast(intervals)
-      val pkType = vsm.rvd.typ.pkType
-      val pkRowFieldIdx = vsm.rvd.typ.pkRowFieldIdx
-      val rowType = vsm.rvd.typ.rowType
+object TableFilterIntervals {
+  def apply(ht: Table, jintervals: java.util.ArrayList[Interval], keep: Boolean): Table = {
+    assert(ht.key.isDefined)
 
-      vsm.copy2(rvd = vsm.rvd.mapPartitionsPreservesPartitioning(vsm.rvd.typ, { (ctx, it) =>
-        val pkUR = new UnsafeRow(pkType)
-        it.filter { rv =>
-          ctx.rvb.start(pkType)
-          ctx.rvb.selectRegionValue(rowType, pkRowFieldIdx, rv)
-          pkUR.set(ctx.region, ctx.rvb.end())
-          !intervalsBc.value.contains(pkType.ordering, pkUR)
-        }
-      }))
+    val orvd = ht.rvd match {
+      case ordered: OrderedRVD => ordered
+      case unordered =>
+        OrderedRVD.coerce(
+          new OrderedRVDType(ht.key.get.toArray, ht.key.get.toArray, ht.signature),
+          unordered)
     }
+
+    val intervals = IntervalTree(orvd.typ.pkType.ordering, jintervals.asScala.toArray)
+    ht.copy2(rvd = orvd.filterIntervals(intervals, keep))
   }
 }

--- a/src/main/scala/is/hail/methods/FilterIntervals.scala
+++ b/src/main/scala/is/hail/methods/FilterIntervals.scala
@@ -17,15 +17,7 @@ object MatrixFilterIntervals {
 object TableFilterIntervals {
   def apply(ht: Table, jintervals: java.util.ArrayList[Interval], keep: Boolean): Table = {
     assert(ht.key.isDefined)
-
-    val orvd = ht.rvd match {
-      case ordered: OrderedRVD => ordered
-      case unordered =>
-        OrderedRVD.coerce(
-          new OrderedRVDType(ht.key.get.toArray, ht.key.get.toArray, ht.signature),
-          unordered)
-    }
-
+    val orvd = ht.value.enforceOrderingRVD.asInstanceOf[OrderedRVD]
     val intervals = IntervalTree(orvd.typ.pkType.ordering, jintervals.asScala.toArray)
     ht.copy2(rvd = orvd.filterIntervals(intervals, keep))
   }

--- a/src/test/scala/is/hail/variant/LocusIntervalSuite.scala
+++ b/src/test/scala/is/hail/variant/LocusIntervalSuite.scala
@@ -1,14 +1,7 @@
 package is.hail.variant
 
 import is.hail.{SparkSuite, TestUtils}
-import is.hail.annotations.Annotation
-import is.hail.check.{Gen, Prop}
-import is.hail.expr.types._
-import is.hail.io.annotators.IntervalList
-import is.hail.methods.FilterIntervals
 import is.hail.utils._
-import is.hail.testUtils._
-import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
 class LocusIntervalSuite extends SparkSuite {
@@ -92,13 +85,5 @@ class LocusIntervalSuite extends SparkSuite {
     val z = "[HLA-DRB1*13:02:01:5-100)"
     assert(Locus.parseInterval(z, gr38) ==
       Interval(Locus("HLA-DRB1*13:02:01", 5), Locus("HLA-DRB1*13:02:01", 100), true, false))
-  }
-
-  @Test def testFilterIntervals() {
-    val ds = hc.importVCF("src/test/resources/sample.vcf", nPartitions=Some(20))
-    val intervals = Array(Interval(Row(Locus("20", 10019093)), Row(Locus("20", 10026348)), true, true),
-      Interval(Row(Locus("20", 17705793)), Row(Locus("20", 17716416)), true, true))
-    val iTree = IntervalTree(ds.rvd.typ.pkType.ordering, intervals)
-    assert(FilterIntervals(ds, iTree, true).countRows() == 4)
   }
 }


### PR DESCRIPTION
Along the way, I slightly generalized filter_intervals to support filtering on intervals that are a prefix of the partition key.

FYI @konradjk 