### PR TITLE
CI in CI

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -48,24 +48,29 @@ restart-batch-proxy:
                          | head -n 1))
 	kubectl port-forward ${BATCH_POD} 8888:5000 > batch-proxy.log 2>batch-proxy.err & echo $$! > batch-proxy.pid
 
+PROXY_IP=35.239.252.237
+
 run-local: HAIL_CI_REMOTE_PORT = 3000
 run-local: restart-all-proxies
-	SELF_HOSTNAME=http://35.232.159.176:${HAIL_CI_REMOTE_PORT} \
+	SELF_HOSTNAME=http://${PROXY_IP}:${HAIL_CI_REMOTE_PORT} \
 	BATCH_SERVER_URL=http://127.0.0.1:${HAIL_CI_LOCAL_BATCH_PORT} \
 	source activate hail-ci && python ci/ci.py
 
 run-local-for-tests: HAIL_CI_REMOTE_PORT = 3001
 run-local-for-tests: restart-all-proxies
-	SELF_HOSTNAME=http://35.232.159.176:${HAIL_CI_REMOTE_PORT} \
+	SELF_HOSTNAME=http://${PROXY_IP}:${HAIL_CI_REMOTE_PORT} \
 	BATCH_SERVER_URL=http://127.0.0.1:${HAIL_CI_LOCAL_BATCH_PORT} \
 	WATCHED_TARGETS='[["hail-is/ci-test:master", true]]' \
 	source activate hail-ci && pip install ./batch && python ci/ci.py
 
 test-locally: HAIL_CI_REMOTE_PORT = 3001
 test-locally: restart-all-proxies
-	SELF_HOSTNAME=http://35.232.159.176:${HAIL_CI_REMOTE_PORT} \
+	SELF_HOSTNAME=http://${PROXY_IP}:${HAIL_CI_REMOTE_PORT} \
 	BATCH_SERVER_URL=http://127.0.0.1:${HAIL_CI_LOCAL_BATCH_PORT} \
-	source activate hail-ci && ./test-locally.sh
+	./test-locally.sh
+
+test-in-cluster:
+	./test-in-cluster.sh
 
 deploy:
 	sed -e "s,@sha@,$(shell git rev-parse --short=12 HEAD)," \

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -1,5 +1,6 @@
 .PHONY: run restart-proxy restart-batch-proxy restart-all-proxies
 .PHONY: setup-conda-env build-hail-ci push-hail-ci test-locally
+.PHONY: test-in-cluster
 
 HAIL_CI_LOCAL_BATCH_PORT ?= 8888
 

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -95,12 +95,6 @@ def github_pull_request_review():
     action = d['action']
     gh_pr = GitHubPR.from_gh_json(d['pull_request'])
 
-    log.info(json.dumps({
-        'action': action,
-        'pull_request': gh_pr.to_json(),
-        'reivew': d['review']
-    }))
-
     if action == 'submitted':
         state = d['review']['state'].lower()
         if state == 'changes_requested':

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -101,11 +101,11 @@ def github_pull_request_review():
             prs.review(gh_pr, state)
         else:
             # FIXME: track all reviewers, then we don't need to talk to github
-            reviews = get_reviews(gh_pr.target_ref.repo, gh_pr.number)
-            log.info(reviews)
-            real_state = review_status(reviews)
-            log.info(real_state)
-            prs.review(gh_pr, real_state)
+            prs.review(
+                gh_pr,
+                review_status(
+                    get_reviews(gh_pr.target_ref.repo,
+                                gh_pr.number)))
     elif action == 'dismissed':
         # FIXME: track all reviewers, then we don't need to talk to github
         prs.review(

--- a/ci/ci/environment.py
+++ b/ci/ci/environment.py
@@ -42,7 +42,7 @@ except FileNotFoundError as e:
         "containing a string that is passed to `/bin/sh -c'") from e
 try:
     with open('oauth-token/oauth-token', 'r') as f:
