### PR TITLE
IRSuite tests for ToDict and LowerBoundOrderedCollection

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
@@ -57,11 +57,11 @@ class BinarySearch(mb: EmitMethodBuilder, typ: TContainer, keyOnly: Boolean) {
       region, (typ.isElementMissing(region, array, i),
         region.loadIRIntermediate(elt)(typ.elementOffset(array, len, i))))
 
-  // return smallest i such that elem <= array(i)
+  // Returns smallest i, 0 <= i < n, for which a(i) >= key, or returns n if a(i) < key for all i
   findElt.emit(Code(
     len := typ.loadLength(region, array),
     low := 0,
-    high := len - 1,
+    high := len,
     Code.whileLoop(low < high,
       i := (low + high) / 2,
       (cmp(i) <= 0).mux(

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -268,18 +268,17 @@ object Interpret {
         if (cValue == null)
           null
         else {
-          val nSmaller = cValue match {
+          cValue match {
             case s: Set[_] =>
               assert(!onKey)
-              s.count(elem.typ.ordering.lteq(_, eValue))
+              s.count(elem.typ.ordering.lt(_, eValue))
             case d: Map[_, _] =>
               assert(onKey)
-              d.count { case (k, _) => elem.typ.ordering.lteq(k, eValue) }
+              d.count { case (k, _) => elem.typ.ordering.lt(k, eValue) }
             case a: IndexedSeq[_] =>
               assert(!onKey)
-              a.count(elem.typ.ordering.lteq(_, eValue))
+              a.count(elem.typ.ordering.lt(_, eValue))
           }
-          Integer.max(0, nSmaller - 1)
         }
 
       case GroupByKey(collection) =>

--- a/hail/src/main/scala/is/hail/expr/ir/functions/SetFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/SetFunctions.scala
@@ -6,13 +6,20 @@ import is.hail.expr.types
 import is.hail.utils.FastSeq
 
 object SetFunctions extends RegistryFunctions {
-  def contains(set: IR, elem: IR) =
+  def contains(set: IR, elem: IR) = {
+    val n = Ref(genUID(), TInt32())
+    val i = Ref(genUID(), TInt32())
+
     If(IsNA(set),
       NA(TBoolean()),
-      !ArrayLen(ToArray(set)).ceq(0) && ApplyComparisonOp(
-        EQWithNA(elem.typ),
-        ArrayRef(ToArray(set), LowerBoundOnOrderedCollection(set, elem, onKey=false)),
-        elem))
+      Let(n.name,
+        ArrayLen(ToArray(set)),
+        !n.ceq(0) && Let(i.name,
+          LowerBoundOnOrderedCollection(set, elem, onKey = false),
+          If(i.ceq(n),
+            False(),
+            ApplyComparisonOp(EQWithNA(elem.typ), ArrayRef(ToArray(set), i), elem)))))
+  }
 
   def registerAll() {
     registerIR("toSet", TArray(tv("T"))) { a =>

--- a/hail/src/main/scala/is/hail/expr/ir/functions/SetFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/SetFunctions.scala
@@ -7,18 +7,15 @@ import is.hail.utils.FastSeq
 
 object SetFunctions extends RegistryFunctions {
   def contains(set: IR, elem: IR) = {
-    val n = Ref(genUID(), TInt32())
     val i = Ref(genUID(), TInt32())
 
     If(IsNA(set),
       NA(TBoolean()),
-      Let(n.name,
-        ArrayLen(ToArray(set)),
-        !n.ceq(0) && Let(i.name,
-          LowerBoundOnOrderedCollection(set, elem, onKey = false),
-          If(i.ceq(n),
-            False(),
-            ApplyComparisonOp(EQWithNA(elem.typ), ArrayRef(ToArray(set), i), elem)))))
+      Let(i.name,
+        LowerBoundOnOrderedCollection(set, elem, onKey = false),
+        If(i.ceq(ArrayLen(ToArray(set))),
+          False(),
+          ApplyComparisonOp(EQWithNA(elem.typ), ArrayRef(ToArray(set), i), elem))))
   }
 
   def registerAll() {

--- a/hail/src/test/scala/is/hail/expr/ir/DictFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/DictFunctionsSuite.scala
@@ -1,6 +1,5 @@
 package is.hail.expr.ir
 
-import is.hail.utils._
 import is.hail.TestUtils._
 import is.hail.expr.ir.TestUtils._
 import is.hail.expr.types.{TDict, TInt32}

--- a/hail/src/test/scala/is/hail/expr/ir/DictFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/DictFunctionsSuite.scala
@@ -89,6 +89,7 @@ class DictFunctionsSuite extends TestNGSuite {
   }
 
   val d = IRDict((1, 3), (3, 7), (5, null), (null, 5))
+  val dwoutna = IRDict((1, 3), (3, 7), (5, null))
   val na = NA(TInt32())
 
   @Test def dictGet() {
@@ -100,8 +101,10 @@ class DictFunctionsSuite extends TestNGSuite {
     assertEvalsTo(invoke("get", d, 4, -7), -7)
     assertEvalsTo(invoke("get", d, 5, 50), null)
     assertEvalsTo(invoke("get", d, na, 50), 5)
+    assertEvalsTo(invoke("get", dwoutna, na, 50), 50)
     assertEvalsTo(invoke("get", d, 100, 50), 50)
     assertEvalsTo(invoke("get", d, 100, na), null)
+    assertEvalsTo(invoke("get", dwoutna, 100, 50), 50)
 
     assertEvalsTo(invoke("get", IRDict(), 100, na), null)
     assertEvalsTo(invoke("get", IRDict(), 100, 50), 50)
@@ -123,6 +126,7 @@ class DictFunctionsSuite extends TestNGSuite {
     assertEvalsTo(invoke("contains", d, 4), false)
     assertEvalsTo(invoke("contains", d, 5), true)
     assertEvalsTo(invoke("contains", d, 100), false)
+    assertEvalsTo(invoke("contains", dwoutna, 100), false)
     assertEvalsTo(invoke("contains", d, na), true)
 
     assert(eval(invoke("contains", IRDict(), 100)) == false)

--- a/hail/src/test/scala/is/hail/expr/ir/SetFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/SetFunctionsSuite.scala
@@ -39,9 +39,14 @@ class SetFunctionsSuite extends TestNGSuite {
 
   @Test def contains() {
     val s = IRSet(3, null, 7)
+    val swoutna = IRSet(3, 7)
+
     assertEvalsTo(invoke("contains", s, I32(3)), true)
     assertEvalsTo(invoke("contains", s, I32(4)), false)
+    assertEvalsTo(invoke("contains", s, I32(10)), false)
+    assertEvalsTo(invoke("contains", swoutna, I32(10)), false)
     assertEvalsTo(invoke("contains", s, NA(TInt32())), true)
+    assertEvalsTo(invoke("contains", swoutna, NA(TInt32())), false)
     assertEvalsTo(invoke("contains", IRSet(3, 7), NA(TInt32())), false)
     assert(eval(invoke("contains", IRSet(), 3)) == false)
   }


### PR DESCRIPTION
- For #4014
- Changed behavior of LowerBoundOnOrderedCollection to return `n` if all elements are less than the search value (no lower bound)
- Fixed the interpreter for LowerBoundOnOrderedCollection