### PR TITLE
Update tutorial links

### DIFF
--- a/hail/python/hail/docs/tutorials/01-genome-wide-association-study.ipynb
+++ b/hail/python/hail/docs/tutorials/01-genome-wide-association-study.ipynb
@@ -66,7 +66,7 @@
    "source": [
     "### Loading data from disk\n",
     "\n",
-    "Hail has its own internal data representation, called a MatrixTable. This is both an on-disk file format and a [Python object](https://hail.is/docs/devel/hail.MatrixTable.html#hail.MatrixTable). Here, we read a MatrixTable from disk.\n",
+    "Hail has its own internal data representation, called a MatrixTable. This is both an on-disk file format and a [Python object](https://hail.is/docs/0.2/hail.MatrixTable.html#hail.MatrixTable). Here, we read a MatrixTable from disk.\n",
     "\n",
     "This dataset was created by downsampling a public 1000 genomes VCF to about 50 MB."
    ]
@@ -93,9 +93,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The [rows](https://hail.is/docs/devel/hail.MatrixTable.html#hail.MatrixTable.rows) method can be used to get a table with all the row fields in our MatrixTable. \n",
+    "The [rows](https://hail.is/docs/0.2/hail.MatrixTable.html#hail.MatrixTable.rows) method can be used to get a table with all the row fields in our MatrixTable. \n",
     "\n",
-    "We can use `rows` along with [select](https://hail.is/docs/devel/hail.Table.html#hail.Table.select) to pull out 5 variants. The `select` method takes either a string refering to a field name in the table, or a Hail [Expression](https://hail.is/docs/devel/expr/expression.html#hail.expr.expression.Expression). Here, we leave the arguments blank to keep only the row key fields, `locus` and `alleles`.\n",
+    "We can use `rows` along with [select](https://hail.is/docs/0.2/hail.Table.html#hail.Table.select) to pull out 5 variants. The `select` method takes either a string refering to a field name in the table, or a Hail [Expression](https://hail.is/docs/0.2/expr/expression.html#hail.expr.expression.Expression). Here, we leave the arguments blank to keep only the row key fields, `locus` and `alleles`.\n",
     "\n",
     "Use the `show` method to display the variants."
    ]
@@ -129,7 +129,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To look at the first few genotype calls, we can use [entries](https://hail.is/docs/devel/hail.MatrixTable.html#hail.MatrixTable.entries) along with `select` and `take`. The `take` method collects the first n rows into a list. Alternatively, we can use the `show` method, which prints the first n rows to the console in a table format. \n",
+    "To look at the first few genotype calls, we can use [entries](https://hail.is/docs/0.2/hail.MatrixTable.html#hail.MatrixTable.entries) along with `select` and `take`. The `take` method collects the first n rows into a list. Alternatively, we can use the `show` method, which prints the first n rows to the console in a table format. \n",
     "\n",
     "Try changing `take` to `show` in the cell below."
    ]
