### PR TITLE
[ci] Recover from missing deploy jobs as well

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -211,8 +211,7 @@ def refresh_deploy_jobs(jobs):
                     f'cancelling {job.id}, preferring {job2.id}'
                 )
                 try_to_cancel_job(job)
-    for (target, job) in latest_jobs.items():
-        prs.refresh_from_deploy_job(target, job)
+    refresh_from_deploy_jobs(latest_jobs)
 
 @app.route('/force_retest', methods=['POST'])
 def force_retest():

--- a/ci/ci/prs.py
+++ b/ci/ci/prs.py
@@ -331,6 +331,17 @@ class PRS(object):
             self.latest_deployed[target.ref] = target.sha
         job.delete()
 
+    def refresh_from_deploy_jobs(jobs):
+        lost_jobs = {target_ref for target_ref in self.deploy_jobs.keys()}
+        for (target, job) in jobs.items():
+            lost_jobs.discard(target.ref)
+            self.refresh_from_deploy_job(target, job)
+        for target_ref in lost_jobs:
+            log.info(f'{target_ref.short_str()} was not found in batch refresh '
+                     f'and will be treated like a cancelled job')
+            self.deploy_jobs[target.ref].delete()
+            del self.deploy_jobs[target.ref]
+
     def refresh_from_deploy_job(self, target, job):
         assert isinstance(job, Job), job
         assert isinstance(target, FQSHA), target

--- a/ci/ci/prs.py
+++ b/ci/ci/prs.py
@@ -339,7 +339,6 @@ class PRS(object):
         for target_ref in lost_jobs:
             log.info(f'{target_ref.short_str()} was not found in batch refresh '
                      f'and will be treated like a cancelled job')
-            self.deploy_jobs[target.ref].delete()
             del self.deploy_jobs[target.ref]
 
     def refresh_from_deploy_job(self, target, job):


### PR DESCRIPTION
#4659 teaches CI to recover from a build job gone missing, but
I neglected to teach CI how to recover from a deploy job gone
missing. This follows the same strategy but for deploy jobs.

If a deploy job is not found in the list of refreshed jobs
it is simply removed from the deploy_jobs map. The next heal
stage of CI will kick off a new batch job for whatever the
latest undeployed SHA is.