### PR TITLE
[ci] make dependency of image and deploy explicit in Make

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -76,7 +76,7 @@ test-locally: restart-all-proxies
 run-service:
 	kubectl apply -f service.yaml
 
-deploy:
+deploy: push-hail-ci
 	sed -e "s,@sha@,$(shell git rev-parse --short=12 HEAD)," \
 	  -e "s,@image@,$(shell cat hail-ci-image)," \
 	  < deployment.yaml.in > k8s/deployment.yaml

--- a/ci/hail-ci-deploy.sh
+++ b/ci/hail-ci-deploy.sh
@@ -8,4 +8,4 @@ gcloud -q auth activate-service-account \
 
 gcloud -q auth configure-docker
 
-make push-hail-ci deploy
+make deploy


### PR DESCRIPTION
Previously everything was fine because the deploy script called
both the image creation and the deploy targets in make. However,
if we need to manually deploy, it is easy to forget this. I
modified the Makefile to make the dependency explicit.