@@ -165,7 +165,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This file can be imported into Hail with [import_table](https://hail.is/docs/devel/methods/impex.html#hail.methods.import_table). This method produces a [Table](https://hail.is/docs/devel/hail.Table.html#hail.Table) object. Think of this as a Pandas or R dataframe that isn't limited by the memory on your machine -- behind the scenes, it's distributed with Spark."
+    "This file can be imported into Hail with [import_table](https://hail.is/docs/0.2/methods/impex.html#hail.methods.import_table). This method produces a [Table](https://hail.is/docs/0.2/hail.Table.html#hail.Table) object. Think of this as a Pandas or R dataframe that isn't limited by the memory on your machine -- behind the scenes, it's distributed with Spark."
    ]
   },
   {
@@ -231,7 +231,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We use the [annotate_cols](https://hail.is/docs/devel/hail.MatrixTable.html#hail.MatrixTable.annotate_cols) method to join the table with the MatrixTable containing our dataset."
+    "We use the [annotate_cols](https://hail.is/docs/0.2/hail.MatrixTable.html#hail.MatrixTable.annotate_cols) method to join the table with the MatrixTable containing our dataset."
    ]
   },
   {
@@ -269,7 +269,7 @@
     "\n",
     "Hail has a number of useful query functions that can be used for gathering statistics on our dataset. These query functions take Hail Expressions as arguments.\n",
     "\n",
-    "We will start by looking at some statistics of the information in our table. The [aggregate](https://hail.is/docs/devel/hail.Table.html#hail.Table.aggregate) method can be used to aggregate over rows of the table."
+    "We will start by looking at some statistics of the information in our table. The [aggregate](https://hail.is/docs/0.2/hail.Table.html#hail.Table.aggregate) method can be used to aggregate over rows of the table."
    ]
   },
   {
@@ -333,7 +333,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since there are fewer samples in our dataset than in the full thousand genomes cohort, we need to look at annotations on the dataset. We can use [aggregate_cols](https://hail.is/docs/devel/hail.MatrixTable.html#hail.MatrixTable.aggregate_cols) to get the metrics for only the samples in our dataset."
+    "Since there are fewer samples in our dataset than in the full thousand genomes cohort, we need to look at annotations on the dataset. We can use [aggregate_cols](https://hail.is/docs/0.2/hail.MatrixTable.html#hail.MatrixTable.aggregate_cols) to get the metrics for only the samples in our dataset."
    ]
   },
   {
@@ -439,7 +439,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "QC is entirely based on the ability to understand the properties of a dataset. Hail attempts to make this easier by providing the [sample_qc](https://hail.is/docs/devel/methods/genetics.html#hail.methods.sample_qc) method, which produces a set of useful metrics and stores them in a column field."
+    "QC is entirely based on the ability to understand the properties of a dataset. Hail attempts to make this easier by providing the [sample_qc](https://hail.is/docs/0.2/methods/genetics.html#hail.methods.sample_qc) method, which produces a set of useful metrics and stores them in a column field."
    ]
   },
   {
@@ -606,7 +606,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Variant QC is a bit more of the same: we can use the [variant_qc](https://hail.is/docs/devel/methods/genetics.html?highlight=variant%20qc#hail.methods.variant_qc) method to produce a variety of useful statistics, plot them, and filter."
+    "Variant QC is a bit more of the same: we can use the [variant_qc](https://hail.is/docs/0.2/methods/genetics.html?highlight=variant%20qc#hail.methods.variant_qc) method to produce a variety of useful statistics, plot them, and filter."
    ]
   },
   {
@@ -622,7 +622,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The [cache](https://hail.is/docs/devel/hail.MatrixTable.html#hail.MatrixTable.cache) is used to optimize some of the downstream operations."
+    "The [cache](https://hail.is/docs/0.2/hail.MatrixTable.html#hail.MatrixTable.cache) is used to optimize some of the downstream operations."
    ]
   },
   {
@@ -671,7 +671,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "These statistics actually look pretty good: we don't need to filter this dataset. Most datasets require thoughtful quality control, though. The [filter_rows](https://hail.is/docs/devel/hail.MatrixTable.html#hail.MatrixTable.filter_rows) method can help!"
+    "These statistics actually look pretty good: we don't need to filter this dataset. Most datasets require thoughtful quality control, though. The [filter_rows](https://hail.is/docs/0.2/hail.MatrixTable.html#hail.MatrixTable.filter_rows) method can help!"
    ]
   },
   {
@@ -752,9 +752,9 @@
     "\n",
     "We didn't tell you, but sample ancestry was actually used to simulate this phenotype. This leads to a [stratified](https://en.wikipedia.org/wiki/Population_stratification) distribution of the phenotype. The solution is to include ancestry as a covariate in our regression. \n",
     "\n",
-    "The [linear_regression](https://hail.is/docs/devel/methods/stats.html#hail.methods.linear_regression) method can also take column fields to use as covariates. We already annotated our samples with reported ancestry, but it is good to be skeptical of these labels due to human error. Genomes don't have that problem! Instead of using reported ancestry, we will use genetic ancestry by including computed principal components in our model.\n",
+    "The [linear_regression](https://hail.is/docs/0.2/methods/stats.html#hail.methods.linear_regression) method can also take column fields to use as covariates. We already annotated our samples with reported ancestry, but it is good to be skeptical of these labels due to human error. Genomes don't have that problem! Instead of using reported ancestry, we will use genetic ancestry by including computed principal components in our model.\n",
     "\n",
-    "The [pca](https://hail.is/docs/devel/methods/stats.html#hail.methods.pca) method produces eigenvalues as a list and sample PCs as a Table, and can also produce variant loadings when asked. The [hwe_normalized_pca](https://hail.is/docs/devel/methods/genetics.html#hail.methods.hwe_normalized_pca) method does the same, using HWE-normalized genotypes for the PCA."
+    "The [pca](https://hail.is/docs/0.2/methods/stats.html#hail.methods.pca) method produces eigenvalues as a list and sample PCs as a Table, and can also produce variant loadings when asked. The [hwe_normalized_pca](https://hail.is/docs/0.2/methods/genetics.html#hail.methods.hwe_normalized_pca) method does the same, using HWE-normalized genotypes for the PCA."
    ]
   },
   {
@@ -956,7 +956,7 @@
    "source": [
     "### Epilogue\n",
     "\n",
-    "Congrats! You've reached the end of the first tutorial. To learn more about Hail's API and functionality, take a look at the other tutorials. You can check out the [Python API](https://hail.is/docs/devel/api.html#python-api) for documentation on additional Hail functions. If you use Hail for your own science, we'd love to hear from you on [Zulip chat](https://hail.zulipchat.com) or the [discussion forum](http://discuss.hail.is).\n",
+    "Congrats! You've reached the end of the first tutorial. To learn more about Hail's API and functionality, take a look at the other tutorials. You can check out the [Python API](https://hail.is/docs/0.2/api.html#python-api) for documentation on additional Hail functions. If you use Hail for your own science, we'd love to hear from you on [Zulip chat](https://hail.zulipchat.com) or the [discussion forum](http://discuss.hail.is).\n",
     "\n",
     "For reference, here's the full workflow to all tutorial endpoints combined into one cell. It may take a minute! It's doing a lot of work."
    ]

--- a/hail/python/hail/docs/tutorials/03-expressions.ipynb
+++ b/hail/python/hail/docs/tutorials/03-expressions.ipynb
@@ -12,9 +12,9 @@
     "\n",
     "This tutorial covers data representation with Hail's expression classes. We will go over Hail's data types and the expressions that represent them, as well as a few features of expressions, such as lazy evaluation and missingness. We will also cover how expressions can refer to fields in a table or matrix table.\n",
     "\n",
-    "As you are working through the tutorial, you can also check out the [expression API](https://hail.is/docs/devel/expressions.html#expressions) for documentation on specific expressions and their methods, or the [expression](https://hail.is/docs/devel/hailpedia/expressions.html) page in the Hailpedia for more information on expressions.\n",
+    "As you are working through the tutorial, you can also check out the [expression API](https://hail.is/docs/0.2/expressions.html#expressions) for documentation on specific expressions and their methods, or the [expression](https://hail.is/docs/0.2/hailpedia/expressions.html) page in the Hailpedia for more information on expressions.\n",
     "\n",
-    "Start by importing the Hail module, which we typically abbreviate as `hl`, and initializing Hail and Spark with the [init](https://hail.is/docs/devel/api.html#hail.init) method:"
+    "Start by importing the Hail module, which we typically abbreviate as `hl`, and initializing Hail and Spark with the [init](https://hail.is/docs/0.2/api.html#hail.init) method:"
    ]
   },
   {
@@ -53,7 +53,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Hail has its own data types for representing data. Here is a Hail string, which we construct with the [str](https://hail.is/docs/devel/functions/core.html?highlight=str#hail.expr.functions.str) method. We can access the string's Hail type with the `dtype` field."
+    "Hail has its own data types for representing data. Here is a Hail string, which we construct with the [str](https://hail.is/docs/0.2/functions/core.html?highlight=str#hail.expr.functions.str) method. We can access the string's Hail type with the `dtype` field."
    ]
   },
   {
@@ -71,9 +71,9 @@
    "source": [
     "Hail has primitive and container types, as well as a few types specific to the field of genetics.\n",
     "\n",
-    "* primitive types: [int32](https://hail.is/docs/devel/types.html#hail.expr.types.tint32), [int64](https://hail.is/docs/devel/types.html#hail.expr.types.tint64), [float32](https://hail.is/docs/devel/types.html#hail.expr.types.tfloat32), [float64](https://hail.is/docs/devel/types.html#hail.expr.types.tfloat64), [bool](https://hail.is/docs/devel/types.html#hail.expr.types.tbool), [str](https://hail.is/docs/devel/types.html#hail.expr.types.tstr)\n",
-    "* container types: [arrays](https://hail.is/docs/devel/types.html#hail.expr.types.tarray), [sets](https://hail.is/docs/devel/types.html#hail.expr.types.tset), [dicts](https://hail.is/docs/devel/types.html#hail.expr.types.tdict), [tuples](https://hail.is/docs/devel/types.html#hail.expr.types.ttuple), [structs](https://hail.is/docs/devel/types.html#hail.expr.types.tstruct), [intervals](https://hail.is/docs/devel/types.html#hail.expr.types.tinterval)\n",
-    "* genetics types: [locus](https://hail.is/docs/devel/types.html#hail.expr.types.tlocus), [call](https://hail.is/docs/devel/types.html#hail.expr.types.tcall)\n",
+    "* primitive types: [int32](https://hail.is/docs/0.2/types.html#hail.expr.types.tint32), [int64](https://hail.is/docs/0.2/types.html#hail.expr.types.tint64), [float32](https://hail.is/docs/0.2/types.html#hail.expr.types.tfloat32), [float64](https://hail.is/docs/0.2/types.html#hail.expr.types.tfloat64), [bool](https://hail.is/docs/0.2/types.html#hail.expr.types.tbool), [str](https://hail.is/docs/0.2/types.html#hail.expr.types.tstr)\n",
+    "* container types: [arrays](https://hail.is/docs/0.2/types.html#hail.expr.types.tarray), [sets](https://hail.is/docs/0.2/types.html#hail.expr.types.tset), [dicts](https://hail.is/docs/0.2/types.html#hail.expr.types.tdict), [tuples](https://hail.is/docs/0.2/types.html#hail.expr.types.ttuple), [structs](https://hail.is/docs/0.2/types.html#hail.expr.types.tstruct), [intervals](https://hail.is/docs/0.2/types.html#hail.expr.types.tinterval)\n",
+    "* genetics types: [locus](https://hail.is/docs/0.2/types.html#hail.expr.types.tlocus), [call](https://hail.is/docs/0.2/types.html#hail.expr.types.tcall)\n",
     "\n",
     "Each of these types has its own constructor method, which returns an expression:"
    ]
@@ -97,9 +97,9 @@
    "source": [
     "### What is an Expression?\n",
     "\n",
-    "Data types in Hail are represented by [expression](https://hail.is/docs/devel/expressions.html#expressions) classes. Each data type has its own expression class. For example, an integer of type `tint32` is represented by an `Int32Expression`. \n",
+    "Data types in Hail are represented by [expression](https://hail.is/docs/0.2/expressions.html#expressions) classes. Each data type has its own expression class. For example, an integer of type `tint32` is represented by an `Int32Expression`. \n",
     "\n",
-    "We can construct an integer expression in Hail with the [int32](https://hail.is/docs/devel/functions/constructors.html?highlight=int32#hail.expr.functions.int32) function."
+    "We can construct an integer expression in Hail with the [int32](https://hail.is/docs/0.2/functions/constructors.html?highlight=int32#hail.expr.functions.int32) function."
    ]
   },
   {
@@ -115,7 +115,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To automatically impute the type when converting a Python object to a Hail expression, use the [literal](https://hail.is/docs/devel/functions/core.html?highlight=literal#hail.expr.functions.literal) method. Let's try it out on a Python list."
+    "To automatically impute the type when converting a Python object to a Hail expression, use the [literal](https://hail.is/docs/0.2/functions/core.html?highlight=literal#hail.expr.functions.literal) method. Let's try it out on a Python list."
    ]
   },
   {
@@ -195,7 +195,7 @@
     "Hail evaluates an expression only when it must. For example:\n",
     "\n",
     " - when performing an aggregation\n",
-    " - when calling the methods [take](https://hail.is/docs/devel/expressions.html?highlight=take#hail.expr.expressions.Expression.take), [collect](https://hail.is/docs/devel/expressions.html?highlight=take#hail.expr.expressions.Expression.collect), and [show](https://hail.is/docs/devel/expressions.html?highlight=take#hail.expr.expressions.Expression.show)\n",
+    " - when calling the methods [take](https://hail.is/docs/0.2/expressions.html?highlight=take#hail.expr.expressions.Expression.take), [collect](https://hail.is/docs/0.2/expressions.html?highlight=take#hail.expr.expressions.Expression.collect), and [show](https://hail.is/docs/0.2/expressions.html?highlight=take#hail.expr.expressions.Expression.show)\n",
     " - when exporting or writing to disk\n",
     "\n",
     "Hail evaluates expressions by streaming to accomodate very large datasets."
@@ -205,7 +205,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you want to force the evaluation of an expression, you can do so by [evaluating it](https://hail.is/docs/devel/expressions.html?highlight=take#hail.expr.expressions.Expression.eval). Note that this can only be done on an expression with no index, such as `hl.int32(1) + 2`. If the expression has an index, e.g. `table.idx + 1`, \n",
+    "If you want to force the evaluation of an expression, you can do so by [evaluating it](https://hail.is/docs/0.2/expressions.html?highlight=take#hail.expr.expressions.Expression.eval). Note that this can only be done on an expression with no index, such as `hl.int32(1) + 2`. If the expression has an index, e.g. `table.idx + 1`, \n",
     "then the `eval` method will fail. The section on indices below explains this concept further. "
    ]
   },
