### PR TITLE
fix trio matrix filter_to typecheck error

### DIFF
--- a/hail/python/hail/genetics/pedigree.py
+++ b/hail/python/hail/genetics/pedigree.py
@@ -222,7 +222,7 @@ class Pedigree(object):
         """
         return list(filter(lambda t: t.is_complete(), self.trios))
 
-    @typecheck_method(samples=sequenceof(str))
+    @typecheck_method(samples=sequenceof(nullable(str)))
     def filter_to(self, samples):
         """Filter the pedigree to a given list of sample IDs.
 

--- a/hail/python/test/hail/methods/test_family_methods.py
+++ b/hail/python/test/hail/methods/test_family_methods.py
@@ -80,6 +80,19 @@ class Tests(unittest.TestCase):
         self.assertEqual(e_cols.row.dtype, t_cols.row.dtype)
         self.assertTrue(e_cols._same(t_cols))
 
+    def test_trio_matrix_null_keys(self):
+        ped = hl.Pedigree.read(resource('triomatrix.fam'))
+        ht = hl.import_fam(resource('triomatrix.fam'))
+
+        mt = hl.import_vcf(resource('triomatrix.vcf'))
+        mt = mt.annotate_cols(fam=ht[mt.s].fam_id)
+
+        # Make keys all null
+        mt = mt.key_cols_by(s=hl.null(hl.tstr))
+
+        tt = hl.trio_matrix(mt, ped, complete_trios=True)
+        self.assertEqual(tt.count_cols(), 0)
+
     def test_mendel_errors(self):
         mt = hl.import_vcf(resource('mendel.vcf'))
         ped = hl.Pedigree.read(resource('mendel.fam'))


### PR DESCRIPTION
Fixes #5293

@tpoterba I decided not to throw an error if the key is null and instead just let the `flatMap` in `restrictTo` take care of it. Let me know if you think we should error out.