### PR TITLE
move _select logic to key_by

### DIFF
--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -771,8 +771,8 @@ class Expression(object):
         :obj:`list`
         """
         uid = Env.get_uid()
-        t = self._to_table(uid)
-        return [r[uid] for r in t._select("collect", hl.struct(**{uid: t[uid]}), []).collect()]
+        t = self._to_table(uid).key_by()
+        return [r[uid] for r in t._select("collect", hl.struct(**{uid: t[uid]})).collect()]
 
     @property
     def value(self):

--- a/hail/python/hail/methods/misc.py
+++ b/hail/python/hail/methods/misc.py
@@ -140,7 +140,7 @@ def maximal_independent_set(i, j, keep=True, tie_breaker=None) -> Table:
              .key_by('node')
              .select())
 
-    edges = t.key_by(None).select('i', 'j')
+    edges = t.key_by().select('i', 'j')
     nodes_in_set = Env.hail().utils.Graph.maximalIndependentSet(edges._jt.collect(), node_t._jtype, joption(tie_breaker_str))
 
     nt = Table(nodes._jt.annotateGlobal(nodes_in_set, hl.tset(node_t)._jtype, 'nodes_in_set'))

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -401,55 +401,11 @@ class Table(ExprContainer):
         return self._jt.forceCount()
 
     @typecheck_method(caller=str,
-                      row=expr_struct(),
-                      new_keys=oneof(exactly("default"), sequenceof(str)))
-    def _select(self, caller, row, new_keys="default"):
-        if new_keys == "default":
-            new_key = list(self.key.keys())
-            preserved_key = preserved_key_new = new_key
-        else:
-            key_struct = hl.struct(**{name: row[name] for name in new_keys})
-            preserved_key, preserved_key_new, new_key = self._preserved_key_pairs(key_struct)
-
+                      row=expr_struct())
+    def _select(self, caller, row):
         analyze(caller, row, self._row_indices)
         base, cleanup = self._process_joins(row)
-        return cleanup(base._select_scala(row, preserved_key, preserved_key_new, new_key))
-
-    @typecheck_method(row=expr_struct(),
-                      preserved_key=sequenceof(str),
-                      preserved_key_new=sequenceof(str),
-                      new_key=sequenceof(str))
-    def _select_scala(self, row, preserved_key, preserved_key_new, new_key):
-        jt = self._jt
-        if preserved_key != list(self.key):
-            jt = jt.keyBy(preserved_key)
-        name_map = {old_name: new_name for (old_name, new_name) in zip(preserved_key, preserved_key_new)}
-        name_map_inv = {new_name: old_name for (old_name, new_name) in zip(preserved_key, preserved_key_new)}
-        row = StructExpression._from_fields({name_map_inv.get(n, n): e for (n, e) in row._fields.items()})
-        jt = jt.mapRows(str(row._ir))
-        if preserved_key != preserved_key_new:
-            jt = jt.rename(name_map, {})
-        if new_key != preserved_key_new:
-            jt = jt.keyBy(new_key)
-        return Table(jt)
-
-    @typecheck_method(key_struct=expr_struct())
-    def _preserved_key_pairs(self, key_struct):
-        def is_copy(ir, name, indices):
-            return (indices.source is self and
-                    isinstance(ir, GetField) and
-                    ir.name == name and
-                    isinstance(ir.o, TopLevelReference) and
-                    ir.o.name == 'row')
-        preserved_key_pairs =\
-            list(map(lambda pair: (pair[1]._ir.name, pair[0]),
-                     itertools.takewhile(
-                         lambda pair: is_copy(pair[1]._ir, pair[2], pair[1]._indices),
-                         zip(key_struct.keys(), key_struct.values(), self.key.keys()))))
-        (preserved_key, preserved_key_new) =\
-            (list(k) for k in zip(*preserved_key_pairs)) if preserved_key_pairs != [] else ([], [])
-        new_key = list(key_struct.keys())
-        return preserved_key, preserved_key_new, new_key
+        return cleanup(Table(base._jt.mapRows(str(row._ir))))
 
     @typecheck_method(caller=str, s=expr_struct())
     def _select_globals(self, caller, s):
@@ -500,9 +456,8 @@ class Table(ExprContainer):
             table = table.key_by(*key)
         return table
 
-    @typecheck_method(keys=oneof(nullable(oneof(str, Expression)), exactly([])),
-                      named_keys=expr_any
-                      )
+    @typecheck_method(keys=oneof(str, expr_any),
+                      named_keys=expr_any)
     def key_by(self, *keys, **named_keys) -> 'Table':
         """Key table by a new set of fields.
 
@@ -552,9 +507,6 @@ class Table(ExprContainer):
         :class:`.Table`
             Table with a new key.
         """
-        if len(named_keys) == 0 and (len(keys) == 0 or (len(keys) == 1 and keys[0] is None)):
-            return Table(self._jt.unkey())
-
         if len(named_keys) == 0 and (len(keys) == 1 and isinstance(keys[0], list) and keys[0] == []):
             key_fields = dict()
         else:
@@ -562,9 +514,20 @@ class Table(ExprContainer):
                                           keys, named_keys, self._row_indices,
                                           protect_keys=False)
 
-        return self._select("Table.key_by",
-                            self.row.annotate(**key_fields),
-                            new_keys=list(key_fields.keys()))
+        if all(isinstance(ir, GetField) and ir.o == TopLevelReference('row')
+               for ir in map(lambda e: e._ir, key_fields.values())):
+            # avoid creating a 'TableMapRows' node if all keys are existing fields
+            name_map = {expr._ir.name: new_name for (new_name, expr) in key_fields.items()}
+            return Table(self._jt.rename(name_map, {}).keyBy(list(key_fields)))
+        else:
+            new_row = self.row.annotate(**key_fields)
+            base, cleanup = self._process_joins(new_row)
+
+            return cleanup(Table(
+                base._jt
+                    .keyBy([])
+                    .mapRows(str(new_row._ir))
+                    .keyBy(list(key_fields))))
 
     def annotate_globals(self, **named_exprs):
         """Add new global fields.

