### PR TITLE
[c++] write templated array builder in C++; use in StagedContainerBuilder

### DIFF
--- a/hail/src/main/resources/include/hail/ArrayBuilder.h
+++ b/hail/src/main/resources/include/hail/ArrayBuilder.h
@@ -35,7 +35,7 @@ class BaseArrayBuilder {
 
   char * element_address(int idx) const { return elem_addr_ + idx * ArrayImpl::array_elem_size; }
 
-  const char * offset() const { return off_; }
+  char * offset() const { return off_; }
 };
 
 template<typename ElemT, bool elem_required, size_t elem_size, size_t elem_align, size_t array_align>
@@ -46,7 +46,7 @@ class ArrayLoadBuilder : public BaseArrayBuilder<elem_required, elem_size, elem_
     void set_element(int idx, ElemT elem) {
       *reinterpret_cast<ElemT *>(Base::element_address(idx)) = elem;
     }
-    using Base::BaseArrayBuilder;
+    using Base::Base;
 };
 
 template<bool elem_required, size_t elem_size, size_t elem_align, size_t array_align>
@@ -57,7 +57,7 @@ class ArrayAddrBuilder : public BaseArrayBuilder<elem_required, elem_size, elem_
     void set_element(int idx, const char * elem) {
       memcpy(Base::element_address(idx), elem, elem_size);
     }
-    using Base::BaseArrayBuilder;
+    using Base::Base;
 };
 
 }

--- a/hail/src/main/resources/include/hail/ArrayBuilder.h
+++ b/hail/src/main/resources/include/hail/ArrayBuilder.h
@@ -1,0 +1,65 @@
+#ifndef HAIL_ARRAYBUILDER_H
+#define HAIL_ARRAYBUILDER_H 1
+
+#include "hail/Utils.h"
+#include "hail/Region.h"
+
+namespace hail {
+
+template<bool elem_required, size_t elem_size, size_t elem_align, size_t array_align>
+class BaseArrayBuilder {
+  public:
+    using ArrayImpl = BaseArrayImpl<elem_required, elem_size, elem_align>;
+    int len_;
+    char * off_;
+    char * elem_addr_;
+
+    BaseArrayBuilder(int len, Region * region) :
+    len_(len), off_(nullptr), elem_addr_(nullptr) {
+      int elem_off = ArrayImpl::elements_offset(len_);
+      off_ = region->allocate(array_align, elem_off + len_ * ArrayImpl::array_elem_size);
+      elem_addr_ = off_ + elem_off;
+      store_int(off_, len_);
+    }
+
+    BaseArrayBuilder(int len, RegionPtr region) : BaseArrayBuilder(len, region.get()) { }
+
+  void clear_missing_bits() {
+    if (!elem_required) { memset(off_ + 4, 0, n_missing_bytes(len_)); }
+  }
+
+  void set_missing(int idx) {
+    if (elem_required) { throw FatalError("Required array element cannot be missing."); }
+    set_bit(off_ + 4, idx);
+  }
+
+  char * element_address(int idx) const { return elem_addr_ + idx * ArrayImpl::array_elem_size; }
+
+  const char * offset() const { return off_; }
+};
+
+template<typename ElemT, bool elem_required, size_t elem_size, size_t elem_align, size_t array_align>
+class ArrayLoadBuilder : public BaseArrayBuilder<elem_required, elem_size, elem_align, array_align> {
+  public:
+    using T = ElemT;
+    using Base = BaseArrayBuilder<elem_required, elem_size, elem_align, array_align>;
+    void set_element(int idx, ElemT elem) {
+      *reinterpret_cast<ElemT *>(Base::element_address(idx)) = elem;
+    }
+    using Base::BaseArrayBuilder;
+};
+
+template<bool elem_required, size_t elem_size, size_t elem_align, size_t array_align>
+class ArrayAddrBuilder : public BaseArrayBuilder<elem_required, elem_size, elem_align, array_align> {
+  public:
+    using T = char *;
+    using Base = BaseArrayBuilder<elem_required, elem_size, elem_align, array_align>;
+    void set_element(int idx, const char * elem) {
+      memcpy(Base::element_address(idx), elem, elem_size);
+    }
+    using Base::BaseArrayBuilder;
+};
+
+}
+
+#endif

