### PR TITLE
Add TableMultiWayZipJoin IR Node

### DIFF
--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -249,6 +249,20 @@ class TableRename(TableIR):
                f'{r(self.child)})'
 
 
+class TableMultiWayZipJoin(TableIR):
+    def __init__(self, childs, data_name, global_name):
+        super().__init__()
+        self.childs = childs
+        self.data_name = data_name
+        self.global_name = global_name
+
+    def render(self, r):
+        return f'(TableMultiWayZipJoin '\
+               f'"{escape_str(self.data_name)}" '\
+               f'"{escape_str(self.global_name)}" '\
+               f'{" ".join([r(child) for child in self.childs])})'
+
+
 class JavaTable(TableIR):
     def __init__(self, jir):
         self._jir = jir

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2593,4 +2593,11 @@ class Table(ExprContainer):
     def _unlocalize_entries(self, cols, entries_field_name):
         return hl.MatrixTable(self._jt.unlocalizeEntries(cols._jt, entries_field_name))
 
+    @staticmethod
+    def _multi_way_zip_join(tables, data_field_name, global_field_name):
+        jt = Env.hail().table.Table.multiWayZipJoin([t._jt for t in tables],
+                                                    data_field_name,
+                                                    global_field_name)
+        return Table(jt)
+
 table_type.set(Table)

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -146,7 +146,8 @@ class TableIRTests(unittest.TestCase):
             ir.TableOrderBy(ir.TableKeyBy(table_read, []), [('m', 'A'), ('m', 'D')]),
             ir.TableDistinct(table_read),
             ir.LocalizeEntries(matrix_read, '__entries'),
-            ir.TableRename(table_read, {'idx': 'idx_foo'}, {'global_f32': 'global_foo'})
+            ir.TableRename(table_read, {'idx': 'idx_foo'}, {'global_f32': 'global_foo'}),
+            ir.TableMultiWayZipJoin([table_read, table_read], '__data', '__globals'),
         ]
 
         return table_irs

