### PR TITLE
gcs connector install fix

### DIFF
--- a/hail/install-gcs-connector.sh
+++ b/hail/install-gcs-connector.sh
@@ -10,7 +10,7 @@ set -e
 
 COMPUTE_ENGINE_SERVICE_ACCOUNT=$(gcloud iam service-accounts list \
                                      | grep -e 'Compute Engine default service account' \
-                                     | sed 's:Compute Engine default service account[ ]*::')
+                                     | sed 's:Compute Engine default service account[ ]*::' | awk '{print $1}')
 
 mkdir -p ${HOME}/.hail/gcs-keys/
 


### PR DESCRIPTION
Need to get only the service account (there is now a `disabled` column that needs to be cut out)