### PR TITLE
InsertFields takes the final field order

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -1368,7 +1368,7 @@ class StructExpression(Mapping, Expression):
         result_type = tstruct(**new_types)
         indices, aggregations = unify_all(self, *[x for (f, x) in named_exprs.items()])
 
-        return construct_expr(InsertFields(self._ir, list(map(lambda x: (x[0], x[1]._ir), named_exprs.items()))),
+        return construct_expr(InsertFields(self._ir, list(map(lambda x: (x[0], x[1]._ir), named_exprs.items())), None),
                               result_type, indices, aggregations)
 
     @typecheck_method(fields=str, named_exprs=expr_any)

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2567,16 +2567,16 @@ class MatrixTable(ExprContainer):
         mir = base._mir
 
         if row_exprs:
-            row_struct = InsertFields(base.row._ir, [(n, e._ir) for (n, e) in row_exprs.items()])
+            row_struct = InsertFields(base.row._ir, [(n, e._ir) for (n, e) in row_exprs.items()], None)
             mir = MatrixMapRows(mir, row_struct)
         if col_exprs:
-            col_struct = InsertFields(base.col._ir, [(n, e._ir) for (n, e) in col_exprs.items()])
+            col_struct = InsertFields(base.col._ir, [(n, e._ir) for (n, e) in col_exprs.items()], None)
             mir = MatrixMapCols(mir, col_struct, None)
         if entry_exprs:
-            entry_struct = InsertFields(base.entry._ir, [(n, e._ir) for (n, e) in entry_exprs.items()])
+            entry_struct = InsertFields(base.entry._ir, [(n, e._ir) for (n, e) in entry_exprs.items()], None)
             mir = MatrixMapEntries(mir, entry_struct)
         if global_exprs:
-            globals_struct = InsertFields(base.globals._ir, [(n, e._ir) for (n, e) in global_exprs.items()])
+            globals_struct = InsertFields(base.globals._ir, [(n, e._ir) for (n, e) in global_exprs.items()], None)
             mir = MatrixMapGlobals(mir, globals_struct)
 
         return cleanup(MatrixTable(mir))
@@ -2979,7 +2979,7 @@ class MatrixTable(ExprContainer):
         new_key = list(key_struct.keys())
         keys = Env.get_uid()
         fields = [(n, GetField(Ref(keys), n)) for (n, t) in key_struct.dtype.items()]
-        row_ir = Let(keys, key_struct._ir, InsertFields(self.row._ir, fields))
+        row_ir = Let(keys, key_struct._ir, InsertFields(self.row._ir, fields, None))
         return MatrixTable(
             MatrixKeyRowsBy(
                 MatrixMapRows(
@@ -3000,7 +3000,7 @@ class MatrixTable(ExprContainer):
         new_key = list(key_struct.keys())
         keys = Env.get_uid()
         fields = [(n, GetField(Ref(keys), n)) for (n, t) in key_struct.dtype.items()]
-        col_ir = Let(keys, key_struct._ir, InsertFields(self.col._ir, fields))
+        col_ir = Let(keys, key_struct._ir, InsertFields(self.col._ir, fields, None))
         return MatrixTable(MatrixMapCols(self._mir, col_ir, new_key))
 
     @typecheck_method(caller=str, s=expr_struct())

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1462,7 +1462,8 @@ class Table(ExprContainer):
                     original_key = list(left.key)
                     left = Table(TableMapRows(left.key_by()._tir,
                                               InsertFields(left._row._ir,
-                                                           list(zip(uids, [e._ir for e in exprs]))))).key_by(*uids)
+                                                           list(zip(uids, [e._ir for e in exprs])),
+                                                           None))).key_by(*uids)
                     rekey_f = lambda t: t.key_by(*original_key)
                 else:
                     rekey_f = identity

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -67,7 +67,7 @@ class ValueIRTests(unittest.TestCase):
             ir.Begin([ir.Void()]),
             ir.MakeStruct([('x', i)]),
             ir.SelectFields(s, ['x', 'z']),
-            ir.InsertFields(s, [('x', i)]),
+            ir.InsertFields(s, [('x', i)], None),
             ir.GetField(s, 'x'),
             ir.MakeTuple([i, b]),
             ir.GetTupleElement(t, 1),
@@ -259,6 +259,7 @@ class ValueTests(unittest.TestCase):
                 ir.TableRange(1, 1),
                 ir.InsertFields(
                     ir.Ref("global"),
-                    [("foo", row_v)]))
+                    [("foo", row_v)],
+                    None))
             new_globals = hl.eval(hl.Table(map_globals_ir).globals)
             self.assertEquals(new_globals, hl.Struct(foo=v))

