### PR TITLE
[c++] fix test times

### DIFF
--- a/hail/src/main/scala/is/hail/cxx/Compile.scala
+++ b/hail/src/main/scala/is/hail/cxx/Compile.scala
@@ -19,8 +19,8 @@ object Compile {
     tub.include("<cstring>")
 
     val fb = tub.buildFunction(tub.genSym("f"),
-      (("SparkFunctionContext", "ctx") +: args.map { case (name, typ) =>
-        typeToCXXType(typ) -> name  }).toArray,
+      (("SparkFunctionContext", "ctx") +: args.zipWithIndex.map { case ((name, typ), i) =>
+        typeToCXXType(typ) -> s"v$i" }).toArray,
       typeToCXXType(body.pType))
 
     val emitEnv = args.zipWithIndex
@@ -69,7 +69,7 @@ object Compile {
     }
 
     val tu = tub.end()
-    val mod = tu.build(if (optimize) "-ggdb -O1" else "-ggdb -O0")
+    val mod = tu.build(if (optimize) "-ggdb -O1" else "-ggdb -O0", System.out)
 
     val st = new NativeStatus()
     mod.findOrBuild(st)

--- a/hail/src/main/scala/is/hail/cxx/Compile.scala
+++ b/hail/src/main/scala/is/hail/cxx/Compile.scala
@@ -19,8 +19,8 @@ object Compile {
     tub.include("<cstring>")
 
     val fb = tub.buildFunction(tub.genSym("f"),
-      (("SparkFunctionContext", "ctx") +: args.map { case (name, typ) =>
-        typeToCXXType(typ) -> tub.genSym("v") }).toArray,
+      (("SparkFunctionContext", "ctx") +: args.map { case (_, typ) =>
+        typeToCXXType(typ) -> "v" }).toArray,
       typeToCXXType(body.pType))
 
     val emitEnv = args.zipWithIndex

--- a/hail/src/main/scala/is/hail/cxx/Compile.scala
+++ b/hail/src/main/scala/is/hail/cxx/Compile.scala
@@ -19,8 +19,8 @@ object Compile {
     tub.include("<cstring>")
 
     val fb = tub.buildFunction(tub.genSym("f"),
-      (("SparkFunctionContext", "ctx") +: args.zipWithIndex.map { case ((name, typ), i) =>
-        typeToCXXType(typ) -> s"v$i" }).toArray,
+      (("SparkFunctionContext", "ctx") +: args.map { case (name, typ) =>
+        typeToCXXType(typ) -> tub.genSym("v") }).toArray,
       typeToCXXType(body.pType))
 
     val emitEnv = args.zipWithIndex
@@ -69,7 +69,7 @@ object Compile {
     }
 
     val tu = tub.end()
-    val mod = tu.build(if (optimize) "-ggdb -O1" else "-ggdb -O0", System.out)
+    val mod = tu.build(if (optimize) "-ggdb -O1" else "-ggdb -O0")
 
     val st = new NativeStatus()
     mod.findOrBuild(st)

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -361,14 +361,13 @@ object TestUtils {
     assert(t.valuesSimilar(i, c), s"interpret $i vs compile $c")
     assert(t.valuesSimilar(i2, c), s"interpret (optimize = false) $i vs compile $c")
 
-    // FIXME: unmanageable test times
-//    try {
-//      val c2 = nativeExecute(x, env, args, agg)
-//      assert(t.typeCheck(c2))
-//      assert(t.valuesSimilar(c2, c), s"native compile $c2 vs compile $c")
-//    } catch {
-//      case _: CXXUnsupportedOperation =>
-//    }
+    try {
+      val c2 = nativeExecute(x, env, args, agg)
+      assert(t.typeCheck(c2))
+      assert(t.valuesSimilar(c2, c), s"native compile $c2 vs compile $c")
+    } catch {
+      case _: CXXUnsupportedOperation =>
+    }
   }
 
   def assertEvalsTo(x: IR, expected: Any) {


### PR DESCRIPTION
@cseed @tpoterba I accidentally undid the caching behavior in the tests by using the name of input variables from their name in the environment instead of just using a default set of variable names. Should be much faster now.