### PR TITLE
remove all references to Scala Table from Python

### DIFF
--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -30,11 +30,11 @@ class Backend(abc.ABC):
     def matrix_type(self, mir):
         return
 
-    def persist_table(self, ht, storage_level):
-        return ht
+    def persist_table(self, t, storage_level):
+        return t
 
-    def unpersist_table(self, ht):
-        return ht
+    def unpersist_table(self, t):
+        return t
 
     def persist_matrix_table(self, mt, storage_level):
         return mt
@@ -105,11 +105,11 @@ class SparkBackend(Backend):
         jir = self._to_java_ir(mir)
         return tmatrix._from_java(jir.typ())
 
-    def persist_table(self, ht, storage_level):
-        return Table._from_java(self.to_java_ir(ht._tir).pyPersist(storage_level))
+    def persist_table(self, t, storage_level):
+        return Table._from_java(self._to_java_ir(t._tir).pyPersist(storage_level))
 
-    def unpersist_table(self, ht):
-        return Table._from_java(self.to_java_ir(ht._tir).pyUnpersist())
+    def unpersist_table(self, t):
+        return Table._from_java(self.to_java_ir(t._tir).pyUnpersist())
 
     def persist_matrix_table(self, mt, storage_level):
         return MatrixTable._from_java(mt._jmt.persist(storage_level))
@@ -122,13 +122,13 @@ class SparkBackend(Backend):
         return tblockmatrix._from_java(jir.typ())
 
     def from_spark(self, df, key):
-        return Table._from_java(Env.hail().table.Table.pyFromDF(Env.hc()._jhc, df._jdf, key))
+        return Table._from_java(Env.hail().table.Table.pyFromDF(df._jdf, key))
 
     def to_spark(self, t, flatten):
         t = t.expand_types()
         if flatten:
             t = t.flatten()
-        return pyspark.sql.DataFrame(t._jt.pyToDF(), Env.sql_context())
+        return pyspark.sql.DataFrame(self._to_java_ir(t._tir).pyToDF(), Env.sql_context())
 
     def to_pandas(self, t, flatten):
         return self.to_spark(t, flatten).toPandas()

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -106,10 +106,10 @@ class SparkBackend(Backend):
         return tmatrix._from_java(jir.typ())
 
     def persist_table(self, ht, storage_level):
-        return Table._from_java(ht._jt.persist(storage_level))
+        return Table._from_java(self.to_java_ir(ht._tir).pyPersist(storage_level))
 
     def unpersist_table(self, ht):
-        return Table._from_java(ht._jt.unpersist())
+        return Table._from_java(self.to_java_ir(ht._tir).pyUnpersist())
 
     def persist_matrix_table(self, mt, storage_level):
         return MatrixTable._from_java(mt._jmt.persist(storage_level))
@@ -122,13 +122,13 @@ class SparkBackend(Backend):
         return tblockmatrix._from_java(jir.typ())
 
     def from_spark(self, df, key):
-        return Table._from_java(Env.hail().table.Table.fromDF(Env.hc()._jhc, df._jdf, key))
+        return Table._from_java(Env.hail().table.Table.pyFromDF(Env.hc()._jhc, df._jdf, key))
 
     def to_spark(self, t, flatten):
         t = t.expand_types()
         if flatten:
             t = t.flatten()
-        return pyspark.sql.DataFrame(t._jt.toDF(Env.hc()._jsql_context), Env.sql_context())
+        return pyspark.sql.DataFrame(t._jt.pyToDF(), Env.sql_context())
 
     def to_pandas(self, t, flatten):
         return self.to_spark(t, flatten).toPandas()

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1934,8 +1934,11 @@ class TableToValueApply(IR):
 
     def _compute_type(self, env, agg_env):
         name = self.config['name']
-        assert name == 'ForceCountTable', name
-        self._type = tint64
+        if: name == 'ForceCountTable':
+            self._type = tint64
+        else:
+            assert name == 'NPartitionsTable', name
+            self._type = tint32
 
 
 class MatrixToValueApply(IR):
@@ -1959,6 +1962,8 @@ class MatrixToValueApply(IR):
         name = self.config['name']
         if name == 'ForceCountMatrixTable':
             self._type = tint64
+        elif name == 'NPartitionsMatrixTable':
+            self._type = tint32
         elif name == 'MatrixExportEntriesByCol':
             self._type = tvoid
         else:

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -2044,6 +2044,9 @@ class JavaIR(IR):
     def render(self, r):
         return f'(JavaIR {r.add_jir(self._jir)})'
 
+    def _compute_type(self, env, agg_env):
+        self._type = dtype(self._jir.typ().toString())
+
 
 def subst(ir, env, agg_env):
     def _subst(ir, env2=None, agg_env2=None):

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1934,7 +1934,7 @@ class TableToValueApply(IR):
 
     def _compute_type(self, env, agg_env):
         name = self.config['name']
-        if: name == 'ForceCountTable':
+        if name == 'ForceCountTable':
             self._type = tint64
         else:
             assert name == 'NPartitionsTable', name

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -437,9 +437,13 @@ class TableToTableApply(TableIR):
         return f'(TableToTableApply {dump_json(self.config)} {r(self.child)})'
 
     def _compute_type(self):
