### PR TITLE
Refactor _select methods in python

### DIFF
--- a/python/hail/expr/expressions/base_expression.py
+++ b/python/hail/expr/expressions/base_expression.py
@@ -766,7 +766,7 @@ class Expression(object):
         """
         uid = Env.get_uid()
         t = self._to_table(uid)
-        return [r[uid] for r in t._select("collect", None, hl.struct(**{uid: t[uid]})).collect()]
+        return [r[uid] for r in t._select("collect", hl.struct(**{uid: t[uid]}), None).collect()]
 
     @property
     def value(self):

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -394,9 +394,9 @@ class Table(ExprContainer):
 
     @typecheck_method(caller=str,
                       row=expr_struct(),
-                      new_keys=oneof(nullable(sequenceof(str)), exactly("default")))
+                      new_keys=oneof(exactly("default"), nullable(sequenceof(str))))
     def _select(self, caller, row, new_keys="default"):
-        if new_keys == 'default':
+        if new_keys == "default":
             new_key = list(self.key.keys()) if self.key is not None else None
             preserved_key = preserved_key_new = new_key
         elif new_keys == None:
@@ -404,6 +404,7 @@ class Table(ExprContainer):
             preserved_key_new = None
             new_key = None
         else:
+            print(new_keys)
             key_struct = hl.struct(**{name: row[name] for name in new_keys})
             preserved_key, preserved_key_new, new_key = self._preserved_key_pairs(key_struct)
 
@@ -899,7 +900,7 @@ class Table(ExprContainer):
                                      protect_keys=True)
         row = self.key.annotate(**row_exprs) if self.key else hl.struct(**row_exprs)
 
-        return self._select('Table.select', **row)
+        return self._select('Table.select', row)
 
     @typecheck_method(exprs=oneof(str, Expression))
     def drop(self, *exprs):

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -1996,7 +1996,7 @@ class Table(ExprContainer):
 
         table = self
         if row_key_map or row_value_map:
-            new_keys = {row_key_map.get(k, k): v for k, v in table.key.items()} if table.key else None
+            new_keys = {row_key_map.get(k, k): v for k, v in table.key.items()} if table.key else dict()
             new_values = {row_value_map.get(k, k): v for k, v in table.row_value.items()}
             table = table._select("Table.rename",
                                   hl.struct(**new_keys, **new_values),

--- a/python/test/hail/table/test_table.py
+++ b/python/test/hail/table/test_table.py
@@ -380,11 +380,11 @@ class Tests(unittest.TestCase):
         kt = kt.annotate(sq=kt.idx ** 2, foo='foo', bar='bar').key_by('foo')
 
         ktd = kt.drop('idx')
-        self.assertEqual(list(ktd.row), ['foo', 'sq', 'bar'])
+        self.assertEqual(set(ktd.row), {'foo', 'sq', 'bar'})
         ktd = ktd.key_by(None).drop('foo')
         self.assertEqual(ktd.key, None)
 
-        self.assertEqual(list(kt.drop(kt['idx']).row), ['foo', 'sq', 'bar'])
+        self.assertEqual(set(kt.drop(kt['idx']).row), {'foo', 'sq', 'bar'})
 
         d = kt.key_by(None).drop(*list(kt.row))
         self.assertEqual(list(d.row), [])


### PR DESCRIPTION
for better IR generation. This change the (`key_struct`, `value_struct`) arguments to a more general (`row`, `new_keys`) which allows individual methods more flexibility in how the row is constructed.

@tpoterba this fixes the specific case in #4001, but I'm not sure if you wanted to keep that open as a general issue or just open issues with other cases as we test them? With this change I'm getting:

```
2018-07-30 18:11:23 root: INFO: optimize: before:
(TableMapRows (idx) 1
  (TableRange 5 2)
  (InsertFields
    (Ref Struct{idx:Int32} row)
    (x
      (I32 5))))
2018-07-30 18:11:23 root: INFO: optimize: after:
(TableMapRows (idx) 1
  (TableRange 5 2)
  (InsertFields
    (Ref Struct{idx:Int32} row)
    (x
      (I32 5))))
```