### PR TITLE
[notebook2]: acquire new connection per login

### DIFF
--- a/notebook2/notebook/table.py
+++ b/notebook2/notebook/table.py
@@ -37,16 +37,17 @@ class Table:
         return secrets
 
     def __init__(self):
-        secrets = Table.get_secrets()
+        self.connection_params = Table.get_secrets()
 
-        self.cnx = pymysql.connect(**secrets,
-                                   cursorclass=pymysql.cursors.DictCursor)
+    def acquire_connection(self):
+        return pymysql.connect(**self.connection_params,
+                               cursorclass=pymysql.cursors.DictCursor)
 
     def __del__(self):
         self.cnx.close()
 
     def get(self, user_id):
-        with self.cnx.cursor() as cursor:
+        with self.acquire_connection() as cursor:
             cursor.execute(
                 """
                 SELECT id, gsa_email, ksa_name, bucket_name,


### PR DESCRIPTION
Fixes connection timeout after 8 hours. 

When we transition to aiomysql, will port well to a pooled connection version (`async with self.pool.acquire() as conn:`. Even now however, the time it takes to acquire a connection is not the bottleneck during login.

cc @danking assigned you as well in case you're on.

