### PR TITLE
throw exceptions in generated code

### DIFF
--- a/hail/src/main/resources/include/hail/Utils.h
+++ b/hail/src/main/resources/include/hail/Utils.h
@@ -1,6 +1,10 @@
 #ifndef HAIL_UTILS_H
 #define HAIL_UTILS_H 1
 
+#include <exception>
+#include <string>
+#include <cstdarg>
+
 #define LIKELY(condition)   __builtin_expect(static_cast<bool>(condition), 1)
 #define UNLIKELY(condition) __builtin_expect(static_cast<bool>(condition), 0)
 
@@ -127,6 +131,21 @@ public:
   static ElemT load_element(const char *a, int i) {
     return *reinterpret_cast<const ElemT *>(Base::element_address(a, i));
   }
+};
+
+struct HailFatalError: public std::exception {
+  private:
+    static constexpr int max_error_len = 512;
+    char error_msg[max_error_len];
+  public:
+    virtual const char * what() const throw() { return error_msg; }
+    virtual ~HailFatalError() throw() {};
+    explicit HailFatalError(const char * fmtstring, ...) : std::exception() {
+      va_list args;
+      va_start(args, fmtstring);
+      vsnprintf(error_msg, max_error_len, fmtstring, args);
+      va_end(args);
+    }
 };
 
 #endif

--- a/hail/src/main/resources/include/hail/Utils.h
+++ b/hail/src/main/resources/include/hail/Utils.h
@@ -135,17 +135,18 @@ public:
 
 struct FatalError: public std::exception {
   private:
-    static constexpr int max_error_len = 512;
-    int errno_;
-    char error_msg[max_error_len];
+    static constexpr int max_error_len = 4 * 1024;
+    std::string error_msg_;
   public:
-    virtual const char * what() const throw() { return (std::string("FatalError ") + std::to_string(errno_) + ": " + error_msg).c_str(); }
+    virtual const char * what() const throw() { return error_msg_.c_str(); }
     virtual ~FatalError() throw() {}
-    explicit FatalError(int errno, const char * fmtstring, ...) : std::exception(), errno_(errno) {
+    explicit FatalError(const char * fmtstring, ...) : std::exception() {
+      char error_msg[max_error_len];
       va_list args;
       va_start(args, fmtstring);
       vsnprintf(error_msg, max_error_len, fmtstring, args);
       va_end(args);
+      error_msg_ = std::string("FatalError: ") + std::string(error_msg);
     }
 };
 

--- a/hail/src/main/resources/include/hail/Utils.h
+++ b/hail/src/main/resources/include/hail/Utils.h
@@ -133,14 +133,15 @@ public:
   }
 };
 
