### PR TITLE
Optional intercept in regressions and skat

### DIFF
--- a/python/hail/docs/tutorials/01-genome-wide-association-study.ipynb
+++ b/python/hail/docs/tutorials/01-genome-wide-association-study.ipynb
@@ -735,7 +735,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gwas = hl.linear_regression(y=common_mt.CaffeineConsumption, x=common_mt.GT.n_alt_alleles())\n",
+    "gwas = hl.linear_regression(y=common_mt.CaffeineConsumption, x=common_mt.GT.n_alt_alleles(), covariates=[1.0])\n",
     "gwas.row.describe()"
    ]
   },
@@ -838,7 +838,7 @@
     "\n",
     "linear_regression_results = hl.linear_regression(\n",
     "    y=cmt.CaffeineConsumption, x=cmt.GT.n_alt_alleles(),\n",
-    "    covariates=[cmt.isFemale, cmt.pca.scores[0], cmt.pca.scores[1], cmt.pca.scores[2]])"
+    "    covariates=[1.0, cmt.isFemale, cmt.pca.scores[0], cmt.pca.scores[1], cmt.pca.scores[2]])"
    ]
   },
   {
@@ -881,7 +881,7 @@
    "source": [
     "linear_regression_results = hl.linear_regression(\n",
     "    y=cmt.CaffeineConsumption, x=plDosage(cmt.PL),\n",
-    "    covariates=[cmt.isFemale, cmt.pca.scores[0], cmt.pca.scores[1], cmt.pca.scores[2]])"
+    "    covariates=[1.0, cmt.isFemale, cmt.pca.scores[0], cmt.pca.scores[1], cmt.pca.scores[2]])"
    ]
   },
   {
@@ -929,7 +929,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results.show()"
+   "results.show()"
    ]
   },
   {
@@ -1008,7 +1008,7 @@
     "cmt = common_mt.annotate_cols(pca = pca_scores[common_mt.s])\n",
     "linear_regression_results = hl.linear_regression(\n",
     "    y=cmt.CaffeineConsumption, x=cmt.GT.n_alt_alleles(),\n",
-    "    covariates=[cmt.isFemale, cmt.pca.scores[0], cmt.pca.scores[1], cmt.pca.scores[2]])\n",
+    "    covariates=[1.0, cmt.isFemale, cmt.pca.scores[0], cmt.pca.scores[1], cmt.pca.scores[2]])\n",
     "pvals = linear_regression_results.linreg.p_value.collect()"
    ]
   },

--- a/python/hail/docs/tutorials/plotting.ipynb
+++ b/python/hail/docs/tutorials/plotting.ipynb
@@ -134,7 +134,7 @@
     "mt = mt.filter_entries(filter_condition_ab)\n",
     "mt = hl.variant_qc(mt).cache()\n",
     "common_mt = mt.filter_rows(mt.variant_qc.AF[1] > 0.01)\n",
-    "gwas = hl.linear_regression(y=common_mt.CaffeineConsumption, x=common_mt.GT.n_alt_alleles())\n",
+    "gwas = hl.linear_regression(y=common_mt.CaffeineConsumption, x=common_mt.GT.n_alt_alleles(), covariates=[1.0])\n",
     "pca_eigenvalues, pca_scores, _ = hl.hwe_normalized_pca(common_mt.GT)"
    ]
   },

--- a/python/hail/expr/aggregators/aggregators.py
+++ b/python/hail/expr/aggregators/aggregators.py
@@ -1112,7 +1112,7 @@ def info_score(gp) -> StructExpression:
 @typecheck(y=agg_expr(expr_float64),
            x=oneof(expr_float64, sequenceof(expr_float64)))
 def linreg(y, x):
-    """Compute linear regression statistics.
+    """Compute multivariate linear regression statistics.
 
     Examples
     --------

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -246,7 +246,7 @@ def linear_regression(y, x, covariates=(), root='linreg', block_size=16) -> Matr
 
     >>> dataset_result = hl.linear_regression(y=dataset.pheno.height,
     ...                                       x=dataset.GT.n_alt_alleles(),
-    ...                                       covariates=[dataset.pheno.age, dataset.pheno.is_female])
+    ...                                       covariates=[1.0, dataset.pheno.age, dataset.pheno.is_female])
 
     Warning
     -------
@@ -283,22 +283,22 @@ def linear_regression(y, x, covariates=(), root='linreg', block_size=16) -> Matr
 
     .. math::
 
