### PR TITLE
[batch] remove scratch_folder

### DIFF
--- a/batch/batch/aioclient.py
+++ b/batch/batch/aioclient.py
@@ -73,15 +73,13 @@ class Batch:
 
     async def create_job(self, image, command=None, args=None, env=None, ports=None,
                          resources=None, tolerations=None, volumes=None, security_context=None,
-                         service_account_name=None, attributes=None, callback=None, parent_ids=None,
-                         input_files=None, output_files=None, copy_service_account_name=None,
-                         always_run=False):
+                         attributes=None, callback=None, parent_ids=None, input_files=None,
+                         output_files=None, always_run=False):
         if parent_ids is None:
             parent_ids = []
         return await self.client._create_job(
             image, command, args, env, ports, resources, tolerations, volumes, security_context,
-            service_account_name, attributes, self.id, callback, parent_ids,
-            input_files, output_files, copy_service_account_name, always_run)
+            attributes, self.id, callback, parent_ids, input_files, output_files, always_run)
 
     async def close(self):
         await self.client._patch('/batches/{}/close'.format(self.id))
@@ -158,14 +156,12 @@ class BatchClient:
                           tolerations,
                           volumes,
                           security_context,
-                          service_account_name,
                           attributes,
                           batch_id,
                           callback,
                           parent_ids,
                           input_files,
                           output_files,
-                          copy_service_account_name,
                           always_run):
         if env:
             env = [{'name': k, 'value': v} for (k, v) in env.items()]
@@ -212,8 +208,6 @@ class BatchClient:
             spec['tolerations'] = tolerations
         if security_context:
             spec['securityContext'] = security_context
-        if service_account_name:
-            spec['serviceAccountName'] = service_account_name
 
         doc = {
             'spec': spec,
@@ -230,8 +224,6 @@ class BatchClient:
             doc['input_files'] = input_files
         if output_files:
             doc['output_files'] = output_files
-        if copy_service_account_name:
-            doc['copy_service_account_name'] = copy_service_account_name
 
         j = await self._post('/jobs/create', json=doc)
 
@@ -285,20 +277,17 @@ class BatchClient:
                          tolerations=None,
                          volumes=None,
                          security_context=None,
-                         service_account_name=None,
                          attributes=None,
                          callback=None,
                          parent_ids=None,
                          input_files=None,
                          output_files=None,
-                         copy_service_account_name=None,
                          always_run=False):
         if parent_ids is None:
             parent_ids = []
         return await self._create_job(
             image, command, args, env, ports, resources, tolerations, volumes, security_context,
-            service_account_name, attributes, None, callback, parent_ids,
-            input_files, output_files, copy_service_account_name, always_run)
+            attributes, None, callback, parent_ids, input_files, output_files, always_run)
 
     async def create_batch(self, attributes=None, callback=None, ttl=None):
         doc = {}

--- a/batch/batch/aioclient.py
+++ b/batch/batch/aioclient.py
@@ -12,7 +12,7 @@ from . import schemas
 
 
 class Job:
-    def __init__(self, client, id, attributes=None, parent_ids=None, scratch_folder=None, _status=None):
+    def __init__(self, client, id, attributes=None, parent_ids=None, _status=None):
         if parent_ids is None:
             parent_ids = []
         if attributes is None:
@@ -22,7 +22,6 @@ class Job:
         self.id = id
         self.attributes = attributes
         self.parent_ids = parent_ids
-        self.scratch_folder = scratch_folder
         self._status = _status
 
     async def is_complete(self):
@@ -60,7 +59,6 @@ class Job:
         del self.id
         del self.attributes
         del self.parent_ids
-        del self.scratch_folder
         del self._status
 
     async def log(self):
@@ -76,13 +74,13 @@ class Batch:
     async def create_job(self, image, command=None, args=None, env=None, ports=None,
                          resources=None, tolerations=None, volumes=None, security_context=None,
                          service_account_name=None, attributes=None, callback=None, parent_ids=None,
-                         scratch_folder=None, input_files=None, output_files=None,
-                         copy_service_account_name=None, always_run=False):
+                         input_files=None, output_files=None, copy_service_account_name=None,
+                         always_run=False):
         if parent_ids is None:
             parent_ids = []
         return await self.client._create_job(
             image, command, args, env, ports, resources, tolerations, volumes, security_context,
-            service_account_name, attributes, self.id, callback, parent_ids, scratch_folder,
+            service_account_name, attributes, self.id, callback, parent_ids,
             input_files, output_files, copy_service_account_name, always_run)
 
     async def close(self):
