### PR TITLE
Allow required types to be subtypes of optional types in isSupertype

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1058,10 +1058,6 @@ object PruneDeadFields {
     if (ir.typ == rType)
       ir
     else {
-      // FIXME: Remove this assertion before this code is merged
-      assert(isSupertype(rType, ir.typ), s"""Error, supertype relation not satisfied in upcast.
-        |Supertype: ${ rType.parsableString() }
-        |Subtype  : ${ ir.typ.parsableString() }""".stripMargin)
       ir.typ match {
         case ts: TStruct =>
           val rs = rType.asInstanceOf[TStruct]

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -880,14 +880,8 @@ object PruneDeadFields {
         val child2 = rebuild(child, memo)
         MatrixMapEntries(child2, rebuild(newEntries, child2.typ, memo))
       case MatrixMapRows(child, newRow) =>
-        // XXX hack to preserve relative order of entries in rvRowType to preserve subtype relationships
-        val child2 = rebuild(child, memo)
-        val newRow2 = rebuild(newRow, child2.typ, memo)
-        if (newRow2.typ.asInstanceOf[TStruct].contains(MatrixType.entriesIdentifier))
-          MatrixMapRows(child2, newRow2)
-        else {
-          null // TODO make this thing work
-        }
+        var child2 = rebuild(child, memo)
+        MatrixMapRows(child2, rebuild(newRow, child2.typ, memo))
       case MatrixMapCols(child, newCol, newKey) =>
         // FIXME account for key
         val child2 = rebuild(child, memo)
@@ -942,6 +936,7 @@ object PruneDeadFields {
         case childT: TableIR => rebuild(childT, memo)
         case childM: MatrixIR => rebuild(childM, memo)
       })
+
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -880,8 +880,14 @@ object PruneDeadFields {
         val child2 = rebuild(child, memo)
         MatrixMapEntries(child2, rebuild(newEntries, child2.typ, memo))
       case MatrixMapRows(child, newRow) =>
-        var child2 = rebuild(child, memo)
-        MatrixMapRows(child2, rebuild(newRow, child2.typ, memo))
+        // XXX hack to preserve relative order of entries in rvRowType to preserve subtype relationships
+        val child2 = rebuild(child, memo)
+        val newRow2 = rebuild(newRow, child2.typ, memo)
+        if (newRow2.typ.asInstanceOf[TStruct].contains(MatrixType.entriesIdentifier))
+          MatrixMapRows(child2, newRow2)
+        else {
+          null // TODO make this thing work
+        }
       case MatrixMapCols(child, newCol, newKey) =>
         // FIXME account for key
         val child2 = rebuild(child, memo)
@@ -936,7 +942,6 @@ object PruneDeadFields {
         case childT: TableIR => rebuild(childT, memo)
         case childM: MatrixIR => rebuild(childM, memo)
       })
-
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1053,6 +1053,10 @@ object PruneDeadFields {
     if (ir.typ == rType)
       ir
     else {
+      // FIXME: Remove this assertion before this code is merged
+      assert(isSupertype(rType, ir.typ), s"""Error, supertype relation not satisfied in upcast.
+        |Supertype: ${ rType.toPrettyString(0, false) }
+        |Subtype  : ${ ir.typ.toPrettyString(0, false) }""".stripMargin)
       ir.typ match {
         case ts: TStruct =>
           val rs = rType.asInstanceOf[TStruct]

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -46,7 +46,7 @@ object PruneDeadFields {
             t1.size == t2.size &&
             t1.types.zip(t2.types)
               .forall { case (elt1, elt2) => isSupertype(elt1, elt2) }
-        case (t1: Type, t2: Type) => t1 == t2 || t1.setRequired(true) == t2
+        case (t1: Type, t2: Type) => t1 == t2 || t2.required && t2.isOfType(t1)
         case _ => fatal(s"invalid comparison: $superType / $subType")
       }
     } catch {
@@ -1055,8 +1055,8 @@ object PruneDeadFields {
     else {
       // FIXME: Remove this assertion before this code is merged
       assert(isSupertype(rType, ir.typ), s"""Error, supertype relation not satisfied in upcast.
-        |Supertype: ${ rType.toPrettyString(0, false) }
-        |Subtype  : ${ ir.typ.toPrettyString(0, false) }""".stripMargin)
+        |Supertype: ${ rType.parsableString() }
+        |Subtype  : ${ ir.typ.parsableString() }""".stripMargin)
       ir.typ match {
         case ts: TStruct =>
           val rs = rType.asInstanceOf[TStruct]

--- a/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
+++ b/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
@@ -16,7 +16,7 @@ object BitPackedVectorView {
   val bpvElementSize = PInt64Required.byteSize
 
   def rvRowType(locusType: Type, allelesType: Type): PStruct = TStruct("locus" -> locusType, "alleles" -> allelesType,
-    "bpv" -> TArray(TInt64Required), "nSamples" -> TInt32Required, "mean" -> TFloat64Required, "centered_length_rec" -> TFloat64Required).physicalType
+    "bpv" -> TArray(TInt64Required), "nSamples" -> TInt32Required, "mean" -> TFloat64(), "centered_length_rec" -> TFloat64()).physicalType
 }
 
 class BitPackedVectorView(rvRowType: PStruct) {
@@ -320,7 +320,7 @@ object LocalLDPrune {
     val rvdLP = pruneLocal(standardizedRDD, r2Threshold, windowSize, Some(maxQueueSize))
 
     val tableType = TableType(
-      rowType = mt.rowKeyStruct ++ TStruct("mean" -> TFloat64Required, "centered_length_rec" -> TFloat64Required),
+      rowType = mt.rowKeyStruct ++ TStruct("mean" -> TFloat64(), "centered_length_rec" -> TFloat64()),
       key = mt.rowKey, globalType = TStruct.empty())
 
     val fieldIndicesToAdd = Array("locus", "alleles", "mean", "centered_length_rec")


### PR DESCRIPTION
I noticed that the `testIfWithDifferentRequiredness` and `testMakeArrayWithDifferentRequiredness` were failing after I added the assertion in `upcast` for #4585 

After discussing with @tpoterba , it seemed like it would be okay to allow a required type to be a subtype of an optional type. This PR also includes the assertion, which may cause other tests to fail, and so I have marked it as a WIP.