### PR TITLE
Sort all the tables

### DIFF
--- a/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -201,7 +201,7 @@ case class TableKeyBy(child: TableIR, keys: IndexedSeq[String], isSorted: Boolea
 
   val children: IndexedSeq[BaseIR] = Array(child)
 
-  val typ: TableType = child.typ.copy(key = Some(keys))
+  val typ: TableType = child.typ.copy(key = if (keys.isEmpty) None else Some(keys))
 
   def copy(newChildren: IndexedSeq[BaseIR]): TableKeyBy = {
     assert(newChildren.length == 1)
@@ -222,7 +222,7 @@ case class TableKeyBy(child: TableIR, keys: IndexedSeq[String], isSorted: Boolea
     } else {
       orvd.changeKey(keys)
     }.toOldStyleRVD
-    tv.copy(typ = typ, rvd = rvd)
+    tv.copy(typ = typ, rvd = if (typ.key.isDefined) rvd else rvd.toUnpartitionedRVD)
   }
 }
 

--- a/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -805,7 +805,10 @@ case class TableUnion(children: IndexedSeq[TableIR]) extends TableIR {
   def execute(hc: HailContext): TableValue = {
     val tvs = children.map(_.execute(hc))
     tvs(0).copy(
-      rvd = RVD.union(tvs.map(_.rvd)))
+      rvd = if (typ.key.isDefined)
+        OrderedRVD.union(tvs.map(_.rvd.asInstanceOf[OrderedRVD]))
+      else
+        RVD.union(tvs.map(_.rvd)))
   }
 }
 

--- a/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -16,8 +16,6 @@ import org.json4s.jackson.JsonMethods
 case class TableValue(typ: TableType, globals: BroadcastRow, rvd: RVD) {
   require(typ.rowType == rvd.rowType)
   require(typ.key.isDefined == rvd.isInstanceOf[OrderedRVD])
-  if (typ.key.exists(k => !rvd.asInstanceOf[OrderedRVD].typ.key.startsWith(k)))
-    println(s"type key: ${typ.key.get}, rvd key: ${rvd.asInstanceOf[OrderedRVD].typ.key}")
   require(typ.key.forall(k => rvd.asInstanceOf[OrderedRVD].typ.key.startsWith(k)))
 
   def rdd: RDD[Row] =

--- a/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -15,7 +15,10 @@ import org.json4s.jackson.JsonMethods
 
 case class TableValue(typ: TableType, globals: BroadcastRow, rvd: RVD) {
   require(typ.rowType == rvd.rowType)
-  require(typ.key.isDefined || rvd.isInstanceOf[UnpartitionedRVD])
+  require(typ.key.isDefined == rvd.isInstanceOf[OrderedRVD])
+  if (typ.key.exists(k => !rvd.asInstanceOf[OrderedRVD].typ.key.startsWith(k)))
+    println(s"type key: ${typ.key.get}, rvd key: ${rvd.asInstanceOf[OrderedRVD].typ.key}")
+  require(typ.key.forall(k => rvd.asInstanceOf[OrderedRVD].typ.key.startsWith(k)))
 
   def rdd: RDD[Row] =
     rvd.toRows

--- a/src/main/scala/is/hail/expr/types/MatrixType.scala
+++ b/src/main/scala/is/hail/expr/types/MatrixType.scala
@@ -73,13 +73,13 @@ case class MatrixType(
   val colsTableType: TableType =
     TableType(
       colType,
-      Some(colKey),
+      if (colKey.isEmpty) None else Some(colKey),
       globalType)
 
   val rowsTableType: TableType =
     TableType(
       rowType,
-      Some(rowKey),
+      if (rowKey.isEmpty) None else Some(rowKey),
       globalType)
 
   lazy val entriesTableType: TableType = {

--- a/src/main/scala/is/hail/expr/types/TableType.scala
+++ b/src/main/scala/is/hail/expr/types/TableType.scala
@@ -12,6 +12,7 @@ class TableTypeSerializer extends CustomSerializer[TableType](format => (
   { case tt: TableType => JString(tt.toString) }))
 
 case class TableType(rowType: TStruct, key: Option[IndexedSeq[String]], globalType: TStruct) extends BaseType {
+  assert(!key.exists(_.isEmpty))
 
   val keyOrEmpty: IndexedSeq[String] = key.getOrElse(IndexedSeq.empty)
   val keyOrNull: IndexedSeq[String] = key.orNull

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -443,7 +443,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
   def select(newRow: IR, newKey: Option[IndexedSeq[String]], preservedKeyFields: Option[Int]): Table = {
     require(newKey.isDefined == preservedKeyFields.isDefined)
     val preservedKeyOld = typ.key.flatMap(k => preservedKeyFields.map(k.take))
-    val preservedKeyNew = newKey.map(_.take(preservedKeyFields.get))
+    val preservedKeyNew = typ.key.flatMap(_ => newKey.map(_.take(preservedKeyFields.get)))
     val shortenedKey = if (typ.key.isDefined) TableKeyBy(tir, preservedKeyOld.get) else tir
     val mapped = TableMapRows(shortenedKey, newRow, preservedKeyNew)
     val lengthenedKey =

--- a/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -28,10 +28,9 @@ class PartitioningSuite extends SparkSuite {
   }
 
   @Test def testShuffleOnEmptyRDD() {
+    val typ = TableType(TStruct("tidx" -> TInt32()), Some(IndexedSeq("tidx")), TStruct.empty())
     val t = TableLiteral(TableValue(
-      TableType(TStruct("tidx" -> TInt32()), Some(IndexedSeq("tidx")), TStruct.empty()),
-      BroadcastRow(Row.empty, TStruct.empty(), sc),
-      UnpartitionedRVD.empty(sc, TStruct("tidx" -> TInt32()))))
+      typ, BroadcastRow(Row.empty, TStruct.empty(), sc), OrderedRVD.empty(sc, typ.rvdType)))
     val rangeReader = ir.MatrixRangeReader(100, 10, Some(10))
     MatrixAnnotateRowsTable(ir.MatrixRead(rangeReader.fullType, false, false, rangeReader), t, "foo", None)
       .execute(hc).rvd.count()


### PR DESCRIPTION
Fixes the remaining few places that were producing tables with keys but backed by an `UnpartitionedRVD`. Strengthens the invariants of `TableValue` and `TableType` to enforce this, and to ease the transition to required keys and the removal of `UnpartitionedRVD`. In particular, now if a table's key is `None`, then it is backed by an `UnpartitionedRVD`, and if its key is `Some(key)`, then it is backed by an `OrderedRVD` with a key starting with `key`.