### PR TITLE
remove partitionKey from TableToMatrixTable

### DIFF
--- a/python/hail/ir/matrix_ir.py
+++ b/python/hail/ir/matrix_ir.py
@@ -220,14 +220,13 @@ class MatrixAggregateColsByKey(MatrixIR):
         return '(MatrixAggregateColsByKey {} {})'.format(self.child, self.agg_ir)
 
 class TableToMatrixTable(MatrixIR):
-    def __init__(self, child, row_key, col_key, row_fields, col_fields, partition_key, n_partitions):
+    def __init__(self, child, row_key, col_key, row_fields, col_fields, n_partitions):
         super().__init__()
         self.child = child
         self.row_key = row_key
         self.col_key = col_key
         self.row_fields = row_fields
         self.col_fields = col_fields
-        self.partition_key = partition_key
         self.n_partitions = n_partitions
 
     def __str__(self):
@@ -236,7 +235,6 @@ class TableToMatrixTable(MatrixIR):
                f'{parsable_strings(self.col_key)} ' \
                f'{parsable_strings(self.row_fields)} ' \
                f'{parsable_strings(self.col_fields)} ' \
-               f'{parsable_strings(self.partition_key)} ' \
                f'{"None" if self.n_partitions is None else str(self.n_partitions)} ' \
                f'{self.child})'
 

--- a/python/test/hail/test_ir.py
+++ b/python/test/hail/test_ir.py
@@ -181,7 +181,7 @@ class TableIRTests(unittest.TestCase):
             ir.MatrixMapRows(matrix_read, ir.MakeStruct([('x', ir.I64(20))]), (['x'], [])),
             ir.MatrixMapEntries(matrix_read, ir.MakeStruct([('x', ir.I64(20))])),
             ir.MatrixMapGlobals(matrix_read, ir.MakeStruct([('x', ir.I64(20))])),
-            ir.TableToMatrixTable(table_read, ['f32', 'i64'], ['m', 'astruct'], ['aset'], ['mset'], ['f32'], 100),
+            ir.TableToMatrixTable(table_read, ['f32', 'i64'], ['m', 'astruct'], ['aset'], ['mset'], 100),
             ir.MatrixCollectColsByKey(matrix_read),
             ir.MatrixExplodeRows(matrix_read, ['row_aset']),
             ir.MatrixExplodeCols(matrix_read, ['col_aset']),

--- a/src/main/scala/is/hail/expr/Parser.scala
+++ b/src/main/scala/is/hail/expr/Parser.scala
@@ -654,9 +654,9 @@ object Parser extends JavaTokenParsers {
           val reader = Serialization.read[ir.MatrixReader](readerStr)
           ir.MatrixRead(typ.getOrElse(reader.fullType), dropCols, dropRows, reader)
       } |
