### PR TITLE
Update batch README.md

### DIFF
--- a/batch/README.md
+++ b/batch/README.md
@@ -49,7 +49,7 @@ gcloud config set project <PROJECT_ID>
 
 <br>
 
-#####2. Update your `kubeconfig` to point `kubectl` to the desired cluster
+##### 2. Update your `kubeconfig` to point `kubectl` to the desired cluster
 
 List available clusters
 
@@ -124,13 +124,7 @@ kubectl create clusterrolebinding \
 Create a `batch` service:
 
 ```
-kubectl create -f deployment.yaml.in
-```
-
-If you ever need to shutdown the service, execute:
-
-```
-kubectl delete -f deployment.yaml.in
+make deploy
 ```
 
 Look for the newly created `batch` pod:
@@ -272,4 +266,4 @@ make build build-test
 
 You must also set the `imagePullPolicy` of any `container` you `kubectl create` to `Never` if you're using the `:latest` image tag (which is implicitly used if no tag is specified on the image name).
 
-Otherwise, k8s will always tryto check if there is a newer version of the image. Even if `imagePullPolicy` is set to `NotIfPresent`, k8s will still check for a newer image if you use the `:latest` tag.
+Otherwise, k8s will always try to check if there is a newer version of the image. Even if `imagePullPolicy` is set to `NotIfPresent`, k8s will still check for a newer image if you use the `:latest` tag.

--- a/batch/README.md
+++ b/batch/README.md
@@ -8,6 +8,13 @@ cluster:
 minikube start
 ```
 
+Set some environment variables so that docker images are placed in the
+`minikube` cluster's docker registry:
+
+```
+eval $(minikube docker-env)
+```
+
 If you get a weird minikube error, try
 
 ```
@@ -19,18 +26,37 @@ minikube start
 
 When you want to return to using a google k8s cluster, you can run this:
 
-```
-gcloud container clusters get-credentials CLUSTER_NAME
+```sh
+# Login with a Google account that is linked to a Google Cloud project that manages the cluster of interest
+gcloud auth login
+
+gcloud projects list
+# Shows
+#PROJECT_ID             NAME             PROJECT_NUMBER
+#my-awesome-project     xxxx             xxxx
+
+gcloud config set project my-awesome-project
+gcloud container clusters list
+
+#NAME             LOCATION       MASTER_VERSION  MASTER_IP        MACHINE_TYPE   NODE_VERSION    NUM_NODES  STATUS
+#awesome-cluster  us-central1-a  xxxx            xxxx               xxxx         xxxx            N          RUNNING
+
+# Here zone is called LOCATION
+# Lets set kubectl to use awesome-cluster
+gcloud container clusters get-credentials awesome-cluster --zone us-central1-a
 ```
 
-Set some environment variables so that docker images are placed in the
-`minikube` cluster's docker registry:
+To check what cluster `kubectl` is currently configured to use
 
-```
-eval $(minikube docker-env)
+```sh
+kubectl config view
+
+# Shows
+#...
+# current-context: gke_my-awesome-project_us-central1-a_awesome-cluster
 ```
 
-Build the batch and test image
+### Build the batch and test image
 
 ```
 make build-batch build-test
@@ -99,7 +125,7 @@ Kubernetes [Python client](https://github.com/kubernetes-client/python/blob/mast
 To get kubectl credentials for a GKE cluster:
 
 ```
-$ gcloud container clusters get-credentials <cluster>
+$ gcloud container clusters get-credentials <cluster> [--zone <zone/LOCATION> or --region <region>]
 ```
 
 To authorize docker to push to GCR:

--- a/batch/README.md
+++ b/batch/README.md
@@ -24,25 +24,28 @@ brew cask reinstall minikube # or equivalent on your OS
 minikube start
 ```
 
-When you want to return to using a google k8s cluster, you can run this:
+To use a remote Google Cloud k8s cluster instead:
 
