### PR TITLE
[batch] Added triple pod to Job

### DIFF
--- a/batch/Makefile
+++ b/batch/Makefile
@@ -16,11 +16,11 @@ build/conda-env: environment.yml
 	mkdir -p build && touch $@
 
 build/flake8: $(PY_FILES) build/conda-env
-	. ../loadconda && conda activate hail-batch && python -m flake8 batch
+	source activate hail-batch && python -m flake8 batch # . ../loadconda && conda
 	mkdir -p build && touch $@
 
 build/pylint: $(PY_FILES) build/conda-env
-	. ../loadconda && conda activate hail-batch && python -m pylint --rcfile batch/pylintrc batch --score=n
+	source activate hail-batch && python -m pylint --rcfile batch/pylintrc batch --score=n #. ../loadconda && conda
 	mkdir -p build && touch $@
 
 build:
@@ -55,11 +55,12 @@ test: push-test
 	  < test-batch-pod.yaml.in > test-batch-pod.yaml
 	kubectl create -f test-batch-pod.yaml
 
+# PY_CHECK = false
 ifneq ($(PY_CHECK),false)
 test-local: $(PY_CHECKERS)
 endif
 test-local: build/conda-env
-	. ../loadconda && conda activate hail-batch && POD_NAMESPACE='test' BATCH_USE_KUBE_CONFIG=1 ./test-locally.sh
+	source activate hail-batch && POD_NAMESPACE='test' BATCH_USE_KUBE_CONFIG=1 ./test-locally.sh # . ../loadconda && conda
 
 # local means server and test client are two processes on one machine
 # in-cluster means in a k8s pod (from which we get k8s creds)

--- a/batch/Makefile
+++ b/batch/Makefile
@@ -16,11 +16,11 @@ build/conda-env: environment.yml
 	mkdir -p build && touch $@
 
 build/flake8: $(PY_FILES) build/conda-env
-	source activate hail-batch && python -m flake8 batch # . ../loadconda && conda
+	. ../loadconda && conda activate hail-batch && python -m flake8 batch
 	mkdir -p build && touch $@
 
 build/pylint: $(PY_FILES) build/conda-env
-	source activate hail-batch && python -m pylint --rcfile batch/pylintrc batch --score=n #. ../loadconda && conda
+	. ../loadconda && conda activate hail-batch && python -m pylint --rcfile batch/pylintrc batch --score=n
 	mkdir -p build && touch $@
 
 build:
@@ -55,12 +55,11 @@ test: push-test
 	  < test-batch-pod.yaml.in > test-batch-pod.yaml
 	kubectl create -f test-batch-pod.yaml
 
-# PY_CHECK = false
 ifneq ($(PY_CHECK),false)
 test-local: $(PY_CHECKERS)
 endif
 test-local: build/conda-env
-	source activate hail-batch && POD_NAMESPACE='test' BATCH_USE_KUBE_CONFIG=1 ./test-locally.sh # . ../loadconda && conda
+	. ../loadconda && conda activate hail-batch && POD_NAMESPACE='test' BATCH_USE_KUBE_CONFIG=1 ./test-locally.sh
 
 # local means server and test client are two processes on one machine
 # in-cluster means in a k8s pod (from which we get k8s creds)

