### PR TITLE
Move localizeEntries from function to IR

### DIFF
--- a/python/hail/ir/table_ir.py
+++ b/python/hail/ir/table_ir.py
@@ -230,3 +230,12 @@ class TableRepartition(TableIR):
 
     def __str__(self):
         return f'(TableRepartition {self.n} {self.shuffle} {self.child})'
+
+class LocalizeEntries(TableIR):
+    def __init__(self, child, entry_field_name):
+        super().__init__()
+        self.child = child
+        self.entry_field_name = entry_field_name
+
+    def __str__(self):
+        return f'(LocalizeEntries {escape_id(self.entry_field_name)} {self.child})'

--- a/python/hail/ir/table_ir.py
+++ b/python/hail/ir/table_ir.py
@@ -238,4 +238,4 @@ class LocalizeEntries(TableIR):
         self.entry_field_name = entry_field_name
 
     def __str__(self):
-        return f'(LocalizeEntries {escape_str(self.entry_field_name)} {self.child})'
+        return f'(LocalizeEntries "{escape_str(self.entry_field_name)}" {self.child})'

--- a/python/hail/ir/table_ir.py
+++ b/python/hail/ir/table_ir.py
@@ -238,4 +238,4 @@ class LocalizeEntries(TableIR):
         self.entry_field_name = entry_field_name
 
     def __str__(self):
-        return f'(LocalizeEntries {escape_id(self.entry_field_name)} {self.child})'
+        return f'(LocalizeEntries {escape_str(self.entry_field_name)} {self.child})'

--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -2449,7 +2449,7 @@ class MatrixTable(ExprContainer):
             uids.append(col_uid)
 
             def joiner(left: MatrixTable):
-                localized = Table(self._jvds.localizeEntries(row_uid))
+                localized = self._localize_entries(row_uid)
                 src_cols_indexed = self.cols().add_index(col_uid)
                 src_cols_indexed = src_cols_indexed.annotate(**{col_uid: hl.int32(src_cols_indexed[col_uid])})
                 left = left._annotate_all(row_exprs = {row_uid: localized.index(*row_exprs)[row_uid]},
@@ -2461,6 +2461,10 @@ class MatrixTable(ExprContainer):
                       [*row_exprs, *col_exprs],
                       joiner)
             return construct_expr(ir, self.entry.dtype, indices, aggregations)
+
+    @typecheck_method(entries_field_name=str)
+    def _localize_entries(self, entries_field_name):
+        return Table(self._jvds.localizeEntries(entries_field_name))
 
     @typecheck_method(row_exprs=dictof(str, expr_any),
                       col_exprs=dictof(str, expr_any),

--- a/python/test/hail/table/test_table.py
+++ b/python/test/hail/table/test_table.py
@@ -588,3 +588,14 @@ class Tests(unittest.TestCase):
         self.assertEqual(
             ht._filter_partitions([0, 7]).idx.collect(),
             [0, 1, 2, 21, 22])
+
+    def test_localize_entries(self):
+        ref_schema = hl.tstruct(row_idx=hl.tint32,
+                                __entries=hl.tarray(hl.tstruct(v=hl.tint32)))
+        ref_data = [{'row_idx': i, '__entries': [{'v': i+j} for j in range(6)]}
+                    for i in range(8)]
+        ref_tab = hl.Table.parallelize(ref_data, ref_schema).key_by('row_idx')
+        mt = hl.utils.range_matrix_table(8, 6)
+        mt = mt.annotate_entries(v=mt.row_idx+mt.col_idx)
+        t = mt._localize_entries('__entries')
+        self.assertTrue(t._same(ref_tab))

--- a/python/test/hail/test_ir.py
+++ b/python/test/hail/test_ir.py
@@ -147,6 +147,7 @@ class TableIRTests(unittest.TestCase):
             ir.TableExplode(table_read, 'mset'),
             ir.TableOrderBy(ir.TableUnkey(table_read), [('m', 'A'), ('m', 'D')]),
             ir.TableDistinct(table_read),
+            ir.LocalizeEntries(matrix_read, '__entries')
         ]
 
         return table_irs

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -621,7 +621,7 @@ object Parser extends JavaTokenParsers {
             SortField(i.substring(1), Descending)))
       } |
       "TableExplode" ~> identifier ~ table_ir ^^ { case field ~ child => ir.TableExplode(child, field) } |
-      "LocalizeEntries" ~> identifier ~ matrix_ir ^^ { case field ~ child =>
+      "LocalizeEntries" ~> string_literal ~ matrix_ir ^^ { case field ~ child =>
         ir.LocalizeEntries(child, field)
       }
 

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -620,7 +620,10 @@ object Parser extends JavaTokenParsers {
           else
             SortField(i.substring(1), Descending)))
       } |
-      "TableExplode" ~> identifier ~ table_ir ^^ { case field ~ child => ir.TableExplode(child, field) }
+      "TableExplode" ~> identifier ~ table_ir ^^ { case field ~ child => ir.TableExplode(child, field) } |
+      "LocalizeEntries" ~> identifier ~ matrix_ir ^^ { case field ~ child =>
+        ir.LocalizeEntries(child, field)
+      }
 
   def matrix_ir: Parser[ir.MatrixIR] = "(" ~> matrix_ir_1 <~ ")"
 

