### PR TITLE
Add ability to unify many matrix table writes into one RDD and therefore, one spark stage.

### DIFF
--- a/hail/python/hail/experimental/__init__.py
+++ b/hail/python/hail/experimental/__init__.py
@@ -5,6 +5,7 @@ from .plots import hail_metadata, plot_roc_curve
 from .phase_by_transmission import *
 from .datasets import load_dataset
 from .import_gtf import import_gtf
+from .write_multiple import write_matrix_tables
 
 __all__ = ['ld_score',
            'filtering_allele_frequency',
@@ -15,4 +16,5 @@ __all__ = ['ld_score',
            'plot_roc_curve',
            'load_dataset',
            'import_gtf',
-           'haplotype_freq_em']
+           'haplotype_freq_em',
+           'write_matrix_tables']

--- a/hail/python/hail/experimental/write_multiple.py
+++ b/hail/python/hail/experimental/write_multiple.py
@@ -1,0 +1,12 @@
+from typing import List
+
+from hail import MatrixTable
+from hail.typecheck import sequenceof, typecheck_method
+
+@typecheck_method(objs=sequenceof(MatrixTable),
+                  prefix=str,
+                  overwrite=bool,
+                  stage_locally=bool)
+def write_matrix_tables(objs: List[MatrixTable], prefix: str, overwrite: bool = False,
+                        stage_locally: bool = False):
+    pass  # TODO, implement

--- a/hail/python/hail/experimental/write_multiple.py
+++ b/hail/python/hail/experimental/write_multiple.py
@@ -1,12 +1,15 @@
 from typing import List
 
 from hail import MatrixTable
-from hail.typecheck import sequenceof, typecheck_method
+from hail.ir import MatrixMultiWrite, MatrixNativeMultiWriter
+from hail.typecheck import sequenceof, typecheck
+from hail.utils.java import Env
 
