### PR TITLE
MatrixAggregateRowsByKey -- aggregate row annotations

### DIFF
--- a/python/hail/ir/matrix_ir.py
+++ b/python/hail/ir/matrix_ir.py
@@ -3,14 +3,14 @@ from hail.ir.base_ir import *
 from hail.utils.java import escape_str, escape_id, parsable_strings
 
 class MatrixAggregateRowsByKey(MatrixIR):
-    def __init__(self, child, entryExpr, rowExpr):
+    def __init__(self, child, entry_expr, row_expr):
         super().__init__()
         self.child = child
-        self.entryExpr = entryExpr
-        self.rowExpr = rowExpr
+        self.entry_expr = entry_expr
+        self.row_expr = row_expr
 
     def __str__(self):
-        return '(MatrixAggregateRowsByKey {} {} {})'.format(self.child, self.entryExpr, self.rowExpr)
+        return '(MatrixAggregateRowsByKey {} {} {})'.format(self.child, self.entry_expr, self.row_expr)
 
 
 class MatrixRead(MatrixIR):

--- a/python/hail/ir/matrix_ir.py
+++ b/python/hail/ir/matrix_ir.py
@@ -3,13 +3,14 @@ from hail.ir.base_ir import *
 from hail.utils.java import escape_str, escape_id, parsable_strings
 
 class MatrixAggregateRowsByKey(MatrixIR):
-    def __init__(self, child, expr):
+    def __init__(self, child, entryExpr, rowExpr):
         super().__init__()
         self.child = child
-        self.expr = expr
+        self.entryExpr = entryExpr
+        self.rowExpr = rowExpr
 
     def __str__(self):
-        return '(MatrixAggregateRowsByKey {} {})'.format(self.child, self.expr)
+        return '(MatrixAggregateRowsByKey {} {} {})'.format(self.child, self.entryExpr, self.rowExpr)
 
 
 class MatrixRead(MatrixIR):

--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -302,7 +302,7 @@ class GroupedMatrixTable(ExprContainer):
             if self._partition_key is None:
                 self._partition_key = self._row_keys.keys()
             keyed_mt = base._select_rows_processed(hl.struct(**group_exprs))
-            mt = MatrixTable(keyed_mt._jvds.aggregateRowsByKey(str(hl.struct(**named_exprs)._ir)))
+            mt = MatrixTable(keyed_mt._jvds.aggregateRowsByKey(str(hl.struct(**named_exprs)._ir, str(hl.struct()._ir))))
         else:
             raise ValueError("GroupedMatrixTable cannot be aggregated if no groupings are specified.")
 

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -649,7 +649,7 @@ object Parser extends JavaTokenParsers {
           BroadcastRow(v.asInstanceOf[Row], t.asInstanceOf[TBaseStruct], HailContext.get.sc))
       } |
       "MatrixAggregateColsByKey" ~> matrix_ir ~ ir_value_expr() ^^ { case child ~ agg => ir.MatrixAggregateColsByKey(child, agg) } |
