### PR TITLE
Add BlockMatrixToValue IR node

### DIFF
--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1976,6 +1976,29 @@ class MatrixToValueApply(IR):
             self._type = tvoid
 
 
+class BlockMatrixToValueApply(IR):
+    def __init__(self, child, config):
+        super().__init__()
+        self.child = child
+        self.config = config
+
+    @typecheck_method(child=BlockMatrixIR)
+    def copy(self, child):
+        new_instance = self.__class__
+        return new_instance(child, self.config)
+
+    def render(self, r):
+        return f'(BlockMatrixToValueApply {dump_json(self.config)} {r(self.child)})'
+
+    def __eq__(self, other):
+        return isinstance(other, BlockMatrixToValueApply) and other.child == self.child and other.config == self.config
+
+    def _compute_type(self, env, agg_env):
+        name = self.config['name']
+        assert name == 'GetElement'
+        self._type = tfloat64
+
+
 class Literal(IR):
     @typecheck_method(typ=hail_type,
                       value=anytype)

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1994,8 +1994,7 @@ class BlockMatrixToValueApply(IR):
         return isinstance(other, BlockMatrixToValueApply) and other.child == self.child and other.config == self.config
 
     def _compute_type(self, env, agg_env):
-        name = self.config['name']
-        assert name == 'GetElement'
+        assert self.config['name'] == 'GetElement'
         self._type = tfloat64
 
 

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -7,7 +7,8 @@ import hail.expr.aggregators as agg
 from hail.expr import construct_expr
 from hail.ir import BlockMatrixWrite, BlockMatrixMap2, ApplyBinaryOp, Ref, F64, \
     BlockMatrixBroadcast, ValueToBlockMatrix, MakeArray, BlockMatrixRead, JavaBlockMatrix, BlockMatrixMap, \
-    ApplyUnaryOp, IR, BlockMatrixDot, tensor_shape_to_matrix_shape, BlockMatrixAgg, BlockMatrixRandom
+    ApplyUnaryOp, IR, BlockMatrixDot, tensor_shape_to_matrix_shape, BlockMatrixAgg, BlockMatrixRandom, \
+    BlockMatrixToValueApply
 from hail.utils import new_temp_file, new_local_temp_file, local_path_uri, storage_level
 from hail.utils.java import Env, jarray, joption
 from hail.typecheck import *
@@ -802,7 +803,9 @@ class BlockMatrix(object):
         if isinstance(row_idx, int) and isinstance(col_idx, int):
             i = BlockMatrix._pos_index(row_idx, self.n_rows, 'row index')
             j = BlockMatrix._pos_index(col_idx, self.n_cols, 'col index')
-            return self._jbm.getElement(i, j)
+
+            return Env.backend().execute(BlockMatrixToValueApply(self._bmir,
+                                                                 {'name': 'GetElement', 'row': i, 'col': j}))
 
         rows_to_keep = BlockMatrix._range_to_keep(row_idx, self.n_rows)
         cols_to_keep = BlockMatrix._range_to_keep(col_idx, self.n_cols)

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -805,7 +805,7 @@ class BlockMatrix(object):
             j = BlockMatrix._pos_index(col_idx, self.n_cols, 'col index')
 
             return Env.backend().execute(BlockMatrixToValueApply(self._bmir,
-                                                                 {'name': 'GetElement', 'row': i, 'col': j}))
+                                                                 {'name': 'GetElement', 'index': [i, j]}))
 
         rows_to_keep = BlockMatrix._range_to_keep(row_idx, self.n_rows)
         cols_to_keep = BlockMatrix._range_to_keep(col_idx, self.n_cols)

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -198,7 +198,7 @@ case class BlockMatrixMap2(left: BlockMatrixIR, right: BlockMatrixIR, f: IR) ext
           case scalar: Double => scalar
           case oneElementArray: IndexedSeq[Double] => oneElementArray.head
         }
-      case _ => ir.execute(hc).toBreezeMatrix().apply(0, 0)
+      case _ => ir.execute(hc).getElement(row = 0, col = 0)
     }
   }
 
@@ -256,7 +256,7 @@ case class BlockMatrixMap2(left: BlockMatrixIR, right: BlockMatrixIR, f: IR) ext
         assert(right.nRows == 1 && right.nCols == 1)
         // BlockMatrix does not currently support elem-wise pow and this case would
         // only get hit when left and right are both 1x1
-        left.pow(right.toBreezeMatrix().apply(0, 0))
+        left.pow(right.getElement(row = 0, col = 0))
     }
   }
 }
