### PR TITLE
pin urllib because google.resumable_media.requests subpackage require…

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -21,5 +21,6 @@ pylint
 pymysql
 pytest
 requests
+urllib<1.25,>=1.21.1
 uvloop>=0.12
 werkzeug


### PR DESCRIPTION
…s this