### PR TITLE
Backend read

### DIFF
--- a/hail/python/hail/expr/matrix_type.py
+++ b/hail/python/hail/expr/matrix_type.py
@@ -1,8 +1,19 @@
 from hail.typecheck import *
 from hail.utils.java import escape_parsable
-from hail.expr.types import tstruct
+from hail.expr.types import dtype, tstruct
+from hail.utils.java import jiterable_to_list
 
 class tmatrix(object):
+    @staticmethod
+    def _from_java(jtt):
+        return tmatrix(
+            dtype(jtt.globalType().toString()),
+            dtype(jtt.colType().toString()),
+            jiterable_to_list(jtt.colKey()),
+            dtype(jtt.rowType().toString()),
+            jiterable_to_list(jtt.rowKey()),
+            dtype(jtt.entryType().toString()))
+
     @typecheck_method(global_type=tstruct,
                       col_type=tstruct, col_key=sequenceof(str),
                       row_type=tstruct, row_key=sequenceof(str),

--- a/hail/python/hail/expr/table_type.py
+++ b/hail/python/hail/expr/table_type.py
@@ -1,8 +1,16 @@
 from hail.typecheck import *
 from hail.utils.java import escape_parsable
-from hail.expr.types import tstruct
+from hail.expr.types import dtype, tstruct
+from hail.utils.java import jiterable_to_list
 
 class ttable(object):
+    @staticmethod
+    def _from_java(jtt):
+        return ttable(
+            dtype(jtt.globalType().toString()),
+            dtype(jtt.rowType().toString()),
+            jiterable_to_list(jtt.key()))
+
     @typecheck_method(global_type=tstruct, row_type=tstruct, row_key=sequenceof(str))
     def __init__(self, global_type, row_type, row_key):
         self.global_type = global_type

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -148,38 +148,46 @@ class Cast(IR):
     def __init__(self, v, typ):
         super().__init__(v)
         self.v = v
-        self.typ = typ
+        self._typ = typ
+
+    @property
+    def typ(self):
+        return self._typ
 
     @typecheck_method(v=IR)
     def copy(self, v):
         new_instance = self.__class__
-        return new_instance(v, self.typ)
+        return new_instance(v, self._typ)
 
     def render(self, r):
-        return '(Cast {} {})'.format(self.typ._parsable_string(), r(self.v))
+        return '(Cast {} {})'.format(self._typ._parsable_string(), r(self.v))
 
     def __eq__(self, other):
         return isinstance(other, Cast) and \
         other.v == self.v and \
-        other.typ == self.typ
+        other._typ == self._typ
 
 
 class NA(IR):
     @typecheck_method(typ=hail_type)
     def __init__(self, typ):
         super().__init__()
-        self.typ = typ
+        self._typ = typ
+
+    @property
+    def typ(self):
+        return self._typ
 
     def copy(self):
         new_instance = self.__class__
-        return new_instance(self.typ)
+        return new_instance(self._typ)
 
     def render(self, r):
-        return '(NA {})'.format(self.typ._parsable_string())
+        return '(NA {})'.format(self._typ._parsable_string())
 
     def __eq__(self, other):
         return isinstance(other, NA) and \
-               other.typ == self.typ
+               other._typ == self._typ
 
 
 class IsNA(IR):
@@ -354,25 +362,25 @@ class ApplyComparisonOp(IR):
 
 
 class MakeArray(IR):
-    @typecheck_method(args=sequenceof(IR), typ=nullable(hail_type))
-    def __init__(self, args, typ):
+    @typecheck_method(args=sequenceof(IR), element_type=nullable(hail_type))
+    def __init__(self, args, element_type):
         super().__init__(*args)
         self.args = args
-        self.typ = typ
+        self._element_type = element_type
 
     def copy(self, *args):
         new_instance = self.__class__
-        return new_instance(list(args), self.typ)
+        return new_instance(list(args), self._element_type)
 
     def render(self, r):
         return '(MakeArray {} {})'.format(
-            self.typ._parsable_string() if self.typ is not None else 'None',
+            self._element_type._parsable_string() if self._element_type is not None else 'None',
             ' '.join([r(x) for x in self.args]))
 
     def __eq__(self, other):
         return isinstance(other, MakeArray) and \
                other.args == self.args and \
-               other.typ == self.typ
+               other._element_type == self._element_type
 
 
 class ArrayRef(IR):
@@ -1056,19 +1064,23 @@ class In(IR):
     def __init__(self, i, typ):
         super().__init__()
         self.i = i
-        self.typ = typ
+        self._typ = typ
+
+    @property
+    def typ(self):
+        return self._typ
 
     def copy(self):
         new_instance = self.__class__
-        return new_instance(self.i, self.typ)
+        return new_instance(self.i, self._typ)
 
     def render(self, r):
-        return '(In {} {})'.format(self.typ._parsable_string(), self.i)
+        return '(In {} {})'.format(self._typ._parsable_string(), self.i)
 
     def __eq__(self, other):
         return isinstance(other, In) and \
                other.i == self.i and \
-               other.typ == self.typ
+               other._typ == self._typ
 
 
 class Die(IR):
@@ -1076,19 +1088,23 @@ class Die(IR):
     def __init__(self, message, typ):
         super().__init__()
         self.message = message
-        self.typ = typ
+        self._typ = typ
+
+    @property
+    def typ(self):
+        return self._typ
 
     def copy(self):
         new_instance = self.__class__
-        return new_instance(self.message, self.typ)
+        return new_instance(self.message, self._typ)
 
     def render(self, r):
-        return '(Die {} {})'.format(self.typ._parsable_string(), r(self.message))
+        return '(Die {} {})'.format(self._typ._parsable_string(), r(self.message))
 
     def __eq__(self, other):
         return isinstance(other, Die) and \
                other.message == self.message and \
-               other.typ == self.typ
+               other._typ == self._typ
 
 
 class Apply(IR):

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -94,26 +94,26 @@ class TableRead(TableIR):
         super().__init__()
         self.path = path
         self.drop_rows = drop_rows
-        self.typ = typ
+        self._typ = typ
 
     def render(self, r):
         return '(TableRead "{}" {} {})'.format(
             escape_str(self.path),
             self.drop_rows,
-            self.typ)
+            self._typ)
 
 
 class TableImport(TableIR):
     def __init__(self, paths, typ, reader_options):
         super().__init__()
         self.paths = paths