@@ -165,7 +163,6 @@ class BatchClient:
                           batch_id,
                           callback,
                           parent_ids,
-                          scratch_folder,
                           input_files,
                           output_files,
                           copy_service_account_name,
@@ -229,8 +226,6 @@ class BatchClient:
             doc['batch_id'] = batch_id
         if callback:
             doc['callback'] = callback
-        if scratch_folder:
-            doc['scratch_folder'] = scratch_folder
         if input_files:
             doc['input_files'] = input_files
         if output_files:
@@ -294,7 +289,6 @@ class BatchClient:
                          attributes=None,
                          callback=None,
                          parent_ids=None,
-                         scratch_folder=None,
                          input_files=None,
                          output_files=None,
                          copy_service_account_name=None,
@@ -303,7 +297,7 @@ class BatchClient:
             parent_ids = []
         return await self._create_job(
             image, command, args, env, ports, resources, tolerations, volumes, security_context,
-            service_account_name, attributes, None, callback, parent_ids, scratch_folder,
+            service_account_name, attributes, None, callback, parent_ids,
             input_files, output_files, copy_service_account_name, always_run)
 
     async def create_batch(self, attributes=None, callback=None, ttl=None):

--- a/batch/batch/api.py
+++ b/batch/batch/api.py
@@ -51,7 +51,7 @@ class API():
         return self.http(requests.delete, *args, **kwargs)
 
     def create_job(self, url, spec, attributes, batch_id, callback, parent_ids,
-                   scratch_folder, input_files, output_files, always_run):
+                   input_files, output_files, always_run):
         doc = {
             'spec': spec,
             'parent_ids': parent_ids,
@@ -63,8 +63,6 @@ class API():
             doc['batch_id'] = batch_id
         if callback:
             doc['callback'] = callback
-        if scratch_folder:
-            doc['scratch_folder'] = scratch_folder
         if input_files:
             doc['input_files'] = input_files
         if output_files:

--- a/batch/batch/client.py
+++ b/batch/batch/client.py
@@ -69,13 +69,13 @@ class Batch:
 
     def create_job(self, image, command=None, args=None, env=None, ports=None,
                    resources=None, tolerations=None, volumes=None, security_context=None,
-                   service_account_name=None, attributes=None, callback=None, parent_ids=None,
-                   input_files=None, output_files=None, always_run=False):
+                   attributes=None, callback=None, parent_ids=None, input_files=None,
+                   output_files=None, always_run=False):
         if parent_ids is None:
             parent_ids = []
         return self.client._create_job(
             image, command, args, env, ports, resources, tolerations, volumes, security_context,
-            service_account_name, attributes, self.id, callback, parent_ids, input_files,
+            attributes, self.id, callback, parent_ids, input_files,
             output_files, always_run)
 
     def close(self):
@@ -133,7 +133,6 @@ class BatchClient:
                     tolerations,
                     volumes,
                     security_context,
-                    service_account_name,
                     attributes,
                     batch_id,
                     callback,
@@ -186,8 +185,6 @@ class BatchClient:
             spec['tolerations'] = tolerations
         if security_context:
             spec['securityContext'] = security_context
-        if service_account_name:
-            spec['serviceAccountName'] = service_account_name
 
         j = self.api.create_job(self.url, spec, attributes, batch_id, callback,
                                 parent_ids, input_files, output_files, always_run)
@@ -261,7 +258,6 @@ class BatchClient:
                    tolerations=None,
                    volumes=None,
                    security_context=None,
-                   service_account_name=None,
                    attributes=None,
                    callback=None,
                    parent_ids=None,
@@ -272,8 +268,7 @@ class BatchClient:
             parent_ids = []
         return self._create_job(
             image, command, args, env, ports, resources, tolerations, volumes, security_context,
-            service_account_name, attributes, None, callback, parent_ids, input_files, output_files,
-            always_run)
+            attributes, None, callback, parent_ids, input_files, output_files, always_run)
 
     def create_batch(self, attributes=None, callback=None, ttl=None):
         batch = self.api.create_batch(self.url, attributes, callback, ttl)

--- a/batch/batch/client.py
+++ b/batch/batch/client.py
@@ -10,7 +10,7 @@ from .poll_until import poll_until
 
 
 class Job:
-    def __init__(self, client, id, attributes=None, parent_ids=None, scratch_folder=None, _status=None):
+    def __init__(self, client, id, attributes=None, parent_ids=None, _status=None):
         if parent_ids is None:
             parent_ids = []
         if attributes is None:
