### PR TITLE
added weights to linreg

### DIFF
--- a/python/hail/expr/aggregators/aggregators.py
+++ b/python/hail/expr/aggregators/aggregators.py
@@ -1224,9 +1224,8 @@ def linreg(y, x, nested_dim=1, weight=None) -> StructExpression:
     -----
     In relation to
     `lm.summary <https://stat.ethz.ch/R-manual/R-devel/library/stats/html/summary.lm.html>`__
-    in R,
-    ``linreg(y, x = [1, mt.x1, mt.x2])``
-    computes ``summary(lm(y ~ x1 + x2))`` and
+    in R, ``linreg(y, x = [1, mt.x1, mt.x2])`` computes
+    ``summary(lm(y ~ x1 + x2))`` and
     ``linreg(y, x = [mt.x1, mt.x2], nested_dim=0)`` computes
     ``summary(lm(y ~ x1 + x2 - 1))``.
 

--- a/python/hail/expr/aggregators/aggregators.py
+++ b/python/hail/expr/aggregators/aggregators.py
@@ -1182,10 +1182,11 @@ def info_score(gp) -> StructExpression:
     return _agg_func('InfoScore', gp, t)
 
 
-@typecheck(y=agg_expr(expr_float64),
+@typecheck(y=expr_float64,
            x=oneof(expr_float64, sequenceof(expr_float64)),
-           nested_dim=int)
-def linreg(y, x, nested_dim=1) -> StructExpression:
+           nested_dim=int,
+           weight=nullable(expr_float64))
+def linreg(y, x, nested_dim=1, weight=None) -> StructExpression:
     """Compute multivariate linear regression statistics.
 
     Examples
@@ -1222,7 +1223,7 @@ def linreg(y, x, nested_dim=1) -> StructExpression:
     Notes
     -----
     In relation to
-    `lm.summary <https://stat.ethz.ch/R-manual/R-devel/library/stats/html/summary.lm.html>`__.
+    `lm.summary <https://stat.ethz.ch/R-manual/R-devel/library/stats/html/summary.lm.html>`__
     in R,
     ``linreg(y, x = [1, mt.x1, mt.x2])``
     computes ``summary(lm(y ~ x1 + x2))`` and
@@ -1257,10 +1258,18 @@ def linreg(y, x, nested_dim=1) -> StructExpression:
        nested models.
      - `n` (:py:data:`.tint64`):
        Number of samples included in the regression. A sample is included if and
-       only if `y` and all elements of `x` are non-missing.
+       only if `y`, all elements of `x`, and `weight` (if set) are non-missing.
 
     All but the last field are missing if `n` is less than or equal to the
     number of covariates or if the covariates are linearly dependent.
+
+    If set, the `weight` parameter generalizes the model to `weighted least
+    squares <https://en.wikipedia.org/wiki/Weighted_least_squares>`__, useful
+    for heteroscedastic (diagonal but non-constant) variance.
+
+    Warning
+    -------
+    If any weight is negative, the resulting statistics will be ``nan``.
 
     Parameters
     ----------
@@ -1271,6 +1280,8 @@ def linreg(y, x, nested_dim=1) -> StructExpression:
     nested_dim : :obj:`int`
         The null model includes the first `nested_dim` covariates.
         Must be between 0 and `k` (the length of `x`).
+    weight : :class:`.Float64Expression`, optional
+        Non-negative weight for weighted least squares.
 
     Returns
     -------
@@ -1278,6 +1289,11 @@ def linreg(y, x, nested_dim=1) -> StructExpression:
         Struct of regression results.
     """
     x = wrap_to_list(x)
+    if weight is not None:
+        return linreg(hl.sqrt(weight) * y,
+                      [hl.sqrt(weight) * xi for xi in x],
+                      nested_dim)
+
     k = len(x)
     if k == 0:
         raise ValueError("linreg: must have at least one covariate in `x`")
@@ -1304,7 +1320,7 @@ def linreg(y, x, nested_dim=1) -> StructExpression:
     k = hl.int32(k)
     k0 = hl.int32(k0)
 
-    return _agg_func('LinearRegression', y, t, [k, k0], seq_op_args=[lambda y: y, x])
+    return _agg_func('LinearRegression', _to_agg(y), t, [k, k0], seq_op_args=[lambda y: y, x])
 
 
 @typecheck(group=expr_any,

--- a/python/test/hail/expr/test_expr.py
+++ b/python/test/hail/expr/test_expr.py
@@ -381,6 +381,25 @@ class Tests(unittest.TestCase):
         self.assertAlmostEqual(r.multiple_p_value, 0.6331017)
         self.assertAlmostEqual(r.n, 5)
 
+        # weighted OLS
+        t = t.add_index()
+        r = t.aggregate(hl.struct(
+            linreg=hl.agg.linreg(t.y, [1, t.x], weight=t.idx))).linreg
+        self.assertAlmostEqual(r.beta[0], 0.2339059)
+        self.assertAlmostEqual(r.beta[1], 0.4275577)
+        self.assertAlmostEqual(r.standard_error[0], 0.6638324)
+        self.assertAlmostEqual(r.standard_error[1], 0.6662581)
+        self.assertAlmostEqual(r.t_stat[0], 0.3523569)
+        self.assertAlmostEqual(r.t_stat[1], 0.6417299)
+        self.assertAlmostEqual(r.p_value[0], 0.7478709)
+        self.assertAlmostEqual(r.p_value[1], 0.5667139)
+        self.assertAlmostEqual(r.multiple_standard_error, 3.26238997)
+        self.assertAlmostEqual(r.multiple_r_squared, 0.12070321)
+        self.assertAlmostEqual(r.adjusted_r_squared, -0.17239572)
+        self.assertAlmostEqual(r.f_stat, 0.41181729)
+        self.assertAlmostEqual(r.multiple_p_value, 0.56671386)
+        self.assertAlmostEqual(r.n, 5)
+
     def test_aggregators_downsample(self):
         xs = [2, 6, 4, 9, 1, 8, 5, 10, 3, 7]
         ys = [2, 6, 4, 9, 1, 8, 5, 10, 3, 7]


### PR DESCRIPTION
@konradjk asked for weighted OLS, which is just a transformation of `x` and `y` by `sqrt(w)`. Currently `sqrt` is done `1 + len(x)` per record rather than once because you can't bind inside an aggregate. If that's a bottleneck, I could rework the aggregator to pass the w through to scala and avoid taking sqrt altogether. But for now this simple change at the Python level seems reasonable.