### PR TITLE
Raise expression error for misuse of filter/explode without aggregation

### DIFF
--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -23,7 +23,10 @@ class AggregableChecker(TypeChecker):
 
     def check(self, x, caller, param):
         x = self.coercer.check(x, caller, param)
-        assert(len(x._ir.search(lambda node: isinstance(node, BaseApplyAggOp))) != 0)
+        if len(x._ir.search(lambda node: isinstance(node, BaseApplyAggOp))) == 0:
+            raise ExpressionException("{} must be placed outside of an aggregation. See "
+                                      "https://discuss.hail.is/t/breaking-change-redesign-of-aggregator-interface/701"
+                                      .format(caller))
         return x
 
 

--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -24,9 +24,8 @@ class AggregableChecker(TypeChecker):
     def check(self, x, caller, param):
         x = self.coercer.check(x, caller, param)
         if len(x._ir.search(lambda node: isinstance(node, BaseApplyAggOp))) == 0:
-            raise ExpressionException("{} must be placed outside of an aggregation. See "
-                                      "https://discuss.hail.is/t/breaking-change-redesign-of-aggregator-interface/701"
-                                      .format(caller))
+            raise ExpressionException(f"{caller} must be placed outside of an aggregation. See "
+                                      "https://discuss.hail.is/t/breaking-change-redesign-of-aggregator-interface/701")
         return x
 
 

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -380,6 +380,10 @@ class Tests(unittest.TestCase):
             t.aggregate(agg.filter(t.idx > 7, agg.sum(t.idx) / t.idx))
         with self.assertRaises(hl.expr.ExpressionException):
             t.aggregate(agg.group_by(t.idx % 3, agg.sum(t.idx) / t.idx))
+        with self.assertRaises(hl.expr.ExpressionException):
+            t.aggregate(agg.filter(t.idx > 1, t.idx))
+        with self.assertRaises(hl.expr.ExpressionException):
+            t.aggregate(agg.explode(lambda elt: elt, [t.idx, t.idx + 1]))
 
         tests = [(agg.filter(t.idx > 7,
                              agg.explode(lambda x: agg.collect(hl.int64(x + 1)),

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -381,9 +381,9 @@ class Tests(unittest.TestCase):
         with self.assertRaises(hl.expr.ExpressionException):
             t.aggregate(agg.group_by(t.idx % 3, agg.sum(t.idx) / t.idx))
         with self.assertRaises(hl.expr.ExpressionException):
-            t.aggregate(agg.filter(t.idx > 1, t.idx))
+            hl.agg.counter(agg.filter(t.idx > 1, t.idx))
         with self.assertRaises(hl.expr.ExpressionException):
-            t.aggregate(agg.explode(lambda elt: elt, [t.idx, t.idx + 1]))
+            hl.agg.counter(agg.explode(lambda elt: elt, [t.idx, t.idx + 1]))
 
         tests = [(agg.filter(t.idx > 7,
                              agg.explode(lambda x: agg.collect(hl.int64(x + 1)),


### PR DESCRIPTION
Now raises an error instead of asserting. resolves #4770 by clarifying problem with old syntax introduced by [breaking change](https://discuss.hail.is/t/breaking-change-redesign-of-aggregator-interface/701)