### PR TITLE
[Hail][Feature] Add product option to index methods

### DIFF
--- a/hail/python/hail/ir/matrix_ir.py
+++ b/hail/python/hail/ir/matrix_ir.py
@@ -392,14 +392,14 @@ class MatrixAnnotateRowsTable(MatrixIR):
     def _compute_type(self):
         child_typ = self.child.typ
         if self.product:
-            new_row_type = child_typ.row_type._insert_field(self.root, hl.tarray(self.table.typ.value_type))
+            value_type = hl.tarray(self.table.typ.value_type)
         else:
-            new_row_type = child_typ.row_type._insert_field(self.root, self.table.typ.value_type)
+            value_type = self.table.typ.value_type
         self._type = hl.tmatrix(
             child_typ.global_type,
             child_typ.col_type,
             child_typ.col_key,
-            new_row_type,
+            child_typ.row_type._insert_field(self.root, value_type),
             child_typ.row_key,
             child_typ.entry_type)
 

--- a/hail/python/hail/ir/matrix_ir.py
+++ b/hail/python/hail/ir/matrix_ir.py
@@ -376,25 +376,30 @@ class CastTableToMatrix(MatrixIR):
 
 
 class MatrixAnnotateRowsTable(MatrixIR):
-    def __init__(self, child, table, root):
+    def __init__(self, child, table, root, product=False):
         super().__init__(child, table)
         self.child = child
         self.table = table
         self.root = root
+        self.product = product
 
     def head_str(self):
-        return f'"{escape_str(self.root)}"'
+        return f'"{escape_str(self.root)}" {self.product}'
 
     def _eq(self, other):
-        return self.root == other.root
+        return self.root == other.root and self.product == other.product
 
     def _compute_type(self):
         child_typ = self.child.typ
+        if self.product:
+            new_row_type = child_typ.row_type._insert_field(self.root, hl.tarray(self.table.typ.value_type))
+        else:
+            new_row_type = child_typ.row_type._insert_field(self.root, self.table.typ.value_type)
         self._type = hl.tmatrix(
             child_typ.global_type,
             child_typ.col_type,
             child_typ.col_key,
-            child_typ.row_type._insert_field(self.root, self.table.typ.value_type),
+            new_row_type,
             child_typ.row_key,
             child_typ.entry_type)
 

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -63,24 +63,29 @@ class TableLeftJoinRightDistinct(TableIR):
 
 
 class TableIntervalJoin(TableIR):
-    def __init__(self, left, right, root):
+    def __init__(self, left, right, root, product=False):
         super().__init__(left, right)
         self.left = left
         self.right = right
         self.root = root
+        self.product = product
 
     def head_str(self):
-        return escape_id(self.root)
+        return f'{escape_id(self.root)} {self.product}'
 
     def _eq(self, other):
-        return self.root == other.root
+        return self.root == other.root and self.product == other.product
 
     def _compute_type(self):
         left_typ = self.left.typ
         right_typ = self.right.typ
+        if self.product:
+            right_val_typ = left_typ.row_type._insert_field(self.root, hl.tarray(right_typ.value_type))
+        else:
+            right_val_typ = left_typ.row_type._insert_field(self.root, right_typ.value_type)
         self._type = hl.ttable(
             left_typ.global_type,
-            left_typ.row_type._insert_field(self.root, right_typ.value_type),
+            right_val_typ,
             left_typ.row_key)
 
 

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2742,7 +2742,7 @@ class MatrixTable(ExprContainer):
         :class:`.Expression`
         """
         try:
-            return self.rows()._index(*exprs, product=product)
+            return self.rows()._index(*exprs, all_matches=all_matches)
         except TableIndexKeyError as err:
             key_type, exprs = err.args
             raise ExpressionException(
@@ -2782,7 +2782,7 @@ class MatrixTable(ExprContainer):
         :class:`.Expression`
         """
         try:
