### PR TITLE
set up deployment for site

### DIFF
--- a/batch/get-deployed-sha.sh
+++ b/batch/get-deployed-sha.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ex
+
+kubectl get --selector=app=batch deployments -o "jsonpath={.items[*].metadata.labels.hail\.is/sha}"

--- a/batch/hail-ci-deploy.sh
+++ b/batch/hail-ci-deploy.sh
@@ -1,34 +1,24 @@
+#!/bin/bash
 set -ex
+
+source activate hail-batch
 
 gcloud -q auth activate-service-account \
   --key-file=/secrets/gcr-push-service-account-key.json
 
 gcloud -q auth configure-docker
 
-SHA=$(git rev-parse --short=12 HEAD)
-
-# get sha label of batch deployment
-DEPLOYED_SHA=$(kubectl get --selector=app=batch deployments -o "jsonpath={.items[*].metadata.labels.hail\.is/sha}")
-
-if [[ $(git cat-file -t "$DEPLOYED_SHA" 2>/dev/null || true) == commit ]]; then
-    if [[ "$SHA" == "$DEPLOYED_SHA" ]]; then
-	exit 0
-    fi
-
-    NEEDS_REDEPLOY=$(cd $ROOT && python3 project-changed.py $DEPLOYED_SHA batch)
-    if [[ $NEEDS_REDEPLOY = no ]]; then
-        exit 0
-    fi
-fi
-
 # requires docker
 make push-batch
+
+SHA=$(git rev-parse --short=12 HEAD)
 
 sed -e "s,@sha@,$SHA," \
     -e "s,@image@,$(cat batch-image)," \
     < deployment.yaml.in > deployment.yaml
 
 kubectl apply -f deployment.yaml
+kubectl rollout status deployment batch-deployment
 
 # ci can't recover from batch restart yet
 kubectl delete pods -l app=hail-ci

--- a/hail-ci-build.sh
+++ b/hail-ci-build.sh
@@ -7,7 +7,7 @@ for project in $PROJECTS; do
     if [[ -e $project/hail-ci-build.sh ]]; then
         CHANGED=$(python3 project-changed.py target/$TARGET_BRANCH $project)
         if [[ $CHANGED != no ]]; then
-	    (cd $project && /bin/bash hail-ci-build.sh)
-	fi
+            (cd $project && /bin/bash hail-ci-build.sh)
+        fi
     fi
 done

--- a/hail-ci-build.sh
+++ b/hail-ci-build.sh
@@ -4,12 +4,10 @@ set -ex
 PROJECTS='hail batch ci site scorecard cloudtools'
 
 for project in $PROJECTS; do
-    CHANGED=$(python3 project-changed.py target/$TARGET_BRANCH $project)
-    if [[ $CHANGED != no ]]; then
-	if [[ -e $project/hail-ci-build.sh ]]; then
+    if [[ -e $project/hail-ci-build.sh ]]; then
+        CHANGED=$(python3 project-changed.py target/$TARGET_BRANCH $project)
+        if [[ $CHANGED != no ]]; then
 	    (cd $project && /bin/bash hail-ci-build.sh)
 	fi
     fi
 done
-
-    

--- a/hail-ci-deploy.sh
+++ b/hail-ci-deploy.sh
@@ -3,3 +3,4 @@ set -ex
 
 (cd hail && /bin/bash hail-ci-deploy.sh)
 (cd batch && /bin/bash hail-ci-deploy.sh)
+(cd site && /bin/bash hail-ci-deploy.sh)

--- a/hail-ci-deploy.sh
+++ b/hail-ci-deploy.sh
@@ -1,6 +1,24 @@
 #!/bin/bash
 set -ex
 
