### PR TITLE
[ci2] concurrency improvements

### DIFF
--- a/ci2/ci/build.py
+++ b/ci2/ci/build.py
@@ -1,21 +1,12 @@
 import os.path
 import json
-import string
-import secrets
 from shlex import quote as shq
 import yaml
 import jinja2
 from .log import log
-from .utils import flatten
+from .utils import flatten, generate_token
 from .constants import BUCKET
 from .environment import GCP_PROJECT, DOMAIN, IP, CI_UTILS_IMAGE
-
-
-def generate_token(size=12):
-    assert size > 0
-    alpha = string.ascii_lowercase
-    alnum = string.ascii_lowercase + string.digits
-    return secrets.choice(alpha) + ''.join([secrets.choice(alnum) for _ in range(size - 1)])
 
 
 def expand_value_from(value, config):

--- a/ci2/ci/ci.py
+++ b/ci2/ci/ci.py
@@ -109,7 +109,7 @@ async def pull_request_callback(event):
     target_branch = FQBranch.from_gh_json(gh_pr['base'])
     for wb in watched_branches:
         if (number in wb.prs) or (wb.branch == target_branch):
-            await wb.update(event.app)
+            await wb.notify_github_changed(event.app)
 
 
 @gh_router.register('push')
@@ -121,7 +121,7 @@ async def push_callback(event):
         branch = FQBranch(Repo.from_gh_json(data['repository']), branch_name)
         for wb in watched_branches:
             if wb.branch == branch or any(pr.branch == branch for pr in wb.prs.values()):
-                await wb.update(event.app)
+                await wb.notify_github_changed(event.app)
 
 
 @gh_router.register('pull_request_review')
@@ -130,7 +130,7 @@ async def pull_request_review_callback(event):
     number = gh_pr['number']
     for wb in watched_branches:
         if number in wb.prs:
-            await wb.update(event.app)
+            await wb.notify_github_changed(event.app)
 
 
 @routes.post('/callback')

--- a/ci2/ci/ci.py
+++ b/ci2/ci/ci.py
@@ -29,12 +29,6 @@ watched_branches = [
 
 app = web.Application()
 
-app['client_session'] = aiohttp.ClientSession(
-    raise_for_status=True,
-    timeout=aiohttp.ClientTimeout(total=60))
-app['github_client'] = gh_aiohttp.GitHubAPI(app['client_session'], 'ci2', oauth_token=oauth_token)
-app['batch_client'] = batch.aioclient.BatchClient(app['client_session'], url=os.environ.get('BATCH_SERVER_URL'))
-
 routes = web.RouteTableDef()
 
 
@@ -166,6 +160,12 @@ aiohttp_jinja2.setup(app, loader=jinja2.FileSystemLoader('ci/templates'))
 
 
 async def on_startup(app):
+    app['client_session'] = aiohttp.ClientSession(
+        raise_for_status=True,
+        timeout=aiohttp.ClientTimeout(total=60))
+    app['github_client'] = gh_aiohttp.GitHubAPI(app['client_session'], 'ci2', oauth_token=oauth_token)
+    app['batch_client'] = batch.aioclient.BatchClient(app['client_session'], url=os.environ.get('BATCH_SERVER_URL'))
+
     asyncio.ensure_future(refresh_loop(app))
 
 app.on_startup.append(on_startup)

--- a/ci2/ci/github.py
+++ b/ci2/ci/github.py
@@ -267,6 +267,7 @@ git -C {shq(repo_dir)} merge {shq(self.source_sha)} -m 'merge PR'
             status = await self.batch.status()
             if all(j['state'] == 'Complete' for j in status['jobs']):
                 self.build_state = 'success' if all(j['exit_code'] == 0 for j in status['jobs']) else 'failure'
+                self.batch_changed = True
 
 
 class WatchedBranch:

--- a/ci2/ci/github.py
+++ b/ci2/ci/github.py
@@ -209,7 +209,7 @@ git -C {shq(repo_dir)} merge {shq(self.source_sha)} -m 'merge PR'
         except (CalledProcessError, FileNotFoundError) as e:
             log.exception(f'could not open build.yaml due to {e}')
             self.build_state = 'merge_failure'
-            self.target_branch.batch_state = True
+            self.target_branch.batch_changed = True
             return
 
         batch = None

--- a/ci2/ci/github.py
+++ b/ci2/ci/github.py
@@ -330,7 +330,7 @@ class WatchedBranch:
             number = gh_json_pr['number']
             if self.prs is not None and number in self.prs:
                 pr = self.prs[number]
-                pr.update_from_gh_json(self, gh_json_pr)
+                pr.update_from_gh_json(gh_json_pr)
             else:
                 pr = PR.from_gh_json(gh_json_pr, self)
             new_prs[number] = pr

--- a/ci2/ci/github.py
+++ b/ci2/ci/github.py
@@ -175,7 +175,7 @@ class PR:
 
         try:
             log.info(f'merging for {self.number}')
-            repo_dir = f'repos/{self.target_branch.branch.short_str()}'
+            repo_dir = f'repos/{self.target_branch.branch.repo.short_str()}'
 
             merge_script = f'''
 set -ex

--- a/ci2/ci/utils.py
+++ b/ci2/ci/utils.py
@@ -1,9 +1,42 @@
-import subprocess as sp
+import string
+import secrets
+import asyncio
+
+
+class CalledProcessError(Exception):
+    def __init__(self, command, returncode):
+        super().__init__()
+        self.command = command
+        self.returncode = returncode
+
+    def __str__(self):
+        return f'Command {self.command} returned non-zero exit status {self.returncode}.'
+
+
+async def check_shell(script):
+    proc = await asyncio.create_subprocess_shell(script)
+    await proc.wait()
+    if proc.returncode != 0:
+        raise CalledProcessError(script, proc.returncode)
+
+
+async def check_shell_output(script):
+    proc = await asyncio.create_subprocess_shell(
+        script,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE)
+    outerr = await proc.communicate()
+    if proc.returncode != 0:
+        raise CalledProcessError(script, proc.returncode)
+    return outerr
+
+
+def generate_token(size=12):
+    assert size > 0
+    alpha = string.ascii_lowercase
+    alnum = string.ascii_lowercase + string.digits
+    return secrets.choice(alpha) + ''.join([secrets.choice(alnum) for _ in range(size - 1)])
 
 
 def flatten(xxs):
     return [x for xs in xxs for x in xs]
-
-
-def shell(*args):
-    sp.run(args, stderr=sp.PIPE, stdout=sp.PIPE, check=True)


### PR DESCRIPTION
 - All subprocess calls are async.  The UI is much more responsive now.
 - Make refresh (rather than heal) non-reentrant.  There was a race condition where we could update the Github state of a PR we were actively deploying.  This seemed error prone.
 - We need to lock the repos until the build is fully deployed.  I now protect pr.heal.
 - Set `batch_changed = True` whenever heal needs to be rerun becomes some of its inputs (build_state, source or target sha, collection of PRs) changed.

Next up: deploy.
