### PR TITLE
move from_spark, etc. to SparkBackend

### DIFF
--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -54,8 +54,8 @@ class SparkBackend(Backend):
             t = t.flatten()
         return pyspark.sql.DataFrame(t._jt.toDF(Env.hc()._jsql_context), Env.sql_context())
 
-    def to_pandas(self, flatten):
-        return self.to_spark(flatten).toPandas()
+    def to_pandas(self, t, flatten):
+        return self.to_spark(t, flatten).toPandas()
 
     def from_pandas(self, df, key):
         return Table.from_spark(Env.sql_context().createDataFrame(df), key)

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -57,7 +57,7 @@ class SparkBackend(Backend):
     def to_pandas(self, flatten):
         return self.to_spark(flatten).toPandas()
 
-    def from_pandas(df, key):
+    def from_pandas(self, df, key):
         return Table.from_spark(Env.sql_context().createDataFrame(df), key)
 
 class ServiceBackend(Backend):

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2438,8 +2438,7 @@ class Table(ExprContainer):
         :class:`.Table`
             Table constructed from the Spark SQL DataFrame.
         """
-
-        return Table._from_java(Env.hail().table.Table.fromDF(Env.hc()._jhc, df._jdf, key))
+        return Env.spark_backend('from_spark').from_spark(df, key)
 
     @typecheck_method(flatten=bool)
     def to_spark(self, flatten=True):
@@ -2458,10 +2457,7 @@ class Table(ExprContainer):
         :class:`.pyspark.sql.DataFrame`
 
         """
-        t = self.expand_types()
-        if flatten:
-            t = t.flatten()
-        return pyspark.sql.DataFrame(t._jt.toDF(Env.hc()._jsql_context), Env.sql_context())
+        return Env.spark_backend('to_spark').to_spark(flatten)
 
     @typecheck_method(flatten=bool)
     def to_pandas(self, flatten=True):
@@ -2481,7 +2477,7 @@ class Table(ExprContainer):
         :class:`.pandas.DataFrame`
 
         """
-        return self.to_spark(flatten).toPandas()
+        return Env.spark_backend('to_pandas').to_pandas(flatten)
 
     @staticmethod
     @typecheck(df=pandas.DataFrame,
@@ -2505,7 +2501,7 @@ class Table(ExprContainer):
         -------
         :class:`.Table`
         """
-        return Table.from_spark(Env.sql_context().createDataFrame(df), key)
+        return Env.spark_backend('from_pandas').from_pandas(df, key)
 
     @typecheck_method(other=table_type, tolerance=nullable(numeric), absolute=bool)
     def _same(self, other, tolerance=1e-6, absolute=False):

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2457,7 +2457,7 @@ class Table(ExprContainer):
         :class:`.pyspark.sql.DataFrame`
 
         """
-        return Env.spark_backend('to_spark').to_spark(flatten)
+        return Env.spark_backend('to_spark').to_spark(self, flatten)
 
     @typecheck_method(flatten=bool)
     def to_pandas(self, flatten=True):
@@ -2477,7 +2477,7 @@ class Table(ExprContainer):
         :class:`.pandas.DataFrame`
 
         """
-        return Env.spark_backend('to_pandas').to_pandas(flatten)
+        return Env.spark_backend('to_pandas').to_pandas(self, flatten)
 
     @staticmethod
     @typecheck(df=pandas.DataFrame,

--- a/hail/python/hail/utils/java.py
+++ b/hail/python/hail/utils/java.py
@@ -65,6 +65,13 @@ class Env:
     def backend():
         return Env.hc()._backend
 
+    def spark_backend(op):
+        b = Env.backend()
+        if isinstance(b, hail.backend.SparkBackend):
+            return b
+        else:
+            raise NotImplementedError(f"{b.__class__.__name__} doesn't support {op}, only SparkBackend")
+
     @staticmethod
     def sql_context():
         return Env.hc()._sql_context


### PR DESCRIPTION
This is part of a larger set of changes to separate the Python front end from Java and Spark to support connecting to a REST API Hail backend.