### PR TITLE
Move entries array to end of rvRowType for MatrixUnionRows

### DIFF
--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -1203,6 +1203,12 @@ class Tests(unittest.TestCase):
         ds1 = ds1.drop('was_split', 'a_index')
         self.assertTrue(ds1._same(ds2))
 
+    def test_issue_4527(self):
+        mt = hl.utils.range_matrix_table(1, 1)
+        mt = mt.key_rows_by(locus=hl.locus(hl.str(mt.row_idx+1), mt.row_idx+1), alleles=['A', 'T'])
+        mt = hl.split_multi(mt)
+        self.assertEqual(1, mt._force_count_rows())
+
     def test_ld_prune(self):
         r2_threshold = 0.001
         window_size = 5

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -161,7 +161,7 @@ object LowerMatrixIR {
 
     case MatrixUnionRows(children) =>
       // FIXME: this should check that all children have the same column keys.
-      TableUnion(children.map(lower))
+      TableUnion(MatrixUnionRows.unify(children).map(lower))
 
     case MatrixDistinctByRow(child) => TableDistinct(lower(child))
 

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -2105,7 +2105,9 @@ case class MatrixUnionRows(children: IndexedSeq[MatrixIR]) extends MatrixIR {
 
   val typ = MatrixUnionRows.fixup(children.head).typ
 
-  require(children.tail.forall(_.typ.canonicalRVDType == typ.canonicalRVDType))
+  require(children.tail.forall(_.typ.rowKeyStruct == typ.rowKeyStruct))
+  require(children.tail.forall(_.typ.rowType == typ.rowType))
+  require(children.tail.forall(_.typ.entryType == typ.entryType))
   require(children.tail.forall(_.typ.colKeyStruct == typ.colKeyStruct))
 
   def copy(newChildren: IndexedSeq[BaseIR]): MatrixUnionRows =

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -144,11 +144,6 @@ object Pretty {
           conf.useColIndices.foreachBetween(i => sb.append(i))(sb.append(','))
           sb += ')'
           sb += ')'
-        case MatrixUnionRows(unmappedChildren) =>
-          if (unmappedChildren.nonEmpty) {
-            sb += '\n'
-            unmappedChildren.foreachBetween(c => pretty(c, depth + 2))(sb += '\n')
-          }
         case _ =>
           val header = ir match {
             case I32(x) => x.toString

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -123,7 +123,7 @@ object Pretty {
             fields.foreachBetween { case (n, a) =>
               sb.append(" " * (depth + 2))
               sb += '('
-              sb.append(n)
+              sb.append(prettyIdentifier(n))
               sb += '\n'
               pretty(a, depth + 4)
               sb += ')'
@@ -144,6 +144,11 @@ object Pretty {
           conf.useColIndices.foreachBetween(i => sb.append(i))(sb.append(','))
           sb += ')'
           sb += ')'
+        case MatrixUnionRows(unmappedChildren) =>
+          if (unmappedChildren.nonEmpty) {
+            sb += '\n'
+            unmappedChildren.foreachBetween(c => pretty(c, depth + 2))(sb += '\n')
+          }
         case _ =>
           val header = ir match {
             case I32(x) => x.toString

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -789,6 +789,7 @@ class IRSuite extends SparkSuite {
       MakeStruct(Seq("x" -> i)),
       SelectFields(s, Seq("x", "z")),
       InsertFields(s, Seq("x" -> i)),
+      InsertFields(s, Seq("* x *" -> i)), // Won't parse as a simple identifier
       GetField(s, "x"),
       MakeTuple(Seq(i, b)),
       GetTupleElement(t, 1),


### PR DESCRIPTION
Closes #4527
Closes #4761

This is a workaround to prevent issues with MatrixUnionRows when the
entries arrays are in different places in the rvRowType in each of the
children.  Furthermore, it prevents issues if the entries array is
pruned and then re-added later in rebuild, where it will often be
inserted, likely by MatrixMapRows, at the end of the rvRowType. This
rearrangement caused the type equality assertion in Optimize to fail.