### PR TITLE
TArray -> TStreamable within value IR typing

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir
 
-import is.hail.expr.types.virtual.{TArray, TContainer, TFloat64, Type}
+import is.hail.expr.types.virtual._
 
 object Binds {
   def apply(x: IR, v: String, i: Int): Boolean = Bindings(x, i).exists(_._1 == v)
@@ -49,9 +49,9 @@ object AggBindings {
 
   def apply(x: BaseIR, i: Int): Iterable[(String, Type)] = x match {
     case AggLet(name, value, _, false) => if (i == 1) Array(name -> value.typ) else empty
-    case AggExplode(a, name, _, false) => if (i == 1) Array(name -> a.typ.asInstanceOf[TContainer].elementType) else empty
-    case AggArrayPerElement(a, name, _, false) => if (i == 1) Array(name -> a.typ.asInstanceOf[TContainer].elementType) else empty
-    case ArrayAgg(a, name, _) => if (i == 1) Array(name -> a.typ.asInstanceOf[TContainer].elementType) else empty
+    case AggExplode(a, name, _, false) => if (i == 1) Array(name -> a.typ.asInstanceOf[TIterable].elementType) else empty
+    case AggArrayPerElement(a, name, _, false) => if (i == 1) Array(name -> a.typ.asInstanceOf[TIterable].elementType) else empty
+    case ArrayAgg(a, name, _) => if (i == 1) Array(name -> a.typ.asInstanceOf[TIterable].elementType) else empty
     case TableAggregate(child, _) => if (i == 1) child.typ.rowEnv.m else empty
     case MatrixAggregate(child, _) => if (i == 1) child.typ.entryEnv.m else empty
     case TableAggregateByKey(child, _) => if (i == 1) child.typ.rowEnv.m else empty
@@ -69,8 +69,8 @@ object ScanBindings {
 
   def apply(x: BaseIR, i: Int): Iterable[(String, Type)] = x match {
     case AggLet(name, value, _, true) => if (i == 1) Array(name -> value.typ) else empty
-    case AggExplode(a, name, _, true) => if (i == 1) Array(name -> a.typ.asInstanceOf[TContainer].elementType) else empty
-    case AggArrayPerElement(a, name, _, true) => if (i == 1) Array(name -> a.typ.asInstanceOf[TContainer].elementType) else empty
+    case AggExplode(a, name, _, true) => if (i == 1) Array(name -> a.typ.asInstanceOf[TIterable].elementType) else empty
+    case AggArrayPerElement(a, name, _, true) => if (i == 1) Array(name -> a.typ.asInstanceOf[TIterable].elementType) else empty
     case MatrixMapRows(child, _) => if (i == 1) child.typ.rowEnv.m else empty
     case MatrixMapCols(child, _, _) => if (i == 1) child.typ.colEnv.m else empty
     case TableMapRows(child, _) => if (i == 1) child.typ.rowEnv.m else empty

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -60,7 +60,7 @@ case class ArrayIteratorTriplet(calcLength: Code[Unit], length: Option[Code[Int]
   def wrapContinuation(contMap: (Emit.F, Code[Boolean], Code[_]) => Code[Unit]): ArrayIteratorTriplet =
     copy(calcLength = calcLength, length = length, arrayEmitter = { cont: Emit.F => arrayEmitter(contMap(cont, _, _)) })
 
-  def toEmitTriplet(mb: MethodBuilder, aTyp: PArray): EmitTriplet = {
+  def toEmitTriplet(mb: MethodBuilder, aTyp: PStreamable): EmitTriplet = {
     val srvb = new StagedRegionValueBuilder(mb, aTyp)
 
     length match {
@@ -390,7 +390,7 @@ private class Emit(
       case x@ArrayRef(a, i) =>
         val typ = x.typ
         val ti = typeToTypeInfo(typ)
-        val pArray = coerce[PArray](a.pType)
+        val pArray = coerce[PStreamable](a.pType).asPArray
         val ati = coerce[Long](typeToTypeInfo(pArray))
         val codeA = emit(a)
         val codeI = emit(i)
@@ -435,7 +435,7 @@ private class Emit(
         strict(PContainer.loadLength(region, coerce[Long](codeA.v)), codeA)
 
       case x@(_: ArraySort | _: ToSet | _: ToDict) =>
-        val atyp = coerce[PContainer](x.pType)
+        val atyp = coerce[PIterable](x.pType)
         val eltType = -atyp.elementType.virtualType
         val vab = new StagedArrayBuilder(atyp.elementType, mb, 16)
         val sorter = new ArraySorter(mb, vab)
@@ -487,7 +487,7 @@ private class Emit(
         emit(a)
 
       case x@LowerBoundOnOrderedCollection(orderedCollection, elem, onKey) =>
-        val typ = coerce[PContainer](orderedCollection.pType)
+        val typ: PContainer = coerce[PIterable](orderedCollection.pType).asPContainer
         val a = emit(orderedCollection)
         val e = emit(elem)
         val bs = new BinarySearch(mb, typ, keyOnly = onKey)
@@ -506,7 +506,7 @@ private class Emit(
 
       case GroupByKey(collection) =>
         //sort collection by group
-        val atyp = coerce[PArray](collection.pType)
+        val atyp = coerce[PStreamable](collection.pType).asPArray
         val etyp = coerce[PBaseStruct](atyp.elementType)
         val ktyp = etyp.types(0)
         val vtyp = etyp.types(1)
@@ -577,7 +577,7 @@ private class Emit(
                     structbuilder.start(),
                     structbuilder.addIRIntermediate(ktyp)(loadKey(i)),
                     structbuilder.advance(),
-                    structbuilder.addArray(coerce[PArray](eltOut.types(1)), { arraybuilder =>
+                    structbuilder.addArray(coerce[PStreamable](eltOut.types(1)).asPArray, { arraybuilder =>
                       Code(
                         arraybuilder.start(coerce[Int](nab(srvb.arrayIdx))),
                         Code.whileLoop(arraybuilder.arrayIdx < coerce[Int](nab(srvb.arrayIdx)),
@@ -596,11 +596,11 @@ private class Emit(
             ))))
 
       case _: ArrayMap | _: ArrayFilter | _: ArrayRange | _: ArrayFlatMap | _: ArrayScan | _: ArrayLeftJoinDistinct =>
-        emitArrayIterator(ir).toEmitTriplet(mb, coerce[PArray](ir.pType))
+        emitArrayIterator(ir).toEmitTriplet(mb, coerce[PStreamable](ir.pType))
 
       case ArrayFold(a, zero, name1, name2, body) =>
         val typ = ir.typ
-        val tarray = coerce[TArray](a.typ)
+        val tarray = coerce[TStreamable](a.typ)
         val tti = typeToTypeInfo(typ)
         val eti = typeToTypeInfo(tarray.elementType)
         val xmv = mb.newField[Boolean](name2 + "_missing")
@@ -645,7 +645,7 @@ private class Emit(
         ), xmaccum, xvaccum)
 
       case ArrayFor(a, valueName, body) =>
-        val tarray = coerce[TArray](a.typ)
+        val tarray = coerce[TStreamable](a.typ)
         val eti = typeToTypeInfo(tarray.elementType)
         val xmv = mb.newField[Boolean]()
         val xvv = coerce[Any](mb.newField(valueName)(eti))
@@ -678,7 +678,7 @@ private class Emit(
 
         val codeInit = emit(init, rvas = Some(rvas))
 
-        val tarray = coerce[TArray](a.typ)
+        val tarray = coerce[TStreamable](a.typ)
         val eti = typeToTypeInfo(tarray.elementType)
         val xmv = mb.newField[Boolean]()
         val xvv = coerce[Any](mb.newField(name)(eti))
@@ -1241,7 +1241,7 @@ private class Emit(
         emitArrayIterator(a).copy(length = None).wrapContinuation(filterCont)
 
       case x@ArrayFlatMap(a, name, body) =>
-        val elementTypeInfoA = coerce[Any](typeToTypeInfo(coerce[TArray](a.typ).elementType))
+        val elementTypeInfoA = coerce[Any](typeToTypeInfo(coerce[TStreamable](a.typ).elementType))
         val xmv = mb.newField[Boolean]()
         val xvv = mb.newField(name)(elementTypeInfoA)
         val bodyenv = env.bind(name -> (elementTypeInfoA, xmv.load(), xvv.load()))
@@ -1264,7 +1264,7 @@ private class Emit(
         emitArrayIterator(a).copy(length = None).wrapContinuation(bodyCont)
 
       case x@ArrayMap(a, name, body) =>
-        val elt = coerce[TArray](a.typ).elementType
+        val elt = coerce[TStreamable](a.typ).elementType
         val elementTypeInfoA = coerce[Any](typeToTypeInfo(elt))
         val xmv = mb.newField[Boolean]()
         val xvv = mb.newField(name)(elementTypeInfoA)
@@ -1280,7 +1280,7 @@ private class Emit(
         emitArrayIterator(a).wrapContinuation(mapCont)
 
       case x@ArrayScan(a, zero, accumName, eltName, body) =>
-        val elt = coerce[TArray](a.typ).elementType
+        val elt = coerce[TStreamable](a.typ).elementType
         val accumTypeInfo = coerce[Any](typeToTypeInfo(zero.typ))
         val elementTypeInfoA = coerce[Any](typeToTypeInfo(elt))
         val xmbody = mb.newField[Boolean]()
@@ -1362,9 +1362,9 @@ private class Emit(
 
       case x@ArrayLeftJoinDistinct(left, right, l, r, compKey, join) =>
         // no missing
-        val lelt = coerce[TArray](left.typ).elementType
-        val relt = coerce[TArray](right.typ).elementType
-        val rtyp = coerce[PArray](right.pType)
+        val lelt = coerce[TStreamable](left.typ).elementType
+        val relt = coerce[TStreamable](right.typ).elementType
+        val rtyp = coerce[PStreamable](right.pType).asPArray
 
         val larray = emitArrayIterator(left)
         val rarray = emitArrayIterator(right).toEmitTriplet(mb, rtyp)
@@ -1416,7 +1416,7 @@ private class Emit(
         ArrayIteratorTriplet(larray.calcLength, larray.length, ae)
 
       case _ =>
-        val t: PArray = coerce[PArray](ir.pType)
+        val t: PArray = coerce[PStreamable](ir.pType).asPArray
         val i = mb.newLocal[Int]("i")
         val len = mb.newLocal[Int]("len")
         val aoff = mb.newLocal[Long]("aoff")

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -114,13 +114,13 @@ final case class ApplyUnaryPrimOp(op: UnaryOp, x: IR) extends IR
 final case class ApplyComparisonOp(op: ComparisonOp[_], l: IR, r: IR) extends IR
 
 object MakeArray {
-  def unify(args: Seq[IR], typ: TStreamable = null): MakeArray = {
+  def unify(args: Seq[IR], typ: TArray = null): MakeArray = {
     assert(typ != null || args.nonEmpty)
-    var t: TStreamable = typ
+    var t: TArray = typ
     if (t == null) {
       t = if (args.tail.forall(_.typ == args.head.typ)) {
-        TStream(args.head.typ)
-      } else TStream(args.head.typ.deepOptional())
+        TArray(args.head.typ)
+      } else TArray(args.head.typ.deepOptional())
     }
     assert(t.elementType.deepOptional() == t.elementType ||
       args.forall(a => a.typ == t.elementType),
@@ -138,7 +138,7 @@ object MakeArray {
   }
 }
 
-final case class MakeArray(args: Seq[IR], _typ: TStreamable) extends IR
+final case class MakeArray(args: Seq[IR], _typ: TArray) extends IR
 final case class ArrayRef(a: IR, i: IR) extends IR
 final case class ArrayLen(a: IR) extends IR
 final case class ArrayRange(start: IR, stop: IR, step: IR) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -114,13 +114,13 @@ final case class ApplyUnaryPrimOp(op: UnaryOp, x: IR) extends IR
 final case class ApplyComparisonOp(op: ComparisonOp[_], l: IR, r: IR) extends IR
 
 object MakeArray {
-  def unify(args: Seq[IR], typ: TArray = null): MakeArray = {
+  def unify(args: Seq[IR], typ: TStreamable = null): MakeArray = {
     assert(typ != null || args.nonEmpty)
-    var t = typ
+    var t: TStreamable = typ
     if (t == null) {
       t = if (args.tail.forall(_.typ == args.head.typ)) {
-        TArray(args.head.typ)
-      } else TArray(args.head.typ.deepOptional())
+        TStream(args.head.typ)
+      } else TStream(args.head.typ.deepOptional())
     }
     assert(t.elementType.deepOptional() == t.elementType ||
       args.forall(a => a.typ == t.elementType),
@@ -138,7 +138,7 @@ object MakeArray {
   }
 }
 
-final case class MakeArray(args: Seq[IR], _typ: TArray) extends IR
+final case class MakeArray(args: Seq[IR], _typ: TStreamable) extends IR
 final case class ArrayRef(a: IR, i: IR) extends IR
 final case class ArrayLen(a: IR) extends IR
 final case class ArrayRange(start: IR, stop: IR, step: IR) extends IR
@@ -148,15 +148,15 @@ object ArraySort {
   def apply(a: IR, ascending: IR = True(), onKey: Boolean = false): ArraySort = {
     val l = genUID()
     val r = genUID()
-    val atyp = coerce[TContainer](a.typ)
+    val atyp = coerce[TIterable](a.typ)
     val compare = if (onKey) {
       a.typ match {
         case atyp: TDict =>
           ApplyComparisonOp(Compare(atyp.keyType), GetField(Ref(l, atyp.elementType), "key"), GetField(Ref(r, atyp.elementType), "key"))
-        case atyp: TArray if atyp.elementType.isInstanceOf[TStruct] =>
+        case atyp: TStreamable if atyp.elementType.isInstanceOf[TStruct] =>
           val elt = coerce[TStruct](atyp.elementType)
           ApplyComparisonOp(Compare(elt.types(0)), GetField(Ref(l, elt), elt.fieldNames(0)), GetField(Ref(r, atyp.elementType), elt.fieldNames(0)))
-        case atyp: TArray if atyp.elementType.isInstanceOf[TTuple] =>
+        case atyp: TStreamable if atyp.elementType.isInstanceOf[TTuple] =>
           val elt = coerce[TTuple](atyp.elementType)
           ApplyComparisonOp(Compare(elt.types(0)), GetTupleElement(Ref(l, elt), 0), GetTupleElement(Ref(r, atyp.elementType), 0))
       }
@@ -178,14 +178,14 @@ final case class LowerBoundOnOrderedCollection(orderedCollection: IR, elem: IR, 
 final case class GroupByKey(collection: IR) extends IR
 
 final case class ArrayMap(a: IR, name: String, body: IR) extends IR {
-  override def typ: TArray = coerce[TArray](super.typ)
+  override def typ: TStreamable = coerce[TStreamable](super.typ)
   def elementTyp: Type = typ.elementType
 }
 final case class ArrayFilter(a: IR, name: String, cond: IR) extends IR {
-  override def typ: TArray = super.typ.asInstanceOf[TArray]
+  override def typ: TStreamable = coerce[TStreamable](super.typ)
 }
 final case class ArrayFlatMap(a: IR, name: String, body: IR) extends IR {
-  override def typ: TArray = coerce[TArray](super.typ)
+  override def typ: TStreamable = coerce[TStreamable](super.typ)
 }
 final case class ArrayFold(a: IR, zero: IR, accumName: String, valueName: String, body: IR) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -29,7 +29,7 @@ object InferPType {
       case MakeArray(_, t) => PType.canonical(t)
       case MakeNDArray(data, _, _) => PNDArray(data.pType.asInstanceOf[PStreamable].elementType)
       case _: ArrayLen => PInt32()
-      case _: ArrayRange => PStream(PInt32())
+      case _: ArrayRange => PArray(PInt32())
       case _: LowerBoundOnOrderedCollection => PInt32()
       case _: ArrayFor => PVoid
       case _: InitOp => PVoid

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -29,7 +29,7 @@ object InferType {
       case MakeArray(_, t) => t
       case MakeNDArray(data, _, _) => TNDArray(data.typ.asInstanceOf[TStreamable].elementType)
       case _: ArrayLen => TInt32()
-      case _: ArrayRange => TStream(TInt32())
+      case _: ArrayRange => TArray(TInt32())
       case _: LowerBoundOnOrderedCollection => TInt32()
       case _: ArrayFor => TVoid
       case _: InitOp => TVoid

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -311,7 +311,7 @@ object Interpret {
           aValue.asInstanceOf[IndexedSeq[Row]].filter(_ != null).map { case Row(k, v) => (k, v) }.toMap
 
       case ToArray(c) =>
-        val ordering = coerce[TContainer](c.typ).elementType.ordering.toOrdering
+        val ordering = coerce[TIterable](c.typ).elementType.ordering.toOrdering
         val cValue = interpret(c, env, args, agg)
         if (cValue == null)
           null

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -587,7 +587,7 @@ object IRParser {
         val op = ComparisonOp.fromStringAndTypes(opName, l.typ, r.typ)
         ApplyComparisonOp(op, l, r)
       case "MakeArray" =>
-        val typ = opt(it, type_expr).map(_.asInstanceOf[TStreamable]).orNull
+        val typ = opt(it, type_expr).map(_.asInstanceOf[TArray]).orNull
         val args = ir_value_children(env)(it)
         MakeArray.unify(args, typ)
       case "ArrayRef" =>

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -587,7 +587,7 @@ object IRParser {
         val op = ComparisonOp.fromStringAndTypes(opName, l.typ, r.typ)
         ApplyComparisonOp(op, l, r)
       case "MakeArray" =>
-        val typ = opt(it, type_expr).map(_.asInstanceOf[TArray]).orNull
+        val typ = opt(it, type_expr).map(_.asInstanceOf[TStreamable]).orNull
         val args = ir_value_children(env)(it)
         MakeArray.unify(args, typ)
       case "ArrayRef" =>
@@ -604,7 +604,7 @@ object IRParser {
         val l = identifier(it)
         val r = identifier(it)
         val a = ir_value_expr(env)(it)
-        val elt = coerce[TArray](a.typ).elementType
+        val elt = coerce[TStreamable](a.typ).elementType
         val body = ir_value_expr(env + (l -> elt) + (r -> elt))(it)
         ArraySort(a, l, r, body)
       case "MakeNDArray" =>
@@ -631,24 +631,24 @@ object IRParser {
       case "ArrayMap" =>
         val name = identifier(it)
         val a = ir_value_expr(env)(it)
-        val body = ir_value_expr(env + (name -> coerce[TArray](a.typ).elementType))(it)
+        val body = ir_value_expr(env + (name -> coerce[TStreamable](a.typ).elementType))(it)
         ArrayMap(a, name, body)
       case "ArrayFilter" =>
         val name = identifier(it)
         val a = ir_value_expr(env)(it)
-        val body = ir_value_expr(env + (name -> coerce[TArray](a.typ).elementType))(it)
+        val body = ir_value_expr(env + (name -> coerce[TStreamable](a.typ).elementType))(it)
         ArrayFilter(a, name, body)
       case "ArrayFlatMap" =>
         val name = identifier(it)
         val a = ir_value_expr(env)(it)
-        val body = ir_value_expr(env + (name -> coerce[TArray](a.typ).elementType))(it)
+        val body = ir_value_expr(env + (name -> coerce[TStreamable](a.typ).elementType))(it)
         ArrayFlatMap(a, name, body)
       case "ArrayFold" =>
         val accumName = identifier(it)
         val valueName = identifier(it)
         val a = ir_value_expr(env)(it)
         val zero = ir_value_expr(env)(it)
-        val eltType = coerce[TArray](a.typ).elementType
+        val eltType = coerce[TStreamable](a.typ).elementType
         val body = ir_value_expr(env.update(Map(accumName -> zero.typ, valueName -> eltType)))(it)
         ArrayFold(a, zero, accumName, valueName, body)
       case "ArrayScan" =>
@@ -656,7 +656,7 @@ object IRParser {
         val valueName = identifier(it)
         val a = ir_value_expr(env)(it)
         val zero = ir_value_expr(env)(it)
-        val eltType = coerce[TArray](a.typ).elementType
+        val eltType = coerce[TStreamable](a.typ).elementType
         val body = ir_value_expr(env.update(Map(accumName -> zero.typ, valueName -> eltType)))(it)
         ArrayScan(a, zero, accumName, valueName, body)
       case "ArrayLeftJoinDistinct" =>
@@ -664,18 +664,20 @@ object IRParser {
         val r = identifier(it)
         val left = ir_value_expr(env)(it)
         val right = ir_value_expr(env)(it)
-        val comp = ir_value_expr(env.update(Map(l -> coerce[TArray](left.typ).elementType, r -> coerce[TArray](right.typ).elementType)))(it)
-        val join = ir_value_expr(env.update(Map(l -> coerce[TArray](left.typ).elementType, r -> coerce[TArray](right.typ).elementType)))(it)
+        val lelt = coerce[TStreamable](left.typ).elementType
+        val relt = coerce[TStreamable](right.typ).elementType
+        val comp = ir_value_expr(env.update(Map(l -> lelt, r -> relt)))(it)
+        val join = ir_value_expr(env.update(Map(l -> lelt, r -> relt)))(it)
         ArrayLeftJoinDistinct(left, right, l, r, comp, join)
       case "ArrayFor" =>
         val name = identifier(it)
         val a = ir_value_expr(env)(it)
-        val body = ir_value_expr(env + (name, coerce[TArray](a.typ).elementType))(it)
+        val body = ir_value_expr(env + (name, coerce[TStreamable](a.typ).elementType))(it)
         ArrayFor(a, name, body)
       case "ArrayAgg" =>
         val name = identifier(it)
         val a = ir_value_expr(env)(it)
-        val query = ir_value_expr(env + (name, coerce[TArray](a.typ).elementType))(it)
+        val query = ir_value_expr(env + (name, coerce[TStreamable](a.typ).elementType))(it)
         ArrayAgg(a, name, query)
       case "AggFilter" =>
         val isScan = boolean_literal(it)
@@ -686,7 +688,7 @@ object IRParser {
         val name = identifier(it)
         val isScan = boolean_literal(it)
         val a = ir_value_expr(env)(it)
-        val aggBody = ir_value_expr(env + (name -> coerce[TArray](a.typ).elementType))(it)
+        val aggBody = ir_value_expr(env + (name -> coerce[TStreamable](a.typ).elementType))(it)
         AggExplode(a, name, aggBody, isScan)
       case "AggGroupBy" =>
         val isScan = boolean_literal(it)
@@ -697,7 +699,7 @@ object IRParser {
         val name = identifier(it)
         val isScan = boolean_literal(it)
         val a = ir_value_expr(env)(it)
-        val aggBody = ir_value_expr(env + (name -> coerce[TArray](a.typ).elementType))(it)
+        val aggBody = ir_value_expr(env + (name -> coerce[TStreamable](a.typ).elementType))(it)
         AggArrayPerElement(a, name, aggBody, isScan)
       case "ApplyAggOp" =>
         val aggOp = agg_op(it)
@@ -843,7 +845,7 @@ object IRParser {
         val gname = identifier(it)
         val ctxs = ir_value_expr(env)(it)
         val globals = ir_value_expr(env)(it)
-        val body = ir_value_expr(env + (cname, coerce[TArray](ctxs.typ).elementType) + (gname, globals.typ))(it)
+        val body = ir_value_expr(env + (cname, coerce[TStreamable](ctxs.typ).elementType) + (gname, globals.typ))(it)
         CollectDistributedArray(ctxs, globals, cname, gname, body)
       case "JavaIR" =>
         val name = identifier(it)

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1266,7 +1266,7 @@ object PruneDeadFields {
       case Ref(name, t) =>
         Ref(name, in.lookupOption(name).getOrElse(t))
       case MakeArray(args, t) =>
-        val depArray = requestedType.asInstanceOf[TStreamable]
+        val depArray = requestedType.asInstanceOf[TArray]
         MakeArray(args.map(a => upcast(rebuild(a, in, memo), depArray.elementType)), depArray)
       case ArrayMap(a, name, body) =>
         val a2 = rebuild(a, in, memo)

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -13,7 +13,7 @@ object PruneDeadFields {
     else
       t match {
         case ts: TStruct => TStruct(ts.required, path(index) -> subsetType(ts.field(path(index)).typ, path, index + 1))
-        case ta: TArray => TArray(subsetType(ta.elementType, path, index), ta.required)
+        case ta: TStreamable => ta.copyStreamable(subsetType(ta.elementType, path, index))
       }
   }
 
@@ -29,6 +29,7 @@ object PruneDeadFields {
             isSupertype(mt1.colType, mt2.colType) &&
             isSupertype(mt1.entryType, mt2.entryType)
         case (TArray(et1, r1), TArray(et2, r2)) => (!r1 || r2) && isSupertype(et1, et2)
+        case (TStream(et1, r1), TStream(et2, r2)) => (!r1 || r2) && isSupertype(et1, et2)
         case (TSet(et1, r1), TSet(et2, r2)) => (!r1 || r2) && isSupertype(et1, et2)
         case (TDict(kt1, vt1, r1), TDict(kt2, vt2, r2)) => (!r1 || r2) && isSupertype(kt1, kt2) && isSupertype(vt1, vt2)
         case (s1: TStruct, s2: TStruct) =>
@@ -134,7 +135,7 @@ object PruneDeadFields {
   def minimal[T <: Type](base: T): T = {
     val result = base match {
       case ts: TStruct => TStruct(ts.required)
-      case ta: TArray => TArray(minimal(ta.elementType), ta.required)
+      case ta: TStreamable => ta.copyStreamable(minimal(ta.elementType))
       case t => t
     }
     result.asInstanceOf[T]
@@ -182,8 +183,8 @@ object PruneDeadFields {
           case tt: TTuple =>
             val subTuples = children.map(_.asInstanceOf[TTuple])
             TTuple(tt.required, tt.types.indices.map(i => unifySeq(tt.types(i), subTuples.map(_.types(i)))): _*)
-          case ta: TArray =>
-            TArray(unifySeq(ta.elementType, children.map(_.asInstanceOf[TArray].elementType)), ta.required)
+          case ta: TStreamable =>
+            ta.copyStreamable(unifySeq(ta.elementType, children.map(_.asInstanceOf[TStreamable].elementType)))
           case _ =>
             assert(children.forall(_.asInstanceOf[Type].isOfType(t)))
             base
@@ -329,10 +330,10 @@ object PruneDeadFields {
         }
       case TableMultiWayZipJoin(children, fieldName, globalName) =>
         val gType = requestedType.globalType.fieldOption(globalName)
-          .map(_.typ.asInstanceOf[TArray].elementType)
+          .map(_.typ.asInstanceOf[TStreamable].elementType)
           .getOrElse(TStruct()).asInstanceOf[TStruct]
         val rType = requestedType.rowType.fieldOption(fieldName)
-          .map(_.typ.asInstanceOf[TArray].elementType)
+          .map(_.typ.asInstanceOf[TStreamable].elementType)
           .getOrElse(TStruct()).asInstanceOf[TStruct]
         val child1 = children.head
         val dep = child1.typ.copy(
@@ -348,7 +349,7 @@ object PruneDeadFields {
         val prunedPreExlosionFieldType = try {
           val t = getExplodedField(requestedType)
           preExplosionFieldType match {
-            case ta: TArray => ta.copy(elementType = t)
+            case ta: TStreamable => ta.copyStreamable(t)
             case ts: TSet => ts.copy(elementType = t)
           }
         } catch {
@@ -428,7 +429,7 @@ object PruneDeadFields {
             requestedType.globalType,
           colType = if (requestedType.globalType.hasField(colsFieldName))
             unify(child.typ.colType, minChild.colType,
-              requestedType.globalType.field(colsFieldName).typ.asInstanceOf[TArray].elementType.asInstanceOf[TStruct])
+              requestedType.globalType.field(colsFieldName).typ.asInstanceOf[TStreamable].elementType.asInstanceOf[TStruct])
           else
             minChild.colType,
           rvRowType = unify(child.typ.rvRowType, minChild.rvRowType, requestedType.rowType.rename(m)))
@@ -468,8 +469,12 @@ object PruneDeadFields {
       case MatrixMapEntries(child, newEntries) =>
         val irDep = memoizeAndGetDep(newEntries, requestedType.entryType, child.typ, memo)
         val depMod = requestedType.copy(rvRowType = TStruct(requestedType.rvRowType.required, requestedType.rvRowType.fields.map { f =>
-          if (f.name == MatrixType.entriesIdentifier)
-            f.name -> f.typ.asInstanceOf[TArray].copy(elementType = irDep.entryType)
+          if (f.name == MatrixType.entriesIdentifier) {
+            f.name -> (f.typ match {
+              case t: TStreamable => t.copyStreamable(irDep.entryType)
+              case t: TStream => t.copy(elementType = irDep.entryType)
+            })
+          }
           else
             f.name -> f.typ
         }: _*))
@@ -508,14 +513,14 @@ object PruneDeadFields {
             if (colKeySet.contains(f.name))
               f.name -> f.typ
             else {
-              f.name -> f.typ.asInstanceOf[TArray].elementType
+              f.name -> f.typ.asInstanceOf[TStreamable].elementType
             }
           }: _*),
           rvRowType = requestedType.rvRowType.copy(fields = requestedType.rvRowType.fields.map { f =>
             if (f.name == MatrixType.entriesIdentifier)
               f.copy(typ = TArray(
                 TStruct(requestedType.entryType.required, requestedType.entryType.fields.map(ef =>
-                  ef.name -> ef.typ.asInstanceOf[TArray].elementType): _*), f.typ.required))
+                  ef.name -> ef.typ.asInstanceOf[TStreamable].elementType): _*), f.typ.required))
             else
               f
           })
@@ -599,7 +604,7 @@ object PruneDeadFields {
         val prunedPreExlosionFieldType = try {
           val t = getExplodedField(requestedType)
           preExplosionFieldType match {
-            case ta: TArray => ta.copy(elementType = t)
+            case ta: TStreamable => ta.copyStreamable(t)
             case ts: TSet => ts.copy(elementType = t)
           }
         } catch {
@@ -615,7 +620,7 @@ object PruneDeadFields {
         val prunedPreExplosionFieldType = try {
           val t = getExplodedField(requestedType)
           preExplosionFieldType match {
-            case ta: TArray => ta.copy(elementType = t)
+            case ta: TStreamable => ta.copyStreamable(t)
             case ts: TSet => ts.copy(elementType = t)
           }
         } catch {
@@ -769,49 +774,49 @@ object PruneDeadFields {
         ab += requestedType
         BindingEnv.empty.bindEval(name -> ab)
       case MakeArray(args, _) =>
-        val eltType = requestedType.asInstanceOf[TArray].elementType
+        val eltType = requestedType.asInstanceOf[TStreamable].elementType
         unifyEnvsSeq(args.map(a => memoizeValueIR(a, eltType, memo)))
       case ArrayRef(a, i) =>
         unifyEnvs(
-          memoizeValueIR(a, a.typ.asInstanceOf[TArray].copy(elementType = requestedType), memo),
+          memoizeValueIR(a, a.typ.asInstanceOf[TStreamable].copyStreamable(requestedType), memo),
           memoizeValueIR(i, i.typ, memo))
       case ArrayLen(a) =>
         memoizeValueIR(a, minimal(a.typ), memo)
       case ArrayMap(a, name, body) =>
-        val aType = a.typ.asInstanceOf[TArray]
+        val aType = a.typ.asInstanceOf[TStreamable]
         val bodyEnv = memoizeValueIR(body,
-          requestedType.asInstanceOf[TArray].elementType,
+          requestedType.asInstanceOf[TStreamable].elementType,
           memo)
         val valueType = unifySeq(
           aType.elementType,
           bodyEnv.eval.lookupOption(name).map(_.result()).getOrElse(Array()))
         unifyEnvs(
           bodyEnv.deleteEval(name),
-          memoizeValueIR(a, aType.copy(elementType = valueType), memo)
+          memoizeValueIR(a, aType.copyStreamable(valueType), memo)
         )
       case ArrayFilter(a, name, cond) =>
-        val aType = a.typ.asInstanceOf[TArray]
+        val aType = a.typ.asInstanceOf[TStreamable]
         val bodyEnv = memoizeValueIR(cond, cond.typ, memo)
         val valueType = unifySeq(
           aType.elementType,
-          FastIndexedSeq(requestedType.asInstanceOf[TArray].elementType) ++
+          FastIndexedSeq(requestedType.asInstanceOf[TStreamable].elementType) ++
             bodyEnv.eval.lookupOption(name).map(_.result()).getOrElse(Array()))
         unifyEnvs(
           bodyEnv.deleteEval(name),
-          memoizeValueIR(a, aType.copy(elementType = valueType), memo)
+          memoizeValueIR(a, aType.copyStreamable(valueType), memo)
         )
       case ArrayFlatMap(a, name, body) =>
-        val aType = a.typ.asInstanceOf[TArray]
+        val aType = a.typ.asInstanceOf[TStreamable]
         val bodyEnv = memoizeValueIR(body, requestedType, memo)
         val valueType = unifySeq(
           aType.elementType,
           bodyEnv.eval.lookupOption(name).map(_.result()).getOrElse(Array()))
         unifyEnvs(
           bodyEnv.deleteEval(name),
-          memoizeValueIR(a, aType.copy(elementType = valueType), memo)
+          memoizeValueIR(a, aType.copyStreamable(valueType), memo)
         )
       case ArrayFold(a, zero, accumName, valueName, body) =>
-        val aType = a.typ.asInstanceOf[TArray]
+        val aType = a.typ.asInstanceOf[TStreamable]
         val zeroEnv = memoizeValueIR(zero, zero.typ, memo)
         val bodyEnv = memoizeValueIR(body, body.typ, memo)
         val valueType = unifySeq(
@@ -821,10 +826,10 @@ object PruneDeadFields {
         unifyEnvs(
           zeroEnv,
           bodyEnv.deleteEval(valueName).deleteEval(accumName),
-          memoizeValueIR(a, aType.copy(elementType = valueType), memo)
+          memoizeValueIR(a, aType.copyStreamable(valueType), memo)
         )
       case ArrayScan(a, zero, accumName, valueName, body) =>
-        val aType = a.typ.asInstanceOf[TArray]
+        val aType = a.typ.asInstanceOf[TStreamable]
         val zeroEnv = memoizeValueIR(zero, zero.typ, memo)
         val bodyEnv = memoizeValueIR(body, body.typ, memo)
         val valueType = unifySeq(
@@ -833,14 +838,14 @@ object PruneDeadFields {
         unifyEnvs(
           zeroEnv,
           bodyEnv.deleteEval(valueName).deleteEval(accumName),
-          memoizeValueIR(a, aType.copy(elementType = valueType), memo)
+          memoizeValueIR(a, aType.copyStreamable(valueType), memo)
         )
       case ArrayLeftJoinDistinct(left, right, l, r, compare, join) =>
-        val lType = left.typ.asInstanceOf[TArray]
-        val rType = right.typ.asInstanceOf[TArray]
+        val lType = left.typ.asInstanceOf[TStreamable]
+        val rType = right.typ.asInstanceOf[TStreamable]
 
         val compEnv = memoizeValueIR(compare, compare.typ, memo)
-        val joinEnv = memoizeValueIR(join, requestedType.asInstanceOf[TArray].elementType, memo)
+        val joinEnv = memoizeValueIR(join, requestedType.asInstanceOf[TStreamable].elementType, memo)
 
         val combEnv = unifyEnvs(compEnv, joinEnv)
 
@@ -854,19 +859,19 @@ object PruneDeadFields {
 
         unifyEnvs(
           combEnv.deleteEval(l).deleteEval(r),
-          memoizeValueIR(left, lType.copy(elementType = lRequested), memo),
-          memoizeValueIR(right, rType.copy(elementType = rRequested), memo))
+          memoizeValueIR(left, lType.copyStreamable(lRequested), memo),
+          memoizeValueIR(right, rType.copyStreamable(rRequested), memo))
       case ArraySort(a, left, right, compare) =>
         val compEnv = memoizeValueIR(compare, compare.typ, memo)
 
-        val aType = a.typ.asInstanceOf[TArray]
+        val aType = a.typ.asInstanceOf[TStreamable]
         val requestedElementType = unifySeq(
           aType.elementType,
-          Array(requestedType.asInstanceOf[TArray].elementType) ++
+          Array(requestedType.asInstanceOf[TStreamable].elementType) ++
           compEnv.eval.lookupOption(left).map(_.result()).getOrElse(Array()) ++
           compEnv.eval.lookupOption(right).map(_.result()).getOrElse(Array()))
 
-        val aEnv = memoizeValueIR(a, aType.copy(elementType = requestedElementType), memo)
+        val aEnv = memoizeValueIR(a, aType.copyStreamable(requestedElementType), memo)
 
         unifyEnvs(
           compEnv.deleteEval(left).deleteEval(right),
@@ -874,17 +879,17 @@ object PruneDeadFields {
         )
       case ArrayFor(a, valueName, body) =>
         assert(requestedType == TVoid)
-        val aType = a.typ.asInstanceOf[TArray]
+        val aType = a.typ.asInstanceOf[TStreamable]
         val bodyEnv = memoizeValueIR(body, body.typ, memo)
         val valueType = unifySeq(
           aType.elementType,
           bodyEnv.eval.lookupOption(valueName).map(_.result()).getOrElse(Array()))
         unifyEnvs(
           bodyEnv.deleteEval(valueName),
-          memoizeValueIR(a, aType.copy(elementType = valueType), memo)
+          memoizeValueIR(a, aType.copyStreamable(valueType), memo)
         )
       case AggExplode(a, name, body, isScan) =>
-        val aType = a.typ.asInstanceOf[TArray]
+        val aType = a.typ.asInstanceOf[TStreamable]
         val bodyEnv = memoizeValueIR(body,
           requestedType,
           memo)
@@ -893,7 +898,7 @@ object PruneDeadFields {
             aType.elementType,
             bodyEnv.scanOrEmpty.lookupOption(name).map(_.result()).getOrElse(Array()))
 
-          val aEnv = memoizeValueIR(a, aType.copy(elementType = valueType), memo)
+          val aEnv = memoizeValueIR(a, aType.copyStreamable(valueType), memo)
           unifyEnvs(
             BindingEnv(scan = bodyEnv.scan.map(_.delete(name))),
             BindingEnv(scan = Some(aEnv.eval))
@@ -903,7 +908,7 @@ object PruneDeadFields {
             aType.elementType,
             bodyEnv.aggOrEmpty.lookupOption(name).map(_.result()).getOrElse(Array()))
 
-          val aEnv = memoizeValueIR(a, aType.copy(elementType = valueType), memo)
+          val aEnv = memoizeValueIR(a, aType.copyStreamable(valueType), memo)
           unifyEnvs(
             BindingEnv(agg = bodyEnv.agg.map(_.delete(name))),
             BindingEnv(agg = Some(aEnv.eval))
@@ -928,16 +933,16 @@ object PruneDeadFields {
           memoizeValueIR(aggIR, requestedType.asInstanceOf[TDict].valueType, memo)
         )
       case AggArrayPerElement(a, name, aggBody, isScan) =>
-        val aType = a.typ.asInstanceOf[TArray]
+        val aType = a.typ.asInstanceOf[TStreamable]
         val bodyEnv = memoizeValueIR(aggBody,
-          requestedType.asInstanceOf[TArray].elementType,
+          requestedType.asInstanceOf[TStreamable].elementType,
           memo)
         if (isScan) {
           val valueType = unifySeq(
             aType.elementType,
             bodyEnv.scanOrEmpty.lookupOption(name).map(_.result()).getOrElse(Array()))
 
-          val aEnv = memoizeValueIR(a, aType.copy(elementType = valueType), memo)
+          val aEnv = memoizeValueIR(a, aType.copyStreamable(valueType), memo)
           unifyEnvs(
             bodyEnv.copy(scan = bodyEnv.scan.map(_.delete(name))),
             BindingEnv(scan = Some(aEnv.eval))
@@ -947,7 +952,7 @@ object PruneDeadFields {
             aType.elementType,
             bodyEnv.aggOrEmpty.lookupOption(name).map(_.result()).getOrElse(Array()))
 
-          val aEnv = memoizeValueIR(a, aType.copy(elementType = valueType), memo)
+          val aEnv = memoizeValueIR(a, aType.copyStreamable(valueType), memo)
           unifyEnvs(
             bodyEnv.copy(agg = bodyEnv.agg.map(_.delete(name))),
             BindingEnv(agg = Some(aEnv.eval))
@@ -972,12 +977,12 @@ object PruneDeadFields {
 
         BindingEnv(eval = initEnv.eval, scan = Some(seqOpEnv.eval))
       case ArrayAgg(a, name, query) =>
-        val aType = a.typ.asInstanceOf[TArray]
+        val aType = a.typ.asInstanceOf[TStreamable]
         val queryEnv = memoizeValueIR(query, requestedType, memo)
         val requestedElemType = unifySeq(
           aType.elementType,
           queryEnv.aggOrEmpty.lookupOption(name).map(_.result()).getOrElse(Array()))
-        val aEnv = memoizeValueIR(a, aType.copy(elementType = requestedElemType), memo)
+        val aEnv = memoizeValueIR(a, aType.copyStreamable(requestedElemType), memo)
         unifyEnvs(
           BindingEnv(eval = concatEnvs(Array(queryEnv.eval, queryEnv.agg.get.delete(name)))),
           aEnv)
@@ -1039,7 +1044,7 @@ object PruneDeadFields {
         memoizeTableIR(child, TableType(
           unify(child.typ.rowType,
             minimalChild.rowType,
-            rStruct.fieldOption("rows").map(_.typ.asInstanceOf[TArray].elementType.asInstanceOf[TStruct]).getOrElse(TStruct())),
+            rStruct.fieldOption("rows").map(_.typ.asInstanceOf[TStreamable].elementType.asInstanceOf[TStruct]).getOrElse(TStruct())),
           minimalChild.key,
           rStruct.fieldOption("global").map(_.typ.asInstanceOf[TStruct]).getOrElse(TStruct())),
           memo)
@@ -1261,17 +1266,17 @@ object PruneDeadFields {
       case Ref(name, t) =>
         Ref(name, in.lookupOption(name).getOrElse(t))
       case MakeArray(args, t) =>
-        val depArray = requestedType.asInstanceOf[TArray]
-        MakeArray(args.map(a => upcast(rebuild(a, in, memo), depArray.elementType)), requestedType.asInstanceOf[TArray])
+        val depArray = requestedType.asInstanceOf[TStreamable]
+        MakeArray(args.map(a => upcast(rebuild(a, in, memo), depArray.elementType)), depArray)
       case ArrayMap(a, name, body) =>
         val a2 = rebuild(a, in, memo)
-        ArrayMap(a2, name, rebuild(body, in.bind(name, -a2.typ.asInstanceOf[TArray].elementType), memo))
+        ArrayMap(a2, name, rebuild(body, in.bind(name, -a2.typ.asInstanceOf[TStreamable].elementType), memo))
       case ArrayFilter(a, name, cond) =>
         val a2 = rebuild(a, in, memo)
-        ArrayFilter(a2, name, rebuild(cond, in.bind(name, -a2.typ.asInstanceOf[TArray].elementType), memo))
+        ArrayFilter(a2, name, rebuild(cond, in.bind(name, -a2.typ.asInstanceOf[TStreamable].elementType), memo))
       case ArrayFlatMap(a, name, body) =>
         val a2 = rebuild(a, in, memo)
-        ArrayFlatMap(a2, name, rebuild(body, in.bind(name, -a2.typ.asInstanceOf[TArray].elementType), memo))
+        ArrayFlatMap(a2, name, rebuild(body, in.bind(name, -a2.typ.asInstanceOf[TStreamable].elementType), memo))
       case ArrayFold(a, zero, accumName, valueName, body) =>
         val a2 = rebuild(a, in, memo)
         val z2 = rebuild(zero, in, memo)
@@ -1280,7 +1285,7 @@ object PruneDeadFields {
           z2,
           accumName,
           valueName,
-          rebuild(body, in.bind(accumName -> z2.typ, valueName -> -a2.typ.asInstanceOf[TArray].elementType), memo)
+          rebuild(body, in.bind(accumName -> z2.typ, valueName -> -a2.typ.asInstanceOf[TStreamable].elementType), memo)
         )
       case ArrayScan(a, zero, accumName, valueName, body) =>
         val a2 = rebuild(a, in, memo)
@@ -1290,14 +1295,14 @@ object PruneDeadFields {
           z2,
           accumName,
           valueName,
-          rebuild(body, in.bind(accumName -> z2.typ, valueName -> -a2.typ.asInstanceOf[TArray].elementType), memo)
+          rebuild(body, in.bind(accumName -> z2.typ, valueName -> -a2.typ.asInstanceOf[TStreamable].elementType), memo)
         )
       case ArrayLeftJoinDistinct(left, right, l, r, compare, join) =>
         val left2 = rebuild(left, in, memo)
         val right2 = rebuild(right, in, memo)
 
-        val ltyp = left2.typ.asInstanceOf[TArray]
-        val rtyp = right2.typ.asInstanceOf[TArray]
+        val ltyp = left2.typ.asInstanceOf[TStreamable]
+        val rtyp = right2.typ.asInstanceOf[TStreamable]
         ArrayLeftJoinDistinct(
           left2, right2, l, r,
           rebuild(compare, in.bind(l -> -ltyp.elementType, r -> -rtyp.elementType), memo),
@@ -1305,11 +1310,11 @@ object PruneDeadFields {
 
       case ArrayFor(a, valueName, body) =>
         val a2 = rebuild(a, in, memo)
-        val body2 = rebuild(body, in.bind(valueName -> -a2.typ.asInstanceOf[TArray].elementType), memo)
+        val body2 = rebuild(body, in.bind(valueName -> -a2.typ.asInstanceOf[TStreamable].elementType), memo)
         ArrayFor(a2, valueName, body2)
       case ArraySort(a, left, right, compare) =>
         val a2 = rebuild(a, in, memo)
-        val et = -a2.typ.asInstanceOf[TArray].elementType
+        val et = -a2.typ.asInstanceOf[TStreamable].elementType
         val compare2 = rebuild(compare, in.bind(left -> et, right -> et), memo)
         ArraySort(a2, left, right, compare2)
       case MakeStruct(fields) =>
@@ -1370,7 +1375,7 @@ object PruneDeadFields {
         ArrayAgg(
           a2,
           name,
-          rebuild(query, in.bind(name, a2.typ.asInstanceOf[TArray].elementType), memo)
+          rebuild(query, in.bind(name, a2.typ.asInstanceOf[TStreamable].elementType), memo)
         )
       case _ =>
         ir.copy(ir.children.map {
@@ -1397,8 +1402,8 @@ object PruneDeadFields {
             }
           )
           Let(uid, ir, ms)
-        case ta: TArray =>
-          val ra = rType.asInstanceOf[TArray]
+        case ta: TStreamable =>
+          val ra = rType.asInstanceOf[TStreamable]
           val uid = genUID()
           val ref = Ref(uid, -ta.elementType)
           ArrayMap(ir, uid, upcast(ref, ra.elementType))

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -295,7 +295,7 @@ object Simplify {
             g1.typ.asInstanceOf[TStruct].fields.map(f => f.name -> (GetField(Ref(g1s, g1.typ), f.name): IR)) ++
               g2.typ.asInstanceOf[TStruct].fields.map(f => f.name -> (GetField(Ref(g2s, g2.typ), f.name): IR)))))
     case TableGetGlobals(x@TableMultiWayZipJoin(children, _, globalName)) =>
-      MakeStruct(FastSeq(globalName -> MakeArray(children.map(TableGetGlobals), TArray(children.head.typ.globalType))))
+      MakeStruct(FastSeq(globalName -> MakeArray(children.map(TableGetGlobals), TStream(children.head.typ.globalType))))
     case TableGetGlobals(TableZipUnchecked(left, _)) => TableGetGlobals(left)
     case TableGetGlobals(TableLeftJoinRightDistinct(child, _, _)) => TableGetGlobals(child)
     case TableGetGlobals(TableMapRows(child, _)) => TableGetGlobals(child)

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -295,7 +295,7 @@ object Simplify {
             g1.typ.asInstanceOf[TStruct].fields.map(f => f.name -> (GetField(Ref(g1s, g1.typ), f.name): IR)) ++
               g2.typ.asInstanceOf[TStruct].fields.map(f => f.name -> (GetField(Ref(g2s, g2.typ), f.name): IR)))))
     case TableGetGlobals(x@TableMultiWayZipJoin(children, _, globalName)) =>
-      MakeStruct(FastSeq(globalName -> MakeArray(children.map(TableGetGlobals), TStream(children.head.typ.globalType))))
+      MakeStruct(FastSeq(globalName -> MakeArray(children.map(TableGetGlobals), TArray(children.head.typ.globalType))))
     case TableGetGlobals(TableZipUnchecked(left, _)) => TableGetGlobals(left)
     case TableGetGlobals(TableLeftJoinRightDistinct(child, _, _)) => TableGetGlobals(child)
     case TableGetGlobals(TableMapRows(child, _)) => TableGetGlobals(child)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -88,23 +88,23 @@ object TypeCheck {
         }
       case x@ArrayRef(a, i) =>
         assert(i.typ.isOfType(TInt32()))
-        assert(x.typ == -coerce[TArray](a.typ).elementType)
+        assert(x.typ == -coerce[TStreamable](a.typ).elementType)
       case ArrayLen(a) =>
-        assert(a.typ.isInstanceOf[TArray])
+        assert(a.typ.isInstanceOf[TStreamable])
       case x@ArrayRange(a, b, c) =>
         assert(a.typ.isOfType(TInt32()))
         assert(b.typ.isOfType(TInt32()))
         assert(c.typ.isOfType(TInt32()))
       case x@MakeNDArray(data, shape, row_major) =>
-        assert(data.typ.isInstanceOf[TArray])
-        assert(coerce[TNDArray](x.typ).elementType == coerce[TArray](data.typ).elementType)
-        assert(shape.typ.isOfType(TArray(TInt64())))
+        assert(data.typ.isInstanceOf[TStreamable])
+        assert(coerce[TNDArray](x.typ).elementType == coerce[TStreamable](data.typ).elementType)
+        assert(coerce[TStreamable](shape.typ).elementType.isOfType(TInt64()))
         assert(row_major.typ.isOfType(TBoolean()))
       case x@NDArrayRef(nd, idxs) =>
         assert(nd.typ.isInstanceOf[TNDArray])
-        assert(idxs.typ.isOfType(TArray(TInt64())))
+        assert(coerce[TStreamable](idxs.typ).isOfType(TInt64()))
       case x@ArraySort(a, l, r, compare) =>
-        val tarray = coerce[TArray](a.typ)
+        assert(a.typ.isInstanceOf[TStreamable])
         assert(compare.typ.isOfType(TBoolean()))
       case x@ToSet(a) =>
         assert(a.typ.isInstanceOf[TIterable])
@@ -116,45 +116,46 @@ object TypeCheck {
       case x@ToStream(a) =>
         assert(a.typ.isInstanceOf[TIterable])
       case x@LowerBoundOnOrderedCollection(orderedCollection, elem, onKey) =>
-        val elt = -coerce[TContainer](orderedCollection.typ).elementType
+        val elt = -coerce[TIterable](orderedCollection.typ).elementType
         assert(-elem.typ == (if (onKey) -coerce[TStruct](elt).types(0) else elt))
       case x@GroupByKey(collection) =>
-        val telt = coerce[TBaseStruct](coerce[TArray](collection.typ).elementType)
+        val telt = coerce[TBaseStruct](coerce[TStreamable](collection.typ).elementType)
         val td = coerce[TDict](x.typ)
         assert(td.keyType == telt.types(0))
         assert(td.valueType == TArray(telt.types(1)))
       case x@ArrayMap(a, name, body) =>
+        assert(a.typ.isInstanceOf[TStreamable])
         assert(x.elementTyp == body.typ)
       case x@ArrayFilter(a, name, cond) =>
-        val tarray = coerce[TArray](a.typ)
+        assert(a.typ.isInstanceOf[TStreamable])
         assert(cond.typ.isOfType(TBoolean()))
       case x@ArrayFlatMap(a, name, body) =>
-        val tarray = coerce[TArray](a.typ)
+        assert(a.typ.isInstanceOf[TStreamable])
         assert(body.typ.isInstanceOf[TArray])
       case x@ArrayFold(a, zero, accumName, valueName, body) =>
-        val tarray = coerce[TArray](a.typ)
+        assert(a.typ.isInstanceOf[TStreamable])
         assert(body.typ == zero.typ)
         assert(x.typ == zero.typ)
       case x@ArrayScan(a, zero, accumName, valueName, body) =>
-        val tarray = coerce[TArray](a.typ)
+        assert(a.typ.isInstanceOf[TStreamable])
         assert(body.typ == zero.typ)
-        assert(x.typ == TArray(zero.typ))
+        assert(coerce[TStreamable](x.typ).elementType == zero.typ)
       case x@ArrayLeftJoinDistinct(left, right, l, r, compare, join) =>
-        val ltyp = coerce[TArray](left.typ)
-        val rtyp = coerce[TArray](right.typ)
+        val ltyp = coerce[TStreamable](left.typ)
+        val rtyp = coerce[TStreamable](right.typ)
         assert(compare.typ.isOfType(TInt32()))
-        assert(x.typ == TArray(join.typ))
+        assert(coerce[TStreamable](x.typ) == join.typ)
       case x@ArrayFor(a, valueName, body) =>
-        val tarray = coerce[TArray](a.typ)
+        assert(a.typ.isInstanceOf[TStreamable])
         assert(body.typ == TVoid)
       case x@ArrayAgg(a, name, query) =>
-        val tarray = coerce[TArray](a.typ)
+        assert(a.typ.isInstanceOf[TStreamable])
         assert(env.agg.isEmpty)
       case x@AggFilter(cond, aggIR, _) =>
         assert(cond.typ isOfType TBoolean())
         assert(x.typ == aggIR.typ)
       case x@AggExplode(array, name, aggBody, _) =>
-        assert(array.typ.isInstanceOf[TArray])
+        assert(array.typ.isInstanceOf[TStreamable])
         assert(x.typ == aggBody.typ)
       case x@AggGroupBy(key, aggIR, _) =>
         assert(x.typ == TDict(key.typ, aggIR.typ))
@@ -235,7 +236,7 @@ object TypeCheck {
         assert(ctxs.typ.isInstanceOf[TArray])
       case x@ReadPartition(path, _, _, rowType) =>
         assert(path.typ == TString())
-        assert(x.typ == TArray(rowType))
+        assert(x.typ == TStream(rowType))
     }
 
     checkChildren(ir, Some(env))

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -102,7 +102,7 @@ object TypeCheck {
         assert(row_major.typ.isOfType(TBoolean()))
       case x@NDArrayRef(nd, idxs) =>
         assert(nd.typ.isInstanceOf[TNDArray])
-        assert(coerce[TStreamable](idxs.typ).isOfType(TInt64()))
+        assert(coerce[TStreamable](idxs.typ).elementType.isOfType(TInt64()))
       case x@ArraySort(a, l, r, compare) =>
         assert(a.typ.isInstanceOf[TStreamable])
         assert(compare.typ.isOfType(TBoolean()))
@@ -144,7 +144,7 @@ object TypeCheck {
         val ltyp = coerce[TStreamable](left.typ)
         val rtyp = coerce[TStreamable](right.typ)
         assert(compare.typ.isOfType(TInt32()))
-        assert(coerce[TStreamable](x.typ) == join.typ)
+        assert(coerce[TStreamable](x.typ).elementType == join.typ)
       case x@ArrayFor(a, valueName, body) =>
         assert(a.typ.isInstanceOf[TStreamable])
         assert(body.typ == TVoid)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PArray.scala
@@ -8,7 +8,7 @@ import org.json4s.jackson.JsonMethods
 
 import scala.reflect.{ClassTag, _}
 
-final case class PArray(elementType: PType, override val required: Boolean = false) extends PContainer {
+final case class PArray(elementType: PType, override val required: Boolean = false) extends PContainer with PStreamable {
   lazy val virtualType: TArray = TArray(elementType.virtualType, required)
 
   val elementByteSize: Long = UnsafeUtils.arrayElementSize(elementType)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PIterable.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PIterable.scala
@@ -2,4 +2,9 @@ package is.hail.expr.types.physical
 
 abstract class PIterable extends PType {
   def elementType: PType
+
+  def asPContainer: PContainer = this match {
+    case _: PStream => PArray(this.elementType, this.required)
+    case x: PContainer => x
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PStream.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PStream.scala
@@ -4,7 +4,12 @@ import is.hail.annotations.CodeOrdering
 import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.expr.types.virtual.TStream
 
-final case class PStream(elementType: PType, override val required: Boolean = false) extends PIterable {
+trait PStreamable extends PIterable {
+  def asPArray: PArray = PArray(this.elementType, this.required)
+
+}
+
+final case class PStream(elementType: PType, override val required: Boolean = false) extends PStreamable {
   lazy val virtualType: TStream = TStream(elementType.virtualType, required)
 
   override def pyString(sb: StringBuilder): Unit = {

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TArray.scala
@@ -8,7 +8,7 @@ import org.json4s.jackson.JsonMethods
 
 import scala.reflect.{ClassTag, classTag}
 
-final case class TArray(elementType: Type, override val required: Boolean = false) extends TContainer {
+final case class TArray(elementType: Type, override val required: Boolean = false) extends TContainer with TStreamable {
   lazy val physicalType: PArray = PArray(elementType.physicalType, required)
 
   override def pyString(sb: StringBuilder): Unit = {
@@ -28,13 +28,6 @@ final case class TArray(elementType: Type, override val required: Boolean = fals
   override def canCompare(other: Type): Boolean = other match {
     case TArray(otherType, _) => elementType.canCompare(otherType)
     case _ => false
-  }
-
-  override def unify(concrete: Type): Boolean = {
-    concrete match {
-      case TArray(celementType, _) => elementType.unify(celementType)
-      case _ => false
-    }
   }
 
   override def subst() = TArray(elementType.subst().setRequired(false))

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TStream.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TStream.scala
@@ -7,7 +7,24 @@ import org.json4s.jackson.JsonMethods
 
 import scala.reflect.{ClassTag, classTag}
 
-final case class TStream(elementType: Type, override val required: Boolean = false) extends TIterable {
+trait TStreamable extends TIterable {
+  def copyStreamable(elt: Type, req: Boolean = required): TStreamable = {
+    this match {
+      case _: TArray => TArray(elt, req)
+      case _: TStream => TStream(elt, req)
+    }
+  }
+
+  override def unify(concrete: Type): Boolean = {
+    concrete match {
+      case t: TStreamable => elementType.unify(t.elementType)
+      case _ => false
+    }
+  }
+
+}
+
+final case class TStream(elementType: Type, override val required: Boolean = false) extends TStreamable {
   lazy val physicalType: PStream = PStream(elementType.physicalType, required)
 
   override def pyString(sb: StringBuilder): Unit = {
@@ -26,13 +43,6 @@ final case class TStream(elementType: Type, override val required: Boolean = fal
 
   override def canCompare(other: Type): Boolean =
     throw new UnsupportedOperationException("Stream comparison is currently undefined.")
-
-  override def unify(concrete: Type): Boolean = {
-    concrete match {
-      case TStream(celementType, _) => elementType.unify(celementType)
-      case _ => false
-    }
-  }
 
   override def subst() = TStream(elementType.subst().setRequired(false))
 

--- a/hail/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/hail/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -4,7 +4,7 @@ import is.hail.annotations._
 import is.hail.check.Gen
 import is.hail.expr.ir._
 import is.hail.expr.types._
-import is.hail.expr.types.physical.{PArray, PStruct}
+import is.hail.expr.types.physical.PStruct
 import is.hail.expr.types.virtual._
 import is.hail.expr.{ir, _}
 import is.hail.linalg._

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -19,7 +19,7 @@ class OrderingSuite extends SparkSuite {
   def recursiveSize(t: Type): Int = {
     val inner = t match {
       case ti: TInterval => recursiveSize(ti.pointType)
-      case tc: TContainer => recursiveSize(tc.elementType)
+      case tc: TIterable => recursiveSize(tc.elementType)
       case tbs: TBaseStruct =>
         tbs.types.map { t => recursiveSize(t) }.sum
       case _ => 0


### PR DESCRIPTION
and correspondingly, TContainer -> TIterable.

This paves the way for more strict enforcement of stream types in deforested code generation in the lowerer. We assume that basically anywhere that expects an array in the current value IR, it could also be a stream. When streamable values are expected to have a physical layout/representation, we convert to PArray and treat as a PArray.

MakeArray, ArrayRange and ReadPartitions are also always a stream type. (MakeArray takes type Streamable to be consistent with python, but I could fix that.)

The next step from here is to add a streamifying pass during lowering that adds ToStream and ToArray everywhere, and then more strictly enforce that anything deforested in cxx.Emit is of type TStream, and anything not deforested is of type TArray.

EDIT: I changed MakeArray and ArrayRange back to using TArray because I wanted to keep them consistent with Python. I'll introduce MakeStream and StreamRange for the corresponding stream versions, I guess.