### PR TITLE
Pyshow

### DIFF
--- a/hail/python/hail/conftest.py
+++ b/hail/python/hail/conftest.py
@@ -76,7 +76,8 @@ def init(doctest_namespace):
     doctest_namespace['table4'] = table4
 
     people_table = hl.import_table('data/explode_example.tsv', delimiter='\\s+',
-                                   types={'Age': hl.tint32, 'Children': hl.tarray(hl.tstr)})
+                                   types={'Age': hl.tint32, 'Children': hl.tarray(hl.tstr)},
+                                   key_by='Name')
     doctest_namespace['people_table'] = people_table
 
     # TDT

--- a/hail/python/hail/conftest.py
+++ b/hail/python/hail/conftest.py
@@ -77,7 +77,7 @@ def init(doctest_namespace):
 
     people_table = hl.import_table('data/explode_example.tsv', delimiter='\\s+',
                                    types={'Age': hl.tint32, 'Children': hl.tarray(hl.tstr)},
-                                   key_by='Name')
+                                   key='Name')
     doctest_namespace['people_table'] = people_table
 
     # TDT

--- a/hail/python/hail/docs/hailpedia/matrix_table.rst
+++ b/hail/python/hail/docs/hailpedia/matrix_table.rst
@@ -263,7 +263,7 @@ One use case of explode is to duplicate rows:
     >>> mt_new.count_rows()
     692
 
-    >>> mt_new.replicate_num.show() # doctest: +SKIP
+    >>> mt_new.replicate_num.show() # doctest: +NOTEST
     +---------------+------------+---------------+
     | locus         | alleles    | replicate_num |
     +---------------+------------+---------------+

--- a/hail/python/hail/docs/hailpedia/matrix_table.rst
+++ b/hail/python/hail/docs/hailpedia/matrix_table.rst
@@ -263,7 +263,7 @@ One use case of explode is to duplicate rows:
     >>> mt_new.count_rows()
     692
 
-    >>> mt_new.replicate_num.show()
+    >>> mt_new.replicate_num.show() # doctest: +SKIP
     +---------------+------------+---------------+
     | locus         | alleles    | replicate_num |
     +---------------+------------+---------------+

--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -682,7 +682,7 @@ class Expression(object):
         """
         handler(self._show(n, width, truncate, types))
 
-    def _show(self, n=10, width=90, truncate=None, types=True):
+    def _show(self, n, width, truncate, types):
         name = '<expr>'
         source = self._indices.source
         if isinstance(source, hl.Table):

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -4356,3 +4356,7 @@ def approx_equal(x, y, tolerance=1e-6, absolute=False, nan_same=False):
     """
 
     return _func("approxEqual", hl.tbool, x, y, tolerance, absolute, nan_same)
+
+@typecheck(s=expr_str)
+def _escape_string(s):
+    return _func("escapeString", hl.tstr, s)

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -1998,7 +1998,7 @@ class MatrixTable(ExprContainer):
         ...     .explode_cols('foo'))
         >>> mt = mt.annotate_entries(bar = mt.row_idx * mt.foo)
 
-        >>> mt.cols().show()
+        >>> mt.cols().show() # doctest: +SKIP
         +---------+-------+
         | col_idx |   foo |
         +---------+-------+

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -1998,7 +1998,7 @@ class MatrixTable(ExprContainer):
         ...     .explode_cols('foo'))
         >>> mt = mt.annotate_entries(bar = mt.row_idx * mt.foo)
 
-        >>> mt.cols().show() # doctest: +SKIP
+        >>> mt.cols().show() # doctest: +NOTEST
         +---------+-------+
         | col_idx |   foo |
         +---------+-------+
@@ -2012,7 +2012,7 @@ class MatrixTable(ExprContainer):
         |       2 |     6 |
         +---------+-------+
 
-        >>> mt.entries().show() # doctest: +SKIP
+        >>> mt.entries().show() # doctest: +NOTEST
         +---------+---------+-------+-------+
         | row_idx | col_idx |   foo |   bar |
         +---------+---------+-------+-------+
@@ -2043,7 +2043,7 @@ class MatrixTable(ExprContainer):
         |       2 | [4,5,6]      |
         +---------+--------------+
 
