### PR TITLE
[pipeline] Refactor backend code

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -34,6 +34,8 @@ steps:
     # hail|test-batch
     - user-jwt-vkqfw
     - gsa-key-2x975
+    # pipeline|test-user
+    - pipeline-test-0-1--hail-is-service-account-key
    dependsOn:
     - default_ns
     - deploy_batch_sa
@@ -89,6 +91,13 @@ steps:
    dockerFile: batch/Dockerfile.test
    contextPath: .
    publishAs: test-batch
+   dependsOn:
+     - base_image
+ - kind: buildImage
+   name: test_pipeline_image
+   dockerFile: pipeline/Dockerfile.test
+   contextPath: .
+   publishAs: test-pipeline
    dependsOn:
      - base_image
  - kind: buildImage
@@ -485,6 +494,20 @@ steps:
     - deploy_batch
     - deploy_batch_pods
     - test_batch_image
+ - kind: deploy
+   name: test_pipeline
+   namespace:
+     valueFrom: batch_pods_ns.name
+   config: pipeline/test-pipeline-pod.yaml
+   wait:
+    - kind: Pod
+      name: test-pipeline
+      for: completed
+   dependsOn:
+    - default_ns
+    - batch_pods_ns
+    - deploy_batch
+    - test_pipeline_image
  - kind: deploy
    name: deploy_apiserver
    namespace:

--- a/pipeline/Dockerfile.test
+++ b/pipeline/Dockerfile.test
@@ -1,0 +1,20 @@
+FROM {{ base_image.image }}
+
+COPY hailjwt/setup.py /hailjwt/
+COPY hailjwt/hailjwt /hailjwt/hailjwt/
+RUN pip3 install --no-cache-dir /hailjwt && \
+  rm -rf /hailjwt
+
+COPY batch/setup.py /batch/
+COPY batch/batch/ /batch/batch/
+RUN pip3 install --no-cache-dir /batch && \
+  rm -rf /batch
+
+COPY pipeline/setup.py /pipeline/
+COPY pipeline/pipeline/ /pipeline/pipeline/
+RUN pip3 install --no-cache-dir /pipeline && \
+  rm -rf /pipeline
+
+COPY pipeline/test/ /test/
+
+CMD ["python3", "-m", "pytest", "-v", "/test/"]

--- a/pipeline/Dockerfile.test
+++ b/pipeline/Dockerfile.test
@@ -6,15 +6,15 @@ RUN pip3 install --no-cache-dir /hailjwt && \
   rm -rf /hailjwt
 
 COPY batch/setup.py /batch/
-COPY batch/batch/ /batch/batch/
+COPY batch/batch /batch/batch/
 RUN pip3 install --no-cache-dir /batch && \
   rm -rf /batch
 
 COPY pipeline/setup.py /pipeline/
-COPY pipeline/pipeline/ /pipeline/pipeline/
+COPY pipeline/pipeline /pipeline/pipeline/
 RUN pip3 install --no-cache-dir /pipeline && \
   rm -rf /pipeline
 
-COPY pipeline/test/ /test/
+COPY pipeline/test /test/
 
-CMD ["python3", "-m", "pytest", "-v", "/test/"]
+CMD ["python3", "-m", "pytest", "-v", "-s", "/test/"]

--- a/pipeline/pipeline/backend.py
+++ b/pipeline/pipeline/backend.py
@@ -301,6 +301,7 @@ class BatchBackend(Backend):
             job_id_to_command[j.id] = cmd
             n_jobs_submitted += 1
 
+        batch.close()
         status = batch.wait()
 
         failed_jobs = [(j['id'], j['exit_code']) for j in status['jobs'] if 'exit_code' in j and j['exit_code'] > 0]

--- a/pipeline/pipeline/backend.py
+++ b/pipeline/pipeline/backend.py
@@ -299,6 +299,7 @@ class BatchBackend(Backend):
                 attributes={'label': 'remove_tmpdir'},
                 always_run=True)
             job_id_to_command[j.id] = cmd
+            n_jobs_submitted += 1
 
         status = batch.wait()
 

--- a/pipeline/pipeline/backend.py
+++ b/pipeline/pipeline/backend.py
@@ -273,14 +273,12 @@ class BatchBackend(Backend):
             if verbose:
                 print(f"Submitted Job {j.id} with command: {defs + cmd}")
 
