### PR TITLE
Refactor Python IR to reduce code duplication and complexity

### DIFF
--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -83,9 +83,8 @@ class SparkBackend(Backend):
     def _to_java_ir(self, ir):
         if not hasattr(ir, '_jir'):
             r = Renderer(stop_at_jir=True)
-            code = r(ir)
             # FIXME parse should be static
-            ir._jir = ir.parse(code, ir_map=r.jirs)
+            ir._jir = ir.parse(r(ir), ir_map=r.jirs)
         return ir._jir
 
     def execute(self, ir):
@@ -173,9 +172,8 @@ class LocalBackend(Backend):
     def _to_java_ir(self, ir):
         if not hasattr(ir, '_jir'):
             r = Renderer(stop_at_jir=True)
-            code = r(ir)
             # FIXME parse should be static
-            ir._jir = ir.parse(code, ir_map=r.jirs)
+            ir._jir = ir.parse(r(ir), ir_map=r.jirs)
         return ir._jir
 
     def execute(self, ir):
@@ -189,9 +187,8 @@ class ServiceBackend(Backend):
 
     def _render(self, ir):
         r = Renderer()
-        code = r(ir)
         assert len(r.jirs) == 0
-        return code
+        return r(ir)
 
     def execute(self, ir):
         code = self._render(ir)

--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -430,13 +430,13 @@ class Expression(object):
         return to_expr(other)._bin_op_numeric(name, self, ret_type_f)
 
     def _unary_op(self, name):
-        return expressions.construct_expr(ApplyUnaryOp(name, self._ir), self._type, self._indices, self._aggregations)
+        return expressions.construct_expr(ApplyUnaryPrimOp(name, self._ir), self._type, self._indices, self._aggregations)
 
     def _bin_op(self, name, other, ret_type):
         other = to_expr(other)
         indices, aggregations = unify_all(self, other)
         if (name in {'+', '-', '*', '/', '//'}) and (ret_type in {tint32, tint64, tfloat32, tfloat64}):
-            op = ApplyBinaryOp(name, self._ir, other._ir)
+            op = ApplyBinaryPrimOp(name, self._ir, other._ir)
         elif name in {"==", "!=", "<", "<=", ">", ">="}:
             op = ApplyComparisonOp(name, self._ir, other._ir)
         else:

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -4484,7 +4484,7 @@ def _shift_op(x, y, op):
     return hl.bind(lambda x, y: (
         hl.case()
             .when(y >= word_size, hl.sign(x) if op == '>>' else zero)
-            .when(y > 0, construct_expr(ApplyBinaryOp(op, x._ir, y._ir), t, indices, aggregations))
+            .when(y > 0, construct_expr(ApplyBinaryPrimOp(op, x._ir, y._ir), t, indices, aggregations))
             .or_error('cannot shift by a negative value: ' + hl.str(x) + f" {op} " + hl.str(y))), x, y)
 
 def _bit_op(x, y, op):
@@ -4497,7 +4497,7 @@ def _bit_op(x, y, op):
     y = coercer.coerce(y)
 
     indices, aggregations = unify_all(x, y)
-    return construct_expr(ApplyBinaryOp(op, x._ir, y._ir), t, indices, aggregations)
+    return construct_expr(ApplyBinaryPrimOp(op, x._ir, y._ir), t, indices, aggregations)
 
 
 @typecheck(x=expr_oneof(expr_int32, expr_int64), y=expr_oneof(expr_int32, expr_int64))
