### PR TITLE
Add readers and writers to BlockMatrix IR

### DIFF
--- a/hail/python/hail/ir/__init__.py
+++ b/hail/python/hail/ir/__init__.py
@@ -7,4 +7,6 @@ from .blockmatrix_ir import *
 from .utils import *
 from .matrix_reader import *
 from .table_reader import *
+from .blockmatrix_reader import *
 from .matrix_writer import *
+from .blockmatrix_writer import *

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -1,19 +1,21 @@
 from hail.expr.blockmatrix_type import tblockmatrix
-from hail.ir import BlockMatrixIR, IR, tarray, hl
-from hail.utils.java import escape_str
+from hail.ir import hl
+from hail.expr.types import tarray
+from hail.ir import BlockMatrixIR, IR
+from hail.ir.blockmatrix_reader import BlockMatrixReader
 from hail.typecheck import typecheck_method, sequenceof
 
 from hail.utils.java import Env
 
 
 class BlockMatrixRead(BlockMatrixIR):
-    @typecheck_method(path=str)
-    def __init__(self, path):
+    @typecheck_method(reader=BlockMatrixReader)
+    def __init__(self, reader):
         super().__init__()
-        self.path = path
+        self.reader = reader
 
     def render(self, r):
-        return f'(BlockMatrixRead "{escape_str(self.path)}")'
+        return f'(BlockMatrixRead "{r(self.reader)}")'
 
     def _compute_type(self):
         self._type = Env.backend().blockmatrix_type(self)

--- a/hail/python/hail/ir/blockmatrix_reader.py
+++ b/hail/python/hail/ir/blockmatrix_reader.py
@@ -27,7 +27,7 @@ class BlockMatrixNativeReader(BlockMatrixReader):
 
     def __eq__(self, other):
         return isinstance(other, BlockMatrixNativeReader) and \
-               other.path == self.path
+               self.path == other.path
 
 
 class BlockMatrixBinaryReader(BlockMatrixReader):

--- a/hail/python/hail/ir/blockmatrix_reader.py
+++ b/hail/python/hail/ir/blockmatrix_reader.py
@@ -1,0 +1,51 @@
+import abc
+import json
+
+from ..typecheck import *
+from ..utils.java import escape_str
+
+
+class BlockMatrixReader(object):
+    @abc.abstractmethod
+    def render(self, r):
+        pass
+
+    @abc.abstractmethod
+    def __eq__(self, other):
+        pass
+
+
+class BlockMatrixNativeReader(BlockMatrixReader):
+    @typecheck_method(path=str)
+    def __init__(self, path):
+        self.path = path
+
+    def render(self, r):
+        reader = {'name': 'BlockMatrixNativeReader',
+                  'path': self.path}
+        return escape_str(json.dumps(reader))
+
+    def __eq__(self, other):
+        return isinstance(other, BlockMatrixNativeReader) and \
+               other.path == self.path
+
+
+class BlockMatrixBinaryReader(BlockMatrixReader):
+    @typecheck_method(path=str, shape=sequenceof(int), block_size=int)
+    def __init__(self, path, shape, block_size):
+        self.path = path
+        self.shape = shape
+        self.block_size = block_size
+
+    def render(self, r):
+        reader = {'name': 'BlockMatrixBinaryReader',
+                  'path': self.path,
+                  'shape': self.shape,
+                  'blockSize': self.block_size}
+        return escape_str(json.dumps(reader))
+
+    def __eq__(self, other):
+        return isinstance(other, BlockMatrixBinaryReader) and \
+               self.path == other.path and \
+               self.shape == other.shape and \
+               self.block_size == other.block_size

