### PR TITLE
Lower MatrixAnnotateRowsTable

### DIFF
--- a/hail/python/benchmark/table_benchmarks.py
+++ b/hail/python/benchmark/table_benchmarks.py
@@ -54,3 +54,16 @@ def table_big_aggregate_compile_and_execute():
     ht = hl.utils.range_table(M)
     expr = tuple([hl.agg.fraction(ht.idx % i == 0) for i in range(N) if i > 0])
     ht.aggregate(expr)
+
+def table_foreign_key_join(n1: int, n2: int):
+    ht = hl.utils.range_table(n1)
+    ht2 = hl.utils.range_table(n2)
+    ht.annotate(x = ht2[(n1 - 1 - ht.idx) % n2])._force_count()
+
+@benchmark
+def table_foreign_key_join_same_cardinality():
+    table_foreign_key_join(1_000_000, 1_000_000)
+
+@benchmark
+def table_foreign_key_join_left_higher_cardinality():
+    table_foreign_key_join(1_000_000, 1_000)

--- a/hail/python/hail/ir/matrix_ir.py
+++ b/hail/python/hail/ir/matrix_ir.py
@@ -402,21 +402,14 @@ class CastTableToMatrix(MatrixIR):
 
 
 class MatrixAnnotateRowsTable(MatrixIR):
-    def __init__(self, child, table, root, key):
+    def __init__(self, child, table, root):
         super().__init__()
         self.child = child
         self.table = table
         self.root = root
-        self.key = key
 
     def render(self, r):
-        if self.key is None:
-            key_bool = False
-            key_strs = ''
-        else:
-            key_bool = True
-            key_strs = ' '.join(str(x) for x in self.key)
-        return f'(MatrixAnnotateRowsTable "{self.root}" {key_bool} {r(self.child)} {r(self.table)} {key_strs})'
+        return f'(MatrixAnnotateRowsTable "{self.root}" {r(self.child)} {r(self.table)})'
 
     def _compute_type(self):
         child_typ = self.child.typ

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2387,7 +2387,7 @@ class MatrixTable(ExprContainer):
             if is_row_key:
                 def joiner(left):
                     return MatrixTable(MatrixAnnotateRowsTable(
-                        left._mir, right.rows()._tir, uid, None))
+                        left._mir, right.rows()._tir, uid))
                 schema = tstruct(**{f: t for f, t in self.row.dtype.items() if f not in self.row_key})
                 ir = Join(GetField(TopLevelReference('va'), uid),
                           uids_to_delete,

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1508,12 +1508,37 @@ class Table(ExprContainer):
                                               f"  Table key:         {', '.join(str(t) for t in self.key.dtype.values())}\n"
                                               f"  Index Expressions: {', '.join(str(e.dtype) for e in exprs)}")
 
-                if is_subset_row_key or is_interval:
-                    key = None
+                if not (is_subset_row_key or is_interval):
+                    # foreign-key join
+                    foreign_key_annotates = {Env.get_uid(): e for e in exprs}
+
+                    # contains original key and join key
+                    join_table = src.select_rows(**foreign_key_annotates).rows()
+
+                    join_table = join_table.key_by(*foreign_key_annotates)
+
+                    value_uid = Env.get_uid()
+                    join_table = join_table.annotate(**{value_uid: right.index(join_table.key)})
+
+                    #  FIXME: TableZipUnchecked would make this faster
+                    join_table = join_table.group_by(*src.row_key).aggregate(**{uid:
+                        hl.dict(hl.agg.collect(hl.tuple([hl.tuple([join_table[f] for f in foreign_key_annotates]),
+                                                         join_table[value_uid]])))})
+
+                    def joiner(left: MatrixTable):
+                        return MatrixTable(
+                            MatrixMapRows(
+                                MatrixAnnotateRowsTable(left._mir, join_table._tir, uid),
+                                InsertFields(
+                                    Ref('va'),
+                                    [(uid, Apply('get',
+                                                 GetField(GetField(Ref('va'), uid), uid),
+                                                 MakeTuple([e._ir for e in exprs])))]
+                                ))
+                            )
                 else:
