### PR TITLE
[CI] Refresh From Batch

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -29,7 +29,7 @@ restart-proxy:
 	$(shell gcloud compute \
 	  --project "broad-ctsa" \
 	  ssh \
-	  --zone "us-central1-f" \
+	  --zone "us-central1-a" \
 	  "dk-test" \
 	  --ssh-flag="-R 0.0.0.0:${HAIL_CI_REMOTE_PORT}:127.0.0.1:5000" \
 	  --ssh-flag='-N' \
@@ -49,15 +49,17 @@ restart-batch-proxy:
                          | head -n 1))
 	kubectl port-forward ${BATCH_POD} 8888:5000 > batch-proxy.log 2>batch-proxy.err & echo $$! > batch-proxy.pid
 
-PROXY_IP=35.239.252.237
+
 
 run-local: HAIL_CI_REMOTE_PORT = 3000
+run-local: PROXY_IP=$(shell gcloud compute instances list --filter=name=dk-test | tail -n +2 | awk '{ print $$5 }')
 run-local: restart-all-proxies
 	SELF_HOSTNAME=http://${PROXY_IP}:${HAIL_CI_REMOTE_PORT} \
 	BATCH_SERVER_URL=http://127.0.0.1:${HAIL_CI_LOCAL_BATCH_PORT} \
 	source activate hail-ci && python ci/ci.py
 
 run-local-for-tests: HAIL_CI_REMOTE_PORT = 3001
+run-local-for-tests: PROXY_IP=$(shell gcloud compute instances list --filter=name=dk-test | tail -n +2 | awk '{ print $$5 }')
 run-local-for-tests: restart-all-proxies
 	SELF_HOSTNAME=http://${PROXY_IP}:${HAIL_CI_REMOTE_PORT} \
 	BATCH_SERVER_URL=http://127.0.0.1:${HAIL_CI_LOCAL_BATCH_PORT} \
@@ -65,6 +67,7 @@ run-local-for-tests: restart-all-proxies
 	source activate hail-ci && pip install ./batch && python ci/ci.py
 
 test-locally: HAIL_CI_REMOTE_PORT = 3001
+test-locally: PROXY_IP=$(shell gcloud compute instances list --filter=name=dk-test | tail -n +2 | awk '{ print $$5 }')
 test-locally: restart-all-proxies
 	SELF_HOSTNAME=http://${PROXY_IP}:${HAIL_CI_REMOTE_PORT} \
 	BATCH_SERVER_URL=http://127.0.0.1:${HAIL_CI_LOCAL_BATCH_PORT} \

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -52,14 +52,14 @@ restart-batch-proxy:
 
 
 run-local: HAIL_CI_REMOTE_PORT = 3000
-run-local: PROXY_IP=$(shell gcloud compute instances list --filter=name=dk-test | tail -n +2 | awk '{ print $$5 }')
+run-local: PROXY_IP=$(shell gcloud compute instances list --filter=name=dk-test --format="value(EXTERNAL_IP)")
 run-local: restart-all-proxies
 	SELF_HOSTNAME=http://${PROXY_IP}:${HAIL_CI_REMOTE_PORT} \
 	BATCH_SERVER_URL=http://127.0.0.1:${HAIL_CI_LOCAL_BATCH_PORT} \
 	source activate hail-ci && python ci/ci.py
 
 run-local-for-tests: HAIL_CI_REMOTE_PORT = 3001
-run-local-for-tests: PROXY_IP=$(shell gcloud compute instances list --filter=name=dk-test | tail -n +2 | awk '{ print $$5 }')
+run-local-for-tests: PROXY_IP=$(shell gcloud compute instances list --filter=name=dk-test --format="value(EXTERNAL_IP)")
 run-local-for-tests: restart-all-proxies
 	SELF_HOSTNAME=http://${PROXY_IP}:${HAIL_CI_REMOTE_PORT} \
 	BATCH_SERVER_URL=http://127.0.0.1:${HAIL_CI_LOCAL_BATCH_PORT} \
