### PR TITLE
fix various Spark ports, expose on pods

### DIFF
--- a/apiserver/Dockerfile.apiserver
+++ b/apiserver/Dockerfile.apiserver
@@ -2,4 +2,6 @@ FROM hail-base
 
 COPY apiserver /apiserver
 
+ENV HAIL_SPARK_PROPERTIES "spark.driver.port=9001,spark.blockManager.port=9002"
+
 CMD ["/bin/bash", "-c", "source activate hail; python /apiserver/apiserver.py"]

--- a/apiserver/deployment.yaml.in
+++ b/apiserver/deployment.yaml.in
@@ -54,6 +54,8 @@ spec:
           imagePullPolicy: Always
           ports:
           - containerPort: 8081
+          - containerPort: 9000
+          - containerPort: 9002
           volumeMounts:
           - mountPath: /hail-vdc-sa-key
             name: hail-vdc-sa-key
@@ -91,6 +93,8 @@ spec:
           imagePullPolicy: Always
           ports:
           - containerPort: 5000
+          - containerPort: 9001
+          - containerPort: 9002
           volumeMounts:
           - mountPath: /hail-vdc-sa-key
             name: hail-vdc-sa-key

--- a/apiserver/start-worker.sh
+++ b/apiserver/start-worker.sh
@@ -6,4 +6,4 @@ unset SPARK_MASTER_PORT
 
 export SPARK_DAEMON_JAVA_OPTS="-Djava.net.preferIPv4Stack=true"
 
-/spark-2.2.0-bin-hadoop2.7/bin/spark-class org.apache.spark.deploy.worker.Worker -c 2 --webui-port 8081 spark://spark-master:7077
+/spark-2.2.0-bin-hadoop2.7/bin/spark-class org.apache.spark.deploy.worker.Worker -c 2 -p 9000 --webui-port 8081 spark://spark-master:7077


### PR DESCRIPTION
Spark worker port (on spark-worker) 9000
Spark driver port (on apiserver) 9001
Block manager port (on apiserver and spark-worker) 9002

The apiserver was hanging trying to connect to the master (and therefore notebook2 notebooks trying to connect to it) without this.  Tested hand deploy and it fixed it.
