### PR TITLE
[c++] NDArray transpose

### DIFF
--- a/hail/src/main/resources/include/hail/NDArray.h
+++ b/hail/src/main/resources/include/hail/NDArray.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 struct NDArray {
+  int flags; // Not currently used. Will store metadata for numpy compatibility
   int offset;
   size_t elem_size;
   std::vector<long> shape;
@@ -11,7 +12,7 @@ struct NDArray {
   const char *data;
 };
 
-NDArray make_ndarray(size_t elem_size, std::vector<long> shape, std::vector<long> strides, const char *data);
+NDArray make_ndarray(int flags, int offset, size_t elem_size, std::vector<long> shape, std::vector<long> strides, const char *data);
 char const *load_indices(NDArray &nd, std::vector<long> indices);
 char const *load_index(NDArray &nd, int index);
 int n_elements(std::vector<long> &shape);
@@ -19,8 +20,9 @@ std::vector<long> make_strides(int row_major, std::vector<long> &shape);
 std::vector<long> strides_row_major(std::vector<long> &shape);
 std::vector<long> strides_col_major(std::vector<long> &shape);
 
-NDArray make_ndarray(int offset, size_t elem_size, std::vector<long> shape, std::vector<long> strides, const char *data) {
+NDArray make_ndarray(int flags, int offset, size_t elem_size, std::vector<long> shape, std::vector<long> strides, const char *data) {
   NDArray nd;
+  nd.flags = flags;
   nd.offset = offset;
   nd.elem_size = elem_size;
   nd.shape = shape;

--- a/hail/src/main/resources/include/hail/NDArray.h
+++ b/hail/src/main/resources/include/hail/NDArray.h
@@ -4,7 +4,6 @@
 #include <vector>
 
 struct NDArray {
-  int flags; // least sig. bit denotes if row major
   int offset;
   size_t elem_size;
   std::vector<long> shape;
@@ -12,7 +11,7 @@ struct NDArray {
   const char *data;
 };
 
-NDArray make_ndarray(int flags, size_t elem_size, std::vector<long> shape, std::vector<long> strides, const char *data);
+NDArray make_ndarray(size_t elem_size, std::vector<long> shape, std::vector<long> strides, const char *data);
 char const *load_indices(NDArray &nd, std::vector<long> indices);
 char const *load_index(NDArray &nd, int index);
 int n_elements(std::vector<long> &shape);
@@ -20,10 +19,9 @@ std::vector<long> make_strides(int row_major, std::vector<long> &shape);
 std::vector<long> strides_row_major(std::vector<long> &shape);
 std::vector<long> strides_col_major(std::vector<long> &shape);
 
-NDArray make_ndarray(int flags, size_t elem_size, std::vector<long> shape, std::vector<long> strides, const char *data) {
+NDArray make_ndarray(int offset, size_t elem_size, std::vector<long> shape, std::vector<long> strides, const char *data) {
   NDArray nd;
-  nd.flags = flags;
-  nd.offset = 0;
+  nd.offset = offset;
   nd.elem_size = elem_size;
   nd.shape = shape;
   nd.data = data;

--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -854,7 +854,7 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
              |   ${ fb.nativeError("Number of elements does not match NDArray shape") }
              | }
              |
-             | make_ndarray(0, $elemSize, $shape, $strides, ${dataContainer.cxxImpl}::elements_address(${ datat.v }));
+             | make_ndarray(0, 0, $elemSize, $shape, $strides, ${dataContainer.cxxImpl}::elements_address(${ datat.v }));
              |})
              |""".stripMargin)
 
@@ -987,7 +987,7 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
              |  ${ strides.define }
              |
              |  ${ permuteShapeAndStrides }
-             |  make_ndarray($nd.offset, $nd.elem_size, $shape, $strides, $nd.data);
+             |  make_ndarray($nd.flags, $nd.offset, $nd.elem_size, $shape, $strides, $nd.data);
              |})
            """.stripMargin)
 

--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -967,9 +967,9 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
              |})
            """.stripMargin)
 
-      case ir.NDArrayBroadcast(child, indexExpr) =>
+      case ir.NDArrayReindex(child, indexExpr) =>
         assert(indexExpr.length == child.typ.asInstanceOf[TNDArray].nDims,
-          "Cannot realize broadcast that is not a transpose")
+          "Cannot realize reindexing that is not a transpose")
         val ndt = emit(child)
         val nd = fb.variable("nd", "NDArray", ndt.v)
         val shape = fb.variable("shape", "std::vector<long>")

--- a/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
+++ b/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
@@ -132,7 +132,7 @@ abstract class NDArrayLoopEmitter(
       | ${ emitLoops() }
       |
       | $data = ${container.cxxImpl}::elements_address($builder.offset());
-      | make_ndarray(0, ${resultElemType.byteSize}, $resultShape, $strides, $data);
+      | make_ndarray(0, 0, ${resultElemType.byteSize}, $resultShape, $strides, $data);
       |})
     """.stripMargin
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -84,6 +84,8 @@ object Children {
       Array(nd, body)
     case NDArrayMap2(l, r, _, _, body) =>
       Array(l, r, body)
+    case NDArrayBroadcast(nd, _) =>
+      Array(nd)
     case AggFilter(cond, aggIR, _) =>
       Array(cond, aggIR)
     case AggExplode(array, _, aggBody, _) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -84,7 +84,7 @@ object Children {
       Array(nd, body)
     case NDArrayMap2(l, r, _, _, body) =>
       Array(l, r, body)
-    case NDArrayBroadcast(nd, _) =>
+    case NDArrayReindex(nd, _) =>
       Array(nd)
     case AggFilter(cond, aggIR, _) =>
       Array(cond, aggIR)

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -68,6 +68,9 @@ object Copy {
       case NDArrayMap2(_, _, lName, rName, _) =>
         val IndexedSeq(l: IR, r: IR, body: IR) = newChildren
         NDArrayMap2(l, r, lName, rName, body)
+      case NDArrayBroadcast(_, indexExpr) =>
+        val IndexedSeq(nd: IR) = newChildren
+        NDArrayBroadcast(nd, indexExpr)
       case ArraySort(_, l, r, _) =>
         val IndexedSeq(a: IR, comp: IR) = newChildren
         ArraySort(a, l, r, comp)

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -68,9 +68,9 @@ object Copy {
       case NDArrayMap2(_, _, lName, rName, _) =>
         val IndexedSeq(l: IR, r: IR, body: IR) = newChildren
         NDArrayMap2(l, r, lName, rName, body)
-      case NDArrayBroadcast(_, indexExpr) =>
+      case NDArrayReindex(_, indexExpr) =>
         val IndexedSeq(nd: IR) = newChildren
-        NDArrayBroadcast(nd, indexExpr)
+        NDArrayReindex(nd, indexExpr)
       case ArraySort(_, l, r, _) =>
         val IndexedSeq(a: IR, comp: IR) = newChildren
         ArraySort(a, l, r, comp)

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -213,6 +213,8 @@ final case class NDArrayMap2(l: IR, r: IR, lName: String, rName: String, body: I
   def elementTyp: Type = typ.elementType
 }
 
+final case class NDArrayBroadcast(nd: IR, indexExpr: IndexedSeq[Int]) extends IR
+
 final case class AggFilter(cond: IR, aggIR: IR, isScan: Boolean) extends IR
 
 final case class AggExplode(array: IR, name: String, aggBody: IR, isScan: Boolean) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -213,7 +213,7 @@ final case class NDArrayMap2(l: IR, r: IR, lName: String, rName: String, body: I
   def elementTyp: Type = typ.elementType
 }
 
-final case class NDArrayBroadcast(nd: IR, indexExpr: IndexedSeq[Int]) extends IR
+final case class NDArrayReindex(nd: IR, indexExpr: IndexedSeq[Int]) extends IR
 
 final case class AggFilter(cond: IR, aggIR: IR, isScan: Boolean) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -103,6 +103,8 @@ object InferPType {
         PNDArray(body.pType, coerce[TNDArray](nd.typ).nDims, nd.typ.required)
       case NDArrayMap2(l, _, _, _, body) =>
         PNDArray(body.pType, coerce[TNDArray](l.typ).nDims, l.typ.required)
+      case NDArrayBroadcast(nd, indexExpr) =>
+        PNDArray(coerce[PNDArray](nd.pType).elementType, indexExpr.length)
       case NDArrayRef(nd, idxs) =>
         coerce[PNDArray](nd.pType).elementType.setRequired(nd.pType.required && 
           idxs.pType.required &&

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -103,7 +103,7 @@ object InferPType {
         PNDArray(body.pType, coerce[TNDArray](nd.typ).nDims, nd.typ.required)
       case NDArrayMap2(l, _, _, _, body) =>
         PNDArray(body.pType, coerce[TNDArray](l.typ).nDims, l.typ.required)
-      case NDArrayBroadcast(nd, indexExpr) =>
+      case NDArrayReindex(nd, indexExpr) =>
         PNDArray(coerce[PNDArray](nd.pType).elementType, indexExpr.length)
       case NDArrayRef(nd, idxs) =>
         coerce[PNDArray](nd.pType).elementType.setRequired(nd.pType.required && 

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -103,7 +103,7 @@ object InferType {
         TNDArray(body.typ, coerce[TNDArray](nd.typ).nDimsBase, nd.typ.required)
       case NDArrayMap2(l, _, _, _, body) =>
         TNDArray(body.typ, coerce[TNDArray](l.typ).nDimsBase, l.typ.required)
-      case NDArrayBroadcast(nd, indexExpr) =>
+      case NDArrayReindex(nd, indexExpr) =>
         TNDArray(coerce[TNDArray](nd.typ).elementType, Nat(indexExpr.length), nd.typ.required)
       case NDArrayRef(nd, idxs) =>
         assert(coerce[TStreamable](idxs.typ).elementType.isOfType(TInt64()))

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -103,6 +103,8 @@ object InferType {
         TNDArray(body.typ, coerce[TNDArray](nd.typ).nDimsBase, nd.typ.required)
       case NDArrayMap2(l, _, _, _, body) =>
         TNDArray(body.typ, coerce[TNDArray](l.typ).nDimsBase, l.typ.required)
+      case NDArrayBroadcast(nd, indexExpr) =>
+        TNDArray(coerce[TNDArray](nd.typ).elementType, Nat(indexExpr.length), nd.typ.required)
       case NDArrayRef(nd, idxs) =>
         assert(coerce[TStreamable](idxs.typ).elementType.isOfType(TInt64()))
         coerce[TNDArray](nd.typ).elementType.setRequired(nd.typ.required && 

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -636,6 +636,10 @@ object IRParser {
         val r = ir_value_expr(env)(it)
         val body = ir_value_expr(env)(it)
         NDArrayMap2(l, r, lName, rName, body)
+      case "NDArrayBroadcast" =>
+        val indexExpr = int32_literals(it)
+        val nd = ir_value_expr(env)(it)
+        NDArrayBroadcast(nd, indexExpr)
       case "NDArrayRef" =>
         val nd = ir_value_expr(env)(it)
         val idxs = ir_value_expr(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -636,10 +636,10 @@ object IRParser {
         val r = ir_value_expr(env)(it)
         val body = ir_value_expr(env)(it)
         NDArrayMap2(l, r, lName, rName, body)
-      case "NDArrayBroadcast" =>
+      case "NDArrayReindex" =>
         val indexExpr = int32_literals(it)
         val nd = ir_value_expr(env)(it)
-        NDArrayBroadcast(nd, indexExpr)
+        NDArrayReindex(nd, indexExpr)
       case "NDArrayRef" =>
         val nd = ir_value_expr(env)(it)
         val idxs = ir_value_expr(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -185,7 +185,11 @@ object Pretty {
             case AggArrayPerElement(_, name, _, isScan) => prettyIdentifier(name) + " " + prettyBooleanLiteral(isScan)
             case MakeNDArray(nDim, _, _, _) => nDim.toString
             case NDArrayMap(_, name, _) => prettyIdentifier(name)
+<<<<<<< HEAD
             case NDArrayMap2(_, _, lName, rName, _) => prettyIdentifier(lName) + " " + prettyIdentifier(rName)
+=======
+            case NDArrayBroadcast(_, indexExpr) => prettyInts(indexExpr)
+>>>>>>> add and emit NDArrayBroadcast IR node
             case ArraySort(_, l, r, _) => prettyIdentifier(l) + " " + prettyIdentifier(r)
             case ApplyIR(function, _) => prettyIdentifier(function)
             case Apply(function, _) => prettyIdentifier(function)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -186,7 +186,7 @@ object Pretty {
             case MakeNDArray(nDim, _, _, _) => nDim.toString
             case NDArrayMap(_, name, _) => prettyIdentifier(name)
             case NDArrayMap2(_, _, lName, rName, _) => prettyIdentifier(lName) + " " + prettyIdentifier(rName)
-            case NDArrayBroadcast(_, indexExpr) => prettyInts(indexExpr)
+            case NDArrayReindex(_, indexExpr) => prettyInts(indexExpr)
             case ArraySort(_, l, r, _) => prettyIdentifier(l) + " " + prettyIdentifier(r)
             case ApplyIR(function, _) => prettyIdentifier(function)
             case Apply(function, _) => prettyIdentifier(function)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -185,11 +185,8 @@ object Pretty {
             case AggArrayPerElement(_, name, _, isScan) => prettyIdentifier(name) + " " + prettyBooleanLiteral(isScan)
             case MakeNDArray(nDim, _, _, _) => nDim.toString
             case NDArrayMap(_, name, _) => prettyIdentifier(name)
-<<<<<<< HEAD
             case NDArrayMap2(_, _, lName, rName, _) => prettyIdentifier(lName) + " " + prettyIdentifier(rName)
-=======
             case NDArrayBroadcast(_, indexExpr) => prettyInts(indexExpr)
->>>>>>> add and emit NDArrayBroadcast IR node
             case ArraySort(_, l, r, _) => prettyIdentifier(l) + " " + prettyIdentifier(r)
             case ApplyIR(function, _) => prettyIdentifier(function)
             case Apply(function, _) => prettyIdentifier(function)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -137,7 +137,11 @@ object TypeCheck {
         assert(x.elementTyp == body.typ)
       case x@NDArrayReindex(nd, indexExpr) =>
         assert(nd.typ.isInstanceOf[TNDArray])
-        assert(coerce[TNDArray](nd.typ).nDims <= indexExpr.length)
+        val nInputDims = coerce[TNDArray](nd.typ).nDims
+        val nOutputDims = indexExpr.length
+        assert(nInputDims <= nOutputDims)
+        assert(indexExpr.forall(i => i < nOutputDims))
+        assert((0 until nOutputDims).forall(i => indexExpr.contains(i)))
       case x@ArraySort(a, l, r, compare) =>
         assert(a.typ.isInstanceOf[TStreamable])
         assert(compare.typ.isOfType(TBoolean()))

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -135,7 +135,7 @@ object TypeCheck {
         val rTyp = coerce[TNDArray](r.typ)
         assert(lTyp.nDims == rTyp.nDims)
         assert(x.elementTyp == body.typ)
-      case x@NDArrayBroadcast(nd, indexExpr) =>
+      case x@NDArrayReindex(nd, indexExpr) =>
         assert(nd.typ.isInstanceOf[TNDArray])
         assert(coerce[TNDArray](nd.typ).nDims <= indexExpr.length)
       case x@ArraySort(a, l, r, compare) =>

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -127,13 +127,17 @@ object TypeCheck {
         assert(nd.typ.isInstanceOf[TNDArray])
         assert(coerce[TStreamable](idxs.typ).elementType.isOfType(TInt64()))
         assert(idxs.typ.isOfType(TArray(TInt64())))
-      case x@NDArrayMap(_, _, body) =>
+      case x@NDArrayMap(nd, _, body) =>
+        assert(nd.typ.isInstanceOf[TNDArray])
         assert(x.elementTyp == body.typ)
       case x@NDArrayMap2(l, r, _, _, body) =>
         val lTyp = coerce[TNDArray](l.typ)
         val rTyp = coerce[TNDArray](r.typ)
         assert(lTyp.nDims == rTyp.nDims)
         assert(x.elementTyp == body.typ)
+      case x@NDArrayBroadcast(nd, indexExpr) =>
+        assert(nd.typ.isInstanceOf[TNDArray])
+        assert(coerce[TNDArray](nd.typ).nDims <= indexExpr.length)
       case x@ArraySort(a, l, r, compare) =>
         assert(a.typ.isInstanceOf[TStreamable])
         assert(compare.typ.isOfType(TBoolean()))

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -998,13 +998,13 @@ class IRSuite extends SparkSuite {
     assertEvalsTo(twentyTwo, 22.0)
   }
 
-  @Test def testNDArrayBroadcast() {
+  @Test def testNDArrayReindex() {
     implicit val execStrats = Set(ExecStrategy.CxxCompile)
 
     val mat = MakeNDArray(2, MakeArray(Seq(F64(1.0), F64(2.0), F64(3.0), F64(4.0)), TArray(TFloat64())),
       MakeArray(Seq(I64(2L), I64(2L)), TArray(TInt64())), True())
-    val transpose = NDArrayBroadcast(mat, IndexedSeq(1, 0))
-    val identity = NDArrayBroadcast(mat, IndexedSeq(0, 1))
+    val transpose = NDArrayReindex(mat, IndexedSeq(1, 0))
+    val identity = NDArrayReindex(mat, IndexedSeq(0, 1))
 
     val topLeftIndex = MakeArray(FastSeq(0L, 0L), TArray(TInt64()))
     val bottomLeftIndex = MakeArray(FastSeq(1L, 0L), TArray(TInt64()))
@@ -1016,11 +1016,11 @@ class IRSuite extends SparkSuite {
     assertEvalsTo(NDArrayRef(identity, bottomLeftIndex), 3.0)
     assertEvalsTo(NDArrayRef(transpose, bottomLeftIndex), 2.0)
 
-    val partialTranspose = NDArrayBroadcast(cubeRowMajor, IndexedSeq(0, 2, 1))
+    val partialTranspose = NDArrayReindex(cubeRowMajor, IndexedSeq(0, 2, 1))
     val idx = MakeArray(FastSeq(0L, 1L, 0L), TArray(TInt64()))
-    val mirroredIdx = MakeArray(FastSeq(0L, 0L, 1L), TArray(TInt64()))
+    val partialTranposeIdx = MakeArray(FastSeq(0L, 0L, 1L), TArray(TInt64()))
     assertEvalsTo(NDArrayRef(cubeRowMajor, idx), 3.0)
-    assertEvalsTo(NDArrayRef(partialTranspose, mirroredIdx), 3.0)
+    assertEvalsTo(NDArrayRef(partialTranspose, partialTranposeIdx), 3.0)
   }
 
   @Test def testLeftJoinRightDistinct() {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -992,6 +992,25 @@ class IRSuite extends SparkSuite {
     assertEvalsTo(twentyTwo, 22.0)
   }
 
+  @Test def testNDArrayBroadcast() {
+    implicit val execStrats = Set(ExecStrategy.CxxCompile)
+    val shape = MakeArray(Seq(I64(2L), I64(2L)), TArray(TInt64()))
+
+    val mat = MakeNDArray(2, MakeArray(Seq(F64(1.0), F64(2.0), F64(3.0), F64(4.0)), TArray(TFloat64())), shape, True())
+    val transpose = NDArrayBroadcast(mat, IndexedSeq(1, 0))
+    val identity = NDArrayBroadcast(mat, IndexedSeq(0, 1))
+
+    val topLeftIndex = MakeArray(FastSeq(0L, 0L), TArray(TInt64()))
+    val bottomLeftIndex = MakeArray(FastSeq(1L, 0L), TArray(TInt64()))
+
+    assertEvalsTo(NDArrayRef(mat, topLeftIndex), 1.0)
+    assertEvalsTo(NDArrayRef(identity, topLeftIndex), 1.0)
+    assertEvalsTo(NDArrayRef(transpose, topLeftIndex), 1.0)
+    assertEvalsTo(NDArrayRef(mat, bottomLeftIndex), 3.0)
+    assertEvalsTo(NDArrayRef(identity, bottomLeftIndex), 3.0)
+    assertEvalsTo(NDArrayRef(transpose, bottomLeftIndex), 2.0)
+  }
+
   @Test def testLeftJoinRightDistinct() {
     implicit val execStrats = ExecStrategy.javaOnly
 


### PR DESCRIPTION
- Implement `NDArrayReindex` IR node in Scala. This node specifies a surjective function onto the node's child's set of dimensions. In the case where this is a bijection, the reindex is a transpose and the dimensions are permuted. If it is not a bijection, you introduce new dimensions (a broadcast) that have no specified length. Therefore, broadcasts are impossible to realize and must be deforested (not implemented yet).
- Implement emit for top-level reindexing (must be a transpose).
- Storage format is completely encoded in strides so the `row_major` flag in `NDArray` is superfluous and doesn't make sense after arbitrary transposes. Removed it but kept the `flags` field of `NDArray` which will be used for other metadata.