### PR TITLE
[hail] improve makefile in anticipation of approximate quantiles

### DIFF
--- a/hail/.gitignore
+++ b/hail/.gitignore
@@ -11,6 +11,7 @@ src/main/c/headers
 src/main/c/lib
 src/main/c/libsimdpp-2*
 src/main/resources/build-info.properties
+src/main/resources/include/catch.hpp
 src/test/resources/example.8bits.bgen.idx*
 src/test/resources/example.v11.bgen.idx*
 src/test/resources/parallelBgenExport.bgen/part-00000.idx*

--- a/hail/src/main/c/Makefile
+++ b/hail/src/main/c/Makefile
@@ -1,11 +1,12 @@
-.PHONY: top all clean debug prebuilt test
-
-top: all
+MAKEFLAGS += --no-builtin-rules
+.PHONY: all clean debug prebuilt test
+.SUFFIXES:
+.DEFAULT: all
 
 UNAME_S :=$(shell uname -s)
 UNAME_P :=$(shell uname -p)
 
-BUILD :=build
+BUILD := build
 
 # Control optimization level and gdb-in-xterm code in NativePtr.cpp
 HAIL_ENABLE_DEBUG := 0
@@ -17,7 +18,9 @@ else
 endif
 
 # Change this setting to update the version of libsimdpp
-LIBSIMDPP :=libsimdpp-2.1
+LIBSIMDPP := libsimdpp-2.1
+
+CATCH_HEADER_LOCATION := ../resources/include/catch.hpp
 
 # If you want to add a new cpp file, like foo.cpp, to the library, add foo.o to
 # this list
@@ -39,14 +42,33 @@ OBJECTS := \
 
 BUILD_OBJECTS := $(OBJECTS:%=$(BUILD)/%.o)
 
-TEST_OBJECTS := $(foreach obj, $(OBJECTS), $(foreach file, $(wildcard $(obj)_test.cpp), $(BUILD)/$(basename $(file)).o))
+# before libsimdpp and catch.hpp are downloaded, clang -MG -MM will generate
+# unresolved dependencies
+.PHONY: simdpp/simd.h catch.hpp
+simdpp/simd.h: $(LIBSIMDPP)
+catch.hpp: $(CATCH_HEADER_LOCATION)
+
+TEST_CPP := $(foreach obj,$(OBJECTS),$(wildcard $(obj)_test.cpp)) ApproximateQuantiles_test.cpp
+TEST_OBJECTS := $(foreach file,$(TEST_CPP),$(BUILD)/$(basename $(file)).o)
 TEST_OBJECTS += $(BUILD)/unit-tests.o
 
+HEADER_DEPENDENCIES := $(BUILD_OBJECTS:%.o=%.d) $(TEST_OBJECTS:%.o=%.d)
+-include $(HEADER_DEPENDENCIES)
+
 $(BUILD)/unit-tests.o: testutils/unit-tests.cpp
+	mkdir -p $(@D)
 	$(CXX) -o $@ $(CXXFLAGS) -c $<
 
+$(BUILD)/%.d: %.cpp
+	mkdir -p $(@D)
+	$(CXX) $(CXXFLAGS) $< -MG -MM -MF $@ -MT $(@:%.d=%.o)
+
 $(BUILD)/%.o: %.cpp
-	$(CXX) -o $@ $(CXXFLAGS) -c $<
+	mkdir -p $(@D)
+	$(CXX) -o $@ $(CXXFLAGS) -MMD -MF $(@:%.o=%.d) -MT $@ -c $<
+
+$(BUILD)/ibs.d: CXXFLAGS += -DNUMBER_OF_GENOTYPES_PER_ROW=256
+$(BUILD)/ibs.o: CXXFLAGS += -DNUMBER_OF_GENOTYPES_PER_ROW=256
 
 ifndef JAVA_HOME
   TMP :=$(shell java -XshowSettings:properties -version 2>&1 | fgrep -i java.home)
@@ -128,10 +150,7 @@ ifeq ($(UNAME_S),Darwin)
   LIBHAIL := lib/darwin/libhail.dylib
 endif
 
-all: $(BUILD) $(LIBBOOT) $(LIBHAIL)
-
-$(BUILD):
-	-mkdir -p $@
+all: $(LIBBOOT) $(LIBHAIL)
 
 debug:
 	echo "make debug"
