### PR TITLE
add test for exporting sparse matrix

### DIFF
--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1692,7 +1692,7 @@ class BlockMatrix(object):
         ...                [ 5.0,  6.0,  7.0,  8.0],
         ...                [ 9.0, 10.0, 11.0, 12.0],
         ...                [13.0, 14.0, 15.0, 16.0]])
-        >>> bm = BlockMatrix.from_numpy(nd)
+        >>> bm = BlockMatrix.from_numpy(nd, block_size=2)
 
         Filter to blocks covering three rectangles and collect to NumPy:
 

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -25,6 +25,13 @@ class Tests(unittest.TestCase):
     def _assert_close(self, a, b):
         self.assertTrue(np.allclose(self._np_matrix(a), self._np_matrix(b)))
 
+    def _assert_rectangles_eq(self, expected, rect_path, export_rects):
+        for (i, r) in enumerate(export_rects):
+            file = rect_path + '/rect-' + str(i) + '_' + '-'.join(map(str, r))
+            expected_rect = expected[r[0]:r[1], r[2]:r[3]]
+            actual_rect = np.loadtxt(file, ndmin = 2)
+            self._assert_eq(expected_rect, actual_rect)
+
     @skip_unless_spark_backend()
     def test_from_entry_expr(self):
         mt = get_dataset()
@@ -633,22 +640,13 @@ class Tests(unittest.TestCase):
                 bm = BlockMatrix.from_numpy(nd, block_size=block_size)
                 bm.export_rectangles(rect_uri, rects)
 
-                for (i, r) in enumerate(rects):
-                    file = rect_path + '/rect-' + str(i) + '_' + '-'.join(map(str, r))
-                    expected = nd[r[0]:r[1], r[2]:r[3]]
-                    actual = np.loadtxt(file, ndmin = 2)
-                    self._assert_eq(expected, actual)
+                self._assert_rectangles_eq(nd, rect_path, rects)
 
                 rect_path_bytes = new_local_temp_dir()
                 rect_uri_bytes = local_path_uri(rect_path_bytes)
 
                 bm.export_rectangles(rect_uri_bytes, rects, binary=True)
-
-                for (i, r) in enumerate(rects):
-                    file = rect_path_bytes + '/rect-' + str(i) + '_' + '-'.join(map(str, r))
-                    expected = nd[r[0]:r[1], r[2]:r[3]]
-                    actual = np.reshape(np.fromfile(file), (r[1] - r[0], r[3] - r[2]))
-                    self._assert_eq(expected, actual)
+                self._assert_rectangles_eq(nd, rect_path_bytes, rects)
 
     @skip_unless_spark_backend()
     def test_export_rectangles_sparse(self):
@@ -667,12 +665,27 @@ class Tests(unittest.TestCase):
                              [5.0, 6.0, 7.0, 8.0],
                              [9.0, 10.0, 0.0, 0.0],
                              [13.0, 14.0, 0.0, 0.0]])
-        for (i, r) in enumerate(export_rects):
-            file = rect_path + '/rect-' + str(i) + '_' + '-'.join(map(str, r))
-            expected_rect = expected[r[0]:r[1], r[2]:r[3]]
-            actual_rect = np.loadtxt(file, ndmin = 2)
-            self._assert_eq(expected_rect, actual_rect)
- 
+
+        self._assert_rectangles_eq(expected, rect_path, export_rects)
+
+    @skip_unless_spark_backend()
+    def test_export_rectangles_filtered(self):
+        rect_path = new_local_temp_dir()
+        rect_uri = local_path_uri(rect_path)
+        nd = np.array([[1.0, 2.0, 3.0, 4.0],
+                       [5.0, 6.0, 7.0, 8.0],
+                       [9.0, 10.0, 11.0, 12.0],
+                       [13.0, 14.0, 15.0, 16.0]])
+        bm = BlockMatrix.from_numpy(nd)
+        bm = bm[1:2, 1:2]
+        export_rects = [[0, 1, 0, 2], [1, 2, 0, 2]]
+        bm.export_rectangles(rect_uri, export_rects)
+
+        expected = np.array([[6.0, 7.0],
+                             [10.0, 11.0]])
+
+        self._assert_rectangles_eq(expected, rect_path, export_rects)
+
     @skip_unless_spark_backend()
     def test_block_matrix_entries(self):
         n_rows, n_cols = 5, 3

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -25,11 +25,11 @@ class Tests(unittest.TestCase):
     def _assert_close(self, a, b):
         self.assertTrue(np.allclose(self._np_matrix(a), self._np_matrix(b)))
 
-    def _assert_rectangles_eq(self, expected, rect_path, export_rects):
+    def _assert_rectangles_eq(self, expected, rect_path, export_rects, binary=False):
         for (i, r) in enumerate(export_rects):
             file = rect_path + '/rect-' + str(i) + '_' + '-'.join(map(str, r))
             expected_rect = expected[r[0]:r[1], r[2]:r[3]]
-            actual_rect = np.loadtxt(file, ndmin = 2)
+            actual_rect = np.reshape(np.fromfile(file), (r[1] - r[0], r[3] - r[2])) if binary else np.loadtxt(file, ndmin=2)
             self._assert_eq(expected_rect, actual_rect)
 
     @skip_unless_spark_backend()
@@ -646,7 +646,7 @@ class Tests(unittest.TestCase):
                 rect_uri_bytes = local_path_uri(rect_path_bytes)
 
                 bm.export_rectangles(rect_uri_bytes, rects, binary=True)
-                self._assert_rectangles_eq(nd, rect_path_bytes, rects)
+                self._assert_rectangles_eq(nd, rect_path_bytes, rects, binary=True)
 
     @skip_unless_spark_backend()
     def test_export_rectangles_sparse(self):
@@ -677,7 +677,7 @@ class Tests(unittest.TestCase):
                        [9.0, 10.0, 11.0, 12.0],
                        [13.0, 14.0, 15.0, 16.0]])
         bm = BlockMatrix.from_numpy(nd)
-        bm = bm[1:2, 1:2]
+        bm = bm[1:3, 1:3]
         export_rects = [[0, 1, 0, 2], [1, 2, 0, 2]]
         bm.export_rectangles(rect_uri, export_rects)
 


### PR DESCRIPTION
Updated incorrect doc and added test to verify that if you try to export a sparse block it writes a file of zeros. resolves #5500