-        oauth_token = f.read()
+        oauth_token = f.read().strip()
 except FileNotFoundError as e:
     raise ValueError(
         "working directory must contain `oauth-token/oauth-token' "
@@ -54,6 +54,5 @@ log.info(f'REFRESH_INTERVAL_IN_SECONDS {REFRESH_INTERVAL_IN_SECONDS}')
 log.info(f'WATCHED_TARGETS {[(ref.short_str(), deployable) for (ref, deployable) in WATCHED_TARGETS]}')
 log.info(f'INSTANCE_ID = {INSTANCE_ID}')
 log.info(f'CONTEXT = {CONTEXT}')
-
 
 batch_client = BatchClient(url=BATCH_SERVER_URL)

--- a/ci/ci/environment.py
+++ b/ci/ci/environment.py
@@ -55,4 +55,5 @@ log.info(f'WATCHED_TARGETS {[(ref.short_str(), deployable) for (ref, deployable)
 log.info(f'INSTANCE_ID = {INSTANCE_ID}')
 log.info(f'CONTEXT = {CONTEXT}')
 
+
 batch_client = BatchClient(url=BATCH_SERVER_URL)

--- a/ci/ci/pr.py
+++ b/ci/ci/pr.py
@@ -413,7 +413,6 @@ class PR(object):
     def update_from_github_review_state(self, review):
         if self.review != review:
             log.info(f'review state changing from {self.review} to {review} {self.short_str()}')
-            # FIXME: start merge flow if approved and success
             return self.copy(review=review)
         else:
             return self

--- a/ci/ci/prs.py
+++ b/ci/ci/prs.py
@@ -129,11 +129,14 @@ class PRS(object):
         assert isinstance(target, FQRef)
         ready_to_merge = self.ready_to_merge(target)
         if len(ready_to_merge) != 0:
+            log.info(f'merging {ready_to_merge.short_str()}')
             pr = ready_to_merge[-1]
             self.merge(pr)
         else:
+            log.info(f'nothing ready to merge for {target.short_str()}')
             self.build_next(target)
         if self.is_deployable_target_ref(target):
+            log.info(f'deploying {target.short_str()}')
             self.try_deploy(target)
         else:
             log.info(f'not deploying target {target.short_str()}')

--- a/ci/ci/prs.py
+++ b/ci/ci/prs.py
@@ -239,7 +239,7 @@ class PRS(object):
                 },
                 attributes=attributes,
                 callback=SELF_HOSTNAME + '/deploy_build_done')
-            log.info(f'deploying {target_ref.short_str()} in job {job.id}')
+            log.info(f'deploying {target_ref.short_str()}:{latest_sha} in job {job.id}')
             self.deploy_jobs[target_ref] = job
         except Exception as e:
             log.exception(f'could not start deploy job due to {e}')
@@ -365,17 +365,6 @@ class PRS(object):
         assert source.sha == pr.source.sha, f'{source} {pr}'
         assert target.sha == pr.target.sha, f'{target} {pr}'
         self._set(source.ref, target.ref, pr.refresh_from_batch_job(job))
-
-    def refresh_from_github_build_status(self, gh_pr, status):
-        assert isinstance(gh_pr, GitHubPR), gh_pr
-        pr = self._get(gh_pr.source.ref, gh_pr.target_ref)
-        if pr is None:
-            log.warning(
-                f'found new PR during GitHub build status update {gh_pr.short_str()}')
-            pr = gh_pr.to_PR()
-        self._set(gh_pr.source.ref,
-                  gh_pr.target_ref,
-                  pr.update_from_github_status(status))
 
     def build(self, source, target):
         assert isinstance(source, FQRef)

--- a/ci/ci/prs.py
+++ b/ci/ci/prs.py
@@ -129,7 +129,7 @@ class PRS(object):
         assert isinstance(target, FQRef)
         ready_to_merge = self.ready_to_merge(target)
         if len(ready_to_merge) != 0:
-            log.info(f'merging {ready_to_merge.short_str()}')
+            log.info(f'merging {ready_to_merge[-1].short_str()}')
             pr = ready_to_merge[-1]
             self.merge(pr)
         else:

--- a/ci/generate-uid.sh
+++ b/ci/generate-uid.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+LC_CTYPE=C LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 8

--- a/ci/hail-ci-build.sh
+++ b/ci/hail-ci-build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -ex
+
+make test-in-cluster

--- a/ci/test-in-cluster.sh
+++ b/ci/test-in-cluster.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -ex
+
+export UUID=$(./generate-uid.sh)
+export SERVICE_NAME=test-ci-$UUID
+
+kubectl expose pod $POD_NAME --name $SERVICE_NAME \
+        --type ClusterIP \
+        --port 80 \
+        --target-port 5000
+
+cleanup() {
+    set +e
+    trap - INT TERM
+    kubectl delete service $SERVICE_NAME
+}
+trap cleanup EXIT
+
+trap "exit 42" INT TERM
+
+get_ip() {
+    kubectl get service $SERVICE_NAME --no-headers | awk '{print $4}'
+}
+
+cp /secrets/user* github-tokens
+mkdir oauth-token
+cp /secrets/oauth-token oauth-token
+mkdir gcloud-token
+cp /secrets/hail-ci-0-1.key gcloud-token
+
+export IN_CLUSTER=true
+export SELF_HOSTNAME=https://ci.hail.is/$SERVICE_NAME
+export BATCH_SERVER_URL=http://batch
+
+./test-locally.sh

