### PR TITLE
Add BlockMatrixMap to IR

### DIFF
--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -23,14 +23,14 @@ class BlockMatrixMap(BlockMatrixIR):
     @typecheck_method(child=BlockMatrixIR, op=IR)
     def __init__(self, child, op):
         super().__init__()
-        self._child = child
-        self._op = op
+        self.child = child
+        self.op = op
 
     def render(self, r):
-        return f'(BlockMatrixMap {r(self._child)} {r(self._op)})'
+        return f'(BlockMatrixMap {r(self.child)} {r(self.op)})'
 
     def _compute_type(self):
-        self._type = self._child.typ
+        self._type = self.child.typ
 
 
 class BlockMatrixMap2(BlockMatrixIR):

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -1,5 +1,6 @@
 from hail.expr.blockmatrix_type import tblockmatrix
-from hail.ir import BlockMatrixIR, ApplyBinaryOp, IR, parsable_strings, tarray
+from hail.expr.types import tarray
+from hail.ir import BlockMatrixIR, IR
 from hail.utils.java import escape_str
 from hail.typecheck import typecheck_method, sequenceof
 
@@ -20,14 +21,14 @@ class BlockMatrixRead(BlockMatrixIR):
 
 
 class BlockMatrixMap(BlockMatrixIR):
-    @typecheck_method(child=BlockMatrixIR, op=IR)
-    def __init__(self, child, op):
+    @typecheck_method(child=BlockMatrixIR, f=IR)
+    def __init__(self, child, f):
         super().__init__()
         self.child = child
-        self.op = op
+        self.f = f
 
     def render(self, r):
-        return f'(BlockMatrixMap {r(self.child)} {r(self.op)})'
+        return f'(BlockMatrixMap {r(self.child)} {r(self.f)})'
 
     def _compute_type(self):
         self._type = self.child.typ

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -34,15 +34,15 @@ class BlockMatrixMap(BlockMatrixIR):
 
 
 class BlockMatrixMap2(BlockMatrixIR):
-    @typecheck_method(left=BlockMatrixIR, right=BlockMatrixIR, apply_bin_op=ApplyBinaryOp)
-    def __init__(self, left, right, apply_bin_op):
+    @typecheck_method(left=BlockMatrixIR, right=BlockMatrixIR, f=IR)
+    def __init__(self, left, right, f):
         super().__init__()
         self.left = left
         self.right = right
-        self.apply_bin_op = apply_bin_op
+        self.f = f
 
     def render(self, r):
-        return f'(BlockMatrixMap2 {r(self.left)} {r(self.right)} {r(self.apply_bin_op)})'
+        return f'(BlockMatrixMap2 {r(self.left)} {r(self.right)} {r(self.f)})'
 
     def _compute_type(self):
         self.right.typ  # Force

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -19,6 +19,20 @@ class BlockMatrixRead(BlockMatrixIR):
         self._type = Env.backend().blockmatrix_type(self)
 
 
+class BlockMatrixMap(BlockMatrixIR):
+    @typecheck_method(child=BlockMatrixIR, op=IR)
+    def __init__(self, child, op):
+        super().__init__()
+        self._child = child
+        self._op = op
+
+    def render(self, r):
+        return f'(BlockMatrixMap {r(self._child)} {r(self._op)})'
+
+    def _compute_type(self):
+        self._type = self._child.typ
+
+
 class BlockMatrixMap2(BlockMatrixIR):
     @typecheck_method(left=BlockMatrixIR, right=BlockMatrixIR, apply_bin_op=ApplyBinaryOp)
     def __init__(self, left, right, apply_bin_op):

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1279,7 +1279,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map2('+', self, b)
+        return self._apply_map2('+', b)
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
     def __sub__(self, b):
@@ -1293,7 +1293,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map2('-', self, b)
+        return self._apply_map2('-', b)
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
     def __mul__(self, b):
@@ -1307,7 +1307,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map2('*', self, b)
+        return self._apply_map2('*', b)
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
     def __truediv__(self, b):
