### PR TITLE
fix conda

### DIFF
--- a/batch/hail-ci-build.sh
+++ b/batch/hail-ci-build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -ex
 
-. activate hail-batch
+. ../loadconda
+conda activate hail-batch
 
 flake8 batch
 pylint batch --rcfile batch/pylintrc --score=n

--- a/batch/hail-ci-deploy.sh
+++ b/batch/hail-ci-deploy.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -ex
 
-source activate hail-batch
+. ../loadconda
+conda activate hail-batch
 
 gcloud -q auth activate-service-account \
   --key-file=/secrets/gcr-push-service-account-key.json

--- a/batch/test-locally.sh
+++ b/batch/test-locally.sh
@@ -2,7 +2,8 @@
 
 set -ex
 
-. activate hail-batch
+. ../loadconda
+conda activate hail-batch
 
 cleanup() {
     set +e

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -60,7 +60,7 @@ run-local: PROXY_IP=$(shell gcloud compute instances list --filter=name=dk-test 
 run-local: restart-all-proxies
 	SELF_HOSTNAME=http://${PROXY_IP}:${HAIL_CI_REMOTE_PORT} \
 	BATCH_SERVER_URL=http://127.0.0.1:${HAIL_CI_LOCAL_BATCH_PORT} \
-	source activate hail-ci && python run_ci.py
+	../loadconda && conda activate hail-ci && python run_ci.py
 
 run-local-for-tests: HAIL_CI_REMOTE_PORT = 3001
 run-local-for-tests: PROXY_IP=$(shell gcloud compute instances list --filter=name=dk-test --format="value(EXTERNAL_IP)")
@@ -68,7 +68,7 @@ run-local-for-tests: restart-all-proxies
 	SELF_HOSTNAME=http://${PROXY_IP}:${HAIL_CI_REMOTE_PORT} \
 	BATCH_SERVER_URL=http://127.0.0.1:${HAIL_CI_LOCAL_BATCH_PORT} \
 	WATCHED_TARGETS='[["hail-is/ci-test:master", true]]' \
-	source activate hail-ci && pip install ./batch && python run_ci.py
+	../loadconda && conda activate hail-ci && pip install ./batch && python run_ci.py
 
 test-locally: HAIL_CI_REMOTE_PORT = 3001
 test-locally: PROXY_IP=$(shell gcloud compute instances list --filter=name=dk-test --format="value(EXTERNAL_IP)")

--- a/ci/hail-ci-deploy.sh
+++ b/ci/hail-ci-deploy.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -ex
 
-source activate hail-ci
+. ../loadconda
+conda activate hail-ci
 
 gcloud -q auth activate-service-account \
   --key-file=/secrets/gcr-push-service-account-key.json

--- a/ci/test-locally.sh
+++ b/ci/test-locally.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -ex
 
-. activate hail-ci
+. ../loadconda
+conda activate hail-ci
 
 pip install -U ../batch
 
@@ -60,7 +61,6 @@ git push origin master:master
 popd
 
 # start CI system
-source activate hail-ci
 python run_ci.py --debug & echo $! > ci.pid
 
 sleep 10

--- a/loadconda
+++ b/loadconda
@@ -1,0 +1,19 @@
+#!/bin/sh
+# POSIX non-interactive shells do not guarantee any file to be loaded so there
+# is no profile or rc file that we can reliably put this line into
+
+try_source() {
+    [ ! -e "$1" ] || . "$1"
+}
+
+if ! conda activate 2>/dev/null
+then
+    try_source /opt/conda/etc/profile.d/conda.sh
+    try_source "${HOME}/anaconda2/etc/profile.d/conda.sh"
+    try_source "${HOME}/miniconda/etc/profile.d/conda.sh"
+    if which conda >/dev/null 2>/dev/null
+    then
+        conda_dir=$(dirname $(dirname $(which conda)))
+        try_source "$conda_dir/etc/profile.d/conda.sh"
+    fi
+fi


### PR DESCRIPTION
`. activate NAME` might silently fail if `NAME` does not exist or `conda` is not configured. `. ./loadconda` tries to find conda in a variety of places and configure it (meaning source `conda.sh`). After this, `conda activate NAME` will work correctly.

---

This is already in my batch dag PR, but that's getting bogged down in test issues, and this is blocking @akotlar 's https://github.com/hail-is/hail/pull/5065 PR.