### PR TITLE
[batch][dag12] Extract a data object for a job

### DIFF
--- a/batch/batch/api.py
+++ b/batch/batch/api.py
@@ -14,16 +14,8 @@ class API():
         """
         self.timeout = timeout
 
-    def create_job(self, url, spec, attributes, batch_id, callback):
-        doc = {'spec': spec}
-        if attributes:
-            doc['attributes'] = attributes
-        if batch_id:
-            doc['batch_id'] = batch_id
-        if callback:
-            doc['callback'] = callback
-
-        response = requests.post(url + '/jobs/create', json=doc, timeout=self.timeout)
+    def create_job(self, url, job_spec):
+        response = requests.post(url + '/jobs/create', json=job_spec.to_json(), timeout=self.timeout)
         raise_on_failure(response)
         return response.json()
 

--- a/batch/batch/client.py
+++ b/batch/batch/client.py
@@ -2,6 +2,7 @@ import time
 import random
 
 from . import api
+from .data import JobSpec
 
 
 class Job:
@@ -64,8 +65,9 @@ class Batch:
                    resources=None, tolerations=None, volumes=None, security_context=None,
                    service_account_name=None, attributes=None, callback=None):
         return self.client._create_job(
-            image, command, args, env, ports, resources, tolerations, volumes, security_context,
-            service_account_name, attributes, self.id, callback)
+            JobSpec.from_parameters(
+                image, command, args, env, ports, resources, tolerations, volumes,
+                security_context, service_account_name, attributes, self.id, callback))
 
     def status(self):
         return self.client._get_batch(self.id)
@@ -90,69 +92,8 @@ class BatchClient:
         self.url = url
         self.api = api
 
-    def _create_job(self,
-                    image,
-                    command,
-                    args,
-                    env,
-                    ports,
-                    resources,
-                    tolerations,
-                    volumes,
-                    security_context,
-                    service_account_name,
-                    attributes,
-                    batch_id,
-                    callback):
-        if env:
-            env = [{'name': k, 'value': v} for (k, v) in env.items()]
-        else:
-            env = []
-        env.extend([{
-            'name': 'POD_IP',
-            'valueFrom': {
-                'fieldRef': {'fieldPath': 'status.podIP'}
-            }
-        }, {
-            'name': 'POD_NAME',
-            'valueFrom': {
-                'fieldRef': {'fieldPath': 'metadata.name'}
-            }
-        }])
-
-        container = {
-            'image': image,
-            'name': 'default'
-        }
-        if command:
-            container['command'] = command
-        if args:
-            container['args'] = args
-        if env:
-            container['env'] = env
-        if ports:
-            container['ports'] = [{
-                'containerPort': p,
-                'protocol': 'TCP'
-            } for p in ports]
-        if resources:
-            container['resources'] = resources
-        if volumes:
-            container['volumeMounts'] = [v['volume_mount'] for v in volumes]
-        spec = {
-            'containers': [container],
-            'restartPolicy': 'Never'
-        }
-        if volumes:
-            spec['volumes'] = [v['volume'] for v in volumes]
-        if tolerations:
-            spec['tolerations'] = tolerations
-        if security_context:
-            spec['securityContext'] = security_context
-        if service_account_name:
-            spec['serviceAccountName'] = service_account_name
-
-        j = self.api.create_job(self.url, spec, attributes, batch_id, callback)
+    def _create_job(self, spec):
+        j = self.api.create_job(self.url, spec)
         return Job(self, j['id'], j.get('attributes'))
 
     def _get_job(self, id):
@@ -196,8 +137,9 @@ class BatchClient:
                    attributes=None,
                    callback=None):
         return self._create_job(
-            image, command, args, env, ports, resources, tolerations, volumes, security_context,
-            service_account_name, attributes, None, callback)
+            JobSpec.from_parameters(
+                image, command, args, env, ports, resources, tolerations, volumes,
+                security_context, service_account_name, attributes, None, callback))
 
     def create_batch(self, attributes=None):
         batch = self.api.create_batch(self.url, attributes)

--- a/batch/batch/data.py
+++ b/batch/batch/data.py
@@ -1,0 +1,109 @@
+import cerberus
+import kubernetes as kube
+
+from .kube_client import kube_api_client
+
+
+class JobSpec:
+    schema = {
+        'pod_spec': {
+            'type': 'dict',
+            'required': True,
+            'allow_unknown': True,
+            'schema': {}  # checked by k8s
+        },
+        'batch_id': {'type': 'integer'},
+        'attributes': {
+            'type': 'dict',
+            'keyschema': {'type': 'string'},
+            'valueschema': {'type': 'string'}
+        },
+        'callback': {'type': 'string'}
+    }
+    validator = cerberus.Validator(schema)
+
+    @staticmethod
+    def from_json(doc):
+        return JobSpec(
+            kube_api_client._ApiClient__deserialize(
+                doc['pod_spec'],
+                kube.client.V1PodSpec),
+            doc.get('attributes', None),
+            doc.get('batch_id', None),
+            doc.get('callback', None))
+
+    @staticmethod
+    def from_parameters(image,
+                        command=None,
+                        args=None,
+                        env=None,
+                        ports=None,
+                        resources=None,
+                        tolerations=None,
+                        volumes=None,
+                        security_context=None,
+                        service_account_name=None,
+                        attributes=None,
+                        batch_id=None,
+                        callback=None):
+        ports = [] if ports is None else ports
+        volumes = [] if volumes is None else volumes
+        if env:
+            env = [{'name': k, 'value': v} for (k, v) in env.items()]
+        else:
+            env = []
+        env.extend([{
+            'name': 'POD_IP',
+            'valueFrom': {
+                'fieldRef': {'fieldPath': 'status.podIP'}
+            }
+        }, {
+            'name': 'POD_NAME',
+            'valueFrom': {
+                'fieldRef': {'fieldPath': 'metadata.name'}
+            }
+        }])
+
+        pod_spec = kube.client.V1PodSpec(
+            containers=[kube.client.V1Container(
+                image=image,
+                name='default',
+                command=command,
+                args=args,
+                env=env,
+                ports=[
+                    kube.client.V1ContainerPort(
+                        container_port=p,
+                        protocol='TCP')
+                    for p in ports],
+                resources=resources,
+                volume_mounts=[v['volume_mount'] for v in volumes])],
+            restart_policy='Never',
+            service_account_name=service_account_name,
+            security_context=security_context,
+            tolerations=tolerations,
+            volumes=[v['volume'] for v in volumes])
+
+        return JobSpec(pod_spec, attributes, batch_id, callback)
+
+    def __init__(self, pod_spec, attributes, batch_id, callback):
+        self.pod_spec = pod_spec
+        self.attributes = attributes
+        self.batch_id = batch_id
+        self.callback = callback
+
+    def to_json(self):
+        doc = {'pod_spec': self.pod_spec.to_dict()}
+        if self.attributes:
+            doc['attributes'] = self.attributes
+        if self.batch_id:
+            doc['batch_id'] = self.batch_id
+        if self.callback:
+            doc['callback'] = self.callback
+        return doc
+
+    def __str__(self):
+        return str(self.to_json())
+
+    def __repr__(self):
+        return self.__str__()

--- a/batch/batch/kube_client.py
+++ b/batch/batch/kube_client.py
@@ -1,0 +1,3 @@
+import kubernetes as kube
+
+kube_api_client = kube.client.ApiClient()


### PR DESCRIPTION
This is a minor architectural change (cc'ing @cseed @tpoterba) that I hope will improve maintainability of `batch`. It foreshadows the DAG functionality.

There may be shared data structures between the server and the client. At the very least, the client sends structured data to the server (e.g. a pod spec and metadata about the job). Often, the server parses this data into an object or series of objects which contain methods for performing the server's job (e.g. `batch/server/job.py`).

I think this architecture is more or less a different way of defining the API (see `batch/api.py`). I think defining the API via data objects is appealing because
 - it centralizes serialization and deserialization for each data structure in one class,
 - it enables sharing (via object composition) of that basic data structure between potentially complex client and server objects that implement algorithms on that data structure (I want to do this with the forthcoming DAG stuff), and
 - the client has objects representing its ideas (i.e. "a job") and those objects can have `__str__`'s and `__repr__`'s facilitating debugging of the client

Moreover, this change pushes the use of k8s' swagger models everywhere possible. This means it's harder for us to make code mistakes because pylint will notice when we, for example, misspell a parameter to a k8s model.