### PR TITLE
remove per-row flush in table write

### DIFF
--- a/src/main/scala/is/hail/io/RowStore.scala
+++ b/src/main/scala/is/hail/io/RowStore.scala
@@ -1071,7 +1071,6 @@ object RichContextRDDRegionValue {
     it.foreach { rv =>
       en.writeByte(1)
       en.writeRegionValue(rv.region, rv.offset)
-      en.flush()
       ctx.region.clear()
       rowCount += 1
 
@@ -1083,8 +1082,11 @@ object RichContextRDDRegionValue {
 
     en.writeByte(0) // end
     en.flush()
+    if (outputMetrics != null) {
+      ExposedMetrics.setBytes(outputMetrics, trackedOS.bytesWritten)
+    }
     os.close()
-
+    
     rowCount
   }
 }


### PR DESCRIPTION
Table write was completely fucked.  It was flushing the encoder after every record (putting each row in its own compression block).

before:

```
In [2]: %%time
   ...: t1 = hl.utils.range_table(10 * 1000 * 1000)
   ...: t2 = t1.annotate(x = hl.rand_unif(0, 1))
   ...: t2.write('t2.ht', overwrite=True)
   ...: 
2018-07-29 14:16:23 Hail: INFO: wrote 10000000 items in 8 partitions
CPU times: user 14.6 ms, sys: 775 µs, total: 15.3 ms
Wall time: 27.9 s

In [3]: %%time
   ...: t3 = hl.read_table('t2.ht')
   ...: t3._force_count()
   ...: 
CPU times: user 4.09 ms, sys: 8 µs, total: 4.1 ms
Wall time: 1.48 s
```

after:

```
In [3]: %%time
   ...: t1 = hl.utils.range_table(10 * 1000 * 1000)
   ...: t2 = t1.annotate(x = hl.rand_unif(0, 1))
   ...: t2.write('t2.ht', overwrite=True)
   ...: 
2018-07-29 14:20:34 Hail: INFO: wrote 10000000 items in 8 partitions
CPU times: user 11.4 ms, sys: 495 µs, total: 11.9 ms
Wall time: 2.89 s

In [4]: %%time
   ...: t3 = hl.read_table('t2.ht')
   ...: t3._force_count()
   ...: 
CPU times: user 3.36 ms, sys: 221 µs, total: 3.58 ms
Wall time: 1.42 s
```

File size was about cut in half (220MB => 120MB).