@@ -4692,7 +4692,7 @@ def bit_not(x):
     -------
     :class:`.Int32Expression` or :class:`.Int64Expression`
     """
-    return construct_expr(ApplyUnaryOp('~', x._ir), x.dtype, x._indices, x._aggregations)
+    return construct_expr(ApplyUnaryPrimOp('~', x._ir), x.dtype, x._indices, x._aggregations)
 
 
 @typecheck(s=expr_str)

--- a/hail/python/hail/ir/base_ir.py
+++ b/hail/python/hail/ir/base_ir.py
@@ -1,16 +1,44 @@
 import abc
-from .renderer import Renderer
+
+from typing import List
+
 from hail.utils.java import Env
+from .renderer import Renderer, Renderable, RenderableStr
 
 
-class BaseIR(object):
-    def __init__(self):
+class BaseIR(Renderable):
+    def __init__(self, *children):
         super().__init__()
         self._type = None
+        self.children = children
 
     def __str__(self):
-        r = Renderer(stop_at_jir = False)
+        r = Renderer(stop_at_jir=False)
         return r(self)
+
+    def render_head(self, r):
+        head_str = self.head_str()
+        if head_str != '':
+            head_str = f' {head_str}'
+        return f'({self._ir_name()}{head_str}'
+
+    def render_tail(self, r):
+        return ')'
+
+    def _ir_name(self):
+        return self.__class__.__name__
+
+    def render_children(self, r):
+        return self.children
+
+    def head_str(self):
+        """String to be added after IR name in serialized representation.
+
+        Returns
+        -------
+        str
+        """
+        return ''
 
     @abc.abstractmethod
     def parse(self, code, ref_map, ir_map):
@@ -20,12 +48,31 @@ class BaseIR(object):
     def typ(self):
         return
 
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.children == other.children and self._eq(other)
+
+    def __ne__(self, other):
+        return not self == other
+
+    def _eq(self, other):
+        """Compare non-child-BaseIR attributes of the BaseIR.
+
+        Parameters
+        ----------
+        other
+            BaseIR of the same class.
+
+        Returns
+        -------
+        bool
+        """
+        return True
+
 
 class IR(BaseIR):
     def __init__(self, *children):
-        super().__init__()
+        super().__init__(*children)
         self._aggregations = None
-        self.children = children
 
     @property
     def aggregations(self):
@@ -79,12 +126,12 @@ class IR(BaseIR):
 
 
 class TableIR(BaseIR):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *children):
+        super().__init__(*children)
 
     @abc.abstractmethod
     def _compute_type(self):
-        raise NotImplementedError(self)
+        ...
 
     @property
     def typ(self):
@@ -98,12 +145,12 @@ class TableIR(BaseIR):
 
 
 class MatrixIR(BaseIR):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *children):
+        super().__init__(*children)
 
     @abc.abstractmethod
     def _compute_type(self):
-        raise NotImplementedError(self)
+        ...
 
     @property
     def typ(self):
@@ -117,12 +164,12 @@ class MatrixIR(BaseIR):
 
 
 class BlockMatrixIR(BaseIR):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *children):
+        super().__init__(*children)
 
     @abc.abstractmethod
     def _compute_type(self):
-        raise NotImplementedError(self)
+        ...
 
     @property
     def typ(self):

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -3,7 +3,11 @@ from hail.ir import hl
 from hail.expr.types import tarray
 from hail.ir import BlockMatrixIR, IR
 from hail.ir.blockmatrix_reader import BlockMatrixReader
+from hail.ir import BlockMatrixIR, IR, tarray, Renderer
+from hail.utils.java import escape_str
 from hail.typecheck import typecheck_method, sequenceof
+
+from typing import List
 
 from hail.utils.java import Env
 
@@ -14,8 +18,11 @@ class BlockMatrixRead(BlockMatrixIR):
         super().__init__()
         self.reader = reader
 
-    def render(self, r):
-        return f'(BlockMatrixRead "{r(self.reader)}")'
+    def head_str(self):
+        return f'"{self.reader.render()}"'
+
+    def _eq(self, other):
+        return self.reader == other.reader
 
     def _compute_type(self):
         self._type = Env.backend().blockmatrix_type(self)
@@ -24,12 +31,9 @@ class BlockMatrixRead(BlockMatrixIR):
 class BlockMatrixMap(BlockMatrixIR):
     @typecheck_method(child=BlockMatrixIR, f=IR)
     def __init__(self, child, f):
-        super().__init__()
+        super().__init__(child, f)
         self.child = child
         self.f = f
-
-    def render(self, r):
-        return f'(BlockMatrixMap {r(self.child)} {r(self.f)})'
 
     def _compute_type(self):
         self._type = self.child.typ
@@ -38,13 +42,10 @@ class BlockMatrixMap(BlockMatrixIR):
 class BlockMatrixMap2(BlockMatrixIR):
     @typecheck_method(left=BlockMatrixIR, right=BlockMatrixIR, f=IR)
     def __init__(self, left, right, f):
-        super().__init__()
+        super().__init__(left, right, f)
         self.left = left
         self.right = right
         self.f = f
-
-    def render(self, r):
-        return f'(BlockMatrixMap2 {r(self.left)} {r(self.right)} {r(self.f)})'
 
     def _compute_type(self):
         self.right.typ  # Force
@@ -54,12 +55,9 @@ class BlockMatrixMap2(BlockMatrixIR):
 class BlockMatrixDot(BlockMatrixIR):
     @typecheck_method(left=BlockMatrixIR, right=BlockMatrixIR)
     def __init__(self, left, right):
-        super().__init__()
+        super().__init__(left, right)
         self.left = left
         self.right = right
-
-    def render(self, r):
-        return '(BlockMatrixDot {} {})'.format(r(self.left), r(self.right))
 
     def _compute_type(self):
         l_rows, l_cols = tensor_shape_to_matrix_shape(self.left)
@@ -79,18 +77,21 @@ class BlockMatrixBroadcast(BlockMatrixIR):
                       shape=sequenceof(int),
                       block_size=int)
     def __init__(self, child, in_index_expr, shape, block_size):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.in_index_expr = in_index_expr
         self.shape = shape
         self.block_size = block_size
 
-    def render(self, r):
-        return '(BlockMatrixBroadcast {} {} {} {})'\
-            .format(_serialize_list(self.in_index_expr),
-                    _serialize_list(self.shape),
-                    self.block_size,
-                    r(self.child))
+    def head_str(self):
+        return '{} {} {}'.format(_serialize_list(self.in_index_expr),
+                                 _serialize_list(self.shape),
+                                 self.block_size)
+
+    def _eq(self, other):
+        return self.in_index_expr == other.in_index_expr and \
+               self.shape == other.shape and \
+               self.block_size == other.block_size
 
     def _compute_type(self):
         assert len(self.shape) == 2
@@ -105,14 +106,15 @@ class BlockMatrixAgg(BlockMatrixIR):
     @typecheck_method(child=BlockMatrixIR,
                       out_index_expr=sequenceof(int))
     def __init__(self, child, out_index_expr):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.out_index_expr = out_index_expr
 
-    def render(self, r):
-        return '(BlockMatrixAgg {} {})' \
-            .format(_serialize_list(self.out_index_expr),
-                    r(self.child))
+    def head_str(self):
+        return _serialize_list(self.out_index_expr)
+
+    def _eq(self, other):
+        return self.out_index_expr == other.out_index_expr
 
     def _compute_type(self):
         shape = [self.child.typ.shape[i] for i in self.out_index_expr]
@@ -137,7 +139,8 @@ class BlockMatrixFilter(BlockMatrixIR):
 
     def _compute_type(self):
         assert len(self.indices_to_keep) == 2
-        shape = [len(idxs) if len(idxs) != 0 else self.child.typ.shape[i] for i, idxs in enumerate(self.indices_to_keep)]
+        shape = [len(idxs) if len(idxs) != 0 else self.child.typ.shape[i] for i, idxs in
+                 enumerate(self.indices_to_keep)]
 
         tensor_shape, is_row_vector = _matrix_shape_to_tensor_shape(shape[0], shape[1])
         self._type = tblockmatrix(self.child.typ.element_type,
@@ -151,15 +154,18 @@ class ValueToBlockMatrix(BlockMatrixIR):
                       shape=sequenceof(int),
                       block_size=int)
     def __init__(self, child, shape, block_size):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.shape = shape
         self.block_size = block_size
 
-    def render(self, r):
-        return '(ValueToBlockMatrix {} {} {})'.format(_serialize_list(self.shape),
-                                                      self.block_size,
-                                                      r(self.child))
+    def head_str(self):
+        return '{} {}'.format(_serialize_list(self.shape),
+                              self.block_size)
+
+    def _eq(self, other):
+        return self.shape == other.shape and \
+               self.block_size == other.block_size
 
     def _compute_type(self):
         child_type = self.child.typ
@@ -185,11 +191,11 @@ class BlockMatrixRandom(BlockMatrixIR):
         self.shape = shape
         self.block_size = block_size
 
-    def render(self, r):
-        return '(BlockMatrixRandom {} {} {} {})'.format(self.seed,
-                                                        self.gaussian,
-                                                        _serialize_list(self.shape),
-                                                        self.block_size)
+    def head_str(self):
+        return '{} {} {} {}'.format(self.seed,
+                                    self.gaussian,
+                                    _serialize_list(self.shape),
+                                    self.block_size)
 
     def _compute_type(self):
         assert len(self.shape) == 2
@@ -203,8 +209,8 @@ class JavaBlockMatrix(BlockMatrixIR):
         super().__init__()
         self.jir = Env.hail().expr.ir.BlockMatrixLiteral(jbm)
 
-    def render(self, r):
-        return f'(JavaBlockMatrix {r.add_jir(self.jir)})'
+    def render_head(self, r):
+        return f'(JavaBlockMatrix {r.add_jir(self.jir)}'
 
     def _compute_type(self):
         self._type = tblockmatrix._from_java(self.jir.typ())

--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -129,13 +129,15 @@ class BlockMatrixAgg(BlockMatrixIR):
 class BlockMatrixFilter(BlockMatrixIR):
     @typecheck_method(child=BlockMatrixIR, indices_to_keep=sequenceof(sequenceof(int)))
     def __init__(self, child, indices_to_keep):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.indices_to_keep = indices_to_keep
 
-    def render(self, r):
-        formatted_indices = _serialize_list([_serialize_list(idxs) for idxs in self.indices_to_keep])
-        return f'(BlockMatrixFilter {formatted_indices} {r(self.child)})'
+    def head_str(self):
+        return _serialize_list([_serialize_list(idxs) for idxs in self.indices_to_keep])
+
+    def _eq(self, other):
+        return self.indices_to_keep == other.indices_to_keep
 
     def _compute_type(self):
         assert len(self.indices_to_keep) == 2
@@ -196,6 +198,12 @@ class BlockMatrixRandom(BlockMatrixIR):
                                     self.gaussian,
                                     _serialize_list(self.shape),
                                     self.block_size)
+
+    def _eq(self, other):
+        return self.seed == other.seed and \
+               self.gaussian == other.gaussian and \
+               self.shape == other.shape and \
+               self.block_size == other.block_size
 
     def _compute_type(self):
         assert len(self.shape) == 2

--- a/hail/python/hail/ir/blockmatrix_reader.py
+++ b/hail/python/hail/ir/blockmatrix_reader.py
@@ -7,7 +7,7 @@ from ..utils.java import escape_str
 
 class BlockMatrixReader(object):
     @abc.abstractmethod
-    def render(self, r):
+    def render(self):
         pass
 
     @abc.abstractmethod
@@ -20,7 +20,7 @@ class BlockMatrixNativeReader(BlockMatrixReader):
     def __init__(self, path):
         self.path = path
 
-    def render(self, r):
+    def render(self):
         reader = {'name': 'BlockMatrixNativeReader',
                   'path': self.path}
         return escape_str(json.dumps(reader))
@@ -37,7 +37,7 @@ class BlockMatrixBinaryReader(BlockMatrixReader):
         self.shape = shape
         self.block_size = block_size
 
-    def render(self, r):
+    def render(self):
         reader = {'name': 'BlockMatrixBinaryReader',
                   'path': self.path,
                   'shape': self.shape,

--- a/hail/python/hail/ir/blockmatrix_writer.py
+++ b/hail/python/hail/ir/blockmatrix_writer.py
@@ -7,7 +7,7 @@ from ..utils.java import escape_str
 
 class BlockMatrixWriter(object):
     @abc.abstractmethod
-    def render(self, r):
+    def render(self):
         pass
 
     @abc.abstractmethod
@@ -23,7 +23,7 @@ class BlockMatrixNativeWriter(BlockMatrixWriter):
         self.force_row_major = force_row_major
         self.stage_locally = stage_locally
 
-    def render(self, r):
+    def render(self):
         writer = {'name': 'BlockMatrixNativeWriter',
                   'path': self.path,
                   'overwrite': self.overwrite,
@@ -44,7 +44,7 @@ class BlockMatrixBinaryWriter(BlockMatrixWriter):
     def __init__(self, path):
         self.path = path
 
-    def render(self, r):
+    def render(self):
         writer = {'name': 'BlockMatrixBinaryWriter',
                   'path': self.path}
         return escape_str(json.dumps(writer))
@@ -65,7 +65,7 @@ class BlockMatrixRectanglesWriter(BlockMatrixWriter):
         self.delimiter = delimiter
         self.binary = binary
 
-    def render(self, r):
+    def render(self):
         writer = {'name': 'BlockMatrixRectanglesWriter',
                   'path': self.path,
                   'rectangles': self.rectangles,

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -7,6 +7,7 @@ from hail.expr.types import *
 from hail.typecheck import *
 from .base_ir import *
 from .matrix_writer import MatrixWriter, MatrixNativeMultiWriter
+from .renderer import Renderer, Renderable, RenderableStr, ParensRenderer
 
 
 def _env_bind(env, k, v):
@@ -21,16 +22,14 @@ class I32(IR):
         super().__init__()
         self.x = x
 
+    def _eq(self, other):
+        return self.x == other.x
+
     def copy(self):
-        new_instance = self.__class__
-        return new_instance(self.x)
+        return I32(self.x)
 
-    def render(self, r):
-        return '(I32 {})'.format(self.x)
-
-    def __eq__(self, other):
-        return isinstance(other, I32) and \
-               other.x == self.x
+    def head_str(self):
+        return self.x
 
     def _compute_type(self, env, agg_env):
         self._type = tint32
@@ -42,16 +41,14 @@ class I64(IR):
         super().__init__()
         self.x = x
 
+    def _eq(self, other):
+        return self.x == other.x
+
     def copy(self):
-        new_instance = self.__class__
-        return new_instance(self.x)
+        return I64(self.x)
 
-    def render(self, r):
-        return '(I64 {})'.format(self.x)
-
-    def __eq__(self, other):
-        return isinstance(other, I64) and \
-               other.x == self.x
+    def head_str(self):
+        return self.x
 
     def _compute_type(self, env, agg_env):
         self._type = tint64
@@ -63,19 +60,18 @@ class F32(IR):
         super().__init__()
         self.x = x
 
+    def _eq(self, other):
+        return self.x == other.x
+
     def copy(self):
-        new_instance = self.__class__
-        return new_instance(self.x)
+        return F32(self.x)
 
-    def render(self, r):
-        return '(F32 {})'.format(self.x)
-
-    def __eq__(self, other):
-        return isinstance(other, F32) and \
-               other.x == self.x
+    def head_str(self):
+        return self.x
 
     def _compute_type(self, env, agg_env):
         self._type = tfloat32
+
 
 class F64(IR):
     @typecheck_method(x=numeric)
@@ -83,16 +79,14 @@ class F64(IR):
         super().__init__()
         self.x = x
 
+    def _eq(self, other):
+        return self.x == other.x
+
     def copy(self):
-        new_instance = self.__class__
-        return new_instance(self.x)
+        return F64(self.x)
 
-    def render(self, r):
-        return '(F64 {})'.format(self.x)
-
-    def __eq__(self, other):
-        return isinstance(other, F64) and \
-               other.x == self.x
+    def head_str(self):
+        return self.x
 
     def _compute_type(self, env, agg_env):
         self._type = tfloat64
@@ -104,16 +98,14 @@ class Str(IR):
         super().__init__()
         self.x = x
 
+    def _eq(self, other):
+        return self.x == other.x
+
     def copy(self):
-        new_instance = self.__class__
-        return new_instance(self.x)
+        return Str(self.x)
 
-    def render(self, r):
-        return '(Str "{}")'.format(escape_str(self.x))
-
-    def __eq__(self, other):
-        return isinstance(other, Str) and \
-               other.x == self.x
+    def head_str(self):
+        return f'"{escape_str(self.x)}"'
 
     def _compute_type(self, env, agg_env):
         self._type = tstr
@@ -124,14 +116,10 @@ class FalseIR(IR):
         super().__init__()
 
     def copy(self):
-        new_instance = self.__class__
-        return new_instance()
+        return FalseIR()
 
-    def render(self, r):
-        return '(False)'
-
-    def __eq__(self, other):
-        return isinstance(other, FalseIR)
+    def _ir_name(self):
+        return 'False'
 
     def _compute_type(self, env, agg_env):
         self._type = tbool
@@ -142,14 +130,10 @@ class TrueIR(IR):
         super().__init__()
 
     def copy(self):
-        new_instance = self.__class__
-        return new_instance()
+        return TrueIR()
 
-    def render(self, r):
-        return '(True)'
-
-    def __eq__(self, other):
-        return isinstance(other, TrueIR)
+    def _ir_name(self):
+        return 'True'
 
     def _compute_type(self, env, agg_env):
         self._type = tbool
@@ -160,14 +144,7 @@ class Void(IR):
         super().__init__()
 
     def copy(self):
-        new_instance = self.__class__
-        return new_instance()
-
-    def render(self, r):
-        return '(Void)'
-
-    def __eq__(self, other):
-        return isinstance(other, Void)
+        return Void()
 
     def _compute_type(self, env, agg_env):
         self._type = tvoid
@@ -184,18 +161,15 @@ class Cast(IR):
     def typ(self):
         return self._typ
 
+    def _eq(self, other):
+        return self._typ == other._typ
+
     @typecheck_method(v=IR)
     def copy(self, v):
-        new_instance = self.__class__
-        return new_instance(v, self._typ)
+        return Cast(v, self.typ)
 
-    def render(self, r):
-        return '(Cast {} {})'.format(self._typ._parsable_string(), r(self.v))
-
-    def __eq__(self, other):
-        return isinstance(other, Cast) and \
-        other.v == self.v and \
-        other._typ == self._typ
+    def head_str(self):
+        return self._typ._parsable_string()
 
     def _compute_type(self, env, agg_env):
         self.v._compute_type(env, agg_env)
@@ -212,16 +186,14 @@ class NA(IR):
     def typ(self):
         return self._typ
 
+    def _eq(self, other):
+        return self._typ == other._typ
+
     def copy(self):
-        new_instance = self.__class__
-        return new_instance(self._typ)
+        return NA(self._typ)
 
-    def render(self, r):
-        return '(NA {})'.format(self._typ._parsable_string())
-
-    def __eq__(self, other):
-        return isinstance(other, NA) and \
-               other._typ == self._typ
+    def head_str(self):
+        return self._typ._parsable_string()
 
     def _compute_type(self, env, agg_env):
         self._type = self._typ
@@ -235,15 +207,7 @@ class IsNA(IR):
 
     @typecheck_method(value=IR)
     def copy(self, value):
-        new_instance = self.__class__
-        return new_instance(value)
-
-    def render(self, r):
-        return '(IsNA {})'.format(r(self.value))
-
-    def __eq__(self, other):
-        return isinstance(other, IsNA) and \
-               other.value == self.value
+        return IsNA(value)
 
     def _compute_type(self, env, agg_env):
         self.value._compute_type(env, agg_env)
@@ -260,25 +224,15 @@ class If(IR):
 
     @typecheck_method(cond=IR, cnsq=IR, altr=IR)
     def copy(self, cond, cnsq, altr):
-        new_instance = self.__class__
-        return new_instance(cond, cnsq, altr)
-
-    def render(self, r):
-        return '(If {} {} {})'.format(r(self.cond), r(self.cnsq), r(self.altr))
-
-    def __eq__(self, other):
-        return isinstance(other, If) and \
-               other.cond == self.cond and \
-               other.cnsq == self.cnsq and \
-               other.altr == self.altr
+        return If(cond, cnsq, altr)
 
     def _compute_type(self, env, agg_env):
         self.cond._compute_type(env, agg_env)
         self.cnsq._compute_type(env, agg_env)
         self.altr._compute_type(env, agg_env)
-        assert(self.cnsq.typ == self.altr.typ)
+        assert (self.cnsq.typ == self.altr.typ)
         self._type = self.cnsq.typ
-    
+
 
 class Let(IR):
     @typecheck_method(name=str, value=IR, body=IR)
@@ -290,21 +244,17 @@ class Let(IR):
 
     @typecheck_method(value=IR, body=IR)
     def copy(self, value, body):
-        new_instance = self.__class__
-        return new_instance(self.name, value, body)
+        return Let(self.name, value, body)
 
-    def render(self, r):
-        return '(Let {} {} {})'.format(escape_id(self.name), r(self.value), r(self.body))
+    def head_str(self):
+        return escape_id(self.name)
 
     @property
     def bound_variables(self):
         return {self.name} | super().bound_variables
 
-    def __eq__(self, other):
-        return isinstance(other, Let) and \
-               other.name == self.name and \
-               other.value == self.value and \
-               other.body == self.body
+    def _eq(self, other):
+        return other.name == self.name
 
     def _compute_type(self, env, agg_env):
         self.value._compute_type(env, agg_env)
@@ -319,15 +269,13 @@ class Ref(IR):
         self.name = name
 
     def copy(self):
-        new_instance = self.__class__
-        return new_instance(self.name)
+        return Ref(self.name)
 
-    def render(self, r):
-        return '(Ref {})'.format(escape_id(self.name))
+    def head_str(self):
+        return escape_id(self.name)
 
-    def __eq__(self, other):
-        return isinstance(other, Ref) and \
-               other.name == self.name
+    def _eq(self, other):
+        return other.name == self.name
 
     def _compute_type(self, env, agg_env):
         self._type = env[self.name]
@@ -343,19 +291,17 @@ class TopLevelReference(Ref):
         return True
 
     def copy(self):
-        new_instance = self.__class__
-        return new_instance(self.name)
+        return TopLevelReference(self.name)
 
-    def __eq__(self, other):
-        return isinstance(other, TopLevelReference) and \
-               other.name == self.name
+    def _ir_name(self):
+        return 'Ref'
 
     def _compute_type(self, env, agg_env):
         assert self.name in env, f'{self.name} not found in {env}'
         self._type = env[self.name]
 
 
-class ApplyBinaryOp(IR):
+class ApplyBinaryPrimOp(IR):
     @typecheck_method(op=str, l=IR, r=IR)
     def __init__(self, op, l, r):
         super().__init__(l, r)
@@ -365,17 +311,13 @@ class ApplyBinaryOp(IR):
 
     @typecheck_method(l=IR, r=IR)
     def copy(self, l, r):
-        new_instance = self.__class__
-        return new_instance(self.op, l, r)
+        return ApplyBinaryPrimOp(self.op, l, r)
 
-    def render(self, r):
-        return '(ApplyBinaryPrimOp {} {} {})'.format(escape_id(self.op), r(self.l), r(self.r))
+    def head_str(self):
+        return escape_id(self.op)
 
-    def __eq__(self, other):
-        return isinstance(other, ApplyBinaryOp) and \
-               other.op == self.op and \
-               other.l == self.l and \
-               other.r == self.r
+    def _eq(self, other):
+        return other.op == self.op
 
     def _compute_type(self, env, agg_env):
         self.l._compute_type(env, agg_env)
@@ -387,9 +329,9 @@ class ApplyBinaryOp(IR):
                 self._type = tfloat32
         else:
             self._type = self.l.typ
-                
 
-class ApplyUnaryOp(IR):
+
+class ApplyUnaryPrimOp(IR):
     @typecheck_method(op=str, x=IR)
     def __init__(self, op, x):
         super().__init__(x)
@@ -398,16 +340,13 @@ class ApplyUnaryOp(IR):
 
     @typecheck_method(x=IR)
     def copy(self, x):
-        new_instance = self.__class__
-        return new_instance(self.op, x)
+        return ApplyUnaryPrimOp(self.op, x)
 
-    def render(self, r):
-        return '(ApplyUnaryPrimOp {} {})'.format(escape_id(self.op), r(self.x))
+    def head_str(self):
+        return escape_id(self.op)
 
-    def __eq__(self, other):
-        return isinstance(other, ApplyUnaryOp) and \
-               other.op == self.op and \
-               other.x == self.x
+    def _eq(self, other):
+        return other.op == self.op
 
     def _compute_type(self, env, agg_env):
         self.x._compute_type(env, agg_env)
@@ -424,17 +363,13 @@ class ApplyComparisonOp(IR):
 
     @typecheck_method(l=IR, r=IR)
     def copy(self, l, r):
-        new_instance = self.__class__
-        return new_instance(self.op, l, r)
+        return ApplyComparisonOp(self.op, l, r)
 
-    def render(self, r):
-        return '(ApplyComparisonOp {} {} {})'.format(escape_id(self.op), r(self.l), r(self.r))
+    def head_str(self):
+        return escape_id(self.op)
 
-    def __eq__(self, other):
-        return isinstance(other, ApplyComparisonOp) and \
-               other.op == self.op and \
-               other.l == self.l and \
-               other.r == self.r
+    def _eq(self, other):
+        return other.op == self.op
 
     def _compute_type(self, env, agg_env):
         self.l._compute_type(env, agg_env)
@@ -450,18 +385,13 @@ class MakeArray(IR):
         self._type = type
 
     def copy(self, *args):
-        new_instance = self.__class__
-        return new_instance(list(args), self._type)
+        return MakeArray(args, self._type)
 
-    def render(self, r):
-        return '(MakeArray {} {})'.format(
-            self._type._parsable_string() if self._type is not None else 'None',
-            ' '.join([r(x) for x in self.args]))
+    def head_str(self):
+        return self._type._parsable_string() if self._type is not None else 'None'
 
-    def __eq__(self, other):
-        return isinstance(other, MakeArray) and \
-               other.args == self.args and \
-               other._type == self._type
+    def _eq(self, other):
+        return other._type == self._type
 
     def _compute_type(self, env, agg_env):
         for a in self.args:
@@ -479,16 +409,7 @@ class ArrayRef(IR):
 
     @typecheck_method(a=IR, i=IR)
     def copy(self, a, i):
-        new_instance = self.__class__
-        return new_instance(a, i)
-
-    def render(self, r):
-        return '(ArrayRef {} {})'.format(r(self.a), r(self.i))
-
-    def __eq__(self, other):
-        return isinstance(other, ArrayRef) and \
-               other.a == self.a and \
-               other.i == self.i
+        return ArrayRef(a, i)
 
     def _compute_type(self, env, agg_env):
         self.a._compute_type(env, agg_env)
@@ -504,19 +425,12 @@ class ArrayLen(IR):
 
     @typecheck_method(a=IR)
     def copy(self, a):
-        new_instance = self.__class__
-        return new_instance(a)
-
-    def render(self, r):
-        return '(ArrayLen {})'.format(r(self.a))
-
-    def __eq__(self, other):
-        return isinstance(other, ArrayLen) and \
-               other.a == self.a
+        return ArrayLen(a)
 
     def _compute_type(self, env, agg_env):
         self.a._compute_type(env, agg_env)
         self._type = tint32
+
 
 class ArrayRange(IR):
     @typecheck_method(start=IR, stop=IR, step=IR)
@@ -528,17 +442,7 @@ class ArrayRange(IR):
 
     @typecheck_method(start=IR, stop=IR, step=IR)
     def copy(self, start, stop, step):
-        new_instance = self.__class__
-        return new_instance(start, stop, step)
-
-    def render(self, r):
-        return '(ArrayRange {} {} {})'.format(r(self.start), r(self.stop), r(self.step))
-
-    def __eq__(self, other):
-        return isinstance(other, ArrayRange) and \
-               other.start == self.start and \
-               other.stop == self.stop and \
-               other.step == self.step
+        return ArrayRange(start, stop, step)
 
     def _compute_type(self, env, agg_env):
         self.start._compute_type(env, agg_env)
@@ -557,20 +461,7 @@ class MakeNDArray(IR):
 
     @typecheck_method(data=IR, shape=IR, row_major=IR)
     def copy(self, data, shape, row_major):
-        new_instance = self.__class__
-        return new_instance(data, shape, row_major)
-
-    def render(self, r):
-        return '(MakeNDArray {} {} {})'.format(
-            r(self.data),
-            r(self.shape),
-            r(self.row_major))
-
-    def __eq__(self, other):
-        return isinstance(other, MakeNDArray) and \
-               other.data == self.data and \
-               other.shape == self.shape and \
-               other.row_major == self.row_major
+        return MakeNDArray(data, shape, row_major)
 
     def _compute_type(self, env, agg_env):
         self.data._compute_type(env, agg_env)
@@ -588,16 +479,7 @@ class NDArrayRef(IR):
 
     @typecheck_method(nd=IR, idxs=IR)
     def copy(self, nd, idxs):
-        new_instance = self.__class__
-        return new_instance(nd, idxs)
-
-    def render(self, r):
-        return '(NDArrayRef {} {})'.format(r(self.nd), r(self.idxs))
-
-    def __eq__(self, other):
-        return isinstance(other, NDArrayRef) and \
-               other.nd == self.nd and \
-               other.idxs == self.idxs
+        return NDArrayRef(nd, idxs)
 
     def _compute_type(self, env, agg_env):
         self.nd._compute_type(env, agg_env)
@@ -616,21 +498,17 @@ class ArraySort(IR):
 
     @typecheck_method(a=IR, compare=IR)
     def copy(self, a, compare):
-        new_instance = self.__class__
-        return new_instance(a, self.l_name, self.r_name, compare)
+        return ArraySort(a, self.l_name, self.r_name, compare)
 
-    def render(self, r):
-        return '(ArraySort {} {} {} {})'.format(self.l_name, self.r_name, r(self.a), r(self.compare))
+    def head_str(self):
+        return f'{escape_id(self.l_name)} {escape_id(self.r_name)}'
 
     @property
     def bound_variables(self):
         return {self.l_name, self.r_name} | super().bound_variables
 
     def __eq__(self, other):
-        return isinstance(other, ArraySort) and \
-               other.a == self.a and \
-               other.compare == self.compare and \
-               other.l_name == self.l_name and other.r_name == self.r_name
+        return other.l_name == self.l_name and other.r_name == self.r_name
 
     def _compute_type(self, env, agg_env):
         self.a._compute_type(env, agg_env)
@@ -645,15 +523,7 @@ class ToSet(IR):
 
     @typecheck_method(a=IR)
     def copy(self, a):
-        new_instance = self.__class__
-        return new_instance(a)
-
-    def render(self, r):
-        return '(ToSet {})'.format(r(self.a))
-
-    def __eq__(self, other):
-        return isinstance(other, ToSet) and \
-               other.a == self.a
+        return ToSet(a)
 
     def _compute_type(self, env, agg_env):
         self.a._compute_type(env, agg_env)
@@ -668,15 +538,7 @@ class ToDict(IR):
 
     @typecheck_method(a=IR)
     def copy(self, a):
-        new_instance = self.__class__
-        return new_instance(a)
-
-    def render(self, r):
-        return '(ToDict {})'.format(r(self.a))
-
-    def __eq__(self, other):
-        return isinstance(other, ToDict) and \
-               other.a == self.a
+        return ToDict(a)
 
     def _compute_type(self, env, agg_env):
         self.a._compute_type(env, agg_env)
@@ -691,19 +553,12 @@ class ToArray(IR):
 
     @typecheck_method(a=IR)
     def copy(self, a):
-        new_instance = self.__class__
-        return new_instance(a)
-
-    def render(self, r):
-        return '(ToArray {})'.format(r(self.a))
-
-    def __eq__(self, other):
-        return isinstance(other, ToArray) and \
-               other.a == self.a
+        return ToArray(a)
 
     def _compute_type(self, env, agg_env):
         self.a._compute_type(env, agg_env)
         self._type = tarray(self.a.typ.element_type)
+
 
 class LowerBoundOnOrderedCollection(IR):
     @typecheck_method(ordered_collection=IR, elem=IR, on_key=bool)
@@ -715,22 +570,16 @@ class LowerBoundOnOrderedCollection(IR):
 
     @typecheck_method(ordered_collection=IR, elem=IR)
     def copy(self, ordered_collection, elem):
-        new_instance = self.__class__
-        return new_instance(ordered_collection, elem, self.on_key)
+        return LowerBoundOnOrderedCollection(ordered_collection, elem, self.on_key)
 
-    def render(self, r):
-        return '(LowerBoundOnOrderedCollection {} {} {})'.format(self.on_key, r(self.ordered_collection), r(self.elem))
-
-    def __eq__(self, other):
-        return isinstance(other, LowerBoundOnOrderedCollection) and \
-               other.ordered_collection == self.ordered_collection and \
-               other.elem == self.elem and \
-               other.on_key == self.on_key
+    def head_str(self):
+        return self.on_key
 
     def _compute_type(self, env, agg_env):
         self.a._compute_type(env, agg_env)
         self.elem._compute_type(env, agg_env)
         self._type = tint32
+
 
 class GroupByKey(IR):
     @typecheck_method(collection=IR)
@@ -740,20 +589,13 @@ class GroupByKey(IR):
 
     @typecheck_method(collection=IR)
     def copy(self, collection):
-        new_instance = self.__class__
-        return new_instance(collection)
-
-    def render(self, r):
-        return '(GroupByKey {})'.format(r(self.collection))
-
-    def __eq__(self, other):
-        return isinstance(other, GroupByKey) and \
-               other.collection == self.collection
+        return GroupByKey(collection)
 
     def _compute_type(self, env, agg_env):
         self.collection._compute_type(env, agg_env)
         self._type = tdict(self.collection.typ.element_type.types[0],
                            tarray(self.collection.typ.element_type.types[1]))
+
 
 class ArrayMap(IR):
     @typecheck_method(a=IR, name=str, body=IR)
@@ -765,26 +607,23 @@ class ArrayMap(IR):
 
     @typecheck_method(a=IR, body=IR)
     def copy(self, a, body):
-        new_instance = self.__class__
-        return new_instance(a, self.name, body)
+        return ArrayMap(a, self.name, body)
 
-    def render(self, r):
-        return '(ArrayMap {} {} {})'.format(escape_id(self.name), r(self.a), r(self.body))
+    def head_str(self):
+        return escape_id(self.name)
+
+    def _eq(self, other):
+        return self.name == other.name
 
     @property
     def bound_variables(self):
         return {self.name} | super().bound_variables
 
-    def __eq__(self, other):
-        return isinstance(other, ArrayMap) and \
-               other.a == self.a and \
-               other.name == self.name and \
-               other.body == self.body
-
     def _compute_type(self, env, agg_env):
         self.a._compute_type(env, agg_env)
         self.body._compute_type(_env_bind(env, self.name, self.a.typ.element_type), agg_env)
         self._type = tarray(self.body.typ)
+
 
 class ArrayFilter(IR):
     @typecheck_method(a=IR, name=str, body=IR)
@@ -796,26 +635,23 @@ class ArrayFilter(IR):
 
     @typecheck_method(a=IR, body=IR)
     def copy(self, a, body):
-        new_instance = self.__class__
-        return new_instance(a, self.name, body)
+        return ArrayFilter(a, self.name, body)
 
-    def render(self, r):
-        return '(ArrayFilter {} {} {})'.format(escape_id(self.name), r(self.a), r(self.body))
+    def head_str(self):
+        return escape_id(self.name)
+
+    def _eq(self, other):
+        return self.name == other.name
 
     @property
     def bound_variables(self):
         return {self.name} | super().bound_variables
 
-    def __eq__(self, other):
-        return isinstance(other, ArrayFilter) and \
-               other.a == self.a and \
-               other.name == self.name and \
-               other.body == self.body
-
     def _compute_type(self, env, agg_env):
         self.a._compute_type(env, agg_env)
         self.body._compute_type(_env_bind(env, self.name, self.a.typ.element_type), agg_env)
         self._type = self.a.typ
+
 
 class ArrayFlatMap(IR):
     @typecheck_method(a=IR, name=str, body=IR)
@@ -827,21 +663,17 @@ class ArrayFlatMap(IR):
 
     @typecheck_method(a=IR, body=IR)
     def copy(self, a, body):
-        new_instance = self.__class__
-        return new_instance(a, self.name, body)
+        return ArrayFlatMap(a, self.name, body)
 
-    def render(self, r):
-        return '(ArrayFlatMap {} {} {})'.format(escape_id(self.name), r(self.a), r(self.body))
+    def head_str(self):
+        return escape_id(self.name)
+
+    def _eq(self, other):
+        return self.name == other.name
 
     @property
     def bound_variables(self):
         return {self.name} | super().bound_variables
-
-    def __eq__(self, other):
-        return isinstance(other, ArrayFlatMap) and \
-               other.a == self.a and \
-               other.name == self.name and \
-               other.body == self.body
 
     def _compute_type(self, env, agg_env):
         self.a._compute_type(env, agg_env)
@@ -861,25 +693,17 @@ class ArrayFold(IR):
 
     @typecheck_method(a=IR, zero=IR, body=IR)
     def copy(self, a, zero, body):
-        new_instance = self.__class__
-        return new_instance(a, zero, self.accum_name, self.value_name, body)
+        return ArrayFold(a, zero, self.accum_name, self.value_name, body)
 
-    def render(self, r):
-        return '(ArrayFold {} {} {} {} {})'.format(
-            escape_id(self.accum_name), escape_id(self.value_name),
-            r(self.a), r(self.zero), r(self.body))
+    def head_str(self):
+        return f'{escape_id(self.accum_name)} {escape_id(self.value_name)}'
 
-    @property
+    def _eq(self, other):
+        return other.accum_name == self.accum_name and \
+               other.value_name == self.value_name
+
     def bound_variables(self):
         return {self.accum_name, self.value_name} | super().bound_variables
-
-    def __eq__(self, other):
-        return isinstance(other, ArrayFold) and \
-               other.a == self.a and \
-               other.zero == self.zero and \
-               other.accum_name == self.accum_name and \
-               other.value_name == self.value_name and \
-               other.body == self.body
 
     def _compute_type(self, env, agg_env):
         self.a._compute_type(env, agg_env)
@@ -891,7 +715,7 @@ class ArrayFold(IR):
             agg_env)
         self._type = self.zero.typ
 
-        
+
 class ArrayScan(IR):
     @typecheck_method(a=IR, zero=IR, accum_name=str, value_name=str, body=IR)
     def __init__(self, a, zero, accum_name, value_name, body):
@@ -904,25 +728,18 @@ class ArrayScan(IR):
 
     @typecheck_method(a=IR, zero=IR, body=IR)
     def copy(self, a, zero, body):
-        new_instance = self.__class__
-        return new_instance(a, zero, self.accum_name, self.value_name, body)
+        return ArrayScan(a, zero, self.accum_name, self.value_name, body)
 
-    def render(self, r):
-        return '(ArrayScan {} {} {} {} {})'.format(
-            escape_id(self.accum_name), escape_id(self.value_name),
-            r(self.a), r(self.zero), r(self.body))
+    def head_str(self):
+        return f'{escape_id(self.accum_name)} {escape_id(self.value_name)}'
+
+    def _eq(self, other):
+        return other.accum_name == self.accum_name and \
+               other.value_name == self.value_name
 
     @property
     def bound_variables(self):
         return {self.accum_name, self.value_name} | super().bound_variables
-
-    def __eq__(self, other):
-        return isinstance(other, ArrayScan) and \
-               other.a == self.a and \
-               other.zero == self.zero and \
-               other.accum_name == self.accum_name and \
-               other.value_name == self.value_name and \
-               other.body == self.body
 
     def _compute_type(self, env, agg_env):
         self.a._compute_type(env, agg_env)
@@ -948,26 +765,18 @@ class ArrayLeftJoinDistinct(IR):
 
     @typecheck_method(left=IR, right=IR, compare=IR, join=IR)
     def copy(self, left, right, compare, join):
-        new_instance = self.__class__
-        return new_instance(left, right, self.l_name, self.r_name, compare, join)
+        return ArrayLeftJoinDistinct(left, right, self.l_name, self.r_name, compare, join)
 
-    def render(self, r):
-        return '(ArrayLeftJoinDistinct {} {} {} {} {} {})'.format(
-            escape_id(self.l_name), escape_id(self.r_name),
-            r(self.left), r(self.right), r(self.compare), r(self.join))
+    def head_str(self):
+        return f'{escape_id(self.l_name)} {escape_id(self.r_name)}'
+
+    def _eq(self, other):
+        return other.l_name == self.l_name and \
+               other.r_name == self.r_name
 
     @property
     def bound_variables(self):
         return {self.l_name, self.r_name} | super().bound_variables
-
-    def __eq__(self, other):
-        return isinstance(other, ArrayLeftJoinDistinct) and \
-               other.left == self.left and \
-               other.right == self.right and \
-               other.l_name == self.l_name and \
-               other.r_name == self.r_name and \
-               other.compare == self.compare and \
-               other.join == self.join
 
 
 class ArrayFor(IR):
@@ -980,21 +789,17 @@ class ArrayFor(IR):
 
     @typecheck_method(a=IR, body=IR)
     def copy(self, a, body):
-        new_instance = self.__class__
-        return new_instance(a, self.value_name, body)
+        return ArrayFor(a, self.value_name, body)
 
-    def render(self, r):
-        return '(ArrayFor {} {} {})'.format(escape_id(self.value_name), r(self.a), r(self.body))
+    def head_str(self):
+        return escape_id(self.value_name)
+
+    def _eq(self, other):
+        return self.value_name == other.value_name
 
     @property
     def bound_variables(self):
         return {self.value_name} | super().bound_variables
-
-    def __eq__(self, other):
-        return isinstance(other, ArrayFor) and \
-               other.a == self.a and \
-               other.value_name == self.value_name and \
-               other.body == self.body
 
     def _compute_type(self, env, agg_env):
         self.a._compute_type(env, agg_env)
@@ -1012,16 +817,13 @@ class AggFilter(IR):
 
     @typecheck_method(cond=IR, agg_ir=IR)
     def copy(self, cond, agg_ir):
-        new_instance = self.__class__
-        return new_instance(cond, agg_ir, self.is_scan)
+        return AggFilter(cond, agg_ir, self.is_scan)
 
-    def render(self, r):
-        return '(AggFilter {} {} {})'.format(self.is_scan, r(self.cond), r(self.agg_ir))
+    def head_str(self):
+        return str(self.is_scan)
 
-    def __eq__(self, other):
-        return isinstance(other, AggFilter) and \
-               other.cond == self.cond and \
-               other.agg_ir == self.agg_ir
+    def _eq(self, other):
+        return self.is_scan == other.is_scan
 
     def _compute_type(self, env, agg_env):
         self.cond._compute_type(agg_env, None)
@@ -1040,21 +842,17 @@ class AggExplode(IR):
 
     @typecheck_method(array=IR, agg_body=IR)
     def copy(self, array, agg_body):
-        new_instance = self.__class__
-        return new_instance(array, self.name, agg_body, self.is_scan)
+        return AggExplode(array, self.name, agg_body, self.is_scan)
 
-    def render(self, r):
-        return '(AggExplode {} {} {} {})'.format(escape_id(self.name), self.is_scan, r(self.array), r(self.agg_body))
+    def head_str(self):
+        return f'{escape_id(self.name)} {self.is_scan}'
+
+    def _eq(self, other):
+        return self.name == other.name and self.is_scan == other.is_scan
 
     @property
     def bound_variables(self):
         return {self.name} | super().bound_variables
-
-    def __eq__(self, other):
-        return isinstance(other, AggExplode) and \
-               other.array == self.array and \
-               other.name == self.name and \
-               other.agg_body == self.agg_body
 
     def _compute_type(self, env, agg_env):
         self.array._compute_type(agg_env, None)
@@ -1072,21 +870,19 @@ class AggGroupBy(IR):
 
     @typecheck_method(key=IR, agg_ir=IR)
     def copy(self, key, agg_ir):
-        new_instance = self.__class__
-        return new_instance(key, agg_ir, self.is_scan)
+        return AggGroupBy(key, agg_ir, self.is_scan)
 
-    def render(self, r):
-        return '(AggGroupBy {} {} {})'.format(self.is_scan, r(self.key), r(self.agg_ir))
+    def head_str(self):
+        return str(self.is_scan)
 
-    def __eq__(self, other):
-        return isinstance(other, AggGroupBy) and \
-               other.key == self.key and \
-               other.agg_ir == self.agg_ir
+    def _eq(self, other):
+        return self.is_scan == other.is_scan
 
     def _compute_type(self, env, agg_env):
         self.key._compute_type(agg_env, None)
         self.agg_ir._compute_type(env, agg_env)
         self._type = tdict(self.key.typ, self.agg_ir.typ)
+
 
 class AggArrayPerElement(IR):
     @typecheck_method(array=IR, name=str, agg_ir=IR, is_scan=bool)
@@ -1099,17 +895,13 @@ class AggArrayPerElement(IR):
 
     @typecheck_method(array=IR, agg_ir=IR)
     def copy(self, array, agg_ir):
-        new_instance = self.__class__
-        return new_instance(array, self.name, agg_ir, self.is_scan)
+        return AggArrayPerElement(array, self.name, agg_ir, self.is_scan)
 
-    def render(self, r):
-        return '(AggArrayPerElement {} {} {} {})'.format(escape_id(self.name), self.is_scan, r(self.array), r(self.agg_ir))
+    def head_str(self):
+        return f'{escape_id(self.name)} {self.is_scan}'
 
-    def __eq__(self, other):
-        return isinstance(other, AggArrayPerElement) and \
-               other.array == self.array and \
-               other.name == self.name and \
-               other.agg_ir == self.agg_ir
+    def _eq(self, other):
+        return self.name == other.name and self.is_scan == other.is_scan
 
     def _compute_type(self, env, agg_env):
         self.array._compute_type(agg_env, None)
@@ -1127,10 +919,13 @@ def _register(registry, name, f):
     else:
         registry[name] = [f]
 
+
 _aggregator_registry = {}
+
 
 def register_aggregator(name, ctor_params, init_params, seq_params, ret_type):
     _register(_aggregator_registry, name, (ctor_params, init_params, seq_params, ret_type))
+
 
 def lookup_aggregator_return_type(name, ctor_args, init_args, seq_args):
     if name in _aggregator_registry:
@@ -1149,12 +944,10 @@ def lookup_aggregator_return_type(name, ctor_args, init_args, seq_args):
             else:
                 init_match = init_args is None
             if (init_match
-                and all(p.unify(a) for p, a in zip(ctor_params, ctor_args))
-                and all(p.unify(a) for p, a in zip(seq_params, seq_args))):
+                    and all(p.unify(a) for p, a in zip(ctor_params, ctor_args))
+                    and all(p.unify(a) for p, a in zip(seq_params, seq_args))):
                 return ret_type.subst()
     raise KeyError(f'aggregator {name}({ ",".join([str(t) for t in seq_args]) }) not found')
-            
-            
 
 
 class BaseApplyAggOp(IR):
@@ -1179,13 +972,15 @@ class BaseApplyAggOp(IR):
         seq_op_args = args[-n_seq_op_args:]
         return new_instance(self.agg_op, constr_args, init_op_args if len(init_op_args) != 0 else None, seq_op_args)
 
-    def render(self, r):
-        return '({} {} ({}) {} ({}))'.format(
-            self.__class__.__name__,
-            self.agg_op,
-            ' '.join([r(x) for x in self.constructor_args]),
-            '(' + ' '.join([r(x) for x in self.init_op_args]) + ')' if self.init_op_args else 'None',
-            ' '.join([r(x) for x in self.seq_op_args]))
+    def head_str(self):
+        return f' {self.agg_op} '
+
+    def render_children(self, r):
+        return [
+            ParensRenderer(self.constructor_args),
+            RenderableStr('None') if not self.init_op_args else ParensRenderer(self.init_op_args),
+            ParensRenderer(self.seq_op_args)
+        ]
 
     @property
     def aggregations(self):
@@ -1214,6 +1009,7 @@ class BaseApplyAggOp(IR):
             [a.typ for a in self.init_op_args] if self.init_op_args else None,
             [a.typ for a in self.seq_op_args])
 
+
 class ApplyAggOp(BaseApplyAggOp):
     @typecheck_method(agg_op=str,
                       constructor_args=sequenceof(IR),
@@ -1239,15 +1035,7 @@ class Begin(IR):
         self.xs = xs
 
     def copy(self, *xs):
-        new_instance = self.__class__
-        return new_instance(list(xs))
-
-    def render(self, r):
-        return '(Begin {})'.format(' '.join([r(x) for x in self.xs]))
-
-    def __eq__(self, other):
-        return isinstance(other, Begin) \
-               and other.xs == self.xs
+        return Begin(xs)
 
     def _compute_type(self, env, agg_env):
         for x in self.xs:
@@ -1262,12 +1050,11 @@ class MakeStruct(IR):
         self.fields = fields
 
     def copy(self, *irs):
-        new_instance = self.__class__
         assert len(irs) == len(self.fields)
-        return new_instance([(n, ir) for (n, _), ir in zip(self.fields, irs)])
+        return MakeStruct([(n, ir) for (n, _), ir in zip(self.fields, irs)])
 
-    def render(self, r):
-        return '(MakeStruct {})'.format(' '.join(['({} {})'.format(escape_id(f), r(x)) for (f, x) in self.fields]))
+    def render_children(self, r):
+        return [InsertFields.IFRenderField(escape_id(f), x) for f, x in self.fields]
 
     def __eq__(self, other):
         return isinstance(other, MakeStruct) \
@@ -1288,16 +1075,13 @@ class SelectFields(IR):
 
     @typecheck_method(old=IR)
     def copy(self, old):
-        new_instance = self.__class__
-        return new_instance(old, self.fields)
+        return SelectFields(old, self.fields)
 
-    def render(self, r):
-        return '(SelectFields ({}) {})'.format(' '.join(map(escape_id, self.fields)), r(self.old))
+    def head_str(self):
+        return '({})'.format(' '.join(map(escape_id, self.fields)))
 
-    def __eq__(self, other):
-        return isinstance(other, SelectFields) and \
-               other.old == self.old and \
-               other.fields == self.fields
+    def _eq(self, other):
+        return self.fields == other.fields
 
     def _compute_type(self, env, agg_env):
         self.old._compute_type(env, agg_env)
@@ -1305,6 +1089,20 @@ class SelectFields(IR):
 
 
 class InsertFields(IR):
+    class IFRenderField(Renderable):
+        def __init__(self, field, child):
+            self.field = field
+            self.child = child
+
+        def render_head(self, r: 'Renderer'):
+            return f'({self.field} '
+
+        def render_tail(self, r: 'Renderer'):
+            return ')'
+
+        def render_children(self, r: 'Renderer'):
+            return [self.child]
+
     @typecheck_method(old=IR, fields=sequenceof(sized_tupleof(str, IR)), field_order=nullable(sequenceof(str)))
     def __init__(self, old, fields, field_order):
         super().__init__(old, *[ir for (f, ir) in fields])
@@ -1313,15 +1111,15 @@ class InsertFields(IR):
         self.field_order = field_order
 
     def copy(self, *args):
-        new_instance = self.__class__
         assert len(args) == len(self.fields) + 1
-        return new_instance(args[0], [(n, ir) for (n, _), ir in zip(self.fields, args[1:])], self.field_order)
+        return InsertFields(args[0], [(n, ir) for (n, _), ir in zip(self.fields, args[1:])], self.field_order)
 
-    def render(self, r):
-        return '(InsertFields {} {} {})'.format(
+    def render_children(self, r):
+        return [
             self.old,
-            'None' if self.field_order is None else parsable_strings(self.field_order),
-            ' '.join(['({} {})'.format(escape_id(f), r(x)) for (f, x) in self.fields]))
+            hail.ir.RenderableStr('None' if self.field_order is None else parsable_strings(self.field_order)),
+            *(InsertFields.IFRenderField(escape_id(f), x) for f, x in self.fields)
+        ]
 
     def __eq__(self, other):
         return isinstance(other, InsertFields) and \
@@ -1347,20 +1145,17 @@ class GetField(IR):
 
     @typecheck_method(o=IR)
     def copy(self, o):
-        new_instance = self.__class__
-        return new_instance(o, self.name)
+        return GetField(o, self.name)
 
-    def render(self, r):
-        return '(GetField {} {})'.format(escape_id(self.name), r(self.o))
+    def head_str(self):
+        return escape_id(self.name)
+
+    def _eq(self, other):
+        return self.name == other.name
 
     @property
     def is_nested_field(self):
         return self.o.is_nested_field
-
-    def __eq__(self, other):
-        return isinstance(other, GetField) and \
-               other.o == self.o and \
-               other.name == self.name
 
     def _compute_type(self, env, agg_env):
         self.o._compute_type(env, agg_env)
@@ -1374,15 +1169,7 @@ class MakeTuple(IR):
         self.elements = elements
 
     def copy(self, *args):
-        new_instance = self.__class__
-        return new_instance(list(args))
-
-    def render(self, r):
-        return '(MakeTuple {})'.format(' '.join([r(x) for x in self.elements]))
-
-    def __eq__(self, other):
-        return isinstance(other, MakeTuple) and \
-               other.elements == self.elements
+        return MakeTuple(args)
 
     def _compute_type(self, env, agg_env):
         for x in self.elements:
@@ -1399,21 +1186,17 @@ class GetTupleElement(IR):
 
     @typecheck_method(o=IR)
     def copy(self, o):
-        new_instance = self.__class__
-        return new_instance(o, self.idx)
+        return GetTupleElement(o, self.idx)
 
-    def render(self, r):
-        return '(GetTupleElement {} {})'.format(self.idx, r(self.o))
+    def head_str(self):
+        return self.idx
 
-    def __eq__(self, other):
-        return isinstance(other, GetTupleElement) and \
-               other.o == self.o and \
-               other.idx == self.idx
+    def _eq(self, other):
+        return self.idx == other.idx
 
     def _compute_type(self, env, agg_env):
         self.o._compute_type(env, agg_env)
         self._type = self.o.typ.types[self.idx]
-
 
 class In(IR):
     @typecheck_method(i=int, typ=hail_type)
@@ -1427,15 +1210,13 @@ class In(IR):
         return self._typ
 
     def copy(self):
-        new_instance = self.__class__
-        return new_instance(self.i, self._typ)
+        return In(self.i, self._typ)
 
-    def render(self, r):
-        return '(In {} {})'.format(self._typ._parsable_string(), self.i)
+    def head_str(self):
+        return f'{self._typ._parsable_string()} {self.i}'
 
-    def __eq__(self, other):
-        return isinstance(other, In) and \
-               other.i == self.i and \
+    def _eq(self, other):
+        return other.i == self.i and \
                other._typ == self._typ
 
     def _compute_type(self, env, agg_env):
@@ -1445,7 +1226,7 @@ class In(IR):
 class Die(IR):
     @typecheck_method(message=IR, typ=hail_type)
     def __init__(self, message, typ):
-        super().__init__()
+        super().__init__(message)
         self.message = message
         self._typ = typ
 
@@ -1453,17 +1234,14 @@ class Die(IR):
     def typ(self):
         return self._typ
 
-    def copy(self):
-        new_instance = self.__class__
-        return new_instance(self.message, self._typ)
+    def copy(self, message):
+        return Die(message, self._typ)
 
-    def render(self, r):
-        return '(Die {} {})'.format(self._typ._parsable_string(), r(self.message))
+    def head_str(self):
+        return self._typ._parsable_string()
 
-    def __eq__(self, other):
-        return isinstance(other, Die) and \
-               other.message == self.message and \
-               other._typ == self._typ
+    def _eq(self, other):
+        return other._typ == self._typ
 
     def _compute_type(self, env, agg_env):
         self._type = self._typ
@@ -1472,11 +1250,14 @@ class Die(IR):
 _function_registry = {}
 _seeded_function_registry = {}
 
+
 def register_function(name, param_types, ret_type):
     _register(_function_registry, name, (param_types, ret_type))
 
+
 def register_seeded_function(name, param_types, ret_type):
     _register(_seeded_function_registry, name, (param_types, ret_type))
+
 
 def _lookup_function_return_type(registry, fkind, name, arg_types):
     if name in registry:
@@ -1490,8 +1271,10 @@ def _lookup_function_return_type(registry, fkind, name, arg_types):
                 return ret_type.subst()
     raise KeyError(f'{fkind} {name}({ ",".join([str(t) for t in arg_types]) }) not found')
 
+
 def lookup_function_return_type(name, arg_types):
     return _lookup_function_return_type(_function_registry, 'function', name, arg_types)
+
 
 def lookup_seeded_function_return_type(name, arg_types):
     return _lookup_function_return_type(_seeded_function_registry, 'seeded function', name, arg_types)
@@ -1505,16 +1288,13 @@ class Apply(IR):
         self.args = args
 
     def copy(self, *args):
-        new_instance = self.__class__
-        return new_instance(self.function, *args)
+        return Apply(self.function, *args)
 
-    def render(self, r):
-        return '(Apply {} {})'.format(escape_id(self.function), ' '.join([r(x) for x in self.args]))
+    def head_str(self):
+        return escape_id(self.function)
 
-    def __eq__(self, other):
-        return isinstance(other, Apply) and \
-               other.function == self.function and \
-               other.args == self.args
+    def _eq(self, other):
+        return other.function == self.function
 
     def _compute_type(self, env, agg_env):
         for arg in self.args:
@@ -1532,19 +1312,14 @@ class ApplySeeded(IR):
         self.seed = seed
 
     def copy(self, *args):
-        new_instance = self.__class__
-        return new_instance(self.function, self.seed, *args)
+        return ApplySeeded(self.function, self.seed, *args)
 
-    def render(self, r):
-        return '(ApplySeeded {} {} {})'.format(
-            escape_id(self.function),
-            self.seed,
-            ' '.join([r(x) for x in self.args]))
+    def head_str(self):
+        return f'{escape_id(self.function)} {self.seed}'
 
-    def __eq__(self, other):
-        return isinstance(other, Apply) and \
-               other.function == self.function and \
-               other.args == self.args
+    def _eq(self, other):
+        return other.function == self.function and \
+               other.seed == self.seed
 
     def _compute_type(self, env, agg_env):
         for arg in self.args:
@@ -1564,23 +1339,17 @@ class Uniroot(IR):
 
     @typecheck_method(function=IR, min=IR, max=IR)
     def copy(self, function, min, max):
-        new_instance = self.__class__
-        return new_instance(self.argname, function, min, max)
+        return Uniroot(self.argname, function, min, max)
 
-    def render(self, r):
-        return '(Uniroot {} {} {} {})'.format(
-            escape_id(self.argname), r(self.function), r(self.min), r(self.max))
+    def head_str(self):
+        return escape_id(self.argname)
 
     @property
     def bound_variables(self):
         return {self.argname} | super().bound_variables
 
-    def __eq__(self, other):
-        return isinstance(other, Uniroot) and \
-               other.argname == self.argname and \
-               other.function == self.function and \
-               other.min == self.min and \
-               other.max == self.max
+    def _eq(self, other):
+        return other.argname == self.argname
 
     def _compute_type(self, env, agg_env):
         self.function._compute_type(_env_bind(env, self.argname, tfloat64), agg_env)
@@ -1597,15 +1366,7 @@ class TableCount(IR):
 
     @typecheck_method(child=TableIR)
     def copy(self, child):
-        new_instance = self.__class__
-        return new_instance(child)
-
-    def render(self, r):
-        return '(TableCount {})'.format(r(self.child))
-
-    def __eq__(self, other):
-        return isinstance(other, TableCount) and \
-               other.child == self.child
+        return TableCount(child)
 
     def _compute_type(self, env, agg_env):
         self.child._compute_type()
@@ -1620,19 +1381,12 @@ class TableGetGlobals(IR):
 
     @typecheck_method(child=TableIR)
     def copy(self, child):
-        new_instance = self.__class__
-        return new_instance(child)
-
-    def render(self, r):
-        return '(TableGetGlobals {})'.format(r(self.child))
-
-    def __eq__(self, other):
-        return isinstance(other, TableGetGlobals) and \
-               other.child == self.child
+        return TableGetGlobals(child)
 
     def _compute_type(self, env, agg_env):
         self.child._compute_type()
         self._type = self.child.typ.global_type
+
 
 class TableCollect(IR):
     @typecheck_method(child=TableIR)
@@ -1642,15 +1396,7 @@ class TableCollect(IR):
 
     @typecheck_method(child=TableIR)
     def copy(self, child):
-        new_instance = self.__class__
-        return new_instance(child)
-
-    def render(self, r):
-        return '(TableCollect {})'.format(r(self.child))
-
-    def __eq__(self, other):
-        return isinstance(other, TableCollect) and \
-               other.child == self.child
+        return TableCollect(child)
 
     def _compute_type(self, env, agg_env):
         self.child._compute_type()
@@ -1667,16 +1413,7 @@ class TableAggregate(IR):
 
     @typecheck_method(child=TableIR, query=IR)
     def copy(self, child, query):
-        new_instance = self.__class__
-        return new_instance(child, query)
-
-    def render(self, r):
-        return '(TableAggregate {} {})'.format(r(self.child), r(self.query))
-
-    def __eq__(self, other):
-        return isinstance(other, TableAggregate) and \
-               other.child == self.child and \
-               other.query == self.query
+        return TableAggregate(child, query)
 
     def _compute_type(self, env, agg_env):
         self.query._compute_type(self.child.typ.global_env(), self.child.typ.row_env())
@@ -1692,11 +1429,7 @@ class MatrixAggregate(IR):
 
     @typecheck_method(child=MatrixIR, query=IR)
     def copy(self, child, query):
-        new_instance = self.__class__
-        return new_instance(child, query)
-
-    def render(self, r):
-        return '(MatrixAggregate {} {})'.format(r(self.child), r(self.query))
+        return MatrixAggregate(child, query)
 
     def __eq__(self, other):
         return isinstance(other, MatrixAggregate) and \
@@ -1720,18 +1453,15 @@ class TableWrite(IR):
 
     @typecheck_method(child=TableIR)
     def copy(self, child):
-        new_instance = self.__class__
-        return new_instance(child, self.path, self.overwrite, self.stage_locally, self._codec_spec)
+        return TableWrite(child, self.path, self.overwrite, self.stage_locally, self._codec_spec)
 
-    def render(self, r):
-        return '(TableWrite "{}" {} {} {} {})'.format(escape_str(self.path), self.overwrite, self.stage_locally,
-                                                      "\"" + escape_str(self._codec_spec) + "\"" if self._codec_spec else "None",
-                                                        r(self.child))
+    def head_str(self):
+        return '"{}" {} {} {}'.format(escape_str(self.path), self.overwrite, self.stage_locally,
+                                      "\"" + escape_str(
+                                          self._codec_spec) + "\"" if self._codec_spec else "None")
 
-    def __eq__(self, other):
-        return isinstance(other, TableWrite) and \
-               other.child == self.child and \
-               other.path == self.path and \
+    def _eq(self, other):
+        return other.path == self.path and \
                other.overwrite == self.overwrite and \
                other.stage_locally == self.stage_locally and \
                other._codec_spec == self._codec_spec
@@ -1759,23 +1489,19 @@ class TableExport(IR):
 
     @typecheck_method(child=TableIR)
     def copy(self, child):
-        new_instance = self.__class__
-        return new_instance(child, self.path, self.types_file, self.header, self.export_type, self.delimiter)
+        return TableExport(child, self.path, self.types_file, self.header, self.export_type, self.delimiter)
 
-    def render(self, r):
-        return '(TableExport "{}" {} {} {} "{}" {})'.format(
+    def head_str(self):
+        return '"{}" {} {} {} "{}"'.format(
             escape_str(self.path),
             f'"{escape_str(self.types_file)}"' if self.types_file else 'None',
             self.header,
             self.export_type,
             escape_str(self.delimiter),
-            r(self.child)
         )
 
-    def __eq__(self, other):
-        return isinstance(other, TableExport) and \
-               other.child == self.child and \
-               other.path == self.path and \
+    def _eq(self, other):
+        return other.path == self.path and \
                other.types_file == self.types_file and \
                other.header == self.header and \
                other.export_type == self.export_type and \
@@ -1795,18 +1521,13 @@ class MatrixWrite(IR):
 
     @typecheck_method(child=MatrixIR)
     def copy(self, child):
-        new_instance = self.__class__
-        return new_instance(child, self.matrix_writer)
+        return MatrixWrite(child, self.matrix_writer)
 
-    def render(self, r):
-        return '(MatrixWrite "{}" {})'.format(
-            r(self.matrix_writer),
-            r(self.child))
+    def head_str(self):
+        return f'"{self.matrix_writer.render()}"'
 
-    def __eq__(self, other):
-        return isinstance(other, MatrixWrite) and \
-               other.child == self.child and \
-               other.matrix_writer == self.matrix_writer
+    def _eq(self, other):
+        return other.matrix_writer == self.matrix_writer
 
     def _compute_type(self, env, agg_env):
         self.child._compute_type()
@@ -1820,18 +1541,13 @@ class MatrixMultiWrite(IR):
         self.writer = writer
 
     def copy(self, *children):
-        new_instance = self.__class__
-        return new_instance(list(children), self.writer)
+        return MatrixMultiWrite(children, self.writer)
 
-    def render(self, r):
-        return '(MatrixMultiWrite "{}" {})'.format(
-            r(self.writer),
-            ' '.join(map(r, self.children)))
+    def head_str(self):
+        return f'"{self.writer.render()}"'
 
-    def __eq__(self, other):
-        return isinstance(other, MatrixMultiWrite) and \
-               other.children == self.children and \
-               other.writer == self.writer
+    def _eq(self, other):
+        return other.writer == self.writer
 
     def _compute_type(self, env, agg_env):
         for x in self.children:
@@ -1847,16 +1563,13 @@ class BlockMatrixWrite(IR):
         self.writer = writer
 
     def copy(self, child):
-        new_instance = self.__class__
-        return new_instance(child, self.writer)
+        return BlockMatrixWrite(child, self.writer)
 
-    def render(self, r):
-        return f'(BlockMatrixWrite "{r(self.writer)}" {r(self.child)})'
+    def head_str(self):
+        return self.writer.render()
 
-    def __eq__(self, other):
-        return isinstance(other, BlockMatrixWrite) and \
-               other.child == self.child and \
-               other.writer == self.writer
+    def _eq(self, other):
+        return self.writer == other.writer
 
     def _compute_type(self, env, agg_env):
         self.child._compute_type()
@@ -1871,14 +1584,13 @@ class TableToValueApply(IR):
 
     @typecheck_method(child=TableIR)
     def copy(self, child):
-        new_instance = self.__class__
-        return new_instance(child, self.config)
+        return TableToValueApply(child, self.config)
 
-    def render(self, r):
-        return f'(TableToValueApply {dump_json(self.config)} {r(self.child)})'
+    def head_str(self):
+        return dump_json(self.config)
 
-    def __eq__(self, other):
-        return isinstance(other, TableToValueApply) and other.child == self.child and other.config == self.config
+    def _eq(self, other):
+        return other.config == self.config
 
     def _compute_type(self, env, agg_env):
         name = self.config['name']
@@ -1897,14 +1609,13 @@ class MatrixToValueApply(IR):
 
     @typecheck_method(child=MatrixIR)
     def copy(self, child):
-        new_instance = self.__class__
-        return new_instance(child, self.config)
+        return MatrixToValueApply(child, self.config)
 
-    def render(self, r):
-        return f'(MatrixToValueApply {dump_json(self.config)} {r(self.child)})'
+    def head_str(self):
+        return dump_json(self.config)
 
-    def __eq__(self, other):
-        return isinstance(other, MatrixToValueApply) and other.child == self.child and other.config == self.config
+    def _eq(self, other):
+        return other.config == self.config
 
     def _compute_type(self, env, agg_env):
         name = self.config['name']
@@ -1952,13 +1663,11 @@ class Literal(IR):
     def copy(self):
         return Literal(self._typ, self.value)
 
-    def render(self, r):
-        return f'(Literal {self._typ._parsable_string()} ' \
-               f'"{escape_str(self._typ._to_json(self.value))}")'
+    def head_str(self):
+        return f'{self._typ._parsable_string()} {dump_json(self._typ._convert_to_json_na(self.value))}'
 
-    def __eq__(self, other):
-        return isinstance(other, Literal) and \
-               other._typ == self._typ and \
+    def _eq(self, other):
+        return other._typ == self._typ and \
                other.value == self.value
 
     def _compute_type(self, env, agg_env):
@@ -1982,6 +1691,7 @@ class Join(IR):
         Join._idx += 1
 
     def copy(self, virtual_ir):
+        # FIXME: This is pretty fucked, Joins should probably be tracked on Expression?
         new_instance = self.__class__
         new_instance = new_instance(virtual_ir,
                                     self.temp_vars,
@@ -1997,8 +1707,14 @@ class Join(IR):
         matches += super(Join, self).search(criteria)
         return matches
 
-    def render(self, r):
-        return r(self.virtual_ir)
+    def render_head(self, r):
+        return self.virtual_ir.render_head(r)
+
+    def render_tail(self, r):
+        return self.virtual_ir.render_tail(r)
+
+    def render_children(self, r):
+        return self.virtual_ir.render_children(r)
 
     def _compute_type(self, env, agg_env):
         self.virtual_ir._compute_type(env, agg_env)
@@ -2011,8 +1727,14 @@ class JavaIR(IR):
         self._jir = jir
         super().__init__()
 
-    def render(self, r):
-        return f'(JavaIR {r.add_jir(self._jir)})'
+    def copy(self):
+        return JavaIR(self._jir)
+
+    def render_head(self, r):
+        return f'(JavaIR{r.add_jir(self._jir)}'
+
+    def _eq(self, other):
+        return self._jir == other._jir
 
     def _compute_type(self, env, agg_env):
         self._type = dtype(self._jir.typ().toString())
@@ -2077,7 +1799,8 @@ def subst(ir, env, agg_env):
                           ir.is_scan)
     elif isinstance(ir, ApplyAggOp):
         subst_constr_args = [x.map_ir(lambda x: _subst(x)) for x in ir.constructor_args]
-        subst_init_op_args = [x.map_ir(lambda x: _subst(x)) for x in ir.init_op_args] if ir.init_op_args else ir.init_op_args
+        subst_init_op_args = [x.map_ir(lambda x: _subst(x)) for x in
+                              ir.init_op_args] if ir.init_op_args else ir.init_op_args
         subst_seq_op_args = [subst(x, agg_env, {}) for x in ir.seq_op_args]
         return ApplyAggOp(ir.agg_op,
                           subst_constr_args,

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -702,6 +702,7 @@ class ArrayFold(IR):
         return other.accum_name == self.accum_name and \
                other.value_name == self.value_name
 
+    @property
     def bound_variables(self):
         return {self.accum_name, self.value_name} | super().bound_variables
 

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1566,7 +1566,7 @@ class BlockMatrixWrite(IR):
         return BlockMatrixWrite(child, self.writer)
 
     def head_str(self):
-        return self.writer.render()
+        return f'"{self.writer.render()}"'
 
     def _eq(self, other):
         return self.writer == other.writer
@@ -1632,7 +1632,7 @@ class MatrixToValueApply(IR):
 
 class BlockMatrixToValueApply(IR):
     def __init__(self, child, config):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.config = config
 
@@ -1641,11 +1641,11 @@ class BlockMatrixToValueApply(IR):
         new_instance = self.__class__
         return new_instance(child, self.config)
 
-    def render(self, r):
-        return f'(BlockMatrixToValueApply {dump_json(self.config)} {r(self.child)})'
+    def head_str(self):
+        return dump_json(self.config)
 
-    def __eq__(self, other):
-        return isinstance(other, BlockMatrixToValueApply) and other.child == self.child and other.config == self.config
+    def _eq(self, other):
+        return other.config == self.config
 
     def _compute_type(self, env, agg_env):
         assert self.config['name'] == 'GetElement'

--- a/hail/python/hail/ir/matrix_ir.py
+++ b/hail/python/hail/ir/matrix_ir.py
@@ -1,17 +1,14 @@
-import json
 import hail as hl
 from hail.ir.base_ir import *
 from hail.utils.java import escape_str, escape_id, parsable_strings, dump_json
 
+
 class MatrixAggregateRowsByKey(MatrixIR):
     def __init__(self, child, entry_expr, row_expr):
-        super().__init__()
+        super().__init__(child, entry_expr, row_expr)
         self.child = child
         self.entry_expr = entry_expr
         self.row_expr = row_expr
-
-    def render(self, r):
-        return f'(MatrixAggregateRowsByKey {r(self.child)} {r(self.entry_expr)} {r(self.row_expr)})'
 
     def _compute_type(self):
         child_typ = self.child.typ
@@ -33,8 +30,11 @@ class MatrixRead(MatrixIR):
         self.drop_cols = drop_cols
         self.drop_rows = drop_rows
 
-    def render(self, r):
-        return f'(MatrixRead None {self.drop_cols} {self.drop_rows} "{r(self.reader)}")'
+    def head_str(self):
+        return f'None {self.drop_cols} {self.drop_rows} "{self.reader.render()}"'
+
+    def _eq(self, other):
+        return self.reader == other.reader and self.drop_cols == other.drop_cols and self.drop_rows == other.drop_rows
 
     def _compute_type(self):
         self._type = Env.backend().matrix_type(self)
@@ -42,41 +42,43 @@ class MatrixRead(MatrixIR):
 
 class MatrixFilterRows(MatrixIR):
     def __init__(self, child, pred):
-        super().__init__()
+        super().__init__(child, pred)
         self.child = child
         self.pred = pred
-
-    def render(self, r):
-        return '(MatrixFilterRows {} {})'.format(r(self.child), r(self.pred))
 
     def _compute_type(self):
         self.pred._compute_type(self.child.typ.row_env(), None)
         self._type = self.child.typ
 
+
 class MatrixChooseCols(MatrixIR):
     def __init__(self, child, old_indices):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.old_indices = old_indices
 
-    def render(self, r):
-        return '(MatrixChooseCols ({}) {})'.format(
-            ' '.join([str(i) for i in self.old_indices]), r(self.child))
+    def head_str(self):
+        return f'({" ".join([str(i) for i in self.old_indices])})'
+
+    def _eq(self, other):
+        return self.old_indices == other.old_indices
 
     def _compute_type(self):
         self._type = self.child.typ
 
+
 class MatrixMapCols(MatrixIR):
     def __init__(self, child, new_col, new_key):
-        super().__init__()
+        super().__init__(child, new_col)
         self.child = child
         self.new_col = new_col
         self.new_key = new_key
 
-    def render(self, r):
-        return '(MatrixMapCols {} {} {})'.format(
-            '(' + ' '.join(f'"{escape_str(f)}"' for f in self.new_key) + ')' if self.new_key is not None else 'None',
-            r(self.child), r(self.new_col))
+    def head_str(self):
+        return '(' + ' '.join(f'"{escape_str(f)}"' for f in self.new_key) + ')' if self.new_key is not None else 'None'
+
+    def _eq(self, other):
+        return self.new_key == other.new_key
 
     def _compute_type(self):
         child_typ = self.child.typ
@@ -89,27 +91,23 @@ class MatrixMapCols(MatrixIR):
             child_typ.row_key,
             child_typ.entry_type)
 
+
 class MatrixUnionCols(MatrixIR):
     def __init__(self, left, right):
-        super().__init__()
+        super().__init__(left, right)
         self.left = left
         self.right = right
 
-    def render(self, r):
-        return f'(MatrixUnionCols {r(self.left)} {r(self.right)})'
-
     def _compute_type(self):
-        self.right.typ # force
+        self.right.typ  # force
         self._type = self.left.typ
+
 
 class MatrixMapEntries(MatrixIR):
     def __init__(self, child, new_entry):
-        super().__init__()
+        super().__init__(child, new_entry)
         self.child = child
         self.new_entry = new_entry
-
-    def render(self, r):
-        return '(MatrixMapEntries {} {})'.format(r(self.child), r(self.new_entry))
 
     def _compute_type(self):
         child_typ = self.child.typ
@@ -125,29 +123,29 @@ class MatrixMapEntries(MatrixIR):
 
 class MatrixFilterEntries(MatrixIR):
     def __init__(self, child, pred):
-        super().__init__()
+        super().__init__(child, pred)
         self.child = child
         self.pred = pred
-
-    def render(self, r):
-        return '(MatrixFilterEntries {} {})'.format(r(self.child), r(self.pred))
 
     def _compute_type(self):
         self.pred._compute_type(self.child.typ.entry_env(), None)
         self._type = self.child.typ
 
+
 class MatrixKeyRowsBy(MatrixIR):
     def __init__(self, child, keys, is_sorted=False):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.keys = keys
         self.is_sorted = is_sorted
 
-    def render(self, r):
-        return '(MatrixKeyRowsBy ({}) {} {})'.format(
+    def head_str(self):
+        return '({}) {}'.format(
             ' '.join([escape_id(x) for x in self.keys]),
-            self.is_sorted,
-            r(self.child))
+            self.is_sorted)
+
+    def _eq(self, other):
+        return self.keys == other.keys and self.is_sorted == other.is_sorted
 
     def _compute_type(self):
         child_typ = self.child.typ
@@ -162,12 +160,9 @@ class MatrixKeyRowsBy(MatrixIR):
 
 class MatrixMapRows(MatrixIR):
     def __init__(self, child, new_row):
-        super().__init__()
+        super().__init__(child, new_row)
         self.child = child
         self.new_row = new_row
-
-    def render(self, r):
-        return '(MatrixMapRows {} {})'.format(r(self.child), r(self.new_row))
 
     def _compute_type(self):
         child_typ = self.child.typ
@@ -180,14 +175,12 @@ class MatrixMapRows(MatrixIR):
             child_typ.row_key,
             child_typ.entry_type)
 
+
 class MatrixMapGlobals(MatrixIR):
     def __init__(self, child, new_global):
-        super().__init__()
+        super().__init__(child, new_global)
         self.child = child
         self.new_global = new_global
-
-    def render(self, r):
-        return f'(MatrixMapGlobals {r(self.child)} {r(self.new_global)})'
 
     def _compute_type(self):
         child_typ = self.child.typ
@@ -203,24 +196,19 @@ class MatrixMapGlobals(MatrixIR):
 
 class MatrixFilterCols(MatrixIR):
     def __init__(self, child, pred):
-        super().__init__()
+        super().__init__(child, pred)
         self.child = child
         self.pred = pred
-
-    def render(self, r):
-        return f'(MatrixFilterCols {r(self.child)} {r(self.pred)})'
 
     def _compute_type(self):
         self.pred._compute_type(self.child.typ.col_env(), None)
         self._type = self.child.typ
 
+
 class MatrixCollectColsByKey(MatrixIR):
     def __init__(self, child):
-        super().__init__()
+        super().__init__(child)
         self.child = child
-
-    def render(self, r):
-        return f'(MatrixCollectColsByKey {r(self.child)})'
 
     def _compute_type(self):
         child_typ = self.child.typ
@@ -233,15 +221,13 @@ class MatrixCollectColsByKey(MatrixIR):
             child_typ.row_key,
             hl.tstruct(**{f: hl.tarray(t) for f, t in child_typ.entry_type.items()}))
 
+
 class MatrixAggregateColsByKey(MatrixIR):
     def __init__(self, child, entry_expr, col_expr):
-        super().__init__()
+        super().__init__(child, entry_expr, col_expr)
         self.child = child
         self.entry_expr = entry_expr
         self.col_expr = col_expr
-
-    def render(self, r):
-        return '(MatrixAggregateColsByKey {} {} {})'.format(r(self.child), r(self.entry_expr), r(self.col_expr))
 
     def _compute_type(self):
         child_typ = self.child.typ
@@ -258,14 +244,15 @@ class MatrixAggregateColsByKey(MatrixIR):
 
 class MatrixExplodeRows(MatrixIR):
     def __init__(self, child, path):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.path = path
 
-    def render(self, r):
-        return '(MatrixExplodeRows ({}) {})'.format(
-            ' '.join([escape_id(id) for id in self.path]),
-            r(self.child))
+    def head_str(self):
+        return f"({' '.join([escape_id(id) for id in self.path])})"
+
+    def _eq(self, other):
+        return self.path == other.path
 
     def _compute_type(self):
         child_typ = self.child.typ
@@ -282,13 +269,16 @@ class MatrixExplodeRows(MatrixIR):
 
 class MatrixRepartition(MatrixIR):
     def __init__(self, child, n, strategy):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.n = n
         self.strategy = strategy
 
-    def render(self, r):
-        return f'(MatrixRepartition {r(self.child)} {self.n} {self.strategy})'
+    def head_str(self):
+        return f'{self.n} {self.strategy}'
+
+    def _eq(self, other):
+        return self.n == other.n and self.strategy == other.strategy
 
     def _compute_type(self):
         self._type = self.child.typ
@@ -296,24 +286,19 @@ class MatrixRepartition(MatrixIR):
 
 class MatrixUnionRows(MatrixIR):
     def __init__(self, *children):
-        super().__init__()
+        super().__init__(*children)
         self.children = children
-
-    def render(self, r):
-        return '(MatrixUnionRows {})'.format(' '.join(map(r, self.children)))
 
     def _compute_type(self):
         for c in self.children:
-            c.typ # force
+            c.typ  # force
         self._type = self.children[0].typ
+
 
 class MatrixDistinctByRow(MatrixIR):
     def __init__(self, child):
-        super().__init__()
+        super().__init__(child)
         self.child = child
-
-    def render(self, r):
-        return f'(MatrixDistinctByRow {r(self.child)})'
 
     def _compute_type(self):
         self._type = self.child.typ
@@ -321,12 +306,15 @@ class MatrixDistinctByRow(MatrixIR):
 
 class MatrixRowsHead(MatrixIR):
     def __init__(self, child, n):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.n = n
 
-    def render(self, r):
-        return f'(MatrixRowsHead {self.n} {r(self.child)})'
+    def head_str(self):
+        return self.n
+
+    def _eq(self, other):
+        return self.n == other.n
 
     def _compute_type(self):
         self._type = self.child.typ
@@ -334,14 +322,15 @@ class MatrixRowsHead(MatrixIR):
 
 class MatrixExplodeCols(MatrixIR):
     def __init__(self, child, path):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.path = path
 
-    def render(self, r):
-        return '(MatrixExplodeCols ({}) {})'.format(
-            ' '.join([escape_id(id) for id in self.path]),
-            r(self.child))
+    def head_str(self):
+        return f"({' '.join([escape_id(id) for id in self.path])})"
+
+    def _eq(self, other):
+        return self.path == other.path
 
     def _compute_type(self):
         child_typ = self.child.typ
@@ -358,18 +347,22 @@ class MatrixExplodeCols(MatrixIR):
 
 class CastTableToMatrix(MatrixIR):
     def __init__(self, child, entries_field_name, cols_field_name, col_key):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.entries_field_name = entries_field_name
         self.cols_field_name = cols_field_name
         self.col_key = col_key
 
-    def render(self, r):
-        return '(CastTableToMatrix {} {} ({}) {})'.format(
-           escape_str(self.entries_field_name),
-           escape_str(self.cols_field_name),
-           ' '.join([escape_id(id) for id in self.col_key]),
-           r(self.child))
+    def head_str(self):
+        return '{} {} ({})'.format(
+            escape_str(self.entries_field_name),
+            escape_str(self.cols_field_name),
+            ' '.join([escape_id(id) for id in self.col_key]))
+
+    def _eq(self, other):
+        return self.entries_field_name == other.entries_field_name and \
+               self.cols_field_name == other.cols_field_name and \
+               self.col_key == other.col_key
 
     def _compute_type(self):
         child_typ = self.child.typ
@@ -384,13 +377,16 @@ class CastTableToMatrix(MatrixIR):
 
 class MatrixAnnotateRowsTable(MatrixIR):
     def __init__(self, child, table, root):
-        super().__init__()
+        super().__init__(child, table)
         self.child = child
         self.table = table
         self.root = root
 
-    def render(self, r):
-        return f'(MatrixAnnotateRowsTable "{self.root}" {r(self.child)} {r(self.table)})'
+    def head_str(self):
+        return f'"{escape_str(self.root)}"'
+
+    def _eq(self, other):
+        return self.root == other.root
 
     def _compute_type(self):
         child_typ = self.child.typ
@@ -402,15 +398,19 @@ class MatrixAnnotateRowsTable(MatrixIR):
             child_typ.row_key,
             child_typ.entry_type)
 
+
 class MatrixAnnotateColsTable(MatrixIR):
     def __init__(self, child, table, root):
-        super().__init__()
+        super().__init__(child, table)
         self.child = child
         self.table = table
         self.root = root
 
-    def render(self, r):
-        return f'(MatrixAnnotateColsTable "{self.root}" {r(self.child)} {r(self.table)})'
+    def head_str(self):
+        return f'"{escape_str(self.root)}"'
+
+    def _eq(self, other):
+        return self.root == other.root
 
     def _compute_type(self):
         child_typ = self.child.typ
@@ -425,18 +425,21 @@ class MatrixAnnotateColsTable(MatrixIR):
 
 class MatrixToMatrixApply(MatrixIR):
     def __init__(self, child, config):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.config = config
 
-    def render(self, r):
-        return f'(MatrixToMatrixApply {dump_json(self.config)} {r(self.child)})'
+    def head_str(self):
+        return dump_json(self.config)
+
+    def _eq(self, other):
+        return self.config == other.config
 
     def _compute_type(self):
         name = self.config['name']
         child_typ = self.child.typ
         if (name == 'MatrixFilterPartitions'
-            or name == 'MatrixFilterIntervals'):
+                or name == 'MatrixFilterIntervals'):
             self._type = child_typ
         else:
             assert name == 'WindowByLocus', name
@@ -448,26 +451,31 @@ class MatrixToMatrixApply(MatrixIR):
                 child_typ.row_key,
                 child_typ.entry_type._insert_field('prev_entries', hl.tarray(child_typ.entry_type)))
 
+
 class MatrixRename(MatrixIR):
     def __init__(self, child, global_map, col_map, row_map, entry_map):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.global_map = global_map
         self.col_map = col_map
         self.row_map = row_map
         self.entry_map = entry_map
 
-    def render(self, r):
-        return f'(MatrixRename ' \
-               f'{parsable_strings(self.global_map.keys())} ' \
+    def head_str(self):
+        return f'{parsable_strings(self.global_map.keys())} ' \
                f'{parsable_strings(self.global_map.values())} ' \
                f'{parsable_strings(self.col_map.keys())} ' \
                f'{parsable_strings(self.col_map.values())} ' \
                f'{parsable_strings(self.row_map.keys())} ' \
                f'{parsable_strings(self.row_map.values())} ' \
                f'{parsable_strings(self.entry_map.keys())} ' \
-               f'{parsable_strings(self.entry_map.values())} ' \
-               f'{r(self.child)})'
+               f'{parsable_strings(self.entry_map.values())} '
+
+    def _eq(self, other):
+        return self.global_map == other.global_map and \
+               self.col_map == other.col_map and \
+               self.row_map == other.row_map and \
+               self.entry_map == other.entry_map
 
     def _compute_type(self):
         self._type = self.child.typ._rename(self.global_map, self.col_map, self.row_map, self.entry_map)
@@ -478,8 +486,8 @@ class JavaMatrix(MatrixIR):
         super().__init__()
         self._jir = jir
 
-    def render(self, r):
-        return f'(JavaMatrix {r.add_jir(self._jir)})'
+    def render_head(self, r):
+        return f'(JavaMatrix {r.add_jir(self._jir)}'
 
     def _compute_type(self):
         self._type = hl.tmatrix._from_java(self._jir.typ())

--- a/hail/python/hail/ir/matrix_ir.py
+++ b/hail/python/hail/ir/matrix_ir.py
@@ -30,8 +30,8 @@ class MatrixRead(MatrixIR):
         self.drop_cols = drop_cols
         self.drop_rows = drop_rows
 
-    def head_str(self):
-        return f'None {self.drop_cols} {self.drop_rows} "{self.reader.render()}"'
+    def render_head(self, r):
+        return f'(MatrixRead None {self.drop_cols} {self.drop_rows} "{self.reader.render(r)}"'
 
     def _eq(self, other):
         return self.reader == other.reader and self.drop_cols == other.drop_cols and self.drop_rows == other.drop_rows
@@ -498,8 +498,8 @@ class JavaMatrixVectorRef(MatrixIR):
         self.vec_ref = vec_ref
         self.idx = idx
 
-    def render(self, r):
-        return f'(JavaMatrixVectorRef {self.vec_ref.jid} {self.idx})'
+    def head_str(self):
+        return f'{self.vec_ref.jid} {self.idx}'
 
     def _compute_type(self):
         self._type = self.vec_ref.item_type

--- a/hail/python/hail/ir/matrix_reader.py
+++ b/hail/python/hail/ir/matrix_reader.py
@@ -11,7 +11,7 @@ from ..utils.java import escape_str
 
 class MatrixReader(object):
     @abc.abstractmethod
-    def render(self):
+    def render(self, r):
         pass
 
     @abc.abstractmethod
@@ -24,7 +24,7 @@ class MatrixNativeReader(MatrixReader):
     def __init__(self, path):
         self.path = path
 
-    def render(self):
+    def render(self, r):
         reader = {'name': 'MatrixNativeReader',
                   'path': self.path}
         return escape_str(json.dumps(reader))
@@ -43,7 +43,7 @@ class MatrixRangeReader(MatrixReader):
         self.n_cols = n_cols
         self.n_partitions = n_partitions
 
-    def render(self):
+    def render(self, r):
         reader = {'name': 'MatrixRangeReader',
                   'nRows': self.n_rows,
                   'nCols': self.n_cols,
@@ -102,7 +102,7 @@ class MatrixVCFReader(MatrixReader):
         self.find_replace = find_replace
         self._partitions_json = _partitions_json
 
-    def render(self):
+    def render(self, r):
         reader = {'name': 'MatrixVCFReader',
                   'files': self.path,
                   'callFields': self.call_fields,
@@ -156,13 +156,14 @@ class MatrixBGENReader(MatrixReader):
             assert (isinstance(included_variants, Table))
         self.included_variants = included_variants
 
-    def render(self):
+    def render(self, r):
         reader = {'name': 'MatrixBGENReader',
                   'files': self.path,
                   'sampleFile': self.sample_file,
                   'indexFileMap': self.index_file_map,
                   'nPartitions': self.n_partitions,
                   'blockSizeInMB': self.block_size,
+                   # FIXME: This has to be wrong. The included_variants IR is not included as a child
                   'includedVariants': r(self.included_variants._tir) if self.included_variants else None
                   }
         return escape_str(json.dumps(reader))
@@ -195,7 +196,7 @@ class MatrixPLINKReader(MatrixReader):
         self.contig_recoding = contig_recoding
         self.skip_invalid_loci = skip_invalid_loci
 
-    def render(self):
+    def render(self, r):
         reader = {'name': 'MatrixPLINKReader',
                   'bed': self.bed,
                   'bim': self.bim,
@@ -243,7 +244,7 @@ class MatrixGENReader(MatrixReader):
             'skipInvalidLoci': skip_invalid_loci
         }
 
-    def render(self):
+    def render(self, r):
         return escape_str(json.dumps(self.config))
 
     def __eq__(self, other):

--- a/hail/python/hail/ir/matrix_reader.py
+++ b/hail/python/hail/ir/matrix_reader.py
@@ -1,18 +1,17 @@
 import abc
 import json
 
+from .utils import make_filter_and_replace
 from ..expr.types import tfloat32, tfloat64
+from ..genetics.reference_genome import reference_genome_type
 from ..typecheck import *
 from ..utils import wrap_to_list
 from ..utils.java import escape_str
-from ..genetics.reference_genome import reference_genome_type
-
-from .utils import make_filter_and_replace
 
 
 class MatrixReader(object):
     @abc.abstractmethod
-    def render(self, r):
+    def render(self):
         pass
 
     @abc.abstractmethod
@@ -25,7 +24,7 @@ class MatrixNativeReader(MatrixReader):
     def __init__(self, path):
         self.path = path
 
-    def render(self, r):
+    def render(self):
         reader = {'name': 'MatrixNativeReader',
                   'path': self.path}
         return escape_str(json.dumps(reader))
@@ -44,7 +43,7 @@ class MatrixRangeReader(MatrixReader):
         self.n_cols = n_cols
         self.n_partitions = n_partitions
 
-    def render(self, r):
+    def render(self):
         reader = {'name': 'MatrixRangeReader',
                   'nRows': self.n_rows,
                   'nCols': self.n_cols,
@@ -103,7 +102,7 @@ class MatrixVCFReader(MatrixReader):
         self.find_replace = find_replace
         self._partitions_json = _partitions_json
 
-    def render(self, r):
+    def render(self):
         reader = {'name': 'MatrixVCFReader',
                   'files': self.path,
                   'callFields': self.call_fields,
@@ -154,10 +153,10 @@ class MatrixBGENReader(MatrixReader):
 
         from hail.table import Table
         if included_variants is not None:
-            assert(isinstance(included_variants, Table))
+            assert (isinstance(included_variants, Table))
         self.included_variants = included_variants
 
-    def render(self, r):
+    def render(self):
         reader = {'name': 'MatrixBGENReader',
                   'files': self.path,
                   'sampleFile': self.sample_file,
@@ -196,7 +195,7 @@ class MatrixPLINKReader(MatrixReader):
         self.contig_recoding = contig_recoding
         self.skip_invalid_loci = skip_invalid_loci
 
-    def render(self, r):
+    def render(self):
         reader = {'name': 'MatrixPLINKReader',
                   'bed': self.bed,
                   'bim': self.bim,
@@ -225,6 +224,7 @@ class MatrixPLINKReader(MatrixReader):
                other.contig_recoding == self.contig_recoding and \
                other.skip_invalid_loci == self.skip_invalid_loci
 
+
 class MatrixGENReader(MatrixReader):
     @typecheck_method(files=sequenceof(str), sample_file=str, chromosome=nullable(str),
                       min_partitions=nullable(int), tolerance=float, rg=nullable(str),
@@ -243,9 +243,9 @@ class MatrixGENReader(MatrixReader):
             'skipInvalidLoci': skip_invalid_loci
         }
 
-    def render(self, r):
+    def render(self):
         return escape_str(json.dumps(self.config))
 
     def __eq__(self, other):
         return isinstance(other, MatrixGENReader) and \
-            self.config == other.config
+               self.config == other.config

--- a/hail/python/hail/ir/matrix_writer.py
+++ b/hail/python/hail/ir/matrix_writer.py
@@ -6,7 +6,7 @@ from ..utils.java import escape_str
 
 class MatrixWriter(object):
     @abc.abstractmethod
-    def render(self, r):
+    def render(self):
         pass
 
     @abc.abstractmethod
@@ -25,7 +25,7 @@ class MatrixNativeWriter(MatrixWriter):
         self.stage_locally = stage_locally
         self.codec_spec = codec_spec
 
-    def render(self, r):
+    def render(self):
         writer = {'name': 'MatrixNativeWriter',
                   'path': self.path,
                   'overwrite': self.overwrite,
@@ -52,7 +52,7 @@ class MatrixVCFWriter(MatrixWriter):
         self.export_type = export_type
         self.metadata = metadata
 
-    def render(self, r):
+    def render(self):
         writer = {'name': 'MatrixVCFWriter',
                   'path': self.path,
                   'append': self.append,
@@ -75,7 +75,7 @@ class MatrixGENWriter(MatrixWriter):
         self.path = path
         self.precision = precision
 
-    def render(self, r):
+    def render(self):
         writer = {'name': 'MatrixGENWriter',
                   'path': self.path,
                   'precision': self.precision}
@@ -92,7 +92,7 @@ class MatrixPLINKWriter(MatrixWriter):
     def __init__(self, path):
         self.path = path
 
-    def render(self, r):
+    def render(self):
         writer = {'name': 'MatrixPLINKWriter',
                   'path': self.path}
         return escape_str(json.dumps(writer))
@@ -111,7 +111,7 @@ class MatrixNativeMultiWriter(object):
         self.overwrite = overwrite
         self.stage_locally = stage_locally
 
-    def render(self, r):
+    def render(self):
         writer = {'name': 'MatrixNativeMultiWriter',
                   'prefix': self.prefix,
                   'overwrite': self.overwrite,

--- a/hail/python/hail/ir/renderer.py
+++ b/hail/python/hail/ir/renderer.py
@@ -117,7 +117,7 @@ class Renderer(object):
                         builder.append(f'(JavaBlockMatrix {jir_id})')
                     else:
                         assert isinstance(x, ir.IR)
-                        builder.append('(JavaIR {jir_id})')
+                        builder.append(f'(JavaIR {jir_id})')
                 else:
                     head = x.render_head(self)
                     if head != '':

--- a/hail/python/hail/ir/renderer.py
+++ b/hail/python/hail/ir/renderer.py
@@ -1,4 +1,91 @@
 from hail import ir
+import abc
+from typing import Sequence, List
+
+
+class Renderable(object):
+    @abc.abstractmethod
+    def render_head(self, r: 'Renderer') -> str:
+        ...
+
+    @abc.abstractmethod
+    def render_tail(self, r: 'Renderer') -> str:
+        ...
+
+    @abc.abstractmethod
+    def render_children(self, r: 'Renderer') -> Sequence['Renderable']:
+        ...
+
+
+class RenderableStr(Renderable):
+    def __init__(self, s: str):
+        self.s = s
+
+    def render_head(self, r: 'Renderer') -> str:
+        return self.s
+
+    @abc.abstractmethod
+    def render_tail(self, r: 'Renderer') -> str:
+        return ''
+
+    @abc.abstractmethod
+    def render_children(self, r: 'Renderer') -> Sequence['Renderable']:
+        return []
+
+
+class ParensRenderer(Renderable):
+    def __init__(self, rs: Sequence['Renderable']):
+        self.rs = rs
+
+    def render_head(self, r: 'Renderer') -> str:
+        return '('
+
+    @abc.abstractmethod
+    def render_tail(self, r: 'Renderer') -> str:
+        return ')'
+
+    @abc.abstractmethod
+    def render_children(self, r: 'Renderer') -> Sequence['Renderable']:
+        return self.rs
+
+
+class RenderableQueue(object):
+    def __init__(self, elements: Sequence[Renderable], tail: str):
+        self._elements = elements
+        self._elements_len = len(elements)
+        self.tail = tail
+        self._idx = 0
+
+    def exhausted(self):
+        return self._elements_len == self._idx
+
+    def pop(self) -> Renderable:
+        idx = self._idx
+        self._idx += 1
+        return self._elements[idx]
+
+
+class RQStack(object):
+    def __init__(self):
+        self._list: List[RenderableQueue] = []
+        self._idx = -1
+
+    def push(self, x: RenderableQueue):
+        self._idx += 1
+        self._list.append(x)
+
+    def peek(self) -> RenderableQueue:
+        return self._list[self._idx]
+
+    def pop(self) -> RenderableQueue:
+        self._idx -= 1
+        return self._list.pop()
+
+    def non_empty(self) -> bool:
+        return self._idx >= 0
+
+    def is_empty(self) -> bool:
+        return self._idx < 0
 
 
 class Renderer(object):
@@ -13,17 +100,37 @@ class Renderer(object):
         self.jirs[jir_id] = jir
         return jir_id
 
-    def __call__(self, x):
-        if self.stop_at_jir and hasattr(x, '_jir'):
-            jir_id = self.add_jir(x._jir)
-            if isinstance(x, ir.MatrixIR):
-                return f'(JavaMatrix {jir_id})'
-            elif isinstance(x, ir.TableIR):
-                return f'(JavaTable {jir_id})'
-            elif isinstance(x, ir.BlockMatrixIR):
-                return f'(JavaBlockMatrix {jir_id})'
+    def __call__(self, x: 'Renderable'):
+        stack = RQStack()
+        builder = []
+
+        while x is not None or stack.non_empty():
+            if x is not None:
+                # TODO: it would be nice to put the JavaIR logic in BaseIR somewhere but this isn't trivial
+                if self.stop_at_jir and hasattr(x, '_jir'):
+                    jir_id = self.add_jir(x._jir)
+                    if isinstance(x, ir.MatrixIR):
+                        builder.append(f'(JavaMatrix {jir_id})')
+                    elif isinstance(x, ir.TableIR):
+                        builder.append(f'(JavaTable {jir_id})')
+                    elif isinstance(x, ir.BlockMatrixIR):
+                        builder.append(f'(JavaBlockMatrix {jir_id})')
+                    else:
+                        assert isinstance(x, ir.IR)
+                        builder.append('(JavaIR {jir_id})')
+                else:
+                    head = x.render_head(self)
+                    if head != '':
+                        builder.append(x.render_head(self))
+                    stack.push(RenderableQueue(x.render_children(self), x.render_tail(self)))
+                x = None
             else:
-                assert isinstance(x, ir.IR)
-                return f'(JavaIR {jir_id})'
-        else:
-            return x.render(self)
+                top = stack.peek()
+                if top.exhausted():
+                    stack.pop()
+                    builder.append(top.tail)
+                else:
+                    builder.append(' ')
+                    x = top.pop()
+
+        return ''.join(builder)

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -549,11 +549,8 @@ class MatrixToTableApply(TableIR):
 
 class BlockMatrixToTable(TableIR):
     def __init__(self, child):
-        super().__init__()
+        super().__init__(child)
         self.child = child
-
-    def render(self, r):
-        return f'(BlockMatrixToTable {r(self.child)})'
 
     def _compute_type(self):
         self._type = hl.ttable(hl.tstruct(), hl.tstruct(**{'i': hl.tint64, 'j': hl.tint64, 'entry': hl.tfloat64}), [])

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -8,28 +8,29 @@ from hail.utils.java import Env, escape_str, escape_id, parsable_strings, dump_j
 
 class MatrixRowsTable(TableIR):
     def __init__(self, child):
-        super().__init__()
+        super().__init__(child)
         self.child = child
-
-    def render(self, r):
-        return '(MatrixRowsTable {})'.format(r(self.child))
 
     def _compute_type(self):
         self._type = hl.ttable(self.child.typ.global_type,
                                self.child.typ.row_type,
                                self.child.typ.row_key)
 
+
 class TableJoin(TableIR):
     def __init__(self, left, right, join_type, join_key):
-        super().__init__()
+        super().__init__(left, right)
         self.left = left
         self.right = right
         self.join_type = join_type
         self.join_key = join_key
 
-    def render(self, r):
-        return '(TableJoin {} {} {} {})'.format(
-            escape_id(self.join_type), self.join_key, r(self.left), r(self.right))
+    def head_str(self):
+        return f'{escape_id(self.join_type)} {self.join_key}'
+
+    def _eq(self, other):
+        return self.join_key == other.join_key and \
+               self.join_type == other.join_type
 
     def _compute_type(self):
         left_typ = self.left.typ
@@ -38,16 +39,19 @@ class TableJoin(TableIR):
                                left_typ.key_type._concat(left_typ.value_type)._concat(right_typ.value_type),
                                left_typ.row_key + right_typ.row_key[self.join_key:])
 
+
 class TableLeftJoinRightDistinct(TableIR):
     def __init__(self, left, right, root):
-        super().__init__()
+        super().__init__(left, right)
         self.left = left
         self.right = right
         self.root = root
 
-    def render(self, r):
-        return '(TableLeftJoinRightDistinct {} {} {})'.format(
-            escape_id(self.root), r(self.left), r(self.right))
+    def head_str(self):
+        return escape_id(self.root)
+
+    def _eq(self, other):
+        return self.root == other.root
 
     def _compute_type(self):
         left_typ = self.left.typ
@@ -57,16 +61,19 @@ class TableLeftJoinRightDistinct(TableIR):
             left_typ.row_type._insert_field(self.root, right_typ.value_type),
             left_typ.row_key)
 
+
 class TableIntervalJoin(TableIR):
     def __init__(self, left, right, root):
-        super().__init__()
+        super().__init__(left, right)
         self.left = left
         self.right = right
         self.root = root
 
-    def render(self, r):
-        return '(TableIntervalJoin {} {} {})'.format(
-            escape_id(self.root), r(self.left), r(self.right))
+    def head_str(self):
+        return escape_id(self.root)
+
+    def _eq(self, other):
+        return self.root == other.root
 
     def _compute_type(self):
         left_typ = self.left.typ
@@ -79,15 +86,12 @@ class TableIntervalJoin(TableIR):
 
 class TableUnion(TableIR):
     def __init__(self, children):
-        super().__init__()
+        super().__init__(*children)
         self.children = children
-
-    def render(self, r):
-        return '(TableUnion {})'.format(' '.join([r(x) for x in self.children]))
 
     def _compute_type(self):
         for c in self.children:
-            c.typ # force
+            c.typ  # force
         self._type = self.children[0].typ
 
 
@@ -97,37 +101,42 @@ class TableRange(TableIR):
         self.n = n
         self.n_partitions = n_partitions
 
-    def render(self, r):
-        return '(TableRange {} {})'.format(self.n, self.n_partitions)
+    def head_str(self):
+        return f'{self.n} {self.n_partitions}'
+
+    def _eq(self, other):
+        return self.n == other.n and self.n_partitions == other.n_partitions
 
     def _compute_type(self):
         self._type = hl.ttable(hl.tstruct(),
                                hl.tstruct(idx=hl.tint32),
                                ['idx'])
 
-class TableMapGlobals(TableIR):
-    def __init__(self, child, new_row):
-        super().__init__()
-        self.child = child
-        self.new_row = new_row
 
-    def render(self, r):
-        return '(TableMapGlobals {} {})'.format(r(self.child), r(self.new_row))
+class TableMapGlobals(TableIR):
+    def __init__(self, child, new_globals):
+        super().__init__(child, new_globals)
+        self.child = child
+        self.new_globals = new_globals
 
     def _compute_type(self):
-        self.new_row._compute_type(self.child.typ.global_env(), None)
-        self._type = hl.ttable(self.new_row.typ,
+        self.new_globals._compute_type(self.child.typ.global_env(), None)
+        self._type = hl.ttable(self.new_globals.typ,
                                self.child.typ.row_type,
                                self.child.typ.row_key)
 
+
 class TableExplode(TableIR):
     def __init__(self, child, path):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.path = path
 
-    def render(self, r):
-        return '(TableExplode {} {})'.format(parsable_strings(self.path), r(self.child))
+    def head_str(self):
+        return parsable_strings(self.path)
+
+    def _eq(self, other):
+        return self.path == other.path
 
     def _compute_type(self):
         atyp = self.child.typ.row_type._index_path(self.path)
@@ -138,16 +147,16 @@ class TableExplode(TableIR):
 
 class TableKeyBy(TableIR):
     def __init__(self, child, keys, is_sorted=False):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.keys = keys
         self.is_sorted = is_sorted
 
-    def render(self, r):
-        return '(TableKeyBy ({}) {} {})'.format(
-            ' '.join([escape_id(x) for x in self.keys]),
-            self.is_sorted,
-            r(self.child))
+    def head_str(self):
+        return '({}) {}'.format(' '.join([escape_id(x) for x in self.keys]), self.is_sorted)
+
+    def _eq(self, other):
+        return self.keys == other.keys and self.is_sorter == other.is_sorted
 
     def _compute_type(self):
         self._type = hl.ttable(self.child.typ.global_type,
@@ -157,12 +166,9 @@ class TableKeyBy(TableIR):
 
 class TableMapRows(TableIR):
     def __init__(self, child, new_row):
-        super().__init__()
+        super().__init__(child, new_row)
         self.child = child
         self.new_row = new_row
-
-    def render(self, r):
-        return '(TableMapRows {} {})'.format(r(self.child), r(self.new_row))
 
     def _compute_type(self):
         # agg_env for scans
@@ -172,14 +178,18 @@ class TableMapRows(TableIR):
             self.new_row.typ,
             self.child.typ.row_key)
 
+
 class TableRead(TableIR):
-    def __init__(self, reader, drop_rows = False):
+    def __init__(self, reader, drop_rows=False):
         super().__init__()
         self.reader = reader
         self.drop_rows = drop_rows
 
-    def render(self, r):
-        return f'(TableRead None {self.drop_rows} "{r(self.reader)}")'
+    def head_str(self):
+        return f'None {self.drop_rows} "{self.reader.render()}"'
+
+    def _eq(self, other):
+        return self.reader == other.reader and self.drop_rows == other.drop_rows
 
     def _compute_type(self):
         self._type = Env.backend().table_type(self)
@@ -192,11 +202,14 @@ class TableImport(TableIR):
         self._typ = typ
         self.reader_options = reader_options
 
-    def render(self, r):
-        return '(TableImport ({}) {} {})'.format(
+    def head_str(self):
+        return '(({}) {} {}'.format(
             ' '.join([escape_str(path) for path in self.paths]),
             self._typ._parsable_string(),
             escape_str(json.dumps(self.reader_options)))
+
+    def _eq(self, other):
+        return self.paths == other.paths and self.typ == other.typ and self.reader_options == other.reader_options
 
     def _compute_type(self):
         self._type = Env.backend().table_type(self)
@@ -204,11 +217,8 @@ class TableImport(TableIR):
 
 class MatrixEntriesTable(TableIR):
     def __init__(self, child):
-        super().__init__()
+        super().__init__(child)
         self.child = child
-
-    def render(self, r):
-        return '(MatrixEntriesTable {})'.format(r(self.child))
 
     def _compute_type(self):
         child_typ = self.child.typ
@@ -221,12 +231,9 @@ class MatrixEntriesTable(TableIR):
 
 class TableFilter(TableIR):
     def __init__(self, child, pred):
-        super().__init__()
+        super().__init__(child, pred)
         self.child = child
         self.pred = pred
-
-    def render(self, r):
-        return '(TableFilter {} {})'.format(r(self.child), r(self.pred))
 
     def _compute_type(self):
         self.pred._compute_type(self.child.typ.row_env(), None)
@@ -235,19 +242,18 @@ class TableFilter(TableIR):
 
 class TableKeyByAndAggregate(TableIR):
     def __init__(self, child, expr, new_key, n_partitions, buffer_size):
-        super().__init__()
+        super().__init__(child, expr, new_key)
         self.child = child
         self.expr = expr
         self.new_key = new_key
         self.n_partitions = n_partitions
         self.buffer_size = buffer_size
 
-    def render(self, r):
-        return '(TableKeyByAndAggregate {} {} {} {} {})'.format(self.n_partitions,
-                                                                self.buffer_size,
-                                                                r(self.child),
-                                                                r(self.expr),
-                                                                self.new_key)
+    def head_str(self):
+        return f'{self.n_partitions} {self.buffer_size}'
+
+    def _eq(self, other):
+        return self.n_partitions == other.n_partitions and self.buffer_size == other.buffer_size
 
     def _compute_type(self):
         self.expr._compute_type(self.child.typ.global_env(), self.child.typ.row_env())
@@ -259,12 +265,9 @@ class TableKeyByAndAggregate(TableIR):
 
 class TableAggregateByKey(TableIR):
     def __init__(self, child, expr):
-        super().__init__()
+        super().__init__(child, expr)
         self.child = child
         self.expr = expr
-
-    def render(self, r):
-        return '(TableAggregateByKey {} {})'.format(r(self.child), r(self.expr))
 
     def _compute_type(self):
         child_typ = self.child.typ
@@ -273,13 +276,11 @@ class TableAggregateByKey(TableIR):
                                child_typ.key_type._concat(self.expr.typ),
                                child_typ.row_key)
 
+
 class MatrixColsTable(TableIR):
     def __init__(self, child):
-        super().__init__()
+        super().__init__(child)
         self.child = child
-
-    def render(self, r):
-        return '(MatrixColsTable {})'.format(r(self.child))
 
     def _compute_type(self):
         self._type = hl.ttable(self.child.typ.global_type,
@@ -289,14 +290,15 @@ class MatrixColsTable(TableIR):
 
 class TableParallelize(TableIR):
     def __init__(self, rows_and_global, n_partitions):
-        super().__init__()
+        super().__init__(rows_and_global)
         self.rows_and_global = rows_and_global
         self.n_partitions = n_partitions
 
-    def render(self, r):
-        return '(TableParallelize {} {})'.format(
-            self.n_partitions,
-            r(self.rows_and_global))
+    def head_str(self):
+        return self.n_partitions
+
+    def _eq(self, other):
+        return self.n_partitions == other.n_partitions
 
     def _compute_type(self):
         self.rows_and_global._compute_type({}, None)
@@ -307,12 +309,15 @@ class TableParallelize(TableIR):
 
 class TableHead(TableIR):
     def __init__(self, child, n):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.n = n
 
-    def render(self, r):
-        return f'(TableHead {self.n} {r(self.child)})'
+    def head_str(self):
+        return self.n
+
+    def _eq(self, other):
+        return self.n == other.n
 
     def _compute_type(self):
         self._type = self.child.typ
@@ -320,14 +325,15 @@ class TableHead(TableIR):
 
 class TableOrderBy(TableIR):
     def __init__(self, child, sort_fields):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.sort_fields = sort_fields
 
-    def render(self, r):
-        return '(TableOrderBy ({}) {})'.format(
-            ' '.join([escape_id(order + f) for (f, order) in self.sort_fields]),
-            r(self.child))
+    def head_str(self):
+        return f'({" ".join([escape_id(order + f) for (f, order) in self.sort_fields])})'
+
+    def _eq(self, other):
+        return self.sort_fields == other.sort_fields
 
     def _compute_type(self):
         self._type = hl.ttable(self.child.typ.global_type,
@@ -337,29 +343,31 @@ class TableOrderBy(TableIR):
 
 class TableDistinct(TableIR):
     def __init__(self, child):
-        super().__init__()
+        super().__init__(child)
         self.child = child
-
-    def render(self, r):
-        return f'(TableDistinct {r(self.child)})'
 
     def _compute_type(self):
         self._type = self.child.typ
+
 
 class RepartitionStrategy:
     SHUFFLE = 0
     COALESCE = 1
     NAIVE_COALESCE = 2
 
+
 class TableRepartition(TableIR):
     def __init__(self, child, n, strategy):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.n = n
         self.strategy = strategy
 
-    def render(self, r):
-        return f'(TableRepartition {self.n} {self.strategy} {r(self.child)})'
+    def head_str(self):
+        return f'{self.n} {self.strategy}'
+
+    def _eq(self, other):
+        return self.n == other.n and self.strategy == other.strategy
 
     def _compute_type(self):
         self._type = self.child.typ
@@ -367,38 +375,40 @@ class TableRepartition(TableIR):
 
 class CastMatrixToTable(TableIR):
     def __init__(self, child, entries_field_name, cols_field_name):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.entries_field_name = entries_field_name
         self.cols_field_name = cols_field_name
 
-    def render(self, r):
-        return f'(CastMatrixToTable ' \
-               f'"{escape_str(self.entries_field_name)}" ' \
-               f'"{escape_str(self.cols_field_name)}" ' \
-               f'{r(self.child)})'
+    def head_str(self):
+        return f'"{escape_str(self.entries_field_name)}" "{escape_str(self.cols_field_name)}"'
+
+    def _eq(self, other):
+        return self.entries_field_name == other.entries_field_name and self.cols_field_name == other.cols_field_name
 
     def _compute_type(self):
         child_typ = self.child.typ
         self._type = hl.ttable(child_typ.global_type._insert_field(self.cols_field_name, hl.tarray(child_typ.col_type)),
-                               child_typ.row_type._insert_field(self.entries_field_name, hl.tarray(child_typ.entry_type)),
+                               child_typ.row_type._insert_field(self.entries_field_name,
+                                                                hl.tarray(child_typ.entry_type)),
                                child_typ.row_key)
 
 
 class TableRename(TableIR):
     def __init__(self, child, row_map, global_map):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.row_map = row_map
         self.global_map = global_map
 
-    def render(self, r):
-        return f'(TableRename ' \
-               f'{parsable_strings(self.row_map.keys())} ' \
+    def head_str(self):
+        return f'{parsable_strings(self.row_map.keys())} ' \
                f'{parsable_strings(self.row_map.values())} ' \
                f'{parsable_strings(self.global_map.keys())} ' \
-               f'{parsable_strings(self.global_map.values())} ' \
-               f'{r(self.child)})'
+               f'{parsable_strings(self.global_map.values())} '
+
+    def _eq(self, other):
+        return self.row_map == other.row_map and self.global_map == other.global_map
 
     def _compute_type(self):
         self._type = self.child.typ._rename(self.global_map, self.row_map)
@@ -406,20 +416,20 @@ class TableRename(TableIR):
 
 class TableMultiWayZipJoin(TableIR):
     def __init__(self, children, data_name, global_name):
-        super().__init__()
+        super().__init__(*children)
         self.children = children
         self.data_name = data_name
         self.global_name = global_name
 
-    def render(self, r):
-        return f'(TableMultiWayZipJoin '\
-               f'"{escape_str(self.data_name)}" '\
-               f'"{escape_str(self.global_name)}" '\
-               f'{" ".join([r(child) for child in self.children])})'
+    def head_str(self):
+        return f'"{escape_str(self.data_name)}" "{escape_str(self.global_name)}"'
+
+    def _eq(self, other):
+        return self.data_name == other.data_name and self.global_name == other.global_name
 
     def _compute_type(self):
         for c in self.children:
-            c.typ # force
+            c.typ  # force
         child_typ = self.children[0].typ
         self._type = hl.ttable(
             hl.tstruct(**{self.global_name: hl.tarray(child_typ.global_type)}),
@@ -429,12 +439,15 @@ class TableMultiWayZipJoin(TableIR):
 
 class TableToTableApply(TableIR):
     def __init__(self, child, config):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.config = config
 
-    def render(self, r):
-        return f'(TableToTableApply {dump_json(self.config)} {r(self.child)})'
+    def head_str(self):
+        return dump_json(self.config)
+
+    def _eq(self, other):
+        return self.config == other.config
 
     def _compute_type(self):
         name = self.config['name']
@@ -448,7 +461,8 @@ class TableToTableApply(TableIR):
 def regression_test_type(test):
     glm_fit_schema = dtype('struct{n_iterations:int32,converged:bool,exploded:bool}')
     if test == 'wald':
-        return dtype(f'struct{{beta:float64,standard_error:float64,z_stat:float64,p_value:float64,fit:{glm_fit_schema}}}')
+        return dtype(
+            f'struct{{beta:float64,standard_error:float64,z_stat:float64,p_value:float64,fit:{glm_fit_schema}}}')
     elif test == 'lrt':
         return dtype(f'struct{{beta:float64,chi_sq_stat:float64,p_value:float64,fit:{glm_fit_schema}}}')
     elif test == 'score':
@@ -460,19 +474,23 @@ def regression_test_type(test):
 
 class MatrixToTableApply(TableIR):
     def __init__(self, child, config):
-        super().__init__()
+        super().__init__(child)
         self.child = child
         self.config = config
 
-    def render(self, r):
-        return f'(MatrixToTableApply {dump_json(self.config)} {r(self.child)})'
+    def head_str(self):
+        return dump_json(self.config)
+
+    def _eq(self, other):
+        return self.config == other.config
 
     def _compute_type(self):
         name = self.config['name']
         child_typ = self.child.typ
         if name == 'LinearRegressionRowsChained':
             pass_through = self.config['passThrough']
-            chained_schema = hl.dtype('struct{n:array<int32>,sum_x:array<float64>,y_transpose_x:array<array<float64>>,beta:array<array<float64>>,standard_error:array<array<float64>>,t_stat:array<array<float64>>,p_value:array<array<float64>>}')
+            chained_schema = hl.dtype(
+                'struct{n:array<int32>,sum_x:array<float64>,y_transpose_x:array<array<float64>>,beta:array<array<float64>>,standard_error:array<array<float64>>,t_stat:array<array<float64>>,p_value:array<array<float64>>}')
             self._type = hl.ttable(
                 child_typ.global_type,
                 (child_typ.row_key_type
@@ -481,7 +499,8 @@ class MatrixToTableApply(TableIR):
                 child_typ.row_key)
         elif name == 'LinearRegressionRowsSingle':
             pass_through = self.config['passThrough']
-            chained_schema = hl.dtype('struct{n:int32,sum_x:float64,y_transpose_x:array<float64>,beta:array<float64>,standard_error:array<float64>,t_stat:array<float64>,p_value:array<float64>}')
+            chained_schema = hl.dtype(
+                'struct{n:int32,sum_x:float64,y_transpose_x:array<float64>,beta:array<float64>,standard_error:array<float64>,t_stat:array<float64>,p_value:array<float64>}')
             self._type = hl.ttable(
                 child_typ.global_type,
                 (child_typ.row_key_type
@@ -545,8 +564,8 @@ class JavaTable(TableIR):
         super().__init__()
         self._jir = jir
 
-    def render(self, r):
-        return f'(JavaTable {r.add_jir(self._jir)})'
+    def render_head(self, r):
+        return f'(JavaTable {r.add_jir(self._jir)}'
 
     def _compute_type(self):
         self._type = hl.ttable._from_java(self._jir.typ())

--- a/hail/python/hail/ir/table_reader.py
+++ b/hail/python/hail/ir/table_reader.py
@@ -1,13 +1,14 @@
 import abc
 import json
 
+from hail.ir.utils import make_filter_and_replace
 from hail.typecheck import *
 from hail.utils.java import escape_str
-from hail.ir.utils import make_filter_and_replace
+
 
 class TableReader(object):
     @abc.abstractmethod
-    def render(self, r):
+    def render(self):
         pass
 
     @abc.abstractmethod
@@ -20,7 +21,7 @@ class TableNativeReader(TableReader):
     def __init__(self, path):
         self.path = path
 
-    def render(self, r):
+    def render(self):
         reader = {'name': 'TableNativeReader',
                   'path': self.path}
         return escape_str(json.dumps(reader))
@@ -50,7 +51,7 @@ class TextTableReader(TableReader):
             'forceGZ': force_gz
         }
 
-    def render(self, r):
+    def render(self):
         reader = {'name': 'TextTableReader',
                   'options': self.config}
         return escape_str(json.dumps(reader))

--- a/hail/python/hail/ir/table_reader.py
+++ b/hail/python/hail/ir/table_reader.py
@@ -67,7 +67,7 @@ class TableFromBlockMatrixNativeReader(TableReader):
         self.path = path
         self.n_partitions = n_partitions
 
-    def render(self, r):
+    def render(self):
         reader = {'name': 'TableFromBlockMatrixNativeReader',
                   'path': self.path,
                   'nPartitions': self.n_partitions}

--- a/hail/python/hail/ir/utils.py
+++ b/hail/python/hail/ir/utils.py
@@ -5,7 +5,7 @@ from .ir import *
 def filter_predicate_with_keep(ir_pred, keep):
     pred = Env.get_uid()
     return Let(pred,
-               ir_pred if keep else ApplyUnaryOp('!', ir_pred),
+               ir_pred if keep else ApplyUnaryPrimOp('!', ir_pred),
                   If(IsNA(Ref(pred)),
                      FalseIR(),
                      Ref(pred)))

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1,23 +1,24 @@
-import numpy as np
-import scipy.linalg as spla
-import itertools
 import os
+
+import itertools
+import numpy as np
 import re
+import scipy.linalg as spla
 
 import hail as hl
 import hail.expr.aggregators as agg
 from hail.expr import construct_expr
-from hail.ir import BlockMatrixWrite, BlockMatrixMap2, ApplyBinaryOp, Ref, F64, \
+from hail.expr.expressions import expr_float64, matrix_table_source, check_entry_indexed
+from hail.ir import BlockMatrixWrite, BlockMatrixMap2, ApplyBinaryPrimOp, Ref, F64, \
     BlockMatrixBroadcast, ValueToBlockMatrix, BlockMatrixRead, JavaBlockMatrix, BlockMatrixMap, \
-    ApplyUnaryOp, IR, BlockMatrixDot, tensor_shape_to_matrix_shape, BlockMatrixAgg, BlockMatrixRandom, \
+    ApplyUnaryPrimOp, IR, BlockMatrixDot, tensor_shape_to_matrix_shape, BlockMatrixAgg, BlockMatrixRandom, \
     BlockMatrixToValueApply, BlockMatrixToTable, BlockMatrixFilter, TableFromBlockMatrixNativeReader, TableRead
 from hail.ir.blockmatrix_reader import BlockMatrixNativeReader, BlockMatrixBinaryReader
 from hail.ir.blockmatrix_writer import BlockMatrixBinaryWriter, BlockMatrixNativeWriter, BlockMatrixRectanglesWriter
+from hail.table import Table
+from hail.typecheck import *
 from hail.utils import new_temp_file, new_local_temp_file, local_path_uri, storage_level
 from hail.utils.java import Env, jarray, joption
-from hail.typecheck import *
-from hail.table import Table
-from hail.expr.expressions import expr_float64, matrix_table_source, check_entry_indexed
 
 block_matrix_type = lazy()
 
@@ -1236,14 +1237,14 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return self._apply_map(ApplyUnaryOp('-', Ref('element')))
+        return self._apply_map(ApplyUnaryPrimOp('-', Ref('element')))
 
     def _unary_func_ir(self, hail_func):
         return hail_func(construct_expr(Ref('element'), self.element_type))._ir
 
     @staticmethod
     def _binary_op_ir(op):
-        return ApplyBinaryOp(op, Ref('l'), Ref('r'))
+        return ApplyBinaryPrimOp(op, Ref('l'), Ref('r'))
 
     @typecheck_method(f=IR)
     def _apply_map(self, f):

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1895,7 +1895,7 @@ class Table(ExprContainer):
         --------
         Subset to the first three rows:
 
-        >>> table_result = table1.render_head(3)
+        >>> table_result = table1.head(3)
         >>> table_result.count()
         3
 

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1,22 +1,16 @@
+from collections import Counter
+
+import itertools
 import pandas
 import pyspark
-import warnings
-
 from typing import *
 
-import hail as hl
 from hail.expr.expressions import *
-from hail.expr.types import *
 from hail.expr.table_type import *
-from hail.expr.matrix_type import *
 from hail.ir import *
 from hail.typecheck import *
-from hail.utils import wrap_to_list, storage_level, LinkedList, Struct
 from hail.utils.java import *
 from hail.utils.misc import *
-
-from collections import OrderedDict, Counter
-import itertools
 
 table_type = lazy()
 
@@ -25,6 +19,12 @@ class Ascending(object):
     def __init__(self, col):
         self.col = col
 
+    def __eq__(self, other):
+        return isinstance(other, Ascending) and self.col == other.col
+
+    def __ne__(self, other):
+        return not self == other
+
     def _j_obj(self):
         return scala_package_object(Env.hail().table).asc(self.col)
 
@@ -32,6 +32,12 @@ class Ascending(object):
 class Descending(object):
     def __init__(self, col):
         self.col = col
+
+    def __eq__(self, other):
+        return isinstance(other, Descending) and self.col == other.col
+
+    def __ne__(self, other):
+        return not self == other
 
     def _j_obj(self):
         return scala_package_object(Env.hail().table).desc(self.col)
@@ -1889,7 +1895,7 @@ class Table(ExprContainer):
         --------
         Subset to the first three rows:
 
-        >>> table_result = table1.head(3)
+        >>> table_result = table1.render_head(3)
         >>> table_result.count()
         3
 

--- a/hail/python/hail/utils/misc.py
+++ b/hail/python/hail/utils/misc.py
@@ -418,10 +418,10 @@ def process_joins(obj, exprs):
     for e in exprs:
         joins = e._ir.search(lambda a: isinstance(a, hail.ir.Join))
         for j in sorted(joins, key=lambda j: j.idx): # Make sure joins happen in order
-            if j not in used_joins:
+            if j.idx not in used_joins:
                 left = j.join_func(left)
                 all_uids.extend(j.temp_vars)
-                used_joins.add(j)
+                used_joins.add(j.idx)
 
     def cleanup(table):
         remaining_uids = [uid for uid in all_uids if uid in table._fields]

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -41,8 +41,8 @@ class ValueIRTests(unittest.TestCase):
             ir.If(b, i, j),
             ir.Let('v', i, v),
             ir.Ref('x'),
-            ir.ApplyBinaryOp('+', i, j),
-            ir.ApplyUnaryOp('-', i),
+            ir.ApplyBinaryPrimOp('+', i, j),
+            ir.ApplyUnaryPrimOp('-', i),
             ir.ApplyComparisonOp('EQ', i, j),
             ir.MakeArray([i, ir.NA(hl.tint32), ir.I32(-3)], hl.tarray(hl.tint32)),
             ir.ArrayRef(a, i),
@@ -247,6 +247,17 @@ class MatrixIRTests(unittest.TestCase):
             except Exception as e:
                 raise ValueError(str(x)) from e
 
+    def test_highly_nested_ir(self):
+        N = 10
+        M = 250
+        ht = hl.utils.range_table(N)
+        for i in range(M):
+            ht = ht.annotate(**{f'x{i}': i})
+        str(ht._tir)
+
+        # TODO: Scala Pretty errors out with a StackOverflowError here
+        # ht._force_count()
+
 
 class BlockMatrixIRTests(unittest.TestCase):
     def blockmatrix_irs(self):
@@ -255,7 +266,7 @@ class BlockMatrixIRTests(unittest.TestCase):
 
         read = ir.BlockMatrixRead(ir.BlockMatrixNativeReader(resource('blockmatrix_example/0')))
         add_two_bms = ir.BlockMatrixMap2(read, read, ir.ApplyBinaryOp('+', ir.Ref('l'), ir.Ref('r')))
-        negate_bm = ir.BlockMatrixMap(read, ir.ApplyUnaryOp('-', ir.Ref('element')))
+        negate_bm = ir.BlockMatrixMap(read, ir.ApplyUnaryPrimOp('-', ir.Ref('element')))
         sqrt_bm = ir.BlockMatrixMap(read, hl.sqrt(construct_expr(ir.Ref('element'), hl.tfloat64))._ir)
 
         scalar_to_bm = ir.ValueToBlockMatrix(scalar_ir, [1, 1], 1)

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -265,7 +265,7 @@ class BlockMatrixIRTests(unittest.TestCase):
         vector_ir = ir.MakeArray([ir.F64(3), ir.F64(2)], hl.tarray(hl.tfloat64))
 
         read = ir.BlockMatrixRead(ir.BlockMatrixNativeReader(resource('blockmatrix_example/0')))
-        add_two_bms = ir.BlockMatrixMap2(read, read, ir.ApplyBinaryOp('+', ir.Ref('l'), ir.Ref('r')))
+        add_two_bms = ir.BlockMatrixMap2(read, read, ir.ApplyBinaryPrimOp('+', ir.Ref('l'), ir.Ref('r')))
         negate_bm = ir.BlockMatrixMap(read, ir.ApplyUnaryPrimOp('-', ir.Ref('element')))
         sqrt_bm = ir.BlockMatrixMap(read, hl.sqrt(construct_expr(ir.Ref('element'), hl.tfloat64))._ir)
 

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1114,9 +1114,9 @@ object IRParser {
         val child = matrix_ir(env)(it)
         MatrixCollectColsByKey(child)
       case "MatrixRepartition" =>
-        val child = matrix_ir(env)(it)
         val n = int32_literal(it)
         val strategy = int32_literal(it)
+        val child = matrix_ir(env)(it)
         MatrixRepartition(child, n, strategy)
       case "MatrixUnionRows" =>
         val children = matrix_ir_children(env)(it)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1462,6 +1462,7 @@ class IRSuite extends SparkSuite {
         MatrixMapCols(read, newCol, None),
         MatrixKeyRowsBy(read, FastIndexedSeq("row_m", "row_d"), false),
         MatrixMapRows(read, newRow),
+        MatrixRepartition(read, 10, 0),
         MatrixMapEntries(read, MakeStruct(FastIndexedSeq(
           "global_f32" -> ApplyBinaryPrimOp(Add(),
             GetField(Ref("global", read.typ.globalType), "global_f32"),


### PR DESCRIPTION
Contains one piece of a fix for #5262

This refactor was initially undertaken to resolve the above issue, which
manifested due to the nested stack frames created by the IR renderer.