### PR TITLE
add PY_CHECK=false to disable flake8 and pylint in batch

### DIFF
--- a/batch/Makefile
+++ b/batch/Makefile
@@ -55,7 +55,10 @@ test: push-test
 	  < test-batch-pod.yaml.in > test-batch-pod.yaml
 	kubectl create -f test-batch-pod.yaml
 
-test-local: build/conda-env $(PY_CHECKERS)
+ifneq ($(PY_CHECK),false)
+test-local: $(PY_CHECKERS)
+endif
+test-local: build/conda-env
 	. ../loadconda && conda activate hail-batch && POD_NAMESPACE='test' BATCH_USE_KUBE_CONFIG=1 ./test-locally.sh
 
 # local means server and test client are two processes on one machine


### PR DESCRIPTION
This is only relevant to the local testing case. `pylint` is really slow (even if you run it on one file, which was my first attempt to mitigate slowness).