@@ -1321,23 +1321,23 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map2('/', self, b)
+        return self._apply_map2('/', b)
 
     @typecheck_method(b=numeric)
     def __radd__(self, b):
-        return self._apply_map2('+', b, self)
+        return self._apply_map2('+', b, reverse=True)
 
     @typecheck_method(b=numeric)
     def __rsub__(self, b):
-        return self._apply_map2('-', b, self)
+        return self._apply_map2('-', b, reverse=True)
 
     @typecheck_method(b=numeric)
     def __rmul__(self, b):
-        return self._apply_map2('*', b, self)
+        return self._apply_map2('*', b, reverse=True)
 
     @typecheck_method(b=numeric)
     def __rtruediv__(self, b):
-        return self._apply_map2('/', b, self)
+        return self._apply_map2('/', b, reverse=True)
 
     @typecheck_method(b=oneof(np.ndarray, block_matrix_type))
     def __matmul__(self, b):

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -501,6 +501,10 @@ class BlockMatrix(object):
         return Env.hail().linalg.BlockMatrix.defaultBlockSize()
 
     @property
+    def element_type(self):
+        return self._bmir.typ.element_type
+
+    @property
     def n_rows(self):
         """Number of rows.
 
@@ -1241,18 +1245,23 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map(ApplyUnaryOp("-", Ref("element")))
+        return self._apply_map(ApplyUnaryOp('-', Ref('element')))
+
+    def _unary_func_ir(self, hail_func):
+        return hail_func(construct_expr(Ref('element'), self.element_type))._ir
+
+    @staticmethod
+    def _binary_op_ir(op):
+        return ApplyBinaryOp(op, Ref('l'), Ref('r'))
 
     @typecheck_method(f=IR)
     def _apply_map(self, f):
         return BlockMatrix(BlockMatrixMap(self._bmir, f))
 
-    @typecheck_method(op=str,
+    @typecheck_method(f=IR,
                       other=oneof(numeric, np.ndarray, block_matrix_type),
                       reverse=bool)
-    def _apply_map2(self, op, other, reverse=False):
-        apply_bin_op = ApplyBinaryOp(op, Ref('l'), Ref('r'))
-
+    def _apply_map2(self, f, other, reverse=False):
         if not isinstance(other, BlockMatrix):
             other = BlockMatrix(_to_bmir(other, self.block_size))
 
@@ -1267,7 +1276,7 @@ class BlockMatrix(object):
         else:
             left, right = self_bmir, other_bmir
 
-        return BlockMatrix(BlockMatrixMap2(left, right, apply_bin_op))
+        return BlockMatrix(BlockMatrixMap2(left, right, f))
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
     def __add__(self, b):
@@ -1281,7 +1290,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map2('+', b)
+        return self._apply_map2(BlockMatrix._binary_op_ir('+'), b)
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
     def __sub__(self, b):
@@ -1295,7 +1304,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map2('-', b)
+        return self._apply_map2(BlockMatrix._binary_op_ir('-'), b)
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
     def __mul__(self, b):
@@ -1309,7 +1318,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map2('*', b)
+        return self._apply_map2(BlockMatrix._binary_op_ir('*'), b)
 
     @typecheck_method(b=oneof(numeric, np.ndarray, block_matrix_type))
     def __truediv__(self, b):
@@ -1323,23 +1332,23 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map2('/', b)
+        return self._apply_map2(BlockMatrix._binary_op_ir('/'), b)
 
     @typecheck_method(b=numeric)
     def __radd__(self, b):
-        return self._apply_map2('+', b, reverse=True)
+        return self._apply_map2(BlockMatrix._binary_op_ir('+'), b, reverse=True)
 
     @typecheck_method(b=numeric)
     def __rsub__(self, b):
-        return self._apply_map2('-', b, reverse=True)
+        return self._apply_map2(BlockMatrix._binary_op_ir('-'), b, reverse=True)
 
     @typecheck_method(b=numeric)
     def __rmul__(self, b):
-        return self._apply_map2('*', b, reverse=True)
+        return self._apply_map2(BlockMatrix._binary_op_ir('*'), b, reverse=True)
 
     @typecheck_method(b=numeric)
     def __rtruediv__(self, b):
-        return self._apply_map2('/', b, reverse=True)
+        return self._apply_map2(BlockMatrix._binary_op_ir('/'), b, reverse=True)
 
     @typecheck_method(b=oneof(np.ndarray, block_matrix_type))
     def __matmul__(self, b):
@@ -1373,7 +1382,8 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return BlockMatrix._from_java(self._jbm.pow(float(x)))
+        pow_ir = (construct_expr(Ref('l'), self.element_type) ** construct_expr(Ref('r'), hl.tfloat64))._ir
+        return self._apply_map2(pow_ir, x)
 
     def sqrt(self):
         """Element-wise square root.
