### PR TITLE
Table get globals

### DIFF
--- a/hail/python/hail/expr/expressions/expression_utils.py
+++ b/hail/python/hail/expr/expressions/expression_utils.py
@@ -1,4 +1,5 @@
 from hail.utils import warn, error, java
+from hail.utils.java import Env
 from .indices import *
 from ..expressions import Expression, ExpressionException, expr_any
 from typing import *
@@ -189,9 +190,7 @@ def eval_typed(expression):
     analyze('eval_typed', expression, Indices(expression._indices.source))
 
     if expression._indices.source is None:
-        return (expression.dtype._from_json(
-            java.Env.hail().expr.ir.Interpret.interpretPyIR(str(expression._ir), {}, {})),
-                expression.dtype)
+        return (Env.hc()._backend.interpret(expression._ir), expression.dtype)
     else:
         return expression.collect()[0], expression.dtype
 

--- a/hail/python/hail/ir/base_ir.py
+++ b/hail/python/hail/ir/base_ir.py
@@ -41,7 +41,7 @@ class IR(BaseIR):
         return False
 
     def search(self, criteria):
-        others = [node for child in self.children for node in child.search(criteria)]
+        others = [node for child in self.children if isinstance(child, IR) for node in child.search(criteria)]
         if criteria(self):
             return others + [self]
         return others

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1183,6 +1183,24 @@ class TableCount(IR):
                other.child == self.child
 
 
+class TableGetGlobals(IR):
+    @typecheck_method(child=TableIR)
+    def __init__(self, child):
+        super().__init__(child)
+        self.child = child
+
+    @typecheck_method(child=TableIR)
+    def copy(self, child):
+        new_instance = self.__class__
+        return new_instance(child)
+
+    def render(self, r):
+        return '(TableGetGlobals {})'.format(r(self.child))
+
+    def __eq__(self, other):
+        return isinstance(other, TableGetGlobals) and \
+               other.child == self.child
+
 class TableAggregate(IR):
     @typecheck_method(child=TableIR, query=IR)
     def __init__(self, child, query):

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2280,15 +2280,21 @@ class MatrixTable(ExprContainer):
         -------
         :class:`.StructExpression`
         """
-
+        return construct_expr(TableGetGlobals(MatrixRowsTable(self._mir)), self.globals.dtype)
         uid = Env.get_uid()
 
         def joiner(obj):
             if isinstance(obj, MatrixTable):
-                return MatrixTable._from_java(Env.jutils().joinGlobals(obj._jmt, self._jmt, uid))
+                return MatrixTable(MatrixMapGlobals(obj._mir,
+                                                    InsertFields(
+                                                        Ref('global'),
+                                                            [(uid, TableGetGlobals(MatrixRowsTable(self._mir)))])))
             else:
                 assert isinstance(obj, Table)
-                return Table._from_java(Env.jutils().joinGlobals(obj._jt, self._jmt, uid))
+                return Table(TableMapGlobals(obj._tir,
+                                                    InsertFields(
+                                                        Ref('global'),
+                                                            [(uid, TableGetGlobals(MatrixRowsTable(self._mir)))])))
 
         ir = Join(GetField(TopLevelReference('global'), uid),
                   [uid],

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2281,26 +2281,6 @@ class MatrixTable(ExprContainer):
         :class:`.StructExpression`
         """
         return construct_expr(TableGetGlobals(MatrixRowsTable(self._mir)), self.globals.dtype)
-        uid = Env.get_uid()
-
-        def joiner(obj):
-            if isinstance(obj, MatrixTable):
-                return MatrixTable(MatrixMapGlobals(obj._mir,
-                                                    InsertFields(
-                                                        Ref('global'),
-                                                            [(uid, TableGetGlobals(MatrixRowsTable(self._mir)))])))
-            else:
-                assert isinstance(obj, Table)
-                return Table(TableMapGlobals(obj._tir,
-                                                    InsertFields(
-                                                        Ref('global'),
-                                                            [(uid, TableGetGlobals(MatrixRowsTable(self._mir)))])))
-
-        ir = Join(GetField(TopLevelReference('global'), uid),
-                  [uid],
-                  [],
-                  joiner)
-        return construct_expr(ir, self.globals.dtype)
 
     def index_rows(self, *exprs):
         """Expose the row values as if looked up in a dictionary, indexing

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1439,14 +1439,24 @@ class Table(ExprContainer):
         -------
         :class:`.StructExpression`
         """
