### PR TITLE
[hail] Prevent segfaults when joining two tables using `.join`

### DIFF
--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -983,3 +983,12 @@ def test_large_number_of_fields(tmpdir):
 
 def test_import_many_fields():
     assert_time(lambda: hl.import_table(resource('many_cols.txt')), 5)
+
+def test_segfault():
+    t = hl.utils.range_table(1)
+    t2 = hl.utils.range_table(3)
+    t = t.annotate(foo = [0])
+    t2 = t2.annotate(foo = [0])
+    joined = t.key_by('foo').join(t2.key_by('foo'))
+    joined = joined.filter(hl.is_missing(joined.idx))
+    assert joined.collect() == []

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -448,7 +448,7 @@ class RVD(
         if (f(c, rv))
           true
         else {
-          rv.region.clear()
+          context.r.clear()
           false
         }
       }

--- a/hail/src/main/scala/is/hail/rvd/RVDContext.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDContext.scala
@@ -10,7 +10,7 @@ object RVDContext {
   def fromRegion(region: Region): RVDContext = new RVDContext(region)
 }
 
-class RVDContext(r: Region) extends AutoCloseable {
+class RVDContext(val r: Region) extends AutoCloseable {
   private[this] val children = new mutable.HashSet[AutoCloseable]()
 
   private[this] def own(child: AutoCloseable): Unit = children += child


### PR DESCRIPTION
cc: @tpoterba @patrick-schultz @catoverdrive 

We are not allowed to clear a region we do not own.

Someone should test this doesn't blow memory on a severe filter in the cloud.

---

Prevent segfaults when joining two tables using `t1.join(t2)`. This syntax does a "product join", i.e., a normal join. The `t2[t1.key]` syntax takes only one matching element from `t2` for each element in `t1`. When performing a "product join", hail keeps a side-buffer of region values from the right-hand-side table. This side buffer *must not be cleared* by down stream operations (it is owned by the join node). Unfortunately, hail's filter method was incorrectly clearing regions it might not own. This bug only appeared as a segfault when `t1.join(t2)` was followed by a filter.