### PR TITLE
change BlockMatrix.random parameter from uniform to gaussian

### DIFF
--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -410,8 +410,8 @@ class BlockMatrix(object):
                       n_cols=int,
                       block_size=nullable(int),
                       seed=int,
-                      uniform=bool)
-    def random(cls, n_rows, n_cols, block_size=None, seed=0, uniform=False):
+                      gaussian=bool)
+    def random(cls, n_rows, n_cols, block_size=None, seed=0, gaussian=True):
         """Creates a block matrix with standard normal or uniform random entries.
 
         Examples
@@ -430,10 +430,10 @@ class BlockMatrix(object):
             Block size. Default given by :meth:`default_block_size`.
         seed: :obj:`int`
             Random seed.
-        uniform: :obj:`bool`
-            If ``True``, entries are drawn from the uniform distribution
-            on [0,1]. If ``False``, entries are drawn from the standard
-            normal distribution.
+        gaussian: :obj:`bool`
+            If ``True``, entries are drawn from the standard
+            normal distribution. If ``False``, entries are drawn from
+            the uniform distribution on [0,1].
 
         Returns
         -------
@@ -441,7 +441,7 @@ class BlockMatrix(object):
         """
         if not block_size:
             block_size = BlockMatrix.default_block_size()
-        return BlockMatrix._from_java(Env.hail().linalg.BlockMatrix.random(Env.hc()._jhc, n_rows, n_cols, block_size, seed, uniform))
+        return BlockMatrix._from_java(Env.hail().linalg.BlockMatrix.random(Env.hc()._jhc, n_rows, n_cols, block_size, seed, gaussian))
 
     @classmethod
     @typecheck_method(n_rows=int,

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -94,7 +94,15 @@ class Tests(unittest.TestCase):
 
         BlockMatrix.write_from_entry_expr(mt.x + 2, path2, overwrite=True)
         self._assert_eq(BlockMatrix.read(path2), bm + 2)
-        
+
+    def test_random_uniform(self):
+        uniform = BlockMatrix.random(10, 10, gaussian=False)
+
+        nuniform = uniform.to_numpy()
+        for row in nuniform:
+            for entry in row:
+                assert entry > 0
+
     def test_to_from_numpy(self):
         n_rows = 10
         n_cols = 11


### PR DESCRIPTION
The front-end accepted a boolean flag to make the a random BlockMatrix with a uniform distribution and would default to gaussian, whereas the backend method it's calling accepts a `gaussian` flag. Updated the front-end API to match the backend and added a test to check that matrices made explicitly uniform have no negative values and are (very likely) not gaussian.