### PR TITLE
[notebook] fix get-deployed-sha.sh

### DIFF
--- a/notebook/get-deployed-sha.sh
+++ b/notebook/get-deployed-sha.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -ex
 
-kubectl get --selector=app=notebook deployments -o "jsonpath={.items[*].metadata.labels.hail\.is/sha}"
+kubectl -n default get --selector=app=notebook deployments -o "jsonpath={.items[*].metadata.labels.hail\.is/sha}"


### PR DESCRIPTION
The default namespace of the CI job is batch-pods, so
it fails to find the notebook deployment