--- a/hail/src/main/resources/include/hail/ArrayBuilder.h
+++ b/hail/src/main/resources/include/hail/ArrayBuilder.h
@@ -8,11 +8,13 @@ namespace hail {
 
 template<bool elem_required, size_t elem_size, size_t elem_align, size_t array_align>
 class BaseArrayBuilder {
-  public:
-    using ArrayImpl = BaseArrayImpl<elem_required, elem_size, elem_align>;
+  private:
     int len_;
     char * off_;
     char * elem_addr_;
+    
+  public:
+    using ArrayImpl = BaseArrayImpl<elem_required, elem_size, elem_align>;
 
     BaseArrayBuilder(int len, Region * region) :
     len_(len), off_(nullptr), elem_addr_(nullptr) {
@@ -24,18 +26,18 @@ class BaseArrayBuilder {
 
     BaseArrayBuilder(int len, RegionPtr region) : BaseArrayBuilder(len, region.get()) { }
 
-  void clear_missing_bits() {
-    if (!elem_required) { memset(off_ + 4, 0, n_missing_bytes(len_)); }
-  }
+    void clear_missing_bits() {
+      if (!elem_required) { memset(off_ + 4, 0, n_missing_bytes(len_)); }
+    }
 
-  void set_missing(int idx) {
-    if (elem_required) { throw FatalError("Required array element cannot be missing."); }
-    set_bit(off_ + 4, idx);
-  }
+    void set_missing(int idx) {
+      if (elem_required) { throw FatalError("Required array element cannot be missing."); }
+      set_bit(off_ + 4, idx);
+    }
 
-  char * element_address(int idx) const { return elem_addr_ + idx * ArrayImpl::array_elem_size; }
+    char * element_address(int idx) const { return elem_addr_ + idx * ArrayImpl::array_elem_size; }
 
-  char * offset() const { return off_; }
+    char * offset() const { return off_; }
 };
 
 template<typename ElemT, bool elem_required, size_t elem_size, size_t elem_align, size_t array_align>

--- a/hail/src/main/resources/include/hail/Utils.h
+++ b/hail/src/main/resources/include/hail/Utils.h
@@ -79,10 +79,9 @@ inline long lfloordiv(long n, long d) {
 
 template<bool elem_required, size_t elem_size, size_t elem_align>
 class BaseArrayImpl {
-private:
-  static constexpr size_t array_elem_size = round_up_offset(elem_size, elem_align);
-  
 public:
+  static constexpr size_t array_elem_size = round_up_offset(elem_size, elem_align);
+
   static int load_length(const char *a) {
     return load_int(a);
   }

--- a/hail/src/main/scala/is/hail/cxx/PackDecoder.scala
+++ b/hail/src/main/scala/is/hail/cxx/PackDecoder.scala
@@ -92,7 +92,7 @@ object PackDecoder {
 
     s"""
        |${ len.define }
-       |${ sab.start(len, clearMissing = false) }
+       |${ sab.start(len.toString, clearMissing = false) }
        |store_address($off, ${ sab.end() });
        |${ if (rt.elementType.required) "" else s"$input_buf_ptr->read_bytes(${ sab.end() } + 4, ${ rt.cxxNMissingBytes(s"$len") });" }
        |while (${ sab.idx } < $len) {

--- a/hail/src/main/scala/is/hail/cxx/StagedContainerBuilder.scala
+++ b/hail/src/main/scala/is/hail/cxx/StagedContainerBuilder.scala
@@ -1,56 +1,37 @@
 package is.hail.cxx
 
-import is.hail.annotations.UnsafeUtils
-import is.hail.cxx
-import is.hail.expr.types.physical.PContainer
+import is.hail.expr.types.physical.{PBaseStruct, PContainer, PType}
 
 class StagedContainerBuilder(fb: FunctionBuilder, region: Code, containerPType: PContainer) {
-  private[this] val aoff = fb.variable("aoff", "char *")
-  private[this] val eltOff = fb.variable("eltOff", "char *")
+  fb.translationUnitBuilder().include("hail/ArrayBuilder.h")
+
+  val eltType: PType = containerPType.elementType.fundamentalType
+
+  private[this] val params = s"${ eltType.required }, ${ eltType.byteSize }, ${ eltType.alignment }, ${ containerPType.contentsAlignment }"
+  private[this] val builderType: Type = eltType match {
+    case _: PBaseStruct => s"ArrayAddrBuilder<$params>"
+    case t => s"ArrayLoadBuilder<${typeToCXXType(t)}, $params>"
+  }
+  private[this] val builder = fb.variable("builder", builderType)
   private[this] val i = fb.variable("i", "int", "0")
-  private[this] val eltRequired = containerPType.elementType.required
 
   def start(len: Code, clearMissing: Boolean = true): Code = {
-    val __len = fb.variable("len", "int", len)
-    s"""${ __len.define }
-       |${ start(__len, clearMissing) }
-     """.stripMargin
-  }
-
-  def start(len: Variable, clearMissing: Boolean): Code = {
-    val nMissingBytes = containerPType.cxxNMissingBytes(len.toString)
-    val elementsOffset = containerPType.cxxElementsOffset(len.toString)
-    val allocate = s"${ region }->allocate(${ containerPType.contentsAlignment }, ${ containerPType.cxxContentsByteSize(len.toString) })"
-
-    s"""${ aoff.defineWith(allocate) }
-       |${ eltOff.defineWith(s"$aoff + $elementsOffset") }
+    s"""
+       |${ builder.defineWith(s"{ (int)$len, $region }") }
        |${ i.define }
-       |store_int($aoff, ${ len });
-       |${ if (!eltRequired && clearMissing) s"memset($aoff + 4, 0, $nMissingBytes);" else "" }
+       |${ if (clearMissing) s"$builder.clear_missing_bits();" }
      """.stripMargin
-
   }
 
-  def add(x: Code): Code = {
-    s"${
-      storeIRIntermediate(containerPType.elementType,
-        eltOffset,
-        x)
-    };"
-  }
+  def add(x: Code): Code = s"$builder.set_element($i, $x);"
 
-  def setMissing(): Code = {
-    if (eltRequired)
-      fb.nativeError("Required array element cannot be missing.")
-    else
-      s"set_bit($aoff + 4, $i);"
-  }
+  def setMissing(): Code = s"$builder.set_missing($i);"
 
   def advance(): Code = s"++$i;"
 
   def idx: Code = i.toString
 
-  def eltOffset: Code = s"$eltOff + $i * ${ UnsafeUtils.arrayElementSize(containerPType.elementType) }"
+  def eltOffset: Code = s"$builder.element_address($i)"
 
-  def end(): Code = aoff.toString
+  def end(): Code = s"$builder.offset()"
 }

--- a/hail/src/main/scala/is/hail/cxx/StagedContainerBuilder.scala
+++ b/hail/src/main/scala/is/hail/cxx/StagedContainerBuilder.scala
@@ -22,7 +22,7 @@ class StagedContainerBuilder(fb: FunctionBuilder, region: Code, containerPType: 
     s"""
        |${ builder.defineWith(s"{ (int)$len, $region }") }
        |${ i.define }
-       |${ if (clearMissing) s"$builder.clear_missing_bits();" }
+       |${ if (clearMissing) s"$builder.clear_missing_bits();" else "" }
      """.stripMargin
   }
 


### PR DESCRIPTION
Again, shouldn't change behavior but moves the implementation of StagedContainerBuilder from entirely Scala-generated to a templated C++ function so that we can construct arrays more easily from C++.