### PR TITLE
Reimplemented IR Parser

### DIFF
--- a/hail/python/hail/ir/base_ir.py
+++ b/hail/python/hail/ir/base_ir.py
@@ -64,7 +64,7 @@ class IR(BaseIR):
         return {v for child in self.children for v in child.bound_variables}
 
     def parse(self, code, ref_map={}, ir_map={}):
-        return Env.hail().expr.Parser.parse_value_ir(code, ref_map, ir_map)
+        return Env.hail().expr.ir.IRParser.parse_value_ir(code, ref_map, ir_map)
 
 
 class TableIR(BaseIR):
@@ -72,7 +72,7 @@ class TableIR(BaseIR):
         super().__init__()
 
     def parse(self, code, ref_map={}, ir_map={}):
-        return Env.hail().expr.Parser.parse_table_ir(code, ref_map, ir_map)
+        return Env.hail().expr.ir.IRParser.parse_table_ir(code, ref_map, ir_map)
 
 
 class MatrixIR(BaseIR):
@@ -80,4 +80,4 @@ class MatrixIR(BaseIR):
         super().__init__()
 
     def parse(self, code, ref_map={}, ir_map={}):
-        return Env.hail().expr.Parser.parse_matrix_ir(code, ref_map, ir_map)
+        return Env.hail().expr.ir.IRParser.parse_matrix_ir(code, ref_map, ir_map)

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -342,7 +342,7 @@ class ApplyComparisonOp(IR):
         return new_instance(self.op, l, r)
 
     def render(self, r):
-        return '(ApplyComparisonOp ({}) {} {})'.format(escape_id(self.op), r(self.l), r(self.r))
+        return '(ApplyComparisonOp {} {} {})'.format(escape_id(self.op), r(self.l), r(self.r))
 
     def __eq__(self, other):
         return isinstance(other, ApplyComparisonOp) and \

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -35,6 +35,8 @@ class ValueIRTests(unittest.TestCase):
 
         take_by_sig = ir.AggSignature('TakeBy', [hl.tint32], None, [hl.tfloat64, hl.tfloat64])
 
+        table = ir.TableRange(10, 4)
+
         value_irs = [
             i, ir.I64(5), ir.F32(3.14), ir.F64(3.14), s, ir.TrueIR(), ir.FalseIR(), ir.Void(),
             ir.Cast(i, hl.tfloat64),
@@ -107,7 +109,7 @@ class ValueIRTests(unittest.TestCase):
                'x': hl.tint32}
         env = {name: t._jtype for name, t in env.items()}
         for x in self.value_irs():
-            Env.hail().expr.Parser.parse_value_ir(str(x), env, {})
+            Env.hail().expr.ir.IRParser.parse_value_ir(str(x), env, {})
 
     def test_copies(self):
         for x in self.value_irs():
@@ -171,7 +173,7 @@ class TableIRTests(unittest.TestCase):
 
     def test_parses(self):
         for x in self.table_irs():