-        >>> mt.entries().show() # doctest: +SKIP
+        >>> mt.entries().show() # doctest: +NOTEST
         +---------+---------+--------------+--------------+
         | row_idx | col_idx | foo          | bar          |
         +---------+---------+--------------+--------------+

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2012,7 +2012,7 @@ class MatrixTable(ExprContainer):
         |       2 |     6 |
         +---------+-------+
 
-        >>> mt.entries().show()
+        >>> mt.entries().show() # doctest: +SKIP
         +---------+---------+-------+-------+
         | row_idx | col_idx |   foo |   bar |
         +---------+---------+-------+-------+
@@ -2043,7 +2043,7 @@ class MatrixTable(ExprContainer):
         |       2 | [4,5,6]      |
         +---------+--------------+
 
-        >>> mt.entries().show()
+        >>> mt.entries().show() # doctest: +SKIP
         +---------+---------+--------------+--------------+
         | row_idx | col_idx | foo          | bar          |
         +---------+---------+--------------+--------------+

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1168,6 +1168,109 @@ class Table(ExprContainer):
 
         Env.backend().execute(TableWrite(self._tir, output, overwrite, stage_locally, _codec_spec))
 
+    def _show_str(t, n, width, truncate, types):
+        width = max(width, 8)
+
+        if truncate:
+            truncate = min(max(truncate, 4), width - 4)
+        else:
+            truncate = width - 4
+
+        def trunc(s):
+            if len(s) > truncate:
+                return s[:truncate - 3] + "..."
+            else:
+                return s
+
+        def hl_repr(v):
+            if v.dtype == hl.tfloat32 or v.dtype == hl.tfloat64:
+                return hl.format('%.2e', v)
+            elif v.dtype == hl.tstr:
+                # FIXME doesn't quote
+                return hl.format('"%s"', v)
+            else:
+                return hl.str(v)
+
+        def hl_trunc(s):
+            return hl.cond(hl.len(s) > truncate,
+                           s[:truncate - 3] + "...",
+                           s)
+
+        def hl_format(v):
+            return hl.bind(lambda s: hl_trunc(s),
+                           hl.cond(hl.is_defined(v), hl_repr(v), "NA"))
+
+        t = t.flatten()
+        fields = [trunc(f) for f in t.row]
+        n_fields = len(fields)
+
+        types = [trunc(str(t.row[f].dtype)) for f in fields]
+        right_align = [hl.expr.types.is_numeric(t.row[f].dtype) for f in fields]
+
+        t = t.select(**{k: hl_format(v) for (k, v) in t.row.items()})
+        rows = t.take(n + 1)
+
+        has_more = len(rows) > n
+        rows = rows[:n]
+
+        rows = [[row[f] for f in fields] for row in rows]
+
+        column_width = [max(len(fields[i]), len(types[i]), max([len(row[i]) for row in rows]))
+                        for i in range(n_fields)]
+
+        column_blocks = []
+        start = 0
+        i = 1
+        w = column_width[0] + 4
+        while i < len(fields):
+            w = w + column_width[i] + 3
+            if w > width:
+                column_blocks.append((start, i))
+                start = i
+                w = column_width[i] + 4
+            i = i + 1
+        assert i == n_fields
+        column_blocks.append((start, i))
+
+        def format_hline(widths):
+            return '+-' + '-+-'.join(['-' * w for w in widths]) + '-+\n'
+
+        def pad(v, w, ra):
+            e =  w - len(v)
+            if ra:
+                return ' ' * e + v
+            else:
+                return v + ' ' * e
+
+        def format_line(values, widths, right_align):
+            values = map(pad, values, widths, right_align)
+            return '| ' + ' | '.join(values) + ' |\n'
+
+        s = ''
+        first = True
+        for (start, end) in column_blocks:
+            if first:
+                first = False
+            else:
+                s += '\n'
+
+            block_column_width = column_width[start:end]
+            block_right_align = right_align[start:end]
+            hline = format_hline(block_column_width)
+
+            s += hline
+            s += format_line(fields[start:end], block_column_width, block_right_align)
+            s += hline
+            if types:
+                s += format_line(types[start:end], block_column_width, block_right_align)
+                s += hline
+            for row in rows:
+                row = row[start:end]
+                s += format_line(row, block_column_width, block_right_align)
+            s += hline
+
+        return s
+
     @typecheck_method(n=int, width=int, truncate=nullable(int), types=bool, handler=anyfunc)
     def show(self, n=10, width=90, truncate=None, types=True, handler=print):
         """Print the first few rows of the table to the console.
@@ -1202,10 +1305,7 @@ class Table(ExprContainer):
         handler : Callable[[str], Any]
             Handler function for data string.
         """
