### PR TITLE
Index query by key

### DIFF
--- a/src/main/scala/is/hail/io/index/IndexReader.scala
+++ b/src/main/scala/is/hail/io/index/IndexReader.scala
@@ -21,6 +21,7 @@ class IndexReader(conf: Configuration, path: String, cacheCapacity: Int = 256) {
   private val metadata = readMetadata(path + "/metadata.json.gz")
   val branchingFactor = metadata.branchingFactor
   val nKeys = metadata.nKeys
+  val attributes = metadata.attributes
 
   val keyType = Parser.parseType(metadata.keyType)
   val leafType = LeafNodeBuilder.typ(keyType)

--- a/src/main/scala/is/hail/io/index/IndexReader.scala
+++ b/src/main/scala/is/hail/io/index/IndexReader.scala
@@ -32,6 +32,7 @@ class IndexReader(hConf: Configuration, path: String, cacheCapacity: Int = 8) ex
   val attributes = metadata.attributes
 
   val keyType = Parser.parseType(metadata.keyType)
+  val ordering = keyType.ordering
   val leafType = LeafNodeBuilder.typ(keyType)
   val internalType = InternalNodeBuilder.typ(keyType)
 
@@ -80,6 +81,169 @@ class IndexReader(hConf: Configuration, path: String, cacheCapacity: Int = 8) ex
     }
   }
 
+  private def binarySearchLeftmost(n: Int, key: Annotation, f: (Int) => Annotation): Int = {
+    var left = 0
+    var right = n
+    while (left < right) {
+      val mid = left + (right - left) / 2
+      if (ordering.lt(f(mid), key))
+        left = mid + 1
+      else
+        right = mid
+    }
+    left // if left < n and A[left] == key, leftmost element that equals key. Otherwise, left is the insertion point of key in A.
+  }
+
+  private def binarySearchRightmost(n: Int, key: Annotation, f: (Int) => Annotation): Int = {
+    var left = 0
+    var right = n
+    while (left < right) {
+      val mid = left + (right - left) / 2
+      if (ordering.gt(f(mid), key))
+        right = mid
+      else
+        left = mid + 1
+    }
+    left // if left > 0 and A[left - 1] == key, rightmost element that equals key. Otherwise, left is the insertion point of key in A.
+  }
+
+  private def queryByKeyAllMatches(key: Annotation, level: Int, offset: Long, ab: ArrayBuilder[LeafChild]) {
+    if (level == 0) {
+      val node = readLeafNode(offset)
+      val n = node.children.length
+      var idx = binarySearchLeftmost(node.children.length, key, { i => node.children(i).key })
+      while (idx < n && ordering.equiv(node.children(idx).key, key)) {
+        ab += node.children(idx)
+        idx += 1
+      }
+    } else {
+      val node = readInternalNode(offset)
+      val n = node.children.length
+
+      var idx = binarySearchLeftmost(node.children.length, key, { i => node.children(i).lastKey })
+      while (idx < n && {
+        val child = node.children(idx)
+        ordering.gteq(key, child.firstKey) && ordering.lteq(key, child.lastKey)
+      }) {
+        queryByKeyAllMatches(key, level - 1, node.children(idx).childOffset, ab)
+        idx += 1
+      }
+    }
+  }
+
+  private def queryByKeyGtEq(key: Annotation, level: Int, offset: Long): Option[LeafChild] = {
+    if (level == 0) {
+      val node = readLeafNode(offset)
+      val n = node.children.length
+      val idx = binarySearchRightmost(node.children.length, key, { i => node.children(i).key })
+      if (idx > 0 && ordering.equiv(node.children(idx - 1).key, key))
+        Some(node.children(idx - 1))
+      else if (idx == n)
+        None
+      else
+        Some(node.children(idx))
+    } else {
+      val node = readInternalNode(offset)
+      val n = node.children.length
+      val idx = binarySearchRightmost(node.children.length, key, { i => node.children(i).firstKey })
+      if (idx > 0 && ordering.lteq(key, node.children(idx - 1).lastKey))
+        queryByKeyGtEq(key, level - 1, node.children(idx - 1).childOffset)
+      else if (idx == n)
+        None
+      else
+        queryByKeyGtEq(key, level - 1, node.children(idx).childOffset)
+    }
+  }
+
+  private def queryByKeyGt(key: Annotation, level: Int, offset: Long): Option[LeafChild] = {
+    if (level == 0) {
+      val node = readLeafNode(offset)
+      val n = node.children.length
+      val idx = binarySearchRightmost(node.children.length, key, { i => node.children(i).key })
+      if (idx == n)
+        None
+      else
+        Some(node.children(idx))
+    } else {
+      val node = readInternalNode(offset)
+      val n = node.children.length
+      val idx = binarySearchRightmost(node.children.length, key, { i => node.children(i).firstKey })
+      if (idx > 0 && ordering.lt(key, node.children(idx - 1).lastKey))
+        queryByKeyGt(key, level - 1, node.children(idx - 1).childOffset)
+      else if (idx == n)
+        None
+      else
+        queryByKeyGt(key, level - 1, node.children(idx).childOffset)
+    }
+  }
+
+  private def queryByKeyLtEq(key: Annotation, level: Int, offset: Long): Option[LeafChild] = {
+    if (level == 0) {
+      val node = readLeafNode(offset)
+      val n = node.children.length
+      val idx = binarySearchLeftmost(node.children.length, key, { i => node.children(i).key })
+      if (idx < n && ordering.equiv(node.children(idx).key, key))
+        Some(node.children(idx))
+      else if (idx == 0)
+        None
+      else
+        Some(node.children(idx - 1))
+    } else {
+      val node = readInternalNode(offset)
+      val n = node.children.length
+      val idx = binarySearchLeftmost(node.children.length, key, { i => node.children(i).lastKey })
+      if (idx < n && ordering.gteq(key, node.children(0).firstKey))
+        queryByKeyLtEq(key, level - 1, node.children(idx).childOffset)
+      else if (idx == 0)
+        None
+      else
+        queryByKeyLtEq(key, level - 1, node.children(idx - 1).childOffset)
+    }
+  }
+
+  private def queryByKeyLt(key: Annotation, level: Int, offset: Long): Option[LeafChild] = {
+    if (level == 0) {
+      val node = readLeafNode(offset)
+      val n = node.children.length
+      val idx = binarySearchLeftmost(node.children.length, key, { i => node.children(i).key })
+      if (idx == 0)
+        None
+      else
+        Some(node.children(idx - 1))
+    } else {
+      val node = readInternalNode(offset)
+      val n = node.children.length
+      val idx = binarySearchLeftmost(node.children.length, key, { i => node.children(i).lastKey })
+      if (idx < n && ordering.gt(key, node.children(idx).firstKey))
+        queryByKeyLt(key, level - 1, node.children(idx).childOffset)
+      else if (idx == 0)
+        None
+      else
+        queryByKeyLt(key, level - 1, node.children(idx - 1).childOffset)
+    }
+  }
+
+  def queryByKeyAllMatches(key: Annotation): Array[LeafChild] = {
+    val ab = new ArrayBuilder[LeafChild]()
+    if (nKeys != 0)
+      queryByKeyAllMatches(key, height - 1, metadata.rootOffset, ab)
+    ab.result()
+  }
+
+  def queryByKey(key: Annotation, greater: Boolean = true, closed: Boolean = true): Option[LeafChild] = {
+    if (nKeys == 0)
+      return None
+
+    if (greater && closed)
+      queryByKeyGtEq(key, height - 1, metadata.rootOffset)
+    else if (greater && !closed)
+      queryByKeyGt(key, height - 1, metadata.rootOffset)
+    else if (!greater && closed)
+      queryByKeyLtEq(key, height - 1, metadata.rootOffset)
+    else
+      queryByKeyLt(key, height - 1, metadata.rootOffset)
+  }
+
   private def queryByIndex(idx: Long, level: Int, offset: Long): LeafChild = {
     if (level == 0) {
       val node = readLeafNode(offset)
@@ -107,12 +271,12 @@ class IndexReader(hConf: Configuration, path: String, cacheCapacity: Int = 8) ex
   }
 }
 
