### PR TITLE
Banish hundreds of `scala.immutable.Vector` usages

### DIFF
--- a/hail/src/main/scala/is/hail/experimental/package.scala
+++ b/hail/src/main/scala/is/hail/experimental/package.scala
@@ -43,7 +43,7 @@ package object experimental {
     val nSamples = sum(_gtCounts)
 
     //Needs some non-ref samples to compute
-    if(_gtCounts(0) >= nSamples){ return IndexedSeq(_gtCounts(0),0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0)}
+    if(_gtCounts(0) >= nSamples){ return FastIndexedSeq(_gtCounts(0),0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0)}
 
     val nHaplotypes = 2.0*nSamples.toDouble
 

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -4,7 +4,7 @@ import is.hail.HailContext
 import is.hail.expr.types.BlockMatrixType
 import is.hail.expr.types.virtual.{TArray, TFloat64}
 import is.hail.linalg.BlockMatrix
-import is.hail.utils.fatal
+import is.hail.utils.{FastIndexedSeq, fatal}
 import breeze.linalg.DenseMatrix
 import is.hail.expr.types.virtual.Type
 
@@ -26,10 +26,10 @@ object BlockMatrixIR {
 
   def matrixShapeToTensorShape(nRows: Long,  nCols: Long): (IndexedSeq[Long], Boolean) = {
     (nRows, nCols) match {
-      case (1, 1) => (IndexedSeq(), false)
-      case (_, 1) => (IndexedSeq(nRows), false)
-      case (1, _) => (IndexedSeq(nCols), true)
-      case _ => (IndexedSeq(nRows, nCols), false)
+      case (1, 1) => (FastIndexedSeq(), false)
+      case (_, 1) => (FastIndexedSeq(nRows), false)
+      case (1, _) => (FastIndexedSeq(nCols), true)
+      case _ => (FastIndexedSeq(nRows, nCols), false)
     }
   }
 
@@ -385,7 +385,7 @@ case class BlockMatrixAgg(
 
   override def typ: BlockMatrixType = {
     val shape = outIndexExpr.map({ i: Int => child.typ.shape(i) }).toIndexedSeq
-    val isRowVector = outIndexExpr == IndexedSeq(1)
+    val isRowVector = outIndexExpr == FastIndexedSeq(1)
 
     BlockMatrixType(child.typ.elementType, shape, isRowVector, child.typ.blockSize)
   }
@@ -473,7 +473,7 @@ case class ValueToBlockMatrix(
   override protected[ir] def execute(hc: HailContext): BlockMatrix = {
     Interpret[Any](child) match {
       case scalar: Double =>
-        assert(shape == IndexedSeq(1, 1))
+        assert(shape == FastIndexedSeq(1, 1))
         BlockMatrix.fill(hc, nRows = 1, nCols = 1, scalar, blockSize)
       case data: IndexedSeq[Double] =>
         BlockMatrixIR.toBlockMatrix(hc, shape(0).toInt, shape(1).toInt, data.toArray, blockSize)

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -130,24 +130,24 @@ object Children {
     case ApplySpecial(_, args) =>
       args.toFastIndexedSeq
     case Uniroot(_, fn, min, max) =>
-      FastIndexedSeq(fn, min, max)
+      Array(fn, min, max)
     // from MatrixIR
-    case MatrixWrite(child, _) => IndexedSeq(child)
+    case MatrixWrite(child, _) => Array(child)
     case MatrixMultiWrite(children, _) => children
     // from TableIR
-    case TableCount(child) => IndexedSeq(child)
-    case TableGetGlobals(child) => IndexedSeq(child)
-    case TableCollect(child) => IndexedSeq(child)
-    case TableAggregate(child, query) => IndexedSeq(child, query)
-    case MatrixAggregate(child, query) => IndexedSeq(child, query)
-    case TableWrite(child, _) => IndexedSeq(child)
-    case TableToValueApply(child, _) => IndexedSeq(child)
-    case MatrixToValueApply(child, _) => IndexedSeq(child)
+    case TableCount(child) => Array(child)
+    case TableGetGlobals(child) => Array(child)
+    case TableCollect(child) => Array(child)
+    case TableAggregate(child, query) => Array(child, query)
+    case MatrixAggregate(child, query) => Array(child, query)
+    case TableWrite(child, _) => Array(child)
+    case TableToValueApply(child, _) => Array(child)
+    case MatrixToValueApply(child, _) => Array(child)
     // from BlockMatrixIR
-    case BlockMatrixToValueApply(child, _) => IndexedSeq(child)
-    case BlockMatrixWrite(child, _) => IndexedSeq(child)
+    case BlockMatrixToValueApply(child, _) => Array(child)
+    case BlockMatrixWrite(child, _) => Array(child)
     case BlockMatrixMultiWrite(blockMatrices, _) => blockMatrices
-    case CollectDistributedArray(ctxs, globals, _, _, body) => IndexedSeq(ctxs, globals, body)
-    case ReadPartition(path, _, _, _) => IndexedSeq(path)
+    case CollectDistributedArray(ctxs, globals, _, _, body) => Array(ctxs, globals, body)
+    case ReadPartition(path, _, _, _) => Array(path)
   }
 }

--- a/hail/src/main/scala/is/hail/methods/IBD.scala
+++ b/hail/src/main/scala/is/hail/methods/IBD.scala
@@ -333,7 +333,7 @@ object IBD {
 
   def toKeyTable(sc: HailContext, ibdMatrix: RDD[((Annotation, Annotation), ExtendedIBDInfo)]): Table = {
     val ktRdd = ibdMatrix.map { case ((i, j), eibd) => eibd.makeRow(i, j) }
-    Table(sc, ktRdd, ibdSignature, IndexedSeq("i", "j"))
+    Table(sc, ktRdd, ibdSignature, FastIndexedSeq("i", "j"))
   }
 
   def toRDD(tv: TableValue): RDD[((Annotation, Annotation), ExtendedIBDInfo)] = {

--- a/hail/src/main/scala/is/hail/methods/VEP.scala
+++ b/hail/src/main/scala/is/hail/methods/VEP.scala
@@ -83,7 +83,7 @@ object VEP {
     val env = pb.environment()
     confEnv.foreach { case (key, value) => env.put(key, value) }
 
-    val (jt, proc) = List((Locus("1", 13372), IndexedSeq("G", "C"))).iterator.pipe(pb,
+    val (jt, proc) = List((Locus("1", 13372), FastIndexedSeq("G", "C"))).iterator.pipe(pb,
       printContext,
       printElement,
       _ => ())

--- a/hail/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
@@ -52,8 +52,8 @@ class AnnotationsSuite extends SparkSuite {
     // type Array - info.AC (allele count)
     val acQuery = vas.query("info", "AC")
     assert(vas.fieldOption("info", "AC").exists(f => f.typ == TArray(TInt32()) || f.typ == TArray(+TInt32())))
-    assert(acQuery(variantAnnotationMap(firstVariant)) == IndexedSeq(89))
-    assert(acQuery(variantAnnotationMap(anotherVariant)) == IndexedSeq(13))
+    assert(acQuery(variantAnnotationMap(firstVariant)) == FastIndexedSeq(89))
+    assert(acQuery(variantAnnotationMap(anotherVariant)) == FastIndexedSeq(13))
 
     // type Boolean/flag - info.DB (dbSNP membership)
     val dbQuery = vas.query("info", "DB")

--- a/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
@@ -945,10 +945,10 @@ class AggregatorsSuite extends SparkSuite {
   @Test def downsample() {
     runAggregator(Downsample(),
       TStruct("x" -> TFloat64(), "y" -> TFloat64(), "label" -> TArray(TString())),
-      FastIndexedSeq(Row(1500.0, 1500.0, IndexedSeq("1500")), Row(5500.0, 5500.0, IndexedSeq("5500")), Row(5600.0, 5600.0, IndexedSeq("5600")),
-        Row(9200.0, 9200.0, IndexedSeq("9200")), Row(9400.0, 9400.0, IndexedSeq("9400")), Row(0.0, 10000.0, IndexedSeq("0, 10000"))),
-      FastIndexedSeq(Row(1500.0, 1500.0, IndexedSeq("1500")), Row(5600.0, 5600.0, IndexedSeq("5600")), Row(9400.0, 9400.0, IndexedSeq("9400")),
-        Row(0.0, 10000.0, IndexedSeq("0, 10000"))),
+      FastIndexedSeq(Row(1500.0, 1500.0, FastIndexedSeq("1500")), Row(5500.0, 5500.0, FastIndexedSeq("5500")), Row(5600.0, 5600.0, FastIndexedSeq("5600")),
+        Row(9200.0, 9200.0, FastIndexedSeq("9200")), Row(9400.0, 9400.0, FastIndexedSeq("9400")), Row(0.0, 10000.0, FastIndexedSeq("0, 10000"))),
+      FastIndexedSeq(Row(1500.0, 1500.0, FastIndexedSeq("1500")), Row(5600.0, 5600.0, FastIndexedSeq("5600")), Row(9400.0, 9400.0, FastIndexedSeq("9400")),
+        Row(0.0, 10000.0, FastIndexedSeq("0, 10000"))),
       FastIndexedSeq(10),
       None,
       seqOpArgs = FastIndexedSeq(Ref("x", TFloat64()), Ref("y", TFloat64()), Ref("label", TArray(TString()))))
@@ -1009,9 +1009,9 @@ class AggregatorsSuite extends SparkSuite {
         ht,
         AggArrayPerElement(GetField(Ref("row", ht.typ.rowType), "aRange"), "elt", "_'",
           ApplyAggOp(
-            IndexedSeq(),
+            FastIndexedSeq(),
             None,
-            IndexedSeq(Cast(Ref("elt", TInt32()), TInt64())),
+            FastIndexedSeq(Cast(Ref("elt", TInt32()), TInt64())),
             AggSignature(Sum(), FastIndexedSeq(), None, FastIndexedSeq(TInt64()))),
           false
         )

--- a/hail/src/test/scala/is/hail/expr/ir/ArrayFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ArrayFunctionsSuite.scala
@@ -16,10 +16,10 @@ class ArrayFunctionsSuite extends TestNGSuite {
 
   @DataProvider(name = "basic")
   def basicData(): Array[Array[Any]] = Array(
-    Array(IndexedSeq(3, 7)),
+    Array(FastIndexedSeq(3, 7)),
     Array(null),
-    Array(IndexedSeq(3, null, 7, null)),
-    Array(IndexedSeq())
+    Array(FastIndexedSeq(3, null, 7, null)),
+    Array(FastIndexedSeq())
   )
 
   @DataProvider(name = "basicPairs")
@@ -84,11 +84,11 @@ class ArrayFunctionsSuite extends TestNGSuite {
 
   @DataProvider(name = "sort")
   def sortData(): Array[Array[Any]] = Array(
-    Array(IndexedSeq(3, 9, 7), IndexedSeq(3, 7, 9), IndexedSeq(9, 7, 3)),
+    Array(FastIndexedSeq(3, 9, 7), FastIndexedSeq(3, 7, 9), FastIndexedSeq(9, 7, 3)),
     Array(null, null, null),
-    Array(IndexedSeq(3, null, 1, null, 3), IndexedSeq(1, 3, 3, null, null), IndexedSeq(3, 3, 1, null, null)),
-    Array(IndexedSeq(1, null, 3, null, 1), IndexedSeq(1, 1, 3, null, null), IndexedSeq(3, 1, 1, null, null)),
-    Array(IndexedSeq(), IndexedSeq(), IndexedSeq())
+    Array(FastIndexedSeq(3, null, 1, null, 3), FastIndexedSeq(1, 3, 3, null, null), FastIndexedSeq(3, 3, 1, null, null)),
+    Array(FastIndexedSeq(1, null, 3, null, 1), FastIndexedSeq(1, 1, 3, null, null), FastIndexedSeq(3, 1, 1, null, null)),
+    Array(FastIndexedSeq(), FastIndexedSeq(), FastIndexedSeq())
   )
 
   @Test(dataProvider = "sort")
@@ -105,11 +105,11 @@ class ArrayFunctionsSuite extends TestNGSuite {
 
   @DataProvider(name = "argminmax")
   def argMinMaxData(): Array[Array[Any]] = Array(
-    Array(IndexedSeq(3, 9, 7), 0, 1),
+    Array(FastIndexedSeq(3, 9, 7), 0, 1),
     Array(null, null, null),
-    Array(IndexedSeq(3, null, 1, null, 3), 2, 0),
-    Array(IndexedSeq(1, null, 3, null, 1), 0, 2),
-    Array(IndexedSeq(), null, null)
+    Array(FastIndexedSeq(3, null, 1, null, 3), 2, 0),
+    Array(FastIndexedSeq(1, null, 3, null, 1), 0, 2),
+    Array(FastIndexedSeq(), null, null)
   )
 
   @Test(dataProvider = "argminmax")
@@ -124,11 +124,11 @@ class ArrayFunctionsSuite extends TestNGSuite {
 
   @DataProvider(name = "uniqueMinMaxIndex")
   def uniqueMinMaxData(): Array[Array[Any]] = Array(
-    Array(IndexedSeq(3, 9, 7), 0, 1),
+    Array(FastIndexedSeq(3, 9, 7), 0, 1),
     Array(null, null, null),
-    Array(IndexedSeq(3, null, 1, null, 3), 2, null),
-    Array(IndexedSeq(1, null, 3, null, 1), null, 2),
-    Array(IndexedSeq(), null, null)
+    Array(FastIndexedSeq(3, null, 1, null, 3), 2, null),
+    Array(FastIndexedSeq(1, null, 3, null, 1), null, 2),
+    Array(FastIndexedSeq(), null, null)
   )
 
   @Test(dataProvider = "uniqueMinMaxIndex")
@@ -143,9 +143,9 @@ class ArrayFunctionsSuite extends TestNGSuite {
 
   @DataProvider(name = "arrayOpsData")
   def arrayOpsData(): Array[Array[Any]] = Array[Any](
-    IndexedSeq(3, 9, 7, 1),
-    IndexedSeq(null, 2, null, 8),
-    IndexedSeq(5, 3, null, null),
+    FastIndexedSeq(3, 9, 7, 1),
+    FastIndexedSeq(null, 2, null, 8),
+    FastIndexedSeq(5, 3, null, null),
     null
   ).combinations(2).toArray
 
@@ -212,33 +212,33 @@ class ArrayFunctionsSuite extends TestNGSuite {
 
   @Test def slicing() {
     val a = IRArray(0, null, 2)
-    assertEvalsTo(invoke("[:]", a), IndexedSeq(0, null, 2))
+    assertEvalsTo(invoke("[:]", a), FastIndexedSeq(0, null, 2))
     assertEvalsTo(invoke("[:]", naa), null)
 
-    assertEvalsTo(invoke("[*:]", a, I32(1)), IndexedSeq(null, 2))
-    assertEvalsTo(invoke("[*:]", a, I32(-2)), IndexedSeq(null, 2))
-    assertEvalsTo(invoke("[*:]", a, I32(5)), IndexedSeq())
-    assertEvalsTo(invoke("[*:]", a, I32(-5)), IndexedSeq(0, null, 2))
+    assertEvalsTo(invoke("[*:]", a, I32(1)), FastIndexedSeq(null, 2))
+    assertEvalsTo(invoke("[*:]", a, I32(-2)), FastIndexedSeq(null, 2))
+    assertEvalsTo(invoke("[*:]", a, I32(5)), FastIndexedSeq())
+    assertEvalsTo(invoke("[*:]", a, I32(-5)), FastIndexedSeq(0, null, 2))
     assertEvalsTo(invoke("[*:]", naa, I32(1)), null)
     assertEvalsTo(invoke("[*:]", a, NA(TInt32())), null)
 
-    assertEvalsTo(invoke("[:*]", a, I32(2)), IndexedSeq(0, null))
-    assertEvalsTo(invoke("[:*]", a, I32(-1)), IndexedSeq(0, null))
-    assertEvalsTo(invoke("[:*]", a, I32(5)), IndexedSeq(0, null, 2))
-    assertEvalsTo(invoke("[:*]", a, I32(-5)), IndexedSeq())
+    assertEvalsTo(invoke("[:*]", a, I32(2)), FastIndexedSeq(0, null))
+    assertEvalsTo(invoke("[:*]", a, I32(-1)), FastIndexedSeq(0, null))
+    assertEvalsTo(invoke("[:*]", a, I32(5)), FastIndexedSeq(0, null, 2))
+    assertEvalsTo(invoke("[:*]", a, I32(-5)), FastIndexedSeq())
     assertEvalsTo(invoke("[:*]", naa, I32(1)), null)
     assertEvalsTo(invoke("[:*]", a, NA(TInt32())), null)
 
-    assertEvalsTo(invoke("[*:*]", a, I32(1), I32(3)), IndexedSeq(null, 2))
-    assertEvalsTo(invoke("[*:*]", a, I32(1), I32(2)), IndexedSeq(null))
-    assertEvalsTo(invoke("[*:*]", a, I32(0), I32(2)), IndexedSeq(0, null))
-    assertEvalsTo(invoke("[*:*]", a, I32(0), I32(3)), IndexedSeq(0, null, 2))
-    assertEvalsTo(invoke("[*:*]", a, I32(-1), I32(3)), IndexedSeq(2))
-    assertEvalsTo(invoke("[*:*]", a, I32(-4), I32(4)), IndexedSeq(0, null, 2))
+    assertEvalsTo(invoke("[*:*]", a, I32(1), I32(3)), FastIndexedSeq(null, 2))
+    assertEvalsTo(invoke("[*:*]", a, I32(1), I32(2)), FastIndexedSeq(null))
+    assertEvalsTo(invoke("[*:*]", a, I32(0), I32(2)), FastIndexedSeq(0, null))
+    assertEvalsTo(invoke("[*:*]", a, I32(0), I32(3)), FastIndexedSeq(0, null, 2))
+    assertEvalsTo(invoke("[*:*]", a, I32(-1), I32(3)), FastIndexedSeq(2))
+    assertEvalsTo(invoke("[*:*]", a, I32(-4), I32(4)), FastIndexedSeq(0, null, 2))
     assertEvalsTo(invoke("[*:*]", naa, I32(1), I32(2)), null)
     assertEvalsTo(invoke("[*:*]", a, I32(1), NA(TInt32())), null)
     assertEvalsTo(invoke("[*:*]", a, NA(TInt32()), I32(1)), null)
-    assertEvalsTo(invoke("[*:*]", a, I32(3), I32(2)), IndexedSeq())
+    assertEvalsTo(invoke("[*:*]", a, I32(3), I32(2)), FastIndexedSeq())
   }
 
   @DataProvider(name = "flatten")

--- a/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -4,6 +4,7 @@ import breeze.linalg.{DenseMatrix => BDM}
 import is.hail.SparkSuite
 import is.hail.expr.types.virtual.{TArray, TFloat64}
 import is.hail.linalg.BlockMatrix
+import is.hail.utils.FastIndexedSeq
 import org.testng.annotations.Test
 
 class BlockMatrixIRSuite extends SparkSuite {
@@ -58,10 +59,10 @@ class BlockMatrixIRSuite extends SparkSuite {
 
 
   @Test def testBlockMatrixMap() {
-    val sqrtFoursIR = BlockMatrixMap(new BlockMatrixLiteral(fours), Apply("sqrt", IndexedSeq(Ref("element", TFloat64()))))
+    val sqrtFoursIR = BlockMatrixMap(new BlockMatrixLiteral(fours), Apply("sqrt", FastIndexedSeq(Ref("element", TFloat64()))))
     val negFoursIR = BlockMatrixMap(new BlockMatrixLiteral(fours), ApplyUnaryPrimOp(Negate(), Ref("element", TFloat64())))
-    val logOnesIR = BlockMatrixMap(new BlockMatrixLiteral(ones), Apply("log", IndexedSeq(Ref("element", TFloat64()))))
-    val absNegFoursIR = BlockMatrixMap(new BlockMatrixLiteral(negFours), Apply("abs", IndexedSeq(Ref("element", TFloat64()))))
+    val logOnesIR = BlockMatrixMap(new BlockMatrixLiteral(ones), Apply("log", FastIndexedSeq(Ref("element", TFloat64()))))
+    val absNegFoursIR = BlockMatrixMap(new BlockMatrixLiteral(negFours), Apply("abs", FastIndexedSeq(Ref("element", TFloat64()))))
 
     assertBmEq(sqrtFoursIR.execute(hc), twos)
     assertBmEq(negFoursIR.execute(hc), negFours)
@@ -72,14 +73,14 @@ class BlockMatrixIRSuite extends SparkSuite {
   @Test def testBlockMatrixBroadcastValue_Scalars() {
     val broadcastTwo = BlockMatrixBroadcast(
       ValueToBlockMatrix(MakeArray(Seq[F64](F64(2)), TArray(TFloat64())), Array[Long](1, 1), 0),
-        IndexedSeq(), shape, 0)
+      FastIndexedSeq(), shape, 0)
 
     val onesAddTwo = makeMap2(new BlockMatrixLiteral(ones), broadcastTwo, Add())
     val threesSubTwo = makeMap2(new BlockMatrixLiteral(threes), broadcastTwo, Subtract())
     val twosMulTwo = makeMap2(new BlockMatrixLiteral(twos), broadcastTwo, Multiply())
     val foursDivTwo = makeMap2(new BlockMatrixLiteral(fours), broadcastTwo, FloatingPointDivide())
     val twosPowTwo = BlockMatrixMap2(new BlockMatrixLiteral(twos), broadcastTwo,
-      Apply("**", IndexedSeq(Ref("l", TFloat64()), Ref("r", TFloat64()))))
+      Apply("**", FastIndexedSeq(Ref("l", TFloat64()), Ref("r", TFloat64()))))
 
     assertBmEq(onesAddTwo.execute(hc), threes)
     assertBmEq(threesSubTwo.execute(hc), ones)
@@ -92,9 +93,9 @@ class BlockMatrixIRSuite extends SparkSuite {
     val vectorLiteral = MakeArray(Seq[F64](F64(1), F64(2), F64(3)), TArray(TFloat64()))
 
     val broadcastRowVector = BlockMatrixBroadcast(ValueToBlockMatrix(vectorLiteral, Array[Long](1, 3),
-      0), IndexedSeq(1), shape, 0)
+      0), FastIndexedSeq(1), shape, 0)
     val broadcastColVector = BlockMatrixBroadcast(ValueToBlockMatrix(vectorLiteral, Array[Long](3, 1),
-      0), IndexedSeq(0), shape, 0)
+      0), FastIndexedSeq(0), shape, 0)
 
     // Addition
     val actualOnesAddRowOnRight = makeMap2(new BlockMatrixLiteral(ones), broadcastRowVector, Add())

--- a/hail/src/test/scala/is/hail/expr/ir/DictFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/DictFunctionsSuite.scala
@@ -4,6 +4,7 @@ import is.hail.ExecStrategy
 import is.hail.TestUtils._
 import is.hail.expr.ir.TestUtils._
 import is.hail.expr.types.virtual.{TDict, TInt32}
+import is.hail.utils.FastIndexedSeq
 import org.apache.spark.sql.Row
 import org.testng.annotations.{DataProvider, Test}
 import org.scalatest.testng.TestNGSuite
@@ -42,11 +43,11 @@ class DictFunctionsSuite extends TestNGSuite {
 
   @DataProvider(name = "dictToArray")
   def dictToArrayData(): Array[Array[Any]] = Array(
-    Array(Seq(1 -> 3, 2 -> 7), IndexedSeq(Row(1, 3), Row(2, 7))),
-    Array(Seq(1 -> 3, 2 -> null, null, (null, 1), 3 -> 7),
-      IndexedSeq(Row(1, 3), Row(2, null), Row(3, 7), Row(null, 1))),
-    Array(Seq(), IndexedSeq()),
-    Array(Seq(null), IndexedSeq()),
+    Array(FastIndexedSeq(1 -> 3, 2 -> 7), FastIndexedSeq(Row(1, 3), Row(2, 7))),
+    Array(FastIndexedSeq(1 -> 3, 2 -> null, null, (null, 1), 3 -> 7),
+      FastIndexedSeq(Row(1, 3), Row(2, null), Row(3, 7), Row(null, 1))),
+    Array(FastIndexedSeq(), FastIndexedSeq()),
+    Array(FastIndexedSeq(null), FastIndexedSeq()),
     Array(null, null))
 
   @Test(dataProvider = "dictToArray")
@@ -56,11 +57,11 @@ class DictFunctionsSuite extends TestNGSuite {
 
   @DataProvider(name = "keysAndValues")
   def keysAndValuesData(): Array[Array[Any]] = Array(
-    Array(Seq(1 -> 3, 2 -> 7), IndexedSeq(1, 2), IndexedSeq(3, 7)),
-    Array(Seq(1 -> 3, 2 -> null, null, (null, 1), 3 -> 7),
-      IndexedSeq(1, 2, 3, null), IndexedSeq(3, null, 7, 1)),
-    Array(Seq(), IndexedSeq(), IndexedSeq()),
-    Array(Seq(null), IndexedSeq(), IndexedSeq()),
+    Array(FastIndexedSeq(1 -> 3, 2 -> 7), FastIndexedSeq(1, 2), FastIndexedSeq(3, 7)),
+    Array(FastIndexedSeq(1 -> 3, 2 -> null, null, (null, 1), 3 -> 7),
+      FastIndexedSeq(1, 2, 3, null), FastIndexedSeq(3, null, 7, 1)),
+    Array(FastIndexedSeq(), FastIndexedSeq(), FastIndexedSeq()),
+    Array(FastIndexedSeq(null), FastIndexedSeq(), FastIndexedSeq()),
     Array(null, null, null))
 
   @Test(dataProvider = "keysAndValues")

--- a/hail/src/test/scala/is/hail/expr/ir/GenotypeFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/GenotypeFunctionsSuite.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir
 import is.hail.ExecStrategy
 import is.hail.TestUtils._
 import is.hail.expr.ir.TestUtils._
+import is.hail.utils.FastIndexedSeq
 import org.testng.annotations.{DataProvider, Test}
 import org.scalatest.testng.TestNGSuite
 
@@ -12,17 +13,17 @@ class GenotypeFunctionsSuite extends TestNGSuite {
 
   @DataProvider(name="gps")
   def gpData(): Array[Array[Any]] = Array(
-    Array(IndexedSeq(1.0, 0.0, 0.0), 0.0),
-    Array(IndexedSeq(0.0, 1.0, 0.0), 1.0),
-    Array(IndexedSeq(0.0, 0.0, 1.0), 2.0),
-    Array(IndexedSeq(0.5, 0.5, 0.0), 0.5),
-    Array(IndexedSeq(0.0, 0.5, 0.5), 1.5))
+    Array(FastIndexedSeq(1.0, 0.0, 0.0), 0.0),
+    Array(FastIndexedSeq(0.0, 1.0, 0.0), 1.0),
+    Array(FastIndexedSeq(0.0, 0.0, 1.0), 2.0),
+    Array(FastIndexedSeq(0.5, 0.5, 0.0), 0.5),
+    Array(FastIndexedSeq(0.0, 0.5, 0.5), 1.5))
 
   @DataProvider(name="pls")
   def plData(): Array[Array[Any]] = Array(
-    Array(IndexedSeq(0, 20, 100), 0.009900990296049406),
-    Array(IndexedSeq(20, 0, 100), 0.9900990100009803),
-    Array(IndexedSeq(20, 100, 0), 1.980198019704931))
+    Array(FastIndexedSeq(0, 20, 100), 0.009900990296049406),
+    Array(FastIndexedSeq(20, 0, 100), 0.9900990100009803),
+    Array(FastIndexedSeq(20, 100, 0), 1.980198019704931))
 
   @Test(dataProvider="gps")
   def testDosage(gp: IndexedSeq[java.lang.Double], expected: java.lang.Double) {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1001,8 +1001,8 @@ class IRSuite extends SparkSuite {
 
     val mat = MakeNDArray(2, MakeArray(Seq(F64(1.0), F64(2.0), F64(3.0), F64(4.0)), TArray(TFloat64())),
       MakeArray(Seq(I64(2L), I64(2L)), TArray(TInt64())), True())
-    val transpose = NDArrayReindex(mat, IndexedSeq(1, 0))
-    val identity = NDArrayReindex(mat, IndexedSeq(0, 1))
+    val transpose = NDArrayReindex(mat, FastIndexedSeq(1, 0))
+    val identity = NDArrayReindex(mat, FastIndexedSeq(0, 1))
 
     val topLeftIndex = FastSeq(0L, 0L).map(I64)
     val bottomLeftIndex = FastSeq(1L, 0L).map(I64)
@@ -1332,15 +1332,15 @@ class IRSuite extends SparkSuite {
   def testComparisonOpDifferentTypes(a: Any, t1: Type, t2: Type) {
     implicit val execStrats = ExecStrategy.javaOnly
 
-    assertEvalsTo(ApplyComparisonOp(EQ(t1, t2), In(0, t1), In(1, t2)), IndexedSeq(a -> t1, a -> t2), true)
-    assertEvalsTo(ApplyComparisonOp(LT(t1, t2), In(0, t1), In(1, t2)), IndexedSeq(a -> t1, a -> t2), false)
-    assertEvalsTo(ApplyComparisonOp(GT(t1, t2), In(0, t1), In(1, t2)), IndexedSeq(a -> t1, a -> t2), false)
-    assertEvalsTo(ApplyComparisonOp(LTEQ(t1, t2), In(0, t1), In(1, t2)), IndexedSeq(a -> t1, a -> t2), true)
-    assertEvalsTo(ApplyComparisonOp(GTEQ(t1, t2), In(0, t1), In(1, t2)), IndexedSeq(a -> t1, a -> t2), true)
-    assertEvalsTo(ApplyComparisonOp(NEQ(t1, t2), In(0, t1), In(1, t2)), IndexedSeq(a -> t1, a -> t2), false)
-    assertEvalsTo(ApplyComparisonOp(EQWithNA(t1, t2), In(0, t1), In(1, t2)), IndexedSeq(a -> t1, a -> t2), true)
-    assertEvalsTo(ApplyComparisonOp(NEQWithNA(t1, t2), In(0, t1), In(1, t2)), IndexedSeq(a -> t1, a -> t2), false)
-    assertEvalsTo(ApplyComparisonOp(Compare(t1, t2), In(0, t1), In(1, t2)), IndexedSeq(a -> t1, a -> t2), 0)
+    assertEvalsTo(ApplyComparisonOp(EQ(t1, t2), In(0, t1), In(1, t2)), FastIndexedSeq(a -> t1, a -> t2), true)
+    assertEvalsTo(ApplyComparisonOp(LT(t1, t2), In(0, t1), In(1, t2)), FastIndexedSeq(a -> t1, a -> t2), false)
+    assertEvalsTo(ApplyComparisonOp(GT(t1, t2), In(0, t1), In(1, t2)), FastIndexedSeq(a -> t1, a -> t2), false)
+    assertEvalsTo(ApplyComparisonOp(LTEQ(t1, t2), In(0, t1), In(1, t2)), FastIndexedSeq(a -> t1, a -> t2), true)
+    assertEvalsTo(ApplyComparisonOp(GTEQ(t1, t2), In(0, t1), In(1, t2)), FastIndexedSeq(a -> t1, a -> t2), true)
+    assertEvalsTo(ApplyComparisonOp(NEQ(t1, t2), In(0, t1), In(1, t2)), FastIndexedSeq(a -> t1, a -> t2), false)
+    assertEvalsTo(ApplyComparisonOp(EQWithNA(t1, t2), In(0, t1), In(1, t2)), FastIndexedSeq(a -> t1, a -> t2), true)
+    assertEvalsTo(ApplyComparisonOp(NEQWithNA(t1, t2), In(0, t1), In(1, t2)), FastIndexedSeq(a -> t1, a -> t2), false)
+    assertEvalsTo(ApplyComparisonOp(Compare(t1, t2), In(0, t1), In(1, t2)), FastIndexedSeq(a -> t1, a -> t2), 0)
   }
 
   @DataProvider(name = "valueIRs")
@@ -1411,7 +1411,7 @@ class IRSuite extends SparkSuite {
       NDArrayRef(nd, FastSeq(I64(1), I64(2))),
       NDArrayMap(nd, "v", ApplyUnaryPrimOp(Negate(), v)),
       NDArrayMap2(nd, nd, "l", "r", ApplyBinaryPrimOp(Add(), l, r)),
-      NDArrayReindex(nd, IndexedSeq(0, 1)),
+      NDArrayReindex(nd, FastIndexedSeq(0, 1)),
       NDArrayWrite(nd, Str(tmpDir.createTempFile())),
       ArrayRef(a, i),
       ArrayLen(a),
@@ -1442,13 +1442,13 @@ class IRSuite extends SparkSuite {
       InitOp(I32(0), FastIndexedSeq(I32(2)), callStatsSig),
       SeqOp(I32(0), FastIndexedSeq(i), collectSig),
       SeqOp(I32(0), FastIndexedSeq(F64(-2.11), I32(17)), takeBySig),
-      Begin(IndexedSeq(Void())),
-      MakeStruct(Seq("x" -> i)),
-      SelectFields(s, Seq("x", "z")),
-      InsertFields(s, Seq("x" -> i)),
-      InsertFields(s, Seq("* x *" -> i)), // Won't parse as a simple identifier
+      Begin(FastIndexedSeq(Void())),
+      MakeStruct(FastIndexedSeq("x" -> i)),
+      SelectFields(s, FastIndexedSeq("x", "z")),
+      InsertFields(s, FastIndexedSeq("x" -> i)),
+      InsertFields(s, FastIndexedSeq("* x *" -> i)), // Won't parse as a simple identifier
       GetField(s, "x"),
-      MakeTuple(Seq(i, b)),
+      MakeTuple(FastIndexedSeq(i, b)),
       GetTupleElement(t, 1),
       In(2, TFloat64()),
       Die("mumblefoo", TFloat64()),
@@ -1501,7 +1501,7 @@ class IRSuite extends SparkSuite {
         TableJoin(read,
           TableRange(100, 10), "inner", 1),
         TableLeftJoinRightDistinct(read, TableRange(100, 10), "root"),
-        TableMultiWayZipJoin(IndexedSeq(read, read), " * data * ", "globals"),
+        TableMultiWayZipJoin(FastIndexedSeq(read, read), " * data * ", "globals"),
         MatrixEntriesTable(mtRead),
         MatrixRowsTable(mtRead),
         TableRepartition(read, 10, RepartitionStrategy.COALESCE),
@@ -1627,7 +1627,7 @@ class IRSuite extends SparkSuite {
   @DataProvider(name = "blockMatrixIRs")
   def blockMatrixIRs(): Array[Array[BlockMatrixIR]] = {
     val read = BlockMatrixRead(BlockMatrixNativeReader("src/test/resources/blockmatrix_example/0"))
-    val transpose = BlockMatrixBroadcast(read, IndexedSeq(1, 0), IndexedSeq(2, 2), 2)
+    val transpose = BlockMatrixBroadcast(read, FastIndexedSeq(1, 0), FastIndexedSeq(2, 2), 2)
     val dot = BlockMatrixDot(read, transpose)
 
     val blockMatrixIRs = Array[BlockMatrixIR](read, transpose, dot)
@@ -1723,7 +1723,7 @@ class IRSuite extends SparkSuite {
 
     def test(x: IR, i: java.lang.Boolean, expectedEvaluations: Int) {
       val env = Env.empty[(Any, Type)]
-      val args = IndexedSeq((i, TBoolean()))
+      val args = FastIndexedSeq((i, TBoolean()))
 
       IRSuite.globalCounter = 0
       Interpret[Any](x, env, args, None, optimize = false)
@@ -1883,8 +1883,8 @@ class IRSuite extends SparkSuite {
   @Test def testTableGetGlobalsSimplifyRules() {
     implicit val execStrats = ExecStrategy.interpretOnly
 
-    val t1 = TableType(TStruct("a" -> TInt32()), IndexedSeq("a"), TStruct("g1" -> TInt32(), "g2" -> TFloat64()))
-    val t2 = TableType(TStruct("a" -> TInt32()), IndexedSeq("a"), TStruct("g3" -> TInt32(), "g4" -> TFloat64()))
+    val t1 = TableType(TStruct("a" -> TInt32()), FastIndexedSeq("a"), TStruct("g1" -> TInt32(), "g2" -> TFloat64()))
+    val t2 = TableType(TStruct("a" -> TInt32()), FastIndexedSeq("a"), TStruct("g3" -> TInt32(), "g4" -> TFloat64()))
     val tab1 = TableLiteral(TableValue(t1, BroadcastRow(Row(1, 1.1), t1.globalType, sc), RVD.empty(sc, t1.canonicalRVDType)))
     val tab2 = TableLiteral(TableValue(t2, BroadcastRow(Row(2, 2.2), t2.globalType, sc), RVD.empty(sc, t2.canonicalRVDType)))
 

--- a/hail/src/test/scala/is/hail/expr/ir/LocusFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/LocusFunctionsSuite.scala
@@ -4,7 +4,7 @@ import is.hail.ExecStrategy
 import is.hail.SparkSuite
 import is.hail.TestUtils.assertEvalsTo
 import is.hail.expr.types.virtual.{TArray, TString}
-import is.hail.utils.FastSeq
+import is.hail.utils.{FastIndexedSeq, FastSeq}
 import is.hail.variant.{Locus, RGBase, ReferenceGenome}
 import org.apache.spark.sql.Row
 import org.testng.annotations.Test
@@ -61,7 +61,7 @@ class LocusFunctionsSuite extends SparkSuite {
 
   @Test def minRep() {
     val alleles = MakeArray(Seq(Str("AA"), Str("AT")), TArray(TString()))
-    assertEvalsTo(invoke("min_rep", locusIR, alleles), Row(Locus("chr22", 2), IndexedSeq("A", "T")))
+    assertEvalsTo(invoke("min_rep", locusIR, alleles), Row(Locus("chr22", 2), FastIndexedSeq("A", "T")))
     assertEvalsTo(invoke("min_rep", locusIR, NA(TArray(TString()))), null)
   }
   

--- a/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
@@ -157,7 +157,7 @@ class MatrixIRSuite extends SparkSuite {
       "animal" -> TString(),
       "__entries" -> TArray(TStruct("ent1" -> TString(), "ent2" -> TFloat64()))
     )
-    val keyNames = IndexedSeq("row_idx")
+    val keyNames = FastIndexedSeq("row_idx")
 
     val colSig = TStruct("col_idx" -> TInt32(), "tag" -> TString())
 
@@ -166,9 +166,9 @@ class MatrixIRSuite extends SparkSuite {
 
   @Test def testCastTableToMatrix() {
     val rdata = Array(
-      Row(1, "fish", IndexedSeq(Row("a", 1.0), Row("x", 2.0))),
-      Row(2, "cat", IndexedSeq(Row("b", 0.0), Row("y", 0.1))),
-      Row(3, "dog", IndexedSeq(Row("c", -1.0), Row("z", 30.0)))
+      Row(1, "fish", FastIndexedSeq(Row("a", 1.0), Row("x", 2.0))),
+      Row(2, "cat", FastIndexedSeq(Row("b", 0.0), Row("y", 0.1))),
+      Row(3, "dog", FastIndexedSeq(Row("c", -1.0), Row("z", 30.0)))
     )
     val cdata = Array(
       Row(1, "atag"),
@@ -195,9 +195,9 @@ class MatrixIRSuite extends SparkSuite {
 
   @Test def testCastTableToMatrixErrors() {
     val rdata = Array(
-      Row(1, "fish", IndexedSeq(Row("x", 2.0))),
-      Row(2, "cat", IndexedSeq(Row("b", 0.0), Row("y", 0.1))),
-      Row(3, "dog", IndexedSeq(Row("c", -1.0), Row("z", 30.0)))
+      Row(1, "fish", FastIndexedSeq(Row("x", 2.0))),
+      Row(2, "cat", FastIndexedSeq(Row("b", 0.0), Row("y", 0.1))),
+      Row(3, "dog", FastIndexedSeq(Row("c", -1.0), Row("z", 30.0)))
     )
     val cdata = Array(
       Row(1, "atag"),
@@ -219,8 +219,8 @@ class MatrixIRSuite extends SparkSuite {
 
     val rdata2 = Array(
       Row(1, "fish", null),
-      Row(2, "cat", IndexedSeq(Row("b", 0.0), Row("y", 0.1))),
-      Row(3, "dog", IndexedSeq(Row("c", -1.0), Row("z", 30.0)))
+      Row(2, "cat", FastIndexedSeq(Row("b", 0.0), Row("y", 0.1))),
+      Row(3, "dog", FastIndexedSeq(Row("c", -1.0), Row("z", 30.0)))
     )
     val rowTab2 = makeLocalizedTable(rdata2, cdata)
     val mir2 = CastTableToMatrix(rowTab2.tir, "__entries", "__cols", Array("col_idx"))
@@ -297,7 +297,7 @@ class MatrixIRSuite extends SparkSuite {
 
   @Test def testMatrixMultiWrite() {
     // partitioning must be the same
-    val ranges = IndexedSeq(MatrixTable.range(hc, 15, 3, Some(10)), MatrixTable.range(hc, 15, 27, Some(10)))
+    val ranges = FastIndexedSeq(MatrixTable.range(hc, 15, 3, Some(10)), MatrixTable.range(hc, 15, 27, Some(10)))
     val path = tmpDir.createLocalTempFile()
     Interpret(MatrixMultiWrite(ranges.map(_.ast), MatrixNativeMultiWriter(path)))
     val read0 = MatrixTable.read(hc, path + "0.mt")
@@ -316,7 +316,7 @@ class MatrixIRSuite extends SparkSuite {
     val range = MatrixTable.range(hc, 10, 2, None)
     val path = tmpDir.createLocalTempFile()
     intercept[java.lang.IllegalArgumentException] {
-      val ir = MatrixMultiWrite(IndexedSeq(vcf.ast, range.ast), MatrixNativeMultiWriter(path))
+      val ir = MatrixMultiWrite(FastIndexedSeq(vcf.ast, range.ast), MatrixNativeMultiWriter(path))
     }
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -253,7 +253,7 @@ class OrderingSuite extends SparkSuite {
     }
     val p = Prop.forAll(compareGen) { case (tdict: TDict, dict: Map[Any, Any]@unchecked, testKey1) =>
       assertEvalsTo(invoke("get", In(0, tdict), In(1, -tdict.keyType)),
-        IndexedSeq(dict -> tdict,
+        FastIndexedSeq(dict -> tdict,
           testKey1 -> -tdict.keyType),
         dict.getOrElse(testKey1, null))
 
@@ -261,7 +261,7 @@ class OrderingSuite extends SparkSuite {
         val testKey2 = dict.keys.toSeq.head
         val expected2 = dict(testKey2)
         assertEvalsTo(invoke("get", In(0, tdict), In(1, -tdict.keyType)),
-          IndexedSeq(dict -> tdict,
+          FastIndexedSeq(dict -> tdict,
             testKey2 -> -tdict.keyType),
           expected2)
       }
@@ -397,7 +397,7 @@ class OrderingSuite extends SparkSuite {
     a: IndexedSeq[Any], a2: IndexedSeq[Any]) {
     val t = TArray(TFloat64())
 
-    val args = IndexedSeq(a -> t, a2 -> t)
+    val args = FastIndexedSeq(a -> t, a2 -> t)
 
     assertEvalSame(ApplyComparisonOp(EQ(t, t), In(0, t), In(1, t)), args)
     assertEvalSame(ApplyComparisonOp(EQWithNA(t, t), In(0, t), In(1, t)), args)
@@ -417,7 +417,7 @@ class OrderingSuite extends SparkSuite {
 
     val s = if (a != null) a.toSet else null
     val s2 = if (a2 != null) a2.toSet else null
-    val args = IndexedSeq(s -> t, s2 -> t)
+    val args = FastIndexedSeq(s -> t, s2 -> t)
 
     assertEvalSame(ApplyComparisonOp(EQ(t, t), In(0, t), In(1, t)), args)
     assertEvalSame(ApplyComparisonOp(EQWithNA(t, t), In(0, t), In(1, t)), args)
@@ -434,7 +434,7 @@ class OrderingSuite extends SparkSuite {
   def rowDoubleOrderingData(): Array[Array[Any]] = {
     val xs = Array[Any](null, Double.NegativeInfinity, -0.0, 0.0, 1.0, Double.PositiveInfinity, Double.NaN)
     val as = Array(null: IndexedSeq[Any]) ++
-      (for (x <- xs) yield IndexedSeq[Any](x))
+      (for (x <- xs) yield FastIndexedSeq[Any](x))
     val ss = Array[Any](null, "a", "aa")
 
     val rs = for (x <- xs; s <- ss)
@@ -449,7 +449,7 @@ class OrderingSuite extends SparkSuite {
     r: Row, r2: Row) {
     val t = TStruct("x" -> TFloat64(), "s" -> TString())
 
-    val args = IndexedSeq(r -> t, r2 -> t)
+    val args = FastIndexedSeq(r -> t, r2 -> t)
 
     assertEvalSame(ApplyComparisonOp(EQ(t, t), In(0, t), In(1, t)), args)
     assertEvalSame(ApplyComparisonOp(EQWithNA(t, t), In(0, t), In(1, t)), args)

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -523,7 +523,7 @@ class PruneSuite extends SparkSuite {
   }
 
   @Test def testArrayFlatMapMemo() {
-    checkMemo(ArrayFlatMap(arr, "foo", MakeArray(IndexedSeq(Ref("foo", ref.typ)), TArray(ref.typ))),
+    checkMemo(ArrayFlatMap(arr, "foo", MakeArray(FastIndexedSeq(Ref("foo", ref.typ)), TArray(ref.typ))),
       TArray(justA),
       Array(TArray(justA), null))
   }

--- a/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
@@ -59,9 +59,9 @@ class SimplifySuite extends SparkSuite {
   }
 
   @Test def testBlockMatrixRewriteRules() {
-    val bmir = ValueToBlockMatrix(MakeArray(IndexedSeq(F64(1), F64(2), F64(3), F64(4)), TArray(TFloat64())),
-      IndexedSeq(2, 2), 10)
-    val identityBroadcast = BlockMatrixBroadcast(bmir, IndexedSeq(0, 1), IndexedSeq(2, 2), 10)
+    val bmir = ValueToBlockMatrix(MakeArray(FastIndexedSeq(F64(1), F64(2), F64(3), F64(4)), TArray(TFloat64())),
+      FastIndexedSeq(2, 2), 10)
+    val identityBroadcast = BlockMatrixBroadcast(bmir, FastIndexedSeq(0, 1), FastIndexedSeq(2, 2), 10)
 
     assert(Simplify(identityBroadcast) == bmir)
   }

--- a/hail/src/test/scala/is/hail/expr/ir/StringSliceSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StringSliceSuite.scala
@@ -124,22 +124,22 @@ class StringSliceSuite extends SparkSuite {
   }
 
   @Test def testStringIndex() {
-    assertEvalsTo(invoke("[]", In(0, TString()), I32(0)), IndexedSeq("Baz" -> TString()), "B")
-    assertEvalsTo(invoke("[]", In(0, TString()), I32(1)), IndexedSeq("Baz" -> TString()), "a")
-    assertEvalsTo(invoke("[]", In(0, TString()), I32(2)), IndexedSeq("Baz" -> TString()), "z")
-    assertEvalsTo(invoke("[]", In(0, TString()), I32(-1)), IndexedSeq("Baz" -> TString()), "z")
-    assertEvalsTo(invoke("[]", In(0, TString()), I32(-2)), IndexedSeq("Baz" -> TString()), "a")
-    assertEvalsTo(invoke("[]", In(0, TString()), I32(-3)), IndexedSeq("Baz" -> TString()), "B")
+    assertEvalsTo(invoke("[]", In(0, TString()), I32(0)), FastIndexedSeq("Baz" -> TString()), "B")
+    assertEvalsTo(invoke("[]", In(0, TString()), I32(1)), FastIndexedSeq("Baz" -> TString()), "a")
+    assertEvalsTo(invoke("[]", In(0, TString()), I32(2)), FastIndexedSeq("Baz" -> TString()), "z")
+    assertEvalsTo(invoke("[]", In(0, TString()), I32(-1)), FastIndexedSeq("Baz" -> TString()), "z")
+    assertEvalsTo(invoke("[]", In(0, TString()), I32(-2)), FastIndexedSeq("Baz" -> TString()), "a")
+    assertEvalsTo(invoke("[]", In(0, TString()), I32(-3)), FastIndexedSeq("Baz" -> TString()), "B")
 
     interceptFatal("string index out of bounds") {
-      assertEvalsTo(invoke("[]", In(0, TString()), I32(3)), IndexedSeq("Baz" -> TString()), "B")
+      assertEvalsTo(invoke("[]", In(0, TString()), I32(3)), FastIndexedSeq("Baz" -> TString()), "B")
     }
     interceptFatal("string index out of bounds") {
-      assertEvalsTo(invoke("[]", In(0, TString()), I32(-4)), IndexedSeq("Baz" -> TString()), "B")
+      assertEvalsTo(invoke("[]", In(0, TString()), I32(-4)), FastIndexedSeq("Baz" -> TString()), "B")
     }
   }
 
   @Test def testStringCopy() {
-    assertEvalsTo(invoke("[:]", In(0, TString())), IndexedSeq("Baz" -> TString()), "Baz")
+    assertEvalsTo(invoke("[:]", In(0, TString())), FastIndexedSeq("Baz" -> TString()), "Baz")
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -16,7 +16,7 @@ class TableIRSuite extends SparkSuite {
     val data = Array(Array("Sample1", 9, 5), Array("Sample2", 3, 5), Array("Sample3", 2, 5), Array("Sample4", 1, 5))
     val rdd = sc.parallelize(data.map(Row.fromSeq(_)))
     val signature = TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32()))
-    val keyNames = IndexedSeq("Sample")
+    val keyNames = FastIndexedSeq("Sample")
 
     val kt = Table(hc, rdd, signature, keyNames)
     kt.typeCheck()
@@ -131,7 +131,7 @@ class TableIRSuite extends SparkSuite {
   val joinedType = TStruct(("A", TInt32()), ("B", TInt32()), ("C", TInt32()), ("B_1", TInt32()), ("C_1", TInt32()))
   val kType = TStruct(("A", TInt32()), ("B", TInt32()))
 
-  val leftData = IndexedSeq(
+  val leftData = FastIndexedSeq(
     (3, 1, -1),
     (3, 2, -1),
     (11, 1, -1),
@@ -158,7 +158,7 @@ class TableIRSuite extends SparkSuite {
     (37, 2, -1)
   ).map(Row.fromTuple)
 
-  val rightData = IndexedSeq(
+  val rightData = FastIndexedSeq(
     (6, 1, 1),
     (6, 2, 1),
     (17, 1, 1),
@@ -237,27 +237,27 @@ class TableIRSuite extends SparkSuite {
   ).map(Row.fromTuple)
 
   val leftPartitioners = Array(
-    IndexedSeq(
+    FastIndexedSeq(
       Interval(Row(0, 0), Row(4, 1), true, false),
       Interval(Row(10, -1), Row(19, 1), true, false),
       Interval(Row(20, 0), Row(24, 0), true, true),
       Interval(Row(25, 0), Row(39, 0), true, true))
-    //    IndexedSeq(
+    //    FastIndexedSeq(
     //      Interval(Row(0, 0), Row(10), true, false),
     //      Interval(Row(10), Row(44, 0), true, true)),
-    //    IndexedSeq(Interval(Row(), Row(), true, true))
+    //    FastIndexedSeq(Interval(Row(), Row(), true, true))
   ).map(new RVDPartitioner(kType, _))
 
   val rightPartitioners = Array(
-    IndexedSeq(
+    FastIndexedSeq(
       Interval(Row(5, 0), Row(9, 1), true, false),
       Interval(Row(15, -1), Row(29, 1), true, false),
       Interval(Row(30, 0), Row(34, 0), true, true),
       Interval(Row(35, 0), Row(44, 0), true, true))
-    //    IndexedSeq(
+    //    FastIndexedSeq(
     //      Interval(Row(0, 0), Row(10), true, false),
     //      Interval(Row(10), Row(44, 0), true, true)),
-    //    IndexedSeq(Interval(Row(), Row(), true, true))
+    //    FastIndexedSeq(Interval(Row(), Row(), true, true))
   ).map(new RVDPartitioner(kType, _))
 
   val joinTypes = Array(
@@ -295,7 +295,7 @@ class TableIRSuite extends SparkSuite {
           TStruct("rows" -> TArray(leftType), "global" -> TStruct()),
           Row(leftData.map(leftProjectF.asInstanceOf[Row => Row]), Row())),
         Some(1)),
-      if (!leftProject.contains(1)) IndexedSeq("A", "B") else IndexedSeq("A")))
+      if (!leftProject.contains(1)) FastIndexedSeq("A", "B") else FastIndexedSeq("A")))
     val partitionedLeft = left.copy2(
       rvd = left.value.rvd
         .repartition(if (!leftProject.contains(1)) leftPart else leftPart.coarsen(1)))
@@ -307,7 +307,7 @@ class TableIRSuite extends SparkSuite {
           TStruct("rows" -> TArray(rightType), "global" -> TStruct()),
           Row(rightData.map(rightProjectF.asInstanceOf[Row => Row]), Row())),
         Some(1)),
-      if (!rightProject.contains(1)) IndexedSeq("A", "B") else IndexedSeq("A")))
+      if (!rightProject.contains(1)) FastIndexedSeq("A", "B") else FastIndexedSeq("A")))
     val partitionedRight = right.copy2(
       rvd = right.value.rvd
         .repartition(if (!rightProject.contains(1)) rightPart else rightPart.coarsen(1)))
@@ -332,10 +332,10 @@ class TableIRSuite extends SparkSuite {
     val data = Array(Array("A", 1), Array("A", 2), Array("B", 1))
     val rdd = sc.parallelize(data.map(Row.fromSeq(_)))
     val signature = TStruct(("field1", TString()), ("field2", TInt32()))
-    val keyNames = IndexedSeq("field1", "field2")
+    val keyNames = FastIndexedSeq("field1", "field2")
     val kt = Table(hc, rdd, signature, keyNames)
     val distinctCount = TableCount(TableDistinct(TableLiteral(
-      kt.value.copy(typ = kt.typ.copy(key = IndexedSeq("field1")))
+      kt.value.copy(typ = kt.typ.copy(key = FastIndexedSeq("field1")))
     )))
     assertEvalsTo(distinctCount, 2L)
   }
@@ -343,7 +343,7 @@ class TableIRSuite extends SparkSuite {
   @Test def testTableParallelize() {
     implicit val execStrats = ExecStrategy.interpretOnly
     val t = TStruct("rows" -> TArray(TStruct("a" -> TInt32(), "b" -> TString())), "global" -> TStruct("x" -> TString()))
-    val value = Row(IndexedSeq(Row(0, "row1"), Row(1, "row2")), Row("glob"))
+    val value = Row(FastIndexedSeq(Row(0, "row1"), Row(1, "row2")), Row("glob"))
 
     assertEvalsTo(
       TableCollect(
@@ -398,7 +398,7 @@ class TableIRSuite extends SparkSuite {
       "name" -> TString(),
       "data" -> TFloat64()
     )
-    val key = IndexedSeq("id")
+    val key = FastIndexedSeq("id")
     val d1 = sc.parallelize(Array(
       Array(0, "a", 0.0),
       Array(1, "b", 3.14),
@@ -415,7 +415,7 @@ class TableIRSuite extends SparkSuite {
     val t2 = Table(hc, d2, rowSig, key)
     val t3 = Table(hc, d3, rowSig, key)
 
-    val testIr = TableMultiWayZipJoin(IndexedSeq(t1, t2, t3).map(_.tir), "__data", "__globals")
+    val testIr = TableMultiWayZipJoin(FastIndexedSeq(t1, t2, t3).map(_.tir), "__data", "__globals")
     val testTable = new Table(hc, testIr)
 
     val expectedSchema = TStruct(
@@ -425,13 +425,13 @@ class TableIRSuite extends SparkSuite {
         "data" -> TFloat64()))
     )
     val globalSig = TStruct("__globals" -> TArray(TStruct()))
-    val globalData = Row.fromSeq(Array(IndexedSeq(Array[Any](), Array[Any](), Array[Any]()).map(Row.fromSeq(_))))
+    val globalData = Row.fromSeq(Array(FastIndexedSeq(Array[Any](), Array[Any](), Array[Any]()).map(Row.fromSeq(_))))
     val expectedData = sc.parallelize(Array(
-      Array(0, IndexedSeq(Row.fromSeq(Array("a", 0.0)), Row.fromSeq(Array("d", 1.1)), null)),
-      Array(0, IndexedSeq(null, Row.fromSeq(Array("x", 2.2)), null)),
-      Array(1, IndexedSeq(Row.fromSeq(Array("b", 3.14)), null, Row.fromSeq(Array("f", 9.99)))),
-      Array(2, IndexedSeq(Row.fromSeq(Array("c", 2.78)), Row.fromSeq(Array("v", 7.89)), Row.fromSeq(Array("g", -1.0)))),
-      Array(3, IndexedSeq(null, null, Row.fromSeq(Array("z", 0.01))))
+      Array(0, FastIndexedSeq(Row.fromSeq(Array("a", 0.0)), Row.fromSeq(Array("d", 1.1)), null)),
+      Array(0, FastIndexedSeq(null, Row.fromSeq(Array("x", 2.2)), null)),
+      Array(1, FastIndexedSeq(Row.fromSeq(Array("b", 3.14)), null, Row.fromSeq(Array("f", 9.99)))),
+      Array(2, FastIndexedSeq(Row.fromSeq(Array("c", 2.78)), Row.fromSeq(Array("v", 7.89)), Row.fromSeq(Array("g", -1.0)))),
+      Array(3, FastIndexedSeq(null, null, Row.fromSeq(Array("z", 0.01))))
     ).map(Row.fromSeq(_)))
     val expectedTable = Table(hc, expectedData, expectedSchema, key, globalSig, globalData)
     assert(testTable.same(expectedTable))
@@ -442,7 +442,7 @@ class TableIRSuite extends SparkSuite {
     val t1 = TableMapGlobals(TableRange(10, 1), MakeStruct(Seq("x" -> I32(5))))
     val t2 = TableMapGlobals(TableRange(10, 1), MakeStruct(Seq("x" -> I32(0))))
     val t3 = TableMapGlobals(TableRange(10, 1), MakeStruct(Seq("x" -> NA(TInt32()))))
-    val testIr = TableMultiWayZipJoin(IndexedSeq(t1, t2, t3), "__data", "__globals")
+    val testIr = TableMultiWayZipJoin(FastIndexedSeq(t1, t2, t3), "__data", "__globals")
     val testTable = new Table(hc, testIr)
     val texp = new Table(hc, TableMapGlobals(
       TableRange(10, 1),

--- a/hail/src/test/scala/is/hail/methods/ConcordanceSuite.scala
+++ b/hail/src/test/scala/is/hail/methods/ConcordanceSuite.scala
@@ -26,12 +26,12 @@ class ConcordanceSuite extends SparkSuite {
     comb.merge(0, 4)
     comb.merge(2, 0)
 
-    assert(comb.toAnnotation == IndexedSeq(
-      IndexedSeq(0L, 0L, 0L, 0L, 1L),
-      IndexedSeq(0L, 0L, 0L, 4L, 0L),
-      IndexedSeq(1L, 0L, 0L, 0L, 0L),
-      IndexedSeq(0L, 0L, 0L, 0L, 0L),
-      IndexedSeq(0L, 0L, 0L, 0L, 0L)
+    assert(comb.toAnnotation == FastIndexedSeq(
+      FastIndexedSeq(0L, 0L, 0L, 0L, 1L),
+      FastIndexedSeq(0L, 0L, 0L, 4L, 0L),
+      FastIndexedSeq(1L, 0L, 0L, 0L, 0L),
+      FastIndexedSeq(0L, 0L, 0L, 0L, 0L),
+      FastIndexedSeq(0L, 0L, 0L, 0L, 0L)
     ))
 
     val comb2 = new ConcordanceCombiner
@@ -54,12 +54,12 @@ class ConcordanceSuite extends SparkSuite {
     comb2.merge(4, 1)
     comb2.merge(4, 1)
 
-    assert(comb2.toAnnotation == IndexedSeq(
-      IndexedSeq(0L, 0L, 1L, 2L, 0L),
-      IndexedSeq(2L, 0L, 0L, 2L, 0L),
-      IndexedSeq(0L, 0L, 0L, 0L, 0L),
-      IndexedSeq(0L, 2L, 0L, 2L, 0L),
-      IndexedSeq(3L, 3L, 0L, 0L, 0L)
+    assert(comb2.toAnnotation == FastIndexedSeq(
+      FastIndexedSeq(0L, 0L, 1L, 2L, 0L),
+      FastIndexedSeq(2L, 0L, 0L, 2L, 0L),
+      FastIndexedSeq(0L, 0L, 0L, 0L, 0L),
+      FastIndexedSeq(0L, 2L, 0L, 2L, 0L),
+      FastIndexedSeq(3L, 3L, 0L, 0L, 0L)
     ))
 
     assert(comb2.nDiscordant == 0)

--- a/hail/src/test/scala/is/hail/methods/LocalLDPruneSuite.scala
+++ b/hail/src/test/scala/is/hail/methods/LocalLDPruneSuite.scala
@@ -62,7 +62,7 @@ object LocalLDPruneSuite {
     rvb.start(rvRowType.physicalType)
     rvb.startStruct()
     rvb.addAnnotation(rvRowType.types(0), Locus("1", 1))
-    rvb.addAnnotation(rvRowType.types(1), IndexedSeq("A", "T"))
+    rvb.addAnnotation(rvRowType.types(1), FastIndexedSeq("A", "T"))
     rvb.addAnnotation(TArray(Genotype.htsGenotypeType), gArr)
     rvb.endStruct()
     rvb.end()
@@ -95,7 +95,7 @@ object LocalLDPruneSuite {
     rvb.start(bitPackedVectorViewType)
     rvb.startStruct()
     rvb.addAnnotation(rvRowType.types(0), Locus("1", 1))
-    rvb.addAnnotation(rvRowType.types(1), IndexedSeq("A", "T"))
+    rvb.addAnnotation(rvRowType.types(1), FastIndexedSeq("A", "T"))
     val keep = LocalLDPrune.addBitPackedVector(rvb, hcView, nSamples)
 
     if (keep) {

--- a/hail/src/test/scala/is/hail/methods/TableSuite.scala
+++ b/hail/src/test/scala/is/hail/methods/TableSuite.scala
@@ -16,7 +16,7 @@ class TableSuite extends SparkSuite {
     val data = Array(Array("Sample1", 9, 5), Array("Sample2", 3, 5), Array("Sample3", 2, 5), Array("Sample4", 1, 5))
     val rdd = sc.parallelize(data.map(Row.fromSeq(_)))
     val signature = TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32()))
-    val keyNames = IndexedSeq("Sample")
+    val keyNames = FastIndexedSeq("Sample")
 
     val kt = Table(hc, rdd, signature, keyNames)
     kt.typeCheck()
@@ -24,22 +24,25 @@ class TableSuite extends SparkSuite {
   }
 
   def sampleKT2: Table = {
-    val data = Array(Array("Sample1", IndexedSeq(9, 1), 5), Array("Sample2", IndexedSeq(3), 5),
-      Array("Sample3", IndexedSeq(2, 3, 4), 5), Array("Sample4", IndexedSeq.empty[Int], 5))
+    val data = Array(Array("Sample1", FastIndexedSeq(9, 1), 5), Array("Sample2", FastIndexedSeq(3), 5),
+      Array("Sample3", FastIndexedSeq(2, 3, 4), 5), Array("Sample4", FastIndexedSeq.empty[Int], 5))
     val rdd = sc.parallelize(data.map(Row.fromSeq(_)))
     val signature = TStruct(("Sample", TString()), ("field1", TArray(TInt32())), ("field2", TInt32()))
-    val keyNames = IndexedSeq("Sample")
+    val keyNames = FastIndexedSeq("Sample")
     val kt = Table(hc, rdd, signature, keyNames)
     kt.typeCheck()
     kt
   }
 
   def sampleKT3: Table = {
-    val data = Array(Array("Sample1", IndexedSeq(IndexedSeq(9, 10), IndexedSeq(1)), IndexedSeq(5, 6)), Array("Sample2", IndexedSeq(IndexedSeq(3), IndexedSeq.empty[Int]), IndexedSeq(5, 3)),
-      Array("Sample3", IndexedSeq(IndexedSeq(2, 3, 4), IndexedSeq(3), IndexedSeq(4, 10)), IndexedSeq.empty[Int]), Array("Sample4", IndexedSeq.empty[Int], IndexedSeq(5)))
+    val data = Array(
+      Array("Sample1", FastIndexedSeq(FastIndexedSeq(9, 10), FastIndexedSeq(1)), FastIndexedSeq(5, 6)),
+      Array("Sample2", FastIndexedSeq(FastIndexedSeq(3), FastIndexedSeq.empty[Int]), FastIndexedSeq(5, 3)),
+      Array("Sample3", FastIndexedSeq(FastIndexedSeq(2, 3, 4), FastIndexedSeq(3), FastIndexedSeq(4, 10)),
+        FastIndexedSeq.empty[Int]), Array("Sample4", FastIndexedSeq.empty[Int], FastIndexedSeq(5)))
     val rdd = sc.parallelize(data.map(Row.fromSeq(_)))
     val signature = TStruct(("Sample", TString()), ("field1", TArray(TArray(TInt32()))), ("field2", TArray(TInt32())))
-    val keyNames = IndexedSeq("Sample")
+    val keyNames = FastIndexedSeq("Sample")
     val kt = Table(hc, rdd, signature, keyNames)
     kt.typeCheck()
     kt
@@ -97,7 +100,7 @@ class TableSuite extends SparkSuite {
     val resRDD2 = sc.parallelize(result2.map(Row.fromSeq(_)))
     val ktResult2 = Table(hc, resRDD2,
       TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32())),
-      key = IndexedSeq("Sample"))
+      key = FastIndexedSeq("Sample"))
     ktResult2.typeCheck()
 
     val result3 = Array(Array("Sample1", 9, 5), Array("Sample1", 10, 5), Array("Sample1", 9, 6), Array("Sample1", 10, 6),
@@ -105,7 +108,7 @@ class TableSuite extends SparkSuite {
     val resRDD3 = sc.parallelize(result3.map(Row.fromSeq(_)))
     val ktResult3 = Table(hc, resRDD3,
       TStruct(("Sample", TString()), ("field1", TInt32()), ("field2", TInt32())),
-      key = IndexedSeq("Sample"))
+      key = FastIndexedSeq("Sample"))
     ktResult3.typeCheck()
 
     assert(ktResult2.same(kt2.explode(Array("field1"))))

--- a/hail/src/test/scala/is/hail/rvd/RVDPartitionerSuite.scala
+++ b/hail/src/test/scala/is/hail/rvd/RVDPartitionerSuite.scala
@@ -3,7 +3,7 @@ package is.hail.rvd
 import is.hail.annotations.UnsafeIndexedSeq
 import is.hail.expr.types._
 import is.hail.expr.types.virtual.{TInt32, TStruct}
-import is.hail.utils.Interval
+import is.hail.utils.{FastIndexedSeq, Interval}
 import org.apache.spark.sql.Row
 import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.Test
@@ -138,13 +138,13 @@ class RVDPartitionerSuite extends TestNGSuite {
     val intervals1 = Array(Interval(Row(), Row(), true, true))
     val intervals5 = Array.fill(5)(Interval(Row(), Row(), true, true))
 
-    val p5 = RVDPartitioner.generate(IndexedSeq(), TStruct.empty(), intervals5)
+    val p5 = RVDPartitioner.generate(FastIndexedSeq(), TStruct.empty(), intervals5)
     assert(p5.rangeBounds sameElements intervals1)
 
-    val p1 = RVDPartitioner.generate(IndexedSeq(), TStruct.empty(), intervals1)
+    val p1 = RVDPartitioner.generate(FastIndexedSeq(), TStruct.empty(), intervals1)
     assert(p1.rangeBounds sameElements intervals1)
 
-    val p0 = RVDPartitioner.generate(IndexedSeq(), TStruct.empty(), IndexedSeq())
+    val p0 = RVDPartitioner.generate(FastIndexedSeq(), TStruct.empty(), FastIndexedSeq())
     assert(p0.rangeBounds.isEmpty)
   }
 

--- a/hail/src/test/scala/is/hail/stats/StatsSuite.scala
+++ b/hail/src/test/scala/is/hail/stats/StatsSuite.scala
@@ -58,7 +58,7 @@ class StatsSuite extends SparkSuite {
 
     vds.variantRDD.collect().foreach{ case (v, (va, gs)) => gs.zipWithIndex.foreach { case (g, i) => G1(i, v.start - 1) = Genotype.call(g).map(Call.nNonRefAlleles).getOrElse(-1) } }
 
-    assert(vds.stringSampleIds == IndexedSeq("0", "1", "2"))
+    assert(vds.stringSampleIds == FastIndexedSeq("0", "1", "2"))
     assert(vds.variants.collect().toSet == Set(Variant("1", 1, "A", "C"), Variant("1", 2, "A", "C")))
 
     for (i <- 0 to 2)

--- a/hail/src/test/scala/is/hail/utils/RowIntervalSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/RowIntervalSuite.scala
@@ -6,7 +6,7 @@ import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.Test
 
 class RowIntervalSuite extends TestNGSuite {
-  val pord = TTuple(IndexedSeq(TInt32(), TInt32(), TInt32())).ordering
+  val pord = TTuple(FastIndexedSeq(TInt32(), TInt32(), TInt32())).ordering
 
   @Test def testContains() {
     assert(Interval(Row(0, 1, 5), Row(1, 2, 4), true, true).contains(pord, Row(1, 1, 3)))

--- a/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -10,6 +10,7 @@ import is.hail.rvd.RVD
 import is.hail.table.Table
 import is.hail.variant.MatrixTable
 import is.hail.testUtils._
+import is.hail.utils.FastIndexedSeq
 import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
@@ -28,7 +29,7 @@ class PartitioningSuite extends SparkSuite {
   }
 
   @Test def testShuffleOnEmptyRDD() {
-    val typ = TableType(TStruct("tidx" -> TInt32()), IndexedSeq("tidx"), TStruct.empty())
+    val typ = TableType(TStruct("tidx" -> TInt32()), FastIndexedSeq("tidx"), TStruct.empty())
     val t = TableLiteral(TableValue(
       typ, BroadcastRow(Row.empty, TStruct.empty(), sc), RVD.empty(sc, typ.canonicalRVDType)))
     val rangeReader = ir.MatrixRangeReader(100, 10, Some(10))


### PR DESCRIPTION
We must be vigilant against these intruders.