### PR TITLE
make sure interpreted and compiled orderings agree

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/CodeOrdering.scala
+++ b/hail/src/main/scala/is/hail/annotations/CodeOrdering.scala
@@ -70,6 +70,24 @@ object CodeOrdering {
       }.foldRight[Code[Boolean]](true) { case ((clteq, ceq), cont) => clteq && (!ceq || cont) }
     }
 
+    override def gtNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Boolean] = {
+      Array.tabulate(t1.size) { i =>
+        val mbgt = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.gt)
+        val mbequiv = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.equiv)
+        (Code(setup(i)(rx, x, ry, y), mbgt(rx, (m1, v1s(i)), ry, (m2, v2s(i)))),
+          mbequiv(rx, (m1, v1s(i)), ry, (m2, v2s(i))))
+      }.foldRight[Code[Boolean]](false) { case ((cgt, ceq), cont) => cgt || (ceq && cont) }
+    }
+
+    override def gteqNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Boolean] = {
+      Array.tabulate(t1.size) { i =>
+        val mbgteq = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.gteq)
+        val mbequiv = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.equiv)
+        (Code(setup(i)(rx, x, ry, y), mbgteq(rx, (m1, v1s(i)), ry, (m2, v2s(i)))),
+          mbequiv(rx, (m1, v1s(i)), ry, (m2, v2s(i))))
+      }.foldRight[Code[Boolean]](true) { case ((cgteq, ceq), cont) => cgteq && (!ceq || cont) }
+    }
+
     override def equivNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Boolean] = {
       Array.tabulate(t1.size) { i =>
         val mbequiv = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.equiv)
@@ -144,6 +162,36 @@ object CodeOrdering {
       Code(lteq := true, eq := true,
         loop(lcmp, eq)(rx, x, ry, y),
         lteq && (!eq || lord.lteqNonnull(rx, coerce[lord.T](len1.load()), ry, coerce[lord.T](len2.load()))))
+    }
+
+    override def gtNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Boolean] = {
+      val mbgt = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.gt)
+      val mbequiv = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.equiv)
+      val gt = mb.newLocal[Boolean]
+      val lcmp = Code(
+        gt := mbgt(rx, (m1, v1), ry, (m2, v2)),
+        eq := !gt && mbequiv(rx, (m1, v1), ry, (m2, v2)))
+
+      Code(gt := false,
+        eq := true,
+        loop(lcmp, eq)(rx, x, ry, y),
+        gt || (eq &&
+            lord.gtNonnull(rx, coerce[lord.T](len1.load()), ry, coerce[lord.T](len2.load()))))
+    }
+
+    override def gteqNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Boolean] = {
+      val mbgteq = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.gteq)
+      val mbequiv = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.equiv)
+
+      val gteq = mb.newLocal[Boolean]
+      val lcmp = Code(
+        gteq := mbgteq(rx, (m1, v1), ry, (m2, v2)),
+        eq := mbequiv(rx, (m1, v1), ry, (m2, v2)))
+
+      Code(gteq := true,
+        eq := true,
+        loop(lcmp, eq)(rx, x, ry, y),
+        gteq && (!eq || lord.gteqNonnull(rx, coerce[lord.T](len1.load()), ry, coerce[lord.T](len2.load()))))
     }
 
     override def equivNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Boolean] = {
@@ -225,11 +273,35 @@ object CodeOrdering {
       val mbeq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.equiv)
 
       Code(loadStart(rx, x, ry, y), mblteq(rx, (mp1, p1), ry, (mp2, p2))) && (
-        !mbeq(rx, (mp1, p1), ry, (mp2, p2)) || (// if not equal, then lt
+        !mbeq(rx, (mp1, p1), ry, (mp2, p2)) || ( // if not equal, then lt
           Code(mp1 := t1.includeStart(rx, x), mp2 := t2.includeStart(ry, y), mp1 && !mp2) || (mp1.ceq(mp2) && (
             Code(loadEnd(rx, x, ry, y), mblteq(rx, (mp1, p1), ry, (mp2, p2))) && (
               !mbeq(rx, (mp1, p1), ry, (mp2, p2)) ||
                 !t1.includeEnd(rx, x) || t2.includeEnd(ry, y))))))
+    }
+
+    override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] = {
+      val mbgt = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.gt)
+      val mbeq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.equiv)
+
+      Code(loadStart(rx, x, ry, y), mbgt(rx, (mp1, p1), ry, (mp2, p2))) || (
+        mbeq(rx, (mp1, p1), ry, (mp2, p2)) && (
+          Code(mp1 := t1.includeStart(rx, x), mp2 := t2.includeStart(ry, y), !mp1 && mp2) || (mp1.ceq(mp2) && (
+            Code(loadEnd(rx, x, ry, y), mbgt(rx, (mp1, p1), ry, (mp2, p2))) || (
+              mbeq(rx, (mp1, p1), ry, (mp2, p2)) &&
+                t1.includeEnd(rx, x) && !t2.includeEnd(ry, y))))))
+    }
+
+    override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] = {
+      val mbgteq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.gteq)
+      val mbeq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.equiv)
+
+      Code(loadStart(rx, x, ry, y), mbgteq(rx, (mp1, p1), ry, (mp2, p2))) && (
+        !mbeq(rx, (mp1, p1), ry, (mp2, p2)) || ( // if not equal, then lt
+          Code(mp1 := t1.includeStart(rx, x), mp2 := t2.includeStart(ry, y), !mp1 && mp2) || (mp1.ceq(mp2) && (
+            Code(loadEnd(rx, x, ry, y), mbgteq(rx, (mp1, p1), ry, (mp2, p2))) && (
+              !mbeq(rx, (mp1, p1), ry, (mp2, p2)) ||
+                t1.includeEnd(rx, x) || !t2.includeEnd(ry, y))))))
     }
   }
 
