### PR TITLE
Implement a set of logging improvements

### DIFF
--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -37,7 +37,7 @@ from . import experimental as experimental
 from . import ir as ir
 from hail.expr import aggregators as agg
 from hail.utils import Struct, Interval, hadoop_copy, hadoop_open, hadoop_ls, \
-    hadoop_stat, hadoop_exists, hadoop_is_file, hadoop_is_dir
+    hadoop_stat, hadoop_exists, hadoop_is_file, hadoop_is_dir, copy_log
 
 scan = agg.aggregators.ScanFunctions({name: getattr(agg, name) for name in agg.__all__})
 
@@ -60,6 +60,7 @@ __all__ = [
     'hadoop_is_file',
     'hadoop_stat',
     'hadoop_ls',
+    'copy_log',
     'Struct',
     'Interval',
     'agg',

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -4,7 +4,7 @@ from pyspark.sql import SQLContext
 import hail
 from hail.genetics.reference_genome import ReferenceGenome
 from hail.typecheck import nullable, typecheck, typecheck_method, enumeration
-from hail.utils import wrap_to_list, get_env_or_default, local_path_uri
+from hail.utils import wrap_to_list, get_env_or_default
 from hail.utils.java import Env, joption, FatalError, connect_logger, install_exception_handler, uninstall_exception_handler
 
 import sys

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -4,7 +4,7 @@ from pyspark.sql import SQLContext
 import hail
 from hail.genetics.reference_genome import ReferenceGenome
 from hail.typecheck import nullable, typecheck, typecheck_method, enumeration
-from hail.utils import wrap_to_list, get_env_or_default
+from hail.utils import wrap_to_list, get_env_or_default, local_path_uri
 from hail.utils.java import Env, joption, FatalError, connect_logger, install_exception_handler, uninstall_exception_handler
 
 import sys
@@ -15,7 +15,7 @@ class HailContext(object):
                       app_name=str,
                       master=nullable(str),
                       local=str,
-                      log=str,
+                      log=nullable(str),
                       quiet=bool,
                       append=bool,
                       min_block_size=int,
@@ -25,7 +25,7 @@ class HailContext(object):
                       idempotent=bool,
                       global_seed=nullable(int))
     def __init__(self, sc=None, app_name="Hail", master=None, local='local[*]',
-                 log='hail.log', quiet=False, append=False,
+                 log=None, quiet=False, append=False,
                  min_block_size=1, branching_factor=50, tmp_dir=None,
                  default_reference="GRCh37", idempotent=False,
                  global_seed=6348563392232659379):
@@ -55,6 +55,14 @@ class HailContext(object):
 
         tmp_dir = get_env_or_default(tmp_dir, 'TMPDIR', '/tmp')
 
+        version = read_version_info()
+        hail.__version__ = version
+
+        if log is None:
+            log = hail.utils.timestamp_path(os.path.join(os.getcwd(), 'hail'),
+                                            suffix=f'-{version}.log')
+        self._log = log
+
         # we always pass 'quiet' to the JVM because stderr output needs
         # to be routed through Python separately.
         # if idempotent:
@@ -80,15 +88,14 @@ class HailContext(object):
         self._default_ref = None
         Env.hail().variant.ReferenceGenome.setDefaultReference(self._jhc, default_reference)
 
-        version = self._jhc.version()
-        hail.__version__ = version
+        jar_version = self._jhc.version()
 
-        if not os.getenv('HAIL_IGNORE_PYTHON_VERSION'):
-            py_version = read_version_info()
-            if py_version != version:
-                raise RuntimeError(f"Hail version mismatch between JAR and Python library\n"
-                                   f"  JAR:    {version}\n"
-                                   f"  Python: {py_version}")
+        if jar_version != version:
+            raise RuntimeError(f"Hail version mismatch between JAR and Python library\n"
+                   f"  JAR:    {jar_version}\n"
+                   f"  Python: {version}")
+
+
 
         if not quiet:
             sys.stderr.write('Running on Apache Spark version {}\n'.format(self.sc.version))
@@ -110,6 +117,7 @@ class HailContext(object):
                 sys.stderr.write('NOTE: This is a beta version. Interfaces may change\n'
                                  '  during the beta period. We recommend pulling\n'
                                  '  the latest changes weekly.\n')
+            sys.stderr.write(f'LOGGING: writing to {log}\n')
 
         install_exception_handler()
         Env.set_seed(global_seed)