@@ -320,7 +320,7 @@ case class BlockMatrixBroadcast(
 
     inIndexExpr match {
       case IndexedSeq() =>
-        val scalar = childBm.toBreezeMatrix().apply(0,0)
+        val scalar = childBm.getElement(row = 0, col = 0)
         BlockMatrix.fill(hc, nRows, nCols, scalar, blockSize)
       case IndexedSeq(0) => broadcastColVector(hc, childBm.toBreezeMatrix().data, nRows, nCols)
       case IndexedSeq(1) => broadcastRowVector(hc, childBm.toBreezeMatrix().data, nRows, nCols)

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -136,6 +136,7 @@ object Children {
     case MatrixToValueApply(child, _) => IndexedSeq(child)
     // from BlockMatrixIR
     case BlockMatrixWrite(child, _, _, _, _) => IndexedSeq(child)
+    case BlockMatrixToValueApply(child, _) => IndexedSeq(child)
     case CollectDistributedArray(ctxs, globals, _, _, body) => IndexedSeq(ctxs, globals, body)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
@@ -14,6 +14,7 @@ object Compilable {
       case _: BlockMatrixWrite => false
       case _: TableToValueApply => false
       case _: MatrixToValueApply => false
+      case _: BlockMatrixToValueApply => false
       case _: Literal => false
       case _: CollectDistributedArray => false
 

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -198,12 +198,15 @@ object Copy {
       case TableExport(_, path, typesFile, header, exportType, delimiter) =>
         val IndexedSeq(child: TableIR) = newChildren
         TableExport(child, path, typesFile, header, exportType, delimiter)
-      case TableToValueApply(child, function) =>
+      case TableToValueApply(_, function) =>
         val IndexedSeq(newChild: TableIR) = newChildren
         TableToValueApply(newChild, function)
-      case MatrixToValueApply(child, function) =>
+      case MatrixToValueApply(_, function) =>
         val IndexedSeq(newChild: MatrixIR) = newChildren
         MatrixToValueApply(newChild, function)
+      case BlockMatrixToValueApply(_, function) =>
+        val IndexedSeq(newChild: BlockMatrixIR) = newChildren
+        BlockMatrixToValueApply(newChild, function)
       case BlockMatrixWrite(_, path, overwrite, forceRowMajor, stageLocally) =>
         val IndexedSeq(newChild: BlockMatrixIR) = newChildren
         BlockMatrixWrite(newChild, path, overwrite, forceRowMajor, stageLocally)

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -320,6 +320,7 @@ final case class MatrixMultiWrite(
 
 final case class TableToValueApply(child: TableIR, function: TableToValueFunction) extends IR
 final case class MatrixToValueApply(child: MatrixIR, function: MatrixToValueFunction) extends IR
+final case class BlockMatrixToValueApply(child: BlockMatrixIR, function: BlockMatrixToValueFunction) extends IR
 
 final case class BlockMatrixWrite(child: BlockMatrixIR, path: String,
   overwrite: Boolean, forceRowMajor: Boolean, stageLocally: Boolean) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -142,6 +142,7 @@ object InferPType {
       case TableCollect(child) => PStruct("rows" -> PArray(PType.canonical(child.typ.rowType)), "global" -> PType.canonical(child.typ.globalType))
       case TableToValueApply(child, function) => PType.canonical(function.typ(child.typ))
       case MatrixToValueApply(child, function) => PType.canonical(function.typ(child.typ))
+      case BlockMatrixToValueApply(child, function) => PType.canonical(function.typ(child.typ))
       case CollectDistributedArray(_, _, _, _, body) => PArray(body.pType)
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -151,6 +151,7 @@ object InferType {
       case TableCollect(child) => TStruct("rows" -> TArray(child.typ.rowType), "global" -> child.typ.globalType)
       case TableToValueApply(child, function) => function.typ(child.typ)
       case MatrixToValueApply(child, function) => function.typ(child.typ)
+      case BlockMatrixToValueApply(child, function) => function.typ(child.typ)
       case CollectDistributedArray(_, _, _, _, body) => TArray(body.typ)
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -789,6 +789,8 @@ object Interpret {
         function.execute(child.execute(HailContext.get))
       case MatrixToValueApply(child, function) =>
         function.execute(child.execute(HailContext.get))
+      case BlockMatrixToValueApply(child, function) =>
+        function.execute(child.execute(HailContext.get))
       case TableAggregate(child, query) =>
         val localGlobalSignature = child.typ.globalType
         val (rvAggs, initOps, seqOps, aggResultType, postAggIR) = CompileWithAggregators[Long, Long, Long](

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -776,6 +776,10 @@ object IRParser {
         val config = string_literal(it)
         val child = matrix_ir(env)(it)
         MatrixToValueApply(child, RelationalFunctions.lookupMatrixToValue(config))
+      case "BlockMatrixToValueApply" =>
+        val config = string_literal(it)
+        val child = blockmatrix_ir(env)(it)
+        BlockMatrixToValueApply(child, RelationalFunctions.lookupBlockMatrixToValue(config))
       case "TableExport" =>
         val path = string_literal(it)
         val typesFile = opt(it, string_literal).orNull

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -310,6 +310,7 @@ object TypeCheck {
       case TableCollect(_) =>
       case TableToValueApply(_, _) =>
       case MatrixToValueApply(_, _) =>
+      case BlockMatrixToValueApply(_, _) =>
       case BlockMatrixWrite(_, _, _, _, _) =>
       case CollectDistributedArray(ctxs, globals, cname, gname, body) =>
         check(ctxs)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GetElement.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GetElement.scala
@@ -4,8 +4,10 @@ import is.hail.expr.types.BlockMatrixType
 import is.hail.expr.types.virtual.Type
 import is.hail.linalg.BlockMatrix
 
-case class GetElement(row: Long, col: Long) extends BlockMatrixToValueFunction {
+case class GetElement(index: Seq[Long]) extends BlockMatrixToValueFunction {
+  assert(index.length == 2)
+
   override def typ(childType: BlockMatrixType): Type = childType.elementType
 
-  override def execute(bm: BlockMatrix): Any = bm.getElement(row, col)
+  override def execute(bm: BlockMatrix): Any = bm.getElement(index.head, index(1))
 }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GetElement.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GetElement.scala
@@ -1,0 +1,11 @@
+package is.hail.expr.ir.functions
+
+import is.hail.expr.types.BlockMatrixType
+import is.hail.expr.types.virtual.Type
+import is.hail.linalg.BlockMatrix
+
+case class GetElement(row: Long, col: Long) extends BlockMatrixToValueFunction {
+  override def typ(childType: BlockMatrixType): Type = childType.elementType
+
+  override def execute(bm: BlockMatrix): Any = bm.getElement(row, col)
+}

--- a/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
@@ -2,7 +2,8 @@ package is.hail.expr.ir.functions
 
 import is.hail.expr.ir.{MatrixValue, TableValue}
 import is.hail.expr.types.virtual.Type
-import is.hail.expr.types.{MatrixType, TableType}
+import is.hail.expr.types.{BlockMatrixType, MatrixType, TableType}
+import is.hail.linalg.BlockMatrix
 import is.hail.methods._
 import is.hail.rvd.RVDType
 import is.hail.variant.RelationalSpec
@@ -46,6 +47,12 @@ abstract class MatrixToValueFunction {
   def execute(mv: MatrixValue): Any
 }
 
+abstract class BlockMatrixToValueFunction {
+  def typ(childType: BlockMatrixType): Type
+
+  def execute(bm: BlockMatrix): Any
+}
+
 object RelationalFunctions {
   implicit val formats = RelationalSpec.formats + ShortTypeHints(List(
     classOf[LinearRegressionRowsSingle],
@@ -66,7 +73,8 @@ object RelationalFunctions {
     classOf[LocalLDPrune],
     classOf[MatrixExportEntriesByCol],
     classOf[PCA],
-    classOf[VEP]
+    classOf[VEP],
+    classOf[GetElement]
   )) +
     new MatrixFilterIntervalsSerializer +
     new TableFilterIntervalsSerializer
@@ -80,4 +88,5 @@ object RelationalFunctions {
   def lookupTableToTable(config: String): TableToTableFunction = extractTo[TableToTableFunction](config)
   def lookupTableToValue(config: String): TableToValueFunction = extractTo[TableToValueFunction](config)
   def lookupMatrixToValue(config: String): MatrixToValueFunction = extractTo[MatrixToValueFunction](config)
+  def lookupBlockMatrixToValue(config: String): BlockMatrixToValueFunction = extractTo[BlockMatrixToValueFunction](config)
 }


### PR DESCRIPTION
- Added IR node to go from a BlockMatrix to a value
- Added BlockMatrixToValueFunction to get an element at a certain index and used it to access elements in BlockMatrix.__getitem__
- This raises an interesting question of whether accessing an element of a tensor should return a Python value or a Hail expr. Right now, it just builds a BlockMatrixToValue IR and immediately executes it to return a Python number (matches existing behavior), but we could just as easily return the IR node.