### PR TITLE
[batch] Volumes

### DIFF
--- a/batch/batch/client.py
+++ b/batch/batch/client.py
@@ -1,3 +1,4 @@
+import math
 import time
 import random
 import yaml
@@ -42,7 +43,7 @@ class Job:
             self.status()  # update
             if self.is_complete():
                 return self._status
-            j = random.randrange(2 ** i)
+            j = random.randrange(math.floor(1.5 ** i))
             time.sleep(0.100 * j)
             # max 5.12s
             if i < 9:

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -136,7 +136,7 @@ class Job:
         return pvc
 
     def _create_pod(self):
-        assert self._pod_name is not None
+        assert self._pod_name is None
         assert self._current_task is not None
 
         if len(self._tasks) > 1:

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -132,7 +132,7 @@ class Job:
                         requests={'storage': POD_VOLUME_SIZE}),
                     storage_class_name=STORAGE_CLASS_NAME)),
             _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS)
-        log.info(f'created pvc name: {self._pvc.metadata.name} for job {self.id}')
+        log.info(f'created pvc name: {pvc.metadata.name} for job {self.id}')
         return pvc
 
     def _create_pod(self):

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -355,8 +355,7 @@ class Job:
             if self._has_next_task():
                 self._create_pod()
                 return
-            else:
-                self._delete_pvc()
+            self._delete_pvc()
         else:
             self._delete_pvc()
 

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -58,13 +58,16 @@ def make_logger():
 log = make_logger()
 
 KUBERNETES_TIMEOUT_IN_SECONDS = float(os.environ.get('KUBERNETES_TIMEOUT_IN_SECONDS', 5.0))
-
 REFRESH_INTERVAL_IN_SECONDS = int(os.environ.get('REFRESH_INTERVAL_IN_SECONDS', 5 * 60))
-
 POD_NAMESPACE = os.environ.get('POD_NAMESPACE', 'batch-pods')
+POD_VOLUME_SIZE = os.environ.get('POD_VOLUME_SIZE', '10Mi')
 
 log.info(f'KUBERNETES_TIMEOUT_IN_SECONDS {KUBERNETES_TIMEOUT_IN_SECONDS}')
 log.info(f'REFRESH_INTERVAL_IN_SECONDS {REFRESH_INTERVAL_IN_SECONDS}')
+log.info(f'POD_NAMESPACE {POD_NAMESPACE}')
+log.info(f'POD_VOLUME_SIZE {POD_VOLUME_SIZE}')
+
+STORAGE_CLASS_NAME = 'batch'
 
 if 'BATCH_USE_KUBE_CONFIG' in os.environ:
     kube.config.load_kube_config()
@@ -110,13 +113,51 @@ class Job:
         self._task_idx += 1
         if self._task_idx < len(self._tasks):
             self._current_task = self._tasks[self._task_idx]
+        else:
+            self._delete_pvc()
 
     def _has_next_task(self):
         return self._task_idx < len(self._tasks)
 
+    def pvc(self):
+        if self._pvc is None:
+            self._pvc = v1.create_namespaced_persistent_volume_claim(
+                POD_NAMESPACE,
+                kube.client.V1PersistentVolumeClaim(
+                    metadata=kube.client.V1ObjectMeta(
+                        generate_name=f'job-{self.id}-',
+                        labels={'app': 'batch-job',
+                                'hail.is/batch-instance': instance_id}),
+                    spec=kube.client.V1PersistentVolumeClaimSpec(
+                        access_modes=['ReadWriteOnce'],
+                        volume_mode='Filesystem',
+                        resources=kube.client.V1ResourceRequirements(
+                            requests={'storage': POD_VOLUME_SIZE}),
+                        storage_class_name=STORAGE_CLASS_NAME)),
+                _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS)
+            log.info(f'created pvc name: {self._pvc.metadata.name} for job {self.id}')
+        return self._pvc
+
     def _create_pod(self):
         assert not self._pod_name
         assert self._current_task is not None
+
+        if len(self._tasks) > 1:
+            current_pod_spec = self._current_task.pod_template.spec
+            if current_pod_spec.volumes is None:
+                current_pod_spec.volumes = []
+            current_pod_spec.volumes.append(
+                kube.client.V1Volume(
+                    persistent_volume_claim=kube.client.V1PersistentVolumeClaimVolumeSource(
+                        claim_name=self.pvc().metadata.name),
+                    name=self.pvc().metadata.name))
+            for container in current_pod_spec.containers:
+                if container.volume_mounts is None:
+                    container.volume_mounts = []
+                container.volume_mounts.append(
+                    kube.client.V1VolumeMount(
+                        mount_path='/volume',
+                        name=self.pvc().metadata.name))
 
         pod = v1.create_namespaced_pod(
             POD_NAMESPACE,
@@ -132,8 +173,25 @@ class Job:
                                                                    self.id,
                                                                    self._current_task.name))
 
