### PR TITLE
Add new string representation of values for Table.show

### DIFF
--- a/hail/src/main/scala/is/hail/expr/types/TArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/TArray.scala
@@ -62,4 +62,13 @@ final case class TArray(elementType: Type, override val required: Boolean = fals
     ExtendedOrdering.iterableOrdering(elementType.ordering)
 
   override def scalaClassTag: ClassTag[IndexedSeq[AnyRef]] = classTag[IndexedSeq[AnyRef]]
+
+  override def _showStr(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder): Unit = {
+    val array = a.asInstanceOf[IndexedSeq[Any]]
+    sb.append('[')
+    array.foreachBetween({ elt => elementType._showStrNA(elt, cfg, sb) }) {
+      sb.append(',')
+    }
+    sb.append(']')
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/types/TBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/TBaseStruct.scala
@@ -218,4 +218,13 @@ abstract class TBaseStruct extends Type {
       case _ => fieldOffset
     }
   }
+
+  override def _showStr(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder): Unit = {
+    val r = a.asInstanceOf[Row]
+    sb.append('(')
+    types.zipWithIndex.foreachBetween({ case (t, i) => t._showStrNA(r.get(i), cfg, sb) }) {
+      sb.append(',')
+    }
+    sb.append(')')
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/types/TDict.scala
+++ b/hail/src/main/scala/is/hail/expr/types/TDict.scala
@@ -77,4 +77,18 @@ final case class TDict(keyType: Type, valueType: Type, override val required: Bo
 
   val ordering: ExtendedOrdering =
     ExtendedOrdering.mapOrdering(elementType.ordering)
+
+
+  override def _showStr(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder): Unit = {
+    val dict = a.asInstanceOf[Map[Any, Any]]
+    sb.append('{')
+    dict.foreachBetween({ case (k, v) =>
+      keyType._showStrNA(k, cfg, sb)
+      sb.append(':')
+      valueType._showStrNA(v, cfg, sb)
+    }) {
+      sb.append(',')
+    }
+    sb.append('}')
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/types/TFloat32.scala
+++ b/hail/src/main/scala/is/hail/expr/types/TFloat32.scala
@@ -26,6 +26,9 @@ class TFloat32(override val required: Boolean) extends TNumeric {
 
   override def str(a: Annotation): String = if (a == null) "NA" else a.asInstanceOf[Float].formatted("%.5e")
 
+  override def _showStr(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder): Unit =
+    sb.append(cfg.floatFormat.format(a.asInstanceOf[Float]))
+
   override def genNonmissingValue: Gen[Annotation] = arbitrary[Double].map(_.toFloat)
 
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean): Boolean =

--- a/hail/src/main/scala/is/hail/expr/types/TFloat64.scala
+++ b/hail/src/main/scala/is/hail/expr/types/TFloat64.scala
@@ -26,6 +26,9 @@ class TFloat64(override val required: Boolean) extends TNumeric {
 
   override def str(a: Annotation): String = if (a == null) "NA" else a.asInstanceOf[Double].formatted("%.5e")
 
+  override def _showStr(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder): Unit =
+    sb.append(cfg.floatFormat.format(a.asInstanceOf[Double]))
+
   override def genNonmissingValue: Gen[Annotation] = arbitrary[Double]
 
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean): Boolean =

--- a/hail/src/main/scala/is/hail/expr/types/TSet.scala
+++ b/hail/src/main/scala/is/hail/expr/types/TSet.scala
@@ -54,4 +54,13 @@ final case class TSet(elementType: Type, override val required: Boolean = false)
   override def genNonmissingValue: Gen[Annotation] = Gen.buildableOf[Set](elementType.genValue)
 
   override def scalaClassTag: ClassTag[Set[AnyRef]] = classTag[Set[AnyRef]]
+
+  override def _showStr(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder): Unit = {
+    val set = a.asInstanceOf[Set[Any]]
+    sb.append('{')
+    set.foreachBetween({ elt => elementType._showStrNA(elt, cfg, sb) }) {
+      sb.append(',')
+    }
+    sb.append('}')
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/types/TString.scala
+++ b/hail/src/main/scala/is/hail/expr/types/TString.scala
@@ -34,6 +34,12 @@ class TString(override val required: Boolean) extends Type {
   override def byteSize: Long = 8
 
   override def fundamentalType: Type = TBinary(required)
+
+  override def _showStr(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder): Unit = {
+    sb.append('"')
+    sb.append(StringEscapeUtils.escapeString(a.asInstanceOf[String]))
+    sb.append('"')
+  }
 }
 
 object TString {

--- a/hail/src/main/scala/is/hail/expr/types/Type.scala
+++ b/hail/src/main/scala/is/hail/expr/types/Type.scala
@@ -203,7 +203,8 @@ abstract class Type extends BaseType with Serializable {
     if (a == null)
       sb.append(cfg.missing)
     else
-      _showStr(a, cfg, sb)}
+      _showStr(a, cfg, sb)
+  }
 
   def _showStr(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder): Unit = sb.append(str(a))
 

--- a/hail/src/main/scala/is/hail/expr/types/Type.scala
+++ b/hail/src/main/scala/is/hail/expr/types/Type.scala
@@ -188,6 +188,25 @@ abstract class Type extends BaseType with Serializable {
 
   def str(a: Annotation): String = if (a == null) "NA" else a.toString
 
+  final def showStr(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder = null): String = {
+    val sb_ = if (sb == null)
+      new StringBuilder
+    else {
+      sb.clear()
+      sb
+    }
+    _showStrNA(a, cfg, sb_)
+    sb_.result()
+  }
+
+  final def _showStrNA(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder): Unit = {
+    if (a == null)
+      sb.append(cfg.missing)
+    else
+      _showStr(a, cfg, sb)}
+
+  def _showStr(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder): Unit = sb.append(str(a))
+
   def toJSON(a: Annotation): JValue = JSONAnnotationImpex.exportAnnotation(a, this)
 
   def genNonmissingValue: Gen[Annotation] = ???

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -656,13 +656,15 @@ class Table(val hc: HailContext, val tir: TableIR) {
     convertType(signature, null, headerBuilder)
     val (names, types, rightAlign) = headerBuilder.result().unzip3
 
+    val sb = new StringBuilder()
+    val config = ShowStrConfig()
     def convertValue(t: Type, v: Annotation, ab: ArrayBuilder[String]) {
       t match {
         case s: TStruct =>
           val r = v.asInstanceOf[Row]
           s.fields.foreach(f => convertValue(f.typ, if (r == null) null else r.get(f.index), ab))
         case _ =>
-          ab += t.str(v)
+          ab += t.showStr(v, config, sb)
       }
     }
 
@@ -699,7 +701,6 @@ class Table(val hc: HailContext, val tir: TableIR) {
       }
     }
 
-    val sb = new StringBuilder()
     sb.clear()
 
     // writes cols [startIndex, endIndex)

--- a/hail/src/main/scala/is/hail/utils/ShowStrConfig.scala
+++ b/hail/src/main/scala/is/hail/utils/ShowStrConfig.scala
@@ -1,0 +1,6 @@
+package is.hail.utils
+
+
+case class ShowStrConfig(
+  floatFormat: String = "%.2e",
+  missing: String = "NA")


### PR DESCRIPTION
Important differences:
 - quotes around strings, always. this fixes problems
   like newlines which we weren't handling correctly
 - don't default to json, use python-repr-like syntax
 - print structs and tuples the same (like tuples). This
   might be contentious, but it'll only happen inside
   nested objects where the inline field names is going
   to blow out character limits anyway.

It should still be totally parsable (won't generate
patterns that are ambiguous), though we'd need to
write a separate parser for it.