+        print(TableGetGlobals(self._tir))
+        return construct_expr(TableGetGlobals(self._tir), self.globals.dtype)
+
         uid = Env.get_uid()
 
         def joiner(obj):
             from hail.matrixtable import MatrixTable
             if isinstance(obj, MatrixTable):
-                return MatrixTable._from_java(Env.jutils().joinGlobals(obj._jmt, self._jt, uid))
-            assert isinstance(obj, Table)
-            return Table._from_java(Env.jutils().joinGlobals(obj._jt, self._jt, uid))
+                return MatrixTable(MatrixMapGlobals(obj._mir,
+                                                    InsertFields(
+                                                        Ref('global'),
+                                                            [(uid, TableGetGlobals(self._tir))])))
+            else:
+                assert isinstance(obj, Table)
+                return Table(TableMapGlobals(obj._tir,
+                                             InsertFields(
+                                                 Ref('global'),
+                                                     [(uid, TableGetGlobals(self._tir))])))
 
         ir = Join(GetField(TopLevelReference('global'), uid),
                   [uid],

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1439,30 +1439,7 @@ class Table(ExprContainer):
         -------
         :class:`.StructExpression`
         """
-        print(TableGetGlobals(self._tir))
         return construct_expr(TableGetGlobals(self._tir), self.globals.dtype)
-
-        uid = Env.get_uid()
-
-        def joiner(obj):
-            from hail.matrixtable import MatrixTable
-            if isinstance(obj, MatrixTable):
-                return MatrixTable(MatrixMapGlobals(obj._mir,
-                                                    InsertFields(
-                                                        Ref('global'),
-                                                            [(uid, TableGetGlobals(self._tir))])))
-            else:
-                assert isinstance(obj, Table)
-                return Table(TableMapGlobals(obj._tir,
-                                             InsertFields(
-                                                 Ref('global'),
-                                                     [(uid, TableGetGlobals(self._tir))])))
-
-        ir = Join(GetField(TopLevelReference('global'), uid),
-                  [uid],
-                  [],
-                  joiner)
-        return construct_expr(ir, self.globals.dtype)
 
     def _process_joins(self, *exprs):
         return process_joins(self, exprs)

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -80,6 +80,7 @@ class ValueIRTests(unittest.TestCase):
             ir.Uniroot('x', ir.F64(3.14), ir.F64(-5.0), ir.F64(5.0)),
             ir.Literal(hl.tarray(hl.tint32), [1, 2, None]),
             ir.TableCount(table),
+            ir.TableGetGlobals(table),
             ir.TableAggregate(table, ir.MakeStruct([('foo', ir.ApplyAggOp('Collect', [], None, [ir.I32(0)]))])),
             ir.TableWrite(table, new_temp_file(), False, True, "fake_codec_spec$$"),
             ir.MatrixWrite(matrix_read, ir.MatrixNativeWriter(new_temp_file(), False, False, "")),

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -114,6 +114,7 @@ object Children {
     case MatrixWrite(child, _) => IndexedSeq(child)
     // from TableIR
     case TableCount(child) => IndexedSeq(child)
+    case TableGetGlobals(child) => IndexedSeq(child)
     case TableAggregate(child, query) => IndexedSeq(child, query)
     case MatrixAggregate(child, query) => IndexedSeq(child, query)
     case TableWrite(child, _, _, _, _) => IndexedSeq(child)

--- a/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
@@ -4,6 +4,7 @@ object Compilable {
   def apply(ir: IR): Boolean = {
     ir match {
       case _: TableCount => false
+      case _: TableGetGlobals => false
       case _: TableAggregate => false
       case _: MatrixAggregate => false
       case _: TableWrite => false

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -158,6 +158,9 @@ object Copy {
       case TableCount(_) =>
         val IndexedSeq(child: TableIR) = newChildren
         TableCount(child)
+      case TableGetGlobals(_) =>
+        val IndexedSeq(child: TableIR) = newChildren
+        TableGetGlobals(child)
       case TableAggregate(_, _) =>
         val IndexedSeq(child: TableIR, query: IR) = newChildren
         TableAggregate(child, query)

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -293,6 +293,8 @@ final case class MatrixWrite(
   val typ: Type = TVoid
 }
 
+final case class TableGetGlobals(child: TableIR) extends InferIR
+
 class PrimitiveIR(val self: IR) extends AnyVal {
   def +(other: IR): IR = ApplyBinaryPrimOp(Add(), self, other)
   def -(other: IR): IR = ApplyBinaryPrimOp(Subtract(), self, other)

--- a/hail/src/main/scala/is/hail/expr/ir/Infer.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Infer.scala
@@ -83,6 +83,7 @@ object Infer {
         query.typ
       case MatrixAggregate(child, query) =>
         query.typ
+      case TableGetGlobals(child) => child.typ.globalType
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -723,6 +723,8 @@ object Interpret {
         child.partitionCounts
           .map(_.sum)
           .getOrElse(child.execute(HailContext.get).rvd.count())
+      case TableGetGlobals(child) =>
+        child.execute(HailContext.get).globals.value
       case MatrixWrite(child, writer) =>
         val mv = child.execute(HailContext.get)
         writer(mv)

--- a/hail/src/main/scala/is/hail/expr/ir/LiftLiterals.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LiftLiterals.scala
@@ -36,33 +36,47 @@ object LiftLiterals {
   }
 
   def addLiterals(tir: TableIR, literals: Map[String, IR]): TableIR = {
-    TableMapGlobals(tir,
-      InsertFields(
-        Ref("global", tir.typ.globalType),
-        literals.toFastIndexedSeq))
+    if (literals.isEmpty)
+      tir
+    else
+      TableMapGlobals(tir,
+        InsertFields(
+          Ref("global", tir.typ.globalType),
+          literals.toFastIndexedSeq))
   }
 
   def addLiterals(mir: MatrixIR, literals: Map[String, IR]): MatrixIR = {
-    MatrixMapGlobals(mir,
-      InsertFields(
-        Ref("global", mir.typ.globalType),
-        literals.toFastIndexedSeq))
+    if (literals.isEmpty)
+      mir
+    else
+      MatrixMapGlobals(mir,
+        InsertFields(
+          Ref("global", mir.typ.globalType),
+          literals.toFastIndexedSeq))
   }
 
   def removeLiterals(tir: TableIR, literals: Map[String, IR]): TableIR = {
-    val literalFields = literals.keySet
-    TableMapGlobals(tir,
-      SelectFields(
-        Ref("global", tir.typ.globalType),
-        tir.typ.globalType.fieldNames.filter(f => !literalFields.contains(f))))
+    if (literals.isEmpty)
+      tir
+    else {
+      val literalFields = literals.keySet
+      TableMapGlobals(tir,
+        SelectFields(
+          Ref("global", tir.typ.globalType),
+          tir.typ.globalType.fieldNames.filter(f => !literalFields.contains(f))))
+    }
   }
 
   def removeLiterals(mir: MatrixIR, literals: Map[String, IR]): MatrixIR = {
-    val literalFields = literals.keySet
-    MatrixMapGlobals(mir,
-      SelectFields(
-        Ref("global", mir.typ.globalType),
-        mir.typ.globalType.fieldNames.filter(f => !literalFields.contains(f))))
+    if (literals.isEmpty)
+      mir
+    else {
+      val literalFields = literals.keySet
+      MatrixMapGlobals(mir,
+        SelectFields(
+          Ref("global", mir.typ.globalType),
+          mir.typ.globalType.fieldNames.filter(f => !literalFields.contains(f))))
+    }
   }
 
   def rewriteIR(ir: IR, newGlobalType: Type, literals: Map[String, IR]): IR = {

--- a/hail/src/main/scala/is/hail/expr/ir/LiftLiterals.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LiftLiterals.scala
@@ -11,20 +11,23 @@ import scala.collection.mutable
 object LiftLiterals {
   lazy val emptyRow: BroadcastRow = BroadcastRow.empty(HailContext.get.sc)
 
-  def getLiterals(irs: IR*): Map[String, Literal] = {
-    val included = mutable.Set.empty[Literal]
+  def getLiterals(irs: IR*): Map[String, IR] = {
+    val included = mutable.Set.empty[IR]
 
     def visit(ir: IR): Unit = {
-      ir match {
-        case l: Literal =>
-          if (!included.contains(l)) {
-            included += l
-          }
+      val rewrite = ir match {
+        case _: Literal => true
+        case ta: TableAggregate => true
+        case ma: MatrixAggregate => true
+        case tgg: TableGetGlobals => true
+        case tc: TableCount => true
+        case _ => false
+      }
+      if (rewrite && !included.contains(ir))
+        included += ir
+      ir.children.foreach {
+        case ir: IR => visit(ir)
         case _ =>
-          ir.children.foreach {
-            case ir: IR => visit(ir)
-            case _ =>
-          }
       }
     }
 
@@ -32,21 +35,21 @@ object LiftLiterals {
     included.toArray.map { l => genUID() -> l }.toMap
   }
 
-  def addLiterals(tir: TableIR, literals: Map[String, Literal]): TableIR = {
+  def addLiterals(tir: TableIR, literals: Map[String, IR]): TableIR = {
     TableMapGlobals(tir,
       InsertFields(
         Ref("global", tir.typ.globalType),
         literals.toFastIndexedSeq))
   }
 
-  def addLiterals(mir: MatrixIR, literals: Map[String, Literal]): MatrixIR = {
+  def addLiterals(mir: MatrixIR, literals: Map[String, IR]): MatrixIR = {
     MatrixMapGlobals(mir,
       InsertFields(
         Ref("global", mir.typ.globalType),
         literals.toFastIndexedSeq))
   }
 
-  def removeLiterals(tir: TableIR, literals: Map[String, Literal]): TableIR = {
+  def removeLiterals(tir: TableIR, literals: Map[String, IR]): TableIR = {
     val literalFields = literals.keySet
     TableMapGlobals(tir,
       SelectFields(
@@ -54,7 +57,7 @@ object LiftLiterals {
         tir.typ.globalType.fieldNames.filter(f => !literalFields.contains(f))))
   }
 
-  def removeLiterals(mir: MatrixIR, literals: Map[String, Literal]): MatrixIR = {
+  def removeLiterals(mir: MatrixIR, literals: Map[String, IR]): MatrixIR = {
     val literalFields = literals.keySet
     MatrixMapGlobals(mir,
       SelectFields(
@@ -62,14 +65,15 @@ object LiftLiterals {
         mir.typ.globalType.fieldNames.filter(f => !literalFields.contains(f))))
   }
 
-  def rewriteIR(ir: IR, newGlobalType: Type, literals: Map[String, Literal]): IR = {
+  def rewriteIR(ir: IR, newGlobalType: Type, literals: Map[String, IR]): IR = {
     val revMap = literals.map { case (id, literal) => (literal, id) }
 
     def rewrite(ir: IR): IR = {
       ir match {
         case Ref("global", t) => SelectFields(Ref("global", newGlobalType), t.asInstanceOf[TStruct].fieldNames)
-        case l: Literal => GetField(Ref("global", newGlobalType), revMap(l))
-        case _ => MapIR(rewrite)(ir)
+        case _ => revMap.get(ir)
+          .map(f => GetField(Ref("global", newGlobalType), f))
+          .getOrElse(MapIR(rewrite)(ir))
       }
     }
     rewrite(ir)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -722,6 +722,9 @@ object IRParser {
       case "TableCount" =>
         val child = table_ir(env)(it)
         TableCount(child)
+      case "TableGetGlobals" =>
+        val child = table_ir(env)(it)
+        TableGetGlobals(child)
       case "TableAggregate" =>
         val child = table_ir(env)(it)
         val query = ir_value_expr(env.update(child.typ.refMap))(it)

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -770,6 +770,9 @@ object PruneDeadFields {
       case TableCount(child) =>
         memoizeTableIR(child, minimal(child.typ), memo)
         Env.empty[(Type, Type)]
+      case TableGetGlobals(child) =>
+        memoizeTableIR(child, minimal(child.typ).copy(globalType = requestedType.asInstanceOf[TStruct]), memo)
+        Env.empty[(Type, Type)]
       case TableAggregate(child, query) =>
         val queryDep = memoizeAndGetDep(query, query.typ, child.typ, memo)
         memoizeTableIR(child, queryDep, memo)

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -240,7 +240,7 @@ object Simplify {
     case TableGetGlobals(TableFilter(child, _)) => TableGetGlobals(child)
     case TableGetGlobals(TableHead(child, _)) => TableGetGlobals(child)
     case TableGetGlobals(TableRepartition(child, _, _)) => TableGetGlobals(child)
-    case TableGetGlobals(TableJoin(child, _, _, _)) => TableGetGlobals(child)
+    case TableGetGlobals(TableJoin(child1, child2, _, _)) => invoke("annotate", TableGetGlobals(child1), TableGetGlobals(child2))
     case TableGetGlobals(x@TableMultiWayZipJoin(children, _, globalName)) =>
       MakeStruct(FastSeq(globalName -> MakeArray(children.map(TableGetGlobals), TArray(x.typ.globalType))))
     case TableGetGlobals(TableLeftJoinRightDistinct(child, _, _)) => TableGetGlobals(child)

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -246,8 +246,9 @@ object Simplify {
     case TableGetGlobals(TableLeftJoinRightDistinct(child, _, _)) => TableGetGlobals(child)
     case TableGetGlobals(TableMapRows(child, _)) => TableGetGlobals(child)
     case TableGetGlobals(TableMapGlobals(child, newGlobals)) =>
-      val ref = Ref("global", child.typ.globalType)
-      Let("global", TableGetGlobals(child), newGlobals)
+      val uid = genUID()
+      val ref = Ref(uid, child.typ.globalType)
+      Let(uid, TableGetGlobals(child), Subst(newGlobals, Env.empty[IR].bind("global", ref)))
     case TableGetGlobals(TableExplode(child, _)) => TableGetGlobals(child)
     case TableGetGlobals(TableUnion(children)) => TableGetGlobals(children.head)
     case TableGetGlobals(TableDistinct(child)) => TableGetGlobals(child)

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir
 
-import is.hail.expr.types.virtual.{TInt32, TInt64, TStruct}
+import is.hail.expr.types.virtual.{TArray, TInt32, TInt64, TStruct}
 import is.hail.table.Ascending
 import is.hail.utils._
 
@@ -222,27 +222,48 @@ object Simplify {
     case GetTupleElement(MakeTuple(xs), idx) => xs(idx)
 
     case TableCount(TableMapGlobals(child, _)) => TableCount(child)
-
     case TableCount(TableMapRows(child, _)) => TableCount(child)
-
     case TableCount(TableRepartition(child, _, _)) => TableCount(child)
-
     case TableCount(TableUnion(children)) =>
       children.map(TableCount).reduce[IR](ApplyBinaryPrimOp(Add(), _, _))
-
     case TableCount(TableKeyBy(child, _, _)) => TableCount(child)
-
     case TableCount(TableOrderBy(child, _)) => TableCount(child)
-
     case TableCount(TableLeftJoinRightDistinct(child, _, _)) => TableCount(child)
-
     case TableCount(TableRange(n, _)) => I64(n)
-
     case TableCount(TableParallelize(rows, _)) => Cast(ArrayLen(rows), TInt64())
-
     case TableCount(TableRename(child, _, _)) => TableCount(child)
-
     case TableCount(TableAggregateByKey(child, _)) => TableCount(TableDistinct(child))
+
+    // TableGetGlobals should simplify very aggressively
+    case TableGetGlobals(child) if child.typ.globalType == TStruct() => MakeStruct(FastSeq())
+    case TableGetGlobals(TableKeyBy(child, _, _)) => TableGetGlobals(child)
+    case TableGetGlobals(TableFilter(child, _)) => TableGetGlobals(child)
+    case TableGetGlobals(TableHead(child, _)) => TableGetGlobals(child)
+    case TableGetGlobals(TableRepartition(child, _, _)) => TableGetGlobals(child)
+    case TableGetGlobals(TableJoin(child, _, _, _)) => TableGetGlobals(child)
+    case TableGetGlobals(x@TableMultiWayZipJoin(children, _, globalName)) =>
+      MakeStruct(FastSeq(globalName -> MakeArray(children.map(TableGetGlobals), TArray(x.typ.globalType))))
+    case TableGetGlobals(TableLeftJoinRightDistinct(child, _, _)) => TableGetGlobals(child)
+    case TableGetGlobals(TableMapRows(child, _)) => TableGetGlobals(child)
+    case TableGetGlobals(TableMapGlobals(child, newGlobals)) =>
+      val ref = Ref("global", child.typ.globalType)
+      Let("global", TableGetGlobals(child), newGlobals)
+    case TableGetGlobals(TableExplode(child, _)) => TableGetGlobals(child)
+    case TableGetGlobals(TableUnion(children)) => TableGetGlobals(children.head)
+    case TableGetGlobals(TableDistinct(child)) => TableGetGlobals(child)
+    case TableGetGlobals(TableAggregateByKey(child, _)) => TableGetGlobals(child)
+    case TableGetGlobals(TableKeyByAndAggregate(child, _, _, _, _)) => TableGetGlobals(child)
+    case TableGetGlobals(TableOrderBy(child, _)) => TableGetGlobals(child)
+    case TableGetGlobals(TableRename(child, _, globalMap)) =>
+      if (globalMap.isEmpty)
+        TableGetGlobals(child)
+      else {
+        val uid = genUID()
+        val ref = Ref(uid, child.typ.globalType)
+        Let(uid, TableGetGlobals(child), MakeStruct(child.typ.globalType.fieldNames.map { f =>
+          globalMap.getOrElse(f, f) -> GetField(ref, f)
+        }))
+      }
 
     case ApplyIR("annotate", Seq(s, MakeStruct(fields)), _) =>
       InsertFields(s, fields)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -267,6 +267,7 @@ object TypeCheck {
       case TableWrite(_, _, _, _, _) =>
       case TableExport(_, _, _, _, _) =>
       case TableCount(_) =>
+      case TableGetGlobals(_) =>
     }
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -676,6 +676,10 @@ class IRSuite extends SparkSuite {
     assertEvalsTo(TableCount(TableRange(7, 4)), 7L)
   }
 
+  @Test def testTableGetGlobals() {
+    assertEvalsTo(TableGetGlobals(TableMapGlobals(TableRange(0, 1), Literal(TStruct("a" -> TInt32()), Row(1)))), Row(1))
+  }
+
   @Test def testTableAggregate() {
     hc // need to initialize lazy HailContext
     val table = TableRange(3, 2)
@@ -805,6 +809,7 @@ class IRSuite extends SparkSuite {
       Uniroot("x", F64(3.14), F64(-5.0), F64(5.0)),
       Literal(TStruct("x" -> TInt32()), Row(1)),
       TableCount(table),
+      TableGetGlobals(table),
       TableAggregate(table, MakeStruct(Seq("foo" -> count))),
       TableWrite(table, tmpDir.createLocalTempFile(extension = "ht")),
       MatrixWrite(mt, MatrixNativeWriter(tmpDir.createLocalTempFile(extension = "mt"))),

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2,11 +2,14 @@ package is.hail.expr.ir
 
 import is.hail.SparkSuite
 import is.hail.TestUtils._
+import is.hail.annotations.BroadcastRow
 import is.hail.asm4s.Code
 import is.hail.expr.ir
 import is.hail.expr.ir.IRSuite.TestFunctions
 import is.hail.expr.ir.functions.{IRFunctionRegistry, RegistryFunctions, SeededIRFunction, SetFunctions}
+import is.hail.expr.types.TableType
 import is.hail.expr.types.virtual._
+import is.hail.rvd.RVD
 import is.hail.table.{Ascending, Descending, SortField, Table}
 import is.hail.utils._
 import is.hail.variant.MatrixTable
@@ -1121,7 +1124,7 @@ class IRSuite extends SparkSuite {
     assertEvalsTo(ir, FastIndexedSeq(true -> TBoolean(), FastIndexedSeq(0) -> TArray(TInt32())), FastIndexedSeq(0L))
   }
 
-  @Test def setContainsSegfault: Unit = {
+  @Test def setContainsSegfault(): Unit = {
     hc // assert initialized
     val irStr =
       """
@@ -1180,5 +1183,16 @@ class IRSuite extends SparkSuite {
       """.stripMargin
 
     Interpret(ir.IRParser.parse_table_ir(irStr), optimize = false).rvd.count()
+  }
+
+  @Test def testTableGetGlobalsSimplifyRules() {
+    val t1 = TableType(TStruct("a" -> TInt32()), IndexedSeq("a"), TStruct("g1" -> TInt32(), "g2" -> TFloat64()))
+    val t2 = TableType(TStruct("a" -> TInt32()), IndexedSeq("a"), TStruct("g3" -> TInt32(), "g4" -> TFloat64()))
+    val tab1 = TableLiteral(TableValue(t1, BroadcastRow(Row(1, 1.1), t1.globalType, sc), RVD.empty(sc, t1.canonicalRVDType)))
+    val tab2 = TableLiteral(TableValue(t2, BroadcastRow(Row(2, 2.2), t2.globalType, sc), RVD.empty(sc, t2.canonicalRVDType)))
+
+    assertEvalsTo(TableGetGlobals(TableJoin(tab1, tab2, "left")), Row(1, 1.1, 2, 2.2))
+    assertEvalsTo(TableGetGlobals(TableMapGlobals(tab1, InsertFields(Ref("global", t1.globalType), Seq("g1" -> I32(3))))), Row(3, 1.1))
+    assertEvalsTo(TableGetGlobals(TableRename(tab1, Map.empty, Map("g2" -> "g3"))), Row(1, 1.1))
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -562,6 +562,10 @@ class PruneSuite extends SparkSuite {
     checkMemo(TableCount(tab), TInt64(), Array(subsetTable(tab.typ)))
   }
 
+  @Test def testTableGetGlobalsMemo() {
+    checkMemo(TableGetGlobals(tab), TStruct("g1" -> TInt32()), Array(subsetTable(tab.typ, "global.g1")))
+  }
+
   @Test def testTableAggregateMemo() {
     checkMemo(TableAggregate(tab, tableRefBoolean(tab.typ, "global.g1")),
       TBoolean(),


### PR DESCRIPTION
With good optimization too:


```
hl.eval(hl.utils.range_table(10).annotate(x=[1,2,3]).explode('x').annotate(y=10).index_globals())
```

```
2018-12-05 18:33:33 root: INFO: optimize: before:
(TableGetGlobals
  (TableMapRows
    (TableExplode x
      (TableMapRows
        (TableRange 10 12)
        (InsertFields
          (Ref row)
          (x
            (Literal Array[Int32] "[1,2,3]")))))
    (InsertFields
      (Ref row)
      (y
        (I32 10)))))
2018-12-05 18:33:33 root: INFO: optimize: after:
(MakeStruct)
```