### PR TITLE
rewrite cxx iterator

### DIFF
--- a/hail/src/main/resources/include/hail/Decoder.h
+++ b/hail/src/main/resources/include/hail/Decoder.h
@@ -217,9 +217,9 @@ class Reader {
 private:
   Decoder dec_;
   ScalaRegion * region_;
-  char * value_;
+  mutable char * value_;
 
-  bool read() {
+  bool read() const {
     if (dec_.decode_byte()) {
       value_ = dec_.decode_row(region_->get_wrapped_region());
     } else {
@@ -239,9 +239,10 @@ public:
   class Iterator {
   friend class Reader;
   private:
-    Reader<Decoder> * reader_;
-    explicit Iterator(Reader<Decoder> * reader) :
+    const Reader<Decoder> * reader_;
+    explicit Iterator(const Reader<Decoder> * reader) :
     reader_(reader) { }
+    explicit Iterator(nullptr_t) : reader_(nullptr) { }
 
   public:
     Iterator& operator++() {
@@ -262,8 +263,8 @@ public:
     }
   };
 
-  Iterator begin() { return Iterator(this); }
-  Iterator end() { return Iterator(nullptr); }
+  Iterator begin() const { return Iterator(this); }
+  Iterator end() const { return Iterator(nullptr); }
 };
 
 }

--- a/hail/src/main/resources/include/hail/Decoder.h
+++ b/hail/src/main/resources/include/hail/Decoder.h
@@ -242,7 +242,7 @@ public:
     const Reader<Decoder> * reader_;
     explicit Iterator(const Reader<Decoder> * reader) :
     reader_(reader) { }
-    explicit Iterator(nullptr_t) : reader_(nullptr) { }
+    explicit Iterator(std::nullptr_t) : reader_(nullptr) { }
 
   public:
     Iterator& operator++() {

--- a/hail/src/main/resources/include/hail/PartitionIterators.h
+++ b/hail/src/main/resources/include/hail/PartitionIterators.h
@@ -50,13 +50,14 @@ using RVIterator = JavaIteratorObject::Iterator;
 template <typename Range>
 class ScalaStagingIterator : public NativeObj {
   private:
-    const Range range_;
-    const typename Range::Iterator it_ = range_.begin();
-    const typename Range::Iterator end_ = range_.end();
+    Range range_;
+    typename Range::Iterator it_ = range_.begin();
+    typename Range::Iterator end_ = range_.end();
   public:
     template <typename ... Args>
-    ScalaStagingIterator(Args ... args) : range_(args ...) { }
-    char const * get() { return *it_; }
+    ScalaStagingIterator(Args ... args) :
+    range_(args ...) { }
+    char const * get() const { return *it_; }
     bool advance() { return ++it_ != end_; }
 };
 

--- a/hail/src/main/resources/include/hail/PartitionIterators.h
+++ b/hail/src/main/resources/include/hail/PartitionIterators.h
@@ -50,9 +50,9 @@ using RVIterator = JavaIteratorObject::Iterator;
 template <typename Range>
 class ScalaStagingIterator : public NativeObj {
   private:
-    Range range_;
+    const Range range_;
     typename Range::Iterator it_ = range_.begin();
-    typename Range::Iterator end_ = range_.end();
+    const typename Range::Iterator end_ = range_.end();
   public:
     template <typename ... Args>
     ScalaStagingIterator(Args ... args) :

--- a/hail/src/main/resources/include/hail/PartitionIterators.h
+++ b/hail/src/main/resources/include/hail/PartitionIterators.h
@@ -47,17 +47,15 @@ class JavaIteratorObject : public NativeObj {
 
 using RVIterator = JavaIteratorObject::Iterator;
 
-template <typename IteratorRange>
-class ScalaIterator : public NativeObj {
+template <typename Range>
+class ScalaStagingIterator : public NativeObj {
   private:
-    std::shared_ptr<IteratorRange> range_{};
-    typename IteratorRange::Iterator it_;
-    typename IteratorRange::Iterator end_;
+    const Range range_;
+    const typename Range::Iterator it_ = range_.begin();
+    const typename Range::Iterator end_ = range_.end();
   public:
-    ScalaIterator(std::shared_ptr<IteratorRange> range) :
-    range_(range),
-    it_(range->begin()),
-    end_(range->end()) { }
+    template <typename ... Args>
+    ScalaStagingIterator(Args ... args) : range_(args ...) { }
     char const * get() { return *it_; }
     bool advance() { return ++it_ != end_; }
 };

--- a/hail/src/main/resources/include/hail/PartitionIterators.h
+++ b/hail/src/main/resources/include/hail/PartitionIterators.h
@@ -47,6 +47,21 @@ class JavaIteratorObject : public NativeObj {
 
 using RVIterator = JavaIteratorObject::Iterator;
 
+template <typename IteratorRange>
+class ScalaIterator : public NativeObj {
+  private:
+    std::shared_ptr<IteratorRange> range_{};
+    typename IteratorRange::Iterator it_;
+    typename IteratorRange::Iterator end_;
+  public:
+    ScalaIterator(std::shared_ptr<IteratorRange> range) :
+    range_(range),
+    it_(range->begin()),
+    end_(range->end()) { }
+    char const * get() { return *it_; }
+    bool advance() { return ++it_ != end_; }
+};
+
 }
 
 #endif

--- a/hail/src/main/scala/is/hail/cxx/Definition.scala
+++ b/hail/src/main/scala/is/hail/cxx/Definition.scala
@@ -44,19 +44,19 @@ class ArrayVariable(prefix: String, typ: String, length: Expression) extends Var
   override def defineWith(value: Code): Code = s"$typ $name[$length] = $value;"
 }
 
-class Function(returnType: Type, val name: String, args: Array[Variable], body: Code) extends Definition {
+class Function(returnType: Type, val name: String, args: Array[Variable], body: Code, const: Boolean = false) extends Definition {
 
   def typ: Type = returnType
 
-  def define: Code = s"$returnType $name(${args.map(a => s"${a.typ} ${a.name}").mkString(", ")}) {\n$body\n}"
+  def define: Code = s"$returnType $name(${args.map(a => s"${a.typ} ${a.name}").mkString(", ")}) ${ if (const) "const " else "" }{\n$body\n}"
 }
 
-class FunctionBuilder(val parent: ScopeBuilder, prefix: String, args: Array[Variable], returnType: Type)
+class FunctionBuilder(val parent: ScopeBuilder, prefix: String, args: Array[Variable], returnType: Type, const: Boolean = false)
   extends ScopeBuilder with DefinitionBuilder[Function] {
 
   def getArg(i: Int): Variable = args(i)
 
-  def build(): Function = new Function(returnType, prefix, args, definitions.result().mkString("\n"))
+  def build(): Function = new Function(returnType, prefix, args, definitions.result().mkString("\n"), const)
 
   def defaultReturn: Code = {
     if (returnType == "long")
@@ -91,6 +91,6 @@ class ClassBuilder(val parent: ScopeBuilder, val name: String, superClass: Strin
   extends ScopeBuilder with DefinitionBuilder[Class] {
   def build(): Class = new Class(name, superClass, definitions.result())
 
-  def buildMethod(prefix: String, args: Array[(cxx.Type, String)], returnType: Type): FunctionBuilder =
-    new FunctionBuilder(this, prefix, args.map { case (typ, p) => new Variable(p, typ, null) }, returnType)
+  def buildMethod(prefix: String, args: Array[(cxx.Type, String)], returnType: Type, const: Boolean = false): FunctionBuilder =
+    new FunctionBuilder(this, prefix, args.map { case (typ, p) => new Variable(p, typ, null) }, returnType, const)
 }

--- a/hail/src/main/scala/is/hail/cxx/PackDecoder.scala
+++ b/hail/src/main/scala/is/hail/cxx/PackDecoder.scala
@@ -183,7 +183,7 @@ object PackDecoder {
 
     decoderBuilder += s"${ decoderBuilder.name }(std::shared_ptr<InputStream> is) : $buf(std::make_shared<$bufType>(is)) { }"
 
-    val rowFB = decoderBuilder.buildMethod("decode_row", Array("Region *" -> "region"), "char *")
+    val rowFB = decoderBuilder.buildMethod("decode_row", Array("Region *" -> "region"), "char *", const = true)
     val region = rowFB.getArg(0)
     val initialSize = rt match {
       case _: PArray | _: PBinary => 8
@@ -198,7 +198,7 @@ object PackDecoder {
     })
     rowFB.end()
 
-    val byteFB = decoderBuilder.buildMethod("decode_byte", Array(), "char")
+    val byteFB = decoderBuilder.buildMethod("decode_byte", Array(), "char", const = true)
     byteFB += s"return $buf->read_byte();"
     byteFB.end()
 

--- a/hail/src/main/scala/is/hail/cxx/RegionValueIterator.scala
+++ b/hail/src/main/scala/is/hail/cxx/RegionValueIterator.scala
@@ -4,7 +4,7 @@ import is.hail.annotations.{Region, RegionValue}
 import is.hail.expr.types.physical.PType
 import is.hail.nativecode._
 import is.hail.rvd.RVDContext
-import is.hail.utils.{StagingIterator, StateMachine}
+import is.hail.utils.{FlipbookIterator, StagingIterator, StateMachine}
 
 class RegionValueIterator(it: Iterator[RegionValue]) extends Iterator[Long] {
 
@@ -14,62 +14,37 @@ class RegionValueIterator(it: Iterator[RegionValue]) extends Iterator[Long] {
 }
 
 object CXXRegionValueIterator {
-  def apply(itClass: TranslationUnitBuilder => Class): (Region, AnyRef) => StagingIterator[RegionValue] = {
-    val tub = new TranslationUnitBuilder()
-    val cls = itClass(tub)
-    tub.include("hail/ObjectArray.h")
-
+  def apply[T](itTyp: Type, tub: TranslationUnitBuilder, makeItF: (NativeModule, Region, T) => NativePtr): (Region, T) => FlipbookIterator[RegionValue] = {
     val st = tub.variable("st", "NativeStatus *")
-    val region = tub.variable("region", "long")
     val ptr = tub.variable("it", "long")
-    tub += new Function("NativeObjPtr", "make_iterator", Array(st, ptr, region),
-      s"return std::make_shared<$cls>(reinterpret_cast<ObjectArray*>($ptr)->at(0), reinterpret_cast<ScalaRegion*>($region), $st);")
+    tub += new Function("long", "get", Array(st, ptr), s"return reinterpret_cast<long>(reinterpret_cast<${ itTyp } *>($ptr)->get());")
+    tub += new Function("long", "advance", Array(st, ptr), s"return (reinterpret_cast<${ itTyp } *>($ptr)->advance()) ? 1 : 0;")
 
-    tub += new Function("long", "get", Array(st, ptr),
-      s"""
-         |${ cls.name } it = *reinterpret_cast<${ cls.name } *>($ptr);
-         |return reinterpret_cast<long>(*it);
-       """.stripMargin)
-    tub += new Function("long", "advance", Array(st, ptr),
-      s"""
-         |auto it = ++(*reinterpret_cast<${ cls.name } *>($ptr));
-         |return (*it == nullptr) ? 0 : 1;
-       """.stripMargin)
-
-    val mod = tub.end().build("-O1 -llz4")
+    val mod = tub.end().build("-O2")
     val key = mod.getKey
     val bin = mod.getBinary
 
-    { case (r, v) => StagingIterator(new CXXStateMachine(key, bin, v, r)) }
+    { case (r, v) => StagingIterator(new CXXStateMachine(key, bin, makeItF(_, r, v))).map(RegionValue(r, _)) }
   }
-
 }
 
-class CXXStateMachine(key: String, bin: Array[Byte], obj: AnyRef, region: Region) extends StateMachine[RegionValue] with AutoCloseable {
+class CXXStateMachine(key: String, bin: Array[Byte], iteratorF: NativeModule => NativePtr) extends StateMachine[Long] with AutoCloseable {
   private[this] val st = new NativeStatus()
   private[this] val mod = new NativeModule(key, bin)
-  private[this] val objArray = new ObjectArray(obj)
-
-  private[this] val itF = mod.findPtrFuncL2(st, "make_iterator")
-  assert(st.ok, st.toString)
   private[this] val getF = mod.findLongFuncL1(st, "get")
   assert(st.ok, st.toString)
   private[this] val advanceF = mod.findLongFuncL1(st, "advance")
   assert(st.ok, st.toString)
 
-  private[this] val ptr = new NativePtr(itF, st, objArray.get(), region.get())
-  itF.close()
-  objArray.close()
+  private[this] val ptr = iteratorF(mod)
 
   var isValid: Boolean = true
-  var value: RegionValue = RegionValue(region, getF(st, ptr.get()))
+  var value: Long = getF(st, ptr.get())
 
   def advance(): Unit = {
     isValid = advanceF(st, ptr.get()) != 0
     if (isValid) {
-      value = RegionValue(region, getF(st, ptr.get()))
-    } else {
-      close()
+      value = getF(st, ptr.get())
     }
   }
 


### PR DESCRIPTION
I didn't like how the scala wrapper was written, so I rewrote it? Should make it easier to use as an endpoint for code-generated stages.