### PR TITLE
convert more Table operations to IR

### DIFF
--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -9,8 +9,12 @@ from hail.ir.renderer import Renderer
 
 class Backend(object):
     @abc.abstractmethod
-    def interpret(self, ir):
+    def execute(self, ir):
         return
+
+    # FIXME delete
+    def interpret(self, ir):
+        return self.execute(ir)
 
     @abc.abstractmethod
     def table_read_type(self, table_read_ir):
@@ -30,7 +34,7 @@ class SparkBackend(Backend):
             ir._jir = ir.parse(code, ir_map=r.jirs)
         return ir._jir
 
-    def interpret(self, ir):
+    def execute(self, ir):
         return ir.typ._from_json(
             Env.hail().expr.ir.Interpret.interpretJSON(
                 self._to_java_ir(ir)))
@@ -50,7 +54,7 @@ class ServiceBackend(Backend):
         self.host = host
         self.port = port
 
-    def interpret(self, ir):
+    def execute(self, ir):
         r = Renderer(stop_at_jir=True)
         code = r(ir)
         assert len(r.jirs) == 0

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1291,9 +1291,9 @@ class TableWrite(IR):
 class TableExport(IR):
     @typecheck_method(child=TableIR,
                       path=str,
-                      types_file=str,
+                      types_file=nullable(str),
                       header=bool,
-                      export_type=hail_type)
+                      export_type=int)
     def __init__(self, child, path, types_file, header, export_type):
         super().__init__(child)
         self.child = child
@@ -1308,12 +1308,12 @@ class TableExport(IR):
         return new_instance(child, self.path, self.types_file, self.header, self.export_type)
 
     def render(self, r):
-        return '(TableExport "{}" "{}" "{}" {} {})'.format(
+        return '(TableExport {} "{}" "{}" {} {})'.format(
+            r(self.child),
             escape_str(self.path),
-            escape_str(self.types_file),
-            escape_str(self.header),
-            self.export_type,
-            r(self.child))
+            escape_str(self.types_file) if self.types_file else 'None',
+            self.header,
+            self.export_type)
 
     def __eq__(self, other):
         return isinstance(other, TableExport) and \

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -25,6 +25,15 @@ class TableJoin(TableIR):
         return '(TableJoin {} {} {} {})'.format(
             escape_id(self.join_type), self.join_key, r(self.left), r(self.right))
 
+class TableLeftJoinRightDistinct(TableIR):
+    def __init__(self, left, right, root):
+        self.left = left
+        self.right = right
+        self.root = root
+
+    def render(self, r):
+        return '(TableLeftJoinRightDistinct {} {} {})'.format(
+            escape_id(self.root), r(self.left), r(self.right))
 
 class TableUnion(TableIR):
     def __init__(self, children):

--- a/hail/python/hail/utils/java.py
+++ b/hail/python/hail/utils/java.py
@@ -62,6 +62,10 @@ class Env:
         return Env._hc
 
     @staticmethod
+    def backend():
+        return Env.hc()._backend
+
+    @staticmethod
     def sql_context():
         return Env.hc()._sql_context
 

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -730,6 +730,13 @@ object IRParser {
         val child = table_ir(env)(it)
         val query = ir_value_expr(env.update(child.typ.refMap))(it)
         TableAggregate(child, query)
+      case "TableExport" =>
+        val child = table_ir(env)(it)
+        val path = string_literal(it)
+        val typesFile = opt(it, string_literal).orNull
+        val header = boolean_literal(it)
+        val exportType = int32_literal(it)
+        TableExport(child, path, typesFile, header, exportType)
       case "TableWrite" =>
         val path = string_literal(it)
         val overwrite = boolean_literal(it)

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -444,17 +444,6 @@ class Table(val hc: HailContext, val tir: TableIR) {
       signature = keySignature ++ TStruct(name -> TArray(valueSignature)))
   }
 
-  def jToMatrixTable(rowKeys: java.util.ArrayList[String],
-    colKeys: java.util.ArrayList[String],
-    rowFields: java.util.ArrayList[String],
-    colFields: java.util.ArrayList[String],
-    nPartitions: java.lang.Integer): MatrixTable = {
-
-    toMatrixTable(rowKeys.asScala.toArray, colKeys.asScala.toArray,
-      rowFields.asScala.toArray, colFields.asScala.toArray,
-      Option(nPartitions).map(_.asInstanceOf[Int])
-    )
-  }
 
   def toMatrixTable(
     rowKeys: Array[String],


### PR DESCRIPTION
Builds on: https://github.com/hail-is/hail/pull/5004

Convert all operations in table.py to IR (if possible).  Here are the things that remain in order to get rid of Table._jt in table.py.

Rewrite in Python:
 - expandTypes
 - flatten
 - collectJSON: use aggregate/collect (@tpoterba, do you feel this will be significantly slower now?)
 - showString: rewrite in Python in terms of collect

Add IR:
 - intervalJoin
 - same
 - groupByKey

Should only work with SparkBackend:
 - toDF

Hmm:
 - forceCount: remove?  add force option to TableCount that disables optimization?
 - nPartitions
 - filterPartitions
 - persist, unpersist