-        \mathrm{height} = \\beta_0 + \\beta_1 \, \mathrm{genotype}
-                          + \\beta_2 \, \mathrm{age}
-                          + \\beta_3 \, \mathrm{is\_female}
+        \mathrm{height} = \\beta_0 \, \mathrm{genotype}
+                          + \\beta_1 \, \mathrm{age}
+                          + \\beta_2 \, \mathrm{is\_female}
                           + \\varepsilon, \quad \\varepsilon
                         \sim \mathrm{N}(0, \sigma^2)
 
     Boolean covariates like :math:`\mathrm{is\_female}` are encoded as 1 for
-    ``True`` and 0 for ``False``. The null model sets :math:`\\beta_1 = 0`.
+    ``True`` and 0 for ``False``. The null model sets :math:`\\beta_0 = 0`.
 
     The standard least-squares linear regression model is derived in Section
     3.2 of `The Elements of Statistical Learning, 2nd Edition
     <http://statweb.stanford.edu/~tibs/ElemStatLearn/printings/ESLII_print10.pdf>`__.
     See equation 3.12 for the t-statistic which follows the t-distribution with
-    :math:`n - k - 2` degrees of freedom, under the null hypothesis of no
+    :math:`n - k - 1` degrees of freedom, under the null hypothesis of no
     effect, with :math:`n` samples and :math:`k` covariates in addition to
-    ``x`` and the intercept.
+    ``x``.
 
     Parameters
     ----------
@@ -384,14 +384,16 @@ def logistic_regression(test, y, x, covariates=(), root='logreg') -> MatrixTable
 
     Examples
     --------
+
     Run the logistic regression Wald test per variant using a Boolean
-    phenotype and two covariates stored in column-indexed fields:
+    phenotype, intercept and two covariates stored in column-indexed
+    fields:
 
     >>> ds_result = hl.logistic_regression(
     ...     test='wald',
     ...     y=dataset.pheno.is_case,
     ...     x=dataset.GT.n_alt_alleles(),
-    ...     covariates=[dataset.pheno.age, dataset.pheno.is_female])
+    ...     covariates=[1.0, dataset.pheno.age, dataset.pheno.is_female])
 
     Notes
     -----
@@ -422,7 +424,7 @@ def logistic_regression(test, y, x, covariates=(), root='logreg') -> MatrixTable
     :math:`\mathrm{gt}` is coded as 0 for HomRef, 1 for Het, and 2 for
     HomVar, and the Boolean covariate :math:`\mathrm{is\_female}` is coded as
     for ``True`` (female) and 0 for ``False`` (male). The null model sets
-    :math:`\beta_1 = 0`.
+    :math:`\beta_0 = 0`.
 
     .. _sigmoid function: https://en.wikipedia.org/wiki/Sigmoid_function
 
@@ -443,7 +445,7 @@ def logistic_regression(test, y, x, covariates=(), root='logreg') -> MatrixTable
                                                :math:`\hat\beta_1`
     LRT, Firth `logreg.chi_sq_stat`    float64 deviance statistic
     LRT, Firth `logreg.p_value`        float64 LRT / Firth p-value testing
-                                               :math:`\beta_1 = 0`
+                                               :math:`\beta_1 = 1`
     Score      `logreg.chi_sq_stat`    float64 score statistic
     Score      `logreg.p_value`        float64 score p-value testing :math:`\beta_1 = 0`
     ========== ======================= ======= ============================================

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -253,7 +253,8 @@ def linear_regression(y, x, covariates=(), root='linreg', block_size=16) -> Matr
     :func:`.linear_regression` considers the same set of columns (i.e., samples, points)
     for every response variable and row, namely those columns for which **all**
     response variables and covariates are defined. For each row, missing values
-    of `x` are mean-imputed over these columns.
+    of `x` are mean-imputed over these columns. As in the example, the intercept
+    covariate ``1.0`` must be included explicitly if desired.
 
     Notes
     -----
@@ -384,7 +385,6 @@ def logistic_regression(test, y, x, covariates=(), root='logreg') -> MatrixTable
 
     Examples
     --------
-
     Run the logistic regression Wald test per variant using a Boolean
     phenotype, intercept and two covariates stored in column-indexed
     fields:
@@ -401,7 +401,8 @@ def logistic_regression(test, y, x, covariates=(), root='logreg') -> MatrixTable
     variable in predicting a binary (case-control) response variable based on
     the logistic regression model. The response variable type must either be
     numeric (with all present values 0 or 1) or Boolean, in which case true and
-    false are coded as 1 and 0, respectively.
+    false are coded as 1 and 0, respectively. As in the example, the intercept
+    covariate ``1.0`` must be included explicitly if desired.
 
     Hail supports the Wald test ('wald'), likelihood ratio test ('lrt'), Rao
     score test ('score'), and Firth test ('firth'). Hail only includes columns
