### PR TITLE
Include NGINX logs in pod logs

### DIFF
--- a/site/site.sh
+++ b/site/site.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 bash /poll-devel.sh
 bash /poll-0.1.sh
 
@@ -9,5 +11,9 @@ touch /etc/crontab /etc/cron.*/*
 
 service rsyslog start
 service cron start
+
+# link nginx logs to docker log collectors
+ln -sf /dev/stdout /var/log/nginx/access.log
+ln -sf /dev/stderr /var/log/nginx/error.log
 
 nginx -g "daemon off;"


### PR DESCRIPTION
[This is what the nginx docker image does](https://github.com/nginxinc/docker-nginx/blob/master/stable/alpine/Dockerfile#L136-L137).

The polls will finish first so we'll still see those logs.