### PR TITLE
reduce cpu and memory minimums

### DIFF
--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -101,7 +101,7 @@ def start_pod(jupyter_token, image):
                 image=image,
                 ports=[kube.client.V1ContainerPort(container_port=8888)],
                 resources=kube.client.V1ResourceRequirements(
-                    requests={'cpu': '3.001', 'memory': '4G'}),
+                    requests={'cpu': '1.601', 'memory': '1.601G'}),
                 readiness_probe=kube.client.V1Probe(
                     http_get=kube.client.V1HTTPGetAction(
                         path=f'/instance/{svc.metadata.name}/login',


### PR DESCRIPTION
We want to pack four notebooks per 8-core machine with extra space
for k8s jobs and daemon sets that in practice do not utilize their
required CPU. To prevent a fifth notebook we should set CPU
requirement to x such that:

    8 - 4x < x

ergo: x > 8/5 = 1.6, x = 1.6 + 0.001