### PR TITLE
[ci] restest form needs to POST the endpoint

### DIFF
--- a/ci/ci/templates/index.html
+++ b/ci/ci/templates/index.html
@@ -64,7 +64,7 @@
             {{ pr.review }}
           </td>
           <td align="left">
-            <form action="https://ci.hail.is/force_retest_flat">
+            <form action="https://ci.hail.is/force_retest_flat" method="POST">
               <input name="source_branch_name" type="hidden" value="{{ pr.source.ref.name }}">
               <input name="source_repo_name" type="hidden" value="{{ pr.source.ref.repo.name }}">
               <input name="source_repo_owner" type="hidden" value="{{ pr.source.ref.repo.owner }}">


### PR DESCRIPTION
Turn out [the default method is GET](https://www.w3.org/TR/html401/interact/forms.html#h-17.3).