### PR TITLE
Fix error messages to be consistent about using quotes, not backticks.

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/aggregators/RegionValueArraySumAggregator.scala
+++ b/hail/src/main/scala/is/hail/annotations/aggregators/RegionValueArraySumAggregator.scala
@@ -22,7 +22,7 @@ class RegionValueArraySumLongAggregator(t: Type) extends RegionValueAggregator {
         val len = typ.loadLength(region, aoff)
         if (len != sum.length)
           fatal(
-            s"""cannot aggregate arrays of unequal length with `sum'
+            s"""cannot aggregate arrays of unequal length with 'sum'
                |Found conflicting arrays of size (${ sum.length }) and ($len)""".stripMargin)
         else {
           var i = 0
@@ -40,7 +40,7 @@ class RegionValueArraySumLongAggregator(t: Type) extends RegionValueAggregator {
     val that = _that.asInstanceOf[RegionValueArraySumLongAggregator]
     if (that.sum != null && sum != null && that.sum.length != sum.length)
       fatal(
-        s"""cannot aggregate arrays of unequal length with `sum'
+        s"""cannot aggregate arrays of unequal length with 'sum'
                |Found conflicting arrays of size (${ sum.length })
                |and (${ that.sum.length })""".stripMargin)
     if (sum == null)
@@ -95,7 +95,7 @@ class RegionValueArraySumDoubleAggregator(t: Type) extends RegionValueAggregator
         val len = typ.loadLength(region, aoff)
         if (len != sum.length)
           fatal(
-            s"""cannot aggregate arrays of unequal length with `sum'
+            s"""cannot aggregate arrays of unequal length with 'sum'
                |Found conflicting arrays of size (${ sum.length }) and ($len)""".stripMargin)
         else {
           var i = 0
@@ -113,7 +113,7 @@ class RegionValueArraySumDoubleAggregator(t: Type) extends RegionValueAggregator
     val that = _that.asInstanceOf[RegionValueArraySumDoubleAggregator]
     if (that.sum != null && sum != null && that.sum.length != sum.length)
       fatal(
-        s"""cannot aggregate arrays of unequal length with `sum'
+        s"""cannot aggregate arrays of unequal length with 'sum'
                |Found conflicting arrays of size (${ sum.length })
                |and (${ that.sum.length })""".stripMargin)
     if (sum == null)

--- a/hail/src/main/scala/is/hail/annotations/aggregators/RegionValueHistogramAggregator.scala
+++ b/hail/src/main/scala/is/hail/annotations/aggregators/RegionValueHistogramAggregator.scala
@@ -13,7 +13,7 @@ object RegionValueHistogramAggregator {
 
 class RegionValueHistogramAggregator(start: Double, end: Double, bins: Int) extends RegionValueAggregator {
   if (bins <= 0)
-    fatal(s"""method `hist' expects `bins' argument to be > 0, but got $bins""")
+    fatal(s"""method 'hist' expects 'bins' argument to be > 0, but got $bins""")
 
   private val binSize = (end - start) / bins
   if (binSize <= 0)

--- a/hail/src/main/scala/is/hail/expr/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/Parser.scala
@@ -59,7 +59,7 @@ object Parser extends JavaTokenParsers {
     parseAll[Interval](locusInterval(rg), input) match {
       case Success(r, _) => r
       case NoSuccess(msg, next) => fatal(
-        s"""invalid interval expression: `$input': $msg
+        s"""invalid interval expression: '$input': $msg
            |  Acceptable formats:
            |    CHR:POS-CHR:POS e.g. 1:12345-1:17299 or [5:151111-8:191293]
            |            An interval from the starting locus (chromosome, position)
@@ -80,7 +80,7 @@ object Parser extends JavaTokenParsers {
   def parseCall(input: String): Call = {
     parseAll[Call](call, input) match {
       case Success(r, _) => r
-      case NoSuccess(msg, next) => fatal(s"invalid call expression: `$input': $msg")
+      case NoSuccess(msg, next) => fatal(s"invalid call expression: '$input': $msg")
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -587,7 +587,7 @@ object Interpret {
             val binsValue = interpret(bins, Env.empty[Any], null, null).asInstanceOf[Int]
 
             if (binsValue <= 0)
-              fatal(s"""method `hist' expects `bins' argument to be > 0, but got $bins""")
+              fatal(s"""method 'hist' expects 'bins' argument to be > 0, but got $bins""")
 
             val binSize = (endValue - startValue) / binsValue
             if (binSize <= 0)

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
@@ -335,7 +335,7 @@ object CompileDecoder {
             nAlleles2 := reader.invoke[Int]("readShort"),
             (nAlleles.cne(nAlleles2)).mux(
               Code._fatal(
-                const("""Value for `nAlleles' in genotype probability data storage is
+                const("""Value for 'nAlleles' in genotype probability data storage is
                         |not equal to value in variant identifying data. Expected""".stripMargin)
                   .concat(nAlleles.toS)
                   .concat(" but found ")
@@ -350,9 +350,9 @@ object CompileDecoder {
             maxPloidy := reader.invoke[Int]("read"),
             (minPloidy.cne(2) || maxPloidy.cne(2)).mux(
               Code._fatal(
-                const("Hail only supports diploid genotypes. Found min ploidy `")
+                const("Hail only supports diploid genotypes. Found min ploidy '")
                   .concat(minPloidy.toS)
-                  .concat("' and max ploidy `")
+                  .concat("' and max ploidy '")
                   .concat(maxPloidy.toS)
                   .concat("'.")),
               Code._empty),
@@ -393,9 +393,9 @@ object CompileDecoder {
             nExpectedBytesProbs := settings.nSamples * 2,
             (reader.invoke[Int]("length").cne(nExpectedBytesProbs + settings.nSamples + 10)).mux(
               Code._fatal(
-                const("Number of uncompressed bytes `")
+                const("Number of uncompressed bytes '")
                   .concat(reader.invoke[Int]("length").toS)
-                  .concat("' does not match the expected size `")
+                  .concat("' does not match the expected size '")
                   .concat(nExpectedBytesProbs.toS)
                   .concat("'.")),
               Code._empty),

--- a/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/LoadBgen.scala
@@ -68,7 +68,7 @@ object LoadBgen {
         }.toArray
       }
     } else {
-      warn(s"BGEN file `$file' contains no sample ID block and no sample ID file given.\n" +
+      warn(s"BGEN file '$file' contains no sample ID block and no sample ID file given.\n" +
         s"  Using _0, _1, ..., _N as sample IDs.")
       (0 until bState.nSamples).map(i => s"_$i").toArray
     }

--- a/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
@@ -73,7 +73,7 @@ object LoadPlink {
           case "0" => null
           case "1" => false
           case "2" => true
-          case _ => fatal(s"Invalid sex: `$isFemale'. Male is `1', female is `2', unknown is `0'")
+          case _ => fatal(s"Invalid sex: '$isFemale'. Male is '1', female is '2', unknown is '0'")
         }
 
         var warnedAbout9 = false
@@ -90,7 +90,7 @@ object LoadPlink {
                 }
                 -9d
               case numericRegex() => pheno.toDouble
-              case _ => fatal(s"Invalid quantitative phenotype: `$pheno'. Value must be numeric or `${ ffConfig.missingValue }'")
+              case _ => fatal(s"Invalid quantitative phenotype: '$pheno'. Value must be numeric or '${ ffConfig.missingValue }'")
             }
           else
             pheno match {
@@ -100,7 +100,7 @@ object LoadPlink {
               case "0" => null
               case "-9" => null
               case "N/A" => null
-              case numericRegex() => fatal(s"Invalid case-control phenotype: `$pheno'. Control is `1', case is `2', missing is `0', `-9', `${ ffConfig.missingValue }', or non-numeric.")
+              case numericRegex() => fatal(s"Invalid case-control phenotype: '$pheno'. Control is '1', case is '2', missing is '0', '-9', '${ ffConfig.missingValue }', or non-numeric.")
               case _ => null
             }
         idBuilder += kid

--- a/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -119,7 +119,7 @@ object ExportVCF {
     }
     tOption match {
       case Some(s) => s
-      case _ => fatal(s"INFO field '${ f.name }': VCF does not support type `${ f.typ }'.")
+      case _ => fatal(s"INFO field '${ f.name }': VCF does not support type '${ f.typ }'.")
     }
   }
 
@@ -140,7 +140,7 @@ object ExportVCF {
 
     tOption match {
       case Some(s) => s
-      case _ => fatal(s"FORMAT field '$fieldName': VCF does not support type `$t'.")
+      case _ => fatal(s"FORMAT field '$fieldName': VCF does not support type '$t'.")
     }
   }
 

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -680,7 +680,7 @@ object LoadVCF {
 
     inputs.foreach { input =>
       if (!(input.endsWith(".vcf") || input.endsWith(".vcf.bgz") || !input.endsWith(".vcf.gz")))
-        warn(s"expected input file `$input' to end in .vcf[.bgz, .gz]")
+        warn(s"expected input file '$input' to end in .vcf[.bgz, .gz]")
       if (input.endsWith(".gz"))
         checkGzippedFile(hConf, input, forceGZ, gzAsBGZ)
     }
@@ -714,7 +714,7 @@ object LoadVCF {
       case (VCFHeaderLineType.String, false) => TString()
       case (VCFHeaderLineType.Character, false) => TString()
       case (VCFHeaderLineType.Flag, false) => TBoolean()
-      case (_, true) => fatal(s"Can only convert a header line with type `String' to a call type. Found `${ line.getType }'.")
+      case (_, true) => fatal(s"Can only convert a header line with type 'String' to a call type. Found '${ line.getType }'.")
     }
 
     val attrs = Map("Description" -> line.getDescription,
@@ -776,7 +776,7 @@ object LoadVCF {
     val headerLine = lines.last
     if (!(headerLine(0) == '#' && headerLine(1) != '#'))
       fatal(
-        s"""corrupt VCF: expected final header line of format `#CHROM\tPOS\tID...'
+        s"""corrupt VCF: expected final header line of format '#CHROM\tPOS\tID...'
            |  found: @1""".stripMargin, headerLine)
 
     val sampleIds: Array[String] = headerLine.split("\t").drop(9)

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -665,7 +665,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       StorageLevel.fromString(storageLevel)
     } catch {
       case e: IllegalArgumentException =>
-        fatal(s"unknown StorageLevel `$storageLevel'")
+        fatal(s"unknown StorageLevel '$storageLevel'")
     }
     persist(level)
   }

--- a/hail/src/main/scala/is/hail/methods/Aggregators.scala
+++ b/hail/src/main/scala/is/hail/methods/Aggregators.scala
@@ -289,7 +289,7 @@ class SumArrayAggregator[T](implicit ev: scala.math.Numeric[T], ct: ClassTag[T])
       else {
         if (r.length != _state.length)
           fatal(
-            s"""cannot aggregate arrays of unequal length with `sum'
+            s"""cannot aggregate arrays of unequal length with 'sum'
                |Found conflicting arrays of size (${ _state.length }) and (${ r.length })""".stripMargin)
         else {
           var i = 0
@@ -310,7 +310,7 @@ class SumArrayAggregator[T](implicit ev: scala.math.Numeric[T], ct: ClassTag[T])
     else if (agg2._state != null) {
       if (_state.length != agg2state.length)
         fatal(
-          s"""cannot aggregate arrays of unequal length with `sum'
+          s"""cannot aggregate arrays of unequal length with 'sum'
              |  Found conflicting arrays of size (${ _state.length }) and (${ agg2state.length })""".
             stripMargin)
       for (i <- _state.indices)

--- a/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
+++ b/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
@@ -299,7 +299,7 @@ case class LocalLDPrune(
 
   def execute(mv: MatrixValue): TableValue = {
     if (maxQueueSize < 1)
-      fatal(s"Maximum queue size must be positive. Found `$maxQueueSize'.")
+      fatal(s"Maximum queue size must be positive. Found '$maxQueueSize'.")
 
     val nSamples = mv.nCols
     

--- a/hail/src/main/scala/is/hail/methods/Nirvana.scala
+++ b/hail/src/main/scala/is/hail/methods/Nirvana.scala
@@ -377,7 +377,7 @@ object Nirvana {
 
     val nirvanaLocation = properties.getProperty("hail.nirvana.location")
     if (nirvanaLocation == null)
-      fatal("property `hail.nirvana.location' required")
+      fatal("property hail.nirvana.location' required")
 
     val path = Option(properties.getProperty("hail.nirvana.path"))
 

--- a/hail/src/main/scala/is/hail/misc/BGZipBlocks.scala
+++ b/hail/src/main/scala/is/hail/misc/BGZipBlocks.scala
@@ -10,7 +10,7 @@ object BGZipBlocks {
   def apply(hadoopConf: hadoop.conf.Configuration, file: String) {
     var buf = new Array[Byte](64 * 1024)
 
-    // position of `buf[0]' in input stream
+    // position of 'buf[0]' in input stream
     var bufPos = 0L
 
     var bufSize = 0

--- a/hail/src/main/scala/is/hail/utils/ExportType.scala
+++ b/hail/src/main/scala/is/hail/utils/ExportType.scala
@@ -10,7 +10,7 @@ object ExportType {
       case null => CONCATENATED
       case "separate_header" => PARALLEL_SEPARATE_HEADER
       case "header_per_shard" => PARALLEL_HEADER_IN_SHARD
-      case _ => fatal(s"Unknown export type: `$typ'")
+      case _ => fatal(s"Unknown export type: '$typ'")
     }
   }
 }

--- a/hail/src/main/scala/is/hail/utils/StringEscapeUtils.scala
+++ b/hail/src/main/scala/is/hail/utils/StringEscapeUtils.scala
@@ -171,7 +171,7 @@ object StringEscapeUtils {
           case 'n' => sb += '\n'
           case 'b' => sb += '\b'
           case 'u' => inUnicode = true
-          case _ => fatal(s"Got invalid string escape character: `\\$ch'")
+          case _ => fatal(s"Got invalid string escape character: '\\$ch'")
         }
       } else if (ch == '\\')
         hadSlash = true

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -244,7 +244,7 @@ package object utils extends Logging
     if (str.matches("""[_a-zA-Z]\w*"""))
       str
     else
-      s"'${ StringEscapeUtils.escapeString(str, backticked = true) }`"
+      s"`${ StringEscapeUtils.escapeString(str, backticked = true) }`"
   }
 
   def formatDouble(d: Double, precision: Int): String = d.formatted(s"%.${ precision }f")

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -231,7 +231,7 @@ package object utils extends Logging
 
     fname match {
       case partRegex(i) => i.toInt
-      case _ => throw new PathIOException(s"invalid partition file `$fname'")
+      case _ => throw new PathIOException(s"invalid partition file '$fname'")
     }
   }
 
@@ -244,7 +244,7 @@ package object utils extends Logging
     if (str.matches("""[_a-zA-Z]\w*"""))
       str
     else
-      s"`${ StringEscapeUtils.escapeString(str, backticked = true) }`"
+      s"'${ StringEscapeUtils.escapeString(str, backticked = true) }`"
   }
 
   def formatDouble(d: Double, precision: Int): String = d.formatted(s"%.${ precision }f")
@@ -441,25 +441,6 @@ package object utils extends Logging
 
   val defaultJSONFormats: Formats = Serialization.formats(NoTypeHints) + GenericIndexedSeqSerializer
 
-  def splitWarning(leftSplit: Boolean, left: String, rightSplit: Boolean, right: String) {
-    val msg =
-      """Merge behavior may not be as expected, as all alternate alleles are
-        |  part of the variant key.  See `annotatevariants' documentation for
-        |  more information.""".stripMargin
-    (leftSplit, rightSplit) match {
-      case (true, true) =>
-      case (false, false) => warn(
-        s"""annotating an unsplit $left from an unsplit $right
-           |  $msg""".stripMargin)
-      case (true, false) => warn(
-        s"""annotating a biallelic (split) $left from an unsplit $right
-           |  $msg""".stripMargin)
-      case (false, true) => warn(
-        s"""annotating an unsplit $left from a biallelic (split) $right
-           |  $msg""".stripMargin)
-    }
-  }
-
   def box(i: Int): java.lang.Integer = i
 
   def box(l: Long): java.lang.Long = l
@@ -493,7 +474,7 @@ package object utils extends Logging
 
   def loadFromResource[T](file: String)(reader: (InputStream) => T): T = {
     val resourceStream = Thread.currentThread().getContextClassLoader.getResourceAsStream(file)
-    assert(resourceStream != null, s"Error while locating file `$file'")
+    assert(resourceStream != null, s"Error while locating file '$file'")
 
     try
       reader(resourceStream)

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichHadoopConfiguration.scala
@@ -116,7 +116,7 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
         val fss = glob(arg)
         val files = fss.map(_.getPath.toString)
         if (files.isEmpty)
-          warn(s"`$arg' refers to no files")
+          warn(s"'$arg' refers to no files")
         files
       }.toArray
   }
@@ -125,7 +125,7 @@ class RichHadoopConfiguration(val hConf: hadoop.conf.Configuration) extends AnyV
     filenames.flatMap { filename =>
       val statuses = glob(filename)
       if (statuses.isEmpty)
-        warn(s"`$filename' refers to no files")
+        warn(s"'$filename' refers to no files")
       statuses
     }.toArray
   }

--- a/hail/src/main/scala/is/hail/variant/Call.scala
+++ b/hail/src/main/scala/is/hail/variant/Call.scala
@@ -318,7 +318,7 @@ object Call extends Serializable {
             unphasedDiploidGtIndex(Call2(p.j, p.k))
           } else
             unphasedDiploidGtIndex(c)
-        assert(udtn < nGenotypes, s"Invalid call found `${ c.toString }' for number of alleles equal to `$nAlleles'.")
+        assert(udtn < nGenotypes, s"Invalid call found '${ c.toString }' for number of alleles equal to '$nAlleles'.")
       case _ =>
         alleles(c).foreach(a => assert(a >= 0 && a < nAlleles))
     }

--- a/hail/src/main/scala/is/hail/variant/Locus.scala
+++ b/hail/src/main/scala/is/hail/variant/Locus.scala
@@ -44,7 +44,7 @@ object Locus {
     val elts = str.split(":")
     val size = elts.length
     if (size < 2)
-      fatal(s"Invalid string for Locus. Expecting contig:pos -- found `$str'.")
+      fatal(s"Invalid string for Locus. Expecting contig:pos -- found '$str'.")
 
     val contig = elts.take(size - 1).mkString(":")
     Locus(contig, elts(size - 1).toInt, rg)

--- a/hail/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/hail/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -458,7 +458,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
   def head(n: Long): MatrixTable = {
     if (n < 0)
-      fatal(s"n must be non-negative! Found `$n'.")
+      fatal(s"n must be non-negative! Found '$n'.")
     copy2(rvd = rvd.head(n, None))
   }
 

--- a/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -116,16 +116,16 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
     fatal(s"No lengths given for the following contigs: ${ missingLengths.mkString(", ") }")
 
   if (extraLengths.nonEmpty)
-    fatal(s"Contigs found in `lengths' that are not present in `contigs': ${ extraLengths.mkString(", ") }")
+    fatal(s"Contigs found in 'lengths' that are not present in 'contigs': ${ extraLengths.mkString(", ") }")
 
   if (xContigs.intersect(yContigs).nonEmpty)
-    fatal(s"Found the contigs `${ xContigs.intersect(yContigs).mkString(", ") }' in both X and Y contigs.")
+    fatal(s"Found the contigs '${ xContigs.intersect(yContigs).mkString(", ") }' in both X and Y contigs.")
 
   if (xContigs.intersect(mtContigs).nonEmpty)
-    fatal(s"Found the contigs `${ xContigs.intersect(mtContigs).mkString(", ") }' in both X and MT contigs.")
+    fatal(s"Found the contigs '${ xContigs.intersect(mtContigs).mkString(", ") }' in both X and MT contigs.")
 
   if (yContigs.intersect(mtContigs).nonEmpty)
-    fatal(s"Found the contigs `${ yContigs.intersect(mtContigs).mkString(", ") }' in both Y and MT contigs.")
+    fatal(s"Found the contigs '${ yContigs.intersect(mtContigs).mkString(", ") }' in both Y and MT contigs.")
 
   val contigsIndex: Map[String, Int] = contigs.zipWithIndex.toMap
   val contigsSet: Set[String] = contigs.toSet
@@ -133,7 +133,7 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
 
   lengths.foreach { case (n, l) =>
     if (l <= 0)
-      fatal(s"Contig length must be positive. Contig `$n' has length equal to $l.")
+      fatal(s"Contig length must be positive. Contig '$n' has length equal to $l.")
   }
 
   val xNotInRef = xContigs.diff(contigsSet)
@@ -141,13 +141,13 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
   val mtNotInRef = mtContigs.diff(contigsSet)
 
   if (xNotInRef.nonEmpty)
-    fatal(s"The following X contig names are absent from the reference: `${ xNotInRef.mkString(", ") }'.")
+    fatal(s"The following X contig names are absent from the reference: '${ xNotInRef.mkString(", ") }'.")
 
   if (yNotInRef.nonEmpty)
-    fatal(s"The following Y contig names are absent from the reference: `${ yNotInRef.mkString(", ") }'.")
+    fatal(s"The following Y contig names are absent from the reference: '${ yNotInRef.mkString(", ") }'.")
 
   if (mtNotInRef.nonEmpty)
-    fatal(s"The following mitochondrial contig names are absent from the reference: `${ mtNotInRef.mkString(", ") }'.")
+    fatal(s"The following mitochondrial contig names are absent from the reference: '${ mtNotInRef.mkString(", ") }'.")
 
   val xContigIndices = xContigs.map(contigsIndex)
   val yContigIndices = yContigs.map(contigsIndex)
@@ -175,11 +175,11 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
 
   val par = parInput.map { case (start, end) =>
     if (start.contig != end.contig)
-      fatal(s"The contigs for the `start' and `end' of a PAR interval must be the same. Found `$start-$end'.")
+      fatal(s"The contigs for the 'start' and 'end' of a PAR interval must be the same. Found '$start-$end'.")
 
     if ((!xContigs.contains(start.contig) && !yContigs.contains(start.contig)) ||
       (!xContigs.contains(end.contig) && !yContigs.contains(end.contig)))
-      fatal(s"The contig name for PAR interval `$start-$end' was not found in xContigs `${ xContigs.mkString(",") }' or in yContigs `${ yContigs.mkString(",") }'.")
+      fatal(s"The contig name for PAR interval '$start-$end' was not found in xContigs '${ xContigs.mkString(",") }' or in yContigs '${ yContigs.mkString(",") }'.")
 
     Interval(start, end, includesStart = true, includesEnd = false)
   }
@@ -223,7 +223,7 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
 
   def contigLength(contig: String): Int = lengths.get(contig) match {
     case Some(l) => l
-    case None => fatal(s"Invalid contig name: `$contig'.")
+    case None => fatal(s"Invalid contig name: '$contig'.")
   }
 
   def contigLength(contigIdx: Int): Int = {
@@ -248,9 +248,9 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
   def checkLocus(contig: String, pos: Int): Unit = {
     if (!isValidLocus(contig, pos)) {
       if (!isValidContig(contig))
-        fatal(s"Invalid locus `$contig:$pos' found. Contig `$contig' is not in the reference genome `$name'.")
+        fatal(s"Invalid locus '$contig:$pos' found. Contig '$contig' is not in the reference genome '$name'.")
       else
-        fatal(s"Invalid locus `$contig:$pos' found. Position `$pos' is not within the range [1-${ contigLength(contig) }] for reference genome `$name'.")
+        fatal(s"Invalid locus '$contig:$pos' found. Position '$pos' is not within the range [1-${ contigLength(contig) }] for reference genome '$name'.")
     }
   }
 
@@ -262,23 +262,23 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
 
     if (!isValidLocus(start.contig, if (includesStart) start.position else start.position + 1)) {
       if (!isValidContig(start.contig))
-        fatal(s"Invalid interval `$i' found. Contig `${ start.contig }' is not in the reference genome `$name'.")
+        fatal(s"Invalid interval '$i' found. Contig '${ start.contig }' is not in the reference genome '$name'.")
       else
-        fatal(s"Invalid interval `$i' found. Start `$start' is not within the range [1-${ contigLength(start.contig) }] for reference genome `$name'.")
+        fatal(s"Invalid interval '$i' found. Start '$start' is not within the range [1-${ contigLength(start.contig) }] for reference genome '$name'.")
     }
 
     if (!isValidLocus(end.contig, if (includesEnd) end.position else end.position - 1)) {
       if (!isValidContig(end.contig))
-        fatal(s"Invalid interval `$i' found. Contig `${ end.contig }' is not in the reference genome `$name'.")
+        fatal(s"Invalid interval '$i' found. Contig '${ end.contig }' is not in the reference genome '$name'.")
       else
-        fatal(s"Invalid interval `$i' found. End `$end' is not within the range [1-${ contigLength(end.contig) }] for reference genome `$name'.")
+        fatal(s"Invalid interval '$i' found. End '$end' is not within the range [1-${ contigLength(end.contig) }] for reference genome '$name'.")
     }
 
     if (!Interval.isValid(locusType.ordering, start, end, includesStart, includesEnd))
       if (start == end && ((includesStart && !includesEnd) || (!includesStart && includesStart)))
-        fatal(s"Invalid interval `$i' found. Start and end cannot be equal if one endpoint is inclusive and the other endpoint is exclusive.")
+        fatal(s"Invalid interval '$i' found. Start and end cannot be equal if one endpoint is inclusive and the other endpoint is exclusive.")
       else
-        fatal(s"Invalid interval `$i' found. ")
+        fatal(s"Invalid interval '$i' found. ")
   }
 
   def normalizeLocusInterval(i: Interval): Interval = {
@@ -335,7 +335,7 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
 
   def addSequence(hc: HailContext, fastaFile: String, indexFile: String) {
     if (hasSequence)
-      fatal(s"FASTA sequence has already been loaded for reference genome `$name'.")
+      fatal(s"FASTA sequence has already been loaded for reference genome '$name'.")
 
     val hConf = hc.hadoopConf
     if (!hConf.exists(fastaFile))
@@ -348,7 +348,7 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
 
     val missingContigs = contigs.filterNot(index.hasIndexEntry)
     if (missingContigs.nonEmpty)
-      fatal(s"Contigs missing in FASTA `$fastaFile' that are present in reference genome `$name':\n  " +
+      fatal(s"Contigs missing in FASTA '$fastaFile' that are present in reference genome '$name':\n  " +
         s"@1", missingContigs.truncatable("\n  "))
 
     val invalidLengths = lengths.flatMap { case (c, l) =>
@@ -360,7 +360,7 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
     }.map { case (c, e, f) => s"$c\texpected:$e\tfound:$f"}
 
     if (invalidLengths.nonEmpty)
-      fatal(s"Contig sizes in FASTA `$fastaFile' do not match expected sizes for reference genome `$name':\n  " +
+      fatal(s"Contig sizes in FASTA '$fastaFile' do not match expected sizes for reference genome '$name':\n  " +
         s"@1", invalidLengths.truncatable("\n  "))
 
     val fastaPath = hConf.fileStatus(fastaFile).getPath.toString
@@ -575,7 +575,7 @@ object ReferenceGenome {
     references.get(rg.name) match {
       case Some(rg2) =>
         if (rg != rg2) {
-          fatal(s"Cannot add reference genome `${ rg.name }', a different reference with that name already exists. Choose a reference name NOT in the following list:\n  " +
+          fatal(s"Cannot add reference genome '${ rg.name }', a different reference with that name already exists. Choose a reference name NOT in the following list:\n  " +
             s"@1", references.keys.truncatable("\n  "))
         }
       case None =>
@@ -587,7 +587,7 @@ object ReferenceGenome {
   def getReference(name: String): ReferenceGenome = {
     references.get(name) match {
       case Some(rg) => rg
-      case None => fatal(s"Reference genome `$name' does not exist. Choose a reference name from the following list:\n  " +
+      case None => fatal(s"Reference genome '$name' does not exist. Choose a reference name from the following list:\n  " +
         s"@1", references.keys.truncatable("\n  "))
     }
   }
@@ -682,7 +682,7 @@ object ReferenceGenome {
           addReference(rg)
         else {
           if (ReferenceGenome.getReference(name) != rg)
-            fatal(s"`$name' already exists and is not identical to the imported reference from `$rgPath'.")
+            fatal(s"'$name' already exists and is not identical to the imported reference from '$rgPath'.")
         }
       }
     }

--- a/hail/src/main/scala/is/hail/variant/VariantMethods.scala
+++ b/hail/src/main/scala/is/hail/variant/VariantMethods.scala
@@ -14,7 +14,7 @@ object VariantMethods {
     val elts = str.split(":")
     val size = elts.length
     if (size < 4)
-      fatal(s"Invalid string for Variant. Expecting contig:pos:ref:alt1,alt2 -- found `$str'.")
+      fatal(s"Invalid string for Variant. Expecting contig:pos:ref:alt1,alt2 -- found '$str'.")
 
     val contig = elts.take(size - 3).mkString(":")
     (Locus(contig, elts(size - 3).toInt, rg), elts(size - 2) +: elts(size - 1).split(","))

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -32,7 +32,7 @@ object TestUtils {
     val thrown = intercept[E](f)
     val p = regex.r.findFirstIn(thrown.getMessage).isDefined
     val msg =
-      s"""expected fatal exception with pattern `$regex'
+      s"""expected fatal exception with pattern '$regex'
          |  Found: ${ thrown.getMessage } """
     if (!p)
       println(msg)

--- a/hail/src/test/scala/is/hail/testUtils/Variant.scala
+++ b/hail/src/test/scala/is/hail/testUtils/Variant.scala
@@ -55,8 +55,8 @@ case class Variant(contig: String,
 
   /* The position is 1-based. Telomeres are indicated by using positions 0 or N+1, where N is the length of the
        corresponding chromosome or contig. See the VCF spec, v4.2, section 1.4.1. */
-  require(start >= 0, s"invalid variant: negative position: `${ this.toString }'")
-  require(!ref.isEmpty, s"invalid variant: empty contig: `${ this.toString }'")
+  require(start >= 0, s"invalid variant: negative position: '${ this.toString }'")
+  require(!ref.isEmpty, s"invalid variant: empty contig: '${ this.toString }'")
 
   def nAltAlleles: Int = altAlleles.length
 

--- a/hail/src/test/scala/is/hail/variant/LocusIntervalSuite.scala
+++ b/hail/src/test/scala/is/hail/variant/LocusIntervalSuite.scala
@@ -40,8 +40,8 @@ class LocusIntervalSuite extends SparkSuite {
     // test normalizing end points
     assert(Locus.parseInterval(s"(X:100-${ xMax + 1 })", rg) == Interval(Locus("X", 100), Locus("X", xMax), false, true))
     assert(Locus.parseInterval(s"(X:0-$xMax]", rg) == Interval(Locus("X", 1), Locus("X", xMax), true, true))
-    TestUtils.interceptFatal("Start `X:0' is not within the range")(Locus.parseInterval("[X:0-5)", rg))
-    TestUtils.interceptFatal(s"End `X:${ xMax + 1 }' is not within the range")(Locus.parseInterval(s"[X:1-${ xMax + 1 }]", rg))
+    TestUtils.interceptFatal("Start 'X:0' is not within the range")(Locus.parseInterval("[X:0-5)", rg))
+    TestUtils.interceptFatal(s"End 'X:${ xMax + 1 }' is not within the range")(Locus.parseInterval(s"[X:1-${ xMax + 1 }]", rg))
 
     assert(Locus.parseInterval("[16:29500000-30200000)", rg) == Interval(Locus("16", 29500000), Locus("16", 30200000), true, false))
     assert(Locus.parseInterval("[16:29.5M-30.2M)", rg) == Interval(Locus("16", 29500000), Locus("16", 30200000), true, false))

--- a/hail/src/test/scala/is/hail/variant/ReferenceGenomeSuite.scala
+++ b/hail/src/test/scala/is/hail/variant/ReferenceGenomeSuite.scala
@@ -53,7 +53,7 @@ class ReferenceGenomeSuite extends SparkSuite {
   @Test def testAssertions() {
     TestUtils.interceptFatal("Must have at least one contig in the reference genome.")(ReferenceGenome("test", Array.empty[String], Map.empty[String, Int]))
     TestUtils.interceptFatal("No lengths given for the following contigs:")(ReferenceGenome("test", Array("1", "2", "3"), Map("1" -> 5)))
-    TestUtils.interceptFatal("Contigs found in `lengths' that are not present in `contigs'")(ReferenceGenome("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5, "4" -> 100)))
+    TestUtils.interceptFatal("Contigs found in 'lengths' that are not present in 'contigs'")(ReferenceGenome("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5, "4" -> 100)))
     TestUtils.interceptFatal("The following X contig names are absent from the reference:")(ReferenceGenome("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5), xContigs = Set("X")))
     TestUtils.interceptFatal("The following Y contig names are absent from the reference:")(ReferenceGenome("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5), yContigs = Set("Y")))
     TestUtils.interceptFatal("The following mitochondrial contig names are absent from the reference:")(ReferenceGenome("test", Array("1", "2", "3"), Map("1" -> 5, "2" -> 5, "3" -> 5), mtContigs = Set("MT")))


### PR DESCRIPTION
We mix the two right now, with most of the new code using quotes. I
feel that quotes are a better solution given the prevalence of markdown
editors (like Zulip) where copy-pasting an error message with backticks
leads to badly formatted renderings.

cc @cseed who I believe favored the use of the backtick style in the first place.