### PR TITLE
tune ImportVCFs

### DIFF
--- a/hail/src/main/scala/is/hail/io/tabix/TabixReader.scala
+++ b/hail/src/main/scala/is/hail/io/tabix/TabixReader.scala
@@ -1,38 +1,33 @@
 package is.hail.io.tabix
 
-import is.hail.HailContext
 import is.hail.io.compress.BGzipInputStream
 import is.hail.utils._
 
 import htsjdk.tribble.util.{ParsingUtils, TabixUtils}
 import org.apache.{hadoop => hd}
-import org.apache.hadoop.io.compress.SplitCompressionInputStream
-import org.apache.spark.SparkContext
 import org.apache.spark.broadcast.Broadcast
 
 import java.io.InputStream
-import java.nio.{ByteBuffer, ByteOrder}
 import java.nio.charset.StandardCharsets
-import java.util.Arrays
 
-import scala.collection.mutable.HashMap
+import scala.collection.mutable
 import scala.language.implicitConversions
 
 // Helper data classes
 
-case class Tabix(
+class Tabix(
   val format: Int,
   val colSeq: Int,
   val colBeg: Int,
   val meta: Int,
   val seqs: Array[String],
-  val chr2tid: HashMap[String, Int],
-  val indices: Array[(HashMap[Int, Array[TbiPair]], Array[Long])]
+  val chr2tid: mutable.HashMap[String, Int],
+  val indices: Array[(mutable.HashMap[Int, Array[TbiPair]], Array[Long])]
 )
 
 case class TbiPair(var _1: Long, var _2: Long) extends java.lang.Comparable[TbiPair] {
   @Override
-  def compareTo(other: TbiPair) = TbiOrd.compare(this, other)
+  def compareTo(other: TbiPair): Int = TbiOrd.compare(this, other)
 }
 
 object TbiPair {
@@ -40,7 +35,7 @@ object TbiPair {
 }
 
 object TbiOrd extends Ordering[TbiPair] {
-  def compare(u: TbiPair, v: TbiPair) = if (u._1 == v._1) {
+  def compare(u: TbiPair, v: TbiPair): Int = if (u._1 == v._1) {
     0
   } else if (less64(u._1, v._1)) {
     -1
@@ -48,7 +43,7 @@ object TbiOrd extends Ordering[TbiPair] {
     1
   }
 
-  def less64(u: Long, v: Long) = (u < v) ^ (u < 0) ^ (v < 0)
+  def less64(u: Long, v: Long): Boolean = (u < v) ^ (u < 0) ^ (v < 0)
 }
 
 // Tabix reader
@@ -95,17 +90,16 @@ object TabixReader {
 
 }
 
-class TabixReader(val filePath: String, private val hConf: hd.conf.Configuration, private val idxFilePath: Option[String] = None) {
+class TabixReader(val filePath: String, hConf: hd.conf.Configuration, idxFilePath: Option[String] = None) {
   import TabixReader._
 
   val indexPath: String = idxFilePath match {
     case None => ParsingUtils.appendToPath(filePath, TabixUtils.STANDARD_INDEX_EXTENSION)
-    case Some(s) => {
+    case Some(s) =>
       if (s.endsWith(TabixUtils.STANDARD_INDEX_EXTENSION))
         s
       else
-        fatal(s"unknown file extension for tabix index: ${s}")
-    }
+        fatal(s"unknown file extension for tabix index: $s")
   }
 
   val index: Tabix = hConf.readFile(indexPath) { is =>
@@ -124,7 +118,7 @@ class TabixReader(val filePath: String, private val hConf: hd.conf.Configuration
     val meta = readInt(is)
     // meta char for VCF is '#'
     assert(meta == '#', s"Meta character was ${ meta }, should be '#' for VCF")
-    val chr2tid = new HashMap[String, Int]()
+    val chr2tid = new mutable.HashMap[String, Int]()
     readInt(is) // unused, need to consume
 
     // read the sequence dictionary
@@ -143,15 +137,15 @@ class TabixReader(val filePath: String, private val hConf: hd.conf.Configuration
     }
 
     // read the index
-    val indices = new ArrayBuilder[(HashMap[Int, Array[TbiPair]], Array[Long])](seqs.length)
+    val indices = new ArrayBuilder[(mutable.HashMap[Int, Array[TbiPair]], Array[Long])](seqs.length)
     i = 0
     while (i < seqs.length) {
       // binning index
-      val nBin = readInt(is);
-      val binIdx = new HashMap[Int, Array[TbiPair]]()
+      val nBin = readInt(is)
+      val binIdx = new mutable.HashMap[Int, Array[TbiPair]]()
       j = 0
       while (j < nBin) {
-        val bin = readInt(is);
+        val bin = readInt(is)
         val chunks = new Array[TbiPair](readInt(is))
         k = 0
         while (k < chunks.length) {
@@ -172,7 +166,7 @@ class TabixReader(val filePath: String, private val hConf: hd.conf.Configuration
       i += 1
     }
     is.close()
-    Tabix(format, colSeq, colBeg, meta, seqs, chr2tid, indices.result())
+    new Tabix(format, colSeq, colBeg, meta, seqs, chr2tid, indices.result())
   }
 
   def chr2tid(chr: String): Int = index.chr2tid.get(chr) match {
@@ -206,7 +200,7 @@ class TabixReader(val filePath: String, private val hConf: hd.conf.Configuration
       if (nOff == 0)
         new Array[TbiPair](0)
       else {
-        var off = new Array[TbiPair](nOff)
+        val off = new Array[TbiPair](nOff)
         nOff = 0
         i = 0
         while (i < bins.length) {
@@ -222,7 +216,7 @@ class TabixReader(val filePath: String, private val hConf: hd.conf.Configuration
           }
           i += 1
         }
-        Arrays.sort(off, 0, nOff, null)
+        java.util.Arrays.sort(off, 0, nOff, null)
         // resolve contained adjacent blocks
         var l = 0
         i = 1
@@ -330,21 +324,21 @@ class TabixLineIterator(
     var s: String = null
     while (s == null && !isEof) {
       if (curOff == 0 || !TbiOrd.less64(curOff, offsets(i)._2)) { // jump to next chunk
-        if (i == offsets.size - 1) {
+        if (i == offsets.length - 1) {
           isEof = true
           return s
         }
         if (i >= 0) assert(curOff == offsets(i)._2)
         if (i < 0 || offsets(i)._2 != offsets(i + 1)._1) {
           is.virtualSeek(offsets(i + 1)._1)
-          curOff = is.getVirtualOffset()
+          curOff = is.getVirtualOffset
         }
         i += 1
       }
       s = TabixReader.readLine(is)
       if (s != null) {
-        curOff = is.getVirtualOffset()
-        if (s.isEmpty() || s.charAt(0) == '#')
+        curOff = is.getVirtualOffset
+        if (s.isEmpty || s.charAt(0) == '#')
           s = null // continue
       } else
         isEof = true
@@ -352,8 +346,10 @@ class TabixLineIterator(
     s
   }
 
-  override def close() = if (is != null) {
-    is.close()
-    is = null
+  override def close() {
+    if (is != null) {
+      is.close()
+      is = null
+    }
   }
 }


### PR DESCRIPTION
There was some real bad capture/broadcast issues in VCFsReader.  I made the following changes:

 - import_vcfs requires the signature of all files to be the same,
 - compute the type once from the first file,
 - verify the types agree when parallelizing over files computing the partitions,
 - always broadcast the header lines (which can be large)

This reduced the DAGScheduler RDD broadcast by about 4x (6MB => 1.4MB) on a simple 10-input pipeline of import_vcfs/transform_one/combine/write_multi.
