### PR TITLE
Use index expressions for broadcasting and transpose

### DIFF
--- a/hail/python/hail/expr/blockmatrix_type.py
+++ b/hail/python/hail/expr/blockmatrix_type.py
@@ -9,17 +9,24 @@ class tblockmatrix(object):
         return tblockmatrix(
             dtype(jtbm.elementType().toString()),
             jiterable_to_list(jtbm.shape()),
+            jtbm.isRowVector(),
             jtbm.blockSize(),
             jiterable_to_list(jtbm.dimsPartitioned()))
 
     @staticmethod
     def _from_json(json):
-        return tblockmatrix(dtype(json['elementType']), json['shape'], json['blockSize'], json['dimsPartitioned'])
+        return tblockmatrix(dtype(json['elementType']),
+                            json['shape'],
+                            json['isRowVector'],
+                            json['blockSize'],
+                            json['dimsPartitioned'])
 
-    @typecheck_method(element_type=hail_type, shape=sequenceof(int), block_size=int, dims_partitioned=sequenceof(bool))
-    def __init__(self, element_type, shape, block_size, dims_partitioned):
+    @typecheck_method(element_type=hail_type, shape=sequenceof(int), is_row_vector=bool,
+                      block_size=int, dims_partitioned=sequenceof(bool))
+    def __init__(self, element_type, shape, is_row_vector, block_size, dims_partitioned):
         self.element_type = element_type
         self.shape = shape
+        self.is_row_vector = is_row_vector
         self.block_size = block_size
         self.dims_partitioned = dims_partitioned
 
@@ -27,6 +34,7 @@ class tblockmatrix(object):
         return isinstance(other, tblockmatrix) and \
                self.element_type == other.element_type and \
                self.shape == other.shape and \
+               self.is_row_vector == other.is_row_vector and \
                self.block_size == other.block_size and \
                self.dims_partitioned == other.dims_partitioned
 
@@ -34,10 +42,14 @@ class tblockmatrix(object):
         return 43 + hash(str(self))
 
     def __repr__(self):
-        return f'tblockmatrix(element_type={self.element_type!r}, shape={self.shape!r}, block_size={self.block_size!r}, dims_partitioned={self.dims_partitioned!r})'
+        return f'tblockmatrix(element_type={self.element_type!r}, shape={self.shape!r}, ' \
+            f'is_row_vector={self.is_row_vector!r}, block_size={self.block_size!r}, ' \
+            f'dims_partitioned={self.dims_partitioned!r})'
 
     def __str__(self):
-        return f'blockmatrix {{element_type: {self.element_type}, shape: {self.shape}, block_size: {self.block_size}, dims_partitioned: {self.dims_partitioned}}}'
+        return f'blockmatrix {{element_type: {self.element_type}, shape: {self.shape}, ' \
+            f'is_row_vector: {self.is_row_vector}, block_size: {self.block_size}, ' \
+            f'dims_partitioned: {self.dims_partitioned}}}'
 
     def pretty(self, indent=0, increment=4):
         l = []
@@ -52,6 +64,11 @@ class tblockmatrix(object):
 
         l.append(' ' * indent)
         l.append(f'shape: [{self.shape}],\n')
+
+        l.append(' ' * indent)
+        l.append('is_row_vector: ')
+        self.is_row_vector._pretty(l, indent, increment)
+        l.append(',\n')
 
         l.append(' ' * indent)
         l.append('block_size: ')

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -93,8 +93,9 @@ class ValueToBlockMatrix(BlockMatrixIR):
         tensor_shape, is_row_vector = self._matrix_shape_to_tensor_shape(self.shape)
         self._type = tblockmatrix(element_type, tensor_shape, is_row_vector, self.block_size, self.dims_partitioned)
 
-    def _matrix_shape_to_tensor_shape(self, shape):
-        assert len(self.shape) == 2
+    @staticmethod
+    def _matrix_shape_to_tensor_shape(shape):
+        assert len(shape) == 2
 
         if shape == [1, 1]:
             return [], False

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -1,6 +1,5 @@
-from hail import tarray
 from hail.expr.blockmatrix_type import tblockmatrix
-from hail.ir import BlockMatrixIR, ApplyBinaryOp, IR, parsable_strings
+from hail.ir import BlockMatrixIR, ApplyBinaryOp, IR, parsable_strings, tarray
 from hail.utils.java import escape_str
 from hail.typecheck import typecheck_method, sequenceof
 

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -37,8 +37,8 @@ class BlockMatrixMap2(BlockMatrixIR):
 
 class BlockMatrixBroadcast(BlockMatrixIR):
     @typecheck_method(child=BlockMatrixIR,
-                      in_index_expr=sequenceof(str),
-                      out_index_expr=sequenceof(str),
+                      in_index_expr=sequenceof(int),
+                      out_index_expr=sequenceof(int),
                       shape=sequenceof(int),
                       block_size=int,
                       dims_partitioned=sequenceof(bool))
@@ -52,12 +52,12 @@ class BlockMatrixBroadcast(BlockMatrixIR):
         self.dims_partitioned = dims_partitioned
 
     def render(self, r):
