### PR TITLE
[batch][dag5] Cleanup Dockerfiles

### DIFF
--- a/batch/Dockerfile
+++ b/batch/Dockerfile
@@ -1,10 +1,13 @@
 FROM alpine:3.8
 
-RUN apk update
-RUN apk add python3 py3-cffi py3-cryptography
+RUN apk add --no-cache \
+  py3-cffi \
+  py3-cryptography \
+  python3 \
+  && true
 
-COPY batch /batch/batch
 COPY setup.py /batch/
+COPY batch /batch/batch/
 RUN pip3 install --no-cache-dir /batch
 
 EXPOSE 5000

--- a/batch/Dockerfile.test
+++ b/batch/Dockerfile.test
@@ -1,10 +1,13 @@
 FROM alpine:3.8
 
-RUN apk update
-RUN apk add python3 py3-cffi py3-cryptography
+RUN apk add --no-cache \
+  py3-cffi \
+  py3-cryptography \
+  python3 \
+  && true
 
-COPY batch /batch/batch
 COPY setup.py /batch/
+COPY batch /batch/batch/
 RUN pip3 install --no-cache-dir /batch
 COPY test /test
 

--- a/batch/batch/api.py
+++ b/batch/batch/api.py
@@ -1,4 +1,5 @@
 import requests
+from .requests_helper import raise_on_failure
 
 
 class API():
@@ -23,32 +24,32 @@ class API():
             doc['callback'] = callback
 
         response = requests.post(url + '/jobs/create', json=doc, timeout=self.timeout)
-        response.raise_for_status()
+        raise_on_failure(response)
         return response.json()
 
     def list_jobs(self, url):
         response = requests.get(url + '/jobs', timeout=self.timeout)
-        response.raise_for_status()
+        raise_on_failure(response)
         return response.json()
 
     def get_job(self, url, job_id):
         response = requests.get(url + '/jobs/{}'.format(job_id), timeout=self.timeout)
-        response.raise_for_status()
+        raise_on_failure(response)
         return response.json()
 
     def get_job_log(self, url, job_id):
         response = requests.get(url + '/jobs/{}/log'.format(job_id), timeout=self.timeout)
-        response.raise_for_status()
+        raise_on_failure(response)
         return response.text
 
     def delete_job(self, url, job_id):
         response = requests.delete(url + '/jobs/{}/delete'.format(job_id), timeout=self.timeout)
-        response.raise_for_status()
+        raise_on_failure(response)
         return response.json()
 
     def cancel_job(self, url, job_id):
         response = requests.post(url + '/jobs/{}/cancel'.format(job_id), timeout=self.timeout)
-        response.raise_for_status()
+        raise_on_failure(response)
         return response.json()
 
     def create_batch(self, url, attributes):
@@ -56,22 +57,22 @@ class API():
         if attributes:
             doc['attributes'] = attributes
         response = requests.post(url + '/batches/create', json=doc, timeout=self.timeout)
-        response.raise_for_status()
+        raise_on_failure(response)
         return response.json()
 
     def get_batch(self, url, batch_id):
         response = requests.get(url + '/batches/{}'.format(batch_id), timeout=self.timeout)
-        response.raise_for_status()
+        raise_on_failure(response)
         return response.json()
 
     def delete_batch(self, url, batch_id):
         response = requests.delete(url + '/batches/{}'.format(batch_id), timeout=self.timeout)
-        response.raise_for_status()
+        raise_on_failure(response)
         return response.json()
 
     def refresh_k8s_state(self, url):
         response = requests.post(url + '/refresh_k8s_state', timeout=self.timeout)
-        response.raise_for_status()
+        raise_on_failure(response)
 
 
 DEFAULT_API = API()

--- a/batch/batch/requests_helper.py
+++ b/batch/batch/requests_helper.py
@@ -1,0 +1,20 @@
+import requests
+
+
+# https://github.com/requests/requests/pull/4234
+def raise_on_failure(response, max_body_text=500):
+    if 400 <= response.status_code < 600:
+        blame = 'Client' if response.status_code < 500 else 'Server'
+        raise requests.HTTPError(
+            f'{response.status_code} {blame} Error for '
+            f'url {response.url}. {short_body(response, max_body_text)}',
+            response=response
+        )
+
+
+def short_body(response, max_body_text):
+    if isinstance(response.text, str):
+        if len(response.text) < max_body_text:
+            return response.text
+        return response.text[:max_body_text-3] + '...'
+    return ''

--- a/batch/batch/server/__init__.py
+++ b/batch/batch/server/__init__.py
@@ -1,0 +1,5 @@
+from .server import serve
+
+__all__ = [
+    'serve'
+]

--- a/batch/batch/server/globals.py
+++ b/batch/batch/server/globals.py
@@ -1,0 +1,26 @@
+pod_name_job = {}
+job_id_job = {}
+batch_id_batch = {}
+
+
+def _log_path(id):
+    return f'logs/job-{id}.log'
+
+
+def _read_file(fname):
+    with open(fname, 'r') as f:
+        return f.read()
+
+
+_counter = 0
+
+
+def max_id():
+    return _counter
+
+
+def next_id():
+    global _counter
+
+    _counter = _counter + 1
+    return _counter

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -11,6 +11,9 @@ import kubernetes as kube
 import cerberus
 import requests
 
+from .globals import max_id, pod_name_job, job_id_job, _log_path, _read_file, batch_id_batch
+from .globals import next_id
+
 if not os.path.exists('logs'):
     os.mkdir('logs')
 else:
@@ -59,28 +62,6 @@ v1 = kube.client.CoreV1Api()
 
 instance_id = uuid.uuid4().hex
 log.info(f'instance_id = {instance_id}')
-
-counter = 0
-
-
-def next_id():
-    global counter
-
-    counter = counter + 1
-    return counter
-
-
-pod_name_job = {}
-job_id_job = {}
-
-
-def _log_path(id):
-    return f'logs/job-{id}.log'
-
-
-def _read_file(fname):
-    with open(fname, 'r') as f:
-        return f.read()
 
 
 class Job:
@@ -291,7 +272,7 @@ def get_job(job_id):
 
 @app.route('/jobs/<int:job_id>/log', methods=['GET'])
 def get_job_log(job_id):  # pylint: disable=R1710
-    if job_id > counter:
+    if job_id > max_id():
         abort(404)
 
     job = job_id_job.get(job_id)
@@ -323,9 +304,6 @@ def cancel_job(job_id):
         abort(404)
     job.cancel()
     return jsonify({})
-
-
-batch_id_batch = {}
 
 
 class Batch:


### PR DESCRIPTION
1. Separating the `apk update` from the `apk add` means that if the apk package repository metadata changes (say, the URL of some repository changes) and we change our `apk add` line (say we add a new package), then the `apk add` will fail (e.g. because it has an out of date URL for the repository that should contain the new package). The `apk add --no-cache ...` invocation is essentially the same as `apk update && apk add ... && rm -rf /path/to/repo/cache`. When using docker, it is good practice remove unnecessary files so that they do not get included in the "image diff" for that line of the Dockerfile. `apk add --no-cache ...` succinctly performs exactly what we want.

2. Keeping each package on a separate line and sorting those lines makes diffs easy-to-read with one line per new package.

3. Because `COPY` moves all the *contents* of a source folder into the destination path (creating it if it does not exist) which must be a folder, it seems more clear to say `/batch/batch/`, indicating that we are moving data into a folder.