### PR TITLE
[batch][dag5] Cleanup Dockerfile's

### DIFF
--- a/batch/Dockerfile
+++ b/batch/Dockerfile
@@ -1,10 +1,13 @@
 FROM alpine:3.8
 
-RUN apk update
-RUN apk add python3 py3-cffi py3-cryptography
+RUN apk add --no-cache \
+  py3-cffi \
+  py3-cryptography \
+  python3 \
+  && true
 
-COPY batch /batch/batch
 COPY setup.py /batch/
+COPY batch /batch/batch/
 RUN pip3 install --no-cache-dir /batch
 
 EXPOSE 5000

--- a/batch/Dockerfile.test
+++ b/batch/Dockerfile.test
@@ -1,10 +1,13 @@
 FROM alpine:3.8
 
-RUN apk update
-RUN apk add python3 py3-cffi py3-cryptography
+RUN apk add --no-cache \
+  py3-cffi \
+  py3-cryptography \
+  python3 \
+  && true
 
-COPY batch /batch/batch
 COPY setup.py /batch/
+COPY batch /batch/batch/
 RUN pip3 install --no-cache-dir /batch
 COPY test /test
 


### PR DESCRIPTION
@jigold I screwed up the stacked PRs so I'll need reapprovals. Sorry :(
---
1. Separating the `apk update` from the `apk add` means that
   if the apk package repository metadata changes (say, the
   URL of some repository changes) and we change our `apk add`
   line (say we add a new package), then the `apk add` will
   fail (e.g. because it has an out of date URL for the
   repository that should contain the new package). The
   `apk add --no-cache ...` invocation is essentially the same
   as `apk update && apk add ... && rm -rf /path/to/repo/cache`.
   When using docker, it is good practice remove unnecessary
   files so that they do not get included in the "image diff"
   for that line of the Dockerfile. `apk add --no-cache ...`
   succinctly performs exactly what we want.

2. Keeping each package on a separate line and sorting those
   lines makes diffs easy-to-read with one line per new package.

3. Because `COPY` moves all the *contents* of a source folder into
   the contents of the destination path (creating it if it does not
   exist), it seems more clear to say `/batch/batch/`, indicating
   that we are moving data into a folder.