### PR TITLE
fix batch build, migrate to base

### DIFF
--- a/batch/Dockerfile
+++ b/batch/Dockerfile
@@ -1,10 +1,4 @@
-FROM alpine:3.8
-
-RUN apk add --no-cache \
-  py3-cffi \
-  py3-cryptography \
-  python3 \
-  && true
+FROM base
 
 COPY setup.py /batch/
 COPY MANIFEST.in /batch/


### PR DESCRIPTION
Deploy is still failing because batch build is failing.  The async stuff had new requirements that didn't install on alpine.  I migrated it to base.  I verified the build by hand.