### PR TITLE
[hail][feature] Super array expression

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -19,7 +19,9 @@ libsass
 pip
 pylint
 pymysql
-pytest
+pytest>=4.4,<4.5
+pytest-html>=1.22,<1.23
+pytest-xdist>=1.28,<1.29
 requests
 urllib3<1.25,>=1.21.1
 uvloop>=0.12

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -19,9 +19,7 @@ libsass
 pip
 pylint
 pymysql
-pytest>=4.4,<4.5
-pytest-html>=1.22,<1.23
-pytest-xdist>=1.28,<1.29
+pytest
 requests
 urllib3<1.25,>=1.21.1
 uvloop>=0.12

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -645,15 +645,15 @@ class ArrayStructExpression(ArrayExpression):
 
     See Also
     --------
-    :class:`.ArrayExpression:`, class:`.CollectionExpression`, :class:`.SetStructExpression`
+    :class:`.ArrayExpression`, class:`.CollectionExpression`, :class:`.SetStructExpression`
     """
 
     def __getattr__(self, item):
         return ArrayStructExpression.__getitem__(self, item)
 
-    @typecheck_method(item=oneof(str))
     def __getitem__(self, item):
-        """Get a field from each struct in this array.
+        """If a string, get a field from each struct in this array. If an integer, get
+        the item at that index.
 
         Examples
         --------
@@ -684,9 +684,15 @@ class ArrayStructExpression(ArrayExpression):
         :class:`.ArrayExpression`
             An array formed by getting the given field for each struct in
             this array
+
+        See Also
+        --------
+        :meth:`.ArrayExpression.__getitem__`
         """
 
-        return self.map(lambda x: x[item])
+        if isinstance(item, str):
+            return self.map(lambda x: x[item])
+        return super().__getitem__(item)
 
 
 class ArrayNumericExpression(ArrayExpression):
@@ -1124,7 +1130,7 @@ class SetStructExpression(SetExpression):
 
     See Also
     --------
-    :class:`.SetExpression:`, class:`.CollectionExpression`, :class:`.SetStructExpression`
+    :class:`.SetExpression`, class:`.CollectionExpression`, :class:`.SetStructExpression`
     """
 
     def __getattr__(self, item):

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -82,10 +82,10 @@ class CollectionExpression(Expression):
             if isinstance(etype, (hl.tarray, hl.tset)):
                 return self.map(lambda x: x.__getitem__(item))
         except TypeError as err:
-            if "Cannot use 'collection.foo' or" not in str(err):
+            if "elements must be structs or collections that eventaully contain structs." not in str(err):
                 raise
         raise TypeError(
-            f"Cannot use 'collection.foo' or 'collection['foo']' on "
+            f"Cannot use 'collection.{item}' or 'collection['{item}']' on "
             f"{type(self).__name__} of type {self.dtype}, the "
             f"elements must be structs or collections that eventaully "
             f"contain structs.")

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -54,7 +54,7 @@ class CollectionExpression(Expression):
         ...                            hl.struct(inner=2)]),
         ...               hl.struct(b=[hl.struct(inner=3)])])
         >>> hl.eval(a.b)
-        [[hl.struct(inner=1), hl.struct(inner=2)], [hl.struct(inner=3)]]
+        [[Struct(inner=1), Struct(inner=2)], [Struct(inner=3)]]
         >>> hl.eval(a.b.inner)
         [[1, 2], [3]]
         >>> hl.eval(hl.flatten(a.b).inner)

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3571,29 +3571,34 @@ def construct_expr(ir: IR,
                    aggregations: LinkedList = LinkedList(Aggregation)):
     if type is None:
         return Expression(ir, None, indices, aggregations)
-    if isinstance(type, tarray) and is_numeric(type.element_type):
+    elif isinstance(type, tarray) and is_numeric(type.element_type):
         return ArrayNumericExpression(ir, type, indices, aggregations)
-    if isinstance(type, tarray):
+    elif isinstance(type, tarray):
         etype = type.element_type
         if isinstance(etype, (hl.tarray, hl.tset)):
             while isinstance(etype, (hl.tarray, hl.tset)):
                 etype = etype.element_type
         if isinstance(etype, hl.tstruct):
             return ArrayStructExpression(ir, type, indices, aggregations)
-    if isinstance(type, tset) and isinstance(type.element_type, tstruct):
+        else:
+            raise NotImplementedError(type)
+    elif isinstance(type, tset) and isinstance(type.element_type, tstruct):
         etype = type.element_type
         if isinstance(etype, (hl.tarray, hl.tset)):
             while isinstance(etype, (hl.tarray, hl.tset)):
                 etype = etype.element_type
         if isinstance(etype, hl.tstruct):
             return SetStructExpression(ir, type, indices, aggregations)
-    if isinstance(type, tndarray) and is_numeric(type.element_type):
+        else:
+            raise NotImplementedError(type)
+    elif isinstance(type, tndarray) and is_numeric(type.element_type):
         return NDArrayNumericExpression(ir, type, indices, aggregations)
-    if type in scalars:
+    elif type in scalars:
         return scalars[type](ir, type, indices, aggregations)
-    if type.__class__ in typ_to_expr:
+    elif type.__class__ in typ_to_expr:
         return typ_to_expr[type.__class__](ir, type, indices, aggregations)
-    raise NotImplementedError(type)
+    else:
+        raise NotImplementedError(type)
 
 
 @typecheck(name=str, type=HailType, indices=Indices)

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -423,13 +423,14 @@ class ArrayExpression(CollectionExpression):
         """
         if isinstance(item, slice):
             return self._slice(self.dtype, item.start, item.stop, item.step)
