### PR TITLE
Prep for Hail CI changes

### DIFF
--- a/Dockerfile.pr-builder
+++ b/Dockerfile.pr-builder
@@ -40,7 +40,8 @@ COPY gradle gradle
 RUN mkdir -p /gradle-cache
 RUN ./gradlew downloadDependencies --gradle-user-home /gradle-cache
 COPY python/hail/dev-environment.yml python/hail/dev-environment.yml
-RUN conda env create hail -f ./python/hail/dev-environment.yml
+RUN conda env create hail -f ./python/hail/dev-environment.yml && \
+    rm -rf /opt/conda/pkgs/*
 
 # this seems easier than getting the keys right for apt
 #

--- a/Dockerfile.pr-builder
+++ b/Dockerfile.pr-builder
@@ -1,0 +1,57 @@
+FROM continuumio/miniconda
+MAINTAINER Hail Team <hail@broadinstitute.org>
+
+USER root
+RUN apt-get -y install \
+    bash \
+    cmake \
+    curl \
+    g++ \
+    git \
+    openjdk-8-jdk-headless \
+    r-base \
+    tar \
+    unzip
+
+RUN apt-get -y install libnlopt-dev # https://github.com/jyypma/nloptr/issues/40
+RUN Rscript -e 'install.packages(c("jsonlite", "SKAT", "logistf"), repos = "http://cran.us.r-project.org")'
+RUN apt-get -y install r-cran-ncdf4 r-cran-rnetcdf libcurl4-openssl-dev libxml2-dev
+RUN Rscript -e 'source("https://bioconductor.org/biocLite.R"); biocLite("GENESIS"); biocLite("SNPRelate"); biocLite("GWASTools")'
+
+WORKDIR /plink
+ADD http://www.cog-genomics.org/static/bin/plink/plink_linux_x86_64.zip /plink
+RUN unzip plink_linux_x86_64.zip && \
+    rm -rf plink_linux_x86_64.zip && \
+    ln -s /plink/plink /bin/plink
+
+WORKDIR /qctool
+ADD http://www.well.ox.ac.uk/~gav/resources/qctool_v2.0-CentOS6.8-x86_64.tgz /qctool
+RUN tar --strip-components=1 -xvzf qctool_v2.0-CentOS6.8-x86_64.tgz -C /qctool && \
+    rm -rf qctool_v2.0-CentOS6.8-x86_64.tgz && \
+    ln -s /qctool/qctool /bin/qctool
+
+# cache (almost all) gradle dependencies (and gradle itself)
+#
+# Some plugin we use hides its dependencies in a so-called "detached
+# configuration" so there is no way for us to ensure it gets cached.
+WORKDIR /hail
+COPY gradlew build.gradle settings.gradle deployed-spark-versions.txt ./
+COPY gradle gradle
+RUN mkdir -p /gradle-cache
+RUN ./gradlew downloadDependencies --gradle-user-home /gradle-cache
+COPY python/hail/dev-environment.yml python/hail/dev-environment.yml
+RUN conda env create hail -f ./python/hail/dev-environment.yml
+
+# this seems easier than getting the keys right for apt
+#
+# source: https://cloud.google.com/storage/docs/gsutil_install#linux
+RUN /bin/sh -c 'curl https://sdk.cloud.google.com | bash'
+ENV PATH $PATH:/root/google-cloud-sdk/bin
+# gcloud iam key files will be stored here
+VOLUME /secrets
+
+WORKDIR /spark
+ADD https://archive.apache.org/dist/spark/spark-2.2.0/spark-2.2.0-bin-hadoop2.7.tgz /spark
+RUN tar --strip-components=1 -xvzf spark-2.2.0-bin-hadoop2.7.tgz -C /spark && \
+    rm -rf spark-2.2.2-bin-hadoop2.7.tgz
+ENV SPARK_HOME /spark/

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,16 @@
-.PHONY hail-ci-build-image push-hail-ci-build-image
+.PHONY: hail-ci-build-image push-hail-ci-build-image
+.DEFAULT_GOAL := default
 
+hail-ci-build-image: GIT_SHA = $(shell git rev-parse HEAD)
 hail-ci-build-image:
-	docker build . -t hail-pr-builder -f Dockerfile.pr-builder
+	docker build . -t hail-pr-builder:${GIT_SHA} -f Dockerfile.pr-builder
 
-push-hail-ci-build-image:
-	docker tag hail-pr-builder gcr.io/broad-ctsa/hail-pr-builder
+push-hail-ci-build-image: GIT_SHA = $(shell git rev-parse HEAD)
+push-hail-ci-build-image: hail-ci-build-image
+	docker tag hail-pr-builder:${GIT_SHA} gcr.io/broad-ctsa/hail-pr-builder:${GIT_SHA}
 	docker push gcr.io/broad-ctsa/hail-pr-builder
+
+default:
+	echo Do not use this makefile to build hail, for information on how to \
+	     build hail see: https://hail.is/docs/devel/
+	exit -1

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY hail-ci-build-image push-hail-ci-build-image
+
+hail-ci-build-image:
+	docker build . -t hail-pr-builder -f Dockerfile.pr-builder
+
+push-hail-ci-build-image:
+	docker tag hail-pr-builder gcr.io/broad-ctsa/hail-pr-builder
+	docker push gcr.io/broad-ctsa/hail-pr-builder

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@
 hail-ci-build-image: GIT_SHA = $(shell git rev-parse HEAD)
 hail-ci-build-image:
 	docker build . -t hail-pr-builder:${GIT_SHA} -f Dockerfile.pr-builder
-	echo hail-pr-builder:${GIT_SHA} > hail-ci-build-image
 
 push-hail-ci-build-image: GIT_SHA = $(shell git rev-parse HEAD)
 push-hail-ci-build-image: hail-ci-build-image
 	docker tag hail-pr-builder:${GIT_SHA} gcr.io/broad-ctsa/hail-pr-builder:${GIT_SHA}
 	docker push gcr.io/broad-ctsa/hail-pr-builder
+	echo gcr.io/broad-ctsa/hail-pr-builder:${GIT_SHA} > hail-ci-build-image
 
 default:
 	echo Do not use this makefile to build hail, for information on how to \

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 hail-ci-build-image: GIT_SHA = $(shell git rev-parse HEAD)
 hail-ci-build-image:
 	docker build . -t hail-pr-builder:${GIT_SHA} -f Dockerfile.pr-builder
+	echo hail-pr-builder:${GIT_SHA} > hail-ci-build-image
 
 push-hail-ci-build-image: GIT_SHA = $(shell git rev-parse HEAD)
 push-hail-ci-build-image: hail-ci-build-image

--- a/build.gradle
+++ b/build.gradle
@@ -363,6 +363,12 @@ jacocoTestReport {
     }
 }
 
+task downloadDependencies(type: Exec) {
+    configurations.testCompile.files
+    configurations.testRuntime.files
+    commandLine 'echo', 'Downloaded all dependencies'
+}
+
 task coverage(dependsOn: jacocoTestReport)
 
 task testJar(type: Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -397,29 +397,21 @@ task generateDistLinks(type: Exec, dependsOn: ['cleanDocs']) {
 }
 
 task makeDocs(type: Exec, dependsOn: ['shadowJar', 'generateDistLinks']) {
-    doLast {
-        gitHash = exec {commandLine 'git', 'rev-parse', '--short=12', 'HEAD'}
-        commandLine 'sh', 'python/hail/docs/makeDocs.sh'
-        environment SPARK_HOME: sparkHome
-        environment PYSPARK_SUBMIT_ARGS: '--conf spark.driver.extraClassPath=' + projectDir + '/build/libs/hail-all-spark.jar --conf spark.executor.extraClassPath=' + projectDir + '/build/libs/hail-all-spark.jar pyspark-shell'
-        environment PYTHONPATH: '' + projectDir + '/python:' + sparkHome + '/python:' + sparkHome + '/python/lib/py4j-' + py4jVersion + '-src.zip'
-        environment HAIL_VERSION: hailVersion
-        environment HAIL_RELEASE: hailVersion + '-' + gitHash
-        environment SPHINXOPTS: '-tchecktutorial'
-    }
+    commandLine 'sh', 'python/hail/docs/makeDocs.sh'
+    environment SPARK_HOME: sparkHome
+    environment PYSPARK_SUBMIT_ARGS: '--conf spark.driver.extraClassPath=' + projectDir + '/build/libs/hail-all-spark.jar --conf spark.executor.extraClassPath=' + projectDir + '/build/libs/hail-all-spark.jar pyspark-shell'
+    environment PYTHONPATH: '' + projectDir + '/python:' + sparkHome + '/python:' + sparkHome + '/python/lib/py4j-' + py4jVersion + '-src.zip'
+    environment HAIL_VERSION: hailVersion
+    environment SPHINXOPTS: '-tchecktutorial'
 }
 
 task makeDocsNoTest(type: Exec, dependsOn: ['shadowJar', 'generateDistLinks']) {
-    doLast {
-        gitHash = exec {commandLine 'git', 'rev-parse', '--short=12', 'HEAD'}
-        commandLine 'sh', 'python/hail/docs/makeDocs.sh'
-        environment SPARK_HOME: sparkHome
-        environment PYSPARK_SUBMIT_ARGS: '--conf spark.driver.extraClassPath=' + projectDir + '/build/libs/hail-all-spark.jar --conf spark.executor.extraClassPath=' + projectDir + '/build/libs/hail-all-spark.jar pyspark-shell'
-        environment PYTHONPATH: '' + projectDir + '/python:' + sparkHome + '/python:' + sparkHome + '/python/lib/py4j-' + py4jVersion + '-src.zip'
-        environment HAIL_VERSION: hailVersion
-        environment HAIL_RELEASE: hailVersion + '-' + gitHash
-        environment SPHINXOPTS: ''
-    }
+    commandLine 'sh', 'python/hail/docs/makeDocs.sh'
+    environment SPARK_HOME: sparkHome
+    environment PYSPARK_SUBMIT_ARGS: '--conf spark.driver.extraClassPath=' + projectDir + '/build/libs/hail-all-spark.jar --conf spark.executor.extraClassPath=' + projectDir + '/build/libs/hail-all-spark.jar pyspark-shell'
+    environment PYTHONPATH: '' + projectDir + '/python:' + sparkHome + '/python:' + sparkHome + '/python/lib/py4j-' + py4jVersion + '-src.zip'
+    environment HAIL_VERSION: hailVersion
+    environment SPHINXOPTS: ''
 }
 
 task assemblePackage(type: Copy, dependsOn: ['makeDocs' , 'shadowJar']) {

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ buildScan {
 
 String hailVersion = "devel"
 String[] deployedSparkVersions = new File("deployed-spark-versions.txt")
-String gitHash = exec {commandLine 'git', 'rev-parse', '--short=12', 'HEAD'}
 
 String sparkVersion = System.getProperty("spark.version", "2.2.0")
 String breezeVersion = System.getProperty("breeze.version")
@@ -392,23 +391,29 @@ task generateDistLinks(type: Exec, dependsOn: ['cleanDocs']) {
 }
 
 task makeDocs(type: Exec, dependsOn: ['shadowJar', 'generateDistLinks']) {
-    commandLine 'sh', 'python/hail/docs/makeDocs.sh'
-    environment SPARK_HOME: sparkHome
-    environment PYSPARK_SUBMIT_ARGS: '--conf spark.driver.extraClassPath=' + projectDir + '/build/libs/hail-all-spark.jar --conf spark.executor.extraClassPath=' + projectDir + '/build/libs/hail-all-spark.jar pyspark-shell'
-    environment PYTHONPATH: '' + projectDir + '/python:' + sparkHome + '/python:' + sparkHome + '/python/lib/py4j-' + py4jVersion + '-src.zip'
-    environment HAIL_VERSION: hailVersion
-    environment HAIL_RELEASE: hailVersion + '-' + gitHash
-    environment SPHINXOPTS: '-tchecktutorial'
+    doLast {
+        gitHash = exec {commandLine 'git', 'rev-parse', '--short=12', 'HEAD'}
+        commandLine 'sh', 'python/hail/docs/makeDocs.sh'
+        environment SPARK_HOME: sparkHome
+        environment PYSPARK_SUBMIT_ARGS: '--conf spark.driver.extraClassPath=' + projectDir + '/build/libs/hail-all-spark.jar --conf spark.executor.extraClassPath=' + projectDir + '/build/libs/hail-all-spark.jar pyspark-shell'
+        environment PYTHONPATH: '' + projectDir + '/python:' + sparkHome + '/python:' + sparkHome + '/python/lib/py4j-' + py4jVersion + '-src.zip'
+        environment HAIL_VERSION: hailVersion
+        environment HAIL_RELEASE: hailVersion + '-' + gitHash
+        environment SPHINXOPTS: '-tchecktutorial'
+    }
 }
 
 task makeDocsNoTest(type: Exec, dependsOn: ['shadowJar', 'generateDistLinks']) {
-    commandLine 'sh', 'python/hail/docs/makeDocs.sh'
-    environment SPARK_HOME: sparkHome
-    environment PYSPARK_SUBMIT_ARGS: '--conf spark.driver.extraClassPath=' + projectDir + '/build/libs/hail-all-spark.jar --conf spark.executor.extraClassPath=' + projectDir + '/build/libs/hail-all-spark.jar pyspark-shell'
-    environment PYTHONPATH: '' + projectDir + '/python:' + sparkHome + '/python:' + sparkHome + '/python/lib/py4j-' + py4jVersion + '-src.zip'
-    environment HAIL_VERSION: hailVersion
-    environment HAIL_RELEASE: hailVersion + '-' + gitHash
-    environment SPHINXOPTS: ''
+    doLast {
+        gitHash = exec {commandLine 'git', 'rev-parse', '--short=12', 'HEAD'}
+        commandLine 'sh', 'python/hail/docs/makeDocs.sh'
+        environment SPARK_HOME: sparkHome
+        environment PYSPARK_SUBMIT_ARGS: '--conf spark.driver.extraClassPath=' + projectDir + '/build/libs/hail-all-spark.jar --conf spark.executor.extraClassPath=' + projectDir + '/build/libs/hail-all-spark.jar pyspark-shell'
+        environment PYTHONPATH: '' + projectDir + '/python:' + sparkHome + '/python:' + sparkHome + '/python/lib/py4j-' + py4jVersion + '-src.zip'
+        environment HAIL_VERSION: hailVersion
+        environment HAIL_RELEASE: hailVersion + '-' + gitHash
+        environment SPHINXOPTS: ''
+    }
 }
 
 task assemblePackage(type: Copy, dependsOn: ['makeDocs' , 'shadowJar']) {

--- a/hail-ci-build-image
+++ b/hail-ci-build-image
@@ -1,1 +1,1 @@
-gcr.io/broad-ctsa/hail-pr-builder
+gcr.io/broad-ctsa/hail-pr-builder:3940e02dc75643e59e3f0c3b02ee732a15bc6849

--- a/hail-ci-build-image
+++ b/hail-ci-build-image
@@ -1,1 +1,1 @@
-gcr.io/broad-ctsa/hail-pr-builder:3940e02dc75643e59e3f0c3b02ee732a15bc6849
+gcr.io/broad-ctsa/hail-pr-builder:5e4cb29982b5c42d39983f39954acf70f16ab25a

--- a/hail-ci-build-image
+++ b/hail-ci-build-image
@@ -1,0 +1,1 @@
+gcr.io/broad-ctsa/hail-pr-builder

--- a/hail-ci-build.sh
+++ b/hail-ci-build.sh
@@ -1,0 +1,3 @@
+set -ex
+source activate hail
+GRADLE_OPTS=-Xmx2048m ./gradlew testAll --gradle-user-home /gradle-cache

--- a/python/hail/docs/makeDocs.sh
+++ b/python/hail/docs/makeDocs.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+export HAIL_RELEASE=${HAIL_VERSION}-$(git rev-parse --short=12 HEAD)
+
 # make directories
 mkdir -p build/www/ build/tmp/python/ build/tmp/docs build/www/docs
 


### PR DESCRIPTION
This is the plan for the new Hail CI (tentatively: Hephaestus aka h8s [but Hodor is also in the running, see CI software name in Zulip for the real big questions of our time]).

# Expected Repo Structure
Every repository to be tested has at least two files: `hail-ci-build-image` and `hail-ci-build.sh`. The former contains a docker image in a publicly accessible repository. The latter is a shell script that exits with 0 if this branch passes the tests, otherwise it exists with a non-zero code. The logs of this shell script will be shared publicly via the GH PR Status. This script will be executed in the image referenced by `hail-ci-build-image`.

# Dockerfile.pr-builder
I carefully wrote a docker file to cache as much gradle crap as possible.

# gitHash in Gradle
I pushed `gitHash`'s definition into the `doLast` blocks of the gradle steps that actually need it. `doLast` is only run when the task is actually requested. This allows me to run `downloadDependencies` without creating a dependency on the entire `.git` directory (which changes with each commit, thus invalidating the cache'd docker image).