### PR TITLE
[notebook, notebook2]: fix create-services-and-pods binding, add get-users permission

### DIFF
--- a/vdc/k8s-config.yaml
+++ b/vdc/k8s-config.yaml
@@ -108,6 +108,31 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
+  name: read-get-user-secret
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["get-users"]
+  verbs: ["get"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: default
+  name: notebook-read-get-users-secret
+subjects:
+- kind: ServiceAccount
+  name: notebook
+  namespace: default
+roleRef:
+  kind: Role
+  name: read-get-user-secret
+  apiGroup: ""
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: default
   name: update-letsencrypt-config
 rules:
 - apiGroups: [""]

--- a/vdc/k8s-config.yaml
+++ b/vdc/k8s-config.yaml
@@ -57,30 +57,6 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
-  name: create-services
-rules:
-- apiGroups: [""]
-  resources: ["services"]
-  verbs: ["*"]
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: default
-  name: notebook-create-services
-subjects:
-- kind: ServiceAccount
-  name: notebook
-  namespace: default
-roleRef:
-  kind: Role
-  name: create-services
-  apiGroup: ""
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: default
   name: create-services-and-pods
 rules:
 - apiGroups: [""]
@@ -101,7 +77,7 @@ subjects:
   namespace: default
 roleRef:
   kind: Role
-  name: create-services
+  name: create-services-and-pods
   apiGroup: ""
 ---
 kind: Role


### PR DESCRIPTION
This fixes the notebook2 deployment permission issue that was resulting in CrashLoopBackoff (no permissions for the Table class to `read_namespaced_secret('get-users', 'default')`). Already tested, works (notebook2 back up).

It also fixes an apparent error in the master branch RoleBinding.

This diff looks slightly weird. I fixed the existing notebook  Roles/RoleBindings by deleting the `create-services` `Role` and `notebook-create-services` `RoleBinding`, and then fixing the broken `notebook-create-servivces-and-pods` `RoleBiding`, by correctly updating the `roleRef` to read `create-services-and-pods`.

When notebook1 totally goes away, we can probably remove the "services" permission.

Before:
```yaml
---
kind: Role
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  namespace: default
  name: create-services
rules:
- apiGroups: [""]
  resources: ["services"]
  verbs: ["*"]
---
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  namespace: default
  name: notebook-create-services
subjects:
- kind: ServiceAccount
  name: notebook
  namespace: default
roleRef:
  kind: Role
  name: create-services
  apiGroup: ""
---
kind: Role
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  namespace: default
  name: create-services-and-pods
rules:
- apiGroups: [""]
  resources: ["services"]
  verbs: ["*"]
- apiGroups: [""]
  resources: ["pods"]
  verbs: ["*"]
---
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  namespace: default
  name: notebook-create-services-and-pods
subjects:
- kind: ServiceAccount
  name: notebook
  namespace: default
roleRef:
  kind: Role
  name: create-services #this was causing the error, and of course the create-services role is superseded by the the create-services-and-pods role
  apiGroup: ""
---
```

After:
```yaml
kind: Role
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  namespace: default
  name: create-services-and-pods
rules:
- apiGroups: [""]
  resources: ["services"]
  verbs: ["*"]
- apiGroups: [""]
  resources: ["pods"]
  verbs: ["*"]
---
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  namespace: default
  name: notebook-create-services-and-pods
subjects:
- kind: ServiceAccount
  name: notebook
  namespace: default
roleRef:
  kind: Role
  name: create-services-and-pods
  apiGroup: ""
---
```

### Results of test runs

Before:

```sh
kubectl apply -f k8s-config.yaml
ERROR: (gcloud.compute.addresses.describe) Could not fetch resource:
 - Required 'compute.addresses.get' permission for 'projects/hail-vdc-staging/regions/us-central1/addresses/site'

namespace/batch-pods unchanged
...
The RoleBinding "notebook-create-services-and-pods" is invalid: roleRef: Invalid value: rbac.RoleRef{APIGroup:"rbac.authorization.k8s.io", Kind:"Role", Name:"create-services"}: cannot change roleRef
make: *** [k8s-config] Error 1
```

After:
```sh
ERROR: (gcloud.compute.addresses.describe) Could not fetch resource:
 - Required 'compute.addresses.get' permission for 'projects/hail-vdc-staging/regions/us-central1/addresses/site'

...
role.rbac.authorization.k8s.io/create-services-and-pods unchanged
rolebinding.rbac.authorization.k8s.io/notebook-create-services-and-pods configured
role.rbac.authorization.k8s.io/read-get-user-secret unchanged
rolebinding.rbac.authorization.k8s.io/notebook-read-get-users-secret configured
```

I think the error just reflects my not having hail-vdc-staging permissions, that is unaffected by this PR.

cc @cseed, @danking 
 