### PR TITLE
[bug-fix] Check keyed table for collect_by_key and distinct

### DIFF
--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -14,7 +14,6 @@ from hail.typecheck import *
 from hail.utils import wrap_to_list, storage_level, LinkedList, Struct
 from hail.utils.java import *
 from hail.utils.misc import *
-from hail.methods.misc import require_key
 
 from collections import OrderedDict, Counter
 import itertools
@@ -2924,7 +2923,8 @@ class Table(ExprContainer):
         :class:`.Table`
         """
 
-        require_key(self, 'collect_by_key')
+        import hail.methods.misc as misc
+        misc.require_key(self, 'collect_by_key')
 
         return Table(TableAggregateByKey(
             self._tir,
@@ -2974,7 +2974,8 @@ class Table(ExprContainer):
         :class:`.Table`
         """
 
-        require_key(self, 'distinct')
+        import hail.methods.misc as misc
+        misc.require_key(self, 'distinct')
 
         return Table(TableDistinct(self._tir))
 

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -14,6 +14,7 @@ from hail.typecheck import *
 from hail.utils import wrap_to_list, storage_level, LinkedList, Struct
 from hail.utils.java import *
 from hail.utils.misc import *
+from hail.methods.misc import require_key
 
 from collections import OrderedDict, Counter
 import itertools
@@ -2923,6 +2924,8 @@ class Table(ExprContainer):
         :class:`.Table`
         """
 
+        require_key(self, 'collect_by_key')
+
         return Table(TableAggregateByKey(
             self._tir,
             hl.struct(**{name: hl.agg.collect(self.row_value)})._ir))
@@ -2970,6 +2973,8 @@ class Table(ExprContainer):
         -------
         :class:`.Table`
         """
+
+        require_key(self, 'distinct')
 
         return Table(TableDistinct(self._tir))
 


### PR DESCRIPTION
We weren't checking for a key even though the docs said the table needed to be keyed. This led to undefined behavior for `distinct`. Not sure what the error mode for `collect_by_key` was.