### PR TITLE
[hail] Add map of ints to Arrays of IRs to context, use in import_vcfs

### DIFF
--- a/hail/python/hail/ir/base_ir.py
+++ b/hail/python/hail/ir/base_ir.py
@@ -133,3 +133,21 @@ class BlockMatrixIR(BaseIR):
 
     def parse(self, code, ref_map={}, ir_map={}):
         return Env.hail().expr.ir.IRParser.parse_blockmatrix_ir(code, ref_map, ir_map)
+
+
+class JIRVectorReference(object):
+    def __init__(self, jid, length, item_type):
+        self.jid = jid
+        self.length = length
+        self.item_type = item_type
+
+    def __len__(self):
+        return self.length
+
+    def __del__(self):
+        try:
+            Env.hc()._jhc.pyRemoveIrVector(self.jid)
+        # there is only so much we can do if the attempt to remove the unused IR fails,
+        # especially since this will often get called during interpreter shutdown.
+        except Exception:
+            pass

--- a/hail/python/hail/ir/matrix_ir.py
+++ b/hail/python/hail/ir/matrix_ir.py
@@ -254,7 +254,7 @@ class MatrixAggregateColsByKey(MatrixIR):
             child_typ.row_type,
             child_typ.row_key,
             self.entry_expr.typ)
-            
+
 
 class MatrixExplodeRows(MatrixIR):
     def __init__(self, child, path):
@@ -278,7 +278,7 @@ class MatrixExplodeRows(MatrixIR):
             new_row_type,
             child_typ.row_key,
             child_typ.entry_type)
-            
+
 
 class MatrixRepartition(MatrixIR):
     def __init__(self, child, n, strategy):
@@ -483,3 +483,15 @@ class JavaMatrix(MatrixIR):
 
     def _compute_type(self):
         self._type = hl.tmatrix._from_java(self._jir.typ())
+
+class JavaMatrixVectorRef(MatrixIR):
+    def __init__(self, vec_ref, idx):
+        super().__init__()
+        self.vec_ref = vec_ref
+        self.idx = idx
+
+    def render(self, r):
+        return f'(JavaMatrixVectorRef {self.vec_ref.jid} {self.idx})'
+
+    def _compute_type(self):
+        self._type = self.vec_ref.item_type

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -4,7 +4,8 @@ import java.io.{File, InputStream}
 import java.util.Properties
 
 import is.hail.annotations._
-import is.hail.expr.ir.{IRParser, MatrixIR, TextTableReader}
+import is.hail.expr.Parser
+import is.hail.expr.ir.{BaseIR, IRParser, MatrixIR, TextTableReader}
 import is.hail.expr.types.physical.PStruct
 import is.hail.expr.types.virtual._
 import is.hail.io.bgen.IndexBgen
@@ -365,6 +366,10 @@ object HailContext {
       }
     }
   }
