### PR TITLE
Fix the build image

### DIFF
--- a/Dockerfile.pr-builder
+++ b/Dockerfile.pr-builder
@@ -68,6 +68,7 @@ RUN conda env create hail -f ./python/hail/dev-environment.yml && \
 #
 # source: https://cloud.google.com/storage/docs/gsutil_install#linux
 RUN /bin/sh -c 'curl https://sdk.cloud.google.com | bash'
+ENV PATH $PATH:/home/hail/google-cloud-sdk/bin
 # gcloud iam key files will be stored here
 VOLUME /secrets
 

--- a/hail-ci-build-image
+++ b/hail-ci-build-image
@@ -1,1 +1,1 @@
-gcr.io/broad-ctsa/hail-pr-builder:3e7eeeaac08405462686d607ba0a2b89b53492fd
+gcr.io/broad-ctsa/hail-pr-builder:d93cb0a86433fb669c311398911e9497b2a8cfc3


### PR DESCRIPTION
gcloud isn't in the path so no builds are copying the artifacts. I also need to fix the `hail-ci-build.sh` to fail if the gcloud commands fail, but this is quick fix before I go to bed.