### PR TITLE
Lower MatrixAnnotateColsTable better by unkeying before collecting

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/IRBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IRBuilder.scala
@@ -131,13 +131,13 @@ object IRBuilder {
     def selectFields(fields: String*): IRProxy = (env: E) =>
       SelectFields(ir(env), fields)
 
-    def dropFields(fields: String*): IRProxy = (env: E) => {
+    def dropFieldList(fields: Seq[String]): IRProxy = (env: E) => {
       val struct = ir(env)
       val typ = struct.typ.asInstanceOf[TStruct]
       SelectFields(struct, typ.fieldNames.diff(fields))
     }
 
-    def dropFields(fields: Symbol*): IRProxy = dropFields(fields.map(_.name): _*)
+    def dropFields(fields: Symbol*): IRProxy = dropFieldList(fields.map(_.name))
 
     def len: IRProxy = (env: E) => ArrayLen(ir(env))
 
@@ -187,7 +187,7 @@ object IRBuilder {
         .map(element ~>
           makeTuple(
             element.selectFields(fields: _*),
-            element.dropFields(fields: _*)))
+            element.dropFieldList(fields)))
         .toDict
     }
 

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -142,6 +142,7 @@ object LowerMatrixIR {
         .mapGlobals(let(__dictfield = lower(table)
           .keyBy(FastIndexedSeq())
           .collect()
+          .apply('rows)
           .arrayStructToDict(table.typ.key)) {
           'global.insertFields(colsField ->
             'global(colsField).map(col ~> col.insertFields(Symbol(root) -> '__dictfield.invoke("get", colKey))))

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -141,7 +141,8 @@ object LowerMatrixIR {
       lower(child)
         .mapGlobals(let(__dictfield = lower(table)
           .keyBy(FastIndexedSeq())
-          .collectAsDict()) {
+          .collect()
+          .arrayStructToDict(table.typ.key)) {
           'global.insertFields(colsField ->
             'global(colsField).map(col ~> col.insertFields(Symbol(root) -> '__dictfield.invoke("get", colKey))))
         })

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -140,7 +140,7 @@ object LowerMatrixIR {
       val colKey = makeStruct(table.typ.key.zip(child.typ.colKey).map { case (tk, mck) => Symbol(tk) -> col(Symbol(mck))}: _*)
       lower(child)
         .mapGlobals(let(__dictfield = lower(table)
-          .distinct()
+          .keyBy(FastIndexedSeq())
           .collectAsDict()) {
           'global.insertFields(colsField ->
             'global(colsField).map(col ~> col.insertFields(Symbol(root) -> '__dictfield.invoke("get", colKey))))


### PR DESCRIPTION
The `distinct` is safe to remove since `ToDict` will do its own distinct. The only occasion when we'd want the distinct there is if we have tons of highly duplicated keys in `table`, which is very rare. Otherwise, removing the distinct and inserting an unkey will generate better IRs with fewer shuffles.