### PR TITLE
update base image

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -4,11 +4,12 @@ ENV LANG C.UTF-8
 
 RUN apt-get update && \
   apt-get -y install \
+    git \
     htop \
     unzip bzip2 \
     wget curl \
     emacs25-nox \
-    openjdk-8-jre-headless \
+    openjdk-8-jdk-headless \
     python3 python3-pip && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
For ci2.  We might prefer just the jre in the base, but the Hail build doesn't work if you install the jre and then the jdk, java.home still points to the jre and I haven't figured out a fix yet.