-      "TableToMatrixTable" ~> string_literals ~ string_literals ~ string_literals ~ string_literals ~ string_literals ~ int32_literal_opt ~ table_ir ^^ {
-        case rowKey ~ colKey ~ rowFields ~ colFields ~ partitionKey ~ nPartitions ~ child =>
-          ir.TableToMatrixTable(child, rowKey, colKey, rowFields, colFields, partitionKey, nPartitions)
+      "TableToMatrixTable" ~> string_literals ~ string_literals ~ string_literals ~ string_literals ~ int32_literal_opt ~ table_ir ^^ {
+        case rowKey ~ colKey ~ rowFields ~ colFields ~ nPartitions ~ child =>
+          ir.TableToMatrixTable(child, rowKey, colKey, rowFields, colFields, nPartitions)
       } |
       "MatrixAnnotateRowsTable" ~> string_literal ~ boolean_literal ~ matrix_ir ~ table_ir ~ rep(ir_value_expr) ^^ {
         case uid ~ hasKey ~ child ~ table ~ key =>

--- a/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -1932,7 +1932,6 @@ case class TableToMatrixTable(
   colKey: IndexedSeq[String],
   rowFields: IndexedSeq[String],
   colFields: IndexedSeq[String],
-  partitionKey: IndexedSeq[String],
   nPartitions: Option[Int] = None
 ) extends MatrixIR {
   // no fields used twice
@@ -1941,6 +1940,10 @@ case class TableToMatrixTable(
     assert(!fieldsUsed.contains(f))
     fieldsUsed += f
   }
+
+  // need keys for rows and cols
+  assert(rowKey.nonEmpty)
+  assert(colKey.nonEmpty)
 
   def children: IndexedSeq[BaseIR] = FastIndexedSeq(child)
 
@@ -1952,19 +1955,9 @@ case class TableToMatrixTable(
       colKey,
       rowFields,
       colFields,
-      partitionKey,
       nPartitions
     )
   }
-
-
-  // need keys for rows and cols
-  assert(rowKey.nonEmpty)
-  assert(colKey.nonEmpty)
-
-  // check partition key is appropriate and not empty
-  assert(rowKey.startsWith(partitionKey))
-  assert(partitionKey.nonEmpty)
 
   private val rowType = TStruct((rowKey ++ rowFields).map(f => f -> child.typ.rowType.fieldByName(f).typ): _*)
   private val colType = TStruct((colKey ++ colFields).map(f => f -> child.typ.rowType.fieldByName(f).typ): _*)

--- a/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -194,12 +194,11 @@ object Pretty {
               prettyBooleanLiteral(dropCols) + " " +
               prettyBooleanLiteral(dropRows) + " " +
               '"' + StringEscapeUtils.escapeString(Serialization.write(reader)(MatrixReader.formats)) + '"'
-            case TableToMatrixTable(_, rowKey, colKey, rowFields, colFields, partitionKey, nPartitions) =>
+            case TableToMatrixTable(_, rowKey, colKey, rowFields, colFields, nPartitions) =>
               prettyStrings(rowKey) + " " +
               prettyStrings(colKey) +  " " +
               prettyStrings(rowFields) + " " +
               prettyStrings(colFields) + " " +
-              prettyStrings(partitionKey) + " " +
               prettyIntOpt(nPartitions)
             case MatrixAnnotateRowsTable(_, _, uid, key) =>
               prettyStringLiteral(uid) + " " +

--- a/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -461,7 +461,7 @@ object PruneDeadFields {
           colType = irDep.colType
         )
         memoizeMatrixIR(child, childDep, memo)
-      case TableToMatrixTable(child, rowKey, colKey, rowFields, colFields, partitionKey, nPartitions) =>
+      case TableToMatrixTable(child, rowKey, colKey, rowFields, colFields, nPartitions) =>
         val dependencyMap = (requestedType.rowType.fields.map(f => f.name -> f.typ) ++
           requestedType.colType.fields.map(f => f.name -> f.typ) ++
           requestedType.entryType.fields.map(f => f.name -> f.typ)).toMap
@@ -850,7 +850,7 @@ object PruneDeadFields {
       case MatrixAggregateColsByKey(child, expr) =>
         val child2 = rebuild(child, memo)
         MatrixAggregateColsByKey(child2, rebuild(expr, child2.typ, memo))
-      case TableToMatrixTable(child, rowKey, colKey, rowFields, colFields, partitionKey, nPartitions) =>
+      case TableToMatrixTable(child, rowKey, colKey, rowFields, colFields, nPartitions) =>
         val child2 = rebuild(child, memo)
         val childFieldSet = child2.typ.rowType.fieldNames.toSet
         TableToMatrixTable(
@@ -859,7 +859,6 @@ object PruneDeadFields {
           colKey,
           rowFields.filter(childFieldSet.contains),
           colFields.filter(childFieldSet.contains),
-          partitionKey,
           nPartitions)
       case MatrixUnionRows(children) =>
         val requestedType = memo.lookup(mir).asInstanceOf[MatrixType]

--- a/src/main/scala/is/hail/table/Table.scala
+++ b/src/main/scala/is/hail/table/Table.scala
@@ -495,7 +495,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
     colFields: Array[String],
     nPartitions: Option[Int] = None
   ): MatrixTable = {
-    new MatrixTable(hc, TableToMatrixTable(tir, rowKeys, colKeys, rowFields, colFields, rowKeys, nPartitions))
+    new MatrixTable(hc, TableToMatrixTable(tir, rowKeys, colKeys, rowFields, colFields, nPartitions))
   }
 
   def keyByAndAggregate(expr: String, key: String, nPartitions: Option[Int], bufferSize: Int): Table = {

--- a/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -647,7 +647,6 @@ class IRSuite extends SparkSuite {
           Array("d", "ml"),
           Array("mc"),
           Array("t"),
-          Array("astruct"),
           None),
         MatrixExplodeRows(read, FastIndexedSeq("row_mset")),
         MatrixUnionRows(FastIndexedSeq(range1, range2)),

--- a/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -366,8 +366,7 @@ class PruneSuite extends SparkSuite {
       rowKey = FastIndexedSeq("1"),
       colKey = FastIndexedSeq("2"),
       rowFields = FastIndexedSeq("5"),
-      colFields = FastIndexedSeq("4"),
-      partitionKey = FastIndexedSeq("1")
+      colFields = FastIndexedSeq("4")
     )
 
     checkMemo(ttmt,
@@ -702,8 +701,7 @@ class PruneSuite extends SparkSuite {
       rowKey = FastIndexedSeq("1"),
       colKey = FastIndexedSeq("2"),
       rowFields = FastIndexedSeq("5"),
-      colFields = FastIndexedSeq("4"),
-      partitionKey = FastIndexedSeq("1")
+      colFields = FastIndexedSeq("4")
     )
 
     checkRebuild(ttmt, subsetMatrixTable(ttmt.typ),


### PR DESCRIPTION
This is just cleanup I missed earlier. The `partitionKey` field wasn't being used.