### PR TITLE
Blockmatrix filter IR node

### DIFF
--- a/hail/python/hail/ir/blockmatrix_ir.py
+++ b/hail/python/hail/ir/blockmatrix_ir.py
@@ -143,8 +143,7 @@ class BlockMatrixFilter(BlockMatrixIR):
         self._type = tblockmatrix(self.child.typ.element_type,
                                   tensor_shape,
                                   is_row_vector,
-                                  self.child.typ.block_size,
-                                  self.child.typ.dims_partitioned)
+                                  self.child.typ.block_size)
 
 
 class ValueToBlockMatrix(BlockMatrixIR):

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -8,7 +8,7 @@ from hail.expr import construct_expr
 from hail.ir import BlockMatrixWrite, BlockMatrixMap2, ApplyBinaryOp, Ref, F64, \
     BlockMatrixBroadcast, ValueToBlockMatrix, MakeArray, BlockMatrixRead, JavaBlockMatrix, BlockMatrixMap, \
     ApplyUnaryOp, IR, BlockMatrixDot, tensor_shape_to_matrix_shape, BlockMatrixAgg, BlockMatrixRandom, \
-    BlockMatrixToValueApply, BlockMatrixToTable
+    BlockMatrixToValueApply, BlockMatrixToTable, BlockMatrixFilter
 from hail.ir.blockmatrix_reader import BlockMatrixNativeReader, BlockMatrixBinaryReader
 from hail.ir.blockmatrix_writer import BlockMatrixBinaryWriter, BlockMatrixNativeWriter, BlockMatrixRectanglesWriter
 from hail.utils import new_temp_file, new_local_temp_file, local_path_uri, storage_level
@@ -721,7 +721,7 @@ class BlockMatrix(object):
         :class:`.BlockMatrix`
         """
         BlockMatrix._check_indices(rows_to_keep, self.n_rows)
-        return BlockMatrix._from_java(self._jbm.filterRows(jarray(Env.jvm().long, rows_to_keep)))
+        return BlockMatrix(BlockMatrixFilter(self._bmir, [rows_to_keep, []]))
 
     @typecheck_method(cols_to_keep=sequenceof(int))
     def filter_cols(self, cols_to_keep):
@@ -737,7 +737,7 @@ class BlockMatrix(object):
         :class:`.BlockMatrix`
         """
         BlockMatrix._check_indices(cols_to_keep, self.n_cols)
-        return BlockMatrix._from_java(self._jbm.filterCols(jarray(Env.jvm().long, cols_to_keep)))
+        return BlockMatrix(BlockMatrixFilter(self._bmir, [[], cols_to_keep]))
 
     @typecheck_method(rows_to_keep=sequenceof(int),
                       cols_to_keep=sequenceof(int))
@@ -763,8 +763,7 @@ class BlockMatrix(object):
         """
         BlockMatrix._check_indices(rows_to_keep, self.n_rows)
         BlockMatrix._check_indices(cols_to_keep, self.n_cols)
-        return BlockMatrix._from_java(self._jbm.filter(jarray(Env.jvm().long, rows_to_keep),
-                                                       jarray(Env.jvm().long, cols_to_keep)))
+        return BlockMatrix(BlockMatrixFilter(self._bmir, [rows_to_keep, cols_to_keep]))
 
     @staticmethod
     def _pos_index(i, size, name, allow_size=False):

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1179,9 +1179,9 @@ object IRParser {
         val child = blockmatrix_ir(env)(it)
         BlockMatrixAgg(child, outIndexExpr)
       case "BlockMatrixFilter" =>
-        val intervals = literals(literals(int64_literal))(it)
+        val indices = literals(literals(int64_literal))(it)
         val child = blockmatrix_ir(env)(it)
-        BlockMatrixFilter(child, intervals)
+        BlockMatrixFilter(child, indices)
       case "ValueToBlockMatrix" =>
         val shape = int64_literals(it)
         val blockSize = int32_literal(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1178,6 +1178,10 @@ object IRParser {
         val outIndexExpr = int32_literals(it)
         val child = blockmatrix_ir(env)(it)
         BlockMatrixAgg(child, outIndexExpr)
+      case "BlockMatrixFilter" =>
+        val intervals = literals(literals(int64_literal))(it)
+        val child = blockmatrix_ir(env)(it)
+        BlockMatrixFilter(child, intervals)
       case "ValueToBlockMatrix" =>
         val shape = int64_literals(it)
         val blockSize = int32_literal(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -204,6 +204,8 @@ object Pretty {
             case ValueToBlockMatrix(_, shape, blockSize) =>
               prettyLongs(shape) + " " +
               blockSize.toString + " "
+            case BlockMatrixFilter(_, indicesToKeepPerDim) =>
+              indicesToKeepPerDim.map(indices => prettyLongs(indices.toIndexedSeq)).mkString("(", " ", ")")
             case BlockMatrixRandom(seed, gaussian, shape, blockSize) =>
               seed.toString + " " +
               prettyBooleanLiteral(gaussian) + " " +


### PR DESCRIPTION
- Added a single `BlockMatrixFilter` IR node for filtering a subset of rows and columns.
- I don't really have a great way of talking about filtering on some dimensions and not others. Filter takes a list of list of indices (one list per dimension) and if the list is empty that dimension is not filtered on. While there's no other meaningful interpretation of an empty list it feels like you're saying you don't want to keep any of the indices. Could use optionals for each dimension but `None` seems just as confusing and would require some small refactoring of the parser. The more consistent thing to do is pass along something like `range(n_rows)` but that just seems wasteful.