### PR TITLE
First steps for Python Table to use IR

### DIFF
--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -7,6 +7,7 @@ from hail.genetics.reference_genome import ReferenceGenome
 from hail.typecheck import nullable, typecheck, typecheck_method, enumeration
 from hail.utils import wrap_to_list, get_env_or_default
 from hail.utils.java import Env, joption, FatalError, connect_logger, install_exception_handler, uninstall_exception_handler
+from hail.utils.backend import SparkBackend
 
 import sys
 import os
@@ -63,6 +64,8 @@ class HailContext(object):
         Env._gateway = self._gateway
 
         jsc = sc._jsc.sc() if sc else None
+
+        self._backend = SparkBackend()
 
         tmp_dir = get_env_or_default(tmp_dir, 'TMPDIR', '/tmp')
 

--- a/hail/python/hail/expr/expressions/expression_utils.py
+++ b/hail/python/hail/expr/expressions/expression_utils.py
@@ -190,7 +190,7 @@ def eval_typed(expression):
 
     if expression._indices.source is None:
         return (expression.dtype._from_json(
-            java.Env.hail().expr.ir.Interpret.interpretPyIR(str(expression._ir))),
+            java.Env.hail().expr.ir.Interpret.interpretPyIR(str(expression._ir), {}, {})),
                 expression.dtype)
     else:
         return expression.collect()[0], expression.dtype

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1397,4 +1397,4 @@ class JavaIR(IR):
         self._jir = jir
 
     def render(self, r):
-        return f'(JavaIR {r.add_jir(self)})'
+        return f'(JavaIR {r.add_jir(self._jir)})'

--- a/hail/python/hail/ir/matrix_ir.py
+++ b/hail/python/hail/ir/matrix_ir.py
@@ -327,4 +327,4 @@ class JavaMatrix(MatrixIR):
         self._jir = jir
 
     def render(self, r):
-        return f'(JavaMatrix {r.add_jir(self)})'
+        return f'(JavaMatrix {r.add_jir(self._jir)})'

--- a/hail/python/hail/ir/renderer.py
+++ b/hail/python/hail/ir/renderer.py
@@ -8,7 +8,7 @@ class Renderer(object):
 
     def add_jir(self, jir):
         jir_id = f'm{self.count}'
-        self.count = self.count + 1
+        self.count += 1
         self.jirs[jir_id] = jir
         return jir_id
 

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -214,6 +214,7 @@ class TableDistinct(TableIR):
     def render(self, r):
         return f'(TableDistinct {r(self.child)})'
 
+
 class TableRepartition(TableIR):
     def __init__(self, child, n, shuffle):
         super().__init__()
@@ -223,6 +224,7 @@ class TableRepartition(TableIR):
 
     def render(self, r):
         return f'(TableRepartition {self.n} {self.shuffle} {r(self.child)})'
+
 
 class CastMatrixToTable(TableIR):
     def __init__(self, child, entries_field_name, cols_field_name):
@@ -236,6 +238,7 @@ class CastMatrixToTable(TableIR):
                f'"{escape_str(self.entries_field_name)}" ' \
                f'"{escape_str(self.cols_field_name)}" ' \
                f'{r(self.child)})'
+
 
 class TableRename(TableIR):
     def __init__(self, child, row_map, global_map):

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -261,4 +261,4 @@ class JavaTable(TableIR):
         self._jir = jir
 
     def render(self, r):
-        return f'(JavaTable {r.add_jir(self)})'
+        return f'(JavaTable {r.add_jir(self._jir)})'

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -832,7 +832,7 @@ class BlockMatrix(object):
                       radius=int,
                       include_diagonal=bool)
     def _filtered_entries_table(self, table, radius, include_diagonal):
-        return Table(self._jbm.filteredEntriesTable(table._jt, radius, include_diagonal))
+        return Table._from_java(self._jbm.filteredEntriesTable(table._jt, radius, include_diagonal))
 
     @typecheck_method(lower=int, upper=int, blocks_only=bool)
     def sparsify_band(self, lower=0, upper=0, blocks_only=False):
@@ -1581,7 +1581,7 @@ class BlockMatrix(object):
         :class:`.Table`
             Table with a row for each entry.
         """
-        return Table(self._jbm.entriesTable(Env.hc()._jhc))
+        return Table._from_java(self._jbm.entriesTable(Env.hc()._jhc))
 
     @staticmethod
     @typecheck(path_in=str,

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2161,7 +2161,7 @@ class MatrixTable(ExprContainer):
         :class:`.Table`
             Table with the globals from the matrix, with a single row.
         """
-        return Table(self._jvds.globalsTable())
+        return Table._from_java(self._jvds.globalsTable())
 
     def rows(self) -> Table:
         """Returns a table with all row fields in the matrix.
@@ -2177,7 +2177,7 @@ class MatrixTable(ExprContainer):
         :class:`.Table`
             Table with all row fields from the matrix, with one row per row of the matrix.
         """