--- a/hail/python/hail/utils/java.py
+++ b/hail/python/hail/utils/java.py
@@ -71,7 +71,7 @@ class Env:
     def dummy_table():
         if Env._dummy_table is None:
             import hail
-            Env._dummy_table = hail.utils.range_table(1, 1).key_by(None).cache()
+            Env._dummy_table = hail.utils.range_table(1, 1).key_by().cache()
         return Env._dummy_table
 
     @staticmethod

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -251,7 +251,7 @@ class Tests(unittest.TestCase):
     def test_transmute_key(self):
         ht = hl.utils.range_table(10)
         self.assertEqual(ht.transmute(y = ht.idx + 2).row.dtype, hl.dtype('struct{idx: int32, y: int32}'))
-        ht = ht.key_by(None)
+        ht = ht.key_by()
         self.assertEqual(ht.transmute(y = ht.idx + 2).row.dtype, hl.dtype('struct{y: int32}'))
 
     def test_select(self):
@@ -401,12 +401,12 @@ class Tests(unittest.TestCase):
 
         ktd = kt.drop('idx')
         self.assertEqual(set(ktd.row), {'foo', 'sq', 'bar'})
-        ktd = ktd.key_by(None).drop('foo')
+        ktd = ktd.key_by().drop('foo')
         self.assertEqual(list(ktd.key), [])
 
         self.assertEqual(set(kt.drop(kt['idx']).row), {'foo', 'sq', 'bar'})
 
-        d = kt.key_by(None).drop(*list(kt.row))
+        d = kt.key_by().drop(*list(kt.row))
         self.assertEqual(list(d.row), [])
         self.assertEqual(list(d.key), [])
 
@@ -622,8 +622,8 @@ class Tests(unittest.TestCase):
         t3 = t3.key_by(idx = t3.idx + 10)
 
         self.assertTrue(t1.union(t2, t3)._same(hl.utils.range_table(15)))
-        self.assertTrue(t1.key_by(None).union(t2.key_by(None), t3.key_by(None))
-                        ._same(hl.utils.range_table(15).key_by(None)))
+        self.assertTrue(t1.key_by().union(t2.key_by(), t3.key_by())
+                        ._same(hl.utils.range_table(15).key_by()))
 
     def test_table_head_returns_right_number(self):
         rt = hl.utils.range_table(10, 11)

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -752,7 +752,7 @@ case class TableUnion(children: IndexedSeq[TableIR]) extends TableIR {
   def execute(hc: HailContext): TableValue = {
     val tvs = children.map(_.execute(hc))
     tvs(0).copy(
-      rvd = RVD.union(tvs.map(_.rvd)))
+      rvd = RVD.union(tvs.map(_.rvd), tvs(0).typ.key.length))
   }
 }
 
@@ -1179,6 +1179,9 @@ case class LocalizeEntries(child: MatrixIR, entriesFieldName: String) extends Ta
 case class TableRename(child: TableIR, rowMap: Map[String, String], globalMap: Map[String, String]) extends TableIR {
   require(rowMap.keys.forall(child.typ.rowType.hasField))
   require(globalMap.keys.forall(child.typ.globalType.hasField))
+
+  def rowF(old: String): String = rowMap.getOrElse(old, old)
+  def globalF(old: String): String = globalMap.getOrElse(old, old)
 
   def typ: TableType = child.typ.copy(
     rowType = child.typ.rowType.rename(rowMap),

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -395,6 +395,9 @@ class Table(val hc: HailContext, val tir: TableIR) {
   def keyBy(keys: java.util.ArrayList[String]): Table =
     keyBy(keys.asScala.toFastIndexedSeq)
 
+  def keyBy(keys: java.util.ArrayList[String], isSorted: Boolean): Table =
+    keyBy(keys.asScala.toFastIndexedSeq, isSorted)
+
   def keyBy(keys: IndexedSeq[String], isSorted: Boolean = false): Table =
     new Table(hc, TableKeyBy(tir, keys, isSorted))
 


### PR DESCRIPTION
`Table._select` got way too complicated (mostly my fault) when key changing moved from `TableMapRows` to `TableKeyBy`. Making `_select` a simple wrapper around `TableMapRows`, and moving the key logic to `key_by`, made both way simpler. I then realized the `key_by` code could be even simpler by adding some rules to the optimizer to clean up the case where all new keys are existing fields.

I actually think some things had gotten broken in the old `_select` (performance wise). In particular, in `split_multi`, in the `split_rows` function with `rekey=false`, I think it's supposed to extend the key from `['locus']` to `['locus', 'alleles']`, but that wasn't happening.

I changed `key_by` to no longer accept `key_by(None)` or `key_by([])`, both of which should now be `key_by()`, which is more consistent with the rest of our interface, but is a breaking change. Is it worth the disruption? Should I add a warning? Or just continue to accept both?