### PR TITLE
Add multiZipJoin to FlipbookIterator

### DIFF
--- a/hail/src/main/scala/is/hail/sparkextras/MultiWayZipPartitionsRDD.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/MultiWayZipPartitionsRDD.scala
@@ -5,18 +5,18 @@ import org.apache.spark.rdd.RDD
 
 import scala.reflect.ClassTag
 
-object MultiWayZipRDD {
+object MultiWayZipPartitionsRDD {
   def apply[T: ClassTag , V: ClassTag](
     rdds: IndexedSeq[RDD[T]]
-  )(f: (Array[Iterator[T]]) => Iterator[V]): MultiWayZipRDD[T, V] = {
-    new MultiWayZipRDD(rdds.head.sparkContext, rdds, f)
+  )(f: (Array[Iterator[T]]) => Iterator[V]): MultiWayZipPartitionsRDD[T, V] = {
+    new MultiWayZipPartitionsRDD(rdds.head.sparkContext, rdds, f)
   }
 }
 
 private case class MultiWayZipPartition(val index: Int, val partitions: IndexedSeq[Partition])
   extends Partition
 
-class MultiWayZipRDD[T: ClassTag, V: ClassTag](
+class MultiWayZipPartitionsRDD[T: ClassTag, V: ClassTag](
   sc: SparkContext,
   var rdds: IndexedSeq[RDD[T]],
   var f: (Array[Iterator[T]]) => Iterator[V]

--- a/hail/src/test/scala/is/hail/utils/FlipbookIteratorSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/FlipbookIteratorSuite.scala
@@ -275,7 +275,7 @@ class FlipbookIteratorSuite extends SparkSuite {
     val two = makeTestIterator(2, 3, 4, 5, 5, 6, 1000, 1000)
     val three = makeTestIterator(2, 3, 4, 4, 5, 6, 1000, 1000)
     val its: Array[FlipbookIterator[Box[Int]]] = Array(one, two, three)
-    val zipped = FlipbookIterator.multiZipJoinPq(its, boxIntOrd(missingValue = 1000))
+    val zipped = FlipbookIterator.multiZipJoin(its, boxIntOrd(missingValue = 1000))
     def fillOut(ar: ArrayBuilder[(Box[Int], Int)], default: Box[Int]): Array[Box[Int]] = {
       val a: Array[Box[Int]] = Array.fill(3)(default)
       var i = 0; while (i < ar.size) {

--- a/hail/src/test/scala/is/hail/utils/FlipbookIteratorSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/FlipbookIteratorSuite.scala
@@ -119,6 +119,16 @@ class FlipbookIteratorSuite extends SparkSuite {
       )
   }
 
+  implicit class RichTestIteratorArrayIterator(it: FlipbookIterator[Array[Box[Int]]]) {
+    def shouldBe(that: Iterator[Array[Int]]): Boolean = {
+      it.sameElementsUsing(
+        that,
+        (arrBox: Array[Box[Int]], arr: Array[Int]) =>
+          arrBox.length == arr.length && arrBox.zip(arr).forall({ case (a, b) => a.value == b })
+      )
+    }
+  }
+
   @Test def flipbookIteratorStartsWithRightValue() {
     val it: FlipbookIterator[Box[Int]] =
       makeTestIterator(1, 2, 3, 4, 5)
@@ -258,5 +268,44 @@ class FlipbookIteratorSuite extends SparkSuite {
     val it = Iterator((1, 0), (2, 2), (2, 2), (2, 2), (2, 2), (4, 4), (4, 4), (5, 5), (5, 5), (0, 6), (1000, 0), (1000, 0), (0, 1000), (0, 1000))
 
     assert(joined shouldBe it)
+  }
+
+  @Test def multiZipJoinWorks() {
+    val one = makeTestIterator(1, 2, 2, 4, 5, 5, 1000, 1000)
+    val two = makeTestIterator(2, 3, 4, 5, 5, 6, 1000, 1000)
+    val three = makeTestIterator(2, 3, 4, 4, 5, 6, 1000, 1000)
+    val its: Array[FlipbookIterator[Box[Int]]] = Array(one, two, three)
+    val zipped = FlipbookIterator.multiZipJoinPq(its, boxIntOrd(missingValue = 1000))
+    def fillOut(ar: ArrayBuilder[(Box[Int], Int)], default: Box[Int]): Array[Box[Int]] = {
+      val a: Array[Box[Int]] = Array.fill(3)(default)
+      var i = 0; while (i < ar.size) {
+        var v = ar(i)
+        a(v._2) = v._1
+        i += 1
+      }
+      a
+    }
+
+    val comp = zipped.map(fillOut(_, Box(0)))
+
+    val it = Iterator(
+      Array(1, 0, 0),
+      Array(2, 2, 2),
+      Array(2, 0, 0),
+      Array(0, 3, 3),
+      Array(4, 4, 4),
+      Array(0, 0, 4),
+      Array(5, 5, 5),
+      Array(5, 5, 0),
+      Array(0, 6, 6),
+      Array(0, 1000, 0), // XXX the exact order of these fields may be unstable
+      Array(0, 1000, 0),
+      Array(0, 0, 1000),
+      Array(0, 0, 1000),
+      Array(1000, 0, 0),
+      Array(1000, 0, 0)
+    )
+
+    assert(comp shouldBe it)
   }
 }


### PR DESCRIPTION
Applies on top of #4713 

Compared to previous versions, this uses a priority queue rather than a linear search to create the list of returned items. We return tuples so that the caller can construct arrays as appropriate rather than constructing an array of values here.