### PR TITLE
Lift non-compilable nodes and use compiler in TableMapGlobals

### DIFF
--- a/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
+++ b/hail/src/main/scala/is/hail/backend/local/LocalBackend.scala
@@ -19,7 +19,7 @@ object LocalBackend {
 
     ir = ir.unwrap
     ir = Optimize(ir, noisy = true, canGenerateLiterals = true)
-    ir = LiftLiterals(ir).asInstanceOf[IR]
+    ir = LiftNonCompilable(ir).asInstanceOf[IR]
     ir = LowerMatrixIR(ir)
     ir = Optimize(ir, noisy = true, canGenerateLiterals = false)
 

--- a/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
@@ -13,6 +13,7 @@ object Compilable {
       case _: MatrixWrite => false
       case _: TableToValueApply => false
       case _: MatrixToValueApply => false
+      case _: Literal => false
 
       case _ => true
     }

--- a/hail/src/main/scala/is/hail/expr/ir/EvaluateNonCompilable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EvaluateNonCompilable.scala
@@ -1,0 +1,30 @@
+package is.hail.expr.ir
+
+import is.hail.expr.types.virtual.TStruct
+import org.apache.spark.sql.Row
+
+object EvaluateNonCompilable {
+
+  def apply(ir: IR, name: String): (IR, Row, TStruct) = {
+
+    val nonCompilableNodes = LiftNonCompilable.extractNonCompilable(ir).toArray
+    val emittable = nonCompilableNodes.filter { case (_, value) => CanEmit(value.typ) }
+    val nonEmittable = nonCompilableNodes.filter { case (_, value) => !CanEmit(value.typ) }
+
+    val rowType = TStruct(nonEmittable.map { case (k, v) => (k, v.typ)}: _*)
+    val nonEmittableValues = Row.fromSeq(nonEmittable.map(_._2).map(Interpret[Any](_, optimize = false)))
+
+    val nonEmittableMap = nonEmittable.map { case (k, v) => (v, GetField(Ref(name, rowType), k)) }.toMap
+    val emittableMap = emittable.map { case (k, v) => (v, Literal.coerce(v.typ, Interpret(v, optimize = false))) }.toMap
+    val jointMap = emittableMap ++ nonEmittableMap
+
+    def rewrite(ir: IR): IR = {
+      jointMap.get(ir) match {
+        case Some(binding) => binding
+        case None => MapIR(rewrite)(ir)
+      }
+    }
+
+    (rewrite(ir), nonEmittableValues, rowType)
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -33,7 +33,7 @@ object Interpret {
     else
       tir
 
-    val lowered = LowerMatrixIR(LiftLiterals(tiropt).asInstanceOf[TableIR])
+    val lowered = LowerMatrixIR(LiftNonCompilable(tiropt).asInstanceOf[TableIR])
     val lowopt = if (optimize)
       Optimize(lowered, noisy = true, canGenerateLiterals = false)
     else
@@ -51,7 +51,7 @@ object Interpret {
     else
       mir
 
-    val lowered = LowerMatrixIR(LiftLiterals(miropt).asInstanceOf[MatrixIR])
+    val lowered = LowerMatrixIR(LiftNonCompilable(miropt).asInstanceOf[MatrixIR])
     val lowopt = if (optimize)
       Optimize(lowered, noisy = true, canGenerateLiterals = false)
     else
@@ -86,7 +86,7 @@ object Interpret {
     }
 
     if (optimize) optimizeIR(true)
-    ir = LiftLiterals(ir).asInstanceOf[IR]
+    ir = LiftNonCompilable(ir).asInstanceOf[IR]
     ir = LowerMatrixIR(ir)
     if (optimize) optimizeIR(false)
 


### PR DESCRIPTION
Required for adequate performance in forthcoming lowered MatrixIRs involving the cols.

There are a few changes here.

1) LiftLiterals is renamed to LiftNonCompilable. This pass functions to lift non-compilable IRs into MapGlobals nodes.
2) Introduced EvaluateNonCompilable pass. This evaluates all non-compilable nodes, and replaces them either with primitives (I32, Str, NA), or with references to a struct of compound values.
3) TableMapGlobals uses EvaluateNonCompilable and the compiler.