### PR TITLE
Fix Python generating Terrible, Horrible, No Good, Very Bad IR

### DIFF
--- a/hail/python/hail/expr/expressions/indices.py
+++ b/hail/python/hail/expr/expressions/indices.py
@@ -1,12 +1,22 @@
 from hail.typecheck import *
 import hail as hl
 
+from typing import List
+
 
 class Indices(object):
     @typecheck_method(source=anytype, axes=setof(str))
     def __init__(self, source=None, axes=set()):
         self.source = source
         self.axes = axes
+        self._initialized_key = False
+
+    def __hash__(self):
+        h = 37
+        h = h * 31 + hash(self.source)
+        for a in self.axes:
+            h = h * 31 + hash(a)
+        return h
 
     def __eq__(self, other):
         return isinstance(other, Indices) and self.source is other.source and self.axes == other.axes
@@ -31,24 +41,30 @@ class Indices(object):
         return Indices(src, axes)
 
     @property
-    def key(self):
+    def protected_key(self) -> List[str]:
+        if self._initialized_key:
+            return self._cached_key
+        else:
+            self._cached_key = self._get_key()
+            self._initialized_key = True
+            return self._cached_key
+
+    def _get_key(self):
         if self.source is None:
-            return None
+            return []
         elif isinstance(self.source, hl.Table):
             if self == self.source._row_indices:
-                return self.source.key
+                return list(self.source.key)
             else:
-                return None
+                return []
         else:
             assert isinstance(self.source, hl.MatrixTable)
             if self == self.source._row_indices:
-                return self.source.row_key
+                return list(self.source.row_key)
             elif self == self.source._col_indices:
-                return self.source.col_key
-            elif self == self.source._entry_indices:
-                return hl.struct(**self.source.row_key, **self.source.col_key)
+                return list(self.source.col_key)
             else:
-                return None
+                return []
 
     def __str__(self):
         return 'Indices(axes={}, source={})'.format(self.axes, self.source)

--- a/hail/python/hail/expr/expressions/indices.py
+++ b/hail/python/hail/expr/expressions/indices.py
@@ -9,14 +9,10 @@ class Indices(object):
     def __init__(self, source=None, axes=set()):
         self.source = source
         self.axes = axes
-        self._initialized_key = False
+        self._cached_key = None
 
     def __hash__(self):
-        h = 37
-        h = h * 31 + hash(self.source)
-        for a in self.axes:
-            h = h * 31 + hash(a)
-        return h
+        return 37 + hash((self.source, *self.axes))
 
     def __eq__(self, other):
         return isinstance(other, Indices) and self.source is other.source and self.axes == other.axes
@@ -42,11 +38,10 @@ class Indices(object):
 
     @property
     def protected_key(self) -> List[str]:
-        if self._initialized_key:
+        if self._cached_key is None:
+            self._cached_key = self._get_key()
             return self._cached_key
         else:
-            self._cached_key = self._get_key()
-            self._initialized_key = True
             return self._cached_key
 
     def _get_key(self):

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -1334,6 +1334,20 @@ class StructExpression(Mapping[str, Expression], Expression):
     def __nonzero__(self):
         return Expression.__nonzero__(self)
 
