### PR TITLE
Improve github issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,10 +1,7 @@
 To report a bug, fill in the information below. 
-For support and feature requests, please use the discussion forum: http://discuss.hail.is/
+For support and feature requests, please use the discussion forum: 
+https://discuss.hail.is/
 
--------------------------------------------------------------------------------------------
+Please include the full Hail version and as much detail as possible.
 
-### Hail version:
-
-### What you did:
-
-### What went wrong (all error messages here, including the full java stack trace):
+-----------------------------------------------------------------------------


### PR DESCRIPTION
The current one splits text across lines and looks pretty bad in the editor mode.