### PR TITLE
[ci] do not fail if expected job is gone

### DIFF
--- a/ci/ci/prs.py
+++ b/ci/ci/prs.py
@@ -2,7 +2,7 @@ import json
 
 from batch.client import Job
 
-from .batch_helper import short_str_build_job
+from .batch_helper import short_str_build_job, try_to_cancel_job
 from .ci_logging import log
 from .constants import VERSION, DEPLOY_JOB_TYPE
 from .environment import \
@@ -323,7 +323,7 @@ class PRS(object):
         if expected_job.id != job.id:
             expected_target = FQSHA.from_json(json.loads(expected_job.attributes['target']))
             if expected_target == target:
-                expected_job.delete()
+                try_to_cancel_job(expected_job)
                 log.info(
                     f'proceeding with unexpected deploy job {job.id}, '
                     f'because targets matched: {target} {expected_target}. '


### PR DESCRIPTION
The deploy job we thought was running may have been deleted for a variety of reasons. It's not an error for that to happen, especially since we're about to accept a different deploy job that was running for the same desired target sha. This can happen if an old CI starts a deploy but is then killed and this CI creates another deploy job before it hears of the old CI's deploy job (and the old one finishes first).