@@ -142,55 +161,43 @@ endif
 	echo "CXX is $(CXX)"
 	-$(CXX) --version
 
-$(BUILD)/functional-tests: ibs.cpp test.cpp
-	-mkdir -p build
-	$(CXX) $(CXXFLAGS) -DNUMBER_OF_GENOTYPES_PER_ROW=256 ibs.cpp test.cpp -o $(BUILD)/functional-tests
+$(BUILD)/functional-tests: $(BUILD)/ibs.o $(BUILD)/test.o
+	mkdir -p $(@D)
+	$(CXX) $(CXXFLAGS) -ldl -o $(BUILD)/functional-tests $^
 
-$(BUILD)/unit-tests: all $(TEST_OBJECTS)
+$(BUILD)/unit-tests: $(BUILD_OBJECTS) $(TEST_OBJECTS)
+	mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -ldl -o $(BUILD)/unit-tests $(BUILD_OBJECTS) $(TEST_OBJECTS)
 
-prebuilt: all
-	@echo updating $(PREBUILT) ...
-	cp -p -f $(LIBBOOT) $(PREBUILT)/$(LIBBOOT)
-	cp -p -f $(LIBHAIL) $(PREBUILT)/$(LIBHAIL)
+$(PREBUILT)/$(LIBBOOT): $(LIBBOOT)
+	cp -p -f $< $@
+
+$(PREBUILT)/$(LIBHAIL): $(LIBHAIL)
+	cp -p -f $< $@
+
+prebuilt: $(PREBUILT)/$(LIBBOOT) $(PREBUILT)/$(LIBHAIL)
 
 test: $(BUILD)/functional-tests $(BUILD)/unit-tests
 	./$(BUILD)/unit-tests -w NoAssertions -s -d yes -# --use-colour yes -r xml -o $(BUILD)/cxx-test.xml; \
-    	case "$$?" in \
-    		*) \
-    		mkdir -p $(BUILD)/reports; \
-    		cp testutils/style.css $(BUILD)/reports; \
-    		xsltproc -o $(BUILD)/reports/index.html testutils/test-reporter.xslt $(BUILD)/cxx-test.xml;; \
-		esac
+			case "$$?" in \
+				*) \
+				mkdir -p $(BUILD)/reports; \
+				cp testutils/style.css $(BUILD)/reports; \
+				xsltproc -o $(BUILD)/reports/index.html testutils/test-reporter.xslt $(BUILD)/cxx-test.xml;; \
+			esac
 	./$(BUILD)/functional-tests
 
 benchmark: $(BUILD)/unit-tests
 	./$(BUILD)/unit-tests "[!benchmark]" -s -d yes -# -r xml -o $(BUILD)/cxx-benchmark.xml; \
-    	case "$$?" in \
-    		*) \
-    		mkdir -p $(BUILD)/benchmark-reports; \
-    		cp testutils/style.css $(BUILD)/benchmark-reports; \
-    		xsltproc -o $(BUILD)/benchmark-reports/index.html testutils/test-reporter.xslt $(BUILD)/cxx-benchmark.xml;; \
-    	esac
+			case "$$?" in \
+				*) \
+				mkdir -p $(BUILD)/benchmark-reports; \
+				cp testutils/style.css $(BUILD)/benchmark-reports; \
+				xsltproc -o $(BUILD)/benchmark-reports/index.html testutils/test-reporter.xslt $(BUILD)/cxx-benchmark.xml;; \
+			esac
 
 clean:
 	-rm -rf $(BUILD) $(LIBSIMDPP) $(LIBBOOT) $(LIBHAIL)
-
-# The $(BUILD)/headers target is updated whenever any .h file has changed
-# under either the source directory, *or* the ../resources/include tree.
-# Header files under ../resources/include are visible to both libhail.so
-# code and dynamic-generated code; headers under the source are only visible
-# to code that goes into libhail.so
-#
-# We use this as a pessimistic dependency: if any header has changed, all
-# objects will be rebuilt. Since the quantity of code is small and the
-# clean-rebuild time is short (compared to other parts of the build process),
-# this seems good enough, and simpler than managing precise dependencies.
-
-$(BUILD)/headers: $(LIBSIMDPP) $(shell find . -name "*.h"; find ../resources/include -name "*.h")
-	touch $@
-
-$(BUILD_OBJECTS) $(BUILD)/NativeBoot.o: $(BUILD)/headers
 
 # We take all headers files visible to dynamic-generated code, together with
 # the output of "$(CXX) --version", to give a checksum $(ALL_HEADER_CKSUM)
