### PR TITLE
Add secrets to scorecard gitignore

### DIFF
--- a/scorecard/.gitignore
+++ b/scorecard/.gitignore
@@ -1,2 +1,3 @@
 /deployment.yaml
 /scorecard-image
+/secrets/


### PR DESCRIPTION
There is an assumption that the secrets file for scorecard will be in a folder called secrets in the scorecard directory. This makes sure that it is harder to commit github API tokens.