### PR TITLE
Fix tuple nested in dict type will fail when calling `to_spark()`

### DIFF
--- a/hail/python/test/hail/expr/test_types.py
+++ b/hail/python/test/hail/expr/test_types.py
@@ -82,3 +82,8 @@ class Tests(unittest.TestCase):
             c = coercer_from_dtype(t)
             self.assertTrue(c.can_coerce(t))
             self.assertFalse(c.requires_conversion(t))
+
+    def test_nested_type_to_spark(self):
+        ht = hl.utils.range_table(10)
+        ht = ht.annotate(nested=hl.dict({"tup": hl.tuple([ht.idx])}))
+        ht.to_spark() # should not throw exception

--- a/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
+++ b/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
@@ -53,6 +53,10 @@ object SparkAnnotationImpex {
         StructType(tbs.fields
           .map(f =>
             StructField(escapeColumnName(f.name), f.typ.schema, nullable = !f.typ.required)))
+    case TTuple(types, required) =>
+      StructType(types.zipWithIndex.map {
+        case (typ: Type, i: Int) => StructField("_" + i.toString, exportType(typ), required)
+      })
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
+++ b/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
@@ -46,17 +46,13 @@ object SparkAnnotationImpex {
     case _: TBinary => BinaryType
     case TArray(elementType, _) =>
       ArrayType(exportType(elementType), containsNull = !elementType.required)
-    case tbs: TStruct =>
+    case tbs: TBaseStruct =>
       if (tbs.fields.isEmpty)
         BooleanType //placeholder
       else
         StructType(tbs.fields
           .map(f =>
             StructField(escapeColumnName(f.name), f.typ.schema, nullable = !f.typ.required)))
-    case TTuple(types, required) =>
-      StructType(types.zipWithIndex.map {
-        case (typ: Type, i: Int) => StructField("_" + i.toString, exportType(typ), required)
-      })
   }
 }
 


### PR DESCRIPTION
When putting `tuple` in `dict` type, it will fail to convert spark dataframe. The issue could be reproduce by:

```
ht = hl.utils.range_table(10)
ht = ht.annotate(nested=hl.dict({"tup": hl.tuple([ht.idx])}))
ht.to_spark()
```

This PR fix this issue.