--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -267,6 +267,7 @@ object Pretty {
                   JsonMethods.compact(JSONAnnotationImpex.exportAnnotation(value.value, value.t)))
             case TableOrderBy(_, sortFields) => prettyIdentifiers(sortFields.map(sf =>
               (if (sf.sortOrder == Ascending) "A" else "D") + sf.field))
+            case LocalizeEntries(_, name) => name
             case _ => ""
           }
 

--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -267,7 +267,7 @@ object Pretty {
                   JsonMethods.compact(JSONAnnotationImpex.exportAnnotation(value.value, value.t)))
             case TableOrderBy(_, sortFields) => prettyIdentifiers(sortFields.map(sf =>
               (if (sf.sortOrder == Ascending) "A" else "D") + sf.field))
-            case LocalizeEntries(_, name) => name
+            case LocalizeEntries(_, name) => prettyStringLiteral(name)
             case _ => ""
           }
 

--- a/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -331,9 +331,10 @@ object PruneDeadFields {
         }
       case LocalizeEntries(child, fieldName) =>
         val minChild = minimal(child.typ)
+        val m = Map(fieldName -> MatrixType.entriesIdentifier)
         val childDep = minChild.copy(
           globalType = requestedType.globalType,
-          rvRowType = unify(child.typ.rvRowType, minChild.rvRowType, requestedType.rowType))
+          rvRowType = unify(child.typ.rvRowType, minChild.rvRowType, requestedType.rowType.rename(m)))
         memoizeMatrixIR(child, childDep, memo)
     }
   }
@@ -693,6 +694,12 @@ object PruneDeadFields {
         val expr2 = rebuild(expr, child2.typ, memo)
         val newKey2 = rebuild(newKey, child2.typ, memo)
         TableKeyByAndAggregate(child2, expr2, newKey2, nPartitions, bufferSize)
+      case LocalizeEntries(child, fieldName) =>
+        val child2 = rebuild(child, memo)
+        if (child2.typ.rvRowType.fields.contains(MatrixType.entriesIdentifier))
+          LocalizeEntries(child2, fieldName)
+        else
+          MatrixRowsTable(child2)
       case _ => tir.copy(tir.children.map {
         // IR should be a match error - all nodes with child value IRs should have a rule
         case childT: TableIR => rebuild(childT, memo)

--- a/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -696,7 +696,7 @@ object PruneDeadFields {
         TableKeyByAndAggregate(child2, expr2, newKey2, nPartitions, bufferSize)
       case LocalizeEntries(child, fieldName) =>
         val child2 = rebuild(child, memo)
-        if (child2.typ.rvRowType.fields.contains(MatrixType.entriesIdentifier))
+        if (dep.rowType.hasField(fieldName))
           LocalizeEntries(child2, fieldName)
         else
           MatrixRowsTable(child2)

--- a/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -329,6 +329,12 @@ object PruneDeadFields {
               memo)
           case None => memoizeTableIR(child, requestedType, memo)
         }
+      case LocalizeEntries(child, fieldName) =>
+        val minChild = minimal(child.typ)
+        val childDep = minChild.copy(
+          globalType = requestedType.globalType,
+          rvRowType = unify(child.typ.rvRowType, minChild.rvRowType, requestedType.rowType))
+        memoizeMatrixIR(child, childDep, memo)
     }
   }
 

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -840,14 +840,8 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     copyAST(MatrixExplodeCols(ast, path.toFastIndexedSeq))
   }
 
-  def localizeEntries(entriesFieldName: String): Table = {
-    val m = Map(MatrixType.entriesIdentifier -> entriesFieldName)
-    val newRowType = rvRowType.rename(m)
-    new Table(hc, TableLiteral(TableValue(
-      TableType(newRowType, Some(rowKey), globalType),
-      globals,
-      rvd.copy(typ = rvd.typ.copy(rowType = newRowType)))))
-  }
+  def localizeEntries(entriesFieldName: String): Table =
+    new Table(hc, LocalizeEntries(ast, entriesFieldName))
 
   def filterCols(p: (Annotation, Int) => Boolean): MatrixTable = {
     val (newType, filterF) = MatrixIR.filterCols(matrixType)

--- a/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -502,7 +502,8 @@ class IRSuite extends SparkSuite {
           FastIndexedSeq(TableRange(100, 10), TableRange(50, 10))),
         TableExplode(read, "mset"),
         TableUnkey(read),
-        TableOrderBy(TableUnkey(read), FastIndexedSeq(SortField("m", Ascending), SortField("m", Descending)))
+        TableOrderBy(TableUnkey(read), FastIndexedSeq(SortField("m", Ascending), SortField("m", Descending))),
+        LocalizeEntries(mtRead, "__entries")
       )
       xs.map(x => Array(x))
     } catch {

--- a/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -503,7 +503,7 @@ class IRSuite extends SparkSuite {
         TableExplode(read, "mset"),
         TableUnkey(read),
         TableOrderBy(TableUnkey(read), FastIndexedSeq(SortField("m", Ascending), SortField("m", Descending))),
-        LocalizeEntries(mtRead, "__entries")
+        LocalizeEntries(mtRead, " # entries")
       )
       xs.map(x => Array(x))
     } catch {


### PR DESCRIPTION
This is part of my work on UnlocalizeEntries (this function's 'inverse'). Separated out into it's own change.
Just moves `MatrixTable.localizeEntries` to the TableIR `LocalizeEntries` class.