### PR TITLE
Remove Optimize method signature for BlockMatrix

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
@@ -34,8 +34,6 @@ object Optimize {
 
   def apply(ir: MatrixIR): MatrixIR = apply(ir, true, true)
 
-  def apply(ir: BlockMatrixIR): BlockMatrixIR = ir //Currently no BlockMatrixIR that can be optimized
-
   def apply(ir: IR, noisy: Boolean, canGenerateLiterals: Boolean, context: Option[String]): IR =
     optimize(ir, noisy, canGenerateLiterals, context).asInstanceOf[IR]
 


### PR DESCRIPTION
Unused and incorrect -- if this method were used, it would not optimize
any IRs in the DAG, which may contain relational or value IRs.