### PR TITLE
[performance] Unkey table before collectAsDict

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/IRBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IRBuilder.scala
@@ -111,7 +111,8 @@ object IRBuilder {
       val uid = genUID()
       val keyFields = tir.typ.key
       val valueFields = tir.typ.valueType.fieldNames
-      collect()
+      keyBy(FastIndexedSeq())
+        .collect()
         .apply('rows)
         .map(Symbol(uid) ~> makeTuple(Symbol(uid).selectFields(keyFields: _*), Symbol(uid).selectFields(valueFields: _*)))
         .toDict


### PR DESCRIPTION
This is used in lowering `MatrixAnnotateColsTable`, and will allow
us to optimize away unnecessary keying shuffles that happen in column
annotation table manipulations.