### PR TITLE
[notebook] Make notebook deletion reliable

### DIFF
--- a/notebook/notebook/templates/workers.html
+++ b/notebook/notebook/templates/workers.html
@@ -29,7 +29,7 @@
             <td>{{ w[0].status.start_time }}</td>
             <td>{{ w[1].metadata.name }}</td>
             <td>{{ w[0].metadata.labels.get("hail.is/notebook-instance") }}</td>
-            <td><a href="{{ workers_url }}/{{ w[0].metadata.name }}/delete">delete</a></td>
+            <td><a href="{{ workers_url }}/{{ w[0].metadata.name }}/{{w[1].metadata.name}}/delete">delete</a></td>
           </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
 - two network requests instead of four now that we know the name of both the service name and pod name
 - use try-catch to avoid 500ing if a user hits `GET /new` and their service or pod is already gone (for whatever reason)