@@ -67,7 +67,7 @@ run-local-for-tests: restart-all-proxies
 	source activate hail-ci && pip install ./batch && python ci/ci.py
 
 test-locally: HAIL_CI_REMOTE_PORT = 3001
-test-locally: PROXY_IP=$(shell gcloud compute instances list --filter=name=dk-test | tail -n +2 | awk '{ print $$5 }')
+test-locally: PROXY_IP=$(shell gcloud compute instances list --filter=name=dk-test --format="value(EXTERNAL_IP)")
 test-locally: restart-all-proxies
 	SELF_HOSTNAME=http://${PROXY_IP}:${HAIL_CI_REMOTE_PORT} \
 	BATCH_SERVER_URL=http://127.0.0.1:${HAIL_CI_LOCAL_BATCH_PORT} \

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -180,8 +180,7 @@ def refresh_ci_build_jobs(jobs):
                     f'cancelling {job.id}, preferring {job2.id}'
                 )
                 try_to_cancel_job(job)
-    for ((source, target), job) in latest_jobs.items():
-        prs.refresh_from_ci_job(source, target, job)
+    prs.refresh_from_ci_jobs(latest_jobs)
 
 def refresh_deploy_jobs(jobs):
     jobs = [

--- a/ci/ci/pr.py
+++ b/ci/ci/pr.py
@@ -378,7 +378,7 @@ class PR(object):
     def is_approved(self):
         return self.review == 'approved'
 
-    def is_running(self):
+    def is_building(self):
         return isinstance(self.build, Building)
 
     def is_pending_build(self):
@@ -454,6 +454,10 @@ class PR(object):
                 log.info(f'found deploy job {job.id} for wrong target {target}, should be {self.target}')
                 job.delete()
                 return self
+
+    def refresh_from_missing_job(self):
+        assert isinstance(self.build, Buildable)
+        return self.build_it()
 
     def update_from_completed_batch_job(self, job):
         assert isinstance(job, Job)

--- a/ci/ci/prs.py
+++ b/ci/ci/prs.py
@@ -356,6 +356,10 @@ class PRS(object):
         # eagerly heal because a finished job might mean new work to do
         self.heal_target(target.ref)
 
+    def refresh_from_ci_jobs(self, jobs):
+        for ((source, target), job) in jobs.items():
+            self.refresh_from_ci_job(source, target, job)
+
     def refresh_from_ci_job(self, source, target, job):
         assert isinstance(job, Job), job
         assert isinstance(source, FQSHA), source

--- a/ci/test/test-ci.py
+++ b/ci/test/test-ci.py
@@ -166,7 +166,7 @@ def poll_until_finished_pr(source_ref,
                            max_polls=MAX_POLLS):
     return poll_pr(
         source_ref,
-        lambda pr: pr.is_running() or pr.is_pending_build(),
+        lambda pr: pr.is_building() or pr.is_pending_build(),
         delay_in_seconds=delay_in_seconds,
         max_polls=max_polls)
 
@@ -386,7 +386,7 @@ def test_push_while_building(tmpdir):
         # get details on first job of slow branch
         pr[SLOW_BRANCH_NAME] = poll_until_pr_exists_and(
             SLOW_BRANCH_NAME,
-            lambda x: x.is_running())
+            lambda x: x.is_building())
         assertDictHasKVs(
             pr[SLOW_BRANCH_NAME].to_json(),
             {


### PR DESCRIPTION
1. Makefile is a bit more resilient to changes in the `dk-test` instance that is used to route traffic from GitHub to a local laptop test. It now looks up the ip. The zone is still hardcoded and it's moved to zone `us-central1-a`. The name is also hardcoded to `dk-test`.
2. I renamed `is_running` to `is_building`
3. When a job refresh happens, it is now `PRS` responsibility to determine what to do. It starts the same as it always does, updating existing PRs with new job information. The difference is that it tracks which (believed to be) currently building jobs are not seen in the job list. All such jobs are re-built, under the assumption that the job must have failed.

cc: @cseed 

This should allow CI to recover from the loss of batch.

Fixes #4654.