### PR TITLE
Blockmatrix export rects

### DIFF
--- a/hail/python/hail/ir/blockmatrix_writer.py
+++ b/hail/python/hail/ir/blockmatrix_writer.py
@@ -52,3 +52,30 @@ class BlockMatrixBinaryWriter(BlockMatrixWriter):
     def __eq__(self, other):
         return isinstance(other, BlockMatrixBinaryWriter) and \
                self.path == other.path
+
+
+class BlockMatrixRectanglesWriter(BlockMatrixWriter):
+    @typecheck_method(path=str,
+                      flattened_rectangles=sequenceof(int),
+                      delimiter=str,
+                      binary=bool)
+    def __init__(self, path, flattened_rectangles, delimiter, binary):
+        self.path = path
+        self.flattened_rectangles = flattened_rectangles
+        self.delimiter = delimiter
+        self.binary = binary
+
+    def render(self, r):
+        writer = {'name': 'BlockMatrixRectanglesWriter',
+                  'path': self.path,
+                  'flattenedRectangles': self.flattened_rectangles,
+                  'delimiter': self.delimiter,
+                  'binary': self.binary}
+        return escape_str(json.dumps(writer))
+
+    def __eq__(self, other):
+        return isinstance(other, BlockMatrixRectanglesWriter) and \
+               self.path == other.path and \
+               self.flattened_rectangles == other.flattened_rectangles and \
+               self.delimiter == other.delimiter and \
+               self.binary == other.binary

--- a/hail/python/hail/ir/blockmatrix_writer.py
+++ b/hail/python/hail/ir/blockmatrix_writer.py
@@ -56,19 +56,19 @@ class BlockMatrixBinaryWriter(BlockMatrixWriter):
 
 class BlockMatrixRectanglesWriter(BlockMatrixWriter):
     @typecheck_method(path=str,
-                      flattened_rectangles=sequenceof(int),
+                      rectangles=sequenceof(sequenceof(int)),
                       delimiter=str,
                       binary=bool)
-    def __init__(self, path, flattened_rectangles, delimiter, binary):
+    def __init__(self, path, rectangles, delimiter, binary):
         self.path = path
-        self.flattened_rectangles = flattened_rectangles
+        self.rectangles = rectangles
         self.delimiter = delimiter
         self.binary = binary
 
     def render(self, r):
         writer = {'name': 'BlockMatrixRectanglesWriter',
                   'path': self.path,
-                  'flattenedRectangles': self.flattened_rectangles,
+                  'rectangles': self.rectangles,
                   'delimiter': self.delimiter,
                   'binary': self.binary}
         return escape_str(json.dumps(writer))
@@ -76,6 +76,6 @@ class BlockMatrixRectanglesWriter(BlockMatrixWriter):
     def __eq__(self, other):
         return isinstance(other, BlockMatrixRectanglesWriter) and \
                self.path == other.path and \
-               self.flattened_rectangles == other.flattened_rectangles and \
+               self.rectangles == other.rectangles and \
                self.delimiter == other.delimiter and \
                self.binary == other.binary

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -11,6 +11,7 @@ from hail.ir import BlockMatrixWrite, BlockMatrixMap2, ApplyBinaryOp, Ref, F64, 
     BlockMatrixToValueApply, BlockMatrixToTable
 from hail.ir.blockmatrix_writer import BlockMatrixBinaryWriter, BlockMatrixNativeWriter
 from hail.ir.blockmatrix_reader import BlockMatrixNativeReader, BlockMatrixBinaryReader
+from hail.ir.blockmatrix_writer import BlockMatrixBinaryWriter, BlockMatrixNativeWriter
 from hail.utils import new_temp_file, new_local_temp_file, local_path_uri, storage_level
 from hail.utils.java import Env, jarray, joption
 from hail.typecheck import *

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1752,7 +1752,7 @@ class BlockMatrix(object):
                       delimiter=str,
                       binary=bool)
     def export_rectangles(self, path_out, rectangles, delimiter='\t', binary=False):
-        """Export rectangular regions from a stored block matrix to delimited text or binary files.
+        """Export rectangular regions from a block matrix to delimited text or binary files.
 
         Examples
         --------