--- a/hail/python/hail/ir/blockmatrix_writer.py
+++ b/hail/python/hail/ir/blockmatrix_writer.py
@@ -1,0 +1,54 @@
+import abc
+import json
+
+from ..typecheck import *
+from ..utils.java import escape_str
+
+
+class BlockMatrixWriter(object):
+    @abc.abstractmethod
+    def render(self, r):
+        pass
+
+    @abc.abstractmethod
+    def __eq__(self, other):
+        pass
+
+
+class BlockMatrixNativeWriter(BlockMatrixWriter):
+    @typecheck_method(path=str, overwrite=bool, force_row_major=bool, stage_locally=bool)
+    def __init__(self, path, overwrite, force_row_major, stage_locally):
+        self.path = path
+        self.overwrite = overwrite
+        self.force_row_major = force_row_major
+        self.stage_locally = stage_locally
+
+    def render(self, r):
+        writer = {'name': 'BlockMatrixNativeWriter',
+                  'path': self.path,
+                  'overwrite': self.overwrite,
+                  'forceRowMajor': self.force_row_major,
+                  'stageLocally': self.stage_locally}
+        return escape_str(json.dumps(writer))
+
+    def __eq__(self, other):
+        return isinstance(other, BlockMatrixNativeWriter) and \
+               self.path == other.path and \
+               self.overwrite == other.overwrite and \
+               self.force_row_major == other.force_row_major and \
+               self.stage_locally == other.stage_locally
+
+
+class BlockMatrixBinaryWriter(BlockMatrixWriter):
+    @typecheck_method(path=str)
+    def __init__(self, path):
+        self.path = path
+
+    def render(self, r):
+        writer = {'name': 'BlockMatrixBinaryWriter',
+                  'path': self.path}
+        return escape_str(json.dumps(writer))
+
+    def __eq__(self, other):
+        return isinstance(other, BlockMatrixBinaryWriter) and \
+               self.path == other.path

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -501,7 +501,9 @@ class BlockMatrix(object):
     @staticmethod
     def default_block_size():
         """Default block side length."""