-        if isinstance(item, str):
+        elif isinstance(item, str):
             return CollectionExpression.__getitem__(self, item)
         item = to_expr(item)
         if not item.dtype == tint32:
             raise TypeError("array expects key to be type 'slice' or expression of type 'int32', "
                             "found expression of type '{}'".format(item._type))
-        return self._method("indexArray", self.dtype.element_type, item)
+        else:
+            return self._method("indexArray", self.dtype.element_type, item)
 
     @typecheck_method(item=expr_any)
     def contains(self, item):

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -46,13 +46,13 @@ class CollectionExpression(Expression):
         necssary to use ``hl.eval`` inside ``annotate_rows`` or similar
         methods.
 
-        >>> x = [hl.struct(a='foo', b=3), hl.struct(a='bar', b=4)]
+        >>> x = hl.array([hl.struct(a='foo', b=3), hl.struct(a='bar', b=4)])
         >>> hl.eval(x.a)
         ['foo', 'bar']
 
-        >>> a = [hl.struct(b=[hl.struct(inner=1),
-        ...                   hl.struct(inner=2)]),
-        ...      hl.struct(b=[hl.struct(inner=3)])]
+        >>> a = hl.array([hl.struct(b=[hl.struct(inner=1),
+        ...                            hl.struct(inner=2)]),
+        ...               hl.struct(b=[hl.struct(inner=3)])]
         >>> hl.eval(a.b)
         [[hl.struct(inner=1), hl.struct(inner=2)], [hl.struct(inner=3)]]
         >>> hl.eval(a.b.inner)

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -76,11 +76,10 @@ class CollectionExpression(Expression):
 
         etype = self.dtype.element_type
         if isinstance(etype, hl.tstruct):
-            return hl.struct(
-                **{k: self.map(lambda x: x[k]) for k in etype}).__getitem__(item)
+            return self.map(lambda x: x[item])
         try:
             if isinstance(etype, (hl.tarray, hl.tset)):
-                return self.map(lambda x: x.__getitem__(item))
+                return self.map(lambda x: x[item])
         except TypeError as err:
             if "elements must be structs or collections that eventaully contain structs." not in str(err):
                 raise

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -1126,8 +1126,8 @@ class SetStructExpression(SetExpression):
     Nested collections that contain structs are also
     :class:`.SetStructExpressions`s
 
-    >>> people = hl.set([hl.set([hl.struct(name='Alice', age=57), hl.struct(name='Bob', age=12)],
-    ...                         [hl.struct(name='Charlie', age=34)])])
+    >>> people = hl.set([hl.set([hl.struct(name='Alice', age=57), hl.struct(name='Bob', age=12)]),
+    ...                  hl.set([hl.struct(name='Charlie', age=34)])])
 
     See Also
     --------
@@ -3583,7 +3583,7 @@ def construct_expr(ir: IR,
             return ArrayStructExpression(ir, type, indices, aggregations)
         else:
             return typ_to_expr[type.__class__](ir, type, indices, aggregations)
-    elif isinstance(type, tset) and isinstance(type.element_type, tstruct):
+    elif isinstance(type, tset):
         etype = type.element_type
         if isinstance(etype, (hl.tarray, hl.tset)):
             while isinstance(etype, (hl.tarray, hl.tset)):

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3582,7 +3582,7 @@ def construct_expr(ir: IR,
         if isinstance(etype, hl.tstruct):
             return ArrayStructExpression(ir, type, indices, aggregations)
         else:
-            raise NotImplementedError(type)
+            return typ_to_expr[type.__class__](ir, type, indices, aggregations)
     elif isinstance(type, tset) and isinstance(type.element_type, tstruct):
         etype = type.element_type
         if isinstance(etype, (hl.tarray, hl.tset)):
@@ -3591,7 +3591,7 @@ def construct_expr(ir: IR,
         if isinstance(etype, hl.tstruct):
             return SetStructExpression(ir, type, indices, aggregations)
         else:
-            raise NotImplementedError(type)
+            return typ_to_expr[type.__class__](ir, type, indices, aggregations)
     elif isinstance(type, tndarray) and is_numeric(type.element_type):
         return NDArrayNumericExpression(ir, type, indices, aggregations)
     elif type in scalars:

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -52,7 +52,7 @@ class CollectionExpression(Expression):
 
         >>> a = hl.array([hl.struct(b=[hl.struct(inner=1),
         ...                            hl.struct(inner=2)]),
-        ...               hl.struct(b=[hl.struct(inner=3)])]
+        ...               hl.struct(b=[hl.struct(inner=3)])])
         >>> hl.eval(a.b)
         [[hl.struct(inner=1), hl.struct(inner=2)], [hl.struct(inner=3)]]
         >>> hl.eval(a.b.inner)

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2838,18 +2838,18 @@ class Tests(unittest.TestCase):
         self.assertRaises(ValueError, lambda: cube.transpose((1, 1)))
 
     def test_collection_getitem(self):
-        collection_types = [hl.array, hl.set]
-        for typ in collection_types:
-            x = typ([hl.struct(a='foo', b=3), hl.struct(a='bar', b=4)])
+        collection_types = [(hl.array, list), (hl.set, set)]
+        for (htyp, ptyp) in collection_hl.arrayes:
+            x = htyp([hl.struct(a='foo', b=3), hl.struct(a='bar', b=4)])
             assert hl.eval(x.a) == ['foo', 'bar']
 
-            a = typ([hl.struct(b=[hl.struct(inner=1),
-                                  hl.struct(inner=2)]),
-                     hl.struct(b=[hl.struct(inner=3)])])
-            assert hl.eval(a.b) == [[hl.struct(inner=1), hl.struct(inner=2)],
-                                    [hl.struct(inner=3)]]
-            assert hl.eval(hl.flatten(a.b).inner) == [1, 2, 3]
-            assert hl.eval(a.b.inner) == [[1, 2], [3]]
-            assert hl.eval(a["b"].inner) == [[1, 2], [3]]
-            assert hl.eval(a["b"]["inner"]) == [[1, 2], [3]]
-            assert hl.eval(a.b["inner"]) == [[1, 2], [3]]
+            a = htyp([hl.struct(b=htyp([hl.struct(inner=1),
+                                      hl.struct(inner=2)])),
+                      hl.struct(b=htyp([hl.struct(inner=3)]))])
+            assert hl.eval(a.b) == ptyp([ptyp([hl.struct(inner=1), hl.struct(inner=2)]),
+                                         ptyp([hl.struct(inner=3)])])
+            assert hl.eval(hl.flatten(a.b).inner) == ptyp([1, 2, 3])
+            assert hl.eval(a.b.inner) == ptyp([ptyp([1, 2]), ptyp([3])])
+            assert hl.eval(a["b"].inner) == ptyp([ptyp([1, 2]), ptyp([3])])
+            assert hl.eval(a["b"]["inner"]) == ptyp([ptyp([1, 2]), ptyp([3])])
+            assert hl.eval(a.b["inner"]) == ptyp([ptyp([1, 2]), ptyp([3])])

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2838,18 +2838,23 @@ class Tests(unittest.TestCase):
         self.assertRaises(ValueError, lambda: cube.transpose((1, 1)))
 
     def test_collection_getitem(self):
-        collection_types = [(hl.array, list), (hl.set, set)]
-        for (htyp, ptyp) in collection_types:
+        collection_types = [(hl.array, list), (hl.set, frozenset)]
+        for (htyp, pytyp) in collection_types:
             x = htyp([hl.struct(a='foo', b=3), hl.struct(a='bar', b=4)])
-            assert hl.eval(x.a) == ['foo', 'bar']
+            assert hl.eval(x.a) == pytyp(['foo', 'bar'])
 
-            a = htyp([hl.struct(b=htyp([hl.struct(inner=1),
-                                        hl.struct(inner=2)])),
-                      hl.struct(b=htyp([hl.struct(inner=3)]))])
-            assert hl.eval(a.b) == ptyp([ptyp([hl.Struct(inner=1), hl.Struct(inner=2)]),
-                                         ptyp([hl.Struct(inner=3)])])
-            assert hl.eval(hl.flatten(a.b).inner) == ptyp([1, 2, 3])
-            assert hl.eval(a.b.inner) == ptyp([ptyp([1, 2]), ptyp([3])])
-            assert hl.eval(a["b"].inner) == ptyp([ptyp([1, 2]), ptyp([3])])
-            assert hl.eval(a["b"]["inner"]) == ptyp([ptyp([1, 2]), ptyp([3])])
-            assert hl.eval(a.b["inner"]) == ptyp([ptyp([1, 2]), ptyp([3])])
+        a = hl.array([hl.struct(b=[hl.struct(inner=1),
+                                   hl.struct(inner=2)]),
+                      hl.struct(b=[hl.struct(inner=3)])])
+        assert hl.eval(a.b) == [[hl.Struct(inner=1), hl.Struct(inner=2)],
+                                [hl.Struct(inner=3)]]
+        assert hl.eval(hl.flatten(a.b).inner) == [1, 2, 3]
+        assert hl.eval(a.b.inner) == [[1, 2], [3]]
+        assert hl.eval(a["b"].inner) == [[1, 2], [3]]
+        assert hl.eval(a["b"]["inner"]) == [[1, 2], [3]]
+        assert hl.eval(a.b["inner"]) == [[1, 2], [3]]
+
+        self.assertRaises(TypeError, lambda: hl.array([1,2,3]).a)
+        self.assertRaises(TypeError, lambda: hl.array([1,2,3])["a"])
+        self.assertRaises(TypeError, lambda: hl.array([[1],[2],[3]])["a"])
+        self.assertRaises(TypeError, lambda: hl.array([{1},{2},{3}])["a"])

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2854,7 +2854,7 @@ class Tests(unittest.TestCase):
         assert hl.eval(a["b"]["inner"]) == [[1, 2], [3]]
         assert hl.eval(a.b["inner"]) == [[1, 2], [3]]
 
-        self.assertRaises(TypeError, lambda: hl.array([1,2,3]).a)
-        self.assertRaises(TypeError, lambda: hl.array([1,2,3])["a"])
-        self.assertRaises(TypeError, lambda: hl.array([[1],[2],[3]])["a"])
-        self.assertRaises(TypeError, lambda: hl.array([{1},{2},{3}])["a"])
+        self.assertRaises(AttributeError, lambda: hl.array([1,2,3]).a)
+        self.assertRaises(AttributeError, lambda: hl.array([1,2,3])["a"])
+        self.assertRaises(AttributeError, lambda: hl.array([[1],[2],[3]])["a"])
+        self.assertRaises(AttributeError, lambda: hl.array([{1},{2},{3}])["a"])

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2837,16 +2837,19 @@ class Tests(unittest.TestCase):
         self.assertRaises(ValueError, lambda: v.transpose((1,)))
         self.assertRaises(ValueError, lambda: cube.transpose((1, 1)))
 
-    def test_project(self):
+    def test_collection_getitem(self):
         collection_types = [hl.array, hl.set]
         for typ in collection_types:
             x = typ([hl.struct(a='foo', b=3), hl.struct(a='bar', b=4)])
-            assert x.a == ['foo', 'bar']
+            assert hl.eval(x.a) == ['foo', 'bar']
 
             a = typ([hl.struct(b=[hl.struct(inner=1),
                                   hl.struct(inner=2)]),
                      hl.struct(b=[hl.struct(inner=3)])])
-            assert a.b == [[hl.struct(inner=1), hl.struct(inner=2)],
-                           [hl.struct(inner=3)]]
-            assert hl.flatten(a.b).inner == [1, 2, 3]
-            assert a.b.inner = [[1, 2], [3]]
+            assert hl.eval(a.b) == [[hl.struct(inner=1), hl.struct(inner=2)],
+                                    [hl.struct(inner=3)]]
+            assert hl.eval(hl.flatten(a.b).inner) == [1, 2, 3]
+            assert hl.eval(a.b.inner) == [[1, 2], [3]]
+            assert hl.eval(a["b"].inner) == [[1, 2], [3]]
+            assert hl.eval(a["b"]["inner"]) == [[1, 2], [3]]
+            assert hl.eval(a.b["inner"]) == [[1, 2], [3]]

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2844,10 +2844,10 @@ class Tests(unittest.TestCase):
             assert hl.eval(x.a) == ['foo', 'bar']
 
             a = htyp([hl.struct(b=htyp([hl.struct(inner=1),
-                                      hl.struct(inner=2)])),
+                                        hl.struct(inner=2)])),
                       hl.struct(b=htyp([hl.struct(inner=3)]))])