--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -434,7 +434,7 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int) {
              |})
              |""".stripMargin)
 
-      case ir.InsertFields(old, fields) =>
+      case ir.InsertFields(old, fields, fieldOrder) =>
         val pStruct = pType.asInstanceOf[PStruct]
         val oldPStruct = old.pType.asInstanceOf[PStruct]
         val oldt = emit(old)

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -74,7 +74,7 @@ object Children {
       fields.map(_._2).toFastIndexedSeq
     case SelectFields(old, fields) =>
       Array(old)
-    case InsertFields(old, fields) =>
+    case InsertFields(old, fields, _) =>
       (old +: fields.map(_._2)).toFastIndexedSeq
     case InitOp(i, args, aggSig) =>
       i +: args

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -98,9 +98,9 @@ object Copy {
       case SelectFields(_, fields) =>
         val IndexedSeq(old: IR) = newChildren
         SelectFields(old, fields)
-      case InsertFields(_, fields) =>
+      case InsertFields(_, fields, fieldOrder) =>
         assert(newChildren.length == fields.length + 1)
-        InsertFields(newChildren.head.asInstanceOf[IR], fields.zip(newChildren.tail).map { case ((n, _), a) => (n, a.asInstanceOf[IR]) })
+        InsertFields(newChildren.head.asInstanceOf[IR], fields.zip(newChildren.tail).map { case ((n, _), a) => (n, a.asInstanceOf[IR]) }, fieldOrder)
       case GetField(_, name) =>
         val IndexedSeq(o: IR) = newChildren
         GetField(o, name)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -804,7 +804,7 @@ private class Emit(
             srvb.offset))
 
 
-      case x@InsertFields(old, fields) =>
+      case x@InsertFields(old, fields, fieldOrder) =>
         if (fields.isEmpty)
           emit(old)
         else

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -195,7 +195,12 @@ final case class SeqOp(i: IR, args: IndexedSeq[IR], aggSig: AggSignature) extend
 final case class Begin(xs: IndexedSeq[IR]) extends IR
 final case class MakeStruct(fields: Seq[(String, IR)]) extends IR
 final case class SelectFields(old: IR, fields: Seq[String]) extends IR
-final case class InsertFields(old: IR, fields: Seq[(String, IR)]) extends IR {
+
+object InsertFields {
+  def apply(old: IR, fields: Seq[(String, IR)]): InsertFields = InsertFields(old, fields, None)
+}
+final case class InsertFields(old: IR, fields: Seq[(String, IR)], fieldOrder: Option[IndexedSeq[String]]) extends IR {
+
   override def typ: TStruct = coerce[TStruct](super.typ)
 
   override def pType: PStruct = coerce[PStruct](super.pType)

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -101,9 +101,10 @@ object InferPType {
       case SelectFields(old, fields) =>
         val tbs = coerce[PStruct](old.pType)
         tbs.selectFields(fields)
-      case InsertFields(old, fields) =>
-        val tbs = coerce[PStruct](old.pType)
-        tbs.insertFields(fields.map(f => (f._1, f._2.pType)))
+      case InsertFields(old, fields, fieldOrder) =>
+        val tbs = coerce[TStruct](old.typ)
+        val s = tbs.insertFields(fields.map(f => (f._1, f._2.typ)))
+        fieldOrder.map(fds => TStruct(fds.map(f => f -> s.fieldType(f)): _*)).getOrElse(s).physicalType
       case GetField(o, name) =>
         val t = coerce[PStruct](o.pType)
         val fd = t.field(name).typ

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -104,9 +104,10 @@ object InferType {
       case SelectFields(old, fields) =>
         val tbs = coerce[TStruct](old.typ)
         tbs.select(fields.toFastIndexedSeq)._1
-      case InsertFields(old, fields) =>
+      case InsertFields(old, fields, fieldOrder) =>
         val tbs = coerce[TStruct](old.typ)
-        tbs.insertFields(fields.map(f => (f._1, f._2.typ)))
+        val s = tbs.insertFields(fields.map(f => (f._1, f._2.typ)))
+        fieldOrder.map(fds => TStruct(fds.map(f => f -> s.fieldType(f)): _*)).getOrElse(s)
       case GetField(o, name) =>
         val t = coerce[TStruct](o.typ)
         if (t.index(name).isEmpty)

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -611,6 +611,8 @@ object Interpret {
               }
               struct
           }
+        else
+          null
       case GetField(o, name) =>
         val oValue = interpret(o, env, args, agg)
         if (oValue == null)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -678,8 +678,9 @@ object IRParser {
         SelectFields(old, fields)
       case "InsertFields" =>
         val old = ir_value_expr(env)(it)
+        val fieldOrder = opt(it, string_literals)
         val fields = named_value_irs(env)(it)
-        InsertFields(old, fields)
+        InsertFields(old, fields, fieldOrder.map(_.toFastIndexedSeq))
       case "GetField" =>
         val name = identifier(it)
         val s = ir_value_expr(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -116,9 +116,12 @@ object Pretty {
           pretty(i, depth + 2)
           sb += '\n'
           prettySeq(args, depth + 2)
-        case InsertFields(old, fields) =>
+        case InsertFields(old, fields, fieldOrder) =>
           sb += '\n'
           pretty(old, depth + 2)
+          sb.append('\n')
+          sb.append(" " * (depth + 2))
+          sb.append(prettyStringsOpt(fieldOrder))
           if (fields.nonEmpty) {
             sb += '\n'
             fields.foreachBetween { case (n, a) =>

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1152,12 +1152,13 @@ class IRSuite extends SparkSuite {
         |            (TableRange 1 12)
         |            (InsertFields
         |              (Ref row)
+        |              None
         |              (s
         |                (Literal Set[String] "[\"foo\"]"))
         |              (nested
         |                (NA Struct{elt:String})))))
         |        (InsertFields
-        |          (Ref row))))
+        |          (Ref row) None)))
         |    (SelectFields (s nested)
         |      (Ref row)))
         |  (Let __uid_1

--- a/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
@@ -3,8 +3,10 @@ package is.hail.expr.ir
 import is.hail.SparkSuite
 import is.hail.TestUtils.assertEvalsTo
 import is.hail.expr.ir.TestUtils.IRAggCount
+import is.hail.expr.types.virtual.{TInt32, TStruct}
 import is.hail.table.{Ascending, SortField}
 import is.hail.utils.FastIndexedSeq
+import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
 class SimplifySuite extends SparkSuite {
@@ -24,4 +26,23 @@ class SimplifySuite extends SparkSuite {
     assertEvalsTo(TableAggregate(checksRepartitioningIR, IRAggCount), 1L)
   }
 
+  lazy val base = Literal(TStruct("1" -> TInt32(), "2" -> TInt32()), Row(1,2))
+  @Test def testInsertFieldsRewriteRules() {
+    val ir1 = InsertFields(InsertFields(base, Seq("1" -> I32(2)), None), Seq("1" -> I32(3)), None)
+    assert(Simplify(ir1) == InsertFields(base, Seq("1" -> I32(3)), None))
+
+    val ir2 = InsertFields(InsertFields(base, Seq("3" -> I32(2)), Some(FastIndexedSeq("3", "1", "2"))), Seq("3" -> I32(3)), None)
+    assert(Simplify(ir2) == InsertFields(base, Seq("3" -> I32(3)), Some(FastIndexedSeq("3", "1", "2"))))
+
+    val ir3 = InsertFields(InsertFields(base, Seq("3" -> I32(2)), Some(FastIndexedSeq("3", "1", "2"))), Seq("4" -> I32(3)), Some(FastIndexedSeq("3", "1", "2", "4")))
+    assert(Simplify(ir3) == InsertFields(base, Seq("3" -> I32(2), "4" -> I32(3)), Some(FastIndexedSeq("3", "1", "2", "4"))))
+  }
+
+  @Test def testInsertSelectRewriteRules() {
+    val ir1 = SelectFields(InsertFields(base, FastIndexedSeq("3" -> I32(1)), None), FastIndexedSeq("1"))
+    assert(Simplify(ir1) == SelectFields(base, FastIndexedSeq("1")))
+
+    val ir2 = SelectFields(InsertFields(base, FastIndexedSeq("3" -> I32(1)), None), FastIndexedSeq("3", "1"))
+    assert(Simplify(ir2) == InsertFields(SelectFields(base, FastIndexedSeq("1")), FastIndexedSeq("3" -> I32(1)), Some(FastIndexedSeq("3", "1"))))
+  }
 }


### PR DESCRIPTION
This allows us to insert fields elsewhere in the struct, and
is necessary for a forthcoming Python IR generation change, which will fix the BGEN allocation performance problem.