### PR TITLE
Tune write rows split files

### DIFF
--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -1588,161 +1588,8 @@ object RichContextRDDRegionValue {
 
     rowCount
   }
-}
 
-class RichContextRDDRegionValue(val crdd: ContextRDD[RVDContext, RegionValue]) extends AnyVal {
-  def boundary: ContextRDD[RVDContext, RegionValue] =
-    crdd.cmapPartitionsAndContext { (consumerCtx, part) =>
-      val producerCtx = consumerCtx.freshContext
-      val it = part.flatMap(_ (producerCtx))
-      new Iterator[RegionValue]() {
-        private[this] var cleared: Boolean = false
-
-        def hasNext: Boolean = {
-          if (!cleared) {
-            cleared = true
-            producerCtx.region.clear()
-          }
-          it.hasNext
-        }
-
-        def next: RegionValue = {
-          if (!cleared) {
-            producerCtx.region.clear()
-          }
-          cleared = false
-          it.next
-        }
-      }
-    }
-
-  def writeRows(path: String, t: PStruct, stageLocally: Boolean, codecSpec: CodecSpec): (Array[String], Array[Long]) = {
-    crdd.writePartitions(path, stageLocally, RichContextRDDRegionValue.writeRowsPartition(codecSpec.buildEncoder(t)))
-  }
-
-  def writeRowsSplitFiles(
-    path: String,
-    t: RVDType,
-    codecSpec: CodecSpec,
-    partitioners: IndexedSeq[RVDPartitioner],
-    stageLocally: Boolean
-  ): Array[Array[Long]] = {
-    val sc = crdd.sparkContext
-    val hConf = sc.hadoopConfiguration
-    val rdd = crdd.rdd.asInstanceOf[OriginUnionRDD[RegionValue]]
-    require(partitioners.length == rdd.rdds.length)
-
-    val partitions = rdd.partitions
-    val partDigits = digitsNeeded(rdd.getNumPartitions)
-    val fileDigits = digitsNeeded(partitioners.length)
-    for (i <- 0 until partitioners.length) {
-      val s = StringUtils.leftPad(i.toString, fileDigits, '0')
-      hConf.mkDir(path + s + ".mt" + "/rows/rows/parts")
-      hConf.mkDir(path + s + ".mt" + "/entries/rows/parts")
-    }
-
-    val sHConfBc = HailContext.hadoopConfBc
-
-    val fullRowType = t.rowType
-    val rowsRVType = MatrixType.getRowType(fullRowType)
-    val entriesRVType = MatrixType.getSplitEntriesType(fullRowType)
-
-    val makeRowsEnc = codecSpec.buildEncoder(rowsRVType)
-
-    val makeEntriesEnc = codecSpec.buildEncoder(entriesRVType)
-    val partFilePartitionCounts = crdd.cmapPartitionsWithIndex { (i, ctx, it) =>
-      val hConf = sHConfBc.value.value
-      val originIdx = partitions(i).asInstanceOf[OriginUnionPartition[_]].originIdx
-      val s = StringUtils.leftPad(originIdx.toString, fileDigits, '0')
-      val fullPath = path + s + ".mt"
-      val (f, rowCount) = writeSplitRegion(
-        hConf,
-        fullPath,
-        t,
-        it,
-        i,
-        ctx,
-        partDigits,
-        stageLocally,
-        makeRowsEnc,
-        makeEntriesEnc)
-      Iterator.single((f, rowCount, originIdx))
-    }.collect()
-    val partFilesByOrigin = Array.fill[ArrayBuilder[String]](rdd.rdds.length)(new ArrayBuilder())
-    val partitionCountsByOrigin = Array.fill[ArrayBuilder[Long]](rdd.rdds.length)(new ArrayBuilder())
-
-    for ((f, rowCount, oidx) <- partFilePartitionCounts) {
-      partFilesByOrigin(oidx) += f
-      partitionCountsByOrigin(oidx) += rowCount
-    }
-
-    val partFiles = partFilesByOrigin.map(_.result())
-    val partCounts = partitionCountsByOrigin.map(_.result())
-
-    sc.parallelize(
-      partFiles.zip(partitioners).zip(partCounts.map(_.length)).zipWithIndex,
-      partitioners.length
-    ).foreach { tup =>
-      val (((partFiles, partitioner), partLen), i) = tup
-      val hConf = sHConfBc.value.value
-      val s = StringUtils.leftPad(i.toString, fileDigits, '0')
-      val basePath = path + s + ".mt"
-      writeSplitSpecs(hConf, basePath, codecSpec, t.key, rowsRVType, entriesRVType, partFiles, partitioner, partLen)
-    }
-    partCounts
-  }
-
-  def writeRowsSplit(
-    path: String,
-    t: RVDType,
-    codecSpec: CodecSpec,
-    partitioner: RVDPartitioner,
-    stageLocally: Boolean
-  ): Array[Long] = {
-    val sc = crdd.sparkContext
-    val hConf = sc.hadoopConfiguration
-
-    hConf.mkDir(path + "/rows/rows/parts")
-    hConf.mkDir(path + "/entries/rows/parts")
-
-    val sHConfBc = HailContext.hadoopConfBc
-
-    val nPartitions = crdd.getNumPartitions
-    val d = digitsNeeded(nPartitions)
-
-    val fullRowType = t.rowType
-    val rowsRVType = MatrixType.getRowType(fullRowType)
-    val entriesRVType = MatrixType.getSplitEntriesType(fullRowType)
-
-    val makeRowsEnc = codecSpec.buildEncoder(rowsRVType)
-
-    val makeEntriesEnc = codecSpec.buildEncoder(entriesRVType)
-
-    val partFilePartitionCounts = crdd.cmapPartitionsWithIndex { (i, ctx, it) =>
-      val hConf = sHConfBc.value.value
-      val partFileAndCount = writeSplitRegion(
-        hConf,
-        path,
-        t,
-        it,
-        i,
-        ctx,
-        d,
-        stageLocally,
-        makeRowsEnc,
-        makeEntriesEnc)
-
-      Iterator.single(partFileAndCount)
-    }.collect()
-
-    val (partFiles, partitionCounts) = partFilePartitionCounts.unzip
-
-    writeSplitSpecs(hConf, path, codecSpec, t.key, rowsRVType, entriesRVType, partFiles, partitioner, partitionCounts.length)
-
-    partitionCounts
-  }
-
-  private def writeSplitRegion(
+  def writeSplitRegion(
     hConf: HadoopConf,
     path: String,
     t: RVDType,
@@ -1768,12 +1615,12 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RVDContext, RegionValue]) e
     val (rowsPartPath, entriesPartPath) =
       if (stageLocally) {
         val rowsPartPath = hConf.getTemporaryFile("file:///tmp")
-          val entriesPartPath = hConf.getTemporaryFile("file:///tmp")
-            context.addTaskCompletionListener { context =>
-              hConf.delete(rowsPartPath, recursive = false)
-              hConf.delete(entriesPartPath, recursive = false)
-            }
-            (rowsPartPath, entriesPartPath)
+        val entriesPartPath = hConf.getTemporaryFile("file:///tmp")
+        context.addTaskCompletionListener { context =>
+          hConf.delete(rowsPartPath, recursive = false)
+          hConf.delete(entriesPartPath, recursive = false)
+        }
+        (rowsPartPath, entriesPartPath)
       } else
         (finalRowsPartPath, finalEntriesPartPath)
 
@@ -1845,17 +1692,95 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RVDContext, RegionValue]) e
     rowsRVType: PStruct,
     entriesRVType: PStruct,
     partFiles: Array[String],
