### PR TITLE
pc_relate is not experimental any more

### DIFF
--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -1354,7 +1354,6 @@ def pc_relate(call_expr, min_individual_maf, *, k=None, scores_expr=None,
     """Compute relatedness estimates between individuals using a variant of the
     PC-Relate method.
 
-    .. include:: ../_templates/experimental.rst
     .. include:: ../_templates/req_diploid_gt.rst
 
     Examples


### PR DESCRIPTION
I feel pretty good about pc_relate at this point. It's stood up to interrogation on a few real world datasets. We have automated testing of it. I think it's still a tricky method to use if you don't understand the underlying assumptions (which are listed here, specifically the limitations of PC Relate's estimator for "individual-specific allele frequency").

@cseed @tpoterba @jbloom22