### PR TITLE
Python Table methods to IR

### DIFF
--- a/hail/python/hail/ir/__init__.py
+++ b/hail/python/hail/ir/__init__.py
@@ -2,3 +2,4 @@ from .ir import *
 from .table_ir import *
 from .matrix_ir import *
 from .aggsig import *
+from .utils import *

--- a/hail/python/hail/ir/utils.py
+++ b/hail/python/hail/ir/utils.py
@@ -1,0 +1,11 @@
+from hail.utils.java import Env
+from .ir import *
+
+
+def filter_predicate_with_keep(ir_pred, keep):
+    pred = Env.get_uid()
+    return Let(pred,
+               ir_pred if keep else ApplyUnaryOp('!', ir_pred),
+                  If(IsNA(Ref(pred)),
+                     FalseIR(),
+                     Ref(pred)))

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -207,13 +207,13 @@ class GroupedTable(ExprContainer):
             raise ValueError(
                 f'GroupedTable.aggregate: Group names and aggregration expression names overlap: {intersection}')
 
-        base, cleanup = self._parent._process_joins(*group_exprs.values(), *named_exprs.values())
+        base, _ = self._parent._process_joins(*group_exprs.values(), *named_exprs.values())
 
-        return cleanup(Table(TableKeyByAndAggregate(base._tir,
-                                                    hl.struct(**named_exprs)._ir,
-                                                    hl.struct(**group_exprs)._ir,
-                                                    self._npartitions,
-                                                    self._buffer_size)))
+        return Table(TableKeyByAndAggregate(base._tir,
+                                            hl.struct(**named_exprs)._ir,
+                                            hl.struct(**group_exprs)._ir,
+                                            self._npartitions,
+                                            self._buffer_size))
 
 
 class Table(ExprContainer):

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2148,6 +2148,7 @@ class Table(ExprContainer):
                         raise ValueError("Expect top-level field, found a complex expression")
                     if not e.col._indices == self._row_indices:
                         raise ValueError("Sort fields must be row-indexed, found global field '{}'".format(e))
+                    e.col = self._fields_inverse[e.col]
                     sort_fields.append((e.col, sort_type))
         return Table(TableOrderBy(self.key_by()._tir, sort_fields))
 

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -383,12 +383,6 @@ class Table(val hc: HailContext, val tir: TableIR) {
     new Table(hc, TableMapGlobals(tir, ir))
   }
 
-  def filter(cond: String, keep: Boolean): Table = {
-    var irPred = Parser.parse_value_ir(cond, IRParserEnvironment(typ.refMap))
-    new Table(hc,
-      TableFilter(tir, ir.filterPredicateWithKeep(irPred, keep)))
-  }
-
   def head(n: Long): Table = new Table(hc, TableHead(tir, n))
 
   def keyBy(keys: java.util.ArrayList[String]): Table =
@@ -412,9 +406,6 @@ class Table(val hc: HailContext, val tir: TableIR) {
 
   def mapRows(newRow: IR): Table =
     new Table(hc, TableMapRows(tir, newRow))
-
-  def join(other: Table, joinType: String): Table =
-    new Table(hc, TableJoin(this.tir, other.tir, joinType, typ.key.length))
 
   def leftJoinRightDistinct(other: Table, root: String): Table =
     new Table(hc, TableLeftJoinRightDistinct(tir, other.tir, root))
@@ -455,15 +446,6 @@ class Table(val hc: HailContext, val tir: TableIR) {
     nPartitions: Option[Int] = None
   ): MatrixTable = {
     new MatrixTable(hc, TableToMatrixTable(tir, rowKeys, colKeys, rowFields, colFields, nPartitions))
-  }
-
-  def keyByAndAggregate(expr: String, key: String, nPartitions: Option[Int], bufferSize: Int): Table = {
-    new Table(hc, TableKeyByAndAggregate(tir,
-      Parser.parse_value_ir(expr, IRParserEnvironment(typ.refMap)),
-      Parser.parse_value_ir(key, IRParserEnvironment(typ.refMap)),
-      nPartitions,
-      bufferSize
-    ))
   }
 
   def unlocalizeEntries(
@@ -568,19 +550,6 @@ class Table(val hc: HailContext, val tir: TableIR) {
   }
 
   def unpersist(): Table = copy2(rvd = rvd.unpersist())
-
-  def orderBy(sortFields: Array[SortField]): Table = {
-    new Table(hc, TableOrderBy(TableKeyBy(tir, FastIndexedSeq()), sortFields))
-  }
-
-  def rename(rowMap: java.util.HashMap[String, String], globalMap: java.util.HashMap[String, String]): Table =
-    new Table(hc, TableRename(tir, rowMap.asScala.toMap, globalMap.asScala.toMap))
-
-  def repartition(n: Int, shuffle: Boolean = true): Table = new Table(hc, ir.TableRepartition(tir, n, shuffle))
-
-  def union(kts: java.util.ArrayList[Table]): Table = union(kts.asScala.toArray: _*)
-
-  def union(kts: Table*): Table = new Table(hc, TableUnion((tir +: kts.map(_.tir)).toFastIndexedSeq))
 
   def show(n: Int = 10, truncate: Option[Int] = None, printTypes: Boolean = true, maxWidth: Int = 100): Unit = {
     println(showString(n, truncate, printTypes, maxWidth))

--- a/hail/src/test/scala/is/hail/methods/TableSuite.scala
+++ b/hail/src/test/scala/is/hail/methods/TableSuite.scala
@@ -141,33 +141,6 @@ class TableSuite extends SparkSuite {
     kt2.explode(Array("field1")).export(outputFile)
   }
 
-  @Test def testKeyOrder() {
-    val kt1 = Table(hc,
-      sc.parallelize(Array(Row("foo", "bar", 3, "baz"))),
-      TStruct(
-        "f1" -> TString(),
-        "f2" -> TString(),
-        "f3" -> TInt32(),
-        "f4" -> TString()
-      ),
-      IndexedSeq("f3", "f2", "f1"))
-    kt1.typeCheck()
-
-    val kt2 = Table(hc,
-      sc.parallelize(Array(Row(3, "foo", "bar", "qux"))),
-      TStruct(
-        "f3" -> TInt32(),
-        "f1" -> TString(),
-        "f2" -> TString(),
-        "f5" -> TString()
-      ),
-      IndexedSeq("f3", "f2", "f1"))
-    kt2.typeCheck()
-
-    assert(kt1.join(kt2, "inner").count() == 1L)
-    kt1.join(kt2, "outer").typeCheck()
-  }
-
   @Test def testSame() {
     val kt = hc.importTable("src/test/resources/sampleAnnotations.tsv", impute = true)
     assert(kt.same(kt))


### PR DESCRIPTION
- still more methods to convert -- these were the easiest to do
- removed corresponding methods on Table in Scala where possible

Methods:
- GroupedTable.aggregate
- Table.key_by
- Table.filter
- Table.union
- Table.head
- Table.repartition
- Table.join
- Table.rename
- Table.order_by
- Table.explode
- Table.distinct