### PR TITLE
[c++] Make NDarrayRef take a sequence of index IR

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3089,13 +3089,7 @@ class NDArrayExpression(Expression):
             raise ValueError(f'Must specify one index per dimension. '
                              f'Expected {self.ndim} dimensions but got {len(item)}')
 
-        # indexes must be iterable
-        if len(item) == 0:
-            idxs = hl.empty_array(hl.tint64)
-        else:
-            idxs = hl.array(list(item))
-
-        return construct_expr(ir.NDArrayRef(self._ir, idxs._ir), self._type.element_type)
+        return construct_expr(ir.NDArrayRef(self._ir, [idx._ir for idx in item]), self._type.element_type)
 
     @typecheck_method(f=func_spec(1, expr_any))
     def map(self, f):

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -504,19 +504,19 @@ class NDArrayMap(IR):
 
 
 class NDArrayRef(IR):
-    @typecheck_method(nd=IR, idxs=IR)
+    @typecheck_method(nd=IR, idxs=sequenceof(IR))
     def __init__(self, nd, idxs):
-        super().__init__(nd, idxs)
+        super().__init__(nd, *idxs)
         self.nd = nd
         self.idxs = idxs
 
-    @typecheck_method(nd=IR, idxs=IR)
-    def copy(self, nd, idxs):
-        return NDArrayRef(nd, idxs)
+    @typecheck_method(nd=IR, idxs=sequenceof(IR))
+    def copy(self, *args):
+        return NDArrayRef(args[0], args[1:])
 
     def _compute_type(self, env, agg_env):
         self.nd._compute_type(env, agg_env)
-        self.idxs._compute_type(env, agg_env)
+        [idx._compute_type(env, agg_env) for idx in self.idxs]
         self._type = self.nd.typ.element_type
 
 

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -510,7 +510,6 @@ class NDArrayRef(IR):
         self.nd = nd
         self.idxs = idxs
 
-    @typecheck_method(nd=IR, idxs=sequenceof(IR))
     def copy(self, *args):
         return NDArrayRef(args[0], args[1:])
 

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -56,7 +56,7 @@ class ValueIRTests(unittest.TestCase):
                            ir.MakeArray([ir.F64(-1.0), ir.F64(1.0)], hl.tarray(hl.tfloat64)),
                            ir.MakeArray([ir.I64(1), ir.I64(2)], hl.tarray(hl.tint64)),
                            ir.TrueIR()),
-            ir.NDArrayRef(nd, ir.MakeArray([ir.I64(1), ir.I64(2)], hl.tarray(hl.tint64))),
+            ir.NDArrayRef(nd, [ir.I64(1), ir.I64(2)]),
             ir.LowerBoundOnOrderedCollection(a, i, True),
             ir.GroupByKey(da),
             ir.ArrayMap(a, 'v', v),

--- a/hail/src/main/resources/include/hail/NDArray.h
+++ b/hail/src/main/resources/include/hail/NDArray.h
@@ -13,7 +13,6 @@ struct NDArray {
 };
 
 NDArray make_ndarray(int flags, int offset, size_t elem_size, std::vector<long> shape, std::vector<long> strides, const char *data);
-char const *load_indices(NDArray &nd, std::vector<long> indices);
 char const *load_index(NDArray &nd, int index);
 int n_elements(std::vector<long> &shape);
 std::vector<long> make_strides(int row_major, std::vector<long> &shape);