-                    key = [str(k._ir) for k in exprs]
-                joiner = lambda left: MatrixTable(MatrixAnnotateRowsTable(
-                    left._mir, right._tir, uid, key))
+                    joiner = lambda left: MatrixTable(MatrixAnnotateRowsTable(
+                        left._mir, right._tir, uid))
                 ast = Join(GetField(TopLevelReference('va'), uid),
                            [uid],
                            exprs,

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1533,7 +1533,8 @@ class Table(ExprContainer):
                                     Ref('va'),
                                     [(uid, Apply('get',
                                                  GetField(GetField(Ref('va'), uid), uid),
-                                                 MakeTuple([e._ir for e in exprs])))]
+                                                 MakeTuple([e._ir for e in exprs])))],
+                                    None
                                 ))
                             )
                 else:

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -221,7 +221,7 @@ class TableIRTests(unittest.TestCase):
             ir.MatrixCollectColsByKey(matrix_read),
             ir.MatrixExplodeRows(matrix_read, ['row_aset']),
             ir.MatrixExplodeCols(matrix_read, ['col_aset']),
-            ir.MatrixAnnotateRowsTable(matrix_read, table_read, '__foo', None),
+            ir.MatrixAnnotateRowsTable(matrix_read, table_read, '__foo'),
             ir.MatrixAnnotateColsTable(matrix_read, table_read, '__foo'),
             ir.MatrixToMatrixApply(matrix_read, {'name': 'MatrixFilterPartitions', 'parts': [0], 'keep': True})
         ]

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -1541,54 +1541,6 @@ case class MatrixAnnotateRowsTable(
     val IndexedSeq(child: MatrixIR, table: TableIR) = newChildren
     MatrixAnnotateRowsTable(child, table, root)
   }
