### PR TITLE
add check for expression source in write_expression

### DIFF
--- a/hail/python/hail/experimental/expressions.py
+++ b/hail/python/hail/experimental/expressions.py
@@ -1,5 +1,6 @@
 import hail as hl
 from hail.expr.expressions.expression_typecheck import *
+from hail.expr.expressions.expression_utils import *
 from hail.typecheck import *
 
 
@@ -34,6 +35,11 @@ def write_expression(expr, path, overwrite=False):
    -------
    None
     """
+    source = expr._indices.source
+    if source is not None:
+        analyze('write_expression.expr', expr, source._global_indices)
+        source = source.select_globals(__expr=expr)
+        expr = source.index_globals().__expr
     hl.utils.range_table(1).filter(False).annotate_globals(expr=expr).write(path, overwrite=overwrite)
 
 


### PR DESCRIPTION
Can you double check the `analyze` syntax? I'm not sure that's 100% correct but I couldn't find an existing example of checking specifically for globals