### PR TITLE
[hail] Correctly merge files in ExportPlink

### DIFF
--- a/hail/src/main/scala/is/hail/io/plink/ExportPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/ExportPlink.scala
@@ -77,7 +77,7 @@ object ExportPlink {
     val nSamples = mv.colValues.value.length
     val fullRowType = mv.typ.rvRowType.physicalType
 
-    val nRecordsWritten = mv.rvd.mapPartitionsWithIndex { (i, ctx, it) =>
+    val (partFiles, nRecordsWritten) = mv.rvd.mapPartitionsWithIndex { (i, ctx, it) =>
       val hConf = sHConfBc.value.value
       val f = partFile(d, i, TaskContext.get)
       val bedPartPath = tmpBedDir + "/" + f
@@ -104,15 +104,17 @@ object ExportPlink {
         }
       }
 
-      Iterator.single(rowCount)
-    }.collect().sum
+      Iterator.single(f -> rowCount)
+    }.collect().foldLeft(
+      (FastIndexedSeq[String](), 0L)
+    ) { case ((files, sum), (f, n)) => (files :+ f, sum + n) }
 
     hConf.writeFile(tmpBedDir + "/_SUCCESS")(out => ())
     hConf.writeFile(tmpBedDir + "/header")(out => out.write(ExportPlink.bedHeader))
-    hConf.copyMerge(tmpBedDir, path + ".bed", nPartitions, header = true)
+    hConf.copyMerge(tmpBedDir, path + ".bed", nPartitions, header = true, partFilesOpt = Some(partFiles))
 
     hConf.writeTextFile(tmpBimDir + "/_SUCCESS")(out => ())
-    hConf.copyMerge(tmpBimDir, path + ".bim", nPartitions, header = false)
+    hConf.copyMerge(tmpBimDir, path + ".bim", nPartitions, header = false, partFilesOpt = Some(partFiles))
 
     mv.colsTableValue.export(path + ".fam", header = false)
 

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
@@ -46,11 +46,8 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
       is
   }
 
-  def getFileSize(filename: String): Long = {
-    val fs = fileSystem(filename)
-    val hPath = new hadoop.fs.Path(filename)
-    fs.getFileStatus(hPath).getLen
-  }
+  def getFileSize(filename: String): Long =
+    fileStatus(filename).getLen
 
   def listStatus(filename: String): Array[FileStatus] = {
     val fs = fileSystem(filename)
@@ -143,7 +140,14 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
       false, hConf)
   }
 
-  def copyMerge(sourceFolder: String, destinationFile: String, numPartFilesExpected: Int, deleteSource: Boolean = true, header: Boolean = true) {
+  def copyMerge(
+    sourceFolder: String,
+    destinationFile: String,
+    numPartFilesExpected: Int,
+    deleteSource: Boolean = true,
+    header: Boolean = true,
+    partFilesOpt: Option[IndexedSeq[String]] = None
+  ) {
     if (!exists(sourceFolder + "/_SUCCESS"))
       fatal("write failed: no success indicator found")
 
@@ -156,12 +160,16 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
     else if (!header && headerFileStatus.nonEmpty)
       fatal(s"Found unexpected header file")
 
-    val partFileStatuses = glob(sourceFolder + "/part-*").sortBy(fs => getPartNumber(fs.getPath.getName))
+    val partFileStatuses = partFilesOpt match {
+      case None => glob(sourceFolder + "/part-*")
+      case Some(files) => files.map(fileStatus _).toArray
+    }
+    val sortedPartFileStatuses = partFileStatuses.sortBy(fs => getPartNumber(fs.getPath.getName)
+)
+    if (sortedPartFileStatuses.length != numPartFilesExpected)
+      fatal(s"Expected $numPartFilesExpected part files but found ${ sortedPartFileStatuses.length }")
 
-    if (partFileStatuses.length != numPartFilesExpected)
-      fatal(s"Expected $numPartFilesExpected part files but found ${ partFileStatuses.length }")
-
-    val filesToMerge = headerFileStatus ++ partFileStatuses
+    val filesToMerge = headerFileStatus ++ sortedPartFileStatuses
 
     val (_, dt) = time {
       copyMergeList(filesToMerge, destinationFile, deleteSource)
@@ -244,7 +252,10 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
       }.getOrElse("")
   }
 
-  def fileStatus(filename: String): FileStatus = fileSystem(filename).getFileStatus(new hadoop.fs.Path(filename))
+  def fileStatus(filename: String): FileStatus = {
+    val p = new hadoop.fs.Path(filename)
+    p.getFileSystem(hConf).getFileStatus(p)
+  }
 
   def writeObjectFile[T](filename: String)(f: (ObjectOutputStream) => T): T =
     using(create(filename)) { ois => using(new ObjectOutputStream(ois))(f) }

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
@@ -162,7 +162,7 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
 
     val partFileStatuses = partFilesOpt match {
       case None => glob(sourceFolder + "/part-*")
-      case Some(files) => files.map(fileStatus _).toArray
+      case Some(files) => files.map(f => fileStatus(sourceFolder + "/" + f)).toArray
     }
     val sortedPartFileStatuses = partFileStatuses.sortBy(fs => getPartNumber(fs.getPath.getName)
 )


### PR DESCRIPTION
### Problem Description

`ExportPlink` was previously modified to resiliently handle failure of a
Spark task by including a per-task UUID. `copyMerge` was not modified to
correctly handle the directories generated by this modified
`ExportPlink`.

For example, if exactly one task out of N fails during `ExportPlink`, the
temporary output directory will contain N+1 partition files. One of
these partition files is corrupted and invalid. The other N are the
output of successful task completion. The invalid file should simply be
ignored by `copyMerge`.

### Changes Made

This PR modifies `copyMerge` to take an optional list of files to
merge. If that argument is set to `None`, the original behavior
persists. The original behavior is used by `RichRDD.writeTable` and
`RichRDDByteArray.saveFromByteArrays`. These two methods use the default
Spark parallel export system. This system is not resilient to all task
failures, but *does* ensure failed tasks do not generate garbage
partitions in the output directory. Ergo, they can safely use the
original behavior of `copyMerge`.

### On Testing

I do not test this behavior because failing a task during write is a
little bit tricky. I have verified that all users of `copyMerge` now use
`copyMerge` correctly. Adding a test to `ExportPlink` would not save us
from incorrectly using `copyMerge` in the future.

A longer term testing strategy that includes a Chaos Monkey that kills
entire containers during Hail Scala tests execution would protect
against this type of bug.

---

Fixes #4932