-            return self.cols()._index(*exprs, product=product)
+            return self.cols()._index(*exprs, all_matches=all_matches)
         except TableIndexKeyError as err:
             key_type, exprs = err.args
             raise ExpressionException(

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2710,7 +2710,7 @@ class MatrixTable(ExprContainer):
         """
         return construct_expr(TableGetGlobals(MatrixRowsTable(self._mir)), self.globals.dtype)
 
-    def index_rows(self, *exprs, product=False) -> 'Expression':
+    def index_rows(self, *exprs, all_matches=False) -> 'Expression':
         """Expose the row values as if looked up in a dictionary, indexing
         with `exprs`.
 
@@ -2726,8 +2726,8 @@ class MatrixTable(ExprContainer):
         ----------
         exprs : variable-length args of :class:`.Expression`
             Index expressions.
-        product : bool
-            If ``True``, value of expression is array of all matches.
+        all_matches : bool
+            Experimental. If ``True``, value of expression is array of all matches.
 
         Notes
         -----
@@ -2750,7 +2750,7 @@ class MatrixTable(ExprContainer):
                 f"  MatrixTable row key: {', '.join(str(t) for t in key_type.values())}\n"
                 f"  Index expressions:   {', '.join(str(e.dtype) for e in exprs)}")
 
-    def index_cols(self, *exprs, product=False) -> 'Expression':
+    def index_cols(self, *exprs, all_matches=False) -> 'Expression':
         """Expose the column values as if looked up in a dictionary, indexing
         with `exprs`.
 
@@ -2766,8 +2766,8 @@ class MatrixTable(ExprContainer):
         ----------
         exprs : variable-length args of :class:`.Expression`
             Index expressions.
-        product : bool
-            If ``True``, value of expression is array of all matches.
+        all_matches : bool
+            Experimental. If ``True``, value of expression is array of all matches.
 
         Notes
         -----

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1438,7 +1438,7 @@ class Table(ExprContainer):
                 handler = print
         handler(self._show(n, width, truncate, types))
 
-    def index(self, *exprs, product=False) -> 'Expression':
+    def index(self, *exprs, all_matches=False) -> 'Expression':
         """Expose the row values as if looked up in a dictionary, indexing
         with `exprs`.
 
@@ -1504,8 +1504,8 @@ class Table(ExprContainer):
         ----------
         exprs : variable-length args of :class:`.Expression`
             Index expressions.
-        product : bool
-            If ``True``, value of expression is array of all matches.
+        all_matches : bool
+            Experimental. If ``True``, value of expression is array of all matches.
 
         Returns
         -------

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1549,7 +1549,10 @@ class Table(ExprContainer):
         if product and not is_interval:
             return self.collect_by_key(uid).index(*exprs)[uid]
 
-        new_schema = self.row_value.dtype
+        if product:
+            new_schema = hl.tarray(self.row_value.dtype)
+        else:
+            new_schema = self.row_value.dtype
 
         if isinstance(src, Table):
             for e in exprs:

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1549,13 +1549,12 @@ class Table(ExprContainer):
                 return self._index(*exprs[0].values(), all_matches=all_matches)
 
             if not is_interval:
-                if all_matches:
-                    uid = Env.get_uid()
-                    return self.collect_by_key(uid).index(*exprs)[uid]
-                else:
-                    raise TableIndexKeyError(self.key.dtype, exprs)
+                raise TableIndexKeyError(self.key.dtype, exprs)
 
         uid = Env.get_uid()
+
+        if all_matches and not is_interval:
+            return self.collect_by_key(uid).index(*exprs)[uid]
 
         new_schema = self.row_value.dtype
         if all_matches:

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -546,6 +546,26 @@ class Tests(unittest.TestCase):
                 rt['value'] == "IB",
                 hl.is_missing(rt['value']))))
 
