### PR TITLE
Blockmatrix export blocks

### DIFF
--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1115,7 +1115,8 @@ class BlockMatrix(object):
 
         Notes
         -----
-        The number of entries must be less than :math:`2^{31}`.
+        The number of entries must be less than :math:`2^{31}`. If the number of entries is
+        larger than this, consider using :meth:`.export_blocks` and :meth:`.rectangles_to_numpy`.
 
         The resulting ndarray will have the same shape as the block matrix.
 

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1867,9 +1867,9 @@ class BlockMatrix(object):
         Consider the following block matrix:
 
         >>> import numpy as np
-        >>> nd = np.array([[ 1.0,  2.0,  3.0],
-        ...                [ 5.0,  6.0,  7.0],
-        ...                [ 9.0, 10.0, 11.0]])
+        >>> nd = np.array([[ 1.0, 2.0, 3.0],
+        ...                [ 4.0, 5.0, 6.0],
+        ...                [ 7.0, 8.0, 9.0]])
 
         >>> BlockMatrix.from_numpy(nd, block_size=2).export_blocks('output/example')
 
@@ -1880,26 +1880,26 @@ class BlockMatrix(object):
         .. code-block:: text
 
             1.0 2.0
-            5.0 6.0
+            4.0 5.0
 
         The second file is ``rect-1_0-2-2-3``:
 
         .. code-block:: text
 
             3.0
-            7.0
+            6.0
 
         The third file is ``rect-2_2-3-0-2``:
 
         .. code-block:: text
 
-            9.0 10.0
+            7.0 8.0
 
         And the fourth file is ``rect-3_3-4-3-4``:
 
         .. code-block:: text
 
-            11.0
+            9.0
 
         Notes
         -----
@@ -1947,10 +1947,29 @@ class BlockMatrix(object):
     @typecheck(path=str)
     def rectangles_to_numpy(path):
         """Instantiates a NumPy ndarray from files of rectangles written out using
-        :meth:`.export_rectangles` or :meth:`.export_blocks`, with `binary=True`. The
-        resulting ndarray will have number of rows equal to the largest row covered by
-        any of the given rectangles, and likewise with the columns. Entries not covered
-        by any rectangle will be initialized as 0.
+        :meth:`.export_rectangles` or :meth:`.export_blocks`, with `binary=True`. For any given
+        dimension, the ndarray will have length equal to the upper bound of that dimension
+        across the union of the rectangles. Entries not covered by any rectangle will be initialized to 0.
+
+        Examples
+        --------
+        Consider the following:
+
+        >>> import numpy as np
+        >>> nd = np.array([[ 1.0, 2.0, 3.0],
+        ...                [ 4.0, 5.0, 6.0],
+        ...                [ 7.0, 8.0, 9.0]])
+
+        >>> BlockMatrix.from_numpy(nd).export_rectangles('output/example', [[0, 3, 0, 1], [1, 2, 0, 2]])
+        >>> BlockMatrix.rectangles_to_numpy('output/example')
+
+        This would produce the following NumPy ndarray:
+
+        .. code-block:: text
+
+            1.0 0.0
+            4.0 5.0
+            7.0 0.0
 
         See Also
         --------
@@ -1966,13 +1985,13 @@ class BlockMatrix(object):
         -------
         :class:`numpy.ndarray`
         """
-        def parse_rectangles(fname):
+        def parse_rects(fname):
             rect_idx_and_bounds = [int(i) for i in re.findall(r'\d+', fname)]
             assert len(rect_idx_and_bounds) == 5
             return rect_idx_and_bounds
 
         rect_files = [file for file in os.listdir(path) if not re.match(r'.*\.crc', file)]
-        rects = [parse_rectangles(file) for file in rect_files]
+        rects = [parse_rects(file) for file in rect_files]
 
         n_rows = max(rects, key=lambda r: r[2])[2]
         n_cols = max(rects, key=lambda r: r[3])[3]

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1124,8 +1124,8 @@ class BlockMatrix(object):
         uri = local_path_uri(path)
 
         if self.n_rows * self.n_cols > 1 << 31:
-            self.export_blocks(uri)
-            return BlockMatrix.rectangles_to_numpy(path)
+            self.export_blocks(uri, binary=True)
+            return BlockMatrix.rectangles_to_numpy(path, binary=True)
 
         self.tofile(uri)
         return np.fromfile(path).reshape((self.n_rows, self.n_cols))

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -662,6 +662,20 @@ class Tests(unittest.TestCase):
 
         self._assert_eq(nd, actual)
 
