### PR TITLE
OrderedRVD -> RVD

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/OrderedRVIterator.scala
+++ b/hail/src/main/scala/is/hail/annotations/OrderedRVIterator.scala
@@ -1,13 +1,13 @@
 package is.hail.annotations
 
-import is.hail.rvd.{OrderedRVDType, RVDContext}
+import is.hail.rvd.{RVDType, RVDContext}
 import is.hail.utils._
 
 import scala.collection.generic.Growable
 import scala.collection.mutable
 
 case class OrderedRVIterator(
-  t: OrderedRVDType,
+  t: RVDType,
   iterator: Iterator[RegionValue],
   ctx: RVDContext
 ) {
@@ -29,7 +29,7 @@ case class OrderedRVIterator(
       other.iterator.toFlipbookIterator,
       leftDefault = null,
       rightDefault = null,
-      OrderedRVDType.selectUnsafeOrdering(
+      RVDType.selectUnsafeOrdering(
         t.rowType, t.kFieldIdx, other.t.rowType, other.t.kFieldIdx)
         .compare
     )

--- a/hail/src/main/scala/is/hail/expr/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/Parser.scala
@@ -4,7 +4,7 @@ import is.hail.HailContext
 import is.hail.expr.ir.{AggSignature, BaseIR, IR, MatrixIR, TableIR}
 import is.hail.expr.types._
 import is.hail.expr.types.physical.PType
-import is.hail.rvd.OrderedRVDType
+import is.hail.rvd.RVDType
 import is.hail.table.{Ascending, Descending, SortField}
 import is.hail.utils.StringEscapeUtils._
 import is.hail.utils._
@@ -91,7 +91,7 @@ object Parser extends JavaTokenParsers {
 
   def parseStructType(code: String): TStruct = parse(struct_expr, code)
 
-  def parseOrderedRVDType(code: String): OrderedRVDType = parse(ordered_rvd_type_expr, code)
+  def parseRVDType(code: String): RVDType = parse(rvd_type_expr, code)
 
   def parseTableType(code: String): TableType = parse(table_type_expr, code)
 
@@ -299,10 +299,10 @@ object Parser extends JavaTokenParsers {
     _.toArray
   }
 
-  def ordered_rvd_type_expr: Parser[OrderedRVDType] =
-    (("OrderedRVDType" ~ "{" ~ "key" ~ ":" ~ "[") ~> key) ~ (trailing_keys <~ "]") ~
+  def rvd_type_expr: Parser[RVDType] =
+    ((("RVDType" | "OrderedRVDType") ~ "{" ~ "key" ~ ":" ~ "[") ~> key) ~ (trailing_keys <~ "]") ~
       (("," ~ "row" ~ ":") ~> struct_expr <~ "}") ^^ { case partitionKey ~ restKey ~ rowType =>
-      OrderedRVDType(rowType, partitionKey ++ restKey)
+      RVDType(rowType, partitionKey ++ restKey)
     }
 
   def table_type_expr: Parser[TableType] =

--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -5,7 +5,7 @@ import is.hail.annotations.{BroadcastRow, RegionValue, RegionValueBuilder, Unsaf
 import is.hail.expr.TableAnnotationImpex
 import is.hail.expr.types.TableType
 import is.hail.io.{CodecSpec, exportTypes}
-import is.hail.rvd.{OrderedRVD, RVDSpec}
+import is.hail.rvd.{RVD, RVDSpec}
 import is.hail.table.TableSpec
 import is.hail.utils._
 import is.hail.variant.{FileFormat, PartitionCountsComponentSpec, RVDComponentSpec, ReferenceGenome}
@@ -13,7 +13,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.json4s.jackson.JsonMethods
 
-case class TableValue(typ: TableType, globals: BroadcastRow, rvd: OrderedRVD) {
+case class TableValue(typ: TableType, globals: BroadcastRow, rvd: RVD) {
   require(typ.rowType == rvd.rowType)
   require(rvd.typ.key.startsWith(typ.key))
 

--- a/hail/src/main/scala/is/hail/expr/types/MatrixType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/MatrixType.scala
@@ -3,7 +3,7 @@ package is.hail.expr.types
 import is.hail.annotations.Annotation
 import is.hail.expr.Parser
 import is.hail.expr.ir.Env
-import is.hail.rvd.OrderedRVDType
+import is.hail.rvd.RVDType
 import is.hail.utils._
 import org.apache.spark.sql.Row
 import org.json4s.CustomSerializer
@@ -79,9 +79,9 @@ case class MatrixType(
     TableType(resultStruct, rowKey ++ colKey, globalType)
   }
 
-  def orvdType: OrderedRVDType = OrderedRVDType(rvRowType, rowKey)
+  def rvdType: RVDType = RVDType(rvRowType, rowKey)
 
-  def rowORVDType: OrderedRVDType = OrderedRVDType(rowType, rowKey)
+  def rowRVDType: RVDType = RVDType(rowType, rowKey)
 
   def refMap: Map[String, Type] = Map(
     "global" -> globalType,

--- a/hail/src/main/scala/is/hail/expr/types/TableType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/TableType.scala
@@ -2,7 +2,7 @@ package is.hail.expr.types
 
 import is.hail.expr.Parser
 import is.hail.expr.ir._
-import is.hail.rvd.OrderedRVDType
+import is.hail.rvd.RVDType
 import is.hail.utils._
 import org.json4s.CustomSerializer
 import org.json4s.JsonAST.JString
@@ -12,7 +12,7 @@ class TableTypeSerializer extends CustomSerializer[TableType](format => (
   { case tt: TableType => JString(tt.toString) }))
 
 case class TableType(rowType: TStruct, key: IndexedSeq[String], globalType: TStruct) extends BaseType {
-  val rvdType = OrderedRVDType(rowType, key)
+  val rvdType = RVDType(rowType, key)
 
   def env: Env[Type] = {
     Env.empty[Type]

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -5,7 +5,7 @@ import is.hail.expr.JSONAnnotationImpex
 import is.hail.expr.types._
 import is.hail.io.compress.LZ4Utils
 import is.hail.nativecode._
-import is.hail.rvd.{OrderedRVDPartitioner, OrderedRVDSpec, RVDContext, RVDSpec, UnpartitionedRVDSpec}
+import is.hail.rvd.{RVDPartitioner, OrderedRVDSpec, RVDContext, RVDSpec, UnpartitionedRVDSpec}
 import is.hail.sparkextras._
 import is.hail.utils._
 import org.apache.spark.rdd.RDD
@@ -1612,7 +1612,7 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RVDContext, RegionValue]) e
     path: String,
     t: MatrixType,
     codecSpec: CodecSpec,
-    partitioner: OrderedRVDPartitioner,
+    partitioner: RVDPartitioner,
     stageLocally: Boolean
   ): Array[Long] = {
     val sc = crdd.sparkContext
@@ -1722,7 +1722,7 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RVDContext, RegionValue]) e
 
     val (partFiles, partitionCounts) = partFilePartitionCounts.unzip
 
-    val rowsSpec = OrderedRVDSpec(t.rowORVDType,
+    val rowsSpec = OrderedRVDSpec(t.rowRVDType,
       codecSpec,
       partFiles,
       JSONAnnotationImpex.exportAnnotation(partitioner.rangeBounds, partitioner.rangeBoundsType))

--- a/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
@@ -3,7 +3,7 @@ package is.hail.io.bgen
 import is.hail.HailContext
 import is.hail.expr.types.TStruct
 import is.hail.io.index.IndexWriter
-import is.hail.rvd.{OrderedRVD, OrderedRVDPartitioner, OrderedRVDType}
+import is.hail.rvd.{RVD, RVDPartitioner, RVDType}
 import is.hail.utils._
 import is.hail.variant.ReferenceGenome
 import org.apache.spark.{Partition, TaskContext}
@@ -61,7 +61,7 @@ object IndexBgen {
       annotationType
     )
 
-    val typ = new OrderedRVDType(settings.typ, Array("file_idx", "locus", "alleles"))
+    val typ = RVDType(settings.typ, Array("file_idx", "locus", "alleles"))
 
     val sHadoopConfBc = hc.sc.broadcast(new SerializableHadoopConfiguration(hConf))
 
@@ -90,10 +90,10 @@ object IndexBgen {
       "skip_invalid_loci" -> skipInvalidLoci)
 
     val rangeBounds = files.zipWithIndex.map { case (_, i) => Interval(Row(i), Row(i), includesStart = true, includesEnd = true) }
-    val partitioner = new OrderedRVDPartitioner(Array("file_idx"), keyType.asInstanceOf[TStruct], rangeBounds)
+    val partitioner = new RVDPartitioner(Array("file_idx"), keyType.asInstanceOf[TStruct], rangeBounds)
     val crvd = BgenRDD(hc.sc, partitions, settings, null)
 
-    OrderedRVD
+    RVD
       .coerce(typ, crvd)
       .repartition(partitioner)
       .toRows

--- a/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -7,7 +7,7 @@ import is.hail.expr.types._
 import is.hail.io._
 import is.hail.io.index.IndexReader
 import is.hail.io.vcf.LoadVCF
-import is.hail.rvd.{OrderedRVD, OrderedRVDPartitioner}
+import is.hail.rvd.{RVD, RVDPartitioner}
 import is.hail.sparkextras.RepartitionedOrderedRDD2
 import is.hail.table.Table
 import is.hail.utils._
@@ -371,7 +371,7 @@ case class MatrixBGENReader(
   val (indexKeyType, indexAnnotationType) = LoadBgen.getIndexTypes(fileMetadata)
 
   val (maybePartitions, partitionRangeBounds) = BgenRDDPartitions(sc, fileMetadata, blockSizeInMB, nPartitions, indexKeyType)
-  val partitioner = new OrderedRVDPartitioner(indexKeyType.asInstanceOf[TStruct], partitionRangeBounds)
+  val partitioner = new RVDPartitioner(indexKeyType.asInstanceOf[TStruct], partitionRangeBounds)
 
   val (partitions, variants) = includedVariants match {
     case Some(variantsTable) =>
@@ -424,9 +424,9 @@ case class MatrixBGENReader(
     assert(mr.typ.rowKeyStruct == indexKeyType)
 
     val rvd = if (mr.dropRows)
-      OrderedRVD.empty(sc, requestedType.orvdType)
+      RVD.empty(sc, requestedType.rvdType)
     else
-      new OrderedRVD(requestedType.orvdType,
+      new RVD(requestedType.rvdType,
         partitioner,
         BgenRDD(sc, partitions, settings, variants))
 

--- a/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
@@ -4,7 +4,7 @@ import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.expr.types._
 import is.hail.io.vcf.LoadVCF
-import is.hail.rvd.{OrderedRVD, RVDContext}
+import is.hail.rvd.{RVD, RVDContext}
 import is.hail.sparkextras.ContextRDD
 import is.hail.utils.StringEscapeUtils._
 import is.hail.utils._
@@ -154,7 +154,7 @@ object LoadPlink {
       rowKey = Array("locus", "alleles"),
       entryType = TStruct("GT" -> TCall()))
 
-    val kType = matrixType.orvdType.kType
+    val kType = matrixType.rvdType.kType
     val rvRowType = matrixType.rvRowType
 
     val fastKeys = crdd.cmapPartitions { (ctx, it) =>
@@ -215,7 +215,7 @@ object LoadPlink {
     new MatrixTable(hc, matrixType,
       BroadcastRow(Row.empty, matrixType.globalType, sc),
       BroadcastIndexedSeq(sampleAnnotations, TArray(matrixType.colType), sc),
-      OrderedRVD.coerce(matrixType.orvdType, rdd2, fastKeys))
+      RVD.coerce(matrixType.rvdType, rdd2, fastKeys))
   }
 
   def apply(hc: HailContext, bedPath: String, bimPath: String, famPath: String, ffConfig: FamFileConfig,

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -7,7 +7,7 @@ import is.hail.expr.ir.{MatrixRead, MatrixReader, MatrixValue, PruneDeadFields}
 import is.hail.expr.types._
 import is.hail.io.vcf.LoadVCF.{getHeaderLines, parseHeader, parseLines}
 import is.hail.io.{VCFAttributes, VCFMetadata}
-import is.hail.rvd.{OrderedRVD, RVDContext}
+import is.hail.rvd.{RVD, RVDContext}
 import is.hail.sparkextras.ContextRDD
 import is.hail.utils._
 import is.hail.variant._
@@ -971,8 +971,8 @@ case class MatrixVCFReader(
     }
   }
 
-  private lazy val coercer = OrderedRVD.makeCoercer(
-    fullType.orvdType,
+  private lazy val coercer = RVD.makeCoercer(
+    fullType.rvdType,
     1,
     parseLines(
       () => ()
@@ -1003,9 +1003,9 @@ case class MatrixVCFReader(
     val nSamples = localSampleIDs.length
 
     val rvd = if (mr.dropRows)
-      OrderedRVD.empty(sc, requestedType.orvdType)
+      RVD.empty(sc, requestedType.rvdType)
     else
-      coercer.coerce(requestedType.orvdType, parseLines { () =>
+      coercer.coerce(requestedType.rvdType, parseLines { () =>
         new ParseLineContext(formatSignature, new BufferedLineIterator(headerLinesBc.value.iterator.buffered))
       } { (c, l, rvb) =>
         val vc = c.codec.decode(l.line)

--- a/hail/src/main/scala/is/hail/linalg/RowMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/RowMatrix.scala
@@ -4,7 +4,7 @@ import breeze.linalg.DenseMatrix
 import is.hail.HailContext
 import is.hail.expr.types.{TInt64, TStruct}
 import is.hail.io.InputBuffer
-import is.hail.rvd.OrderedRVDPartitioner
+import is.hail.rvd.RVDPartitioner
 import is.hail.utils._
 import org.apache.spark.{Partition, Partitioner, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
@@ -69,13 +69,13 @@ class RowMatrix(val hc: HailContext,
   // length nPartitions + 1, first element 0, last element rdd2 count
   def partitionStarts(): Array[Long] = partitionCounts().scanLeft(0L)(_ + _)
 
-  def orderedRVDPartitioner(
+  def partitioner(
     partitionKey: Array[String] = Array("idx"),
-    kType: TStruct = TStruct("idx" -> TInt64())): OrderedRVDPartitioner = {
+    kType: TStruct = TStruct("idx" -> TInt64())): RVDPartitioner = {
     
     val partStarts = partitionStarts()
 
-    new OrderedRVDPartitioner(partitionKey, kType,
+    new RVDPartitioner(partitionKey, kType,
       Array.tabulate(partStarts.length - 1) { i =>
         val start = partStarts(i)
         val end = partStarts(i + 1)

--- a/hail/src/main/scala/is/hail/methods/FilterIntervals.scala
+++ b/hail/src/main/scala/is/hail/methods/FilterIntervals.scala
@@ -1,6 +1,6 @@
 package is.hail.methods
 
-import is.hail.rvd.{OrderedRVD, OrderedRVDType}
+import is.hail.rvd.{RVD, RVDType}
 import is.hail.table.Table
 import is.hail.utils.{Interval, IntervalTree}
 import is.hail.variant.MatrixTable
@@ -16,8 +16,8 @@ object MatrixFilterIntervals {
 
 object TableFilterIntervals {
   def apply(ht: Table, jintervals: java.util.ArrayList[Interval], keep: Boolean): Table = {
-    val orvd = ht.value.rvd
-    val intervals = IntervalTree(orvd.typ.kType.ordering, jintervals.asScala.toArray)
-    ht.copy2(rvd = orvd.filterIntervals(intervals, keep))
+    val rvd = ht.value.rvd
+    val intervals = IntervalTree(rvd.typ.kType.ordering, jintervals.asScala.toArray)
+    ht.copy2(rvd = rvd.filterIntervals(intervals, keep))
   }
 }

--- a/hail/src/main/scala/is/hail/methods/LinearRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/LinearRegression.scala
@@ -67,7 +67,7 @@ object LinearRegression {
     val newMatrixType = vsm.matrixType.copy(rvRowType = newRVType)
 
     val newRDD2 = vsm.rvd.boundary.mapPartitions(
-      newMatrixType.orvdType, { (ctx, it) =>
+      newMatrixType.rvdType, { (ctx, it) =>
         val rvb = new RegionValueBuilder()
         val rv2 = RegionValue()
 

--- a/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
+++ b/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
@@ -5,7 +5,7 @@ import java.util
 import is.hail.annotations._
 import is.hail.expr.types._
 import org.apache.spark.storage.StorageLevel
-import is.hail.rvd.{OrderedRVD, OrderedRVDType}
+import is.hail.rvd.{RVD, RVDType}
 import is.hail.table.Table
 import is.hail.variant._
 import is.hail.utils._
@@ -223,7 +223,7 @@ object LocalLDPrune {
     r2
   }
 
-  private def pruneLocal(inputRDD: OrderedRVD, r2Threshold: Double, windowSize: Int, queueSize: Option[Int]): OrderedRVD = {
+  private def pruneLocal(inputRDD: RVD, r2Threshold: Double, windowSize: Int, queueSize: Option[Int]): RVD = {
     val localRowType = inputRDD.typ.rowType
 
     inputRDD.mapPartitions(inputRDD.typ, { (ctx, it) =>

--- a/hail/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -68,7 +68,7 @@ object LogisticRegression {
     val newRVType = newRVPType.virtualType
     val newMatrixType = vsm.matrixType.copy(rvRowType = newRVType)
 
-    val newRVD = vsm.rvd.mapPartitions(newMatrixType.orvdType) { it =>
+    val newRVD = vsm.rvd.mapPartitions(newMatrixType.rvdType) { it =>
       val rvb = new RegionValueBuilder()
       val rv2 = RegionValue()
 

--- a/hail/src/main/scala/is/hail/methods/Nirvana.scala
+++ b/hail/src/main/scala/is/hail/methods/Nirvana.scala
@@ -7,7 +7,7 @@ import is.hail.annotations._
 import is.hail.expr.JSONAnnotationImpex
 import is.hail.expr.ir.{TableLiteral, TableValue}
 import is.hail.expr.types._
-import is.hail.rvd.{OrderedRVD, RVDContext}
+import is.hail.rvd.{RVD, RVDContext}
 import is.hail.sparkextras.ContextRDD
 import is.hail.table.Table
 import is.hail.utils._
@@ -448,12 +448,12 @@ object Nirvana {
       }
       .persist(StorageLevel.MEMORY_AND_DISK)
 
-    val nirvanaORVDType = prev.typ.copy(rowType = localRowType ++ TStruct("nirvana" -> nirvanaSignature))
+    val nirvanaRVDType = prev.typ.copy(rowType = localRowType ++ TStruct("nirvana" -> nirvanaSignature))
 
-    val nirvanaRowType = nirvanaORVDType.rowType
+    val nirvanaRowType = nirvanaRVDType.rowType
 
-    val nirvanaRVD: OrderedRVD = OrderedRVD(
-      nirvanaORVDType,
+    val nirvanaRVD: RVD = RVD(
+      nirvanaRVDType,
       prev.partitioner,
       ContextRDD.weaken[RVDContext](annotations).cmapPartitions { (ctx, it) =>
         val region = ctx.region

--- a/hail/src/main/scala/is/hail/methods/VEP.scala
+++ b/hail/src/main/scala/is/hail/methods/VEP.scala
@@ -5,7 +5,7 @@ import is.hail.annotations._
 import is.hail.expr._
 import is.hail.expr.ir.{TableLiteral, TableValue}
 import is.hail.expr.types._
-import is.hail.rvd.{OrderedRVD, RVDContext}
+import is.hail.rvd.{RVD, RVDContext}
 import is.hail.sparkextras.ContextRDD
 import is.hail.table.Table
 import is.hail.utils._
@@ -186,12 +186,12 @@ object VEP {
 
     val vepType: Type = if (csq) TArray(TString()) else vepSignature
 
-    val vepORVDType = prev.typ.copy(rowType = prev.rowType ++ TStruct("vep" -> vepType))
+    val vepRVDType = prev.typ.copy(rowType = prev.rowType ++ TStruct("vep" -> vepType))
 
-    val vepRowType = vepORVDType.rowType
+    val vepRowType = vepRVDType.rowType
 
-    val vepRVD: OrderedRVD = OrderedRVD(
-      vepORVDType,
+    val vepRVD: RVD = RVD(
+      vepRVDType,
       prev.partitioner,
       ContextRDD.weaken[RVDContext](annotations).cmapPartitions { (ctx, it) =>
         val region = ctx.region

--- a/hail/src/main/scala/is/hail/rvd/RVDPartitionInfo.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDPartitionInfo.scala
@@ -4,7 +4,7 @@ import is.hail.utils._
 import is.hail.annotations.{RegionValue, SafeRow, WritableRegionValue}
 import is.hail.expr.types.Type
 
-case class OrderedRVPartitionInfo(
+case class RVDPartitionInfo(
   partitionIndex: Int,
   size: Int,
   min: Any,
@@ -20,20 +20,20 @@ case class OrderedRVPartitionInfo(
   }
 }
 
-object OrderedRVPartitionInfo {
+object RVDPartitionInfo {
   final val UNSORTED = 0
   final val TSORTED = 1
   final val KSORTED = 2
 
   def apply(
-    typ: OrderedRVDType,
+    typ: RVDType,
     partitionKey: Int,
     sampleSize: Int,
     partitionIndex: Int,
     it: Iterator[RegionValue],
     seed: Int,
     producerContext: RVDContext
-  ): OrderedRVPartitionInfo = {
+  ): RVDPartitionInfo = {
     using(RVDContext.default) { localctx =>
       val pkOrd = typ.copy(key = typ.key.take(partitionKey)).kOrd
       val minF = WritableRegionValue(typ.kType, localctx.freshRegion)
@@ -97,7 +97,7 @@ object OrderedRVPartitionInfo {
 
       val safe: RegionValue => Any = SafeRow(kPType, _)
 
-      OrderedRVPartitionInfo(partitionIndex, i,
+      RVDPartitionInfo(partitionIndex, i,
         safe(minF.value), safe(maxF.value),
         Array.tabulate[Any](math.min(i, sampleSize))(i => safe(samples(i).value)),
         sortedness)

--- a/hail/src/main/scala/is/hail/rvd/RVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDSpec.scala
@@ -28,6 +28,7 @@ object RVDSpec {
   def read(hc: HailContext, path: String): RVDSpec = {
     val metadataFile = path + "/metadata.json.gz"
     val jv = hc.hadoopConf.readFile(metadataFile) { in => JsonMethods.parse(in) }
+        .transformField { case ("orvdType", value) => ("rvdType", value) }
     jv.extract[RVDSpec]
   }
 

--- a/hail/src/main/scala/is/hail/rvd/RVDType.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDType.scala
@@ -8,13 +8,13 @@ import org.apache.commons.lang3.builder.HashCodeBuilder
 import org.json4s.CustomSerializer
 import org.json4s.JsonAST.{JArray, JObject, JString, JValue}
 
-class OrderedRVDTypeSerializer extends CustomSerializer[OrderedRVDType](format => ( {
-  case JString(s) => Parser.parseOrderedRVDType(s)
+class RVDTypeSerializer extends CustomSerializer[RVDType](format => ( {
+  case JString(s) => Parser.parseRVDType(s)
 }, {
-  case orvdType: OrderedRVDType => JString(orvdType.toString)
+  case rvdType: RVDType => JString(rvdType.toString)
 }))
 
-final case class OrderedRVDType(rowType: TStruct, key: IndexedSeq[String] = FastIndexedSeq())
+final case class RVDType(rowType: TStruct, key: IndexedSeq[String] = FastIndexedSeq())
   extends Serializable {
 
   val keySet: Set[String] = key.toSet
@@ -29,20 +29,20 @@ final case class OrderedRVDType(rowType: TStruct, key: IndexedSeq[String] = Fast
 
   val kOrd: UnsafeOrdering = kType.physicalType.unsafeOrdering(missingGreatest = true)
   val kInRowOrd: UnsafeOrdering =
-    OrderedRVDType.selectUnsafeOrdering(rowType, kFieldIdx, rowType, kFieldIdx)
+    RVDType.selectUnsafeOrdering(rowType, kFieldIdx, rowType, kFieldIdx)
   val kRowOrd: UnsafeOrdering =
-    OrderedRVDType.selectUnsafeOrdering(kType, Array.range(0, kType.size), rowType, kFieldIdx)
+    RVDType.selectUnsafeOrdering(kType, Array.range(0, kType.size), rowType, kFieldIdx)
 
-  def kComp(other: OrderedRVDType): UnsafeOrdering =
-    OrderedRVDType.selectUnsafeOrdering(
+  def kComp(other: RVDType): UnsafeOrdering =
+    RVDType.selectUnsafeOrdering(
       this.rowType,
       this.kFieldIdx,
       other.rowType,
       other.kFieldIdx,
       true)
 
-  def joinComp(other: OrderedRVDType): UnsafeOrdering =
-    OrderedRVDType.selectUnsafeOrdering(
+  def joinComp(other: RVDType): UnsafeOrdering =
+    RVDType.selectUnsafeOrdering(
       this.rowType,
       this.kFieldIdx,
       other.rowType,
@@ -58,14 +58,14 @@ final case class OrderedRVDType(rowType: TStruct, key: IndexedSeq[String] = Fast
       kRowOrd.compare(wrv.value, rv)
   }
 
-  def insert(typeToInsert: Type, path: List[String]): (OrderedRVDType, UnsafeInserter) = {
+  def insert(typeToInsert: Type, path: List[String]): (RVDType, UnsafeInserter) = {
     assert(path.nonEmpty)
     assert(!key.contains(path.head))
 
     val (newRowPType, inserter) = rowType.physicalType.unsafeInsert(typeToInsert.physicalType, path)
     val newRowType = newRowPType.virtualType
 
-    (OrderedRVDType(newRowType.asInstanceOf[TStruct], key), inserter)
+    (RVDType(newRowType.asInstanceOf[TStruct], key), inserter)
   }
 
   def toJSON: JValue =
@@ -76,7 +76,7 @@ final case class OrderedRVDType(rowType: TStruct, key: IndexedSeq[String] = Fast
 
   override def toString: String = {
     val sb = new StringBuilder()
-    sb.append("OrderedRVDType{key:[[")
+    sb.append("RVDType{key:[[")
     if (key.nonEmpty) {
       key.foreachBetween(k => sb.append(prettyIdentifier(k)))(sb += ',')
     }
@@ -87,7 +87,7 @@ final case class OrderedRVDType(rowType: TStruct, key: IndexedSeq[String] = Fast
   }
 }
 
-object OrderedRVDType {
+object RVDType {
   def selectUnsafeOrdering(t1: TStruct, fields1: Array[Int],
     t2: TStruct, fields2: Array[Int], missingEqual: Boolean=true): UnsafeOrdering = {
     require(fields1.length == fields2.length)

--- a/hail/src/main/scala/is/hail/utils/SortedDistinctRowIterator.scala
+++ b/hail/src/main/scala/is/hail/utils/SortedDistinctRowIterator.scala
@@ -1,14 +1,14 @@
 package is.hail.utils
 
 import is.hail.annotations._
-import is.hail.rvd.{OrderedRVDType, RVDContext}
+import is.hail.rvd.{RVDType, RVDContext}
 
 object SortedDistinctRowIterator {
-  def transformer(ort: OrderedRVDType): (RVDContext, Iterator[RegionValue]) => SortedDistinctRowIterator =
+  def transformer(ort: RVDType): (RVDContext, Iterator[RegionValue]) => SortedDistinctRowIterator =
     (ctx, it) => new SortedDistinctRowIterator(ort, it, ctx)
 }
 
-class SortedDistinctRowIterator(ort: OrderedRVDType, it: Iterator[RegionValue], ctx: RVDContext) extends Iterator[RegionValue] {
+class SortedDistinctRowIterator(ort: RVDType, it: Iterator[RegionValue], ctx: RVDContext) extends Iterator[RegionValue] {
   private val bit = it.buffered
   private val wrv: WritableRegionValue = WritableRegionValue(ort.rowType, ctx.freshRegion)
 

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -4,7 +4,7 @@ import is.hail.SparkSuite
 import is.hail.annotations.{BroadcastIndexedSeq, BroadcastRow}
 import is.hail.expr._
 import is.hail.expr.types._
-import is.hail.rvd.OrderedRVD
+import is.hail.rvd.RVD
 import is.hail.table.{Ascending, SortField, Table, TableSpec}
 import is.hail.utils._
 import is.hail.variant.MatrixTable
@@ -95,7 +95,7 @@ class PruneSuite extends SparkSuite {
     mType,
     BroadcastRow(Row(1, 1.0), mType.globalType, sc),
     BroadcastIndexedSeq(FastIndexedSeq(Row("1", 2, FastIndexedSeq(Row(3)))), TArray(mType.colType), sc),
-    OrderedRVD.empty(sc, mType.orvdType)))
+    RVD.empty(sc, mType.rvdType)))
 
   val mr = MatrixRead(mat.typ, false, false,
     new MatrixReader {

--- a/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
@@ -4,7 +4,7 @@ import is.hail.SparkSuite
 import is.hail.asm4s.Code
 import is.hail.expr.ir.functions.{IRRandomness, RegistryFunctions}
 import is.hail.expr.types._
-import is.hail.rvd.OrderedRVD
+import is.hail.rvd.RVD
 import is.hail.TestUtils._
 import is.hail.table.Table
 import is.hail.utils._

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir
 import is.hail.SparkSuite
 import is.hail.expr.ir.TestUtils._
 import is.hail.expr.types._
-import is.hail.rvd.{OrderedRVD, OrderedRVDPartitioner}
+import is.hail.rvd.{RVD, RVDPartitioner}
 import is.hail.table.Table
 import is.hail.utils._
 import org.apache.spark.sql.Row
@@ -169,7 +169,7 @@ class TableIRSuite extends SparkSuite {
 //      Interval(Row(0, 0), Row(10), true, false),
 //      Interval(Row(10), Row(44, 0), true, true)),
 //    IndexedSeq(Interval(Row(), Row(), true, true))
-  ).map(new OrderedRVDPartitioner(kType, _))
+  ).map(new RVDPartitioner(kType, _))
 
   val rightPartitioners = Array(
     IndexedSeq(
@@ -181,7 +181,7 @@ class TableIRSuite extends SparkSuite {
 //      Interval(Row(0, 0), Row(10), true, false),
 //      Interval(Row(10), Row(44, 0), true, true)),
 //    IndexedSeq(Interval(Row(), Row(), true, true))
-  ).map(new OrderedRVDPartitioner(kType, _))
+  ).map(new RVDPartitioner(kType, _))
 
   val joinTypes = Array(
     ("outer", (row: Row) => true),
@@ -203,8 +203,8 @@ class TableIRSuite extends SparkSuite {
 
   @Test(dataProvider = "join")
   def testTableJoin(
-    leftPart: OrderedRVDPartitioner,
-    rightPart: OrderedRVDPartitioner,
+    leftPart: RVDPartitioner,
+    rightPart: RVDPartitioner,
     joinType: String,
     pred: Row => Boolean,
     leftProject: Set[Int],

--- a/hail/src/test/scala/is/hail/io/ImportMatrixSuite.scala
+++ b/hail/src/test/scala/is/hail/io/ImportMatrixSuite.scala
@@ -6,7 +6,7 @@ import is.hail.check.Gen
 import is.hail.check.Prop.forAll
 import is.hail.expr._
 import is.hail.expr.types._
-import is.hail.rvd.OrderedRVD
+import is.hail.rvd.RVD
 import is.hail.table.Table
 import is.hail.variant.{ReferenceGenome$, MatrixTable, VSMSubgen}
 import org.apache.spark.SparkException

--- a/hail/src/test/scala/is/hail/methods/TableSuite.scala
+++ b/hail/src/test/scala/is/hail/methods/TableSuite.scala
@@ -3,7 +3,7 @@ package is.hail.methods
 import is.hail.{SparkSuite, TestUtils}
 import is.hail.expr._
 import is.hail.expr.types._
-import is.hail.rvd.OrderedRVD
+import is.hail.rvd.RVD
 import is.hail.table.Table
 import is.hail.utils._
 import is.hail.testUtils._

--- a/hail/src/test/scala/is/hail/rvd/RVDPartitionerSuite.scala
+++ b/hail/src/test/scala/is/hail/rvd/RVDPartitionerSuite.scala
@@ -7,10 +7,10 @@ import org.apache.spark.sql.Row
 import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.Test
 
-class OrderedRVDPartitionerSuite extends TestNGSuite {
+class RVDPartitionerSuite extends TestNGSuite {
   val kType = TStruct(("A", TInt32()), ("B", TInt32()), ("C", TInt32()))
   val partitioner =
-    new OrderedRVDPartitioner(kType,
+    new RVDPartitioner(kType,
       Array(
         Interval(Row(1, 0), Row(4, 3), true, false),
         Interval(Row(4, 3), Row(7, 9), true, false),
@@ -18,7 +18,7 @@ class OrderedRVDPartitionerSuite extends TestNGSuite {
     )
 
   @Test def testExtendKey() {
-    val p = new OrderedRVDPartitioner(TStruct(("A", TInt32()), ("B", TInt32())),
+    val p = new RVDPartitioner(TStruct(("A", TInt32()), ("B", TInt32())),
       Array(
         Interval(Row(1, 0), Row(4, 3), true, true),
         Interval(Row(4, 3), Row(4, 3), true, true),
@@ -101,7 +101,7 @@ class OrderedRVDPartitionerSuite extends TestNGSuite {
         Interval(Row(11, 0, 2), Row(11, 0, 15), false, true),
         Interval(Row(11, 0, 15), Row(11, 0, 20), true, false))
 
-    val p3 = OrderedRVDPartitioner.generate(Array("A", "B", "C"), kType, intervals)
+    val p3 = RVDPartitioner.generate(Array("A", "B", "C"), kType, intervals)
     assert(p3.satisfiesAllowedOverlap(2))
     assert(p3.rangeBounds sameElements
       Array(
@@ -112,7 +112,7 @@ class OrderedRVDPartitionerSuite extends TestNGSuite {
         Interval(Row(11, 0, 15), Row(11, 0, 20), false, false))
     )
 
-    val p2 = OrderedRVDPartitioner.generate(Array("A", "B"), kType, intervals)
+    val p2 = RVDPartitioner.generate(Array("A", "B"), kType, intervals)
     assert(p2.satisfiesAllowedOverlap(1))
     assert(p2.rangeBounds sameElements
       Array(
@@ -122,7 +122,7 @@ class OrderedRVDPartitionerSuite extends TestNGSuite {
         Interval(Row(11, 0, 2), Row(11, 0, 20), false, false))
     )
 
-    val p1 = OrderedRVDPartitioner.generate(Array("A"), kType, intervals)
+    val p1 = RVDPartitioner.generate(Array("A"), kType, intervals)
     assert(p1.satisfiesAllowedOverlap(0))
     assert(p1.rangeBounds sameElements
       Array(
@@ -137,27 +137,27 @@ class OrderedRVDPartitionerSuite extends TestNGSuite {
     val intervals1 = Array(Interval(Row(), Row(), true, true))
     val intervals5 = Array.fill(5)(Interval(Row(), Row(), true, true))
 
-    val p5 = OrderedRVDPartitioner.generate(IndexedSeq(), TStruct.empty(), intervals5)
+    val p5 = RVDPartitioner.generate(IndexedSeq(), TStruct.empty(), intervals5)
     assert(p5.rangeBounds sameElements intervals1)
 
-    val p1 = OrderedRVDPartitioner.generate(IndexedSeq(), TStruct.empty(), intervals1)
+    val p1 = RVDPartitioner.generate(IndexedSeq(), TStruct.empty(), intervals1)
     assert(p1.rangeBounds sameElements intervals1)
 
-    val p0 = OrderedRVDPartitioner.generate(IndexedSeq(), TStruct.empty(), IndexedSeq())
+    val p0 = RVDPartitioner.generate(IndexedSeq(), TStruct.empty(), IndexedSeq())
     assert(p0.rangeBounds.isEmpty)
   }
 
   @Test def testIntersect() {
     val kType = TStruct(("key", TInt32()))
     val left =
-      new OrderedRVDPartitioner(kType,
+      new RVDPartitioner(kType,
         Array(
           Interval(Row(1), Row(10), true, false),
           Interval(Row(12), Row(13), true, false),
           Interval(Row(14), Row(19), true, false))
       )
     val right =
-      new OrderedRVDPartitioner(kType,
+      new RVDPartitioner(kType,
         Array(
           Interval(Row(1), Row(4), true, false),
           Interval(Row(4), Row(5), true, false),

--- a/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -5,7 +5,7 @@ import is.hail.annotations.BroadcastRow
 import is.hail.expr.ir
 import is.hail.expr.ir.{MatrixAnnotateRowsTable, TableLiteral, TableValue}
 import is.hail.expr.types._
-import is.hail.rvd.OrderedRVD
+import is.hail.rvd.RVD
 import is.hail.table.Table
 import is.hail.variant.MatrixTable
 import is.hail.testUtils._
@@ -29,7 +29,7 @@ class PartitioningSuite extends SparkSuite {
   @Test def testShuffleOnEmptyRDD() {
     val typ = TableType(TStruct("tidx" -> TInt32()), IndexedSeq("tidx"), TStruct.empty())
     val t = TableLiteral(TableValue(
-      typ, BroadcastRow(Row.empty, TStruct.empty(), sc), OrderedRVD.empty(sc, typ.rvdType)))
+      typ, BroadcastRow(Row.empty, TStruct.empty(), sc), RVD.empty(sc, typ.rvdType)))
     val rangeReader = ir.MatrixRangeReader(100, 10, Some(10))
     MatrixAnnotateRowsTable(ir.MatrixRead(rangeReader.fullType, false, false, rangeReader), t, "foo", None)
       .execute(hc).rvd.count()
@@ -37,22 +37,22 @@ class PartitioningSuite extends SparkSuite {
 
   @Test def testEmptyRightRDDOrderedJoinDistinct() {
     val mt = MatrixTable.fromRowsTable(Table.range(hc, 100, nPartitions = Some(6)))
-    val orvdType = mt.matrixType.orvdType
+    val rvdType = mt.matrixType.rvdType
 
-    mt.rvd.orderedJoinDistinct(OrderedRVD.empty(hc.sc, orvdType), "left", (_, it) => it.map(_._1), orvdType).count()
-    mt.rvd.orderedJoinDistinct(OrderedRVD.empty(hc.sc, orvdType), "inner", (_, it) => it.map(_._1), orvdType).count()
+    mt.rvd.orderedJoinDistinct(RVD.empty(hc.sc, rvdType), "left", (_, it) => it.map(_._1), rvdType).count()
+    mt.rvd.orderedJoinDistinct(RVD.empty(hc.sc, rvdType), "inner", (_, it) => it.map(_._1), rvdType).count()
   }
 
   @Test def testEmptyRDDOrderedJoin() {
     val mt = MatrixTable.fromRowsTable(Table.range(hc, 100, nPartitions = Some(6)))
-    val orvdType = mt.matrixType.orvdType
+    val rvdType = mt.matrixType.rvdType
 
     val nonEmptyRVD = mt.rvd
-    val emptyRVD = OrderedRVD.empty(hc.sc, orvdType)
+    val emptyRVD = RVD.empty(hc.sc, rvdType)
 
-    emptyRVD.orderedJoin(nonEmptyRVD, "left", (_, it) => it.map(_._1), orvdType).count()
-    emptyRVD.orderedJoin(nonEmptyRVD, "inner", (_, it) => it.map(_._1), orvdType).count()
-    nonEmptyRVD.orderedJoin(emptyRVD, "left", (_, it) => it.map(_._1), orvdType).count()
-    nonEmptyRVD.orderedJoin(emptyRVD, "inner", (_, it) => it.map(_._1), orvdType).count()
+    emptyRVD.orderedJoin(nonEmptyRVD, "left", (_, it) => it.map(_._1), rvdType).count()
+    emptyRVD.orderedJoin(nonEmptyRVD, "inner", (_, it) => it.map(_._1), rvdType).count()
+    nonEmptyRVD.orderedJoin(emptyRVD, "left", (_, it) => it.map(_._1), rvdType).count()
+    nonEmptyRVD.orderedJoin(emptyRVD, "inner", (_, it) => it.map(_._1), rvdType).count()
   }
 }


### PR DESCRIPTION
Rename `OrderedRVD` to `RVD` in all its forms, `orvd` to `rvd`, etc.