### PR TITLE
speed up TableFilter.

### DIFF
--- a/src/main/scala/is/hail/rvd/RVD.scala
+++ b/src/main/scala/is/hail/rvd/RVD.scala
@@ -272,6 +272,8 @@ trait RVD {
 
   def filter(f: (RegionValue) => Boolean): RVD
 
+  def filterWithContext[C](makeContext: RVDContext => C, f: (C, RegionValue) => Boolean): RVD
+
   def map(newRowType: TStruct)(f: (RegionValue) => RegionValue): UnpartitionedRVD =
     new UnpartitionedRVD(newRowType, crdd.map(f))
 


### PR DESCRIPTION
1. Convert globals once per partition instead of once per row.

2. Add filterWithContext method so filter doesn't strip partitioning