### PR TITLE
fix condition bug in emit

### DIFF
--- a/src/main/scala/is/hail/asm4s/Code.scala
+++ b/src/main/scala/is/hail/asm4s/Code.scala
@@ -174,8 +174,11 @@ object Code {
     m.invoke(staticObj.get(), args)
   }
 
+  def invokeScalaObject[S](cls: Class[_], method: String)(implicit sct: ClassTag[S]): Code[S] =
+    invokeScalaObject[S](cls, method, Array[Class[_]](), Array[Code[_]]())
+
   def invokeScalaObject[A1, S](cls: Class[_], method: String, a1: Code[A1])(implicit a1ct: ClassTag[A1], sct: ClassTag[S]): Code[S] =
-    invokeScalaObject[S](cls, method, Array[Class[_]](a1ct.runtimeClass), Array(a1))
+    invokeScalaObject[S](cls, method, Array[Class[_]](a1ct.runtimeClass), Array[Code[_]](a1))
 
   def invokeScalaObject[A1, A2, S](cls: Class[_], method: String, a1: Code[A1], a2: Code[A2])(implicit a1ct: ClassTag[A1], a2ct: ClassTag[A2], sct: ClassTag[S]): Code[S] =
     invokeScalaObject[S](cls, method, Array[Class[_]](a1ct.runtimeClass, a2ct.runtimeClass), Array(a1, a2))

--- a/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -260,8 +260,8 @@ private class Emit(
             codeCond.m.mux(
               Code(mout := true, out := defaultValue(typ)),
               coerce[Boolean](codeCond.v).mux(
-                Code(codeCnsq.setup, mout := codeCnsq.m, out := codeCnsq.m.mux(defaultValue(typ), codeCnsq.v)),
-                Code(codeAltr.setup, mout := codeAltr.m, out := codeAltr.m.mux(defaultValue(typ), codeAltr.v)))))
+                Code(codeCnsq.setup, mout := codeCnsq.m, out := mout.mux(defaultValue(typ), codeCnsq.v)),
+                Code(codeAltr.setup, mout := codeAltr.m, out := mout.mux(defaultValue(typ), codeAltr.v)))))
 
           EmitTriplet(setup, mout, out)
         }


### PR DESCRIPTION
Fixes https://github.com/hail-is/hail/issues/3969

This was quite a subtle one.  I was able to replicate:

before:

```
>>> ht = hl.utils.range_table(1000)
>>> ht = ht.annotate(tp = True)
>>> ht = ht.annotate(x = hl.cond(~ht.tp, ht.tp, ht.tp & hl.rand_bool(0.5)))
>>> ht.aggregate(hl.agg.counter(ht.x))
{False: 755, True: 245}
>>> ht = hl.utils.range_table(1000)
>>> ht = ht.annotate(tp = True)
>>> ht = ht.annotate(x = ht.tp & hl.rand_bool(0.5))
>>> ht.aggregate(hl.agg.counter(ht.x))
{False: 490, True: 510}
```

after

```
>>> ht = ht.annotate(tp = True)
>>> ht = ht.annotate(x = hl.cond(~ht.tp, ht.tp, ht.tp & hl.rand_bool(0.5)))
>>> ht.aggregate(hl.agg.counter(ht.x))
{False: 498, True: 502}
>>> ht = hl.utils.range_table(1000)
>>> ht = ht.annotate(tp = True)
>>> ht = ht.annotate(x = ht.tp & hl.rand_bool(0.5))
>>> ht.aggregate(hl.agg.counter(ht.x))
{False: 489, True: 511}
```

Rather than put in a probabilistic test, I directly test the number of executions of the parts of the EmitTriplet of the children of the conditional.  I verified the test catches the bug.