-@typecheck_method(objs=sequenceof(MatrixTable),
-                  prefix=str,
-                  overwrite=bool,
-                  stage_locally=bool)
-def write_matrix_tables(objs: List[MatrixTable], prefix: str, overwrite: bool = False,
+@typecheck(mts=sequenceof(MatrixTable),
+           prefix=str,
+           overwrite=bool,
+           stage_locally=bool)
+def write_matrix_tables(mts: List[MatrixTable], prefix: str, overwrite: bool = False,
                         stage_locally: bool = False):
-    pass  # TODO, implement
+    writer = MatrixNativeMultiWriter(prefix, overwrite, stage_locally)
+    Env.hc()._backend.interpret(MatrixMultiWrite([mt._mir for mt in mts], writer))

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -5,7 +5,7 @@ from hail.expr.types import hail_type
 from hail.typecheck import *
 from hail.utils.java import escape_str, escape_id
 from .base_ir import *
-from .matrix_writer import MatrixWriter
+from .matrix_writer import MatrixWriter, MatrixNativeMultiWriter
 
 
 class I32(IR):
@@ -1365,6 +1365,27 @@ class MatrixWrite(IR):
         return isinstance(other, MatrixWrite) and \
                other.child == self.child and \
                other.matrix_writer == self.matrix_writer
+
+
+class MatrixMultiWrite(IR):
+    @typecheck_method(children=sequenceof(MatrixIR), writer=MatrixNativeMultiWriter)
+    def __init__(self, children, writer):
+        super().__init__(*children)
+        self.writer = writer
+
+    def copy(self, *children):
+        new_instance = self.__class__
+        return new_instance(list(children), self.writer)
+
+    def render(self, r):
+        return '(MatrixMultiWrite "{}" {})'.format(
+            r(self.writer),
+            ' '.join(map(r, self.children)))
+
+    def __eq__(self, other):
+        return isinstance(other, MatrixMultiWrite) and \
+               other.children == self.children and \
+               other.writer == self.writer
 
 
 class Literal(IR):

--- a/hail/python/hail/ir/matrix_writer.py
+++ b/hail/python/hail/ir/matrix_writer.py
@@ -100,3 +100,26 @@ class MatrixPLINKWriter(MatrixWriter):
     def __eq__(self, other):
         return isinstance(other, MatrixPLINKWriter) and \
                other.path == self.path
+
+
+class MatrixNativeMultiWriter(object):
+    @typecheck_method(prefix=str,
+                      overwrite=bool,
+                      stage_locally=bool)
+    def __init__(self, prefix, overwrite, stage_locally):
+        self.prefix = prefix
+        self.overwrite = overwrite
+        self.stage_locally = stage_locally
+
+    def render(self, r):
+        writer = {'name': 'MatrixNativeMultiWriter',
+                  'prefix': self.prefix,
+                  'overwrite': self.overwrite,
+                  'stageLocally': self.stage_locally}
+        return escape_str(json.dumps(writer))
+
+    def __eq__(self, other):
+        return isinstance(other, MatrixNativeMultiWriter) and \
+               other.prefix == self.prefix and \
+               other.overwrite == self.overwrite and \
+               other.stage_locally == self.stage_locally

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -89,6 +89,7 @@ class ValueIRTests(unittest.TestCase):
             ir.MatrixWrite(matrix_read, ir.MatrixVCFWriter(new_temp_file(), None, False, None)),
             ir.MatrixWrite(matrix_read, ir.MatrixGENWriter(new_temp_file(), 4)),
             ir.MatrixWrite(matrix_read, ir.MatrixPLINKWriter(new_temp_file())),
+            ir.MatrixMultiWrite([matrix_read, matrix_read], ir.MatrixNativeMultiWriter(new_temp_file(), False, False)),
         ]
 
         return value_irs

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -112,6 +112,7 @@ object Children {
       FastIndexedSeq(fn, min, max)
     // from MatrixIR
     case MatrixWrite(child, _) => IndexedSeq(child)
+    case MatrixMultiWrite(children, _) => children
     // from TableIR
     case TableCount(child) => IndexedSeq(child)
     case TableGetGlobals(child) => IndexedSeq(child)

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -154,6 +154,8 @@ object Copy {
       case MatrixWrite(_, writer) =>
         val IndexedSeq(child: MatrixIR) = newChildren
         MatrixWrite(child, writer)
+      case MatrixMultiWrite(_, writer) =>
+        MatrixMultiWrite(newChildren.map(_.asInstanceOf[MatrixIR]), writer)
       // from TableIR
       case TableCount(_) =>
         val IndexedSeq(child: TableIR) = newChildren

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -260,10 +260,17 @@ final case class TableExport(
   header: Boolean = true,
   exportType: Int = ExportType.CONCATENATED) extends IR
 
-final case class MatrixWrite(child: MatrixIR, writer: MatrixWriter) extends IR
-
 final case class TableGetGlobals(child: TableIR) extends IR
 final case class TableCollect(child: TableIR) extends IR
+
+final case class MatrixWrite(child: MatrixIR, writer: MatrixWriter) extends IR
+
+final case class MatrixMultiWrite(
+  override val children: IndexedSeq[MatrixIR],
+  writer: MatrixNativeMultiWriter) extends IR {
+  private val t = children.head.typ
+  require(children.forall(_.typ == t))
+}
 
 class PrimitiveIR(val self: IR) extends AnyVal {
   def +(other: IR): IR = ApplyBinaryPrimOp(Add(), self, other)

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -127,6 +127,7 @@ object InferType {
         query.typ
       case _: TableWrite => TVoid
       case _: MatrixWrite => TVoid
+      case _: MatrixMultiWrite => TVoid
       case _: TableExport => TVoid
       case TableGetGlobals(child) => child.typ.globalType
       case TableCollect(child) => TStruct("rows" -> TArray(child.typ.rowType), "global" -> child.typ.globalType)

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -718,6 +718,10 @@ object Interpret {
       case MatrixWrite(child, writer) =>
         val mv = child.execute(HailContext.get)
         writer(mv)
+      case MatrixMultiWrite(children, writer) =>
+        val hc = HailContext.get
+        val mvs = children.map(_.execute(hc))
+        writer(mvs)
       case TableWrite(child, path, overwrite, stageLocally, codecSpecJSONStr) =>
         val hc = HailContext.get
         val tableValue = child.execute(hc)

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
@@ -91,26 +91,9 @@ case class MatrixValue(
       hadoopConf.writeTextFile(path + "/_SUCCESS")(out => ())
     }
 
-    def write(path: String, overwrite: Boolean = false, stageLocally: Boolean = false, codecSpecJSONStr: String = null) = {
+    private def finalizeWrite(path: String, codecSpec: CodecSpec, partitionCounts: Array[Long]) = {
       val hc = HailContext.get
       val hadoopConf = hc.hadoopConf
-
-      val codecSpec =
-        if (codecSpecJSONStr != null) {
-          implicit val formats = AbstractRVDSpec.formats
-          val codecSpecJSON = parse(codecSpecJSONStr)
-          codecSpecJSON.extract[CodecSpec]
-        } else
-          CodecSpec.default
-
-      if (overwrite)
-        hadoopConf.delete(path, recursive = true)
-      else if (hadoopConf.exists(path))
-        fatal(s"file already exists: $path")
-
-      hc.hadoopConf.mkDir(path)
-
-      val partitionCounts = rvd.writeRowsSplit(path, codecSpec, stageLocally)
 
       val globalsPath = path + "/globals"
       hadoopConf.mkDir(globalsPath)
@@ -169,7 +152,30 @@ case class MatrixValue(
         s"and $nCols ${ plural(nCols, "column") } " +
         s"in ${ partitionCounts.length } ${ plural(partitionCounts.length, "partition") } " +
         s"to $path")
+    }
 
+    def write(path: String, overwrite: Boolean = false, stageLocally: Boolean = false, codecSpecJSONStr: String = null) = {
+      val hc = HailContext.get
+      val hadoopConf = hc.hadoopConf
+
+      val codecSpec =
+        if (codecSpecJSONStr != null) {
+          implicit val formats = AbstractRVDSpec.formats
+          val codecSpecJSON = parse(codecSpecJSONStr)
+          codecSpecJSON.extract[CodecSpec]
+        } else
+          CodecSpec.default
+
+      if (overwrite)
+        hadoopConf.delete(path, recursive = true)
+      else if (hadoopConf.exists(path))
+        fatal(s"file already exists: $path")
+
+      hc.hadoopConf.mkDir(path)
+
+      val partitionCounts = rvd.writeRowsSplit(path, codecSpec, stageLocally)
+
+      finalizeWrite(path, codecSpec, partitionCounts)
     }
 
     lazy val (sortedColValues, sortedColsToOldIdx): (BroadcastIndexedSeq, BroadcastIndexedSeq) = {
@@ -357,75 +363,22 @@ object MatrixValue {
     val first = mvs.head
     require(mvs.forall(_.typ == first.typ))
     val hc = HailContext.get
-    val hConf = hc.hadoopConf
+    val hadoopConf = hc.hadoopConf
     val codecSpec = CodecSpec.default
 
     val d = digitsNeeded(mvs.length)
     val paths = (0 until mvs.length).map { i => prefix + StringUtils.leftPad(i.toString, d, '0') + ".mt" }
     paths.foreach { path =>
       if (overwrite)
-        hConf.delete(path, recursive = true)
-      else if (hConf.exists(path))
+        hadoopConf.delete(path, recursive = true)
+      else if (hadoopConf.exists(path))
         fatal(s"file already exists: $path")
-      hConf.mkDir(path)
+      hadoopConf.mkDir(path)
     }
 
     val partitionCounts = RVD.writeRowsSplitFiles(mvs.map(_.rvd), prefix, codecSpec, stageLocally)
     for ((mv, path, partCounts) <- (mvs, paths, partitionCounts).zipped) {
-      val globalsPath = path + "/globals"
-      hConf.mkDir(globalsPath)
-      mv.writeGlobals(globalsPath, codecSpec)
-
-      val rowsSpec = TableSpec(
-        FileFormat.version.rep,
-        hc.version,
-        "../references",
-        mv.typ.rowsTableType,
-        Map("globals" -> RVDComponentSpec("../globals/rows"),
-          "rows" -> RVDComponentSpec("rows"),
-          "partition_counts" -> PartitionCountsComponentSpec(partCounts)))
-      rowsSpec.write(hc, path + "/rows")
-      hConf.writeTextFile(path + "/rows/_SUCCESS")(out => ())
-
-      val entriesSpec = TableSpec(
-        FileFormat.version.rep,
-        hc.version,
-        "../references",
-        TableType(mv.typ.entriesRVType, FastIndexedSeq(), mv.typ.globalType),
-        Map("globals" -> RVDComponentSpec("../globals/rows"),
-          "rows" -> RVDComponentSpec("rows"),
-          "partition_counts" -> PartitionCountsComponentSpec(partCounts)))
-      entriesSpec.write(hc, path + "/entries")
-      hConf.writeTextFile(path + "/entries/_SUCCESS")(out => ())
-
-      hConf.mkDir(path + "/cols")
-      mv.writeCols(path + "/cols", codecSpec)
-
-      val refPath = path + "/references"
-      hc.hadoopConf.mkDir(refPath)
-      Array(mv.typ.colType, mv.typ.rowType, mv.typ.entryType, mv.typ.globalType).foreach { t =>
-        ReferenceGenome.exportReferences(hc, refPath, t)
-      }
-
-      val spec = MatrixTableSpec(
-        FileFormat.version.rep,
-        hc.version,
-        "references",
-        mv.typ,
-        Map("globals" -> RVDComponentSpec("globals/rows"),
-          "cols" -> RVDComponentSpec("cols/rows"),
-          "rows" -> RVDComponentSpec("rows/rows"),
-          "entries" -> RVDComponentSpec("entries/rows"),
-          "partition_counts" -> PartitionCountsComponentSpec(partCounts)))
-      spec.write(hc, path)
-
-      hConf.writeTextFile(path + "/_SUCCESS")(out => ())
-      val nRows = partCounts.sum
-      val nCols = mv.colValues.value.length
-      info(s"wrote matrix table with $nRows ${ plural(nRows, "row") } " +
-        s"and $nCols ${ plural(nCols, "column") } " +
-        s"in ${ partCounts.length } ${ plural(partCounts.length, "partition") } " +
-        s"to $path")
+      mv.finalizeWrite(path, codecSpec, partCounts)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
@@ -345,3 +345,14 @@ case class MatrixValue(
         })
     }
   }
+
+object MatrixValue {
+  def writeMultiple(
+    mvs: Array[MatrixValue],
+    prefix: String,
+    overwrite: Boolean,
+    stageLocally: Boolean
+  ): Unit = {
+    ???
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
@@ -373,7 +373,9 @@ object MatrixValue {
     val partitionCounts = RVD.writeRowsSplitFiles(mvs.map(_.rvd), prefix, codecSpec, stageLocally)
     for ((mv, path, partCounts) <- (mvs, paths, partitionCounts).zipped) {
       val globalsPath = path + "/globals"
+      hConf.mkDir(globalsPath)
       mv.writeGlobals(globalsPath, codecSpec)
+
       val rowsSpec = TableSpec(
         FileFormat.version.rep,
         hc.version,
@@ -383,8 +385,8 @@ object MatrixValue {
           "rows" -> RVDComponentSpec("rows"),
           "partition_counts" -> PartitionCountsComponentSpec(partCounts)))
       rowsSpec.write(hc, path + "/rows")
-
       hConf.writeTextFile(path + "/rows/_SUCCESS")(out => ())
+
       val entriesSpec = TableSpec(
         FileFormat.version.rep,
         hc.version,
@@ -394,7 +396,6 @@ object MatrixValue {
           "rows" -> RVDComponentSpec("rows"),
           "partition_counts" -> PartitionCountsComponentSpec(partCounts)))
       entriesSpec.write(hc, path + "/entries")
-
       hConf.writeTextFile(path + "/entries/_SUCCESS")(out => ())
 
       hConf.mkDir(path + "/cols")

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
@@ -11,6 +11,7 @@ import is.hail.sparkextras.ContextRDD
 import is.hail.table.TableSpec
 import is.hail.utils._
 import is.hail.variant._
+import org.apache.commons.lang3.StringUtils
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.Row
 import org.json4s.jackson.JsonMethods.parse
@@ -348,11 +349,82 @@ case class MatrixValue(
 
 object MatrixValue {
   def writeMultiple(
-    mvs: Array[MatrixValue],
+    mvs: IndexedSeq[MatrixValue],
     prefix: String,
     overwrite: Boolean,
     stageLocally: Boolean
   ): Unit = {
-    ???
+    val first = mvs.head
+    require(mvs.forall(_.typ == first.typ))
+    val hc = HailContext.get
+    val hConf = hc.hadoopConf
+    val codecSpec = CodecSpec.default
+
+    val d = digitsNeeded(mvs.length)
+    val paths = (0 until mvs.length).map { i => prefix + StringUtils.leftPad(i.toString, d, '0') + ".mt" }
+    paths.foreach { path =>
+      if (overwrite)
+        hConf.delete(path, recursive = true)
+      else if (hConf.exists(path))
+        fatal(s"file already exists: $path")
+      hConf.mkDir(path)
+    }
+
+    val partitionCounts = RVD.writeRowsSplitFiles(mvs.map(_.rvd), prefix, codecSpec, stageLocally)
+    for ((mv, path, partCounts) <- (mvs, paths, partitionCounts).zipped) {
+      val globalsPath = path + "/globals"
+      mv.writeGlobals(globalsPath, codecSpec)
+      val rowsSpec = TableSpec(
+        FileFormat.version.rep,
+        hc.version,
+        "../references",
+        mv.typ.rowsTableType,
+        Map("globals" -> RVDComponentSpec("../globals/rows"),
+          "rows" -> RVDComponentSpec("rows"),
+          "partition_counts" -> PartitionCountsComponentSpec(partCounts)))
+      rowsSpec.write(hc, path + "/rows")
+
+      hConf.writeTextFile(path + "/rows/_SUCCESS")(out => ())
+      val entriesSpec = TableSpec(
+        FileFormat.version.rep,
+        hc.version,
+        "../references",
+        TableType(mv.typ.entriesRVType, FastIndexedSeq(), mv.typ.globalType),
+        Map("globals" -> RVDComponentSpec("../globals/rows"),
+          "rows" -> RVDComponentSpec("rows"),
+          "partition_counts" -> PartitionCountsComponentSpec(partCounts)))
+      entriesSpec.write(hc, path + "/entries")
+
+      hConf.writeTextFile(path + "/entries/_SUCCESS")(out => ())
+
+      hConf.mkDir(path + "/cols")
+      mv.writeCols(path + "/cols", codecSpec)
+
+      val refPath = path + "/references"
+      hc.hadoopConf.mkDir(refPath)
+      Array(mv.typ.colType, mv.typ.rowType, mv.typ.entryType, mv.typ.globalType).foreach { t =>
+        ReferenceGenome.exportReferences(hc, refPath, t)
+      }
+
+      val spec = MatrixTableSpec(
+        FileFormat.version.rep,
+        hc.version,
+        "references",
+        mv.typ,
+        Map("globals" -> RVDComponentSpec("globals/rows"),
+          "cols" -> RVDComponentSpec("cols/rows"),
+          "rows" -> RVDComponentSpec("rows/rows"),
+          "entries" -> RVDComponentSpec("entries/rows"),
+          "partition_counts" -> PartitionCountsComponentSpec(partCounts)))
+      spec.write(hc, path)
+
+      hConf.writeTextFile(path + "/_SUCCESS")(out => ())
+      val nRows = partCounts.sum
+      val nCols = mv.colValues.value.length
+      info(s"wrote matrix table with $nRows ${ plural(nRows, "row") } " +
+        s"and $nCols ${ plural(nCols, "column") } " +
+        s"in ${ partCounts.length } ${ plural(partCounts.length, "partition") } " +
+        s"to $path")
+    }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -62,5 +62,5 @@ case class MatrixNativeMultiWriter(
   overwrite: Boolean = false,
   stageLocally: Boolean = false
 ) {
-  def apply(mvs: Array[MatrixValue]): Unit = MatrixValue.writeMultiple(mvs, prefix, overwrite, stageLocally)
+  def apply(mvs: IndexedSeq[MatrixValue]): Unit = MatrixValue.writeMultiple(mvs, prefix, overwrite, stageLocally)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixWriter.scala
@@ -49,3 +49,18 @@ case class MatrixPLINKWriter(
 ) extends MatrixWriter {
   def apply(mv: MatrixValue): Unit = ExportPlink(mv, path)
 }
+
+object MatrixNativeMultiWriter {
+  implicit val formats: Formats = new DefaultFormats() {
+    override val typeHints = ShortTypeHints(List(classOf[MatrixNativeMultiWriter]))
+    override val typeHintFieldName = "name"
+  }
+}
+
+case class MatrixNativeMultiWriter(
+  prefix: String,
+  overwrite: Boolean = false,
+  stageLocally: Boolean = false
+) {
+  def apply(mvs: Array[MatrixValue]): Unit = MatrixValue.writeMultiple(mvs, prefix, overwrite, stageLocally)
+}

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -759,6 +759,12 @@ object IRParser {
         val writer = Serialization.read[MatrixWriter](writerStr)
         val child = matrix_ir(env)(it)
         MatrixWrite(child, writer)
+      case "MatrixMultiWrite" =>
+        val writerStr = string_literal(it)
+        implicit val formats = MatrixNativeMultiWriter.formats
+        val writer = Serialization.read[MatrixNativeMultiWriter](writerStr)
+        val children = matrix_ir_children(env)(it)
+        MatrixMultiWrite(children, writer)
       case "JavaIR" =>
         val name = identifier(it)
         env.irMap(name).asInstanceOf[IR]

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -193,6 +193,8 @@ object Pretty {
               '"' + StringEscapeUtils.escapeString(Serialization.write(reader)(MatrixReader.formats)) + '"'
             case MatrixWrite(_, writer) =>
               '"' + StringEscapeUtils.escapeString(Serialization.write(writer)(MatrixWriter.formats)) + '"'
+            case MatrixMultiWrite(_, writer) =>
+              '"' + StringEscapeUtils.escapeString(Serialization.write(writer)(MatrixNativeMultiWriter.formats)) + '"'
             case TableToMatrixTable(_, rowKey, colKey, rowFields, colFields, nPartitions) =>
               prettyStrings(rowKey) + " " +
               prettyStrings(colKey) +  " " +

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -257,6 +257,7 @@ object TypeCheck {
         assert(min.typ.isInstanceOf[TFloat64])
         assert(max.typ.isInstanceOf[TFloat64])
       case MatrixWrite(_, _) =>
+      case MatrixMultiWrite(_, _) => // do nothing
       case x@TableAggregate(child, query) =>
         check(query,
           env = child.typ.globalEnv,

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -1318,7 +1318,7 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RVDContext, RegionValue]) e
     path: String,
     t: RVDType,
     codecSpec: CodecSpec,
-    partitioners: Array[RVDPartitioner],
+    partitioners: IndexedSeq[RVDPartitioner],
     stageLocally: Boolean
   ): Array[Array[Long]] = {
     val sc = crdd.sparkContext
@@ -1427,8 +1427,8 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RVDContext, RegionValue]) e
 
       Iterator.single((f, rowCount, originIdx))
     }.collect()
-    val partFilesByOrigin = new Array[ArrayBuilder[String]](rdd.rdds.length)
-    val partitionCountsByOrigin = new Array[ArrayBuilder[Long]](rdd.rdds.length)
+    val partFilesByOrigin = Array.fill[ArrayBuilder[String]](rdd.rdds.length)(new ArrayBuilder())
+    val partitionCountsByOrigin = Array.fill[ArrayBuilder[Long]](rdd.rdds.length)(new ArrayBuilder())
 
     for ((f, rowCount, oidx) <- partFilePartitionCounts) {
       partFilesByOrigin(oidx) += f

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -1353,8 +1353,8 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RVDContext, RegionValue]) e
       val f = partFile(partDigits, i, context)
       val s = StringUtils.leftPad(originIdx.toString, fileDigits, '0')
       val outputMetrics = context.taskMetrics().outputMetrics
-      val finalRowsPartPath = path + s + ".mt" + "/rows/rows/parts" + f
-      val finalEntriesPartPath = path + s + ".mt" + "/entries/rows/parts" + f
+      val finalRowsPartPath = path + s + ".mt" + "/rows/rows/parts/" + f
+      val finalEntriesPartPath = path + s + ".mt" + "/entries/rows/parts/" + f
 
       val (rowsPartPath, entriesPartPath) =
         if (stageLocally) {
@@ -1447,7 +1447,7 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RVDContext, RegionValue]) e
       rowsSpec.write(hConf, basePath + "/rows/rows")
 
       val entriesSpec = OrderedRVDSpec(entriesRVType, FastIndexedSeq(), codecSpec, partFiles(i), RVDPartitioner.unkeyed(partCounts(i).length))
-      rowsSpec.write(hConf, basePath + "/entries/rows")
+      entriesSpec.write(hConf, basePath + "/entries/rows")
 
       i += 1
     }

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -674,6 +674,14 @@ class RVD(
     stageLocally: Boolean
   ): Array[Long] = crdd.writeRowsSplit(path, typ, codecSpec, partitioner, stageLocally)
 
+  def writeRowsSplitFiles(
+    path: String,
+    codecSpec: CodecSpec,
+    stageLocally: Boolean
+  ): Array[(Int, Long)] = {
+    ???
+  }
+
   // Joining
 
   def orderedLeftJoinDistinctAndInsert(

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -1295,7 +1295,7 @@ object RVD {
     union(rvds, rvds.head.typ.key.length)
 
   def writeRowsSplitFiles(
-    rvds: Array[RVD],
+    rvds: IndexedSeq[RVD],
     path: String,
     codecSpec: CodecSpec,
     stageLocally: Boolean

--- a/hail/src/main/scala/is/hail/sparkextras/OriginUnionRDD.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/OriginUnionRDD.scala
@@ -8,11 +8,9 @@ import scala.reflect.ClassTag
 
 private[hail] case class OriginUnionPartition[T: ClassTag](
   val index: Int,
-  @transient private val rdd: RDD[T],
   val originIdx: Int,
-  @transient private val originPartIdx: Int
+  val originPart: Partition
 ) extends Partition {
-  val originPart = rdd.partitions(originPartIdx)
 }
 
 class OriginUnionRDD[T: ClassTag](
@@ -23,7 +21,7 @@ class OriginUnionRDD[T: ClassTag](
     val arr = new Array[Partition](rdds.map(_.partitions.length).sum)
     var i = 0
     for ((rdd, rddIdx) <- rdds.zipWithIndex; part <- rdd.partitions) {
-      arr(i) = OriginUnionPartition(i, rdd, rddIdx, part.index)
+      arr(i) = OriginUnionPartition(i, rddIdx, part)
       i += 1
     }
     arr

--- a/hail/src/main/scala/is/hail/sparkextras/OriginUnionRDD.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/OriginUnionRDD.scala
@@ -1,0 +1,51 @@
+package is.hail.sparkextras
+
+import org.apache.spark.{Dependency, Partition, RangeDependency, SparkContext, TaskContext}
+import org.apache.spark.rdd.RDD
+
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
+
+private[hail] case class OriginUnionPartition[T: ClassTag](
+  val index: Int,
+  @transient private val rdd: RDD[T],
+  val originIdx: Int,
+  @transient private val originPartIdx: Int
+) extends Partition {
+  val originPart = rdd.partitions(originPartIdx)
+}
+
+class OriginUnionRDD[T: ClassTag](
+  sc: SparkContext,
+  var rdds: IndexedSeq[RDD[T]]
+) extends RDD[T](sc, Nil) {
+  override def getPartitions: Array[Partition] = {
+    val arr = new Array[Partition](rdds.map(_.partitions.length).sum)
+    var i = 0
+    for ((rdd, rddIdx) <- rdds.zipWithIndex; part <- rdd.partitions) {
+      arr(i) = OriginUnionPartition(i, rdd, rddIdx, part.index)
+      i += 1
+    }
+    arr
+  }
+
+  override def getDependencies(): Seq[Dependency[_]] = {
+    val deps = new ArrayBuffer[Dependency[_]]
+    var i = 0
+    for (rdd <- rdds) {
+      deps += new RangeDependency(rdd, 0, i, rdd.partitions.length)
+      i += rdd.partitions.length
+    }
+    deps
+  }
+
+  override def compute(s: Partition, tc: TaskContext) = {
+    val p = s.asInstanceOf[OriginUnionPartition[T]]
+    parent[T](p.originIdx).iterator(p.originPart, tc)
+  }
+
+  override def clearDependencies() {
+    super.clearDependencies()
+    rdds = null
+  }
+}

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -827,7 +827,7 @@ class IRSuite extends SparkSuite {
       MatrixWrite(vcf, MatrixVCFWriter(tmpDir.createLocalTempFile(extension = "vcf"))),
       MatrixWrite(vcf, MatrixPLINKWriter(tmpDir.createLocalTempFile())),
       MatrixWrite(bgen, MatrixGENWriter(tmpDir.createLocalTempFile())),
-      MatrixMultiWrite(Array(mt), MatrixNativeMultiWriter(tmpDir.createLocalTempFile())),
+      MatrixMultiWrite(Array(mt, mt), MatrixNativeMultiWriter(tmpDir.createLocalTempFile())),
       MatrixAggregate(mt, MakeStruct(Seq("foo" -> count)))
     )
     irs.map(x => Array(x))

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -827,6 +827,7 @@ class IRSuite extends SparkSuite {
       MatrixWrite(vcf, MatrixVCFWriter(tmpDir.createLocalTempFile(extension = "vcf"))),
       MatrixWrite(vcf, MatrixPLINKWriter(tmpDir.createLocalTempFile())),
       MatrixWrite(bgen, MatrixGENWriter(tmpDir.createLocalTempFile())),
+      MatrixMultiWrite(Array(mt), MatrixNativeMultiWriter(tmpDir.createLocalTempFile())),
       MatrixAggregate(mt, MakeStruct(Seq("foo" -> count)))
     )
     irs.map(x => Array(x))

--- a/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
@@ -42,7 +42,7 @@ class MatrixIRSuite extends SparkSuite {
 
     val newMatrix = MatrixMapRows(mt, newRow)
     val rows = getRows(newMatrix)
-    assert(rows.forall { case Row(row_idx: Int, range: IndexedSeq[Int]) => range sameElements Array.range(0, row_idx) })
+    assert(rows.forall { case Row(row_idx: Int, range: IndexedSeq[_]) => range sameElements Array.range(0, row_idx) })
   }
 
   @Test def testScanCollectBehavesLikeRangeWithAggregationOnRows() {
@@ -53,7 +53,7 @@ class MatrixIRSuite extends SparkSuite {
 
     val newMatrix = MatrixMapRows(mt, newRow)
     val rows = getRows(newMatrix)
-    assert(rows.forall { case Row(row_idx: Int, n: Long, range: IndexedSeq[Int]) => (n == 20) && (range sameElements Array.range(0, row_idx)) })
+    assert(rows.forall { case Row(row_idx: Int, n: Long, range: IndexedSeq[_]) => (n == 20) && (range sameElements Array.range(0, row_idx)) })
   }
 
   @Test def testScanCountBehavesLikeIndexOnCols() {
@@ -75,7 +75,7 @@ class MatrixIRSuite extends SparkSuite {
 
     val newMatrix = MatrixMapCols(mt, newCol, None)
     val cols = getCols(newMatrix)
-    assert(cols.forall { case Row(col_idx: Int, range: IndexedSeq[Int]) => range sameElements Array.range(0, col_idx) })
+    assert(cols.forall { case Row(col_idx: Int, range: IndexedSeq[_]) => range sameElements Array.range(0, col_idx) })
   }
 
   @Test def testScanCollectBehavesLikeRangeWithAggregationOnCols() {
@@ -86,7 +86,7 @@ class MatrixIRSuite extends SparkSuite {
 
     val newMatrix = MatrixMapCols(mt, newCol, None)
     val cols = getCols(newMatrix)
-    assert(cols.forall { case Row(col_idx: Int, n: Long, range: IndexedSeq[Int]) => (n == 20) && (range sameElements Array.range(0, col_idx)) })
+    assert(cols.forall { case Row(col_idx: Int, n: Long, range: IndexedSeq[_]) => (n == 20) && (range sameElements Array.range(0, col_idx)) })
   }
 
   def rangeRowMatrix(start: Int, end: Int): MatrixIR = {

--- a/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
@@ -315,6 +315,11 @@ class MatrixIRSuite extends SparkSuite {
     val read1 = MatrixTable.read(hc, path + "1.mt")
     assert(ranges(0).same(read0))
     assert(ranges(1).same(read1))
+
+    val pathRef = tmpDir.createLocalTempFile(extension = "mt")
+    Interpret(MatrixWrite(ranges(1).ast, MatrixNativeWriter(path)))
+    val readRef = MatrixTable.read(hc, path)
+    assert(readRef.same(read1))
   }
 
   @Test def testMatrixMultiWriteDifferentTypesFails() {


### PR DESCRIPTION
Some notes
- Currently, all matrix tables must have the same type.
- The `path` argument is treated as a prefix, to which zero-padded `0.mt` to `n.mt` is appended.
- The partfile file names are sequential across all writes.