### PR TITLE
Teach batch to test itself locally

### DIFF
--- a/batch/Makefile
+++ b/batch/Makefile
@@ -35,7 +35,7 @@ test: push-test
 	kubectl create -f test-batch-pod.yaml
 
 test-local:
-	POD_IP='127.0.0.1' BATCH_URL='http://127.0.0.1:5000' python -m unittest -v test/test_batch.py
+	./test-locally.sh
 
 deploy: push
 	sed -e "s,@sha@,$$(git rev-parse --short=12 HEAD)," \

--- a/batch/test-locally.sh
+++ b/batch/test-locally.sh
@@ -1,0 +1,19 @@
+set -ex
+
+cleanup() {
+    set +e
+    trap "" INT TERM
+    kill -9 $server_pid
+}
+trap cleanup EXIT
+trap "exit 24" INT TERM
+
+BATCH_USE_KUBE_CONFIG=1 python batch/server.py &
+server_pid=$!
+
+until curl -fL 127.0.0.1:5000/jobs >/dev/null 2>&1
+do
+    sleep 1
+done
+
+POD_IP='127.0.0.1' BATCH_URL='http://127.0.0.1:5000' python -m unittest -v test/test_batch.py


### PR DESCRIPTION
Without this `make test-local` fails because there is no running server. This ensures that `make test-local` first starts a server to test against.

The `until curl ...` nonsense is because the server takes some time to start up, so we poll until we get a successful return value from `curl`. `-f` means return non-zero-exit-code on failure. `-L` means follow redirects (not really necessary here, but I think it's good practice to use `-L`).

`BATCH_USE_KUBE_CONFG=1` tells batch to use the latent kubernetes configuration, which means the developer must already have set up `kubectl`. This is a reasonable expectation for a developer of `batch`.

The `trap cleanup EXIT` ensures we run cleanup before the shell exits. `trap "exit 24" INT TERM` converts interruption (`Ctrl-c`) and termination (`kill -15`) into an `EXIT` signal. We do this to ensure that the exit handler is called once. if we did `trap cleanup EXIT INT TERM` some shells would call `cleanup` twice. Once for the interruption and once for the shell exiting.

Inside `cleanup` we `trap "" INT TERM` to make `Ctrl-c` do nothing, because the user COUGH cotton COUGH might smash ctrl-c repeatedly and we might not kill the subprocess before they kills us ;).