### PR TITLE
add parallelized write block matrices functions

### DIFF
--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -174,7 +174,7 @@ compileScala {
     scalaCompileOptions.forkOptions.with {
         jvmArgs = ["-Xms512M",
                    "-Xmx4096M",
-                   "-Xss2M",
+                   "-Xss4M",
                    "-XX:MaxMetaspaceSize=1024M"]
     }
 }

--- a/hail/python/hail/experimental/__init__.py
+++ b/hail/python/hail/experimental/__init__.py
@@ -7,7 +7,7 @@ from .plots import hail_metadata, plot_roc_curve
 from .phase_by_transmission import *
 from .datasets import load_dataset
 from .import_gtf import import_gtf, get_gene_intervals
-from .write_multiple import write_matrix_tables
+from .write_multiple import write_matrix_tables, block_matrices_tofiles, export_block_matrices
 from .export_entries_by_col import export_entries_by_col
 from .densify import densify
 from .sparse_split_multi import sparse_split_multi
@@ -30,6 +30,8 @@ __all__ = ['ld_score',
            'get_gene_intervals',
            'haplotype_freq_em',
            'write_matrix_tables',
+           'block_matrices_tofiles',
+           'export_block_matrices',
            'export_entries_by_col',
            'densify',
            'sparse_split_multi',

--- a/hail/python/hail/experimental/write_multiple.py
+++ b/hail/python/hail/experimental/write_multiple.py
@@ -1,9 +1,9 @@
-from typing import List
+from typing import List, Optional
 
 from hail import MatrixTable
 from hail.linalg import BlockMatrix
-from hail.ir import MatrixMultiWrite, MatrixNativeMultiWriter
-from hail.typecheck import sequenceof, typecheck
+from hail.ir import MatrixMultiWrite, MatrixNativeMultiWriter, BlockMatrixMultiWrite, BlockMatrixBinaryMultiWriter, BlockMatrixTextMultiWriter
+from hail.typecheck import nullable, sequenceof, typecheck
 from hail.utils.java import Env
 
 @typecheck(mts=sequenceof(MatrixTable),
@@ -15,12 +15,20 @@ def write_matrix_tables(mts: List[MatrixTable], prefix: str, overwrite: bool = F
     writer = MatrixNativeMultiWriter(prefix, overwrite, stage_locally)
     Env.backend().execute(MatrixMultiWrite([mt._mir for mt in mts], writer))
 
-@typecheck(mts=sequenceof(BlockMatrix),
+@typecheck(bms=sequenceof(BlockMatrix),
+           prefix=str,
+           overwrite=bool)
+def block_matrices_tofiles(bms: List[BlockMatrix], prefix: str, overwrite: bool = False):
+    writer = BlockMatrixBinaryMultiWriter(prefix, overwrite)
+    Env.backend().execute(BlockMatrixMultiWrite([bm._bmir for bm in bms], writer))
+
+@typecheck(bms=sequenceof(BlockMatrix),
            prefix=str,
            overwrite=bool,
-           force_row_major=bool,
-           stage_locally=bool)
-def write_block_matrices(bms: List[BlockMatrix], prefix: str, overwrite: bool = False,
-                         force_row_major: bool = False, stage_locally: bool = False):
-    writer = BlockMatrixNativeWriter(prefix, overwrite, force_row_major, stage_locally)
-    Env.backend().execute(MatrixMultiWrite([bm._bmir for bm in bms], writer))
+           delimiter=str,
+           header=nullable(str),
+           add_index=bool)
+def export_block_matrices(bms: List[BlockMatrix], prefix: str, overwrite: bool = False,
+                          delimiter: str = '\t', header: Optional[str] = None,  add_index: bool = False):
+    writer = BlockMatrixTextMultiWriter(prefix, overwrite, delimiter, header, add_index)
+    Env.backend().execute(BlockMatrixMultiWrite([bm._bmir for bm in bms], writer))

--- a/hail/python/hail/experimental/write_multiple.py
+++ b/hail/python/hail/experimental/write_multiple.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from hail import MatrixTable
+from hail.linalg import BlockMatrix
 from hail.ir import MatrixMultiWrite, MatrixNativeMultiWriter
 from hail.typecheck import sequenceof, typecheck
 from hail.utils.java import Env
@@ -13,3 +14,13 @@ def write_matrix_tables(mts: List[MatrixTable], prefix: str, overwrite: bool = F
                         stage_locally: bool = False):
     writer = MatrixNativeMultiWriter(prefix, overwrite, stage_locally)
     Env.backend().execute(MatrixMultiWrite([mt._mir for mt in mts], writer))
+
+@typecheck(mts=sequenceof(BlockMatrix),
+           prefix=str,
+           overwrite=bool,
+           force_row_major=bool,
+           stage_locally=bool)
+def write_block_matrices(bms: List[BlockMatrix], prefix: str, overwrite: bool = False,
+                         force_row_major: bool = False, stage_locally: bool = False):
+    writer = BlockMatrixNativeWriter(prefix, overwrite, force_row_major, stage_locally)
+    Env.backend().execute(MatrixMultiWrite([bm._bmir for bm in bms], writer))

--- a/hail/python/hail/ir/blockmatrix_writer.py
+++ b/hail/python/hail/ir/blockmatrix_writer.py
@@ -79,3 +79,37 @@ class BlockMatrixRectanglesWriter(BlockMatrixWriter):
                self.rectangles == other.rectangles and \
                self.delimiter == other.delimiter and \
                self.binary == other.binary
+
+
+class BlockMatrixWriter(object):
+    @abc.abstractmethod
+    def render(self):
+        pass
+
+    @abc.abstractmethod
+    def __eq__(self, other):
+        pass
+
+
+class BlockMatrixNativeMultiWriter(BlockMatrixMultiWriter):
+    @typecheck_method(prefix=str, overwrite=bool, force_row_major=bool, stage_locally=bool)
+    def __init__(self, prefix, overwrite, force_row_major, stage_locally):
+        self.prefix = prefix
+        self.overwrite = overwrite
+        self.force_row_major = force_row_major
+        self.stage_locally = stage_locally
+
+    def render(self):
+        writer = {'name': 'BlockMatrixNativeMultiWriter',
+                  'prefix': self.prefix,
+                  'overwrite': self.overwrite,
+                  'forceRowMajor': self.force_row_major,
+                  'stageLocally': self.stage_locally}
+        return escape_str(json.dumps(writer))
+
+    def __eq__(self, other):
+        return isinstance(other, BlockMatrixNativeMultiWriter) and \
+               self.prefix == other.prefix and \
+               self.overwrite == other.overwrite and \
+               self.force_row_major == other.force_row_major and \
+               self.stage_locally == other.stage_locally

--- a/hail/python/hail/ir/blockmatrix_writer.py
+++ b/hail/python/hail/ir/blockmatrix_writer.py
@@ -81,7 +81,7 @@ class BlockMatrixRectanglesWriter(BlockMatrixWriter):
                self.binary == other.binary
 
 
-class BlockMatrixWriter(object):
+class BlockMatrixMultiWriter(object):
     @abc.abstractmethod
     def render(self):
         pass
@@ -91,25 +91,46 @@ class BlockMatrixWriter(object):
         pass
 
 
-class BlockMatrixNativeMultiWriter(BlockMatrixMultiWriter):
-    @typecheck_method(prefix=str, overwrite=bool, force_row_major=bool, stage_locally=bool)
-    def __init__(self, prefix, overwrite, force_row_major, stage_locally):
+class BlockMatrixBinaryMultiWriter(BlockMatrixMultiWriter):
+    @typecheck_method(prefix=str, overwrite=bool)
+    def __init__(self, prefix, overwrite):
         self.prefix = prefix
         self.overwrite = overwrite
-        self.force_row_major = force_row_major
-        self.stage_locally = stage_locally
 
     def render(self):
-        writer = {'name': 'BlockMatrixNativeMultiWriter',
+        writer = {'name': 'BlockMatrixBinaryMultiWriter',
                   'prefix': self.prefix,
-                  'overwrite': self.overwrite,
-                  'forceRowMajor': self.force_row_major,
-                  'stageLocally': self.stage_locally}
+                  'overwrite': self.overwrite}
         return escape_str(json.dumps(writer))
 
     def __eq__(self, other):
         return isinstance(other, BlockMatrixNativeMultiWriter) and \
                self.prefix == other.prefix and \
+               self.overwrite == other.overwrite
+
+
+class BlockMatrixTextMultiWriter(BlockMatrixMultiWriter):
+    @typecheck_method(prefix=str, overwrite=bool, delimiter=str, header=nullable(str), add_index=bool)
+    def __init__(self, prefix, overwrite, delimiter, header, add_index):
+        self.prefix = prefix
+        self.overwrite = overwrite
+        self.delimiter = delimiter
+        self.header = header
+        self.add_index = add_index
+
+    def render(self):
+        writer = {'name': 'BlockMatrixTextMultiWriter',
+                  'prefix': self.prefix,
+                  'overwrite': self.overwrite,
+                  'delimiter': self.delimiter,
+                  'header': self.header,
+                  'addIndex': self.add_index}
+        return escape_str(json.dumps(writer))
+
+    def __eq__(self, other):
+        return isinstance(other, BlockMatrixTextMultiWriter) and \
+               self.prefix == other.prefix and \
                self.overwrite == other.overwrite and \
-               self.force_row_major == other.force_row_major and \
-               self.stage_locally == other.stage_locally
+               self.delimiter == other.overwrite and \
+               self.header == other.header and \
+               self.add_index == other.add_index

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1562,6 +1562,27 @@ class BlockMatrixWrite(IR):
         self._type = tvoid
 
 
+class BlockMatrixMultiWrite(IR):
+    @typecheck_method(block_matrices=sequenceof(BlockMatrixIR), writer=BlockMatrixWriter)
+    def __init__(self, child, writer):
+        super().__init__(child)
+        self.block_matrices = block_matrices
+        self.writer = writer
+
+    def copy(self, *block_matrices):
+        return BlockMatrixWrite(block_matrices, self.writer)
+
+    def head_str(self):
+        return f'"{self.writer.render()}"'
+
+    def _eq(self, other):
+        return self.writer == other.writer
+
+    def _compute_type(self, env, agg_env):
+        self.child._compute_type()
+        self._type = tvoid
+
+
 class TableToValueApply(IR):
     def __init__(self, child, config):
         super().__init__(child)

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1,7 +1,7 @@
 import copy
 
 import hail
-from hail.ir.blockmatrix_writer import BlockMatrixWriter
+from hail.ir.blockmatrix_writer import BlockMatrixWriter, BlockMatrixMultiWriter
 from hail.utils.java import escape_str, escape_id, dump_json, parsable_strings
 from hail.expr.types import *
 from hail.typecheck import *
@@ -1563,9 +1563,9 @@ class BlockMatrixWrite(IR):
 
 
 class BlockMatrixMultiWrite(IR):
-    @typecheck_method(block_matrices=sequenceof(BlockMatrixIR), writer=BlockMatrixWriter)
-    def __init__(self, child, writer):
-        super().__init__(child)
+    @typecheck_method(block_matrices=sequenceof(BlockMatrixIR), writer=BlockMatrixMultiWriter)
+    def __init__(self, block_matrices, writer):
+        super().__init__(*block_matrices)
         self.block_matrices = block_matrices
         self.writer = writer
 

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1579,7 +1579,8 @@ class BlockMatrixMultiWrite(IR):
         return self.writer == other.writer
 
     def _compute_type(self, env, agg_env):
-        self.child._compute_type()
+        for x in self.block_matrices:
+            x._compute_type()
         self._type = tvoid
 
 

--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -306,8 +306,6 @@ class Tests(unittest.TestCase):
             hl.linalg.BlockMatrix._create(11, 12, data[0].tolist(), block_size=4),
             hl.linalg.BlockMatrix._create(5, 17, data[1].tolist(), block_size=8)
         ]
-        # prefix = new_local_temp_dir()
-        prefix = '/tmp/spaz'
         hl.experimental.block_matrices_tofiles(bms, f'{prefix}/files')
         for i in range(len(bms)):
             a = data[i]
@@ -327,8 +325,6 @@ class Tests(unittest.TestCase):
             hl.linalg.BlockMatrix._create(11, 12, data[0].tolist(), block_size=4),
             hl.linalg.BlockMatrix._create(5, 17, data[1].tolist(), block_size=8)
         ]
-        # prefix = new_local_temp_dir()
-        prefix = '/tmp/spaz'
         hl.experimental.export_block_matrices(bms, f'{prefix}/files')
         for i in range(len(bms)):
             a = arrs[i]

--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -328,5 +328,5 @@ class Tests(unittest.TestCase):
         hl.experimental.export_block_matrices(bms, f'{prefix}/files')
         for i in range(len(bms)):
             a = arrs[i]
-            a2 = np.loadtxt(f'{prefix}/files/{i}')
+            a2 = np.loadtxt(f'{prefix}/files/{i}.tsv')
             self.assertTrue(np.array_equal(a, a2))

--- a/hail/python/test/hail/experimental/test_experimental.py
+++ b/hail/python/test/hail/experimental/test_experimental.py
@@ -306,6 +306,7 @@ class Tests(unittest.TestCase):
             hl.linalg.BlockMatrix._create(11, 12, data[0].tolist(), block_size=4),
             hl.linalg.BlockMatrix._create(5, 17, data[1].tolist(), block_size=8)
         ]
