### PR TITLE
[batch][dag3] Use pip dependencies

### DIFF
--- a/batch/Dockerfile
+++ b/batch/Dockerfile
@@ -2,13 +2,10 @@ FROM alpine:3.8
 
 RUN apk update
 RUN apk add python3 py3-cffi py3-cryptography
-RUN pip3 install -U pip
-RUN pip install flask
-RUN pip install kubernetes
-RUN pip install cerberus
 
-COPY batch /batch
-RUN pip install /batch
+COPY batch /batch/batch
+COPY setup.py /batch/
+RUN pip3 install --no-cache-dir /batch
 
 EXPOSE 5000
 

--- a/batch/Dockerfile.test
+++ b/batch/Dockerfile.test
@@ -2,13 +2,10 @@ FROM alpine:3.8
 
 RUN apk update
 RUN apk add python3 py3-cffi py3-cryptography
-RUN pip3 install -U pip
-RUN pip install flask
-RUN pip install kubernetes
-RUN pip install cerberus
 
-COPY batch /batch
-RUN pip install /batch
+COPY batch /batch/batch
+COPY setup.py /batch/
+RUN pip3 install --no-cache-dir /batch
 COPY test /test
 
 CMD ["python3", "-m", "unittest", "-v", "/test/test_batch.py"]

--- a/batch/setup.py
+++ b/batch/setup.py
@@ -7,5 +7,10 @@ setup(
     author = 'Hail Team',
     author_email = 'hail@broadinstitute.org',
     description = 'Job manager for k8s',
-    packages = find_packages()
+    packages = find_packages(),
+    install_requires=[
+        'cerberus',
+        'kubernetes',
+        'flask',
+    ],
 )


### PR DESCRIPTION
Now that we are using proper python packages and modules, we can use pip dependencies instead of explicitly writing out the dependencies in the `Dockerfile`.