### PR TITLE
[notebook] permit local R package installation by default

### DIFF
--- a/notebook/Makefile
+++ b/notebook/Makefile
@@ -5,7 +5,7 @@ IMAGE_SHORT_NAMES = $(shell ls -1 images)
 BUILT = $(foreach image,$(IMAGE_SHORT_NAMES),build/images/$(image)/_BUILT)
 PUSHED = $(foreach image,$(IMAGE_SHORT_NAMES),build/images/$(image)/_PUSHED)
 
-.PHONY: $(IMAGE_SHORT_NAMES) $(IMAGE_RUN_TARGETS)
+.PHONY: $(IMAGE_SHORT_NAMES)
 
 build/images/%/_BUILT: images/%/Dockerfile $(shell find images/$*)
 	mkdir -p $(dir $@)

--- a/notebook/Makefile
+++ b/notebook/Makefile
@@ -1,8 +1,11 @@
 .PHONY: build push run-docker run deploy clean clean-workers
 
 PROJECT = $(shell gcloud config get-value project)
-BUILT = $(shell ls -1 images | awk '{print "build/images/" $$0 "/_BUILT"}')
-PUSHED = $(shell ls -1 images | awk '{print "build/images/" $$0 "/_PUSHED"}')
+IMAGE_SHORT_NAMES = $(shell ls -1 images)
+BUILT = $(foreach image,$(IMAGE_SHORT_NAMES),build/images/$(image)/_BUILT)
+PUSHED = $(foreach image,$(IMAGE_SHORT_NAMES),build/images/$(image)/_PUSHED)
+
+.PHONY: $(IMAGE_SHORT_NAMES) $(IMAGE_RUN_TARGETS)
 
 build/images/%/_BUILT: images/%/Dockerfile $(shell find images/$*)
 	mkdir -p $(dir $@)
@@ -14,6 +17,8 @@ build/images/%/_PUSHED: build/images/%/_BUILT
 	docker tag $* $(IMAGE)
 	docker push $(IMAGE)
 	echo $(IMAGE) > $@
+
+$(IMAGE_SHORT_NAMES): %: build/images/%/_BUILT
 
 notebook-worker-images: $(PUSHED)
 	cat $^ > $@

--- a/notebook/images/ccg-workshop/Dockerfile
+++ b/notebook/images/ccg-workshop/Dockerfile
@@ -122,3 +122,6 @@ RUN (cd /home/jovyan && \
         | xargs -I % /bin/sh -c 'set -ex ; ln -s ${PWD}/% /usr/local/bin/$(basename %)')
 RUN chown jovyan:users -R /home/jovyan
 USER jovyan
+
+ENV R_LIBS=/home/jovyan/.R_libs/
+RUN mkdir -p $R_LIBS


### PR DESCRIPTION
I also added short names to build images for ease of development. You can now say `make hail` or `make ccg-workshop`.