-        assert (self.config['name'] == 'TableFilterPartitions'
-                or self.config['name'] == 'TableFilterIntervals')
-        self._type = self.child.typ
+        name = self.config['name']
+        if name == 'TableFilterPartitions' or name == 'TableFilterIntervals':
+            self._type = self.child.typ
+        else:
+            assert name == 'VEP', name
+            self._type = Env.backend().table_type(self)
+
 
 def regression_test_type(test):
     glm_fit_schema = dtype('struct{n_iterations:int32,converged:bool,exploded:bool}')

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1472,7 +1472,7 @@ class BlockMatrix(object):
         :class:`.Table`
             Table with a row for each entry.
         """
-        t = Table._from_java(self._jbm.entriesTable(Env.hc()._jhc))
+        t = Table._from_java(self._jbm.entriesTable())
         if keyed:
             t = t.key_by('i', 'j')
         return t

--- a/hail/python/hail/methods/misc.py
+++ b/hail/python/hail/methods/misc.py
@@ -148,7 +148,7 @@ def maximal_independent_set(i, j, keep=True, tie_breaker=None, keyed=True) -> Ta
 
     mis_nodes_t = hl.tset(node_t)
     mis_nodes = mis_nodes_t._from_json(Env.hail().utils.Graph.pyMaximalIndependentSetJSON(
-        edges.row.dtype._to_json(edges.collect()),
+        hl.tarray(edges.row.dtype)._to_json(edges.collect()),
         node_t._parsable_string(),
         joption(tie_breaker_str)))
     

--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -519,7 +519,7 @@ def vep(dataset: Union[Table, MatrixTable], config, block_size=1000, name='vep',
                                           {'name': 'VEP',
                                            'config': config,
                                            'csq': csq,
-                                           'block_size': block_size}))
+                                           'blockSize': block_size}))
 
     if csq:
         dataset = dataset.annotate_globals(

--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -7,6 +7,7 @@ from hail.utils.java import Env
 from hail.utils.misc import divide_null
 from hail.matrixtable import MatrixTable
 from hail.table import Table
+from hail.ir import TableToTableApply
 from .misc import require_biallelic, require_row_key_variant, require_col_key_str, require_table_key_variant
 
 

--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -410,7 +410,7 @@ def concordance(left, right) -> Tuple[List[List[int]], Table, Table]:
     left = require_biallelic(left, "concordance, left")
     right = require_biallelic(right, "concordance, right")
 
-    r = Env.hail().methods.CalculateConcordance.apply(left._jmt, right._jmt)
+    r = Env.hail().methods.CalculateConcordance.pyApply(left._jmt, right._jmt)
     j_global_conc = r._1()
     col_conc = Table._from_java(r._2())
     row_conc = Table._from_java(r._3())
@@ -514,7 +514,11 @@ def vep(dataset: Union[Table, MatrixTable], config, block_size=1000, name='vep',
         require_table_key_variant(dataset, 'vep')
         ht = dataset.select()
 
-    annotations = Table._from_java(Env.hail().methods.VEP.apply(ht._jt, config, csq, block_size))
+    annotations = Table(TableToTableApply(ht._tir,
+                                          {'name': 'VEP',
+                                           'config': config,
+                                           'csq': csq,
+                                           'block_size': block_size}))
 
     if csq:
         dataset = dataset.annotate_globals(

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -98,11 +98,11 @@ def identity_by_descent(dataset, maf=None, bounded=True, min=None, max=None) -> 
     else:
         dataset = dataset.select_rows()
     dataset = dataset.select_cols().select_globals().select_entries('GT')
-    return Table._from_java(Env.hail().methods.IBD.apply(require_biallelic(dataset, 'ibd')._jmt,
-                                                         joption('__maf' if maf is not None else None),
-                                                         bounded,
-                                                         joption(min),
-                                                         joption(max)))
+    return Table._from_java(Env.hail().methods.IBD.pyApply(require_biallelic(dataset, 'ibd')._jmt,
+                                                           joption('__maf' if maf is not None else None),
+                                                           bounded,
+                                                           joption(min),
+                                                           joption(max)))
 
 
 @typecheck(call=expr_call,
@@ -1810,13 +1810,12 @@ def pc_relate(call_expr, min_individual_maf, *, k=None, scores_expr=None,
     int_statistics = {'kin': 0, 'kin2': 1, 'kin20': 2, 'all': 3}[statistics]
 
     ht = Table._from_java(scala_object(Env.hail().methods, 'PCRelate')
-                          .apply(Env.hc()._jhc,
-                                 g._jbm,
-                                 scores_table._jt,
-                                 min_individual_maf,
-                                 block_size,
-                                 min_kinship,
-                                 int_statistics))
+                          .pyApply(g._jbm,
+                                   Env.spark_backend()._to_java_ir(scores_table.collect(_localize=False)._ir),
+                                   min_individual_maf,
+                                   block_size,
+                                   min_kinship,
+                                   int_statistics))
 
     if statistics == 'kin':
         ht = ht.drop('ibd0', 'ibd1', 'ibd2')

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -1811,7 +1811,7 @@ def pc_relate(call_expr, min_individual_maf, *, k=None, scores_expr=None,
 
     ht = Table._from_java(scala_object(Env.hail().methods, 'PCRelate')
                           .pyApply(g._jbm,
-                                   Env.spark_backend()._to_java_ir(scores_table.collect(_localize=False)._ir),
+                                   Env.spark_backend('pc_relate')._to_java_ir(scores_table.collect(_localize=False)._ir),
                                    min_individual_maf,
                                    block_size,
                                    min_kinship,

--- a/hail/python/hail/stats/linear_mixed_model.py
+++ b/hail/python/hail/stats/linear_mixed_model.py
@@ -830,8 +830,7 @@ class LinearMixedModel(object):
         if not self._fitted:
             raise Exception("null model is not fit. Run 'fit' first.")
 
-        self._scala_model = Env.hail().stats.LinearMixedModel.apply(
-            Env.hc()._jhc,
+        self._scala_model = Env.hail().stats.LinearMixedModel.pyApply(
             self.gamma,
             self._residual_sq,
             _jarray_from_ndarray(self.py),

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -313,21 +313,12 @@ class Table(ExprContainer):
     """
 
     @staticmethod
-    def _from_java(jt):
-        return Table(JavaTable(jt.tir()))
+    def _from_java(jtir):
+        return Table(JavaTable(jtir))
     
-    @property
-    def _jt(self):
-        if self._jt_cache is None:
-            self._jt_cache = Env.hail().table.Table(
-                Env.hc()._jhc, Env.hc()._backend._to_java_ir(self._tir))
-        return self._jt_cache
-
     def __init__(self, tir):
         super(Table, self).__init__()
 
