### PR TITLE
[batch] batch cleans up after itself when it is deployed

### DIFF
--- a/batch/Makefile
+++ b/batch/Makefile
@@ -70,4 +70,8 @@ deploy: push
 	sed -e "s,@sha@,$$(git rev-parse --short=12 HEAD)," \
 	  -e "s,@image@,$$(cat batch-image)," \
 	  < deployment.yaml.in > deployment.yaml
+	kubectl delete persistvolumeclaim --all --namespace batch-pods
+	kubectl delete namespace test
+	./kubectl-wait-for-delete namespace test
+	kubectl create -f test-namespace.yaml
 	kubectl -n default apply -f deployment.yaml

--- a/batch/Makefile
+++ b/batch/Makefile
@@ -70,7 +70,7 @@ deploy: push
 	sed -e "s,@sha@,$$(git rev-parse --short=12 HEAD)," \
 	  -e "s,@image@,$$(cat batch-image)," \
 	  < deployment.yaml.in > deployment.yaml
-	kubectl delete namespace test
+	-kubectl delete namespace test
 	./kubectl-wait-for-delete namespace test
 	kubectl create -f test-namespace.yaml
 	kubectl delete persistvolumeclaim --all --namespace batch-pods

--- a/batch/Makefile
+++ b/batch/Makefile
@@ -70,8 +70,8 @@ deploy: push
 	sed -e "s,@sha@,$$(git rev-parse --short=12 HEAD)," \
 	  -e "s,@image@,$$(cat batch-image)," \
 	  < deployment.yaml.in > deployment.yaml
-	kubectl delete persistvolumeclaim --all --namespace batch-pods
 	kubectl delete namespace test
 	./kubectl-wait-for-delete namespace test
 	kubectl create -f test-namespace.yaml
+	kubectl delete persistvolumeclaim --all --namespace batch-pods
 	kubectl -n default apply -f deployment.yaml

--- a/batch/hail-ci-deploy.sh
+++ b/batch/hail-ci-deploy.sh
@@ -9,16 +9,4 @@ gcloud -q auth activate-service-account \
 
 gcloud -q auth configure-docker
 
-kubectl delete persistvolumeclaim --all --namespace batch-pods
-kubectl delete namespace test
-# when we have k8s 1.12 https://github.com/kubernetes/kubernetes/pull/64034:
-# kubectl wait --for=delete namespace/test
-: $((delay = 1))
-while kubectl get namespace test
-do
-    : $((delay = delay + delay))
-    sleep ${delay}
-done
-kubectl create -f test-namespace.yaml
-
 make deploy

--- a/batch/hail-ci-deploy.sh
+++ b/batch/hail-ci-deploy.sh
@@ -9,4 +9,16 @@ gcloud -q auth activate-service-account \
 
 gcloud -q auth configure-docker
 
+kubectl delete persistvolumeclaim --all --namespace batch-pods
+kubectl delete namespace test
+# when we have k8s 1.12 https://github.com/kubernetes/kubernetes/pull/64034:
+# kubectl wait --for=delete namespace/test
+: $((delay = 1))
+while kubectl get namespace test
+do
+    : $((delay = delay + delay))
+    sleep ${delay}
+done
+kubectl create -f test-namespace.yaml
+
 make deploy

--- a/batch/kubectl-wait-for-delete
+++ b/batch/kubectl-wait-for-delete
@@ -1,0 +1,18 @@
+#!/bin/sh
+# kubectl-wait-for-delete TYPE NAME
+#
+# Wait for a k8s resource of type TYPE and name NAME to not exist.
+#
+# When we have k8s 1.12 https://github.com/kubernetes/kubernetes/pull/64034, we
+# can rely directly on kubectl:
+#
+#     kubectl wait --for=delete namespace/test
+#
+# This script is intended to be POSIX compliant.
+
+: $((delay = 1))
+while kubectl get $1 $2
+do
+    : $((delay = delay + delay))
+    sleep ${delay}
+done

--- a/batch/test-namespace.yaml
+++ b/batch/test-namespace.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: test
+  name: test-test
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: test-svc-test-test-binding
+  namespace: test
+subjects:
+- kind: ServiceAccount
+  name: test-svc
+  namespace: batch-pods
+roleRef:
+  kind: Role
+  name: test-test
+  apiGroup: "rbac.authorization.k8s.io"


### PR DESCRIPTION
Currently, garbage pods will sit around in the batch-pods and test namespaces forever.

In anticipation of adding expensive resources (storage), batch needs to learn to clean up after itself. Batch creates garbage whenever it is killed without warning. This happens in two circumstances:
- when batch is killed by a deploy
- CI job is running a test batch instance and is killed because master or the feature branch changed

To mitigate this issue we delete all PVCs (storage, ergo monetarily expensive resources) from the batch-pods namespace before we deploy batch. These PVCs are no longer needed because the batch instance that owns them is about to be re-deployed.

Since the test namespace (where CI jobs will spin up batch instances to test) might also contain PVCs, we delete the whole namespace. We can do this because the deploy job (the one running `make deploy` is in the `batch-pods` namespace, not the `test` namespace). Since we delete the whole namespace, we need to recreate anything that's expected to exist there.

---

This is a short term fix. The long term fix mitigates these two situations differently:
- persistence of batch jobs ensures that after a deploy, the new batch instance finds the orphaned resources and adopts them
- each test job will get a fresh namespace in which it creates whatever it needs to test, batch then ensures this namespace is destroyed when the job is finished (which, of course, requires persistence of batch jobs)