### PR TITLE
lower MatrixIR to TableIR

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/IRBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IRBuilder.scala
@@ -1,0 +1,136 @@
+package is.hail.expr.ir
+
+import is.hail.expr.types.{TArray, TStruct, Type}
+
+import scala.language.implicitConversions
+
+object IRBuilder {
+  type E = Env[Type]
+
+  implicit def tableIRToProxy(tir: TableIR): TableIRProxy =
+    new TableIRProxy(tir)
+
+  implicit def funcToIRProxy(ir: E => IR): IRProxy = new IRProxy(ir)
+
+  implicit def irToProxy(ir: IR): IRProxy = new IRProxy(_ => ir)
+
+  implicit def intToProxy(i: Int): IRProxy = irToProxy(I32(i))
+
+  implicit def ref(s: Symbol): IRProxy = new IRProxy( env =>
+    Ref(s.name, env.lookup(s.name)))
+
+  implicit def symbolToSymbolProxy(s: Symbol): SymbolProxy = new SymbolProxy(s)
+
+  implicit def arrayToProxy(seq: Seq[IRProxy]): IRProxy = { (env: E) =>
+    val irs = seq.map(_(env))
+    val elType = irs.head.typ
+    MakeArray(irs, TArray(elType))
+  }
+
+  implicit def arrayIRToProxy(seq: Seq[IR]): IRProxy = arrayToProxy(seq.map(irToProxy))
+
+  def irRange(start: IRProxy, end: IRProxy, step: IRProxy = 1): IRProxy = (env: E) =>
+    ArrayRange(start(env), end(env), step(env))
+
+  def let(bindings: BindingProxy*): LetProxy = new LetProxy(bindings.toList)
+
+  def irIf(cond: IRProxy)(cnsq: IRProxy)(altr: IRProxy): IRProxy = (env: E) =>
+    If(cond(env), cnsq(env), altr(env))
+
+  class TableIRProxy(val tir: TableIR) {
+    def empty: E = Env.empty
+    def globalEnv: E = Env("global" -> typ.globalType)
+    def env: E = Env("row" -> typ.rowType, "global" -> typ.globalType)
+
+    def typ = tir.typ
+
+    def mapGlobals(newGlobals: IRProxy): TableIR =
+      TableMapGlobals(tir, newGlobals(globalEnv))
+
+    def mapRows(newRow: IRProxy): TableIR =
+      TableMapRows(tir, newRow(env))
+
+    def keyBy(keys: IndexedSeq[String], isSorted: Boolean = false): TableIR =
+      TableKeyBy(tir, keys, isSorted)
+
+    def rename(rowMap: Map[String, String], globalMap: Map[String, String] = Map.empty): TableIR =
+      TableRename(tir, rowMap, globalMap)
+
+    def renameGlobals(globalMap: Map[String, String]): TableIR =
+      rename(Map.empty, globalMap)
+
+    def filter(ir: IRProxy): TableIR =
+      TableFilter(tir, ir(env))
+  }
+
+  class IRProxy(val ir: E => IR) {
+    def <=: (s: Symbol): BindingProxy = new BindingProxy(s, ir)
+
+    def apply(idx: IRProxy): IRProxy = (env: E) =>
+      ArrayRef(ir(env), idx(env))
+
+    def apply(lookup: Symbol): IRProxy = { (env: E) =>
+      val eval = ir(env)
+      eval.typ match {
+        case _: TStruct =>
+          GetField(eval, lookup.name)
+        case _: TArray =>
+          ArrayRef(ir(env), ref(lookup)(env))
+      }
+    }
+
+    def insertFields(fields: (Symbol, IRProxy)*): IRProxy = (env: E) =>
+      InsertFields(ir(env), fields.map { case (s, fir) => (s.name, fir(env)) })
+
+    def selectFields(fields: String*): IRProxy = (env: E) =>
+      SelectFields(ir(env), fields)
+
+    def dropFields(fields: Symbol*): IRProxy = { (env: E) =>
+      val struct = ir(env)
+      val typ = struct.typ.asInstanceOf[TStruct]
+      SelectFields(struct, typ.fieldNames.diff(fields.map(_.name)))
+    }
+
+    def len: IRProxy = (env: E) => ArrayLen(ir(env))
+
+    def filter(pred: LambdaProxy): IRProxy = (env: E) => {
+      val array = ir(env)
+      val eltType = array.typ.asInstanceOf[TArray].elementType
+      ArrayFilter(array, pred.s.name, pred.body(env.bind(pred.s.name -> eltType)))
+    }
+
+    def map(f: LambdaProxy): IRProxy = (env: E) => {
+      val array = ir(env)
+      val eltType = array.typ.asInstanceOf[TArray].elementType
+      ArrayMap(ir(env), f.s.name, f.body(env.bind(f.s.name -> eltType)))
+    }
+
+    private[ir] def apply(env: E) = ir(env)
+  }
+
+  class LambdaProxy(val s: Symbol, val body: IRProxy)
+
+  class SymbolProxy(val s: Symbol) extends AnyVal {
+    def ~> (body: IRProxy): LambdaProxy = new LambdaProxy(s, body)
+  }
+
+  case class BindingProxy(s: Symbol, value: IRProxy)
+
+  object LetProxy {
+    def bind(bindings: List[BindingProxy], body: IRProxy, env: E): IR =
+      bindings match {
+        case BindingProxy(sym, binding) :: rest =>
+          val name = sym.name
+          val value = binding(env)
+          Let(name, value, bind(rest, body, env.bind(name -> value.typ)))
+        case Nil =>
+          body(env)
+      }
+  }
+
+  class LetProxy(bindings: List[BindingProxy]) {
+    def in(body: IRProxy): IRProxy = { (env: E) =>
+      LetProxy.bind(bindings, body, env)
+    }
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/IRBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IRBuilder.scala
@@ -76,6 +76,8 @@ object IRBuilder {
     def selectDynamic(field: String): IRProxy = (env: E) =>
       GetField(ir(env), field)
 
+    def unary_! = new IRProxy((env: E) => ApplyUnaryPrimOp(Bang(), ir(env)))
+
     def apply(lookup: Symbol): IRProxy = (env: E) => {
       val eval = ir(env)
       eval.typ match {
@@ -147,9 +149,9 @@ object IRBuilder {
   }
 
   object let extends Dynamic {
-    def applyDynamicNamed(method: String)(args: (String, Any)*): LetProxy = {
+    def applyDynamicNamed(method: String)(args: (String, IRProxy)*): LetProxy = {
       assert(method == "apply")
-      new LetProxy(args.map { case (s, b) => BindingProxy(Symbol(s), b.asInstanceOf[IRProxy]) })
+      new LetProxy(args.map { case (s, b) => BindingProxy(Symbol(s), b) })
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/IRBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IRBuilder.scala
@@ -68,8 +68,6 @@ object IRBuilder {
   }
 
   class IRProxy(val ir: E => IR) extends AnyVal with Dynamic {
-    def <=: (s: Symbol): BindingProxy = BindingProxy(s, this)
-
     def apply(idx: IRProxy): IRProxy = (env: E) =>
       ArrayRef(ir(env), idx(env))
 

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -685,7 +685,7 @@ object Interpret {
           .map(_.sum)
           .getOrElse(child.execute(HailContext.get).rvd.count())
       case MatrixWrite(child, f) =>
-        val mv = Interpret(child, optimize = false)
+        val mv = child.execute(HailContext.get)
         f(mv)
       case TableWrite(child, path, overwrite, stageLocally, codecSpecJSONStr) =>
         val hc = HailContext.get
@@ -766,7 +766,7 @@ object Interpret {
         }
       case MatrixAggregate(child, query) =>
         val localGlobalSignature = child.typ.globalType
-        val value = Interpret(child, optimize = false)
+        val value = child.execute(HailContext.get)
         val colArrayType = TArray(child.typ.colType)
         val (rvAggs, initOps, seqOps, aggResultType, postAggIR) = CompileWithAggregators[Long, Long, Long, Long](
           "global", child.typ.globalType,

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -1,0 +1,74 @@
+package is.hail.expr.ir
+
+object LowerMatrixIR {
+  val entriesFieldName = "__entries"
+  val colsFieldName = "__cols"
+
+  def apply(ir: IR): IR = lower(ir)
+  def apply(tir: TableIR): TableIR = lower(tir)
+  def apply(mir: MatrixIR): TableIR = lower(mir)
+
+  private[this] def lower(bir: BaseIR): BaseIR = bir match {
+    case ir: IR => lower(ir)
+    case tir: TableIR => lower(tir)
+    case mir: MatrixIR => lower(mir)
+  }
+
+  private[this] def lower(ir: IR): IR =
+    lowerChildren(ir).asInstanceOf[IR]
+
+  private[this] def lower(tir: TableIR): TableIR =
+    tableRules.applyOrElse(tir, (tir: TableIR) => lowerChildren(tir).asInstanceOf[TableIR])
+
+  private[this] def lower(mir: MatrixIR): TableIR =
+    matrixRules.applyOrElse(mir, (mir: MatrixIR) =>
+      CastMatrixToTable(lowerChildren(mir).asInstanceOf[MatrixIR], entriesFieldName, colsFieldName))
+
+  private[this] def lowerChildren(ir: BaseIR): BaseIR = {
+    val loweredChildren = ir.children.map(lower)
+    if ((ir.children, loweredChildren).zipped.forall(_ eq _))
+      ir
+    else {
+      val newChildren = ir.children.zip(loweredChildren).map {
+        case (_: MatrixIR, CastMatrixToTable(childMIR, _, _)) =>
+          childMIR
+        case (mir: MatrixIR, loweredChild: TableIR) =>
+          CastTableToMatrix(
+            loweredChild,
+            entriesFieldName,
+            colsFieldName,
+            mir.typ.colKey)
+        case (_, loweredChild) =>
+          loweredChild
+      }
+      ir.copy(newChildren)
+    }
+  }
+
+  private[this] def matrixRules: PartialFunction[MatrixIR, TableIR] = {
+    case MatrixKeyRowsBy(child, keys, isSorted) =>
+      TableKeyBy(lower(child), keys, isSorted)
+  }
+
+  private[this] def tableRules: PartialFunction[TableIR, TableIR] = {
+    case CastMatrixToTable(child, entries, cols) =>
+      CastMatrixToTable(
+        CastTableToMatrix(lower(child), entriesFieldName, colsFieldName, child.typ.colKey),
+        entries,
+        cols)
+
+    case MatrixRowsTable(child) =>
+      val lowered = lower(child)
+      val dropCols =
+        TableMapGlobals(
+          lowered,
+          SelectFields(
+            Ref("global", lowered.typ.globalType),
+            child.typ.globalType.fieldNames))
+      TableMapRows(
+        dropCols,
+        SelectFields(
+          Ref("row", lowered.typ.rowType),
+          child.typ.rowType.fieldNames))
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -78,9 +78,9 @@ object MatrixIR {
     val oldEntryArrayType = typ.entryArrayType.physicalType
     val oldEntryType = typ.entryType.physicalType
 
-    val newColValueType = TStruct(typ.colValueStruct.fields.map(f => f.copy(typ = TArray(f.typ, required = true))))
+    val newColValueType = TStruct(typ.colValueStruct.fields.map(f => f.copy(typ = TArray(f.typ, required = false))))
     val newColType = typ.colKeyStruct ++ newColValueType
-    val newEntryType = TStruct(typ.entryType.fields.map(f => f.copy(typ = TArray(f.typ, required = true))))
+    val newEntryType = TStruct(typ.entryType.fields.map(f => f.copy(typ = TArray(f.typ, required = false))))
     val newMatrixType = typ.copyParts(colType = newColType, entryType = newEntryType)
     val newRVRowType = newMatrixType.rvRowType
     val localRowSize = newRVRowType.size

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -1833,8 +1833,7 @@ case class MatrixMapGlobals(child: MatrixIR, newGlobals: IR) extends MatrixIR {
 
     val newGlobalVals = Interpret[Row](
       newGlobals,
-      Env.empty[(Any, Type)].bind(
-        "global" -> (prev.globals.value, child.typ.globalType)),
+      Env[(Any, Type)]("global" -> (prev.globals.value, child.typ.globalType)),
       FastIndexedSeq(),
       None)
 

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -1813,11 +1813,11 @@ case class MatrixMapCols(child: MatrixIR, newCol: IR, newKey: Option[IndexedSeq[
   }
 }
 
-case class MatrixMapGlobals(child: MatrixIR, newRow: IR) extends MatrixIR {
-  val children: IndexedSeq[BaseIR] = Array(child, newRow)
+case class MatrixMapGlobals(child: MatrixIR, newGlobals: IR) extends MatrixIR {
+  val children: IndexedSeq[BaseIR] = Array(child, newGlobals)
 
   val typ: MatrixType =
-    child.typ.copy(globalType = newRow.typ.asInstanceOf[TStruct])
+    child.typ.copy(globalType = newGlobals.typ.asInstanceOf[TStruct])
 
   def copy(newChildren: IndexedSeq[BaseIR]): MatrixMapGlobals = {
     assert(newChildren.length == 2)
@@ -1831,14 +1831,14 @@ case class MatrixMapGlobals(child: MatrixIR, newRow: IR) extends MatrixIR {
   def execute(hc: HailContext): MatrixValue = {
     val prev = child.execute(hc)
 
-    val newGlobals = Interpret[Row](
-      newRow,
+    val newGlobalVals = Interpret[Row](
+      newGlobals,
       Env.empty[(Any, Type)].bind(
         "global" -> (prev.globals.value, child.typ.globalType)),
       FastIndexedSeq(),
       None)
 
-    prev.copy(typ = typ, globals = BroadcastRow(newGlobals, typ.globalType, hc.sc))
+    prev.copy(typ = typ, globals = BroadcastRow(newGlobalVals, typ.globalType, hc.sc))
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -180,7 +180,7 @@ abstract sealed class MatrixIR extends BaseIR {
 
   def columnCount: Option[Int] = None
 
-  def execute(hc: HailContext): MatrixValue
+  protected[ir] def execute(hc: HailContext): MatrixValue
 
   override def copy(newChildren: IndexedSeq[BaseIR]): MatrixIR
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
@@ -22,10 +22,18 @@ object Optimize {
     ir
   }
 
-  def apply(ir: TableIR): TableIR = optimize(ir, noisy = true, canGenerateLiterals = true).asInstanceOf[TableIR]
+  def apply(ir: TableIR, noisy: Boolean, canGenerateLiterals: Boolean): TableIR =
+    optimize(ir, noisy, canGenerateLiterals).asInstanceOf[TableIR]
 
-  def apply(ir: MatrixIR): MatrixIR = optimize(ir, noisy = true, canGenerateLiterals = true).asInstanceOf[MatrixIR]
+  def apply(ir: TableIR): TableIR = apply(ir, true, true)
 
-  def apply(ir: IR, noisy: Boolean, canGenerateLiterals: Boolean): IR = optimize(ir, noisy, canGenerateLiterals).asInstanceOf[IR]
-  def apply(ir: IR): IR = optimize(ir, noisy = true, canGenerateLiterals = true).asInstanceOf[IR]
+  def apply(ir: MatrixIR, noisy: Boolean, canGenerateLiterals: Boolean): MatrixIR =
+   optimize(ir, noisy, canGenerateLiterals).asInstanceOf[MatrixIR]
+
+  def apply(ir: MatrixIR): MatrixIR = apply(ir, true, true)
+
+  def apply(ir: IR, noisy: Boolean, canGenerateLiterals: Boolean): IR =
+    optimize(ir, noisy, canGenerateLiterals).asInstanceOf[IR]
+
+  def apply(ir: IR): IR = apply(ir, true, true)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -819,12 +819,6 @@ object PruneDeadFields {
         val expr2 = rebuild(expr, child2.typ, memo)
         val newKey2 = rebuild(newKey, child2.typ, memo)
         TableKeyByAndAggregate(child2, expr2, newKey2, nPartitions, bufferSize)
-      case CastMatrixToTable(child, entriesFieldName, colsFieldName) =>
-        val child2 = rebuild(child, memo)
-        if (dep.rowType.hasField(entriesFieldName))
-          CastMatrixToTable(child2, entriesFieldName, colsFieldName)
-        else
-          MatrixRowsTable(child2)
       case TableRename(child, rowMap, globalMap) =>
         val child2 = rebuild(child, memo)
         TableRename(
@@ -841,7 +835,7 @@ object PruneDeadFields {
         // IR should be a match error - all nodes with child value IRs should have a rule
         case childT: TableIR => rebuild(childT, memo)
         case childM: MatrixIR => rebuild(childM, memo)
-      }).asInstanceOf[TableIR]
+      })
     }
   }
 
@@ -918,7 +912,7 @@ object PruneDeadFields {
         // IR should be a match error - all nodes with child value IRs should have a rule
         case childT: TableIR => rebuild(childT, memo)
         case childM: MatrixIR => rebuild(childM, memo)
-      }).asInstanceOf[MatrixIR]
+      })
 
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -302,8 +302,8 @@ object PruneDeadFields {
       case TableMapRows(child, newRow) =>
         val rowDep = memoizeAndGetDep(newRow, requestedType.rowType, child.typ, memo)
         memoizeTableIR(child, unify(child.typ, minimal(child.typ).copy(globalType = requestedType.globalType), rowDep), memo)
-      case TableMapGlobals(child, newRow) =>
-        val globalDep = memoizeAndGetDep(newRow, requestedType.globalType, child.typ, memo)
+      case TableMapGlobals(child, newGlobals) =>
+        val globalDep = memoizeAndGetDep(newGlobals, requestedType.globalType, child.typ, memo)
         memoizeTableIR(child, unify(child.typ, requestedType.copy(globalType = globalDep.globalType), globalDep), memo)
       case TableAggregateByKey(child, newRow) =>
         val aggDep = memoizeAndGetDep(newRow, requestedType.rowType, child.typ, memo)
@@ -412,8 +412,8 @@ object PruneDeadFields {
         val depMod = minimal(child.typ).copy(rvRowType = requestedType.rvRowType,
           globalType = requestedType.globalType)
         memoizeMatrixIR(child, unify(child.typ, depMod, irDep), memo)
-      case MatrixMapGlobals(child, newRow) =>
-        val irDep = memoizeAndGetDep(newRow, requestedType.globalType, child.typ, memo)
+      case MatrixMapGlobals(child, newGlobals) =>
+        val irDep = memoizeAndGetDep(newGlobals, requestedType.globalType, child.typ, memo)
         memoizeMatrixIR(child, unify(child.typ, requestedType.copy(globalType = irDep.globalType), irDep), memo)
       case MatrixRead(_, _, _, _) =>
       case MatrixLiteral(value) =>
@@ -793,9 +793,9 @@ object PruneDeadFields {
         val child2 = rebuild(child, memo)
         val newRow2 = rebuild(newRow, child2.typ, memo)
         TableMapRows(child2, newRow2)
-      case TableMapGlobals(child, newRow) =>
+      case TableMapGlobals(child, newGlobals) =>
         val child2 = rebuild(child, memo)
-        TableMapGlobals(child2, rebuild(newRow, child2.typ, memo))
+        TableMapGlobals(child2, rebuild(newGlobals, child2.typ, memo))
       case TableKeyBy(child, keys, isSorted) =>
         var child2 = rebuild(child, memo)
         // fully upcast before shuffle
@@ -869,9 +869,9 @@ object PruneDeadFields {
         // FIXME account for key
         val child2 = rebuild(child, memo)
         MatrixMapCols(child2, rebuild(newCol, child2.typ, memo), newKey)
-      case MatrixMapGlobals(child, newRow) =>
+      case MatrixMapGlobals(child, newGlobals) =>
         val child2 = rebuild(child, memo)
-        MatrixMapGlobals(child2, rebuild(newRow, child2.typ, memo))
+        MatrixMapGlobals(child2, rebuild(newGlobals, child2.typ, memo))
       case MatrixAggregateRowsByKey(child, entryExpr, rowExpr) =>
         val child2 = rebuild(child, memo)
         MatrixAggregateRowsByKey(child2, rebuild(entryExpr, child2.typ, memo), rebuild(rowExpr, child2.typ, memo))

--- a/hail/src/main/scala/is/hail/expr/ir/RewriteBottomUp.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/RewriteBottomUp.scala
@@ -1,7 +1,5 @@
 package is.hail.expr.ir
 
-import is.hail.expr._
-
 object RewriteBottomUp {
   def apply(ir: BaseIR, rule: (BaseIR) => Option[BaseIR]): BaseIR = {
     def rewrite(ast: BaseIR): BaseIR = {

--- a/hail/src/main/scala/is/hail/expr/ir/RewriteTopDown.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/RewriteTopDown.scala
@@ -1,7 +1,5 @@
 package is.hail.expr.ir
 
-import is.hail.expr._
-
 object RewriteTopDown {
   def rewriteTopDown(ast: BaseIR, rule: PartialFunction[BaseIR, BaseIR]): BaseIR = {
     def rewrite(ast: BaseIR): BaseIR = {

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -251,7 +251,7 @@ object Simplify {
 
   private[this] def tableRules(canRepartition: Boolean): PartialFunction[TableIR, TableIR] = {
 
-    case TableRename(child, m1, m2) if m1.isEmpty && m2.isEmpty => child
+    case TableRename(child, m1, m2) if m1.isTrivial && m2.isTrivial => child
 
     // TODO: Write more rules like this to bubble 'TableRename' nodes towards the root.
     case t@TableRename(TableKeyBy(child, keys, isSorted), rowMap, globalMap) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -335,14 +335,14 @@ object Simplify {
       val mct = MatrixColsTable(child)
       TableMapRows(
         mct,
-        Subst(newRow, Env.empty[IR].bind("sa" -> Ref("row", mct.typ.rowType))))
+        Subst(newRow, Env("sa" -> Ref("row", mct.typ.rowType))))
 
     case MatrixColsTable(MatrixFilterCols(child, pred))
       if !Mentions(pred, "g") && !Mentions(pred, "va") =>
       val mct = MatrixColsTable(child)
       TableFilter(
         mct,
-        Subst(pred, Env.empty[IR].bind("sa" -> Ref("row", mct.typ.rowType))))
+        Subst(pred, Env("sa" -> Ref("row", mct.typ.rowType))))
 
     case MatrixColsTable(MatrixMapGlobals(child, newGlobals)) => TableMapGlobals(MatrixColsTable(child), newGlobals)
     case MatrixColsTable(MatrixMapRows(child, _)) => MatrixColsTable(child)

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -201,6 +201,9 @@ object Simplify {
 
     case InsertFields(struct, Seq()) => struct
 
+    case SelectFields(old, fields) if coerce[TStruct](old.typ).fieldNames sameElements fields =>
+      old
+
     case SelectFields(SelectFields(old, _), fields) =>
       SelectFields(old, fields)
 

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -312,14 +312,14 @@ object Simplify {
     case MatrixColsTable(MatrixRead(typ, dropCols, false, reader)) =>
       MatrixColsTable(MatrixRead(typ, dropCols, dropRows = true, reader))
 
-    case MatrixRowsTable(MatrixFilterRows(child, newRow))
-      if !Mentions(newRow, "g") && !Mentions(newRow, "sa") && !ContainsAgg(newRow) =>
+    case MatrixRowsTable(MatrixFilterRows(child, pred))
+      if !Mentions(pred, "g") && !Mentions(pred, "sa") && !ContainsAgg(pred) =>
       val mrt = MatrixRowsTable(child)
       TableFilter(
         mrt,
-        Subst(newRow, Env.empty[IR].bind("va" -> Ref("row", mrt.typ.rowType))))
+        Subst(pred, Env("va" -> Ref("row", mrt.typ.rowType))))
 
-    case MatrixRowsTable(MatrixMapGlobals(child, newRow)) => TableMapGlobals(MatrixRowsTable(child), newRow)
+    case MatrixRowsTable(MatrixMapGlobals(child, newGlobals)) => TableMapGlobals(MatrixRowsTable(child), newGlobals)
     case MatrixRowsTable(MatrixMapCols(child, _, _)) => MatrixRowsTable(child)
     case MatrixRowsTable(MatrixMapEntries(child, _)) => MatrixRowsTable(child)
     case MatrixRowsTable(MatrixFilterEntries(child, _)) => MatrixRowsTable(child)
@@ -344,7 +344,7 @@ object Simplify {
         mct,
         Subst(pred, Env.empty[IR].bind("sa" -> Ref("row", mct.typ.rowType))))
 
-    case MatrixColsTable(MatrixMapGlobals(child, newRow)) => TableMapGlobals(MatrixColsTable(child), newRow)
+    case MatrixColsTable(MatrixMapGlobals(child, newGlobals)) => TableMapGlobals(MatrixColsTable(child), newGlobals)
     case MatrixColsTable(MatrixMapRows(child, _)) => MatrixColsTable(child)
     case MatrixColsTable(MatrixMapEntries(child, _)) => MatrixColsTable(child)
     case MatrixColsTable(MatrixFilterEntries(child, _)) => MatrixColsTable(child)
@@ -364,8 +364,8 @@ object Simplify {
       else
         tr
 
-    case TableHead(TableMapGlobals(child, newRow), n) =>
-      TableMapGlobals(TableHead(child, n), newRow)
+    case TableHead(TableMapGlobals(child, newGlobals), n) =>
+      TableMapGlobals(TableHead(child, n), newGlobals)
 
     case TableHead(TableOrderBy(child, sortFields), n)
       if sortFields.forall(_.sortOrder == Ascending) && n < 256 && canRepartition =>

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -656,8 +656,7 @@ case class TableMapGlobals(child: TableIR, newGlobals: IR) extends TableIR {
 
     val newGlobalVals = Interpret[Row](
       newGlobals,
-      Env.empty[(Any, Type)].bind(
-        "global" -> (tv.globals.value, child.typ.globalType)),
+      Env[(Any, Type)]("global" -> (tv.globals.value, child.typ.globalType)),
       FastIndexedSeq(),
       None)
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -759,13 +759,6 @@ case class MatrixRowsTable(child: MatrixIR) extends TableIR {
   }
 
   val typ: TableType = child.typ.rowsTableType
-
-  protected[ir] override def execute(hc: HailContext): TableValue = {
-    val mv = child.execute(hc)
-    val rtv = mv.rowsTableValue
-    assert(rtv.typ == typ)
-    rtv
-  }
 }
 
 case class MatrixColsTable(child: MatrixIR) extends TableIR {

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1158,10 +1158,7 @@ case class CastMatrixToTable(
   colsFieldName: String
 ) extends TableIR {
 
-  def typ: TableType = TableType(
-    rowType = child.typ.rvRowType.rename(Map(MatrixType.entriesIdentifier -> entriesFieldName)),
-    key = child.typ.rowKey,
-    globalType = child.typ.globalType.appendKey(colsFieldName, TArray(child.typ.colType)))
+  def typ: TableType = LowerMatrixIR.loweredType(child.typ, entriesFieldName, colsFieldName)
 
   def children: IndexedSeq[BaseIR] = FastIndexedSeq(child)
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -34,7 +34,7 @@ abstract sealed class TableIR extends BaseIR {
 
   def partitionCounts: Option[IndexedSeq[Long]] = None
 
-  def execute(hc: HailContext): TableValue
+  protected[ir] def execute(hc: HailContext): TableValue
 
   override def copy(newChildren: IndexedSeq[BaseIR]): TableIR
 }

--- a/hail/src/main/scala/is/hail/expr/types/TStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/TStruct.scala
@@ -174,6 +174,8 @@ final case class TStruct(fields: IndexedSeq[Field], override val required: Boole
     (t.asInstanceOf[TStruct], f)
   }
 
+  def updateKey(key: String, sig: Type): TStruct = updateKey(key, fieldIdx(key), sig)
+
   def updateKey(key: String, i: Int, sig: Type): TStruct = {
     assert(fieldIdx.contains(key))
 

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDD.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDD.scala
@@ -33,6 +33,7 @@ sealed case class RowFields (
 case class BgenSettings(
   nSamples: Int,
   entries: EntriesSetting,
+  dropCols: Boolean,
   rowFields: RowFields,
   rg: Option[ReferenceGenome],
   indexAnnotationType: Type

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
@@ -295,6 +295,14 @@ object CompileDecoder {
         case NoEntries =>
           Code.toUnit(cbfis.invoke[Long, Long]("skipBytes", dataSize.toL))
 
+        case EntriesWithFields(_, _, _) if settings.dropCols =>
+          Code(
+            srvb.addArray(settings.matrixType.entryArrayType.physicalType, { srvb =>
+              srvb.start(0)
+            }),
+            srvb.advance(),
+            Code.toUnit(cbfis.invoke[Long, Long]("skipBytes", dataSize.toL)))
+
         case EntriesWithFields(gt, gp, dosage) if !(gt || gp || dosage) =>
           assert(settings.matrixType.entryType.physicalType.byteSize == 0)
           Code(

--- a/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
@@ -56,6 +56,7 @@ object IndexBgen {
     val settings: BgenSettings = BgenSettings(
       0, // nSamples not used if there are no entries
       NoEntries,
+      dropCols = true,
       RowFields(false, false, true, true),
       referenceGenome,
       annotationType

--- a/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -418,6 +418,7 @@ case class MatrixBGENReader(
     val settings = BgenSettings(
       nSamples,
       EntriesWithFields(includeGT, includeGP, includeDosage),
+      mr.dropCols,
       RowFields(includeLid, includeRsid, includeOffset, includeFileIdx),
       referenceGenome,
       indexAnnotationType)

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -197,7 +197,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
 
   def typ: TableType = tir.typ
 
-  lazy val value@TableValue(ktType, globals, rvd) = Interpret(tir, optimize = true, lowerMatrix = true)
+  lazy val value@TableValue(ktType, globals, rvd) = Interpret(tir, optimize = true)
 
   val TableType(signature, key, globalSignature) = tir.typ
 

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -196,13 +196,8 @@ class Table(val hc: HailContext, val tir: TableIR) {
   )
 
   def typ: TableType = tir.typ
-  
-  lazy val value: TableValue = {
-    val opt = LiftLiterals(ir.Optimize(tir)).asInstanceOf[TableIR]
-    opt.execute(hc)
-  }
 
-  lazy val TableValue(ktType, globals, rvd) = value
+  lazy val value@TableValue(ktType, globals, rvd) = Interpret(tir, optimize = true, lowerMatrix = true)
 
   val TableType(signature, key, globalSignature) = tir.typ
 

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichMap.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichMap.scala
@@ -6,4 +6,7 @@ class RichMap[K, V](val m: Map[K, V]) extends AnyVal {
   def outerJoin[V2](other: Map[K, V2]): Map[K, (Option[V], Option[V2])] = {
     (m.keySet ++ other.keySet).map { k => (k, (m.get(k), other.get(k))) }.toMap
   }
+
+  def isTrivial(implicit eq: K =:= V): Boolean =
+    m.forall { case (k, v) => k == v }
 }

--- a/hail/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/hail/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -413,7 +413,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
   val rowKeyStruct: TStruct = TStruct(rowKey.zip(rowKeyTypes): _*)
 
-  lazy val value@MatrixValue(_, globals, colValues, rvd) = Interpret(ast, optimize = true, lowerMatrix = true)
+  lazy val value@MatrixValue(_, globals, colValues, rvd) = Interpret(ast, optimize = true)
 
   def partitionCounts(): Array[Long] = {
     ast.partitionCounts match {

--- a/hail/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/hail/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -413,14 +413,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
   val rowKeyStruct: TStruct = TStruct(rowKey.zip(rowKeyTypes): _*)
 
-  lazy val value: MatrixValue = {
-    val opt = LiftLiterals(ir.Optimize(ast)).asInstanceOf[MatrixIR]
-    val v = opt.execute(hc)
-    assert(v.typ == matrixType)
-    v
-  }
-
-  lazy val MatrixValue(_, globals, colValues, rvd) = value
+  lazy val value@MatrixValue(_, globals, colValues, rvd) = Interpret(ast, optimize = true, lowerMatrix = true)
 
   def partitionCounts(): Array[Long] = {
     ast.partitionCounts match {

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -583,7 +583,7 @@ class PruneSuite extends SparkSuite {
     checkRebuild(tmg, subsetTable(tmg.typ, "global.foo"),
       (_: BaseIR, r: BaseIR) => {
         val tmg = r.asInstanceOf[TableMapGlobals]
-        TypeCheck(tmg.newRow, PruneDeadFields.relationalTypeToEnv(tmg.child.typ), None)
+        TypeCheck(tmg.newGlobals, PruneDeadFields.relationalTypeToEnv(tmg.child.typ), None)
         tmg.child.typ == subsetTable(tr.typ, "global.g1")
       })
   }
@@ -680,7 +680,7 @@ class PruneSuite extends SparkSuite {
     checkRebuild(mmg, subsetMatrixTable(mmg.typ, "global.foo", "g.e1", "va.r2"),
       (_: BaseIR, r: BaseIR) => {
         val mmg = r.asInstanceOf[MatrixMapGlobals]
-        TypeCheck(mmg.newRow, PruneDeadFields.relationalTypeToEnv(mmg.child.typ), None)
+        TypeCheck(mmg.newGlobals, PruneDeadFields.relationalTypeToEnv(mmg.child.typ), None)
         mmg.child.asInstanceOf[MatrixRead].typ == subsetMatrixTable(mr.typ, "global.g1", "va.r2", "g.e1")
       }
     )

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -352,7 +352,7 @@ class PruneSuite extends SparkSuite {
   }
 
   @Test def testMatrixAnnotateRowsTableMemo() {
-    val tl = TableLiteral(MatrixRowsTable(mat).execute(hc))
+    val tl = TableLiteral(Interpret(MatrixRowsTable(mat)))
     val mart = MatrixAnnotateRowsTable(mat, tl, "foo", None)
     checkMemo(mart, subsetMatrixTable(mart.typ,"va.foo.r3", "va.r3"),
       Array(subsetMatrixTable(mat.typ, "va.r3"), subsetTable(tl.typ, "row.r3")))
@@ -709,7 +709,7 @@ class PruneSuite extends SparkSuite {
   }
 
   @Test def testMatrixAnnotateRowsTableRebuild() {
-    val tl = TableLiteral(MatrixRowsTable(mat).execute(hc))
+    val tl = TableLiteral(Interpret(MatrixRowsTable(mat)))
     val mart = MatrixAnnotateRowsTable(mat, tl, "foo", None)
     checkRebuild(mart, subsetMatrixTable(mart.typ),
       (_: BaseIR, r: BaseIR) => {

--- a/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
@@ -66,7 +66,7 @@ class RandomFunctionsSuite extends SparkSuite {
   }
 
   @Test def testRandomAcrossJoins() {
-    def asArray(ir: TableIR) = ir.execute(hc).rdd.collect()
+    def asArray(ir: TableIR) = Interpret(ir).rdd.collect()
 
     val joined = TableJoin(
       mapped2(10, 4),
@@ -83,7 +83,7 @@ class RandomFunctionsSuite extends SparkSuite {
   }
 
   @Test def testRepartitioningAfterRandomness() {
-    val mapped = mapped2(15, 4).execute(hc).rvd
+    val mapped = Interpret(mapped2(15, 4)).rvd
     val newRangeBounds = FastIndexedSeq(
       Interval(Row(0), Row(4), true, true),
       Interval(Row(4), Row(10), false, true),
@@ -131,7 +131,7 @@ class RandomFunctionsSuite extends SparkSuite {
           "pi" -> partitionIdx,
           "counter" -> counter)))
 
-    val expected = tir.execute(hc).rvd.toRows.collect()
+    val expected = Interpret(tir).rvd.toRows.collect()
     val actual = new Table(hc, tir).rdd.collect()
 
     assert(expected.sameElements(actual))

--- a/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -3,7 +3,7 @@ package is.hail.variant.vsm
 import is.hail.SparkSuite
 import is.hail.annotations.BroadcastRow
 import is.hail.expr.ir
-import is.hail.expr.ir.{MatrixAnnotateRowsTable, TableLiteral, TableValue}
+import is.hail.expr.ir.{Interpret, MatrixAnnotateRowsTable, TableLiteral, TableValue}
 import is.hail.expr.types._
 import is.hail.rvd.RVD
 import is.hail.table.Table
@@ -31,8 +31,13 @@ class PartitioningSuite extends SparkSuite {
     val t = TableLiteral(TableValue(
       typ, BroadcastRow(Row.empty, TStruct.empty(), sc), RVD.empty(sc, typ.rvdType)))
     val rangeReader = ir.MatrixRangeReader(100, 10, Some(10))
-    MatrixAnnotateRowsTable(ir.MatrixRead(rangeReader.fullType, false, false, rangeReader), t, "foo", None)
-      .execute(hc).rvd.count()
+    Interpret(
+      MatrixAnnotateRowsTable(
+        ir.MatrixRead(rangeReader.fullType, false, false, rangeReader),
+        t,
+        "foo",
+        None))
+      .rvd.count()
   }
 
   @Test def testEmptyRightRDDOrderedJoinDistinct() {


### PR DESCRIPTION
* Add a lightweight DSL for writing IR in Scala, which made the lowerings much easier to write, and read. It is implemented in `IRBuilder`, and can be used by importing `IRBuilder._` into scope. It's not complete, and I want to make it eagerly typecheck eventually, but we can build on it.
* Make `execute` protected on `MatrixIR` and `TableIR`, making `Interpret` the official place to execute IR.
* Add a compiler pass lowering some `MatrixIR` to `TableIR`. The `Interpret` gateway to `execute` always lowers, so we can safely remove the execute methods of IR nodes which are rewritten by the lowering.
* Fix `LoadBgen` to not create entries arrays when `dropCols` is true.