### PR TITLE
[notebook] remove use of $*

### DIFF
--- a/notebook/Makefile
+++ b/notebook/Makefile
@@ -37,8 +37,8 @@ notebook-worker-images: $(PUSHED)
 
 build: $(BUILT) notebook-worker-images
 ifeq ($(CI_BUILD),true)
-	-docker pull gcr.io/${PROJECT}/$*:latest
-	docker build . -t notebook --cache-from=gcr.io/${PROJECT}/$*:latest
+	-docker pull gcr.io/${PROJECT}/notebook:latest
+	docker build . -t notebook --cache-from=gcr.io/${PROJECT}/notebook:latest
 else
 	docker build . -t notebook
 endif


### PR DESCRIPTION
This was preventing use of cache when building the notebook leader image. The `$*` variable is for use with [Pattern Rules](https://www.gnu.org/software/make/manual/html_node/Automatic-Variables.html#Automatic-Variables).

Still note sure why the build is failing.