### PR TITLE
Added options to keep col/entry trio data to explode_trio_matrix

### DIFF
--- a/hail/python/hail/experimental/phase_by_transmission.py
+++ b/hail/python/hail/experimental/phase_by_transmission.py
@@ -280,7 +280,9 @@ def phase_trio_matrix_by_transmission(tm: hl.MatrixTable, call_field: str = 'GT'
 
 
 @typecheck(tm=MatrixTable,
-           col_keys=sequenceof(str))
+           col_keys=sequenceof(str),
+           keep_trio_cols=bool,
+           keep_trio_entries=bool)
 def explode_trio_matrix(tm: hl.MatrixTable, col_keys: List[str] = ['s'], keep_trio_cols: bool = True, keep_trio_entries: bool = False) -> hl.MatrixTable:
     """Splits a trio MatrixTable back into a sample MatrixTable.
 


### PR DESCRIPTION
Background for this is the following: I have data with quads (parents + 2 offspring). This is represented as two trios in the trio matrix format. When exploding the trio matrix, I'm left with duplicate columns for the parents but no way of backtracking which parent corresponds to which trio.
More generally the previous implementation did not allow to carry any trio-specific data over, which was somewhat restrictive.