--- a/ci/test-in-cluster.sh
+++ b/ci/test-in-cluster.sh
@@ -11,7 +11,7 @@ kubectl expose pod $POD_NAME --name $SERVICE_NAME \
 
 cleanup() {
     set +e
-    trap - INT TERM
+    trap "" INT TERM
     kubectl delete service $SERVICE_NAME
 }
 trap cleanup EXIT

--- a/ci/test-locally.sh
+++ b/ci/test-locally.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 set -ex
 
-export REPO_NAME=ci-test-$(LC_CTYPE=C LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 8)
+. activate hail-ci
+
+pip install -U ../batch
+
+export UUID=${UUID:-$(./generate-uid.sh)}
+export REPO_NAME=ci-test-$UUID
 export WATCHED_TARGETS='[["hail-ci-test/'${REPO_NAME}':master", true]]'
 
 set +x
@@ -31,11 +36,6 @@ curl -XPOST \
      -d "{ \"name\" : \"${REPO_NAME}\" }"
 set -x
 
-# start CI system
-source activate hail-ci
-python ci/ci.py & echo $! > ci.pid
-sleep 10
-
 # upload files to temp repo
 # https://unix.stackexchange.com/questions/30091/fix-or-alternative-for-mktemp-in-os-x
 REPO_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
@@ -53,10 +53,14 @@ git commit -m 'inital commit'
 git push origin master:master
 popd
 
+# start CI system
+source activate hail-ci
+python ci/ci.py --debug & echo $! > ci.pid
+sleep 10
+
 # setup webhooks for temp repo
 set +x
 ./setup-endpoints.sh hail-ci-test/${REPO_NAME} ${TOKEN} ${SELF_HOSTNAME}
 set -x
 
-export PYTHONPATH=$PYTHONPATH:${PWD}/ci
-pytest -vv test/test-ci.py
+PYTHONPATH=$PYTHONPATH:${PWD}/ci pytest -vv test/test-ci.py

--- a/ci/test/test-ci.py
+++ b/ci/test/test-ci.py
@@ -107,8 +107,8 @@ def dictKVMismatches(actual, kvs):
 
 REPO_NAME = os.environ['REPO_NAME']
 FQ_REPO = 'hail-ci-test/' + os.environ['REPO_NAME']
-DELAY_IN_SECONDS = 5
-MAX_POLLS = 20
+DELAY_IN_SECONDS = 15
+MAX_POLLS = 30
 
 
 def test_pull_request_comment_does_not_overwrite_approval():

--- a/ci/test/test-ci.py
+++ b/ci/test/test-ci.py
@@ -1,4 +1,5 @@
 from http_helper import get_repo, post_repo, patch_repo
+from environment import INSTANCE_ID
 from pr import PR
 from subprocess import call, run
 import inspect
@@ -99,6 +100,32 @@ def dictKVMismatches(actual, kvs):
             elif actual_v != v:
                 errors[k] = f'{actual_v} != {v}'
     return errors
+
+
+class NoCleanUpTemporaryDirectory(object):
+    def __init__(self, f):
+        self.f = f
+
+    def __enter__(self):
+        return self.f
+
+    def __exit__(self, a, b, c):
+        return
+
+i = 0
+
+def tempdir():
+    in_cluster = os.environ.get("IN_CLUSTER")
+    if in_cluster and in_cluster == "true":
+        # for some reason, pytest does not work in a k8s pod using a temporary
+        # directory that is deleted when the test finishes
+        global i
+        path = f'/tmp/hail-ci-{INSTANCE_ID}-{i}'
+        i = i + 1
+        os.mkdir(path)
+        return NoCleanUpTemporaryDirectory(path)
+    else:
+        return tempfile.TemporaryDirectory()
 
 
 ###############################################################################
@@ -226,7 +253,7 @@ class TestCIAgainstGitHub(unittest.TestCase):
 
     def test_pull_request_trigger(self):
         BRANCH_NAME = 'test_pull_request_trigger'
-        with tempfile.TemporaryDirectory() as d:
+        with tempdir() as d:
             pr_number = None
             try:
                 status = ci_get('/status', status_code=200)
@@ -237,8 +264,10 @@ class TestCIAgainstGitHub(unittest.TestCase):
                                      'owner': 'hail-ci-test'},
                                     'name': 'master'}, True]])
                 os.chdir(d)
-                call(['git', 'clone', f'git@github.com:hail-ci-test/{self.repo_name}.git'])
+                call(['git', 'clone', f'https://{oauth_tokens["user1"]}@github.com/hail-ci-test/{self.repo_name}.git'])
                 os.chdir(self.repo_name)