-final case class InternalChild(childOffset: Long, firstKey: Annotation, firstKeyOffset: Long)
+final case class InternalChild(childOffset: Long, firstKey: Annotation, firstKeyOffset: Long, lastKey: Annotation)
 
 object InternalNode {
   def apply(r: Row): InternalNode = {
     val blockFirstKeyIndex = r.getLong(0)
-    val children = r.get(1).asInstanceOf[IndexedSeq[Row]].map(r => InternalChild(r.getLong(0), r.get(1), r.getLong(2)))
+    val children = r.get(1).asInstanceOf[IndexedSeq[Row]].map(r => InternalChild(r.getLong(0), r.get(1), r.getLong(2), r.get(3)))
     InternalNode(blockFirstKeyIndex, children)
   }
 }

--- a/src/main/scala/is/hail/io/index/IndexReader.scala
+++ b/src/main/scala/is/hail/io/index/IndexReader.scala
@@ -1,0 +1,120 @@
+package is.hail.io.index
+
+import java.util
+import java.util.Map.Entry
+
+import is.hail.annotations.{Annotation, RegionValue, SafeRow}
+import is.hail.expr.Parser
+import is.hail.io._
+import is.hail.rvd.RVDContext
+import is.hail.utils._
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.FSDataInputStream
+import org.apache.spark.sql.Row
+import org.json4s.Formats
+import org.json4s.jackson.JsonMethods
+
+class IndexReader(conf: Configuration, path: String, cacheCapacity: Int = 256) {
+  private val is = conf.unsafeReader(path + "/index").asInstanceOf[FSDataInputStream]
+  private val codecSpec = CodecSpec.default
+
+  private val metadata = readMetadata(path + "/metadata.json.gz")
+  val branchingFactor = metadata.branchingFactor
+  val nKeys = metadata.nKeys
+
+  val keyType = Parser.parseType(metadata.keyType)
+  val leafType = LeafNodeBuilder.typ(keyType)
+  val internalType = InternalNodeBuilder.typ(keyType)
+
+  private val leafDecoder = codecSpec.buildDecoder(leafType, leafType)(is)
+  private val internalDecoder = codecSpec.buildDecoder(internalType, internalType)(is)
+
+  private val ctx = RVDContext.default
+  private val region = ctx.region
+  private val rv = RegionValue(region)
+
+  @transient private[this] lazy val leafCache = new util.LinkedHashMap[Long, LeafNode](cacheCapacity, 0.75f, true) {
+    override def removeEldestEntry(eldest: Entry[Long, LeafNode]): Boolean = size() > cacheCapacity
+  }
+
+  def readMetadata(metadataFile: String): IndexMetadata = {
+    val jv = conf.readFile(metadataFile) { in => JsonMethods.parse(in) }
+    implicit val formats: Formats = defaultJSONFormats
+    jv.extract[IndexMetadata]
+  }
+
+  def readInternalNode(offset: Long): InternalNode = {
+    is.seek(offset)
+    assert(internalDecoder.readByte() == 1)
+    rv.setOffset(internalDecoder.readRegionValue(region))
+    InternalNode(SafeRow(internalType, rv))
+  }
+
+  def readLeafNode(offset: Long): LeafNode = {
+    is.seek(offset)
+    assert(leafDecoder.readByte() == 0)
+    rv.setOffset(leafDecoder.readRegionValue(region))
+    LeafNode(SafeRow(leafType, rv))
+  }
+
+  private def queryByIndex(idx: Long, depth: Int, offset: Long): LeafChild = {
+    if (depth == 0) {
+      val node = readLeafNode(offset)
+      val localIdx = idx - node.firstKeyIndex
+
+      if (!leafCache.containsKey(node.firstKeyIndex))
+        leafCache.put(node.firstKeyIndex, node)
+
+      node.keys(localIdx.toInt)
+    } else {
+      val node = readInternalNode(offset)
+      val blockStartIdx = node.blockFirstKeyIndex
+      val nKeysPerBlock = math.pow(branchingFactor, depth).toLong
+      val localIdx = (idx - blockStartIdx) / nKeysPerBlock
+      queryByIndex(idx, depth - 1, node.children(localIdx.toInt).childOffset)
+    }
+  }
+
+  def queryByIndex(idx: Long): LeafChild = {
+    require(idx >= 0 && idx < nKeys)
+
+    val hash = idx / branchingFactor * branchingFactor
+
+    if (leafCache.containsKey(hash)) {
+      val node = leafCache.get(hash)
+      node.keys((idx - node.firstKeyIndex).toInt)
+    } else {
+      val maxDepth = math.max(IndexUtils.calcDepth(nKeys, branchingFactor) - 1, 1)
+      queryByIndex(idx, maxDepth, metadata.rootOffset)
+    }
+  }
+
+  def close() {
+    leafDecoder.close()
+    internalDecoder.close()
+  }
+}
+
+final case class InternalChild(childOffset: Long, firstKey: Annotation, firstKeyOffset: Long)
+
+object InternalNode {
+  def apply(r: Row): InternalNode = {
+    val blockFirstKeyIndex = r.getLong(0)
+    val children = r.get(1).asInstanceOf[IndexedSeq[Row]].map(r => InternalChild(r.getLong(0), r.get(1), r.getLong(2)))
+    InternalNode(blockFirstKeyIndex, children)
+  }
+}
+
+final case class InternalNode(blockFirstKeyIndex: Long, children: IndexedSeq[InternalChild])
+
+final case class LeafChild(key: Annotation, offset: Long) { }
+
+object LeafNode {
+  def apply(r: Row): LeafNode = {
+    val firstKeyIndex = r.getLong(0)
+    val keys = r.get(1).asInstanceOf[IndexedSeq[Row]].map(r => LeafChild(r.get(0), r.getLong(1)))
+    LeafNode(firstKeyIndex, keys)
+  }
+}
+
+final case class LeafNode(firstKeyIndex: Long, keys: IndexedSeq[LeafChild]) { }

