### PR TITLE
Fix pip install dependency name

### DIFF
--- a/notebook/environment.yml
+++ b/notebook/environment.yml
@@ -6,4 +6,4 @@ dependencies:
 - pip
 - pip:
   - kubernetes
-  - Flask_Socket
+  - Flask_Sockets


### PR DESCRIPTION
had the wrong name. Not used by deployment, just for developers.