### PR TITLE
remove duplicate api link from sidebar

### DIFF
--- a/python/hail/docs/index.rst
+++ b/python/hail/docs/index.rst
@@ -15,7 +15,6 @@ Contents
     Tutorials <tutorials-landing>
     Reference (Python API) <api>
     Hailpedia <overview>
-    Python API <api>
     For Software Developers <getting_started_developing>
     Other Resources <other_resources>
 


### PR DESCRIPTION
accidentally duplicated this link when I was rebasing #4097.