### PR TITLE
Removed MatrixAggregate IR node

### DIFF
--- a/python/hail/ir/ir.py
+++ b/python/hail/ir/ir.py
@@ -1145,27 +1145,6 @@ class TableAggregate(IR):
                other.query == self.query
 
 
-class MatrixAggregate(IR):
-    @typecheck_method(child=MatrixIR, query=IR)
-    def __init__(self, child, query):
-        super().__init__(child, query)
-        self.child = child
-        self.query = query
-
-    @typecheck_method(child=MatrixIR, query=IR)
-    def copy(self, child, query):
-        new_instance = self.__class__
-        return new_instance(child, query)
-
-    def __str__(self):
-        return '(MatrixAggregate {} {})'.format(self.child, self.query)
-
-    def __eq__(self, other):
-        return isinstance(other, MatrixAggregate) and \
-               other.child == self.child and \
-               other.query == self.query
-
-
 class TableWrite(IR):
     @typecheck_method(child=TableIR, path=str, overwrite=bool)
     def __init__(self, child, path, overwrite):

--- a/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/src/main/scala/is/hail/expr/ir/Children.scala
@@ -107,7 +107,6 @@ object Children {
     // from TableIR
     case TableCount(child) => IndexedSeq(child)
     case TableAggregate(child, query) => IndexedSeq(child, query)
-    case MatrixAggregate(child, query) => IndexedSeq(child, query)
     case TableWrite(child, _, _, _, _) => IndexedSeq(child)
     case TableExport(child, _, _, _, _) => IndexedSeq(child)
   }

