### PR TITLE
[ci] delete a job after its information has been incorporated into internal state

### DIFF
--- a/ci/ci/batch_helper.py
+++ b/ci/ci/batch_helper.py
@@ -6,13 +6,6 @@ from .ci_logging import log
 from .git_state import FQSHA
 
 
-def try_to_cancel_job(job):
-    try:
-        job.cancel()
-    except requests.exceptions.HTTPError as e:
-        log.warning(f'could not cancel job {job.id} due to {e}')
-
-
 def try_to_delete_job(job):
     try:
         job.delete()

--- a/ci/ci/batch_helper.py
+++ b/ci/ci/batch_helper.py
@@ -13,6 +13,13 @@ def try_to_cancel_job(job):
         log.warning(f'could not cancel job {job.id} due to {e}')
 
 
+def try_to_delete_job(job):
+    try:
+        job.delete()
+    except requests.exceptions.HTTPError as e:
+        log.warning(f'could not delete job {job.id} due to {e}')
+
+
 # job_ordering(x, y) > 0 if x is closer to finishing or has a larger id
 def job_ordering(job1, job2):
     x = job1.cached_status()['state']

--- a/ci/ci/build_state.py
+++ b/ci/ci/build_state.py
@@ -3,7 +3,7 @@ import json
 import re
 from batch.client import Job
 
-from .batch_helper import try_to_cancel_job
+from .batch_helper import try_to_delete_job
 from .ci_logging import log
 from .environment import batch_client, CONTEXT
 
@@ -215,8 +215,8 @@ class Building(object):
         if (not isinstance(other, Failure) and
             not isinstance(other, Mergeable) and
             not isinstance(other, NoMergeSHA)):
-            log.info(f'cancelling unneeded job {self.job.id} {self} {other}')
-            try_to_cancel_job(self.job)
+            log.info(f'deleting unneeded job {self.job.id} {self} {other}')
+            try_to_delete_job(self.job)
         return other
 
     def __str__(self):

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -9,7 +9,7 @@ from batch.client import Job
 from flask import Flask, request, jsonify, render_template, redirect
 from flask_cors import CORS
 
-from .batch_helper import try_to_cancel_job, job_ordering
+from .batch_helper import try_to_delete_job, job_ordering
 from .ci_logging import log
 from .constants import BUILD_JOB_TYPE, GCS_BUCKET, GCS_BUCKET_PREFIX, \
     DEPLOY_JOB_TYPE
@@ -172,15 +172,15 @@ def refresh_ci_build_jobs(jobs):
         else:
             if job_ordering(job, job2) > 0:
                 log.info(
-                    f'cancelling {job2.id}, preferring {job.id}'
+                    f'deleting {job2.id}, preferring {job.id}'
                 )
-                try_to_cancel_job(job2)
+                try_to_delete_job(job2)
                 latest_jobs[key] = job
             else:
                 log.info(
-                    f'cancelling {job.id}, preferring {job2.id}'
+                    f'deleting {job.id}, preferring {job2.id}'
                 )
-                try_to_cancel_job(job)
+                try_to_delete_job(job)
     prs.refresh_from_ci_jobs(latest_jobs)
 
 def refresh_deploy_jobs(jobs):
@@ -203,15 +203,15 @@ def refresh_deploy_jobs(jobs):
         else:
             if job_ordering(job, job2) > 0:
                 log.info(
-                    f'cancelling {job2.id}, preferring {job.id}'
+                    f'deleting {job2.id}, preferring {job.id}'
                 )
-                try_to_cancel_job(job2)
+                try_to_delete_job(job2)
                 latest_jobs[target] = job
             else:
                 log.info(
-                    f'cancelling {job.id}, preferring {job2.id}'
+                    f'deleting {job.id}, preferring {job2.id}'
                 )
-                try_to_cancel_job(job)
+                try_to_delete_job(job)
     prs.refresh_from_deploy_jobs(latest_jobs)
 
 

--- a/ci/ci/pr.py
+++ b/ci/ci/pr.py
@@ -434,7 +434,7 @@ class PR(object):
                 return self._new_build(Building(job, image, target.sha))
             else:
                 log.info(f'found deploy job {job.id} for wrong target {target}, should be {self.target}')
-                job.cancel()
+                job.delete()
                 return self
 
     def refresh_from_missing_job(self):
@@ -472,5 +472,5 @@ class PR(object):
                         job,
                         job.attributes['image'],
                         self.target.sha))
-        job.cancel()
+        job.delete()
         return x

--- a/ci/ci/prs.py
+++ b/ci/ci/prs.py
@@ -342,7 +342,7 @@ class PRS(object):
         else:
             log.info(f'deploy job {job.id} succeeded for {target.short_str()}')
             self.latest_deployed[target.ref] = target.sha
-        job.cancel()
+        job.delete()
 
     def refresh_from_deploy_jobs(self, jobs):
         lost_jobs = {target_ref for target_ref in self.deploy_jobs.keys()}
@@ -366,7 +366,7 @@ class PRS(object):
         elif state == 'Cancelled':
             log.info(f'refreshing from cancelled deploy job {job.id} {job.attributes}')
             del self.deploy_jobs[target.ref]
-            job.cancel()
+            job.delete()
         else:
             assert state == 'Created', f'{state} {job.id} {job.attributes}'
             existing_job = self.deploy_jobs[target.ref]
@@ -374,7 +374,7 @@ class PRS(object):
                 self.deploy_jobs[target.ref] = job
             elif existing_job.id != job.id:
                 log.info(f'found deploy job {job.id} other than mine {existing_job.id}, canceling')
-                job.cancel()
+                job.delete()
 
     def ci_build_finished(self, source, target, job):
         assert isinstance(job, Job), job

--- a/ci/ci/prs.py
+++ b/ci/ci/prs.py
@@ -2,7 +2,7 @@ import json
 
 from batch.client import Job
 
-from .batch_helper import short_str_build_job, try_to_cancel_job
+from .batch_helper import short_str_build_job, try_to_delete_job
 from .ci_logging import log
 from .constants import VERSION, DEPLOY_JOB_TYPE
 from .environment import \
@@ -323,7 +323,7 @@ class PRS(object):
         if expected_job.id != job.id:
             expected_target = FQSHA.from_json(json.loads(expected_job.attributes['target']))
             if expected_target == target:
-                try_to_cancel_job(expected_job)
+                try_to_delete_job(expected_job)
                 log.info(
                     f'proceeding with unexpected deploy job {job.id}, '
                     f'because targets matched: {target} {expected_target}. '
@@ -373,7 +373,7 @@ class PRS(object):
             if existing_job is None:
                 self.deploy_jobs[target.ref] = job
             elif existing_job.id != job.id:
-                log.info(f'found deploy job {job.id} other than mine {existing_job.id}, canceling')
+                log.info(f'found deploy job {job.id} other than mine {existing_job.id}, deleting')
                 job.delete()
 
     def ci_build_finished(self, source, target, job):


### PR DESCRIPTION
I think this resolves a number of our issues actually wherein CI keeps hearing about jobs that it's already updated its internal state about.