### PR TITLE
implement ArrayLeftJoinDistinct IR node

### DIFF
--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -714,6 +714,41 @@ class ArrayScan(IR):
                other.body == self.body
 
 
+class ArrayLeftJoinDistinct(IR):
+    @typecheck_method(left=IR, right=IR, l_name=str, r_name=str, compare=IR, join=IR)
+    def __init__(self, left, right, l_name, r_name, compare, join):
+        super().__init__(left, right, compare, join)
+        self.left = left
+        self.right = right
+        self.l_name = l_name
+        self.r_name = r_name
+        self.compare = compare
+        self.join = join
+
+    @typecheck_method(left=IR, right=IR, compare=IR, join=IR)
+    def copy(self, left, right, compare, join):
+        new_instance = self.__class__
+        return new_instance(left, right, self.l_name, self.r_name, compare, join)
+
+    def render(self, r):
+        return '(ArrayLeftJoinDistinct {} {} {} {} {} {})'.format(
+            escape_id(self.l_name), escape_id(self.r_name),
+            r(self.left), r(self.right), r(self.compare), r(self.join))
+
+    @property
+    def bound_variables(self):
+        return {self.l_name, self.r_name} | super().bound_variables
+
+    def __eq__(self, other):
+        return isinstance(other, ArrayLeftJoinDistinct) and \
+               other.left == self.left and \
+               other.right == self.right and \
+               other.l_name == self.l_name and \
+               other.r_name == self.r_name and \
+               other.compare == self.compare and \
+               other.join == self.join
+
+
 class ArrayFor(IR):
     @typecheck_method(a=IR, value_name=str, body=IR)
     def __init__(self, a, value_name, body):

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -55,6 +55,7 @@ class ValueIRTests(unittest.TestCase):
             ir.ArrayFlatMap(aa, 'v', v),
             ir.ArrayFold(a, ir.I32(0), 'x', 'v', v),
             ir.ArrayScan(a, ir.I32(0), 'x', 'v', v),