+1. Login with a Google account that is linked to a Google Cloud project that manages the cluster of interest
 ```sh
-# Login with a Google account that is linked to a Google Cloud project that manages the cluster of interest
 gcloud auth login
+```
 
+2. Set the active project 
+```sh
 gcloud projects list
-# Shows
-#PROJECT_ID             NAME             PROJECT_NUMBER
-#my-awesome-project     xxxx             xxxx
+PROJECT_ID             NAME             PROJECT_NUMBER
+my-awesome-project     xxxx             xxxx
 
 gcloud config set project my-awesome-project
+```
+
+3. Update your `kubeconfig` file to point `kubectl` to the desired cluster
+```sh
 gcloud container clusters list
+NAME             LOCATION       MASTER_VERSION  MASTER_IP        MACHINE_TYPE   NODE_VERSION    NUM_NODES  STATUS
+awesome-cluster  us-central1-a  xxxx            xxxx               xxxx         xxxx            N          RUNNING
 
-#NAME             LOCATION       MASTER_VERSION  MASTER_IP        MACHINE_TYPE   NODE_VERSION    NUM_NODES  STATUS
-#awesome-cluster  us-central1-a  xxxx            xxxx               xxxx         xxxx            N          RUNNING
-
-# Here zone is called LOCATION
-# Lets set kubectl to use awesome-cluster
 gcloud container clusters get-credentials awesome-cluster --zone us-central1-a
 ```
 
@@ -51,9 +54,7 @@ To check what cluster `kubectl` is currently configured to use
 ```sh
 kubectl config view
 
-# Shows
-#...
-# current-context: gke_my-awesome-project_us-central1-a_awesome-cluster
+... current-context: gke_my-awesome-project_us-central1-a_awesome-cluster
 ```
 
 ### Build the batch and test image

--- a/batch/README.md
+++ b/batch/README.md
@@ -99,13 +99,13 @@ kubeconfig entry generated for vdc.
 
 ---
 
-### Build Batch and test image
+## Build Batch and test image
 
 Edit `deployment.yaml.in` so that the container named `batch` has `imagePullPolicy: Never`.
 
 - Ensures that k8s looks for images in the local image cache (which you updated when you ran `make build build-test`), instead of the Google Container Registry.
 
-Create 2 Docker images: Batch and an image for testing Batch
+Create 2 Docker images: `batch` and an image for testing `batch`
 
 ```
 make build build-test
@@ -121,7 +121,7 @@ kubectl create clusterrolebinding \
   --serviceaccount=default:default
 ```
 
-Create a batch service:
+Create a `batch` service:
 
 ```
 kubectl create -f deployment.yaml.in
@@ -133,7 +133,7 @@ If you ever need to shutdown the service, execute:
 kubectl delete -f deployment.yaml.in
 ```
 
-Look for the newly created batch pod:
+Look for the newly created `batch` pod:
 
 ```
 kubectl get pods
@@ -158,7 +158,7 @@ make test-local
 
 ---
 
-### Kubernetes and Docker primer
+## Kubernetes and Docker primer
 
 [Python client api](https://github.com/kubernetes-client/python/blob/master/kubernetes/README.md)
 
@@ -259,7 +259,7 @@ docker inspect <container-id> | grep IPAddress
 
 ---
 
-### Testing docker images
+## Testing docker images
 
 The following will set some environment variables so that future invocations of
 `docker build` will make images available to the minikube cluster. This allows

--- a/batch/README.md
+++ b/batch/README.md
@@ -1,5 +1,4 @@
-Getting Started
----
+## Getting Started
 
 Start a `minikube` k8s cluster and configure your `kubectl` to point at that k8s
 cluster:
@@ -15,7 +14,7 @@ Set some environment variables so that docker images are placed in the
 eval $(minikube docker-env)
 ```
 
