### PR TITLE
fix to_expr bug

### DIFF
--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -106,7 +106,7 @@ def to_expr(e, dtype=None) -> 'Expression':
 
 def _to_expr(e, dtype):
     if e is None:
-        return hl.null(dtype)
+        return None
     elif isinstance(e, Expression):
         if e.dtype != dtype:
             assert is_numeric(dtype), 'expected {}, got {}'.format(dtype, e.dtype)


### PR DESCRIPTION
Otherwise to_expr generates code (rather than a literal) for literal data containing a missing value which can blow up on large examples.