-    def _delete_pod(self):
-        if self._pod_name:
+    def _delete_pvc(self):
+        if self._pvc is not None:
+            try:
+                v1.delete_namespaced_persistent_volume_claim(
+                    self._pvc.metadata.name,
+                    POD_NAMESPACE,
+                    kube.client.V1DeleteOptions(),
+                    _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS)
+            except kube.client.rest.ApiException as err:
+                if err.status == 404:
+                    log.info(f'persistent volume claim {self._pvc.metadata.name} in '
+                             f'{self._pvc.metadata.namespace} is already deleted')
+                else:
+                    log.warning(f'persistent volume claim {self._pvc.metadata.name} in '
+                                f'{self._pvc.metadata.namespace} could not be deleted')
+
+    def _delete_k8s_resources(self):
+        self._delete_pvc()
+        if self._pod_name is not None:
             try:
                 v1.delete_namespaced_pod(
                     self._pod_name,
@@ -178,6 +236,7 @@ class Job:
         self.incomplete_parent_ids = set(self.parent_ids)
         self.scratch_folder = scratch_folder
 
+        self._pvc = None
         self._pod_name = None
         self.exit_code = None
         self._state = 'Created'
@@ -251,7 +310,7 @@ class Job:
     def cancel(self):
         if self.is_complete():
             return
-        self._delete_pod()
+        self._delete_k8s_resources()
         self.set_state('Cancelled')
 
     def delete(self):
@@ -261,7 +320,7 @@ class Job:
             batch = batch_id_batch[self.batch_id]
             batch.remove(self)
 
-        self._delete_pod()
+        self._delete_k8s_resources()
         self.set_state('Cancelled')
 
     def is_complete(self):

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -354,9 +354,12 @@ class Job:
             self._pod_name = None
 
         self._next_task()
-        if self.exit_code == 0 and self._has_next_task():
-            self._create_pod()
-            return
+        if self.exit_code == 0:
+            if self._has_next_task():
+                self._create_pod()
+                return
+        else:
+            self._delete_pvc()
 
         self.set_state('Complete')
 

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -255,10 +255,10 @@ def test_callback(client):
         batch.wait()
         i = 0
         while len(output) != 4:
-            j = random.randrange(2 ** i)
-            time.sleep(0.100 * j)
-            if i < 9:
-                i = i + 1
+            time.sleep(0.100 * (3/2) ** i)
+            i = i + 1
+            if i > 14:
+                break
         assert len(output) == 4
         assert all([job_result['state'] == 'Complete' and job_result['exit_code'] == 0
                     for job_result in output])

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -1,5 +1,4 @@
 import os
-import random
 import time
 import pkg_resources
 import pytest

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -1,4 +1,6 @@
 import os
+import random
+import time
 import pkg_resources
 import pytest
 import re
@@ -251,6 +253,12 @@ def test_callback(client):
         right = batch.create_job('alpine:3.8', command=['echo', 'right'], parent_ids=[head.id])
         tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parent_ids=[left.id, right.id])
         batch.wait()
+        i = 0
+        while len(output) != 4:
+            j = random.randrange(2 ** i)
+            time.sleep(0.100 * j)
+            if i < 9:
+                i = i + 1
         assert len(output) == 4
         assert all([job_result['state'] == 'Complete' and job_result['exit_code'] == 0
                     for job_result in output])

--- a/vdc/k8s-config.yaml
+++ b/vdc/k8s-config.yaml
@@ -323,3 +323,23 @@ roleRef:
   kind: Role
   name: delete-batch-pods-pvc
   apiGroup: "rbac.authorization.k8s.io"
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: batch
+  namespace: batch-pods
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-standard
+  replication-type: none
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: batch
+  namespace: test
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-standard
+  replication-type: none

--- a/vdc/k8s-config.yaml
+++ b/vdc/k8s-config.yaml
@@ -144,6 +144,9 @@ rules:
 - apiGroups: [""]
   resources: ["services"]
   verbs: ["*"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["*"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/vdc/k8s-config.yaml
+++ b/vdc/k8s-config.yaml
@@ -334,6 +334,16 @@ parameters:
   type: pd-standard
   replication-type: none
 ---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: batch-storage-class-quota
+  namespace: batch-pods
+spec:
+  hard:
+    batch.storageclass.storage.k8s.io/requests.storage: 100Gi
+    batch.storageclass.storage.k8s.io/persistentvolumeclaims: 100
+---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
@@ -343,3 +353,13 @@ provisioner: kubernetes.io/gce-pd
 parameters:
   type: pd-standard
   replication-type: none
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: batch-storage-class-quota
+  namespace: test
+spec:
+  hard:
+    batch.storageclass.storage.k8s.io/requests.storage: 100Gi
+    batch.storageclass.storage.k8s.io/persistentvolumeclaims: 100


### PR DESCRIPTION
Add volumes to `batch`, which are mounted by each pod, but are not written to or read from.

Key Changes
---
- Introduce a k8s [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) and associated [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/#storage-resource-quota) which creates and destroys disks for use by k8s pods whenever a PersistentVolumeClaim is created or delete, respectively. 1GB of disk [costs 0.04 USD per month](https://cloud.google.com/compute/pricing#disk), so I feel pretty fine with a 100GB limit for each, limiting our total possible monthly cost to 8 USD per month.

- If there is more than one task (ergo there is a need for a shared disk), then we create a PVC and mount it to `/volume`. We delete this PVC if 1) all tasks complete, 2) a task fails, or 3) the job is cancelled or deleted. We may want to copy data off this volume for debugging purposes. We leave such changes for future PRs.

Minor Changes
---
- decreased the exponential backoff parameter from 2 to 1.5, which in practice ~halves test time when waiting on a volume
- print POD_NAMESPACE on startup
