### PR TITLE
Specify which execution strategies should pass for assertEvalsTo

### DIFF
--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -422,9 +422,7 @@ object TestUtils {
         assert(t.valuesSimilar(res, expected), s"($res, $expected)")
       } catch {
         case e: Exception =>
-          if (execStrats.contains(strat)) {
-            fail(s"Failed to execute for $strat: ${e.getMessage}")
-          }
+          if (execStrats.contains(strat)) throw e
       }
     }
   }

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -421,9 +421,9 @@ object TestUtils {
         assert(t.typeCheck(res))
         assert(t.valuesSimilar(res, expected), s"($res, $expected)")
       } catch {
-        case _: Exception =>
+        case e: Exception =>
           if (execStrats.contains(strat)) {
-            fail(s"Failed to execute for $strat")
+            fail(s"Failed to execute for $strat: ${e.getMessage}")
           }
       }
     }

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -1,6 +1,7 @@
 package is.hail
 
 import breeze.linalg.{DenseMatrix, Matrix, Vector}
+import is.hail.ExecStrategy.ExecStrategy
 import is.hail.annotations.{Annotation, Region, RegionValueBuilder, SafeRow}
 import is.hail.backend.spark.SparkBackend
 import is.hail.cxx.CXXUnsupportedOperation
@@ -14,6 +15,14 @@ import is.hail.utils._
 import is.hail.variant._
 import org.apache.spark.SparkException
 import org.apache.spark.sql.Row
+
+object ExecStrategy extends Enumeration {
+  type ExecStrategy = Value
+  val Interpret, InterpretUnoptimized, JvmCompile, CxxCompile = Value
+
+  val javaOnly:Set[ExecStrategy] = Set(Interpret, InterpretUnoptimized, JvmCompile)
+  val interpretOnly: Set[ExecStrategy] = Set(Interpret, InterpretUnoptimized)
+}
 
 object TestUtils {
 
@@ -370,19 +379,28 @@ object TestUtils {
     }
   }
 