-      "MatrixAggregateRowsByKey" ~> matrix_ir ~ ir_value_expr() ^^ { case child ~ agg => ir.MatrixAggregateRowsByKey(child, agg) } |
+      "MatrixAggregateRowsByKey" ~> matrix_ir ~ ir_value_expr() ~ ir_value_expr() ^^ { case child ~ aggEntry ~ aggRow => ir.MatrixAggregateRowsByKey(child, aggEntry, aggRow) } |
       "MatrixRead" ~> matrix_type_expr_opt ~ boolean_literal ~ boolean_literal ~ string_literal ^^ {
         case typ ~ dropCols ~ dropRows ~ readerStr =>
           implicit val formats = ir.MatrixReader.formats

--- a/src/main/scala/is/hail/expr/ir/LiftLiterals.scala
+++ b/src/main/scala/is/hail/expr/ir/LiftLiterals.scala
@@ -119,11 +119,13 @@ object LiftLiterals {
         removeLiterals(
           MatrixFilterEntries(rewriteChild, rewriteIR(pred, rewriteChild.typ.globalType)),
           literals)
-      case MatrixAggregateRowsByKey(child, aggIR) =>
-        val literals = getLiterals(aggIR)
+      case MatrixAggregateRowsByKey(child, entryAggIR, rowAggIR) =>
+        val literals = getLiterals(entryAggIR, rowAggIR)
         val rewriteChild = addLiterals(child, literals)
         removeLiterals(
-          MatrixAggregateRowsByKey(rewriteChild, rewriteIR(aggIR, rewriteChild.typ.globalType)),
+          MatrixAggregateRowsByKey(rewriteChild,
+            rewriteIR(entryAggIR, rewriteChild.typ.globalType),
+            rewriteIR(rowAggIR, rewriteChild.typ.globalType)),
           literals)
       case MatrixAggregateColsByKey(child, aggIR) =>
         val literals = getLiterals(aggIR)

--- a/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -434,15 +434,10 @@ object PruneDeadFields {
       case MatrixAggregateRowsByKey(child, entryExpr, rowExpr) =>
         val irDepEntry = memoizeAndGetDep(entryExpr, requestedType.entryType, child.typ, memo)
         val irDepRow = memoizeAndGetDep(rowExpr, requestedType.rowType, child.typ, memo)
-        val childDep = child.typ.copy(
-          globalType = unify(child.typ.globalType, irDepEntry.globalType, requestedType.globalType),
-          rvRowType = irDepRow.rvRowType.copy(irDepRow.rvRowType.fields.map { f =>
-            if (f.name == MatrixType.entriesIdentifier)
-              f.copy(typ = irDepEntry.entryArrayType)
-            else
-              f
-          }),
-          colType = unify(child.typ.colType, irDepEntry.colType, requestedType.colType)
+        val childDep = unify(child.typ,
+          irDepEntry,
+          irDepRow,
+          minimal(child.typ).copy(globalType = requestedType.globalType, colType = requestedType.colType)
         )
         memoizeMatrixIR(child, childDep, memo)
       case MatrixAggregateColsByKey(child, expr) =>

--- a/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -275,7 +275,7 @@ object Simplify {
       case MatrixColsTable(MatrixMapEntries(child, _)) => MatrixColsTable(child)
       case MatrixColsTable(MatrixFilterEntries(child, _)) => MatrixColsTable(child)
       case MatrixColsTable(MatrixFilterRows(child, _)) => MatrixColsTable(child)
-      case MatrixColsTable(MatrixAggregateRowsByKey(child, _)) => MatrixColsTable(child)
+      case MatrixColsTable(MatrixAggregateRowsByKey(child, _, _)) => MatrixColsTable(child)
 
       case TableHead(TableMapRows(child, newRow, newKey, preservedKeyFields), n) =>
         TableMapRows(TableHead(child, n), newRow, newKey, preservedKeyFields)

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -506,10 +506,12 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     new MatrixTable(hc, MatrixAggregateColsByKey(ast, aggIR))
   }
 
-  def aggregateRowsByKey(expr: String): MatrixTable = {
-    log.info(expr)
-    val rowsIR = Parser.parse_value_ir(expr, matrixType.refMap)
-    new MatrixTable(hc, MatrixAggregateRowsByKey(ast, rowsIR))
+  def aggregateRowsByKey(entryExpr: String, rowExpr: String): MatrixTable = {
+    log.info(entryExpr)
+    log.info(rowExpr)
+    val entriesIR = Parser.parse_value_ir(entryExpr, matrixType.refMap)
+    val rowsIR = Parser.parse_value_ir(rowExpr, matrixType.refMap)
+    new MatrixTable(hc, MatrixAggregateRowsByKey(ast, entriesIR, rowsIR))
   }
 
   def annotateGlobal(a: Annotation, t: Type, name: String): MatrixTable = {

--- a/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -601,8 +601,13 @@ class IRSuite extends SparkSuite {
         "new_f32" -> ApplyBinaryPrimOp(Add(),
           GetField(Ref("va", read.typ.rowType), "row_f32"),
           F32(-5.2f))))
+
+      val newRowAnn = MakeStruct(FastIndexedSeq(
+        "new_f32"-> ApplyBinaryPrimOp(Add(),
+          GetField(Ref("va", read.typ.rowType), "row_f32"),
+          F32(-5.2f))))
       val newEntry = MakeStruct(FastIndexedSeq(
-        "new_f32" -> ApplyBinaryPrimOp(Add(),
+        "new_f32_entry" -> ApplyBinaryPrimOp(Add(),
           GetField(Ref("g", read.typ.entryType), "entry_f32"),
           F32(-5.2f))))
 
@@ -619,8 +624,8 @@ class IRSuite extends SparkSuite {
             GetField(Ref("global", read.typ.globalType), "global_f32"),
             F32(-5.2f))))),
         MatrixCollectColsByKey(read),
-        MatrixAggregateColsByKey(read, newCol),
-        MatrixAggregateRowsByKey(read, newEntry, newRow),
+        MatrixAggregateColsByKey(read, newEntry),
+        MatrixAggregateRowsByKey(read, newEntry, newRowAnn),
         range,
         vcf,
         bgen,

--- a/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -601,6 +601,10 @@ class IRSuite extends SparkSuite {
         "new_f32" -> ApplyBinaryPrimOp(Add(),
           GetField(Ref("va", read.typ.rowType), "row_f32"),
           F32(-5.2f))))
+      val newEntry = MakeStruct(FastIndexedSeq(
+        "new_f32" -> ApplyBinaryPrimOp(Add(),
+          GetField(Ref("g", read.typ.entryType), "entry_f32"),
+          F32(-5.2f))))
 
       val xs = Array[MatrixIR](
         read,
@@ -616,7 +620,7 @@ class IRSuite extends SparkSuite {
             F32(-5.2f))))),
         MatrixCollectColsByKey(read),
         MatrixAggregateColsByKey(read, newCol),