-        return Table(self._jvds.rowsTable())
+        return Table._from_java(self._jvds.rowsTable())
 
     def cols(self) -> Table:
         """Returns a table with all column fields in the matrix.
@@ -2209,7 +2209,7 @@ class MatrixTable(ExprContainer):
                  "first unkey columns with 'key_cols_by()'")
             Env.hc()._warn_cols_order = False
 
-        return Table(self._jvds.colsTable())
+        return Table._from_java(self._jvds.colsTable())
 
     def entries(self) -> Table:
         """Returns a matrix in coordinate table form.
@@ -2248,7 +2248,7 @@ class MatrixTable(ExprContainer):
                  "first unkey columns with 'key_cols_by()'")
             Env.hc()._warn_entries_order = False
 
-        return Table(self._jvds.entriesTable())
+        return Table._from_java(self._jvds.entriesTable())
 
     def index_globals(self) -> Expression:
         """Return this matrix table's global variables for use in another
@@ -2272,7 +2272,7 @@ class MatrixTable(ExprContainer):
                 return MatrixTable(Env.jutils().joinGlobals(obj._jvds, self._jvds, uid))
             else:
                 assert isinstance(obj, Table)
-                return Table(Env.jutils().joinGlobals(obj._jt, self._jvds, uid))
+                return Table._from_java(Env.jutils().joinGlobals(obj._jt, self._jvds, uid))
 
         ir = Join(GetField(TopLevelReference('global'), uid),
                   [uid],
@@ -2508,7 +2508,7 @@ class MatrixTable(ExprContainer):
 
     @typecheck_method(entries_field_name=str, cols_field_name=str)
     def _localize_entries(self, entries_field_name, cols_field_name):
-        return Table(self._jvds.localizeEntries(entries_field_name, cols_field_name))
+        return Table._from_java(self._jvds.localizeEntries(entries_field_name, cols_field_name))
 
     @typecheck_method(row_exprs=dictof(str, expr_any),
                       col_exprs=dictof(str, expr_any),
@@ -3331,6 +3331,6 @@ class MatrixTable(ExprContainer):
         :class:`.Table`
 
         """
-        return Table(self._jvds.makeTable(separator))
+        return Table._from_java(self._jvds.makeTable(separator))
 
 matrix_table_type.set(MatrixTable)

--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -744,7 +744,7 @@ def import_fam(path, quant_pheno=False, delimiter=r'\\s+', missing='NA') -> Tabl
 
     jkt = Env.hail().table.Table.importFam(Env.hc()._jhc, path,
                                            quant_pheno, delimiter, missing)
