### PR TITLE
[pipeline] Added implicit copy of resource group

### DIFF
--- a/pipeline/pipeline/pipeline.py
+++ b/pipeline/pipeline/pipeline.py
@@ -92,7 +92,8 @@ class Pipeline:
         return rg
 
     def write_output(self, resource, dest):  # pylint: disable=R0201
-        assert isinstance(resource, Resource)
+        if not isinstance(resource, Resource):
+            raise Exception(f"'write_output' only accepts Resource inputs. Found '{type(resource)}'.")
         if isinstance(resource, TaskResourceFile) and resource not in resource._source._mentioned:
             name = resource._source._resources_inverse
             raise Exception(f"undefined resource '{name}'\n"

--- a/pipeline/pipeline/pipeline.py
+++ b/pipeline/pipeline/pipeline.py
@@ -3,7 +3,7 @@ import uuid
 
 from .backend import LocalBackend
 from .task import Task
-from .resource import ResourceGroup, InputResourceFile, TaskResourceFile
+from .resource import Resource, InputResourceFile, TaskResourceFile, ResourceGroup
 
 
 class Pipeline:
@@ -92,6 +92,12 @@ class Pipeline:
         return rg
 
     def write_output(self, resource, dest):  # pylint: disable=R0201
+        assert isinstance(resource, Resource)
+        if isinstance(resource, TaskResourceFile) and resource not in resource._source._mentioned:
+            name = resource._source._resources_inverse
+            raise Exception(f"undefined resource '{name}'\n"
+                            f"Hint: resources must be defined within the "
+                            "task methods 'command' or 'declare_resource_group'")
         resource.add_output_path(dest)
 
     def select_tasks(self, pattern):

--- a/pipeline/pipeline/resource.py
+++ b/pipeline/pipeline/resource.py
@@ -101,10 +101,10 @@ class ResourceGroup(Resource):
         self._uid = ResourceGroup._new_uid()
         self._output_paths = set()
 
-        for name, resource in values.items():
-            assert isinstance(resource, ResourceFile)
-            self._resources[name] = resource
-            resource.add_resource_group(self)
+        for name, resource_file in values.items():
+            assert isinstance(resource_file, ResourceFile)
+            self._resources[name] = resource_file
+            resource_file.add_resource_group(self)
 
     @property
     def path(self):

--- a/pipeline/pipeline/resource.py
+++ b/pipeline/pipeline/resource.py
@@ -8,12 +8,16 @@ class Resource:
 
     @property
     @abc.abstractmethod
-    def file_name(self) -> str:
+    def path(self) -> str:
+        pass
+
+    @abc.abstractmethod
+    def add_output_path(self, path):
         pass
 
     def declare(self, directory=None):
         directory = directory + '/' if directory else ''
-        return f"{self._uid}={escape_string(directory + self.file_name)}"
+        return f"{self._uid}={escape_string(directory + self.path)}"
 
 
 class ResourceFile(Resource, str):
@@ -34,6 +38,7 @@ class ResourceFile(Resource, str):
         self._source = None
         self._uid = ResourceFile._new_uid()
         self._output_paths = set()
+        self._resource_group = None
 
     def add_source(self, source):
         from .task import Task
@@ -43,9 +48,20 @@ class ResourceFile(Resource, str):
 
     def add_output_path(self, path):
         self._output_paths.add(path)
+        if self._source is not None:
+            self._source._add_outputs(self)
+
+    def add_resource_group(self, rg):
+        self._resource_group = rg
+
+    def has_resource_group(self):
+        return self._resource_group is not None
+
+    def get_resource_group(self):
+        return self._resource_group
 
     @property
-    def file_name(self):
+    def path(self):
         assert self._value is not None
         return self._value
 
@@ -86,14 +102,18 @@ class ResourceGroup(Resource):
         self._output_paths = set()
 
         for name, resource in values.items():
+            assert isinstance(resource, ResourceFile)
             self._resources[name] = resource
+            resource.add_resource_group(self)
 
     @property
-    def file_name(self):
+    def path(self):
         return self._root
 
     def add_output_path(self, path):
         self._output_paths.add(path)
+        if self._source is not None:
+            self._source._add_outputs(self)
 
     def _get_resource(self, item):
         if item not in self._resources:

--- a/pipeline/test-locally.sh
+++ b/pipeline/test-locally.sh
@@ -4,6 +4,8 @@ set -ex
 
 . activate hail-pipeline
 
+PYTEST_ARGS=${PYTEST_ARGS:- -v --failed-first}
+
 cleanup() {
     set +e
     trap "" INT TERM
@@ -24,4 +26,4 @@ do
     sleep 1
 done
 
-BATCH_URL='http://127.0.0.1:5000' pytest -v test
+BATCH_URL='http://127.0.0.1:5000' pytest ${PYTEST_ARGS} test

--- a/pipeline/test/test_pipeline.py
+++ b/pipeline/test/test_pipeline.py
@@ -107,7 +107,7 @@ class LocalTests(unittest.TestCase):
     def test_single_task_bad_command(self):
         p = Pipeline()
         t = p.new_task()
-        t.command("foo") # this should fail!
+        t.command("foo")  # this should fail!
         with self.assertRaises(sp.CalledProcessError):
             p.run()
 
@@ -122,6 +122,48 @@ class LocalTests(unittest.TestCase):
             p.run()
 
             assert self.read(output_file.name) == msg
+
+    def test_resource_group_get_all_inputs(self):
+        p = Pipeline()
+        input = p.read_input_group(fasta="foo",
+                                   idx="bar")
+        t = p.new_task()
+        t.command(f"cat {input.fasta}")
+        assert(input.fasta in t._inputs)
+        assert(input.idx in t._inputs)
+
+    def test_resource_group_get_all_mentioned(self):
+        p = Pipeline()
+        t = p.new_task()
+        t.declare_resource_group(foo={'bed': '{root}.bed', 'bim': '{root}.bim'})
+        t.command(f"cat {t.foo.bed}")
+        assert(t.foo.bed in t._mentioned)
+        assert(t.foo.bim not in t._mentioned)
+
+    def test_resource_group_get_all_mentioned_dependent_tasks(self):
+        p = Pipeline()
+        t = p.new_task()
+        t.declare_resource_group(foo={'bed': '{root}.bed', 'bim': '{root}.bim'})
+        t.command(f"cat")
+        t2 = p.new_task()
+        t2.command(f"cat {t.foo}")
+
+    def test_resource_group_get_all_outputs(self):
+        p = Pipeline()
+        t1 = p.new_task()
+        t1.declare_resource_group(foo={'bed': '{root}.bed', 'bim': '{root}.bim'})
+        t1.command(f"cat {t1.foo.bed}")
+        t2 = p.new_task()
+        t2.command(f"cat {t1.foo.bed}")
+        assert(t1.foo.bed in t1._outputs)
+        assert(t1.foo.bed in t2._inputs)
+        assert(t1.foo.bed in t1._mentioned)
+        assert(t1.foo.bed not in t2._mentioned)
+
+        assert(t1.foo.bim in t1._outputs)
+        assert(t1.foo.bim in t2._inputs)
+        assert(t1.foo.bim not in t1._mentioned)
+        assert(t1.foo.bim not in t2._mentioned)
 
     def test_multiple_isolated_tasks(self):
         p = Pipeline()
@@ -238,6 +280,21 @@ class BatchTests(unittest.TestCase):
         t.command(f'echo "hello" > {t.output.foo}')
         p.write_output(t.output, f'{gcs_output_dir}/test_single_task_write_resource_group')
         p.write_output(t.output.foo, f'{gcs_output_dir}/test_single_task_write_resource_group_file.txt')
+        p.run()
+
+    def test_multiple_dependent_tasks(self):
+        output_file = f'{gcs_output_dir}/test_multiple_dependent_tasks.txt'
+        p = self.pipeline()
+        t = p.new_task()
+        t.command(f'echo "0" >> {t.ofile}')
+
+        for i in range(1, 3):
+            t2 = p.new_task()
+            t2.command(f'echo "{i}" > {t2.tmp1}')
+            t2.command(f'cat {t.ofile} {t2.tmp1} > {t2.ofile}')
+            t = t2
+
+        p.write_output(t.ofile, output_file)
         p.run()
 
     def test_specify_cpu(self):


### PR DESCRIPTION
Plus better error checking!

- Some bioinformatic tools expect a secondary implied file to be present. For example, sample.vcf and it's index file sample.vcf.tbi. This PR adds file localization such that if any file in a resource group is used, the entire resource group will be copied and not just the mentioned file.

- Added a mentioned set that tracks whether a resource was defined in the command or declare resource group functions. Otherwise, you could do something like this which would throw an error upon execution:

```python
p = Pipeline()
t = p.new_task()
p.write_output(t.undefined_variable, 'gs://foo/foo')
p.run()
```