### PR TITLE
Improve robustness of export_plink and export_gen tests

### DIFF
--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2232,7 +2232,7 @@ class MatrixTable(ExprContainer):
             Table with all column fields from the matrix, with one row per column of the matrix.
         """
 
-        if self.col_key is not None and len(self.col_key) != 0 and Env.hc()._warn_cols_order:
+        if len(self.col_key) != 0 and Env.hc()._warn_cols_order:
             warn("cols(): Resulting column table is sorted by 'col_key'."
                  "\n    To preserve matrix table column order, "
                  "first unkey columns with 'key_cols_by()'")

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2231,8 +2231,8 @@ class MatrixTable(ExprContainer):
         :class:`.Table`
             Table with all column fields from the matrix, with one row per column of the matrix.
         """
-        
-        if self.col_key is not None and Env.hc()._warn_cols_order:
+
+        if self.col_key is not None and len(self.col_key) != 0 and Env.hc()._warn_cols_order:
             warn("cols(): Resulting column table is sorted by 'col_key'."
                  "\n    To preserve matrix table column order, "
                  "first unkey columns with 'key_cols_by()'")

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -283,6 +283,12 @@ class PLINKTests(unittest.TestCase):
         vcf_file = resource('sample.vcf')
         mt = hl.split_multi_hts(hl.import_vcf(vcf_file, min_partitions=10))
 
+        # permute columns so not in alphabetical order!
+        import random
+        indices = list(range(mt.count_cols()))
+        random.shuffle(indices)
+        mt = mt.choose_cols(indices)
+
         split_vcf_file = uri_path(new_temp_file())
         hl_output = uri_path(new_temp_file())
         plink_output = uri_path(new_temp_file())
@@ -876,6 +882,12 @@ class GENTests(unittest.TestCase):
                             contig_recoding={"01": "1"},
                             reference_genome='GRCh37',
                             min_partitions=3)
+
+        # permute columns so not in alphabetical order!
+        import random
+        indices = list(range(gen.count_cols()))
+        random.shuffle(indices)
+        gen = gen.choose_cols(indices)
 
         file = '/tmp/test_export_gen'
         hl.export_gen(gen, file)


### PR DESCRIPTION
Addresses #4508. Can you double check I can turn off the warning if the col key is an empty struct and not None?