-        handler(self._show(n,width, truncate, types))
-
-    def _show(self, n=10, width=90, truncate=None, types=True):
-        return self._jt.showString(n, joption(truncate), types, width)
+        handler(self._show_str(n, width, truncate, types))
 
     def index(self, *exprs):
         """Expose the row values as if looked up in a dictionary, indexing
@@ -1553,7 +1653,7 @@ class Table(ExprContainer):
         :obj:`list` of :class:`.Struct`
             List of rows.
         """
-        return Env.hc()._backend.execute(GetField(TableCollect(self._tir), 'rows'))
+        return Env.backend().execute(GetField(TableCollect(self._tir), 'rows'))
 
     def describe(self, handler=print):
         """Print information about the fields in the table."""

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2370,7 +2370,7 @@ class Table(ExprContainer):
         element in the `Children` field:
 
         >>> exploded = people_table.explode('Children')
-        >>> exploded.show()
+        >>> exploded.show() # doctest: +SKIP
         +---------+-------+----------+
         | Name    |   Age | Children |
         +---------+-------+----------+

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1168,7 +1168,7 @@ class Table(ExprContainer):
 
         Env.backend().execute(TableWrite(self._tir, output, overwrite, stage_locally, _codec_spec))
 
-    def _show_str(t, n, width, truncate, types):
+    def _show(self, n, width, truncate, types):
         width = max(width, 8)
 
         if truncate:
@@ -1206,6 +1206,7 @@ class Table(ExprContainer):
         def hl_format(v):
             return hl.bind(lambda s: hl_trunc(s), hl_repr(v))
 
+        t = self
         t = t.flatten()
         fields = [trunc(f) for f in t.row]
         n_fields = len(fields)

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2370,7 +2370,7 @@ class Table(ExprContainer):
         element in the `Children` field:
 
         >>> exploded = people_table.explode('Children')
-        >>> exploded.show() # doctest: +SKIP
+        >>> exploded.show() # doctest: +NOTEST
         +---------+-------+----------+
         | Name    |   Age | Children |
         +---------+-------+----------+
@@ -2387,7 +2387,7 @@ class Table(ExprContainer):
         names:
 
         >>> exploded = people_table.explode('Children', name='Child')
-        >>> exploded.show() # doctest: +SKIP
+        >>> exploded.show() # doctest: +NOTEST
         +---------+-------+---------+
         | Name    |   Age | Child   |
         +---------+-------+---------+

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1277,6 +1277,10 @@ class Table(ExprContainer):
                 s += format_line(row, block_column_width, block_right_align)
             s += hline
 
+        if has_more:
+            n_rows = len(rows)
+            s += f"showing top { n_rows } { 'row' if n_rows == 1 else 'rows' }\n"
+
         return s
 
     @typecheck_method(n=int, width=int, truncate=nullable(int), types=bool, handler=anyfunc)

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1193,6 +1193,8 @@ class Table(ExprContainer):
                 s = "{" + hl.delimit(hl.map(lambda x: x[0] + ":" + hl_repr(x[1]), hl.array(v)), ",") + "}"
             elif v.dtype == hl.tstr:
                 s = hl.str('"') + hl.expr.functions._escape_string(v) + '"'
+            elif isinstance(v.dtype, (hl.tstruct, hl.tarray)):
+                s = "(" + hl.delimit([hl_repr(v[i]) for i in range(len(v))], ",") + ")"
             else:
                 s = hl.str(v)
             return hl.cond(hl.is_defined(v), s, "NA")

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1192,8 +1192,7 @@ class Table(ExprContainer):
             elif isinstance(v.dtype, hl.tdict):
                 s = "{" + hl.delimit(hl.map(lambda x: x[0] + ":" + hl_repr(x[1]), hl.array(v)), ",") + "}"
             elif v.dtype == hl.tstr:
