### PR TITLE
fix #4114 to_matrix_table bug with duplicate row key

### DIFF
--- a/python/test/hail/table/test_table.py
+++ b/python/test/hail/table/test_table.py
@@ -617,6 +617,19 @@ class Tests(unittest.TestCase):
         t = mt._localize_entries('__entries')
         self.assertTrue(t._same(ref_tab))
 
+    def test_to_matrix_table_with_duplicate_row_keys(self):
+        ht = hl.Table.parallelize([
+            {'locus': '1:32280610', 'alleles': ['T', 'C'], 'p_value': .5,
+             'phenotype': 'foo'},
+            {'locus': '1:32280610', 'alleles': ['T', 'C'], 'p_value': .6,
+             'phenotype': 'foo'},
+        ], hl.tstruct(locus=hl.tstr, alleles=hl.tarray(hl.tstr),
+                      p_value=hl.tfloat32, phenotype=hl.tstr))
+
+        mt = ht.to_matrix_table(['locus', 'alleles'], ['phenotype'])
+
+        self.assertEqual(mt.count(), (2, 1))
+
     def test_union(self):
         t1 = hl.utils.range_table(5)
 

--- a/src/test/scala/is/hail/methods/TableSuite.scala
+++ b/src/test/scala/is/hail/methods/TableSuite.scala
@@ -95,6 +95,20 @@ class TableSuite extends SparkSuite {
     assert(kt.unkey().keyBy(Array("Sample")).count() == count)
   }
 
+  @Test def testTableToMatrixTableWithDuplicateRowKeys(): Unit = {
+    val table = Table.parallelize(
+      hc,
+      FastIndexedSeq(
+        Row("1:100", 0.5.toFloat, "trait1"),
+        Row("1:100", 0.6.toFloat, "trait1")),
+      TStruct("locus" -> TString(), "pval" -> TFloat32Required,
+        "phenotype" -> TString()),
+      None, None)
+
+    assert(table.toMatrixTable(Array("locus"), Array("phenotype"), Array(),
+      Array(), Array("locus")).count() == (2L, 1L))
+  }
+
   @Test def testToMatrixTable() {
     val vds = hc.importVCF("src/test/resources/sample.vcf")
     val gkt = vds.entriesTable()


### PR DESCRIPTION
Unsure if the test for this should go in python or scala, so I have both right now. I can delete one of them.