### PR TITLE
[c++] Add NDArray in C++ and emit MakeNDArray and NDArrayRef

### DIFF
--- a/hail/src/main/resources/include/hail/NDArray.h
+++ b/hail/src/main/resources/include/hail/NDArray.h
@@ -11,12 +11,12 @@ struct NDArray {
   const char *data;
 };
 
-NDArray make_ndarray(size_t elem_size, std::vector<long> shape, char *data) {
+NDArray make_ndarray(size_t elem_size, std::vector<long> shape, const char *data) {
   NDArray nd;
   nd.flags = 0;
   nd.elem_size = elem_size;
   nd.shape = shape;
-  nd.data = ArrayAddrImpl<true, 8, 8>::load_element(data, 0);
+  nd.data = data;
 
   std::vector<long> strides(shape.size());
   strides[shape.size() - 1] = 1;

--- a/hail/src/main/resources/include/hail/NDArray.h
+++ b/hail/src/main/resources/include/hail/NDArray.h
@@ -6,17 +6,11 @@
 struct NDArray {
   int flags;
   size_t elem_size;
-  std::vector<int> shape;
-  std::vector<int> stride;
+  std::vector<long> shape;
   char *data;
 };
 
-NDArray make_ndarray(size_t elem_size, std::vector<int> shape, char *data);
-
-template<typename T>
-T load_ndarray_element(NDArray nd, std::vector<int> indices);
-
-NDArray make_ndarray(size_t elem_size, std::vector<int> shape, char *data) {
+NDArray make_ndarray(size_t elem_size, std::vector<long> shape, char *data) {
   NDArray nd;
   nd.flags = 0;
   nd.elem_size = elem_size;
@@ -26,14 +20,15 @@ NDArray make_ndarray(size_t elem_size, std::vector<int> shape, char *data) {
   return nd;
 }
 
-template<typename T>
-T load_ndarray_element(NDArray nd, std::vector<int> indices) {
+template<typename ElemT, bool elem_required, size_t elem_size, size_t elem_align>
+ElemT load_ndarray_element(NDArray nd, std::vector<long> indices) {
   int offset = 0;
-  for (int i = 0; i < nd.shape.size() - 1; i++) {
-    offset += nd.shape[nd.shape.size() - i - 1] * indices[i] * nd.elem_size;
+  for (int i = 0; i < indices.size() - 1; ++i) {
+    offset += nd.shape[nd.shape.size() - i - 1] * indices[i];
   }
-  offset += indices.back() * nd.elem_size;
-  return *reinterpret_cast<T *>(nd.data + offset);
+  offset += indices.back();
+
+  return ArrayLoadImpl<ElemT, elem_required, elem_size, elem_align>::load_element(nd.data, offset);
 }
 
 #endif

--- a/hail/src/main/resources/include/hail/NDArray.h
+++ b/hail/src/main/resources/include/hail/NDArray.h
@@ -4,7 +4,7 @@
 #include <vector>
 
 struct NDArray {
-  int flags;
+  int flags; // least sig. bit denotes if row major
   size_t elem_size;
   std::vector<long> shape;
   std::vector<long> strides;
@@ -43,7 +43,7 @@ char const *load_ndarray_addr(NDArray nd, std::vector<long> indices) {
   int offset = 0;
   for (int i = 0; i < indices.size(); ++i) {
     if (indices[i] < 0 || indices[i] > nd.shape[i]) {
-      throw new FatalError("Invalid index: " + indices[i]);
+      throw new FatalError("Invalid index");
     }
     offset += nd.strides[i] * indices[i];
   }

--- a/hail/src/main/resources/include/hail/NDArray.h
+++ b/hail/src/main/resources/include/hail/NDArray.h
@@ -13,6 +13,7 @@ struct NDArray {
 
 NDArray make_ndarray(int flags, size_t elem_size, std::vector<long> shape, const char *data);
 char const *load_ndarray_addr(NDArray nd, std::vector<long> indices);
+int n_elements(std::vector<long> &shape);
 
 void set_strides_row_major(std::vector<long> &strides, std::vector<long> &shape);
 void set_strides_col_major(std::vector<long> &strides, std::vector<long> &shape);
@@ -49,6 +50,15 @@ char const *load_ndarray_addr(NDArray nd, std::vector<long> indices) {
   }
 
   return nd.data + offset * nd.elem_size;
+}
+
+int n_elements(std::vector<long> &shape) {
+  int total = 1;
+  for (int i = 0; i < shape.size(); ++i) {
+    total *= shape[i];
+  }
+
+  return total;
 }
 
 void set_strides_row_major(std::vector<long> &strides, std::vector<long> &shape) {

--- a/hail/src/main/resources/include/hail/NDArray.h
+++ b/hail/src/main/resources/include/hail/NDArray.h
@@ -11,31 +11,62 @@ struct NDArray {
   const char *data;
 };
 
-NDArray make_ndarray(size_t elem_size, std::vector<long> shape, const char *data) {
+NDArray make_ndarray(int flags, size_t elem_size, std::vector<long> shape, const char *data);
+char const *load_ndarray_addr(NDArray nd, std::vector<long> indices);
+
+void set_strides_row_major(std::vector<long> &strides, std::vector<long> &shape);
+void set_strides_col_major(std::vector<long> &strides, std::vector<long> &shape);
+
+NDArray make_ndarray(int flags, size_t elem_size, std::vector<long> shape, const char *data) {
   NDArray nd;
-  nd.flags = 0;
+  nd.flags = flags;
   nd.elem_size = elem_size;
   nd.shape = shape;
   nd.data = data;
 
   std::vector<long> strides(shape.size());
-  strides[shape.size() - 1] = 1;
-  for (int i = shape.size() - 1; i > 0; --i) {
-    strides[i - 1] = shape[i] * strides[i];
+  if (flags == 1) {
+    set_strides_row_major(strides, shape);
+  } else {
+    set_strides_col_major(strides, shape);
   }
   nd.strides = strides;
 
   return nd;
 }
 
-template<typename ElemT>
-ElemT load_ndarray_element(NDArray nd, std::vector<long> indices) {
+char const *load_ndarray_addr(NDArray nd, std::vector<long> indices) {
+  if (indices.size() != nd.shape.size()) {
+    throw new FatalError("Number of indices must match number of dimensions.");
+  }
+
   int offset = 0;
   for (int i = 0; i < indices.size(); ++i) {
+    if (indices[i] < 0 || indices[i] > nd.shape[i]) {
+      throw new FatalError("Invalid index: " + indices[i]);
+    }
     offset += nd.strides[i] * indices[i];
   }
 
-  return *reinterpret_cast<const ElemT *>(nd.data + offset * nd.elem_size);
+  return nd.data + offset * nd.elem_size;
+}
+
+void set_strides_row_major(std::vector<long> &strides, std::vector<long> &shape) {
+  if (shape.size() > 0) {
+    strides[shape.size() - 1] = 1;
+    for (int i = shape.size() - 2; i >= 0; --i) {
+      strides[i] = shape[i + 1] * strides[i + 1];
+    }
+  }
+}
+
+void set_strides_col_major(std::vector<long> &strides, std::vector<long> &shape) {
+  if (shape.size() > 0) {
+    strides[0] = 1;
+    for (int i = 1; i < shape.size(); ++i) {
+      strides[i] = shape[i - 1] * strides[i - 1];
+    }
+  }
 }
 
 #endif

--- a/hail/src/main/resources/include/hail/NDArray.h
+++ b/hail/src/main/resources/include/hail/NDArray.h
@@ -1,0 +1,39 @@
+#ifndef HAIL_NDARRAY_H
+#define HAIL_NDARRAY_H 1
+
+#include <vector>
+
+struct NDArray {
+  int flags;
+  size_t elem_size;
+  std::vector<int> shape;
+  std::vector<int> stride;
+  char *data;
+};
+
+NDArray make_ndarray(size_t elem_size, std::vector<int> shape, char *data);
+
+template<typename T>
+T load_ndarray_element(NDArray nd, std::vector<int> indices);
+
+NDArray make_ndarray(size_t elem_size, std::vector<int> shape, char *data) {
+  NDArray nd;
+  nd.flags = 0;
+  nd.elem_size = elem_size;
+  nd.shape = shape;
+  nd.data = data;
+
+  return nd;
+}
+
+template<typename T>
+T load_ndarray_element(NDArray nd, std::vector<int> indices) {
+  int offset = 0;
+  for (int i = 0; i < nd.shape.size() - 1; i++) {
+    offset += nd.shape[nd.shape.size() - i - 1] * indices[i] * nd.elem_size;
+  }
+  offset += indices.back() * nd.elem_size;
+  return *reinterpret_cast<T *>(nd.data + offset);
+}
+
+#endif

--- a/hail/src/main/resources/include/hail/NDArray.h
+++ b/hail/src/main/resources/include/hail/NDArray.h
@@ -43,7 +43,7 @@ char const *load_ndarray_addr(NDArray nd, std::vector<long> indices) {
   int offset = 0;
   for (int i = 0; i < indices.size(); ++i) {
     if (indices[i] < 0 || indices[i] > nd.shape[i]) {
-      throw new FatalError("Invalid index");
+      throw new FatalError(("Invalid index: " + std::to_string(indices[i])).c_str());
     }
     offset += nd.strides[i] * indices[i];
   }

--- a/hail/src/main/resources/include/hail/Utils.h
+++ b/hail/src/main/resources/include/hail/Utils.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <cstdarg>
 #include <vector>
+#include <iostream>
 
 #define LIKELY(condition)   __builtin_expect(static_cast<bool>(condition), 1)
 #define UNLIKELY(condition) __builtin_expect(static_cast<bool>(condition), 0)
@@ -133,13 +134,13 @@ public:
   }
 };
 
-template<typename T>
-std::vector<T> load_vector(const char *data, int length) {
-  std::vector<int> vec(length);
-  const T *ts = reinterpret_cast<const T *>(data);
+template<typename ElemT, bool elem_required, size_t elem_size, size_t elem_align>
+std::vector<ElemT> load_vector(const char *data) {
+  std::vector<ElemT> vec;
+  int length = load_length(data);
 
-  for (int i = 0; i < length; i++) {
-    vec.push_back(ts[i]);
+  for (int i = 0; i < length; ++i) {
+    vec.push_back(ArrayLoadImpl<ElemT, elem_required, elem_size, elem_align>::load_element(data, i));
   }
 
   return vec;

--- a/hail/src/main/resources/include/hail/Utils.h
+++ b/hail/src/main/resources/include/hail/Utils.h
@@ -133,43 +133,16 @@ public:
   }
 };
 
-struct NDArray {
-  int flags;
-  int offset;
-  std::vector<int> shape;
-  std::vector<int> stride;
-  char *data;
-};
-
-NDArray make_ndarray(int offset, std::vector<int> shape, char *data) {
-  NDArray nd;
-  nd.flags = 0;
-  nd.offset = offset;
-  nd.shape = shape;
-  nd.data = data;
-
-  return nd;
-}
-
-//TODO Make generic
-std::vector<int> to_int_vec(const char *data, int length) {
+template<typename T>
+std::vector<T> load_vector(const char *data, int length) {
   std::vector<int> vec(length);
-  const int *ints = reinterpret_cast<const int *>(data);
+  const T *ts = reinterpret_cast<const T *>(data);
 
   for (int i = 0; i < length; i++) {
-    vec.push_back(ints[i]);
+    vec.push_back(ts[i]);
   }
 
   return vec;
-}
-
-char *load_ndarray_element(NDArray nd, std::vector<int> indices) {
-  int offset = 0;
-  for (int i = 0; i < nd.shape.size() - 1; i++) {
-    offset += nd.shape[nd.shape.size() - i - 1] * indices[i] * nd.offset;
-  }
-  offset += indices.back() * nd.offset;
-  return nd.data + offset;
 }
 
 struct FatalError: public std::exception {

--- a/hail/src/main/resources/include/hail/Utils.h
+++ b/hail/src/main/resources/include/hail/Utils.h
@@ -10,6 +10,23 @@
 #define LIKELY(condition)   __builtin_expect(static_cast<bool>(condition), 1)
 #define UNLIKELY(condition) __builtin_expect(static_cast<bool>(condition), 0)
 
+struct FatalError: public std::exception {
+  private:
+    static constexpr int max_error_len = 4 * 1024;
+    std::string error_msg_;
+  public:
+    virtual const char * what() const throw() { return error_msg_.c_str(); }
+    virtual ~FatalError() throw() {}
+    explicit FatalError(const char * fmtstring, ...) : std::exception() {
+      char error_msg[max_error_len];
+      va_list args;
+      va_start(args, fmtstring);
+      vsnprintf(error_msg, max_error_len, fmtstring, args);
+      va_end(args);
+      error_msg_ = std::string("FatalError: ") + std::string(error_msg);
+    }
+};
+
 template<typename ElemT>
 ElemT load_element(char const* off) { return *reinterpret_cast<ElemT const*>(off); }
 
@@ -98,6 +115,16 @@ public:
       return load_bit(a + 4, i);
   }
 
+  static bool has_missing_elements(const char *a) {
+    for (auto i = 0; i < load_length(a); ++i) {
+      if (is_element_missing(a, i)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   static constexpr int elements_offset(int len) {
     return round_up_alignment(4 + (elem_required ? 0 : n_missing_bytes(len)), elem_align);
   }
@@ -137,33 +164,19 @@ public:
   }
 };
 
-template<typename ElemT, bool elem_required, size_t elem_size, size_t elem_align>
-std::vector<ElemT> load_vector(const char *data) {
-  int length = load_length(data);
-  std::vector<ElemT> vec(length);
+template<typename ArrayImpl>
+std::vector<typename ArrayImpl::T> load_non_missing_vector(const char *data) {
+  if (ArrayImpl::has_missing_elements(data)) {
+    throw new FatalError("Tried to construct non-missing vector with missing data");
+  }
 
+  int length = load_length(data);
+  std::vector<typename ArrayImpl::T> vec(length);
   for (int i = 0; i < length; ++i) {
-    vec[i] = ArrayLoadImpl<ElemT, elem_required, elem_size, elem_align>::load_element(data, i);
+    vec[i] = ArrayImpl::load_element(data, i);
   }
 
   return vec;
 }
-
-struct FatalError: public std::exception {
-  private:
-    static constexpr int max_error_len = 4 * 1024;
-    std::string error_msg_;
-  public:
-    virtual const char * what() const throw() { return error_msg_.c_str(); }
-    virtual ~FatalError() throw() {}
-    explicit FatalError(const char * fmtstring, ...) : std::exception() {
-      char error_msg[max_error_len];
-      va_list args;
-      va_start(args, fmtstring);
-      vsnprintf(error_msg, max_error_len, fmtstring, args);
-      va_end(args);
-      error_msg_ = std::string("FatalError: ") + std::string(error_msg);
-    }
-};
 
 #endif

--- a/hail/src/main/resources/include/hail/Utils.h
+++ b/hail/src/main/resources/include/hail/Utils.h
@@ -10,6 +10,9 @@
 #define LIKELY(condition)   __builtin_expect(static_cast<bool>(condition), 1)
 #define UNLIKELY(condition) __builtin_expect(static_cast<bool>(condition), 0)
 
+template<typename ElemT>
+ElemT load_element(char const* off) { return *reinterpret_cast<ElemT const*>(off); }
+
 inline char load_byte(char const* off) { return *off; }
 inline bool load_bool(char const* off) { return *off; }
 inline int load_int(char const* off) { return *reinterpret_cast<int const*>(off); }
@@ -136,11 +139,11 @@ public:
 
 template<typename ElemT, bool elem_required, size_t elem_size, size_t elem_align>
 std::vector<ElemT> load_vector(const char *data) {
-  std::vector<ElemT> vec;
   int length = load_length(data);
+  std::vector<ElemT> vec(length);
 
   for (int i = 0; i < length; ++i) {
-    vec.push_back(ArrayLoadImpl<ElemT, elem_required, elem_size, elem_align>::load_element(data, i));
+    vec[i] = ArrayLoadImpl<ElemT, elem_required, elem_size, elem_align>::load_element(data, i);
   }
 
   return vec;

--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -811,9 +811,8 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
            """.stripMargin,
           s"${datat.m} || ${shapet.m} || ${rowMajort.m}",
           s"""
-             |NDArray(${shapet.v}, ${datat.v}, ${rowMajort.v})
-           """.stripMargin
-        )
+             |new NDArray(${shapet.v}, ${datat.v}, ${rowMajort.v})
+           """.stripMargin)
 
       case ir.NDArrayRef(nd, idxs) =>
         val ndt = emit(nd)
@@ -825,9 +824,7 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
              |${idxst.setup}
            """.stripMargin,
           s"${ndt.m} || ${idxst.m}",
-          s"""
-             |${ndt.v}[${idxst.v}]
-           """.stripMargin)
+          s"${ndt.v}.get_element(${idxst.v})")
       case _ =>
         throw new CXXUnsupportedOperation(ir.Pretty(x))
     }

--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -797,6 +797,37 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
            """.stripMargin,
           resultRegion)
 
+      case ir.MakeNDArray(data, shape, rowMajor) =>
+        val containerPType = data.pType.asInstanceOf[PContainer]
+        val datat = emit(data)
+        val shapet = emit(shape)
+        val rowMajort = emit(rowMajor)
+
+        triplet(
+          s"""
+             |${datat.setup}
+             |${shapet.setup}
+             |${rowMajort.setup}
+           """.stripMargin,
+          s"${datat.m} || ${shapet.m} || ${rowMajort.m}",
+          s"""
+             |NDArray(${shapet.v}, ${datat.v}, ${rowMajort.v})
+           """.stripMargin
+        )
+
+      case ir.NDArrayRef(nd, idxs) =>
+        val ndt = emit(nd)
+        val idxst = emit(idxs)
+
+        triplet(
+          s"""
+             |${ndt.setup}
+             |${idxst.setup}
+           """.stripMargin,
+          s"${ndt.m} || ${idxst.m}",
+          s"""
+             |${ndt.v}[${idxst.v}]
+           """.stripMargin)
       case _ =>
         throw new CXXUnsupportedOperation(ir.Pretty(x))
     }

--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -803,8 +803,7 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
         val shapet = emit(shape)
         val datat = emit(data)
 
-        val offset = containerPType.elementType.byteSize.toString
-
+        val elemSize = containerPType.elementType.byteSize.toString
         val shapeRegion = fb.variable("shapeRegion", "const char *", shapet.v)
         val nDims = fb.variable("nDims", "int", containerPType.cxxLoadLength(shapeRegion.toString))
         triplet("",
@@ -813,15 +812,17 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
              |({
              | ${ shapeRegion.define }
              | ${ nDims.define }
-             | make_ndarray($offset, to_int_vec(${shapeRegion.toString}, ${nDims.toString}), ${datat.v});
+             | make_ndarray($elemSize, load_vector<int>(${shapeRegion.toString}, ${nDims.toString}), ${datat.v});
              |})
              |""".stripMargin)
 
       case ir.NDArrayRef(nd, idxs) =>
+        fb.translationUnitBuilder().include("hail/NDArray.h")
         val idxContainerPType = idxs.pType.asInstanceOf[PContainer]
+        val cxxElemType = typeToCXXType(nd.pType.asInstanceOf[PNDArray].elementType)
+
         val ndt = emit(nd)
         val idxst = emit(idxs)
-
         val idxsRegion = fb.variable("idxsRegion", "const char *", idxst.v)
         val nDims = fb.variable("nDims", "int", idxContainerPType.cxxLoadLength(idxsRegion.toString))
         triplet(
@@ -833,7 +834,7 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
              |({
              | ${ idxsRegion.define }
              | ${ nDims.define }
-             | load_double(load_ndarray_element(${ndt.v}, to_int_vec(${idxsRegion.toString}, ${nDims.toString})));
+             | load_ndarray_element<$cxxElemType>(${ndt.v}, load_vector<int>(${idxsRegion.toString}, ${nDims.toString}));
              |})
              |""".stripMargin)
       case _ =>

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -186,7 +186,7 @@ final case class ArrayAgg(a: IR, name: String, query: IR) extends IR
 
 final case class ArrayLeftJoinDistinct(left: IR, right: IR, l: String, r: String, keyF: IR, joinF: IR) extends IR
 
-final case class MakeNDArray(data: IR, shape: IR, rowMajor: IR) extends IR
+final case class MakeNDArray(data: IR, shape: IR, leftOrdered: IR) extends IR
 
 final case class NDArrayRef(nd: IR, idxs: IR) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -186,7 +186,7 @@ final case class ArrayAgg(a: IR, name: String, query: IR) extends IR
 
 final case class ArrayLeftJoinDistinct(left: IR, right: IR, l: String, r: String, keyF: IR, joinF: IR) extends IR
 
-final case class MakeNDArray(data: IR, shape: IR, leftOrdered: IR) extends IR
+final case class MakeNDArray(data: IR, shape: IR, rowMajor: IR) extends IR
 
 final case class NDArrayRef(nd: IR, idxs: IR) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -186,7 +186,7 @@ final case class ArrayAgg(a: IR, name: String, query: IR) extends IR
 
 final case class ArrayLeftJoinDistinct(left: IR, right: IR, l: String, r: String, keyF: IR, joinF: IR) extends IR
 
-final case class MakeNDArray(data: IR, shape: IR, row_major: IR) extends IR
+final case class MakeNDArray(data: IR, shape: IR, rowMajor: IR) extends IR
 
 final case class NDArrayRef(nd: IR, idxs: IR) extends IR
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -901,15 +901,22 @@ class IRSuite extends SparkSuite {
   @Test def testNDArrayRef() {
     implicit val execStrats = Set(ExecStrategy.CxxCompile)
 
-    def nd = MakeNDArray(
+    def vector = MakeNDArray(
       MakeArray(FastSeq(F64(1.0), F64(-1.0)), TArray(TFloat64())),
       MakeArray(FastSeq(I64(2)), TArray(TInt64())),
       True())
 
-    def one = NDArrayRef(nd, MakeArray(FastSeq(I64(0)), TArray(TInt64())))
-    def negOne = NDArrayRef(nd, MakeArray(FastSeq(I64(1)), TArray(TInt64())))
+    def one = NDArrayRef(vector, MakeArray(FastSeq(I64(0)), TArray(TInt64())))
+    def negOne = NDArrayRef(vector, MakeArray(FastSeq(I64(1)), TArray(TInt64())))
     assertEvalsTo(one, 1.0)
     assertEvalsTo(negOne, -1.0)
+
+    def cube = MakeNDArray(
+      MakeArray((0 until 27).map { F64(_) }.toFastSeq, TArray(TFloat64())),
+      MakeArray(FastSeq(I64(3), I64(3), I64(3)), TArray(TInt64())),
+      True())
+    def center = NDArrayRef(cube, MakeArray(FastSeq(I64(1), I64(1), I64(1)), TArray(TInt64())))
+    assertEvalsTo(center, 13.0)
   }
 
   @Test def testLeftJoinRightDistinct() {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -898,6 +898,37 @@ class IRSuite extends SparkSuite {
     assertEvalsTo(scan(TestUtils.IRArray(1, null, 3), 0, (accum, elt) => accum + elt), FastIndexedSeq(0, 1, null, null))
   }
 
+  @Test def testMakeNDArray() {
+    def nd = MakeNDArray(
+      MakeArray(FastSeq(F64(-1.0), F64(1.0)), TArray(TFloat64())),
+      MakeArray(FastSeq(I64(2)), TArray(TInt64())),
+      True())
+
+    def ndRow = MakeNDArray(
+      MakeArray(FastSeq(F64(-1.0), F64(1.0)), TArray(TFloat64())),
+      MakeArray(FastSeq(I64(1), I64(2)), TArray(TInt64())),
+      True())
+
+    def ndCol = MakeNDArray(
+      MakeArray(FastSeq(F64(-1.0), F64(1.0)), TArray(TFloat64())),
+      MakeArray(FastSeq(I64(2), I64(1)), TArray(TInt64())),
+      True())
+
+    assertEvalsTo(nd, FastIndexedSeq(-1.0, 1.0))
+    assertEvalsTo(nd, FastIndexedSeq(FastIndexedSeq(-1.0, 1.0)))
+    assertEvalsTo(nd, FastIndexedSeq(FastIndexedSeq(-1.0), FastIndexedSeq(1.0)))
+  }
+
+  @Test def testNDArrayRef() {
+    def nd = MakeNDArray(
+      MakeArray(FastSeq(F64(-1.0), F64(1.0)), TArray(TFloat64())),
+      MakeArray(FastSeq(I64(2)), TArray(TInt64())),
+      True())
+
+    def negOne = NDArrayRef(nd, MakeArray(FastSeq(F64(0)), TArray(TFloat64())))
+    assertEvalsTo(negOne, -1)
+  }
+
   @Test def testLeftJoinRightDistinct() {
     implicit val execStrats = ExecStrategy.javaOnly
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -899,12 +899,16 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testNDArrayRef() {
+    implicit val execStrats = Set(ExecStrategy.CxxCompile)
+
     def nd = MakeNDArray(
-      MakeArray(FastSeq(F64(-1.0), F64(1.0)), TArray(TFloat64())),
+      MakeArray(FastSeq(F64(1.0), F64(-1.0)), TArray(TFloat64())),
       MakeArray(FastSeq(I64(2)), TArray(TInt64())),
       True())
 
-    def negOne = NDArrayRef(nd, MakeArray(FastSeq(I64(0)), TArray(TInt64())))
+    def one = NDArrayRef(nd, MakeArray(FastSeq(I64(0)), TArray(TInt64())))
+    def negOne = NDArrayRef(nd, MakeArray(FastSeq(I64(1)), TArray(TInt64())))
+    assertEvalsTo(one, 1.0)
     assertEvalsTo(negOne, -1.0)
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -898,35 +898,14 @@ class IRSuite extends SparkSuite {
     assertEvalsTo(scan(TestUtils.IRArray(1, null, 3), 0, (accum, elt) => accum + elt), FastIndexedSeq(0, 1, null, null))
   }
 
-  @Test def testMakeNDArray() {
-    def nd = MakeNDArray(
-      MakeArray(FastSeq(F64(-1.0), F64(1.0)), TArray(TFloat64())),
-      MakeArray(FastSeq(I64(2)), TArray(TInt64())),
-      True())
-
-    def ndRow = MakeNDArray(
-      MakeArray(FastSeq(F64(-1.0), F64(1.0)), TArray(TFloat64())),
-      MakeArray(FastSeq(I64(1), I64(2)), TArray(TInt64())),
-      True())
-
-    def ndCol = MakeNDArray(
-      MakeArray(FastSeq(F64(-1.0), F64(1.0)), TArray(TFloat64())),
-      MakeArray(FastSeq(I64(2), I64(1)), TArray(TInt64())),
-      True())
-
-    assertEvalsTo(nd, FastIndexedSeq(-1.0, 1.0))
-    assertEvalsTo(nd, FastIndexedSeq(FastIndexedSeq(-1.0, 1.0)))
-    assertEvalsTo(nd, FastIndexedSeq(FastIndexedSeq(-1.0), FastIndexedSeq(1.0)))
-  }
-
   @Test def testNDArrayRef() {
     def nd = MakeNDArray(
       MakeArray(FastSeq(F64(-1.0), F64(1.0)), TArray(TFloat64())),
       MakeArray(FastSeq(I64(2)), TArray(TInt64())),
       True())
 
-    def negOne = NDArrayRef(nd, MakeArray(FastSeq(F64(0)), TArray(TFloat64())))
-    assertEvalsTo(negOne, -1)
+    def negOne = NDArrayRef(nd, MakeArray(FastSeq(I64(0)), TArray(TInt64())))
+    assertEvalsTo(negOne, -1.0)
   }
 
   @Test def testLeftJoinRightDistinct() {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -901,22 +901,38 @@ class IRSuite extends SparkSuite {
   @Test def testNDArrayRef() {
     implicit val execStrats = Set(ExecStrategy.CxxCompile)
 
-    def vector = MakeNDArray(
-      MakeArray(FastSeq(F64(1.0), F64(-1.0)), TArray(TFloat64())),
-      MakeArray(FastSeq(I64(2)), TArray(TInt64())),
-      True())
+    def makeNDArray(data: Seq[Double], shape: Seq[Long], rowMajor: IR): MakeNDArray = {
+      MakeNDArray(MakeArray(data.map(F64), TArray(TFloat64())), MakeArray(shape.map(I64), TArray(TInt64())), rowMajor)
+    }
+    def makeNDArrayRef(nd: IR, indxs: Seq[Long]): NDArrayRef = {
+      NDArrayRef(nd, MakeArray(indxs.map(I64), TArray(TInt64())))
+    }
 
-    def one = NDArrayRef(vector, MakeArray(FastSeq(I64(0)), TArray(TInt64())))
-    def negOne = NDArrayRef(vector, MakeArray(FastSeq(I64(1)), TArray(TInt64())))
-    assertEvalsTo(one, 1.0)
-    assertEvalsTo(negOne, -1.0)
+    def scalarRowMajor = makeNDArray(FastSeq(3.0), FastSeq(), True())
+    def scalarColMajor = makeNDArray(FastSeq(3.0), FastSeq(), False())
+    assertEvalsTo(makeNDArrayRef(scalarRowMajor, FastSeq()), 3.0)
+    assertEvalsTo(makeNDArrayRef(scalarColMajor, FastSeq()), 3.0)
 
-    def cube = MakeNDArray(
-      MakeArray((0 until 27).map { F64(_) }.toFastSeq, TArray(TFloat64())),
-      MakeArray(FastSeq(I64(3), I64(3), I64(3)), TArray(TInt64())),
-      True())
-    def center = NDArrayRef(cube, MakeArray(FastSeq(I64(1), I64(1), I64(1)), TArray(TInt64())))
-    assertEvalsTo(center, 13.0)
+    def vectorRowMajor = makeNDArray(FastSeq(1.0, -1.0), FastSeq(2), True())
+    def vectorColMajor = makeNDArray(FastSeq(1.0, -1.0), FastSeq(2), False())
+    assertEvalsTo(makeNDArrayRef(vectorRowMajor, FastSeq(0)), 1.0)
+    assertEvalsTo(makeNDArrayRef(vectorColMajor, FastSeq(0)), 1.0)
+    assertEvalsTo(makeNDArrayRef(vectorRowMajor, FastSeq(1)), -1.0)
+    assertEvalsTo(makeNDArrayRef(vectorColMajor, FastSeq(1)), -1.0)
+
+    def threeTensorRowMajor = makeNDArray((0 until 30).map(_.toDouble), FastSeq(2, 3, 5), True())
+    def threeTensorColMajor = makeNDArray((0 until 30).map(_.toDouble), FastSeq(2, 3, 5), False())
+    def sevenRowMajor = makeNDArrayRef(threeTensorRowMajor, FastSeq(0, 1, 2))
+    def sevenColMajor = makeNDArrayRef(threeTensorColMajor, FastSeq(1, 0, 1))
+    assertEvalsTo(sevenRowMajor, 7.0)
+    assertEvalsTo(sevenColMajor, 7.0)
+
+    def cubeRowMajor = makeNDArray((0 until 27).map(_.toDouble), FastSeq(3, 3, 3), True())
+    def cubeColMajor = makeNDArray((0 until 27).map(_.toDouble), FastSeq(3, 3, 3), False())
+    def centerRowMajor = makeNDArrayRef(cubeRowMajor, FastSeq(1, 1, 1))
+    def centerColMajor = makeNDArrayRef(cubeColMajor, FastSeq(1, 1, 1))
+    assertEvalsTo(centerRowMajor, 13.0)
+    assertEvalsTo(centerColMajor, 13.0)
   }
 
   @Test def testLeftJoinRightDistinct() {


### PR DESCRIPTION
- Implemented an NDArray as simply a struct with enough information to properly index but no knowledge of the data type, so no templating required.
- Convert child IRs from regions to `std::vector` so the NDArray logic is simpler and isn't coupled to regions. Maybe it doesn't need to be decoupled?
- Currently passing by value in the code-gen for simplicity and since the values are pretty small, but would appreciate feedback on memory-management strategies for non-region values like NDArray.
- Tests extract singular values since we can't translate these arrays back into Java.