### PR TITLE
[notebook] Banish 50x

### DIFF
--- a/gateway/hail.nginx.conf.in
+++ b/gateway/hail.nginx.conf.in
@@ -92,6 +92,9 @@ server {
 server {
     server_name notebook.@domain@;
 
+    # needed to correctly handle error_page with internal handles
+    recursive_error_pages on;
+
     location = /auth {
         internal;
         proxy_pass http://notebook/auth/$jupyter_auth_name;
@@ -102,12 +105,12 @@ server {
         auth_request /auth;
 
         resolver kube-dns.kube-system.svc.cluster.local;
-        proxy_pass http://$1.default.svc.cluster.local/instance/$1/$2$is_args$args;
+        proxy_pass http://$1.notebook-test.svc.cluster.local/instance/$1/$2$is_args$args;
 
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_http_version 1.1;
         proxy_redirect off;
@@ -115,20 +118,30 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_read_timeout 86400;
+
+        proxy_connect_timeout 5s;
+
+        proxy_intercept_errors on;
+        # 502: no service, 504: pod not responding
+        error_page 502 504 = @pod_dead;
+    }
+
+    location @pod_dead {
+        return 307 $scheme://$http_host/new;
     }
 
     location ~ /instance-ready/([^/]+)/ {
         resolver kube-dns.kube-system.svc.cluster.local;
-        proxy_pass http://$1.default.svc.cluster.local/instance/$1/;
+        proxy_pass http://$1.notebook-test.svc.cluster.local/instance/$1/;
     }
 
     location / {
         proxy_pass http://notebook/;
 
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_http_version 1.1;
         proxy_redirect off;

--- a/gateway/hail.nginx.conf.in
+++ b/gateway/hail.nginx.conf.in
@@ -105,7 +105,7 @@ server {
         auth_request /auth;
 
         resolver kube-dns.kube-system.svc.cluster.local;
-        proxy_pass http://$1.notebook-test.svc.cluster.local/instance/$1/$2$is_args$args;
+        proxy_pass http://$1.default.svc.cluster.local/instance/$1/$2$is_args$args;
 
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -132,7 +132,7 @@ server {
 
     location ~ /instance-ready/([^/]+)/ {
         resolver kube-dns.kube-system.svc.cluster.local;
-        proxy_pass http://$1.notebook-test.svc.cluster.local/instance/$1/;
+        proxy_pass http://$1.default.svc.cluster.local/instance/$1/;
     }
 
     location / {


### PR DESCRIPTION
Assigning @tpoterba since he (and cotton) have the most context to review this.

A few preliminaries:

1. I noticed the proxy headers were not quite right when you're testing this without SSL or on some non-standard port. `$host` does not include the port, `$http_host` does. `$scheme` returns `http` or `https` depending on how the user connected to gateway
2. The admin privilege check was too restrictive, if `delete_worker_pod` is called by `/new` there's no need to check admin privs
3. I realized that the timeout logic wasn't quite right because a misconfigured gateway (I was testing with a broken gateway config) will return 5xx codes, but that doesn't mean the server is alive. We probably should error here, but I'm hesitant to add new error modes so close to a tutorial.


Ok, how does this work? Basically, if the gateway cannot connect to the notebook pod, we intercept the error and redirect the user to the "create new notebook" webpage. That webpage deletes whatever remains of the users previous notebook pod & service. Here are the pieces:

1. `recursive_error_pages on;` the internet suggests that without this we cannot use `error_page` with an "internal" rule (the `@` rules are internal rules that users cannot directly access)
2. `proxy_connect_timeout` defaults to 60s which is a shit user experience if your pod dies. Honestly, I might set this to 100ms. This is all inside a datacenter.
3. `proxy_intercept_errors` permits us to use `error_page` with 5xx errors from failing to connect to the proxy

---

I tested this with a pile of hacks to deploy this into an anonymous namespace in `vdc`. I'm not ready to PR those changes, they need a clean up before others use them. Sometime next week I hope to get that in. Getting it requires some restructuring of `vdc/` and `gateway/` to be more modular.