### PR TITLE
Fix MakeArray

### DIFF
--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -161,7 +161,7 @@ def _to_expr(e, dtype):
                      else hl.literal(element, dtype.element_type)
                      for element in elements]
             indices, aggregations = unify_all(*exprs)
-        ir = MakeArray([e._ir for e in exprs], dtype)
+        ir = MakeArray([e._ir for e in exprs], None)
         return expressions.construct_expr(ir, dtype, indices, aggregations)
     elif isinstance(dtype, tset):
         elements = []
@@ -178,7 +178,7 @@ def _to_expr(e, dtype):
                      else hl.literal(element, dtype.element_type)
                      for element in elements]
             indices, aggregations = unify_all(*exprs)
-            ir = ToSet(MakeArray([e._ir for e in exprs], tarray(dtype.element_type)))
+            ir = ToSet(MakeArray([e._ir for e in exprs], None))
             return expressions.construct_expr(ir, dtype, indices, aggregations)
     elif isinstance(dtype, ttuple):
         elements = []

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3353,7 +3353,7 @@ def empty_set(t: Union[HailType, str]) -> SetExpression:
     -------
     :class:`.SetExpression`
     """
-    return filter(lambda x: False, set([null(t)]))
+    return hl.set(empty_array(t))
 
 
 @typecheck(collection=expr_oneof(expr_set(), expr_array(), expr_dict()))
@@ -3404,7 +3404,8 @@ def empty_array(t: Union[HailType, str]) -> ArrayExpression:
     -------
     :class:`.ArrayExpression`
     """