-(cd hail && /bin/bash hail-ci-deploy.sh)
-(cd batch && /bin/bash hail-ci-deploy.sh)
-(cd site && /bin/bash hail-ci-deploy.sh)
+PROJECTS='hail batch ci site scorecard cloudtools'
+
+SHA=$(git rev-parse --short=12 HEAD)
+
+for project in $PROJECTS; do
+    if [[ -e $project/hail-ci-deploy.sh ]]; then
+        CHANGED=yes # default
+        if [[ -e $project/get-deployed-sha.sh ]]; then
+            DEPLOYED_SHA=$(cd $project && /bin/bash get-deployed-sha.sh 2>/dev/null || true)
+            if [[ $DEPLOYED_SHA != $SHA ]]; then
+                if [[ $(git cat-file -t "$DEPLOYED_SHA" 2>/dev/null || true) == commit ]]; then
+                    CHANGED=$(python3 project-changed.py $DEPLOYED_SHA hail)
+                fi
+            fi
+        fi
+        
+        if [[ $CHANGED != no ]]; then
+            (cd $project && /bin/bash hail-ci-deploy.sh)
+        fi
+    fi
+done

--- a/hail/get-deployed-sha.sh
+++ b/hail/get-deployed-sha.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ex
+
+SPARK_VERSION=2.2.0
+BRANCH=devel
+CLOUDTOOLS_VERSION=2
+HASH_TARGET=gs://hail-common/builds/${BRANCH}/latest-hash/cloudtools-${CLOUDTOOLS_VERSION}-spark-${SPARK_VERSION}.txt
+
+gsutil cat ${HASH_TARGET} || true

--- a/hail/hail-ci-deploy.sh
+++ b/hail/hail-ci-deploy.sh
@@ -1,24 +1,11 @@
 #!/bin/bash
 set -ex
 
-ROOT=$(cd .. && pwd)
-
 SPARK_VERSION=2.2.0
 BRANCH=devel
 CLOUDTOOLS_VERSION=2
 HASH_TARGET=gs://hail-common/builds/${BRANCH}/latest-hash/cloudtools-${CLOUDTOOLS_VERSION}-spark-${SPARK_VERSION}.txt
 SHA=$(git rev-parse --short=12 HEAD)
-
-DEPLOYED_SHA=$(gsutil cat ${HASH_TARGET})
-
-if [[ $SHA == $DEPLOYED_SHA ]]; then
-    exit 0
-fi
-
-NEEDS_REDEPLOY=$(cd $ROOT && python3 project-changed.py $DEPLOYED_SHA hail)
-if [[ $NEEDS_REDEPLOY = no ]]; then
-    exit 0
-fi
 
 gcloud auth activate-service-account \
   --key-file=/secrets/ci-deploy-0-1--hail-is-hail.json

--- a/scorecard/Makefile
+++ b/scorecard/Makefile
@@ -3,9 +3,11 @@
 build:
 	docker build . -t scorecard
 
+push-site: IMAGE = gcr.io/broad-ctsa/scorecard:$(shell docker images -q --no-trunc site | sed -e 's,[^:]*:,,')
 push: build
-	docker tag scorecard gcr.io/broad-ctsa/scorecard
-	docker push gcr.io/broad-ctsa/scorecard
+	echo $(IMAGE) > scorecard-image
+	docker tag scorecard $(IMAGE)
+	docker push $(IMAGE)
 
 run-docker:
 	docker run -i -p 5000:5000 -v secrets:/secrets -t scorecard
@@ -14,6 +16,7 @@ run:
 	GITHUB_TOKEN_PATH=secrets/scorecard-github-access-token.txt python scorecard/scorecard.py
 
 deploy:
-	kubectl delete -f deployment.yaml
-	sleep 5
-	kubectl create -f deployment.yaml
+	sed -e "s,@sha@,$(shell git rev-parse --short=12 HEAD)," \
+	  -e "s,@image@,$(shell cat scorecard-image)," \
+	  < site-deployment.yaml.in > site-deployment.yaml
+	kubectl apply -f deployment.yaml

--- a/scorecard/Makefile
+++ b/scorecard/Makefile
@@ -3,7 +3,7 @@
 build:
 	docker build . -t scorecard
 
-push-site: IMAGE = gcr.io/broad-ctsa/scorecard:$(shell docker images -q --no-trunc scorecard | sed -e 's,[^:]*:,,')
+push: IMAGE = gcr.io/broad-ctsa/scorecard:$(shell docker images -q --no-trunc scorecard | sed -e 's,[^:]*:,,')
 push: build
 	echo $(IMAGE) > scorecard-image
 	docker tag scorecard $(IMAGE)
