### PR TITLE
Hailpedia 404 fix, 301 redirect

### DIFF
--- a/site/hail.nginx.conf
+++ b/site/hail.nginx.conf
@@ -8,19 +8,23 @@ server {
     }
 
     location = /docs/ {
-        return 307 $scheme://$http_host/docs/0.2;
+        return 301 $scheme://$http_host/docs/0.2;
     }
 
     location ~ ^/hail(|/.*)$ {
         return 301 $scheme://$http_host/docs/0.1$1;
     }
 
+    location ~ ^/docs/([^\/]+)/hailpedia/([^\/]*)$ {
+        return 301 $scheme://$http_host/docs/0.2/overview/$2;
+    }
+
     location ~ ^/docs/devel(|/.*)$ {
-        return 307 $scheme://$http_host/docs/0.2$1;
+        return 301 $scheme://$http_host/docs/0.2$1;
     }
 
     location ~ ^/docs/stable(|/.*)$ {
-        return 307 $scheme://$http_host/docs/0.2$1;
+        return 301 $scheme://$http_host/docs/0.2$1;
     }
 
     error_page 404 /404.html;


### PR DESCRIPTION
Fixes #5095 and tips Google that we don't want it to index /devel /stable (also 301 redirects are cached, should be faster).