### PR TITLE
[batch][dag1] Teach batch to test itself locally

### DIFF
--- a/batch/Makefile
+++ b/batch/Makefile
@@ -35,7 +35,7 @@ test: push-test
 	kubectl create -f test-batch-pod.yaml
 
 test-local:
-	POD_IP='127.0.0.1' BATCH_URL='http://127.0.0.1:5000' python -m unittest -v test/test_batch.py
+	./test-locally.sh
 
 deploy: push
 	sed -e "s,@sha@,$$(git rev-parse --short=12 HEAD)," \

--- a/batch/test-locally.sh
+++ b/batch/test-locally.sh
@@ -1,0 +1,19 @@
+set -ex
+
+cleanup() {
+    set +e
+    trap "" INT TERM
+    kill -9 $server_pid
+}
+trap cleanup EXIT
+trap "exit 24" INT TERM
+
+BATCH_USE_KUBE_CONFIG=1 python batch/server.py &
+server_pid=$!
+
+until curl -fL 127.0.0.1:5000/jobs >/dev/null 2>&1
+do
+    sleep 1
+done
+
+POD_IP='127.0.0.1' BATCH_URL='http://127.0.0.1:5000' python -m unittest -v test/test_batch.py

--- a/batch/test-locally.sh
+++ b/batch/test-locally.sh
@@ -8,13 +8,12 @@ cleanup() {
 trap cleanup EXIT
 trap "exit 24" INT TERM
 
-BATCH_USE_KUBE_CONFIG=1 python batch/server.py &
+# BATCH_USE_KUBE_CONFIG=1 python batch/server.py &
 server_pid=$!
 
 until curl -fL 127.0.0.1:5000/jobs >/dev/null 2>&1
 do
-    ((tries++))
-    ((tries==30)) && break || true
+    ((tries++)) && [ $tries -lt 2 ]
     sleep 1
 done
 

--- a/batch/test-locally.sh
+++ b/batch/test-locally.sh
@@ -13,7 +13,7 @@ server_pid=$!
 
 until curl -fL 127.0.0.1:5000/jobs >/dev/null 2>&1
 do
-    ((tries++)) && [ $tries -lt 2 ]
+    ((tries++)) && [ $tries -lt 30 ]
     sleep 1
 done
 

--- a/batch/test-locally.sh
+++ b/batch/test-locally.sh
@@ -13,6 +13,8 @@ server_pid=$!
 
 until curl -fL 127.0.0.1:5000/jobs >/dev/null 2>&1
 do
+    ((tries++))
+    ((tries==30)) && break || true
     sleep 1
 done
 

--- a/batch/test-locally.sh
+++ b/batch/test-locally.sh
@@ -8,7 +8,7 @@ cleanup() {
 trap cleanup EXIT
 trap "exit 24" INT TERM
 
-# BATCH_USE_KUBE_CONFIG=1 python batch/server.py &
+BATCH_USE_KUBE_CONFIG=1 python batch/server.py &
 server_pid=$!
 
 until curl -fL 127.0.0.1:5000/jobs >/dev/null 2>&1

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -180,16 +180,17 @@ class Test(unittest.TestCase):
 
         port = 5869
         server = ServerThread(app, host=self.ip, port=port)
-        server.start()
+        try:
+            server.start()
 
-        j = self.batch.create_job('alpine', ['echo', 'test'],
-                                  attributes={'foo': 'bar'},
-                                  callback='http://{}:{}/test'.format(self.ip, port))
-        j.wait()
+            j = self.batch.create_job('alpine', ['echo', 'test'],
+                                      attributes={'foo': 'bar'},
+                                      callback='http://{}:{}/test'.format(self.ip, port))
+            j.wait()
 
-        status = d['status']
-        self.assertEqual(status['state'], 'Complete')
-        self.assertEqual(status['attributes'], {'foo': 'bar'})
-
-        server.shutdown()
-        server.join()
+            status = d['status']
+            self.assertEqual(status['state'], 'Complete')
+            self.assertEqual(status['attributes'], {'foo': 'bar'})
+        finally:
+            server.shutdown()
+            server.join()


### PR DESCRIPTION
Without this `make test-local` fails because there is no running server. This ensures that `make test-local` first starts a server to test against.

Recreated for stacked PRs from #4785

---

The `until curl ...` nonsense is because the server takes some time to start up, so we poll until we get a successful return value from `curl`. `-f` means return non-zero-exit-code on failure. `-L` means follow redirects (not really necessary here, but I think it's good practice to use `-L`).

`BATCH_USE_KUBE_CONFG=1` tells batch to use the latent kubernetes configuration, which means the developer must already have set up `kubectl`. This is a reasonable expectation for a developer of `batch`.

The `trap cleanup EXIT` ensures we run cleanup before the shell exits. `trap "exit 24" INT TERM` converts interruption (`Ctrl-c`) and termination (`kill -15`) into an `EXIT` signal. We do this to ensure that the exit handler is called once. if we did `trap cleanup EXIT INT TERM` some shells would call `cleanup` twice. Once for the interruption and once for the shell exiting.

Inside `cleanup` we `trap "" INT TERM` to make `Ctrl-c` do nothing, because the user COUGH cotton COUGH might smash ctrl-c repeatedly and we might not kill the subprocess before they kills us ;).