### PR TITLE
fix LinearMixedModel bug

### DIFF
--- a/python/hail/stats/linear_mixed_model.py
+++ b/python/hail/stats/linear_mixed_model.py
@@ -537,14 +537,15 @@ class LinearMixedModel(object):
 
         self.gamma = np.exp(self.log_gamma)
         self.h_sq = self.sigma_sq / (self.sigma_sq + self.tau_sq)
-        if fit_log_gamma:
-            self.h_sq_standard_error = self._estimate_h_sq_standard_error()
 
         self._residual_sq = self.sigma_sq * self._dof
         self._d_alt = self._d
         self._ydy_alt = self._ydy
         self._xdy_alt[1:] = self._xdy
         self._xdx_alt[1:, 1:] = self._xdx
+
+        if fit_log_gamma:
+            self.h_sq_standard_error = self._estimate_h_sq_standard_error()
 
         self._fitted = True
 

--- a/python/test/hail/stats/test_linear_mixed_model.py
+++ b/python/test/hail/stats/test_linear_mixed_model.py
@@ -103,6 +103,7 @@ class Tests(unittest.TestCase):
 
         # compare NumPy and Hail LMM per alternative
         df_numpy = model.fit_alternatives_numpy(pa, a).to_pandas()
+        assert np.min(df_numpy['chi_sq']) > 0
 
         na_numpy = df_numpy.isna().any(axis=1)
         na_lmm = df_lmm.isna().any(axis=1)
@@ -183,6 +184,7 @@ class Tests(unittest.TestCase):
 
         # compare NumPy and Hail LMM per alternative
         df_numpy = model.fit_alternatives_numpy(pa, a).to_pandas()
+        assert np.min(df_numpy['chi_sq']) > 0
 
         na_numpy = df_numpy.isna().any(axis=1)
         na_lmm = df_lmm.isna().any(axis=1)


### PR DESCRIPTION
The point of setting the following values at the end of fit() is so they won't be mutated by further calls to `compute_neg_log_lkhd`:

```
self._residual_sq = self.sigma_sq * self._dof
self._d_alt = self._d
self._ydy_alt = self._ydy
self._xdy_alt[1:] = self._xdy
self._xdx_alt[1:, 1:] = self._xdx
```

But when I added `h_sq_standard_error` above them, it introduced a very subtle bug by calling `compute_neg_log_lkhd` at a value `1e-4` to the right of the fit `log_gamma`. This caused both the scala and python routes to use the value of `self._residual_sq` at `log_gamma` but the value of `self._d_alt` and the rest at `log_gamma + 1e-4`. So these two routes remained consistent, but sometimes the alternate residual was coming up greater than the null residual, resulting in negative chi_sq stat. The modified tests catch this.