-                # FIXME doesn't quote
-                s = hl.format('"%s"', v)
+                s = hl.str('"') + hl.expr.functions._escape_string(v) + '"'
             else:
                 s = hl.str(v)
             return hl.cond(hl.is_defined(v), s, "NA")

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1312,7 +1312,7 @@ class Table(ExprContainer):
         handler : Callable[[str], Any]
             Handler function for data string.
         """
-        handler(self._show_str(n, width, truncate, types))
+        handler(self._show(n, width, truncate, types))
 
     def index(self, *exprs):
         """Expose the row values as if looked up in a dictionary, indexing

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1190,7 +1190,7 @@ class Table(ExprContainer):
             elif isinstance(v.dtype, hl.tset):
                 s = "{" + hl.delimit(hl.map(hl_repr, hl.array(v)), ",") + "}"
             elif isinstance(v.dtype, hl.tdict):
-                s = "{" + hl.delimit(hl.map(lambda x: x[0] + ": " + hl_repr(x[1]), hl.array(v)), ",") + "}"
+                s = "{" + hl.delimit(hl.map(lambda x: x[0] + ":" + hl_repr(x[1]), hl.array(v)), ",") + "}"
             elif v.dtype == hl.tstr:
                 # FIXME doesn't quote
                 s = hl.format('"%s"', v)

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2249,7 +2249,8 @@ class Table(ExprContainer):
                 return [(k, v) for (f, e) in s.items() for (k, v) in _flatten(prefix + '.' + f, e)]
             else:
                 return [(prefix, s)]
-        t = self.key_by()
+        # unkey but preserve order
+        t = self.order_by(*self.key)
         t = t.select(**{k: v for (f, e) in t.row.items() for (k, v) in _flatten(f, e)})
         return t
 

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2387,7 +2387,7 @@ class Table(ExprContainer):
         names:
 
         >>> exploded = people_table.explode('Children', name='Child')
