### PR TITLE
[notebook2] mount gsa key secret

### DIFF
--- a/notebook2/notebook/notebook.py
+++ b/notebook2/notebook/notebook.py
@@ -162,7 +162,7 @@ def requires_auth(for_page = True):
     return auth
 
 
-def start_pod(jupyter_token, image, name, user_id):
+def start_pod(jupyter_token, image, name, user_id, gsa_key_secret_name):
     pod_id = uuid.uuid4().hex
 
     pod_spec = kube.client.V1PodSpec(
@@ -184,7 +184,25 @@ def start_pod(jupyter_token, image, name, user_id):
                     period_seconds=5,
                     http_get=kube.client.V1HTTPGetAction(
                         path=f'/instance/{pod_id}/login',
-                        port=POD_PORT)))])
+                        port=POD_PORT)),
+                volume_mounts=[
+                    kube.client.V1VolumeMount(
+                        mount_path='/gsa-key-secret-name',
+                        name='gsa-key-secret-name',
+                        read_only=True
+                    )
+                ]
+            )
+        ],
+        volumes=[
+            kube.client.V1Volume(
+                name='gsa-key-secret-name',
+                secret=kube.client.V1SecretVolumeSource(
+                    secret_name=gsa_key_secret_name
+                )
+            )
+        ]
+    )
     pod_template = kube.client.V1Pod(
         metadata=kube.client.V1ObjectMeta(
             generate_name='notebook2-worker-',
@@ -353,7 +371,8 @@ def notebook_post():
     name = request.form.get('name', 'a_notebook')
     safe_user_id = user_id_transform(g.user['auth0_id'])
 
-    pod = start_pod(jupyter_token, WORKER_IMAGES[image], name, safe_user_id)
+    pod = start_pod(jupyter_token, WORKER_IMAGES[image], name,
+                    safe_user_id, g.user['gsa_key_secret_name'])
     session['notebook'] = notebooks_for_ui([pod])[0]
 
     return redirect(external_url_for('notebook'))
@@ -420,7 +439,6 @@ def delete_worker_pod(pod_name):
         k8s.delete_namespaced_pod(
             pod_name,
             'default',
-            kube.client.V1DeleteOptions(),
             _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS)
     except kube.client.rest.ApiException as e:
         log.info(f'pod {pod_name} already deleted {e}')

--- a/notebook2/notebook/notebook.py
+++ b/notebook2/notebook/notebook.py
@@ -162,10 +162,11 @@ def requires_auth(for_page = True):
     return auth
 
 
-def start_pod(jupyter_token, image, name, user_id, gsa_key_secret_name):
+def start_pod(jupyter_token, image, name, user_id, ksa_name, gsa_key_secret_name):
     pod_id = uuid.uuid4().hex
 
     pod_spec = kube.client.V1PodSpec(
+        service_account_name=ksa_name,
         containers=[
             kube.client.V1Container(
                 command=[
@@ -372,7 +373,7 @@ def notebook_post():
     safe_user_id = user_id_transform(g.user['auth0_id'])
 
     pod = start_pod(jupyter_token, WORKER_IMAGES[image], name,
-                    safe_user_id, g.user['gsa_key_secret_name'])
+                    safe_user_id, g.user['ksa_name'], g.user['gsa_key_secret_name'])
     session['notebook'] = notebooks_for_ui([pod])[0]
 
     return redirect(external_url_for('notebook'))


### PR DESCRIPTION
Allows the notebook container to have access to the user's gsa secret key, a necessary step in mounting the user's bucket.

I modified `delete_worker_pod` to exclude the  V1DeleteOptions, because the signature appears to have changed, and no options were actually provided.

```sh
  File "notebook/notebook.py", line 443, in delete_worker_pod
    kube.client.V1DeleteOptions())
TypeError: delete_namespaced_pod() takes 3 positional arguments but 4 were given
```

Will double check that I have necessary permissions: its the case when running on local, but I think I will need to update vdc to provide broad secret read access for notebook for this to work on the cluster. Checking now

cc @cseed, @danking, @jigold 