### PR TITLE
Add hail-ci-deploy.sh for master

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -440,29 +440,3 @@ task createPackage(type: Zip, dependsOn: ['assemblePackage']) {
     into 'hail'
     baseName 'hail'
 }
-
-task assemblePackageNoTest(type: Copy, dependsOn: ['makeDocsNoTest' , 'shadowJar']) {
-    from('python') {
-        into 'python'
-    }
-    from('build/www/docs') {
-        into 'docs'
-    }
-    from('scripts') {
-        into 'bin'
-    }
-    from('build/libs/hail-all-spark.jar') {
-        into 'jars'
-    }
-    from('python/hail/docs/tutorials') {
-        into 'tutorials'
-        include '*.ipynb'
-    }
-    into 'build/package'
-}
-
-task createPackageNoTest(type: Zip, dependsOn: ['assemblePackageNoTest']) {
-    from 'build/package'
-    into 'hail'
-    baseName 'hail'
-}

--- a/build.gradle
+++ b/build.gradle
@@ -440,3 +440,29 @@ task createPackage(type: Zip, dependsOn: ['assemblePackage']) {
     into 'hail'
     baseName 'hail'
 }
+
+task assemblePackageNoTest(type: Copy, dependsOn: ['makeDocsNoTest' , 'shadowJar']) {
+    from('python') {
+        into 'python'
+    }
+    from('build/www/docs') {
+        into 'docs'
+    }
+    from('scripts') {
+        into 'bin'
+    }
+    from('build/libs/hail-all-spark.jar') {
+        into 'jars'
+    }
+    from('python/hail/docs/tutorials') {
+        into 'tutorials'
+        include '*.ipynb'
+    }
+    into 'build/package'
+}
+
+task createPackageNoTest(type: Zip, dependsOn: ['assemblePackageNoTest']) {
+    from 'build/package'
+    into 'hail'
+    baseName 'hail'
+}

--- a/hail-ci-deploy.sh
+++ b/hail-ci-deploy.sh
@@ -15,7 +15,7 @@ GRADLE_OPTS=-Xmx2048m ./gradlew \
 SHA=$(git rev-parse --short=12 HEAD)
 
 # update jar, zip, and distribution
-GS_JAR=gs://hail-common/${BRANCH}/jars/hail-${BRANCH}-${SHA}-Spark-${SPARK_VERSION}.jar
+GS_JAR=gs://hail-common/builds/${BRANCH}/jars/hail-${BRANCH}-${SHA}-Spark-${SPARK_VERSION}.jar
 gsutil cp build/libs/hail-all-spark.jar ${GS_JAR}
 gsutil acl set public-read ${GS_JAR}
 

--- a/hail-ci-deploy.sh
+++ b/hail-ci-deploy.sh
@@ -20,7 +20,7 @@ gsutil cp build/libs/hail-all-spark.jar ${GS_JAR}
 gsutil acl set public-read ${GS_JAR}
 
 GS_HAIL_ZIP=gs://hail-common/builds/${BRANCH}/python/hail-${BRANCH}-${SHA}.zip
-gsutil cp build/libs/hail-all-spark.jar ${GS_HAIL_ZIP}
+gsutil cp build/distributions/hail-python.zip ${GS_HAIL_ZIP}
 gsutil acl set public-read ${GS_HAIL_ZIP}
 
 DISTRIBUTION=gs://hail-common/distributions/${BRANCH}/Hail-${BRANCH}-${SHA}-Spark-${SPARK_VERSION}.zip

--- a/hail-ci-deploy.sh
+++ b/hail-ci-deploy.sh
@@ -36,8 +36,11 @@ gsutil acl set public-read ${HASH_TARGET}
 ## since we're interactive, we explicitly state the fingerprint for ci.hail.is
 mkdir -p ~/.ssh
 printf 'ci.hail.is ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3tuH5V3ubO7PqQ3gD2G7yFJ4bkwgSFNBqmaLmiuiCF86UpE4Lo4yQryt9VYssoLqsdStIOR0P/Bo3S4Nuj8cHCzAbft3/u25oa8lQKAazoiA0I82d7JXYurV/NvjH7O1MMuPohwjlBp+d4damUA3TO2oIHbYqzmArrvTs/k6DxUonWRRxZa0zW+edv78y6IdLXuSVyN5FPa+jWBMJar9CsvbsWUWtcJ8vHHldg0DJ7TFVecouy4U3hmQxi90OCGSk4N9vi+XC+EjoNeCmGt5/VGAnKCUZntOZluBqKKZ0/TWlC6HJgBWYQllnjAE1tFs9Xrrx+5ADB9quMtYVqk0R\n' \
