### PR TITLE
remove missingGreatest argument from orderings

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/ExtendedOrdering.scala
+++ b/hail/src/main/scala/is/hail/annotations/ExtendedOrdering.scala
@@ -6,52 +6,52 @@ import org.apache.spark.sql.Row
 object ExtendedOrdering {
   def extendToNull[S](ord: Ordering[S]): ExtendedOrdering = {
     new ExtendedOrdering {
-      def compareNonnull(x: T, y: T, missingGreatest: Boolean): Int = ord.compare(x.asInstanceOf[S], y.asInstanceOf[S])
+      def compareNonnull(x: T, y: T): Int = ord.compare(x.asInstanceOf[S], y.asInstanceOf[S])
 
-      override def ltNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = ord.lt(x.asInstanceOf[S], y.asInstanceOf[S])
+      override def ltNonnull(x: T, y: T): Boolean = ord.lt(x.asInstanceOf[S], y.asInstanceOf[S])
 
-      override def lteqNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = ord.lteq(x.asInstanceOf[S], y.asInstanceOf[S])
+      override def lteqNonnull(x: T, y: T): Boolean = ord.lteq(x.asInstanceOf[S], y.asInstanceOf[S])
 
-      override def gtNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = ord.gt(x.asInstanceOf[S], y.asInstanceOf[S])
+      override def gtNonnull(x: T, y: T): Boolean = ord.gt(x.asInstanceOf[S], y.asInstanceOf[S])
 
-      override def gteqNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = ord.gteq(x.asInstanceOf[S], y.asInstanceOf[S])
+      override def gteqNonnull(x: T, y: T): Boolean = ord.gteq(x.asInstanceOf[S], y.asInstanceOf[S])
 
-      override def equivNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = ord.equiv(x.asInstanceOf[S], y.asInstanceOf[S])
+      override def equivNonnull(x: T, y: T): Boolean = ord.equiv(x.asInstanceOf[S], y.asInstanceOf[S])
 
-      override def minNonnull(x: T, y: T, missingGreatest: Boolean): T = ord.min(x.asInstanceOf[S], y.asInstanceOf[S])
+      override def minNonnull(x: T, y: T): T = ord.min(x.asInstanceOf[S], y.asInstanceOf[S])
 
-      override def maxNonnull(x: T, y: T, missingGreatest: Boolean): T = ord.max(x.asInstanceOf[S], y.asInstanceOf[S])
+      override def maxNonnull(x: T, y: T): T = ord.max(x.asInstanceOf[S], y.asInstanceOf[S])
     }
   }
 
   def extendToNull(ord: ExtendedOrdering): ExtendedOrdering = {
     new ExtendedOrdering {
-      def compareNonnull(x: T, y: T, missingGreatest: Boolean): Int = ord.compare(x, y, missingGreatest)
+      def compareNonnull(x: T, y: T): Int = ord.compare(x, y)
 
-      override def ltNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = ord.lt(x, y, missingGreatest)
+      override def ltNonnull(x: T, y: T): Boolean = ord.lt(x, y)
 
-      override def lteqNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = ord.lteq(x, y, missingGreatest)
+      override def lteqNonnull(x: T, y: T): Boolean = ord.lteq(x, y)
 
-      override def gtNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = ord.gt(x, y, missingGreatest)
+      override def gtNonnull(x: T, y: T): Boolean = ord.gt(x, y)
 
-      override def gteqNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = ord.gteq(x, y, missingGreatest)
+      override def gteqNonnull(x: T, y: T): Boolean = ord.gteq(x, y)
 
-      override def equivNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = ord.equiv(x, y, missingGreatest)
+      override def equivNonnull(x: T, y: T): Boolean = ord.equiv(x, y)
 
-      override def minNonnull(x: T, y: T, missingGreatest: Boolean): T = ord.min(x, y, missingGreatest)
+      override def minNonnull(x: T, y: T): T = ord.min(x, y)
 
-      override def maxNonnull(x: T, y: T, missingGreatest: Boolean): T = ord.max(x, y, missingGreatest)
+      override def maxNonnull(x: T, y: T): T = ord.max(x, y)
     }
   }
 
   def iterableOrdering[T](ord: ExtendedOrdering): ExtendedOrdering =
     new ExtendedOrdering {
-      def compareNonnull(x: T, y: T, missingGreatest: Boolean): Int = {
+      def compareNonnull(x: T, y: T): Int = {
         val xit = x.asInstanceOf[Iterable[T]].iterator
         val yit = y.asInstanceOf[Iterable[T]].iterator
 
         while (xit.hasNext && yit.hasNext) {
-          val c = ord.compare(xit.next(), yit.next(), missingGreatest)
+          val c = ord.compare(xit.next(), yit.next())
           if (c != 0)
             return c
         }
@@ -64,11 +64,11 @@ object ExtendedOrdering {
     new ExtendedOrdering {
       private val itOrd = iterableOrdering(ord)
       
-      def compareNonnull(x: T, y: T, missingGreatest: Boolean): Int = {
+      def compareNonnull(x: T, y: T): Int = {
         val ax = x.asInstanceOf[Array[T]]
         val ay = y.asInstanceOf[Array[T]]
         val scalaOrd = ord.toOrdering
-        itOrd.compareNonnull(ax.sorted(scalaOrd).toFastIndexedSeq, ay.sorted(scalaOrd).toFastIndexedSeq, missingGreatest)
+        itOrd.compareNonnull(ax.sorted(scalaOrd).toFastIndexedSeq, ay.sorted(scalaOrd).toFastIndexedSeq)
       }
     }
 
@@ -76,10 +76,10 @@ object ExtendedOrdering {
     new ExtendedOrdering {
       private val saOrd = sortArrayOrdering(ord)
 
-      def compareNonnull(x: T, y: T, missingGreatest: Boolean): Int = {
+      def compareNonnull(x: T, y: T): Int = {
         val ix = x.asInstanceOf[Iterable[T]]
         val iy = y.asInstanceOf[Iterable[T]]
-        saOrd.compareNonnull(ix.toArray, iy.toArray, missingGreatest)
+        saOrd.compareNonnull(ix.toArray, iy.toArray)
       }
     }
 
@@ -87,27 +87,26 @@ object ExtendedOrdering {
     new ExtendedOrdering {
       private val saOrd = sortArrayOrdering(ord)
 
-      def compareNonnull(x: T, y: T, missingGreatest: Boolean): Int = {
+      def compareNonnull(x: T, y: T): Int = {
         val mx = x.asInstanceOf[Map[T, T]]
         val my = y.asInstanceOf[Map[T, T]]
         
         saOrd.compareNonnull(
           mx.toArray.map { case (k, v) => Row(k, v): T },
-          my.toArray.map { case (k, v) => Row(k, v): T },
-          missingGreatest)
+          my.toArray.map { case (k, v) => Row(k, v): T })
       }
     }
 
   def rowOrdering(fieldOrd: Array[ExtendedOrdering]): ExtendedOrdering =
     new ExtendedOrdering { outer =>
-      override def compareNonnull(x: T, y: T, missingGreatest: Boolean): Int = {
+      override def compareNonnull(x: T, y: T): Int = {
         val rx = x.asInstanceOf[Row]
         val ry = y.asInstanceOf[Row]
 
         val commonPrefix = math.min(fieldOrd.length, math.min(rx.length, ry.length))
         var i = 0
         while (i < commonPrefix) {
-          val c = fieldOrd(i).compare(rx.get(i), ry.get(i), missingGreatest)
+          val c = fieldOrd(i).compare(rx.get(i), ry.get(i))
           if (c != 0)
             return c
           i += 1
@@ -118,12 +117,12 @@ object ExtendedOrdering {
       }
 
       override lazy val intervalEndpointOrdering = new IntervalEndpointOrdering {
-        override def compareIntervalEndpoints(xp: Any, xs: Int, yp: Any, ys: Int, missingGreatest: Boolean): Int = {
+        override def compareIntervalEndpoints(xp: Any, xs: Int, yp: Any, ys: Int): Int = {
           val xpp = xp.asInstanceOf[Row]
           val ypp = yp.asInstanceOf[Row]
           val l = fieldOrd.length
 
-          val c = outer.compare(xpp, ypp, missingGreatest)
+          val c = outer.compare(xpp, ypp)
           if (c != 0 || xpp == null || ypp == null || (l < xpp.length && l < ypp.length))
             c
           else {
@@ -137,7 +136,7 @@ object ExtendedOrdering {
         // Returns true if for any rows r1 and r2 with r1 < x and r2 > y,
         // the length of the largest common prefix of r1 and r2 is less than
         // or equal to 'allowedOverlap'
-        override def lteqWithOverlap(allowedOverlap: Int, missingGreatest: Boolean = true)(x: IntervalEndpoint, y: IntervalEndpoint): Boolean = {
+        override def lteqWithOverlap(allowedOverlap: Int)(x: IntervalEndpoint, y: IntervalEndpoint): Boolean = {
           require(allowedOverlap <= fieldOrd.length)
           val xp = x
           val yp = y
@@ -148,7 +147,7 @@ object ExtendedOrdering {
           val prefix = Seq(l, xpp.length, ypp.length, allowedOverlap + 1).min
           var i = 0
           while (i < prefix) {
-            val c = fieldOrd(i).compare(xpp.get(i), ypp.get(i), missingGreatest)
+            val c = fieldOrd(i).compare(xpp.get(i), ypp.get(i))
             if (c != 0)
               return c < 0
             i += 1
@@ -174,102 +173,99 @@ abstract class ExtendedOrdering extends Serializable {
 
   type T = Any
 
-  def compareNonnull(x: T, y: T, missingGreatest: Boolean): Int
+  def compareNonnull(x: T, y: T): Int
 
-  def ltNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = compareNonnull(x, y, missingGreatest) < 0
+  def ltNonnull(x: T, y: T): Boolean = compareNonnull(x, y) < 0
 
-  def lteqNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = compareNonnull(x, y, missingGreatest) <= 0
+  def lteqNonnull(x: T, y: T): Boolean  = compareNonnull(x, y) <= 0
 
-  def gtNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = compareNonnull(x, y, missingGreatest) > 0
+  def gtNonnull(x: T, y: T): Boolean = compareNonnull(x, y) > 0
 
-  def gteqNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = compareNonnull(x, y, missingGreatest) >= 0
+  def gteqNonnull(x: T, y: T): Boolean = compareNonnull(x, y) >= 0
 
-  def equivNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = compareNonnull(x, y, missingGreatest) == 0
+  def equivNonnull(x: T, y: T): Boolean = compareNonnull(x, y) == 0
 
-  def minNonnull(x: T, y: T, missingGreatest: Boolean): T = {
-    if (ltNonnull(x, y, missingGreatest))
+  def minNonnull(x: T, y: T): T = {
+    if (ltNonnull(x, y))
       x
     else
       y
   }
 
-  def maxNonnull(x: T, y: T, missingGreatest: Boolean): T = {
-    if (gtNonnull(x, y, missingGreatest))
+  def maxNonnull(x: T, y: T): T = {
+    if (gtNonnull(x, y))
       x
     else
       y
   }
 
-  def compare(x: T, y: T, missingGreatest: Boolean): Int = {
+  def compare(x: T, y: T): Int = {
     if (y == null) {
       if (x == null)
         0
-      else if (missingGreatest) -1 else 1
+      else -1
     } else {
       if (x == null)
-        if (missingGreatest) 1 else -1
+        1
       else
-        compareNonnull(x, y, missingGreatest)
+        compareNonnull(x, y)
     }
   }
 
-  def lt(x: T, y: T, missingGreatest: Boolean): Boolean = {
+  def lt(x: T, y: T): Boolean = {
     if (y == null) {
       if (x == null)
         false
       else
-        missingGreatest
-    } else {
-      if (x == null)
-        !missingGreatest
-      else
-        ltNonnull(x, y, missingGreatest)
-    }
-  }
-
-  def lteq(x: T, y: T, missingGreatest: Boolean): Boolean = {
-    if (y == null) {
-      if (x == null)
         true
-      else
-        missingGreatest
     } else {
-      if (x == null)
-        !missingGreatest
-      else
-        lteqNonnull(x, y, missingGreatest)
-    }
-  }
-
-  def gt(x: T, y: T, missingGreatest: Boolean): Boolean = {
-    if (y == null) {
       if (x == null)
         false
       else
-        !missingGreatest
-    } else {
-      if (x == null)
-        missingGreatest
-      else
-        gtNonnull(x, y, missingGreatest)
+        ltNonnull(x, y)
     }
   }
 
-  def gteq(x: T, y: T, missingGreatest: Boolean): Boolean = {
+  def lteq(x: T, y: T): Boolean = {
     if (y == null) {
       if (x == null)
         true
       else
-        !missingGreatest
+        true
     } else {
       if (x == null)
-        missingGreatest
+        false
       else
-        gteqNonnull(x, y, missingGreatest)
+        lteqNonnull(x, y)
     }
   }
 
-  def equiv(x: T, y: T, missingGreatest: Boolean): Boolean = {
+  def gt(x: T, y: T): Boolean = {
+    if (y == null)
+      false
+    else {
+      if (x == null)
+        true
+      else
+        gtNonnull(x, y)
+    }
+  }
+
+  def gteq(x: T, y: T): Boolean = {
+    if (y == null) {
+      if (x == null)
+        true
+      else
+        false
+    } else {
+      if (x == null)
+        true
+      else
+        gteqNonnull(x, y)
+    }
+  }
+
+  def equiv(x: T, y: T): Boolean = {
     if (y == null) {
       if (x == null)
         true
@@ -279,67 +275,51 @@ abstract class ExtendedOrdering extends Serializable {
       if (x == null)
         false
       else
-        equivNonnull(x, y, missingGreatest)
+        equivNonnull(x, y)
     }
   }
 
-  def min(x: T, y: T, missingGreatest: Boolean): T = {
+  def min(x: T, y: T): T = {
     if (y == null) {
-      if (missingGreatest) x else y
+      x
     } else {
       if (x == null)
-        if (missingGreatest) y else x
+        y
       else
-        minNonnull(x, y, missingGreatest)
+        minNonnull(x, y)
     }
   }
 
-  def max(x: T, y: T, missingGreatest: Boolean): T = {
+  def max(x: T, y: T): T = {
     if (y == null) {
-      if (missingGreatest) y else x
+      y
     } else {
       if (x == null)
-        if (missingGreatest) x else y
+        x
       else
-        maxNonnull(x, y, missingGreatest)
+        maxNonnull(x, y)
     }
   }
-
-  def compare(x: T, y: T): Int = compare(x, y, missingGreatest = true)
-
-  def lt(x: T, y: T): Boolean = lt(x, y, missingGreatest = true)
-
-  def lteq(x: T, y: T): Boolean = lteq(x, y, missingGreatest = true)
-
-  def gt(x: T, y: T): Boolean = gt(x, y, missingGreatest = true)
-
-  def gteq(x: T, y: T): Boolean = gteq(x, y, missingGreatest = true)
-
-  def equiv(x: T, y: T): Boolean = equiv(x, y, missingGreatest = true)
-
-  def min(x: T, y: T): T = min(x, y, missingGreatest = true)
-
-  def max(x: T, y: T): T = max(x, y, missingGreatest = true)
 
   // reverses the sense of the non-null comparison only
   def reverse: ExtendedOrdering = new ExtendedOrdering {
     override def reverse: ExtendedOrdering = outer
 
-    def compareNonnull(x: T, y: T, missingGreatest: Boolean): Int = outer.compareNonnull(y, x, missingGreatest)
+    def compareNonnull(x: T, y: T): Int = outer.compareNonnull(y, x)
 
-    override def ltNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = outer.ltNonnull(y, x, missingGreatest)
+    override def ltNonnull(x: T, y: T): Boolean = outer.ltNonnull(y, x)
 
-    override def lteqNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = outer.lteqNonnull(y, x, missingGreatest)
+    override def lteqNonnull(x: T, y: T): Boolean = outer.lteqNonnull(y, x)
 
-    override def gtNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = outer.gtNonnull(y, x, missingGreatest)
+    override def gtNonnull(x: T, y: T): Boolean = outer.gtNonnull(y, x)
 
-    override def gteqNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = outer.gteqNonnull(y, x, missingGreatest)
+    override def gteqNonnull(x: T, y: T): Boolean = outer.gteqNonnull(y, x)
 
-    override def equivNonnull(x: T, y: T, missingGreatest: Boolean): Boolean = outer.equivNonnull(y, x, missingGreatest)
+    override def equivNonnull(x: T, y: T): Boolean = outer.equivNonnull(y, x)
 
-    override def minNonnull(x: T, y: T, missingGreatest: Boolean): T = outer.maxNonnull(x, y, missingGreatest)
+    override def minNonnull(x: T, y: T): T = outer.maxNonnull(x, y)
 
-    override def maxNonnull(x: T, y: T, missingGreatest: Boolean): T = outer.minNonnull(x, y, missingGreatest)
+    override def maxNonnull(x: T, y: T): T = outer.minNonnull(x, y)
   }
 
   def toOrdering: Ordering[T] = new Ordering[T] {
@@ -361,40 +341,40 @@ abstract class ExtendedOrdering extends Serializable {
   }
 
   def toOrdering(missingGreatest: Boolean): Ordering[T] = new Ordering[T] {
-    def compare(x: T, y: T): Int = outer.compare(x, y, missingGreatest)
+    def compare(x: T, y: T): Int = outer.compare(x, y)
 
-    override def lt(x: T, y: T): Boolean = outer.lt(x, y, missingGreatest)
+    override def lt(x: T, y: T): Boolean = outer.lt(x, y)
 
-    override def lteq(x: T, y: T): Boolean = outer.lteq(x, y, missingGreatest)
+    override def lteq(x: T, y: T): Boolean = outer.lteq(x, y)
 
-    override def gt(x: T, y: T): Boolean = outer.gt(x, y, missingGreatest)
+    override def gt(x: T, y: T): Boolean = outer.gt(x, y)
 
-    override def gteq(x: T, y: T): Boolean = outer.gteq(x, y, missingGreatest)
+    override def gteq(x: T, y: T): Boolean = outer.gteq(x, y)
 
-    override def equiv(x: T, y: T): Boolean = outer.equiv(x, y, missingGreatest)
+    override def equiv(x: T, y: T): Boolean = outer.equiv(x, y)
 
-    override def min(x: T, y: T): T = outer.min(x, y, missingGreatest)
+    override def min(x: T, y: T): T = outer.min(x, y)
 
-    override def max(x: T, y: T): T = outer.max(x, y, missingGreatest)
+    override def max(x: T, y: T): T = outer.max(x, y)
   }
 
   lazy val intervalEndpointOrdering: IntervalEndpointOrdering =
     new IntervalEndpointOrdering {
-      override def compareIntervalEndpoints(xp: Any, xs: Int, yp: Any, ys: Int, missingGreatest: Boolean): Int = {
-        val c = outer.compare(xp, yp, missingGreatest)
+      override def compareIntervalEndpoints(xp: Any, xs: Int, yp: Any, ys: Int): Int = {
+        val c = outer.compare(xp, yp)
         if (c != 0)
           c
         else
           xs compare ys
       }
 
-      override def lteqWithOverlap(allowedOverlap: Int, missingGreatest: Boolean = true)(x: IntervalEndpoint, y: IntervalEndpoint): Boolean = {
+      override def lteqWithOverlap(allowedOverlap: Int)(x: IntervalEndpoint, y: IntervalEndpoint): Boolean = {
         val xp = x.point
         val xs = x.sign
         val yp = y.point
         val ys = y.sign
 
-        val c = outer.compare(xp, yp, missingGreatest)
+        val c = outer.compare(xp, yp)
         if (c != 0)
           c < 0
         else
@@ -404,15 +384,15 @@ abstract class ExtendedOrdering extends Serializable {
 }
 
 abstract class IntervalEndpointOrdering extends ExtendedOrdering {
-  def compareIntervalEndpoints(xp: Any, xs: Int, yp: Any, ys: Int, missingGreatest: Boolean): Int
+  def compareIntervalEndpoints(xp: Any, xs: Int, yp: Any, ys: Int): Int
 
-  def lteqWithOverlap(allowedOverlap: Int, missingGreatest: Boolean = true)(x: IntervalEndpoint, y: IntervalEndpoint): Boolean
+  def lteqWithOverlap(allowedOverlap: Int)(x: IntervalEndpoint, y: IntervalEndpoint): Boolean
 
-  override def compareNonnull(x: Any, y: Any, missingGreatest: Boolean): Int = {
+  override def compareNonnull(x: Any, y: Any): Int = {
     val xp = if (x.isInstanceOf[IntervalEndpoint]) x.asInstanceOf[IntervalEndpoint].point else x
     val xs = if (x.isInstanceOf[IntervalEndpoint]) x.asInstanceOf[IntervalEndpoint].sign else 0
     val yp = if (y.isInstanceOf[IntervalEndpoint]) y.asInstanceOf[IntervalEndpoint].point else y
     val ys = if (y.isInstanceOf[IntervalEndpoint]) y.asInstanceOf[IntervalEndpoint].sign else 0
-    compareIntervalEndpoints(xp, xs, yp, ys, missingGreatest)
+    compareIntervalEndpoints(xp, xs, yp, ys)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
@@ -26,12 +26,12 @@ class ArraySorter(mb: EmitMethodBuilder, array: StagedArrayBuilder, keyOnly: Boo
           val k1 = mk1l.mux(defaultValue(kt), r1.loadIRIntermediate(kt)(ttype.fieldOffset(v1, 0)))
           val k2 = mk2l.mux(defaultValue(kt), r2.loadIRIntermediate(kt)(ttype.fieldOffset(v2, 0)))
 
-          mb.getCodeOrdering[Boolean](kt, CodeOrdering.equiv, missingGreatest = true)(r1, (mk1, k1), r2, (mk2, k2))
+          mb.getCodeOrdering[Boolean](kt, CodeOrdering.equiv)(r1, (mk1, k1), r2, (mk2, k2))
       }
     }
     ceq
   } else
-      mb.getCodeOrdering[Boolean](typ, CodeOrdering.equiv, missingGreatest = true)
+      mb.getCodeOrdering[Boolean](typ, CodeOrdering.equiv)
 
   def sort(ascending: Code[Boolean]): Code[Unit] = {
 
@@ -56,7 +56,7 @@ class ArraySorter(mb: EmitMethodBuilder, array: StagedArrayBuilder, keyOnly: Boo
 
       val k1 = mk1.mux(defaultValue(kt), sorterRegion.loadIRIntermediate(kt)(ttype.fieldOffset(v1, 0)))
       val k2 = mk2.mux(defaultValue(kt), sorterRegion.loadIRIntermediate(kt)(ttype.fieldOffset(v2, 0)))
-      val cmp = sorter.getCodeOrdering[Int](kt, CodeOrdering.compare, missingGreatest = true, ignoreMissingness = false)
+      val cmp = sorter.getCodeOrdering[Int](kt, CodeOrdering.compare, ignoreMissingness = false)
       sorter.emit(Code(
         mk1 := ttype.isFieldMissing(sorterRegion, v1, 0),
         mk2 := ttype.isFieldMissing(sorterRegion, v2, 0),
@@ -64,7 +64,7 @@ class ArraySorter(mb: EmitMethodBuilder, array: StagedArrayBuilder, keyOnly: Boo
           cmp(sorterRegion, (mk1, k1), sorterRegion, (mk2, k2)) < 0,
           cmp(sorterRegion, (mk1, k1), sorterRegion, (mk2, k2)) > 0)))
     } else {
-      val cmp = sorter.getCodeOrdering[Int](typ, CodeOrdering.compare, missingGreatest = true, ignoreMissingness = true)(
+      val cmp = sorter.getCodeOrdering[Int](typ, CodeOrdering.compare, ignoreMissingness = true)(
         sorterRegion, (false, sorter.getArg(1)(ti)),
         sorterRegion, (false, sorter.getArg(2)(ti)))
       sorter.emit(asc.mux(cmp < 0, cmp > 0))

--- a/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
@@ -26,7 +26,7 @@ class BinarySearch(mb: EmitMethodBuilder, typ: PContainer, keyOnly: Boolean) {
       (m2: Code[Boolean], v2: Code[Long] @unchecked)) =>
         val mk2 = Code(mk2l := m2 || ttype.isFieldMissing(r2, v2, 0), mk2l)
         val k2 = mk2l.mux(defaultValue(kt), r2.loadIRIntermediate(kt)(ttype.fieldOffset(v2, 0)))
-        findMB.getCodeOrdering[Int](kt, CodeOrdering.compare, missingGreatest = true)(r1, (mk1, k1), r2, (mk2, k2))
+        findMB.getCodeOrdering[Int](kt, CodeOrdering.compare)(r1, (mk1, k1), r2, (mk2, k2))
     }
     val ceq: CodeOrdering.F[Boolean] = {
       case (r1: Code[Region],
@@ -35,12 +35,12 @@ class BinarySearch(mb: EmitMethodBuilder, typ: PContainer, keyOnly: Boolean) {
       (m2: Code[Boolean], v2: Code[Long] @unchecked)) =>
         val mk2 = Code(mk2l1 := m2 || ttype.isFieldMissing(r2, v2, 0), mk2l1)
         val k2 = mk2l1.mux(defaultValue(kt), r2.loadIRIntermediate(kt)(ttype.fieldOffset(v2, 0)))
-        mb.getCodeOrdering[Boolean](kt, CodeOrdering.equiv, missingGreatest = true)(r1, (mk1, k1), r2, (mk2, k2))
+        mb.getCodeOrdering[Boolean](kt, CodeOrdering.equiv)(r1, (mk1, k1), r2, (mk2, k2))
     }
     (comp, ceq, findMB, kt)
   } else
-    (mb.getCodeOrdering[Int](elt, CodeOrdering.compare, missingGreatest = true),
-      mb.getCodeOrdering[Boolean](elt, CodeOrdering.equiv, missingGreatest = true),
+    (mb.getCodeOrdering[Int](elt, CodeOrdering.compare),
+      mb.getCodeOrdering[Boolean](elt, CodeOrdering.equiv),
       mb.fb.newMethod(Array[TypeInfo[_]](typeInfo[Region], typeInfo[Long], typeInfo[Boolean], typeToTypeInfo(elt)), typeInfo[Int]), elt)
 
   private[this] val region = findElt.getArg[Region](1).load()

--- a/hail/src/main/scala/is/hail/expr/ir/ComparisonOp.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ComparisonOp.scala
@@ -40,7 +40,7 @@ sealed trait ComparisonOp {
   def op: CodeOrdering.Op
   val strict: Boolean = true
   def codeOrdering(mb: EmitMethodBuilder): CodeOrdering.F[Boolean] = {
-    mb.getCodeOrdering[Boolean](t1.physicalType, t2.physicalType, op, missingGreatest = true)
+    mb.getCodeOrdering[Boolean](t1.physicalType, t2.physicalType, op)
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -70,17 +70,17 @@ class EmitMethodBuilder(
 
   def getPType(t: PType): Code[PType] = fb.getPType(t)
 
-  def getCodeOrdering[T](t: PType, op: CodeOrdering.Op, missingGreatest: Boolean): CodeOrdering.F[T] =
-    getCodeOrdering[T](t, op, missingGreatest, ignoreMissingness = false)
+  def getCodeOrdering[T](t: PType, op: CodeOrdering.Op): CodeOrdering.F[T] =
+    getCodeOrdering[T](t, op, ignoreMissingness = false)
 
-  def getCodeOrdering[T](t: PType, op: CodeOrdering.Op, missingGreatest: Boolean, ignoreMissingness: Boolean): CodeOrdering.F[T] =
-    fb.getCodeOrdering[T](t, op, missingGreatest, ignoreMissingness)
+  def getCodeOrdering[T](t: PType, op: CodeOrdering.Op, ignoreMissingness: Boolean): CodeOrdering.F[T] =
+    fb.getCodeOrdering[T](t, op, ignoreMissingness)
 
-  def getCodeOrdering[T](t1: PType, t2: PType, op: CodeOrdering.Op, missingGreatest: Boolean): CodeOrdering.F[T] =
-    fb.getCodeOrdering[T](t1, t2, op, missingGreatest, ignoreMissingness = false)
+  def getCodeOrdering[T](t1: PType, t2: PType, op: CodeOrdering.Op): CodeOrdering.F[T] =
+    fb.getCodeOrdering[T](t1, t2, op, ignoreMissingness = false)
 
-  def getCodeOrdering[T](t1: PType, t2: PType, op: CodeOrdering.Op, missingGreatest: Boolean, ignoreMissingness: Boolean): CodeOrdering.F[T] =
-    fb.getCodeOrdering[T](t1, t2, op, missingGreatest, ignoreMissingness)
+  def getCodeOrdering[T](t1: PType, t2: PType, op: CodeOrdering.Op, ignoreMissingness: Boolean): CodeOrdering.F[T] =
+    fb.getCodeOrdering[T](t1, t2, op, ignoreMissingness)
 
   def newRNG(seed: Long): Code[IRRandomness] = fb.newRNG(seed)
 }
@@ -128,8 +128,8 @@ class EmitFunctionBuilder[F >: Null](
 
   private[this] val pTypeMap: mutable.Map[PType, Code[PType]] = mutable.Map[PType, Code[PType]]()
 
-  private[this] val compareMap: mutable.Map[(PType, PType, CodeOrdering.Op, Boolean, Boolean), CodeOrdering.F[_]] =
-    mutable.Map[(PType, PType, CodeOrdering.Op, Boolean, Boolean), CodeOrdering.F[_]]()
+  private[this] val compareMap: mutable.Map[(PType, PType, CodeOrdering.Op, Boolean), CodeOrdering.F[_]] =
+    mutable.Map[(PType, PType, CodeOrdering.Op, Boolean), CodeOrdering.F[_]]()
 
   def numReferenceGenomes: Int = rgMap.size
 
@@ -184,8 +184,8 @@ class EmitFunctionBuilder[F >: Null](
       newLazyField[Type](setup))
   }
 
-  def getCodeOrdering[T](t1: PType, t2: PType, op: CodeOrdering.Op, missingGreatest: Boolean, ignoreMissingness: Boolean): CodeOrdering.F[T] = {
-    val f = compareMap.getOrElseUpdate((t1, t2, op, missingGreatest, ignoreMissingness), {
+  def getCodeOrdering[T](t1: PType, t2: PType, op: CodeOrdering.Op, ignoreMissingness: Boolean): CodeOrdering.F[T] = {
+    val f = compareMap.getOrElseUpdate((t1, t2, op, ignoreMissingness), {
       val ti = typeToTypeInfo(t1)
       val rt = if (op == CodeOrdering.compare) typeInfo[Int] else typeInfo[Boolean]
 
@@ -197,13 +197,13 @@ class EmitFunctionBuilder[F >: Null](
         val v1 = newMB.getArg(2)(ti)
         val v2 = newMB.getArg(4)(ti)
         val c: Code[_] = op match {
-          case CodeOrdering.compare => ord.compareNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2), missingGreatest)
-          case CodeOrdering.equiv => ord.equivNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2), missingGreatest)
-          case CodeOrdering.lt => ord.ltNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2), missingGreatest)
-          case CodeOrdering.lteq => ord.lteqNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2), missingGreatest)
-          case CodeOrdering.gt => ord.gtNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2), missingGreatest)
-          case CodeOrdering.gteq => ord.gteqNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2), missingGreatest)
-          case CodeOrdering.neq => !ord.equivNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2), missingGreatest)
+          case CodeOrdering.compare => ord.compareNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2))
+          case CodeOrdering.equiv => ord.equivNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2))
+          case CodeOrdering.lt => ord.ltNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2))
+          case CodeOrdering.lteq => ord.lteqNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2))
+          case CodeOrdering.gt => ord.gtNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2))
+          case CodeOrdering.gteq => ord.gteqNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2))
+          case CodeOrdering.neq => !ord.equivNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2))
         }
         newMB.emit(c)
         newMB
@@ -217,13 +217,13 @@ class EmitFunctionBuilder[F >: Null](
         val m2 = newMB.getArg[Boolean](5)
         val v2 = newMB.getArg(6)(ti)
         val c: Code[_] = op match {
-          case CodeOrdering.compare => ord.compare(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)), missingGreatest)
-          case CodeOrdering.equiv => ord.equiv(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)), missingGreatest)
-          case CodeOrdering.lt => ord.lt(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)), missingGreatest)
-          case CodeOrdering.lteq => ord.lteq(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)), missingGreatest)
-          case CodeOrdering.gt => ord.gt(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)), missingGreatest)
-          case CodeOrdering.gteq => ord.gteq(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)), missingGreatest)
-          case CodeOrdering.neq => !ord.equiv(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)), missingGreatest)
+          case CodeOrdering.compare => ord.compare(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)))
+          case CodeOrdering.equiv => ord.equiv(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)))
+          case CodeOrdering.lt => ord.lt(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)))
+          case CodeOrdering.lteq => ord.lteq(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)))
+          case CodeOrdering.gt => ord.gt(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)))
+          case CodeOrdering.gteq => ord.gteq(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)))
+          case CodeOrdering.neq => !ord.equiv(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)))
         }
         newMB.emit(c)
         newMB