-            Env.hail().expr.Parser.parse_table_ir(str(x))
+            Env.hail().expr.ir.IRParser.parse_table_ir(str(x))
 
     def test_matrix_ir_parses(self):
         hl.index_bgen(resource('example.8bits.bgen'),
@@ -218,7 +220,7 @@ class TableIRTests(unittest.TestCase):
 
         for x in matrix_irs:
             try:
-                Env.hail().expr.Parser.parse_matrix_ir(str(x))
+                Env.hail().expr.ir.IRParser.parse_matrix_ir(str(x))
             except Exception as e:
                 raise ValueError(str(x)) from e
 

--- a/hail/src/main/scala/is/hail/expr/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/Parser.scala
@@ -1,37 +1,11 @@
 package is.hail.expr
 
-import is.hail.HailContext
-import is.hail.expr.ir.{AggSignature, BaseIR, IR, MatrixIR, TableIR}
-import is.hail.expr.types._
-import is.hail.expr.types.physical.PType
-import is.hail.expr.types.virtual._
-import is.hail.rvd.RVDType
-import is.hail.table.{Ascending, Descending, SortField}
 import is.hail.utils.StringEscapeUtils._
 import is.hail.utils._
 import is.hail.variant._
-import org.json4s.jackson.{JsonMethods, Serialization}
 
 import scala.util.parsing.combinator.JavaTokenParsers
-import scala.util.parsing.input.{Position, Positional}
-import scala.collection.JavaConverters._
-
-case class Positioned[T](x: T) extends Positional
-
-case class IRParserEnvironment(
-  refMap: Map[String, Type] = Map.empty,
-  irMap: Map[String, BaseIR] = Map.empty
-) {
-  def update(newRefMap: Map[String, Type] = Map.empty, newIRMap: Map[String, BaseIR] = Map.empty): IRParserEnvironment =
-    copy(refMap = refMap ++ newRefMap, irMap = irMap ++ newIRMap)
-
-  def withRefMap(newRefMap: Map[String, Type]): IRParserEnvironment = {
-    assert(refMap.isEmpty)
-    copy(refMap = newRefMap)
-  }
-
-  def +(t: (String, Type)): IRParserEnvironment = copy(refMap = refMap + t, irMap)
-}
+import scala.util.parsing.input.Position
 
 class RichParser[T](parser: Parser.Parser[T]) {
   def parse(input: String): T = {
@@ -81,18 +55,6 @@ object Parser extends JavaTokenParsers {
     }
   }
 
-  def parseType(code: String): Type = parse(type_expr, code)
-
-  def parsePType(code: String): PType = parse(type_expr, code).physicalType
-
-  def parseStructType(code: String): TStruct = parse(struct_expr, code)
-
-  def parseRVDType(code: String): RVDType = parse(rvd_type_expr, code)
-
-  def parseTableType(code: String): TableType = parse(table_type_expr, code)
-
-  def parseMatrixType(code: String): MatrixType = parse(matrix_type_expr, code)
-
   def parseAnnotationRoot(code: String, root: String): List[String] = {
     val path = parseAll(annotationIdentifier, code) match {
       case Success(result, _) => result.asInstanceOf[List[String]]
@@ -120,9 +82,6 @@ object Parser extends JavaTokenParsers {
       case NoSuccess(msg, next) => fatal(s"invalid call expression: `$input': $msg")
     }
   }
-
-  def withPos[T](p: => Parser[T]): Parser[Positioned[T]] =
-    positioned[Positioned[T]](p ^^ { x => Positioned(x) })
 
   def oneOfLiteral(s: String*): Parser[String] = oneOfLiteral(s.toArray)
 
@@ -159,30 +118,12 @@ object Parser extends JavaTokenParsers {
     }
   }
 
-  def comma_delimited_doubles: Parser[Array[Double]] =
-    repsep(floatingPointNumber, ",") ^^ (_.map(_.toDouble).toArray)
-
   def annotationIdentifier: Parser[List[String]] =
     rep1sep(identifier, ".") ^^ {
       _.toList
     }
 
-  def annotationIdentifierArray: Parser[Array[List[String]]] =
-    rep1sep(annotationIdentifier, ",") ^^ {
-      _.toArray
-    }
-
-  def tsvIdentifier: Parser[String] = backtickLiteral | """[^\s\p{Cntrl}=,]+""".r
-
   def identifier = backtickLiteral | ident
-
-  def advancePosition(pos: Position, delta: Int) = new Position {
-    def line = pos.line
-
-    def column = pos.column + delta
-
-    def lineContents = pos.longString.split("\n").head
-  }
 
   def quotedLiteral(delim: Char, what: String): Parser[String] =
     new Parser[String] {
@@ -231,93 +172,6 @@ object Parser extends JavaTokenParsers {
   override def stringLiteral: Parser[String] =
     quotedLiteral('"', "string literal") | quotedLiteral('\'', "string literal")
 
-  def tuplify[T, S](p: ~[T, S]): (T, S) = p match {
-    case t ~ s => (t, s)
-  }
-
-  def tuplify[T, S, V](p: ~[~[T, S], V]): (T, S, V) = p match {
-    case t ~ s ~ v => (t, s, v)
-  }
-
-  def decorator: Parser[(String, String)] =
-    ("@" ~> (identifier <~ "=")) ~ stringLiteral ^^ { case name ~ desc =>
-      //    ("@" ~> (identifier <~ "=")) ~ stringLiteral("\"" ~> "[^\"]".r <~ "\"") ^^ { case name ~ desc =>
-      (name, desc)
-    }
-
-  def type_field_decorator: Parser[(String, Type)] =
-    (identifier <~ ":") ~ type_expr ~ rep(decorator) ^^ { case name ~ t ~ decorators => (name, t) }
-
-  def type_field: Parser[(String, Type)] =
-    (identifier <~ ":") ~ type_expr ^^ { case name ~ t => (name, t) }
-
-  def type_fields: Parser[Array[Field]] = repsep(type_field_decorator | type_field, ",") ^^ {
-    _.zipWithIndex.map { case ((id, t), index) => Field(id, t, index) }
-      .toArray
-  }
-
-  def type_expr_opt: Parser[Option[Type]] = type_expr ^^ {
-    Some(_)
-  } | "None" ^^ { _ => None }
-
-  def type_expr: Parser[Type] = _required_type ~ _type_expr ^^ { case req ~ t => t.setRequired(req) }
-
-  def _required_type: Parser[Boolean] = "+" ^^ { _ => true } | success(false)
-
-  def _type_expr: Parser[Type] =
-    "Interval" ~> "[" ~> type_expr <~ "]" ^^ { pointType => TInterval(pointType) } |
-      "Boolean" ^^ { _ => TBoolean() } |
-      "Int32" ^^ { _ => TInt32() } |
-      "Int64" ^^ { _ => TInt64() } |
-      "Int" ^^ { _ => TInt32() } |
-      "Float32" ^^ { _ => TFloat32() } |
-      "Float64" ^^ { _ => TFloat64() } |
-      "Float" ^^ { _ => TFloat64() } |
-      "String" ^^ { _ => TString() } |
-      ("Locus" ~ "(") ~> identifier <~ ")" ^^ { id => ReferenceGenome.getReference(id).locusType } |
-      ("LocusAlleles" ~ "(") ~> identifier <~ ")" ^^ { id => ReferenceGenome.getReference(id).locusType } |
-      "Call" ^^ { _ => TCall() } |
-      ("Array" ~ "[") ~> type_expr <~ "]" ^^ { elementType => TArray(elementType) } |
-      ("Set" ~ "[") ~> type_expr <~ "]" ^^ { elementType => TSet(elementType) } |
-      ("Dict" ~ "[") ~> type_expr ~ "," ~ type_expr <~ "]" ^^ { case kt ~ _ ~ vt => TDict(kt, vt) } |
-      ("Tuple" ~ "[") ~> repsep(type_expr, ",") <~ "]" ^^ { types => TTuple(types.toArray) } |
-      _struct_expr
-
-  def struct_expr: Parser[TStruct] = _required_type ~ _struct_expr ^^ { case req ~ t => t.setRequired(req).asInstanceOf[TStruct] }
-
-  def _struct_expr: Parser[TStruct] = ("Struct" ~ "{") ~> type_fields <~ "}" ^^ { fields => TStruct(fields) }
-
-  def key: Parser[Array[String]] = "[" ~> (repsep(identifier, ",") ^^ {
-    _.toArray
-  }) <~ "]"
-
-  def trailing_keys: Parser[Array[String]] = rep("," ~> identifier) ^^ {
-    _.toArray
-  }
-
-  def rvd_type_expr: Parser[RVDType] =
-    ((("RVDType" | "OrderedRVDType") ~ "{" ~ "key" ~ ":" ~ "[") ~> key) ~ (trailing_keys <~ "]") ~
-      (("," ~ "row" ~ ":") ~> struct_expr <~ "}") ^^ { case partitionKey ~ restKey ~ rowType =>
-      RVDType(rowType.physicalType, partitionKey ++ restKey)
-    }
-
-  def table_type_expr: Parser[TableType] =
-    (("Table" ~ "{" ~ "global" ~ ":") ~> struct_expr) ~
-      (("," ~ "key" ~ ":") ~> ("None" ^^ { _ => FastIndexedSeq() } | key ^^ { key => key.toFastIndexedSeq })) ~
-      (("," ~ "row" ~ ":") ~> struct_expr <~ "}") ^^ { case globalType ~ key ~ rowType =>
-      TableType(rowType, key, globalType.setRequired(false).asInstanceOf[TStruct])
-    }
-
-  def matrix_type_expr: Parser[MatrixType] =
-    (("Matrix" ~ "{" ~ "global" ~ ":") ~> struct_expr) ~
-      (("," ~ "col_key" ~ ":") ~> key) ~
-      (("," ~ "col" ~ ":") ~> struct_expr) ~
-      (("," ~ "row_key" ~ ":" ~ "[") ~> key) ~ (trailing_keys <~ "]") ~
-      (("," ~ "row" ~ ":") ~> struct_expr) ~
-      (("," ~ "entry" ~ ":") ~> struct_expr <~ "}") ^^ { case globalType ~ colKey ~ colType ~ rowPartitionKey ~ rowRestKey ~ rowType ~ entryType =>
-      MatrixType.fromParts(globalType.setRequired(false).asInstanceOf[TStruct], colKey, colType, rowPartitionKey ++ rowRestKey, rowType, entryType)
-    }
-
   def call: Parser[Call] = {
     wholeNumber ~ "/" ~ rep1sep(wholeNumber, "/") ^^ { case a0 ~ _ ~ arest =>
       CallN(coerceInt(a0) +: arest.map(coerceInt).toArray, phased = false)
@@ -330,10 +184,6 @@ object Parser extends JavaTokenParsers {
       "-" ^^ { _ => Call0(phased = false) } |
       "|-" ^^ { _ => Call0(phased = true) }
   }
-
-  def referenceGenomeDependentFunction: Parser[String] = "LocusInterval" | "LocusAlleles" | "Locus" |
-    "getReferenceSequence" | "isValidContig" | "isValidLocus" | "liftoverLocusInterval" | "liftoverLocus" |
-    "locusToGlobalPos" | "globalPosToLocus"
 
   def intervalWithEndpoints[T](bounds: Parser[(T, T, Boolean, Boolean)]): Parser[Interval] = {
     val start = ("[" ^^^ true) | ("(" ^^^ false)
@@ -399,332 +249,4 @@ object Parser extends JavaTokenParsers {
       "\\d+".r ~ "." ~ "\\d{1,6}".r ~ "[Mm]".r ^^ { case lft ~ _ ~ rt ~ _ => Some(coerceInt(lft + rt) * exp10(6 - rt.length)) } |
       "\\d+".r ^^ { i => Some(coerceInt(i)) }
   }
-
-  def int32_literal: Parser[Int] = wholeNumber.map(_.toInt)
-
-  def int64_literal: Parser[Long] = wholeNumber.map(_.toLong)
-
-  def float32_literal: Parser[Float] =
-    "nan" ^^ { _ => Float.NaN } |
-      "inf" ^^ { _ => Float.PositiveInfinity } |
-      "neginf" ^^ { _ => Float.NegativeInfinity } |
-      """-?\d+(\.\d+)?[eE][+-]?\d+""".r ^^ {
-        _.toFloat
-      } |
-      """-?\d*(\.\d+)?""".r ^^ {
-        _.toFloat
-      }
-
-  def float64_literal: Parser[Double] =
-    "nan" ^^ { _ => Double.NaN } |
-      "inf" ^^ { _ => Double.PositiveInfinity } |
-      "-inf" ^^ { _ => Double.NegativeInfinity } |
-      "neginf" ^^ { _ => Double.NegativeInfinity } |
-      """-?\d+(\.\d+)?[eE][+-]?\d+""".r ^^ {
-        _.toDouble
-      } |
-      """-?\d*(\.\d+)?""".r ^^ {
-        _.toDouble
-      }
-
-  def int32_literals: Parser[IndexedSeq[Int]] = "(" ~> rep(int32_literal) <~ ")" ^^ {
-    _.toFastIndexedSeq
-  }
-
-  def int32_literal_opt: Parser[Option[Int]] = int32_literal ^^ {
-    Some(_)
-  } | "None" ^^ { _ => None }
-
-  def int64_literals: Parser[IndexedSeq[Long]] = "(" ~> rep(int64_literal) <~ ")" ^^ {
-    _.toFastIndexedSeq
-  }
-
-  def int64_literals_opt: Parser[Option[IndexedSeq[Long]]] = int64_literals ^^ {
-    Some(_)
-  } | "None" ^^ { _ => None }
-
-  def string_literal: Parser[String] = stringLiteral
-
-  def string_literal_opt: Parser[Option[String]] = string_literal ^^ {
-    Some(_)
-  } | "None" ^^ { _ => None }
-
-  def string_literals: Parser[IndexedSeq[String]] = "(" ~> rep(string_literal).map(_.toFastIndexedSeq) <~ ")"
-
-  def string_literals_opt: Parser[Option[IndexedSeq[String]]] = string_literals ^^ {
-    Some(_)
-  } | "None" ^^ { _ => None }
-
-  def boolean_literal: Parser[Boolean] = "True" ^^ { _ => true } | "False" ^^ { _ => false }
-
-  def ir_identifier: Parser[String] = identifier
-
-  def ir_identifiers: Parser[IndexedSeq[String]] = "(" ~> rep(ir_identifier) <~ ")" ^^ {
-    _.toFastIndexedSeq
-  }
-
-  def ir_binary_op: Parser[ir.BinaryOp] =
-    ir_identifier ^^ { x => ir.BinaryOp.fromString(x) }
-
-  def ir_unary_op: Parser[ir.UnaryOp] =
-    ir_identifier ^^ { x => ir.UnaryOp.fromString(x) }
-
-  def ir_comparison_op: Parser[ir.ComparisonOp] =
-    "(" ~> ir_identifier ~ type_expr ~ type_expr <~ ")" ^^ { case x ~ t1 ~ t2 => ir.ComparisonOp.fromStringAndTypes(x, t1, t2) }
-
-  def ir_untyped_comparison_op: Parser[String] =
-    "(" ~> ir_identifier <~ ")" ^^ { x => x }
-
-  def ir_agg_op: Parser[ir.AggOp] =
-    ir_identifier ^^ { x => ir.AggOp.fromString(x) }
-
-  def ir_children(env: IRParserEnvironment): Parser[IndexedSeq[ir.IR]] =
-    rep(ir_value_expr(env)) ^^ (_.toFastIndexedSeq)
-
-  def table_ir_children(env: IRParserEnvironment): Parser[IndexedSeq[ir.TableIR]] = rep(table_ir(env)) ^^ (_.toFastIndexedSeq)
-
-  def matrix_ir_children(env: IRParserEnvironment): Parser[IndexedSeq[ir.MatrixIR]] = rep(matrix_ir(env)) ^^ (_.toFastIndexedSeq)
-
-  def ir_value_exprs(env: IRParserEnvironment): Parser[IndexedSeq[ir.IR]] =
-    "(" ~> rep(ir_value_expr(env)) <~ ")" ^^ (_.toFastIndexedSeq)
-
-  def ir_value_exprs_opt(env: IRParserEnvironment): Parser[Option[IndexedSeq[ir.IR]]] =
-    ir_value_exprs(env) ^^ { xs => Some(xs) } |
-      "None" ^^ { _ => None }
-
-  def matrix_type_expr_opt: Parser[Option[MatrixType]] = matrix_type_expr ^^ {
-    Some(_)
-  } | "None" ^^ { _ => None }
-
-  def type_exprs: Parser[Seq[Type]] = "(" ~> rep(type_expr) <~ ")"
-
-  def type_exprs_opt: Parser[Option[Seq[Type]]] = type_exprs ^^ { ts => Some(ts) } | "None" ^^ { _ => None }
-
-  def agg_signature: Parser[AggSignature] =
-    "(" ~> ir_agg_op ~ type_exprs ~ type_exprs_opt ~ type_exprs <~ ")" ^^ { case op ~ ctorArgTypes ~ initOpArgTypes ~ seqOpArgTypes =>
-      AggSignature(op, ctorArgTypes.map(t => -t), initOpArgTypes.map(_.map(t => -t)), seqOpArgTypes.map(t => -t))
-    }
-
-  def ir_named_value_exprs(env: IRParserEnvironment): Parser[Seq[(String, ir.IR)]] =
-    rep(ir_named_value_expr(env))
-
-  def ir_named_value_expr(env: IRParserEnvironment): Parser[(String, ir.IR)] =
-    "(" ~> ir_identifier ~ ir_value_expr(env) <~ ")" ^^ { case n ~ x => (n, x) }
-
-  def ir_opt[T](p: Parser[T]): Parser[Option[T]] = p ^^ {
-    Some(_)
-  } | "None" ^^ { _ => None }
-
-  def ir_value_expr(env: IRParserEnvironment): Parser[ir.IR] = "(" ~> ir_value_expr_1(env) <~ ")"
-
-  def ir_value_expr_1(env: IRParserEnvironment): Parser[ir.IR] = {
-    "I32" ~> int32_literal ^^ { x => ir.I32(x) } |
-      "I64" ~> int64_literal ^^ { x => ir.I64(x) } |
-      "F32" ~> float32_literal ^^ { x => ir.F32(x) } |
-      "F64" ~> float64_literal ^^ { x => ir.F64(x) } |
-      "Str" ~> string_literal ^^ { x => ir.Str(x) } |
-      "True" ^^ { x => ir.True() } |
-      "False" ^^ { x => ir.False() } |
-      "Literal" ~> ir_value ^^ { value => ir.Literal.coerce(value._1, value._2) } |
-      "Void" ^^ { x => ir.Void() } |
-      "Cast" ~> type_expr ~ ir_value_expr(env) ^^ { case t ~ v => ir.Cast(v, t) } |
-      "NA" ~> type_expr ^^ { t => ir.NA(t) } |
-      "IsNA" ~> ir_value_expr(env) ^^ { value => ir.IsNA(value) } |
-      "If" ~> ir_value_expr(env) ~ ir_value_expr(env) ~ ir_value_expr(env) ^^ { case cond ~ consq ~ altr => ir.If.unify(cond, consq, altr) } |
-      "Let" ~> ir_identifier ~ ir_value_expr(env) >> { case name ~ value =>
-        ir_value_expr(env + (name -> value.typ)) ^^ { body => ir.Let(name, value, body) }} |
-      "Ref" ~> ir_identifier ^^ { name => ir.Ref(name, env.refMap(name)) } |
-      "ApplyBinaryPrimOp" ~> ir_binary_op ~ ir_value_expr(env) ~ ir_value_expr(env) ^^ { case op ~ l ~ r => ir.ApplyBinaryPrimOp(op, l, r) } |
-      "ApplyUnaryPrimOp" ~> ir_unary_op ~ ir_value_expr(env) ^^ { case op ~ x => ir.ApplyUnaryPrimOp(op, x) } |
-      "ApplyComparisonOp" ~> ir_comparison_op ~ ir_value_expr(env) ~ ir_value_expr(env) ^^ { case op ~ l ~ r => ir.ApplyComparisonOp(op, l, r) } |
-      "ApplyComparisonOp" ~> ir_untyped_comparison_op ~ ir_value_expr(env) ~ ir_value_expr(env) ^^ { case op ~ l ~ r => ir.ApplyComparisonOp(ir.ComparisonOp.fromStringAndTypes(op, l.typ, r.typ), l, r) } |
-      "MakeArray" ~> type_expr_opt ~ ir_children(env) ^^ { case t ~ args => ir.MakeArray.unify(args, t.map(_.asInstanceOf[TArray]).orNull) } |
-      "ArrayRef" ~> ir_value_expr(env) ~ ir_value_expr(env) ^^ { case a ~ i => ir.ArrayRef(a, i) } |
-      "ArrayLen" ~> ir_value_expr(env) ^^ { a => ir.ArrayLen(a) } |
-      "ArrayRange" ~> ir_value_expr(env) ~ ir_value_expr(env) ~ ir_value_expr(env) ^^ { case start ~ stop ~ step => ir.ArrayRange(start, stop, step) } |
-      "ArraySort" ~> boolean_literal ~ ir_value_expr(env) ~ ir_value_expr(env) ^^ { case onKey ~ a ~ ascending => ir.ArraySort(a, ascending, onKey) } |
-      "ToSet" ~> ir_value_expr(env) ^^ { a => ir.ToSet(a) } |
-      "ToDict" ~> ir_value_expr(env) ^^ { a => ir.ToDict(a) } |
-      "ToArray" ~> ir_value_expr(env) ^^ { a => ir.ToArray(a) } |
-      "LowerBoundOnOrderedCollection" ~> boolean_literal ~ ir_value_expr(env) ~ ir_value_expr(env) ^^ { case onKey ~ col ~ elem => ir.LowerBoundOnOrderedCollection(col, elem, onKey) } |
-      "GroupByKey" ~> ir_value_expr(env) ^^ { a => ir.GroupByKey(a) } |
-      "ArrayMap" ~> ir_identifier ~ ir_value_expr(env) >> { case name ~ a =>
-        ir_value_expr(env + (name -> coerce[TArray](a.typ).elementType)) ^^ { body => ir.ArrayMap(a, name, body) }} |
-      "ArrayFilter" ~> ir_identifier ~ ir_value_expr(env) >> { case name ~ a =>
-        ir_value_expr(env + (name -> coerce[TArray](a.typ).elementType)) ^^ { body => ir.ArrayFilter(a, name, body) }} |
-      "ArrayFlatMap" ~> ir_identifier ~ ir_value_expr(env) >> { case name ~ a =>
-        ir_value_expr(env + (name -> coerce[TArray](a.typ).elementType)) ^^ { body => ir.ArrayFlatMap(a, name, body) }} |
-      "ArrayFold" ~> ir_identifier ~ ir_identifier ~ ir_value_expr(env) ~ ir_value_expr(env) >> { case accumName ~ valueName ~ a ~ zero =>
-        val eltType = coerce[TArray](a.typ).elementType
-        ir_value_expr(env.update(Map(accumName -> zero.typ, valueName -> eltType))) ^^ { body => ir.ArrayFold(a, zero, accumName, valueName, body) }} |
-      "ArrayScan" ~> ir_identifier ~ ir_identifier ~ ir_value_expr(env) ~ ir_value_expr(env) >> { case accumName ~ valueName ~ a ~ zero =>
-        val eltType = coerce[TArray](a.typ).elementType
-        ir_value_expr(env.update(Map(accumName -> zero.typ, valueName -> eltType))) ^^ { body => ir.ArrayScan(a, zero, accumName, valueName, body) }} |
-      "ArrayFor" ~> ir_identifier ~ ir_value_expr(env) >> { case name ~ a =>
-        ir_value_expr(env + (name -> coerce[TArray](a.typ).elementType)) ^^ { body => ir.ArrayFor(a, name, body) }} |
-      "AggFilter" ~> ir_value_expr(env) ~ ir_value_expr(env) ^^ { case cond ~ aggIR => ir.AggFilter(cond, aggIR) } |
-      "AggExplode" ~> ir_identifier ~ ir_value_expr(env) >> { case name ~ a =>
-        ir_value_expr(env + (name -> coerce[TArray](a.typ).elementType)) ^^ { aggBody => ir.AggExplode(a, name, aggBody) }} |
-      "AggGroupBy" ~> ir_value_expr(env) ~ ir_value_expr(env) ^^ { case key ~ aggIR => ir.AggGroupBy(key, aggIR) } |
-      "ApplyAggOp" ~> agg_signature ~ ir_value_exprs(env) ~ ir_value_exprs_opt(env) ~ ir_value_exprs(env) ^^ { case aggSig ~ ctorArgs ~ initOpArgs ~ seqOpArgs => ir.ApplyAggOp(ctorArgs, initOpArgs, seqOpArgs, aggSig) } |
-      "ApplyScanOp" ~> agg_signature ~ ir_value_exprs(env) ~ ir_value_exprs_opt(env) ~ ir_value_exprs(env) ^^ { case aggSig ~ ctorArgs ~ initOpArgs ~ seqOpArgs => ir.ApplyScanOp(ctorArgs, initOpArgs, seqOpArgs, aggSig) } |
-      "InitOp" ~> agg_signature ~ ir_value_expr(env) ~ ir_value_exprs(env) ^^ { case aggSig ~ i ~ args => ir.InitOp(i, args, aggSig) } |
-      "SeqOp" ~> agg_signature ~ ir_value_expr(env) ~ ir_value_exprs(env) ^^ { case aggSig ~ i ~ args => ir.SeqOp(i, args, aggSig) } |
-      "Begin" ~> ir_children(env) ^^ { xs => ir.Begin(xs) } |
-      "MakeStruct" ~> ir_named_value_exprs(env) ^^ { fields => ir.MakeStruct(fields) } |
-      "SelectFields" ~> ir_identifiers ~ ir_value_expr(env) ^^ { case fields ~ old => ir.SelectFields(old, fields) } |
-      "InsertFields" ~> ir_value_expr(env) ~ ir_named_value_exprs(env) ^^ { case old ~ fields => ir.InsertFields(old, fields) } |
-      "GetField" ~> ir_identifier ~ ir_value_expr(env) ^^ { case name ~ o => ir.GetField(o, name) } |
-      "MakeTuple" ~> ir_children(env) ^^ { xs => ir.MakeTuple(xs) } |
-      "GetTupleElement" ~> int32_literal ~ ir_value_expr(env) ^^ { case idx ~ o => ir.GetTupleElement(o, idx) } |
-      "StringSlice" ~> ir_value_expr(env) ~ ir_value_expr(env) ~ ir_value_expr(env) ^^ { case s ~ start ~ end => ir.StringSlice(s, start, end) } |
-      "StringLength" ~> ir_value_expr(env) ^^ { s => ir.StringLength(s) } |
-      "In" ~> type_expr ~ int32_literal ^^ { case t ~ i => ir.In(i, t) } |
-      "Die" ~> type_expr ~ string_literal ^^ { case t ~ message => ir.Die(message, t) } |
-      "ApplySeeded" ~> ir_identifier ~ int64_literal ~ ir_children(env) ^^ { case function ~ seed ~ args => ir.ApplySeeded(function, args, seed) } |
-      ("ApplyIR" | "ApplySpecial" | "Apply") ~> ir_identifier ~ ir_children(env) ^^ { case function ~ args => ir.invoke(function, args: _*) } |
-      "Uniroot" ~> ir_identifier >> { name => ir_value_expr(env + (name -> TFloat64())) ~ ir_value_expr(env) ~ ir_value_expr(env) ^^ { case f ~ min ~ max => ir.Uniroot(name, f, min, max) }} |
-      "JavaIR" ~> ir_identifier ^^ { name => env.irMap(name).asInstanceOf[IR] } |
-      "TableCount" ~> table_ir(env) ^^ { child => ir.TableCount(child) } |
-      "TableAggregate" ~> table_ir(env) >> { child =>
-        ir_value_expr(env.update(child.typ.refMap)) ^^ { query => ir.TableAggregate(child, query) }} |
-      "TableWrite" ~> string_literal ~ boolean_literal ~ boolean_literal ~ string_literal_opt ~ table_ir(env) ^^ {
-        case path ~ overwrite ~ shuffleLocally ~ codecSpecJsonStr ~ child =>
-          ir.TableWrite(child, path, overwrite, shuffleLocally, codecSpecJsonStr.orNull) }
-  }
-
-  def ir_value: Parser[(Type, Any)] = type_expr ~ string_literal ^^ { case t ~ vJSONStr =>
-    val vJSON = JsonMethods.parse(vJSONStr)
-    val v = JSONAnnotationImpex.importAnnotation(vJSON, t)
-    (t, v)
-  }
-
-  def table_ir(env: IRParserEnvironment): Parser[ir.TableIR] = "(" ~> table_ir_1(env) <~ ")"
-
-  def table_irs(env: IRParserEnvironment): Parser[IndexedSeq[ir.TableIR]] = "(" ~> rep(table_ir(env)) <~ ")" ^^ {
-    _.toFastIndexedSeq
-  }
-
-  def table_ir_1(env: IRParserEnvironment): Parser[ir.TableIR] = {
-    // FIXME TableImport
-    "TableKeyBy" ~> ir_identifiers ~ boolean_literal ~ table_ir(env) ^^ { case key ~ isSorted ~ child =>
-      ir.TableKeyBy(child, key, isSorted)
-    } |
-      "TableDistinct" ~> table_ir(env) ^^ { t => ir.TableDistinct(t) } |
-      "TableFilter" ~> table_ir(env) >> { child =>
-        ir_value_expr(env.withRefMap(child.typ.refMap)) ^^ { pred => ir.TableFilter(child, pred) }} |
-      "TableRead" ~> string_literal ~ boolean_literal ~ ir_opt(table_type_expr) ^^ { case path ~ dropRows ~ typ =>
-        TableIR.read(HailContext.get, path, dropRows, typ)
-      } |
-      "MatrixColsTable" ~> matrix_ir(env) ^^ { child => ir.MatrixColsTable(child) } |
-      "MatrixRowsTable" ~> matrix_ir(env) ^^ { child => ir.MatrixRowsTable(child) } |
-      "MatrixEntriesTable" ~> matrix_ir(env) ^^ { child => ir.MatrixEntriesTable(child) } |
-      "TableAggregateByKey" ~> table_ir(env) >> { child =>
-        ir_value_expr(env.withRefMap(child.typ.refMap)) ^^ { expr => ir.TableAggregateByKey(child, expr) }} |
-      "TableKeyByAndAggregate" ~> int32_literal_opt ~ int32_literal ~ table_ir(env) >> { case nPartitions ~ bufferSize ~ child =>
-        val newEnv = env.withRefMap(child.typ.refMap)
-        ir_value_expr(newEnv) ~ ir_value_expr(newEnv) ^^ {
-        case expr ~ newKey => ir.TableKeyByAndAggregate(child, expr, newKey, nPartitions, bufferSize) }} |
-      "TableRepartition" ~> int32_literal ~ boolean_literal ~ table_ir(env) ^^ { case n ~ shuffle ~ child => ir.TableRepartition(child, n, shuffle) } |
-      "TableHead" ~> int64_literal ~ table_ir(env) ^^ { case n ~ child => ir.TableHead(child, n) } |
-      "TableJoin" ~> ir_identifier ~ int32_literal ~ table_ir(env) ~ table_ir(env) ^^ { case joinType ~ joinKey ~ left ~ right =>
-        ir.TableJoin(left, right, joinType, joinKey) } |
-      "TableLeftJoinRightDistinct" ~> ir_identifier ~ table_ir(env) ~ table_ir(env) ^^ { case root ~ left ~ right => ir.TableLeftJoinRightDistinct(left, right, root) } |
-      "TableMultiWayZipJoin" ~> string_literal ~ string_literal ~ table_ir_children(env) ^^ { case dataName ~ globalsName ~ children =>
-        ir.TableMultiWayZipJoin(children, dataName, globalsName)
-      } |
-      "TableParallelize" ~> int32_literal_opt ~ ir_value_expr(env) ^^ { case nPartitions ~ rows =>
-        ir.TableParallelize(rows, nPartitions)
-      } |
-      "TableMapRows" ~> table_ir(env) >> { child => ir_value_expr(env.withRefMap(child.typ.refMap)) ^^ { newRow => ir.TableMapRows(child, newRow) }} |
-      "TableMapGlobals" ~> table_ir(env) >> { child => ir_value_expr(env.withRefMap(child.typ.refMap)) ^^ { newRow => ir.TableMapGlobals(child, newRow) }} |
-      "TableRange" ~> int32_literal ~ int32_literal ^^ { case n ~ nPartitions => ir.TableRange(n, nPartitions) } |
-      "TableUnion" ~> table_ir_children(env) ^^ { children => ir.TableUnion(children) } |
-      "TableOrderBy" ~> ir_identifiers ~ table_ir(env) ^^ { case identifiers ~ child =>
-        ir.TableOrderBy(child, identifiers.map(i =>
-          if (i.charAt(0) == 'A')
-            SortField(i.substring(1), Ascending)
-          else
-            SortField(i.substring(1), Descending)))
-      } |
-      "TableExplode" ~> ir_identifier ~ table_ir(env) ^^ { case field ~ child => ir.TableExplode(child, field) } |
-      "CastMatrixToTable" ~> string_literal ~ string_literal ~ matrix_ir(env) ^^ { case entriesField ~ colsField ~ child =>
-        ir.CastMatrixToTable(child, entriesField, colsField)
-      } |
-      "TableRename" ~> string_literals ~ string_literals ~ string_literals ~ string_literals ~ table_ir(env) ^^ {
-        case rowK ~ rowV ~ globalK ~ globalV ~ child => ir.TableRename(child, rowK.zip(rowV).toMap, globalK.zip(globalV).toMap)
-      } |
-      "JavaTable" ~> ir_identifier ^^ { ident => env.irMap(ident).asInstanceOf[TableIR] }
-  }
-
-  def matrix_ir(env: IRParserEnvironment): Parser[ir.MatrixIR] = "(" ~> matrix_ir_1(env) <~ ")"
-
-  def matrix_ir_1(env: IRParserEnvironment): Parser[ir.MatrixIR] = {
-    "MatrixFilterCols" ~> matrix_ir(env) >> { child => ir_value_expr(env.withRefMap(child.typ.refMap)) ^^ (pred => ir.MatrixFilterCols(child, pred)) } |
-      "MatrixFilterRows" ~> matrix_ir(env) >> { child => ir_value_expr(env.withRefMap(child.typ.refMap)) ^^ (pred => ir.MatrixFilterRows(child, pred)) } |
-      "MatrixFilterEntries" ~> matrix_ir(env) >> { child => ir_value_expr(env.withRefMap(child.typ.refMap)) ^^ (pred => ir.MatrixFilterEntries(child, pred)) } |
-      "MatrixMapCols" ~> string_literals_opt ~ matrix_ir(env) >> { case newKey ~ child =>
-        ir_value_expr(env.withRefMap(child.typ.refMap)) ^^ { newCol => ir.MatrixMapCols(child, newCol, newKey) }} |
-      "MatrixKeyRowsBy" ~> ir_identifiers ~ boolean_literal ~ matrix_ir(env) ^^ { case key ~ isSorted ~ child => ir.MatrixKeyRowsBy(child, key, isSorted) } |
-      "MatrixMapRows" ~> matrix_ir(env) >> { child => ir_value_expr(env.withRefMap(child.typ.refMap)) ^^ (newRow => ir.MatrixMapRows(child, newRow)) } |
-      "MatrixMapEntries" ~> matrix_ir(env) >> { child => ir_value_expr(env.withRefMap(child.typ.refMap)) ^^ (newEntry => ir.MatrixMapEntries(child, newEntry)) } |
-      "MatrixMapGlobals" ~> matrix_ir(env) >> { child => ir_value_expr(env.withRefMap(child.typ.refMap)) ^^ (newGlobals => ir.MatrixMapGlobals(child, newGlobals)) } |
-      "MatrixAggregateColsByKey" ~> matrix_ir(env) >> { child =>
-        val newEnv = env.withRefMap(child.typ.refMap)
-        ir_value_expr(newEnv) ~ ir_value_expr(newEnv) ^^ {
-          case entryExpr ~ colExpr => ir.MatrixAggregateColsByKey(child, entryExpr, colExpr) }} |
-      "MatrixAggregateRowsByKey" ~> matrix_ir(env) >> { child =>
-        val newEnv = env.withRefMap(child.typ.refMap)
-        ir_value_expr(newEnv) ~ ir_value_expr(newEnv) ^^ {
-          case entryExpr ~ rowExpr => ir.MatrixAggregateRowsByKey(child, entryExpr, rowExpr) }} |
-      "MatrixRead" ~> matrix_type_expr_opt ~ boolean_literal ~ boolean_literal ~ string_literal ^^ {
-        case typ ~ dropCols ~ dropRows ~ readerStr =>
-          implicit val formats = ir.MatrixReader.formats
-          val reader = Serialization.read[ir.MatrixReader](readerStr)
-          ir.MatrixRead(typ.getOrElse(reader.fullType), dropCols, dropRows, reader)
-      } |
-      "TableToMatrixTable" ~> string_literals ~ string_literals ~ string_literals ~ string_literals ~ int32_literal_opt ~ table_ir(env) ^^ {
-        case rowKey ~ colKey ~ rowFields ~ colFields ~ nPartitions ~ child =>
-          ir.TableToMatrixTable(child, rowKey, colKey, rowFields, colFields, nPartitions)
-      } |
-      "MatrixAnnotateRowsTable" ~> string_literal ~ boolean_literal ~ matrix_ir(env) ~ table_ir(env) >> {
-        case uid ~ hasKey ~ child ~ table => rep(ir_value_expr(env.withRefMap(child.typ.refMap))) ^^ {
-          key =>
-          val keyIRs = if (hasKey) Some(key.toFastIndexedSeq) else None
-          ir.MatrixAnnotateRowsTable(child, table, uid, keyIRs)
-      }} |
-      "MatrixAnnotateColsTable" ~> string_literal ~ matrix_ir(env) ~ table_ir(env) ^^ {
-        case root ~ child ~ table =>
-          ir.MatrixAnnotateColsTable(child, table, root)
-      } |
-      "MatrixExplodeRows" ~> ir_identifiers ~ matrix_ir(env) ^^ { case path ~ child => ir.MatrixExplodeRows(child, path) } |
-      "MatrixExplodeCols" ~> ir_identifiers ~ matrix_ir(env) ^^ { case path ~ child => ir.MatrixExplodeCols(child, path) } |
-      "MatrixChooseCols" ~> int32_literals ~ matrix_ir(env) ^^ { case oldIndices ~ child => ir.MatrixChooseCols(child, oldIndices) } |
-      "MatrixCollectColsByKey" ~> matrix_ir(env) ^^ { child => ir.MatrixCollectColsByKey(child) } |
-      "MatrixUnionRows" ~> matrix_ir_children(env) ^^ { children => ir.MatrixUnionRows(children) } |
-      "CastTableToMatrix" ~> ir_identifier ~ ir_identifier ~ ir_identifiers ~ table_ir(env) ^^ {
-        case entriesField ~ colsField ~ colKey ~ child => ir.CastTableToMatrix(child, entriesField, colsField, colKey)
-      } |
-      "JavaMatrix" ~> ir_identifier ^^ { ident => env.irMap(ident).asInstanceOf[MatrixIR] }
-  }
-
-  def parse_value_ir(s: String): IR = parse_value_ir(s, IRParserEnvironment())
-  def parse_value_ir(s: String, refMap: java.util.HashMap[String, Type], irMap: java.util.HashMap[String, BaseIR]): IR =
-    parse_value_ir(s, IRParserEnvironment(refMap.asScala.toMap, irMap.asScala.toMap))
-  def parse_value_ir(s: String, env: IRParserEnvironment): IR = parse(ir_value_expr(env), s)
-
-  def parse_named_value_irs(s: String): Array[(String, IR)] = parse_named_value_irs(s, IRParserEnvironment())
-  def parse_named_value_irs(s: String, refMap: java.util.HashMap[String, Type], irMap: java.util.HashMap[String, BaseIR]): Array[(String, IR)] =
-    parse_named_value_irs(s, IRParserEnvironment(refMap.asScala.toMap, irMap.asScala.toMap))
-  def parse_named_value_irs(s: String, env: IRParserEnvironment): Array[(String, IR)] = parse(ir_named_value_exprs(env), s).toArray
-
-  def parse_table_ir(s: String): TableIR = parse_table_ir(s, IRParserEnvironment())
-  def parse_table_ir(s: String, refMap: java.util.HashMap[String, Type], irMap: java.util.HashMap[String, BaseIR]): TableIR =
-    parse_table_ir(s, IRParserEnvironment(refMap.asScala.toMap, irMap.asScala.toMap))
-  def parse_table_ir(s: String, env: IRParserEnvironment): TableIR = parse(table_ir(env), s)
-
-  def parse_matrix_ir(s: String): MatrixIR = parse(matrix_ir(IRParserEnvironment()), s)
-  def parse_matrix_ir(s: String, refMap: java.util.HashMap[String, Type], irMap: java.util.HashMap[String, BaseIR]): MatrixIR =
-    parse_matrix_ir(s, IRParserEnvironment(refMap.asScala.toMap, irMap.asScala.toMap))
-  def parse_matrix_ir(s: String, env: IRParserEnvironment): MatrixIR = parse(matrix_ir(env), s)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -170,7 +170,7 @@ class EmitFunctionBuilder[F >: Null](
     val references = ReferenceGenome.getReferences(t.virtualType).toArray
     val setup = Code(Code(references.map(addReferenceGenome): _*),
       Code.invokeScalaObject[String, PType](
-        Parser.getClass, "parsePType", const(t.parsableString())))
+        IRParser.getClass, "parsePType", const(t.parsableString())))
     pTypeMap.getOrElseUpdate(t,
       newLazyField[PType](setup))
   }
@@ -179,7 +179,7 @@ class EmitFunctionBuilder[F >: Null](
     val references = ReferenceGenome.getReferences(t).toArray
     val setup = Code(Code(references.map(addReferenceGenome): _*),
       Code.invokeScalaObject[String, Type](
-        Parser.getClass, "parseType", const(t.parsableString())))
+        IRParser.getClass, "parseType", const(t.parsableString())))
     typMap.getOrElseUpdate(t,
       newLazyField[Type](setup))
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -6,7 +6,7 @@ import is.hail.{HailContext, Uploader, stats}
 import is.hail.annotations.aggregators.RegionValueAggregator
 import is.hail.annotations._
 import is.hail.asm4s.AsmFunction3
-import is.hail.expr.{IRParserEnvironment, JSONAnnotationImpex, Parser, TypedAggregator}
+import is.hail.expr.{JSONAnnotationImpex, TypedAggregator}
 import is.hail.expr.types._
 import is.hail.expr.types.physical.PTuple
 import is.hail.expr.types.virtual._
@@ -26,7 +26,7 @@ object Interpret {
   }
 
   def interpretPyIR(s: String, refMap: Map[String, Type] = Map.empty, irMap: Map[String, BaseIR] = Map.empty): String = {
-    val ir = Parser.parse_value_ir(s, IRParserEnvironment(refMap, irMap))
+    val ir = IRParser.parse_value_ir(s, IRParserEnvironment(refMap, irMap))
     val t = ir.typ
     val value = Interpret[Any](ir)
 

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -46,8 +46,8 @@ object IRLexer extends JavaTokenParsers {
   val token: Parser[Token] =
     "[()\\[\\]{}<>,:+@=]".r ^^ { p => PunctuationToken(p) } |
       identifier ^^ { id => IdentifierToken(id) } |
-      int64_literal ^^ { l => IntegerToken(l) } |
       float64_literal ^^ { d => FloatToken(d) } |
+      int64_literal ^^ { l => IntegerToken(l) } |
       string_literal ^^ { s => StringToken(s) }
 
   val lexer: Parser[Array[Token]] = rep(positioned(token)) ^^ { l => l.toArray }

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -107,9 +107,7 @@ object IRLexer extends JavaTokenParsers {
   def int64_literal: Parser[Long] = wholeNumber.map(_.toLong)
 
   def float64_literal: Parser[Double] =
-    "nan" ^^ { _ => Double.NaN } |
-      "inf" ^^ { _ => Double.PositiveInfinity } |
-      "-inf" ^^ { _ => Double.NegativeInfinity } |
+      "-inf" ^^ { _ => Double.NegativeInfinity } | // inf, neginf, and nan are parsed as identifiers
       """[+-]?\d+(\.\d+)?[eE][+-]?\d+""".r ^^ { _.toDouble } |
       """[+-]?\d*\.\d+""".r ^^ { _.toDouble }
 
@@ -336,11 +334,6 @@ object IRParser {
         val id = identifier(it)
         punctuation(it, ")")
         ReferenceGenome.getReference(id).locusType
-      case "LocusAlleles" =>
-        punctuation(it, "(")
-        val id = identifier(it)
-        punctuation(it, ")")
-        ReferenceGenome.getReference(id).intervalType
       case "Call" => TCall()
       case "Array" =>
         punctuation(it, "[")

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -2,7 +2,8 @@ package is.hail.expr.ir
 
 import is.hail.HailContext
 import is.hail.expr.{JSONAnnotationImpex, ParserUtils}
-import is.hail.expr.types._
+import is.hail.expr.types.{MatrixType, TableType}
+import is.hail.expr.types.virtual._
 import is.hail.expr.types.physical.PType
 import is.hail.rvd.RVDType
 import is.hail.table.{Ascending, Descending, SortField}

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1,0 +1,1025 @@
+package is.hail.expr.ir
+
+import is.hail.HailContext
+import is.hail.expr.{JSONAnnotationImpex, ParserUtils}
+import is.hail.expr.types._
+import is.hail.expr.types.physical.PType
+import is.hail.rvd.RVDType
+import is.hail.table.{Ascending, Descending, SortField}
+import is.hail.utils.StringEscapeUtils._
+import is.hail.utils._
+import is.hail.variant.ReferenceGenome
+import org.json4s.jackson.{JsonMethods, Serialization}
+
+import scala.util.parsing.combinator.JavaTokenParsers
+import scala.collection.JavaConverters._
+import scala.reflect.ClassTag
+import scala.util.parsing.input.Positional
+
+abstract class Token extends Positional {
+  def value: Any
+}
+
+final case class IdentifierToken(value: String) extends Token { }
+final case class StringToken(value: String) extends Token { }
+final case class IntegerToken(value: Long) extends Token { }
+final case class FloatToken(value: Double) extends Token { }
+final case class PunctuationToken(value: String) extends Token { }
+
+case class TokenIterator(a: Array[Token]) extends BufferedIterator[Token] {
+  private var pos = 0
+
+  def next(): Token = {
+    val x = a(pos)
+    pos += 1
+    x
+  }
+
+  def hasNext(): Boolean = pos < a.length
+
+  def head(): Token = {
+    assert(hasNext())
+    a(pos)
+  }
+}
+
+object IRLexer extends JavaTokenParsers {
+  val token: Parser[Token] =
+    "[()\\[\\]{}<>,:+@=]".r ^^ { p => PunctuationToken(p) } |
+      identifier ^^ { id => IdentifierToken(id) } |
+      float64_literal ^^ { d => FloatToken(d) } |
+      int64_literal ^^ { l => IntegerToken(l) } |
+      string_literal ^^ { s => StringToken(s) }
+
+  val lexer: Parser[Array[Token]] = rep(positioned(token)) ^^ { l => l.toArray }
+
+  def quotedLiteral(delim: Char, what: String): Parser[String] =
+    new Parser[String] {
+      def apply(in: Input): ParseResult[String] = {
+        var r = in
+
+        val source = in.source
+        val offset = in.offset
+        val start = handleWhiteSpace(source, offset)
+        r = r.drop(start - offset)
+
+        if (r.atEnd || r.first != delim)
+          return Failure(s"consumed $what", r)
+        r = r.rest
+
+        val sb = new StringBuilder()
+
+        val escapeChars = "\\bfnrt'\"`".toSet
+        var continue = true
+        while (continue) {
+          if (r.atEnd)
+            return Failure(s"unterminated $what", r)
+          val c = r.first
+          r = r.rest
+          if (c == delim)
+            continue = false
+          else {
+            sb += c
+            if (c == '\\') {
+              if (r.atEnd)
+                return Failure(s"unterminated $what", r)
+              val d = r.first
+              if (!escapeChars.contains(d))
+                return Failure(s"invalid escape character in $what", r)
+              sb += d
+              r = r.rest
+            }
+          }
+        }
+        Success(unescapeString(sb.result()), r)
+      }
+    }
+
+  override def stringLiteral: Parser[String] =
+    quotedLiteral('"', "string literal") | quotedLiteral('\'', "string literal")
+
+  def backtickLiteral: Parser[String] = quotedLiteral('`', "backtick identifier")
+
+  def identifier = backtickLiteral | ident
+
+  def string_literal: Parser[String] = stringLiteral
+
+  def int64_literal: Parser[Long] = wholeNumber.map(_.toLong)
+
+  def float64_literal: Parser[Double] =
+      "-inf" ^^ { _ => Double.NegativeInfinity } |
+      """-?\d+(\.\d+)?[eE][+-]?\d+""".r ^^ { _.toDouble } |
+      """-?\d*\.\d+""".r ^^ { _.toDouble } // FIXME: Is this correct??
+
+  def parse(code: String): Array[Token] = {
+    parseAll(lexer, code) match {
+      case Success(result, _) => result
+      case NoSuccess(msg, next) => ParserUtils.error(next.pos, msg)
+    }
+  }
+}
+
+case class IRParserEnvironment(
+  refMap: Map[String, Type] = Map.empty,
+  irMap: Map[String, BaseIR] = Map.empty
+) {
+  def update(newRefMap: Map[String, Type] = Map.empty, newIRMap: Map[String, BaseIR] = Map.empty): IRParserEnvironment =
+    copy(refMap = refMap ++ newRefMap, irMap = irMap ++ newIRMap)
+
+  def withRefMap(newRefMap: Map[String, Type]): IRParserEnvironment = {
+    assert(refMap.isEmpty)
+    copy(refMap = newRefMap)
+  }
+
+  def +(t: (String, Type)): IRParserEnvironment = copy(refMap = refMap + t, irMap)
+}
+
+object IRParser {
+  def error(t: Token, msg: String): Nothing = ParserUtils.error(t.pos, msg)
+
+  def consumeToken(it: TokenIterator): Token = {
+    if (!it.hasNext)
+      fatal("No more tokens to consume.")
+    it.next()
+  }
+
+  def punctuation(it: TokenIterator, symbol: String): String = {
+    consumeToken(it) match {
+      case x: PunctuationToken if x.value == symbol => x.value
+      case x: Token => error(x, s"Expected punctuation with symbol '$symbol' but found ${ x.getClass } with value '${ x.value }'.")
+    }
+  }
+
+  def identifier(it: TokenIterator): String = {
+    consumeToken(it) match {
+      case x: IdentifierToken => x.value
+      case x: Token => error(x, s"Expected identifier but found ${ x.getClass } with value '${ x.value }'.")
+    }
+  }
+
+  def identifier(it: TokenIterator, expectedId: String): String = {
+    consumeToken(it) match {
+      case x: IdentifierToken if x.value == expectedId => x.value
+      case x: Token => error(x, s"Expected identifier with value '$expectedId' but found ${ x.getClass } with value '${ x.value }'.")
+    }
+  }
+
+  def identifiers(it: TokenIterator): Array[String] = {
+    punctuation(it, "(")
+    val ids = repUntil(it, identifier, PunctuationToken(")"))
+    punctuation(it, ")")
+    ids
+  }
+
+  def boolean_literal(it: TokenIterator): Boolean = {
+    consumeToken(it) match {
+      case x: IdentifierToken => x.value match {
+          case "True" => true
+          case "False" => false
+          case _ => error(x, s"Expected boolean but found ${ x.getClass } with value '${ x.value }'.")
+        }
+      case x: Token => error(x, s"Expected boolean but found ${ x.getClass } with value '${ x.value }'.")
+    }
+  }
+
+  def int32_literal(it: TokenIterator): Int = {
+    consumeToken(it) match {
+      case x: IntegerToken =>
+        if (x.value >= Int.MinValue && x.value <= Int.MaxValue)
+          x.value.toInt
+        else
+          error(x, s"Found integer value '${ x.value }' that is outside the numeric range for int32.")
+      case x: Token => error(x, s"Expected int32 but found ${ x.getClass } with value '${ x.value }'.")
+    }
+  }
+
+  def int32_literals(it: TokenIterator): Array[Int] = {
+    punctuation(it, "(")
+    val ints = repUntil(it, int32_literal, PunctuationToken(")"))
+    punctuation(it, ")")
+    ints
+  }
+
+  def int64_literal(it: TokenIterator): Long = {
+    consumeToken(it) match {
+      case x: IntegerToken => x.value
+      case x: Token => error(x, s"Expected int64 but found ${ x.getClass } with value '${ x.value }'.")
+    }
+  }
+
+  def float32_literal(it: TokenIterator): Float = {
+    consumeToken(it) match {
+      case x: FloatToken =>
+        if (x.value >= Float.MinValue && x.value <= Float.MaxValue)
+          x.value.toFloat
+        else
+          error(x, s"Found float value '${ x.value }' that is outside the numeric range for float32.")
+      case x: IntegerToken => x.value.toFloat
+      case x: IdentifierToken => x.value match {
+        case "nan" => Float.NaN
+        case "inf" => Float.PositiveInfinity
+        case "neginf" => Float.NegativeInfinity
+        case _ => error(x, s"Expected float32 but found ${ x.getClass } with value '${ x.value }'.")
+      }
+      case x: Token => error(x, s"Expected float32 but found ${ x.getClass } with value '${ x.value }'.")
+    }
+  }
+
+  def float64_literal(it: TokenIterator): Double = {
+    consumeToken(it) match {
+      case x: FloatToken => x.value
+      case x: IntegerToken => x.value.toDouble
+      case x: IdentifierToken => x.value match {
+        case "nan" => Double.NaN
+        case "inf" => Double.PositiveInfinity
+        case "neginf" => Double.NegativeInfinity
+        case _ => error(x, s"Expected float64 but found ${ x.getClass } with value '${ x.value }'.")
+      }
+      case x: Token => error(x, s"Expected float64 but found ${ x.getClass } with value '${ x.value }'.")
+    }
+  }
+
+  def string_literal(it: TokenIterator): String = {
+    consumeToken(it) match {
+      case x: StringToken => x.value
+      case x: Token => error(x, s"Expected string but found ${ x.getClass } with value '${ x.value }'.")
+    }
+  }
+
+  def string_literals(it: TokenIterator): Array[String] = {
+    punctuation(it, "(")
+    val strings = repUntil(it, string_literal, PunctuationToken(")"))
+    punctuation(it, ")")
+    strings
+  }
+
+  def opt[T](it: TokenIterator, f: (TokenIterator) => T)(implicit tct: ClassTag[T]): Option[T] = {
+    it.head() match {
+      case x: IdentifierToken if x.value == "None" =>
+        consumeToken(it)
+        None
+      case _ =>
+        Some(f(it))
+    }
+  }
+
+  def repsepUntil[T](it: TokenIterator,
+    f: (TokenIterator) => T,
+    sep: Token,
+    end: Token)(implicit tct: ClassTag[T]): Array[T] = {
+    val xs = new ArrayBuilder[T]()
+    while (it.hasNext() && it.head() != end) {
+      xs += f(it)
+      if (it.head() == sep)
+        consumeToken(it)
+    }
+    xs.result()
+  }
+
+  def repUntil[T](it: TokenIterator,
+    f: (TokenIterator) => T,
+    end: Token)(implicit tct: ClassTag[T]): Array[T] = {
+    val xs = new ArrayBuilder[T]()
+    while (it.hasNext() && it.head() != end) {
+      xs += f(it)
+    }
+    xs.result()
+  }
+
+  def decorator(it: TokenIterator): (String, String) = {
+    punctuation(it, "@")
+    val name = identifier(it)
+    punctuation(it, "=")
+    val desc = string_literal(it)
+    (name, desc)
+  }
+
+  def type_field(it: TokenIterator): (String, Type) = {
+    val name = identifier(it)
+    punctuation(it, ":")
+    val typ = type_expr(it)
+    while (it.hasNext() && it.head() == PunctuationToken("@")) {
+      decorator(it)
+    }
+    (name, typ)
+  }
+
+  def type_exprs(it: TokenIterator): Array[Type] = {
+    punctuation(it, "(")
+    val types = repUntil(it, type_expr, PunctuationToken(")"))
+    punctuation(it, ")")
+    types
+  }
+
+  def type_expr(it: TokenIterator): Type = {
+    val req = it.head() match {
+      case x: PunctuationToken if x.value == "+" =>
+        consumeToken(it)
+        true
+      case _ => false
+    }
+
+    val typ = identifier(it) match {
+      case "Interval" =>
+        punctuation(it, "[")
+        val pointType = type_expr(it)
+        punctuation(it, "]")
+        TInterval(pointType)
+      case "Boolean" => TBoolean()
+      case "Int32" => TInt32()
+      case "Int64" => TInt64()
+      case "Int" => TInt32()
+      case "Float32" => TFloat32()
+      case "Float64" => TFloat64()
+      case "String" => TString()
+      case "Locus" =>
+        punctuation(it, "(")
+        val id = identifier(it)
+        punctuation(it, ")")
+        ReferenceGenome.getReference(id).locusType
+      case "LocusAlleles" =>
+        punctuation(it, "(")
+        val id = identifier(it)
+        punctuation(it, ")")
+        ReferenceGenome.getReference(id).intervalType
+      case "Call" => TCall()
+      case "Array" =>
+        punctuation(it, "[")
+        val elementType = type_expr(it)
+        punctuation(it, "]")
+        TArray(elementType)
+      case "Set" =>
+        punctuation(it, "[")
+        val elementType = type_expr(it)
+        punctuation(it, "]")
+        TSet(elementType)
+      case "Dict" =>
+        punctuation(it, "[")
+        val keyType = type_expr(it)
+        punctuation(it, ",")
+        val valueType = type_expr(it)
+        punctuation(it, "]")
+        TDict(keyType, valueType)
+      case "Tuple" =>
+        punctuation(it, "[")
+        val types = repsepUntil(it, type_expr, PunctuationToken(","), PunctuationToken("]"))
+        punctuation(it, "]")
+        TTuple(types)
+      case "Struct" =>
+        punctuation(it, "{")
+        val args = repsepUntil(it, type_field, PunctuationToken(","), PunctuationToken("}"))
+        punctuation(it, "}")
+        val fields = args.zipWithIndex.map { case ((id, t), i) => Field(id, t, i) }
+        TStruct(fields)
+    }
+
+    typ.setRequired(req)
+  }
+
+  def keys(it: TokenIterator): Array[String] = {
+    punctuation(it, "[")
+    val keys = repsepUntil(it, identifier, PunctuationToken(","), PunctuationToken("]"))
+    punctuation(it, "]")
+    keys
+  }
+
+  def trailing_keys(it: TokenIterator): Array[String] = {
+    it.head() match {
+      case x: PunctuationToken if x.value == "]" =>
+        Array.empty[String]
+      case x: PunctuationToken if x.value == "," =>
+        punctuation(it, ",")
+        repsepUntil(it, identifier, PunctuationToken(","), PunctuationToken("]"))
+    }
+  }
+
+  def rvd_type_expr(it: TokenIterator): RVDType = {
+    identifier(it) match {
+      case "RVDType" | "OrderedRVDType" =>
+        punctuation(it, "{")
+        identifier(it, "key")
+        punctuation(it, ":")
+        punctuation(it, "[")
+        val partitionKey = keys(it)
+        val restKey = trailing_keys(it)
+        punctuation(it, "]")
+        punctuation(it, ",")
+        identifier(it, "row")
+        punctuation(it, ":")
+        val rowType = coerce[TStruct](type_expr(it))
+        RVDType(rowType.physicalType, partitionKey ++ restKey)
+    }
+  }
+
+  def table_type_expr(it: TokenIterator): TableType = {
+    identifier(it, "Table")
+    punctuation(it, "{")
+
+    identifier(it, "global")
+    punctuation(it, ":")
+    val globalType = coerce[TStruct](type_expr(it))
+    punctuation(it, ",")
+
+    identifier(it, "key")
+    punctuation(it, ":")
+    val key = opt(it, keys).getOrElse(Array.empty[String])
+    punctuation(it, ",")
+
+    identifier(it, "row")
+    punctuation(it, ":")
+    val rowType = coerce[TStruct](type_expr(it))
+    punctuation(it, "}")
+    TableType(rowType, key.toFastIndexedSeq, globalType)
+  }
+
+  def matrix_type_expr(it: TokenIterator): MatrixType = {
+    identifier(it, "Matrix")
+    punctuation(it, "{")
+
+    identifier(it, "global")
+    punctuation(it, ":")
+    val globalType = coerce[TStruct](type_expr(it))
+    punctuation(it, ",")
+
+    identifier(it, "col_key")
+    punctuation(it, ":")
+    val colKey = keys(it)
+    punctuation(it, ",")
+
+    identifier(it, "col")
+    punctuation(it, ":")
+    val colType = coerce[TStruct](type_expr(it))
+    punctuation(it, ",")
+
+    identifier(it, "row_key")
+    punctuation(it, ":")
+    punctuation(it, "[")
+    val rowPartitionKey = keys(it)
+    val rowRestKey = trailing_keys(it)
+    punctuation(it, "]")
+    punctuation(it, ",")
+
+    identifier(it, "row")
+    punctuation(it, ":")
+    val rowType = coerce[TStruct](type_expr(it))
+    punctuation(it, ",")
+
+    identifier(it, "entry")
+    punctuation(it, ":")
+    val entryType = coerce[TStruct](type_expr(it))
+    punctuation(it, "}")
+
+    MatrixType.fromParts(globalType, colKey, colType, rowPartitionKey ++ rowRestKey, rowType, entryType)
+  }
+
+  def agg_signature(it: TokenIterator): AggSignature = {
+    punctuation(it, "(")
+    val op = AggOp.fromString(identifier(it))
+    val ctorArgs = type_exprs(it).map(t => -t)
+    val initOpArgs = opt(it, type_exprs).map(_.map(t => -t))
+    val seqOpArgs = type_exprs(it).map(t => -t)
+    punctuation(it, ")")
+    AggSignature(op, ctorArgs, initOpArgs.map(_.toFastIndexedSeq), seqOpArgs)
+  }
+
+  def ir_value(it: TokenIterator): (Type, Any) = {
+    val typ = type_expr(it)
+    val s = string_literal(it)
+    val vJSON = JsonMethods.parse(s)
+    val v = JSONAnnotationImpex.importAnnotation(vJSON, typ)
+    (typ, v)
+  }
+
+  def named_value_irs(env: IRParserEnvironment)(it: TokenIterator): Array[(String, IR)] =
+    repUntil(it, named_value_ir(env), PunctuationToken(")"))
+
+  def named_value_ir(env: IRParserEnvironment)(it: TokenIterator): (String, IR) = {
+    punctuation(it, "(")
+    val name = identifier(it)
+    val value = ir_value_expr(env)(it)
+    punctuation(it, ")")
+    (name, value)
+  }
+
+  def ir_value_exprs(env: IRParserEnvironment)(it: TokenIterator): Array[IR] = {
+    punctuation(it, "(")
+    val irs = ir_value_children(env)(it)
+    punctuation(it, ")")
+    irs
+  }
+
+  def ir_value_children(env: IRParserEnvironment)(it: TokenIterator): Array[IR] =
+    repUntil(it, ir_value_expr(env), PunctuationToken(")"))
+
+  def ir_value_expr(env: IRParserEnvironment)(it: TokenIterator): IR = {
+    punctuation(it, "(")
+    val ir = ir_value_expr_1(env)(it)
+    punctuation(it, ")")
+    ir
+  }
+
+  def ir_value_expr_1(env: IRParserEnvironment)(it: TokenIterator): IR = {
+    identifier(it) match {
+      case "I32" => I32(int32_literal(it))
+      case "I64" => I64(int64_literal(it))
+      case "F32" => F32(float32_literal(it))
+      case "F64" => F64(float64_literal(it))
+      case "Str" => Str(string_literal(it))
+      case "True" => True()
+      case "False" => False()
+      case "Literal" =>
+        val (t, v) = ir_value(it)
+        Literal.coerce(t, v)
+      case "Void" => Void()
+      case "Cast" =>
+        val typ = type_expr(it)
+        val v = ir_value_expr(env)(it)
+        Cast(v, typ)
+      case "NA" => NA(type_expr(it))
+      case "IsNA" => IsNA(ir_value_expr(env)(it))
+      case "If" =>
+        val cond = ir_value_expr(env)(it)
+        val consq = ir_value_expr(env)(it)
+        val altr = ir_value_expr(env)(it)
+        If(cond, consq, altr)
+      case "Let" =>
+        val name = identifier(it)
+        val value = ir_value_expr(env)(it)
+        val body = ir_value_expr(env + (name -> value.typ))(it)
+        Let(name, value, body)
+      case "Ref" =>
+        val id = identifier(it)
+        Ref(id, env.refMap(id))
+      case "ApplyBinaryPrimOp" =>
+        val op = BinaryOp.fromString(identifier(it))
+        val l = ir_value_expr(env)(it)
+        val r = ir_value_expr(env)(it)
+        ApplyBinaryPrimOp(op, l, r)
+      case "ApplyUnaryPrimOp" =>
+        val op = UnaryOp.fromString(identifier(it))
+        val x = ir_value_expr(env)(it)
+        ApplyUnaryPrimOp(op, x)
+      case "ApplyComparisonOp" =>
+        val opName = identifier(it)
+        val l = ir_value_expr(env)(it)
+        val r = ir_value_expr(env)(it)
+        val op = ComparisonOp.fromStringAndTypes(opName, l.typ, r.typ)
+        ApplyComparisonOp(op, l, r)
+      case "MakeArray" =>
+        val typ = opt(it, type_expr).map(_.asInstanceOf[TArray]).orNull
+        val args = ir_value_children(env)(it)
+        MakeArray.unify(args, typ)
+      case "ArrayRef" =>
+        val a = ir_value_expr(env)(it)
+        val i = ir_value_expr(env)(it)
+        ArrayRef(a, i)
+      case "ArrayLen" => ArrayLen(ir_value_expr(env)(it))
+      case "ArrayRange" =>
+        val start = ir_value_expr(env)(it)
+        val stop = ir_value_expr(env)(it)
+        val step = ir_value_expr(env)(it)
+        ArrayRange(start, stop, step)
+      case "ArraySort" =>
+        val onKey = boolean_literal(it)
+        val a = ir_value_expr(env)(it)
+        val ascending = ir_value_expr(env)(it)
+        ArraySort(a, ascending, onKey)
+      case "ToSet" => ToSet(ir_value_expr(env)(it))
+      case "ToDict" => ToDict(ir_value_expr(env)(it))
+      case "ToArray" => ToArray(ir_value_expr(env)(it))
+      case "LowerBoundOnOrderedCollection" =>
+        val onKey = boolean_literal(it)
+        val col = ir_value_expr(env)(it)
+        val elem = ir_value_expr(env)(it)
+        LowerBoundOnOrderedCollection(col, elem, onKey)
+      case "GroupByKey" =>
+        val col = ir_value_expr(env)(it)
+        GroupByKey(col)
+      case "ArrayMap" =>
+        val name = identifier(it)
+        val a = ir_value_expr(env)(it)
+        val body = ir_value_expr(env + (name -> coerce[TArray](a.typ).elementType))(it)
+        ArrayMap(a, name, body)
+      case "ArrayFilter" =>
+        val name = identifier(it)
+        val a = ir_value_expr(env)(it)
+        val body = ir_value_expr(env + (name -> coerce[TArray](a.typ).elementType))(it)
+        ArrayFilter(a, name, body)
+      case "ArrayFlatMap" =>
+        val name = identifier(it)
+        val a = ir_value_expr(env)(it)
+        val body = ir_value_expr(env + (name -> coerce[TArray](a.typ).elementType))(it)
+        ArrayFlatMap(a, name, body)
+      case "ArrayFold" =>
+        val accumName = identifier(it)
+        val valueName = identifier(it)
+        val a = ir_value_expr(env)(it)
+        val zero = ir_value_expr(env)(it)
+        val eltType = coerce[TArray](a.typ).elementType
+        val body = ir_value_expr(env.update(Map(accumName -> zero.typ, valueName -> eltType)))(it)
+        ArrayFold(a, zero, accumName, valueName, body)
+      case "ArrayScan" =>
+        val accumName = identifier(it)
+        val valueName = identifier(it)
+        val a = ir_value_expr(env)(it)
+        val zero = ir_value_expr(env)(it)
+        val eltType = coerce[TArray](a.typ).elementType
+        val body = ir_value_expr(env.update(Map(accumName -> zero.typ, valueName -> eltType)))(it)
+        ArrayScan(a, zero, accumName, valueName, body)
+      case "ArrayFor" =>
+        val name = identifier(it)
+        val a = ir_value_expr(env)(it)
+        val body = ir_value_expr(env + (name, coerce[TArray](a.typ).elementType))(it)
+        ArrayFor(a, name, body)
+      case "AggFilter" =>
+        val cond = ir_value_expr(env)(it)
+        val aggIR = ir_value_expr(env)(it)
+        AggFilter(cond, aggIR)
+      case "AggExplode" =>
+        val name = identifier(it)
+        val a = ir_value_expr(env)(it)
+        val aggBody = ir_value_expr(env + (name -> coerce[TArray](a.typ).elementType))(it)
+        AggExplode(a, name, aggBody)
+      case "AggGroupBy" =>
+        val key = ir_value_expr(env)(it)
+        val aggIR = ir_value_expr(env)(it)
+        AggGroupBy(key, aggIR)
+      case "ApplyAggOp" =>
+        val aggSig = agg_signature(it)
+        val seqOpArgs = ir_value_exprs(env)(it)
+        val ctorArgs = ir_value_exprs(env)(it)
+        val initOpArgs = opt(it, ir_value_exprs(env))
+        ApplyAggOp(seqOpArgs, ctorArgs, initOpArgs.map(_.toFastIndexedSeq), aggSig)
+      case "ApplyScanOp" =>
+        val aggSig = agg_signature(it)
+        val seqOpArgs = ir_value_exprs(env)(it)
+        val ctorArgs = ir_value_exprs(env)(it)
+        val initOpArgs = opt(it, ir_value_exprs(env))
+        ApplyScanOp(seqOpArgs, ctorArgs, initOpArgs.map(_.toFastIndexedSeq), aggSig)
+      case "InitOp" =>
+        val aggSig = agg_signature(it)
+        val i = ir_value_expr(env)(it)
+        val args = ir_value_exprs(env)(it)
+        InitOp(i, args, aggSig)
+      case "SeqOp" =>
+        val aggSig = agg_signature(it)
+        val i = ir_value_expr(env)(it)
+        val args = ir_value_exprs(env)(it)
+        SeqOp(i, args, aggSig)
+      case "Begin" =>
+        val xs = ir_value_children(env)(it)
+        Begin(xs)
+      case "MakeStruct" =>
+        val fields = named_value_irs(env)(it)
+        MakeStruct(fields)
+      case "SelectFields" =>
+        val fields = identifiers(it)
+        val old = ir_value_expr(env)(it)
+        SelectFields(old, fields)
+      case "InsertFields" =>
+        val old = ir_value_expr(env)(it)
+        val fields = named_value_irs(env)(it)
+        InsertFields(old, fields)
+      case "GetField" =>
+        val name = identifier(it)
+        val s = ir_value_expr(env)(it)
+        GetField(s, name)
+      case "MakeTuple" =>
+        val args = ir_value_children(env)(it)
+        MakeTuple(args)
+      case "GetTupleElement" =>
+        val idx = int32_literal(it)
+        val tuple = ir_value_expr(env)(it)
+        GetTupleElement(tuple, idx)
+      case "StringSlice" =>
+        val s = ir_value_expr(env)(it)
+        val start = ir_value_expr(env)(it)
+        val end = ir_value_expr(env)(it)
+        StringSlice(s, start, end)
+      case "StringLength" =>
+        val s = ir_value_expr(env)(it)
+        StringLength(s)
+      case "In" =>
+        val typ = type_expr(it)
+        val idx = int32_literal(it)
+        In(idx, typ)
+      case "Die" =>
+        val typ = type_expr(it)
+        val msg = string_literal(it)
+        Die(msg, typ)
+      case "ApplySeeded" =>
+        val function = identifier(it)
+        val seed = int64_literal(it)
+        val args = ir_value_children(env)(it)
+        ApplySeeded(function, args, seed)
+      case "ApplyIR" | "ApplySpecial" | "Apply" =>
+        val function = identifier(it)
+        val args = ir_value_children(env)(it)
+        invoke(function, args: _*)
+      case "Uniroot" =>
+        val name = identifier(it)
+        val function = ir_value_expr(env + (name -> TFloat64()))(it)
+        val min = ir_value_expr(env)(it)
+        val max = ir_value_expr(env)(it)
+        Uniroot(name, function, min, max)
+      case "TableCount" =>
+        val child = table_ir(env)(it)
+        TableCount(child)
+      case "TableAggregate" =>
+        val child = table_ir(env)(it)
+        val query = ir_value_expr(env.update(child.typ.refMap))(it)
+        TableAggregate(child, query)
+      case "TableWrite" =>
+        val path = string_literal(it)
+        val overwrite = boolean_literal(it)
+        val shuffleLocally = boolean_literal(it)
+        val codecSpecJsonStr = opt(it, string_literal)
+        val child = table_ir(env)(it)
+        TableWrite(child, path, overwrite, shuffleLocally, codecSpecJsonStr.orNull)
+      case "JavaIR" =>
+        val name = identifier(it)
+        env.irMap(name).asInstanceOf[IR]
+    }
+  }
+
+  def table_irs(env: IRParserEnvironment)(it: TokenIterator): Array[TableIR] = {
+    punctuation(it, "(")
+    val tirs = table_ir_children(env)(it)
+    punctuation(it, ")")
+    tirs
+  }
+
+  def table_ir_children(env: IRParserEnvironment)(it: TokenIterator): Array[TableIR] =
+    repUntil(it, table_ir(env), PunctuationToken(")"))
+
+  def table_ir(env: IRParserEnvironment)(it: TokenIterator): TableIR = {
+    punctuation(it, "(")
+    val ir = table_ir_1(env)(it)
+    punctuation(it, ")")
+    ir
+  }
+
+  def table_ir_1(env: IRParserEnvironment)(it: TokenIterator): TableIR = {
+    // FIXME TableImport
+    identifier(it) match {
+      case "TableKeyBy" =>
+        val keys = identifiers(it)
+        val isSorted = boolean_literal(it)
+        val child = table_ir(env)(it)
+        TableKeyBy(child, keys, isSorted)
+      case "TableDistinct" =>
+        val child = table_ir(env)(it)
+        TableDistinct(child)
+      case "TableFilter" =>
+        val child = table_ir(env)(it)
+        val pred = ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+        TableFilter(child, pred)
+      case "TableRead" =>
+        val path = string_literal(it)
+        val dropRows = boolean_literal(it)
+        val typ = opt(it, table_type_expr)
+        TableIR.read(HailContext.get, path, dropRows, typ)
+      case "MatrixColsTable" =>
+        val child = matrix_ir(env)(it)
+        MatrixColsTable(child)
+      case "MatrixRowsTable" =>
+        val child = matrix_ir(env)(it)
+        MatrixRowsTable(child)
+      case "MatrixEntriesTable" =>
+        val child = matrix_ir(env)(it)
+        MatrixEntriesTable(child)
+      case "TableAggregateByKey" =>
+        val child = table_ir(env)(it)
+        val expr = ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+        TableAggregateByKey(child, expr)
+      case "TableKeyByAndAggregate" =>
+        val nPartitions = opt(it, int32_literal)
+        val bufferSize = int32_literal(it)
+        val child = table_ir(env)(it)
+        val newEnv = env.withRefMap(child.typ.refMap)
+        val expr = ir_value_expr(newEnv)(it)
+        val newKey = ir_value_expr(newEnv)(it)
+        TableKeyByAndAggregate(child, expr, newKey, nPartitions, bufferSize)
+      case "TableRepartition" =>
+        val n = int32_literal(it)
+        val shuffle = boolean_literal(it)
+        val child = table_ir(env)(it)
+        TableRepartition(child, n, shuffle)
+      case "TableHead" =>
+        val n = int64_literal(it)
+        val child = table_ir(env)(it)
+        TableHead(child, n)
+      case "TableJoin" =>
+        val joinType = identifier(it)
+        val joinKey = int32_literal(it)
+        val left = table_ir(env)(it)
+        val right = table_ir(env)(it)
+        TableJoin(left, right, joinType, joinKey)
+      case "TableLeftJoinRightDistinct" =>
+        val root = identifier(it)
+        val left = table_ir(env)(it)
+        val right = table_ir(env)(it)
+        TableLeftJoinRightDistinct(left, right, root)
+      case "TableMultiWayZipJoin" =>
+        val dataName = string_literal(it)
+        val globalsName = string_literal(it)
+        val children = table_ir_children(env)(it)
+        TableMultiWayZipJoin(children, dataName, globalsName)
+      case "TableParallelize" =>
+        val nPartitions = opt(it, int32_literal)
+        val rows = ir_value_expr(env)(it)
+        TableParallelize(rows, nPartitions)
+      case "TableMapRows" =>
+        val child = table_ir(env)(it)
+        val newRow = ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+        TableMapRows(child, newRow)
+      case "TableMapGlobals" =>
+        val child = table_ir(env)(it)
+        val newRow = ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+        TableMapGlobals(child, newRow)
+      case "TableRange" =>
+        val n = int32_literal(it)
+        val nPartitions = int32_literal(it)
+        TableRange(n, nPartitions)
+      case "TableUnion" =>
+        val children = table_ir_children(env)(it)
+        TableUnion(children)
+      case "TableOrderBy" =>
+        val ids = identifiers(it)
+        val child = table_ir(env)(it)
+        TableOrderBy(child, ids.map(i =>
+          if (i.charAt(0) == 'A')
+            SortField(i.substring(1), Ascending)
+          else
+            SortField(i.substring(1), Descending)))
+      case "TableExplode" =>
+        val field = identifier(it)
+        val child = table_ir(env)(it)
+        TableExplode(child, field)
+      case "CastMatrixToTable" =>
+        val entriesField = string_literal(it)
+        val colsField = string_literal(it)
+        val child = matrix_ir(env)(it)
+        CastMatrixToTable(child, entriesField, colsField)
+      case "TableRename" =>
+        val rowK = string_literals(it)
+        val rowV = string_literals(it)
+        val globalK = string_literals(it)
+        val globalV = string_literals(it)
+        val child = table_ir(env)(it)
+        TableRename(child, rowK.zip(rowV).toMap, globalK.zip(globalV).toMap)
+      case "JavaTable" =>
+        val name = identifier(it)
+        env.irMap(name).asInstanceOf[TableIR]
+    }
+  }
+
+  def matrix_ir_children(env: IRParserEnvironment)(it: TokenIterator): Array[MatrixIR] =
+    repUntil(it, matrix_ir(env), PunctuationToken(")"))
+
+  def matrix_ir(env: IRParserEnvironment)(it: TokenIterator): MatrixIR = {
+    punctuation(it, "(")
+    val ir = matrix_ir_1(env)(it)
+    punctuation(it, ")")
+    ir
+  }
+
+  def matrix_ir_1(env: IRParserEnvironment)(it: TokenIterator): MatrixIR = {
+    identifier(it) match {
+      case "MatrixFilterCols" =>
+        val child = matrix_ir(env)(it)
+        val pred = ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+        MatrixFilterCols(child, pred)
+      case "MatrixFilterRows" =>
+        val child = matrix_ir(env)(it)
+        val pred = ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+        MatrixFilterRows(child, pred)
+      case "MatrixFilterEntries" =>
+        val child = matrix_ir(env)(it)
+        val pred = ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+        MatrixFilterEntries(child, pred)
+      case "MatrixMapCols" =>
+        val newKey = opt(it, string_literals)
+        val child = matrix_ir(env)(it)
+        val newCol = ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+        MatrixMapCols(child, newCol, newKey.map(_.toFastIndexedSeq))
+      case "MatrixKeyRowsBy" =>
+        val key = identifiers(it)
+        val isSorted = boolean_literal(it)
+        val child = matrix_ir(env)(it)
+        MatrixKeyRowsBy(child, key, isSorted)
+      case "MatrixMapRows" =>
+        val child = matrix_ir(env)(it)
+        val newRow = ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+        MatrixMapRows(child, newRow)
+      case "MatrixMapEntries" =>
+        val child = matrix_ir(env)(it)
+        val newEntry = ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+        MatrixMapEntries(child, newEntry)
+      case "MatrixMapGlobals" =>
+        val child = matrix_ir(env)(it)
+        val newGlobals = ir_value_expr(env.withRefMap(child.typ.refMap))(it)
+        MatrixMapGlobals(child, newGlobals)
+      case "MatrixAggregateColsByKey" =>
+        val child = matrix_ir(env)(it)
+        val newEnv = env.withRefMap(child.typ.refMap)
+        val entryExpr = ir_value_expr(newEnv)(it)
+        val colExpr = ir_value_expr(newEnv)(it)
+        MatrixAggregateColsByKey(child, entryExpr, colExpr)
+      case "MatrixAggregateRowsByKey" =>
+        val child = matrix_ir(env)(it)
+        val newEnv = env.withRefMap(child.typ.refMap)
+        val entryExpr = ir_value_expr(newEnv)(it)
+        val rowExpr = ir_value_expr(newEnv)(it)
+        MatrixAggregateRowsByKey(child, entryExpr, rowExpr)
+      case "MatrixRead" =>
+        val typ = opt(it, matrix_type_expr)
+        val dropCols = boolean_literal(it)
+        val dropRows = boolean_literal(it)
+        val readerStr = string_literal(it)
+        implicit val formats = MatrixReader.formats
+        val reader = Serialization.read[MatrixReader](readerStr)
+        MatrixRead(typ.getOrElse(reader.fullType), dropCols, dropRows, reader)
+      case "TableToMatrixTable" =>
+        val rowKey = string_literals(it)
+        val colKey = string_literals(it)
+        val rowFields = string_literals(it)
+        val colFields = string_literals(it)
+        val nPartitions = opt(it, int32_literal)
+        val child = table_ir(env)(it)
+        TableToMatrixTable(child, rowKey, colKey, rowFields, colFields, nPartitions)
+      case "MatrixAnnotateRowsTable" =>
+        val root = string_literal(it)
+        val hasKey = boolean_literal(it)
+        val child = matrix_ir(env)(it)
+        val table = table_ir(env)(it)
+        val key = ir_value_children(env.withRefMap(child.typ.refMap))(it)
+        val keyIRs = if (hasKey) Some(key.toFastIndexedSeq) else None
+        MatrixAnnotateRowsTable(child, table, root, keyIRs)
+      case "MatrixAnnotateColsTable" =>
+        val root = string_literal(it)
+        val child = matrix_ir(env)(it)
+        val table = table_ir(env)(it)
+        MatrixAnnotateColsTable(child, table, root)
+      case "MatrixExplodeRows" =>
+        val path = identifiers(it)
+        val child = matrix_ir(env)(it)
+        MatrixExplodeRows(child, path)
+      case "MatrixExplodeCols" =>
+        val path = identifiers(it)
+        val child = matrix_ir(env)(it)
+        MatrixExplodeCols(child, path)
+      case "MatrixChooseCols" =>
+        val oldIndices = int32_literals(it)
+        val child = matrix_ir(env)(it)
+        MatrixChooseCols(child, oldIndices)
+      case "MatrixCollectColsByKey" =>
+        val child = matrix_ir(env)(it)
+        MatrixCollectColsByKey(child)
+      case "MatrixUnionRows" =>
+        val children = matrix_ir_children(env)(it)
+        MatrixUnionRows(children)
+      case "CastTableToMatrix" =>
+        val entriesField = identifier(it)
+        val colsField = identifier(it)
+        val colKey = identifiers(it)
+        val child = table_ir(env)(it)
+        CastTableToMatrix(child, entriesField, colsField, colKey)
+      case "JavaMatrix" =>
+        val name = identifier(it)
+        env.irMap(name).asInstanceOf[MatrixIR]
+    }
+  }
+
+  def parse[T](s: String, f: (TokenIterator) => T): T = {
+    val it = TokenIterator(IRLexer.parse(s))
+    f(it)
+  }
+
+  def parse_value_ir(s: String): IR = parse_value_ir(s, IRParserEnvironment())
+  def parse_value_ir(s: String, refMap: java.util.HashMap[String, Type], irMap: java.util.HashMap[String, BaseIR]): IR =
+    parse_value_ir(s, IRParserEnvironment(refMap.asScala.toMap, irMap.asScala.toMap))
+  def parse_value_ir(s: String, env: IRParserEnvironment): IR = parse(s, ir_value_expr(env))
+
+  def parse_table_ir(s: String): TableIR = parse_table_ir(s, IRParserEnvironment())
+  def parse_table_ir(s: String, refMap: java.util.HashMap[String, Type], irMap: java.util.HashMap[String, BaseIR]): TableIR =
+    parse_table_ir(s, IRParserEnvironment(refMap.asScala.toMap, irMap.asScala.toMap))
+  def parse_table_ir(s: String, env: IRParserEnvironment): TableIR = parse(s, table_ir(env))
+
+  def parse_matrix_ir(s: String): MatrixIR = parse_matrix_ir(s, IRParserEnvironment())
+  def parse_matrix_ir(s: String, refMap: java.util.HashMap[String, Type], irMap: java.util.HashMap[String, BaseIR]): MatrixIR =
+    parse_matrix_ir(s, IRParserEnvironment(refMap.asScala.toMap, irMap.asScala.toMap))
+  def parse_matrix_ir(s: String, env: IRParserEnvironment): MatrixIR = parse(s, matrix_ir(env))
+
+  def parseType(code: String): Type = parse(code, type_expr)
+
+  def parsePType(code: String): PType = parse(code, type_expr).physicalType
+
+  def parseStructType(code: String): TStruct = coerce[TStruct](parse(code, type_expr))
+
+  def parseRVDType(code: String): RVDType = parse(code, rvd_type_expr)
+
+  def parseTableType(code: String): TableType = parse(code, table_type_expr)
+
+  def parseMatrixType(code: String): MatrixType = parse(code, matrix_type_expr)
+}

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -646,16 +646,16 @@ object IRParser {
         AggGroupBy(key, aggIR)
       case "ApplyAggOp" =>
         val aggSig = agg_signature(it)
-        val seqOpArgs = ir_value_exprs(env)(it)
         val ctorArgs = ir_value_exprs(env)(it)
         val initOpArgs = opt(it, ir_value_exprs(env))
-        ApplyAggOp(seqOpArgs, ctorArgs, initOpArgs.map(_.toFastIndexedSeq), aggSig)
+        val seqOpArgs = ir_value_exprs(env)(it)
+        ApplyAggOp(ctorArgs, initOpArgs.map(_.toFastIndexedSeq), seqOpArgs, aggSig)
       case "ApplyScanOp" =>
         val aggSig = agg_signature(it)
-        val seqOpArgs = ir_value_exprs(env)(it)
         val ctorArgs = ir_value_exprs(env)(it)
         val initOpArgs = opt(it, ir_value_exprs(env))
-        ApplyScanOp(seqOpArgs, ctorArgs, initOpArgs.map(_.toFastIndexedSeq), aggSig)
+        val seqOpArgs = ir_value_exprs(env)(it)
+        ApplyScanOp(ctorArgs, initOpArgs.map(_.toFastIndexedSeq), seqOpArgs, aggSig)
       case "InitOp" =>
         val aggSig = agg_signature(it)
         val i = ir_value_expr(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -44,11 +44,11 @@ final case class PunctuationToken(value: String) extends Token {
 
 object IRLexer extends JavaTokenParsers {
   val token: Parser[Token] =
-    "[()\\[\\]{}<>,:+@=]".r ^^ { p => PunctuationToken(p) } |
-      identifier ^^ { id => IdentifierToken(id) } |
+    identifier ^^ { id => IdentifierToken(id) } |
       float64_literal ^^ { d => FloatToken(d) } |
       int64_literal ^^ { l => IntegerToken(l) } |
-      string_literal ^^ { s => StringToken(s) }
+      string_literal ^^ { s => StringToken(s) } |
+      "[()\\[\\]{}<>,:+@=]".r ^^ { p => PunctuationToken(p) }
 
   val lexer: Parser[Array[Token]] = rep(positioned(token)) ^^ { l => l.toArray }
 
@@ -109,7 +109,8 @@ object IRLexer extends JavaTokenParsers {
     "nan" ^^ { _ => Double.NaN } |
       "inf" ^^ { _ => Double.PositiveInfinity } |
       "-inf" ^^ { _ => Double.NegativeInfinity } |
-      floatingPointNumber ^^ { _.toDouble }
+      """[+-]?\d+(\.\d+)?[eE][+-]?\d+""".r ^^ { _.toDouble } |
+      """[+-]?\d*\.\d+""".r ^^ { _.toDouble }
 
   def parse(code: String): Array[Token] = {
     parseAll(lexer, code) match {

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -1,11 +1,8 @@
 package is.hail.expr.ir
 
 import is.hail.expr.JSONAnnotationImpex
-import is.hail.expr.types.virtual.TArray
-import is.hail.io.vcf.MatrixVCFReader
 import is.hail.table.Ascending
 import is.hail.utils._
-import is.hail.variant.RelationalSpec
 import org.json4s.jackson.{JsonMethods, Serialization}
 
 object Pretty {
@@ -163,7 +160,7 @@ object Pretty {
             case Ref(name, _) => prettyIdentifier(name)
             case ApplyBinaryPrimOp(op, _, _) => prettyClass(op)
             case ApplyUnaryPrimOp(op, _) => prettyClass(op)
-            case ApplyComparisonOp(op, _, _) => s"(${ prettyClass(op) } ${ op.t1.parsableString() } ${ op.t2.parsableString() })"
+            case ApplyComparisonOp(op, _, _) => prettyClass(op)
             case GetField(_, name) => prettyIdentifier(name)
             case GetTupleElement(_, idx) => idx.toString
             case MakeArray(_, typ) => typ.parsableString()

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -11,6 +11,8 @@ import is.hail.utils._
 import scala.language.implicitConversions
 
 package object ir {
+  type TokenIterator = BufferedIterator[Token]
+
   var uidCounter: Long = 0
 
   def genUID(): String = {

--- a/hail/src/main/scala/is/hail/expr/types/MatrixType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/MatrixType.scala
@@ -1,8 +1,7 @@
 package is.hail.expr.types
 
 import is.hail.annotations.Annotation
-import is.hail.expr.Parser
-import is.hail.expr.ir.Env
+import is.hail.expr.ir.{Env, IRParser}
 import is.hail.expr.types.physical.{PArray, PStruct}
 import is.hail.expr.types.virtual.{TArray, TStruct, Type}
 import is.hail.rvd.RVDType
@@ -13,7 +12,7 @@ import org.json4s.JsonAST.JString
 
 
 class MatrixTypeSerializer extends CustomSerializer[MatrixType](format => (
-  { case JString(s) => Parser.parseMatrixType(s) },
+  { case JString(s) => IRParser.parseMatrixType(s) },
   { case mt: MatrixType => JString(mt.toString) }))
 
 object MatrixType {

--- a/hail/src/main/scala/is/hail/expr/types/TableType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/TableType.scala
@@ -9,7 +9,7 @@ import org.json4s.CustomSerializer
 import org.json4s.JsonAST.JString
 
 class TableTypeSerializer extends CustomSerializer[TableType](format => (
-  { case JString(s) => Parser.parseTableType(s) },
+  { case JString(s) => IRParser.parseTableType(s) },
   { case tt: TableType => JString(tt.toString) }))
 
 case class TableType(rowType: TStruct, key: IndexedSeq[String], globalType: TStruct) extends BaseType {

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TStruct.scala
@@ -1,8 +1,7 @@
 package is.hail.expr.types.virtual
 
 import is.hail.annotations.{Annotation, AnnotationPathException, _}
-import is.hail.expr.Parser
-import is.hail.expr.ir.Env
+import is.hail.expr.ir.{Env, IRParser}
 import is.hail.expr.types.physical.{PField, PStruct}
 import is.hail.utils._
 import org.apache.spark.sql.Row
@@ -12,7 +11,7 @@ import org.json4s.JsonAST.JString
 import scala.collection.JavaConverters._
 
 class TStructSerializer extends CustomSerializer[TStruct](format => (
-  { case JString(s) => Parser.parseStructType(s) },
+  { case JString(s) => IRParser.parseStructType(s) },
   { case t: TStruct => JString(t.parsableString()) }))
 
 object TStruct {

--- a/hail/src/main/scala/is/hail/io/index/IndexReader.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexReader.scala
@@ -5,8 +5,8 @@ import java.util
 import java.util.Map.Entry
 
 import is.hail.annotations._
-import is.hail.expr.Parser
 import is.hail.expr.types.virtual.Type
+import is.hail.expr.ir.IRParser
 import is.hail.io._
 import is.hail.io.bgen.BgenSettings
 import is.hail.utils._
@@ -19,8 +19,8 @@ import org.json4s.jackson.JsonMethods
 object IndexReaderBuilder {
   def apply(hConf: Configuration, path: String): (Configuration, String, Int) => IndexReader = {
     val metadata = IndexReader.readMetadata(hConf, path)
-    val keyType = Parser.parseType(metadata.keyType)
-    val annotationType = Parser.parseType(metadata.annotationType)
+    val keyType = IRParser.parseType(metadata.keyType)
+    val annotationType = IRParser.parseType(metadata.annotationType)
     IndexReaderBuilder(keyType, annotationType)
   }
 
@@ -67,8 +67,8 @@ class IndexReader(hConf: Configuration,
   val indexRelativePath = metadata.indexPath
 
   val version = SemanticVersion(metadata.fileVersion)
-  val keyType = Parser.parseType(metadata.keyType)
-  val annotationType = Parser.parseType(metadata.annotationType)
+  val keyType = IRParser.parseType(metadata.keyType)
+  val annotationType = IRParser.parseType(metadata.annotationType)
   val leafType = LeafNodeBuilder.typ(keyType, annotationType)
   val leafPType = leafType.physicalType
   val internalType = InternalNodeBuilder.typ(keyType, annotationType)

--- a/hail/src/main/scala/is/hail/rvd/RVDType.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDType.scala
@@ -1,7 +1,7 @@
 package is.hail.rvd
 
 import is.hail.annotations._
-import is.hail.expr.Parser
+import is.hail.expr.ir.IRParser
 import is.hail.expr.types._
 import is.hail.expr.types.physical.{PInterval, PStruct, PType}
 import is.hail.utils._
@@ -10,7 +10,7 @@ import org.json4s.CustomSerializer
 import org.json4s.JsonAST.{JArray, JObject, JString, JValue}
 
 class RVDTypeSerializer extends CustomSerializer[RVDType](format => ( {
-  case JString(s) => Parser.parseRVDType(s)
+  case JString(s) => IRParser.parseRVDType(s)
 }, {
   case rvdType: RVDType => JString(rvdType.toString)
 }))

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -60,7 +60,7 @@ object Table {
     new Table(hc, TableIR.read(hc, path, dropRows = false, None))
 
   def parallelize(ir: String, nPartitions: Option[Int]): Table = {
-    val rowsIR = Parser.parse_value_ir(ir)
+    val rowsIR = IRParser.parse_value_ir(ir)
     new Table(HailContext.get, TableParallelize(rowsIR, nPartitions))
   }
 
@@ -377,7 +377,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
   }
 
   def aggregate(expr: String): (Any, Type) =
-    aggregate(Parser.parse_value_ir(expr, IRParserEnvironment(typ.refMap)))
+    aggregate(IRParser.parse_value_ir(expr, IRParserEnvironment(typ.refMap)))
 
   def aggregate(query: IR): (Any, Type) = {
     val t = ir.TableAggregate(tir, query)
@@ -390,7 +390,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
   }
 
   def selectGlobal(expr: String): Table = {
-    val ir = Parser.parse_value_ir(expr, IRParserEnvironment(typ.refMap))
+    val ir = IRParser.parse_value_ir(expr, IRParserEnvironment(typ.refMap))
     new Table(hc, TableMapGlobals(tir, ir))
   }
 
@@ -413,7 +413,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
   def unkey(): Table = keyBy(FastIndexedSeq())
 
   def mapRows(expr: String): Table =
-    mapRows(Parser.parse_value_ir(expr, IRParserEnvironment(typ.refMap)))
+    mapRows(IRParser.parse_value_ir(expr, IRParserEnvironment(typ.refMap)))
 
   def mapRows(newRow: IR): Table =
     new Table(hc, TableMapRows(tir, newRow))
@@ -468,7 +468,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
       CastTableToMatrix(tir, entriesFieldName, colsFieldName, colKey.asScala.toFastIndexedSeq))
 
   def aggregateByKey(expr: String): Table = {
-    val x = Parser.parse_value_ir(expr, IRParserEnvironment(typ.refMap))
+    val x = IRParser.parse_value_ir(expr, IRParserEnvironment(typ.refMap))
     new Table(hc, TableAggregateByKey(tir, x))
   }
 

--- a/hail/src/main/scala/is/hail/utils/Graph.scala
+++ b/hail/src/main/scala/is/hail/utils/Graph.scala
@@ -1,10 +1,9 @@
 package is.hail.utils
 
 import is.hail.annotations.{Region, RegionValueBuilder, SafeRow}
-import is.hail.expr.ir.{Compile, MakeTuple}
+import is.hail.expr.ir.{Compile, MakeTuple, IRParserEnvironment, IRParser}
 import is.hail.expr.types.physical.PBaseStruct
 import is.hail.expr.types.virtual.{TInt64, TTuple, Type}
-import is.hail.expr.{IRParserEnvironment, Parser}
 import org.apache.spark.sql.Row
 
 import scala.collection.mutable
@@ -47,7 +46,7 @@ object Graph {
     val refMap = Map("l" -> wrappedNodeType, "r" -> wrappedNodeType)
 
     val tieBreakerF = tieBreaker.map { e =>
-      val ir = Parser.parse_value_ir(e, IRParserEnvironment(refMap))
+      val ir = IRParser.parse_value_ir(e, IRParserEnvironment(refMap))
       val (t, f) = Compile[Long, Long, Long]("l", wrappedNodeType.physicalType, "r", wrappedNodeType.physicalType, MakeTuple(FastSeq(ir)))
       assert(t.virtualType.isOfType(TTuple(TInt64())))
 

--- a/hail/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/hail/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -468,15 +468,15 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
   def aggregateColsByKey(entryExpr: String, colExpr: String): MatrixTable = {
     val env = IRParserEnvironment(matrixType.refMap)
-    val entriesIR = Parser.parse_value_ir(entryExpr, env)
-    val colsIR = Parser.parse_value_ir(colExpr, env)
+    val entriesIR = IRParser.parse_value_ir(entryExpr, env)
+    val colsIR = IRParser.parse_value_ir(colExpr, env)
     new MatrixTable(hc, MatrixAggregateColsByKey(ast, entriesIR, colsIR))
   }
 
   def aggregateRowsByKey(entryExpr: String, rowExpr: String): MatrixTable = {
     val env = IRParserEnvironment(matrixType.refMap)
-    val entriesIR = Parser.parse_value_ir(entryExpr, env)
-    val rowsIR = Parser.parse_value_ir(rowExpr, env)
+    val entriesIR = IRParser.parse_value_ir(entryExpr, env)
+    val rowsIR = IRParser.parse_value_ir(rowExpr, env)
     new MatrixTable(hc, MatrixAggregateRowsByKey(ast, entriesIR, rowsIR))
   }
 
@@ -575,13 +575,13 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     val key = Option(irs).map { irs =>
       irs.asScala
         .toFastIndexedSeq
-        .map(Parser.parse_value_ir(_, parseEnv))
+        .map(IRParser.parse_value_ir(_, parseEnv))
     }
     new MatrixTable(hc, MatrixAnnotateRowsTable(ast, table.tir, uid, key))
   }
 
   def selectGlobals(expr: String): MatrixTable = {
-    val globalIR = Parser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
+    val globalIR = IRParser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
     new MatrixTable(hc, MatrixMapGlobals(ast, globalIR))
   }
 
@@ -589,18 +589,18 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     selectCols(expr, Option(newKey).map(_.asScala.toFastIndexedSeq))
 
   def selectCols(expr: String, newKey: Option[IndexedSeq[String]]): MatrixTable = {
-    val ir = Parser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
+    val ir = IRParser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
     val newColKey = newKey.getOrElse(colKey)
     new MatrixTable(hc, MatrixMapCols(ast, ir, newKey))
   }
 
   def selectRows(expr: String): MatrixTable = {
-    val rowsIR = Parser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
+    val rowsIR = IRParser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
     new MatrixTable(hc, MatrixMapRows(ast, rowsIR))
   }
 
   def selectEntries(expr: String): MatrixTable = {
-    val ir = Parser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
+    val ir = IRParser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
     new MatrixTable(hc, MatrixMapEntries(ast, ir))
   }
 
@@ -661,13 +661,13 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
   def filterColsExpr(filterExpr: String, keep: Boolean = true): MatrixTable = {
-    var irPred = Parser.parse_value_ir(filterExpr, IRParserEnvironment(matrixType.refMap))
+    var irPred = IRParser.parse_value_ir(filterExpr, IRParserEnvironment(matrixType.refMap))
     new MatrixTable(hc,
       MatrixFilterCols(ast, ir.filterPredicateWithKeep(irPred, keep)))
   }
 
   def filterRowsExpr(filterExpr: String, keep: Boolean = true): MatrixTable = {
-    var irPred = Parser.parse_value_ir(filterExpr, IRParserEnvironment(matrixType.refMap))
+    var irPred = IRParser.parse_value_ir(filterExpr, IRParserEnvironment(matrixType.refMap))
     new MatrixTable(hc,
       MatrixFilterRows(ast, ir.filterPredicateWithKeep(irPred, keep)))
   }
@@ -884,12 +884,12 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
   def aggregateEntries(expr: String): (Annotation, Type) = {
-    val qir = Parser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
+    val qir = IRParser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
     (Interpret(MatrixAggregate(ast, qir)), qir.typ)
   }
 
   def aggregateCols(expr: String): (Annotation, Type) = {
-    val qir = Parser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
+    val qir = IRParser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
     val ct = colsTable()
     val aggEnv = new ir.Env[ir.IR].bind("sa" -> ir.Ref("row", ct.typ.rowType))
     val sqir = ir.Subst(qir.unwrap, ir.Env.empty, aggEnv)
@@ -897,7 +897,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
   def aggregateRows(expr: String): (Annotation, Type) = {
-    val qir = Parser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
+    val qir = IRParser.parse_value_ir(expr, IRParserEnvironment(matrixType.refMap))
     val rt = rowsTable()
     val aggEnv = new ir.Env[ir.IR].bind("va" -> ir.Ref("row", rt.typ.rowType))
     val sqir = ir.Subst(qir.unwrap, ir.Env.empty, aggEnv)
@@ -1226,7 +1226,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
   }
 
   def filterEntries(filterExpr: String, keep: Boolean = true): MatrixTable = {
-    val filterIR = Parser.parse_value_ir(filterExpr, IRParserEnvironment(matrixType.refMap))
+    val filterIR = IRParser.parse_value_ir(filterExpr, IRParserEnvironment(matrixType.refMap))
     new MatrixTable(hc, MatrixFilterEntries(ast, ir.filterPredicateWithKeep(filterIR, keep)))
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -5,7 +5,6 @@ import is.hail.expr.types.{virtual, _}
 import is.hail.TestUtils._
 import is.hail.annotations.{Region, RegionValue, RegionValueBuilder, SafeRow}
 import is.hail.asm4s.Code
-import is.hail.expr.{IRParserEnvironment, Parser}
 import is.hail.expr.ir.IRSuite.TestFunctions
 import is.hail.expr.ir.functions.{IRFunctionRegistry, RegistryFunctions, SeededIRFunction}
 import is.hail.expr.types.physical.{PBaseStruct, PInt64, PStruct}
@@ -967,42 +966,42 @@ class IRSuite extends SparkSuite {
     ))
 
     val s = Pretty(x)
-    val x2 = Parser.parse_value_ir(s, env)
+    val x2 = IRParser.parse_value_ir(s, env)
     assert(x2 == x)
   }
 
   @Test(dataProvider = "tableIRs")
   def testTableIRParser(x: TableIR) {
     val s = Pretty(x)
-    val x2 = Parser.parse_table_ir(s)
+    val x2 = IRParser.parse_table_ir(s)
     assert(x2 == x)
   }
 
   @Test(dataProvider = "matrixIRs")
   def testMatrixIRParser(x: MatrixIR) {
     val s = Pretty(x)
-    val x2 = Parser.parse_matrix_ir(s)
+    val x2 = IRParser.parse_matrix_ir(s)
     assert(x2 == x)
   }
 
   @Test def testCachedIR() {
     val cached = Literal(TSet(TInt32()), Set(1))
     val s = s"(JavaIR __uid1)"
-    val x2 = Parser.parse_value_ir(s, IRParserEnvironment(refMap = Map.empty, irMap = Map("__uid1" -> cached)))
+    val x2 = IRParser.parse_value_ir(s, IRParserEnvironment(refMap = Map.empty, irMap = Map("__uid1" -> cached)))
     assert(x2 eq cached)
   }
 
   @Test def testCachedTableIR() {
     val cached = TableRange(1, 1)
     val s = s"(JavaTable __uid1)"
-    val x2 = Parser.parse_table_ir(s, IRParserEnvironment(refMap = Map.empty, irMap = Map("__uid1" -> cached)))
+    val x2 = IRParser.parse_table_ir(s, IRParserEnvironment(refMap = Map.empty, irMap = Map("__uid1" -> cached)))
     assert(x2 eq cached)
   }
 
   @Test def testCachedMatrixIR() {
     val cached = MatrixTable.range(hc, 3, 7, None).ast
     val s = s"(JavaMatrix __uid1)"
-    val x2 = Parser.parse_matrix_ir(s, IRParserEnvironment(refMap = Map.empty, irMap = Map("__uid1" -> cached)))
+    val x2 = IRParser.parse_matrix_ir(s, IRParserEnvironment(refMap = Map.empty, irMap = Map("__uid1" -> cached)))
     assert(x2 eq cached)
   }
 

--- a/hail/src/test/scala/is/hail/methods/ExprSuite.scala
+++ b/hail/src/test/scala/is/hail/methods/ExprSuite.scala
@@ -5,6 +5,7 @@ import is.hail.check.Prop._
 import is.hail.check.Properties
 import is.hail.expr._
 import is.hail.expr.types.virtual.{TFloat64, TInt32, Type}
+import is.hail.expr.ir.IRParser
 import is.hail.utils.StringEscapeUtils._
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
@@ -20,19 +21,19 @@ class ExprSuite extends SparkSuite {
       sb.clear()
       t.pretty(sb, 0, compact = true)
       val res = sb.result()
-      val parsed = Parser.parseType(res)
+      val parsed = IRParser.parseType(res)
       t == parsed
     })
     check(forAll { (t: Type) =>
       sb.clear()
       t.pretty(sb, 0, compact = false)
       val res = sb.result()
-      val parsed = Parser.parseType(res)
+      val parsed = IRParser.parseType(res)
       t == parsed
     })
     check(forAll { (t: Type) =>
       val s = t.parsableString()
-      val parsed = Parser.parseType(s)
+      val parsed = IRParser.parseType(s)
       t == parsed
     })
   }


### PR DESCRIPTION
@cseed Can you look over this for structure before I assign it randomly? There's three things I am not happy about or want double checked:

1. I had to replicate the parsing code for `quoted_literal` etc. between the two parser classes. I couldn't figure out how to have the function in one place and be able to call it.

2. I debated back and forth what the `repsepUntil` and `repUntil` interface should look like. I decided to make it take the desired tokens instead of comparing to a string or any value because that seems more error proof and explicit. However, the users of the function have something like this now `repsepUntil(it, f, PunctuationToken(","), PunctuationToken("}"))`, which is quite verbose. I thought about making a second function that took string arguments and converted it to PunctuationToken and then called the functions that took tokens, but decided it was better to be explicit.

3. Can you double check the regex for `float_literal` is still correct? This was to fix the empty string match I had during our check-in last week.