-If you get a weird minikube error, try
+If you get a weird minikube error, try:
 
 ```
 minikube delete
@@ -24,49 +23,93 @@ brew cask reinstall minikube # or equivalent on your OS
 minikube start
 ```
 
-To use a remote Google Cloud k8s cluster instead:
+---
 
-1. Login with a Google account that is linked to a Google Cloud project that manages the cluster of interest
+## Use a remote Google Cloud k8s cluster with Kubernets
+
+##### 1. Link a Google Cloud project
+
+Login with the Google account that is linked to the Google Cloud project that manages the cluster of interest
+
 ```sh
 gcloud auth login
 ```
 
-2. Set the active project 
-```sh
-gcloud projects list
-PROJECT_ID             NAME             PROJECT_NUMBER
-my-awesome-project     xxxx             xxxx
+List available projects
 
-gcloud config set project my-awesome-project
+```
+gcloud projects list
 ```
 
-3. Update your `kubeconfig` file to point `kubectl` to the desired cluster
+Set the active proect
+
+```sh
+gcloud config set project <PROJECT_ID>
+```
+
+<br>
+
+#####2. Update your `kubeconfig` to point `kubectl` to the desired cluster
+
+List available clusters
+
 ```sh
 gcloud container clusters list
-NAME             LOCATION       MASTER_VERSION  MASTER_IP        MACHINE_TYPE   NODE_VERSION    NUM_NODES  STATUS
-awesome-cluster  us-central1-a  xxxx            xxxx               xxxx         xxxx            N          RUNNING
-
-gcloud container clusters get-credentials awesome-cluster --zone us-central1-a
 ```
 
-To check what cluster `kubectl` is currently configured to use
+Update your `kubeconfig` to point `kubectl` to the desired cluster
+
+```sh
+gcloud container clusters get-credentials <CLUSTER_NAME> --zone <ZONE/LOCATION>
+```
+
+Check what cluster `kubectl` is currently configured to use
 
 ```sh
 kubectl config view
-
-... current-context: gke_my-awesome-project_us-central1-a_awesome-cluster
 ```
 
-### Build the batch and test image
+<br>
+
+##### Example:
+
+```console
+$ gcloud auth login
+Your browser has been opened to visit:
+
+    https://accounts.google.com/o/oauth2/auth...
+
+You are now logged in as [...].
+
+$ gcloud projects list
+PROJECT_ID             NAME             PROJECT_NUMBER
+hail-vdc               hail-vdc         859893752941
+
+$ gcloud config set project hail-vdc
+Updated property [core/project].
+
+$ gcloud container clusters list
+NAME  LOCATION       MASTER_VERSION  MASTER_IP        MACHINE_TYPE   NODE_VERSION    NUM_NODES  STATUS
+vdc   us-central1-a  1.10.7-gke.11   104.198.230.143  n1-standard-1  1.10.7-gke.6 *  15         RUNNING
+
+$ gcloud container clusters get-credentials vdc --zone us-central1-a
+Fetching cluster endpoint and auth data.
+kubeconfig entry generated for vdc.
+```
+
+---
+
+### Build Batch and test image
+
+Edit `deployment.yaml.in` so that the container named `batch` has `imagePullPolicy: Never`.
+
+- Ensures that k8s looks for images in the local image cache (which you updated when you ran `make build build-test`), instead of the Google Container Registry.
+
+Create 2 Docker images: Batch and an image for testing Batch
 
 ```
 make build build-test
 ```
-
-edit the `deployment.yaml` so that the container named `batch` has
-`imagePullPolicy: Never`. This ensures that k8s does not go look for the image
-in the Google Container Registry and instead uses the local image cache (which
-you just updated when you ran `make build build-test`).
 
 Give way too many privileges to the default service account so that `batch` can
 start new pods:
@@ -81,13 +124,13 @@ kubectl create clusterrolebinding \
 Create a batch service:
 
 ```
