### PR TITLE
[batch] simplify batch api.py

### DIFF
--- a/batch/batch/api.py
+++ b/batch/batch/api.py
@@ -22,7 +22,7 @@ class API():
             headers = {}
         self.headers = headers
 
-    def http(self, verb, url, json=None, timeout=None, cookies=None, headers=None, params=None):
+    def http(self, verb, url, json=None, timeout=None, cookies=None, headers=None, json_response=True, params=None):
         if timeout is None:
             timeout = self.timeout
         if cookies is None:
@@ -34,7 +34,10 @@ class API():
         else:
             response = verb(url, timeout=timeout, cookies=cookies, headers=headers, params=params)
         raise_on_failure(response)
-        return response.json()
+        if json_response:
+            return response.json()
+        else:
+            return response
 
     def post(self, *args, **kwargs):
         return self.http(requests.post, *args, **kwargs)
@@ -120,4 +123,4 @@ class API():
         return self.delete(f'{url}/batches/{batch_id}')
 
     def refresh_k8s_state(self, url):
-        self.post(f'{url}/refresh_k8s_state')
+        self.post(f'{url}/refresh_k8s_state', json_response=False)

--- a/batch/batch/api.py
+++ b/batch/batch/api.py
@@ -3,7 +3,7 @@ from .requests_helper import raise_on_failure
 
 
 class API():
-    def __init__(self, timeout=60):
+    def __init__(self, timeout=None, cookies=None, headers=None):
         """
         Python API for accessing the batch server's HTTP endpoints.
 
@@ -12,7 +12,38 @@ class API():
         timeout : :obj:`int` or :obj:`float`
             timeout, in seconds, passed to ``requests`` calls
         """
+        if timeout is None:
+            timeout = 60
         self.timeout = timeout
