### PR TITLE
Notebook2: add libsass to docker image

### DIFF
--- a/notebook2/Dockerfile
+++ b/notebook2/Dockerfile
@@ -15,7 +15,8 @@ RUN apk add \
   flask \
   Flask_Sockets \
   kubernetes \
-  'urllib3<1.24'
+  'urllib3<1.24'\
+  libsass
 
 COPY notebook /notebook
 COPY notebook-worker-images /notebook


### PR DESCRIPTION
Dependency was only added to environment.yml, causing the container to fail to run. Would be nice if we could specify in one place.