+    def test_interval_join(self):
+        left = hl.utils.range_matrix_table(50, 1, n_partitions=10)
+        intervals = hl.utils.range_table(4)
+        intervals = intervals.key_by(interval=hl.interval(intervals.idx * 10, intervals.idx * 10 + 5))
+        left = left.annotate_rows(interval_matches=intervals.index(left.row_key))
+        rows = left.rows()
+        self.assertTrue(rows.all(hl.case()
+                                 .when(rows.row_idx % 10 < 5, rows.interval_matches.idx == rows.row_idx // 10)
+                                 .default(hl.is_missing(rows.interval_matches))))
+
+    # def test_interval_product_join(self):
+    #     left = hl.utils.range_matrix_table(50, 1, n_partitions=8)
+    #     intervals = hl.utils.range_table(25)
+    #     intervals = intervals.key_by(interval=hl.interval(
+    #         1 + (intervals.idx // 5) * 10 + (intervals.idx % 5),
+    #         (1 + intervals.idx // 5) * 10 - (intervals.idx % 5)))
+    #     left = left.annotate_rows(interval_matches=intervals.index(left.row_key, product=True))
+    #     rows = left.rows()
+    #     self.assertTrue(rows.all(rows.interval_matches.length() == hl.min(rows.row_idx % 10, 10 - rows.row_idx % 10)))
+
     def test_entry_join_self(self):
         mt1 = hl.utils.range_matrix_table(10, 10, n_partitions=4).choose_cols([9, 8, 7, 6, 5, 4, 3, 2, 1, 0])
         mt1 = mt1.annotate_entries(x=10 * mt1.row_idx + mt1.col_idx)

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -392,7 +392,7 @@ class Tests(unittest.TestCase):
         left = hl.utils.range_matrix_table(5, 1)
         right = hl.utils.range_table(5)
         right = right.annotate(i=hl.range(right.idx + 1, 5)).explode('i').key_by('i')
-        left = left.annotate_rows(matches=right.index(left.row_key, product=True))
+        left = left.annotate_rows(matches=right.index(left.row_key, all_matches=True))
         rows = left.rows()
         self.assertTrue(rows.all(rows.matches.map(lambda x: x.idx) == hl.range(0, rows.row_idx)))
 
@@ -571,7 +571,7 @@ class Tests(unittest.TestCase):
             1 + (intervals.idx // 5) * 10 + (intervals.idx % 5),
             (1 + intervals.idx // 5) * 10 - (intervals.idx % 5)))
         intervals = intervals.annotate(i=intervals.idx % 5)
-        left = left.annotate_rows(interval_matches=intervals.index(left.row_key, product=True))
+        left = left.annotate_rows(interval_matches=intervals.index(left.row_key, all_matches=True))
         rows = left.rows()
         self.assertTrue(rows.all(hl.sorted(rows.interval_matches.map(lambda x: x.i))
                                  == hl.range(0, hl.min(rows.row_idx % 10, 10 - rows.row_idx % 10))))

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -388,6 +388,14 @@ class Tests(unittest.TestCase):
         self.assertTrue(ds.union_cols(ds.drop(ds.info))
                         .count_rows(), 346)
 
+    def test_table_product_join(self):
+        left = hl.utils.range_matrix_table(5, 1)
+        right = hl.utils.range_table(5)
+        right = right.select(i=hl.range(right.idx + 1, 5)).explode('i').key_by('i')
+        left = left.annotate_rows(matches=right.index(left.row_key, product=True))
+        rows = left.rows()
+        self.assertTrue(rows.all(rows.matches.length() == rows.row_idx))
+
     def test_naive_coalesce(self):
         vds = self.get_vds(min_partitions=8)
         self.assertEqual(vds.n_partitions(), 8)

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -556,15 +556,15 @@ class Tests(unittest.TestCase):
                                  .when(rows.row_idx % 10 < 5, rows.interval_matches.idx == rows.row_idx // 10)
                                  .default(hl.is_missing(rows.interval_matches))))
 
-    # def test_interval_product_join(self):
-    #     left = hl.utils.range_matrix_table(50, 1, n_partitions=8)
-    #     intervals = hl.utils.range_table(25)
-    #     intervals = intervals.key_by(interval=hl.interval(
-    #         1 + (intervals.idx // 5) * 10 + (intervals.idx % 5),
-    #         (1 + intervals.idx // 5) * 10 - (intervals.idx % 5)))
-    #     left = left.annotate_rows(interval_matches=intervals.index(left.row_key, product=True))
-    #     rows = left.rows()
-    #     self.assertTrue(rows.all(rows.interval_matches.length() == hl.min(rows.row_idx % 10, 10 - rows.row_idx % 10)))
+    def test_interval_product_join(self):
+        left = hl.utils.range_matrix_table(50, 1, n_partitions=8)
+        intervals = hl.utils.range_table(25)
+        intervals = intervals.key_by(interval=hl.interval(
+            1 + (intervals.idx // 5) * 10 + (intervals.idx % 5),
+            (1 + intervals.idx // 5) * 10 - (intervals.idx % 5)))
+        left = left.annotate_rows(interval_matches=intervals.index(left.row_key, product=True))
+        rows = left.rows()
+        self.assertTrue(rows.all(rows.interval_matches.length() == hl.min(rows.row_idx % 10, 10 - rows.row_idx % 10)))
 
     def test_entry_join_self(self):
         mt1 = hl.utils.range_matrix_table(10, 10, n_partitions=4).choose_cols([9, 8, 7, 6, 5, 4, 3, 2, 1, 0])

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -402,7 +402,7 @@ class Tests(unittest.TestCase):
             1 + (intervals.idx // 5) * 10 + (intervals.idx % 5),
             (1 + intervals.idx // 5) * 10 - (intervals.idx % 5)))
         intervals = intervals.annotate(i=intervals.idx % 5)
-        left = left.annotate(interval_matches=intervals.index(left.key, product=True))
+        left = left.annotate(interval_matches=intervals.index(left.key, all_matches=True))
         self.assertTrue(left.all(hl.sorted(left.interval_matches.map(lambda x: x.i))
                                  == hl.range(0, hl.min(left.idx % 10, 10 - left.idx % 10))))
 
@@ -420,7 +420,7 @@ class Tests(unittest.TestCase):
         left = hl.utils.range_table(5)
         right = hl.utils.range_table(5)
         right = right.annotate(i=hl.range(right.idx + 1, 5)).explode('i').key_by('i')
-        left = left.annotate(matches=right.index(left.key, product=True))
+        left = left.annotate(matches=right.index(left.key, all_matches=True))
         self.assertTrue(left.all(left.matches.length() == left.idx))
         self.assertTrue(left.all(left.matches.map(lambda x: x.idx) == hl.range(0, left.idx)))
 

--- a/hail/src/main/scala/is/hail/annotations/WritableRegionValue.scala
+++ b/hail/src/main/scala/is/hail/annotations/WritableRegionValue.scala
@@ -3,7 +3,7 @@ package is.hail.annotations
 import java.io.{ObjectInputStream, ObjectOutputStream}
 
 import scala.collection.generic.Growable
-import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.{ArrayBuffer, PriorityQueue}
 import is.hail.expr.types._
 import is.hail.expr.types.physical.{PBaseStruct, PStruct, PType}
 import is.hail.rvd.RVDContext
@@ -67,6 +67,39 @@ class WritableRegionValue private (
   private def readObject(s: ObjectInputStream): Unit = {
     throw new NotImplementedException()
   }
+}
+
+class RegionValuePriorityQueue(val t: PType, ctx: RVDContext, ord: Ordering[RegionValue])
+  extends Iterable[RegionValue]
+{
+  private val queue = new PriorityQueue[RegionValue]()(ord)
+  private val rvb = new RegionValueBuilder(null)
+
+  override def nonEmpty: Boolean = queue.nonEmpty
+
+  def empty: Boolean = queue.nonEmpty
+
+  override def head: RegionValue = queue.head
+
+  def enqueue(rv: RegionValue) {
+    val region = ctx.freshRegion
+    rvb.set(region)
+    rvb.start(t)
+    rvb.addRegionValue(t, rv)
+    queue.enqueue(RegionValue(region, rvb.end()))
+  }
+
+  def +=(rv: RegionValue): this.type = {
+    enqueue(rv)
+    this
+  }
+
+  def dequeue() {
+    val popped = queue.dequeue()
+    popped.region.close()
+  }
+
+  def iterator: Iterator[RegionValue] = queue.iterator
 }
 
 class RegionValueArrayBuffer(val t: PType, region: Region)

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -129,10 +129,10 @@ object LowerMatrixIR {
             'global('newColIdx).map('i ~> 'global(colsField)('i)))
           .dropFields('newColIdx))
 
-    case MatrixAnnotateRowsTable(child, table, root) =>
+    case MatrixAnnotateRowsTable(child, table, root, product) =>
       val kt = table.typ.keyType
-      if (kt.size == 1 && kt.types(0).isInstanceOf[TInterval] && !child.typ.rowKeyStruct.types(0).isInstanceOf[TInterval])
-        TableIntervalJoin(lower(child), lower(table), root)
+      if (kt.size == 1 && kt.types(0) == TInterval(child.typ.rowKeyStruct.types(0)))
+        TableIntervalJoin(lower(child), lower(table), root, product)
       else
         TableLeftJoinRightDistinct(lower(child), lower(table), root)
 

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -883,8 +883,10 @@ case class MatrixAnnotateColsTable(
 case class MatrixAnnotateRowsTable(
   child: MatrixIR,
   table: TableIR,
-  root: String) extends MatrixIR {
-  require(table.typ.keyType.isPrefixOf(child.typ.rowKeyStruct) ||
+  root: String,
+  product: Boolean
+) extends MatrixIR {
+  require((!product && table.typ.keyType.isPrefixOf(child.typ.rowKeyStruct)) ||
     (table.typ.keyType.size == 1 && table.typ.keyType.types(0) == TInterval(child.typ.rowKeyStruct.types(0))),
     s"\n  L: ${ child.typ }\n  R: ${ table.typ }")
 
@@ -903,7 +905,7 @@ case class MatrixAnnotateRowsTable(
 
   def copy(newChildren: IndexedSeq[BaseIR]): MatrixAnnotateRowsTable = {
     val IndexedSeq(child: MatrixIR, table: TableIR) = newChildren
-    MatrixAnnotateRowsTable(child, table, root)
+    MatrixAnnotateRowsTable(child, table, root, product)
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -978,9 +978,10 @@ object IRParser {
         TableLeftJoinRightDistinct(left, right, root)
       case "TableIntervalJoin" =>
         val root = identifier(it)
+        val product = boolean_literal(it)
         val left = table_ir(env)(it)
         val right = table_ir(env)(it)
-        TableIntervalJoin(left, right, root)
+        TableIntervalJoin(left, right, root, product)
       case "TableZipUnchecked" =>
         val left = table_ir(env)(it)
         val right = table_ir(env)(it)
@@ -1126,9 +1127,10 @@ object IRParser {
         MatrixRead(requestedType.getOrElse(reader.fullMatrixType), dropCols, dropRows, reader)
       case "MatrixAnnotateRowsTable" =>
         val root = string_literal(it)
+        val product = boolean_literal(it)
         val child = matrix_ir(env)(it)
         val table = table_ir(env)(it)
-        MatrixAnnotateRowsTable(child, table, root)
+        MatrixAnnotateRowsTable(child, table, root, product)
       case "MatrixAnnotateColsTable" =>
         val root = string_literal(it)
         val child = matrix_ir(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -232,8 +232,8 @@ object Pretty {
               prettyLongs(shape) + " " +
               blockSize.toString + " "
             case MatrixRowsHead(_, n) => n.toString
-            case MatrixAnnotateRowsTable(_, _, uid) =>
-              prettyStringLiteral(uid) + " "
+            case MatrixAnnotateRowsTable(_, _, uid, product) =>
+              prettyStringLiteral(uid) + " " + prettyBooleanLiteral(product)
             case MatrixAnnotateColsTable(_, _, uid) =>
               prettyStringLiteral(uid)
             case MatrixExplodeRows(_, path) => prettyIdentifiers(path)
@@ -258,7 +258,8 @@ object Pretty {
             case TableHead(_, n) => n.toString
             case TableJoin(_, _, joinType, joinKey) => s"$joinType $joinKey"
             case TableLeftJoinRightDistinct(_, _, root) => prettyIdentifier(root)
-            case TableIntervalJoin(_, _, root) => prettyIdentifier(root)
+            case TableIntervalJoin(_, _, root, product) =>
+              prettyIdentifier(root) + " " + prettyBooleanLiteral(product)
             case TableMultiWayZipJoin(_, dataName, globalName) =>
               s"${ prettyStringLiteral(dataName) } ${ prettyStringLiteral(globalName) }"
             case TableKeyByAndAggregate(_, _, _, nPartitions, bufferSize) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -270,7 +270,7 @@ object Simplify {
     case TableCount(TableKeyBy(child, _, _)) => TableCount(child)
     case TableCount(TableOrderBy(child, _)) => TableCount(child)
     case TableCount(TableLeftJoinRightDistinct(child, _, _)) => TableCount(child)
-    case TableCount(TableIntervalJoin(child, _, _)) => TableCount(child)
+    case TableCount(TableIntervalJoin(child, _, _, _)) => TableCount(child)
     case TableCount(TableRange(n, _)) => I64(n)
     case TableCount(TableParallelize(rowsAndGlobal, _)) => Cast(ArrayLen(GetField(rowsAndGlobal, "rows")), TInt64())
     case TableCount(TableRename(child, _, _)) => TableCount(child)

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -551,16 +551,22 @@ case class TableJoin(left: TableIR, right: TableIR, joinType: String, joinKey: I
   }
 }
 
-case class TableIntervalJoin(left: TableIR, right: TableIR, root: String) extends TableIR {
+case class TableIntervalJoin(
+  left: TableIR,
+  right: TableIR,
+  root: String,
+  product: Boolean
+) extends TableIR {
   lazy val children: IndexedSeq[BaseIR] = Array(left, right)
 
-  val (newRowPType, ins) = left.typ.rowType.physicalType.unsafeStructInsert(right.typ.valueType.physicalType, List(root))
+  val rightType: Type = if (product) TArray(right.typ.valueType) else right.typ.valueType
+  val (newRowPType, ins) = left.typ.rowType.physicalType.unsafeStructInsert(rightType.physicalType, List(root))
   val typ: TableType = left.typ.copy(rowType = newRowPType.virtualType)
 
   override def rvdType: RVDType = RVDType(newRowPType, typ.key)
 
   override def copy(newChildren: IndexedSeq[BaseIR]): TableIR =
-    TableIntervalJoin(newChildren(0).asInstanceOf[TableIR], newChildren(1).asInstanceOf[TableIR], root)
+    TableIntervalJoin(newChildren(0).asInstanceOf[TableIR], newChildren(1).asInstanceOf[TableIR], root, product)
 
   override def partitionCounts: Option[IndexedSeq[Long]] = left.partitionCounts
 
@@ -568,32 +574,61 @@ case class TableIntervalJoin(left: TableIR, right: TableIR, root: String) extend
     val leftValue = left.execute(hc)
     val rightValue = right.execute(hc)
 
-    val leftRVDType = leftValue.rvd.typ
     val rightRVDType = rightValue.rvd.typ
 
     val localNewRowPType = newRowPType
     val localIns = ins
 
-    val zipper = { (ctx: RVDContext, it: Iterator[RegionValue], intervals: Iterator[RegionValue]) =>
-      val rvb = new RegionValueBuilder()
-      val rv2 = RegionValue()
-      OrderedRVIterator(leftRVDType, it, ctx).leftIntervalJoinDistinct(
-        OrderedRVIterator(rightRVDType, intervals, ctx))
-        .map { case Muple(rv, i) =>
-          rvb.set(rv.region)
-          rvb.start(localNewRowPType)
-          localIns(
-            rv.region,
-            rv.offset,
-            rvb,
-            () => if (i == null) rvb.setMissing() else rvb.selectRegionValue(rightRVDType.rowType, rightRVDType.valueFieldIdx, i))
-          rv2.set(rv.region, rvb.end())
+    val joinedType = RVDType(newRowPType, typ.key)
+    val newRVD =
+      if (product) {
+        val joiner = (_: RVDContext, it: Iterator[Muple[RegionValue, Iterable[RegionValue]]]) => {
+          val rvb = new RegionValueBuilder()
+          val rv2 = RegionValue()
+          it.map { case Muple(rv, is) =>
+            rvb.set(rv.region)
+            rvb.start(localNewRowPType)
+            localIns(
+              rv.region,
+              rv.offset,
+              rvb,
+              () => {
+                rvb.startArray(is.size)
+                is.foreach(i => rvb.selectRegionValue(rightRVDType.rowType, rightRVDType.valueFieldIdx, i))
+                rvb.endArray()
+              })
+            rv2.set(rv.region, rvb.end())
 
-          rv2
+            rv2
+          }
         }
-    }
 
-    val newRVD = leftValue.rvd.intervalAlignAndZipPartitions(RVDType(newRowPType, typ.key), rightValue.rvd)(zipper)
+        leftValue.rvd.orderedLeftIntervalJoin(rightValue.rvd, joiner, joinedType)
+      } else {
+        val joiner = (_: RVDContext, it: Iterator[JoinedRegionValue]) => {
+          val rvb = new RegionValueBuilder()
+          val rv2 = RegionValue()
+          it.map { case Muple(rv, i) =>
+            rvb.set(rv.region)
+            rvb.start(localNewRowPType)
+            localIns(
+              rv.region,
+              rv.offset,
+              rvb,
+              () =>
+                if (i == null)
+                  rvb.setMissing()
+                else
+                  rvb.selectRegionValue(rightRVDType.rowType, rightRVDType.valueFieldIdx, i))
+            rv2.set(rv.region, rvb.end())
+
+            rv2
+          }
+        }
+
+        leftValue.rvd.orderedLeftIntervalJoinDistinct(rightValue.rvd, joiner, joinedType)
+      }
+
     TableValue(typ, leftValue.globals, newRVD)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PInterval.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PInterval.scala
@@ -31,7 +31,6 @@ case class PInterval(pointType: PType, override val required: Boolean = false) e
     CodeOrdering.intervalOrdering(this, other.asInstanceOf[PInterval], mb)
   }
 
-
   override def unsafeOrdering(): UnsafeOrdering =
     new UnsafeOrdering {
       private val pOrd = pointType.unsafeOrdering()
@@ -56,6 +55,34 @@ case class PInterval(pointType: PType, override val required: Boolean = false) e
           } else cmp
         } else {
           if (sdef1) -1 else 1
+        }
+      }
+    }
+
+  def endPrimaryUnsafeOrdering(): UnsafeOrdering =
+    new UnsafeOrdering {
+      private val pOrd = pointType.unsafeOrdering()
+      def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
+        val edef1 = endDefined(r1, o1)
+        if (edef1 == endDefined(r2, o2)) {
+          val cmp = pOrd.compare(r1, loadEnd(r1, o1), r2, loadEnd(r2, o2))
+          if (cmp == 0) {
+            val includesE1 = includesEnd(r1, o1)
+            if (includesE1 == includesEnd(r2, o2)) {
+              val sdef1 = startDefined(r1, o1)
+              if (sdef1 == startDefined(r2, o2)) {
+                val cmp = pOrd.compare(r1, loadStart(r1, o1), r2, loadStart(r2, o2))
+                if (cmp == 0) {
+                  val includesS1 = includesStart(r1, o1)
+                  if (includesS1 == includesStart(r2, o2)) {
+                    0
+                  } else if (includesS1) 1 else -1
+                } else cmp
+              } else if (sdef1) -1 else 1
+            } else if (includesE1) -1 else 1
+          } else cmp
+        } else {
+          if (edef1) -1 else 1
         }
       }
     }

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -777,6 +777,20 @@ class RVD(
   ): RVD =
     keyBy(joinKey).orderedJoinDistinct(right.keyBy(joinKey), joinType, joiner, joinedType)
 
+  def orderedLeftIntervalJoin(
+    right: RVD,
+    joiner: (RVDContext, Iterator[Muple[RegionValue, Iterable[RegionValue]]]) => Iterator[RegionValue],
+    joinedType: RVDType
+  ): RVD =
+    keyBy(1).orderedLeftIntervalJoin(right.keyBy(1), joiner, joinedType)
+
+  def orderedLeftIntervalJoinDistinct(
+    right: RVD,
+    joiner: (RVDContext, Iterator[JoinedRegionValue]) => Iterator[RegionValue],
+    joinedType: RVDType
+  ): RVD =
+    keyBy(1).orderedLeftIntervalJoinDistinct(right.keyBy(1), joiner, joinedType)
+
   def orderedZipJoin(right: RVD): (RVDPartitioner, ContextRDD[RVDContext, JoinedRegionValue]) =
     orderedZipJoin(right, typ.key.length)
 

--- a/hail/src/main/scala/is/hail/rvd/RVDType.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVDType.scala
@@ -158,17 +158,30 @@ final case class RVDType(rowType: PStruct, key: IndexedSeq[String])
 }
 
 object RVDType {
-  def selectUnsafeOrdering(t1: PStruct, fields1: Array[Int],
-    t2: PStruct, fields2: Array[Int], missingEqual: Boolean=true): UnsafeOrdering = {
+  def selectUnsafeOrdering(
+    t1: PStruct, fields1: Array[Int],
+    t2: PStruct, fields2: Array[Int],
+    missingEqual: Boolean=true
+  ): UnsafeOrdering = {
+    val fieldOrderings = Range(0, fields1.length).map { i =>
+      t1.types(fields1(i)).unsafeOrdering(t2.types(fields2(i)))
+    }.toArray
+
+    selectUnsafeOrdering(t1, fields1, t2, fields2, fieldOrderings, missingEqual)
+  }
+
+  def selectUnsafeOrdering(
+    t1: PStruct, fields1: Array[Int],
+    t2: PStruct, fields2: Array[Int],
+    fieldOrderings: Array[UnsafeOrdering],
+    missingEqual: Boolean
+  ): UnsafeOrdering = {
     require(fields1.length == fields2.length)
     require((fields1, fields2).zipped.forall { case (f1, f2) =>
       t1.types(f1) isOfType t2.types(f2)
     })
 
     val nFields = fields1.length
-    val fieldOrderings = Range(0, nFields).map { i =>
-      t1.types(fields1(i)).unsafeOrdering(t2.types(fields2(i)))
-    }.toArray
 
     new UnsafeOrdering {
       def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1671,7 +1671,7 @@ class IRSuite extends SparkSuite {
           " # cols",
           read.typ.colKey),
         MatrixAnnotateColsTable(read, tableRead, "uid_123"),
-        MatrixAnnotateRowsTable(read, tableRead, "uid_123"),
+        MatrixAnnotateRowsTable(read, tableRead, "uid_123", product=false),
         MatrixRename(read, Map("global_i64" -> "foo"), Map("col_i64" -> "bar"), Map("row_i64" -> "baz"), Map("entry_i64" -> "quam"))
       )
 

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -282,7 +282,7 @@ class PruneSuite extends SparkSuite {
   @Test def testTableIntervalJoinMemo() {
     val tk1 = TableKeyBy(tab, Array("1"))
     val tk2 = TableKeyBy(tab, Array("3"))
-    val tj = TableIntervalJoin(tk1, tk2, "foo")
+    val tj = TableIntervalJoin(tk1, tk2, "foo", product=false)
     checkMemo(tj,
       subsetTable(tj.typ, "row.1", "row.4", "row.foo"),
       Array(
@@ -437,7 +437,7 @@ class PruneSuite extends SparkSuite {
 
   @Test def testMatrixAnnotateRowsTableMemo() {
     val tl = TableLiteral(Interpret(MatrixRowsTable(mat)))
-    val mart = MatrixAnnotateRowsTable(mat, tl, "foo")
+    val mart = MatrixAnnotateRowsTable(mat, tl, "foo", product=false)
     checkMemo(mart, subsetMatrixTable(mart.typ, "va.foo.r3", "va.r3"),
       Array(subsetMatrixTable(mat.typ, "va.r3"), subsetTable(tl.typ, "row.r3")))
   }
@@ -767,7 +767,7 @@ class PruneSuite extends SparkSuite {
   @Test def testTableIntervalJoinRebuild() {
     val tk1 = TableKeyBy(tab, Array("1"))
     val tk2 = TableKeyBy(tab, Array("3"))
-    val tj = TableIntervalJoin(tk1, tk2, "foo")
+    val tj = TableIntervalJoin(tk1, tk2, "foo", product=false)
 
     checkRebuild(tj, subsetTable(tj.typ, "row.1", "row.4"),
       (_: BaseIR, r: BaseIR) => {
@@ -901,7 +901,7 @@ class PruneSuite extends SparkSuite {
 
   @Test def testMatrixAnnotateRowsTableRebuild() {
     val tl = TableLiteral(Interpret(MatrixRowsTable(mat)))
-    val mart = MatrixAnnotateRowsTable(mat, tl, "foo")
+    val mart = MatrixAnnotateRowsTable(mat, tl, "foo", product=false)
     checkRebuild(mart, subsetMatrixTable(mart.typ),
       (_: BaseIR, r: BaseIR) => {
         r.isInstanceOf[MatrixLiteral]

--- a/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -37,7 +37,8 @@ class PartitioningSuite extends SparkSuite {
       MatrixAnnotateRowsTable(
         ir.MatrixRead(rangeReader.fullMatrixType, false, false, rangeReader),
         t,
-        "foo"))
+        "foo",
+        product=false))
       .rvd.count()
   }
 


### PR DESCRIPTION
Add `product` option to `Table.index`, and `MatrixTable.{index_rows, index_cols}`. Supports interval joins. Refactored the index methods to reduce code duplication, and make them more consistent with each other. Only case not supporting `product=True` is annotating columns of a matrix table with an interval keyed table.