### PR TITLE
[hail] export ALT as '.' when there is only one allele

### DIFF
--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -226,6 +226,15 @@ class VCFTests(unittest.TestCase):
 
         assert hl.import_vcf(tmp)._same(mt)
 
+    def test_export_vcf_no_alt_alleles(self):
+        mt = hl.import_vcf(resource('gvcfs/HG0096_excerpt.g.vcf'), reference_genome='GRCh38')
+        self.assertEqual(mt.filter_rows(hl.len(mt.alleles) == 1).count_rows(), 5)
+
+        tmp = new_temp_file(suffix="vcf")
+        hl.export_vcf(mt, tmp)
+        mt2 = hl.import_vcf(tmp, reference_genome='GRCh38')
+        self.assertTrue(mt._same(mt2))
+
     @skip_unless_spark_backend()
     def test_import_vcfs(self):
         path = resource('sample.vcf.bgz')

--- a/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -52,7 +52,7 @@ object ExportVCF {
         fatal(s"VCF does not support type $elementType")
     }
   }
-  
+
   def iterableVCF(sb: StringBuilder, t: PContainer, m: Region, length: Int, offset: Long, delim: Char) {
     if (length > 0) {
       var i = 0
@@ -155,7 +155,7 @@ object ExportVCF {
       case _ => false
     }
   }
-  
+
   def checkFormatSignature(tg: TStruct) {
     tg.fields.foreach { fd =>
       val valid = fd.typ match {
@@ -166,7 +166,7 @@ object ExportVCF {
         fatal(s"Invalid type for format field '${ fd.name }'. Found '${ fd.typ }'.")
     }
   }
-  
+
   def emitGenotype(sb: StringBuilder, formatFieldOrder: Array[Int], tg: PStruct, m: Region, offset: Long, fieldDefined: Array[Boolean], missingFormat: String) {
     var i = 0
     while (i < formatFieldOrder.length) {
@@ -368,7 +368,7 @@ object ExportVCF {
     val (qualExists, qualIdx) = lookupVAField("qual", "QUAL", Some(TFloat64()))
     val (filtersExists, filtersIdx) = lookupVAField("filters", "FILTERS", Some(filtersType))
     val (infoExists, infoIdx) = lookupVAField("info", "INFO", None)
-    
+
     val fullRowType = typ.rvRowType.physicalType
     val localEntriesIndex = typ.entriesIdx
     val localEntriesType = typ.entryArrayType.physicalType
@@ -400,8 +400,12 @@ object ExportVCF {
         sb += '\t'
         sb.append(rvv.alleles()(0))
         sb += '\t'
-        rvv.alleles().tail.foreachBetween(aa =>
-          sb.append(aa))(sb += ',')
+        if (rvv.alleles().length > 1) {
+          rvv.alleles().tail.foreachBetween(aa =>
+            sb.append(aa))(sb += ',')
+        } else {
+          sb += '.'
+        }
         sb += '\t'
 
         if (qualExists && fullRowType.isFieldDefined(rv, qualIdx)) {
@@ -456,7 +460,7 @@ object ExportVCF {
             i += 1
           }
         }
-        
+
         sb.result()
       }
     }.writeTable(path, HailContext.get.tmpDir, Some(header), exportType = exportType)

--- a/hail/src/test/resources/gvcfs/HG0096_excerpt.g.vcf
+++ b/hail/src/test/resources/gvcfs/HG0096_excerpt.g.vcf
@@ -1,0 +1,34 @@
+##fileformat=VCFv4.2
+##ALT=<ID=NON_REF,Description="Represents any possible alternative allele at this location">
+##FILTER=<ID=LowQual,Description="Low quality">
+##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth (reads with MQ=255 or with bad mates are filtered)">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=MIN_DP,Number=1,Type=Integer,Description="Minimum DP observed within the GVCF block">
+##FORMAT=<ID=PGT,Number=1,Type=String,Description="Physical phasing haplotype information, describing how the alternate alleles are phased in relation to one another">
+##FORMAT=<ID=PID,Number=1,Type=String,Description="Physical phasing ID information, where each unique ID within a given sample (but not across samples) connects records within a phasing group">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification">
+##FORMAT=<ID=SB,Number=4,Type=Integer,Description="Per-sample component statistics which comprise the Fisher's Exact Test to detect strand bias.">
+##INFO=<ID=BaseQRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt Vs. Ref base qualities">
+##INFO=<ID=ClippingRankSum,Number=1,Type=Float,Description="Z-score From Wilcoxon rank sum test of Alt vs. Ref number of hard clipped bases">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have been filtered">
+##INFO=<ID=DS,Number=0,Type=Flag,Description="Were any of the samples downsampled?">
+##INFO=<ID=END,Number=1,Type=Integer,Description="Stop position of the interval">
+##INFO=<ID=ExcessHet,Number=1,Type=Float,Description="Phred-scaled p-value for exact test of excess heterozygosity">
+##INFO=<ID=HaplotypeScore,Number=1,Type=Float,Description="Consistency of the site with at most two segregating haplotypes">
+##INFO=<ID=InbreedingCoeff,Number=1,Type=Float,Description="Inbreeding coefficient as estimated from the genotype likelihoods per-sample when compared against the Hardy-Weinberg expectation">
+##INFO=<ID=MLEAC,Number=A,Type=Integer,Description="Maximum likelihood expectation (MLE) for the allele counts (not necessarily the same as the AC), for each ALT allele, in the same order as listed">
+##INFO=<ID=MLEAF,Number=A,Type=Float,Description="Maximum likelihood expectation (MLE) for the allele frequency (not necessarily the same as the AF), for each ALT allele, in the same order as listed">
+##INFO=<ID=MQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+##INFO=<ID=MQRankSum,Number=1,Type=Float,Description="Z-score From Wilcoxon rank sum test of Alt vs. Ref read mapping qualities">
+##INFO=<ID=RAW_MQ,Number=1,Type=Float,Description="Raw data for RMS Mapping Quality">
+##INFO=<ID=ReadPosRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt vs. Ref read position bias">
+##contig=<ID=chr20,length=64444167>
+##contig=<ID=chr21,length=46709983>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	HG00096
+chr20	17959479	.	T	.	.	.	END=17959479	GT:DP:GQ:MIN_DP	0/0:45:0:45
+chr20	17959480	.	T	.	.	.	END=17959639	GT:DP:GQ:MIN_DP	0/0:45:99:42
+chr20	17959640	.	A	.	.	.	END=17959640	GT:DP:GQ:MIN_DP	0/0:42:91:42
+chr20	17959641	.	T	.	.	.	END=17959660	GT:DP:GQ:MIN_DP	0/0:41:99:36
+chr20	17959661	.	A	.	.	.	END=17959671	GT:DP:GQ:MIN_DP	0/0:34:96:32


### PR DESCRIPTION
Previously export_vcf would write nothing when there were no alternate
alleles, hail would then fail to import the exported vcf.