### PR TITLE
Implement BlockMatrix.diagonal in the IR

### DIFF
--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1405,18 +1405,18 @@ class BlockMatrix(object):
         return self._apply_map(self._unary_func_ir(hl.log))
 
     def diagonal(self):
-        """Extracts diagonal elements as ndarray.
+        """Extracts diagonal elements as a row vector.
 
         Returns
         -------
-        :class:`numpy.ndarray`
+        :class:`.BlockMatrix`
         """
         diag_bmir = BlockMatrixBroadcast(self._bmir,
                                          [0, 0],
                                          [1, min(self.n_rows, self.n_cols)],
                                          self.block_size,
                                          [True])
-        return BlockMatrix(diag_bmir).to_numpy()
+        return BlockMatrix(diag_bmir)
 
     @typecheck_method(axis=nullable(int))
     def sum(self, axis=None):

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1411,7 +1411,12 @@ class BlockMatrix(object):
         -------
         :class:`numpy.ndarray`
         """
-        return _ndarray_from_jarray(self._jbm.diagonal())
+        diag_bmir = BlockMatrixBroadcast(self._bmir,
+                                         [0, 0],
+                                         [1, min(self.n_rows, self.n_cols)],
+                                         self.block_size,
+                                         [True])
+        return BlockMatrix(diag_bmir).to_numpy()
 
     @typecheck_method(axis=nullable(int))
     def sum(self, axis=None):

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -297,7 +297,6 @@ case class BlockMatrixBroadcast(
   dimsPartitioned: IndexedSeq[Boolean]) extends BlockMatrixIR {
 
   assert(shape.length == 2)
-  assert(inIndexExpr.length < 2 || (inIndexExpr.length == 2 && inIndexExpr(0) != inIndexExpr(1)))
 
   override def typ: BlockMatrixType = {
     val (tensorShape, isRowVector) = BlockMatrixIR.matrixShapeToTensorShape(shape(0), shape(1))
@@ -324,6 +323,7 @@ case class BlockMatrixBroadcast(
         BlockMatrix.fill(hc, nRows, nCols, scalar, blockSize)
       case IndexedSeq(0) => broadcastColVector(hc, childBm.toBreezeMatrix().data, nRows, nCols)
       case IndexedSeq(1) => broadcastRowVector(hc, childBm.toBreezeMatrix().data, nRows, nCols)
+      case IndexedSeq(0, 0) => BlockMatrixIR.toBlockMatrix(hc, nRows, nCols, childBm.diagonal(), blockSize)
       case IndexedSeq(1, 0) => childBm.transpose()
       case IndexedSeq(0, 1) => childBm
     }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -297,6 +297,7 @@ case class BlockMatrixBroadcast(
   dimsPartitioned: IndexedSeq[Boolean]) extends BlockMatrixIR {
 
   assert(shape.length == 2)
+  assert(inIndexExpr.length <= 2 && inIndexExpr.forall(x => x == 0 || x == 1))
 
   override def typ: BlockMatrixType = {
     val (tensorShape, isRowVector) = BlockMatrixIR.matrixShapeToTensorShape(shape(0), shape(1))


### PR DESCRIPTION
Implementation of extracting a diagonal of a matrix in the IR. This can be represented by saying that given a matrix of indices `[i, j]`, I am going to take entries corresponding to an index expression of `[i, i]` (or in the code `[0, 0]`).

Also made the method return a `BlockMatrix` instead of numpy `ndarray` so we don't unnecessarily force the IR execution. @jbloom22 thoughts on the user-facing change?