### PR TITLE
centralize serializable and broadcasted Hadoop configuration

### DIFF
--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -1336,7 +1336,7 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RVDContext, RegionValue]) e
       hConf.mkDir(path + s + ".mt" + "/entries/rows/parts")
     }
 
-    val sHConfBc = sc.broadcast(new SerializableHadoopConfiguration(hConf))
+    val sHConfBc = HailContext.hadoopConfBc
 
     val fullRowType = t.rowType
     val rowsRVType = MatrixType.getRowType(fullRowType)
@@ -1400,7 +1400,7 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RVDContext, RegionValue]) e
     hConf.mkDir(path + "/rows/rows/parts")
     hConf.mkDir(path + "/entries/rows/parts")
 
-    val sHConfBc = sc.broadcast(new SerializableHadoopConfiguration(hConf))
+    val sHConfBc = HailContext.hadoopConfBc
 
     val nPartitions = crdd.getNumPartitions
     val d = digitsNeeded(nPartitions)

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
@@ -1,5 +1,6 @@
 package is.hail.io.bgen
 
+import is.hail.HailContext
 import is.hail.annotations.{Region, _}
 import is.hail.asm4s._
 import is.hail.expr.types._
@@ -91,7 +92,7 @@ object BgenRDDPartitions extends Logging {
     keyType: Type
   ): (Array[Partition], Array[Interval]) = {
     val hConf = sc.hadoopConfiguration
-    val sHadoopConfBc = sc.broadcast(new SerializableHadoopConfiguration(hConf))
+    val sHadoopConfBc = HailContext.hadoopConfBc
 
     val fileRangeBounds = checkFilesDisjoint(hConf, files, keyType)
     val intervalOrdering = TInterval(keyType).ordering

--- a/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
@@ -64,8 +64,6 @@ object IndexBgen {
 
     val typ = RVDType(settings.typ.physicalType, Array("file_idx", "locus", "alleles"))
 
-    val sHadoopConfBc = hc.sc.broadcast(new SerializableHadoopConfiguration(hConf))
-
     val partitions: Array[Partition] = headers.zipWithIndex.map { case (f, i) =>
       IndexBgenPartition(
         f.path,
@@ -75,7 +73,7 @@ object IndexBgen {
         f.dataStart,
         f.fileByteSize,
         i,
-        sHadoopConfBc)
+        hc.hadoopConfBc)
     }
 
     val rowType = typ.rowType

--- a/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
@@ -33,6 +33,7 @@ object IndexBgen {
     contigRecoding: Map[String, String] = null,
     skipInvalidLoci: Boolean = false) {
     val hConf = hc.hadoopConf
+    val hConfBc = hc.hadoopConfBc
 
     val statuses = LoadBgen.getAllFileStatuses(hConf, files)
     val bgenFilePaths = statuses.map(_.getPath.toString)
@@ -73,7 +74,7 @@ object IndexBgen {
         f.dataStart,
         f.fileByteSize,
         i,
-        hc.hadoopConfBc)
+        hConfBc)
     }
 
     val rowType = typ.rowType
@@ -98,7 +99,7 @@ object IndexBgen {
       .foreachPartition({ it =>
         val partIdx = TaskContext.get.partitionId()
 
-        using(new IndexWriter(sHadoopConfBc.value.value, indexFilePaths(partIdx), indexKeyType, annotationType, attributes = attributes)) { iw =>
+        using(new IndexWriter(hConfBc.value.value, indexFilePaths(partIdx), indexKeyType, annotationType, attributes = attributes)) { iw =>
           it.foreach { r =>
             assert(r.getInt(fileIdxIdx) == partIdx)
             iw += (Row(r(locusIdx), r(allelesIdx)), r.getLong(offsetIdx), Row())

--- a/hail/src/main/scala/is/hail/io/reference/FASTAReader.scala
+++ b/hail/src/main/scala/is/hail/io/reference/FASTAReader.scala
@@ -59,14 +59,12 @@ object FASTAReader {
 
   def apply(hc: HailContext, rg: ReferenceGenome, fastaFile: String, indexFile: String,
     blockSize: Int = 4096, capacity: Int = 100): FASTAReader = {
-    val hConf = new SerializableHadoopConfiguration(hc.hadoopConf)
-
     if (blockSize <= 0)
       fatal(s"'blockSize' must be greater than 0. Found $blockSize.")
     if (capacity <= 0)
       fatal(s"'capacity' must be greater than 0. Found $capacity.")
 
-    new FASTAReader(hConf, rg, fastaFile, indexFile, blockSize, capacity)
+    new FASTAReader(hc.sHadoopConf, rg, fastaFile, indexFile, blockSize, capacity)
   }
 }
 

--- a/hail/src/main/scala/is/hail/io/reference/LiftOver.scala
+++ b/hail/src/main/scala/is/hail/io/reference/LiftOver.scala
@@ -38,10 +38,8 @@ object LiftOver {
     uriPath(localChainFile)
   }
 
-  def apply(hc: HailContext, chainFile: String): LiftOver = {
-    val hConf = new SerializableHadoopConfiguration(hc.hadoopConf)
-    new LiftOver(hConf, chainFile)
-  }
+  def apply(hc: HailContext, chainFile: String): LiftOver =
+    new LiftOver(hc.sHadoopConf, chainFile)
 }
 
 class LiftOver(val hConf: SerializableHadoopConfiguration, val chainFile: String) extends Serializable {

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -954,7 +954,7 @@ class PartitionedVCFRDD(
   @(transient@param) _partitions: Array[Partition]
 ) extends RDD[String](sc, Seq()) {
   protected def getPartitions: Array[Partition] = _partitions
-  val confBc = sc.broadcast(new SerializableHadoopConfiguration(sc.hadoopConfiguration))
+  val confBc = HailContext.hadoopConfBc
 
   def compute(split: Partition, context: TaskContext): Iterator[String] = {
     val p = split.asInstanceOf[PartitionedVCFPartition]
@@ -1025,7 +1025,7 @@ case class MatrixVCFReader(
   private val header1 = parseHeader(reader, headerLines1, arrayElementsRequired = arrayElementsRequired)
 
   if (headerFile.isEmpty) {
-    val confBc = sc.broadcast(new SerializableHadoopConfiguration(hConf))
+    val confBc = HailContext.hadoopConfBc
     val header1Bc = sc.broadcast(header1)
 
     val localReader = reader
@@ -1237,7 +1237,7 @@ case class VCFsReader(
   }
 
   private val fileInfo = {
-    val confBc = sc.broadcast(new SerializableHadoopConfiguration(hConf))
+    val confBc = HailContext.hadoopConfBc
 
     val localLocusType = locusType
     val localReader = new HtsjdkRecordReader(callFields, entryFloatType)

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -165,7 +165,7 @@ object BlockMatrix {
     val rectangles = flattenedRectangles.grouped(4).toArray    
     val dRect = digitsNeeded(rectangles.length)
 
-    val sHadoopBc = hc.sc.broadcast(new SerializableHadoopConfiguration(hc.hadoopConf))
+    val sHadoopBc = HailContext.hadoopConfBc
     val partFilesBc = hc.sc.broadcast(partFiles)
 
     val rdd = hc.sc.parallelize(rectangles.zipWithIndex, numSlices = nPartitions).map { case (r, index) =>
@@ -1572,7 +1572,7 @@ class WriteBlocksRDD(path: String,
   private val rvRowType = rvd.rowPType
 
   private val d = digitsNeeded(gp.numPartitions)
-  private val sHadoopBc = sc.broadcast(new SerializableHadoopConfiguration(sc.hadoopConfiguration))
+  private val sHadoopBc = HailContext.hadoopConfBc
 
   override def getDependencies: Seq[Dependency[_]] =
     Array[Dependency[_]](

--- a/hail/src/main/scala/is/hail/linalg/RowMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/RowMatrix.scala
@@ -189,7 +189,7 @@ class ReadBlocksAsRowsRDD(path: String,
   private val nBlockCols = gp.nBlockCols
   private val blockSize = gp.blockSize
 
-  private val sHadoopBc = sc.broadcast(new SerializableHadoopConfiguration(sc.hadoopConfiguration))
+  private val sHadoopBc = HailContext.hadoopConfBc
 
   protected def getPartitions: Array[Partition] = Array.tabulate(partitionStarts.length - 1)(pi => 
     ReadBlocksAsRowsRDDPartition(pi, partitionStarts(pi), partitionStarts(pi + 1)))

--- a/hail/src/main/scala/is/hail/methods/MatrixExportEntriesByCol.scala
+++ b/hail/src/main/scala/is/hail/methods/MatrixExportEntriesByCol.scala
@@ -2,6 +2,7 @@ package is.hail.methods
 
 import java.io.OutputStreamWriter
 
+import is.hail.HailContext
 import is.hail.annotations.{UnsafeIndexedSeq, UnsafeRow}
 import is.hail.expr.TableAnnotationImpex
 import is.hail.expr.ir.MatrixValue
@@ -41,7 +42,7 @@ case class MatrixExportEntriesByCol(parallelism: Int, path: String, bgzip: Boole
 
       val partFileBase = path + "/tmp/"
 
-      val hConfBc = mv.sparkContext.broadcast(new SerializableHadoopConfiguration(hConf))
+      val hConfBc = HailContext.hadoopConfBc
 
       val extension = if (bgzip) ".tsv.bgz" else ".tsv"
 

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
@@ -2,6 +2,7 @@ package is.hail.utils.richUtils
 
 import java.io._
 
+import is.hail.HailContext
 import is.hail.rvd.RVDContext
 import org.apache.spark.TaskContext
 import is.hail.utils._
@@ -26,7 +27,7 @@ class RichContextRDD[T: ClassTag](crdd: ContextRDD[RVDContext, T]) {
 
     hadoopConf.mkDir(path + "/parts")
 
-    val sHadoopConfBc = sc.broadcast(new SerializableHadoopConfiguration(hadoopConf))
+    val sHadoopConfBc = HailContext.hadoopConfBc
 
     val nPartitions = crdd.getNumPartitions
 

--- a/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -473,7 +473,7 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
 
     var rg = Code.invokeScalaObject[String, ReferenceGenome](ReferenceGenome.getClass, "parse", stringAssembler)
     if (fastaReader != null) {
-      fb.addHadoopConfiguration(fastaReader.hConf)
+      fb.addHadoopConfiguration(HailContext.sHadoopConf)
       rg = rg.invoke[SerializableHadoopConfiguration, String, String, Int, Int, ReferenceGenome](
         "addSequenceFromReader",
         fb.getHadoopConfiguration,
@@ -484,7 +484,7 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
     }
 
     for ((destRG, lo) <- liftoverMaps) {
-      fb.addHadoopConfiguration(lo.hConf)
+      fb.addHadoopConfiguration(HailContext.sHadoopConf)
       rg = rg.invoke[SerializableHadoopConfiguration, String, String, ReferenceGenome](
         "addLiftoverFromHConf",
         fb.getHadoopConfiguration,

--- a/hail/src/test/scala/is/hail/io/TabixSuite.scala
+++ b/hail/src/test/scala/is/hail/io/TabixSuite.scala
@@ -17,7 +17,7 @@ class TabixSuite extends SparkSuite {
   val vcfGzFile = vcfFile + ".gz"
   val vcfGzTbiFile = vcfGzFile + ".tbi"
 
-  lazy val bcConf = hc.sc.broadcast(new SerializableHadoopConfiguration(hc.hadoopConf))
+  lazy val bcConf = hc.hadoopConfBc
   lazy val reader = new TabixReader(vcfGzFile, hc.hadoopConf)
 
   @BeforeTest def initialize() {


### PR DESCRIPTION
Only create serializable and broadcasted HadoopConf once in HailContext and use everywhere else.  I was seeing pipelines with MANY duplicate broadcasts the Hadoop configuration.