-//
-//  protected[ir] override def execute(hc: HailContext): MatrixValue = {
-//    val prev = child.execute(hc)
-//    val tv = table.execute(hc)
-//
-//      // annotateRowsIntervals
-//    if (table.typ.keyType.size == 1 && table.typ.keyType.types(0) == TInterval(child.typ.rowKeyStruct.types(0))) {
-//      val (newRVPType, ins) =
-//      prev.rvd.rowPType.unsafeStructInsert (table.typ.valueType.physicalType, List (root) )
-//
-//      val rightRVDType = tv.rvd.typ
-//      val leftRVDType = child.typ.canonicalRVDType
-//
-//      val zipper = {
-//      (ctx: RVDContext, it: Iterator[RegionValue], intervals: Iterator[RegionValue] ) =>
-//      val rvb = new RegionValueBuilder ()
-//      val rv2 = RegionValue ()
-//      OrderedRVIterator (leftRVDType, it, ctx).leftIntervalJoinDistinct (
-//      OrderedRVIterator (rightRVDType, intervals, ctx)
-//      )
-//      .map {
-//      case Muple (rv, i) =>
-//      rvb.set (rv.region)
-//      rvb.start (newRVPType)
-//      ins (
-//      rv.region,
-//      rv.offset,
-//      rvb,
-//      () => if (i == null) rvb.setMissing () else rvb.selectRegionValue (rightRVDType.rowType, rightRVDType.valueFieldIdx, i) )
-//      rv2.set (rv.region, rvb.end () )
-//
-//      rv2
-//      }
-//      }
-//
-//      val newMatrixType = child.typ.copy (rvRowType = newRVPType.virtualType)
-//      val newRVD = prev.rvd.intervalAlignAndZipPartitions (RVDType (newRVPType, newMatrixType.rowKey), tv.rvd) (zipper)
-//      prev.copy (typ = typ, rvd = newRVD)
-//
-//    } else {
-//      // annotateRowsTable using non-key MT fields
-//      case None =>
-//        assert(child.typ.rowKeyStruct.types.zip(table.typ.keyType.types).forall { case (l, r) => l.isOfType(r) })
-//        val newRVD = prev.rvd.orderedLeftJoinDistinctAndInsert(
-//          tv.rvd, root)
-//        prev.copy(typ = typ, rvd = newRVD)
-//    }
-//  }
 }
 
 case class TableToMatrixTable(

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -1522,12 +1522,11 @@ case class MatrixAnnotateColsTable(
 case class MatrixAnnotateRowsTable(
   child: MatrixIR,
   table: TableIR,
-  root: String,
-  key: Option[IndexedSeq[IR]]) extends MatrixIR {
+  root: String) extends MatrixIR {
 
-  def children: IndexedSeq[BaseIR] = FastIndexedSeq(child, table) ++ key.getOrElse(FastIndexedSeq.empty[IR])
+  def children: IndexedSeq[BaseIR] = FastIndexedSeq(child, table)
 
-  override def columnCount: Option[Call] = child.columnCount
+  override def columnCount: Option[Int] = child.columnCount
 
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
 
@@ -1539,114 +1538,57 @@ case class MatrixAnnotateRowsTable(
       table.rvdType.rowType.dropFields(table.typ.key.toSet)))
 
   def copy(newChildren: IndexedSeq[BaseIR]): MatrixAnnotateRowsTable = {
-    val (child: MatrixIR) +: (table: TableIR) +: newKey = newChildren
-    MatrixAnnotateRowsTable(
-      child, table,
-      root,
-      key.map { keyIRs =>
-        assert(newKey.length == keyIRs.length)
-        newKey.map(_.asInstanceOf[IR])
-      }
-    )
+    val IndexedSeq(child: MatrixIR, table: TableIR) = newChildren
+    MatrixAnnotateRowsTable(child, table, root)
   }
-
-  protected[ir] override def execute(hc: HailContext): MatrixValue = {
-    val prev = child.execute(hc)
-    val tv = table.execute(hc)
-    key match {
-      // annotateRowsIntervals
-      case None if table.typ.keyType.size == 1
-        && table.typ.keyType.types(0) == TInterval(child.typ.rowKeyStruct.types(0)) =>
-        val (newRVPType, ins) =
-          prev.rvd.rowPType.unsafeStructInsert(table.typ.valueType.physicalType, List(root))
-
-        val rightRVDType = tv.rvd.typ
-        val leftRVDType = child.typ.canonicalRVDType
-
-        val zipper = { (ctx: RVDContext, it: Iterator[RegionValue], intervals: Iterator[RegionValue]) =>
-          val rvb = new RegionValueBuilder()
-          val rv2 = RegionValue()
-          OrderedRVIterator(leftRVDType, it, ctx).leftIntervalJoinDistinct(
-            OrderedRVIterator(rightRVDType, intervals, ctx)
-          )
-            .map { case Muple(rv, i) =>
-              rvb.set(rv.region)
-              rvb.start(newRVPType)
-              ins(
-                rv.region,
-                rv.offset,
-                rvb,
-                () => if (i == null) rvb.setMissing() else rvb.selectRegionValue(rightRVDType.rowType, rightRVDType.valueFieldIdx, i))
-              rv2.set(rv.region, rvb.end())
-
-              rv2
-            }
-        }
-
-        val newMatrixType = child.typ.copy(rvRowType = newRVPType.virtualType)
-        val newRVD = prev.rvd.intervalAlignAndZipPartitions(RVDType(newRVPType, newMatrixType.rowKey), tv.rvd)(zipper)
-        prev.copy(typ = typ, rvd = newRVD)
-
-      // annotateRowsTable using non-key MT fields
-      case Some(newKeys) =>
-        // FIXME: here be monsters
-
-        // used to zipWithIndex in multiple places
-        val partitionCounts = child.getOrComputePartitionCounts()
-
-        val prevRowKeys = child.typ.rowKey.toArray
-        val newKeyUIDs = Array.fill(newKeys.length)(ir.genUID())
-        val indexUID = ir.genUID()
-
-        // has matrix row key and foreign join key
-        val mrt = Interpret(
-          MatrixRowsTable(
-            MatrixMapRows(
-              child,
-              MakeStruct(
-                prevRowKeys.zip(
-                  prevRowKeys.map(rk => GetField(Ref("va", child.typ.rvRowType), rk))
-                ) ++ newKeyUIDs.zip(newKeys)))))
-        val indexedRVD1 = mrt.rvd
-          .zipWithIndex(indexUID, Some(partitionCounts))
-        val tl1 = TableLiteral(mrt.copy(typ = mrt.typ.copy(rowType = indexedRVD1.rowType), rvd = indexedRVD1))
-
-        // ordered by foreign key, filtered to remove null keys
-        val sortedTL = Interpret(
-          TableKeyBy(
-            TableFilter(tl1,
-              ApplyUnaryPrimOp(
-                Bang(),
-                newKeyUIDs
-                  .map(k => IsNA(GetField(Ref("row", mrt.typ.rowType), k)))
-                  .reduce[IR] { case (l, r) => ApplySpecial("||", FastIndexedSeq(l, r)) })),
-            newKeyUIDs))
-
-        val left = sortedTL.rvd
-        val right = tv.rvd
-        val joined = left.orderedLeftJoinDistinctAndInsert(right, root)
-
-        // At this point 'joined' is sorted by the foreign key, so need to resort by row key
-        // first, change the partitioner to include the index field in the key so the shuffled result is sorted by index
-        val extendedKey = prev.rvd.typ.key ++ Array(indexUID)
-        val rpJoined = joined.repartition(
-          prev.rvd.partitioner.extendKey(joined.typ.copy(key = extendedKey).kType.virtualType),
-          shuffle = true)
-
-        // the lift and dropLeft flags are used to optimize some of the struct manipulation operations
-        val newRVD = prev.rvd.zipWithIndex(indexUID, Some(partitionCounts))
-          .extendKeyPreservesPartitioning(prev.rvd.typ.key ++ Array(indexUID))
-          .orderedLeftJoinDistinctAndInsert(rpJoined, root, lift = Some(root), dropLeft = Some(Array(indexUID)))
-        MatrixValue(typ, prev.globals, prev.colValues, newRVD)
-
-      // annotateRowsTable using key
-      case None =>
-        assert(child.typ.rowKeyStruct.types.zip(table.typ.keyType.types).forall { case (l, r) => l.isOfType(r) })
-        val newRVD = prev.rvd.orderedLeftJoinDistinctAndInsert(
-          tv.rvd, root)
-        prev.copy(typ = typ, rvd = newRVD)
-    }
-  }
+//
+//  protected[ir] override def execute(hc: HailContext): MatrixValue = {
+//    val prev = child.execute(hc)
+//    val tv = table.execute(hc)
+//
+//      // annotateRowsIntervals
+//    if (table.typ.keyType.size == 1 && table.typ.keyType.types(0) == TInterval(child.typ.rowKeyStruct.types(0))) {
+//      val (newRVPType, ins) =
+//      prev.rvd.rowPType.unsafeStructInsert (table.typ.valueType.physicalType, List (root) )
+//
+//      val rightRVDType = tv.rvd.typ
+//      val leftRVDType = child.typ.canonicalRVDType
+//
+//      val zipper = {
+//      (ctx: RVDContext, it: Iterator[RegionValue], intervals: Iterator[RegionValue] ) =>
+//      val rvb = new RegionValueBuilder ()
+//      val rv2 = RegionValue ()
+//      OrderedRVIterator (leftRVDType, it, ctx).leftIntervalJoinDistinct (
+//      OrderedRVIterator (rightRVDType, intervals, ctx)
+//      )
+//      .map {
+//      case Muple (rv, i) =>
+//      rvb.set (rv.region)
+//      rvb.start (newRVPType)
+//      ins (
+//      rv.region,
+//      rv.offset,
+//      rvb,
+//      () => if (i == null) rvb.setMissing () else rvb.selectRegionValue (rightRVDType.rowType, rightRVDType.valueFieldIdx, i) )
+//      rv2.set (rv.region, rvb.end () )
+//
+//      rv2
+//      }
+//      }
+//
+//      val newMatrixType = child.typ.copy (rvRowType = newRVPType.virtualType)
+//      val newRVD = prev.rvd.intervalAlignAndZipPartitions (RVDType (newRVPType, newMatrixType.rowKey), tv.rvd) (zipper)
+//      prev.copy (typ = typ, rvd = newRVD)
+//
+//    } else {
+//      // annotateRowsTable using non-key MT fields
+//      case None =>
+//        assert(child.typ.rowKeyStruct.types.zip(table.typ.keyType.types).forall { case (l, r) => l.isOfType(r) })
+//        val newRVD = prev.rvd.orderedLeftJoinDistinctAndInsert(
+//          tv.rvd, root)
+//        prev.copy(typ = typ, rvd = newRVD)
+//    }
+//  }
 }
 
 case class TableToMatrixTable(

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1023,12 +1023,9 @@ object IRParser {
         TableToMatrixTable(child, rowKey, colKey, rowFields, colFields, nPartitions)
       case "MatrixAnnotateRowsTable" =>
         val root = string_literal(it)
-        val hasKey = boolean_literal(it)
         val child = matrix_ir(env)(it)
         val table = table_ir(env)(it)
-        val key = ir_value_children(env.withRefMap(child.typ.refMap))(it)
-        val keyIRs = if (hasKey) Some(key.toFastIndexedSeq) else None
-        MatrixAnnotateRowsTable(child, table, root, keyIRs)
+        MatrixAnnotateRowsTable(child, table, root)
       case "MatrixAnnotateColsTable" =>
         val root = string_literal(it)
         val child = matrix_ir(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -206,9 +206,8 @@ object Pretty {
               prettyStrings(rowFields) + " " +
               prettyStrings(colFields) + " " +
               prettyIntOpt(nPartitions)
-            case MatrixAnnotateRowsTable(_, _, uid, key) =>
-              prettyStringLiteral(uid) + " " +
-              prettyBooleanLiteral(key.isDefined)
+            case MatrixAnnotateRowsTable(_, _, uid) =>
+              prettyStringLiteral(uid) + " "
             case MatrixAnnotateColsTable(_, _, uid) =>
               prettyStringLiteral(uid)
             case MatrixExplodeRows(_, path) => prettyIdentifiers(path)

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -535,6 +535,9 @@ case class TableIntervalJoin(left: TableIR, right: TableIR, root: String) extend
     val leftRVDType = leftValue.rvd.typ
     val rightRVDType = rightValue.rvd.typ
 
+    val localNewRowPType = newRowPType
+    val localIns = ins
+
     val zipper = { (ctx: RVDContext, it: Iterator[RegionValue], intervals: Iterator[RegionValue]) =>
       val rvb = new RegionValueBuilder()
       val rv2 = RegionValue()
@@ -542,8 +545,8 @@ case class TableIntervalJoin(left: TableIR, right: TableIR, root: String) extend
         OrderedRVIterator(rightRVDType, intervals, ctx))
         .map { case Muple(rv, i) =>
           rvb.set(rv.region)
-          rvb.start(newRowPType)
-          ins(
+          rvb.start(localNewRowPType)
+          localIns(
             rv.region,
             rv.offset,
             rvb,

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1055,7 +1055,7 @@ class IRSuite extends SparkSuite {
           " # cols",
           read.typ.colKey),
         MatrixAnnotateColsTable(read, tableRead, "uid_123"),
-        MatrixAnnotateRowsTable(read, tableRead, "uid_123", Some(FastIndexedSeq(I32(1))))
+        MatrixAnnotateRowsTable(read, tableRead, "uid_123")
       )
 
       xs.map(x => Array(x))

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -381,14 +381,9 @@ class PruneSuite extends SparkSuite {
 
   @Test def testMatrixAnnotateRowsTableMemo() {
     val tl = TableLiteral(Interpret(MatrixRowsTable(mat)))
-    val mart = MatrixAnnotateRowsTable(mat, tl, "foo", None)
+    val mart = MatrixAnnotateRowsTable(mat, tl, "foo")
     checkMemo(mart, subsetMatrixTable(mart.typ,"va.foo.r3", "va.r3"),
       Array(subsetMatrixTable(mat.typ, "va.r3"), subsetTable(tl.typ, "row.r3")))
-
-    val mart2 = MatrixAnnotateRowsTable(mat, tl, "foo",
-      Some(FastIndexedSeq(GetField(GetField(Ref("va", mat.typ.rvRowType), "r2"), "x"))))
-    checkMemo(mart2, subsetMatrixTable(mart2.typ,"va.foo.r3", "va.r3"),
-      Array(subsetMatrixTable(mat.typ, "va.r3", "va.r2.x"), subsetTable(tl.typ, "row.r3"), null))
   }
 
   @Test def testCollectColsByKeyMemo() {
@@ -818,7 +813,7 @@ class PruneSuite extends SparkSuite {
 
   @Test def testMatrixAnnotateRowsTableRebuild() {
     val tl = TableLiteral(Interpret(MatrixRowsTable(mat)))
-    val mart = MatrixAnnotateRowsTable(mat, tl, "foo", None)
+    val mart = MatrixAnnotateRowsTable(mat, tl, "foo")
     checkRebuild(mart, subsetMatrixTable(mart.typ),
       (_: BaseIR, r: BaseIR) => {
         r.isInstanceOf[MatrixLiteral]

--- a/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -36,8 +36,7 @@ class PartitioningSuite extends SparkSuite {
       MatrixAnnotateRowsTable(
         ir.MatrixRead(rangeReader.fullType, false, false, rangeReader),
         t,
-        "foo",
-        None))
+        "foo"))
       .rvd.count()
   }
 


### PR DESCRIPTION
Some context:

We have 3 kinds of IRs currently: 
 - Value IRs (MakeStruct, I32, ApplyComparisonOp, etc)
 - TableIRs (TableRange, TableFilter, etc)
 - MatrixIRs (MatrixMapRows, MatrixExplodeCols, etc)

One of the passes of the optimizer is to reformulate MatrixIRs in terms of TableIRs, and we're in the middle of this push to write lowerers for each MatrixIR node (which means writing an algorithm in LowerMatrixTable.scala, and removing the node's 'execute' method).

Here I implement lowering MatrixAnnotateRowsTable as either TableIntervalJoin or TableLeftJoinRightDistinct (a future PR should split MatrixAnnotateRowsTable into 2 nodes like Table has, probably).

The one bit of extra complexity in Python comes from implementing foreign-key joins explicitly (this was previously handled by the IR node itself).