### PR TITLE
[docker, scorecard] add docker base image, use in scorecard

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -6,9 +6,15 @@ RUN apt-get update && \
     unzip bzip2 \
     wget curl \
     emacs25-nox \
-    default-jdk \
+    default-jdk-headless \
     python3 python3-pip && \
   rm -rf /var/lib/apt/lists/*
+
+# source: https://cloud.google.com/storage/docs/gsutil_install#linux
+RUN /bin/sh -c 'curl https://sdk.cloud.google.com | bash' && \
+    mv /root/google-cloud-sdk / && \
+    /google-cloud-sdk/bin/gcloud components install beta kubectl
+ENV PATH $PATH:/google-cloud-sdk/bin
 
 RUN python3 -m pip install -U \
   pip decorator pylint pytest flake8 \
@@ -18,9 +24,3 @@ RUN python3 -m pip install -U \
   werkzeug flask flask-cors Flask_Sockets \
   kubernetes google-cloud-storage \
   PyGithub cerberus humanize libsass authlib
-
-# source: https://cloud.google.com/storage/docs/gsutil_install#linux
-RUN /bin/sh -c 'curl https://sdk.cloud.google.com | bash' && \
-    mv /root/google-cloud-sdk / && \
-    /google-cloud-sdk/bin/gcloud components install beta kubectl
-ENV PATH $PATH:/google-cloud-sdk/bin

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -14,7 +14,7 @@ RUN python3 -m pip install -U \
   pip decorator pylint pytest flake8 \
   requests \
   jinja2 \
-  aiohttp aiodns aiohttp_jinja2 uvloop>=0.12 \
+  pyasyncinit aiohttp aiodns aiohttp_jinja2 uvloop>=0.12 \
   werkzeug flask flask-cors Flask_Sockets \
   kubernetes google-cloud-storage \
   PyGithub cerberus humanize libsass authlib

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,0 +1,26 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && \
+  apt-get -y install \
+    htop \
+    unzip bzip2 \
+    wget curl \
+    emacs25-nox \
+    default-jdk \
+    python3 python3-pip && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install -U \
+  pip decorator pylint pytest flake8 \
+  requests \
+  jinja2 \
+  aiohttp aiodns aiohttp_jinja2 uvloop>=0.12 \
+  werkzeug flask flask-cors Flask_Sockets \
+  kubernetes google-cloud-storage \
+  PyGithub cerberus humanize libsass authlib
+
+# source: https://cloud.google.com/storage/docs/gsutil_install#linux
+RUN /bin/sh -c 'curl https://sdk.cloud.google.com | bash' && \
+    mv /root/google-cloud-sdk / && \
+    /google-cloud-sdk/bin/gcloud components install beta kubectl
+ENV PATH $PATH:/google-cloud-sdk/bin

--- a/docker/Dockerfile.spark-base
+++ b/docker/Dockerfile.spark-base
@@ -1,0 +1,11 @@
+FROM base
+
+RUN wget -O spark-2.2.0-bin-hadoop2.7.tgz https://archive.apache.org/dist/spark/spark-2.2.0/spark-2.2.0-bin-hadoop2.7.tgz && \
+  tar xzf spark-2.2.0-bin-hadoop2.7.tgz && \
+  rm spark-2.2.0-bin-hadoop2.7.tgz
+
+RUN wget -O /spark-2.2.0-bin-hadoop2.7/jars/gcs-connector-hadoop2-latest.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-latest.jar
+COPY core-site.xml /spark-2.2.0-bin-hadoop2.7/conf/core-site.xml
+
+ENV SPARK_HOME /spark-2.2.0-bin-hadoop2.7
+ENV PATH "$PATH:$SPARK_HOME/sbin:$SPARK_HOME/bin"

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,21 @@
+.PHONY: build push deploy
+
+PROJECT = $(shell gcloud config get-value project)
+
+BASE_IMAGE = gcr.io/$(PROJECT)/base:$(shell docker images -q --no-trunc base:latest | sed -e 's,[^:]*:,,')
+SPARK_BASE_IMAGE = gcr.io/$(PROJECT)/spark-base:$(shell docker images -q --no-trunc spark-base:latest | sed -e 's,[^:]*:,,')
+
+build:
+	-docker pull ubuntu:18.04
+	-docker pull gcr.io/$(PROJECT)/base
+	-docker pull gcr.io/$(PROJECT)/spark-base
+	docker build . -t base -f Dockerfile.base --cache-from base,ubuntu:18.04
+	docker build . -t spark-base -f Dockerfile.spark-base --cache-from spark-base,base,ubuntu:18.04
+
+push: build
+	docker tag base $(BASE_IMAGE)
+	docker push $(BASE_IMAGE)
+	docker tag spark-base $(SPARK_BASE_IMAGE)
+	docker push $(SPARK_BASE_IMAGE)
+
+deploy: push

--- a/docker/core-site.xml
+++ b/docker/core-site.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+
+  <property>
+    <name>google.cloud.auth.service.account.enable</name>
+    <value>true</value>
+  </property>
+  
+  <property>
+    <name>google.cloud.auth.service.account.json.keyfile</name>
+    <value>/hail-vdc-sa-key/hail-vdc-sa-key.json</value>
+  </property>
+  
+</configuration>

--- a/docker/hail-ci-build.sh
+++ b/docker/hail-ci-build.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -ex
-
-gcloud -q auth activate-service-account \
-  --key-file=/secrets/gcr-push-service-account-key.json
-
-gcloud -q auth configure-docker
-
-make build

--- a/docker/hail-ci-build.sh
+++ b/docker/hail-ci-build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ex
+
+make build

--- a/docker/hail-ci-build.sh
+++ b/docker/hail-ci-build.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 set -ex
 
+gcloud -q auth activate-service-account \
+  --key-file=/secrets/gcr-push-service-account-key.json
+
+gcloud -q auth configure-docker
+
 make build

--- a/docker/hail-ci-deploy.sh
+++ b/docker/hail-ci-deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ex
+
+gcloud -q auth activate-service-account \
+  --key-file=/secrets/gcr-push-service-account-key.json
+
+gcloud -q auth configure-docker
+
+make deploy

--- a/projects.yaml
+++ b/projects.yaml
@@ -1,3 +1,4 @@
+- project: docker
 - project: auth-gateway
 - project: batch
 - project: ci
@@ -15,6 +16,7 @@
 - project: pipeline
   dependencies: ["batch"]
 - project: scorecard
+  dependencies: ["docker"]
 - project: site
 - project: upload
 - project: vdc

--- a/scorecard/Dockerfile
+++ b/scorecard/Dockerfile
@@ -1,13 +1,7 @@
-FROM continuumio/miniconda
-MAINTAINER Hail Team <hail@broadinstitute.org>
-
-COPY environment.yml .
-RUN conda env create scorecard -f environment.yml && \
-    rm -f environment.yml && \
-    rm -rf /home/root/.conda/pkgs/*
+FROM base
 
 COPY scorecard /scorecard
 
 EXPOSE 5000
 
-CMD ["bash", "-c", "source activate scorecard; python /scorecard/scorecard.py"]
+CMD ["bash", "-c", "python3 /scorecard/scorecard.py"]

--- a/scorecard/Makefile
+++ b/scorecard/Makefile
@@ -2,23 +2,24 @@
 
 PROJECT = $(shell gcloud config get-value project)
 
-build:
-	docker build . -t scorecard
+SCORECARD_IMAGE = gcr.io/$(PROJECT)/scorecard:$(shell docker images -q --no-trunc scorecard:latest | sed -e 's,[^:]*:,,')
 
-push: IMAGE = gcr.io/$(PROJECT)/scorecard:$(shell docker images -q --no-trunc scorecard | sed -e 's,[^:]*:,,')
+build:
+	-docker pull gcr.io/$(PROJECT)/scorecard
+	docker build . -t scorecard --cache-from scorecard,base,ubuntu:18.04
+
 push: build
-	echo $(IMAGE) > scorecard-image
-	docker tag scorecard $(IMAGE)
-	docker push $(IMAGE)
+	docker tag scorecard $(SCORECARD_IMAGE)
+	docker push $(SCORECARD_IMAGE)
 
 run-docker: build
-	docker run -i -p 5000:5000 -v secrets:/secrets -t scorecard
+	docker run -i -p 5000:5000 -v `pwd`/secrets:/secrets -t scorecard
 
 run:
 	GITHUB_TOKEN_PATH=secrets/scorecard-github-access-token.txt python scorecard/scorecard.py
 
 deploy: push
 	sed -e "s,@sha@,$(shell git rev-parse --short=12 HEAD)," \
-	  -e "s,@image@,$(shell cat scorecard-image)," \
+	  -e "s,@image@,$(SCORECARD_IMAGE)," \
 	  < deployment.yaml.in > deployment.yaml
 	kubectl -n default apply -f deployment.yaml

--- a/scorecard/environment.yml
+++ b/scorecard/environment.yml
@@ -1,9 +1,0 @@
-name: scorecard
-dependencies:
-- python=3.7
-- flask
-- flask-cors
-- humanize
-- pip
-- pip:
-    - PyGithub


### PR DESCRIPTION
FYI @danking @jigold @akotlar This might be contentious.  The wisdom is to make docker images small, but I think this will greatly improve our docker pull/build/push times.

Watching some recent builds and deploys, it seems insane, the time we spend and the number of images we build with (mostly) duplicate contents.  The goal here is to build a common base image for all containers in our cluster.  I built on Ubuntu instead of Debian because it has Python 3.6 by default.  It contains useful stuff I often find myself installing when debugging inside the cluster (htop, emacs, others should feel free to add tools they like), python3 and pip packages needed by any service (no conda, thank you very much), jvm and the google-cloud-sdk with kubectl.  I also build a spark-base (built on base) with spark and the google hadoop connector.

Currently, I just use the base in scorecard.  If we like this, I'll convert the other services (and pr-builder, which is hopefully not long for this world) on top of this.  I will also make image fetcher fetch the base image as well as the notebook images.

The current scorecard image is ~900MB.  The new base image is ~2GB, and scorecard adds an additional 15KB to that.
