### PR TITLE
added ci2 skeleton

### DIFF
--- a/ci2/Dockerfile.ci2
+++ b/ci2/Dockerfile.ci2
@@ -1,0 +1,7 @@
+FROM base
+
+COPY ci /ci
+
+EXPOSE 5000
+
+CMD ["python3", "/ci/ci.py"]

--- a/ci2/Makefile
+++ b/ci2/Makefile
@@ -1,0 +1,36 @@
+.PHONY: build
+
+ifeq ($(IN_HAIL_CI),1)
+.PHONY: push deploy
+
+PROJECT = $(shell gcloud config get-value project)
+CI2_LATEST = gcr.io/$(PROJECT)/ci2:latest
+CI2_IMAGE = gcr.io/$(PROJECT)/ci2:$(shell docker images -q --no-trunc ci2 | sed -e 's,[^:]*:,,')
+
+build:
+	make -C ../docker build
+	-docker	pull $(CI2_LATEST)
+	docker build -t ci2 -f Dockerfile.ci2 --cache-from ci2,$(CI2_LATEST),base,ubuntu:18.04 .
+
+push: build
+	docker tag ci2 $(CI2_LATEST)
+	docker push $(CI2_LATEST)
+	docker tag ci2 $(CI2_IMAGE)
+	docker push $(CI2_IMAGE)
+
+deploy: push
+	sed -e "s,@sha@,$(shell git rev-parse --short=12 HEAD)," \
+	  -e "s,@image@,$(CI2_IMAGE)," \
+	  < deployment.yaml.in > deployment.yaml
+	kubectl -n default apply -f deployment.yaml
+else
+build:
+	make -C ../docker build
+	docker build . -t ci2 -f Dockerfile.ci2
+endif
+
+run-local:
+	python3 ci/ci.py
+
+run-docker:
+	docker run -p 5000:5000 ci2

--- a/ci2/ci/ci.py
+++ b/ci2/ci/ci.py
@@ -1,0 +1,16 @@
+import uvloop
+import asyncio
+import aiodns
+from aiohttp import web
+
+uvloop.install()
+
+app = web.Application()
+routes = web.RouteTableDef()
+
+@routes.get('/healthcheck')
+async def healthcheck(request):
+    return web.Response(status=200)
+
+app.add_routes(routes)
+web.run_app(app, host='0.0.0.0', port=5000)

--- a/ci2/deployment.yaml.in
+++ b/ci2/deployment.yaml.in
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ci2
+  labels:
+    app: ci2
+    hail.is/sha: "@sha@"
+spec:
+  selector:
+    matchLabels:
+      app: ci2
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ci2
+        hail.is/sha: "@sha@"
+    spec:
+      containers:
+        - name: ci2
+          image: @image@
+          ports:
+            - containerPort: 5000
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 5000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 5000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ci2
+  labels:
+    app: ci2
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 5000
+  selector:
+    app: ci2

--- a/ci2/hail-ci-deploy.sh
+++ b/ci2/hail-ci-deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ex
+
+gcloud -q auth activate-service-account \
+  --key-file=/secrets/gcr-push-service-account-key.json
+
+gcloud -q auth configure-docker
+
+make deploy

--- a/gateway/hail.nginx.conf.in
+++ b/gateway/hail.nginx.conf.in
@@ -70,6 +70,21 @@ server {
 }
 
 server {
+    server_name ci2.@domain@;
+
+    location / {
+        proxy_pass http://ci2/;
+    }
+
+    listen [::]:443 ssl;
+    listen 443 ssl;
+    ssl_certificate /etc/letsencrypt/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}
+
+server {
     server_name upload.@domain@;
 
     location / {

--- a/projects.yaml
+++ b/projects.yaml
@@ -5,6 +5,7 @@
   dependencies: ["docker"]
 - project: ci
   dependencies: ["batch"]
+- project: ci2
 - project: cloudtools
 - project: etc
 - project: gateway


### PR DESCRIPTION
I'm forking ci => ci2 to address the existing ci issues.  I plan to steal lots of code from ci, this is just a skeleton to get started.  Along the way, I'm going to convert everything to async.

I already deployed the ci2 service, so the gateway change shouldn't break anything.
