### PR TITLE
[hail][new feature] Add regex filter/substitution to import_table and import_vcf

### DIFF
--- a/hail/python/hail/ir/matrix_reader.py
+++ b/hail/python/hail/ir/matrix_reader.py
@@ -7,6 +7,8 @@ from ..utils import wrap_to_list
 from ..utils.java import escape_str
 from ..genetics.reference_genome import reference_genome_type
 
+from .utils import make_filter_and_replace
+
 
 class MatrixReader(object):
     @abc.abstractmethod
@@ -68,6 +70,8 @@ class MatrixVCFReader(MatrixReader):
                       skip_invalid_loci=bool,
                       force_bgz=bool,
                       force_gz=bool,
+                      filter=nullable(str),
+                      find_replace=nullable(sized_tupleof(str, str)),
                       _partitions_json=nullable(str))
     def __init__(self,
                  path,
@@ -81,6 +85,8 @@ class MatrixVCFReader(MatrixReader):
                  skip_invalid_loci,
                  force_bgz,
                  force_gz,
+                 filter,
+                 find_replace,
                  _partitions_json):
         self.path = wrap_to_list(path)
         self.header_file = header_file
@@ -93,6 +99,8 @@ class MatrixVCFReader(MatrixReader):
         self.skip_invalid_loci = skip_invalid_loci
         self.force_gz = force_gz
         self.force_bgz = force_bgz
+        self.filter = filter
+        self.find_replace = find_replace
         self._partitions_json = _partitions_json
 
     def render(self, r):
@@ -108,6 +116,7 @@ class MatrixVCFReader(MatrixReader):
                   'skipInvalidLoci': self.skip_invalid_loci,
                   'gzAsBGZ': self.force_bgz,
                   'forceGZ': self.force_gz,
+                  'filterAndReplace': make_filter_and_replace(self.filter, self.find_replace),
                   'partitionsJSON': self._partitions_json}
         return escape_str(json.dumps(reader))
 
@@ -124,6 +133,8 @@ class MatrixVCFReader(MatrixReader):
                other.skip_invalid_loci == self.skip_invalid_loci and \
                other.force_bgz == self.force_bgz and \
                other.force_gz == self.force_gz and \
+               other.filter == self.filter and \
+               other.find_replace == self.find_replace and \
                other._partitions_json == self._partitions_json
 
 

--- a/hail/python/hail/ir/table_reader.py
+++ b/hail/python/hail/ir/table_reader.py
@@ -3,6 +3,7 @@ import json
 
 from hail.typecheck import *
 from hail.utils.java import escape_str
+from hail.ir.utils import make_filter_and_replace
 
 class TableReader(object):
     @abc.abstractmethod
@@ -31,7 +32,7 @@ class TableNativeReader(TableReader):
 class TextTableReader(TableReader):
     def __init__(self, paths, min_partitions, types, comment,
                  delimiter, missing, no_header, impute, quote,
-                 skip_blank_lines, force_bgz):
+                 skip_blank_lines, force_bgz, filter, find_replace):
         self.config = {
             'files': paths,
             'typeMapStr': {f: t._parsable_string() for f, t in types.items()},
@@ -43,7 +44,8 @@ class TextTableReader(TableReader):
             'nPartitions': min_partitions,
             'quoteStr': quote,
             'skipBlankLines': skip_blank_lines,
-            'forceBGZ': force_bgz
+            'forceBGZ': force_bgz,
+            'filterAndReplace': make_filter_and_replace(filter, find_replace)
         }
 
     def render(self, r):

--- a/hail/python/hail/ir/utils.py
+++ b/hail/python/hail/ir/utils.py
@@ -9,3 +9,15 @@ def filter_predicate_with_keep(ir_pred, keep):
                   If(IsNA(Ref(pred)),
                      FalseIR(),
                      Ref(pred)))
+
+def make_filter_and_replace(filter, find_replace):
+    if find_replace is None:
+        find = None
+        replace = None
+    else:
+        find, replace = find_replace
+    return {
+        'filterPattern': filter,
+        'findPattern': find,
+        'replacePattern': replace
+    }

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -46,6 +46,18 @@ class VCFTests(unittest.TestCase):
             (hl.import_vcf([resource('sample.vcf'), t])
              ._force_count_rows())
 
