### PR TITLE
use cp instead of rsync to avoid updating pr-builder

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -35,8 +35,11 @@ jupyter_notebook_config.py:
 	    -e "s,@keyfile@,$(GSA_KEY_FILE),g" \
             < jupyter_notebook_config.py.in > $@
 
+# FIXME rsync not in pr-builder
+# rsync --delete --recursive ../hailjwt hailjwt
 hailjwt:
-	rsync --delete --recursive ../hailjwt hailjwt
+	rm -rf hailjwt
+	cp -a ../hailjwt hailjwt
 
 ifeq ($(IN_HAIL_CI),1)
 .PHONY: push deploy build-hail-base build-spark-master build-spark-worker build-apiserver

--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -5,7 +5,7 @@ REPO := gcr.io/$(PROJECT)
 GSA_KEY_FILE := /gsa-key/privateKeyData
 PY_FILES := $(shell find apiserver -iname \*.py -not -exec git check-ignore -q {} \; -print)
 
-PYTHONPATH := ../hail/python:../hailjwt:$(shell ls $SPARK_HOME/python/lib/py4j-*-src.zip):$SPARK_HOME/python:$${PYTHONPATH:+:$$PYTHONPATH}
+PYTHONPATH := $${PYTHONPATH:+:$$PYTHONPATH}../hail/python:../hailjwt:$(shell ls $$SPARK_HOME/python/lib/py4j-*-src.zip):$SPARK_HOME/python
 PYTHON := PYTHONPATH=$(PYTHONPATH) python3
 
 flake8-stmp: $(PY_FILES)


### PR DESCRIPTION
This will be easier to put right once we get rid of pr-builder and ci2 is building all the dependent images each time.