-        self._jt_cache = None
-        
         self._tir = tir
         self._type = self._tir.typ
 
@@ -402,7 +393,7 @@ class Table(ExprContainer):
         -------
         :obj:`int`
         """
-        return self._jt.nPartitions()
+        return Env.backend().execute(TableToValueApply(self._tir, {'name': 'NPartitionsTable'}))
 
     def count(self):
         """Count the number of rows in the table.

--- a/hail/src/main/scala/is/hail/annotations/BroadcastValue.scala
+++ b/hail/src/main/scala/is/hail/annotations/BroadcastValue.scala
@@ -1,5 +1,6 @@
 package is.hail.annotations
 
+import is.hail.HailContext
 import is.hail.expr.types._
 import is.hail.expr.types.virtual.{TArray, TBaseStruct, TStruct, Type}
 import org.apache.spark.SparkContext
@@ -23,8 +24,8 @@ abstract class BroadcastValue[T: ClassTag](value: T, t: Type, sc: SparkContext) 
 }
 
 object BroadcastRow {
-  def empty(sc: SparkContext): BroadcastRow =
-    BroadcastRow(Row.empty, TStruct.empty(), sc)
+  def empty(): BroadcastRow =
+    BroadcastRow(Row.empty, TStruct.empty(), HailContext.get.sc)
 }
 
 case class BroadcastRow(value: Row,

--- a/hail/src/main/scala/is/hail/expr/ir/LiftNonCompilable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LiftNonCompilable.scala
@@ -9,7 +9,7 @@ import org.apache.spark.sql.Row
 import scala.collection.mutable
 
 object LiftNonCompilable {
-  lazy val emptyRow: BroadcastRow = BroadcastRow.empty(HailContext.get.sc)
+  lazy val emptyRow: BroadcastRow = BroadcastRow.empty()
 
   def extractNonCompilable(irs: IR*): Map[String, IR] = {
     val included = mutable.Set.empty[IR]

--- a/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
@@ -55,6 +55,8 @@ object RelationalFunctions {
     classOf[MatrixFilterPartitions],
     classOf[ForceCountTable],
     classOf[ForceCountMatrixTable],
+    classOf[NPartitionsTable],
+    classOf[NPartitionsMatrixTable],
     classOf[LogisticRegression],
     classOf[MatrixWriteBlockMatrix],
     classOf[TableFilterIntervals],
@@ -63,7 +65,8 @@ object RelationalFunctions {
     classOf[Skat],
     classOf[LocalLDPrune],
     classOf[MatrixExportEntriesByCol],
-    classOf[PCA]
+    classOf[PCA],
+    classOf[VEP]
   )) +
     new MatrixFilterIntervalsSerializer +
     new TableFilterIntervalsSerializer

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -1215,9 +1215,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
         }
     }
 
-    TableLiteral(TableValue(TableType(rowType, IndexedSeq.empty[String], TStruct.empty()),
-      BroadcastRow.empty(),
-      RVD.unkeyed(rowType.physicalType, entriesRDD)))
+    TableLiteral(TableValue(rowType, FastIndexedSeq(), entriesRDD))
   }
 }
 

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -21,6 +21,7 @@ import org.apache.commons.math3.random.MersenneTwister
 import org.apache.spark.executor.InputMetrics
 import org.apache.spark._
 import org.apache.spark.mllib.linalg.distributed._
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
 import org.json4s._
@@ -1215,7 +1216,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     }
 
     TableLiteral(TableValue(TableType(rowType, IndexedSeq.empty[String], TStruct.empty()),
-      BroadcastRow.empty(HailContext.get.sc),
+      BroadcastRow.empty(),
       RVD.unkeyed(rowType.physicalType, entriesRDD)))
   }
 }

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -7,6 +7,7 @@ import breeze.numerics.{abs => breezeAbs, log => breezeLog, pow => breezePow, sq
 import breeze.stats.distributions.{RandBasis, ThreadLocalRandomGenerator}
 import is.hail._
 import is.hail.annotations._
+import is.hail.expr.ir.TableIR
 import is.hail.table.Table
 import is.hail.expr.types._
 import is.hail.expr.types.virtual.{TFloat64, TFloat64Optional, TInt64Optional, TStruct}
@@ -1189,7 +1190,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       blockSize, keepRows.length, keepCols.length)
   }
 
-  def entriesTable(hc: HailContext): Table = {
+  def entriesTable(hc: HailContext): TableIR = {
     val rvRowType = TStruct("i" -> TInt64Optional, "j" -> TInt64Optional, "entry" -> TFloat64Optional)
     
     val entriesRDD = ContextRDD.weaken[RVDContext](blocks).cflatMap { case (ctx, ((blockRow, blockCol), block)) =>
@@ -1213,7 +1214,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
         }
     }
 
-    new Table(hc, entriesRDD, rvRowType, Array[String]())
+    new Table(hc, entriesRDD, rvRowType, Array[String]()).tir
   }
 }
 

--- a/hail/src/main/scala/is/hail/methods/CalculateConcordance.scala
+++ b/hail/src/main/scala/is/hail/methods/CalculateConcordance.scala
@@ -1,6 +1,7 @@
 package is.hail.methods
 
 import is.hail.annotations.UnsafeRow
+import is.hail.expr.ir.TableIR
 import is.hail.expr.types._
 import is.hail.expr.types.virtual.{TArray, TInt64, TStruct}
 import is.hail.table.Table