@@ -1764,20 +1764,12 @@ class BlockMatrix(object):
         ...                [ 9.0, 10.0, 11.0, 12.0],
         ...                [13.0, 14.0, 15.0, 16.0]])
 
-        Filter to the three rectangles and write.
+        Filter to the three rectangles and export as TSV files.
 
         >>> rectangles = [[0, 1, 0, 1], [0, 3, 0, 2], [1, 2, 0, 4]]
         >>>
         >>> (BlockMatrix.from_numpy(nd)
-        ...     .sparsify_rectangles(rectangles)
-        ...     .write('output/example.bm', overwrite=True, force_row_major=True))
-
-        Export the three rectangles to TSV files:
-
-        >>> BlockMatrix.export_rectangles(
-        ...     path_in='output/example.bm',
-        ...     path_out='output/example',
-        ...     rectangles = rectangles)
+        ...     .export_rectangles('output/example.bm', rectangles))
 
         This produces three files in the folder ``output/example``.
 
@@ -1800,13 +1792,6 @@ class BlockMatrix(object):
         .. code-block:: text
 
             5.0 6.0 7.0 8.0
-
-        Warning
-        -------
-        The block matrix must be stored in row-major format, as results
-        from :meth:`.BlockMatrix.write` with ``force_row_major=True`` and
-        from :meth:`.BlockMatrix.write_from_entry_expr`. Otherwise,
-        :meth:`export` will fail.
 
         Notes
         -----
@@ -1843,8 +1828,6 @@ class BlockMatrix(object):
 
         Parameters
         ----------
-        path_in: :obj:`srt`
-            Path to input block matrix, stored row-major on disk.
         path_out: :obj:`str`
             Path for folder of exported files.
         rectangles: :obj:`list` of :obj:`list` of :obj:`int`
@@ -1852,9 +1835,6 @@ class BlockMatrix(object):
             ``[row_start, row_stop, col_start, col_stop]``.
         delimiter: :obj:`str`
             Column delimiter.
-        n_partitions: :obj:`int`, optional
-            Maximum parallelism of export.
-            Defaults to (and cannot exceed) the number of rectangles.
         binary: :obj:`bool`
             If true, export elements as raw bytes in row major order.
         """

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1871,9 +1871,7 @@ class BlockMatrix(object):
                 raise ValueError(f'rectangle {r} does not satisfy '
                                  f'0 <= r[0] <= r[1] <= n_rows and 0 <= r[2] <= r[3] <= n_cols')
 
-        flattened_rectangles = [x for rect in rectangles for x in rect]
-
-        writer = BlockMatrixRectanglesWriter(path_out, flattened_rectangles, delimiter, binary)
+        writer = BlockMatrixRectanglesWriter(path_out, rectangles, delimiter, binary)
         Env.backend().execute(BlockMatrixWrite(self._bmir, writer))
 
     @typecheck_method(compute_uv=bool,

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -9,7 +9,6 @@ from hail.ir import BlockMatrixWrite, BlockMatrixMap2, ApplyBinaryOp, Ref, F64, 
     BlockMatrixBroadcast, ValueToBlockMatrix, MakeArray, BlockMatrixRead, JavaBlockMatrix, BlockMatrixMap, \
     ApplyUnaryOp, IR, BlockMatrixDot, tensor_shape_to_matrix_shape, BlockMatrixAgg, BlockMatrixRandom, \
     BlockMatrixToValueApply, BlockMatrixToTable
-from hail.ir.blockmatrix_writer import BlockMatrixBinaryWriter, BlockMatrixNativeWriter
 from hail.ir.blockmatrix_reader import BlockMatrixNativeReader, BlockMatrixBinaryReader
 from hail.ir.blockmatrix_writer import BlockMatrixBinaryWriter, BlockMatrixNativeWriter
 from hail.utils import new_temp_file, new_local_temp_file, local_path_uri, storage_level
@@ -295,9 +294,6 @@ class BlockMatrix(object):
         --------
         :meth:`.from_numpy`
         """
-        n_entries = n_rows * n_cols
-        if n_entries >= 1 << 31:
-            raise ValueError(f'number of entries must be less than 2^31, found {n_entries}')
 
         if not block_size:
             block_size = BlockMatrix.default_block_size()

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1889,8 +1889,11 @@ class BlockMatrix(object):
 
         flattened_rectangles = jarray(Env.jvm().long, list(itertools.chain(*rectangles)))
 