-        return Env.hail().linalg.BlockMatrix.defaultBlockSize()
+
+        # This should match BlockMatrix.defaultBlockSize in the Scala backend.
+        return 4096  # 32 * 1024 bytes
 
     @property
     def element_type(self):

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1101,7 +1101,7 @@ class BlockMatrix(object):
         --------
         :meth:`.to_numpy`
         """
-        _check_num_entries(self.n_rows, self.n_cols)
+        _check_entries_size(self.n_rows, self.n_cols)
 
         writer = BlockMatrixBinaryWriter(uri)
         Env.backend().execute(BlockMatrixWrite(self._bmir, writer))
@@ -2179,12 +2179,12 @@ def _ndarray_from_jarray(ja):
 
 
 def _breeze_fromfile(uri, n_rows, n_cols):
-    _check_num_entries(n_rows, n_cols)
+    _check_entries_size(n_rows, n_cols)
 
     return Env.hail().utils.richUtils.RichDenseMatrixDouble.importFromDoubles(Env.hc()._jhc, uri, n_rows, n_cols, True)
 
 
-def _check_num_entries(n_rows, n_cols):
+def _check_entries_size(n_rows, n_cols):
     n_entries = n_rows * n_cols
     if n_entries >= 1 << 31:
         raise ValueError(f'number of entries must be less than 2^31, found {n_entries}')

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -31,7 +31,7 @@ class ValueIRTests(unittest.TestCase):
         matrix_read = ir.MatrixRead(ir.MatrixNativeReader(
             resource('backward_compatability/1.0.0/matrix_table/0.hmt')), False, False)
 
-        block_matrix_read = ir.BlockMatrixRead('fake_file_path')
+        block_matrix_read = ir.BlockMatrixRead(ir.BlockMatrixNativeReader('fake_file_path'))
 
         value_irs = [
             i, ir.I64(5), ir.F32(3.14), ir.F64(3.14), s, ir.TrueIR(), ir.FalseIR(), ir.Void(),
@@ -103,7 +103,7 @@ class ValueIRTests(unittest.TestCase):
             ir.MatrixWrite(matrix_read, ir.MatrixGENWriter(new_temp_file(), 4)),
             ir.MatrixWrite(matrix_read, ir.MatrixPLINKWriter(new_temp_file())),
             ir.MatrixMultiWrite([matrix_read, matrix_read], ir.MatrixNativeMultiWriter(new_temp_file(), False, False)),
-            ir.BlockMatrixWrite(block_matrix_read, 'fake_file_path', False, False, False)
+            ir.BlockMatrixWrite(block_matrix_read, ir.BlockMatrixNativeWriter('fake_file_path', False, False, False))
         ]
 
         return value_irs
@@ -251,7 +251,7 @@ class BlockMatrixIRTests(unittest.TestCase):
         scalar_ir = ir.F64(2)
         vector_ir = ir.MakeArray([ir.F64(3), ir.F64(2)], hl.tarray(hl.tfloat64))
 
-        read = ir.BlockMatrixRead(resource('blockmatrix_example/0'))
+        read = ir.BlockMatrixRead(ir.BlockMatrixNativeReader(resource('blockmatrix_example/0')))
         add_two_bms = ir.BlockMatrixMap2(read, read, ir.ApplyBinaryOp('+', ir.Ref('l'), ir.Ref('r')))
         negate_bm = ir.BlockMatrixMap(read, ir.ApplyUnaryOp('-', ir.Ref('element')))
         sqrt_bm = ir.BlockMatrixMap(read, hl.sqrt(construct_expr(ir.Ref('element'), hl.tfloat64))._ir)

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -15,7 +15,7 @@ object BlockMatrixWriter {
 
 
 abstract class BlockMatrixWriter {
-  def apply(bm: BlockMatrix): Unit
+  def apply(hc: HailContext, bm: BlockMatrix): Unit
 }
 
 case class BlockMatrixNativeWriter(

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -24,11 +24,11 @@ case class BlockMatrixNativeWriter(
   forceRowMajor: Boolean,
   stageLocally: Boolean) extends BlockMatrixWriter {
 
-  def apply(bm: BlockMatrix): Unit = bm.write(path, overwrite, forceRowMajor, stageLocally)
+  def apply(hc: HailContext, bm: BlockMatrix): Unit = bm.write(path, overwrite, forceRowMajor, stageLocally)
 }
 
 case class BlockMatrixBinaryWriter(path: String) extends BlockMatrixWriter {
-  def apply(bm: BlockMatrix): Unit = {
-    RichDenseMatrixDouble.exportToDoubles(HailContext.get, path, bm.toBreezeMatrix(), forceRowMajor = true)
+  def apply(hc: HailContext, bm: BlockMatrix): Unit = {
+    RichDenseMatrixDouble.exportToDoubles(hc, path, bm.toBreezeMatrix(), forceRowMajor = true)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -1,0 +1,34 @@
+package is.hail.expr.ir
+
+import is.hail.HailContext
+import is.hail.linalg.BlockMatrix
+import is.hail.utils.richUtils.RichDenseMatrixDouble
+import org.json4s.{DefaultFormats, Formats, ShortTypeHints}
+
+object BlockMatrixWriter {
+  implicit val formats: Formats = new DefaultFormats() {
+    override val typeHints = ShortTypeHints(
+      List(classOf[BlockMatrixNativeWriter], classOf[BlockMatrixBinaryWriter]))
+    override val typeHintFieldName: String = "name"
+  }
+}
+
+
+abstract class BlockMatrixWriter {
+  def apply(bm: BlockMatrix): Unit
+}
+
+case class BlockMatrixNativeWriter(
+  path: String,
+  overwrite: Boolean,
+  forceRowMajor: Boolean,
+  stageLocally: Boolean) extends BlockMatrixWriter {
+
+  def apply(bm: BlockMatrix): Unit = bm.write(path, overwrite, forceRowMajor, stageLocally)
+}
+
+case class BlockMatrixBinaryWriter(path: String) extends BlockMatrixWriter {
+  def apply(bm: BlockMatrix): Unit = {
+    RichDenseMatrixDouble.exportToDoubles(HailContext.get, path, bm.toBreezeMatrix(), forceRowMajor = true)
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -135,8 +135,8 @@ object Children {
     case TableToValueApply(child, _) => IndexedSeq(child)
     case MatrixToValueApply(child, _) => IndexedSeq(child)
     // from BlockMatrixIR
-    case BlockMatrixWrite(child, _, _, _, _) => IndexedSeq(child)
     case BlockMatrixToValueApply(child, _) => IndexedSeq(child)
+    case BlockMatrixWrite(child, _) => IndexedSeq(child)
     case CollectDistributedArray(ctxs, globals, _, _, body) => IndexedSeq(ctxs, globals, body)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -207,9 +207,9 @@ object Copy {
       case BlockMatrixToValueApply(_, function) =>
         val IndexedSeq(newChild: BlockMatrixIR) = newChildren
         BlockMatrixToValueApply(newChild, function)
-      case BlockMatrixWrite(_, path, overwrite, forceRowMajor, stageLocally) =>
+      case BlockMatrixWrite(_, writer) =>
         val IndexedSeq(newChild: BlockMatrixIR) = newChildren
-        BlockMatrixWrite(newChild, path, overwrite, forceRowMajor, stageLocally)
+        BlockMatrixWrite(newChild, writer)
       case CollectDistributedArray(_, _, cname, gname, _) =>
         val IndexedSeq(ctxs: IR, globals: IR, newBody: IR) = newChildren
         CollectDistributedArray(ctxs, globals, cname, gname, newBody)

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -322,8 +322,7 @@ final case class TableToValueApply(child: TableIR, function: TableToValueFunctio
 final case class MatrixToValueApply(child: MatrixIR, function: MatrixToValueFunction) extends IR
 final case class BlockMatrixToValueApply(child: BlockMatrixIR, function: BlockMatrixToValueFunction) extends IR
 
-final case class BlockMatrixWrite(child: BlockMatrixIR, path: String,
-  overwrite: Boolean, forceRowMajor: Boolean, stageLocally: Boolean) extends IR
+final case class BlockMatrixWrite(child: BlockMatrixIR, writer: BlockMatrixWriter) extends IR
 
 final case class CollectDistributedArray(contexts: IR, globals: IR, cname: String, gname: String, body: IR) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -781,10 +781,9 @@ object Interpret {
         val hc = HailContext.get
         val tableValue = child.execute(hc)
         tableValue.export(path, typesFile, header, exportType, delimiter)
-      case BlockMatrixWrite(child, path, overwrite, forceRowMajor, stageLocally) =>
+      case BlockMatrixWrite(child, writer) =>
         val hc = HailContext.get
-        val blockMatrix = child.execute(hc)
-        blockMatrix.write(path, overwrite, forceRowMajor, stageLocally)
+        writer(child.execute(hc))
       case TableToValueApply(child, function) =>
         function.execute(child.execute(HailContext.get))
       case MatrixToValueApply(child, function) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -783,7 +783,7 @@ object Interpret {
         tableValue.export(path, typesFile, header, exportType, delimiter)
       case BlockMatrixWrite(child, writer) =>
         val hc = HailContext.get
-        writer(child.execute(hc))
+        writer(hc, child.execute(hc))
       case TableToValueApply(child, function) =>
         function.execute(child.execute(HailContext.get))
       case MatrixToValueApply(child, function) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -820,12 +820,15 @@ object IRParser {
         val children = matrix_ir_children(env)(it)
         MatrixMultiWrite(children, writer)
       case "BlockMatrixWrite" =>
-        val path = string_literal(it)
-        val overwrite = boolean_literal(it)
-        val forceRowMajor = boolean_literal(it)
-        val stageLocally = boolean_literal(it)
+        val writerStr = string_literal(it)
+        implicit val formats: Formats = BlockMatrixWriter.formats
+        val writer = try {
+          Serialization.read[BlockMatrixWriter](writerStr)
+        } catch {
+          case e: MappingException => throw e.cause
+        }
         val child = blockmatrix_ir(env)(it)
-        BlockMatrixWrite(child, path, overwrite, forceRowMajor, stageLocally)
+        BlockMatrixWrite(child, writer)
       case "CollectDistributedArray" =>
         val cname = identifier(it)
         val gname = identifier(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -140,6 +140,14 @@ case class IRParserEnvironment(
 object IRParser {
   def error(t: Token, msg: String): Nothing = ParserUtils.error(t.pos, msg)
 
+  def deserialize[T](str: String)(implicit formats: Formats, mf: Manifest[T]): T = {
+    try {
+      Serialization.read[T](str)
+    } catch {
+      case e: MappingException => throw e.cause
+    }
+  }
+
   def consumeToken(it: TokenIterator): Token = {
     if (!it.hasNext)
       fatal("No more tokens to consume.")
@@ -801,12 +809,8 @@ object IRParser {
         MatrixAggregate(child, query)
       case "MatrixWrite" =>
         val writerStr = string_literal(it)
-        implicit val formats = MatrixWriter.formats
-        val writer = try {
-          Serialization.read[MatrixWriter](writerStr)
-        } catch {
-          case e: MappingException => throw e.cause
-        }
+        implicit val formats: Formats = MatrixWriter.formats
+        val writer = deserialize[MatrixWriter](writerStr)
         val child = matrix_ir(env.withRefMap(Map.empty))(it)
         MatrixWrite(child, writer)
       case "MatrixMultiWrite" =>
@@ -822,11 +826,7 @@ object IRParser {
       case "BlockMatrixWrite" =>
         val writerStr = string_literal(it)
         implicit val formats: Formats = BlockMatrixWriter.formats
-        val writer = try {
-          Serialization.read[BlockMatrixWriter](writerStr)
-        } catch {
-          case e: MappingException => throw e.cause
-        }
+        val writer = deserialize[BlockMatrixWriter](writerStr)
         val child = blockmatrix_ir(env)(it)
         BlockMatrixWrite(child, writer)
       case "CollectDistributedArray" =>
@@ -878,13 +878,8 @@ object IRParser {
         val requestedType = opt(it, table_type_expr)
         val dropRows = boolean_literal(it)
         val readerStr = string_literal(it)
-        implicit val formats = TableReader.formats
-          val reader = try {
-            Serialization.read[TableReader](readerStr)
-          } catch {
-            case e: MappingException =>
-              throw e.cause
-          }
+        implicit val formats: Formats = TableReader.formats
+        val reader = deserialize[TableReader](readerStr)
     TableRead(requestedType.getOrElse(reader.fullType), dropRows, reader)
       case "MatrixColsTable" =>
         val child = matrix_ir(env)(it)
@@ -1065,12 +1060,8 @@ object IRParser {
         val dropCols = boolean_literal(it)
         val dropRows = boolean_literal(it)
         val readerStr = string_literal(it)
-        implicit val formats = MatrixReader.formats + new MatrixBGENReaderSerializer(env)
-        val reader = try {
-          Serialization.read[MatrixReader](readerStr)
-        } catch {
-          case e: MappingException => throw e.cause
-        }
+        implicit val formats: Formats = MatrixReader.formats + new MatrixBGENReaderSerializer(env)
+        val reader = deserialize[MatrixReader](readerStr)
         MatrixRead(requestedType.getOrElse(reader.fullType), dropCols, dropRows, reader)
       case "MatrixAnnotateRowsTable" =>
         val root = string_literal(it)
@@ -1151,11 +1142,7 @@ object IRParser {
       case "BlockMatrixRead" =>
         val readerStr = string_literal(it)
         implicit val formats: Formats = BlockMatrixReader.formats
-        val reader = try {
-          Serialization.read[BlockMatrixReader](readerStr)
-        } catch {
-          case e: MappingException => throw e.cause
-        }
+        val reader = deserialize[BlockMatrixReader](readerStr)
         BlockMatrixRead(reader)
       case "BlockMatrixMap" =>
         val child = blockmatrix_ir(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -192,6 +192,8 @@ object Pretty {
               '"' + StringEscapeUtils.escapeString(Serialization.write(writer)(MatrixWriter.formats)) + '"'
             case MatrixMultiWrite(_, writer) =>
               '"' + StringEscapeUtils.escapeString(Serialization.write(writer)(MatrixNativeMultiWriter.formats)) + '"'
+            case BlockMatrixRead(reader) =>
+              '"' + StringEscapeUtils.escapeString(Serialization.write(reader)(BlockMatrixReader.formats)) + '"'
             case BlockMatrixWrite(_, writer) =>
               '"' + StringEscapeUtils.escapeString(Serialization.write(writer)(BlockMatrixWriter.formats)) + '"'
             case BlockMatrixBroadcast(_, inIndexExpr, shape, blockSize, dimsPartitioned) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -192,11 +192,8 @@ object Pretty {
               '"' + StringEscapeUtils.escapeString(Serialization.write(writer)(MatrixWriter.formats)) + '"'
             case MatrixMultiWrite(_, writer) =>
               '"' + StringEscapeUtils.escapeString(Serialization.write(writer)(MatrixNativeMultiWriter.formats)) + '"'
-            case BlockMatrixWrite(_, path, overwrite, forceRowMajor, stageLocally) =>
-              prettyStringLiteral(path) + " " +
-              prettyBooleanLiteral(overwrite) + " " +
-              prettyBooleanLiteral(forceRowMajor) + " " +
-              prettyBooleanLiteral(stageLocally)
+            case BlockMatrixWrite(_, writer) =>
+              '"' + StringEscapeUtils.escapeString(Serialization.write(writer)(BlockMatrixWriter.formats)) + '"'
             case BlockMatrixBroadcast(_, inIndexExpr, shape, blockSize, dimsPartitioned) =>
               prettyInts(inIndexExpr) + " " +
               prettyLongs(shape) + " " +

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -192,8 +192,6 @@ object Pretty {
               '"' + StringEscapeUtils.escapeString(Serialization.write(writer)(MatrixWriter.formats)) + '"'
             case MatrixMultiWrite(_, writer) =>
               '"' + StringEscapeUtils.escapeString(Serialization.write(writer)(MatrixNativeMultiWriter.formats)) + '"'
-            case BlockMatrixRead(path) =>
-              prettyStringLiteral(path)
             case BlockMatrixWrite(_, path, overwrite, forceRowMajor, stageLocally) =>
               prettyStringLiteral(path) + " " +
               prettyBooleanLiteral(overwrite) + " " +

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -311,7 +311,7 @@ object TypeCheck {
       case TableToValueApply(_, _) =>
       case MatrixToValueApply(_, _) =>
       case BlockMatrixToValueApply(_, _) =>
-      case BlockMatrixWrite(_, _, _, _, _) =>
+      case BlockMatrixWrite(_, _) =>
       case CollectDistributedArray(ctxs, globals, cname, gname, body) =>
         check(ctxs)
         assert(ctxs.typ.isInstanceOf[TArray])

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -49,10 +49,11 @@ class BlockMatrixIRSuite extends SparkSuite {
 
   @Test def testBlockMatrixWriteRead() {
     val tempPath = tmpDir.createLocalTempFile()
-    Interpret(BlockMatrixWrite(new BlockMatrixLiteral(ones), tempPath, false, false, false))
+    Interpret(BlockMatrixWrite(new BlockMatrixLiteral(sampleMatrix),
+      BlockMatrixNativeWriter(tempPath, false, false, false)))
 
-    val actualMatrix = BlockMatrixRead(tempPath).execute(hc)
-    assertBmEq(actualMatrix, ones)
+    val actualMatrix = BlockMatrixRead(BlockMatrixNativeReader(tempPath)).execute(hc)
+    assertBmEq(actualMatrix, sampleMatrix)
   }
 
 

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -49,11 +49,11 @@ class BlockMatrixIRSuite extends SparkSuite {
 
   @Test def testBlockMatrixWriteRead() {
     val tempPath = tmpDir.createLocalTempFile()
-    Interpret(BlockMatrixWrite(new BlockMatrixLiteral(sampleMatrix),
+    Interpret(BlockMatrixWrite(new BlockMatrixLiteral(ones),
       BlockMatrixNativeWriter(tempPath, false, false, false)))
 
     val actualMatrix = BlockMatrixRead(BlockMatrixNativeReader(tempPath)).execute(hc)
-    assertBmEq(actualMatrix, sampleMatrix)
+    assertBmEq(actualMatrix, ones)
   }
 
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -966,7 +966,7 @@ class IRSuite extends SparkSuite {
     val bgenReader = MatrixBGENReader(FastIndexedSeq("src/test/resources/example.8bits.bgen"), None, Map.empty[String, String], None, None, None)
     val bgen = MatrixRead(bgenReader.fullType, false, false, bgenReader)
 
-    val blockMatrix = BlockMatrixRead(tmpDir.createLocalTempFile())
+    val blockMatrix = BlockMatrixRead(BlockMatrixNativeReader(tmpDir.createLocalTempFile()))
 
     val irs = Array(
       i, I64(5), F32(3.14f), F64(3.14), str, True(), False(), Void(),
@@ -1041,7 +1041,7 @@ class IRSuite extends SparkSuite {
       MatrixWrite(bgen, MatrixGENWriter(tmpDir.createLocalTempFile())),
       MatrixMultiWrite(Array(mt, mt), MatrixNativeMultiWriter(tmpDir.createLocalTempFile())),
       MatrixAggregate(mt, MakeStruct(Seq("foo" -> count))),
-      BlockMatrixWrite(blockMatrix, tmpDir.createLocalTempFile(), false, false, false),
+      BlockMatrixWrite(blockMatrix, BlockMatrixNativeWriter(tmpDir.createLocalTempFile(), false, false, false)),
       CollectDistributedArray(ArrayRange(0, 3, 1), 1, "x", "y", Ref("x", TInt32()))
     )
     irs.map(x => Array(x))
@@ -1195,7 +1195,7 @@ class IRSuite extends SparkSuite {
 
   @DataProvider(name = "blockMatrixIRs")
   def blockMatrixIRs(): Array[Array[BlockMatrixIR]] = {
-    val read = BlockMatrixRead("src/test/resources/blockmatrix_example/0")
+    val read = BlockMatrixRead(BlockMatrixNativeReader("src/test/resources/blockmatrix_example/0"))
     val transpose = BlockMatrixBroadcast(read, IndexedSeq(1, 0), IndexedSeq(2, 2), 2, IndexedSeq(true, true))
     val dot = BlockMatrixDot(read, transpose)
 


### PR DESCRIPTION
Previously, the BlockMatrix IR had nodes for reading and writing that only covered the BlockMatrix part file format. Implemented readers and writers for both native and binary file formats (compatible with numpy) refactored read/write nodes, and implemented `tofile` and `fromfile` BlockMatrix methods in terms of the IR. Also hardcoded the front end default block size so now tests running IO/basic algebra should be able to run on the service.