@@ -60,7 +61,7 @@ class ConcordanceCombiner extends Serializable {
 
 object CalculateConcordance {
 
-  def apply(left: MatrixTable, right: MatrixTable): (IndexedSeq[IndexedSeq[Long]], Table, Table) = {
+  def pyApply(left: MatrixTable, right: MatrixTable): (IndexedSeq[IndexedSeq[Long]], TableIR, TableIR) = {
     left.requireUniqueSamples("concordance")
     right.requireUniqueSamples("concordance")
 
@@ -235,6 +236,6 @@ object CalculateConcordance {
 
     val variantKT = Table(left.hc, variantCRDD, variantSchema, left.rowKey, isSorted = false)
 
-    (global.toAnnotation, sampleKT, variantKT)
+    (global.toAnnotation, sampleKT.tir, variantKT.tir)
   }
 }

--- a/hail/src/main/scala/is/hail/methods/CalculateConcordance.scala
+++ b/hail/src/main/scala/is/hail/methods/CalculateConcordance.scala
@@ -240,9 +240,7 @@ object CalculateConcordance {
       left.colKey)
 
     val variant = TableKeyBy(
-      TableLiteral(TableValue(TableType(variantSchema, FastIndexedSeq(), TStruct.empty()),
-        BroadcastRow.empty(HailContext.get.sc),
-        variantCRDD)),
+      TableLiteral(TableValue(variantSchema, FastIndexedSeq(), variantCRDD.toRegionValues(variantSchema))),
       left.rowKey,
       isSorted = false)
 

--- a/hail/src/main/scala/is/hail/methods/IBD.scala
+++ b/hail/src/main/scala/is/hail/methods/IBD.scala
@@ -326,9 +326,7 @@ object IBD {
     val sampleIds = vds.stringSampleIds
 
     val ktRdd2 = computeIBDMatrix(vds, computeMaf, min, max, sampleIds, bounded)
-    TableKeyBy(TableLiteral(TableValue.fromCRDDRV(TableType(ibdSignature, FastIndexedSeq(), TStruct.empty()),
-      BroadcastRow.empty(HailContext.get.sc),
-      ktRdd2)),
+    TableKeyBy(TableLiteral(TableValue(ibdSignature, FastIndexedSeq(), ktRdd2)),
       FastIndexedSeq("i", "j"))
   }
 

--- a/hail/src/main/scala/is/hail/methods/IBD.scala
+++ b/hail/src/main/scala/is/hail/methods/IBD.scala
@@ -8,7 +8,7 @@ import is.hail.annotations._
 import is.hail.expr.types._
 import is.hail.expr.types.physical.{PString, PType}
 import is.hail.expr.types.virtual.{TFloat64, TInt64, TString, TStruct}
-import is.hail.rvd.RVDContext
+import is.hail.rvd.{RVD, RVDContext}
 import is.hail.sparkextras.ContextRDD
 import is.hail.variant.{Call, Genotype, HardCallView, MatrixTable}
 import is.hail.stats.RegressionUtils
@@ -326,7 +326,10 @@ object IBD {
     val sampleIds = vds.stringSampleIds
 
     val ktRdd2 = computeIBDMatrix(vds, computeMaf, min, max, sampleIds, bounded)
-    new Table(vds.hc, ktRdd2, ibdSignature, IndexedSeq("i", "j")).tir
+    TableKeyBy(TableLiteral(TableValue.fromCRDDRV(TableType(ibdSignature, FastIndexedSeq(), TStruct.empty()),
+      BroadcastRow.empty(HailContext.get.sc),
+      ktRdd2)),
+      FastIndexedSeq("i", "j"))
   }
 
   private val ibdSignature = TStruct(("i", TString()), ("j", TString())) ++ ExtendedIBDInfo.signature

--- a/hail/src/main/scala/is/hail/methods/IBD.scala
+++ b/hail/src/main/scala/is/hail/methods/IBD.scala
@@ -306,11 +306,11 @@ object IBD {
       }
   }
 
-  def apply(vds: MatrixTable,
+  def pyApply(vds: MatrixTable,
     mafFieldName: Option[String] = None,
     bounded: Boolean = true,
     min: Option[Double] = None,
-    max: Option[Double] = None): Table = {
+    max: Option[Double] = None): TableIR = {
 
     min.foreach(min => optionCheckInRangeInclusive(0.0, 1.0)("minimum", min))
     max.foreach(max => optionCheckInRangeInclusive(0.0, 1.0)("maximum", max))
@@ -326,7 +326,7 @@ object IBD {
     val sampleIds = vds.stringSampleIds
 
     val ktRdd2 = computeIBDMatrix(vds, computeMaf, min, max, sampleIds, bounded)
-    new Table(vds.hc, ktRdd2, ibdSignature, IndexedSeq("i", "j"))
+    new Table(vds.hc, ktRdd2, ibdSignature, IndexedSeq("i", "j")).tir
   }
 
   private val ibdSignature = TStruct(("i", TString()), ("j", TString())) ++ ExtendedIBDInfo.signature
@@ -338,8 +338,8 @@ object IBD {
     Table(sc, ktRdd, ibdSignature, IndexedSeq("i", "j"))
   }
 
-  def toRDD(kt: Table): RDD[((Annotation, Annotation), ExtendedIBDInfo)] = {
-    val rvd = kt.rvd
+  def toRDD(tv: TableValue): RDD[((Annotation, Annotation), ExtendedIBDInfo)] = {
+    val rvd = tv.rvd
     rvd.map { rv =>
       val region = rv.region
       val i = PString.loadString(region, ibdPType.loadField(rv, 0))

--- a/hail/src/main/scala/is/hail/methods/IBD.scala
+++ b/hail/src/main/scala/is/hail/methods/IBD.scala
@@ -325,9 +325,8 @@ object IBD {
     val computeMaf = mafFieldName.map(generateComputeMaf(vds, _))
     val sampleIds = vds.stringSampleIds
 
-    val ktRdd2 = computeIBDMatrix(vds, computeMaf, min, max, sampleIds, bounded)
-    TableKeyBy(TableLiteral(TableValue(ibdSignature, FastIndexedSeq(), ktRdd2)),
-      FastIndexedSeq("i", "j"))
+    TableLiteral(TableValue(ibdSignature, FastIndexedSeq("i", "j"),
+      computeIBDMatrix(vds, computeMaf, min, max, sampleIds, bounded)))
   }
 
   private val ibdSignature = TStruct(("i", TString()), ("j", TString())) ++ ExtendedIBDInfo.signature

--- a/hail/src/main/scala/is/hail/methods/LinearRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/LinearRegression.scala
@@ -166,7 +166,7 @@ case class LinearRegressionRowsSingle(
             }
           }
       })
-    TableValue(tableType, BroadcastRow.empty(sc), newRVD)
+    TableValue(tableType, BroadcastRow.empty(), newRVD)
   }
 }
 
@@ -355,7 +355,7 @@ case class LinearRegressionRowsChained(
             }
           }
       })