@@ -222,7 +222,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The [show](https://hail.is/docs/devel/hail.Table.html?highlight=show#hail.Table.show) method can also be used to evaluate and display the expression."
+    "The [show](https://hail.is/docs/0.2/hail.Table.html?highlight=show#hail.Table.show) method can also be used to evaluate and display the expression."
    ]
   },
   {
@@ -244,9 +244,9 @@
    "source": [
     "### Missing data\n",
     "\n",
-    "All expressions in Hail can represent missing data. Hail has a [collection of primitive operations](https://hail.is/docs/devel/functions/core.html) for dealing with missingness. \n",
+    "All expressions in Hail can represent missing data. Hail has a [collection of primitive operations](https://hail.is/docs/0.2/functions/core.html) for dealing with missingness. \n",
     "\n",
-    "The [null](https://hail.is/docs/devel/functions/core.html?highlight=null#hail.expr.functions.null) constructor can be used to create a missing expression of a specific type, such as a missing string:"
+    "The [null](https://hail.is/docs/0.2/functions/core.html?highlight=null#hail.expr.functions.null) constructor can be used to create a missing expression of a specific type, such as a missing string:"
    ]
   },
   {
@@ -262,7 +262,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Use [is_defined](https://hail.is/docs/devel/functions/core.html?highlight=is_defined#hail.expr.functions.is_defined) or [is_missing](https://hail.is/docs/devel/functions/core.html?highlight=is_defined#hail.expr.functions.is_missing) to test an expression for missingness."
+    "Use [is_defined](https://hail.is/docs/0.2/functions/core.html?highlight=is_defined#hail.expr.functions.is_defined) or [is_missing](https://hail.is/docs/0.2/functions/core.html?highlight=is_defined#hail.expr.functions.is_missing) to test an expression for missingness."
    ]
   },
   {
@@ -327,7 +327,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[or_missing](https://hail.is/docs/devel/functions/core.html?highlight=is_defined#hail.expr.functions.or_missing) takes a predicate and a value. If the predicate is True, it returns the value; otherwise, it returns a missing value. "
+    "[or_missing](https://hail.is/docs/0.2/functions/core.html?highlight=is_defined#hail.expr.functions.or_missing) takes a predicate and a value. If the predicate is True, it returns the value; otherwise, it returns a missing value. "
    ]
   },
   {
@@ -419,7 +419,7 @@
     }
    },
    "source": [
-    "We can examine any field of the matrix table with the [describe](https://hail.is/docs/devel/expressions.html?highlight=describe#hail.expr.expressions.Expression.describe) method. If we examine the field we just added, notice that it has no indices, because it is a global field."
+    "We can examine any field of the matrix table with the [describe](https://hail.is/docs/0.2/expressions.html?highlight=describe#hail.expr.expressions.Expression.describe) method. If we examine the field we just added, notice that it has no indices, because it is a global field."
    ]
   },
   {
@@ -550,7 +550,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can [collect](https://hail.is/docs/devel/expressions.html?highlight=collect#hail.expr.expressions.Expression.collect) an expression to localize all values, like getting a list of all sample IDs of a dataset.\n",
+    "You can [collect](https://hail.is/docs/0.2/expressions.html?highlight=collect#hail.expr.expressions.Expression.collect) an expression to localize all values, like getting a list of all sample IDs of a dataset.\n",
     "\n",
     "But be careful -- don't `collect` more data than can fit in memory!"
    ]
@@ -575,9 +575,9 @@
    "source": [
     "### Learning more\n",
     "\n",
-    "Hail has a suite of of [functions](https://hail.is/docs/devel/functions/index.html) to transform and build expressions. \n",
+    "Hail has a suite of of [functions](https://hail.is/docs/0.2/functions/index.html) to transform and build expressions. \n",
     "\n",
-    "For further documentation on expressions, see the [expression API](https://hail.is/docs/devel/expressions.html) and the [expression](https://hail.is/docs/devel/hailpedia/expressions.html) page. "
+    "For further documentation on expressions, see the [expression API](https://hail.is/docs/0.2/expressions.html) and the [expression](https://hail.is/docs/0.2/hailpedia/expressions.html) page. "
    ]
   }
  ],

