### PR TITLE
also send stderr to log file

### DIFF
--- a/hail/hail-ci-build.sh
+++ b/hail/hail-ci-build.sh
@@ -169,17 +169,17 @@ export GRADLE_OPTS="-Xmx2048m"
 export GRADLE_USER_HOME="/gradle-cache"
 
 echo "Compiling..."
-./gradlew shadowJar archiveZip > ${COMPILE_LOG}
+./gradlew shadowJar archiveZip > ${COMPILE_LOG} 2>&1
 touch ${COMP_SUCCESS}
 
 test_project() {
-    ./gradlew test > ${SCALA_TEST_LOG}
+    ./gradlew test > ${SCALA_TEST_LOG} 2>&1
     touch ${SCALA_TEST_SUCCESS}
-    ./gradlew testPython > ${PYTHON_TEST_LOG}
+    ./gradlew testPython > ${PYTHON_TEST_LOG} 2>&1
     touch ${PYTHON_TEST_SUCCESS}
-    ./gradlew doctest > ${DOCTEST_LOG}
+    ./gradlew doctest > ${DOCTEST_LOG} 2>&1
     touch ${DOCTEST_SUCCESS}
-    ./gradlew makeDocs > ${DOCS_LOG}
+    ./gradlew makeDocs > ${DOCS_LOG} 2>&1
     touch ${DOCS_SUCCESS}
 }
 
@@ -226,7 +226,7 @@ test_pip_package() {
 test_project &
 PID1=$!
 
-test_gcp > ${GCP_LOG} &
+test_gcp > ${GCP_LOG} 2>&1 &
 PID2=$!
 
 test_pip_package > ${PIP_PACKAGE_LOG} 2>&1 &


### PR DESCRIPTION
cc: @tpoterba 

Previously stderr ended up in the build log while stdout ended up in the per-task log. This change ensures all output (err or out) goes to the log. The only information in the build log is about the orchestration script. This should make debugging CI build failures much easier because stderr and stdout are in one place.