### PR TITLE
add gcs connector installer

### DIFF
--- a/hail/install-gcs-connector.sh
+++ b/hail/install-gcs-connector.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+which gcloud >/dev/null \
+    || (echo 'install `gcloud` first https://cloud.google.com/sdk/docs/quickstarts' ; exit 1)
+
+gcloud auth list | grep -Ee '^\* ' | grep -vq 'compute@developer.gserviceaccount.com' \
+    || (echo "WARNING: you are logged in as $(gcloud auth list | grep -Ee '^\* '), if this fails, try logging in as YOU@YOUR_ORGANIZATION.com")
+
+set -e
+
+COMPUTE_ENGINE_SERVICE_ACCOUNT=$(gcloud iam service-accounts list \
+                                     | grep -e 'Compute Engine default service account' \
+                                     | sed 's:Compute Engine default service account[ ]*::')
+
+mkdir -p ${HOME}/.hail/gcs-keys/
+
+KEY_FILE=${HOME}/.hail/gcs-keys/gcs-connector-key.json
+gcloud iam service-accounts keys create \
+       ${KEY_FILE} \
+       --iam-account $COMPUTE_ENGINE_SERVICE_ACCOUNT
+chmod 440 ${KEY_FILE}
+
+which find_spark_home.py >/dev/null \
+    || (echo 'you do not have find_spark_home.py on your path, did you already `pip install hail`?' ; exit 1)
+
+SPARK_HOME=$(find_spark_home.py)
+
+set +e
+mkdir ${SPARK_HOME}/conf
+set -e
+
+CONF_FILE=${SPARK_HOME}/conf/spark-defaults.conf
+
+SVC_ACCT_ENABLE=spark.hadoop.google.cloud.auth.service.account.enable
+SVC_ACCT_KEY_FILE=spark.hadoop.google.cloud.auth.service.account.json.keyfile
+sed -i '' "/${SVC_ACCT_ENABLE}/d" ${CONF_FILE}
+sed -i '' "/${SVC_ACCT_KEY_FILE}/d" ${CONF_FILE}
+echo "${SVC_ACCT_ENABLE} true" >> ${CONF_FILE}
+echo "${SVC_ACCT_KEY_FILE} ${KEY_FILE}" >> ${CONF_FILE}
+
+echo "success"


### PR DESCRIPTION
Looks like this:
```
(py37) dking@wmb16-359 # ./install-gcs-connector.sh              

To set the active account, run:
    $ gcloud config set account `ACCOUNT`

created key [bd10c2da666d327144166cc71ba13075dbd7ea26] of type [json] as [/Users/dking/.hail/gcs-keys/gcs-connector-key.json] for [842871226259-compute@developer.gserviceaccount.com]
mkdir: /Users/dking/anaconda2/envs/py37/lib/python3.7/site-packages/pyspark/conf: File exists
success
```
I tested it by running `python -c 'import hail as hl; hl.read_table("gs://danking/gnomad-test.mt").describe()'`