### PR TITLE
Parse tabix during reading, not during import

### DIFF
--- a/hail/src/main/scala/is/hail/io/tabix/TabixReader.scala
+++ b/hail/src/main/scala/is/hail/io/tabix/TabixReader.scala
@@ -105,19 +105,22 @@ class TabixReader(val filePath: String, hConf: hd.conf.Configuration, idxFilePat
   val index: Tabix = hConf.readFile(indexPath) { is =>
     var buf = new Array[Byte](4)
     is.read(buf, 0, 4) // read magic bytes "TBI\1"
-    assert(Magic sameElements buf, s"""magic number failed validation
-      |magic: ${ Magic.mkString("[", ",", "]") }
-      |data : ${ buf.mkString("[", ",", "]") }""".stripMargin)
+    if (!(Magic sameElements buf))
+      fatal(s"""magic number failed validation
+        |magic: ${ Magic.mkString("[", ",", "]") }
+        |data : ${ buf.mkString("[", ",", "]") }""".stripMargin)
     val seqs = new Array[String](readInt(is))
     val format = readInt(is)
     // Require VCF for now
-    assert(format == 2, s"Hail only supports tabix indexing for VCF, found format code ${ format }")
+    if (format != 2)
+      fatal(s"Hail only supports tabix indexing for VCF, found format code ${ format }")
     val colSeq = readInt(is)
     val colBeg = readInt(is)
     val colEnd = readInt(is)
     val meta = readInt(is)
     // meta char for VCF is '#'
-    assert(meta == '#', s"Meta character was ${ meta }, should be '#' for VCF")
+    if (meta != '#')
+      fatal(s"Meta character was ${ meta }, should be '#' for VCF")
     val chr2tid = new mutable.HashMap[String, Int]()
     readInt(is) // unused, need to consume
 

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -929,7 +929,7 @@ object LoadVCF {
   }
 }
 
-case class PartitionedVCFPartition(index: Int, chrom: String, start: Int, end: Int, reg: Array[TbiPair]) extends Partition
+case class PartitionedVCFPartition(index: Int, chrom: String, start: Int, end: Int) extends Partition
 
 class PartitionedVCFRDD(
   @(transient@param) sc: SparkContext,
@@ -942,7 +942,12 @@ class PartitionedVCFRDD(
   def compute(split: Partition, context: TaskContext): Iterator[String] = {
     val p = split.asInstanceOf[PartitionedVCFPartition]
 
-    val lines = new TabixLineIterator(confBc, file, p.reg)
+    val reg = {
+      val r = new TabixReader(file, confBc.value.value)
+      val tid = r.chr2tid(p.chrom)
+      r.queryPairs(tid, p.start - 1, p.end)
+    }
+    val lines = new TabixLineIterator(confBc, file, reg)
 
     // clean up
     val context = TaskContext.get
@@ -1225,6 +1230,12 @@ class VCFsReader(
       rangeBounds)
   }
 
+  val partitions = partitioner.rangeBounds.zipWithIndex.map { case (b, i) =>
+    val start = b.start.asInstanceOf[Row].getAs[Locus](0)
+    val end = b.end.asInstanceOf[Row].getAs[Locus](0)
+    PartitionedVCFPartition(i, start.contig, start.position, end.position): Partition
+  }
+
   private val fileInfo = {
     val localHConfBc = hConfBc
     val localFile1 = file1
@@ -1234,7 +1245,6 @@ class VCFsReader(
     val localFilterAndReplace = filterAndReplace
     val localGenotypeSignature = header1.genotypeSignature
     val localVASignature = header1.vaSignature
-    val partitionerBc = partitioner.broadcast(sc)
 
     sc.parallelize(files, files.length).map { file =>
       val hConf = localHConfBc.value.value
@@ -1254,29 +1264,15 @@ class VCFsReader(
              |   $localFile1: $localVASignature
              |   $file: ${header.vaSignature}""".stripMargin)
 
-      val r = new TabixReader(file, hConf)
-      val partitions = partitionerBc.value.rangeBounds.zipWithIndex.map { case (b, i) =>
-        val start = b.start.asInstanceOf[Row].getAs[Locus](0)
-        val end = b.end.asInstanceOf[Row].getAs[Locus](0)
 
-        val contig = start.contig
-        val startPos = start.position
-        val endPos = end.position
-
-        val tid = r.chr2tid(contig)
-        val reg = r.queryPairs(tid, startPos - 1, endPos)
-
-        PartitionedVCFPartition(i, start.contig, start.position, end.position, reg): Partition
-      }
-
-      (header.sampleIds, partitions)
+      header.sampleIds
     }
       .collect()
   }
 
-  def readFile(file: String, i: Int): MatrixIR = {
-    val (sampleIDs, partitions) = fileInfo(i)
 
+  def readFile(file: String, i: Int): MatrixIR = {
+    val sampleIDs = fileInfo(i)
     val localEntryFloatType = entryFloatType
     val localCallFields = callFields
     val localHeaderLines1Bc = headerLines1Bc


### PR DESCRIPTION
Saves memory on the master but has an unfortunate side effect of
drastically multiplying the number of times a tabix file is read, as it
is read once per partition per vcf rather than once per vcf.

This change places tabix reading in a more critical path of the gVCF
merger, I would appreciate a more detailed performance audit of that
code, in addition to looking over this change.

From my measurements it looks like we pay a 20-30 second cost per partition of 100 gVCFs

cc: @cseed 