--- a/hail/src/main/scala/is/hail/annotations/OrderedRVIterator.scala
+++ b/hail/src/main/scala/is/hail/annotations/OrderedRVIterator.scala
@@ -14,7 +14,7 @@ object OrderedRVIterator {
     val first = its(0)
     val flipbooks = its.map(_.iterator.toFlipbookIterator)
     FlipbookIterator.multiZipJoin(
-      flipbooks,
+      flipbooks.toArray,
       null,
       first.t.joinComp(first.t).compare
     )

--- a/hail/src/main/scala/is/hail/annotations/OrderedRVIterator.scala
+++ b/hail/src/main/scala/is/hail/annotations/OrderedRVIterator.scala
@@ -4,11 +4,9 @@ import is.hail.rvd.{RVDType, RVDContext}
 import is.hail.utils._
 
 import scala.collection.generic.Growable
-import scala.collection.mutable
-import scala.reflect.ClassTag
 
 object OrderedRVIterator {
-  def multiZipJoin[A: ClassTag](
+  def multiZipJoin(
     its: IndexedSeq[OrderedRVIterator]
   ): Iterator[Array[RegionValue]] = {
     require(its.length > 0)

--- a/hail/src/main/scala/is/hail/annotations/OrderedRVIterator.scala
+++ b/hail/src/main/scala/is/hail/annotations/OrderedRVIterator.scala
@@ -4,6 +4,7 @@ import is.hail.rvd.{RVDType, RVDContext}
 import is.hail.utils._
 
 import scala.collection.generic.Growable
+import scala.collection.mutable
 
 object OrderedRVIterator {
   def multiZipJoin(

--- a/hail/src/main/scala/is/hail/annotations/OrderedRVIterator.scala
+++ b/hail/src/main/scala/is/hail/annotations/OrderedRVIterator.scala
@@ -5,6 +5,22 @@ import is.hail.utils._
 
 import scala.collection.generic.Growable
 import scala.collection.mutable
+import scala.reflect.ClassTag
+
+object OrderedRVIterator {
+  def multiZipJoin[A: ClassTag](
+    its: IndexedSeq[OrderedRVIterator]
+  ): Iterator[Array[RegionValue]] = {
+    require(its.length > 0)
+    val first = its(0)
+    val flipbooks = its.map(_.iterator.toFlipbookIterator)
+    FlipbookIterator.multiZipJoin(
+      flipbooks,
+      null,
+      first.t.joinComp(first.t).compare
+    )
+  }
+}
 
 case class OrderedRVIterator(
   t: RVDType,

--- a/hail/src/main/scala/is/hail/expr/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/Parser.scala
@@ -611,6 +611,9 @@ object Parser extends JavaTokenParsers {
       "TableJoin" ~> ir_identifier ~ int32_literal ~ table_ir ~ table_ir ^^ { case joinType ~ joinKey ~ left ~ right =>
         ir.TableJoin(left, right, joinType, joinKey) } |
       "TableLeftJoinRightDistinct" ~> ir_identifier ~ table_ir ~ table_ir ^^ { case root ~ left ~ right => ir.TableLeftJoinRightDistinct(left, right, root) } |
+      "TableMultiWayZipJoin" ~> string_literal ~ string_literal ~ table_ir_children ^^ { case dataName ~ globalsName ~ children =>
+        ir.TableMultiWayZipJoin(children, dataName, globalsName)
+      } |
       "TableParallelize" ~> int32_literal_opt ~ ir_value_expr ^^ { case nPartitions ~ rows =>
         ir.TableParallelize(rows, nPartitions)
       } |

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -260,6 +260,9 @@ object Pretty {
             case TableHead(_, n) => n.toString
             case TableJoin(_, _, joinType, joinKey) => s"$joinType $joinKey"
             case TableLeftJoinRightDistinct(_, _, root) => prettyIdentifier(root)
+            case TableMultiWayZipJoin(_, dataName, globalName) =>
+              s"${prettyStringLiteral(dataName)} ${prettyStringLiteral(globalName)}"
+            case TableMapRows(_, _, newKey) => prettyIdentifiersOpt(newKey)
             case TableKeyByAndAggregate(_, _, _, nPartitions, bufferSize) =>
               prettyIntOpt(nPartitions) + " " + bufferSize.toString
             case TableExplode(_, field) => field

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -262,7 +262,6 @@ object Pretty {
             case TableLeftJoinRightDistinct(_, _, root) => prettyIdentifier(root)
             case TableMultiWayZipJoin(_, dataName, globalName) =>
               s"${prettyStringLiteral(dataName)} ${prettyStringLiteral(globalName)}"
-            case TableMapRows(_, _, newKey) => prettyIdentifiersOpt(newKey)
             case TableKeyByAndAggregate(_, _, _, nPartitions, bufferSize) =>
               prettyIntOpt(nPartitions) + " " + bufferSize.toString
             case TableExplode(_, field) => field

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -271,6 +271,21 @@ object PruneDeadFields {
             // don't memoize right if we are going to elide it during rebuild
             memoizeTableIR(left, requestedType, memo)
         }
+      case TableMultiWayZipJoin(children, fieldName, globalName) =>
+        val gType = requestedType.globalType.fieldOption(globalName)
+          .map(_.typ.asInstanceOf[TArray].elementType)
+          .getOrElse(TStruct()).asInstanceOf[TStruct]
+        val rType = requestedType.rowType.fieldOption(fieldName)
+          .map(_.typ.asInstanceOf[TArray].elementType)
+          .getOrElse(TStruct()).asInstanceOf[TStruct]
+        children.foreach { child =>
+          val dep = child.typ.copy(
+            rowType = TStruct(child.typ.rowType.required, child.typ.rowType.fieldNames.flatMap(f =>
+                child.typ.keyType.fieldOption(f).orElse(rType.fieldOption(f)).map(reqF => f -> reqF.typ)
+              ): _*),
+            globalType = gType)
+          memoizeTableIR(child, dep, memo)
+        }
       case TableExplode(child, field) =>
         val minChild = minimal(child.typ)
         val dep2 = unify(child.typ, requestedType.copy(rowType = requestedType.rowType.filter(_.name != field)._1),

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -517,7 +517,7 @@ case class TableMultiWayZipJoin(children: IndexedSeq[TableIR], fieldName: String
 
       it.map { rvs =>
         val len = rvs.length
-        val rv = rvs.dropWhile(rv => rv == null).head
+        val rv = rvs.find(rv => rv != null).get
         rvb.set(rv.region)
         rvb.start(localNewRowType)
         rvb.startStruct()

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -491,7 +491,7 @@ case class TableMultiWayZipJoin(children: IndexedSeq[TableIR], fieldName: String
   require(rest.forall(e => e.typ.globalType == first.typ.globalType),
     "all globals must have the same type")
 
-  private val rvdType = OrderedRVDType(first.typ.key, first.typ.rowType)
+  private val rvdType = OrderedRVDType(first.typ.rowType, first.typ.key)
   private val newGlobalType = TStruct(globalName -> TArray(first.typ.globalType))
   private val newValueType = TStruct(fieldName -> TArray(rvdType.valueType))
   private val newRowType = rvdType.kType ++ newValueType
@@ -548,7 +548,7 @@ case class TableMultiWayZipJoin(children: IndexedSeq[TableIR], fieldName: String
     val childRanges = childRVDs.flatMap(_.partitioner.rangeBounds)
     val newPartitioner = OrderedRVDPartitioner.generate(childRVDs.head.typ.kType, childRanges)
     val repartitionedRVDs = childRVDs.map(_.constrainToOrderedPartitioner(newPartitioner))
-    val newORVDType = OrderedRVDType(localRVDType.key, localNewRowType)
+    val newORVDType = OrderedRVDType(localNewRowType, localRVDType.key)
     val orvd = OrderedRVD.alignAndZipNPartitions(repartitionedRVDs, newORVDType) { (ctx, its) =>
       val orvIters = its.map(it => OrderedRVIterator(localRVDType, it, ctx))
       rvMerger(OrderedRVIterator.multiZipJoin(orvIters))

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -188,7 +188,7 @@ case class TableImport(paths: Array[String], typ: TableType, readerOpts: TableRe
   * Let n be the longest common prefix of 'keys' and the old key, i.e. the
   * number of key fields that are not being changed.
   * - If 'isSorted', then 'child' must already be sorted by 'keys', and n must
-  *   not be zero. Thus, if 'isSorted', TableKeyBy will not shuffle or scan. 
+  *   not be zero. Thus, if 'isSorted', TableKeyBy will not shuffle or scan.
   *   The new partitioner will be the old one with partition bounds truncated
   *   to length n.
   * - If n = 'keys.length', i.e. we are simply shortening the key, do nothing

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -1176,17 +1176,17 @@ object RVD {
   }
 
   def alignAndZipNPartitions(
-    orvds: IndexedSeq[OrderedRVD],
-    newTyp: OrderedRVDType
+    rvds: IndexedSeq[RVD],
+    newTyp: RVDType
   )(zipper: (RVDContext, Array[Iterator[RegionValue]]) => Iterator[RegionValue]
-  ): OrderedRVD = {
-    val first = orvds.head
+  ): RVD = {
+    val first = rvds.head
     require(newTyp.kType isIsomorphicTo first.typ.kType)
-    require(orvds.forall(_.typ.kType isIsomorphicTo first.typ.kType))
+    require(rvds.forall(_.typ.kType isIsomorphicTo first.typ.kType))
 
-    val crdds = orvds.map(RepartitionedOrderedRDD2(_, first.partitioner.rangeBounds).boundary)
+    val crdds = rvds.map(RepartitionedOrderedRDD2(_, first.partitioner.rangeBounds).boundary)
 
-    OrderedRVD(
+    RVD(
       typ = newTyp,
       partitioner = first.partitioner,
       crdd = ContextRDD.czipNPartitions(crdds)(zipper))

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -1175,23 +1175,6 @@ object RVD {
       })
   }
 
-  def alignAndZipNPartitions(
-    rvds: IndexedSeq[RVD],
-    newTyp: RVDType
-  )(zipper: (RVDContext, Array[Iterator[RegionValue]]) => Iterator[RegionValue]
-  ): RVD = {
-    val first = rvds.head
-    require(newTyp.kType isIsomorphicTo first.typ.kType)
-    require(rvds.forall(_.typ.kType isIsomorphicTo first.typ.kType))
-
-    val crdds = rvds.map(RepartitionedOrderedRDD2(_, first.partitioner.rangeBounds).boundary)
-
-    RVD(
-      typ = newTyp,
-      partitioner = first.partitioner,
-      crdd = ContextRDD.czipNPartitions(crdds)(zipper))
-  }
-
   def apply(
     typ: RVDType,
     partitioner: RVDPartitioner,

--- a/hail/src/main/scala/is/hail/sparkextras/MultiWayJoinRDD.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/MultiWayJoinRDD.scala
@@ -1,0 +1,52 @@
+package is.hail.sparkextras
+
+import org.apache.spark.{OneToOneDependency, Partition, SparkContext, TaskContext}
+import org.apache.spark.rdd.RDD
+
+import scala.reflect.ClassTag
+
+object MultiWayJoinRDD {
+  def apply[T: ClassTag , V: ClassTag](
+    rdds: IndexedSeq[RDD[T]],
+    preservesPartitioning: Boolean = false
+  )(f: (Array[Iterator[T]]) => Iterator[V]): MultiWayJoinRDD[T, V] = {
+    new MultiWayJoinRDD(rdds.head.sparkContext, rdds, f, preservesPartitioning)
+  }
+}
+
+private class MultiWayJoinPartition[T: ClassTag](
+  idx: Int,
+  @transient private val rdds: Seq[RDD[T]]
+) extends Partition {
+  override val index: Int = idx
+  var partitionVals = rdds.map(rdd => rdd.partitions(idx))
+  def partitions = partitionVals
+}
+
+class MultiWayJoinRDD[T: ClassTag, V: ClassTag](
+  sc: SparkContext,
+  var rdds: IndexedSeq[RDD[T]],
+  var f: (Array[Iterator[T]]) => Iterator[V],
+  preservesPartitioning: Boolean = false
+) extends RDD[V](sc, rdds.map(x => new OneToOneDependency(x))) {
+
+  override val partitioner = if (preservesPartitioning) firstParent[Any].partitioner else None
+
+  override def getPartitions: Array[Partition] = {
+    val numParts = rdds(0).partitions.length
+    require(rdds.forall(rdd => rdd.partitions.length == numParts))
+    Array.tabulate[Partition](numParts)(new MultiWayJoinPartition(_, rdds))
+  }
+
+  override def compute(s: Partition, tc: TaskContext) = {
+    val partitions = s.asInstanceOf[MultiWayJoinPartition[T]].partitions
+    val arr = Array.tabulate(rdds.length)(i => rdds(i).iterator(partitions(i), tc))
+    f(arr)
+  }
+
+  override def clearDependencies() {
+    super.clearDependencies
+    rdds = null
+    f = null
+  }
+}

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -207,7 +207,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
   )
 
   def typ: TableType = tir.typ
-  
+
   lazy val value: TableValue = {
     val opt = LiftLiterals(ir.Optimize(tir)).asInstanceOf[TableIR]
     opt.execute(hc)

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -178,6 +178,16 @@ object Table {
     }
     return true
   }
+
+    def multiWayZipJoin(tables: java.util.ArrayList[Table], fieldName: String, globalName: String): Table = {
+      val tabs = tables.asScala.toFastIndexedSeq
+      new Table(
+        tabs.head.hc,
+        TableMultiWayZipJoin(
+          tabs.map(_.tir),
+          fieldName,
+          globalName))
+    }
 }
 
 class Table(val hc: HailContext, val tir: TableIR) {

--- a/hail/src/main/scala/is/hail/utils/FlipbookIterator.scala
+++ b/hail/src/main/scala/is/hail/utils/FlipbookIterator.scala
@@ -88,7 +88,7 @@ object FlipbookIterator {
   def empty[A] = StagingIterator(StateMachine.terminal[A])
 
   def multiZipJoin[A: ClassTag](
-    its: IndexedSeq[FlipbookIterator[A]],
+    its: Array[FlipbookIterator[A]],
     default: A,
     ord: (A, A) => Int
   ): FlipbookIterator[Array[A]] = {

--- a/hail/src/main/scala/is/hail/utils/FlipbookIterator.scala
+++ b/hail/src/main/scala/is/hail/utils/FlipbookIterator.scala
@@ -2,7 +2,6 @@ package is.hail.utils
 
 import scala.collection.GenTraversableOnce
 import scala.collection.generic.Growable
-import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 
 /**
@@ -97,7 +96,7 @@ object FlipbookIterator {
       private val len = its.length
       var value: Array[A] = Array.fill(len)(default)
       var isValid = true
-      var buf = new ArrayBuffer[Int]
+      var buf = new ArrayBuilder[Int](len)
       def advance() {
         buf.clear()
         var smallest = -1
@@ -108,22 +107,22 @@ object FlipbookIterator {
         }
 
         i = 0
-        staging.map(_.stage())
+        staging.foreach(_.stage())
         while (i < its.length) {
           if (staging(i).isValid) {
             if (smallest == -1) { // set the minimum
               smallest = i
-              buf.append(i)
+              buf += i
             } else {
             // check the current value against the smallest, if they are the same, add
             // the index to the buffer, if it is greater, do nothing, if it is less,
             // less, clear the buffer, and set the smallest index
               val c = ord(staging(smallest).value, staging(i).value)
               if (c == 0) {
-                buf.append(i)
+                buf += i
               } else if (c > 0) {
                 buf.clear()
-                buf.append(i)
+                buf += i
                 smallest = i
               }
             }
@@ -136,8 +135,9 @@ object FlipbookIterator {
           return
         }
 
-        for (i <- buf) {
-          value(i) = staging(i).consume()
+        i = 0; while (i < buf.length) {
+          value(buf(i)) = staging(buf(i)).consume
+          i += 1
         }
       }
     }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -587,6 +587,7 @@ class IRSuite extends SparkSuite {
         TableJoin(read,
           TableRange(100, 10), "inner", 1),
         TableLeftJoinRightDistinct(read, TableRange(100, 10), "root"),
+        TableMultiWayZipJoin(IndexedSeq(read, read), " * data * ", "globals"),
         MatrixEntriesTable(mtRead),
         MatrixRowsTable(mtRead),
         TableRepartition(read, 10, false),

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -47,7 +47,7 @@ class TableIRSuite extends SparkSuite {
     val newRow = InsertFields(oldRow, Seq("range" -> IRScanCollect(GetField(oldRow, "idx"))))
     val newTable = TableMapRows(t, newRow)
     val rows = Interpret[IndexedSeq[Row]](TableAggregate(newTable, IRAggCollect(Ref("row", newRow.typ))), optimize = false)
-    assert(rows.forall { case Row(row_idx: Int, range: IndexedSeq[Int]) => range sameElements Array.range(0, row_idx)})
+    assert(rows.forall { case Row(row_idx: Int, range: IndexedSeq[_]) => range sameElements Array.range(0, row_idx)})
   }
 
   val rowType = TStruct(("A", TInt32()), ("B", TInt32()), ("C", TInt32()))

--- a/hail/src/test/scala/is/hail/utils/FlipbookIteratorSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/FlipbookIteratorSuite.scala
@@ -276,7 +276,7 @@ class FlipbookIteratorSuite extends SparkSuite {
     val one = makeTestIterator(1, 2, 2, 4, 5, 5, 1000, 1000)
     val two = makeTestIterator(2, 3, 4, 5, 5, 6, 1000, 1000)
     val three = makeTestIterator(2, 3, 4, 4, 5, 6, 1000, 1000)
-    val its = IndexedSeq(one, two, three)
+    val its: Array[FlipbookIterator[Box[Int]]] = Array(one, two, three)
     val zipped = FlipbookIterator.multiZipJoin(its, Box(0), boxIntOrd(missingValue = 1000))
 
     val it = Iterator(


### PR DESCRIPTION
TableMultiWayZipJoin takes a list of TableIRs in addition to strings fieldName and globalName. All TableIRs must have the same type. The output is a single TableIR with rowType being the key and an array of structs holding all non-key fields. The globalType is an array of the children's globalType, named globalName.

This is a zip join. The number of rows for a given key will be the maximum number of rows with that key in any of the child tables. This ensures that all data in the input is present in some row of the output even if it is not as complete for describing the relations of the data as a true product would be.