### PR TITLE
remove jrep from Interval

### DIFF
--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -2,10 +2,8 @@ from typing import *
 
 from hail.expr import expressions
 from hail.expr.types import *
-from hail.genetics import Locus, Call
 from hail.ir import *
 from hail.typecheck import linked_list
-from hail.utils import Interval, Struct
 from hail.utils.java import *
 from hail.utils.linkedlist import LinkedList
 from .indices import *
@@ -24,6 +22,9 @@ class ExpressionWarning(Warning):
 
 
 def impute_type(x):
+    from hail.genetics import Locus, Call
+    from hail.utils import Interval, Struct
+    
     if isinstance(x, Expression):
         return x.dtype
     elif isinstance(x, bool):

--- a/hail/python/hail/expr/expressions/expression_utils.py
+++ b/hail/python/hail/expr/expressions/expression_utils.py
@@ -1,5 +1,3 @@
-from hail.utils import warn, error, java
-from hail.utils.java import Env
 from .indices import *
 from ..expressions import Expression, ExpressionException, expr_any
 from typing import *
@@ -15,6 +13,8 @@ def analyze(caller: str,
             expected_indices: Indices,
             aggregation_axes: Set = set(),
             broadcast=True):
+    from hail.utils import warn, error
+
     indices = expr._indices
     source = indices.source
     axes = indices.axes
@@ -187,6 +187,8 @@ def eval_typed(expression):
         Result of evaluating `expression`, and its type.
 
     """
+    from hail.utils.java import Env
+
     analyze('eval_typed', expression, Indices(expression._indices.source))
 
     if expression._indices.source is None:

--- a/hail/python/hail/genetics/locus.py
+++ b/hail/python/hail/genetics/locus.py
@@ -50,7 +50,6 @@ class Locus(object):
         l._contig = jrep.contig()
         l._position = jrep.position()
         l._rg = reference_genome
-        reference_genome._check_locus(jrep)
         super(Locus, l).__init__()
         return l
 

--- a/hail/python/hail/genetics/reference_genome.py
+++ b/hail/python/hail/genetics/reference_genome.py
@@ -201,7 +201,8 @@ class ReferenceGenome(object):
 
         from hail.utils.interval import Interval
         if self._par is None:
-            self._par = [Interval._from_java(jrep, hl.tlocus(self)) for jrep in self._jrep.par()]
+            t = hl.tinterval(hl.tlocus(self))
+            self._par = [t._convert_to_py(jrep) for jrep in self._jrep.par()]
         return self._par
 
     @typecheck_method(contig=str)
@@ -490,10 +491,5 @@ class ReferenceGenome(object):
 
         return gr
 
-    def _check_locus(self, l_jrep):
-        self._jrep.checkLocus(l_jrep)
-
-    def _check_interval(self, interval_jrep):
-        self._jrep.checkInterval(interval_jrep)
 
 rg_type.set(ReferenceGenome)

--- a/hail/python/hail/utils/interval.py
+++ b/hail/python/hail/utils/interval.py
@@ -50,7 +50,7 @@ class Interval(object):
         else:
             bounds = f'{self._start}-{self._end}'
         open = '[' if self._includes_start else '('
-        close = '[' if self._includes_end else '('
+        close = ']' if self._includes_end else ')'
         return f'{open}{bounds}{close}'
 
     def __repr__(self):

--- a/hail/python/hail/utils/interval.py
+++ b/hail/python/hail/utils/interval.py
@@ -1,5 +1,6 @@
 from hail.typecheck import *
 from hail.utils.java import *
+from hail.expr.types import hail_type
 import hail as hl
 
 interval_type = lazy()
@@ -26,15 +27,16 @@ class Interval(object):
     @typecheck_method(start=anytype,
                       end=anytype,
                       includes_start=bool,
-                      includes_end=bool)
-    def __init__(self, start, end, includes_start=True, includes_end=False):
-        from hail.expr.expressions import impute_type, unify_types_limited
-        start_type = impute_type(start)
-        end_type = impute_type(end)
-        point_type = unify_types_limited(start_type, end_type)
-
+                      includes_end=bool,
+                      point_type=nullable(hail_type))
+    def __init__(self, start, end, includes_start=True, includes_end=False, point_type=None):
         if point_type is None:
-            raise TypeError("'start' and 'end' have incompatible types: '{}', '{}'.".format(start_type, end_type))
+            from hail.expr.expressions import impute_type, unify_types_limited
+            start_type = impute_type(start)
+            end_type = impute_type(end)
+            point_type = unify_types_limited(start_type, end_type)
+            if point_type is None:
+                raise TypeError("'start' and 'end' have incompatible types: '{}', '{}'.".format(start_type, end_type))
 
         self._point_type = point_type
         self._start = start
@@ -42,36 +44,28 @@ class Interval(object):
         self._includes_start = includes_start
         self._includes_end = includes_end
 
-        self._jrep = scala_object(Env.hail().utils, 'Interval').apply(
-            point_type._convert_to_j(start),
-            point_type._convert_to_j(end),
-            includes_start,
-            includes_end)
-
     def __str__(self):
-        return self._jrep.toString()
+        if isinstance(self._start, Locus) and self._start.contig == self._end.contig:
+            bounds = f'{self._start}-{self._end.position}'
+        else:
+            bounds = f'{self._start}-{self._end}'
+        open = '[' if self._includes_start else '('
+        close = '[' if self._includes_end else '('
+        return f'{open}{bounds}{close}'
 
     def __repr__(self):
         return 'Interval(start={}, end={}, includes_start={}, includes_end={})'\
             .format(repr(self.start), repr(self.end), repr(self.includes_start), repr(self._includes_end))
 
     def __eq__(self, other):
-        return isinstance(other, Interval) and self._point_type == other._point_type and self._jrep.equals(other._jrep)
+        return (isinstance(other, Interval)
+                and self._start == other._start
+                and self._end == other._end
+                and self._includes_start == other._includes_start
+                and self._includes_end == other._includes_end)
 
     def __hash__(self):
-        return self._jrep.hashCode()
-
-    @classmethod
-    def _from_java(cls, jrep, point_type):
-        interval = Interval.__new__(cls)
-        interval._jrep = jrep
-        interval._point_type = point_type
-        interval._start = None
-        interval._end = None
-        interval._includes_start = None
-        interval._includes_end = None
-        super(Interval, interval).__init__()
-        return interval
+        return hash(self._start) ^ hash(self._end) ^ hash(self._includes_start) ^ hash(self._includes_end)
 
     @property
     def start(self):
@@ -88,8 +82,6 @@ class Interval(object):
         Object with type :meth:`.point_type`
         """
 
