### PR TITLE
[c++] PackEncoder/PackDecoder can serialize primitive values

### DIFF
--- a/hail/src/main/scala/is/hail/cxx/PackDecoder.scala
+++ b/hail/src/main/scala/is/hail/cxx/PackDecoder.scala
@@ -183,33 +183,20 @@ object PackDecoder {
 
     decoderBuilder += s"${ decoderBuilder.name }(std::shared_ptr<InputStream> is) : $buf(std::make_shared<$bufType>(is)) { }"
 
-    rt.fundamentalType match {
-      case node if node.isPrimitive =>
-        val rowFB = decoderBuilder.buildMethod("decode_row", Array("Region *" -> "region"), typeToCXXType(rt), const = true)
-        val region = rowFB.getArg(0)
-        val row = rowFB.variable("row", "char *", s"$region->allocate(${ rt.alignment }, ${ rt.byteSize })")
-        rowFB += row.define
-        rowFB += decode(t.fundamentalType, rt.fundamentalType, buf.ref, region.ref, row.ref, rowFB)
-        rowFB += s"return *reinterpret_cast<${typeToCXXType(rt)} *>($row);"
-        rowFB.end()
-
-      case _ =>
-        val rowFB = decoderBuilder.buildMethod("decode_row", Array("Region *" -> "region"), "char *", const = true)
-        val region = rowFB.getArg(0)
-        val initialSize = rt match {
-          case _: PArray | _: PBinary => 8
-          case _ => rt.byteSize
-        }
-        val row = rowFB.variable("row", "char *", s"$region->allocate(${ rt.alignment }, $initialSize)")
-        rowFB += row.define
-        rowFB += decode(t.fundamentalType, rt.fundamentalType, buf.ref, region.ref, row.ref, rowFB)
-        rowFB += (rt match {
-          case _: PArray | _: PBinary => s"return load_address($row);"
-          case _ => s"return $row;"
-        })
-        rowFB.end()
+    val (valueType, initialSize, returnVal) = rt match {
+      case typ if typ.isPrimitive =>
+        (typeToCXXType(rt), rt.byteSize, { r: Variable => s"*reinterpret_cast<${typeToCXXType(rt)} *>($r)" })
+      case _: PArray | _: PBinary => ("char *", 8, { r: Variable => s"load_address($r)" })
+      case _ => ("char *", rt.byteSize, { r: Variable => s"$r" })
     }
 
+    val rowFB = decoderBuilder.buildMethod("decode_row", Array("Region *" -> "region"), valueType, const = true)
+    val region = rowFB.getArg(0)
+    val row = rowFB.variable("row", "char *", s"$region->allocate(${ rt.alignment }, $initialSize)")
+    rowFB += row.define
+    rowFB += decode(t.fundamentalType, rt.fundamentalType, buf.ref, region.ref, row.ref, rowFB)
+    rowFB += s"return ${ returnVal(row) }"
+    rowFB.end()
 
     val byteFB = decoderBuilder.buildMethod("decode_byte", Array(), "char", const = true)
     byteFB += s"return $buf->read_byte();"

--- a/hail/src/main/scala/is/hail/cxx/PackDecoder.scala
+++ b/hail/src/main/scala/is/hail/cxx/PackDecoder.scala
@@ -195,7 +195,7 @@ object PackDecoder {
     val row = rowFB.variable("row", "char *", s"$region->allocate(${ rt.alignment }, $initialSize)")
     rowFB += row.define
     rowFB += decode(t.fundamentalType, rt.fundamentalType, buf.ref, region.ref, row.ref, rowFB)
-    rowFB += s"return ${ returnVal(row) }"
+    rowFB += s"return ${ returnVal(row) };"
     rowFB.end()
 
     val byteFB = decoderBuilder.buildMethod("decode_byte", Array(), "char", const = true)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
@@ -220,7 +220,7 @@ abstract class PContainer extends PType {
 
   def cxxImpl: String = {
     elementType match {
-      case _: PStruct =>
+      case _: PStruct | _: PTuple =>
         s"ArrayAddrImpl<${ elementType.required },${ elementType.byteSize },${ elementType.alignment }>"
       case _ =>
         s"ArrayLoadImpl<${ cxx.typeToCXXType(elementType) },${ elementType.required },${ elementType.byteSize },${ elementType.alignment }>"


### PR DESCRIPTION
Unnecessary currently, but I'll be using this functionality to be able to directly serialize the result of partition computations that return primitive values. (see #5450) Seemed easier than explicitly writing and calling different versions of a function for different primitive types.