@@ -30,22 +29,6 @@ NDArray make_ndarray(int flags, int offset, size_t elem_size, std::vector<long> 
   nd.strides = strides;
 
   return nd;
-}
-
-char const *load_indices(NDArray nd, std::vector<long> indices) {
-  if (indices.size() != nd.shape.size()) {
-    throw new FatalError("Number of indices must match number of dimensions.");
-  }
-
-  int index = 0;
-  for (int i = 0; i < indices.size(); ++i) {
-    if (indices[i] < 0 || indices[i] >= nd.shape[i]) {
-      throw new FatalError(("Invalid index: " + std::to_string(indices[i])).c_str());
-    }
-    index += nd.strides[i] * indices[i];
-  }
-
-  return load_index(nd, index);
 }
 
 char const *load_index(NDArray &nd, int index) {

--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -1006,7 +1006,7 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
         triplet(
           s"""
              | ${ ndt.setup }
-             | ${ idxst.setup }
+             | ${ idxst.map(_.setup).mkString("\n") }
            """.stripMargin,
           idxst.foldLeft("false"){ case (b, idxt) => s"$b || ${ idxt.m }" },
           s"""

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -79,7 +79,7 @@ object Children {
     case ArrayAgg(a, name, query) =>
       Array(a, query)
     case NDArrayRef(nd, idxs) =>
-      Array(nd, idxs)
+      nd +: idxs
     case NDArrayMap(nd, _, body) =>
       Array(nd, body)
     case NDArrayMap2(l, r, _, _, body) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -60,7 +60,7 @@ object Copy {
         val IndexedSeq(data: IR, shape: IR, rowMajor: IR) = newChildren
         MakeNDArray(nDim, data, shape, rowMajor)
       case NDArrayRef(_, _) =>
-        val IndexedSeq(nd: IR, idxs: IR) = newChildren
+        val (nd: IR) +: (idxs: IndexedSeq[IR]) = newChildren
         NDArrayRef(nd, idxs)
       case NDArrayMap(_, name, _) =>
         val IndexedSeq(nd: IR, body: IR) = newChildren

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -201,7 +201,7 @@ final case class ArrayLeftJoinDistinct(left: IR, right: IR, l: String, r: String
 
 final case class MakeNDArray(nDim: Int, data: IR, shape: IR, rowMajor: IR) extends IR
 
-final case class NDArrayRef(nd: IR, idxs: IR) extends IR
+final case class NDArrayRef(nd: IR, idxs: IndexedSeq[IR]) extends IR
 
 final case class NDArrayMap(nd: IR, valueName: String, body: IR) extends IR {
   override def typ: TNDArray = coerce[TNDArray](super.typ)

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -106,9 +106,7 @@ object InferPType {
       case NDArrayReindex(nd, indexExpr) =>
         PNDArray(coerce[PNDArray](nd.pType).elementType, indexExpr.length)
       case NDArrayRef(nd, idxs) =>
-        coerce[PNDArray](nd.pType).elementType.setRequired(nd.pType.required && 
-          idxs.pType.required &&
-          coerce[PStreamable](idxs.pType).elementType.required)
+        coerce[PNDArray](nd.pType).elementType.setRequired(nd.pType.required && idxs.forall(_.typ.required))
       case NDArrayWrite(_, _) => PVoid
       case AggFilter(_, aggIR, _) =>
         aggIR.pType

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -106,10 +106,8 @@ object InferType {
       case NDArrayReindex(nd, indexExpr) =>
         TNDArray(coerce[TNDArray](nd.typ).elementType, Nat(indexExpr.length), nd.typ.required)
       case NDArrayRef(nd, idxs) =>
-        assert(coerce[TStreamable](idxs.typ).elementType.isOfType(TInt64()))
-        coerce[TNDArray](nd.typ).elementType.setRequired(nd.typ.required && 
-          idxs.typ.required && 
-          coerce[TStreamable](idxs.typ).elementType.required)
+        assert(idxs.forall(_.typ.isOfType(TInt64())))
+        coerce[TNDArray](nd.typ).elementType.setRequired(nd.typ.required && idxs.forall(_.typ.required))
       case NDArrayWrite(_, _) => TVoid
       case AggFilter(_, aggIR, _) =>
         aggIR.typ

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -642,7 +642,7 @@ object IRParser {
         NDArrayReindex(nd, indexExpr)
       case "NDArrayRef" =>
         val nd = ir_value_expr(env)(it)
-        val idxs = ir_value_expr(env)(it)
+        val idxs = ir_value_children(env)(it)
         NDArrayRef(nd, idxs)
       case "NDArrayWrite" =>
         val nd = ir_value_expr(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -125,10 +125,8 @@ object TypeCheck {
         assert(rowMajor.typ.isOfType(TBoolean()))
       case x@NDArrayRef(nd, idxs) =>
         assert(nd.typ.isInstanceOf[TNDArray])
-        assert(coerce[TStreamable](idxs.typ).elementType.isOfType(TInt64()))
-        assert(idxs.typ.isOfType(TArray(TInt64())))
-      case x@NDArrayMap(nd, _, body) =>
-        assert(nd.typ.isInstanceOf[TNDArray])
+        assert(idxs.forall(_.typ.isOfType(TInt64())))
+      case x@NDArrayMap(_, _, body) =>
         assert(x.elementTyp == body.typ)
       case x@NDArrayMap2(l, r, _, _, body) =>
         val lTyp = coerce[TNDArray](l.typ)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -125,6 +125,7 @@ object TypeCheck {
         assert(rowMajor.typ.isOfType(TBoolean()))
       case x@NDArrayRef(nd, idxs) =>
         assert(nd.typ.isInstanceOf[TNDArray])
+        assert(nd.typ.asInstanceOf[TNDArray].nDims == idxs.length)
         assert(idxs.forall(_.typ.isOfType(TInt64())))
       case x@NDArrayMap(_, _, body) =>
         assert(x.elementTyp == body.typ)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -7,7 +7,7 @@ import is.hail.asm4s.Code
 import is.hail.expr.{Nat, ir}
 import is.hail.expr.ir.IRBuilder._
 import is.hail.expr.ir.IRSuite.TestFunctions
-import is.hail.expr.ir.functions.{IRFunctionRegistry, RegistryFunctions, SeededIRFunction}
+import is.hail.expr.ir.functions._
 import is.hail.expr.types.TableType
 import is.hail.expr.types.virtual._
 import is.hail.io.CodecSpec
@@ -913,9 +913,7 @@ class IRSuite extends SparkSuite {
       rowMajor)
   }
 
-  def makeNDArrayRef(nd: IR, indxs: Seq[Long]): NDArrayRef = {
-    NDArrayRef(nd, MakeArray(indxs.map(I64), TArray(TInt64())))
-  }
+  def makeNDArrayRef(nd: IR, indxs: IndexedSeq[Long]): NDArrayRef = NDArrayRef(nd, indxs.map(I64))
 
   val scalarRowMajor = makeNDArray(FastSeq(3.0), FastSeq(), True())
   val scalarColMajor = makeNDArray(FastSeq(3.0), FastSeq(), False())
@@ -1006,8 +1004,8 @@ class IRSuite extends SparkSuite {
     val transpose = NDArrayReindex(mat, IndexedSeq(1, 0))
     val identity = NDArrayReindex(mat, IndexedSeq(0, 1))
 
-    val topLeftIndex = MakeArray(FastSeq(0L, 0L), TArray(TInt64()))
-    val bottomLeftIndex = MakeArray(FastSeq(1L, 0L), TArray(TInt64()))
+    val topLeftIndex = FastSeq(0L, 0L).map(I64)
+    val bottomLeftIndex = FastSeq(1L, 0L).map(I64)
 
     assertEvalsTo(NDArrayRef(mat, topLeftIndex), 1.0)
     assertEvalsTo(NDArrayRef(identity, topLeftIndex), 1.0)
@@ -1017,8 +1015,8 @@ class IRSuite extends SparkSuite {
     assertEvalsTo(NDArrayRef(transpose, bottomLeftIndex), 2.0)
 
     val partialTranspose = NDArrayReindex(cubeRowMajor, IndexedSeq(0, 2, 1))
-    val idx = MakeArray(FastSeq(0L, 1L, 0L), TArray(TInt64()))
-    val partialTranposeIdx = MakeArray(FastSeq(0L, 0L, 1L), TArray(TInt64()))
+    val idx = FastSeq(0L, 1L, 0L).map(I64)
+    val partialTranposeIdx = FastSeq(0L, 0L, 1L).map(I64)
     assertEvalsTo(NDArrayRef(cubeRowMajor, idx), 3.0)
     assertEvalsTo(NDArrayRef(partialTranspose, partialTranposeIdx), 3.0)
   }


### PR DESCRIPTION
- Changed NDArrayRef node to take a _sequence_ of IR for the indices as opposed to a single IR. This will make operations like slicing much easier, simplifies IR emission and allows us to typecheck that you have enough index variables
- Refactored `linearizeIndices`, a function that takes a Scala sequence of index variables for a ndarray and emits the single array index, so that it actually checks now that each index is within the shape length bounds of that dimension.