### PR TITLE
Add TableLeftJoinRightDistinct node.

### DIFF
--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -1366,7 +1366,7 @@ class Table(ExprContainer):
                 if is_interval:
                     left = Table(left._jt.intervalJoin(self._jt, uid))
                 else:
-                    left = Table(left._jt.join(self.select(**{uid: self.row_value}).distinct()._jt, 'left'))
+                    left = Table(left._jt.leftJoinRightDistinct(self._jt, uid))
                 return rekey_f(left)
 
             all_uids.append(uid)

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -602,6 +602,7 @@ object Parser extends JavaTokenParsers {
       "TableRepartition" ~> int32_literal ~ boolean_literal ~ table_ir ^^ { case n ~ shuffle ~ child => ir.TableRepartition(child, n, shuffle) } |
       "TableHead" ~> int64_literal ~ table_ir ^^ { case n ~ child => ir.TableHead(child, n) } |
       "TableJoin" ~> ir_identifier ~ table_ir ~ table_ir ^^ { case joinType ~ left ~ right => ir.TableJoin(left, right, joinType) } |
+      "TableLeftJoinRightDistinct" ~> ir_identifier ~ table_ir ~ table_ir ^^ { case root ~ left ~ right => ir.TableLeftJoinRightDistinct(left, right, root) } |
       "TableParallelize" ~> table_type_expr ~ ir_value ~ int32_literal_opt ^^ { case typ ~ ((rowsType, rows)) ~ nPartitions =>
         ir.TableParallelize(typ, rows.asInstanceOf[IndexedSeq[Row]], nPartitions)
       } |

--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -254,6 +254,7 @@ object Pretty {
             case TableRepartition(_, n, shuffle) => n.toString + " " + prettyBooleanLiteral(shuffle)
             case TableHead(_, n) => n.toString
             case TableJoin(_, _, joinType) => joinType
+            case TableLeftJoinRightDistinct(_, _, root) => prettyIdentifier(root)
             case TableMapRows(_, _, newKey, preservedKeyFields) =>
               prettyIdentifiersOpt(newKey) + " " + prettyIntOpt(preservedKeyFields)
             case TableKeyByAndAggregate(_, _, _, nPartitions, bufferSize) =>

--- a/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -254,6 +254,25 @@ object PruneDeadFields {
           }: _*),
           globalType = minimal(right.typ.globalType))
         memoizeTableIR(right, rightDep, memo)
+      case TableLeftJoinRightDistinct(left, right, root) =>
+        val fieldDep = requestedType.rowType.fieldOption(root).map(_.typ.asInstanceOf[TStruct])
+        fieldDep match {
+          case Some(struct) =>
+            val rightDep = right.typ.copy(rowType = unify(
+              right.typ.rowType,
+              FastIndexedSeq[TStruct](right.typ.rowType.filterSet(right.typ.key.get.toSet, true)._1) ++
+                FastIndexedSeq(struct): _*),
+              globalType = minimal(right.typ.globalType))
+            memoizeTableIR(right, rightDep, memo)
+            val leftDep = unify(
+              left.typ,
+              requestedType.copy(rowType =
+                requestedType.rowType.filterSet(Set(root), include = false)._1))
+            memoizeTableIR(left, leftDep, memo)
+          case None =>
+            // don't memoize right if we are going to elide it during rebuild
+            memoizeTableIR(left, requestedType, memo)
+        }
       case TableExplode(child, field) =>
         val minChild = minimal(child.typ)
         val dep2 = unify(child.typ, requestedType.copy(rowType = requestedType.rowType.filter(_.name != field)._1),
@@ -736,6 +755,11 @@ object PruneDeadFields {
         // fixme push down into value
         val child2 = rebuild(child, memo)
         TableMapGlobals(child2, rebuild(newRow, child2.typ, memo, "value" -> value.t), value)
+      case TableLeftJoinRightDistinct(left, right, root) =>
+        if (dep.rowType.hasField(root))
+          TableLeftJoinRightDistinct(rebuild(left, memo), rebuild(right, memo), root)
+        else
+          rebuild(left, memo)
       case TableAggregateByKey(child, expr) =>
         val child2 = rebuild(child, memo)
         TableAggregateByKey(child2, rebuild(expr, child2.typ, memo))

--- a/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -188,6 +188,8 @@ object Simplify {
 
       case TableCount(TableUnkey(child)) => TableCount(child)
 
+      case TableCount(TableLeftJoinRightDistinct(child, _, _)) => TableCount(child)
+
       case TableCount(TableRange(n, _)) => I64(n)
 
       case TableCount(TableParallelize(_, rows, _)) => I64(rows.length)

--- a/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -453,6 +453,34 @@ case class TableJoin(left: TableIR, right: TableIR, joinType: String) extends Ta
   }
 }
 
+case class TableLeftJoinRightDistinct(left: TableIR, right: TableIR, root: String) extends TableIR {
+  require(left.typ.key.isDefined)
+  require(right.typ.key.isDefined)
+  require(left.typ.keyType.exists(l => right.typ.keyType.exists(r => l.isIsomorphicTo(r))))
+
+  def children: IndexedSeq[BaseIR] = Array(left, right)
+
+  private val newRowType = left.typ.rowType.structInsert(right.typ.valueType, List(root))._1
+  val typ: TableType = left.typ.copy(rowType = newRowType)
+
+  override def partitionCounts: Option[IndexedSeq[Long]] = left.partitionCounts
+
+  def copy(newChildren: IndexedSeq[BaseIR]): BaseIR = {
+    val IndexedSeq(newLeft: TableIR, newRight: TableIR) = newChildren
+    TableLeftJoinRightDistinct(newLeft, newRight, root)
+  }
+
+  override def execute(hc: HailContext): TableValue = {
+    val leftValue = left.execute(hc)
+    val rightValue = right.execute(hc)
+
+    leftValue.copy(
+      typ = typ,
+      rvd = leftValue.enforceOrderingRVD.asInstanceOf[OrderedRVD]
+        .orderedLeftJoinDistinctAndInsert(rightValue.enforceOrderingRVD.asInstanceOf[OrderedRVD], root))
+  }
+}
+
 // Must not modify key ordering.
 // newKey is key of resulting Table, if newKey=None then result is unkeyed.
 // preservedKeyFields is length of initial sequence of key fields whose values are unchanged.

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -481,6 +481,9 @@ class Table(val hc: HailContext, val tir: TableIR) {
   def join(other: Table, joinType: String): Table =
     new Table(hc, TableJoin(this.tir, other.tir, joinType))
 
+  def leftJoinRightDistinct(other: Table, root: String): Table =
+    new Table(hc, TableLeftJoinRightDistinct(tir, other.tir, root))
+
   def export(path: String, typesFile: String = null, header: Boolean = true, exportType: Int = ExportType.CONCATENATED) {
     ir.Interpret(ir.TableExport(tir, path, typesFile, header, exportType))
   }

--- a/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -513,6 +513,7 @@ class IRSuite extends SparkSuite {
           NA(TStruct()), NA(TStruct()), Some(1), 2),
         TableJoin(read,
           TableRange(100, 10), "inner"),
+        TableLeftJoinRightDistinct(read, TableRange(100, 10), "root"),
         MatrixEntriesTable(mtRead),
         MatrixRowsTable(mtRead),
         TableRepartition(read, 10, false),


### PR DESCRIPTION
This should really speed up heavy table-join pipelines, especially
ones that involve foreign-key joins, by permitting the pruner to
work on that kind of pattern.