### PR TITLE
Add support for typechecking IRs in full relational IR

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -41,7 +41,7 @@ object Emit {
     fb: EmitFunctionBuilder[_],
     env: E,
     nSpecialArguments: Int): EmitTriplet = {
-    TypeCheck(ir)
+    TypeCheck(ir, Env.empty[Type], None)
     new Emit(fb.apply_method, nSpecialArguments).emit(ir, env)
   }
 }


### PR DESCRIPTION
I don't add typecheck rules for the relational nodes themselves,
but this is now very easy to add.