### PR TITLE
Fix the If unification problem

### DIFF
--- a/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -41,6 +41,7 @@ object Compile {
 
     var ir = body
     ir = Optimize(ir, noisy = false)
+    TypeCheck(ir, Env.empty[Type].bind(args.map { case (name, t, _) => name -> t}: _*), None)
 
     val env = args
       .zipWithIndex

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -7,6 +7,7 @@ object Infer {
     ir match {
       case If(cond, cnsq, altr) =>
         assert(cond.typ.isOfType(TBoolean()))
+        assert(cnsq.typ.isOfType(altr.typ))
         if (cnsq.typ != altr.typ)
           cnsq.typ.deepOptional()
         else

--- a/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -7,9 +7,10 @@ object Infer {
     ir match {
       case If(cond, cnsq, altr) =>
         assert(cond.typ.isOfType(TBoolean()))
-        assert(cnsq.typ == altr.typ, s"mismatch:\n  ${ cnsq.typ.parsableString() }\n  ${ altr.typ.parsableString() }\n  $cond")
-        cnsq.typ
-
+        if (cnsq.typ != altr.typ)
+          cnsq.typ.deepOptional()
+        else
+          cnsq.typ
       case Let(name, value, body) =>
         body.typ
       case ApplyBinaryPrimOp(op, l, r) =>

--- a/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1006,8 +1006,9 @@ object PruneDeadFields {
         case ta: TArray =>
           val ra = rType.asInstanceOf[TArray]
           val uid = genUID()
-          val ref = Ref(uid, ta.elementType)
+          val ref = Ref(uid, -ta.elementType)
           ArrayMap(ir, uid, upcast(ref, ra.elementType))
+        case t => ir
       }
     }
   }

--- a/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -104,8 +104,8 @@ object Simplify {
 
       case Let(n1, v, Ref(n2, _)) if n1 == n2 => v
 
-      case If(True(), x, _) => x
-      case If(False(), _, x) => x
+      case x@If(True(), cnsq, _) if x.typ == cnsq.typ => cnsq
+      case x@If(False(), _, altr) if x.typ == altr.typ => altr
 
       case If(c, cnsq, altr) if cnsq == altr =>
         if (cnsq.typ.required)

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -5,16 +5,25 @@ import is.hail.utils._
 
 object TypeCheck {
   def apply(ir: IR, aggEnv: Option[Env[Type]] = None) {
+    apply(ir, new Env[Type](), aggEnv)
     try {
-      apply(ir, new Env[Type](), aggEnv)
     } catch {
-      case e: Throwable => fatal(s"Error while typechecking IR:\n${Pretty(ir)}", e)
+      case e: Throwable => fatal(s"Error while typechecking IR:\n${ Pretty(ir) }", e)
     }
   }
 
-  def apply(ir: IR, env: Env[Type], aggEnv: Option[Env[Type]]) {
+  def apply(ir: IR, env: Env[Type], aggEnv: Option[Env[Type]]): Unit = {
+    try {
+      _apply(ir, env, aggEnv)
+    } catch {
+      case e: Throwable => fatal(s"Error while typechecking IR:\n${ Pretty(ir) }", e)
+    }
+
+  }
+
+  private def _apply(ir: IR, env: Env[Type], aggEnv: Option[Env[Type]]) {
     def check(ir: IR, env: Env[Type] = env, aggEnv: Option[Env[Type]] = aggEnv) {
-      apply(ir, env, aggEnv)
+      _apply(ir, env, aggEnv)
     }
 
     ir match {
@@ -178,7 +187,7 @@ object TypeCheck {
         }: _*))
       case x@SelectFields(old, fields) =>
         check(old)
-        assert{
+        assert {
           val oldfields = coerce[TStruct](old.typ).fieldNames.toSet
           fields.forall { id => oldfields.contains(id) }
         }

--- a/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -6,10 +6,6 @@ import is.hail.utils._
 object TypeCheck {
   def apply(ir: IR, aggEnv: Option[Env[Type]] = None) {
     apply(ir, new Env[Type](), aggEnv)
-    try {
-    } catch {
-      case e: Throwable => fatal(s"Error while typechecking IR:\n${ Pretty(ir) }", e)
-    }
   }
 
   def apply(ir: IR, env: Env[Type], aggEnv: Option[Env[Type]]): Unit = {
@@ -18,7 +14,6 @@ object TypeCheck {
     } catch {
       case e: Throwable => fatal(s"Error while typechecking IR:\n${ Pretty(ir) }", e)
     }
-
   }
 
   private def _apply(ir: IR, env: Env[Type], aggEnv: Option[Env[Type]]) {

--- a/src/main/scala/is/hail/expr/types/Type.scala
+++ b/src/main/scala/is/hail/expr/types/Type.scala
@@ -295,6 +295,7 @@ abstract class Type extends BaseType with Serializable {
       case t2: TArray => t.isInstanceOf[TArray] && t.asInstanceOf[TArray].elementType.isOfType(t2.elementType)
       case t2: TSet => t.isInstanceOf[TSet] && t.asInstanceOf[TSet].elementType.isOfType(t2.elementType)
       case t2: TDict => t.isInstanceOf[TDict] && t.asInstanceOf[TDict].keyType.isOfType(t2.keyType) && t.asInstanceOf[TDict].valueType.isOfType(t2.valueType)
+      case TVoid => t == TVoid
     }
   }
 

--- a/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -141,10 +141,10 @@ class IRSuite extends SparkSuite {
     val value = Row(FastIndexedSeq(1, 2, 3))
     assertEvalsTo(
       If(
-        True(),
-        In(0, t),
+        In(0, TBoolean()),
+        In(1, t),
         MakeStruct(Seq("foo" -> ArrayRange(I32(0), I32(1), I32(1))))),
-      FastIndexedSeq((value, t)),
+      FastIndexedSeq((true, TBoolean()), (value, t)),
       value
     )
   }

--- a/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -137,13 +137,13 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testIfWithDifferentRequiredness() {
-    val t = TStruct("foo" -> TArray(TInt32Required, required = true))
-    val value = Row(FastIndexedSeq(1, 2, 3))
+    val t = TStruct(true, "foo" -> TStruct("bar" -> TArray(TInt32Required, required = true)))
+    val value = Row(Row(FastIndexedSeq(1, 2, 3)))
     assertEvalsTo(
       If(
         In(0, TBoolean()),
         In(1, t),
-        MakeStruct(Seq("foo" -> ArrayRange(I32(0), I32(1), I32(1))))),
+        MakeStruct(Seq("foo" -> MakeStruct(Seq("bar" -> ArrayRange(I32(0), I32(1), I32(1))))))),
       FastIndexedSeq((true, TBoolean()), (value, t)),
       value
     )

--- a/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -136,6 +136,19 @@ class IRSuite extends SparkSuite {
     assertEvalsTo(If(True(), NA(TInt32()), I32(7)), null)
   }
 
+  @Test def testIfWithDifferentRequiredness() {
+    val t = TStruct("foo" -> TArray(TInt32Required, required = true))
+    val value = Row(FastIndexedSeq(1, 2, 3))
+    assertEvalsTo(
+      If(
+        True(),
+        In(0, t),
+        MakeStruct(Seq("foo" -> ArrayRange(I32(0), I32(1), I32(1))))),
+      FastIndexedSeq((value, t)),
+      value
+    )
+  }
+
   @Test def testLet() {
     assertEvalsTo(Let("v", I32(5), Ref("v", TInt32())), 5)
     assertEvalsTo(Let("v", NA(TInt32()), Ref("v", TInt32())), null)


### PR DESCRIPTION
The fix is somewhat subtle and relies on PruneDeadFields, which is called (a) by the optimizer and (b) by the compiler, so this is safe. The important piece is that the process of upcasting strips requiredness.

This isn't a great design, but I'm comfortable with it for now since I hope physical types will solve this in The Right Way™ before 0.2 release anyway.

fixes #4134