### PR TITLE
set base image default language to C.UTF-8

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,5 +1,7 @@
 FROM ubuntu:18.04
 
+ENV LANG C.UTF-8
+
 RUN apt-get update && \
   apt-get -y install \
     htop \


### PR DESCRIPTION
The ubuntu 18.04 docker default is ascii, which was causing batch to barf on logs that contained special characters.