### PR TITLE
fix blockmatrix sparse sum bug

### DIFF
--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -425,12 +425,18 @@ class Tests(unittest.TestCase):
         nd2[3, 5] = 4.0
         bm2 = BlockMatrix.from_numpy(nd2, block_size=2).sparsify_rectangles([[2, 4, 4, 6]])
 
-        nd3 = np.zeros(shape=(5, 7))
-        bm3 = BlockMatrix.fill(5, 7, value=0.0, block_size=2).sparsify_rectangles([])
+        bm3 = BlockMatrix.from_numpy(nd2, block_size=2).sparsify_rectangles([[2, 4, 4, 6], [0, 5, 0, 1]])
+
+        bm4 = BlockMatrix.from_numpy(nd2, block_size=2).sparsify_rectangles([[2, 4, 4, 6], [0, 1, 0, 7]])
+
+        nd5 = np.zeros(shape=(5, 7))
+        bm5 = BlockMatrix.fill(5, 7, value=0.0, block_size=2).sparsify_rectangles([])
 
         sums_agree(bm, nd)
         sums_agree(bm2, nd2)
-        sums_agree(bm3, nd3)
+        sums_agree(bm3, nd2)
+        sums_agree(bm4, nd2)
+        sums_agree(bm5, nd5)
 
     def test_slicing(self):
         nd = np.array(np.arange(0, 80, dtype=float)).reshape(8, 10)

--- a/hail/src/main/scala/is/hail/linalg/GridPartitioner.scala
+++ b/hail/src/main/scala/is/hail/linalg/GridPartitioner.scala
@@ -123,9 +123,21 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks
     v(firstCol until firstCol + blockColNCols(j))
   }
 
-  def maybeBlockRows(): Option[Array[Int]] = maybeBlocks.map(_.map(blockBlockRow).distinct)
+  def maybeBlockRows(): Option[Array[Int]] =
+    maybeBlocks match {
+      case Some(bis) =>
+        val bisRow = bis.map(blockBlockRow).distinct
+        if (bisRow.length < nBlockRows) Some(bisRow) else None
+      case None => None
+    }
 
-  def maybeBlockCols(): Option[Array[Int]] = maybeBlocks.map(_.map(blockBlockCol).distinct)
+  def maybeBlockCols(): Option[Array[Int]] =
+    maybeBlocks match {
+      case Some(bis) =>
+        val bisCol = bis.map(blockBlockCol).distinct
+        if (bisCol.length < nBlockCols) Some(bisCol) else None
+      case None => None
+    }
 
   // returns increasing array of all blocks intersecting the diagonal band consisting of
   //   all elements with lower <= jj - ii <= upper


### PR DESCRIPTION
Summing a block-sparse matrix may result in a block-dense vector, in which case maybeBlocks should be None (otherwise the `bis.length < maxNBlocks` assert fails...when rebuilding BlockMatrix in Python/C++ I may change the invariants).

Also extended test cases to serve as regression test.