### PR TITLE
let container start

### DIFF
--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -79,7 +79,7 @@ def test_cancel_tail(client):
     right = batch.create_job('alpine:3.8', command=['echo', 'right'], parent_ids=[head.id])
     tail = batch.create_job(
         'alpine:3.8',
-        command=['/bin/bash', '-c', 'while true; do sleep 86000; done'],
+        command=['/bin/sh', '-c', 'while true; do sleep 86000; done'],
         parent_ids=[left.id, right.id])
     tail.cancel()
     status = batch.wait()
@@ -96,7 +96,7 @@ def test_cancel_left_before_tail(client):
     head = batch.create_job('alpine:3.8', command=['echo', 'head'])
     left = batch.create_job(
         'alpine:3.8',
-        command=['/bin/bash', '-c', 'while true; do sleep 86000; done'],
+        command=['/bin/sh', '-c', 'while true; do sleep 86000; done'],
         parent_ids=[head.id])
     left.cancel()
     right = batch.create_job('alpine:3.8', command=['echo', 'right'], parent_ids=[head.id])


### PR DESCRIPTION
cc: @cseed 

---

Root issue is that `alpine` does not have `/bin/bash`, so we use `/bin/sh` instead. The syntax for the loops is POSIX compliant.

---

Interesting, these pods were failing due to:

```
    State:      Terminated
      Reason:   ContainerCannotRun
      Message:  oci runtime error: container_linux.go:247: starting container process caused "exec: \"/bin/bash\": stat /bin/bash: no such file or directory"

      Exit Code:    127
      Started:      Fri, 18 Jan 2019 16:15:45 -0500
      Finished:     Fri, 18 Jan 2019 16:15:45 -0500
    Ready:          False
```

But this didn't fail the tests. I suppose because we cancel it faster than k8s realizes the container cannot run and notifies batch?

