### PR TITLE
change field 'key' to 'id' in skat

### DIFF
--- a/python/hail/methods/statgen.py
+++ b/python/hail/methods/statgen.py
@@ -695,13 +695,13 @@ def skat(key_expr, weight_expr, y, x, covariates, logistic=False,
     present values 0 or 1) or Boolean, in which case true and false are coded
     as 1 and 0, respectively.
 
-    The resulting :class:`.Table` provides the group's key, the size (number of
-    rows) in the group, the variance component score `q_stat`, the SKAT
-    p-value, and a fault flag. For the toy example above, the table has the
+    The resulting :class:`.Table` provides the group's key (`id`), thenumber of
+    rows in the group (`size`), the variance component score `q_stat`, the SKAT
+    `p-value`, and a `fault` flag. For the toy example above, the table has the
     form:
 
     +-------+------+--------+---------+-------+
-    |  key  | size | q_stat | p_value | fault |
+    |  id   | size | q_stat | p_value | fault |
     +=======+======+========+=========+=======+
     | geneA |   2  | 4.136  | 0.205   |   0   |
     +-------+------+--------+---------+-------+

--- a/python/test/hail/methods/test_statgen.py
+++ b/python/test/hail/methods/test_statgen.py
@@ -1084,28 +1084,28 @@ class Tests(unittest.TestCase):
                 y=ds.pheno,
                 x=ds.GT.n_alt_alleles(),
                 covariates=[],
-                logistic=False).count()
+                logistic=False)._force_count()
 
         hl.skat(key_expr=ds.gene,
                 weight_expr=ds.weight,
                 y=ds.pheno,
                 x=ds.GT.n_alt_alleles(),
                 covariates=[],
-                logistic=True).count()
+                logistic=True)._force_count()
 
         hl.skat(key_expr=ds.gene,
                 weight_expr=ds.weight,
                 y=ds.pheno,
                 x=ds.GT.n_alt_alleles(),
                 covariates=[1.0, ds.cov.Cov1, ds.cov.Cov2],
-                logistic=False).count()
+                logistic=False)._force_count()
 
         hl.skat(key_expr=ds.gene,
                 weight_expr=ds.weight,
                 y=ds.pheno,
                 x=hl.pl_dosage(ds.PL),
                 covariates=[1.0, ds.cov.Cov1, ds.cov.Cov2],
-                logistic=True).count()
+                logistic=True)._force_count()
 
     def test_de_novo(self):
         mt = hl.import_vcf(resource('denovo.vcf'))

--- a/src/main/scala/is/hail/methods/Skat.scala
+++ b/src/main/scala/is/hail/methods/Skat.scala
@@ -196,13 +196,13 @@ object Skat {
     val skatRdd = if (logistic) logisticSkat() else linearSkat()
     
     val skatSignature = TStruct(
-      ("key", keyType),
+      ("id", keyType),
       ("size", TInt32()),
       ("q_stat", TFloat64()),
       ("p_value", TFloat64()),
       ("fault", TInt32()))
 
-    Table(vsm.hc, skatRdd, skatSignature, Some(FastIndexedSeq("key")))
+    Table(vsm.hc, skatRdd, skatSignature, Some(FastIndexedSeq("id")))
   }
 
   def computeKeyGsWeightRdd(vsm: MatrixTable,

--- a/src/main/scala/is/hail/methods/Skat.scala
+++ b/src/main/scala/is/hail/methods/Skat.scala
@@ -190,7 +190,7 @@ object Skat {
         } else {
           Row(key, size, null, null, null)
         }
-      }
+      }.persist()
     }
     
     val skatRdd = if (logistic) logisticSkat() else linearSkat()


### PR DESCRIPTION
This removes the name conflict with the `key` attribute of a table. I also changed the test `count` to `_force_count` to be sure they aren't ever optimized.