@@ -203,15 +210,15 @@ ALL_HEADER_FILES := $(shell find ../resources/include -name "*.h")
 ALL_HEADER_CKSUM := $(shell $(CXX) --version >.cxx.vsn ; cat .cxx.vsn $(ALL_HEADER_FILES) | cksum | cut -d " " -f 1)
 
 $(BUILD)/NativeModule.o: NativeModule.cpp
+	mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -DALL_HEADER_CKSUM=$(ALL_HEADER_CKSUM)UL -c NativeModule.cpp -o $@
 
-# If your build machine cannot access this URL, download this tar.gz and place
-# it in the same directory as this Makefile. If you do so, the build will
-# succeed without attempting to access the Internet.
-# WGET ?= wget
-WGET ?= curl -L -O
+$(CATCH_HEADER_LOCATION):
+	mkdir -p $(@D)
+	curl -sSL 'https://github.com/catchorg/Catch2/releases/download/v2.6.0/catch.hpp' > $@
+
 $(LIBSIMDPP).tar.gz:
-	$(WGET) https://storage.googleapis.com/hail-common/$@
+	curl -sSL https://storage.googleapis.com/hail-common/$@ > $@
 
 $(LIBSIMDPP): $(LIBSIMDPP).tar.gz
 	tar -xzf $<

--- a/hail/src/main/c/Makefile
+++ b/hail/src/main/c/Makefile
@@ -48,7 +48,7 @@ BUILD_OBJECTS := $(OBJECTS:%=$(BUILD)/%.o)
 simdpp/simd.h: $(LIBSIMDPP)
 catch.hpp: $(CATCH_HEADER_LOCATION)
 
-TEST_CPP := $(foreach obj,$(OBJECTS),$(wildcard $(obj)_test.cpp)) ApproximateQuantiles_test.cpp
+TEST_CPP := $(foreach obj,$(OBJECTS),$(wildcard $(obj)_test.cpp))
 TEST_OBJECTS := $(foreach file,$(TEST_CPP),$(BUILD)/$(basename $(file)).o)
 TEST_OBJECTS += $(BUILD)/unit-tests.o
 

--- a/hail/src/main/c/Makefile
+++ b/hail/src/main/c/Makefile
@@ -1,7 +1,7 @@
 MAKEFLAGS += --no-builtin-rules
 .PHONY: all clean debug prebuilt test
 .SUFFIXES:
-.DEFAULT: all
+.DEFAULT_GOAL: all
 
 UNAME_S :=$(shell uname -s)
 UNAME_P :=$(shell uname -p)
@@ -56,15 +56,15 @@ HEADER_DEPENDENCIES := $(BUILD_OBJECTS:%.o=%.d) $(TEST_OBJECTS:%.o=%.d)
 -include $(HEADER_DEPENDENCIES)
 
 $(BUILD)/unit-tests.o: testutils/unit-tests.cpp
-	mkdir -p $(@D)
+	@mkdir -p $(@D)
 	$(CXX) -o $@ $(CXXFLAGS) -c $<
 
 $(BUILD)/%.d: %.cpp
-	mkdir -p $(@D)
+	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) $< -MG -M -MF $@ -MT $(@:%.d=%.o)
 
 $(BUILD)/%.o: %.cpp
-	mkdir -p $(@D)
+	@mkdir -p $(@D)
 	$(CXX) -o $@ $(CXXFLAGS) -MD -MF $(@:%.o=%.d) -MT $@ -c $<
 
 $(BUILD)/ibs.d: CXXFLAGS += -DNUMBER_OF_GENOTYPES_PER_ROW=256
@@ -162,11 +162,11 @@ endif
 	-$(CXX) --version
 
 $(BUILD)/functional-tests: $(BUILD)/ibs.o $(BUILD)/test.o
-	mkdir -p $(@D)
+	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -ldl -o $(BUILD)/functional-tests $^
 
 $(BUILD)/unit-tests: $(BUILD_OBJECTS) $(TEST_OBJECTS)
-	mkdir -p $(@D)
+	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -ldl -o $(BUILD)/unit-tests $(BUILD_OBJECTS) $(TEST_OBJECTS)
 
 $(PREBUILT)/$(LIBBOOT): $(LIBBOOT)
