### PR TITLE
[hail] reduce default block size to 1024

### DIFF
--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -26,7 +26,7 @@ import org.json4s._
 
 object BlockMatrix {
   type M = BlockMatrix
-  val defaultBlockSize: Int = 4096 // 32 * 1024 bytes
+  val defaultBlockSize: Int = 1024
   val bufferSpec: BufferSpec =
     new BlockingBufferSpec(32 * 1024,
       new LZ4BlockBufferSpec(32 * 1024,


### PR DESCRIPTION
cc: @jbloom22 

I feel like I am frequently telling people to set their block size to 1024. Just had to do this for Danfeng. For whom is 4096 the right choice? I believe we should cater to the most common use-case.