### PR TITLE
[batch] Fix dockerignore

### DIFF
--- a/batch/.dockerignore
+++ b/batch/.dockerignore
@@ -1,5 +1,9 @@
-batch.log
-logs
-*~
-*.pyc
+**/*.log
+**/*.pyc
+**/*~
 **/__pycache__
+.pytest_cache/
+batch.log
+build
+dist
+logs

--- a/batch/.dockerignore
+++ b/batch/.dockerignore
@@ -7,3 +7,4 @@ batch.log
 build
 dist
 logs
+batch-secrets


### PR DESCRIPTION
The language of a [`.dockerignore`](https://docs.docker.com/engine/reference/builder/#dockerignore-file) file is different from that of a `.gitignore` file. This changes batch's ignore file to do what the original author probably intended.