@@ -256,14 +328,14 @@ abstract class CodeOrdering {
   def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
     compareNonnull(rx, x, ry, y) <= 0
 
-  def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-    compareNonnull(rx, x, ry, y).ceq(0)
-
   def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-    ltNonnull(ry, y, rx, x)
+    compareNonnull(rx, x, ry, y) > 0
 
   def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-    lteqNonnull(ry, y, rx, x)
+    compareNonnull(rx, x, ry, y) >= 0
+
+  def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
+    compareNonnull(rx, x, ry, y).ceq(0)
 
   def compare(rx: Code[Region], x: P, ry: Code[Region], y: P): Code[Int] = {
     val (xm, xv) = x
@@ -289,14 +361,26 @@ abstract class CodeOrdering {
     (xm || ym).mux(compMissing, lteqNonnull(rx, xv, ry, yv))
   }
 
+  def gt(rx: Code[Region], x: P, ry: Code[Region], y: P): Code[Boolean] = {
+    val (xm, xv) = x
+    val (ym, yv) = y
+    val compMissing = (xm && ym).mux(false, xm)
+
+    (xm || ym).mux(compMissing, gtNonnull(rx, xv, ry, yv))
+  }
+
+  def gteq(rx: Code[Region], x: P, ry: Code[Region], y: P): Code[Boolean] = {
+    val (xm, xv) = x
+    val (ym, yv) = y
+    val compMissing = (xm && ym).mux(true, xm)
+
+    (xm || ym).mux(compMissing, gteqNonnull(rx, xv, ry, yv))
+  }
+
   def equiv(rx: Code[Region], x: P, ry: Code[Region], y: P): Code[Boolean] = {
     val (xm, xv) = x
     val (ym, yv) = y
 
     (xm || ym).mux(xm && ym, equivNonnull(rx, xv, ry, yv))
   }
-
-  def gt(rx: Code[Region], x: P, ry: Code[Region], y: P): Code[Boolean] = lt(ry, y, rx, x)
-
-  def gteq(rx: Code[Region], x: P, ry: Code[Region], y: P): Code[Boolean] = lteq(ry, y, rx, x)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -242,8 +242,10 @@ object Interpret {
           null
         else
           op match {
-            case EQ(_, _) | EQWithNA(_, _) => lValue == rValue
-            case NEQ(_, _) | NEQWithNA(_, _) => lValue != rValue
+            case EQ(t, _) => t.ordering.equiv(lValue, rValue)
+            case EQWithNA(t, _) => t.ordering.equiv(lValue, rValue)
+            case NEQ(t, _) => !t.ordering.equiv(lValue, rValue)
+            case NEQWithNA(t, _) => !t.ordering.equiv(lValue, rValue)
             case LT(t, _) => t.ordering.lt(lValue, rValue)
             case GT(t, _) => t.ordering.gt(lValue, rValue)
             case LTEQ(t, _) => t.ordering.lteq(lValue, rValue)

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -399,6 +399,10 @@ object TestUtils {
     assertEvalSame(x, Env.empty, FastIndexedSeq(), None)
   }
 
+  def assertEvalSame(x: IR, args: IndexedSeq[(Any, Type)]) {
+    assertEvalSame(x, Env.empty, args, None)
+  }
+
   def assertEvalSame(x: IR, agg: (IndexedSeq[Row], TStruct)) {
     assertEvalSame(x, Env.empty, FastIndexedSeq(), Some(agg))
   }
@@ -414,13 +418,13 @@ object TestUtils {
     assert(t.typeCheck(i2))
     assert(t.typeCheck(c))
 
-    assert(t.valuesSimilar(i, c))
-    assert(t.valuesSimilar(i2, c))
+    assert(t.valuesSimilar(i, c), s"interpret $i vs compile $c")
+    assert(t.valuesSimilar(i2, c), s"interpret (optimize = false) $i vs compile $c")
 
     try {
       val c2 = nativeExecute(x, env, args, agg)
       assert(t.typeCheck(c2))
-      assert(t.valuesSimilar(c2, c))
+      assert(t.valuesSimilar(c2, c), s"native compile $c2 vs compile $c")
     } catch {
       case _: CXXUnsupportedOperation =>
     }

--- a/hail/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
@@ -88,17 +88,9 @@ class AnnotationsSuite extends SparkSuite {
     assert(ord.gt(null, 7))
     assert(ord.equiv(3, 3))
     assert(ord.equiv(null, null))
-    assert(ord.max(5, 7) == 7)
-    assert(ord.max(5, null) == null)
-    assert(ord.min(5, 7) == 5)
-    assert(ord.min(5, null) == 5)
 
     assert(rord.gt(5, 7))
     assert(rord.lt(5, null))
     assert(rord.gt(null, 7))
-    assert(rord.max(5, 7) == 5)
-    assert(rord.max(5, null) == null)
-    assert(rord.min(5, 7) == 7)
-    assert(rord.min(5, null) == 5)
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1,14 +1,11 @@
 package is.hail.expr.ir
 
 import is.hail.SparkSuite
-import is.hail.expr.types.{virtual, _}
 import is.hail.TestUtils._
-import is.hail.annotations.{Region, RegionValue, RegionValueBuilder, SafeRow}
 import is.hail.asm4s.Code
 import is.hail.expr.ir
 import is.hail.expr.ir.IRSuite.TestFunctions
 import is.hail.expr.ir.functions.{IRFunctionRegistry, RegistryFunctions, SeededIRFunction, SetFunctions}
-import is.hail.expr.types.physical.{PBaseStruct, PInt64, PStruct}
 import is.hail.expr.types.virtual._
 import is.hail.table.{Ascending, Descending, SortField, Table}
 import is.hail.utils._

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -372,6 +372,10 @@ class OrderingSuite extends TestNGSuite {
     }
   }
 
+  // FIXME test Set
+  // FIXME use generator
+  // FIXME add Row test
+  // FIXME add Map test (like row, but with key + value)
   @Test def testOrderingArrayDouble() {
     val xs = Array[java.lang.Double](null, Double.NegativeInfinity, -0.0, 0.0, 1.0, Double.PositiveInfinity, Double.NaN)
 
@@ -382,7 +386,7 @@ class OrderingSuite extends TestNGSuite {
     val t = TArray(TFloat64())
 
     for (a <- as; b <- as) {
-      println("a", a, "b", b)
+      // FIXME all comparisons
       assertEvalSame(ApplyComparisonOp(EQ(t, t), In(0, t), In(1, t)),
         IndexedSeq(a -> t, b -> t))
     }

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -3,8 +3,6 @@ package is.hail.expr.ir
 import is.hail.annotations._
 import is.hail.check.{Gen, Prop}
 import is.hail.asm4s._
-import is.hail.expr.types._
-import is.hail.expr.ir.TestUtils._
 import is.hail.TestUtils._
 import is.hail.expr.types.physical._
 import is.hail.expr.types.virtual._
@@ -20,7 +18,7 @@ class OrderingSuite extends TestNGSuite {
       case ti: TInterval => recursiveSize(ti.pointType)
       case tc: TContainer => recursiveSize(tc.elementType)
       case tbs: TBaseStruct =>
-        tbs.types.map{ t => recursiveSize(t) }.sum
+        tbs.types.map { t => recursiveSize(t) }.sum
       case _ => 0
     }
     inner + 1
@@ -184,7 +182,7 @@ class OrderingSuite extends TestNGSuite {
       telt = TTuple(kt, vt)
       a <- TArray(telt).genNonmissingValue
     } yield (telt, a)
-    val p = Prop.forAll(compareGen) { case (telt: TTuple, a: IndexedSeq[Row] @unchecked) =>
+    val p = Prop.forAll(compareGen) { case (telt: TTuple, a: IndexedSeq[Row]@unchecked) =>
       val array: IndexedSeq[Row] = a ++ a
       val irF = { irs: Seq[IR] => ToDict(irs(0)) }
       val f = getCompiledFunction(irF, TArray(telt), TArray(+telt))
@@ -220,7 +218,7 @@ class OrderingSuite extends TestNGSuite {
   @Test def testSetContainsOnRandomSet() {
     val compareGen = Type.genArb
       .flatMap(t => Gen.zip(Gen.const(TSet(t)), TSet(t).genNonmissingValue, t.genValue))
-    val p = Prop.forAll(compareGen) { case (tset: TSet, set: Set[Any] @unchecked, test1) =>
+    val p = Prop.forAll(compareGen) { case (tset: TSet, set: Set[Any]@unchecked, test1) =>
       val telt = tset.elementType
 
       val ir = { irs: Seq[IR] => invoke("contains", irs(0), irs(1)) }
@@ -248,7 +246,7 @@ class OrderingSuite extends TestNGSuite {
       case (k, v) =>
         Gen.zip(Gen.const(TDict(k, v)), TDict(k, v).genNonmissingValue, k.genNonmissingValue)
     }
-    val p = Prop.forAll(compareGen) { case (tdict: TDict, dict: Map[Any, Any] @unchecked, testKey1) =>
+    val p = Prop.forAll(compareGen) { case (tdict: TDict, dict: Map[Any, Any]@unchecked, testKey1) =>
       assertEvalsTo(invoke("get", In(0, tdict), In(1, -tdict.keyType)),
         IndexedSeq(dict -> tdict,
           testKey1 -> -tdict.keyType),
@@ -338,7 +336,9 @@ class OrderingSuite extends TestNGSuite {
 
         val f = fb.resultWithIndex()(0)
         val closestI = f(region, soff, eoff)
+
         def getKey(i: Int) = asArray(i).asInstanceOf[Row].get(0)
+
         val maybeEqual = getKey(closestI)
 
         val closestIIsClosest =
@@ -358,10 +358,10 @@ class OrderingSuite extends TestNGSuite {
     val set2 = ToSet(MakeArray(Seq(I32(9), I32(1), I32(4)), TArray(TInt32())))
     val ir =
       ArrayFold(ToArray(set1), True(), "accumulator", "setelt",
-      ApplySpecial("&&",
-        FastSeq(
-          Ref("accumulator", TBoolean()),
-          invoke("contains", set2, Ref("setelt", TInt32())))))
+        ApplySpecial("&&",
+          FastSeq(
+            Ref("accumulator", TBoolean()),
+            invoke("contains", set2, Ref("setelt", TInt32())))))
 
     val fb = EmitFunctionBuilder[Region, Boolean]
     Emit(ir, fb)
@@ -369,6 +369,22 @@ class OrderingSuite extends TestNGSuite {
     val f = fb.resultWithIndex()(0)
     Region.scoped { region =>
       assert(f(region))
+    }
+  }
+
+  @Test def testOrderingArrayDouble() {
+    val xs = Array[java.lang.Double](null, Double.NegativeInfinity, -0.0, 0.0, 1.0, Double.PositiveInfinity, Double.NaN)
+
+    val as = Array(null) ++
+      (for (x <- xs) yield IndexedSeq(x)) ++
+      (for (x <- xs; y <- xs) yield IndexedSeq(x, y))
+
+    val t = TArray(TFloat64())
+
+    for (a <- as; b <- as) {
+      println("a", a, "b", b)
+      assertEvalSame(ApplyComparisonOp(EQ(t, t), In(0, t), In(1, t)),
+        IndexedSeq(a -> t, b -> t))
     }
   }
 }


### PR DESCRIPTION
Builds on: https://github.com/hail-is/hail/pull/4869

ExtendedOrdering on rows and containers now matches CodeOrdering by using lt instead of compare in lt, etc.

FYI @tpoterba since this could potentially (e.g. comparing arrays with nans) cause a user-visible change in behavior.
