### PR TITLE
change identifiers to symbols

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -261,7 +261,7 @@ task testPython(type: Exec, dependsOn: shadowJar) {
             parallelism,
             '--dist=loadscope',
             '--noconftest',
-            '--color=yes',
+            '--color=no',
             '-r a',
             '--html=build/reports/pytest.html',
             '--self-contained-html',

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -33,9 +33,8 @@ class SparkBackend(Backend):
         return ir._jir
 
     def execute(self, ir):
-        return ir.typ._from_json(
-            Env.hail().expr.ir.Interpret.interpretJSON(
-                self._to_java_ir(ir)))
+        return ir.typ._from_json(Env.hail().expr.ir.Interpret.interpretJSON(
+            self._to_java_ir(ir)))
 
     def table_read_type(self, tir):
         jir = self._to_java_ir(tir)

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -2985,7 +2985,7 @@ def construct_expr(ir: IR,
         raise NotImplementedError(type)
 
 
-@typecheck(name=str, type=HailType, indices=Indices)
+@typecheck(name=oneof(str, Symbol), type=HailType, indices=Indices)
 def construct_reference(name, type, indices):
     assert isinstance(type, hl.tstruct)
     ir = SelectFields(TopLevelReference(name), list(type))

--- a/hail/python/hail/expr/matrix_type.py
+++ b/hail/python/hail/expr/matrix_type.py
@@ -1,3 +1,4 @@
+import hail
 from hail.typecheck import *
 from hail.utils.java import escape_parsable
 from hail.expr.types import dtype, tstruct
@@ -9,9 +10,9 @@ class tmatrix(object):
         return tmatrix(
             dtype(jtt.globalType().toString()),
             dtype(jtt.colType().toString()),
-            jiterable_to_list(jtt.colKey()),
+            [hail.ir.Symbol.from_jsymbol(k) for k in jiterable_to_list(jtt.colKey())],
             dtype(jtt.rowType().toString()),
-            jiterable_to_list(jtt.rowKey()),
+            [hail.ir.Symbol.from_jsymbol(k) for k in jiterable_to_list(jtt.rowKey())],
             dtype(jtt.entryType().toString()))
 
     @typecheck_method(global_type=tstruct,

--- a/hail/python/hail/expr/table_type.py
+++ b/hail/python/hail/expr/table_type.py
@@ -1,3 +1,4 @@
+import hail
 from hail.typecheck import *
 from hail.utils.java import escape_parsable
 from hail.expr.types import dtype, tstruct
@@ -9,7 +10,7 @@ class ttable(object):
         return ttable(
             dtype(jtt.globalType().toString()),
             dtype(jtt.rowType().toString()),
-            jiterable_to_list(jtt.key()))
+            [hail.ir.Symbol.from_jsymbol(k) for k in jiterable_to_list(jtt.key())])
 
     @typecheck_method(global_type=tstruct, row_type=tstruct, row_key=sequenceof(str))
     def __init__(self, global_type, row_type, row_key):

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -9,7 +9,7 @@ from hail.expr.type_parsing import type_grammar, type_node_visitor
 from hail.genetics.reference_genome import reference_genome_type
 from hail.typecheck import *
 from hail.utils import Struct, Interval
-from hail.utils.java import scala_object, jset, Env, escape_parsable
+from hail.utils.java import scala_object, jset, Env, escape_parsable, escape_id
 
 __all__ = [
     'dtype',
@@ -856,10 +856,10 @@ class tstruct(HailType, Mapping):
             ','.join('{}:{}'.format(escape_parsable(f), t._parsable_string()) for f, t in self.items()))
 
     def _convert_from_json(self, x):
-        return Struct(**{f: t._convert_from_json_na(x.get(f)) for f, t in self.items()})
+        return Struct(**{f: t._convert_from_json_na(x.get(escape_id(f))) for f, t in self.items()})
 
     def _convert_to_json(self, x):
-        return {f: t._convert_to_json_na(x[f]) for f, t in self.items()}
+        return {escape_id(f): t._convert_to_json_na(x[f]) for f, t in self.items()}
 
     def _is_prefix_of(self, other):
         return (isinstance(other, tstruct) and

--- a/hail/python/hail/ir/__init__.py
+++ b/hail/python/hail/ir/__init__.py
@@ -4,3 +4,4 @@ from .matrix_ir import *
 from .utils import *
 from .matrix_reader import *
 from .matrix_writer import *
+from .symbol import *

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -6,6 +6,7 @@ from hail.typecheck import *
 from hail.utils.java import escape_str, escape_id
 from .base_ir import *
 from .matrix_writer import MatrixWriter
+from .symbol import Symbol
 
 
 class I32(IR):
@@ -232,7 +233,7 @@ class If(IR):
                other.altr == self.altr
 
 class Let(IR):
-    @typecheck_method(name=str, value=IR, body=IR)
+    @typecheck_method(name=oneof(str, Symbol), value=IR, body=IR)
     def __init__(self, name, value, body):
         super().__init__(value, body)
         self.name = name
@@ -259,7 +260,7 @@ class Let(IR):
 
 
 class Ref(IR):
-    @typecheck_method(name=str)
+    @typecheck_method(name=oneof(str, Symbol))
     def __init__(self, name):
         super().__init__()
         self.name = name
@@ -277,7 +278,7 @@ class Ref(IR):
 
 
 class TopLevelReference(Ref):
-    @typecheck_method(name=str)
+    @typecheck_method(name=oneof(str, Symbol))
     def __init__(self, name):
         super().__init__(name)
 
@@ -569,7 +570,7 @@ class GroupByKey(IR):
 
 
 class ArrayMap(IR):
-    @typecheck_method(a=IR, name=str, body=IR)
+    @typecheck_method(a=IR, name=oneof(str, Symbol), body=IR)
     def __init__(self, a, name, body):
         super().__init__(a, body)
         self.a = a
@@ -596,7 +597,7 @@ class ArrayMap(IR):
 
 
 class ArrayFilter(IR):
-    @typecheck_method(a=IR, name=str, body=IR)
+    @typecheck_method(a=IR, name=oneof(str, Symbol), body=IR)
     def __init__(self, a, name, body):
         super().__init__(a, body)
         self.a = a
@@ -623,7 +624,7 @@ class ArrayFilter(IR):
 
 
 class ArrayFlatMap(IR):
-    @typecheck_method(a=IR, name=str, body=IR)
+    @typecheck_method(a=IR, name=oneof(str, Symbol), body=IR)
     def __init__(self, a, name, body):
         super().__init__(a, body)
         self.a = a
@@ -650,7 +651,7 @@ class ArrayFlatMap(IR):
 
 
 class ArrayFold(IR):
-    @typecheck_method(a=IR, zero=IR, accum_name=str, value_name=str, body=IR)
+    @typecheck_method(a=IR, zero=IR, accum_name=oneof(str, Symbol), value_name=oneof(str, Symbol), body=IR)
     def __init__(self, a, zero, accum_name, value_name, body):
         super().__init__(a, zero, body)
         self.a = a
@@ -683,7 +684,7 @@ class ArrayFold(IR):
 
 
 class ArrayScan(IR):
-    @typecheck_method(a=IR, zero=IR, accum_name=str, value_name=str, body=IR)
+    @typecheck_method(a=IR, zero=IR, accum_name=oneof(str, Symbol), value_name=oneof(str, Symbol), body=IR)
     def __init__(self, a, zero, accum_name, value_name, body):
         super().__init__(a, zero, body)
         self.a = a
@@ -716,7 +717,7 @@ class ArrayScan(IR):
 
 
 class ArrayFor(IR):
-    @typecheck_method(a=IR, value_name=str, body=IR)
+    @typecheck_method(a=IR, value_name=oneof(str, Symbol), body=IR)
     def __init__(self, a, value_name, body):
         super().__init__(a, body)
         self.a = a
@@ -764,7 +765,7 @@ class AggFilter(IR):
 
 
 class AggExplode(IR):
-    @typecheck_method(array=IR, name=str, agg_body=IR)
+    @typecheck_method(array=IR, name=oneof(str, Symbol), agg_body=IR)
     def __init__(self, array, name, agg_body):
         super().__init__(array, agg_body)
         self.name = name
@@ -891,7 +892,7 @@ class Begin(IR):
 
 
 class MakeStruct(IR):
-    @typecheck_method(fields=sequenceof(sized_tupleof(str, IR)))
+    @typecheck_method(fields=sequenceof(sized_tupleof(oneof(str, Symbol), IR)))
     def __init__(self, fields):
         super().__init__(*[ir for (n, ir) in fields])
         self.fields = fields
@@ -954,7 +955,7 @@ class InsertFields(IR):
 
 
 class GetField(IR):
-    @typecheck_method(o=IR, name=str)
+    @typecheck_method(o=IR, name=oneof(str, Symbol))
     def __init__(self, o, name):
         super().__init__(o)
         self.o = o
@@ -1152,7 +1153,7 @@ class ApplySeeded(IR):
 
 
 class Uniroot(IR):
-    @typecheck_method(argname=str, function=IR, min=IR, max=IR)
+    @typecheck_method(argname=oneof(str, Symbol), function=IR, min=IR, max=IR)
     def __init__(self, argname, function, min, max):
         super().__init__(function, min, max)
         self.argname = argname

--- a/hail/python/hail/ir/matrix_ir.py
+++ b/hail/python/hail/ir/matrix_ir.py
@@ -1,6 +1,6 @@
 import json
 from hail.ir.base_ir import *
-from hail.utils.java import escape_str, escape_id, parsable_strings, dump_json
+from hail.utils.java import escape_id, parsable_ids, dump_json
 
 class MatrixAggregateRowsByKey(MatrixIR):
     def __init__(self, child, entry_expr, row_expr):
@@ -52,7 +52,7 @@ class MatrixMapCols(MatrixIR):
 
     def render(self, r):
         return '(MatrixMapCols {} {} {})'.format(
-            '(' + ' '.join(f'"{escape_str(f)}"' for f in self.new_key) + ')' if self.new_key is not None else 'None',
+            '(' + ' '.join(f'{escape_id(f)}' for f in self.new_key) + ')' if self.new_key is not None else 'None',
             r(self.child), r(self.new_col))
 
 class MatrixUnionCols(MatrixIR):
@@ -152,10 +152,10 @@ class TableToMatrixTable(MatrixIR):
 
     def render(self, r):
         return f'(TableToMatrixTable ' \
-               f'{parsable_strings(self.row_key)} ' \
-               f'{parsable_strings(self.col_key)} ' \
-               f'{parsable_strings(self.row_fields)} ' \
-               f'{parsable_strings(self.col_fields)} ' \
+               f'{parsable_ids(self.row_key)} ' \
+               f'{parsable_ids(self.col_key)} ' \
+               f'{parsable_ids(self.row_fields)} ' \
+               f'{parsable_ids(self.col_fields)} ' \
                f'{"None" if self.n_partitions is None else str(self.n_partitions)} ' \
                f'{r(self.child)})'
 
@@ -222,8 +222,8 @@ class CastTableToMatrix(MatrixIR):
 
     def render(self, r):
         return '(CastTableToMatrix {} {} ({}) {})'.format(
-           escape_str(self.entries_field_name),
-           escape_str(self.cols_field_name),
+           escape_id(self.entries_field_name),
+           escape_id(self.cols_field_name),
            ' '.join([escape_id(id) for id in self.col_key]),
            r(self.child))
 
@@ -243,7 +243,7 @@ class MatrixAnnotateRowsTable(MatrixIR):
         else:
             key_bool = True
             key_strs = ' '.join(str(x) for x in self.key)
-        return f'(MatrixAnnotateRowsTable "{self.root}" {key_bool} {r(self.child)} {r(self.table)} {key_strs})'
+        return f'(MatrixAnnotateRowsTable {escape_id(self.root)} {key_bool} {r(self.child)} {r(self.table)} {key_strs})'
 
 class MatrixAnnotateColsTable(MatrixIR):
     def __init__(self, child, table, root):
@@ -253,7 +253,7 @@ class MatrixAnnotateColsTable(MatrixIR):
         self.root = root
 
     def render(self, r):
-        return f'(MatrixAnnotateColsTable "{self.root}" {r(self.child)} {r(self.table)})'
+        return f'(MatrixAnnotateColsTable {escape_id(self.root)} {r(self.child)} {r(self.table)})'
 
 
 class MatrixToMatrixApply(MatrixIR):

--- a/hail/python/hail/ir/symbol.py
+++ b/hail/python/hail/ir/symbol.py
@@ -1,0 +1,71 @@
+from hail.utils.java import _escape_id, _unescape_id
+
+class Symbol(object):
+    @staticmethod
+    def parse(s):
+        if s[0] == ':':
+            s = s[1:]
+            t = _internal_symbol_table.get(s)
+            if t:
+                return t
+            
+            [base, count] = s.split('-')
+            count = int(count)
+            return Generated(base, count)
+        else:
+            return _unescape_id(s)
+    
+    @staticmethod
+    def from_jsymbol(s):
+        return Symbol.parse(s.toString())
+
+class Identifier(Symbol):
+    def __init__(self, name):
+        self.name = name
+
+    def __str__(self):
+        return _escape_id(self.name)
+
+    def __hash__(self):
+        return hash(self.name)
+
+    def __eq__(self, other):
+        return isinstance(other, Identifier) and self.name == other.name
+
+class Generated(Symbol):
+    def __init__(base, count):
+        self.base = base
+        self.count = count
+
+    def __str__(self):
+        return f':{base}-{count}'
+
+    def __hash__(self):
+        return hash(self.name) ^ hash(self.count)
+
+    def __eq__(self, other):
+        return (isinstance(other, Generated)
+                and self.base == other.base
+                and self.count == self.count)
+
+class InternalSymbol(Symbol):
+    def __init__(self, name):
+        self.name = name
+
+    def __str__(self):
+        return f':{self.name}'
+
+    def __hash__(self):
+        return hash(self.name)
+
+    def __eq__(self, other):
+        return isinstance(other, InternalSymbol) and self.name == other.name
+
+global_sym = InternalSymbol('global')
+row_sym = InternalSymbol('row')
+col_sym = InternalSymbol('col')
+rows_sym = InternalSymbol('rows')
+entry_sym = InternalSymbol('entry')
+
+_internal_symbols = [global_sym, row_sym, col_sym, rows_sym, entry_sym]
+_internal_symbol_table = {s.name: s for s in _internal_symbols}

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -81,7 +81,7 @@ class TableExplode(TableIR):
         self.path = path
 
     def render(self, r):
-        return '(TableExplode {} {})'.format(parsable_strings(self.path), r(self.child))
+        return '(TableExplode {} {})'.format(parsable_ids(self.path), r(self.child))
 
 
 class TableKeyBy(TableIR):

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -1,7 +1,7 @@
 import json
 
 from hail.ir.base_ir import *
-from hail.utils.java import escape_str, escape_id, parsable_strings, dump_json
+from hail.utils.java import escape_str, escape_id, parsable_ids, dump_json
 
 
 class MatrixRowsTable(TableIR):
@@ -169,7 +169,7 @@ class TableKeyByAndAggregate(TableIR):
                                                                 self.buffer_size,
                                                                 r(self.child),
                                                                 r(self.expr),
-                                                                self.new_key)
+                                                                r(self.new_key))
 
 
 class TableAggregateByKey(TableIR):
@@ -221,7 +221,7 @@ class TableOrderBy(TableIR):
 
     def render(self, r):
         return '(TableOrderBy ({}) {})'.format(
-            ' '.join(['{}{}'.format(order, escape_id(f)) for (f, order) in self.sort_fields]),
+            ' '.join(['{} {}'.format(order, escape_id(f)) for (f, order) in self.sort_fields]),
             r(self.child))
 
 
@@ -258,8 +258,8 @@ class CastMatrixToTable(TableIR):
 
     def render(self, r):
         return f'(CastMatrixToTable ' \
-               f'"{escape_str(self.entries_field_name)}" ' \
-               f'"{escape_str(self.cols_field_name)}" ' \
+               f'{escape_id(self.entries_field_name)} ' \
+               f'{escape_id(self.cols_field_name)} ' \
                f'{r(self.child)})'
 
 
@@ -272,10 +272,10 @@ class TableRename(TableIR):
 
     def render(self, r):
         return f'(TableRename ' \
-               f'{parsable_strings(self.row_map.keys())} ' \
-               f'{parsable_strings(self.row_map.values())} ' \
-               f'{parsable_strings(self.global_map.keys())} ' \
-               f'{parsable_strings(self.global_map.values())} ' \
+               f'{parsable_ids(self.row_map.keys())} ' \
+               f'{parsable_ids(self.row_map.values())} ' \
+               f'{parsable_ids(self.global_map.keys())} ' \
+               f'{parsable_ids(self.global_map.values())} ' \
                f'{r(self.child)})'
 
 
@@ -288,8 +288,8 @@ class TableMultiWayZipJoin(TableIR):
 
     def render(self, r):
         return f'(TableMultiWayZipJoin '\
-               f'"{escape_str(self.data_name)}" '\
-               f'"{escape_str(self.global_name)}" '\
+               f'{escape_id(self.data_name)} '\
+               f'{escape_id(self.global_name)} '\
                f'{" ".join([r(child) for child in self.childs])})'
 
 

--- a/hail/python/hail/utils/java.py
+++ b/hail/python/hail/utils/java.py
@@ -158,10 +158,6 @@ def dump_json(obj):
 def escape_str(s):
     return Env.jutils().escapePyString(s)
 
-def parsable_strings(strs):
-    strs = ' '.join(f'"{escape_str(s)}"' for s in strs)
-    return f"({strs})"
-
 
 _parsable_str = re.compile(r'[\w_]+')
 
@@ -176,9 +172,20 @@ def escape_parsable(s):
 def unescape_parsable(s):
     return bytes(s.replace('\\`', '`'), 'utf-8').decode('unicode_escape')
 
+def _escape_id(s):
+    return Env.jutils().escapeIdentifier(s)
+
+def _unescape_id(s):
+    return Env.jutils().unescapeIdentifier(s)
 
 def escape_id(s):
-    return Env.jutils().escapeIdentifier(s)
+    if isinstance(s, str):
+        return _escape_id(s)
+    else:
+        return str(s)
+
+def parsable_ids(ids):
+    return '(' + ' '.join(escape_str(id) for id in ids) + ')'
 
 def jarray_to_list(a):
     return list(a) if a else None

--- a/hail/python/hail/utils/java.py
+++ b/hail/python/hail/utils/java.py
@@ -185,7 +185,7 @@ def escape_id(s):
         return str(s)
 
 def parsable_ids(ids):
-    return '(' + ' '.join(escape_str(id) for id in ids) + ')'
+    return '(' + ' '.join(escape_id(id) for id in ids) + ')'
 
 def jarray_to_list(a):
     return list(a) if a else None

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -143,12 +143,12 @@ class TableIRTests(unittest.TestCase):
             ir.MatrixEntriesTable(matrix_read),
             ir.MatrixRowsTable(matrix_read),
             ir.TableParallelize(ir.MakeStruct([
-                ('rows', ir.Literal(hl.tarray(hl.tstruct(a=hl.tint32)), [{'a':None}, {'a':5}, {'a':-3}])),
-                ('global', ir.MakeStruct([]))]), None),
+                (ir.rows_sym, ir.Literal(hl.tarray(hl.tstruct(a=hl.tint32)), [{'a':None}, {'a':5}, {'a':-3}])),
+                (ir.global_sym, ir.MakeStruct([]))]), None),
             ir.TableMapRows(
                 ir.TableKeyBy(table_read, []),
                 ir.MakeStruct([
-                    ('a', ir.GetField(ir.Ref('row'), 'f32')),
+                    ('a', ir.GetField(ir.Ref(ir.row_sym), 'f32')),
                     ('b', ir.F64(-2.11))])),
             ir.TableMapGlobals(
                 table_read,
@@ -255,7 +255,7 @@ class ValueTests(unittest.TestCase):
             map_globals_ir = ir.TableMapGlobals(
                 ir.TableRange(1, 1),
                 ir.InsertFields(
-                    ir.Ref("global"),
+                    ir.Ref(ir.global_sym),
                     [("foo", row_v)]))
             new_globals = hl.eval(hl.Table(map_globals_ir).globals)
             self.assertEquals(new_globals, hl.Struct(foo=v))

--- a/hail/src/main/scala/is/hail/annotations/OrderedRVIterator.scala
+++ b/hail/src/main/scala/is/hail/annotations/OrderedRVIterator.scala
@@ -1,6 +1,7 @@
 package is.hail.annotations
 
-import is.hail.rvd.{RVDType, RVDContext}
+import is.hail.expr.ir.Sym
+import is.hail.rvd.{RVDContext, RVDType}
 import is.hail.utils._
 
 import scala.collection.generic.Growable
@@ -142,7 +143,7 @@ case class OrderedRVIterator(
   }
 
   def localKeySort(
-    newKey: IndexedSeq[String]
+    newKey: IndexedSeq[Sym]
   ): Iterator[RegionValue] = {
     require(newKey startsWith t.key)
     require(newKey.forall(t.rowType.fieldNames.contains))

--- a/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -3,6 +3,8 @@ package is.hail.asm4s
 import java.io._
 import java.util
 
+import is.hail.expr.ir.Sym
+
 import scala.collection.JavaConverters._
 import scala.collection.generic.Growable
 import scala.collection.mutable
@@ -95,9 +97,13 @@ class MethodBuilder(val fb: FunctionBuilder[_], val mname: String, val parameter
 
   def newField[T: TypeInfo](name: String = null): ClassFieldRef[T] = fb.newField[T](name)
 
+  def newField[T: TypeInfo](name: Sym): ClassFieldRef[T] = fb.newField[T](name.toString)
+
   def newLazyField[T: TypeInfo](setup: Code[T]): LazyFieldRef[T] = newLazyField("")(setup)
 
   def newLazyField[T: TypeInfo](name: String)(setup: Code[T]): LazyFieldRef[T] = fb.newLazyField(name)(setup)
+
+  def newLazyField[T: TypeInfo](name: Sym)(setup: Code[T]): LazyFieldRef[T] = fb.newLazyField(name.toString)(setup)
 
   def getArg[T](i: Int)(implicit tti: TypeInfo[T]): LocalRef[T] = {
     assert(i >= 0)

--- a/hail/src/main/scala/is/hail/check/Gen.scala
+++ b/hail/src/main/scala/is/hail/check/Gen.scala
@@ -6,6 +6,7 @@ import is.hail.utils.roundWithConstantSum
 import is.hail.utils.UInt
 import is.hail.utils.roundWithConstantSum
 import is.hail.check.Arbitrary.arbitrary
+import is.hail.expr.ir.{Identifier, Sym}
 import org.apache.commons.math3.random._
 
 import scala.collection.generic.CanBuildFrom
@@ -424,6 +425,9 @@ object Gen {
 
   def identifier: Gen[String] =
     identifierGen(identifierLeadingChars, identifierChars)
+
+  def symbol: Gen[Sym] =
+    identifier.map(Identifier)
 
   def plinkSafeIdentifier: Gen[String] =
     identifierGen(plinkSafeStartOfIdentifierChars, plinkSafeChars)

--- a/hail/src/main/scala/is/hail/compatibility/UnpartitionedRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/compatibility/UnpartitionedRVDSpec.scala
@@ -1,5 +1,6 @@
 package is.hail.compatibility
 
+import is.hail.expr.ir.Sym
 import is.hail.{HailContext, cxx}
 import is.hail.expr.types.physical.PStruct
 import is.hail.expr.types.virtual.TStruct
@@ -15,7 +16,7 @@ case class UnpartitionedRVDSpec(
 ) extends AbstractRVDSpec {
   def partitioner: RVDPartitioner = RVDPartitioner.unkeyed(partFiles.length)
 
-  def key: IndexedSeq[String] = FastIndexedSeq()
+  def key: IndexedSeq[Sym] = FastIndexedSeq()
 
   def encodedType: PStruct = rowType.physicalType
 

--- a/hail/src/main/scala/is/hail/cxx/Compile.scala
+++ b/hail/src/main/scala/is/hail/cxx/Compile.scala
@@ -3,6 +3,7 @@ package is.hail.cxx
 import java.io.PrintWriter
 
 import is.hail.expr.ir
+import is.hail.expr.ir.Sym
 import is.hail.expr.types.physical._
 import is.hail.nativecode.{NativeLongFuncL2, NativeModule, NativeStatus}
 
@@ -10,7 +11,7 @@ import scala.reflect.classTag
 
 object Compile {
   def apply(
-    arg0: String, arg0Type: PType,
+    arg0: Sym, arg0Type: PType,
     body: ir.IR, optimize: Boolean): NativeLongFuncL2 = {
     assert(ir.TypeToIRIntermediateClassTag(arg0Type.virtualType) == classTag[Long])
     assert(arg0Type.isInstanceOf[PBaseStruct])

--- a/hail/src/main/scala/is/hail/cxx/TableEmit.scala
+++ b/hail/src/main/scala/is/hail/cxx/TableEmit.scala
@@ -4,6 +4,7 @@ import java.io.InputStream
 import is.hail.HailContext
 import is.hail.annotations.BroadcastRow
 import is.hail.expr.ir
+import is.hail.expr.ir.RowSym
 import is.hail.expr.types._
 import is.hail.io.CodecSpec
 import is.hail.rvd.AbstractRVDSpec
@@ -112,7 +113,7 @@ class TableEmitter(tub: TranslationUnitBuilder) { outer =>
            """.stripMargin
 
         val mapF = tub.buildFunction("map_row", Array("ScalaRegion*" -> "region", "const char *" -> "row"), "char *")
-        val substEnv = ir.Env.empty[ir.IR].bind("row", ir.In(0, child.typ.rowType))
+        val substEnv = ir.Env.empty[ir.IR].bind(RowSym, ir.In(0, child.typ.rowType))
         val et = Emit(mapF, 1, ir.Subst(newRow, substEnv))
         mapF +=
           s"""
@@ -177,7 +178,7 @@ class TableEmitter(tub: TranslationUnitBuilder) { outer =>
            """.stripMargin
 
         val filterF = tub.buildFunction("keep_row", Array("ScalaRegion*" -> "region", "const char *" -> "row"), "bool")
-        val substEnv = ir.Env.empty[ir.IR].bind("row", ir.In(0, child.typ.rowType))
+        val substEnv = ir.Env.empty[ir.IR].bind(RowSym, ir.In(0, child.typ.rowType))
         val et = Emit(filterF, 1, ir.Subst(cond, substEnv))
         filterF +=
           s"""

--- a/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
+++ b/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
@@ -1,6 +1,7 @@
 package is.hail.expr
 
 import is.hail.annotations.Annotation
+import is.hail.expr.ir.{IRParser, Identifier}
 import is.hail.expr.ir.functions.UtilFunctions
 import is.hail.expr.types._
 import is.hail.expr.types.virtual._
@@ -52,7 +53,7 @@ object SparkAnnotationImpex {
       else
         StructType(tbs.fields
           .map(f =>
-            StructField(escapeColumnName(f.name), f.typ.schema, nullable = !f.typ.required)))
+            StructField(escapeColumnName(f.name.toString), f.typ.schema, nullable = !f.typ.required)))
   }
 }
 
@@ -121,7 +122,7 @@ object JSONAnnotationImpex {
         case TStruct(fields, _) =>
           val row = a.asInstanceOf[Row]
           JObject(List.tabulate(row.size) { i =>
-            (fields(i).name, exportAnnotation(row.get(i), fields(i).typ))
+            (fields(i).name.toString, exportAnnotation(row.get(i), fields(i).typ))
           })
         case TTuple(types, _) =>
           val row = a.asInstanceOf[Row]
@@ -193,7 +194,7 @@ object JSONAnnotationImpex {
           val a = Array.fill[Any](annotationSize)(null)
 
           for ((name, jv2) <- jfields) {
-            t.selfField(name) match {
+            t.selfField(IRParser.parseSymbol(name)) match {
               case Some(f) =>
                 a(f.index) = importAnnotation(jv2, f.typ, parent + "." + name, padNulls)
 

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -1,7 +1,7 @@
 package is.hail.expr.ir
 
 object Binds {
-  def apply(x: IR, v: String, i: Int): Boolean = {
+  def apply(x: IR, v: Sym, i: Int): Boolean = {
     x match {
       case Let(n, _, _) =>
         v == n && i == 1

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -12,7 +12,7 @@ import scala.reflect.{ClassTag, classTag}
 object Compile {
 
   def apply[F >: Null : TypeInfo, R: TypeInfo : ClassTag](
-    args: Seq[(String, PType, ClassTag[_])],
+    args: Seq[(Sym, PType, ClassTag[_])],
     body: IR,
     nSpecialArgs: Int
   ): (PType, Int => F) = {
@@ -33,7 +33,7 @@ object Compile {
   }
 
   private def apply[F >: Null : TypeInfo, R: TypeInfo : ClassTag](
-    args: Seq[(String, PType, ClassTag[_])],
+    args: Seq[(Sym, PType, ClassTag[_])],
     argTypeInfo: Array[MaybeGenericTypeInfo[_]],
     body: IR,
     nSpecialArgs: Int
@@ -55,11 +55,11 @@ object Compile {
   }
 
   def apply[R: TypeInfo : ClassTag](body: IR): (PType, Int => AsmFunction1[Region, R]) = {
-    apply[AsmFunction1[Region, R], R](FastSeq[(String, PType, ClassTag[_])](), body, 1)
+    apply[AsmFunction1[Region, R], R](FastSeq[(Sym, PType, ClassTag[_])](), body, 1)
   }
 
   def apply[T0: ClassTag, R: TypeInfo : ClassTag](
-    name0: String,
+    name0: Sym,
     typ0: PType,
     body: IR): (PType, Int => AsmFunction3[Region, T0, Boolean, R]) = {
 
@@ -67,9 +67,9 @@ object Compile {
   }
 
   def apply[T0: ClassTag, T1: ClassTag, R: TypeInfo : ClassTag](
-    name0: String,
+    name0: Sym,
     typ0: PType,
-    name1: String,
+    name1: Sym,
     typ1: PType,
     body: IR): (PType, Int => AsmFunction5[Region, T0, Boolean, T1, Boolean, R]) = {
 
@@ -81,11 +81,11 @@ object Compile {
   T1: TypeInfo : ClassTag,
   T2: TypeInfo : ClassTag,
   R: TypeInfo : ClassTag
-  ](name0: String,
+  ](name0: Sym,
     typ0: PType,
-    name1: String,
+    name1: Sym,
     typ1: PType,
-    name2: String,
+    name2: Sym,
     typ2: PType,
     body: IR
   ): (PType, Int => AsmFunction7[Region, T0, Boolean, T1, Boolean, T2, Boolean, R]) = {
@@ -102,10 +102,10 @@ object Compile {
   T2: TypeInfo : ClassTag,
   T3: TypeInfo : ClassTag,
   R: TypeInfo : ClassTag
-  ](name0: String, typ0: PType,
-    name1: String, typ1: PType,
-    name2: String, typ2: PType,
-    name3: String, typ3: PType,
+  ](name0: Sym, typ0: PType,
+    name1: Sym, typ1: PType,
+    name2: Sym, typ2: PType,
+    name3: Sym, typ3: PType,
     body: IR
   ): (PType, Int => AsmFunction9[Region, T0, Boolean, T1, Boolean, T2, Boolean, T3, Boolean, R]) = {
     apply[AsmFunction9[Region, T0, Boolean, T1, Boolean, T2, Boolean, T3, Boolean, R], R](FastSeq(
@@ -124,12 +124,12 @@ object Compile {
   T4: ClassTag,
   T5: ClassTag,
   R: TypeInfo : ClassTag
-  ](name0: String, typ0: PType,
-    name1: String, typ1: PType,
-    name2: String, typ2: PType,
-    name3: String, typ3: PType,
-    name4: String, typ4: PType,
-    name5: String, typ5: PType,
+  ](name0: Sym, typ0: PType,
+    name1: Sym, typ1: PType,
+    name2: Sym, typ2: PType,
+    name3: Sym, typ3: PType,
+    name4: Sym, typ4: PType,
+    name5: Sym, typ5: PType,
     body: IR
   ): (PType, Int => AsmFunction13[Region, T0, Boolean, T1, Boolean, T2, Boolean, T3, Boolean, T4, Boolean, T5, Boolean, R]) = {
 
@@ -184,9 +184,9 @@ object CompileWithAggregators {
   def compileAggIRs[
   FAggInit >: Null : TypeInfo,
   FAggSeq >: Null : TypeInfo
-  ](initScopeArgs: Seq[(String, PType, ClassTag[_])],
-    aggScopeArgs: Seq[(String, PType, ClassTag[_])],
-    body: IR, aggResultName: String
+  ](initScopeArgs: Seq[(Sym, PType, ClassTag[_])],
+    aggScopeArgs: Seq[(Sym, PType, ClassTag[_])],
+    body: IR, aggResultName: Sym
   ): (Array[RegionValueAggregator], (IR, Compiler[FAggInit]), (IR, Compiler[FAggSeq]), PType, IR) = {
     assert((initScopeArgs ++ aggScopeArgs).forall { case (_, t, ct) => TypeToIRIntermediateClassTag(t.virtualType) == ct })
 
@@ -204,9 +204,9 @@ object CompileWithAggregators {
   def apply[
   F0 >: Null : TypeInfo,
   F1 >: Null : TypeInfo
-  ](initScopeArgs: Seq[(String, PType, ClassTag[_])],
-    aggScopeArgs: Seq[(String, PType, ClassTag[_])],
-    body: IR, aggResultName: String,
+  ](initScopeArgs: Seq[(Sym, PType, ClassTag[_])],
+    aggScopeArgs: Seq[(Sym, PType, ClassTag[_])],
+    body: IR, aggResultName: Sym,
     transformInitOp: (Int, IR) => IR,
     transformSeqOp: (Int, IR) => IR
   ): (Array[RegionValueAggregator], Int => F0, Int => F1, PType, IR) = {
@@ -230,10 +230,10 @@ object CompileWithAggregators {
   T0: ClassTag,
   S0: ClassTag,
   S1: ClassTag
-  ](name0: String, typ0: PType,
-    aggName0: String, aggTyp0: PType,
-    aggName1: String, aggTyp1: PType,
-    body: IR, aggResultName: String,
+  ](name0: Sym, typ0: PType,
+    aggName0: Sym, aggTyp0: PType,
+    aggName1: Sym, aggTyp1: PType,
+    body: IR, aggResultName: Sym,
     transformInitOp: (Int, IR) => IR,
     transformSeqOp: (Int, IR) => IR
   ): (Array[RegionValueAggregator],
@@ -256,12 +256,12 @@ object CompileWithAggregators {
   S0: ClassTag,
   S1: ClassTag,
   S2: ClassTag
-  ](name0: String, typ0: PType,
-    name1: String, typ1: PType,
-    aggName0: String, aggType0: PType,
-    aggName1: String, aggType1: PType,
-    aggName2: String, aggType2: PType,
-    body: IR, aggResultName: String,
+  ](name0: Sym, typ0: PType,
+    name1: Sym, typ1: PType,
+    aggName0: Sym, aggType0: PType,
+    aggName1: Sym, aggType1: PType,
+    aggName2: Sym, aggType2: PType,
+    body: IR, aggResultName: Sym,
     transformInitOp: (Int, IR) => IR,
     transformSeqOp: (Int, IR) => IR
   ): (Array[RegionValueAggregator],
@@ -286,11 +286,11 @@ object CompileWithAggregators {
     S0: ClassTag,
     S1: ClassTag,
     S2: ClassTag
-  ](name0: String, typ0: PType,
-    aggName0: String, aggTyp0: PType,
-    aggName1: String, aggTyp1: PType,
-    aggName2: String, aggTyp2: PType,
-    body: IR, aggResultName: String,
+  ](name0: Sym, typ0: PType,
+    aggName0: Sym, aggTyp0: PType,
+    aggName1: Sym, aggTyp1: PType,
+    aggName2: Sym, aggTyp2: PType,
+    body: IR, aggResultName: Sym,
     transformInitOp: (Int, IR) => IR,
     transformSeqOp: (Int, IR) => IR
   ): (Array[RegionValueAggregator],
@@ -315,13 +315,13 @@ object CompileWithAggregators {
   S1: ClassTag,
   S2: ClassTag,
   S3: ClassTag
-  ](name0: String, typ0: PType,
-    name1: String, typ1: PType,
-    aggName0: String, aggType0: PType,
-    aggName1: String, aggType1: PType,
-    aggName2: String, aggType2: PType,
-    aggName3: String, aggType3: PType,
-    body: IR, aggResultName: String,
+  ](name0: Sym, typ0: PType,
+    name1: Sym, typ1: PType,
+    aggName0: Sym, aggType0: PType,
+    aggName1: Sym, aggType1: PType,
+    aggName2: Sym, aggType2: PType,
+    aggName3: Sym, aggType3: PType,
+    body: IR, aggResultName: Sym,
     transformInitOp: (Int, IR) => IR,
     transformSeqOp: (Int, IR) => IR
   ): (Array[RegionValueAggregator],

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1025,9 +1025,9 @@ private class Emit(
   }
 
   private def getAsDependentFunction[A1: TypeInfo, R: TypeInfo](
-    ir: IR, argname: String, env: Emit.E, fb: EmitFunctionBuilder[_], errorMsg: String
+    ir: IR, argname: Sym, env: Emit.E, fb: EmitFunctionBuilder[_], errorMsg: String
   ): DependentFunction[AsmFunction3[Region, A1, Boolean, R]] = {
-    var ids = Set[String]()
+    var ids = Set[Sym]()
 
     def getReferenced: IR => IR = {
       case Ref(id, typ) if id == argname =>
@@ -1042,7 +1042,7 @@ private class Emit(
 
     val newIR = getReferenced(ir)
     val newEnv = ids.foldLeft(
-      Env.empty[(TypeInfo[_], Code[Boolean], Code[_])]) { (e: Emit.E, id: String) =>
+      Env.empty[(TypeInfo[_], Code[Boolean], Code[_])]) { (e: Emit.E, id: Sym) =>
       val (ti, m, v) = env.lookup(id)
       val newM = f.addField[Boolean](m)
       val newV = f.addField(v)(ti.asInstanceOf[TypeInfo[Any]])

--- a/hail/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -16,7 +16,7 @@ object ExtractAggregators {
   private case class IRAgg(i: Int, rvAgg: RegionValueAggregator, rt: Type)
   private case class AggOps(initOp: Option[IR], seqOp: IR)
 
-  def apply(ir: IR, resultName: String = "AGGR"): ExtractedAggregators = {
+  def apply(ir: IR, resultName: Sym = AGGRSym): ExtractedAggregators = {
     val ab = new ArrayBuilder[IRAgg]()
     val ab2 = new ArrayBuilder[AggOps]()
     val ref = Ref(resultName, null)

--- a/hail/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -68,7 +68,7 @@ object ExtractAggregators {
 
         val newRVAggBuilder = new ArrayBuilder[IRAgg]()
         val newBuilder = new ArrayBuilder[AggOps]()
-        val newRef = Ref(genUID(), null)
+        val newRef = Ref(genSym("pair"), null)
         val transformed = this.extract(aggIR, newRVAggBuilder, newBuilder, GetField(newRef, "value"))
 
         val nestedAggs = newRVAggBuilder.result()

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -94,8 +94,8 @@ object If {
 
 final case class If(cond: IR, cnsq: IR, altr: IR) extends IR
 
-final case class Let(name: String, value: IR, body: IR) extends IR
-final case class Ref(name: String, var _typ: Type) extends IR
+final case class Let(name: Sym, value: IR, body: IR) extends IR
+final case class Ref(name: Sym, var _typ: Type) extends IR
 
 final case class ApplyBinaryPrimOp(op: BinaryOp, l: IR, r: IR) extends IR
 final case class ApplyUnaryPrimOp(op: UnaryOp, x: IR) extends IR
@@ -140,25 +140,25 @@ final case class LowerBoundOnOrderedCollection(orderedCollection: IR, elem: IR, 
 
 final case class GroupByKey(collection: IR) extends IR
 
-final case class ArrayMap(a: IR, name: String, body: IR) extends IR {
+final case class ArrayMap(a: IR, name: Sym, body: IR) extends IR {
   override def typ: TArray = coerce[TArray](super.typ)
   def elementTyp: Type = typ.elementType
 }
-final case class ArrayFilter(a: IR, name: String, cond: IR) extends IR {
+final case class ArrayFilter(a: IR, name: Sym, cond: IR) extends IR {
   override def typ: TArray = super.typ.asInstanceOf[TArray]
 }
-final case class ArrayFlatMap(a: IR, name: String, body: IR) extends IR {
+final case class ArrayFlatMap(a: IR, name: Sym, body: IR) extends IR {
   override def typ: TArray = coerce[TArray](super.typ)
 }
-final case class ArrayFold(a: IR, zero: IR, accumName: String, valueName: String, body: IR) extends IR
+final case class ArrayFold(a: IR, zero: IR, accumName: Sym, valueName: Sym, body: IR) extends IR
 
-final case class ArrayScan(a: IR, zero: IR, accumName: String, valueName: String, body: IR) extends IR
+final case class ArrayScan(a: IR, zero: IR, accumName: Sym, valueName: Sym, body: IR) extends IR
 
-final case class ArrayFor(a: IR, valueName: String, body: IR) extends IR
+final case class ArrayFor(a: IR, valueName: Sym, body: IR) extends IR
 
 final case class AggFilter(cond: IR, aggIR: IR) extends IR
 
-final case class AggExplode(array: IR, name: String, aggBody: IR) extends IR
+final case class AggExplode(array: IR, name: Sym, aggBody: IR) extends IR
 
 final case class AggGroupBy(key: IR, aggIR: IR) extends IR
 
@@ -193,15 +193,17 @@ final case class ApplyScanOp(constructorArgs: IndexedSeq[IR], initOpArgs: Option
 final case class InitOp(i: IR, args: IndexedSeq[IR], aggSig: AggSignature) extends IR
 final case class SeqOp(i: IR, args: IndexedSeq[IR], aggSig: AggSignature) extends IR
 final case class Begin(xs: IndexedSeq[IR]) extends IR
-final case class MakeStruct(fields: Seq[(String, IR)]) extends IR
-final case class SelectFields(old: IR, fields: Seq[String]) extends IR
-final case class InsertFields(old: IR, fields: Seq[(String, IR)]) extends IR {
+
+final case class MakeStruct(fields: Seq[(Sym, IR)]) extends IR
+final case class SelectFields(old: IR, fields: Seq[Sym]) extends IR
+
+final case class InsertFields(old: IR, fields: Seq[(Sym, IR)]) extends IR {
   override def typ: TStruct = coerce[TStruct](super.typ)
 
   override def pType: PStruct = coerce[PStruct](super.pType)
 }
 
-final case class GetField(o: IR, name: String) extends IR
+final case class GetField(o: IR, name: Sym) extends IR
 
 final case class MakeTuple(types: Seq[IR]) extends IR
 final case class GetTupleElement(o: IR, idx: Int) extends IR
@@ -220,7 +222,7 @@ final case class Die(message: IR, _typ: Type) extends IR
 
 final case class ApplyIR(function: String, args: Seq[IR], conversion: Seq[IR] => IR) extends IR {
   lazy val explicitNode: IR = {
-    val refs = args.map(a => Ref(genUID(), a.typ)).toArray
+    val refs = args.map(a => Ref(genSym("arg"), a.typ)).toArray
     var body = conversion(refs)
 
     // foldRight because arg1 should be at the top so it is evaluated first
@@ -241,7 +243,7 @@ final case class ApplySeeded(function: String, args: Seq[IR], seed: Long) extend
 
 final case class ApplySpecial(function: String, args: Seq[IR]) extends AbstractApplyNode[IRFunctionWithMissingness]
 
-final case class Uniroot(argname: String, function: IR, min: IR, max: IR) extends IR
+final case class Uniroot(argname: Sym, function: IR, min: IR, max: IR) extends IR
 
 final case class TableCount(child: TableIR) extends IR
 final case class TableAggregate(child: TableIR, query: IR) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -124,7 +124,7 @@ object InferPType {
       case _: MatrixWrite => PVoid
       case _: TableExport => PVoid
       case TableGetGlobals(child) => PType.canonical(child.typ.globalType)
-      case TableCollect(child) => PStruct("rows" -> PArray(PType.canonical(child.typ.rowType)), "global" -> PType.canonical(child.typ.globalType))
+      case TableCollect(child) => PStruct(RowsSym -> PArray(PType.canonical(child.typ.rowType)), GlobalSym -> PType.canonical(child.typ.globalType))
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -129,7 +129,7 @@ object InferType {
       case _: MatrixWrite => TVoid
       case _: TableExport => TVoid
       case TableGetGlobals(child) => child.typ.globalType
-      case TableCollect(child) => TStruct("rows" -> TArray(child.typ.rowType), "global" -> child.typ.globalType)
+      case TableCollect(child) => TStruct(RowsSym -> TArray(child.typ.rowType), GlobalSym -> child.typ.globalType)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -2036,6 +2036,15 @@ case class MatrixExplodeRows(child: MatrixIR, path: IndexedSeq[Sym]) extends Mat
 
   private val rvRowType = child.typ.rvRowType
 
+  val length: IR = {
+    val len = genSym("len")
+    Let(len,
+      ArrayLen(ToArray(
+        path.foldLeft[IR](Ref(RowSym, rvRowType))((struct, field) =>
+          GetField(struct, field)))),
+      If(IsNA(Ref(len, TInt32())), 0, Ref(len, TInt32())))
+  }
+
   val idx = Ref(genSym("idx"), TInt32())
   val newRVRow: InsertFields = {
     val refs = path.init.scanLeft(Ref(RowSym, rvRowType))((struct, name) =>

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
@@ -295,20 +295,20 @@ case class MatrixValue(
     }
 
     def insertEntries[PC](makePartitionContext: () => PC, newColType: TStruct = typ.colType,
-      newColKey: IndexedSeq[String] = typ.colKey,
+      newColKey: IndexedSeq[Sym] = typ.colKey,
       newColValues: BroadcastIndexedSeq = colValues,
       newGlobalType: TStruct = typ.globalType,
       newGlobals: BroadcastRow = globals)(newEntryType: PStruct,
       inserter: (PC, RegionValue, RegionValueBuilder) => Unit): MatrixValue = {
       insertIntoRow(makePartitionContext, newColType, newColKey, newColValues, newGlobalType, newGlobals)(
-        PArray(newEntryType), MatrixType.entriesIdentifier, inserter)
+        PArray(newEntryType), EntriesSym, inserter)
     }
 
     def insertIntoRow[PC](makePartitionContext: () => PC, newColType: TStruct = typ.colType,
-      newColKey: IndexedSeq[String] = typ.colKey,
+      newColKey: IndexedSeq[Sym] = typ.colKey,
       newColValues: BroadcastIndexedSeq = colValues,
       newGlobalType: TStruct = typ.globalType,
-      newGlobals: BroadcastRow = globals)(typeToInsert: PType, path: String,
+      newGlobals: BroadcastRow = globals)(typeToInsert: PType, path: Sym,
       inserter: (PC, RegionValue, RegionValueBuilder) => Unit): MatrixValue = {
       assert(!typ.rowKey.contains(path))
 

--- a/hail/src/main/scala/is/hail/expr/ir/Mentions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Mentions.scala
@@ -1,11 +1,11 @@
 package is.hail.expr.ir
 
 object Mentions {
-  def apply(x: IR, v: String): Boolean = CountMentions(x, v) > 0
+  def apply(x: IR, v: Sym): Boolean = CountMentions(x, v) > 0
 }
 
 object CountMentions {
-  def apply(x: IR, v: String): Int = {
+  def apply(x: IR, v: Sym): Int = {
     x match {
       case Ref(n, _) =>
         if (v == n)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -41,9 +41,9 @@ object Pretty {
   def prettyLongsOpt(x: Option[IndexedSeq[Long]]): String =
     x.map(prettyLongs).getOrElse("None")
 
-  def prettyIdentifiers(x: IndexedSeq[String]): String = x.map(prettyIdentifier).mkString("(", " ", ")")
+  def prettySymbols(x: IndexedSeq[Sym]): String = x.mkString("(", " ", ")")
 
-  def prettyIdentifiersOpt(x: Option[IndexedSeq[String]]): String = x.map(prettyIdentifiers).getOrElse("None")
+  def prettySymbolsOpt(x: Option[IndexedSeq[Sym]]): String = x.map(prettySymbols).getOrElse("None")
 
   def apply(ir: BaseIR, elideLiterals: Boolean = false): String = {
     val sb = new StringBuilder
@@ -124,7 +124,7 @@ object Pretty {
             fields.foreachBetween { case (n, a) =>
               sb.append(" " * (depth + 2))
               sb += '('
-              sb.append(prettyIdentifier(n))
+              sb.append(n)
               sb += '\n'
               pretty(a, depth + 4)
               sb += ')'
@@ -146,7 +146,7 @@ object Pretty {
           sb += ')'
           sb += ')'
         case _ =>
-          val header = ir match {
+          val header: String = ir match {
             case I32(x) => x.toString
             case I64(x) => x.toString
             case F32(x) => x.toString
@@ -161,31 +161,31 @@ object Pretty {
                   else
                     "<literal value>"
                 )
-            case Let(name, _, _) => prettyIdentifier(name)
-            case Ref(name, _) => prettyIdentifier(name)
+            case Let(name, _, _) => name.toString
+            case Ref(name, _) => name.toString
             case ApplyBinaryPrimOp(op, _, _) => prettyClass(op)
             case ApplyUnaryPrimOp(op, _) => prettyClass(op)
             case ApplyComparisonOp(op, _, _) => prettyClass(op)
-            case GetField(_, name) => prettyIdentifier(name)
+            case GetField(_, name) => name.toString
             case GetTupleElement(_, idx) => idx.toString
             case MakeArray(_, typ) => typ.parsableString()
-            case ArrayMap(_, name, _) => prettyIdentifier(name)
-            case ArrayFilter(_, name, _) => prettyIdentifier(name)
-            case ArrayFlatMap(_, name, _) => prettyIdentifier(name)
-            case ArrayFold(_, _, accumName, valueName, _) => prettyIdentifier(accumName) + " " + prettyIdentifier(valueName)
-            case ArrayScan(_, _, accumName, valueName, _) => prettyIdentifier(accumName) + " " + prettyIdentifier(valueName)
-            case ArrayFor(_, valueName, _) => prettyIdentifier(valueName)
-            case AggExplode(_, name, _) => prettyIdentifier(name)
+            case ArrayMap(_, name, _) => name.toString
+            case ArrayFilter(_, name, _) => name.toString
+            case ArrayFlatMap(_, name, _) => name.toString
+            case ArrayFold(_, _, accumName, valueName, _) => accumName + " " + valueName
+            case ArrayScan(_, _, accumName, valueName, _) => accumName + " " + valueName
+            case ArrayFor(_, valueName, _) => valueName.toString
+            case AggExplode(_, name, _) => name.toString
             case ArraySort(_, _, onKey) => prettyBooleanLiteral(onKey)
             case ApplyIR(function, _, _) => prettyIdentifier(function)
             case Apply(function, _) => prettyIdentifier(function)
             case ApplySeeded(function, _, seed) => prettyIdentifier(function) + " " + seed.toString
             case ApplySpecial(function, _) => prettyIdentifier(function)
-            case SelectFields(_, fields) => fields.map(prettyIdentifier).mkString("(", " ", ")")
+            case SelectFields(_, fields) => fields.mkString("(", " ", ")")
             case LowerBoundOnOrderedCollection(_, _, onKey) => prettyBooleanLiteral(onKey)
             case In(i, typ) => s"${ typ.parsableString() } $i"
             case Die(message, typ) => typ.parsableString()
-            case Uniroot(name, _, _, _) => prettyIdentifier(name)
+            case Uniroot(name, _, _, _) => name.toString
             case MatrixRead(typ, dropCols, dropRows, reader) =>
               (if (typ == reader.fullType) "None" else typ.parsableString()) + " " +
               prettyBooleanLiteral(dropCols) + " " +
@@ -194,23 +194,22 @@ object Pretty {
             case MatrixWrite(_, writer) =>
               '"' + StringEscapeUtils.escapeString(Serialization.write(writer)(MatrixWriter.formats)) + '"'
             case TableToMatrixTable(_, rowKey, colKey, rowFields, colFields, nPartitions) =>
-              prettyStrings(rowKey) + " " +
-              prettyStrings(colKey) +  " " +
-              prettyStrings(rowFields) + " " +
-              prettyStrings(colFields) + " " +
+              prettySymbols(rowKey) + " " +
+              prettySymbols(colKey) +  " " +
+              prettySymbols(rowFields) + " " +
+              prettySymbols(colFields) + " " +
               prettyIntOpt(nPartitions)
             case MatrixAnnotateRowsTable(_, _, uid, key) =>
-              prettyStringLiteral(uid) + " " +
-              prettyBooleanLiteral(key.isDefined)
+              uid + " " + prettyBooleanLiteral(key.isDefined)
             case MatrixAnnotateColsTable(_, _, uid) =>
-              prettyStringLiteral(uid)
-            case MatrixExplodeRows(_, path) => prettyIdentifiers(path)
-            case MatrixExplodeCols(_, path) => prettyIdentifiers(path)
+              uid.toString
+            case MatrixExplodeRows(_, path) => prettySymbols(path)
+            case MatrixExplodeCols(_, path) => prettySymbols(path)
             case MatrixRepartition(_, n, strategy) => s"$n $strategy"
             case MatrixChooseCols(_, oldIndices) => prettyInts(oldIndices)
-            case MatrixMapCols(_, _, newKey) => prettyStringsOpt(newKey)
+            case MatrixMapCols(_, _, newKey) => prettySymbolsOpt(newKey)
             case MatrixKeyRowsBy(_, keys, isSorted) =>
-              prettyIdentifiers(keys) + " " +
+              prettySymbols(keys) + " " +
                 prettyBooleanLiteral(isSorted)
             case TableImport(paths, _, _) =>
               if (paths.length == 1)
@@ -258,36 +257,36 @@ object Pretty {
 
               ""
             case TableKeyBy(_, keys, isSorted) =>
-              prettyIdentifiers(keys) + " " +
+              prettySymbols(keys) + " " +
                 prettyBooleanLiteral(isSorted)
             case TableRange(n, nPartitions) => s"$n $nPartitions"
             case TableRepartition(_, n, strategy) => s"$n $strategy"
             case TableHead(_, n) => n.toString
             case TableJoin(_, _, joinType, joinKey) => s"$joinType $joinKey"
-            case TableLeftJoinRightDistinct(_, _, root) => prettyIdentifier(root)
-            case TableIntervalJoin(_, _, root) => prettyIdentifier(root)
+            case TableLeftJoinRightDistinct(_, _, root) => root.toString
+            case TableIntervalJoin(_, _, root) => root.toString
             case TableMultiWayZipJoin(_, dataName, globalName) =>
-              s"${ prettyStringLiteral(dataName) } ${ prettyStringLiteral(globalName) }"
+              s"$dataName $globalName"
             case TableKeyByAndAggregate(_, _, _, nPartitions, bufferSize) =>
               prettyIntOpt(nPartitions) + " " + bufferSize.toString
-            case TableExplode(_, path) => prettyStrings(path)
+            case TableExplode(_, path) => prettySymbols(path)
             case TableParallelize(_, nPartitions) =>
                 prettyIntOpt(nPartitions)
-            case TableOrderBy(_, sortFields) => prettyIdentifiers(sortFields.map(sf =>
-              (if (sf.sortOrder == Ascending) "A" else "D") + sf.field))
+            case TableOrderBy(_, sortFields) => sortFields.map(sf =>
+              s"${ if (sf.sortOrder == Ascending) "A" else "D" } ${ sf.field }").mkString("(", " ", ")")
             case CastMatrixToTable(_, entriesFieldName, colsFieldName) =>
-              s"${ prettyStringLiteral(entriesFieldName) } ${ prettyStringLiteral(colsFieldName) }"
+              s"$entriesFieldName $colsFieldName"
             case CastTableToMatrix(_, entriesFieldName, colsFieldName, colKey) =>
-              s"${ prettyIdentifier(entriesFieldName) } ${ prettyIdentifier(colsFieldName) } " +
-                prettyIdentifiers(colKey)
+              s"$entriesFieldName $colsFieldName" +
+                prettySymbols(colKey)
             case MatrixToMatrixApply(_, config) => prettyStringLiteral(Serialization.write(config)(RelationalFunctions.formats))
             case MatrixToTableApply(_, config) => prettyStringLiteral(Serialization.write(config)(RelationalFunctions.formats))
             case TableToTableApply(_, config) => prettyStringLiteral(Serialization.write(config)(RelationalFunctions.formats))
             case TableRename(_, rowMap, globalMap) =>
               val rowKV = rowMap.toArray
               val globalKV = globalMap.toArray
-              s"${ prettyStrings(rowKV.map(_._1)) } ${ prettyStrings(rowKV.map(_._2)) } " +
-                s"${ prettyStrings(globalKV.map(_._1)) } ${ prettyStrings(globalKV.map(_._2)) }"
+              s"${ prettySymbols(rowKV.map(_._1)) } ${ prettySymbols(rowKV.map(_._2)) } " +
+                s"${ prettySymbols(globalKV.map(_._1)) } ${ prettySymbols(globalKV.map(_._2)) }"
             case _ => ""
           }
 

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -7,7 +7,7 @@ import is.hail.expr.types.virtual._
 import is.hail.utils._
 
 object PruneDeadFields {
-  def subsetType(t: Type, path: Array[String], index: Int = 0): Type = {
+  def subsetType(t: Type, path: IndexedSeq[Sym], index: Int = 0): Type = {
     if (index == path.length)
       PruneDeadFields.minimal(t)
     else
@@ -77,6 +77,7 @@ object PruneDeadFields {
   }
 
   def pruneColValues(mv: MatrixValue, valueIR: IR, isArray: Boolean = false): (Type, BroadcastIndexedSeq, IR) = {
+    val values = genSym("values")
     val matrixType = mv.typ
     val oldColValues = mv.colValues
     val oldColType = matrixType.colType
@@ -84,20 +85,20 @@ object PruneDeadFields {
     val valueIRCopy = valueIR.deepCopy()
     val colDep = memoizeValueIR(valueIRCopy, valueIR.typ, memo)
       .m.mapValues(_._2)
-      .getOrElse("sa", if (isArray) TArray(TStruct()) else TStruct())
+      .getOrElse(ColSym, if (isArray) TArray(TStruct()) else TStruct())
     if (colDep != oldColType)
       log.info(s"pruned col values:\n  From: $oldColType\n  To: ${ colDep }")
     val newColsType = if (isArray) colDep.asInstanceOf[TArray] else TArray(colDep)
     val newIndexedSeq = Interpret[IndexedSeq[Annotation]](
-      upcast(Ref("values", TArray(oldColType)), newColsType),
+      upcast(Ref(values, TArray(oldColType)), newColsType),
       Env.empty[(Any, Type)]
-        .bind("values" -> (mv.colValues.value, TArray(oldColType))),
+        .bind(values -> (mv.colValues.value, TArray(oldColType))),
       FastIndexedSeq(),
       None,
       optimize = false)
     (colDep,
       BroadcastIndexedSeq(newIndexedSeq, newColsType, mv.sparkContext),
-      rebuild(valueIRCopy, relationalTypeToEnv(matrixType).bind("sa" -> colDep), memo)
+      rebuild(valueIRCopy, relationalTypeToEnv(matrixType).bind(ColSym -> colDep), memo)
     )
   }
 
@@ -116,7 +117,7 @@ object PruneDeadFields {
       rvRowType = TStruct(mt.rvRowType.required, mt.rvRowType.fields.flatMap { f =>
         if (rowKeySet.contains(f.name))
           Some(f.name -> f.typ)
-        else if (f.name == MatrixType.entriesIdentifier)
+        else if (f.name == EntriesSym)
           Some(f.name -> minimal(f.typ))
         else
           None
@@ -214,14 +215,14 @@ object PruneDeadFields {
     bt match {
       case tt: TableType =>
         Env.empty[Type]
-          .bind("row", tt.rowType)
-          .bind("global", tt.globalType)
+          .bind(RowSym, tt.rowType)
+          .bind(GlobalSym, tt.globalType)
       case mt: MatrixType =>
         Env.empty[Type]
-          .bind("global", mt.globalType)
-          .bind("sa", mt.colType)
-          .bind("va", mt.rvRowType)
-          .bind("g", mt.entryType)
+          .bind(GlobalSym, mt.globalType)
+          .bind(ColSym, mt.colType)
+          .bind(RowSym, mt.rvRowType)
+          .bind(EntrySym, mt.entryType)
     }
   }
 
@@ -231,7 +232,7 @@ object PruneDeadFields {
       case TableRead(_, _, _, _) =>
       case TableLiteral(_) =>
       case TableParallelize(rowsAndGlobal, _) =>
-        memoizeValueIR(rowsAndGlobal, TStruct("rows" -> TArray(requestedType.rowType), "global" -> requestedType.globalType), memo)
+        memoizeValueIR(rowsAndGlobal, TStruct(RowsSym -> TArray(requestedType.rowType), GlobalSym -> requestedType.globalType), memo)
       case TableImport(paths, typ, readerOpts) =>
       case TableRange(_, _) =>
       case TableRepartition(child, _, _) => memoizeTableIR(child, requestedType, memo)
@@ -369,7 +370,7 @@ object PruneDeadFields {
           colType = TStruct(child.typ.colType.required,
             child.typ.colType.fields.flatMap(f => requestedType.rowType.fieldOption(f.name).map(f2 => f.name -> f2.typ)): _*),
           rvRowType = TStruct(child.typ.rvRowType.required, child.typ.rvRowType.fields.flatMap { f =>
-            if (f.name == MatrixType.entriesIdentifier) {
+            if (f.name == EntriesSym) {
               Some(f.name -> TArray(TStruct(child.typ.entryType.required, child.typ.entryType.fields.flatMap { entryField =>
                 requestedType.rowType.fieldOption(entryField.name).map(f2 => f2.name -> f2.typ)
               }: _*), f.typ.required))
@@ -383,7 +384,7 @@ object PruneDeadFields {
         children.foreach(memoizeTableIR(_, requestedType, memo))
       case CastMatrixToTable(child, entriesFieldName, colsFieldName) =>
         val minChild = minimal(child.typ)
-        val m = Map(entriesFieldName -> MatrixType.entriesIdentifier)
+        val m = Map(entriesFieldName -> EntriesSym)
         val childDep = minChild.copy(
           globalType = if (requestedType.globalType.hasField(colsFieldName))
               requestedType.globalType.deleteKey(colsFieldName)
@@ -425,12 +426,12 @@ object PruneDeadFields {
         memoizeMatrixIR(left, requestedType, memo)
         memoizeMatrixIR(right,
           requestedType.copy(globalType = TStruct.empty(),
-            rvRowType = requestedType.rvRowType.filterSet((requestedType.rowKey :+ MatrixType.entriesIdentifier).toSet)._1),
+            rvRowType = requestedType.rvRowType.filterSet((requestedType.rowKey :+ EntriesSym).toSet)._1),
           memo)
       case MatrixMapEntries(child, newEntries) =>
         val irDep = memoizeAndGetDep(newEntries, requestedType.entryType, child.typ, memo)
         val depMod = requestedType.copy(rvRowType = TStruct(requestedType.rvRowType.required, requestedType.rvRowType.fields.map { f =>
-          if (f.name == MatrixType.entriesIdentifier)
+          if (f.name == EntriesSym)
             f.name -> f.typ.asInstanceOf[TArray].copy(elementType = irDep.entryType)
           else
             f.name -> f.typ
@@ -443,10 +444,10 @@ object PruneDeadFields {
       case MatrixMapRows(child, newRow) =>
         val irDep = memoizeAndGetDep(newRow, requestedType.rowType, child.typ, memo)
         val depMod = child.typ.copy(rvRowType = TStruct(irDep.rvRowType.fields.map { f =>
-          if (f.name == MatrixType.entriesIdentifier)
-            f.name -> unify(child.typ.rvRowType.field(MatrixType.entriesIdentifier).typ,
+          if (f.name == EntriesSym)
+            f.name -> unify(child.typ.rvRowType.field(EntriesSym).typ,
               f.typ,
-              requestedType.rvRowType.field(MatrixType.entriesIdentifier).typ)
+              requestedType.rvRowType.field(EntriesSym).typ)
           else
             f.name -> f.typ
         }: _*), colType = requestedType.colType, globalType = requestedType.globalType)
@@ -474,7 +475,7 @@ object PruneDeadFields {
             }
           }: _*),
           rvRowType = requestedType.rvRowType.copy(fields = requestedType.rvRowType.fields.map { f =>
-            if (f.name == MatrixType.entriesIdentifier)
+            if (f.name == EntriesSym)
               f.copy(typ = TArray(
                 TStruct(requestedType.entryType.required, requestedType.entryType.fields.map(ef =>
                   ef.name -> ef.typ.asInstanceOf[TArray].elementType): _*), f.typ.required))
@@ -497,7 +498,7 @@ object PruneDeadFields {
         val irDepCol = memoizeAndGetDep(colExpr, requestedType.colValueStruct, child.typ, memo)
         val rvRowDep = TStruct(
           child.typ.rvRowType.required, child.typ.rvRowType.fields.flatMap { f =>
-            if (f.name == MatrixType.entriesIdentifier)
+            if (f.name == EntriesSym)
               Some(f.name -> irDepEntry.entryArrayType)
             else {
               val requestedFieldDep = requestedType.rvRowType.fieldOption(f.name).map(_.typ)
@@ -608,7 +609,7 @@ object PruneDeadFields {
       case MatrixDistinctByRow(child) =>
         memoizeMatrixIR(child, requestedType, memo)
       case CastTableToMatrix(child, entriesFieldName, colsFieldName, _) =>
-        val m = Map(MatrixType.entriesIdentifier -> entriesFieldName)
+        val m = Map[Sym, Sym](EntriesSym -> entriesFieldName)
         val childDep = child.typ.copy(
           globalType = unify(child.typ.globalType, requestedType.globalType, TStruct((colsFieldName, TArray(requestedType.colType)))),
           rowType = requestedType.rvRowType.rename(m)
@@ -623,8 +624,8 @@ object PruneDeadFields {
     val depEnv = memoizeValueIR(ir, requestedType, memo).m.mapValues(_._2)
     val min = minimal(base)
     val rowArgs = (Iterator.single(min.rowType) ++
-      depEnv.get("row").map(_.asInstanceOf[TStruct]).iterator).toArray
-    val globalArgs = (Iterator.single(min.globalType) ++ depEnv.get("global").map(_.asInstanceOf[TStruct]).iterator).toArray
+      depEnv.get(RowSym).map(_.asInstanceOf[TStruct]).iterator).toArray
+    val globalArgs = (Iterator.single(min.globalType) ++ depEnv.get(GlobalSym).map(_.asInstanceOf[TStruct]).iterator).toArray
     base.copy(rowType = unifySeq(base.rowType, rowArgs),
       globalType = unifySeq(base.globalType, globalArgs))
   }
@@ -632,14 +633,14 @@ object PruneDeadFields {
   def memoizeAndGetDep(ir: IR, requestedType: Type, base: MatrixType, memo: Memo[BaseType]): MatrixType = {
     val depEnv = memoizeValueIR(ir, requestedType, memo).m.mapValues(_._2)
     val min = minimal(base)
-    val eField = base.rvRowType.field(MatrixType.entriesIdentifier)
-    val rowArgs = (Iterator.single(min.rvRowType) ++ depEnv.get("va").iterator ++
+    val eField = base.rvRowType.field(EntriesSym)
+    val rowArgs = (Iterator.single(min.rvRowType) ++ depEnv.get(RowSym).iterator ++
       Iterator.single(TStruct(eField.name -> TArray(
         unifySeq(eField.typ.asInstanceOf[TArray].elementType,
-          depEnv.get("g").iterator.toFastSeq),
+          depEnv.get(EntrySym).iterator.toFastSeq),
         eField.typ.required)))).toFastSeq
-    val colArgs = (Iterator.single(min.colType) ++ depEnv.get("sa").iterator).toFastSeq
-    val globalArgs = (Iterator.single(min.globalType) ++ depEnv.get("global").iterator).toFastSeq
+    val colArgs = (Iterator.single(min.colType) ++ depEnv.get(ColSym).iterator).toFastSeq
+    val globalArgs = (Iterator.single(min.globalType) ++ depEnv.get(GlobalSym).iterator).toFastSeq
     base.copy(rvRowType = unifySeq(base.rvRowType, rowArgs).asInstanceOf[TStruct],
       globalType = unifySeq(base.globalType, globalArgs).asInstanceOf[TStruct],
       colType = unifySeq(base.colType, colArgs).asInstanceOf[TStruct])
@@ -809,9 +810,9 @@ object PruneDeadFields {
         memoizeTableIR(child, TableType(
           unify(child.typ.rowType,
             minimalChild.rowType,
-            rStruct.fieldOption("rows").map(_.typ.asInstanceOf[TArray].elementType.asInstanceOf[TStruct]).getOrElse(TStruct())),
+            rStruct.fieldOption(RowsSym).map(_.typ.asInstanceOf[TArray].elementType.asInstanceOf[TStruct]).getOrElse(TStruct())),
           minimalChild.key,
-          rStruct.fieldOption("global").map(_.typ.asInstanceOf[TStruct]).getOrElse(TStruct())),
+          rStruct.fieldOption(GlobalSym).map(_.typ.asInstanceOf[TStruct]).getOrElse(TStruct())),
           memo)
         Env.empty[(Type, Type)]
       case TableAggregate(child, query) =>
@@ -1094,9 +1095,9 @@ object PruneDeadFields {
         MatrixAggregate(child2, query2)
       case TableCollect(child) =>
         val rStruct = requestedType.asInstanceOf[TStruct]
-        if (!rStruct.hasField("rows"))
-          if (rStruct.hasField("global"))
-            MakeStruct(FastSeq("global" -> TableGetGlobals(rebuild(child, memo))))
+        if (!rStruct.hasField(RowsSym))
+          if (rStruct.hasField(GlobalSym))
+            MakeStruct(FastSeq(GlobalSym -> TableGetGlobals(rebuild(child, memo))))
           else
             MakeStruct(FastSeq())
         else
@@ -1117,19 +1118,18 @@ object PruneDeadFields {
       ir.typ match {
         case ts: TStruct =>
           val rs = rType.asInstanceOf[TStruct]
-          val uid = genUID()
-          val ref = Ref(uid, ir.typ)
+          val s = genSym("struct")
           val ms = MakeStruct(
             rs.fields.map { f =>
-              f.name -> upcast(GetField(ref, f.name), f.typ)
+              f.name -> upcast(GetField(Ref(s, ir.typ), f.name), f.typ)
             }
           )
-          Let(uid, ir, ms)
+          Let(s, ir, ms)
         case ta: TArray =>
           val ra = rType.asInstanceOf[TArray]
-          val uid = genUID()
-          val ref = Ref(uid, -ta.elementType)
-          ArrayMap(ir, uid, upcast(ref, ra.elementType))
+          val elem = genSym("elem")
+          val ref = Ref(elem, -ta.elementType)
+          ArrayMap(ir, elem, upcast(ref, ra.elementType))
         case t => ir
       }
     }
@@ -1146,16 +1146,16 @@ object PruneDeadFields {
     else {
       var mt = ir
       if (upcastEntries && mt.typ.entryType != rType.entryType)
-        mt = MatrixMapEntries(mt, upcast(Ref("g", mt.typ.entryType), rType.entryType))
+        mt = MatrixMapEntries(mt, upcast(Ref(EntrySym, mt.typ.entryType), rType.entryType))
 
       if (upcastRows && mt.typ.rowType != rType.rowType)
-        mt = MatrixMapRows(mt, upcast(Ref("va", mt.typ.rvRowType), rType.rvRowType))
+        mt = MatrixMapRows(mt, upcast(Ref(RowSym, mt.typ.rvRowType), rType.rvRowType))
 
       if (upcastCols && mt.typ.colType != rType.colType)
-        mt = MatrixMapCols(mt, upcast(Ref("sa", mt.typ.colType), rType.colType), None)
+        mt = MatrixMapCols(mt, upcast(Ref(ColSym, mt.typ.colType), rType.colType), None)
 
       if (upcastGlobals && mt.typ.globalType != rType.globalType)
-        mt = MatrixMapGlobals(mt, upcast(Ref("global", ir.typ.globalType), rType.globalType))
+        mt = MatrixMapGlobals(mt, upcast(Ref(GlobalSym, ir.typ.globalType), rType.globalType))
 
       mt
     }
@@ -1172,11 +1172,11 @@ object PruneDeadFields {
     else {
       var table = ir
       if (upcastRow && ir.typ.rowType != rType.rowType) {
-        table = TableMapRows(table, upcast(Ref("row", table.typ.rowType), rType.rowType))
+        table = TableMapRows(table, upcast(Ref(RowSym, table.typ.rowType), rType.rowType))
       }
       if (upcastGlobals && ir.typ.globalType != rType.globalType) {
         table = TableMapGlobals(table,
-          upcast(Ref("global", table.typ.globalType), rType.globalType))
+          upcast(Ref(GlobalSym, table.typ.globalType), rType.globalType))
       }
       table
     }

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -410,7 +410,6 @@ object Simplify {
     case TableHead(TableOrderBy(child, sortFields), n)
       if sortFields.forall(_.sortOrder == Ascending) && n < 256 && canRepartition =>
       // n < 256 is arbitrary for memory concerns
-      val uid = genUID()
       val row = Ref(RowSym, child.typ.rowType)
       val keyStruct = MakeStruct(sortFields.map(f => f.field -> GetField(row, f.field)))
       val aggSig = AggSignature(TakeBy(), FastSeq(TInt32()), None, FastSeq(row.typ, keyStruct.typ))

--- a/hail/src/main/scala/is/hail/expr/ir/Sym.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Sym.scala
@@ -1,6 +1,8 @@
 package is.hail.expr.ir
 
 import is.hail.utils.StringEscapeUtils
+import org.json4s.CustomSerializer
+import org.json4s.JsonAST.JString
 
 // FIXME Sym instead of Symbol so we don't conflict with Scala's Symbol which is currently used by by the IR DSL
 object Sym {
@@ -8,11 +10,19 @@ object Sym {
 
   def gen(base: String): Sym = {
     counter += 1
-    Generated("j", base, counter)
+    Generated(s"j$base", counter)
   }
 }
 
+class SymSerializer extends CustomSerializer[Sym](format => (
+  { case JString(s) => IRParser.parseSymbol(s) },
+  { case s: Sym => JString(s.toString) }))
+
 abstract class Sym
+
+object I {
+  def apply(name: String): Sym = Identifier(name)
+}
 
 case class Identifier(name: String) extends Sym {
   override def toString: String = {
@@ -23,21 +33,25 @@ case class Identifier(name: String) extends Sym {
   }
 }
 
-// lang is one of "py" or "j"
-case class Generated(lang: String, base: String, i: Int) extends Sym {
-  override def toString: String = s":$lang$base-$i"
+case class Generated(base: String, i: Int) extends Sym {
+  override def toString: String = s":$base-$i"
 }
 
-case object GlobalSym {
+case object GlobalSym extends Sym {
   override def toString: String = ":global"
 }
 
-case object ColSym {
+case object ColSym extends Sym {
   override def toString: String = ":col"
 }
 
-case object RowSym {
+case object RowSym extends Sym {
   override def toString: String = ":row"
+}
+
+// used by TableParallelize
+case object RowsSym extends Sym {
+  override def toString: String = ":rows"
 }
 
 case object EntrySym extends Sym {
@@ -54,4 +68,12 @@ case object GlobalAndColsSym extends Sym {
 
 case object EntriesSym extends Sym {
   override def toString: String = ":entries"
+}
+
+case object AGGRSym extends Sym {
+  override def toString: String = ":AGGR"
+}
+
+case object SCANRSym extends Sym {
+  override def toString: String = ":SCANR"
 }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/DictFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/DictFunctions.scala
@@ -7,7 +7,7 @@ import is.hail.expr.types.virtual._
 
 object DictFunctions extends RegistryFunctions {
   def contains(dict: IR, key: IR) = {
-    val i = Ref(genUID(), TInt32())
+    val i = Ref(genSym("i"), TInt32())
 
     If(IsNA(dict),
       NA(TBoolean()),
@@ -17,12 +17,12 @@ object DictFunctions extends RegistryFunctions {
           False(),
           ApplyComparisonOp(
             EQWithNA(key.typ),
-            GetField(ArrayRef(ToArray(dict), i), "key"),
+            GetField(ArrayRef(ToArray(dict), i), I("key")),
             key))))
   }
 
   def get(dict: IR, key: IR, default: IR): IR = {
-    val i = Ref(genUID(), TInt32())
+    val i = Ref(genSym("i"), TInt32())
 
     If(IsNA(dict),
       NA(default.typ),
@@ -56,16 +56,16 @@ object DictFunctions extends RegistryFunctions {
     }
 
     registerIR("dictToArray", tdict) { d =>
-      val elt = Ref(genUID(), -types.coerce[TContainer](d.typ).elementType)
+      val elt = Ref(genSym("elt"), -types.coerce[TContainer](d.typ).elementType)
       ArrayMap(
         ToArray(d),
         elt.name,
-        MakeTuple(Seq(GetField(elt, "key"), GetField(elt, "value"))))
+        MakeTuple(Seq(GetField(elt, I("key")), GetField(elt, I("value")))))
     }
 
     registerIR("keySet", tdict) { d =>
-      val pairs = Ref(genUID(), -types.coerce[TContainer](d.typ).elementType)
-      ToSet(ArrayMap(ToArray(d), pairs.name, GetField(pairs, "key")))
+      val pairs = Ref(genSym("pairs"), -types.coerce[TContainer](d.typ).elementType)
+      ToSet(ArrayMap(ToArray(d), pairs.name, GetField(pairs, I("key"))))
     }
 
     registerIR("dict", TSet(TTuple(tv("key"), tv("value"))))(s => ToDict(ToArray(s)))

--- a/hail/src/main/scala/is/hail/expr/ir/functions/DictFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/DictFunctions.scala
@@ -73,12 +73,12 @@ object DictFunctions extends RegistryFunctions {
     registerIR("dict", TArray(TTuple(tv("key"), tv("value"))))(ToDict)
 
     registerIR("keys", tdict) { d =>
-      val elt = Ref(genUID(), -types.coerce[TContainer](d.typ).elementType)
+      val elt = Ref(genSym("elt"), -types.coerce[TContainer](d.typ).elementType)
       ArrayMap(ToArray(d), elt.name, GetField(elt, "key"))
     }
 
     registerIR("values", tdict) { d =>
-      val elt = Ref(genUID(), -types.coerce[TContainer](d.typ).elementType)
+      val elt = Ref(genSym("elt"), -types.coerce[TContainer](d.typ).elementType)
       ArrayMap(ToArray(d), elt.name, GetField(elt, "value"))
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir.functions
 
-import is.hail.expr.ir.{MatrixValue, TableValue}
+import is.hail.expr.ir.{MatrixValue, TableValue, SymSerializer}
 import is.hail.expr.types.{MatrixType, TableType}
 import is.hail.methods._
 import is.hail.rvd.RVDType
@@ -40,7 +40,8 @@ object RelationalFunctions {
     classOf[WindowByLocus],
     classOf[TableFilterPartitions],
     classOf[MatrixFilterPartitions]
-  ))
+  )) +
+    new SymSerializer
 
   def extractTo[T : Manifest](config: String): T = {
     Serialization.read[T](config)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/SetFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/SetFunctions.scala
@@ -8,7 +8,7 @@ import is.hail.utils.FastSeq
 
 object SetFunctions extends RegistryFunctions {
   def contains(set: IR, elem: IR) = {
-    val i = Ref(genUID(), TInt32())
+    val i = Ref(genSym("i"), TInt32())
 
     If(IsNA(set),
       NA(TBoolean()),
@@ -32,7 +32,7 @@ object SetFunctions extends RegistryFunctions {
 
     registerIR("remove", TSet(tv("T")), tv("T")) { (s, v) =>
       val t = v.typ
-      val x = genUID()
+      val x = genSym("x")
       ToSet(
         ArrayFilter(
           ToArray(s),
@@ -42,7 +42,7 @@ object SetFunctions extends RegistryFunctions {
 
     registerIR("add", TSet(tv("T")), tv("T")) { (s, v) =>
       val t = v.typ
-      val x = genUID()
+      val x = genSym("x")
       ToSet(
         ArrayFlatMap(
           MakeArray(FastSeq(ToArray(s), MakeArray(FastSeq(v), TArray(t))), TArray(TArray(t))),
@@ -52,7 +52,7 @@ object SetFunctions extends RegistryFunctions {
 
     registerIR("union", TSet(tv("T")), TSet(tv("T"))) { (s1, s2) =>
       val t = -s1.typ.asInstanceOf[TSet].elementType
-      val x = genUID()
+      val x = genSym("x")
       ToSet(
         ArrayFlatMap(
           MakeArray(FastSeq(ToArray(s1), ToArray(s2)), TArray(TArray(t))),
@@ -62,7 +62,7 @@ object SetFunctions extends RegistryFunctions {
 
     registerIR("intersection", TSet(tv("T")), TSet(tv("T"))) { (s1, s2) =>
       val t = -s1.typ.asInstanceOf[TSet].elementType
-      val x = genUID()
+      val x = genSym("x")
       ToSet(
         ArrayFilter(ToArray(s1), x,
           contains(s2, Ref(x, t))))
@@ -70,7 +70,7 @@ object SetFunctions extends RegistryFunctions {
 
     registerIR("difference", TSet(tv("T")), TSet(tv("T"))) { (s1, s2) =>
       val t = -s1.typ.asInstanceOf[TSet].elementType
-      val x = genUID()
+      val x = genSym("x")
       ToSet(
         ArrayFilter(ToArray(s1), x,
           ApplyUnaryPrimOp(Bang(), contains(s2, Ref(x, t)))))
@@ -78,8 +78,8 @@ object SetFunctions extends RegistryFunctions {
 
     registerIR("isSubset", TSet(tv("T")), TSet(tv("T"))) { (s, w) =>
       val t = -s.typ.asInstanceOf[TSet].elementType
-      val a = genUID()
-      val x = genUID()
+      val a = genSym("a")
+      val x = genSym("x")
       ArrayFold(ToArray(s), True(), a, x,
         // FIXME short circuit
         ApplySpecial("&&",
@@ -96,9 +96,9 @@ object SetFunctions extends RegistryFunctions {
 
     registerIR("min", TSet(tnum("T"))) { s =>
       val t = s.typ.asInstanceOf[TSet].elementType
-      val a = genUID()
-      val size = genUID()
-      val last = genUID()
+      val a = genSym("a")
+      val size = genSym("size")
+      val last = genSym("last")
 
       Let(a, ToArray(s),
         Let(size, ArrayLen(Ref(a, TArray(t))),
@@ -111,9 +111,9 @@ object SetFunctions extends RegistryFunctions {
 
     registerIR("max", TSet(tnum("T"))) { s =>
       val t = s.typ.asInstanceOf[TSet].elementType
-      val a = genUID()
-      val size = genUID()
-      val last = genUID()
+      val a = genSym("a")
+      val size = genSym("size")
+      val last = genSym("last")
 
       Let(a, ToArray(s),
         Let(size, ArrayLen(Ref(a, TArray(t))),
@@ -126,8 +126,8 @@ object SetFunctions extends RegistryFunctions {
 
     registerIR("median", TSet(tnum("T"))) { s =>
       val t = -s.typ.asInstanceOf[TSet].elementType
-      val a = Ref(genUID(), TArray(t))
-      val size = Ref(genUID(), TInt32())
+      val a = Ref(genSym("a"), TArray(t))
+      val size = Ref(genSym("size"), TInt32())
       val lastIdx = size - 1
       val midIdx = lastIdx.floorDiv(2)
       def ref(i: IR) = ArrayRef(a, i)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -52,7 +52,7 @@ object StringFunctions extends RegistryFunctions {
 
     registerIR("[]", TString(), TInt32()) { (s, idx) =>
       // rather than do a bunch of bounds checking here, check the length of the StringSlice result - way easier
-      val sName = ir.genUID()
+      val sName = ir.genSym("s")
       val sResult = ir.Ref(sName, TString())
       ir.Let(
         sName,

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -47,7 +47,7 @@ object UtilFunctions extends RegistryFunctions {
         case s2: MakeStruct => InsertFields(s, s2.fields)
         case s2 =>
           val s2typ = coerce[TStruct](s2.typ)
-          val s2id = genUID()
+          val s2id = genSym("s2")
           Let(s2id, s2, InsertFields(s, s2typ.fieldNames.map { n => n -> GetField(Ref(s2id, s2typ), n) }))
       }
     }

--- a/hail/src/main/scala/is/hail/expr/ir/package.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/package.scala
@@ -3,7 +3,6 @@ package is.hail.expr
 import is.hail.asm4s
 import is.hail.asm4s._
 import is.hail.expr.ir.functions.IRFunctionRegistry
-import is.hail.expr.types._
 import is.hail.expr.types.physical.PType
 import is.hail.expr.types.virtual._
 import is.hail.utils._
@@ -12,14 +11,6 @@ import scala.language.implicitConversions
 
 package object ir {
   type TokenIterator = BufferedIterator[Token]
-
-  var uidCounter: Long = 0
-
-  def genUID(): String = {
-    val uid = s"__iruid_$uidCounter"
-    uidCounter += 1
-    uid
-  }
 
   def genSym(base: String): Sym = Sym.gen(base)
 

--- a/hail/src/main/scala/is/hail/expr/types/TableType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/TableType.scala
@@ -11,25 +11,25 @@ class TableTypeSerializer extends CustomSerializer[TableType](format => (
   { case JString(s) => IRParser.parseTableType(s) },
   { case tt: TableType => JString(tt.toString) }))
 
-case class TableType(rowType: TStruct, key: IndexedSeq[String], globalType: TStruct) extends BaseType {
+case class TableType(rowType: TStruct, key: IndexedSeq[Sym], globalType: TStruct) extends BaseType {
   val canonicalRVDType = RVDType(rowType.physicalType, key)
 
   def env: Env[Type] = {
     Env.empty[Type]
-      .bind(("global", globalType))
-      .bind(("row", rowType))
+      .bind((GlobalSym, globalType))
+      .bind((RowSym, rowType))
   }
 
   def globalEnv: Env[Type] = Env.empty[Type]
-    .bind("global" -> globalType)
+    .bind(GlobalSym -> globalType)
 
   def rowEnv: Env[Type] = Env.empty[Type]
-    .bind("global" -> globalType)
-    .bind("row" -> rowType)
+    .bind(GlobalSym -> globalType)
+    .bind(RowSym -> rowType)
 
-  def refMap: Map[String, Type] = Map(
-    "global" -> globalType,
-    "row" -> rowType)
+  def refMap: Map[Sym, Type] = Map(
+    GlobalSym -> globalType,
+    RowSym -> rowType)
 
   def keyType: TStruct = canonicalRVDType.kType.virtualType
   val keyFieldIdx: Array[Int] = canonicalRVDType.kFieldIdx
@@ -58,7 +58,7 @@ case class TableType(rowType: TStruct, key: IndexedSeq[String], globalType: TStr
     newline()
 
     sb.append(s"key:$space[")
-    key.foreachBetween(k => sb.append(prettyIdentifier(k)))(sb.append(s",$space"))
+    key.foreachBetween(k => sb.append(k))(sb.append(s",$space"))
     sb += ']'
     sb += ','
     newline()

--- a/hail/src/main/scala/is/hail/expr/types/physical/PField.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PField.scala
@@ -1,15 +1,15 @@
 package is.hail.expr.types.physical
 
-import is.hail.utils._
+import is.hail.expr.ir.Sym
 
-final case class PField(name: String, typ: PType, index: Int) {
+final case class PField(name: Sym, typ: PType, index: Int) {
   def pretty(sb: StringBuilder, indent: Int, compact: Boolean) {
     if (compact) {
-      sb.append(prettyIdentifier(name))
+      sb.append(name)
       sb.append(":")
     } else {
       sb.append(" " * indent)
-      sb.append(prettyIdentifier(name))
+      sb.append(name)
       sb.append(": ")
     }
     typ.pretty(sb, indent, compact)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
@@ -2,7 +2,7 @@ package is.hail.expr.types.physical
 
 import is.hail.annotations._
 import is.hail.check.{Arbitrary, Gen}
-import is.hail.expr.ir.EmitMethodBuilder
+import is.hail.expr.ir.{EmitMethodBuilder, Sym}
 import is.hail.expr.types.virtual._
 import is.hail.expr.types.{BaseType, EncodedType}
 import is.hail.utils._
@@ -30,7 +30,7 @@ object PType {
 
   def genFields(required: Boolean, genFieldType: Gen[PType]): Gen[Array[PField]] = {
     Gen.buildableOf[Array](
-      Gen.zip(Gen.identifier, genFieldType))
+      Gen.zip(Gen.symbol, genFieldType))
       .filter(fields => fields.map(_._1).areDistinct())
       .map(fields => fields
         .iterator
@@ -163,7 +163,7 @@ abstract class PType extends BaseType with Serializable {
     unsafeOrdering()
   }
 
-  def unsafeInsert(typeToInsert: PType, path: List[String]): (PType, UnsafeInserter) =
+  def unsafeInsert(typeToInsert: PType, path: List[Sym]): (PType, UnsafeInserter) =
     PStruct.empty().unsafeInsert(typeToInsert, path)
 
   def insert(signature: PType, fields: String*): (PType, Inserter) = insert(signature, fields.toList)

--- a/hail/src/main/scala/is/hail/expr/types/virtual/Field.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/Field.scala
@@ -1,8 +1,8 @@
 package is.hail.expr.types.virtual
 
-import is.hail.utils._
+import is.hail.expr.ir.Sym
 
-final case class Field(name: String, typ: Type, index: Int) {
+final case class Field(name: Sym, typ: Type, index: Int) {
 
   def unify(cf: Field): Boolean =
     name == cf.name &&
@@ -11,11 +11,11 @@ final case class Field(name: String, typ: Type, index: Int) {
 
   def pretty(sb: StringBuilder, indent: Int, compact: Boolean) {
     if (compact) {
-      sb.append(prettyIdentifier(name))
+      sb.append(name)
       sb.append(":")
     } else {
       sb.append(" " * indent)
-      sb.append(prettyIdentifier(name))
+      sb.append(name)
       sb.append(": ")
     }
     typ.pretty(sb, indent, compact)

--- a/hail/src/main/scala/is/hail/expr/types/virtual/Type.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/Type.scala
@@ -2,6 +2,7 @@ package is.hail.expr.types.virtual
 
 import is.hail.annotations._
 import is.hail.check.{Arbitrary, Gen}
+import is.hail.expr.ir.Sym
 import is.hail.expr.types._
 import is.hail.expr.types.physical.PType
 import is.hail.expr.{JSONAnnotationImpex, SparkAnnotationImpex}
@@ -35,7 +36,7 @@ object Type {
 
   def genFields(required: Boolean, genFieldType: Gen[Type]): Gen[Array[Field]] = {
     Gen.buildableOf[Array](
-      Gen.zip(Gen.identifier, genFieldType))
+      Gen.zip(Gen.symbol, genFieldType))
       .filter(fields => fields.map(_._1).areDistinct())
       .map(fields => fields
         .iterator
@@ -142,25 +143,25 @@ abstract class Type extends BaseType with Serializable {
 
   def subst(): Type = this.setRequired(false)
 
-  def insert(signature: Type, fields: String*): (Type, Inserter) = insert(signature, fields.toList)
+  def insert(signature: Type, fields: Sym*): (Type, Inserter) = insert(signature, fields.toList)
 
-  def insert(signature: Type, path: List[String]): (Type, Inserter) = {
+  def insert(signature: Type, path: List[Sym]): (Type, Inserter) = {
     if (path.nonEmpty)
       TStruct.empty().insert(signature, path)
     else
       (signature, (a, toIns) => toIns)
   }
 
-  def query(fields: String*): Querier = query(fields.toList)
+  def query(fields: Sym*): Querier = query(fields.toList)
 
-  def query(path: List[String]): Querier = {
+  def query(path: List[Sym]): Querier = {
     val (t, q) = queryTyped(path)
     q
   }
 
-  def queryTyped(fields: String*): (Type, Querier) = queryTyped(fields.toList)
+  def queryTyped(fields: Sym*): (Type, Querier) = queryTyped(fields.toList)
 
-  def queryTyped(path: List[String]): (Type, Querier) = {
+  def queryTyped(path: List[Sym]): (Type, Querier) = {
     if (path.nonEmpty)
       throw new AnnotationPathException(s"invalid path ${ path.mkString(".") } from type ${ this }")
     else
@@ -179,9 +180,9 @@ abstract class Type extends BaseType with Serializable {
     sb.append(_toPretty)
   }
 
-  def fieldOption(fields: String*): Option[Field] = fieldOption(fields.toList)
+  def fieldOption(fields: Sym*): Option[Field] = fieldOption(fields.toList)
 
-  def fieldOption(path: List[String]): Option[Field] =
+  def fieldOption(path: List[Sym]): Option[Field] =
     None
 
   def schema: DataType = SparkAnnotationImpex.exportType(this)

--- a/hail/src/main/scala/is/hail/io/LoadMatrix.scala
+++ b/hail/src/main/scala/is/hail/io/LoadMatrix.scala
@@ -2,6 +2,7 @@ package is.hail.io
 
 import is.hail.HailContext
 import is.hail.annotations._
+import is.hail.expr.ir.{I, Sym}
 import is.hail.expr.types._
 import is.hail.expr.types.virtual._
 import is.hail.rvd.{RVD, RVDContext, RVDPartitioner}
@@ -217,13 +218,13 @@ object LoadMatrix {
     }
   }
 
-  def splitHeader(cols: Array[String], nRowFields: Int, nColIDs: Int): (Array[String], Array[_]) = {
+  def splitHeader(cols: Array[String], nRowFields: Int, nColIDs: Int): (Array[Sym], Array[_]) = {
     if (cols.length == nColIDs) {
-      (Array.tabulate(nRowFields)(i => s"f$i"), cols)
+      (Array.tabulate(nRowFields)(i => I(s"f$i")), cols)
     } else if (cols.length == nColIDs + nRowFields) {
-      (cols.take(nRowFields), cols.drop(nRowFields))
+      (cols.take(nRowFields).map(I(_)), cols.drop(nRowFields))
     } else if (cols.isEmpty) {
-      (Array.tabulate(nRowFields)(i => s"f$i"), Array.range(0, nColIDs))
+      (Array.tabulate(nRowFields)(i => I(s"f$i")), Array.range(0, nColIDs))
     } else
       fatal(
         s"""Expected file header to contain all $nColIDs column IDs and
@@ -247,12 +248,12 @@ object LoadMatrix {
     (new RVDPartitioner(Array(kType.fieldNames(0)), kType, ranges), keepPartitions.result())
   }
 
-  def verifyRowFields(fieldNames: Array[String], fieldTypes: Map[String, Type]): TStruct = {
+  def verifyRowFields(fieldNames: Array[Sym], fieldTypes: Map[Sym, Type]): TStruct = {
     val headerDups = fieldNames.duplicates()
     if (headerDups.nonEmpty)
       fatal(s"Found following duplicate row fields in header: \n    ${ headerDups.mkString("\n    ") }")
 
-    val fields: Array[(String, Type)] = fieldNames.map { name =>
+    val fields: Array[(Sym, Type)] = fieldNames.map { name =>
       fieldTypes.get(name) match {
         case Some(t) => (name, t)
         case None => fatal(
@@ -269,9 +270,9 @@ object LoadMatrix {
 
   def apply(hc: HailContext,
     files: Array[String],
-    rowFields: Map[String, Type],
-    keyFields: Array[String],
-    cellType: TStruct = TStruct("x" -> TInt64()),
+    rowFields: Map[Sym, Type],
+    keyFields: IndexedSeq[Sym],
+    cellType: TStruct = TStruct(I("x") -> TInt64()),
     missingValue: String = "NA",
     nPartitions: Option[Int] = None,
     noHeader: Boolean = false,
@@ -342,7 +343,7 @@ object LoadMatrix {
     val useIndex = keyFields.isEmpty
     val (rowKey, rowType) =
       if (useIndex)
-        (Array("row_id"), TStruct("row_id" -> TInt64()) ++ rowFieldType)
+        (ISeq[Sym]("row_id"), TStruct("row_id" -> TInt64()) ++ rowFieldType)
       else (keyFields, rowFieldType)
 
     if (!keyFields.forall(rowType.fieldNames.contains))
@@ -355,7 +356,7 @@ object LoadMatrix {
     val matrixType = MatrixType.fromParts(
       TStruct.empty(),
       colType = TStruct("col_id" -> (if (noHeader) TInt32() else TString())),
-      colKey = Array("col_id"),
+      colKey = ISeq("col_id"),
       rowType = rowType,
       rowKey = rowKey.toFastIndexedSeq,
       entryType = cellType)

--- a/hail/src/main/scala/is/hail/io/LoadMatrix.scala
+++ b/hail/src/main/scala/is/hail/io/LoadMatrix.scala
@@ -272,7 +272,7 @@ object LoadMatrix {
     files: Array[String],
     rowFields: Map[Sym, Type],
     keyFields: IndexedSeq[Sym],
-    cellType: TStruct = TStruct(I("x") -> TInt64()),
+    cellType: TStruct = TStruct("x" -> TInt64()),
     missingValue: String = "NA",
     nPartitions: Option[Int] = None,
     noHeader: Boolean = false,

--- a/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
@@ -62,7 +62,7 @@ object IndexBgen {
       annotationType
     )
 
-    val typ = RVDType(settings.typ.physicalType, Array("file_idx", "locus", "alleles"))
+    val typ = RVDType(settings.typ.physicalType, FastIndexedSeq("file_idx", "locus", "alleles"))
 
     val sHadoopConfBc = hc.sc.broadcast(new SerializableHadoopConfiguration(hConf))
 
@@ -83,15 +83,15 @@ object IndexBgen {
     val allelesIdx = rowType.fieldIdx("alleles")
     val offsetIdx = rowType.fieldIdx("offset")
     val fileIdxIdx = rowType.fieldIdx("file_idx")
-    val (keyType, _) = rowType.virtualType.select(Array("file_idx", "locus", "alleles"))
-    val (indexKeyType, _) = keyType.select(Array("locus", "alleles"))
+    val (keyType, _) = rowType.virtualType.select(FastIndexedSeq("file_idx", "locus", "alleles"))
+    val (indexKeyType, _) = keyType.select(FastIndexedSeq("locus", "alleles"))
 
     val attributes = Map("reference_genome" -> rg.orNull,
       "contig_recoding" -> recoding,
       "skip_invalid_loci" -> skipInvalidLoci)
 
     val rangeBounds = files.zipWithIndex.map { case (_, i) => Interval(Row(i), Row(i), includesStart = true, includesEnd = true) }
-    val partitioner = new RVDPartitioner(Array("file_idx"), keyType.asInstanceOf[TStruct], rangeBounds)
+    val partitioner = new RVDPartitioner(ISeq("file_idx"), keyType.asInstanceOf[TStruct], rangeBounds)
     val crvd = BgenRDD(hc.sc, partitions, settings, null)
 
     RVD.unkeyed(rowType, crvd)

--- a/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -341,10 +341,10 @@ object MatrixBGENReader {
 
     MatrixType.fromParts(
       globalType = TStruct.empty(),
-      colKey = Array("s"),
+      colKey = ISeq("s"),
       colType = TStruct("s" -> TString()),
       rowType = TStruct(typedRowFields: _*),
-      rowKey = Array("locus", "alleles"),
+      rowKey = ISeq("locus", "alleles"),
       entryType = TStruct(typedEntryFields: _*))
   }
 }

--- a/hail/src/main/scala/is/hail/io/package.scala
+++ b/hail/src/main/scala/is/hail/io/package.scala
@@ -1,5 +1,6 @@
 package is.hail
 
+import is.hail.expr.ir.Sym
 import is.hail.expr.types.virtual.Type
 import is.hail.utils._
 import org.apache.hadoop.conf.Configuration
@@ -9,11 +10,11 @@ package object io {
   type VCFAttributes = Map[String, VCFFieldAttributes]
   type VCFMetadata = Map[String, VCFAttributes]
 
-  def exportTypes(filename: String, hConf: Configuration, info: Array[(String, Type)]) {
+  def exportTypes(filename: String, hConf: Configuration, info: Array[(Sym, Type)]) {
     val sb = new StringBuilder
     hConf.writeTextFile(filename) { out =>
       info.foreachBetween { case (name, t) =>
-        sb.append(prettyIdentifier(name))
+        sb.append(name)
         sb.append(":")
         t.pretty(sb, 0, compact = true)
       } { sb += ',' }

--- a/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
@@ -2,7 +2,7 @@ package is.hail.io.plink
 
 import is.hail.HailContext
 import is.hail.annotations._
-import is.hail.expr.ir.{MatrixRead, MatrixReader, MatrixValue, PruneDeadFields}
+import is.hail.expr.ir.{I, MatrixRead, MatrixReader, MatrixValue, PruneDeadFields}
 import is.hail.expr.types._
 import is.hail.expr.types.virtual._
 import is.hail.io.vcf.LoadVCF
@@ -140,7 +140,7 @@ case class MatrixPLINKReader(
 
   val (sampleInfo, signature) = LoadPlink.parseFam(fam, ffConfig, hc.hadoopConf)
 
-  val nameMap = Map("id" -> "s")
+  val nameMap = Map(I("id") -> I("s"))
   val saSignature = signature.copy(fields = signature.fields.map(f => f.copy(name = nameMap.getOrElse(f.name, f.name))))
 
   val nSamples = sampleInfo.length
@@ -180,14 +180,14 @@ case class MatrixPLINKReader(
 
   val fullType: MatrixType = MatrixType.fromParts(
     globalType = TStruct.empty(),
-    colKey = Array("s"),
+    colKey = ISeq("s"),
     colType = saSignature,
     rowType = TStruct(
       "locus" -> TLocus.schemaFromRG(referenceGenome),
       "alleles" -> TArray(TString()),
       "rsid" -> TString(),
       "cm_position" -> TFloat64()),
-    rowKey = Array("locus", "alleles"),
+    rowKey = ISeq("locus", "alleles"),
     entryType = TStruct("GT" -> TCall()))
 
   val fullRVDType: RVDType = fullType.canonicalRVDType

--- a/hail/src/main/scala/is/hail/io/vcf/HtsjdkRecordReader.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/HtsjdkRecordReader.scala
@@ -2,6 +2,7 @@ package is.hail.io.vcf
 
 import htsjdk.variant.variantcontext.VariantContext
 import is.hail.annotations._
+import is.hail.expr.ir.Sym
 import is.hail.expr.types._
 import is.hail.expr.types.virtual._
 import is.hail.utils._
@@ -18,7 +19,7 @@ class BufferedLineIterator(bit: BufferedIterator[String]) extends htsjdk.tribble
   }
 }
 
-class HtsjdkRecordReader(val callFields: Set[String]) extends Serializable {
+class HtsjdkRecordReader(val callFields: Set[Sym]) extends Serializable {
 
   import HtsjdkRecordReader._
 
@@ -29,7 +30,7 @@ class HtsjdkRecordReader(val callFields: Set[String]) extends Serializable {
     hasQual: Boolean,
     hasFilters: Boolean,
     infoType: TStruct,
-    infoFlagFieldNames: Set[String]) {
+    infoFlagFieldNames: Set[Sym]) {
     // locus, alleles added via VCFLine
 
     // rsid
@@ -66,7 +67,7 @@ class HtsjdkRecordReader(val callFields: Set[String]) extends Serializable {
     if (infoType != null) {
       rvb.startStruct()
       infoType.fields.foreach { f =>
-        val a = vc.getAttribute(f.name)
+        val a = vc.getAttribute(f.name.toString)
         addAttribute(rvb, a, f.typ, -1, isFlag = infoFlagFieldNames.contains(f.name))
       }
       rvb.endStruct()

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -612,10 +612,10 @@ class FormatParser(
 
 class ParseLineContext(typ: MatrixType, val infoFlagFieldNames: Set[Sym], headerLines: BufferedLineIterator) {
   val gType: TStruct = typ.entryType
-  val infoSignature = typ.rowType.fieldOption(I("info")).map(_.typ.asInstanceOf[TStruct]).orNull
-  val hasRSID = typ.rowType.hasField(I("rsid"))
-  val hasQual = typ.rowType.hasField(I("qual"))
-  val hasFilters = typ.rowType.hasField(I("filters"))
+  val infoSignature = typ.rowType.fieldOption("info").map(_.typ.asInstanceOf[TStruct]).orNull
+  val hasRSID = typ.rowType.hasField("rsid")
+  val hasQual = typ.rowType.hasField("qual")
+  val hasFilters = typ.rowType.hasField("filters")
   val formatSignature = typ.entryType
   val hasEntryFields = formatSignature.size > 0
 

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -7,6 +7,7 @@ import breeze.numerics.{abs => breezeAbs, log => breezeLog, pow => breezePow, sq
 import breeze.stats.distributions.{RandBasis, ThreadLocalRandomGenerator}
 import is.hail._
 import is.hail.annotations._
+import is.hail.expr.ir.Sym
 import is.hail.table.Table
 import is.hail.expr.types._
 import is.hail.expr.types.virtual.{TFloat64, TFloat64Optional, TInt64Optional, TStruct}
@@ -1213,7 +1214,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
         }
     }
 
-    new Table(hc, entriesRDD, rvRowType, Array("i", "j"))
+    new Table(hc, entriesRDD, rvRowType, ISeq("i", "j"))
   }
 }
 
@@ -1560,7 +1561,7 @@ class WriteBlocksRDD(path: String,
   @transient rvd: RVD,
   sc: SparkContext,
   @transient parentPartStarts: Array[Long],
-  entryField: String,
+  entryField: Sym,
   gp: GridPartitioner) extends RDD[(Int, String)](sc, Nil) {
 
   require(gp.nRows == parentPartStarts.last)

--- a/hail/src/main/scala/is/hail/linalg/RowMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/RowMatrix.scala
@@ -2,6 +2,7 @@ package is.hail.linalg
 
 import breeze.linalg.DenseMatrix
 import is.hail.HailContext
+import is.hail.expr.ir.Sym
 import is.hail.expr.types.virtual.{TInt64, TStruct}
 import is.hail.io.InputBuffer
 import is.hail.rvd.RVDPartitioner
@@ -70,7 +71,7 @@ class RowMatrix(val hc: HailContext,
   def partitionStarts(): Array[Long] = partitionCounts().scanLeft(0L)(_ + _)
 
   def partitioner(
-    partitionKey: Array[String] = Array("idx"),
+    partitionKey: IndexedSeq[Sym] = ISeq("idx"),
     kType: TStruct = TStruct("idx" -> TInt64())): RVDPartitioner = {
     
     val partStarts = partitionStarts()

--- a/hail/src/main/scala/is/hail/methods/IBD.scala
+++ b/hail/src/main/scala/is/hail/methods/IBD.scala
@@ -353,7 +353,7 @@ object IBD {
     }
   }
 
-  private[methods] def generateComputeMaf(vds: MatrixTable, fieldName: String): (RegionValue) => Double = {
+  private[methods] def generateComputeMaf(vds: MatrixTable, fieldName: Sym): (RegionValue) => Double = {
     val rvRowType = vds.rvRowType
     val rvRowPType = rvRowType.physicalType
     val field = rvRowType.field(fieldName)

--- a/hail/src/main/scala/is/hail/methods/LinearRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/LinearRegression.scala
@@ -23,13 +23,13 @@ case class LinearRegressionRowsSingle(
   override def typeInfo(childType: MatrixType, childRVDType: RVDType): (TableType, RVDType) = {
     val passThroughType = TStruct(passThrough.map(f => f -> childType.rowType.field(f).typ): _*)
     val schema = TStruct(
-      (I("n"), TInt32()),
-      (I("sum_x"), TFloat64()),
-      (I("y_transpose_x"), TArray(TFloat64())),
-      (I("beta"), TArray(TFloat64())),
-      (I("standard_error"), TArray(TFloat64())),
-      (I("t_stat"), TArray(TFloat64())),
-      (I("p_value"), TArray(TFloat64())))
+      ("n", TInt32()),
+      ("sum_x", TFloat64()),
+      ("y_transpose_x", TArray(TFloat64())),
+      ("beta", TArray(TFloat64())),
+      ("standard_error", TArray(TFloat64())),
+      ("t_stat", TArray(TFloat64())),
+      ("p_value", TArray(TFloat64())))
     val tt = TableType(
       childType.rowKeyStruct ++ passThroughType ++ schema,
       childType.rowKey,
@@ -180,13 +180,13 @@ case class LinearRegressionRowsChained(
   override def typeInfo(childType: MatrixType, childRVDType: RVDType): (TableType, RVDType) = {
     val passThroughType = TStruct(passThrough.map(f => f -> childType.rowType.field(f).typ): _*)
     val chainedSchema = TStruct(
-      (I("n"), TArray(TInt32())),
-      (I("sum_x"), TArray(TFloat64())),
-      (I("y_transpose_x"), TArray(TArray(TFloat64()))),
-      (I("beta"), TArray(TArray(TFloat64()))),
-      (I("standard_error"), TArray(TArray(TFloat64()))),
-      (I("t_stat"), TArray(TArray(TFloat64()))),
-      (I("p_value"), TArray(TArray(TFloat64()))))
+      ("n", TArray(TInt32())),
+      ("sum_x", TArray(TFloat64())),
+      ("y_transpose_x", TArray(TArray(TFloat64()))),
+      ("beta", TArray(TArray(TFloat64()))),
+      ("standard_error", TArray(TArray(TFloat64()))),
+      ("t_stat", TArray(TArray(TFloat64()))),
+      ("p_value", TArray(TArray(TFloat64()))))
     val tt = TableType(
       childType.rowKeyStruct ++ passThroughType ++ chainedSchema,
       childType.rowKey,

--- a/hail/src/main/scala/is/hail/methods/LinearRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/LinearRegression.scala
@@ -4,7 +4,7 @@ import breeze.linalg._
 import breeze.numerics.sqrt
 import is.hail.annotations._
 import is.hail.expr.ir.functions.MatrixToTableFunction
-import is.hail.expr.ir.{MatrixValue, TableValue}
+import is.hail.expr.ir.{I, MatrixValue, Sym, TableValue}
 import is.hail.expr.types._
 import is.hail.expr.types.physical.PStruct
 import is.hail.expr.types.virtual.{TArray, TFloat64, TInt32, TStruct}
@@ -14,22 +14,22 @@ import is.hail.utils._
 import net.sourceforge.jdistlib.T
 
 case class LinearRegressionRowsSingle(
-  yFields: Array[String],
-  xField: String,
-  covFields: Array[String],
+  yFields: Array[Sym],
+  xField: Sym,
+  covFields: Array[Sym],
   rowBlockSize: Int,
-  passThrough: Array[String]) extends MatrixToTableFunction {
+  passThrough: Array[Sym]) extends MatrixToTableFunction {
 
   override def typeInfo(childType: MatrixType, childRVDType: RVDType): (TableType, RVDType) = {
     val passThroughType = TStruct(passThrough.map(f => f -> childType.rowType.field(f).typ): _*)
     val schema = TStruct(
-      ("n", TInt32()),
-      ("sum_x", TFloat64()),
-      ("y_transpose_x", TArray(TFloat64())),
-      ("beta", TArray(TFloat64())),
-      ("standard_error", TArray(TFloat64())),
-      ("t_stat", TArray(TFloat64())),
-      ("p_value", TArray(TFloat64())))
+      (I("n"), TInt32()),
+      (I("sum_x"), TFloat64()),
+      (I("y_transpose_x"), TArray(TFloat64())),
+      (I("beta"), TArray(TFloat64())),
+      (I("standard_error"), TArray(TFloat64())),
+      (I("t_stat"), TArray(TFloat64())),
+      (I("p_value"), TArray(TFloat64())))
     val tt = TableType(
       childType.rowKeyStruct ++ passThroughType ++ schema,
       childType.rowKey,
@@ -171,22 +171,22 @@ case class LinearRegressionRowsSingle(
 }
 
 case class LinearRegressionRowsChained(
-  yFields: Array[Array[String]],
-  xField: String,
-  covFields: Array[String],
+  yFields: Array[Array[Sym]],
+  xField: Sym,
+  covFields: Array[Sym],
   rowBlockSize: Int,
-  passThrough: Array[String]) extends MatrixToTableFunction {
+  passThrough: Array[Sym]) extends MatrixToTableFunction {
 
   override def typeInfo(childType: MatrixType, childRVDType: RVDType): (TableType, RVDType) = {
     val passThroughType = TStruct(passThrough.map(f => f -> childType.rowType.field(f).typ): _*)
     val chainedSchema = TStruct(
-      ("n", TArray(TInt32())),
-      ("sum_x", TArray(TFloat64())),
-      ("y_transpose_x", TArray(TArray(TFloat64()))),
-      ("beta", TArray(TArray(TFloat64()))),
-      ("standard_error", TArray(TArray(TFloat64()))),
-      ("t_stat", TArray(TArray(TFloat64()))),
-      ("p_value", TArray(TArray(TFloat64()))))
+      (I("n"), TArray(TInt32())),
+      (I("sum_x"), TArray(TFloat64())),
+      (I("y_transpose_x"), TArray(TArray(TFloat64()))),
+      (I("beta"), TArray(TArray(TFloat64()))),
+      (I("standard_error"), TArray(TArray(TFloat64()))),
+      (I("t_stat"), TArray(TArray(TFloat64()))),
+      (I("p_value"), TArray(TArray(TFloat64()))))
     val tt = TableType(
       childType.rowKeyStruct ++ passThroughType ++ chainedSchema,
       childType.rowKey,

--- a/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
+++ b/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
@@ -278,7 +278,7 @@ object LocalLDPrune {
   def apply(mt: MatrixTable, callField: String, r2Threshold: Double, windowSize: Int, maxQueueSize: Int): Table =
     apply(mt, IRParser.parseSymbol(callField), r2Threshold, windowSize, maxQueueSize)
 
-  def apply(mt: MatrixTable, callField: Sym = I("GT"), r2Threshold: Double = 0.2, windowSize: Int = 1000000, maxQueueSize: Int): Table = {
+  def apply(mt: MatrixTable, callField: Sym = "GT", r2Threshold: Double = 0.2, windowSize: Int = 1000000, maxQueueSize: Int): Table = {
     if (maxQueueSize < 1)
       fatal(s"Maximum queue size must be positive. Found `$maxQueueSize'.")
 

--- a/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
+++ b/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
@@ -3,6 +3,7 @@ package is.hail.methods
 import java.util
 
 import is.hail.annotations._
+import is.hail.expr.ir.{I, Sym, IRParser}
 import is.hail.expr.types._
 import is.hail.expr.types.physical.{PArray, PInt64Required, PStruct}
 import is.hail.expr.types.virtual._
@@ -274,7 +275,10 @@ object LocalLDPrune {
     })
   }
 
-  def apply(mt: MatrixTable, callField: String = "GT", r2Threshold: Double = 0.2, windowSize: Int = 1000000, maxQueueSize: Int): Table = {
+  def apply(mt: MatrixTable, callField: String, r2Threshold: Double, windowSize: Int, maxQueueSize: Int): Table =
+    apply(mt, IRParser.parseSymbol(callField), r2Threshold, windowSize, maxQueueSize)
+
+  def apply(mt: MatrixTable, callField: Sym = I("GT"), r2Threshold: Double = 0.2, windowSize: Int = 1000000, maxQueueSize: Int): Table = {
     if (maxQueueSize < 1)
       fatal(s"Maximum queue size must be positive. Found `$maxQueueSize'.")
 

--- a/hail/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -2,7 +2,7 @@ package is.hail.methods
 
 import breeze.linalg._
 import is.hail.annotations._
-import is.hail.expr.ir.{TableLiteral, TableValue}
+import is.hail.expr.ir.{IRParser, Sym, TableLiteral, TableValue}
 import is.hail.expr.types.virtual.{TArray, TFloat64, TStruct}
 import is.hail.expr.types.TableType
 import is.hail.stats._
@@ -19,10 +19,20 @@ object LogisticRegression {
     test: String,
     yField: String,
     xField: String,
-    _covFields: java.util.ArrayList[String],
-    _passThrough: java.util.ArrayList[String]): Table = {
-    val covFields = _covFields.asScala.toArray
-    val passThrough = _passThrough.asScala.toArray
+    covFields: java.util.ArrayList[String],
+    passThrough: java.util.ArrayList[String]): Table =
+    LogisticRegression(vsm, test,
+      IRParser.parseSymbol(yField),
+      IRParser.parseSymbol(xField),
+      covFields.asScala.map(IRParser.parseSymbol).toArray,
+      passThrough.asScala.map(IRParser.parseSymbol).toArray)
+
+  def apply(vsm: MatrixTable,
+    test: String,
+    yField: Sym,
+    xField: Sym,
+    covFields: Array[Sym],
+    passThrough: Array[Sym]): Table = {
     val logRegTest = LogisticRegressionTest.tests(test)
 
     val (y, cov, completeColIdx) = RegressionUtils.getPhenoCovCompleteSamples(vsm, yField, covFields)

--- a/hail/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -118,15 +118,26 @@ object LogisticRegression {
   }
 
   def apply(vsm: MatrixTable,
-            test: String,
-            _yFields: java.util.ArrayList[String],
-            xField: String,
-            _covFields: java.util.ArrayList[String],
-            _passThrough: java.util.ArrayList[String]): Table = {
+    test: String,
+    yFields: java.util.ArrayList[String],
+    xField: String,
+    covFields: java.util.ArrayList[String],
+    passThrough: java.util.ArrayList[String]): Table = {
+    apply(vsm,
+      test,
+      yFields.asScala.map(IRParser.parseSymbol).toArray,
+      IRParser.parseSymbol(xField),
+      covFields.asScala.map(IRParser.parseSymbol).toArray,
+      passThrough.asScala.map(IRParser.parseSymbol).toArray)
+  }
 
-    val yFields = _yFields.asScala.toArray
-    val covFields = _covFields.asScala.toArray
-    val passThrough = _passThrough.asScala.toArray
+  def apply(vsm: MatrixTable,
+    test: String,
+    yFields: Array[Sym],
+    xField: Sym,
+    covFields: Array[Sym],
+    passThrough: Array[Sym]): Table = {
+
     val logRegTest = LogisticRegressionTest.tests(test)
     val multiPhenoSchema = TStruct(("logistic_regression", TArray(logRegTest.schema)))
 

--- a/hail/src/main/scala/is/hail/methods/Nirvana.scala
+++ b/hail/src/main/scala/is/hail/methods/Nirvana.scala
@@ -5,7 +5,7 @@ import java.util.Properties
 
 import is.hail.annotations._
 import is.hail.expr.JSONAnnotationImpex
-import is.hail.expr.ir.{TableLiteral, TableValue}
+import is.hail.expr.ir.{I, TableLiteral, TableValue}
 import is.hail.expr.types._
 import is.hail.expr.types.physical.PType
 import is.hail.expr.types.virtual._
@@ -358,7 +358,7 @@ object Nirvana {
   }
 
   def annotate(ht: Table, config: String, blockSize: Int): Table = {
-    assert(ht.key.contains(FastIndexedSeq("locus", "alleles")))
+    assert(ht.key == ISeq(I("locus"), I("alleles")))
     assert(ht.typ.rowType.size == 2)
 
     val properties = try {

--- a/hail/src/main/scala/is/hail/methods/PCA.scala
+++ b/hail/src/main/scala/is/hail/methods/PCA.scala
@@ -2,6 +2,7 @@ package is.hail.methods
 
 import breeze.linalg.{*, DenseMatrix, DenseVector}
 import is.hail.annotations._
+import is.hail.expr.ir.{Sym, IRParser}
 import is.hail.expr.types._
 import is.hail.expr.types.virtual.{TArray, TFloat64, TStruct}
 import is.hail.rvd.RVDContext
@@ -56,8 +57,11 @@ object PCA {
     new Table(hc, scoresRDD, rowType, vsm.colKey)
   }
 
+  def apply(vsm: MatrixTable, entryField: String, k: Int, computeLoadings: Boolean): (IndexedSeq[Double], DenseMatrix[Double], Option[Table]) =
+    apply(vsm, IRParser.parseSymbol(entryField), k, computeLoadings)
+
   // returns (eigenvalues, sample scores, optional variant loadings)
-  def apply(vsm: MatrixTable, entryField: String, k: Int, computeLoadings: Boolean): (IndexedSeq[Double], DenseMatrix[Double], Option[Table]) = {
+  def apply(vsm: MatrixTable, entryField: Sym, k: Int, computeLoadings: Boolean): (IndexedSeq[Double], DenseMatrix[Double], Option[Table]) = {
     if (k < 1)
       fatal(s"""requested invalid number of components: $k
                |  Expect componenents >= 1""".stripMargin)

--- a/hail/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/hail/src/main/scala/is/hail/methods/PCRelate.scala
@@ -9,6 +9,7 @@ import is.hail.table.Table
 import is.hail.utils._
 import is.hail.variant.{Call, HardCallView, MatrixTable}
 import is.hail.HailContext
+import is.hail.expr.ir.Sym
 import is.hail.expr.types.virtual._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.mllib.linalg.Vectors
@@ -43,7 +44,7 @@ object PCRelate {
       ("ibd1", TFloat64()),
       ("ibd2", TFloat64()))
 
-  private val keys: IndexedSeq[String] = Array("i", "j")
+  private val keys: IndexedSeq[Sym] = ISeq("i", "j")
 
   def apply(
     hc: HailContext,
@@ -80,12 +81,12 @@ object PCRelate {
     val result = new PCRelate(maf, blockSize, statistics, defaultStorageLevel)(hc, blockedG, pcs)
 
     val irFields = Array(
-      "i" -> "(Apply `[]` (GetField sample_ids (Ref global)) (GetField i (Ref row)))",
-      "j" -> "(Apply `[]` (GetField sample_ids (Ref global)) (GetField j (Ref row)))",
-      "kin" -> "(GetField kin (Ref row))",
-      "ibd0" -> "(GetField ibd0 (Ref row))",
-      "ibd1" -> "(GetField ibd1 (Ref row))",
-      "ibd2" -> "(GetField ibd2 (Ref row))"
+      "i" -> "(Apply `[]` (GetField sample_ids (Ref :global)) (GetField i (Ref :row)))",
+      "j" -> "(Apply `[]` (GetField sample_ids (Ref :global)) (GetField j (Ref :row)))",
+      "kin" -> "(GetField kin (Ref :row))",
+      "ibd0" -> "(GetField ibd0 (Ref :row))",
+      "ibd1" -> "(GetField ibd1 (Ref :row))",
+      "ibd2" -> "(GetField ibd2 (Ref :row))"
     ).map { case (name, expr) => s"($name $expr)" }
     val irExpr = s"(MakeStruct ${irFields.mkString(" ")})"
 

--- a/hail/src/main/scala/is/hail/methods/PoissonRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/PoissonRegression.scala
@@ -2,7 +2,7 @@ package is.hail.methods
 
 import breeze.linalg._
 import is.hail.annotations._
-import is.hail.expr.ir.{TableLiteral, TableValue}
+import is.hail.expr.ir.{IRParser, Sym, TableLiteral, TableValue}
 import is.hail.expr.types.virtual.{TFloat64, TStruct}
 import is.hail.expr.types.TableType
 import is.hail.stats._
@@ -19,12 +19,21 @@ object PoissonRegression {
     test: String,
     yField: String,
     xField: String,
-    _covFields: java.util.ArrayList[String],
-    _passThrough: java.util.ArrayList[String]): Table = {
-    val covFields = _covFields.asScala.toArray
-    val passThrough = _passThrough.asScala.toArray
+    covFields: java.util.ArrayList[String],
+    passThrough: java.util.ArrayList[String]): Table =
+    PoissonRegression(vsm, test,
+      IRParser.parseSymbol(yField),
+      IRParser.parseSymbol(xField),
+      covFields.asScala.map(IRParser.parseSymbol).toArray,
+      passThrough.asScala.map(IRParser.parseSymbol).toArray)
 
-    val poisRegTest = PoissonRegressionTest.tests(test)
+    def apply(vsm: MatrixTable,
+      test: String,
+      yField: Sym,
+      xField: Sym,
+      covFields: Array[Sym],
+      passThrough: Array[Sym]): Table = {
+        val poisRegTest = PoissonRegressionTest.tests(test)
 
     val (y, cov, completeColIdx) = RegressionUtils.getPhenoCovCompleteSamples(vsm, yField, covFields)
 

--- a/hail/src/main/scala/is/hail/methods/Skat.scala
+++ b/hail/src/main/scala/is/hail/methods/Skat.scala
@@ -217,13 +217,13 @@ object Skat {
     val skatRdd = if (logistic) logisticSkat() else linearSkat()
     
     val skatSignature = TStruct(
-      (I("id"), keyType),
-      (I("size"), TInt32()),
-      (I("q_stat"), TFloat64()),
-      (I("p_value"), TFloat64()),
-      (I("fault"), TInt32()))
+      ("id", keyType),
+      ("size", TInt32()),
+      ("q_stat", TFloat64()),
+      ("p_value", TFloat64()),
+      ("fault", TInt32()))
 
-    Table(vsm.hc, skatRdd, skatSignature, FastIndexedSeq(I("id")))
+    Table(vsm.hc, skatRdd, skatSignature, ISeq("id"))
   }
 
   def computeKeyGsWeightRdd(vsm: MatrixTable,

--- a/hail/src/main/scala/is/hail/methods/VEP.scala
+++ b/hail/src/main/scala/is/hail/methods/VEP.scala
@@ -3,7 +3,7 @@ package is.hail.methods
 import com.fasterxml.jackson.core.JsonParseException
 import is.hail.annotations._
 import is.hail.expr._
-import is.hail.expr.ir.{TableLiteral, TableValue}
+import is.hail.expr.ir.{I, TableLiteral, TableValue}
 import is.hail.expr.types._
 import is.hail.expr.types.virtual._
 import is.hail.rvd.{RVD, RVDContext}
@@ -87,7 +87,7 @@ object VEP {
   }
 
   def annotate(ht: Table, config: String, csq: Boolean, blockSize: Int): Table = {
-    assert(ht.key == FastIndexedSeq("locus", "alleles"))
+    assert(ht.key == ISeq(I("locus"), I("alleles")))
     assert(ht.typ.rowType.size == 2)
 
     val conf = readConfiguration(ht.hc.hadoopConf, config)
@@ -224,7 +224,7 @@ object VEP {
         (Row(), TStruct())
 
     new Table(ht.hc, TableLiteral(TableValue(
-      TableType(vepRowType.virtualType, FastIndexedSeq("locus", "alleles"), globalType),
+      TableType(vepRowType.virtualType, ISeq("locus", "alleles"), globalType),
       BroadcastRow(globalValue, globalType, ht.hc.sc),
       vepRVD)))
   }

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -5,6 +5,7 @@ import is.hail.annotations._
 import is.hail.compatibility.UnpartitionedRVDSpec
 import is.hail.cxx
 import is.hail.expr.JSONAnnotationImpex
+import is.hail.expr.ir.Sym
 import is.hail.expr.types.virtual._
 import is.hail.expr.types.physical.PStruct
 import is.hail.expr.types.virtual.{TStruct, TStructSerializer}
@@ -92,7 +93,7 @@ object AbstractRVDSpec {
 
 object OrderedRVDSpec {
   def apply(rowType: PStruct,
-    key: IndexedSeq[String],
+    key: IndexedSeq[Sym],
     codecSpec: CodecSpec,
     partFiles: Array[String],
     partitioner: RVDPartitioner): AbstractRVDSpec = {
@@ -113,7 +114,7 @@ case class OrderedRVDSpec(
   partFiles: Array[String],
   jRangeBounds: JValue
 ) extends AbstractRVDSpec {
-  def key: IndexedSeq[String] = rvdType.key
+  def key: IndexedSeq[Sym] = rvdType.key
 
   override def encodedType: PStruct = rvdType.rowType
 
@@ -139,7 +140,7 @@ abstract class AbstractRVDSpec {
   // FIXME introduce EType
   def encodedType: PStruct
 
-  def key: IndexedSeq[String]
+  def key: IndexedSeq[Sym]
 
   def partFiles: Array[String]
 

--- a/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
@@ -1,7 +1,7 @@
 package is.hail.rvd
 
 import is.hail.annotations.ExtendedOrdering
-import is.hail.expr.types._
+import is.hail.expr.ir.Sym
 import is.hail.expr.types.virtual.{TArray, TInterval, TStruct}
 import is.hail.utils._
 import org.apache.spark.sql.Row
@@ -27,7 +27,7 @@ class RVDPartitioner(
   ) = this(kType, rangeBounds.toArray, kType.size)
 
   def this(
-    partitionKey: Array[String],
+    partitionKey: IndexedSeq[Sym],
     kType: TStruct,
     rangeBounds: IndexedSeq[Interval]
   ) = this(kType, rangeBounds.toArray, math.max(partitionKey.length - 1, 0))
@@ -176,7 +176,7 @@ class RVDPartitioner(
     new RVDPartitioner(kType, ab.result())
   }
 
-  def rename(nameMap: Map[String, String]): RVDPartitioner = new RVDPartitioner(
+  def rename(nameMap: Map[Sym, Sym]): RVDPartitioner = new RVDPartitioner(
     kType.rename(nameMap),
     rangeBounds,
     allowedOverlap
@@ -292,7 +292,7 @@ object RVDPartitioner {
     generate(kType.fieldNames, kType, intervals)
 
   def generate(
-    partitionKey: IndexedSeq[String],
+    partitionKey: IndexedSeq[Sym],
     kType: TStruct,
     intervals: IndexedSeq[Interval]
   ): RVDPartitioner = {

--- a/hail/src/main/scala/is/hail/stats/RegressionUtils.scala
+++ b/hail/src/main/scala/is/hail/stats/RegressionUtils.scala
@@ -3,7 +3,7 @@ package is.hail.stats
 import breeze.linalg._
 import is.hail.annotations.RegionValue
 import is.hail.expr._
-import is.hail.expr.ir.MatrixValue
+import is.hail.expr.ir.{MatrixValue, Sym}
 import is.hail.expr.types._
 import is.hail.expr.types.physical.{PArray, PStruct}
 import is.hail.expr.types.virtual.TFloat64
@@ -56,7 +56,7 @@ object RegressionUtils {
   }
 
   // IndexedSeq indexed by column, Array by field
-  def getColumnVariables(mv: MatrixValue, names: Array[String]): IndexedSeq[Array[Option[Double]]] = {
+  def getColumnVariables(mv: MatrixValue, names: Array[Sym]): IndexedSeq[Array[Option[Double]]] = {
     val colType = mv.typ.colType
     assert(names.forall(name => mv.typ.colType.field(name).typ.isOfType(TFloat64())))
     val fieldIndices = names.map { name =>
@@ -74,8 +74,8 @@ object RegressionUtils {
 
   def getPhenoCovCompleteSamples(
     vsm: MatrixTable,
-    yField: String,
-    covFields: Array[String]): (DenseVector[Double], DenseMatrix[Double], Array[Int]) = {
+    yField: Sym,
+    covFields: Array[Sym]): (DenseVector[Double], DenseMatrix[Double], Array[Int]) = {
 
     val (y, covs, completeSamples) = getPhenosCovCompleteSamples(vsm, Array(yField), covFields)
 
@@ -84,13 +84,13 @@ object RegressionUtils {
 
   def getPhenosCovCompleteSamples(
     vsm: MatrixTable,
-    yFields: Array[String],
-    covFields: Array[String]): (DenseMatrix[Double], DenseMatrix[Double], Array[Int]) = getPhenosCovCompleteSamples(vsm.value, yFields, covFields)
+    yFields: Array[Sym],
+    covFields: Array[Sym]): (DenseMatrix[Double], DenseMatrix[Double], Array[Int]) = getPhenosCovCompleteSamples(vsm.value, yFields, covFields)
 
   def getPhenosCovCompleteSamples(
     mv: MatrixValue,
-    yFields: Array[String],
-    covFields: Array[String]): (DenseMatrix[Double], DenseMatrix[Double], Array[Int]) = {
+    yFields: Array[Sym],
+    covFields: Array[Sym]): (DenseMatrix[Double], DenseMatrix[Double], Array[Int]) = {
 
     val nPhenos = yFields.length
     val nCovs = covFields.length

--- a/hail/src/main/scala/is/hail/stats/package.scala
+++ b/hail/src/main/scala/is/hail/stats/package.scala
@@ -404,9 +404,9 @@ package object stats {
 
     MatrixTable.fromLegacy(hc, MatrixType.fromParts(
       globalType = TStruct.empty(),
-      colKey = Array("s"),
+      colKey = ISeq("s"),
       colType = TStruct("s" -> TString()),
-      rowKey = Array("locus", "alleles"),
+      rowKey = ISeq("locus", "alleles"),
       rowType = TStruct("locus" -> TLocus(ReferenceGenome.defaultReference),
         "alleles" -> TArray(TString())),
       entryType = Genotype.htsGenotypeType),
@@ -438,9 +438,9 @@ package object stats {
 
     MatrixTable.fromLegacy(hc, MatrixType.fromParts(
       globalType = TStruct.empty(),
-      colKey = Array("s"),
+      colKey = ISeq("s"),
       colType = TStruct("s" -> TString()),
-      rowKey = Array("locus", "alleles"),
+      rowKey = ISeq("locus", "alleles"),
       rowType = TStruct("locus" -> TLocus(ReferenceGenome.defaultReference),
         "alleles" -> TArray(TString())),
       entryType = TStruct(

--- a/hail/src/main/scala/is/hail/table/package.scala
+++ b/hail/src/main/scala/is/hail/table/package.scala
@@ -1,7 +1,9 @@
 package is.hail
 
-package object table {
-  def asc(field: String): SortField = SortField(field, Ascending)
+import is.hail.expr.ir.Sym
 
-  def desc(field: String): SortField = SortField(field, Descending)
+package object table {
+  def asc(field: Sym): SortField = SortField(field, Ascending)
+
+  def desc(field: Sym): SortField = SortField(field, Descending)
 }

--- a/hail/src/main/scala/is/hail/utils/Graph.scala
+++ b/hail/src/main/scala/is/hail/utils/Graph.scala
@@ -1,7 +1,7 @@
 package is.hail.utils
 
 import is.hail.annotations.{Region, RegionValueBuilder, SafeRow}
-import is.hail.expr.ir.{Compile, MakeTuple, IRParserEnvironment, IRParser}
+import is.hail.expr.ir.{Compile, I, IRParser, IRParserEnvironment, MakeTuple}
 import is.hail.expr.types.physical.PBaseStruct
 import is.hail.expr.types.virtual.{TInt64, TTuple, Type}
 import org.apache.spark.sql.Row
@@ -46,7 +46,7 @@ object Graph {
       warn(s"over 400,000 edges are in the graph; maximal_independent_set may run out of memory")
 
     val wrappedNodeType = TTuple(nodeType)
-    val refMap = Map("l" -> wrappedNodeType, "r" -> wrappedNodeType)
+    val refMap = Map(I("l") -> wrappedNodeType, I("r") -> wrappedNodeType)
 
     val tieBreakerF = tieBreaker.map { e =>
       val ir = IRParser.parse_value_ir(e, IRParserEnvironment(refMap))

--- a/hail/src/main/scala/is/hail/utils/ISeq.scala
+++ b/hail/src/main/scala/is/hail/utils/ISeq.scala
@@ -1,0 +1,16 @@
+package is.hail.utils
+
+import scala.collection.mutable
+import scala.reflect.ClassTag
+
+object ISeq {
+  def empty[T](implicit tct: ClassTag[T]): IndexedSeq[T] = FastIndexedSeq()
+
+  def apply[T](args: T*)(implicit tct: ClassTag[T]): IndexedSeq[T] = {
+    args match {
+      case args: mutable.WrappedArray[T] => args
+      case args: mutable.ArrayBuffer[T] => args
+      case _ => args.toArray[T]
+    }
+  }
+}

--- a/hail/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/hail/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -4,6 +4,7 @@ import java.io.{InputStream, OutputStream}
 
 import is.hail.HailContext
 import is.hail.expr.JSONAnnotationImpex
+import is.hail.expr.ir.{IRLexer, Sym}
 import is.hail.expr.types.virtual.Type
 import is.hail.table.Table
 import is.hail.variant.MatrixTable
@@ -133,25 +134,27 @@ trait Py4jUtils {
     error(msg)
   }
 
-  def joinGlobals(left: Table, right: Table, identifier: String): Table = {
+  def joinGlobals(left: Table, right: Table, identifier: Sym): Table = {
     left.annotateGlobal(right.globals.value, right.globalSignature, identifier)
   }
 
-  def joinGlobals(left: Table, right: MatrixTable, identifier: String): Table = {
+  def joinGlobals(left: Table, right: MatrixTable, identifier: Sym): Table = {
     left.annotateGlobal(right.globals.value, right.globalType, identifier)
   }
 
-  def joinGlobals(left: MatrixTable, right: Table, identifier: String): MatrixTable = {
+  def joinGlobals(left: MatrixTable, right: Table, identifier: Sym): MatrixTable = {
     left.annotateGlobal(right.globals.value, right.globalSignature, identifier)
   }
 
-  def joinGlobals(left: MatrixTable, right: MatrixTable, identifier: String): MatrixTable = {
+  def joinGlobals(left: MatrixTable, right: MatrixTable, identifier: Sym): MatrixTable = {
     left.annotateGlobal(right.globals.value, right.globalType, identifier)
   }
 
   def escapePyString(s: String): String = StringEscapeUtils.escapeString(s)
 
   def escapeIdentifier(s: String): String = prettyIdentifier(s)
+
+  def unescapeIdentifier(s: String): String = IRLexer.parseIdentifier(s)
 
   def fileExists(hc: HailContext, path: String): Boolean = hc.hadoopConf.exists(path) && hc.hadoopConf.isFile(path)
 

--- a/hail/src/main/scala/is/hail/utils/TextTableReader.scala
+++ b/hail/src/main/scala/is/hail/utils/TextTableReader.scala
@@ -4,7 +4,7 @@ import java.util.regex.Pattern
 
 import is.hail.HailContext
 import is.hail.expr._
-import is.hail.expr.ir.TableImport
+import is.hail.expr.ir.{Sym, TableImport}
 import is.hail.expr.types._
 import is.hail.expr.types.virtual._
 import is.hail.table.Table
@@ -194,8 +194,8 @@ object TextTableReader {
   }
 
   def read(hc: HailContext)(files: Array[String],
-    types: Map[String, Type] = Map.empty[String, Type],
-    comment: Array[String] = Array.empty[String],
+    types: Map[Sym, Type] = Map.empty,
+    comment: Array[String] = Array.empty,
     separator: String = "\t",
     missing: String = "NA",
     noHeader: Boolean = false,

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichIterable.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichIterable.scala
@@ -83,4 +83,6 @@ class RichIterable[T](val i: Iterable[T]) extends Serializable {
       case _ => i.toArray[T]
     }
   }
+
+  def toISeq(implicit tct: ClassTag[T]): IndexedSeq[T] = toFastIndexedSeq
 }

--- a/hail/src/main/scala/is/hail/variant/HardCallView.scala
+++ b/hail/src/main/scala/is/hail/variant/HardCallView.scala
@@ -1,6 +1,7 @@
 package is.hail.variant
 
 import is.hail.annotations.{Region, RegionValue}
+import is.hail.expr.ir.{EntriesSym, I, Sym}
 import is.hail.expr.types._
 import is.hail.expr.types.physical._
 
@@ -9,11 +10,11 @@ object ArrayGenotypeView {
 }
 
 final class ArrayGenotypeView(rvType: PStruct) {
-  private val entriesIndex = rvType.fieldByName(MatrixType.entriesIdentifier).index
+  private val entriesIndex = rvType.fieldByName(EntriesSym).index
   private val tgs = rvType.types(entriesIndex).asInstanceOf[PArray]
   private val tg = tgs.elementType.asInstanceOf[PStruct]
 
-  private def lookupField(name: String, expected: PType): (Boolean, Int) = {
+  private def lookupField(name: Sym, expected: PType): (Boolean, Int) = {
     tg.selfField(name) match {
       case Some(f) =>
         if (f.typ == expected)
@@ -74,16 +75,16 @@ final class ArrayGenotypeView(rvType: PStruct) {
 
 object HardCallView {
   def apply(rowSignature: PStruct): HardCallView = {
-    new HardCallView(rowSignature, "GT")
+    new HardCallView(rowSignature, I("GT"))
   }
 }
 
-final class HardCallView(rvType: PStruct, callField: String) {
-  private val entriesIndex = rvType.fieldByName(MatrixType.entriesIdentifier).index
+final class HardCallView(rvType: PStruct, callField: Sym) {
+  private val entriesIndex = rvType.fieldByName(EntriesSym).index
   private val tgs = rvType.types(entriesIndex).asInstanceOf[PArray]
   private val tg = tgs.elementType.asInstanceOf[PStruct]
 
-  private def lookupField(name: String, expected: PType): (Boolean, Int) = {
+  private def lookupField(name: Sym, expected: PType): (Boolean, Int) = {
     tg.selfField(name) match {
       case Some(f) =>
         if (f.typ == expected)

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -216,7 +216,7 @@ object TestUtils {
 
     val argsType = TTuple(inputTypesB.result(): _*)
     val resultType = TTuple(x.typ)
-    val argsVar = genUID()
+    val argsVar = genSym("args")
 
     val (_, substEnv) = env.m.foldLeft((args.length, Env.empty[IR])) { case ((i, env), (name, (v, t))) =>
       (i + 1, env.bind(name, GetTupleElement(In(0, argsType), i)))

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -278,7 +278,7 @@ object TestUtils {
 
     val argsType = TTuple(inputTypesB.result(): _*)
     val resultType = TTuple(x.typ)
-    val argsVar = genUID()
+    val argsVar = genSym("args")
 
     val (_, substEnv) = env.m.foldLeft((args.length, Env.empty[IR])) { case ((i, env), (name, (v, t))) =>
       (i + 1, env.bind(name, GetTupleElement(Ref(argsVar, argsType), i)))
@@ -295,7 +295,7 @@ object TestUtils {
 
     agg match {
       case Some((aggElements, aggType)) =>
-        val aggVar = genUID()
+        val aggVar = genSym("agg")
         val substAggEnv = aggType.fields.foldLeft(Env.empty[IR]) { case (env, f) =>
             env.bind(f.name, GetField(Ref(aggVar, aggType), f.name))
         }
@@ -303,12 +303,12 @@ object TestUtils {
           argsVar, argsType.physicalType,
           argsVar, argsType.physicalType,
           aggVar, aggType.physicalType,
-          MakeTuple(FastSeq(rewrite(Subst(x, substEnv, substAggEnv)))), "AGGR",
+          MakeTuple(FastSeq(rewrite(Subst(x, substEnv, substAggEnv)))), AGGRSym,
           (i, x) => x,
           (i, x) => x)
 
         val (resultType2, f) = Compile[Long, Long, Long](
-          "AGGR", aggResultType,
+          AGGRSym, aggResultType,
           argsVar, argsType.physicalType,
           postAggIR)
         assert(resultType2.virtualType == resultType)
@@ -517,7 +517,7 @@ object TestUtils {
     headerFile: Option[String] = None,
     nPartitions: Option[Int] = None,
     dropSamples: Boolean = false,
-    callFields: Set[String] = Set.empty[String],
+    callFields: Set[Sym] = Set.empty[Sym],
     rg: Option[ReferenceGenome] = Some(ReferenceGenome.defaultReference),
     contigRecoding: Option[Map[String, String]] = None,
     arrayElementsRequired: Boolean = true,

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -878,7 +878,7 @@ class IRSuite extends SparkSuite {
         TableRange(100, 10),
         TableUnion(
           FastIndexedSeq(TableRange(100, 10), TableRange(50, 10))),
-        TableExplode(read, Array("mset")),
+        TableExplode(read, ISeq("mset")),
         TableOrderBy(TableKeyBy(read, FastIndexedSeq()), FastIndexedSeq(SortField("m", Ascending), SortField("m", Descending))),
         CastMatrixToTable(mtRead, " # entries", " # cols"),
         TableRename(read, Map(I("idx") -> I("idx_foo")), Map(I("global_f32") -> I("global_foo")))

--- a/hail/src/test/scala/is/hail/expr/ir/InterpretSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/InterpretSuite.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir
 
-import is.hail.utils.{FastIndexedSeq, FastSeq}
+import is.hail.utils.{FastIndexedSeq, FastSeq, ISeq}
 import is.hail.TestUtils._
 import is.hail.expr.types.virtual._
 import org.apache.spark.sql.Row
@@ -23,11 +23,11 @@ class InterpretSuite {
   private val t = True()
   private val f = False()
 
-  private val arr = MakeArray(List(I32(1), I32(5), I32(2), NA(TInt32())), TArray(TInt32()))
+  private val arr = MakeArray(ISeq(I32(1), I32(5), I32(2), NA(TInt32())), TArray(TInt32()))
 
-  private val struct = MakeStruct(List("a" -> i32, "b" -> f32, "c" -> ArrayRange(I32(0), I32(5), I32(1))))
+  private val struct = MakeStruct(NamedIRSeq("a" -> i32, "b" -> f32, "c" -> ArrayRange(I32(0), I32(5), I32(1))))
 
-  private val tuple = MakeTuple(List(i32, f32, ArrayRange(I32(0), I32(5), I32(1))))
+  private val tuple = MakeTuple(ISeq(i32, f32, ArrayRange(I32(0), I32(5), I32(1))))
 
   @Test def testUnaryPrimOp() {
     assertEvalSame(t)
@@ -256,7 +256,7 @@ class InterpretSuite {
   }
 
   @Test def testInsertFields() {
-    assertEvalSame(InsertFields(struct, List("a" -> f64, "bar" -> i32)))
+    assertEvalSame(InsertFields(struct, NamedIRSeq("a" -> f64, "bar" -> i32)))
   }
 
   @Test def testGetField() {

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -124,7 +124,7 @@ class PruneSuite extends SparkSuite {
       split.tail.foreach { field =>
         ir = GetField(ir, field)
       }
-      let = Let(genUID(), ir, let)
+      let = Let(genSym("t"), ir, let)
     }
     let
   }
@@ -147,7 +147,7 @@ class PruneSuite extends SparkSuite {
       split.tail.foreach { field =>
         ir = GetField(ir, field)
       }
-      let = Let(genUID(), ir, let)
+      let = Let(genSym("t"), ir, let)
     }
     let
   }

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -255,7 +255,7 @@ class PruneSuite extends SparkSuite {
   }
 
   @Test def testTableExplodeMemo() {
-    val te = TableExplode(tab, Array("2"))
+    val te = TableExplode(tab, ISeq("2"))
     checkMemo(te, subsetTable(te.typ), Array(subsetTable(tab.typ, "row.2")))
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
@@ -57,8 +57,8 @@ class RandomFunctionsSuite extends SparkSuite {
 
   def mapped2(n: Int, npart: Int) = TableMapRows(
     TableRange(n, npart),
-    InsertFields(Ref("row", TableRange(1, 1).typ.rowType),
-      FastSeq(
+    InsertFields(Ref(RowSym, TableRange(1, 1).typ.rowType),
+      ISeq[(String, IR)](
         "pi" -> partitionIdx,
         "counter" -> counter)))
 
@@ -71,7 +71,7 @@ class RandomFunctionsSuite extends SparkSuite {
 
     val joined = TableJoin(
       mapped2(10, 4),
-      TableRename(mapped2(10, 3), Map("pi" -> "pi2", "counter" -> "counter2"), Map.empty),
+      TableRename(mapped2(10, 3), Map(I("pi") -> I("pi2"), I("counter") -> I("counter2")), Map.empty),
       "left")
 
     val expected = asArray(mapped2(10, 4)).zip(asArray(mapped2(10, 3)))
@@ -124,11 +124,11 @@ class RandomFunctionsSuite extends SparkSuite {
       TableHead(
         TableMapRows(
           TableRange(10, 3),
-          Ref("row", TableRange(1, 1).typ.rowType)),
+          Ref(RowSym, TableRange(1, 1).typ.rowType)),
         5L),
       InsertFields(
-        Ref("row", TableRange(1, 1).typ.rowType),
-        FastSeq(
+        Ref(RowSym, TableRange(1, 1).typ.rowType),
+        NamedIRSeq(
           "pi" -> partitionIdx,
           "counter" -> counter)))
 

--- a/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
@@ -14,7 +14,7 @@ class SimplifySuite extends SparkSuite {
     val range = TableKeyBy(TableRange(10, 3), FastIndexedSeq())
     val simplifiableIR =
       If(True(),
-        GetField(Ref("row", range.typ.rowType), "idx").ceq(0),
+        GetField(Ref(RowSym, range.typ.rowType), "idx").ceq(0),
         False())
     val checksRepartitioningIR =
       TableFilter(

--- a/hail/src/test/scala/is/hail/io/ExportVCFSuite.scala
+++ b/hail/src/test/scala/is/hail/io/ExportVCFSuite.scala
@@ -4,6 +4,7 @@ import is.hail.{SparkSuite, TestUtils}
 import is.hail.annotations.Annotation
 import is.hail.check.Gen
 import is.hail.check.Prop._
+import is.hail.expr.ir.{I, Sym}
 import is.hail.expr.types._
 import is.hail.expr.types.virtual._
 import is.hail.io.vcf.ExportVCF

--- a/hail/src/test/scala/is/hail/methods/LocalLDPruneSuite.scala
+++ b/hail/src/test/scala/is/hail/methods/LocalLDPruneSuite.scala
@@ -5,6 +5,7 @@ import is.hail.{SparkSuite, TestUtils}
 import is.hail.annotations.{Annotation, Region, RegionValue, RegionValueBuilder}
 import is.hail.check.Prop._
 import is.hail.check.{Gen, Properties}
+import is.hail.expr.ir.EntriesSym
 import is.hail.expr.types._
 import is.hail.expr.types.virtual.{TArray, TLocus, TString, TStruct}
 import is.hail.variant._
@@ -50,7 +51,7 @@ object LocalLDPruneSuite {
   val rvRowType = TStruct(
     "locus" -> ReferenceGenome.GRCh37.locusType,
     "alleles" -> TArray(TString()),
-    MatrixType.entriesIdentifier -> TArray(Genotype.htsGenotypeType)
+    EntriesSym -> TArray(Genotype.htsGenotypeType)
   )
 
   val bitPackedVectorViewType = BitPackedVectorView.rvRowType(rvRowType.field("locus").typ,

--- a/hail/src/test/scala/is/hail/methods/LogisticRegressionTest.scala
+++ b/hail/src/test/scala/is/hail/methods/LogisticRegressionTest.scala
@@ -3,24 +3,11 @@ package is.hail.methods
 import java.util
 
 import is.hail.{SparkSuite, TestUtils}
-import is.hail.annotations.Annotation
-import is.hail.check.Prop._
-import is.hail.check.{Gen, Properties}
-import is.hail.expr.ir.{F64,I32, GetField, InsertFields, MatrixMapCols, Ref}
-import is.hail.expr.ir.TestUtils.IRScanCollect
-import is.hail.expr.types._
-import is.hail.expr.types.virtual.{TFloat64, TInt32, TString}
-import is.hail.io.vcf.ExportVCF
-import is.hail.utils.AbsoluteFuzzyComparable._
-import is.hail.utils.{AbsoluteFuzzyComparable, TextTableReader, _}
+import is.hail.expr.ir.{ColSym, GetField, I, InsertFields, MatrixMapCols, NamedIRSeq, Ref, SymTypeMap}
+import is.hail.expr.types.virtual.{TInt32, TString}
+import is.hail.utils.{FastIndexedSeq, ISeq}
 import is.hail.variant._
-import org.apache.spark.sql.Row
 import org.testng.annotations.Test
-import is.hail.table.Table
-
-
-
-
 
 class LogisticRegressionTest extends SparkSuite {
 
@@ -28,13 +15,13 @@ class LogisticRegressionTest extends SparkSuite {
     hc.indexBgen(FastIndexedSeq("src/test/resources/example.8bits.bgen"), rg = Some("GRCh37"), contigRecoding = Map("01" -> "1"))
     val mt: MatrixTable = TestUtils.importBgens(hc, FastIndexedSeq("src/test/resources/example.8bits.bgen"),
       includeDosage = true)//TestUtils.importVCF(hc, "src/test/resources/regressionLogistic.vcf")
-    val covs = hc.importTable("src/test/resources/regressionLogisticMultiPheno.cov", impute = true).keyBy(Array("Sample"))
-    val pt = hc.importTable("src/test/resources/regressionLogisticMultiPheno.pheno",types = Map("Sample" -> TString(),
-      "Pheno1" -> TInt32(), "Pheno2" -> TInt32()), keyNames=Some(Array("Sample")))
+    val covs = hc.importTable("src/test/resources/regressionLogisticMultiPheno.cov", impute = true).keyBy(ISeq("Sample"))
+    val pt = hc.importTable("src/test/resources/regressionLogisticMultiPheno.pheno",types = SymTypeMap("Sample" -> TString(),
+      "Pheno1" -> TInt32(), "Pheno2" -> TInt32()), keyNames=Some(ISeq("Sample")))
     val mt2 = mt.annotateColsTable(pt,"p")
     val mt3 = mt2.annotateColsTable(covs,"c").cache()
-    val oldCol = Ref("sa", mt3.colType)
-    val newCol = InsertFields(oldCol, Seq("Pheno1" -> GetField(GetField(oldCol, "p"), "Pheno1").toD,
+    val oldCol = Ref(ColSym, mt3.colType)
+    val newCol = InsertFields(oldCol, NamedIRSeq("Pheno1" -> GetField(GetField(oldCol, "p"), "Pheno1").toD,
                                           "Cov1" -> GetField(GetField(oldCol, "c"), "Cov1").toD,
                                           "Cov2" -> GetField(GetField(oldCol, "c"), "Cov2").toD))
     val newMatrixIR = MatrixMapCols(mt3.ast, newCol, None)
@@ -46,21 +33,21 @@ class LogisticRegressionTest extends SparkSuite {
     covFields.add("Cov2")
     val res = LogisticRegression(newMatrix, "wald", "Pheno1", "dosage", covFields, passFields)
     assert(res.count() > 0, "expecting more than zero results")
-    assert(res.typ.rowType.fieldNames.contains("p_value"),"expecting result table to have p_value")
-    assert(res.typ.rowType.fieldNames.contains("beta"), "expecting result table to have beta")
+    assert(res.typ.rowType.fieldNames.contains(I("p_value")),"expecting result table to have p_value")
+    assert(res.typ.rowType.fieldNames.contains(I("beta")), "expecting result table to have beta")
   }
 
   @Test def testLogisticRegressionMultiPhenotype() {
     hc.indexBgen(FastIndexedSeq("src/test/resources/example.8bits.bgen"), rg = Some("GRCh37"), contigRecoding = Map("01" -> "1"))
     val mt: MatrixTable = TestUtils.importBgens(hc, FastIndexedSeq("src/test/resources/example.8bits.bgen"),
       includeDosage = true)//TestUtils.importVCF(hc, "src/test/resources/regressionLogistic.vcf")
-    val covs = hc.importTable("src/test/resources/regressionLogisticMultiPheno.cov", impute = true).keyBy(Array("Sample"))
-    val pt = hc.importTable("src/test/resources/regressionLogisticMultiPheno.pheno",types = Map("Sample" -> TString(),
-      "Pheno1" -> TInt32(), "Pheno2" -> TInt32()), keyNames=Some(Array("Sample")))
+    val covs = hc.importTable("src/test/resources/regressionLogisticMultiPheno.cov", impute = true).keyBy(ISeq("Sample"))
+    val pt = hc.importTable("src/test/resources/regressionLogisticMultiPheno.pheno",types = SymTypeMap("Sample" -> TString(),
+      "Pheno1" -> TInt32(), "Pheno2" -> TInt32()), keyNames=Some(ISeq("Sample")))
     val mt2 = mt.annotateColsTable(pt,"p")
     val mt3 = mt2.annotateColsTable(covs,"c").cache()
-    val oldCol = Ref("sa", mt3.colType)
-    val newCol = InsertFields(oldCol, Seq("Pheno1" -> GetField(GetField(oldCol, "p"), "Pheno1").toD,
+    val oldCol = Ref(ColSym, mt3.colType)
+    val newCol = InsertFields(oldCol, NamedIRSeq("Pheno1" -> GetField(GetField(oldCol, "p"), "Pheno1").toD,
       "Pheno2" -> GetField(GetField(oldCol, "p"), "Pheno2").toD,
       "Cov1" -> GetField(GetField(oldCol, "c"), "Cov1").toD,
       "Cov2" -> GetField(GetField(oldCol, "c"), "Cov2").toD))
@@ -76,6 +63,6 @@ class LogisticRegressionTest extends SparkSuite {
     pheFields.add("Pheno2")
     val res = LogisticRegression(newMatrix, "wald", pheFields, "dosage", covFields, passFields)
     assert(res.count() > 0, "expecting more than zero results")
-    assert(res.typ.rowType.fieldNames.contains("logistic_regression"),"expecting result table to have logistic regression field")
+    assert(res.typ.rowType.fieldNames.contains(I("logistic_regression")),"expecting result table to have logistic regression field")
   }
 }

--- a/hail/src/test/scala/is/hail/nativecode/TableEmitSuite.scala
+++ b/hail/src/test/scala/is/hail/nativecode/TableEmitSuite.scala
@@ -3,9 +3,9 @@ package is.hail.nativecode
 import is.hail.SparkSuite
 import is.hail.cxx._
 import is.hail.expr.ir
+import is.hail.expr.ir.RowSym
 import is.hail.io.CodecSpec
 import is.hail.table.Table
-import is.hail.utils.FastIndexedSeq
 import org.testng.annotations.Test
 
 class TableEmitSuite extends SparkSuite {
@@ -22,7 +22,7 @@ class TableEmitSuite extends SparkSuite {
     def tir(orig: ir.TableIR): ir.TableIR =
       ir.TableFilter(
         ir.TableMapRows(orig,
-          ir.InsertFields(ir.Ref("row", read.typ.rowType), FastIndexedSeq("x" -> ir.I32(0)))),
+          ir.InsertFields(ir.Ref(RowSym, read.typ.rowType), ir.NamedIRSeq("x" -> ir.I32(0)))),
         ir.True())
 
     val tub = new TranslationUnitBuilder()

--- a/hail/src/test/scala/is/hail/rvd/RVDPartitionerSuite.scala
+++ b/hail/src/test/scala/is/hail/rvd/RVDPartitionerSuite.scala
@@ -3,7 +3,7 @@ package is.hail.rvd
 import is.hail.annotations.UnsafeIndexedSeq
 import is.hail.expr.types._
 import is.hail.expr.types.virtual.{TInt32, TStruct}
-import is.hail.utils.Interval
+import is.hail.utils.{ISeq, Interval}
 import org.apache.spark.sql.Row
 import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.Test
@@ -102,7 +102,7 @@ class RVDPartitionerSuite extends TestNGSuite {
         Interval(Row(11, 0, 2), Row(11, 0, 15), false, true),
         Interval(Row(11, 0, 15), Row(11, 0, 20), true, false))
 
-    val p3 = RVDPartitioner.generate(Array("A", "B", "C"), kType, intervals)
+    val p3 = RVDPartitioner.generate(ISeq("A", "B", "C"), kType, intervals)
     assert(p3.satisfiesAllowedOverlap(2))
     assert(p3.rangeBounds sameElements
       Array(
@@ -113,7 +113,7 @@ class RVDPartitionerSuite extends TestNGSuite {
         Interval(Row(11, 0, 15), Row(11, 0, 20), false, false))
     )
 
-    val p2 = RVDPartitioner.generate(Array("A", "B"), kType, intervals)
+    val p2 = RVDPartitioner.generate(ISeq("A", "B"), kType, intervals)
     assert(p2.satisfiesAllowedOverlap(1))
     assert(p2.rangeBounds sameElements
       Array(
@@ -123,7 +123,7 @@ class RVDPartitionerSuite extends TestNGSuite {
         Interval(Row(11, 0, 2), Row(11, 0, 20), false, false))
     )
 
-    val p1 = RVDPartitioner.generate(Array("A"), kType, intervals)
+    val p1 = RVDPartitioner.generate(ISeq("A"), kType, intervals)
     assert(p1.satisfiesAllowedOverlap(0))
     assert(p1.rangeBounds sameElements
       Array(

--- a/hail/src/test/scala/is/hail/utils/TextTableSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/TextTableSuite.scala
@@ -67,7 +67,7 @@ class TextTableSuite extends SparkSuite {
       "Gene" -> TString()))
 
     val schema2 = TextTableReader.read(hc)(Array("src/test/resources/variantAnnotations.tsv"),
-      types = Map("Chromosome" -> TString()), impute = true).signature
+      types = Map[String, Type]("Chromosome" -> TString()), impute = true).signature
     assert(schema2 == TStruct(
       "Chromosome" -> TString(),
       "Position" -> TInt32(),

--- a/hail/src/test/scala/is/hail/vds/JoinSuite.scala
+++ b/hail/src/test/scala/is/hail/vds/JoinSuite.scala
@@ -5,6 +5,7 @@ import is.hail.annotations._
 import is.hail.expr.types.virtual.{TLocus, TStruct}
 import is.hail.table.Table
 import is.hail.testUtils._
+import is.hail.utils.ISeq
 import is.hail.variant.{Locus, MatrixTable, ReferenceGenome}
 import org.apache.spark.sql.Row
 import org.testng.annotations.Test
@@ -41,11 +42,11 @@ class JoinSuite extends SparkSuite {
       Locus("1", 15))
 
     val vType = TLocus(ReferenceGenome.GRCh37)
-    val leftKt = Table(hc, sc.parallelize(leftVariants.map(Row(_))), TStruct("v" -> vType)).keyBy(Array("v"))
+    val leftKt = Table(hc, sc.parallelize(leftVariants.map(Row(_))), TStruct("v" -> vType)).keyBy(ISeq("v"))
     leftKt.typeCheck()
     val left = MatrixTable.fromRowsTable(leftKt)
 
-    val rightKt = Table(hc, sc.parallelize(rightVariants.map(Row(_))), TStruct("v" -> vType)).keyBy(Array("v"))
+    val rightKt = Table(hc, sc.parallelize(rightVariants.map(Row(_))), TStruct("v" -> vType)).keyBy(ISeq("v"))
     rightKt.typeCheck()
     val right = MatrixTable.fromRowsTable(rightKt)
 


### PR DESCRIPTION
Sorry in advance for the spicy meatball and rebase pain.

the entries! [hash] is now gone!

Added Symbol hierarchy in Scala  and Python.  Symbols have 3 types: user-level identifiers, generated symbols and "internal" symbols like :row and :entries.  Generated and internal symbols are printed with a leading colon (with no backtick quotes).  Internal symbols are never visible to the user.

On the Scala side, symbols are all `Sym` but there is implicit conversions from String to Sym so client code can just write strings.

On the Python side, symbols are `str` or `Symbol`.  I didn't change Python gen_uid to produce Generated symbols yet.  I will do that in a second PR.

Generally, we pass strings through the py-j boundary and parse on either side.

I turned off color on testPython because it leaves the logs full of unreadable escape codes.

There is one user-visible change: the JSON exporter now escapes strings in structs so we will have ```{"`$foo`": 5}``` instead of `{"$foo": 5}`.  This is necessary to disambiguate complex names and internal symbols.