### PR TITLE
Add binary option to export rectangles

### DIFF
--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1831,7 +1831,7 @@ class BlockMatrix(object):
                n_partitions=nullable(int),
                write_bytes=bool)
     def export_rectangles(path_in, path_out, rectangles, delimiter='\t', n_partitions=None, write_bytes=False):
-        """Export rectangular regions from a stored block matrix to delimited text files.
+        """Export rectangular regions from a stored block matrix to delimited text or binary files.
 
         Examples
         --------
@@ -1868,7 +1868,7 @@ class BlockMatrix(object):
 
         The second file is ``rect-1_0-3-0-2``:
 
-        .. code-block:: text
+        .. code-block:: textd
 
             1.0 2.0
             5.0 6.0
@@ -1890,11 +1890,7 @@ class BlockMatrix(object):
         Notes
         -----
         This method exports rectangular regions of a stored block matrix
-        to delimited text files, in parallel by region.
-
-        The block matrix can be sparse so long as all blocks overlapping
-        the rectangles are present, i.e. this method does not currently
-        support implicit zeros.
+        to delimited text or binary files, in parallel by region.
 
         Each rectangle is encoded as a list of length four of
         the form ``[row_start, row_stop, col_start, col_stop]``,
@@ -1908,6 +1904,19 @@ class BlockMatrix(object):
 
         Each file name encodes the index of the rectangle in `rectangles`
         and the bounds as formatted in the example.
+
+        The block matrix can be sparse so long as all blocks overlapping
+        the rectangles are present, i.e. this method does not currently
+        support implicit zeros.
+
+        If `write_bytes` is true, each element is exported as 8 bytes, in row
+        major order with no delimiting, new lines, or shape information. Such
+        files can instantiate, for example, NumPy ndarrays using
+        `fromfile <https://docs.scipy.org/doc/numpy/reference/generated/numpy.fromfile.html>`__
+        and
+        `reshape <https://docs.scipy.org/doc/numpy/reference/generated/numpy.reshape.html>`__.
+        Note however that these binary files are not platform independent; in
+        particular, no byte-order or data-type information is saved.
 
         The number of rectangles must be less than :math:`2^{29}`.
 
@@ -1926,7 +1935,7 @@ class BlockMatrix(object):
             Maximum parallelism of export.
             Defaults to (and cannot exceed) the number of rectangles.
         write_bytes: :obj:`bool`
-            If true, export raw doubles in row major.
+            If true, export elements as raw bytes in row major order.
         """
         n_rectangles = len(rectangles)
         if n_rectangles == 0:

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1868,7 +1868,7 @@ class BlockMatrix(object):
 
         The second file is ``rect-1_0-3-0-2``:
 
-        .. code-block:: textd
+        .. code-block:: text
 
             1.0 2.0
             5.0 6.0

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1828,8 +1828,9 @@ class BlockMatrix(object):
                path_out=str,
                rectangles=sequenceof(sequenceof(int)),
                delimiter=str,
-               n_partitions=nullable(int))
-    def export_rectangles(path_in, path_out, rectangles, delimiter='\t', n_partitions=None):
+               n_partitions=nullable(int),
+               write_bytes=bool)
+    def export_rectangles(path_in, path_out, rectangles, delimiter='\t', n_partitions=None, write_bytes=False):
         """Export rectangular regions from a stored block matrix to delimited text files.
 
         Examples
@@ -1924,6 +1925,8 @@ class BlockMatrix(object):
         n_partitions: :obj:`int`, optional
             Maximum parallelism of export.
             Defaults to (and cannot exceed) the number of rectangles.
+        write_bytes: :obj:`bool`
+            If true, export raw doubles in row major.
         """
         n_rectangles = len(rectangles)
         if n_rectangles == 0:
@@ -1954,7 +1957,7 @@ class BlockMatrix(object):
         flattened_rectangles = jarray(Env.jvm().long, list(itertools.chain(*rectangles)))
 
         return Env.hail().linalg.BlockMatrix.exportRectangles(
-            Env.hc()._jhc, path_in, path_out, flattened_rectangles, delimiter, n_partitions)
+            Env.hc()._jhc, path_in, path_out, flattened_rectangles, delimiter, n_partitions, write_bytes)
 
     @typecheck_method(compute_uv=bool,
                       complexity_bound=int)

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1829,8 +1829,8 @@ class BlockMatrix(object):
                rectangles=sequenceof(sequenceof(int)),
                delimiter=str,
                n_partitions=nullable(int),
-               write_bytes=bool)
-    def export_rectangles(path_in, path_out, rectangles, delimiter='\t', n_partitions=None, write_bytes=False):
+               binary=bool)
+    def export_rectangles(path_in, path_out, rectangles, delimiter='\t', n_partitions=None, binary=False):
         """Export rectangular regions from a stored block matrix to delimited text or binary files.
 
         Examples
@@ -1905,11 +1905,11 @@ class BlockMatrix(object):
         Each file name encodes the index of the rectangle in `rectangles`
         and the bounds as formatted in the example.
 
-        The block matrix can be sparse so long as all blocks overlapping
+        The block matrix can be sparse provided all blocks overlapping
         the rectangles are present, i.e. this method does not currently
         support implicit zeros.
 
-        If `write_bytes` is true, each element is exported as 8 bytes, in row
+        If `binary` is true, each element is exported as 8 bytes, in row
         major order with no delimiting, new lines, or shape information. Such
         files can instantiate, for example, NumPy ndarrays using
         `fromfile <https://docs.scipy.org/doc/numpy/reference/generated/numpy.fromfile.html>`__
