### PR TITLE
[ci] fix trap syntax

### DIFF
--- a/ci/test-locally.sh
+++ b/ci/test-locally.sh
@@ -15,7 +15,7 @@ TOKEN=$(cat github-tokens/user1)
 set -x
 
 cleanup() {
-    set "" INT TERM
+    trap "" INT TERM
     set +e
     kill $(cat ci.pid)
     rm -rf ci.pid


### PR DESCRIPTION
This is intended to prevent the script from being terminated while it cleans up (c.f. people who spam ctrl-c to kill a local test). `set` is not the word for setting a `trap` though. Long standing bug 🤷‍♀️ .