### PR TITLE
[hail] only -Werror on CI builds

### DIFF
--- a/hail/hail-ci-build.sh
+++ b/hail/hail-ci-build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -ex
 
+export CXXFLAGS="${CXXFLAGS} -Werror"
+
 ROOT=$(cd .. && pwd)
 
 CLUSTER_NAME=ci-test-$(LC_CTYPE=C LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 8)

--- a/hail/hail-ci-deploy.sh
+++ b/hail/hail-ci-deploy.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -ex
 
+export CXXFLAGS="${CXXFLAGS} -Werror"
+
 SPARK_VERSION=2.2.0
 BRANCH=0.2
 CLOUDTOOLS_VERSION=3

--- a/hail/src/main/c/Makefile
+++ b/hail/src/main/c/Makefile
@@ -122,7 +122,7 @@ ifeq ($(filter -march=%,$(CXXFLAGS)),)
 endif
 
 # Append to any inherited flags which survived filtering
-CXXFLAGS += $(HAIL_OPT_FLAGS) $(CXXSTD) -I$(LIBSIMDPP) -Wall -Werror -Wextra
+CXXFLAGS += $(HAIL_OPT_FLAGS) $(CXXSTD) -I$(LIBSIMDPP) -Wall -Wextra
 CXXFLAGS += -fPIC -ggdb -fno-strict-aliasing
 CXXFLAGS += -I../resources/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/$(JAVA_MD)
 LIBFLAGS += -fvisibility=default


### PR DESCRIPTION
Developers should manually enable `-Werror` in their local `CXXFLAGS`

