### PR TITLE
make split behavior mimic python

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -36,7 +36,7 @@ object StringFunctions extends RegistryFunctions {
   def replace(str: String, pattern1: String, pattern2: String): String =
     str.replaceAll(pattern1, pattern2)
 
-  def split(s: String, p: String): IndexedSeq[String] = s.split(p)
+  def split(s: String, p: String): IndexedSeq[String] = s.split(p, -1)
 
   def splitLimited(s: String, p: String, n: Int): IndexedSeq[String] = s.split(p, n)
 

--- a/hail/src/test/scala/is/hail/expr/ir/StringFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StringFunctionsSuite.scala
@@ -31,6 +31,7 @@ class StringFunctionsSuite extends TestNGSuite {
     assertEvalsTo(invoke("split", NA(TString()), Str(",")), null)
     assertEvalsTo(invoke("split", Str("a,b,c"), NA(TString())), null)
 
+    assertEvalsTo(invoke("split", Str("x"), Str("x")), FastIndexedSeq("", ""))
     assertEvalsTo(invoke("split", Str("a,b,c"), Str(",")), FastIndexedSeq("a", "b", "c"))
 
     assertEvalsTo(invoke("split", NA(TString()), Str(","), I32(2)), null)


### PR DESCRIPTION
the default Scala behavior is to strip trailing empty strings. I think it's pretty reasonable to expect Hail to mimic python behavior, but I'm not sure if this counts as a breaking change?

Fixes #4740.