### PR TITLE
Simplify fix

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/BaseIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BaseIR.scala
@@ -12,6 +12,10 @@ abstract class BaseIR {
   def deepCopy(): this.type = copy(newChildren = children.map(_.deepCopy())).asInstanceOf[this.type]
 
   def mapChildren(f: (BaseIR) => BaseIR): BaseIR = {
-    copy(children.map(f))
+    val newChildren = children.map(f)
+    if ((children, newChildren).zipped.forall(_ eq _))
+      this
+    else
+      copy(newChildren)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -1,7 +1,7 @@
 package is.hail.expr.ir
 
 object Copy {
-  def apply(x: IR, newChildren: IndexedSeq[BaseIR]): BaseIR = {
+  def apply(x: IR, newChildren: IndexedSeq[BaseIR]): IR = {
     x match {
       case I32(value) => I32(value)
       case I64(value) => I64(value)

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -16,7 +16,7 @@ sealed trait IR extends BaseIR {
   override def children: IndexedSeq[BaseIR] =
     Children(this)
 
-  override def copy(newChildren: IndexedSeq[BaseIR]): BaseIR =
+  override def copy(newChildren: IndexedSeq[BaseIR]): IR =
     Copy(this, newChildren)
 
   def size: Int = 1 + children.map {

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -181,6 +181,8 @@ abstract sealed class MatrixIR extends BaseIR {
   def columnCount: Option[Int] = None
 
   def execute(hc: HailContext): MatrixValue
+
+  override def copy(newChildren: IndexedSeq[BaseIR]): MatrixIR
 }
 
 case class MatrixLiteral(value: MatrixValue) extends MatrixIR {
@@ -1925,7 +1927,7 @@ case class MatrixAnnotateColsTable(
   private val (colType, inserter) = child.typ.colType.structInsert(table.typ.valueType, List(root))
   val typ: MatrixType = child.typ.copy(colType = colType)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BaseIR = {
+  def copy(newChildren: IndexedSeq[BaseIR]): MatrixAnnotateColsTable = {
     MatrixAnnotateColsTable(
       newChildren(0).asInstanceOf[MatrixIR],
       newChildren(1).asInstanceOf[TableIR],
@@ -1973,7 +1975,7 @@ case class MatrixAnnotateRowsTable(
 
   val typ: MatrixType = child.typ.copy(rvRowType = child.typ.rvRowType ++ TStruct(root -> table.typ.valueType))
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BaseIR = {
+  def copy(newChildren: IndexedSeq[BaseIR]): MatrixAnnotateRowsTable = {
     val (child: MatrixIR) +: (table: TableIR) +: newKey = newChildren
     MatrixAnnotateRowsTable(
       child, table,
@@ -2109,7 +2111,7 @@ case class TableToMatrixTable(
 
   def children: IndexedSeq[BaseIR] = FastIndexedSeq(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BaseIR = {
+  def copy(newChildren: IndexedSeq[BaseIR]): TableToMatrixTable = {
     val IndexedSeq(newChild) = newChildren
     TableToMatrixTable(
       newChild.asInstanceOf[TableIR],
@@ -2277,7 +2279,7 @@ case class MatrixExplodeRows(child: MatrixIR, path: IndexedSeq[String]) extends 
 
   def children: IndexedSeq[BaseIR] = FastIndexedSeq(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BaseIR = {
+  def copy(newChildren: IndexedSeq[BaseIR]): MatrixExplodeRows = {
     val IndexedSeq(newChild) = newChildren
     MatrixExplodeRows(newChild.asInstanceOf[MatrixIR], path)
   }
@@ -2354,7 +2356,7 @@ case class MatrixUnionRows(children: IndexedSeq[MatrixIR]) extends MatrixIR {
   require(children.tail.forall(_.typ.rvdType == typ.rvdType))
   require(children.tail.forall(_.typ.colKeyStruct == typ.colKeyStruct))
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BaseIR =
+  def copy(newChildren: IndexedSeq[BaseIR]): MatrixUnionRows =
     MatrixUnionRows(newChildren.asInstanceOf[IndexedSeq[MatrixIR]])
 
   override def columnCount: Option[Int] =
@@ -2397,7 +2399,7 @@ case class MatrixExplodeCols(child: MatrixIR, path: IndexedSeq[String]) extends 
 
   def children: IndexedSeq[BaseIR] = FastIndexedSeq(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BaseIR = {
+  def copy(newChildren: IndexedSeq[BaseIR]): MatrixExplodeCols = {
     val IndexedSeq(newChild) = newChildren
     MatrixExplodeCols(newChild.asInstanceOf[MatrixIR], path)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -37,13 +37,13 @@ object Simplify {
 
   private[this] def simplifyTable(allowRepartitioning: Boolean): TableIR => TableIR =
     visitNode(
-      simplifyTableChildren(allowRepartitioning),
+      simplifyChildren[TableIR](allowRepartitioning),
       rewriteTableNode(allowRepartitioning),
       simplifyTable(allowRepartitioning))
 
   private[this] def simplifyMatrix(allowRepartitioning: Boolean): MatrixIR => MatrixIR =
     visitNode(
-      simplifyMatrixChildren(allowRepartitioning),
+      simplifyChildren[MatrixIR](allowRepartitioning),
       rewriteMatrixNode(allowRepartitioning),
       simplifyMatrix(allowRepartitioning))
 
@@ -55,19 +55,13 @@ object Simplify {
       ir.copy(newChildren)
   }
 
-  private[this] def simplifyTableChildren(allowRepartitioning: Boolean)(tir: TableIR): TableIR =
-    simplifyChildren(tir, allowRepartitioning).asInstanceOf[TableIR]
-
-  private[this] def simplifyMatrixChildren(allowRepartitioning: Boolean)(mir: MatrixIR): MatrixIR =
-    simplifyChildren(mir, allowRepartitioning).asInstanceOf[MatrixIR]
-
-  private[this] def simplifyChildren(ir: BaseIR, allowRepartitioning: Boolean): BaseIR = {
+  private[this] def simplifyChildren[T <: BaseIR](allowRepartitioning: Boolean)(ir: T): T = {
     val newChildren = ir.children.map(Simplify(_, allowRepartitioning && isDeterministic(ir)))
 
     if ((ir.children, newChildren).zipped.forall(_ eq _))
       ir
     else
-      ir.copy(newChildren)
+      ir.copy(newChildren).asInstanceOf[T]
   }
 
   private[this] def rewriteValueNode: IR => Option[IR] = valueRules.lift

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -6,6 +6,81 @@ import is.hail.expr.types.{TArray, TInt32, TInt64, TStruct}
 import is.hail.table.{Ascending, SortField}
 
 object Simplify {
+
+  def apply(ir: BaseIR): BaseIR = Simplify(ir, allowRepartitioning = true)
+
+  private[ir] def apply(ast: BaseIR, allowRepartitioning: Boolean): BaseIR = {
+    ast match {
+      case ir: IR => simplifyValue(ir)
+      case tir: TableIR => simplifyTable(allowRepartitioning)(tir)
+      case mir: MatrixIR => simplifyMatrix(allowRepartitioning)(mir)
+    }
+  }
+
+  private[this] def visitNode[T <: BaseIR](
+    pre: T => T,
+    transform: T => Option[T],
+    post: T => T
+  ): T => T = { t =>
+    val t1 = pre(t)
+    transform(t1) match {
+      case Some(t2) => post(t2)
+      case None => t1
+    }
+  }
+
+  private[this] def simplifyValue: IR => IR =
+    visitNode(
+      simplifyValueChildren,
+      rewriteValueNode,
+      simplifyValue)
+
+  private[this] def simplifyTable(allowRepartitioning: Boolean): TableIR => TableIR =
+    visitNode(
+      simplifyTableChildren(allowRepartitioning),
+      rewriteTableNode(allowRepartitioning),
+      simplifyTable(allowRepartitioning))
+
+  private[this] def simplifyMatrix(allowRepartitioning: Boolean): MatrixIR => MatrixIR =
+    visitNode(
+      simplifyMatrixChildren(allowRepartitioning),
+      rewriteMatrixNode(allowRepartitioning),
+      simplifyMatrix(allowRepartitioning))
+
+  private[this] def simplifyValueChildren(ir: IR): IR = {
+    val newChildren = ir.children.map(Simplify.apply)
+    if ((ir.children, newChildren).zipped.forall(_ eq _))
+      ir
+    else
+      ir.copy(newChildren)
+  }
+
+  private[this] def simplifyTableChildren(allowRepartitioning: Boolean)(tir: TableIR): TableIR =
+    simplifyChildren(tir, allowRepartitioning).asInstanceOf[TableIR]
+
+  private[this] def simplifyMatrixChildren(allowRepartitioning: Boolean)(mir: MatrixIR): MatrixIR =
+    simplifyChildren(mir, allowRepartitioning).asInstanceOf[MatrixIR]
+
+  private[this] def simplifyChildren(ir: BaseIR, allowRepartitioning: Boolean): BaseIR = {
+    val newChildren = ir.children.map(Simplify(_, allowRepartitioning && isDeterministic(ir)))
+
+    if ((ir.children, newChildren).zipped.forall(_ eq _))
+      ir
+    else
+      ir.copy(newChildren)
+  }
+
+  private[this] def rewriteValueNode: IR => Option[IR] = valueRules.lift
+
+  private[this] def rewriteTableNode(allowRepartitioning: Boolean)(tir: TableIR): Option[TableIR] =
+    tableRules(allowRepartitioning && isDeterministic(tir)).lift(tir)
+
+  private[this] def rewriteMatrixNode(allowRepartitioning: Boolean)(mir: MatrixIR): Option[MatrixIR] =
+    matrixRules(allowRepartitioning && isDeterministic(mir)).lift(mir)
+
+  /** Returns true if 'x' propagates missingness, meaning if any child of 'x'
+    * evaluates to missing, then 'x' will evaluate to missing.
+    */
   private[this] def isStrict(x: IR): Boolean = {
     x match {
       case _: Apply |
@@ -22,6 +97,8 @@ object Simplify {
     }
   }
 
+  /** Returns true if 'x' will never evaluate to missing.
+    */
   private[this] def isDefinitelyDefined(x: IR): Boolean = {
     x match {
       case _: MakeArray |
@@ -32,6 +109,15 @@ object Simplify {
            ApplyComparisonOp(NEQWithNA(_, _), _, _) |
            _: I32 | _: I64 | _: F32 | _: F64 | True() | False() => true
       case _ => false
+    }
+  }
+
+  /** Returns true if 'ir' all value IR children of 'ir' are deterministic.
+    */
+  private[this] def isDeterministic(ir: BaseIR): Boolean = {
+    ir.children.forall{
+      case child: IR => !Exists(child, _.isInstanceOf[ApplySeeded])
+      case _ => true
     }
   }
 
@@ -47,360 +133,327 @@ object Simplify {
     }
   }
 
-  private[this] def storeRepartitionability(
-    x: BaseIR,
-    repartitionability: Memo[(Boolean, Boolean)],
-    downstreamOK: Boolean
-  ): Unit = {
-    if (repartitionability.get(x).forall(_._1 != downstreamOK)) {
-      val selfOK = repartitionability.getOrElse(x, true -> x.children.forall {
-        case child: IR => !Exists(child, _.isInstanceOf[ApplySeeded])
-        case _ => true
-      })._2
-      x.children.foreach(storeRepartitionability(_, repartitionability, downstreamOK && selfOK))
-      repartitionability.update(x, downstreamOK -> selfOK)
-    }
-  }
+  private[this] def valueRules: PartialFunction[IR, IR] = {
+    // propagate NA
+    case x: IR if isStrict(x) && Children(x).exists(_.isInstanceOf[NA]) =>
+      NA(x.typ)
 
-  def apply(ir: BaseIR): BaseIR = {
-    val repartitionabilityMap = Memo.empty[(Boolean, Boolean)]
+    case x@If(NA(_), _, _) => NA(x.typ)
 
-    val canRepartition = { node: BaseIR =>
-      val (downstream, self) = repartitionabilityMap(node)
-      downstream && self
-    }
+    case x@ArrayMap(NA(_), _, _) => NA(x.typ)
 
-    RewriteBottomUp(ir, { node =>
-      val (downstream, _) = repartitionabilityMap.getOrElse(node, true -> true)
-      storeRepartitionability(node, repartitionabilityMap, downstream)
-      rules(canRepartition)(node).map { rewritten =>
-        storeRepartitionability(rewritten, repartitionabilityMap, downstream)
-        rewritten
+    case x@ArrayFlatMap(NA(_), _, _) => NA(x.typ)
+
+    case x@ArrayFilter(NA(_), _, _) => NA(x.typ)
+
+    case x@ArrayFold(NA(_), _, _, _, _) => NA(x.typ)
+
+    case IsNA(NA(_)) => True()
+
+    case IsNA(x) if isDefinitelyDefined(x) => False()
+
+    case Let(n1, v, Ref(n2, _)) if n1 == n2 => v
+
+    case x@If(True(), cnsq, _) if x.typ == cnsq.typ => cnsq
+    case x@If(False(), _, altr) if x.typ == altr.typ => altr
+
+    case If(c, cnsq, altr) if cnsq == altr =>
+      if (cnsq.typ.required)
+        cnsq
+      else
+        If(IsNA(c), NA(cnsq.typ), cnsq)
+
+    case Cast(x, t) if x.typ == t => x
+
+    case ArrayLen(MakeArray(args, _)) => I32(args.length)
+
+    case ArrayRef(MakeArray(args, _), I32(i)) if i >= 0 && i < args.length => args(i)
+
+    case ArrayFilter(a, _, True()) => a
+
+    case Let(n, v, b) if !Mentions(b, n) => b
+
+    case Let(_, _, Begin(Seq())) => Begin(FastIndexedSeq())
+
+    case ArrayFor(_, _, Begin(Seq())) => Begin(FastIndexedSeq())
+
+    case ArrayFold(ArrayMap(a, n1, b), zero, accumName, valueName, body) => ArrayFold(a, zero, accumName, n1, Let(valueName, b, body))
+
+    case ArrayLen(ArrayRange(start, end, I32(1))) => ApplyBinaryPrimOp(Subtract(), end, start)
+
+    case ArrayLen(ArrayMap(a, _, _)) => ArrayLen(a)
+
+    case ArrayLen(ArrayFlatMap(a, _, MakeArray(args, _))) => ApplyBinaryPrimOp(Multiply(), I32(args.length), ArrayLen(a))
+
+    case ArrayFlatMap(ArrayMap(a, n1, b1), n2, b2) =>
+      ArrayFlatMap(a, n1, Let(n2, b1, b2))
+
+    case ArrayMap(ArrayMap(a, n1, b1), n2, b2) =>
+      ArrayMap(a, n1, Let(n2, b1, b2))
+
+    case GetField(MakeStruct(fields), name) =>
+      val (_, x) = fields.find { case (n, _) => n == name }.get
+      x
+
+    case GetField(InsertFields(old, fields), name) =>
+      fields.find { case (n, _) => n == name } match {
+        case Some((_, x)) => x
+        case None => GetField(old, name)
       }
-    })
+
+    case InsertFields(InsertFields(base, fields1), fields2) =>
+      val fields1Set = fields1.map(_._1).toSet
+      val fields2Map = fields2.toMap
+
+      val finalFields = fields1.map { case (name, fieldIR) => name -> fields2Map.getOrElse(name, fieldIR) } ++
+        fields2.filter { case (name, _) => !fields1Set.contains(name) }
+      InsertFields(base, finalFields)
+
+    case InsertFields(MakeStruct(fields1), fields2) =>
+      val fields1Set = fields1.map(_._1).toSet
+      val fields2Map = fields2.toMap
+
+      val finalFields = fields1.map { case (name, fieldIR) => name -> fields2Map.getOrElse(name, fieldIR) } ++
+        fields2.filter { case (name, _) => !fields1Set.contains(name) }
+      MakeStruct(finalFields)
+
+    case InsertFields(struct, Seq()) => struct
+
+    case GetField(SelectFields(old, fields), name) => GetField(old, name)
+
+    case SelectFields(MakeStruct(fields), fieldNames) =>
+      val makeStructFields = fields.toMap
+      MakeStruct(fieldNames.map(f => f -> makeStructFields(f)))
+
+    case x@SelectFields(InsertFields(struct, insertFields), selectFields) =>
+      val selectSet = selectFields.toSet
+      val insertFields2 = insertFields.filter { case (fName, _) => selectSet.contains(fName) }
+      val structSet = struct.typ.asInstanceOf[TStruct].fieldNames.toSet
+      val selectFields2 = selectFields.filter(structSet.contains)
+      val x2 = InsertFields(SelectFields(struct, selectFields2), insertFields2)
+      assert(x2.typ == x.typ)
+      x2
+
+    case GetTupleElement(MakeTuple(xs), idx) => xs(idx)
+
+    case ApplyIR("annotate", Seq(s1, MakeStruct(Seq())), _) =>
+      s1
+
+    case TableCount(TableMapGlobals(child, _)) => TableCount(child)
+
+    case TableCount(TableMapRows(child, _)) => TableCount(child)
+
+    case TableCount(TableRepartition(child, _, _)) => TableCount(child)
+
+    case TableCount(TableUnion(children)) =>
+      children.map(TableCount).reduce[IR](ApplyBinaryPrimOp(Add(), _, _))
+
+    case TableCount(TableKeyBy(child, _, _)) => TableCount(child)
+
+    case TableCount(TableOrderBy(child, _)) => TableCount(child)
+
+    case TableCount(TableLeftJoinRightDistinct(child, _, _)) => TableCount(child)
+
+    case TableCount(TableRange(n, _)) => I64(n)
+
+    case TableCount(TableParallelize(rows, _)) => Cast(ArrayLen(rows), TInt64())
+
+    case TableCount(TableRename(child, _, _)) => TableCount(child)
+
+    case TableCount(TableAggregateByKey(child, _)) => TableCount(TableDistinct(child))
+
+    case ApplyIR("annotate", Seq(s, MakeStruct(fields)), _) =>
+      InsertFields(s, fields)
+
+    case SelectFields(SelectFields(old, _), fields) =>
+      SelectFields(old, fields)
   }
 
-  def rules(canRepartition: BaseIR => Boolean): BaseIR => Option[BaseIR] =
-    matchErrorToNone {
-      // optimize IR
+  private[this] def tableRules(canRepartition: Boolean): PartialFunction[TableIR, TableIR] = {
+    case TableFilter(t, True()) => t
 
-      // propagate NA
-      case x: IR if isStrict(x) && Children(x).exists(_.isInstanceOf[NA]) =>
-        NA(x.typ)
+    case TableFilter(TableRead(path, spec, typ, _), False() | NA(_)) =>
+      TableRead(path, spec, typ, dropRows = true)
 
-      case x@If(NA(_), _, _) => NA(x.typ)
+    case TableFilter(TableFilter(t, p1), p2) =>
+      TableFilter(t,
+        ApplySpecial("&&", Array(p1, p2)))
 
-      case x@ArrayMap(NA(_), _, _) => NA(x.typ)
+    case TableFilter(TableOrderBy(child, sortFields), pred) if canRepartition =>
+      TableOrderBy(TableFilter(child, pred), sortFields)
 
-      case x@ArrayFlatMap(NA(_), _, _) => NA(x.typ)
+    case TableKeyBy(TableOrderBy(child, sortFields), keys, false) if canRepartition =>
+      TableKeyBy(child, keys, false)
 
-      case x@ArrayFilter(NA(_), _, _) => NA(x.typ)
+    case TableKeyBy(TableKeyBy(child, _, _), keys, false) if canRepartition =>
+      TableKeyBy(child, keys, false)
 
-      case x@ArrayFold(NA(_), _, _, _, _) => NA(x.typ)
+    case TableKeyBy(TableKeyBy(child, _, true), keys, true) if canRepartition =>
+      TableKeyBy(child, keys, true)
 
-      case IsNA(NA(_)) => True()
+    case TableKeyBy(child, key, _) if key == child.typ.key => child
 
-      case IsNA(x) if isDefinitelyDefined(x) => False()
+    // TODO: Write more rules like this to bubble 'TableRename' nodes towards the root.
+    case t@TableRename(TableKeyBy(child, keys, isSorted), rowMap, globalMap) =>
+      TableKeyBy(TableRename(child, rowMap, globalMap), keys.map(t.rowF), isSorted)
 
-      case Let(n1, v, Ref(n2, _)) if n1 == n2 => v
+    case TableMapRows(child, Ref("row", _)) => child
 
-      case x@If(True(), cnsq, _) if x.typ == cnsq.typ => cnsq
-      case x@If(False(), _, altr) if x.typ == altr.typ => altr
-
-      case If(c, cnsq, altr) if cnsq == altr =>
-        if (cnsq.typ.required)
-          cnsq
-        else
-          If(IsNA(c), NA(cnsq.typ), cnsq)
-
-      case Cast(x, t) if x.typ == t => x
-
-      case ArrayLen(MakeArray(args, _)) => I32(args.length)
-
-      case ArrayRef(MakeArray(args, _), I32(i)) if i >= 0 && i < args.length => args(i)
-
-      case ArrayFilter(a, _, True()) => a
-
-      case Let(n, v, b) if !Mentions(b, n) => b
-
-      case Let(_, _, Begin(Seq())) => Begin(FastIndexedSeq())
-
-      case ArrayFor(_, _, Begin(Seq())) => Begin(FastIndexedSeq())
-
-      case ArrayFold(ArrayMap(a, n1, b), zero, accumName, valueName, body) => ArrayFold(a, zero, accumName, n1, Let(valueName, b, body))
-
-      case ArrayLen(ArrayRange(start, end, I32(1))) => ApplyBinaryPrimOp(Subtract(), end, start)
-
-      case ArrayLen(ArrayMap(a, _, _)) => ArrayLen(a)
-
-      case ArrayLen(ArrayFlatMap(a, _, MakeArray(args, _))) => ApplyBinaryPrimOp(Multiply(), I32(args.length), ArrayLen(a))
-
-      case ArrayFlatMap(ArrayMap(a, n1, b1), n2, b2) =>
-        ArrayFlatMap(a, n1, Let(n2, b1, b2))
-
-      case ArrayMap(ArrayMap(a, n1, b1), n2, b2) =>
-        ArrayMap(a, n1, Let(n2, b1, b2))
-
-      case GetField(MakeStruct(fields), name) =>
-        val (_, x) = fields.find { case (n, _) => n == name }.get
-        x
-
-      case GetField(InsertFields(old, fields), name) =>
-        fields.find { case (n, _) => n == name } match {
-          case Some((_, x)) => x
-          case None => GetField(old, name)
-        }
-
-      case InsertFields(InsertFields(base, fields1), fields2) =>
-        val fields1Set = fields1.map(_._1).toSet
-        val fields2Map = fields2.toMap
-
-        val finalFields = fields1.map { case (name, fieldIR) => name -> fields2Map.getOrElse(name, fieldIR) } ++
-          fields2.filter { case (name, _) => !fields1Set.contains(name) }
-        InsertFields(base, finalFields)
-
-      case InsertFields(MakeStruct(fields1), fields2) =>
-        val fields1Set = fields1.map(_._1).toSet
-        val fields2Map = fields2.toMap
-
-        val finalFields = fields1.map { case (name, fieldIR) => name -> fields2Map.getOrElse(name, fieldIR) } ++
-          fields2.filter { case (name, _) => !fields1Set.contains(name) }
-        MakeStruct(finalFields)
-
-      case InsertFields(struct, Seq()) => struct
-
-      case GetField(SelectFields(old, fields), name) => GetField(old, name)
-
-      case SelectFields(MakeStruct(fields), fieldNames) =>
-        val makeStructFields = fields.toMap
-        MakeStruct(fieldNames.map(f => f -> makeStructFields(f)))
-
-      case x@SelectFields(InsertFields(struct, insertFields), selectFields) =>
-        val selectSet = selectFields.toSet
-        val insertFields2 = insertFields.filter { case (fName, _) => selectSet.contains(fName) }
-        val structSet = struct.typ.asInstanceOf[TStruct].fieldNames.toSet
-        val selectFields2 = selectFields.filter(structSet.contains)
-        val x2 = InsertFields(SelectFields(struct, selectFields2), insertFields2)
-        assert(x2.typ == x.typ)
-        x2
-
-      case GetTupleElement(MakeTuple(xs), idx) => xs(idx)
-
-      case ApplyIR("annotate", Seq(s1, MakeStruct(Seq())), _) =>
-        s1
-
-      // optimize TableIR
-      case TableFilter(t, True()) => t
-
-      case TableFilter(TableRead(path, spec, typ, _), False() | NA(_)) =>
-        TableRead(path, spec, typ, dropRows = true)
-
-      case TableFilter(TableFilter(t, p1), p2) =>
-        TableFilter(t,
-          ApplySpecial("&&", Array(p1, p2)))
-
-      case t@TableFilter(TableOrderBy(child, sortFields), pred) if canRepartition(t) =>
-        TableOrderBy(TableFilter(child, pred), sortFields)
-
-      case t@TableKeyBy(TableOrderBy(child, sortFields), keys, false) if canRepartition(t) =>
-        TableKeyBy(child, keys, false)
-
-      case t@TableKeyBy(TableKeyBy(child, _, _), keys, false) if canRepartition(t) =>
-        TableKeyBy(child, keys, false)
-
-      case t@TableKeyBy(TableKeyBy(child, _, true), keys, true) if canRepartition(t) =>
-        TableKeyBy(child, keys, true)
-
-      case TableKeyBy(child, key, _) if key == child.typ.key => child
-
-      // TODO: Write more rules like this to bubble 'TableRename' nodes towards the root.
-      case t@TableRename(TableKeyBy(child, keys, isSorted), rowMap, globalMap) =>
-        TableKeyBy(TableRename(child, rowMap, globalMap), keys.map(t.rowF), isSorted)
-
-      case TableMapRows(child, Ref("row", _)) => child
-
-      case TableMapRows(child, MakeStruct(fields))
+    case TableMapRows(child, MakeStruct(fields))
       if fields.length == child.typ.rowType.size
         && fields.zip(child.typ.rowType.fields).forall { case ((_, ir), field) =>
-          ir == GetField(Ref("row", field.typ), field.name)
+        ir == GetField(Ref("row", field.typ), field.name)
       } =>
-        val renamedPairs = for {
-          (oldName, (newName, _)) <- child.typ.rowType.fieldNames zip fields
-          if oldName != newName
-        } yield oldName -> newName
-        TableRename(child, Map(renamedPairs: _*), Map.empty)
+      val renamedPairs = for {
+        (oldName, (newName, _)) <- child.typ.rowType.fieldNames zip fields
+        if oldName != newName
+      } yield oldName -> newName
+      TableRename(child, Map(renamedPairs: _*), Map.empty)
 
-      case TableMapGlobals(child, Ref("global", _)) => child
+    case TableMapGlobals(child, Ref("global", _)) => child
 
-      case MatrixMapRows(child, Ref("va", _)) => child
+    case TableRename(child, m1, m2) if m1.isEmpty && m2.isEmpty => child
 
-      case t@MatrixKeyRowsBy(MatrixKeyRowsBy(child, _, _), keys, false) if canRepartition(t) =>
-        MatrixKeyRowsBy(child, keys, false)
+    // flatten unions
+    case TableUnion(children) if children.exists(_.isInstanceOf[TableUnion]) & canRepartition =>
+      TableUnion(children.flatMap {
+        case u: TableUnion => u.children
+        case c => Some(c)
+      })
 
-      case t@MatrixKeyRowsBy(MatrixKeyRowsBy(child, _, true), keys, true) if canRepartition(t) =>
-        MatrixKeyRowsBy(child, keys, true)
+    // FIXME: currently doesn't work because TableUnion makes no guarantee on order. Put back in once ordering is enforced on Tables
+    //      case MatrixRowsTable(MatrixUnionRows(children)) =>
+    //        TableUnion(children.map(MatrixRowsTable))
 
-      case MatrixMapCols(child, Ref("sa", _), None) => child
+    case MatrixColsTable(MatrixUnionRows(children)) =>
+      MatrixColsTable(children(0))
 
-      case x@MatrixMapEntries(child, Ref("g", _)) =>
-        assert(child.typ == x.typ)
-        child
+    // Ignore column or row data that is immediately dropped
+    case MatrixRowsTable(MatrixRead(typ, false, dropRows, reader)) =>
+      MatrixRowsTable(MatrixRead(typ, dropCols = true, dropRows, reader))
 
-      case MatrixMapGlobals(child, Ref("global", _)) => child
+    case MatrixColsTable(MatrixRead(typ, dropCols, false, reader)) =>
+      MatrixColsTable(MatrixRead(typ, dropCols, dropRows = true, reader))
 
-      case TableCount(TableMapGlobals(child, _)) => TableCount(child)
+    case MatrixRowsTable(MatrixFilterRows(child, newRow))
+      if !Mentions(newRow, "g") && !Mentions(newRow, "sa") && !ContainsAgg(newRow) =>
+      val mrt = MatrixRowsTable(child)
+      TableFilter(
+        mrt,
+        Subst(newRow, Env.empty[IR].bind("va" -> Ref("row", mrt.typ.rowType))))
+    case MatrixRowsTable(MatrixMapGlobals(child, newRow)) => TableMapGlobals(MatrixRowsTable(child), newRow)
+    case MatrixRowsTable(MatrixMapCols(child, _, _)) => MatrixRowsTable(child)
+    case MatrixRowsTable(MatrixMapEntries(child, _)) => MatrixRowsTable(child)
+    case MatrixRowsTable(MatrixFilterEntries(child, _)) => MatrixRowsTable(child)
+    case MatrixRowsTable(MatrixFilterCols(child, _)) => MatrixRowsTable(child)
+    case MatrixRowsTable(MatrixAggregateColsByKey(child, _, _)) => MatrixRowsTable(child)
+    case MatrixRowsTable(MatrixChooseCols(child, _)) => MatrixRowsTable(child)
+    case MatrixRowsTable(MatrixCollectColsByKey(child)) => MatrixRowsTable(child)
+    case MatrixRowsTable(MatrixKeyRowsBy(child, keys, isSorted)) => TableKeyBy(MatrixRowsTable(child), keys, isSorted)
 
-      case TableCount(TableMapRows(child, _)) => TableCount(child)
+    case MatrixColsTable(x@MatrixMapCols(child, newRow, newKey))
+      if newKey.isEmpty && !Mentions(newRow, "g") && !Mentions(newRow, "va") &&
+        !ContainsAgg(newRow) && canRepartition && isDeterministic(x) && !ContainsScan(newRow) =>
+      val mct = MatrixColsTable(child)
+      TableMapRows(
+        mct,
+        Subst(newRow, Env.empty[IR].bind("sa" -> Ref("row", mct.typ.rowType))))
+    case MatrixColsTable(MatrixFilterCols(child, pred))
+      if !Mentions(pred, "g") && !Mentions(pred, "va") =>
+      val mct = MatrixColsTable(child)
+      TableFilter(
+        mct,
+        Subst(pred, Env.empty[IR].bind("sa" -> Ref("row", mct.typ.rowType))))
+    case MatrixColsTable(MatrixMapGlobals(child, newRow)) => TableMapGlobals(MatrixColsTable(child), newRow)
+    case MatrixColsTable(MatrixMapRows(child, _)) => MatrixColsTable(child)
+    case MatrixColsTable(MatrixMapEntries(child, _)) => MatrixColsTable(child)
+    case MatrixColsTable(MatrixFilterEntries(child, _)) => MatrixColsTable(child)
+    case MatrixColsTable(MatrixFilterRows(child, _)) => MatrixColsTable(child)
+    case MatrixColsTable(MatrixAggregateRowsByKey(child, _, _)) => MatrixColsTable(child)
+    case MatrixColsTable(MatrixKeyRowsBy(child, _, _)) => MatrixColsTable(child)
 
-      case TableCount(TableRepartition(child, _, _)) => TableCount(child)
+    case TableHead(TableMapRows(child, newRow), n) =>
+      TableMapRows(TableHead(child, n), newRow)
+    case TableHead(TableRepartition(child, nPar, shuffle), n) if canRepartition =>
+      TableRepartition(TableHead(child, n), nPar, shuffle)
+    case TableHead(tr@TableRange(nRows, nPar), n) if canRepartition =>
+      if (n < nRows)
+        TableRange(n.toInt, (nPar.toFloat * n / nRows).toInt.max(1))
+      else
+        tr
+    case TableHead(TableMapGlobals(child, newRow), n) =>
+      TableMapGlobals(TableHead(child, n), newRow)
+    case TableHead(TableOrderBy(child, sortFields), n)
+      if sortFields.forall(_.sortOrder == Ascending) && n < 256 && canRepartition =>
+      // n < 256 is arbitrary for memory concerns
+      val uid = genUID()
+      val row = Ref("row", child.typ.rowType)
+      val keyStruct = MakeStruct(sortFields.map(f => f.field -> GetField(row, f.field)))
+      val aggSig = AggSignature(TakeBy(), FastSeq(TInt32()), None, FastSeq(row.typ, keyStruct.typ))
+      val te =
+        TableExplode(
+          TableKeyByAndAggregate(child,
+            MakeStruct(Seq(
+              "row" -> ApplyAggOp(
+                Array(row, keyStruct),
+                FastIndexedSeq(I32(n.toInt)),
+                None,
+                aggSig))),
+            MakeStruct(Seq()), // aggregate to one row
+            Some(1), 10),
+          "row")
+      TableMapRows(te, GetField(Ref("row", te.typ.rowType), "row"))
 
-      case TableCount(TableUnion(children)) =>
-        children.map(TableCount).reduce[IR](ApplyBinaryPrimOp(Add(), _, _))
+    case TableKeyByAndAggregate(child, MakeStruct(Seq()), k@MakeStruct(keyFields), _, _) if canRepartition =>
+      TableDistinct(TableMapRows(child, k))
+    case TableKeyByAndAggregate(child, expr, newKey, _, _)
+      if newKey == MakeStruct(child.typ.key.map(k => k -> GetField(Ref("row", child.typ.rowType), k)))
+        && child.typ.key.nonEmpty && canRepartition =>
+      TableAggregateByKey(child, expr)
+    case TableAggregateByKey(TableKeyBy(child, keys, _), expr) if canRepartition =>
+      TableKeyByAndAggregate(child, expr, MakeStruct(keys.map(k => k -> GetField(Ref("row", child.typ.rowType), k))))
+  }
 
-      case TableCount(TableKeyBy(child, _, _)) => TableCount(child)
+  private[this] def matrixRules(canRepartition: Boolean): PartialFunction[MatrixIR, MatrixIR] = {
+    case MatrixMapRows(child, Ref("va", _)) => child
 
-      case TableCount(TableOrderBy(child, _)) => TableCount(child)
+    case MatrixKeyRowsBy(MatrixKeyRowsBy(child, _, _), keys, false) if canRepartition =>
+      MatrixKeyRowsBy(child, keys, false)
 
-      case TableCount(TableLeftJoinRightDistinct(child, _, _)) => TableCount(child)
+    case MatrixKeyRowsBy(MatrixKeyRowsBy(child, _, true), keys, true) if canRepartition =>
+      MatrixKeyRowsBy(child, keys, true)
 
-      case TableCount(TableRange(n, _)) => I64(n)
+    case MatrixMapCols(child, Ref("sa", _), None) => child
 
-      case TableCount(TableParallelize(rows, _)) => Cast(ArrayLen(rows), TInt64())
+    case x@MatrixMapEntries(child, Ref("g", _)) =>
+      assert(child.typ == x.typ)
+      child
 
-      case TableCount(TableRename(child, _, _)) => TableCount(child)
+    case MatrixMapGlobals(child, Ref("global", _)) => child
 
-      case TableRename(child, m1, m2) if m1.isEmpty && m2.isEmpty => child
+    // flatten unions
+    case MatrixUnionRows(children) if children.exists(_.isInstanceOf[MatrixUnionRows]) & canRepartition =>
+      MatrixUnionRows(children.flatMap {
+        case u: MatrixUnionRows => u.children
+        case c => Some(c)
+      })
 
-      case ApplyIR("annotate", Seq(s, MakeStruct(fields)), _) =>
-        InsertFields(s, fields)
+    // Equivalent rewrites for the new Filter{Cols,Rows}IR
+    case MatrixFilterRows(MatrixRead(typ, dropCols, _, reader), False() | NA(_)) =>
+      MatrixRead(typ, dropCols, dropRows = true, reader)
 
-      case SelectFields(SelectFields(old, _), fields) =>
-        SelectFields(old, fields)
+    case MatrixFilterCols(MatrixRead(typ, _, dropRows, reader), False() | NA(_)) =>
+      MatrixRead(typ, dropCols = true, dropRows, reader)
 
-      // flatten unions
-      case TableUnion(children) if children.exists(_.isInstanceOf[TableUnion]) & children.forall(canRepartition(_)) =>
-        TableUnion(children.flatMap {
-          case u: TableUnion => u.children
-          case c => Some(c)
-        })
+    // Keep all rows/cols = do nothing
+    case MatrixFilterRows(m, True()) => m
 
-      case MatrixUnionRows(children) if children.exists(_.isInstanceOf[MatrixUnionRows]) & children.forall(canRepartition(_)) =>
-        MatrixUnionRows(children.flatMap {
-          case u: MatrixUnionRows => u.children
-          case c => Some(c)
-        })
+    case MatrixFilterCols(m, True()) => m
 
-      // FIXME: currently doesn't work because TableUnion makes no guarantee on order. Put back in once ordering is enforced on Tables
-      //      case MatrixRowsTable(MatrixUnionRows(children)) =>
-      //        TableUnion(children.map(MatrixRowsTable))
+    case MatrixFilterRows(MatrixFilterRows(child, pred1), pred2) => MatrixFilterRows(child, ApplySpecial("&&", FastSeq(pred1, pred2)))
 
-      case MatrixColsTable(MatrixUnionRows(children)) =>
-        MatrixColsTable(children(0))
-
-      // optimize MatrixIR
-
-      // Equivalent rewrites for the new Filter{Cols,Rows}IR
-      case MatrixFilterRows(MatrixRead(typ, dropCols, _, reader), False() | NA(_)) =>
-        MatrixRead(typ, dropCols, dropRows = true, reader)
-
-      case MatrixFilterCols(MatrixRead(typ, _, dropRows, reader), False() | NA(_)) =>
-        MatrixRead(typ, dropCols = true, dropRows, reader)
-
-      // Ignore column or row data that is immediately dropped
-      case MatrixRowsTable(MatrixRead(typ, false, dropRows, reader)) =>
-        MatrixRowsTable(MatrixRead(typ, dropCols = true, dropRows, reader))
-
-      case MatrixColsTable(MatrixRead(typ, dropCols, false, reader)) =>
-        MatrixColsTable(MatrixRead(typ, dropCols, dropRows = true, reader))
-
-      // Keep all rows/cols = do nothing
-      case MatrixFilterRows(m, True()) => m
-
-      case MatrixFilterCols(m, True()) => m
-
-      case MatrixFilterRows(MatrixFilterRows(child, pred1), pred2) => MatrixFilterRows(child, ApplySpecial("&&", FastSeq(pred1, pred2)))
-
-      case MatrixFilterCols(MatrixFilterCols(child, pred1), pred2) => MatrixFilterCols(child, ApplySpecial("&&", FastSeq(pred1, pred2)))
-
-      case MatrixFilterEntries(MatrixFilterEntries(child, pred1), pred2) => MatrixFilterEntries(child, ApplySpecial("&&", FastSeq(pred1, pred2)))
-
-      case MatrixRowsTable(MatrixFilterRows(child, newRow))
-        if !Mentions(newRow, "g") && !Mentions(newRow, "sa") && !ContainsAgg(newRow) =>
-        val mrt = MatrixRowsTable(child)
-        TableFilter(
-          mrt,
-          Subst(newRow, Env.empty[IR].bind("va" -> Ref("row", mrt.typ.rowType))))
-      case MatrixRowsTable(MatrixMapGlobals(child, newRow)) => TableMapGlobals(MatrixRowsTable(child), newRow)
-      case MatrixRowsTable(MatrixMapCols(child, _, _)) => MatrixRowsTable(child)
-      case MatrixRowsTable(MatrixMapEntries(child, _)) => MatrixRowsTable(child)
-      case MatrixRowsTable(MatrixFilterEntries(child, _)) => MatrixRowsTable(child)
-      case MatrixRowsTable(MatrixFilterCols(child, _)) => MatrixRowsTable(child)
-      case MatrixRowsTable(MatrixAggregateColsByKey(child, _, _)) => MatrixRowsTable(child)
-      case MatrixRowsTable(MatrixChooseCols(child, _)) => MatrixRowsTable(child)
-      case MatrixRowsTable(MatrixCollectColsByKey(child)) => MatrixRowsTable(child)
-      case MatrixRowsTable(MatrixKeyRowsBy(child, keys, isSorted)) => TableKeyBy(MatrixRowsTable(child), keys, isSorted)
-
-      case MatrixColsTable(x@MatrixMapCols(child, newRow, newKey))
-        if newKey.isEmpty && !Mentions(newRow, "g") && !Mentions(newRow, "va") &&
-          !ContainsAgg(newRow) && canRepartition(x) && !ContainsScan(newRow) =>
-        val mct = MatrixColsTable(child)
-        TableMapRows(
-          mct,
-          Subst(newRow, Env.empty[IR].bind("sa" -> Ref("row", mct.typ.rowType))))
-      case MatrixColsTable(MatrixFilterCols(child, pred))
-        if !Mentions(pred, "g") && !Mentions(pred, "va") =>
-        val mct = MatrixColsTable(child)
-        TableFilter(
-          mct,
-          Subst(pred, Env.empty[IR].bind("sa" -> Ref("row", mct.typ.rowType))))
-      case MatrixColsTable(MatrixMapGlobals(child, newRow)) => TableMapGlobals(MatrixColsTable(child), newRow)
-      case MatrixColsTable(MatrixMapRows(child, _)) => MatrixColsTable(child)
-      case MatrixColsTable(MatrixMapEntries(child, _)) => MatrixColsTable(child)
-      case MatrixColsTable(MatrixFilterEntries(child, _)) => MatrixColsTable(child)
-      case MatrixColsTable(MatrixFilterRows(child, _)) => MatrixColsTable(child)
-      case MatrixColsTable(MatrixAggregateRowsByKey(child, _, _)) => MatrixColsTable(child)
-      case MatrixColsTable(MatrixKeyRowsBy(child, _, _)) => MatrixColsTable(child)
-
-      case TableHead(TableMapRows(child, newRow), n) =>
-        TableMapRows(TableHead(child, n), newRow)
-      case t@TableHead(TableRepartition(child, nPar, shuffle), n) if canRepartition(t) =>
-        TableRepartition(TableHead(child, n), nPar, shuffle)
-      case t@TableHead(tr@TableRange(nRows, nPar), n) if canRepartition(t) =>
-        if (n < nRows)
-          TableRange(n.toInt, (nPar.toFloat * n / nRows).toInt.max(1))
-        else
-          tr
-      case TableHead(TableMapGlobals(child, newRow), n) =>
-        TableMapGlobals(TableHead(child, n), newRow)
-      case t@TableHead(TableOrderBy(child, sortFields), n)
-        if sortFields.forall(_.sortOrder == Ascending) && n < 256 && canRepartition(t) =>
-        // n < 256 is arbitrary for memory concerns
-        val uid = genUID()
-        val row = Ref("row", child.typ.rowType)
-        val keyStruct = MakeStruct(sortFields.map(f => f.field -> GetField(row, f.field)))
-        val aggSig = AggSignature(TakeBy(), FastSeq(TInt32()), None, FastSeq(row.typ, keyStruct.typ))
-        val te =
-          TableExplode(
-            TableKeyByAndAggregate(child,
-              MakeStruct(Seq(
-                "row" -> ApplyAggOp(
-                  Array(row, keyStruct),
-                  FastIndexedSeq(I32(n.toInt)),
-                  None,
-                  aggSig))),
-              MakeStruct(Seq()), // aggregate to one row
-              Some(1), 10),
-            "row")
-        TableMapRows(te, GetField(Ref("row", te.typ.rowType), "row"))
-
-      case TableCount(TableAggregateByKey(child, _)) => TableCount(TableDistinct(child))
-      case t@TableKeyByAndAggregate(child, MakeStruct(Seq()), k@MakeStruct(keyFields), _, _) if canRepartition(t) =>
-        TableDistinct(TableMapRows(child, k))
-      case t@TableKeyByAndAggregate(child, expr, newKey, _, _)
-        if newKey == MakeStruct(child.typ.key.map(k => k -> GetField(Ref("row", child.typ.rowType), k)))
-          && child.typ.key.nonEmpty && canRepartition(t) =>
-        TableAggregateByKey(child, expr)
-      case t@TableAggregateByKey(TableKeyBy(child, keys, _), expr) if canRepartition(t) =>
-        TableKeyByAndAggregate(child, expr, MakeStruct(keys.map(k => k -> GetField(Ref("row", child.typ.rowType), k))))
-    }
+    case MatrixFilterCols(MatrixFilterCols(child, pred1), pred2) => MatrixFilterCols(child, ApplySpecial("&&", FastSeq(pred1, pred2)))
+      
+    case MatrixFilterEntries(MatrixFilterEntries(child, pred1), pred2) => MatrixFilterEntries(child, ApplySpecial("&&", FastSeq(pred1, pred2)))
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -20,7 +20,7 @@ object Simplify {
   private[this] def visitNode[T <: BaseIR](
     pre: T => T,
     transform: T => Option[T],
-    post: T => T
+    post: => (T => T)
   ): T => T = { t =>
     val t1 = pre(t)
     transform(t1) match {

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -439,7 +439,7 @@ object Simplify {
     case MatrixFilterRows(MatrixFilterRows(child, pred1), pred2) => MatrixFilterRows(child, ApplySpecial("&&", FastSeq(pred1, pred2)))
 
     case MatrixFilterCols(MatrixFilterCols(child, pred1), pred2) => MatrixFilterCols(child, ApplySpecial("&&", FastSeq(pred1, pred2)))
-      
+
     case MatrixFilterEntries(MatrixFilterEntries(child, pred1), pred2) => MatrixFilterEntries(child, ApplySpecial("&&", FastSeq(pred1, pred2)))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -35,6 +35,8 @@ abstract sealed class TableIR extends BaseIR {
   def partitionCounts: Option[IndexedSeq[Long]] = None
 
   def execute(hc: HailContext): TableValue
+
+  override def copy(newChildren: IndexedSeq[BaseIR]): TableIR
 }
 
 case class TableLiteral(value: TableValue) extends TableIR {
@@ -306,7 +308,7 @@ case class TableHead(child: TableIR, n: Long) extends TableIR {
 
   def children: IndexedSeq[BaseIR] = FastIndexedSeq(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BaseIR = {
+  def copy(newChildren: IndexedSeq[BaseIR]): TableHead = {
     val IndexedSeq(newChild: TableIR) = newChildren
     TableHead(newChild, n)
   }
@@ -325,7 +327,7 @@ case class TableRepartition(child: TableIR, n: Int, shuffle: Boolean) extends Ta
 
   def children: IndexedSeq[BaseIR] = FastIndexedSeq(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BaseIR = {
+  def copy(newChildren: IndexedSeq[BaseIR]): TableRepartition = {
     val IndexedSeq(newChild: TableIR) = newChildren
     TableRepartition(newChild, n, shuffle)
   }
@@ -478,7 +480,7 @@ case class TableLeftJoinRightDistinct(left: TableIR, right: TableIR, root: Strin
 
   override def partitionCounts: Option[IndexedSeq[Long]] = left.partitionCounts
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BaseIR = {
+  def copy(newChildren: IndexedSeq[BaseIR]): TableLeftJoinRightDistinct = {
     val IndexedSeq(newLeft: TableIR, newRight: TableIR) = newChildren
     TableLeftJoinRightDistinct(newLeft, newRight, root)
   }
@@ -1119,7 +1121,7 @@ case class TableOrderBy(child: TableIR, sortFields: IndexedSeq[SortField]) exten
 
   val children: IndexedSeq[BaseIR] = FastIndexedSeq(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BaseIR = {
+  def copy(newChildren: IndexedSeq[BaseIR]): TableOrderBy = {
     val IndexedSeq(newChild) = newChildren
     TableOrderBy(newChild.asInstanceOf[TableIR], sortFields)
   }
@@ -1155,7 +1157,7 @@ case class LocalizeEntries(child: MatrixIR, entriesFieldName: String) extends Ta
   def typ: TableType = TableType(newRowType, child.typ.rowKey, child.typ.globalType)
 
   def children: IndexedSeq[BaseIR] = FastIndexedSeq(child)
-  def copy(newChildren: IndexedSeq[BaseIR]): BaseIR = {
+  def copy(newChildren: IndexedSeq[BaseIR]): LocalizeEntries = {
     val IndexedSeq(newChild) = newChildren
     LocalizeEntries(newChild.asInstanceOf[MatrixIR], entriesFieldName)
   }
@@ -1184,7 +1186,7 @@ case class TableRename(child: TableIR, rowMap: Map[String, String], globalMap: M
 
   def children: IndexedSeq[BaseIR] = FastIndexedSeq(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): BaseIR = {
+  def copy(newChildren: IndexedSeq[BaseIR]): TableRename = {
     val IndexedSeq(newChild: TableIR) = newChildren
     TableRename(newChild, rowMap, globalMap)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -79,4 +79,12 @@ package object ir {
   implicit def floatToIR(f: Float): IR = F32(f)
   implicit def doubleToIR(d: Double): IR = F64(d)
   implicit def booleanToIR(b: Boolean): IR = if (b) True() else False()
+
+  def applyOrIdentity[T <: BaseIR](f: T => Option[T]): T => T = { x =>
+    f(x) match {
+      case Some(y) => y
+      case None => x
+    }
+  }
 }
+

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -79,12 +79,5 @@ package object ir {
   implicit def floatToIR(f: Float): IR = F32(f)
   implicit def doubleToIR(d: Double): IR = F64(d)
   implicit def booleanToIR(b: Boolean): IR = if (b) True() else False()
-
-  def applyOrIdentity[T <: BaseIR](f: T => Option[T]): T => T = { x =>
-    f(x) match {
-      case Some(y) => y
-      case None => x
-    }
-  }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -80,4 +80,3 @@ package object ir {
   implicit def doubleToIR(d: Double): IR = F64(d)
   implicit def booleanToIR(b: Boolean): IR = if (b) True() else False()
 }
-

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -70,7 +70,7 @@ class PruneSuite extends SparkSuite {
       fatal(s"IR did not rebuild the same:\n  Base:    $ir\n  Rebuilt: $rebuilt")
   }
 
-  val tab = TableLiteral(new Table(hc,
+  lazy val tab = TableLiteral(new Table(hc,
     TableParallelize(
       Literal(
         TArray(TStruct("1" -> TString(),
@@ -82,7 +82,7 @@ class PruneSuite extends SparkSuite {
       None)
   ).annotateGlobal(5, TInt32(), "g1").annotateGlobal(10, TInt32(), "g2").value)
 
-  val tr = TableRead("", TableSpec(0, "", "", tab.typ, Map.empty), tab.typ, false)
+  lazy val tr = TableRead("", TableSpec(0, "", "", tab.typ, Map.empty), tab.typ, false)
 
   val mType = MatrixType.fromParts(
     TStruct("g1" -> TInt32(), "g2" -> TFloat64()),

--- a/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
@@ -118,7 +118,18 @@ class RandomFunctionsSuite extends SparkSuite {
   }
 
   @Test def testRepartitioningSimplifyRules() {
-    val tir = TableHead(mapped2(10, 3), 5L)
+    val tir =
+    TableMapRows(
+      TableHead(
+        TableMapRows(
+          TableRange(10, 3),
+          Ref("row", TableRange(1, 1).typ.rowType)),
+        5L),
+      InsertFields(
+        Ref("row", TableRange(1, 1).typ.rowType),
+        FastSeq(
+          "pi" -> partitionIdx,
+          "counter" -> counter)))
 
     val expected = tir.execute(hc).rvd.toRows.collect()
     val actual = new Table(hc, tir).rdd.collect()


### PR DESCRIPTION
Adding a new compiler pass (lowering MatrixIR to TableIR) exposed a problem in Simplify. The logic for preventing some simplifications from triggering if they would introduce non-determinism was broken, and fixing it required a pretty complete overhaul. Fortunately, I think it's now a lot simpler.

Besides the rewrite of the high level Simplify architecture, I also:
* Changed `testRepartitioningSimplifyRules` to something that failed in the old version.
* Changed the `copy` signature on the IR hierarchy to be more precise (to avoid unnecessary coercions).
* Grouped the Simplify rules into IR, MatrixIR, and TableIR. After the reorganization, a couple of rule redundancies became evident.
* A couple of vals in PruneSuite required running the compiler. When I had a bug in Simplify, this was causing the test runner to fail before any tests were run, on class initialization of PruneSuite, which gives very little help in diagnosing the issue. I made them lazy vals to prevent this in the future.