### PR TITLE
document repartitioning after heavy filter when going to block matrix

### DIFF
--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -386,6 +386,10 @@ class BlockMatrix(object):
 
         Warning
         -------
+        If the rows of the matrix table have been filtered to a small fraction,
+        then :meth:`.MatrixTable.repartition` before this method to improve
+        performance.
+
         If you encounter a Hadoop write/replication error, increase the
         number of persistent workers or the disk size per persistent worker,
         or use :meth:`write_from_entry_expr` to write to external storage.
@@ -626,6 +630,10 @@ class BlockMatrix(object):
 
         Warning
         -------
+        If the rows of the matrix table have been filtered to a small fraction,
+        then :meth:`.MatrixTable.repartition` before this method to improve
+        performance.
+
         This method opens ``n_cols / block_size`` files concurrently per task.
         To not blow out memory when the number of columns is very large,
         limit the Hadoop write buffer size; e.g. on GCP, set this property on

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -713,6 +713,10 @@ def linear_mixed_model(y,
     `mean_impute` to false if you expect no missing values, both for performance
     and as a sanity check.
 
+    In the example, if the markers constitute a small fraction of the original
+    data, then :meth:`.MatrixTable.repartition` before applying this method for
+    better performance.
+
     Parameters
     ----------
     y: :class:`.Float64Expression`


### PR DESCRIPTION
I'm still not sure why writing to block matrix after a deep filter performs so badly, but in the meantime I want to document the fix.