### PR TITLE
add apiserver to tests

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install-hail-locally build push run run-hail rm deploy src-test-resources
+.PHONY: install-hail-locally build push run run-hail rm deploy
 
 PROJECT = $(shell gcloud config get-value project)
 
@@ -43,20 +43,6 @@ run-hail:
 
 rm:
 	docker rm -f spark-master spark-w-1
-
-src-test-resources:
-	rm -rf src
-	mkdir -p src/test
-	cp -a ../hail/src/test/resources src/test/
-
-# SPARK_PATH must be set
-run-local-apiserver:
-	(cd ../hail && ./gradlew shadowJar)
-	(cd ../hail && \
-  PYTHONPATH=$$(ls $$SPARK_HOME/python/lib/py4j-*-src.zip):$$SPARK_HOME/python:./python \
-  JAR=./build/libs/hail-all-spark.jar \
-  PYSPARK_SUBMIT_ARGS="--conf spark.driver.extraClassPath=./build/libs/hail-all-spark.jar --conf spark.executor.extraClassPath=./build/libs/hail-all-spark.jar pyspark-shell" \
-  python ../apiserver/apiserver/apiserver.py)
 
 # doesn't push
 run-hail-jupyter-pod: HAIL_JUPYTER_IMAGE=$(shell kubectl get deployment apiserver -o jsonpath='{.metadata.annotations.hail-jupyter-image}')

--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install-hail-locally build push run run-hail rm deploy
+.PHONY: install-hail-locally build push run run-hail rm deploy src-test-resources
 
 PROJECT = $(shell gcloud config get-value project)
 
@@ -43,6 +43,20 @@ run-hail:
 
 rm:
 	docker rm -f spark-master spark-w-1
+
+src-test-resources:
+	rm -rf src
+	mkdir -p src/test
+	cp -a ../hail/src/test/resources src/test/
+
+# SPARK_PATH must be set
+run-local-apiserver:
+	(cd ../hail && ./gradlew shadowJar)
+	(cd ../hail && \
+  PYTHONPATH=$$(ls $$SPARK_HOME/python/lib/py4j-*-src.zip):$$SPARK_HOME/python:./python \
+  JAR=./build/libs/hail-all-spark.jar \
+  PYSPARK_SUBMIT_ARGS="--conf spark.driver.extraClassPath=./build/libs/hail-all-spark.jar --conf spark.executor.extraClassPath=./build/libs/hail-all-spark.jar pyspark-shell" \
+  python ../apiserver/apiserver/apiserver.py)
 
 # doesn't push
 run-hail-jupyter-pod: HAIL_JUPYTER_IMAGE=$(shell kubectl get deployment apiserver -o jsonpath='{.metadata.annotations.hail-jupyter-image}')

--- a/apiserver/apiserver/apiserver.py
+++ b/apiserver/apiserver/apiserver.py
@@ -13,6 +13,10 @@ hl.init(master=master, min_block_size=0)
 
 app = flask.Flask('hail-apiserver')
 
+@app.route('/healthcheck')
+def healthcheck():
+    return '', 200
+
 @app.route('/execute', methods=['POST'])
 def execute():
     code = flask.request.json

--- a/hail-ci-build-image
+++ b/hail-ci-build-image
@@ -1,1 +1,1 @@
-gcr.io/hail-vdc/hail-pr-builder:5c9ace7888abbd2356688160e1c43f550a5232f95b22aa38b69ab0d255011f32
+gcr.io/hail-vdc/hail-pr-builder:bec585e2a68611174c329dac052ec27ee9fca17fbe9e37618f7e114f58c277a9

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -1,0 +1,7 @@
+.PHONY: shadowJar test-apiserver
+
+shadowJar:
+	./gradlew shadowJar
+
+test-apiserver: shadowJar
+	./test-apiserver.sh

--- a/hail/hail-ci-build.sh
+++ b/hail/hail-ci-build.sh
@@ -21,6 +21,7 @@ SCALA_TEST_LOG="build/scala-test.log"
 CXX_CODEGEN_TEST_LOG="build/codegen-test.log"
 PYTHON_TEST_LOG="build/python-test.log"
 APISERVER_TEST_LOG="build/apiserver-test.log"
+APISERVER_LOG="build/apiserver.log"
 DOCTEST_LOG="build/doctest.log"
 DOCS_LOG="build/docs.log"
 GCP_LOG="build/gcp.log"
