### PR TITLE
Do not redeploy batch and CI constantly

### DIFF
--- a/hail-ci-deploy.sh
+++ b/hail-ci-deploy.sh
@@ -14,6 +14,8 @@ for project in $PROJECTS; do
                 if [[ $(git cat-file -t "$DEPLOYED_SHA" 2>/dev/null || true) == commit ]]; then
                     CHANGED=$(python3 project-changed.py $DEPLOYED_SHA hail)
                 fi
+            else
+                CHANGED=no
             fi
         fi
         


### PR DESCRIPTION
cc: @cseed 

I missed this in review. Note that if we have a way to check deployed sha (i.e. get-deployed-sha.sh exists), and the deployed SHA is the same as the current SHA, then the state of the service is unchanged.