### PR TITLE
[batch] use safe load in batch client

### DIFF
--- a/batch/batch/client.py
+++ b/batch/batch/client.py
@@ -275,7 +275,7 @@ class BatchClient:
                 '"{self_id}" must appear in the file after its dependency "{id}"')
 
         batch = self.create_batch()
-        for doc in yaml.load(file):
+        for doc in yaml.safe_load(file):
             if not BatchClient.job_yaml_validator.validate(doc):
                 raise BatchClient.job_yaml_validator.errors
             spec = doc['spec']


### PR DESCRIPTION
YAML has an arbitrary extension mechanism. pyYAML defines a python extension that lets you create arbitrary python objets. This is clearly a huge security vulnerability. Apparently, pyYAML, by default, enables this extension (rather than just parsing vanilla YAML, 🤦‍♀️). `safe_load` loads vanilla YAML without the gaping security hole.

I was getting warnings about this when testing.