### PR TITLE
pave the way for computing types in Python

### DIFF
--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1455,10 +1455,8 @@ class Table(ExprContainer):
                 if not is_key:
                     original_key = list(left.key)
                     left = Table(TableMapRows(left.key_by()._tir,
-                                              Apply('annotate',
-                                                    left._row._ir,
-                                                    hl.struct(**dict(zip(uids, exprs)))._ir))
-                           ).key_by(*uids)
+                                              InsertFields(left._row._ir,
+                                                           list(zip(uids, [e._ir for e in exprs]))))).key_by(*uids)
                     rekey_f = lambda t: t.key_by(*original_key)
                 else:
                     rekey_f = identity

--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -100,15 +100,19 @@ object IRFunctionRegistry {
 
     irRegistry.foreach { case (name, fns) =>
         fns.foreach { case (argTypes, retType, f) =>
-          println(s"""register("${ StringEscapeUtils.escapeString(name) }", (${ argTypes.map(dtype).mkString(",") }), ${ dtype(retType) })""")
+          println(s"""register_function("${ StringEscapeUtils.escapeString(name) }", (${ argTypes.map(dtype).mkString(",") }), ${ dtype(retType) })""")
         }
     }
 
     codeRegistry.foreach { case (name, fns) =>
         fns.foreach { f =>
-          println(s"""register("${ StringEscapeUtils.escapeString(name) }", (${ f.argTypes.map(dtype).mkString(",") }), ${ dtype(f.returnType) })""")
+          println(s"""${
+            if (f.isInstanceOf[SeededIRFunction])
+              "register_seeded_function"
+            else
+              "register_function"
+          }("${ StringEscapeUtils.escapeString(name) }", (${ f.argTypes.map(dtype).mkString(",") }), ${ dtype(f.returnType) })""")
         }
-
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -1,7 +1,6 @@
 package is.hail.expr.ir.functions
 
 import is.hail.annotations._
-import is.hail.asm4s
 import is.hail.asm4s._
 import is.hail.expr.ir._
 import is.hail.expr.types._
@@ -10,15 +9,14 @@ import is.hail.asm4s.coerce
 import is.hail.experimental.ExperimentalFunctions
 import is.hail.expr.types.physical.{PString, PType}
 import is.hail.expr.types.virtual._
-import is.hail.variant.Call
 
 import scala.collection.mutable
 import scala.reflect._
 
 object IRFunctionRegistry {
 
-  val irRegistry: mutable.MultiMap[String, (Seq[Type], Seq[IR] => IR)] =
-    new mutable.HashMap[String, mutable.Set[(Seq[Type], Seq[IR] => IR)]] with mutable.MultiMap[String, (Seq[Type], Seq[IR] => IR)]
+  val irRegistry: mutable.MultiMap[String, (Seq[Type], Type, Seq[IR] => IR)] =
+    new mutable.HashMap[String, mutable.Set[(Seq[Type], Type, Seq[IR] => IR)]] with mutable.MultiMap[String, (Seq[Type], Type, Seq[IR] => IR)]
 
   val codeRegistry: mutable.MultiMap[String, IRFunction] =
     new mutable.HashMap[String, mutable.Set[IRFunction]] with mutable.MultiMap[String, IRFunction]
@@ -26,8 +24,8 @@ object IRFunctionRegistry {
   def addIRFunction(f: IRFunction): Unit =
     codeRegistry.addBinding(f.name, f)
 
-  def addIR(name: String, types: Seq[Type], f: Seq[IR] => IR): Unit =
-    irRegistry.addBinding(name, (types, f))
+  def addIR(name: String, argTypes: Seq[Type], retType: Type, f: Seq[IR] => IR): Unit =
+    irRegistry.addBinding(name, (argTypes, retType, f))
 
   def removeIRFunction(name: String, args: Seq[Type]): Unit = {
     val functions = codeRegistry(name)
@@ -51,16 +49,16 @@ object IRFunctionRegistry {
     lookupInRegistry(codeRegistry, name, args, (f: IRFunction, ts: Seq[Type]) => f.unify(ts))
 
   def lookupConversion(name: String, args: Seq[Type]): Option[Seq[IR] => IR] = {
-    type Conversion = (Seq[Type], Seq[IR] => IR)
+    type Conversion = (Seq[Type], Type, Seq[IR] => IR)
     val findIR: (Conversion, Seq[Type]) => Boolean = {
-      case ((ts, _), t2s) =>
+      case ((ts, _, _), t2s) =>
         ts.length == args.length && {
           ts.foreach(_.clear())
           (ts, t2s).zipped.forall(_.unify(_))
         }
     }
     val validIR: Option[Seq[IR] => IR] = lookupInRegistry[Conversion](irRegistry, name, args, findIR).map {
-      case (_, conversion) => args => ApplyIR(name, args, conversion)
+      case (_, _, conversion) => args => ApplyIR(name, args, conversion)
     }
 
     val validMethods = lookupFunction(name, args).map { f => { irArgs: Seq[IR] =>
@@ -96,6 +94,23 @@ object IRFunctionRegistry {
     UtilFunctions,
     ExperimentalFunctions
   ).foreach(_.registerAll())
+
+  def dumpFunctions(): Unit = {
+    def dtype(t: Type): String = s"""dtype("${ StringEscapeUtils.escapeString(t.toString) }\")"""
+
+    irRegistry.foreach { case (name, fns) =>
+        fns.foreach { case (argTypes, retType, f) =>
+          println(s"""register("${ StringEscapeUtils.escapeString(name) }", (${ argTypes.map(dtype).mkString(",") }), ${ dtype(retType) })""")
+        }
+    }
+
+    codeRegistry.foreach { case (name, fns) =>
+        fns.foreach { f =>
+          println(s"""register("${ StringEscapeUtils.escapeString(name) }", (${ f.argTypes.map(dtype).mkString(",") }), ${ dtype(f.returnType) })""")
+        }
+
+    }
+  }
 }
 
 abstract class RegistryFunctions {
@@ -104,16 +119,14 @@ abstract class RegistryFunctions {
 
   private val boxes = mutable.Map[String, Box[Type]]()
 
-  private def tvBoxes(name: String) = boxes.getOrElseUpdate(name, Box[Type](matchCond = {(t1, t2) => -t1 == -t2}))
-
   def tv(name: String): TVariable =
-    TVariable(name, b = tvBoxes(name))
+    TVariable(name)
 
-  def tv(name: String, cond: Type => Boolean): TVariable =
-    TVariable(name, cond, tvBoxes(name))
+  def tv(name: String, cond: String): TVariable =
+    TVariable(name, cond)
 
   def tnum(name: String): TVariable =
-    tv(name, _.isInstanceOf[TNumeric])
+    tv(name, "numeric")
 
   def getRegion(mb: EmitMethodBuilder): Code[Region] = mb.getArg[Region](1)
 
@@ -282,8 +295,8 @@ abstract class RegistryFunctions {
   def registerJavaStaticFunction(mname: String, types: Type*)(cls: Class[_], method: String): Unit =
     registerJavaStaticFunction(mname, types.init.toArray, types.last)(cls, method)
 
-  def registerIR(mname: String, argTypes: Array[Type])(f: Seq[IR] => IR) {
-    IRFunctionRegistry.addIR(mname, argTypes, f)
+  def registerIR(mname: String, argTypes: Array[Type], retType: Type)(f: Seq[IR] => IR) {
+    IRFunctionRegistry.addIR(mname, argTypes, retType, f)
   }
 
   def registerCode(mname: String, rt: Type)(impl: EmitMethodBuilder => Code[_]): Unit =
@@ -333,20 +346,20 @@ abstract class RegistryFunctions {
   def registerCodeWithMissingness(mname: String, mt1: Type, mt2: Type, mt3: Type, mt4: Type, rt: Type)(impl: (EmitMethodBuilder, EmitTriplet, EmitTriplet, EmitTriplet, EmitTriplet) => EmitTriplet): Unit =
     registerCodeWithMissingness(mname, Array(mt1, mt2, mt3, mt4), rt) { case (mb, Array(a1, a2, a3, a4)) => impl(mb, a1, a2, a3, a4) }
 
-  def registerIR(mname: String)(f: () => IR): Unit =
-    registerIR(mname, Array[Type]()) { case Seq() => f() }
+  def registerIR(mname: String, retType: Type)(f: () => IR): Unit =
+    registerIR(mname, Array[Type](), retType) { case Seq() => f() }
 
-  def registerIR(mname: String, mt1: Type)(f: IR => IR): Unit =
-    registerIR(mname, Array(mt1)) { case Seq(a1) => f(a1) }
+  def registerIR(mname: String, mt1: Type, retType: Type)(f: IR => IR): Unit =
+    registerIR(mname, Array(mt1), retType) { case Seq(a1) => f(a1) }
 
-  def registerIR(mname: String, mt1: Type, mt2: Type)(f: (IR, IR) => IR): Unit =
-    registerIR(mname, Array(mt1, mt2)) { case Seq(a1, a2) => f(a1, a2) }
+  def registerIR(mname: String, mt1: Type, mt2: Type, retType: Type)(f: (IR, IR) => IR): Unit =
+    registerIR(mname, Array(mt1, mt2), retType) { case Seq(a1, a2) => f(a1, a2) }
 
-  def registerIR(mname: String, mt1: Type, mt2: Type, mt3: Type)(f: (IR, IR, IR) => IR): Unit =
-    registerIR(mname, Array(mt1, mt2, mt3)) { case Seq(a1, a2, a3) => f(a1, a2, a3) }
+  def registerIR(mname: String, mt1: Type, mt2: Type, mt3: Type, retType: Type)(f: (IR, IR, IR) => IR): Unit =
+    registerIR(mname, Array(mt1, mt2, mt3), retType) { case Seq(a1, a2, a3) => f(a1, a2, a3) }
 
-  def registerIR(mname: String, mt1: Type, mt2: Type, mt3: Type, mt4: Type)(f: (IR, IR, IR, IR) => IR): Unit =
-    registerIR(mname, Array(mt1, mt2, mt3, mt4)) { case Seq(a1, a2, a3, a4) => f(a1, a2, a3, a4) }
+  def registerIR(mname: String, mt1: Type, mt2: Type, mt3: Type, mt4: Type, retType: Type)(f: (IR, IR, IR, IR) => IR): Unit =
+    registerIR(mname, Array(mt1, mt2, mt3, mt4), retType) { case Seq(a1, a2, a3, a4) => f(a1, a2, a3, a4) }
 
   def registerSeeded(mname: String, aTypes: Array[Type], rType: Type)(impl: (EmitMethodBuilder, Long, Array[Code[_]]) => Code[_]) {
     IRFunctionRegistry.addIRFunction(new SeededIRFunction {

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -12,7 +12,7 @@ import is.hail.variant.Genotype
 object GenotypeFunctions extends RegistryFunctions {
 
   def registerAll() {
-    registerCode("gqFromPL", TArray(tv("N", _.isInstanceOf[TInt32])), TInt32()) { (mb, pl: Code[Long]) =>
+    registerCode("gqFromPL", TArray(tv("N", "int32")), TInt32()) { (mb, pl: Code[Long]) =>
       val region = getRegion(mb)
       val tPL = PArray(tv("N").t.physicalType)
       val m = mb.newLocal[Int]("m")
@@ -41,7 +41,7 @@ object GenotypeFunctions extends RegistryFunctions {
       )
     }
 
-    registerCode("dosage", TArray(tv("N", _ isOfType TFloat64())), TFloat64()) { (mb, gpOff: Code[Long]) =>
+    registerCode("dosage", TArray(tv("N", "float64")), TFloat64()) { (mb, gpOff: Code[Long]) =>
       def getRegion(mb: EmitMethodBuilder): Code[Region] = mb.getArg[Region](1)
       val pArray = TArray(tv("N").t).physicalType
       val gp = mb.newLocal[Long]
@@ -58,7 +58,7 @@ object GenotypeFunctions extends RegistryFunctions {
 
     // FIXME: remove when SkatSuite is moved to Python
     // the pl_dosage function in Python is implemented in Python
-    registerCode("plDosage", TArray(tv("N", _ isOfType TInt32())), TFloat64()) { (mb, plOff: Code[Long]) =>
+    registerCode("plDosage", TArray(tv("N", "int32")), TFloat64()) { (mb, plOff: Code[Long]) =>
       def getRegion(mb: EmitMethodBuilder): Code[Region] = mb.getArg[Region](1)
       val pArray = TArray(tv("N").t).physicalType
       val pl = mb.newLocal[Long]

--- a/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -20,7 +20,7 @@ object LocusFunctions extends RegistryFunctions {
   }
 
   def registerLocusCode(methodName: String): Unit = {
-    registerCode(methodName, tv("T", _.isInstanceOf[TLocus]), TBoolean()) {
+    registerCode(methodName, tv("T", "locus"), TBoolean()) {
       case (mb: EmitMethodBuilder, locus: Code[Long]) =>
         val locusObject = getLocus(mb, locus, "T")
         val tlocus = types.coerce[TLocus](tv("T").t)
@@ -32,14 +32,14 @@ object LocusFunctions extends RegistryFunctions {
   }
 
   def registerAll() {
-    registerCode("contig", tv("T", _.isInstanceOf[TLocus]), TString()) {
+    registerCode("contig", tv("T", "locus"), TString()) {
       case (mb, locus: Code[Long]) =>
         val region = getRegion(mb)
         val tlocus = types.coerce[TLocus](tv("T").t).physicalType
         tlocus.contig(region, locus)
     }
 
-    registerCode("position", tv("T", _.isInstanceOf[TLocus]), TInt32()) {
+    registerCode("position", tv("T", "locus"), TInt32()) {
       case (mb, locus: Code[Long]) =>
         val region = getRegion(mb)
         val tlocus = types.coerce[TLocus](tv("T").t).physicalType
@@ -54,7 +54,7 @@ object LocusFunctions extends RegistryFunctions {
     registerLocusCode("inXNonPar")
     registerLocusCode("inYPar")
 
-    registerCode("min_rep", tv("T", _.isInstanceOf[TLocus]), TArray(TString()), TStruct("locus" -> tv("T"), "alleles" -> TArray(TString()))) { (mb, lOff, aOff) =>
+    registerCode("min_rep", tv("T", "locus"), TArray(TString()), TStruct("locus" -> tv("T"), "alleles" -> TArray(TString()))) { (mb, lOff, aOff) =>
       val returnTuple = mb.newLocal[(Locus, IndexedSeq[String])]
       val locus = getLocus(mb, lOff, "T")
       val alleles = Code.checkcast[IndexedSeq[String]](wrapArg(mb, TArray(TString()))(aOff).asInstanceOf[Code[AnyRef]])

--- a/hail/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
@@ -110,10 +110,10 @@ object MathFunctions extends RegistryFunctions {
     val jDoubleClass = classOf[java.lang.Double]    
 
     // numeric conversions
-    registerIR("toInt32", tnum("T"))(x => Cast(x, TInt32()))
-    registerIR("toInt64", tnum("T"))(x => Cast(x, TInt64()))
-    registerIR("toFloat32", tnum("T"))(x => Cast(x, TFloat32()))
-    registerIR("toFloat64", tnum("T"))(x => Cast(x, TFloat64()))
+    registerIR("toInt32", tnum("T"), TInt32())(x => Cast(x, TInt32()))
+    registerIR("toInt64", tnum("T"), TInt64())(x => Cast(x, TInt64()))
+    registerIR("toFloat32", tnum("T"), TFloat32())(x => Cast(x, TFloat32()))
+    registerIR("toFloat64", tnum("T"), TFloat64())(x => Cast(x, TFloat64()))
     
     registerScalaFunction("abs", TInt32(), TInt32())(mathPackageClass, "abs")
     registerScalaFunction("abs", TInt64(), TInt64())(mathPackageClass, "abs")

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ReferenceGenomeFunctions.scala
@@ -5,7 +5,6 @@ import is.hail.asm4s
 import is.hail.asm4s._
 import is.hail.expr.ir._
 import is.hail.expr.types
-import is.hail.expr.types._
 import is.hail.expr.types.physical.{PBaseStruct, PString, PStruct}
 import is.hail.expr.types.virtual._
 import is.hail.utils._
@@ -255,7 +254,7 @@ class ReferenceGenomeFunctions(rg: ReferenceGenome) extends RegistryFunctions {
         unwrapReturn(mb, TString())(rgCode(mb).invoke[String, Int, Int, Int, String]("getSequence", scontig, pos, before, after))
     }
 
-    registerIR(rg.wrapFunctionName("getReferenceSequence"), TString(), TInt32(), TInt32(), TInt32()) {
+    registerIR(rg.wrapFunctionName("getReferenceSequence"), TString(), TInt32(), TInt32(), TInt32(), TString()) {
       (contig, pos, before, after) =>
         val getRef = IRFunctionRegistry.lookupConversion(
           rg.wrapFunctionName("getReferenceSequenceFromValidLocus"),

--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -50,7 +50,7 @@ object StringFunctions extends RegistryFunctions {
   def registerAll(): Unit = {
     val thisClass = getClass
 
-    registerIR("[]", TString(), TInt32()) { (s, idx) =>
+    registerIR("[]", TString(), TInt32(), TString()) { (s, idx) =>
       // rather than do a bunch of bounds checking here, check the length of the StringSlice result - way easier
       val sName = ir.genUID()
       val sResult = ir.Ref(sName, TString())
@@ -70,10 +70,10 @@ object StringFunctions extends RegistryFunctions {
         )
       )
     }
-    registerIR("[:]", TString())(x => x)
-    registerIR("[*:]", TString(), TInt32()) { (s, start) => ir.StringSlice(s, start, StringLength(s)) }
-    registerIR("[:*]", TString(), TInt32()) { (s, end) => ir.StringSlice(s, ir.I32(0), end) }
-    registerIR("[*:*]", TString(), TInt32(), TInt32()) { (s, start, end) => ir.StringSlice(s, start, end) }
+    registerIR("[:]", TString(), TString())(x => x)
+    registerIR("[*:]", TString(), TInt32(), TString()) { (s, start) => ir.StringSlice(s, start, StringLength(s)) }
+    registerIR("[:*]", TString(), TInt32(), TString()) { (s, end) => ir.StringSlice(s, ir.I32(0), end) }
+    registerIR("[*:*]", TString(), TInt32(), TInt32(), TString()) { (s, start, end) => ir.StringSlice(s, start, end) }
 
     registerCode("str", tv("T"), TString()) { (mb, a) =>
       val typ = tv("T").subst()

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TVariable.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TVariable.scala
@@ -4,16 +4,57 @@ import is.hail.annotations.ExtendedOrdering
 import is.hail.expr.types.Box
 import is.hail.expr.types.physical.PType
 
+import scala.collection.mutable
 import scala.reflect.ClassTag
 
-final case class TVariable(name: String, cond: (Type) => Boolean = { _ => true }, var b: Box[Type] = Box(matchCond = _.isOfType(_))) extends Type {
+object TVariable {
+  val condMap: Map[String, (Type) => Boolean] = Map(
+    "numeric" -> ((t: Type) => t.isInstanceOf[TNumeric]),
+    "int32" -> ((t: Type) => t.isInstanceOf[TInt32]),
+    "int64" -> ((t: Type) => t.isInstanceOf[TInt64]),
+    "float32" -> ((t: Type) => t.isInstanceOf[TFloat32]),
+    "float64" -> ((t: Type) => t.isInstanceOf[TInt32]),
+    "locus" -> ((t: Type) => t.isInstanceOf[TLocus]),
+    "struct" -> ((t: Type) => t.isInstanceOf[TStruct]),
+    "tuple" -> ((t: Type) => t.isInstanceOf[TTuple]))
+
+  private[this] val namedBoxes: mutable.Map[String, Box[Type]] = mutable.Map()
+
+  def fromName(name: String): Box[Type] = this.synchronized {
+    namedBoxes.get(name) match {
+      case Some(b) => b
+      case None =>
+        val b = Box[Type](matchCond = _.isOfType(_))
+        namedBoxes(name) = b
+        b
+    }
+  }
+}
+
+final case class TVariable(name: String, cond: String = null) extends Type {
+  private[this] val b = TVariable.fromName(name)
+
+  private[this] val condf: (Type) => Boolean =
+    if (cond != null)
+      TVariable.condMap(cond)
+    else
+      (t: Type) => true
+
   def physicalType: PType = ???
 
   def t: Type = b.get
 
   override val required = true
 
-  override def _toPretty: String = s"?$name"
+  override def _toPretty: String =
+    if (cond != null)
+      s"?$name:$cond"
+    else
+      s"?$name"
+
+  override def pyString(sb: StringBuilder): Unit = {
+    sb.append(_toPretty)
+  }
 
   override def isRealizable = false
 
@@ -21,7 +62,7 @@ final case class TVariable(name: String, cond: (Type) => Boolean = { _ => true }
     throw new RuntimeException("TVariable is not realizable")
 
   override def unify(concrete: Type): Boolean =
-    concrete.isRealizable && cond(concrete) && b.unify(concrete)
+    concrete.isRealizable && condf(concrete) && b.unify(concrete)
 
   override def isBound: Boolean = b.isEmpty
 

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TVariable.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TVariable.scala
@@ -13,7 +13,7 @@ object TVariable {
     "int32" -> ((t: Type) => t.isInstanceOf[TInt32]),
     "int64" -> ((t: Type) => t.isInstanceOf[TInt64]),
     "float32" -> ((t: Type) => t.isInstanceOf[TFloat32]),
-    "float64" -> ((t: Type) => t.isInstanceOf[TInt32]),
+    "float64" -> ((t: Type) => t.isInstanceOf[TFloat64]),
     "locus" -> ((t: Type) => t.isInstanceOf[TLocus]),
     "struct" -> ((t: Type) => t.isInstanceOf[TStruct]),
     "tuple" -> ((t: Type) => t.isInstanceOf[TTuple]))

--- a/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -26,16 +26,20 @@ class ScalaTestCompanion {
 
 object TestRegisterFunctions extends RegistryFunctions {
   def registerAll() {
-    registerIR("addone", TInt32())(ApplyBinaryPrimOp(Add(), _, I32(1)))
+    registerIR("addone", TInt32(), TInt32())(ApplyBinaryPrimOp(Add(), _, I32(1)))
     registerJavaStaticFunction("compare", TInt32(), TInt32(), TInt32())(classOf[java.lang.Integer], "compare")
     registerScalaFunction("foobar1", TInt32())(ScalaTestObject.getClass, "testFunction")
     registerScalaFunction("foobar2", TInt32())(ScalaTestCompanion.getClass, "testFunction")
-    registerCode("testCodeUnification", tnum("x"), tv("x", _.isInstanceOf[TInt32]), tv("x")){ (_, a: Code[Int], b: Code[Int]) => a + b }
+    registerCode("testCodeUnification", tnum("x"), tv("x", "int32"), tv("x")){ (_, a: Code[Int], b: Code[Int]) => a + b }
     registerCode("testCodeUnification2", tv("x"), tv("x")){ case (_, a: Code[Long]) => a }
   }
 }
 
 class FunctionSuite extends SparkSuite {
+
+  @Test def dump(): Unit = {
+    IRFunctionRegistry.dumpFunctions()
+  }
 
   val region = Region()
 

--- a/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/FunctionSuite.scala
@@ -37,10 +37,6 @@ object TestRegisterFunctions extends RegistryFunctions {
 
 class FunctionSuite extends SparkSuite {
 
-  @Test def dump(): Unit = {
-    IRFunctionRegistry.dumpFunctions()
-  }
-
   val region = Region()
 
   TestRegisterFunctions.registerAll()


### PR DESCRIPTION
Some infrastructure changes to support type checking in Python:
 - include return types on registerIR,
 - make the TVariable condition representable so it can be dumped to Python
 - add a dump function that dumps the register IR function signatures as Pyhton
