### PR TITLE
Py ndarray map

### DIFF
--- a/hail/python/hail/expr/expressions/expression_typecheck.py
+++ b/hail/python/hail/expr/expressions/expression_typecheck.py
@@ -254,7 +254,7 @@ class ArrayCoercer(ExprCoercer):
         return hl.map(lambda x_: self.ec.coerce(x_), x)
 
 
-# Does not coerce anything. NDArrayExpressions must be created explicity using `hl._ndarray`
+# NDArrayExpressions must be created explicity using `hl._ndarray`
 class NDArrayCoercer(ExprCoercer):
     def __init__(self, ec: ExprCoercer = AnyCoercer()):
         super(NDArrayCoercer, self).__init__()

--- a/hail/python/hail/expr/expressions/expression_typecheck.py
+++ b/hail/python/hail/expr/expressions/expression_typecheck.py
@@ -268,7 +268,7 @@ class NDArrayCoercer(ExprCoercer):
         return False
 
     def can_coerce(self, t: HailType) -> bool:
-        return isinstance(t, tndarray)
+        return isinstance(t, tndarray) and self.ec.can_coerce(t.element_type)
 
     def _coerce(self, x: Expression):
         raise NotImplementedError

--- a/hail/python/hail/expr/expressions/expression_typecheck.py
+++ b/hail/python/hail/expr/expressions/expression_typecheck.py
@@ -254,20 +254,21 @@ class ArrayCoercer(ExprCoercer):
         return hl.map(lambda x_: self.ec.coerce(x_), x)
 
 
+# Does not coerce anything. NDArrayExpressions must be created explicity using `hl._ndarray`
 class NDArrayCoercer(ExprCoercer):
-    def __init__(self, t: HailType):
+    def __init__(self, ec: ExprCoercer = AnyCoercer()):
         super(NDArrayCoercer, self).__init__()
-        self.t = t
+        self.ec = ec
 
     @property
     def str_t(self):
-        return f'ndarray<{self.t}>'
+        return f'ndarray<{self.ec.str_t}>'
 
     def _requires_conversion(self, t: HailType) -> bool:
         return False
 
     def can_coerce(self, t: HailType) -> bool:
-        return isinstance(t, tndarray) and self.t == t.element_type
+        return isinstance(t, tndarray)
 
     def _coerce(self, x: Expression):
         raise NotImplementedError
@@ -456,7 +457,7 @@ def coercer_from_dtype(t: HailType) -> ExprCoercer:
     elif isinstance(t, tarray):
         return expr_array(coercer_from_dtype(t.element_type))
     elif isinstance(t, tndarray):
-        return expr_ndarray(t.element_type)
+        return expr_ndarray(coercer_from_dtype(t.element_type))
     elif isinstance(t, tset):
         return expr_set(coercer_from_dtype(t.element_type))
     elif isinstance(t, tdict):

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -831,7 +831,7 @@ class NDArrayExpression(Expression):
         """
 
         element_type, ndim = self._type.element_type, self._type.ndim
-        ndarray_map = self._ir_lambda_method(NDArrayMap, f, element_type, lambda t: self._type.__class__(t, ndim))
+        ndarray_map = self._ir_lambda_method(NDArrayMap, f, element_type, lambda t: tndarray(t, ndim))
 
         assert isinstance(self._type, tndarray)
         return ndarray_map

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -819,13 +819,6 @@ class NDArrayExpression(Expression):
     def map(self, f):
         """Transform each element of an NDArray.
 
-        Examples
-        --------
-
-        >>> hl.eval(nd.map(lambda x: x ** 3))
-        [[1.0, 8.0],
-         [27.0, 64.0]]
-
         Parameters
         ----------
         f : function ( (arg) -> :class:`.Expression`)

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3240,7 +3240,6 @@ def abs(x):
     :class:`.NumericExpression`, :class:`.ArrayNumericExpression` or :class:`.NDArrayNumericExpression`.
     """
     if isinstance(x.dtype, tarray) or isinstance(x.dtype, tndarray):
-        print("HIIIIII")
         return map(abs, x)
     else:
         return x._method('abs', x.dtype)

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3014,7 +3014,7 @@ def zip_with_index(a, index_first=True):
 
 
 @typecheck(f=func_spec(1, expr_any),
-           collection=expr_oneof(expr_set(), expr_array()))
+           collection=expr_oneof(expr_set(), expr_array(), expr_ndarray()))
 def map(f: Callable, collection):
     """Transform each element of a collection.
 
@@ -3218,9 +3218,9 @@ def min(*exprs, filter_missing: bool = True) -> NumericExpression:
         return min(hl.array(list(exprs)), filter_missing=filter_missing)
 
 
-@typecheck(x=expr_oneof(expr_numeric, expr_array(expr_numeric)))
+@typecheck(x=expr_oneof(expr_numeric, expr_array(expr_numeric), expr_ndarray(expr_numeric)))
 def abs(x):
