### PR TITLE
fix potential memory buffer bug

### DIFF
--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -246,10 +246,11 @@ final class StreamBlockInputBuffer(in: InputStream) extends InputBlockBuffer {
 }
 
 final class MemoryBuffer extends Serializable {
-  var capacity: Int = 8
-  var mem: Array[Byte] = new Array[Byte](capacity)
+  var mem: Array[Byte] = new Array[Byte](8)
   var pos: Int = 0
   var end: Int = 0
+
+  def capacity: Int = mem.length
 
   def clear() {
     pos = 0
@@ -261,8 +262,7 @@ final class MemoryBuffer extends Serializable {
   }
 
   def grow(n: Int) {
-    capacity = math.max(capacity * 2, end + n)
-    mem = util.Arrays.copyOf(mem, capacity)
+    mem = util.Arrays.copyOf(mem, math.max(capacity * 2, end + n))
   }
 
   def copyFrom(src: MemoryBuffer) {


### PR DESCRIPTION
This might fix the bug you're seeing.  Capacity (which should have been tracked separately) wasn't getting updated correctly in copyFrom, so if you did two copyFrom's, the second one would truncate the data.