-        >>> exploded.show()
+        >>> exploded.show() # doctest: +SKIP
         +---------+-------+---------+
         | Name    |   Age | Child   |
         +---------+-------+---------+

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -298,6 +298,9 @@ object Simplify {
       TableFilter(t,
         ApplySpecial("&&", Array(p1, p2)))
 
+    case TableOrderBy(child, sortFields) if sortFields.isEmpty =>
+      child
+
     case TableFilter(TableOrderBy(child, sortFields), pred) if canRepartition =>
       TableOrderBy(TableFilter(child, pred), sortFields)
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1305,11 +1305,9 @@ case class TableOrderBy(child: TableIR, sortFields: IndexedSeq[SortField]) exten
   protected[ir] override def execute(hc: HailContext): TableValue = {
     val prev = child.execute(hc)
 
-    if (sortFields.isEmpty)
-      return prev
-
-    if (sortFields.length <= prev.typ.key.length &&
-      sortFields.zip(prev.typ.key).forall { case (sf, k) =>
+    val physicalKey = prev.rvd.typ.key
+    if (sortFields.length <= physicalKey.length &&
+      sortFields.zip(physicalKey).forall { case (sf, k) =>
         sf.sortOrder == Ascending && sf.field == k
       })
     // already sorted

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -210,11 +210,11 @@ case class TableImport(paths: Array[String], typ: TableType, readerOpts: TableRe
   * Let n be the longest common prefix of 'keys' and the old key, i.e. the
   * number of key fields that are not being changed.
   * - If 'isSorted', then 'child' must already be sorted by 'keys', and n must
-  *   not be zero. Thus, if 'isSorted', TableKeyBy will not shuffle or scan.
-  *   The new partitioner will be the old one with partition bounds truncated
-  *   to length n.
+  * not be zero. Thus, if 'isSorted', TableKeyBy will not shuffle or scan.
+  * The new partitioner will be the old one with partition bounds truncated
+  * to length n.
   * - If n = 'keys.length', i.e. we are simply shortening the key, do nothing
-  *   but change the table type to the new key. 'isSorted' is ignored.
+  * but change the table type to the new key. 'isSorted' is ignored.
   * - Otherwise, if 'isSorted' is false and n < 'keys.length', then shuffle.
   */
 case class TableKeyBy(child: TableIR, keys: IndexedSeq[String], isSorted: Boolean = false) extends TableIR {
@@ -328,6 +328,7 @@ case class TableFilter(child: TableIR, pred: IR) extends TableIR {
 
 case class TableHead(child: TableIR, n: Long) extends TableIR {
   require(n >= 0, fatal(s"TableHead: n must be non-negative! Found '$n'."))
+
   def typ: TableType = child.typ
 
   override lazy val rvdType: RVDType = child.rvdType
@@ -399,10 +400,10 @@ object TableJoin {
   * and 'right' has multiple rows with the corresponding join key
   * [k_1, ..., k_j] but distinct full keys, then the resulting table will have
   * out-of-order keys. To avoid this, ensure one of the following:
-  *   * j == m
-  *   * 'left' has distinct keys
-  *   * 'right' has distinct join keys (length j prefix), or at least no
-  *     distinct keys with the same join key.
+  * * j == m
+  * * 'left' has distinct keys
+  * * 'right' has distinct join keys (length j prefix), or at least no
+  * distinct keys with the same join key.
   */
 case class TableJoin(left: TableIR, right: TableIR, joinType: String, joinKey: Int)
   extends TableIR {
@@ -606,7 +607,7 @@ case class TableMultiWayZipJoin(children: IndexedSeq[TableIR], fieldName: String
         rvb.startStruct()
         rvb.addFields(rowType, rv, keyIdx) // Add the key
         rvb.startMissingArray(localDataLength) // add the values
-        var i = 0
+      var i = 0
         while (i < rvs.length) {
           val (rv, j) = rvs(i)
           rvb.setArrayIndex(j)
@@ -701,20 +702,18 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
       "global", gType.physicalType,
       "global", gType.physicalType,
       "row", tv.typ.rowType.physicalType,
-      CompileWithAggregators.liftScan(newRow), "SCANR",
-      { (nAggs: Int, initOp: IR) =>
+      CompileWithAggregators.liftScan(newRow), "SCANR", { (nAggs: Int, initOp: IR) =>
         scanInitNeedsGlobals |= Mentions(initOp, "global")
         initOp
-      },
-      { (nAggs: Int, seqOp: IR) =>
+      }, { (nAggs: Int, seqOp: IR) =>
         scanSeqNeedsGlobals |= Mentions(seqOp, "global")
         seqOp
       })
 
     val (rTyp, f) = ir.Compile[Long, Long, Long, Long](
       "SCANR", scanResultType,
-      "global", child.typ.globalType.physicalType ,
-      "row", child.typ.rowType.physicalType ,
+      "global", child.typ.globalType.physicalType,
+      "row", child.typ.rowType.physicalType,
       postScanIR)
     assert(rTyp.virtualType == typ.rowType)
 
@@ -902,7 +901,7 @@ case class TableExplode(child: TableIR, fieldName: String) extends TableIR {
             val off = rowF(ctx.region, rv.offset, false, i, false)
             rv2.set(ctx.region, off)
             rv2
-        }
+          }
       }
     }
 
@@ -1306,6 +1305,16 @@ case class TableOrderBy(child: TableIR, sortFields: IndexedSeq[SortField]) exten
   protected[ir] override def execute(hc: HailContext): TableValue = {
     val prev = child.execute(hc)
 
+    if (sortFields.isEmpty)
+      return prev
+
+    if (sortFields.length <= prev.typ.key.length &&
+      sortFields.zip(prev.typ.key).forall { case (sf, k) =>
+        sf.sortOrder == Ascending && sf.field == k
+      })
+    // already sorted
+      return prev
+
     val rowType = child.typ.rowType
     val sortColIndexOrd = sortFields.map { case SortField(n, so) =>
       val i = rowType.fieldIdx(n)
@@ -1365,6 +1374,7 @@ case class TableRename(child: TableIR, rowMap: Map[String, String], globalMap: M
   require(globalMap.keys.forall(child.typ.globalType.hasField))
 
   def rowF(old: String): String = rowMap.getOrElse(old, old)
+
   def globalF(old: String): String = globalMap.getOrElse(old, old)
 
   def typ: TableType = child.typ.copy(

--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -45,6 +45,8 @@ object StringFunctions extends RegistryFunctions {
 
   def setMkString(s: Set[String], sep: String): String = s.mkString(sep)
 
+  def escapeString(s: String): String = StringEscapeUtils.escapeString(s)
+
   def registerAll(): Unit = {
     val thisClass = getClass
 
@@ -172,5 +174,7 @@ object StringFunctions extends RegistryFunctions {
           e1.m || e2.m || m,
           m.mux(ir.defaultValue(TInt32()), v))
     }
+
+    registerWrappedScalaFunction("escapeString", TString(), TString())(thisClass, "escapeString")
   }
 }

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TArray.scala
@@ -57,13 +57,4 @@ final case class TArray(elementType: Type, override val required: Boolean = fals
     ExtendedOrdering.iterableOrdering(elementType.ordering)
 
   override def scalaClassTag: ClassTag[IndexedSeq[AnyRef]] = classTag[IndexedSeq[AnyRef]]
-
-  override def _showStr(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder): Unit = {
-    val array = a.asInstanceOf[IndexedSeq[Any]]
-    sb.append('[')
-    array.foreachBetween({ elt => elementType._showStrNA(elt, cfg, sb) }) {
-      sb.append(',')
-    }
-    sb.append(']')
-  }
 }

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TBaseStruct.scala
@@ -106,13 +106,4 @@ abstract class TBaseStruct extends Type {
   override def scalaClassTag: ClassTag[Row] = classTag[Row]
 
   def missingIdx: Array[Int]
-
-  override def _showStr(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder): Unit = {
-    val r = a.asInstanceOf[Row]
-    sb.append('(')
-    types.zipWithIndex.foreachBetween({ case (t, i) => t._showStrNA(r.get(i), cfg, sb) }) {
-      sb.append(',')
-    }
-    sb.append(')')
-  }
 }

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TDict.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TDict.scala
@@ -71,18 +71,4 @@ final case class TDict(keyType: Type, valueType: Type, override val required: Bo
 
   val ordering: ExtendedOrdering =
     ExtendedOrdering.mapOrdering(elementType.ordering)
-
-
-  override def _showStr(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder): Unit = {
-    val dict = a.asInstanceOf[Map[Any, Any]]
-    sb.append('{')
-    dict.foreachBetween({ case (k, v) =>
-      keyType._showStrNA(k, cfg, sb)
-      sb.append(':')
-      valueType._showStrNA(v, cfg, sb)
-    }) {
-      sb.append(',')
-    }
-    sb.append('}')
-  }
 }

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TFloat32.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TFloat32.scala
@@ -24,9 +24,6 @@ class TFloat32(override val required: Boolean) extends TNumeric {
 
   override def str(a: Annotation): String = if (a == null) "NA" else a.asInstanceOf[Float].formatted("%.5e")
 
-  override def _showStr(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder): Unit =
-    sb.append(cfg.floatFormat.format(a.asInstanceOf[Float]))
-
   override def genNonmissingValue: Gen[Annotation] = arbitrary[Double].map(_.toFloat)
 
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean): Boolean =

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TFloat64.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TFloat64.scala
@@ -24,9 +24,6 @@ class TFloat64(override val required: Boolean) extends TNumeric {
 
   override def str(a: Annotation): String = if (a == null) "NA" else a.asInstanceOf[Double].formatted("%.5e")
 
-  override def _showStr(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder): Unit =
-    sb.append(cfg.floatFormat.format(a.asInstanceOf[Double]))
-
   override def genNonmissingValue: Gen[Annotation] = arbitrary[Double]
 
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean): Boolean =

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TSet.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TSet.scala
@@ -50,13 +50,4 @@ final case class TSet(elementType: Type, override val required: Boolean = false)
   override def genNonmissingValue: Gen[Annotation] = Gen.buildableOf[Set](elementType.genValue)
 
   override def scalaClassTag: ClassTag[Set[AnyRef]] = classTag[Set[AnyRef]]
-
-  override def _showStr(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder): Unit = {
-    val set = a.asInstanceOf[Set[Any]]
-    sb.append('{')
-    set.foreachBetween({ elt => elementType._showStrNA(elt, cfg, sb) }) {
-      sb.append(',')
-    }
-    sb.append('}')
-  }
 }

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TString.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TString.scala
@@ -30,12 +30,6 @@ class TString(override val required: Boolean) extends Type {
     ExtendedOrdering.extendToNull(implicitly[Ordering[String]])
 
   override def fundamentalType: Type = TBinary(required)
-
-  override def _showStr(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder): Unit = {
-    sb.append('"')
-    sb.append(StringEscapeUtils.escapeString(a.asInstanceOf[String]))
-    sb.append('"')
-  }
 }
 
 object TString {

--- a/hail/src/main/scala/is/hail/expr/types/virtual/Type.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/Type.scala
@@ -188,26 +188,6 @@ abstract class Type extends BaseType with Serializable {
 
   def str(a: Annotation): String = if (a == null) "NA" else a.toString
 
-  final def showStr(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder = null): String = {
-    val sb_ = if (sb == null)
-      new StringBuilder
-    else {
-      sb.clear()
-      sb
-    }
-    _showStrNA(a, cfg, sb_)
-    sb_.result()
-  }
-
-  final def _showStrNA(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder): Unit = {
-    if (a == null)
-      sb.append(cfg.missing)
-    else
-      _showStr(a, cfg, sb)
-  }
-
-  def _showStr(a: Annotation, cfg: ShowStrConfig, sb: StringBuilder): Unit = sb.append(str(a))
-
   def toJSON(a: Annotation): JValue = JSONAnnotationImpex.exportAnnotation(a, this)
 
   def genNonmissingValue: Gen[Annotation] = ???

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -1,10 +1,9 @@
 package is.hail.table
 
-import is.hail.compatibility
 import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.expr.{ir, _}
-import is.hail.expr.ir.{CastTableToMatrix, IR, LiftLiterals, TableAggregateByKey, TableExplode, TableFilter, TableIR, TableJoin, TableKeyBy, TableKeyByAndAggregate, TableLiteral, TableMapGlobals, TableMapRows, TableOrderBy, TableParallelize, TableRange, TableToMatrixTable, TableUnion, TableValue, _}
+import is.hail.expr.ir._
 import is.hail.expr.types._
 import is.hail.expr.types.virtual._
 import is.hail.io.plink.{FamFileConfig, LoadPlink}
@@ -12,7 +11,6 @@ import is.hail.rvd._
 import is.hail.sparkextras.ContextRDD
 import is.hail.utils._
 import is.hail.variant._
-import org.apache.commons.lang3.StringUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
@@ -520,152 +518,6 @@ class Table(val hc: HailContext, val tir: TableIR) {
   }
 
   def unpersist(): Table = copy2(rvd = rvd.unpersist())
-
-  def show(n: Int = 10, truncate: Option[Int] = None, printTypes: Boolean = true, maxWidth: Int = 100): Unit = {
-    println(showString(n, truncate, printTypes, maxWidth))
-  }
-
-  def showString(n: Int = 10, truncate: Option[Int] = None, printTypes: Boolean = true, maxWidth: Int = 100): String = {
-    /**
-      * Parts of this method are lifted from:
-      *   org.apache.spark.sql.Dataset.showString
-      * Spark version 2.0.2
-      */
-
-    truncate.foreach { tr => require(tr > 3, s"truncation length too small: $tr") }
-    require(maxWidth >= 10, s"max width too small: $maxWidth")
-
-    val (data, hasMoreData) = if (n < 0)
-      collect() -> false
-    else {
-      val takeResult = head(n + 1).collect()
-      val hasMoreData = takeResult.length > n
-      takeResult.take(n) -> hasMoreData
-    }
-
-    def convertType(t: Type, name: String, ab: ArrayBuilder[(String, String, Boolean)]) {
-      t match {
-        case s: TStruct => s.fields.foreach { f =>
-          convertType(f.typ, if (name == null) f.name else name + "." + f.name, ab)
-        }
-        case _ =>
-          ab += (name, t.toString, t.isInstanceOf[TNumeric])
-      }
-    }
-
-    val headerBuilder = new ArrayBuilder[(String, String, Boolean)]()
-    convertType(signature, null, headerBuilder)
-    val (names, types, rightAlign) = headerBuilder.result().unzip3
-
-    val sb = new StringBuilder()
-    val config = ShowStrConfig()
-    def convertValue(t: Type, v: Annotation, ab: ArrayBuilder[String]) {
-      t match {
-        case s: TStruct =>
-          val r = v.asInstanceOf[Row]
-          s.fields.foreach(f => convertValue(f.typ, if (r == null) null else r.get(f.index), ab))
-        case _ =>
-          ab += t.showStr(v, config, sb)
-      }
-    }
-
-    val valueBuilder = new ArrayBuilder[String]()
-    val dataStrings = data.map { r =>
-      valueBuilder.clear()
-      convertValue(signature, r, valueBuilder)
-      valueBuilder.result()
-    }
-
-    val fixedWidth = 4 // "| " + " |"
-    val delimWidth = 3 // " | "
-
-    val tr = truncate.getOrElse(maxWidth - 4)
-
-    val allStrings = (Iterator(names, types) ++ dataStrings.iterator).map { arr =>
-      arr.map { str => if (str.length > tr) str.substring(0, tr - 3) + "..." else str }
-    }.toArray
-
-    val nCols = names.length
-    val colWidths = Array.fill(nCols)(0)
-
-    // Compute the width of each column
-    for (i <- allStrings.indices)
-      for (j <- 0 until nCols)
-        colWidths(j) = math.max(colWidths(j), allStrings(i)(j).length)
-
-    val normedStrings = allStrings.map { line =>
-      line.zipWithIndex.map { case (cell, i) =>
-        if (rightAlign(i))
-          StringUtils.leftPad(cell, colWidths(i))
-        else
-          StringUtils.rightPad(cell, colWidths(i))
-      }
-    }
-
-    sb.clear()
-
-    // writes cols [startIndex, endIndex)
-    def writeCols(startIndex: Int, endIndex: Int) {
-
-      val toWrite = (startIndex until endIndex).toArray
-
-      val sep = toWrite.map(i => "-" * colWidths(i)).addString(new StringBuilder, "+-", "-+-", "-+\n").result()
-      // add separator line
-      sb.append(sep)
-
-      // add column names
-      toWrite.map(normedStrings(0)(_)).addString(sb, "| ", " | ", " |\n")
-
-      // add separator line
-      sb.append(sep)
-
-      if (printTypes) {
-        // add types
-        toWrite.map(normedStrings(1)(_)).addString(sb, "| ", " | ", " |\n")
-
-        // add separator line
-        sb.append(sep)
-      }
-
-      // data
-      normedStrings.drop(2).foreach {
-        toWrite.map(_).addString(sb, "| ", " | ", " |\n")
-      }
-
-      // add separator line
-      sb.append(sep)
-    }
-
-    if (nCols == 0)
-      writeCols(0, 0)
-
-    var colIdx = 0
-    var first = true
-
-    while (colIdx < nCols) {
-      val startIdx = colIdx
-      var colWidth = fixedWidth
-
-      // consume at least one column, and take until the next column would put the width over maxWidth
-      do {
-        colWidth += 3 + colWidths(colIdx)
-        colIdx += 1
-      } while (colIdx < nCols && colWidth + delimWidth + colWidths(colIdx) <= maxWidth)
-
-      if (!first) {
-        sb.append('\n')
-      }
-
-      writeCols(startIdx, colIdx)
-
-      first = false
-    }
-
-    if (hasMoreData)
-      sb.append(s"showing top $n ${ plural(n, "row") }\n")
-
-    sb.result()
-  }
 
   def copy2(rvd: RVD = rvd,
     signature: TStruct = signature,

--- a/hail/src/main/scala/is/hail/utils/ShowStrConfig.scala
+++ b/hail/src/main/scala/is/hail/utils/ShowStrConfig.scala
@@ -1,6 +1,0 @@
-package is.hail.utils
-
-
-case class ShowStrConfig(
-  floatFormat: String = "%.2e",
-  missing: String = "NA")


### PR DESCRIPTION
One issue to fix: doesn't escape string values correctly.  I will add a registry function for that.

The Scala version had a slight width miscalculation (started at fixedWidth instead of 2), otherwise character for character identical on a non-trivial VCF row table example.