-    return filter(lambda x: False, array([null(t)]))
+    ir = MakeArray([], t)
+    return construct_expr(ir, t)
 
 
 @typecheck(key_type=hail_type, value_type=hail_type)

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3404,8 +3404,9 @@ def empty_array(t: Union[HailType, str]) -> ArrayExpression:
     -------
     :class:`.ArrayExpression`
     """
-    ir = MakeArray([], t)
-    return construct_expr(ir, t)
+    array_t = hl.tarray(t)
+    ir = MakeArray([], array_t)
+    return construct_expr(ir, array_t)
 
 
 @typecheck(key_type=hail_type, value_type=hail_type)

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -356,7 +356,7 @@ class ApplyComparisonOp(IR):
 
 
 class MakeArray(IR):
-    @typecheck_method(args=sequenceof(IR), typ=hail_type)
+    @typecheck_method(args=sequenceof(IR), typ=nullable(hail_type))
     def __init__(self, args, typ):
         super().__init__(*args)
         self.args = args
@@ -367,7 +367,9 @@ class MakeArray(IR):
         return new_instance(list(args), self.typ)
 
     def render(self, r):
-        return '(MakeArray {} {})'.format(self.typ._jtype.parsableString(), ' '.join([r(x) for x in self.args]))
+        return '(MakeArray {} {})'.format(
+            self.typ._jtype.parsableString() if self.typ is not None else 'None',
+            ' '.join([r(x) for x in self.args]))
 
     def __eq__(self, other):
         return isinstance(other, MakeArray) and \

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2061,3 +2061,9 @@ class Tests(unittest.TestCase):
         assert hl.is_nan(infinite).value == False
         assert hl.is_nan(nan).value == True
         assert hl.is_nan(na).value == None
+
+    def test_array_and_if_requiredness(self):
+        mt = hl.import_vcf(resource('sample.vcf'), array_elements_required=True)
+        hl.tuple((mt.AD, mt.PL)).show()
+        hl.array([mt.AD, mt.PL]).show()
+        hl.array([mt.AD, [1,2]]).show()

--- a/hail/src/main/scala/is/hail/expr/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/Parser.scala
@@ -260,6 +260,10 @@ object Parser extends JavaTokenParsers {
       .toArray
   }
 
+  def type_expr_opt: Parser[Option[Type]] = type_expr ^^ {
+    Some(_)
+  } | "None" ^^ { _ => None }
+
   def type_expr: Parser[Type] = _required_type ~ _type_expr ^^ { case req ~ t => t.setRequired(req) }
 
   def _required_type: Parser[Boolean] = "+" ^^ { _ => true } | success(false)
@@ -536,7 +540,7 @@ object Parser extends JavaTokenParsers {
       "ApplyUnaryPrimOp" ~> ir_unary_op ~ ir_value_expr ^^ { case op ~ x => ir.ApplyUnaryPrimOp(op, x) } |
       "ApplyComparisonOp" ~> ir_comparison_op ~ ir_value_expr ~ ir_value_expr ^^ { case op ~ l ~ r => ir.ApplyComparisonOp(op, l, r) } |
       "ApplyComparisonOp" ~> ir_untyped_comparison_op ~ ir_value_expr ~ ir_value_expr ^^ { case op ~ l ~ r => ir.ApplyComparisonOp(ir.ComparisonOp.fromStringAndTypes(op, l.typ, r.typ), l, r) } |
-      "MakeArray" ~> type_expr ~ ir_children ^^ { case t ~ args => ir.MakeArray(args, t.asInstanceOf[TArray]) } |
+      "MakeArray" ~> type_expr_opt ~ ir_children ^^ { case t ~ args => ir.MakeArray.unify(args, t.map(_.asInstanceOf[TArray]).orNull) } |
       "ArrayRef" ~> ir_value_expr ~ ir_value_expr ^^ { case a ~ i => ir.ArrayRef(a, i) } |
       "ArrayLen" ~> ir_value_expr ^^ { a => ir.ArrayLen(a) } |
       "ArrayRange" ~> ir_value_expr ~ ir_value_expr ~ ir_value_expr ^^ { case start ~ stop ~ step => ir.ArrayRange(start, stop, step) } |

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -88,17 +88,16 @@ final case class ApplyComparisonOp(op: ComparisonOp, l: IR, r: IR) extends Infer
 
 object MakeArray {
   def unify(args: Seq[IR], typ: TArray = null): MakeArray = {
+    assert(typ != null || args.nonEmpty)
     var t = typ
     if (t == null) {
-      val typSet = args.map(_.typ).toSet
-      if (typSet.size == 1)
-        t = TArray(typSet.head)
-      else
-        t = TArray(args.head.typ.deepOptional())
-    } else
-      assert(t.elementType.deepOptional() == t.elementType ||
-        args.forall(a => a.typ == t.elementType),
-        s"${ t.parsableString() }: ${ args.map(a => "\n    " + a.typ.parsableString()).mkString } ")
+      t = if (args.tail.forall(_.typ == args.head.typ)) {
+        TArray(args.head.typ)
+      } else TArray(args.head.typ.deepOptional())
+    }
+    assert(t.elementType.deepOptional() == t.elementType ||
+      args.forall(a => a.typ == t.elementType),
+      s"${ t.parsableString() }: ${ args.map(a => "\n    " + a.typ.parsableString()).mkString } ")
 
     MakeArray(args.map { arg =>
       if (arg.typ == t.elementType)

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -112,10 +112,7 @@ object MakeArray {
   }
 }
 
-final case class MakeArray(args: Seq[IR], typ: TArray) extends IR {
-  assert(args.forall(a => a.typ == typ.elementType),
-    s"${ typ.parsableString() }: ${ args.map(a => "\n    " + a.typ.parsableString()).mkString } ")
-}
+final case class MakeArray(args: Seq[IR], typ: TArray) extends IR
 
 final case class ArrayRef(a: IR, i: IR) extends InferIR
 final case class ArrayLen(a: IR) extends IR { val typ = TInt32() }

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -144,8 +144,8 @@ object Simplify {
       case ArrayMap(ArrayMap(a, n1, b1), n2, b2) =>
         ArrayMap(a, n1, Let(n2, b1, b2))
 
-      case ArrayMap(MakeArray(args, typ), name, body) =>
-        MakeArray(args.map(a => Subst(body, Env.empty[IR].bind(name -> a))), typ)
+      case x@ArrayMap(MakeArray(args, typ), name, body) =>
+        MakeArray(args.map(a => Subst(body, Env.empty[IR].bind(name -> a))), x.typ)
 
       case GetField(MakeStruct(fields), name) =>
         val (_, x) = fields.find { case (n, _) => n == name }.get

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -144,6 +144,9 @@ object Simplify {
       case ArrayMap(ArrayMap(a, n1, b1), n2, b2) =>
         ArrayMap(a, n1, Let(n2, b1, b2))
 
+      case ArrayMap(MakeArray(args, typ), name, body) =>
+        MakeArray(args.map(a => Subst(body, Env.empty[IR].bind(name -> a))), typ)
+
       case GetField(MakeStruct(fields), name) =>
         val (_, x) = fields.find { case (n, _) => n == name }.get
         x

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -144,9 +144,6 @@ object Simplify {
       case ArrayMap(ArrayMap(a, n1, b1), n2, b2) =>
         ArrayMap(a, n1, Let(n2, b1, b2))
 
-      case x@ArrayMap(MakeArray(args, typ), name, body) =>
-        MakeArray(args.map(a => Subst(body, Env.empty[IR].bind(name -> a))), x.typ)
-
       case GetField(MakeStruct(fields), name) =>
         val (_, x) = fields.find { case (n, _) => n == name }.get
         x

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -71,13 +71,12 @@ object TypeCheck {
         assert(op.t2.fundamentalType == r.typ.fundamentalType)
         assert(x.typ == TBoolean())
       case x@MakeArray(args, typ) =>
-        if (args.length == 0)
-          assert(typ != null)
-        else {
-          args.foreach(check(_))
-          val t = args.head.typ
-          args.map(_.typ).zipWithIndex.tail.foreach { case (x, i) => assert(x.isOfType(t), s"at position $i type mismatch: $t $x") }
-          assert(x.typ == TArray(t))
+        assert(typ != null)
+        assert(args.forall(a => a.typ == typ.elementType),
+          s"${ typ.parsableString() }: ${ args.map(a => "\n    " + a.typ.parsableString()).mkString } ")
+        args.foreach(check(_))
+        args.map(_.typ).zipWithIndex.tail.foreach { case (x, i) => assert(x == typ.elementType,
+          s"at position $i type mismatch: ${ typ.parsableString() } ${ x.parsableString() }")
         }
       case x@ArrayRef(a, i) =>
         check(a)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -75,7 +75,7 @@ object TypeCheck {
         assert(args.forall(a => a.typ == typ.elementType),
           s"${ typ.parsableString() }: ${ args.map(a => "\n    " + a.typ.parsableString()).mkString } ")
         args.foreach(check(_))
-        args.map(_.typ).zipWithIndex.tail.foreach { case (x, i) => assert(x == typ.elementType,
+        args.map(_.typ).zipWithIndex.foreach { case (x, i) => assert(x == typ.elementType,
           s"at position $i type mismatch: ${ typ.parsableString() } ${ x.parsableString() }")
         }
       case x@ArrayRef(a, i) =>

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -72,12 +72,10 @@ object TypeCheck {
         assert(x.typ == TBoolean())
       case x@MakeArray(args, typ) =>
         assert(typ != null)
-        assert(args.forall(a => a.typ == typ.elementType),
-          s"${ typ.parsableString() }: ${ args.map(a => "\n    " + a.typ.parsableString()).mkString } ")
-        args.foreach(check(_))
         args.map(_.typ).zipWithIndex.foreach { case (x, i) => assert(x == typ.elementType,
           s"at position $i type mismatch: ${ typ.parsableString() } ${ x.parsableString() }")
         }
+        args.foreach(check(_))
       case x@ArrayRef(a, i) =>
         check(a)
         check(i)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -167,6 +167,18 @@ class IRSuite extends SparkSuite {
     assertEvalsTo(GetField(MakeStruct((0 until 20000).map(i => s"foo$i" -> I32(1))), "foo1"), 1)
   }
 
+  @Test def testMakeArrayWithDifferentRequiredness(): Unit = {
+    val t = TArray(TStruct("a" -> TInt32Required, "b" -> TArray(TInt32Optional, required = true)))
+    val value = Row(2, FastIndexedSeq(1))
+    assertEvalsTo(
+      MakeArray.unify(
+        Seq(NA(t.elementType.deepOptional()), In(0, t.elementType))
+      ),
+      FastIndexedSeq((value, t.elementType)),
+      FastIndexedSeq(null, value)
+    )
+  }
+
   @Test def testMakeTuple() {
     assertEvalsTo(MakeTuple(FastSeq()), Row())
     assertEvalsTo(MakeTuple(FastSeq(NA(TInt32()), 4, 0.5)), Row(null, 4, 0.5))


### PR DESCRIPTION
The core of the change is the MakeArray.unify method, and Python only passing the type when constructing an empty array. I added strong assertions about types. to that and the node constructor.