### PR TITLE
Fix Hail 0.1 Deploying

### DIFF
--- a/hail-ci-deploy.sh
+++ b/hail-ci-deploy.sh
@@ -15,7 +15,6 @@ GRADLE_OPTS=-Xmx2048m ./gradlew \
            -Dspark.version=${SPARK_VERSION} \
            -Dspark.home=/spark \
            -Dtutorial.home=/usr/local/hail-tutorial-files \
-           -Dsphinx-build=sphinx-build2.7 \
            --gradle-user-home /gradle-cache
 SHA=$(git rev-parse --short=12 HEAD)
 


### PR DESCRIPTION
The build script does not use this sphinx-build parameter. It is used for compatibility with the TeamCity Build Agents. In the Dockerfile for 0.1, `sphinx-build` is already the correct version of `sphinx-build` so there is no need to refer to a specific version (in fact, there is no such binary as `sphinx-build2.7` in our 0.1 Dockerfile).