### PR TITLE
[hail] Clean up readers using Task Completion Listeners

### DIFF
--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -482,6 +482,9 @@ class HailContext private(val sc: SparkContext,
         val p = split.asInstanceOf[FilePartition]
         val filename = path + "/parts/" + p.file
         val in = localHadoopConfBc.value.value.unsafeReader(filename)
+        context.addTaskCompletionListener { _ =>
+          in.close()
+        }
         read(p.index, in, context.taskMetrics().inputMetrics)
       }
 

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -482,9 +482,7 @@ class HailContext private(val sc: SparkContext,
         val p = split.asInstanceOf[FilePartition]
         val filename = path + "/parts/" + p.file
         val in = localHadoopConfBc.value.value.unsafeReader(filename)
-        context.addTaskCompletionListener { _ =>
-          in.close()
-        }
+        context.addTaskCompletionListener(_ => in.close())
         read(p.index, in, context.taskMetrics().inputMetrics)
       }
 

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -953,7 +953,7 @@ class PartitionedVCFRDD(
 
     // clean up
     val context = TaskContext.get
-    context.addTaskCompletionListener { context =>
+    context.addTaskCompletionListener { _ =>
       lines.close()
     }
 

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -1702,6 +1702,7 @@ class BlockMatrixReadRowBlockedRDD(
     val filename = path + "/parts/" + pFile
     val is = localHadoopConfBc.value.value.unsafeReader(filename)
     val in = BlockMatrix.bufferSpec.buildInputBuffer(is)
+    TaskContext.get.addTaskCompletionListener(_ => in.close())
 
     val rows = in.readInt()
     val cols = in.readInt()

--- a/hail/src/main/scala/is/hail/linalg/RowMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/RowMatrix.scala
@@ -216,6 +216,7 @@ class ReadBlocksAsRowsRDD(path: String,
 
                 val is = sHadoopBc.value.value.unsafeReader(filename)
                 val in = BlockMatrix.bufferSpec.buildInputBuffer(is)
+                TaskContext.get.addTaskCompletionListener(_ => in.close())
 
                 val nColsInBlock = gp.blockColNCols(blockCol)
 

--- a/hail/src/main/scala/is/hail/utils/Py4jUtils.scala
+++ b/hail/src/main/scala/is/hail/utils/Py4jUtils.scala
@@ -102,9 +102,8 @@ trait Py4jUtils {
     (n / factor.toDouble).formatted("%.1f")
   }
 
-  def readFile(path: String, hc: HailContext, buffSize: Int): HadoopPyReader = hc.hadoopConf.readFile(path) { in =>
+  def readFile(path: String, hc: HailContext, buffSize: Int): HadoopPyReader =
     new HadoopPyReader(hc.hadoopConf.unsafeReader(path), buffSize)
-  }
 
   def writeFile(path: String, hc: HailContext, exclusive: Boolean): HadoopPyWriter = {
     if (exclusive && hc.hadoopConf.exists(path))


### PR DESCRIPTION
`HailContext.readPartitions` is used by RVDSpec.read. I am surprised we haven't had bug reports related to leaving file handles open. The first (and only) report of which I'm aware [comes from Carlos De Niz via Zulip](https://hail.zulipchat.com/#narrow/stream/123010-Hail-0.2E2.20support/topic/stats.20to.20multiple.20fields)

cc: @tpoterba, can you look at the py4j bit? Seems like we unnecessarily opened the file twice, but I'm not sure I understand the intention.