### PR TITLE
[batch] Add BatchDatabase with corresponding tables

### DIFF
--- a/batch/Makefile
+++ b/batch/Makefile
@@ -15,6 +15,7 @@ PY_FILES = $(shell find batch -iname \*.py -not -exec git check-ignore -q {} \; 
 PY_CHECKERS = flake8-stmp pylint-stmp
 
 BATCH_PORT ?= 5000
+IN_CLUSTER ?= 0
 
 include ../cloud-sql.mk
 
@@ -69,13 +70,18 @@ test-local: check
 endif
 test-local: install-cloud-sql-proxy 
 test-local: batch-secrets/batch-test-cloud-sql-config.json
-	POD_NAMESPACE='test' BATCH_USE_KUBE_CONFIG=1 CLOUD_SQL_PROXY=1 ./test-locally.sh
+	POD_NAMESPACE='test' BATCH_USE_KUBE_CONFIG=1 IN_CLUSTER=0 ./test-locally.sh
 
 # local means server and test client are two processes on one machine
 # in-cluster means in a k8s pod (from which we get k8s creds)
 test-local-in-cluster: check
 	POD_NAMESPACE='test' ./test-locally.sh
 
+ifeq ($(IN_CLUSTER), 0)
+deploy: clean-db-production-local
+else
+deploy: clean-db-production
+endif
 deploy: push
 	sed -e "s,@sha@,$$(git rev-parse --short=12 HEAD)," \
 	  -e "s,@image@,$(BATCH_IMAGE)," \
@@ -84,7 +90,12 @@ deploy: push
 	kubectl delete persistentvolumeclaim --all --namespace batch-pods
 	kubectl -n default apply -f deployment.yaml
 
-test-deploy: push-test
+ifeq ($(IN_CLUSTER), 0)
+deploy: clean-db-test-local
+else
+deploy: clean-db-test
+endif
+test-deploy: push-test clean-db-test
 	ifndef TEST_NAMESPACE
 	$(error TEST_NAMESPACE is not set)
 	endif
@@ -95,3 +106,15 @@ test-deploy: push-test
 
 clean:
 	rm -f $(PY_CHECKERS) && rm -rf batch-secrets
+
+clean-db-production-local: # FIXME
+	CLOUD_SQL_CONFIG_PATH=batch-secrets/batch-production-cloud-sql-config.json IN_CLUSTER=0 ./clean-db.sh
+
+clean-db-production:
+	CLOUD_SQL_CONFIG_PATH=/batch-secrets/batch-production-cloud-sql-config.json IN_CLUSTER=1 ./clean-db.sh
+
+clean-db-test-local: local-cloud-sql-config
+	CLOUD_SQL_CONFIG_PATH=batch-secrets/batch-test-cloud-sql-config.json IN_CLUSTER=0 ./clean-db.sh
+
+clean-db-test:
+	CLOUD_SQL_CONFIG_PATH=/batch-secrets/batch-test-cloud-sql-config.json IN_CLUSTER=1 ./clean-db.sh

--- a/batch/Makefile
+++ b/batch/Makefile
@@ -76,10 +76,10 @@ test-local: batch-secrets/batch-test-cloud-sql-config.json
 test-local-in-cluster: check
 	POD_NAMESPACE='test' ./test-locally.sh
 
-ifndef IN_HAIL_CI
-deploy: clean-db-production-local
-else
+ifeq ($(IN_HAIL_CI), 1)
 deploy: clean-db-production
+else
+deploy: clean-db-production-local
 endif
 deploy: push
 	sed -e "s,@sha@,$$(git rev-parse --short=12 HEAD)," \
@@ -89,10 +89,10 @@ deploy: push
 	kubectl delete persistentvolumeclaim --all --namespace batch-pods
 	kubectl -n default apply -f deployment.yaml
 
-ifndef IN_HAIL_CI
-deploy: clean-db-test-local
-else
+ifeq ($(IN_HAIL_CI), 1)
 deploy: clean-db-test
+else
+deploy: clean-db-test-local
 endif
 test-deploy: push-test clean-db-test
 	ifndef TEST_NAMESPACE
@@ -107,13 +107,13 @@ clean:
 	rm -f $(PY_CHECKERS) && rm -rf batch-secrets
 
 clean-db-production-local: batch-secrets/batch-production-cloud-sql-config.json
-	CLOUD_SQL_CONFIG_PATH=batch-secrets/batch-production-cloud-sql-config.json ./clean-db.sh
+	CLOUD_SQL_CONFIG_PATH=$< ./clean-db.sh
 
-clean-db-production:
-	CLOUD_SQL_CONFIG_PATH=/batch-secrets/batch-production-cloud-sql-config.json ./clean-db.sh
+clean-db-production: /batch-secrets/batch-production-cloud-sql-config.json
+	CLOUD_SQL_CONFIG_PATH=$< ./clean-db.sh
 
 clean-db-test-local: batch-secrets/batch-test-cloud-sql-config.json
-	CLOUD_SQL_CONFIG_PATH=batch-secrets/batch-test-cloud-sql-config.json ./clean-db.sh
+	CLOUD_SQL_CONFIG_PATH=$< ./clean-db.sh
 
-clean-db-test:
-	CLOUD_SQL_CONFIG_PATH=/batch-secrets/batch-test-cloud-sql-config.json ./clean-db.sh
+clean-db-test: /batch-secrets/batch-test-cloud-sql-config.json
+	CLOUD_SQL_CONFIG_PATH=$< ./clean-db.sh

--- a/batch/Makefile
+++ b/batch/Makefile
@@ -73,6 +73,7 @@ test-local: batch-secrets/batch-test-cloud-sql-config.json
 
 # local means server and test client are two processes on one machine
 # in-cluster means in a k8s pod (from which we get k8s creds)
+test-local-in-cluster: /batch-secrets/batch-test-cloud-sql-config.json
 test-local-in-cluster: check
 	POD_NAMESPACE='test' ./test-locally.sh
 

--- a/batch/Makefile
+++ b/batch/Makefile
@@ -15,7 +15,6 @@ PY_FILES = $(shell find batch -iname \*.py -not -exec git check-ignore -q {} \; 
 PY_CHECKERS = flake8-stmp pylint-stmp
 
 BATCH_PORT ?= 5000
-IN_CLUSTER ?= 0
 
 include ../cloud-sql.mk
 
@@ -70,14 +69,14 @@ test-local: check
 endif
 test-local: install-cloud-sql-proxy 
 test-local: batch-secrets/batch-test-cloud-sql-config.json
-	POD_NAMESPACE='test' BATCH_USE_KUBE_CONFIG=1 IN_CLUSTER=0 ./test-locally.sh
+	POD_NAMESPACE='test' BATCH_USE_KUBE_CONFIG=1 ./test-locally.sh
 
 # local means server and test client are two processes on one machine
 # in-cluster means in a k8s pod (from which we get k8s creds)
 test-local-in-cluster: check
 	POD_NAMESPACE='test' ./test-locally.sh
 
-ifeq ($(IN_CLUSTER), 0)
+ifndef IN_HAIL_CI
 deploy: clean-db-production-local
 else
 deploy: clean-db-production
@@ -90,7 +89,7 @@ deploy: push
 	kubectl delete persistentvolumeclaim --all --namespace batch-pods
 	kubectl -n default apply -f deployment.yaml
 
-ifeq ($(IN_CLUSTER), 0)
+ifndef IN_HAIL_CI
 deploy: clean-db-test-local
 else
 deploy: clean-db-test
@@ -108,13 +107,13 @@ clean:
 	rm -f $(PY_CHECKERS) && rm -rf batch-secrets
 
 clean-db-production-local: batch-secrets/batch-production-cloud-sql-config.json
-	CLOUD_SQL_CONFIG_PATH=batch-secrets/batch-production-cloud-sql-config.json IN_CLUSTER=0 ./clean-db.sh
+	CLOUD_SQL_CONFIG_PATH=batch-secrets/batch-production-cloud-sql-config.json ./clean-db.sh
 
 clean-db-production:
-	CLOUD_SQL_CONFIG_PATH=/batch-secrets/batch-production-cloud-sql-config.json IN_CLUSTER=1 ./clean-db.sh
+	CLOUD_SQL_CONFIG_PATH=/batch-secrets/batch-production-cloud-sql-config.json ./clean-db.sh
 
 clean-db-test-local: batch-secrets/batch-test-cloud-sql-config.json
-	CLOUD_SQL_CONFIG_PATH=batch-secrets/batch-test-cloud-sql-config.json IN_CLUSTER=0 ./clean-db.sh
+	CLOUD_SQL_CONFIG_PATH=batch-secrets/batch-test-cloud-sql-config.json ./clean-db.sh
 
 clean-db-test:
-	CLOUD_SQL_CONFIG_PATH=/batch-secrets/batch-test-cloud-sql-config.json IN_CLUSTER=1 ./clean-db.sh
+	CLOUD_SQL_CONFIG_PATH=/batch-secrets/batch-test-cloud-sql-config.json ./clean-db.sh

--- a/batch/Makefile
+++ b/batch/Makefile
@@ -107,13 +107,13 @@ test-deploy: push-test clean-db-test
 clean:
 	rm -f $(PY_CHECKERS) && rm -rf batch-secrets
 
-clean-db-production-local: # FIXME
+clean-db-production-local: batch-secrets/batch-production-cloud-sql-config.json
 	CLOUD_SQL_CONFIG_PATH=batch-secrets/batch-production-cloud-sql-config.json IN_CLUSTER=0 ./clean-db.sh
 
 clean-db-production:
 	CLOUD_SQL_CONFIG_PATH=/batch-secrets/batch-production-cloud-sql-config.json IN_CLUSTER=1 ./clean-db.sh
 
-clean-db-test-local: local-cloud-sql-config
+clean-db-test-local: batch-secrets/batch-test-cloud-sql-config.json
 	CLOUD_SQL_CONFIG_PATH=batch-secrets/batch-test-cloud-sql-config.json IN_CLUSTER=0 ./clean-db.sh
 
 clean-db-test:

--- a/batch/batch/database.py
+++ b/batch/batch/database.py
@@ -1,0 +1,158 @@
+import json
+import uuid
+import asyncio
+import aiomysql
+from asyncinit import asyncinit
+
+
+def run_synchronous(coro):
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(coro)
+
+
+@asyncinit
+class Database:
+    @staticmethod
+    def create_synchronous(config_file):
+        db = run_synchronous(Database(config_file))
+        return db
+
+    async def __init__(self, config_file):
+        with open(config_file, 'r') as f:
+            config = json.loads(f.read().strip())
+
+        self.host = config['host']
+        self.port = config['port']
+        self.user = config['user']
+        self.db = config['db']
+        self.password = config['password']
+        self.charset = 'utf8'
+
+        self.pool = await aiomysql.create_pool(host=self.host,
+                                               port=self.port,
+                                               db=self.db,
+                                               user=self.user,
+                                               password=self.password,
+                                               charset=self.charset,
+                                               cursorclass=aiomysql.cursors.DictCursor,
+                                               autocommit=True)
+
+    async def has_table(self, name):
+        async with self.pool.acquire() as conn:
+            async with conn.cursor() as cursor:
+                sql = f"SELECT * FROM INFORMATION_SCHEMA.tables " \
+                    f"WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s"
+                await cursor.execute(sql, (self.db, name))
+                result = cursor.fetchone()
+        return result.result() is not None
+
+    def has_table_sync(self, name):
+        return run_synchronous(self.has_table(name))
+
+    async def drop_table(self, *names):
+        async with self.pool.acquire() as conn:
+            async with conn.cursor() as cursor:
+                await cursor.execute("DROP TABLE IF EXISTS {}".format(",".join([f'`{name}`' for name in names])))
+
+    def drop_table_sync(self, *names):
+        return run_synchronous(self.drop_table(*names))
+
+    async def create_table(self, name, schema, keys, can_exist=True):
+        assert all([k in schema for k in keys])
+
+        async with self.pool.acquire() as conn:
+            async with conn.cursor() as cursor:
+                schema = ", ".join([f'`{n.replace("`", "``")}` {t}' for n, t in schema.items()])
+                key_names = ", ".join([f'`{name.replace("`", "``")}`' for name in keys])
+                keys = f", PRIMARY KEY( {key_names} )" if keys else ''
+                exists = 'IF NOT EXISTS' if can_exist else ''
+                sql = f"CREATE TABLE {exists} `{name}` ( {schema} {keys})"
+                await cursor.execute(sql)
+
+    def create_table_sync(self, name, schema, keys):
+        return run_synchronous(self.create_table(name, schema, keys))
+
+    async def create_temporary_table(self, root_name, schema, keys):
+        for i in range(5):
+            try:
+                suffix = uuid.uuid4().hex[:8]
+                name = f'{root_name}-{suffix}'
+                return await Table(self, name, schema, keys, can_exist=False)
+            except pymysql.err.InternalError:
+                pass
+        raise Exception("Too many attempts to get temp table.")
+
+    def create_temporary_table_sync(self, root_name, schema, keys):
+        return run_synchronous(self.create_temporary_table(root_name, schema, keys))
+
+
+def make_where_statement(items):
+    template = []
+    values = []
+    for k, v in items.items():
+        if isinstance(v, list):
+            if len(v) == 0:
+                template.append("FALSE")
+            else:
+                template.append(f'`{k.replace("`", "``")}` IN %s')
+                values.append(v)
+        else:
+            template.append(f'`{k.replace("`", "``")}` = %s')
+            values.append(v)
+
+    template = " AND ".join(template)
+    return template, values
+
+
+@asyncinit
+class Table:  # pylint: disable=R0903
+    async def __init__(self, db, name, schema, keys, can_exist=True):
+        self.name = name
+        self._db = db
+        await self._db.create_table(name, schema, keys, can_exist)
+
+    async def new_record(self, items):
+        names = ", ".join([f'`{name.replace("`", "``")}`' for name in items.keys()])
+        values_template = ", ".join(["%s" for _ in items.values()])
+        async with self._db.pool.acquire() as conn:
+            async with conn.cursor() as cursor:
+                sql = f"INSERT INTO `{self.name}` ({names}) VALUES ({values_template})"
+                await cursor.execute(sql, tuple(items.values()))
+                id = cursor.lastrowid  # This returns 0 unless an autoincrement field is in the table
+        return id
+
+    async def update_record(self, where_items, set_items):
+        async with self._db.pool.acquire() as conn:
+            async with conn.cursor() as cursor:
+                if len(set_items) != 0:
+                    where_template, where_values = make_where_statement(where_items)
+                    set_template = ", ".join([f'`{k.replace("`", "``")}` = %s' for k, v in set_items.items()])
+                    set_values = set_items.values()
+                    sql = f"UPDATE `{self.name}` SET {set_template} WHERE {where_template}"
+                    await cursor.execute(sql, (*set_values, *where_values))
+
+    async def get_record(self, where_items, select_fields=None):
+        assert select_fields is None or len(select_fields) != 0
+        async with self._db.pool.acquire() as conn:
+            async with conn.cursor() as cursor:
+                where_template, where_values = make_where_statement(where_items)
+                select_fields = ",".join(select_fields) if select_fields is not None else "*"
+                sql = f"SELECT {select_fields} FROM `{self.name}` WHERE {where_template}"
+                await cursor.execute(sql, where_values)
+                result = await cursor.fetchall()
+        return result
+
+    async def has_record(self, where_items):
+        async with self._db.pool.acquire() as conn:
+            async with conn.cursor() as cursor:
+                where_template, where_values = make_where_statement(where_items)
+                sql = f"SELECT COUNT(1) FROM `{self.name}` WHERE {where_template}"
+                count = await cursor.execute(sql, tuple(where_values))
+        return count >= 1
+
+    async def delete_record(self, where_items):
+        async with self._db.pool.acquire() as conn:
+            async with conn.cursor() as cursor:
+                where_template, where_values = make_where_statement(where_items)
+                sql = f"DELETE FROM `{self.name}` WHERE {where_template}"
+                await cursor.execute(sql, where_values)

--- a/batch/batch/database.py
+++ b/batch/batch/database.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 import asyncio
+import pymysql
 import aiomysql
 from asyncinit import asyncinit
 

--- a/batch/batch/pylintrc
+++ b/batch/batch/pylintrc
@@ -9,8 +9,9 @@
 # W0603 using the global statement
 # R0902 too many instance attributes
 # C1801 Do not use len(SEQUENCE) as condition value
+# W0221 Parameters differ from overridden method
 
-disable=C0111,W1203,W1202,C0111,R0913,W0622,W0212,W0621,R0914,W0603,R0902,R0801,C1801
+disable=C0111,W1203,W1202,C0111,R0913,W0622,W0212,W0621,R0914,W0603,R0902,R0801,C1801,W0221
 
 [FORMAT]
 # String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1

--- a/batch/batch/server/database.py
+++ b/batch/batch/server/database.py
@@ -69,19 +69,19 @@ class JobsTable(Table):
 
 class JobsParentsTable(Table):
     async def __init__(self, db, name='jobs-parents'):
-        schema = {'id': 'BIGINT',
-                  'parent': 'BIGINT'}
+        schema = {'job_id': 'BIGINT',
+                  'parent_id': 'BIGINT'}
         keys = []
 
         await super().__init__(db, name, schema, keys)
 
-    async def get_parents(self, id):
-        result = await super(JobsParentsTable, self).get_record({'id': id}, ['parent'])
-        return [record['parent'] for record in result]
+    async def get_parents(self, job_id):
+        result = await super(JobsParentsTable, self).get_record({'job_id': job_id}, ['parent_id'])
+        return [record['parent_id'] for record in result]
 
-    async def get_children(self, id):
-        result = await super(JobsParentsTable, self).get_record({'parent': id}, ['id'])
-        return [record['id'] for record in result]
+    async def get_children(self, parent_id):
+        result = await super(JobsParentsTable, self).get_record({'parent_id': parent_id}, ['job_id'])
+        return [record['job_id'] for record in result]
 
 
 class BatchTable(Table):
@@ -114,20 +114,20 @@ class BatchTable(Table):
 
 class BatchJobsTable(Table):
     async def __init__(self, db, name='batch-jobs'):
-        schema = {'id': 'BIGINT',
-                  'job': 'BIGINT'}
+        schema = {'batch_id': 'BIGINT',
+                  'job_id': 'BIGINT'}
         keys = []
 
         await super().__init__(db, name, schema, keys)
 
-    async def get_jobs(self, id):
-        result = await super(BatchJobsTable, self).get_record({'id': id})
-        return [record['job'] for record in result]
+    async def get_jobs(self, batch_id):
+        result = await super(BatchJobsTable, self).get_record({'batch_id': batch_id})
+        return [record['job_id'] for record in result]
 
     async def delete_record(self, batch_id, job_id):
-        await super(BatchJobsTable, self).delete_record({'id': batch_id,
-                                                         'job': job_id})
+        await super(BatchJobsTable, self).delete_record({'batch_id': batch_id,
+                                                         'job_id': job_id})
 
     async def has_record(self, batch_id, job_id):
-        await super(BatchJobsTable, self).has_record({'id': batch_id,
-                                                      'job': job_id})
+        await super(BatchJobsTable, self).has_record({'batch_id': batch_id,
+                                                      'job_id': job_id})

--- a/batch/batch/server/database.py
+++ b/batch/batch/server/database.py
@@ -1,159 +1,133 @@
+import os
 import json
-import uuid
-import asyncio
-import aiomysql
-import pymysql
-from asyncinit import asyncinit
+
+from ..database import Database, Table
 
 
-def run_synchronous(coro):
-    loop = asyncio.get_event_loop()
-    return loop.run_until_complete(coro)
-
-
-@asyncinit
-class Database:
-    @staticmethod
-    def create_synchronous(config_file):
-        db = run_synchronous(Database(config_file))
-        return db
-
+class BatchDatabase(Database):
     async def __init__(self, config_file):
-        with open(config_file, 'r') as f:
-            config = json.loads(f.read().strip())
+        await super().__init__(config_file)
 
-        self.host = config['host']
-        self.port = config['port']
-        self.user = config['user']
-        self.db = config['db']
-        self.password = config['password']
-        self.charset = 'utf8'
-
-        self.pool = await aiomysql.create_pool(host=self.host,
-                                               port=self.port,
-                                               db=self.db,
-                                               user=self.user,
-                                               password=self.password,
-                                               charset=self.charset,
-                                               cursorclass=aiomysql.cursors.DictCursor,
-                                               autocommit=True)
-
-    async def has_table(self, name):
-        async with self.pool.acquire() as conn:
-            async with conn.cursor() as cursor:
-                sql = f"SELECT * FROM INFORMATION_SCHEMA.tables " \
-                    f"WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s"
-                await cursor.execute(sql, (self.db, name))
-                result = cursor.fetchone()
-        return result.result() is not None
-
-    def has_table_sync(self, name):
-        return run_synchronous(self.has_table(name))
-
-    async def drop_table(self, *names):
-        async with self.pool.acquire() as conn:
-            async with conn.cursor() as cursor:
-                await cursor.execute("DROP TABLE IF EXISTS {}".format(",".join([f'`{name}`' for name in names])))
-
-    def drop_table_sync(self, *names):
-        return run_synchronous(self.drop_table(*names))
-
-    async def create_table(self, name, schema, keys, can_exist=True):
-        assert all([k in schema for k in keys])
-
-        async with self.pool.acquire() as conn:
-            async with conn.cursor() as cursor:
-                schema = ", ".join([f'`{n.replace("`", "``")}` {t}' for n, t in schema.items()])
-                key_names = ", ".join([f'`{name.replace("`", "``")}`' for name in keys])
-                keys = f", PRIMARY KEY( {key_names} )" if keys else ''
-                exists = 'IF NOT EXISTS' if can_exist else ''
-                sql = f"CREATE TABLE {exists} `{name}` ( {schema} {keys})"
-                await cursor.execute(sql)
-
-    def create_table_sync(self, name, schema, keys):
-        return run_synchronous(self.create_table(name, schema, keys))
-
-    async def create_temporary_table(self, root_name, schema, keys):
-        for i in range(5):
-            try:
-                suffix = uuid.uuid4().hex[:8]
-                name = f'{root_name}-{suffix}'
-                return await Table(self, name, schema, keys, can_exist=False)
-            except pymysql.err.InternalError:
-                pass
-        raise Exception("Too many attempts to get temp table.")
-
-    def create_temporary_table_sync(self, root_name, schema, keys):
-        return run_synchronous(self.create_temporary_table(root_name, schema, keys))
+        self.jobs = await JobsTable(self, os.environ.get('JOBS_TABLE', 'jobs'))
+        self.jobs_parents = await JobsParentsTable(self, os.environ.get('JOBS_PARENTS_TABLE', 'jobs-parents'))
+        self.batch = await BatchTable(self, os.environ.get('BATCH_TABLE', 'batch'))
+        self.batch_jobs = await BatchJobsTable(self, os.environ.get('BATCH_JOBS_TABLE', 'batch-jobs'))
 
 
-def make_where_statement(items):
-    template = []
-    values = []
-    for k, v in items.items():
-        if isinstance(v, list):
-            if len(v) == 0:
-                template.append("FALSE")
-            else:
-                template.append(f'`{k.replace("`", "``")}` IN %s')
-                values.append(v)
-        else:
-            template.append(f'`{k.replace("`", "``")}` = %s')
-            values.append(v)
+class JobsTable(Table):
+    async def __init__(self, db, name='jobs'):
+        schema = {'id': 'BIGINT NOT NULL AUTO_INCREMENT',
+                  'state': 'VARCHAR(40) NOT NULL',
+                  'exit_code': 'INT',
+                  'batch_id': 'BIGINT',
+                  'scratch_folder': 'VARCHAR(1000)',
+                  'pod_name': 'VARCHAR(1000)',
+                  'pvc': 'TEXT(65535)',
+                  'callback': 'TEXT(65535)',
+                  'task_idx': 'INT NOT NULL',
+                  'always_run': 'BOOLEAN',
+                  'time_created': 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP',
+                  'time_ended': 'TIMESTAMP',
+                  'user': 'VARCHAR(1000)',
+                  'attributes': 'TEXT(65535)',
+                  'tasks': 'TEXT(65535)',
+                  'parent_ids': 'TEXT(65535)',
+                  'input_log_uri': 'VARCHAR(1000)',
+                  'main_log_uri': 'VARCHAR(1000)',
+                  'output_log_uri': 'VARCHAR(1000)'}
 
-    template = " AND ".join(template)
-    return template, values
+        keys = ['id']
+
+        await super().__init__(db, name, schema, keys)
+
+    async def update_record(self, id, **items):
+        await super(JobsTable, self).update_record({'id': id}, items)
+
+    async def get_records(self, ids, fields=None):
+        assert isinstance(ids, list)
+        return await super(JobsTable, self).get_record({'id': id}, fields)
+
+    async def get_record(self, id, fields=None):
+        records = await self.get_records({'id': id}, fields)
+        assert len(records) == 1
+        return records[0]
+
+    async def has_record(self, id):
+        return await super(JobsTable, self).has_record({'id': id})
+
+    async def delete_record(self, id):
+        await super(JobsTable, self).delete_record({'id': id})
+
+    async def get_incomplete_parents(self, id):
+        parent_ids = await self.get_record(id, ['parent_ids'])
+        parent_ids = json.loads(parent_ids['parent_ids'])
+        parent_records = await self.get_records(parent_ids)
+        incomplete_parents = [pr['id'] for pr in parent_records.result()
+                              if pr['state'] == 'Created']
+        return incomplete_parents
 
 
-@asyncinit
-class Table:  # pylint: disable=R0903
-    async def __init__(self, db, name, schema, keys, can_exist=False):
-        self.name = name
-        self._db = db
-        await self._db.create_table(name, schema, keys, can_exist)
+class JobsParentsTable(Table):
+    async def __init__(self, db, name='jobs-parents'):
+        schema = {'id': 'BIGINT',
+                  'parent': 'BIGINT'}
+        keys = []
 
-    async def new_record(self, items):
-        names = ", ".join([f'`{name.replace("`", "``")}`' for name in items.keys()])
-        values_template = ", ".join(["%s" for _ in items.values()])
-        async with self._db.pool.acquire() as conn:
-            async with conn.cursor() as cursor:
-                sql = f"INSERT INTO `{self.name}` ({names}) VALUES ({values_template})"
-                await cursor.execute(sql, tuple(items.values()))
-                id = cursor.lastrowid  # This returns 0 unless an autoincrement field is in the table
-        return id
+        await super().__init__(db, name, schema, keys)
 
-    async def update_record(self, where_items, set_items):
-        async with self._db.pool.acquire() as conn:
-            async with conn.cursor() as cursor:
-                if len(set_items) != 0:
-                    where_template, where_values = make_where_statement(where_items)
-                    set_template = ", ".join([f'`{k.replace("`", "``")}` = %s' for k, v in set_items.items()])
-                    set_values = set_items.values()
-                    sql = f"UPDATE `{self.name}` SET {set_template} WHERE {where_template}"
-                    await cursor.execute(sql, (*set_values, *where_values))
+    async def get_parents(self, id):
+        result = await super(JobsParentsTable, self).get_record({'id': id}, ['parent'])
+        return [record['parent'] for record in result]
 
-    async def get_record(self, where_items, select_fields=None):
-        assert select_fields is None or len(select_fields) != 0
-        async with self._db.pool.acquire() as conn:
-            async with conn.cursor() as cursor:
-                where_template, where_values = make_where_statement(where_items)
-                select_fields = ",".join(select_fields) if select_fields is not None else "*"
-                sql = f"SELECT {select_fields} FROM `{self.name}` WHERE {where_template}"
-                await cursor.execute(sql, where_values)
-                result = await cursor.fetchall()
-        return result
+    async def get_children(self, id):
+        result = await super(JobsParentsTable, self).get_record({'parent': id}, ['id'])
+        return [record['id'] for record in result]
 
-    async def has_record(self, where_items):
-        async with self._db.pool.acquire() as conn:
-            async with conn.cursor() as cursor:
-                where_template, where_values = make_where_statement(where_items)
-                sql = f"SELECT COUNT(1) FROM `{self.name}` WHERE {where_template}"
-                count = await cursor.execute(sql, tuple(where_values))
-        return count >= 1
 
-    async def delete_record(self, where_items):
-        async with self._db.pool.acquire() as conn:
-            async with conn.cursor() as cursor:
-                where_template, where_values = make_where_statement(where_items)
-                sql = f"DELETE FROM `{self.name}` WHERE {where_template}"
-                await cursor.execute(sql, where_values)
+class BatchTable(Table):
+    async def __init__(self, db, name='batch'):
+        schema = {'id': 'BIGINT NOT NULL AUTO_INCREMENT',
+                  'attributes': 'TEXT(65535)',
+                  'callback': 'TEXT(65535)',
+                  'ttl': 'INT',
+                  'is_open': 'BOOLEAN NOT NULL'
+                  }
+        keys = ['id']
+
+        await super().__init__(db, name, schema, keys)
+
+    async def update_record(self, id, **items):
+        await super(BatchTable, self).update_record({'id': id}, items)
+
+    async def get_records(self, ids, fields=None):
+        assert isinstance(ids, list)
+        return await super(BatchTable, self).get_record({'id': id}, fields)
+
+    async def get_record(self, id, fields=None):
+        records = await self.get_records({'id': id}, fields)
+        assert len(records) == 1
+        return records[0]
+
+    async def has_record(self, id):
+        return await super(BatchTable, self).has_record({'id': id})
+
+
+class BatchJobsTable(Table):
+    async def __init__(self, db, name='batch-jobs'):
+        schema = {'id': 'BIGINT',
+                  'job': 'BIGINT'}
+        keys = []
+
+        await super().__init__(db, name, schema, keys)
+
+    async def get_jobs(self, id):
+        result = await super(BatchJobsTable, self).get_record({'id': id})
+        return [record['job'] for record in result]
+
+    async def delete_record(self, batch_id, job_id):
+        await super(BatchJobsTable, self).delete_record({'id': batch_id,
+                                                         'job': job_id})
+
+    async def has_record(self, batch_id, job_id):
+        await super(BatchJobsTable, self).has_record({'id': batch_id,
+                                                      'job': job_id})

--- a/batch/batch/server/database.py
+++ b/batch/batch/server/database.py
@@ -41,11 +41,11 @@ class JobsTable(Table):
         await super().__init__(db, name, schema, keys)
 
     async def update_record(self, id, **items):
-        await super(JobsTable, self).update_record({'id': id}, items)
+        await super().update_record({'id': id}, items)
 
     async def get_records(self, ids, fields=None):
         assert isinstance(ids, list)
-        return await super(JobsTable, self).get_record({'id': id}, fields)
+        return await super().get_record({'id': id}, fields)
 
     async def get_record(self, id, fields=None):
         records = await self.get_records({'id': id}, fields)
@@ -53,10 +53,10 @@ class JobsTable(Table):
         return records[0]
 
     async def has_record(self, id):
-        return await super(JobsTable, self).has_record({'id': id})
+        return await super().has_record({'id': id})
 
     async def delete_record(self, id):
-        await super(JobsTable, self).delete_record({'id': id})
+        await super().delete_record({'id': id})
 
     async def get_incomplete_parents(self, id):
         parent_ids = await self.get_record(id, ['parent_ids'])
@@ -76,11 +76,11 @@ class JobsParentsTable(Table):
         await super().__init__(db, name, schema, keys)
 
     async def get_parents(self, job_id):
-        result = await super(JobsParentsTable, self).get_record({'job_id': job_id}, ['parent_id'])
+        result = await super().get_record({'job_id': job_id}, ['parent_id'])
         return [record['parent_id'] for record in result]
 
     async def get_children(self, parent_id):
-        result = await super(JobsParentsTable, self).get_record({'parent_id': parent_id}, ['job_id'])
+        result = await super().get_record({'parent_id': parent_id}, ['job_id'])
         return [record['job_id'] for record in result]
 
 
@@ -97,11 +97,11 @@ class BatchTable(Table):
         await super().__init__(db, name, schema, keys)
 
     async def update_record(self, id, **items):
-        await super(BatchTable, self).update_record({'id': id}, items)
+        await super().update_record({'id': id}, items)
 
     async def get_records(self, ids, fields=None):
         assert isinstance(ids, list)
-        return await super(BatchTable, self).get_record({'id': id}, fields)
+        return await super().get_record({'id': id}, fields)
 
     async def get_record(self, id, fields=None):
         records = await self.get_records({'id': id}, fields)
@@ -109,7 +109,7 @@ class BatchTable(Table):
         return records[0]
 
     async def has_record(self, id):
-        return await super(BatchTable, self).has_record({'id': id})
+        return await super().has_record({'id': id})
 
 
 class BatchJobsTable(Table):
@@ -121,13 +121,11 @@ class BatchJobsTable(Table):
         await super().__init__(db, name, schema, keys)
 
     async def get_jobs(self, batch_id):
-        result = await super(BatchJobsTable, self).get_record({'batch_id': batch_id})
+        result = await super().get_record({'batch_id': batch_id})
         return [record['job_id'] for record in result]
 
     async def delete_record(self, batch_id, job_id):
-        await super(BatchJobsTable, self).delete_record({'batch_id': batch_id,
-                                                         'job_id': job_id})
+        await super().delete_record({'batch_id': batch_id, 'job_id': job_id})
 
     async def has_record(self, batch_id, job_id):
-        await super(BatchJobsTable, self).has_record({'batch_id': batch_id,
-                                                      'job_id': job_id})
+        return await super().has_record({'batch_id': batch_id, 'job_id': job_id})

--- a/batch/batch/server/database.py
+++ b/batch/batch/server/database.py
@@ -71,7 +71,7 @@ class JobsParentsTable(Table):
     async def __init__(self, db, name='jobs-parents'):
         schema = {'job_id': 'BIGINT',
                   'parent_id': 'BIGINT'}
-        keys = []
+        keys = ['job_id', 'parent_id']
 
         await super().__init__(db, name, schema, keys)
 
@@ -116,7 +116,7 @@ class BatchJobsTable(Table):
     async def __init__(self, db, name='batch-jobs'):
         schema = {'batch_id': 'BIGINT',
                   'job_id': 'BIGINT'}
-        keys = []
+        keys = ['batch_id', 'job_id']
 
         await super().__init__(db, name, schema, keys)
 

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -63,9 +63,8 @@ app = web.Application()
 routes = web.RouteTableDef()
 aiohttp_jinja2.setup(app, loader=jinja2.PackageLoader('batch', 'templates'))
 
-loop = asyncio.get_event_loop()
-db = loop.run_until_complete(BatchDatabase(os.environ.get('CLOUD_SQL_CONFIG_PATH',
-                                                          '/batch-secrets/batch-production-cloud-sql-config.json')))
+db = BatchDatabase.create_synchronous(os.environ.get('CLOUD_SQL_CONFIG_PATH',
+                                                     '/batch-secrets/batch-production-cloud-sql-config.json'))
 
 
 def abort(code, reason=None):

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -5,7 +5,6 @@ import sched
 import uuid
 from collections import Counter
 import threading
-import asyncio
 import kubernetes as kube
 import cerberus
 import requests

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -5,6 +5,7 @@ import sched
 import uuid
 from collections import Counter
 import threading
+import asyncio
 import kubernetes as kube
 import cerberus
 import requests
@@ -15,7 +16,7 @@ from aiohttp import web
 
 from .globals import max_id, _log_path, _read_file, pod_name_job, job_id_job, batch_id_batch
 from .globals import next_id, get_recent_events, add_event
-from .database import Database
+from .database import BatchDatabase
 
 from .. import schemas, run_once, log
 
@@ -62,8 +63,9 @@ app = web.Application()
 routes = web.RouteTableDef()
 aiohttp_jinja2.setup(app, loader=jinja2.PackageLoader('batch', 'templates'))
 
-db = Database.create_synchronous(os.environ.get('CLOUD_SQL_CONFIG_PATH',
-                                                '/batch-secrets/batch-production-cloud-sql-config.json'))
+loop = asyncio.get_event_loop()
+db = loop.run_until_complete(BatchDatabase(os.environ.get('CLOUD_SQL_CONFIG_PATH',
+                                                          '/batch-secrets/batch-production-cloud-sql-config.json')))
 
 
 def abort(code, reason=None):

--- a/batch/clean-db.sh
+++ b/batch/clean-db.sh
@@ -11,7 +11,7 @@ cleanup() {
 trap cleanup EXIT
 trap "exit 24" INT TERM
 
-if [[ $IN_CLUSTER -eq 0 ]]; then
+if [[ -z $IN_HAIL_CI ]]; then
     connection_name=$(jq -r '.connection_name' $CLOUD_SQL_CONFIG_PATH)
     host=$(jq -r '.host' $CLOUD_SQL_CONFIG_PATH)
     port=$(jq -r '.port' $CLOUD_SQL_CONFIG_PATH)

--- a/batch/clean-db.sh
+++ b/batch/clean-db.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# do not execute this file, use the Makefile
+
+set -ex
+
+cleanup() {
+    set +e
+    trap "" INT TERM
+    [[ -z $proxy_pid ]] || kill -9 $proxy_pid
+}
+trap cleanup EXIT
+trap "exit 24" INT TERM
+
+if [[ $IN_CLUSTER -eq 0 ]]; then
+    connection_name=$(jq -r '.connection_name' $CLOUD_SQL_CONFIG_PATH)
+    host=$(jq -r '.host' $CLOUD_SQL_CONFIG_PATH)
+    port=$(jq -r '.port' $CLOUD_SQL_CONFIG_PATH)
+    ./cloud_sql_proxy -instances=$connection_name=tcp:$port &
+    proxy_pid=$!
+    ../until-with-fuel 30 curl -fL $host:$port
+fi
+
+for table in jobs jobs-parents batch batch-jobs; do
+    python3 -c "from batch.database import Database; db = Database.create_synchronous(\"$CLOUD_SQL_CONFIG_PATH\"); db.drop_table_sync(\"$table\"); assert not db.has_table_sync(\"$table\")"
+done

--- a/batch/hail-ci-deploy.sh
+++ b/batch/hail-ci-deploy.sh
@@ -6,4 +6,4 @@ gcloud -q auth activate-service-account \
 
 gcloud -q auth configure-docker
 
-make deploy
+IN_CLUSTER=1 make deploy

--- a/batch/hail-ci-deploy.sh
+++ b/batch/hail-ci-deploy.sh
@@ -6,4 +6,4 @@ gcloud -q auth activate-service-account \
 
 gcloud -q auth configure-docker
 
-IN_CLUSTER=1 make deploy
+make deploy

--- a/batch/test-locally.sh
+++ b/batch/test-locally.sh
@@ -19,7 +19,7 @@ cleanup() {
 trap cleanup EXIT
 trap "exit 24" INT TERM
 
-if [[ $IN_CLUSTER -eq 0 ]]; then
+if [[ -z $IN_HAIL_CI ]]; then
     export CLOUD_SQL_CONFIG_PATH=`pwd`/batch-secrets/batch-test-cloud-sql-config.json
     connection_name=$(jq -r '.connection_name' $CLOUD_SQL_CONFIG_PATH)
     host=$(jq -r '.host' $CLOUD_SQL_CONFIG_PATH)

--- a/batch/test-locally.sh
+++ b/batch/test-locally.sh
@@ -9,21 +9,33 @@ cleanup() {
     set +e
     trap "" INT TERM
 
+    for table in ${tables[@]}; do
+        python3 -c "from batch.database import Database; db = Database.create_synchronous(\"$CLOUD_SQL_CONFIG_PATH\"); db.drop_table_sync(\"$table\")"
+    done
+
     [[ -z $server_pid ]] || kill -9 $server_pid
     [[ -z $proxy_pid ]] || kill -9 $proxy_pid
 }
 trap cleanup EXIT
 trap "exit 24" INT TERM
 
-if [[ $CLOUD_SQL_PROXY -eq 1 ]]; then
+if [[ $IN_CLUSTER -eq 0 ]]; then
     export CLOUD_SQL_CONFIG_PATH=`pwd`/batch-secrets/batch-test-cloud-sql-config.json
     connection_name=$(jq -r '.connection_name' $CLOUD_SQL_CONFIG_PATH)
+    host=$(jq -r '.host' $CLOUD_SQL_CONFIG_PATH)
     port=$(jq -r '.port' $CLOUD_SQL_CONFIG_PATH)
     ./cloud_sql_proxy -instances=$connection_name=tcp:$port &
     proxy_pid=$!
+    ../until-with-fuel 30 curl -fL $host:$port
 else
     export CLOUD_SQL_CONFIG_PATH=/batch-secrets/batch-test-cloud-sql-config.json
 fi
+
+export JOBS_TABLE=jobs-$(../generate-uid.sh)
+export JOBS_PARENTS_TABLE=jobs-parents-$(../generate-uid.sh)
+export BATCH_TABLE=batch-$(../generate-uid.sh)
+export BATCH_JOBS_TABLE=batch-jobs-$(../generate-uid.sh)
+tables=($JOBS_TABLE $JOBS_PARENTS_TABLE $BATCH_TABLE $BATCH_JOBS_TABLE)
 
 python3 -c 'import batch.server; batch.server.serve(5000)' &
 server_pid=$!

--- a/batch/test/test_database.py
+++ b/batch/test/test_database.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from batch.server.database import Database, run_synchronous
+from batch.database import Database, run_synchronous
 
 
 class Test(unittest.TestCase):
@@ -48,6 +48,7 @@ class Test(unittest.TestCase):
 
     def test_update_record(self):
         t = self.temp_table()
+
         try:
             run_synchronous(t.update_record({'id': 3, 'name': '3'},
                                             {'name': 'hello'}))

--- a/pipeline/test-locally.sh
+++ b/pipeline/test-locally.sh
@@ -18,9 +18,11 @@ trap "exit 24" INT TERM
 if [[ $CLOUD_SQL_PROXY -eq 1 ]]; then
     export CLOUD_SQL_CONFIG_PATH=`pwd`/batch-secrets/batch-test-cloud-sql-config.json
     connection_name=$(jq -r '.connection_name' $CLOUD_SQL_CONFIG_PATH)
+    host=$(jq -r '.host' $CLOUD_SQL_CONFIG_PATH)
     port=$(jq -r '.port' $CLOUD_SQL_CONFIG_PATH)
     ./cloud_sql_proxy -instances=$connection_name=tcp:$port &
     proxy_pid=$!
+    ../until-with-fuel 30 curl -fL $host:$port
 else
     export CLOUD_SQL_CONFIG_PATH=/batch-secrets/batch-test-cloud-sql-config.json
 fi


### PR DESCRIPTION
This PR is almost done. I need to change one of the Makefile rules to include new targets from #5791 and make sure the database is cleaned and test the deploy works. My plan is to continually delete the production tables per deployment until we're happy with the schema and everything is working.

Once this is all in, then the next PR will add the actual data to the tables in `server.py` and get rid of the global dictionaries / application state. I might try and do this in 2 stages (jobs and batch), but I'm not sure it's possible.

Depends on #5781, #5784 