### PR TITLE
also print the entries index

### DIFF
--- a/hail/src/main/scala/is/hail/expr/types/MatrixType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/MatrixType.scala
@@ -135,6 +135,8 @@ case class MatrixType(
     sb.append(s"entry:$space")
     entryType.pretty(sb, indent, compact)
 
+    sb.append(s"entriesIndex:$space${entriesIdx}")
+
     indent -= 4
     newline()
     sb += '}'


### PR DESCRIPTION
Fixes #4524

Two matrix types can be non-equal if they have different entries locations, so we should include that information in the printed form.

Example:
```
Matrix{global:Struct{},col_key:[col_idx],col:Struct{col_idx:Int32},row_key:[[locus,alleles]],row:Struct{row_idx:Int32,locus:Locus(GRCh37),alleles:Array[String],a_index:Int32,was_split:Boolean,old_locus:Locus(GRCh37),old_alleles:Array[String]},entry:Struct{}entriesIndex:7}
```