### PR TITLE
Python MatrixTable to IR

### DIFF
--- a/hail/python/hail/ir/matrix_ir.py
+++ b/hail/python/hail/ir/matrix_ir.py
@@ -276,6 +276,7 @@ class MatrixUnionRows(MatrixIR):
     def render(self, r):
         return '(MatrixUnionRows {})'.format(' '.join(map(r, self.children)))
 
+
 class MatrixDistinctByRow(MatrixIR):
     def __init__(self, child):
         super().__init__()
@@ -283,6 +284,7 @@ class MatrixDistinctByRow(MatrixIR):
 
     def render(self, r):
         return f'(MatrixDistinctByRow {r(self.child)})'
+
 
 class MatrixExplodeCols(MatrixIR):
     def __init__(self, child, path):

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -7,6 +7,7 @@ import hail as hl
 import hail.expr.aggregators as agg
 from hail.expr.expressions import *
 from hail.expr.types import *
+from hail.ir import *
 from hail.genetics.reference_genome import reference_genome_type
 from hail.linalg import BlockMatrix
 from hail.matrixtable import MatrixTable
@@ -1906,10 +1907,7 @@ def split_multi(ds, keep_star=False, left_aligned=False):
             if rekey:
                 return mt.key_rows_by('locus', 'alleles')
             else:
-                return MatrixTable._from_java(mt._jmt.keyRowsBy(
-                    ['locus', 'alleles'],
-                    True # isSorted
-                ))
+                return MatrixTable(MatrixKeyRowsBy(mt._mir, ['locus', 'alleles'], is_sorted=True))
         else:
             assert isinstance(ds, Table)
             ht = (ds.annotate(**{new_id: expr})
@@ -1929,11 +1927,7 @@ def split_multi(ds, keep_star=False, left_aligned=False):
             if rekey:
                 return ht.key_by('locus', 'alleles')
             else:
-                return Table._from_java(ht._jt.keyBy(
-                    ['locus', 'alleles'],
-                    True # isSorted
-                ))
-
+                return Table(TableKeyBy(ht._tir, ['locus', 'alleles'], is_sorted=True))
 
     if left_aligned:
         def make_struct(i):

--- a/hail/src/main/scala/is/hail/expr/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/Parser.scala
@@ -55,20 +55,6 @@ object Parser extends JavaTokenParsers {
     }
   }
 
-  def parseAnnotationRoot(code: String, root: String): List[String] = {
-    val path = parseAll(annotationIdentifier, code) match {
-      case Success(result, _) => result.asInstanceOf[List[String]]
-      case NoSuccess(msg, _) => fatal(msg)
-    }
-
-    if (path.isEmpty)
-      fatal(s"expected an annotation path starting in `$root', but got an empty path")
-    else if (path.head != root)
-      fatal(s"expected an annotation path starting in `$root', but got a path starting in '${ path.head }'")
-    else
-      path.tail
-  }
-
   def parseLocusInterval(input: String, rg: RGBase): Interval = {
     parseAll[Interval](locusInterval(rg), input) match {
       case Success(r, _) => r


### PR DESCRIPTION
- converted aggregateColsByKey, aggregateRowsByKey, keyRowsBy, keyColsBy, explodeRows, explodeCols, filterCols, filterRows, filterEntries, select_*, annotate_*,
- deleted unused Scala methods