-        if self._start is None:
-            self._start = self.point_type._convert_to_py(self._jrep.start())
         return self._start
 
     @property
@@ -107,8 +99,6 @@ class Interval(object):
         Object with type :meth:`.point_type`
         """
 
-        if self._end is None:
-            self._end = self.point_type._convert_to_py(self._jrep.end())
         return self._end
 
     @property
@@ -126,8 +116,6 @@ class Interval(object):
         :obj:`bool`
         """
 
-        if self._includes_start is None:
-            self._includes_start = self._jrep.includesStart()
         return self._includes_start
 
     @property
@@ -145,8 +133,6 @@ class Interval(object):
         :obj:`bool`
         """
 
-        if self._includes_end is None:
-            self._includes_end = self._jrep.includesEnd()
         return self._includes_end
 
     @property
@@ -188,11 +174,7 @@ class Interval(object):
         :obj:`bool`
         """
 
-        from hail.expr.expressions import impute_type
-        value_type = impute_type(value)
-        if value_type != self.point_type:
-            raise TypeError("'value' is incompatible with the interval point type: '{}', '{}'".format(value_type, self.point_type))
-        return self._jrep.contains(self.point_type._parsable_string(), self.point_type._convert_to_j(value))
+        return hl.eval(hl.literal(self, hl.tinterval(self._point_type)).contains(value))
 
     @typecheck_method(interval=interval_type)
     def overlaps(self, interval):
@@ -208,8 +190,6 @@ class Interval(object):
         :obj:`bool`
         """
 
-        if self.point_type != interval.point_type:
-            raise TypeError("'interval' must have the point type '{}', but found '{}'".format(self.point_type, interval.point_type))
-        return self._jrep.overlaps(self.point_type._parsable_string(), interval._jrep)
+        return hl.eval(hl.literal(self, hl.tinterval(self._point_type)).overlaps(interval))
 
 interval_type.set(Interval)


### PR DESCRIPTION
remove _convert_to_j, no longer used (pending some other PRs)

note, this is a breaking change, I'm removing overlaps and contains from the Interval interface.  I doubt anyone is using them.  Users should use hl.eval and the corresponding functions on IntervalExpression.  FYI @tpoterba for release notes (or pushback)
