### PR TITLE
make MakeArray.element_type reflect the element type

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3509,9 +3509,8 @@ def empty_array(t: Union[HailType, str]) -> ArrayExpression:
     -------
     :class:`.ArrayExpression`
     """
-    array_t = hl.tarray(t)
-    ir = MakeArray([], array_t)
-    return construct_expr(ir, array_t)
+    ir = MakeArray([], t)
+    return construct_expr(ir, ir.typ)
 
 
 @typecheck(key_type=hail_type, value_type=hail_type)

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -466,7 +466,7 @@ class MakeArray(IR):
         for a in self.args:
             a._compute_type(env, agg_env)
         if self._element_type:
-            self._type = self._element_type
+            self._type = tarray(self._element_type)
         else:
             self._type = tarray(self.args[0].typ)
 

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -2099,7 +2099,7 @@ def _ndarray_to_makearray(ndarray):
         data = [x for row in data for x in row]
 
     data_as_ir = [F64(x) for x in data]
-    return MakeArray(data_as_ir, hl.tarray(hl.tfloat64))
+    return MakeArray(data_as_ir, hl.tfloat64)
 
 
 def _broadcast_kind(shape):

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -43,7 +43,7 @@ class ValueIRTests(unittest.TestCase):
             ir.ApplyBinaryOp('+', i, j),
             ir.ApplyUnaryOp('-', i),
             ir.ApplyComparisonOp('EQ', i, j),
-            ir.MakeArray([i, ir.NA(hl.tint32), ir.I32(-3)], hl.tarray(hl.tint32)),
+            ir.MakeArray([i, ir.NA(hl.tint32), ir.I32(-3)], hl.tint32),
             ir.ArrayRef(a, i),
             ir.ArrayLen(a),
             ir.ArrayRange(ir.I32(0), ir.I32(5), ir.I32(1)),
@@ -253,7 +253,7 @@ class BlockMatrixIRTests(unittest.TestCase):
 
     def block_matrix_irs(self):
         scalar_ir = ir.F64(2)
-        vector_ir = ir.MakeArray([ir.F64(3), ir.F64(2)], hl.tarray(hl.tfloat64))
+        vector_ir = ir.MakeArray([ir.F64(3), ir.F64(2)], hl.tfloat64)
 
         read = ir.BlockMatrixRead(resource('blockmatrix_example/0'))
         add_two_bms = BlockMatrixIRTests._make_element_wise_op_ir(read, read, '+')

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -102,27 +102,27 @@ final case class ApplyUnaryPrimOp(op: UnaryOp, x: IR) extends IR
 final case class ApplyComparisonOp(op: ComparisonOp[_], l: IR, r: IR) extends IR
 
 object MakeArray {
-  def unify(args: Seq[IR], typ: TArray = null): MakeArray = {
-    assert(typ != null || args.nonEmpty)
-    var t = typ
+  def unify(args: Seq[IR], elementType: Type = null): MakeArray = {
+    assert(elementType != null || args.nonEmpty)
+    var t = elementType
     if (t == null) {
       t = if (args.tail.forall(_.typ == args.head.typ)) {
-        TArray(args.head.typ)
-      } else TArray(args.head.typ.deepOptional())
+        args.head.typ
+      } else args.head.typ.deepOptional()
     }
-    assert(t.elementType.deepOptional() == t.elementType ||
-      args.forall(a => a.typ == t.elementType),
+    assert(t.deepOptional() == t ||
+      args.forall(a => a.typ == t),
       s"${ t.parsableString() }: ${ args.map(a => "\n    " + a.typ.parsableString()).mkString } ")
 
     MakeArray(args.map { arg =>
-      if (arg.typ == t.elementType)
+      if (arg.typ == t)
         arg
       else {
-        val upcast = PruneDeadFields.upcast(arg, t.elementType)
-        assert(upcast.typ == t.elementType)
+        val upcast = PruneDeadFields.upcast(arg, t)
+        assert(upcast.typ == t)
         upcast
       }
-    }, t)
+    }, TArray(t))
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -567,9 +567,9 @@ object IRParser {
         val op = ComparisonOp.fromStringAndTypes(opName, l.typ, r.typ)
         ApplyComparisonOp(op, l, r)
       case "MakeArray" =>
-        val typ = opt[Type](it, type_expr).orNull
+        val elementType = opt[Type](it, type_expr).orNull
         val args = ir_value_children(env)(it)
-        MakeArray.unify(args, typ)
+        MakeArray.unify(args, elementType)
       case "ArrayRef" =>
         val a = ir_value_expr(env)(it)
         val i = ir_value_expr(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -567,7 +567,7 @@ object IRParser {
         val op = ComparisonOp.fromStringAndTypes(opName, l.typ, r.typ)
         ApplyComparisonOp(op, l, r)
       case "MakeArray" =>
-        val typ = opt(it, type_expr).map(_.asInstanceOf[TArray]).orNull
+        val typ = opt[Type](it, type_expr).orNull
         val args = ir_value_children(env)(it)
         MakeArray.unify(args, typ)
       case "ArrayRef" =>


### PR DESCRIPTION
MakeArray expected a `tarray<type>` for the constructor parameter `element_type`. Changed usages and IR so it just expects the element-type.