### PR TITLE
[docker] Add missing requirements

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -19,7 +19,7 @@ libsass
 pip
 pylint
 pymysql
-pytest-html>=1.22,<1.23
+pytest-html>=1.20,<1.21
 pytest-xdist>=1.28,<1.29
 pytest>=4.4,<4.5
 requests

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -19,7 +19,10 @@ libsass
 pip
 pylint
 pymysql
-pytest
+pytest-html>=1.22,<1.23
+pytest-xdist>=1.28,<1.29
+pytest>=4.4,<4.5
 requests
+twine>=1.13,<1.14
 uvloop>=0.12
 werkzeug


### PR DESCRIPTION
I'm using one hail environment or everything now and I need these to test hail.


I also added twine which we'll need for deploying anything to PyPI including cloudtools.