### PR TITLE
add VEP csq header definition to globals when csq=true

### DIFF
--- a/python/hail/methods/qc.py
+++ b/python/hail/methods/qc.py
@@ -518,7 +518,7 @@ def vep(dataset: Union[Table, MatrixTable], config, block_size=1000, name='vep',
 
     if csq:
         dataset = dataset.annotate_globals(
-            **{name + '_csq_header': annotations["vep_csq_header"]})
+            **{name + '_csq_header': annotations['vep_csq_header'].value})
 
     if isinstance(dataset, MatrixTable):
         return dataset.annotate_rows(**{name: annotations[dataset.row_key].vep})

--- a/python/hail/methods/qc.py
+++ b/python/hail/methods/qc.py
@@ -480,7 +480,12 @@ def vep(dataset: Union[Table, MatrixTable], config, block_size=1000, name='vep',
 
     **Annotations**
 
-    A new row field is added in the location specified by `name` with type given by the type given by the `json_vep_schema` (if `csq` is ``False``) or :py:data:`.tstr` (if `csq` is ``True``).
+    A new row field is added in the location specified by `name` with type given
+    by the type given by the `json_vep_schema` (if `csq` is ``False``) or
+    :py:data:`.tstr` (if `csq` is ``True``).
+
+    If csq is ``True``, then the CSQ header string is also added as a global
+    field with name ``name + '_csq_header'``.
 
     Parameters
     ----------
@@ -510,6 +515,10 @@ def vep(dataset: Union[Table, MatrixTable], config, block_size=1000, name='vep',
         ht = dataset.select()
 
     annotations = Table(Env.hail().methods.VEP.apply(ht._jt, config, csq, block_size))
+
+    if csq:
+        dataset = dataset.annotate_globals(
+            **{name + '_csq_header': annotations["vep_csq_header"]})
 
     if isinstance(dataset, MatrixTable):
         return dataset.annotate_rows(**{name: annotations[dataset.row_key].vep})

--- a/src/main/scala/is/hail/methods/VEP.scala
+++ b/src/main/scala/is/hail/methods/VEP.scala
@@ -208,13 +208,16 @@ object VEP {
 
     info(s"vep: annotated ${ annotations.count() } variants")
 
+    val (globalValue, globalType) =
+      if (csq)
+        (Row(csqHeader.getOrElse("")), TStruct("vep_csq_header" -> TString()))
+      else
+        (Row(), TStruct())
+    
     new Table(ht.hc, TableLiteral(TableValue(
-        TableType(vepRowType, Some(FastIndexedSeq("locus", "alleles")), TStruct()),
-        if (csq)
-          BroadcastRow(Row(csqHeader.getOrElse("")), TStruct("vep_csq_header" -> TString()), ht.hc.sc)
-        else
-          BroadcastRow(Row(), TStruct(), ht.hc.sc),
-        vepRVD)))
+      TableType(vepRowType, Some(FastIndexedSeq("locus", "alleles")), globalType),
+      BroadcastRow(globalValue, globalType, ht.hc.sc),
+      vepRVD)))
   }
 
   def apply(ht: Table, config: String, csq: Boolean = false, blockSize: Int = 1000): Table =

--- a/src/main/scala/is/hail/methods/VEP.scala
+++ b/src/main/scala/is/hail/methods/VEP.scala
@@ -56,6 +56,30 @@ object VEP {
     (Locus(a(0), a(1).toInt), a(3) +: a(4).split(","))
   }
 
+  def getCSQHeaderDefinition(cmd: Array[String], confEnv: Map[String, String]): Option[String] = {
+    val csqHeaderRegex = "ID=CSQ[^>]+Description=\"([^\"]+)".r
+    val pb = new ProcessBuilder(cmd.toList.asJava)
+    val env = pb.environment()
+    confEnv.foreach { case (key, value) => env.put(key, value) }
+    
+    val (jt, proc) = List((Locus("1", 13372), IndexedSeq("G", "C"))).iterator.pipe(pb,
+      printContext,
+      printElement,
+      _ => ())
+
+    val csqHeader = jt.flatMap(s => csqHeaderRegex.findFirstMatchIn(s).map(m => m.group(1)))
+    val rc = proc.waitFor()
+    if (rc != 0)
+      fatal(s"VEP command failed with non-zero exit status $rc")
+
+    if (csqHeader.hasNext)
+      Some(csqHeader.next())
+    else {
+      warn("could not get VEP CSQ header")
+      None
+    }
+  }
+  
   def annotate(ht: Table, config: String, csq: Boolean, blockSize: Int): Table = {
     assert(ht.key.contains(FastIndexedSeq("locus", "alleles")))
     assert(ht.typ.rowType.size == 2)
@@ -69,6 +93,8 @@ object VEP {
       else
         s)
 
+    val csqHeader = if (csq) getCSQHeaderDefinition(cmd, conf.env) else None
+    
     val inputQuery = vepSignature.query("input")
 
     val csqRegex = "CSQ=[^;^\\t]+".r
@@ -184,7 +210,10 @@ object VEP {
 
     new Table(ht.hc, TableLiteral(TableValue(
         TableType(vepRowType, Some(FastIndexedSeq("locus", "alleles")), TStruct()),
-        BroadcastRow(Row(), TStruct(), ht.hc.sc),
+        if (csq)
+          BroadcastRow(Row(csqHeader.getOrElse("")), TStruct("vep_csq_header" -> TString()), ht.hc.sc)
+        else
+          BroadcastRow(Row(), TStruct(), ht.hc.sc),
         vepRVD)))
   }
 


### PR DESCRIPTION
@konradjk once this builds i'll see what header is produced and run that by you for reasonable-ness. Should we be testing vep with `csq=true` as well? I could produce a second copy of the gold standard with that option and add it to the script, which would also test that this string is created correctly