@@ -18,5 +18,5 @@ run:
 deploy:
 	sed -e "s,@sha@,$(shell git rev-parse --short=12 HEAD)," \
 	  -e "s,@image@,$(shell cat scorecard-image)," \
-	  < site-deployment.yaml.in > site-deployment.yaml
+	  < deployment.yaml.in > deployment.yaml
 	kubectl apply -f deployment.yaml

--- a/scorecard/Makefile
+++ b/scorecard/Makefile
@@ -3,7 +3,7 @@
 build:
 	docker build . -t scorecard
 
-push-site: IMAGE = gcr.io/broad-ctsa/scorecard:$(shell docker images -q --no-trunc site | sed -e 's,[^:]*:,,')
+push-site: IMAGE = gcr.io/broad-ctsa/scorecard:$(shell docker images -q --no-trunc scorecard | sed -e 's,[^:]*:,,')
 push: build
 	echo $(IMAGE) > scorecard-image
 	docker tag scorecard $(IMAGE)

--- a/scorecard/deployment.yaml.in
+++ b/scorecard/deployment.yaml.in
@@ -2,6 +2,8 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: scorecard-deployment
+  labels:
+    hail.is/sha: @sha@
 spec:
   selector:
     matchLabels:
@@ -11,10 +13,11 @@ spec:
     metadata:
       labels:
         app: scorecard
+        hail.is/sha: @sha@
     spec:
       containers:
       - name: scorecard
-        image: gcr.io/broad-ctsa/scorecard
+        image: @image@
         ports:
         - containerPort: 5000
         volumeMounts:

--- a/scorecard/get-deployed-sha.sh
+++ b/scorecard/get-deployed-sha.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ex
+
+kubectl get --selector=app=scorecard deployments -o "jsonpath={.items[*].metadata.labels.hail\.is/sha}"

--- a/scorecard/hail-ci-deploy.sh
+++ b/scorecard/hail-ci-deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ex
+
+gcloud -q auth activate-service-account \
+  --key-file=/secrets/gcr-push-service-account-key.json
+
+gcloud -q auth configure-docker
+
+make push deploy

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,1 +1,3 @@
 *~
+/site-deployment.yaml
+/site-image

--- a/site/Makefile
+++ b/site/Makefile
@@ -1,4 +1,5 @@
-SHELL=/bin/bash
+.PHONY: build build-site build-run-letsencrypt push push-site push-run-letsencrypt \
+  run-letsencrypt serve deploy-site
 
 build: build-site build-run-letsencrypt
 
@@ -10,54 +11,25 @@ build-run-letsencrypt:
 
 push: push-site push-run-letsencrypt
 
-push-site: build-site
-	docker tag site gcr.io/broad-ctsa/site
-	docker push gcr.io/broad-ctsa/site
+push-site: IMAGE=gcr.io/broad-ctsa/site:$(shell docker images -q --no-trunc batch-pr-builder | sed -e 's,[^:]*:,,')
+site-image push-site: build-site
+	echo $IMAGE > site-image
+	docker tag site $IMAGE
+	docker push $IMAGE
 
 push-run-letsencrypt: build-run-letsencrypt
 	docker tag run-letsencrypt gcr.io/broad-ctsa/run-letsencrypt
 	docker push gcr.io/broad-ctsa/run-letsencrypt
 
 run-letsencrypt:
