### PR TITLE
Add UnlocalizeEntries IR Node

### DIFF
--- a/python/hail/ir/matrix_ir.py
+++ b/python/hail/ir/matrix_ir.py
@@ -273,3 +273,16 @@ class MatrixExplodeCols(MatrixIR):
         return '(MatrixExplodeCols ({}) {})'.format(
             ' '.join([escape_id(id) for id in self.path]),
             self.child)
+
+class UnlocalizeEntries(MatrixIR):
+    def __init__(self, rows_entries, cols, entry_field_name):
+        super().__init__()
+        self.rows_entries = rows_entries
+        self.cols = cols
+        self.entry_field_name = entry_field_name
+
+    def __str__(self):
+        return '(UnlocalizeEntries ' \
+                f'"{escape_str(self.entry_field_name)}" ' \
+                f'{self.rows_entries} ' \
+                f'{self.cols})'

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -2642,6 +2642,6 @@ class Table(ExprContainer):
 
     @typecheck_method(cols=table_type, entries_field_name=str)
     def _unlocalize_entries(self, cols, entries_field_name):
-        return MatrixTable(self._jt.unlocalizeEntries(cols, entries_field_name))
+        return hl.MatrixTable(self._jt.unlocalizeEntries(cols._jt, entries_field_name))
 
 table_type.set(Table)

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -2640,4 +2640,8 @@ class Table(ExprContainer):
     def _filter_partitions(self, parts, keep=True):
         return Table(self._jt.filterPartitions(parts, keep))
 
+    @typecheck_method(cols=table_type, entries_field_name=str)
+    def _unlocalize_entries(self, cols, entries_field_name):
+        return MatrixTable(self._jt.unlocalizeEntries(cols, entries_field_name))
+
 table_type.set(Table)

--- a/python/test/hail/test_ir.py
+++ b/python/test/hail/test_ir.py
@@ -157,8 +157,14 @@ class TableIRTests(unittest.TestCase):
             Env.hail().expr.Parser.parse_table_ir(str(x))
 
     def test_matrix_ir_parses(self):
