### PR TITLE
Make the parser faster; add support for cached IR nodes

### DIFF
--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -15,9 +15,7 @@ import org.json4s.jackson.{JsonMethods, Serialization}
 import scala.util.parsing.combinator.JavaTokenParsers
 import scala.util.parsing.input.Position
 
-//case class EnvBox(var env: IRParserEnvironment)
 object IRParserEnvironment {
-  //  val theEnv: IRParserEnvironment = EnvBox(null)
   var theEnv: IRParserEnvironment = null
 }
 
@@ -497,22 +495,14 @@ object Parser extends JavaTokenParsers {
     "Keyed(" ~> ir_agg_op <~ ")" ^^ { aggOp => ir.Keyed(aggOp) }
 
   def ir_children: Parser[IndexedSeq[ir.IR]] =
-    rep(ir_value_expr) ^^ {
-      _.toFastIndexedSeq
-    }
+    rep(ir_value_expr) ^^ (_.toFastIndexedSeq)
 
-  def table_ir_children: Parser[IndexedSeq[ir.TableIR]] = rep(table_ir) ^^ {
-    _.toFastIndexedSeq
-  }
+  def table_ir_children: Parser[IndexedSeq[ir.TableIR]] = rep(table_ir) ^^ (_.toFastIndexedSeq)
 
-  def matrix_ir_children: Parser[IndexedSeq[ir.MatrixIR]] = rep(matrix_ir) ^^ {
-    _.toFastIndexedSeq
-  }
+  def matrix_ir_children: Parser[IndexedSeq[ir.MatrixIR]] = rep(matrix_ir) ^^ (_.toFastIndexedSeq)
 
   def ir_value_exprs: Parser[IndexedSeq[ir.IR]] =
-    "(" ~> rep(ir_value_expr) <~ ")" ^^ {
-      _.toFastIndexedSeq
-    }
+    "(" ~> rep(ir_value_expr) <~ ")" ^^ (_.toFastIndexedSeq)
 
   def ir_value_exprs_opt: Parser[Option[IndexedSeq[ir.IR]]] =
     ir_value_exprs ^^ { xs => Some(xs) } |

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -696,12 +696,16 @@ object Parser extends JavaTokenParsers {
       "CachedMatrixTable" ~> ir_identifier ^^ { ident => IRParserEnvironment.theEnv.ir_map(ident).asInstanceOf[MatrixIR] }
   }
 
-  def parse_value_ir(s: String, env: IRParserEnvironment = IRParserEnvironment()): IR = parseWithEnv(ir_value_expr, s, env)
+  def parse_value_ir(s: String): IR = parse_value_ir(s, IRParserEnvironment())
+  def parse_value_ir(s: String, env: IRParserEnvironment): IR = parseWithEnv(ir_value_expr, s, env)
 
-  def parse_named_value_irs(s: String, env: IRParserEnvironment = IRParserEnvironment()): Array[(String, IR)] =
+  def parse_named_value_irs(s: String): Array[(String, IR)] = parse_named_value_irs(s, IRParserEnvironment())
+  def parse_named_value_irs(s: String, env: IRParserEnvironment): Array[(String, IR)] =
     parseWithEnv(ir_named_value_exprs, s, env).toArray
 
-  def parse_table_ir(s: String, env: IRParserEnvironment = IRParserEnvironment()): TableIR = parseWithEnv(table_ir, s, env)
+  def parse_table_ir(s: String): TableIR = parse_table_ir(s, IRParserEnvironment())
+  def parse_table_ir(s: String, env: IRParserEnvironment): TableIR = parseWithEnv(table_ir, s, env)
 
-  def parse_matrix_ir(s: String, env: IRParserEnvironment = IRParserEnvironment()): MatrixIR = parseWithEnv(matrix_ir, s, env)
+  def parse_matrix_ir(s: String): MatrixIR = parse_matrix_ir(s, IRParserEnvironment())
+  def parse_matrix_ir(s: String, env: IRParserEnvironment): MatrixIR = parseWithEnv(matrix_ir, s, env)
 }

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -2,7 +2,7 @@ package is.hail.expr
 
 import is.hail.HailContext
 import is.hail.annotations.BroadcastRow
-import is.hail.expr.ir.{AggSignature, IR, MatrixIR, TableIR}
+import is.hail.expr.ir.{AggSignature, BaseIR, IR, MatrixIR, TableIR}
 import is.hail.expr.types._
 import is.hail.rvd.OrderedRVDType
 import is.hail.table.{Ascending, Descending, SortField, TableSpec}
@@ -14,6 +14,17 @@ import org.json4s.jackson.{JsonMethods, Serialization}
 
 import scala.util.parsing.combinator.JavaTokenParsers
 import scala.util.parsing.input.Position
