### PR TITLE
Added tmatrix/ttable types, {Matrix}Table.schema.

### DIFF
--- a/hail/python/hail/expr/__init__.py
+++ b/hail/python/hail/expr/__init__.py
@@ -1,4 +1,6 @@
 from .types import *
+from .table_type import ttable
+from .matrix_type import tmatrix
 from .expressions import eval, eval_typed
 from .functions import *
 __all__ = ['HailType',
@@ -20,6 +22,8 @@ __all__ = ['HailType',
            'tlocus',
            'tcall',
            'tvoid',
+           'ttable',
+           'tmatrix',
            'hts_entry_schema',
            'eval',
            'eval_typed',

--- a/hail/python/hail/expr/__init__.py
+++ b/hail/python/hail/expr/__init__.py
@@ -1,6 +1,6 @@
 from .types import *
-from .table_type import ttable
-from .matrix_type import tmatrix
+from .table_type import *
+from .matrix_type import *
 from .expressions import eval, eval_typed
 from .functions import *
 __all__ = ['HailType',

--- a/hail/python/hail/expr/matrix_type.py
+++ b/hail/python/hail/expr/matrix_type.py
@@ -1,0 +1,97 @@
+from hail.typecheck import *
+from hail.utils.java import escape_parsable
+from hail.expr.types import tstruct
+
+class tmatrix(object):
+    @typecheck_method(global_type=tstruct,
+                      col_type=tstruct, col_key=sequenceof(str),
+                      row_type=tstruct, row_key=sequenceof(str),
+                      entry_type=tstruct)
+    def __init__(self, global_type, col_type, col_key, row_type, row_key, entry_type):
+        self.global_type = global_type
+        self.col_type = col_type
+        self.col_key = col_key
+        self.row_type = row_type
+        self.row_key = row_key
+        self.entry_type = entry_type
+
+    def __eq__(self, other):
+        return (isinstance(other, ttable)
+                and self.global_type == other.global_type
+                and self.col_type == other.col_type
+                and self.col_key == other.col_key
+                and self.row_type == other.row_type
+                and self.row_key == other.row_key
+                and self.entry_type == other.entry_type)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return 43 + hash(str(self))
+
+    def __repr__(self):
+        return f'tmatrix(global_type={self.global_type!r}, col_type={self.col_type!r}, col_key={self.col_key!r}, row_type={self.row_type!r}, row_key={self.row_key!r}, entry_type={self.entry_type!r})'
+
+    def _row_key_str(self):
+        return ', '.join([escape_parsable(k) for k in self.row_key])
+
+    def _col_key_str(self):
+        return ', '.join([escape_parsable(k) for k in self.col_key])
+
+    def __str__(self):
+        return f'matrix {{global: {self.global_type}, col: {self.col_type}, col_key: {self._col_key_str()}, row: {self.row_type}, row_key: [{self._row_key_str()}], entry: {self.entry_type}}}'
+
+    def pretty(self, indent=0, increment=4):
+        l = []
+        l.append(' ' * indent)
+        l.append('matrix {\n')
+        indent += increment
+        
+        l.append(' ' * indent)
+        l.append('global: ')
+        self.global_type._pretty(l, indent, increment)
+        l.append(',\n')
+        
+        l.append(' ' * indent)
+        l.append('row: ')
+        self.row_type._pretty(l, indent, increment)
+        l.append(',\n')
+        
+        l.append(' ' * indent)
+        l.append(f'row_key: [{self._row_key_str()}],\n')
+        
+        l.append(' ' * indent)
+        l.append('col: ')
+        self.col_type._pretty(l, indent, increment)
+        l.append(',\n')
+        
+        l.append(' ' * indent)
+        l.append(f'col_key: [{self._col_key_str()}],\n')
+        
+        l.append(' ' * indent)
+        l.append('entry: ')
+        self.entry_type._pretty(l, indent, increment)
+        l.append('\n')
+        
+        indent -= increment
+        l.append(' ' * indent)
+        l.append('}')
+        
+        return ''.join(l)
+
+
+import pprint
+
+_old_printer = pprint.PrettyPrinter
+
+
+class TypePrettyPrinter(pprint.PrettyPrinter):
+    def _format(self, object, stream, indent, allowance, context, level):
+        if isinstance(object, tmatrix):
+            stream.write(object.pretty(self._indent_per_level))
+        else:
+            return _old_printer._format(self, object, stream, indent, allowance, context, level)
+
+
+pprint.PrettyPrinter = TypePrettyPrinter  # monkey-patch pprint

--- a/hail/python/hail/expr/matrix_type.py
+++ b/hail/python/hail/expr/matrix_type.py
@@ -24,9 +24,6 @@ class tmatrix(object):
                 and self.row_key == other.row_key
                 and self.entry_type == other.entry_type)
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
     def __hash__(self):
         return 43 + hash(str(self))
 

--- a/hail/python/hail/expr/matrix_type.py
+++ b/hail/python/hail/expr/matrix_type.py
@@ -86,7 +86,7 @@ import pprint
 _old_printer = pprint.PrettyPrinter
 
 
-class TypePrettyPrinter(pprint.PrettyPrinter):
+class PrettyPrinter(pprint.PrettyPrinter):
     def _format(self, object, stream, indent, allowance, context, level):
         if isinstance(object, tmatrix):
             stream.write(object.pretty(self._indent_per_level))
@@ -94,4 +94,4 @@ class TypePrettyPrinter(pprint.PrettyPrinter):
             return _old_printer._format(self, object, stream, indent, allowance, context, level)
 
 
-pprint.PrettyPrinter = TypePrettyPrinter  # monkey-patch pprint
+pprint.PrettyPrinter = PrettyPrinter  # monkey-patch pprint

--- a/hail/python/hail/expr/table_type.py
+++ b/hail/python/hail/expr/table_type.py
@@ -1,0 +1,72 @@
+from hail.typecheck import *
+from hail.utils.java import escape_parsable
+from hail.expr.types import tstruct
+
+class ttable(object):
+    @typecheck_method(global_type=tstruct, row_type=tstruct, row_key=sequenceof(str))
+    def __init__(self, global_type, row_type, row_key):
+        self.global_type = global_type
+        self.row_type = row_type
+        self.row_key = row_key
+
+    def __eq__(self, other):
+        return (isinstance(other, ttable)
+                and self.global_type == other.global_type
+                and self.row_type == other.row_type
+                and self.row_key == other.row_key)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return 43 + hash(str(self))
+
+    def __repr__(self):
+        return f'ttable(global_type={self.global_type!r}, row_type={self.row_type!r}, row_key={self.row_key!r})'
+
+    def _key_str(self):
+        return ', '.join([escape_parsable(k) for k in self.row_key])
+
+    def __str__(self):
+        return f'table {{global: {self.global_type}, row: {self.row_type}, row_key: [{self._key_str()}]}}'
+
+    def pretty(self, indent=0, increment=4):
+        l = []
+        l.append(' ' * indent)
+        l.append('table {\n')
+        indent += increment
+        
+        l.append(' ' * indent)
+        l.append('global: ')
+        self.global_type._pretty(l, indent, increment)
+        l.append(',\n')
+        
+        l.append(' ' * indent)
+        l.append('row: ')
+        self.row_type._pretty(l, indent, increment)
+        l.append(',\n')
+        
+        l.append(' ' * indent)
+        l.append(f'row_key: [{self._key_str()}]\n')
+
+        indent -= increment
+        l.append(' ' * indent)
+        l.append('}')
+        
+        return ''.join(l)
+
+
+import pprint
+
+_old_printer = pprint.PrettyPrinter
+
+
+class TypePrettyPrinter(pprint.PrettyPrinter):
+    def _format(self, object, stream, indent, allowance, context, level):
+        if isinstance(object, ttable):
+            stream.write(object.pretty(self._indent_per_level))
+        else:
+            return _old_printer._format(self, object, stream, indent, allowance, context, level)
+
+
+pprint.PrettyPrinter = TypePrettyPrinter  # monkey-patch pprint

--- a/hail/python/hail/expr/table_type.py
+++ b/hail/python/hail/expr/table_type.py
@@ -15,9 +15,6 @@ class ttable(object):
                 and self.row_type == other.row_type
                 and self.row_key == other.row_key)
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
     def __hash__(self):
         return 43 + hash(str(self))
 

--- a/hail/python/hail/expr/table_type.py
+++ b/hail/python/hail/expr/table_type.py
@@ -61,7 +61,7 @@ import pprint
 _old_printer = pprint.PrettyPrinter
 
 
-class TypePrettyPrinter(pprint.PrettyPrinter):
+class PrettyPrinter(pprint.PrettyPrinter):
     def _format(self, object, stream, indent, allowance, context, level):
         if isinstance(object, ttable):
             stream.write(object.pretty(self._indent_per_level))
@@ -69,4 +69,4 @@ class TypePrettyPrinter(pprint.PrettyPrinter):
             return _old_printer._format(self, object, stream, indent, allowance, context, level)
 
 
-pprint.PrettyPrinter = TypePrettyPrinter  # monkey-patch pprint
+pprint.PrettyPrinter = PrettyPrinter  # monkey-patch pprint

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -836,14 +836,14 @@ class tstruct(HailType, Mapping):
                 and all(self[f] == other[f] for f in self._fields))
 
     def _pretty(self, l, indent, increment):
