### PR TITLE
Increase verbosity of Compile optimization

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -35,7 +35,7 @@ object Compile {
     val fb = new EmitFunctionBuilder[F](argTypeInfo, GenericTypeInfo[R]())
 
     var ir = body
-    ir = Optimize(ir, noisy = false, canGenerateLiterals = false, context = Some("Compile"))
+    ir = Optimize(ir, noisy = true, canGenerateLiterals = false, context = Some("Compile"))
     TypeCheck(ir, BindingEnv(Env.fromSeq[Type](args.map { case (name, t, _) => name -> t.virtualType })))
 
     val env = args


### PR DESCRIPTION
Needed to debug Laurent's pipeline. And we should be logging everything anyway -- this is the only way we get to see the post-extract-aggregators executed IR