### PR TITLE
Make all aggregators deterministic

### DIFF
--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -521,19 +521,7 @@ class RVD(
 
   // Aggregating
 
-  def aggregate[U: ClassTag](
-    zeroValue: U
-  )(seqOp: (U, RegionValue) => U,
-    combOp: (U, U) => U
-  ): U = {
-    val clearingSeqOp = { (ctx: RVDContext, u: U, rv: RegionValue) =>
-      val u2 = seqOp(u, rv)
-      ctx.region.clear()
-      u2
-    }
-    crdd.aggregate(zeroValue, clearingSeqOp, combOp)
-  }
-
+  // used in Interpret by TableAggregate, MatrixAggregate
   def aggregateWithPartitionOp[PC, U: ClassTag](
     zeroValue: U,
     makePC: (Int, RVDContext) => PC
@@ -555,6 +543,7 @@ class RVD(
     ac.result()
   }
 
+  // only used by MatrixMapCols
   def treeAggregateWithPartitionOp[PC, U: ClassTag](
     zeroValue: U,
     makePC: (Int, RVDContext) => PC

--- a/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -5,7 +5,6 @@ import org.apache.spark._
 import org.apache.spark.rdd._
 import org.apache.spark.ExposedUtils
 
-import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
 class AssociativeCombiner[U](zero: U, combine: (U, U) => U) {

--- a/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -27,9 +27,11 @@ class AssociativeCombiner[U](zero: U, combine: (U, U) => U) {
     val prevEntry = t.floorEntry(i - 1)
     if (prevEntry != null) {
       val prevtv = prevEntry.getValue
-      prevtv.value = combine(prevtv.value, value)
-      prevtv.end = end
-      return
+      if (prevtv.end == i - 1) {
+        prevtv.value = combine(prevtv.value, value)
+        prevtv.end = end
+        return
+      }
     }
 
     t.put(i, TreeValue(value, end))

--- a/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/ContextRDD.scala
@@ -5,6 +5,7 @@ import org.apache.spark._
 import org.apache.spark.rdd._
 import org.apache.spark.ExposedUtils
 
+import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
 class AssociativeCombiner[U](zero: U, combine: (U, U) => U) {
@@ -23,8 +24,9 @@ class AssociativeCombiner[U](zero: U, combine: (U, U) => U) {
       t.remove(i + 1)
     }
 
-    val prevtv = t.get(i - 1)
-    if (prevtv != null) {
+    val prevEntry = t.floorEntry(i - 1)
+    if (prevEntry != null) {
+      val prevtv = prevEntry.getValue
       prevtv.value = combine(prevtv.value, value)
       prevtv.end = end
       return

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -592,6 +592,31 @@ package object utils extends Logging
 
   def point[T]()(implicit t: Pointed[T]): T = t.point
 
+  def singletonElement[T](it: Iterator[T]): T = {
+    val x = it.next()
+    assert(!it.hasNext)
+    x
+  }
+
+  // return partition of the ith item
+  def itemPartition(i: Int, n: Int, k: Int): Int = {
+    assert(n >= 0)
+    assert(k > 0)
+    assert(i >= 0 && i < n)
+    val minItemsPerPartition = n / k
+    val r = n % k
+    if (r == 0)
+      i / minItemsPerPartition
+    else {
+      val maxItemsPerPartition = minItemsPerPartition + 1
+      val crossover = maxItemsPerPartition * r
+      if (i < crossover)
+        i / maxItemsPerPartition
+      else
+        r + ((i - crossover) / minItemsPerPartition)
+    }
+  }
+
   def partition(n: Int, k: Int): Array[Int] = {
     if (k == 0) {
       assert(n == 0)

--- a/hail/src/test/scala/is/hail/utils/UtilsSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/UtilsSuite.scala
@@ -225,4 +225,30 @@ class UtilsSuite extends SparkSuite {
     assert(toMapIfUnique(Seq(1 -> 2, 6 -> 6, 10 -> 2))(x => x % 5) ==
       Left(Map(1 -> Seq(1, 6))))
   }
+
+  @Test def testItemPartition(): Unit = {
+    def test(n: Int, k: Int) {
+      val a = new Array[Int](k)
+      var prevj = 0
+      for (i <- 0 until n) {
+        val j = itemPartition(i, n, k)
+
+        assert(j >= 0)
+        assert(j < k)
+        a(j) += 1
+
+        assert(prevj <= j)
+        prevj = j
+      }
+      val p = partition(n, k)
+      assert(a sameElements p)
+    }
+
+    test(0, 0)
+    test(0, 4)
+    test(2, 4)
+    test(2, 5)
+    test(12, 4)
+    test(12, 5)
+  }
 }


### PR DESCRIPTION
... in the sense that they always aggregate in partition order.

This is achieved by a `AssociativeCombiner` which greedily combOp's aggregator state from adjacent partitions.  I think this is the best you can do.  Later we should have a `CommutativeCombiner` and choose between the two based on the whether the user-level aggregators are (duh) associative (like collect and prev_nonnull) or commutative (like collectAsSet or count).

This is slightly conservative as I converted, with slavish consistency, all aggregators and reducers, included one only used by concordance, which I think is commutative.  I'm OK with that mostly because this is safer and concordance really needs to get rewritten in Python (I think @tpoterba has a draft but it needed some performance work).

FYI @chrisvittal this should fix any prev_nonnull aggregator/scan issues.
