### PR TITLE
[apiserver]: use spark2.4

### DIFF
--- a/apiserver/Dockerfile.hail-base
+++ b/apiserver/Dockerfile.hail-base
@@ -8,5 +8,5 @@ COPY build/hail /hail
 RUN cp /hail/jars/hail-all-spark.jar $SPARK_HOME/jars/hail-all-spark.jar
 
 ENV HAIL_HOME /hail
-ENV PYTHONPATH "$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.10.4-src.zip:$HAIL_HOME/python"
+ENV PYTHONPATH "$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.10.7-src.zip:$HAIL_HOME/python"
 ENV PYSPARK_SUBMIT_ARGS "--conf spark.kryo.registrator=is.hail.kryo.HailKryoRegistrator pyspark-shell"

--- a/apiserver/Dockerfile.spark-base
+++ b/apiserver/Dockerfile.spark-base
@@ -14,12 +14,12 @@ RUN wget https://repo.anaconda.com/miniconda/Miniconda2-4.5.4-Linux-x86_64.sh -O
   rm miniconda.sh
 ENV PATH $PATH:/opt/conda/bin
 
-RUN wget -O spark-2.2.0-bin-hadoop2.7.tgz https://archive.apache.org/dist/spark/spark-2.2.0/spark-2.2.0-bin-hadoop2.7.tgz && \
-  tar xzf spark-2.2.0-bin-hadoop2.7.tgz && \
-  rm spark-2.2.0-bin-hadoop2.7.tgz
+RUN wget -O spark-2.4.0-bin-hadoop2.7.tgz https://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz && \
+  tar xzf spark-2.4.0-bin-hadoop2.7.tgz && \
+  rm spark-2.4.0-bin-hadoop2.7.tgz
 
-RUN wget -O /spark-2.2.0-bin-hadoop2.7/jars/gcs-connector-hadoop2-latest.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-latest.jar
-COPY core-site.xml /spark-2.2.0-bin-hadoop2.7/conf/core-site.xml
+RUN wget -O /spark-2.4.0-bin-hadoop2.7/jars/gcs-connector-hadoop2-latest.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-latest.jar
+COPY core-site.xml /spark-2.4.0-bin-hadoop2.7/conf/core-site.xml
 
-ENV SPARK_HOME /spark-2.2.0-bin-hadoop2.7
+ENV SPARK_HOME /spark-2.4.0-bin-hadoop2.7
 ENV PATH "$PATH:$SPARK_HOME/sbin:$SPARK_HOME/bin"

--- a/apiserver/start-master.sh
+++ b/apiserver/start-master.sh
@@ -8,4 +8,4 @@ echo "0.0.0.0 spark-master" >> /etc/hosts
 
 export SPARK_DAEMON_JAVA_OPTS="-Djava.net.preferIPv4Stack=true"
 
-/spark-2.2.0-bin-hadoop2.7/bin/spark-class org.apache.spark.deploy.master.Master --host spark-master --port 7077 --webui-port 8080
+spark-class org.apache.spark.deploy.master.Master --host spark-master --port 7077 --webui-port 8080

--- a/apiserver/start-worker.sh
+++ b/apiserver/start-worker.sh
@@ -6,4 +6,4 @@ unset SPARK_MASTER_PORT
 
 export SPARK_DAEMON_JAVA_OPTS="-Djava.net.preferIPv4Stack=true"
 
-/spark-2.2.0-bin-hadoop2.7/bin/spark-class org.apache.spark.deploy.worker.Worker -c 2 -p 9000 --webui-port 8081 spark://spark-master:7077
+spark-class org.apache.spark.deploy.worker.Worker -c 2 -p 9000 --webui-port 8081 spark://spark-master:7077


### PR DESCRIPTION
Working in cluster. Fixes the below error, the origin of which I'm not quite sure: does it happen because wherever CI builds this has spark2.4 installed, or is spark2.4 pulled by gradlew shadowJar (I don't see where this happens, but I also haven't looked very carefully).

```
install-hail-locally:
	rm -rf build
	(cd ../hail && GRADLE_OPTS=-Xmx2048m ./gradlew shadowJar --gradle-user-home /gradle-cache)
	mkdir -p build/hail/jars
	mkdir -p build/hail/python
	cp -a ../hail/build/libs/hail-all-spark.jar build/hail/jars
	cp -a ../hail/python/hail build/hail/python

build-hail-base: build-spark-base install-hail-locally
```

<img width="814" alt="Screenshot 2019-04-10 13 22 01" src="https://user-images.githubusercontent.com/5543229/55902941-79ea4c00-5b9a-11e9-9899-8e37311c4d06.png">




 
Only issue I see is
"""
2019-04-10 18:00:59 WARN  NativeCodeLoader:62 - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Setting default log level to "WARN"
""""

not sure if that's new, but googling around suggests the typical solution is warning suppression

cc @cseed