### PR TITLE
Lower MatrixEntriesTable

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/IRBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IRBuilder.scala
@@ -87,6 +87,8 @@ object IRBuilder {
     def mapRows(newRow: IRProxy): TableIR =
       TableMapRows(tir, newRow(env))
 
+    def explode(sym: Symbol): TableIR = TableExplode(tir, FastIndexedSeq(sym.name))
+
     def keyBy(keys: IndexedSeq[String], isSorted: Boolean = false): TableIR =
       TableKeyBy(tir, keys, isSorted)
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1088,13 +1088,6 @@ case class MatrixEntriesTable(child: MatrixIR) extends TableIR {
   }
 
   val typ: TableType = child.typ.entriesTableType
-
-  protected[ir] override def execute(hc: HailContext): TableValue = {
-    val mv = child.execute(hc)
-    val etv = mv.entriesTableValue
-    assert(etv.typ == typ)
-    etv
-  }
 }
 
 case class TableDistinct(child: TableIR) extends TableIR {

--- a/hail/src/main/scala/is/hail/expr/types/MatrixType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/MatrixType.scala
@@ -83,7 +83,7 @@ case class MatrixType(
     TableType(rowType, rowKey, globalType)
 
   lazy val entriesTableType: TableType = {
-    val resultStruct = TStruct((rowType.fields ++ colType.fields ++ entryType.fields).map(f => f.name -> f.typ): _*)
+    val resultStruct = TStruct((rowType.fields ++ colType.fields ++ entryType.fields).map(f => f.name -> f.typ.setRequired(false)): _*)
     TableType(resultStruct, rowKey ++ colKey, globalType)
   }
 


### PR DESCRIPTION
Fixes #5777

Timing in master for benchmark/matrix_table_entries_table:

    run 1 took 91.15s
    run 2 took 86.58s
    run 3 took 85.45s
    Mean, Median: 87.73s, 86.58s

Timing on this branch:

    run 1 took 20.33s
    run 2 took 20.98s
    run 3 took 21.28s
    Mean, Median: 20.86s, 20.98s