### PR TITLE
fix _sort_by test, Interpret behavior with missing comparison

### DIFF
--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -1923,8 +1923,11 @@ class Tests(unittest.TestCase):
 
     def test_sort_by(self):
         self.assertEqual(hl.eval(hl._sort_by(["c", "aaa", "bb", hl.null(hl.tstr)], lambda l, r: hl.len(l) < hl.len(r))), ["c", "bb", "aaa", None])
-        self.assertEqual(hl.eval(hl._sort_by([hl.Struct(x=i, y="foo", z=5.5) for i in [5, 3, 8, 2, 5, hl.null(hl.tint32)]], lambda l, r: l.x < r.x)),
-                         [hl.Struct(x=i, y="foo", z=5.5) for i in [2, 3, 5, 5, 8, None]])
+        self.assertEqual(hl.eval(hl._sort_by([hl.Struct(x=i, y="foo", z=5.5) for i in [5, 3, 8, 2, 5]], lambda l, r: l.x < r.x)),
+                         [hl.Struct(x=i, y="foo", z=5.5) for i in [2, 3, 5, 5, 8]])
+        with self.assertRaises(hl.utils.java.FatalError):
+            self.assertEqual(hl.eval(hl._sort_by([hl.Struct(x=i, y="foo", z=5.5) for i in [5, 3, 8, 2, 5, hl.null(hl.tint32)]], lambda l, r: l.x < r.x)),
+                             [hl.Struct(x=i, y="foo", z=5.5) for i in [2, 3, 5, 5, 8, None]])
 
     def test_bool_r_ops(self):
         self.assertTrue(hl.eval(hl.literal(True) & True))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1185,7 +1185,7 @@ private class Emit(
     val sort = f.newMethod[Region, T, Boolean, T, Boolean, Boolean]
     val EmitTriplet(setup, m, v) = new Emit(sort, 1).emit(newIR, newEnv)
 
-    sort.emit(Code(setup, m.mux(Code._fatal("result of sorting function cannot be missing"), v)))
+    sort.emit(Code(setup, m.mux(Code._fatal("Result of sorting function cannot be missing."), v)))
     f.apply_method.emit(Code(sort.invoke(fregion, f.getArg[T](1), false, f.getArg[T](2), false)))
     f
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -294,7 +294,10 @@ object Interpret {
         else {
           aValue.asInstanceOf[IndexedSeq[Any]].sortWith { (left, right) =>
             if (left != null && right != null) {
-              interpret(compare, env.bind(l, left).bind(r, right), args, agg).asInstanceOf[Boolean]
+              val res = interpret(compare, env.bind(l, left).bind(r, right), args, agg)
+              if (res == null)
+                fatal("Result of sorting function cannot be missing.")
+              res.asInstanceOf[Boolean]
             } else {
               right == null
             }


### PR DESCRIPTION
if the comparison returns missing for two non-missing values, we throw an error (and user-facing comparison functions are constructed to never hit this case). I accidentally did this in one of the test cases and the interpreter didn't have the same behavior so the tests were passing. I've fixed the Interpret behavior as well; this was caught in the tests for #5283.