### PR TITLE
Add BlockMatrixDot to IR

### DIFF
--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -50,6 +50,25 @@ class BlockMatrixMap2(BlockMatrixIR):
         self._type = self.left.typ
 
 
+class BlockMatrixDot(BlockMatrixIR):
+    @typecheck_method(left=BlockMatrixIR, right=BlockMatrixIR)
+    def __init__(self, left, right):
+        super().__init__()
+        self.left = left
+        self.right = right
+
+    def render(self, r):
+        return '(BlockMatrixDot {} {})'.format(r(self.left), r(self.right))
+
+    def _compute_type(self):
+        l_type = self.left.typ
+        r_type = self.right.typ
+        self._type = tblockmatrix(l_type.element_type,
+                                  [l_type.shape[0], r_type.shape[1]],
+                                  l_type.block_size,
+                                  [l_type.dims_partitioned[0], r_type.dims_partitioned[1]])
+
+
 class BlockMatrixBroadcast(BlockMatrixIR):
     @typecheck_method(child=BlockMatrixIR,
                       in_index_expr=sequenceof(int),

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1353,7 +1353,7 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        if not isinstance(b, BlockMatrix):
+        if isinstance(b, np.ndarray):
             b = BlockMatrix(_to_bmir(b, self.block_size))
 
         if self.n_cols != b.n_rows:

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -533,7 +533,7 @@ class BlockMatrix(object):
         (:obj:`int`, :obj:`int`)
            Number of rows and number of columns.
         """
-        return tensor_shape_to_matrix_shape(self._bmir.typ.shape, self._bmir.typ.is_row_vector)
+        return tensor_shape_to_matrix_shape(self._bmir)
 
     @property
     def block_size(self):

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -342,14 +342,22 @@ class Tests(unittest.TestCase):
         nm = np.matrix([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         m = BlockMatrix.from_numpy(nm, block_size=2)
 
+        nrow = np.matrix([[7.0, 8.0, 9.0]])
+        row = BlockMatrix.from_numpy(nrow, block_size=2)
+
         self._assert_eq(m.T, nm.T)
         self._assert_eq(m.T, nm.T)
+        self._assert_eq(row.T, nrow.T)
 
         self._assert_eq(m @ m.T, nm @ nm.T)
         self._assert_eq(m @ nm.T, nm @ nm.T)
+        self._assert_eq(row @ row.T, nrow @ nrow.T)
+        self._assert_eq(row @ nrow.T, nrow @ nrow.T)
 
         self._assert_eq(m.T @ m, nm.T @ nm)
         self._assert_eq(m.T @ nm, nm.T @ nm)
+        self._assert_eq(row.T @ row, nrow.T @ nrow)
+        self._assert_eq(row.T @ nrow, nrow.T @ nrow)
 
         self.assertRaises(ValueError, lambda: m @ m)
         self.assertRaises(ValueError, lambda: m @ nm)

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -262,6 +262,8 @@ class BlockMatrixIRTests(unittest.TestCase):
         broadcast_scalar = ir.BlockMatrixBroadcast(scalar_to_bm, [], [2, 2], 256, [False, False])
         broadcast_col = ir.BlockMatrixBroadcast(col_vector_to_bm, [0], [2, 2], 256, [False, False])
         broadcast_row = ir.BlockMatrixBroadcast(row_vector_to_bm, [1], [2, 2], 256, [False, False])
+        transpose = ir.BlockMatrixBroadcast(broadcast_scalar, [1, 0], [2, 2], 256, [False, False])
+        matmul = ir.BlockMatrixDot(broadcast_scalar, transpose)
 
         pow_ir = (construct_expr(ir.Ref('l'), hl.tfloat64) ** construct_expr(ir.Ref('r'), hl.tfloat64))._ir
         squared_bm = ir.BlockMatrixMap2(scalar_to_bm, scalar_to_bm, pow_ir)
@@ -277,7 +279,9 @@ class BlockMatrixIRTests(unittest.TestCase):
             broadcast_scalar,
             broadcast_col,
             broadcast_row,
-            squared_bm
+            squared_bm,
+            transpose,
+            matmul
         ]
 
     def test_parses(self):

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -31,9 +31,11 @@ object BlockMatrixIR {
     }
   }
 
-  def tensorShapeToMatrixShape(shape: IndexedSeq[Long], isRowVector: Boolean): (Long, Long) = {
-    assert(shape.length <= 2)
+  def tensorShapeToMatrixShape(bmir: BlockMatrixIR): (Long, Long) = {
+    val shape = bmir.typ.shape
+    val isRowVector = bmir.typ.isRowVector
 
+    assert(shape.length <= 2)
     shape match {
       case IndexedSeq() => (1, 1)
       case IndexedSeq(len) => if (isRowVector) (len, 1) else (1, len)
@@ -262,8 +264,8 @@ case class BlockMatrixMap2(left: BlockMatrixIR, right: BlockMatrixIR, f: IR) ext
 case class BlockMatrixDot(left: BlockMatrixIR, right: BlockMatrixIR) extends BlockMatrixIR {
 
   override def typ: BlockMatrixType = {
-    val (lRows, lCols) = BlockMatrixIR.tensorShapeToMatrixShape(left.typ.shape, left.typ.isRowVector)
-    val (rRows, rCols) = BlockMatrixIR.tensorShapeToMatrixShape(left.typ.shape, left.typ.isRowVector)
+    val (lRows, lCols) = BlockMatrixIR.tensorShapeToMatrixShape(left)
+    val (rRows, rCols) = BlockMatrixIR.tensorShapeToMatrixShape(left)
     assert(lCols == rRows)
 
     val (tensorShape, isRowVector) = BlockMatrixIR.matrixShapeToTensorShape(lRows, rCols)
@@ -272,7 +274,7 @@ case class BlockMatrixDot(left: BlockMatrixIR, right: BlockMatrixIR) extends Blo
       tensorShape,
       isRowVector,
       left.typ.blockSize,
-      IndexedSeq(left.typ.dimsPartitioned(0), right.typ.dimsPartitioned(1)))
+      tensorShape.map(_ => true))
   }
 
   override def children: IndexedSeq[BaseIR] = Array(left, right)

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -249,6 +249,27 @@ case class BlockMatrixMap2(left: BlockMatrixIR, right: BlockMatrixIR, f: IR) ext
   }
 }
 
+case class BlockMatrixDot(left: BlockMatrixIR, right: BlockMatrixIR) extends BlockMatrixIR {
+  override def typ: BlockMatrixType = {
+    BlockMatrixType(
+      left.typ.elementType,
+      IndexedSeq(left.typ.shape(0), right.typ.shape(1)),
+      left.typ.blockSize,
+      IndexedSeq(left.typ.dimsPartitioned(0), right.typ.dimsPartitioned(1)))
+  }
+
+  override def children: IndexedSeq[BaseIR] = Array(left, right)
+
+  override def copy(newChildren: IndexedSeq[BaseIR]): BaseIR = {
+    assert(newChildren.length == 2)
+    BlockMatrixDot(newChildren(0).asInstanceOf[BlockMatrixIR], newChildren(1).asInstanceOf[BlockMatrixIR])
+  }
+
+  override protected[ir] def execute(hc: HailContext): BlockMatrix = {
+    left.execute(hc).dot(right.execute(hc))
+  }
+}
+
 case class BlockMatrixBroadcast(
   child: BlockMatrixIR,
   inIndexExpr: IndexedSeq[Int],

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -265,7 +265,7 @@ case class BlockMatrixDot(left: BlockMatrixIR, right: BlockMatrixIR) extends Blo
 
   override def typ: BlockMatrixType = {
     val (lRows, lCols) = BlockMatrixIR.tensorShapeToMatrixShape(left)
-    val (rRows, rCols) = BlockMatrixIR.tensorShapeToMatrixShape(left)
+    val (rRows, rCols) = BlockMatrixIR.tensorShapeToMatrixShape(right)
     assert(lCols == rRows)
 
     val (tensorShape, isRowVector) = BlockMatrixIR.matrixShapeToTensorShape(lRows, rCols)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1146,6 +1146,10 @@ object IRParser {
         val right = blockmatrix_ir(env)(it)
         val f = ir_value_expr(env.update(Map("l" -> left.typ.elementType, "r" -> right.typ.elementType)))(it)
         BlockMatrixMap2(left, right, f)
+      case "BlockMatrixDot" =>
+        val left = blockmatrix_ir(env)(it)
+        val right = blockmatrix_ir(env)(it)
+        BlockMatrixDot(left, right)
       case "BlockMatrixBroadcast" =>
         val inIndexExpr = int32_literals(it)
         val shape = int64_literals(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -38,7 +38,7 @@ object Pretty {
 
   def prettyInts(x: IndexedSeq[Int]): String = x.mkString("(", " ", ")")
 
-  def prettyLiterals[T](x: IndexedSeq[T]): String = x.mkString("(", " ", ")")
+  def prettyBooleans(bools: IndexedSeq[Boolean]): String = prettyIdentifiers(bools.map(prettyBooleanLiteral))
 
   def prettyLongsOpt(x: Option[IndexedSeq[Long]]): String =
     x.map(prettyLongs).getOrElse("None")
@@ -200,11 +200,11 @@ object Pretty {
               prettyInts(inIndexExpr) + " " +
               prettyLongs(shape) + " " +
               blockSize.toString + " " +
-              prettyLiterals(dimsPartitioned)
+              prettyBooleans(dimsPartitioned)
             case ValueToBlockMatrix(_, shape, blockSize, dimsPartitioned) =>
               prettyLongs(shape) + " " +
               blockSize.toString + " " +
-              prettyLiterals(dimsPartitioned)
+              prettyBooleans(dimsPartitioned)
             case MatrixRowsHead(_, n) => n.toString
             case MatrixAnnotateRowsTable(_, _, uid) =>
               prettyStringLiteral(uid) + " "

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -158,4 +158,9 @@ class BlockMatrixIRSuite extends SparkSuite {
     assertBmEq(actualOnesDivRowOnLeft.execute(hc),  expectedOnesDivRowLeft)
     assertBmEq(actualOnesDivColOnLeft.execute(hc),  expectedOnesDivColLeft)
   }
+
+  @Test def testBlockMatrixDot() {
+    val dotTwosAndThrees = BlockMatrixDot(new BlockMatrixLiteral(twos), new BlockMatrixLiteral(threes))
+    assertBmEq(dotTwosAndThrees.execute(hc), BlockMatrix.fill(hc, 3, 3, 2 * 3 * 3))
+  }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1194,9 +1194,11 @@ class IRSuite extends SparkSuite {
 
   @DataProvider(name = "blockMatrixIRs")
   def blockMatrixIRs(): Array[Array[BlockMatrixIR]] = {
-    val read = BlockMatrixRead(tmpDir.createLocalTempFile())
+    val read = BlockMatrixRead("src/test/resources/blockmatrix_example/0")
+    val transpose = BlockMatrixBroadcast(read, IndexedSeq(1, 0), IndexedSeq(2, 2), 2, IndexedSeq(true, true))
+    val dot = BlockMatrixDot(read, transpose)
 
-    val blockMatrixIRs = Array[BlockMatrixIR](read)
+    val blockMatrixIRs = Array[BlockMatrixIR](read, transpose, dot)
 
     blockMatrixIRs.map(ir => Array(ir))
   }


### PR DESCRIPTION
- Add an IR node to represent matrix multiplication between two `BlockMatrixIR`.
- Cleaned up the workaround introduced in #5338 for differentiating between a matrix shape (2-D shape that the `BlockMatrix` front-end is aware of) and a tensor shape (n-D shape of the IR type).