@@ -210,11 +210,11 @@ ALL_HEADER_FILES := $(shell find ../resources/include -name "*.h")
 ALL_HEADER_CKSUM := $(shell $(CXX) --version >.cxx.vsn ; cat .cxx.vsn $(ALL_HEADER_FILES) | cksum | cut -d " " -f 1)
 
 $(BUILD)/NativeModule.o: NativeModule.cpp
-	mkdir -p $(@D)
+	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -DALL_HEADER_CKSUM=$(ALL_HEADER_CKSUM)UL -c NativeModule.cpp -o $@
 
 $(CATCH_HEADER_LOCATION):
-	mkdir -p $(@D)
+	@mkdir -p $(@D)
 	curl -sSL 'https://github.com/catchorg/Catch2/releases/download/v2.6.0/catch.hpp' > $@
 
 $(LIBSIMDPP).tar.gz:
@@ -224,9 +224,9 @@ $(LIBSIMDPP): $(LIBSIMDPP).tar.gz
 	tar -xzf $<
 
 $(LIBBOOT): $(BUILD)/NativeBoot.o
-	-mkdir -p $(basename $(LIBBOOT))
+	@mkdir -p $(basename $(LIBBOOT))
 	$(CXX) $(LIBFLAGS) $(LIBDIRS) $(CXXFLAGS) $(BUILD)/NativeBoot.o -o $@
 
 $(LIBHAIL): $(BUILD_OBJECTS)
-	-mkdir -p $(basename $(LIBHAIL))
+	@mkdir -p $(basename $(LIBHAIL))
 	$(CXX) $(LIBFLAGS) $(LIBDIRS) $(CXXFLAGS) $(BUILD_OBJECTS) -o $@

--- a/hail/src/main/c/Makefile
+++ b/hail/src/main/c/Makefile
@@ -22,7 +22,7 @@ LIBSIMDPP := libsimdpp-2.1
 
 CATCH_HEADER_LOCATION := ../resources/include/catch.hpp
 
-# If you want to add a new cpp file, like foo.cpp, to the library, add foo.o to
+# If you want to add a new cpp file, like foo.cpp, to the library, add foo to
 # this list
 OBJECTS := \
   davies \
@@ -67,7 +67,9 @@ $(BUILD)/%.o: %.cpp
 	@mkdir -p $(@D)
 	$(CXX) -o $@ $(CXXFLAGS) -MD -MF $(@:%.o=%.d) -MT $@ -c $<
 
-$(BUILD)/ibs.d: CXXFLAGS += -DNUMBER_OF_GENOTYPES_PER_ROW=256
+# if libsimdpp does not exist (e.g. after a clean), UNIT64_VECTOR_SIZE needs to
+# be set explicitly via HAIL_OVERRIDE_WIDTH
+$(BUILD)/ibs.d: CXXFLAGS += -DHAIL_OVERRIDE_WIDTH=4 -DNUMBER_OF_GENOTYPES_PER_ROW=256
 $(BUILD)/ibs.o: CXXFLAGS += -DNUMBER_OF_GENOTYPES_PER_ROW=256
 
 ifndef JAVA_HOME

--- a/hail/src/main/c/Makefile
+++ b/hail/src/main/c/Makefile
@@ -1,7 +1,7 @@
 MAKEFLAGS += --no-builtin-rules
 .PHONY: all clean debug prebuilt test
 .SUFFIXES:
-.DEFAULT_GOAL: all
+.DEFAULT_GOAL := all
 
 UNAME_S :=$(shell uname -s)
 UNAME_P :=$(shell uname -p)

--- a/hail/src/main/c/Makefile
+++ b/hail/src/main/c/Makefile
@@ -61,11 +61,11 @@ $(BUILD)/unit-tests.o: testutils/unit-tests.cpp
 
 $(BUILD)/%.d: %.cpp
 	mkdir -p $(@D)
-	$(CXX) $(CXXFLAGS) $< -MG -MM -MF $@ -MT $(@:%.d=%.o)
+	$(CXX) $(CXXFLAGS) $< -MG -M -MF $@ -MT $(@:%.d=%.o)
 
 $(BUILD)/%.o: %.cpp
 	mkdir -p $(@D)
