### PR TITLE
changes to C++ emit code for (coming) ordering

### DIFF
--- a/hail/src/main/scala/is/hail/cxx/Compile.scala
+++ b/hail/src/main/scala/is/hail/cxx/Compile.scala
@@ -24,7 +24,6 @@ object Compile {
     tub.include("hail/hail.h")
     tub.include("hail/Utils.h")
     tub.include("hail/Region.h")
-    tub.include("hail/Ordering.h")
 
     tub.include("<limits.h>")
     tub.include("<math.h>")

--- a/hail/src/main/scala/is/hail/cxx/Compile.scala
+++ b/hail/src/main/scala/is/hail/cxx/Compile.scala
@@ -55,9 +55,7 @@ object Compile {
     }
 
     val tu = tub.end()
-    val mod = tu.build("-ggdb -O1"
-      , System.out
-    )
+    val mod = tu.build("-ggdb -O1")
 
     val st = new NativeStatus()
     mod.findOrBuild(st)

--- a/hail/src/main/scala/is/hail/cxx/RVDEmitTriplet.scala
+++ b/hail/src/main/scala/is/hail/cxx/RVDEmitTriplet.scala
@@ -34,7 +34,6 @@ object RVDEmitTriplet {
     tub: TranslationUnitBuilder
   ): RVDEmitTriplet = {
     val decoder = codecSpec.buildNativeDecoderClass(t, requestedType.rowType, tub)
-    tub += decoder
     tub.include("hail/Decoder.h")
     tub.include("hail/ObjectArray.h")
     tub.include("<memory>")
@@ -64,7 +63,6 @@ object RVDEmitTriplet {
 
   def write[T](t: RVDEmitTriplet, tub: TranslationUnitBuilder, path: String, stageLocally: Boolean, codecSpec: CodecSpec): Array[Long] = {
     val encClass = codecSpec.buildNativeEncoderClass(t.typ.rowType, tub)
-    tub += encClass
     tub.include("hail/Encoder.h")
 
     val os = Variable("os", "long")

--- a/hail/src/main/scala/is/hail/cxx/RVDEmitTriplet.scala
+++ b/hail/src/main/scala/is/hail/cxx/RVDEmitTriplet.scala
@@ -91,7 +91,7 @@ object RVDEmitTriplet {
          |return $nRows;
        """.stripMargin)
 
-    val mod = tub.result().build("-O2 -llz4")
+    val mod = tub.end().build("-O2 -llz4")
     val modKey = mod.getKey
     val modBinary = mod.getBinary
 

--- a/hail/src/main/scala/is/hail/cxx/RegionValueIterator.scala
+++ b/hail/src/main/scala/is/hail/cxx/RegionValueIterator.scala
@@ -17,7 +17,6 @@ object CXXRegionValueIterator {
   def apply(itClass: TranslationUnitBuilder => Class): (Region, AnyRef) => StagingIterator[RegionValue] = {
     val tub = new TranslationUnitBuilder()
     val cls = itClass(tub)
-    tub += cls
     tub.include("hail/ObjectArray.h")
 
     val st = Variable("st", "NativeStatus *")
@@ -37,7 +36,7 @@ object CXXRegionValueIterator {
          |return (*it == nullptr) ? 0 : 1;
        """.stripMargin)
 
-    val mod = tub.result().build("-O1 -llz4")
+    val mod = tub.end().build("-O1 -llz4")
     val key = mod.getKey
     val bin = mod.getBinary
 

--- a/hail/src/test/scala/is/hail/nativecode/NativeCodeSuite.scala
+++ b/hail/src/test/scala/is/hail/nativecode/NativeCodeSuite.scala
@@ -215,7 +215,7 @@ class NativeCodeSuite extends SparkSuite {
     tub.include("hail/hail.h")
     tub.include("<cstdio>")
 
-    val fb = FunctionBuilder("testUpcall", Array("NativeStatus*" -> "st", "long" -> "a0"), "long")
+    val fb = tub.buildFunction("testUpcall", Array("NativeStatus*" -> "st", "long" -> "a0"), "long")
 
     fb +=
       s"""
@@ -223,10 +223,9 @@ class NativeCodeSuite extends SparkSuite {
          |return 1000+${fb.getArg(1)};
        """.stripMargin
 
-    val f = fb.result()
-    tub += f
+    val f = fb.end()
 
-    val mod = tub.result().build("")
+    val mod = tub.end().build("")
 
     val st = new NativeStatus()
     val testUpcall = mod.findLongFuncL1(st, f.name)

--- a/hail/src/test/scala/is/hail/nativecode/NativeEncoderSuite.scala
+++ b/hail/src/test/scala/is/hail/nativecode/NativeEncoderSuite.scala
@@ -23,23 +23,23 @@ class NativeEncoderSuite extends SparkSuite {
     tub.include("<cstdio>")
     tub.include("<memory>")
 
-    val fb = FunctionBuilder("testOutputStream", Array("NativeStatus*" -> "st", "long" -> "array"), "long")
+    val fb = tub.buildFunction("testOutputStream", Array("NativeStatus*" -> "st", "long" -> "array"), "long")
 
-    fb += s"""UpcallEnv up;
-             |auto h = reinterpret_cast<ObjectArray*>(${fb.getArg(1)});
-             |auto jos = h->at(0);
-             |
-             |char * buf = new char[10]{97, 98, 99, 100, 101, 102, 103, 104, 105, 106};
-             |
-             |auto os = std::make_shared<OutputStream>(up, jos);
-             |os->write(buf, 10);
-             |
-             |return 0;""".stripMargin
+    fb +=
+      s"""UpcallEnv up;
+         |auto h = reinterpret_cast<ObjectArray*>(${ fb.getArg(1) });
+         |auto jos = h->at(0);
+         |
+         |char * buf = new char[10]{97, 98, 99, 100, 101, 102, 103, 104, 105, 106};
+         |
+         |auto os = std::make_shared<OutputStream>(up, jos);
+         |os->write(buf, 10);
+         |
+         |return 0;""".stripMargin
 
-    val f = fb.result()
-    tub += f
+    val f = fb.end()
 
-    val mod = tub.result().build("")
+    val mod = tub.end().build("")
 
     val st = new NativeStatus()
     val testOS = mod.findLongFuncL1(st, f.name)
@@ -64,18 +64,18 @@ class NativeEncoderSuite extends SparkSuite {
     tub.include("<cstdio>")
     tub.include("<memory>")
 
-    val fb = FunctionBuilder("testOutputBuffers", Array("NativeStatus*" -> "st", "long" -> "holder"), "long")
+    val fb = tub.buildFunction("testOutputBuffers", Array("NativeStatus*" -> "st", "long" -> "holder"), "long")
 
     val bytes = Array.tabulate[Byte](100)(i => new Integer(i + 97).byteValue())
 
     fb +=
       s"""
          |UpcallEnv up;
-         |auto h = reinterpret_cast<ObjectArray*>(${fb.getArg(1)});
+         |auto h = reinterpret_cast<ObjectArray*>(${ fb.getArg(1) });
          |auto jos = h->at(0);
          |
          |auto os = std::make_shared<OutputStream>(up, jos);
-         |using LZ4Buf = LZ4OutputBlockBuffer<${LZ4Utils.maxCompressedLength(32) + 4}, StreamOutputBlockBuffer>;
+         |using LZ4Buf = LZ4OutputBlockBuffer<${ LZ4Utils.maxCompressedLength(32) + 4 }, StreamOutputBlockBuffer>;
          |using BlockBuf = BlockingOutputBuffer<32, LZ4Buf>;
          |LEB128OutputBuffer<BlockBuf> leb_buf {os};
          |
@@ -85,17 +85,16 @@ class NativeEncoderSuite extends SparkSuite {
          |leb_buf.write_long(3l);
          |leb_buf.write_float(3.3f);
          |leb_buf.write_double(3.3);
-         |leb_buf.write_bytes(new char[${bytes.length}] {${bytes.mkString(", ")}}, ${bytes.length});
+         |leb_buf.write_bytes(new char[${ bytes.length }] {${ bytes.mkString(", ") }}, ${ bytes.length });
          |leb_buf.flush();
          |leb_buf.close();
          |
          |return 0;
        """.stripMargin
 
-    val f = fb.result()
-    tub += f
+    val f = fb.end()
 
-    val mod = tub.result().build("-O1 -llz4")
+    val mod = tub.end().build("-O1 -llz4")
 
     val st = new NativeStatus()
     val testOB = mod.findLongFuncL1(st, f.name)
@@ -135,7 +134,7 @@ class NativeEncoderSuite extends SparkSuite {
       new BlockingBufferSpec(32,
         new LZ4BlockBufferSpec(32,
           new StreamBlockBufferSpec)))
-    val t = TTuple(TInterval(TStruct("x"->TSet(TInt32()))))
+    val t = TTuple(TInterval(TStruct("x" -> TSet(TInt32()))))
 
     val a = Row(Interval(Row(Set(-1478292367)), Row(Set(2084728308)), true, true))
 

--- a/hail/src/test/scala/is/hail/nativecode/RegionValueIteratorSuite.scala
+++ b/hail/src/test/scala/is/hail/nativecode/RegionValueIteratorSuite.scala
@@ -59,6 +59,7 @@ class RegionValueIteratorSuite extends SparkSuite {
          |$encoder.flush(${ partitionFB.getArg(0) });
          |return 0;
        """.stripMargin
+    partitionFB.end()
 
     val mod = tub.end().build("-O2 -llz4")
     val key = mod.getKey


### PR DESCRIPTION
Builds on: https://github.com/hail-is/hail/pull/4851

Basically, various builders have parents so we can walk up to the translation unit to store the orderings that have been generated.
