### PR TITLE
[bugfix] Fix Expression.show() with a key field that isn't the first key

### DIFF
--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -706,7 +706,7 @@ class Expression(object):
             name = source._fields_inverse.get(self, name)
         t = self._to_table(name)
         if name in t.key:
-            t = t.key_by(name).select()
+            t = t.order_by(*t.key).select(name)
         return t._show(n, width, truncate, types)
 
 


### PR DESCRIPTION
Fixes #5449

We don't have machinery for testing performance behavior of something
like show() right now, so I can't test it easily. But I did verify by
hand.