### PR TITLE
added experimental aggregator _prev_nonnull and densify

### DIFF
--- a/hail/python/hail/experimental/__init__.py
+++ b/hail/python/hail/experimental/__init__.py
@@ -8,6 +8,7 @@ from .datasets import load_dataset
 from .import_gtf import import_gtf
 from .write_multiple import write_matrix_tables
 from .export_entries_by_col import export_entries_by_col
+from .densify import densify
 
 __all__ = ['ld_score',
            'ld_score_regression',
@@ -21,4 +22,5 @@ __all__ = ['ld_score',
            'import_gtf',
            'haplotype_freq_em',
            'write_matrix_tables',
-           'export_entries_by_col']
+           'export_entries_by_col',
+           'densify']

--- a/hail/python/hail/experimental/densify.py
+++ b/hail/python/hail/experimental/densify.py
@@ -1,0 +1,50 @@
+import hail as hl
+from hail.methods.misc import require_row_key_variant
+
+from hail import MatrixTable
+
+def densify(sparse_mt):
+    """Convert sparse MatrixTable to a dense one.
+
+    Parameters
+    ----------
+    sparse_mt : :class:`.MatrixTable`
+        Sparse MatrixTable to densify.  The first row key field must
+        be named ``locus`` and have type ``locus``.  Must have an
+        ``END`` entry field of type ``int32``.
+
+    Returns
+    -------
+    :class:`.MatrixTable`
+        The densified MatrixTable.  The ``END`` entry field is dropped.
+
+    """
+    if list(sparse_mt.row_key)[0] != 'locus' or not isinstance(sparse_mt.locus.dtype, hl.tlocus):
+        raise ValueError("first row key field must be named 'locus' and have type 'locus'")
+    if 'END' not in sparse_mt.entry or sparse_mt.END.dtype != hl.tint32:
+        raise ValueError("'densify' requires 'END' entry field of type 'int32'")
+    col_key_fields = list(sparse_mt.col_key)
+
+    mt = sparse_mt
+    mt = sparse_mt.annotate_entries(__contig = mt.locus.contig)
+    t = mt._localize_entries('__entries', '__cols')
+    t = t.annotate(
+        __entries = hl.rbind(
+            hl.scan.array_agg(
+                lambda entry: hl.scan._prev_nonnull(entry),
+                t.__entries),
+            lambda prev_entries: hl.map(
+                lambda i:
+                hl.rbind(
+                    prev_entries[i], t.__entries[i],
+                    lambda prev_entry, entry:
+                    hl.cond(
+                        (hl.is_defined(prev_entry.END) &
+                         (prev_entry.END >= t.locus.position) &
+                         (prev_entry.__contig == t.locus.contig)),
+                        prev_entry,
+                        entry)),
+                hl.range(0, hl.len(t.__entries)))))
+    mt = t._unlocalize_entries('__entries', '__cols', col_key_fields)
+    mt = mt.drop('__contig', 'END')
+    return mt

--- a/hail/python/hail/experimental/densify.py
+++ b/hail/python/hail/experimental/densify.py
@@ -1,7 +1,5 @@
 import hail as hl
 