-        return Env.hail().linalg.BlockMatrix.exportRectangles(
-            Env.hc()._jhc, path_in, path_out, flattened_rectangles, delimiter, n_partitions, binary)
+        jbm = BlockMatrix.read(path_in)._jbm
+
+        jbm.exportRectangles(Env.hc()._jhc, path_out, flattened_rectangles, delimiter, n_partitions, binary)
+        # return Env.hail().linalg.BlockMatrix.exportRectangles(
+        #     Env.hc()._jhc, path_in, path_out, flattened_rectangles, delimiter, n_partitions, binary)
 
     @typecheck_method(compute_uv=bool,
                       complexity_bound=int)

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -9,8 +9,8 @@ from hail.ir import BlockMatrixWrite, BlockMatrixMap2, ApplyBinaryOp, Ref, F64, 
     BlockMatrixBroadcast, ValueToBlockMatrix, MakeArray, BlockMatrixRead, JavaBlockMatrix, BlockMatrixMap, \
     ApplyUnaryOp, IR, BlockMatrixDot, tensor_shape_to_matrix_shape, BlockMatrixAgg, BlockMatrixRandom, \
     BlockMatrixToValueApply, BlockMatrixToTable
-from hail.ir.blockmatrix_reader import BlockMatrixNativeReader, BlockMatrixBinaryReader
 from hail.ir.blockmatrix_writer import BlockMatrixBinaryWriter, BlockMatrixNativeWriter
+from hail.ir.blockmatrix_reader import BlockMatrixNativeReader, BlockMatrixBinaryReader
 from hail.utils import new_temp_file, new_local_temp_file, local_path_uri, storage_level
 from hail.utils.java import Env, jarray, joption
 from hail.typecheck import *
