### PR TITLE
[notebook2]: remove ibg 2019

### DIFF
--- a/notebook2/notebook/notebook.py
+++ b/notebook2/notebook/notebook.py
@@ -321,7 +321,7 @@ def notebook_page():
         return render_template('notebook.html',
                                form_action_url=external_url_for('notebook'),
                                images=list(WORKER_IMAGES),
-                               default='ibg2019')
+                               default='hail')
 
     session['notebook'] = notebooks[0]
 

--- a/notebook2/notebook/templates/notebook-form.html
+++ b/notebook2/notebook/templates/notebook-form.html
@@ -1,4 +1,4 @@
 <form action="{{ form_action_url }}" method="post">
-  <input type="hidden" name="image" value="ibg2019" />
+  <input type="hidden" name="image" value="hail" />
   <button>Create</button>
 </form>


### PR DESCRIPTION
This just removes the ibg2019 image from notebook2, resets the default (and only image) to the hail image that preceded it.