--- a/hail/python/hail/docs/tutorials/05-tables.ipynb
+++ b/hail/python/hail/docs/tutorials/05-tables.ipynb
@@ -10,7 +10,7 @@
    "source": [
     "## Table Tutorial\n",
     "\n",
-    "[Table](https://hail.is/docs/devel/hail.Table.html) is Hail's distributed analogue of a data frame or SQL table.  It will be familiar if you've used R or `pandas`, but `Table` differs in 3 important ways:\n",
+    "[Table](https://hail.is/docs/0.2/hail.Table.html) is Hail's distributed analogue of a data frame or SQL table.  It will be familiar if you've used R or `pandas`, but `Table` differs in 3 important ways:\n",
     "\n",
     "- It is distributed.  Hail tables can store far more data than can fit on a single computer.\n",
     "- It carries global fields.\n",
@@ -32,9 +32,9 @@
    "source": [
     "### Importing and Reading\n",
     "\n",
-    "Hail can [import](https://hail.is/docs/devel/methods/impex.html) data from many sources: TSV and CSV files, JSON files, FAM files, databases, Spark, etc.  It can also *read* (and *write*) a native Hail format.\n",
+    "Hail can [import](https://hail.is/docs/0.2/methods/impex.html) data from many sources: TSV and CSV files, JSON files, FAM files, databases, Spark, etc.  It can also *read* (and *write*) a native Hail format.\n",
     "\n",
-    "You can read a dataset with [hl.read_table](https://hail.is/docs/devel/methods/impex.html#hail.methods.read_table).  It take a path and returns a `Table`.  `ht` stands for Hail Table.\n",
+    "You can read a dataset with [hl.read_table](https://hail.is/docs/0.2/methods/impex.html#hail.methods.read_table).  It take a path and returns a `Table`.  `ht` stands for Hail Table.\n",
     "\n",
     "We've provided a method to download and import [the MovieLens dataset](https://grouplens.org/datasets/movielens/100k/) of movie ratings in the Hail native format. Let's read it!\n",
     "\n",
@@ -84,7 +84,7 @@
    "source": [
     "### Exploring Tables\n",
     "\n",
-    "The [describe](https://hail.is/docs/devel/hail.Table.html#hail.Table.describe) method prints the structure of a table: the fields and their types."
+    "The [describe](https://hail.is/docs/0.2/hail.Table.html#hail.Table.describe) method prints the structure of a table: the fields and their types."
    ]
   },
   {
@@ -108,7 +108,7 @@
     }
    },
    "source": [
-    "You can view the first few rows of the table using [show](https://hail.is/docs/devel/hail.Table.html#hail.Table.show). 10 rows are displayed by default. Try changing the code in the cell below to `users.show(5)`."
+    "You can view the first few rows of the table using [show](https://hail.is/docs/0.2/hail.Table.html#hail.Table.show). 10 rows are displayed by default. Try changing the code in the cell below to `users.show(5)`."
    ]
   },
   {
@@ -132,7 +132,7 @@
     }
    },
    "source": [
-    "You can [count](https://hail.is/docs/devel/hail.Table.html#hail.Table.count) the rows of a table."
+    "You can [count](https://hail.is/docs/0.2/hail.Table.html#hail.Table.count) the rows of a table."
    ]
   },
   {

--- a/hail/python/hail/docs/tutorials/06-aggregation.ipynb
+++ b/hail/python/hail/docs/tutorials/06-aggregation.ipynb
@@ -18,14 +18,14 @@
     "\n",
     "To start, we'll aggregate all the values in a table.  (Later, we'll learn how to aggregate over subsets.)\n",
     "\n",
-    "We can do this with the [Table.aggregate](https://hail.is/docs/devel/hail.Table.html#hail.Table.aggregate) method.\n",
+    "We can do this with the [Table.aggregate](https://hail.is/docs/0.2/hail.Table.html#hail.Table.aggregate) method.\n",
     "\n",
     "A call to `aggregate` has two parts:\n",
     "\n",
     " - The expression to aggregate over (e.g. a field of a `Table`).\n",
     " - The *aggregator* to combine the values into the summary.\n",
     " \n",
-    "Hail has a large suite of [aggregators](https://hail.is/docs/devel/aggregators.html) for summarizing data.  Let's see some in action!"
+    "Hail has a large suite of [aggregators](https://hail.is/docs/0.2/aggregators.html) for summarizing data.  Let's see some in action!"
    ]
   },
   {
@@ -37,7 +37,7 @@
    },
    "source": [
     "### `count`\n",
-    "Aggregators live in the `hl.agg` module.  The simplest aggregator is [count](https://hail.is/docs/devel/aggregators.html#hail.expr.aggregators.count).  It takes no arguments and returns the number of values aggregated."
+    "Aggregators live in the `hl.agg` module.  The simplest aggregator is [count](https://hail.is/docs/0.2/aggregators.html#hail.expr.aggregators.count).  It takes no arguments and returns the number of values aggregated."
    ]
   },
   {
@@ -97,7 +97,7 @@
    },
    "source": [
     "### `stats`\n",
-    "[stats](https://hail.is/docs/devel/aggregators.html#hail.expr.aggregators.stats) computes useful statistics about a numeric expression at once.  There are also aggregators for `mean`, `min`, `max`, `sum`, `product` and `array_sum`."
+    "[stats](https://hail.is/docs/0.2/aggregators.html#hail.expr.aggregators.stats) computes useful statistics about a numeric expression at once.  There are also aggregators for `mean`, `min`, `max`, `sum`, `product` and `array_sum`."
    ]
   },
   {
@@ -133,7 +133,7 @@
     "### `counter`\n",
     "What about non-numeric data, like the `occupation` field?  \n",
     "\n",
-    "[counter](https://hail.is/docs/devel/aggregators.html#hail.expr.aggregators.counter) is modeled on the Python Counter object: it counts the number of times each distinct value occurs in the collection of values being aggregated."
+    "[counter](https://hail.is/docs/0.2/aggregators.html#hail.expr.aggregators.counter) is modeled on the Python Counter object: it counts the number of times each distinct value occurs in the collection of values being aggregated."
    ]
   },
   {
@@ -158,7 +158,7 @@
    },
    "source": [
     "### `filter`\n",
-    "You can filter elements of a collection before aggregation by using [filter](https://hail.is/docs/devel/aggregators.html#hail.expr.aggregators.filter)."
+    "You can filter elements of a collection before aggregation by using [filter](https://hail.is/docs/0.2/aggregators.html#hail.expr.aggregators.filter)."
    ]
   },
   {
@@ -204,7 +204,7 @@
    "source": [
     "### `hist`\n",
     "\n",
-    "As we saw in the first tutorial, [hist](https://hail.is/docs/devel/aggregators.html#hail.expr.aggregators.hist) can be used to build a histogram over numeric data."
+    "As we saw in the first tutorial, [hist](https://hail.is/docs/0.2/aggregators.html#hail.expr.aggregators.hist) can be used to build a histogram over numeric data."
    ]
   },
   {

--- a/hail/python/hail/docs/tutorials/07-filter-annotate.ipynb
+++ b/hail/python/hail/docs/tutorials/07-filter-annotate.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "### Filter\n",
     "\n",
-    "You can filter the rows of a table with [Table.filter](https://hail.is/docs/devel/hail.Table.html#hail.Table.filter).   This returns a table of those rows for which the expression evaluates to `True`."
+    "You can filter the rows of a table with [Table.filter](https://hail.is/docs/0.2/hail.Table.html#hail.Table.filter).   This returns a table of those rows for which the expression evaluates to `True`."
    ]
   },
   {
@@ -55,7 +55,7 @@
    "source": [
     "### Annotate\n",
     "\n",
-    "You can add new fields to a table with [annotate](https://hail.is/docs/devel/hail.Table.html#hail.Table.annotate).  Let's mean-center and variance-normalize the `age` field."
+    "You can add new fields to a table with [annotate](https://hail.is/docs/0.2/hail.Table.html#hail.Table.annotate).  Let's mean-center and variance-normalize the `age` field."
    ]
   },
   {
@@ -106,7 +106,7 @@
     }
    },
    "source": [
-    "There are two other annotate methods: [select](https://hail.is/docs/devel/hail.Table.html#hail.Table.select) and [transmute](https://hail.is/docs/devel/hail.Table.html#hail.Table.transmute).  `select` returns a table with the key and an entirely new set of value fields.  `transmute` replaces any fields mentioned on the right-hand side with the new fields, but leaves unmentioned fields unchanged.  `transmute` is useful for transforming data into a new form.  How about some examples?"
+    "There are two other annotate methods: [select](https://hail.is/docs/0.2/hail.Table.html#hail.Table.select) and [transmute](https://hail.is/docs/0.2/hail.Table.html#hail.Table.transmute).  `select` returns a table with the key and an entirely new set of value fields.  `transmute` replaces any fields mentioned on the right-hand side with the new fields, but leaves unmentioned fields unchanged.  `transmute` is useful for transforming data into a new form.  How about some examples?"
    ]
   },
   {
@@ -148,7 +148,7 @@
     }
    },
    "source": [
-    "Finally, you can add global fields with [annotate_globals](https://hail.is/docs/devel/hail.Table.html#hail.Table.annotate_globals).  Globals are useful for storing metadata about a dataset or storing small data structures like sets and maps."
+    "Finally, you can add global fields with [annotate_globals](https://hail.is/docs/0.2/hail.Table.html#hail.Table.annotate_globals).  Globals are useful for storing metadata about a dataset or storing small data structures like sets and maps."
    ]
   },
   {
@@ -195,7 +195,7 @@
     "\n",
     "\n",
     "- [Z-score normalize](https://en.wikipedia.org/wiki/Standard_score) the age field of `users`.\n",
-    "- Convert `zip` to an integer.  Hint: Not all zipcodes are US zipcodes!  Use [hl.int32](https://hail.is/docs/devel/functions/constructors.html#hail.expr.functions.int32) to convert a string to an integer.  Use [StringExpression.matches](https://hail.is/docs/devel/expressions.html#hail.expr.expression.StringExpression.matches) to see if a string matches a regular expression."
+    "- Convert `zip` to an integer.  Hint: Not all zipcodes are US zipcodes!  Use [hl.int32](https://hail.is/docs/0.2/functions/constructors.html#hail.expr.functions.int32) to convert a string to an integer.  Use [StringExpression.matches](https://hail.is/docs/0.2/expressions.html#hail.expr.expression.StringExpression.matches) to see if a string matches a regular expression."
    ]
   },
   {

--- a/hail/python/hail/docs/tutorials/08-joins.ipynb
+++ b/hail/python/hail/docs/tutorials/08-joins.ipynb
@@ -203,7 +203,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since we only want the field `x` from `t2`, we can select it with `t2[t1.a].x`. Then we add this field to `t1` with the `anntotate_rows()` method. The new joined table `j` has a field `t2_x` that comes from the rows of `t2`. The tables could be joined, because they shared the same number of keys (1) and the same key type (string). The keys do not need to share the same name. Notice that the rows with keys present in `t2` but not in `t1` do not show up in the final result. This join syntax performs a left join. Tables also have a SQL-style inner/left/right/outer [join()](https://hail.is/docs/devel/hail.Table.html?highlight=join#hail.Table.join) method.\n",
+    "Since we only want the field `x` from `t2`, we can select it with `t2[t1.a].x`. Then we add this field to `t1` with the `anntotate_rows()` method. The new joined table `j` has a field `t2_x` that comes from the rows of `t2`. The tables could be joined, because they shared the same number of keys (1) and the same key type (string). The keys do not need to share the same name. Notice that the rows with keys present in `t2` but not in `t1` do not show up in the final result. This join syntax performs a left join. Tables also have a SQL-style inner/left/right/outer [join()](https://hail.is/docs/0.2/hail.Table.html?highlight=join#hail.Table.join) method.\n",
     "\n",
     "The magic of keys is that they can be used to create a mapping, like a Python dictionary, between the keys of one table and the row values of another table: `table[expr]` will refer to the row of `table` that has a key value of `expr`. If the row is not unique, one such row is chosen arbitrarily.\n",
     "\n",
@@ -300,7 +300,7 @@
     }
    },
    "source": [
-    "We want to group the ratings by genre, but they're packed up in an array. To unpack the genres, we can use [explode](https://hail.is/docs/devel/hail.Table.html#hail.Table.explode). \n",
+    "We want to group the ratings by genre, but they're packed up in an array. To unpack the genres, we can use [explode](https://hail.is/docs/0.2/hail.Table.html#hail.Table.explode). \n",
     "\n",
     "`explode` creates a new row for each element in the value of the field, which must be a collection (array or set)."
    ]

