### PR TITLE
[ci] link to logs for all PRs in CI UI

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -31,13 +31,14 @@ restart-proxy:
 	$(shell gcloud compute \
 	  --project "$(PROJECT)" \
 	  ssh \
-	  --zone "us-central1-a" \
+	  --zone "us-east1-b" \
 	  "dk-test" \
 	  --ssh-flag="-R 0.0.0.0:${HAIL_CI_REMOTE_PORT}:127.0.0.1:5000" \
 	  --ssh-flag='-N' \
 	  --ssh-flag='-T' \
 	  --ssh-flag='-v' \
 	  --dry-run) > proxy.log 2>proxy.err & echo $$! > proxy.pid
+	sleep 2 && kill -0 $$(cat proxy.pid)
 
 restart-batch-proxy:
 	-kill $(shell cat batch-proxy.pid)
@@ -50,6 +51,7 @@ restart-batch-proxy:
                          | sed 's:pods/::' \
                          | head -n 1))
 	kubectl port-forward ${BATCH_POD} 8888:5000 > batch-proxy.log 2>batch-proxy.err & echo $$! > batch-proxy.pid
+	sleep 2 && kill -0 $$(cat batch-proxy.pid)
 
 
 

--- a/ci/ci/batch_helper.py
+++ b/ci/ci/batch_helper.py
@@ -9,7 +9,6 @@ from .git_state import FQSHA
 def try_to_cancel_job(job):
     try:
         job.cancel()
-        job.delete()
     except requests.exceptions.HTTPError as e:
         log.warning(f'could not cancel job {job.id} due to {e}')
 

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -11,7 +11,8 @@ from flask_cors import CORS
 
 from .batch_helper import try_to_cancel_job, job_ordering
 from .ci_logging import log
-from .constants import BUILD_JOB_TYPE, GCS_BUCKET, DEPLOY_JOB_TYPE
+from .constants import BUILD_JOB_TYPE, GCS_BUCKET, GCS_BUCKET_PREFIX, \
+    DEPLOY_JOB_TYPE
 from .environment import \
     batch_client, \
     WATCHED_TARGETS, \
@@ -334,22 +335,22 @@ def job_log(id):
 
 def receive_ci_job(source, target, job):
     upload_public_gs_file_from_string(GCS_BUCKET,
-                                      f'ci/{source.sha}/{target.sha}/job.log',
+                                      f'{GCS_BUCKET_PREFIX}ci/{source.sha}/{target.sha}/job.log',
                                       job.cached_status()['log'])
     upload_public_gs_file_from_filename(
         GCS_BUCKET,
-        f'ci/{source.sha}/{target.sha}/index.html',
+        f'{GCS_BUCKET_PREFIX}ci/{source.sha}/{target.sha}/index.html',
         'index.html')
     prs.ci_build_finished(source, target, job)
 
 
 def receive_deploy_job(target, job):
     upload_public_gs_file_from_string(GCS_BUCKET,
-                                      f'deploy/{target.sha}/job.log',
+                                      f'{GCS_BUCKET_PREFIX}deploy/{target.sha}/job.log',
                                       job.cached_status()['log'])
     upload_public_gs_file_from_filename(
         GCS_BUCKET,
-        f'deploy/{target.sha}/index.html',
+        f'{GCS_BUCKET_PREFIX}deploy/{target.sha}/index.html',
         'deploy-index.html')
     prs.deploy_build_finished(target, job)
 

--- a/ci/ci/constants.py
+++ b/ci/ci/constants.py
@@ -1,3 +1,5 @@
+import os
+
 GITHUB_API_URL = 'https://api.github.com/'
 GITHUB_CLONE_URL = 'https://github.com/'
 VERSION = '0-1'
@@ -5,5 +7,15 @@ BUILD_JOB_PREFIX = 'hail-ci-0-2-1'
 BUILD_JOB_TYPE = BUILD_JOB_PREFIX + '-build'
 DEPLOY_JOB_TYPE = BUILD_JOB_PREFIX + '-deploy'
 GCP_PROJECT = 'broad-ctsa'
-GCS_BUCKET = 'hail-ci-' + VERSION
+gcs_path = os.environ.get('HAIL_CI_GCS_PATH')
+if gcs_path:
+    path_pieces = gcs_path.split('/')
+    GCS_BUCKET = path_pieces[0]
+    if len(path_pieces) > 1:
+        GCS_BUCKET_PREFIX = '/'.join(path_pieces[1:]) + '/'
+    else:
+        GCS_BUCKET_PREFIX = ''
+else:
+    GCS_BUCKET = 'hail-ci-' + VERSION
+    GCS_BUCKET_PREFIX = ''
 SHA_LENGTH = 12

--- a/ci/ci/prs.py
+++ b/ci/ci/prs.py
@@ -342,7 +342,7 @@ class PRS(object):
         else:
             log.info(f'deploy job {job.id} succeeded for {target.short_str()}')
             self.latest_deployed[target.ref] = target.sha
-        job.delete()
+        job.cancel()
 
     def refresh_from_deploy_jobs(self, jobs):
         lost_jobs = {target_ref for target_ref in self.deploy_jobs.keys()}
@@ -366,15 +366,15 @@ class PRS(object):
         elif state == 'Cancelled':
             log.info(f'refreshing from cancelled deploy job {job.id} {job.attributes}')
             del self.deploy_jobs[target.ref]
-            job.delete()
+            job.cancel()
         else:
             assert state == 'Created', f'{state} {job.id} {job.attributes}'
             existing_job = self.deploy_jobs[target.ref]
             if existing_job is None:
                 self.deploy_jobs[target.ref] = job
             elif existing_job.id != job.id:
-                log.info(f'found deploy job {job.id} other than mine {existing_job.id}, deleting')
-                job.delete()
+                log.info(f'found deploy job {job.id} other than mine {existing_job.id}, canceling')
+                job.cancel()
 
     def ci_build_finished(self, source, target, job):
         assert isinstance(job, Job), job

--- a/ci/ci/templates/index.html
+++ b/ci/ci/templates/index.html
@@ -54,7 +54,11 @@
             {{ pr.title }}
           </td>
           <td align="left">
+            {% if pr.build.job is defined %}
+            <a href="job-log/{{ pr.build.job.id }}">{{ pr.build }}</a>
+            {% else %}
             {{ pr.build }}
+            {% endif %}
           </td>
           <td align="left">
             {{ pr.review }}


### PR DESCRIPTION
Major Changes:
 - never delete CI jobs, only cancel them
 - Mergeable (success) and Failure build states include the job that triggered the build state
 - if a PR's build state has a job, link to that job

Minor Changes:
 - fix location of dk-test instance
 - test that proxy processes are still alive (if proxy creation fails, the process usually exits)
 - provide `HAIL_CI_GCS_PATH` for developers to set an alternative deploy bucket and path-within-bucket (now that `gs://hail-ci-0-1` is protected)