### PR TITLE
use -march=corei7_avx with g++-4.8.x

### DIFF
--- a/hail/src/main/c/Makefile
+++ b/hail/src/main/c/Makefile
@@ -66,7 +66,7 @@ ifneq ($(WARNFLAGS),)
   CXXFLAGS := $(filter-out $(WARNFLAGS),$(CXXFLAGS))
 endif
 
-# If no inherited "-march=%", then use "-march=sandybridge" or "-march=corei7_avx"
+# If no inherited "-march=%", then use "-march=sandybridge" or "-march=corei7-avx"
 # for ISA compatibility with MacBook Pro's since 2011 (also the earliest cpu with AVX).
 # Fall back to "-march=native" if the compiler doesn't support either of those.
 
@@ -75,10 +75,10 @@ ifeq ($(filter -march=%,$(CXXFLAGS)),)
   ifeq ($(FAIL_A),)
     CXXFLAGS += -march=sandybridge
   else
-    # g++-4.8.x accepts "-march=corei7_avx" but not "-march=sandybridge	"
-    FAIL_B :=$(shell cp /dev/null a.cpp; $(CXX) -march=corei7_avx -c a.cpp 2>1 || echo FAIL; rm -f a.cpp a.o)
+    # g++-4.8.x accepts "-march=corei7-avx" but not "-march=sandybridge	"
+    FAIL_B :=$(shell cp /dev/null a.cpp; $(CXX) -march=corei7-avx -c a.cpp 2>1 || echo FAIL; rm -f a.cpp a.o)
     ifeq ($(FAIL_B),)
-      CXXFLAGS += -march=corei7_avx
+      CXXFLAGS += -march=corei7-avx
     else
       CXXFLAGS += -march=native
     endif

--- a/hail/src/main/c/Makefile
+++ b/hail/src/main/c/Makefile
@@ -66,11 +66,23 @@ ifneq ($(WARNFLAGS),)
   CXXFLAGS := $(filter-out $(WARNFLAGS),$(CXXFLAGS))
 endif
 
-# If no inherited "-march=%", then use "-march=sandybridge" for ISA compatibility
-# with MacBook Pro's since 2011 (also the earliest cpu with AVX).
+# If no inherited "-march=%", then use "-march=sandybridge" or "-march=corei7_avx"
+# for ISA compatibility with MacBook Pro's since 2011 (also the earliest cpu with AVX).
+# Fall back to "-march=native" if the compiler doesn't support either of those.
 
 ifeq ($(filter -march=%,$(CXXFLAGS)),)
-  CXXFLAGS += -march=sandybridge
+  FAIL_A :=$(shell cp /dev/null a.cpp; $(CXX) -march=sandybridge -c a.cpp 2>1 || echo FAIL; rm -f a.cpp a.o)
+  ifeq ($(FAIL_A),)
+    CXXFLAGS += -march=sandybridge
+  else
+    # g++-4.8.x accepts "-march=corei7_avx" but not "-march=sandybridge	"
+    FAIL_B :=$(shell cp /dev/null a.cpp; $(CXX) -march=corei7_avx -c a.cpp 2>1 || echo FAIL; rm -f a.cpp a.o)
+    ifeq ($(FAIL_B),)
+      CXXFLAGS += -march=corei7_avx
+    else
+      CXXFLAGS += -march=native
+    endif
+  endif
 endif
 
 # Append to any inherited flags which survived filtering


### PR DESCRIPTION
User reported that hail wouldn't build on an EMR instance.  It turns out that g++-4.8.x doesn't
support "-march=sandybridge", but has the same architecture called "-march=corei7_avx". 
With this PR the Makefile tests a trivial compilation to pick a -march which works for the
particular $(CXX).