### PR TITLE
tables README logic typo fix

### DIFF
--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -1357,7 +1357,7 @@ class MatrixTable(ExprContainer):
         The expression `expr` will be evaluated for every row of the table. If `keep`
         is ``True``, then rows where `expr` evaluates to ``False`` will be removed (the
         filter keeps the rows where the predicate evaluates to ``True``). If `keep` is
-        ``False``, then rows where `expr` evaluates to ``False`` will be removed (the
+        ``False``, then rows where `expr` evaluates to ``True`` will be removed (the
         filter removes the rows where the predicate evaluates to ``True``).
 
         Warning

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -772,7 +772,7 @@ class Table(ExprContainer):
         The expression `expr` will be evaluated for every row of the table. If `keep`
         is ``True``, then rows where `expr` evaluates to ``False`` will be removed (the
         filter keeps the rows where the predicate evaluates to ``True``). If `keep` is
-        ``False``, then rows where `expr` evaluates to ``False`` will be removed (the
+        ``False``, then rows where `expr` evaluates to ``True`` will be removed (the
         filter removes the rows where the predicate evaluates to ``True``).
 
         Warning


### PR DESCRIPTION
Was confused when reading https://hail.is/docs/0.2/hail.Table.html#hail.Table.filter, so did something about it.