### PR TITLE
Fix agg.group_by

### DIFF
--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -466,18 +466,22 @@ class Tests(unittest.TestCase):
 
     def test_aggregator_group_by(self):
         t = hl.Table.parallelize([
-            {"cohort": None, "pop": "EUR", "GT": hl.Call([0, 0])},
-            {"cohort": None, "pop": "ASN", "GT": hl.Call([0, 1])},
-            {"cohort": None, "pop": None, "GT": hl.Call([0, 0])},
-            {"cohort": "SIGMA", "pop": "AFR", "GT": hl.Call([0, 1])},
-            {"cohort": "SIGMA", "pop": "EUR", "GT": hl.Call([1, 1])},
-            {"cohort": "IBD", "pop": "EUR", "GT": None},
-            {"cohort": "IBD", "pop": "EUR", "GT": hl.Call([0, 0])},
-            {"cohort": "IBD", "pop": None, "GT": hl.Call([0, 1])}
-        ], hl.tstruct(cohort=hl.tstr, pop=hl.tstr, GT=hl.tcall), n_partitions=3)
+            {"cohort": None, "pop": "EUR", "GT": hl.Call([0, 0]), "x": 6},
+            {"cohort": None, "pop": "ASN", "GT": hl.Call([0, 1]), "x": 2},
+            {"cohort": None, "pop": None, "GT": hl.Call([0, 0]), "x": 4},
+            {"cohort": "SIGMA", "pop": "AFR", "GT": hl.Call([0, 1]), "x": None},
+            {"cohort": "SIGMA", "pop": "EUR", "GT": hl.Call([1, 1]), "x": 2},
+            {"cohort": "IBD", "pop": "EUR", "GT": None, "x": 0},
+            {"cohort": "IBD", "pop": "EUR", "GT": hl.Call([0, 0]), "x": 1},
+            {"cohort": "IBD", "pop": None, "GT": hl.Call([0, 1]), "x": None}
+        ], hl.tstruct(cohort=hl.tstr, pop=hl.tstr, GT=hl.tcall, x=hl.tint), n_partitions=3)
 
         r = t.aggregate(hl.struct(count=hl.agg.group_by(t.cohort, hl.agg.group_by(t.pop, hl.agg.count_where(hl.is_defined(t.GT)))),
-                                  inbreeding=hl.agg.group_by(t.cohort, hl.agg.inbreeding(t.GT, 0.1))))
+                                  inbreeding=hl.agg.group_by(t.cohort, hl.agg.inbreeding(t.GT, 0.1)),
+                                  mean=hl.agg.group_by(t.cohort, hl.agg.mean(t.x)),
+                                  mean_plus_three=hl.agg.group_by(t.cohort, hl.agg.mean(t.x) + 3),
+                                  nested_mean=hl.agg.group_by(t.cohort, hl.agg.group_by(t.pop, hl.agg.mean(t.x))),
+                                  mean_squared=hl.agg.group_by(t.cohort, hl.agg.mean(t.x) * hl.agg.mean(t.x))))
 
         expected_count = {None: {'EUR': 1, 'ASN': 1, None: 1},
                     'SIGMA': {'AFR': 1, 'EUR': 1},
@@ -489,7 +493,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(r.inbreeding[None].n_called, 3)
         self.assertAlmostEqual(r.inbreeding[None].expected_homs, 2.46)
         self.assertEqual(r.inbreeding[None].observed_homs, 2)
-        
+
         self.assertAlmostEqual(r.inbreeding['SIGMA'].f_stat, -1.777777777777777)
         self.assertEqual(r.inbreeding['SIGMA'].n_called, 2)
         self.assertAlmostEqual(r.inbreeding['SIGMA'].expected_homs, 1.64)
@@ -499,6 +503,26 @@ class Tests(unittest.TestCase):
         self.assertEqual(r.inbreeding['IBD'].n_called, 2)
         self.assertAlmostEqual(r.inbreeding['IBD'].expected_homs, 1.64)
         self.assertEqual(r.inbreeding['IBD'].observed_homs, 1)
+
+        expected_mean = {None: 4,
+                         'SIGMA': 2,
+                         'IBD': 0.5}
+
+        self.assertEqual(r.mean, expected_mean)
+
+        expected_mean_plus_three = {None: 7, 'SIGMA': 5, 'IBD': 3.5}
+
+        self.assertEqual(r.mean_plus_three, expected_mean_plus_three)
+
+        expected_nested_mean = {None: {'EUR': 6, 'ASN': 2, None: 4},
+                                'SIGMA': {'AFR': None, 'EUR': 2},
+                                'IBD': {'EUR': 0.5, None: None}}
+
+        self.assertEqual(r.nested_mean, expected_nested_mean)
+
+        expected_mean_squared = {None: 4 ** 2, 'SIGMA': 2 ** 2, 'IBD': 0.5 ** 2}
+
+        self.assertEqual(r.mean_squared, expected_mean_squared)
 
     def test_aggregator_group_by_sorts_result(self):
         t = hl.Table.parallelize([ # the `s` key is stored before the `m` in java.util.HashMap

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -481,7 +481,9 @@ class Tests(unittest.TestCase):
                                   mean=hl.agg.group_by(t.cohort, hl.agg.mean(t.x)),
                                   mean_plus_three=hl.agg.group_by(t.cohort, hl.agg.mean(t.x) + 3),
                                   nested_mean=hl.agg.group_by(t.cohort, hl.agg.group_by(t.pop, hl.agg.mean(t.x))),
-                                  mean_squared=hl.agg.group_by(t.cohort, hl.agg.mean(t.x) * hl.agg.mean(t.x))))
+                                  mean_squared=hl.agg.group_by(t.cohort, hl.agg.mean(t.x) * hl.agg.mean(t.x)),
+                                  count_where=hl.agg.group_by(t.cohort, hl.agg.count_where(t.x <= 2)),
+                                  count_where_nested=hl.agg.group_by(t.cohort, hl.agg.group_by(t.pop, hl.agg.count_where(t.x <= 2)))))
 
         expected_count = {None: {'EUR': 1, 'ASN': 1, None: 1},
                     'SIGMA': {'AFR': 1, 'EUR': 1},
@@ -507,22 +509,27 @@ class Tests(unittest.TestCase):
         expected_mean = {None: 4,
                          'SIGMA': 2,
                          'IBD': 0.5}
-
         self.assertEqual(r.mean, expected_mean)
 
         expected_mean_plus_three = {None: 7, 'SIGMA': 5, 'IBD': 3.5}
-
         self.assertEqual(r.mean_plus_three, expected_mean_plus_three)
 
         expected_nested_mean = {None: {'EUR': 6, 'ASN': 2, None: 4},
                                 'SIGMA': {'AFR': None, 'EUR': 2},
                                 'IBD': {'EUR': 0.5, None: None}}
-
         self.assertEqual(r.nested_mean, expected_nested_mean)
 
         expected_mean_squared = {None: 4 ** 2, 'SIGMA': 2 ** 2, 'IBD': 0.5 ** 2}
-
         self.assertEqual(r.mean_squared, expected_mean_squared)
+
+        expected_count_where = {None: 1, 'SIGMA': 1, 'IBD': 2}
+        self.assertEqual(r.count_where, expected_count_where)
+
+        # FIXME: This should include keys where value of count == 0
+        expected_count_where_nested = {None: {'ASN': 1},
+                                       'SIGMA': {'EUR': 1},
+                                       'IBD': {'EUR': 2}}
+        self.assertEqual(r.count_where_nested, expected_count_where_nested)
 
     def test_aggregator_group_by_sorts_result(self):
         t = hl.Table.parallelize([ # the `s` key is stored before the `m` in java.util.HashMap

--- a/hail/src/main/scala/is/hail/annotations/aggregators/KeyedRegionValueAggregator.scala
+++ b/hail/src/main/scala/is/hail/annotations/aggregators/KeyedRegionValueAggregator.scala
@@ -28,11 +28,10 @@ case class KeyedRegionValueAggregator(
     val m2 = rva2.asInstanceOf[KeyedRegionValueAggregator].m
     m2.asScala.foreach { case (k, agg2) =>
       val agg = m.get(k)
-        if (agg == null)
-          m.put(k, agg2)
-        else {
-          agg.combOp(agg2)
-        }
+      if (agg == null)
+        m.put(k, agg2)
+      else
+        agg.combOp(agg2)
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/Parser.scala
@@ -97,6 +97,8 @@ object Parser extends JavaTokenParsers {
 
   def parseMatrixType(code: String): MatrixType = parse(matrix_type_expr, code)
 
+  def parseAggSignature(code: String): AggSignature = parse(agg_signature, code)
+
   def parseAnnotationRoot(code: String, root: String): List[String] = {
     val path = parseAll(annotationIdentifier, code) match {
       case Success(result, _) => result.asInstanceOf[List[String]]
@@ -476,7 +478,7 @@ object Parser extends JavaTokenParsers {
     "(" ~> ir_identifier <~ ")" ^^ { x => x }
 
   def ir_agg_op: Parser[ir.AggOp] =
-    ir_keyed_agg_op | ir_identifier ^^ { x => ir.AggOp.fromString(x) }
+    ir_keyed_agg_op | ir_identifier ^^ { x => ir.AggOpRegistry.fromString(x) }
 
   def ir_keyed_agg_op: Parser[ir.Keyed] =
     "Keyed(" ~> ir_agg_op <~ ")" ^^ { aggOp => ir.Keyed(aggOp) }

--- a/hail/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -38,7 +38,7 @@ final case class TakeBy() extends AggOp { }
 // exists === map(p).sum, needs short-circuiting aggs
 // forall === map(p).product, needs short-circuiting aggs
 
-object AggOp {
+object AggOpRegistry {
 
   def get(aggSig: AggSignature): BaseCodeAggregator[T] forSome { type T <: RegionValueAggregator } =
     getOption(aggSig).getOrElse(incompatible(aggSig))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -639,7 +639,7 @@ private class Emit(
           )
         }.toArray: _*)
 
-        val agg = AggOp.get(aggSig)
+        val agg = AggOpRegistry.get(aggSig)
         EmitTriplet(
           Code(codeI.setup,
             Code(codeA.map(_.setup): _*),
@@ -656,7 +656,7 @@ private class Emit(
 
       case x@SeqOp(i, args, aggSig) =>
         val codeI = emit(i)
-        val agg = AggOp.get(aggSig)
+        val agg = AggOpRegistry.get(aggSig)
         val nArgs = args.length
         val argsm = Array.fill[ClassFieldRef[Boolean]](nArgs)(mb.newField[Boolean]())
         val argsv = (0 until nArgs).map(i => mb.newField(typeToTypeInfo(args(i).typ))).toArray

--- a/hail/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -102,7 +102,7 @@ object ExtractAggregators {
 
             fb.emit(Code(
               Code(codeConstructorArgs.map(_.setup): _*),
-              AggOp.get(aggSig).asInstanceOf[CodeAggregator[_]]
+              AggOpRegistry.get(aggSig).asInstanceOf[CodeAggregator[_]]
                 .stagedNew(codeConstructorArgs.map(_.v).toArray, codeConstructorArgs.map(_.m).toArray)))
 
             Region.scoped(fb.resultWithIndex()(0)(_))

--- a/hail/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -50,9 +50,9 @@ object Infer {
         assert(body.typ == zero.typ)
         TArray(zero.typ)
       case ApplyAggOp(a, constructorArgs, initOpArgs, aggSig) =>
-        AggOp.getType(aggSig)
+        AggOpRegistry.getType(aggSig)
       case ApplyScanOp(a, constructorArgs, initOpArgs, aggSig) =>
-        AggOp.getType(aggSig)
+        AggOpRegistry.getType(aggSig)
       case MakeStruct(fields) =>
         TStruct(fields.map { case (name, a) =>
           (name, a.typ)

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -383,7 +383,7 @@ object Interpret {
             aggregator.get.seqOp(interpret(a))
         }
       case x@ApplyAggOp(a, constructorArgs, initOpArgs, aggSig) =>
-        assert(AggOp.getType(aggSig) == x.typ)
+        assert(AggOpRegistry.getType(aggSig) == x.typ)
 
         def getAggregator(aggOp: AggOp, seqOpArgTypes: Seq[Type]): TypedAggregator[_] = aggOp match {
           case CallStats() =>

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -172,13 +172,13 @@ object TypeCheck {
         constructorArgs.foreach(check(_))
         initOpArgs.foreach(_.foreach(check(_)))
         assert(a.typ == TVoid)
-        assert(x.typ == AggOp.getType(aggSig))
+        assert(x.typ == AggOpRegistry.getType(aggSig))
       case x@ApplyScanOp(a, constructorArgs, initOpArgs, aggSig) =>
         check(a)
         constructorArgs.foreach(check(_))
         initOpArgs.foreach(_.foreach(check(_)))
         assert(a.typ == TVoid)
-        assert(x.typ == AggOp.getType(aggSig))
+        assert(x.typ == AggOpRegistry.getType(aggSig))
       case x@MakeStruct(fields) =>
         fields.foreach { case (name, a) => check(a) }
         assert(x.typ == TStruct(fields.map { case (name, a) =>


### PR DESCRIPTION
Fixes #4193 
Depends on #4450

Before, the aggregation expression to `group_by` had to be an `ApplyAggOp` or a `ScanAggOp`, which was limiting (hl.agg.mean didn't work because it was implemented as hl.agg.sum / hl.agg.count). Now, any expression should work as long as there is at least one `ApplyAggOp` or `ScanAggOp`. I implemented this by converting the expression into a map values operation. Where the original ApplyAggOps are replaced by Apply operations getting the value from the dictionary that is defined with a Let IR outside of the ArrayMap over the keys operation. I had to compute the keySet because it's possible not every key appears in each dictionary due to filters in the SeqOp.