-    partitioner: RVDPartitioner,
-    nPartitions: Int
-  ) = {
+    partitioner: RVDPartitioner
+  ) {
     val rowsSpec = OrderedRVDSpec(rowsRVType, key, codecSpec, partFiles, partitioner)
     rowsSpec.write(hConf, path + "/rows/rows")
 
-    val entriesSpec = OrderedRVDSpec(entriesRVType, FastIndexedSeq(), codecSpec, partFiles, RVDPartitioner.unkeyed(nPartitions))
+    val entriesSpec = OrderedRVDSpec(entriesRVType, FastIndexedSeq(), codecSpec, partFiles, RVDPartitioner.unkeyed(partitioner.numPartitions))
     entriesSpec.write(hConf, path + "/entries/rows")
   }
+}
 
+class RichContextRDDRegionValue(val crdd: ContextRDD[RVDContext, RegionValue]) extends AnyVal {
+  def boundary: ContextRDD[RVDContext, RegionValue] =
+    crdd.cmapPartitionsAndContext { (consumerCtx, part) =>
+      val producerCtx = consumerCtx.freshContext
+      val it = part.flatMap(_ (producerCtx))
+      new Iterator[RegionValue]() {
+        private[this] var cleared: Boolean = false
 
+        def hasNext: Boolean = {
+          if (!cleared) {
+            cleared = true
+            producerCtx.region.clear()
+          }
+          it.hasNext
+        }
+
+        def next: RegionValue = {
+          if (!cleared) {
+            producerCtx.region.clear()
+          }
+          cleared = false
+          it.next
+        }
+      }
+    }
+
+  def writeRows(path: String, t: PStruct, stageLocally: Boolean, codecSpec: CodecSpec): (Array[String], Array[Long]) = {
+    crdd.writePartitions(path, stageLocally, RichContextRDDRegionValue.writeRowsPartition(codecSpec.buildEncoder(t)))
+  }
+
+  def writeRowsSplit(
+    path: String,
+    t: RVDType,
+    codecSpec: CodecSpec,
+    partitioner: RVDPartitioner,
+    stageLocally: Boolean
+  ): Array[Long] = {
+    val sc = crdd.sparkContext
+    val hConf = sc.hadoopConfiguration
+
+    hConf.mkDir(path + "/rows/rows/parts")
+    hConf.mkDir(path + "/entries/rows/parts")
+
+    val sHConfBc = HailContext.hadoopConfBc
+
+    val nPartitions = crdd.getNumPartitions
+    val d = digitsNeeded(nPartitions)
+
+    val fullRowType = t.rowType
+    val rowsRVType = MatrixType.getRowType(fullRowType)
+    val entriesRVType = MatrixType.getSplitEntriesType(fullRowType)
+
+    val makeRowsEnc = codecSpec.buildEncoder(rowsRVType)
+
+    val makeEntriesEnc = codecSpec.buildEncoder(entriesRVType)
+
+    val partFilePartitionCounts = crdd.cmapPartitionsWithIndex { (i, ctx, it) =>
+      val hConf = sHConfBc.value.value
+      val partFileAndCount = RichContextRDDRegionValue.writeSplitRegion(
+        hConf,
+        path,
+        t,
+        it,
+        i,
+        ctx,
+        d,
+        stageLocally,
+        makeRowsEnc,
+        makeEntriesEnc)
+
+      Iterator.single(partFileAndCount)
+    }.collect()
+
+    val (partFiles, partitionCounts) = partFilePartitionCounts.unzip
+
+    RichContextRDDRegionValue.writeSplitSpecs(hConf, path, codecSpec, t.key, rowsRVType, entriesRVType, partFiles, partitioner)
+
+    partitionCounts
+  }
 
   def toRows(rowType: PStruct): RDD[Row] = {
     crdd.run.map(rv => SafeRow(rowType, rv.region, rv.offset))

--- a/hail/src/main/scala/is/hail/sparkextras/OriginUnionRDD.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/OriginUnionRDD.scala
@@ -6,22 +6,22 @@ import org.apache.spark.rdd.RDD
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 
-private[hail] case class OriginUnionPartition[T: ClassTag](
+private[hail] class OriginUnionPartition(
   val index: Int,
   val originIdx: Int,
   val originPart: Partition
-) extends Partition {
-}
+) extends Partition
 
-class OriginUnionRDD[T: ClassTag](
+class OriginUnionRDD[T: ClassTag, S: ClassTag](
   sc: SparkContext,
-  var rdds: IndexedSeq[RDD[T]]
-) extends RDD[T](sc, Nil) {
+  var rdds: IndexedSeq[RDD[T]],
+  f: (Int, Int, Iterator[T]) => Iterator[S]
+) extends RDD[S](sc, Nil) {
   override def getPartitions: Array[Partition] = {
     val arr = new Array[Partition](rdds.map(_.partitions.length).sum)
     var i = 0
     for ((rdd, rddIdx) <- rdds.zipWithIndex; part <- rdd.partitions) {
-      arr(i) = OriginUnionPartition(i, rddIdx, part)
+      arr(i) = new OriginUnionPartition(i, rddIdx, part)
       i += 1
     }
     arr
@@ -37,9 +37,9 @@ class OriginUnionRDD[T: ClassTag](
     deps
   }
 
-  override def compute(s: Partition, tc: TaskContext) = {
-    val p = s.asInstanceOf[OriginUnionPartition[T]]
-    parent[T](p.originIdx).iterator(p.originPart, tc)
+  override def compute(s: Partition, tc: TaskContext): Iterator[S] = {
+    val p = s.asInstanceOf[OriginUnionPartition]
+    f(p.originIdx, p.originPart.index, parent[T](p.originIdx).iterator(p.originPart, tc))
   }
 
   override def clearDependencies() {

--- a/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
@@ -298,7 +298,8 @@ class MatrixIRSuite extends SparkSuite {
   }
 
   @Test def testMatrixMultiWrite() {
-    val ranges = IndexedSeq(MatrixTable.range(hc, 15, 3, Some(10)), MatrixTable.range(hc, 8, 27, Some(1)))
+    // partitioning must be the same
+    val ranges = IndexedSeq(MatrixTable.range(hc, 15, 3, Some(10)), MatrixTable.range(hc, 15, 27, Some(10)))
     val path = tmpDir.createLocalTempFile()
     Interpret(MatrixMultiWrite(ranges.map(_.ast), MatrixNativeMultiWriter(path)))
     val read0 = MatrixTable.read(hc, path + "0.mt")


### PR DESCRIPTION
Stacked on: https://github.com/hail-is/hail/pull/5507

Drops one broadcast from my test dataset from 1.4MB => 300KB (5x).  I think that corresponds to the parallelize for writeSplitSpecs, which is now constant (won't scale according to the number of inputs).  The RDD actually doing the writing, the OriginUnionRDD, still scales linearly.  I think that's inevitable unless we do the LightweightContextRVDDistributedArray thing I mentioned on Zulip since we necessarily allocate at least one RDD per input.  It might still be possible to push the constants down.

The point of this change is to avoid capturing the OriginUnionRDD partitions inside the map step.  I did this essentially by turning OriginUnionRDD into a union with "mapPartitionsWithOriginIndex".

I think it might be wroth trying to re-run it after this goes in.  Between this one and the last one, there are some pretty big memory/broadcast savings here.