@@ -1934,7 +1934,7 @@ class BlockMatrix(object):
         n_partitions: :obj:`int`, optional
             Maximum parallelism of export.
             Defaults to (and cannot exceed) the number of rectangles.
-        write_bytes: :obj:`bool`
+        binary: :obj:`bool`
             If true, export elements as raw bytes in row major order.
         """
         n_rectangles = len(rectangles)
@@ -1966,7 +1966,7 @@ class BlockMatrix(object):
         flattened_rectangles = jarray(Env.jvm().long, list(itertools.chain(*rectangles)))
 
         return Env.hail().linalg.BlockMatrix.exportRectangles(
-            Env.hc()._jhc, path_in, path_out, flattened_rectangles, delimiter, n_partitions, write_bytes)
+            Env.hc()._jhc, path_in, path_out, flattened_rectangles, delimiter, n_partitions, binary)
 
     @typecheck_method(compute_uv=bool,
                       complexity_bound=int)

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -640,6 +640,9 @@ class Tests(unittest.TestCase):
                 rect_path = new_local_temp_dir()
                 rect_uri = local_path_uri(rect_path)
 
+                rect_path_bytes = new_local_temp_dir()
+                rect_uri_bytes = local_path_uri(rect_path_bytes)
+
                 (BlockMatrix.from_numpy(nd, block_size=block_size)
                     .sparsify_rectangles(rects)
                     .write(bm_uri, force_row_major=True))
@@ -650,6 +653,14 @@ class Tests(unittest.TestCase):
                     file = rect_path + '/rect-' + str(i) + '_' + '-'.join(map(str, r))
                     expected = nd[r[0]:r[1], r[2]:r[3]]
                     actual = np.reshape(np.loadtxt(file), (r[1] - r[0], r[3] - r[2]))
+                    self._assert_eq(expected, actual)
+
+                BlockMatrix.export_rectangles(bm_uri, rect_uri_bytes, rects, write_bytes=True)
+
+                for (i, r) in enumerate(rects):
+                    file = rect_path_bytes + '/rect-' + str(i) + '_' + '-'.join(map(str, r))
+                    expected = nd[r[0]:r[1], r[2]:r[3]]
+                    actual = np.reshape(np.fromfile(file), (r[1] - r[0], r[3] - r[2]))
                     self._assert_eq(expected, actual)
 
         bm_uri = new_temp_file()

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -637,11 +637,9 @@ class Tests(unittest.TestCase):
         for rects in [rects1, rects2, rects3]:
             for block_size in [3, 4, 10]:
                 bm_uri = new_temp_file()
+
                 rect_path = new_local_temp_dir()
                 rect_uri = local_path_uri(rect_path)
-
-                rect_path_bytes = new_local_temp_dir()
-                rect_uri_bytes = local_path_uri(rect_path_bytes)
 
                 (BlockMatrix.from_numpy(nd, block_size=block_size)
                     .sparsify_rectangles(rects)
@@ -652,8 +650,11 @@ class Tests(unittest.TestCase):
                 for (i, r) in enumerate(rects):
                     file = rect_path + '/rect-' + str(i) + '_' + '-'.join(map(str, r))
                     expected = nd[r[0]:r[1], r[2]:r[3]]
-                    actual = np.reshape(np.loadtxt(file), (r[1] - r[0], r[3] - r[2]))
+                    actual = np.loadtxt(file)
                     self._assert_eq(expected, actual)
+
+                rect_path_bytes = new_local_temp_dir()
+                rect_uri_bytes = local_path_uri(rect_path_bytes)
 
                 BlockMatrix.export_rectangles(bm_uri, rect_uri_bytes, rects, write_bytes=True)
 

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -622,7 +622,7 @@ class Tests(unittest.TestCase):
                       [13., 14.,  0.,  0.]]))
 
         self._assert_eq(bm.sparsify_rectangles([]), np.zeros(shape=(4, 4)))
-                        
+
     def test_export_rectangles(self):
         nd = np.arange(0, 80, dtype=float).reshape(8, 10)
 

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -650,7 +650,7 @@ class Tests(unittest.TestCase):
                 for (i, r) in enumerate(rects):
                     file = rect_path + '/rect-' + str(i) + '_' + '-'.join(map(str, r))
                     expected = nd[r[0]:r[1], r[2]:r[3]]
-                    actual = np.loadtxt(file)
+                    actual = np.loadtxt(file, ndmin = 2)
                     self._assert_eq(expected, actual)
 
                 rect_path_bytes = new_local_temp_dir()

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -656,7 +656,7 @@ class Tests(unittest.TestCase):
                 rect_path_bytes = new_local_temp_dir()
                 rect_uri_bytes = local_path_uri(rect_path_bytes)
 
-                BlockMatrix.export_rectangles(bm_uri, rect_uri_bytes, rects, write_bytes=True)
+                BlockMatrix.export_rectangles(bm_uri, rect_uri_bytes, rects, binary=True)
 
                 for (i, r) in enumerate(rects):
                     file = rect_path_bytes + '/rect-' + str(i) + '_' + '-'.join(map(str, r))

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -265,7 +265,7 @@ object BlockMatrix {
                     k += 1
                   }
                   sb.append(data(n - 1))
-                  if (blockCol < stopBlockCol)
+                  if (blockCol < stopBlockCol - 1)
                     sb.append(delimiter)
                   else
                     sb.append("\n")


### PR DESCRIPTION
@danking I rebased in the process of addressing your requested changes, so git won't allow me to re-open the closed branch #4842. I think this is now safe with regard to closing resources. Do you see a way to not include the branch on binary twice? I'd prefer to consider changing the types of streams/buffers as another PR.