@@ -294,6 +294,9 @@ class BlockMatrix(object):
         --------
         :meth:`.from_numpy`
         """
+        n_entries = n_rows * n_cols
+        if n_entries >= 1 << 31:
+            raise ValueError(f'number of entries must be less than 2^31, found {n_entries}')
 
         if not block_size:
             block_size = BlockMatrix.default_block_size()

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -627,14 +627,10 @@ class Tests(unittest.TestCase):
 
         for rects in [rects1, rects2, rects3]:
             for block_size in [3, 4, 10]:
-                bm_uri = new_temp_file()
-
                 rect_path = new_local_temp_dir()
                 rect_uri = local_path_uri(rect_path)
 
                 bm = BlockMatrix.from_numpy(nd, block_size=block_size)
-
-                bm.sparsify_rectangles(rects).write(bm_uri, force_row_major=True)
                 bm.export_rectangles(rect_uri, rects)
 
                 for (i, r) in enumerate(rects):

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -632,11 +632,10 @@ class Tests(unittest.TestCase):
                 rect_path = new_local_temp_dir()
                 rect_uri = local_path_uri(rect_path)
 
-                (BlockMatrix.from_numpy(nd, block_size=block_size)
-                    .sparsify_rectangles(rects)
-                    .write(bm_uri, force_row_major=True))
+                bm = BlockMatrix.from_numpy(nd, block_size=block_size)
 
-                BlockMatrix.export_rectangles(bm_uri, rect_uri, rects)
+                bm.sparsify_rectangles(rects).write(bm_uri, force_row_major=True)
+                bm.export_rectangles(rect_uri, rects)
 
                 for (i, r) in enumerate(rects):
                     file = rect_path + '/rect-' + str(i) + '_' + '-'.join(map(str, r))
@@ -647,7 +646,7 @@ class Tests(unittest.TestCase):
                 rect_path_bytes = new_local_temp_dir()
                 rect_uri_bytes = local_path_uri(rect_path_bytes)
 
-                BlockMatrix.export_rectangles(bm_uri, rect_uri_bytes, rects, binary=True)
+                bm.export_rectangles(rect_uri_bytes, rects, binary=True)
 
                 for (i, r) in enumerate(rects):
                     file = rect_path_bytes + '/rect-' + str(i) + '_' + '-'.join(map(str, r))

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -655,17 +655,6 @@ class Tests(unittest.TestCase):
                     actual = np.reshape(np.fromfile(file), (r[1] - r[0], r[3] - r[2]))
                     self._assert_eq(expected, actual)
 
-        bm_uri = new_temp_file()
-        rect_uri = new_temp_file()
-
-        (BlockMatrix.from_numpy(nd, block_size=5)
-            .sparsify_rectangles([[0, 1, 0, 1]])
-            .write(bm_uri, force_row_major=True))
-
-        with self.assertRaises(FatalError) as e:
-            BlockMatrix.export_rectangles(bm_uri, rect_uri, [[5, 6, 5, 6]])
-            self.assertEquals(e.msg, 'block (1, 1) missing for rectangle 0 with bounds [5, 6, 5, 6]')
-
     @skip_unless_spark_backend()
     def test_block_matrix_entries(self):
         n_rows, n_cols = 5, 3

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -15,7 +15,7 @@ object BlockMatrixWriter {
 
 
 abstract class BlockMatrixWriter {
-  def apply(bm: BlockMatrix): Unit
+  def apply(hc: HailContext, bm: BlockMatrix): Unit
 }
 
 case class BlockMatrixNativeWriter(

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -24,11 +24,11 @@ case class BlockMatrixNativeWriter(
   forceRowMajor: Boolean,
   stageLocally: Boolean) extends BlockMatrixWriter {
 
-  def apply(bm: BlockMatrix): Unit = bm.write(path, overwrite, forceRowMajor, stageLocally)
+  def apply(hc: HailContext, bm: BlockMatrix): Unit = bm.write(path, overwrite, forceRowMajor, stageLocally)
 }
 
 case class BlockMatrixBinaryWriter(path: String) extends BlockMatrixWriter {
-  def apply(bm: BlockMatrix): Unit = {
-    RichDenseMatrixDouble.exportToDoubles(HailContext.get, path, bm.toBreezeMatrix(), forceRowMajor = true)
+  def apply(hc: HailContext, bm: BlockMatrix): Unit = {
+    RichDenseMatrixDouble.exportToDoubles(hc, path, bm.toBreezeMatrix(), forceRowMajor = true)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -8,7 +8,7 @@ import org.json4s.{DefaultFormats, Formats, ShortTypeHints}
 object BlockMatrixWriter {
   implicit val formats: Formats = new DefaultFormats() {
     override val typeHints = ShortTypeHints(
-      List(classOf[BlockMatrixNativeWriter], classOf[BlockMatrixBinaryWriter]))
+      List(classOf[BlockMatrixNativeWriter], classOf[BlockMatrixBinaryWriter], classOf[BlockMatrixRectanglesWriter]))
     override val typeHintFieldName: String = "name"
   }
 }
@@ -30,5 +30,16 @@ case class BlockMatrixNativeWriter(
 case class BlockMatrixBinaryWriter(path: String) extends BlockMatrixWriter {
   def apply(hc: HailContext, bm: BlockMatrix): Unit = {
     RichDenseMatrixDouble.exportToDoubles(hc, path, bm.toBreezeMatrix(), forceRowMajor = true)
+  }
+}
+
+case class BlockMatrixRectanglesWriter(
+  path: String,
+  flattenedRectangles: Seq[Long],
+  delimiter: String,
+  binary: Boolean) extends BlockMatrixWriter {
+
+  def apply(hc: HailContext, bm: BlockMatrix): Unit = {
+    bm.exportRectangles(hc, path, flattenedRectangles.toArray, delimiter, binary)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -15,7 +15,7 @@ object BlockMatrixWriter {
 
 
 abstract class BlockMatrixWriter {
-  def apply(hc: HailContext, bm: BlockMatrix): Unit
+  def apply(bm: BlockMatrix): Unit
 }
 
 case class BlockMatrixNativeWriter(
@@ -24,11 +24,11 @@ case class BlockMatrixNativeWriter(
   forceRowMajor: Boolean,
   stageLocally: Boolean) extends BlockMatrixWriter {
 
-  def apply(hc: HailContext, bm: BlockMatrix): Unit = bm.write(path, overwrite, forceRowMajor, stageLocally)
+  def apply(bm: BlockMatrix): Unit = bm.write(path, overwrite, forceRowMajor, stageLocally)
 }
 
 case class BlockMatrixBinaryWriter(path: String) extends BlockMatrixWriter {
-  def apply(hc: HailContext, bm: BlockMatrix): Unit = {
-    RichDenseMatrixDouble.exportToDoubles(hc, path, bm.toBreezeMatrix(), forceRowMajor = true)
+  def apply(bm: BlockMatrix): Unit = {
+    RichDenseMatrixDouble.exportToDoubles(HailContext.get, path, bm.toBreezeMatrix(), forceRowMajor = true)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -35,11 +35,11 @@ case class BlockMatrixBinaryWriter(path: String) extends BlockMatrixWriter {
 
 case class BlockMatrixRectanglesWriter(
   path: String,
-  flattenedRectangles: Seq[Long],
+  rectangles: Array[Array[Long]],
   delimiter: String,
   binary: Boolean) extends BlockMatrixWriter {
 
   def apply(hc: HailContext, bm: BlockMatrix): Unit = {
-    bm.exportRectangles(hc, path, flattenedRectangles.toArray, delimiter, binary)
+    bm.exportRectangles(hc, path, rectangles, delimiter, binary)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -783,7 +783,7 @@ object Interpret {
         tableValue.export(path, typesFile, header, exportType, delimiter)
       case BlockMatrixWrite(child, writer) =>
         val hc = HailContext.get
-        writer(child.execute(hc))
+        writer(hc, child.execute(hc))
       case TableToValueApply(child, function) =>
         function.execute(child.execute(HailContext.get))
       case MatrixToValueApply(child, function) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -783,7 +783,7 @@ object Interpret {
         tableValue.export(path, typesFile, header, exportType, delimiter)
       case BlockMatrixWrite(child, writer) =>
         val hc = HailContext.get
-        writer(hc, child.execute(hc))
+        writer(child.execute(hc))
       case TableToValueApply(child, function) =>
         function.execute(child.execute(HailContext.get))
       case MatrixToValueApply(child, function) =>

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -384,7 +384,6 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     output: String,
     flattenedRectangles: Array[Long],
     delimiter: String,
-    nPartitions: Int,
     binary: Boolean) {
 
     val writeRectangle = (uos: OutputStream, data: Array[Double], nCols: Long) => {

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -382,7 +382,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   def exportRectangles(
     hc: HailContext,
     output: String,
-    flattenedRectangles: Array[Long],
+    rectangles: Array[Array[Long]],
     delimiter: String,
     binary: Boolean) {
 
@@ -416,7 +416,6 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
 
     val writeRectangle = if (binary) writeRectangleBinary else writeRectangleText
 
-    val rectangles = flattenedRectangles.grouped(4).toArray
     val dRect = digitsNeeded(rectangles.length)
     val sHadoopBc = hc.hadoopConfBc
     BlockMatrixRectanglesRDD(rectangles, bm = this).foreach({ case (index, rectData) =>

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -418,13 +418,14 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
 
     val rectangles = flattenedRectangles.grouped(4).toArray
     val dRect = digitsNeeded(rectangles.length)
+    val sHadoopBc = hc.hadoopConfBc
     BlockMatrixRectanglesRDD(rectangles, bm = this).foreach({ case (index, rectData) =>
       val r = rectangles(index)
       val paddedIndex = StringUtils.leftPad(index.toString, dRect, "0")
       val outputFile = output + "/rect-" + paddedIndex + "_" + r.mkString("-")
 
       if (rectData.size > 0) {
-        hc.hadoopConfBc.value.value.writeFile(outputFile) { uos =>
+        sHadoopBc.value.value.writeFile(outputFile) { uos =>
           writeRectangle(uos, rectData)
           uos.close()
         }


### PR DESCRIPTION
- Refactored `exportRectangles` on BlockMatrix from a static function with an input and output file to an instance function with an output file that writes the instance.
- Added `BlockMatrixRectanglesWriter` so exporting rectangles happens through the IR.
- Updated tests and deleted parts of tests that dealt with invalid inputs that aren't applicable when exporting from an already loaded BlockMatrix.