+            ir.ArrayLeftJoinDistinct(a, a, 'l', 'r', ir.I32(0), ir.I32(1)),
             ir.ArrayFor(a, 'v', ir.Void()),
             ir.AggFilter(ir.TrueIR(), ir.I32(0)),
             ir.AggExplode(ir.ArrayRange(ir.I32(0), ir.I32(2), ir.I32(1)), 'x', ir.I32(0)),

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -15,6 +15,8 @@ object Binds {
         (v == accumName || v == valueName) && i == 2
       case ArrayScan(_, _, accumName, valueName, _) =>
         (v == accumName || v == valueName) && i == 2
+      case ArrayLeftJoinDistinct(_, _, l, r, _, _) =>
+        (v == l || v == r) && i == 2
       case AggExplode(_, n, _) =>
         v == n && i == 1
       case _ =>

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -62,6 +62,8 @@ object Children {
       Array(a, zero, body)
     case ArrayScan(a, zero, accumName, valueName, body) =>
       Array(a, zero, body)
+    case ArrayLeftJoinDistinct(left, right, l, r, compare, join) =>
+      Array(left, right, compare, join)
     case ArrayFor(a, valueName, body) =>
       Array(a, body)
     case ArrayAgg(a, name, query) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -80,6 +80,9 @@ object Copy {
       case ArrayScan(_, _, accumName, valueName, _) =>
         val IndexedSeq(a: IR, zero: IR, body: IR) = newChildren
         ArrayScan(a, zero, accumName, valueName, body)
+      case ArrayLeftJoinDistinct(_, _, l, r, _, _) =>
+        val IndexedSeq(left: IR, right: IR, compare: IR, join: IR) = newChildren
+        ArrayLeftJoinDistinct(left, right, l, r, compare, join)
       case ArrayFor(_, valueName, _) =>
         val IndexedSeq(a: IR, body: IR) = newChildren
         ArrayFor(a, valueName, body)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1317,7 +1317,7 @@ private class Emit(
 
         val fenv = env.bind(
           l -> (typeToTypeInfo(lelt), lm.load(), lv.load()),
-          r -> (typeToTypeInfo(lelt), rm.load() || rtyp.isElementMissing(region, rv, ri), rtyp.loadElement(region, rv, ri)))
+          r -> (typeToTypeInfo(relt), rm.load() || rtyp.isElementMissing(region, rv, ri), rtyp.loadElement(region, rv, ri)))
 
         val compKeyF = mb.fb.newMethod(typeInfo[Region], typeInfo[Int])
         val et = new Emit(compKeyF, 1).emit(compKey, fenv)
@@ -1343,7 +1343,8 @@ private class Emit(
             rarray.setup,
             ri := 0,
             rm := rarray.m,
-            rm.mux(Code._empty,
+            rm.mux(
+              rlen := 0,
               Code(
                 rv := rarray.value[Long],
                 rlen := rtyp.loadLength(region, rv))))

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -158,6 +158,8 @@ final case class ArrayFor(a: IR, valueName: String, body: IR) extends IR
 
 final case class ArrayAgg(a: IR, name: String, query: IR) extends IR
 
+final case class ArrayLeftJoinDistinct(left: IR, right: IR, l: String, r: String, keyF: IR, joinF: IR) extends IR
+
 final case class AggFilter(cond: IR, aggIR: IR) extends IR
 
 final case class AggExplode(array: IR, name: String, aggBody: IR) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -84,6 +84,8 @@ object InferPType {
         PArray(zero.pType)
       case ArrayAgg(_, _, query) =>
         query.pType
+      case ArrayLeftJoinDistinct(left, right, l, r, compare, join) =>
+        PArray(join.pType)
       case AggFilter(_, aggIR) =>
         aggIR.pType
       case AggExplode(array, name, aggBody) =>

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -89,6 +89,8 @@ object InferType {
         TArray(zero.typ)
       case ArrayAgg(_, _, query) =>
         query.typ
+      case ArrayLeftJoinDistinct(left, right, l, r, compare, join) =>
+        TArray(join.typ)
       case AggFilter(_, aggIR) =>
         aggIR.typ
       case AggExplode(array, name, aggBody) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -629,6 +629,14 @@ object IRParser {
         val eltType = coerce[TArray](a.typ).elementType
         val body = ir_value_expr(env.update(Map(accumName -> zero.typ, valueName -> eltType)))(it)
         ArrayScan(a, zero, accumName, valueName, body)
+      case "ArrayLeftJoinDistinct" =>
+        val l = identifier(it)
+        val r = identifier(it)
+        val left = ir_value_expr(env)(it)
+        val right = ir_value_expr(env)(it)
+        val comp = ir_value_expr(env.update(Map(l -> coerce[TArray](left.typ).elementType, r -> coerce[TArray](right.typ).elementType)))(it)
+        val join = ir_value_expr(env.update(Map(l -> coerce[TArray](left.typ).elementType, r -> coerce[TArray](right.typ).elementType)))(it)
+        ArrayLeftJoinDistinct(left, right, l, r, comp, join)
       case "ArrayFor" =>
         val name = identifier(it)
         val a = ir_value_expr(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -177,6 +177,7 @@ object Pretty {
             case ArrayFlatMap(_, name, _) => prettyIdentifier(name)
             case ArrayFold(_, _, accumName, valueName, _) => prettyIdentifier(accumName) + " " + prettyIdentifier(valueName)
             case ArrayScan(_, _, accumName, valueName, _) => prettyIdentifier(accumName) + " " + prettyIdentifier(valueName)
+            case ArrayLeftJoinDistinct(_, _, l, r, _, _) => prettyIdentifier(l) + " " + prettyIdentifier(r)
             case ArrayFor(_, valueName, _) => prettyIdentifier(valueName)
             case ArrayAgg(a, name, query) => prettyIdentifier(name)
             case AggExplode(_, name, _) => prettyIdentifier(name)

--- a/hail/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
@@ -8,7 +8,7 @@ import scala.reflect.ClassTag
 
 class StagedArrayBuilder(val elt: PType, mb: MethodBuilder, len: Code[Int]) {
 
-  val ti = typeToTypeInfo(elt)
+  val ti: TypeInfo[_] = typeToTypeInfo(elt)
 
   val ref: Settable[Any] = coerce[Any](ti match {
     case BooleanInfo => mb.newLazyField[BooleanArrayBuilder]("zab")(Code.newInstance[BooleanArrayBuilder, Int](len))
@@ -16,7 +16,7 @@ class StagedArrayBuilder(val elt: PType, mb: MethodBuilder, len: Code[Int]) {
     case LongInfo => mb.newLazyField[LongArrayBuilder]("jab")(Code.newInstance[LongArrayBuilder, Int](len))
     case FloatInfo => mb.newLazyField[FloatArrayBuilder]("fab")(Code.newInstance[FloatArrayBuilder, Int](len))
     case DoubleInfo => mb.newLazyField[DoubleArrayBuilder]("dab")(Code.newInstance[DoubleArrayBuilder, Int](len))
-    case ti => throw new RuntimeException(s"unsupported type found: $elt whose type info is $ti")
+    case ti => throw new RuntimeException(s"unsupported typeinfo found: $ti")
   })
 
   def add(x: Code[_]): Code[Unit] = ti match {

--- a/hail/src/main/scala/is/hail/expr/ir/Subst.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Subst.scala
@@ -22,6 +22,8 @@ object Subst {
         ArrayFold(subst(a), subst(zero), accumName, valueName, subst(body, env.delete(accumName).delete(valueName)))
       case ArrayScan(a, zero, accumName, valueName, body) =>
         ArrayScan(subst(a), subst(zero), accumName, valueName, subst(body, env.delete(accumName).delete(valueName)))
+      case ArrayLeftJoinDistinct(left, right, l, r, compare, join) =>
+        ArrayLeftJoinDistinct(subst(left), subst(right), l, r, subst(compare, env.delete(l).delete(r)), subst(join, env.delete(l).delete(r)))
       case ArrayFor(a, valueName, body) =>
         ArrayFor(subst(a), valueName, subst(body, env.delete(valueName)))
       case ArrayAgg(a, name, query) =>

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -151,6 +151,15 @@ object TypeCheck {
         check(body, env = env.bind(accumName -> zero.typ, valueName -> -tarray.elementType))
         assert(body.typ == zero.typ)
         assert(x.typ == TArray(zero.typ))
+      case x@ArrayLeftJoinDistinct(left, right, l, r, compare, join) =>
+        check(left)
+        check(right)
+        val ltyp = coerce[TArray](left.typ)
+        val rtyp = coerce[TArray](right.typ)
+        check(compare, env = env.bind(l -> -ltyp.elementType, r -> -rtyp.elementType))
+        check(join, env = env.bind(l -> -ltyp.elementType, r -> -rtyp.elementType))
+        assert(compare.typ.isOfType(TInt32()))
+        assert(x.typ == TArray(join.typ))
       case x@ArrayFor(a, valueName, body) =>
         check(a)
         val tarray = coerce[TArray](a.typ)

--- a/hail/src/main/scala/is/hail/expr/ir/add-ir-checklist.txt
+++ b/hail/src/main/scala/is/hail/expr/ir/add-ir-checklist.txt
@@ -29,8 +29,7 @@ This is the list of things you need to do to add a new IR node.
 
  - Add a rule to Typecheck
 
- - It must define typ, or extend InferIR and define its type inference
-   rule in Infer
+ - It must define its type inference rule in InferType/InferPType
 
  - Support it in Children and Copy
 

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -452,7 +452,7 @@ object TestUtils {
       agg.map(_._2.toEnv))
 
     val t = x.typ
-    assert(t.typeCheck(expected))
+    assert(t.typeCheck(expected), t)
 
     val i = Interpret[Any](x, env, args, agg)
     assert(t.typeCheck(i))

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -595,24 +595,28 @@ class IRSuite extends SparkSuite {
         joinF(Ref("_l", coerce[TArray](left.typ).elementType), Ref("_r", coerce[TArray](right.typ).elementType)))
     }
 
-    def joinRows(left: IndexedSeq[Int], right: IndexedSeq[Int]): IR = {
+    def joinRows(left: IndexedSeq[Integer], right: IndexedSeq[Integer]): IR = {
       join(
-        MakeArray.unify(left.zipWithIndex.map { case (n, idx) => MakeStruct(FastIndexedSeq("idx" -> I32(n), "x" -> Str("x"), "a" -> I32(idx))) }),
-        MakeArray.unify(right.zipWithIndex.map { case (n, idx) => MakeStruct(FastIndexedSeq("b" -> I32(idx), "x" -> Str("x"), "idx" -> I32(n))) }),
-        FastIndexedSeq("idx", "x"))
+        MakeArray.unify(left.zipWithIndex.map { case (n, idx) => MakeStruct(FastIndexedSeq("k1" -> (if (n == null) NA(TInt32()) else I32(n)), "k2" -> Str("x"), "a" -> I32(idx))) }),
+        MakeArray.unify(right.zipWithIndex.map { case (n, idx) => MakeStruct(FastIndexedSeq("b" -> I32(idx), "k2" -> Str("x"), "k1" -> (if (n == null) NA(TInt32()) else I32(n)))) }),
+        FastIndexedSeq("k1", "k2"))
     }
 
-    assertEvalsTo(joinRows(Array(0, 1, 2), Array(1)), FastIndexedSeq(
+    assertEvalsTo(joinRows(Array[Integer](0, null), Array[Integer](1)), FastIndexedSeq(
+      Row(0, "x", 0, null),
+      Row(null, "x", 1, null)))
+
+    assertEvalsTo(joinRows(Array[Integer](0, 1, 2), Array[Integer](1)), FastIndexedSeq(
       Row(0, "x", 0, null),
       Row(1, "x", 1, 0),
       Row(2, "x", 2, null)))
 
-    assertEvalsTo(joinRows(Array(0, 1, 2), Array(-1, 0, 0, 1, 1, 2, 2, 3)), FastIndexedSeq(
+    assertEvalsTo(joinRows(Array[Integer](0, 1, 2), Array[Integer](-1, 0, 0, 1, 1, 2, 2, 3)), FastIndexedSeq(
       Row(0, "x", 0, 1),
       Row(1, "x", 1, 3),
       Row(2, "x", 2, 5)))
 
-    assertEvalsTo(joinRows(Array(0, 1, 1, 2), Array(-1, 0, 0, 1, 1, 2, 2, 3)), FastIndexedSeq(
+    assertEvalsTo(joinRows(Array[Integer](0, 1, 1, 2), Array[Integer](-1, 0, 0, 1, 1, 2, 2, 3)), FastIndexedSeq(
       Row(0, "x", 0, 1),
       Row(1, "x", 1, 3),
       Row(1, "x", 2, 3),

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -597,8 +597,8 @@ class IRSuite extends SparkSuite {
 
     def joinRows(left: IndexedSeq[Int], right: IndexedSeq[Int]): IR = {
       join(
-        MakeArray.unify(left.zipWithIndex.map { case (n, idx) => MakeStruct(FastIndexedSeq("b" -> I32(idx), "x" -> Str("x"), "idx" -> I32(n))) }),
-        MakeArray.unify(right.zipWithIndex.map { case (n, idx) => MakeStruct(FastIndexedSeq("idx" -> I32(n), "x" -> Str("x"), "a" -> I32(idx))) }),
+        MakeArray.unify(left.zipWithIndex.map { case (n, idx) => MakeStruct(FastIndexedSeq("idx" -> I32(n), "x" -> Str("x"), "a" -> I32(idx))) }),
+        MakeArray.unify(right.zipWithIndex.map { case (n, idx) => MakeStruct(FastIndexedSeq("b" -> I32(idx), "x" -> Str("x"), "idx" -> I32(n))) }),
         FastIndexedSeq("idx", "x"))
     }
 
@@ -611,6 +611,12 @@ class IRSuite extends SparkSuite {
       Row(0, "x", 0, 1),
       Row(1, "x", 1, 3),
       Row(2, "x", 2, 5)))
+
+    assertEvalsTo(joinRows(Array(0, 1, 1, 2), Array(-1, 0, 0, 1, 1, 2, 2, 3)), FastIndexedSeq(
+      Row(0, "x", 0, 1),
+      Row(1, "x", 1, 3),
+      Row(1, "x", 2, 3),
+      Row(2, "x", 3, 5)))
   }
 
   @Test def testDie() {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -597,30 +597,30 @@ class IRSuite extends SparkSuite {
 
     def joinRows(left: IndexedSeq[Integer], right: IndexedSeq[Integer]): IR = {
       join(
-        MakeArray.unify(left.zipWithIndex.map { case (n, idx) => MakeStruct(FastIndexedSeq("k1" -> (if (n == null) NA(TInt32()) else I32(n)), "k2" -> Str("x"), "a" -> I32(idx))) }),
-        MakeArray.unify(right.zipWithIndex.map { case (n, idx) => MakeStruct(FastIndexedSeq("b" -> I32(idx), "k2" -> Str("x"), "k1" -> (if (n == null) NA(TInt32()) else I32(n)))) }),
+        MakeArray.unify(left.zipWithIndex.map { case (n, idx) => MakeStruct(FastIndexedSeq("k1" -> (if (n == null) NA(TInt32()) else I32(n)), "k2" -> Str("x"), "a" -> I64(idx))) }),
+        MakeArray.unify(right.zipWithIndex.map { case (n, idx) => MakeStruct(FastIndexedSeq("b" -> I32(idx), "k2" -> Str("x"), "k1" -> (if (n == null) NA(TInt32()) else I32(n)), "c" -> Str("foo"))) }),
         FastIndexedSeq("k1", "k2"))
     }
 
-    assertEvalsTo(joinRows(Array[Integer](0, null), Array[Integer](1)), FastIndexedSeq(
-      Row(0, "x", 0, null),
-      Row(null, "x", 1, null)))
+    assertEvalsTo(joinRows(Array[Integer](0, null), Array[Integer](1, null)), FastIndexedSeq(
+      Row(0, "x", 0L, null, null),
+      Row(null, "x", 1L, 1, "foo")))
 
     assertEvalsTo(joinRows(Array[Integer](0, 1, 2), Array[Integer](1)), FastIndexedSeq(
-      Row(0, "x", 0, null),
-      Row(1, "x", 1, 0),
-      Row(2, "x", 2, null)))
+      Row(0, "x", 0L, null, null),
+      Row(1, "x", 1L, 0, "foo"),
+      Row(2, "x", 2L, null, null)))
 
     assertEvalsTo(joinRows(Array[Integer](0, 1, 2), Array[Integer](-1, 0, 0, 1, 1, 2, 2, 3)), FastIndexedSeq(
-      Row(0, "x", 0, 1),
-      Row(1, "x", 1, 3),
-      Row(2, "x", 2, 5)))
+      Row(0, "x", 0L, 1, "foo"),
+      Row(1, "x", 1L, 3, "foo"),
+      Row(2, "x", 2L, 5, "foo")))
 
     assertEvalsTo(joinRows(Array[Integer](0, 1, 1, 2), Array[Integer](-1, 0, 0, 1, 1, 2, 2, 3)), FastIndexedSeq(
-      Row(0, "x", 0, 1),
-      Row(1, "x", 1, 3),
-      Row(1, "x", 2, 3),
-      Row(2, "x", 3, 5)))
+      Row(0, "x", 0L, 1, "foo"),
+      Row(1, "x", 1L, 3, "foo"),
+      Row(1, "x", 2L, 3, "foo"),
+      Row(2, "x", 3L, 5, "foo")))
   }
 
   @Test def testDie() {

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -540,6 +540,16 @@ class PruneSuite extends SparkSuite {
       Array(TArray(justA), null, null))
   }
 
+  @Test def testArrayLeftJoinDistinct() {
+    TStruct("a" -> TInt32(), "b" -> TInt32(), "c" -> TInt32())
+    val l = Ref("l", ref.typ)
+    val r = Ref("r", ref.typ)
+    checkMemo(ArrayLeftJoinDistinct(arr, arr, "l", "r",
+      ApplyComparisonOp(LT(TInt32()), GetField(l, "a"), GetField(r, "a")),
+      MakeStruct(FastIndexedSeq("a" -> GetField(l, "a"), "b" -> GetField(l, "b"), "c" -> GetField(l, "c"), "d" -> GetField(r, "b"), "e" -> GetField(r, "c")))),
+      TArray(justA),
+      Array(TArray(justA), TArray(justA), null, justA))
+  }
 
   @Test def testArrayForMemo() {
     checkMemo(ArrayFor(arr, "foo", Begin(FastIndexedSeq(GetField(Ref("foo", ref.typ), "a")))),

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -541,7 +541,6 @@ class PruneSuite extends SparkSuite {
   }
 
   @Test def testArrayLeftJoinDistinct() {
-    TStruct("a" -> TInt32(), "b" -> TInt32(), "c" -> TInt32())
     val l = Ref("l", ref.typ)
     val r = Ref("r", ref.typ)
     checkMemo(ArrayLeftJoinDistinct(arr, arr, "l", "r",


### PR DESCRIPTION
(basically, the same behavior as the rows of TableLeftJoinRightDistinct, but for arrays)

This isn't used anywhere yet. The hope is that eventually we can generate an IR to represent the per-partition work for each stage of computation, at which point this will be used in the per-partition piece for the corresponding TableIR node.

During array deforestation, the left side is completely deforested. The right side is just computed directly and stuck into a RegionValue for now, although when this is pushed into C++ the right side should also be deforested as far as possible (see #4997, #4998 for what I kind of hope to do there).