### PR TITLE
define parseable scala ReadPartition IR node

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -138,5 +138,6 @@ object Children {
     case BlockMatrixToValueApply(child, _) => IndexedSeq(child)
     case BlockMatrixWrite(child, _) => IndexedSeq(child)
     case CollectDistributedArray(ctxs, globals, _, _, body) => IndexedSeq(ctxs, globals, body)
+    case ReadPartition(path, _, _, _) => IndexedSeq(path)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
@@ -17,6 +17,7 @@ object Compilable {
       case _: BlockMatrixToValueApply => false
       case _: Literal => false
       case _: CollectDistributedArray => false
+      case _: ReadPartition => false
 
       case _ => true
     }

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -213,6 +213,9 @@ object Copy {
       case CollectDistributedArray(_, _, cname, gname, _) =>
         val IndexedSeq(ctxs: IR, globals: IR, newBody: IR) = newChildren
         CollectDistributedArray(ctxs, globals, cname, gname, newBody)
+      case ReadPartition(path, spec, encodedType, rowType) =>
+        val IndexedSeq(newPath: IR) = newChildren
+        ReadPartition(newPath, spec, encodedType, rowType)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -5,6 +5,7 @@ import is.hail.expr.types._
 import is.hail.expr.ir.functions._
 import is.hail.expr.types.physical._
 import is.hail.expr.types.virtual._
+import is.hail.io.CodecSpec
 import is.hail.utils.{ExportType, FastIndexedSeq}
 
 import scala.language.existentials
@@ -325,6 +326,7 @@ final case class BlockMatrixToValueApply(child: BlockMatrixIR, function: BlockMa
 final case class BlockMatrixWrite(child: BlockMatrixIR, writer: BlockMatrixWriter) extends IR
 
 final case class CollectDistributedArray(contexts: IR, globals: IR, cname: String, gname: String, body: IR) extends IR
+final case class ReadPartition(path: IR, spec: CodecSpec, encodedType: TStruct, rowType: TStruct) extends IR
 
 class PrimitiveIR(val self: IR) extends AnyVal {
   def +(other: IR): IR = ApplyBinaryPrimOp(Add(), self, other)

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -144,6 +144,7 @@ object InferPType {
       case MatrixToValueApply(child, function) => PType.canonical(function.typ(child.typ))
       case BlockMatrixToValueApply(child, function) => PType.canonical(function.typ(child.typ))
       case CollectDistributedArray(_, _, _, _, body) => PArray(body.pType)
+      case ReadPartition(_, _, _, rowType) => PType.canonical(TArray(rowType))
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -153,6 +153,7 @@ object InferType {
       case MatrixToValueApply(child, function) => function.typ(child.typ)
       case BlockMatrixToValueApply(child, function) => function.typ(child.typ)
       case CollectDistributedArray(_, _, _, _, body) => TArray(body.typ)
+      case ReadPartition(_, _, _, rowType) => TArray(rowType)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -946,6 +946,8 @@ object Interpret {
           SafeRow(coerce[PTuple](t), region, resultOffset)
             .get(0)
         }
+      case x: ReadPartition =>
+        fatal(s"cannot interpret ${ Pretty(x) }")
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -6,8 +6,9 @@ import is.hail.expr.{JSONAnnotationImpex, ParserUtils}
 import is.hail.expr.types.{MatrixType, TableType}
 import is.hail.expr.types.virtual._
 import is.hail.expr.types.physical.PType
+import is.hail.io.CodecSpec
 import is.hail.io.bgen.MatrixBGENReaderSerializer
-import is.hail.rvd.RVDType
+import is.hail.rvd.{AbstractRVDSpec, RVDType}
 import is.hail.table.{Ascending, Descending, SortField}
 import is.hail.utils.StringEscapeUtils._
 import is.hail.utils._
@@ -839,6 +840,13 @@ object IRParser {
       case "JavaIR" =>
         val name = identifier(it)
         env.irMap(name).asInstanceOf[IR]
+      case "ReadPartition" =>
+        implicit val formats: Formats = AbstractRVDSpec.formats
+        val spec = JsonMethods.parse(string_literal(it)).extract[CodecSpec]
+        val encType = coerce[TStruct](type_expr(it))
+        val rowType = coerce[TStruct](type_expr(it))
+        val path = ir_value_expr(env)(it)
+        ReadPartition(path, spec, encType, rowType)
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -287,6 +287,8 @@ object Pretty {
                 s"${ prettyStrings(colKV.map(_._1)) } ${ prettyStrings(colKV.map(_._2)) } " +
                 s"${ prettyStrings(rowKV.map(_._1)) } ${ prettyStrings(rowKV.map(_._2)) } " +
                 s"${ prettyStrings(entryKV.map(_._1)) } ${ prettyStrings(entryKV.map(_._2)) }"
+            case ReadPartition(path, spec, encodedType, rowType) =>
+              s"${ prettyStringLiteral(spec.toString) } ${ encodedType.parsableString() } ${ rowType.parsableString() }"
 
             case _ => ""
           }

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -20,13 +20,13 @@ import org.json4s.{Formats, ShortTypeHints}
 import scala.reflect.ClassTag
 
 object TableIR {
-  def read(hc: HailContext, path: String, dropRows: Boolean = false, requestedType: Option[TableType]): TableIR = {
+  def read(hc: HailContext, path: String, dropRows: Boolean, requestedType: Option[TableType]): TableIR = {
     val successFile = path + "/_SUCCESS"
     if (!hc.hadoopConf.exists(path + "/_SUCCESS"))
       fatal(s"write failed: file not found: $successFile")
 
     val tr = TableNativeReader(path)
-    TableRead(requestedType.getOrElse(tr.fullType), dropRows = false, tr)
+    TableRead(requestedType.getOrElse(tr.fullType), dropRows = dropRows, tr)
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -317,6 +317,9 @@ object TypeCheck {
         assert(ctxs.typ.isInstanceOf[TArray])
         check(globals)
         check(body, env = env.bind(cname, coerce[TArray](ctxs.typ).elementType).bind(gname, globals.typ))
+      case x@ReadPartition(path, _, _, rowType) =>
+        check(path.typ == TString())
+        assert(x.typ == TArray(rowType))
     }
   }
 }

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -34,7 +34,7 @@ trait BufferSpec extends Serializable {
   def nativeInputBufferType: String
 }
 
-final class LEB128BufferSpec(child: BufferSpec) extends BufferSpec {
+final case class LEB128BufferSpec(child: BufferSpec) extends BufferSpec {
   def buildInputBuffer(in: InputStream): InputBuffer = new LEB128InputBuffer(child.buildInputBuffer(in))
 
   def buildOutputBuffer(out: OutputStream): OutputBuffer = new LEB128OutputBuffer(child.buildOutputBuffer(out))
@@ -44,7 +44,7 @@ final class LEB128BufferSpec(child: BufferSpec) extends BufferSpec {
   def nativeInputBufferType: String = s"LEB128InputBuffer<${ child.nativeInputBufferType }>"
 }
 
-final class BlockingBufferSpec(blockSize: Int, child: BlockBufferSpec) extends BufferSpec {
+final case class BlockingBufferSpec(blockSize: Int, child: BlockBufferSpec) extends BufferSpec {
   def buildInputBuffer(in: InputStream): InputBuffer = new BlockingInputBuffer(blockSize, child.buildInputBuffer(in))
 
   def buildOutputBuffer(out: OutputStream): OutputBuffer = new BlockingOutputBuffer(blockSize, child.buildOutputBuffer(out))
@@ -64,7 +64,7 @@ trait BlockBufferSpec extends Serializable {
   def nativeInputBufferType: String
 }
 
-final class LZ4BlockBufferSpec(blockSize: Int, child: BlockBufferSpec) extends BlockBufferSpec {
+final case class LZ4BlockBufferSpec(blockSize: Int, child: BlockBufferSpec) extends BlockBufferSpec {
   def buildInputBuffer(in: InputStream): InputBlockBuffer = new LZ4InputBlockBuffer(blockSize, child.buildInputBuffer(in))
 
   def buildOutputBuffer(out: OutputStream): OutputBlockBuffer = new LZ4OutputBlockBuffer(blockSize, child.buildOutputBuffer(out))
@@ -86,6 +86,8 @@ final class StreamBlockBufferSpec extends BlockBufferSpec {
   def nativeOutputBufferType: String = s"StreamOutputBlockBuffer"
 
   def nativeInputBufferType: String = s"StreamInputBlockBuffer"
+
+  override def equals(other: Any): Boolean = other.isInstanceOf[StreamBlockBufferSpec]
 }
 
 object CodecSpec {

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -28,12 +28,14 @@ object AbstractRVDSpec {
     new TStructSerializer +
     new RVDTypeSerializer
 
-  def read(hc: HailContext, path: String): AbstractRVDSpec = {
+  def read(conf: org.apache.hadoop.conf.Configuration, path: String): AbstractRVDSpec = {
     val metadataFile = path + "/metadata.json.gz"
-    hc.hadoopConf.readFile(metadataFile) { in => JsonMethods.parse(in) }
+    conf.readFile(metadataFile) { in => JsonMethods.parse(in) }
       .transformField { case ("orvdType", value) => ("rvdType", value) } // ugh
       .extract[AbstractRVDSpec]
   }
+
+  def read(hc: HailContext, path: String): AbstractRVDSpec = read(hc.hadoopConf, path)
 
   def readLocal(hc: HailContext, path: String, rowType: PStruct, codecSpec: CodecSpec, partFiles: Array[String], requestedType: PStruct): IndexedSeq[Row] = {
     assert(partFiles.length == 1)

--- a/hail/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/hail/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -90,21 +90,24 @@ abstract class RelationalSpec {
 }
 
 case class RVDComponentSpec(rel_path: String) extends ComponentSpec {
+  def rvdSpec(hadoopConf: org.apache.hadoop.conf.Configuration, path: String): AbstractRVDSpec =
+    AbstractRVDSpec.read(hadoopConf, path + "/" + rel_path)
+
   def read(hc: HailContext, path: String, requestedType: PStruct): RVD = {
     val rvdPath = path + "/" + rel_path
-    AbstractRVDSpec.read(hc, rvdPath)
+    rvdSpec(hc.hadoopConf, path)
       .read(hc, rvdPath, requestedType)
   }
 
   def readLocal(hc: HailContext, path: String, requestedType: PStruct): IndexedSeq[Row] = {
     val rvdPath = path + "/" + rel_path
-    AbstractRVDSpec.read(hc, rvdPath)
+    rvdSpec(hc.hadoopConf, path)
       .readLocal(hc, rvdPath, requestedType)
   }
 
   def cxxEmitRead(hc: HailContext, path: String, requestedType: TStruct, tub: cxx.TranslationUnitBuilder): cxx.RVDEmitTriplet = {
     val rvdPath = path + "/" + rel_path
-    AbstractRVDSpec.read(hc, rvdPath)
+    rvdSpec(hc.hadoopConf, path)
       .cxxEmitRead(hc, rvdPath, requestedType, tub)
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -10,6 +10,7 @@ import is.hail.expr.ir.IRSuite.TestFunctions
 import is.hail.expr.ir.functions.{IRFunctionRegistry, RegistryFunctions, SeededIRFunction}
 import is.hail.expr.types.TableType
 import is.hail.expr.types.virtual._
+import is.hail.io.CodecSpec
 import is.hail.io.bgen.MatrixBGENReader
 import is.hail.linalg.BlockMatrix
 import is.hail.methods.{ForceCountMatrixTable, ForceCountTable}
@@ -1042,7 +1043,8 @@ class IRSuite extends SparkSuite {
       MatrixMultiWrite(Array(mt, mt), MatrixNativeMultiWriter(tmpDir.createLocalTempFile())),
       MatrixAggregate(mt, MakeStruct(Seq("foo" -> count))),
       BlockMatrixWrite(blockMatrix, BlockMatrixNativeWriter(tmpDir.createLocalTempFile(), false, false, false)),
-      CollectDistributedArray(ArrayRange(0, 3, 1), 1, "x", "y", Ref("x", TInt32()))
+      CollectDistributedArray(ArrayRange(0, 3, 1), 1, "x", "y", Ref("x", TInt32())),
+      ReadPartition(Str("foo"), CodecSpec.default, TStruct("foo"->TInt32(), "bar" -> TString()), TStruct("foo"->TInt32()))
     )
     irs.map(x => Array(x))
   }


### PR DESCRIPTION
This defines (but doesn't yet implement) a ReadPartition value IR node. For an idea of how it would be implemented and used, see #5326 for a (non-working) example. I think I need to make the interface for c++ to call back into spark a little better before I implement this, but in the meantime I'm PRing the IR bits.