### PR TITLE
Combine locus keyed

### DIFF
--- a/hail/python/hail/experimental/vcf_combiner.py
+++ b/hail/python/hail/experimental/vcf_combiner.py
@@ -120,7 +120,6 @@ def combine_gvcfs(mts):
                           .when(locus == mr.locus, hl.struct(ref=mr.alleles[0], alt=mr.alleles[1]))
                           .or_error("locus before and after minrep differ"))
 
-    mts = [hl.MatrixTable(MatrixKeyRowsBy(mt._mir, ['locus'], is_sorted=True)) for mt in mts]
     mts = [mt.annotate_rows(
         # now minrep'ed (ref, alt) allele pairs
         alleles=hl.bind(lambda ref, locus: mt.alleles[1:].map(lambda alt: min_rep(locus, ref, alt)),
@@ -129,10 +128,7 @@ def combine_gvcfs(mts):
     combined = combine(ts)
     combined = combined.annotate(alleles=fix_alleles(combined.alleles))
     return hl.MatrixTable(
-        MatrixKeyRowsBy(
-            combined._unlocalize_entries('__entries', '__cols', ['s'])._mir,
-            ['locus', 'alleles'],
-            is_sorted=True))
+        combined._unlocalize_entries('__entries', '__cols', ['s'])._mir)
 
 
 @typecheck(lgt=expr_call, la=expr_array(expr_int32))

--- a/hail/python/hail/experimental/vcf_combiner.py
+++ b/hail/python/hail/experimental/vcf_combiner.py
@@ -127,8 +127,7 @@ def combine_gvcfs(mts):
     ts = hl.Table._multi_way_zip_join([localize(mt) for mt in mts], 'data', 'g')
     combined = combine(ts)
     combined = combined.annotate(alleles=fix_alleles(combined.alleles))
-    return hl.MatrixTable(
-        combined._unlocalize_entries('__entries', '__cols', ['s'])._mir)
+    return combined._unlocalize_entries('__entries', '__cols', ['s'])
 
 
 @typecheck(lgt=expr_call, la=expr_array(expr_int32))

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -244,7 +244,7 @@ class VCFTests(unittest.TestCase):
                      'includeEnd': True},
                 ]
         parts_str = json.dumps(parts)
-        vcf1 = hl.import_vcf(path)
+        vcf1 = hl.import_vcf(path).key_rows_by('locus')
         vcf2 = hl.import_vcfs([path], parts_str)[0]
         self.assertEqual(len(parts), vcf2.n_partitions())
         self.assertTrue(vcf1._same(vcf2))
@@ -273,7 +273,7 @@ class VCFTests(unittest.TestCase):
                      'includeEnd': True},
                 ]
         parts_str = json.dumps(parts)
