### PR TITLE
[ci] Fix CI test flakiness

### DIFF
--- a/ci/test/test-ci.py
+++ b/ci/test/test-ci.py
@@ -141,7 +141,7 @@ def get_deployed_sha(target_ref):
     assert 'latest_deployed' in status
     latest_deployed = {
         FQRef.from_json(x[0]): x[1] for x in status['latest_deployed']}
-    return latest_deployed(target_ref)
+    return latest_deployed[target_ref]
 
 
 def poll_until_deployed_sha_is(target_ref,

--- a/ci/test/test-ci.py
+++ b/ci/test/test-ci.py
@@ -139,7 +139,8 @@ def get_deployed_sha(target_ref):
     assert isinstance(target_ref, FQRef)
     status = ci_get('/status', status_code=200)
     assert 'latest_deployed' in status
-    latest_deployed = {x[0]: x[1] for x in status['latest_deployed']}
+    latest_deployed = {
+        FQRef.from_json(x[0]): x[1] for x in status['latest_deployed']}
     return latest_deployed(target_ref)
 
 


### PR DESCRIPTION
Sleeping used to work when we had a small number of PRs and other jobs. Now, test-CI deploy jobs need to wait a long time to start running. We should have always been polling for CI to be finished deploying, I was just lazy. Fixed now. Also should free up @jigold 's PR.