-struct HailFatalError: public std::exception {
+struct FatalError: public std::exception {
   private:
     static constexpr int max_error_len = 512;
+    int errno_;
     char error_msg[max_error_len];
   public:
-    virtual const char * what() const throw() { return error_msg; }
-    virtual ~HailFatalError() throw() {};
-    explicit HailFatalError(const char * fmtstring, ...) : std::exception() {
+    virtual const char * what() const throw() { return (std::string("FatalError ") + std::to_string(errno_) + ": " + error_msg).c_str(); }
+    virtual ~FatalError() throw() {}
+    explicit FatalError(int errno, const char * fmtstring, ...) : std::exception(), errno_(errno) {
       va_list args;
       va_start(args, fmtstring);
       vsnprintf(error_msg, max_error_len, fmtstring, args);

--- a/hail/src/main/scala/is/hail/cxx/Compile.scala
+++ b/hail/src/main/scala/is/hail/cxx/Compile.scala
@@ -50,7 +50,7 @@ object Compile {
            |long entrypoint(NativeStatus *st, long region, long v) {
            |  try {
            |    return (long)${ f.name }(((ScalaRegion *)region)->get_wrapped_region(), (char *)v);
-           |  } catch (const HailFatalError& e) {
+           |  } catch (const FatalError& e) {
            |    NATIVE_ERROR(st, 1005, e.what());
            |    return -1;
            |  }

--- a/hail/src/main/scala/is/hail/cxx/Definition.scala
+++ b/hail/src/main/scala/is/hail/cxx/Definition.scala
@@ -58,7 +58,7 @@ class FunctionBuilder(val parent: ScopeBuilder, prefix: String, args: Array[Vari
 
   def build(): Function = new Function(returnType, prefix, args, definitions.result().mkString("\n"), const)
 
-  def nativeError(msg: String, args: Code*): Code = s"""throw HailFatalError("$msg"${ args.map(a => s", ($a)").mkString });"""
+  def nativeError(msg: String, args: Code*): Code = s"""throw FatalError($genErr, "$msg"${ args.map(a => s", ($a)").mkString });"""
 
 }
 

--- a/hail/src/main/scala/is/hail/cxx/Definition.scala
+++ b/hail/src/main/scala/is/hail/cxx/Definition.scala
@@ -58,17 +58,7 @@ class FunctionBuilder(val parent: ScopeBuilder, prefix: String, args: Array[Vari
 
   def build(): Function = new Function(returnType, prefix, args, definitions.result().mkString("\n"), const)
 
-  def defaultReturn: Code = {
-    if (returnType == "long")
-      "return 0l;"
-    else
-      "return nullptr;"
-  }
-
-  def nativeError(code: Int, msg: Code): Code =
-    s"""NATIVE_ERROR(${getArg(0)}, $code, $msg);
-       |$defaultReturn
-     """.stripMargin
+  def nativeError(msg: String, args: Code*): Code = s"""throw HailFatalError("$msg"${ args.map(a => s", ($a)").mkString });"""
 
 }
 

--- a/hail/src/main/scala/is/hail/cxx/Definition.scala
+++ b/hail/src/main/scala/is/hail/cxx/Definition.scala
@@ -58,7 +58,7 @@ class FunctionBuilder(val parent: ScopeBuilder, prefix: String, args: Array[Vari
 
   def build(): Function = new Function(returnType, prefix, args, definitions.result().mkString("\n"), const)
 
-  def nativeError(msg: String, args: Code*): Code = s"""throw FatalError($genErr, "$msg"${ args.map(a => s", ($a)").mkString });"""
+  def nativeError(msg: String, args: Code*): Code = s"""throw FatalError("$msg"${ args.map(a => s", ($a)").mkString });"""
 
 }
 

--- a/hail/src/main/scala/is/hail/cxx/RVDEmitTriplet.scala
+++ b/hail/src/main/scala/is/hail/cxx/RVDEmitTriplet.scala
@@ -90,7 +90,7 @@ object RVDEmitTriplet {
          |  $enc.encode_byte(0);
          |  $enc.flush();
          |  return $nRows;
-         |} catch (const HailFatalError& e) {
+         |} catch (const FatalError& e) {
          |  NATIVE_ERROR($st, 1005, e.what());
          |  return -1;
          |}

--- a/hail/src/main/scala/is/hail/cxx/StagedBaseStructBuilder.scala
+++ b/hail/src/main/scala/is/hail/cxx/StagedBaseStructBuilder.scala
@@ -13,7 +13,7 @@ class StagedBaseStructBuilder(fb: FunctionBuilder, pStruct: PBaseStruct, off: Ex
 
   def setMissing(idx: Int): Code = {
     if (pStruct.fieldRequired(idx))
-      fb.nativeError(1010, "\"Required field cannot be missing.\"")
+      fb.nativeError("Required field cannot be missing.")
     else
       s"set_bit($off, ${ pStruct.missingIdx(idx) });"
   }
@@ -32,7 +32,7 @@ class StagedBaseStructBuilder(fb: FunctionBuilder, pStruct: PBaseStruct, off: Ex
 }
 
 class StagedBaseStructTripletBuilder(fb: FunctionBuilder, pStruct: PBaseStruct) {
-  private[this] val s = fb.variable("s", "char *", s"${ fb.getArg(1) }->allocate(${ pStruct.alignment }, ${ pStruct.byteSize })")
+  private[this] val s = fb.variable("s", "char *", s"${ fb.getArg(0) }->allocate(${ pStruct.alignment }, ${ pStruct.byteSize })")
   private[this] val ssb = new StagedBaseStructBuilder(fb, pStruct, s.ref)
   private[this] val ab = new ArrayBuilder[Code]
   ab += s.define

--- a/hail/src/main/scala/is/hail/cxx/StagedContainerBuilder.scala
+++ b/hail/src/main/scala/is/hail/cxx/StagedContainerBuilder.scala
@@ -41,7 +41,7 @@ class StagedContainerBuilder(fb: FunctionBuilder, region: Code, containerPType: 
 
   def setMissing(): Code = {
     if (eltRequired)
-      fb.nativeError(1010, "\"Required array element cannot be missing.\"")
+      fb.nativeError("Required array element cannot be missing.")
     else
       s"set_bit($aoff + 4, $i);"
   }

--- a/hail/src/main/scala/is/hail/cxx/TranslationUnit.scala
+++ b/hail/src/main/scala/is/hail/cxx/TranslationUnit.scala
@@ -88,6 +88,8 @@ trait ScopeBuilder {
   }
 
   def genSym(name: String): String = translationUnitBuilder().genSym(name)
+
+  def genErr: Long = translationUnitBuilder().genErr
 }
 
 class TranslationUnitBuilder() extends ScopeBuilder {
@@ -120,6 +122,8 @@ class TranslationUnitBuilder() extends ScopeBuilder {
     symCounter += 1
     s"$name$symCounter"
   }
+
+  override def genErr: Long = symCounter
 
   def end(): TranslationUnit = {
 


### PR DESCRIPTION
Basically what it says on the box. NativeStatus is now only used in the generated code in the wrapper function signature; internally, we just throw a HailFatalError object that's caught in the wrapper.