### PR TITLE
[Notebook] Image Fetcher

### DIFF
--- a/image-fetcher/.gitignore
+++ b/image-fetcher/.gitignore
@@ -1,0 +1,2 @@
+images
+image-fetcher-image

--- a/image-fetcher/Dockerfile
+++ b/image-fetcher/Dockerfile
@@ -1,0 +1,14 @@
+FROM docker:dind
+MAINTAINER hail-team@broadinstitute.org
+
+RUN apk --no-cache add \
+    bash \
+    curl \
+    python
+
+RUN curl -sSL https://sdk.cloud.google.com | bash
+ENV PATH $PATH:/root/google-cloud-sdk/bin
+
+ADD images fetch-image.sh ./
+
+CMD /bin/sh fetch-image.sh

--- a/image-fetcher/Dockerfile
+++ b/image-fetcher/Dockerfile
@@ -1,10 +1,11 @@
-FROM docker:dind
+FROM alpine:3.8
 MAINTAINER hail-team@broadinstitute.org
 
 RUN apk --no-cache add \
     bash \
     curl \
-    python
+    python \
+    docker
 
 RUN curl -sSL https://sdk.cloud.google.com | bash
 ENV PATH $PATH:/root/google-cloud-sdk/bin

--- a/image-fetcher/Makefile
+++ b/image-fetcher/Makefile
@@ -1,0 +1,19 @@
+.PHONY: build push deploy
+
+images: # ../notebook/notebook-worker-image
+	cat /dev/null $< > images
+
+build: images
+	docker build . -t image-fetcher
+
+push: IMAGE = gcr.io/broad-ctsa/image-fetcher:$(shell docker images -q --no-trunc image-fetcher | sed -e 's,[^:]*:,,')
+push: build
+	echo $(IMAGE) > image-fetcher-image
+	docker tag image-fetcher $(IMAGE)
+	docker push $(IMAGE)
+
+deploy: push
+	sed -e "s,@sha@,$(shell git rev-parse --short=12 HEAD)," \
+	  -e "s,@image@,$(shell cat image-fetcher-image)," \
+	  < deployment.yaml.in > deployment.yaml
+	kubectl apply -f deployment.yaml

--- a/image-fetcher/SECRETS.md
+++ b/image-fetcher/SECRETS.md
@@ -1,0 +1,5 @@
+# Secrets
+
+gcr-pull-key:
+ - `gcr-pull.json` a key for a GCP service account with sufficient privileges to
+   pull from gcr.io/broad-ctsa

--- a/image-fetcher/deployment.yaml.in
+++ b/image-fetcher/deployment.yaml.in
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: image-fetcher
+  labels:
+    app: image-fetcher
+    hail.is/sha: "@sha@"
+spec:
+  selector:
+    matchLabels:
+      app: image-fetcher
+  template:
+    metadata:
+      labels:
+        app: image-fetcher
+        hail.is/sha: "@sha@"
+    spec:
+      containers:
+      - name: image-fetcher
+        image: @image@
+        resources:
+          requests:
+            cpu: 1m
+            memory: 1Mi
+        volumeMounts:
+        - name: docksock
+          mountPath: /var/run/docker.sock
+        - name: gcr-pull-key
+          mountPath: /secrets
+      volumes:
+      - name: docksock
+        hostPath:
+          path: /var/run/docker.sock
+      - name: gcr-pull-key
+        secret:
+          optional: False
+          secretName: gcr-pull-key

--- a/image-fetcher/fetch-image.sh
+++ b/image-fetcher/fetch-image.sh
@@ -9,6 +9,6 @@ gcloud auth configure-docker
 
 while [ 1 ]
 do
-    cat images | xargs docker pull
+    [ $(cat images | wc -l) -eq 0 ] || (cat images | xargs docker pull)
     sleep 10
 done

--- a/image-fetcher/fetch-image.sh
+++ b/image-fetcher/fetch-image.sh
@@ -10,5 +10,5 @@ gcloud auth configure-docker
 while [ 1 ]
 do
     [ $(cat images | wc -l) -eq 0 ] || (cat images | xargs docker pull)
-    sleep 10
+    sleep 360
 done

--- a/image-fetcher/fetch-image.sh
+++ b/image-fetcher/fetch-image.sh
@@ -7,7 +7,7 @@ gcloud auth activate-service-account \
 
 gcloud auth configure-docker
 
-while [ 1 ]
+while true
 do
     [ $(cat images | wc -l) -eq 0 ] || (cat images | xargs docker pull)
     sleep 360

--- a/image-fetcher/fetch-image.sh
+++ b/image-fetcher/fetch-image.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -ex
+
+gcloud auth activate-service-account \
+  --key-file=/secrets/gcr-pull.json
+
+gcloud auth configure-docker
+
+while [ 1 ]
+do
+    cat images | xargs docker pull
+    sleep 10
+done

--- a/image-fetcher/hail-ci-deploy.sh
+++ b/image-fetcher/hail-ci-deploy.sh
@@ -1,0 +1,1 @@
+make deploy

--- a/projects.txt
+++ b/projects.txt
@@ -3,6 +3,7 @@ ci
 cloudtools
 gateway
 hail
+image-fetcher
 letsencrypt
 scorecard
 site


### PR DESCRIPTION
A [daemonset](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) which, given a list of images, constantly tries to keep those images cached on the nodes docker container. Because the preemptible nodes that execute CI builds are tainted, this will only execute on the main nodes and the non-preemptibles, which is the functionality we desire for now because this tool will be used to ensure `notebook` worker images are always cached.

cc: @cseed