+    def test_rectangles_to_numpy(self):
+        nd = np.array([[1.0, 2.0, 3.0],
+                       [4.0, 5.0, 6.0],
+                       [7.0, 8.0, 9.0]])
+
+        rect_path = new_local_temp_dir()
+        rect_uri = local_path_uri(rect_path)
+        BlockMatrix.from_numpy(nd).export_rectangles(rect_uri, [[0, 3, 0, 1], [1, 2, 0, 2]])
+
+        expected = np.array([[1.0, 0.0],
+                             [4.0, 5.0],
+                             [7.0, 0.0]])
+        self._assert_eq(expected, BlockMatrix.rectangles_to_numpy(rect_path))
+
     def test_block_matrix_entries(self):
         n_rows, n_cols = 5, 3
         rows = [{'i': i, 'j': j, 'entry': float(i + j)} for i in range(n_rows) for j in range(n_cols)]

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -651,6 +651,13 @@ class Tests(unittest.TestCase):
                     self._assert_eq(expected, actual)
 
     @skip_unless_spark_backend()
+    def test_export_blocks(self):
+        nd = np.arange(0, 80, dtype=float).reshape(8, 10)
+
+        bm_path = new_local_temp_dir()
+        bm_uri = local_path_uri(bm_path)
+        BlockMatrix.from_numpy(nd, block_size=4).export_blocks_binary(bm_uri)
+
     def test_block_matrix_entries(self):
         n_rows, n_cols = 5, 3
         rows = [{'i': i, 'j': j, 'entry': float(i + j)} for i in range(n_rows) for j in range(n_cols)]

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -658,7 +658,7 @@ class Tests(unittest.TestCase):
         bm_path = new_local_temp_dir()
         bm_uri = local_path_uri(bm_path)
         bm.export_blocks(bm_uri, binary=True)
-        actual = BlockMatrix.rectangles_to_numpy(bm_path)
+        actual = BlockMatrix.rectangles_to_numpy(bm_path, binary=True)
 
         self._assert_eq(nd, actual)
 

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -667,14 +667,21 @@ class Tests(unittest.TestCase):
                        [4.0, 5.0, 6.0],
                        [7.0, 8.0, 9.0]])
 
+        rects = [[0, 3, 0, 1], [1, 2, 0, 2]]
+
         rect_path = new_local_temp_dir()
         rect_uri = local_path_uri(rect_path)
-        BlockMatrix.from_numpy(nd).export_rectangles(rect_uri, [[0, 3, 0, 1], [1, 2, 0, 2]])
+        BlockMatrix.from_numpy(nd).export_rectangles(rect_uri, rects)
+
+        rect_bytes_path = new_local_temp_dir()
+        rect_bytes_uri = local_path_uri(rect_bytes_path)
+        BlockMatrix.from_numpy(nd).export_rectangles(rect_bytes_uri, rects, binary=True)
 
         expected = np.array([[1.0, 0.0],
                              [4.0, 5.0],
                              [7.0, 0.0]])
         self._assert_eq(expected, BlockMatrix.rectangles_to_numpy(rect_path))
+        self._assert_eq(expected, BlockMatrix.rectangles_to_numpy(rect_bytes_path, binary=True))
 
     def test_block_matrix_entries(self):
         n_rows, n_cols = 5, 3

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -658,7 +658,7 @@ class Tests(unittest.TestCase):
         bm_path = new_local_temp_dir()
         bm_uri = local_path_uri(bm_path)
         bm.export_blocks(bm_uri, binary=True)
-        actual = BlockMatrix.blocks_to_numpy(bm_path)
+        actual = BlockMatrix.rectangles_to_numpy(bm_path)
 
         self._assert_eq(nd, actual)
 

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -652,11 +652,15 @@ class Tests(unittest.TestCase):
 
     @skip_unless_spark_backend()
     def test_export_blocks(self):
-        nd = np.arange(0, 80, dtype=float).reshape(8, 10)
+        nd = np.ones(shape=(8, 10))
+        bm = BlockMatrix.from_numpy(nd, block_size=20)
 
         bm_path = new_local_temp_dir()
         bm_uri = local_path_uri(bm_path)
-        BlockMatrix.from_numpy(nd, block_size=4).export_blocks_binary(bm_uri)
+        bm.export_blocks(bm_uri, binary=True)
+        actual = BlockMatrix.blocks_to_numpy(bm_path)
+
+        self._assert_eq(nd, actual)
 
     def test_block_matrix_entries(self):
         n_rows, n_cols = 5, 3


### PR DESCRIPTION
- Added convenience method to export each block of a BlockMatrix into its own file using `export_rectangles`
- Added static method to load rectangle files into a NumPy NDArray