@@ -568,7 +569,7 @@ def logistic_regression(test, y, x, covariates=(), root='logreg') -> MatrixTable
     x : :class:`.Float64Expression`
         Entry-indexed expression for input variable.
     covariates : :obj:`list` of :class:`.Float64Expression`
-        List of column-indexed covariate expressions.
+        Non-empty list of column-indexed covariate expressions.
     root : :obj:`str`, optional
         Name of resulting row-indexed field.
 
@@ -577,6 +578,9 @@ def logistic_regression(test, y, x, covariates=(), root='logreg') -> MatrixTable
     :class:`.MatrixTable`
         Matrix table with regression results in a new row-indexed field.
     """
+    if len(covariates) == 0:
+        raise ValueError('logistic regression requires at least one covariate expression')
+
     mt = matrix_table_source('logistic_regression/x', x)
     check_entry_indexed('logistic_regression/x', x)
 
@@ -627,7 +631,7 @@ def logistic_regression(test, y, x, covariates=(), root='logreg') -> MatrixTable
            max_size=int,
            accuracy=numeric,
            iterations=int)
-def skat(key_expr, weight_expr, y, x, covariates=[], logistic=False,
+def skat(key_expr, weight_expr, y, x, covariates=(), logistic=False,
          max_size=46340, accuracy=1e-6, iterations=10000) -> Table:
     r"""Test each keyed group of rows for association by linear or logistic
     SKAT test.
@@ -643,7 +647,7 @@ def skat(key_expr, weight_expr, y, x, covariates=[], logistic=False,
     ...                      weight_expr=burden_ds.weight,
     ...                      y=burden_ds.burden.pheno,
     ...                      x=burden_ds.GT.n_alt_alleles(),
-    ...                      covariates=[burden_ds.burden.cov1, burden_ds.burden.cov2])
+    ...                      covariates=[1.0, burden_ds.burden.cov1, burden_ds.burden.cov2])
 
     .. caution::
 
