### PR TITLE
write codegen tests to their own directory

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -140,6 +140,8 @@ task testCppCodegen(type: Test) {
     systemProperty "file.encoding", "utf-8"
 }
 
+testCppCodegen.reports.html.destination = file("$buildDir/reports/codegen-tests")
+
 compileJava {
     options.compilerArgs << "-Xlint:all" << "-Werror"
 }

--- a/hail/hail-ci-build.sh
+++ b/hail/hail-ci-build.sh
@@ -73,8 +73,8 @@ on_exit() {
     cp ${PIP_PACKAGE_LOG} ${ARTIFACTS}
     cp -R build/www ${ARTIFACTS}/www
     cp -R src/main/c/build/reports ${ARTIFACTS}/cxx-report
-    cp -R build/reports/scala-tests ${ARTIFACTS}/test-report
-    cp -R build/reports/tests ${ARTIFACTS}/codegen-test-report
+    cp -R build/reports/tests ${ARTIFACTS}/test-report
+    cp -R build/reports/codegen-tests ${ARTIFACTS}/codegen-test-report
     cp -R build/reports/pytest.html ${ARTIFACTS}/hail-python-test.html
 
     COMP_STATUS=$(get_status "${COMP_SUCCESS}")
@@ -210,16 +210,8 @@ touch ${COMP_SUCCESS}
 test_project() {
     ./gradlew nativeLibTest > ${CXX_TEST_LOG} 2>&1
     touch ${CXX_TEST_SUCCESS}
-
-    # move Scala test log even if tests fail
-    set +e
     ./gradlew test > ${SCALA_TEST_LOG} 2>&1
-    SCALA_TEST_RC=$?
-    mv build/reports/tests build/reports/scala-tests
-    set -e
-    [ ${SCALA_TEST_RC} == 0 ]
     touch ${SCALA_TEST_SUCCESS}
-
     ./gradlew testCppCodegen > ${CXX_CODEGEN_TEST_LOG} 2>&1
     touch ${CXX_CODEGEN_TEST_SUCCESS}
     ./gradlew testPython > ${PYTHON_TEST_LOG} 2>&1


### PR DESCRIPTION
Fixes #5106.

(I realized halfway through that cseed fixed the problem with the artifacts not getting copied in a PR a few weeks ago, but I think the codegen tests should probably be writing to their own directory and not overwriting other tests.)