### PR TITLE
IR conversion between Table and MatrixTable

### DIFF
--- a/hail/python/hail/ir/matrix_ir.py
+++ b/hail/python/hail/ir/matrix_ir.py
@@ -280,17 +280,19 @@ class MatrixExplodeCols(MatrixIR):
 
 
 class UnlocalizeEntries(MatrixIR):
-    def __init__(self, rows_entries, cols, entry_field_name):
+    def __init__(self, child, entries_field_name, cols_field_name, col_key):
         super().__init__()
-        self.rows_entries = rows_entries
-        self.cols = cols
-        self.entry_field_name = entry_field_name
+        self.child = child
+        self.entries_field_name = entries_field_name
+        self.cols_field_name = cols_field_name
+        self.col_key = col_key
 
     def render(self, r):
-        return '(UnlocalizeEntries ' \
-                f'"{escape_str(self.entry_field_name)}" ' \
-                f'{r(self.rows_entries)} ' \
-                f'{r(self.cols)})'
+        return '(UnlocalizeEntries {} {} ({}) {})'.format(
+           escape_str(self.entries_field_name),
+           escape_str(self.cols_field_name),
+           ' '.join([escape_id(id) for id in self.col_key]),
+           r(self.child))
 
 
 class MatrixAnnotateRowsTable(MatrixIR):

--- a/hail/python/hail/ir/matrix_ir.py
+++ b/hail/python/hail/ir/matrix_ir.py
@@ -279,7 +279,7 @@ class MatrixExplodeCols(MatrixIR):
             r(self.child))
 
 
-class UnlocalizeEntries(MatrixIR):
+class CastTableToMatrix(MatrixIR):
     def __init__(self, child, entries_field_name, cols_field_name, col_key):
         super().__init__()
         self.child = child
@@ -288,7 +288,7 @@ class UnlocalizeEntries(MatrixIR):
         self.col_key = col_key
 
     def render(self, r):