@@ -135,7 +143,7 @@ class HailContext(object):
            app_name=str,
            master=nullable(str),
            local=str,
-           log=str,
+           log=nullable(str),
            quiet=bool,
            append=bool,
            min_block_size=int,
@@ -145,7 +153,7 @@ class HailContext(object):
            idempotent=bool,
            global_seed=nullable(int))
 def init(sc=None, app_name='Hail', master=None, local='local[*]',
-         log='hail.log', quiet=False, append=False,
+         log=None, quiet=False, append=False,
          min_block_size=1, branching_factor=50, tmp_dir='/tmp',
          default_reference='GRCh37', idempotent=False,
          global_seed=6348563392232659379):

--- a/hail/python/hail/docs/utils/index.rst
+++ b/hail/python/hail/docs/utils/index.rst
@@ -14,6 +14,7 @@ utils
     hadoop_is_dir
     hadoop_stat
     hadoop_ls
+    copy_log
     range_table
     range_matrix_table
     get_1kg
@@ -28,6 +29,7 @@ utils
 .. autofunction:: hadoop_is_dir
 .. autofunction:: hadoop_stat
 .. autofunction:: hadoop_ls
+.. autofunction:: copy_log
 .. autofunction:: range_table
 .. autofunction:: range_matrix_table
 .. autofunction:: get_1kg

--- a/hail/python/hail/utils/__init__.py
+++ b/hail/python/hail/utils/__init__.py
@@ -1,5 +1,5 @@
-from .misc import wrap_to_list, get_env_or_default, uri_path, local_path_uri, new_temp_file, new_local_temp_dir, new_local_temp_file, storage_level, range_matrix_table, range_table, run_command, HailSeedGenerator
-from .hadoop_utils import hadoop_copy, hadoop_open, hadoop_exists, hadoop_is_dir, hadoop_is_file, hadoop_ls, hadoop_stat
+from .misc import wrap_to_list, get_env_or_default, uri_path, local_path_uri, new_temp_file, new_local_temp_dir, new_local_temp_file, storage_level, range_matrix_table, range_table, run_command, HailSeedGenerator, timestamp_path
+from .hadoop_utils import hadoop_copy, hadoop_open, hadoop_exists, hadoop_is_dir, hadoop_is_file, hadoop_ls, hadoop_stat, copy_log
 from .struct import Struct
 from .linkedlist import LinkedList
 from .interval import Interval
@@ -13,6 +13,7 @@ __all__ = ['hadoop_open',
            'hadoop_is_file',
            'hadoop_stat',
            'hadoop_ls',
+           'copy_log',
            'wrap_to_list',
            'new_local_temp_dir',
            'new_local_temp_file',
@@ -33,4 +34,5 @@ __all__ = ['hadoop_open',
            'HailSeedGenerator',
            'LinkedList',
            'get_1kg',
-           'get_movie_lens']
+           'get_movie_lens',
+           'timestamp_path']

--- a/hail/python/hail/utils/misc.py
+++ b/hail/python/hail/utils/misc.py
@@ -1,12 +1,15 @@
-import hail
-from hail.utils.java import Env, joption, error
-from hail.typecheck import enumeration, typecheck, nullable
-import difflib
-from collections import defaultdict, Counter, OrderedDict
 import atexit
+import datetime
+import difflib
 import shutil
 import tempfile
+from collections import defaultdict, Counter, OrderedDict
 from random import Random
+
+import hail
+from hail.typecheck import enumeration, typecheck, nullable
+from hail.utils.java import Env, joption, error
+
 
 @typecheck(n_rows=int, n_cols=int, n_partitions=nullable(int))
 def range_matrix_table(n_rows, n_cols, n_partitions=None) -> 'hail.MatrixTable':
@@ -379,3 +382,10 @@ class HailSeedGenerator(object):
 
     def next_seed(self):
         return self.generator.randint(0, (1 << 63) - 1)
+
+
+def timestamp_path(base, suffix=''):
+    return ''.join([base,
+                    '-',
+                    datetime.datetime.now().strftime("%Y%m%d-%H%M"),
+                    suffix])


### PR DESCRIPTION
1. The default log path includes the version and a
   timestamp. This will help people avoid overwriting
   log files, which will help us.
2. Echo the full path to the log after the hail logo
3. Add a function `hl.copy_log` which can be used to
   copy the session log to a hadoop-api-compliant
   location.