### PR TITLE
Fix bad error message in Table.order_by, extend functionality

### DIFF
--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2133,15 +2133,17 @@ class Table(ExprContainer):
         """
         lifted_exprs = []
         for e in exprs:
-            if isinstance(e, str):
+            sort_type = 'A'
+            if isinstance(e, Ascending):
+                expr = e.col
+            elif isinstance(e, Descending):
+                expr = e.col
+                sort_type = 'D'
+            elif isinstance(e, str):
                 expr = self[e]
-                lifted_exprs.append((expr, 'A'))
-            elif isinstance(e, Expression):
-                lifted_exprs.append((e, 'A'))
             else:
-                assert isinstance(e, Ascending) or isinstance(e, Descending)
-                sort_type = 'A' if isinstance(e, Ascending) else 'D'
-                lifted_exprs.append((e.col, sort_type))
+                expr = e
+            lifted_exprs.append((expr, sort_type))
 
         sort_fields = []
         complex_exprs = {}

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2135,11 +2135,12 @@ class Table(ExprContainer):
         for e in exprs:
             sort_type = 'A'
             if isinstance(e, Ascending):
-                expr = e.col
+                e = e.col
             elif isinstance(e, Descending):
-                expr = e.col
+                e = e.col
                 sort_type = 'D'
-            elif isinstance(e, str):
+
+            if isinstance(e, str):
                 expr = self[e]
             else:
                 expr = e

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -699,6 +699,10 @@ class Tests(unittest.TestCase):
         self.assertEqual(ht.order_by(hl.asc('idx')).idx.collect(), list(range(10)))
         self.assertEqual(ht.order_by(hl.desc('idx')).idx.collect(), list(range(10))[::-1])
 
+    def test_order_by_complex_exprs(self):
+        ht = hl.utils.range_table(10)
+        assert ht.order_by(-ht.idx).idx.collect() == list(range(10))[::-1]
+
     def test_order_by_intervals(self):
         intervals = {0: hl.Interval(0, 3, includes_start=True, includes_end=False),
                      1: hl.Interval(0, 4, includes_start=True, includes_end=True),


### PR DESCRIPTION
BUG: fixes #4920

FEATURE: Adds the ability to order by any row expression, not just
  top-level fields.