### PR TITLE
add more logic to MatrixUnionRows

### DIFF
--- a/src/main/scala/is/hail/annotations/OrderedRVIterator.scala
+++ b/src/main/scala/is/hail/annotations/OrderedRVIterator.scala
@@ -124,4 +124,11 @@ case class OrderedRVIterator(
       this.t.kComp(other.t).compare
     )
   }
+
+  def merge(other: OrderedRVIterator): Iterator[RegionValue] = {
+    iterator.toFlipbookIterator.merge(
+      other.iterator.toFlipbookIterator,
+      this.t.kComp(other.t).compare
+    )
+  }
 }

--- a/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -1978,8 +1978,7 @@ case class MatrixUnionRows(children: IndexedSeq[MatrixIR]) extends MatrixIR {
 
   def execute(hc: HailContext): MatrixValue = {
     val values = children.map(_.execute(hc))
-    checkColKeysSame(values.map(_.colValues.value))
-
+    checkColKeysSame(values.map(_.colValues.value))O
     val rvds = values.map(  _.rvd)
     val first = rvds.head
     require(rvds.tail.forall(_.partitioner.pkType == first.partitioner.pkType))

--- a/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -1981,7 +1981,7 @@ case class MatrixUnionRows(children: IndexedSeq[MatrixIR]) extends MatrixIR {
     checkColKeysSame(values.map(_.colValues.value))
     val rvds = values.map(_.rvd)
     val first = rvds.head
-    require(rvds.tail.forall(_.partitioner.pkType == first.partitioner.pkType))
+    require(rvds.tail.forall(_.partitioner.kType == first.partitioner.kType))
     rvds.filter(_.partitioner.range.isDefined) match {
       case IndexedSeq() =>
         values.head

--- a/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -1978,7 +1978,7 @@ case class MatrixUnionRows(children: IndexedSeq[MatrixIR]) extends MatrixIR {
 
   def execute(hc: HailContext): MatrixValue = {
     val values = children.map(_.execute(hc))
-    checkColKeysSame(values.map(_.colValues.value))O
+    checkColKeysSame(values.map(_.colValues.value))
     val rvds = values.map(  _.rvd)
     val first = rvds.head
     require(rvds.tail.forall(_.partitioner.pkType == first.partitioner.pkType))

--- a/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -1982,11 +1982,14 @@ case class MatrixUnionRows(children: IndexedSeq[MatrixIR]) extends MatrixIR {
     val rvds = values.map(_.rvd)
     val first = rvds.head
     require(rvds.tail.forall(_.partitioner.pkType == first.partitioner.pkType))
-    val nonEmpty = rvds.filter(_.partitioner.range.isDefined)
-    if (nonEmpty.isEmpty)
-      values.head
-    else
-      values.head.copy(rvd = OrderedRVD.union(nonEmpty))
+    rvds.filter(_.partitioner.range.isDefined) match {
+      case IndexedSeq() =>
+        values.head
+      case IndexedSeq(rvd) =>
+        values.head.copy(rvd = rvd)
+      case nonEmpty =>
+        values.head.copy(rvd = OrderedRVD.union(nonEmpty))
+    }
   }
 }
 

--- a/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -210,9 +210,6 @@ object Simplify {
           case c => Some(c)
         })
 
-      case MatrixRowsTable(MatrixUnionRows(children)) =>
-        TableUnion(children.map(MatrixRowsTable))
-
       case MatrixColsTable(MatrixUnionRows(children)) =>
         MatrixColsTable(children(0))
 

--- a/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -210,6 +210,10 @@ object Simplify {
           case c => Some(c)
         })
 
+      // FIXME: currently doesn't work because TableUnion makes no guarantee on order. Put back in once ordering is enforced on Tables
+//      case MatrixRowsTable(MatrixUnionRows(children)) =>
+//        TableUnion(children.map(MatrixRowsTable))
+
       case MatrixColsTable(MatrixUnionRows(children)) =>
         MatrixColsTable(children(0))
 

--- a/src/main/scala/is/hail/rvd/KeyedOrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/KeyedOrderedRVD.scala
@@ -114,4 +114,26 @@ class KeyedOrderedRVD(val rvd: OrderedRVD, val key: Array[String]) {
         .zipJoin(OrderedRVIterator(rightType, rightIt, ctx))
     }
   }
+
+  def orderedMerge(right: KeyedOrderedRVD): OrderedRVD = {
+    checkJoinCompatability(right)
+    require(this.typ.rowType == right.typ.rowType)
+
+    val newPartitioner = OrderedRVDPartitioner.mergePartitioners(Array(this.rvd.partitioner, right.rvd.partitioner))
+    val repartitionedLeft =
+      this.rvd.constrainToOrderedPartitioner(this.typ, newPartitioner)
+    val repartitionedRight =
+      right.rvd.constrainToOrderedPartitioner(right.typ, newPartitioner)
+    val leftType = this.typ
+    val rightType = right.typ
+    repartitionedLeft.zipPartitions(
+      this.typ,
+      newPartitioner,
+      repartitionedRight,
+      preservesPartitioning = true
+    ) { (ctx, leftIt, rightIt) =>
+      OrderedRVIterator(leftType, leftIt, ctx)
+        .merge(OrderedRVIterator(rightType, rightIt, ctx))
+    }
+  }
 }

--- a/src/main/scala/is/hail/rvd/KeyedOrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/KeyedOrderedRVD.scala
@@ -119,7 +119,7 @@ class KeyedOrderedRVD(val rvd: OrderedRVD, val key: Array[String]) {
     checkJoinCompatability(right)
     require(this.typ.rowType == right.typ.rowType)
 
-    val newPartitioner = OrderedRVDPartitioner.mergePartitioners(Array(this.rvd.partitioner, right.rvd.partitioner))
+    val newPartitioner = OrderedRVDPartitioner.mergePartitioners(this.rvd.partitioner, right.rvd.partitioner)
     val repartitionedLeft =
       this.rvd.constrainToOrderedPartitioner(this.typ, newPartitioner)
     val repartitionedRight =

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -1067,7 +1067,7 @@ object OrderedRVD {
         new OrderedRVD(
           first.typ,
           first.partitioner.copy(numPartitions = newRangeBounds.length, rangeBounds = newRangeBounds),
-          ContextRDD.union(first.sparkContext, rvds.map(_.crdd)))
+          ContextRDD.union(first.sparkContext, sorted.map(_.crdd)))
     }
   }
 

