### PR TITLE
RegionValueBuilder: Enable a random access pattern for arrays of non-required types

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
@@ -167,12 +167,7 @@ class RegionValueBuilder(var region: Region) {
     val length = t.loadLength(region, aoff)
     assert(length == indexstk.top)
 
-    typestk.pop()
-    offsetstk.pop()
-    elementsOffsetstk.pop()
-    indexstk.pop()
-
-    advance()
+    endArrayUnchecked()
   }
 
   // using this function, rather than startArray will set all elements of the array to missing by

--- a/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
@@ -230,6 +230,8 @@ class RegionValueBuilder(var region: Region) {
   def setPresent() {
     val i = indexstk.top
     typestk.top match {
+      case t: PBaseStruct =>
+        t.setFieldPresent(region, offsetstk.top, i)
       case t: PArray =>
         t.setElementPresent(region, offsetstk.top, i)
     }

--- a/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
@@ -175,7 +175,9 @@ class RegionValueBuilder(var region: Region) {
     advance()
   }
 
-  def startRandomArray(length: Int, init: Boolean = true) {
+  // using this function, rather than startArray will set all elements of the array to missing by
+  // default, you will need to use setPresent to add a value to this array.
+  def startMissingArray(length: Int, init: Boolean = true) {
     val t = currentType().asInstanceOf[PArray]
     if (t.elementType.required)
       fatal(s"cannot use random array pattern for required type ${ t.elementType }")
@@ -196,11 +198,7 @@ class RegionValueBuilder(var region: Region) {
       t.initialize(region, aoff, length, setMissing = true)
   }
 
-  def endRandomArray() {
-    val t = typestk.top.asInstanceOf[PArray]
-    val aoff = offsetstk.top
-    val length = t.loadLength(region, aoff)
-
+  def endArrayUnchecked() {
     typestk.pop()
     offsetstk.pop()
     elementsOffsetstk.pop()

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -174,6 +174,16 @@ abstract class PBaseStruct extends PType {
     region.setBit(offset, missingIdx(fieldIdx))
   }
 
+  def setFieldPresent(region: Region, offset: Long, fieldIdx: Int) {
+    assert(!fieldRequired(fieldIdx))
+    region.clearBit(offset, missingIdx(fieldIdx))
+  }
+
+  def setFieldPresent(region: Code[Region], offset: Code[Long], fieldIdx: Int): Code[Unit] = {
+    assert(!fieldRequired(fieldIdx))
+    region.clearBit(offset, missingIdx(fieldIdx))
+  }
+
   def fieldOffset(offset: Long, fieldIdx: Int): Long =
     offset + byteOffsets(fieldIdx)
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
@@ -89,6 +89,15 @@ abstract class PContainer extends PType {
     region.setBit(aoff + 4L, i.toL)
   }
 
+  def setElementPresent(region: Region, aoff: Long, i: Int) {
+    assert(!elementType.required)
+    region.clearBit(aoff + 4, i)
+  }
+
+  def setElementPresent(region: Code[Region], aoff: Code[Long], i: Code[Int]): Code[Unit] = {
+    region.clearBit(aoff + 4L, i.toL)
+  }
+
   def elementOffset(aoff: Long, length: Int, i: Int): Long =
     aoff + elementsOffset(length) + i * elementByteSize
 
@@ -127,6 +136,17 @@ abstract class PContainer extends PType {
     region.allocate(contentsAlignment, contentsByteSize(length))
   }
 
+  def setAllMissingBits(region: Region, aoff: Long, length: Int) {
+    if (elementType.required)
+      return
+    val nMissingBytes = (length + 7) / 8
+    var i = 0
+    while (i < nMissingBytes) {
+      region.storeByte(aoff + 4 + i, -1)
+      i += 1
+    }
+  }
+
   def clearMissingBits(region: Region, aoff: Long, length: Int) {
     if (elementType.required)
       return
@@ -138,9 +158,12 @@ abstract class PContainer extends PType {
     }
   }
 
-  def initialize(region: Region, aoff: Long, length: Int) {
+  def initialize(region: Region, aoff: Long, length: Int, setMissing: Boolean = false) {
     region.storeInt(aoff, length)
-    clearMissingBits(region, aoff, length)
+    if (setMissing)
+      setAllMissingBits(region, aoff, length)
+    else
+      clearMissingBits(region, aoff, length)
   }
 
   def initialize(region: Code[Region], aoff: Code[Long], length: Code[Int], a: Settable[Int]): Code[Unit] = {


### PR DESCRIPTION
An example of the new pattern is:

```scala
rvb.startMissingArray(10)
rvb.setArrayIndex(5)
rvb.setPresent()
rvb.startStruct()
// ... add struct fields here
rvb.endStruct()
rvb.endArrayUnchecked()
```