### PR TITLE
add batch/recent endpoint

### DIFF
--- a/batch/batch/server/globals.py
+++ b/batch/batch/server/globals.py
@@ -1,3 +1,5 @@
+import datetime
+
 pod_name_job = {}
 job_id_job = {}
 batch_id_batch = {}
@@ -24,3 +26,19 @@ def next_id():
 
     _counter = _counter + 1
     return _counter
+
+
+_recent_events = []
+
+
+def get_recent_events():
+    return _recent_events
+
+
+def add_event(event):
+    event['time'] = str(datetime.datetime.now())
+
+    global _recent_events
+
+    _recent_events = _recent_events[:100]
+    _recent_events.append(event)

--- a/batch/batch/server/globals.py
+++ b/batch/batch/server/globals.py
@@ -1,4 +1,5 @@
 import datetime
+import collections
 
 pod_name_job = {}
 job_id_job = {}
@@ -28,7 +29,7 @@ def next_id():
     return _counter
 
 
-_recent_events = []
+_recent_events = collections.deque(maxlen=50)
 
 
 def get_recent_events():
@@ -36,9 +37,7 @@ def get_recent_events():
 
 
 def add_event(event):
-    event['time'] = str(datetime.datetime.now())
-
     global _recent_events
 
-    _recent_events = _recent_events[:100]
+    event['time'] = str(datetime.datetime.now())
     _recent_events.append(event)

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -142,7 +142,6 @@ class Job:
             spec=pod_spec)
 
         log.info('created job {}'.format(self.id))
-        print('pod_spec', pod_spec.containers[0].command)
         add_event({'message': f'created job {self.id}', 'command': ' '.join(pod_spec.containers[0].command)})
 
         if not self.parent_ids:
@@ -222,7 +221,7 @@ class Job:
             POD_NAMESPACE,
             _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS)
 
-        add_event({'message': f'job {self.id} exited', 'log': pod_log})
+        add_event({'message': f'job {self.id} exited', 'log': pod_log[:64000]})
 
         fname = _log_path(self.id)
         with open(fname, 'w') as f:
@@ -541,7 +540,6 @@ def refresh_k8s_state():
 @app.route('/recent', methods=['GET'])
 def recent():
     recent_events = get_recent_events()
-    print(recent_events)
     return render_template('recent.html', recent=list(reversed(recent_events)))
 
 

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -6,13 +6,13 @@ import uuid
 from collections import Counter
 import logging
 import threading
-from flask import Flask, request, jsonify, abort
+from flask import Flask, request, jsonify, abort, render_template
 import kubernetes as kube
 import cerberus
 import requests
 
 from .globals import max_id, pod_name_job, job_id_job, _log_path, _read_file, batch_id_batch
-from .globals import next_id
+from .globals import next_id, get_recent_events, add_event
 
 from .. import schemas
 
@@ -142,6 +142,8 @@ class Job:
             spec=pod_spec)
 
         log.info('created job {}'.format(self.id))
+        print('pod_spec', pod_spec.containers[0].command)
+        add_event({'message': f'created job {self.id}', 'command': ' '.join(pod_spec.containers[0].command)})
 
         if not self.parent_ids:
             self._create_pod()
@@ -219,6 +221,9 @@ class Job:
             pod.metadata.name,
             POD_NAMESPACE,
             _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS)
+
+        add_event({'message': f'job {self.id} exited', 'log': pod_log})
+
         fname = _log_path(self.id)
         with open(fname, 'w') as f:
             f.write(pod_log)
@@ -531,6 +536,13 @@ def refresh_k8s_state():
     log.info('k8s state refresh complete')
 
     return '', 204
+
+
+@app.route('/recent', methods=['GET'])
+def recent():
+    recent_events = get_recent_events()
+    print(recent_events)
+    return render_template('recent.html', recent=list(reversed(recent_events)))
 
 
 def run_forever(target, *args, **kwargs):

--- a/batch/batch/templates/recent.html
+++ b/batch/batch/templates/recent.html
@@ -1,0 +1,34 @@
+<html lang="en">
+  <head>
+    <title>Batch: Recent Events</title>
+    <style type="text/css">
+      h2 { font-size: 1.2em; }
+      .log { margin-left: 1em; }
+      body {
+	  font-family: "Lucida Sans Unicode", "Lucida Grande", sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>Recent Events</h2>
+    {% if recent|length > 0 %}
+    {% for event in recent %}
+    <div>
+      <p>
+	{{ event.time }}
+	{{ event.message }}{% if event.command %}:
+	<code>{{ event.command }}</code>
+	{% endif %}
+      </p>
+      {% if event.log %}
+      <div class="log">
+	<pre>{{ event.log }}</pre>
+      </div>
+      {% endif %}
+    </div>
+    {% endfor %}
+    {% else %}
+    <p>There are no recent events.</p>
+    {% endif %}
+  </body>
+</html>


### PR DESCRIPTION
informational page for last 100 job created (with command line) and job finished (with log) events

This is for @jigold's demo on Monday so she can give some sense of progress of jobs when running a pipeline demo.

Note, batch isn't exposed publicly so you'll have to `kubectl` port forward to access it.

Not the most beautiful, but should be functional.  Here's a screenshot:

![screenshot](https://user-images.githubusercontent.com/1244990/52447370-8997d680-2afe-11e9-92f5-2e56121b4af7.png)
