### PR TITLE
fix reference genome unify

### DIFF
--- a/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -446,7 +446,7 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
     }
   }
 
-  def unify(concrete: RGBase): Boolean = this eq concrete
+  def unify(concrete: RGBase): Boolean = this == concrete
 
   def isBound: Boolean = true
 
@@ -745,7 +745,7 @@ case class RGVariable(var rg: RGBase = null) extends RGBase {
       rg = concrete
       true
     } else
-      rg eq concrete
+      rg == concrete
   }
 
   def isBound: Boolean = rg != null


### PR DESCRIPTION
@chrisvittal This will fix your define_function issue.  I was wrong, the types were the same.

@danking Something very strange is going on here.  I can verify only one GenomeReference is being constructed, so this and concrete must be the same object, but eq is returning false.  I don't see how this can be possible.

I some something similar last week which caused me to add ReferenceGenome.hashCode (we were defining one but not the other).  However, that shouldn't matter because there was only one reference genome object, but two different pointers captured at different times were returning different values of hashCode.

I don't see how that's possible but I don't see an alternate explanation.

This fixes the immediate bug.  I think ReferenceGenome shouldn't be a case class, and it should only use ref equality (don't override equals, hashCode).  That will take a little work because the case class is being used for JSON serialization.