### PR TITLE
Freeze Sphinx at 1.7.5 so makeDocs works on macOS 10.13 and Spark 2.3.1

### DIFF
--- a/python/hail/dev-environment.yml
+++ b/python/hail/dev-environment.yml
@@ -1,7 +1,7 @@
 name: hail
 dependencies:
 - python=3.6
-- Sphinx=1.7
+- Sphinx=1.7.5
 - sphinxcontrib
 - conda-forge::nbsphinx
 - conda-forge::sphinx_rtd_theme


### PR DESCRIPTION
This PR freezes Sphinx at 1.7.5. Confirmed to work on at least one laptop running macOS 10.13 and Spark 2.3.1.