### PR TITLE
fix batch cancel logic

### DIFF
--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -76,8 +76,13 @@ class Job:
             _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS)
         self._pod_name = pod.metadata.name
         pod_name_job[self._pod_name] = self
-
-        log.info('created pod name: {} for job {}'.format(self._pod_name, self.id))
+        if self._state == 'Cancelled':
+            self._delete_pod()
+            log.info(f'job was cancelled while waiting on pod creation, but has'
+                     'now been deleted, pod name was: {self._pod_name} for job '
+                     f'{self.id}')
+            return
+        log.info(f'created pod name: {self._pod_name} for job {self.id}')
 
     def _delete_pod(self):
         if self._pod_name:


### PR DESCRIPTION
@cseed You're really the only one who understands this well enough to review it.

resolves #5168 

In order to create a test, we'd have to expose the pod_name to the clients and the tests would have to talk to k8s to ensure said pod was really deleted. Not a terrible test, but maybe more work than I care to do right now given my other commitments.

See the [description of the issue in a comment on #5168](
https://github.com/hail-is/hail/issues/5168#issuecomment-456618542)


cc: k8s-and-services team: @jigold @tpoterba @akotlar 