### PR TITLE
set driver bind address, add apiserver service ports

### DIFF
--- a/apiserver/Dockerfile.apiserver
+++ b/apiserver/Dockerfile.apiserver
@@ -2,6 +2,6 @@ FROM hail-base
 
 COPY apiserver /apiserver
 
-ENV HAIL_SPARK_PROPERTIES "spark.driver.port=9001,spark.blockManager.port=9002"
+ENV HAIL_SPARK_PROPERTIES "spark.driver.host=apiserver,spark.driver.bindAddress=0.0.0.0,spark.driver.port=9001,spark.blockManager.port=9002"
 
 CMD ["/bin/bash", "-c", "source activate hail; python /apiserver/apiserver.py"]

--- a/apiserver/deployment.yaml.in
+++ b/apiserver/deployment.yaml.in
@@ -134,9 +134,17 @@ metadata:
     app: apiserver
 spec:
   ports:
-  - name: http
+  - name: hail
     port: 5000
     protocol: TCP
     targetPort: 5000
+  - name: spark-driver
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
+  - name: spark-block-manager
+    port: 9002
+    protocol: TCP
+    targetPort: 9002
   selector:
     app: apiserver


### PR DESCRIPTION
I guess the Spark 2.4 upgrade broke apiserver, but honestly I don't know how this could have worked before.

Deployed by hand and verified it's working.

I'm talking in methods tomorrow, might try to demo this.  It would be nice if it is working.
