### PR TITLE
Fix notebook deploy

### DIFF
--- a/notebook/Makefile
+++ b/notebook/Makefile
@@ -4,4 +4,4 @@ deploy:
 	sed -e "s,@sha@,$(shell git rev-parse --short=12 HEAD)," \
 	  -e "s,@image@,$(shell cat notebook-image)," \
 	  < deployment.yaml.in > deployment.yaml
-	kubectl apply -f deployment.yaml -n default
+	kubectl -n default apply -f deployment.yaml

--- a/notebook/Makefile
+++ b/notebook/Makefile
@@ -4,4 +4,4 @@ deploy:
 	sed -e "s,@sha@,$(shell git rev-parse --short=12 HEAD)," \
 	  -e "s,@image@,$(shell cat notebook-image)," \
 	  < deployment.yaml.in > deployment.yaml
-	kubectl apply -f deployment.yaml
+	kubectl apply -f deployment.yaml -n default


### PR DESCRIPTION
fixes  #4656 

The deploy service account does not have privileges to create anything in `batch-pods` (as noted by the error message in #4656). The correct namespace in which to create the notebook service is `default`. That is rectified here with the `-n` or "namespace" argument.