### PR TITLE
Lower MatrixExplodeRows

### DIFF
--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -75,13 +75,13 @@ class TableMapGlobals(TableIR):
 
 
 class TableExplode(TableIR):
-    def __init__(self, child, field):
+    def __init__(self, child, path):
         super().__init__()
         self.child = child
-        self.field = field
+        self.path = path
 
     def render(self, r):
-        return '(TableExplode {} {})'.format(escape_id(self.field), r(self.child))
+        return '(TableExplode {} {})'.format(parsable_strings(self.path), r(self.child))
 
 
 class TableKeyBy(TableIR):

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -2441,7 +2441,7 @@ class Table(ExprContainer):
                 raise ValueError(f"method 'explode' cannot explode a key field")
 
         f = self._fields_inverse[field]
-        t = Table(TableExplode(self._tir, f))
+        t = Table(TableExplode(self._tir, [f]))
         if name is not None:
             t = t.rename({f: name})
         return t

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -158,7 +158,7 @@ class TableIRTests(unittest.TestCase):
             ir.TableRepartition(table_read, 10, ir.RepartitionStrategy.COALESCE),
             ir.TableUnion(
                 [ir.TableRange(100, 10), ir.TableRange(50, 10)]),
-            ir.TableExplode(table_read, 'mset'),
+            ir.TableExplode(table_read, ['mset']),
             ir.TableHead(table_read, 10),
             ir.TableOrderBy(ir.TableKeyBy(table_read, []), [('m', 'A'), ('m', 'D')]),
             ir.TableDistinct(table_read),

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -210,6 +210,8 @@ object LowerMatrixIR {
             })
           .dropFields('newColIdx)
         )
+
+    case MatrixExplodeRows(child, path) => TableExplode(lower(child), path)
   }
 
   private[this] def tableRules: PartialFunction[TableIR, TableIR] = {

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -881,9 +881,9 @@ object IRParser {
           else
             SortField(i.substring(1), Descending)))
       case "TableExplode" =>
-        val field = identifier(it)
+        val path = string_literals(it)
         val child = table_ir(env)(it)
-        TableExplode(child, field)
+        TableExplode(child, path)
       case "CastMatrixToTable" =>
         val entriesField = string_literal(it)
         val colsField = string_literal(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -270,7 +270,7 @@ object Pretty {
               s"${ prettyStringLiteral(dataName) } ${ prettyStringLiteral(globalName) }"
             case TableKeyByAndAggregate(_, _, _, nPartitions, bufferSize) =>
               prettyIntOpt(nPartitions) + " " + bufferSize.toString
-            case TableExplode(_, field) => field
+            case TableExplode(_, path) => prettyStrings(path)
             case TableParallelize(_, nPartitions) =>
                 prettyIntOpt(nPartitions)
             case TableOrderBy(_, sortFields) => prettyIdentifiers(sortFields.map(sf =>

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -305,19 +305,21 @@ object PruneDeadFields {
             ): _*),
           globalType = gType)
         children.foreach(memoizeTableIR(_, dep, memo))
-      case TableExplode(child, field) =>
-        val minChild = minimal(child.typ)
-        val dep2 = unify(child.typ, requestedType.copy(rowType = requestedType.rowType.filter(_.name != field)._1),
-          minChild.copy(rowType = unify(
-            child.typ.rowType,
-            minChild.rowType,
-            TStruct(field -> requestedType.rowType
-              .fieldOption(field)
-              .map(f => child.typ.rowType.field(field).typ match {
-                case _: TArray => TArray(f.typ)
-                case _: TSet => TSet(f.typ)
-              }).getOrElse(minimal(child.typ.rowType.field(field).typ))))))
-        memoizeTableIR(child, dep2, memo)
+      case TableExplode(child, path) =>
+        def getExplodedField(typ: TableType): Type = typ.rowType.queryTyped(path.toList)._1
+        val preExplosionFieldType = getExplodedField(child.typ)
+        val prunedPreExlosionFieldType = try {
+          val t = getExplodedField(requestedType)
+          preExplosionFieldType match {
+            case ta: TArray => ta.copy(elementType = t)
+            case ts: TSet => ts.copy(elementType = t)
+          }
+        } catch {
+          case e: AnnotationPathException => minimal(preExplosionFieldType)
+        }
+        val dep = requestedType.copy(rowType = unify(child.typ.rowType,
+          requestedType.rowType.insert(prunedPreExlosionFieldType, path.toList)._1.asInstanceOf[TStruct]))
+        memoizeTableIR(child, dep, memo)
       case TableFilter(child, pred) =>
         val irDep = memoizeAndGetDep(pred, pred.typ, child.typ, memo)
         memoizeTableIR(child, unify(child.typ, requestedType, irDep), memo)

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -423,7 +423,7 @@ object Simplify {
                 aggSig))),
             MakeStruct(Seq()), // aggregate to one row
             Some(1), 10),
-          "row")
+          FastIndexedSeq("row"))
       TableMapRows(te, GetField(Ref("row", te.typ.rowType), "row"))
 
     case TableKeyByAndAggregate(child, MakeStruct(Seq()), k@MakeStruct(keyFields), _, _) if canRepartition =>

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -484,7 +484,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
       signature.schema.asInstanceOf[StructType])
   }
 
-  def explode(column: String): Table = new Table(hc, TableExplode(tir, column))
+  def explode(column: String): Table = new Table(hc, TableExplode(tir, Array(column)))
 
   def explode(columnNames: Array[String]): Table = {
     columnNames.foldLeft(this)((kt, name) => kt.explode(name))

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -878,7 +878,7 @@ class IRSuite extends SparkSuite {
         TableRange(100, 10),
         TableUnion(
           FastIndexedSeq(TableRange(100, 10), TableRange(50, 10))),
-        TableExplode(read, "mset"),
+        TableExplode(read, Array("mset")),
         TableOrderBy(TableKeyBy(read, FastIndexedSeq()), FastIndexedSeq(SortField("m", Ascending), SortField("m", Descending))),
         CastMatrixToTable(mtRead, " # entries", " # cols"),
         TableRename(read, Map("idx" -> "idx_foo"), Map("global_f32" -> "global_foo"))

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -255,7 +255,7 @@ class PruneSuite extends SparkSuite {
   }
 
   @Test def testTableExplodeMemo() {
-    val te = TableExplode(tab, "2")
+    val te = TableExplode(tab, Array("2"))
     checkMemo(te, subsetTable(te.typ), Array(subsetTable(tab.typ, "row.2")))
   }
 


### PR DESCRIPTION
This makes it possible to explode nested fields in TableExplode,
but I don't want to solve the interface problem in this PR.