-    TableValue(tableType, BroadcastRow.empty(sc), newRVD)
+    TableValue(tableType, BroadcastRow.empty(), newRVD)
   }
 }
 

--- a/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
+++ b/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
@@ -365,7 +365,7 @@ case class LocalLDPrune(
       }
     })
 
-    TableValue(tableType, BroadcastRow.empty(mv.sparkContext), sitesOnly)
+    TableValue(tableType, BroadcastRow.empty(), sitesOnly)
   }
 }
 

--- a/hail/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -126,6 +126,6 @@ case class LogisticRegression(
       }
     }.persist(StorageLevel.MEMORY_AND_DISK)
 
-    TableValue(tableType, BroadcastRow.empty(sc), newRVD)
+    TableValue(tableType, BroadcastRow.empty(), newRVD)
   }
 }

--- a/hail/src/main/scala/is/hail/methods/NPartitions.scala
+++ b/hail/src/main/scala/is/hail/methods/NPartitions.scala
@@ -1,0 +1,18 @@
+package is.hail.methods
+
+import is.hail.expr.ir.{MatrixValue, TableValue}
+import is.hail.expr.ir.functions.{MatrixToValueFunction, TableToValueFunction}
+import is.hail.expr.types.{MatrixType, TableType}
+import is.hail.expr.types.virtual.{TInt32, Type}
+
+case class NPartitionsTable() extends TableToValueFunction {
+  override def typ(childType: TableType): Type = TInt32()
+
+  override def execute(tv: TableValue): Any = tv.rvd.getNumPartitions
+}
+
+case class NPartitionsMatrixTable() extends MatrixToValueFunction {
+  override def typ(childType: MatrixType): Type = TInt32()
+
+  override def execute(mv: MatrixValue): Any = mv.rvd.getNumPartitions
+}

--- a/hail/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/hail/src/main/scala/is/hail/methods/PCRelate.scala
@@ -1,14 +1,15 @@
 package is.hail.methods
 
 import breeze.linalg.{DenseMatrix => BDM}
-import is.hail.annotations.Annotation
+import is.hail.annotations.{Annotation, BroadcastRow}
 import is.hail.linalg.BlockMatrix
 import is.hail.linalg.BlockMatrix.ops._
 import is.hail.table.Table
 import is.hail.utils._
 import is.hail.variant.{Call, HardCallView, MatrixTable}
 import is.hail.HailContext
-import is.hail.expr.ir.{IR, Interpret, TableIR}
+import is.hail.expr.ir.{IR, Interpret, TableIR, TableKeyBy, TableLiteral, TableValue}
+import is.hail.expr.types.TableType
 import is.hail.expr.types.virtual._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.mllib.linalg.Vectors
@@ -60,7 +61,10 @@ object PCRelate {
     
     val result = new PCRelate(maf, blockSize, statistics, defaultStorageLevel)(HailContext.get, blockedG, pcs)
 
-    Table(HailContext.get, toRowRdd(result, blockSize, minKinship, statistics), sig, keys).tir
+    TableKeyBy(TableLiteral(TableValue(TableType(sig, FastIndexedSeq(), TStruct.empty()),
+      BroadcastRow.empty(HailContext.get.sc),
+      toRowRdd(result, blockSize, minKinship, statistics))),
+      keys)
   }
 
   private[methods] def apply(hc: HailContext,

--- a/hail/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/hail/src/main/scala/is/hail/methods/PCRelate.scala
@@ -11,6 +11,8 @@ import is.hail.HailContext
 import is.hail.expr.ir.{IR, Interpret, TableIR, TableKeyBy, TableLiteral, TableValue}
 import is.hail.expr.types.TableType
 import is.hail.expr.types.virtual._
+import is.hail.rvd.RVDContext
+import is.hail.sparkextras.ContextRDD
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix}
@@ -61,9 +63,7 @@ object PCRelate {
     
     val result = new PCRelate(maf, blockSize, statistics, defaultStorageLevel)(HailContext.get, blockedG, pcs)
 
-    TableKeyBy(TableLiteral(TableValue(TableType(sig, FastIndexedSeq(), TStruct.empty()),
-      BroadcastRow.empty(HailContext.get.sc),
-      toRowRdd(result, blockSize, minKinship, statistics))),
+    TableKeyBy(TableLiteral(TableValue(sig, FastIndexedSeq(), toRowRdd(result, blockSize, minKinship, statistics))),
       keys)
   }
 

--- a/hail/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/hail/src/main/scala/is/hail/methods/PCRelate.scala
@@ -63,8 +63,7 @@ object PCRelate {
     
     val result = new PCRelate(maf, blockSize, statistics, defaultStorageLevel)(HailContext.get, blockedG, pcs)
 
-    TableKeyBy(TableLiteral(TableValue(sig, FastIndexedSeq(), toRowRdd(result, blockSize, minKinship, statistics))),
-      keys)
+    TableLiteral(TableValue(sig, keys, toRowRdd(result, blockSize, minKinship, statistics)))
   }
 
   private[methods] def apply(hc: HailContext,

--- a/hail/src/main/scala/is/hail/methods/PoissonRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/PoissonRegression.scala
@@ -103,6 +103,6 @@ case class PoissonRegression(
       }
     }.persist(StorageLevel.MEMORY_AND_DISK)
 
-    TableValue(tableType, BroadcastRow.empty(sc), newRVD)
+    TableValue(tableType, BroadcastRow.empty(), newRVD)
   }
 }

