### PR TITLE
[batch] no parents allowed in other batch

### DIFF
--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -300,7 +300,7 @@ def create_job():
         parent_job = job_id_job.get(parent_id, None)
         if parent_job is None:
             abort(400, f'invalid parent_id: no job with id {parent_id}')
-        if parent_job.batch_id != batch_id:
+        if parent_job.batch_id != batch_id or parent_job.batch_id is None or batch_id is None:
             abort(400,
                   f'invalid parent batch: {parent_id} is in batch '
                   f'{parent_job.batch_id} but child is in {batch_id}')
@@ -309,7 +309,7 @@ def create_job():
         abort(400, f'only one container allowed in pod_spec {pod_spec}')
 
     if pod_spec.containers[0].name != 'default':
-        abort(400, f'container name must be "default" was {pod_spec.containres[0].name}')
+        abort(400, f'container name must be "default" was {pod_spec.containers[0].name}')
 
     job = Job(
         pod_spec,

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -297,8 +297,13 @@ def create_job():
 
     parent_ids = parameters.get('parent_ids', [])
     for parent_id in parent_ids:
-        if parent_id not in job_id_job:
+        parent_job = job_id_job.get(parent_id, None)
+        if parent_job is None:
             abort(400, f'invalid parent_id: no job with id {parent_id}')
+        if parent_job.batch_id != batch_id:
+            abort(400,
+                  f'invalid parent batch: {parent_id} is in batch '
+                  f'{parent_job.batch_id} but child is in {batch_id}')
 
     if len(pod_spec.containers) != 1:
         abort(400, f'only one container allowed in pod_spec {pod_spec}')

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -272,3 +272,28 @@ def test_from_file(client):
 
         status = batch.wait()
         assert status['jobs']['Complete'] == 4
+
+
+def test_no_parents_allowed_without_batch(client):
+    head = client.create_job('alpine:3.8', command=['echo', 'head'])
+    assert head.parent_ids == []
+    try:
+        client.create_job('alpine:3.8', command=['echo', 'tail'], parent_ids=[head.id])
+    except requests.exceptions.HTTPError as err:
+        assert err.response.status_code == 400
+        assert re.search('.*invalid parent batch: .*', err.response.text)
+        return
+    assert False
+
+
+def test_no_parents_allowed_in_other_batches(client):
+    b1 = client.create_batch()
+    b2 = client.create_batch()
+    head = b1.create_job('alpine:3.8', command=['echo', 'head'])
+    try:
+        b2.create_job('alpine:3.8', command=['echo', 'tail'], parent_ids=[head.id])
+    except requests.exceptions.HTTPError as err:
+        assert err.response.status_code == 400
+        assert re.search('.*invalid parent batch: .*', err.response.text)
+        return
+    assert False


### PR DESCRIPTION
Jobs are now only allowed to have parents in the same batch. This is necessary for a long term goal: inter-job dependencies. We plan to temporarily store the output of a job. We need to know when a job can no longer have children (ergo it is safe to delete the job's output). We will add a `batch.close` which prevents a batch from receiving new children. If batch jobs may only depend on other jobs in the batch, then a `close` means that we can delete any output from a job whose children have already read its output.