-        return '(UnlocalizeEntries {} {} ({}) {})'.format(
+        return '(CastTableToMatrix {} {} ({}) {})'.format(
            escape_str(self.entries_field_name),
            escape_str(self.cols_field_name),
            ' '.join([escape_id(id) for id in self.col_key]),

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -225,13 +225,17 @@ class TableRepartition(TableIR):
         return f'(TableRepartition {self.n} {self.shuffle} {r(self.child)})'
 
 class LocalizeEntries(TableIR):
-    def __init__(self, child, entry_field_name):
+    def __init__(self, child, entries_field_name, cols_field_name):
         super().__init__()
         self.child = child
-        self.entry_field_name = entry_field_name
+        self.entries_field_name = entries_field_name
+        self.cols_field_name = cols_field_name
 
     def render(self, r):
-        return f'(LocalizeEntries "{escape_str(self.entry_field_name)}" {r(self.child)})'
+        return f'(LocalizeEntries ' \
+               f'"{escape_str(self.entries_field_name)}" ' \
+               f'"{escape_str(self.cols_field_name)}" ' \
+               f'{r(self.child)})'
 
 class TableRename(TableIR):
     def __init__(self, child, row_map, global_map):

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -224,7 +224,7 @@ class TableRepartition(TableIR):
     def render(self, r):
         return f'(TableRepartition {self.n} {self.shuffle} {r(self.child)})'
 
-class LocalizeEntries(TableIR):
+class CastMatrixToTable(TableIR):
     def __init__(self, child, entries_field_name, cols_field_name):
         super().__init__()
         self.child = child
@@ -232,7 +232,7 @@ class LocalizeEntries(TableIR):
         self.cols_field_name = cols_field_name
 
     def render(self, r):
-        return f'(LocalizeEntries ' \
+        return f'(CastMatrixToTable ' \
                f'"{escape_str(self.entries_field_name)}" ' \
                f'"{escape_str(self.cols_field_name)}" ' \
                f'{r(self.child)})'

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2493,7 +2493,7 @@ class MatrixTable(ExprContainer):
             uids.append(col_uid)
 
             def joiner(left: MatrixTable):
-                localized = self._localize_entries(row_uid)
+                localized = self._localize_entries(row_uid, col_uid)
                 src_cols_indexed = self.add_col_index(col_uid).cols()
                 src_cols_indexed = src_cols_indexed.annotate(**{col_uid: hl.int32(src_cols_indexed[col_uid])})
                 left = left._annotate_all(row_exprs = {row_uid: localized.index(*row_exprs)[row_uid]},
@@ -2506,9 +2506,9 @@ class MatrixTable(ExprContainer):
                       joiner)
             return construct_expr(ir, self.entry.dtype, indices, aggregations)
 
-    @typecheck_method(entries_field_name=str)
-    def _localize_entries(self, entries_field_name):
-        return Table(self._jvds.localizeEntries(entries_field_name))
+    @typecheck_method(entries_field_name=str, cols_field_name=str)
+    def _localize_entries(self, entries_field_name, cols_field_name):
+        return Table(self._jvds.localizeEntries(entries_field_name, cols_field_name))
 
     @typecheck_method(row_exprs=dictof(str, expr_any),
                       col_exprs=dictof(str, expr_any),

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -599,7 +599,7 @@ class Tests(unittest.TestCase):
         ref_tab = hl.Table.parallelize(ref_data, ref_schema).key_by('row_idx')
         mt = hl.utils.range_matrix_table(8, 6)
         mt = mt.annotate_entries(v=mt.row_idx+mt.col_idx)
-        t = mt._localize_entries('__entries')
+        t = mt._localize_entries('__entries', '__cols').drop('__cols')
         self.assertTrue(t._same(ref_tab))
 
     def test_localize_self_join(self):
@@ -611,7 +611,7 @@ class Tests(unittest.TestCase):
         ref_tab = ref_tab.join(ref_tab, how='outer')
         mt = hl.utils.range_matrix_table(8, 6)
         mt = mt.annotate_entries(v=mt.row_idx+mt.col_idx)
-        t = mt._localize_entries('__entries')
+        t = mt._localize_entries('__entries', '__cols').drop('__cols')
         t = t.join(t, how='outer')
         self.assertTrue(t._same(ref_tab))
 

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -597,9 +597,10 @@ class Tests(unittest.TestCase):
         ref_data = [{'row_idx': i, '__entries': [{'v': i+j} for j in range(6)]}
                     for i in range(8)]
         ref_tab = hl.Table.parallelize(ref_data, ref_schema).key_by('row_idx')
+        ref_tab = ref_tab.select_globals(__cols=[hl.struct(col_idx=i) for i in range(6)])
         mt = hl.utils.range_matrix_table(8, 6)
         mt = mt.annotate_entries(v=mt.row_idx+mt.col_idx)
-        t = mt._localize_entries('__entries', '__cols').drop('__cols')
+        t = mt._localize_entries('__entries', '__cols')
         self.assertTrue(t._same(ref_tab))
 
     def test_localize_self_join(self):

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -166,7 +166,7 @@ class TableIRTests(unittest.TestCase):
             ir.TableHead(table_read, 10),
             ir.TableOrderBy(ir.TableKeyBy(table_read, []), [('m', 'A'), ('m', 'D')]),
             ir.TableDistinct(table_read),
-            ir.LocalizeEntries(matrix_read, '__entries', '__cols'),
+            ir.CastMatrixToTable(matrix_read, '__entries', '__cols'),
             ir.TableRename(table_read, {'idx': 'idx_foo'}, {'global_f32': 'global_foo'})
         ]
 
@@ -190,8 +190,8 @@ class TableIRTests(unittest.TestCase):
 
         matrix_irs = [
             ir.MatrixUnionRows(ir.MatrixRange(5, 5, 1), ir.MatrixRange(5, 5, 1)),
-            ir.UnlocalizeEntries(
-                ir.LocalizeEntries(matrix_read, '__entries', '__cols'),
+            ir.CastTableToMatrix(
+                ir.CastMatrixToTable(matrix_read, '__entries', '__cols'),
                 '__entries',
                 '__cols',
                 []),

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -166,7 +166,7 @@ class TableIRTests(unittest.TestCase):
             ir.TableHead(table_read, 10),
             ir.TableOrderBy(ir.TableKeyBy(table_read, []), [('m', 'A'), ('m', 'D')]),
             ir.TableDistinct(table_read),
-            ir.LocalizeEntries(matrix_read, '__entries'),
+            ir.LocalizeEntries(matrix_read, '__entries', '__cols'),
             ir.TableRename(table_read, {'idx': 'idx_foo'}, {'global_f32': 'global_foo'})
         ]
 
@@ -191,9 +191,10 @@ class TableIRTests(unittest.TestCase):
         matrix_irs = [
             ir.MatrixUnionRows(ir.MatrixRange(5, 5, 1), ir.MatrixRange(5, 5, 1)),
             ir.UnlocalizeEntries(
-                ir.LocalizeEntries(matrix_read, '__entries'),
-                ir.MatrixColsTable(matrix_read),
-                '__entries'),
+                ir.LocalizeEntries(matrix_read, '__entries', '__cols'),
+                '__entries',
+                '__cols',
+                []),
             ir.MatrixAggregateRowsByKey(matrix_read, collect, collect),
             ir.MatrixAggregateColsByKey(matrix_read, collect, collect),
             ir.MatrixRange(1, 1, 10),

--- a/hail/src/main/scala/is/hail/expr/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/Parser.scala
@@ -634,7 +634,7 @@ object Parser extends JavaTokenParsers {
             SortField(i.substring(1), Descending)))
       } |
       "TableExplode" ~> ir_identifier ~ table_ir(env) ^^ { case field ~ child => ir.TableExplode(child, field) } |
-      "LocalizeEntries" ~> string_literal ~ string_literal ~ matrix_ir(env) ^^ { case entriesField ~ colsField ~ child =>
+      "CastMatrixToTable" ~> string_literal ~ string_literal ~ matrix_ir(env) ^^ { case entriesField ~ colsField ~ child =>
         ir.CastMatrixToTable(child, entriesField, colsField)
       } |
       "TableRename" ~> string_literals ~ string_literals ~ string_literals ~ string_literals ~ table_ir(env) ^^ {
@@ -688,7 +688,7 @@ object Parser extends JavaTokenParsers {
       "MatrixChooseCols" ~> int32_literals ~ matrix_ir(env) ^^ { case oldIndices ~ child => ir.MatrixChooseCols(child, oldIndices) } |
       "MatrixCollectColsByKey" ~> matrix_ir(env) ^^ { child => ir.MatrixCollectColsByKey(child) } |
       "MatrixUnionRows" ~> matrix_ir_children(env) ^^ { children => ir.MatrixUnionRows(children) } |
-      "UnlocalizeEntries" ~> ir_identifier ~ ir_identifier ~ ir_identifiers ~ table_ir(env) ^^ {
+      "CastTableToMatrix" ~> ir_identifier ~ ir_identifier ~ ir_identifiers ~ table_ir(env) ^^ {
         case entriesField ~ colsField ~ colKey ~ child => ir.CastTableToMatrix(child, entriesField, colsField, colKey)
       } |
       "JavaMatrix" ~> ir_identifier ^^ { ident => env.irMap(ident).asInstanceOf[MatrixIR] }

--- a/hail/src/main/scala/is/hail/expr/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/Parser.scala
@@ -634,8 +634,8 @@ object Parser extends JavaTokenParsers {
             SortField(i.substring(1), Descending)))
       } |
       "TableExplode" ~> ir_identifier ~ table_ir(env) ^^ { case field ~ child => ir.TableExplode(child, field) } |
-      "LocalizeEntries" ~> string_literal ~ matrix_ir(env) ^^ { case field ~ child =>
-        ir.LocalizeEntries(child, field)
+      "LocalizeEntries" ~> string_literal ~ string_literal ~ matrix_ir(env) ^^ { case entriesField ~ colsField ~ child =>
+        ir.LocalizeEntries(child, entriesField, colsField)
       } |
       "TableRename" ~> string_literals ~ string_literals ~ string_literals ~ string_literals ~ table_ir(env) ^^ {
         case rowK ~ rowV ~ globalK ~ globalV ~ child => ir.TableRename(child, rowK.zip(rowV).toMap, globalK.zip(globalV).toMap)
@@ -688,8 +688,8 @@ object Parser extends JavaTokenParsers {
       "MatrixChooseCols" ~> int32_literals ~ matrix_ir(env) ^^ { case oldIndices ~ child => ir.MatrixChooseCols(child, oldIndices) } |
       "MatrixCollectColsByKey" ~> matrix_ir(env) ^^ { child => ir.MatrixCollectColsByKey(child) } |
       "MatrixUnionRows" ~> matrix_ir_children(env) ^^ { children => ir.MatrixUnionRows(children) } |
-      "UnlocalizeEntries" ~> string_literal ~ table_ir(env) ~ table_ir(env) ^^ {
-        case entryField ~ rowsEntries ~ cols => ir.UnlocalizeEntries(rowsEntries, cols, entryField)
+      "UnlocalizeEntries" ~> ir_identifier ~ ir_identifier ~ ir_identifiers ~ table_ir(env) ^^ {
+        case entriesField ~ colsField ~ colKey ~ child => ir.UnlocalizeEntries(child, entriesField, colsField, colKey)
       } |
       "JavaMatrix" ~> ir_identifier ^^ { ident => env.irMap(ident).asInstanceOf[MatrixIR] }
   }

--- a/hail/src/main/scala/is/hail/expr/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/Parser.scala
@@ -635,7 +635,7 @@ object Parser extends JavaTokenParsers {
       } |
       "TableExplode" ~> ir_identifier ~ table_ir(env) ^^ { case field ~ child => ir.TableExplode(child, field) } |
       "LocalizeEntries" ~> string_literal ~ string_literal ~ matrix_ir(env) ^^ { case entriesField ~ colsField ~ child =>
-        ir.LocalizeEntries(child, entriesField, colsField)
+        ir.CastMatrixToTable(child, entriesField, colsField)
       } |
       "TableRename" ~> string_literals ~ string_literals ~ string_literals ~ string_literals ~ table_ir(env) ^^ {
         case rowK ~ rowV ~ globalK ~ globalV ~ child => ir.TableRename(child, rowK.zip(rowV).toMap, globalK.zip(globalV).toMap)
@@ -689,7 +689,7 @@ object Parser extends JavaTokenParsers {
       "MatrixCollectColsByKey" ~> matrix_ir(env) ^^ { child => ir.MatrixCollectColsByKey(child) } |
       "MatrixUnionRows" ~> matrix_ir_children(env) ^^ { children => ir.MatrixUnionRows(children) } |
       "UnlocalizeEntries" ~> ir_identifier ~ ir_identifier ~ ir_identifiers ~ table_ir(env) ^^ {
-        case entriesField ~ colsField ~ colKey ~ child => ir.UnlocalizeEntries(child, entriesField, colsField, colKey)
+        case entriesField ~ colsField ~ colKey ~ child => ir.CastTableToMatrix(child, entriesField, colsField, colKey)
       } |
       "JavaMatrix" ~> ir_identifier ^^ { ident => env.irMap(ident).asInstanceOf[MatrixIR] }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -2468,7 +2468,7 @@ case class MatrixExplodeCols(child: MatrixIR, path: IndexedSeq[String]) extends 
 }
 
 /**
- * This is intended to be an inverse to LocalizeEntries on a MatrixTable
+ * This is intended to be an inverse to CastMatrixToTable
  *
  * Some notes on semantics,
  * `rowsEntries`'s globals populate the resulting matrixtable, `cols`' are discarded
@@ -2476,7 +2476,7 @@ case class MatrixExplodeCols(child: MatrixIR, path: IndexedSeq[String]) extends 
  * all elements in the array field that `entriesFieldName` refers to must be present. Furthermore,
  * all array elements must be the same length, though individual array items may be missing.
  */
-case class UnlocalizeEntries(
+case class CastTableToMatrix(
   child: TableIR,
   entriesFieldName: String,
   colsFieldName: String,
@@ -2503,9 +2503,9 @@ case class UnlocalizeEntries(
 
   def children: IndexedSeq[BaseIR] = Array(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): UnlocalizeEntries = {
+  def copy(newChildren: IndexedSeq[BaseIR]): CastTableToMatrix = {
     assert(newChildren.length == 2)
-    UnlocalizeEntries(
+    CastTableToMatrix(
       newChildren(0).asInstanceOf[TableIR],
       entriesFieldName,
       colsFieldName,

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -2504,7 +2504,7 @@ case class CastTableToMatrix(
   def children: IndexedSeq[BaseIR] = Array(child)
 
   def copy(newChildren: IndexedSeq[BaseIR]): CastTableToMatrix = {
-    assert(newChildren.length == 2)
+    assert(newChildren.length == 1)
     CastTableToMatrix(
       newChildren(0).asInstanceOf[TableIR],
       entriesFieldName,

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -264,8 +264,11 @@ object Pretty {
                 prettyIntOpt(nPartitions)
             case TableOrderBy(_, sortFields) => prettyIdentifiers(sortFields.map(sf =>
               (if (sf.sortOrder == Ascending) "A" else "D") + sf.field))
-            case LocalizeEntries(_, name) => prettyStringLiteral(name)
-            case UnlocalizeEntries(_, _, name) => prettyStringLiteral(name)
+            case LocalizeEntries(_, entriesFieldName, colsFieldName) =>
+              s"${prettyStringLiteral(entriesFieldName)} ${prettyStringLiteral(colsFieldName)}"
+            case UnlocalizeEntries(_, entriesFieldName, colsFieldName, colKey) =>
+              s"${prettyStringLiteral(entriesFieldName)} ${prettyStringLiteral(colsFieldName)} " +
+                prettyIdentifiers(colKey)
             case TableRename(_, rowMap, globalMap) =>
               val rowKV = rowMap.toArray
               val globalKV = globalMap.toArray

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -264,10 +264,10 @@ object Pretty {
                 prettyIntOpt(nPartitions)
             case TableOrderBy(_, sortFields) => prettyIdentifiers(sortFields.map(sf =>
               (if (sf.sortOrder == Ascending) "A" else "D") + sf.field))
-            case LocalizeEntries(_, entriesFieldName, colsFieldName) =>
+            case CastMatrixToTable(_, entriesFieldName, colsFieldName) =>
               s"${prettyStringLiteral(entriesFieldName)} ${prettyStringLiteral(colsFieldName)}"
-            case UnlocalizeEntries(_, entriesFieldName, colsFieldName, colKey) =>
-              s"${prettyStringLiteral(entriesFieldName)} ${prettyStringLiteral(colsFieldName)} " +
+            case CastTableToMatrix(_, entriesFieldName, colsFieldName, colKey) =>
+              s"${prettyIdentifier(entriesFieldName)} ${prettyIdentifier(colsFieldName)} " +
                 prettyIdentifiers(colKey)
             case TableRename(_, rowMap, globalMap) =>
               val rowKV = rowMap.toArray

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -345,7 +345,7 @@ object PruneDeadFields {
         memoizeMatrixIR(child, mtDep, memo)
       case TableUnion(children) =>
         children.foreach(memoizeTableIR(_, requestedType, memo))
-      case LocalizeEntries(child, entriesFieldName, colsFieldName) =>
+      case CastMatrixToTable(child, entriesFieldName, colsFieldName) =>
         val minChild = minimal(child.typ)
         val m = Map(entriesFieldName -> MatrixType.entriesIdentifier)
         val childDep = minChild.copy(
@@ -559,7 +559,7 @@ object PruneDeadFields {
         memoizeMatrixIR(child, dep, memo)
       case MatrixUnionRows(children) =>
         children.foreach(memoizeMatrixIR(_, requestedType, memo))
-      case UnlocalizeEntries(child, entriesFieldName, colsFieldName, _) =>
+      case CastTableToMatrix(child, entriesFieldName, colsFieldName, _) =>
         val m = Map(MatrixType.entriesIdentifier -> entriesFieldName)
         val childDep = child.typ.copy(
           globalType = unify(child.typ.globalType, requestedType.globalType, TStruct((colsFieldName, TArray(requestedType.colType)))),
@@ -819,10 +819,10 @@ object PruneDeadFields {
         val expr2 = rebuild(expr, child2.typ, memo)
         val newKey2 = rebuild(newKey, child2.typ, memo)
         TableKeyByAndAggregate(child2, expr2, newKey2, nPartitions, bufferSize)
-      case LocalizeEntries(child, entriesFieldName, colsFieldName) =>
+      case CastMatrixToTable(child, entriesFieldName, colsFieldName) =>
         val child2 = rebuild(child, memo)
         if (dep.rowType.hasField(entriesFieldName))
-          LocalizeEntries(child2, entriesFieldName, colsFieldName)
+          CastMatrixToTable(child2, entriesFieldName, colsFieldName)
         else
           MatrixRowsTable(child2)
       case TableRename(child, rowMap, globalMap) =>

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1163,7 +1163,7 @@ case class CastMatrixToTable(
   def typ: TableType = TableType(
     rowType = child.typ.rvRowType.rename(Map(MatrixType.entriesIdentifier -> entriesFieldName)),
     key = child.typ.rowKey,
-    globalType = child.typ.globalType.appendKey(colsFieldName, +TArray(child.typ.colType)))
+    globalType = child.typ.globalType.appendKey(colsFieldName, TArray(child.typ.colType)))
 
   def children: IndexedSeq[BaseIR] = FastIndexedSeq(child)
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1150,7 +1150,16 @@ case class TableOrderBy(child: TableIR, sortFields: IndexedSeq[SortField]) exten
   }
 }
 
-case class CastMatrixToTable(child: MatrixIR, entriesFieldName: String, colsFieldName: String) extends TableIR {
+/** Create a Table from a MatrixTable, storing the column values in a global
+  * field 'colsFieldName', and storing the entry values in a row field
+  * 'entriesFieldName'.
+  */
+case class CastMatrixToTable(
+  child: MatrixIR,
+  entriesFieldName: String,
+  colsFieldName: String
+) extends TableIR {
+
   def typ: TableType = TableType(
     rowType = child.typ.rvRowType.rename(Map(MatrixType.entriesIdentifier -> entriesFieldName)),
     key = child.typ.rowKey,

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1150,7 +1150,7 @@ case class TableOrderBy(child: TableIR, sortFields: IndexedSeq[SortField]) exten
   }
 }
 
-case class LocalizeEntries(child: MatrixIR, entriesFieldName: String, colsFieldName: String) extends TableIR {
+case class CastMatrixToTable(child: MatrixIR, entriesFieldName: String, colsFieldName: String) extends TableIR {
   def typ: TableType = TableType(
     rowType = child.typ.rvRowType.rename(Map(MatrixType.entriesIdentifier -> entriesFieldName)),
     key = child.typ.rowKey,
@@ -1158,9 +1158,9 @@ case class LocalizeEntries(child: MatrixIR, entriesFieldName: String, colsFieldN
 
   def children: IndexedSeq[BaseIR] = FastIndexedSeq(child)
 
-  def copy(newChildren: IndexedSeq[BaseIR]): LocalizeEntries = {
+  def copy(newChildren: IndexedSeq[BaseIR]): CastMatrixToTable = {
     val IndexedSeq(newChild) = newChildren
-    LocalizeEntries(newChild.asInstanceOf[MatrixIR], entriesFieldName, colsFieldName)
+    CastMatrixToTable(newChild.asInstanceOf[MatrixIR], entriesFieldName, colsFieldName)
   }
 
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts

--- a/hail/src/main/scala/is/hail/expr/types/TStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/TStruct.scala
@@ -186,6 +186,8 @@ final case class TStruct(fields: IndexedSeq[Field], override val required: Boole
     TStruct(newFields, required)
   }
 
+  def deleteKey(key: String): TStruct = deleteKey(key, fieldIdx(key))
+
   def deleteKey(key: String, index: Int): TStruct = {
     assert(fieldIdx.contains(key))
     if (fields.length == 1)

--- a/hail/src/main/scala/is/hail/expr/types/TStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/TStruct.scala
@@ -78,8 +78,6 @@ final case class TStruct(fields: IndexedSeq[Field], override val required: Boole
 
   val ordering: ExtendedOrdering = TBaseStruct.getOrdering(types)
 
-  def fieldByName(name: String): Field = fields(fieldIdx(name))
-
   override def canCompare(other: Type): Boolean = other match {
     case t: TStruct => size == t.size && fields.zip(t.fields).forall { case (f1, f2) =>
       f1.name == f2.name && f1.typ.canCompare(f2.typ)
@@ -105,6 +103,8 @@ final case class TStruct(fields: IndexedSeq[Field], override val required: Boole
   def hasField(name: String): Boolean = fieldIdx.contains(name)
 
   def field(name: String): Field = fields(fieldIdx(name))
+
+  def fieldType(name: String): Type = types(fieldIdx(name))
 
   def toTTuple: TTuple = new TTuple(types, required)
 

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -923,7 +923,7 @@ class RVD(
     that: RVD
   )(zipper: (RVDContext, Iterator[RegionValue], Iterator[RegionValue]) => Iterator[RegionValue]
   ): RVD = {
-    require(that.rowType.fieldByName(that.typ.key(0)).typ.asInstanceOf[TInterval].pointType == rowType.fieldByName(typ.key(0)).typ)
+    require(that.rowType.field(that.typ.key(0)).typ.asInstanceOf[TInterval].pointType == rowType.field(typ.key(0)).typ)
 
     val partBc = partitioner.broadcast(sparkContext)
     val rightTyp = that.typ

--- a/hail/src/main/scala/is/hail/rvd/RVDType.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDType.scala
@@ -54,7 +54,7 @@ final case class RVDType(rowType: TStruct, key: IndexedSeq[String] = FastIndexed
     */
   def intervalJoinComp(other: RVDType): UnsafeOrdering = {
     require(other.key.length == 1)
-    require(other.rowType.fieldByName(other.key(0)).typ.asInstanceOf[TInterval].pointType == rowType.fieldByName(key(0)).typ)
+    require(other.rowType.field(other.key(0)).typ.asInstanceOf[TInterval].pointType == rowType.field(key(0)).typ)
 
     new UnsafeOrdering {
       val t1 = rowType

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -3,7 +3,7 @@ package is.hail.table
 import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.expr.{ir, _}
-import is.hail.expr.ir.{IR, LiftLiterals, TableAggregateByKey, TableExplode, TableFilter, TableIR, TableJoin, TableKeyBy, TableKeyByAndAggregate, TableLiteral, TableMapGlobals, TableMapRows, TableOrderBy, TableParallelize, TableRange, TableToMatrixTable, TableUnion, TableValue, UnlocalizeEntries, _}
+import is.hail.expr.ir.{IR, LiftLiterals, TableAggregateByKey, TableExplode, TableFilter, TableIR, TableJoin, TableKeyBy, TableKeyByAndAggregate, TableLiteral, TableMapGlobals, TableMapRows, TableOrderBy, TableParallelize, TableRange, TableToMatrixTable, TableUnion, TableValue, CastTableToMatrix, _}
 import is.hail.expr.types._
 import is.hail.io.plink.{FamFileConfig, LoadPlink}
 import is.hail.rvd._
@@ -472,7 +472,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
     colKey: java.util.ArrayList[String]
   ): MatrixTable =
     new MatrixTable(hc,
-      UnlocalizeEntries(tir, entriesFieldName, colsFieldName, colKey.asScala.toFastIndexedSeq))
+      CastTableToMatrix(tir, entriesFieldName, colsFieldName, colKey.asScala.toFastIndexedSeq))
 
   def aggregateByKey(expr: String): Table = {
     val x = Parser.parse_value_ir(expr, IRParserEnvironment(typ.refMap))

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -466,8 +466,13 @@ class Table(val hc: HailContext, val tir: TableIR) {
     ))
   }
 
-  def unlocalizeEntries(cols: Table, entriesFieldName: String): MatrixTable =
-    new MatrixTable(hc, UnlocalizeEntries(tir, cols.tir, entriesFieldName))
+  def unlocalizeEntries(
+    entriesFieldName: String,
+    colsFieldName: String,
+    colKey: java.util.ArrayList[String]
+  ): MatrixTable =
+    new MatrixTable(hc,
+      UnlocalizeEntries(tir, entriesFieldName, colsFieldName, colKey.asScala.toFastIndexedSeq))
 
   def aggregateByKey(expr: String): Table = {
     val x = Parser.parse_value_ir(expr, IRParserEnvironment(typ.refMap))

--- a/hail/src/main/scala/is/hail/utils/ErrorHandling.scala
+++ b/hail/src/main/scala/is/hail/utils/ErrorHandling.scala
@@ -39,7 +39,7 @@ trait ErrorHandling {
       case e: HailException => e.logMsg.filter(_ => logMessage).getOrElse(e.msg)
       case _ => e.getLocalizedMessage
     }
-    s"${ e.getClass.getName }: $msg\n\tat ${ e.getStackTrace.mkString("\n\tat ") }${
+    s"${ e.getClass.getName }: $msg\n\tat ${ e.getStackTrace.mkString("\n\tat ") }\n\n${
       Option(e.getCause).map(exception => expandException(exception, logMessage)).getOrElse("")
     }\n"
   }

--- a/hail/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/hail/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -655,8 +655,8 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     copyAST(MatrixExplodeCols(ast, path.toFastIndexedSeq))
   }
 
-  def localizeEntries(entriesFieldName: String): Table =
-    new Table(hc, LocalizeEntries(ast, entriesFieldName))
+  def localizeEntries(entriesFieldName: String, colsFieldName: String): Table =
+    new Table(hc, LocalizeEntries(ast, entriesFieldName, colsFieldName))
 
   def filterCols(p: (Annotation, Int) => Boolean): MatrixTable = {
     val (newType, filterF) = MatrixIR.filterCols(matrixType)

--- a/hail/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/hail/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -656,7 +656,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
   def localizeEntries(entriesFieldName: String, colsFieldName: String): Table =
-    new Table(hc, LocalizeEntries(ast, entriesFieldName, colsFieldName))
+    new Table(hc, CastMatrixToTable(ast, entriesFieldName, colsFieldName))
 
   def filterCols(p: (Annotation, Int) => Boolean): MatrixTable = {
     val (newType, filterF) = MatrixIR.filterCols(matrixType)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -827,7 +827,7 @@ class IRSuite extends SparkSuite {
           FastIndexedSeq(TableRange(100, 10), TableRange(50, 10))),
         TableExplode(read, "mset"),
         TableOrderBy(TableKeyBy(read, FastIndexedSeq()), FastIndexedSeq(SortField("m", Ascending), SortField("m", Descending))),
-        LocalizeEntries(mtRead, " # entries"),
+        LocalizeEntries(mtRead, " # entries", " # cols"),
         TableRename(read, Map("idx" -> "idx_foo"), Map("global_f32" -> "global_foo"))
       )
       xs.map(x => Array(x))
@@ -910,9 +910,10 @@ class IRSuite extends SparkSuite {
         MatrixUnionRows(FastIndexedSeq(range1, range2)),
         MatrixExplodeCols(read, FastIndexedSeq("col_mset")),
         UnlocalizeEntries(
-          LocalizeEntries(read, "all of the entries"),
-          MatrixColsTable(read),
-          "all of the entries"),
+          LocalizeEntries(read, " # entries", " # cols"),
+          " # entries",
+          " # cols",
+          read.typ.colKey),
         MatrixAnnotateColsTable(read, tableRead, "uid_123"),
         MatrixAnnotateRowsTable(read, tableRead, "uid_123", Some(FastIndexedSeq(I32(1))))
       )

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -827,7 +827,7 @@ class IRSuite extends SparkSuite {
           FastIndexedSeq(TableRange(100, 10), TableRange(50, 10))),
         TableExplode(read, "mset"),
         TableOrderBy(TableKeyBy(read, FastIndexedSeq()), FastIndexedSeq(SortField("m", Ascending), SortField("m", Descending))),
-        LocalizeEntries(mtRead, " # entries", " # cols"),
+        CastMatrixToTable(mtRead, " # entries", " # cols"),
         TableRename(read, Map("idx" -> "idx_foo"), Map("global_f32" -> "global_foo"))
       )
       xs.map(x => Array(x))
@@ -909,8 +909,8 @@ class IRSuite extends SparkSuite {
         MatrixExplodeRows(read, FastIndexedSeq("row_mset")),
         MatrixUnionRows(FastIndexedSeq(range1, range2)),
         MatrixExplodeCols(read, FastIndexedSeq("col_mset")),
-        UnlocalizeEntries(
-          LocalizeEntries(read, " # entries", " # cols"),
+        CastTableToMatrix(
+          CastMatrixToTable(read, " # entries", " # cols"),
           " # entries",
           " # cols",
           read.typ.colKey),

--- a/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
@@ -7,6 +7,7 @@ import is.hail.table.Table
 import is.hail.utils._
 import is.hail.TestUtils._
 import is.hail.variant.MatrixTable
+import org.apache.spark.SparkException
 import org.apache.spark.sql.Row
 import org.testng.annotations.{DataProvider, Test}
 
@@ -149,99 +150,82 @@ class MatrixIRSuite extends SparkSuite {
   }
 
   // these two items are helper for UnlocalizedEntries testing,
-  def makeLocalizedTable(data: Array[Array[Any]]): Table = {
-    val rowRdd = sc.parallelize(data.map(Row.fromSeq(_)))
+  def makeLocalizedTable(rdata: Array[Row], cdata: Array[Row]): Table = {
+    val rowRdd = sc.parallelize(rdata)
     val rowSig = TStruct(
-      "idx" -> TInt32(),
+      "row_idx" -> TInt32(),
       "animal" -> TString(),
       "__entries" -> TArray(TStruct("ent1" -> TString(), "ent2" -> TFloat64()))
     )
-    val keyNames = IndexedSeq("idx")
-    Table(hc, rowRdd, rowSig, keyNames)
-  }
-  def getLocalizedCols: Table = {
-    val cdata = Array(
-      Array(1, "atag"),
-      Array(2, "btag")
-    )
-    val colRdd = sc.parallelize(cdata.map(Row.fromSeq(_)))
-    val colSig = TStruct("idx" -> TInt32(), "tag" -> TString())
-    val keyNames = IndexedSeq("idx")
-    Table(hc, colRdd, colSig, keyNames)
+    val keyNames = IndexedSeq("row_idx")
+
+    val colSig = TStruct("col_idx" -> TInt32(), "tag" -> TString())
+
+    Table(hc, rowRdd, rowSig, keyNames, TStruct(("__cols", TArray(colSig))), Row(cdata.toIndexedSeq))
   }
 
   @Test def testUnlocalizeEntries() {
     val rdata = Array(
-      Array(1, "fish", IndexedSeq(Row.fromSeq(Array("a", 1.0)), Row.fromSeq(Array("x", 2.0)))),
-      Array(2, "cat", IndexedSeq(Row.fromSeq(Array("b", 0.0)), Row.fromSeq(Array("y", 0.1)))),
-      Array(3, "dog", IndexedSeq(Row.fromSeq(Array("c", -1.0)), Row.fromSeq(Array("z", 30.0))))
+      Row(1, "fish", IndexedSeq(Row("a", 1.0), Row("x", 2.0))),
+      Row(2, "cat", IndexedSeq(Row("b", 0.0), Row("y", 0.1))),
+      Row(3, "dog", IndexedSeq(Row("c", -1.0), Row("z", 30.0)))
     )
-    val rowTab = makeLocalizedTable(rdata)
-    val colTab = getLocalizedCols
+    val cdata = Array(
+      Row(1, "atag"),
+      Row(2, "btag")
+    )
+    val rowTab = makeLocalizedTable(rdata, cdata)
 
-    val mir = UnlocalizeEntries(rowTab.tir, colTab.tir, "__entries")
+    val mir = UnlocalizeEntries(rowTab.tir, "__entries", "__cols", Array("col_idx"))
     // cols are same
     val mtCols = MatrixColsTable(mir).execute(hc).rdd.collect()
-    val taCols = colTab.tir.execute(hc).rdd.collect()
-    assert(mtCols sameElements taCols)
+    assert(mtCols sameElements cdata)
 
     // Rows are same
     val mtRows = MatrixRowsTable(mir).execute(hc).rdd.collect()
-    val taRows = rowTab.tir.execute(hc).rdd
-    assert(mtRows sameElements taRows.map(row => Row.fromSeq(row.toSeq.take(2))).collect())
+    assert(mtRows sameElements rdata.map(row => Row.fromSeq(row.toSeq.take(2))))
 
     // Round trip
-    val localRows = new MatrixTable(hc, mir).localizeEntries("__entries").tir.execute(hc).rdd.collect()
-    assert(localRows sameElements taRows.collect())
+    val roundTrip = LocalizeEntries(mir, "__entries", "__cols").execute(hc)
+    val localRows = roundTrip.rdd.collect()
+    assert(localRows sameElements rdata)
+    val localCols = roundTrip.globals.value.getAs[IndexedSeq[Row]](0)
+    assert(localCols sameElements cdata)
   }
 
   @Test def testUnlocalizeEntriesErrors() {
     val rdata = Array(
-      Array(1, "fish", IndexedSeq(Row.fromSeq(Array("x", 2.0)))),
-      Array(2, "cat", IndexedSeq(Row.fromSeq(Array("b", 0.0)), Row.fromSeq(Array("y", 0.1)))),
-      Array(3, "dog", IndexedSeq(Row.fromSeq(Array("c", -1.0)), Row.fromSeq(Array("z", 30.0))))
+      Row(1, "fish", IndexedSeq(Row("x", 2.0))),
+      Row(2, "cat", IndexedSeq(Row("b", 0.0), Row("y", 0.1))),
+      Row(3, "dog", IndexedSeq(Row("c", -1.0), Row("z", 30.0)))
     )
-    val rowTab = makeLocalizedTable(rdata)
-    val colTab = getLocalizedCols
-    val mir = UnlocalizeEntries(rowTab.tir, colTab.tir, "__entries")
+    val cdata = Array(
+      Row(1, "atag"),
+      Row(2, "btag")
+    )
+    val rowTab = makeLocalizedTable(rdata, cdata)
+
+    val mir = UnlocalizeEntries(rowTab.tir, "__entries", "__cols", Array("col_idx"))
+
     // All rows must have the same number of elements in the entry field as colTab has rows
-    try {
-      val mv = mir.execute(hc)
-      mv.rvd.count // force evaluation of mapPartitionsPreservesPartitioning in UnlocalizeEntries.execute
-      assert(false, "should have thrown an error, as the number of columns must match "
-        + "the number of array entries")
-    } catch {
-      case e: org.apache.spark.SparkException => {
-        assert(e.getCause.getClass.toString.contains("HailException"))
-        assert(e.getCause.getMessage.contains("incorrect entry array length"))
-      }
+    interceptSpark("incorrect entry array length") {
+      mir.execute(hc).rvd.count()
     }
 
     // The entry field must be an array
-    try {
-      val mir1 = UnlocalizeEntries(rowTab.tir, colTab.tir, "animal")
-    } catch {
-      case e: is.hail.utils.HailException => {}
+    interceptFatal("") {
+      UnlocalizeEntries(rowTab.tir, "animal", "__cols", Array("col_idx"))
     }
 
     val rdata2 = Array(
-      Array(1, "fish", null),
-      Array(2, "cat", IndexedSeq(Row.fromSeq(Array("b", 0.0)), Row.fromSeq(Array("y", 0.1)))),
-      Array(3, "dog", IndexedSeq(Row.fromSeq(Array("c", -1.0)), Row.fromSeq(Array("z", 30.0))))
+      Row(1, "fish", null),
+      Row(2, "cat", IndexedSeq(Row("b", 0.0), Row("y", 0.1))),
+      Row(3, "dog", IndexedSeq(Row("c", -1.0), Row("z", 30.0)))
     )
-    val rowTab2 = makeLocalizedTable(rdata2)
-    val mir2 = UnlocalizeEntries(rowTab2.tir, colTab.tir, "__entries")
+    val rowTab2 = makeLocalizedTable(rdata2, cdata)
+    val mir2 = UnlocalizeEntries(rowTab2.tir, "__entries", "__cols", Array("col_idx"))
 
-    try {
-      val mv = mir2.execute(hc)
-      mv.rvd.count // force evaluation of mapPartitionsPreservesPartitioning in UnlocalizeEntries.execute
-      assert(false, "should have thrown an error, as no array should be missing")
-    } catch {
-      case e: org.apache.spark.SparkException => {
-        assert(e.getCause.getClass.toString.contains("HailException"))
-        assert(e.getCause.getMessage.contains("missing"))
-      }
-    }
+    interceptSpark("missing") { mir2.execute(hc).rvd.count() }
   }
 
   @Test def testMatrixFiltersWorkWithRandomness() {

--- a/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
@@ -176,7 +176,7 @@ class MatrixIRSuite extends SparkSuite {
     )
     val rowTab = makeLocalizedTable(rdata, cdata)
 
-    val mir = UnlocalizeEntries(rowTab.tir, "__entries", "__cols", Array("col_idx"))
+    val mir = CastTableToMatrix(rowTab.tir, "__entries", "__cols", Array("col_idx"))
     // cols are same
     val mtCols = MatrixColsTable(mir).execute(hc).rdd.collect()
     assert(mtCols sameElements cdata)
@@ -186,7 +186,7 @@ class MatrixIRSuite extends SparkSuite {
     assert(mtRows sameElements rdata.map(row => Row.fromSeq(row.toSeq.take(2))))
 
     // Round trip
-    val roundTrip = LocalizeEntries(mir, "__entries", "__cols").execute(hc)
+    val roundTrip = CastMatrixToTable(mir, "__entries", "__cols").execute(hc)
     val localRows = roundTrip.rdd.collect()
     assert(localRows sameElements rdata)
     val localCols = roundTrip.globals.value.getAs[IndexedSeq[Row]](0)
@@ -205,7 +205,7 @@ class MatrixIRSuite extends SparkSuite {
     )
     val rowTab = makeLocalizedTable(rdata, cdata)
 
-    val mir = UnlocalizeEntries(rowTab.tir, "__entries", "__cols", Array("col_idx"))
+    val mir = CastTableToMatrix(rowTab.tir, "__entries", "__cols", Array("col_idx"))
 
     // All rows must have the same number of elements in the entry field as colTab has rows
     interceptSpark("incorrect entry array length") {
@@ -214,7 +214,7 @@ class MatrixIRSuite extends SparkSuite {
 
     // The entry field must be an array
     interceptFatal("") {
-      UnlocalizeEntries(rowTab.tir, "animal", "__cols", Array("col_idx"))
+      CastTableToMatrix(rowTab.tir, "animal", "__cols", Array("col_idx"))
     }
 
     val rdata2 = Array(
@@ -223,7 +223,7 @@ class MatrixIRSuite extends SparkSuite {
       Row(3, "dog", IndexedSeq(Row("c", -1.0), Row("z", 30.0)))
     )
     val rowTab2 = makeLocalizedTable(rdata2, cdata)
-    val mir2 = UnlocalizeEntries(rowTab2.tir, "__entries", "__cols", Array("col_idx"))
+    val mir2 = CastTableToMatrix(rowTab2.tir, "__entries", "__cols", Array("col_idx"))
 
     interceptSpark("missing") { mir2.execute(hc).rvd.count() }
   }

--- a/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
@@ -164,7 +164,7 @@ class MatrixIRSuite extends SparkSuite {
     Table(hc, rowRdd, rowSig, keyNames, TStruct(("__cols", TArray(colSig))), Row(cdata.toIndexedSeq))
   }
 
-  @Test def testUnlocalizeEntries() {
+  @Test def testCastTableToMatrix() {
     val rdata = Array(
       Row(1, "fish", IndexedSeq(Row("a", 1.0), Row("x", 2.0))),
       Row(2, "cat", IndexedSeq(Row("b", 0.0), Row("y", 0.1))),
@@ -193,7 +193,7 @@ class MatrixIRSuite extends SparkSuite {
     assert(localCols sameElements cdata)
   }
 
-  @Test def testUnlocalizeEntriesErrors() {
+  @Test def testCastTableToMatrixErrors() {
     val rdata = Array(
       Row(1, "fish", IndexedSeq(Row("x", 2.0))),
       Row(2, "cat", IndexedSeq(Row("b", 0.0), Row("y", 0.1))),

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -302,6 +302,14 @@ class PruneSuite extends SparkSuite {
     checkMemo(tob, subsetTable(tob.typ), Array(subsetTable(tab.typ, "row.2", "row.2.2A")))
   }
 
+  @Test def testCastMatrixToTableMemo() {
+    val m2t = CastMatrixToTable(mat, "__entries", "__cols")
+    checkMemo(m2t,
+      subsetTable(m2t.typ, "row.r2", "global.__cols.c2", "global.g2", "row.__entries.e2"),
+      Array(subsetMatrixTable(mat.typ, "va.r2", "global.g2", "sa.c2", "g.e2"))
+    )
+  }
+
   @Test def testMatrixFilterColsMemo() {
     val mfc = MatrixFilterCols(mat, matrixRefBoolean(mat.typ, "global.g1", "sa.c2"))
     checkMemo(mfc,
@@ -395,6 +403,15 @@ class PruneSuite extends SparkSuite {
     checkMemo(mer,
       subsetMatrixTable(mer.typ, "va.r2"),
       Array(subsetMatrixTable(mat.typ, "va.r2", "sa.c3")))
+  }
+
+  @Test def testCastTableToMatrixMemo() {
+    val m2t = CastMatrixToTable(mat, "__entries", "__cols")
+    val t2m = CastTableToMatrix(m2t, "__entries", "__cols", FastIndexedSeq("ck"))
+    checkMemo(t2m,
+      subsetMatrixTable(mat.typ, "va.r2", "sa.c2", "global.g2", "g.e2"),
+      Array(subsetTable(m2t.typ, "row.r2", "global.g2", "global.__cols.ck", "global.__cols.c2", "row.__entries.e2"))
+    )
   }
 
   @Test def testMatrixAggregateRowsByKeyMemo() {

--- a/hail/src/test/scala/is/hail/methods/LocalLDPruneSuite.scala
+++ b/hail/src/test/scala/is/hail/methods/LocalLDPruneSuite.scala
@@ -52,8 +52,8 @@ object LocalLDPruneSuite {
     MatrixType.entriesIdentifier -> TArray(Genotype.htsGenotypeType)
   )
 
-  val bitPackedVectorViewType = BitPackedVectorView.rvRowType(rvRowType.fieldByName("locus").typ,
-    rvRowType.fieldByName("alleles").typ)
+  val bitPackedVectorViewType = BitPackedVectorView.rvRowType(rvRowType.field("locus").typ,
+    rvRowType.field("alleles").typ)
 
   def makeRV(gs: Iterable[Annotation]): RegionValue = {
     val gArr = gs.toFastIndexedSeq


### PR DESCRIPTION
Preparation for compiler pass lowering MatrixIR to TableIR. Make LocalizeEntries and UnlocalizeEntries preserve column values, so they are completely information preserving and inverse to each other.