### PR TITLE
Experimentally Support python 3.7

### DIFF
--- a/hail/python/hail/dev-environment-py3.7.yml
+++ b/hail/python/hail/dev-environment-py3.7.yml
@@ -1,0 +1,20 @@
+name: hail-py3.7
+dependencies:
+- python=3.7
+- Sphinx>=1.8.1
+- sphinxcontrib>=1.0
+- conda-forge::nbsphinx>=0.3.5
+- conda-forge::sphinx_rtd_theme>=0.4.2
+- numpy>=1.15.3
+- pandas>=0.23.4
+- matplotlib>=3.0.1
+- seaborn>=0.9.0
+- bokeh>=1.0.0
+- jupyter>=1.0.0
+- pip>=18.1
+- pytest>=3.9.2
+- pip:
+    - parsimonious>=0.8.1
+    - ipykernel>=4.9.0
+    - pytest-xdist>=1.22.2
+    - decorator>=4.3.0

--- a/hail/python/hail/dev-environment-py3.7.yml
+++ b/hail/python/hail/dev-environment-py3.7.yml
@@ -1,20 +1,20 @@
 name: hail-py3.7
 dependencies:
 - python=3.7
-- Sphinx>=1.8.1
-- sphinxcontrib>=1.0
-- conda-forge::nbsphinx>=0.3.5
-- conda-forge::sphinx_rtd_theme>=0.4.2
-- numpy>=1.15.3
-- pandas>=0.23.4
-- matplotlib>=3.0.1
-- seaborn>=0.9.0
-- bokeh>=1.0.0
-- jupyter>=1.0.0
-- pip>=18.1
-- pytest>=3.9.2
+- Sphinx=1.7.5
+- sphinxcontrib=1.0
+- conda-forge::nbsphinx=0.3.5
+- conda-forge::sphinx_rtd_theme=0.4.2
+- numpy=1.15.3
+- pandas=0.23.4
+- matplotlib=3.0.1
+- seaborn=0.9.0
+- bokeh=1.0.0
+- jupyter=1.0.0
+- pip=18.0
+- pytest=3.9.2
 - pip:
-    - parsimonious>=0.8.1
-    - ipykernel>=4.9.0
-    - pytest-xdist>=1.22.2
-    - decorator>=4.3.0
+    - parsimonious==0.8.1
+    - ipykernel==5.1.0
+    - pytest-xdist==1.23.2
+    - decorator==4.3.0

--- a/hail/python/hail/typecheck2/check.py
+++ b/hail/python/hail/typecheck2/check.py
@@ -282,7 +282,16 @@ known_checkers = {
     List: check_list,
     Tuple: check_tuple,
     Collection: check_collection,
-    Callable: check_callable
+    Callable: check_callable,
+    collections.abc.Callable: check_callable,
+    collections.abc.Collection: check_collection,
+    collections.abc.Mapping: check_mapping,
+    collections.abc.Sequence: check_sequence,
+    dict: check_dict,
+    frozenset: check_frozenset,
+    list: check_list,
+    set: check_set,
+    tuple: check_tuple,
 }
 
 


### PR DESCRIPTION
This adds preliminary support for python 3.7 including a conda env with relaxed dependencies compared to what we currently ship. I've tested this manually and found no problems aside from a lot of warnings about upcoming depreciation in new versions of dependencies.

The value of `__origin__` changed for many types from 3.6 to 3.7, which is why the check function map needed to be expanded.