-  def assertEvalsTo(x: IR, expected: Any) {
+  def assertEvalsTo(x: IR, expected: Any)
+    (implicit execStrats: Set[ExecStrategy]) {
     assertEvalsTo(x, Env.empty, FastIndexedSeq(), None, expected)
   }
 
-  def assertEvalsTo(x: IR, args: IndexedSeq[(Any, Type)], expected: Any) {
+  def assertEvalsTo(x: IR, args: IndexedSeq[(Any, Type)], expected: Any)
+    (implicit execStrats: Set[ExecStrategy]) {
     assertEvalsTo(x, Env.empty, args, None, expected)
   }
 
-  def assertEvalsTo(x: IR, agg: (IndexedSeq[Row], TStruct), expected: Any) {
+  def assertEvalsTo(x: IR, agg: (IndexedSeq[Row], TStruct), expected: Any)
+    (implicit execStrats: Set[ExecStrategy]) {
     assertEvalsTo(x, Env.empty, FastIndexedSeq(), Some(agg), expected)
   }
 
-  def assertEvalsTo(x: IR, env: Env[(Any, Type)], args: IndexedSeq[(Any, Type)], agg: Option[(IndexedSeq[Row], TStruct)], expected: Any) {
+  def assertEvalsTo(x: IR,
+    env: Env[(Any, Type)],
+    args: IndexedSeq[(Any, Type)],
+    agg: Option[(IndexedSeq[Row], TStruct)],
+    expected: Any)
+    (implicit execStrats: Set[ExecStrategy]) {
+
     TypeCheck(x,
       env.mapValues(_._2),
       agg.map(_._2.toEnv))
@@ -390,26 +408,24 @@ object TestUtils {
     val t = x.typ
     assert(t.typeCheck(expected), t)
 
-    val i = Interpret[Any](x, env, args, agg)
-    assert(t.typeCheck(i))
-    assert(t.valuesSimilar(i, expected), s"($i, $expected)")
-
-    val i2 = Interpret[Any](x, env, args, agg, optimize = false)
-    assert(t.typeCheck(i2))
-    assert(t.valuesSimilar(i2, expected), s"($i2, $expected)")
-
-    if (Forall(x, node => node.isInstanceOf[IR] && Compilable(node.asInstanceOf[IR]))) {
-      val c = eval(x, env, args, agg)
-      assert(t.typeCheck(c))
-      assert(t.valuesSimilar(c, expected), s"($c, $expected)")
-    }
-
-    try {
-      val c = nativeExecute(x, env, args, agg)
-      assert(t.typeCheck(c))
-      assert(t.valuesSimilar(c, expected), s"($c, $expected)")
-    } catch {
-      case _: CXXUnsupportedOperation =>
+    ExecStrategy.values.foreach { strat =>
+      try {
+        val res = strat match {
+          case ExecStrategy.Interpret => Interpret[Any](x, env, args, agg)
+          case ExecStrategy.InterpretUnoptimized => Interpret[Any](x, env, args, agg, optimize = false)
+          case ExecStrategy.JvmCompile =>
+            assert(Forall(x, node => node.isInstanceOf[IR] && Compilable(node.asInstanceOf[IR])))
+            eval(x, env, args, agg)
+          case ExecStrategy.CxxCompile => nativeExecute(x, env, args, agg)
+        }
+        assert(t.typeCheck(res))
+        assert(t.valuesSimilar(res, expected), s"($res, $expected)")
+      } catch {
+        case _: Exception =>
+          if (execStrats.contains(strat)) {
+            fail(s"Failed to execute for $strat")
+          }
+      }
     }
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir
 
-import is.hail.SparkSuite
+import is.hail.{ExecStrategy, SparkSuite}
 import is.hail.expr._
 import is.hail.expr.types._
 import is.hail.utils._
@@ -17,6 +17,9 @@ import is.hail.expr.ir.IRBuilder._
 import org.apache.spark.sql.Row
 
 class AggregatorsSuite extends SparkSuite {
+
+  implicit val execStrats = ExecStrategy.javaOnly
+
   def runAggregator(op: AggOp, aggType: TStruct, agg: IndexedSeq[Row], expected: Any, constrArgs: IndexedSeq[IR],
     initOpArgs: Option[IndexedSeq[IR]], seqOpArgs: IndexedSeq[IR]) {
 
@@ -992,6 +995,8 @@ class AggregatorsSuite extends SparkSuite {
   }
 
   @Test def testArrayElementsAggregator(): Unit = {
+    implicit val execStrats = ExecStrategy.interpretOnly
+
     def getAgg(n: Int, m: Int): IR = {
       hc
       val ht = TableRange(10, 3)
@@ -1011,5 +1016,4 @@ class AggregatorsSuite extends SparkSuite {
 
     assertEvalsTo(getAgg(10, 10), IndexedSeq.range(0, 10).map(_ * 10L))
   }
-
 }

--- a/hail/src/test/scala/is/hail/expr/ir/ArrayDeforestationSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ArrayDeforestationSuite.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir
 
-import is.hail.SparkSuite
+import is.hail.{ExecStrategy, SparkSuite}
 import is.hail.expr.types.virtual._
 import is.hail.TestUtils._
 import is.hail.utils._
@@ -10,6 +10,8 @@ import org.testng.annotations.{BeforeClass, Test}
 class ArrayDeforestationSuite extends SparkSuite {
 
   @BeforeClass def ensureHC() { initializeHailContext() }
+
+  implicit val execStrats = ExecStrategy.values
 
   def primitiveArrayNoRegion(len: IR): IR =
     ArrayMap(

--- a/hail/src/test/scala/is/hail/expr/ir/ArrayFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ArrayFunctionsSuite.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir
 
+import is.hail.ExecStrategy
 import is.hail.expr.types.{virtual, _}
 import is.hail.TestUtils._
 import is.hail.expr.ir.TestUtils._
@@ -10,6 +11,8 @@ import org.scalatest.testng.TestNGSuite
 
 class ArrayFunctionsSuite extends TestNGSuite {
   val naa = NA(TArray(TInt32()))
+
+  implicit val execStrats = ExecStrategy.javaOnly
 
   @DataProvider(name = "basic")
   def basicData(): Array[Array[Any]] = Array(

--- a/hail/src/test/scala/is/hail/expr/ir/CallFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/CallFunctionsSuite.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir
 
+import is.hail.ExecStrategy
 import is.hail.TestUtils._
 import is.hail.expr.ir.TestUtils.IRCall
 import is.hail.variant._
@@ -7,6 +8,9 @@ import org.testng.annotations.{DataProvider, Test}
 import org.scalatest.testng.TestNGSuite
 
 class CallFunctionsSuite extends TestNGSuite {
+
+  implicit val execStrats = ExecStrategy.javaOnly
+
   @DataProvider(name = "basic")
   def basicData(): Array[Array[Any]] = {
     assert(true)

--- a/hail/src/test/scala/is/hail/expr/ir/DictFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/DictFunctionsSuite.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir
 
+import is.hail.ExecStrategy
 import is.hail.TestUtils._
 import is.hail.expr.ir.TestUtils._
 import is.hail.expr.types.virtual.{TDict, TInt32}
@@ -10,6 +11,8 @@ import org.scalatest.testng.TestNGSuite
 class DictFunctionsSuite extends TestNGSuite {
   def tuplesToMap(a: Seq[(Integer, Integer)]): Map[Integer, Integer] =
     Option(a).map(_.filter(_ != null).toMap).orNull
+
+  implicit val execStrats = ExecStrategy.javaOnly
 
   @DataProvider(name = "basic")
   def basicData(): Array[Array[Any]] = Array(

--- a/hail/src/test/scala/is/hail/expr/ir/GenotypeFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/GenotypeFunctionsSuite.scala
@@ -1,11 +1,14 @@
 package is.hail.expr.ir
 
+import is.hail.ExecStrategy
 import is.hail.TestUtils._
 import is.hail.expr.ir.TestUtils._
 import org.testng.annotations.{DataProvider, Test}
 import org.scalatest.testng.TestNGSuite
 
 class GenotypeFunctionsSuite extends TestNGSuite {
+
+  implicit val execStrats = ExecStrategy.javaOnly
 
   @DataProvider(name="gps")
   def gpData(): Array[Array[Any]] = Array(

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
-import is.hail.SparkSuite
+import is.hail.ExecStrategy.ExecStrategy
+import is.hail.{ExecStrategy, SparkSuite}
 import is.hail.TestUtils._
 import is.hail.annotations.BroadcastRow
 import is.hail.asm4s.Code
@@ -78,6 +79,8 @@ object IRSuite {
 class IRSuite extends SparkSuite {
   @BeforeClass def ensureHCDefined() { initializeHailContext() }
 
+  implicit val execStrats = ExecStrategy.values
+
   @Test def testI32() {
     assertEvalsTo(I32(5), 5)
   }
@@ -95,6 +98,8 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testStr() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     assertEvalsTo(Str("Hail"), "Hail")
   }
 
@@ -547,6 +552,8 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testGetTupleElement() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     val t = MakeTuple(FastIndexedSeq(I32(5), Str("abc"), NA(TInt32())))
     val na = NA(TTuple(TInt32(), TString()))
 
@@ -571,6 +578,8 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testArraySort() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     assertEvalsTo(ArraySort(NA(TArray(TInt32()))), null)
 
     val a = MakeArray(FastIndexedSeq(I32(-7), I32(2), NA(TInt32()), I32(2)), TArray(TInt32()))
@@ -581,6 +590,8 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testToSet() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     assertEvalsTo(ToSet(NA(TArray(TInt32()))), null)
 
     val a = MakeArray(FastIndexedSeq(I32(-7), I32(2), NA(TInt32()), I32(2)), TArray(TInt32()))
@@ -596,6 +607,8 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testToDict() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     assertEvalsTo(ToDict(NA(TArray(TTuple(FastIndexedSeq(TInt32(), TString()))))), null)
 
     val a = MakeArray(FastIndexedSeq(
@@ -629,6 +642,8 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testSetContains() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     val t = TSet(TInt32())
     assertEvalsTo(invoke("contains", NA(t), I32(2)), null)
 
@@ -647,6 +662,8 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testDictContains() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     val t = TDict(TInt32(), TString())
     assertEvalsTo(invoke("contains", NA(t), I32(2)), null)
 
@@ -666,6 +683,8 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testLowerBoundOnOrderedCollectionArray() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     val na = NA(TArray(TInt32()))
     assertEvalsTo(LowerBoundOnOrderedCollection(na, I32(0), onKey = false), null)
 
@@ -689,6 +708,8 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testLowerBoundOnOrderedCollectionSet() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     val na = NA(TSet(TInt32()))
     assertEvalsTo(LowerBoundOnOrderedCollection(na, I32(0), onKey = false), null)
 
@@ -708,6 +729,8 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testLowerBoundOnOrderedCollectionDict() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     val na = NA(TDict(TInt32(), TString()))
     assertEvalsTo(LowerBoundOnOrderedCollection(na, I32(0), onKey = true), null)
 
@@ -795,6 +818,8 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testArrayScan() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     def scan(array: IR, zero: IR, f: (IR, IR) => IR): IR =
       ArrayScan(array, zero, "_accum", "_elt", f(Ref("_accum", zero.typ), Ref("_elt", zero.typ)))
 
@@ -806,6 +831,8 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testLeftJoinRightDistinct() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     def join(left: IR, right: IR, keys: IndexedSeq[String]): IR = {
       val compF = { (l: IR, r: IR) =>
         ApplyComparisonOp(Compare(coerce[TStruct](l.typ).select(keys)._1), SelectFields(l, keys), SelectFields(r, keys))
@@ -874,6 +901,8 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testArrayAgg() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     val sumSig = AggSignature(Sum(), Seq(), None, Seq(TInt64()))
     assertEvalsTo(
       ArrayAgg(
@@ -884,6 +913,8 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testInsertFields() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     val s = TStruct("a" -> TInt64(), "b" -> TString())
     val emptyStruct = MakeStruct(Seq("a" -> NA(TInt64()), "b" -> NA(TString())))
 
@@ -982,6 +1013,8 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testGetField() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     val s = MakeStruct(Seq("a" -> NA(TInt64()), "b" -> Str("abc")))
     val na = NA(TStruct("a" -> TInt64(), "b" -> TString()))
 
@@ -991,15 +1024,19 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testTableCount() {
+    implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized, ExecStrategy.CxxCompile)
     assertEvalsTo(TableCount(TableRange(0, 4)), 0L)
     assertEvalsTo(TableCount(TableRange(7, 4)), 7L)
   }
 
   @Test def testTableGetGlobals() {
+    implicit val execStrats = ExecStrategy.interpretOnly
     assertEvalsTo(TableGetGlobals(TableMapGlobals(TableRange(0, 1), Literal(TStruct("a" -> TInt32()), Row(1)))), Row(1))
   }
 
   @Test def testTableAggregate() {
+    implicit val execStrats = ExecStrategy.interpretOnly
+
     val table = Table.range(hc, 3, Some(2))
     val countSig = AggSignature(Count(), Seq(), None, Seq())
     val count = ApplyAggOp(FastIndexedSeq.empty, None, FastIndexedSeq.empty, countSig)
@@ -1007,6 +1044,8 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testMatrixAggregate() {
+    implicit val execStrats = ExecStrategy.interpretOnly
+
     val matrix = MatrixTable.range(hc, 5, 5, None)
     val countSig = AggSignature(Count(), Seq(), None, Seq())
     val count = ApplyAggOp(FastIndexedSeq.empty, None, FastIndexedSeq.empty, countSig)
@@ -1014,6 +1053,8 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testGroupByKey() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     def tuple(k: String, v: Int): IR = MakeTuple(Seq(Str(k), I32(v)))
 
     def groupby(tuples: IR*): IR = GroupByKey(MakeArray(tuples, TArray(TTuple(TString(), TInt32()))))
@@ -1036,6 +1077,8 @@ class IRSuite extends SparkSuite {
 
   @Test(dataProvider = "compareDifferentTypes")
   def testComparisonOpDifferentTypes(a: Any, t1: Type, t2: Type) {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     assertEvalsTo(ApplyComparisonOp(EQ(t1, t2), In(0, t1), In(1, t2)), IndexedSeq(a -> t1, a -> t2), true)
     assertEvalsTo(ApplyComparisonOp(LT(t1, t2), In(0, t1), In(1, t2)), IndexedSeq(a -> t1, a -> t2), false)
     assertEvalsTo(ApplyComparisonOp(GT(t1, t2), In(0, t1), In(1, t2)), IndexedSeq(a -> t1, a -> t2), false)
@@ -1560,6 +1603,8 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testTableGetGlobalsSimplifyRules() {
+    implicit val execStrats = ExecStrategy.interpretOnly
+
     val t1 = TableType(TStruct("a" -> TInt32()), IndexedSeq("a"), TStruct("g1" -> TInt32(), "g2" -> TFloat64()))
     val t2 = TableType(TStruct("a" -> TInt32()), IndexedSeq("a"), TStruct("g3" -> TInt32(), "g4" -> TFloat64()))
     val tab1 = TableLiteral(TableValue(t1, BroadcastRow(Row(1, 1.1), t1.globalType, sc), RVD.empty(sc, t1.canonicalRVDType)))
@@ -1573,6 +1618,7 @@ class IRSuite extends SparkSuite {
 
 
   @Test def testAggLet() {
+    implicit val execStrats = ExecStrategy.interpretOnly
     val ir = TableRange(2, 2)
       .aggregate(
         aggLet(a = 'row('idx).toL + I64(1)) {

--- a/hail/src/test/scala/is/hail/expr/ir/IntervalSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IntervalSuite.scala
@@ -83,8 +83,6 @@ class IntervalSuite extends TestNGSuite {
     invoke("Interval", i.start, i.end, i.includesStart, i.includesEnd)
 
   @Test def contains() {
-    implicit val execStrats = ExecStrategy.values
-
     for (setInterval <- testIntervals; p <- points) {
       val interval = toIRInterval(setInterval)
       assert(eval(invoke("contains", interval, p)) == setInterval.contains(p))
@@ -92,8 +90,6 @@ class IntervalSuite extends TestNGSuite {
   }
 
   @Test def isEmpty() {
-    implicit val execStrats = ExecStrategy.values
-
     for (setInterval <- testIntervals) {
       val interval = toIRInterval(setInterval)
       assert(eval(invoke("isEmpty", interval)) == setInterval.definitelyEmpty())
@@ -101,8 +97,6 @@ class IntervalSuite extends TestNGSuite {
   }
 
   @Test def overlaps() {
-    implicit val execStrats = ExecStrategy.values
-
     for (setInterval1 <- testIntervals; setInterval2 <- testIntervals) {
       val interval1 = toIRInterval(setInterval1)
       val interval2 = toIRInterval(setInterval2)

--- a/hail/src/test/scala/is/hail/expr/ir/IntervalSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IntervalSuite.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir
 
+import is.hail.ExecStrategy
 import is.hail.TestUtils._
 import is.hail.expr.types.virtual.{TBoolean, TInt32, TInterval, TTuple}
 import is.hail.utils._
@@ -8,6 +9,8 @@ import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.Test
 
 class IntervalSuite extends TestNGSuite {
+
+  implicit val execStrats = ExecStrategy.javaOnly
 
   val tpoint1 = TTuple(TInt32())
   val tinterval1 = TInterval(tpoint1)
@@ -80,6 +83,8 @@ class IntervalSuite extends TestNGSuite {
     invoke("Interval", i.start, i.end, i.includesStart, i.includesEnd)
 
   @Test def contains() {
+    implicit val execStrats = ExecStrategy.values
+
     for (setInterval <- testIntervals; p <- points) {
       val interval = toIRInterval(setInterval)
       assert(eval(invoke("contains", interval, p)) == setInterval.contains(p))
@@ -87,6 +92,8 @@ class IntervalSuite extends TestNGSuite {
   }
 
   @Test def isEmpty() {
+    implicit val execStrats = ExecStrategy.values
+
     for (setInterval <- testIntervals) {
       val interval = toIRInterval(setInterval)
       assert(eval(invoke("isEmpty", interval)) == setInterval.definitelyEmpty())
@@ -94,6 +101,8 @@ class IntervalSuite extends TestNGSuite {
   }
 
   @Test def overlaps() {
+    implicit val execStrats = ExecStrategy.values
+
     for (setInterval1 <- testIntervals; setInterval2 <- testIntervals) {
       val interval1 = toIRInterval(setInterval1)
       val interval2 = toIRInterval(setInterval2)

--- a/hail/src/test/scala/is/hail/expr/ir/LiftLiteralsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/LiftLiteralsSuite.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir
 
-import is.hail.SparkSuite
+import is.hail.{ExecStrategy, SparkSuite}
 import is.hail.expr.types.virtual.TInt64
 import is.hail.utils.FastSeq
 import is.hail.TestUtils._
@@ -8,6 +8,8 @@ import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
 class LiftLiteralsSuite extends SparkSuite {
+  implicit val execStrats = ExecStrategy.interpretOnly
+
   @Test def testNestedGlobalsRewrite() {
     val tab = TableLiteral(TableRange(10, 1).execute(hc))
     val ir = TableGetGlobals(

--- a/hail/src/test/scala/is/hail/expr/ir/LocusFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/LocusFunctionsSuite.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir
 
+import is.hail.ExecStrategy
 import is.hail.TestUtils.assertEvalsTo
 import is.hail.expr.types.virtual.{TArray, TString}
 import is.hail.utils.FastSeq
@@ -9,6 +10,8 @@ import org.testng.annotations.Test
 import org.scalatest.testng.TestNGSuite
 
 class LocusFunctionsSuite extends TestNGSuite {
+
+  implicit val execStrats = ExecStrategy.javaOnly
 
   val grch38: ReferenceGenome = ReferenceGenome.GRCh38
 

--- a/hail/src/test/scala/is/hail/expr/ir/MathFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/MathFunctionsSuite.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir
 
+import is.hail.ExecStrategy
 import is.hail.expr.types._
 import is.hail.utils._
 import is.hail.TestUtils._
@@ -11,9 +12,13 @@ import org.scalatest.testng.TestNGSuite
 
 class MathFunctionsSuite extends TestNGSuite {
 
+  implicit val execStrats = ExecStrategy.values
+
   val tfloat = TFloat64()
 
   @Test def basicUnirootFunction() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     val ir = Uniroot("x",
       ApplyBinaryPrimOp(Add(), Ref("x", tfloat), F64(3)),
       F64(-6), F64(0))
@@ -22,6 +27,8 @@ class MathFunctionsSuite extends TestNGSuite {
   }
 
   @Test def unirootWithExternalBinding() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     val fn = ApplyBinaryPrimOp(Add(),
       Ref("x", tfloat),
       Ref("b", tfloat))
@@ -32,6 +39,8 @@ class MathFunctionsSuite extends TestNGSuite {
   }
 
   @Test def unirootWithRegionManipulation() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     def sum(array: IR): IR =
       ArrayFold(array, F64(0), "sum", "i", ApplyBinaryPrimOp(Add(), Ref("sum", tfloat), Ref("i", tfloat)))
     val fn = ApplyBinaryPrimOp(Add(),
@@ -44,6 +53,8 @@ class MathFunctionsSuite extends TestNGSuite {
   }
 
   @Test def isnan() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     assertEvalsTo(invoke("isnan", F32(0)), false)
     assertEvalsTo(invoke("isnan", F32(Float.NaN)), true)
 
@@ -52,6 +63,8 @@ class MathFunctionsSuite extends TestNGSuite {
   }
 
   @Test def is_finite() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     assertEvalsTo(invoke("is_finite", F32(0)), expected = true)
     assertEvalsTo(invoke("is_finite", F32(Float.MaxValue)), expected = true)
     assertEvalsTo(invoke("is_finite", F32(Float.NaN)), expected = false)
@@ -66,6 +79,8 @@ class MathFunctionsSuite extends TestNGSuite {
   }
 
   @Test def is_infinite() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     assertEvalsTo(invoke("is_infinite", F32(0)), expected = false)
     assertEvalsTo(invoke("is_infinite", F32(Float.MaxValue)), expected = false)
     assertEvalsTo(invoke("is_infinite", F32(Float.NaN)), expected = false)
@@ -81,6 +96,8 @@ class MathFunctionsSuite extends TestNGSuite {
 
 
   @Test def sign() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     assertEvalsTo(invoke("sign", I32(2)), 1)
     assertEvalsTo(invoke("sign", I32(0)), 0)
     assertEvalsTo(invoke("sign", I32(-2)), -1)
@@ -103,6 +120,8 @@ class MathFunctionsSuite extends TestNGSuite {
   }
 
   @Test def approxEqual() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     assertEvalsTo(invoke("approxEqual", F64(0.025), F64(0.0250000001), F64(1e-4), False(), False()), true)
     assertEvalsTo(invoke("approxEqual", F64(0.0154), F64(0.0156), F64(1e-4), True(), False()), false)
     assertEvalsTo(invoke("approxEqual", F64(0.0154), F64(0.0156), F64(1e-3), True(), False()), true)
@@ -114,6 +133,8 @@ class MathFunctionsSuite extends TestNGSuite {
   }
 
   @Test def entropy() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     assertEvalsTo(invoke("entropy", Str("")), 0.0)
     assertEvalsTo(invoke("entropy", Str("a")), 0.0)
     assertEvalsTo(invoke("entropy", Str("aa")), 0.0)
@@ -122,6 +143,8 @@ class MathFunctionsSuite extends TestNGSuite {
   }
 
   @Test def unirootIsStrictInMinAndMax() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     assertEvalsTo(
       Uniroot("x", Ref("x", tfloat), F64(-6), NA(tfloat)),
       null)

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir
 
+import is.hail.ExecStrategy
 import is.hail.annotations._
 import is.hail.check.{Gen, Prop}
 import is.hail.asm4s._
@@ -12,6 +13,8 @@ import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.{DataProvider, Test}
 
 class OrderingSuite extends TestNGSuite {
+
+  implicit val execStrats = ExecStrategy.values
 
   def recursiveSize(t: Type): Int = {
     val inner = t match {
@@ -242,6 +245,8 @@ class OrderingSuite extends TestNGSuite {
   }
 
   @Test def testDictGetOnRandomDict() {
+    implicit val execStrats = ExecStrategy.javaOnly
+
     val compareGen = Gen.zip(Type.genArb, Type.genArb).flatMap {
       case (k, v) =>
         Gen.zip(Gen.const(TDict(k, v)), TDict(k, v).genNonmissingValue, k.genNonmissingValue)

--- a/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir
 
-import is.hail.SparkSuite
+import is.hail.{ExecStrategy, SparkSuite}
 import is.hail.asm4s.Code
 import is.hail.expr.ir.functions.{IRRandomness, RegistryFunctions}
 import is.hail.expr.types._
@@ -51,6 +51,8 @@ object TestRandomFunctions extends RegistryFunctions {
 }
 
 class RandomFunctionsSuite extends SparkSuite {
+
+  implicit val execStrats = ExecStrategy.javaOnly
 
   val counter = ApplySeeded("counter_seeded", FastSeq(), 0L)
   val partitionIdx = ApplySeeded("pi_seeded", FastSeq(), 0L)

--- a/hail/src/test/scala/is/hail/expr/ir/SetFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/SetFunctionsSuite.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir
 
+import is.hail.ExecStrategy
 import is.hail.expr.types._
 import is.hail.TestUtils._
 import is.hail.expr.ir.TestUtils._
@@ -11,6 +12,8 @@ import org.scalatest.testng.TestNGSuite
 class SetFunctionsSuite extends TestNGSuite {
   val naa = NA(TArray(TInt32()))
   val nas = NA(TSet(TInt32()))
+
+  implicit val execStrats = ExecStrategy.javaOnly
 
   @Test def toSet() {
     assertEvalsTo(IRSet(3, 7), Set(3, 7))

--- a/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir
 
-import is.hail.SparkSuite
+import is.hail.{ExecStrategy, SparkSuite}
 import is.hail.TestUtils.assertEvalsTo
 import is.hail.expr.ir.TestUtils.IRAggCount
 import is.hail.expr.types.virtual.{TArray, TFloat64, TInt32, TStruct}
@@ -10,6 +10,8 @@ import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
 class SimplifySuite extends SparkSuite {
+  implicit val execStrats = ExecStrategy.interpretOnly
+
   @Test def testTableMultiWayZipJoinGlobalsRewrite() {
     hc
     val tmwzj = TableGetGlobals(TableMultiWayZipJoin(

--- a/hail/src/test/scala/is/hail/expr/ir/StringFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StringFunctionsSuite.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir
 
+import is.hail.ExecStrategy
 import is.hail.expr.types._
 import is.hail.TestUtils._
 import is.hail.expr.ir.TestUtils._
@@ -10,6 +11,8 @@ import org.testng.annotations.{DataProvider, Test}
 import org.scalatest.testng.TestNGSuite
 
 class StringFunctionsSuite extends TestNGSuite {
+  implicit val execStrats = ExecStrategy.javaOnly
+
   @Test def testRegexMatch() {
     assertEvalsTo(invoke("~", Str("a"), NA(TString())), null)
     assertEvalsTo(invoke("~", NA(TString()), Str("b")), null)

--- a/hail/src/test/scala/is/hail/expr/ir/StringLengthSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StringLengthSuite.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir
 
+import is.hail.ExecStrategy
 import is.hail.TestUtils._
 import is.hail.expr.types._
 import is.hail.expr.types.virtual.TString
@@ -7,6 +8,8 @@ import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.Test
 
 class StringLengthSuite extends TestNGSuite {
+  implicit val execStrats = ExecStrategy.javaOnly
+
   @Test def sameAsJavaStringLength() {
     assertEvalsTo(StringLength(Str("abc")), 3)
     assertEvalsTo(StringLength(Str("")), 0)

--- a/hail/src/test/scala/is/hail/expr/ir/StringSliceSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StringSliceSuite.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir
 
+import is.hail.ExecStrategy
 import is.hail.utils._
 import is.hail.TestUtils._
 import is.hail.expr.types._
@@ -8,6 +9,8 @@ import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.Test
 
 class StringSliceSuite extends TestNGSuite {
+  implicit val execStrats = ExecStrategy.javaOnly
+
   @Test def zeroToLengthIsIdentity() {
     assertEvalsTo(StringSlice(Str("abc"), I32(0), I32(3)), "abc")
   }

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir
 
-import is.hail.SparkSuite
+import is.hail.{ExecStrategy, SparkSuite}
 import is.hail.expr.ir.TestUtils._
 import is.hail.expr.types._
 import is.hail.expr.types.virtual.{TArray, TFloat64, TInt32, TString, TStruct}
@@ -27,6 +27,8 @@ class TableIRSuite extends SparkSuite {
   }
 
   def rangeKT: TableIR = Table.range(hc, 20, Some(4)).unkey().tir
+
+  implicit val execStrats = ExecStrategy.interpretOnly
 
   @BeforeClass def ensureHCDefined() {
     initializeHailContext()

--- a/hail/src/test/scala/is/hail/expr/ir/UtilFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/UtilFunctionsSuite.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir
 
+import is.hail.ExecStrategy
 import is.hail.TestUtils._
 import is.hail.expr.types._
 import is.hail.expr.types.virtual.{TArray, TBoolean}
@@ -7,6 +8,8 @@ import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.Test
 
 class UtilFunctionsSuite extends TestNGSuite {
+  implicit val execStrats = ExecStrategy.javaOnly
+
   val na = NA(TBoolean())
   val die = Die("it ded", TBoolean())
   val folded = ArrayFold(


### PR DESCRIPTION
- Added an implicit parameter to `assertEvalsTo` to specify the execution strategies you want to ensure support the IR instead of silently failing
- For every test suite that uses `assertEvalsTo`, declared the set of execution strategies that work for a majority of the tests in that suite, overriding individual test methods when necessary
- This gives pretty easy visibility as to the progress of every test block

cc: @cseed 