### PR TITLE
[apiserver, notebook2] notebook2 depends on apiserver

### DIFF
--- a/apiserver/environment.yml
+++ b/apiserver/environment.yml
@@ -8,6 +8,7 @@ dependencies:
 - seaborn=0.8.1
 - bokeh=0.12.13
 - jupyter=1.0.0
+- tornado<6
 - flask=1.0.2
 - pip=10.0.1
 - pip:

--- a/apiserver/hail-ci-deploy.sh
+++ b/apiserver/hail-ci-deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ex
+
+gcloud -q auth activate-service-account \
+  --key-file=/secrets/gcr-push-service-account-key.json
+
+gcloud -q auth configure-docker
+
+make deploy

--- a/notebook2/Makefile
+++ b/notebook2/Makefile
@@ -33,7 +33,6 @@ build/images/%/_PUSHED_LATEST_TAG: build/images/%/_BUILT
 
 $(IMAGE_SHORT_NAMES): %: build/images/%/_BUILT
 
-
 notebook-worker-images: $(PUSHED)
 	cat $^ > $@ && test $(APISERVER) && echo $(APISERVER) >> $@
 

--- a/notebook2/Makefile
+++ b/notebook2/Makefile
@@ -5,6 +5,7 @@ IMAGE_SHORT_NAMES = $(shell ls -1 images)
 BUILT = $(foreach image,$(IMAGE_SHORT_NAMES),build/images/$(image)/_BUILT)
 PUSHED = $(foreach image,$(IMAGE_SHORT_NAMES),build/images/$(image)/_PUSHED)
 PUSHED_LATEST_TAG = $(foreach image,$(IMAGE_SHORT_NAMES),build/images/$(image)/_PUSHED_LATEST_TAG)
+APISERVER = $(shell kubectl -n default get deployments apiserver -o json -o "jsonpath={.metadata.annotations.hail-jupyter-image}")
 
 .PHONY: $(IMAGE_SHORT_NAMES)
 
@@ -32,8 +33,9 @@ build/images/%/_PUSHED_LATEST_TAG: build/images/%/_BUILT
 
 $(IMAGE_SHORT_NAMES): %: build/images/%/_BUILT
 
+
 notebook-worker-images: $(PUSHED)
-	cat $^ > $@
+	cat $^ > $@ && test $(APISERVER) && echo $(APISERVER) >> $@
 
 build: $(BUILT) notebook-worker-images
 ifeq ($(CI_BUILD),true)

--- a/notebook2/Makefile
+++ b/notebook2/Makefile
@@ -5,7 +5,7 @@ IMAGE_SHORT_NAMES = $(shell ls -1 images)
 BUILT = $(foreach image,$(IMAGE_SHORT_NAMES),build/images/$(image)/_BUILT)
 PUSHED = $(foreach image,$(IMAGE_SHORT_NAMES),build/images/$(image)/_PUSHED)
 PUSHED_LATEST_TAG = $(foreach image,$(IMAGE_SHORT_NAMES),build/images/$(image)/_PUSHED_LATEST_TAG)
-APISERVER = $(shell kubectl -n default get deployments apiserver -o json -o "jsonpath={.metadata.annotations.hail-jupyter-image}")
+APISERVER_JUPYTER_IMAGE = $(shell kubectl -n default get deployments apiserver -o json -o "jsonpath={.metadata.annotations.hail-jupyter-image}")
 
 .PHONY: $(IMAGE_SHORT_NAMES)
 
@@ -34,7 +34,7 @@ build/images/%/_PUSHED_LATEST_TAG: build/images/%/_BUILT
 $(IMAGE_SHORT_NAMES): %: build/images/%/_BUILT
 
 notebook-worker-images: $(PUSHED)
-	cat $^ > $@ && test $(APISERVER) && echo $(APISERVER) >> $@
+	cat $^ > $@ && test $(APISERVER_JUPYTER_IMAGE) && echo $(APISERVER_JUPYTER_IMAGE) >> $@
 
 build: $(BUILT) notebook-worker-images
 ifeq ($(CI_BUILD),true)

