### PR TITLE
make BaseIR not serializable

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/BaseIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BaseIR.scala
@@ -1,5 +1,7 @@
 package is.hail.expr.ir
 
+import java.io.{ObjectInputStream, ObjectOutputStream}
+
 import is.hail.expr.types.BaseType
 
 abstract class BaseIR {
@@ -18,4 +20,8 @@ abstract class BaseIR {
     else
       copy(newChildren)
   }
+
+  private final def writeObject(out: ObjectOutputStream): Unit = throw new UnsupportedOperationException(this.toString)
+
+  private final def readObject(in: ObjectInputStream): Unit = throw new UnsupportedOperationException(this.toString)
 }


### PR DESCRIPTION
IRs can be huge, we shouldn't be serializing them.