### PR TITLE
Revert functools to decorator

### DIFF
--- a/Dockerfile.pr-builder
+++ b/Dockerfile.pr-builder
@@ -2,7 +2,7 @@ FROM continuumio/miniconda
 MAINTAINER Hail Team <hail@broadinstitute.org>
 
 USER root
-RUN apt-get -y install \
+RUN apt-get update && apt-get -y install --fix-missing \
     bash \
     cmake \
     curl \

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,18 @@
 .PHONY: hail-ci-build-image push-hail-ci-build-image
 .DEFAULT_GOAL := default
 
-hail-ci-build-image: GIT_SHA = $(shell git rev-parse HEAD)
+hail-ci-build-image: GIT_SHA = $(shell git rev-parse HEAD) 
 hail-ci-build-image:
-	docker build . -t hail-pr-builder:${GIT_SHA} -f Dockerfile.pr-builder
+	docker build . -t hail-pr-builder:${GIT_SHA} -f Dockerfile.pr-builder --cache-from $(shell cat hail-ci-build-image)
 
 push-hail-ci-build-image: GIT_SHA = $(shell git rev-parse HEAD)
 push-hail-ci-build-image: hail-ci-build-image
 	docker tag hail-pr-builder:${GIT_SHA} gcr.io/broad-ctsa/hail-pr-builder:${GIT_SHA}
 	docker push gcr.io/broad-ctsa/hail-pr-builder
 	echo gcr.io/broad-ctsa/hail-pr-builder:${GIT_SHA} > hail-ci-build-image
+
+prime-the-engines:
+	docker --cache-from $(cat hail-ci-build-image)
 
 default:
 	echo Do not use this makefile to build hail, for information on how to \

--- a/hail-ci-build-image
+++ b/hail-ci-build-image
@@ -1,1 +1,1 @@
-gcr.io/broad-ctsa/hail-pr-builder:45c84e01b80ad990ce053b22cb07ed2187954712
+gcr.io/broad-ctsa/hail-pr-builder:e8f1a8556d86a833ffb5e7e9f85414dd7de0af2e

--- a/python/hail/dev-environment.yml
+++ b/python/hail/dev-environment.yml
@@ -14,6 +14,7 @@ dependencies:
 - pip
 - pytest
 - pip:
-    - parsimonious
+    - parsimonious==0.8.0
     - ipykernel
     - pytest-xdist
+    - decorator==4.2.1

--- a/python/hail/environment.yml
+++ b/python/hail/environment.yml
@@ -9,5 +9,6 @@ dependencies:
 - jupyter
 - pip
 - pip:
-    - parsimonious
+    - parsimonious==0.8.0
     - ipykernel
+    - decorator==4.2.1