--- a/batch/batch/api.py
+++ b/batch/batch/api.py
@@ -14,7 +14,8 @@ class API():
         """
         self.timeout = timeout
 
-    def create_job(self, url, spec, attributes, batch_id, callback, parent_ids, scratch_folder):
+    def create_job(self, url, spec, attributes, batch_id, callback, parent_ids,
+                   scratch_folder, input_files, output_files):
         doc = {
             'spec': spec,
             'parent_ids': parent_ids
@@ -27,6 +28,10 @@ class API():
             doc['callback'] = callback
         if scratch_folder:
             doc['scratch_folder'] = scratch_folder
+        if input_files:
+            doc['input_files'] = input_files
+        if output_files:
+            doc['output_files'] = output_files
 
         response = requests.post(url + '/jobs/create', json=doc, timeout=self.timeout)
         raise_on_failure(response)
@@ -45,7 +50,7 @@ class API():
     def get_job_log(self, url, job_id):
         response = requests.get(url + '/jobs/{}/log'.format(job_id), timeout=self.timeout)
         raise_on_failure(response)
-        return response.text
+        return response.json()
 
     def delete_job(self, url, job_id):
         response = requests.delete(url + '/jobs/{}/delete'.format(job_id), timeout=self.timeout)
@@ -92,8 +97,11 @@ class API():
 DEFAULT_API = API()
 
 
-def create_job(url, spec, attributes, batch_id, callback, parent_ids, scratch_folder):
-    return DEFAULT_API.create_job(url, spec, attributes, batch_id, callback, parent_ids, scratch_folder)
+def create_job(url, spec, attributes, batch_id, callback, parent_ids, scratch_folder,
+               input_files, output_files):
+    return DEFAULT_API.create_job(url, spec, attributes, batch_id, callback,
+                                  parent_ids, scratch_folder, input_files,
+                                  output_files)
 
 
 def list_jobs(url):

--- a/batch/batch/client.py
+++ b/batch/batch/client.py
@@ -70,12 +70,13 @@ class Batch:
     def create_job(self, image, command=None, args=None, env=None, ports=None,
                    resources=None, tolerations=None, volumes=None, security_context=None,
                    service_account_name=None, attributes=None, callback=None, parent_ids=None,
-                   scratch_folder=None):
+                   scratch_folder=None, input_files=None, output_files=None):
         if parent_ids is None:
             parent_ids = []
         return self.client._create_job(
             image, command, args, env, ports, resources, tolerations, volumes, security_context,
-            service_account_name, attributes, self.id, callback, parent_ids, scratch_folder)
+            service_account_name, attributes, self.id, callback, parent_ids, scratch_folder,
+            input_files, output_files)
 
     def close(self):
         self.client._close_batch(self.id)
@@ -118,7 +119,9 @@ class BatchClient:
                     batch_id,
                     callback,
                     parent_ids,
-                    scratch_folder):
+                    scratch_folder,
+                    input_files,
+                    output_files):
         if env:
             env = [{'name': k, 'value': v} for (k, v) in env.items()]
         else:
@@ -167,7 +170,8 @@ class BatchClient:
         if service_account_name:
             spec['serviceAccountName'] = service_account_name
 
-        j = self.api.create_job(self.url, spec, attributes, batch_id, callback, parent_ids, scratch_folder)
+        j = self.api.create_job(self.url, spec, attributes, batch_id, callback,
+                                parent_ids, scratch_folder, input_files, output_files)
         return Job(self, j['id'], j.get('attributes'), j.get('parent_ids', []))
 
     def _get_job(self, id):
@@ -214,12 +218,15 @@ class BatchClient:
                    attributes=None,
                    callback=None,
                    parent_ids=None,
-                   scratch_folder=None):
+                   scratch_folder=None,
+                   input_files=None,
+                   output_files=None):
         if parent_ids is None:
             parent_ids = []
         return self._create_job(
             image, command, args, env, ports, resources, tolerations, volumes, security_context,
-            service_account_name, attributes, None, callback, parent_ids, scratch_folder)
+            service_account_name, attributes, None, callback, parent_ids, scratch_folder,
+            input_files, output_files)
 
     def create_batch(self, attributes=None, callback=None, ttl=None):
         batch = self.api.create_batch(self.url, attributes, callback, ttl)

--- a/batch/batch/client.py
+++ b/batch/batch/client.py
@@ -140,7 +140,7 @@ class BatchClient:
 
         container = {
             'image': image,
-            'name': 'default'
+            'name': 'main'
         }
         if command:
             container['command'] = command

--- a/batch/batch/server/globals.py
+++ b/batch/batch/server/globals.py
@@ -1,13 +1,13 @@
 import datetime
 import collections
 
-pod_name_job = {}
+pod_name_job_task = {}
 job_id_job = {}
 batch_id_batch = {}
 
 
-def _log_path(id):
-    return f'logs/job-{id}.log'
+def _log_path(id, task_name):
+    return f'logs/job-{id}-{task_name}.log'
 
 
 def _read_file(fname):

--- a/batch/batch/server/globals.py
+++ b/batch/batch/server/globals.py
@@ -1,7 +1,7 @@
 import datetime
 import collections
 
-pod_name_job_task = {}
+pod_name_job = {}
 job_id_job = {}
 batch_id_batch = {}
 

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -90,10 +90,10 @@ class JobTask:  # pylint: disable=R0903
             return JobTask(job_id, task_name, spec)
         return None
 
-    def __init__(self, job, name, pod_spec):
+    def __init__(self, job_id, name, pod_spec):
         assert pod_spec is not None
 
-        metadata = kube.client.V1ObjectMeta(generate_name='job-{}-{}-'.format(job.id, name),
+        metadata = kube.client.V1ObjectMeta(generate_name='job-{}-{}-'.format(job_id, name),
                                             labels={
                                                 'app': 'batch-job',
                                                 'hail.is/batch-instance': instance_id,
@@ -181,9 +181,9 @@ class Job:
         self.exit_code = None
         self._state = 'Created'
 
-        self._tasks = [JobTask.copy_task(self, 'input', input_files),
-                       JobTask(self, 'main', pod_spec),
-                       JobTask.copy_task(self, 'output', output_files)]
+        self._tasks = [JobTask.copy_task(self.id, 'input', input_files),
+                       JobTask(self.id, 'main', pod_spec),
+                       JobTask.copy_task(self.id, 'output', output_files)]
 
         self._tasks = [t for t in self._tasks if t is not None]
         self._task_idx = -1

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -20,8 +20,8 @@ class Test(unittest.TestCase):
         self.assertEqual(status['state'], 'Complete')
         self.assertEqual(status['exit_code'], 0)
 
-        self.assertEqual(status['log'], 'test\n')
-        self.assertEqual(j.log(), 'test\n')
+        self.assertEqual(status['log']['main'], 'test\n')
+        self.assertEqual(j.log(), {'main': 'test\n'})
 
         self.assertTrue(j.is_complete())
 
@@ -70,7 +70,7 @@ class Test(unittest.TestCase):
         id = j.id
         j.wait()
         j.delete()
-        self.assertEqual(self.batch._get_job_log(id), 'test\n')
+        self.assertEqual(self.batch._get_job_log(id), {'main': 'test\n'})
 
     def test_delete_job(self):
         j = self.batch.create_job('alpine', ['sleep', '30'])
@@ -183,3 +183,80 @@ class Test(unittest.TestCase):
         finally:
             server.shutdown()
             server.join()
+
+    def test_inputs(self):
+        j = self.batch.create_job('alpine', ['echo', 'main'], input_files=['foo'])
+        status = j.wait()
+        self.assertTrue('attributes' not in status)
+        self.assertEqual(status['state'], 'Complete')
+        self.assertEqual(status['exit_code'], 0)
+
+        self.assertEqual(status['log'], {'main': 'main\n', 'input': 'hello\n'})
+        self.assertEqual(j.log(), {'main': 'main\n', 'input': 'hello\n'})
+
+        self.assertTrue(j.is_complete())
+
+    def test_outputs(self):
+        j = self.batch.create_job('alpine', ['echo', 'main'], output_files=['foo'])
+        status = j.wait()
+        self.assertTrue('attributes' not in status)
+        self.assertEqual(status['state'], 'Complete')
+        self.assertEqual(status['exit_code'], 0)
+
+        self.assertEqual(status['log'], {'main': 'main\n', 'output': 'hello\n'})
+        self.assertEqual(j.log(), {'main': 'main\n', 'output': 'hello\n'})
+
+        self.assertTrue(j.is_complete())
+
+    def test_inputs_and_outputs(self):
+        j = self.batch.create_job('alpine', ['echo', 'main'],
+                                  input_files=['foo_in'], output_files=['foo_out'])
+        status = j.wait()
+        self.assertTrue('attributes' not in status)
+        self.assertEqual(status['state'], 'Complete')
+        self.assertEqual(status['exit_code'], 0)
+
+        self.assertEqual(status['log'], {'main': 'main\n',
+                                         'input': 'hello\n',
+                                         'output': 'hello\n'})
+        self.assertEqual(j.log(), {'main': 'main\n',
+                                   'input': 'hello\n',
+                                   'output': 'hello\n'})
+
+        self.assertTrue(j.is_complete())
+
+    def test_inputs_and_outputs_delete(self):
+        j = self.batch.create_job('alpine', ['sleep', '30'],
+                                  input_files=['foo_in'], output_files=['foo_out'])
+        id = j.id
+        j.delete()
+
+        # verify doesn't exist
+        try:
+            self.batch._get_job(id)
+        except requests.HTTPError as e:
+            if e.response.status_code == 404:
+                pass
+            else:
+                raise
+
+    def test_inputs_outputs_cancel(self):
+        j = self.batch.create_job('alpine', ['sleep', '30'],
+                                  input_files=['foo_in'], output_files=['foo_out'])
+        status = j.status()
+        self.assertTrue(status['state'], 'Created')
+
+        j.cancel()
+
+        status = j.status()
+        self.assertTrue(status['state'], 'Cancelled')
+        self.assertTrue('log' not in status)
+
+        # cancelled job has no log
+        try:
+            j.log()
+        except requests.HTTPError as e:
+            if e.response.status_code == 404:
+                pass
+            else:
+                raise

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -3,6 +3,7 @@ import pkg_resources
 import pytest
 import re
 import requests
+from flask import Response
 
 from batch.client import BatchClient
 
@@ -239,7 +240,7 @@ def test_callback(client):
     @app.route('/test', methods=['POST'])
     def test():
         output.append(request.get_json())
-        return 200
+        return Response(status=200)
 
     try:
         server = ServerThread(app)


### PR DESCRIPTION
I had a choice on how to implement this and I decided to add a JobTask class that takes care of a single pod and the Job changes to just be a manager of the pods. However, I could have done it all within the Job if you think that is clearer. Happy to refactor if needed.

Please look and see if I have enough tests. The tests are passing, but I'm getting this error message. Is this expected or a bug in my code? 

```
INFO	| 2019-02-22 11:48:48,126 	| _internal.py 	| _log:87 | 127.0.0.1 - - [22/Feb/2019 11:48:48] "POST /pod_changed HTTP/1.1" 204 -
INFO	| 2019-02-22 11:48:48,210 	| _internal.py 	| _log:87 | 127.0.0.1 - - [22/Feb/2019 11:48:48] "POST /pod_changed HTTP/1.1" 204 -
INFO	| 2019-02-22 11:48:48,833 	| server.py 	| mark_complete:190 | wrote log for job 61, main task to logs/job-61-main.log
INFO	| 2019-02-22 11:48:48,845 	| server.py 	| set_state:272 | job 61 changed state: Created -> Complete
INFO	| 2019-02-22 11:48:48,851 	| server.py 	| parent_new_state:287 | parent 61 successfully complete for 63
INFO	| 2019-02-22 11:48:48,857 	| server.py 	| parent_new_state:292 | all parents successfully complete for 63, creating pod
INFO	| 2019-02-22 11:48:48,918 	| server.py 	| create_pod:135 | created pod name: job-63-main-qqwb2 for job 63, main task
INFO	| 2019-02-22 11:48:48,929 	| server.py 	| mark_complete:330 | job 61 complete, exit_code 0
INFO	| 2019-02-22 11:48:48,995 	| _internal.py 	| _log:87 | 127.0.0.1 - - [22/Feb/2019 11:48:48] "POST /pod_changed HTTP/1.1" 204 -
[2019-02-22 11:48:49,043] ERROR in app: Exception on /test [POST]
Traceback (most recent call last):
  File "//anaconda/envs/hail-batch/lib/python3.6/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "//anaconda/envs/hail-batch/lib/python3.6/site-packages/flask/app.py", line 1615, in full_dispatch_request
    return self.finalize_request(rv)
  File "//anaconda/envs/hail-batch/lib/python3.6/site-packages/flask/app.py", line 1630, in finalize_request
    response = self.make_response(rv)
  File "//anaconda/envs/hail-batch/lib/python3.6/site-packages/flask/app.py", line 1740, in make_response
    rv = self.response_class.force_type(rv, request.environ)
  File "//anaconda/envs/hail-batch/lib/python3.6/site-packages/werkzeug/wrappers.py", line 885, in force_type
    response = BaseResponse(*_run_wsgi_app(response, environ))
  File "//anaconda/envs/hail-batch/lib/python3.6/site-packages/werkzeug/test.py", line 884, in run_wsgi_app
    app_rv = app(environ, start_response)
TypeError: 'int' object is not callable
```