### PR TITLE
[batch][dag13] Add basic DAG

### DIFF
--- a/batch/batch/api.py
+++ b/batch/batch/api.py
@@ -35,7 +35,7 @@ class API():
         return response.text
 
     def delete_job(self, url, job_id):
-        response = requests.delete(url + '/jobs/{}/delete'.format(job_id), timeout=self.timeout)
+        response = requests.delete(url + '/jobs/{}'.format(job_id), timeout=self.timeout)
         raise_on_failure(response)
         return response.json()
 
@@ -73,6 +73,16 @@ class API():
 
     def get_dag(self, url, id):
         response = requests.get(f'{url}/dag/{id}', timeout=self.timeout)
+        raise_on_failure(response)
+        return response.json()
+
+    def delete_dag(self, url, id):
+        response = requests.delete(f'{url}/dag/{id}', timeout=self.timeout)
+        raise_on_failure(response)
+        return response.json()
+
+    def cancel_dag(self, url, id):
+        response = requests.post(f'{url}/dag/{id}/cancel', timeout=self.timeout)
         raise_on_failure(response)
         return response.json()
 
@@ -126,3 +136,11 @@ def create_dag(url, dag):
 
 def get_dag(url, id):
     return DEFAULT_API.get_dag(url, id)
+
+
+def delete_dag(url, id):
+    return DEFAULT_API.delete_dag(url, id)
+
+
+def cancel_dag(url, id):
+    return DEFAULT_API.cancel_dag(url, id)

--- a/batch/batch/api.py
+++ b/batch/batch/api.py
@@ -66,6 +66,16 @@ class API():
         response = requests.post(url + '/refresh_k8s_state', timeout=self.timeout)
         raise_on_failure(response)
 
+    def create_dag(self, url, dag):
+        response = requests.post(url + '/dag/create', json=dag.to_json(), timeout=self.timeout)
+        raise_on_failure(response)
+        return response.json()
+
+    def get_dag(self, url, id):
+        response = requests.get(f'{url}/dag/{id}', timeout=self.timeout)
+        raise_on_failure(response)
+        return response.json()
+
 
 DEFAULT_API = API()
 
@@ -108,3 +118,11 @@ def delete_batch(url, batch_id):
 
 def refresh_k8s_state(url):
     return DEFAULT_API.refresh_k8s_state(url)
+
+
+def create_dag(url, dag):
+    return DEFAULT_API.creat_dag(url, dag)
+
+
+def get_dag(url, id):
+    return DEFAULT_API.get_dag(url, id)

--- a/batch/batch/client.py
+++ b/batch/batch/client.py
@@ -150,3 +150,9 @@ class BatchClient:
 
     def get_dag(self, id):
         return Dag.from_json(self.api.get_dag(self.url, id))
+
+    def delete_dag(self, id):
+        self.api.delete_dag(self.url, id)
+
+    def cancel_dag(self, id):
+        self.api.cancel_dag(self.url, id)

--- a/batch/batch/client.py
+++ b/batch/batch/client.py
@@ -2,7 +2,7 @@ import time
 import random
 
 from . import api
-from .data import JobSpec
+from .data import JobSpec, Dag
 
 
 class Job:
@@ -144,3 +144,9 @@ class BatchClient:
     def create_batch(self, attributes=None):
         batch = self.api.create_batch(self.url, attributes)
         return Batch(self, batch['id'])
+
+    def create_dag(self, nodes):
+        return self.api.create_dag(self.url, Dag(nodes))
+
+    def get_dag(self, id):
+        return Dag.from_json(self.api.get_dag(self.url, id))

--- a/batch/batch/pylintrc
+++ b/batch/batch/pylintrc
@@ -3,8 +3,10 @@
 # doc string, R0913 too many arguments, W0622 redefining built in, W0212
 # protected member access, W0621 redefining name from outer scope, R0914 too
 # many local variables, W0603 using the global statement, R0902 too many
-# instance attributes
-disable=C0111,W1203,W1202,C0111,R0913,W0622,W0212,W0621,R0914,W0603,R0902
+# instance attributes, R0801 similar lines
+disable=C0111,W1203,W1202,C0111,R0913,W0622,W0212,W0621,R0914,W0603,R0902,R0801
+
+ignore-patterns=flycheck_.*
 
 [FORMAT]
 # String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1

--- a/batch/batch/pylintrc
+++ b/batch/batch/pylintrc
@@ -3,8 +3,8 @@
 # doc string, R0913 too many arguments, W0622 redefining built in, W0212
 # protected member access, W0621 redefining name from outer scope, R0914 too
 # many local variables, W0603 using the global statement, R0902 too many