-            assert hl.eval(a.b) == ptyp([ptyp([hl.struct(inner=1), hl.struct(inner=2)]),
-                                         ptyp([hl.struct(inner=3)])])
+            assert hl.eval(a.b) == ptyp([ptyp([hl.Struct(inner=1), hl.Struct(inner=2)]),
+                                         ptyp([hl.Struct(inner=3)])])
             assert hl.eval(hl.flatten(a.b).inner) == ptyp([1, 2, 3])
             assert hl.eval(a.b.inner) == ptyp([ptyp([1, 2]), ptyp([3])])
             assert hl.eval(a["b"].inner) == ptyp([ptyp([1, 2]), ptyp([3])])

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2836,3 +2836,17 @@ class Tests(unittest.TestCase):
 
         self.assertRaises(ValueError, lambda: v.transpose((1,)))
         self.assertRaises(ValueError, lambda: cube.transpose((1, 1)))
+
+    def test_project(self):
+        collection_types = [hl.array, hl.set]
+        for typ in collection_types:
+            x = typ([hl.struct(a='foo', b=3), hl.struct(a='bar', b=4)])
+            assert x.a == ['foo', 'bar']
+
+            a = typ([hl.struct(b=[hl.struct(inner=1),
+                                  hl.struct(inner=2)]),
+                     hl.struct(b=[hl.struct(inner=3)])])
+            assert a.b == [[hl.struct(inner=1), hl.struct(inner=2)],
+                           [hl.struct(inner=3)]]
+            assert hl.flatten(a.b).inner == [1, 2, 3]
+            assert a.b.inner = [[1, 2], [3]]

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2839,7 +2839,7 @@ class Tests(unittest.TestCase):
 
     def test_collection_getitem(self):
         collection_types = [(hl.array, list), (hl.set, set)]
-        for (htyp, ptyp) in collection_hl.arrayes:
+        for (htyp, ptyp) in collection_types:
             x = htyp([hl.struct(a='foo', b=3), hl.struct(a='bar', b=4)])
             assert hl.eval(x.a) == ['foo', 'bar']
 


### PR DESCRIPTION
First step towards treating `CollectionExpression`s exactly like non-distributed tables. Works for arrays and sets.

cc: @konradjk

```python
>>> a = [hl.struct(b=[hl.struct(inner=1),
...                   hl.struct(inner=2)]),
...      hl.struct(b=[hl.struct(inner=3)])]
>>> hl.eval(a.b)
[[hl.struct(inner=1), hl.struct(inner=2)], [hl.struct(inner=3)]]
>>> hl.eval(a.b.inner)
[[1, 2], [3]]
>>> hl.eval(hl.flatten(a.b).inner)
[1, 2, 3]
>>> hl.eval(hl.flatten(a.b.inner))
[1, 2, 3]
```