### PR TITLE
modify hail-jupyter image so jupyter can be invoked directory

### DIFF
--- a/apiserver/Dockerfile.hail-jupyter
+++ b/apiserver/Dockerfile.hail-jupyter
@@ -1,3 +1,17 @@
 FROM hail-base
 
-CMD ["/bin/bash", "-c", "source activate hail; jupyter notebook --ip 0.0.0.0 --no-browser --allow-root"]
+RUN mkdir /home/jovian && \
+    mkdir /home/jovian/bin && \
+    groupadd jovian && \
+    useradd -g jovian jovian && \
+    chown -R jovian:jovian /home/jovian
+
+USER jovian
+WORKDIR /home/jovian
+ENV HOME /home/jovian
+ENV PATH "/home/jovian/bin:$PATH"
+ENV HAIL_APISERVER_URL "http://apiserver:5000"
+
+COPY jupyter /home/jovian/bin/jupyter
+
+CMD ["jupyter", "notebook", "--ip", "0.0.0.0", "--no-browser"]

--- a/apiserver/hail-jupyter-pod.yaml.in
+++ b/apiserver/hail-jupyter-pod.yaml.in
@@ -8,9 +8,6 @@ spec:
   containers:
   - name: hail-jupyter
     image: @hail_jupyter_image@
-    env:
-    - name: HAIL_APISERVER_URL
-      value: http://apiserver:5000
     ports:
     - containerPort: 8888
   restartPolicy: Never

--- a/apiserver/jupyter
+++ b/apiserver/jupyter
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+source activate hail
+jupyter "$@"


### PR DESCRIPTION
for use by new notebook server

Let's make sure this is working in the test setup before we merge it.
