### PR TITLE
Refactor Die to take a string IR child

### DIFF
--- a/hail/python/hail/expr/builders.py
+++ b/hail/python/hail/expr/builders.py
@@ -1,6 +1,6 @@
 from hail.typecheck import typecheck_method
 from hail.expr.expressions import unify_types, unify_types_limited, expr_any, \
-    expr_bool, ExpressionException, construct_expr
+    expr_bool, ExpressionException, construct_expr, expr_str
 from hail import ir
 
 
@@ -285,7 +285,7 @@ class CaseBuilder(ConditionalBuilder):
         from hail.expr.functions import null
         return self._finish(null(self._ret_type))
 
-    @typecheck_method(message=str)
+    @typecheck_method(message=expr_str)
     def or_error(self, message):
         """Finish the case statement by throwing an error with the given message.
 

--- a/hail/python/hail/expr/builders.py
+++ b/hail/python/hail/expr/builders.py
@@ -304,5 +304,5 @@ class CaseBuilder(ConditionalBuilder):
         """
         if len(self._cases) == 0:
             raise ExpressionException("'or_error' cannot be called without at least one 'when' call")
-        error_expr = construct_expr(ir.Die(message, self._ret_type), self._ret_type)
+        error_expr = construct_expr(ir.Die(message._ir, self._ret_type), self._ret_type)
         return self._finish(error_expr)

--- a/hail/python/hail/expr/builders.py
+++ b/hail/python/hail/expr/builders.py
@@ -296,7 +296,7 @@ class CaseBuilder(ConditionalBuilder):
 
         Parameters
         ----------
-        message : :obj:`str`
+        message : :class:`.Expression` of type :data:`tstr`
 
         Returns
         -------

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1124,7 +1124,7 @@ class Die(IR):
         return new_instance(self.message, self.typ)
 
     def render(self, r):
-        return '(Die {} "{}")'.format(self.typ._jtype.parsableString(), r(self.message))
+        return '(Die {} {})'.format(self.typ._jtype.parsableString(), r(self.message))
 
     def __eq__(self, other):
         return isinstance(other, Die) and \

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1113,7 +1113,7 @@ class In(IR):
 
 
 class Die(IR):
-    @typecheck_method(message=str, typ=hail_type)
+    @typecheck_method(message=IR, typ=hail_type)
     def __init__(self, message, typ):
         super().__init__()
         self.message = message
@@ -1124,7 +1124,7 @@ class Die(IR):
         return new_instance(self.message, self.typ)
 
     def render(self, r):
-        return '(Die {} "{}")'.format(self.typ._jtype.parsableString(), escape_str(self.message))
+        return '(Die {} "{}")'.format(self.typ._jtype.parsableString(), r(self.message))
 
     def __eq__(self, other):
         return isinstance(other, Die) and \

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -85,7 +85,7 @@ class ValueIRTests(unittest.TestCase):
             ir.StringSlice(st, ir.I32(1), ir.I32(2)),
             ir.StringLength(st),
             ir.In(2, hl.tfloat64),
