### PR TITLE
[batch] fix batch logs

### DIFF
--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -294,8 +294,8 @@ class Job:
             del pod_name_job[self._pod_name]
             self._pod_name = None
 
+        self._next_task()
         if self.exit_code == 0 and self._has_next_task():
-            self._next_task()
             self._create_pod()
             return
 

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -260,3 +260,15 @@ class Test(unittest.TestCase):
                 pass
             else:
                 raise
+
+    def test_log_after_failing_job(self):
+        j = self.batch.create_job('alpine', ['/bin/sh', '-c', 'echo test; exit 127'])
+        status = j.wait()
+        self.assertTrue('attributes' not in status)
+        self.assertEqual(status['state'], 'Complete')
+        self.assertEqual(status['exit_code'], 127)
+
+        self.assertEqual(status['log']['main'], 'test\n')
+        self.assertEqual(j.log(), {'main': 'test\n'})
+
+        self.assertTrue(j.is_complete())


### PR DESCRIPTION
If batch job fails we should still increment the _task_idx.
Otherwise, we ignore the log for the failing task.