@@ -1382,7 +1392,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map(hl.sqrt(construct_expr(Ref("element"), hl.tfloat64))._ir)
+        return self._apply_map(self._unary_func_ir(hl.sqrt))
 
     def abs(self):
         """Element-wise absolute value.
@@ -1391,7 +1401,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map(hl.abs(construct_expr(Ref("element"), hl.tfloat64))._ir)
+        return self._apply_map(self._unary_func_ir(hl.abs))
 
     def log(self):
         """Element-wise natural logarithm.
@@ -1400,7 +1410,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map(hl.log(construct_expr(Ref("element"), hl.tfloat64))._ir)
+        return self._apply_map(self._unary_func_ir(hl.log))
 
     def diagonal(self):
         """Extracts diagonal elements as ndarray.

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -256,6 +256,7 @@ class BlockMatrixIRTests(unittest.TestCase):
 
         read = ir.BlockMatrixRead(resource('blockmatrix_example/0'))
         add_two_bms = BlockMatrixIRTests._make_element_wise_op_ir(read, read, '+')
+        abs_bm = ir.BlockMatrixMap(read, ir.ApplyUnaryOp('abs', ir.Ref('element')))
         negate_bm = ir.BlockMatrixMap(read, ir.ApplyUnaryOp('-', ir.Ref('element')))
         sqrt_bm = ir.BlockMatrixMap(read, ir.ApplyUnaryOp('sqrt', ir.Ref('element')))
 
@@ -275,6 +276,7 @@ class BlockMatrixIRTests(unittest.TestCase):
             broadcast_scalar,
             broadcast_col,
             broadcast_row,
+            abs_bm,
             negate_bm,
             sqrt_bm
         ]

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -256,6 +256,8 @@ class BlockMatrixIRTests(unittest.TestCase):
 
         read = ir.BlockMatrixRead(resource('blockmatrix_example/0'))
         add_two_bms = BlockMatrixIRTests._make_element_wise_op_ir(read, read, '+')
+        negate_bm = ir.BlockMatrixMap(read, ir.ApplyUnaryOp('-', ir.Ref('element')))
+        sqrt_bm = ir.BlockMatrixMap(read, ir.ApplyUnaryOp('sqrt', ir.Ref('element')))
 
         scalar_to_bm = ir.ValueToBlockMatrix(scalar_ir, [1, 1], 1, [])
         col_vector_to_bm = ir.ValueToBlockMatrix(vector_ir, [2, 1], 1, [False])
@@ -273,6 +275,8 @@ class BlockMatrixIRTests(unittest.TestCase):
             broadcast_scalar,
             broadcast_col,
             broadcast_row,
+            negate_bm,
+            sqrt_bm
         ]
 
     def test_parses(self):

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -1,6 +1,7 @@
 import unittest
 import hail as hl
 import hail.ir as ir
+from hail.expr import construct_expr
 from hail.utils.java import Env
 from hail.utils import new_temp_file
 from .helpers import *
@@ -256,9 +257,8 @@ class BlockMatrixIRTests(unittest.TestCase):
 
         read = ir.BlockMatrixRead(resource('blockmatrix_example/0'))
         add_two_bms = BlockMatrixIRTests._make_element_wise_op_ir(read, read, '+')
-        abs_bm = ir.BlockMatrixMap(read, ir.ApplyUnaryOp('abs', ir.Ref('element')))
         negate_bm = ir.BlockMatrixMap(read, ir.ApplyUnaryOp('-', ir.Ref('element')))
-        sqrt_bm = ir.BlockMatrixMap(read, ir.ApplyUnaryOp('sqrt', ir.Ref('element')))
+        sqrt_bm = ir.BlockMatrixMap(read, hl.sqrt(construct_expr(ir.Ref("element"), hl.tfloat64))._ir)
 
         scalar_to_bm = ir.ValueToBlockMatrix(scalar_ir, [1, 1], 1, [])
         col_vector_to_bm = ir.ValueToBlockMatrix(vector_ir, [2, 1], 1, [False])
@@ -276,7 +276,6 @@ class BlockMatrixIRTests(unittest.TestCase):
             broadcast_scalar,
             broadcast_col,
             broadcast_row,
-            abs_bm,
             negate_bm,
             sqrt_bm
         ]

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -75,20 +75,22 @@ class BlockMatrixLiteral(value: BlockMatrix) extends BlockMatrixIR {
   override protected[ir] def execute(hc: HailContext): BlockMatrix = value
 }
 
-case class BlockMatrixMap(child: BlockMatrixIR, op: IR) extends BlockMatrixIR {
+case class BlockMatrixMap(child: BlockMatrixIR, f: IR) extends BlockMatrixIR {
+  assert(f.isInstanceOf[ApplyUnaryPrimOp])
+
   override def typ: BlockMatrixType = child.typ
 
   override def children: IndexedSeq[BaseIR] = Array(child)
 
   override def copy(newChildren: IndexedSeq[BaseIR]): BaseIR = {
     assert(newChildren.length == 1)
-    BlockMatrixMap(newChildren(0).asInstanceOf[BlockMatrixIR], op)
+    BlockMatrixMap(newChildren(0).asInstanceOf[BlockMatrixIR], f)
   }
 
   override protected[ir] def execute(hc: HailContext): BlockMatrix = {
-    op match {
+    f match {
       case ApplyUnaryPrimOp(unaryOp, _) => applyUnaryOp(hc, unaryOp)
-      case _ => fatal(s"Unsupported operation on BlockMatrices: ${Pretty(op)}")
+      case _ => fatal(s"Unsupported operation on BlockMatrices: ${Pretty(f)}")
     }
   }
 
@@ -99,7 +101,7 @@ case class BlockMatrixMap(child: BlockMatrixIR, op: IR) extends BlockMatrixIR {
       case Abs() => childBm.abs()
       case Log() => childBm.log()
       case Sqrt() => childBm.sqrt()
-      case _ => fatal(s"Unsupported unary operation on BlockMatrices: ${Pretty(op)}")
+      case _ => fatal(s"Unsupported unary operation on BlockMatrices: $unaryOp")
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -76,7 +76,7 @@ class BlockMatrixLiteral(value: BlockMatrix) extends BlockMatrixIR {
 }
 
 case class BlockMatrixMap(child: BlockMatrixIR, f: IR) extends BlockMatrixIR {
-  assert(f.isInstanceOf[ApplyUnaryPrimOp] || f.isInstanceOf[Apply], s"${Pretty(f)}")
+  assert(f.isInstanceOf[ApplyUnaryPrimOp] || f.isInstanceOf[Apply])
 
   override def typ: BlockMatrixType = child.typ
 

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -88,28 +88,13 @@ case class BlockMatrixMap(child: BlockMatrixIR, f: IR) extends BlockMatrixIR {
   }
 
   override protected[ir] def execute(hc: HailContext): BlockMatrix = {
+    val blockMatrix = child.execute(hc)
     f match {
-      case ApplyUnaryPrimOp(unaryOp, _) => applyUnaryOp(hc, unaryOp)
-      case Apply(fName, _) => applyRegisteredFunc(hc, fName)
+      case ApplyUnaryPrimOp(Negate(), _) => blockMatrix.unary_-()
+      case Apply("abs", _) => blockMatrix.abs()
+      case Apply("log", _) => blockMatrix.log()
+      case Apply("sqrt", _) => blockMatrix.sqrt()
       case _ => fatal(s"Unsupported operation on BlockMatrices: ${Pretty(f)}")
-    }
-  }
-
-  private def applyUnaryOp(hc: HailContext, unaryOp: UnaryOp): BlockMatrix = {
-    val blockMatrix = child.execute(hc)
-    unaryOp match {
-      case Negate() => blockMatrix.unary_-()
-      case _ => fatal(s"Unsupported unary operation on BlockMatrices: $unaryOp")
-    }
-  }
-
-  private def applyRegisteredFunc(hc: HailContext, fName: String): BlockMatrix = {
-    val blockMatrix = child.execute(hc)
-    fName match {
-      case "abs" => blockMatrix.abs()
-      case "log" => blockMatrix.log()
-      case "sqrt" => blockMatrix.sqrt()
-      case _ => fatal(s"Unsupported registered function on BlockMatrices: $fName")
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -95,12 +95,12 @@ case class BlockMatrixMap(child: BlockMatrixIR, f: IR) extends BlockMatrixIR {
   }
 
   private def applyUnaryOp(hc: HailContext, unaryOp: UnaryOp): BlockMatrix = {
-    val childBm = child.execute(hc)
+    val blockMatrix = child.execute(hc)
     unaryOp match {
-      case Negate() => childBm.unary_-()
-      case Abs() => childBm.abs()
-      case Log() => childBm.log()
-      case Sqrt() => childBm.sqrt()
+      case Negate() => blockMatrix.unary_-()
+      case Abs() => blockMatrix.abs()
+      case Log() => blockMatrix.log()
+      case Sqrt() => blockMatrix.sqrt()
       case _ => fatal(s"Unsupported unary operation on BlockMatrices: $unaryOp")
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1137,6 +1137,10 @@ object IRParser {
       case "BlockMatrixRead" =>
         val path = string_literal(it)
         BlockMatrixRead(path)
+      case "BlockMatrixMap" =>
+        val child = blockmatrix_ir(env)(it)
+        val op = ir_value_expr(env + ("element" -> child.typ.elementType))(it)
+        BlockMatrixMap(child, op)
       case "BlockMatrixMap2" =>
         val left = blockmatrix_ir(env)(it)
         val right = blockmatrix_ir(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1144,8 +1144,8 @@ object IRParser {
       case "BlockMatrixMap2" =>
         val left = blockmatrix_ir(env)(it)
         val right = blockmatrix_ir(env)(it)
-        val applyBinOp = ir_value_expr(env.update(Map("l" -> left.typ.elementType, "r" -> right.typ.elementType)))(it)
-        BlockMatrixMap2(left, right, applyBinOp.asInstanceOf[ApplyBinaryPrimOp])
+        val f = ir_value_expr(env.update(Map("l" -> left.typ.elementType, "r" -> right.typ.elementType)))(it)
+        BlockMatrixMap2(left, right, f)
       case "BlockMatrixBroadcast" =>
         val inIndexExpr = int32_literals(it)
         val shape = int64_literals(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1139,8 +1139,8 @@ object IRParser {
         BlockMatrixRead(path)
       case "BlockMatrixMap" =>
         val child = blockmatrix_ir(env)(it)
-        val op = ir_value_expr(env + ("element" -> child.typ.elementType))(it)
-        BlockMatrixMap(child, op)
+        val f = ir_value_expr(env + ("element" -> child.typ.elementType))(it)
+        BlockMatrixMap(child, f)
       case "BlockMatrixMap2" =>
         val left = blockmatrix_ir(env)(it)
         val right = blockmatrix_ir(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/UnaryOp.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/UnaryOp.scala
@@ -63,6 +63,9 @@ object UnaryOp {
     case "-" | "Negate" => Negate()
     case "!" | "Bang" => Bang()
     case "~" | "BitNot" => BitNot()
+    case "abs" => Abs()
+    case "log" => Log()
+    case "sqrt" => Sqrt()
   }
 }
 
@@ -70,3 +73,6 @@ sealed trait UnaryOp { }
 case class Negate() extends UnaryOp { }
 case class Bang() extends UnaryOp { }
 case class BitNot() extends UnaryOp
+case class Abs() extends UnaryOp
+case class Log() extends UnaryOp
+case class Sqrt() extends UnaryOp

--- a/hail/src/main/scala/is/hail/expr/ir/UnaryOp.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/UnaryOp.scala
@@ -63,9 +63,6 @@ object UnaryOp {
     case "-" | "Negate" => Negate()
     case "!" | "Bang" => Bang()
     case "~" | "BitNot" => BitNot()
-    case "abs" => Abs()
-    case "log" => Log()
-    case "sqrt" => Sqrt()
   }
 }
 
@@ -73,6 +70,3 @@ sealed trait UnaryOp { }
 case class Negate() extends UnaryOp { }
 case class Bang() extends UnaryOp { }
 case class BitNot() extends UnaryOp
-case class Abs() extends UnaryOp
-case class Log() extends UnaryOp
-case class Sqrt() extends UnaryOp

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -77,11 +77,14 @@ class BlockMatrixIRSuite extends SparkSuite {
     val threesSubTwo = makeMap2(new BlockMatrixLiteral(threes), broadcastTwo, Subtract())
     val twosMulTwo = makeMap2(new BlockMatrixLiteral(twos), broadcastTwo, Multiply())
     val foursDivTwo = makeMap2(new BlockMatrixLiteral(fours), broadcastTwo, FloatingPointDivide())
+    val twosPowTwo = BlockMatrixMap2(new BlockMatrixLiteral(twos), broadcastTwo,
+      Apply("**", IndexedSeq(Ref("l", TFloat64()), Ref("r", TFloat64()))))
 
     assertBmEq(onesAddTwo.execute(hc), threes)
     assertBmEq(threesSubTwo.execute(hc), ones)
     assertBmEq(twosMulTwo.execute(hc), fours)
     assertBmEq(foursDivTwo.execute(hc), twos)
+    assertBmEq(twosPowTwo.execute(hc), fours)
   }
 
   @Test def testBlockMatrixBroadcastValue_Vectors() {

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -57,10 +57,10 @@ class BlockMatrixIRSuite extends SparkSuite {
 
 
   @Test def testBlockMatrixMap() {
-    val sqrtFoursIR = BlockMatrixMap(new BlockMatrixLiteral(fours), ApplyUnaryPrimOp(Sqrt(), Ref("element", TFloat64())))
+    val sqrtFoursIR = BlockMatrixMap(new BlockMatrixLiteral(fours), Apply("sqrt", IndexedSeq(Ref("element", TFloat64()))))
     val negFoursIR = BlockMatrixMap(new BlockMatrixLiteral(fours), ApplyUnaryPrimOp(Negate(), Ref("element", TFloat64())))
-    val logOnesIR = BlockMatrixMap(new BlockMatrixLiteral(ones), ApplyUnaryPrimOp(Log(), Ref("element", TFloat64())))
-    val absNegFoursIR = BlockMatrixMap(new BlockMatrixLiteral(negFours), ApplyUnaryPrimOp(Abs(), Ref("element", TFloat64())))
+    val logOnesIR = BlockMatrixMap(new BlockMatrixLiteral(ones), Apply("log", IndexedSeq(Ref("element", TFloat64()))))
+    val absNegFoursIR = BlockMatrixMap(new BlockMatrixLiteral(negFours), Apply("abs", IndexedSeq(Ref("element", TFloat64()))))
 
     assertBmEq(sqrtFoursIR.execute(hc), twos)
     assertBmEq(negFoursIR.execute(hc), negFours)


### PR DESCRIPTION
- Add a `BlockMatrixMap` IR node that handles operations like: `neg`, `log`, `sqrt`, `abs`
- Change the function on Map2 to be an `IR`, not just `ApplyBinaryPrimOp`. This allows Map2 to support `pow` and other registered functions as well as arbitrary functions on tensors.