### PR TITLE
Fix Env logic in PruneDeadFields.rebuild

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Env.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Env.scala
@@ -20,13 +20,11 @@ case class BindingEnv[V](
   def allEmpty: Boolean = eval.isEmpty && agg.forall(_.isEmpty) && scan.forall(_.isEmpty)
 
   def promoteAgg: BindingEnv[V] = {
-    assert(agg.isDefined)
-    BindingEnv(agg.get)
+    BindingEnv(aggOrEmpty)
   }
 
   def promoteScan: BindingEnv[V] = {
-    assert(scan.isDefined)
-    BindingEnv(scan.get)
+    BindingEnv(scanOrEmpty)
   }
 
   def bindEval(name: String, v: V): BindingEnv[V] =
@@ -38,18 +36,18 @@ case class BindingEnv[V](
   def deleteEval(name: String): BindingEnv[V] = copy(eval = eval.delete(name))
 
   def bindAgg(name: String, v: V): BindingEnv[V] =
-    copy(agg = Some(agg.get.bind(name, v)))
+    copy(agg = Some(aggOrEmpty.bind(name, v)))
 
   def bindAgg(bindings: (String, V)*): BindingEnv[V] =
-    copy(agg = Some(agg.get.bindIterable(bindings)))
+    copy(agg = Some(aggOrEmpty.bindIterable(bindings)))
 
   def aggOrEmpty: Env[V] = agg.getOrElse(Env.empty)
 
   def bindScan(name: String, v: V): BindingEnv[V] =
-    copy(scan = Some(scan.get.bind(name, v)))
+    copy(scan = Some(scanOrEmpty.bind(name, v)))
 
   def bindScan(bindings: (String, V)*): BindingEnv[V] =
-    copy(scan = Some(scan.get.bindIterable(bindings)))
+    copy(scan = Some(scanOrEmpty.bindIterable(bindings)))
 
   def scanOrEmpty: Env[V] = scan.getOrElse(Env.empty)
 

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1241,7 +1241,7 @@ object PruneDeadFields {
     bmir.children.map {
       case tir: TableIR => rebuild(tir, memo)
       case mir: MatrixIR => rebuild(mir, memo)
-      case ir: IR => rebuild(ir, Env.empty[Type], memo)
+      case ir: IR => rebuildIR(ir, BindingEnv.empty[Type], memo)
       case bmir: BlockMatrixIR => rebuild(bmir, memo)
     }
   )


### PR DESCRIPTION
This should be the last of the Env-unfuckings. IRBuilder has the same
problem, but it's not really a compiler analysis/pass itself so that's
okay for the moment.