--- a/hail/python/hail/docs/tutorials/09-matrixtable.ipynb
+++ b/hail/python/hail/docs/tutorials/09-matrixtable.ipynb
@@ -15,7 +15,7 @@
     "- \"Can't I do all of this in `pandas` or `R`?\" \n",
     "- \"What does this have to do with biology?\"\n",
     "\n",
-    "The two crucial features that Hail adds are _scalability_ and the _domain-specific primitives_ needed to work easily with biological data. Fear not! You've learned most of the basic concepts of Hail and now are ready for the bit that makes it possible to represent and compute on genetic matrices: the [MatrixTable](https://hail.is/docs/devel/hail.MatrixTable.html)."
+    "The two crucial features that Hail adds are _scalability_ and the _domain-specific primitives_ needed to work easily with biological data. Fear not! You've learned most of the basic concepts of Hail and now are ready for the bit that makes it possible to represent and compute on genetic matrices: the [MatrixTable](https://hail.is/docs/0.2/hail.MatrixTable.html)."
    ]
   },
   {
@@ -26,7 +26,7 @@
     }
    },
    "source": [
-    "In the last example of the [Table Joins Tutorial](https://hail.is/docs/devel/tutorials/08-joins.html), the ratings table had a compound key: `movie_id` and `user_id`.  The ratings were secretly a movie-by-user matrix!\n",
+    "In the last example of the [Table Joins Tutorial](https://hail.is/docs/0.2/tutorials/08-joins.html), the ratings table had a compound key: `movie_id` and `user_id`.  The ratings were secretly a movie-by-user matrix!\n",
     "\n",
     "However, since this matrix is very sparse, it is reasonably represented in a so-called \"coordinate form\" `Table`, where each row of the table is an entry of the sparse matrix. For large and dense matrices (like sequencing data), the per-row overhead of coordinate reresentations is untenable. That's why we built `MatrixTable`, a 2-dimensional generalization of `Table`."
    ]
