### PR TITLE
[hail] do not create a new RVDPartitioner with unchanged key

### DIFF
--- a/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDPartitioner.scala
@@ -106,11 +106,15 @@ class RVDPartitioner(
     rangeBounds.map(_.coarsen(newKeyLen))
 
   def coarsen(newKeyLen: Int): RVDPartitioner = {
-    assert(newKeyLen <= kType.size)
-    new RVDPartitioner(
-      kType.truncate(newKeyLen),
-      coarsenedRangeBounds(newKeyLen),
-      math.min(allowedOverlap, newKeyLen))
+    if (newKeyLen == kType.size)
+      this
+    else {
+      assert(newKeyLen < kType.size)
+      new RVDPartitioner(
+        kType.truncate(newKeyLen),
+        coarsenedRangeBounds(newKeyLen),
+        math.min(allowedOverlap, newKeyLen))
+    }
   }
 
   def strictify: RVDPartitioner = extendKey(kType)


### PR DESCRIPTION
Should hopefully save some allocations in TableMapRows and elsewhere.