### PR TITLE
make Encoder/Decoder generate cpp classes

### DIFF
--- a/hail/src/main/resources/include/hail/Decoder.h
+++ b/hail/src/main/resources/include/hail/Decoder.h
@@ -209,16 +209,6 @@ class LEB128InputBuffer {
     bool read_boolean() { return buf_.read_boolean(); }
 };
 
-template<typename InputBuffer>
-class Decoder : public NativeObj {
-  public:
-    InputBuffer buf_;
-    Decoder() = delete;
-    Decoder(Decoder &dec) = delete;
-    Decoder(std::shared_ptr<InputStream> is) :
-      buf_(is) { }
-};
-
 }
 
 #endif

--- a/hail/src/main/resources/include/hail/Encoder.h
+++ b/hail/src/main/resources/include/hail/Encoder.h
@@ -186,16 +186,6 @@ class LEB128OutputBuffer {
     void close() { buf_.close(); }
 };
 
-template<typename OutputBuffer>
-class Encoder : public NativeObj {
-  public:
-    OutputBuffer buf_;
-    Encoder() = delete;
-    Encoder(Encoder &enc) = delete;
-    Encoder(std::shared_ptr<OutputStream> out) :
-    buf_(out) { }
-};
-
 }
 
 #endif

--- a/hail/src/main/scala/is/hail/cxx/Definition.scala
+++ b/hail/src/main/scala/is/hail/cxx/Definition.scala
@@ -93,7 +93,7 @@ class Class(val name: String, superClass: String, privateDefs: Array[Definition]
   override def toString: Type = name
 
   def define: Code =
-    s"""class $name${ if (superClass == null) "" else s":$superClass" } {
+    s"""class $name${ if (superClass == null) "" else s" : public $superClass" } {
        |  private:
        |    ${ privateDefs.map(_.define).mkString("\n") }
        |  public:

--- a/hail/src/main/scala/is/hail/cxx/Definition.scala
+++ b/hail/src/main/scala/is/hail/cxx/Definition.scala
@@ -86,3 +86,45 @@ class FunctionBuilder(prefix: String, args: Array[Variable], returnType: Type) {
      """.stripMargin
 
 }
+
+class Class(val name: String, superClass: String, privateDefs: Array[Definition], publicDefs: Array[Definition]) extends Definition {
+  def typ: Type = name
+
+  override def toString: Type = name
+
+  def define: Code =
+    s"""class $name${ if (superClass == null) "" else s":$superClass" } {
+       |  private:
+       |    ${ privateDefs.map(_.define).mkString("\n") }
+       |  public:
+       |    ${ publicDefs.map(_.define).mkString("\n") }
+       |};
+     """.stripMargin
+}
+
+class ClassBuilder(val name: String, superClass: String = null) {
+  private[this] val privateDefs = new ArrayBuilder[Definition]()
+  private[this] val publicDefs = new ArrayBuilder[Definition]()
+
+  def +=(d: Definition) { publicDefs += d }
+
+  def addPrivate(d: Definition) { privateDefs += d }
+
+  def result(): Class = new Class(name, superClass, privateDefs.result(), publicDefs.result())
+
+  def addConstructor(definition: Code) {
+    publicDefs += new Definition {
+      def name: String = this.name
+      def typ: Type = name
+      def define: Code = definition
+    }
+  }
+
+  def addDestructor(definition: Code) {
+    publicDefs += new Definition {
+      def name: String = this.name
+      def typ: Type = name
+      def define: Code = definition
+    }
+  }
+}

--- a/hail/src/main/scala/is/hail/cxx/Definition.scala
+++ b/hail/src/main/scala/is/hail/cxx/Definition.scala
@@ -113,16 +113,18 @@ class ClassBuilder(val name: String, superClass: String = null) {
   def result(): Class = new Class(name, superClass, privateDefs.result(), publicDefs.result())
 
   def addConstructor(definition: Code) {
+    val className = name
     publicDefs += new Definition {
-      def name: String = this.name
+      def name: String = className
       def typ: Type = name
       def define: Code = definition
     }
   }
 
   def addDestructor(definition: Code) {
+    val className = name
     publicDefs += new Definition {
-      def name: String = this.name
+      def name: String = className
       def typ: Type = name
       def define: Code = definition
     }

--- a/hail/src/main/scala/is/hail/cxx/PackDecoder.scala
+++ b/hail/src/main/scala/is/hail/cxx/PackDecoder.scala
@@ -177,13 +177,13 @@ object PackDecoder {
     tub.include("<cstdio>")
     tub.include("<memory>")
 
-    val decoderBuilder = new ClassBuilder(genSym("Decoder"), "public NativeObj")
+    val decoderBuilder = new ClassBuilder(genSym("Decoder"), "NativeObj")
 
     val bufType = bufSpec.nativeInputBufferType
     val buf = Variable("buf", s"std::shared_ptr<$bufType>")
     decoderBuilder.addPrivate(buf)
 
-    decoderBuilder.addConstructor(s"${ decoderBuilder.name }(std::shared_ptr<InputStream> is) { $buf = std::make_shared<$bufType>(is); }")
+    decoderBuilder.addConstructor(s"${ decoderBuilder.name }(std::shared_ptr<InputStream> is) $buf(std::make_shared<$bufType>(is)) { }")
 
     val rowFB = FunctionBuilder("decode_row", Array("NativeStatus*" -> "st", "Region *" -> "region"), "char *")
     val region = rowFB.getArg(1)

--- a/hail/src/main/scala/is/hail/cxx/PackDecoder.scala
+++ b/hail/src/main/scala/is/hail/cxx/PackDecoder.scala
@@ -1,0 +1,240 @@
+package is.hail.cxx
+
+import java.io.PrintWriter
+
+import is.hail.expr.types.physical._
+import is.hail.io.{BufferSpec, NativeDecoderModule}
+
+object PackDecoder {
+  def skipBinary(input_buf_ptr: Expression): Code = {
+    val len = Variable("skip_len", "int", s"$input_buf_ptr->read_int()")
+    s"""
+       |${ len.define }
+       |$input_buf_ptr->skip_bytes($len);""".stripMargin
+  }
+
+  def skipArray(t: PArray, input_buf_ptr: Expression): Code = {
+    val len = Variable("len", "int", s"$input_buf_ptr->read_int()")
+    val i = Variable("i", "int", "0")
+    if (t.elementType.required) {
+      s"""
+         |${ len.define }
+         |for (${ i.define } $i < $len; $i++) {
+         |  ${ skip(t.elementType, input_buf_ptr) }
+         |}""".stripMargin
+    } else {
+      val missingBytes = ArrayVariable(s"missing", "char", s"n_missing_bytes($len)")
+      s"""
+         |${ len.define }
+         |${ missingBytes.define }
+         |$input_buf_ptr->read_bytes($missingBytes, n_missing_bytes($len));
+         |for (${ i.define } $i < $len; $i++) {
+         |  if (!load_bit($missingBytes, $i)) {
+         |    ${ skip(t.elementType, input_buf_ptr) }
+         |  }
+         |}""".stripMargin
+    }
+  }
+
+  def skipBaseStruct(t: PBaseStruct, input_buf_ptr: Expression): Code = {
+    val missingBytes = ArrayVariable("missing", "char", s"${ t.nMissingBytes }")
+    val skipFields = Array.tabulate[Code](t.size) { idx =>
+      val fieldType = t.types(idx)
+      if (fieldType.required)
+        skip(fieldType, input_buf_ptr)
+      else
+        s"""
+           |if (!load_bit($missingBytes, ${ t.missingIdx(idx) })) {
+           |  ${ skip(fieldType, input_buf_ptr) }
+           |}""".stripMargin
+    }
+
+    if (t.nMissingBytes > 0)
+      s"""
+         |${ missingBytes.define }
+         |$input_buf_ptr->read_bytes($missingBytes, ${ t.nMissingBytes });
+         |${ skipFields.mkString("\n") }""".stripMargin
+    else
+      skipFields.mkString("\n")
+  }
+
+  def skip(t: PType, input_buf_ptr: Expression): Code = t match {
+    case t2: PArray => skipArray(t2, input_buf_ptr)
+    case t2: PBaseStruct => skipBaseStruct(t2, input_buf_ptr)
+    case _: PBinary => skipBinary(input_buf_ptr)
+    case _: PBoolean => s"$input_buf_ptr->skip_boolean();"
+    case _: PInt32 => s"$input_buf_ptr->skip_int();"
+    case _: PInt64 => s"$input_buf_ptr->skip_long();"
+    case _: PFloat32 => s"$input_buf_ptr->skip_float();"
+    case _: PFloat64 => s"$input_buf_ptr->skip_double();"
+  }
+
+  def decodeBinary(input_buf_ptr: Expression, region: Expression, off: Expression, fb: FunctionBuilder): Code = {
+    val len = Variable("len", "int", s"$input_buf_ptr->read_int()")
+    val boff = Variable("boff", "char *", s"$region->allocate(${ PBinary.contentAlignment }, $len + 4)")
+    s"""
+       |${ len.define }
+       |${ boff.define }
+       |store_address($off, $boff);
+       |store_int($boff, $len);
+       |$input_buf_ptr->read_bytes($boff + 4, $len);""".stripMargin
+  }
+
+  def decodeArray(t: PArray, rt: PArray, input_buf_ptr: Expression, region: Expression, off: Expression, fb: FunctionBuilder): Code = {
+    val len = Variable("len", "int", s"$input_buf_ptr->read_int()")
+    val sab = new StagedContainerBuilder(fb, region.toString, rt)
+    var decodeElt = decode(t.elementType, rt.elementType, input_buf_ptr, region, Expression(sab.eltOffset), fb)
+    if (rt.elementType.required)
+      decodeElt =
+        s"""
+           |if (!${ rt.cxxIsElementMissing(sab.end(), sab.idx) }) {
+           |  $decodeElt
+           |}
+         """.stripMargin
+
+    s"""
+       |${ len.define }
+       |${ sab.start(len, clearMissing = false) }
+       |store_address($off, ${ sab.end() });
+       |${ if (rt.elementType.required) "" else s"$input_buf_ptr->read_bytes(${ sab.end() } + 4, ${ rt.cxxNMissingBytes(s"$len") });" }
+       |while (${ sab.idx } < $len) {
+       |  $decodeElt
+       |  ${ sab.advance() }
+       |}
+     """.stripMargin
+  }
+
+  def decodeBaseStruct(t: PBaseStruct, rt: PBaseStruct, input_buf_ptr: Expression, region: Expression, off: Expression, fb: FunctionBuilder): Code = {
+    val ssb = new StagedBaseStructBuilder(fb, rt, off)
+
+    def wrapMissing(missingBytes: Code, tidx: Int)(processField: Code): Code = {
+      if (!t.fieldRequired(tidx)) {
+        s"""
+           |if (!${ t.cxxIsFieldMissing(missingBytes, tidx) }) {
+           |  $processField
+           |}""".stripMargin
+      } else processField
+    }
+
+    if (t.size == rt.size) {
+      assert((t.isInstanceOf[PTuple] && rt.isInstanceOf[PTuple]) || (t.asInstanceOf[PStruct].fieldNames sameElements t.asInstanceOf[PStruct].fieldNames))
+      val decodeFields = Array.tabulate[Code](rt.size) { idx =>
+        wrapMissing(s"$off", idx)(ssb.addField(idx, foff => decode(t.types(idx), rt.types(idx), input_buf_ptr, region, Expression(foff), fb)))
+      }.mkString("\n")
+      if (t.nMissingBytes > 0) {
+        s"""
+           |$input_buf_ptr->read_bytes($off, ${ t.nMissingBytes });
+           |$decodeFields""".stripMargin
+      } else
+        decodeFields
+    } else {
+      val names = t.asInstanceOf[PStruct].fieldNames
+      val rnames = rt.asInstanceOf[PStruct].fieldNames
+      val t_missing_bytes = ArrayVariable(s"missing", "char", s"${ t.nMissingBytes }")
+
+      var rtidx = 0
+      val decodeFields = Array.tabulate[Code](t.size) { tidx =>
+        val f = t.types(tidx)
+        val skipField = rtidx >= rt.size || names(tidx) != rnames(rtidx)
+        val processField = if (skipField)
+          wrapMissing(s"$t_missing_bytes", tidx)(skip(f, input_buf_ptr))
+        else
+          s"""
+             |${ wrapMissing(s"$t_missing_bytes", tidx)(ssb.addField(rtidx, foff => decode(f, rt.types(rtidx), input_buf_ptr, region, Expression(foff), fb))) }
+             |${ if (f.required) "" else s" else { ${ ssb.setMissing(rtidx) } }" }
+           """.stripMargin
+        if (!skipField)
+          rtidx += 1
+        wrapMissing(s"$t_missing_bytes", tidx)(processField)
+      }.mkString("\n")
+      if (t.nMissingBytes > 0) {
+        s"""
+           |${ t_missing_bytes.define }
+           |${ ssb.clearAllMissing() };
+           |$input_buf_ptr->read_bytes($t_missing_bytes, ${ t.nMissingBytes });
+           |$decodeFields""".stripMargin
+      } else
+        decodeFields
+    }
+  }
+
+  def decode(t: PType, rt: PType, input_buf_ptr: Expression, region: Expression, off: Expression, fb: FunctionBuilder): Code = t match {
+    case _: PBoolean => s"store_byte($off, $input_buf_ptr->read_byte());"
+    case _: PInt32 => s"store_int($off, $input_buf_ptr->read_int());"
+    case _: PInt64 => s"store_long($off, $input_buf_ptr->read_long());"
+    case _: PFloat32 => s"store_float($off, $input_buf_ptr->read_float());"
+    case _: PFloat64 => s"store_double($off, $input_buf_ptr->read_double());"
+    case _: PBinary => decodeBinary(input_buf_ptr, region, off, fb)
+    case t2: PArray => decodeArray(t2, rt.asInstanceOf[PArray], input_buf_ptr, region, off, fb)
+    case t2: PBaseStruct => decodeBaseStruct(t2, rt.asInstanceOf[PBaseStruct], input_buf_ptr, region, off, fb)
+  }
+
+  def apply(t: PType, rt: PType, bufSpec: BufferSpec, tub: TranslationUnitBuilder): Class = {
+    tub.include("hail/hail.h")
+    tub.include("hail/Decoder.h")
+    tub.include("hail/Region.h")
+    tub.include("hail/Utils.h")
+    tub.include("<cstdio>")
+    tub.include("<memory>")
+
+    val decoderBuilder = new ClassBuilder(genSym("Decoder"), "public NativeObj")
+
+    val bufType = bufSpec.nativeInputBufferType
+    val buf = Variable("buf", s"std::shared_ptr<$bufType>")
+    decoderBuilder.addPrivate(buf)
+
+    decoderBuilder.addConstructor(s"${ decoderBuilder.name }(std::shared_ptr<InputStream> is) { $buf = std::make_shared<$bufType>(is); }")
+
+    val rowFB = FunctionBuilder("decode_row", Array("NativeStatus*" -> "st", "Region *" -> "region"), "char *")
+    val region = rowFB.getArg(1)
+    val initialSize = rt match {
+      case _: PArray | _: PBinary => 8
+      case _ => rt.byteSize
+    }
+    val row = Variable("row", "char *", s"$region->allocate(${ rt.alignment }, $initialSize)")
+    rowFB += row.define
+    rowFB += decode(t.fundamentalType, rt.fundamentalType, buf.ref, region.ref, row.ref, rowFB)
+    rowFB += (rt match {
+      case _: PArray | _: PBinary => s"return load_address($row);"
+      case _ => s"return $row;"
+    })
+    decoderBuilder += rowFB.result()
+
+    val byteFB = FunctionBuilder("decode_byte", Array("NativeStatus*" -> "st"), "char")
+    byteFB += s"return $buf->read_byte();"
+    decoderBuilder += byteFB.result()
+
+    decoderBuilder.result()
+  }
+
+  def buildModule(t: PType, rt: PType, bufSpec: BufferSpec): NativeDecoderModule = {
+    assert(t.isInstanceOf[PBaseStruct] || t.isInstanceOf[PArray])
+    val tub = new TranslationUnitBuilder()
+
+    val decoder = apply(t, rt, bufSpec, tub)
+    tub += decoder
+
+    tub.include("hail/Decoder.h")
+    tub.include("hail/ObjectArray.h")
+    tub.include("<memory>")
+
+    val inBufFB = FunctionBuilder("make_input_buffer", Array("NativeStatus*" -> "st", "long" -> "objects"), "NativeObjPtr")
+    inBufFB += "UpcallEnv up;"
+    inBufFB += s"auto jinput_stream = reinterpret_cast<ObjectArray*>(${ inBufFB.getArg(1) })->at(0);"
+    inBufFB += s"return std::make_shared<$decoder>(std::make_shared<InputStream>(up, jinput_stream));"
+    tub += inBufFB.result()
+
+    val rowFB = FunctionBuilder("decode_row", Array("NativeStatus*" -> "st", "long" -> "buf", "long" -> "region"), "long")
+    rowFB += s"return (long) reinterpret_cast<$decoder *>(${ rowFB.getArg(1) })->decode_row(${ rowFB.getArg(0) }, reinterpret_cast<Region *>(${ rowFB.getArg(2) }));"
+    tub += rowFB.result()
+
+    val byteFB = FunctionBuilder("decode_byte", Array("NativeStatus*" -> "st", "long" -> "buf"), "long")
+    byteFB += s"return (long) reinterpret_cast<$decoder *>(${ byteFB.getArg(1) })->decode_byte(${ byteFB.getArg(0) });"
+    tub += byteFB.result()
+
+    val mod = tub.result().build("-O2 -llz4")
+
+    NativeDecoderModule(mod.getKey, mod.getBinary)
+  }
+
+}

--- a/hail/src/main/scala/is/hail/cxx/PackDecoder.scala
+++ b/hail/src/main/scala/is/hail/cxx/PackDecoder.scala
@@ -183,7 +183,7 @@ object PackDecoder {
     val buf = Variable("buf", s"std::shared_ptr<$bufType>")
     decoderBuilder.addPrivate(buf)
 
-    decoderBuilder.addConstructor(s"${ decoderBuilder.name }(std::shared_ptr<InputStream> is) $buf(std::make_shared<$bufType>(is)) { }")
+    decoderBuilder.addConstructor(s"${ decoderBuilder.name }(std::shared_ptr<InputStream> is) : $buf(std::make_shared<$bufType>(is)) { }")
 
     val rowFB = FunctionBuilder("decode_row", Array("NativeStatus*" -> "st", "Region *" -> "region"), "char *")
     val region = rowFB.getArg(1)

--- a/hail/src/main/scala/is/hail/cxx/PackEncoder.scala
+++ b/hail/src/main/scala/is/hail/cxx/PackEncoder.scala
@@ -127,7 +127,7 @@ object PackEncoder {
     encBuilder.result()
   }
 
-  def apply(t: PType, bufSpec: BufferSpec): NativeEncoderModule = {
+  def buildModule(t: PType, bufSpec: BufferSpec): NativeEncoderModule = {
     assert(t.isInstanceOf[PBaseStruct] || t.isInstanceOf[PArray])
     val tub = new TranslationUnitBuilder()
 

--- a/hail/src/main/scala/is/hail/cxx/PackEncoder.scala
+++ b/hail/src/main/scala/is/hail/cxx/PackEncoder.scala
@@ -94,13 +94,13 @@ object PackEncoder {
     tub.include("<cstdio>")
     tub.include("<memory>")
 
-    val encBuilder = new ClassBuilder("Encoder", "public NativeObj")
+    val encBuilder = new ClassBuilder("Encoder", "NativeObj")
 
     val bufType = bufSpec.nativeOutputBufferType
     val buf = Variable("buf", s"std::shared_ptr<$bufType>")
     encBuilder.addPrivate(buf)
 
-    encBuilder.addConstructor(s"${ encBuilder.name }(std::shared_ptr<OutputStream> os) { $buf = std::make_shared<$bufType>(os); }")
+    encBuilder.addConstructor(s"${ encBuilder.name }(std::shared_ptr<OutputStream> os) $buf(std::make_shared<$bufType>(os)) { }")
 
     val rowFB = FunctionBuilder("encode_row", Array("NativeStatus*" -> "st", "char *" -> "row"), "void")
     rowFB += encode(t.fundamentalType, buf.ref, rowFB.getArg(1).ref)

--- a/hail/src/main/scala/is/hail/cxx/PackEncoder.scala
+++ b/hail/src/main/scala/is/hail/cxx/PackEncoder.scala
@@ -100,7 +100,7 @@ object PackEncoder {
     val buf = Variable("buf", s"std::shared_ptr<$bufType>")
     encBuilder.addPrivate(buf)
 
-    encBuilder.addConstructor(s"${ encBuilder.name }(std::shared_ptr<OutputStream> os) $buf(std::make_shared<$bufType>(os)) { }")
+    encBuilder.addConstructor(s"${ encBuilder.name }(std::shared_ptr<OutputStream> os) : $buf(std::make_shared<$bufType>(os)) { }")
 
     val rowFB = FunctionBuilder("encode_row", Array("NativeStatus*" -> "st", "char *" -> "row"), "void")
     rowFB += encode(t.fundamentalType, buf.ref, rowFB.getArg(1).ref)

--- a/hail/src/main/scala/is/hail/cxx/PackEncoder.scala
+++ b/hail/src/main/scala/is/hail/cxx/PackEncoder.scala
@@ -1,0 +1,168 @@
+package is.hail.cxx
+
+import is.hail.expr.types.physical._
+import is.hail.io.{BufferSpec, NativeEncoderModule}
+
+object PackEncoder {
+
+  def encodeBinary(output_buf_ptr: Expression, off: Expression): Code = {
+    val len = Variable("len", "int", s"load_length($off)")
+    s"""
+       |${ len.define }
+       |$output_buf_ptr->write_int($len);
+       |$output_buf_ptr->write_bytes($off + 4, $len);""".stripMargin
+  }
+
+  def encodeArray(t: PArray, output_buf_ptr: Expression, off: Expression): Code = {
+    val len = Variable("len", "int", s"load_length($off)")
+    val i = Variable("i", "int", s"0")
+    val copyLengthAndMissing = if (t.elementType.required)
+      s"$output_buf_ptr->write_int($len);"
+    else
+      s"""
+         |$output_buf_ptr->write_int($len);
+         |$output_buf_ptr->write_bytes($off + 4, n_missing_bytes($len));""".stripMargin
+    val eltOff = Variable("eoff",
+      "char *",
+      s"round_up_alignment(${ if (!t.elementType.required) s"$off + 4 + n_missing_bytes($len)" else s"$off + 4" }, ${ t.elementType.alignment })")
+    val elt = t.elementType match {
+      case (_: PBinary | _: PArray) => s"load_address($eltOff)"
+      case _ => eltOff.toString
+    }
+
+    val writeElt = if (t.elementType.required)
+      encode(t.elementType, output_buf_ptr, Expression(elt))
+    else
+      s"""
+         |if (!load_bit($off + 4, $i)) {
+         |  ${ encode(t.elementType, output_buf_ptr, Expression(elt)) };
+         |}""".stripMargin
+
+    s"""
+       |${ len.define }
+       |$copyLengthAndMissing
+       |${ eltOff.define }
+       |for (${ i.define } $i < $len; $i++) {
+       |  $writeElt
+       |  $eltOff += ${ t.elementByteSize };
+       |}
+      """.stripMargin
+  }
+
+  def encodeBaseStruct(t: PBaseStruct, output_buf_ptr: Expression, off: Expression): Code = {
+    val nMissingBytes = t.nMissingBytes
+    val storeFields: Array[Code] = Array.tabulate[Code](t.size) { idx =>
+      val store = t.types(idx) match {
+        case t2@(_: PArray | _: PBinary) =>
+          encode(t2, output_buf_ptr, Expression(s"load_address($off + ${ t.byteOffsets(idx) })"))
+        case t2 =>
+          encode(t2, output_buf_ptr, Expression(s"$off + ${ t.byteOffsets(idx) }"))
+
+      }
+      if (t.fieldRequired(idx)) {
+        store
+      } else {
+        s"""
+           |if (!load_bit($off, ${ t.missingIdx(idx) })) {
+           |  $store
+           |}""".stripMargin
+      }
+    }
+    s"""
+       |$output_buf_ptr->write_bytes($off, $nMissingBytes);
+       |${ storeFields.mkString("\n") }
+      """.stripMargin
+  }
+
+  def encode(t: PType, output_buf_ptr: Expression, off: Expression): Code = t match {
+    case _: PBoolean => s"$output_buf_ptr->write_byte(*($off) ? 1 : 0);"
+    case _: PInt32 => s"$output_buf_ptr->write_int(load_int($off));"
+    case _: PInt64 => s"$output_buf_ptr->write_long(load_long($off));"
+    case _: PFloat32 => s"$output_buf_ptr->write_float(load_float($off));"
+    case _: PFloat64 => s"$output_buf_ptr->write_double(load_double($off));"
+    case _: PBinary => encodeBinary(output_buf_ptr, off)
+    case t2: PArray => encodeArray(t2, output_buf_ptr, off)
+    case t2: PBaseStruct => encodeBaseStruct(t2, output_buf_ptr, off)
+  }
+
+  def apply(t: PType, bufSpec: BufferSpec, tub: TranslationUnitBuilder): Class = {
+    assert(t.isInstanceOf[PBaseStruct] || t.isInstanceOf[PArray])
+    tub.include("hail/hail.h")
+    tub.include("hail/Encoder.h")
+    tub.include("hail/ObjectArray.h")
+    tub.include("hail/Utils.h")
+    tub.include("<cstdio>")
+    tub.include("<memory>")
+
+    val encBuilder = new ClassBuilder("Encoder", "public NativeObj")
+
+    val bufType = bufSpec.nativeOutputBufferType
+    val buf = Variable("buf", s"std::shared_ptr<$bufType>")
+    encBuilder.addPrivate(buf)
+
+    encBuilder.addConstructor(s"${ encBuilder.name }(std::shared_ptr<OutputStream> os) { $buf = std::make_shared<$bufType>(os); }")
+
+    val rowFB = FunctionBuilder("encode_row", Array("NativeStatus*" -> "st", "char *" -> "row"), "void")
+    rowFB += encode(t.fundamentalType, buf.ref, rowFB.getArg(1).ref)
+    rowFB += "return;"
+    encBuilder += rowFB.result()
+
+    val byteFB = FunctionBuilder("encode_byte", Array("NativeStatus*" -> "st", "char" -> "b"), "void")
+    byteFB += s"$buf->write_byte(${ byteFB.getArg(1) });"
+    byteFB += "return;"
+    encBuilder += byteFB.result()
+
+    val flushFB = FunctionBuilder("flush", Array("NativeStatus*" -> "st"), "void")
+    flushFB += s"$buf->flush();"
+    flushFB += "return;"
+    encBuilder += flushFB.result()
+
+    val closeFB = FunctionBuilder("close", Array("NativeStatus*" -> "st"), "void")
+    closeFB +=
+      s"""
+         |$buf->close();
+         |return;""".stripMargin
+    encBuilder += closeFB.result()
+
+    encBuilder.result()
+  }
+
+  def apply(t: PType, bufSpec: BufferSpec): NativeEncoderModule = {
+    assert(t.isInstanceOf[PBaseStruct] || t.isInstanceOf[PArray])
+    val tub = new TranslationUnitBuilder()
+
+    val encClass = apply(t, bufSpec, tub)
+    tub += encClass
+
+    val outBufFB = FunctionBuilder("makeOutputBuffer", Array("NativeStatus*" -> "st", "long" -> "objects"), "NativeObjPtr")
+    outBufFB += "UpcallEnv up;"
+    outBufFB += s"auto joutput_stream = reinterpret_cast<ObjectArray*>(${ outBufFB.getArg(1) })->at(0);"
+    val bufType = bufSpec.nativeOutputBufferType
+    outBufFB += s"return std::make_shared<$encClass>(std::make_shared<OutputStream>(up, joutput_stream));"
+    tub += outBufFB.result()
+
+    val rowFB = FunctionBuilder("encode_row", Array("NativeStatus*" -> "st", "long" -> "buf", "long" -> "row"), "long")
+    rowFB += s"reinterpret_cast<$encClass *>(${ rowFB.getArg(1) })->encode_row(${ rowFB.getArg(0) }, reinterpret_cast<char *>(${ rowFB.getArg(2) }));"
+    rowFB += "return 0;"
+    tub += rowFB.result()
+
+    val byteFB = FunctionBuilder("encode_byte", Array("NativeStatus*" -> "st", "long" -> "buf", "long" -> "b"), "long")
+    byteFB += s"reinterpret_cast<$encClass *>(${ byteFB.getArg(1) })->encode_byte(${ byteFB.getArg(0) }, ${ byteFB.getArg(2) } & 0xff);"
+    byteFB += "return 0;"
+    tub += byteFB.result()
+
+    val flushFB = FunctionBuilder("encoder_flush", Array("NativeStatus*" -> "st", "long" -> "buf"), "long")
+    flushFB += s"reinterpret_cast<$encClass *>(${ flushFB.getArg(1) })->flush(${ flushFB.getArg(0) });"
+    flushFB += "return 0;"
+    tub += flushFB.result()
+
+    val closeFB = FunctionBuilder("encoder_close", Array("NativeStatus*" -> "st", "long" -> "buf"), "long")
+    closeFB += s"reinterpret_cast<$encClass *>(${ closeFB.getArg(1) })->close(${ closeFB.getArg(0) });"
+    closeFB += "return 0;"
+    tub += closeFB.result()
+
+    val mod = tub.result().build("-O1 -llz4")
+
+    NativeEncoderModule(mod.getKey, mod.getBinary)
+  }
+}

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -177,7 +177,7 @@ final case class PackCodecSpec(child: BufferSpec) extends CodecSpec {
 
   def buildEncoder(t: PType): (OutputStream) => Encoder = {
     if (HailContext.get.flags.get("cpp") != null) {
-      val e: NativeEncoderModule = cxx.PackEncoder(t, child)
+      val e: NativeEncoderModule = cxx.PackEncoder.buildModule(t, child)
       (out: OutputStream) => new NativePackEncoder(out, e)
     } else {
       out: OutputStream => new PackEncoder(t, child.buildOutputBuffer(out))

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -123,6 +123,10 @@ trait CodecSpec extends Serializable {
 
   def buildDecoder(t: PType, requestedType: PType): (InputStream) => Decoder
 
+  def buildNativeDecoderClass(t: PType, requestedType: PType, tub: cxx.TranslationUnitBuilder): cxx.Class
+
+  def buildNativeEncoderClass(t: PType, tub: cxx.TranslationUnitBuilder): cxx.Class
+
   // FIXME: is there a better place for this to live?
   def decodeRDD(t: PType, bytes: RDD[Array[Byte]]): ContextRDD[RVDContext, RegionValue] = {
     val dec = buildDecoder(t, t)
@@ -173,7 +177,7 @@ final case class PackCodecSpec(child: BufferSpec) extends CodecSpec {
 
   def buildEncoder(t: PType): (OutputStream) => Encoder = {
     if (HailContext.get.flags.get("cpp") != null) {
-      val e: NativeEncoderModule = NativeEncoder(t, child)
+      val e: NativeEncoderModule = cxx.PackEncoder(t, child)
       (out: OutputStream) => new NativePackEncoder(out, e)
     } else {
       out: OutputStream => new PackEncoder(t, child.buildOutputBuffer(out))
@@ -182,13 +186,17 @@ final case class PackCodecSpec(child: BufferSpec) extends CodecSpec {
 
   def buildDecoder(t: PType, requestedType: PType): (InputStream) => Decoder = {
     if (HailContext.get.flags.get("cpp") != null) {
-      val d: NativeDecoderModule = NativeDecoder(t, requestedType, child)
+      val d: NativeDecoderModule = cxx.PackDecoder.buildModule(t, requestedType, child)
       (in: InputStream) => new NativePackDecoder(in, d)
     } else {
       val f = EmitPackDecoder(t, requestedType)
       (in: InputStream) => new CompiledPackDecoder(child.buildInputBuffer(in), f)
     }
   }
+
+  def buildNativeDecoderClass(t: PType, requestedType: PType, tub: cxx.TranslationUnitBuilder): cxx.Class = cxx.PackDecoder(t, requestedType, child, tub)
+
+  def buildNativeEncoderClass(t: PType, tub: cxx.TranslationUnitBuilder): cxx.Class = cxx.PackEncoder(t, child, tub)
 }
 
 trait OutputBlockBuffer extends Closeable {
@@ -935,216 +943,6 @@ object EmitPackDecoder {
   }
 }
 
-object NativeDecoder {
-  def skipBinary(input_buf_ptr: cxx.Expression): cxx.Code = {
-    val len = cxx.Variable("skip_len", "int", s"$input_buf_ptr->read_int()")
-    s"""
-       |${ len.define }
-       |$input_buf_ptr->skip_bytes($len);""".stripMargin
-  }
-
-  def skipArray(t: PArray, input_buf_ptr: cxx.Expression): cxx.Code = {
-    val len = cxx.Variable("len", "int", s"$input_buf_ptr->read_int()")
-    val i = cxx.Variable("i", "int", "0")
-    if (t.elementType.required) {
-      s"""
-         |${ len.define }
-         |for (${ i.define } $i < $len; $i++) {
-         |  ${ skip(t.elementType, input_buf_ptr) }
-         |}""".stripMargin
-    } else {
-      val missingBytes = cxx.ArrayVariable(s"missing", "char", s"n_missing_bytes($len)")
-      s"""
-         |${ len.define }
-         |${ missingBytes.define }
-         |$input_buf_ptr->read_bytes($missingBytes, n_missing_bytes($len));
-         |for (${ i.define } $i < $len; $i++) {
-         |  if (!load_bit($missingBytes, $i)) {
-         |    ${ skip(t.elementType, input_buf_ptr) }
-         |  }
-         |}""".stripMargin
-    }
-  }
-
-  def skipBaseStruct(t: PBaseStruct, input_buf_ptr: cxx.Expression): cxx.Code = {
-    val missingBytes = cxx.ArrayVariable("missing", "char", s"${ t.nMissingBytes }")
-    val skipFields = Array.tabulate[cxx.Code](t.size) { idx =>
-      val fieldType = t.types(idx)
-      if (fieldType.required)
-        skip(fieldType, input_buf_ptr)
-      else
-        s"""
-           |if (!load_bit($missingBytes, ${ t.missingIdx(idx) })) {
-           |  ${ skip(fieldType, input_buf_ptr) }
-           |}""".stripMargin
-    }
-
-    if (t.nMissingBytes > 0)
-      s"""
-         |${ missingBytes.define }
-         |$input_buf_ptr->read_bytes($missingBytes, ${ t.nMissingBytes });
-         |${ skipFields.mkString("\n") }""".stripMargin
-    else
-      skipFields.mkString("\n")
-  }
-
-  def skip(t: PType, input_buf_ptr: cxx.Expression): cxx.Code = t match {
-    case t2: PArray => skipArray(t2, input_buf_ptr)
-    case t2: PBaseStruct => skipBaseStruct(t2, input_buf_ptr)
-    case _: PBinary => skipBinary(input_buf_ptr)
-    case _: PBoolean => s"$input_buf_ptr->skip_boolean();"
-    case _: PInt32 => s"$input_buf_ptr->skip_int();"
-    case _: PInt64 => s"$input_buf_ptr->skip_long();"
-    case _: PFloat32 => s"$input_buf_ptr->skip_float();"
-    case _: PFloat64 => s"$input_buf_ptr->skip_double();"
-  }
-
-  def decodeBinary(input_buf_ptr: cxx.Expression, region: cxx.Expression, off: cxx.Expression, fb: cxx.FunctionBuilder): cxx.Code = {
-    val len = cxx.Variable("len", "int", s"$input_buf_ptr->read_int()")
-    val boff = cxx.Variable("boff", "char *", s"$region->allocate(${ PBinary.contentAlignment }, $len + 4)")
-    s"""
-       |${ len.define }
-       |${ boff.define }
-       |store_address($off, $boff);
-       |store_int($boff, $len);
-       |$input_buf_ptr->read_bytes($boff + 4, $len);""".stripMargin
-  }
-
-  def decodeArray(t: PArray, rt: PArray, input_buf_ptr: cxx.Expression, region: cxx.Expression, off: cxx.Expression, fb: cxx.FunctionBuilder): cxx.Code = {
-    val len = cxx.Variable("len", "int", s"$input_buf_ptr->read_int()")
-    val sab = new cxx.StagedContainerBuilder(fb, region.toString, rt)
-    var decodeElt = decode(t.elementType, rt.elementType, input_buf_ptr, region, cxx.Expression(sab.eltOffset), fb)
-    if (rt.elementType.required)
-      decodeElt =
-        s"""
-           |if (!${ rt.cxxIsElementMissing(sab.end(), sab.idx) }) {
-           |  $decodeElt
-           |}
-         """.stripMargin
-
-    s"""
-       |${ len.define }
-       |${ sab.start(len, clearMissing = false) }
-       |store_address($off, ${ sab.end() });
-       |${ if (rt.elementType.required) "" else s"$input_buf_ptr->read_bytes(${ sab.end() } + 4, ${ rt.cxxNMissingBytes(s"$len") });" }
-       |while (${ sab.idx } < $len) {
-       |  $decodeElt
-       |  ${ sab.advance() }
-       |}
-     """.stripMargin
-  }
-
-  def decodeBaseStruct(t: PBaseStruct, rt: PBaseStruct, input_buf_ptr: cxx.Expression, region: cxx.Expression, off: cxx.Expression, fb: cxx.FunctionBuilder): cxx.Code = {
-    val ssb = new cxx.StagedBaseStructBuilder(fb, rt, off)
-
-    def wrapMissing(missingBytes: cxx.Code, tidx: Int)(processField: cxx.Code): cxx.Code = {
-      if (!t.fieldRequired(tidx)) {
-        s"""
-           |if (!${ t.cxxIsFieldMissing(missingBytes, tidx) }) {
-           |  $processField
-           |}""".stripMargin
-      } else processField
-    }
-
-    if (t.size == rt.size) {
-      assert((t.isInstanceOf[PTuple] && rt.isInstanceOf[PTuple]) || (t.asInstanceOf[PStruct].fieldNames sameElements t.asInstanceOf[PStruct].fieldNames))
-      val decodeFields = Array.tabulate[cxx.Code](rt.size) { idx =>
-        wrapMissing(s"$off", idx)(ssb.addField(idx, foff => decode(t.types(idx), rt.types(idx), input_buf_ptr, region, cxx.Expression(foff), fb)))
-      }.mkString("\n")
-      if (t.nMissingBytes > 0) {
-        s"""
-           |$input_buf_ptr->read_bytes($off, ${ t.nMissingBytes });
-           |$decodeFields""".stripMargin
-      } else
-        decodeFields
-    } else {
-      val names = t.asInstanceOf[PStruct].fieldNames
-      val rnames = rt.asInstanceOf[PStruct].fieldNames
-      val t_missing_bytes = cxx.ArrayVariable(s"missing", "char", s"${ t.nMissingBytes }")
-
-      var rtidx = 0
-      val decodeFields = Array.tabulate[cxx.Code](t.size) { tidx =>
-        val f = t.types(tidx)
-        val skipField = rtidx >= rt.size || names(tidx) != rnames(rtidx)
-        val processField = if (skipField)
-          wrapMissing(s"$t_missing_bytes", tidx)(skip(f, input_buf_ptr))
-        else
-          s"""
-             |${ wrapMissing(s"$t_missing_bytes", tidx)(ssb.addField(rtidx, foff => decode(f, rt.types(rtidx), input_buf_ptr, region, cxx.Expression(foff), fb))) }
-             |${ if (f.required) "" else s" else { ${ ssb.setMissing(rtidx) } }" }
-           """.stripMargin
-        if (!skipField)
-          rtidx += 1
-        wrapMissing(s"$t_missing_bytes", tidx)(processField)
-      }.mkString("\n")
-      if (t.nMissingBytes > 0) {
-        s"""
-           |${ t_missing_bytes.define }
-           |${ ssb.clearAllMissing() };
-           |$input_buf_ptr->read_bytes($t_missing_bytes, ${ t.nMissingBytes });
-           |$decodeFields""".stripMargin
-      } else
-        decodeFields
-    }
-  }
-
-  def decode(t: PType, rt: PType, input_buf_ptr: cxx.Expression, region: cxx.Expression, off: cxx.Expression, fb: cxx.FunctionBuilder): cxx.Code = t match {
-    case _: PBoolean => s"store_byte($off, $input_buf_ptr->read_byte());"
-    case _: PInt32 => s"store_int($off, $input_buf_ptr->read_int());"
-    case _: PInt64 => s"store_long($off, $input_buf_ptr->read_long());"
-    case _: PFloat32 => s"store_float($off, $input_buf_ptr->read_float());"
-    case _: PFloat64 => s"store_double($off, $input_buf_ptr->read_double());"
-    case _: PBinary => decodeBinary(input_buf_ptr, region, off, fb)
-    case t2: PArray => decodeArray(t2, rt.asInstanceOf[PArray], input_buf_ptr, region, off, fb)
-    case t2: PBaseStruct => decodeBaseStruct(t2, rt.asInstanceOf[PBaseStruct], input_buf_ptr, region, off, fb)
-  }
-
-  def apply(t: PType, rt: PType, bufSpec: BufferSpec): NativeDecoderModule = {
-    assert(t.isInstanceOf[PBaseStruct] || t.isInstanceOf[PArray])
-    val tub = new cxx.TranslationUnitBuilder()
-    tub.include("hail/hail.h")
-    tub.include("hail/Decoder.h")
-    tub.include("hail/ObjectArray.h")
-    tub.include("hail/Region.h")
-    tub.include("hail/Utils.h")
-    tub.include("<cstdio>")
-    tub.include("<memory>")
-
-    val inBufFB = cxx.FunctionBuilder("make_input_buffer", Array("NativeStatus*" -> "st", "long" -> "objects"), "NativeObjPtr")
-    inBufFB += "UpcallEnv up;"
-    inBufFB += s"auto jinput_stream = reinterpret_cast<ObjectArray*>(${ inBufFB.getArg(1) })->at(0);"
-    val bufType = bufSpec.nativeInputBufferType
-    inBufFB += s"return std::make_shared<Decoder<$bufType>>(std::make_shared<InputStream>(up, jinput_stream));"
-    tub += inBufFB.result()
-
-    val rowFB = cxx.FunctionBuilder("decode_row", Array("NativeStatus*" -> "st", "long" -> "buf", "long" -> "region"), "long")
-    val buf = cxx.Variable("buf", s"$bufType *", s"&reinterpret_cast<Decoder<$bufType> *>(${ rowFB.getArg(1) })->buf_")
-    val region = cxx.Variable("region", "Region *", s"reinterpret_cast<Region *>(${ rowFB.getArg(2) })")
-    val initialSize = rt match {
-      case _: PArray | _: PBinary => 8
-      case _ => rt.byteSize
-    }
-    val row = cxx.Variable("row", "char *", s"$region->allocate(${ rt.alignment }, $initialSize)")
-    rowFB += buf.define
-    rowFB += region.define
-    rowFB += row.define
-    rowFB += decode(t.fundamentalType, rt.fundamentalType, buf.ref, region.ref, row.ref, rowFB)
-    rowFB += (rt match {
-      case _: PArray | _: PBinary => s"return read_long($row);"
-      case _ => s"return reinterpret_cast<long>($row);"
-    })
-    tub += rowFB.result()
-
-    val byteFB = cxx.FunctionBuilder("decode_byte", Array("NativeStatus*" -> "st", "long" -> "buf"), "long")
-    byteFB += s"return reinterpret_cast<Decoder<$bufType> *>(${ byteFB.getArg(1) })->buf_.read_byte();"
-    tub += byteFB.result()
-
-    val mod = tub.result().build("-O2 -llz4")
-
-    NativeDecoderModule(mod.getKey, mod.getBinary)
-  }
-}
-
 case class NativeDecoderModule(
   modKey: String,
   modBinary: Array[Byte]) extends Serializable
@@ -1394,137 +1192,6 @@ final class PackEncoder(rowType: PType, out: OutputBuffer) extends Encoder {
       case t: PArray =>
         writeArray(t, region, offset)
     }
-  }
-}
-
-object NativeEncoder {
-
-  def encodeBinary(output_buf_ptr: cxx.Expression, off: cxx.Expression): cxx.Code = {
-    val len = cxx.Variable("len", "int", s"load_length($off)")
-    s"""
-       |${ len.define }
-       |$output_buf_ptr->write_int($len);
-       |$output_buf_ptr->write_bytes($off + 4, $len);""".stripMargin
-  }
-
-  def encodeArray(t: PArray, output_buf_ptr: cxx.Expression, off: cxx.Expression): cxx.Code = {
-    val len = cxx.Variable("len", "int", s"load_length($off)")
-    val i = cxx.Variable("i", "int", s"0")
-    val copyLengthAndMissing = if (t.elementType.required)
-      s"$output_buf_ptr->write_int($len);"
-    else
-      s"""
-         |$output_buf_ptr->write_int($len);
-         |$output_buf_ptr->write_bytes($off + 4, n_missing_bytes($len));""".stripMargin
-    val eltOff = cxx.Variable("eoff",
-      "char *",
-      s"round_up_alignment(${ if (!t.elementType.required) s"$off + 4 + n_missing_bytes($len)" else s"$off + 4" }, ${ t.elementType.alignment })")
-    val elt = t.elementType match {
-      case (_: PBinary | _: PArray) => s"load_address($eltOff)"
-      case _ => eltOff.toString
-    }
-
-    val writeElt = if (t.elementType.required)
-      encode(t.elementType, output_buf_ptr, cxx.Expression(elt))
-    else
-      s"""
-         |if (!load_bit($off + 4, $i)) {
-         |  ${ encode(t.elementType, output_buf_ptr, cxx.Expression(elt)) };
-         |}""".stripMargin
-
-    s"""
-       |${ len.define }
-       |$copyLengthAndMissing
-       |${ eltOff.define }
-       |for (${ i.define } $i < $len; $i++) {
-       |  $writeElt
-       |  $eltOff += ${ t.elementByteSize };
-       |}
-      """.stripMargin
-  }
-
-  def encodeBaseStruct(t: PBaseStruct, output_buf_ptr: cxx.Expression, off: cxx.Expression): cxx.Code = {
-    val nMissingBytes = t.nMissingBytes
-    val storeFields: Array[cxx.Code] = Array.tabulate[cxx.Code](t.size) { idx =>
-      val store = t.types(idx) match {
-        case t2@(_: PArray | _: PBinary) =>
-          encode(t2, output_buf_ptr, cxx.Expression(s"load_address($off + ${ t.byteOffsets(idx) })"))
-        case t2 =>
-          encode(t2, output_buf_ptr, cxx.Expression(s"$off + ${ t.byteOffsets(idx) }"))
-
-      }
-      if (t.fieldRequired(idx)) {
-        store
-      } else {
-        s"""
-           |if (!load_bit($off, ${ t.missingIdx(idx) })) {
-           |  $store
-           |}""".stripMargin
-      }
-    }
-    s"""
-       |$output_buf_ptr->write_bytes($off, $nMissingBytes);
-       |${ storeFields.mkString("\n") }
-      """.stripMargin
-  }
-
-  def encode(t: PType, output_buf_ptr: cxx.Expression, off: cxx.Expression): cxx.Code = t match {
-    case _: PBoolean => s"$output_buf_ptr->write_byte(*($off) ? 1 : 0);"
-    case _: PInt32 => s"$output_buf_ptr->write_int(load_int($off));"
-    case _: PInt64 => s"$output_buf_ptr->write_long(load_long($off));"
-    case _: PFloat32 => s"$output_buf_ptr->write_float(load_float($off));"
-    case _: PFloat64 => s"$output_buf_ptr->write_double(load_double($off));"
-    case _: PBinary => encodeBinary(output_buf_ptr, off)
-    case t2: PArray => encodeArray(t2, output_buf_ptr, off)
-    case t2: PBaseStruct => encodeBaseStruct(t2, output_buf_ptr, off)
-  }
-
-  def apply(t: PType, bufSpec: BufferSpec): NativeEncoderModule = {
-    assert(t.isInstanceOf[PBaseStruct] || t.isInstanceOf[PArray])
-    val tub = new cxx.TranslationUnitBuilder()
-    tub.include("hail/hail.h")
-    tub.include("hail/Encoder.h")
-    tub.include("hail/ObjectArray.h")
-    tub.include("hail/Utils.h")
-    tub.include("<cstdio>")
-    tub.include("<memory>")
-
-    val outBufFB = cxx.FunctionBuilder("makeOutputBuffer", Array("NativeStatus*" -> "st", "long" -> "objects"), "NativeObjPtr")
-    outBufFB += "UpcallEnv up;"
-    outBufFB += s"auto joutput_stream = reinterpret_cast<ObjectArray*>(${ outBufFB.getArg(1) })->at(0);"
-    val bufType = bufSpec.nativeOutputBufferType
-    outBufFB += s"return std::make_shared<Encoder<$bufType>>(std::make_shared<OutputStream>(up, joutput_stream));"
-    tub += outBufFB.result()
-
-    val rowFB = cxx.FunctionBuilder("encode_row", Array("NativeStatus*" -> "st", "long" -> "buf", "long" -> "row"), "long")
-    val buf = cxx.Variable("buf", s"$bufType *", s"&reinterpret_cast<Encoder<$bufType> *>(${ rowFB.getArg(1) })->buf_")
-    val row = cxx.Variable("row", "char *", s"reinterpret_cast<char *>(${ rowFB.getArg(2) })")
-    rowFB += buf.define
-    rowFB += row.define
-    rowFB += encode(t.fundamentalType, buf.ref, row.ref)
-    rowFB += "return 0;"
-    tub += rowFB.result()
-
-    val byteFB = cxx.FunctionBuilder("encode_byte", Array("NativeStatus*" -> "st", "long" -> "buf", "long" -> "b"), "long")
-    byteFB += s"reinterpret_cast<Encoder<$bufType> *>(${ byteFB.getArg(1) })->buf_.write_byte(${ byteFB.getArg(2) } & 0xff);"
-    byteFB += "return 0;"
-    tub += byteFB.result()
-
-    val flushFB = cxx.FunctionBuilder("encoder_flush", Array("NativeStatus*" -> "st", "long" -> "buf"), "long")
-    flushFB += s"reinterpret_cast<Encoder<$bufType> *>(${ flushFB.getArg(1) })->buf_.flush();"
-    flushFB += "return 0;"
-    tub += flushFB.result()
-
-    val closeFB = cxx.FunctionBuilder("encoder_close", Array("NativeStatus*" -> "st", "long" -> "buf"), "long")
-    closeFB +=
-      s"""
-         |reinterpret_cast<Encoder<$bufType> *>(${ closeFB.getArg(1) })->buf_.close();
-         |return 0;""".stripMargin
-    tub += closeFB.result()
-
-    val mod = tub.result().build("-O1 -llz4")
-
-    NativeEncoderModule(mod.getKey, mod.getBinary)
   }
 }
 

--- a/hail/src/test/scala/is/hail/nativecode/NativeDecoderSuite.scala
+++ b/hail/src/test/scala/is/hail/nativecode/NativeDecoderSuite.scala
@@ -177,9 +177,9 @@ class NativeDecoderSuite extends SparkSuite {
     }
 
     val bais = new ByteArrayInputStream(baos.toByteArray)
-    val dec = new NativePackDecoder(bais, NativeDecoder(t.physicalType, t.physicalType, spec))
+    val dec = new NativePackDecoder(bais, PackDecoder.buildModule(t.physicalType, t.physicalType, spec))
     val bais2 = new ByteArrayInputStream(baos.toByteArray)
-    val dec2 = new NativePackDecoder(bais2, NativeDecoder(t.physicalType, rt.physicalType, spec))
+    val dec2 = new NativePackDecoder(bais2, PackDecoder.buildModule(t.physicalType, rt.physicalType, spec))
 
     Region.scoped { region =>
       val off = dec.readRegionValue(region)
@@ -188,5 +188,4 @@ class NativeDecoderSuite extends SparkSuite {
       assert(SafeRow.read(rt.physicalType, region, off2) == requested)
     }
   }
-
 }

--- a/hail/src/test/scala/is/hail/nativecode/NativeEncoderSuite.scala
+++ b/hail/src/test/scala/is/hail/nativecode/NativeEncoderSuite.scala
@@ -140,7 +140,7 @@ class NativeEncoderSuite extends SparkSuite {
     val a = Row(Interval(Row(Set(-1478292367)), Row(Set(2084728308)), true, true))
 
     val baos = new ByteArrayOutputStream()
-    val enc = new NativePackEncoder(baos, NativeEncoder(t.physicalType, spec))
+    val enc = new NativePackEncoder(baos, PackEncoder(t.physicalType, spec))
 
     val baos2 = new ByteArrayOutputStream()
     val enc2 = new PackEncoder(t.physicalType, spec.buildOutputBuffer(baos2))

--- a/hail/src/test/scala/is/hail/nativecode/NativeEncoderSuite.scala
+++ b/hail/src/test/scala/is/hail/nativecode/NativeEncoderSuite.scala
@@ -140,7 +140,7 @@ class NativeEncoderSuite extends SparkSuite {
     val a = Row(Interval(Row(Set(-1478292367)), Row(Set(2084728308)), true, true))
 
     val baos = new ByteArrayOutputStream()
-    val enc = new NativePackEncoder(baos, PackEncoder(t.physicalType, spec))
+    val enc = new NativePackEncoder(baos, PackEncoder.buildModule(t.physicalType, spec))
 
     val baos2 = new ByteArrayOutputStream()
     val enc2 = new PackEncoder(t.physicalType, spec.buildOutputBuffer(baos2))


### PR DESCRIPTION
This basically just pulls out the logic from the `NativeDecoder` and `NativeEncoder` stuff in RowStore.scala into their own objects, and dynamically generates a c++ class for the row type. (The only things that have changed between `NativeDecoder`/`cxx.PackDecoder` and the encoders are the `apply` functions; I'm generating an Encoder class that inherits NativeObj instead of relying on the wrapper classes in `Encoder.h` and `Decoder.h`.

This mostly felt like it made things easier to reason about when I started writing the full-stage code generation stuff, but I've pulled it out here as a separate PR.

cc @cseed