--- a/src/main/scala/is/hail/expr/ir/Compilable.scala
+++ b/src/main/scala/is/hail/expr/ir/Compilable.scala
@@ -5,7 +5,6 @@ object Compilable {
     ir match {
       case _: TableCount => false
       case _: TableAggregate => false
-      case _: MatrixAggregate => false
       case _: TableWrite => false
       case _: TableExport  => false
       case _: MatrixWrite => false

--- a/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -147,9 +147,6 @@ object Copy {
       case TableAggregate(_, _) =>
         val IndexedSeq(child: TableIR, query: IR) = newChildren
         TableAggregate(child, query)
-      case MatrixAggregate(_, _) =>
-        val IndexedSeq(child: MatrixIR, query: IR) = newChildren
-        MatrixAggregate(child, query)
       case TableWrite(_, path, overwrite, stageLocally, codecSpecJSONStr) =>
         val IndexedSeq(child: TableIR) = newChildren
         TableWrite(child, path, overwrite, stageLocally, codecSpecJSONStr)

--- a/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/src/main/scala/is/hail/expr/ir/IR.scala
@@ -200,7 +200,6 @@ final case class Uniroot(argname: String, function: IR, min: IR, max: IR) extend
 
 final case class TableCount(child: TableIR) extends IR { val typ: Type = TInt64() }
 final case class TableAggregate(child: TableIR, query: IR) extends InferIR
-final case class MatrixAggregate(child: MatrixIR, query: IR) extends InferIR
 final case class TableWrite(
   child: TableIR,
   path: String,

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -77,8 +77,6 @@ object Infer {
         -t.types(idx)
       case TableAggregate(child, query) =>
         query.typ
-      case MatrixAggregate(child, query) =>
-        query.typ
     }
   }
 }

--- a/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -246,7 +246,7 @@ object Interpret {
         if (aValue == null)
           null
         else
-          aValue.asInstanceOf[IndexedSeq[Row]].filter(_ != null).map{ case Row(k, v) => (k, v) }.toMap
+          aValue.asInstanceOf[IndexedSeq[Row]].filter(_ != null).map { case Row(k, v) => (k, v) }.toMap
 
       case ToArray(c) =>
         val ordering = coerce[TContainer](c.typ).elementType.ordering.toOrdering
@@ -624,7 +624,6 @@ object Interpret {
             initOps(0)(region, rvAggs, globals, false)
           }
 
-          val zval = rvAggs
           val combOp = { (rvAggs1: Array[RegionValueAggregator], rvAggs2: Array[RegionValueAggregator]) =>
             rvAggs1.zip(rvAggs2).foreach { case (rvAgg1, rvAgg2) => rvAgg1.combOp(rvAgg2) }
             rvAggs1
@@ -638,95 +637,8 @@ object Interpret {
             val globalsOffset = rvb.end()
             val seqOpsFunction = seqOps(i)
             (globalsOffset, seqOpsFunction)
-          })( { case ((globalsOffset, seqOpsFunction), comb, rv) =>
+          })({ case ((globalsOffset, seqOpsFunction), comb, rv) =>
             seqOpsFunction(rv.region, comb, globalsOffset, false, rv.offset, false)
-          }, combOp)
-        } else
-          Array.empty[RegionValueAggregator]
-
-        Region.scoped { region =>
-          val rvb: RegionValueBuilder = new RegionValueBuilder()
-          rvb.set(region)
-
-          rvb.start(aggResultType)
-          rvb.startStruct()
-          aggResults.foreach(_.result(rvb))
-          rvb.endStruct()
-          val aggResultsOffset = rvb.end()
-
-          rvb.start(localGlobalSignature)
-          rvb.addAnnotation(localGlobalSignature, globalsBc.value)
-          val globalsOffset = rvb.end()
-
-          val resultOffset = f(0)(region, aggResultsOffset, false, globalsOffset, false)
-
-          SafeRow(coerce[TTuple](t), region, resultOffset)
-            .get(0)
-        }
-      case MatrixAggregate(child, query) =>
-        val localGlobalSignature = child.typ.globalType
-        val value = child.execute(HailContext.get)
-        val colArrayType = TArray(child.typ.colType)
-        val (rvAggs, initOps, seqOps, aggResultType, postAggIR) = CompileWithAggregators[Long, Long, Long, Long](
-          "global", child.typ.globalType,
-          "global", child.typ.globalType,
-          "sa", colArrayType,
-          "va", child.typ.rvRowType,
-          MakeTuple(Array(query)), "AGGR",
-          (nAggs: Int, initOpIR: IR) => initOpIR,
-          (nAggs: Int, seqOpIR: IR) =>
-            ArrayFor(
-              ArrayRange(I32(0), I32(value.nCols), I32(1)),
-              "idx",
-              Let(
-                "sa",
-                ArrayRef(Ref("sa", colArrayType), Ref("idx", TInt32Optional)),
-                Let(
-                  "g",
-                  ArrayRef(GetField(Ref("va", child.typ.rvRowType), MatrixType.entriesIdentifier), Ref("idx", TInt32Optional)),
-                  seqOpIR))))
-
-        val (t, f) = Compile[Long, Long, Long](
-          "AGGR", aggResultType,
-          "global", child.typ.globalType,
-          postAggIR)
-
-        val globalsBc = value.globals.broadcast
-        val colValuesBc = value.colValues.broadcast
-        val localColsType = TArray(child.typ.colType)
-
-        val aggResults = if (rvAggs.nonEmpty) {
-          Region.scoped { region =>
-            val rvb: RegionValueBuilder = new RegionValueBuilder()
-            rvb.set(region)
-
-            rvb.start(localGlobalSignature)
-            rvb.addAnnotation(localGlobalSignature, globalsBc.value)
-            val globals = rvb.end()
-
-            initOps(0)(region, rvAggs, globals, false)
-          }
-
-          val zval = rvAggs
-          val combOp = { (rvAggs1: Array[RegionValueAggregator], rvAggs2: Array[RegionValueAggregator]) =>
-            rvAggs1.zip(rvAggs2).foreach { case (rvAgg1, rvAgg2) => rvAgg1.combOp(rvAgg2) }
-            rvAggs1
-          }
-
-          value.rvd.aggregateWithPartitionOp(rvAggs, (i, ctx) => {
-            val r = ctx.freshRegion
-            val rvb = new RegionValueBuilder()
-            rvb.set(r)
-            rvb.start(localGlobalSignature)
-            rvb.addAnnotation(localGlobalSignature, globalsBc.value)
-            val globalsOffset = rvb.end()
-            rvb.start(localColsType)
-            rvb.addAnnotation(localColsType, colValuesBc.value)
-            val colsOffset = rvb.end()
-            val seqOpsFunction = seqOps(i)
-            (globalsOffset, colsOffset, seqOpsFunction)
-          })( { case ((globalsOffset, colsOffset, seqOpsFunction), comb, rv) =>
-            seqOpsFunction(rv.region, comb, globalsOffset, false, colsOffset, false, rv.offset, false)
           }, combOp)
         } else
           Array.empty[RegionValueAggregator]

--- a/src/main/scala/is/hail/expr/ir/LiftLiterals.scala
+++ b/src/main/scala/is/hail/expr/ir/LiftLiterals.scala
@@ -160,10 +160,6 @@ object LiftLiterals {
         val literals = getLiterals(expr)
         val rewriteChild = addLiterals(child, literals)
         TableAggregate(rewriteChild, rewriteIR(expr, rewriteChild.typ.globalType))
-      case MatrixAggregate(child, expr) =>
-        val literals = getLiterals(expr)
-        val rewriteChild = addLiterals(child, literals)
-        MatrixAggregate(rewriteChild, rewriteIR(expr, rewriteChild.typ.globalType))
       case ir => ir
     })
   }

