### PR TITLE
[Notebook] Add server to Gateway

### DIFF
--- a/gateway/hail.nginx.conf.in
+++ b/gateway/hail.nginx.conf.in
@@ -2,7 +2,7 @@ server {
     listen 80 default_server;
     listen [::]:80 default_server;
     server_name _;
-    
+
     location /.well-known/acme-challenge {
         proxy_pass http://letsencrypt;
 
@@ -49,7 +49,7 @@ server {
 
 server {
     server_name ci.@domain@;
-    
+
     location ~ /(test-ci-[a-z0-9]+)/(.*) {
         resolver kube-dns.kube-system.svc.cluster.local;
         proxy_pass http://$1.batch-pods.svc.cluster.local/$2;
@@ -80,6 +80,58 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Forwarded-Proto https;
+
+    listen [::]:443 ssl;
+    listen 443 ssl;
+    ssl_certificate /etc/letsencrypt/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}
+
+server {
+    server_name notebook.@domain@;
+
+    location = /auth {
+        internal;
+        proxy_pass http://notebook/auth/$jupyter_auth_name;
+    }
+
+    location ~ /instance/([^/]+)/(.*) {
+        set $jupyter_auth_name $1;
+        auth_request /auth;
+
+        resolver kube-dns.kube-system.svc.cluster.local;
+        proxy_pass http://$1.default.svc.cluster.local/instance/$1/$2$is_args$args;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_http_version 1.1;
+        proxy_redirect off;
+        proxy_buffering off;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 86400;
+    }
+
+    location / {
+        proxy_pass http://notebook/;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_http_version 1.1;
+        proxy_redirect off;
+        proxy_buffering off;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 86400;
+    }
 
     listen [::]:443 ssl;
     listen 443 ssl;

--- a/notebook/.gitignore
+++ b/notebook/.gitignore
@@ -1,0 +1,1 @@
+/deployment.yaml

--- a/notebook/Makefile
+++ b/notebook/Makefile
@@ -1,0 +1,7 @@
+.PHONY: deploy
+
+deploy:
+	sed -e "s,@sha@,$(shell git rev-parse --short=12 HEAD)," \
+	  -e "s,@image@,$(shell cat notebook-image)," \
+	  < deployment.yaml.in > deployment.yaml
+	kubectl apply -f deployment.yaml

--- a/notebook/deployment.yaml.in
+++ b/notebook/deployment.yaml.in
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: notebook
+  labels:
+    app: notebook
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 5000
+  selector:
+    app: notebook

--- a/notebook/hail-ci-deploy.sh
+++ b/notebook/hail-ci-deploy.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+make deploy

--- a/projects.txt
+++ b/projects.txt
@@ -1,6 +1,7 @@
 batch
 ci
 cloudtools
+notebook
 gateway
 hail
 letsencrypt


### PR DESCRIPTION
This adds the minimal resources to k8s to allow us to modify the gateway's configuration to include redirects for https://notebook.hail.is. Currently, that domain will timeout, but there should otherwise be no errors introduces to the k8s system.

cc: @cseed
