### PR TITLE
[hail] Print the temporary directory on context start-up

### DIFF
--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -252,6 +252,7 @@ object HailContext {
 
     val sqlContext = new org.apache.spark.sql.SQLContext(sparkContext)
     val hailTempDir = TempDir.createTempDir(tmpDir, sparkContext.hadoopConfiguration)
+    info(s"Hail temporary directory: $hailTempDir")
     val hc = new HailContext(sparkContext, sqlContext, logFile, hailTempDir, branchingFactor)
     sparkContext.uiWebUrl.foreach(ui => info(s"SparkUI: $ui"))
 


### PR DESCRIPTION
cc: @tpoterba 

Not sure why this wasn't printed before. I found it a bit surprising we weren't actually using the `tmpDir` that I specified in `hl.init`. At least this way, I can figure out which temp dir is for my current session.