-            ir.Die('mumblefoo', hl.tfloat64),
+            ir.Die(ir.Str('mumblefoo'), hl.tfloat64),
             ir.Apply('&&', b, c),
             ir.Apply('toFloat64', i),
             ir.Uniroot('x', ir.F64(3.14), ir.F64(-5.0), ir.F64(5.0)),

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -99,7 +99,7 @@ object Children {
     case In(i, typ) =>
       none
     case Die(message, typ) =>
-      none
+      Array(message)
     case ApplyIR(_, args, _) =>
       args.toFastIndexedSeq
     case Apply(_, args) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -136,7 +136,9 @@ object Copy {
         val IndexedSeq(s: IR) = newChildren
         StringLength(s)
       case In(i, t) => In(i, t)
-      case Die(message, typ) => Die(message, typ)
+      case Die(_, typ) =>
+        val IndexedSeq(s: IR) = newChildren
+        Die(s, typ)
       case ApplyIR(fn, args, conversion) =>
         ApplyIR(fn, newChildren.map(_.asInstanceOf[IR]), conversion)
       case Apply(fn, args) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir
 import is.hail.annotations._
 import is.hail.annotations.aggregators._
 import is.hail.asm4s._
-import is.hail.expr.ir.functions.MathFunctions
+import is.hail.expr.ir.functions.{MathFunctions, StringFunctions}
 import is.hail.expr.types.physical._
 import is.hail.expr.types.virtual._
 import is.hail.utils._
@@ -937,7 +937,12 @@ private class Emit(
           mb.getArg[Boolean](normalArgumentPosition(i) + 1),
           mb.getArg(normalArgumentPosition(i))(typeToTypeInfo(typ)))
       case Die(m, typ) =>
-        present(Code._throw(Code.newInstance[HailException, String](m)))
+        val cm = emit(m)
+        present(
+          Code._throw(Code.newInstance[HailException, String](
+            cm.m.mux[String](
+              "<exception message missing>",
+               coerce[String](StringFunctions.wrapArg(mb, m.typ)(cm.v))))))
       case ir@ApplyIR(fn, args, conversion) =>
         if (ir.explicitNode.size < 10)
           emit(ir.explicitNode)

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -226,7 +226,12 @@ final case class StringLength(s: IR) extends IR {
 
 final case class In(i: Int, typ: Type) extends IR
 // FIXME: should be type any
-final case class Die(message: String, typ: Type) extends IR
+
+object Die {
+  def apply(message: String, typ: Type): Die = Die(Str(message), typ)
+}
+
+final case class Die(message: IR, typ: Type) extends IR
 
 final case class ApplyIR(function: String, args: Seq[IR], conversion: Seq[IR] => IR) extends IR {
   lazy val explicitNode: IR = {

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -652,7 +652,9 @@ object Interpret {
       case In(i, _) =>
         val (a, _) = args(i)
         a
-      case Die(message, typ) => fatal(message)
+      case Die(message, typ) =>
+        val message_ = interpret(message).asInstanceOf[String]
+        fatal(if (message_ != null) message_ else "<exception message missing>")
       case ir@ApplyIR(function, functionArgs, conversion) =>
         interpret(ir.explicitNode, env, args, agg)
       case ApplySpecial("||", Seq(left_, right_)) =>

--- a/hail/src/main/scala/is/hail/expr/ir/IsConstant.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IsConstant.scala
@@ -15,7 +15,7 @@ object CanEmit {
 object IsConstant {
   def apply(ir: IR): Boolean = {
     ir match {
-      case I32(_) | I64(_) | F32(_) | F64(_) | True() | False() | NA(_) | Literal(_, _) | Die(_, _) => true
+      case I32(_) | I64(_) | F32(_) | F64(_) | True() | False() | NA(_) | Literal(_, _) => true
       case _ => false
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -697,7 +697,7 @@ object IRParser {
         In(idx, typ)
       case "Die" =>
         val typ = type_expr(it)
-        val msg = string_literal(it)
+        val msg = ir_value_expr(env)(it)
         Die(msg, typ)
       case "ApplySeeded" =>
         val function = identifier(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -179,7 +179,7 @@ object Pretty {
             case SelectFields(_, fields) => fields.map(prettyIdentifier).mkString("(", " ", ")")
             case LowerBoundOnOrderedCollection(_, _, onKey) => prettyBooleanLiteral(onKey)
             case In(i, typ) => s"${ typ.parsableString() } $i"
-            case Die(message, typ) => typ.parsableString() + " " + prettyStringLiteral(message)
+            case Die(message, typ) => typ.parsableString()
             case Uniroot(name, _, _, _) => prettyIdentifier(name)
             case MatrixRead(typ, dropCols, dropRows, reader) =>
               (if (typ == reader.fullType) "None" else typ.parsableString()) + " " +

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -242,6 +242,8 @@ object TypeCheck {
       case In(i, typ) =>
         assert(typ != null)
       case Die(msg, typ) =>
+        check(msg)
+        assert(msg.typ isOfType TString())
       case x@ApplyIR(fn, args, conversion) =>
         check(x.explicitNode)
       case x: AbstractApplyNode[_] =>

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -581,6 +581,7 @@ class IRSuite extends SparkSuite {
 
   @Test def testDie() {
     assertFatal(Die("mumblefoo", TFloat64()), "mble")
+    assertFatal(Die(NA(TString()), TFloat64()), "message missing")
   }
 
   @Test def testArrayRange() {


### PR DESCRIPTION
Follow-up PRs will use this for better error messages in places like require_biallelic