+    def test_filter(self):
+        mt = hl.import_vcf(resource('malformed.vcf'), filter='rs685723')
+        mt._force_count_rows()
+
+        mt = hl.import_vcf(resource('sample.vcf'), filter='\trs\d+\t')
+        assert mt.aggregate_rows(hl.agg.all(hl.is_missing(mt.rsid)))
+
+    def test_find_replace(self):
+        mt = hl.import_vcf(resource('sample.vcf'), find_replace=('\trs\d+\t', '\t.\t'))
+        mt.rows().show()
+        assert mt.aggregate_rows(hl.agg.all(hl.is_missing(mt.rsid)))
+
     def test_haploid(self):
         expected = hl.Table.parallelize(
             [hl.struct(locus = hl.locus("X", 16050036), s = "C1046::HG02024",

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -931,6 +931,16 @@ class Tests(unittest.TestCase):
     def test_show_long_field_names(self):
         hl.utils.range_table(1).annotate(**{'a' * 256: 5}).show()
 
+    def test_import_filter_replace(self):
+        def assert_filter_equals(filter, find_replace, to):
+            assert hl.import_table(resource('filter_replace.txt'),
+                                   filter=filter,
+                                   find_replace=find_replace)['HEADER1'].collect() == to
+
+        assert_filter_equals('Foo', None, ['(Baz),(Qux)('])
+        assert_filter_equals(None, (r',', ''), ['(Foo(Bar))', '(Baz)(Qux)('])
+        assert_filter_equals(None, (r'\((\w+)\)', '$1'), ['(Foo,Bar)', 'Baz,Qux('])
+
 def test_large_number_of_fields(tmpdir):
     ht = hl.utils.range_table(100)
     ht = ht.annotate(**{

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -218,7 +218,7 @@ class TableIRTests(unittest.TestCase):
             matrix_read,
             matrix_range,
             ir.MatrixRead(ir.MatrixVCFReader(resource('sample.vcf'), ['GT'], hl.tfloat64, None, None, None, None,
-                                             False, True, False, True, None)),
+                                             False, True, False, True, None, None, None)),
             ir.MatrixRead(ir.MatrixBGENReader(resource('example.8bits.bgen'), None, {}, 10, 1, None)),
             ir.MatrixFilterRows(matrix_read, ir.FalseIR()),
             ir.MatrixFilterCols(matrix_read, ir.FalseIR()),

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -128,7 +128,8 @@ case class MatrixLiteral(value: MatrixValue) extends MatrixIR {
 object MatrixReader {
   implicit val formats: Formats = RelationalSpec.formats + ShortTypeHints(
     List(classOf[MatrixNativeReader], classOf[MatrixRangeReader], classOf[MatrixVCFReader],
-      classOf[MatrixBGENReader], classOf[MatrixPLINKReader], classOf[MatrixGENReader]))
+      classOf[MatrixBGENReader], classOf[MatrixPLINKReader], classOf[MatrixGENReader],
+      classOf[TextInputFilterAndReplace]))
 }
 
 abstract class MatrixReader {

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -58,7 +58,8 @@ case class TableLiteral(value: TableValue) extends TableIR {
 object TableReader {
   implicit val formats: Formats = RelationalSpec.formats + ShortTypeHints(
     List(classOf[TableNativeReader],
-      classOf[TextTableReader]))
+      classOf[TextTableReader],
+      classOf[TextInputFilterAndReplace]))
 }
 
 abstract class TableReader {

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -1234,10 +1234,11 @@ case class VCFsReader(
     val localFiles = files
     val localArrayElementsRequired = arrayElementsRequired
     val localRangeBounds = partitioner.rangeBounds
+    val localFilterAndReplace = filterAndReplace
 
     sc.parallelize(localFiles, localFiles.length).map { file =>
       val hConf = confBc.value.value
-      val headerLines = getHeaderLines(hConf, file, filterAndReplace)
+      val headerLines = getHeaderLines(hConf, file, localFilterAndReplace)
       val header = parseHeader(localReader, headerLines, arrayElementsRequired = localArrayElementsRequired)
       val VCFHeaderInfo(_, infoSignature, vaSignature, genotypeSignature, _, _, _, infoFlagFieldNames) = header
 

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -797,10 +797,13 @@ object LoadVCF {
       infoFlagFields)
   }
 
-  def getHeaderLines[T](hConf: Configuration, file: String): Array[String] = hConf.readFile(file) { s =>
-    Source.fromInputStream(s)
-      .getLines()
-      .takeWhile { line => line(0) == '#' }
+  def getHeaderLines[T](
+    hConf: Configuration,
+    file: String,
+    filterAndReplace: TextInputFilterAndReplace): Array[String] = hConf.readLines(file, filterAndReplace) { lines =>
+      lines
+      .takeWhile { line => line.value(0) == '#' }
+      .map(_.value)
       .toArray
   }
 
@@ -878,7 +881,7 @@ object LoadVCF {
 
   def parseHeaderMetadata(hc: HailContext, reader: HtsjdkRecordReader, headerFile: String): VCFMetadata = {
     val hConf = hc.hadoopConf
-    val headerLines = getHeaderLines(hConf, headerFile)
+    val headerLines = getHeaderLines(hConf, headerFile, TextInputFilterAndReplace())
     val VCFHeaderInfo(_, _, _, _, filterAttrs, infoAttrs, formatAttrs, _) = parseHeader(reader, headerLines)
 
     Map("filter" -> filterAttrs, "info" -> infoAttrs, "format" -> formatAttrs)
@@ -994,6 +997,7 @@ case class MatrixVCFReader(
   skipInvalidLoci: Boolean,
   gzAsBGZ: Boolean,
   forceGZ: Boolean,
+  filterAndReplace: TextInputFilterAndReplace,
   partitionsJSON: String) extends MatrixReader {
 
   private val hc = HailContext.get
@@ -1007,7 +1011,7 @@ case class MatrixVCFReader(
 
   private val reader = new HtsjdkRecordReader(callFields, entryFloatType)
 
-  private val headerLines1 = getHeaderLines(hConf, headerFile.getOrElse(inputs.head))
+  private val headerLines1 = getHeaderLines(hConf, headerFile.getOrElse(inputs.head), filterAndReplace)
   private val header1 = parseHeader(reader, headerLines1, arrayElementsRequired = arrayElementsRequired)
 
   if (headerFile.isEmpty) {
@@ -1017,9 +1021,10 @@ case class MatrixVCFReader(
     val localReader = reader
     val localInputs = inputs
     val localArrayElementsRequired = arrayElementsRequired
+    val localFilterAndReplace = filterAndReplace
     sc.parallelize(inputs.tail, math.max(1, inputs.length - 1)).foreach { file =>
       val hConf = confBc.value.value
-      val hd = parseHeader(localReader, getHeaderLines(hConf, file), arrayElementsRequired = localArrayElementsRequired)
+      val hd = parseHeader(localReader, getHeaderLines(hConf, file, localFilterAndReplace), arrayElementsRequired = localArrayElementsRequired)
       val hd1 = header1Bc.value
 
       if (hd1.sampleIds.length != hd.sampleIds.length) {
@@ -1098,7 +1103,7 @@ case class MatrixVCFReader(
 
   private lazy val lines = {
     HailContext.maybeGZipAsBGZip(gzAsBGZ) {
-      ContextRDD.textFilesLines[RVDContext](sc, inputs, minPartitions)
+      ContextRDD.textFilesLines[RVDContext](sc, inputs, minPartitions, filterAndReplace)
     }
   }
 
@@ -1158,7 +1163,10 @@ object ImportVCFs {
     skipInvalidLoci: Boolean,
     gzAsBGZ: Boolean,
     forceGZ: Boolean,
-    partitionsJSON: String
+    partitionsJSON: String,
+    filter: String,
+    find: String,
+    replace: String
   ): Array[MatrixTable] = {
     val reader = VCFsReader(
       files.asScala.toArray,
@@ -1170,6 +1178,7 @@ object ImportVCFs {
       skipInvalidLoci,
       gzAsBGZ,
       forceGZ,
+      TextInputFilterAndReplace(Option(find), Option(filter), Option(replace)),
       partitionsJSON)
 
     reader.read()
@@ -1193,6 +1202,7 @@ case class VCFsReader(
   skipInvalidLoci: Boolean,
   gzAsBGZ: Boolean,
   forceGZ: Boolean,
+  filterAndReplace: TextInputFilterAndReplace,
   partitionsJSON: String) {
 
   private val hc = HailContext.get
@@ -1227,7 +1237,7 @@ case class VCFsReader(
 
     sc.parallelize(localFiles, localFiles.length).map { file =>
       val hConf = confBc.value.value
-      val headerLines = getHeaderLines(hConf, file)
+      val headerLines = getHeaderLines(hConf, file, filterAndReplace)
       val header = parseHeader(localReader, headerLines, arrayElementsRequired = localArrayElementsRequired)
       val VCFHeaderInfo(_, infoSignature, vaSignature, genotypeSignature, _, _, _, infoFlagFieldNames) = header
 

--- a/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -65,24 +65,28 @@ object ContextRDD {
   def textFilesLines[C <: AutoCloseable](
     sc: SparkContext,
     files: Array[String],
-    nPartitions: Option[Int] = None
+    nPartitions: Option[Int] = None,
+    filterAndReplace: TextInputFilterAndReplace = TextInputFilterAndReplace()
   )(implicit c: Pointed[C]
   ): ContextRDD[C, WithContext[String]] =
     textFilesLines(
       sc,
       files,
-      nPartitions.getOrElse(sc.defaultMinPartitions))
+      nPartitions.getOrElse(sc.defaultMinPartitions),
+      filterAndReplace)
 
   def textFilesLines[C <: AutoCloseable](
     sc: SparkContext,
     files: Array[String],
-    nPartitions: Int
+    nPartitions: Int,
+    filterAndReplace: TextInputFilterAndReplace
   )(implicit c: Pointed[C]
   ): ContextRDD[C, WithContext[String]] =
     ContextRDD.weaken[C](
       sc.textFilesLines(
         files,
-        nPartitions))
+        nPartitions)
+        .mapPartitions(filterAndReplace.apply))
 
   // this one weird trick permits the caller to specify C without T
   sealed trait Parallelize[C <: AutoCloseable] {

--- a/hail/src/main/scala/is/hail/utils/TextInputFilterAndReplace.scala
+++ b/hail/src/main/scala/is/hail/utils/TextInputFilterAndReplace.scala
@@ -1,0 +1,18 @@
+package is.hail.utils
+
+case class TextInputFilterAndReplace(filterPattern: Option[String] = None, findPattern: Option[String] = None, replacePattern: Option[String] = None) {
+  require(!(findPattern.isDefined ^ replacePattern.isDefined))
+
+  private val fpRegex = filterPattern.map(_.r).orNull
+  private val find = findPattern.orNull
+  private val replace = replacePattern.orNull
+
+  def apply(it: Iterator[WithContext[String]]): Iterator[WithContext[String]] = {
+    var iter = it
+    if (fpRegex != null)
+      iter = iter.filter(c => fpRegex.findFirstIn(c.value).isEmpty)
+    if (find != null)
+      iter = iter.map(c => c.map(_.replaceAll(find, replace)))
+    iter
+  }
+}

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
@@ -287,7 +287,7 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
   def writeFile[T](filename: String)(f: (OutputStream) => T): T =
     using(create(filename))(f)
 
-  def readLines[T](filename: String)(reader: (Iterator[WithContext[String]] => T)): T = {
+  def readLines[T](filename: String, filtAndReplace: TextInputFilterAndReplace = TextInputFilterAndReplace())(reader: Iterator[WithContext[String]] => T): T = {
     readFile[T](filename) {
       is =>
         val lines = Source.fromInputStream(is)
@@ -298,7 +298,7 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
               val source = Context(value, filename, Some(position))
               WithContext(value, source)
           }
-        reader(lines)
+        reader(filtAndReplace(lines))
     }
   }
 

--- a/hail/src/test/resources/filter_replace.txt
+++ b/hail/src/test/resources/filter_replace.txt
@@ -1,0 +1,3 @@
+HEADER1
+(Foo,(Bar))
+(Baz),(Qux)(

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -479,6 +479,7 @@ object TestUtils {
       skipInvalidLoci,
       forceBGZ,
       force,
+      TextInputFilterAndReplace(),
       partitionsJSON
     )
     if (addedReference)


### PR DESCRIPTION
Add the `filter` and `find_replace` arguments to `import_table` and `import_vcf`.

These are regex filter and substitution arguments, which will make it possible to tolerate some invalid inputs.