### PR TITLE
Fix image fetcher and notebook

### DIFF
--- a/image-fetcher/Dockerfile
+++ b/image-fetcher/Dockerfile
@@ -10,6 +10,6 @@ RUN apk --no-cache add \
 RUN curl -sSL https://sdk.cloud.google.com | bash
 ENV PATH $PATH:/root/google-cloud-sdk/bin
 
-ADD images fetch-image.sh ./
+ADD fetch-image.sh ./
 
 CMD /bin/sh fetch-image.sh

--- a/image-fetcher/Makefile
+++ b/image-fetcher/Makefile
@@ -1,9 +1,6 @@
 .PHONY: build push deploy
 
-images: ../notebook/notebook-worker-image
-	cat /dev/null $< > images
-
-build: images
+build:
 	docker build . -t image-fetcher
 
 push: IMAGE = gcr.io/broad-ctsa/image-fetcher:$(shell docker images -q --no-trunc image-fetcher | sed -e 's,[^:]*:,,')

--- a/image-fetcher/fetch-image.sh
+++ b/image-fetcher/fetch-image.sh
@@ -9,6 +9,6 @@ gcloud auth configure-docker
 
 while true
 do
-    [ $(cat images | wc -l) -eq 0 ] || (cat images | xargs docker pull)
+    curl -sSL http://notebook/worker-image | xargs docker pull
     sleep 360
 done

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -210,6 +210,11 @@ def admin_login_post():
     return redirect(external_url_for('workers'))
 
 
+@app.route('/worker-image')
+def worker_image():
+    return WORKER_IMAGE, 200
+
+
 @sockets.route('/wait')
 def wait(ws):
     pod_name = session['pod_name']

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -230,7 +230,9 @@ def wait(ws):
         # FIXME, ERRORS?
         gevent.sleep(1)
     log.info(f'wait finished for {svc_name} {pod_name}')
+    gevent.sleep(5) # wait a bit for the service to get ready
     ws.send(external_url_for(f'instance/{svc_name}/?token={jupyter_token}'))
+    log.info(f'notification sent to user for {svc_name} {pod_name}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Now image fetcher asks the running notebook image what worker image its using and pulls that.

Also, add a five second sleep after the service's endpoints are configured. Hopefully that prevents these intermittent gateway errors.