### PR TITLE
Blockmatrix agg

### DIFF
--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -107,19 +107,16 @@ class BlockMatrixBroadcast(BlockMatrixIR):
 class BlockMatrixAgg(BlockMatrixIR):
     @typecheck_method(child=BlockMatrixIR,
                       out_index_expr=sequenceof(int),
-                      block_size=int,
                       dims_partitioned=sequenceof(bool))
-    def __init__(self, child, out_index_expr, block_size, dims_partitioned):
+    def __init__(self, child, out_index_expr, dims_partitioned):
         super().__init__()
         self.child = child
         self.out_index_expr = out_index_expr
-        self.block_size = block_size
         self.dims_partitioned = dims_partitioned
 
     def render(self, r):
-        return '(BlockMatrixAgg {} {} {} {})' \
+        return '(BlockMatrixAgg {} {} {})' \
             .format(_serialize_ints(self.out_index_expr),
-                    self.block_size,
                     _serialize_ints(self.dims_partitioned),
                     r(self.child))
 
@@ -130,7 +127,7 @@ class BlockMatrixAgg(BlockMatrixIR):
         self._type = tblockmatrix(self.child.typ.element_type,
                                   shape,
                                   is_row_vector,
-                                  self.block_size,
+                                  self.child.typ.block_size,
                                   self.dims_partitioned)
 
 

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1449,12 +1449,12 @@ class BlockMatrix(object):
             If ``1``, returns a block matrix with a single column.
         """
         if axis is None:
-            bmir = BlockMatrixAgg(self._bmir, [], self.block_size, [])
+            bmir = BlockMatrixAgg(self._bmir, [], [])
             return BlockMatrix(bmir)[0, 0]
         elif axis == 0 or axis == 1:
             out_index_expr = [dim for dim in range(len(self.shape)) if dim != axis]
 
-            bmir = BlockMatrixAgg(self._bmir, out_index_expr, self.block_size, [True])
+            bmir = BlockMatrixAgg(self._bmir, out_index_expr, [True])
             return BlockMatrix(bmir)
         else:
             raise ValueError(f'axis must be None, 0, or 1: found {axis}')

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1452,7 +1452,7 @@ class BlockMatrix(object):
             bmir = BlockMatrixAgg(self._bmir, [], self.block_size, [])
             return BlockMatrix(bmir)[0, 0]
         elif axis == 0 or axis == 1:
-            out_index_expr = [1] if axis == 0 else [0]
+            out_index_expr = [dim for dim in range(len(self.shape)) if dim != axis]
 
             bmir = BlockMatrixAgg(self._bmir, out_index_expr, self.block_size, [True])
             return BlockMatrix(bmir)

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -347,7 +347,6 @@ case class BlockMatrixBroadcast(
 case class BlockMatrixAgg(
   child: BlockMatrixIR,
   outIndexExpr: IndexedSeq[Int],
-  blockSize: Int,
   dimsPartitioned: IndexedSeq[Boolean]) extends BlockMatrixIR {
 
   assert(outIndexExpr.length < 2)
@@ -356,21 +355,21 @@ case class BlockMatrixAgg(
     val shape = outIndexExpr.map({ i: Int => child.typ.shape(i) }).toIndexedSeq
     val isRowVector = outIndexExpr == IndexedSeq(1)
 
-    BlockMatrixType(child.typ.elementType, shape, isRowVector, blockSize, dimsPartitioned)
+    BlockMatrixType(child.typ.elementType, shape, isRowVector, child.typ.blockSize, dimsPartitioned)
   }
 
   override def children: IndexedSeq[BaseIR] = Array(child)
 
   override def copy(newChildren: IndexedSeq[BaseIR]): BaseIR = {
     assert(newChildren.length == 1)
-    BlockMatrixAgg(newChildren(0).asInstanceOf[BlockMatrixIR], outIndexExpr, blockSize, dimsPartitioned)
+    BlockMatrixAgg(newChildren(0).asInstanceOf[BlockMatrixIR], outIndexExpr, dimsPartitioned)
   }
 
   override protected[ir] def execute(hc: HailContext): BlockMatrix = {
     val childBm = child.execute(hc)
 
     outIndexExpr match {
-      case IndexedSeq() => BlockMatrixIR.toBlockMatrix(hc, nRows = 1, nCols = 1, Array(childBm.sum()), blockSize)
+      case IndexedSeq() => BlockMatrixIR.toBlockMatrix(hc, nRows = 1, nCols = 1, Array(childBm.sum()), typ.blockSize)
       case IndexedSeq(1) => childBm.rowSum()
       case IndexedSeq(0) => childBm.colSum()
     }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -353,13 +353,10 @@ case class BlockMatrixAgg(
   assert(outIndexExpr.length < 2)
 
   override def typ: BlockMatrixType = {
+    val shape = outIndexExpr.map({ i: Int => child.typ.shape(i) }).toIndexedSeq
     val isRowVector = outIndexExpr == IndexedSeq(1)
 
     BlockMatrixType(child.typ.elementType, shape, isRowVector, blockSize, dimsPartitioned)
-  }
-
-  private def shape: IndexedSeq[Long] = {
-    outIndexExpr.map({ i: Int => child.typ.shape(i) }).toIndexedSeq
   }
 
   override def children: IndexedSeq[BaseIR] = Array(child)

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -344,6 +344,42 @@ case class BlockMatrixBroadcast(
   }
 }
 
+case class BlockMatrixAgg(
+  child: BlockMatrixIR,
+  outIndexExpr: IndexedSeq[Int],
+  blockSize: Int,
+  dimsPartitioned: IndexedSeq[Boolean]) extends BlockMatrixIR {
+
+  assert(outIndexExpr.length < 2)
+
+  override def typ: BlockMatrixType = {
+    val isRowVector = outIndexExpr == IndexedSeq(1)
+
+    BlockMatrixType(child.typ.elementType, shape, isRowVector, blockSize, dimsPartitioned)
+  }
+
+  private def shape: IndexedSeq[Long] = {
+    outIndexExpr.map({ i: Int => child.typ.shape(i) }).toIndexedSeq
+  }
+
+  override def children: IndexedSeq[BaseIR] = Array(child)
+
+  override def copy(newChildren: IndexedSeq[BaseIR]): BaseIR = {
+    assert(newChildren.length == 1)
+    BlockMatrixAgg(newChildren(0).asInstanceOf[BlockMatrixIR], outIndexExpr, blockSize, dimsPartitioned)
+  }
+
+  override protected[ir] def execute(hc: HailContext): BlockMatrix = {
+    val childBm = child.execute(hc)
+
+    outIndexExpr match {
+      case IndexedSeq() => BlockMatrixIR.toBlockMatrix(hc, nRows = 1, nCols = 1, Array(childBm.sum()), blockSize)
+      case IndexedSeq(1) => childBm.rowSum()
+      case IndexedSeq(0) => childBm.colSum()
+    }
+  }
+}
+
 case class ValueToBlockMatrix(
   child: IR,
   shape: IndexedSeq[Long],

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1164,6 +1164,12 @@ object IRParser {
         val dimsPartitioned = boolean_literals(it)
         val child = blockmatrix_ir(env)(it)
         BlockMatrixBroadcast(child, inIndexExpr, shape, blockSize, dimsPartitioned)
+      case "BlockMatrixAgg" =>
+        val outIndexExpr = int32_literals(it)
+        val blockSize = int32_literal(it)
+        val dimsPartitioned = boolean_literals(it)
+        val child = blockmatrix_ir(env)(it)
+        BlockMatrixAgg(child, outIndexExpr, blockSize, dimsPartitioned)
       case "ValueToBlockMatrix" =>
         val shape = int64_literals(it)
         val blockSize = int32_literal(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1166,10 +1166,9 @@ object IRParser {
         BlockMatrixBroadcast(child, inIndexExpr, shape, blockSize, dimsPartitioned)
       case "BlockMatrixAgg" =>
         val outIndexExpr = int32_literals(it)
-        val blockSize = int32_literal(it)
         val dimsPartitioned = boolean_literals(it)
         val child = blockmatrix_ir(env)(it)
-        BlockMatrixAgg(child, outIndexExpr, blockSize, dimsPartitioned)
+        BlockMatrixAgg(child, outIndexExpr, dimsPartitioned)
       case "ValueToBlockMatrix" =>
         val shape = int64_literals(it)
         val blockSize = int32_literal(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -204,9 +204,8 @@ object Pretty {
               prettyLongs(shape) + " " +
               blockSize.toString + " " +
               prettyBooleans(dimsPartitioned)
-            case BlockMatrixAgg(_, outIndexExpr, blockSize, dimsPartitioned) =>
+            case BlockMatrixAgg(_, outIndexExpr, dimsPartitioned) =>
               prettyInts(outIndexExpr) + " " +
-              blockSize.toString + " " +
               prettyBooleans(dimsPartitioned)
             case ValueToBlockMatrix(_, shape, blockSize, dimsPartitioned) =>
               prettyLongs(shape) + " " +

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -204,6 +204,10 @@ object Pretty {
               prettyLongs(shape) + " " +
               blockSize.toString + " " +
               prettyBooleans(dimsPartitioned)
+            case BlockMatrixAgg(_, outIndexExpr, blockSize, dimsPartitioned) =>
+              prettyInts(outIndexExpr) + " " +
+              blockSize.toString + " " +
+              prettyBooleans(dimsPartitioned)
             case ValueToBlockMatrix(_, shape, blockSize, dimsPartitioned) =>
               prettyLongs(shape) + " " +
               blockSize.toString + " " +


### PR DESCRIPTION
Add IR node for aggregations on a single BlockMatrix. This node assumes `sum` as the aggregator since it's currently the only supported monoid.