### PR TITLE
Use define_function in combiner

### DIFF
--- a/hail/python/hail/experimental/vcf_combiner.py
+++ b/hail/python/hail/experimental/vcf_combiner.py
@@ -46,8 +46,8 @@ def transform_one(mt) -> Table:
                         "MQ_DP",
                         "QUALapprox",
                         "RAW_MQ",
-                        "VarDP",
                         "SB_TABLE",
+                        "VarDP",
                     ),
                     __entries=row.__entries.map(
                         lambda e:
@@ -72,7 +72,7 @@ def transform_one(mt) -> Table:
                             MQ=row.info['MQ'],
                             MQRankSum=row.info['MQRankSum'],
                             PID=e.PID,
-                            RGT=hl.cond(
+                            RGQ=hl.cond(
                                 has_non_ref,
                                 e.PL[hl.call(0, alleles_len - 1).unphased_diploid_gt_index()],
                                 hl.null(e.PL.dtype.element_type)),


### PR DESCRIPTION
This astronomically cuts down on IR duplication.

The following is the IR for one invocation to TableMultiWayZipJoin in the old pipeline, this would be replicated for every vcf imported:
```
(CastMatrixToTable "__entries" "__cols"
                    (MatrixMapEntries
                      (MatrixMapRows
                        (MatrixMapEntries
                          (MatrixMapRows
                            (MatrixMapEntries
                              (MatrixLiteral)
                              (InsertFields
                                (SelectFields (AD DP GQ GT MIN_DP PGT PID PL SB)
                                  (Ref g))
                                None
                                (END
                                  (GetField END
                                    (GetField info
                                      (Ref va))))
                                (BaseQRankSum
                                  (GetField BaseQRankSum
                                    (GetField info
                                      (Ref va))))
                                (ClippingRankSum
                                  (GetField ClippingRankSum
                                    (GetField info
                                      (Ref va))))
                                (MQ
                                  (GetField MQ
                                    (GetField info
                                      (Ref va))))
                                (MQRankSum
                                  (GetField MQRankSum
                                    (GetField info
                                      (Ref va))))
                                (ReadPosRankSum
                                  (GetField ReadPosRankSum
                                    (GetField info
                                      (Ref va))))
                                (LGT
                                  (GetField GT
                                    (Ref g)))
                                (LAD
                                  (If
                                    (ApplyComparisonOp EQ
                                      (ApplyIR indexArray
                                        (GetField alleles
                                          (Ref va))
                                        (I32 -1))
                                      (Str "<NON_REF>"))
                                    (ApplyIR `[:*]`
                                      (GetField AD
                                        (Ref g))
                                      (I32 -1))
                                    (GetField AD
                                      (Ref g))))
                                (LPL
                                  (If
                                    (ApplyComparisonOp EQ
                                      (ApplyIR indexArray
                                        (GetField alleles
                                          (Ref va))
                                        (I32 -1))
                                      (Str "<NON_REF>"))
                                    (If
                                      (ApplyComparisonOp GT
                                        (ArrayLen
                                          (GetField alleles
                                            (Ref va)))
                                        (I32 2))
                                      (ApplyIR `[:*]`
                                        (GetField PL
                                          (Ref g))
                                        (ApplyUnaryPrimOp Negate
                                          (ArrayLen
                                            (GetField alleles
                                              (Ref va)))))
                                      (NA Array[Int32]))
                                    (If
                                      (ApplyComparisonOp GT
                                        (ArrayLen
                                          (GetField alleles
                                            (Ref va)))
                                        (I32 1))
                                      (GetField PL
                                        (Ref g))
                                      (NA Array[Int32]))))
                                (LPGT
                                  (GetField PGT
                                    (Ref g)))
                                (RGQ
                                  (If
                                    (ApplyComparisonOp EQ
                                      (ApplyIR indexArray
                                        (GetField alleles
                                          (Ref va))
                                        (I32 -1))
                                      (Str "<NON_REF>"))
                                    (ApplyIR indexArray
                                      (GetField PL
                                        (Ref g))
                                      (Apply unphasedDiploidGtIndex
                                        (Apply Call
                                          (I32 0)
                                          (ApplyBinaryPrimOp Subtract
                                            (ArrayLen
                                              (GetField alleles
                                                (Ref va)))
                                            (I32 1))
                                          (False))))
                                    (NA Int32)))))
                            (InsertFields
                              (SelectFields (locus alleles rsid qual filters info)
                                (Ref va))
                              None
                              (alleles
                                (If
                                  (ApplyComparisonOp EQ
                                    (ApplyIR indexArray
                                      (GetField alleles
                                        (Ref va))
                                      (I32 -1))
                                    (Str "<NON_REF>"))
                                  (ApplyIR `[:*]`
                                    (GetField alleles
                                      (Ref va))
                                    (I32 -1))
                                  (GetField alleles
                                    (Ref va))))
                              (info
                                (SelectFields (MQ_DP QUALapprox RAW_MQ VarDP SB_TABLE)
                                  (InsertFields
                                    (GetField info
                                      (Ref va))
                                    None
                                    (SB_TABLE
                                      (MakeArray Array[Int64]
                                        (ApplyAggOp Sum
                                          ()
                                          None
                                          (                                            (ApplyIR toInt64
                                              (ApplyIR indexArray
                                                (GetField SB
                                                  (Ref g))
                                                (I32 0)))))
                                        (ApplyAggOp Sum
                                          ()
                                          None
                                          (                                            (ApplyIR toInt64
                                              (ApplyIR indexArray
                                                (GetField SB
                                                  (Ref g))
                                                (I32 1)))))
                                        (ApplyAggOp Sum
                                          ()
                                          None
                                          (                                            (ApplyIR toInt64
                                              (ApplyIR indexArray
                                                (GetField SB
                                                  (Ref g))
                                                (I32 2)))))
                                        (ApplyAggOp Sum
                                          ()
                                          None
                                          (                                            (ApplyIR toInt64
                                              (ApplyIR indexArray
                                                (GetField SB
                                                  (Ref g))
                                                (I32 3))))))))))))
                          (InsertFields
                            (SelectFields (AD DP GQ GT MIN_DP PGT PID PL SB END BaseQRankSum ClippingRankSum MQ MQRankSum ReadPosRankSum LGT LAD LPL LPGT RGQ)
                              (Ref g))
                            None
                            (LA
                              (ArrayRange
                                (I32 0)
                                (ArrayLen
                                  (GetField alleles
                                    (Ref va)))
                                (I32 1)))))
                        (SelectFields (locus alleles rsid info)
                          (MakeStruct
                            (locus
                              (GetField locus
                                (Ref va)))
                            (alleles
                              (GetField alleles
                                (Ref va)))
                            (rsid
                              (GetField rsid
                                (Ref va)))
                            (qual
                              (GetField qual
                                (Ref va)))
                            (filters
                              (GetField filters
                                (Ref va)))
                            (info
                              (GetField info
                                (Ref va))))))
                      (SelectFields (DP GQ MIN_DP PID END BaseQRankSum ClippingRankSum MQ MQRankSum ReadPosRankSum LGT LAD LPL LPGT RGQ LA)
                        (SelectFields (AD DP GQ GT MIN_DP PGT PID PL SB END BaseQRankSum ClippingRankSum MQ MQRankSum ReadPosRankSum LGT LAD LPL LPGT RGQ LA)
                          (Ref g)))))
```
Now, we compile, essentially the above IR once, and so this becomes:
```
                  (TableMapRows
                    (CastMatrixToTable "__entries" "__cols"
                      (MatrixLiteral))
                    (ApplyIR __uid_1
                      (Ref row)))
```
This leads to a 4x size reduction in the IR we send to python, for running the joint caller for 10 vcfs (not including the function itself which is of a constant size).