### PR TITLE
Letsencrypt

### DIFF
--- a/gateway/hail.nginx.conf.in
+++ b/gateway/hail.nginx.conf.in
@@ -3,7 +3,18 @@ server {
     listen [::]:80 default_server;
     server_name _;
     
-    return 301 https://$host$request_uri;
+    location /.well-known/acme-challenge {
+        proxy_pass http://letsencrypt;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
 }
 
 server {

--- a/letsencrypt/.gitignore
+++ b/letsencrypt/.gitignore
@@ -1,0 +1,2 @@
+/letsencrypt.sh
+/letsencrypt-pod.yaml

--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -8,7 +8,10 @@ RUN bash -c 'DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata'
 
 RUN add-apt-repository -y ppa:certbot/certbot
 RUN apt-get update -y
-RUN apt-get install -y python-certbot-nginx
+RUN apt-get install -y python-certbot-nginx wget
+
+RUN wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubectl && \
+    chmod +x /usr/local/bin/kubectl
 
 RUN rm -f /etc/nginx/sites-enabled/default
 ADD letsencrypt.nginx.conf /etc/nginx/conf.d/letsencrypt.conf

--- a/letsencrypt/Dockerfile
+++ b/letsencrypt/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:18.04
+
+RUN apt-get update -y
+
+# get add-apt-repository
+RUN apt-get install -y nginx software-properties-common
+RUN bash -c 'DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata'
+
+RUN add-apt-repository -y ppa:certbot/certbot
+RUN apt-get update -y
+RUN apt-get install -y python-certbot-nginx
+
+RUN rm -f /etc/nginx/sites-enabled/default
+ADD letsencrypt.nginx.conf /etc/nginx/conf.d/letsencrypt.conf
+
+ADD letsencrypt.sh /
+
+CMD ["/bin/bash", "/letsencrypt.sh"]

--- a/letsencrypt/Makefile
+++ b/letsencrypt/Makefile
@@ -1,0 +1,26 @@
+.PHONY: build push run clean
+
+PROJECT = $(shell gcloud config get-value project)
+DOMAIN ?= hail.is
+IP ?= 35.224.105.117
+
+STATIC_CONFIG = letsencrypt-pod.yaml letsencrypt.sh
+
+$(STATIC_CONFIG): %: %.in
+	sed -e "s,@project@,$(PROJECT),g" \
+	  -e "s,@domain@,$(DOMAIN),g" \
+	  -e "s,@ip@,$(IP),g" \
+	  < $< > $@
+
+build: letsencrypt.sh
+	docker build -t letsencrypt .
+
+push: build
+	docker tag letsencrypt gcr.io/$(PROJECT)/letsencrypt
+	docker push gcr.io/$(PROJECT)/letsencrypt
+
+run: letsencrypt-pod.yaml service.yaml push
+	/bin/bash run-letsencrypt.sh
+
+clean:
+	rm -rf $(STATIC_CONFIG)

--- a/letsencrypt/certs-volume.yaml
+++ b/letsencrypt/certs-volume.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: letsencrypt-certs
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Mi

--- a/letsencrypt/letsencrypt-pod.yaml.in
+++ b/letsencrypt/letsencrypt-pod.yaml.in
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: letsencrypt
+  labels:
+    app: letsencrypt
+spec:
+  containers:
+  - name: letsencrypt
+    image: gcr.io/@project@/letsencrypt
+    ports:
+    - containerPort: 80
+    volumeMounts:
+      - mountPath: /etc/letsencrypt
+        name: letsencrypt-certs
+  restartPolicy: Never
+  volumes:
+    - name: letsencrypt-certs
+      persistentVolumeClaim:
+        claimName: letsencrypt-certs

--- a/letsencrypt/letsencrypt.nginx.conf
+++ b/letsencrypt/letsencrypt.nginx.conf
@@ -1,0 +1,6 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    root /var/www/html;
+    server_name _;
+}

--- a/letsencrypt/letsencrypt.sh.in
+++ b/letsencrypt/letsencrypt.sh.in
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+/etc/init.d/nginx start
+
+sleep 5
+
+rm -rf /etc/letsencrypt/*
+
+certbot --test-cert --cert-name @domain@ -n --agree-tos -m cseed@broadinstitute.org -d @domain@ -d www.@domain@ -d ci.@domain@ -d upload.@domain@ -d scorecard.@domain@ -d notebook.@domain@ -d test.@domain@ -d dev1.@domain@ --nginx
+
+cat /etc/nginx/conf.d/letsencrypt.conf

--- a/letsencrypt/letsencrypt.sh.in
+++ b/letsencrypt/letsencrypt.sh.in
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ex
 
 /etc/init.d/nginx start
 
@@ -6,6 +7,21 @@ sleep 5
 
 rm -rf /etc/letsencrypt/*
 
-certbot --test-cert --cert-name @domain@ -n --agree-tos -m cseed@broadinstitute.org -d @domain@ -d www.@domain@ -d ci.@domain@ -d upload.@domain@ -d scorecard.@domain@ -d notebook.@domain@ -d test.@domain@ -d dev1.@domain@ --nginx
+# test 
+certbot --cert-name @domain@ -n --agree-tos -m cseed@broadinstitute.org -d @domain@ -d www.@domain@ -d ci.@domain@ -d upload.@domain@ -d scorecard.@domain@ -d notebook.@domain@ -d test.@domain@ -d dev1.@domain@ --nginx
 
 cat /etc/nginx/conf.d/letsencrypt.conf
+
+cat | kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: letsencrypt-config
+  namespace: default
+type: Opaque
+data:
+  fullchain.pem: $(base64 -w 0 /etc/letsencrypt/live/@domain@/fullchain.pem)
+  options-ssl-nginx.conf: $(base64 -w 0 /etc/letsencrypt/options-ssl-nginx.conf)
+  privkey.pem: $(base64 -w 0 /etc/letsencrypt/live/@domain@/privkey.pem)
+  ssl-dhparams.pem: $(base64 -w 0 /etc/letsencrypt/ssl-dhparams.pem)
+EOF

--- a/letsencrypt/run-letsencrypt.sh
+++ b/letsencrypt/run-letsencrypt.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -ex
+
+# start service
+kubectl apply -f service.yaml
+
+# stop existing letsencrypt pod
+kubectl delete pod --ignore-not-found=true letsencrypt
+N=
+while [[ $N != 0 ]]; do
+    sleep 5
+    N=$(kubectl get pod --ignore-not-found=true --no-headers letsencrypt | wc -l | tr -d '[:space:]')
+    echo N=$N
+done
+
+# run letsencrypt pod
+kubectl create -f letsencrypt-pod.yaml
+echo "Waiting for letsencrypt to complete..."
+EC=""
+while [[ $EC = "" ]]; do
+    sleep 5
+    EC=$(kubectl get pod -o "jsonpath={.status.containerStatuses[0].state.terminated.exitCode}" letsencrypt)
+    echo EC=$EC
+done
+kubectl logs letsencrypt
+if [[ $EC != 0 ]]; then
+    exit $EC
+fi
+
+# cleanup
+kubectl delete pod --ignore-not-found=true letsencrypt

--- a/letsencrypt/service.yaml
+++ b/letsencrypt/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: letsencrypt
+  labels:
+    app: letsencrypt
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: letsencrypt


### PR DESCRIPTION
Added back letsencrypt as (non-deployable) letsencrypt project.

Have gateway redirect the challenge to the letsencrypt service/pod.  letsencrypt pod includes kubectl and updates the secret.  Get cert for notebook.hail.is.  Current certs were generated with this.

Two more things to do:
 - run a process in gateway container to reload nginx when secrets change, and
 - set up renew cron job.
