### PR TITLE
[notebook2]: change secret_name -> gsa_key_secret_name

### DIFF
--- a/notebook2/notebook/table.py
+++ b/notebook2/notebook/table.py
@@ -46,7 +46,7 @@ class Table:
 
         cursor.execute(
             """
-            SELECT id, gsa_email, ksa_name, bucket_name, secret_name
+            SELECT id, gsa_email, ksa_name, bucket_name, gsa_key_secret_name
             FROM user_data
             WHERE user_id=%s
             """, (user_id,))


### PR DESCRIPTION
Cotton requested this, to disambiguate the google service account secret name from other secret names, when, at some later date, we have that problem.

Will add the corresponding definition updates in the script PR (https://github.com/hail-is/hail/pull/5618)