### PR TITLE
Update the PR image

### DIFF
--- a/Dockerfile.pr-builder
+++ b/Dockerfile.pr-builder
@@ -57,10 +57,10 @@ USER hail
 #
 # Some plugin we use hides its dependencies in a so-called "detached
 # configuration" so there is no way for us to ensure it gets cached.
-COPY --chown hail:hail gradlew build.gradle settings.gradle deployed-spark-versions.txt ./
-COPY --chown hail:hail gradle gradle
+COPY --chown=hail:hail gradlew build.gradle settings.gradle deployed-spark-versions.txt ./
+COPY --chown=hail:hail gradle gradle
 RUN ./gradlew downloadDependencies --gradle-user-home /gradle-cache
-COPY --chown hail:hail python/hail/dev-environment.yml python/hail/dev-environment.yml
+COPY --chown=hail:hail python/hail/dev-environment.yml python/hail/dev-environment.yml
 RUN conda env create hail -f ./python/hail/dev-environment.yml && \
     rm -rf /home/hail/.conda/pkgs/*
 

--- a/Dockerfile.pr-builder
+++ b/Dockerfile.pr-builder
@@ -41,11 +41,21 @@ RUN tar --strip-components=1 -xvzf qctool_v2.0.1-CentOS6.8-x86_64.tgz -C /qctool
     rm -rf qctool_v2.0.1-CentOS6.8-x86_64.tgz && \
     ln -s /qctool/qctool /bin/qctool
 
+WORKDIR /spark
+ADD https://archive.apache.org/dist/spark/spark-2.2.0/spark-2.2.0-bin-hadoop2.7.tgz /spark
+RUN tar --strip-components=1 -xvzf spark-2.2.0-bin-hadoop2.7.tgz -C /spark && \
+    rm -rf spark-2.2.2-bin-hadoop2.7.tgz
+ENV SPARK_HOME /spark/
+
+WORKDIR /hail
+RUN useradd --create-home --shell /bin/bash hail && \
+    chown -R hail:hail /hail
+USER hail
+
 # cache (almost all) gradle dependencies (and gradle itself)
 #
 # Some plugin we use hides its dependencies in a so-called "detached
 # configuration" so there is no way for us to ensure it gets cached.
-WORKDIR /hail
 COPY gradlew build.gradle settings.gradle deployed-spark-versions.txt ./
 COPY gradle gradle
 RUN mkdir -p /gradle-cache
@@ -53,16 +63,6 @@ RUN ./gradlew downloadDependencies --gradle-user-home /gradle-cache
 COPY python/hail/dev-environment.yml python/hail/dev-environment.yml
 RUN conda env create hail -f ./python/hail/dev-environment.yml && \
     rm -rf /opt/conda/pkgs/*
-
-WORKDIR /spark
-ADD https://archive.apache.org/dist/spark/spark-2.2.0/spark-2.2.0-bin-hadoop2.7.tgz /spark
-RUN tar --strip-components=1 -xvzf spark-2.2.0-bin-hadoop2.7.tgz -C /spark && \
-    rm -rf spark-2.2.2-bin-hadoop2.7.tgz
-ENV SPARK_HOME /spark/
-
-RUN useradd --create-home --shell /bin/bash hail && \
-    chown -R hail:hail /hail
-USER hail
 
 # this seems easier than getting the keys right for apt
 #

--- a/Dockerfile.pr-builder
+++ b/Dockerfile.pr-builder
@@ -57,12 +57,12 @@ USER hail
 #
 # Some plugin we use hides its dependencies in a so-called "detached
 # configuration" so there is no way for us to ensure it gets cached.
-COPY gradlew build.gradle settings.gradle deployed-spark-versions.txt ./
-COPY gradle gradle
+COPY --chown hail:hail gradlew build.gradle settings.gradle deployed-spark-versions.txt ./
+COPY --chown hail:hail gradle gradle
 RUN ./gradlew downloadDependencies --gradle-user-home /gradle-cache
-COPY python/hail/dev-environment.yml python/hail/dev-environment.yml
+COPY --chown hail:hail python/hail/dev-environment.yml python/hail/dev-environment.yml
 RUN conda env create hail -f ./python/hail/dev-environment.yml && \
-    rm -rf /opt/conda/pkgs/*
+    rm -rf /home/hail/.conda/pkgs/*
 
 # this seems easier than getting the keys right for apt
 #

--- a/Dockerfile.pr-builder
+++ b/Dockerfile.pr-builder
@@ -48,8 +48,9 @@ RUN tar --strip-components=1 -xvzf spark-2.2.0-bin-hadoop2.7.tgz -C /spark && \
 ENV SPARK_HOME /spark/
 
 WORKDIR /hail
-RUN useradd --create-home --shell /bin/bash hail && \
-    chown -R hail:hail /hail
+RUN mkdir -p /gradle-cache && \
+    useradd --create-home --shell /bin/bash hail && \
+    chown -R hail:hail /hail /gradle-cache
 USER hail
 
 # cache (almost all) gradle dependencies (and gradle itself)
@@ -58,7 +59,6 @@ USER hail
 # configuration" so there is no way for us to ensure it gets cached.
 COPY gradlew build.gradle settings.gradle deployed-spark-versions.txt ./
 COPY gradle gradle
-RUN mkdir -p /gradle-cache
 RUN ./gradlew downloadDependencies --gradle-user-home /gradle-cache
 COPY python/hail/dev-environment.yml python/hail/dev-environment.yml
 RUN conda env create hail -f ./python/hail/dev-environment.yml && \

--- a/Dockerfile.pr-builder
+++ b/Dockerfile.pr-builder
@@ -2,21 +2,32 @@ FROM continuumio/miniconda
 MAINTAINER Hail Team <hail@broadinstitute.org>
 
 USER root
-RUN apt-get update && apt-get -y install --fix-missing \
+# - libnlopt-dev is for nloptr, a dependency of SKAT:
+#   https://github.com/jyypma/nloptr/issues/40
+#
+# - r-cran-ncdf4, r-cran-rnetcdf, libcurl4-openssl-dev, and libxml2-dve are
+# - depenendencies for the three biolite packages
+RUN apt-get update && apt-get -y install \
     bash \
     cmake \
     curl \
     g++ \
     git \
+    libnlopt-dev \
     openjdk-8-jdk-headless \
+    pandoc \
     r-base \
     tar \
-    unzip
+    unzip \
+    xsltproc \
+    r-cran-ncdf4 \
+    r-cran-rnetcdf \
+    libcurl4-openssl-dev \
+    libxml2-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get -y install libnlopt-dev # https://github.com/jyypma/nloptr/issues/40
-RUN Rscript -e 'install.packages(c("jsonlite", "SKAT", "logistf"), repos = "http://cran.us.r-project.org")'
-RUN apt-get -y install r-cran-ncdf4 r-cran-rnetcdf libcurl4-openssl-dev libxml2-dev
-RUN Rscript -e 'source("https://bioconductor.org/biocLite.R"); biocLite("GENESIS"); biocLite("SNPRelate"); biocLite("GWASTools")'
+RUN Rscript -e 'install.packages(c("jsonlite", "SKAT", "logistf"), repos = "http://cran.us.r-project.org")' && \
+    Rscript -e 'source("https://bioconductor.org/biocLite.R"); biocLite("GENESIS"); biocLite("SNPRelate"); biocLite("GWASTools")'
 
 WORKDIR /plink
 ADD http://www.cog-genomics.org/static/bin/plink/plink_linux_x86_64.zip /plink
@@ -43,20 +54,21 @@ COPY python/hail/dev-environment.yml python/hail/dev-environment.yml
 RUN conda env create hail -f ./python/hail/dev-environment.yml && \
     rm -rf /opt/conda/pkgs/*
 
-# this seems easier than getting the keys right for apt
-#
-# source: https://cloud.google.com/storage/docs/gsutil_install#linux
-RUN /bin/sh -c 'curl https://sdk.cloud.google.com | bash'
-ENV PATH $PATH:/root/google-cloud-sdk/bin
-# gcloud iam key files will be stored here
-VOLUME /secrets
-
 WORKDIR /spark
 ADD https://archive.apache.org/dist/spark/spark-2.2.0/spark-2.2.0-bin-hadoop2.7.tgz /spark
 RUN tar --strip-components=1 -xvzf spark-2.2.0-bin-hadoop2.7.tgz -C /spark && \
     rm -rf spark-2.2.2-bin-hadoop2.7.tgz
 ENV SPARK_HOME /spark/
 
-RUN apt-get -y install xsltproc pandoc
+RUN useradd --create-home --shell /bin/bash hail && \
+    chown -R hail:hail /hail
+USER hail
+
+# this seems easier than getting the keys right for apt
+#
+# source: https://cloud.google.com/storage/docs/gsutil_install#linux
+RUN /bin/sh -c 'curl https://sdk.cloud.google.com | bash'
+# gcloud iam key files will be stored here
+VOLUME /secrets
 
 WORKDIR /hail

--- a/hail-ci-build-image
+++ b/hail-ci-build-image
@@ -1,1 +1,1 @@
-gcr.io/broad-ctsa/hail-pr-builder:3ee31e56095edd7a23bc64c211312465aaf69fd5
+gcr.io/broad-ctsa/hail-pr-builder:244a0f0e1757d7adbce77d4f185c3a1ae8d4370b

--- a/hail-ci-build-image
+++ b/hail-ci-build-image
@@ -1,1 +1,1 @@
-gcr.io/broad-ctsa/hail-pr-builder:244a0f0e1757d7adbce77d4f185c3a1ae8d4370b
+gcr.io/broad-ctsa/hail-pr-builder:3e7eeeaac08405462686d607ba0a2b89b53492fd


### PR DESCRIPTION
This consolidates all the apt-get dependencies into one line and brings them into line with [Dockerfile best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run).

It also sets the default user to a non-root user, thus limiting what can go wrong if we have security holes in the PR builder.