-  >> ~/.ssh/known_hosts
+       >> ~/.ssh/known_hosts
+
 USER=web-updater
+IDENTITY_FILE=/secrets/ci.hail.is-web-updater-rsa-key
+
 rsync -rlv \
       -e "ssh -i /secrets/ci.hail.is-web-updater-rsa-key" \
       --exclude docs \
@@ -46,15 +49,20 @@ rsync -rlv \
       build/www/ \
       ${USER}@ci.hail.is:/var/www/html/ \
       --delete
+
 DEST=/var/www/html/docs/archive/${BRANCH}/$SHA
-ssh -i /secrets/ci.hail.is-web-updater-rsa-key \
+
+ssh -i ${IDENTITY_FILE} \
     ${USER}@ci.hail.is \
     mkdir -p $DEST
-scp -i /secrets/ci.hail.is-web-updater-rsa-key \
+
+scp -i ${IDENTITY_FILE} \
     -r build/www/docs/${BRANCH}/* \
     ${USER}@ci.hail.is:$DEST
-ssh -i /secrets/ci.hail.is-web-updater-rsa-key \
+
+ssh -i ${IDENTITY_FILE} \
     ${USER}@ci.hail.is \
     "rm -rf /var/www/html/docs/${BRANCH} && \
      ln -s $DEST /var/www/html/docs/${BRANCH} && \
-     chown :www-data $DEST /var/www/html/docs/${BRANCH}"
+     chgrp www-data $DEST /var/www/html/docs/${BRANCH}"
+

--- a/hail-ci-deploy.sh
+++ b/hail-ci-deploy.sh
@@ -27,9 +27,9 @@ DISTRIBUTION=gs://hail-common/distributions/${BRANCH}/Hail-${BRANCH}-${SHA}-Spar
 gsutil cp build/distributions/hail.zip $DISTRIBUTION
 gsutil acl set public-read $DISTRIBUTION
 
-echo ${SHA} > latest-hash-spark${SPARK_VERSION}.txt
+echo ${SHA} > latest-hash-spark-${SPARK_VERSION}.txt
 HASH_TARGET=gs://hail-common/builds/${BRANCH}/latest-hash-spark-${SPARK_VERSION}.txt
-gsutil cp ./latest-hash-spark${SPARK_VERSION}.txt ${HASH_TARGET}
+gsutil cp ./latest-hash-spark-${SPARK_VERSION}.txt ${HASH_TARGET}
 gsutil acl set public-read ${HASH_TARGET}
 
 # update website

--- a/hail-ci-deploy.sh
+++ b/hail-ci-deploy.sh
@@ -1,9 +1,39 @@
 set -ex
+
+SPARK_VERSION=2.2.0
+BRANCH=devel
+
 source activate hail
-GRADLE_OPTS=-Xmx2048m ./gradlew shadowJar archiveZip makeDocsNoTest --gradle-user-home /gradle-cache
+
+# build jar, zip, and distribution
+GRADLE_OPTS=-Xmx2048m ./gradlew \
+           shadowJar \
+           archiveZip \
+           makeDocsNoTest \
+           createPackageNoTest \
+           --gradle-user-home /gradle-cache
 SHA=$(git rev-parse --short=12 HEAD)
-gsutil cp build/libs/hail-all-spark.jar gs://hail-common/devel/jars/hail-devel-${SHA}-Spark-2.2.0.jar
-gsutil cp build/libs/hail-all-spark.jar gs://hail-common/devel/python/hail-devel-${SHA}.zip
+
+# update jar, zip, and distribution
+GS_JAR=gs://hail-common/${BRANCH}/jars/hail-${BRANCH}-${SHA}-Spark-${SPARK_VERSION}.jar
+gsutil cp build/libs/hail-all-spark.jar ${GS_JAR}
+gsutil acl set public-read ${GS_JAR}
+
+GS_HAIL_ZIP=gs://hail-common/builds/${BRANCH}/python/hail-${BRANCH}-${SHA}.zip
+gsutil cp build/libs/hail-all-spark.jar ${GS_HAIL_ZIP}
+gsutil acl set public-read ${GS_HAIL_ZIP}
+
+DISTRIBUTION=gs://hail-common/distributions/${BRANCH}/Hail-${BRANCH}-${SHA}-Spark-${SPARK_VERSION}.zip
+gsutil cp build/distributions/hail.zip $DISTRIBUTION
+gsutil acl set public-read $DISTRIBUTION
+
+echo ${SHA} > latest-hash-spark${SPARK_VERSION}.txt
+HASH_TARGET=gs://hail-common/builds/${BRANCH}/latest-hash-spark-${SPARK_VERSION}.txt
+gsutil cp ./latest-hash-spark${SPARK_VERSION}.txt ${HASH_TARGET}
+gsutil acl set public-read ${HASH_TARGET}
+
+# update website
+## since we're interactive, we explicitly state the fingerprint for ci.hail.is
 mkdir -p ~/.ssh
 printf 'ci.hail.is ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3tuH5V3ubO7PqQ3gD2G7yFJ4bkwgSFNBqmaLmiuiCF86UpE4Lo4yQryt9VYssoLqsdStIOR0P/Bo3S4Nuj8cHCzAbft3/u25oa8lQKAazoiA0I82d7JXYurV/NvjH7O1MMuPohwjlBp+d4damUA3TO2oIHbYqzmArrvTs/k6DxUonWRRxZa0zW+edv78y6IdLXuSVyN5FPa+jWBMJar9CsvbsWUWtcJ8vHHldg0DJ7TFVecouy4U3hmQxi90OCGSk4N9vi+XC+EjoNeCmGt5/VGAnKCUZntOZluBqKKZ0/TWlC6HJgBWYQllnjAE1tFs9Xrrx+5ADB9quMtYVqk0R\n' \
   >> ~/.ssh/known_hosts
@@ -16,15 +46,15 @@ rsync -rlv \
       build/www/ \
       ${USER}@ci.hail.is:/var/www/html/ \
       --delete
-DEST=/var/www/html/docs/archive/devel/$SHA
+DEST=/var/www/html/docs/archive/${BRANCH}/$SHA
 ssh -i /secrets/ci.hail.is-web-updater-rsa-key \
     ${USER}@ci.hail.is \
     mkdir -p $DEST
 scp -i /secrets/ci.hail.is-web-updater-rsa-key \
-    -r build/www/docs/devel/* \
+    -r build/www/docs/${BRANCH}/* \
     ${USER}@ci.hail.is:$DEST
 ssh -i /secrets/ci.hail.is-web-updater-rsa-key \
     ${USER}@ci.hail.is \
-    "rm -rf /var/www/html/docs/devel && \
-     ln -s $DEST /var/www/html/docs/devel && \
-     chown :www-data $DEST /var/www/html/docs/devel"
+    "rm -rf /var/www/html/docs/${BRANCH} && \
+     ln -s $DEST /var/www/html/docs/${BRANCH} && \
+     chown :www-data $DEST /var/www/html/docs/${BRANCH}"

--- a/hail-ci-deploy.sh
+++ b/hail-ci-deploy.sh
@@ -42,7 +42,7 @@ USER=web-updater
 IDENTITY_FILE=/secrets/ci.hail.is-web-updater-rsa-key
 
 rsync -rlv \
-      -e "ssh -i /secrets/ci.hail.is-web-updater-rsa-key" \
+      -e "ssh -i ${IDENTITY_FILE}" \
       --exclude docs \
       --exclude misc \
       --exclude tools \

--- a/hail-ci-deploy.sh
+++ b/hail-ci-deploy.sh
@@ -1,0 +1,30 @@
+set -ex
+source activate hail
+GRADLE_OPTS=-Xmx2048m ./gradlew shadowJar archiveZip makeDocsNoTest --gradle-user-home /gradle-cache
+SHA=$(git rev-parse --short=12 HEAD)
+gsutil cp build/libs/hail-all-spark.jar gs://hail-common/devel/jars/hail-devel-${SHA}-Spark-2.2.0.jar
+gsutil cp build/libs/hail-all-spark.jar gs://hail-common/devel/python/hail-devel-${SHA}.zip
+mkdir -p ~/.ssh
+printf 'ci.hail.is ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3tuH5V3ubO7PqQ3gD2G7yFJ4bkwgSFNBqmaLmiuiCF86UpE4Lo4yQryt9VYssoLqsdStIOR0P/Bo3S4Nuj8cHCzAbft3/u25oa8lQKAazoiA0I82d7JXYurV/NvjH7O1MMuPohwjlBp+d4damUA3TO2oIHbYqzmArrvTs/k6DxUonWRRxZa0zW+edv78y6IdLXuSVyN5FPa+jWBMJar9CsvbsWUWtcJ8vHHldg0DJ7TFVecouy4U3hmQxi90OCGSk4N9vi+XC+EjoNeCmGt5/VGAnKCUZntOZluBqKKZ0/TWlC6HJgBWYQllnjAE1tFs9Xrrx+5ADB9quMtYVqk0R\n' \
+  >> ~/.ssh/known_hosts
+USER=web-updater
+rsync -rlv \
+      -e "ssh -i /secrets/ci.hail.is-web-updater-rsa-key" \
+      --exclude docs \
+      --exclude misc \
+      --exclude tools \
+      build/www/ \
+      ${USER}@ci.hail.is:/var/www/html/ \
+      --delete
+DEST=/var/www/html/docs/archive/devel/$SHA
+ssh -i /secrets/ci.hail.is-web-updater-rsa-key \
+    ${USER}@ci.hail.is \
+    mkdir -p $DEST
+scp -i /secrets/ci.hail.is-web-updater-rsa-key \
+    -r build/www/docs/devel/* \
+    ${USER}@ci.hail.is:$DEST
+ssh -i /secrets/ci.hail.is-web-updater-rsa-key \
+    ${USER}@ci.hail.is \
+    "rm -rf /var/www/html/docs/devel && \
+     ln -s $DEST /var/www/html/docs/devel && \
+     chown :www-data $DEST /var/www/html/docs/devel"

--- a/hail-ci-deploy.sh
+++ b/hail-ci-deploy.sh
@@ -9,8 +9,8 @@ source activate hail
 GRADLE_OPTS=-Xmx2048m ./gradlew \
            shadowJar \
            archiveZip \
-           makeDocsNoTest \
-           createPackageNoTest \
+           makeDocs \
+           createPackage \
            --gradle-user-home /gradle-cache
 SHA=$(git rev-parse --short=12 HEAD)
 


### PR DESCRIPTION
A forthcoming change to the hail ci system will introduce deployment. This change adds `hail-ci-deploy.sh` which replicates the ["Deploy Website"](https://ci.hail.is/admin/editRunType.html?id=buildType:HailSourceCode_HailMainline_DeployWebsite&runnerId=RUNNER_29) and ["Deploy Google Cloud"](https://ci.hail.is/admin/editRunType.html?id=buildType:HailSourceCode_HailMainline_DeployDocsAndGoogleCloudSpark220&runnerId=RUNNER_10) TeamCity jobs.

My general thinking for deploy jobs from the CI is that, for the time being, we'll hardcode a mapping from GitHub repository to [Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/). That's where this `/secret/ci.hail.is-web-updater-rsa-key` will come from. Moreover, the CI will always authorize a gcloud account (again with a baked in mapping from GitHub repository to GCP service account) before calling the deploy script.

I did not retest the master branch here. Should we do that even though a PR is only merged to master if it passes the tests? Even after locking down merging, there's still the possibility of CI bugs. cc: @cseed 