### PR TITLE
[combiner] update combiner format in response to feedback

### DIFF
--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -334,7 +334,8 @@ class VCFTests(unittest.TestCase):
             MQ_DP=hl.null(hl.tint32),
             VarDP=hl.null(hl.tint32),
             QUALapprox=hl.null(hl.tint32))))
-                for mt in hl.import_vcfs(paths, parts_str, reference_genome='GRCh38')]
+                for mt in hl.import_vcfs(paths, parts_str, reference_genome='GRCh38',
+                                         array_elements_required=False)]
         comb = combine_gvcfs(vcfs)
         self.assertEqual(len(parts), comb.n_partitions())
         comb._force_count_rows()


### PR DESCRIPTION
To summarize:
    - Filter out '<NON_REF>' allele in transform_one
    - Create RGQ, as PL[GT index of 0/<NON_REF>]
    - Set LPL to missing if alleles only contains the ref after filtering