-    """Take the absolute value of a numeric value or array.
+    """Take the absolute value of a numeric value, array or ndarray.
 
     Examples
     --------
@@ -3233,21 +3233,22 @@ def abs(x):
 
     Parameters
     ----------
-    x : :class:`.NumericExpression` or :class:`.ArrayNumericExpression`
+    x : :class:`.NumericExpression`, :class:`.ArrayNumericExpression` or :class:`.NDArrayNumericExpression`
 
     Returns
     -------
-    :class:`.NumericExpression` or :class:`.ArrayNumericExpression`.
+    :class:`.NumericExpression`, :class:`.ArrayNumericExpression` or :class:`.NDArrayNumericExpression`.
     """
-    if isinstance(x.dtype, tarray):
+    if isinstance(x.dtype, tarray) or isinstance(x.dtype, tndarray):
+        print("HIIIIII")
         return map(abs, x)
     else:
         return x._method('abs', x.dtype)
 
 
-@typecheck(x=expr_oneof(expr_numeric, expr_array(expr_numeric)))
+@typecheck(x=expr_oneof(expr_numeric, expr_array(expr_numeric), expr_ndarray(expr_numeric)))
 def sign(x):
-    """Returns the sign of a numeric value or array.
+    """Returns the sign of a numeric value, array or ndarray.
 
     Examples
     --------
@@ -3270,13 +3271,13 @@ def sign(x):
 
     Parameters
     ----------
-    x : :class:`.NumericExpression` or :class:`.ArrayNumericExpression`
+    x : :class:`.NumericExpression`, :class:`.ArrayNumericExpression` or :class:`.NDArrayNumericExpression`
 
     Returns
     -------
-    :class:`.NumericExpression` or :class:`.ArrayNumericExpression`.
+    :class:`.NumericExpression`, :class:`.ArrayNumericExpression` or :class:`.NDArrayNumericExpression`.
     """
-    if isinstance(x.dtype, tarray):
+    if isinstance(x.dtype, tarray) or isinstance(x.dtype, tndarray):
         return map(sign, x)
     else:
         return x._method('sign', x.dtype)

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2590,7 +2590,7 @@ class Tests(unittest.TestCase):
 
     @skip_unless_spark_backend()
     @run_with_cxx_compile()
-    def test_ndarray(self):
+    def test_ndarray_ref(self):
         import numpy as np
 
         scalar = 5.0
@@ -2612,6 +2612,18 @@ class Tests(unittest.TestCase):
         self.assertEqual(hl.eval(h_np_cube[1, 1, 0]), 6)
 
         self.assertRaises(ValueError, hl._ndarray, [[4], [1, 2, 3], 5])
+
+    @skip_unless_spark_backend()
+    @run_with_cxx_compile()
+    def test_ndarray_map(self):
+        a = hl._ndarray([[2, 3, 4], [5, 6, 7]])
+        b = hl.map(lambda x: -x, a)
+        c = hl.map(lambda x: True, a)
+
+        self.assertEqual(hl.eval(b[0, 0]), -2)
+        self.assertEqual(hl.eval(b[1, 2]), -7)
+        self.assertEqual(hl.eval(c[0, 0]), True)
+        self.assertEqual(hl.eval(c[1, 2]), True)
 
     def test_variant_str(self):
         assert hl.eval(

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -627,7 +627,7 @@ object IRParser {
       case "NDArrayMap" =>
         val name = identifier(it)
         val nd = ir_value_expr(env)(it)
-        val body = ir_value_expr(env)(it)
+        val body = ir_value_expr(env + (name -> coerce[TNDArray](nd.typ).elementType))(it)
         NDArrayMap(nd, name, body)
       case "NDArrayRef" =>
         val nd = ir_value_expr(env)(it)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1299,7 +1299,7 @@ class IRSuite extends SparkSuite {
 
     val blockMatrix = BlockMatrixRead(BlockMatrixNativeReader(tmpDir.createLocalTempFile()))
     val nd = MakeNDArray(2,
-      MakeArray(FastSeq(F64(-1.0), F64(1.0)), TArray(TFloat64())),
+      MakeArray(FastSeq(I32(-1), I32(1)), TArray(TInt32())),
       MakeArray(FastSeq(I64(1), I64(2)), TArray(TInt64())),
       True())
 


### PR DESCRIPTION
- Added `NDArrayMap` IR to python as well as `NDArrayExpression.map`
- Added `NDArrayNumericExpression` so NDArrays can be operated on using `hl.abs` and `hl.sign` etc. However, these native methods aren't supported currently in C++ so they are untested. Once Map2 goes in, arithmetic operations can be added to `NDArrayNumericExpression`.

Note:
- The `NDArrayCoercer` "works" in that it identifies objects that are already `NDArrayExpression`s, but is not meant to actually coerce other data types yet.