### PR TITLE
Remove dims partitioned from BlockMatrixIR constructors

### DIFF
--- a/hail/python/hail/expr/blockmatrix_type.py
+++ b/hail/python/hail/expr/blockmatrix_type.py
@@ -10,46 +10,39 @@ class tblockmatrix(object):
             dtype(jtbm.elementType().toString()),
             jiterable_to_list(jtbm.shape()),
             jtbm.isRowVector(),
-            jtbm.blockSize(),
-            jiterable_to_list(jtbm.dimsPartitioned()))
+            jtbm.blockSize())
 
     @staticmethod
     def _from_json(json):
         return tblockmatrix(dtype(json['elementType']),
                             json['shape'],
                             json['isRowVector'],
-                            json['blockSize'],
-                            json['dimsPartitioned'])
+                            json['blockSize'])
 
-    @typecheck_method(element_type=hail_type, shape=sequenceof(int), is_row_vector=bool,
-                      block_size=int, dims_partitioned=sequenceof(bool))
-    def __init__(self, element_type, shape, is_row_vector, block_size, dims_partitioned):
+    @typecheck_method(element_type=hail_type, shape=sequenceof(int), is_row_vector=bool, block_size=int)
+    def __init__(self, element_type, shape, is_row_vector, block_size):
         self.element_type = element_type
         self.shape = shape
         self.is_row_vector = is_row_vector
         self.block_size = block_size
-        self.dims_partitioned = dims_partitioned
 
     def __eq__(self, other):
         return isinstance(other, tblockmatrix) and \
                self.element_type == other.element_type and \
                self.shape == other.shape and \
                self.is_row_vector == other.is_row_vector and \
-               self.block_size == other.block_size and \
-               self.dims_partitioned == other.dims_partitioned
+               self.block_size == other.block_size
 
     def __hash__(self):
         return 43 + hash(str(self))
 
     def __repr__(self):
         return f'tblockmatrix(element_type={self.element_type!r}, shape={self.shape!r}, ' \
-            f'is_row_vector={self.is_row_vector!r}, block_size={self.block_size!r}, ' \
-            f'dims_partitioned={self.dims_partitioned!r})'
+            f'is_row_vector={self.is_row_vector!r}, block_size={self.block_size!r})'
 
     def __str__(self):
         return f'blockmatrix {{element_type: {self.element_type}, shape: {self.shape}, ' \
-            f'is_row_vector: {self.is_row_vector}, block_size: {self.block_size}, ' \
-            f'dims_partitioned: {self.dims_partitioned}}}'
+            f'is_row_vector: {self.is_row_vector}, block_size: {self.block_size})'
 
     def pretty(self, indent=0, increment=4):
         l = []
@@ -74,9 +67,6 @@ class tblockmatrix(object):
         l.append('block_size: ')
         self.block_size._pretty(l, indent, increment)
         l.append(',\n')
-
-        l.append(' ' * indent)
-        l.append(f'dims_partitioned: [{self.dims_partitioned}],\n')
 
         indent -= increment
         l.append(' ' * indent)

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -78,22 +78,19 @@ class BlockMatrixBroadcast(BlockMatrixIR):
     @typecheck_method(child=BlockMatrixIR,
                       in_index_expr=sequenceof(int),
                       shape=sequenceof(int),
-                      block_size=int,
-                      dims_partitioned=sequenceof(bool))
-    def __init__(self, child, in_index_expr, shape, block_size, dims_partitioned):
+                      block_size=int)
+    def __init__(self, child, in_index_expr, shape, block_size):
         super().__init__()
         self.child = child
         self.in_index_expr = in_index_expr
         self.shape = shape
         self.block_size = block_size
-        self.dims_partitioned = dims_partitioned
 
     def render(self, r):