--- a/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -732,10 +732,6 @@ object PruneDeadFields {
         val queryDep = memoizeAndGetDep(query, query.typ, child.typ, memo)
         memoizeTableIR(child, queryDep, memo)
         Env.empty[(Type, Type)]
-      case MatrixAggregate(child, query) =>
-        val queryDep = memoizeAndGetDep(query, query.typ, child.typ, memo)
-        memoizeMatrixIR(child, queryDep, memo)
-        Env.empty[(Type, Type)]
       case _: IR =>
         val envs = ir.children.flatMap {
           case mir: MatrixIR =>
@@ -973,10 +969,6 @@ object PruneDeadFields {
         val child2 = rebuild(child, memo)
         val query2 = rebuild(query, child2.typ, memo)
         TableAggregate(child2, query2)
-      case MatrixAggregate(child, query) =>
-        val child2 = rebuild(child, memo)
-        val query2 = rebuild(query, child2.typ, memo)
-        MatrixAggregate(child2, query2)
       case _ =>
         ir.copy(ir.children.map {
           case valueIR: IR => rebuild(valueIR, in, memo)

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -238,20 +238,6 @@ object TypeCheck {
               env.bind(n, t)
           }))
         assert(x.typ == query.typ)
-      case x@MatrixAggregate(child, query) =>
-        val aggregationST = Map(
-          "global" -> (0, child.typ.globalType),
-          "g" -> (1, child.typ.entryType),
-          "va" -> (2, child.typ.rvRowType),
-          "sa" -> (3, child.typ.colType))
-        val env = Env.empty[Type]
-          .bind("global" -> child.typ.globalType)
-          .bind("AGG" -> TAggregable(child.typ.entryType, aggregationST))
-        val aggEnv = Env.empty[Type].bind(aggregationST.toArray.map { case (name, (_, t)) => name -> t }: _*)
-        check(query,
-          env = env,
-          aggEnv = Some(aggEnv))
-        assert(x.typ == query.typ)
       case TableWrite(_, _, _, _, _) =>
       case TableExport(_, _, _, _, _) =>
       case TableCount(_) =>

--- a/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -512,12 +512,6 @@ class PruneSuite extends SparkSuite {
       Array(subsetTable(tab.typ, "global.g1"), null))
   }
 
-  @Test def testMatrixAggregateMemo() {
-    checkMemo(MatrixAggregate(mat, matrixRefBoolean(mat.typ, "global.g1")),
-      TBoolean(),
-      Array(subsetMatrixTable(mat.typ, "global.g1"), null))
-  }
-
   @Test def testTableImportRebuild() {
     val tt = TableType(
       TStruct("a" -> TInt32(), "b" -> TFloat64()),
@@ -795,15 +789,6 @@ class PruneSuite extends SparkSuite {
       (_: BaseIR, r: BaseIR) => {
         val ir = r.asInstanceOf[TableAggregate]
         ir.child.typ == subsetTable(tr.typ, "row.2")
-      })
-  }
-
-  @Test def testMatrixAggregateRebuild() {
-    val ma = MatrixAggregate(mr, matrixRefBoolean(mr.typ, "va.r2"))
-    checkRebuild(ma, TBoolean(),
-      (_: BaseIR, r: BaseIR) => {
-        val ir = r.asInstanceOf[MatrixAggregate]
-        ir.child.typ == subsetMatrixTable(mr.typ, "va.r2")
       })
   }
 }


### PR DESCRIPTION
This IR isn't being used anywhere. Instead, `MatrixTable.aggregateRows`, `MatrixTable.aggregateCols`, and `MatrixTable.aggregateEntries` are implemented in terms of TableAggregate after getting the appropriate Table.

@cseed Is there a reason why we should keep this?