### PR TITLE
Scorecard: 1) CORS, 2) /json endpoint 3) properly close <h2> on Urgent

### DIFF
--- a/scorecard/environment.yml
+++ b/scorecard/environment.yml
@@ -2,6 +2,7 @@ name: scorecard
 dependencies:
 - python=3.7
 - flask
+- flask-cors
 - humanize
 - pip
 - pip:

--- a/scorecard/scorecard/scorecard.py
+++ b/scorecard/scorecard/scorecard.py
@@ -46,7 +46,7 @@ repos = {
 }
 
 app = Flask('scorecard')
-CORS(app, resources={r"/json/*": {"origins": "*"}})
+CORS(app, resources={r'/json/*': {'origins': '*'}})
 
 data = None
 timsetamp = None
@@ -221,7 +221,7 @@ def get_issue_data(repo_name, issue):
         'title': issue.title,
         'assignees': assignees,
         'html_url': issue.html_url,
-        'urgent': any(label.name == "prio:high" for label in issue.labels),
+        'urgent': any(label.name == 'prio:high' for label in issue.labels),
         'created_at': issue.created_at
     }
 
@@ -290,5 +290,5 @@ def run_forever(target, *args, **kwargs):
 poll_thread = threading.Thread(target=run_forever, args=(poll,), daemon=True)
 poll_thread.start()
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     app.run(host='0.0.0.0')

--- a/scorecard/scorecard/scorecard.py
+++ b/scorecard/scorecard/scorecard.py
@@ -53,7 +53,7 @@ timsetamp = None
 
 @app.route('/')
 def index():
-    user_data, unassigned, urgent_issues, updated = getUsers()
+    user_data, unassigned, urgent_issues, updated = get_users()
 
     random_user = random.choice(users)
 
@@ -67,7 +67,7 @@ def html_get_user(user):
 
 @app.route('/json')
 def json_all_users():
-    user_data, unassigned, urgent_issues, updated = getUsers()
+    user_data, unassigned, urgent_issues, updated = get_users()
 
     for issue in urgent_issues:
         issue['timedelta'] = humanize.naturaltime(issue['timedelta'])
@@ -83,7 +83,7 @@ def json_user(user):
 def json_random_user():
     return jsonify(random.choice(users))
 
-def getUsers():
+def get_users():
     cur_data = data
     cur_timestamp = timestamp
 

--- a/scorecard/scorecard/templates/index.html
+++ b/scorecard/scorecard/templates/index.html
@@ -83,7 +83,7 @@
 
     {% if urgent_issues %}
     <div class="grid-item">
-        <h2 id="urgent">&#x1F525;&#x1F525;&#x1F525;URGENT&#x1F525;&#x1F525;&#x1F525;</h1>
+        <h2 id="urgent">&#x1F525;&#x1F525;&#x1F525;URGENT&#x1F525;&#x1F525;&#x1F525;</h2>
 
         <table>
             <thead>


### PR DESCRIPTION
Simply enables CORS from all domains. This would be insecure, but our endpoints are read-only operations on public GitHub resources, against a fixed list of users, there is no database to inject, and there are no cookies or local storage entries to steal. I think it's safe enough for the time being, but open to suggestions.

Also expose /json endpoint to return all index.html data without rendering a page.