### PR TITLE
rewrite interval joins

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/OrderedRVIterator.scala
+++ b/hail/src/main/scala/is/hail/annotations/OrderedRVIterator.scala
@@ -47,8 +47,6 @@ case class OrderedRVIterator(
   def leftJoinDistinct(other: OrderedRVIterator): Iterator[JoinedRegionValue] =
     iterator.toFlipbookIterator.leftJoinDistinct(
       other.iterator.toFlipbookIterator,
-      this.t.kRowOrdView(ctx.freshRegion),
-      other.t.kRowOrdView(ctx.freshRegion),
       null,
       null,
       this.t.joinComp(other.t).compare
@@ -57,8 +55,6 @@ case class OrderedRVIterator(
   def leftIntervalJoinDistinct(other: OrderedRVIterator): Iterator[JoinedRegionValue] =
     iterator.toFlipbookIterator.leftJoinDistinct(
       other.iterator.toFlipbookIterator,
-      this.t.kRowOrdView(ctx.freshRegion),
-      other.t.kRowOrdView(ctx.freshRegion),
       null,
       null,
       this.t.intervalJoinComp(other.t).compare

--- a/hail/src/main/scala/is/hail/annotations/OrderedRVIterator.scala
+++ b/hail/src/main/scala/is/hail/annotations/OrderedRVIterator.scala
@@ -54,6 +54,16 @@ case class OrderedRVIterator(
       this.t.joinComp(other.t).compare
     )
 
+  def leftIntervalJoinDistinct(other: OrderedRVIterator): Iterator[JoinedRegionValue] =
+    iterator.toFlipbookIterator.leftJoinDistinct(
+      other.iterator.toFlipbookIterator,
+      this.t.kRowOrdView(ctx.freshRegion),
+      other.t.kRowOrdView(ctx.freshRegion),
+      null,
+      null,
+      this.t.intervalJoinComp(other.t).compare
+    )
+
   def innerJoin(
     other: OrderedRVIterator,
     rightBuffer: Iterable[RegionValue] with Growable[RegionValue]

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -2010,7 +2010,11 @@ case class MatrixAnnotateRowsTable(
             .map { case Muple(rv, i) =>
               rvb.set(rv.region)
               rvb.start(newRVType)
-              ins(rv.region, rv.offset, rvb, () => rvb.selectRegionValue(rightTyp.rowType, rightTyp.valueFieldIdx, i))
+              ins(
+                rv.region,
+                rv.offset,
+                rvb,
+                () => if (i == null) rvb.setMissing() else rvb.selectRegionValue(rightTyp.rowType, rightTyp.valueFieldIdx, i))
               rv2.set(rv.region, rvb.end())
 
               rv2

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -11,7 +11,6 @@ import is.hail.sparkextras.ContextRDD
 import is.hail.utils._
 import is.hail.variant._
 import org.apache.commons.lang3.StringUtils
-import org.apache.spark.Partitioner
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
@@ -739,79 +738,31 @@ class Table(val hc: HailContext, val tir: TableIR) {
     val intervalType = other.keySignature.types(0).asInstanceOf[TInterval]
     assert(keySignature.size == 1 && keySignature.types(0) == intervalType.pointType)
 
-    val leftRVD = rvd
-
-    val typOrdering = intervalType.pointType.ordering
-
     val typToInsert: Type = other.valueSignature
-
     val (newRowPType, ins) = signature.physicalType.unsafeStructInsert(typToInsert.physicalType, List(fieldName))
     val newRowType = newRowPType.virtualType
 
-    val partBc = hc.sc.broadcast(leftRVD.partitioner)
-    val rightSignature = other.signature.physicalType
-    val rightKeyFieldIdx = other.keyFieldIdx(0)
-    val rightValueFieldIdx = other.valueFieldIdx
-    val partitionKeyedIntervals = other.rvd.boundary.crdd
-      .flatMap { rv =>
-        val r = SafeRow(rightSignature, rv)
-        val interval = r.getAs[Interval](rightKeyFieldIdx)
-        if (interval != null) {
-          val rangeTree = partBc.value.rangeTree
-          val kOrd = partBc.value.kType.ordering
-          val wrappedInterval = interval.copy(
-            start = Row(interval.start),
-            end = Row(interval.end))
-          rangeTree.queryOverlappingValues(kOrd, wrappedInterval).map(i => (i, r))
-        } else
-          Iterator()
-      }
+    val rightTyp = other.typ
+    val leftRVDType = typ.rvdType
 
-    val nParts = rvd.getNumPartitions
-    val zipRDD = partitionKeyedIntervals.partitionBy(new Partitioner {
-      def getPartition(key: Any): Int = key.asInstanceOf[Int]
-
-      def numPartitions: Int = nParts
-    }).values
-
-    val localRVRowType = signature.physicalType
-    val pkIndex = signature.fieldIdx(key(0))
-    val newRVDType = RVDType(newRowType, key)
-    val newRVD = leftRVD.zipPartitions(
-      newRVDType,
-      zipRDD
-    ) { (it, intervals) =>
-      val intervalAnnotations: Array[(Interval, Any)] =
-        intervals.map { r =>
-          val interval = r.getAs[Interval](rightKeyFieldIdx)
-          (interval, Row.fromSeq(rightValueFieldIdx.map(r.get)))
-        }.toArray
-
-      val iTree = IntervalTree.annotationTree(typOrdering, intervalAnnotations)
-
+    val zipper = { (ctx: RVDContext, it: Iterator[RegionValue], intervals: Iterator[RegionValue]) =>
       val rvb = new RegionValueBuilder()
       val rv2 = RegionValue()
+      OrderedRVIterator(leftRVDType, it, ctx).leftIntervalJoinDistinct(
+        OrderedRVIterator(rightTyp.rvdType, intervals, ctx)
+      )
+        .map { case Muple(rv, i) =>
+          rvb.set(rv.region)
+          rvb.start(newRowType)
+          ins(rv.region, rv.offset, rvb, () => rvb.selectRegionValue(rightTyp.rowType, rightTyp.valueFieldIdx, i))
+          rv2.set(rv.region, rvb.end())
 
-      it.map { rv =>
-        val ur = new UnsafeRow(localRVRowType, rv)
-        val pk = ur.get(pkIndex)
-        val queries = iTree.queryValues(typOrdering, pk)
-        val value = if (queries.isEmpty)
-          null
-        else
-          queries(0)
-        assert(typToInsert.typeCheck(value))
-
-        rvb.set(rv.region)
-        rvb.start(newRowType)
-
-        ins(rv.region, rv.offset, rvb, () => rvb.addAnnotation(typToInsert, value))
-
-        rv2.set(rv.region, rvb.end())
-
-        rv2
-      }
+          rv2
+        }
     }
+
+    val newRVDType = RVDType(newRowType, key)
+    val newRVD = rvd.intervalAlignAndZipPartitions(newRVDType, other.rvd)(zipper)
 
     copy2(rvd = newRVD, signature = newRowType)
   }

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -754,7 +754,11 @@ class Table(val hc: HailContext, val tir: TableIR) {
         .map { case Muple(rv, i) =>
           rvb.set(rv.region)
           rvb.start(newRowType)
-          ins(rv.region, rv.offset, rvb, () => rvb.selectRegionValue(rightTyp.rowType, rightTyp.valueFieldIdx, i))
+          ins(
+            rv.region,
+            rv.offset,
+            rvb,
+            () => if (i == null) rvb.setMissing() else rvb.selectRegionValue(rightTyp.rowType, rightTyp.valueFieldIdx, i))
           rv2.set(rv.region, rvb.end())
 
           rv2

--- a/hail/src/test/scala/is/hail/utils/FlipbookIteratorSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/FlipbookIteratorSuite.scala
@@ -182,8 +182,6 @@ class FlipbookIteratorSuite extends SparkSuite {
     val right = makeTestIterator(2, 4, 4, 5, 1000, 1000)
     val joined = left.leftJoinDistinct(
       right,
-      boxOrdView[Int],
-      boxOrdView[Int],
       Box(0),
       Box(0),
       boxIntOrd(missingValue = 1000)


### PR DESCRIPTION
This is the precursor to a follow-up PR which removes `IntervalTree`. `IntervalTree` was doing two jobs: handling queries against the range bounds of a partitioner, which have (essentially) no overlap, and in these interval join methods, where they may overlap arbitrarily. It ended up being suboptimal for both use cases. This PR rewrites the interval join methods, which should now be faster, and no longer depends on `IntervalTree`.

The existing interval join methods only supported distinct joins (`product = false`). The implementation I wrote won't work for the `product = true` case, but I have a plan for that, which will fit into the structure I started here.