+        prefix = new_local_temp_dir()
         hl.experimental.block_matrices_tofiles(bms, f'{prefix}/files')
         for i in range(len(bms)):
             a = data[i]
@@ -325,6 +326,7 @@ class Tests(unittest.TestCase):
             hl.linalg.BlockMatrix._create(11, 12, data[0].tolist(), block_size=4),
             hl.linalg.BlockMatrix._create(5, 17, data[1].tolist(), block_size=8)
         ]
+        prefix = new_local_temp_dir()
         hl.experimental.export_block_matrices(bms, f'{prefix}/files')
         for i in range(len(bms)):
             a = arrs[i]

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -8,7 +8,8 @@ import org.json4s.{DefaultFormats, Formats, ShortTypeHints}
 object BlockMatrixWriter {
   implicit val formats: Formats = new DefaultFormats() {
     override val typeHints = ShortTypeHints(
-      List(classOf[BlockMatrixNativeWriter], classOf[BlockMatrixBinaryWriter], classOf[BlockMatrixRectanglesWriter]))
+      List(classOf[BlockMatrixNativeWriter], classOf[BlockMatrixBinaryWriter], classOf[BlockMatrixRectanglesWriter],
+        classOf[BlockMatrixNativeMultiWriter]))
     override val typeHintFieldName: String = "name"
   }
 }
