### PR TITLE
remove unconditional let forwarding to single ref

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -123,9 +123,6 @@ object Simplify {
 
       case Let(n, v, b) if !Mentions(b, n) => b
 
-      case Let(n, v, b) if CountMentions(b, n) == 1 =>
-        Subst(b, Env.empty[IR].bind(n, v))
-
       case Let(_, _, Begin(Seq())) => Begin(FastIndexedSeq())
 
       case ArrayFor(_, _, Begin(Seq())) => Begin(FastIndexedSeq())


### PR DESCRIPTION
There are two problems with this:
 - it is a massive de-optimization if we forward an expensive computation into a loop (e.g. arraymap)
 - in the above case, it is an error in if the body of the let is non-deterministic

To do this right we need to build a control flow graph.
