### PR TITLE
PTypes 53: Bring back InferType alongside InferPType. All IRs inferred.

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -23,7 +23,7 @@ object ExtractAggregators {
     val postAgg = extract(ir, ab, ab2, ref)
     val aggs = ab.result()
     val rt = TTuple(aggs.map(_.rt): _*)
-    ref.typ = rt
+    ref._typ = rt
     val ops = ab2.result()
     ExtractedAggregators(
       postAgg,
@@ -75,7 +75,7 @@ object ExtractAggregators {
         val agg = KeyedRegionValueAggregator(nestedAggs.map(_.rvAgg), key.typ)
         val aggSig = AggSignature(Group(), Seq(), Some(Seq(TVoid)), Seq(key.typ, TVoid))
         val rt = TDict(key.typ, TTuple(nestedAggs.map(_.rt): _*))
-        newRef.typ = -rt.elementType
+        newRef._typ = -rt.elementType
 
         val (initOp, seqOp) = newBuilder.result().map { case AggOps(x, y) => (x, y) }.unzip
         val i = ab.length

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -3,16 +3,27 @@ package is.hail.expr.ir
 import is.hail.annotations.Annotation
 import is.hail.expr.types._
 import is.hail.expr.ir.functions._
-import is.hail.expr.types.physical.{PStruct, PType}
+import is.hail.expr.types.physical._
 import is.hail.expr.types.virtual._
 import is.hail.utils.{ExportType, FastIndexedSeq}
 
 import scala.language.existentials
 
 sealed trait IR extends BaseIR {
-  def typ: Type
+  private var _ptype: PType = null
+  private var _typ: Type = null
 
-  def pType: PType = PType.canonical(typ)
+  def pType: PType = {
+    if (_ptype == null)
+      _ptype = InferPType(this)
+    _ptype
+  }
+
+  def typ: Type = {
+    if (_typ == null)
+      _typ = InferType(this)
+    _typ
+  }
 
   override def children: IndexedSeq[BaseIR] =
     Children(this)
@@ -49,36 +60,24 @@ object Literal {
   }
 }
 
-final case class Literal(typ: Type, value: Annotation) extends IR {
-  require(!CanEmit(typ))
+final case class Literal(_typ: Type, value: Annotation) extends IR {
+  require(!CanEmit(_typ))
   require(value != null)
 }
 
-sealed trait InferIR extends IR {
-  var _ptype: PType = null
+final case class I32(x: Int) extends IR
+final case class I64(x: Long) extends IR
+final case class F32(x: Float) extends IR
+final case class F64(x: Double) extends IR
+final case class Str(x: String) extends IR
+final case class True() extends IR
+final case class False() extends IR
+final case class Void() extends IR
 
-  override def pType: PType = {
-    if (_ptype == null)
-      _ptype = Infer(this)
-    _ptype
-  }
+final case class Cast(v: IR, _typ: Type) extends IR
 
-  def typ: Type = pType.virtualType
-}
-
-final case class I32(x: Int) extends IR { val typ = TInt32() }
-final case class I64(x: Long) extends IR { val typ = TInt64() }
-final case class F32(x: Float) extends IR { val typ = TFloat32() }
-final case class F64(x: Double) extends IR { val typ = TFloat64() }
-final case class Str(x: String) extends IR { val typ = TString() }
-final case class True() extends IR { val typ = TBoolean() }
-final case class False() extends IR { val typ = TBoolean() }
-final case class Void() extends IR { val typ = TVoid }
-
-final case class Cast(v: IR, typ: Type) extends IR
-
-final case class NA(typ: Type) extends IR { assert(!typ.required) }
-final case class IsNA(value: IR) extends IR { val typ = TBoolean() }
+final case class NA(_typ: Type) extends IR { assert(!_typ.required) }
+final case class IsNA(value: IR) extends IR
 
 object If {
   def unify(cond: IR, cnsq: IR, altr: IR, unifyType: Option[Type] = None): If = {
@@ -93,14 +92,14 @@ object If {
   }
 }
 
-final case class If(cond: IR, cnsq: IR, altr: IR) extends InferIR
+final case class If(cond: IR, cnsq: IR, altr: IR) extends IR
 
-final case class Let(name: String, value: IR, body: IR) extends InferIR
-final case class Ref(name: String, var typ: Type) extends IR
+final case class Let(name: String, value: IR, body: IR) extends IR
+final case class Ref(name: String, var _typ: Type) extends IR
 
-final case class ApplyBinaryPrimOp(op: BinaryOp, l: IR, r: IR) extends InferIR
-final case class ApplyUnaryPrimOp(op: UnaryOp, x: IR) extends InferIR
-final case class ApplyComparisonOp(op: ComparisonOp[_], l: IR, r: IR) extends InferIR
+final case class ApplyBinaryPrimOp(op: BinaryOp, l: IR, r: IR) extends IR
+final case class ApplyUnaryPrimOp(op: UnaryOp, x: IR) extends IR
+final case class ApplyComparisonOp(op: ComparisonOp[_], l: IR, r: IR) extends IR
 
 object MakeArray {
   def unify(args: Seq[IR], typ: TArray = null): MakeArray = {
@@ -127,47 +126,43 @@ object MakeArray {
   }
 }
 
-final case class MakeArray(args: Seq[IR], typ: TArray) extends IR {
-}
+final case class MakeArray(args: Seq[IR], _typ: TArray) extends IR
+final case class ArrayRef(a: IR, i: IR) extends IR
+final case class ArrayLen(a: IR) extends IR
+final case class ArrayRange(start: IR, stop: IR, step: IR) extends IR
 
-final case class ArrayRef(a: IR, i: IR) extends InferIR
-final case class ArrayLen(a: IR) extends IR { val typ = TInt32() }
-final case class ArrayRange(start: IR, stop: IR, step: IR) extends IR { val typ: TArray = TArray(TInt32()) }
+final case class ArraySort(a: IR, ascending: IR, onKey: Boolean = false) extends IR
+final case class ToSet(a: IR) extends IR
+final case class ToDict(a: IR) extends IR
+final case class ToArray(a: IR) extends IR
 
-final case class ArraySort(a: IR, ascending: IR, onKey: Boolean = false) extends InferIR
-final case class ToSet(a: IR) extends InferIR
-final case class ToDict(a: IR) extends InferIR
-final case class ToArray(a: IR) extends InferIR
+final case class LowerBoundOnOrderedCollection(orderedCollection: IR, elem: IR, onKey: Boolean) extends IR
 
-final case class LowerBoundOnOrderedCollection(orderedCollection: IR, elem: IR, onKey: Boolean) extends IR { val typ: Type = TInt32() }
+final case class GroupByKey(collection: IR) extends IR
 
-final case class GroupByKey(collection: IR) extends InferIR
-
-final case class ArrayMap(a: IR, name: String, body: IR) extends InferIR {
+final case class ArrayMap(a: IR, name: String, body: IR) extends IR {
   override def typ: TArray = coerce[TArray](super.typ)
   def elementTyp: Type = typ.elementType
 }
-final case class ArrayFilter(a: IR, name: String, cond: IR) extends InferIR {
+final case class ArrayFilter(a: IR, name: String, cond: IR) extends IR {
   override def typ: TArray = super.typ.asInstanceOf[TArray]
 }
-final case class ArrayFlatMap(a: IR, name: String, body: IR) extends InferIR {
+final case class ArrayFlatMap(a: IR, name: String, body: IR) extends IR {
   override def typ: TArray = coerce[TArray](super.typ)
 }
-final case class ArrayFold(a: IR, zero: IR, accumName: String, valueName: String, body: IR) extends InferIR
+final case class ArrayFold(a: IR, zero: IR, accumName: String, valueName: String, body: IR) extends IR
 
-final case class ArrayScan(a: IR, zero: IR, accumName: String, valueName: String, body: IR) extends InferIR
+final case class ArrayScan(a: IR, zero: IR, accumName: String, valueName: String, body: IR) extends IR
 
-final case class ArrayFor(a: IR, valueName: String, body: IR) extends IR {
-  val typ = TVoid
-}
+final case class ArrayFor(a: IR, valueName: String, body: IR) extends IR
 
-final case class AggFilter(cond: IR, aggIR: IR) extends InferIR
+final case class AggFilter(cond: IR, aggIR: IR) extends IR
 
-final case class AggExplode(array: IR, name: String, aggBody: IR) extends InferIR
+final case class AggExplode(array: IR, name: String, aggBody: IR) extends IR
 
-final case class AggGroupBy(key: IR, aggIR: IR) extends InferIR
+final case class AggGroupBy(key: IR, aggIR: IR) extends IR
 
-final case class ApplyAggOp(constructorArgs: IndexedSeq[IR], initOpArgs: Option[IndexedSeq[IR]], seqOpArgs: IndexedSeq[IR], aggSig: AggSignature) extends InferIR {
+final case class ApplyAggOp(constructorArgs: IndexedSeq[IR], initOpArgs: Option[IndexedSeq[IR]], seqOpArgs: IndexedSeq[IR], aggSig: AggSignature) extends IR {
   assert(!(seqOpArgs ++ constructorArgs ++ initOpArgs.getOrElse(FastIndexedSeq.empty[IR])).exists(ContainsScan(_)))
   assert(constructorArgs.map(_.typ) == aggSig.constructorArgs)
   assert(initOpArgs.map(_.map(_.typ)) == aggSig.initOpArgs)
@@ -181,7 +176,7 @@ final case class ApplyAggOp(constructorArgs: IndexedSeq[IR], initOpArgs: Option[
   def op: AggOp = aggSig.op
 }
 
-final case class ApplyScanOp(constructorArgs: IndexedSeq[IR], initOpArgs: Option[IndexedSeq[IR]], seqOpArgs: IndexedSeq[IR], aggSig: AggSignature) extends InferIR {
+final case class ApplyScanOp(constructorArgs: IndexedSeq[IR], initOpArgs: Option[IndexedSeq[IR]], seqOpArgs: IndexedSeq[IR], aggSig: AggSignature) extends IR {
   assert(!(seqOpArgs ++ constructorArgs ++ initOpArgs.getOrElse(FastIndexedSeq.empty[IR])).exists(ContainsAgg(_)))
   assert(constructorArgs.map(_.typ) == aggSig.constructorArgs)
   assert(initOpArgs.map(_.map(_.typ)) == aggSig.initOpArgs)
@@ -195,45 +190,33 @@ final case class ApplyScanOp(constructorArgs: IndexedSeq[IR], initOpArgs: Option
   def op: AggOp = aggSig.op
 }
 
-final case class InitOp(i: IR, args: IndexedSeq[IR], aggSig: AggSignature) extends IR {
-  val typ = TVoid
-}
-final case class SeqOp(i: IR, args: IndexedSeq[IR], aggSig: AggSignature) extends IR {
-  val typ = TVoid
-}
-
-final case class Begin(xs: IndexedSeq[IR]) extends IR {
-  val typ = TVoid
-}
-
-final case class MakeStruct(fields: Seq[(String, IR)]) extends InferIR
-final case class SelectFields(old: IR, fields: Seq[String]) extends InferIR
-final case class InsertFields(old: IR, fields: Seq[(String, IR)]) extends InferIR {
+final case class InitOp(i: IR, args: IndexedSeq[IR], aggSig: AggSignature) extends IR
+final case class SeqOp(i: IR, args: IndexedSeq[IR], aggSig: AggSignature) extends IR
+final case class Begin(xs: IndexedSeq[IR]) extends IR
+final case class MakeStruct(fields: Seq[(String, IR)]) extends IR
+final case class SelectFields(old: IR, fields: Seq[String]) extends IR
+final case class InsertFields(old: IR, fields: Seq[(String, IR)]) extends IR {
   override def typ: TStruct = coerce[TStruct](super.typ)
 
   override def pType: PStruct = coerce[PStruct](super.pType)
 }
 
-final case class GetField(o: IR, name: String) extends InferIR
+final case class GetField(o: IR, name: String) extends IR
 
-final case class MakeTuple(types: Seq[IR]) extends InferIR
-final case class GetTupleElement(o: IR, idx: Int) extends InferIR
+final case class MakeTuple(types: Seq[IR]) extends IR
+final case class GetTupleElement(o: IR, idx: Int) extends IR
 
-final case class StringSlice(s: IR, start: IR, end: IR) extends IR {
-  val typ = TString()
-}
-final case class StringLength(s: IR) extends IR {
-  val typ = TInt32()
-}
+final case class StringSlice(s: IR, start: IR, end: IR) extends IR
+final case class StringLength(s: IR) extends IR
 
-final case class In(i: Int, typ: Type) extends IR
+final case class In(i: Int, _typ: Type) extends IR
+
 // FIXME: should be type any
-
 object Die {
   def apply(message: String, typ: Type): Die = Die(Str(message), typ)
 }
 
-final case class Die(message: IR, typ: Type) extends IR
+final case class Die(message: IR, _typ: Type) extends IR
 
 final case class ApplyIR(function: String, args: Seq[IR], conversion: Seq[IR] => IR) extends IR {
   lazy val explicitNode: IR = {
@@ -243,8 +226,6 @@ final case class ApplyIR(function: String, args: Seq[IR], conversion: Seq[IR] =>
     // foldRight because arg1 should be at the top so it is evaluated first
     refs.zip(args).foldRight(body) { case ((ref, arg), bodyIR) => Let(ref.name, arg, bodyIR) }
   }
-
-  def typ: Type = explicitNode.typ
 }
 
 sealed abstract class AbstractApplyNode[F <: IRFunction] extends IR {
@@ -252,13 +233,6 @@ sealed abstract class AbstractApplyNode[F <: IRFunction] extends IR {
   def args: Seq[IR]
   def argTypes: Seq[Type] = args.map(_.typ)
   lazy val implementation: F = IRFunctionRegistry.lookupFunction(function, argTypes).get.asInstanceOf[F]
-  def typ: Type = {
-    // convert all arg types before unifying
-    val argTypes = args.map(_.typ)
-    implementation.unify(argTypes)
-    implementation.returnType.subst()
-  }
-
 }
 
 final case class Apply(function: String, args: Seq[IR]) extends AbstractApplyNode[IRFunctionWithoutMissingness]
@@ -267,36 +241,29 @@ final case class ApplySeeded(function: String, args: Seq[IR], seed: Long) extend
 
 final case class ApplySpecial(function: String, args: Seq[IR]) extends AbstractApplyNode[IRFunctionWithMissingness]
 
-final case class Uniroot(argname: String, function: IR, min: IR, max: IR) extends IR { val typ: Type = TFloat64() }
+final case class Uniroot(argname: String, function: IR, min: IR, max: IR) extends IR
 
-final case class TableCount(child: TableIR) extends IR { val typ: Type = TInt64() }
-final case class TableAggregate(child: TableIR, query: IR) extends InferIR
-final case class MatrixAggregate(child: MatrixIR, query: IR) extends InferIR
+final case class TableCount(child: TableIR) extends IR
+final case class TableAggregate(child: TableIR, query: IR) extends IR
+final case class MatrixAggregate(child: MatrixIR, query: IR) extends IR
 final case class TableWrite(
   child: TableIR,
   path: String,
   overwrite: Boolean = true,
   stageLocally: Boolean = false,
-  codecSpecJSONStr: String = null) extends IR {
-  val typ: Type = TVoid
-}
+  codecSpecJSONStr: String = null) extends IR
+
 final case class TableExport(
   child: TableIR,
   path: String,
   typesFile: String = null,
   header: Boolean = true,
-  exportType: Int = ExportType.CONCATENATED) extends IR {
-  val typ: Type = TVoid
-}
+  exportType: Int = ExportType.CONCATENATED) extends IR
 
-final case class MatrixWrite(
-  child: MatrixIR,
-  writer: MatrixWriter) extends IR {
-  val typ: Type = TVoid
-}
+final case class MatrixWrite(child: MatrixIR, writer: MatrixWriter) extends IR
 
-final case class TableGetGlobals(child: TableIR) extends InferIR
-final case class TableCollect(child: TableIR) extends InferIR
+final case class TableGetGlobals(child: TableIR) extends IR
+final case class TableCollect(child: TableIR) extends IR
 
 class PrimitiveIR(val self: IR) extends AnyVal {
   def +(other: IR): IR = ApplyBinaryPrimOp(Add(), self, other)

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -1,0 +1,135 @@
+package is.hail.expr.ir
+
+import is.hail.expr.types.virtual._
+import is.hail.utils._
+
+// FIXME: strip all requiredness logic when possible
+object InferType {
+  def apply(ir: IR): Type = {
+    ir match {
+      case I32(_) => TInt32()
+      case I64(_) => TInt64()
+      case F32(_) => TFloat32()
+      case F64(_) => TFloat64()
+      case Str(_) => TString()
+      case Literal(t, _) => t
+      case True() | False() => TBoolean()
+      case Void() => TVoid
+      case Cast(_, t) => t
+      case NA(t) => t
+      case IsNA(_) => TBoolean()
+      case Ref(_, t) => t
+      case In(_, t) => t
+      case MakeArray(_, t) => t
+      case _: ArrayLen => TInt32()
+      case _: ArrayRange => TArray(TInt32())
+      case _: LowerBoundOnOrderedCollection => TInt32()
+      case _: ArrayFor => TVoid
+      case _: InitOp => TVoid
+      case _: SeqOp => TVoid
+      case _: Begin => TVoid
+      case _: StringLength => TInt32()
+      case _: StringSlice => TString()
+      case Die(_, t) => t
+      case If(cond, cnsq, altr) =>
+        assert(cond.typ.isOfType(TBoolean()))
+        assert(cnsq.typ.isOfType(altr.typ))
+        if (cnsq.typ != altr.typ)
+          cnsq.typ.deepOptional()
+        else
+          cnsq.typ
+      case Let(name, value, body) =>
+        body.typ
+      case ApplyBinaryPrimOp(op, l, r) =>
+        BinaryOp.getReturnType(op, l.typ, r.typ).setRequired(l.typ.required && r.typ.required)
+      case ApplyUnaryPrimOp(op, v) =>
+        UnaryOp.getReturnType(op, v.typ).setRequired(v.typ.required)
+      case ApplyComparisonOp(op, l, r) =>
+        assert(l.typ isOfType r.typ)
+        op match {
+          case _: Compare => TInt32(l.pType.required && r.pType.required)
+          case _ => TBoolean(l.pType.required && r.pType.required)
+        }
+      case a: ApplyIR => a.explicitNode.typ
+      case a: AbstractApplyNode[_] =>
+        val argTypes = a.args.map(_.typ)
+        a.implementation.unify(argTypes)
+        a.implementation.returnType.subst()
+      case _: Uniroot => TFloat64()
+      case ArrayRef(a, i) =>
+        assert(i.typ.isOfType(TInt32()))
+        coerce[TArray](a.typ).elementType.setRequired(a.typ.required && i.typ.required)
+      case ArraySort(a, ascending, _) =>
+        assert(ascending.typ.isOfType(TBoolean()))
+        val et = coerce[TArray](a.typ).elementType
+        TArray(et, a.typ.required)
+      case ToSet(a) =>
+        val et = coerce[TArray](a.typ).elementType
+        TSet(et, a.typ.required)
+      case ToDict(a) =>
+        val elt = coerce[TBaseStruct](coerce[TArray](a.typ).elementType)
+        TDict(elt.types(0), elt.types(1), a.typ.required)
+      case ToArray(a) =>
+        val et = coerce[TContainer](a.typ).elementType
+        TArray(et, a.typ.required)
+      case GroupByKey(collection) =>
+        val elt = coerce[TBaseStruct](coerce[TArray](collection.typ).elementType)
+        TDict(elt.types(0), TArray(elt.types(1)), collection.typ.required)
+      case ArrayMap(a, name, body) =>
+        TArray(body.typ.setRequired(false), a.typ.required)
+      case ArrayFilter(a, name, cond) =>
+        TArray(coerce[TArray](a.typ).elementType, a.typ.required)
+      case ArrayFlatMap(a, name, body) =>
+        TArray(coerce[TContainer](body.typ).elementType, a.typ.required)
+      case ArrayFold(a, zero, accumName, valueName, body) =>
+        assert(body.typ == zero.typ)
+        zero.typ
+      case ArrayScan(a, zero, accumName, valueName, body) =>
+        assert(body.typ == zero.typ)
+        TArray(zero.typ)
+      case AggFilter(_, aggIR) =>
+        aggIR.typ
+      case AggExplode(array, name, aggBody) =>
+        aggBody.typ
+      case AggGroupBy(key, aggIR) =>
+        TDict(key.typ, aggIR.typ)
+      case ApplyAggOp(_, _, _, aggSig) =>
+        AggOp.getType(aggSig)
+      case ApplyScanOp(_, _, _, aggSig) =>
+        AggOp.getType(aggSig)
+      case MakeStruct(fields) =>
+        TStruct(fields.map { case (name, a) =>
+          (name, a.typ)
+        }: _*)
+      case SelectFields(old, fields) =>
+        val tbs = coerce[TStruct](old.typ)
+        tbs.select(fields.toFastIndexedSeq)._1
+      case InsertFields(old, fields) =>
+        val tbs = coerce[TStruct](old.typ)
+        tbs.insertFields(fields.map(f => (f._1, f._2.typ)))
+      case GetField(o, name) =>
+        val t = coerce[TStruct](o.typ)
+        if (t.index(name).isEmpty)
+          throw new RuntimeException(s"$name not in $t")
+        val fd = t.field(name).typ
+        fd.setRequired(t.required && fd.required)
+      case MakeTuple(values) =>
+        TTuple(values.map(_.typ).toFastIndexedSeq)
+      case GetTupleElement(o, idx) =>
+        val t = coerce[TTuple](o.typ)
+        assert(idx >= 0 && idx < t.size)
+        val fd = t.types(idx)
+        fd.setRequired(t.required && fd.required)
+      case TableCount(_) => TInt64()
+      case TableAggregate(child, query) =>
+        query.typ
+      case MatrixAggregate(child, query) =>
+        query.typ
+      case _: TableWrite => TVoid
+      case _: MatrixWrite => TVoid
+      case _: TableExport => TVoid
+      case TableGetGlobals(child) => child.typ.globalType
+      case TableCollect(child) => TStruct("rows" -> TArray(child.typ.rowType), "global" -> child.typ.globalType)
+    }
+  }
+}


### PR DESCRIPTION
In last year's PTypes season finale (#4900) I changed Infer to infer the
physical type, and used that to determine the virtual type. This was a
mistake, since there will be plenty of cases where we know the type but
not the physical type (e.g. we have a Ref node). There are also some
nodes where physical types don't even make sense: Literal, TableCollect,
and anything else that fails `CanEmit`.

This PTypes episode changes Infer to InferPType, brings back the old
Infer as InferType, and makes some housekeeping changes to the IR file.