### PR TITLE
 [c++] first argument to Emit is context, which wraps region

### DIFF
--- a/hail/src/main/resources/include/hail/SparkUtils.h
+++ b/hail/src/main/resources/include/hail/SparkUtils.h
@@ -1,0 +1,33 @@
+#ifndef HAIL_SPARKUTILS_H
+#define HAIL_SPARKUTILS_H 1
+
+#include <jni.h>
+#include <cstring>
+#include "hail/Decoder.h"
+#include "hail/Encoder.h"
+#include "hail/Region.h"
+#include "hail/Upcalls.h"
+#include "hail/Utils.h"
+
+namespace hail {
+
+class SparkEnv {
+  private:
+    UpcallEnv up_;
+    UpcallEnv * up() { return &up_; }
+
+  public:
+    JNIEnv * env() { return up_.env(); }
+};
+
+struct SparkFunctionContext {
+  RegionPtr region_;
+  SparkEnv spark_env_;
+
+  SparkFunctionContext(RegionPtr region) :
+  region_(region), spark_env_() { }
+};
+
+}
+
+#endif

--- a/hail/src/main/scala/is/hail/backend/spark/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/LowerTableIR.scala
@@ -96,7 +96,7 @@ case class SparkStage(
     wrapper +=
       s"""
          |try {
-         |  return (long) ${ f.name }(((ScalaRegion *)${ wrapper.getArg(1) })->region_, (char *)${ wrapper.getArg(2) }, (char *)${ wrapper.getArg(3) });
+         |  return (long) ${ f.name }(SparkFunctionContext(((ScalaRegion *)${ wrapper.getArg(1) })->region_), (char *)${ wrapper.getArg(2) }, (char *)${ wrapper.getArg(3) });
          |} catch (const FatalError& e) {
          |  NATIVE_ERROR(${ wrapper.getArg(0) }, 1005, e.what());
          |  return -1;

--- a/hail/src/main/scala/is/hail/cxx/Compile.scala
+++ b/hail/src/main/scala/is/hail/cxx/Compile.scala
@@ -14,11 +14,12 @@ object Compile {
     tub.include("hail/Utils.h")
     tub.include("hail/Region.h")
     tub.include("hail/Upcalls.h")
+    tub.include("hail/SparkUtils.h")
 
     tub.include("<cstring>")
 
     val fb = tub.buildFunction(tub.genSym("f"),
-      (("RegionPtr", "region") +: args.map { case (name, typ) =>
+      (("SparkFunctionContext", "ctx") +: args.map { case (name, typ) =>
         typeToCXXType(typ) -> name  }).toArray,
       typeToCXXType(body.pType))
 
@@ -58,7 +59,7 @@ object Compile {
         s"""
            |long entrypoint(NativeStatus *st, long region, long v) {
            |  try {
-           |    return (long)${ f.name }(((ScalaRegion *)region)->region_, (char *)v);
+           |    return (long)${ f.name }(SparkFunctionContext(((ScalaRegion *)region)->region_), (char *)v);
            |  } catch (const FatalError& e) {
            |    NATIVE_ERROR(st, 1005, e.what());
            |    return -1;

--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -9,7 +9,7 @@ import scala.collection.mutable
 
 object Emit {
   def apply(fb: FunctionBuilder, nSpecialArgs: Int, x: ir.IR): EmitTriplet = {
-    val emitter = new Emitter(fb, nSpecialArgs, EmitContext(fb))
+    val emitter = new Emitter(fb, nSpecialArgs, SparkFunctionContext(fb))
     emitter.emit(x, ir.Env.empty[EmitTriplet])
   }
 }
@@ -161,7 +161,7 @@ class Orderings {
   }
 }
 
-class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: EmitContext) {
+class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext) {
   outer =>
   type E = ir.Env[EmitTriplet]
 

--- a/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
+++ b/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
@@ -66,8 +66,7 @@ class EmitRegion private (val fb: FunctionBuilder, val baseRegion: Code, _region
   def used: Boolean = isUsed
 
   def defineIfUsed(sameRegion: Boolean): Code = {
-    assert(_region != null)
-    if (isUsed && !sameRegion) _region.define else ""
+    if (isUsed && !sameRegion && _region != null) _region.define else ""
   }
 
   def addReference(other: EmitRegion): Code =

--- a/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
+++ b/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
@@ -83,14 +83,14 @@ class EmitRegion private (val fb: FunctionBuilder, val baseRegion: Code, _region
   def newRegion(): EmitRegion = new EmitRegion(fb, baseRegion, fb.variable("region", "RegionPtr", s"$baseRegion->get_region()"))
 }
 
-object EmitContext {
-  def apply(fb: FunctionBuilder, spark_context: Variable): EmitContext =
-    EmitContext(s"$spark_context.spark_env_", EmitRegion(fb, s"$spark_context.region_"))
+object SparkFunctionContext {
+  def apply(fb: FunctionBuilder, spark_context: Variable): SparkFunctionContext =
+    SparkFunctionContext(s"$spark_context.spark_env_", EmitRegion(fb, s"$spark_context.region_"))
 
-  def apply(fb: FunctionBuilder): EmitContext = apply(fb, fb.getArg(0))
+  def apply(fb: FunctionBuilder): SparkFunctionContext = apply(fb, fb.getArg(0))
 }
 
-case class EmitContext(sparkEnv: Code, region: EmitRegion)
+case class SparkFunctionContext(sparkEnv: Code, region: EmitRegion)
 
 abstract class ArrayEmitter(val setup: Code, val m: Code, val setupLen: Code, val length: Option[Code], val arrayRegion: EmitRegion) {
   def emit(f: (Code, Code) => Code): Code

--- a/hail/src/main/scala/is/hail/cxx/TranslationUnit.scala
+++ b/hail/src/main/scala/is/hail/cxx/TranslationUnit.scala
@@ -128,7 +128,7 @@ class TranslationUnitBuilder() extends ScopeBuilder {
   def end(): TranslationUnit = {
 
     new TranslationUnit(
-      includes.result().mkString("\n"),
+      includes.result().distinct.mkString("\n"),
       definitions.result())
   }
 }


### PR DESCRIPTION
Changes the first argument that Emit expects to be a SparkFunctionContext, which currently holds a region and a SparkEnv (currently a stub; will be fleshed out as we start writing code to call back into Spark.) This should let us be more flexible in our ability to pass other necessary (non-IR-value) inputs, such as a hadoop configuration, to the function without relying on function argument ordering and accounting.

builds on #5457.