### PR TITLE
[batch] Batches can be closed

### DIFF
--- a/batch/batch/api.py
+++ b/batch/batch/api.py
@@ -70,6 +70,11 @@ class API():
         raise_on_failure(response)
         return response.json()
 
+    def close_batch(self, url, batch_id):
+        response = requests.post(url + '/batches/{}/close'.format(batch_id), timeout=self.timeout)
+        raise_on_failure(response)
+        return response.json()
+
     def delete_batch(self, url, batch_id):
         response = requests.delete(url + '/batches/{}'.format(batch_id), timeout=self.timeout)
         raise_on_failure(response)
@@ -113,6 +118,10 @@ def create_batch(url, attributes, callback):
 
 def get_batch(url, batch_id):
     return DEFAULT_API.get_batch(url, batch_id)
+
+
+def close_batch(url, batch_id):
+    return DEFAULT_API.close_batch(url, batch_id)
 
 
 def delete_batch(url, batch_id):

--- a/batch/batch/client.py
+++ b/batch/batch/client.py
@@ -101,7 +101,7 @@ class BatchClient:
         self.url = url
         self.api = api
 
-    def _create_job(self,
+    def _create_job(self,  # pylint: disable=R0912
                     image,
                     command,
                     args,

--- a/batch/batch/client.py
+++ b/batch/batch/client.py
@@ -75,6 +75,9 @@ class Batch:
             image, command, args, env, ports, resources, tolerations, volumes, security_context,
             service_account_name, attributes, self.id, callback, parent_ids)
 
+    def close(self):
+        self.client._close_batch(self.id)
+
     def status(self):
         return self.client._get_batch(self.id)
 
@@ -178,6 +181,9 @@ class BatchClient:
 
     def _get_batch(self, batch_id):
         return self.api.get_batch(self.url, batch_id)
+
+    def _close_batch(self, batch_id):
+        return self.api.close_batch(self.url, batch_id)
 
     def _refresh_k8s_state(self):
         self.api.refresh_k8s_state(self.url)

--- a/batch/batch/pylintrc
+++ b/batch/batch/pylintrc
@@ -4,7 +4,7 @@
 # protected member access, W0621 redefining name from outer scope, R0914 too
 # many local variables, W0603 using the global statement, R0902 too many
 # instance attributes
-disable=C0111,W1203,W1202,C0111,R0913,W0622,W0212,W0621,R0914,W0603,R0902
+disable=C0111,W1203,W1202,C0111,R0913,W0622,W0212,W0621,R0914,W0603,R0902,R0801
 
 [FORMAT]
 # String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -268,7 +268,7 @@ app = Flask('batch')
 
 
 @app.route('/jobs/create', methods=['POST'])
-def create_job():
+def create_job():  # pylint: disable=R0912
     parameters = request.json
 
     schema = {

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -296,7 +296,7 @@ def create_job():
         if batch is None:
             abort(404, f'invalid request: batch_id {batch_id} not found')
         if not batch.is_open:
-            abort(404, f'invalid request: batch_id {batch_id} is closed')
+            abort(400, f'invalid request: batch_id {batch_id} is closed')
 
     parent_ids = parameters.get('parent_ids', [])
     for parent_id in parent_ids:

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -292,8 +292,11 @@ def create_job():
 
     batch_id = parameters.get('batch_id')
     if batch_id:
-        if batch_id not in batch_id_batch:
-            abort(404, 'valid request: batch_id {} not found'.format(batch_id))
+        batch = batch_id_batch.get(batch_id)
+        if batch is None:
+            abort(404, f'invalid request: batch_id {batch_id} not found')
+        if not batch.is_open:
+            abort(404, f'invalid request: batch_id {batch_id} is closed')
 
     parent_ids = parameters.get('parent_ids', [])
     for parent_id in parent_ids:
@@ -371,6 +374,7 @@ class Batch:
         self.id = next_id()
         batch_id_batch[self.id] = self
         self.jobs = set([])
+        self.is_open = True
 
     def delete(self):
         del batch_id_batch[self.id]
@@ -396,6 +400,9 @@ class Batch:
                 target=handler,
                 args=(self.id, job.id, self.callback, job.to_json())
             ).start()
+
+    def close(self):
+        self.is_open = False
 
     def to_json(self):
         state_count = Counter([j._state for j in self.jobs])
@@ -445,6 +452,15 @@ def delete_batch(batch_id):
     if not batch:
         abort(404)
     batch.delete()
+    return jsonify({})
+
+
+@app.route('/batches/<int:batch_id>/close', methods=['POST'])
+def close_batch(batch_id):
+    batch = batch_id_batch.get(batch_id)
+    if not batch:
+        abort(404)
+    batch.close()
     return jsonify({})
 
 

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -31,7 +31,7 @@ class Test(unittest.TestCase):
             b.create_job('alpine', ['echo', 'test'])
         except requests.exceptions.HTTPError as err:
             assert err.response.status_code == 400
-            assert re.search('.*invalid request_id: batch_id [0-9]+ is closed', err.response.text)
+            assert re.search('.*invalid request: batch_id [0-9]+ is closed', err.response.text)
             return
         assert False
 

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -1,4 +1,5 @@
 import os
+import re
 import unittest
 import batch
 from flask import Flask, Response, request
@@ -22,6 +23,17 @@ class Test(unittest.TestCase):
         self.assertEqual(j.log(), 'test\n')
 
         self.assertTrue(j.is_complete())
+
+    def test_create_fails_for_closed_batch(self):
+        b = self.batch.create_batch()
+        b.close()
+        try:
+            b.create_job('alpine', ['echo', 'test'])
+        except requests.exceptions.HTTPError as err:
+            assert err.response.status_code == 400
+            assert re.search('.*invalid request_id: batch_id [0-9]+ is closed', err.response.text)
+            return
+        assert False
 
     def test_attributes(self):
         a = {


### PR DESCRIPTION
When a batch is closed the DAG is complete and we do not permit any new jobs to be added. This permits us to safely clean up any job garbage when a job's children are finished. (We don't do any of that right now, but this is necessary for that).