--- a/python/hail/expr/aggregators/aggregators.py
+++ b/python/hail/expr/aggregators/aggregators.py
@@ -1319,7 +1319,7 @@ def group_by(group, agg_expr) -> DictExpression:
     Compute linear regression statistics stratified by SEX:
 
     >>> table1.aggregate(agg.group_by(table1.SEX,
-    ...                               agg.linreg(table1.HT, table1.C1, k_null=0)))
+    ...                               agg.linreg(table1.HT, table1.C1, nested_dim=0)))
     {
     'F': Struct(beta=[6.153846153846154],
                 standard_error=[0.7692307692307685],

--- a/python/hail/expr/aggregators/aggregators.py
+++ b/python/hail/expr/aggregators/aggregators.py
@@ -1,9 +1,14 @@
+import difflib
+from functools import wraps, update_wrapper
+
 import hail as hl
 from hail.expr.expressions import *
 from hail.expr.types import *
-from hail.utils import wrap_to_list
 from hail.ir import *
-import difflib
+from hail.typecheck import *
+from hail.utils import wrap_to_list
+from hail.utils.java import Env
+
 
 class AggregableChecker(TypeChecker):
     def __init__(self, coercer):

--- a/python/hail/expr/expressions/base_expression.py
+++ b/python/hail/expr/expressions/base_expression.py
@@ -1,3 +1,5 @@
+from typing import *
+
 from hail.expr import expressions
 from hail.expr.types import *
 from hail.genetics import Locus, Call
@@ -7,6 +9,7 @@ from hail.utils import Interval, Struct
 from hail.utils.java import *
 from hail.utils.linkedlist import LinkedList
 from .indices import *
+
 
 class ExpressionException(Exception):
     def __init__(self, msg=''):

--- a/python/hail/expr/functions.py
+++ b/python/hail/expr/functions.py
@@ -1,17 +1,14 @@
 import builtins
-import math
 from typing import *
-from random import randint
 
-import hail
 import hail as hl
 from hail.expr.expressions import *
 from hail.expr.expressions.expression_typecheck import *
 from hail.expr.types import *
-from hail.ir import *
 from hail.genetics.reference_genome import reference_genome_type, ReferenceGenome
+from hail.ir import *
 from hail.typecheck import *
-from hail.utils import LinkedList
+from hail.utils.java import Env
 
 Coll_T = TypeVar('Collection_T', ArrayExpression, SetExpression)
 Num_T = TypeVar('Numeric_T', Int32Expression, Int64Expression, Float32Expression, Float64Expression)

--- a/python/hail/ir/ir.py
+++ b/python/hail/ir/ir.py
@@ -1,11 +1,9 @@
-from typing import *
-
 import hail
+from hail.expr.types import hail_type
+from hail.typecheck import *
+from hail.utils.java import escape_str, escape_id
 from .aggsig import AggSignature
 from .base_ir import *
-from hail.expr.types import hail_type
-from hail.typecheck.check import *
-from hail.utils.java import escape_str, escape_id, Env
 
 
 class I32(IR):

--- a/python/hail/matrixtable.py
+++ b/python/hail/matrixtable.py
@@ -301,8 +301,7 @@ class GroupedMatrixTable(ExprContainer):
         elif self._row_keys is not None:
             if self._partition_key is None:
                 self._partition_key = self._row_keys.keys()
-            keyed_mt = base._select_rows_processed(hl.struct(**group_exprs),
-                                                   pk_size=len(self._partition_key))
+            keyed_mt = base._select_rows_processed(hl.struct(**group_exprs))
             mt = MatrixTable(keyed_mt._jvds.aggregateRowsByKey(str(hl.struct(**named_exprs)._ir)))
         else:
             raise ValueError("GroupedMatrixTable cannot be aggregated if no groupings are specified.")

--- a/python/hail/plot/plots.py
+++ b/python/hail/plot/plots.py
@@ -325,8 +325,8 @@ def manhattan(pvals, locus=None, title=None, size=4, hover_fields=None, collect_
     else:
         agg_f = pvals._aggregation_method()
         res = agg_f(aggregators.downsample(locus.global_position(), pvals,
-                                           label=hail.array([hail.str(x) for x in hover_fields.values()])),
-                    n_divisions=n_divisions)
+                                           label=hail.array([hail.str(x) for x in hover_fields.values()]),
+                                           n_divisions=n_divisions))
         fields = [point[2] for point in res]
         for idx, key in enumerate(list(hover_fields.keys())):
             hover_fields[key] = [field[idx] for field in fields]

--- a/python/hail/table.py
+++ b/python/hail/table.py
@@ -465,7 +465,7 @@ class Table(ExprContainer):
 
     @classmethod
     @typecheck_method(rows=anytype,
-                      schema=nullable(tstruct),
+                      schema=nullable(hail_type),
                       key=table_key_type,
                       n_partitions=nullable(int))
     def parallelize(cls, rows, schema=None, key=None, n_partitions=None):

--- a/python/hail/typecheck/__init__.py
+++ b/python/hail/typecheck/__init__.py
@@ -19,4 +19,6 @@ __all__ = ['TypeChecker',
            'identity',
            'transformed',
            'func_spec',
-           'table_key_type']
+           'table_key_type',
+           'TypecheckFailure',
+           ]

--- a/python/hail/typecheck/check.py
+++ b/python/hail/typecheck/check.py
@@ -2,7 +2,7 @@ import re
 import inspect
 import abc
 import collections
-from functools import wraps, update_wrapper
+from decorator import decorator
 
 
 class TypecheckFailure(Exception):
@@ -540,13 +540,9 @@ def typecheck(**checkers):
 def _make_dec(checkers, is_method):
     checkers = {k: only(v) for k, v in checkers.items()}
 
-    def actual_decorator(f):
-        @wraps(f)
-        def wrapper(*args, **kwargs):
-            args_, kwargs_ = check_all(f, args, kwargs, checkers, is_method=is_method)
-            return f(*args_, **kwargs_)
+    @decorator
+    def wrapper(__original_func, *args, **kwargs):
+        args_, kwargs_ = check_all(__original_func, args, kwargs, checkers, is_method=is_method)
+        return __original_func(*args_, **kwargs_)
 
-        update_wrapper(wrapper, f)
-        return wrapper
-
-    return actual_decorator
+    return wrapper

--- a/python/test/hail/table/test_table.py
+++ b/python/test/hail/table/test_table.py
@@ -632,7 +632,7 @@ class Tests(unittest.TestCase):
 
     def test_table_head_returns_right_number(self):
         rt = hl.utils.range_table(10, 11)
-        par = hl.Table.parallelize([hl.Struct(x=x) for x in range(10)], dtype='struct<x: int32>', n_partitions=11)
+        par = hl.Table.parallelize([hl.Struct(x=x) for x in range(10)], schema='struct{x: int32}', n_partitions=11)
 
         # test TableRange and TableParallelize rewrite rules
         tables = [rt, par, rt.cache()]


### PR DESCRIPTION
Had to refactor some things to deal with subtle importing graphs.

I also left the hl.scan stuff using functools, because I'm not sure that
we can fix that as easily.

fixes #4112