-        return '(BlockMatrixBroadcast {} {} {} {} {})'\
+        return '(BlockMatrixBroadcast {} {} {} {})'\
             .format(_serialize_list(self.in_index_expr),
                     _serialize_list(self.shape),
                     self.block_size,
-                    _serialize_list(self.dims_partitioned),
                     r(self.child))
 
     def _compute_type(self):
@@ -103,23 +100,20 @@ class BlockMatrixBroadcast(BlockMatrixIR):
                                   tensor_shape,
                                   is_row_vector,
                                   self.block_size,
-                                  self.dims_partitioned)
+                                  [True for _ in tensor_shape])
 
 
 class BlockMatrixAgg(BlockMatrixIR):
     @typecheck_method(child=BlockMatrixIR,
-                      out_index_expr=sequenceof(int),
-                      dims_partitioned=sequenceof(bool))
-    def __init__(self, child, out_index_expr, dims_partitioned):
+                      out_index_expr=sequenceof(int))
+    def __init__(self, child, out_index_expr):
         super().__init__()
         self.child = child
         self.out_index_expr = out_index_expr
-        self.dims_partitioned = dims_partitioned
 
     def render(self, r):
-        return '(BlockMatrixAgg {} {} {})' \
+        return '(BlockMatrixAgg {} {})' \
             .format(_serialize_list(self.out_index_expr),
-                    _serialize_list(self.dims_partitioned),
                     r(self.child))
 
     def _compute_type(self):
@@ -130,26 +124,23 @@ class BlockMatrixAgg(BlockMatrixIR):
                                   shape,
                                   is_row_vector,
                                   self.child.typ.block_size,
-                                  self.dims_partitioned)
+                                  [True for _ in shape])
 
 
 class ValueToBlockMatrix(BlockMatrixIR):
     @typecheck_method(child=IR,
                       shape=sequenceof(int),
-                      block_size=int,
-                      dims_partitioned=sequenceof(bool))
-    def __init__(self, child, shape, block_size, dims_partitioned):
+                      block_size=int)
+    def __init__(self, child, shape, block_size):
         super().__init__()
         self.child = child
         self.shape = shape
         self.block_size = block_size
-        self.dims_partitioned = dims_partitioned
 
     def render(self, r):
-        return '(ValueToBlockMatrix {} {} {} {})'.format(_serialize_list(self.shape),
-                                                         self.block_size,
-                                                         _serialize_list(self.dims_partitioned),
-                                                         r(self.child))
+        return '(ValueToBlockMatrix {} {} {})'.format(_serialize_list(self.shape),
+                                                      self.block_size,
+                                                      r(self.child))
 
     def _compute_type(self):
         child_type = self.child.typ
@@ -164,29 +155,26 @@ class ValueToBlockMatrix(BlockMatrixIR):
                                   tensor_shape,
                                   is_row_vector,
                                   self.block_size,
-                                  self.dims_partitioned)
+                                  [True for _ in tensor_shape])
 
 
 class BlockMatrixRandom(BlockMatrixIR):
     @typecheck_method(seed=int,
                       gaussian=bool,
                       shape=sequenceof(int),
-                      block_size=int,
-                      dims_partitioned=sequenceof(bool))
-    def __init__(self, seed, gaussian, shape, block_size, dims_partitioned):
+                      block_size=int)
+    def __init__(self, seed, gaussian, shape, block_size):
         super().__init__()
         self.seed = seed
         self.gaussian = gaussian
         self.shape = shape
         self.block_size = block_size
-        self.dims_partitioned = dims_partitioned
 
     def render(self, r):
-        return '(BlockMatrixRandom {} {} {} {} {})'.format(self.seed,
-                                                           self.gaussian,
-                                                           _serialize_list(self.shape),
-                                                           self.block_size,
-                                                           _serialize_list(self.dims_partitioned))
+        return '(BlockMatrixRandom {} {} {} {})'.format(self.seed,
+                                                        self.gaussian,
+                                                        _serialize_list(self.shape),
+                                                        self.block_size)
 
     def _compute_type(self):
         assert len(self.shape) == 2
