### PR TITLE
Fix MatrixAggregateColsByKey lowering

### DIFF
--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -261,6 +261,11 @@ class Tests(unittest.TestCase):
 
         self.assertTrue(result.entries()._same(expected))
 
+    def test_aggregate_cols_by_init_op(self):
+        mt = hl.import_vcf(resource('sample.vcf'))
+        cs = mt.group_cols_by(mt.s).aggregate(cs = hl.agg.call_stats(mt.GT, mt.alleles))
+        cs._force_count_rows() # should run without error
+
     def test_aggregate_rows_by(self):
         mt = hl.utils.range_matrix_table(4, 2)
         mt = (mt.annotate_rows(group=mt.row_idx < 2)

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -356,15 +356,14 @@ object LowerMatrixIR {
               .toArray
           }))
         .mapRows('row.insertFields(entriesField ->
-          let(__entries = 'row (entriesField), __key_map = 'global (keyMap)) {
+          let(__entries = 'row (entriesField), __key_map = 'global (keyMap), va = 'row) {
             irRange(0, '__key_map.len)
               .map(newColIdx1 ~> '__key_map (newColIdx1)
                 .apply('value)
                 .arrayAgg(aggElementIdx ~>
-                  let(va = 'row) {
-                    aggLet(va = 'row, g = '__entries (aggElementIdx), sa = 'global (colsField)(aggElementIdx)) {
-                      entryExpr
-                    }}))}))
+                  aggLet(va = 'row, g = '__entries (aggElementIdx), sa = 'global (colsField)(aggElementIdx)) {
+                    entryExpr
+                  }))}))
         .mapGlobals(
           'global.insertFields(colsField ->
             let(__key_map = 'global (keyMap)) {


### PR DESCRIPTION
`va` needs to be available inside the aggregator init operations, so needs to be bound outside the arrayagg.