### PR TITLE
use hadoop filesystem for reading rectangles to numpy

### DIFF
--- a/hail/python/cluster-tests/cluster-sanity-check.py
+++ b/hail/python/cluster-tests/cluster-sanity-check.py
@@ -1,4 +1,5 @@
 import hail as hl
+from hail.linalg import BlockMatrix
 
 mt = hl.import_vcf('gs://hail-1kg/1kg_coreexome.vcf.bgz')
 mt = mt.annotate_rows(x = 5)
@@ -6,3 +7,6 @@ mt._force_count_rows()
 
 mt = hl.import_bgen('gs://hail-ci/example.8bits.bgen', entry_fields=['GT'])
 mt._force_count_rows()
+
+bm = BlockMatrix.random(10, 11)
+bm.to_numpy(_force_blocking=True)

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -2069,8 +2069,9 @@ class BlockMatrix(object):
 
         nd = np.zeros(shape=(n_rows, n_cols))
         f = new_local_temp_file()
+        uri = local_path_uri(f)
         for rect, file_path in zip(rects, rect_files):
-            hl.utils.hadoop_copy(file_path, f)
+            hl.utils.hadoop_copy(file_path, uri)
             if binary:
                 rect_data = np.reshape(np.fromfile(f), (rect[2]-rect[1], rect[4]-rect[3]))
             else:

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -2068,12 +2068,13 @@ class BlockMatrix(object):
         n_cols = max(rects, key=lambda r: r[4])[4]
 
         nd = np.zeros(shape=(n_rows, n_cols))
+        f = new_local_temp_file()
         for rect, file_path in zip(rects, rect_files):
-            with hl.utils.hadoop_open(file_path, 'rb') as f:
-                if binary:
-                    rect_data = np.reshape(np.frombuffer(f.read()), (rect[2]-rect[1], rect[4]-rect[3]))
-                else:
-                    rect_data = np.loadtxt(f, ndmin=2)
+            hl.utils.hadoop_copy(file_path, f)
+            if binary:
+                rect_data = np.reshape(np.fromfile(f), (rect[2]-rect[1], rect[4]-rect[3]))
+            else:
+                rect_data = np.loadtxt(f, ndmin=2)
             nd[rect[1]:rect[2], rect[3]:rect[4]] = rect_data
 
         return nd

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -160,6 +160,8 @@ class Tests(unittest.TestCase):
                 self._assert_eq(at4, at)
                 self._assert_eq(at5, at)
 
+        self._assert_eq(bm.to_numpy(_force_blocking=True), a)
+
     def test_to_table(self):
         schema = hl.tstruct(row_idx=hl.tint64, entries=hl.tarray(hl.tfloat64))
         rows = [{'row_idx': 0, 'entries': [0.0, 1.0]},


### PR DESCRIPTION
`BlockMatrix.to_numpy` writes separate block files if the matrix size is too big to export in a single file on the leader. This caused a bug on the cluster because the workers were writing to their local filesystems and not Hadoop. This now actually writes and reads with a temp Hadoop path.

Added an underscore parameter to the `to_numpy` method to force writing the block matrix out in blocks and added a sanity check in the cluster tests.