@@ -196,7 +184,7 @@ class BlockMatrixRandom(BlockMatrixIR):
                                   tensor_shape,
                                   is_row_vector,
                                   self.block_size,
-                                  self.dims_partitioned)
+                                  [True for _ in tensor_shape])
 
 
 class JavaBlockMatrix(BlockMatrixIR):

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -70,8 +70,7 @@ class BlockMatrixDot(BlockMatrixIR):
         self._type = tblockmatrix(self.left.typ.element_type,
                                   tensor_shape,
                                   is_row_vector,
-                                  self.left.typ.block_size,
-                                  [True for _ in tensor_shape])
+                                  self.left.typ.block_size)
 
 
 class BlockMatrixBroadcast(BlockMatrixIR):
@@ -99,8 +98,7 @@ class BlockMatrixBroadcast(BlockMatrixIR):
         self._type = tblockmatrix(self.child.typ.element_type,
                                   tensor_shape,
                                   is_row_vector,
-                                  self.block_size,
-                                  [True for _ in tensor_shape])
+                                  self.block_size)
 
 
 class BlockMatrixAgg(BlockMatrixIR):
@@ -123,8 +121,7 @@ class BlockMatrixAgg(BlockMatrixIR):
         self._type = tblockmatrix(self.child.typ.element_type,
                                   shape,
                                   is_row_vector,
-                                  self.child.typ.block_size,
-                                  [True for _ in shape])
+                                  self.child.typ.block_size)
 
 
 class ValueToBlockMatrix(BlockMatrixIR):
@@ -151,11 +148,7 @@ class ValueToBlockMatrix(BlockMatrixIR):
 
         assert len(self.shape) == 2
         tensor_shape, is_row_vector = _matrix_shape_to_tensor_shape(self.shape[0], self.shape[1])
-        self._type = tblockmatrix(element_type,
-                                  tensor_shape,
-                                  is_row_vector,
-                                  self.block_size,
-                                  [True for _ in tensor_shape])
+        self._type = tblockmatrix(element_type, tensor_shape, is_row_vector, self.block_size)
 
 
 class BlockMatrixRandom(BlockMatrixIR):
@@ -180,11 +173,7 @@ class BlockMatrixRandom(BlockMatrixIR):
         assert len(self.shape) == 2
         tensor_shape, is_row_vector = _matrix_shape_to_tensor_shape(self.shape[0], self.shape[1])
 
-        self._type = tblockmatrix(hl.tfloat64,
-                                  tensor_shape,
-                                  is_row_vector,
-                                  self.block_size,
-                                  [True for _ in tensor_shape])
+        self._type = tblockmatrix(hl.tfloat64, tensor_shape, is_row_vector, self.block_size)
 
 
 class JavaBlockMatrix(BlockMatrixIR):

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -443,7 +443,7 @@ class BlockMatrix(object):
         if not block_size:
             block_size = BlockMatrix.default_block_size()
 
-        rand = BlockMatrixRandom(seed, gaussian, [n_rows, n_cols], block_size, [True])
+        rand = BlockMatrixRandom(seed, gaussian, [n_rows, n_cols], block_size)
         return BlockMatrix(rand)
 
     @classmethod
@@ -480,7 +480,7 @@ class BlockMatrix(object):
 
         bmir = BlockMatrixBroadcast(_to_bmir(value, block_size),
                                     [], [n_rows, n_cols],
-                                    block_size, [True, True])
+                                    block_size)
         return BlockMatrix(bmir)
 
     @classmethod
@@ -1158,8 +1158,7 @@ class BlockMatrix(object):
         return BlockMatrix(BlockMatrixBroadcast(self._bmir,
                                                 [1, 0],
                                                 [self.n_cols, self.n_rows],
-                                                self.block_size,
-                                                self._bmir.typ.dims_partitioned[::-1]))
+                                                self.block_size))
 
     def densify(self):
         """Restore all dropped blocks as explicit blocks of zeros.
@@ -1459,12 +1458,12 @@ class BlockMatrix(object):
             If ``1``, returns a block matrix with a single column.
         """
         if axis is None:
