### PR TITLE
[c++] NDArray broadcast

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3176,24 +3176,15 @@ class NDArrayNumericExpression(NDArrayExpression):
         if isinstance(other, list):
             other = hl._ndarray(other)
 
-        self_broadcast, other_broadcast = self._broadcast_to_same_ndim(other)
+        self_broadcast, other_broadcast = self._broadcast_to_same_ndim(other, NDArrayNumericExpression)
         return super(NDArrayNumericExpression, self_broadcast)._bin_op_numeric(name, other_broadcast, ret_type_f)
 
     def _bin_op_numeric_reverse(self, name, other, ret_type_f=None):
         if isinstance(other, list):
             other = hl._ndarray(other)
 
-        self_broadcast, other_broadcast = self._broadcast_to_same_ndim(other)
+        self_broadcast, other_broadcast = self._broadcast_to_same_ndim(other, NDArrayNumericExpression)
         return super(NDArrayNumericExpression, self_broadcast)._bin_op_numeric_reverse(name, other_broadcast, ret_type_f)
-
-    def _broadcast_to_same_ndim(self, other):
-        if isinstance(other, NDArrayNumericExpression):
-            if self.ndim < other.ndim:
-                return self._broadcast(other.ndim, NDArrayNumericExpression), other
-            elif self.ndim > other.ndim:
-                return self, other._broadcast(self.ndim, NDArrayNumericExpression)
-
-        return self, other
 
     def __neg__(self):
         """Negate elements of the ndarray.

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3142,8 +3142,8 @@ class NDArrayExpression(Expression):
                 return self._broadcast(other.ndim, init), other
             elif self.ndim > other.ndim:
                 return self, other._broadcast(self.ndim, init)
-        else:
-            return self, other
+
+        return self, other
 
     def _broadcast(self, n_output_dims, init):
         assert self.ndim < n_output_dims

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3136,16 +3136,16 @@ class NDArrayExpression(Expression):
 
         Env.backend().execute(NDArrayWrite(self._ir, hl.str(uri)._ir))
 
-    def _broadcast_to_same_ndim(self, other, init):
+    def _broadcast_to_same_ndim(self, other):
         if isinstance(other, NDArrayExpression):
             if self.ndim < other.ndim:
-                return self._broadcast(other.ndim, init), other
+                return self._broadcast(other.ndim), other
             elif self.ndim > other.ndim:
-                return self, other._broadcast(self.ndim, init)
+                return self, other._broadcast(self.ndim)
 
         return self, other
 
-    def _broadcast(self, n_output_dims, init):
+    def _broadcast(self, n_output_dims):
         assert self.ndim < n_output_dims
 
         # Right-align existing dimensions and start prepending new ones
@@ -3157,7 +3157,13 @@ class NDArrayExpression(Expression):
         new_dims = range(self.ndim, n_output_dims)
         idx_mapping = list(reversed(new_dims)) + list(old_dims)
 
-        return init(NDArrayReindex(self._ir, idx_mapping), tndarray(self._type.element_type, n_output_dims))
+        ir = NDArrayReindex(self._ir, idx_mapping)
+        expr_type = tndarray(self._type.element_type, n_output_dims)
+
+        if is_numeric(self._type.element_type):
+            return NDArrayNumericExpression(ir, expr_type)
+
+        return NDArrayExpression(ir, expr_type)
 
 
 class NDArrayNumericExpression(NDArrayExpression):
@@ -3176,14 +3182,14 @@ class NDArrayNumericExpression(NDArrayExpression):
         if isinstance(other, list):
             other = hl._ndarray(other)
 
-        self_broadcast, other_broadcast = self._broadcast_to_same_ndim(other, NDArrayNumericExpression)
+        self_broadcast, other_broadcast = self._broadcast_to_same_ndim(other)
         return super(NDArrayNumericExpression, self_broadcast)._bin_op_numeric(name, other_broadcast, ret_type_f)
 
     def _bin_op_numeric_reverse(self, name, other, ret_type_f=None):
         if isinstance(other, list):
             other = hl._ndarray(other)
 
-        self_broadcast, other_broadcast = self._broadcast_to_same_ndim(other, NDArrayNumericExpression)
+        self_broadcast, other_broadcast = self._broadcast_to_same_ndim(other)
         return super(NDArrayNumericExpression, self_broadcast)._bin_op_numeric_reverse(name, other_broadcast, ret_type_f)
 
     def __neg__(self):

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -532,7 +532,7 @@ class NDArrayReindex(IR):
         return NDArrayReindex(nd, self.idx_expr)
 
     def head_str(self):
-        return f'({", ".join([str(i) for i in self.idx_expr])})'
+        return f'({" ".join([str(i) for i in self.idx_expr])})'
 
     def _compute_type(self, env, agg_env):
         self.nd._compute_type(env, agg_env)

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -520,6 +520,31 @@ class NDArrayRef(IR):
         self._type = self.nd.typ.element_type
 
 
+class NDArrayReindex(IR):
+    @typecheck_method(nd=IR, idx_expr=sequenceof(int))
+    def __init__(self, nd, idx_expr):
+        super().__init__(nd)
+        self.nd = nd
+        self.idx_expr = idx_expr
+
+    @typecheck_method(nd=IR)
+    def copy(self, nd):
+        return NDArrayReindex(nd, self.idx_expr)
+
+    def head_str(self):
+        return f'({", ".join([str(i) for i in self.idx_expr])})'
+
+    def _compute_type(self, env, agg_env):
+        self.nd._compute_type(env, agg_env)
+        n_input_dims = self.nd.typ.ndim
+        n_output_dims = len(self.idx_expr)
+        assert n_input_dims <= n_output_dims
+        assert all([i < n_output_dims for i in self.idx_expr])
+        assert all([i in self.idx_expr for i in range(n_output_dims)])
+
+        self._type = tndarray(self.nd.typ.element_type, n_output_dims)
+
+
 class NDArrayWrite(IR):
     @typecheck_method(nd=IR, path=IR)
     def __init__(self, nd, path):

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2666,6 +2666,7 @@ class Tests(unittest.TestCase):
         b = 3.0
         x = [a, b]
         y = [b, a]
+        row_vec = [[1, 2]]
         cube1 = [[[1, 2],
                   [3, 4]],
                  [[5, 6],
@@ -2678,6 +2679,7 @@ class Tests(unittest.TestCase):
         na = hl._ndarray(a)
         nx = hl._ndarray(x)
         ny = hl._ndarray(y)
+        nrow_vec = hl._ndarray(row_vec)
         ncube1 = hl._ndarray(cube1)
         ncube2 = hl._ndarray(cube2)
 
@@ -2694,18 +2696,28 @@ class Tests(unittest.TestCase):
         # Addition
         expr_eq((na + na)[()], a + a)
         expr_eq((nx + ny)[0], a + b)
-        expr_eq((nx + na)[1], a + b)
-        expr_eq((na + nx)[1], b + a)
         expr_eq((ncube1 + ncube2)[0, 0, 0], 10)
         expr_eq((ncube1 + ncube2)[1, 1, 1], 24)
+        # Broadcasting
+        expr_eq((ncube1 + na)[0, 1, 0], 5.0)
+        expr_eq((na + ncube1)[0, 1, 0], 5.0)
+        expr_eq((ncube1 + ny)[0, 1, 0], 6.0)
+        expr_eq((ny + ncube1)[0, 1, 0], 6.0)
+        expr_eq((nrow_vec + ncube1)[0, 1, 0], 4.0)
+        expr_eq((ncube1 + nrow_vec)[0, 1, 0], 4.0)
 
         # Subtraction
         expr_eq((na - na)[()], a - a)
         expr_eq((nx - nx)[0], a - a)
-        expr_eq((nx - na)[1], a - b)
-        expr_eq((na - nx)[1], b - a)
         expr_eq((ncube1 - ncube2)[0, 0, 0], -8)
         expr_eq((ncube1 - ncube2)[1, 1, 1], -8)
+        # Broadcasting
+        expr_eq((ncube1 - na)[0, 1, 0], 1.0)
+        expr_eq((na - ncube1)[0, 1, 0], -1.0)
+        expr_eq((ncube1 - ny)[0, 1, 0], 0.0)
+        expr_eq((ny - ncube1)[0, 1, 0], 0.0)
+        expr_eq((nrow_vec - ncube1)[0, 1, 0], 2.0)
+        expr_eq((ncube1 - nrow_vec)[0, 1, 0], -2.0)
 
         # Multiplication
         expr_eq((na * na)[()], a * a)
@@ -2714,18 +2726,33 @@ class Tests(unittest.TestCase):
         expr_eq((na * nx)[1], b * a)
         expr_eq((ncube1 * ncube2)[0, 0, 0], 9)
         expr_eq((ncube1 * ncube2)[1, 1, 1], 128)
+        # Broadcasting
+        expr_eq((ncube1 * na)[0, 1, 0], 6.0)
+        expr_eq((na * ncube1)[0, 1, 0], 6.0)
+        expr_eq((ncube1 * ny)[0, 1, 0], 9.0)
+        expr_eq((ny * ncube1)[0, 1, 0], 9.0)
+        expr_eq((nrow_vec * ncube1)[0, 1, 0], 3.0)
+        expr_eq((ncube1 * nrow_vec)[0, 1, 0], 3.0)
 
         # Division
         expr_almost_eq((na / na)[()], a / a)
         expr_almost_eq((nx / nx)[0], a / a)
+        expr_almost_eq((nx / na)[1], a / b)
+        expr_almost_eq((na / nx)[1], b / a)
         expr_almost_eq((ncube1 / ncube2)[0, 0, 0], 1 / 9)
         expr_almost_eq((ncube1 / ncube2)[1, 1, 1], 8 / 16)
+        expr_almost_eq((nrow_vec / ncube1)[0, 1, 0], 1 / 3)
+        expr_almost_eq((ncube1 / nrow_vec)[0, 1, 0], 3.0)
 
         # Floor div
         expr_eq((na // na)[()], a // a)
         expr_eq((nx // nx)[0], a // a)
+        expr_eq((nx // na)[1], a // b)
+        expr_eq((na // nx)[1], b // a)
         expr_eq((ncube1 // ncube2)[0, 0, 0], 0)
         expr_eq((ncube1 // ncube2)[1, 1, 1], 0)
+        expr_eq((nrow_vec // ncube1)[0, 1, 0], 0.0)
+        expr_eq((ncube1 // nrow_vec)[0, 1, 0], 3.0)
 
     @skip_unless_spark_backend()
     @run_with_cxx_compile()

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2716,8 +2716,8 @@ class Tests(unittest.TestCase):
         expr_eq((na - ncube1)[0, 1, 0], -1.0)
         expr_eq((ncube1 - ny)[0, 1, 0], 0.0)
         expr_eq((ny - ncube1)[0, 1, 0], 0.0)
-        expr_eq((nrow_vec - ncube1)[0, 1, 0], 2.0)
-        expr_eq((ncube1 - nrow_vec)[0, 1, 0], -2.0)
+        expr_eq((ncube1 - nrow_vec)[0, 1, 0], 2.0)
+        expr_eq((nrow_vec - ncube1)[0, 1, 0], -2.0)
 
         # Multiplication
         expr_eq((na * na)[()], a * a)
@@ -2731,28 +2731,38 @@ class Tests(unittest.TestCase):
         expr_eq((na * ncube1)[0, 1, 0], 6.0)
         expr_eq((ncube1 * ny)[0, 1, 0], 9.0)
         expr_eq((ny * ncube1)[0, 1, 0], 9.0)
-        expr_eq((nrow_vec * ncube1)[0, 1, 0], 3.0)
         expr_eq((ncube1 * nrow_vec)[0, 1, 0], 3.0)
+        expr_eq((nrow_vec * ncube1)[0, 1, 0], 3.0)
 
         # Division
         expr_almost_eq((na / na)[()], a / a)
         expr_almost_eq((nx / nx)[0], a / a)
-        expr_almost_eq((nx / na)[1], a / b)
-        expr_almost_eq((na / nx)[1], b / a)
+        expr_almost_eq((nx / na)[1], b / a)
+        expr_almost_eq((na / nx)[1], a / b)
         expr_almost_eq((ncube1 / ncube2)[0, 0, 0], 1 / 9)
         expr_almost_eq((ncube1 / ncube2)[1, 1, 1], 8 / 16)
+        # Broadcasting
+        expr_almost_eq((ncube1 / na)[0, 1, 0], 3 / 2)
+        expr_almost_eq((na / ncube1)[0, 1, 0], 2 / 3)
+        expr_almost_eq((ncube1 / ny)[0, 1, 0], 3 / 3)
+        expr_almost_eq((ny / ncube1)[0, 1, 0], 3 / 3)
+        expr_almost_eq((ncube1 / nrow_vec)[0, 1, 0], 3 / 1)
         expr_almost_eq((nrow_vec / ncube1)[0, 1, 0], 1 / 3)
-        expr_almost_eq((ncube1 / nrow_vec)[0, 1, 0], 3.0)
 
         # Floor div
         expr_eq((na // na)[()], a // a)
         expr_eq((nx // nx)[0], a // a)
-        expr_eq((nx // na)[1], a // b)
-        expr_eq((na // nx)[1], b // a)
+        expr_eq((nx // na)[1], b // a)
+        expr_eq((na // nx)[1], a // b)
         expr_eq((ncube1 // ncube2)[0, 0, 0], 0)
         expr_eq((ncube1 // ncube2)[1, 1, 1], 0)
-        expr_eq((nrow_vec // ncube1)[0, 1, 0], 0.0)
-        expr_eq((ncube1 // nrow_vec)[0, 1, 0], 3.0)
+        # Broadcasting
+        expr_eq((ncube1 // na)[0, 1, 0], 3 // 2)
+        expr_eq((na // ncube1)[0, 1, 0], 2 // 3)
+        expr_eq((ncube1 // ny)[0, 1, 0], 3 // 3)
+        expr_eq((ny // ncube1)[0, 1, 0], 3 // 3)
+        expr_eq((ncube1 // nrow_vec)[0, 1, 0], 3 // 1)
+        expr_eq((nrow_vec // ncube1)[0, 1, 0], 1 // 3)
 
     @skip_unless_spark_backend()
     @run_with_cxx_compile()

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2694,18 +2694,24 @@ class Tests(unittest.TestCase):
         # Addition
         expr_eq((na + na)[()], a + a)
         expr_eq((nx + ny)[0], a + b)
+        expr_eq((nx + na)[1], a + b)
+        expr_eq((na + nx)[1], b + a)
         expr_eq((ncube1 + ncube2)[0, 0, 0], 10)
         expr_eq((ncube1 + ncube2)[1, 1, 1], 24)
 
         # Subtraction
         expr_eq((na - na)[()], a - a)
         expr_eq((nx - nx)[0], a - a)
+        expr_eq((nx - na)[1], a - b)
+        expr_eq((na - nx)[1], b - a)
         expr_eq((ncube1 - ncube2)[0, 0, 0], -8)
         expr_eq((ncube1 - ncube2)[1, 1, 1], -8)
 
         # Multiplication
         expr_eq((na * na)[()], a * a)
         expr_eq((nx * nx)[0], a * a)
+        expr_eq((nx * na)[1], a * b)
+        expr_eq((na * nx)[1], b * a)
         expr_eq((ncube1 * ncube2)[0, 0, 0], 9)
         expr_eq((ncube1 * ncube2)[1, 1, 1], 128)
 

--- a/hail/src/main/resources/include/hail/NDArray.h
+++ b/hail/src/main/resources/include/hail/NDArray.h
@@ -54,7 +54,13 @@ std::vector<long> strides_row_major(std::vector<long> &shape) {
 
   if (shape.size() > 0) {
     long prev_stride = 1;
-    strides[shape.size() - 1] = prev_stride;
+    int end = shape.size() - 1;
+    if (shape[end] == 1) {
+      strides[end] = 0;
+    } else {
+      strides[end] = prev_stride;
+    }
+
     for (int i = shape.size() - 2; i >= 0; --i) {
       if (shape[i] == 1) {
         strides[i] = 0;
@@ -87,12 +93,16 @@ std::vector<long> strides_col_major(std::vector<long> &shape) {
 
   if (shape.size() > 0) {
     long prev_stride = 1;
-    strides[0] = prev_stride;
+    if (shape[0] == 1) {
+      strides[0] = 0;
+    } else {
+      strides[0] = prev_stride;
+    }
+
     for (int i = 1; i < shape.size(); ++i) {
       if (shape[i] == 1) {
         strides[i] = 0;
-      }
-      else {
+      } else {
         strides[i] = shape[i - 1] * prev_stride;
         prev_stride = strides[i];
       }

--- a/hail/src/main/resources/include/hail/NDArray.h
+++ b/hail/src/main/resources/include/hail/NDArray.h
@@ -88,15 +88,8 @@ std::vector<long> strides_col_major(std::vector<long> &shape) {
   return strides;
 }
 
-std::vector<long> broadcast_shapes(std::vector<long> left, std::vector<long> right) {
-  std::vector<long> result(std::max(left.size(), right.size()));
-
-  int len_diff = left.size() - right.size();
-  if (len_diff < 0) {
-    left.insert(left.begin(), -len_diff, 1);
-  } else if (len_diff > 0) {
-    right.insert(right.begin(), len_diff, 1);
-  }
+std::vector<long> unify_shapes(std::vector<long> left, std::vector<long> right) {
+  std::vector<long> result(left.size());
 
   for (int i = 0; i < left.size(); ++i) {
     if (!(left[i] == right[i] || left[i] == 1 || right[i] == 1)) {

--- a/hail/src/main/resources/include/hail/NDArray.h
+++ b/hail/src/main/resources/include/hail/NDArray.h
@@ -91,14 +91,11 @@ std::vector<long> strides_col_major(std::vector<long> &shape) {
 std::vector<long> broadcast_shapes(std::vector<long> left, std::vector<long> right) {
   std::vector<long> result(std::max(left.size(), right.size()));
 
-  if (left.size() < right.size()) {
-    for (int i = 0; i < right.size() - left.size(); ++i) {
-      left.insert(left.begin(), 1);
-    }
-  } else if (right.size() < left.size()) {
-    for (int i = 0; i < left.size() - right.size(); ++i) {
-      right.insert(left.begin(), 1);
-    }
+  int len_diff = left.size() - right.size();
+  if (len_diff < 0) {
+    left.insert(left.begin(), -len_diff, 1);
+  } else if (len_diff > 0) {
+    right.insert(right.begin(), len_diff, 1);
   }
 
   for (int i = 0; i < left.size(); ++i) {

--- a/hail/src/main/resources/include/hail/NDArray.h
+++ b/hail/src/main/resources/include/hail/NDArray.h
@@ -88,4 +88,27 @@ std::vector<long> strides_col_major(std::vector<long> &shape) {
   return strides;
 }
 
+std::vector<long> broadcast_shapes(std::vector<long> left, std::vector<long> right) {
+  std::vector<long> result(std::max(left.size(), right.size()));
+
+  if (left.size() < right.size()) {
+    for (int i = 0; i < right.size() - left.size(); ++i) {
+      left.insert(left.begin(), 1);
+    }
+  } else if (right.size() < left.size()) {
+    for (int i = 0; i < left.size() - right.size(); ++i) {
+      right.insert(left.begin(), 1);
+    }
+  }
+
+  for (int i = 0; i < left.size(); ++i) {
+    if (!(left[i] == right[i] || left[i] == 1 || right[i] == 1)) {
+      throw new FatalError("Incompatible shapes for broadcasting");
+    }
+    result[i] = std::max(left[i], right[i]);
+  }
+
+  return result;
+}
+
 #endif

--- a/hail/src/main/resources/include/hail/NDArray.h
+++ b/hail/src/main/resources/include/hail/NDArray.h
@@ -88,12 +88,12 @@ std::vector<long> strides_col_major(std::vector<long> &shape) {
   return strides;
 }
 
-std::vector<long> unify_shapes(std::vector<long> left, std::vector<long> right) {
+std::vector<long> unify_shapes(std::vector<long> &left, std::vector<long> &right) {
   std::vector<long> result(left.size());
 
   for (int i = 0; i < left.size(); ++i) {
     if (!(left[i] == right[i] || left[i] == 1 || right[i] == 1)) {
-      throw new FatalError("Incompatible shapes for broadcasting");
+      throw new FatalError("Incompatible shapes for element-wise map");
     }
     result[i] = std::max(left[i], right[i]);
   }

--- a/hail/src/main/resources/include/hail/NDArray.h
+++ b/hail/src/main/resources/include/hail/NDArray.h
@@ -53,9 +53,15 @@ std::vector<long> strides_row_major(std::vector<long> &shape) {
   std::vector<long> strides(shape.size());
 
   if (shape.size() > 0) {
-    strides[shape.size() - 1] = 1;
+    long prev_stride = 1;
+    strides[shape.size() - 1] = prev_stride;
     for (int i = shape.size() - 2; i >= 0; --i) {
-      strides[i] = shape[i + 1] * strides[i + 1];
+      if (shape[i] == 1) {
+        strides[i] = 0;
+      } else {
+        strides[i] = shape[i + 1] * prev_stride;
+        prev_stride = strides[i];
+      }
     }
   }
   return strides;
@@ -80,9 +86,16 @@ std::vector<long> strides_col_major(std::vector<long> &shape) {
   std::vector<long> strides(shape.size());
 
   if (shape.size() > 0) {
-    strides[0] = 1;
+    long prev_stride = 1;
+    strides[0] = prev_stride;
     for (int i = 1; i < shape.size(); ++i) {
-      strides[i] = shape[i - 1] * strides[i - 1];
+      if (shape[i] == 1) {
+        strides[i] = 0;
+      }
+      else {
+        strides[i] = shape[i - 1] * prev_stride;
+        prev_stride = strides[i];
+      }
     }
   }
   return strides;

--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -936,7 +936,7 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
 
         val shape = fb.variable("shape", "std::vector<long>")
         val strides = fb.variable("strides", "std::vector<long>")
-        val reindexShapeAndStrides = indexExpr.map{ i =>
+        val reindexShapeAndStrides = indexExpr.map { i =>
           s"""
              | if ($i < $nd.shape.size()) {
              |  $shape.push_back($nd.shape[$i]);
@@ -1240,20 +1240,6 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
 
   def emitDeforestedNDArray(resultRegion: EmitRegion, x: ir.IR, env: E): NDArrayLoopEmitter = {
     x match {
-//      case ir.NDArrayReindex(child, indexExpr) =>
-//        val nd = emitDeforestedNDArray(resultRegion, child, env)
-//
-//        new NDArrayLoopEmitter(fb, resultRegion, nd.nDims, nd.shape, nd.setup) {
-//          override def outputElement(idxVars: Seq[Variable]): Code = {
-//            val concreteDims = Seq.tabulate(nd.nDims) { dim =>
-//              val idxForDim = indexExpr.indexOf(dim)
-//              idxVars(idxForDim)
-//            }
-//
-//            nd.outputElement(concreteDims)
-//          }
-//        }
-
       case _ =>
         val ndt = emit(resultRegion, x, env)
         val nd = fb.variable("nd", "NDArray", ndt.v)

--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -965,7 +965,7 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
         val nd = fb.variable("nd", "NDArray", ndt.v)
 
         val idxVars = idxst.map(i => fb.variable("idx", "int", i.v))
-        val index = NDArrayLoopEmitter.linearizeIndices(fb, idxVars, s"$nd.strides", s"$nd.shape")
+        val index = NDArrayLoopEmitter.linearizeIndices(idxVars, s"$nd.strides")
 
         triplet(
           s"""
@@ -1250,7 +1250,7 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
         val xType = x.pType.asInstanceOf[PNDArray]
         new NDArrayLoopEmitter(fb, resultRegion, xType.nDims, shape, setup) {
           override def outputElement(idxVars: Seq[Variable]): Code = {
-            val index = NDArrayLoopEmitter.linearizeIndices(fb, idxVars, s"$nd.strides", s"$nd.shape")
+            val index = NDArrayLoopEmitter.linearizeIndices(idxVars, s"$nd.strides")
             NDArrayLoopEmitter.loadElement(nd, index, xType.elementType)
           }
         }

--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -1249,7 +1249,6 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
             nd.outputElement(concreteDims)
           }
         }
-//      case ir.Let(name, value, body) =>
 
       case _ =>
         val ndt = emit(resultRegion, x, env)

--- a/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
+++ b/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
@@ -100,14 +100,8 @@ abstract class ArrayEmitter(val setup: Code, val m: Code, val setupLen: Code, va
 object NDArrayLoopEmitter {
   def linearizeIndices(fb: FunctionBuilder, idxs: Seq[Variable], strides: Code, shape: Code): Code = {
     val result = fb.variable("result", "int", "0")
-    val nDims = idxs.length
     val buildIndex = idxs.zipWithIndex.map { case (idx, dim) =>
         s"""
-           | // Allow only length-1 dimensions to be broadcasted
-           | if ($idx < 0 || ($idx >= $shape[$dim] && $shape[$dim] > 1)) {
-           |   throw new FatalError("Invalid index");
-           | }
-           |
            | // length-1 dimensions not factored into the index for broadcasting
            | if ($shape[$dim] > 1) {
            |   $result += $idx * $strides[$dim];
@@ -117,10 +111,6 @@ object NDArrayLoopEmitter {
 
     s"""
        |({
-       | if ($strides.size() != $nDims) {
-       |   throw new FatalError("Number of indices must match number of dimensions.");
-       | }
-       |
        | ${ result.define }
        | $buildIndex
        | $result;

--- a/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
+++ b/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
@@ -130,15 +130,12 @@ abstract class NDArrayLoopEmitter(
   resultRegion: EmitRegion,
   val nDims: Int,
   val shape: Variable,
-  val setup: Code = "") {
+  val setup: Code) {
 
   fb.translationUnitBuilder().include("hail/ArrayBuilder.h")
 
   def outputElement(idxVars: Seq[Variable]): Code
 
-  // The problem might be with promoting dim-length 1 dimensions to longer
-  // Length and then not changing the linearizing indices method
-  // OR maybe not but this is still definitely a bug
   def linearizeIndices(idxs: Seq[Variable], strides: Code): Code = {
     idxs.zipWithIndex.foldRight("0"){ case ((idx, dim), linearIndex) =>
         s"$idx * $strides[$dim] + $linearIndex"
@@ -161,7 +158,6 @@ abstract class NDArrayLoopEmitter(
       |({
       | ${ setup }
       | ${ data.define }
-      | ${ shape.define }
       | ${ strides.define }
       |
       | ${ builder.defineWith(s"{ (int) n_elements($shape), $resultRegion }") }

--- a/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
+++ b/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
@@ -136,9 +136,10 @@ abstract class NDArrayLoopEmitter(
 
   def outputElement(idxVars: Seq[Variable]): Code
 
-  def linearizeIndices(idxs: Seq[Variable], strides: Code): Code = {
+  def linearizeIndices(idxs: Seq[Variable], shape: Code, strides: Code): Code = {
     idxs.zipWithIndex.foldRight("0"){ case ((idx, dim), linearIndex) =>
-        s"$idx * $strides[$dim] + $linearIndex"
+      // length-1 dimensions not factored into the index for broadcasting
+      s"($shape[$dim] == 1 ? $linearIndex : $idx * $strides[$dim] + $linearIndex)"
     }
   }
 

--- a/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
+++ b/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
@@ -100,7 +100,7 @@ abstract class ArrayEmitter(val setup: Code, val m: Code, val setupLen: Code, va
 object NDArrayLoopEmitter {
   def linearizeIndices(idxs: Seq[Variable], strides: Code): Code = {
     idxs.zipWithIndex.foldRight("0") { case ((idxVar, dim), linearIndex) =>
-        s"$idxVar * $strides[$dim] + $linearIndex"
+        s"($idxVar * $strides[$dim] + $linearIndex)"
     }
   }
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1015,9 +1015,9 @@ class IRSuite extends SparkSuite {
     assertEvalsTo(NDArrayRef(identity, bottomLeftIndex), 3.0)
     assertEvalsTo(NDArrayRef(transpose, bottomLeftIndex), 2.0)
 
-    val partialTranspose = NDArrayReindex(cubeRowMajor, IndexedSeq(0, 2, 1))
-    val idx = FastSeq(0L, 1L, 0L).map(I64)
-    val partialTranposeIdx = FastSeq(0L, 0L, 1L).map(I64)
+    val partialTranspose = NDArrayReindex(cubeRowMajor, FastIndexedSeq(0, 2, 1))
+    val idx = FastIndexedSeq(0L, 1L, 0L).map(I64)
+    val partialTranposeIdx = FastIndexedSeq(0L, 0L, 1L).map(I64)
     assertEvalsTo(NDArrayRef(cubeRowMajor, idx), 3.0)
     assertEvalsTo(NDArrayRef(partialTranspose, partialTranposeIdx), 3.0)
   }
@@ -1026,7 +1026,7 @@ class IRSuite extends SparkSuite {
     implicit val execStrats = Set(ExecStrategy.CxxCompile)
 
     val scalarWithMatrix = NDArrayMap2(
-      NDArrayReindex(scalarRowMajor, IndexedSeq(1, 0)),
+      NDArrayReindex(scalarRowMajor, FastIndexedSeq(1, 0)),
       matrixRowMajor,
       "s", "m",
       ApplyBinaryPrimOp(Add(), Ref("s", TFloat64()), Ref("m", TFloat64())))
@@ -1035,22 +1035,22 @@ class IRSuite extends SparkSuite {
     assertEvalsTo(topLeft, 4.0)
 
     val vectorWithMatrix = NDArrayMap2(
-      NDArrayReindex(vectorRowMajor, IndexedSeq(1, 0)),
+      NDArrayReindex(vectorRowMajor, FastIndexedSeq(1, 0)),
       matrixRowMajor,
       "v", "m",
       ApplyBinaryPrimOp(Add(), Ref("v", TFloat64()), Ref("m", TFloat64())))
 
-    assertEvalsTo(makeNDArrayRef(vectorWithMatrix, Seq(0, 0)), 2.0)
-    assertEvalsTo(makeNDArrayRef(vectorWithMatrix, Seq(0, 1)), 1.0)
-    assertEvalsTo(makeNDArrayRef(vectorWithMatrix, Seq(1, 0)), 4.0)
+    assertEvalsTo(makeNDArrayRef(vectorWithMatrix, FastIndexedSeq(0, 0)), 2.0)
+    assertEvalsTo(makeNDArrayRef(vectorWithMatrix, FastIndexedSeq(0, 1)), 1.0)
+    assertEvalsTo(makeNDArrayRef(vectorWithMatrix, FastIndexedSeq(1, 0)), 4.0)
 
-    val colVector = makeNDArray(FastSeq(1.0, -1.0), FastSeq(2, 1), True())
+    val colVector = makeNDArray(FastIndexedSeq(1.0, -1.0), FastIndexedSeq(2, 1), True())
     val colVectorWithMatrix = NDArrayMap2(colVector, matrixRowMajor, "v", "m",
       ApplyBinaryPrimOp(Add(), Ref("v", TFloat64()), Ref("m", TFloat64())))
 
-    assertEvalsTo(makeNDArrayRef(colVectorWithMatrix, Seq(0, 0)), 2.0)
-    assertEvalsTo(makeNDArrayRef(colVectorWithMatrix, Seq(0, 1)), 3.0)
-    assertEvalsTo(makeNDArrayRef(colVectorWithMatrix, Seq(1, 0)), 2.0)
+    assertEvalsTo(makeNDArrayRef(colVectorWithMatrix, FastIndexedSeq(0, 0)), 2.0)
+    assertEvalsTo(makeNDArrayRef(colVectorWithMatrix, FastIndexedSeq(0, 1)), 3.0)
+    assertEvalsTo(makeNDArrayRef(colVectorWithMatrix, FastIndexedSeq(1, 0)), 2.0)
   }
 
   @Test def testNDArrayWrite() {
@@ -1058,7 +1058,7 @@ class IRSuite extends SparkSuite {
 
     val path = tmpDir.createLocalTempFile()
     val write = NDArrayWrite(threeTensorRowMajor, Str(path))
-    nativeExecute(write, Env.empty, IndexedSeq.empty, None)
+    nativeExecute(write, Env.empty, FastIndexedSeq.empty, None)
   }
 
   @Test def testLeftJoinRightDistinct() {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1039,11 +1039,19 @@ class IRSuite extends SparkSuite {
       matrixRowMajor,
       "v", "m",
       ApplyBinaryPrimOp(Add(), Ref("v", TFloat64()), Ref("m", TFloat64())))
-    val two = makeNDArrayRef(vectorWithMatrix, Seq(0, 0))
-    val one = makeNDArrayRef(vectorWithMatrix, Seq(0, 1))
 
-    assertEvalsTo(two, 2.0)
-    assertEvalsTo(one, 1.0)
+    assertEvalsTo(makeNDArrayRef(vectorWithMatrix, Seq(0, 0)), 2.0)
+    assertEvalsTo(makeNDArrayRef(vectorWithMatrix, Seq(0, 1)), 1.0)
+    assertEvalsTo(makeNDArrayRef(vectorWithMatrix, Seq(1, 0)), 4.0)
+
+    val colVector = makeNDArray(FastSeq(1.0, -1.0), FastSeq(2, 1), True())
+    val colVectorWithMatrix = NDArrayMap2(colVector, matrixRowMajor, "v", "m",
+      ApplyBinaryPrimOp(Add(), Ref("v", TFloat64()), Ref("m", TFloat64())))
+
+    assertEvalsTo(makeNDArrayRef(colVectorWithMatrix, Seq(0, 0)), 2.0)
+    assertEvalsTo(makeNDArrayRef(colVectorWithMatrix, Seq(0, 1)), 3.0)
+    assertEvalsTo(makeNDArrayRef(colVectorWithMatrix, Seq(1, 0)), 2.0)
+
   }
 
   @Test def testNDArrayWrite() {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1028,11 +1028,22 @@ class IRSuite extends SparkSuite {
     val scalarWithMatrix = NDArrayMap2(
       NDArrayReindex(scalarRowMajor, IndexedSeq(1, 0)),
       matrixRowMajor,
-      "s", "e",
-      ApplyBinaryPrimOp(Add(), Ref("s", TFloat64()), Ref("e", TFloat64())))
+      "s", "m",
+      ApplyBinaryPrimOp(Add(), Ref("s", TFloat64()), Ref("m", TFloat64())))
 
     val topLeft = makeNDArrayRef(scalarWithMatrix, FastIndexedSeq(0, 0))
     assertEvalsTo(topLeft, 4.0)
+
+    val vectorWithMatrix = NDArrayMap2(
+      NDArrayReindex(vectorRowMajor, IndexedSeq(1, 0)),
+      matrixRowMajor,
+      "v", "m",
+      ApplyBinaryPrimOp(Add(), Ref("v", TFloat64()), Ref("m", TFloat64())))
+    val two = makeNDArrayRef(vectorWithMatrix, Seq(0, 0))
+    val one = makeNDArrayRef(vectorWithMatrix, Seq(0, 1))
+
+    assertEvalsTo(two, 2.0)
+    assertEvalsTo(one, 1.0)
   }
 
   @Test def testNDArrayWrite() {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1051,7 +1051,6 @@ class IRSuite extends SparkSuite {
     assertEvalsTo(makeNDArrayRef(colVectorWithMatrix, Seq(0, 0)), 2.0)
     assertEvalsTo(makeNDArrayRef(colVectorWithMatrix, Seq(0, 1)), 3.0)
     assertEvalsTo(makeNDArrayRef(colVectorWithMatrix, Seq(1, 0)), 2.0)
-
   }
 
   @Test def testNDArrayWrite() {


### PR DESCRIPTION
- Implement broadcasting of NDArrays. This essentially just gives NDArrays additional dimensions of length one, which changes the view onto the NDArray but not the underlying data. This allows us to promote smaller-dimensional NDArrays before a Map2 so both NDArrays have the same number of dimensions. The loops for the map will loop through the _unified shape_ of both child NDArrays with the same semantics as numpy (if corresponding dimensions are not equal, they are still compatible if one is 1 in which case you would take the larger one). Dimensions of length 1 have a stride of 0, so indexing into the array as if it were broadcast works and is totally free. The only additional benefit deforesting would actually give you is putting fewer loop variables into the calculation of the index.
- Restructured emit for NDArrays with stub-like emit method for deforesting so deforesting will be very easy to implement, but not currently deforesting anything. Thought this was necessary for `NDArrayReindex`. Ultimately it wasn't but is what we'll want to do next with maps anyway.