### PR TITLE
_prev_nonnull aggregator mark 2

### DIFF
--- a/hail/python/hail/expr/__init__.py
+++ b/hail/python/hail/expr/__init__.py
@@ -4,7 +4,7 @@ from .matrix_type import *
 from .blockmatrix_type import *
 from .expressions import eval, eval_typed
 from .functions import *
-from .functions import _sort_by, _compare
+from .functions import _sort_by, _compare, _values_similar
 __all__ = ['HailType',
            'dtype',
            'tint',
@@ -164,6 +164,6 @@ __all__ = ['HailType',
            'bit_lshift',
            'bit_rshift',
            'bit_not',
+           '_values_similar',
            '_sort_by',
-           '_compare',
-           ]
+           '_compare']

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -1014,7 +1014,6 @@ class Tests(unittest.TestCase):
         t = t.annotate(
             prev = hl.scan._prev_nonnull(
                 hl.or_missing((t.idx % 3) != 0, t.row)))
-        t.show()
         self.assertTrue(
             t.all(hl._values_similar(t.prev.idx,
                                      hl.case()

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -1009,6 +1009,19 @@ class Tests(unittest.TestCase):
         self.assertEqual(df.aggregate(agg.filter(False, agg.any(df.all_true))), False)
         self.assertEqual(df.aggregate(agg.filter(False, agg.all(df.all_true))), True)
 
+    def test_agg_prev_nonnull(self):
+        t = hl.utils.range_table(17, n_partitions=8)
+        t = t.annotate(
+            prev = hl.scan._prev_nonnull(
+                hl.or_missing((t.idx % 3) != 0, t.row)))
+        t.show()
+        self.assertTrue(
+            t.all(hl._values_similar(t.prev.idx,
+                                     hl.case()
+                                     .when(t.idx < 2, hl.null(hl.tint32))
+                                     .when(((t.idx - 1) % 3) == 0, t.idx - 2)
+                                     .default(t.idx - 1))))
+
     def test_str_ops(self):
         s = hl.literal("123")
         self.assertEqual(hl.eval(hl.int32(s)), 123)

--- a/hail/src/main/scala/is/hail/annotations/aggregators/RegionValuePrevNonnullAnnotationAggregator.scala
+++ b/hail/src/main/scala/is/hail/annotations/aggregators/RegionValuePrevNonnullAnnotationAggregator.scala
@@ -18,9 +18,9 @@ class RegionValuePrevNonnullAnnotationAggregator2(
   def this(t: Type) = this(t.physicalType)
 
   val mb = new MemoryBuffer
-  val encoder: Encoder = makeEncoder(mb)
-  val decoder: Decoder = makeDecoder(mb)
-
+  @transient lazy val encoder: Encoder = makeEncoder(mb)
+  @transient lazy val decoder: Decoder = makeDecoder(mb)
+  
   var present: Boolean = false
 
   def seqOp(region: Region, offset: Long, missing: Boolean) {

--- a/hail/src/main/scala/is/hail/annotations/aggregators/RegionValuePrevNonnullAnnotationAggregator.scala
+++ b/hail/src/main/scala/is/hail/annotations/aggregators/RegionValuePrevNonnullAnnotationAggregator.scala
@@ -41,6 +41,7 @@ class RegionValuePrevNonnullAnnotationAggregator2(
 
   def result(rvb: RegionValueBuilder) {
     if (present) {
+      mb.clearPos()
       val p = decoder.readRegionValue(rvb.region)
       rvb.addRegionValue(t, rvb.region, p)
     } else

--- a/hail/src/main/scala/is/hail/annotations/aggregators/RegionValuePrevNonnullAnnotationAggregator.scala
+++ b/hail/src/main/scala/is/hail/annotations/aggregators/RegionValuePrevNonnullAnnotationAggregator.scala
@@ -5,10 +5,6 @@ import is.hail.expr.types.physical.PType
 import is.hail.expr.types.virtual.Type
 import is.hail.io._
 
-// TODO
-// CompiledPackEncoder
-//
-
 class RegionValuePrevNonnullAnnotationAggregator2(
   t: PType,
   makeEncoder: (MemoryBuffer) => Encoder,
@@ -67,7 +63,6 @@ class RegionValuePrevNonnullAnnotationAggregator2(
     present = false
   }
 }
-
 
 class RegionValuePrevNonnullAnnotationAggregator(t: Type) extends RegionValueAggregator {
   var last: Annotation = null

--- a/hail/src/main/scala/is/hail/annotations/aggregators/RegionValuePrevNonnullAnnotationAggregator.scala
+++ b/hail/src/main/scala/is/hail/annotations/aggregators/RegionValuePrevNonnullAnnotationAggregator.scala
@@ -15,6 +15,7 @@ class RegionValuePrevNonnullAnnotationAggregator2(
       val f = EmitPackDecoder(t, t)
       (mb: MemoryBuffer) => new CompiledPackDecoder(new MemoryInputBuffer(mb), f)
     })
+  def this(t: Type) = this(t.physicalType)
 
   val mb = new MemoryBuffer
   val encoder: Encoder = makeEncoder(mb)

--- a/hail/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -211,7 +211,7 @@ object AggOp {
         seqOpArgTypes = Array(classOf[Double], classOf[Double])
       )
 
-    case (PrevNonnull(), Seq(), None, Seq(in)) => CodeAggregator[RegionValuePrevNonnullAnnotationAggregator](in, constrArgTypes = Array(classOf[Type]), seqOpArgTypes = Array(classOf[Long]))
+    case (PrevNonnull(), Seq(), None, Seq(in)) => CodeAggregator[RegionValuePrevNonnullAnnotationAggregator2](in, constrArgTypes = Array(classOf[Type]), seqOpArgTypes = Array(classOf[Long]))
   }
 
   private def incompatible(aggSig: AggSignature): Nothing = {

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -29,27 +29,9 @@ trait BufferSpec extends Serializable {
 
   def buildOutputBuffer(out: OutputStream): OutputBuffer
 
-  def buildMemoryInputBuffer(mb: MemoryBuffer): InputBuffer = ???
-
-  def buildMemoryOutputBuffer(mb: MemoryBuffer): OutputBuffer = ???
-
   def nativeOutputBufferType: String
 
   def nativeInputBufferType: String
-}
-
-final class MemoryBufferSpec extends BufferSpec {
-  def buildInputBuffer(in: InputStream): InputBuffer = ???
-
-  def buildOutputBuffer(out: OutputStream): OutputBuffer = ???
-
-  override def buildMemoryInputBuffer(mb: MemoryBuffer): InputBuffer = new MemoryInputBuffer(mb)
-
-  override def buildMemoryOutputBuffer(mb: MemoryBuffer): OutputBuffer = new MemoryOutputBuffer(mb)
-
-  def nativeOutputBufferType: String = ???
-
-  def nativeInputBufferType: String = ???
 }
 
 final class LEB128BufferSpec(child: BufferSpec) extends BufferSpec {
@@ -143,10 +125,6 @@ trait CodecSpec extends Serializable {
 
   def buildDecoder(t: PType, requestedType: PType): (InputStream) => Decoder
 
-  def buildMemoryEncoder(t: PType): (MemoryBuffer) => Encoder
-
-  def buildMemoryDecoder(t: PType): (MemoryBuffer) => Decoder
-
   def buildNativeDecoderClass(t: PType, requestedType: PType, tub: cxx.TranslationUnitBuilder): cxx.Class
 
   def buildNativeEncoderClass(t: PType, tub: cxx.TranslationUnitBuilder): cxx.Class
@@ -217,10 +195,6 @@ final case class PackCodecSpec(child: BufferSpec) extends CodecSpec {
       (in: InputStream) => new CompiledPackDecoder(child.buildInputBuffer(in), f)
     }
   }
-
-  def buildMemoryEncoder(t: PType): (MemoryBuffer) => Encoder = (mb: MemoryBuffer) => new PackEncoder(t, child.buildMemoryOutputBuffer(mb))
-
-  def buildMemoryDecoder(t: PType): (MemoryBuffer) => Decoder = (mb: MemoryBuffer) => new PackDecoder(t, child.buildMemoryInputBuffer(mb))
 
   def buildNativeDecoderClass(t: PType, requestedType: PType, tub: cxx.TranslationUnitBuilder): cxx.Class = cxx.PackDecoder(t, requestedType, child, tub)
 

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -253,6 +253,10 @@ final class MemoryBuffer extends Serializable {
     end = 0
   }
 
+  def clearPos() {
+    pos = 0
+  }
+
   def grow(n: Int) {
     capacity = math.max(capacity * 2, end + n)
     mem = util.Arrays.copyOf(mem, capacity)
@@ -343,7 +347,7 @@ final class MemoryBuffer extends Serializable {
 
   def readBytes(toRegion: Region, toOff: Long, n: Int) {
     assert(pos + n <= end)
-    Memory.memcpy(toOff, pos, n)
+    Memory.memcpy(toOff, mem, pos, n)
     pos += n
   }
 

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -1,6 +1,7 @@
 package is.hail.io
 
 import java.io._
+import java.util
 
 import is.hail.annotations._
 import is.hail.asm4s._
@@ -28,9 +29,27 @@ trait BufferSpec extends Serializable {
 
   def buildOutputBuffer(out: OutputStream): OutputBuffer
 
+  def buildMemoryInputBuffer(mb: MemoryBuffer): InputBuffer = ???
+
+  def buildMemoryOutputBuffer(mb: MemoryBuffer): OutputBuffer = ???
+
   def nativeOutputBufferType: String
 
   def nativeInputBufferType: String
+}
+
+final class MemoryBufferSpec extends BufferSpec {
+  def buildInputBuffer(in: InputStream): InputBuffer = ???
+
+  def buildOutputBuffer(out: OutputStream): OutputBuffer = ???
+
+  override def buildMemoryInputBuffer(mb: MemoryBuffer): InputBuffer = new MemoryInputBuffer(mb)
+
+  override def buildMemoryOutputBuffer(mb: MemoryBuffer): OutputBuffer = new MemoryOutputBuffer(mb)
+
+  def nativeOutputBufferType: String = ???
+
+  def nativeInputBufferType: String = ???
 }
 
 final class LEB128BufferSpec(child: BufferSpec) extends BufferSpec {
@@ -124,6 +143,10 @@ trait CodecSpec extends Serializable {
 
   def buildDecoder(t: PType, requestedType: PType): (InputStream) => Decoder
 
+  def buildMemoryEncoder(t: PType): (MemoryBuffer) => Encoder
+
+  def buildMemoryDecoder(t: PType): (MemoryBuffer) => Decoder
+
   def buildNativeDecoderClass(t: PType, requestedType: PType, tub: cxx.TranslationUnitBuilder): cxx.Class
 
   def buildNativeEncoderClass(t: PType, tub: cxx.TranslationUnitBuilder): cxx.Class
@@ -195,6 +218,10 @@ final case class PackCodecSpec(child: BufferSpec) extends CodecSpec {
     }
   }
 
+  def buildMemoryEncoder(t: PType): (MemoryBuffer) => Encoder = (mb: MemoryBuffer) => new PackEncoder(t, child.buildMemoryOutputBuffer(mb))
+
+  def buildMemoryDecoder(t: PType): (MemoryBuffer) => Decoder = (mb: MemoryBuffer) => new PackDecoder(t, child.buildMemoryInputBuffer(mb))
+
   def buildNativeDecoderClass(t: PType, requestedType: PType, tub: cxx.TranslationUnitBuilder): cxx.Class = cxx.PackDecoder(t, requestedType, child, tub)
 
   def buildNativeEncoderClass(t: PType, tub: cxx.TranslationUnitBuilder): cxx.Class = cxx.PackEncoder(t, child, tub)
@@ -239,6 +266,192 @@ final class StreamBlockInputBuffer(in: InputStream) extends InputBlockBuffer {
     in.readFully(buf, 0, len)
     len
   }
+}
+
+final class MemoryBuffer extends Serializable {
+  var capacity: Int = 8
+  var mem: Array[Byte] = new Array[Byte](capacity)
+  var pos: Int = 0
+  var end: Int = 0
+
+  def clear() {
+    pos = 0
+    end = 0
+  }
+
+  def grow(n: Int) {
+    capacity = math.max(capacity * 2, end + n)
+    mem = util.Arrays.copyOf(mem, capacity)
+  }
+
+  def copyFrom(src: MemoryBuffer) {
+    mem = util.Arrays.copyOf(src.mem, src.capacity)
+    end = src.end
+    pos = src.pos
+  }
+
+  def writeByte(b: Byte) {
+    if (end + 1 > capacity)
+      grow(1)
+    Memory.storeByte(mem, end, b)
+    end += 1
+  }
+
+  def writeInt(i: Int) {
+    if (end + 4 > capacity)
+      grow(4)
+    Memory.storeInt(mem, end, i)
+    end += 4
+  }
+
+  def writeLong(i: Long) {
+    if (end + 8 > capacity)
+      grow(8)
+    Memory.storeLong(mem, end, i)
+    end += 8
+  }
+
+  def writeFloat(i: Float) {
+    if (end + 4 > capacity)
+      grow(4)
+    Memory.storeFloat(mem, end, i)
+    end += 4
+  }
+
+  def writeDouble(i: Double) {
+    if (end + 8 > capacity)
+      grow(8)
+    Memory.storeDouble(mem, end, i)
+    end += 8
+  }
+
+  def writeBytes(region: Region, off: Long, n: Int) {
+    if (end + n > capacity)
+      grow(n)
+    Memory.memcpy(mem, end, off, n)
+    end += n
+  }
+
+  def readByte(): Byte = {
+    assert(pos + 1 <= end)
+    val b = Memory.loadByte(mem, pos)
+    pos += 1
+    b
+  }
+
+  def readInt(): Int = {
+    assert(pos + 4 <= end)
+    val i = Memory.loadInt(mem, pos)
+    pos += 4
+    i
+  }
+
+  def readLong(): Long = {
+    assert(pos + 8 <= end)
+    val l = Memory.loadLong(mem, pos)
+    pos += 8
+    l
+  }
+
+  def readFloat(): Float = {
+    assert(pos + 4 <= end)
+    val f = Memory.loadFloat(mem, pos)
+    pos += 4
+    f
+  }
+
+  def readDouble(): Double = {
+    assert(pos + 8 <= end)
+    val d = Memory.loadDouble(mem, pos)
+    pos += 8
+    d
+  }
+
+  def readBytes(toRegion: Region, toOff: Long, n: Int) {
+    assert(pos + n <= end)
+    Memory.memcpy(toOff, pos, n)
+    pos += n
+  }
+
+  def skipByte() {
+    assert(pos + 1 <= end)
+    pos += 1
+  }
+
+  def skipInt() {
+    assert(pos + 4 <= end)
+    pos += 4
+  }
+
+  def skipLong() {
+    assert(pos + 8 <= end)
+    pos += 8
+  }
+
+  def skipFloat() {
+    assert(pos + 4 <= end)
+    pos += 4
+  }
+
+  def skipDouble() {
+    assert(pos + 8 <= end)
+    pos += 8
+  }
+
+  def skipBytes(n: Int) {
+    assert(pos + n <= end)
+    pos += n
+  }
+}
+
+final class MemoryInputBuffer(mb: MemoryBuffer) extends InputBuffer {
+  def close() {}
+
+  def readByte(): Byte = mb.readByte()
+
+  def readInt(): Int = mb.readInt()
+
+  def readLong(): Long = mb.readLong()
+
+  def readFloat(): Float = mb.readFloat()
+
+  def readDouble(): Double = mb.readDouble()
+
+  def readBytes(toRegion: Region, toOff: Long, n: Int): Unit = mb.readBytes(toRegion, toOff, n)
+
+  def skipByte(): Unit = mb.skipByte()
+
+  def skipInt(): Unit = mb.skipInt()
+
+  def skipLong(): Unit = mb.skipLong()
+
+  def skipFloat(): Unit = mb.skipFloat()
+
+  def skipDouble(): Unit = mb.skipDouble()
+
+  def skipBytes(n: Int): Unit = mb.skipBytes(n)
+
+  def readDoubles(to: Array[Double], off: Int, n: Int): Unit = ???
+}
+
+final class MemoryOutputBuffer(mb: MemoryBuffer) extends OutputBuffer {
+  def flush() {}
+
+  def close() {}
+
+  def writeByte(b: Byte): Unit = mb.writeByte(b)
+
+  def writeInt(i: Int): Unit = mb.writeInt(i)
+
+  def writeLong(l: Long): Unit = mb.writeLong(l)
+
+  def writeFloat(f: Float): Unit = mb.writeFloat(f)
+
+  def writeDouble(d: Double): Unit = mb.writeDouble(d)
+
+  def writeBytes(region: Region, off: Long, n: Int): Unit = mb.writeBytes(region, off, n)
+
+  def writeDoubles(from: Array[Double], fromOff: Int, n: Int): Unit = ???
 }
 
 trait OutputBuffer extends Closeable {
@@ -413,8 +626,6 @@ final class BlockingOutputBuffer(blockSize: Int, out: OutputBlockBuffer) extends
 }
 
 trait InputBuffer extends Closeable {
-  def decoderId: Int
-
   def close(): Unit
 
   def readByte(): Byte
@@ -454,8 +665,6 @@ final class LEB128InputBuffer(in: InputBuffer) extends InputBuffer {
   def close() {
     in.close()
   }
-
-  def decoderId = 1
 
   def readByte(): Byte = {
     in.readByte()
@@ -559,8 +768,6 @@ final class BlockingInputBuffer(blockSize: Int, in: InputBlockBuffer) extends In
   def close() {
     in.close()
   }
-
-  def decoderId = 0
 
   def readByte(): Byte = {
     ensure(1)


### PR DESCRIPTION
I left in the previous one for testing purposes.  When we're confident the new one dominates, I will remove it.

This is the first of several PRs to speed up densify (and scans and aggregates in general).  The rough plan is:
 - add CompiledPackEncoder so we aren't interpreting types in the prev_nonnull seqOp,
 - make RegionValueAggregator.result staged so we don't use RegionValueBuilder to construct aggregator and scan results

I will  do some more benchmarking at that point.