### PR TITLE
Stop iterating logistic/poisson fit once NaN appears

### DIFF
--- a/hail/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
+++ b/hail/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
@@ -291,7 +291,9 @@ class LogisticRegressionModel(X: DenseMatrix[Double], y: DenseVector[Double]) ex
       try {
         deltaB := fisher \ score
 
-        if (max(abs(deltaB)) < tol) {
+        if (deltaB(0).isNaN) {
+          exploded = true
+        } else if (max(abs(deltaB)) < tol) {
           converged = true
         } else {
           iter += 1

--- a/hail/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
+++ b/hail/src/main/scala/is/hail/stats/LogisticRegressionModel.scala
@@ -329,7 +329,9 @@ class LogisticRegressionModel(X: DenseMatrix[Double], y: DenseVector[Double]) ex
         val h = QR.q(*, ::).map(r => r dot r)
         val deltaB = TriSolve(QR.r(0 until m0, 0 until m0), QR.q(::, 0 until m0).t * (((y - mu) + (h *:* (0.5 - mu))) /:/ sqrtW))
 
-        if (max(abs(deltaB)) < tol && iter > 1) {
+        if (deltaB(0).isNaN) {
+          exploded = true
+        } else if (max(abs(deltaB)) < tol && iter > 1) {
           converged = true
           logLkhd = sum(breeze.numerics.log((y *:* mu) + ((1d - y) *:* (1d - mu)))) + sum(log(abs(diag(QR.r))))
         } else {

--- a/hail/src/main/scala/is/hail/stats/PoissonRegressionModel.scala
+++ b/hail/src/main/scala/is/hail/stats/PoissonRegressionModel.scala
@@ -117,7 +117,9 @@ class PoissonRegressionModel(X: DenseMatrix[Double], y: DenseVector[Double]) ext
       try {
         deltaB := fisher \ score
 
-        if (max(abs(deltaB)) < tol) {
+        if (deltaB(0).isNaN) {
+          exploded = true
+        } else if (max(abs(deltaB)) < tol) {
           converged = true
         } else {
           iter += 1


### PR DESCRIPTION
This is a performance improvement (and also returns explosion after the right number of iterations which is more logical). It is only necessary to check the first element because I'm confident NaN appears nowhere or everywhere in deltaB (and certainly if it appears somewhere in one iteration, it spreads to everywhere in the next).