-from hail import MatrixTable
-
 def densify(sparse_mt):
     """Convert sparse MatrixTable to a dense one.
 

--- a/hail/python/hail/experimental/densify.py
+++ b/hail/python/hail/experimental/densify.py
@@ -1,5 +1,4 @@
 import hail as hl
-from hail.methods.misc import require_row_key_variant
 
 from hail import MatrixTable
 

--- a/hail/python/hail/expr/aggregators/__init__.py
+++ b/hail/python/hail/expr/aggregators/__init__.py
@@ -1,7 +1,7 @@
 from .aggregators import collect, collect_as_set, count, count_where, counter, \
     any, all, take, min, max, sum, array_sum, mean, stats, product, fraction, \
     hardy_weinberg_test, explode, filter, inbreeding, call_stats, info_score, \
-    hist, linreg, corr, group_by, downsample, array_agg
+    hist, linreg, corr, group_by, downsample, array_agg, _prev_nonnull
 
 __all__ = [
     'collect',
@@ -31,5 +31,6 @@ __all__ = [
     'corr',
     'group_by',
     'downsample',
-    'array_agg'
+    'array_agg',
+    '_prev_nonnull'
 ]

--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -1416,6 +1416,9 @@ def group_by(group, agg_expr) -> DictExpression:
 
     return _agg_func.group_by(group, agg_expr)
 
+@typecheck(expr=expr_any)
+def _prev_nonnull(expr) -> ArrayExpression:
+    return _agg_func('PrevNonnull', [expr], expr.dtype, [])
 
 @typecheck(f=func_spec(1, expr_any),
            array=expr_array())

--- a/hail/python/hail/ir/register_aggregators.py
+++ b/hail/python/hail/ir/register_aggregators.py
@@ -63,3 +63,5 @@ def register_aggregators():
     register_aggregator('LinearRegression', (dtype('int32'), dtype('int32'),), None, (dtype('float64'), dtype('array<float64>'),), linreg_aggregator_type)
 
     register_aggregator('PearsonCorrelation', (), None, (dtype('tfloat64'), dtype('float64'),), dtype('float64'))
+
+    register_aggregator('PrevNonnull', (), None, (dtype('?in'),), dtype('?in'))

--- a/hail/src/main/scala/is/hail/Uploader.scala
+++ b/hail/src/main/scala/is/hail/Uploader.scala
@@ -104,7 +104,7 @@ class Uploader { self =>
           self.upload(typ, contents, email)
         } catch {
           case e: Exception =>
-            warn(s"upload failed, caught $e")
+            log.warn(s"upload failed, caught $e")
         }
       }
     }

--- a/hail/src/main/scala/is/hail/annotations/aggregators/RegionValuePrevNonnullAnnotationAggregator.scala
+++ b/hail/src/main/scala/is/hail/annotations/aggregators/RegionValuePrevNonnullAnnotationAggregator.scala
@@ -1,0 +1,38 @@
+package is.hail.annotations.aggregators
+
+import is.hail.annotations.{Annotation, Region, RegionValueBuilder, SafeRow}
+import is.hail.expr.types.virtual.Type
+
+class RegionValuePrevNonnullAnnotationAggregator(t: Type) extends RegionValueAggregator {
+  var last: Annotation = null
+
+  def seqOp(region: Region, offset: Long, missing: Boolean) {
+    if (!missing)
+      last = SafeRow.read(t.physicalType, region, offset)
+  }
+
+  def combOp(agg2: RegionValueAggregator) {
+    val that = agg2.asInstanceOf[RegionValuePrevNonnullAnnotationAggregator]
+    if (that.last != null)
+      last = that.last
+  }
+
+  def result(rvb: RegionValueBuilder) {
+    if (last != null)
+      rvb.addAnnotation(t, last)
+    else
+      rvb.setMissing()
+  }
+
+  def newInstance(): RegionValuePrevNonnullAnnotationAggregator = new RegionValuePrevNonnullAnnotationAggregator(t)
+
+  def copy(): RegionValuePrevNonnullAnnotationAggregator = {
+    val rva = new RegionValuePrevNonnullAnnotationAggregator(t)
+    rva.last = last
+    rva
+  }
+
+  def clear() {
+    last = null
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -38,6 +38,7 @@ final case class TakeBy() extends AggOp
 final case class Group() extends AggOp
 final case class AggElements() extends AggOp
 final case class AggElementsLengthCheck() extends AggOp
+final case class PrevNonnull() extends AggOp
 
 // exists === map(p).sum, needs short-circuiting aggs
 // forall === map(p).product, needs short-circuiting aggs
@@ -209,6 +210,8 @@ object AggOp {
         TFloat64(),
         seqOpArgTypes = Array(classOf[Double], classOf[Double])
       )
+
+    case (PrevNonnull(), Seq(), None, Seq(in)) => CodeAggregator[RegionValuePrevNonnullAnnotationAggregator](in, constrArgTypes = Array(classOf[Type]), seqOpArgTypes = Array(classOf[Long]))
   }
 
   private def incompatible(aggSig: AggSignature): Nothing = {
@@ -238,5 +241,6 @@ object AggOp {
     case "linreg" | "LinearRegression" => LinearRegression()
     case "corr" | "PearsonCorrelation" => PearsonCorrelation()
     case "downsample" | "Downsample" => Downsample()
+    case "prevnonnull" | "PrevNonnull" => PrevNonnull()
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -137,7 +137,7 @@ object ExtractAggregators {
 
       aggSig match {
         case AggSignature(Collect() | Take() | CollectAsSet(), _, _, Seq(t@(_: TBoolean | _: TInt32 | _: TInt64 | _: TFloat32 | _: TFloat64 | _: TCall))) =>
-        case AggSignature(Collect() | Take() | CollectAsSet(), _, _, Seq(t)) =>
+        case AggSignature(Collect() | Take() | CollectAsSet() | PrevNonnull(), _, _, Seq(t)) =>
           codeConstructorArgs ++= FastIndexedSeq(EmitTriplet(Code._empty, const(false), fb.getType(t)))
         case AggSignature(Counter(), _, _, Seq(t@(_: TBoolean))) =>
         case AggSignature(Counter(), _, _, Seq(t)) =>


### PR DESCRIPTION
I made `_prev_nonnull` private since it's pretty specific to this use case, but I can imagine we'll want to generalize it to something like `take` which aggregates the last `n` values instead of the first `n` values.

Here is an example pipeline against `test-chr22.mt`:

```
import hail as hl

mt = hl.read_matrix_table('test-chr22.mt')
mt = mt._filter_partitions(range(8)) # make small

# restrict to two samples
mt = mt.filter_cols((mt.s == 'V33335') | (mt.s == 'NWD157935'))
mt = mt.annotate_rows(__n = hl.agg.count_where(hl.is_defined(mt.GT)))
mt = mt.filter_rows(mt.__n > 0)

print(
    mt.count())

def show_mt(mt):
    entry_fields = ['GT']
    if 'END' in mt.entry:
        entry_fields.append('END')
    (mt.select_rows()
     .select_entries(*entry_fields)
     ._localize_entries('__entries', '__cols')
     .show())

show_mt(mt)

mt = hl.experimental.densify(mt)
show_mt(mt)

mt.describe()
```

which produces sparse and dense samples:

```
+----------------+-------------------------------------+
| locus          | __entries                           |
+----------------+-------------------------------------+
| locus<GRCh38>  | array<struct{GT: call, END: int32}> |
+----------------+-------------------------------------+
| chr22:10510746 | [NA,(0/0,10510769)]                 |
| chr22:10510770 | [NA,(1/1,NA)]                       |
| chr22:10510771 | [NA,(0/0,10510891)]                 |
| chr22:10511207 | [NA,(0/0,10511390)]                 |
| chr22:10511272 | [(0/0,10511390),NA]                 |
| chr22:10511391 | [NA,(1/1,NA)]                       |
| chr22:10511392 | [(0/0,10511393),(0/0,10511477)]     |
| chr22:10511397 | [(0/0,10511403),NA]                 |
| chr22:10511406 | [(0/0,10511418),NA]                 |
| chr22:10511420 | [(0/0,10511420),NA]                 |
+----------------+-------------------------------------+
showing top 10 rows

+----------------+-------------------------+
| locus          | __entries               |
+----------------+-------------------------+
| locus<GRCh38>  | array<struct{GT: call}> |
+----------------+-------------------------+
| chr22:10510746 | [NA,(0/0)]              |
| chr22:10510770 | [NA,(1/1)]              |
| chr22:10510771 | [NA,(0/0)]              |
| chr22:10511207 | [NA,(0/0)]              |
| chr22:10511272 | [(0/0),(0/0)]           |
| chr22:10511391 | [NA,(1/1)]              |
| chr22:10511392 | [(0/0),(0/0)]           |
| chr22:10511397 | [(0/0),(0/0)]           |
| chr22:10511406 | [(0/0),(0/0)]           |
| chr22:10511420 | [(0/0),(0/0)]           |
+----------------+-------------------------+
```

Thanks to @tpoterba for the totally sick `array_agg`.  It's crazy how simple this was.  (Unfortunately, it won't be so simple to make it go fast.)
