### PR TITLE
gVCF combiner: Do proper minrep before and after merging

### DIFF
--- a/hail/python/hail/experimental/vcf_combiner.py
+++ b/hail/python/hail/experimental/vcf_combiner.py
@@ -94,7 +94,7 @@ def combine_gvcfs(mts):
         alts = alleles.map(
             lambda a: hl.switch(hl.allele_type(a.ref, a.alt))
                         .when('SNP', a.alt + ref[hl.len(a.alt):])
-                        .when('Insertion', ref + a.alt[hl.len(a.ref):])
+                        .when('Insertion', a.alt + ref[hl.len(a.ref):])
                         .when('Deletion', a.alt + ref[hl.len(a.ref):])
                         .default(a.alt)
         )

--- a/hail/python/hail/experimental/vcf_combiner.py
+++ b/hail/python/hail/experimental/vcf_combiner.py
@@ -89,8 +89,7 @@ def combine_gvcfs(mts):
         return mt._localize_entries('__entries', '__cols')
 
     def fix_alleles(alleles):
-        s = hl.set(alleles.map(lambda d: d.ref))
-        ref = s.fold(lambda s, t: hl.cond(hl.len(s) > hl.len(t), s, t), '')
+        ref = alleles.map(lambda d: d.ref).fold(lambda s, t: hl.cond(hl.len(s) > hl.len(t), s, t), '')
         alts = alleles.map(
             lambda a: hl.switch(hl.allele_type(a.ref, a.alt))
                         .when('SNP', a.alt + ref[hl.len(a.alt):])


### PR DESCRIPTION
This ensures that variants that are identical across combiner inputs
are properly deduplicated during merge, and then we get the appropriate
representation of all alleles after merging.