### PR TITLE
add function for setting feature flags from python

### DIFF
--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -22,7 +22,7 @@ To report a bug, please open an issue: https://github.com/hail-is/hail/issues
 """
 
 from .context import init, stop, spark_context, default_reference, \
-    get_reference, set_global_seed, \
+    get_reference, set_global_seed, _set_flags, \
     _set_upload_url, set_upload_email, enable_pipeline_upload, disable_pipeline_upload, upload_log
 from .table import Table, GroupedTable, asc, desc
 from .matrixtable import MatrixTable, GroupedMatrixTable
@@ -50,6 +50,7 @@ __all__ = [
     'get_reference',
     'set_global_seed',
     '_set_upload_url',
+    '_set_flags',
     'set_upload_email',
     'enable_pipeline_upload',
     'disable_pipeline_upload',

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -352,3 +352,16 @@ def upload_log():
     """
 
     Env.hc()._jhc.uploadLog()
+
+
+def _set_flags(**flags):
+    available = set(Env.hc()._jhc.flags().available())
+    invalid = []
+    for flag, value in flags.items():
+        if flag in available:
+            Env.hc()._jhc.flags().set(flag, value)
+        else:
+            invalid.append(flag)
+    if len(invalid) != 0:
+        raise FatalError("Flags {} not valid. Valid flags: \n    {}"
+                         .format(', '.join(invalid), '\n    '.join(available)))

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -764,7 +764,7 @@ class HailFeatureFlags {
     flags.update(flag, value)
   }
 
-  def get(flag: String): String = flags.get(flag).get
+  def get(flag: String): String = flags(flag)
 
   def exists(flag: String): Boolean = flags.contains(flag)
 }

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -25,6 +25,7 @@ import org.apache.spark._
 import org.apache.spark.executor.InputMetrics
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.language.existentials
 import scala.reflect.ClassTag
@@ -336,6 +337,8 @@ class HailContext private(val sc: SparkContext,
   val tmpDir: String,
   val branchingFactor: Int) {
   val hadoopConf: hadoop.conf.Configuration = sc.hadoopConfiguration
+
+  val flags: HailFeatureFlags = new HailFeatureFlags()
 
   def version: String = is.hail.HAIL_PRETTY_VERSION
 
@@ -746,4 +749,22 @@ class HailContext private(val sc: SparkContext,
     warn(s"uploading $logFile")
     Uploader.upload("log", FileUtils.readFileToString(new File(logFile)))
   }
+}
+
+class HailFeatureFlags {
+  private[this] val flags: mutable.Map[String, String] =
+    mutable.Map[String, String](
+      "cpp" -> null
+    )
+
+  val available: java.util.ArrayList[String] =
+    new java.util.ArrayList[String](java.util.Arrays.asList[String](flags.keys.toSeq: _*))
+
+  def set(flag: String, value: String): Unit = {
+    flags.update(flag, value)
+  }
+
+  def get(flag: String): String = flags.get(flag).get
+
+  def exists(flag: String): Boolean = flags.contains(flag)
 }

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -14,7 +14,7 @@ import java.io._
 
 import scala.collection.mutable.ArrayBuffer
 import is.hail.asm4s._
-import is.hail.cxx
+import is.hail.{HailContext, cxx}
 import is.hail.expr.ir.{EmitUtils, EstimableEmitter, MethodBuilderLike}
 import is.hail.expr.types.MatrixType
 import is.hail.expr.types.physical._
@@ -172,16 +172,16 @@ object ShowBuf {
 final case class PackCodecSpec(child: BufferSpec) extends CodecSpec {
 
   def buildEncoder(t: PType): (OutputStream) => Encoder = {
-    if (System.getenv("HAIL_ENABLE_CPP_CODEGEN") != null) {
+    if (HailContext.get.flags.get("cpp") != null) {
       val e: NativeEncoderModule = NativeEncoder(t, child)
       (out: OutputStream) => new NativePackEncoder(out, e)
     } else {
-      { out: OutputStream => new PackEncoder(t, child.buildOutputBuffer(out)) }
+      out: OutputStream => new PackEncoder(t, child.buildOutputBuffer(out))
     }
   }
 
   def buildDecoder(t: PType, requestedType: PType): (InputStream) => Decoder = {
-    if (System.getenv("HAIL_ENABLE_CPP_CODEGEN") != null) {
+    if (HailContext.get.flags.get("cpp") != null) {
       val d: NativeDecoderModule = NativeDecoder(t, requestedType, child)
       (in: InputStream) => new NativePackDecoder(in, d)
     } else {

--- a/hail/src/test/scala/is/hail/SparkSuite.scala
+++ b/hail/src/test/scala/is/hail/SparkSuite.scala
@@ -19,7 +19,11 @@ object SparkSuite {
 }
 
 class SparkSuite extends TestNGSuite {
-  lazy val hc: HailContext = SparkSuite.hc
+  lazy val hc: HailContext = {
+    if (System.getenv("HAIL_ENABLE_CPP_CODEGEN") != null)
+      SparkSuite.hc.flags.set("cpp", "1")
+    SparkSuite.hc
+  }
 
   lazy val sc: SparkContext = hc.sc
 


### PR DESCRIPTION
currently can be used to control whether the decoder/encoder uses c++ or jvm bytecode, although we're not yet bundling the lz4 dependency so I don't think this will work on a default cloudtools cluster yet.