### PR TITLE
Capital letters are not allowed in k8s pod names

### DIFF
--- a/site/hail.nginx.conf
+++ b/site/hail.nginx.conf
@@ -35,7 +35,7 @@ server {
 server {
     server_name ci.hail.is ci2.hail.is;
     
-    location ~ /(test-ci-[A-z0-9]+)/(.*) {
+    location ~ /(test-ci-[a-z0-9]+)/(.*) {
         resolver kube-dns.kube-system.svc.cluster.local;
         proxy_pass http://$1/$2;
     }


### PR DESCRIPTION
This doesn't really matter, but seems best to keep the regex as limited as possible.