-        self.typ = typ
+        self._typ = typ
         self.reader_options = reader_options
 
     def render(self, r):
         return '(TableImport ({}) {} {})'.format(
             ' '.join([escape_str(path) for path in self.paths]),
-            self.typ._parsable_string(),
+            self._typ._parsable_string(),
             escape_str(json.dumps(self.reader_options)))
 
 

--- a/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
+++ b/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
@@ -101,6 +101,8 @@ object JSONAnnotationImpex {
         case _: TFloat32 => JDouble(a.asInstanceOf[Float])
         case _: TFloat64 => JDouble(a.asInstanceOf[Double])
         case _: TString => JString(a.asInstanceOf[String])
+        case TVoid =>
+          JNull
         case TArray(elementType, _) =>
           val arr = a.asInstanceOf[Seq[Any]]
           JArray(arr.map(elem => exportAnnotation(elem, elementType)).toList)

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -1,7 +1,5 @@
 package is.hail.expr.ir
 
-import java.io.{PrintWriter, StringWriter}
-
 import is.hail.{HailContext, Uploader, stats}
 import is.hail.annotations.aggregators.RegionValueAggregator
 import is.hail.annotations._
@@ -13,29 +11,16 @@ import is.hail.expr.types.virtual._
 import is.hail.methods._
 import is.hail.utils._
 import org.apache.spark.sql.Row
-import org.json4s.JsonAST.JNull
 import org.json4s.jackson.JsonMethods
-
-import scala.collection.JavaConverters._
 
 object Interpret {
   type Agg = (IndexedSeq[Row], TStruct)
 
-  def interpretPyIR(s: String, refMap: java.util.HashMap[String, Type], irMap: java.util.HashMap[String, BaseIR]): String = {
-    interpretPyIR(s, refMap.asScala.toMap, irMap.asScala.toMap)
-  }
-
-  def interpretPyIR(s: String, refMap: Map[String, Type] = Map.empty, irMap: Map[String, BaseIR] = Map.empty): String = {
-    val ir = IRParser.parse_value_ir(s, IRParserEnvironment(refMap, irMap))
+  def interpretJSON(ir: IR): String = {
     val t = ir.typ
     val value = Interpret[Any](ir)
-
-    val jsonValue = t match {
-      case TVoid => JNull
-      case _ => JSONAnnotationImpex.exportAnnotation(value, t)
-    }
-
-    JsonMethods.compact(jsonValue)
+    JsonMethods.compact(
+      JSONAnnotationImpex.exportAnnotation(value, t))
   }
 
   def apply(tir: TableIR): TableValue =

--- a/hail/src/main/scala/is/hail/expr/types/TableType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/TableType.scala
@@ -1,6 +1,5 @@
 package is.hail.expr.types
 
-import is.hail.expr.Parser
 import is.hail.expr.ir._
 import is.hail.expr.types.virtual.{TStruct, Type}
 import is.hail.rvd.RVDType


### PR DESCRIPTION
Builds on: https://github.com/hail-is/hail/pull/4995

First of several (many) changes to rip out Java dependence from the mainline Python code.  Move _to_java_ir to the SparkBackend.  Eventually, only the Spark backend should call Java.  Matrix/Table now gets it types from BaseIR.typ (which will eventually implement the (virtual) typing rules in Python).  Matrix/Table explicitly call into the Spark backend to create _jmt/_jt, but those can be removed once the methods are all using IR.

@tpoterba giving this to you since you got the last one.  Let me know if you would prefer me to spin the wheel.