@@ -239,8 +239,8 @@ class EmitFunctionBuilder[F >: Null](
     (r1: Code[Region], v1: (Code[Boolean], Code[_]), r2: Code[Region], v2: (Code[Boolean], Code[_])) => coerce[T](f(r1, v1, r2, v2))
   }
 
-  def getCodeOrdering[T](t: PType, op: CodeOrdering.Op, missingGreatest: Boolean, ignoreMissingness: Boolean): CodeOrdering.F[T] =
-    getCodeOrdering[T](t, t, op, missingGreatest, ignoreMissingness)
+  def getCodeOrdering[T](t: PType, op: CodeOrdering.Op, ignoreMissingness: Boolean): CodeOrdering.F[T] =
+    getCodeOrdering[T](t, t, op, ignoreMissingness)
 
   override val apply_method: EmitMethodBuilder = {
     val m = new EmitMethodBuilder(this, "apply", parameterTypeInfo.map(_.base), returnTypeInfo.base)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
@@ -133,7 +133,7 @@ class IRInterval(mb: EmitMethodBuilder, typ: PInterval, value: Code[Long]) {
   val region: Code[Region] = IntervalFunctions.getRegion(mb)
 
   def ordering[T](op: CodeOrdering.Op): ((Code[Boolean], Code[_]), (Code[Boolean], Code[_])) => Code[T] =
-    mb.getCodeOrdering[T](typ.pointType, op, missingGreatest = true)(region, _, region, _)
+    mb.getCodeOrdering[T](typ.pointType, op)(region, _, region, _)
 
   def storeToLocal: Code[Unit] = ref := value
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/ComplexPType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/ComplexPType.scala
@@ -9,7 +9,7 @@ abstract class ComplexPType extends PType {
 
   override def alignment: Long = representation.alignment
 
-  override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering = representation.unsafeOrdering(missingGreatest)
+  override def unsafeOrdering(): UnsafeOrdering = representation.unsafeOrdering()
 
   override def fundamentalType: PType = representation.fundamentalType
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -87,15 +87,15 @@ abstract class PBaseStruct extends PType {
 
   override def scalaClassTag: ClassTag[Row] = classTag[Row]
 
-  override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering =
-    unsafeOrdering(this, missingGreatest)
+  override def unsafeOrdering(): UnsafeOrdering =
+    unsafeOrdering(this)
 
-  override def unsafeOrdering(rightType: PType, missingGreatest: Boolean): UnsafeOrdering = {
+  override def unsafeOrdering(rightType: PType): UnsafeOrdering = {
     require(this.isOfType(rightType))
 
     val right = rightType.asInstanceOf[PBaseStruct]
     val fieldOrderings: Array[UnsafeOrdering] =
-      types.zip(right.types).map { case (l, r) => l.unsafeOrdering(r, missingGreatest)}
+      types.zip(right.types).map { case (l, r) => l.unsafeOrdering(r)}
 
     new UnsafeOrdering {
       def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
@@ -110,10 +110,7 @@ abstract class PBaseStruct extends PType {
               return c
           } else if (leftDefined != rightDefined) {
             val c = if (leftDefined) -1 else 1
-            if (missingGreatest)
-              return c
-            else
-              return -c
+            return c
           }
           i += 1
         }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBinary.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBinary.scala
@@ -50,7 +50,7 @@ class PBinary(override val required: Boolean) extends PType {
     new CodeOrdering {
       type T = Long
 
-      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] = {
+      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Int] = {
         val l1 = mb.newLocal[Int]
         val l2 = mb.newLocal[Int]
         val lim = mb.newLocal[Int]

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBinary.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBinary.scala
@@ -22,7 +22,7 @@ class PBinary(override val required: Boolean) extends PType {
 
   override def scalaClassTag: ClassTag[Array[Byte]] = classTag[Array[Byte]]
 
-  override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering = new UnsafeOrdering {
+  override def unsafeOrdering(): UnsafeOrdering = new UnsafeOrdering {
     def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
       val l1 = PBinary.loadLength(r1, o1)
       val l2 = PBinary.loadLength(r2, o2)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBoolean.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBoolean.scala
@@ -21,7 +21,7 @@ class PBoolean(override val required: Boolean) extends PType {
 
   override def scalaClassTag: ClassTag[java.lang.Boolean] = classTag[java.lang.Boolean]
 
-  override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering = new UnsafeOrdering {
+  override def unsafeOrdering(): UnsafeOrdering = new UnsafeOrdering {
     def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
       java.lang.Boolean.compare(r1.loadBoolean(o1), r2.loadBoolean(o2))
     }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBoolean.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBoolean.scala
@@ -32,7 +32,7 @@ class PBoolean(override val required: Boolean) extends PType {
     new CodeOrdering {
       type T = Boolean
 
-      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] =
+      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Int] =
         Code.invokeStatic[java.lang.Boolean, Boolean, Boolean, Int]("compare", x, y)
     }
   }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
@@ -183,16 +183,15 @@ abstract class PContainer extends PType {
     )
   }
 
-  override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering =
-    unsafeOrdering(this, missingGreatest)
+  override def unsafeOrdering(): UnsafeOrdering =
+    unsafeOrdering(this)
 
-  override def unsafeOrdering(rightType: PType, missingGreatest: Boolean): UnsafeOrdering = {
+  override def unsafeOrdering(rightType: PType): UnsafeOrdering = {
     require(this.isOfType(rightType))
 
     val right = rightType.asInstanceOf[PContainer]
     val eltOrd = elementType.unsafeOrdering(
-      right.elementType,
-      missingGreatest)
+      right.elementType)
 
     new UnsafeOrdering {
       override def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
@@ -212,10 +211,7 @@ abstract class PContainer extends PType {
               return c
           } else if (leftDefined != rightDefined) {
             val c = if (leftDefined) -1 else 1
-            if (missingGreatest)
-              return c
-            else
-              return -c
+            return c
           }
           i += 1
         }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PFloat32.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PFloat32.scala
@@ -24,7 +24,7 @@ class PFloat32(override val required: Boolean) extends PNumeric {
 
   override def scalaClassTag: ClassTag[java.lang.Float] = classTag[java.lang.Float]
 
-  override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering = new UnsafeOrdering {
+  override def unsafeOrdering(): UnsafeOrdering = new UnsafeOrdering {
     def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
       java.lang.Float.compare(r1.loadFloat(o1), r2.loadFloat(o2))
     }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PFloat32.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PFloat32.scala
@@ -35,22 +35,22 @@ class PFloat32(override val required: Boolean) extends PNumeric {
     new CodeOrdering {
       type T = Float
 
-      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] =
+      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Int] =
         Code.invokeStatic[java.lang.Float, Float, Float, Int]("compare", x, y)
 
-      override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x < y
 
-      override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x <= y
 
-      override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x > y
 
-      override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x >= y
 
-      override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x.ceq(y)
     }
   }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PFloat64.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PFloat64.scala
@@ -24,7 +24,7 @@ class PFloat64(override val required: Boolean) extends PNumeric {
 
   override def scalaClassTag: ClassTag[java.lang.Double] = classTag[java.lang.Double]
 
-  override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering = new UnsafeOrdering {
+  override def unsafeOrdering(): UnsafeOrdering = new UnsafeOrdering {
     def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
       java.lang.Double.compare(r1.loadDouble(o1), r2.loadDouble(o2))
     }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PFloat64.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PFloat64.scala
@@ -35,22 +35,22 @@ class PFloat64(override val required: Boolean) extends PNumeric {
     new CodeOrdering {
       type T = Double
 
-      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] =
+      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Int] =
         Code.invokeStatic[java.lang.Double, Double, Double, Int]("compare", x, y)
 
-      override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x < y
 
-      override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x <= y
 
-      override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x > y
 
-      override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x >= y
 
-      override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x.ceq(y)
     }
   }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PInt32.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PInt32.scala
@@ -34,22 +34,22 @@ class PInt32(override val required: Boolean) extends PIntegral {
     new CodeOrdering {
       type T = Int
 
-      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] =
+      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Int] =
         Code.invokeStatic[java.lang.Integer, Int, Int, Int]("compare", x, y)
 
-      override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x < y
 
-      override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x <= y
 
-      override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x > y
 
-      override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x >= y
 
-      override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x.ceq(y)
     }
   }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PInt32.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PInt32.scala
@@ -23,7 +23,7 @@ class PInt32(override val required: Boolean) extends PIntegral {
 
   override def scalaClassTag: ClassTag[java.lang.Integer] = classTag[java.lang.Integer]
 
-  override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering = new UnsafeOrdering {
+  override def unsafeOrdering(): UnsafeOrdering = new UnsafeOrdering {
     def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
       Integer.compare(r1.loadInt(o1), r2.loadInt(o2))
     }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PInt64.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PInt64.scala
@@ -24,7 +24,7 @@ class PInt64(override val required: Boolean) extends PIntegral {
 
   override def scalaClassTag: ClassTag[java.lang.Long] = classTag[java.lang.Long]
 
-  override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering = new UnsafeOrdering {
+  override def unsafeOrdering(): UnsafeOrdering = new UnsafeOrdering {
     def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
       java.lang.Long.compare(r1.loadLong(o1), r2.loadLong(o2))
     }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PInt64.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PInt64.scala
@@ -35,22 +35,22 @@ class PInt64(override val required: Boolean) extends PIntegral {
     new CodeOrdering {
       type T = Long
 
-      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] =
+      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Int] =
         Code.invokeStatic[java.lang.Long, Long, Long, Int]("compare", x, y)
 
-      override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x < y
 
-      override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x <= y
 
-      override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x > y
 
-      override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x >= y
 
-      override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x.ceq(y)
     }
   }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PInterval.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PInterval.scala
@@ -36,9 +36,9 @@ case class PInterval(pointType: PType, override val required: Boolean = false) e
   }
 
 
-  override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering =
+  override def unsafeOrdering(): UnsafeOrdering =
     new UnsafeOrdering {
-      private val pOrd = pointType.unsafeOrdering(missingGreatest)
+      private val pOrd = pointType.unsafeOrdering()
       def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
         val sdef1 = startDefined(r1, o1)
         if (sdef1 == startDefined(r2, o2)) {
@@ -55,11 +55,11 @@ case class PInterval(pointType: PType, override val required: Boolean = false) e
                     0
                   } else if (includesE1) 1 else -1
                 } else cmp
-              } else if (edef1 == missingGreatest) -1 else 1
+              } else if (edef1) -1 else 1
             } else if (includesS1) -1 else 1
           } else cmp
         } else {
-          if (sdef1 == missingGreatest) -1 else 1
+          if (sdef1) -1 else 1
         }
       }
     }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PLocus.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PLocus.scala
@@ -38,7 +38,7 @@ case class PLocus(rg: RGBase, override val required: Boolean = false) extends Co
   override def scalaClassTag: ClassTag[Locus] = classTag[Locus]
 
   // FIXME: Remove when representation of contig/position is a naturally-ordered Long
-  override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering = {
+  override def unsafeOrdering(): UnsafeOrdering = {
     val repr = representation.fundamentalType
 
     new UnsafeOrdering {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PLocus.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PLocus.scala
@@ -65,7 +65,7 @@ case class PLocus(rg: RGBase, override val required: Boolean = false) extends Co
     new CodeOrdering {
       type T = Long
 
-      override def compareNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long], missingGreatest: Boolean): Code[Int] = {
+      override def compareNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Int] = {
         val cmp = mb.newLocal[Int]
 
         val c1 = representation.loadField(rx, x, 0)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PString.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PString.scala
@@ -25,7 +25,7 @@ class PString(override val required: Boolean) extends PType {
 
   override def scalaClassTag: ClassTag[String] = classTag[String]
 
-  override def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering = PBinary(required).unsafeOrdering(missingGreatest)
+  override def unsafeOrdering(): UnsafeOrdering = PBinary(required).unsafeOrdering()
 
   override def byteSize: Long = 8
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
@@ -133,16 +133,12 @@ abstract class PType extends BaseType with Serializable {
 
   def subst(): PType = this.setRequired(false)
 
-  def unsafeOrdering(missingGreatest: Boolean): UnsafeOrdering = ???
+  def unsafeOrdering(): UnsafeOrdering = ???
 
-  def unsafeOrdering(): UnsafeOrdering = unsafeOrdering(false)
-
-  def unsafeOrdering(rightType: PType, missingGreatest: Boolean): UnsafeOrdering = {
+  def unsafeOrdering(rightType: PType): UnsafeOrdering = {
     require(this.isOfType(rightType))
-    unsafeOrdering(missingGreatest)
+    unsafeOrdering()
   }
-
-  def unsafeOrdering(rightType: PType): UnsafeOrdering = unsafeOrdering(rightType, false)
 
   def unsafeInsert(typeToInsert: PType, path: List[String]): (PType, UnsafeInserter) =
     PStruct.empty().unsafeInsert(typeToInsert, path)

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TInt32.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TInt32.scala
@@ -35,22 +35,22 @@ class TInt32(override val required: Boolean) extends TIntegral {
     new CodeOrdering {
       type T = Int
 
-      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Int] =
+      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Int] =
         Code.invokeStatic[java.lang.Integer, Int, Int, Int]("compare", x, y)
 
-      override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x < y
 
-      override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x <= y
 
-      override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x > y
 
-      override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x >= y
 
-      override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T], missingGreatest: Boolean): Code[Boolean] =
+      override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
         x.ceq(y)
     }
   }

--- a/hail/src/main/scala/is/hail/rvd/RVDType.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDType.scala
@@ -28,7 +28,7 @@ final case class RVDType(rowType: PStruct, key: IndexedSeq[String] = FastIndexed
     .filter(i => !keySet.contains(rowType.fields(i).name))
     .toArray
 
-  val kOrd: UnsafeOrdering = kType.unsafeOrdering(missingGreatest = true)
+  val kOrd: UnsafeOrdering = kType.unsafeOrdering()
   val kInRowOrd: UnsafeOrdering =
     RVDType.selectUnsafeOrdering(rowType, kFieldIdx, rowType, kFieldIdx)
   val kRowOrd: UnsafeOrdering =
@@ -144,7 +144,7 @@ object RVDType {
 
     val nFields = fields1.length
     val fieldOrderings = Range(0, nFields).map { i =>
-      t1.types(fields1(i)).unsafeOrdering(t2.types(fields2(i)), missingGreatest = true)
+      t1.types(fields1(i)).unsafeOrdering(t2.types(fields2(i)))
     }.toArray
 
     new UnsafeOrdering {

--- a/hail/src/main/scala/is/hail/utils/Interval.scala
+++ b/hail/src/main/scala/is/hail/utils/Interval.scala
@@ -184,16 +184,16 @@ object Interval {
       }
 
   def ordering(pord: ExtendedOrdering, startPrimary: Boolean): ExtendedOrdering = new ExtendedOrdering {
-    override def compareNonnull(x: Any, y: Any, missingGreatest: Boolean): Int = {
+    override def compareNonnull(x: Any, y: Any): Int = {
       val xi = x.asInstanceOf[Interval]
       val yi = y.asInstanceOf[Interval]
 
       if (startPrimary) {
-        val c = pord.intervalEndpointOrdering.compare(xi.left, yi.left, missingGreatest)
-        if (c != 0) c else pord.intervalEndpointOrdering.compare(xi.right, yi.right, missingGreatest)
+        val c = pord.intervalEndpointOrdering.compare(xi.left, yi.left)
+        if (c != 0) c else pord.intervalEndpointOrdering.compare(xi.right, yi.right)
       } else {
-        val c = pord.intervalEndpointOrdering.compare(xi.right, yi.right, missingGreatest)
-        if (c != 0) c else pord.intervalEndpointOrdering.compare(xi.left, yi.left, missingGreatest)
+        val c = pord.intervalEndpointOrdering.compare(xi.right, yi.right)
+        if (c != 0) c else pord.intervalEndpointOrdering.compare(xi.left, yi.left)
       }
     }
   }

--- a/hail/src/test/scala/is/hail/annotations/UnsafeSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/UnsafeSuite.scala
@@ -282,10 +282,10 @@ class UnsafeSuite extends SparkSuite {
     val rvb2 = new RegionValueBuilder(region2)
 
     val g = PType.genStruct
-      .flatMap(t => Gen.zip(Gen.const(t), Gen.zip(t.virtualType.genValue, t.virtualType.genValue), arbitrary[Boolean]))
-      .filter { case (t, (a1, a2), b) => a1 != null && a2 != null }
+      .flatMap(t => Gen.zip(Gen.const(t), Gen.zip(t.virtualType.genValue, t.virtualType.genValue)))
+      .filter { case (t, (a1, a2)) => a1 != null && a2 != null }
       .resize(10)
-    val p = Prop.forAll(g) { case (t, (a1, a2), b) =>
+    val p = Prop.forAll(g) { case (t, (a1, a2)) =>
 
       val tv = t.virtualType
 
@@ -309,10 +309,10 @@ class UnsafeSuite extends SparkSuite {
       assert(tv.valuesSimilar(a2, ur2))
 
       val ord = tv.ordering
-      val uord = t.unsafeOrdering(b)
+      val uord = t.unsafeOrdering(missingGreatest = true)
 
-      val c1 = ord.compare(a1, a2, b)
-      val c2 = ord.compare(ur1, ur2, b)
+      val c1 = ord.compare(a1, a2)
+      val c2 = ord.compare(ur1, ur2)
       val c3 = uord.compare(ur1.region, ur1.offset, ur2.region, ur2.offset)
 
       val p1 = math.signum(c1) == math.signum(c2)

--- a/hail/src/test/scala/is/hail/annotations/UnsafeSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/UnsafeSuite.scala
@@ -309,7 +309,7 @@ class UnsafeSuite extends SparkSuite {
       assert(tv.valuesSimilar(a2, ur2))
 
       val ord = tv.ordering
-      val uord = t.unsafeOrdering(missingGreatest = true)
+      val uord = t.unsafeOrdering()
 
       val c1 = ord.compare(a1, a2)
       val c2 = ord.compare(ur1, ur2)


### PR DESCRIPTION
It isn't used anymore.

There were some defaults of missingGreatest = false in PTypes which were worrisome.  Was was unused, but the other was called once in `RVDType.intervalJoinComp`, RVDType.scala:66, computing `pord`.  I think that was a bug.  The comment in that code even says:

 > always considering missing greatest

FYI @patrick-schultz in case I'm missing something.
