### PR TITLE
added C++ codegen support for orderings

### DIFF
--- a/hail/src/main/resources/include/hail/Ordering.h
+++ b/hail/src/main/resources/include/hail/Ordering.h
@@ -1,7 +1,7 @@
 #ifndef HAIL_ORDERING_H
 #define HAIL_ORDERING_H 1
 
-#include <math.h>
+#include <cmath>
 
 namespace hail {
 

--- a/hail/src/main/resources/include/hail/Ordering.h
+++ b/hail/src/main/resources/include/hail/Ordering.h
@@ -1,0 +1,372 @@
+#ifndef HAIL_ORDERING_H
+#define HAIL_ORDERING_H 1
+
+#include <math.h>
+
+namespace hail {
+
+class IntOrd {
+public:
+    using T = int;
+
+    static bool lt(int l, int r) { return l < r; }
+
+    static bool lteq(int l, int r) { return l <= r; }
+
+    static bool gt(int l, int r) { return l > r; }
+
+    static bool gteq(int l, int r) { return l >= r; }
+
+    static bool eq(int l, int r) { return l == r; }
+
+    static bool neq(int l, int r) { return l != r; }
+
+    static int compare(int l, int r) {
+	return l < r ? -1 : (l > r ? 1 : 0);
+    }
+};
+
+class LongOrd {
+public:
+    using T = long;
+
+    static bool lt(long l, long r) { return l < r; }
+
+    static bool lteq(long l, long r) { return l <= r; }
+
+    static bool gt(long l, long r) { return l > r; }
+
+    static bool gteq(long l, long r) { return l >= r; }
+
+    static bool eq(long l, long r) { return l == r; }
+
+    static bool neq(long l, long r) { return l != r; }
+    
+    static int compare(long l, long r) {
+	return l < r ? -1 : (l > r ? 1 : 0);
+    }
+};
+
+static inline int float_to_int_bits(float f) {
+    return std::isnan(f) ? 0x7fc00000 : *reinterpret_cast<int *>(&f);
+}
+
+static inline long double_to_long_bits(double d) {
+    return std::isnan(d) ? 0x7ff8000000000000l : *reinterpret_cast<long *>(&d);
+}
+
+class FloatOrd {
+public:
+    using T = float;
+
+    static bool lt(float l, float r) { return l < r; }
+
+    static bool lteq(float l, float r) { return l <= r; }
+
+    static bool gt(float l, float r) { return l > r; }
+
+    static bool gteq(float l, float r) { return l >= r; }
+
+    static bool eq(float l, float r) { return l == r; }
+
+    static bool neq(float l, float r) { return l != r; }
+
+    static int compare(float l, float r) {
+	if (l < r)
+	    return -1;
+	if (l > r)
+	    return 1;
+        
+	return IntOrd::compare(float_to_int_bits(l), float_to_int_bits(r));
+    }
+};
+
+class DoubleOrd {
+public:
+    using T = double;
+
+    static bool lt(double l, double r) { return l < r; }
+
+    static bool lteq(double l, double r) { return l <= r; }
+
+    static bool gt(double l, double r) { return l > r; }
+
+    static bool gteq(double l, double r) { return l >= r; }
+
+    static bool eq(double l, double r) { return l == r; }
+
+    static bool neq(double l, double r) { return l != r; }
+
+    static int compare(double l, double r) {
+	if (l < r)
+	    return -1;
+	if (l > r)
+	    return 1;
+	
+	return LongOrd::compare(double_to_long_bits(l), double_to_long_bits(r));
+    }
+};
+
+class BoolOrd {
+public:
+    using T = bool;
+
+    static bool lt(bool l, bool r) { return l < r; }
+
+    static bool lteq(bool l, bool r) { return l <= r; }
+
+    static bool gt(bool l, bool r) { return l > r; }
+
+    static bool gteq(bool l, bool r) { return l >= r; }
+
+    static bool eq(bool l, bool r) { return l == r; }
+
+    static bool neq(bool l, bool r) { return l != r; }
+
+    static int compare(bool l, bool r) {
+	return l < r ? -1 : (l > r ? 1 : 0);
+    }
+};
+
+template<typename Comp> class CompareOrd {
+public:
+    using T = typename Comp::T;
+    
+    static bool lt(T l, T r) { return Comp::compare(l, r) < 0; }
+
+    static bool lteq(T l, T r) { return Comp::compare(l, r) <= 0; }
+
+    static bool gt(T l, T r) { return Comp::compare(l, r) > 0; }
+
+    static bool gteq(T l, T r) { return Comp::compare(l, r) >= 0; }
+
+    static bool eq(T l, T r) { return Comp::compare(l, r) == 0; }
+
+    static bool neq(T l, T r) { return Comp::compare(l, r) != 0; }
+
+    static int compare(T l, T r) { return Comp::compare(l, r); }
+};
+
+class BinaryCompare {
+public:
+    using T = const char *;
+    
+    static int compare(const char *l, const char *r) {
+	int llen = *(const int *)l;
+	int rlen = *(const int *)r;
+	
+	int c = memcmp(l + 4, r + 4, llen < rlen ? llen : rlen);
+	if (c != 0)
+	    return c;
+	
+	if (llen < rlen)
+	    return -1;
+	else if (llen > rlen)
+	    return 1;
+	else
+	    return 0;
+    }
+};
+
+using BinaryOrd = CompareOrd<BinaryCompare>;
+
+template<typename Ord> class ExtOrd {
+public:
+    using T = typename Ord::T;
+
+    static bool lt(bool lm, T l, bool rm, T r) {
+	if (lm)
+	    return false;
+	else if (rm)
+	    return true;
+	else
+	  return Ord::lt(l, r);
+    }
+    
+    static bool lteq(bool lm, T l, bool rm, T r) {
+	if (lm) {
+	    if (rm)
+		return true;
+	    else
+		return false;
+	} else if (rm)
+	    return true;
+	else
+	  return Ord::lteq(l, r);
+    }
+
+  // FIXME
+    static bool gt(bool lm, T l, bool rm, T r) { return lt(rm, r, lm, l); }
+    
+    static bool gteq(bool lm, T l, bool rm, T r) { return lteq(rm, r, lm, l); }
+    
+    static bool eq(bool lm, T l, bool rm, T r) {
+	if (lm)
+	    return rm;
+	else
+	    return !rm && Ord::eq(l, r);
+    }
+
+    static bool neq(bool lm, T l, bool rm, T r) { return !eq(lm, l, rm, r); }
+    
+    static int compare(bool lm, T l, bool rm, T r) {
+	if (lm) {
+	    if (rm)
+		return 0;
+	    else
+		return 1;
+	} else {
+	    if (rm)
+		return 1;
+	    else
+		return Ord::compare(l, r);
+	}
+    }
+};
+
+template<typename AL, typename AR, typename ElemOrd>
+class ArrayOrd {
+ public:
+    using T = const char *;
+
+    static bool lt(const char *l, const char *r) {
+	int ln = AL::load_length(l);
+	int rn = AR::load_length(r);
+	int n = ln < rn ? ln : rn;
+	for (int i = 0; i < n; ++i) {
+	    bool lm = AL::is_element_missing(l, i);
+	    typename ElemOrd::T lx;
+	    if (!lm)
+		lx = AL::load_element(l, i);
+	    bool rm = AR::is_element_missing(r, i);
+	    typename ElemOrd::T rx;
+	    if (!rm)
+		rx = AR::load_element(r, i);
+	    
+	    if (ElemOrd::lt(lm, lx, rm, rx))
+		return true;
+	    if (!ElemOrd::eq(lm, lx, rm, rx))
+		return false;
+	}
+	
+	return ln < rn;
+    }
+
+    static bool lteq(const char *l, const char *r) {
+	int ln = AL::load_length(l);
+	int rn = AR::load_length(r);
+	int n = ln < rn ? ln : rn;
+	for (int i = 0; i < n; ++i) {
+	    bool lm = AL::is_element_missing(l, i);
+	    typename ElemOrd::T lx;
+	    if (!lm)
+		lx = AL::load_element(l, i);
+	    bool rm = AR::is_element_missing(r, i);
+	    typename ElemOrd::T rx;
+	    if (!rm)
+		rx = AR::load_element(r, i);
+	    
+	    if (ElemOrd::lt(lm, lx, rm, rx))
+		return true;
+	    if (!ElemOrd::eq(lm, lx, rm, rx))
+		return false;
+	}
+	
+	return ln <= rn;
+    }
+
+    static bool gt(const char *l, const char *r) {
+	int ln = AL::load_length(l);
+	int rn = AR::load_length(r);
+	int n = ln < rn ? ln : rn;
+	for (int i = 0; i < n; ++i) {
+	    bool lm = AL::is_element_missing(l, i);
+	    typename ElemOrd::T lx;
+	    if (!lm)
+		lx = AL::load_element(l, i);
+	    bool rm = AR::is_element_missing(r, i);
+	    typename ElemOrd::T rx;
+	    if (!rm)
+		rx = AR::load_element(r, i);
+	    
+	    if (ElemOrd::gt(lm, lx, rm, rx))
+		return true;
+	    if (!ElemOrd::eq(lm, lx, rm, rx))
+		return false;
+	}
+	
+	return ln > rn;
+    }
+
+    static bool gteq(const char *l, const char *r) {
+	int ln = AL::load_length(l);
+	int rn = AR::load_length(r);
+	int n = ln < rn ? ln : rn;
+	for (int i = 0; i < n; ++i) {
+	    bool lm = AL::is_element_missing(l, i);
+	    typename ElemOrd::T lx;
+	    if (!lm)
+		lx = AL::load_element(l, i);
+	    bool rm = AR::is_element_missing(r, i);
+	    typename ElemOrd::T rx;
+	    if (!rm)
+		rx = AR::load_element(r, i);
+	    
+	    if (ElemOrd::gt(lm, lx, rm, rx))
+		return true;
+	    if (!ElemOrd::eq(lm, lx, rm, rx))
+		return false;
+	}
+	
+	return ln >= rn;
+    }
+
+    static bool eq(const char *l, const char *r) {
+	int ln = AL::load_length(l);
+	int rn = AR::load_length(r);
+	int n = ln < rn ? ln : rn;
+	for (int i = 0; i < n; ++i) {
+	    bool lm = AL::is_element_missing(l, i);
+	    typename ElemOrd::T lx;
+	    if (!lm)
+		lx = AL::load_element(l, i);
+	    bool rm = AR::is_element_missing(r, i);
+	    typename ElemOrd::T rx;
+	    if (!rm)
+		rx = AR::load_element(r, i);
+	    
+	    if (!ElemOrd::eq(lm, lx, rm, rx))
+		return false;
+	}
+	
+	return ln == rn;
+    }
+    
+    static bool neq(const char *l, const char *r) { return !eq(l, r); }
+    
+    static int compare(const char *l, const char *r) {
+	int ln = AL::load_length(l);
+	int rn = AR::load_length(r);
+	int n = ln < rn ? ln : rn;
+	for (int i = 0; i < n; ++i) {
+	    bool lm = AL::is_element_missing(l, i);
+	    typename ElemOrd::T lx;
+	    if (!lm)
+		lx = AL::load_element(l, i);
+	    bool rm = AR::is_element_missing(r, i);
+	    typename ElemOrd::T rx;
+	    if (!rm)
+		rx = AR::load_element(r, i);
+	    
+	    int c = ElemOrd::compare(lm, lx, rm, rx);
+	    if (!c)
+	      return c;
+	}
+	
+	return IntOrd::compare(ln, rn);
+    }
+};
+
+}
+
+#endif

--- a/hail/src/main/scala/is/hail/cxx/Compile.scala
+++ b/hail/src/main/scala/is/hail/cxx/Compile.scala
@@ -24,6 +24,7 @@ object Compile {
     tub.include("hail/hail.h")
     tub.include("hail/Utils.h")
     tub.include("hail/Region.h")
+    tub.include("hail/Ordering.h")
 
     tub.include("<limits.h>")
     tub.include("<math.h>")

--- a/hail/src/main/scala/is/hail/cxx/Definition.scala
+++ b/hail/src/main/scala/is/hail/cxx/Definition.scala
@@ -9,19 +9,17 @@ trait Definition {
 }
 
 object Variable {
-  def apply(prefix: String, typ: Type): Variable =
-    new Variable(prefix, typ, null)
+  def apply(name: String, typ: Type): Variable =
+    new Variable(name, typ, null)
 
-  def apply(prefix: String, typ: Type, init: Code): Variable =
-    new Variable(prefix, typ, Expression(init))
+  def apply(name: String, typ: Type, init: Code): Variable =
+    new Variable(name, typ, Expression(init))
 
   def make_shared(prefix: String, typ: Type, constructorArgs: Code*): Variable =
     Variable(prefix, s"std::shared_ptr<$typ>", s"std::make_shared<$typ>(${ constructorArgs.mkString(", ") })")
 }
 
-class Variable(prefix: String, val typ: String, init: Expression) extends Definition {
-  val name: String = genSym(prefix)
-
+class Variable(val name: String, val typ: String, init: Expression) extends Definition {
   override def toString: String = name
 
   def ref: Expression = Expression(name)
@@ -54,17 +52,11 @@ class Function(returnType: Type, val name: String, args: Array[Variable], body: 
 }
 
 class FunctionBuilder(val parent: ScopeBuilder, prefix: String, args: Array[Variable], returnType: Type)
-  extends DefinitionBuilder[Function] {
-
-  val statements: ArrayBuilder[Code] = new ArrayBuilder[Code]()
-
-  def +=(statement: Code) {
-    statements += statement
-  }
+  extends ScopeBuilder with DefinitionBuilder[Function] {
 
   def getArg(i: Int): Variable = args(i)
 
-  def build(): Function = new Function(returnType, prefix, args, statements.result().mkString("\n"))
+  def build(): Function = new Function(returnType, prefix, args, definitions.result().mkString("\n"))
 
   def defaultReturn: Code = {
     if (returnType == "long")

--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -6,6 +6,8 @@ import is.hail.expr.types.physical._
 import is.hail.expr.types.virtual._
 import is.hail.utils.{ArrayBuilder, StringEscapeUtils}
 
+import scala.collection.mutable
+
 object Emit {
   def apply(fb: FunctionBuilder, nSpecialArgs: Int, x: ir.IR): EmitTriplet = {
     val emitter = new Emitter(fb, nSpecialArgs)
@@ -17,6 +19,160 @@ class CXXUnsupportedOperation(msg: String = null) extends Exception(msg)
 
 abstract class ArrayEmitter(val setup: Code, val m: Code, val setupLen: Code, val length: Option[Code]) {
   def emit(f: (Code, Code) => Code): Code
+}
+
+class Orderings {
+  val orderings = new ArrayBuilder[Code]
+  val typeOrdering = mutable.Map.empty[(PType, PType), String]
+
+  private def makeOrdering(tub: TranslationUnitBuilder, lp: PType, rp: PType): String = {
+    lp.virtualType match {
+      case TFloat32(_) => "FloatOrd"
+      case TFloat64(_) => "DoubleOrd"
+      case TInt32(_) => "IntOrd"
+      case TInt64(_) => "LongOrd"
+      case TBoolean(_) => "BoolOrd"
+
+      case TString(_) | TBinary(_) => "BinaryOrd"
+
+      case t: TContainer =>
+        val lContainerP = lp.asInstanceOf[PContainer]
+        val rContainerP = rp.asInstanceOf[PContainer]
+
+        val lElemP = lContainerP.elementType
+        val rElemP = rContainerP.elementType
+
+        val elemOrd = ordering(tub, lContainerP.elementType, rContainerP.elementType)
+        val eElemOrd = s"ExtOrd<$elemOrd>"
+
+        s"ArrayOrd<${ lContainerP.cxxImpl },${ rContainerP.cxxImpl },ExtOrd<$elemOrd>>"
+
+      case t: TBaseStruct =>
+        val ord = tub.genSym("Ord")
+
+        val lBaseStructP = lp.asInstanceOf[PBaseStruct]
+        val rBaseStructP = rp.asInstanceOf[PBaseStruct]
+
+        def comparisonTemplate(
+          op: String,
+          rType: String,
+          fieldTest: (TranslationUnitBuilder, String, Code, Code, Code, Code) => Code,
+          finalValue: Code): Code = {
+          s"""
+             |static $rType $op(const char *l, const char *r) {
+             |  ${
+            t.fields.zipWithIndex.map { case (f, i) =>
+              val fOrd = ordering(tub, lBaseStructP.fields(i).typ, rBaseStructP.fields(i).typ)
+
+              val lm = tub.variable("lm", "bool", lBaseStructP.cxxIsFieldMissing("l", i))
+              val lv = tub.variable("lv", typeToCXXType(lBaseStructP.fields(i).typ))
+
+              val rm = tub.variable("rm", "bool", rBaseStructP.cxxIsFieldMissing("r", i))
+              val rv = tub.variable("lv", typeToCXXType(rBaseStructP.fields(i).typ))
+
+              s"""
+                 |${lm.define}
+                 |${lv.define}
+                 |if (!$lm)
+                 |  $lv = ${lBaseStructP.cxxLoadField("l", i)};
+                 |${rm.define}
+                 |${rv.define}
+                 |if (!$rm)
+                 |  $rv = ${rBaseStructP.cxxLoadField("r", i)};
+                 |${ fieldTest(tub, s"ExtOrd<$fOrd>", lm.toString, lv.toString, rm.toString, rv.toString) }
+               """.stripMargin
+            }.mkString
+          }
+             |  return $finalValue;
+             |}
+           """.stripMargin
+        }
+
+        orderings +=
+          s"""
+             |class $ord {
+             |public:
+             |  using T = const char *;
+             |  ${
+            comparisonTemplate("compare", "int",
+              { (tub, efOrd, lm, lv, rm, rv) =>
+                val c = tub.genSym("c")
+                s"""
+                   |int $c = $efOrd::compare($lm, $lv, $rm, $rv);
+                   |if ($c != 0) return $c;
+               """.stripMargin
+              },
+              "0")
+          }
+             |  ${
+            comparisonTemplate("lt", "bool",
+              { (tub, efOrd, lm, lv, rm, rv) =>
+                s"""
+                   |if ($efOrd::lt($lm, $lv, $rm, $rv)) return true;
+                   |if (!$efOrd::eq($lm, $lv, $rm, $rv)) return false;
+               """.stripMargin
+              },
+              "false")
+          }
+             |  ${
+            comparisonTemplate("lteq", "bool",
+              { (tub, efOrd, lm, lv, rm, rv) =>
+                s"""
+                   |if ($efOrd::lt($lm, $lv, $rm, $rv)) return true;
+                   |if (!$efOrd::eq($lm, $lv, $rm, $rv)) return false;
+               """.stripMargin
+              },
+              "true")
+          }
+             |  ${
+            comparisonTemplate("gt", "bool",
+              { (tub, efOrd, lm, lv, rm, rv) =>
+                s"""
+                   |if ($efOrd::gt($lm, $lv, $rm, $rv)) return true;
+                   |if (!$efOrd::eq($lm, $lv, $rm, $rv)) return false;
+               """.stripMargin
+              },
+              "false")
+          }
+             |  ${
+            comparisonTemplate("gteq", "bool",
+              { (tub, efOrd, lm, lv, rm, rv) =>
+                s"""
+                   |if ($efOrd::gt($lm, $lv, $rm, $rv)) return true;
+                   |if (!$efOrd::eq($lm, $lv, $rm, $rv)) return false;
+               """.stripMargin
+              },
+              "true")
+          }
+             |  ${
+            comparisonTemplate("eq", "bool",
+              { (tub, efOrd, lm, lv, rm, rv) =>
+                s"""
+                   |if (!$efOrd::eq($lm, $lv, $rm, $rv)) return false;
+               """.stripMargin
+              },
+              "true")
+          }
+             |  static bool neq(const char *l, const char *r) { return !eq(l, r); }
+             |};
+           """.stripMargin
+
+        ord
+
+      case _: TInterval =>
+        throw new CXXUnsupportedOperation()
+    }
+  }
+
+  def ordering(tub: TranslationUnitBuilder, lp: PType, rp: PType): String = {
+    typeOrdering.get((lp, rp)) match {
+      case Some(o) => o
+      case None =>
+        val o = makeOrdering(tub, lp, rp)
+        typeOrdering += (lp, rp) -> o
+        o
+    }
+  }
 }
 
 class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) { outer =>
@@ -62,8 +218,8 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) { outer =>
         assert(pType == cnsq.pType)
         assert(pType == altr.pType)
 
-        val m = Variable("m", "bool")
-        val v = Variable("v", typeToCXXType(pType))
+        val m = fb.variable("m", "bool")
+        val v = fb.variable("v", typeToCXXType(pType))
         val tcond = emit(cond)
         val tcnsq = emit(cnsq)
         val taltr = emit(altr)
@@ -92,8 +248,8 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) { outer =>
 
       case ir.Let(name, value, body) =>
         val tvalue = emit(value)
-        val m = Variable("m", "bool", tvalue.m)
-        val v = Variable("v", typeToCXXType(value.pType))
+        val m = fb.variable("m", "bool", tvalue.m)
+        val v = fb.variable("v", typeToCXXType(value.pType))
         val tbody = emit(body, env.bind(name, EmitTriplet(value.pType, "", m.toString, v.toString)))
 
         triplet(
@@ -143,16 +299,61 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) { outer =>
 
         triplet(t.setup, t.m, v)
 
+      case ir.ApplyComparisonOp(op, l, r) =>
+        val lt = emit(l)
+        val rt = emit(r)
+
+        val o = fb.parent.ordering(l.pType, r.pType)
+
+        val opf = op match {
+          case ir.GT(_, _) => "gt"
+          case ir.GTEQ(_, _) => "gteq"
+          case ir.LT(_, _) => "lt"
+          case ir.LTEQ(_, _) => "lteq"
+          case ir.EQ(_, _) => "eq"
+          case ir.NEQ(_, _) => "neq"
+          case ir.EQWithNA(_, _) => "eq"
+          case ir.NEQWithNA(_, _) => "neq"
+        }
+
+        if (op.strict) {
+          triplet(Code(lt.setup, rt.setup),
+            s"${ lt.m } || ${ rt.m }",
+            s"$o::$opf(${ lt.v }, ${ rt.v })")
+        } else {
+          val lm = fb.variable("lm", "bool", lt.m)
+          val lv = fb.variable("lv", typeToCXXType(l.pType))
+
+          val rm = fb.variable("rm", "bool", rt.m)
+          val rv = fb.variable("rv", typeToCXXType(r.pType))
+
+          triplet(Code(lt.setup, rt.setup),
+            "false",
+            s"""
+               |({
+               |  ${ lm.define }
+               |  ${ lv.define }
+               |  if (!$lm)
+               |    $lv = ${ lt.v };
+               |  ${ rm.define }
+               |  ${ rv.define }
+               |  if (!$rm)
+               |    $rv = ${ rt.v };
+               |  ExtOrd<$o>::$opf($lm, $lv, $rm, $rv);
+               |})
+             """.stripMargin)
+        }
+
       case ir.ArrayRef(a, i) =>
         val pContainer = a.pType.asInstanceOf[PContainer]
         val at = emit(a)
         val it = emit(i)
 
-        val av = Variable("a", "const char *", at.v)
-        val iv = Variable("i", "int", it.v)
-        val len = Variable("len", "int", pContainer.cxxLoadLength(av.toString))
+        val av = fb.variable("a", "const char *", at.v)
+        val iv = fb.variable("i", "int", it.v)
+        val len = fb.variable("len", "int", pContainer.cxxLoadLength(av.toString))
 
-        val m = Variable("m", "bool")
+        val m = fb.variable("m", "bool")
 
         var s = ir.Pretty(x)
         if (s.length > 100)
@@ -185,14 +386,14 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) { outer =>
       case ir.GetField(o, name) =>
         val fieldIdx = o.typ.asInstanceOf[TStruct].fieldIdx(name)
         val pStruct = o.pType.asInstanceOf[PStruct]
-        val ot = emit(o).memoize()
+        val ot = emit(o).memoize(fb)
         triplet(Code(ot.setup),
           s"${ ot.m } || (${ pStruct.cxxIsFieldMissing(ot.v, fieldIdx) })",
           pStruct.cxxLoadField(ot.v, fieldIdx))
 
       case ir.GetTupleElement(o, idx) =>
         val pStruct = o.pType.asInstanceOf[PTuple]
-        val ot = emit(o).memoize()
+        val ot = emit(o).memoize(fb)
         triplet(Code(ot.setup),
           s"${ ot.m } || (${ pStruct.cxxIsFieldMissing(ot.v, idx) })",
           pStruct.cxxLoadField(ot.v, idx))
@@ -215,7 +416,7 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) { outer =>
         val pStruct = pType.asInstanceOf[PStruct]
         val oldPStruct = old.pType.asInstanceOf[PStruct]
         val oldt = emit(old)
-        val ov = Variable("old", typeToCXXType(oldPStruct), oldt.v)
+        val ov = fb.variable("old", typeToCXXType(oldPStruct), oldt.v)
 
         val sb = new StagedBaseStructTripletBuilder(fb, pStruct)
         fields.foreach { f =>
@@ -238,7 +439,7 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) { outer =>
         val pStruct = pType.asInstanceOf[PStruct]
         val oldPStruct = old.pType.asInstanceOf[PStruct]
         val oldt = emit(old)
-        val ov = Variable("old", typeToCXXType(oldPStruct), oldt.v)
+        val ov = fb.variable("old", typeToCXXType(oldPStruct), oldt.v)
 
         val fieldsMap = fields.toMap
 
@@ -272,12 +473,12 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) { outer =>
       case ir.ArrayFold(a, zero, accumName, valueName, body) =>
         val containerPType = a.pType.asInstanceOf[PContainer]
         val ae = emitArray(a, env)
-        val am = Variable("am", "bool", ae.m)
+        val am = fb.variable("am", "bool", ae.m)
 
         val zerot = emit(zero)
 
-        val accm = Variable("accm", "bool")
-        val accv = Variable("accv", typeToCXXType(zero.pType))
+        val accm = fb.variable("accm", "bool")
+        val accv = fb.variable("accv", typeToCXXType(zero.pType))
         val acct = EmitTriplet(zero.pType, "", accm.toString, accv.toString)
 
         triplet(
@@ -296,15 +497,15 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) { outer =>
              |  ${ ae.setupLen }
              |  ${
             ae.emit { case (m, v) =>
-              val vm = Variable("vm", "bool")
-              val vv = Variable("vv", typeToCXXType(containerPType.elementType))
+              val vm = fb.variable("vm", "bool")
+              val vv = fb.variable("vv", typeToCXXType(containerPType.elementType))
               val vt = EmitTriplet(containerPType.elementType, "", vm.toString, vv.toString)
 
               val bodyt = emit(body, env.bind(accumName -> acct, valueName -> vt))
 
               // necessary because bodyt.v could be accm
-              val bodym = Variable("bodym", "bool", bodyt.m)
-              val bodyv = Variable("bodyv", typeToCXXType(body.pType))
+              val bodym = fb.variable("bodym", "bool", bodyt.m)
+              val bodyv = fb.variable("bodyv", typeToCXXType(body.pType))
 
               s"""
                  |${ vm.define }
@@ -355,9 +556,9 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) { outer =>
                  |""".stripMargin)
 
           case None =>
-            val xs = genSym("xs")
-            val ms = genSym("ms")
-            val i = genSym("i")
+            val xs = fb.genSym("xs")
+            val ms = fb.genSym("ms")
+            val i = fb.genSym("i")
             val sab = new StagedContainerBuilder(fb, fb.getArg(1).toString, containerPType)
             triplet(ae.setup, ae.m,
               s"""
@@ -413,6 +614,7 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) { outer =>
 
       case x@ir.ApplyIR(_, _, _) =>
         // FIXME small only
+        println("explicitNode", ir.Pretty(x.explicitNode))
         emit(x.explicitNode)
 
       case ir.In(i, _) =>
@@ -425,6 +627,8 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) { outer =>
   }
 
   def emitArray(x: ir.IR, env: E): ArrayEmitter = {
+    def emit(x: ir.IR, env: E = env): EmitTriplet = this.emit(x, env)
+
     val elemType = x.pType.asInstanceOf[PContainer].elementType
 
     x match {
@@ -433,12 +637,12 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) { outer =>
         val stopt = emit(stop, env)
         val stept = emit(step, env)
 
-        val startv = Variable("start", "int", startt.v)
-        val stopv = Variable("stop", "int", stopt.v)
-        val stepv = Variable("step", "int", stept.v)
+        val startv = fb.variable("start", "int", startt.v)
+        val stopv = fb.variable("stop", "int", stopt.v)
+        val stepv = fb.variable("step", "int", stept.v)
 
-        val len = Variable("len", "int")
-        val llen = Variable("llen", "long")
+        val len = fb.variable("len", "int")
+        val llen = fb.variable("llen", "long")
 
         var s = ir.Pretty(x)
         if (s.length > 100)
@@ -471,8 +675,8 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) { outer =>
              |} else
              |  $len = ($llen < 0) ? 0 : (int)$llen;
              |""".stripMargin, Some(len.toString)) {
-          val i = Variable("i", "int", "0")
-          val v = Variable("v", "int", startv.toString)
+          val i = fb.variable("i", "int", "0")
+          val v = fb.variable("v", "int", startv.toString)
 
           def emit(f: (Code, Code) => Code): Code = {
             s"""
@@ -500,8 +704,8 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) { outer =>
 
       case ir.ArrayFilter(a, name, cond) =>
         val ae = emitArray(a, env)
-        val vm = Variable("m", "bool")
-        val vv = Variable("v", typeToCXXType(elemType))
+        val vm = fb.variable("m", "bool")
+        val vv = fb.variable("v", typeToCXXType(elemType))
         val condt = outer.emit(cond,
           env.bind(name, EmitTriplet(elemType, "", vm.toString, vv.toString)))
 
@@ -529,8 +733,8 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) { outer =>
         val aElementPType = a.pType.asInstanceOf[PContainer].elementType
         val ae = emitArray(a, env)
 
-        val vm = Variable("m", "bool")
-        val vv = Variable("v", typeToCXXType(aElementPType))
+        val vm = fb.variable("m", "bool")
+        val vv = fb.variable("v", typeToCXXType(aElementPType))
         val bodyt = outer.emit(body,
           env.bind(name, EmitTriplet(aElementPType, "", vm.toString, vv.toString)))
 
@@ -556,14 +760,14 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) { outer =>
         val pArray = x.pType.asInstanceOf[PArray]
         val t = emit(x, env)
 
-        val a = Variable("a", "const char *", t.v)
-        val len = Variable("len", "int", pArray.cxxLoadLength(a.toString))
+        val a = fb.variable("a", "const char *", t.v)
+        val len = fb.variable("len", "int", pArray.cxxLoadLength(a.toString))
         new ArrayEmitter(t.setup, t.m,
           s"""
              |${ a.define }
              |${ len.define }
              |""".stripMargin, Some(len.toString)) {
-          val i = Variable("i", "int", "0")
+          val i = fb.variable("i", "int", "0")
 
           def emit(f: (Code, Code) => Code): Code = {
             s"""

--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -556,16 +556,16 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) { outer =>
                  |""".stripMargin)
 
           case None =>
-            val xs = fb.genSym("xs")
-            val ms = fb.genSym("ms")
-            val i = fb.genSym("i")
+            val xs = fb.variable("xs", s"std::vector<${ typeToCXXType(containerPType.elementType) }>")
+            val ms = fb.variable("ms", "std::vector<bool>")
+            val i = fb.variable("i", "int")
             val sab = new StagedContainerBuilder(fb, fb.getArg(1).toString, containerPType)
             triplet(ae.setup, ae.m,
               s"""
                  |({
                  |  ${ ae.setupLen }
-                 |  std::vector<${ typeToCXXType(containerPType.elementType) }> $xs;
-                 |  std::vector<bool> $ms;
+                 |  ${ xs.define }
+                 |  ${ ms.define }
                  |  ${
                 ae.emit { case (m, v) =>
                   s"""
@@ -580,7 +580,8 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) { outer =>
                 }
               }
                  |  ${ sab.start(s"$xs.size()") }
-                 |  for (int $i = 0; $i < $xs.size(); ++$i) {
+                 |  ${ i.define }
+                 |  for ($i = 0; $i < $xs.size(); ++$i) {
                  |    if ($ms[$i])
                  |      ${ sab.setMissing() }
                  |   else
@@ -614,7 +615,6 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) { outer =>
 
       case x@ir.ApplyIR(_, _, _) =>
         // FIXME small only
-        println("explicitNode", ir.Pretty(x.explicitNode))
         emit(x.explicitNode)
 
       case ir.In(i, _) =>

--- a/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
+++ b/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
@@ -8,9 +8,9 @@ object EmitTriplet {
 }
 
 class EmitTriplet private(val pType: types.physical.PType, val setup: Code, val m: Code, val v: Code) {
-  def memoize(): EmitTriplet = {
-    val mv = Variable("memm", "bool", m)
-    val vv = Variable("memv", typeToCXXType(pType))
+  def memoize(fb: FunctionBuilder): EmitTriplet = {
+    val mv = fb.variable("memm", "bool", m)
+    val vv = fb.variable("memv", typeToCXXType(pType))
 
     EmitTriplet(pType,
       s"""

--- a/hail/src/main/scala/is/hail/cxx/PackEncoder.scala
+++ b/hail/src/main/scala/is/hail/cxx/PackEncoder.scala
@@ -5,24 +5,24 @@ import is.hail.io.{BufferSpec, NativeEncoderModule}
 
 object PackEncoder {
 
-  def encodeBinary(output_buf_ptr: Expression, off: Expression): Code = {
-    val len = Variable("len", "int", s"load_length($off)")
+  def encodeBinary(tub: TranslationUnitBuilder, output_buf_ptr: Expression, off: Expression): Code = {
+    val len = tub.variable("len", "int", s"load_length($off)")
     s"""
        |${ len.define }
        |$output_buf_ptr->write_int($len);
        |$output_buf_ptr->write_bytes($off + 4, $len);""".stripMargin
   }
 
-  def encodeArray(t: PArray, output_buf_ptr: Expression, off: Expression): Code = {
-    val len = Variable("len", "int", s"load_length($off)")
-    val i = Variable("i", "int", s"0")
+  def encodeArray(tub: TranslationUnitBuilder, t: PArray, output_buf_ptr: Expression, off: Expression): Code = {
+    val len = tub.variable("len", "int", s"load_length($off)")
+    val i = tub.variable("i", "int", s"0")
     val copyLengthAndMissing = if (t.elementType.required)
       s"$output_buf_ptr->write_int($len);"
     else
       s"""
          |$output_buf_ptr->write_int($len);
          |$output_buf_ptr->write_bytes($off + 4, n_missing_bytes($len));""".stripMargin
-    val eltOff = Variable("eoff",
+    val eltOff = tub.variable("eoff",
       "char *",
       s"round_up_alignment(${ if (!t.elementType.required) s"$off + 4 + n_missing_bytes($len)" else s"$off + 4" }, ${ t.elementType.alignment })")
     val elt = t.elementType match {
@@ -31,11 +31,11 @@ object PackEncoder {
     }
 
     val writeElt = if (t.elementType.required)
-      encode(t.elementType, output_buf_ptr, Expression(elt))
+      encode(tub,  t.elementType, output_buf_ptr, Expression(elt))
     else
       s"""
          |if (!load_bit($off + 4, $i)) {
-         |  ${ encode(t.elementType, output_buf_ptr, Expression(elt)) };
+         |  ${ encode(tub, t.elementType, output_buf_ptr, Expression(elt)) };
          |}""".stripMargin
 
     s"""
@@ -49,14 +49,14 @@ object PackEncoder {
       """.stripMargin
   }
 
-  def encodeBaseStruct(t: PBaseStruct, output_buf_ptr: Expression, off: Expression): Code = {
+  def encodeBaseStruct(tub: TranslationUnitBuilder, t: PBaseStruct, output_buf_ptr: Expression, off: Expression): Code = {
     val nMissingBytes = t.nMissingBytes
     val storeFields: Array[Code] = Array.tabulate[Code](t.size) { idx =>
       val store = t.types(idx) match {
         case t2@(_: PArray | _: PBinary) =>
-          encode(t2, output_buf_ptr, Expression(s"load_address($off + ${ t.byteOffsets(idx) })"))
+          encode(tub, t2, output_buf_ptr, Expression(s"load_address($off + ${ t.byteOffsets(idx) })"))
         case t2 =>
-          encode(t2, output_buf_ptr, Expression(s"$off + ${ t.byteOffsets(idx) }"))
+          encode(tub, t2, output_buf_ptr, Expression(s"$off + ${ t.byteOffsets(idx) }"))
 
       }
       if (t.fieldRequired(idx)) {
@@ -74,15 +74,15 @@ object PackEncoder {
       """.stripMargin
   }
 
-  def encode(t: PType, output_buf_ptr: Expression, off: Expression): Code = t match {
+  def encode(tub: TranslationUnitBuilder, t: PType, output_buf_ptr: Expression, off: Expression): Code = t match {
     case _: PBoolean => s"$output_buf_ptr->write_byte(*($off) ? 1 : 0);"
     case _: PInt32 => s"$output_buf_ptr->write_int(load_int($off));"
     case _: PInt64 => s"$output_buf_ptr->write_long(load_long($off));"
     case _: PFloat32 => s"$output_buf_ptr->write_float(load_float($off));"
     case _: PFloat64 => s"$output_buf_ptr->write_double(load_double($off));"
-    case _: PBinary => encodeBinary(output_buf_ptr, off)
-    case t2: PArray => encodeArray(t2, output_buf_ptr, off)
-    case t2: PBaseStruct => encodeBaseStruct(t2, output_buf_ptr, off)
+    case _: PBinary => encodeBinary(tub, output_buf_ptr, off)
+    case t2: PArray => encodeArray(tub, t2, output_buf_ptr, off)
+    case t2: PBaseStruct => encodeBaseStruct(tub, t2, output_buf_ptr, off)
   }
 
   def apply(t: PType, bufSpec: BufferSpec, tub: TranslationUnitBuilder): Class = {
@@ -97,13 +97,13 @@ object PackEncoder {
     val encBuilder = tub.buildClass("Encoder", "NativeObj")
 
     val bufType = bufSpec.nativeOutputBufferType
-    val buf = Variable("buf", s"std::shared_ptr<$bufType>")
+    val buf = encBuilder.variable("buf", s"std::shared_ptr<$bufType>")
     encBuilder += buf
 
     encBuilder += s"${ encBuilder.name }(std::shared_ptr<OutputStream> os) : $buf(std::make_shared<$bufType>(os)) { }"
 
     val rowFB = encBuilder.buildMethod("encode_row", Array("NativeStatus*" -> "st", "const char *" -> "row"), "void")
-    rowFB += encode(t.fundamentalType, buf.ref, rowFB.getArg(1).ref)
+    rowFB += encode(tub, t.fundamentalType, buf.ref, rowFB.getArg(1).ref)
     rowFB += "return;"
     rowFB.end()
 

--- a/hail/src/main/scala/is/hail/cxx/RegionValueIterator.scala
+++ b/hail/src/main/scala/is/hail/cxx/RegionValueIterator.scala
@@ -19,9 +19,9 @@ object CXXRegionValueIterator {
     val cls = itClass(tub)
     tub.include("hail/ObjectArray.h")
 
-    val st = Variable("st", "NativeStatus *")
-    val region = Variable("region", "long")
-    val ptr = Variable("it", "long")
+    val st = tub.variable("st", "NativeStatus *")
+    val region = tub.variable("region", "long")
+    val ptr = tub.variable("it", "long")
     tub += new Function("NativeObjPtr", "make_iterator", Array(st, ptr, region),
       s"return std::make_shared<$cls>(reinterpret_cast<ObjectArray*>($ptr)->at(0), reinterpret_cast<ScalaRegion*>($region), $st);")
 

--- a/hail/src/main/scala/is/hail/cxx/StagedBaseStructBuilder.scala
+++ b/hail/src/main/scala/is/hail/cxx/StagedBaseStructBuilder.scala
@@ -32,7 +32,7 @@ class StagedBaseStructBuilder(fb: FunctionBuilder, pStruct: PBaseStruct, off: Ex
 }
 
 class StagedBaseStructTripletBuilder(fb: FunctionBuilder, pStruct: PBaseStruct) {
-  private[this] val s = Variable("s", "char *", s"${ fb.getArg(1) }->allocate(${ pStruct.alignment }, ${ pStruct.byteSize })")
+  private[this] val s = fb.variable("s", "char *", s"${ fb.getArg(1) }->allocate(${ pStruct.alignment }, ${ pStruct.byteSize })")
   private[this] val ssb = new StagedBaseStructBuilder(fb, pStruct, s.ref)
   private[this] val ab = new ArrayBuilder[Code]
   ab += s.define

--- a/hail/src/main/scala/is/hail/cxx/StagedContainerBuilder.scala
+++ b/hail/src/main/scala/is/hail/cxx/StagedContainerBuilder.scala
@@ -5,13 +5,13 @@ import is.hail.cxx
 import is.hail.expr.types.physical.PContainer
 
 class StagedContainerBuilder(fb: FunctionBuilder, region: Code, containerPType: PContainer) {
-  private[this] val aoff = cxx.Variable("aoff", "char *")
-  private[this] val eltOff = cxx.Variable("eltOff", "char *")
-  private[this] val i = cxx.Variable("i", "int", "0")
+  private[this] val aoff = fb.variable("aoff", "char *")
+  private[this] val eltOff = fb.variable("eltOff", "char *")
+  private[this] val i = fb.variable("i", "int", "0")
   private[this] val eltRequired = containerPType.elementType.required
 
   def start(len: Code, clearMissing: Boolean = true): Code = {
-    val __len = cxx.Variable("len", "int", len)
+    val __len = fb.variable("len", "int", len)
     s"""${ __len.define }
        |${ start(__len, clearMissing) }
      """.stripMargin

--- a/hail/src/main/scala/is/hail/cxx/TableEmit.scala
+++ b/hail/src/main/scala/is/hail/cxx/TableEmit.scala
@@ -161,17 +161,10 @@ class TableEmitter(tub: TranslationUnitBuilder) { outer =>
         val filterName = tub.genSym("FilterRowIterator")
         val filter = tub.buildClass(filterName)
 
-<<<<<<< HEAD
-        val st = Variable("st", "NativeStatus *")
-        val region = Variable("region", "ScalaRegion *")
-        val prevIt = Variable("it", oldRowIt.typ)
-        val endIt = Variable("end", oldRowIt.typ)
-=======
         val st = tub.variable("st", "NativeStatus *")
-        val region = tub.variable("region", "Region *")
+        val region = tub.variable("region", "ScalaRegion *")
         val prevIt = tub.variable("it", oldRowIt.typ)
         val endIt = tub.variable("end", oldRowIt.typ)
->>>>>>> wip
         filter += st
         filter += region
         filter += prevIt

--- a/hail/src/main/scala/is/hail/cxx/TranslationUnit.scala
+++ b/hail/src/main/scala/is/hail/cxx/TranslationUnit.scala
@@ -2,6 +2,7 @@ package is.hail.cxx
 
 import java.io.PrintStream
 
+import is.hail.expr.types.physical.PType
 import is.hail.nativecode._
 import is.hail.utils.ArrayBuilder
 
@@ -58,16 +59,41 @@ trait ScopeBuilder {
     definitions += c
   }
 
+  def variable(prefix: String, typ: String, init: Code): Variable = {
+    Variable(genSym(prefix), typ, init)
+  }
+
+  def variable(prefix: String, typ: String): Variable = {
+    Variable(genSym(prefix), typ)
+  }
+
+  def arrayVariable(prefix: String, typ: String, len: Code): ArrayVariable = {
+    ArrayVariable(genSym(prefix), typ, len)
+  }
+
+  def make_shared(prefix: String, typ: String, args: Code*): Variable = {
+    Variable.make_shared(genSym(prefix), typ, args: _*)
+  }
+
   def translationUnitBuilder(): TranslationUnitBuilder = {
     this match {
       case tub: TranslationUnitBuilder => tub
       case _ => parent.translationUnitBuilder()
     }
   }
+
+  def ordering(lp: PType, rp: PType): String = {
+    val tub = translationUnitBuilder()
+    tub.orderings.ordering(tub, lp, rp)
+  }
+
+  def genSym(name: String): String = translationUnitBuilder().genSym(name)
 }
 
 class TranslationUnitBuilder() extends ScopeBuilder {
   val parent: ScopeBuilder = null
+
+  val orderings: Orderings = new Orderings
 
   val includes: ArrayBuilder[String] = new ArrayBuilder[String]()
 
@@ -81,16 +107,25 @@ class TranslationUnitBuilder() extends ScopeBuilder {
   def buildFunction(prefix: String, args: Array[(Type, String)], returnType: Type): FunctionBuilder = {
     new FunctionBuilder(this,
       prefix,
-      args.map { case (typ, p) => new Variable(p, typ, null) },
+      args.map { case (typ, p) => variable(p, typ) },
       returnType)
   }
 
   def buildClass(name: String, superClass: String = null): ClassBuilder =
     new ClassBuilder(this, name, superClass)
 
+  private var symCounter: Long = 0
+
+  override def genSym(name: String): String = {
+    symCounter += 1
+    s"$name$symCounter"
+  }
+
   def end(): TranslationUnit = {
+    val ordDefs = orderings.orderings.result()
+
     new TranslationUnit(
       includes.result().mkString("\n"),
-      definitions.result())
+      ordDefs ++ definitions.result())
   }
 }

--- a/hail/src/main/scala/is/hail/cxx/TranslationUnit.scala
+++ b/hail/src/main/scala/is/hail/cxx/TranslationUnit.scala
@@ -122,10 +122,9 @@ class TranslationUnitBuilder() extends ScopeBuilder {
   }
 
   def end(): TranslationUnit = {
-    val ordDefs = orderings.orderings.result()
 
     new TranslationUnit(
       includes.result().mkString("\n"),
-      ordDefs ++ definitions.result())
+      definitions.result())
   }
 }

--- a/hail/src/main/scala/is/hail/cxx/package.scala
+++ b/hail/src/main/scala/is/hail/cxx/package.scala
@@ -65,13 +65,6 @@ package object cxx {
     }
   }
 
-  var symCounter: Long = 0
-
-  def genSym(name: String): String = {
-    symCounter += 1
-    s"${ name }_$symCounter"
-  }
-
   type Code = String
   type Type = String
 }

--- a/hail/src/test/scala/is/hail/nativecode/RegionValueIteratorSuite.scala
+++ b/hail/src/test/scala/is/hail/nativecode/RegionValueIteratorSuite.scala
@@ -43,10 +43,10 @@ class RegionValueIteratorSuite extends SparkSuite {
     tub.include("<jni.h>")
     tub.include("hail/PartitionIterators.h")
     val partitionFB = tub.buildFunction("partition_f", Array("NativeStatus*" -> "st", "long" -> "objects"), "long")
-    val up = Variable("up", "UpcallEnv")
-    val encoder = Variable("encoder", encClass.name, s"std::make_shared<OutputStream>($up, reinterpret_cast<ObjectArray * >(${ partitionFB.getArg(1) })->at(1))")
-    val jit = Variable("jit", "JavaIteratorObject", s"JavaIteratorObject($up, reinterpret_cast<ObjectArray * >(${ partitionFB.getArg(1) })->at(0))")
-    val it = Variable("it", "RVIterator", s"$jit.begin()")
+    val up = tub.variable("up", "UpcallEnv")
+    val encoder = tub.variable("encoder", encClass.name, s"std::make_shared<OutputStream>($up, reinterpret_cast<ObjectArray * >(${ partitionFB.getArg(1) })->at(1))")
+    val jit = tub.variable("jit", "JavaIteratorObject", s"JavaIteratorObject($up, reinterpret_cast<ObjectArray * >(${ partitionFB.getArg(1) })->at(0))")
+    val it = tub.variable("it", "RVIterator", s"$jit.begin()")
 
     partitionFB += up.define
     partitionFB += encoder.define
@@ -104,7 +104,7 @@ class RegionValueIteratorSuite extends SparkSuite {
       val decClass = PackDecoder(t.physicalType, t.physicalType, spec, tub)
 
       val cb = tub.buildClass("CXXIterator", "NativeObj")
-      val it = Variable("it", s"Reader<${ decClass.name }>")
+      val it = tub.variable("it", s"Reader<${ decClass.name }>")
       cb += it
       cb +=
         s"""${cb.name}(jobject is, ScalaRegion * reg, NativeStatus * st) :


### PR DESCRIPTION
Use in C++ emit of ApplyComparisonOp.

TranslationUnitBuilder keeps a list of orderings.
