### PR TITLE
helpers to create and remove k8s secrets for gcp sa keys

### DIFF
--- a/vdc/list-gcp-sa-keys
+++ b/vdc/list-gcp-sa-keys
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -ex
+
+if [ ! $# -eq 1 ]
+then
+    echo "USAGE: list-gcp-sa-keys SERIVCE_ACCOUNT_NAME"
+    exit 1
+fi
+
+service_account_name=$1
+
+gcloud iam service-accounts keys list \
+       --iam-account="${service_account_name}@$(gcloud config get-value project).iam.gserviceaccount.com"

--- a/vdc/make-k8s-gcp-sa-key
+++ b/vdc/make-k8s-gcp-sa-key
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+set -ex
+
+if [ ! $# -eq 2 ]
+then
+    echo "USAGE: make-k8s-gcp-sa-key SERIVCE_ACCOUNT_NAME NAMESPACE"
+    exit 1
+fi
+
+service_account_name=$1
+namespace=$2
+temp_file=$(mktemp /tmp/key.json.XXXXXX)
+
+cleanup() {
+    set +e
+    trap "" INT TERM
+    rm -rf ${temp_file}
+}
+trap cleanup EXIT
+trap "exit 24" INT TERM
+
+gcloud iam service-accounts keys create ${temp_file} \
+    --iam-account=${service_account_name}@hail-vdc.iam.gserviceaccount.com
+kubectl create secret generic \
+    gcp-sa-key-${service_account_name} \
+    --namespace=${namespace} \
+    --from-file=key.json="${temp_file}"
+
+

--- a/vdc/make-k8s-gcp-sa-key
+++ b/vdc/make-k8s-gcp-sa-key
@@ -26,5 +26,3 @@ kubectl create secret generic \
     gcp-sa-key-${service_account_name} \
     --namespace=${namespace} \
     --from-file=key.json="${temp_file}"
-
-

--- a/vdc/remove-k8s-gcp-sa-key
+++ b/vdc/remove-k8s-gcp-sa-key
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -ex
+
+if [ ! $# -eq 2 ]
+then
+    echo "USAGE: remove-k8s-gcp-sa-key SERIVCE_ACCOUNT_NAME NAMESPACE"
+    exit 1
+fi
+
+service_account_name=$1
+namespace=$2
+private_key_id=$(kubectl get secret gcp-sa-key-${service_account_name} \
+        -o json \
+        --namespace=test \
+    | jq -r '.data["key.json"]' \
+    | base64 -D \
+    | jq -r '.private_key_id')
+
+gcloud iam service-accounts keys delete ${private_key_id} \
+       --iam-account="${service_account_name}@$(gcloud config get-value project).iam.gserviceaccount.com"

--- a/vdc/remove-k8s-gcp-sa-key
+++ b/vdc/remove-k8s-gcp-sa-key
@@ -12,7 +12,7 @@ service_account_name=$1
 namespace=$2
 private_key_id=$(kubectl get secret gcp-sa-key-${service_account_name} \
         -o json \
-        --namespace=test \
+        --namespace=$namespace \
     | jq -r '.data["key.json"]' \
     | base64 -D \
     | jq -r '.private_key_id')


### PR DESCRIPTION
These scripts wrap `gcloud` and `kubectl` to provide one line commands to create and remove k8s secrets, with a standard name scheme, for GCP service accounts.