### PR TITLE
[combiner] drop the first element in AC, AF in summarize

### DIFF
--- a/hail/python/hail/experimental/vcf_combiner.py
+++ b/hail/python/hail/experimental/vcf_combiner.py
@@ -186,8 +186,8 @@ def summarize(mt):
         hl.agg.call_stats(lgt_to_gt(mt.LGT, mt.LA), mt.alleles),
         lambda gs: hl.struct(
             # here, we alphabetize the INFO fields by GATK convention
-            AC=gs.AC,
-            AF=gs.AF,
+            AC=gs.AC[1:],  # The VCF spec indicates that AC and AF have Number=A, so we need
+            AF=gs.AF[1:],  # to drop the first element from each of these.
             AN=gs.AN,
             BaseQRankSum=hl.median(hl.agg.collect(mt.entry.BaseQRankSum)),
             ClippingRankSum=hl.median(hl.agg.collect(mt.entry.ClippingRankSum)),


### PR DESCRIPTION
The VCF spec indicates that there should be 1 element in this array per
alternate allele (`Number=A`), not one per allele (`Number=R`).