@@ -79,7 +79,7 @@
    "source": [
     "### Importing and Reading\n",
     "\n",
-    "Like tables, matrix tables can be [imported](https://hail.is/docs/devel/methods/impex.html) from a variety of formats: VCF, (B)GEN, PLINK, TSV, etc.  Matrix tables can also be *read* from a \"native\" matrix table format.  Let's read a sample of prepared [1KG](https://en.wikipedia.org/wiki/1000_Genomes_Project) data."
+    "Like tables, matrix tables can be [imported](https://hail.is/docs/0.2/methods/impex.html) from a variety of formats: VCF, (B)GEN, PLINK, TSV, etc.  Matrix tables can also be *read* from a \"native\" matrix table format.  Let's read a sample of prepared [1KG](https://en.wikipedia.org/wiki/1000_Genomes_Project) data."
    ]
   },
   {
@@ -200,9 +200,9 @@
    "source": [
     "Some operations are unique to `MatrixTable`:\n",
     "\n",
-    "- The row fields can be accessed as a `Table` with [rows](https://hail.is/docs/devel/hail.MatrixTable.html#hail.MatrixTable.rows)\n",
-    "- The column fields can be accessed as a `Table` with [cols](https://hail.is/docs/devel/hail.MatrixTable.html#hail.MatrixTable.cols).\n",
-    "- The entire field space of a `MatrixTable` can be accessed as a coordinate-form `Table` with [entries](https://hail.is/docs/devel/hail.MatrixTable.html#hail.MatrixTable.entries). Be careful with this! While it's fast to aggregate or query, trying to write this `Table` to disk could produce files _thousands of times larger_ than the corresponding `MatrixTable`.\n",
+    "- The row fields can be accessed as a `Table` with [rows](https://hail.is/docs/0.2/hail.MatrixTable.html#hail.MatrixTable.rows)\n",
+    "- The column fields can be accessed as a `Table` with [cols](https://hail.is/docs/0.2/hail.MatrixTable.html#hail.MatrixTable.cols).\n",
+    "- The entire field space of a `MatrixTable` can be accessed as a coordinate-form `Table` with [entries](https://hail.is/docs/0.2/hail.MatrixTable.html#hail.MatrixTable.entries). Be careful with this! While it's fast to aggregate or query, trying to write this `Table` to disk could produce files _thousands of times larger_ than the corresponding `MatrixTable`.\n",
     "\n",
     "Let's explore `mt` using these tools.  Let's get the size of the dataset."
    ]

--- a/site/poll-devel.sh
+++ b/site/poll-devel.sh
@@ -18,8 +18,8 @@ gsutil cat gs://hail-common/builds/devel/docs/hail-devel-docs-$LATEST_SHA.tar.gz
     tar xvf - -C /var/www/html-new --strip-components=1
 
 ln -s /var/www/0.1 /var/www/html-new/docs/0.1
-ln -s /var/www/html/docs/devel /var/www/html-new/docs/0.2
-ln -s /var/www/html/docs/devel /var/www/html-new/docs/stable
+ln -s /var/www/html/docs/0.2 /var/www/html-new/docs/devel
+ln -s /var/www/html/docs/0.2 /var/www/html-new/docs/stable
 
 # just in case
 rm -rf /var/www/html-old


### PR DESCRIPTION
This also fixes a broken link in site from the devel => 0.2 rename.  See poll-devel.sh.  This is urgent!  I patched it by hand for the moment, but if it redeploys, it will be broken again.