@@ -669,9 +673,10 @@ def skat(key_expr, weight_expr, y, x, covariates=[], logistic=False,
     `Rare-Variant Association Testing for Sequencing Data with the Sequence Kernel Association Test
     <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3135811/>`__.
 
-    The test is run on columns with `y` and all `covariates` non-missing. For
-    each row, missing input (`x`) values are imputed as the mean of all
-    non-missing input values.
+    The test is run on columns with `y` and all `covariates` non-missing.
+    As in the example, the intercept covariate ``1.0`` must be included
+    explicitly if desired. For each row, missing input (`x`) values are
+    imputed as the mean of all non-missing input values.
 
     Row weights must be non-negative. Rows with missing weights are ignored. In
     the R package ``skat``---which assumes rows are variants---default weights

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -283,14 +283,14 @@ def linear_regression(y, x, covariates=(), root='linreg', block_size=16) -> Matr
 
     .. math::
 
-        \mathrm{height} = \\beta_0 \, \mathrm{genotype}
-                          + \\beta_1 \, \mathrm{age}
-                          + \\beta_2 \, \mathrm{is\_female}
+        \mathrm{height} = \\beta_0 + \\beta_1 \, \mathrm{genotype}
+                          + \\beta_2 \, \mathrm{age}
+                          + \\beta_3 \, \mathrm{is\_female}
                           + \\varepsilon, \quad \\varepsilon
                         \sim \mathrm{N}(0, \sigma^2)
 
     Boolean covariates like :math:`\mathrm{is\_female}` are encoded as 1 for
-    ``True`` and 0 for ``False``. The null model sets :math:`\\beta_0 = 0`.
+    ``True`` and 0 for ``False``. The null model sets :math:`\\beta_1 = 0`.
 
     The standard least-squares linear regression model is derived in Section
     3.2 of `The Elements of Statistical Learning, 2nd Edition
@@ -424,7 +424,7 @@ def logistic_regression(test, y, x, covariates=(), root='logreg') -> MatrixTable
     :math:`\mathrm{gt}` is coded as 0 for HomRef, 1 for Het, and 2 for
     HomVar, and the Boolean covariate :math:`\mathrm{is\_female}` is coded as
     for ``True`` (female) and 0 for ``False`` (male). The null model sets
-    :math:`\beta_0 = 0`.
+    :math:`\beta_1 = 0`.
 
     .. _sigmoid function: https://en.wikipedia.org/wiki/Sigmoid_function
 
@@ -445,7 +445,7 @@ def logistic_regression(test, y, x, covariates=(), root='logreg') -> MatrixTable
                                                :math:`\hat\beta_1`
     LRT, Firth `logreg.chi_sq_stat`    float64 deviance statistic
     LRT, Firth `logreg.p_value`        float64 LRT / Firth p-value testing
-                                               :math:`\beta_1 = 1`
+                                               :math:`\beta_1 = 0`
     Score      `logreg.chi_sq_stat`    float64 score statistic
     Score      `logreg.p_value`        float64 score p-value testing :math:`\beta_1 = 0`
     ========== ======================= ======= ============================================

--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -237,7 +237,7 @@ def impute_sex(call, aaf_threshold=0.0, include_par=False, female_threshold=0.2,
            covariates=sequenceof(expr_float64),
            root=str,
            block_size=int)
-def linear_regression(y, x, covariates=(), root='linreg', block_size=16) -> MatrixTable:
+def linear_regression(y, x, covariates, root='linreg', block_size=16) -> MatrixTable:
     """For each row, test an input variable for association with
     response variables using linear regression.
 
@@ -354,7 +354,6 @@ def linear_regression(y, x, covariates=(), root='linreg', block_size=16) -> Matr
                                          **dict(zip(cov_field_names, covariates))),
                           entry_exprs=entry_expr)
 
-
     jm = Env.hail().methods.LinearRegression.apply(
         mt._jvds,
         jarray(Env.jvm().java.lang.String, y_field_names),
@@ -379,7 +378,7 @@ def linear_regression(y, x, covariates=(), root='linreg', block_size=16) -> Matr
            x=expr_float64,
            covariates=sequenceof(expr_float64),
            root=str)
-def logistic_regression(test, y, x, covariates=(), root='logreg') -> MatrixTable:
+def logistic_regression(test, y, x, covariates, root='logreg') -> MatrixTable:
     r"""For each row, test an input variable for association with a
     binary response variable using logistic regression.
 
@@ -631,7 +630,7 @@ def logistic_regression(test, y, x, covariates=(), root='logreg') -> MatrixTable
            max_size=int,
            accuracy=numeric,
            iterations=int)
-def skat(key_expr, weight_expr, y, x, covariates=(), logistic=False,
+def skat(key_expr, weight_expr, y, x, covariates, logistic=False,
          max_size=46340, accuracy=1e-6, iterations=10000) -> Table:
     r"""Test each keyed group of rows for association by linear or logistic
     SKAT test.

--- a/python/test/hail/methods/test_statgen.py
+++ b/python/test/hail/methods/test_statgen.py
@@ -114,19 +114,19 @@ class Tests(unittest.TestCase):
         mt = mt.annotate_entries(x=mt.GT.n_alt_alleles()).cache()
 
         t1 = hl.linear_regression(
-            y=mt.pheno, x=mt.GT.n_alt_alleles(), covariates=[mt.cov.Cov1, mt.cov.Cov2 + 1 - 1]).rows()
+            y=mt.pheno, x=mt.GT.n_alt_alleles(), covariates=[1.0, mt.cov.Cov1, mt.cov.Cov2 + 1 - 1]).rows()
         t1 = t1.select(p=t1.linreg.p_value)
 
         t2 = hl.linear_regression(
-            y=mt.pheno, x=mt.x, covariates=[mt.cov.Cov1, mt.cov.Cov2]).rows()
+            y=mt.pheno, x=mt.x, covariates=[1.0, mt.cov.Cov1, mt.cov.Cov2]).rows()
         t2 = t2.select(p=t2.linreg.p_value)
 
         t3 = hl.linear_regression(
-            y=[mt.pheno], x=mt.x, covariates=[mt.cov.Cov1, mt.cov.Cov2]).rows()
+            y=[mt.pheno], x=mt.x, covariates=[1.0, mt.cov.Cov1, mt.cov.Cov2]).rows()
         t3 = t3.select(p=t3.linreg.p_value[0])
 
         t4 = hl.linear_regression(
-            y=[mt.pheno, mt.pheno], x=mt.x, covariates=[mt.cov.Cov1, mt.cov.Cov2]).rows()
+            y=[mt.pheno, mt.pheno], x=mt.x, covariates=[1.0, mt.cov.Cov1, mt.cov.Cov2]).rows()
         t4a = t4.select(p=t4.linreg.p_value[0])
         t4b = t4.select(p=t4.linreg.p_value[1])
 
@@ -148,7 +148,7 @@ class Tests(unittest.TestCase):
         mt = hl.import_vcf(resource('regressionLinear.vcf'))
         mt = hl.linear_regression(y=pheno[mt.s].Pheno,
                                   x=mt.GT.n_alt_alleles(),
-                                  covariates=list(covariates[mt.s].values()))
+                                  covariates=[1.0] + list(covariates[mt.s].values()))
 
         results = dict(mt.aggregate_rows(hl.agg.collect((mt.locus.position, mt.linreg))))
 
@@ -189,7 +189,7 @@ class Tests(unittest.TestCase):
         mt = hl.import_vcf(resource('regressionLinear.vcf'))
         mt = hl.linear_regression(y=pheno[mt.s].Pheno,
                                   x=hl.pl_dosage(mt.PL),
-                                  covariates=list(covariates[mt.s].values()))
+                                  covariates=[1.0] + list(covariates[mt.s].values()))
 
         results = dict(mt.aggregate_rows(hl.agg.collect((mt.locus.position, mt.linreg))))
 
@@ -220,7 +220,7 @@ class Tests(unittest.TestCase):
         mt = hl.import_gen(resource('regressionLinear.gen'), sample_file=resource('regressionLinear.sample'))
         mt = hl.linear_regression(y=pheno[mt.s].Pheno,
                                   x=hl.gp_dosage(mt.GP),
-                                  covariates=list(covariates[mt.s].values()))
+                                  covariates=[1.0] + list(covariates[mt.s].values()))
 
         results = dict(mt.aggregate_rows(hl.agg.collect((mt.locus.position, mt.linreg))))
 
@@ -240,7 +240,7 @@ class Tests(unittest.TestCase):
         self.assertAlmostEqual(results[3].p_value, 0.2533675, places=6)
         self.assertTrue(np.isnan(results[6].standard_error))
 
-    def test_linear_regression_with_no_cov(self):
+    def test_linear_regression_with_no_cov(self):  # FIXME does no covariates work?
         pheno = hl.import_table(resource('regressionLinear.pheno'),
                                 key='Sample',
                                 missing='0',
@@ -276,7 +276,7 @@ class Tests(unittest.TestCase):
         mt = hl.import_vcf(resource('regressionLinear.vcf'))
         mt = hl.linear_regression(y=fam[mt.s].is_case,
                                   x=mt.GT.n_alt_alleles(),
-                                  covariates=list(covariates[mt.s].values()))
+                                  covariates=[1.0] + list(covariates[mt.s].values()))
 
         results = dict(mt.aggregate_rows(hl.agg.collect((mt.locus.position, mt.linreg))))
 
@@ -306,7 +306,7 @@ class Tests(unittest.TestCase):
         mt = hl.import_vcf(resource('regressionLinear.vcf'))
         mt = hl.linear_regression(y=fam[mt.s].quant_pheno,
                                   x=mt.GT.n_alt_alleles(),
-                                  covariates=list(covariates[mt.s].values()))
+                                  covariates=[1.0] + list(covariates[mt.s].values()))
 
         results = dict(mt.aggregate_rows(hl.agg.collect((mt.locus.position, mt.linreg))))
 
@@ -371,7 +371,7 @@ class Tests(unittest.TestCase):
         mt = hl.logistic_regression('wald',
                                     y=pheno[mt.s].isCase,
                                     x=mt.GT.n_alt_alleles(),
-                                    covariates=[covariates[mt.s].Cov1, covariates[mt.s].Cov2])
+                                    covariates=[1.0, covariates[mt.s].Cov1, covariates[mt.s].Cov2])
 
         results = dict(mt.aggregate_rows(hl.agg.collect((mt.locus.position, mt.logreg))))
 
@@ -407,7 +407,7 @@ class Tests(unittest.TestCase):
         mt = hl.logistic_regression('wald',
                                     y=pheno[mt.s].isCase,
                                     x=hl.pl_dosage(mt.PL),
-                                    covariates=[covariates[mt.s].Cov1, covariates[mt.s].Cov2])
+                                    covariates=[1.0, covariates[mt.s].Cov1, covariates[mt.s].Cov2])
 
         results = dict(mt.aggregate_rows(hl.agg.collect((mt.locus.position, mt.logreg))))
 
@@ -444,7 +444,7 @@ class Tests(unittest.TestCase):
         mt = hl.logistic_regression('wald',
                                     y=pheno[mt.s].isCase,
                                     x=hl.gp_dosage(mt.GP),
-                                    covariates=[covariates[mt.s].Cov1, covariates[mt.s].Cov2])
+                                    covariates=[1.0, covariates[mt.s].Cov1, covariates[mt.s].Cov2])
 
         results = dict(mt.aggregate_rows(hl.agg.collect((mt.locus.position, mt.logreg))))
 
@@ -480,7 +480,7 @@ class Tests(unittest.TestCase):
         mt = hl.logistic_regression('lrt',
                                     y=pheno[mt.s].isCase,
                                     x=mt.GT.n_alt_alleles(),
-                                    covariates=[covariates[mt.s].Cov1, covariates[mt.s].Cov2])
+                                    covariates=[1.0, covariates[mt.s].Cov1, covariates[mt.s].Cov2])
 
         results = dict(mt.aggregate_rows(hl.agg.collect((mt.locus.position, mt.logreg))))
 
@@ -514,7 +514,7 @@ class Tests(unittest.TestCase):
         mt = hl.logistic_regression('score',
                                     y=pheno[mt.s].isCase,
                                     x=mt.GT.n_alt_alleles(),
-                                    covariates=[covariates[mt.s].Cov1, covariates[mt.s].Cov2])
+                                    covariates=[1.0, covariates[mt.s].Cov1, covariates[mt.s].Cov2])
 
         results = dict(mt.aggregate_rows(hl.agg.collect((mt.locus.position, mt.logreg))))
 
@@ -548,22 +548,22 @@ class Tests(unittest.TestCase):
         mt = hl.logistic_regression('wald',
                                     y=mt.is_case,
                                     x=mt.GT.n_alt_alleles(),
-                                    covariates=[mt.is_female, mt.PC1, mt.PC2],
+                                    covariates=[1.0, mt.is_female, mt.PC1, mt.PC2],
                                     root='wald')
         mt = hl.logistic_regression('lrt',
                                     y=mt.is_case,
                                     x=mt.GT.n_alt_alleles(),
-                                    covariates=[mt.is_female, mt.PC1, mt.PC2],
+                                    covariates=[1.0, mt.is_female, mt.PC1, mt.PC2],
                                     root='lrt')
         mt = hl.logistic_regression('score',
                                     y=mt.is_case,
                                     x=mt.GT.n_alt_alleles(),
-                                    covariates=[mt.is_female, mt.PC1, mt.PC2],
+                                    covariates=[1.0, mt.is_female, mt.PC1, mt.PC2],
                                     root='score')
         mt = hl.logistic_regression('firth',
                                     y=mt.is_case,
                                     x=mt.GT.n_alt_alleles(),
-                                    covariates=[mt.is_female, mt.PC1, mt.PC2],
+                                    covariates=[1.0, mt.is_female, mt.PC1, mt.PC2],
                                     root='firth')
 
         # 2535 samples from 1K Genomes Project
@@ -997,14 +997,14 @@ class Tests(unittest.TestCase):
                 weight_expr=ds.weight,
                 y=ds.pheno,
                 x=ds.GT.n_alt_alleles(),
-                covariates=[ds.cov.Cov1, ds.cov.Cov2],
+                covariates=[1.0, ds.cov.Cov1, ds.cov.Cov2],
                 logistic=False).count()
 
         hl.skat(key_expr=ds.gene,
                 weight_expr=ds.weight,
                 y=ds.pheno,
                 x=hl.pl_dosage(ds.PL),
-                covariates=[ds.cov.Cov1, ds.cov.Cov2],
+                covariates=[1.0, ds.cov.Cov1, ds.cov.Cov2],
                 logistic=True).count()
 
     def test_de_novo(self):

--- a/src/main/scala/is/hail/methods/LinearRegression.scala
+++ b/src/main/scala/is/hail/methods/LinearRegression.scala
@@ -31,13 +31,25 @@ object LinearRegression {
     val dRec = 1d / d
 
     if (d < 1)
-      fatal(s"$n samples and ${ k + 1 } ${ plural(k, "covariate") } (including x and intercept) implies $d degrees of freedom.")
+      fatal(s"$n samples and ${ k + 1 } ${ plural(k, "covariate") } (including x) implies $d degrees of freedom.")
 
     info(s"linear_regression: running on $n samples for ${ y.cols } response ${ plural(y.cols, "variable") } y,\n"
-       + s"    with input variable x, intercept, and ${ k - 1 } additional ${ plural(k - 1, "covariate") }...")
+       + s"    with input variable x, and ${ k } additional ${ plural(k, "covariate") }...")
 
-    val Qt = qr.reduced.justQ(cov).t
+    println("y.shape", y.rows, y.cols)
+    println("cov.shape", cov.rows, cov.cols)
+
+    val Qt =
+      if (k > 0)
+        qr.reduced.justQ(cov).t
+      else
+        DenseMatrix.zeros[Double](0, n)
+
+    println("Qt.shape", Qt.rows, Qt.cols)
+
     val Qty = Qt * y
+
+    println("Qty.shape", Qty.rows, Qty.cols)
 
     val sc = vsm.sparkContext
     val completeColIdxBc = sc.broadcast(completeColIdx)

--- a/src/main/scala/is/hail/methods/LinearRegression.scala
+++ b/src/main/scala/is/hail/methods/LinearRegression.scala
@@ -36,20 +36,13 @@ object LinearRegression {
     info(s"linear_regression: running on $n samples for ${ y.cols } response ${ plural(y.cols, "variable") } y,\n"
        + s"    with input variable x, and ${ k } additional ${ plural(k, "covariate") }...")
 
-    println("y.shape", y.rows, y.cols)
-    println("cov.shape", cov.rows, cov.cols)
-
     val Qt =
       if (k > 0)
         qr.reduced.justQ(cov).t
       else
         DenseMatrix.zeros[Double](0, n)
 
-    println("Qt.shape", Qt.rows, Qt.cols)
-
     val Qty = Qt * y
-
-    println("Qty.shape", Qty.rows, Qty.cols)
 
     val sc = vsm.sparkContext
     val completeColIdxBc = sc.broadcast(completeColIdx)

--- a/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -27,10 +27,10 @@ object LogisticRegression {
     val d = n - k - 1
 
     if (d < 1)
-      fatal(s"$n samples and ${ k + 1 } ${ plural(k, "covariate") } (including x and intercept) implies $d degrees of freedom.")
+      fatal(s"$n samples and ${ k + 1 } ${ plural(k, "covariate") } (including x) implies $d degrees of freedom.")
 
     info(s"logistic_regression: running $test on $n samples for response variable y,\n"
-      + s"    with input variable x, intercept, and ${ k - 1 } additional ${ plural(k - 1, "covariate") }...")
+      + s"    with input variable x, and ${ k } additional ${ plural(k, "covariate") }...")
 
     val nullModel = new LogisticRegressionModel(cov, y)
     var nullFit = nullModel.fit()

--- a/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
+++ b/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
@@ -218,6 +218,7 @@ class LogisticRegressionModel(X: DenseMatrix[Double], y: DenseVector[Double]) {
   val m: Int = X.cols
 
   def bInterceptOnly(): DenseVector[Double] = {
+    require(m > 0)
     val b = DenseVector.zeros[Double](m)
     val avg = sum(y) / n
     b(0) = math.log(avg / (1 - avg))

--- a/src/main/scala/is/hail/stats/RegressionUtils.scala
+++ b/src/main/scala/is/hail/stats/RegressionUtils.scala
@@ -85,11 +85,11 @@ object RegressionUtils {
     covFields: Array[String]): (DenseMatrix[Double], DenseMatrix[Double], Array[Int]) = {
 
     val nPhenos = yFields.length
-    val nCovs = covFields.length + 1 // intercept
+    val nCovs = covFields.length
 
     if (nPhenos == 0)
       fatal("No phenotypes present.")
-
+    
     val yIS = getColumnVariables(vsm, yFields)
     val covIS = getColumnVariables(vsm, covFields)
 
@@ -105,7 +105,7 @@ object RegressionUtils {
     val yArray = yForCompleteSamples.flatMap(_.map(_.get)).toArray
     val y = new DenseMatrix(rows = n, cols = nPhenos, data = yArray, offset = 0, majorStride = nPhenos, isTranspose = true)
 
-    val covArray = covForCompleteSamples.flatMap(1.0 +: _.map(_.get)).toArray
+    val covArray = covForCompleteSamples.flatMap(_.map(_.get)).toArray
     val cov = new DenseMatrix(rows = n, cols = nCovs, data = covArray, offset = 0, majorStride = nCovs, isTranspose = true)
 
     if (n < vsm.numCols)

--- a/src/test/scala/is/hail/methods/SkatSuite.scala
+++ b/src/test/scala/is/hail/methods/SkatSuite.scala
@@ -1,22 +1,9 @@
 package is.hail.methods
 
-import is.hail.annotations.Annotation
-import is.hail.io.annotators.IntervalList
 import is.hail.{SparkSuite, TestUtils}
-import is.hail.stats.RegressionUtils._
 import is.hail.utils._
-import is.hail.testUtils._
-import is.hail.variant._
-import is.hail.stats.vdsFromCallMatrix
 import breeze.linalg._
-import breeze.numerics.sigmoid
-import is.hail.expr.types._
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.Row
 import org.testng.annotations.Test
-
-import scala.sys.process._
-import scala.language.postfixOps
 
 case class SkatAggForR(xs: ArrayBuilder[DenseVector[Double]], weights: ArrayBuilder[Double])
 

--- a/src/test/scala/is/hail/testUtils/RichMatrixTable.scala
+++ b/src/test/scala/is/hail/testUtils/RichMatrixTable.scala
@@ -1,13 +1,8 @@
 package is.hail.testUtils
 
 import is.hail.annotations._
-import is.hail.expr.ir
-import is.hail.expr.types._
-import is.hail.expr.{EvalContext, Parser}
-import is.hail.methods._
-import is.hail.table.Table
 import is.hail.utils._
-import is.hail.variant.{Locus, MatrixTable}
+import is.hail.variant.MatrixTable
 import org.apache.spark.rdd.RDD
 
 import scala.reflect.ClassTag
@@ -57,34 +52,5 @@ class RichMatrixTable(vsm: MatrixTable) {
     val newToOld = newIds.map(oldIndex)
 
     vsm.chooseCols(newToOld)
-  }
-
-  def linreg(yExpr: Array[String],
-    xField: String,
-    covExpr: Array[String] = Array.empty[String],
-    root: String = "linreg",
-    rowBlockSize: Int = 16): MatrixTable = {
-    val vsmAnnot = vsm.annotateColsExpr(
-      yExpr.zipWithIndex.map { case (e, i) => s"__y$i" -> e } ++
-      covExpr.zipWithIndex.map { case (e, i) => s"__cov$i" -> e }: _*
-    )
-    LinearRegression(vsmAnnot,
-      yExpr.indices.map(i => s"__y$i").toArray,
-      xField,
-      covExpr.indices.map(i => s"__cov$i").toArray,
-      root,
-      rowBlockSize)
-  }
-
-  def skat(keyExpr: String,
-    weightExpr: String,
-    yExpr: String,
-    xField: String,
-    covExpr: Array[String] = Array.empty[String],
-    logistic: Boolean = false,
-    maxSize: Int = 46340, // floor(sqrt(Int.MaxValue))
-    accuracy: Double = 1e-6,
-    iterations: Int = 10000): Table = {
-    Skat(vsm, keyExpr, weightExpr, yExpr, xField, covExpr, logistic, maxSize, accuracy, iterations)
   }
 }

--- a/src/test/scala/is/hail/testUtils/RichMatrixTable.scala
+++ b/src/test/scala/is/hail/testUtils/RichMatrixTable.scala
@@ -58,4 +58,33 @@ class RichMatrixTable(vsm: MatrixTable) {
 
     vsm.chooseCols(newToOld)
   }
+
+  def linreg(yExpr: Array[String],
+    xField: String,
+    covExpr: Array[String] = Array.empty[String],
+    root: String = "linreg",
+    rowBlockSize: Int = 16): MatrixTable = {
+    val vsmAnnot = vsm.annotateColsExpr(
+      yExpr.zipWithIndex.map { case (e, i) => s"__y$i" -> e } ++
+      covExpr.zipWithIndex.map { case (e, i) => s"__cov$i" -> e }: _*
+    )
+    LinearRegression(vsmAnnot,
+      yExpr.indices.map(i => s"__y$i").toArray,
+      xField,
+      covExpr.indices.map(i => s"__cov$i").toArray,
+      root,
+      rowBlockSize)
+  }
+
+  def skat(keyExpr: String,
+    weightExpr: String,
+    yExpr: String,
+    xField: String,
+    covExpr: Array[String] = Array.empty[String],
+    logistic: Boolean = false,
+    maxSize: Int = 46340, // floor(sqrt(Int.MaxValue))
+    accuracy: Double = 1e-6,
+    iterations: Int = 10000): Table = {
+    Skat(vsm, keyExpr, weightExpr, yExpr, xField, covExpr, logistic, maxSize, accuracy, iterations)
+  }
 }


### PR DESCRIPTION
This PR incorporates @cseed 's changes from #3477, brings everything up to date with master, and adds/fixes the following:
- added a test for linreg with no covariates against R, and deleted old `test_linear_regression_with_no_cov` since that still had intercept.
- extended Skat to work without covariates and added test that it runs, but it’s hard to test result against R given that the latter fails with no covariates: `Error in solve.default(t(X1) %*% X1) : 'a' is 0-diml`. The result look "reasonable" to me.
- added req of at least one covariate for logreg in doc and code. It's going to be painful to get logistic to take no covariates, we can always come back to it if priority goes up. Related fun breeze behavior: `a(::, *) *:* b` with `a` an `(n, 0)` matrix and `b` an `n`-vector has dimensions `(0, 0)`.
- removed default value of empty list for `covariate`, both to help signal users to consider putting in the intercept (pipelines currently using intercept only with default empty `[]` will break) and because empty is not currently valid for logreg.
- noted in docs that intercept must be included explicitly.
- added comment of R code against which linreg and logreg are testing