### PR TITLE
fix deforested If in Emit

### DIFF
--- a/python/test/hail/expr/test_expr.py
+++ b/python/test/hail/expr/test_expr.py
@@ -2002,9 +2002,4 @@ class Tests(unittest.TestCase):
                             [1, 2, 3],
                             [4, 5, 6]).fold(True,
                                             lambda accum, i: accum & (i == t.idx))
-
-        # fold_expr = hl.cond(t.idx == 3,
-        #                     hl.range(0, 3),
-        #                     hl.range(0, 3)).fold(True,
-        #                                     lambda accum, i: accum & (i == t.idx))
-        t.aggregate(hl.agg.count_where(fold_expr))
+        t.annotate(foo=hl.cond(fold_expr, 1, 3))._force_count()

--- a/python/test/hail/expr/test_expr.py
+++ b/python/test/hail/expr/test_expr.py
@@ -1995,3 +1995,16 @@ class Tests(unittest.TestCase):
         self.assertTrue(hl.approx_equal(0.25, 0.25000001).value)
         self.assertTrue(hl.approx_equal(hl.null(hl.tint64), 5).value is None)
         self.assertFalse(hl.approx_equal(0.25, 0.251, absolute=True, tolerance=1e-3).value)
+
+    def test_issue3729(self):
+        t = hl.utils.range_table(10, 3)
+        fold_expr = hl.cond(t.idx == 3,
+                            [1, 2, 3],
+                            [4, 5, 6]).fold(True,
+                                            lambda accum, i: accum & (i == t.idx))
+
+        # fold_expr = hl.cond(t.idx == 3,
+        #                     hl.range(0, 3),
+        #                     hl.range(0, 3)).fold(True,
+        #                                     lambda accum, i: accum & (i == t.idx))
+        t.aggregate(hl.agg.count_where(fold_expr))


### PR DESCRIPTION
Fixes #3729.

The problem with the If in the array emitting logic was that the lengths were being stored in two different local variables, which were only being evaluated/stored depending on which branch was taken. Because we store that information in another local variable, `xvcond`, and check it again when we're actually consuming the array, the analyzer was checking both branches again for that step, and being unhappy that the local variable where the length is stored could have been unpopulated. I have fixed this by only having one branch and doing both the length calculation and the rest of the stuff there. 