### PR TITLE
add CollectDistributedArray IR node

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -27,6 +27,8 @@ object Binds {
         v == n && i == 1
       case ArrayAgg(_, name, _) =>
         v == name && i == 2
+      case CollectDistributedArray(_, _, n1, n2, _) =>
+        (v == n1 || v == n2) && i == 2
       case _ =>
         false
     }

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -136,5 +136,6 @@ object Children {
     case MatrixToValueApply(child, _) => IndexedSeq(child)
     // from BlockMatrixIR
     case BlockMatrixWrite(child, _, _, _, _) => IndexedSeq(child)
+    case CollectDistributedArray(ctxs, globals, _, _, body) => IndexedSeq(ctxs, globals, body)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
@@ -15,6 +15,7 @@ object Compilable {
       case _: TableToValueApply => false
       case _: MatrixToValueApply => false
       case _: Literal => false
+      case _: CollectDistributedArray => false
 
       case _ => true
     }

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -205,9 +205,9 @@ object Copy {
       case BlockMatrixWrite(_, path, overwrite, forceRowMajor, stageLocally) =>
         val IndexedSeq(newChild: BlockMatrixIR) = newChildren
         BlockMatrixWrite(newChild, path, overwrite, forceRowMajor, stageLocally)
-      case CollectDistributedArray(_, _, ctxName, globalsName, _) =>
+      case CollectDistributedArray(_, _, cname, gname, _) =>
         val IndexedSeq(ctxs: IR, globals: IR, newBody: IR) = newChildren
-        CollectDistributedArray(ctxs, globals, ctxName, globalsName, newBody)
+        CollectDistributedArray(ctxs, globals, cname, gname, newBody)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -205,6 +205,9 @@ object Copy {
       case BlockMatrixWrite(_, path, overwrite, forceRowMajor, stageLocally) =>
         val IndexedSeq(newChild: BlockMatrixIR) = newChildren
         BlockMatrixWrite(newChild, path, overwrite, forceRowMajor, stageLocally)
+      case CollectDistributedArray(_, _, ctxName, globalsName, _) =>
+        val IndexedSeq(ctxs: IR, globals: IR, newBody: IR) = newChildren
+        CollectDistributedArray(ctxs, globals, ctxName, globalsName, newBody)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -322,6 +322,8 @@ final case class MatrixToValueApply(child: MatrixIR, function: MatrixToValueFunc
 final case class BlockMatrixWrite(child: BlockMatrixIR, path: String,
   overwrite: Boolean, forceRowMajor: Boolean, stageLocally: Boolean) extends IR
 
+final case class CollectDistributedArray(contexts: IR, globals: IR, contextName: String, globalName: String, body: IR) extends IR
+
 class PrimitiveIR(val self: IR) extends AnyVal {
   def +(other: IR): IR = ApplyBinaryPrimOp(Add(), self, other)
   def -(other: IR): IR = ApplyBinaryPrimOp(Subtract(), self, other)

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -322,7 +322,7 @@ final case class MatrixToValueApply(child: MatrixIR, function: MatrixToValueFunc
 final case class BlockMatrixWrite(child: BlockMatrixIR, path: String,
   overwrite: Boolean, forceRowMajor: Boolean, stageLocally: Boolean) extends IR
 
-final case class CollectDistributedArray(contexts: IR, globals: IR, contextName: String, globalName: String, body: IR) extends IR
+final case class CollectDistributedArray(contexts: IR, globals: IR, cname: String, gname: String, body: IR) extends IR
 
 class PrimitiveIR(val self: IR) extends AnyVal {
   def +(other: IR): IR = ApplyBinaryPrimOp(Add(), self, other)

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -142,6 +142,7 @@ object InferPType {
       case TableCollect(child) => PStruct("rows" -> PArray(PType.canonical(child.typ.rowType)), "global" -> PType.canonical(child.typ.globalType))
       case TableToValueApply(child, function) => PType.canonical(function.typ(child.typ))
       case MatrixToValueApply(child, function) => PType.canonical(function.typ(child.typ))
+      case CollectDistributedArray(_, _, _, _, body) => PArray(body.pType)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -151,6 +151,7 @@ object InferType {
       case TableCollect(child) => TStruct("rows" -> TArray(child.typ.rowType), "global" -> child.typ.globalType)
       case TableToValueApply(child, function) => function.typ(child.typ)
       case MatrixToValueApply(child, function) => function.typ(child.typ)
+      case CollectDistributedArray(_, _, _, _, body) => TArray(body.typ)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -822,6 +822,13 @@ object IRParser {
         val stageLocally = boolean_literal(it)
         val child = blockmatrix_ir(env)(it)
         BlockMatrixWrite(child, path, overwrite, forceRowMajor, stageLocally)
+      case "CollectDistributedArray" =>
+        val cname = identifier(it)
+        val gname = identifier(it)
+        val ctxs = ir_value_expr(env)(it)
+        val globals = ir_value_expr(env)(it)
+        val body = ir_value_expr(env + (cname, coerce[TArray](ctxs.typ).elementType) + (gname, globals.typ))(it)
+        CollectDistributedArray(ctxs, globals, cname, gname, body)
       case "JavaIR" =>
         val name = identifier(it)
         env.irMap(name).asInstanceOf[IR]

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.expr.JSONAnnotationImpex
 import is.hail.expr.ir.functions.RelationalFunctions
+import is.hail.expr.types.virtual.TArray
 import is.hail.table.Ascending
 import is.hail.utils._
 import org.json4s.jackson.{JsonMethods, Serialization}
@@ -180,6 +181,8 @@ object Pretty {
             case In(i, typ) => s"${ typ.parsableString() } $i"
             case Die(message, typ) => typ.parsableString()
             case Uniroot(name, _, _, _) => prettyIdentifier(name)
+            case CollectDistributedArray(_, _, cname, gname, _) =>
+              s"${ prettyIdentifier(cname) } ${ prettyIdentifier(gname) }"
             case MatrixRead(typ, dropCols, dropRows, reader) =>
               (if (typ == reader.fullType) "None" else typ.parsableString()) + " " +
               prettyBooleanLiteral(dropCols) + " " +

--- a/hail/src/main/scala/is/hail/expr/ir/Subst.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Subst.scala
@@ -50,6 +50,8 @@ object Subst {
           initOpArgs.map(arg => MapIR(subst(_))(arg)))
         val substSeqOpArgs = seqOpArgs.map(arg => subst(arg, aggEnv, Env.empty))
         ApplyAggOp(substConstructorArgs, substInitOpArgs, substSeqOpArgs, aggSig)
+      case CollectDistributedArray(contexts, globals, cname, gname, body) =>
+        CollectDistributedArray(subst(contexts, env), subst(globals, env), cname, gname, subst(body, env.delete(cname).delete(gname)))
       case _ =>
         MapIR(subst(_))(e)
     }

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -311,6 +311,11 @@ object TypeCheck {
       case TableToValueApply(_, _) =>
       case MatrixToValueApply(_, _) =>
       case BlockMatrixWrite(_, _, _, _, _) =>
+      case CollectDistributedArray(ctxs, globals, cname, gname, body) =>
+        check(ctxs)
+        assert(ctxs.typ.isInstanceOf[TArray])
+        check(globals)
+        check(body, env = env.bind(cname, coerce[TArray](ctxs.typ).elementType).bind(gname, globals.typ))
     }
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1041,7 +1041,8 @@ class IRSuite extends SparkSuite {
       MatrixWrite(bgen, MatrixGENWriter(tmpDir.createLocalTempFile())),
       MatrixMultiWrite(Array(mt, mt), MatrixNativeMultiWriter(tmpDir.createLocalTempFile())),
       MatrixAggregate(mt, MakeStruct(Seq("foo" -> count))),
-      BlockMatrixWrite(blockMatrix, tmpDir.createLocalTempFile(), false, false, false)
+      BlockMatrixWrite(blockMatrix, tmpDir.createLocalTempFile(), false, false, false),
+      CollectDistributedArray(ArrayRange(0, 3, 1), 1, "x", "y", Ref("x", TInt32()))
     )
     irs.map(x => Array(x))
   }


### PR DESCRIPTION
This adds (but does not implement) a node called CollectDistributedArray, which takes an array of contexts (an array of values that defines the start of a partition of work) and some global values to broadcast and applies `body` to each element of `context`, collecting the result.

Implementation to follow.

cc @cseed