### PR TITLE
[CI] fix review status calculation

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -16,7 +16,7 @@ from google_storage import \
     upload_public_gs_file_from_string
 from http_helper import BadStatus
 from http_helper import get_repo
-from pr import review_status, GitHubPR
+from pr import GitHubPR
 from prs import PRS
 import collections
 import json
@@ -103,15 +103,15 @@ def github_pull_request_review():
             # FIXME: track all reviewers, then we don't need to talk to github
             prs.review(
                 gh_pr,
-                review_status(
+                overall_review_state(
                     get_reviews(gh_pr.target_ref.repo,
                                 gh_pr.number)))
     elif action == 'dismissed':
         # FIXME: track all reviewers, then we don't need to talk to github
         prs.review(
             gh_pr,
-            review_status(get_reviews(gh_pr.target_ref.repo,
-                                      gh_pr.number)))
+            overall_review_state(get_reviews(gh_pr.target_ref.repo,
+                                             gh_pr.number)))
     else:
         log.info(f'ignoring pull_request_review with action {action}')
     return '', 200

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -105,13 +105,13 @@ def github_pull_request_review():
                 gh_pr,
                 overall_review_state(
                     get_reviews(gh_pr.target_ref.repo,
-                                gh_pr.number)))
+                                gh_pr.number))['state'])
     elif action == 'dismissed':
         # FIXME: track all reviewers, then we don't need to talk to github
         prs.review(
             gh_pr,
             overall_review_state(get_reviews(gh_pr.target_ref.repo,
-                                             gh_pr.number)))
+                                             gh_pr.number))['state'])
     else:
         log.info(f'ignoring pull_request_review with action {action}')
     return '', 200

--- a/ci/ci/pr.py
+++ b/ci/ci/pr.py
@@ -16,26 +16,6 @@ import json
 import os
 
 
-def review_status(reviews):
-    latest_state_by_login = {}
-    for review in reviews:
-        login = review['user']['login']
-        state = review['state']
-        # reviews is chronological, so later ones are newer statuses
-        latest_state_by_login[login] = state
-    at_least_one_approved = False
-    for login, state in latest_state_by_login.items():
-        if (state == 'CHANGES_REQUESTED'):
-            return 'changes_requested'
-        elif (state == 'APPROVED'):
-            at_least_one_approved = True
-
-    if at_least_one_approved:
-        return 'approved'
-    else:
-        return 'pending'
-
-
 def try_new_build(source, target):
     img = maybe_get_image(target, source)
     if img:


### PR DESCRIPTION
At some point in the distant past I fixed `refresh_review_state` (full state refresh from GH) but failed to fix `github_pull_request_review` (where web hooks come in). As a result, CI is very confused about https://github.com/hail-is/hail/pull/4644, wherein a `COMMENTED` review came in after a `APPROVED` review. I eliminated the duplicate, incorrect implementation of review status and replaced references to it with references to the correct (and tested) review status function.