### PR TITLE
Gateway + Letsencrypt changes for app , notebook-api 

### DIFF
--- a/gateway/Dockerfile.in
+++ b/gateway/Dockerfile.in
@@ -1,13 +1,6 @@
-FROM debian:9.5
-
-RUN apt-get update -y && \
-    apt-get install -y nginx && \
-    rm -rf /var/lib/apt/lists/*
+FROM nginx:1.15-alpine
 
 RUN rm -f /etc/nginx/sites-enabled/default
 ADD @nginx_conf@ /etc/nginx/conf.d/hail.conf
-
-RUN ln -sf /dev/stdout /var/log/nginx/access.log
-RUN ln -sf /dev/stderr /var/log/nginx/error.log
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/gateway/Dockerfile.in
+++ b/gateway/Dockerfile.in
@@ -1,6 +1,14 @@
-FROM nginx:1.15-alpine
+FROM debian:9.5
+
+RUN apt-get update -y && \
+    apt-get install -y nginx && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN rm -f /etc/nginx/sites-enabled/default
 ADD @nginx_conf@ /etc/nginx/conf.d/hail.conf
+ADD gzip.conf /etc/nginx/conf.d/gzip.conf
+
+RUN ln -sf /dev/stdout /var/log/nginx/access.log
+RUN ln -sf /dev/stderr /var/log/nginx/error.log
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/gateway/gzip.conf
+++ b/gateway/gzip.conf
@@ -1,0 +1,28 @@
+# Re-enable when we migrate to 10.15.8: gzip on;
+gzip_vary on;
+gzip_comp_level 6;
+gzip_buffers 16 8k;
+gzip_http_version 1.1;
+gzip_min_length 512;
+gzip_proxied any;
+
+# suggestions: https://www.fastly.com/blog/new-gzip-settings-and-deciding-what-compress
+# defaults: https://nginx.org/en/docs/http/ngx_http_gzip_module.html
+gzip_types
+    text/plain
+    text/css
+    text/javascript
+    application/json
+    application/javascript
+    application/x-font-ttf
+    application/x-font-truetype
+    application/font-woff
+    font/woff2
+    woff
+    font/eot
+    font/otf
+    font/opentype
+    image/svg+xml
+    svg
+    svgz
+    image/x-icon;

--- a/gateway/hail.nginx.conf.in
+++ b/gateway/hail.nginx.conf.in
@@ -172,8 +172,6 @@ server {
         proxy_pass http://web/;
     }
 
-    #listen 80;
-
     listen [::]:443 ssl;
     listen 443 ssl;
     ssl_certificate /etc/letsencrypt/fullchain.pem;
@@ -185,7 +183,7 @@ server {
 server {
     server_name notebook-api.@domain@;
 
-    # Support arge URI's stemming from access tokens
+    # Support large URI's stemming from access tokens
     client_header_buffer_size 64k;
     large_client_header_buffers 4 64k;
 
@@ -265,9 +263,6 @@ server {
     add_header 'Access-Control-Allow-Credentials' 'true';
     add_header 'Access-Control-Allow-Methods' 'GET, POST, DELETE, OPTIONS';
     add_header 'Access-Control-Allow-Headers' 'Authorization,Keep-Alive,User-Agent,Cache-Control,Content-Type';
-
-
-    #listen 80;
 
     listen [::]:443 ssl;
     listen 443 ssl;

--- a/gateway/hail.nginx.conf.in
+++ b/gateway/hail.nginx.conf.in
@@ -35,9 +35,6 @@ server {
 server {
     server_name scorecard.@domain@;
 
-    gzip on;
-    gzip_types  text/plain text/html application/json;
-
     location / {
         proxy_pass http://scorecard/;
     }
@@ -165,9 +162,6 @@ server {
 server {
     server_name app.@domain@;
 
-    gzip on;
-    gzip_types  text/plain text/css text/html text/javascript application/javascript application/x-javascript text/js text/xml  application/xml application/json application/rss+xml image/svg+xml font/opentype;
-
     location / {
         proxy_pass http://web/;
     }
@@ -186,9 +180,6 @@ server {
     # Support large URI's stemming from access tokens
     client_header_buffer_size 64k;
     large_client_header_buffers 4 64k;
-
-    gzip on;
-    gzip_types  text/plain application/json;
 
     location = /auth {
         internal;

--- a/gateway/hail.nginx.conf.in
+++ b/gateway/hail.nginx.conf.in
@@ -35,6 +35,9 @@ server {
 server {
     server_name scorecard.@domain@;
 
+    gzip on;
+    gzip_types  text/plain text/html application/json;
+
     location / {
         proxy_pass http://scorecard/;
     }
@@ -150,6 +153,121 @@ server {
         proxy_set_header Connection "upgrade";
         proxy_read_timeout 86400;
     }
+
+    listen [::]:443 ssl;
+    listen 443 ssl;
+    ssl_certificate /etc/letsencrypt/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}
+
+server {
+    server_name app.@domain@;
+
+    gzip on;
+    gzip_types  text/plain text/css text/html text/javascript application/javascript application/x-javascript text/js text/xml  application/xml application/json application/rss+xml image/svg+xml font/opentype;
+
+    location / {
+        proxy_pass http://web/;
+    }
+
+    #listen 80;
+
+    listen [::]:443 ssl;
+    listen 443 ssl;
+    ssl_certificate /etc/letsencrypt/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}
+
+server {
+    server_name notebook-api.@domain@;
+
+    # Support arge URI's stemming from access tokens
+    client_header_buffer_size 64k;
+    large_client_header_buffers 4 64k;
+
+    gzip on;
+    gzip_types  text/plain application/json;
+
+    location = /auth {
+        internal;
+
+        resolver kube-dns.kube-system.svc.cluster.local;
+        proxy_pass http://auth-gateway.default.svc.cluster.local/verify/$auth_request_uri;
+    }
+
+    location = /auth-notebook {
+        internal;
+
+        resolver kube-dns.kube-system.svc.cluster.local;
+        proxy_pass http://notebook-api.default.svc.cluster.local/api/verify/$svc_name/$auth_request_uri;
+    }
+
+    location / {
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Credentials' 'true';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, DELETE, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'Authorization,Keep-Alive,User-Agent,X-Requested-With,Cache-Control,Content-Type';
+            add_header 'Access-Control-Max-Age' 86400;
+            add_header 'Content-Type' 'text/plain charset=UTF-8';
+            add_header 'Content-Length' 0;
+            return 204;
+            break;
+        }
+
+        set $auth_request_uri "$is_args$args";
+        auth_request /auth;
+        auth_request_set $auth_user $upstream_http_user;
+        auth_request_set $auth_scope $upstream_http_scope;
+        proxy_pass http://notebook-api;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header User $auth_user;
+        proxy_set_header Scope $auth_scope;
+
+        proxy_http_version 1.1;
+        proxy_read_timeout 86400;
+        proxy_buffering off;
+    }
+
+    location ~ /instance/([^/]+)/(.*) {
+        set $svc_name $1;
+        #set $auth_request_uri "$is_args$args";
+        #auth_request /auth-notebook;
+
+        resolver kube-dns.kube-system.svc.cluster.local;
+        proxy_pass http://$svc_name.default.svc.cluster.local$request_uri;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_http_version 1.1;
+        proxy_redirect off;
+        proxy_buffering off;
+        proxy_read_timeout 86400;
+        proxy_connect_timeout 10s;
+    }
+
+    add_header 'Access-Control-Allow-Origin' '*';
+    add_header 'Access-Control-Allow-Credentials' 'true';
+    add_header 'Access-Control-Allow-Methods' 'GET, POST, DELETE, OPTIONS';
+    add_header 'Access-Control-Allow-Headers' 'Authorization,Keep-Alive,User-Agent,Cache-Control,Content-Type';
+
+
+    #listen 80;
 
     listen [::]:443 ssl;
     listen 443 ssl;

--- a/letsencrypt/domains.txt
+++ b/letsencrypt/domains.txt
@@ -2,6 +2,8 @@
 ci.@domain@
 dev1.@domain@
 notebook.@domain@
+notebook-api.@domain@
+app.@domain@
 scorecard.@domain@
 test.@domain@
 upload.@domain@


### PR DESCRIPTION
Just adds app.hail.is and notebook-api.hail.is server blocks for the two corresponding features, and modifies letsencrypt domain def to allow us to listen on 443/use https.

This has already been pushed to the cluster, works. The auth_request for notebook redirect will be reenabled when I modify it to properly handle not only the initial redirect, but the subsequent ~30 requests issued by the Jupyter web app (various css / js files, and some Ajax requests).