+
+//case class EnvBox(var env: IRParserEnvironment)
+object IRParserEnvironment {
+  //  val theEnv: IRParserEnvironment = EnvBox(null)
+  var theEnv: IRParserEnvironment = null
+}
+
+case class IRParserEnvironment(
+  ref_map: Map[String, Type] = Map.empty,
+  ir_map: Map[String, BaseIR] = Map.empty
+)
 
 class RichParser[T](parser: Parser.Parser[T]) {
   def parse(input: String): T = {
@@ -60,6 +71,17 @@ object Parser extends JavaTokenParsers {
     parseAll(parser, code) match {
       case Success(result, _) => result
       case NoSuccess(msg, next) => ParserUtils.error(next.pos, msg)
+    }
+  }
+
+  private def parseWithEnv[T](parser: Parser[T], code: String, env: IRParserEnvironment): T = {
+    synchronized {
+      try {
+        IRParserEnvironment.theEnv = env
+        parse(parser, code)
+      } finally {
+        IRParserEnvironment.theEnv = null
+      }
     }
   }
 
@@ -474,8 +496,10 @@ object Parser extends JavaTokenParsers {
   def ir_keyed_agg_op: Parser[ir.Keyed] =
     "Keyed(" ~> ir_agg_op <~ ")" ^^ { aggOp => ir.Keyed(aggOp) }
 
-  def ir_children(ref_map: Map[String, Type] = Map.empty): Parser[IndexedSeq[ir.IR]] =
-    rep(ir_value_expr(ref_map)) ^^ { _.toFastIndexedSeq }
+  def ir_children: Parser[IndexedSeq[ir.IR]] =
+    rep(ir_value_expr) ^^ {
+      _.toFastIndexedSeq
+    }
 
   def table_ir_children: Parser[IndexedSeq[ir.TableIR]] = rep(table_ir) ^^ {
     _.toFastIndexedSeq
@@ -485,11 +509,13 @@ object Parser extends JavaTokenParsers {
     _.toFastIndexedSeq
   }
 
-  def ir_value_exprs(ref_map: Map[String, Type] = Map.empty): Parser[IndexedSeq[ir.IR]] =
-    "(" ~> rep(ir_value_expr(ref_map)) <~ ")" ^^ { _.toFastIndexedSeq }
+  def ir_value_exprs: Parser[IndexedSeq[ir.IR]] =
+    "(" ~> rep(ir_value_expr) <~ ")" ^^ {
+      _.toFastIndexedSeq
+    }
 
-  def ir_value_exprs_opt(ref_map: Map[String, Type] = Map.empty): Parser[Option[IndexedSeq[ir.IR]]] =
-    ir_value_exprs(ref_map) ^^ { xs => Some(xs) } |
+  def ir_value_exprs_opt: Parser[Option[IndexedSeq[ir.IR]]] =
+    ir_value_exprs ^^ { xs => Some(xs) } |
       "None" ^^ { _ => None }
 
   def matrix_type_expr_opt: Parser[Option[MatrixType]] = matrix_type_expr ^^ {
@@ -505,17 +531,18 @@ object Parser extends JavaTokenParsers {
       AggSignature(op, ctorArgTypes, initOpArgTypes, seqOpArgTypes)
     }
 
-  def ir_named_value_exprs(ref_map: Map[String, Type] = Map.empty): Parser[Seq[(String, ir.IR)]] = rep(ir_named_value_expr(ref_map))
+  def ir_named_value_exprs: Parser[Seq[(String, ir.IR)]] = rep(ir_named_value_expr)
 
-  def ir_named_value_expr(ref_map: Map[String, Type] = Map.empty): Parser[(String, ir.IR)] =
-    "(" ~> ir_identifier ~ ir_value_expr(ref_map) <~ ")" ^^ { case n ~ x => (n, x) }
+  def ir_named_value_expr: Parser[(String, ir.IR)] =
+    "(" ~> ir_identifier ~ ir_value_expr <~ ")" ^^ { case n ~ x => (n, x) }
 
-  def ir_opt[T](p: Parser[T]): Parser[Option[T]] = p ^^ { Some(_) } | "None" ^^ { _ => None }
+  def ir_opt[T](p: Parser[T]): Parser[Option[T]] = p ^^ {
+    Some(_)
+  } | "None" ^^ { _ => None }
 
-  def ir_value_expr(ref_map: Map[String, Type] = Map.empty): Parser[ir.IR] = "(" ~> ir_value_expr_1(ref_map) <~ ")"
+  def ir_value_expr: Parser[ir.IR] = "(" ~> ir_value_expr_1 <~ ")"
 
-  def ir_value_expr_1(ref_map: Map[String, Type] = Map.empty): Parser[ir.IR] = {
-    def expr_with_map: Parser[ir.IR] = ir_value_expr(ref_map)
+  def ir_value_expr_1: Parser[ir.IR] = {
     "I32" ~> int32_literal ^^ { x => ir.I32(x) } |
       "I64" ~> int64_literal ^^ { x => ir.I64(x) } |
       "F32" ~> float32_literal ^^ { x => ir.F32(x) } |
@@ -523,54 +550,54 @@ object Parser extends JavaTokenParsers {
       "Str" ~> string_literal ^^ { x => ir.Str(x) } |
       "True" ^^ { x => ir.True() } |
       "False" ^^ { x => ir.False() } |
-      "Literal" ~> ir_value ~ string_literal ^^ { case (value ~ id) => ir.Literal(value._1, value._2, id)} |
+      "Literal" ~> ir_value ~ string_literal ^^ { case (value ~ id) => ir.Literal(value._1, value._2, id) } |
       "Void" ^^ { x => ir.Void() } |
-      "Cast" ~> type_expr ~ expr_with_map ^^ { case t ~ v => ir.Cast(v, t) } |
+      "Cast" ~> type_expr ~ ir_value_expr ^^ { case t ~ v => ir.Cast(v, t) } |
       "NA" ~> type_expr ^^ { t => ir.NA(t) } |
-      "IsNA" ~> expr_with_map ^^ { value => ir.IsNA(value) } |
-      "If" ~> expr_with_map ~ expr_with_map ~ expr_with_map ^^ { case cond ~ consq ~ altr => ir.If(cond, consq, altr) } |
-      "Let" ~> ir_identifier ~ expr_with_map ~ expr_with_map ^^ { case name ~ value ~ body => ir.Let(name, value, body) } |
+      "IsNA" ~> ir_value_expr ^^ { value => ir.IsNA(value) } |
+      "If" ~> ir_value_expr ~ ir_value_expr ~ ir_value_expr ^^ { case cond ~ consq ~ altr => ir.If(cond, consq, altr) } |
+      "Let" ~> ir_identifier ~ ir_value_expr ~ ir_value_expr ^^ { case name ~ value ~ body => ir.Let(name, value, body) } |
       "Ref" ~> type_expr ~ ir_identifier ^^ { case t ~ name => ir.Ref(name, t) } |
-      "Ref" ~> ir_identifier ^^ { name => ir.Ref(name, ref_map(name)) } |
-      "ApplyBinaryPrimOp" ~> ir_binary_op ~ expr_with_map ~ expr_with_map ^^ { case op ~ l ~ r => ir.ApplyBinaryPrimOp(op, l, r) } |
-      "ApplyUnaryPrimOp" ~> ir_unary_op ~ expr_with_map ^^ { case op ~ x => ir.ApplyUnaryPrimOp(op, x) } |
-      "ApplyComparisonOp" ~> ir_comparison_op ~ expr_with_map ~ expr_with_map ^^ { case op ~ l ~ r => ir.ApplyComparisonOp(op, l, r) } |
-      "ApplyComparisonOp" ~> ir_untyped_comparison_op ~ expr_with_map ~ expr_with_map ^^ { case op ~ l ~ r => ir.ApplyComparisonOp(ir.ComparisonOp.fromStringAndTypes(op, l.typ, r.typ), l, r) } |
-      "MakeArray" ~> type_expr ~ ir_children(ref_map) ^^ { case t ~ args => ir.MakeArray(args, t.asInstanceOf[TArray]) } |
-      "ArrayRef" ~> expr_with_map  ~ expr_with_map ^^ { case a ~ i => ir.ArrayRef(a, i) } |
-      "ArrayLen" ~> expr_with_map ^^ { a => ir.ArrayLen(a) } |
-      "ArrayRange" ~> expr_with_map  ~ expr_with_map ~ expr_with_map  ^^ { case start ~ stop ~ step => ir.ArrayRange(start, stop, step) } |
-      "ArraySort" ~> boolean_literal ~ expr_with_map ~ expr_with_map ^^ { case onKey ~ a ~ ascending => ir.ArraySort(a, ascending, onKey) } |
-      "ToSet" ~> expr_with_map ^^ { a => ir.ToSet(a) } |
-      "ToDict" ~> expr_with_map ^^ { a => ir.ToDict(a) } |
-      "ToArray" ~> expr_with_map ^^ { a => ir.ToArray(a) } |
-      "LowerBoundOnOrderedCollection" ~> boolean_literal ~ expr_with_map ~ expr_with_map ^^ { case onKey ~ col ~ elem => ir.LowerBoundOnOrderedCollection(col, elem, onKey) } |
-      "GroupByKey" ~> expr_with_map ^^ { a => ir.GroupByKey(a) } |
-      "ArrayMap" ~> ir_identifier ~ expr_with_map ~ expr_with_map ^^ { case name ~ a ~ body => ir.ArrayMap(a, name, body) } |
-      "ArrayFilter" ~> ir_identifier ~ expr_with_map ~ expr_with_map ^^ { case name ~ a ~ body => ir.ArrayFilter(a, name, body) } |
-      "ArrayFlatMap" ~> ir_identifier ~ expr_with_map ~ expr_with_map ^^ { case name ~ a ~ body => ir.ArrayFlatMap(a, name, body) } |
-      "ArrayFold" ~> ir_identifier ~ ir_identifier ~ expr_with_map ~ expr_with_map ~ expr_with_map ^^ { case accumName ~ valueName ~ a ~ zero ~ body => ir.ArrayFold(a, zero, accumName, valueName, body) } |
-      "ArrayFor" ~> ir_identifier ~ expr_with_map ~ expr_with_map ^^ { case name ~ a ~ body => ir.ArrayFor(a, name, body) } |
-      "ApplyAggOp" ~> agg_signature ~ expr_with_map ~ ir_value_exprs(ref_map) ~ ir_value_exprs_opt(ref_map) ^^ { case aggSig ~ a ~ ctorArgs ~ initOpArgs => ir.ApplyAggOp(a, ctorArgs, initOpArgs, aggSig) } |
-      "ApplyScanOp" ~> agg_signature ~ expr_with_map ~ ir_value_exprs(ref_map) ~ ir_value_exprs_opt(ref_map) ^^ { case aggSig ~ a ~ ctorArgs ~ initOpArgs => ir.ApplyScanOp(a, ctorArgs, initOpArgs, aggSig) } |
-      "InitOp" ~> agg_signature ~ expr_with_map ~ ir_value_exprs(ref_map) ^^ { case aggSig ~ i ~ args => ir.InitOp(i, args, aggSig) } |
-      "SeqOp" ~> agg_signature ~ expr_with_map ~ ir_value_exprs(ref_map) ^^ { case aggSig ~ i ~ args => ir.SeqOp(i, args, aggSig) } |
-      "Begin" ~> ir_children(ref_map) ^^ { xs => ir.Begin(xs) } |
-      "MakeStruct" ~> ir_named_value_exprs(ref_map) ^^ { fields => ir.MakeStruct(fields) } |
-      "SelectFields" ~> ir_identifiers ~ expr_with_map ^^ { case fields ~ old => ir.SelectFields(old, fields) } |
-      "InsertFields" ~> expr_with_map ~ ir_named_value_exprs(ref_map) ^^ { case old ~ fields => ir.InsertFields(old, fields) } |
-      "GetField" ~> ir_identifier ~ expr_with_map ^^ { case name ~ o => ir.GetField(o, name) } |
-      "MakeTuple" ~> ir_children(ref_map) ^^ { xs => ir.MakeTuple(xs) } |
-      "GetTupleElement" ~> int32_literal ~ expr_with_map ^^ { case idx ~ o => ir.GetTupleElement(o, idx) } |
-      "StringSlice" ~> expr_with_map ~ expr_with_map ~ expr_with_map ^^ { case s ~ start ~ end => ir.StringSlice(s, start, end) } |
-      "StringLength" ~> expr_with_map ^^ { s => ir.StringLength(s) } |
+      "Ref" ~> ir_identifier ^^ { name => ir.Ref(name, IRParserEnvironment.theEnv.ref_map(name)) } |
+      "ApplyBinaryPrimOp" ~> ir_binary_op ~ ir_value_expr ~ ir_value_expr ^^ { case op ~ l ~ r => ir.ApplyBinaryPrimOp(op, l, r) } |
+      "ApplyUnaryPrimOp" ~> ir_unary_op ~ ir_value_expr ^^ { case op ~ x => ir.ApplyUnaryPrimOp(op, x) } |
+      "ApplyComparisonOp" ~> ir_comparison_op ~ ir_value_expr ~ ir_value_expr ^^ { case op ~ l ~ r => ir.ApplyComparisonOp(op, l, r) } |
+      "ApplyComparisonOp" ~> ir_untyped_comparison_op ~ ir_value_expr ~ ir_value_expr ^^ { case op ~ l ~ r => ir.ApplyComparisonOp(ir.ComparisonOp.fromStringAndTypes(op, l.typ, r.typ), l, r) } |
+      "MakeArray" ~> type_expr ~ ir_children ^^ { case t ~ args => ir.MakeArray(args, t.asInstanceOf[TArray]) } |
+      "ArrayRef" ~> ir_value_expr ~ ir_value_expr ^^ { case a ~ i => ir.ArrayRef(a, i) } |
+      "ArrayLen" ~> ir_value_expr ^^ { a => ir.ArrayLen(a) } |
+      "ArrayRange" ~> ir_value_expr ~ ir_value_expr ~ ir_value_expr ^^ { case start ~ stop ~ step => ir.ArrayRange(start, stop, step) } |
+      "ArraySort" ~> boolean_literal ~ ir_value_expr ~ ir_value_expr ^^ { case onKey ~ a ~ ascending => ir.ArraySort(a, ascending, onKey) } |
+      "ToSet" ~> ir_value_expr ^^ { a => ir.ToSet(a) } |
+      "ToDict" ~> ir_value_expr ^^ { a => ir.ToDict(a) } |
+      "ToArray" ~> ir_value_expr ^^ { a => ir.ToArray(a) } |
+      "LowerBoundOnOrderedCollection" ~> boolean_literal ~ ir_value_expr ~ ir_value_expr ^^ { case onKey ~ col ~ elem => ir.LowerBoundOnOrderedCollection(col, elem, onKey) } |
+      "GroupByKey" ~> ir_value_expr ^^ { a => ir.GroupByKey(a) } |
+      "ArrayMap" ~> ir_identifier ~ ir_value_expr ~ ir_value_expr ^^ { case name ~ a ~ body => ir.ArrayMap(a, name, body) } |
+      "ArrayFilter" ~> ir_identifier ~ ir_value_expr ~ ir_value_expr ^^ { case name ~ a ~ body => ir.ArrayFilter(a, name, body) } |
+      "ArrayFlatMap" ~> ir_identifier ~ ir_value_expr ~ ir_value_expr ^^ { case name ~ a ~ body => ir.ArrayFlatMap(a, name, body) } |
+      "ArrayFold" ~> ir_identifier ~ ir_identifier ~ ir_value_expr ~ ir_value_expr ~ ir_value_expr ^^ { case accumName ~ valueName ~ a ~ zero ~ body => ir.ArrayFold(a, zero, accumName, valueName, body) } |
+      "ArrayFor" ~> ir_identifier ~ ir_value_expr ~ ir_value_expr ^^ { case name ~ a ~ body => ir.ArrayFor(a, name, body) } |
+      "ApplyAggOp" ~> agg_signature ~ ir_value_expr ~ ir_value_exprs ~ ir_value_exprs_opt ^^ { case aggSig ~ a ~ ctorArgs ~ initOpArgs => ir.ApplyAggOp(a, ctorArgs, initOpArgs, aggSig) } |
+      "ApplyScanOp" ~> agg_signature ~ ir_value_expr ~ ir_value_exprs ~ ir_value_exprs_opt ^^ { case aggSig ~ a ~ ctorArgs ~ initOpArgs => ir.ApplyScanOp(a, ctorArgs, initOpArgs, aggSig) } |
+      "InitOp" ~> agg_signature ~ ir_value_expr ~ ir_value_exprs ^^ { case aggSig ~ i ~ args => ir.InitOp(i, args, aggSig) } |
+      "SeqOp" ~> agg_signature ~ ir_value_expr ~ ir_value_exprs ^^ { case aggSig ~ i ~ args => ir.SeqOp(i, args, aggSig) } |
+      "Begin" ~> ir_children ^^ { xs => ir.Begin(xs) } |
+      "MakeStruct" ~> ir_named_value_exprs ^^ { fields => ir.MakeStruct(fields) } |
+      "SelectFields" ~> ir_identifiers ~ ir_value_expr ^^ { case fields ~ old => ir.SelectFields(old, fields) } |
+      "InsertFields" ~> ir_value_expr ~ ir_named_value_exprs ^^ { case old ~ fields => ir.InsertFields(old, fields) } |
+      "GetField" ~> ir_identifier ~ ir_value_expr ^^ { case name ~ o => ir.GetField(o, name) } |
+      "MakeTuple" ~> ir_children ^^ { xs => ir.MakeTuple(xs) } |
+      "GetTupleElement" ~> int32_literal ~ ir_value_expr ^^ { case idx ~ o => ir.GetTupleElement(o, idx) } |
+      "StringSlice" ~> ir_value_expr ~ ir_value_expr ~ ir_value_expr ^^ { case s ~ start ~ end => ir.StringSlice(s, start, end) } |
+      "StringLength" ~> ir_value_expr ^^ { s => ir.StringLength(s) } |
       "In" ~> type_expr ~ int32_literal ^^ { case t ~ i => ir.In(i, t) } |
       "Die" ~> type_expr ~ string_literal ^^ { case t ~ message => ir.Die(message, t) } |
-      "ApplySeeded" ~> ir_identifier ~ int64_literal ~ ir_children(ref_map) ^^ { case function ~ seed ~ args => ir.ApplySeeded(function, args, seed) } |
-      ("ApplyIR" | "ApplySpecial" | "Apply") ~> ir_identifier ~ ir_children(ref_map) ^^ { case function ~ args => ir.invoke(function, args: _*) } |
-      "Uniroot" ~> ir_identifier ~ expr_with_map ~ expr_with_map ~ expr_with_map ^^ { case name ~ f ~ min ~ max => ir.Uniroot(name, f, min, max) }
+      "ApplySeeded" ~> ir_identifier ~ int64_literal ~ ir_children ^^ { case function ~ seed ~ args => ir.ApplySeeded(function, args, seed) } |
+      ("ApplyIR" | "ApplySpecial" | "Apply") ~> ir_identifier ~ ir_children ^^ { case function ~ args => ir.invoke(function, args: _*) } |
+      "Uniroot" ~> ir_identifier ~ ir_value_expr ~ ir_value_expr ~ ir_value_expr ^^ { case name ~ f ~ min ~ max => ir.Uniroot(name, f, min, max) } |
+      "CachedValue" ~> ir_identifier ^^ { name => IRParserEnvironment.theEnv.ir_map(name).asInstanceOf[IR] }
   }
-
 
   def ir_value: Parser[(Type, Any)] = type_expr ~ string_literal ^^ { case t ~ vJSONStr =>
     val vJSON = JsonMethods.parse(vJSONStr)
@@ -584,23 +611,24 @@ object Parser extends JavaTokenParsers {
     _.toFastIndexedSeq
   }
 
-  def table_ir_1: Parser[ir.TableIR] =
-  // FIXME TableImport
+  def table_ir_1: Parser[ir.TableIR] = {
+    // FIXME TableImport
     "TableUnkey" ~> table_ir ^^ { t => ir.TableUnkey(t) } |
       "TableKeyBy" ~> ir_identifiers ~ boolean_literal ~ table_ir ^^ { case key ~ isSorted ~ child =>
         ir.TableKeyBy(child, key, isSorted)
       } |
       "TableDistinct" ~> table_ir ^^ { t => ir.TableDistinct(t) } |
-      "TableFilter" ~> table_ir ~ ir_value_expr() ^^ { case child ~ pred => ir.TableFilter(child, pred) } |
+      "TableFilter" ~> table_ir ~ ir_value_expr ^^ { case child ~ pred => ir.TableFilter(child, pred) } |
       "TableRead" ~> string_literal ~ boolean_literal ~ ir_opt(table_type_expr) ^^ { case path ~ dropRows ~ typ =>
         TableIR.read(HailContext.get, path, dropRows, typ)
       } |
       "MatrixColsTable" ~> matrix_ir ^^ { child => ir.MatrixColsTable(child) } |
       "MatrixRowsTable" ~> matrix_ir ^^ { child => ir.MatrixRowsTable(child) } |
       "MatrixEntriesTable" ~> matrix_ir ^^ { child => ir.MatrixEntriesTable(child) } |
-      "TableAggregateByKey" ~> table_ir ~ ir_value_expr() ^^ { case child ~ expr => ir.TableAggregateByKey(child, expr) } |
-      "TableKeyByAndAggregate" ~> int32_literal_opt ~ int32_literal ~ table_ir ~ ir_value_expr() ~ ir_value_expr() ^^ {
-        case nPartitions ~ bufferSize ~ child ~ expr ~ newKey => ir.TableKeyByAndAggregate(child, expr, newKey, nPartitions, bufferSize) } |
+      "TableAggregateByKey" ~> table_ir ~ ir_value_expr ^^ { case child ~ expr => ir.TableAggregateByKey(child, expr) } |
+      "TableKeyByAndAggregate" ~> int32_literal_opt ~ int32_literal ~ table_ir ~ ir_value_expr ~ ir_value_expr ^^ {
+        case nPartitions ~ bufferSize ~ child ~ expr ~ newKey => ir.TableKeyByAndAggregate(child, expr, newKey, nPartitions, bufferSize)
+      } |
       "TableRepartition" ~> int32_literal ~ boolean_literal ~ table_ir ^^ { case n ~ shuffle ~ child => ir.TableRepartition(child, n, shuffle) } |
       "TableHead" ~> int64_literal ~ table_ir ^^ { case n ~ child => ir.TableHead(child, n) } |
       "TableJoin" ~> ir_identifier ~ table_ir ~ table_ir ^^ { case joinType ~ left ~ right => ir.TableJoin(left, right, joinType) } |
@@ -608,10 +636,10 @@ object Parser extends JavaTokenParsers {
       "TableParallelize" ~> table_type_expr ~ ir_value ~ int32_literal_opt ^^ { case typ ~ ((rowsType, rows)) ~ nPartitions =>
         ir.TableParallelize(typ, rows.asInstanceOf[IndexedSeq[Row]], nPartitions)
       } |
-      "TableMapRows" ~> string_literals_opt ~ int32_literal_opt ~ table_ir ~ ir_value_expr() ^^ { case newKey ~ preservedKeyFields ~ child ~ newRow =>
+      "TableMapRows" ~> string_literals_opt ~ int32_literal_opt ~ table_ir ~ ir_value_expr ^^ { case newKey ~ preservedKeyFields ~ child ~ newRow =>
         ir.TableMapRows(child, newRow, newKey, preservedKeyFields)
       } |
-      "TableMapGlobals" ~> table_ir ~ ir_value_expr() ^^ { case child ~ newRow =>
+      "TableMapGlobals" ~> table_ir ~ ir_value_expr ^^ { case child ~ newRow =>
         ir.TableMapGlobals(child, newRow)
       } |
       "TableRange" ~> int32_literal ~ int32_literal ^^ { case n ~ nPartitions => ir.TableRange(n, nPartitions) } |
@@ -623,31 +651,31 @@ object Parser extends JavaTokenParsers {
           else
             SortField(i.substring(1), Descending)))
       } |
-      "TableExplode" ~> identifier ~ table_ir ^^ { case field ~ child => ir.TableExplode(child, field) } |
+      "TableExplode" ~> ir_identifier ~ table_ir ^^ { case field ~ child => ir.TableExplode(child, field) } |
       "LocalizeEntries" ~> string_literal ~ matrix_ir ^^ { case field ~ child =>
         ir.LocalizeEntries(child, field)
-      }
+      } |
+      "CachedTable" ~> ir_identifier ^^ { ident => IRParserEnvironment.theEnv.ir_map(ident).asInstanceOf[TableIR] }
+  }
 
   def matrix_ir: Parser[ir.MatrixIR] = "(" ~> matrix_ir_1 <~ ")"
 
-  def matrix_ir_1: Parser[ir.MatrixIR] =
-    "MatrixFilterCols" ~> matrix_ir ~ ir_value_expr() ^^ { case child ~ pred => ir.MatrixFilterCols(child, pred) } |
-      "MatrixFilterRows" ~> matrix_ir ~ ir_value_expr() ^^ { case child ~ pred => ir.MatrixFilterRows(child, pred) } |
-      "MatrixFilterEntries" ~> matrix_ir ~ ir_value_expr() ^^ { case child ~ pred => ir.MatrixFilterEntries(child, pred) } |
-      "MatrixMapCols" ~> string_literals_opt ~ matrix_ir ~ ir_value_expr() ^^ { case newKey ~ child ~ newCol => ir.MatrixMapCols(child, newCol, newKey) } |
-      "MatrixMapRows" ~> string_literals_opt ~ string_literals_opt ~ matrix_ir ~ ir_value_expr() ^^ { case newKey ~ newPartitionKey ~ child ~ newRow =>
+  def matrix_ir_1: Parser[ir.MatrixIR] = {
+    "MatrixFilterCols" ~> matrix_ir ~ ir_value_expr ^^ { case child ~ pred => ir.MatrixFilterCols(child, pred) } |
+      "MatrixFilterRows" ~> matrix_ir ~ ir_value_expr ^^ { case child ~ pred => ir.MatrixFilterRows(child, pred) } |
+      "MatrixFilterEntries" ~> matrix_ir ~ ir_value_expr ^^ { case child ~ pred => ir.MatrixFilterEntries(child, pred) } |
+      "MatrixMapCols" ~> string_literals_opt ~ matrix_ir ~ ir_value_expr ^^ { case newKey ~ child ~ newCol => ir.MatrixMapCols(child, newCol, newKey) } |
+      "MatrixMapRows" ~> string_literals_opt ~ string_literals_opt ~ matrix_ir ~ ir_value_expr ^^ { case newKey ~ newPartitionKey ~ child ~ newRow =>
         val newKPK = ((newKey, newPartitionKey): @unchecked) match {
           case (Some(k), Some(pk)) => Some((k, pk))
           case (None, None) => None
         }
         ir.MatrixMapRows(child, newRow, newKPK)
       } |
-      "MatrixMapEntries" ~> matrix_ir ~ ir_value_expr() ^^ { case child ~ newEntries => ir.MatrixMapEntries(child, newEntries) } |
-      "MatrixMapGlobals" ~> matrix_ir ~ ir_value_expr() ^^ { case child ~ newGlobals =>
-        ir.MatrixMapGlobals(child, newGlobals)
-      } |
-      "MatrixAggregateColsByKey" ~> matrix_ir ~ ir_value_expr() ^^ { case child ~ agg => ir.MatrixAggregateColsByKey(child, agg) } |
-      "MatrixAggregateRowsByKey" ~> matrix_ir ~ ir_value_expr() ^^ { case child ~ agg => ir.MatrixAggregateRowsByKey(child, agg) } |
+      "MatrixMapEntries" ~> matrix_ir ~ ir_value_expr ^^ { case child ~ newEntries => ir.MatrixMapEntries(child, newEntries) } |
+      "MatrixMapGlobals" ~> matrix_ir ~ ir_value_expr ^^ { case child ~ newGlobals => ir.MatrixMapGlobals(child, newGlobals) } |
+      "MatrixAggregateColsByKey" ~> matrix_ir ~ ir_value_expr ^^ { case child ~ agg => ir.MatrixAggregateColsByKey(child, agg) } |
+      "MatrixAggregateRowsByKey" ~> matrix_ir ~ ir_value_expr ^^ { case child ~ agg => ir.MatrixAggregateRowsByKey(child, agg) } |
       "MatrixRead" ~> matrix_type_expr_opt ~ boolean_literal ~ boolean_literal ~ string_literal ^^ {
         case typ ~ dropCols ~ dropRows ~ readerStr =>
           implicit val formats = ir.MatrixReader.formats
@@ -658,7 +686,7 @@ object Parser extends JavaTokenParsers {
         case rowKey ~ colKey ~ rowFields ~ colFields ~ partitionKey ~ nPartitions ~ child =>
           ir.TableToMatrixTable(child, rowKey, colKey, rowFields, colFields, partitionKey, nPartitions)
       } |
-      "MatrixAnnotateRowsTable" ~> string_literal ~ boolean_literal ~ matrix_ir ~ table_ir ~ rep(ir_value_expr()) ^^ {
+      "MatrixAnnotateRowsTable" ~> string_literal ~ boolean_literal ~ matrix_ir ~ table_ir ~ rep(ir_value_expr) ^^ {
         case uid ~ hasKey ~ child ~ table ~ key =>
           val keyIRs = if (hasKey) Some(key.toFastIndexedSeq) else None
           ir.MatrixAnnotateRowsTable(child, table, uid, keyIRs)
@@ -667,23 +695,23 @@ object Parser extends JavaTokenParsers {
         case root ~ child ~ table =>
           ir.MatrixAnnotateColsTable(child, table, root)
       } |
-      "MatrixExplodeRows" ~> ir_identifiers ~ matrix_ir ^^ { case path ~ child => ir.MatrixExplodeRows(child, path)} |
-      "MatrixExplodeCols" ~> ir_identifiers ~ matrix_ir ^^ { case path ~ child => ir.MatrixExplodeCols(child, path)} |
+      "MatrixExplodeRows" ~> ir_identifiers ~ matrix_ir ^^ { case path ~ child => ir.MatrixExplodeRows(child, path) } |
+      "MatrixExplodeCols" ~> ir_identifiers ~ matrix_ir ^^ { case path ~ child => ir.MatrixExplodeCols(child, path) } |
       "MatrixChooseCols" ~> int32_literals ~ matrix_ir ^^ { case oldIndices ~ child => ir.MatrixChooseCols(child, oldIndices) } |
       "MatrixCollectColsByKey" ~> matrix_ir ^^ { child => ir.MatrixCollectColsByKey(child) } |
       "MatrixUnionRows" ~> matrix_ir_children ^^ { children => ir.MatrixUnionRows(children) } |
       "UnlocalizeEntries" ~> string_literal ~ table_ir ~ table_ir ^^ {
         case entryField ~ rowsEntries ~ cols => ir.UnlocalizeEntries(rowsEntries, cols, entryField)
-      }
+      } |
+      "CachedMatrixTable" ~> ir_identifier ^^ { ident => IRParserEnvironment.theEnv.ir_map(ident).asInstanceOf[MatrixIR] }
+  }
 
-  def parse_value_ir(s: String, ref_map: Map[String, Type]): IR = parse(ir_value_expr(ref_map), s)
+  def parse_value_ir(s: String, env: IRParserEnvironment = IRParserEnvironment()): IR = parseWithEnv(ir_value_expr, s, env)
 
-  def parse_value_ir(s: String): IR = parse_value_ir(s, Map.empty)
+  def parse_named_value_irs(s: String, env: IRParserEnvironment = IRParserEnvironment()): Array[(String, IR)] =
+    parseWithEnv(ir_named_value_exprs, s, env).toArray
 
-  def parse_named_value_irs(s: String, ref_map: Map[String, Type] = Map.empty): Array[(String, IR)] =
-    parse(ir_named_value_exprs(ref_map), s).toArray
+  def parse_table_ir(s: String, env: IRParserEnvironment = IRParserEnvironment()): TableIR = parseWithEnv(table_ir, s, env)
 
-  def parse_table_ir(s: String): TableIR = parse(table_ir, s)
-
-  def parse_matrix_ir(s: String): MatrixIR = parse(matrix_ir, s)
+  def parse_matrix_ir(s: String, env: IRParserEnvironment = IRParserEnvironment()): MatrixIR = parseWithEnv(matrix_ir, s, env)
 }

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -406,7 +406,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
   }
 
   def aggregate(expr: String): (Any, Type) =
-    aggregate(Parser.parse_value_ir(expr, typ.refMap))
+    aggregate(Parser.parse_value_ir(expr, IRParserEnvironment(typ.refMap)))
 
   def aggregate(query: IR): (Any, Type) = {
     val t = ir.TableAggregate(tir, query)
@@ -419,12 +419,12 @@ class Table(val hc: HailContext, val tir: TableIR) {
   }
 
   def selectGlobal(expr: String): Table = {
-    val ir = Parser.parse_value_ir(expr, typ.refMap)
+    val ir = Parser.parse_value_ir(expr, IRParserEnvironment(typ.refMap))
     new Table(hc, TableMapGlobals(tir, ir))
   }
 
   def filter(cond: String, keep: Boolean): Table = {
-    var irPred = Parser.parse_value_ir(cond, typ.refMap)
+    var irPred = Parser.parse_value_ir(cond, IRParserEnvironment(typ.refMap))
     new Table(hc,
       TableFilter(tir, ir.filterPredicateWithKeep(irPred, keep)))
   }
@@ -464,7 +464,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
     select(expr, Option(newKey).map(_.asScala.toFastIndexedSeq), Option(preservedKeyFields).map(_.toInt))
 
   def select(expr: String, newKey: Option[IndexedSeq[String]], preservedKeyFields: Option[Int]): Table = {
-    val ir = Parser.parse_value_ir(expr, typ.refMap)
+    val ir = Parser.parse_value_ir(expr, IRParserEnvironment(typ.refMap))
     new Table(hc, TableMapRows(tir, ir, newKey, preservedKeyFields))
   }
 
@@ -517,8 +517,8 @@ class Table(val hc: HailContext, val tir: TableIR) {
 
   def keyByAndAggregate(expr: String, key: String, nPartitions: Option[Int], bufferSize: Int): Table = {
     new Table(hc, TableKeyByAndAggregate(tir,
-      Parser.parse_value_ir(expr, typ.refMap),
-      Parser.parse_value_ir(key, typ.refMap),
+      Parser.parse_value_ir(expr, IRParserEnvironment(typ.refMap)),
+      Parser.parse_value_ir(key, IRParserEnvironment(typ.refMap)),
       nPartitions,
       bufferSize
     ))
@@ -528,7 +528,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
     new MatrixTable(hc, UnlocalizeEntries(tir, cols.tir, entriesFieldName))
 
   def aggregateByKey(expr: String): Table = {
-    val x = Parser.parse_value_ir(expr, typ.refMap)
+    val x = Parser.parse_value_ir(expr, IRParserEnvironment(typ.refMap))
     new Table(hc, TableAggregateByKey(tir, x))
   }
 

--- a/src/main/scala/is/hail/utils/Graph.scala
+++ b/src/main/scala/is/hail/utils/Graph.scala
@@ -3,7 +3,7 @@ package is.hail.utils
 import is.hail.annotations.{Region, RegionValueBuilder, SafeRow}
 import is.hail.expr.ir.{Compile, MakeTuple}
 import is.hail.expr.types._
-import is.hail.expr.{EvalContext, Parser}
+import is.hail.expr.{EvalContext, IRParserEnvironment, Parser}
 import org.apache.spark.sql.Row
 
 import scala.collection.mutable
@@ -46,7 +46,7 @@ object Graph {
     val refMap = Map("l" -> wrappedNodeType, "r" -> wrappedNodeType)
 
     val tieBreakerF = tieBreaker.map { e =>
-      val ir = Parser.parse_value_ir(e, refMap)
+      val ir = Parser.parse_value_ir(e, IRParserEnvironment(refMap))
       val (t, f) = Compile[Long, Long, Long]("l", wrappedNodeType, "r", wrappedNodeType, MakeTuple(FastSeq(ir)))
       assert(t.isOfType(TTuple(TInt64())))
 

--- a/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -502,13 +502,13 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   def collectColsByKey(): MatrixTable = new MatrixTable(hc, MatrixCollectColsByKey(ast))
 
   def aggregateColsByKey(aggExpr: String): MatrixTable = {
-    val aggIR = Parser.parse_value_ir(aggExpr, matrixType.refMap)
+    val aggIR = Parser.parse_value_ir(aggExpr, IRParserEnvironment(matrixType.refMap))
     new MatrixTable(hc, MatrixAggregateColsByKey(ast, aggIR))
   }
 
   def aggregateRowsByKey(expr: String): MatrixTable = {
     log.info(expr)
-    val rowsIR = Parser.parse_value_ir(expr, matrixType.refMap)
+    val rowsIR = Parser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
     new MatrixTable(hc, MatrixAggregateRowsByKey(ast, rowsIR))
   }
 
@@ -601,17 +601,17 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
   def annotateRowsTableIR(table: Table, uid: String, irs: java.util.ArrayList[String]): MatrixTable = {
-    val refMap = matrixType.refMap
+    val parseEnv = IRParserEnvironment(matrixType.refMap)
     val key = Option(irs).map { irs =>
       irs.asScala
         .toFastIndexedSeq
-        .map(Parser.parse_value_ir(_, refMap))
+        .map(Parser.parse_value_ir(_, parseEnv))
     }
     new MatrixTable(hc, MatrixAnnotateRowsTable(ast, table.tir, uid, key))
   }
 
   def selectGlobals(expr: String): MatrixTable = {
-    val globalIR = Parser.parse_value_ir(expr, matrixType.refMap)
+    val globalIR = Parser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
     new MatrixTable(hc, MatrixMapGlobals(ast, globalIR))
   }
 
@@ -619,7 +619,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     selectCols(expr, Option(newKey).map(_.asScala.toFastIndexedSeq))
 
   def selectCols(expr: String, newKey: Option[IndexedSeq[String]]): MatrixTable = {
-    val ir = Parser.parse_value_ir(expr, matrixType.refMap)
+    val ir = Parser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
     val newColKey = newKey.getOrElse(colKey)
     new MatrixTable(hc, MatrixMapCols(ast, ir, newKey))
   }
@@ -630,12 +630,12 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
   def selectRows(expr: String, newKey: Option[(IndexedSeq[String], IndexedSeq[String])]): MatrixTable = {
-    val rowsIR = Parser.parse_value_ir(expr, matrixType.refMap)
+    val rowsIR = Parser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
     new MatrixTable(hc, MatrixMapRows(ast, rowsIR, newKey))
   }
 
   def selectEntries(expr: String): MatrixTable = {
-    val ir = Parser.parse_value_ir(expr, matrixType.refMap)
+    val ir = Parser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
     new MatrixTable(hc, MatrixMapEntries(ast, ir))
   }
 
@@ -696,13 +696,13 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
   def filterColsExpr(filterExpr: String, keep: Boolean = true): MatrixTable = {
-    var irPred = Parser.parse_value_ir(filterExpr, matrixType.refMap)
+    var irPred = Parser.parse_value_ir(filterExpr, IRParserEnvironment(matrixType.refMap))
     new MatrixTable(hc,
       MatrixFilterCols(ast, ir.filterPredicateWithKeep(irPred, keep)))
   }
 
   def filterRowsExpr(filterExpr: String, keep: Boolean = true): MatrixTable = {
-    var irPred = Parser.parse_value_ir(filterExpr, matrixType.refMap)
+    var irPred = Parser.parse_value_ir(filterExpr, IRParserEnvironment(matrixType.refMap))
     new MatrixTable(hc,
       MatrixFilterRows(ast, ir.filterPredicateWithKeep(irPred, keep)))
   }
@@ -933,12 +933,12 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
   def aggregateEntries(expr: String): (Annotation, Type) = {
-    val qir = Parser.parse_value_ir(expr, matrixType.refMap)
+    val qir = Parser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
     (Interpret(MatrixAggregate(ast, qir)), qir.typ)
   }
 
   def aggregateCols(expr: String): (Annotation, Type) = {
-    val qir = Parser.parse_value_ir(expr, matrixType.refMap)
+    val qir = Parser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
     val ct = colsTable()
     val aggEnv = new ir.Env[ir.IR].bind("sa" -> ir.Ref("row", ct.typ.rowType))
     val sqir = ir.Subst(qir.unwrap, ir.Env.empty, aggEnv)
@@ -946,7 +946,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
   def aggregateRows(expr: String): (Annotation, Type) = {
-    val qir = Parser.parse_value_ir(expr, matrixType.refMap)
+    val qir = Parser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
     val rt = rowsTable()
     val aggEnv = new ir.Env[ir.IR].bind("va" -> ir.Ref("row", rt.typ.rowType))
     val sqir = ir.Subst(qir.unwrap, ir.Env.empty, aggEnv)
@@ -1283,7 +1283,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
   def filterEntries(filterExpr: String, keep: Boolean = true): MatrixTable = {
-    val filterIR = Parser.parse_value_ir(filterExpr, matrixType.refMap)
+    val filterIR = Parser.parse_value_ir(filterExpr, IRParserEnvironment(matrixType.refMap))
     new MatrixTable(hc, MatrixFilterEntries(ast, ir.filterPredicateWithKeep(filterIR, keep)))
   }
 

--- a/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -5,7 +5,7 @@ import is.hail.expr.types._
 import is.hail.TestUtils._
 import is.hail.annotations.BroadcastRow
 import is.hail.asm4s.Code
-import is.hail.expr.Parser
+import is.hail.expr.{IRParserEnvironment, Parser}
 import is.hail.expr.ir.IRSuite.TestFunctions
 import is.hail.expr.ir.functions.{IRFunctionRegistry, RegistryFunctions, SeededIRFunction}
 import is.hail.io.vcf.LoadVCF
@@ -650,22 +650,44 @@ class IRSuite extends SparkSuite {
   @Test(dataProvider = "valueIRs")
   def testValueIRParser(x: IR) {
     val s = Pretty(x)
-    val x2 = Parser.parse(Parser.ir_value_expr(), s)
+    val x2 = Parser.parse_value_ir(s, IRParserEnvironment())
     assert(x2 == x)
   }
 
   @Test(dataProvider = "tableIRs")
   def testTableIRParser(x: TableIR) {
     val s = Pretty(x)
-    val x2 = Parser.parse(Parser.table_ir, s)
+    val x2 = Parser.parse_table_ir(s, IRParserEnvironment())
     assert(x2 == x)
   }
 
   @Test(dataProvider = "matrixIRs")
   def testMatrixIRParser(x: MatrixIR) {
     val s = Pretty(x)
-    val x2 = Parser.parse(Parser.matrix_ir, s)
+    val x2 = Parser.parse_matrix_ir(s, IRParserEnvironment())
     assert(x2 == x)
+  }
+
+  @Test def testCachedIR() {
+    val cached = Literal(TSet(TInt32()), Set(1), "__unique_id")
+    val s = s"(CachedValue __uid1)"
+    val x2 = Parser.parse_value_ir(s, IRParserEnvironment(ref_map = Map.empty, ir_map = Map("__uid1" -> cached)))
+    assert(x2 eq cached)
+  }
+
+  @Test def testCachedTableIR() {
+    val cached = TableRange(1, 1)
+    val s = s"(CachedTable __uid1)"
+    val x2 = Parser.parse_table_ir(s, IRParserEnvironment(ref_map = Map.empty, ir_map = Map("__uid1" -> cached)))
+    assert(x2 eq cached)
+  }
+
+  @Test def testCachedMatrixIR() {
+    val cached = MatrixTable.range(hc, 3, 7, None).ast
+    val s = s"(CachedMatrixTable __uid1)"
+    val x2 = Parser.parse_matrix_ir(s, IRParserEnvironment(ref_map = Map.empty, ir_map = Map("__uid1" -> cached)))
+    assert(x2 eq cached)
+
   }
 
   @Test def testEvaluations() {


### PR DESCRIPTION
This is one of the first steps in building out relational IR generation
from Python. We need the ability to store IR nodes in a JVM map because
of things like MatrixLiteral and TableLiteral.