### PR TITLE
[hail][site] fix 404 page

### DIFF
--- a/hail/www/404.xslt
+++ b/hail/www/404.xslt
@@ -8,7 +8,7 @@
     <xsl:template name="navbar-script">
         <script>
           $(document).ready(function () {
-            $("#hail-navbar").load("navbar.html",
+            $("#hail-navbar").load("//navbar.html",
                                    function () {});
           });
         </script>

--- a/hail/www/template.xslt
+++ b/hail/www/template.xslt
@@ -18,11 +18,11 @@
                 <title><xsl:call-template name="page-title"/></title>
                 <link rel='shortcut icon' href='hail_logo_sq.png' type='image/x-icon'/>
                 <xsl:call-template name="meta-description"/>
-                <script src="jquery-3.1.1.min.js"></script>
-                <script src="bootstrap.min.js"></script>
-                <link rel="stylesheet" href="bootstrap.min.css" type="text/css"/>
-                <link rel="stylesheet" href="style.css"/>
-                <link rel="stylesheet" href="navbar.css"/>
+                <script src="//jquery-3.1.1.min.js"></script>
+                <script src="//bootstrap.min.js"></script>
+                <link rel="stylesheet" href="//bootstrap.min.css" type="text/css"/>
+                <link rel="stylesheet" href="//style.css"/>
+                <link rel="stylesheet" href="//navbar.css"/>
                 <xsl:call-template name="navbar-script"/>
                 <script>
                     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
Any page that was not a root page did not render properly because it
pointed to relative locations for the css and js resources.  Moreover,
the 404 page incorrectly used a relative load for the navbar. These
changes change the template.xslt to use an absolute
protocol-agnostic (useful for testing locally without TLS/SSL) URL and
change 404.xslt to use an absolute load of the navbar.

Currently, 404 is the only page that might appear at a non-root URL.