-# start service
-	kubectl apply -f service.yaml
-# stop existing site deployment
-	kubectl delete --ignore-not-found=true -f site-deployment.yaml
-	N=
-	while [[ $$N != 0 ]]; do \
-	  sleep 5; \
-	  N=$$(kubectl get pods -l app=site --ignore-not-found=true --no-headers | wc -l | tr -d '[:space:]'); \
-	  echo N=$$N; \
-	done
-# stop existing run-letsencrypt pod
-	kubectl delete pod --ignore-not-found=true run-letsencrypt
-	N=
-	while [[ $$N != 0 ]]; do \
-	  sleep 5; \
-	  N=$$(kubectl get pod --ignore-not-found=true --no-headers run-letsencrypt | wc -l | tr -d '[:space:]'); \
-	  echo N=$$N; \
-	done
-# run run-letsencrypt pod
-	kubectl create -f run-letsencrypt-pod.yaml
-	echo "Waiting for run-letsencrypt to complete..."
-	EC=""
-	while [[ $$EC = "" ]]; do \
-	  sleep 5; \
-	  EC=$$(kubectl get pod -o "jsonpath={.status.containerStatuses[0].state.terminated.exitCode}" run-letsencrypt); \
-	  echo EC=$$EC; \
-	done
-	kubectl logs run-letsencrypt
-	if [[ $$EC != 0 ]]; then \
-	  exit $$EC; \
-	fi
-# cleanup
-	kubectl delete pod --ignore-not-found=true run-letsencrypt
+	run-letsencrypt.sh
 
 serve:
 	docker run -it -p 80:80 -p 443:443 -v $$(pwd)/letsencrypt:/etc/letsencrypt site
 
 deploy-site:
 	kubectl apply -f service.yaml
-	kubectl delete --ignore-not-found=true -f site-deployment.yaml
-	sleep 5
+	sed -e "s,@sha@,$SHA," \
+	  -e "s,@image@,$(cat batch-image)," \
+	  < site-deployment.yaml.in > site-deployment.yaml
 	kubectl apply -f site-deployment.yaml

--- a/site/Makefile
+++ b/site/Makefile
@@ -11,11 +11,11 @@ build-run-letsencrypt:
 
 push: push-site push-run-letsencrypt
 
-push-site: IMAGE=gcr.io/broad-ctsa/site:$(shell docker images -q --no-trunc batch-pr-builder | sed -e 's,[^:]*:,,')
-site-image push-site: build-site
-	echo $IMAGE > site-image
-	docker tag site $IMAGE
-	docker push $IMAGE
+push-site: IMAGE = gcr.io/broad-ctsa/site:$(shell docker images -q --no-trunc site | sed -e 's,[^:]*:,,')
+push-site: build-site
+	echo $(IMAGE) > site-image
+	docker tag site $(IMAGE)
+	docker push $(IMAGE)
 
 push-run-letsencrypt: build-run-letsencrypt
 	docker tag run-letsencrypt gcr.io/broad-ctsa/run-letsencrypt
@@ -29,7 +29,7 @@ serve:
 
 deploy-site:
 	kubectl apply -f service.yaml
-	sed -e "s,@sha@,$SHA," \
-	  -e "s,@image@,$(cat batch-image)," \
+	sed -e "s,@sha@,$(shell git rev-parse --short=12 HEAD)," \
+	  -e "s,@image@,$(shell cat site-image)," \
 	  < site-deployment.yaml.in > site-deployment.yaml
 	kubectl apply -f site-deployment.yaml

--- a/site/get-deployed-sha.sh
+++ b/site/get-deployed-sha.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ex
+
+kubectl get --selector=app=site deployments -o "jsonpath={.items[*].metadata.labels.hail\.is/sha}"

--- a/site/hail-ci-deploy.sh
+++ b/site/hail-ci-deploy.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -ex
+
+ROOT=$(cd .. && pwd)
+
+gcloud -q auth activate-service-account \
+  --key-file=/secrets/gcr-push-service-account-key.json
+
+gcloud -q auth configure-docker
+
+SHA=$(git rev-parse --short=12 HEAD)
+
+# get sha label of batch deployment
+DEPLOYED_SHA=$(kubectl get --selector=app=site deployments -o "jsonpath={.items[*].metadata.labels.hail\.is/sha}")
+if [[ $(git cat-file -t "$DEPLOYED_SHA" 2>/dev/null || true) == commit ]]; then
+    if [[ $SHA == $DEPLOYED_SHA ]]; then
+        exit 0
+    fi
+
+    NEEDS_REDEPLOY=$(cd $ROOT && python3 project-changed.py $DEPLOYED_SHA hail)
+    if [[ $NEEDS_REDEPLOY = no ]]; then
+        exit 0
+    fi
+fi
+
+make push-site deploy-site
+
+sed -e "s,@sha@,$SHA," \
+    -e "s,@image@,$(cat batch-image)," \
+    < site-deployment.yaml.in > site-deployment.yaml
+
+kubectl apply -f site-deployment.yaml