+                call(['git', 'config', 'user.email', 'ci-automated-tests@broadinstitute.org'])
+                call(['git', 'config', 'user.name', 'ci-automated-tests'])
                 call(['git', 'remote', '-v'])
 
                 call(['git', 'checkout', '-b', BRANCH_NAME])
@@ -344,7 +373,7 @@ class TestCIAgainstGitHub(unittest.TestCase):
     def test_push_while_building(self):
         BRANCH_NAME = 'test_push_while_building'
         SLOW_BRANCH_NAME = 'test_push_while_building_slow'
-        with tempfile.TemporaryDirectory() as d:
+        with tempdir() as d:
             pr_number = {}
             source_sha = {}
             gh_pr = {}
@@ -358,8 +387,11 @@ class TestCIAgainstGitHub(unittest.TestCase):
                         'owner': 'hail-ci-test'},
                     'name': 'master'}, True]]
                 os.chdir(d)
-                call(['git', 'clone', f'git@github.com:hail-ci-test/{self.repo_name}.git'])
+
+                call(['git', 'clone', f'https://{oauth_tokens["user1"]}@github.com/hail-ci-test/{self.repo_name}.git'])
                 os.chdir(self.repo_name)
+                call(['git', 'config', 'user.email', 'ci-automated-tests@broadinstitute.org'])
+                call(['git', 'config', 'user.name', 'ci-automated-tests'])
                 call(['git', 'remote', '-v'])
 
                 # start slow branch
@@ -480,7 +512,7 @@ class TestCIAgainstGitHub(unittest.TestCase):
 
     def test_merges_approved_pr(self):
         BRANCH_NAME = 'test_merges_approved_pr'
-        with tempfile.TemporaryDirectory() as d:
+        with tempdir() as d:
             pr_number = None
             try:
                 status = ci_get('/status', status_code=200)
@@ -491,8 +523,10 @@ class TestCIAgainstGitHub(unittest.TestCase):
                         'owner': 'hail-ci-test'},
                     'name': 'master'}, True]]
                 os.chdir(d)
-                call(['git', 'clone', f'git@github.com:hail-ci-test/{self.repo_name}.git'])
+                call(['git', 'clone', f'https://{oauth_tokens["user1"]}@github.com/hail-ci-test/{self.repo_name}.git'])
                 os.chdir(self.repo_name)
+                call(['git', 'config', 'user.email', 'ci-automated-tests@broadinstitute.org'])
+                call(['git', 'config', 'user.name', 'ci-automated-tests'])
                 call(['git', 'remote', '-v'])
 
                 call(['git', 'checkout', '-b', BRANCH_NAME])


### PR DESCRIPTION
![Finally.](https://media.giphy.com/media/yIsbuPCEOgNHO/giphy.gif)

 - update endpoints to handle the "zen" that GitHub sends when a web hook is created

 - update `make run-local` and friends for the new IP of the `dk-test` micro instance

 - remove the unused `refresh_statuses` (this was intended to recover build state from github's commit statuses, but the commit status description is limited to like 120 characters, so I gave up on this a while ago, but never removed the code)

 - `.strip()` the GitHub token in case there are newlines

 - print the SHA being deployed in the log statement

 - add `hail-ci-build.sh` to CI, which just invokes `make test-in-cluster`(which in turn runs `test-in-cluster.sh`

 - `test-in-cluster.sh` copies the secrets for testing to the expected locations and exposes the pod in which it is running with an internal service, recent changes to `site` [redirect sub URLs of ci.test.is to services named using this scheme](https://github.com/hail-is/hail/blob/master/site/hail.nginx.conf#L38-L41). GitHub uses these URLs to send updates to the CI under test about the watched repositories

 - `test-locally.sh` now installs `../batch` into the currently running `pip` before testing (NB: if you edit batch and run the tests without committing the changes you've made to batch, this will pass tests but fail when pushed to a PR!)

 - `test-locally.sh` activates the `hail-ci` conda environment itself because it was not being propagated from the `Makefile`. I don't know why, but this is a simple fix.

 - `test-locally.sh` starts the ci after the repository is created. CI will print error messages if a watched repository doesn't exist.

 - `test/test-ci.py` now uses access tokens for all interaction with GitHub, previously it relied on the latent privileges that I and Cotton had in our environments

 - `test/test-ci.py` uses a temporary, but not automatically deleted, directory when the environment variable `IN_CLUSTER` is set to `true` (to which it is set by `test-in-cluster.sh`). I noticed that, when running in a batch job pod, if an error occurred, `pytest` failed to print any error information and instead failed because the current working directory no longer existed. I found very little information on Google about this. It seems safe to not clean up temporary directories created in the batch job pod because pods are ephemeral.

cc: @cseed

Assigning to @tpoterba since he has the most context on this stuff other than Cotton.