### PR TITLE
[batch] fix deserialize for compound variable names

### DIFF
--- a/batch/batch/server/deserialize.py
+++ b/batch/batch/server/deserialize.py
@@ -3,11 +3,11 @@ import re
 from kubernetes.client import models
 
 
-def deserialize(api_client, data, klass):
+def deserialize(api_client, data, klass):  # pylint: disable=R0911
     if data is None:
         return None
 
-    if type(klass) == str:
+    if isinstance(klass, str):
         if klass.startswith('list['):
             sub_kls = re.match(r'list\[(.*)\]', klass).group(1)
             return [deserialize(api_client, sub_data, sub_kls)
@@ -26,11 +26,11 @@ def deserialize(api_client, data, klass):
 
     if klass in api_client.PRIMITIVE_TYPES:
         return deserialize_primitive(data, klass)
-    elif klass == object:
+    if klass == object:
         return deserialize_object(data)
-    elif klass == date:
+    if klass == date:
         return deserialize_date(data)
-    elif klass == datetime:
+    if klass == datetime:
         return deserialize_datatime(data)
     else:
         return deserialize_model(api_client, data, klass)

--- a/batch/batch/server/deserialize.py
+++ b/batch/batch/server/deserialize.py
@@ -1,0 +1,134 @@
+from datetime import date, datetime
+import re
+from kubernetes.client import models
+
+
+def deserialize(api_client, data, klass):
+    """
+    Deserializes dict, list, str into an object.
+
+    :param data: dict, list or str.
+    :param klass: class literal, or string of class name.
+
+    :return: object.
+    """
+
+    if data is None:
+        return None
+
+    if type(klass) == str:
+        if klass.startswith('list['):
+            sub_kls = re.match('list\[(.*)\]', klass).group(1)
+            return [deserialize(api_client, sub_data, sub_kls)
+                    for sub_data in data]
+
+        if klass.startswith('dict('):
+            sub_kls = re.match('dict\(([^,]*), (.*)\)', klass).group(2)
+            return {k: deserialize(api_client, v, sub_kls)
+                    for k, v in data.items()}
+
+        # convert str to class
+        if klass in api_client.NATIVE_TYPES_MAPPING:
+            klass = api_client.NATIVE_TYPES_MAPPING[klass]
+        else:
+            klass = getattr(models, klass)
+
+    if klass in api_client.PRIMITIVE_TYPES:
+        return deserialize_primitive(data, klass)
+    elif klass == object:
+        return deserialize_object(data)
+    elif klass == date:
+        return deserialize_date(data)
+    elif klass == datetime:
+        return deserialize_datatime(data)
+    else:
+        return deserialize_model(api_client, data, klass)
+
+
+def deserialize_primitive(data, klass):
+    """
+    Deserializes string to primitive type.
+
+    :param data: str.
+    :param klass: class literal.
+
+    :return: int, long, float, str, bool.wha
+    """
+    try:
+        return klass(data)
+    except UnicodeEncodeError:
+        return unicode(data)  # FIXME: What should this be?
+    except TypeError:
+        return data
+
+
+def deserialize_date(string):
+    """
+    Deserializes string to date.
+
+    :param string: str.
+    :return: date.
+    """
+    try:
+        from dateutil.parser import parse
+        return parse(string).date()
+    except ImportError:
+        return string
+    except ValueError:
+        raise Exception("Failed to parse `{0}` into a date object".format(string))
+
+
+def deserialize_datatime(string):
+    """
+    Deserializes string to datetime.
+
+    The string should be in iso8601 datetime format.
+
+    :param string: str.
+    :return: datetime.
+    """
+    try:
+        from dateutil.parser import parse
+        return parse(string)
+    except ImportError:
+        return string
+    except ValueError:
+        raise Exception("Failed to parse `{0}` into a datetime object")
+
+
+def deserialize_object(value):
+    """
+    Return a original value.
+
+    :return: object.
+    """
+    return value
+
+
+def deserialize_model(api_client, data, klass):
+    """
+    Deserializes list or dict to model.
+    :param data: dict, list.
+    :param klass: class literal.
+    :return: model object.
+    """
+
+    if not klass.swagger_types and not hasattr(klass, 'get_real_child_model'):
+        return data
+
+    kwargs = {}
+    if klass.swagger_types is not None:
+        for attr, attr_type in klass.swagger_types.items():
+            if data is not None \
+                    and attr in data \
+                    and isinstance(data, (list, dict)):
+                value = data[attr]
+                kwargs[attr] = deserialize(api_client, value, attr_type)
+
+    instance = klass(**kwargs)
+
+    if hasattr(instance, 'get_real_child_model'):
+        klass_name = instance.get_real_child_model(data)
+        if klass_name:
+            instance = deserialize(api_client, data, klass_name)
+    return instance

--- a/batch/batch/server/deserialize.py
+++ b/batch/batch/server/deserialize.py
@@ -4,15 +4,6 @@ from kubernetes.client import models
 
 
 def deserialize(api_client, data, klass):
-    """
-    Deserializes dict, list, str into an object.
-
-    :param data: dict, list or str.
-    :param klass: class literal, or string of class name.
-
-    :return: object.
-    """
-
     if data is None:
         return None
 
@@ -46,14 +37,6 @@ def deserialize(api_client, data, klass):
 
 
 def deserialize_primitive(data, klass):
-    """
-    Deserializes string to primitive type.
-
-    :param data: str.
-    :param klass: class literal.
-
-    :return: int, long, float, str, bool.wha
-    """
     try:
         return klass(data)
     # except UnicodeEncodeError:
@@ -63,12 +46,6 @@ def deserialize_primitive(data, klass):
 
 
 def deserialize_date(string):
-    """
-    Deserializes string to date.
-
-    :param string: str.
-    :return: date.
-    """
     try:
         from dateutil.parser import parse
         return parse(string).date()
@@ -79,14 +56,6 @@ def deserialize_date(string):
 
 
 def deserialize_datatime(string):
-    """
-    Deserializes string to datetime.
-
-    The string should be in iso8601 datetime format.
-
-    :param string: str.
-    :return: datetime.
-    """
     try:
         from dateutil.parser import parse
         return parse(string)
@@ -97,22 +66,10 @@ def deserialize_datatime(string):
 
 
 def deserialize_object(value):
-    """
-    Return a original value.
-
-    :return: object.
-    """
     return value
 
 
 def deserialize_model(api_client, data, klass):
-    """
-    Deserializes list or dict to model.
-    :param data: dict, list.
-    :param klass: class literal.
-    :return: model object.
-    """
-
     if not klass.swagger_types and not hasattr(klass, 'get_real_child_model'):
         return data
 

--- a/batch/batch/server/deserialize.py
+++ b/batch/batch/server/deserialize.py
@@ -18,12 +18,12 @@ def deserialize(api_client, data, klass):
 
     if type(klass) == str:
         if klass.startswith('list['):
-            sub_kls = re.match('list\[(.*)\]', klass).group(1)
+            sub_kls = re.match(r'list\[(.*)\]', klass).group(1)
             return [deserialize(api_client, sub_data, sub_kls)
                     for sub_data in data]
 
         if klass.startswith('dict('):
-            sub_kls = re.match('dict\(([^,]*), (.*)\)', klass).group(2)
+            sub_kls = re.match(r'dict\(([^,]*), (.*)\)', klass).group(2)
             return {k: deserialize(api_client, v, sub_kls)
                     for k, v in data.items()}
 
@@ -56,8 +56,8 @@ def deserialize_primitive(data, klass):
     """
     try:
         return klass(data)
-    except UnicodeEncodeError:
-        return unicode(data)  # FIXME: What should this be?
+    # except UnicodeEncodeError:
+    #     return unicode(data)  # FIXME: What should this be?
     except TypeError:
         return data
 

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -19,6 +19,7 @@ from aiohttp import web
 
 from .globals import max_id, _log_path, _read_file, pod_name_job, job_id_job, batch_id_batch
 from .globals import next_id, get_recent_events, add_event
+from .deserialize import deserialize
 
 from .. import schemas
 
@@ -486,8 +487,7 @@ async def create_job(request):  # pylint: disable=R0912
     if not validator.validate(parameters):
         abort(400, 'invalid request: {}'.format(validator.errors))
 
-    pod_spec = v1.api_client._ApiClient__deserialize(
-        parameters['spec'], kube.client.V1PodSpec)
+    pod_spec = deserialize(v1.api_client, parameters['spec'], kube.client.V1PodSpec)
 
     batch_id = parameters.get('batch_id')
     if batch_id:


### PR DESCRIPTION
FYI @cseed @danking: I found a bad bug in the Kubernetes deserializer that we use to deserialize the pod spec from the request from the client. Any variable with a compound name like `generate_name` or `cluster_name` was being set to None regardless of what the input was. This is because their code has a mapping from the Python style with underscores to camel case and it was using the camel case to look up the attributes instead of the underscore names. @akotlar was going to make a PR to correct it in their repo. For now, I'm including the correct code in our repo. Without it, I was getting errors trying to deserialize pod templates with metadata from the MySQL database back to Python. The other horrible behavior I found with the deserializer is if you pass `None` to the deserialize function, you get a dictionary with all attributes set to `None` instead of just `None`. Something to be aware of or we should fix it in this PR to return None instead.

@akotlar: I tried to make everything just adhere to Python3, but can you make sure I did the conversions correctly?