--- a/notebook2/notebook/notebook.py
+++ b/notebook2/notebook/notebook.py
@@ -138,7 +138,8 @@ def start_pod(jupyter_token, image, name, user_id):
                     'jupyter',
                     'notebook',
                     f'--NotebookApp.token={jupyter_token}',
-                    f'--NotebookApp.base_url=/instance/{pod_id}/'
+                    f'--NotebookApp.base_url=/instance/{pod_id}/',
+                    "--ip", "0.0.0.0", "--no-browser"
                 ],
                 name='default',
                 image=image,
@@ -285,7 +286,7 @@ def notebook_page():
         return render_template('notebook.html',
                                form_action_url=external_url_for('notebook'),
                                images=list(WORKER_IMAGES),
-                               default='hail')
+                               default='hail-jupyter')
 
     session['notebook'] = notebooks[0]
 

--- a/notebook2/notebook/templates/notebook-form.html
+++ b/notebook2/notebook/templates/notebook-form.html
@@ -1,4 +1,4 @@
 <form action="{{ form_action_url }}" method="post">
-  <input type="hidden" name="image" value="hail" />
+  <input type="hidden" name="image" value="hail-jupyter" />
   <button>Create</button>
 </form>

--- a/projects.yaml
+++ b/projects.yaml
@@ -4,13 +4,14 @@
   dependencies: ["batch"]
 - project: cloudtools
 - project: etc
-- project: notebook
-- project: notebook2
 - project: gateway
 - project: hail
 - project: apiserver
 - project: image-fetcher
 - project: letsencrypt
+- project: notebook
+- project: notebook2
+  dependencies: ["apiserver"]
 - project: pipeline
   dependencies: ["batch"]
 - project: scorecard


### PR DESCRIPTION
This adds apiserver to CI, and modifies notebook to use the hail-jupyter image that the former defines.

To ensure that it's using the appropriate image, notebook2's Makefile has been modified to read the ["hail-jupyter-image" label that the apiserver deployment defines](https://github.com/hail-is/hail/blob/master/apiserver/deployment.yaml.in#L74)
  - the Makefile tests that we get a non-empty string from the kubectl command used to read this value before proceeding

Stacks on https://github.com/hail-is/hail/pull/5592, without which notebook2 wouldn't work when also defaulting to hail-jupyter.

I used the "dependencies" property in `projects.yaml` as well as presenting the proper order, but that doesn't look like it's actually used yet. Still, it seems like a good idea, so if that is planned still I would like notebook2 to take advantage.

```
..//env-setup.sh:for project in $(cat projects.yaml | grep '^- project: ' | sed 's/^- project: //')
..//env-setup.sh-do
..//env-setup.sh-    if [[ -e $project/environment.yml ]]
..//env-setup.sh-    then
..//env-setup.sh-        ${CONDA_BINARY} env create -f $project/environment.yml || ${CONDA_BINARY} env update -f $project/environment.yml
..//env-setup.sh-    fi
..//env-setup.sh-done
```

```
..//hail-ci-build.sh:PROJECTS=$(cat projects.yaml | grep '^- project: ' | sed 's/^- project: //')
..//hail-ci-build.sh-
..//hail-ci-build.sh-for project in $PROJECTS; do
..//hail-ci-build.sh-    if [[ -e $project/hail-ci-build.sh ]]; then
..//hail-ci-build.sh-        CHANGED=$(python3 project-changed.py target/$TARGET_BRANCH $project)
..//hail-ci-build.sh-        if [[ $CHANGED != no ]]; then
..//hail-ci-build.sh-            (cd $project && /bin/bash hail-ci-build.sh)
..//hail-ci-build.sh-        fi
..//hail-ci-build.sh-    fi
..//hail-ci-build.sh-done
```

cc @cseed, @danking 