### PR TITLE
only extract includes on master

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/package.scala
+++ b/hail/src/main/scala/is/hail/asm4s/package.scala
@@ -166,7 +166,7 @@ package object asm4s {
     def newArray() = new TypeInsnNode(ANEWARRAY, iname)
   }
 
-  object HailClassLoader extends ClassLoader {
+  object HailClassLoader extends ClassLoader(this.getClass.getClassLoader) {
     def loadOrDefineClass(name: String, b: Array[Byte]): Class[_] = {
       getClassLoadingLock(name).synchronized {
         try {
@@ -185,6 +185,9 @@ package object asm4s {
 
     System.err.println("HailClassLoader loader")
     dumpClassLoader(HailClassLoader.getClass.getClassLoader)
+
+    System.err.println("SystemClassLoader")
+    dumpClassLoader(ClassLoader.getSystemClassLoader)
 
     HailClassLoader.loadOrDefineClass(className, b)
   }

--- a/hail/src/main/scala/is/hail/asm4s/package.scala
+++ b/hail/src/main/scala/is/hail/asm4s/package.scala
@@ -4,8 +4,6 @@ import org.objectweb.asm.Opcodes._
 import org.objectweb.asm.Type
 import org.objectweb.asm.tree._
 
-import is.hail.utils._
-
 import scala.collection.generic.Growable
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
@@ -166,7 +164,7 @@ package object asm4s {
     def newArray() = new TypeInsnNode(ANEWARRAY, iname)
   }
 
-  object HailClassLoader extends ClassLoader(this.getClass.getClassLoader) {
+  object HailClassLoader extends ClassLoader(getClass.getClassLoader) {
     def loadOrDefineClass(name: String, b: Array[Byte]): Class[_] = {
       getClassLoadingLock(name).synchronized {
         try {
@@ -180,15 +178,6 @@ package object asm4s {
   }
 
   def loadClass(className: String, b: Array[Byte]): Class[_] = {
-    System.err.println("HailClassLoader")
-    dumpClassLoader(HailClassLoader)
-
-    System.err.println("HailClassLoader loader")
-    dumpClassLoader(HailClassLoader.getClass.getClassLoader)
-
-    System.err.println("SystemClassLoader")
-    dumpClassLoader(ClassLoader.getSystemClassLoader)
-
     HailClassLoader.loadOrDefineClass(className, b)
   }
 

--- a/hail/src/main/scala/is/hail/asm4s/package.scala
+++ b/hail/src/main/scala/is/hail/asm4s/package.scala
@@ -4,6 +4,8 @@ import org.objectweb.asm.Opcodes._
 import org.objectweb.asm.Type
 import org.objectweb.asm.tree._
 
+import is.hail.utils._
+
 import scala.collection.generic.Growable
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
@@ -178,6 +180,12 @@ package object asm4s {
   }
 
   def loadClass(className: String, b: Array[Byte]): Class[_] = {
+    System.err.println("HailClassLoader")
+    dumpClassLoader(HailClassLoader)
+
+    System.err.println("HailClassLoader loader")
+    dumpClassLoader(HailClassLoader.getClass.getClassLoader)
+
     HailClassLoader.loadOrDefineClass(className, b)
   }
 

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -164,8 +164,8 @@ final case class PackCodecSpec(child: BufferSpec) extends CodecSpec {
       mod.findOrBuild(st)
       assert(st.ok, st.toString())
       st.close()
-      val modKey = mod.getKey()
-      val modBinary = mod.getBinary()
+      val modKey = mod.getKey
+      val modBinary = mod.getBinary
       mod.close()
       (in: InputStream) => new NativePackDecoder(child.buildInputBuffer(in), modKey, modBinary)
     } else {

--- a/hail/src/main/scala/is/hail/nativecode/NativeCode.java
+++ b/hail/src/main/scala/is/hail/nativecode/NativeCode.java
@@ -2,114 +2,115 @@ package is.hail.nativecode;
 
 import java.io.*;
 import java.util.*;
-import java.util.regex.*;
 import java.util.zip.*;
-import java.net.URL;
 import java.nio.file.*;
-import com.sun.jna.*;
-import org.apache.log4j.*;
+
+import org.apache.spark.TaskContext;
 
 public class NativeCode {
-  private static String includeDir;
-  private static String hailName;
-  
-  static {
-    hailName = "hail";
-    try {
-      // libboot.so has native methods to call dlopen/dlclose
-      String libBoot = libToLocalFile("libboot");
-      System.load(libBoot);
-      String libHail = libToLocalFile("lib"+hailName);
-      // We need libhail.so to be loaded with RTLD_GLOBAL so that its symbols
-      // are visible to dynamic-generated code in other DLLs ...
-      long handle = dlopenGlobal(libHail);
-      // ... but we also need System.load to let the JVM see it
-      System.load(libHail);
-      includeDir = unpackHeadersToTmpIncludeDir();
-    } catch (Throwable err) {
-      System.err.println("FATAL: caught exception " + err.toString());
-      err.printStackTrace();
-      System.exit(1);
-    }
-  }
+    private static String includeDir;
+    private static String hailName;
 
-  public static String getHailName() {
-    // Hail methods implemented with JNA call Native.register(NativeCode.getHailName()),
-    // so that NativeCode gets to choose which DLL to load (though currently there's
-    // only one), *and* to get it loaded with RTLD_GLOBAL so that it also works for
-    // dynamic-generated C++ code.
-    return hailName;
-  }
-  
-  private static Boolean isLinux() {
-    String osName = System.getProperty("os.name").toLowerCase();
-    if ((osName.length() >= 3) && osName.substring(0, 3).equals("mac")) {
-      return false;
-    }
-    return true;
-  }
-  
-  private static String libToLocalFile(String libName) throws IOException {
-    File file = File.createTempFile(libName, ".so");
-    ClassLoader loader = NativeCode.class.getClassLoader();
-    InputStream s = null;
-    if (isLinux()) {
-      s = loader.getResourceAsStream("linux-x86-64/" + libName + ".so");
-    } else {
-      s = loader.getResourceAsStream("darwin/" + libName + ".dylib");
-    }
-    Files.copy(s, file.getAbsoluteFile().toPath(), StandardCopyOption.REPLACE_EXISTING);
-    String path = file.getAbsoluteFile().toPath().toString();
-    return path;
-  }
-    
-  private static String unpackHeadersToTmpIncludeDir() {
-    String result = "IncludeDirNotFound";
-    String name = ClassLoader.getSystemResource("include").toString();
-    if ((name.length() > 5) && name.substring(0, 5).equals("file:")) {
-      // The resources are already unpacked
-      result = name.substring(5, name.length());
-    } else try {
-      // The header files must be unpacked from a jar into local files
-      int jarPos = name.indexOf("file:", 0);
-      int jarEnd = name.indexOf("!", jarPos+1);
-      String jarName = name.substring(jarPos+5, jarEnd);
-      Path dirPath = Files.createTempDirectory("hail_headers_");
-      File includeDir = new File(dirPath.toString());
-      String tmpDirName = includeDir.getAbsolutePath().toString();
-      result = tmpDirName + "/include";
-      File f = new File(jarName);
-      ZipFile zf = new ZipFile(f);
-      Enumeration scan = zf.entries();
-      while (scan.hasMoreElements()) {
-        ZipEntry ze = (ZipEntry)scan.nextElement();
-        String fileName = ze.getName();
-        int len = fileName.length();
-        if ((len > 8) &&
-            fileName.substring(0, 8).equals("include/") &&
-            fileName.substring(len-2, len).equals(".h")) {
-          String dstName = tmpDirName + "/" + fileName;
-          File dst = new File(dstName);
-          Files.createDirectories(dst.toPath().getParent());
-          InputStream src = zf.getInputStream(ze);
-          Files.copy(src, dst.toPath(), StandardCopyOption.REPLACE_EXISTING);
+    static {
+        hailName = "hail";
+        try {
+            // libboot.so has native methods to call dlopen/dlclose
+            String libBoot = libToLocalFile("libboot");
+            System.load(libBoot);
+            String libHail = libToLocalFile("lib" + hailName);
+            // We need libhail.so to be loaded with RTLD_GLOBAL so that its symbols
+            // are visible to dynamic-generated code in other DLLs ...
+            long handle = dlopenGlobal(libHail);
+            // ... but we also need System.load to let the JVM see it
+            System.load(libHail);
+
+            // only compile on master
+            if (TaskContext.get() != null)
+                includeDir = unpackHeadersToTmpIncludeDir();
+        } catch (Throwable err) {
+            System.err.println("FATAL: caught exception " + err.toString());
+            err.printStackTrace();
+            System.exit(1);
         }
-      }
-    } catch (Throwable err) {
-      System.err.println("FATAL: caught exception " + err.toString());
-      err.printStackTrace();
-      System.exit(1);
     }
-    return result;
-  }
-  
-  private native static long dlopenGlobal(String path);
-  
-  private native static long dlclose(long handle);
 
-  public final static String getIncludeDir() {
-    return includeDir;
-  }
+    public static String getHailName() {
+        // Hail methods implemented with JNA call Native.register(NativeCode.getHailName()),
+        // so that NativeCode gets to choose which DLL to load (though currently there's
+        // only one), *and* to get it loaded with RTLD_GLOBAL so that it also works for
+        // dynamic-generated C++ code.
+        return hailName;
+    }
 
-  public final static void forceLoad() { }
+    private static Boolean isMac() {
+        String osName = System.getProperty("os.name").toLowerCase();
+        return osName.length() >= 3 && osName.substring(0, 3).equals("mac");
+    }
+
+    private static String libToLocalFile(String libName) throws IOException {
+        File file = File.createTempFile(libName, ".so");
+        ClassLoader loader = NativeCode.class.getClassLoader();
+        InputStream s = null;
+        if (isMac()) {
+            s = loader.getResourceAsStream("darwin/" + libName + ".dylib");
+        } else {
+            s = loader.getResourceAsStream("linux-x86-64/" + libName + ".so");
+        }
+        Files.copy(s, file.getAbsoluteFile().toPath(), StandardCopyOption.REPLACE_EXISTING);
+        return file.getAbsoluteFile().toPath().toString();
+    }
+
+    private static String unpackHeadersToTmpIncludeDir() {
+        String result = null;
+
+        try {
+            Class<?> nativeCodeClass = Class.forName("is.hail.nativecode.NativeCode");
+            String name = nativeCodeClass.getClassLoader().getResource("include").toString();
+            if ((name.length() > 5) && name.substring(0, 5).equals("file:")) {
+                // The resources are already unpacked
+                result = name.substring(5, name.length());
+            } else {
+                // The header files must be unpacked from a jar into local files
+                int jarPos = name.indexOf("file:", 0);
+                int jarEnd = name.indexOf("!", jarPos + 1);
+                String jarName = name.substring(jarPos + 5, jarEnd);
+                Path dirPath = Files.createTempDirectory("hail_headers_");
+                File includeDir = new File(dirPath.toString());
+                String tmpDirName = includeDir.getAbsolutePath();
+                result = tmpDirName + "/include";
+                File f = new File(jarName);
+                ZipFile zf = new ZipFile(f);
+                Enumeration scan = zf.entries();
+                while (scan.hasMoreElements()) {
+                    ZipEntry ze = (ZipEntry) scan.nextElement();
+                    String fileName = ze.getName();
+                    int len = fileName.length();
+                    if ((len > 8) &&
+                            fileName.substring(0, 8).equals("include/") &&
+                            fileName.substring(len - 2, len).equals(".h")) {
+                        String dstName = tmpDirName + "/" + fileName;
+                        File dst = new File(dstName);
+                        Files.createDirectories(dst.toPath().getParent());
+                        InputStream src = zf.getInputStream(ze);
+                        Files.copy(src, dst.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                    }
+                }
+            }
+        } catch (Throwable err) {
+            System.err.println("FATAL: caught exception " + err.toString());
+            err.printStackTrace();
+            System.exit(1);
+        }
+        return result;
+    }
+
+    private native static long dlopenGlobal(String path);
+
+    private native static long dlclose(long handle);
+
+    public static String getIncludeDir() {
+        return includeDir;
+    }
+
+    public static void forceLoad() { }
 }

--- a/hail/src/main/scala/is/hail/nativecode/NativeCode.java
+++ b/hail/src/main/scala/is/hail/nativecode/NativeCode.java
@@ -23,10 +23,6 @@ public class NativeCode {
             long handle = dlopenGlobal(libHail);
             // ... but we also need System.load to let the JVM see it
             System.load(libHail);
-
-            // only compile on master
-            if (TaskContext.get() != null)
-                includeDir = unpackHeadersToTmpIncludeDir();
         } catch (Throwable err) {
             System.err.println("FATAL: caught exception " + err.toString());
             err.printStackTrace();
@@ -108,9 +104,13 @@ public class NativeCode {
 
     private native static long dlclose(long handle);
 
-    public static String getIncludeDir() {
+    public synchronized static String getIncludeDir() {
+        assert (TaskContext.get() == null);
+        if (includeDir == null)
+            includeDir = unpackHeadersToTmpIncludeDir();
         return includeDir;
     }
 
-    public static void forceLoad() { }
+    public static void forceLoad() {
+    }
 }

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -2,7 +2,7 @@ package is.hail
 
 import java.io._
 import java.lang.reflect.Method
-import java.net.URI
+import java.net.{URI, URLClassLoader}
 import java.util.zip.Inflater
 
 import is.hail.check.Gen
@@ -673,6 +673,19 @@ package object utils extends Logging
         ab += n - scan(lastIdx - 1)
       ab.result()
     }
+  }
+
+  def dumpClassLoader(cl: ClassLoader) {
+    System.err.println(s"ClassLoader ${ cl.getClass.getCanonicalName }:")
+    cl match {
+      case cl: URLClassLoader =>
+        System.err.println(s"  ${ cl.getURLs.mkString(" ") }")
+      case _ =>
+        System.err.println("  non-URLClassLoader")
+    }
+    val parent = cl.getParent
+    if (parent != null)
+      dumpClassLoader(parent)
   }
 }
 

--- a/hail/src/test/scala/is/hail/nativecode/NativeCodeSuite.scala
+++ b/hail/src/test/scala/is/hail/nativecode/NativeCodeSuite.scala
@@ -125,8 +125,8 @@ class NativeCodeSuite extends SparkSuite {
     val myObj = new NativePtr(makeMyObj, st, 55L)
     assert(myObj.get() != 0)
     // Now try getting the binary
-    val key = mod.getKey()
-    val binary = mod.getBinary()
+    val key = mod.getKey
+    val binary = mod.getBinary
     mod.close()
     val workerMod = new NativeModule(key, binary)
     val workerFunc1 = workerMod.findLongFuncL1(st, "testFunc1")


### PR DESCRIPTION
I was seeing crashes on workers in a local install because the Hail jar was loaded by a Spark class loader rather than the system class loader, so the toString in:

 > String name = ClassLoader.getSystemResource("include").toString();

was failing with a null pointer exception.  Fixed this two ways: don't unpack includes on the worker (compilation should only happen on the master) and use the same class loader that loaded the NativeCode object.

Also some reformatting and style changes.
