### PR TITLE
[c++] Implements ArraySort/ToSet/ToDict in Emit.

### DIFF
--- a/hail/src/main/resources/include/hail/ArrayBuilder.h
+++ b/hail/src/main/resources/include/hail/ArrayBuilder.h
@@ -43,6 +43,7 @@ class BaseArrayBuilder {
 template<typename ElemT, bool elem_required, size_t elem_size, size_t elem_align, size_t array_align>
 class ArrayLoadBuilder : public BaseArrayBuilder<elem_required, elem_size, elem_align, array_align> {
   public:
+    using ArrayImpl = ArrayLoadImpl<ElemT, elem_required, elem_size, elem_align>;
     using T = ElemT;
     using Base = BaseArrayBuilder<elem_required, elem_size, elem_align, array_align>;
     void set_element(int idx, ElemT elem) {
@@ -54,6 +55,7 @@ class ArrayLoadBuilder : public BaseArrayBuilder<elem_required, elem_size, elem_
 template<bool elem_required, size_t elem_size, size_t elem_align, size_t array_align>
 class ArrayAddrBuilder : public BaseArrayBuilder<elem_required, elem_size, elem_align, array_align> {
   public:
+    using ArrayImpl = ArrayAddrImpl<elem_required, elem_size, elem_align>;
     using T = char *;
     using Base = BaseArrayBuilder<elem_required, elem_size, elem_align, array_align>;
     void set_element(int idx, const char * elem) {

--- a/hail/src/main/resources/include/hail/ArraySorter.h
+++ b/hail/src/main/resources/include/hail/ArraySorter.h
@@ -1,0 +1,66 @@
+#ifndef HAIL_ARRAYSORTER_H
+#define HAIL_ARRAYSORTER_H 1
+
+#include <vector>
+#include <algorithm>
+
+namespace hail {
+
+template <typename ArrayBuilder, typename LessThan>
+class ArraySorter {
+  public:
+    using ArrayImpl = typename ArrayBuilder::ArrayImpl;
+    using T = typename ArrayImpl::T;
+
+    struct SortableElem {
+      T elem_;
+      LessThan lt_;
+
+      SortableElem(T elem) : elem_(elem) { }
+      friend bool operator<(const SortableElem& lhs, const SortableElem& rhs) { return lhs.lt_(nullptr, lhs.elem_, rhs.elem_); }
+    };
+
+    std::vector<SortableElem> non_missing_;
+    int n_missing_;
+
+    ArraySorter(const char * array) : non_missing_() {
+      int len = ArrayImpl::load_length(array);
+      non_missing_.reserve(len);
+      for (int i=0; i<len; ++i) {
+        if (!ArrayImpl::is_element_missing(array, i)) {
+          non_missing_.emplace_back(ArrayImpl::load_element(array, i));
+        }
+      }
+      n_missing_ = len - non_missing_.size();
+    }
+
+    void sort() { std::stable_sort(non_missing_.begin(), non_missing_.end()); }
+
+    template<typename IsEqual>
+    void distinct() {
+      IsEqual eq_;
+      for (auto it = non_missing_.begin(); it != non_missing_.end(); ) {
+        if (eq_(*it, *(it + 1))) {
+            it = non_missing_.erase(it);
+        } else { ++it; }
+      }
+      if (n_missing_ != 0) { n_missing_ = 1; }
+    }
+
+    char * to_region(Region * region) {
+      int len = (int) non_missing_.size() + n_missing_;
+      ArrayBuilder ab { len, region };
+      ab.clear_missing_bits();
+      for (int i=0; i<non_missing_.size(); ++i) {
+        ab.set_element(i, non_missing_[i].elem_);
+      }
+      for (int i=non_missing_.size(); i<len; ++i) { ab.set_missing(i); }
+      return ab.offset();
+    }
+
+    char * to_region(RegionPtr region) { return to_region(region.get()); }
+};
+
+}
+
+#endif

--- a/hail/src/main/resources/include/hail/ArraySorter.h
+++ b/hail/src/main/resources/include/hail/ArraySorter.h
@@ -15,34 +15,25 @@ class ArraySorter {
     std::vector<T> non_missing_;
     int n_missing_;
 
-    ArraySorter(const char * array) : non_missing_() {
-      int len = ArrayImpl::load_length(array);
-      non_missing_.reserve(len);
-      for (int i=0; i<len; ++i) {
-        if (!ArrayImpl::is_element_missing(array, i)) {
-          non_missing_.push_back(ArrayImpl::load_element(array, i));
-        }
-      }
-      n_missing_ = len - non_missing_.size();
-    }
+    ArraySorter() : non_missing_(), n_missing_(0) { }
+
+    void add_missing() { ++n_missing_; }
+    void add_element(T elt) { non_missing_.push_back(elt); }
 
     void sort() { std::stable_sort(non_missing_.begin(), non_missing_.end(), LessThan()); }
 
     template<typename IsEqual>
-    void distinct() {
-      IsEqual eq_;
+    void distinct(bool remove_missing) {
       auto new_end = std::unique(non_missing_.begin(), non_missing_.end(), IsEqual());
-      non_missing_.erase(new_end, non_missing_.end())
-      if (n_missing_ != 0) { n_missing_ = 1; }
+      non_missing_.erase(new_end, non_missing_.end());
+      if (n_missing_ != 0) { n_missing_ = remove_missing ? 0 : 1; }
     }
 
     char * to_region(Region * region) {
       int len = (int) non_missing_.size() + n_missing_;
       ArrayBuilder ab { len, region };
       ab.clear_missing_bits();
-      for (int i=0; i<non_missing_.size(); ++i) {
-        ab.set_element(i, non_missing_[i].elem_);
-      }
+      for (int i=0; i<non_missing_.size(); ++i) { ab.set_element(i, non_missing_[i]); }
       for (int i=non_missing_.size(); i<len; ++i) { ab.set_missing(i); }
       return ab.offset();
     }

--- a/hail/src/main/resources/include/hail/ArraySorter.h
+++ b/hail/src/main/resources/include/hail/ArraySorter.h
@@ -17,7 +17,7 @@ class ArraySorter {
       LessThan lt_;
 
       SortableElem(T elem) : elem_(elem) { }
-      friend bool operator<(const SortableElem& lhs, const SortableElem& rhs) { return lhs.lt_(nullptr, lhs.elem_, rhs.elem_); }
+      friend bool operator<(const SortableElem& lhs, const SortableElem& rhs) { return lhs.lt_(lhs.elem_, rhs.elem_); }
     };
 
     std::vector<SortableElem> non_missing_;
@@ -39,8 +39,8 @@ class ArraySorter {
     template<typename IsEqual>
     void distinct() {
       IsEqual eq_;
-      for (auto it = non_missing_.begin(); it != non_missing_.end(); ) {
-        if (eq_(*it, *(it + 1))) {
+      for (auto it = ++non_missing_.begin(); it != non_missing_.end(); ) {
+        if (eq_((*it).elem_, (*(it - 1)).elem_)) {
             it = non_missing_.erase(it);
         } else { ++it; }
       }

--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -1,7 +1,7 @@
 package is.hail.cxx
 
 import is.hail.expr.ir
-import is.hail.expr.types.coerce
+import is.hail.expr.types._
 import is.hail.expr.types.physical._
 import is.hail.expr.types.virtual._
 import is.hail.io.CodecSpec

--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -617,7 +617,8 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
 
         val ltClass = fb.translationUnitBuilder().buildClass(fb.translationUnitBuilder().genSym("SorterLessThan"))
         val lt = ltClass.buildMethod("operator()", Array(cxxType -> "l", cxxType -> "r"), "bool", const=true)
-        val trip = Emit(lt, 0, ir.Subst(comp, ir.Env(l -> ir.In(0, eltType), r -> ir.In(1, eltType))))
+        val (trip, mods) = Emit(lt, 0, ir.Subst(comp, ir.Env(l -> ir.In(0, eltType), r -> ir.In(1, eltType))))
+        assert(mods.isEmpty)
         lt += s"""
              |${ trip.setup }
              |if (${ trip.m }) { throw new FatalError("ArraySort: comparison function cannot evaluate to missing."); }
@@ -663,7 +664,8 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
 
         val ltClass = fb.translationUnitBuilder().buildClass(fb.translationUnitBuilder().genSym("SorterLessThan"))
         val lt = ltClass.buildMethod("operator()", Array(cxxType -> "l", cxxType -> "r"), "bool", const=true)
-        val trip = Emit(lt, 0, ltIR)
+        val (trip, mods) = Emit(lt, 0, ltIR)
+        assert(mods.isEmpty)
         lt += s"""
                  |${ trip.setup }
                  |if (${ trip.m }) { abort(); }
@@ -674,7 +676,8 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
 
         val eqClass = fb.translationUnitBuilder().buildClass(fb.translationUnitBuilder().genSym("SorterEq"))
         val eq = eqClass.buildMethod("operator()", Array(cxxType -> "l", cxxType -> "r"), "bool", const=true)
-        val eqTrip = Emit(eq, 0, eqIR)
+        val (eqTrip, eqmods) = Emit(eq, 0, eqIR)
+        assert(eqmods.isEmpty)
         eq += s"""
                  |${ eqTrip.setup }
                  |if (${ eqTrip.m }) { abort(); }

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -242,6 +242,15 @@ final case class InsertFields(old: IR, fields: Seq[(String, IR)], fieldOrder: Op
   override def pType: PStruct = coerce[PStruct](super.pType)
 }
 
+object GetFieldByIdx {
+  def apply(s: IR, field: Int): IR = {
+    (s.typ: @unchecked) match {
+      case t: TStruct => GetField(s, t.fieldNames(field))
+      case _: TTuple => GetTupleElement(s, field)
+    }
+  }
+}
+
 final case class GetField(o: IR, name: String) extends IR
 
 final case class MakeTuple(types: Seq[IR]) extends IR

--- a/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
@@ -227,6 +227,17 @@ abstract class PContainer extends PType {
     }
   }
 
+  def cxxArrayBuilder: String = {
+    elementType match {
+      case _: PStruct | _: PTuple =>
+        s"ArrayAddrBuilder<${ elementType.required },${ elementType.byteSize },${ elementType.alignment }, ${ alignment }>"
+      case _ =>
+        s"ArrayLoadBuilder<${ cxx.typeToCXXType(elementType) },${ elementType.required },${ elementType.byteSize }, ${ elementType.alignment }, ${ alignment }>"
+    }
+  }
+
+  def cxxArraySorter(ltClass: String): String = s"ArraySorter<$cxxArrayBuilder, $ltClass>"
+
   def cxxLoadLength(a: cxx.Code): cxx.Code = {
     s"$cxxImpl::load_length($a)"
   }


### PR DESCRIPTION
Builds on #5463.

This currently just pulls values out into a vector and sorts the vector based on a defined sorting function; could possibly be improved in the future by defining an iterator that we can call e.g. `std::stable_sort` on.