### PR TITLE
[notebook] Fix URLs containing encoded chars

### DIFF
--- a/gateway/hail.nginx.conf.in
+++ b/gateway/hail.nginx.conf.in
@@ -105,7 +105,7 @@ server {
         auth_request /auth;
 
         resolver kube-dns.kube-system.svc.cluster.local;
-        proxy_pass http://$1.default.svc.cluster.local/instance/$1/$2$is_args$args;
+        proxy_pass http://$1.default.svc.cluster.local$request_uri;
 
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Spaces were screwing things up because the `location` directive matches the decoded string (e.g. "%20" is converted back to " "). We don't need to reconstruct the URL explicitly with the regex pieces and the `$args` (which refers to HTTP query parameters), `$request_uri` is all that, but still encoded.

The notebook was receiving requests without encoded spaces which appear as a bunch of weird hex characters. Obviously the notebook errors when it sees such demonic lettering.