### PR TITLE
[batch] default port for mysql 3306

### DIFF
--- a/cloud-sql.mk
+++ b/cloud-sql.mk
@@ -1,6 +1,6 @@
 .PHONY: install-cloud-sql-proxy
 
-CLOUD_SQL_PORT ?= 3307
+CLOUD_SQL_PORT ?= 3306
 
 install-cloud-sql-proxy:
 	test -f cloud_sql_proxy || \


### PR DESCRIPTION
Default mysql port is 3306, should probably stick with that for default CLOUD_SQL_PORT, especially since google doesn't expose way to override the default