-        vcf1 = hl.import_vcf(path)
+        vcf1 = hl.import_vcf(path).key_rows_by('locus')
         vcf2 = hl.import_vcfs([path], parts_str)[0]
         interval = [hl.parse_locus_interval('[20:13509136-16493533]')]
         filter1 = hl.filter_intervals(vcf1, interval)

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -380,6 +380,8 @@ class HailContext private(val sc: SparkContext,
 
   val flags: HailFeatureFlags = new HailFeatureFlags()
 
+  var checkRVDKeys: Boolean = false
+
   def version: String = is.hail.HAIL_PRETTY_VERSION
 
   def grep(regex: String, files: Seq[String], maxLines: Int = 100) {

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -704,7 +704,7 @@ case class TableMultiWayZipJoin(children: IndexedSeq[TableIR], fieldName: String
     val rvd = RVD(
       typ = newRVDType,
       partitioner = newPartitioner,
-      crdd = ContextRDD.czipNPartitions(repartitionedRVDs.map(_.crdd)) { (ctx, its) =>
+      crdd = ContextRDD.czipNPartitions(repartitionedRVDs.map(_.crdd.boundary)) { (ctx, its) =>
         val orvIters = its.map(it => OrderedRVIterator(localRVDType, it, ctx))
         rvMerger(OrderedRVIterator.multiZipJoin(orvIters))
       })

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -669,7 +669,7 @@ case class TableMultiWayZipJoin(children: IndexedSeq[TableIR], fieldName: String
         rvb.startStruct()
         rvb.addFields(rowType, rv, keyIdx) // Add the key
         rvb.startMissingArray(localDataLength) // add the values
-      var i = 0
+        var i = 0
         while (i < rvs.length) {
           val (rv, j) = rvs(i)
           rvb.setArrayIndex(j)
@@ -686,10 +686,10 @@ case class TableMultiWayZipJoin(children: IndexedSeq[TableIR], fieldName: String
         newRegionValue
       }
     }
-
+    
     val childRVDs = childValues.map(_.rvd)
     val repartitionedRVDs =
-      if (childRVDs(0).partitioner.satisfiesAllowedOverlap(0) &&
+      if (childRVDs(0).partitioner.satisfiesAllowedOverlap(typ.key.length - 1) &&
         childRVDs.forall(rvd => rvd.partitioner == childRVDs(0).partitioner))
         childRVDs
       else {

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -884,7 +884,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
 
     tv.copy(
       typ = typ,
-      rvd = tv.rvd.mapPartitionsWithIndex(RVDType(rTyp.asInstanceOf[PStruct], typ.key), itF))
+      rvd = tv.rvd.mapPartitionsPreservePartitioningWithIndex(RVDType(rTyp.asInstanceOf[PStruct], typ.key), itF))
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -696,6 +696,7 @@ case class TableMultiWayZipJoin(children: IndexedSeq[TableIR], fieldName: String
         info("TableMultiWayZipJoin: repartitioning children")
         val childRanges = childRVDs.flatMap(_.partitioner.rangeBounds)
         val newPartitioner = RVDPartitioner.generate(childRVDs.head.typ.kType.virtualType, childRanges)
+          .strictify
         childRVDs.map(_.repartition(newPartitioner))
       }
     val newPartitioner = repartitionedRVDs(0).partitioner

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -884,7 +884,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
 
     tv.copy(
       typ = typ,
-      rvd = tv.rvd.mapPartitionsPreservePartitioningWithIndex(RVDType(rTyp.asInstanceOf[PStruct], typ.key), itF))
+      rvd = tv.rvd.mapPartitionsWithIndex(RVDType(rTyp.asInstanceOf[PStruct], typ.key), itF))
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -689,9 +689,8 @@ case class TableMultiWayZipJoin(children: IndexedSeq[TableIR], fieldName: String
 
     val childRVDs = childValues.map(_.rvd)
     val repartitionedRVDs =
-      if (childRVDs.forall(rvd =>
-        (rvd.partitioner.rangeBounds sameElements childRVDs(0).partitioner.rangeBounds) &&
-          rvd.partitioner.allowedOverlap == 0))
+      if (childRVDs(0).partitioner.satisfiesAllowedOverlap(0) &&
+        childRVDs.forall(rvd => rvd.partitioner == childRVDs(0).partitioner))
         childRVDs
       else {
         info("TableMultiWayZipJoin: repartitioning children")

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -696,7 +696,6 @@ case class TableMultiWayZipJoin(children: IndexedSeq[TableIR], fieldName: String
         info("TableMultiWayZipJoin: repartitioning children")
         val childRanges = childRVDs.flatMap(_.partitioner.rangeBounds)
         val newPartitioner = RVDPartitioner.generate(childRVDs.head.typ.kType.virtualType, childRanges)
-          .strictify
         childRVDs.map(_.repartition(newPartitioner))
       }
     val newPartitioner = repartitionedRVDs(0).partitioner

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -1259,7 +1259,7 @@ case class VCFsReader(
         colType = TStruct("s" -> TString()),
         colKey = Array("s"),
         rowType = kType ++ vaSignature,
-        rowKey = Array("locus", "alleles"),
+        rowKey = Array("locus"),
         entryType = genotypeSignature)
 
       val partitions = {

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -1223,7 +1223,7 @@ case class VCFsReader(
   referenceGenome.foreach(_.validateContigRemap(contigRecoding))
 
   private val locusType = TLocus.schemaFromRG(referenceGenome)
-  private val rowKeyType = TStruct("locus" -> locusType, "alleles" -> TArray(TString()))
+  private val rowKeyType = TStruct("locus" -> locusType)
 
   val partitioner: RVDPartitioner = {
     val pkType = TArray(TInterval(TStruct("locus" -> locusType)))

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -392,6 +392,17 @@ class RVD(
       crdd.cmapPartitionsWithIndex(f))
   }
 
+  def mapPartitionsPreservePartitioningWithIndex(
+    newTyp: RVDType,
+    f: (Int, RVDContext, Iterator[RegionValue]) => Iterator[RegionValue]
+  ): RVD = {
+    require(newTyp.kType == typ.kType)
+    RVD(
+      newTyp,
+      partitioner,
+      crdd.cmapPartitionsWithIndex(f))
+  }
+
   def zipWithIndex(name: String, partitionCounts: Option[IndexedSeq[Long]] = None): RVD = {
     assert(!typ.key.contains(name))
 

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -1249,7 +1249,7 @@ object RVD {
   ): RVD = {
     if (!HailContext.get.checkRVDKeys)
       return new RVD(typ, partitioner, crdd)
-    
+
     val sc = crdd.sparkContext
 
     val partitionerBc = partitioner.broadcast(sc)

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -1247,6 +1247,9 @@ object RVD {
     partitioner: RVDPartitioner,
     crdd: ContextRDD[RVDContext, RegionValue]
   ): RVD = {
+    if (!HailContext.get.checkRVDKeys)
+      return new RVD(typ, partitioner, crdd)
+    
     val sc = crdd.sparkContext
 
     val partitionerBc = partitioner.broadcast(sc)

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -166,12 +166,15 @@ class RVD(
       val shuffledCRDD = codec.decodeRDD(localRowPType, shuffled.values)
 
       RVD(newType, newPartitioner, shuffledCRDD)
-
-    } else
-      new RVD(
-        typ.copy(key = typ.key.take(newPartitioner.kType.size)),
-        newPartitioner,
-        RepartitionedOrderedRDD2(this, newPartitioner.rangeBounds))
+    } else {
+      if (newPartitioner != partitioner)
+        new RVD(
+          typ.copy(key = typ.key.take(newPartitioner.kType.size)),
+          newPartitioner,
+          RepartitionedOrderedRDD2(this, newPartitioner.rangeBounds))
+      else
+        this
+    }
   }
 
   def naiveCoalesce(maxPartitions: Int): RVD = {

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -392,17 +392,6 @@ class RVD(
       crdd.cmapPartitionsWithIndex(f))
   }
 
-  def mapPartitionsPreservePartitioningWithIndex(
-    newTyp: RVDType,
-    f: (Int, RVDContext, Iterator[RegionValue]) => Iterator[RegionValue]
-  ): RVD = {
-    require(newTyp.kType == typ.kType)
-    RVD(
-      newTyp,
-      partitioner,
-      crdd.cmapPartitionsWithIndex(f))
-  }
-
   def zipWithIndex(name: String, partitionCounts: Option[IndexedSeq[Long]] = None): RVD = {
     assert(!typ.key.contains(name))
 

--- a/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
@@ -98,11 +98,13 @@ class RVDPartitioner(
   def coarsenedRangeBounds(newKeyLen: Int): Array[Interval] =
     rangeBounds.map(_.coarsen(newKeyLen))
 
-  def coarsen(newKeyLen: Int): RVDPartitioner =
+  def coarsen(newKeyLen: Int): RVDPartitioner = {
+    assert(newKeyLen <= kType.size)
     new RVDPartitioner(
       kType.truncate(newKeyLen),
-      coarsenedRangeBounds(newKeyLen)
-    )
+      coarsenedRangeBounds(newKeyLen),
+      math.min(allowedOverlap, newKeyLen))
+  }
 
   def strictify: RVDPartitioner = extendKey(kType)
 

--- a/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
@@ -19,7 +19,7 @@ class RVDPartitioner(
     kType: TStruct,
     rangeBounds: IndexedSeq[Interval],
     allowedOverlap: Int
-  ) = this(kType, rangeBounds.toArray, kType.size)
+  ) = this(kType, rangeBounds.toArray, allowedOverlap)
 
   def this(
     kType: TStruct,
@@ -184,9 +184,10 @@ class RVDPartitioner(
 
   def copy(
     kType: TStruct = kType,
-    rangeBounds: IndexedSeq[Interval] = rangeBounds
+    rangeBounds: IndexedSeq[Interval] = rangeBounds,
+    allowedOverlap: Int = allowedOverlap
   ): RVDPartitioner =
-    new RVDPartitioner(kType, rangeBounds)
+    new RVDPartitioner(kType, rangeBounds, allowedOverlap)
 
   def coalesceRangeBounds(newPartEnd: IndexedSeq[Int]): RVDPartitioner = {
     val newRangeBounds = (-1 +: newPartEnd.init).zip(newPartEnd).map { case (s, e) =>

--- a/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
@@ -13,7 +13,7 @@ class RVDPartitioner(
   // rangeBounds: Array[Interval[kType]]
   // rangeBounds is interval containing all keys within a partition
   val rangeBounds: Array[Interval],
-  allowedOverlap: Int
+  val allowedOverlap: Int
 ) {
   def this(
     kType: TStruct,

--- a/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
@@ -4,6 +4,7 @@ import is.hail.annotations.ExtendedOrdering
 import is.hail.expr.types._
 import is.hail.expr.types.virtual.{TArray, TInterval, TStruct}
 import is.hail.utils._
+import org.apache.commons.lang.builder.HashCodeBuilder
 import org.apache.spark.sql.Row
 import org.apache.spark.{Partitioner, SparkContext}
 import org.apache.spark.broadcast.Broadcast
@@ -13,7 +14,7 @@ class RVDPartitioner(
   // rangeBounds: Array[Interval[kType]]
   // rangeBounds is interval containing all keys within a partition
   val rangeBounds: Array[Interval],
-  val allowedOverlap: Int
+  allowedOverlap: Int
 ) {
   def this(
     kType: TStruct,
@@ -66,8 +67,15 @@ class RVDPartitioner(
 
   override def equals(other: Any): Boolean = other match {
     case that: RVDPartitioner =>
-      this.kType == that.kType && this.rangeBounds == that.rangeBounds
+      this.eq(that) || (this.kType == that.kType && this.rangeBounds.sameElements(that.rangeBounds))
     case _ => false
+  }
+
+  override def hashCode: Int = {
+    val b = new HashCodeBuilder()
+    b.append(kType)
+    rangeBounds.foreach(b.append)
+    b.toHashCode
   }
 
   @transient

--- a/hail/src/test/scala/is/hail/SparkSuite.scala
+++ b/hail/src/test/scala/is/hail/SparkSuite.scala
@@ -7,31 +7,35 @@ import org.apache.spark.sql.SQLContext
 import org.scalatest.testng.TestNGSuite
 
 object SparkSuite {
-  lazy val hc = HailContext(
-    sc = new SparkContext(
-      HailContext.createSparkConf(
-        appName = "Hail.TestNG",
-        master = Option(System.getProperty("hail.master")),
-        local = "local[2]",
-        blockSize = 0)
-        .set("spark.unsafe.exceptionOnMemoryLeak", "true")),
-    logFile = "/tmp/hail.log")
+  lazy val hc: HailContext = {
+    val hc = HailContext(
+      sc = new SparkContext(
+        HailContext.createSparkConf(
+          appName = "Hail.TestNG",
+          master = Option(System.getProperty("hail.master")),
+          local = "local[2]",
+          blockSize = 0)
+          .set("spark.unsafe.exceptionOnMemoryLeak", "true")),
+      logFile = "/tmp/hail.log")
+    if (System.getenv("HAIL_ENABLE_CPP_CODEGEN") != null)
+      SparkSuite.hc.flags.set("cpp", "1")
+    hc.testRVDKeys = true
+    hc
+  }
 }
 
 class SparkSuite extends TestNGSuite {
-  lazy val hc: HailContext = {
-    if (System.getenv("HAIL_ENABLE_CPP_CODEGEN") != null)
-      SparkSuite.hc.flags.set("cpp", "1")
-    SparkSuite.hc
+  def hc: HailContext = SparkSuite.hc
+
+  def sc: SparkContext = hc.sc
+
+  def initializeHailContext() {
+    hc
   }
 
-  lazy val sc: SparkContext = hc.sc
+  def sqlContext: SQLContext = hc.sqlContext
 
-  def initializeHailContext(): Unit = { assert(hc != null) }
-
-  lazy val sqlContext: SQLContext = hc.sqlContext
-
-  lazy val hadoopConf: hadoop.conf.Configuration = hc.hadoopConf
+  def hadoopConf: hadoop.conf.Configuration = hc.hadoopConf
 
   lazy val tmpDir: TempDir = TempDir(hadoopConf)
 }

--- a/hail/src/test/scala/is/hail/SparkSuite.scala
+++ b/hail/src/test/scala/is/hail/SparkSuite.scala
@@ -19,7 +19,7 @@ object SparkSuite {
       logFile = "/tmp/hail.log")
     if (System.getenv("HAIL_ENABLE_CPP_CODEGEN") != null)
       SparkSuite.hc.flags.set("cpp", "1")
-    hc.testRVDKeys = true
+    hc.checkRVDKeys = true
     hc
   }
 }

--- a/hail/src/test/scala/is/hail/SparkSuite.scala
+++ b/hail/src/test/scala/is/hail/SparkSuite.scala
@@ -18,7 +18,7 @@ object SparkSuite {
           .set("spark.unsafe.exceptionOnMemoryLeak", "true")),
       logFile = "/tmp/hail.log")
     if (System.getenv("HAIL_ENABLE_CPP_CODEGEN") != null)
-      SparkSuite.hc.flags.set("cpp", "1")
+      hc.flags.set("cpp", "1")
     hc.checkRVDKeys = true
     hc
   }


### PR DESCRIPTION
First, I changed import_vcfs to return a MatrixTable only keyed by locus, and removed the MatrixKeyRowsBy in combine_gvcfs.  To goal here is to avoid re-buidling an re-broadcasting the partitioner once for each gVCF.  We'll need to re-key at the very end.  I'm not so familiar with the end of the joint calling pipeline.  @chrisvittal can you take care of that?

Second, I don't repartition in TableMultiWayZipJoin if the partitioners all match (which they should in in the joint calling pipeline).  For that to work right, I need allowedOverlap == 0 (or to verify the partitions are in fact disjoint).  Turns out allowedOverlap wasn't being propagated in various places.  I fixed that.

@patrick-schultz can you look at the RVDPartitioner changes?  They just look like oversights to me, but maybe there was a reason why, for example, copy and coarsen wasn't preserving allowedOverlap?

Finally, now the joint calling pipeline/test_combiner_works segfaults, ugh:

```
$ hail -m unittest test.hail.methods.test_impex.VCFTests.test_combiner_works
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x000000010e5fa090, pid=64905, tid=33795
#
# JRE version: Java(TM) SE Runtime Environment (8.0_45-b14) (build 1.8.0_45-b14)
# Java VM: Java HotSpot(TM) 64-Bit Server VM (25.45-b02 mixed mode bsd-amd64 compressed oops)
# Problematic frame:
# J 8877 C1 is.hail.expr.types.physical.PLocus$$anon$1.compare(Lis/hail/annotations/Region;JLis/hail/annotations/Region;J)I (117 bytes) @ 0x000000010e5fa090 [0x000000010e5f9de0+0x2b0]
#
```

The rest of the tests pass (the other Python failures are cascaded failures from test_combiner_works, I double-checked in the hopes of finding an easier example to debug.)  It is pretty clearly related to the no repartition optimization.  If I disable it, test_combiner_works passes.

I haven't tracked this down, but I do have one question @chrisvittal: who's responsible for freeing the inputs (that is, clearing the input regions) to multi-way zip join?  I don't see where that happens.
