### PR TITLE
Compiled pack encoder

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/aggregators/RegionValuePrevNonnullAnnotationAggregator.scala
+++ b/hail/src/main/scala/is/hail/annotations/aggregators/RegionValuePrevNonnullAnnotationAggregator.scala
@@ -10,11 +10,13 @@ class RegionValuePrevNonnullAnnotationAggregator2(
   makeEncoder: (MemoryBuffer) => Encoder,
   makeDecoder: (MemoryBuffer) => Decoder
 ) extends RegionValueAggregator {
-  def this(t: PType) = this(t,
-    (mb: MemoryBuffer) => new PackEncoder(t, new MemoryOutputBuffer(mb)), {
-      val f = EmitPackDecoder(t, t)
-      (mb: MemoryBuffer) => new CompiledPackDecoder(new MemoryInputBuffer(mb), f)
-    })
+  def this(t: PType) = this(t, {
+    val f = EmitPackEncoder(t)
+    (mb: MemoryBuffer) => new CompiledPackEncoder(new MemoryOutputBuffer(mb), f)
+  }, {
+    val f = EmitPackDecoder(t, t)
+    (mb: MemoryBuffer) => new CompiledPackDecoder(new MemoryInputBuffer(mb), f)
+  })
   def this(t: Type) = this(t.physicalType)
 
   val mb = new MemoryBuffer

--- a/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
@@ -95,8 +95,8 @@ object IndexBgen {
     val crvd = BgenRDD(hc.sc, partitions, settings, null)
 
     val codecSpec = CodecSpec.default
-    val makeLeafEncoder = codecSpec.buildEncoder(LeafNodeBuilder.typ(keyType, annotationType).physicalType)
-    val makeInternalEncoder = codecSpec.buildEncoder(InternalNodeBuilder.typ(keyType, annotationType).physicalType)
+    val makeLeafEncoder = codecSpec.buildEncoder(LeafNodeBuilder.typ(indexKeyType, annotationType).physicalType)
+    val makeInternalEncoder = codecSpec.buildEncoder(InternalNodeBuilder.typ(indexKeyType, annotationType).physicalType)
 
     RVD.unkeyed(rowType, crvd)
       .repartition(partitioner, shuffle = true)

--- a/hail/src/main/scala/is/hail/utils/richUtils/Implicits.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/Implicits.scala
@@ -6,9 +6,8 @@ import breeze.linalg.DenseMatrix
 import is.hail.annotations.aggregators.RegionValueAggregator
 import is.hail.annotations.{JoinedRegionValue, Region, RegionValue, RegionValueBuilder}
 import is.hail.asm4s.Code
-import is.hail.io.RichContextRDDRegionValue
+import is.hail.io.{InputBuffer, OutputBuffer, RichContextRDDRegionValue}
 import is.hail.rvd.RVDContext
-import is.hail.io.{InputBuffer, RichContextRDDRegionValue}
 import is.hail.sparkextras._
 import is.hail.utils.{ArrayBuilder, HailIterator, JSONWriter, MultiArray2, Truncatable, WithContext}
 import org.apache.hadoop
@@ -127,4 +126,6 @@ trait Implicits {
   implicit def toRichContextRDDRow(x: ContextRDD[RVDContext, Row]): RichContextRDDRow = new RichContextRDDRow(x)
 
   implicit def toRichCodeInputBuffer(in: Code[InputBuffer]): RichCodeInputBuffer = new RichCodeInputBuffer(in)
+
+  implicit def toRichCodeOutputBuffer(out: Code[OutputBuffer]): RichCodeOutputBuffer = new RichCodeOutputBuffer(out)
 }

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichCodeOutputBuffer.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichCodeOutputBuffer.scala
@@ -1,0 +1,35 @@
+package is.hail.utils.richUtils
+
+import is.hail.annotations.Region
+import is.hail.asm4s.Code
+import is.hail.io.OutputBuffer
+
+class RichCodeOutputBuffer(out: Code[OutputBuffer]) {
+  def writeBoolean(b: Code[Boolean]): Code[Unit] = {
+    out.invoke[Boolean, Unit]("writeBoolean", b)
+  }
+
+  def writeByte(b: Code[Byte]): Code[Unit] = {
+    out.invoke[Byte, Unit]("writeByte", b)
+  }
+
+  def writeInt(i: Code[Int]): Code[Unit] = {
+    out.invoke[Int, Unit]("writeInt", i)
+  }
+
+  def writeLong(l: Code[Long]): Code[Unit] = {
+    out.invoke[Long, Unit]("writeLong", l)
+  }
+
+  def writeFloat(f: Code[Float]): Code[Unit] = {
+    out.invoke[Float, Unit]("writeFloat", f)
+  }
+
+  def writeDouble(d: Code[Double]): Code[Unit] = {
+    out.invoke[Double, Unit]("writeDouble", d)
+  }
+
+  def writeBytes(region: Code[Region], off: Code[Long], n: Code[Int]): Code[Unit] = {
+    out.invoke[Region, Long, Int, Unit]("writeBytes", region, off, n)
+  }
+}

--- a/hail/src/test/scala/is/hail/io/IndexSuite.scala
+++ b/hail/src/test/scala/is/hail/io/IndexSuite.scala
@@ -40,7 +40,10 @@ class IndexSuite extends SparkSuite {
     annotationType: Type,
     branchingFactor: Int,
     attributes: Map[String, Any]) {
-    val iw = new IndexWriter(hc.hadoopConf, file, keyType, annotationType, branchingFactor, attributes)
+    val codecSpec = CodecSpec.default
+    val makeLeafEncoder = codecSpec.buildEncoder(LeafNodeBuilder.typ(keyType, annotationType).physicalType)
+    val makeInternalEncoder = codecSpec.buildEncoder(InternalNodeBuilder.typ(keyType, annotationType).physicalType)
+    val iw = new IndexWriter(hc.hadoopConf, file, keyType, annotationType, makeLeafEncoder, makeInternalEncoder, branchingFactor, attributes)
     data.zip(annotations).zipWithIndex.foreach { case ((s, a), offset) =>
       iw += (s, offset, a)
     }


### PR DESCRIPTION
Stacked on: https://github.com/hail-is/hail/pull/5414

UnsafeSuite.testCodec verifies this aggressively.  I also turned the up the test count massively in hand testing and everything looks good.

This should give a modest speed boost to writes, shuffles, anything that uses the encoder generally.

Next up is staging the result from RegionValueAggregators.
