### PR TITLE
A couple more gitignores

### DIFF
--- a/hail/.gitignore
+++ b/hail/.gitignore
@@ -1,5 +1,5 @@
 python/**/*.pyc
-python/hail/dist
+python/dist
 python/hail/docs/_build/*
 src/main/c/.cxx.vsn
 src/main/c/libsimdpp-2*

--- a/hail/.gitignore
+++ b/hail/.gitignore
@@ -1,4 +1,5 @@
 python/**/*.pyc
+python/hail/dist
 python/hail/docs/_build/*
 src/main/c/.cxx.vsn
 src/main/c/libsimdpp-2*

--- a/image-fetcher/.gitignore
+++ b/image-fetcher/.gitignore
@@ -1,2 +1,3 @@
 images
 image-fetcher-image
+deployment.yaml


### PR DESCRIPTION
- `hail/python/dist` is generated by `setup.py` when publishing to PYPI. It is strictly build artifacts and should never be checked in.

- `image-fetcher/deployment.yaml` is auto-generated by the `Makefile`