--- a/src/main/scala/is/hail/rvd/OrderedRVD.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVD.scala
@@ -164,6 +164,9 @@ class OrderedRVD(
   def orderedZipJoin(right: OrderedRVD): ContextRDD[RVDContext, JoinedRegionValue] =
     keyBy().orderedZipJoin(right.keyBy())
 
+  def orderedMerge(right: OrderedRVD): OrderedRVD =
+    keyBy().orderedMerge(right.keyBy())
+
   def partitionSortedUnion(rdd2: OrderedRVD): OrderedRVD = {
     assert(typ == rdd2.typ)
     assert(partitioner == rdd2.partitioner)
@@ -1073,10 +1076,6 @@ object OrderedRVD {
 
   def union(rvds: Seq[OrderedRVD]): OrderedRVD = {
     require(rvds.length > 1)
-    OrderedRVD.coerce(
-      rvds.head.typ,
-      RVD.union(rvds),
-      None,
-      None)
+    rvds.reduce(_.orderedMerge(_))
   }
 }

--- a/src/main/scala/is/hail/rvd/OrderedRVDPartitioner.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVDPartitioner.scala
@@ -200,6 +200,11 @@ object OrderedRVDPartitioner {
   // resulting partition only comes from one partition per original partitioner.
   def mergePartitioners(p1: OrderedRVDPartitioner, p2: OrderedRVDPartitioner): OrderedRVDPartitioner = {
     require(p1.pkType == p2.pkType)
+    if (p1.range.isEmpty)
+      return p2
+    if (p2.range.isEmpty)
+      return p1
+
     val ord = p1.kType.ordering
     def cmp(p1: (Any, Boolean), p2: (Any, Boolean)): Int = {
       val c = ord.compare(p1._1, p2._1)

--- a/src/main/scala/is/hail/rvd/OrderedRVDPartitioner.scala
+++ b/src/main/scala/is/hail/rvd/OrderedRVDPartitioner.scala
@@ -199,7 +199,7 @@ object OrderedRVDPartitioner {
   // takes range bounds from n partitioners and splits them such that each
   // resulting partition only comes from one partition per original partitioner.
   def mergePartitioners(p1: OrderedRVDPartitioner, p2: OrderedRVDPartitioner): OrderedRVDPartitioner = {
-    require(p1.pkType == p2.pkType)
+    require(p1.kType == p2.kType)
     if (p1.range.isEmpty)
       return p2
     if (p2.range.isEmpty)

--- a/src/main/scala/is/hail/utils/FlipbookIterator.scala
+++ b/src/main/scala/is/hail/utils/FlipbookIterator.scala
@@ -390,7 +390,7 @@ abstract class FlipbookIterator[A] extends BufferedIterator[A] { self =>
       }
     }
     val sm = new MergeStateMachine
-      sm.advance()
+    sm.advance()
     FlipbookIterator(sm)
   }
 

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -173,7 +173,10 @@ object MatrixTable {
   }
 
   def range(hc: HailContext, nRows: Int, nCols: Int, nPartitions: Option[Int]): MatrixTable =
-    new MatrixTable(hc, MatrixIR.range(hc, nRows, nCols, nPartitions))
+    if (nRows == 0) {
+      new MatrixTable(hc, MatrixIR.range(hc, nRows, nCols, nPartitions, dropRows=true))
+    } else
+      new MatrixTable(hc, MatrixIR.range(hc, nRows, nCols, nPartitions))
 
   def gen(hc: HailContext, gen: VSMSubgen): Gen[MatrixTable] =
     gen.gen(hc)

--- a/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
@@ -98,6 +98,7 @@ class MatrixIRSuite extends SparkSuite {
 
   @DataProvider(name="unionRowsData")
   def unionRowsData(): Array[Array[Any]] = Array(
+    Array(FastIndexedSeq(0 -> 0, 5 -> 7)),
     Array(FastIndexedSeq(0 -> 1, 5 -> 7)),
     Array(FastIndexedSeq(0 -> 6, 5 -> 7)),
     Array(FastIndexedSeq(2 -> 3, 0 -> 1, 5 -> 7)),

--- a/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
@@ -98,15 +98,14 @@ class MatrixIRSuite extends SparkSuite {
 
   @DataProvider(name="unionRowsData")
   def unionRowsData(): Array[Array[Any]] = Array(
-    Array(Array(0 -> 0, 5 -> 7)),
-    Array(Array(0 -> 1, 5 -> 7)),
-    Array(Array(0 -> 6, 5 -> 7)),
-    Array(Array(2 -> 3, 0 -> 1, 5 -> 7)),
-    Array(Array(2 -> 4, 0 -> 3, 5 -> 7)),
-    Array(Array(3 -> 6, 0 -> 1, 5 -> 7)))
+    Array(FastIndexedSeq(0 -> 1, 5 -> 7)),
+    Array(FastIndexedSeq(0 -> 6, 5 -> 7)),
+    Array(FastIndexedSeq(2 -> 3, 0 -> 1, 5 -> 7)),
+    Array(FastIndexedSeq(2 -> 4, 0 -> 3, 5 -> 7)),
+    Array(FastIndexedSeq(3 -> 6, 0 -> 1, 5 -> 7)))
 
   @Test(dataProvider = "unionRowsData")
-  def testMatrixUnionRows(ranges: Array[(Int, Int)]) {
+  def testMatrixUnionRows(ranges: IndexedSeq[(Int, Int)]) {
     val expectedOrdering = ranges.flatMap{ case (start, end) =>
       Array.range(start, end)
     }.sorted

--- a/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
@@ -3,13 +3,20 @@ package is.hail.expr.ir
 import is.hail.SparkSuite
 import is.hail.expr.ir.TestUtils._
 import is.hail.table.Table
+import is.hail.utils.FastIndexedSeq
 import is.hail.variant.MatrixTable
 import org.apache.spark.sql.Row
-import org.testng.annotations.Test
+import org.testng.annotations.{DataProvider, Test}
 
 class MatrixIRSuite extends SparkSuite {
 
   def rangeMatrix: MatrixIR = MatrixTable.range(hc, 20, 20, Some(4)).ast
+
+  def getRows(mir: MatrixIR): Array[Row] =
+    MatrixRowsTable(mir).execute(hc).rdd.collect()
+
+  def getCols(mir: MatrixIR): Array[Row] =
+    MatrixColsTable(mir).execute(hc).rdd.collect()
 
   @Test def testScanCountBehavesLikeIndexOnRows() {
     val mt = rangeMatrix
@@ -18,7 +25,7 @@ class MatrixIRSuite extends SparkSuite {
     val newRow = InsertFields(oldRow, Seq("idx" -> IRScanCount))
 
     val newMatrix = MatrixMapRows(mt, newRow, None)
-    val rows = MatrixRowsTable(newMatrix).execute(hc).rdd.collect()
+    val rows = getRows(newMatrix)
     assert(rows.forall { case Row(row_idx, idx) => row_idx == idx})
   }
 
@@ -29,7 +36,7 @@ class MatrixIRSuite extends SparkSuite {
     val newRow = InsertFields(oldRow, Seq("range" -> IRScanCollect(GetField(oldRow, "row_idx"))))
 
     val newMatrix = MatrixMapRows(mt, newRow, None)
-    val rows = MatrixRowsTable(newMatrix).execute(hc).rdd.collect()
+    val rows = getRows(newMatrix)
     assert(rows.forall { case Row(row_idx: Int, range: IndexedSeq[Int]) => range sameElements Array.range(0, row_idx)})
   }
 
@@ -40,7 +47,7 @@ class MatrixIRSuite extends SparkSuite {
     val newRow = InsertFields(oldRow, Seq("n" -> IRAggCount, "range" -> IRScanCollect(GetField(oldRow, "row_idx").toL)))
 
     val newMatrix = MatrixMapRows(mt, newRow, None)
-    val rows = MatrixRowsTable(newMatrix).execute(hc).rdd.collect()
+    val rows = getRows(newMatrix)
     assert(rows.forall { case Row(row_idx: Int, n: Long, range: IndexedSeq[Int]) => (n == 20) && (range sameElements Array.range(0, row_idx))})
   }
 
@@ -51,7 +58,7 @@ class MatrixIRSuite extends SparkSuite {
     val newCol = InsertFields(oldCol, Seq("idx" -> IRScanCount))
 
     val newMatrix = MatrixMapCols(mt, newCol, None)
-    val cols = MatrixColsTable(newMatrix).execute(hc).rdd.collect()
+    val cols = getCols(newMatrix)
     assert(cols.forall { case Row(col_idx, idx) => col_idx == idx})
   }
 
@@ -62,10 +69,9 @@ class MatrixIRSuite extends SparkSuite {
     val newCol = InsertFields(oldCol, Seq("range" -> IRScanCollect(GetField(oldCol, "col_idx"))))
 
     val newMatrix = MatrixMapCols(mt, newCol, None)
-    val cols = MatrixColsTable(newMatrix).execute(hc).rdd.collect()
+    val cols = getCols(newMatrix)
     assert(cols.forall { case Row(col_idx: Int, range: IndexedSeq[Int]) => range sameElements Array.range(0, col_idx)})
   }
-
 
   @Test def testScanCollectBehavesLikeRangeWithAggregationOnCols() {
     val mt = rangeMatrix
@@ -74,7 +80,42 @@ class MatrixIRSuite extends SparkSuite {
     val newCol = InsertFields(oldCol, Seq("n" -> IRAggCount, "range" -> IRScanCollect(GetField(oldCol, "col_idx").toL)))
 
     val newMatrix = MatrixMapCols(mt, newCol, None)
-    val cols = MatrixColsTable(newMatrix).execute(hc).rdd.collect()
+    val cols = getCols(newMatrix)
     assert(cols.forall { case Row(col_idx: Int, n: Long, range: IndexedSeq[Int]) => (n == 20) && (range sameElements Array.range(0, col_idx))})
+  }
+
+  def rangeRowMatrix(start: Int, end: Int): MatrixIR = {
+    val i = end - start
+    val baseRange = MatrixTable.range(hc, i, 5, Some(math.min(4, i))).ast
+    val row = Ref("va", baseRange.typ.rvRowType)
+    MatrixMapRows(baseRange,
+      InsertFields(
+        row,
+        FastIndexedSeq("row_idx" -> (GetField(row, "row_idx") + start))),
+      Some(FastIndexedSeq("row_idx") ->
+        FastIndexedSeq.empty))
+  }
+
+  @DataProvider(name="unionRowsData")
+  def unionRowsData(): Array[Array[Any]] = Array(
+    Array(Array(0 -> 0, 5 -> 7)),
+    Array(Array(0 -> 1, 5 -> 7)),
+    Array(Array(0 -> 6, 5 -> 7)),
+    Array(Array(2 -> 3, 0 -> 1, 5 -> 7)),
+    Array(Array(2 -> 4, 0 -> 3, 5 -> 7)),
+    Array(Array(3 -> 6, 0 -> 1, 5 -> 7)))
+
+  @Test(dataProvider = "unionRowsData")
+  def testMatrixUnionRows(ranges: Array[(Int, Int)]) {
+    val expectedOrdering = ranges.flatMap{ case (start, end) =>
+      Array.range(start, end)
+    }.sorted
+
+    val unioned = MatrixUnionRows(ranges.map { case (start, end) =>
+      rangeRowMatrix(start, end)
+    })
+    val actualOrdering = getRows(unioned).map { case Row(i: Int) => i }
+
+    assert(actualOrdering sameElements expectedOrdering)
   }
 }


### PR DESCRIPTION
basically, it now looks at the partitioner for the MatrixValues of its children when it executes, and only shuffles if rvds are non-disjoint. It removes empty rvds and separates children into non-disjoint piles, shuffles those independently, and then concatenates them together in sorted order.

(I'm not sure how this behaves relative to the old behavior (coerce everything together) when we have multiple shuffles that need to happen, but at least filtering out empty RVDs helps a lot in e.g. the split-multi case where none of the variants need to be moved.)

I think the (a?) better optimization would be to add smarter partitioning so that we're adjusting partition bounds and not really shuffling under most circumstances, but I thought I'd PR this first since at least there's a warning in python about unioning non-disjoint datasets (where this will avoid the scan).

I also added tests for MatrixUnionRows and pulled out one of the simplify rules; TableUnion does an unsorted union (I'm not sure this is actually correct behavior now if the tables have keys) and pulling the union outside of a MatrixRowsTable can cause the ordering to be wrong.