### PR TITLE
More workshop fixes

### DIFF
--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -181,14 +181,16 @@ def auth(requested_svc_name):
 def workers():
     if not session.get('admin'):
         return redirect(external_url_for('admin-login'))
-    workers = k8s.list_pod_for_all_namespaces(
+    workers = k8s.list_namespaced_pod(
+        namespace='default',
         watch=False,
         label_selector='app=notebook-worker',
         _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS)
     workers_and_svcs = []
     for w in workers.items:
         uuid = w.metadata.labels['uuid']
-        svcs = k8s.list_service_for_all_namespaces(
+        svcs = k8s.list_namespaced_service(
+            namespace='default',
             watch=False,
             label_selector='uuid='+uuid,
             _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS).items
@@ -223,7 +225,8 @@ def delete_worker_pod(pod_name):
         'default',
         kube.client.V1DeleteOptions(),
         _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS)
-    svcs = k8s.list_service_for_all_namespaces(
+    svcs = k8s.list_namespaced_service(
+        namespace='default',
         watch=False,
         label_selector='uuid='+uuid,
         _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS).items

--- a/vdc/gcp-config.yaml.in
+++ b/vdc/gcp-config.yaml.in
@@ -97,5 +97,21 @@ resources:
         management: {autoRepair: true}
         name: preemptible-pool
         version: 1.10.7-gke.6
+      - autoscaling: {}
+        config:
+          diskSizeGb: 100
+          diskType: pd-standard
+          imageType: COS
+          labels: {preemptible: 'true'}
+          serviceAccount: vdc-sa@@project@.iam.gserviceaccount.com
+          machineType: n1-standard-8
+          oauthScopes: ['https://www.googleapis.com/auth/devstorage.read_only', 'https://www.googleapis.com/auth/logging.write',
+            'https://www.googleapis.com/auth/monitoring', 'https://www.googleapis.com/auth/servicecontrol',
+            'https://www.googleapis.com/auth/service.management.readonly', 'https://www.googleapis.com/auth/trace.append']
+          preemptible: false
+        initialNodeCount: 1
+        management: {autoRepair: true}
+        name: non-preemptible-pool
+        version: 1.10.7-gke.6
       privateClusterConfig: {}
       subnetwork: projects/@project@/regions/@region@/subnetworks/default


### PR DESCRIPTION
@tpoterba @jbloom22 a few more things to fix for the workshop. I was using a too powerful kubernetes command to look up worker pods and services for the admin page. I now use a restricted form of it that is permitted by our security policy.

We also are missing the non-preemptible node pool (!), so this adds that to our gcp-config.

cc: @cseed 