--- a/src/main/scala/is/hail/io/index/IndexReader.scala
+++ b/src/main/scala/is/hail/io/index/IndexReader.scala
@@ -80,53 +80,6 @@ class IndexReader(hConf: Configuration, path: String, cacheCapacity: Int = 8) ex
     }
   }
 
-
-  private def queryByKey(key: Annotation, level: Int, offset: Long, ordering: ExtendedOrdering): Option[LeafChild] = {
-    def searchLeafNode(node: LeafNode): Option[LeafChild] = {
-      var left = 0
-      var right = node.children.length - 1
-      while (left <= right) {
-        val mid = left + (right - left) / 2
-        val midKey = node.children(mid).key
-
-        if (ordering.equiv(key, midKey))
-          return Some(node.children(mid))
-        else if (ordering.lt(key, midKey))
-          right = mid - 1
-        else
-          left = mid + 1
-      }
-      None
-    }
-
-    def searchInternalNode(node: InternalNode): InternalChild = {
-      var left = 0
-      var right = node.children.length - 1
-      while (left <= right) {
-        val mid = left + (right - left) / 2
-        val midKey = node.children(mid).firstKey
-
-        if (ordering.equiv(key, midKey))
-          return node.children(mid)
-        else if (ordering.lt(key, midKey))
-          right = mid - 1
-        else
-          left = mid + 1
-      }
-
-      node.children(left - 1)
-    }
-
-    if (level == 0)
-      searchLeafNode(readLeafNode(offset))
-    else
-      queryByKey(key, level - 1, searchInternalNode(readInternalNode(offset)).childOffset, ordering)
-  }
-
-  def queryByKey(key: Annotation): Option[LeafChild] = {
-    queryByKey(key, height - 1, metadata.rootOffset, keyType.ordering)
-  }
-
   private def queryByIndex(idx: Long, level: Int, offset: Long): LeafChild = {
     if (level == 0) {
       val node = readLeafNode(offset)

--- a/src/main/scala/is/hail/io/index/IndexUtils.scala
+++ b/src/main/scala/is/hail/io/index/IndexUtils.scala
@@ -1,0 +1,7 @@
+package is.hail.io.index
+
+object IndexUtils {
+  def calcDepth(nElements: Long, branchingFactor: Int) =
+  // max necessary for array of length 1 becomes depth = 0
+    math.max(1, (math.log10(nElements) / math.log10(branchingFactor)).ceil.toInt)
+}

--- a/src/main/scala/is/hail/io/index/IndexUtils.scala
+++ b/src/main/scala/is/hail/io/index/IndexUtils.scala
@@ -1,7 +1,0 @@
-package is.hail.io.index
-
-object IndexUtils {
-  def calcDepth(nElements: Long, branchingFactor: Int) =
-  // max necessary for array of length 1 becomes depth = 0
-    math.max(1, (math.log10(nElements) / math.log10(branchingFactor)).ceil.toInt)
-}

--- a/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -15,14 +15,16 @@ case class IndexMetadata(
   keyType: String,
   nKeys: Long,
   indexPath: String,
-  rootOffset: Long
+  rootOffset: Long,
+  attributes: Map[String, Any]
 )
 
 class IndexWriter(
   conf: Configuration,
   path: String,
   keyType: Type,
-  branchingFactor: Int = 1024) {
+  branchingFactor: Int = 1024,
+  attributes: Map[String, Any] = Map.empty[String, Any]) {
 
   private var elementIdx = 0L
   private var rootOffset = 0L
@@ -139,7 +141,7 @@ class IndexWriter(
 
   private def writeMetadata() = {
     conf.writeTextFile(path + "/metadata.json.gz") { out =>
-      val metadata = IndexMetadata(1, branchingFactor, keyType._toPretty, elementIdx, path, rootOffset)
+      val metadata = IndexMetadata(1, branchingFactor, keyType._toPretty, elementIdx, path, rootOffset, attributes)
       implicit val formats: Formats = defaultJSONFormats
       Serialization.write(metadata, out)
     }

--- a/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -1,0 +1,163 @@
+package is.hail.io.index
+
+import is.hail.expr.types._
+import is.hail.io.CodecSpec
+import is.hail.rvd.RVDContext
+import is.hail.utils._
+import is.hail.utils.richUtils.ByteTrackingOutputStream
+import org.apache.hadoop.conf.Configuration
+import org.json4s.Formats
+import org.json4s.jackson.Serialization
+
+case class IndexMetadata(
+  fileVersion: Int,
+  branchingFactor: Int,
+  keyType: String,
+  nKeys: Long,
+  indexPath: String,
+  rootOffset: Long
+)
+
+class IndexWriter(
+  conf: Configuration,
+  path: String,
+  keyType: Type,
+  branchingFactor: Int = 1024) {
+
+  private var elementIdx = 0L
+  private var rootOffset = 0L
+
+  private val ctx = RVDContext.default
+  private val rvb = ctx.rvb
+  private val region = ctx.freshRegion
+  rvb.set(region)
+
+  private val leafNode = new LeafNodeBuilder(keyType)
+  private val internalNodes = new ArrayBuilder[InternalNodeBuilder]()
+
+  private val trackedOS = new ByteTrackingOutputStream(conf.unsafeWriter(path + "/index"))
+  private val codecSpec = CodecSpec.default
+  private val leafEncoder = codecSpec.buildEncoder(leafNode.typ)(trackedOS)
+  private val internalEncoder = codecSpec.buildEncoder(InternalNodeBuilder.typ(keyType))(trackedOS)
+
+  private def writeInternalNode(node: InternalNodeBuilder): (Long, Long, Any, Long) = {
+    val fileOffset = trackedOS.bytesWritten
+    rootOffset = fileOffset
+
+    val firstKey = node.firstKey
+    val firstKeyOffset = node.firstOffset
+    val firstIndex = node.firstIndex
+
+    internalEncoder.writeByte(1)
+
+    val regionOffset = node.write(rvb)
+    internalEncoder.writeRegionValue(region, regionOffset)
+    internalEncoder.flush()
+
+    region.clear()
+    node.clear()
+
+    (fileOffset, firstIndex, firstKey, firstKeyOffset)
+  }
+
+  private def writeLeafNode(idx: Long): (Long, Any, Long) = {
+    val fileOffset = trackedOS.bytesWritten
+    val firstKey = leafNode.firstKey
+    val firstOffset = leafNode.firstOffset
+
+    leafEncoder.writeByte(0)
+
+    val regionOffset = leafNode.write(rvb, idx)
+    leafEncoder.writeRegionValue(region, regionOffset)
+    leafEncoder.flush()
+
+    region.clear()
+    leafNode.clear()
+
+    (fileOffset, firstKey, firstOffset)
+  }
+
+  private def write() {
+    def updateInternalNodes(level: Int, fileOffset: Long, firstIndex: Long, firstKey: Any, firstOffset: Long) {
+      if (level == internalNodes.size)
+        internalNodes += new InternalNodeBuilder(keyType)
+
+      val node = internalNodes(level)
+
+      if (node.size == 0) {
+        node.setFirstIndex(firstIndex)
+      }
+
+      node += (fileOffset, firstKey, firstOffset)
+
+      if (node.size == branchingFactor) {
+        val (fileOffset, firstIndex, firstKey, firstKeyOffset) = writeInternalNode(node)
+        updateInternalNodes(level + 1, fileOffset, firstIndex, firstKey, firstKeyOffset)
+      }
+    }
+
+    val idx = elementIdx - leafNode.size
+    val (leafFileOffset, leafFirstKey, leafFirstOffset) = writeLeafNode(idx)
+    updateInternalNodes(0, leafFileOffset, idx, leafFirstKey, leafFirstOffset)
+  }
+
+  private def flush() {
+    val nInternalLevels = math.max(IndexUtils.calcDepth(elementIdx, branchingFactor) - 1, 1) // ensure always one internal node
+
+    def flushInternalNodes(level: Int, fileOffset: Long, firstIndex: Long, firstKey: Any, firstOffset: Long) {
+      if (level != nInternalLevels) {
+        val node = internalNodes(level)
+
+        if (node.size == 0)
+          node.setFirstIndex(firstIndex)
+
+        node += (fileOffset, firstKey, firstOffset)
+
+        assert(node.size > 0 && node.size <= branchingFactor)
+
+        val (nextFileOffset, nextFirstIndex, nextFirstKey, nextFirstKeyOffset) = writeInternalNode(node)
+
+        flushInternalNodes(level + 1, nextFileOffset, nextFirstIndex, nextFirstKey, nextFirstKeyOffset)
+      }
+    }
+
+    if (leafNode.size > 0) {
+      write()
+    }
+    assert(internalNodes.size > 0)
+
+    var level = 0
+    while (level < nInternalLevels) {
+      val node = internalNodes(level)
+      if (node.size > 0) {
+        val (fileOffset, firstIndex, firstKey, firstKeyOffset) = writeInternalNode(node)
+        flushInternalNodes(level + 1, fileOffset, firstIndex, firstKey, firstKeyOffset)
+      }
+      level += 1
+    }
+  }
+
+  private def writeMetadata() = {
+    conf.writeTextFile(path + "/metadata.json.gz") { out =>
+      val metadata = IndexMetadata(1, branchingFactor, keyType._toPretty, elementIdx, path, rootOffset)
+      implicit val formats: Formats = defaultJSONFormats
+      Serialization.write(metadata, out)
+    }
+  }
+
+  def +=(x: Any, offset: Long) {
+    leafNode += (x, offset)
+    elementIdx += 1
+    if (leafNode.size == branchingFactor) {
+      write()
+    }
+  }
+
+  def close(): Unit = {
+    flush()
+    trackedOS.close()
+    ctx.close()
+
+    writeMetadata()
+  }
+}

--- a/src/main/scala/is/hail/io/index/InternalNodeBuilder.scala
+++ b/src/main/scala/is/hail/io/index/InternalNodeBuilder.scala
@@ -6,11 +6,11 @@ import is.hail.utils.ArrayBuilder
 
 object InternalNodeBuilder {
   def typ(keyType: Type) = TStruct(
-    "block_first_key_idx" -> TInt64(required = true),
-    "children" -> TArray(TStruct(
-      "child_offset" -> TInt64(required = true),
+    "block_first_key_idx" -> +TInt64(),
+    "children" -> +TArray(TStruct(
+      "child_offset" -> +TInt64(),
       "first_key" -> keyType,
-      "first_key_offset" -> TInt64(required = true)
+      "first_key_offset" -> +TInt64()
     ), required = true)
   )
 }

--- a/src/main/scala/is/hail/io/index/InternalNodeBuilder.scala
+++ b/src/main/scala/is/hail/io/index/InternalNodeBuilder.scala
@@ -1,0 +1,76 @@
+package is.hail.io.index
+
+import is.hail.annotations.RegionValueBuilder
+import is.hail.expr.types.{TArray, TInt64, TStruct, Type}
+import is.hail.utils.ArrayBuilder
+
+object InternalNodeBuilder {
+  def typ(keyType: Type) = TStruct(
+    "block_first_key_idx" -> TInt64(required = true),
+    "children" -> TArray(TStruct(
+      "child_offset" -> TInt64(required = true),
+      "first_key" -> keyType,
+      "first_key_offset" -> TInt64(required = true)
+    ), required = true)
+  )
+}
+
+class InternalNodeBuilder(keyType: Type) {
+  val childOffsets = new ArrayBuilder[Long]()
+  val firstKeys = new ArrayBuilder[Any]()
+  val firstKeyOffsets = new ArrayBuilder[Long]()
+  var size = 0
+  val typ = InternalNodeBuilder.typ(keyType)
+  var firstIndex = 0L
+
+  def firstKey: Any = {
+    assert(size > 0)
+    firstKeys(0)
+  }
+
+  def firstOffset: Long = {
+    assert(size > 0)
+    firstKeyOffsets(0)
+  }
+
+  def setFirstIndex(idx: Long) {
+    firstIndex = idx
+  }
+
+  def +=(childOffset: Long, firstKey: Any, firstKeyOffset: Long) {
+    childOffsets += childOffset
+    firstKeys += firstKey
+    firstKeyOffsets += firstKeyOffset
+    size += 1
+  }
+
+  def write(rvb: RegionValueBuilder): Long = {
+    rvb.start(typ)
+    rvb.startStruct()
+    rvb.addLong(firstIndex) // block_first_key_index
+
+    rvb.startArray(size)
+    var i = 0
+    while (i < size) {
+      rvb.startStruct()
+      rvb.addLong(childOffsets(i)) // child_offset
+      rvb.addAnnotation(keyType, firstKeys(i)) // first_key
+      rvb.addLong(firstKeyOffsets(i)) // first_key_offset
+      rvb.endStruct()
+      i += 1
+    }
+    rvb.endArray()
+    rvb.endStruct()
+    rvb.end()
+  }
+
+  def clear() {
+    childOffsets.clear()
+    firstKeys.clear()
+    firstKeyOffsets.clear()
+    size = 0
+    firstIndex = 0L
+  }
+
+  override def toString: String = s"InternalNodeBuilder $size $firstIndex [${ (0 until size).map(i => (childOffsets(i), firstKeys(i), firstKeyOffsets(i))).mkString(",") }]"
+}

--- a/src/main/scala/is/hail/io/index/InternalNodeBuilder.scala
+++ b/src/main/scala/is/hail/io/index/InternalNodeBuilder.scala
@@ -37,10 +37,10 @@ class InternalNodeBuilder(keyType: Type) {
     firstIndex = idx
   }
 
-  def +=(childOffset: Long, firstKey: Any, firstKeyOffset: Long) {
-    childOffsets += childOffset
-    firstKeys += firstKey
-    firstKeyOffsets += firstKeyOffset
+  def +=(info: IndexNodeInfo) {
+    childOffsets += info.fileOffset
+    firstKeys += info.firstKey
+    firstKeyOffsets += info.firstKeyOffset
     size += 1
   }
 
@@ -70,6 +70,11 @@ class InternalNodeBuilder(keyType: Type) {
     firstKeyOffsets.clear()
     size = 0
     firstIndex = 0L
+  }
+
+  def getChild(idx: Int): InternalChild = {
+    assert(size > idx)
+    InternalChild(childOffsets(idx), firstKeys(idx), firstKeyOffsets(idx))
   }
 
   override def toString: String = s"InternalNodeBuilder $size $firstIndex [${ (0 until size).map(i => (childOffsets(i), firstKeys(i), firstKeyOffsets(i))).mkString(",") }]"

--- a/src/main/scala/is/hail/io/index/LeafNodeBuilder.scala
+++ b/src/main/scala/is/hail/io/index/LeafNodeBuilder.scala
@@ -6,10 +6,10 @@ import is.hail.utils.ArrayBuilder
 
 object LeafNodeBuilder {
   def typ(keyType: Type) = TStruct(
-    "first_key_idx" -> TInt64(required = true),
-    "keys" -> TArray(TStruct(
+    "first_key_idx" -> +TInt64(),
+    "keys" -> +TArray(TStruct(
       "key" -> keyType,
-      "offset" -> TInt64(required = true)
+      "offset" -> +TInt64()
     ), required = true)
   )
 }

--- a/src/main/scala/is/hail/io/index/LeafNodeBuilder.scala
+++ b/src/main/scala/is/hail/io/index/LeafNodeBuilder.scala
@@ -26,12 +26,12 @@ class LeafNodeBuilder(keyType: Type) {
 
     rvb.addLong(idx) // first_key_idx
 
-    rvb.startArray(size) // keys
+    rvb.startArray(size)
     var i = 0
     while (i < size) {
       rvb.startStruct()
-      rvb.addAnnotation(keyType, keys(i)) // key
-      rvb.addLong(offsets(i)) // offset
+      rvb.addAnnotation(keyType, keys(i))
+      rvb.addLong(offsets(i))
       rvb.endStruct()
       i += 1
     }
@@ -40,14 +40,9 @@ class LeafNodeBuilder(keyType: Type) {
     rvb.end()
   }
 
-  def firstKey: Any = {
-    assert(size > 0)
-    keys(0)
-  }
-
-  def firstOffset: Long = {
-    assert(size > 0)
-    offsets(0)
+  def getChild(idx: Int): LeafChild = {
+    assert(idx >= 0 && idx < size)
+    LeafChild(keys(idx), offsets(idx))
   }
 
   def +=(key: Any, offset: Long) {

--- a/src/main/scala/is/hail/io/index/LeafNodeBuilder.scala
+++ b/src/main/scala/is/hail/io/index/LeafNodeBuilder.scala
@@ -1,0 +1,66 @@
+package is.hail.io.index
+
+import is.hail.annotations.RegionValueBuilder
+import is.hail.expr.types.{TArray, TInt64, TStruct, Type}
+import is.hail.utils.ArrayBuilder
+
+object LeafNodeBuilder {
+  def typ(keyType: Type) = TStruct(
+    "first_key_idx" -> TInt64(required = true),
+    "keys" -> TArray(TStruct(
+      "key" -> keyType,
+      "offset" -> TInt64(required = true)
+    ), required = true)
+  )
+}
+
+class LeafNodeBuilder(keyType: Type) {
+  val keys = new ArrayBuilder[Any]()
+  val offsets = new ArrayBuilder[Long]()
+  var size = 0
+  val typ = LeafNodeBuilder.typ(keyType)
+
+  def write(rvb: RegionValueBuilder, idx: Long): Long = {
+    rvb.start(typ)
+    rvb.startStruct()
+
+    rvb.addLong(idx) // first_key_idx
+
+    rvb.startArray(size) // keys
+    var i = 0
+    while (i < size) {
+      rvb.startStruct()
+      rvb.addAnnotation(keyType, keys(i)) // key
+      rvb.addLong(offsets(i)) // offset
+      rvb.endStruct()
+      i += 1
+    }
+    rvb.endArray()
+    rvb.endStruct()
+    rvb.end()
+  }
+
+  def firstKey: Any = {
+    assert(size > 0)
+    keys(0)
+  }
+
+  def firstOffset: Long = {
+    assert(size > 0)
+    offsets(0)
+  }
+
+  def +=(key: Any, offset: Long) {
+    keys += key
+    offsets += offset
+    size += 1
+  }
+
+  def clear() {
+    keys.clear()
+    offsets.clear()
+    size = 0
+  }
+
+  override def toString: String = s"LeafNodeBuilder $size [${ (0 until size).map(i => (keys(i), offsets(i))).mkString(",") }]"
+}

--- a/src/test/scala/is/hail/io/IndexSuite.scala
+++ b/src/test/scala/is/hail/io/IndexSuite.scala
@@ -22,8 +22,9 @@ class IndexSuite extends SparkSuite {
   @Test(dataProvider = "elements")
   def writeReadGivesSameAsInput(data: Array[String]) {
     val file = tmpDir.createTempFile("test", "idx")
+    val attributes = Map("foo" -> true, "bar" -> 5)
 
-    val iw = new IndexWriter(hc.hadoopConf, file, TString(), branchingFactor = 2)
+    val iw = new IndexWriter(hc.hadoopConf, file, TString(), branchingFactor = 2, attributes)
     data.zipWithIndex.foreach { case (s, offset) =>
       iw += (s, offset)
     }
@@ -32,6 +33,7 @@ class IndexSuite extends SparkSuite {
     assert(hc.hadoopConf.getFileSize(file) != 0)
 
     val ir = new IndexReader(hc.hadoopConf, file)
+    assert(ir.attributes == attributes)
     data.zipWithIndex.foreach { case (s, i) =>
       assert(ir.queryByIndex(i).key == s)
       assert(ir.queryByKey(s).contains(i))

--- a/src/test/scala/is/hail/io/IndexSuite.scala
+++ b/src/test/scala/is/hail/io/IndexSuite.scala
@@ -2,7 +2,7 @@ package is.hail.io
 
 import is.hail.SparkSuite
 import is.hail.expr.types.TString
-import is.hail.io.index.{IndexReader, IndexWriter}
+import is.hail.io.index._
 import org.testng.annotations.{DataProvider, Test}
 import is.hail.utils._
 
@@ -14,6 +14,14 @@ class IndexSuite extends SparkSuite {
     "skunk", "snail", "squirrel", "vole",
     "weasel", "whale", "yak", "zebra")
 
+  def writeIndex(file: String, data: Array[String], attributes: Map[String, Any] = Map.empty[String, Any]) {
+    val iw = new IndexWriter(hc.hadoopConf, file, TString(), branchingFactor = 2, attributes)
+    data.zipWithIndex.foreach { case (s, offset) =>
+      iw += (s, offset)
+    }
+    iw.close()
+  }
+
   @DataProvider(name = "elements")
   def data(): Array[Array[Array[String]]] = {
     (1 to strings.length).map(i => Array(strings.take(i))).toArray
@@ -24,19 +32,120 @@ class IndexSuite extends SparkSuite {
     val file = tmpDir.createTempFile("test", "idx")
     val attributes = Map("foo" -> true, "bar" -> 5)
 
-    val iw = new IndexWriter(hc.hadoopConf, file, TString(), branchingFactor = 2, attributes)
-    data.zipWithIndex.foreach { case (s, offset) =>
-      iw += (s, offset)
-    }
-    iw.close()
-
+    writeIndex(file, data, attributes)
     assert(hc.hadoopConf.getFileSize(file) != 0)
 
     val ir = new IndexReader(hc.hadoopConf, file)
     assert(ir.attributes == attributes)
     data.zipWithIndex.foreach { case (s, i) =>
       assert(ir.queryByIndex(i).key == s)
+      assert(ir.queryByKeyAllMatches(s).toFastIndexedSeq == IndexedSeq(LeafChild(s, i)))
+      assert(ir.queryByKey(s, greater = true, closed = true).contains(LeafChild(s, i)))
+      assert(ir.queryByKey(s, greater = false, closed = true).contains(LeafChild(s, i)))
+
+      if (i != data.length - 1)
+        assert(ir.queryByKey(s, greater = true, closed = false).map(_.key).contains(data(i + 1)))
+      else
+        assert(ir.queryByKey(s, greater = true, closed = false).isEmpty)
+
+      if (i != 0)
+        assert(ir.queryByKey(s, greater = false, closed = false).map(_.key).contains(data(i - 1)))
+      else
+        assert(ir.queryByKey(s, greater = false, closed = false).isEmpty)
     }
     ir.close()
+  }
+
+  @Test def testEmptyKeys() {
+    val file = tmpDir.createTempFile("empty", "idx")
+    writeIndex(file, Array.empty[String])
+    val ir = new IndexReader(hc.hadoopConf, file)
+    assert(ir.queryByKey("moo", true, true).isEmpty)
+    assert(ir.queryByKey("moo", true, false).isEmpty)
+    assert(ir.queryByKey("moo", false, true).isEmpty)
+    assert(ir.queryByKey("moo", false, false).isEmpty)
+    assert(ir.queryByKeyAllMatches("moo").isEmpty)
+    intercept[IllegalArgumentException](ir.queryByIndex(0L))
+    ir.close()
+  }
+
+  @Test def testDuplicateKeys1() {
+    val strings = Array(
+      "bear", "cat", "cat", "cat",
+      "cat", "cat", "cat", "dog")
+
+    val file = tmpDir.createTempFile("dups1", "idx")
+    writeIndex(file, strings)
+    val ir = new IndexReader(hc.hadoopConf, file)
+    assert(ir.queryByKeyAllMatches("bear").toFastIndexedSeq == IndexedSeq(LeafChild("bear", 0L)))
+    assert(ir.queryByKeyAllMatches("cat").toFastIndexedSeq == (1 until 7).map(i => LeafChild("cat", i.toLong)))
+    assert(ir.queryByKeyAllMatches("dog").toFastIndexedSeq == IndexedSeq(LeafChild("dog", 7L)))
+    assert(ir.queryByKeyAllMatches("foo").length == 0)
+    assert(ir.queryByKeyAllMatches("aardvark").length == 0)
+
+    assert(ir.queryByKey("aardvark", greater = true, closed = true).contains(LeafChild("bear", 0L)))
+    assert(ir.queryByKey("bear", greater = true, closed = true).contains(LeafChild("bear", 0L)))
+    assert(ir.queryByKey("boar", greater = true, closed = true).contains(LeafChild("cat", 1L)))
+    assert(ir.queryByKey("cat", greater = true, closed = true).contains(LeafChild("cat", 6L)))
+    assert(ir.queryByKey("cow", greater = true, closed = true).contains(LeafChild("dog", 7L)))
+    assert(ir.queryByKey("dog", greater = true, closed = true).contains(LeafChild("dog", 7L)))
+    assert(ir.queryByKey("elk", greater = true, closed = true).isEmpty)
+
+    assert(ir.queryByKey("aardvark", greater = true, closed = false).contains(LeafChild("bear", 0L)))
+    assert(ir.queryByKey("bear", greater = true, closed = false).contains(LeafChild("cat", 1L)))
+    assert(ir.queryByKey("boar", greater = true, closed = false).contains(LeafChild("cat", 1L)))
+    assert(ir.queryByKey("cat", greater = true, closed = false).contains(LeafChild("dog", 7L)))
+    assert(ir.queryByKey("cow", greater = true, closed = false).contains(LeafChild("dog", 7L)))
+    assert(ir.queryByKey("dog", greater = true, closed = false).isEmpty)
+    assert(ir.queryByKey("elk", greater = true, closed = false).isEmpty)
+
+    assert(ir.queryByKey("aardvark", greater = false, closed = true).isEmpty)
+    assert(ir.queryByKey("bear", greater = false, closed = true).contains(LeafChild("bear", 0L)))
+    assert(ir.queryByKey("boar", greater = false, closed = true).contains(LeafChild("bear", 0L)))
+    assert(ir.queryByKey("cat", greater = false, closed = true).contains(LeafChild("cat", 1L)))
+    assert(ir.queryByKey("cow", greater = false, closed = true).contains(LeafChild("cat", 6L)))
+    assert(ir.queryByKey("dog", greater = false, closed = true).contains(LeafChild("dog", 7L)))
+    assert(ir.queryByKey("elk", greater = false, closed = true).contains(LeafChild("dog", 7L)))
+
+    assert(ir.queryByKey("aardvark", greater = false, closed = false).isEmpty)
+    assert(ir.queryByKey("bear", greater = false, closed = false).isEmpty)
+    assert(ir.queryByKey("boar", greater = false, closed = false).contains(LeafChild("bear", 0L)))
+    assert(ir.queryByKey("cat", greater = false, closed = false).contains(LeafChild("bear", 0L)))
+    assert(ir.queryByKey("cow", greater = false, closed = false).contains(LeafChild("cat", 6L)))
+    assert(ir.queryByKey("dog", greater = false, closed = false).contains(LeafChild("cat", 6L)))
+    assert(ir.queryByKey("elk", greater = false, closed = false).contains(LeafChild("dog", 7L)))
+  }
+
+  @Test def testDuplicateKeys2() {
+    val strings = Array(
+      "bear", "bear", "cat", "cat",
+      "cat", "cat", "cat", "cat",
+      "cat", "dog", "mouse", "mouse",
+      "skunk", "skunk", "skunk", "whale",
+      "whale", "zebra", "zebra", "zebra")
+
+    val file = tmpDir.createTempFile("dups2", "idx")
+    writeIndex(file, strings)
+    val ir = new IndexReader(hc.hadoopConf, file)
+
+    val uniqueStrings = strings.distinct
+    uniqueStrings.foreach { s =>
+      assert(ir.queryByKey(s, greater = false, closed = true).contains(LeafChild(s, strings.indexOf(s))))
+      assert(ir.queryByKey(s, greater = true, closed = true).contains(LeafChild(s, strings.lastIndexOf(s))))
+
+      if (strings.head == s)
+        assert(ir.queryByKey(s, greater = false, closed = false).isEmpty)
+      else {
+        val idx = strings.indexOf(s) - 1
+        assert(ir.queryByKey(s, greater = false, closed = false).contains(LeafChild(strings(idx), idx)))
+      }
+
+      if (strings.last == s)
+        assert(ir.queryByKey(s, greater = true, closed = false).isEmpty)
+      else {
+        val idx = strings.lastIndexOf(s) + 1
+        assert(ir.queryByKey(s, greater = true, closed = false).contains(LeafChild(strings(idx), idx)))
+      }
+    }
   }
 }

--- a/src/test/scala/is/hail/io/IndexSuite.scala
+++ b/src/test/scala/is/hail/io/IndexSuite.scala
@@ -1,0 +1,40 @@
+package is.hail.io
+
+import is.hail.SparkSuite
+import is.hail.expr.types.TString
+import is.hail.io.index.{IndexReader, IndexWriter}
+import org.testng.annotations.{DataProvider, Test}
+import is.hail.utils._
+
+class IndexSuite extends SparkSuite {
+  val strings = Array(
+    "bear", "cat", "deer", "dog",
+    "lion", "mouse", "parrot", "quail",
+    "rabbit", "raccoon", "rat", "raven",
+    "skunk", "snail", "squirrel", "vole",
+    "weasel", "whale", "yak", "zebra")
+
+  @DataProvider(name = "elements")
+  def data(): Array[Array[Array[String]]] = {
+    (1 until strings.length).map(i => Array(strings.take(i))).toArray // FIXME: empty array ???
+  }
+
+  @Test(dataProvider = "elements")
+  def writeReadGivesSameAsInput(data: Array[String]) {
+    val file = tmpDir.createTempFile("test", "idx")
+
+    val iw = new IndexWriter(hc.hadoopConf, file, TString(), branchingFactor = 2)
+    data.zipWithIndex.foreach { case (s, offset) =>
+      iw += (s, offset)
+    }
+    iw.close()
+
+    assert(hc.hadoopConf.getFileSize(file) != 0)
+
+    val ir = new IndexReader(hc.hadoopConf, file)
+    data.zipWithIndex.foreach { case (s, i) =>
+      assert(ir.queryByIndex(i).key == s)
+    }
+    ir.close()
+  }
+}

--- a/src/test/scala/is/hail/io/IndexSuite.scala
+++ b/src/test/scala/is/hail/io/IndexSuite.scala
@@ -16,7 +16,7 @@ class IndexSuite extends SparkSuite {
 
   @DataProvider(name = "elements")
   def data(): Array[Array[Array[String]]] = {
-    (1 until strings.length).map(i => Array(strings.take(i))).toArray // FIXME: empty array ???
+    (1 to strings.length).map(i => Array(strings.take(i))).toArray // FIXME: empty array ???
   }
 
   @Test(dataProvider = "elements")
@@ -34,7 +34,9 @@ class IndexSuite extends SparkSuite {
     val ir = new IndexReader(hc.hadoopConf, file)
     data.zipWithIndex.foreach { case (s, i) =>
       assert(ir.queryByIndex(i).key == s)
+      assert(ir.queryByKey(s).contains(i))
     }
+    assert(ir.queryByKey("moo").isEmpty)
     ir.close()
   }
 }

--- a/src/test/scala/is/hail/io/IndexSuite.scala
+++ b/src/test/scala/is/hail/io/IndexSuite.scala
@@ -36,7 +36,7 @@ class IndexSuite extends SparkSuite {
     assert(ir.attributes == attributes)
     data.zipWithIndex.foreach { case (s, i) =>
       assert(ir.queryByIndex(i).key == s)
-      assert(ir.queryByKey(s).contains(i))
+      assert(ir.queryByKey(s).map(_.offset).contains(i))
     }
     assert(ir.queryByKey("moo").isEmpty)
     ir.close()

--- a/src/test/scala/is/hail/io/IndexSuite.scala
+++ b/src/test/scala/is/hail/io/IndexSuite.scala
@@ -16,7 +16,7 @@ class IndexSuite extends SparkSuite {
 
   @DataProvider(name = "elements")
   def data(): Array[Array[Array[String]]] = {
-    (1 to strings.length).map(i => Array(strings.take(i))).toArray // FIXME: empty array ???
+    (1 to strings.length).map(i => Array(strings.take(i))).toArray
   }
 
   @Test(dataProvider = "elements")
@@ -36,9 +36,7 @@ class IndexSuite extends SparkSuite {
     assert(ir.attributes == attributes)
     data.zipWithIndex.foreach { case (s, i) =>
       assert(ir.queryByIndex(i).key == s)
-      assert(ir.queryByKey(s).map(_.offset).contains(i))
     }
-    assert(ir.queryByKey("moo").isEmpty)
     ir.close()
   }
 }


### PR DESCRIPTION
Based on #4049. Start with "Added queryByKey methods". I added a new element in internal nodes that records the largest key in the child block. I tried to add as many varied tests as possible, but definitely suggest any you think I am missing.

Here's information on the binary search leftmost and rightmost algorithms:
https://en.wikipedia.org/wiki/Binary_search_algorithm

Java's version doesn't guarantee which element it returns if there are duplicates.