@@ -20,7 +20,6 @@ class Job:
         self.id = id
         self.attributes = attributes
         self.parent_ids = parent_ids
-        self.scratch_folder = scratch_folder
         self._status = _status
 
     def is_complete(self):
@@ -56,7 +55,6 @@ class Job:
         del self.id
         del self.attributes
         del self.parent_ids
-        del self.scratch_folder
         del self._status
 
     def log(self):
@@ -72,13 +70,13 @@ class Batch:
     def create_job(self, image, command=None, args=None, env=None, ports=None,
                    resources=None, tolerations=None, volumes=None, security_context=None,
                    service_account_name=None, attributes=None, callback=None, parent_ids=None,
-                   scratch_folder=None, input_files=None, output_files=None, always_run=False):
+                   input_files=None, output_files=None, always_run=False):
         if parent_ids is None:
             parent_ids = []
         return self.client._create_job(
             image, command, args, env, ports, resources, tolerations, volumes, security_context,
-            service_account_name, attributes, self.id, callback, parent_ids, scratch_folder,
-            input_files, output_files, always_run)
+            service_account_name, attributes, self.id, callback, parent_ids, input_files,
+            output_files, always_run)
 
     def close(self):
         self.client._close_batch(self.id)
@@ -140,7 +138,6 @@ class BatchClient:
                     batch_id,
                     callback,
                     parent_ids,
-                    scratch_folder,
                     input_files,
                     output_files,
                     always_run):
@@ -193,8 +190,7 @@ class BatchClient:
             spec['serviceAccountName'] = service_account_name
 
         j = self.api.create_job(self.url, spec, attributes, batch_id, callback,
-                                parent_ids, scratch_folder, input_files, output_files,
-                                always_run)
+                                parent_ids, input_files, output_files, always_run)
         return Job(self,
                    j['id'],
                    attributes=j.get('attributes'),
@@ -269,7 +265,6 @@ class BatchClient:
                    attributes=None,
                    callback=None,
                    parent_ids=None,
-                   scratch_folder=None,
                    input_files=None,
                    output_files=None,
                    always_run=False):
@@ -277,8 +272,8 @@ class BatchClient:
             parent_ids = []
         return self._create_job(
             image, command, args, env, ports, resources, tolerations, volumes, security_context,
-            service_account_name, attributes, None, callback, parent_ids, scratch_folder,
-            input_files, output_files, always_run)
+            service_account_name, attributes, None, callback, parent_ids, input_files, output_files,
+            always_run)
 
     def create_batch(self, attributes=None, callback=None, ttl=None):
         batch = self.api.create_batch(self.url, attributes, callback, ttl)

--- a/batch/batch/server/database.py
+++ b/batch/batch/server/database.py
@@ -23,7 +23,6 @@ class JobsTable(Table):
                   'state': 'VARCHAR(40) NOT NULL',
                   'exit_code': 'INT',
                   'batch_id': 'BIGINT',
-                  'scratch_folder': 'VARCHAR(1024)',
                   'pod_name': 'VARCHAR(1024)',
                   'pvc': 'TEXT(65535)',
                   'callback': 'TEXT(65535)',

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -123,12 +123,6 @@ class Test(unittest.TestCase):
 
         assert_batch_ids({b2.id}, attributes={'tag': tag, 'name': 'b2'})
 
-    def test_scratch_folder(self):
-        sb = 'gs://test-bucket/folder'
-        j = self.batch.create_job('alpine', ['true'], scratch_folder=sb)
-        status = j.status()
-        assert(status['scratch_folder'] == sb)
-
     def test_fail(self):
         j = self.batch.create_job('alpine', ['false'])
         status = j.wait()

--- a/ci/ci/pr.py
+++ b/ci/ci/pr.py
@@ -54,7 +54,6 @@ def try_new_build(source, target):
                     'key': 'preemptible',
                     'value': 'true'
                 }],
-                service_account_name='test-svc',
                 callback=SELF_HOSTNAME + '/ci_build_done',
                 attributes=attributes,
                 volumes=[{

--- a/ci/ci/prs.py
+++ b/ci/ci/prs.py
@@ -254,7 +254,6 @@ class PRS(object):
                 security_context={
                     'fsGroup': 412,
                 },
-                service_account_name='deploy-svc',
                 attributes=attributes,
                 callback=SELF_HOSTNAME + '/deploy_build_done')
             log.info(f'deploying {target_ref.short_str()}:{latest_sha} in job {job.id}')


### PR DESCRIPTION
Stacked on #5934. `scratch_folder` is not used anymore because we have the bucket_name from the jwt 