-            bmir = BlockMatrixAgg(self._bmir, [], [])
+            bmir = BlockMatrixAgg(self._bmir, [])
             return BlockMatrix(bmir)[0, 0]
         elif axis == 0 or axis == 1:
             out_index_expr = [dim for dim in range(len(self.shape)) if dim != axis]
 
-            bmir = BlockMatrixAgg(self._bmir, out_index_expr, [True])
+            bmir = BlockMatrixAgg(self._bmir, out_index_expr)
             return BlockMatrix(bmir)
         else:
             raise ValueError(f'axis must be None, 0, or 1: found {axis}')
@@ -2112,16 +2111,14 @@ def _shape_after_broadcast(left, right):
 @typecheck(x=oneof(numeric, np.ndarray), block_size=int)
 def _to_bmir(x, block_size):
     if _is_scalar(x):
-        return ValueToBlockMatrix(F64(x), [1, 1], block_size, [True, True])
+        return ValueToBlockMatrix(F64(x), [1, 1], block_size)
     else:
-        return ValueToBlockMatrix(_ndarray_to_makearray(x), list(_ndarray_as_2d(x).shape),
-                                  block_size, [True, True])
+        return ValueToBlockMatrix(_ndarray_to_makearray(x), list(_ndarray_as_2d(x).shape), block_size)
 
 
 def _broadcast_to_shape(bmir, result_shape):
     in_index_expr = _broadcast_index_expr(bmir.typ.shape, bmir.typ.is_row_vector)
-    return BlockMatrixBroadcast(bmir, in_index_expr, result_shape,
-                                bmir.typ.block_size, [True for _ in result_shape])
+    return BlockMatrixBroadcast(bmir, in_index_expr, result_shape, bmir.typ.block_size)
 
 
 def _ndarray_to_makearray(ndarray):

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1418,8 +1418,7 @@ class BlockMatrix(object):
         diag_bmir = BlockMatrixBroadcast(self._bmir,
                                          [0, 0],
                                          [1, min(self.n_rows, self.n_cols)],
-                                         self.block_size,
-                                         [True])
+                                         self.block_size)
         return BlockMatrix(diag_bmir)
 
     @typecheck_method(axis=nullable(int))

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -256,13 +256,13 @@ class BlockMatrixIRTests(unittest.TestCase):
         negate_bm = ir.BlockMatrixMap(read, ir.ApplyUnaryOp('-', ir.Ref('element')))
         sqrt_bm = ir.BlockMatrixMap(read, hl.sqrt(construct_expr(ir.Ref('element'), hl.tfloat64))._ir)
 