-	$(CXX) -o $@ $(CXXFLAGS) -MMD -MF $(@:%.o=%.d) -MT $@ -c $<
+	$(CXX) -o $@ $(CXXFLAGS) -MD -MF $(@:%.o=%.d) -MT $@ -c $<
 
 $(BUILD)/ibs.d: CXXFLAGS += -DNUMBER_OF_GENOTYPES_PER_ROW=256
 $(BUILD)/ibs.o: CXXFLAGS += -DNUMBER_OF_GENOTYPES_PER_ROW=256

--- a/hail/src/main/c/ibs.h
+++ b/hail/src/main/c/ibs.h
@@ -34,7 +34,7 @@ using uint64vector = uint64<UINT64_VECTOR_SIZE>;
 #define NUMBER_OF_UINT64_GENOTYPE_PACKS_PER_ROW (NUMBER_OF_GENOTYPES_PER_ROW / 32)
 
 #if (NUMBER_OF_UINT64_GENOTYPE_PACKS_PER_ROW % UINT64_VECTOR_SIZE) != 0
-#error "genotype packs per row, NUMBER_OF_UINT64_GENOTYPE_PACKS_PER_ROW, must be multuple of vector width, UINT64_VECTOR_SIZE."
+#error "genotype packs per row, NUMBER_OF_UINT64_GENOTYPE_PACKS_PER_ROW, must be multiple of vector width, UINT64_VECTOR_SIZE."
 #endif
 
 #ifndef CACHE_SIZE_PER_MATRIX_IN_KB

--- a/hail/src/main/c/ibs.h
+++ b/hail/src/main/c/ibs.h
@@ -14,7 +14,7 @@
 #endif
 #endif // HAIL_OVERRIDE_ARCH
 
-#include <simdpp/simd.h>
+#include "simdpp/simd.h"
 #include <inttypes.h>
 
 using namespace simdpp;


### PR DESCRIPTION
 - automatically download catch.hpp from GitHub if it's missing
 - remove builtin rules and suffix based rules to improve performance and ease debugging
 - change Makefile variable definitions to match our standard `FOO OP VAL` (note: two spaces)
 - rely on `clang -MM` (see: [Clang command line reference](https://clang.llvm.org/docs/ClangCommandLineReference.html) and below explanation) to generate precise dependencies for object files (including source and header files)
 - explicitly specify which files depend on `NUMBER_OF_GENOTYPES_PER_ROW` to be set (namely the dependency file and the object file associated with `ibs.cpp`)
 - break `TEST_OBJECTS` into two steps so that we can have `_test.cpp` files which do not have corresponding `.cpp` files (consider, for example, a header-only file, which ApproximateQuantiles will be)
 - eliminate `$(BUILD)/headers` in favor of precise dependency tracking described above
 - remove the target `$(BUILD)`, directories don't work the way you think in Make, it's better to have individual rules create the containing directories when necessary
 - remove `wget` nonsense, standardize on `curl -sSL` (which produces useful error messages)

---

# clang -MM

This argument to clang allows us to generate "depfile" or "dependency files" which are valid `Makefile`s describing how object files depend on `c`, `cpp`, `h`, and `hpp` files.

`clang -MM foo.cpp` writes to stdout a Makefile that indicates how `foo.o` depends on preprocessor includes of other *user* files. For example,

```
# cat foo.cpp
#include<stdio.h>
#include "bar.h"
# clang -MM foo.cpp
foo.o: foo.cpp bar.h
```

The `-MT target` allows us to specify the target's name:
```
# clang -MM foo.cpp -MT fiddle
fiddle: foo.cpp bar.h
```

The `-MQ` argument asks `clang` to quote the variable before make sees it, so (nb, I first quote it for the shell so it doesn't get seen as an env var):
```
# clang -MM foo.cpp -MQ '$fiddle'
$$fiddle: foo.cpp bar.h
```

The `-MG` argument tells `clang` to not error if an included file does not exist. This can be helpful if the project's `Makefile` knows how to generate these header files. In our example, `catch.hpp` can be generated by `hail/src/main/c/Makefile` by downloading it from GitHub.
```
# rm -rf bar.h
# clang -MM foo.cpp              
foo.cpp:1:10: fatal error: 'bar.h' file not found
#include "bar.h"
         ^~~~~~~
1 error generated.
# clang -MM foo.cpp -MG
foo.o: foo.cpp bar.h
```

The `-MF file` argument tells `clang` to write to `file` instead of stdout.

The `-MMD` argument is used if we *also want to compile the file*. The `-MM` argument defaults to adding `-E` meaning "only run the preprocessor". 