@@ -70,6 +71,7 @@ on_exit() {
     cp ${CXX_CODEGEN_TEST_LOG} ${ARTIFACTS}
     cp ${PYTHON_TEST_LOG} ${ARTIFACTS}
     cp ${APISERVER_TEST_LOG} ${ARTIFACTS}
+    cp ${APISERVER_LOG} ${ARTIFACTS}
     cp ${DOCS_LOG} ${ARTIFACTS}
     cp ${DOCTEST_LOG} ${ARTIFACTS}
     cp ${GCP_LOG} ${ARTIFACTS}
@@ -155,6 +157,10 @@ on_exit() {
 <tr>
 <td>${APISERVER_TEST_STATUS}</td>
 <td><a href='apiserver-test.log'>apiserver Test log</a></td>
+</tr>
+<tr>
+<td>${APISERVER_TEST_STATUS}</td>
+<td><a href='apiserver.log'>apiserver log</a></td>
 </tr>
 <tr>
 <td>${DOCTEST_STATUS}</td>

--- a/hail/hail-ci-build.sh
+++ b/hail/hail-ci-build.sh
@@ -85,7 +85,8 @@ on_exit() {
     SCALA_TEST_STATUS=$(get_status "${SCALA_TEST_SUCCESS}" "${CXX_TEST_STATUS}")
     CXX_CODEGEN_TEST_STATUS=$(get_status "${CXX_CODEGEN_TEST_SUCCESS}" "${SCALA_TEST_STATUS}")
     PYTHON_TEST_STATUS=$(get_status "${PYTHON_TEST_SUCCESS}" "${CXX_CODEGEN_TEST_STATUS}")
-    DOCTEST_STATUS=$(get_status "${DOCTEST_SUCCESS}" "${PYTHON_TEST_STATUS}")
+    APISERVER_TEST_STATUS=$(get_status "${APISERVER_TEST_SUCCESS}" "${PYTHON_TEST_STATUS}")
+    DOCTEST_STATUS=$(get_status "${DOCTEST_SUCCESS}" "${APISERVER_TEST_STATUS}")
     DOCS_STATUS=$(get_status "${DOCS_SUCCESS}" "${DOCTEST_STATUS}")
     GCP_STATUS=$(if [ -e ${GCP_STOPPED} ]; then echo "${STOPPED}"; else get_status "${GCP_SUCCESS}"; fi)
     PIP_PACKAGE_STATUS=$(if [ -e ${PIP_PACKAGE_STOPPED} ]; then echo "${STOPPED}"; else get_status "${PIP_PACKAGE_SUCCESS}"; fi)
@@ -150,6 +151,10 @@ on_exit() {
 <tr>
 <td>${PYTHON_TEST_STATUS}</td>
 <td><a href='hail-python-test.html'>PyTest report</a></td>
+</tr>
+<tr>
+<td>${APISERVER_TEST_STATUS}</td>
+<td><a href='apiserver-test.log'>PyTest log</a></td>
 </tr>
 <tr>
 <td>${DOCTEST_STATUS}</td>

--- a/hail/hail-ci-build.sh
+++ b/hail/hail-ci-build.sh
@@ -154,7 +154,7 @@ on_exit() {
 </tr>
 <tr>
 <td>${APISERVER_TEST_STATUS}</td>
-<td><a href='apiserver-test.log'>PyTest log</a></td>
+<td><a href='apiserver-test.log'>apiserver Test log</a></td>
 </tr>
 <tr>
 <td>${DOCTEST_STATUS}</td>

--- a/hail/hail-ci-build.sh
+++ b/hail/hail-ci-build.sh
@@ -20,6 +20,7 @@ CXX_TEST_LOG="build/cxx-test.log"
 SCALA_TEST_LOG="build/scala-test.log"
 CXX_CODEGEN_TEST_LOG="build/codegen-test.log"
 PYTHON_TEST_LOG="build/python-test.log"
+APISERVER_TEST_LOG="build/apiserver-test.log"
 DOCTEST_LOG="build/doctest.log"
 DOCS_LOG="build/docs.log"
 GCP_LOG="build/gcp.log"
@@ -30,6 +31,7 @@ CXX_TEST_SUCCESS="build/_CXX_TEST_SUCCESS"
 SCALA_TEST_SUCCESS="build/_SCALA_TEST_SUCCESS"
 CXX_CODEGEN_TEST_SUCCESS="build/_CXX_CODEGEN_TEST_SUCCESS"
 PYTHON_TEST_SUCCESS="build/_PYTHON_TEST_SUCCESS"
+APISERVER_TEST_SUCCESS="build/_APISERVER_TEST_SUCCESS"
 DOCTEST_SUCCESS="build/_DOCTEST_SUCCESS"
 DOCS_SUCCESS="build/_DOCS_SUCCESS"
 GCP_SUCCESS="build/_GCP_SUCCESS"
@@ -67,6 +69,7 @@ on_exit() {
     cp ${SCALA_TEST_LOG} ${ARTIFACTS}
     cp ${CXX_CODEGEN_TEST_LOG} ${ARTIFACTS}
     cp ${PYTHON_TEST_LOG} ${ARTIFACTS}
+    cp ${APISERVER_TEST_LOG} ${ARTIFACTS}
     cp ${DOCS_LOG} ${ARTIFACTS}
     cp ${DOCTEST_LOG} ${ARTIFACTS}
     cp ${GCP_LOG} ${ARTIFACTS}
@@ -216,6 +219,8 @@ test_project() {
     touch ${CXX_CODEGEN_TEST_SUCCESS}
     ./gradlew testPython > ${PYTHON_TEST_LOG} 2>&1
     touch ${PYTHON_TEST_SUCCESS}
+    make test-apiserver > ${APISERVER_TEST_LOG} 2>&1
+    touch ${APISERVER_TEST_SUCCESS}
     ./gradlew doctest > ${DOCTEST_LOG} 2>&1
     touch ${DOCTEST_SUCCESS}
     ./gradlew makeDocs > ${DOCS_LOG} 2>&1

--- a/hail/python/hail/dev-environment.yml
+++ b/hail/python/hail/dev-environment.yml
@@ -14,6 +14,7 @@ dependencies:
 - pip=10.0.1
 - pytest=3.8.0
 - pytest-html=1.19
+- flask=0.12.2
 - pip:
     - parsimonious==0.8.0
     - ipykernel==4.9.0

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -516,7 +516,7 @@ class MatrixToTableApply(TableIR):
         elif name == 'PCA':
             self._type = hl.ttable(
                 hl.tstruct(eigenvalues=hl.tarray(hl.tfloat64),
-                           scores=child_typ.col_key_type._insert_field('scores', hl.tarray(hl.tfloat64))),
+                           scores=hl.tarray(child_typ.col_key_type._insert_field('scores', hl.tarray(hl.tfloat64)))),
                 child_typ.row_key_type._insert_field('loadings', dtype('array<float64>')),
                 child_typ.row_key)
         else:

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -217,7 +217,7 @@ class BlockMatrix(object):
         if self._cached_jbm is not None:
             return self._cached_jbm
         else:
-            self._cached_jbm = Env.hc()._backend._to_java_ir(self._bmir).execute(Env.hc()._jhc)
+            self._cached_jbm = Env.spark_backend('BlockMatrix._jbm')._to_java_ir(self._bmir).execute(Env.hc()._jhc)
             return self._cached_jbm
 
     @classmethod

--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -8,7 +8,7 @@ tearDownModule = stopTestHailContext
 
 
 class Tests(unittest.TestCase):
-
+    @skip_unless_spark_backend()
     def test_ld_score(self):
 
         ht = hl.import_table(doctest_resource('ldsc.annot'),
@@ -91,6 +91,7 @@ class Tests(unittest.TestCase):
         self.assertAlmostEqual(mean_annotated.binary, 0.965, places=3)
         self.assertAlmostEqual(mean_annotated.continuous, 176.528, places=3)
 
+    @skip_unless_spark_backend()
     def test_plot_roc_curve(self):
         x = hl.utils.range_table(100).annotate(score1=hl.rand_norm(), score2=hl.rand_norm())
         x = x.annotate(tp=hl.cond(x.score1 > 0, hl.rand_bool(0.7), False), score3=x.score1 + hl.rand_norm())

--- a/hail/python/test/hail/helpers.py
+++ b/hail/python/test/hail/helpers.py
@@ -1,5 +1,7 @@
 import os
 from timeit import default_timer as timer
+import unittest
+from decorator import decorator
 
 import hail as hl
 
@@ -134,3 +136,13 @@ def create_all_values_matrix_table():
 
 def create_all_values_datasets():
     return (create_all_values_table(), create_all_values_matrix_table())
+
+def skip_unless_spark_backend():
+    @decorator
+    def wrapper(func, *args, **kwargs):
+        if isinstance(hl.utils.java.Env.backend(), hl.backend.SparkBackend):
+            return func(*args, **kwargs)
+        else:
+            raise unittest.SkipTest('requires Spark')
+
+    return wrapper

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -25,6 +25,7 @@ class Tests(unittest.TestCase):
     def _assert_close(self, a, b):
         self.assertTrue(np.allclose(self._np_matrix(a), self._np_matrix(b)))
 
+    @skip_unless_spark_backend()
     def test_from_entry_expr(self):
         mt = get_dataset()
         mt = mt.annotate_entries(x=hl.or_else(mt.GT.n_alt_alleles(), 0)).cache()
@@ -41,6 +42,7 @@ class Tests(unittest.TestCase):
         a4 = BlockMatrix.read(path).to_numpy()
         self._assert_eq(a1, a4)
 
+    @skip_unless_spark_backend()
     def test_from_entry_expr_options(self):
         def build_mt(a):
             data = [{'v': 0, 's': 0, 'x': a[0]},
@@ -75,6 +77,7 @@ class Tests(unittest.TestCase):
         with self.assertRaises(Exception):
             BlockMatrix.from_entry_expr(mt.x)
 
+    @skip_unless_spark_backend()
     def test_write_from_entry_expr_overwrite(self):
         mt = hl.balding_nichols_model(1, 1, 1)
         mt = mt.select_entries(x=mt.GT.n_alt_alleles())
@@ -95,6 +98,7 @@ class Tests(unittest.TestCase):
         BlockMatrix.write_from_entry_expr(mt.x + 2, path2, overwrite=True)
         self._assert_eq(BlockMatrix.read(path2), bm + 2)
 
+    @skip_unless_spark_backend()
     def test_random_uniform(self):
         uniform = BlockMatrix.random(10, 10, gaussian=False)
 
@@ -103,6 +107,7 @@ class Tests(unittest.TestCase):
             for entry in row:
                 assert entry > 0
 
+    @skip_unless_spark_backend()
     def test_to_from_numpy(self):
         n_rows = 10
         n_cols = 11
@@ -148,6 +153,7 @@ class Tests(unittest.TestCase):
                 self._assert_eq(at4, at)
                 self._assert_eq(at5, at)
 
+    @skip_unless_spark_backend()
     def test_elementwise_ops(self):
         nx = np.matrix([[2.0]])
         nc = np.matrix([[1.0], [2.0]])
@@ -334,6 +340,7 @@ class Tests(unittest.TestCase):
         self._assert_close(m / nr, m / r)
         self._assert_close(m / nm, m / m)
 
+    @skip_unless_spark_backend()
     def test_special_elementwise_ops(self):
         nm = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         m = BlockMatrix.from_numpy(nm)
@@ -346,6 +353,7 @@ class Tests(unittest.TestCase):
 
         self._assert_close((m - 4).abs(), np.abs(nm - 4))
 
+    @skip_unless_spark_backend()
     def test_matrix_ops(self):
         nm = np.matrix([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         m = BlockMatrix.from_numpy(nm, block_size=2)
@@ -374,6 +382,7 @@ class Tests(unittest.TestCase):
         self._assert_eq(m.T.diagonal(), np.array([1.0, 5.0]))
         self._assert_eq((m @ m.T).diagonal(), np.array([14.0, 77.0]))
 
+    @skip_unless_spark_backend()
     def test_fill(self):
         nd = np.ones((3, 5))
         bm = BlockMatrix.fill(3, 5, 1.0)
@@ -384,6 +393,7 @@ class Tests(unittest.TestCase):
         self._assert_eq(bm, nd)
         self._assert_eq(bm2, nd)
 
+    @skip_unless_spark_backend()
     def test_sum(self):
         def sums_agree(bm, nd):
             self.assertAlmostEqual(bm.sum(), np.sum(nd))
@@ -413,6 +423,7 @@ class Tests(unittest.TestCase):
         sums_agree(bm4, nd2)
         sums_agree(bm5, nd5)
 
+    @skip_unless_spark_backend()
     def test_slicing(self):
         nd = np.array(np.arange(0, 80, dtype=float)).reshape(8, 10)
         bm = BlockMatrix.from_numpy(nd, block_size=3)
@@ -476,6 +487,7 @@ class Tests(unittest.TestCase):
         self._assert_eq(bm2[1, :], nd2[1:2, :])
         self._assert_eq(bm2[0:5, 0:5], nd2[0:5, 0:5])
 
+    @skip_unless_spark_backend()
     def test_sparsify_row_intervals(self):
         nd = np.array([[ 1.0,  2.0,  3.0,  4.0],
                        [ 5.0,  6.0,  7.0,  8.0],
@@ -521,6 +533,7 @@ class Tests(unittest.TestCase):
                     expected[i, j] = 0.0
             self._assert_eq(actual, expected)
 
+    @skip_unless_spark_backend()
     def test_sparsify_band(self):
         nd = np.array([[ 1.0,  2.0,  3.0,  4.0],
                        [ 5.0,  6.0,  7.0,  8.0],
@@ -551,6 +564,7 @@ class Tests(unittest.TestCase):
             mask = np.fromfunction(lambda i, j: (lower <= j - i) * (j - i <= upper), (8, 10))
             self._assert_eq(actual, nd2 * mask)
 
+    @skip_unless_spark_backend()
     def test_sparsify_triangle(self):
         nd = np.array([[ 1.0,  2.0,  3.0,  4.0],
                        [ 5.0,  6.0,  7.0,  8.0],
@@ -582,6 +596,7 @@ class Tests(unittest.TestCase):
                       [ 0.,  0., 11., 12.],
                       [ 0.,  0., 15., 16.]]))
 
+    @skip_unless_spark_backend()
     def test_sparsify_rectangles(self):
         nd = np.array([[ 1.0,  2.0,  3.0,  4.0],
                        [ 5.0,  6.0,  7.0,  8.0],
@@ -598,6 +613,7 @@ class Tests(unittest.TestCase):
 
         self._assert_eq(bm.sparsify_rectangles([]), np.zeros(shape=(4, 4)))
 
+    @skip_unless_spark_backend()
     def test_export_rectangles(self):
         nd = np.arange(0, 80, dtype=float).reshape(8, 10)
 
@@ -650,6 +666,7 @@ class Tests(unittest.TestCase):
             BlockMatrix.export_rectangles(bm_uri, rect_uri, [[5, 6, 5, 6]])
             self.assertEquals(e.msg, 'block (1, 1) missing for rectangle 0 with bounds [5, 6, 5, 6]')
 
+    @skip_unless_spark_backend()
     def test_block_matrix_entries(self):
         n_rows, n_cols = 5, 3
         rows = [{'i': i, 'j': j, 'entry': float(i + j)} for i in range(n_rows) for j in range(n_cols)]
@@ -790,6 +807,7 @@ class Tests(unittest.TestCase):
 
         self.assertEqual(res, [0, 0, 2, 2, 4, 6])
 
+    @skip_unless_spark_backend()
     def test_write_overwrite(self):
         path = new_temp_file()
 
@@ -801,6 +819,7 @@ class Tests(unittest.TestCase):
         bm2.write(path, overwrite=True)
         self._assert_eq(BlockMatrix.read(path), bm2)
 
+    @skip_unless_spark_backend()
     def test_stage_locally(self):
         nd = np.arange(0, 80, dtype=float).reshape(8, 10)
         bm_uri = new_temp_file()
@@ -809,6 +828,7 @@ class Tests(unittest.TestCase):
         bm = BlockMatrix.read(bm_uri)
         self._assert_eq(nd, bm)
 
+    @skip_unless_spark_backend()
     def test_svd(self):
         def assert_same_columns_up_to_sign(a, b):
             for j in range(a.shape[1]):

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -226,6 +226,7 @@ class VCFTests(unittest.TestCase):
 
         assert hl.import_vcf(tmp)._same(mt)
 
+    @skip_unless_spark_backend()
     def test_import_vcfs(self):
         path = resource('sample.vcf.bgz')
         parts = [
@@ -262,6 +263,7 @@ class VCFTests(unittest.TestCase):
         self.assertEqual(hl.filter_intervals(vcf2, interval_b).n_partitions(), 2)
         self.assertEqual(hl.filter_intervals(vcf2, interval_c).n_partitions(), 3)
 
+    @skip_unless_spark_backend()
     def test_import_vcfs_subset(self):
         path = resource('sample.vcf.bgz')
         parts = [
@@ -278,6 +280,7 @@ class VCFTests(unittest.TestCase):
         self.assertTrue(vcf2._same(filter1))
         self.assertEqual(len(parts), vcf2.n_partitions())
 
+    @skip_unless_spark_backend()
     def test_import_multiple_vcfs(self):
         _paths = ['gvcfs/HG00096.g.vcf.gz', 'gvcfs/HG00268.g.vcf.gz']
         paths = [resource(p) for p in _paths]
@@ -307,6 +310,7 @@ class VCFTests(unittest.TestCase):
         pos268 = set(filt268.locus.position.collect())
         self.assertFalse(pos096 & pos268)
 
+    @skip_unless_spark_backend()
     def test_combiner_works(self):
         from hail.experimental.vcf_combiner import transform_one, combine_gvcfs
         _paths = ['gvcfs/HG00096.g.vcf.gz', 'gvcfs/HG00268.g.vcf.gz']
@@ -1179,6 +1183,7 @@ class LocusIntervalTests(unittest.TestCase):
 
 
 class ImportMatrixTableTests(unittest.TestCase):
+    @skip_unless_spark_backend()
     def test_import_matrix_table(self):
         mt = hl.import_matrix_table(doctest_resource('matrix1.tsv'),
                                     row_fields={'Barcode': hl.tstr, 'Tissue': hl.tstr, 'Days': hl.tfloat32})

--- a/hail/python/test/hail/methods/test_misc.py
+++ b/hail/python/test/hail/methods/test_misc.py
@@ -61,6 +61,7 @@ class Tests(unittest.TestCase):
         self.assertTrue(ds.annotate_rows(target=interval_list2[ds.locus].target).rows()
                         ._same(ds.annotate_rows(target=bed2[ds.locus].target).rows()))
 
+    @skip_unless_spark_backend()
     def test_maximal_independent_set(self):
         # prefer to remove nodes with higher index
         t = hl.utils.range_table(10)
@@ -76,6 +77,7 @@ class Tests(unittest.TestCase):
         self.assertRaises(ValueError, lambda: hl.maximal_independent_set(graph.i, hl.utils.range_table(10).idx, True))
         self.assertRaises(ValueError, lambda: hl.maximal_independent_set(hl.literal(1), hl.literal(2), True))
 
+    @skip_unless_spark_backend()
     def test_maximal_independent_set2(self):
         edges = [(0, 4), (0, 1), (0, 2), (1, 5), (1, 3), (2, 3), (2, 6),
                  (3, 7), (4, 5), (4, 6), (5, 7), (6, 7)]
@@ -91,6 +93,7 @@ class Tests(unittest.TestCase):
         non_maximal_indep_sets = [{0, 7}, {6, 1}]
         self.assertTrue(mis in non_maximal_indep_sets or mis in maximal_indep_sets)
 
+    @skip_unless_spark_backend()
     def test_maximal_independent_set3(self):
         is_case = {"A", "C", "E", "G", "H"}
         edges = [("A", "B"), ("C", "D"), ("E", "F"), ("G", "H")]
@@ -112,6 +115,7 @@ class Tests(unittest.TestCase):
         self.assertTrue(mis.all(mis.node.is_case))
         self.assertTrue(set([row.id for row in mis.select(mis.node.id).collect()]) in expected_sets)
 
+    @skip_unless_spark_backend()
     def test_maximal_independent_set_types(self):
         ht = hl.utils.range_table(10)
         ht = ht.annotate(i=hl.struct(a='1', b=hl.rand_norm(0, 1)),

--- a/hail/python/test/hail/methods/test_qc.py
+++ b/hail/python/test/hail/methods/test_qc.py
@@ -108,6 +108,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(r[1].vqc.gq_stats.mean, 10)
         self.assertEqual(r[1].vqc.gq_stats.stdev, 0)
 
+    @skip_unless_spark_backend()
     def test_concordance(self):
         dataset = get_dataset()
         glob_conc, cols_conc, rows_conc = hl.concordance(dataset, dataset)

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -17,6 +17,7 @@ tearDownModule = stopTestHailContext
 
 
 class Tests(unittest.TestCase):
+    @skip_unless_spark_backend()
     @unittest.skipIf('HAIL_TEST_SKIP_PLINK' in os.environ, 'Skipping tests requiring plink')
     def test_ibd(self):
         dataset = get_dataset()
@@ -1024,6 +1025,7 @@ class Tests(unittest.TestCase):
         assert mt.aggregate_rows(hl.agg.all(mt.foo.bar == ht[mt.row_key].bar))
 
 
+    @skip_unless_spark_backend()
     def test_genetic_relatedness_matrix(self):
         n, m = 100, 200
         hl.set_global_seed(0)
@@ -1056,6 +1058,7 @@ class Tests(unittest.TestCase):
         col_filter = col_lengths > 0
         return np.copy(a[:, np.squeeze(col_filter)] / col_lengths[col_filter])
 
+    @skip_unless_spark_backend()
     def test_realized_relationship_matrix(self):
         n, m = 100, 200
         hl.set_global_seed(0)
@@ -1070,6 +1073,7 @@ class Tests(unittest.TestCase):
         rrm = hl.realized_relationship_matrix(mt.GT).to_numpy()
         self.assertTrue(np.allclose(k, rrm))
 
+    @skip_unless_spark_backend()
     def test_row_correlation_vs_hardcode(self):
         data = [{'v': '1:1:A:C', 's': '1', 'GT': hl.Call([0, 0])},
                 {'v': '1:1:A:C', 's': '2', 'GT': hl.Call([0, 0])},
@@ -1091,6 +1095,7 @@ class Tests(unittest.TestCase):
 
         self.assertTrue(np.allclose(actual, expected))
 
+    @skip_unless_spark_backend()
     def test_row_correlation_vs_numpy(self):
         n, m = 11, 10
         hl.set_global_seed(0)
@@ -1107,6 +1112,7 @@ class Tests(unittest.TestCase):
         self.assertTrue(cor.shape[0] > 5 and cor.shape[0] == cor.shape[1])
         self.assertTrue(np.allclose(l, cor))
 
+    @skip_unless_spark_backend()
     def test_ld_matrix(self):
         data = [{'v': '1:1:A:C',       'cm': 0.1, 's': 'a', 'GT': hl.Call([0, 0])},
                 {'v': '1:1:A:C',       'cm': 0.1, 's': 'b', 'GT': hl.Call([0, 0])},
@@ -1224,6 +1230,7 @@ class Tests(unittest.TestCase):
                                 ibd1=plink_kin.k1,
                                 ibd2=plink_kin.k2).key_by('i', 'j')
 
+    @skip_unless_spark_backend()
     @unittest.skipIf('HAIL_TEST_SKIP_R' in os.environ, 'Skipping tests requiring R')
     def test_pc_relate_on_balding_nichols_against_R_pc_relate(self):
         mt = hl.balding_nichols_model(3, 100, 1000)
@@ -1236,6 +1243,7 @@ class Tests(unittest.TestCase):
         self.assertTrue(rkin.select("ibd1")._same(hkin.select("ibd1"), tolerance=2.6e-2, absolute=True))
         self.assertTrue(rkin.select("ibd2")._same(hkin.select("ibd2"), tolerance=1.3e-2, absolute=True))
 
+    @skip_unless_spark_backend()
     def test_pcrelate_paths(self):
         mt = hl.balding_nichols_model(3, 50, 100)
         _, scores2, _ = hl.hwe_normalized_pca(mt.GT, k=2, compute_loadings=False)
@@ -1269,6 +1277,7 @@ class Tests(unittest.TestCase):
         self.assertTrue(kin3.count() > 0)
         self.assertTrue(kin3.filter(kin3.kin < 0.1).count() == 0)
 
+    @skip_unless_spark_backend()
     def test_pcrelate_issue_5263(self):
         mt = hl.balding_nichols_model(3, 50, 100)
         expected = hl.pc_relate(mt.GT, 0.10, k=2, statistics='all')
@@ -1307,6 +1316,7 @@ class Tests(unittest.TestCase):
         mt = hl.split_multi(mt)
         self.assertEqual(1, mt._force_count_rows())
 
+    @skip_unless_spark_backend()
     def test_ld_prune(self):
         r2_threshold = 0.001
         window_size = 5
@@ -1342,6 +1352,7 @@ class Tests(unittest.TestCase):
 
         self.assertEqual(entries.filter(bad_pair).count(), 0)
 
+    @skip_unless_spark_backend()
     def test_ld_prune_inputs(self):
         ds = hl.balding_nichols_model(n_populations=1, n_samples=1, n_variants=1)
         self.assertRaises(ValueError, lambda: hl.ld_prune(ds.GT, memory_per_core=0))
@@ -1349,17 +1360,20 @@ class Tests(unittest.TestCase):
         self.assertRaises(ValueError, lambda: hl.ld_prune(ds.GT, r2=-1.0))
         self.assertRaises(ValueError, lambda: hl.ld_prune(ds.GT, r2=2.0))
 
+    @skip_unless_spark_backend()
     def test_ld_prune_no_prune(self):
         ds = hl.balding_nichols_model(n_populations=1, n_samples=10, n_variants=10, n_partitions=3)
         pruned_table = hl.ld_prune(ds.GT, r2=0.0, bp_window_size=0)
         expected_count = ds.filter_rows(agg.collect_as_set(ds.GT).size() > 1, keep=True).count_rows()
         self.assertEqual(pruned_table.count(), expected_count)
 
+    @skip_unless_spark_backend()
     def test_ld_prune_identical_variants(self):
         ds = hl.import_vcf(resource('ldprune2.vcf'), min_partitions=2)
         pruned_table = hl.ld_prune(ds.GT)
         self.assertEqual(pruned_table.count(), 1)
 
+    @skip_unless_spark_backend()
     def test_ld_prune_maf(self):
         ds = hl.balding_nichols_model(n_populations=1, n_samples=50, n_variants=10, n_partitions=10).cache()
 
@@ -1374,12 +1388,14 @@ class Tests(unittest.TestCase):
 
         self.assertEqual(kept_maf, max(ht.maf.collect()))
 
+    @skip_unless_spark_backend()
     def test_ld_prune_call_expression(self):
         ds = hl.import_vcf(resource("ldprune2.vcf"), min_partitions=2)
         ds = ds.select_entries(foo=ds.GT)
         pruned_table = hl.ld_prune(ds.foo)
         self.assertEqual(pruned_table.count(), 1)
 
+    @skip_unless_spark_backend()
     def test_ld_prune_with_duplicate_row_keys(self):
         ds = hl.import_vcf(resource('ldprune2.vcf'), min_partitions=2)
         ds_duplicate = ds.annotate_rows(duplicate=[1, 2]).explode_rows('duplicate')

--- a/hail/python/test/hail/stats/test_linear_mixed_model.py
+++ b/hail/python/test/hail/stats/test_linear_mixed_model.py
@@ -22,6 +22,7 @@ class Tests(unittest.TestCase):
         col_filter = col_lengths > 0
         return np.copy(a[:, np.squeeze(col_filter)] / col_lengths[col_filter])
 
+    @skip_unless_spark_backend()
     def test_linear_mixed_model_fastlmm(self):
         # FastLMM Test data is from all.bed, all.bim, all.fam, cov.txt, pheno_10_causals.txt:
         #   https://github.com/MicrosoftGenomics/FaST-LMM/tree/master/tests/datasets/synth
@@ -176,6 +177,7 @@ class Tests(unittest.TestCase):
         assert np.isclose(model.h_sq, h2_fastlmm)
         assert np.isclose(model.h_sq_standard_error, h2_std_error)
 
+    @skip_unless_spark_backend()
     def test_linear_mixed_model_math(self):
         gamma = 2.0  # testing at fixed value of gamma
         n, f, m = 4, 2, 3
@@ -263,6 +265,7 @@ class Tests(unittest.TestCase):
         self.assertAlmostEqual(stats.beta, beta1[0])
         self.assertAlmostEqual(stats.chi_sq, chi_sq)
 
+    @skip_unless_spark_backend()
     def test_linear_mixed_model_function(self):
         n, f, m = 4, 2, 3
         y = np.array([0.0, 1.0, 8.0, 9.0])
@@ -314,6 +317,7 @@ class Tests(unittest.TestCase):
         assert model0._same(model)
         assert np.allclose(p0, p.to_numpy())
 
+    @skip_unless_spark_backend()
     def test_linear_mixed_regression_full_rank(self):
         x_table = hl.import_table(resource('fastlmmCov.txt'), no_header=True, impute=True).key_by('f1')
         y_table = hl.import_table(resource('fastlmmPheno.txt'), no_header=True, impute=True, delimiter=' ').key_by('f1')
@@ -343,6 +347,7 @@ class Tests(unittest.TestCase):
         assert np.allclose(ht.beta.collect(), beta_fastlmm)
         assert np.allclose(ht.p_value.collect(), pval_hail)
 
+    @skip_unless_spark_backend()
     def test_linear_mixed_regression_low_rank(self):
         x_table = hl.import_table(resource('fastlmmCov.txt'), no_header=True, impute=True).key_by('f1')
         y_table = hl.import_table(resource('fastlmmPheno.txt'), no_header=True, impute=True, delimiter=' ').key_by('f1')
@@ -372,6 +377,7 @@ class Tests(unittest.TestCase):
         assert np.allclose(ht.beta.collect(), beta_hail)
         assert np.allclose(ht.p_value.collect(), pval_hail)
 
+    @skip_unless_spark_backend()
     def test_linear_mixed_regression_pass_through(self):
         x_table = hl.import_table(resource('fastlmmCov.txt'), no_header=True, impute=True).key_by('f1')
         y_table = hl.import_table(resource('fastlmmPheno.txt'), no_header=True, impute=True, delimiter=' ').key_by('f1')

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -509,6 +509,7 @@ class Tests(unittest.TestCase):
         kt_small = kt.sample(0.01)
         self.assertTrue(kt_small.count() < kt.count())
 
+    @skip_unless_spark_backend()
     def test_from_spark_works(self):
         sql_context = Env.sql_context()
         df = sql_context.createDataFrame([pyspark.sql.Row(x=5, y='foo')])
@@ -518,6 +519,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(rows[0].x, 5)
         self.assertEqual(rows[0].y, 'foo')
 
+    @skip_unless_spark_backend()
     def test_from_pandas_works(self):
         d = {'a': [1, 2], 'b': ['foo', 'bar']}
         df = pd.DataFrame(data=d)

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -26,6 +26,8 @@ import org.apache.spark._
 import org.apache.spark.executor.InputMetrics
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SQLContext
+import org.json4s.Extraction
+import org.json4s.jackson.JsonMethods
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -498,14 +500,11 @@ class HailContext private(val sc: SparkContext,
     LoadVCF.parseHeaderMetadata(this, reader, file)
   }
 
-  def pyParseVCFMetadata(file: String): java.util.Map[String, java.util.Map[String, java.util.Map[String, String]]] = {
+  def pyParseVCFMetadataJSON(file: String): String = {
     val reader = new HtsjdkRecordReader(Set.empty)
     val metadata = LoadVCF.parseHeaderMetadata(this, reader, file)
-    metadata.mapValues { groupIds =>
-      groupIds.mapValues { fields =>
-        fields.asJava
-      }.asJava
-    }.asJava
+    implicit val formats = defaultJSONFormats
+    JsonMethods.compact(Extraction.decompose(metadata))
   }
   
   def importMatrix(files: java.util.ArrayList[String],

--- a/hail/test-apiserver.sh
+++ b/hail/test-apiserver.sh
@@ -10,9 +10,6 @@ cleanup() {
 trap cleanup EXIT
 trap "exit 1" INT TERM
 
-# FIXME update pr-builder image
-pip install flask
-
 export PYTHONPATH=$(ls $SPARK_HOME/python/lib/py4j-*-src.zip):$SPARK_HOME/python:./python
 export JAR=./build/libs/hail-all-spark.jar
 export PYSPARK_SUBMIT_ARGS="--conf spark.driver.extraClassPath=./build/libs/hail-all-spark.jar --conf spark.executor.extraClassPath=./build/libs/hail-all-spark.jar pyspark-shell"

--- a/hail/test-apiserver.sh
+++ b/hail/test-apiserver.sh
@@ -10,6 +10,9 @@ cleanup() {
 trap cleanup EXIT
 trap "exit 1" INT TERM
 
+# FIXME update pr-builder image
+pip install flask
+
 export PYTHONPATH=$(ls $SPARK_HOME/python/lib/py4j-*-src.zip):$SPARK_HOME/python:./python
 export JAR=./build/libs/hail-all-spark.jar
 export PYSPARK_SUBMIT_ARGS="--conf spark.driver.extraClassPath=./build/libs/hail-all-spark.jar --conf spark.executor.extraClassPath=./build/libs/hail-all-spark.jar pyspark-shell"

--- a/hail/test-apiserver.sh
+++ b/hail/test-apiserver.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -ex
+
+cleanup() {
+    set +e
+    trap "" INT TERM
+    [[ -z $server_pid ]] || kill -9 $server_pid
+}
+trap cleanup EXIT
+trap "exit 1" INT TERM
+
+export PYTHONPATH=$(ls $SPARK_HOME/python/lib/py4j-*-src.zip):$SPARK_HOME/python:./python
+export JAR=./build/libs/hail-all-spark.jar
+export PYSPARK_SUBMIT_ARGS="--conf spark.driver.extraClassPath=./build/libs/hail-all-spark.jar --conf spark.executor.extraClassPath=./build/libs/hail-all-spark.jar pyspark-shell"
+
+python ../apiserver/apiserver/apiserver.py >apiserver.log 2>&1 &
+server_pid=$!
+
+../until-with-fuel 30 curl -fL http://localhost:5000/healthcheck
+
+export HAIL_TEST_SERVICE_BACKEND_URL=http://localhost:5000
+
+python -m unittest test.hail.table.test_table.Tests.test_range_table

--- a/projects.txt
+++ b/projects.txt
@@ -6,11 +6,11 @@ etc
 notebook
 gateway
 hail
+apiserver
 image-fetcher
 letsencrypt
 pipeline
 scorecard
 site
-spark
 upload
 vdc


### PR DESCRIPTION
Stacked on: https://github.com/hail-is/hail/pull/5384

Right now just running one test, since the Python tests are quite long (~10m).  When they get parallelized (ongoing batch changes), we enable the full tests.  The full tests are currently passing when run as:

    HAIL_TEST_SERVICE_BACKEND_URL=http://localhost:5000 gw testPython