-# instance attributes, R0801 similar lines
-disable=C0111,W1203,W1202,C0111,R0913,W0622,W0212,W0621,R0914,W0603,R0902,R0801
+# instance attributes
+disable=C0111,W1203,W1202,C0111,R0913,W0622,W0212,W0621,R0914,W0603,R0902
 
 ignore-patterns=flycheck_.*
 

--- a/batch/batch/server/dag.py
+++ b/batch/batch/server/dag.py
@@ -1,0 +1,109 @@
+from .job import Job
+from ..log import log
+from .. import data
+from .user_error import UserError
+
+
+class DagNode:
+    def __init__(self, spec, parents, children):
+        self.spec = spec
+        self._parents = parents
+        self.children = children
+        self.unfinished_parents = set([])
+        self.job = None
+
+    def add_parent(self, parent):
+        self._parents.append(parent)
+        self.unfinished_parents.add(parent.spec.name)
+
+    def add_child(self, child):
+        self.children.append(child)
+
+    def to_json(self):
+        return {
+            'spec': self.spec.to_json(),
+            'parents': [parent.spec.name for parent in self._parents],
+            'children': [child.spec.name for child in self.children]
+        }
+
+    def __str__(self):
+        return str(self.to_json())
+
+    def __repr__(self):
+        return self.__str__()
+
+    def to_get_json(self):
+        return {
+            'job': self.job,
+            'parents': [parent.name for parent in self._parents],
+            'children': [child.name for child in self.children]
+        }
+
+    def link_job(self, job):
+        self.job = job
+
+    def mark_complete(self):
+        exit_code = self.job.exit_code
+        if exit_code == 0:
+            for child in self.children:
+                child.mark_parent_complete(self)
+        else:
+            log.warning(f'failing pod {exit_code} will not trigger dag completion')
+
+    def mark_parent_complete(self, parent):
+        parent_name = parent.spec.name
+        log.info(f'parent {parent_name}/{parent.job.id} completed for child {self.spec.name}')
+        if parent_name not in self.unfinished_parents:
+            raise ValueError(
+                f'unknown parent: {parent_name} not in {self.unfinished_parents}. '
+                f'{self}')
+        self.unfinished_parents.remove(parent_name)
+        if not self.unfinished_parents:
+            log.info(f'all parents completed for child {self.spec.name}')
+            assert self.job is None
+            self.create_job()
+            assert self.job is not None
+
+    def create_job(self):
+        job_spec = self.spec.job_spec
+        return Job(job_spec.pod_spec, None, job_spec.attributes, job_spec.callback, self)
+
+
+class Dag:
+    schema = data.Dag.schema
+    validator = data.Dag.validator
+
+    @staticmethod
+    def from_json(id, doc):
+        return Dag(id, data.Dag.from_json(doc).nodes)
+
+    def __init__(self, id, specs):
+        self.id = id
+        self.roots = []
+        self.nodes = []
+
+        by_name = {}
+        for spec in specs:
+            node = DagNode(spec, [], [])
+            if spec.name in by_name:
+                raise UserError(f'duplicate name: {spec.name}')
+            by_name[spec.name] = node
+            self.nodes.append(node)
+        for child in by_name.values():
+            if not child.spec.parent_names:
+                self.roots.append(child)
+            else:
+                for parent_name in child.spec.parent_names:
+                    parent = by_name.get(parent_name, None)
+                    if not parent:
+                        raise UserError(f'parent not found: {parent_name}, {by_name.keys()}')
+                    parent.add_child(child)
+                    child.add_parent(parent)
+        for root in self.roots:
+            root.create_job()
+
+    def to_data_dag(self):
+        return data.Dag([node.spec for node in self.nodes])
+
+    def to_get_json(self):
+        return self.to_data_dag().to_json()

--- a/batch/batch/server/dag.py
+++ b/batch/batch/server/dag.py
@@ -1,6 +1,7 @@
-from .job import Job
-from ..log import log
 from .. import data
+
+from .job import Job
+from .log import log
 from .user_error import UserError
 
 
@@ -65,8 +66,7 @@ class DagNode:
             assert self.job is not None
 
     def create_job(self):
-        job_spec = self.spec.job_spec
-        return Job(job_spec.pod_spec, None, job_spec.attributes, job_spec.callback, self)
+        return Job(self.spec.job_spec, self)
 
 
 class Dag:

--- a/batch/batch/server/globals.py
+++ b/batch/batch/server/globals.py
@@ -15,6 +15,7 @@ log.info(f'INSTANCE_ID = {INSTANCE_ID}')
 pod_name_job = {}
 job_id_job = {}
 batch_id_batch = {}
+dag_id_dag = {}
 
 
 def _log_path(id):

--- a/batch/batch/server/job.py
+++ b/batch/batch/server/job.py
@@ -60,10 +60,14 @@ class Job:
         assert self._state == 'Cancelled'
         return None
 
-    def __init__(self, spec):
+    def __init__(self, spec, dag=None):
         self.id = next_id()
         job_id_job[self.id] = self
         self.spec = spec
+
+        self.dag = dag
+        if self.dag:
+            self.dag.link_job(self)
 
         if self.spec.batch_id:
             batch = batch_id_batch[self.spec.batch_id]
@@ -135,6 +139,9 @@ class Job:
             self._pod_name = None
 
         self.set_state('Complete')
+
+        if self.dag:
+            self.dag.mark_complete()
 
         log.info('job {} complete, exit_code {}'.format(
             self.id, self.exit_code))

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -83,7 +83,7 @@ def get_job_log(job_id):  # pylint: disable=R1710
     abort(404)
 
 
-@app.route('/jobs/<int:job_id>/delete', methods=['DELETE'])
+@app.route('/jobs/<int:job_id>', methods=['DELETE'])
 def delete_job(job_id):
     job = job_id_job.get(job_id)
     if not job:
@@ -128,7 +128,7 @@ def get_batch(batch_id):
     return jsonify(batch.to_json())
 
 
-@app.route('/batches/<int:batch_id>/delete', methods=['DELETE'])
+@app.route('/batches/<int:batch_id>', methods=['DELETE'])
 def delete_batch(batch_id):
     batch = batch_id_batch.get(batch_id)
     if not batch:
@@ -147,12 +147,32 @@ def create_dag():
     return str(dag.id), 201
 
 
-@app.route('/dag/<int:dag_id>', methods=['GET'])
-def get_dag(dag_id):
-    dag = dag_id_dag.get(dag_id)
+@app.route('/dag/<int:id>', methods=['GET'])
+def get_dag(id):
+    dag = dag_id_dag.get(id)
     if not dag:
         abort(404)
     return jsonify(dag.to_get_json())
+
+
+@app.route('/dag/<int:id>', methods=['DELETE'])
+def delete_dag(id):
+    dag = dag_id_dag.get(id)
+    if not dag:
+        abort(404)
+    dag.delete()
+    return jsonify({})
+
+
+@app.route('/dag/<int:id>/cancel', methods=['POST'])
+def cancel_dag(id):
+    dag = dag_id_dag.get(id)
+    if not dag:
+        abort(404)
+    if dag.cancelled:
+        raise UserError('dag already cancelled')
+    dag.cancel()
+    return jsonify({})
 
 
 def update_job_with_pod(job, pod):

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -148,11 +148,11 @@ def create_dag():
 
 
 @app.route('/dag/<int:dag_id>', methods=['GET'])
-def get_dag(dag_id):  # pylint: disable=R1710
+def get_dag(dag_id):
     dag = dag_id_dag.get(dag_id)
-    if dag:
-        return jsonify(dag.to_get_json())
-    abort(404)
+    if not dag:
+        abort(404)
+    return jsonify(dag.to_get_json())
 
 
 def update_job_with_pod(job, pod):

--- a/batch/batch/server/user_error.py
+++ b/batch/batch/server/user_error.py
@@ -1,0 +1,6 @@
+class UserError(Exception):
+    def __init__(self, data, status_code=400):
+        assert 400 <= status_code < 500
+        Exception.__init__(self, str(data))
+        self.data = data
+        self.status_code = status_code

--- a/batch/test-locally.sh
+++ b/batch/test-locally.sh
@@ -22,4 +22,4 @@ do
     sleep 1
 done
 
-POD_IP='127.0.0.1' BATCH_URL='http://127.0.0.1:5000' python -m unittest -v test/test_batch.py
+POD_IP='127.0.0.1' BATCH_URL='http://127.0.0.1:5000' pytest ${PYTEST_ARGS:-test}

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -1,9 +1,10 @@
+import batch
+import os
+import re
+import requests
 import threading
 import time
-import os
 import unittest
-import batch
-import requests
 from werkzeug.serving import make_server
 from flask import Flask, request, jsonify, url_for, Response
 

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -1,12 +1,14 @@
-import batch
 import os
-import re
-import requests
 import threading
 import time
 import unittest
+
+import requests
 from werkzeug.serving import make_server
