### PR TITLE
[notebook2] libsass depends on a c++ compiler

### DIFF
--- a/notebook2/Dockerfile
+++ b/notebook2/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Hail Team <hail@broadinstitute.org>
 RUN apk add \
   bash \
   gcc \
+  g++ \
   libffi-dev \
   musl-dev \
   openssl-dev \


### PR DESCRIPTION
notebook2 deploys are currently broken, which breaks all deploys