@@ -42,4 +43,18 @@ case class BlockMatrixRectanglesWriter(
   def apply(hc: HailContext, bm: BlockMatrix): Unit = {
     bm.exportRectangles(hc, path, rectangles, delimiter, binary)
   }
+}
+
+abstract class BlockMatrixMultiWriter {
+  def apply(bm: IndexedSeq[BlockMatrix]): Unit
+}
+
+case class BlockMatrixNativeMultiWriter(
+  prefix: String,
+  overwrite: Boolean,
+  forceRowMajor: Boolean,
+  stageLocally: Boolean) extends BlockMatrixWriter {
+
+  def apply(bms: IndexedSeq[BlockMatrix]): Unit =
+    BlockMatrix.writeBlockMatrices(bms, prefix, overwrite, forceRowMajor, stageLocally)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -146,6 +146,7 @@ object Children {
     // from BlockMatrixIR
     case BlockMatrixToValueApply(child, _) => IndexedSeq(child)
     case BlockMatrixWrite(child, _) => IndexedSeq(child)
+    case BlockMatrixMultiWrite(blockMatrices, _) => blockMatrices
     case CollectDistributedArray(ctxs, globals, _, _, body) => IndexedSeq(ctxs, globals, body)
     case ReadPartition(path, _, _, _) => IndexedSeq(path)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
@@ -11,6 +11,7 @@ object Compilable {
       case _: TableWrite => false
       case _: MatrixWrite => false
       case _: BlockMatrixWrite => false
+      case _: BlockMatrixMultiWrite => false
       case _: TableToValueApply => false
       case _: MatrixToValueApply => false
       case _: BlockMatrixToValueApply => false

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -222,6 +222,8 @@ object Copy {
       case BlockMatrixWrite(_, writer) =>
         val IndexedSeq(newChild: BlockMatrixIR) = newChildren
         BlockMatrixWrite(newChild, writer)
+      case BlockMatrixMultiWrite(_, writer) =>
+        BlockMatrixMultiWrite(newChildren.map(_.asInstanceOf[BlockMatrixIR]), writer)
       case CollectDistributedArray(_, _, cname, gname, _) =>
         val IndexedSeq(ctxs: IR, globals: IR, newBody: IR) = newChildren
         CollectDistributedArray(ctxs, globals, cname, gname, newBody)

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -342,7 +342,7 @@ final case class BlockMatrixToValueApply(child: BlockMatrixIR, function: BlockMa
 
 final case class BlockMatrixWrite(child: BlockMatrixIR, writer: BlockMatrixWriter) extends IR
 
-final case class BlockMatrixMultiWrite(blockMatrices: IndexedSeq[BlockMatrixIR], writer: BlockMatrixWriter) extends IR
+final case class BlockMatrixMultiWrite(blockMatrices: IndexedSeq[BlockMatrixIR], writer: BlockMatrixMultiWriter) extends IR
 
 final case class CollectDistributedArray(contexts: IR, globals: IR, cname: String, gname: String, body: IR) extends IR
 final case class ReadPartition(path: IR, spec: CodecSpec, encodedType: TStruct, rowType: TStruct) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -342,6 +342,8 @@ final case class BlockMatrixToValueApply(child: BlockMatrixIR, function: BlockMa
 
 final case class BlockMatrixWrite(child: BlockMatrixIR, writer: BlockMatrixWriter) extends IR
 
+final case class BlockMatrixMultiWrite(blockMatrices: IndexedSeq[BlockMatrixIR], writer: BlockMatrixWriter) extends IR
+
 final case class CollectDistributedArray(contexts: IR, globals: IR, cname: String, gname: String, body: IR) extends IR
 final case class ReadPartition(path: IR, spec: CodecSpec, encodedType: TStruct, rowType: TStruct) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferPType.scala
@@ -154,6 +154,7 @@ object InferPType {
       case _: MatrixWrite => PVoid
       case _: MatrixMultiWrite => PVoid
       case _: BlockMatrixWrite => PVoid
+      case _: BlockMatrixMultiWrite => PVoid
       case TableGetGlobals(child) => PType.canonical(child.typ.globalType)
       case TableCollect(child) => PStruct("rows" -> PArray(PType.canonical(child.typ.rowType)), "global" -> PType.canonical(child.typ.globalType))
       case TableToValueApply(child, function) => PType.canonical(function.typ(child.typ))

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -158,6 +158,7 @@ object InferType {
       case _: MatrixWrite => TVoid
       case _: MatrixMultiWrite => TVoid
       case _: BlockMatrixWrite => TVoid
+      case _: BlockMatrixMultiWrite => TVoid
       case TableGetGlobals(child) => child.typ.globalType
       case TableCollect(child) => TStruct("rows" -> TArray(child.typ.rowType), "global" -> child.typ.globalType)
       case TableToValueApply(child, function) => function.typ(child.typ)

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -755,8 +755,9 @@ object Interpret {
       case BlockMatrixWrite(child, writer) =>
         val hc = HailContext.get
         writer(hc, child.execute(hc))
-      case BlockMatrixMultiWrite(child, writer) =>
-        ???
+      case BlockMatrixMultiWrite(blockMatrices, writer) =>
+        val hc = HailContext.get
+        writer(blockMatrices.map(_.execute(hc)))
       case TableToValueApply(child, function) =>
         function.execute(child.execute(HailContext.get))
       case BlockMatrixToValueApply(child, function) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -755,6 +755,8 @@ object Interpret {
       case BlockMatrixWrite(child, writer) =>
         val hc = HailContext.get
         writer(hc, child.execute(hc))
+      case BlockMatrixMultiWrite(child, writer) =>
+        ???
       case TableToValueApply(child, function) =>
         function.execute(child.execute(HailContext.get))
       case BlockMatrixToValueApply(child, function) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -868,7 +868,7 @@ object IRParser {
       case "BlockMatrixMultiWrite" =>
         val writerStr = string_literal(it)
         implicit val formats: Formats = BlockMatrixWriter.formats
-        val writer = deserialize[BlockMatrixWriter](writerStr)
+        val writer = deserialize[BlockMatrixMultiWriter](writerStr)
         val blockMatrices = repUntil(it, blockmatrix_ir(env), PunctuationToken(")"))
         BlockMatrixMultiWrite(blockMatrices.toFastIndexedSeq, writer)
       case "CollectDistributedArray" =>

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -865,6 +865,12 @@ object IRParser {
         val writer = deserialize[BlockMatrixWriter](writerStr)
         val child = blockmatrix_ir(env)(it)
         BlockMatrixWrite(child, writer)
+      case "BlockMatrixMultiWrite" =>
+        val writerStr = string_literal(it)
+        implicit val formats: Formats = BlockMatrixWriter.formats
+        val writer = deserialize[BlockMatrixWriter](writerStr)
+        val blockMatrices = repUntil(it, blockmatrix_ir(env), PunctuationToken(")"))
+        BlockMatrixMultiWrite(blockMatrices.toFastIndexedSeq, writer)
       case "CollectDistributedArray" =>
         val cname = identifier(it)
         val gname = identifier(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -213,6 +213,8 @@ object Pretty {
               '"' + StringEscapeUtils.escapeString(Serialization.write(reader)(BlockMatrixReader.formats)) + '"'
             case BlockMatrixWrite(_, writer) =>
               '"' + StringEscapeUtils.escapeString(Serialization.write(writer)(BlockMatrixWriter.formats)) + '"'
+            case BlockMatrixMultiWrite(_, writer) =>
+              '"' + StringEscapeUtils.escapeString(Serialization.write(writer)(BlockMatrixWriter.formats)) + '"'
             case BlockMatrixBroadcast(_, inIndexExpr, shape, blockSize) =>
               prettyInts(inIndexExpr) + " " +
               prettyLongs(shape) + " " +

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -273,6 +273,7 @@ object TypeCheck {
       case MatrixToValueApply(_, _) =>
       case BlockMatrixToValueApply(_, _) =>
       case BlockMatrixWrite(_, _) =>
+      case BlockMatrixMultiWrite(_, _) =>
       case CollectDistributedArray(ctxs, globals, cname, gname, body) =>
         assert(ctxs.typ.isInstanceOf[TArray])
       case x@ReadPartition(path, _, _, rowType) =>

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -172,6 +172,19 @@ object BlockMatrix {
       def /(r: M): M = r.reverseScalarDiv(l)
     }
   }
+
+  def collectBlocks(bms: IndexedSeq[BlockMatrix]): RDD[BDM[Double]] = {
+    val bmNBlocks = bms.map(_.blocks.getNumPartitions)
+    ???
+  }
+
+  def writeBlockMatrices(bms: IndexedSeq[BlockMatrix],
+    prefix: String,
+    overwrite: Boolean,
+    forceRowMajor: Boolean,
+    stageLocally: Boolean): Unit = {
+    ???
+  }
 }
 
 // must be top-level for Jackson to serialize correctly

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -277,36 +277,35 @@ object BlockMatrix {
         val m = it.next()
         val path = prefix + "/" + StringUtils.leftPad(i.toString, d, '0') + ".tsv"
 
-        hadoopConfBc.value.value.writeTextFile(path) { os =>
-          val sb = new StringBuilder()
-
+        using(
+          new PrintWriter(
+            new BufferedWriter(
+              new OutputStreamWriter(
+                hadoopConfBc.value.value.unsafeWriter(path))))) { f =>
           header.foreach { h =>
-            sb.append(h)
-            sb.append('\n')
+            f.println(h)
           }
 
           var i = 0
           while (i < m.rows) {
             if (addIndex) {
-              sb.append(i)
-              sb.append(delimiter)
+              f.print(i)
+              f.print(delimiter)
             }
 
             var j = 0
             while (j < m.cols) {
-              sb.append(m(i, j))
+              f.print(m(i, j))
               if (j < m.cols - 1)
-                sb.append(delimiter)
+                f.print(delimiter)
               j += 1
             }
-            sb.append('\n')
+            f.print('\n')
             i += 1
           }
-
-          os.write(sb.result())
-
-          Iterator.single(1)
         }
+
+        Iterator.single(1)
       }
       .collect()
 

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -275,7 +275,7 @@ object BlockMatrix {
       .mapPartitionsWithIndex { case (i, it) =>
         assert(it.hasNext)
         val m = it.next()
-        val path = prefix + "/" + StringUtils.leftPad(i.toString, d, '0')
+        val path = prefix + "/" + StringUtils.leftPad(i.toString, d, '0') + ".tsv"
 
         hadoopConfBc.value.value.writeTextFile(path) { os =>
           val sb = new StringBuilder()

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichArray.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichArray.scala
@@ -1,5 +1,6 @@
 package is.hail.utils.richUtils
 
+import org.apache.hadoop
 import is.hail.HailContext
 import is.hail.io.{DoubleInputBuffer, DoubleOutputBuffer}
 import is.hail.utils._
@@ -21,11 +22,11 @@ object RichArray {
     }
   }
 
-  def exportToDoubles(hc: HailContext, path: String, a: Array[Double]): Unit =
-    exportToDoubles(hc, path, a, defaultBufSize)
+  def exportToDoubles(hadoopConf: hadoop.conf.Configuration, path: String, a: Array[Double]): Unit =
+    exportToDoubles(hadoopConf, path, a, defaultBufSize)
 
-  def exportToDoubles(hc: HailContext, path: String, a: Array[Double], bufSize: Int): Unit = {
-    hc.hadoopConf.writeFile(path) { os =>
+  def exportToDoubles(hadoopConf: hadoop.conf.Configuration, path: String, a: Array[Double], bufSize: Int): Unit = {
+    hadoopConf.writeFile(path) { os =>
       val out = new DoubleOutputBuffer(os, bufSize)
 
       out.writeDoubles(a)

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichDenseMatrixDouble.scala
@@ -3,6 +3,7 @@ package is.hail.utils.richUtils
 import java.io.{InputStream, OutputStream}
 
 import breeze.linalg.{DenseMatrix => BDM}
+import org.apache.hadoop
 import is.hail.HailContext
 import is.hail.linalg.{BlockMatrix, BlockMatrixMetadata, GridPartitioner}
 import is.hail.io._
@@ -48,11 +49,11 @@ object RichDenseMatrixDouble {
     RichDenseMatrixDouble(nRows, nCols, data, rowMajor)
   }
 
-  def exportToDoubles(hc: HailContext, path: String, m: BDM[Double], forceRowMajor: Boolean): Boolean = {
+  def exportToDoubles(hadoopConf: hadoop.conf.Configuration, path: String, m: BDM[Double], forceRowMajor: Boolean): Boolean = {
     val (data, rowMajor) = m.toCompactData(forceRowMajor)
     assert(data.length == m.rows * m.cols)
     
-    RichArray.exportToDoubles(hc, path, data)
+    RichArray.exportToDoubles(hadoopConf, path, data)
 
     rowMajor
   }

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1389,6 +1389,7 @@ class IRSuite extends SparkSuite {
     val bgen = MatrixRead(bgenReader.fullMatrixType, false, false, bgenReader)
 
     val blockMatrix = BlockMatrixRead(BlockMatrixNativeReader(tmpDir.createLocalTempFile()))
+    val blockMatrixWriter = BlockMatrixNativeWriter(tmpDir.createLocalTempFile(), false, false, false)
     val nd = MakeNDArray(2,
       MakeArray(FastSeq(I32(-1), I32(1)), TArray(TInt32())),
       MakeArray(FastSeq(I64(1), I64(2)), TArray(TInt64())),
@@ -1470,7 +1471,8 @@ class IRSuite extends SparkSuite {
       MatrixWrite(bgen, MatrixGENWriter(tmpDir.createLocalTempFile())),
       MatrixMultiWrite(Array(mt, mt), MatrixNativeMultiWriter(tmpDir.createLocalTempFile())),
       MatrixAggregate(mt, MakeStruct(Seq("foo" -> count))),
-      BlockMatrixWrite(blockMatrix, BlockMatrixNativeWriter(tmpDir.createLocalTempFile(), false, false, false)),
+      BlockMatrixWrite(blockMatrix, blockMatrixWriter),
+      BlockMatrixMultiWrite(IndexedSeq(blockMatrix, blockMatrix), blockMatrixWriter),
       CollectDistributedArray(ArrayRange(0, 3, 1), 1, "x", "y", Ref("x", TInt32())),
       ReadPartition(Str("foo"), CodecSpec.default, TStruct("foo"->TInt32(), "bar" -> TString()), TStruct("foo"->TInt32()))
     )

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1390,6 +1390,7 @@ class IRSuite extends SparkSuite {
 
     val blockMatrix = BlockMatrixRead(BlockMatrixNativeReader(tmpDir.createLocalTempFile()))
     val blockMatrixWriter = BlockMatrixNativeWriter(tmpDir.createLocalTempFile(), false, false, false)
+    val blockMatrixMultiWriter = BlockMatrixBinaryMultiWriter(tmpDir.createLocalTempFile(), false)
     val nd = MakeNDArray(2,
       MakeArray(FastSeq(I32(-1), I32(1)), TArray(TInt32())),
       MakeArray(FastSeq(I64(1), I64(2)), TArray(TInt64())),
@@ -1472,7 +1473,7 @@ class IRSuite extends SparkSuite {
       MatrixMultiWrite(Array(mt, mt), MatrixNativeMultiWriter(tmpDir.createLocalTempFile())),
       MatrixAggregate(mt, MakeStruct(Seq("foo" -> count))),
       BlockMatrixWrite(blockMatrix, blockMatrixWriter),
-      BlockMatrixMultiWrite(IndexedSeq(blockMatrix, blockMatrix), blockMatrixWriter),
+      BlockMatrixMultiWrite(IndexedSeq(blockMatrix, blockMatrix), blockMatrixMultiWriter),
       CollectDistributedArray(ArrayRange(0, 3, 1), 1, "x", "y", Ref("x", TInt32())),
       ReadPartition(Str("foo"), CodecSpec.default, TStruct("foo"->TInt32(), "bar" -> TString()), TStruct("foo"->TInt32()))
     )

--- a/hail/src/test/scala/is/hail/utils/RichArraySuite.scala
+++ b/hail/src/test/scala/is/hail/utils/RichArraySuite.scala
@@ -10,7 +10,7 @@ class RichArraySuite extends SparkSuite {
     val a = Array.fill[Double](100)(util.Random.nextDouble())
     val a2 = new Array[Double](100)
     
-    RichArray.exportToDoubles(hc, file, a, bufSize = 32)
+    RichArray.exportToDoubles(hadoopConf, file, a, bufSize = 32)
     RichArray.importFromDoubles(hc, file, a2, bufSize = 16)
     assert(a === a2)
         

--- a/hail/src/test/scala/is/hail/utils/RichDenseMatrixDoubleSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/RichDenseMatrixDoubleSuite.scala
@@ -22,13 +22,13 @@ class RichDenseMatrixDoubleSuite extends SparkSuite {
   def testReadWriteDoubles(): Unit = {
     val file = tmpDir.createTempFile("test")
     val m = BDM.rand[Double](50, 100)
-    RichDenseMatrixDouble.exportToDoubles(hc, file, m, forceRowMajor = false)
+    RichDenseMatrixDouble.exportToDoubles(hadoopConf, file, m, forceRowMajor = false)
     val m2 = RichDenseMatrixDouble.importFromDoubles(hc, file, 50, 100, rowMajor = false)
     assert(m === m2)
     
     val fileT = tmpDir.createTempFile("test2")
     val mT = m.t
-    RichDenseMatrixDouble.exportToDoubles(hc, fileT, mT, forceRowMajor = true)
+    RichDenseMatrixDouble.exportToDoubles(hadoopConf, fileT, mT, forceRowMajor = true)
     val lmT2 = RichDenseMatrixDouble.importFromDoubles(hc, fileT, 100, 50, rowMajor = true)
     assert(mT === mT)
     


### PR DESCRIPTION
added `export_block_matrices` and `block_matrices_tofiles` to `experimental`, parallel versions of `BlockMatrix.export` and `BlockMatrix.tofile`, in the style of `write_matrix_tables`.