-        if not self.items():
+        if not self._field_types:
             l.append('struct {}')
             return
 
         pre_indent = indent
         indent += increment
         l.append('struct {')
-        for i, (f, t) in enumerate(self.items()):
+        for i, (f, t) in enumerate(self._field_types):
             if i > 0:
                 l.append(', ')
             l.append('\n')

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -148,6 +148,7 @@ class HailType(object):
         :obj:`str`
         """
         l = []
+        l.append(' ' * indent)
         self._pretty(l, indent, increment)
         return ''.join(l)
 
@@ -835,6 +836,10 @@ class tstruct(HailType, Mapping):
                 and all(self[f] == other[f] for f in self._fields))
 
     def _pretty(self, l, indent, increment):
+        if not self.items():
+            l.append('struct {}')
+            return
+
         pre_indent = indent
         indent += increment
         l.append('struct {')
@@ -1281,7 +1286,6 @@ def types_match(left, right) -> bool:
 import pprint
 
 _old_printer = pprint.PrettyPrinter
-
 
 
 class TypePrettyPrinter(pprint.PrettyPrinter):

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -128,9 +128,6 @@ class HailType(object):
     def __str__(self):
         return
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
     def __hash__(self):
         # FIXME this is a bit weird
         return 43 + hash(str(self))
@@ -836,14 +833,14 @@ class tstruct(HailType, Mapping):
                 and all(self[f] == other[f] for f in self._fields))
 
     def _pretty(self, l, indent, increment):
-        if not self._field_types:
+        if not self._fields:
             l.append('struct {}')
             return
 
         pre_indent = indent
         indent += increment
         l.append('struct {')
-        for i, (f, t) in enumerate(self._field_types):
+        for i, (f, t) in enumerate(self.items()):
             if i > 0:
                 l.append(', ')
             l.append('\n')

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -606,13 +606,7 @@ class MatrixTable(ExprContainer):
             self._set_field(k, v)
 
     @property
-    def schema(self) -> tmatrix:
-        """The schema of the matrix table.
-
-        Returns
-        -------
-        :class:`.tmatrix`
-        """
+    def _schema(self) -> tmatrix:
         return tmatrix(
             self._global_type,
             self._col_type, list(self._col_key),

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -7,6 +7,8 @@ import hail
 import hail as hl
 from hail.expr.expressions import *
 from hail.expr.types import *
+from hail.expr.table_type import *
+from hail.expr.matrix_type import *
 from hail.ir import *
 from hail.table import Table, ExprContainer
 from hail.typecheck import *
@@ -602,6 +604,20 @@ class MatrixTable(ExprContainer):
                                     self._col.items(),
                                     self._entry.items()):
             self._set_field(k, v)
+
+    @property
+    def schema(self) -> tmatrix:
+        """The schema of the matrix table.
+
+        Returns
+        -------
+        :class:`.tmatrix`
+        """
+        return tmatrix(
+            self._global_type,
+            self._col_type, list(self._col_key),
+            self._row_type, list(self._row_key),
+            self._entry_type)
 
     def __getitem__(self, item):
         invalid_usage = TypeError(f"MatrixTable.__getitem__: invalid index argument(s)\n"

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -354,13 +354,7 @@ class Table(ExprContainer):
             self._set_field(k, v)
 
     @property
-    def schema(self) -> ttable:
-        """The schema of the table.
-
-        Returns
-        -------
-        :class:`.ttable`
-        """
+    def _schema(self) -> ttable:
         return ttable(self._global_type, self._row_type, list(self._key))
 
     def __getitem__(self, item):

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -7,6 +7,8 @@ from typing import *
 import hail as hl
 from hail.expr.expressions import *
 from hail.expr.types import *
+from hail.expr.table_type import *
+from hail.expr.matrix_type import *
 from hail.ir import *
 from hail.typecheck import *
 from hail.utils import wrap_to_list, storage_level, LinkedList, Struct
@@ -351,6 +353,15 @@ class Table(ExprContainer):
                                     self._row.items()):
             self._set_field(k, v)
 
+    @property
+    def schema(self) -> ttable:
+        """The schema of the table.
+
+        Returns
+        -------
+        :class:`.ttable`
+        """
+        return ttable(self._global_type, self._row_type, list(self._key))
 
     def __getitem__(self, item):
         if isinstance(item, str):


### PR DESCRIPTION
Also fixed a bug, HailType.pretty was missing the initial indent.

A few design questions:
 - Are ttable/tmatrix dtypes?  I'm treating dtype as value types, so no.
 - Unlike HailType, __str__ return a dense but user-readable format, and __repr__ returns code-as-string to recreate the type.
 - I went for the lower case tmatrix and table.  MatrixType and TableType would also be reasonable (and more analogous to HailType).

Also, why is HailType not just Type?  If you're in module hail, I don't see the need for the Hail prefix.

I'll add BaseType, etc. analogous to Scala in another PR.
