### PR TITLE
add check that IR type and expression type are the same

### DIFF
--- a/hail/python/hail/expr/expressions/expression_utils.py
+++ b/hail/python/hail/expr/expressions/expression_utils.py
@@ -190,6 +190,10 @@ def eval_typed(expression):
     analyze('eval_typed', expression, Indices(expression._indices.source))
 
     if expression._indices.source is None:
+        ir_type = expression._ir.typ
+        expression_type = expression.dtype
+        if ir_type != expression.dtype:
+            raise ExpressionException(f'Expression type and IR type differed: \n{ir_type}\n vs \n{expression_type}')
         return (Env.backend().execute(expression._ir), expression.dtype)
     else:
         return expression.collect()[0], expression.dtype

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -692,7 +692,7 @@ class GroupByKey(IR):
     def _compute_type(self, env, agg_env):
         self.collection._compute_type(env, agg_env)
         self._type = tdict(self.collection.typ.element_type.types[0],
-                           self.collection.typ.element_type.types[1])
+                           tarray(self.collection.typ.element_type.types[1]))
 
 class ArrayMap(IR):
     @typecheck_method(a=IR, name=str, body=IR)

--- a/hail/python/test/hail/expr/test_types.py
+++ b/hail/python/test/hail/expr/test_types.py
@@ -83,10 +83,4 @@ class Tests(unittest.TestCase):
             self.assertTrue(c.can_coerce(t))
             self.assertFalse(c.requires_conversion(t))
 
-    def test_issue_5147(self):
-        csqs = hl.array([1, 0, 2])
-        s = hl.array([hl.struct(x=hl.int32(0))])
-        f = csqs.find(lambda c: s.map(lambda elt: elt.x).contains(c)),
-        t = hl.utils.range_table(10, 2)
-        t = t.annotate(f=f)
-        t.show()
+

--- a/hail/python/test/hail/expr/test_types.py
+++ b/hail/python/test/hail/expr/test_types.py
@@ -82,5 +82,3 @@ class Tests(unittest.TestCase):
             c = coercer_from_dtype(t)
             self.assertTrue(c.can_coerce(t))
             self.assertFalse(c.requires_conversion(t))
-
-

--- a/hail/python/test/hail/expr/test_types.py
+++ b/hail/python/test/hail/expr/test_types.py
@@ -82,3 +82,11 @@ class Tests(unittest.TestCase):
             c = coercer_from_dtype(t)
             self.assertTrue(c.can_coerce(t))
             self.assertFalse(c.requires_conversion(t))
+
+    def test_issue_5147(self):
+        csqs = hl.array([1, 0, 2])
+        s = hl.array([hl.struct(x=hl.int32(0))])
+        f = csqs.find(lambda c: s.map(lambda elt: elt.x).contains(c)),
+        t = hl.utils.range_table(10, 2)
+        t = t.annotate(f=f)
+        t.show()


### PR DESCRIPTION
This caught a bug in the type inference in `GroupByKey`, which is also fixed in the PR.

@konradjk I'm pretty sure that this makes #5147 work, but I haven't confirmed directly so if you could confirm that it does and then close (or re-ping) once this goes in, that would be great.