### PR TITLE
Ci changes

### DIFF
--- a/hail-ci-deploy.sh
+++ b/hail-ci-deploy.sh
@@ -1,5 +1,8 @@
 set -ex
 
+gcloud auth activate-service-account \
+  --key-file=/secrets/ci-deploy-0-1--hail-is-hail-test-service-account-key.json
+
 SPARK_VERSION=2.2.0
 BRANCH=devel
 

--- a/hail-ci-deploy.sh
+++ b/hail-ci-deploy.sh
@@ -1,7 +1,7 @@
 set -ex
 
 gcloud auth activate-service-account \
-  --key-file=/secrets/ci-deploy-0-1--hail-is-hail-test-service-account-key.json
+  --key-file=/secrets/ci-deploy-0-1--hail-is-hail-test.json
 
 SPARK_VERSION=2.2.0
 BRANCH=devel


### PR DESCRIPTION
I'm generalizing the CI's deploy system. https://github.com/hail-is/ci/pull/77

In particular, I no longer assume you need to authorize from to a gcloud account. Instead, I just mount you a volume. Each repo will have some secrets that it can authorize with.

This is safe to merge now because before the CI changes go in, this just re-authorizes. When the CI changes merge, we'll go back to authorizing once, except that the command is in `hail-ci-deploy.sh` instead of baked into the CI system.