### PR TITLE
Add tail recursion to IR

### DIFF
--- a/hail/python/hail/experimental/__init__.py
+++ b/hail/python/hail/experimental/__init__.py
@@ -1,5 +1,6 @@
 from .ldscore import ld_score
 from .ld_score_regression import ld_score_regression
+from .loop import loop
 from .filtering_allele_frequency import filtering_allele_frequency
 from .haplotype_freq_em import haplotype_freq_em
 from .plots import hail_metadata, plot_roc_curve
@@ -13,6 +14,7 @@ from .densify import densify
 __all__ = ['ld_score',
            'ld_score_regression',
            'filtering_allele_frequency',
+           'loop',
            'hail_metadata',
            'phase_trio_matrix_by_transmission',
            'phase_by_transmission',

--- a/hail/python/hail/experimental/loop.py
+++ b/hail/python/hail/experimental/loop.py
@@ -1,0 +1,34 @@
+import builtins
+from typing import Callable
+
+from hail.expr.expressions import construct_variable, construct_expr, expr_any, to_expr, unify_all
+from hail.expr.types import hail_type
+from hail.ir.ir import Loop, Recur
+from hail.typecheck import anytype, typecheck
+from hail.utils.java import Env
+
+
+# FIXME, infer loop type?
+@typecheck(f=anytype, typ=hail_type, exprs=expr_any)
+def loop(f: Callable, typ, *exprs):
+    @typecheck(recur_exprs=expr_any)
+    def make_loop(*recur_exprs):
+        if len(recur_exprs) != len(exprs):
+            raise TypeError('loop and recursion must have the same number of arguments')
+        irs = [expr._ir for expr in recur_exprs]
+        indices, aggregations = unify_all(*recur_exprs)
+        return construct_expr(Recur(irs, typ), typ, indices, aggregations)
+
+    uid_irs = []
+    args = []
+
+    for expr in exprs:
+        uid = Env.get_uid()
+        args.append(construct_variable(uid, expr._type, expr._indices, expr._aggregations))
+        uid_irs.append((uid, expr._ir))
+
+    lambda_res = to_expr(f(make_loop, *args))
+    indices, aggregations = unify_all(*exprs, lambda_res)
+    ir = Loop(uid_irs, lambda_res._ir)
+    assert ir.typ == typ, f"requested type {typ} does not match inferred type {ir.typ}"
+    return construct_expr(ir, lambda_res.dtype, indices, aggregations)

--- a/hail/python/hail/experimental/loop.py
+++ b/hail/python/hail/experimental/loop.py
@@ -11,6 +11,37 @@ from hail.utils.java import Env
 # FIXME, infer loop type?
 @typecheck(f=anytype, typ=hail_type, exprs=expr_any)
 def loop(f: Callable, typ, *exprs):
+    """Expression for writing tail recursive expressions.
+
+    Example
+    -------
+
+    >>> x = hl.experimental.loop(lambda recur, acc, n: hl.cond(n > 10, acc, recur(acc + n, n + 1)), hl.tint32, 0, 0)
+    >>> hl.eval(x)
+    55
+
+    Notes
+    -----
+    The first argument to the lambda is a marker for the recursive call.
+
+    Some infinite loop detection is done, and if an infinite loop is detected, `loop` will not
+    typecheck.
+
+    Parameters
+    ----------
+    f : function ( (marker, *args) -> :class:`.Expression`
+        Function of one callable marker, denoting where the recursive call (or calls) is located,
+        and many `exprs`, the loop variables.
+    typ : :obj:`str` or :class:`.HailType`
+        Type the loop returns.
+    exprs : variable-length args of :class:`.Expression`
+        Expressions to initialize the loop values.
+
+    Returns
+    -------
+    :class:`.Expression`
+        Result of the loop with `exprs` as inital loop values.
+    """
     @typecheck(recur_exprs=expr_any)
     def make_loop(*recur_exprs):
         if len(recur_exprs) != len(exprs):

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -395,6 +395,11 @@ class Recur(IR):
         new_instance = self.__class__
         return new_instance(list(args))
 
+    def __eq__(self, other):
+        return isinstance(other, Recur) and \
+            other.args == self.args and \
+            other._typ == self._typ
+
     def render(self, r):
         return '(Recur {})'.format(' '.join([r(arg) for arg in self.args]))
 

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -378,7 +378,11 @@ class Loop(IR):
             other.args == self.args
 
     def _compute_type(self, env, agg_env):
-        self.body._compute_type(env, agg_env)
+        new_env = env.copy()
+        for nm, ir in self.args:
+            ir._compute_type(env, agg_env)
+            new_env[nm] = ir._type
+        self.body._compute_type(new_env, agg_env)
         self._type = self.body.typ
 
 
@@ -409,7 +413,7 @@ class Recur(IR):
 
     def _compute_type(self, env, agg_env):
         for arg in self.args:
-            self._compute_type(env, agg_env)
+            arg._compute_type(env, agg_env)
         self._type = self._typ
 
 

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -40,6 +40,7 @@ class ValueIRTests(unittest.TestCase):
             ir.If(b, i, j),
             ir.Let('v', i, v),
             ir.Ref('x'),
+            ir.Loop([('x', i)], ir.If(b, i, ir.Recur([j], hl.tint32))),
             ir.ApplyBinaryOp('+', i, j),
             ir.ApplyUnaryOp('-', i),
             ir.ApplyComparisonOp('EQ', i, j),
@@ -289,4 +290,4 @@ class ValueTests(unittest.TestCase):
                     [("foo", row_v)],
                     None))
             new_globals = hl.eval(hl.Table(map_globals_ir).globals)
