### PR TITLE
fix docker image cacheing

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -3,6 +3,8 @@
 
 hail-ci-build-image: GIT_SHA = $(shell git rev-parse HEAD) 
 hail-ci-build-image:
+	# pull the image at least once so it can be used as a cache source
+	docker pull $(shell cat ../hail-ci-build-image)
 	docker build . -t hail-pr-builder:${GIT_SHA} -f Dockerfile.pr-builder --cache-from $(shell cat ../hail-ci-build-image)
 
 push-hail-ci-build-image: GIT_SHA = $(shell git rev-parse HEAD)


### PR DESCRIPTION
cc: @cseed @tpoterba

docker does not pull an image specified in --cache-from, so we need to
explicitly pull it before trying to use it as a cache