### PR TITLE
Fix #5174 - LocusInterval length == 0

### DIFF
--- a/hail/python/test/hail/genetics/test_reference_genome.py
+++ b/hail/python/test/hail/genetics/test_reference_genome.py
@@ -3,6 +3,7 @@ import unittest
 import hail as hl
 from hail.genetics import *
 from ..helpers import *
+from hail.utils import FatalError
 
 setUpModule = startTestHailContext
 tearDownModule = stopTestHailContext
@@ -123,5 +124,7 @@ class Tests(unittest.TestCase):
                          hl.eval(hl.struct(result=hl.locus_interval('chr12', 32563117, 32563121, True, True, 'GRCh38'),
                                            is_negative_strand=True)))
 
-        grch37.remove_liftover("GRCh38")
+        with self.assertRaises(FatalError):
+            hl.eval(hl.liftover(hl.parse_locus_interval('1:10000-10000', reference_genome='GRCh37'), 'GRCh38'))
 
+        grch37.remove_liftover("GRCh38")

--- a/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -240,6 +240,12 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
       else
         fatal(s"Invalid interval `$i' found. End `$end' is not within the range [1-${ contigLength(end.contig) }] for reference genome `$name'.")
     }
+
+    if (!Interval.isValid(locusType.ordering, start, end, includesStart, includesEnd))
+      if (start == end && ((includesStart && !includesEnd) || (!includesStart && includesStart)))
+        fatal(s"Invalid interval `$i' found. Start and end cannot be equal if one endpoint is inclusive and the other endpoint is exclusive.")
+      else
+        fatal(s"Invalid interval `$i' found. ")
   }
 
   def normalizeLocusInterval(i: Interval): Interval = {


### PR DESCRIPTION
@patrick-schultz I fixed this for the case of locus intervals, but wasn't sure if there was a reason we don't add the `isValid` check to the Interval constructors.