-        return '(BlockMatrixBroadcast {} {} ({}) {} ({}) {})'\
-            .format(parsable_strings(self.in_index_expr),
-                    parsable_strings(self.out_index_expr),
-                    ' '.join([str(x) for x in self.shape]),
+        return '(BlockMatrixBroadcast {} {} {} {} {} {})'\
+            .format(_serialize_ints(self.in_index_expr),
+                    _serialize_ints(self.out_index_expr),
+                    _serialize_ints(self.shape),
                     self.block_size,
-                    ' '.join([str(b) for b in self.dims_partitioned]),
+                    _serialize_ints(self.dims_partitioned),
                     r(self.child))
 
     def _compute_type(self):
@@ -80,10 +80,10 @@ class ValueToBlockMatrix(BlockMatrixIR):
         self.dims_partitioned = dims_partitioned
 
     def render(self, r):
-        return '(ValueToBlockMatrix ({}) {} ({}) {})'.format(' '.join([str(x) for x in self.shape]),
-                                                             self.block_size,
-                                                             ' '.join([str(b) for b in self.dims_partitioned]),
-                                                             r(self.child))
+        return '(ValueToBlockMatrix {} {} {} {})'.format(_serialize_ints(self.shape),
+                                                         self.block_size,
+                                                         _serialize_ints(self.dims_partitioned),
+                                                         r(self.child))
 
     def _compute_type(self):
         child_type = self.child.typ
@@ -105,3 +105,7 @@ class JavaBlockMatrix(BlockMatrixIR):
 
     def _compute_type(self):
         self._type = tblockmatrix._from_java(self.jir.typ())
+
+
+def _serialize_ints(ints):
+    return "(" + ' '.join([str(x) for x in ints]) + ")"

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -60,6 +60,7 @@ class BlockMatrixBroadcast(BlockMatrixIR):
     def _compute_type(self):
         self._type = tblockmatrix(self.child.typ.element_type,
                                   self.shape,
+                                  False,
                                   self.block_size,
                                   self.dims_partitioned)
 
@@ -89,7 +90,20 @@ class ValueToBlockMatrix(BlockMatrixIR):
         else:
             element_type = child_type
 
-        self._type = tblockmatrix(element_type, self.shape, self.block_size, self.dims_partitioned)
+        tensor_shape, is_row_vector = self._matrix_shape_to_tensor_shape(self.shape)
+        self._type = tblockmatrix(element_type, tensor_shape, is_row_vector, self.block_size, self.dims_partitioned)
+
+    def _matrix_shape_to_tensor_shape(self, shape):
+        assert len(self.shape) == 2
+
+        if shape == [1, 1]:
+            return [], False
+        elif shape[0] == 1:
+            return [shape[1]], True
+        elif shape[1] == 1:
+            return [shape[0]], False
+        else:
+            return shape, False
 
 
 class JavaBlockMatrix(BlockMatrixIR):

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -38,23 +38,20 @@ class BlockMatrixMap2(BlockMatrixIR):
 class BlockMatrixBroadcast(BlockMatrixIR):
     @typecheck_method(child=BlockMatrixIR,
                       in_index_expr=sequenceof(int),
-                      out_index_expr=sequenceof(int),
                       shape=sequenceof(int),
                       block_size=int,
                       dims_partitioned=sequenceof(bool))
-    def __init__(self, child, in_index_expr, out_index_expr, shape, block_size, dims_partitioned):
+    def __init__(self, child, in_index_expr, shape, block_size, dims_partitioned):
         super().__init__()
         self.child = child
         self.in_index_expr = in_index_expr
-        self.out_index_expr = out_index_expr
         self.shape = shape
         self.block_size = block_size
         self.dims_partitioned = dims_partitioned
 
     def render(self, r):
-        return '(BlockMatrixBroadcast {} {} {} {} {} {})'\
+        return '(BlockMatrixBroadcast {} {} {} {} {})'\
             .format(_serialize_ints(self.in_index_expr),
-                    _serialize_ints(self.out_index_expr),
                     _serialize_ints(self.shape),
                     self.block_size,
                     _serialize_ints(self.dims_partitioned),

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -1,6 +1,6 @@
+from hail import tarray
 from hail.expr.blockmatrix_type import tblockmatrix
-from hail.expr.types import hail_type, tarray
-from hail.ir import BlockMatrixIR, ApplyBinaryOp, IR
+from hail.ir import BlockMatrixIR, ApplyBinaryOp, IR, parsable_strings
 from hail.utils.java import escape_str
 from hail.typecheck import typecheck_method, sequenceof
 
@@ -38,21 +38,24 @@ class BlockMatrixMap2(BlockMatrixIR):
 
 class BlockMatrixBroadcast(BlockMatrixIR):
     @typecheck_method(child=BlockMatrixIR,
-                      broadcast_kind=str,
+                      in_index_expr=sequenceof(str),
+                      out_index_expr=sequenceof(str),
                       shape=sequenceof(int),
                       block_size=int,
                       dims_partitioned=sequenceof(bool))
-    def __init__(self, child, broadcast_kind, shape, block_size, dims_partitioned):
+    def __init__(self, child, in_index_expr, out_index_expr, shape, block_size, dims_partitioned):
         super().__init__()
         self.child = child
-        self.broadcast_kind = broadcast_kind
+        self.in_index_expr = in_index_expr
+        self.out_index_expr = out_index_expr
         self.shape = shape
         self.block_size = block_size
         self.dims_partitioned = dims_partitioned
 
     def render(self, r):
-        return '(BlockMatrixBroadcast {} ({}) {} ({}) {})'\
-            .format(escape_str(self.broadcast_kind),
+        return '(BlockMatrixBroadcast {} {} ({}) {} ({}) {})'\
+            .format(parsable_strings(self.in_index_expr),
+                    parsable_strings(self.out_index_expr),
                     ' '.join([str(x) for x in self.shape]),
                     self.block_size,
                     ' '.join([str(b) for b in self.dims_partitioned]),

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -472,7 +472,12 @@ class BlockMatrix(object):
         """
         if not block_size:
             block_size = BlockMatrix.default_block_size()
-        return BlockMatrix._from_java(Env.hail().linalg.BlockMatrix.fill(Env.hc()._jhc, n_rows, n_cols, value, block_size))
+
+        bmir = BlockMatrixBroadcast(_to_bmir(value, block_size),
+                                    [], ["i", "j"],
+                                    [n_rows, n_cols],
+                                    block_size, [True, True])
+        return BlockMatrix(bmir)
 
     @classmethod
     @typecheck_method(n_rows=int,
@@ -533,7 +538,7 @@ class BlockMatrix(object):
         -------
         :obj:`int`
         """
-        return self._jbm.blockSize()
+        return self._bmir.typ.block_size
 
     @typecheck_method(path=str,
                       overwrite=bool,

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -474,7 +474,7 @@ class BlockMatrix(object):
             block_size = BlockMatrix.default_block_size()
 
         bmir = BlockMatrixBroadcast(_to_bmir(value, block_size),
-                                    [], ["i", "j"],
+                                    [], [0, 1],
                                     [n_rows, n_cols],
                                     block_size, [True, True])
         return BlockMatrix(bmir)
@@ -1146,7 +1146,7 @@ class BlockMatrix(object):
         :class:`.BlockMatrix`
         """
         return BlockMatrix(BlockMatrixBroadcast(self._bmir,
-                                                ["i", "j"], ["j", "i"],
+                                                [0, 1], [1, 0],
                                                 [self.n_cols, self.n_rows],
                                                 self.block_size,
                                                 self._bmir.typ.dims_partitioned))
@@ -2115,11 +2115,11 @@ def _broadcast_index_expr(shape):
     assert len(shape) <= 2
 
     if shape == [] or shape == [1] or shape == [1, 1]:
-        return [], ["i", "j"]
+        return [], [0, 1]
     elif shape[0] == 1:
-        return ["i"], ["j", "i"]
+        return [0], [1, 0]
     else:
-        return ["i"], ["i", "j"]
+        return [0], [0, 1]
 
 
 def _ndarray_as_2d(nd):

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1149,7 +1149,7 @@ class BlockMatrix(object):
                                                 [0, 1], [1, 0],
                                                 [self.n_cols, self.n_rows],
                                                 self.block_size,
-                                                self._bmir.typ.dims_partitioned))
+                                                self._bmir.typ.dims_partitioned[::-1]))
 
     def densify(self):
         """Restore all dropped blocks as explicit blocks of zeros.

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -203,11 +203,12 @@ class BlockMatrix(object):
     - Natural logarithm, :meth:`log`.
     """
     @staticmethod
-    def _from_java(jbm):
-        return BlockMatrix(JavaBlockMatrix(jbm))
+    def _from_java(jbm, shape):
+        return BlockMatrix(JavaBlockMatrix(jbm), shape)
 
-    def __init__(self, bmir):
+    def __init__(self, bmir, shape):
         self._bmir = bmir
+        self.shape = shape
         self._cached_jbm = None
 
     @property
@@ -507,7 +508,7 @@ class BlockMatrix(object):
         -------
         :obj:`int`
         """
-        return self._bmir.typ.shape[0]
+        return self.shape[0]
 
     @property
     def n_cols(self):
@@ -517,18 +518,7 @@ class BlockMatrix(object):
         -------
         :obj:`int`
         """
-        return self._bmir.typ.shape[1]
-
-    @property
-    def shape(self):
-        """Shape of matrix.
-
-        Returns
-        -------
-        (:obj:`int`, :obj:`int`)
-           Number of rows and number of columns.
-        """
-        return self.n_rows, self.n_cols
+        return self.shape[1]
 
     @property
     def block_size(self):
@@ -2094,8 +2084,8 @@ def _broadcast_to_shape(bmir, result_shape):
     if current_shape == result_shape:
         return bmir
 
-    in_index_expr, out_index_expr = _broadcast_index_expr(current_shape)
-    return BlockMatrixBroadcast(bmir, in_index_expr, out_index_expr, result_shape,
+    in_index_expr = _broadcast_index_expr(current_shape)
+    return BlockMatrixBroadcast(bmir, in_index_expr, result_shape,
                                 bmir.typ.block_size, [True for _ in result_shape])
 
 
@@ -2115,11 +2105,11 @@ def _broadcast_index_expr(shape):
     assert len(shape) <= 2
 
     if shape == [] or shape == [1] or shape == [1, 1]:
-        return [], [0, 1]
+        return []
     elif shape[0] == 1:
-        return [0], [1, 0]
+        return [1]
     elif shape[1] == 1:
-        return [0], [0, 1]
+        return [0]
     else:
         raise ValueError(f'Cannot broadcast shape: ${shape}')
 

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -2118,8 +2118,10 @@ def _broadcast_index_expr(shape):
         return [], [0, 1]
     elif shape[0] == 1:
         return [0], [1, 0]
-    else:
+    elif shape[1] == 1:
         return [0], [0, 1]
+    else:
+        raise ValueError(f'Cannot broadcast shape: ${shape}')
 
 
 def _ndarray_as_2d(nd):

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -258,11 +258,11 @@ class BlockMatrixIRTests(unittest.TestCase):
         read = ir.BlockMatrixRead(resource('blockmatrix_example/0'))
         add_two_bms = BlockMatrixIRTests._make_element_wise_op_ir(read, read, '+')
 
-        scalar_to_bm = ir.ValueToBlockMatrix(scalar_ir, [], 1, [])
-        vector_to_bm = ir.ValueToBlockMatrix(vector_ir, [2], 1, [False])
-        broadcast_scalar = ir.BlockMatrixBroadcast(scalar_to_bm, "scalar", [2, 2], 256, [False, False])
-        broadcast_col = ir.BlockMatrixBroadcast(vector_to_bm, "col", [2, 2], 256, [False, False])
-        broadcast_row = ir.BlockMatrixBroadcast(vector_to_bm, "row", [2, 2], 256, [False, False])
+        scalar_to_bm = ir.ValueToBlockMatrix(scalar_ir, hl.tfloat64, [], 1, [])
+        vector_to_bm = ir.ValueToBlockMatrix(vector_ir, hl.tfloat64, [2], 1, [False])
+        broadcast_scalar = ir.BlockMatrixBroadcast(scalar_to_bm, [], ["i", "j"], [2, 2], 256, [False, False])
+        broadcast_col = ir.BlockMatrixBroadcast(vector_to_bm, ["i"], ["i", "j"], [2, 2], 256, [False, False])
+        broadcast_row = ir.BlockMatrixBroadcast(vector_to_bm, ["i"], ["j", "i"], [2, 2], 256, [False, False])
 
         return [
             read,

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -258,11 +258,11 @@ class BlockMatrixIRTests(unittest.TestCase):
         read = ir.BlockMatrixRead(resource('blockmatrix_example/0'))
         add_two_bms = BlockMatrixIRTests._make_element_wise_op_ir(read, read, '+')
 
-        scalar_to_bm = ir.ValueToBlockMatrix(scalar_ir, hl.tfloat64, [], 1, [])
-        vector_to_bm = ir.ValueToBlockMatrix(vector_ir, hl.tfloat64, [2], 1, [False])
-        broadcast_scalar = ir.BlockMatrixBroadcast(scalar_to_bm, [], ["i", "j"], [2, 2], 256, [False, False])
-        broadcast_col = ir.BlockMatrixBroadcast(vector_to_bm, ["i"], ["i", "j"], [2, 2], 256, [False, False])
-        broadcast_row = ir.BlockMatrixBroadcast(vector_to_bm, ["i"], ["j", "i"], [2, 2], 256, [False, False])
+        scalar_to_bm = ir.ValueToBlockMatrix(scalar_ir, [], 1, [])
+        vector_to_bm = ir.ValueToBlockMatrix(vector_ir, [2], 1, [False])
+        broadcast_scalar = ir.BlockMatrixBroadcast(scalar_to_bm, [], [0, 1], [2, 2], 256, [False, False])
+        broadcast_col = ir.BlockMatrixBroadcast(vector_to_bm, [0], [0, 1], [2, 2], 256, [False, False])
+        broadcast_row = ir.BlockMatrixBroadcast(vector_to_bm, [0], [1, 0], [2, 2], 256, [False, False])
 
         return [
             read,

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -258,17 +258,19 @@ class BlockMatrixIRTests(unittest.TestCase):
         read = ir.BlockMatrixRead(resource('blockmatrix_example/0'))
         add_two_bms = BlockMatrixIRTests._make_element_wise_op_ir(read, read, '+')
 
-        scalar_to_bm = ir.ValueToBlockMatrix(scalar_ir, [], 1, [])
-        vector_to_bm = ir.ValueToBlockMatrix(vector_ir, [2], 1, [False])
-        broadcast_scalar = ir.BlockMatrixBroadcast(scalar_to_bm, [], [0, 1], [2, 2], 256, [False, False])
-        broadcast_col = ir.BlockMatrixBroadcast(vector_to_bm, [0], [0, 1], [2, 2], 256, [False, False])
-        broadcast_row = ir.BlockMatrixBroadcast(vector_to_bm, [0], [1, 0], [2, 2], 256, [False, False])
+        scalar_to_bm = ir.ValueToBlockMatrix(scalar_ir, [1, 1], 1, [])
+        col_vector_to_bm = ir.ValueToBlockMatrix(vector_ir, [2, 1], 1, [False])
+        row_vector_to_bm = ir.ValueToBlockMatrix(vector_ir, [1, 2], 1, [False])
+        broadcast_scalar = ir.BlockMatrixBroadcast(scalar_to_bm, [], [2, 2], 256, [False, False])
+        broadcast_col = ir.BlockMatrixBroadcast(col_vector_to_bm, [0], [2, 2], 256, [False, False])
+        broadcast_row = ir.BlockMatrixBroadcast(row_vector_to_bm, [1], [2, 2], 256, [False, False])
 
         return [
             read,
             add_two_bms,
             scalar_to_bm,
-            vector_to_bm,
+            col_vector_to_bm,
+            row_vector_to_bm,
             broadcast_scalar,
             broadcast_col,
             broadcast_row,

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -227,17 +227,14 @@ case class BlockMatrixBroadcast(
     val nRows = shape(0).toInt
     val nCols = shape(1).toInt
 
-    inIndexExpr match {
-      case IndexedSeq() =>
-        val scalar = childBm.toBreezeMatrix().apply(0,0)
-        BlockMatrix.fill(hc, nRows, nCols, scalar, blockSize)
-      case IndexedSeq(i) =>
-        outIndexExpr match {
-          case IndexedSeq(_, `i`) => broadcastRowVector(hc, childBm.toBreezeMatrix().data, nRows, nCols)
-          case IndexedSeq(`i`, _) => broadcastColVector(hc, childBm.toBreezeMatrix().data, nRows, nCols)
-        }
+    outIndexExpr match {
       case IndexedSeq(i, j) =>
-        outIndexExpr match {
+        inIndexExpr match {
+          case IndexedSeq() =>
+            val scalar = childBm.toBreezeMatrix().apply(0,0)
+            BlockMatrix.fill(hc, nRows, nCols, scalar, blockSize)
+          case IndexedSeq(`i`) => broadcastColVector(hc, childBm.toBreezeMatrix().data, nRows, nCols)
+          case IndexedSeq(`j`) => broadcastRowVector(hc, childBm.toBreezeMatrix().data, nRows, nCols)
           case IndexedSeq(`j`, `i`) => childBm.transpose()
         }
     }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -224,11 +224,12 @@ case class BlockMatrixBroadcast(
 
   override protected[ir] def execute(hc: HailContext): BlockMatrix = {
     val childBm = child.execute(hc)
-    val nRows = shape(0).toInt
-    val nCols = shape(1).toInt
 
     outIndexExpr match {
       case IndexedSeq(i, j) =>
+        val nRows = shape(0).toInt
+        val nCols = shape(1).toInt
+
         inIndexExpr match {
           case IndexedSeq() =>
             val scalar = childBm.toBreezeMatrix().apply(0,0)

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -276,15 +276,12 @@ case class ValueToBlockMatrix(
   }
 
   override protected[ir] def execute(hc: HailContext): BlockMatrix = {
-    assert(shape.length == 2)
-    val nRows = shape(0).toInt
-    val nCols = shape(1).toInt
-
     Interpret[Any](child) match {
       case scalar: Double =>
-        BlockMatrix.fill(hc, nRows, nCols, scalar, blockSize)
+        BlockMatrix.fill(hc, nRows = 1, nCols = 1, scalar, blockSize)
       case data: IndexedSeq[Double] =>
-        BlockMatrixIR.toBlockMatrix(hc, nRows, nCols, data.toArray, blockSize)
+        assert(shape.length == 2)
+        BlockMatrixIR.toBlockMatrix(hc, shape(0).toInt, shape(1).toInt, data.toArray, blockSize)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -206,8 +206,8 @@ case class BlockMatrixMap2(left: BlockMatrixIR, right: BlockMatrixIR, applyBinOp
 
 case class BlockMatrixBroadcast(
   child: BlockMatrixIR,
-  inIndexExpr: IndexedSeq[String],
-  outIndexExpr: IndexedSeq[String],
+  inIndexExpr: IndexedSeq[Int],
+  outIndexExpr: IndexedSeq[Int],
   shape: IndexedSeq[Long],
   blockSize: Int,
   dimsPartitioned: IndexedSeq[Boolean]) extends BlockMatrixIR {

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1144,8 +1144,8 @@ object IRParser {
         val applyBinOp = ir_value_expr(env.update(Map("l" -> left.typ.elementType, "r" -> right.typ.elementType)))(it)
         BlockMatrixMap2(left, right, applyBinOp.asInstanceOf[ApplyBinaryPrimOp])
       case "BlockMatrixBroadcast" =>
-        val inIndexExpr = string_literals(it)
-        val outIndexExpr = string_literals(it)
+        val inIndexExpr = int32_literals(it)
+        val outIndexExpr = int32_literals(it)
         val shape = int64_literals(it)
         val blockSize = int32_literal(it)
         val dimsPartitioned = boolean_literals(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1144,12 +1144,13 @@ object IRParser {
         val applyBinOp = ir_value_expr(env.update(Map("l" -> left.typ.elementType, "r" -> right.typ.elementType)))(it)
         BlockMatrixMap2(left, right, applyBinOp.asInstanceOf[ApplyBinaryPrimOp])
       case "BlockMatrixBroadcast" =>
-        val broadcastKind = Broadcast2D.fromString(identifier(it))
+        val inIndexExpr = string_literals(it)
+        val outIndexExpr = string_literals(it)
         val shape = int64_literals(it)
         val blockSize = int32_literal(it)
         val dimsPartitioned = boolean_literals(it)
         val child = blockmatrix_ir(env)(it)
-        BlockMatrixBroadcast(child, broadcastKind, shape, blockSize, dimsPartitioned)
+        BlockMatrixBroadcast(child, inIndexExpr, outIndexExpr, shape, blockSize, dimsPartitioned)
       case "ValueToBlockMatrix" =>
         val shape = int64_literals(it)
         val blockSize = int32_literal(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1145,12 +1145,11 @@ object IRParser {
         BlockMatrixMap2(left, right, applyBinOp.asInstanceOf[ApplyBinaryPrimOp])
       case "BlockMatrixBroadcast" =>
         val inIndexExpr = int32_literals(it)
-        val outIndexExpr = int32_literals(it)
         val shape = int64_literals(it)
         val blockSize = int32_literal(it)
         val dimsPartitioned = boolean_literals(it)
         val child = blockmatrix_ir(env)(it)
-        BlockMatrixBroadcast(child, inIndexExpr, outIndexExpr, shape, blockSize, dimsPartitioned)
+        BlockMatrixBroadcast(child, inIndexExpr, shape, blockSize, dimsPartitioned)
       case "ValueToBlockMatrix" =>
         val shape = int64_literals(it)
         val blockSize = int32_literal(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -195,8 +195,9 @@ object Pretty {
               prettyBooleanLiteral(overwrite) + " " +
               prettyBooleanLiteral(forceRowMajor) + " " +
               prettyBooleanLiteral(stageLocally)
-            case BlockMatrixBroadcast(_, broadcastType, shape, blockSize, dimsPartitioned) =>
-              prettyClass(broadcastType) + " " +
+            case BlockMatrixBroadcast(_, inIndexExpr, outIndexExpr, shape, blockSize, dimsPartitioned) =>
+              prettyStrings(inIndexExpr) + " " +
+              prettyStrings(outIndexExpr) + " " +
               prettyLongs(shape) + " " +
               blockSize.toString + " " +
               prettyLiterals(dimsPartitioned)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -195,9 +195,8 @@ object Pretty {
               prettyBooleanLiteral(overwrite) + " " +
               prettyBooleanLiteral(forceRowMajor) + " " +
               prettyBooleanLiteral(stageLocally)
-            case BlockMatrixBroadcast(_, inIndexExpr, outIndexExpr, shape, blockSize, dimsPartitioned) =>
+            case BlockMatrixBroadcast(_, inIndexExpr, shape, blockSize, dimsPartitioned) =>
               prettyInts(inIndexExpr) + " " +
-              prettyInts(outIndexExpr) + " " +
               prettyLongs(shape) + " " +
               blockSize.toString + " " +
               prettyLiterals(dimsPartitioned)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -196,8 +196,8 @@ object Pretty {
               prettyBooleanLiteral(forceRowMajor) + " " +
               prettyBooleanLiteral(stageLocally)
             case BlockMatrixBroadcast(_, inIndexExpr, outIndexExpr, shape, blockSize, dimsPartitioned) =>
-              prettyStrings(inIndexExpr) + " " +
-              prettyStrings(outIndexExpr) + " " +
+              prettyInts(inIndexExpr) + " " +
+              prettyInts(outIndexExpr) + " " +
               prettyLongs(shape) + " " +
               blockSize.toString + " " +
               prettyLiterals(dimsPartitioned)

--- a/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
@@ -6,6 +6,7 @@ import is.hail.expr.types.virtual.Type
 case class BlockMatrixType(
   elementType: Type,
   shape: IndexedSeq[Long],
+  isRowVector: Boolean,
   blockSize: Int,
   dimsPartitioned: IndexedSeq[Boolean]) extends BaseType {
 
@@ -33,6 +34,11 @@ case class BlockMatrixType(
     sb.append(s"shape:$space[")
     shape.foreachBetween(dimSize => sb.append(dimSize))(sb.append(s",$space"))
     sb += ']'
+    sb += ','
+    newline()
+
+    sb.append(s"isRowVector:$space")
+    sb.append(isRowVector)
     sb += ','
     newline()
 

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -55,7 +55,7 @@ class BlockMatrixIRSuite extends SparkSuite {
   @Test def testBlockMatrixBroadcastValue_Scalars() {
     val broadcastTwo = BlockMatrixBroadcast(
       ValueToBlockMatrix(MakeArray(Seq[F64](F64(2)), TArray(TFloat64())), Array[Long](), 0, Array[Boolean]()),
-        IndexedSeq(), IndexedSeq("i", "j"), shape, 0, Array[Boolean](false, false))
+        IndexedSeq(), IndexedSeq(0, 1), shape, 0, Array[Boolean](false, false))
 
     val onesAddTwo = makeMap2(new BlockMatrixLiteral(ones), broadcastTwo, Add())
     val threesSubTwo = makeMap2(new BlockMatrixLiteral(threes), broadcastTwo, Subtract())
@@ -72,9 +72,9 @@ class BlockMatrixIRSuite extends SparkSuite {
     val vectorLiteral = MakeArray(Seq[F64](F64(1), F64(2), F64(3)), TArray(TFloat64()))
 
     val broadcastRowVector = BlockMatrixBroadcast(ValueToBlockMatrix(vectorLiteral, Array[Long](3),
-      0, Array(false)), IndexedSeq("i"), IndexedSeq("j", "i"), shape, 0, Array[Boolean](false, false))
+      0, Array(false)), IndexedSeq(0), IndexedSeq(1, 0), shape, 0, Array[Boolean](false, false))
     val broadcastColVector = BlockMatrixBroadcast(ValueToBlockMatrix(vectorLiteral, Array[Long](3),
-      0, Array(false)), IndexedSeq("i"), IndexedSeq("i", "j"), shape, 0, Array[Boolean](false, false))
+      0, Array(false)), IndexedSeq(0), IndexedSeq(0, 1), shape, 0, Array[Boolean](false, false))
 
     // Addition
     val actualOnesAddRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Add())

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -54,8 +54,13 @@ class BlockMatrixIRSuite extends SparkSuite {
 
   @Test def testBlockMatrixBroadcastValue_Scalars() {
     val broadcastTwo = BlockMatrixBroadcast(
+<<<<<<< HEAD
       ValueToBlockMatrix(MakeArray(Seq[F64](F64(2)), TArray(TFloat64())), Array[Long](), 0, Array[Boolean]()),
         Broadcast2D.SCALAR, shape, 0, Array[Boolean](false, false))
+=======
+      ValueToBlockMatrix(MakeArray(Seq[F64](F64(2)), TArray(TFloat64())), TFloat64(), Array[Long](), 0, Array[Boolean]()),
+        IndexedSeq(), IndexedSeq("i", "j"), shape, 0, Array[Boolean](false, false))
+>>>>>>> implement simple index expr for broadcast and transpose
 
     val onesAddTwo = makeMap2(new BlockMatrixLiteral(ones), broadcastTwo, Add())
     val threesSubTwo = makeMap2(new BlockMatrixLiteral(threes), broadcastTwo, Subtract())
@@ -72,9 +77,9 @@ class BlockMatrixIRSuite extends SparkSuite {
     val vectorLiteral = MakeArray(Seq[F64](F64(1), F64(2), F64(3)), TArray(TFloat64()))
 
     val broadcastRowVector = BlockMatrixBroadcast(ValueToBlockMatrix(vectorLiteral, Array[Long](3),
-      0, Array(false)), Broadcast2D.ROW, shape, 0, Array[Boolean](false, false))
+      0, Array(false)), IndexedSeq("i"), IndexedSeq("j", "i"), shape, 0, Array[Boolean](false, false))
     val broadcastColVector = BlockMatrixBroadcast(ValueToBlockMatrix(vectorLiteral, Array[Long](3),
-      0, Array(false)), Broadcast2D.COL, shape, 0, Array[Boolean](false, false))
+      0, Array(false)), IndexedSeq("i"), IndexedSeq("i", "j"), shape, 0, Array[Boolean](false, false))
 
     // Addition
     val actualOnesAddRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Add())

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -54,13 +54,8 @@ class BlockMatrixIRSuite extends SparkSuite {
 
   @Test def testBlockMatrixBroadcastValue_Scalars() {
     val broadcastTwo = BlockMatrixBroadcast(
-<<<<<<< HEAD
       ValueToBlockMatrix(MakeArray(Seq[F64](F64(2)), TArray(TFloat64())), Array[Long](), 0, Array[Boolean]()),
-        Broadcast2D.SCALAR, shape, 0, Array[Boolean](false, false))
-=======
-      ValueToBlockMatrix(MakeArray(Seq[F64](F64(2)), TArray(TFloat64())), TFloat64(), Array[Long](), 0, Array[Boolean]()),
         IndexedSeq(), IndexedSeq("i", "j"), shape, 0, Array[Boolean](false, false))
->>>>>>> implement simple index expr for broadcast and transpose
 
     val onesAddTwo = makeMap2(new BlockMatrixLiteral(ones), broadcastTwo, Add())
     val threesSubTwo = makeMap2(new BlockMatrixLiteral(threes), broadcastTwo, Subtract())

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -55,7 +55,7 @@ class BlockMatrixIRSuite extends SparkSuite {
   @Test def testBlockMatrixBroadcastValue_Scalars() {
     val broadcastTwo = BlockMatrixBroadcast(
       ValueToBlockMatrix(MakeArray(Seq[F64](F64(2)), TArray(TFloat64())), Array[Long](), 0, Array[Boolean]()),
-        IndexedSeq(), IndexedSeq(0, 1), shape, 0, Array[Boolean](false, false))
+        IndexedSeq(), shape, 0, Array[Boolean](false, false))
 
     val onesAddTwo = makeMap2(new BlockMatrixLiteral(ones), broadcastTwo, Add())
     val threesSubTwo = makeMap2(new BlockMatrixLiteral(threes), broadcastTwo, Subtract())
@@ -72,9 +72,9 @@ class BlockMatrixIRSuite extends SparkSuite {
     val vectorLiteral = MakeArray(Seq[F64](F64(1), F64(2), F64(3)), TArray(TFloat64()))
 
     val broadcastRowVector = BlockMatrixBroadcast(ValueToBlockMatrix(vectorLiteral, Array[Long](3),
-      0, Array(false)), IndexedSeq(0), IndexedSeq(1, 0), shape, 0, Array[Boolean](false, false))
+      0, Array(false)), IndexedSeq(1), shape, 0, Array[Boolean](false, false))
     val broadcastColVector = BlockMatrixBroadcast(ValueToBlockMatrix(vectorLiteral, Array[Long](3),
-      0, Array(false)), IndexedSeq(0), IndexedSeq(0, 1), shape, 0, Array[Boolean](false, false))
+      0, Array(false)), IndexedSeq(0), shape, 0, Array[Boolean](false, false))
 
     // Addition
     val actualOnesAddRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Add())

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -54,7 +54,7 @@ class BlockMatrixIRSuite extends SparkSuite {
 
   @Test def testBlockMatrixBroadcastValue_Scalars() {
     val broadcastTwo = BlockMatrixBroadcast(
-      ValueToBlockMatrix(MakeArray(Seq[F64](F64(2)), TArray(TFloat64())), Array[Long](), 0, Array[Boolean]()),
+      ValueToBlockMatrix(MakeArray(Seq[F64](F64(2)), TArray(TFloat64())), Array[Long](1, 1), 0, Array[Boolean]()),
         IndexedSeq(), shape, 0, Array[Boolean](false, false))
 
     val onesAddTwo = makeMap2(new BlockMatrixLiteral(ones), broadcastTwo, Add())
@@ -71,9 +71,9 @@ class BlockMatrixIRSuite extends SparkSuite {
   @Test def testBlockMatrixBroadcastValue_Vectors() {
     val vectorLiteral = MakeArray(Seq[F64](F64(1), F64(2), F64(3)), TArray(TFloat64()))
 
-    val broadcastRowVector = BlockMatrixBroadcast(ValueToBlockMatrix(vectorLiteral, Array[Long](3),
+    val broadcastRowVector = BlockMatrixBroadcast(ValueToBlockMatrix(vectorLiteral, Array[Long](1, 3),
       0, Array(false)), IndexedSeq(1), shape, 0, Array[Boolean](false, false))
-    val broadcastColVector = BlockMatrixBroadcast(ValueToBlockMatrix(vectorLiteral, Array[Long](3),
+    val broadcastColVector = BlockMatrixBroadcast(ValueToBlockMatrix(vectorLiteral, Array[Long](3, 1),
       0, Array(false)), IndexedSeq(0), shape, 0, Array[Boolean](false, false))
 
     // Addition

--- a/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir
 import is.hail.SparkSuite
 import is.hail.TestUtils.assertEvalsTo
 import is.hail.expr.ir.TestUtils.IRAggCount
-import is.hail.expr.types.virtual.{TInt32, TStruct}
+import is.hail.expr.types.virtual.{TArray, TFloat64, TInt32, TStruct}
 import is.hail.table.{Ascending, SortField}
 import is.hail.utils.FastIndexedSeq
 import org.apache.spark.sql.Row
@@ -54,5 +54,13 @@ class SimplifySuite extends SparkSuite {
 
     val ir2 = SelectFields(InsertFields(base, FastIndexedSeq("3" -> I32(1)), None), FastIndexedSeq("3", "1"))
     assert(Simplify(ir2) == InsertFields(SelectFields(base, FastIndexedSeq("1")), FastIndexedSeq("3" -> I32(1)), Some(FastIndexedSeq("3", "1"))))
+  }
+
+  @Test def testBlockMatrixRewriteRules() {
+    val bmir = ValueToBlockMatrix(MakeArray(IndexedSeq(F64(1), F64(2), F64(3), F64(4)), TArray(TFloat64())),
+      IndexedSeq(2, 2), 10, IndexedSeq(false, false))
+    val identityBroadcast = BlockMatrixBroadcast(bmir, IndexedSeq(0, 1), IndexedSeq(2, 2), 10, IndexedSeq(false, false))
+
+    assert(Simplify(identityBroadcast) == bmir)
   }
 }


### PR DESCRIPTION
Using index expressions to represent abstract transformations on tensors. E.g. broadcasts from scalars and vectors to matrices would be represented by

```
O(i, j) <- A()
O(i, j) <- A(i)
O(i, j) <- A(j)
```
where A is the input tensor and O is the output tensor. Similarly, transpose and identity look like

```
O(i, j) <- A(j, i)
O(i, j) <- A(i, j)
```

Since the `O(i,j)` is the same in all of these, we only need to look at the "in" index expressions for broadcasts to distinguish what operation needs to be performed. There's also a Simplify rule to cut out identity broadcasts.

## Workaround
This method of index expressions treats scalars and vectors as 0-dimensional and 1-dimensional tensors, respectively. As such, their shapes in the IR are 0 and 1-dimensional. However, BlockMatrix (Py API and Scala backend) assumes that all BlockMatrices are 2-dimensional, with the potential to have dimensions of length 1. To satisfy the current user API while maintaining a tensor-like mindset in the IR, the BlockMatrixType now has a `isRowVector` flag to help the front-end BlockMatrix discern whether a 1-tensor IR should be treated as a row or column vector. As BlockMatrix generalizes to n-tensors this flag can be removed. The IR should not rely on this flag for any execution logic.