+
+  def pyRemoveIrVector(id: Int) {
+    get.irVectors.remove(id)
+  }
 }
 
 class HailContext private(val sc: SparkContext,
@@ -379,6 +384,20 @@ class HailContext private(val sc: SparkContext,
   val flags: HailFeatureFlags = new HailFeatureFlags()
 
   var checkRVDKeys: Boolean = false
+
+  private var nextVectorId: Int = 0
+  val irVectors: mutable.Map[Int, Array[_ <: BaseIR]] = mutable.Map.empty[Int, Array[_ <: BaseIR]]
+
+  def addIrVector(irArray: Array[_ <: BaseIR]): Int = {
+    val typ = irArray.head.typ
+    irArray.foreach { ir =>
+      if (ir.typ != typ)
+        fatal("all ir vector items must have the same type")
+    }
+    irVectors(nextVectorId) = irArray
+    nextVectorId += 1
+    nextVectorId - 1
+  }
 
   def version: String = is.hail.HAIL_PRETTY_VERSION
 
@@ -517,7 +536,7 @@ class HailContext private(val sc: SparkContext,
     implicit val formats = defaultJSONFormats
     JsonMethods.compact(Extraction.decompose(metadata))
   }
-  
+
   def importMatrix(files: java.util.List[String],
     rowFields: java.util.Map[String, String],
     keyNames: java.util.List[String],

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1149,6 +1149,10 @@ object IRParser {
       case "JavaMatrix" =>
         val name = identifier(it)
         env.irMap(name).asInstanceOf[MatrixIR]
+      case "JavaMatrixVectorRef" =>
+        val id = int32_literal(it)
+        val idx = int32_literal(it)
+        HailContext.get.irVectors(id)(idx).asInstanceOf[MatrixIR]
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/types/MatrixType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/MatrixType.scala
@@ -9,7 +9,7 @@ import is.hail.utils._
 import is.hail.variant.ReferenceGenome
 import org.apache.spark.sql.Row
 import org.json4s.CustomSerializer
-import org.json4s.JsonAST.JString
+import org.json4s.JsonAST.{JArray, JObject, JString}
 
 
 class MatrixTypeSerializer extends CustomSerializer[MatrixType](format => (
@@ -190,5 +190,16 @@ case class MatrixType(
   def referenceGenome: ReferenceGenome = {
     val firstKeyField = rowKeyStruct.types(0)
     firstKeyField.asInstanceOf[TLocus].rg.asInstanceOf[ReferenceGenome]
+  }
+
+  def pyJson: JObject = {
+    JObject(
+      "row" -> JString(rowType.toString),
+      "row_key" -> JArray(rowKey.toList.map(JString(_))),
+      "col" -> JString(colType.toString),
+      "col_key" -> JArray(colKey.toList.map(JString(_))),
+      "entry" -> JString(entryType.toString),
+      "global" -> JString(globalType.toString)
+    )
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -236,7 +236,7 @@ class IRSuite extends SparkSuite {
     assertExpected(TInt32(), 5, null, null)
     assertExpected(TInt32(), null, 2, null)
     assertExpected(TInt32(), null, null, null)
-    
+
     assertExpected(TInt64(), 5L, 2L, 10L)
     assertExpected(TInt64(), 5L, null, null)
     assertExpected(TInt64(), null, 2L, null)
@@ -1377,7 +1377,7 @@ class IRSuite extends SparkSuite {
         .ast.asInstanceOf[MatrixRead]
       val vcf = is.hail.TestUtils.importVCF(hc, "src/test/resources/sample.vcf")
         .ast.asInstanceOf[MatrixRead]
-      
+
       val bgenReader = MatrixBGENReader(FastIndexedSeq("src/test/resources/example.8bits.bgen"), None, Map.empty[String, String], None, None, None)
       val bgen = MatrixRead(bgenReader.fullMatrixType, false, false, bgenReader)
 
@@ -1529,6 +1529,17 @@ class IRSuite extends SparkSuite {
     val s = s"(JavaBlockMatrix __uid1)"
     val x2 = IRParser.parse_blockmatrix_ir(s, IRParserEnvironment(refMap = Map.empty, irMap = Map("__uid1" -> cached)))
     assert(x2 eq cached)
+  }
+
+  @Test def testContextSavedMatrixIR() {
+    val cached = MatrixTable.range(hc, 3, 8, None).ast
+    val id = hc.addIrVector(Array(cached))
+    val s = s"(JavaMatrixVectorRef $id 0)"
+    val x2 = IRParser.parse_matrix_ir(s, IRParserEnvironment(refMap = Map.empty, irMap = Map.empty))
+    assert(cached eq x2)
+
+    is.hail.HailContext.pyRemoveIrVector(id)
+    assert(hc.irVectors.get(id) eq None)
   }
 
   @Test def testEvaluations() {


### PR DESCRIPTION
This should cut down on expensive py4j calls in import_vcfs, and the
infrastructure should also help us with complex java <=> python
interchanges, by passing the releavant information via primitive types
or strings in all cases.

Brief summary:

- Add vectorIrs map to HailContext to store lists of irs that may need
be referenced later

- Switch import_vcfs to returning a json string with the id of the IR
array that is now stored in the vectorIrs map, along with the size of
that array and its type, suitable to passed to tmatrix._from_json.

- Add JIRVectorReference to python, which is the deserialized version of
the returned json.

- Add JavaMatrixVectorRef, which represents a single IR contained in
some stored IR array.