+    def _annotate_ordered(self, insertions_dict, field_order):
+        def get_type(field):
+            e = insertions_dict.get(field)
+            if e is None:
+                e = self._fields[field]
+            return e.dtype
+
+        new_type = hl.tstruct(**{f: get_type(f) for f in field_order})
+        indices, aggregations = unify_all(self, *insertions_dict.values())
+        return construct_expr(InsertFields(self._ir, [(field, expr._ir) for field, expr in insertions_dict.items()], field_order),
+                              new_type,
+                              indices,
+                              aggregations)
+
     @typecheck_method(named_exprs=expr_any)
     def annotate(self, **named_exprs):
         """Add new fields or recompute existing fields.

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2533,6 +2533,10 @@ class MatrixTable(ExprContainer):
         return Table(CastMatrixToTable(
             self._mir, entries_field_name, cols_field_name))
 
+    def _unfilter_entries(self):
+        entry_ir = hl.cond(hl.is_defined(self.entry), self.entry, hl.struct(**self.entry))._ir
+        return MatrixTable(MatrixMapEntries(self._mir, entry_ir))
+
     @typecheck_method(row_exprs=dictof(str, expr_any),
                       col_exprs=dictof(str, expr_any),
                       entry_exprs=dictof(str, expr_any),

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -1384,6 +1384,7 @@ def hwe_normalized_pca(call_expr, k=10, compute_loadings=False) -> Tuple[List[fl
     mt = mt.annotate_rows(__mean_gt=mt.__AC / mt.__n_called)
     mt = mt.annotate_rows(
         __hwe_scaled_std_dev=hl.sqrt(mt.__mean_gt * (2 - mt.__mean_gt) * n_variants / 2))
+    mt = mt._unfilter_entries()
 
     normalized_gt = hl.or_else((mt.__gt - mt.__mean_gt) / mt.__hwe_scaled_std_dev, 0.0)
 

--- a/hail/python/hail/utils/misc.py
+++ b/hail/python/hail/utils/misc.py
@@ -392,7 +392,7 @@ def get_select_exprs(caller, exprs, named_exprs, indices, base_struct):
 
     check_collisions(caller, final_fields, indices)
 
-    if final_fields != select_fields + list(insertions):
+    if final_fields == select_fields + list(insertions):
         # don't clog the IR with redundant field names
         s = base_struct.select(*select_fields).annotate(**insertions)
     else:

--- a/hail/python/hail/utils/misc.py
+++ b/hail/python/hail/utils/misc.py
@@ -291,58 +291,125 @@ def get_nice_field_error(obj, item):
         s.append("\n    Hint: use 'describe()' to show the names of all data fields.")
     return ''.join(s)
 
-def check_collisions(fields, name, indices):
+def check_collisions(caller, names, indices, override_protected_indices=None):
     from hail.expr.expressions import ExpressionException
-    if name in fields and not fields[name]._indices == indices:
-        msg = "name collision with field indexed by {}: {}".format(list(fields[name]._indices.axes), repr(name))
-        error('Analysis exception: {}'.format(msg))
-        raise ExpressionException(msg)
+    fields = indices.source._fields
 
-def check_field_uniqueness(fields):
-    for k, v in Counter(fields).items():
+    if override_protected_indices is not None:
+        invalid = lambda e: e._indices in override_protected_indices
+    else:
+        invalid = lambda e: e._indices != indices
+
+    # check collisions with fields on other axes
+    for name in names:
+        if name in fields and invalid(fields[name]):
+            msg = f"{caller!r}: name collision with field indexed by {list(fields[name]._indices.axes)}: {name!r}"
+            error('Analysis exception: {}'.format(msg))
+            raise ExpressionException(msg)
+
+    # check duplicate fields
+    for k, v in Counter(names).items():
         if v > 1:
             from hail.expr.expressions import ExpressionException
-            raise ExpressionException("selection would produce duplicate field '{}'".format(repr(k)))
+            raise ExpressionException(f"{caller!r}: selection would produce duplicate field {k!r}")
 
-def check_keys(name, indices):
+def get_key_by_exprs(caller, exprs, named_exprs, indices, override_protected_indices=None):
+    from hail.expr.expressions import to_expr, ExpressionException, analyze
+    exprs = [indices.source[e] if isinstance(e, str) else e for e in exprs]
+    named_exprs = {k: to_expr(v) for k, v in named_exprs.items()}
+
+    bindings = []
+
+    def is_top_level_field(e):
+        return e in indices.source._fields_inverse
+
+    existing_key_fields = []
+    final_key = []
+    for e in exprs:
+        analyze(caller, e, indices, broadcast=False)
+        if not e._ir.is_nested_field:
+            raise ExpressionException(f"{caller!r} expects keyword arguments for complex expressions\n"
+                                      f"  Correct:   ht = ht.key_by('x')\n"
+                                      f"  Correct:   ht = ht.key_by(ht.x)\n"
+                                      f"  Correct:   ht = ht.key_by(x = ht.x.replace(' ', '_'))\n"
+                                      f"  INCORRECT: ht = ht.key_by(ht.x.replace(' ', '_'))")
+
+        name = e._ir.name
+        final_key.append(name)
+
+        if not is_top_level_field(e):
+            bindings.append((name, e))
+        else:
+            existing_key_fields.append(name)
+
+    final_key.extend(named_exprs)
+    bindings.extend(named_exprs.items())
+    check_collisions(caller, final_key, indices, override_protected_indices=override_protected_indices)
+    return final_key, dict(bindings)
+
+
+def check_keys(caller, name, protected_key):
     from hail.expr.expressions import ExpressionException
-    if indices.key is None:
-        return
-    if name in set(indices.key):
-        msg = "cannot overwrite key field {} with annotate, select or drop; use key_by to modify keys.".format(repr(name))
+    if name in protected_key:
+        msg = f"{caller!r}: cannot overwrite key field {name!r} with annotate, select or drop; " \
+              f"use key_by to modify keys."
         error('Analysis exception: {}'.format(msg))
         raise ExpressionException(msg)
 
-def get_select_exprs(caller, exprs, named_exprs, indices, protect_keys=True):
+def get_select_exprs(caller, exprs, named_exprs, indices, base_struct):
     from hail.expr.expressions import to_expr, ExpressionException, analyze
-    exprs = [to_expr(e) if not isinstance(e, str) else indices.source[e] for e in exprs]
+    exprs = [indices.source[e] if isinstance(e, str) else e for e in exprs]
     named_exprs = {k: to_expr(v) for k, v in named_exprs.items()}
-    assignments = OrderedDict()
+    select_fields = indices.protected_key[:]
+    protected_key = set(select_fields)
+    insertions = []
+
+    final_fields = select_fields[:]
+    contains_nested_field = False
+
+    def is_top_level_field(e):
+        return e in indices.source._fields_inverse
 
     for e in exprs:
         if not e._ir.is_nested_field:
-            raise ExpressionException("method '{}' expects keyword arguments for complex expressions".format(caller))
+            raise ExpressionException(f"{caller!r} expects keyword arguments for complex expressions\n"
+                                      f"  Correct:   ht = ht.select('x')\n"
+                                      f"  Correct:   ht = ht.select(ht.x)\n"
+                                      f"  Correct:   ht = ht.select(x = ht.x.replace(' ', '_'))\n"
+                                      f"  INCORRECT: ht = ht.select(ht.x.replace(' ', '_'))")
         analyze(caller, e, indices, broadcast=False)
-        if protect_keys:
-            check_keys(e._ir.name, indices)
-        assignments[e._ir.name] = e
-    for k, e in named_exprs.items():
-        if protect_keys:
-            check_keys(k, indices)
-        check_collisions(indices.source._fields, k, indices)
-        assignments[k] = e
-    check_field_uniqueness(assignments.keys())
-    return assignments
 
-def get_annotate_exprs(caller, named_exprs, indices):
-    from hail.expr.expressions import to_expr, ExpressionException
+        name = e._ir.name
+        check_keys(caller, name, protected_key)
+        final_fields.append(name)
+        if is_top_level_field(e):
+            select_fields.append(name)
+        else:
+            contains_nested_field = True
+            insertions.append((name, e))
+    for k, e in named_exprs.items():
+        check_keys(caller, k, protected_key)
+        insertions.append((k, e))
+        final_fields.append(k)
+
+    check_collisions(caller, final_fields, indices)
+
+    if not contains_nested_field:
+        # don't clog the IR with redundant field names
+        s = base_struct.select(*select_fields).annotate(**dict(insertions))
+    else:
+        s = base_struct.select(*select_fields)._annotate_ordered(dict(insertions), final_fields)
+
+    assert list(s) == final_fields
+    return s
+
+def check_annotate_exprs(caller, named_exprs, indices):
+    from hail.expr.expressions import to_expr
     named_exprs = {k: to_expr(v) for k, v in named_exprs.items()}
-    for k, v in named_exprs.items():
-        check_keys(k, indices)
-        if indices.key and k in indices.key.keys():
-            raise ExpressionException("'{}' cannot overwrite key field: {}"
-                                      .format(caller, repr(k)))
-        check_collisions(indices.source._fields, k, indices)
+    protected_key = set(indices.protected_key)
+    for k in named_exprs:
+        check_keys(caller, k, protected_key)
+    check_collisions(caller, list(named_exprs), indices)
     return named_exprs
 
 def process_joins(obj, exprs):

--- a/hail/python/hail/utils/misc.py
+++ b/hail/python/hail/utils/misc.py
@@ -402,8 +402,6 @@ def get_select_exprs(caller, exprs, named_exprs, indices, base_struct):
     return s
 
 def check_annotate_exprs(caller, named_exprs, indices):
-    from hail.expr.expressions import to_expr
-    named_exprs = {k: to_expr(v) for k, v in named_exprs.items()}
     protected_key = set(indices.protected_key)
     for k in named_exprs:
         check_keys(caller, k, protected_key)

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -206,6 +206,16 @@ class Tests(unittest.TestCase):
         with self.assertRaises(ValueError):
             mt.explode_rows('b')
 
+    def test_group_by_field_lifetimes(self):
+        mt = hl.utils.range_matrix_table(3, 3)
+        mt2 = (mt.group_rows_by(row_idx='100')
+               .aggregate(x=hl.agg.collect_as_set(mt.row_idx + 5)))
+        assert mt2.aggregate_entries(hl.agg.all(mt2.x == hl.set({5, 6, 7})))
+
+        mt3 = (mt.group_cols_by(col_idx='100')
+               .aggregate(x=hl.agg.collect_as_set(mt.col_idx + 5)))
+        assert mt3.aggregate_entries(hl.agg.all(mt3.x == hl.set({5, 6, 7})))
+
     def test_aggregate_cols_by(self):
         mt = hl.utils.range_matrix_table(2, 4)
         mt = (mt.annotate_cols(group=mt.col_idx < 2)

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -191,6 +191,12 @@ class Tests(unittest.TestCase):
         r = kt.aggregate(agg.filter(kt.idx % 2 != 0, agg.sum(kt.idx + 2)) + kt.g1)
         self.assertEqual(r, 40)
 
+    def test_group_by_field_lifetimes(self):
+        ht = hl.utils.range_table(3)
+        ht2 = (ht.group_by(idx='100')
+               .aggregate(x=hl.agg.collect_as_set(ht.idx + 5)))
+        assert (ht2.all(ht2.x == hl.set({5, 6, 7})))
+
     def test_group_aggregate_by_key(self):
         ht = hl.utils.range_table(100, n_partitions=10)
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -111,7 +111,10 @@ object InferType {
       case InsertFields(old, fields, fieldOrder) =>
         val tbs = coerce[TStruct](old.typ)
         val s = tbs.insertFields(fields.map(f => (f._1, f._2.typ)))
-        fieldOrder.map(fds => TStruct(fds.map(f => f -> s.fieldType(f)): _*)).getOrElse(s)
+        fieldOrder.map { fds =>
+          assert(fds.length == s.size)
+          TStruct(fds.map(f => f -> s.fieldType(f)): _*)
+        }.getOrElse(s)
       case GetField(o, name) =>
         val t = coerce[TStruct](o.typ)
         if (t.index(name).isEmpty)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -225,6 +225,7 @@ object TypeCheck {
           val newFieldSet = fields.map(_._1).toSet
           val oldFieldNames = old.typ.asInstanceOf[TStruct].fieldNames
           val oldFieldNameSet = oldFieldNames.toSet
+          assert(fds.length == x.typ.size)
           assert(oldFieldNames
             .filter(f => !newFieldSet.contains(f))
             .sameElements(fds.filter(f => !newFieldSet.contains(f))))


### PR DESCRIPTION
Stacked on #5103 

Fixes #5100 

This PR changes the Python select and key_by operators to generate
the IR we'd expect them to be generating (e.g. `ht.select('x')` emits
a `SelectFields` instead of a `MakeStruct`).

In the process, I found and fixed a bug in group expressions for 
`GroupedMatrixTable`. This is tested for both tables and matrix tables
in the new tests in `test_table` and `test_matrix_table`.

Some timings:

    >>> mt = hl.read_matrix_table('/Users/tpoterba/data/profile.mt')
    >>> %timeit mt.select_entries('GT')._force_count_rows()
    
master: 

    1.64 s ± 106 ms per loop
     
PR: 

    967 ms ± 61.1 ms per loop