### PR TITLE
[batch] ownership checks

### DIFF
--- a/batch/batch/database.py
+++ b/batch/batch/database.py
@@ -117,6 +117,14 @@ class Table:  # pylint: disable=R0903
         self._db = db
         await self._db.create_table(name, schema, keys, can_exist)
 
+    async def new_index(self, index_name, *fields):
+        assert len(fields) != 0
+        async with self._db.pool.acquire() as conn:
+            async with conn.cursor() as cursor:
+                names = ", ".join([f'`{fd.replace("`", "``")}`' for fd in fields])
+                sql = f"CREATE INDEX `{index_name}` ON `{self.name}` ({names})"
+                await cursor.execute(sql)
+
     async def new_record(self, **items):
         async with self._db.pool.acquire() as conn:
             async with conn.cursor() as cursor:

--- a/batch/batch/server/database.py
+++ b/batch/batch/server/database.py
@@ -32,6 +32,7 @@ class JobsTable(Table):
                   'time_created': 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP',
                   'duration': 'BIGINT',
                   'userdata': 'TEXT(65535)',
+                  'user': 'VARCHAR(100)',
                   'attributes': 'TEXT(65535)',
                   'tasks': 'TEXT(65535)',
                   'input_log_uri': 'VARCHAR(1024)',
@@ -41,6 +42,7 @@ class JobsTable(Table):
         keys = ['id']
 
         await super().__init__(db, name, schema, keys)
+        await super().new_index('user', 'user')
 
     async def update_record(self, id, **items):
         await super().update_record({'id': id}, items)
@@ -141,10 +143,13 @@ class BatchTable(Table):
                   'ttl': 'INT',
                   'is_open': 'BOOLEAN NOT NULL',
                   'time_created': 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP',
+                  'userdata': 'TEXT(65535)',
+                  'user': 'VARCHAR(100)'
                   }
         keys = ['id']
 
         await super().__init__(db, name, schema, keys)
+        await super().new_index('user', 'user')
 
     async def update_record(self, id, **items):
         await super().update_record({'id': id}, items)

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -286,7 +286,7 @@ class Job:
     async def from_db(id, user):
         records = await db.jobs.get_records(id)
         if len(records) == 1:
-            job = await Job.from_record(records[0])
+            job = Job.from_record(records[0])
             if user == job.user:
                 return job
         return None

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -668,7 +668,7 @@ async def get_job_list(request, userdata):
     params = request.query
     user = userdata['ksa_name']
 
-    jobs = [Job.from_record(record) for record in await db.jobs.get_all_records() if record['user'] == user]
+    jobs = [Job.from_record(record) for record in await db.jobs.get_record({'user': user})]
 
     for name, value in params.items():
         if name == 'complete':
@@ -874,7 +874,7 @@ async def get_batches_list(request, userdata):
     params = request.query
     user = userdata['ksa_name']
 
-    batches = [Batch.from_record(record) for record in await db.batch.get_all_records() if user == record['user']]
+    batches = [Batch.from_record(record) for record in await db.batch.get_record({'user': user})]
     for name, value in params.items():
         if name == 'complete':
             if value not in ('0', '1'):


### PR DESCRIPTION
I added `user` and `userdata` to the jobs and batch table. I also added `user` as a secondary index, which @danking also did. 

I used the `ksa_name` in the jwt for now. @akotlar We should figure out what this should be instead. 

This does not check authentication for `get_recent_events`. I also am concerned about the case where we can't access jobs, batches easily as there's no support for a super user who can view everything.

Stacked on #5934 