+        if cookies is None:
+            cookies = {}
+        self.cookies = cookies
+        if headers is None:
+            headers = {}
+        self.headers = headers
+
+    def http(self, verb, url, json=None, timeout=None, cookies=None, headers=None, params=None):
+        if timeout is None:
+            timeout = self.timeout
+        if cookies is None:
+            cookies = self.cookies
+        if headers is None:
+            headers = self.headers
+        if json is not None:
+            response = verb(url, json=json, timeout=timeout, cookies=cookies, headers=headers, params=params)
+        else:
+            response = verb(url, timeout=timeout, cookies=cookies, headers=headers, params=params)
+        raise_on_failure(response)
+        return response.json()
+
+    def post(self, *args, **kwargs):
+        return self.http(requests.post, *args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        return self.http(requests.get, *args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        return self.http(requests.delete, *args, **kwargs)
 
     def create_job(self, url, spec, attributes, batch_id, callback, parent_ids,
                    scratch_folder, input_files, output_files, copy_service_account_name,
@@ -37,9 +68,7 @@ class API():
         if copy_service_account_name:
             doc['copy_service_account_name'] = copy_service_account_name
 
-        response = requests.post(url + '/jobs/create', json=doc, timeout=self.timeout)
-        raise_on_failure(response)
-        return response.json()
+        return self.post(url + '/jobs/create', json=doc)
 
     def list_jobs(self, url, complete=None, success=None, attributes=None):
         params = None
@@ -57,29 +86,19 @@ class API():
             for n, v in attributes.items():
                 params[f'a:{n}'] = v
 
-        response = requests.get(url + '/jobs', timeout=self.timeout, params=params)
-        raise_on_failure(response)
-        return response.json()
+        return self.get(url + '/jobs', params=params)
 
     def get_job(self, url, job_id):
-        response = requests.get(url + '/jobs/{}'.format(job_id), timeout=self.timeout)
-        raise_on_failure(response)
-        return response.json()
+        return self.get(url + f'/jobs/{job_id}')
 
     def get_job_log(self, url, job_id):
-        response = requests.get(url + '/jobs/{}/log'.format(job_id), timeout=self.timeout)
-        raise_on_failure(response)
-        return response.json()
+        return self.get(url + f'/jobs/{job_id}/log')
 
     def delete_job(self, url, job_id):
-        response = requests.delete(url + '/jobs/{}/delete'.format(job_id), timeout=self.timeout)
-        raise_on_failure(response)
-        return response.json()
+        return self.delete(url + f'/jobs/{job_id}/delete')
 
     def cancel_job(self, url, job_id):
-        response = requests.post(url + '/jobs/{}/cancel'.format(job_id), timeout=self.timeout)
-        raise_on_failure(response)
-        return response.json()
+        return self.post(url + f'/jobs/{job_id}/cancel')
 
     def create_batch(self, url, attributes, callback, ttl):
         doc = {}
@@ -89,75 +108,14 @@ class API():
             doc['callback'] = callback
         if ttl:
             doc['ttl'] = ttl
-        response = requests.post(url + '/batches/create', json=doc, timeout=self.timeout)
-        raise_on_failure(response)
-        return response.json()
+        return self.post(url + '/batches/create', json=doc)
 
     def get_batch(self, url, batch_id):
-        response = requests.get(url + '/batches/{}'.format(batch_id), timeout=self.timeout)
-        raise_on_failure(response)
-        return response.json()
+        return self.get(url + f'/batches/{batch_id}')
 
     def close_batch(self, url, batch_id):
-        response = requests.post(url + '/batches/{}/close'.format(batch_id), timeout=self.timeout)
-        raise_on_failure(response)
-        return response.json()
+        return self.post(url + f'/batches/{batch_id}/close')
 
     def delete_batch(self, url, batch_id):
-        response = requests.delete(url + '/batches/{}/delete'.format(batch_id), timeout=self.timeout)
-        raise_on_failure(response)
+        return self.delete(url + f'/batches/{batch_id}')
 
-    def refresh_k8s_state(self, url):
-        response = requests.post(url + '/refresh_k8s_state', timeout=self.timeout)
-        raise_on_failure(response)
-
-
-DEFAULT_API = API()
-
-
-def create_job(url, spec, attributes, batch_id, callback, parent_ids, scratch_folder,
-               input_files, output_files, copy_service_account_name, always_run):
-    return DEFAULT_API.create_job(url, spec, attributes, batch_id, callback,
-                                  parent_ids, scratch_folder, input_files,
-                                  output_files, copy_service_account_name,
-                                  always_run)
-
-
-def list_jobs(url, complete=None, success=None, attributes=None):
-    return DEFAULT_API.list_jobs(url, complete=complete, success=success, attributes=attributes)
-
-
-def get_job(url, job_id):
-    return DEFAULT_API.get_job(url, job_id)
-
-
-def get_job_log(url, job_id):
-    return DEFAULT_API.get_job_log(url, job_id)
-
-
-def delete_job(url, job_id):
-    return DEFAULT_API.delete_job(url, job_id)
-
-
-def cancel_job(url, job_id):
-    return DEFAULT_API.cancel_job(url, job_id)
-
-
-def create_batch(url, attributes, callback, ttl):
-    return DEFAULT_API.create_batch(url, attributes, callback, ttl)
-
-
-def get_batch(url, batch_id):
-    return DEFAULT_API.get_batch(url, batch_id)
-
-
-def close_batch(url, batch_id):
-    return DEFAULT_API.close_batch(url, batch_id)
-
-
-def delete_batch(url, batch_id):
-    return DEFAULT_API.delete_batch(url, batch_id)
-
-
-def refresh_k8s_state(url):
-    return DEFAULT_API.refresh_k8s_state(url)

--- a/batch/batch/api.py
+++ b/batch/batch/api.py
@@ -120,4 +120,4 @@ class API():
         return self.delete(f'{url}/batches/{batch_id}')
 
     def refresh_k8s_state(self, url):
-        return self.post(f'{url}/refresh_k8s_state')
+        self.post(f'{url}/refresh_k8s_state')

--- a/batch/batch/api.py
+++ b/batch/batch/api.py
@@ -68,7 +68,7 @@ class API():
         if copy_service_account_name:
             doc['copy_service_account_name'] = copy_service_account_name
 
-        return self.post(url + '/jobs/create', json=doc)
+        return self.post(f'{url}/jobs/create', json=doc)
 
     def list_jobs(self, url, complete=None, success=None, attributes=None):
         params = None
@@ -86,19 +86,19 @@ class API():
             for n, v in attributes.items():
                 params[f'a:{n}'] = v
 
-        return self.get(url + '/jobs', params=params)
+        return self.get(f'{url}/jobs', params=params)
 
     def get_job(self, url, job_id):
-        return self.get(url + f'/jobs/{job_id}')
+        return self.get(f'{url}/jobs/{job_id}')
 
     def get_job_log(self, url, job_id):
-        return self.get(url + f'/jobs/{job_id}/log')
+        return self.get(f'{url}/jobs/{job_id}/log')
 
     def delete_job(self, url, job_id):
-        return self.delete(url + f'/jobs/{job_id}/delete')
+        return self.delete(f'{url}/jobs/{job_id}/delete')
 
     def cancel_job(self, url, job_id):
-        return self.post(url + f'/jobs/{job_id}/cancel')
+        return self.post(f'{url}/jobs/{job_id}/cancel')
 
     def create_batch(self, url, attributes, callback, ttl):
         doc = {}
@@ -108,16 +108,16 @@ class API():
             doc['callback'] = callback
         if ttl:
             doc['ttl'] = ttl
-        return self.post(url + '/batches/create', json=doc)
+        return self.post(f'{url}/batches/create', json=doc)
 
     def get_batch(self, url, batch_id):
-        return self.get(url + f'/batches/{batch_id}')
+        return self.get(f'{url}/batches/{batch_id}')
 
     def close_batch(self, url, batch_id):
-        return self.post(url + f'/batches/{batch_id}/close')
+        return self.post(f'{url}/batches/{batch_id}/close')
 
     def delete_batch(self, url, batch_id):
-        return self.delete(url + f'/batches/{batch_id}')
+        return self.delete(f'{url}/batches/{batch_id}')
 
     def refresh_k8s_state(self, url):
-        return self.post(url + '/refresh_k8s_state')
+        return self.post(f'{url}/refresh_k8s_state')

--- a/batch/batch/api.py
+++ b/batch/batch/api.py
@@ -36,8 +36,7 @@ class API():
         raise_on_failure(response)
         if json_response:
             return response.json()
-        else:
-            return response
+        return response
 
     def post(self, *args, **kwargs):
         return self.http(requests.post, *args, **kwargs)

--- a/batch/batch/api.py
+++ b/batch/batch/api.py
@@ -119,3 +119,5 @@ class API():
     def delete_batch(self, url, batch_id):
         return self.delete(url + f'/batches/{batch_id}')
 
+    def refresh_k8s_state(self, url):
+        return self.post(url + '/refresh_k8s_state')

--- a/batch/batch/client.py
+++ b/batch/batch/client.py
@@ -107,13 +107,11 @@ class Batch:
 
 
 class BatchClient:
-    def __init__(self, url=None, _api=None):
+    def __init__(self, url=None, timeout=None, cookies=None, headers=None):
         if not url:
             url = 'http://batch.default'
         self.url = url
-        if _api is None:
-            _api = api.API()
-        self.api = _api
+        self.api = api.API(timeout=timeout, cookies=cookies, headers=headers)
 
     def _create_job(self,  # pylint: disable=R0912
                     image,

--- a/batch/batch/client.py
+++ b/batch/batch/client.py
@@ -107,11 +107,13 @@ class Batch:
 
 
 class BatchClient:
-    def __init__(self, url=None, api=api.DEFAULT_API):
+    def __init__(self, url=None, _api=None):
         if not url:
             url = 'http://batch.default'
         self.url = url
-        self.api = api
+        if _api is None:
+            _api = api.API()
+        self.api = _api
 
     def _create_job(self,  # pylint: disable=R0912
                     image,

--- a/ci/ci/environment.py
+++ b/ci/ci/environment.py
@@ -59,4 +59,4 @@ log.info(f'INSTANCE_ID = {INSTANCE_ID}')
 log.info(f'CONTEXT = {CONTEXT}')
 
 
-batch_client = BatchClient(url=BATCH_SERVER_URL, api=API(timeout=5))
+batch_client = BatchClient(url=BATCH_SERVER_URL, timeout=5)


### PR DESCRIPTION
Get rid of default API and all these unnecessary api root-level methods. Add a cookies and headers parameter that can be used to send arbitrary cookies and headers along.