--- a/site/hail-ci-deploy.sh
+++ b/site/hail-ci-deploy.sh
@@ -24,9 +24,3 @@ if [[ $(git cat-file -t "$DEPLOYED_SHA" 2>/dev/null || true) == commit ]]; then
 fi
 
 make push-site deploy-site
-
-sed -e "s,@sha@,$SHA," \
-    -e "s,@image@,$(cat batch-image)," \
-    < site-deployment.yaml.in > site-deployment.yaml
-
-kubectl apply -f site-deployment.yaml

--- a/site/hail-ci-deploy.sh
+++ b/site/hail-ci-deploy.sh
@@ -1,26 +1,9 @@
 #!/bin/bash
 set -ex
 
-ROOT=$(cd .. && pwd)
-
 gcloud -q auth activate-service-account \
   --key-file=/secrets/gcr-push-service-account-key.json
 
 gcloud -q auth configure-docker
-
-SHA=$(git rev-parse --short=12 HEAD)
-
-# get sha label of batch deployment
-DEPLOYED_SHA=$(kubectl get --selector=app=site deployments -o "jsonpath={.items[*].metadata.labels.hail\.is/sha}")
-if [[ $(git cat-file -t "$DEPLOYED_SHA" 2>/dev/null || true) == commit ]]; then
-    if [[ $SHA == $DEPLOYED_SHA ]]; then
-        exit 0
-    fi
-
-    NEEDS_REDEPLOY=$(cd $ROOT && python3 project-changed.py $DEPLOYED_SHA hail)
-    if [[ $NEEDS_REDEPLOY = no ]]; then
-        exit 0
-    fi
-fi
 
 make push-site deploy-site

--- a/site/run-letsencrypt.sh
+++ b/site/run-letsencrypt.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -ex
+
+# start service
+kubectl apply -f service.yaml
+
+# stop existing site deployment
+kubectl delete --ignore-not-found=true -f site-deployment.yaml
+N=
+while [[ $N != 0 ]]; do
+    sleep 5
+    N=$(kubectl get pods -l app=site --ignore-not-found=true --no-headers | wc -l | tr -d '[:space:]')
+    echo N=$N
+done
+
+# stop existing run-letsencrypt pod
+kubectl delete pod --ignore-not-found=true run-letsencrypt
+N=
+while [[ $N != 0 ]]; do
+    sleep 5
+    N=$(kubectl get pod --ignore-not-found=true --no-headers run-letsencrypt | wc -l | tr -d '[:space:]')
+    echo N=$N
+done
+
+# run run-letsencrypt pod
+kubectl create -f run-letsencrypt-pod.yaml
+echo "Waiting for run-letsencrypt to complete..."
+EC=""
+while [[ $EC = "" ]]; do
+    sleep 5
+    EC=$(kubectl get pod -o "jsonpath={.status.containerStatuses[0].state.terminated.exitCode}" run-letsencrypt)
+    echo EC=$EC
+done
+kubectl logs run-letsencrypt
+if [[ $EC != 0 ]]; then
+    exit $EC
+fi
+
+# cleanup
+kubectl delete pod --ignore-not-found=true run-letsencrypt

--- a/site/site-deployment.yaml.in
+++ b/site/site-deployment.yaml.in
@@ -2,6 +2,8 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: site-deployment
+  labels:
+    hail.is/sha: @sha@
 spec:
   selector:
     matchLabels:
@@ -11,10 +13,11 @@ spec:
     metadata:
       labels:
         app: site
+        hail.is/sha: @sha@
     spec:
       containers:
       - name: site
-        image: gcr.io/broad-ctsa/site
+        image: @image@
         ports:
         - containerPort: 80
         - containerPort: 443


### PR DESCRIPTION
make appropriate targets phony
include sha in site deployment (like batch)
moved run-letsencrypt target body to shell script (no changes, but easier to work with)

This won't work until this CI PR goes in and is deployed: https://github.com/hail-is/ci/pull/102 (it won't hurt particularly, either.  make push-site will fail and site won't be deployed/up to date)