+        matrix_read = ir.MatrixRead(
+            'src/test/resources/backward_compatability/1.0.0/matrix_table/0.hmt', False, False)
         matrix_irs = [
-            ir.MatrixUnionRows(ir.MatrixRange(5, 5, 1), ir.MatrixRange(5, 5, 1))
+            ir.MatrixUnionRows(ir.MatrixRange(5, 5, 1), ir.MatrixRange(5, 5, 1)),
+            ir.UnlocalizeEntries(
+                ir.LocalizeEntries(matrix_read, '__entries'),
+                ir.MatrixColsTable(matrix_read),
+                '__entries')
         ]
 
         for x in matrix_irs:

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -660,7 +660,10 @@ object Parser extends JavaTokenParsers {
       "MatrixExplodeCols" ~> ir_identifiers ~ matrix_ir ^^ { case path ~ child => ir.MatrixExplodeCols(child, path)} |
       "MatrixChooseCols" ~> int32_literals ~ matrix_ir ^^ { case oldIndices ~ child => ir.MatrixChooseCols(child, oldIndices) } |
       "MatrixCollectColsByKey" ~> matrix_ir ^^ { child => ir.MatrixCollectColsByKey(child) } |
-      "MatrixUnionRows" ~> matrix_ir_children ^^ { children => ir.MatrixUnionRows(children) }
+      "MatrixUnionRows" ~> matrix_ir_children ^^ { children => ir.MatrixUnionRows(children) } |
+      "UnlocalizeEntries" ~> string_literal ~ table_ir ~ table_ir ^^ {
+        case entryField ~ rowsEntries ~ cols => ir.UnlocalizeEntries(rowsEntries, cols, entryField)
+      }
 
   def parse_value_ir(s: String, ref_map: Map[String, Type]): IR = parse(ir_value_expr(ref_map), s)
 

--- a/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -2139,15 +2139,16 @@ case class UnlocalizeEntries(rowsEntries: TableIR, cols: TableIR, entryFieldName
       ir.IsNA(field))
 
     var rowOrvd = rowtab.enforceOrderingRVD.asInstanceOf[OrderedRVD]
-    // this is the check that all arrays have the same length and are present
+    // this checks that all arrays in the entries have the same length and are present
     rowOrvd.mapPartitions { it =>
       it.map { rv =>
         if (missingF()(rv.region, rv.offset, false)) {
-          fatal("missing entry") // FIXME(cdv) error message
+          fatal("missing entry array value in argument to UnlocalizeEntries")
         }
         val l = lenF()(rv.region, rv.offset, false)
         if (l != localColData.length) {
-          fatal(s"entry wrong size, was ${l}, should be ${localColData.length}") // FIXME error message
+          fatal(s"""incorrect entry array length in argument to UnlocalizeEntries:
+                   |   had ${l} elements, should have had ${localColData.length} elements""")
         }
         ()
       }

--- a/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -2147,7 +2147,7 @@ case class UnlocalizeEntries(rowsEntries: TableIR, cols: TableIR, entryFieldName
           val l = lenF()(rv.region, rv.offset, false)
           if (l != localColData.length) {
             fatal(s"""incorrect entry array length in argument to UnlocalizeEntries:
-                     |   had ${l} elements, should have had ${localColData.length} elements""")
+                     |   had ${l} elements, should have had ${localColData.length} elements""".stripMargin)
           }
           rv
         }

--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -268,6 +268,7 @@ object Pretty {
             case TableOrderBy(_, sortFields) => prettyIdentifiers(sortFields.map(sf =>
               (if (sf.sortOrder == Ascending) "A" else "D") + sf.field))
             case LocalizeEntries(_, name) => prettyStringLiteral(name)
+            case UnlocalizeEntries(_, _, name) => prettyStringLiteral(name)
             case _ => ""
           }
 

--- a/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -477,6 +477,20 @@ object PruneDeadFields {
         memoizeMatrixIR(child, dep, memo)
       case MatrixUnionRows(children) =>
         children.foreach(memoizeMatrixIR(_, requestedType, memo))
+      case UnlocalizeEntries(rowsEntries, cols, fieldName) =>
+        val m = Map(MatrixType.entriesIdentifier -> fieldName)
+        val minRowEntries = minimal(rowsEntries.typ)
+        val rowsEntriesDep = minRowEntries.copy(
+          globalType = requestedType.globalType,
+          rowType = unify(rowsEntries.typ.rowType, minRowEntries.rowType, requestedType.rvRowType.rename(m))
+        )
+        memoizeTableIR(rowsEntries, rowsEntriesDep, memo)
+
+        val minCols = minimal(cols.typ)
+        val colDep = cols.typ.copy(
+          rowType = unify(cols.typ.rowType, minCols.rowType, requestedType.colType),
+          globalType = TStruct())
+        memoizeTableIR(cols, colDep, memo)
     }
   }
 

--- a/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -482,14 +482,14 @@ object PruneDeadFields {
         val minRowEntries = minimal(rowsEntries.typ)
         val rowsEntriesDep = minRowEntries.copy(
           globalType = requestedType.globalType,
-          rowType = unify(rowsEntries.typ.rowType, minRowEntries.rowType, requestedType.rvRowType.rename(m))
+          rowType = unify(rowsEntries.typ.rowType, requestedType.rvRowType.rename(m))
         )
         memoizeTableIR(rowsEntries, rowsEntriesDep, memo)
 
         val minCols = minimal(cols.typ)
         val colDep = cols.typ.copy(
-          rowType = unify(cols.typ.rowType, minCols.rowType, requestedType.colType),
-          globalType = TStruct())
+          rowType = unify(cols.typ.rowType, requestedType.colType),
+          globalType = minCols.globalType)
         memoizeTableIR(cols, colDep, memo)
     }
   }

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -4,7 +4,7 @@ import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.expr._
 import is.hail.expr.ir
-import is.hail.expr.ir.{IR, Pretty, TableAggregateByKey, TableExplode, TableFilter, TableIR, TableJoin, TableKeyBy, TableKeyByAndAggregate, TableLiteral, TableMapGlobals, TableMapRows, TableOrderBy, TableParallelize, TableRange, TableRead, TableToMatrixTable, TableUnion, TableUnkey, TableValue}
+import is.hail.expr.ir.{IR, Pretty, TableAggregateByKey, TableExplode, TableFilter, TableIR, TableJoin, TableKeyBy, TableKeyByAndAggregate, TableLiteral, TableMapGlobals, TableMapRows, TableOrderBy, TableParallelize, TableRange, TableRead, TableToMatrixTable, TableUnion, TableUnkey, TableValue, UnlocalizeEntries}
 import is.hail.expr.types._
 import is.hail.io.plink.{FamFileConfig, LoadPlink}
 import is.hail.methods.Aggregators
@@ -538,6 +538,9 @@ class Table(val hc: HailContext, val tir: TableIR) {
       bufferSize
     ))
   }
+
+  def unlocalizeEntries(cols: Table, entriesFieldName: String): MatrixTable =
+    new MatrixTable(hc, UnlocalizeEntries(tir, cols.tir, entriesFieldName))
 
   def aggregateByKey(expr: String): Table = {
     val x = Parser.parse_value_ir(expr, typ.refMap)

--- a/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -573,7 +573,13 @@ class IRSuite extends SparkSuite {
           None),
         MatrixExplodeRows(read, FastIndexedSeq("row_mset")),
         MatrixUnionRows(FastIndexedSeq(range1, range2)),
-        MatrixExplodeCols(read, FastIndexedSeq("col_mset")))
+        MatrixExplodeCols(read, FastIndexedSeq("col_mset")),
+        UnlocalizeEntries(
+          LocalizeEntries(read, "all of the entries"),
+          MatrixColsTable(read),
+          "all of the entries"
+        )
+      )
 
       xs.map(x => Array(x))
     } catch {

--- a/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir
 import is.hail.SparkSuite
 import is.hail.expr.ir.TestUtils._
 import is.hail.expr.types._
+import is.hail.table.Table
 import is.hail.utils._
 import is.hail.TestUtils._
 import is.hail.variant.MatrixTable
@@ -120,7 +121,6 @@ class MatrixIRSuite extends SparkSuite {
     assert(actualOrdering sameElements expectedOrdering)
   }
 
-
   @DataProvider(name = "explodeRowsData")
   def explodeRowsData(): Array[Array[Any]] = Array(
     Array(FastIndexedSeq("empty"), FastIndexedSeq()),
@@ -145,5 +145,99 @@ class MatrixIRSuite extends SparkSuite {
 
     val expected = if (collection == null) Array[Integer]() else Array.fill(5)(collection).flatten
     assert(exploded sameElements expected)
+  }
+  
+  // these two items are helper for UnlocalizedEntries testing,
+  def makeLocalizedTable(data: Array[Array[Any]]): Table = {
+    val rowRdd = sc.parallelize(data.map(Row.fromSeq(_)))
+    val rowSig = TStruct(
+      "idx" -> TInt32(),
+      "animal" -> TString(),
+      "__entries" -> TArray(TStruct("ent1" -> TString(), "ent2" -> TFloat64()))
+    )
+    val keyNames = IndexedSeq("idx")
+    Table(hc, rowRdd, rowSig, Some(keyNames))
+  }
+  def getLocalizedCols: Table = {
+    val cdata = Array(
+      Array(1, "atag"),
+      Array(2, "btag")
+    )
+    val colRdd = sc.parallelize(cdata.map(Row.fromSeq(_)))
+    val colSig = TStruct("idx" -> TInt32(), "tag" -> TString())
+    val keyNames = IndexedSeq("idx")
+    Table(hc, colRdd, colSig, Some(keyNames))
+  }
+
+  @Test def testUnlocalizeEntries() {
+    val rdata = Array(
+      Array(1, "fish", IndexedSeq(Row.fromSeq(Array("a", 1.0)), Row.fromSeq(Array("x", 2.0)))),
+      Array(2, "cat", IndexedSeq(Row.fromSeq(Array("b", 0.0)), Row.fromSeq(Array("y", 0.1)))),
+      Array(3, "dog", IndexedSeq(Row.fromSeq(Array("c", -1.0)), Row.fromSeq(Array("z", 30.0))))
+    )
+    val rowTab = makeLocalizedTable(rdata)
+    val colTab = getLocalizedCols
+
+    val mir = UnlocalizeEntries(rowTab.tir, colTab.tir, "__entries")
+    // cols are same
+    val mtCols = MatrixColsTable(mir).execute(hc).rdd.collect()
+    val taCols = colTab.tir.execute(hc).rdd.collect()
+    assert(mtCols sameElements taCols)
+
+    // Rows are same
+    val mtRows = MatrixRowsTable(mir).execute(hc).rdd.collect()
+    val taRows = rowTab.tir.execute(hc).rdd
+    assert(mtRows sameElements taRows.map(row => Row.fromSeq(row.toSeq.take(2))).collect())
+
+    // Round trip
+    val localRows = new MatrixTable(hc, mir).localizeEntries("__entries").tir.execute(hc).rdd.collect()
+    assert(localRows sameElements taRows.collect())
+  }
+
+  @Test def testUnlocalizeEntriesErrors() {
+    val rdata = Array(
+      Array(1, "fish", IndexedSeq(Row.fromSeq(Array("x", 2.0)))),
+      Array(2, "cat", IndexedSeq(Row.fromSeq(Array("b", 0.0)), Row.fromSeq(Array("y", 0.1)))),
+      Array(3, "dog", IndexedSeq(Row.fromSeq(Array("c", -1.0)), Row.fromSeq(Array("z", 30.0))))
+    )
+    val rowTab = makeLocalizedTable(rdata)
+    val colTab = getLocalizedCols
+    val mir = UnlocalizeEntries(rowTab.tir, colTab.tir, "__entries")
+    // All rows must have the same number of elements in the entry field as colTab has rows
+    try {
+      val mv = mir.execute(hc)
+      assert(false, "should have thrown an error, as the number of columns must match "
+        + "the number of array entries")
+    } catch {
+      case e: org.apache.spark.SparkException => {
+        assert(e.getCause.getClass.toString.contains("HailException"))
+        assert(e.getCause.getMessage.contains("wrong size"))
+      }
+    }
+
+    // The entry field must be an array
+    try {
+      val mir1 = UnlocalizeEntries(rowTab.tir, colTab.tir, "animal")
+    } catch {
+      case e: is.hail.utils.HailException => {}
+    }
+
+    val rdata2 = Array(
+      Array(1, "fish", null),
+      Array(2, "cat", IndexedSeq(Row.fromSeq(Array("b", 0.0)), Row.fromSeq(Array("y", 0.1)))),
+      Array(3, "dog", IndexedSeq(Row.fromSeq(Array("c", -1.0)), Row.fromSeq(Array("z", 30.0))))
+    )
+    val rowTab2 = makeLocalizedTable(rdata2)
+    val mir2 = UnlocalizeEntries(rowTab2.tir, colTab.tir, "__entries")
+
+    try {
+      val mv = mir2.execute(hc)
+      assert(false, "should have thrown an error, as no array should be missing")
+    } catch {
+      case e: org.apache.spark.SparkException => {
+        assert(e.getCause.getClass.toString.contains("HailException"))
+        assert(e.getCause.getMessage.contains("missing"))
+      }
+    }
   }
 }

--- a/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
@@ -146,7 +146,7 @@ class MatrixIRSuite extends SparkSuite {
     val expected = if (collection == null) Array[Integer]() else Array.fill(5)(collection).flatten
     assert(exploded sameElements expected)
   }
-  
+
   // these two items are helper for UnlocalizedEntries testing,
   def makeLocalizedTable(data: Array[Array[Any]]): Table = {
     val rowRdd = sc.parallelize(data.map(Row.fromSeq(_)))
@@ -206,6 +206,7 @@ class MatrixIRSuite extends SparkSuite {
     // All rows must have the same number of elements in the entry field as colTab has rows
     try {
       val mv = mir.execute(hc)
+      mv.rvd.count // force evaluation of mapPartitionsPreservesPartitioning in UnlocalizeEntries.execute
       assert(false, "should have thrown an error, as the number of columns must match "
         + "the number of array entries")
     } catch {
@@ -232,6 +233,7 @@ class MatrixIRSuite extends SparkSuite {
 
     try {
       val mv = mir2.execute(hc)
+      mv.rvd.count // force evaluation of mapPartitionsPreservesPartitioning in UnlocalizeEntries.execute
       assert(false, "should have thrown an error, as no array should be missing")
     } catch {
       case e: org.apache.spark.SparkException => {

--- a/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
@@ -211,7 +211,7 @@ class MatrixIRSuite extends SparkSuite {
     } catch {
       case e: org.apache.spark.SparkException => {
         assert(e.getCause.getClass.toString.contains("HailException"))
-        assert(e.getCause.getMessage.contains("wrong size"))
+        assert(e.getCause.getMessage.contains("incorrect entry array length"))
       }
     }
 


### PR DESCRIPTION
This represents the 'inverse' of LocalizeEntries. It combines two
tables, one representing the 'table view' of a MatrixTable's rows and
entries (with the entries as an array of structs), and the second
representing the column data of the MatrixTable.

UnlocalizeEntries is constructed from two TableIRs (rowsEntries and
cols) and a String (entriesFieldName). entriesFieldName must refer
to an array of structs. All elements of the entriesFieldName field
must be present and have the same length as the number of rows in
cols.