### PR TITLE
[fix] test for bin-search on dict

### DIFF
--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -342,16 +342,20 @@ class OrderingSuite extends SparkSuite {
         val f = fb.resultWithIndex()(0)
         val closestI = f(region, soff, eoff)
 
-        def getKey(i: Int) = asArray(i).asInstanceOf[Row].get(0)
+        if (closestI == asArray.length) {
+          !dict.contains(key) ==> asArray.forall { keyI =>
+            val otherKey = keyI.asInstanceOf[Row].get(0)
+            pDict.keyType.virtualType.ordering.compare(key, otherKey) > 0
+          }
+        } else {
+          def getKey(i: Int) = asArray(i).asInstanceOf[Row].get(0)
+          val maybeEqual = getKey(closestI)
+          val closestIIsClosest =
+            (pDict.keyType.virtualType.ordering.compare(key, maybeEqual) <= 0 || closestI == dict.size - 1) &&
+              (closestI == 0 || pDict.keyType.virtualType.ordering.compare(key, getKey(closestI - 1)) > 0)
 
-        val maybeEqual = getKey(closestI)
-
-        val closestIIsClosest =
-          (pDict.keyType.virtualType.ordering.compare(key, maybeEqual) <= 0 || closestI == dict.size - 1) &&
-            (closestI == 0 || pDict.keyType.virtualType.ordering.compare(key, getKey(closestI - 1)) > 0)
-
-        dict.contains(key) ==> (key == maybeEqual) && closestIIsClosest
-
+          dict.contains(key) ==> (key == maybeEqual) && closestIIsClosest
+        }
       }
     }
     p.check()


### PR DESCRIPTION
Binary search changed to return the size of the keys if the given key was greater than all existing keys. The randomized tests weren't updated and would fail intermittently in this case. Added in a check for this case and asserted that the given key is in fact greater than the entire keyset.

Resolves #5630