-        scalar_to_bm = ir.ValueToBlockMatrix(scalar_ir, [1, 1], 1, [])
-        col_vector_to_bm = ir.ValueToBlockMatrix(vector_ir, [2, 1], 1, [False])
-        row_vector_to_bm = ir.ValueToBlockMatrix(vector_ir, [1, 2], 1, [False])
-        broadcast_scalar = ir.BlockMatrixBroadcast(scalar_to_bm, [], [2, 2], 256, [False, False])
-        broadcast_col = ir.BlockMatrixBroadcast(col_vector_to_bm, [0], [2, 2], 256, [False, False])
-        broadcast_row = ir.BlockMatrixBroadcast(row_vector_to_bm, [1], [2, 2], 256, [False, False])
-        transpose = ir.BlockMatrixBroadcast(broadcast_scalar, [1, 0], [2, 2], 256, [False, False])
+        scalar_to_bm = ir.ValueToBlockMatrix(scalar_ir, [1, 1], 1)
+        col_vector_to_bm = ir.ValueToBlockMatrix(vector_ir, [2, 1], 1)
+        row_vector_to_bm = ir.ValueToBlockMatrix(vector_ir, [1, 2], 1)
+        broadcast_scalar = ir.BlockMatrixBroadcast(scalar_to_bm, [], [2, 2], 256)
+        broadcast_col = ir.BlockMatrixBroadcast(col_vector_to_bm, [0], [2, 2], 256)
+        broadcast_row = ir.BlockMatrixBroadcast(row_vector_to_bm, [1], [2, 2], 256)
+        transpose = ir.BlockMatrixBroadcast(broadcast_scalar, [1, 0], [2, 2], 256)
         matmul = ir.BlockMatrixDot(broadcast_scalar, transpose)
 
         pow_ir = (construct_expr(ir.Ref('l'), hl.tfloat64) ** construct_expr(ir.Ref('r'), hl.tfloat64))._ir

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -123,7 +123,7 @@ class BlockMatrixLiteral(value: BlockMatrix) extends BlockMatrixIR {
 }
 
 case class BlockMatrixMap(child: BlockMatrixIR, f: IR) extends BlockMatrixIR {
-  assert(f.isInstanceOf[ApplyUnaryPrimOp] || f.isInstanceOf[Apply] || f.isInstanceOf[ApplySeeded])
+  assert(f.isInstanceOf[ApplyUnaryPrimOp] || f.isInstanceOf[Apply])
 
   override def typ: BlockMatrixType = child.typ
 

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -86,7 +86,7 @@ case class BlockMatrixNativeReader(path: String) extends BlockMatrixReader {
     val metadata = BlockMatrix.readMetadata(HailContext.get, path)
     val (tensorShape, isRowVector) = BlockMatrixIR.matrixShapeToTensorShape(metadata.nRows, metadata.nCols)
 
-    BlockMatrixType(TFloat64(), tensorShape, isRowVector, metadata.blockSize, IndexedSeq(true, true))
+    BlockMatrixType(TFloat64(), tensorShape, isRowVector, metadata.blockSize)
   }
 
   override def apply(hc: HailContext): BlockMatrix = BlockMatrix.read(hc, path)
@@ -97,7 +97,7 @@ case class BlockMatrixBinaryReader(path: String, shape: Seq[Long], blockSize: In
     assert(shape.length == 2)
     val (tensorShape, isRowVector) = BlockMatrixIR.matrixShapeToTensorShape(shape.head, shape(1))
 
-    BlockMatrixType(TFloat64(), tensorShape, isRowVector, blockSize, IndexedSeq(true, true))
+    BlockMatrixType(TFloat64(), tensorShape, isRowVector, blockSize)
   }
 
   override def apply(hc: HailContext): BlockMatrix = {
@@ -109,7 +109,7 @@ case class BlockMatrixBinaryReader(path: String, shape: Seq[Long], blockSize: In
 class BlockMatrixLiteral(value: BlockMatrix) extends BlockMatrixIR {
   override def typ: BlockMatrixType = {
     val (shape, isRowVector) = BlockMatrixIR.matrixShapeToTensorShape(value.nRows, value.nCols)
-    BlockMatrixType(TFloat64(), shape, isRowVector, value.blockSize, IndexedSeq(true, true))
+    BlockMatrixType(TFloat64(), shape, isRowVector, value.blockSize)
   }
 
   override def children: IndexedSeq[BaseIR] = Array.empty[BlockMatrixIR]
@@ -303,12 +303,7 @@ case class BlockMatrixDot(left: BlockMatrixIR, right: BlockMatrixIR) extends Blo
     assert(lCols == rRows)
 
     val (tensorShape, isRowVector) = BlockMatrixIR.matrixShapeToTensorShape(lRows, rCols)
-    BlockMatrixType(
-      left.typ.elementType,
-      tensorShape,
-      isRowVector,
-      left.typ.blockSize,
-      tensorShape.map(_ => true))
+    BlockMatrixType(left.typ.elementType, tensorShape, isRowVector, left.typ.blockSize)
   }
 
   override def children: IndexedSeq[BaseIR] = Array(left, right)
@@ -336,7 +331,7 @@ case class BlockMatrixBroadcast(
     val (tensorShape, isRowVector) = BlockMatrixIR.matrixShapeToTensorShape(shape(0), shape(1))
     assert(inIndexExpr.zipWithIndex.forall({ case (out: Int, in: Int) => child.typ.shape(in) == tensorShape(out) }))
 
-    BlockMatrixType(child.typ.elementType, tensorShape, isRowVector, blockSize, tensorShape.map(_ => true))
+    BlockMatrixType(child.typ.elementType, tensorShape, isRowVector, blockSize)
   }
 
   override def children: IndexedSeq[BaseIR] = Array(child)
@@ -388,7 +383,7 @@ case class BlockMatrixAgg(
     val shape = outIndexExpr.map({ i: Int => child.typ.shape(i) }).toIndexedSeq
     val isRowVector = outIndexExpr == IndexedSeq(1)
 
-    BlockMatrixType(child.typ.elementType, shape, isRowVector, child.typ.blockSize, shape.map(_ => false))
+    BlockMatrixType(child.typ.elementType, shape, isRowVector, child.typ.blockSize)
   }
 
   override def children: IndexedSeq[BaseIR] = Array(child)
@@ -418,7 +413,7 @@ case class ValueToBlockMatrix(
 
   override def typ: BlockMatrixType = {
     val (tensorShape, isRowVector) = BlockMatrixIR.matrixShapeToTensorShape(shape(0), shape(1))
-    BlockMatrixType(elementType(child.typ), tensorShape, isRowVector, blockSize, tensorShape.map(_ => true))
+    BlockMatrixType(elementType(child.typ), tensorShape, isRowVector, blockSize)
   }
 
   private def elementType(childType: Type): Type = {
@@ -456,7 +451,7 @@ case class BlockMatrixRandom(
 
   override def typ: BlockMatrixType = {
     val (tensorShape, isRowVector) = BlockMatrixIR.matrixShapeToTensorShape(shape(0), shape(1))
-    BlockMatrixType(TFloat64(), tensorShape, isRowVector, blockSize, tensorShape.map(_ => true))
+    BlockMatrixType(TFloat64(), tensorShape, isRowVector, blockSize)
   }
 
   override def children: IndexedSeq[BaseIR] = Array.empty[BaseIR]

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -44,7 +44,6 @@ object BlockMatrixIR {
       case IndexedSeq(r, c) => (r, c)
     }
   }
-
 }
 
 abstract sealed class BlockMatrixIR extends BaseIR {
@@ -124,7 +123,7 @@ class BlockMatrixLiteral(value: BlockMatrix) extends BlockMatrixIR {
 }
 
 case class BlockMatrixMap(child: BlockMatrixIR, f: IR) extends BlockMatrixIR {
-  assert(f.isInstanceOf[ApplyUnaryPrimOp] || f.isInstanceOf[Apply])
+  assert(f.isInstanceOf[ApplyUnaryPrimOp] || f.isInstanceOf[Apply] || f.isInstanceOf[ApplySeeded])
 
   override def typ: BlockMatrixType = child.typ
 

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1161,27 +1161,23 @@ object IRParser {
         val inIndexExpr = int32_literals(it)
         val shape = int64_literals(it)
         val blockSize = int32_literal(it)
-        val dimsPartitioned = boolean_literals(it)
         val child = blockmatrix_ir(env)(it)
-        BlockMatrixBroadcast(child, inIndexExpr, shape, blockSize, dimsPartitioned)
+        BlockMatrixBroadcast(child, inIndexExpr, shape, blockSize)
       case "BlockMatrixAgg" =>
         val outIndexExpr = int32_literals(it)
-        val dimsPartitioned = boolean_literals(it)
         val child = blockmatrix_ir(env)(it)
-        BlockMatrixAgg(child, outIndexExpr, dimsPartitioned)
+        BlockMatrixAgg(child, outIndexExpr)
       case "ValueToBlockMatrix" =>
         val shape = int64_literals(it)
         val blockSize = int32_literal(it)
-        val dimsPartitioned = boolean_literals(it)
         val child = ir_value_expr(env)(it)
-        ValueToBlockMatrix(child, shape, blockSize, dimsPartitioned)
+        ValueToBlockMatrix(child, shape, blockSize)
       case "BlockMatrixRandom" =>
         val seed = int32_literal(it)
         val gaussian = boolean_literal(it)
         val shape = int64_literals(it)
         val blockSize = int32_literal(it)
-        val dimsPartitioned = boolean_literals(it)
-        BlockMatrixRandom(seed, gaussian, shape, blockSize, dimsPartitioned)
+        BlockMatrixRandom(seed, gaussian, shape, blockSize)
       case "JavaBlockMatrix" =>
         val name = identifier(it)
         env.irMap(name).asInstanceOf[BlockMatrixIR]

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -196,24 +196,19 @@ object Pretty {
               '"' + StringEscapeUtils.escapeString(Serialization.write(reader)(BlockMatrixReader.formats)) + '"'
             case BlockMatrixWrite(_, writer) =>
               '"' + StringEscapeUtils.escapeString(Serialization.write(writer)(BlockMatrixWriter.formats)) + '"'
-            case BlockMatrixBroadcast(_, inIndexExpr, shape, blockSize, dimsPartitioned) =>
+            case BlockMatrixBroadcast(_, inIndexExpr, shape, blockSize) =>
               prettyInts(inIndexExpr) + " " +
               prettyLongs(shape) + " " +
-              blockSize.toString + " " +
-              prettyBooleans(dimsPartitioned)
-            case BlockMatrixAgg(_, outIndexExpr, dimsPartitioned) =>
-              prettyInts(outIndexExpr) + " " +
-              prettyBooleans(dimsPartitioned)
-            case ValueToBlockMatrix(_, shape, blockSize, dimsPartitioned) =>
+              blockSize.toString + " "
+            case BlockMatrixAgg(_, outIndexExpr) => prettyInts(outIndexExpr)
+            case ValueToBlockMatrix(_, shape, blockSize) =>
               prettyLongs(shape) + " " +
-              blockSize.toString + " " +
-              prettyBooleans(dimsPartitioned)
-            case BlockMatrixRandom(seed, gaussian, shape, blockSize, dimsPartitioned) =>
+              blockSize.toString + " "
+            case BlockMatrixRandom(seed, gaussian, shape, blockSize) =>
               seed.toString + " " +
               prettyBooleanLiteral(gaussian) + " " +
               prettyLongs(shape) + " " +
-              blockSize.toString + " " +
-              prettyBooleans(dimsPartitioned)
+              blockSize.toString + " "
             case MatrixRowsHead(_, n) => n.toString
             case MatrixAnnotateRowsTable(_, _, uid) =>
               prettyStringLiteral(uid) + " "

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -537,6 +537,6 @@ object Simplify {
   }
 
   private[this] def blockMatrixRules: PartialFunction[BlockMatrixIR, BlockMatrixIR] = {
-    case BlockMatrixBroadcast(child, IndexedSeq(0, 1), _, _, _) => child
+    case BlockMatrixBroadcast(child, IndexedSeq(0, 1), _, _) => child
   }
 }

--- a/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/BlockMatrixType.scala
@@ -7,8 +7,7 @@ case class BlockMatrixType(
   elementType: Type,
   shape: IndexedSeq[Long],
   isRowVector: Boolean,
-  blockSize: Int,
-  dimsPartitioned: IndexedSeq[Boolean]) extends BaseType {
+  blockSize: Int) extends BaseType {
 
   override def pretty(sb: StringBuilder, indent0: Int, compact: Boolean): Unit = {
     var indent = indent0
@@ -46,10 +45,6 @@ case class BlockMatrixType(
     sb.append(blockSize)
     sb += ','
     newline()
-
-    sb.append(s"dimsPartitioned:$space[")
-    dimsPartitioned.foreachBetween(dim => sb.append(dim))(sb.append(s",$space"))
-    sb += ']'
 
     indent -= 4
     newline()

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -71,8 +71,8 @@ class BlockMatrixIRSuite extends SparkSuite {
 
   @Test def testBlockMatrixBroadcastValue_Scalars() {
     val broadcastTwo = BlockMatrixBroadcast(
-      ValueToBlockMatrix(MakeArray(Seq[F64](F64(2)), TArray(TFloat64())), Array[Long](1, 1), 0, Array[Boolean]()),
-        IndexedSeq(), shape, 0, Array[Boolean](false, false))
+      ValueToBlockMatrix(MakeArray(Seq[F64](F64(2)), TArray(TFloat64())), Array[Long](1, 1), 0),
+        IndexedSeq(), shape, 0)
 
     val onesAddTwo = makeMap2(new BlockMatrixLiteral(ones), broadcastTwo, Add())
     val threesSubTwo = makeMap2(new BlockMatrixLiteral(threes), broadcastTwo, Subtract())
@@ -92,9 +92,9 @@ class BlockMatrixIRSuite extends SparkSuite {
     val vectorLiteral = MakeArray(Seq[F64](F64(1), F64(2), F64(3)), TArray(TFloat64()))
 
     val broadcastRowVector = BlockMatrixBroadcast(ValueToBlockMatrix(vectorLiteral, Array[Long](1, 3),
-      0, Array(false)), IndexedSeq(1), shape, 0, Array[Boolean](false, false))
+      0), IndexedSeq(1), shape, 0)
     val broadcastColVector = BlockMatrixBroadcast(ValueToBlockMatrix(vectorLiteral, Array[Long](3, 1),
-      0, Array(false)), IndexedSeq(0), shape, 0, Array[Boolean](false, false))
+      0), IndexedSeq(0), shape, 0)
 
     // Addition
     val actualOnesAddRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Add())

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1196,7 +1196,7 @@ class IRSuite extends SparkSuite {
   @DataProvider(name = "blockMatrixIRs")
   def blockMatrixIRs(): Array[Array[BlockMatrixIR]] = {
     val read = BlockMatrixRead(BlockMatrixNativeReader("src/test/resources/blockmatrix_example/0"))
-    val transpose = BlockMatrixBroadcast(read, IndexedSeq(1, 0), IndexedSeq(2, 2), 2, IndexedSeq(true, true))
+    val transpose = BlockMatrixBroadcast(read, IndexedSeq(1, 0), IndexedSeq(2, 2), 2)
     val dot = BlockMatrixDot(read, transpose)
 
     val blockMatrixIRs = Array[BlockMatrixIR](read, transpose, dot)

--- a/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
@@ -58,8 +58,8 @@ class SimplifySuite extends SparkSuite {
 
   @Test def testBlockMatrixRewriteRules() {
     val bmir = ValueToBlockMatrix(MakeArray(IndexedSeq(F64(1), F64(2), F64(3), F64(4)), TArray(TFloat64())),
-      IndexedSeq(2, 2), 10, IndexedSeq(false, false))
-    val identityBroadcast = BlockMatrixBroadcast(bmir, IndexedSeq(0, 1), IndexedSeq(2, 2), 10, IndexedSeq(false, false))
+      IndexedSeq(2, 2), 10)
+    val identityBroadcast = BlockMatrixBroadcast(bmir, IndexedSeq(0, 1), IndexedSeq(2, 2), 10)
 
     assert(Simplify(identityBroadcast) == bmir)
   }


### PR DESCRIPTION
Removes the specification of what dimensions are partitioned from the construction of IR nodes. In nodes where the dimensionality is subject to change, the resultant dimensions are assumed to all be distributed (this field in the type does not currently affect the behavior of BlockMatrix).