### PR TITLE
Fix plotting label as dict

### DIFF
--- a/hail/python/hail/plot/plots.py
+++ b/hail/python/hail/plot/plots.py
@@ -459,7 +459,7 @@ def _get_scatter_plot_elements(
 
 @typecheck(x=oneof(expr_numeric, sized_tupleof(str, expr_numeric)),
            y=oneof(expr_numeric, sized_tupleof(str, expr_numeric)),
-           label=nullable(oneof(expr_any, dictof(str, expr_any))), title=nullable(str),
+           label=nullable(oneof(dictof(str, expr_any), expr_any)), title=nullable(str),
            xlabel=nullable(str), ylabel=nullable(str), size=int, legend=bool,
            hover_fields=nullable(dictof(str, expr_any)),
            colors=nullable(oneof(bokeh.models.mappers.ColorMapper, dictof(str, bokeh.models.mappers.ColorMapper))),
@@ -608,7 +608,7 @@ def scatter(
 
 @typecheck(x=oneof(expr_numeric, sized_tupleof(str, expr_numeric)),
            y=oneof(expr_numeric, sized_tupleof(str, expr_numeric)),
-           label=nullable(oneof(expr_any, dictof(str, expr_any))), title=nullable(str),
+           label=nullable(oneof(dictof(str, expr_any), expr_any)), title=nullable(str),
            xlabel=nullable(str), ylabel=nullable(str), size=int, legend=bool,
            hover_fields=nullable(dictof(str, expr_any)),
            colors=nullable(oneof(bokeh.models.mappers.ColorMapper, dictof(str, bokeh.models.mappers.ColorMapper))),


### PR DESCRIPTION
The problem here is that `one_of` looks for the first successful match,
and a `Dict[str, Expression]` will always satisfy `expr_any` before
it reaches the dict checker.