### PR TITLE
deploy artifacts as 0.2, not devel

### DIFF
--- a/hail/hail-ci-deploy.sh
+++ b/hail/hail-ci-deploy.sh
@@ -2,7 +2,7 @@
 set -ex
 
 SPARK_VERSION=2.2.0
-BRANCH=devel
+BRANCH=0.2
 CLOUDTOOLS_VERSION=2
 HASH_TARGET=gs://hail-common/builds/${BRANCH}/latest-hash/cloudtools-${CLOUDTOOLS_VERSION}-spark-${SPARK_VERSION}.txt
 SHA=$(git rev-parse --short=12 HEAD)


### PR DESCRIPTION
This will fix the upload location for 0.2 artifacts, and therefore the broken distribution download link.