-        status = batch.wait()
-
         if delete_scratch_on_exit:
             parent_ids = list(job_id_to_command.keys())
             rm_cmd = f'gsutil rm -r {remote_tmpdir}'
             cmd = f'{activate_service_account} && {rm_cmd}'
             j = batch.create_job(
-                image='google/cloud-sdk:alpine',
+                image='google/cloud-sdk:237.0.0-alpine',
                 command=['/bin/bash', '-c', cmd],
                 parent_ids=parent_ids,
                 volumes=volumes,

--- a/pipeline/pipeline/pipeline.py
+++ b/pipeline/pipeline/pipeline.py
@@ -61,6 +61,7 @@ class Pipeline:
         self._tasks = []
         self._resource_map = {}
         self._allocated_files = set()
+        self._input_resources = set()
         self._backend = backend if backend else LocalBackend()
         self._uid = Pipeline._get_uid()
         self._default_image = default_image
@@ -115,6 +116,7 @@ class Pipeline:
         irf = InputResourceFile(value if value else self._tmp_file())
         irf._add_input_path(input_path)
         self._resource_map[irf._uid] = irf
+        self._input_resources.add(irf)
         return irf
 
     def _new_resource_group(self, source, mappings):

--- a/pipeline/pipeline/pylintrc
+++ b/pipeline/pipeline/pylintrc
@@ -7,7 +7,7 @@
 # R0903 Too few public methods, R0401 Cyclic import, R0801 Similar lines,
 # R0912 Too many branches, R1720 no-else-raise
 
-disable=C0111,W1203,W1202,C0111,R0913,W0622,W0212,W0621,R0914,W0603,R0902,R1705,W0511,R0903,R0401,R0801,R0912,R1720
+disable=C0111,W1203,W1202,C0111,R0913,W0622,W0212,W0621,R0914,W0603,R0902,R1705,W0511,R0903,R0401,R0801,R0912,R1720,invalid-name
 
 [FORMAT]
 # String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1

--- a/pipeline/pipeline/resource.py
+++ b/pipeline/pipeline/resource.py
@@ -60,7 +60,7 @@ class ResourceFile(Resource, str):
     def _add_output_path(self, path):
         self._output_paths.add(path)
         if self._source is not None:
-            self._source._add_outputs(self)
+            self._source._external_outputs.add(self)
 
     def _add_resource_group(self, rg):
         self._resource_group = rg
@@ -202,7 +202,6 @@ class ResourceGroup(Resource):
         self._resources = {}  # dict of name to resource uid
         self._root = root
         self._uid = ResourceGroup._new_uid()
-        self._output_paths = set()
 
         for name, resource_file in values.items():
             assert isinstance(resource_file, ResourceFile)
@@ -214,9 +213,8 @@ class ResourceGroup(Resource):
         return directory + '/' + subdir + '/' + self._root
 
     def _add_output_path(self, path):
-        self._output_paths.add(path)
-        if self._source is not None:
-            self._source._add_outputs(self)
+        for name, rf in self._resources.items():
+            rf._add_output_path(path + '.' + name)
 
     def _get_resource(self, item):
         if item not in self._resources:

--- a/pipeline/pipeline/task.py
+++ b/pipeline/pipeline/task.py
@@ -3,14 +3,17 @@ import re
 from .resource import ResourceFile, ResourceGroup
 
 
-def _add_resource_to_set(resource_set, resource):
-    resource_set.add(resource)
-
-    rg = None
-    if isinstance(resource, ResourceFile) and resource._has_resource_group():
-        rg = resource._get_resource_group()
-    elif isinstance(resource, ResourceGroup):
+def _add_resource_to_set(resource_set, resource, include_rg=True):
+    if isinstance(resource, ResourceGroup):
         rg = resource
+        if include_rg:
+            resource_set.add(resource)
+    else:
+        resource_set.add(resource)
+        if isinstance(resource, ResourceFile) and resource._has_resource_group():
+            rg = resource._get_resource_group()
+        else:
+            rg = None
 
     if rg is not None:
         for _, resource_file in rg._resources.items():
@@ -69,8 +72,10 @@ class Task:
         self._uid = Task._new_uid()
 
         self._inputs = set()
-        self._outputs = set()
-        self._mentioned = set()
+        self._internal_outputs = set()
+        self._external_outputs = set()
+        self._mentioned = set()  # resources used in the command
+        self._valid = set()  # resources declared in the appropriate place
         self._dependencies = set()
 
     def _get_resource(self, item):
@@ -87,11 +92,11 @@ class Task:
     def __getattr__(self, item):
         return self._get_resource(item)
 
-    def _add_outputs(self, resource):
-        _add_resource_to_set(self._outputs, resource)
+    def _add_internal_outputs(self, resource):
+        _add_resource_to_set(self._internal_outputs, resource, include_rg=False)
 
     def _add_inputs(self, resource):
-        _add_resource_to_set(self._inputs, resource)
+        _add_resource_to_set(self._inputs, resource, include_rg=False)
 
     def declare_resource_group(self, **mappings):
         """
@@ -138,7 +143,7 @@ class Task:
                 raise ValueError(f"value for name '{name}' is not a dict. Found '{type(d)}' instead.")
             rg = self._pipeline._new_resource_group(self, d)
             self._resources[name] = rg
-            _add_resource_to_set(self._mentioned, rg)
+            _add_resource_to_set(self._valid, rg)
         return self
 
     def depends_on(self, *tasks):
@@ -272,15 +277,16 @@ class Task:
                 if r._source != self:
                     self._add_inputs(r)
                     if r._source is not None:
-                        if r not in r._source._mentioned:
-                            name = r._source._resources_inverse
+                        if r not in r._source._valid:
+                            name = r._source._resources_inverse[r]
                             raise Exception(f"undefined resource '{name}'\n"
                                             f"Hint: resources must be defined within "
                                             "the task methods 'command' or 'declare_resource_group'")
                         self._dependencies.add(r._source)
-                        r._source._add_outputs(r)
+                        r._source._add_internal_outputs(r)
                 else:
-                    self._mentioned.add(r)
+                    _add_resource_to_set(self._valid, r)
+                self._mentioned.add(r)
                 return f"${{{r_uid}}}"
 
         subst_command = re.sub(f"({ResourceFile._regex_pattern})|({ResourceGroup._regex_pattern})"

--- a/pipeline/pipeline/utils.py
+++ b/pipeline/pipeline/utils.py
@@ -1,14 +1,5 @@
 import shlex
-import collections
 
 
 def escape_string(s):
     return shlex.quote(s)
-
-
-def flatten(l):
-    for el in l:
-        if isinstance(el, collections.Iterable) and not isinstance(el, (str, bytes, tuple)):
-            yield from flatten(el)
-        else:
-            yield el

--- a/pipeline/test-pipeline-pod.yaml
+++ b/pipeline/test-pipeline-pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pipeline
+spec:
+  containers:
+  - name: test-pipeline
+    image: "{{ test_pipeline_image.image }}"
+    env:
+     - name: BATCH_URL
+       value: http://batch.{{ default_ns.name }}
+  restartPolicy: Never

--- a/pipeline/test-pipeline-pod.yaml
+++ b/pipeline/test-pipeline-pod.yaml
@@ -7,6 +7,16 @@ spec:
   - name: test-pipeline
     image: "{{ test_pipeline_image.image }}"
     env:
+     - name: HAIL_TOKEN_FILE
+       value: '/jwt/jwt'
      - name: BATCH_URL
        value: http://batch.{{ default_ns.name }}
+    volumeMounts:
+      - mountPath: /jwt
+        readOnly: true
+        name: test-batch-jwt
+  volumes:
+    - name: test-batch-jwt
+      secret:
+        secretName: user-jwt-vkqfw
   restartPolicy: Never

--- a/pipeline/test/test_pipeline.py
+++ b/pipeline/test/test_pipeline.py
@@ -143,16 +143,16 @@ class LocalTests(unittest.TestCase):
                                    idx="bar")
         t = p.new_task()
         t.command(f"cat {input.fasta}")
-        assert(input.fasta in t._inputs)
-        assert(input.idx in t._inputs)
+        assert input.fasta in t._inputs
+        assert input.idx in t._inputs
 
     def test_resource_group_get_all_mentioned(self):
         p = Pipeline()
         t = p.new_task()
         t.declare_resource_group(foo={'bed': '{root}.bed', 'bim': '{root}.bim'})
         t.command(f"cat {t.foo.bed}")
-        assert(t.foo.bed in t._mentioned)
-        assert(t.foo.bim in t._mentioned)
+        assert t.foo.bed in t._mentioned
+        assert t.foo.bim not in t._mentioned
 
     def test_resource_group_get_all_mentioned_dependent_tasks(self):
         p = Pipeline()
@@ -171,10 +171,16 @@ class LocalTests(unittest.TestCase):
         t2.command(f"cat {t1.foo.bed}")
 
         for r in [t1.foo.bed, t1.foo.bim]:
-            assert(r in t1._outputs)
-            assert(r in t2._inputs)
-            assert(r in t1._mentioned)
-            assert(r not in t2._mentioned)
+            assert r in t1._internal_outputs
+            assert r in t2._inputs
+
+        assert t1.foo.bed in t1._mentioned
+        assert t1.foo.bim not in t1._mentioned
+
+        assert t1.foo.bed in t2._mentioned
+        assert t1.foo.bim not in t2._mentioned
+
+        assert t1.foo not in t1._mentioned
 
     def test_multiple_isolated_tasks(self):
         p = Pipeline()


### PR DESCRIPTION
- Added idea of two types of outputs: internal and external. Internal outputs are copied between tasks and external outputs are user specified copies of files.
- Added `valid` and `mentioned` which are sets of resources tasks keep track of. `valid` checks whether the resources were properly declared. `mentioned` keeps a record of the resources used in the command for variables that need to be declared.
- Changed when outputs are copied for external outputs. TaskResourceFiles are copied when the task finishes rather than at the end of the pipeline. InputResourceFiles are copied at the beginning of the pipeline as one job.
- `inputs`, `internal_outputs`, and `external_outputs` only contain resource files (not resource groups) which simplified the code quite a bit!