### PR TITLE
[site] make devel and stable 307 redirects

### DIFF
--- a/site/hail.nginx.conf
+++ b/site/hail.nginx.conf
@@ -15,6 +15,14 @@ server {
         return 301 $scheme://$http_host/docs/0.1$1;
     }
 
+    location ~ ^/docs/devel(|/.*)$ {
+        return 307 $scheme://$http_host/docs/0.2$1;
+    }
+
+    location ~ ^/docs/stable(|/.*)$ {
+        return 307 $scheme://$http_host/docs/0.2$1;
+    }
+
     error_page 404 /404.html;
 
     location / {

--- a/site/poll-0.2.sh
+++ b/site/poll-0.2.sh
@@ -18,8 +18,6 @@ gsutil cat gs://hail-common/builds/0.2/docs/hail-0.2-docs-$LATEST_SHA.tar.gz |
     tar xvf - -C /var/www/html-new --strip-components=1
 
 ln -s /var/www/0.1 /var/www/html-new/docs/0.1
-ln -s /var/www/html/docs/0.2 /var/www/html-new/docs/devel
-ln -s /var/www/html/docs/0.2 /var/www/html-new/docs/stable
 
 # just in case
 rm -rf /var/www/html-old


### PR DESCRIPTION
These follow the same logic as the `/hail` to `/docs/0.1` to redirect,
except they are 307 TEMPORARY REDIRECT because devel and stable may
change to different versions in the future.