### PR TITLE
add PYTEST_ARGS env var to gradle

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -280,7 +280,7 @@ task testPython(type: Exec, dependsOn: shadowJar) {
             '-r a',
             '--html=build/reports/pytest.html',
             '--self-contained-html',
-            *System.env.PYTEST_ARGS.split(" "),
+            *(System.env.PYTEST_ARGS == null ? "" : System.env.PYTEST_ARGS).split(" "),
             'python/test')
     environment SPARK_HOME: sparkHome
     environment PYTHONPATH: '' + projectDir + '/python:' + sparkHome + '/python:' + sparkHome + '/python/lib/py4j-' + py4jVersion + '-src.zip'

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -270,7 +270,7 @@ test {
 test.dependsOn(checkSettings)
 
 task testPython(type: Exec, dependsOn: shadowJar) {
-    commandLine 'pytest',
+    commandLine('pytest',
             '-v',
             '-n',
             parallelism,
@@ -280,7 +280,8 @@ task testPython(type: Exec, dependsOn: shadowJar) {
             '-r a',
             '--html=build/reports/pytest.html',
             '--self-contained-html',
-            'python/test'
+            *System.env.PYTEST_ARGS.split(" "),
+            'python/test')
     environment SPARK_HOME: sparkHome
     environment PYTHONPATH: '' + projectDir + '/python:' + sparkHome + '/python:' + sparkHome + '/python/lib/py4j-' + py4jVersion + '-src.zip'
     environment PYSPARK_SUBMIT_ARGS: '--conf spark.driver.extraClassPath=' + projectDir + '/build/libs/hail-all-spark.jar --conf spark.executor.extraClassPath=' + projectDir + '/build/libs/hail-all-spark.jar pyspark-shell'


### PR DESCRIPTION
So that I'll stop checking in crap.

I have no idea why the parentheses are necessary, but they are.