-    return Table(jkt)
+    return Table._from_java(jkt)
 
 
 @typecheck(regex=str,
@@ -1324,7 +1324,7 @@ def import_table(paths,
     jt = Env.hc()._jhc.importTable(paths, key, min_partitions, jtypes, comment,
                                    delimiter, missing, no_header, impute, quote,
                                    skip_blank_lines, force_bgz)
-    return Table(jt)
+    return Table._from_java(jt)
 
 
 @typecheck(paths=oneof(str, sequenceof(str)),
@@ -1970,7 +1970,7 @@ def read_table(path) -> Table:
     -------
     :class:`.Table`
     """
-    return Table(Env.hc()._jhc.readTable(path))
+    return Table._from_java(Env.hc()._jhc.readTable(path))
 
 @typecheck(t=Table,
            host=str,

--- a/hail/python/hail/methods/misc.py
+++ b/hail/python/hail/methods/misc.py
@@ -143,7 +143,7 @@ def maximal_independent_set(i, j, keep=True, tie_breaker=None) -> Table:
     edges = t.key_by().select('i', 'j')
     nodes_in_set = Env.hail().utils.Graph.maximalIndependentSet(edges._jt.collect(), node_t._jtype, joption(tie_breaker_str))
 
-    nt = Table(nodes._jt.annotateGlobal(nodes_in_set, hl.tset(node_t)._jtype, 'nodes_in_set'))
+    nt = Table._from_java(nodes._jt.annotateGlobal(nodes_in_set, hl.tset(node_t)._jtype, 'nodes_in_set'))
     nt = (nt
           .filter(nt.nodes_in_set.contains(nt.node), keep)
           .drop('nodes_in_set'))
@@ -343,7 +343,7 @@ def filter_intervals(ds, intervals, keep=True) -> Union[Table, MatrixTable]:
         return MatrixTable(jmt)
     else:
         jt = Env.hail().methods.TableFilterIntervals.apply(ds._jt, intervals, keep)
-        return Table(jt)
+        return Table._from_java(jt)
 
 
 @typecheck(mt=MatrixTable, bp_window_size=int)

--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -412,8 +412,8 @@ def concordance(left, right) -> Tuple[List[List[int]], Table, Table]:
 
     r = Env.hail().methods.CalculateConcordance.apply(left._jvds, right._jvds)
     j_global_conc = r._1()
-    col_conc = Table(r._2())
-    row_conc = Table(r._3())
+    col_conc = Table._from_java(r._2())
+    row_conc = Table._from_java(r._3())
     global_conc = [[j_global_conc.apply(j).apply(i) for i in range(5)] for j in range(5)]
 
     return global_conc, col_conc, row_conc
@@ -514,7 +514,7 @@ def vep(dataset: Union[Table, MatrixTable], config, block_size=1000, name='vep',
         require_table_key_variant(dataset, 'vep')
         ht = dataset.select()
 
-    annotations = Table(Env.hail().methods.VEP.apply(ht._jt, config, csq, block_size))
+    annotations = Table._from_java(Env.hail().methods.VEP.apply(ht._jt, config, csq, block_size))
 
     if csq:
         dataset = dataset.annotate_globals(
@@ -857,7 +857,7 @@ def nirvana(dataset: Union[MatrixTable, Table], config, block_size=500000, name=
         require_table_key_variant(dataset, 'nirvana')
         ht = dataset.select()
 
-    annotations = Table(Env.hail().methods.Nirvana.apply(ht._jt, config, block_size))
+    annotations = Table._from_java(Env.hail().methods.Nirvana.apply(ht._jt, config, block_size))
 
     if isinstance(dataset, MatrixTable):
         return dataset.annotate_rows(**{name: annotations[dataset.row_key].nirvana})

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -97,11 +97,11 @@ def identity_by_descent(dataset, maf=None, bounded=True, min=None, max=None) -> 
     else:
         dataset = dataset.select_rows()
     dataset = dataset.select_cols().select_globals().select_entries('GT')
-    return Table(Env.hail().methods.IBD.apply(require_biallelic(dataset, 'ibd')._jvds,
-                                              joption('__maf' if maf is not None else None),
-                                              bounded,
-                                              joption(min),
-                                              joption(max)))
+    return Table._from_java(Env.hail().methods.IBD.apply(require_biallelic(dataset, 'ibd')._jvds,
+                                                         joption('__maf' if maf is not None else None),
+                                                         bounded,
+                                                         joption(min),
+                                                         joption(max)))
 
 
 @typecheck(call=expr_call,
@@ -378,7 +378,7 @@ def linear_regression_rows(y, x, covariates, block_size=16) -> hail.Table:
         cov_field_names,
         block_size)
 
-    ht_result = Table(jt)
+    ht_result = Table._from_java(jt)
 
     if not y_is_list:
         fields = ['y_transpose_x', 'beta', 'standard_error', 't_stat', 'p_value']
@@ -621,7 +621,7 @@ def logistic_regression_rows(test, y, x, covariates) -> hail.Table:
         y_field_name,
         x_field_name,
         jarray(Env.jvm().java.lang.String, cov_field_names))
-    return Table(jt)
+    return Table._from_java(jt)
 
 
 @typecheck(test=enumeration('wald', 'lrt', 'score'),
@@ -683,7 +683,7 @@ def poisson_regression_rows(test, y, x, covariates) -> Table:
         y_field_name,
         x_field_name,
         jarray(Env.jvm().java.lang.String, cov_field_names))
-    return Table(jt)
+    return Table._from_java(jt)
 
 
 @typecheck(y=expr_float64,
@@ -1207,7 +1207,7 @@ def skat(key_expr, weight_expr, y, x, covariates, logistic=False,
         accuracy,
         iterations)
 
-    return Table(jt)
+    return Table._from_java(jt)
 
 
 @typecheck(call_expr=expr_call,
@@ -1387,10 +1387,10 @@ def pca(entry_expr, k=10, compute_loadings=False) -> Tuple[List[float], Table, T
     mt = mt.select_cols().select_rows().select_globals()
 
     r = Env.hail().methods.PCA.apply(mt._jvds, field, k, compute_loadings)
-    scores = Table(Env.hail().methods.PCA.scoresTable(mt._jvds, r._2()))
+    scores = Table._from_java(Env.hail().methods.PCA.scoresTable(mt._jvds, r._2()))
     loadings = from_option(r._3())
     if loadings:
-        loadings = Table(loadings)
+        loadings = Table._from_java(loadings)
     return jiterable_to_list(r._1()), scores, loadings
 
 
@@ -1697,14 +1697,14 @@ def pc_relate(call_expr, min_individual_maf, *, k=None, scores_expr=None,
 
     int_statistics = {'kin': 0, 'kin2': 1, 'kin20': 2, 'all': 3}[statistics]
 
-    ht = Table(scala_object(Env.hail().methods, 'PCRelate')
-            .apply(Env.hc()._jhc,
-                   g._jbm,
-                   scores_table._jt,
-                   min_individual_maf,
-                   block_size,
-                   min_kinship,
-                   int_statistics))
+    ht = Table._from_java(scala_object(Env.hail().methods, 'PCRelate')
+                          .apply(Env.hc()._jhc,
+                                 g._jbm,
+                                 scores_table._jt,
+                                 min_individual_maf,
+                                 block_size,
+                                 min_kinship,
+                                 int_statistics))
 
     if statistics == 'kin':
         ht = ht.drop('ibd0', 'ibd1', 'ibd2')
@@ -1848,7 +1848,7 @@ def split_multi(ds, keep_star=False, left_aligned=False):
             if rekey:
                 return ht.key_by('locus', 'alleles')
             else:
-                return Table(ht._jt.keyBy(
+                return Table._from_java(ht._jt.keyBy(
                     ['locus', 'alleles'],
                     True # isSorted
                 ))
@@ -3094,7 +3094,7 @@ def _local_ld_prune(mt, call_field, r2=0.2, bp_window_size=1000000, memory_per_c
 
     info(f'ld_prune: running local pruning stage with max queue size of {max_queue_size} variants')
 
-    sites_only_table = Table(Env.hail().methods.LocalLDPrune.apply(
+    sites_only_table = Table._from_java(Env.hail().methods.LocalLDPrune.apply(
         mt._jvds, call_field, float(r2), bp_window_size, max_queue_size))
 
     return sites_only_table

--- a/hail/python/hail/stats/linear_mixed_model.py
+++ b/hail/python/hail/stats/linear_mixed_model.py
@@ -741,7 +741,7 @@ class LinearMixedModel(object):
             maybe_ja_t = jsome(
                 Env.hail().linalg.RowMatrix.readBlockMatrix(Env.hc()._jhc, a_t_path, jsome(partition_size)))
 
-        return Table(self._scala_model.fit(jpa_t, maybe_ja_t))
+        return Table._from_java(self._scala_model.fit(jpa_t, maybe_ja_t))
 
     @typecheck_method(pa=np.ndarray, a=nullable(np.ndarray), return_pandas=bool)
     def fit_alternatives_numpy(self, pa, a=None, return_pandas=False):

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -312,12 +312,13 @@ class Table(ExprContainer):
 
         self._tir = tir
 
-        r = Renderer(stop_at_jir=False)
+        r = Renderer(stop_at_jir=True)
         code = r(tir)
-        env = {name: ir._jir for name, ir in r.jirs.items()}
+        ir_map = {name: jir for name, jir in r.jirs.items()}
 
-        self._jtir = Env.hail().expr.Parser.parse_table_ir(code, env)
+        self._jtir = Env.hail().expr.Parser.parse_table_ir(code, {}, ir_map)
         self._jt = Env.hail().table.Table(Env.hc()._jhc, self._jtir)
+        self._tir._jir = self._jtir
 
         jttype = self._jtir.typ()
 

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -311,12 +311,7 @@ class Table(ExprContainer):
         super(Table, self).__init__()
 
         self._tir = tir
-
-        r = Renderer(stop_at_jir=True)
-        code = r(tir)
-        ir_map = {name: jir for name, jir in r.jirs.items()}
-
-        self._jtir = Env.hail().expr.Parser.parse_table_ir(code, {}, ir_map)
+        self._jtir = tir.to_java_ir()
         self._jt = Env.hail().table.Table(Env.hc()._jhc, self._jtir)
         self._tir._jir = self._jtir
 

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -313,7 +313,6 @@ class Table(ExprContainer):
         self._tir = tir
         self._jtir = tir.to_java_ir()
         self._jt = Env.hail().table.Table(Env.hc()._jhc, self._jtir)
-        self._tir._jir = self._jtir
 
         jttype = self._jtir.typ()
 

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -209,7 +209,7 @@ class GroupedTable(ExprContainer):
 
         base, cleanup = self._parent._process_joins(*group_exprs.values(), *named_exprs.values())
 
-        return Table(base._jt.keyByAndAggregate(
+        return Table._from_java(base._jt.keyByAndAggregate(
             str(hl.struct(**named_exprs)._ir),
             str(hl.struct(**group_exprs)._ir),
             joption(self._npartitions),
@@ -304,22 +304,30 @@ class Table(ExprContainer):
     """
 
     @staticmethod
-    def _from_ir(table_ir):
-        jir = Env.hail().expr.Parser.parse_table_ir(str(table_ir))
-        return Table(Env.hail().table.Table(Env.hc()._jhc, jir))
+    def _from_java(jt):
+        return Table(JavaTable(jt.tir()))
 
-    def __init__(self, jt):
+    def __init__(self, tir):
         super(Table, self).__init__()
 
-        self._jt = jt
+        self._tir = tir
+
+        r = Renderer(stop_at_jir=False)
+        code = r(tir)
+        env = {name: ir._jir for name, ir in r.jirs.items()}
+
+        self._jtir = Env.hail().expr.Parser.parse_table_ir(code, env)
+        self._jt = Env.hail().table.Table(Env.hc()._jhc, self._jtir)
+
+        jttype = self._jtir.typ()
 
         self._row_axis = 'row'
 
         self._global_indices = Indices(axes=set(), source=self)
         self._row_indices = Indices(axes={self._row_axis}, source=self)
 
-        self._global_type = HailType._from_java(jt.globalSignature())
-        self._row_type = HailType._from_java(jt.signature())
+        self._global_type = HailType._from_java(jttype.globalType())
+        self._row_type = HailType._from_java(jttype.rowType())
 
         assert isinstance(self._global_type, tstruct)
         assert isinstance(self._row_type, tstruct)
@@ -331,7 +339,7 @@ class Table(ExprContainer):
                                   'row': self._row_indices}
 
         self._key = hail.struct(
-            **{k: self._row[k] for k in jiterable_to_list(jt.key())})
+            **{k: self._row[k] for k in jiterable_to_list(jttype.key())})
 
         for k, v in itertools.chain(self._globals.items(),
                                     self._row.items()):
@@ -395,7 +403,7 @@ class Table(ExprContainer):
         -------
         :obj:`int`
         """
-        return self._jt.count()
+        return Env.hc()._backend.interpret(TableCount(self._tir))
 
     def _force_count(self):
         return self._jt.forceCount()
@@ -405,13 +413,13 @@ class Table(ExprContainer):
     def _select(self, caller, row):
         analyze(caller, row, self._row_indices)
         base, cleanup = self._process_joins(row)
-        return cleanup(Table(base._jt.mapRows(str(row._ir))))
+        return cleanup(Table(TableMapRows(base._tir, row._ir)))
 
     @typecheck_method(caller=str, s=expr_struct())
     def _select_globals(self, caller, s):
         base, cleanup = self._process_joins(s)
         analyze(caller, s, self._global_indices)
-        return cleanup(Table(base._jt.selectGlobal(str(s._ir))))
+        return cleanup(Table(TableMapGlobals(base._tir, s._ir)))
 
     @classmethod
     @typecheck_method(rows=anytype,
@@ -451,7 +459,7 @@ class Table(ExprContainer):
         if not isinstance(rows.dtype.element_type, tstruct):
             raise TypeError("'parallelize' expects an array with element type 'struct', found '{}'"
                             .format(rows.dtype))
-        table = Table(Env.hail().table.Table.parallelize(str(rows._ir), joption(n_partitions)))
+        table = Table(TableParallelize(rows._ir, n_partitions))
         if key is not None:
             table = table.key_by(*key)
         return table
@@ -514,7 +522,7 @@ class Table(ExprContainer):
         new_row = self.row.annotate(**key_fields)
         base, cleanup = self._process_joins(new_row)
 
-        return cleanup(Table(
+        return cleanup(Table._from_java(
             base._jt
                 .keyBy([])
                 .mapRows(str(new_row._ir))
@@ -777,7 +785,7 @@ class Table(ExprContainer):
         analyze('Table.filter', expr, self._row_indices)
         base, cleanup = self._process_joins(expr)
 
-        return cleanup(Table(base._jt.filter(str(expr._ir), keep)))
+        return cleanup(Table._from_java(base._jt.filter(str(expr._ir), keep)))
 
     @typecheck_method(exprs=oneof(Expression, str),
                       named_exprs=anytype)
@@ -1323,7 +1331,7 @@ class Table(ExprContainer):
             def joiner(left):
                 if not is_key:
                     original_key = list(left.key)
-                    left = Table(left.key_by()._jt.mapRows(str(Apply('annotate',
+                    left = Table._from_java(left.key_by()._jt.mapRows(str(Apply('annotate',
                                                              left._row._ir,
                                                              hl.struct(**dict(zip(uids, exprs)))._ir)))
                                  ).key_by(*uids)
@@ -1332,9 +1340,9 @@ class Table(ExprContainer):
                     rekey_f = identity
 
                 if is_interval:
-                    left = Table(left._jt.intervalJoin(self._jt, uid))
+                    left = Table._from_java(left._jt.intervalJoin(self._jt, uid))
                 else:
-                    left = Table(left._jt.leftJoinRightDistinct(self._jt, uid))
+                    left = Table._from_java(left._jt.leftJoinRightDistinct(self._jt, uid))
                 return rekey_f(left)
 
             all_uids.append(uid)
@@ -1433,7 +1441,7 @@ class Table(ExprContainer):
             if isinstance(obj, MatrixTable):
                 return MatrixTable(Env.jutils().joinGlobals(obj._jvds, self._jt, uid))
             assert isinstance(obj, Table)
-            return Table(Env.jutils().joinGlobals(obj._jt, self._jt, uid))
+            return Table._from_java(Env.jutils().joinGlobals(obj._jt, self._jt, uid))
 
         ir = Join(GetField(TopLevelReference('global'), uid),
                   [uid],
@@ -1501,7 +1509,7 @@ class Table(ExprContainer):
         :class:`.Table`
             Persisted table.
         """
-        return Table(self._jt.persist(storage_level))
+        return Table._from_java(self._jt.persist(storage_level))
 
     def unpersist(self):
         """
@@ -1517,7 +1525,7 @@ class Table(ExprContainer):
         :class:`.Table`
             Unpersisted table.
         """
-        return Table(self._jt.unpersist())
+        return Table._from_java(self._jt.unpersist())
 
     def collect(self):
         """Collect the rows of the table into a local list.
@@ -1660,7 +1668,7 @@ class Table(ExprContainer):
                 raise ValueError(f"'union': table {i} has a different key."
                                 f"  Expected:  {left_key}\n"
                                 f"  Table {i}: {right_key}")
-        return Table(self._jt.union([table._jt for table in tables]))
+        return Table._from_java(self._jt.union([table._jt for table in tables]))
 
     @typecheck_method(n=int)
     def take(self, n):
@@ -1727,7 +1735,7 @@ class Table(ExprContainer):
             Table including the first `n` rows.
         """
 
-        return Table(self._jt.head(n))
+        return Table._from_java(self._jt.head(n))
 
     @typecheck_method(p=numeric,
                       seed=nullable(int))
@@ -1791,7 +1799,7 @@ class Table(ExprContainer):
             Repartitioned table.
         """
 
-        return Table(self._jt.repartition(n, shuffle))
+        return Table._from_java(self._jt.repartition(n, shuffle))
 
     @typecheck_method(right=table_type,
                       how=enumeration('inner', 'outer', 'left', 'right'),
@@ -1886,7 +1894,7 @@ class Table(ExprContainer):
             info(f'Table.join: renamed the following fields on the right to avoid name conflicts:' +
                  ''.join(f'\n    {repr(k)} -> {repr(v)}' for k, v in renames.items()))
 
-        return Table(self._jt.join(right._jt, how))
+        return Table._from_java(self._jt.join(right._jt, how))
 
     @typecheck_method(expr=BooleanExpression)
     def all(self, expr):
@@ -1981,7 +1989,7 @@ class Table(ExprContainer):
         stray = set(mapping.keys()) - set(seen.values())
         if stray:
             raise ValueError(f"found rename rules for fields not present in table: {list(stray)}")
-        return Table(self._jt.rename(row_map, global_map))
+        return Table._from_java(self._jt.rename(row_map, global_map))
 
     def expand_types(self):
         """Expand complex types into structs and arrays.
@@ -2013,7 +2021,7 @@ class Table(ExprContainer):
             t = self
         else:
             t = self.key_by()
-        return Table(t._jt.expandTypes())
+        return Table._from_java(t._jt.expandTypes())
 
     def flatten(self):
         """Flatten nested structs.
@@ -2079,7 +2087,7 @@ class Table(ExprContainer):
             t = self
         else:
             t = self.key_by()
-        return Table(t._jt.flatten())
+        return Table._from_java(t._jt.flatten())
 
     @typecheck_method(exprs=oneof(str, Expression, Ascending, Descending))
     def order_by(self, *exprs):
@@ -2144,7 +2152,7 @@ class Table(ExprContainer):
                         raise ValueError("Sort fields must be row-indexed, found global field '{}'".format(e))
                     e.col = self._fields_inverse[e.col]
                     sort_cols.append(e._j_obj())
-        return Table(self._jt.orderBy(jarray(Env.hail().table.SortField, sort_cols)))
+        return Table._from_java(self._jt.orderBy(jarray(Env.hail().table.SortField, sort_cols)))
 
     @typecheck_method(field=oneof(str, Expression),
                       name=nullable(str))
@@ -2247,7 +2255,7 @@ class Table(ExprContainer):
                 raise ValueError(f"method 'explode' cannot explode a key field")
 
         f = self._fields_inverse[field]
-        t = Table(self._jt.explode(f))
+        t = Table._from_java(self._jt.explode(f))
         if name is not None:
             t = t.rename({f: name})
         return t
@@ -2415,7 +2423,7 @@ class Table(ExprContainer):
         :class:`.Table`
             Table constructed from the Spark SQL DataFrame.
         """
-        return Table(Env.hail().table.Table.fromDF(Env.hc()._jhc, df._jdf, key))
+        return Table._from_java(Env.hail().table.Table.fromDF(Env.hc()._jhc, df._jdf, key))
 
     @typecheck_method(flatten=bool)
     def to_spark(self, flatten=True):
@@ -2538,7 +2546,7 @@ class Table(ExprContainer):
         -------
         :class:`.Table`
         """
-        return Table(self._jt.groupByKey(name))
+        return Table._from_java(self._jt.groupByKey(name))
 
     def distinct(self) -> 'Table':
         """Keep only one row for each unique key.
@@ -2583,11 +2591,11 @@ class Table(ExprContainer):
         -------
         :class:`.Table`
         """
-        return Table(self._jt.distinctByKey())
+        return Table._from_java(self._jt.distinctByKey())
 
     @typecheck_method(parts=sequenceof(int), keep=bool)
     def _filter_partitions(self, parts, keep=True):
-        return Table(self._jt.filterPartitions(parts, keep))
+        return Table._from_java(self._jt.filterPartitions(parts, keep))
 
     @typecheck_method(cols=table_type, entries_field_name=str)
     def _unlocalize_entries(self, cols, entries_field_name):

--- a/hail/python/hail/utils/backend.py
+++ b/hail/python/hail/utils/backend.py
@@ -19,7 +19,7 @@ class SparkBackend(Backend):
         code = r(ir)
         ir_map = {name: jir for name, jir in r.jirs.items()}
 
-        jir = ir.parse(code, {}, ir_map)
+        jir = ir.to_java_ir()
 
         typ = HailType._from_java(jir.typ())
         result = Env.hail().expr.ir.Interpret.interpretPyIR(code, {}, ir_map)

--- a/hail/python/hail/utils/backend.py
+++ b/hail/python/hail/utils/backend.py
@@ -1,0 +1,27 @@
+import abc
+
+from hail.utils.java import *
+from hail.expr.types import HailType
+from hail.ir.renderer import Renderer
+
+
+class Backend(object):
+    @abc.abstractmethod
+    def interpret(self, ir):
+        return
+
+
+class SparkBackend(Backend):
+    def interpret(self, ir):
+        assert isinstance(ir, hail.ir.IR)
+
+        r = Renderer(stop_at_jir=False)
+        code = r(ir)
+        ir_map = {name: ir._jir for name, ir in r.jirs.items()}
+
+        jir = Env.hail().expr.Parser.parse_value_ir(code, {}, ir_map)
+
+        typ = HailType._from_java(jir.typ())
+        result = Env.hail().expr.ir.Interpret.interpretPyIR(code, {}, ir_map)
+
+        return typ._from_json(result)

--- a/hail/python/hail/utils/backend.py
+++ b/hail/python/hail/utils/backend.py
@@ -15,9 +15,9 @@ class SparkBackend(Backend):
     def interpret(self, ir):
         assert isinstance(ir, hail.ir.IR)
 
-        r = Renderer(stop_at_jir=False)
+        r = Renderer(stop_at_jir=True)
         code = r(ir)
-        ir_map = {name: ir._jir for name, ir in r.jirs.items()}
+        ir_map = {name: jir for name, jir in r.jirs.items()}
 
         jir = Env.hail().expr.Parser.parse_value_ir(code, {}, ir_map)
 

--- a/hail/python/hail/utils/backend.py
+++ b/hail/python/hail/utils/backend.py
@@ -19,7 +19,7 @@ class SparkBackend(Backend):
         code = r(ir)
         ir_map = {name: jir for name, jir in r.jirs.items()}
 
-        jir = Env.hail().expr.Parser.parse_value_ir(code, {}, ir_map)
+        jir = ir.parse(code, {}, ir_map)
 
         typ = HailType._from_java(jir.typ())
         result = Env.hail().expr.ir.Interpret.interpretPyIR(code, {}, ir_map)

--- a/hail/python/hail/utils/misc.py
+++ b/hail/python/hail/utils/misc.py
@@ -93,7 +93,7 @@ def range_table(n, n_partitions=None) -> 'hail.Table':
     if n_partitions is not None:
         check_positive_and_in_range('range_table', 'n_partitions', n_partitions)
 
-    return hail.Table(Env.hail().table.Table.range(Env.hc()._jhc, n, joption(n_partitions)))
+    return hail.Table._from_java(Env.hail().table.Table.range(Env.hc()._jhc, n, joption(n_partitions)))
 
 def check_positive_and_in_range(caller, name, value):
     if value <= 0:

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -111,7 +111,7 @@ class ValueIRTests(unittest.TestCase):
                'x': hl.tint32}
         env = {name: t._jtype for name, t in env.items()}
         for x in self.value_irs():
-            Env.hail().expr.Parser.parse_value_ir(str(x), env)
+            Env.hail().expr.Parser.parse_value_ir(str(x), env, {})
 
     def test_copies(self):
         for x in self.value_irs():
@@ -254,5 +254,5 @@ class ValueTests(unittest.TestCase):
                 ir.InsertFields(
                     ir.Ref("global"),
                     [("foo", row_v)]))
-            new_globals = hl.eval(hl.Table._from_ir(map_globals_ir).globals)
+            new_globals = hl.eval(hl.Table(map_globals_ir).globals)
             self.assertEquals(new_globals, hl.Struct(foo=v))

--- a/hail/src/main/scala/is/hail/expr/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/Parser.scala
@@ -701,12 +701,17 @@ object Parser extends JavaTokenParsers {
   def parse_value_ir(s: String, env: IRParserEnvironment): IR = parse(ir_value_expr(env), s)
 
   def parse_named_value_irs(s: String): Array[(String, IR)] = parse_named_value_irs(s, IRParserEnvironment())
+  def parse_named_value_irs(s: String, refMap: java.util.HashMap[String, Type], irMap: java.util.HashMap[String, BaseIR]): Array[(String, IR)] =
+    parse_named_value_irs(s, IRParserEnvironment(refMap.asScala.toMap, irMap.asScala.toMap))
   def parse_named_value_irs(s: String, env: IRParserEnvironment): Array[(String, IR)] = parse(ir_named_value_exprs(env), s).toArray
 
   def parse_table_ir(s: String): TableIR = parse_table_ir(s, IRParserEnvironment())
-  def parse_table_ir(s: String, irMap: java.util.HashMap[String, BaseIR]): TableIR = parse(table_ir(IRParserEnvironment(irMap = irMap.asScala.toMap)), s)
+  def parse_table_ir(s: String, refMap: java.util.HashMap[String, Type], irMap: java.util.HashMap[String, BaseIR]): TableIR =
+    parse_table_ir(s, IRParserEnvironment(refMap.asScala.toMap, irMap.asScala.toMap))
   def parse_table_ir(s: String, env: IRParserEnvironment): TableIR = parse(table_ir(env), s)
 
   def parse_matrix_ir(s: String): MatrixIR = parse(matrix_ir(IRParserEnvironment()), s)
+  def parse_matrix_ir(s: String, refMap: java.util.HashMap[String, Type], irMap: java.util.HashMap[String, BaseIR]): MatrixIR =
+    parse_matrix_ir(s, IRParserEnvironment(refMap.asScala.toMap, irMap.asScala.toMap))
   def parse_matrix_ir(s: String, env: IRParserEnvironment): MatrixIR = parse(matrix_ir(env), s)
 }

--- a/hail/src/main/scala/is/hail/expr/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/Parser.scala
@@ -579,7 +579,8 @@ object Parser extends JavaTokenParsers {
       "ApplySeeded" ~> ir_identifier ~ int64_literal ~ ir_children(env) ^^ { case function ~ seed ~ args => ir.ApplySeeded(function, args, seed) } |
       ("ApplyIR" | "ApplySpecial" | "Apply") ~> ir_identifier ~ ir_children(env) ^^ { case function ~ args => ir.invoke(function, args: _*) } |
       "Uniroot" ~> ir_identifier >> { name => ir_value_expr(env + (name -> TFloat64())) ~ ir_value_expr(env) ~ ir_value_expr(env) ^^ { case f ~ min ~ max => ir.Uniroot(name, f, min, max) }} |
-      "JavaIR" ~> ir_identifier ^^ { name => env.irMap(name).asInstanceOf[IR] }
+      "JavaIR" ~> ir_identifier ^^ { name => env.irMap(name).asInstanceOf[IR] } |
+      "TableCount" ~> table_ir(env) ^^ { child => ir.TableCount(child) }
   }
 
   def ir_value: Parser[(Type, Any)] = type_expr ~ string_literal ^^ { case t ~ vJSONStr =>
@@ -695,13 +696,15 @@ object Parser extends JavaTokenParsers {
   }
 
   def parse_value_ir(s: String): IR = parse_value_ir(s, IRParserEnvironment())
-  def parse_value_ir(s: String, refMap: java.util.HashMap[String, Type]): IR = parse_value_ir(s, IRParserEnvironment(refMap = refMap.asScala.toMap))
+  def parse_value_ir(s: String, refMap: java.util.HashMap[String, Type], irMap: java.util.HashMap[String, BaseIR]): IR =
+    parse_value_ir(s, IRParserEnvironment(refMap.asScala.toMap, irMap.asScala.toMap))
   def parse_value_ir(s: String, env: IRParserEnvironment): IR = parse(ir_value_expr(env), s)
 
   def parse_named_value_irs(s: String): Array[(String, IR)] = parse_named_value_irs(s, IRParserEnvironment())
   def parse_named_value_irs(s: String, env: IRParserEnvironment): Array[(String, IR)] = parse(ir_named_value_exprs(env), s).toArray
 
   def parse_table_ir(s: String): TableIR = parse_table_ir(s, IRParserEnvironment())
+  def parse_table_ir(s: String, irMap: java.util.HashMap[String, BaseIR]): TableIR = parse(table_ir(IRParserEnvironment(irMap = irMap.asScala.toMap)), s)
   def parse_table_ir(s: String, env: IRParserEnvironment): TableIR = parse(table_ir(env), s)
 
   def parse_matrix_ir(s: String): MatrixIR = parse(matrix_ir(IRParserEnvironment()), s)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -730,6 +730,8 @@ class IRSuite extends SparkSuite {
 
     val takeBySig = AggSignature(TakeBy(), Seq(TInt32()), None, Seq(TFloat64(), TInt32()))
 
+    val table = TableRange(100, 10)
+
     val irs = Array(
       i, I64(5), F32(3.14f), F64(3.14), str, True(), False(), Void(),
       Cast(i, TFloat64()),
@@ -777,7 +779,8 @@ class IRSuite extends SparkSuite {
       invoke("&&", b, c), // ApplySpecial
       invoke("toFloat64", i), // Apply
       Uniroot("x", F64(3.14), F64(-5.0), F64(5.0)),
-      Literal(TStruct("x" -> TInt32()), Row(1))
+      Literal(TStruct("x" -> TInt32()), Row(1)),
+      TableCount(table)
     )
     irs.map(x => Array(x))
   }


### PR DESCRIPTION
@cseed - Here's the minimal changes needed as a proof of concept. I converted `_select` to use `TableMapRows`, `_select_globals` to use `TableMapGlobals`, `count` to use `TableCount`, and `parallelize` to use `TableParallelize`.

Future to-do items:
- Add TVoid type to Python (interpret needs to know how to return the result -- i.e. TableExport)
- Add parser support and tests for TableExport, TableAggregate, and TableWrite.
- Fix pretty/parser/Python render for some IRs such as TableRange
