### PR TITLE
Fix issue with building encoder on worker nodes (fixes #5144)

### DIFF
--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -177,7 +177,7 @@ object ShowBuf {
 final case class PackCodecSpec(child: BufferSpec) extends CodecSpec {
 
   def buildEncoder(t: PType): (OutputStream) => Encoder = {
-    if (HailContext.get.flags.get("cpp") != null) {
+    if (HailContext.get != null && HailContext.get.flags != null && HailContext.get.flags.get("cpp") != null) {
       val e: NativeEncoderModule = cxx.PackEncoder.buildModule(t, child)
       (out: OutputStream) => new NativePackEncoder(out, e)
     } else {
@@ -186,7 +186,7 @@ final case class PackCodecSpec(child: BufferSpec) extends CodecSpec {
   }
 
   def buildDecoder(t: PType, requestedType: PType): (InputStream) => Decoder = {
-    if (HailContext.get.flags.get("cpp") != null) {
+    if (HailContext.get != null && HailContext.get.flags != null && HailContext.get.flags.get("cpp") != null) {
       val d: NativeDecoderModule = cxx.PackDecoder.buildModule(t, requestedType, child)
       (in: InputStream) => new NativePackDecoder(in, d)
     } else {


### PR DESCRIPTION
Don't check feature flags for encoding/decoding if the HailContext doesn't exist.

This should fix the immediate problem in that issue, although longer term, we probably shouldn't be building the encoder (or anything else, either!) on worker nodes.