-            self.assertEquals(new_globals, hl.Struct(foo=v))
+            self.assertEqual(new_globals, hl.Struct(foo=v))

--- a/hail/src/main/scala/is/hail/cxx/Definition.scala
+++ b/hail/src/main/scala/is/hail/cxx/Definition.scala
@@ -33,6 +33,16 @@ class Variable(val name: String, val typ: String, init: Expression) extends Defi
     s"$typ $name = $value;"
 }
 
+object Label {
+  def apply(name: String): Label = new Label(name)
+}
+
+class Label(val name: String) extends Definition {
+  override def toString: String = name
+
+  def define: Code = s"$name:"
+}
+
 object ArrayVariable {
   def apply(prefix: String, typ: Type, len: Code): ArrayVariable =
     new ArrayVariable(prefix, typ, Expression(len))

--- a/hail/src/main/scala/is/hail/cxx/TranslationUnit.scala
+++ b/hail/src/main/scala/is/hail/cxx/TranslationUnit.scala
@@ -67,6 +67,10 @@ trait ScopeBuilder {
     Variable(genSym(prefix), typ)
   }
 
+  def label(prefix: String): Label = {
+    Label(genSym(prefix))
+  }
+
   def arrayVariable(prefix: String, typ: String, len: Code): ArrayVariable = {
     ArrayVariable(genSym(prefix), typ, len)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -5,6 +5,8 @@ object Binds {
     x match {
       case Let(n, _, _) =>
         v == n && i == 1
+      case Loop(names, _) =>
+        names.map(_._1).contains(v) && i == names.length
       case ArrayMap(_, n, _) =>
         v == n && i == 1
       case ArrayFlatMap(_, n, _) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -26,6 +26,10 @@ object Children {
       Array(value, body)
     case Ref(name, typ) =>
       none
+    case Loop(args, body) =>
+      (body +: args.map(_._2)).toFastIndexedSeq
+    case Recur(args, _) =>
+      args.toFastIndexedSeq
     case ApplyBinaryPrimOp(op, l, r) =>
       Array(l, r)
     case ApplyUnaryPrimOp(op, x) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -26,6 +26,11 @@ object Copy {
         val IndexedSeq(value: IR, body: IR) = newChildren
         Let(name, value, body)
       case Ref(name, t) => Ref(name, t)
+      case Loop(args, _) =>
+        require(newChildren.tail.length == args.length)
+        Loop(args.map(_._1).zip(newChildren.tail.map(_.asInstanceOf[IR])), newChildren.head.asInstanceOf[IR])
+      case Recur(_, t) =>
+        Recur(newChildren.map(_.asInstanceOf[IR]), t)
       case ApplyBinaryPrimOp(op, _, _) =>
         val IndexedSeq(l: IR, r: IR) = newChildren
         ApplyBinaryPrimOp(op, l, r)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -382,7 +382,7 @@ private class Emit(
         val refs = looprefs.get
         val (t, _, jump) = env.lookup("_LOOP_CODE")
         assert(t == ti, s"Recur type annotation, $typ, $t doesn't match typeinfo: $ti")
-        assert(args.length == refs.length, "invalid number of recur arguments compared to loop arguments")
+        assert(args.length == refs.length, "mismatched number of recur arguments and loop arguments")
         val argsEmit = refs.zip(args).map { case ((t, mx, x), ir) =>
           val ti = typeToTypeInfo(ir.typ)
           assert(t == ti, "type mismatch between loop and recur args")

--- a/hail/src/main/scala/is/hail/expr/ir/Env.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Env.scala
@@ -19,6 +19,8 @@ class Env[V] private (val m: Map[Env.K,V]) {
 
   def delete(name: String): Env[V] = new Env(m - name)
 
+  def delete(names: String*): Env[V] = new Env(m -- names)
+
   def lookup(r: Ref): V =
     lookup(r.name)
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -97,6 +97,23 @@ final case class If(cond: IR, cnsq: IR, altr: IR) extends IR
 final case class Let(name: String, value: IR, body: IR) extends IR
 final case class Ref(name: String, var _typ: Type) extends IR
 
+final case class Loop(params: Seq[(String, IR)], body: IR) extends IR
+final case class Recur(args: Seq[IR], var _typ: Type) extends IR
+object Recur {
+  def updateTypes(ir: IR, typ: Type) {
+    ir match {
+      case If(_, cnsq, altr) =>
+        updateTypes(cnsq, typ)
+        updateTypes(altr, typ)
+      case Let(_, _, body) => updateTypes(body, typ)
+      case x: Recur =>
+        if (x._typ == null)
+          x._typ = typ
+      case _ => {} // do nothing
+    }
+  }
+}
+
 final case class ApplyBinaryPrimOp(op: BinaryOp, l: IR, r: IR) extends IR
 final case class ApplyUnaryPrimOp(op: UnaryOp, x: IR) extends IR
 final case class ApplyComparisonOp(op: ComparisonOp[_], l: IR, r: IR) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -20,6 +20,7 @@ object InferPType {
       case IsNA(_) => PBoolean()
       case Ref(_, t) => PType.canonical(t) // FIXME fill in with supplied physical type
       case In(_, t) => PType.canonical(t) // FIXME fill in with supplied physical type
+      case Recur(_, t) => PType.canonical(t) // FIXME fill in with supplied physical type
       case MakeArray(_, t) => PType.canonical(t)
       case MakeNDArray(data, _, _) => PNDArray(data.pType.asInstanceOf[PArray].elementType)
       case _: ArrayLen => PInt32()
@@ -40,6 +41,8 @@ object InferPType {
         else
           cnsq.pType
       case Let(name, value, body) =>
+        body.pType
+      case Loop(_, body) =>
         body.pType
       case ApplyBinaryPrimOp(op, l, r) =>
         PType.canonical(BinaryOp.getReturnType(op, l.typ, r.typ)).setRequired(l.pType.required && r.pType.required)

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -171,6 +171,8 @@ object InferType {
           Recur.updateTypes(altr, t1)
       case Let(_, _, body) =>
         loopType(body)
+      case _: ApplyBinaryPrimOp => fatal("not tail recursive")
+      case _: ApplyComparisonOp => fatal("not tail recursive")
       case _ => {} // do nothing
     }
     ir.typ

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -1,6 +1,5 @@
 package is.hail.expr.ir
 
-import is.hail.expr.types.RecurType
 import is.hail.expr.types.virtual._
 import is.hail.utils._
 

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -138,11 +138,7 @@ object Interpret {
       case NA(_) => null
       case IsNA(value) => interpret(value, env, args, agg) == null
       case If(cond, cnsq, altr) =>
-        try {
-          assert(cnsq.typ == altr.typ)
-        } catch {
-          case _: RecurType => {}
-        }
+        assert(cnsq.typ == altr.typ)
         val condValue = interpret(cond, env, args, agg)
         if (condValue == null)
           null

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -27,11 +27,7 @@ object LowerMatrixIR {
 
   private[this] def lower(ir: IR): IR = {
     val lowered = lowerChildren(ir).asInstanceOf[IR]
-    try {
-      assert(lowered.typ == ir.typ)
-    } catch {
-      case _: RecurType => {} // lowering recursion is always ok
-    }
+    assert(lowered.typ == ir.typ)
     lowered
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -27,7 +27,11 @@ object LowerMatrixIR {
 
   private[this] def lower(ir: IR): IR = {
     val lowered = lowerChildren(ir).asInstanceOf[IR]
-    assert(lowered.typ == ir.typ)
+    try {
+      assert(lowered.typ == ir.typ)
+    } catch {
+      case _: RecurType => {} // lowering recursion is always ok
+    }
     lowered
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -62,6 +62,22 @@ object Pretty {
       sb.append(prettyClass(ir) )
 
       ir match {
+        case Loop(args, body) =>
+          sb += '('
+          if (args.nonEmpty) {
+            sb += '\n'
+            args.foreachBetween { case (n, a) =>
+              sb.append(" " * (depth + 2))
+              sb += '('
+              sb.append(prettyIdentifier(n))
+              sb += '\n'
+              pretty(a, depth + 4)
+              sb += ')'
+            }(sb += '\n')
+          }
+          sb += ')'
+          sb += '\n'
+          pretty(body, depth + 2)
         case MakeStruct(fields) =>
           if (fields.nonEmpty) {
             sb += '\n'

--- a/hail/src/main/scala/is/hail/expr/ir/Subst.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Subst.scala
@@ -15,6 +15,10 @@ object Subst {
       case Let(name, v, body) =>
         val newv = subst(v)
         Let(name, newv, subst(body, env.delete(name).bind(name, Ref(name, newv.typ))))
+      case Loop(args, body) =>
+        val newArgs = args.map { case (nm, ir) => nm -> subst(ir) }
+        val newBody = subst(body, env.delete(args.map(_._1): _*).bind(args.map{ t => t._1 -> Ref(t._1, t._2.typ) }: _*))
+        Loop(newArgs, newBody)
       case ArrayMap(a, name, body) =>
         ArrayMap(subst(a), name, subst(body, env.delete(name)))
       case ArrayFilter(a, name, cond) =>

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -11,15 +11,15 @@ object TypeCheck {
 
   def apply(ir: IR, env: Env[Type], aggEnv: Option[Env[Type]]): Unit = {
     try {
-      _apply(ir, env, aggEnv, false)
+      _apply(ir, env, aggEnv, None)
     } catch {
       case e: Throwable => fatal(s"Error while typechecking IR:\n${ Pretty(ir) }", e)
     }
   }
 
-  private def _apply(ir: IR, env: Env[Type], aggEnv: Option[Env[Type]], tr: Boolean) {
-    def check(ir: IR, env: Env[Type] = env, aggEnv: Option[Env[Type]] = aggEnv, tr: Boolean = false) {
-      _apply(ir, env, aggEnv, tr)
+  private def _apply(ir: IR, env: Env[Type], aggEnv: Option[Env[Type]], loopargtypes: Option[Seq[Type]]) {
+    def check(ir: IR, env: Env[Type] = env, aggEnv: Option[Env[Type]] = aggEnv, loopargtypes: Option[Seq[Type]] = None) {
+      _apply(ir, env, aggEnv, loopargtypes)
     }
 
     ir match {
@@ -45,27 +45,34 @@ object TypeCheck {
 
       case x@If(cond, cnsq, altr) =>
         check(cond)
-        check(cnsq, tr = tr)
-        check(altr, tr = tr)
+        check(cnsq, loopargtypes = loopargtypes)
+        check(altr, loopargtypes = loopargtypes)
         assert(cond.typ.isOfType(TBoolean()))
         assert(cnsq.typ == altr.typ, s"Type mismatch:\n  cnsq: ${ cnsq.typ.parsableString() }\n  altr: ${ altr.typ.parsableString() }\n  $x")
         assert(x.typ == cnsq.typ)
 
       case x@Let(name, value, body) =>
         check(value)
-        check(body, env = env.bind(name, value.typ), tr = tr)
+        check(body, env = env.bind(name, value.typ), loopargtypes = loopargtypes)
         assert(x.typ == body.typ)
       case x@Ref(name, _) =>
         val expected = env.lookup(x)
         assert(x.typ == expected, s"type mismatch:\n  name: $name\n  actual: ${ x.typ.parsableString() }\n  expect: ${ expected.parsableString() }")
       case x@Loop(args, body) =>
         args.foreach { t => check(t._2) }
-        check(body, env = env.bind(args.map { case (nm, ir) => (nm, ir.typ) }: _*), tr = true)
+        check(body,
+              env = env.bind(args.map { case (nm, ir) => (nm, ir.typ) }: _*),
+              loopargtypes = Some(args.map(_._2.typ)))
         assert(x.typ == body.typ)
       case Recur(args, _) =>
-        if (!tr)
+        if (loopargtypes.isEmpty)
           fatal("loops must be tail recursive")
+        val lat = loopargtypes.get
+        assert(args.length == lat.length, "Loop and matching recursion must have matching numbers of arguments")
         args.foreach(check(_))
+        for { (ir, typ) <- args.zip(lat) } {
+          assert(ir.typ == typ, "loop arguments and recursion arguments must be of the same types")
+        }
       case x@ApplyBinaryPrimOp(op, l, r) =>
         check(l)
         check(r)

--- a/hail/src/main/scala/is/hail/expr/types/BaseType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/BaseType.scala
@@ -21,10 +21,3 @@ abstract class BaseType {
 
   def pyString(sb: StringBuilder) = pretty(sb, 0, compact = true)
 }
-
-// The type of a recur node is an exception. We catch them in inferring the type of If nodes in
-// order to type them properly.
-final class RecurType(
-  override val msg: String,
-  override val logMsg: Option[String] = None,
-  cause: Throwable = null) extends HailException(msg, logMsg, cause)

--- a/hail/src/main/scala/is/hail/expr/types/BaseType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/BaseType.scala
@@ -1,5 +1,7 @@
 package is.hail.expr.types
 
+import is.hail.utils.HailException
+
 abstract class BaseType {
   override final def toString: String = {
     val sb = new StringBuilder
@@ -19,3 +21,10 @@ abstract class BaseType {
 
   def pyString(sb: StringBuilder) = pretty(sb, 0, compact = true)
 }
+
+// The type of a recur node is an exception. We catch them in inferring the type of If nodes in
+// order to type them properly.
+final class RecurType(
+  override val msg: String,
+  override val logMsg: Option[String] = None,
+  cause: Throwable = null) extends HailException(msg, logMsg, cause)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -410,6 +410,7 @@ class IRSuite extends SparkSuite {
         ApplyBinaryPrimOp(Add(), Ref("acc", TInt32()), Ref("n", TInt32()))), TInt32()))
     val tst = Loop(Seq("n" -> I32(10), "acc" -> I32(0)), bdy)
     assertEvalsTo(tst, 55)
+    assertEvalsTo(Loop(Seq("s" -> Str("a string")), Ref("s", TString())), "a string")
 
     interceptFatal("recursion") {
       Loop(Seq("n" -> I32(0)), Recur(Seq(ApplyBinaryPrimOp(Add(), I32(1), Ref("n", TInt32()))), null)).typ
@@ -423,6 +424,10 @@ class IRSuite extends SparkSuite {
     interceptFatal("typechecking") {
       val ir = Loop(FastIndexedSeq(), If(False(), Recur(FastIndexedSeq(), null), Recur(FastIndexedSeq(), null)))
       assertEvalsTo(ir, null)
+    }
+
+    interceptFatal("typechecking") {
+      assertEvalsTo(Recur(Seq(), TInt32()), null)
     }
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -969,6 +969,7 @@ class IRSuite extends SparkSuite {
       If(b, i, j),
       Let("v", i, v),
       Ref("x", TInt32()),
+      Loop(Seq("x" -> i), If(b, i, Recur(Seq(j), TInt32()))),
       ApplyBinaryPrimOp(Add(), i, j),
       ApplyUnaryPrimOp(Negate(), i),
       ApplyComparisonOp(EQ(TInt32()), i, j),

--- a/hail/src/test/scala/is/hail/expr/ir/InterpretSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/InterpretSuite.scala
@@ -29,6 +29,19 @@ class InterpretSuite {
 
   private val tuple = MakeTuple(List(i32, f32, ArrayRange(I32(0), I32(5), I32(1))))
 
+  @Test def testLoopREMOVEWHENDONE() {
+    val bdy = If(
+      ApplyComparisonOp(EQ(TInt32()), Ref("n", TInt32()), I32(0)),
+      Ref("acc", TInt32()),
+      Recur(Seq(
+        ApplyBinaryPrimOp(Add(), Ref("n", TInt32()), I32(-1)),
+        ApplyBinaryPrimOp(Add(), Ref("acc", TInt32()), Ref("n", TInt32()))), TInt32()))
+    val tst = Loop(Seq("n" -> I32(10), "acc" -> I32(0)), bdy)
+    val v = Interpret[Any](tst, false)
+    assert(v == 55)
+    val vOpt = Interpret[Any](tst, true)
+  }
+
   @Test def testUnaryPrimOp() {
     assertEvalSame(t)
     assertEvalSame(f)

--- a/hail/src/test/scala/is/hail/expr/ir/InterpretSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/InterpretSuite.scala
@@ -29,19 +29,6 @@ class InterpretSuite {
 
   private val tuple = MakeTuple(List(i32, f32, ArrayRange(I32(0), I32(5), I32(1))))
 
-  @Test def testLoopREMOVEWHENDONE() {
-    val bdy = If(
-      ApplyComparisonOp(EQ(TInt32()), Ref("n", TInt32()), I32(0)),
-      Ref("acc", TInt32()),
-      Recur(Seq(
-        ApplyBinaryPrimOp(Add(), Ref("n", TInt32()), I32(-1)),
-        ApplyBinaryPrimOp(Add(), Ref("acc", TInt32()), Ref("n", TInt32()))), TInt32()))
-    val tst = Loop(Seq("n" -> I32(10), "acc" -> I32(0)), bdy)
-    val v = Interpret[Any](tst, false)
-    assert(v == 55)
-    val vOpt = Interpret[Any](tst, true)
-  }
-
   @Test def testUnaryPrimOp() {
     assertEvalSame(t)
     assertEvalSame(f)
@@ -217,6 +204,17 @@ class InterpretSuite {
 
   @Test def testLet() {
     assertEvalSame(Let("foo", i64, ApplyBinaryPrimOp(Add(), f64, Cast(Ref("foo", TInt64()), TFloat64()))))
+  }
+
+  @Test def testLoop() {
+    val bdy = If(
+      ApplyComparisonOp(EQ(TInt32()), Ref("n", TInt32()), I32(0)),
+      Ref("acc", TInt32()),
+      Recur(Seq(
+        ApplyBinaryPrimOp(Add(), Ref("n", TInt32()), I32(-1)),
+        ApplyBinaryPrimOp(Add(), Ref("acc", TInt32()), Ref("n", TInt32()))), TInt32()))
+    val tst = Loop(Seq("n" -> I32(10), "acc" -> I32(0)), bdy)
+    assertEvalSame(tst)
   }
 
   @Test def testMakeArray() {


### PR DESCRIPTION
There is still work to do here, but it is now complete enough that InterpretSuite can be run properly on a minimal example.

Current TODOs:
- [x] Add C++ emit
- [x] Add Python api (experimental, for now)
- [x] Proper type checking in python? *yes, but no type inference*
- [ ] Test ALL failure pathways
    - [x] Mismatched Number of args between `Loop` and matching `Recur`
    - [x] Mismatched types of args between `Loop` and matching `Recur`
    - [ ] Infinite loop detection
    - [ ] Not tail recursive detection