--- a/hail/src/main/scala/is/hail/methods/Skat.scala
+++ b/hail/src/main/scala/is/hail/methods/Skat.scala
@@ -278,7 +278,7 @@ case class Skat(
 
     val (tableType, _) = typeInfo(mv.typ, mv.rvd.typ)
 
-    TableValue(tableType, BroadcastRow.empty(sc), skatRdd)
+    TableValue(tableType, BroadcastRow.empty(), skatRdd)
   }
 
   def computeKeyGsWeightRdd(mv: MatrixValue,

--- a/hail/src/main/scala/is/hail/methods/VEP.scala
+++ b/hail/src/main/scala/is/hail/methods/VEP.scala
@@ -100,7 +100,7 @@ object VEP {
   }
 }
 
-class VEP(config: String, csq: Boolean, blockSize: Int) extends TableToTableFunction {
+case class VEP(config: String, csq: Boolean, blockSize: Int) extends TableToTableFunction {
   private val conf = VEP.readConfiguration(HailContext.get.hadoopConf, config)
   private val vepSignature = conf.vep_json_schema
 

--- a/hail/src/main/scala/is/hail/methods/VEP.scala
+++ b/hail/src/main/scala/is/hail/methods/VEP.scala
@@ -108,7 +108,7 @@ case class VEP(config: String, csq: Boolean, blockSize: Int) extends TableToTabl
 
   override def typeInfo(childType: TableType, childRVDType: RVDType): (TableType, RVDType) = {
     val vepType = if (csq) TArray(TString()) else vepSignature
-    val t = TableType(childType.rowType ++ TStruct("vep" -> vepType), FastIndexedSeq("locus", "alleles"), childType.globalType)
+    val t = TableType(childType.rowType ++ TStruct("vep" -> vepType), childType.key, childType.globalType)
     (t, t.canonicalRVDType)
   }
 

--- a/hail/src/main/scala/is/hail/stats/LinearMixedModel.scala
+++ b/hail/src/main/scala/is/hail/stats/LinearMixedModel.scala
@@ -3,7 +3,7 @@ package is.hail.stats
 import breeze.linalg.{DenseMatrix => BDM, DenseVector => BDV}
 import is.hail.HailContext
 import is.hail.annotations.{BroadcastRow, Region, RegionValue, RegionValueBuilder}
-import is.hail.expr.ir.{TableLiteral, TableValue}
+import is.hail.expr.ir.{TableIR, TableLiteral, TableValue}
 import is.hail.expr.types.virtual.{TFloat64, TInt64, TStruct}
 import is.hail.expr.types.TableType
 import is.hail.linalg.RowMatrix
@@ -19,11 +19,11 @@ case class LMMData(gamma: Double, residualSq: Double, py: BDV[Double], px: BDM[D
   ydy: Double, xdy: BDV[Double], xdx: BDM[Double], yOpt: Option[BDV[Double]], xOpt: Option[BDM[Double]])
 
 object LinearMixedModel {
-  def apply(hc: HailContext, gamma: Double, residualSq: Double, py: Array[Double], px: BDM[Double], d: Array[Double],
+  def pyApply(gamma: Double, residualSq: Double, py: Array[Double], px: BDM[Double], d: Array[Double],
     ydy: Double, xdy: Array[Double], xdx: BDM[Double],
     yOpt: Option[Array[Double]], xOpt: Option[BDM[Double]]): LinearMixedModel = {
 
-    new LinearMixedModel(hc,
+    new LinearMixedModel(HailContext.get,
       LMMData(gamma, residualSq, BDV(py), px, BDV(d), ydy, BDV(xdy), xdx, yOpt.map(BDV(_)), xOpt))
   }
   
@@ -36,13 +36,13 @@ object LinearMixedModel {
 
   private val tableType = TableType(rowType, FastIndexedSeq("idx"), TStruct())
 
-  def toTable(hc: HailContext, rvd: RVD): Table = {
-    new Table(hc, TableLiteral(TableValue(tableType, BroadcastRow(Row(), tableType.globalType, hc.sc), rvd)))
+  def toTableIR(rvd: RVD): TableIR = {
+    TableLiteral(TableValue(tableType, BroadcastRow(Row(), tableType.globalType, HailContext.get.sc), rvd))
   }
 }
 
 class LinearMixedModel(hc: HailContext, lmmData: LMMData) {
-  def fit(pa_t: RowMatrix, a_t: Option[RowMatrix]): Table =
+  def fit(pa_t: RowMatrix, a_t: Option[RowMatrix]): TableIR =
     if (a_t.isDefined) {
       assert(lmmData.yOpt.isDefined && lmmData.xOpt.isDefined)
       fitLowRank(pa_t, a_t.get)
@@ -51,7 +51,7 @@ class LinearMixedModel(hc: HailContext, lmmData: LMMData) {
       fitFullRank(pa_t)
     }
  
-  def fitLowRank(pa_t: RowMatrix, a_t: RowMatrix): Table = {
+  def fitLowRank(pa_t: RowMatrix, a_t: RowMatrix): TableIR = {
     if (pa_t.nRows != a_t.nRows)
       fatal(s"pa_t and a_t must have the same number of rows, but found ${pa_t.nRows} and ${a_t.nRows}")
     else if (!(pa_t.partitionCounts() sameElements a_t.partitionCounts()))
@@ -122,10 +122,10 @@ class LinearMixedModel(hc: HailContext, lmmData: LMMData) {
       pa_t.partitioner(),
       ContextRDD.weaken[RVDContext](rdd)).persist(StorageLevel.MEMORY_AND_DISK)
 
-    LinearMixedModel.toTable(hc, rvd)
+    LinearMixedModel.toTableIR(rvd)
   }
   
-  def fitFullRank(pa_t: RowMatrix): Table = {
+  def fitFullRank(pa_t: RowMatrix): TableIR = {
     val sc = hc.sc
     val lmmDataBc = sc.broadcast(lmmData)
     val rowType = LinearMixedModel.rowType.physicalType
@@ -189,6 +189,6 @@ class LinearMixedModel(hc: HailContext, lmmData: LMMData) {
       pa_t.partitioner(),
       ContextRDD.weaken[RVDContext](rdd)).persist(StorageLevel.MEMORY_AND_DISK)
 
-    LinearMixedModel.toTable(hc, rvd)
+    LinearMixedModel.toTableIR(rvd)
   }
 }

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -52,7 +52,10 @@ object Table {
   def pyFromDF(df: DataFrame, jKey: java.util.ArrayList[String]): TableIR = {
     val key = jKey.asScala.toArray.toFastIndexedSeq
     val signature = SparkAnnotationImpex.importType(df.schema).asInstanceOf[TStruct]
-    Table(HailContext.get, df.rdd, signature, key).tir
+    TableKeyBy(TableLiteral(TableValue(TableType(signature, FastIndexedSeq(), TStruct.empty()),
+      BroadcastRow.empty(HailContext.get.sc),
+      df.rdd)),
+      key)
   }
 
   def read(hc: HailContext, path: String): Table =

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -52,9 +52,7 @@ object Table {
   def pyFromDF(df: DataFrame, jKey: java.util.ArrayList[String]): TableIR = {
     val key = jKey.asScala.toArray.toFastIndexedSeq
     val signature = SparkAnnotationImpex.importType(df.schema).asInstanceOf[TStruct]
-    TableKeyBy(TableLiteral(TableValue(TableType(signature, FastIndexedSeq(), TStruct.empty()),
-      BroadcastRow.empty(HailContext.get.sc),
-      df.rdd)),
+    TableKeyBy(TableLiteral(TableValue(signature, FastIndexedSeq(), df.rdd)),
       key)
   }
 

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -49,13 +49,10 @@ object Table {
   def range(hc: HailContext, n: Int, nPartitions: Option[Int] = None): Table =
     new Table(hc, TableRange(n, nPartitions.getOrElse(hc.sc.defaultParallelism)))
 
-  def fromDF(hc: HailContext, df: DataFrame, key: java.util.ArrayList[String]): Table = {
-    fromDF(hc, df, key.asScala.toArray.toFastIndexedSeq)
-  }
-
-  def fromDF(hc: HailContext, df: DataFrame, key: IndexedSeq[String] = FastIndexedSeq()): Table = {
+  def pyFromDF(df: DataFrame, jKey: java.util.ArrayList[String]): TableIR = {
+    val key = jKey.asScala.toArray.toFastIndexedSeq
     val signature = SparkAnnotationImpex.importType(df.schema).asInstanceOf[TStruct]
-    Table(hc, df.rdd, signature, key)
+    Table(HailContext.get, df.rdd, signature, key).tir
   }
 
   def read(hc: HailContext, path: String): Table =

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -52,8 +52,7 @@ object Table {
   def pyFromDF(df: DataFrame, jKey: java.util.ArrayList[String]): TableIR = {
     val key = jKey.asScala.toArray.toFastIndexedSeq
     val signature = SparkAnnotationImpex.importType(df.schema).asInstanceOf[TStruct]
-    TableKeyBy(TableLiteral(TableValue(signature, FastIndexedSeq(), df.rdd)),
-      key)
+    TableLiteral(TableValue(signature, key, df.rdd))
   }
 
   def read(hc: HailContext, path: String): Table =

--- a/hail/src/main/scala/is/hail/utils/Graph.scala
+++ b/hail/src/main/scala/is/hail/utils/Graph.scala
@@ -1,10 +1,12 @@
 package is.hail.utils
 
 import is.hail.annotations.{Region, RegionValueBuilder, SafeRow}
-import is.hail.expr.ir.{Compile, MakeTuple, IRParserEnvironment, IRParser}
+import is.hail.expr.JSONAnnotationImpex
+import is.hail.expr.ir.{Compile, IRParser, IRParserEnvironment, MakeTuple}
 import is.hail.expr.types.physical.PBaseStruct
-import is.hail.expr.types.virtual.{TInt64, TTuple, Type}
+import is.hail.expr.types.virtual._
 import org.apache.spark.sql.Row
+import org.json4s.jackson.JsonMethods
 
 import scala.collection.mutable
 import scala.reflect.ClassTag
@@ -33,8 +35,18 @@ object Graph {
     m
   }
 
-  def maximalIndependentSet(edges: Array[Row], nodeType: String, tieBreaker: Option[String]): Set[Any] =
-    maximalIndependentSet(edges, IRParser.parseType(nodeType), tieBreaker)
+  def pyMaximalIndependentSetJSON(edgesJSONStr: String, nodeTypeStr: String, tieBreaker: Option[String]): String = {
+    val nodeType = IRParser.parseType(nodeTypeStr)
+    val edgesType = TStruct("__i" -> nodeType, "__j" -> nodeType)
+
+    val edges = JSONAnnotationImpex.importAnnotation(JsonMethods.parse(edgesJSONStr), edgesType)
+      .asInstanceOf[IndexedSeq[Row]]
+      .toArray
+
+    val resultType = TSet(nodeType)
+    val result = maximalIndependentSet(edges, nodeType, tieBreaker)
+    JsonMethods.compact(JSONAnnotationImpex.exportAnnotation(result, resultType))
+  }
 
   def maximalIndependentSet(edges: Array[Row], nodeType: Type, tieBreaker: Option[String]): Set[Any] = {
     val edges2 = edges.map { r =>

--- a/hail/src/main/scala/is/hail/utils/Graph.scala
+++ b/hail/src/main/scala/is/hail/utils/Graph.scala
@@ -39,7 +39,7 @@ object Graph {
     val nodeType = IRParser.parseType(nodeTypeStr)
     val edgesType = TStruct("__i" -> nodeType, "__j" -> nodeType)
 
-    val edges = JSONAnnotationImpex.importAnnotation(JsonMethods.parse(edgesJSONStr), edgesType)
+    val edges = JSONAnnotationImpex.importAnnotation(JsonMethods.parse(edgesJSONStr), TArray(edgesType))
       .asInstanceOf[IndexedSeq[Row]]
       .toArray
 

--- a/hail/src/main/scala/is/hail/utils/Graph.scala
+++ b/hail/src/main/scala/is/hail/utils/Graph.scala
@@ -35,8 +35,7 @@ object Graph {
 
   def pyMaximalIndependentSet(edgesIR: IR, nodeTypeStr: String, tieBreaker: Option[String]): IR = {
     val nodeType = IRParser.parseType(nodeTypeStr)
-    val edgesType = TStruct("__i" -> nodeType, "__j" -> nodeType)
-
+    
     val edges = Interpret[IndexedSeq[Row]](edgesIR).toArray
 
     val resultType = TSet(nodeType)

--- a/hail/src/main/scala/is/hail/utils/richUtils/Implicits.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/Implicits.scala
@@ -124,5 +124,7 @@ trait Implicits {
 
   implicit def toRichContextRDD[T: ClassTag](x: ContextRDD[RVDContext, T]): RichContextRDD[T] = new RichContextRDD(x)
 
+  implicit def toRichContextRDDRow(x: ContextRDD[RVDContext, Row]): RichContextRDDRow = new RichContextRDDRow(x)
+
   implicit def toRichCodeInputBuffer(in: Code[InputBuffer]): RichCodeInputBuffer = new RichCodeInputBuffer(in)
 }

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDDRow.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDDRow.scala
@@ -1,0 +1,14 @@
+package is.hail.utils.richUtils
+
+import is.hail.annotations.RegionValue
+import is.hail.expr.types.virtual.TStruct
+import is.hail.rvd.RVDContext
+import is.hail.utils._
+import is.hail.sparkextras.ContextRDD
+import org.apache.spark.sql.Row
+
+class RichContextRDDRow(crdd: ContextRDD[RVDContext, Row]) {
+  def toRegionValues(rowType: TStruct): ContextRDD[RVDContext, RegionValue] = {
+    crdd.cmapPartitions((ctx, it) => it.toRegionValueIterator(ctx.region, rowType.physicalType))
+  }
+}

--- a/hail/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
+++ b/hail/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
@@ -744,7 +744,7 @@ class BlockMatrixSuite extends SparkSuite {
     val expectedSignature = TStruct("i" -> TInt64Optional, "j" -> TInt64Optional, "entry" -> TFloat64Optional)
 
     for {blockSize <- Seq(1, 4, 10)} {
-      val entriesTable = toBM(lm, blockSize).entriesTable(hc)
+      val entriesTable = new Table(hc, toBM(lm, blockSize).entriesTable())
       val entries = entriesTable.collect().map(row => (row.get(0), row.get(1), row.get(2))).toSet
       // block size affects order of rows in table, but sets will be the same
       assert(entries === expectedEntries)
@@ -758,9 +758,10 @@ class BlockMatrixSuite extends SparkSuite {
     val lm = new BDM[Double](5, 10, data)
     val bm = toBM(lm, blockSize = 2)
 
-    val expected = bm
-      .filterBlocks(Array(0, 1, 6))
-      .entriesTable(hc)
+    val expected = new Table(hc,
+      bm
+        .filterBlocks(Array(0, 1, 6))
+        .entriesTable())
       .collect()
       .sortBy(r => (r.get(0).asInstanceOf[Long], r.get(1).asInstanceOf[Long]))
       .map(r => r.get(2).asInstanceOf[Double])

--- a/hail/src/test/scala/is/hail/methods/IBDSuite.scala
+++ b/hail/src/test/scala/is/hail/methods/IBDSuite.scala
@@ -1,13 +1,14 @@
 package is.hail.methods
 
-import is.hail.{SparkSuite, TestUtils}
+import is.hail.{HailContext, SparkSuite, TestUtils}
 import is.hail.annotations.Annotation
 import is.hail.check.Prop._
 import is.hail.check.{Gen, Properties}
-import is.hail.expr.ir.TextTableReader
+import is.hail.expr.ir.{Interpret, TextTableReader}
 import is.hail.expr.types._
 import is.hail.expr.types.virtual.{TFloat64, TInt32, TString}
 import is.hail.io.vcf.ExportVCF
+import is.hail.table.Table
 import is.hail.utils.AbsoluteFuzzyComparable._
 import is.hail.utils._
 import is.hail.variant._
@@ -109,7 +110,7 @@ class IBDSuite extends SparkSuite {
     }
     val vds = TestUtils.importVCF(hc, "src/test/resources/sample.vcf")
 
-    val us = IBD.toRDD(IBD(vds)).collect().toMap
+    val us = IBD.toRDD(Interpret(IBD.pyApply(vds))).collect().toMap
 
     val plink = runPlinkIBD(vds)
     val sampleIds = vds.stringSampleIds
@@ -120,6 +121,6 @@ class IBDSuite extends SparkSuite {
 
   @Test def ibdSchemaCorrect() {
     val vds = TestUtils.importVCF(hc, "src/test/resources/sample.vcf")
-    val us = IBD(vds).typeCheck()
+    val us = new Table(HailContext.get, IBD.pyApply(vds)).typeCheck()
   }
 }


### PR DESCRIPTION
Another PR towards Hail as a service.

 - pass Java IR through the boundary where appropriate
 - made VEP a TableToTableApply
 - added NPartitions{Matrix}Table functions
 - prefix Scala entrypoints from Python with "py"

Next PR will remove Scala Table.
