### PR TITLE
[bugfix] Fix persisting of vep, logistic regression, poisson regression

### DIFF
--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -521,7 +521,7 @@ def vep(dataset: Union[Table, MatrixTable], config, block_size=1000, name='vep',
                                           {'name': 'VEP',
                                            'config': config,
                                            'csq': csq,
-                                           'blockSize': block_size}))
+                                           'blockSize': block_size})).persist()
 
     if csq:
         dataset = dataset.annotate_globals(
@@ -864,7 +864,7 @@ def nirvana(dataset: Union[MatrixTable, Table], config, block_size=500000, name=
         require_table_key_variant(dataset, 'nirvana')
         ht = dataset.select()
 
-    annotations = Table._from_java(Env.hail().methods.Nirvana.apply(ht._jt, config, block_size))
+    annotations = Table._from_java(Env.hail().methods.Nirvana.apply(ht._jt, config, block_size)).persist()
 
     if isinstance(dataset, MatrixTable):
         return dataset.annotate_rows(**{name: annotations[dataset.row_key].nirvana})

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -702,7 +702,7 @@ def logistic_regression_rows(test, y, x, covariates, pass_through=()) -> hail.Ta
     if not y_is_list:
         result = result.transmute(**result.logistic_regression[0])
 
-    return result
+    return result.persist()
 
 @typecheck(test=enumeration('wald', 'lrt', 'score'),
            y=expr_float64,
@@ -776,7 +776,7 @@ def poisson_regression_rows(test, y, x, covariates, pass_through=()) -> Table:
         'passThrough': [x for x in row_fields if x not in mt.row_key]
     }
     
-    return Table(MatrixToTableApply(mt._mir, config))
+    return Table(MatrixToTableApply(mt._mir, config)).persist()
 
 
 @typecheck(y=expr_float64,

--- a/hail/src/main/scala/is/hail/methods/LogisticRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/LogisticRegression.scala
@@ -124,7 +124,7 @@ case class LogisticRegression(
         rv2.set(rv.region, rvb.end())
         rv2
       }
-    }.persist(StorageLevel.MEMORY_AND_DISK)
+    }
 
     TableValue(tableType, BroadcastRow.empty(), newRVD)
   }

--- a/hail/src/main/scala/is/hail/methods/Nirvana.scala
+++ b/hail/src/main/scala/is/hail/methods/Nirvana.scala
@@ -448,7 +448,6 @@ object Nirvana {
             r
           }
       }
-      .persist(StorageLevel.MEMORY_AND_DISK)
 
     val nirvanaRVDType = prev.typ.copy(rowType = (ht.typ.rowType ++ TStruct("nirvana" -> nirvanaSignature)).physicalType)
 

--- a/hail/src/main/scala/is/hail/methods/PoissonRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/PoissonRegression.scala
@@ -101,7 +101,7 @@ case class PoissonRegression(
         rv2.set(rv.region, rvb.end())
         rv2
       }
-    }.persist(StorageLevel.MEMORY_AND_DISK)
+    }
 
     TableValue(tableType, BroadcastRow.empty(), newRVD)
   }

--- a/hail/src/main/scala/is/hail/methods/VEP.scala
+++ b/hail/src/main/scala/is/hail/methods/VEP.scala
@@ -239,7 +239,7 @@ case class VEP(config: String, csq: Boolean, blockSize: Int) extends TableToTabl
           rv.setOffset(rvb.end())
           rv
         }
-      }).persist(StorageLevel.MEMORY_AND_DISK)
+      })
 
     val (globalValue, globalType) =
       if (csq)


### PR DESCRIPTION
None of these methods were appropriately persisting, since the call was
in Scala. Since the Python IR was evaluated each time, the a new RVD
would be created and persisted on each call to backend.execute, and
the previous persisted RVDs would only be used once.

We need to be on the lookout for this pattern as we convert more
operations to MatrixToTableFunctions and friends