-        MatrixAggregateRowsByKey(read, newRow),
+        MatrixAggregateRowsByKey(read, newEntry, newRow),
         range,
         vcf,
         bgen,

--- a/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -397,7 +397,8 @@ class PruneSuite extends SparkSuite {
 
   @Test def testMatrixAggregateRowsByKeyMemo() {
     val magg = MatrixAggregateRowsByKey(mat,
-      matrixRefStruct(mat.typ, "g.e2", "va.r2", "sa.c2"))
+      matrixRefStruct(mat.typ, "g.e2", "va.r2", "sa.c2"),
+      matrixRefStruct(mat.typ, "va.r2"))
     checkMemo(magg,
       subsetMatrixTable(magg.typ, "sa.c3", "g.foo"),
       Array(subsetMatrixTable(mat.typ, "sa.c3", "g.e2", "va.r2", "sa.c2"), null)
@@ -659,11 +660,11 @@ class PruneSuite extends SparkSuite {
   }
 
   @Test def testMatrixAggregateRowsByKeyRebuild() {
-    val ma = MatrixAggregateRowsByKey(mr, matrixRefStruct(mr.typ, "sa.c2", "va.r2", "g.e1"))
+    val ma = MatrixAggregateRowsByKey(mr, matrixRefStruct(mr.typ, "sa.c2", "va.r2", "g.e1"), matrixRefStruct(mr.typ, "va.r2"))
     checkRebuild(ma, subsetMatrixTable(ma.typ, "global.g1", "g.foo"),
       (_: BaseIR, r: BaseIR) => {
         val ma = r.asInstanceOf[MatrixAggregateRowsByKey]
-        TypeCheck(ma.expr, PruneDeadFields.relationalTypeToEnv(ma.child.typ), None)
+        TypeCheck(ma.entryExpr, PruneDeadFields.relationalTypeToEnv(ma.child.typ), None)
         ma.child.asInstanceOf[MatrixRead].typ == subsetMatrixTable(mr.typ, "global.g1", "va.r2", "sa.c2", "g.e1")
       }
     )

--- a/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -398,10 +398,10 @@ class PruneSuite extends SparkSuite {
   @Test def testMatrixAggregateRowsByKeyMemo() {
     val magg = MatrixAggregateRowsByKey(mat,
       matrixRefStruct(mat.typ, "g.e2", "va.r2", "sa.c2"),
-      matrixRefStruct(mat.typ, "va.r2"))
+      matrixRefStruct(mat.typ, "va.r3", "global.g1"))
     checkMemo(magg,
-      subsetMatrixTable(magg.typ, "sa.c3", "g.foo"),
-      Array(subsetMatrixTable(mat.typ, "sa.c3", "g.e2", "va.r2", "sa.c2"), null)
+      subsetMatrixTable(magg.typ, "sa.c3", "g.foo", "va.foo"),
+      Array(subsetMatrixTable(mat.typ, "sa.c3", "g.e2", "va.r2", "sa.c2", "global.g1", "va.r3"), null, null)
     )
   }
 


### PR DESCRIPTION
- Added Scala infrastructure to aggregate to new row fields (current is only entry fields)

To Do:
- Expose in Python interface (currently just passing an empty struct)
- Write tests in Python