-kubectl create -f deployment.yaml
+kubectl create -f deployment.yaml.in
 ```
 
 If you ever need to shutdown the service, execute:
 
 ```
-kubectl delete -f deployment.yaml
+kubectl delete -f deployment.yaml.in
 ```
 
 Look for the newly created batch pod:
@@ -96,11 +139,11 @@ Look for the newly created batch pod:
 kubectl get pods
 ```
 
-And create a port forward from the k8s cluster to your local machine (this works
+Create a port forward from the k8s cluster to your local machine (this works
 for clusters in GKE too):
 
 ```
-kubectl port-forward POD_NAME 5000:5000
+kubectl port-forward <POD_NAME> 5000:5000
 ```
 
 The former port is the local one and the latter port is the remote one (i.e. in
@@ -113,32 +156,32 @@ conda activate hail-batch
 make test-local
 ```
 
-
-
 ---
 
-Kubernetes [Python client](https://github.com/kubernetes-client/python/blob/master/kubernetes/README.md)
- - [V1Pod](https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1Pod.md)
- - [create_namespaced_pod](https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/CoreV1Api.md#create_namespaced_pod)
- - [delete_namespaced_pod](https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/CoreV1Api.md#delete_namespaced_pod)
- - 
+### Kubernetes and Docker primer
+
+[Python client api](https://github.com/kubernetes-client/python/blob/master/kubernetes/README.md)
+
+- [V1Pod](https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1Pod.md)
+- [create_namespaced_pod](https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/CoreV1Api.md#create_namespaced_pod)
+- [delete_namespaced_pod](https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/CoreV1Api.md#delete_namespaced_pod)
 
 To get kubectl credentials for a GKE cluster:
 
 ```
-$ gcloud container clusters get-credentials <cluster> [--zone <zone/LOCATION> or --region <region>]
+gcloud container clusters get-credentials <cluster> [--zone <zone/LOCATION> or --region <region>]
 ```
 
 To authorize docker to push to GCR:
 
 ```
-$ gcloud auth configure-docker
+gcloud auth configure-docker
 ```
 
 To run batch locally, using the local kube credentials:
 
 ```
-$ docker run -i -v $HOME/.kube:/root/.kube -p 5000:5000 -t batch
+docker run -i -v $HOME/.kube:/root/.kube -p 5000:5000 -t batch
 ```
 
 On OSX, the port will be accessible on the docker-machine:
@@ -150,61 +193,73 @@ $(docker-machine ip default):5000
 Get a shell in a running pod:
 
 ```
-$ kubectl exec -it <pod> -- /bin/sh
+kubectl exec -it <pod> -- /bin/sh
 ```
 
 Hit a Flask REST endpoint with Curl:
 
 ```
-$ curl -X POST -H "Content-Type: application/json" -d <data> <url>
-$ curl -X POST -H "Content-Type: application/json" -d '{"name": "batchtest", "image": "gcr.io/broad-ctsa/true"}' batch/jobs/create
+curl -X POST -H "Content-Type: application/json" -d <data> <url>
+curl -X POST -H "Content-Type: application/json" -d '{"name": "batchtest", "image": "gcr.io/broad-ctsa/true"}' batch/jobs/create
 ```
 
 Give default:default serviceaccount cluster-admin privileges:
 
 ```
-$ kubectl create clusterrolebinding cluster-admin-default --clusterrole cluster-admin --serviceaccount=default:default
+kubectl create clusterrolebinding cluster-admin-default --clusterrole cluster-admin --serviceaccount=default:default
 ```
 
 Run an image in a new pod:
 
 ```
-$ kubectl run <name> --restart=Never --image <image> -- <cmd>
+kubectl run <name> --restart=Never --image <image> -- <cmd>
 ```
 
 For example, run a shell in an new pod:
 
 ```
-$ kubectl run -i --tty apline --image=alpine --restart=Never -- sh
+kubectl run -i --tty apline --image=alpine --restart=Never -- sh
 ```
 
 Forward from a local port to a port on pod:
 
-```
-$ kubectl port-forward jupyter-deployment-5f54cff675-msr85 8888:8888 # <local port>:<remote port>
+```sh
+kubectl port-forward jupyter-deployment-5f54cff675-msr85 8888:8888 # <local port>:<remote port>
 ```
 
 Run container with a given hostname:
 
-$ docker run -d --rm --name spark-m -h spark-m -p 8080:8080 -p 7077:7077 spark-m
+```sh
+docker run -d --rm --name spark-m -h spark-m -p 8080:8080 -p 7077:7077 spark-m
+```
 
 List all containers, included stopped containers:
 
-$ docker ps -a
+```sh
+docker ps -a
+```
 
 Remove all stopped containers:
 
-$ docker ps -aq --no-trunc -f status=exited | xargs docker rm
+```sh
+docker ps -aq --no-trunc -f status=exited | xargs docker rm
+```
 
 Run a docker container linked to another:
 
-$ docker run -d --rm --cpus 0.5 --name spark-w-0 --link spark-m spark-w -c 1 -m 2g
+```sh
+docker run -d --rm --cpus 0.5 --name spark-w-0 --link spark-m spark-w -c 1 -m 2g
+```
 
 Get IP of container:
 
-$ docker inspect <container-id> | grep IPAddress
+```sh
+docker inspect <container-id> | grep IPAddress
+```
 
 ---
+
+### Testing docker images
 
 The following will set some environment variables so that future invocations of
 `docker build` will make images available to the minikube cluster. This allows
@@ -215,9 +270,6 @@ eval $(minikube docker-env)
 make build build-test
 ```
 
-NB: you must also set the `imagePullPolicy` of any `container` you `kubectl
-create` to `Never` if you're using the `:latest` image tag (which is implicitly
-used if no tag is specified on the image name). Otherwise, k8s will always try
-to check if there is a newer version of the image. Even if `imagePullPolicy`
-is set to `NotIfPresent`, k8s will still check for a newer image if you use the
-`:latest` tag.
+You must also set the `imagePullPolicy` of any `container` you `kubectl create` to `Never` if you're using the `:latest` image tag (which is implicitly used if no tag is specified on the image name).
+
+Otherwise, k8s will always tryto check if there is a newer version of the image. Even if `imagePullPolicy` is set to `NotIfPresent`, k8s will still check for a newer image if you use the `:latest` tag.

--- a/batch/README.md
+++ b/batch/README.md
@@ -108,7 +108,7 @@ the k8s pod). Now you can load the conda environment for testing and run the
 tests against this deployment:
 
 ```
-conda env create -f environment.yaml
+conda env create -f environment.yml
 conda activate hail-batch
 make test-local
 ```

--- a/batch/README.md
+++ b/batch/README.md
@@ -60,13 +60,13 @@ kubectl config view
 ### Build the batch and test image
 
 ```
-make build-batch build-test
+make build build-test
 ```
 
 edit the `deployment.yaml` so that the container named `batch` has
 `imagePullPolicy: Never`. This ensures that k8s does not go look for the image
 in the Google Container Registry and instead uses the local image cache (which
-you just updated when you ran `make build-batch build-test`).
+you just updated when you ran `make build build-test`).
 
 Give way too many privileges to the default service account so that `batch` can
 start new pods:
@@ -212,7 +212,7 @@ you to test images without pushing them to a remote container registry.
 
 ```
 eval $(minikube docker-env)
-make build-batch build-test
+make build build-test
 ```
 
 NB: you must also set the `imagePullPolicy` of any `container` you `kubectl


### PR DESCRIPTION
1) More completely document pointing kubectl to a google cloud cluster.

2) at least in Google Cloud SDK 228.0.0, one of --zone or --region are required.

3) eval $(minikube docker-env) seemed out of place, but I may not have understood
