### PR TITLE
define ToStream IR (stub)

### DIFF
--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -483,6 +483,9 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
       case ir.ToArray(a) =>
         emit(a)
 
+      case ir.ToStream(a) =>
+        emit(a)
+
       case ir.ArrayFold(a, zero, accumName, valueName, body) =>
         val containerPType = a.pType.asInstanceOf[PContainer]
         val ae = emitArray(resultRegion, a, env, sameRegion = false)

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -52,6 +52,8 @@ object Children {
       Array(a)
     case ToArray(a) =>
       Array(a)
+    case ToStream(a) =>
+      Array(a)
     case LowerBoundOnOrderedCollection(orderedCollection, elem, _) =>
       Array(orderedCollection, elem)
     case GroupByKey(collection) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -68,6 +68,9 @@ object Copy {
       case ToArray(_) =>
         val IndexedSeq(a: IR) = newChildren
         ToArray(a)
+      case ToStream(_) =>
+        val IndexedSeq(a: IR) = newChildren
+        ToStream(a)
       case LowerBoundOnOrderedCollection(_, _, asKey) =>
         val IndexedSeq(orderedCollection: IR, elem: IR) = newChildren
         LowerBoundOnOrderedCollection(orderedCollection, elem, asKey)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -435,7 +435,7 @@ private class Emit(
         strict(PContainer.loadLength(region, coerce[Long](codeA.v)), codeA)
 
       case x@(_: ArraySort | _: ToSet | _: ToDict) =>
-        val atyp = coerce[PContainer](ir.pType)
+        val atyp = coerce[PContainer](x.pType)
         val eltType = -atyp.elementType.virtualType
         val vab = new StagedArrayBuilder(atyp.elementType, mb, 16)
         val sorter = new ArraySorter(mb, vab)
@@ -481,6 +481,9 @@ private class Emit(
             sorter.toRegion()))
 
       case ToArray(a) =>
+        emit(a)
+
+      case ToStream(a) =>
         emit(a)
 
       case x@LowerBoundOnOrderedCollection(orderedCollection, elem, onKey) =>

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -161,6 +161,7 @@ final case class ArraySort(a: IR, left: String, right: String, compare: IR) exte
 final case class ToSet(a: IR) extends IR
 final case class ToDict(a: IR) extends IR
 final case class ToArray(a: IR) extends IR
+final case class ToStream(a: IR) extends IR
 
 final case class LowerBoundOnOrderedCollection(orderedCollection: IR, elem: IR, onKey: Boolean) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -62,17 +62,17 @@ object InferPType {
         val et = coerce[PArray](a.pType).elementType
         PArray(et, a.pType.required)
       case ToSet(a) =>
-        val et = coerce[PIterable](a.pType).elementType
-        PSet(et, a.pType.required)
+        val elt = coerce[PIterable](a.pType).elementType
+        PSet(elt, a.pType.required)
       case ToDict(a) =>
         val elt = coerce[PBaseStruct](coerce[PIterable](a.pType).elementType)
         PDict(elt.types(0), elt.types(1), a.pType.required)
       case ToArray(a) =>
-        val et = coerce[PIterable](a.pType).elementType
-        PArray(et, a.pType.required)
+        val elt = coerce[PIterable](a.pType).elementType
+        PArray(elt, a.pType.required)
       case ToStream(a) =>
-        val et = coerce[PIterable](a.pType).elementType
-        PStream(et, a.pType.required)
+        val elt = coerce[PIterable](a.pType).elementType
+        PStream(elt, a.pType.required)
       case GroupByKey(collection) =>
         val elt = coerce[PBaseStruct](coerce[PArray](collection.pType).elementType)
         // FIXME requiredness

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -62,14 +62,17 @@ object InferPType {
         val et = coerce[PArray](a.pType).elementType
         PArray(et, a.pType.required)
       case ToSet(a) =>
-        val et = coerce[PArray](a.pType).elementType
+        val et = coerce[PIterable](a.pType).elementType
         PSet(et, a.pType.required)
       case ToDict(a) =>
-        val elt = coerce[PBaseStruct](coerce[PArray](a.pType).elementType)
+        val elt = coerce[PBaseStruct](coerce[PIterable](a.pType).elementType)
         PDict(elt.types(0), elt.types(1), a.pType.required)
       case ToArray(a) =>
-        val et = coerce[PContainer](a.pType).elementType
+        val et = coerce[PIterable](a.pType).elementType
         PArray(et, a.pType.required)
+      case ToStream(a) =>
+        val et = coerce[PIterable](a.pType).elementType
+        PStream(et, a.pType.required)
       case GroupByKey(collection) =>
         val elt = coerce[PBaseStruct](coerce[PArray](collection.pType).elementType)
         // FIXME requiredness

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -73,11 +73,11 @@ object InferType {
         val elt = coerce[TBaseStruct](coerce[TIterable](a.typ).elementType)
         TDict(elt.types(0), elt.types(1), a.typ.required)
       case ToArray(a) =>
-        val et = coerce[TIterable](a.typ).elementType
-        TArray(et, a.typ.required)
+        val elt = coerce[TIterable](a.typ).elementType
+        TArray(elt, a.typ.required)
       case ToStream(a) =>
-        val et = coerce[TIterable](a.typ).elementType
-        TStream(et, a.typ.required)
+        val elt = coerce[TIterable](a.typ).elementType
+        TStream(elt, a.typ.required)
       case GroupByKey(collection) =>
         val elt = coerce[TBaseStruct](coerce[TArray](collection.typ).elementType)
         TDict(elt.types(0), TArray(elt.types(1)), collection.typ.required)

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -67,14 +67,17 @@ object InferType {
         val et = coerce[TArray](a.typ).elementType
         TArray(et, a.typ.required)
       case ToSet(a) =>
-        val et = coerce[TArray](a.typ).elementType
+        val et = coerce[TIterable](a.typ).elementType
         TSet(et, a.typ.required)
       case ToDict(a) =>
-        val elt = coerce[TBaseStruct](coerce[TArray](a.typ).elementType)
+        val elt = coerce[TBaseStruct](coerce[TIterable](a.typ).elementType)
         TDict(elt.types(0), elt.types(1), a.typ.required)
       case ToArray(a) =>
-        val et = coerce[TContainer](a.typ).elementType
+        val et = coerce[TIterable](a.typ).elementType
         TArray(et, a.typ.required)
+      case ToStream(a) =>
+        val et = coerce[TIterable](a.typ).elementType
+        TStream(et, a.typ.required)
       case GroupByKey(collection) =>
         val elt = coerce[TBaseStruct](coerce[TArray](collection.typ).elementType)
         TDict(elt.types(0), TArray(elt.types(1)), collection.typ.required)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -613,6 +613,7 @@ object IRParser {
       case "ToSet" => ToSet(ir_value_expr(env)(it))
       case "ToDict" => ToDict(ir_value_expr(env)(it))
       case "ToArray" => ToArray(ir_value_expr(env)(it))
+      case "ToStream" => ToStream(ir_value_expr(env)(it))
       case "LowerBoundOnOrderedCollection" =>
         val onKey = boolean_literal(it)
         val col = ir_value_expr(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -91,12 +91,14 @@ object TypeCheck {
         val tarray = coerce[TArray](a.typ)
         assert(compare.typ.isOfType(TBoolean()))
       case x@ToSet(a) =>
-        assert(a.typ.isInstanceOf[TArray])
+        assert(a.typ.isInstanceOf[TIterable])
       case x@ToDict(a) =>
-        assert(a.typ.isInstanceOf[TArray])
-        assert(coerce[TBaseStruct](coerce[TArray](a.typ).elementType).size == 2)
+        assert(a.typ.isInstanceOf[TIterable])
+        assert(coerce[TBaseStruct](coerce[TIterable](a.typ).elementType).size == 2)
       case x@ToArray(a) =>
-        assert(a.typ.isInstanceOf[TContainer])
+        assert(a.typ.isInstanceOf[TIterable])
+      case x@ToStream(a) =>
+        assert(a.typ.isInstanceOf[TIterable])
       case x@LowerBoundOnOrderedCollection(orderedCollection, elem, onKey) =>
         val elt = -coerce[TContainer](orderedCollection.typ).elementType
         assert(-elem.typ == (if (onKey) -coerce[TStruct](elt).types(0) else elt))

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1229,6 +1229,7 @@ class IRSuite extends SparkSuite {
       ToSet(a),
       ToDict(da),
       ToArray(a),
+      ToStream(a),
       LowerBoundOnOrderedCollection(a, i, onKey = true),
       GroupByKey(da),
       ArrayMap(a, "v", v),


### PR DESCRIPTION
This is currently an IR that does nothing except take an IR of a container type and changes the wrapper type to TStream. In this PR, I've defined it in the usual (Scala) IR framework and in Emit (currently equivalent to ToArray, but that will change in the c++ emitter as the stream infrastructure goes in). It's otherwise not used yet (and will essentially continue to be a no-op in the JVM emitter), so I haven't written tests other than the parser test.

I intend to use this mostly to enforce non-instantiation of arrays in the c++ emitter, so that we don't inadvertently try to create e.g. an array of all the rows in a partition.