### PR TITLE
[notebook2]: external url for login redirect should keep https

### DIFF
--- a/notebook2/notebook/notebook.py
+++ b/notebook2/notebook/notebook.py
@@ -382,7 +382,7 @@ def login_page():
 
 @app.route('/login', methods=['POST'])
 def login_auth0():
-    external_url = flask.url_for('auth0_callback', _external = True)
+    external_url = external_url_for('/auth0_callback')
     session['workshop_password'] = request.form.get('workshop-password')
 
     return auth0.authorize_redirect(redirect_uri = external_url, audience = f'{AUTH0_BASE_URL}/userinfo', prompt = 'login')
@@ -391,7 +391,7 @@ def login_auth0():
 @app.route('/logout', methods=['POST'])
 def logout():
     session.clear()
-    params = {'returnTo': flask.url_for('root', _external=True), 'client_id': AUTH0_CLIENT_ID}
+    params = {'returnTo': external_url_for('/'), 'client_id': AUTH0_CLIENT_ID}
     return redirect(auth0.api_base_url + '/v2/logout?' + urlencode(params))
 
 

--- a/notebook2/notebook/notebook.py
+++ b/notebook2/notebook/notebook.py
@@ -382,16 +382,16 @@ def login_page():
 
 @app.route('/login', methods=['POST'])
 def login_auth0():
-    external_url = external_url_for('/auth0_callback')
     session['workshop_password'] = request.form.get('workshop-password')
 
-    return auth0.authorize_redirect(redirect_uri = external_url, audience = f'{AUTH0_BASE_URL}/userinfo', prompt = 'login')
+    return auth0.authorize_redirect(redirect_uri = external_url_for('auth0-callback'),
+                                    audience = f'{AUTH0_BASE_URL}/userinfo', prompt = 'login')
 
 
 @app.route('/logout', methods=['POST'])
 def logout():
     session.clear()
-    params = {'returnTo': external_url_for('/'), 'client_id': AUTH0_CLIENT_ID}
+    params = {'returnTo': external_url_for(''), 'client_id': AUTH0_CLIENT_ID}
     return redirect(auth0.api_base_url + '/v2/logout?' + urlencode(params))
 
 


### PR DESCRIPTION
Just ensures that https isn't stripped, so that auth0 sends credentials to the https site (which is the only address it is allowed to send credentials to).