-from flask import Flask, request, jsonify, url_for, Response
+from flask import Flask, request, Response
+
+import batch
+
 
 class ServerThread(threading.Thread):
     def __init__(self, app, host='127.0.0.1', port=5000):

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -1,0 +1,69 @@
+import os
+import pytest
+import re
+import requests
+
+import batch
+from batch.data import DagNodeSpec, JobSpec
+
+
+@pytest.fixture
+def client():
+    return batch.client.BatchClient(url=os.environ.get('BATCH_URL'))
+
+
+def test_duplicate_name_is_400(client):
+    try:
+        client.create_dag([
+            DagNodeSpec(
+                'head',
+                [],
+                JobSpec.from_parameters('alpine:3.8', ['echo', 'head'])),
+            DagNodeSpec(
+                'head',
+                ['head'],
+                JobSpec.from_parameters('alpine:3.8', ['echo', 'left']))])
+    except requests.exceptions.HTTPError as err:
+        assert err.response.status_code == 400
+        assert re.match('.*duplicate name: head.*', err.response.text)
+        return
+    assert False
+
+
+def test_missing_dependency_is_400(client):
+    try:
+        client.create_dag([
+            DagNodeSpec(
+                'head',
+                [],
+                JobSpec.from_parameters('alpine:3.8', ['echo', 'head'])),
+            DagNodeSpec(
+                'tail',
+                ['missing_dependency'],
+                JobSpec.from_parameters('alpine:3.8', ['echo', 'left']))])
+    except requests.exceptions.HTTPError as err:
+        assert err.response.status_code == 400
+        assert re.match('.*parent not found: missing_dependency.*', err.response.text)
+        return
+    assert False
+
+
+def test_dag(client):
+    head = DagNodeSpec(
+        'head',
+        [],
+        JobSpec.from_parameters('alpine:3.8', ['echo', 'head']))
+    left = DagNodeSpec(
+        'left',
+        ['head'],
+        JobSpec.from_parameters('alpine:3.8', ['echo', 'left']))
+    right = DagNodeSpec(
+        'right',
+        ['head'],
+        JobSpec.from_parameters('alpine:3.8', ['echo', 'right']))
+    tail = DagNodeSpec(
+        'tail',
+        ['left', 'right'],
+        JobSpec.from_parameters('alpine:3.8', ['echo', 'tail']))
+    id = client.create_dag([head, left, right, tail])
+    client.get_dag(id)

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -67,3 +67,49 @@ def test_dag(client):
         JobSpec.from_parameters('alpine:3.8', ['echo', 'tail']))
     id = client.create_dag([head, left, right, tail])
     client.get_dag(id)
+
+
+def test_cancel(client):
+    head = DagNodeSpec(
+        'head',
+        [],
+        JobSpec.from_parameters('alpine:3.8', ['echo', 'head']))
+    tail = DagNodeSpec(
+        'tail',
+        ['head'],
+        JobSpec.from_parameters('alpine:3.8', ['echo', 'tail']))
+    id = client.create_dag([head, tail])
+    client.cancel_dag(id)
+
+
+def test_delete(client):
+    head = DagNodeSpec(
+        'head',
+        [],
+        JobSpec.from_parameters('alpine:3.8', ['echo', 'head']))
+    tail = DagNodeSpec(
+        'tail',
+        ['head'],
+        JobSpec.from_parameters('alpine:3.8', ['echo', 'tail']))
+    id = client.create_dag([head, tail])
+    client.delete_dag(id)
+
+
+def test_cancel_twice_is_400(client):
+    head = DagNodeSpec(
+        'head',
+        [],
+        JobSpec.from_parameters('alpine:3.8', ['echo', 'head']))
+    tail = DagNodeSpec(
+        'tail',
+        ['head'],
+        JobSpec.from_parameters('alpine:3.8', ['echo', 'tail']))
+    id = client.create_dag([head, tail])
+    client.cancel_dag(id)
+    try:
+        client.cancel_dag(id)
+    except requests.exceptions.HTTPError as err:
+        assert err.response.status_code == 400
+        assert re.match('.*dag already cancelled.*', err.response.text)
+        return
+    assert False


### PR DESCRIPTION
I also harmonized the delete endpoint URLs so that `jobs`, `batch`, and `dag` all use `DELETE /{type}/{id}`.

@jigold is reviewing all the infrastructural changes that prepare for this. This is relatively independent of the restructuring so I figure I can assign it to a new person.

@jbloom22 if you'd rather not review `batch` things, I can roll the dice again. Otherwise, here's an opportunity to learn about how that's working.