### PR TITLE
Add `ExtractIntervalFilters` optimizer pass.

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/ComparisonOp.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ComparisonOp.scala
@@ -35,6 +35,20 @@ object ComparisonOp {
       checkCompatible(t1, t2)
       Compare(t1, t2)
   }
+
+  def invert[T](op: ComparisonOp[Boolean]): ComparisonOp[Boolean] = {
+    assert(!op.isInstanceOf[Compare])
+    op match {
+      case GT(t1, t2) => LTEQ(t1, t2)
+      case LT(t1, t2) => GTEQ(t1, t2)
+      case GTEQ(t1, t2) => LT(t1, t2)
+      case LTEQ(t1, t2) => GT(t1, t2)
+      case EQ(t1, t2) => NEQ(t1, t2)
+      case NEQ(t1, t2) => EQ(t1, t2)
+      case EQWithNA(t1, t2) => NEQWithNA(t1, t2)
+      case NEQWithNA(t1, t2) => EQWithNA(t1, t2)
+    }
+  }
 }
 
 sealed trait ComparisonOp[ReturnType] {

--- a/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
@@ -98,86 +98,6 @@ object ExtractIntervalFilters {
     }
   }
 
-  private val noData: (Set[IR], Array[Interval]) = (Set(), Array())
-
-  def processPredicates(p: KeyFilterPredicate, kType: Type): (Set[IR], Array[Interval]) = {
-    p match {
-      case KeyComparison(comp) =>
-        val (v, isFlipped) = if (IsConstant(comp.l)) (comp.l, false) else (comp.r, true)
-        Set[IR](comp) -> Array(openInterval(constValue(v), v.typ, comp.op, isFlipped))
-
-      case LiteralContains(comp: IR) =>
-        val ApplyIR(_, Seq(Literal(_, lit), _)) = comp
-        val intervals = (lit: @unchecked) match {
-          case x: IndexedSeq[_] => x.map(elt => Interval(endpoint(elt, -1), endpoint(elt, 1))).toArray
-          case x: Set[_] => x.map(elt => Interval(endpoint(elt, -1), endpoint(elt, 1))).toArray
-          case x: Map[_, _] => x.keys.map(elt => Interval(endpoint(elt, -1), endpoint(elt, 1))).toArray
-        }
-        Set[IR](comp) -> intervals
-
-      case IntervalContains(comp: IR) =>
-        val ApplySpecial(_, Seq(Literal(_, lit), _)) = comp
-        val intervals = lit match {
-          case null => Array[Interval]()
-          case i: Interval => Array(i)
-        }
-        Set[IR](comp) -> intervals
-
-      case LocusContigComparison(comp) =>
-        val (v, Apply(_, Seq(locus))) = if (IsConstant(comp.l)) (comp.l, comp.r) else (comp.r, comp.l)
-        val interval = (constValue(v): @unchecked) match {
-          case s: String => getIntervalFromContig(s, locus.typ.asInstanceOf[TLocus].rg.asInstanceOf[ReferenceGenome])
-        }
-        Set[IR](comp) -> Array(interval)
-
-      case LocusPositionComparison(comp) =>
-        val (v, isFlipped) = if (IsConstant(comp.l)) (comp.l, false) else (comp.r, true)
-        val pos = constValue(v).asInstanceOf[Int]
-        val rg = kType.asInstanceOf[TLocus].rg.asInstanceOf[ReferenceGenome]
-        val ord = TInt32().ordering
-        val intervals = rg.contigs.indices
-          .flatMap { i =>
-            openInterval(pos, TInt32(), comp.op, isFlipped).intersect(ord,
-              Interval(endpoint(1, -1), endpoint(rg.contigLength(i), -1)))
-              .map { interval =>
-                Interval(endpoint(Locus(rg.contigs(i), interval.left.point.asInstanceOf[Int]), interval.left.sign),
-                  endpoint(Locus(rg.contigs(i), interval.right.point.asInstanceOf[Int]), interval.right.sign))
-              }
-          }.toArray
-
-        Set[IR](comp) -> intervals
-
-
-      case LocusContigContains(comp) =>
-        val ApplyIR(_, Seq(Literal(_, lit), Apply("contig", Seq(locus)))) = comp
-
-        val rg = locus.typ.asInstanceOf[TLocus].rg.asInstanceOf[ReferenceGenome]
-
-        val intervals = (lit: @unchecked) match {
-          case x: IndexedSeq[_] => x.map(elt => getIntervalFromContig(elt.asInstanceOf[String], rg)).toArray
-          case x: Set[_] => x.map(elt => getIntervalFromContig(elt.asInstanceOf[String], rg)).toArray
-          case x: Map[_, _] => x.keys.map(elt => getIntervalFromContig(elt.asInstanceOf[String], rg)).toArray
-        }
-
-        Set(comp) -> intervals
-
-      case Disjunction(x1, x2) =>
-        val (s1, i1) = processPredicates(x1, kType)
-        val (s2, i2) = processPredicates(x2, kType)
-        (s1.union(s2), Interval.union(i1 ++ i2, kType.ordering.intervalEndpointOrdering))
-
-      case Conjunction(x1, x2) =>
-        val (s1, i1) = processPredicates(x1, kType)
-        val (s2, i2) = processPredicates(x2, kType)
-        log.info(s"intersecting list of ${ i1.length } intervals with list of ${ i2.length } intervals")
-        val intersection = Interval.intersection(i1, i2, kType.ordering.intervalEndpointOrdering)
-        log.info(s"intersect generated ${ intersection.length } intersected intervals")
-        (s1.union(s2), intersection)
-
-      case Unknown => noData // should only be found in a conjunction
-    }
-  }
-
   def opIsSupported(op: ComparisonOp[_]): Boolean = {
     op match {
       case _: Compare => false
@@ -188,58 +108,99 @@ object ExtractIntervalFilters {
     }
   }
 
-  def extract(cond1: IR, ref: Ref, k: IR): KeyFilterPredicate = {
+  def extractAndRewrite(cond1: IR, ref: Ref, k: IR): Option[(IR, Array[Interval])] = {
     cond1 match {
       case ApplySpecial("||", Seq(l, r)) =>
-        val ll = extract(l, ref, k)
-        val rr = extract(r, ref, k)
-        if (ll == Unknown || rr == Unknown)
-          Unknown
-        else
-          Disjunction(ll, rr)
+        extractAndRewrite(l, ref, k)
+          .liftedZip(extractAndRewrite(r, ref, k))
+          .map { case ((_, i1), (_, i2)) =>
+            (True(), Interval.union(i1 ++ i2, k.typ.ordering.intervalEndpointOrdering))
+          }
       case ApplySpecial("&&", Seq(l, r)) =>
-        Conjunction(extract(l, ref, k), extract(r, ref, k))
-      case Coalesce(Seq(x, False())) => extract(x, ref, k)
-      case x@ApplyIR("contains", Seq(_: Literal, `k`)) => LiteralContains(x) // don't match string contains
-      case x@ApplySpecial("contains", Seq(_: Literal, `k`)) => IntervalContains(x)
-      case x@ApplyIR("contains", Seq(_: Literal, Apply("contig", Seq(`k`)))) => LocusContigContains(x)
-      case x@ApplyComparisonOp(op, l, r) if opIsSupported(op) =>
-        if (IsConstant(l) && r == k || l == k && IsConstant(r))
+        val ll = extractAndRewrite(l, ref, k)
+        val rr = extractAndRewrite(r, ref, k)
+        (ll, rr) match {
+          case (Some((ir1, i1)), Some((ir2, i2))) =>
+            log.info(s"intersecting list of ${ i1.length } intervals with list of ${ i2.length } intervals")
+            val intersection = Interval.intersection(i1, i2, k.typ.ordering.intervalEndpointOrdering)
+            log.info(s"intersect generated ${ intersection.length } intersected intervals")
+            Some((invoke("&&", ir1, ir2), intersection))
+          case (Some((ir1, i1)), None) =>
+            Some((invoke("&&", ir1, r), i1))
+          case (None, Some((ir2, i2))) =>
+            Some((invoke("&&", l, ir2), i2))
+          case (None, None) =>
+            None
+        }
+      case Coalesce(Seq(x, False())) => extractAndRewrite(x, ref, k)
+        .map { case (ir, intervals) => (Coalesce(FastSeq(ir, False())), intervals) }
+      case ApplyIR("contains", Seq(lit: Literal, `k`)) =>
+        val intervals = (lit.value: @unchecked) match {
+          case x: IndexedSeq[_] => x.map(elt => Interval(endpoint(elt, -1), endpoint(elt, 1))).toArray
+          case x: Set[_] => x.map(elt => Interval(endpoint(elt, -1), endpoint(elt, 1))).toArray
+          case x: Map[_, _] => x.keys.map(elt => Interval(endpoint(elt, -1), endpoint(elt, 1))).toArray
+        }
+        Some((True(), intervals))
+      case ApplySpecial("contains", Seq(lit: Literal, `k`)) =>
+        val intervals = (lit.value: @unchecked) match {
+          case null => Array[Interval]()
+          case i: Interval => Array(i)
+        }
+        Some((True(), intervals))
+      case ApplyIR("contains", Seq(lit: Literal, Apply("contig", Seq(`k`)))) =>
+        val rg = k.typ.asInstanceOf[TLocus].rg.asInstanceOf[ReferenceGenome]
+
+        val intervals = (lit.value: @unchecked) match {
+          case x: IndexedSeq[_] => x.map(elt => getIntervalFromContig(elt.asInstanceOf[String], rg)).toArray
+          case x: Set[_] => x.map(elt => getIntervalFromContig(elt.asInstanceOf[String], rg)).toArray
+          case x: Map[_, _] => x.keys.map(elt => getIntervalFromContig(elt.asInstanceOf[String], rg)).toArray
+        }
+        Some((True(), intervals))
+      case ApplyComparisonOp(op, l, r) if opIsSupported(op) =>
+        if (IsConstant(l) && r == k || l == k && IsConstant(r)) {
+          // simple key comparison
           // TODO: need to look for casts, since patterns like [ `k` > 1.5 ] will not match if `k` is an integer
-          KeyComparison(x)
-        else if ((IsConstant(l) && r == Apply("contig", FastSeq(k))
-          || l == Apply("contig", FastSeq(k)) && IsConstant(r)) && op.isInstanceOf[EQ])
-          LocusContigComparison(x)
-        else if (IsConstant(l) && r == Apply("position", FastSeq(k))
-          || l == Apply("position", FastSeq(k)) && IsConstant(r))
-          LocusPositionComparison(x)
-        else
-          Unknown
-      case Let(name, _, body) if name != ref.name =>
+          val (v, isFlipped) = if (IsConstant(l)) (l, false) else (r, true)
+          Some((True(), Array(openInterval(constValue(v), v.typ, op, isFlipped))))
+        } else if ((IsConstant(l) && r == Apply("contig", FastSeq(k)) || l == Apply("contig", FastSeq(k)) && IsConstant(r)) && op.isInstanceOf[EQ]) {
+          // locus contig comparison
+          val v = if (IsConstant(l)) l else r
+          val intervals = (constValue(v): @unchecked) match {
+            case s: String => Array(getIntervalFromContig(s, k.typ.asInstanceOf[TLocus].rg.asInstanceOf[ReferenceGenome]))
+          }
+          Some((True(), intervals))
+        } else if (IsConstant(l) && r == Apply("position", FastSeq(k)) || l == Apply("position", FastSeq(k)) && IsConstant(r)) {
+          // locus position comparison
+          val (v, isFlipped) = if (IsConstant(l)) (l, false) else (r, true)
+          val pos = constValue(v).asInstanceOf[Int]
+          val rg = k.typ.asInstanceOf[TLocus].rg.asInstanceOf[ReferenceGenome]
+          val ord = TInt32().ordering
+          val intervals = rg.contigs.indices
+            .flatMap { i =>
+              openInterval(pos, TInt32(), op, isFlipped).intersect(ord,
+                Interval(endpoint(1, -1), endpoint(rg.contigLength(i), -1)))
+                .map { interval =>
+                  Interval(endpoint(Locus(rg.contigs(i), interval.left.point.asInstanceOf[Int]), interval.left.sign),
+                    endpoint(Locus(rg.contigs(i), interval.right.point.asInstanceOf[Int]), interval.right.sign))
+                }
+            }.toArray
+
+          Some((True(), intervals))
+        } else None
+      case Let(name, value, body) if name != ref.name =>
         // TODO: thread key identity through values, since this will break when CSE arrives
         // TODO: thread predicates in `value` through `body` as a ref
-        extract(body, ref, k)
-      case _ => Unknown
+        extractAndRewrite(body, ref, k)
+          .map { case (ir, intervals) => (Let(name, value, ir), intervals) }
+      case _ => None
     }
   }
 
-  def extractPartitionFilters(cond: IR, ref: Ref, key: IndexedSeq[String]): Option[(Array[Interval], IR)] = {
+  def extractPartitionFilters(cond: IR, ref: Ref, key: IndexedSeq[String]): Option[(IR, Array[Interval])] = {
     if (key.isEmpty)
-      return None
-
-    val k1 = GetField(ref, key.head)
-
-    val (nodes, intervals) = processPredicates(extract(cond, ref, k1), k1.typ)
-    if (nodes.nonEmpty) {
-      val refSet = nodes.map(RefEquality(_))
-
-      def rewrite(ir: IR): IR = if (refSet.contains(RefEquality(ir))) True() else MapIR(rewrite)(ir)
-
-      Some(intervals -> rewrite(cond))
-    } else {
-      assert(intervals.isEmpty)
       None
-    }
+    else
+      extractAndRewrite(cond, ref, GetField(ref, key.head))
   }
 
   def apply(ir0: BaseIR): BaseIR = {
@@ -247,7 +208,7 @@ object ExtractIntervalFilters {
     RewriteBottomUp(ir0, {
       case TableFilter(child, pred) =>
         extractPartitionFilters(pred, Ref("row", child.typ.rowType), child.typ.key)
-          .map { case (intervals, newCond) =>
+          .map { case (newCond, intervals) =>
             log.info(s"generated TableFilterIntervals node with ${ intervals.length } intervals:\n  " +
               s"Intervals: ${ intervals.mkString(", ") }\n  " +
               s"Predicate: ${ Pretty(pred) }")
@@ -259,7 +220,7 @@ object ExtractIntervalFilters {
           }
       case MatrixFilterRows(child, pred) =>
         extractPartitionFilters(pred, Ref("va", child.typ.rvRowType), child.typ.rowKey)
-          .map { case (intervals, newCond) =>
+          .map { case (newCond, intervals) =>
             log.info(s"generated MatrixFilterIntervals node with ${ intervals.length } intervals:\n  " +
               s"Intervals: ${ intervals.mkString(", ") }\n  " +
               s"Predicate: ${ Pretty(pred) }")

--- a/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
@@ -6,26 +6,6 @@ import is.hail.utils.{FastSeq, Interval, IntervalEndpoint, _}
 import is.hail.variant.{Locus, ReferenceGenome}
 import org.apache.spark.sql.Row
 
-sealed trait KeyFilterPredicate
-
-case class KeyComparison(comp: ApplyComparisonOp) extends KeyFilterPredicate
-
-case class LiteralContains(comp: IR) extends KeyFilterPredicate
-
-case class IntervalContains(comp: IR) extends KeyFilterPredicate
-
-case class LocusContigComparison(comp: ApplyComparisonOp) extends KeyFilterPredicate
-
-case class LocusPositionComparison(comp: ApplyComparisonOp) extends KeyFilterPredicate
-
-case class LocusContigContains(comp: IR) extends KeyFilterPredicate
-
-case class Disjunction(l: KeyFilterPredicate, r: KeyFilterPredicate) extends KeyFilterPredicate
-
-case class Conjunction(l: KeyFilterPredicate, r: KeyFilterPredicate) extends KeyFilterPredicate
-
-case object Unknown extends KeyFilterPredicate
-
 object ExtractIntervalFilters {
   def wrapInRow(intervals: Array[Interval]): Array[Interval] = {
     intervals.map { interval =>

--- a/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
@@ -1,0 +1,367 @@
+package is.hail.expr.ir
+
+import is.hail.expr.types.virtual._
+import is.hail.methods.{MatrixFilterIntervals, TableFilterIntervals}
+import is.hail.utils.{FastSeq, Interval, IntervalEndpoint, _}
+import is.hail.variant.{Locus, ReferenceGenome}
+import org.apache.spark.sql.Row
+
+sealed trait KeyFilterPredicate
+
+case class KeyComparison(comp: ApplyComparisonOp) extends KeyFilterPredicate
+
+case class LiteralContains(comp: IR) extends KeyFilterPredicate
+
+case class IntervalContains(comp: IR) extends KeyFilterPredicate
+
+case class LocusContigComparison(comp: ApplyComparisonOp) extends KeyFilterPredicate
+
+case class LocusContigContains(comp: IR) extends KeyFilterPredicate
+
+case class LocusPositionComparison(comp: IR) extends KeyFilterPredicate
+
+case class Disjunction(xs: Array[KeyFilterPredicate]) extends KeyFilterPredicate
+
+case class Conjunction(xs: Array[KeyFilterPredicate]) extends KeyFilterPredicate
+
+case object Unknown extends KeyFilterPredicate
+
+object ExtractIntervalFilters {
+
+  def getIntervalIntersection(intervals: Iterable[Interval], t: Type): Option[Interval] = {
+    if (intervals.isEmpty)
+      return Some(Interval(minimumValueByType(t), maximumValueByType(t)))
+    val tOrd = t.ordering
+    val iOrd = tOrd.intervalEndpointOrdering
+    val ord = iOrd.toOrdering
+    val minValue = intervals.map(_.left).min(ord)
+    val maxValue = intervals.map(_.right).max(ord)
+    tOrd.compare(minValue.point, maxValue.point) match {
+      case x if x < 0 => Some(Interval(minValue, maxValue))
+      case x if x == 0 => if (minValue.sign < 0 && maxValue.sign > 0) Some(Interval(minValue, maxValue)) else None
+      case _ => None
+    }
+  }
+
+  def intersectIntervalLists(i1: Array[Interval], i2: Array[Interval], t: Type): Array[Interval] = {
+    // FIXME: this is quadratic
+    log.info(s"intersecting list of ${ i1.length } intervals with list of ${ i2.length } intervals")
+    val r = i1.flatMap(i => i2.foldLeft(Option(i)) { case (comb, ii) => comb.flatMap(c => getIntervalIntersection(Array(c, ii), t)) })
+    log.info(s"intersect generated ${ r.length } intersected intervals")
+    r
+  }
+
+  def simplifyPredicates(p: KeyFilterPredicate): KeyFilterPredicate = {
+    p match {
+      case Disjunction(xs) =>
+        if (xs.contains(Unknown))
+          Unknown
+        else {
+          val (ors, other) = xs.map(simplifyPredicates).partition(_.isInstanceOf[Disjunction])
+          Disjunction(ors.flatMap(o => o.asInstanceOf[Disjunction].xs) ++ other)
+        }
+      case Conjunction(xs) =>
+        if (xs.forall(_ == Unknown))
+          Unknown
+        else {
+          val (ands, other) = xs.map(simplifyPredicates).partition(_.isInstanceOf[Conjunction])
+          val elts = ands.flatMap(o => o.asInstanceOf[Conjunction].xs) ++ other.filter(_ != Unknown)
+          if (elts.size == 1)
+            elts.head
+          else
+            Conjunction(elts)
+        }
+      case _ => p
+    }
+  }
+
+  def minimumValueByType(t: Type): IntervalEndpoint = {
+    t match {
+      case _: TInt32 => endpoint(Int.MinValue, -1)
+      case _: TInt64 => endpoint(Long.MinValue, -1)
+      case _: TFloat32 => endpoint(Float.MinValue, -1)
+      case _: TFloat64 => endpoint(Double.MinValue, -1)
+      //      case TLocus(rgBase, _) => Some(IntervalEndpoint(Locus(rgBase.value.asInstanceOf[ReferenceGenome].contigs(0), 1), -1))
+      //      case _ => None
+    }
+  }
+
+  def maximumValueByType(t: Type): IntervalEndpoint = {
+    t match {
+      case _: TInt32 => endpoint(Int.MaxValue, 1)
+      case _: TInt64 => endpoint(Long.MaxValue, 1)
+      case _: TFloat32 => endpoint(Float.MaxValue, 1)
+      case _: TFloat64 => endpoint(Double.MaxValue, 1)
+      //      case TLocus(rgBase, _) =>
+      //        val rg = rgBase.value.asInstanceOf[ReferenceGenome]
+      //        val lastContig = rg.contigs.last
+      //        Some(IntervalEndpoint(Locus(lastContig, rg.contigLength(lastContig)), 1))
+      //      case _ => None
+    }
+  }
+
+  def constValue(x: IR): Any = (x: @unchecked) match {
+    case I32(v) => v
+    case I64(v) => v
+    case F32(v) => v
+    case F64(v) => v
+    case Str(v) => v
+    case Literal(_, v) => v
+  }
+
+  def endpoint(value: Any, inclusivity: Int): IntervalEndpoint = {
+    IntervalEndpoint(Row(value), inclusivity)
+  }
+
+  def getIntervalFromContig(c: String, rg: ReferenceGenome): Interval = {
+    Interval(
+      endpoint(Locus(c, 1), -1),
+      endpoint(Locus(c, rg.contigLength(c)), 1))
+  }
+
+  def openInterval(v: Any, typ: Type, op: ComparisonOp[_], flipped: Boolean = false): Interval = {
+    (op: @unchecked) match {
+      case _: EQ =>
+        Interval(endpoint(v, -1), endpoint(v, 1))
+      case GT(_, _) =>
+        if (flipped)
+        // key > value
+          Interval(endpoint(v, 1), maximumValueByType(typ))
+        else
+        // value > key
+          Interval(minimumValueByType(typ), endpoint(v, -1))
+      case GTEQ(_, _) =>
+        if (flipped)
+        // key >= value
+          Interval(endpoint(v, -1), maximumValueByType(typ))
+        else
+        // value >= key
+          Interval(minimumValueByType(typ), endpoint(v, 1))
+      case LT(_, _) =>
+        if (flipped)
+        // key < value
+          Interval(minimumValueByType(typ), endpoint(v, -1))
+        else
+        // value < key
+          Interval(endpoint(v, 1), maximumValueByType(typ))
+      case LTEQ(_, _) =>
+        if (flipped)
+        // key <= value
+          Interval(minimumValueByType(typ), endpoint(v, 1))
+        else
+        // value <= key
+          Interval(endpoint(v, -1), maximumValueByType(typ))
+    }
+  }
+
+  def transitiveComparisonNodes(f: KeyFilterPredicate): Set[IR] = f match {
+    case KeyComparison(x) => Set(x)
+    case LiteralContains(x) => Set(x)
+    case LocusContigContains(x) => Set(x)
+    case LocusPositionComparison(x) => Set(x)
+    case LocusContigComparison(x) => Set(x)
+    case Disjunction(xs) => xs.map(transitiveComparisonNodes).fold(Set())(_.union(_))
+    case Conjunction(xs) => xs.map(transitiveComparisonNodes).fold(Set())(_.union(_))
+  }
+
+  private val noData: (Set[IR], Array[Interval]) = (Set(), Array())
+
+  def processPredicates(p: KeyFilterPredicate, kType: Type): (Set[IR], Array[Interval]) = {
+    p match {
+      case KeyComparison(comp) =>
+        val (v, isFlipped) = if (IsConstant(comp.l)) (comp.l, false) else (comp.r, true)
+        Set[IR](comp) -> Array(openInterval(constValue(v), v.typ, comp.op, isFlipped))
+
+      case LiteralContains(comp: IR) =>
+        val Apply(_, Seq(Literal(_, lit), _)) = comp
+        val intervals = (lit: @unchecked) match {
+          case x: IndexedSeq[_] => x.map(elt => Interval(endpoint(elt, -1), endpoint(elt, 1))).toArray
+          case x: Set[_] => x.map(elt => Interval(endpoint(elt, -1), endpoint(elt, 1))).toArray
+          case x: Map[_, _] => x.keys.map(elt => Interval(endpoint(elt, -1), endpoint(elt, 1))).toArray
+        }
+        Set[IR](comp) -> intervals
+
+      case IntervalContains(comp: IR) =>
+        val ApplySpecial(_, Seq(Literal(_, lit), _)) = comp
+        val intervals = lit match {
+          case null => Array[Interval]()
+          case i: Interval => Array(Interval(endpoint(i.left.point, i.left.sign), endpoint(i.right.point, i.right.sign)))
+        }
+        Set[IR](comp) -> intervals
+
+      case LocusContigComparison(comp) =>
+        val (v, Apply(_, Seq(locus))) = if (IsConstant(comp.l)) (comp.l, comp.r) else (comp.r, comp.l)
+        val interval = (constValue(v): @unchecked) match {
+          case s: String => getIntervalFromContig(s, locus.typ.asInstanceOf[TLocus].rg.asInstanceOf[ReferenceGenome])
+        }
+        Set[IR](comp) -> Array(interval)
+
+      case LocusPositionComparison(_) => Set[IR]() -> Array() // don't generate intervals per contig due to number of GRCh38 contigs?
+
+
+      case LocusContigContains(comp) =>
+        val ApplyIR(_, Seq(Literal(_, lit), Apply("contig", Seq(locus)))) = comp
+
+        val rg = locus.typ.asInstanceOf[TLocus].rg.asInstanceOf[ReferenceGenome]
+
+        val intervals = (lit: @unchecked) match {
+          case x: IndexedSeq[_] => x.map(elt => getIntervalFromContig(elt.asInstanceOf[String], rg)).toArray
+          case x: Set[_] => x.map(elt => getIntervalFromContig(elt.asInstanceOf[String], rg)).toArray
+          case x: Map[_, _] => x.keys.map(elt => getIntervalFromContig(elt.asInstanceOf[String], rg)).toArray
+        }
+
+        Set(comp) -> intervals
+
+      case Disjunction(xs) =>
+        val (nodes, intervals) = xs.map(processPredicates(_, kType)).unzip
+        nodes.fold(Set())(_.union(_)) -> intervals.flatten
+
+      case x@Conjunction(xs) =>
+        // search for contig and position combination filters
+        val (extractedLocusFilters, other) = xs.partition {
+          case _: LocusPositionComparison | _: LocusContigComparison => true
+          case _ => false
+        }
+
+        val (contigComparisons, positionComparisons) = extractedLocusFilters.partition(_.isInstanceOf[LocusContigComparison])
+
+        val base: (Set[IR], Array[Interval]) = if (contigComparisons.isEmpty && positionComparisons.nonEmpty)
+          noData // could generate intervals per contig, but potentially bad with GRCh38?
+        else {
+          val cc = contigComparisons.map {
+            case LocusContigComparison(ApplyComparisonOp(_, l, r)) =>
+              if (IsConstant(l))
+                constValue(l)
+              else
+                constValue(r)
+          }.toSet
+
+          if (cc.size > 2)
+          // rewrite all pieces of the conjunction, since we have proven it will return no rows
+            transitiveComparisonNodes(x) -> Array()
+          else if (cc.size == 1) {
+            val pc = positionComparisons.map {
+              case LocusPositionComparison(ApplyComparisonOp(op, l, r)) =>
+                if (IsConstant(l))
+                  (op, constValue(l), true)
+                else
+                  (op, constValue(r), false)
+            }.map { case (op, v, isFlipped) => openInterval(v, TInt32(), op, isFlipped) }
+            getIntervalIntersection(pc, TTuple(TInt32())) match {
+              case Some(i) =>
+                val start = i.start.asInstanceOf[Row].getAs[Int](0)
+                val end = i.end.asInstanceOf[Row].getAs[Int](0)
+                val ccHead = contigComparisons.head.asInstanceOf[LocusContigComparison].comp
+                val Apply(_, Seq(k)) = if (IsConstant(ccHead.l)) ccHead.r else ccHead.l
+                val rg = k.typ.asInstanceOf[TLocus].rg.asInstanceOf[ReferenceGenome]
+                val contig = cc.head.asInstanceOf[String]
+                val contigLength = rg.contigLength(contig)
+
+                val intervals = if (end < 1 || start > contigLength)
+                  Array[Interval]()
+                else {
+                  val start2 = if (start < 1)
+                    endpoint(Locus(contig, 1), -1)
+                  else
+                    endpoint(Locus(contig, start), i.left.sign)
+                  val end2 = if (end > contigLength)
+                    endpoint(Locus(contig, contigLength), 1)
+                  else
+                    endpoint(Locus(contig, end), i.right.sign)
+                  Array(Interval(start2, end2))
+                }
+                (contigComparisons.map(_.asInstanceOf[LocusContigComparison].comp).toSet[IR]
+                  .union(positionComparisons.map(_.asInstanceOf[LocusPositionComparison].comp).toSet[IR]),
+                  intervals)
+              case None => transitiveComparisonNodes(x) -> Array()
+            }
+          } else {
+            noData
+          }
+        }
+        other.foldLeft(base) { case ((s, i), f) =>
+          val (s2, i2) = processPredicates(f, kType)
+          (s2.union(s), intersectIntervalLists(i, i2, kType))
+        }
+      case _ => noData
+    }
+  }
+
+  def extractPartitionFilters(cond: IR, ref: Ref, key: IndexedSeq[String]): Option[(Array[Interval], IR)] = {
+    if (key.isEmpty)
+      return None
+
+    val k1 = GetField(ref, key.head)
+
+    def recur[T](cond1: IR): KeyFilterPredicate = {
+      cond1 match {
+        case ApplySpecial("||", Seq(l, r)) =>
+          Disjunction(Array(recur(l), recur(r)))
+        case ApplySpecial("&&", Seq(l, r)) =>
+          Conjunction(Array(recur(l), recur(r)))
+        case Coalesce(Seq(x, False())) => recur(x)
+        case x@ApplyIR("contains", Seq(_: Literal, `k1`)) => LiteralContains(x) // string contains shouldn't match
+        case x@ApplySpecial("contains", Seq(_: Literal, `k1`)) => IntervalContains(x)
+        case x@ApplyIR("contains", Seq(_: Literal, Apply("contig", Seq(`k1`)))) => LocusContigContains(x)
+        case x@ApplyComparisonOp(op, l, r) if !op.isInstanceOf[Compare] && !op.isInstanceOf[EQWithNA] =>
+          if ((IsConstant(l) && r == k1 || l == k1 && IsConstant(r)) && !op.t1.isInstanceOf[TString])
+            KeyComparison(x)
+          else if ((IsConstant(l) && r == Apply("contig", FastSeq(k1))
+            || l == Apply("contig", FastSeq(k1)) && IsConstant(r)) && op.isInstanceOf[EQ])
+            LocusContigComparison(x)
+          else if (IsConstant(l) && r == Apply("position", FastSeq(k1))
+            || l == Apply("position", FastSeq(k1)) && IsConstant(r))
+            LocusPositionComparison(x)
+          else
+            Unknown
+        case Let(name, _, body) if name != ref.name =>
+          // TODO: thread key identity through values, since this will break when CSE arrives
+          // TODO: thread predicates in `value` through `body` as a ref
+          recur(body)
+        case _ => Unknown
+      }
+    }
+
+    val predicates = recur(cond)
+    val (nodes, intervals) = processPredicates(simplifyPredicates(predicates), k1.typ)
+    if (nodes.nonEmpty) {
+      val refSet = nodes.map(RefEquality(_))
+
+      def rewrite(ir: IR): IR = if (refSet.contains(RefEquality(ir))) True() else MapIR(rewrite)(ir)
+
+      Some(intervals -> rewrite(cond))
+    } else None
+  }
+
+  def apply(ir0: BaseIR): BaseIR = {
+
+    RewriteBottomUp(ir0, {
+      case TableFilter(child, pred) =>
+        extractPartitionFilters(pred, Ref("row", child.typ.rowType), child.typ.key)
+          .map { case (intervals, newCond) =>
+            log.info(s"generated TableFilterIntervals node:\n  " +
+              s"Intervals: ${ intervals.mkString(", ") }\n  " +
+              s"Predicate: ${ Pretty(pred) }")
+            TableFilter(
+              TableToTableApply(
+                child,
+                TableFilterIntervals(child.typ.keyType, intervals, keep = true)),
+              newCond)
+          }
+      case MatrixFilterRows(child, pred) =>
+        extractPartitionFilters(pred, Ref("va", child.typ.rvRowType), child.typ.rowKey)
+          .map { case (intervals, newCond) =>
+            log.info(s"generated MatrixFilterIntervals node:\n  " +
+              s"Intervals: ${ intervals.mkString(", ") }\n  " +
+              s"Predicate: ${ Pretty(pred) }")
+            MatrixFilterRows(
+              MatrixToMatrixApply(
+                child,
+                MatrixFilterIntervals(child.typ.rowKeyStruct, intervals, keep = true)),
+              newCond)
+          }
+
+      case _ => None
+    })
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
@@ -119,7 +119,7 @@ object ExtractIntervalFilters {
         val ApplySpecial(_, Seq(Literal(_, lit), _)) = comp
         val intervals = lit match {
           case null => Array[Interval]()
-          case i: Interval => Array(Interval(endpoint(i.left.point, i.left.sign), endpoint(i.right.point, i.right.sign)))
+          case i: Interval => Array(i)
         }
         Set[IR](comp) -> intervals
 
@@ -134,12 +134,11 @@ object ExtractIntervalFilters {
         val (v, isFlipped) = if (IsConstant(comp.l)) (comp.l, false) else (comp.r, true)
         val pos = constValue(v).asInstanceOf[Int]
         val rg = kType.asInstanceOf[TLocus].rg.asInstanceOf[ReferenceGenome]
-        val intOrd = TInt32().ordering.intervalEndpointOrdering
+        val ord = TInt32().ordering
         val intervals = rg.contigs.indices
           .flatMap { i =>
-            Interval.intersection(Array(openInterval(pos, TInt32(), comp.op, isFlipped)),
-              Array(Interval(endpoint(1, -1), endpoint(rg.contigLength(i), -1))),
-              intOrd)
+            openInterval(pos, TInt32(), comp.op, isFlipped).intersect(ord,
+              Interval(endpoint(1, -1), endpoint(rg.contigLength(i), -1)))
               .map { interval =>
                 Interval(endpoint(Locus(rg.contigs(i), interval.left.point.asInstanceOf[Int]), interval.left.sign),
                   endpoint(Locus(rg.contigs(i), interval.right.point.asInstanceOf[Int]), interval.right.sign))

--- a/hail/src/main/scala/is/hail/expr/ir/ForwardLets.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ForwardLets.scala
@@ -48,7 +48,7 @@ object ForwardLets {
       def shouldForward(value: IR, refs: mutable.Set[RefEquality[Ref]], base: IR): Boolean = {
         value.isInstanceOf[Ref] ||
         value.isInstanceOf[In] ||
-          IsConstant(value) ||
+          (IsConstant(value) && !value.isInstanceOf[Str]) ||
           refs.isEmpty ||
           (refs.size == 1 &&
             nestingDepth.lookup(refs.head) == nestingDepth.lookup(base) &&

--- a/hail/src/main/scala/is/hail/expr/ir/IsConstant.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IsConstant.scala
@@ -15,7 +15,7 @@ object CanEmit {
 object IsConstant {
   def apply(ir: IR): Boolean = {
     ir match {
-      case I32(_) | I64(_) | F32(_) | F64(_) | True() | False() | NA(_) | Literal(_, _) => true
+      case I32(_) | I64(_) | F32(_) | F64(_) | True() | False() | NA(_) | Str(_) | Literal(_, _) => true
       case _ => false
     }
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
@@ -18,6 +18,7 @@ object Optimize {
       ir = FoldConstants(ir, canGenerateLiterals = canGenerateLiterals)
       ir = Simplify(ir)
       ir = ForwardLets(ir)
+      ir = ExtractIntervalFilters(ir)
       ir = PruneDeadFields(ir)
 
       iter += 1

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -505,7 +505,7 @@ object PruneDeadFields {
           globalType = requestedType.globalType.rename(globalMapRev),
           key = requestedType.key.map(k => rowMapRev.getOrElse(k, k)))
         memoizeTableIR(child, childDep, memo)
-      case TableToTableApply(child, _) => memoizeTableIR(child, child.typ, memo)
+      case TableToTableApply(child, f) => memoizeTableIR(child, f.requestType(requestedType, child.typ), memo)
       case MatrixToTableApply(child, _) => memoizeMatrixIR(child, child.typ, memo)
       case BlockMatrixToTable(child) => memoizeBlockMatrixIR(child, child.typ, memo)
     }
@@ -743,7 +743,7 @@ object PruneDeadFields {
           rowType = requestedType.rvRowType.rename(m)
         )
         memoizeTableIR(child, childDep, memo)
-      case MatrixToMatrixApply(child, _) => memoizeMatrixIR(child, child.typ, memo)
+      case MatrixToMatrixApply(child, f) => memoizeMatrixIR(child, f.requestType(requestedType, child.typ), memo)
       case MatrixRename(child, globalMap, colMap, rowMap, entryMap) =>
         val globalMapRev = globalMap.map { case (k, v) => (v, k) }
         val colMapRev = colMap.map { case (k, v) => (v, k) }

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -351,6 +351,9 @@ object Simplify {
     case ApplyComparisonOp(EQ(_, _), True(), expr) => expr
     case ApplyComparisonOp(EQ(_, _), expr, False()) => ApplyUnaryPrimOp(Bang(), expr)
     case ApplyComparisonOp(EQ(_, _), False(), expr) => ApplyUnaryPrimOp(Bang(), expr)
+
+    case ApplyUnaryPrimOp(Bang(), ApplyComparisonOp(op, l, r)) =>
+      ApplyComparisonOp(ComparisonOp.invert(op.asInstanceOf[ComparisonOp[Boolean]]), l, r)
   }
 
   private[this] def tableRules(canRepartition: Boolean): PartialFunction[TableIR, TableIR] = {

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -457,12 +457,6 @@ object Simplify {
         mct,
         Subst(newRow, BindingEnv(Env("sa" -> Ref("row", mct.typ.rowType)))))
 
-    case MatrixColsTable(MatrixFilterCols(child, pred)) =>
-      val mct = MatrixColsTable(child)
-      TableFilter(
-        mct,
-        Subst(pred, BindingEnv(Env("sa" -> Ref("row", mct.typ.rowType)))))
-
     case MatrixColsTable(MatrixMapGlobals(child, newGlobals)) => TableMapGlobals(MatrixColsTable(child), newGlobals)
     case MatrixColsTable(MatrixMapRows(child, _)) => MatrixColsTable(child)
     case MatrixColsTable(MatrixMapEntries(child, _)) => MatrixColsTable(child)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
@@ -20,6 +20,8 @@ abstract class MatrixToMatrixFunction {
   def preservesPartitionCounts: Boolean
 
   def lower(): Option[TableToTableFunction] = None
+
+  def requestType(requestedType: MatrixType, childBaseType: MatrixType): MatrixType = childBaseType
 }
 
 abstract class MatrixToTableFunction {
@@ -74,6 +76,8 @@ abstract class TableToTableFunction {
   def execute(tv: TableValue): TableValue
 
   def preservesPartitionCounts: Boolean
+
+  def requestType(requestedType: TableType, childBaseType: TableType): TableType = childBaseType
 }
 
 abstract class TableToValueFunction {

--- a/hail/src/main/scala/is/hail/methods/FilterIntervals.scala
+++ b/hail/src/main/scala/is/hail/methods/FilterIntervals.scala
@@ -41,6 +41,8 @@ case class MatrixFilterIntervals(
   override def lower(): Option[TableToTableFunction] = Some(TableFilterIntervals(keyType, intervals, keep))
 
   def execute(mv: MatrixValue): MatrixValue = throw new UnsupportedOperationException
+
+  override def requestType(requestedType: MatrixType, childBaseType: MatrixType): MatrixType = requestedType
 }
 
 class TableFilterIntervalsSerializer extends CustomSerializer[TableFilterIntervals](format => (
@@ -78,4 +80,6 @@ case class TableFilterIntervals(
       tv.rvd.typ.key.length - 1)
     TableValue(tv.typ, tv.globals, tv.rvd.filterIntervals(partitioner, keep))
   }
+
+  override def requestType(requestedType: TableType, childBaseType: TableType): TableType = requestedType
 }

--- a/hail/src/test/scala/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
@@ -1,0 +1,237 @@
+package is.hail.expr.ir
+
+import is.hail.TestUtils._
+import is.hail.expr.types.virtual._
+import is.hail.utils.{FastIndexedSeq, FastSeq, Interval, IntervalEndpoint}
+import is.hail.variant.{Locus, ReferenceGenome}
+import is.hail.{ExecStrategy, SparkSuite}
+import org.testng.annotations.Test
+
+class ExtractIntervalFiltersSuite extends SparkSuite {
+
+  lazy val ref1 = Ref("foo", TStruct("x" -> TInt32()))
+  lazy val k1 = GetField(ref1, "x")
+
+  @Test def testKeyComparison() {
+    def check(node: ApplyComparisonOp, expectedInterval: Interval) {
+      assert(ExtractIntervalFilters.extract(node, ref1, k1) == KeyComparison(node))
+      val (s, i) = ExtractIntervalFilters.processPredicates(KeyComparison(node), TInt32())
+      assert(s == Set(node))
+      assert(i.toSeq == FastSeq(expectedInterval))
+    }
+
+    check(ApplyComparisonOp(GT(TInt32()), k1, I32(0)),
+      Interval(IntervalEndpoint(0, 1), IntervalEndpoint(Int.MaxValue, 1)))
+    check(ApplyComparisonOp(GT(TInt32()), I32(0), k1),
+      Interval(IntervalEndpoint(Int.MinValue, -1), IntervalEndpoint(0, -1)))
+
+    check(ApplyComparisonOp(GTEQ(TInt32()), k1, I32(0)),
+      Interval(IntervalEndpoint(0, -1), IntervalEndpoint(Int.MaxValue, 1)))
+    check(ApplyComparisonOp(GTEQ(TInt32()), I32(0), k1),
+      Interval(IntervalEndpoint(Int.MinValue, -1), IntervalEndpoint(0, 1)))
+
+    check(ApplyComparisonOp(LT(TInt32()), k1, I32(0)),
+      Interval(IntervalEndpoint(Int.MinValue, -1), IntervalEndpoint(0, -1)))
+    check(ApplyComparisonOp(LT(TInt32()), I32(0), k1),
+      Interval(IntervalEndpoint(0, 1), IntervalEndpoint(Int.MaxValue, 1)))
+
+    check(ApplyComparisonOp(LTEQ(TInt32()), k1, I32(0)),
+      Interval(IntervalEndpoint(Int.MinValue, -1), IntervalEndpoint(0, 1)))
+    check(ApplyComparisonOp(LTEQ(TInt32()), I32(0), k1),
+      Interval(IntervalEndpoint(0, -1), IntervalEndpoint(Int.MaxValue, 1)))
+
+    check(ApplyComparisonOp(EQ(TInt32()), k1, I32(0)),
+      Interval(IntervalEndpoint(0, -1), IntervalEndpoint(0, 1)))
+    check(ApplyComparisonOp(EQ(TInt32()), I32(0), k1),
+      Interval(IntervalEndpoint(0, -1), IntervalEndpoint(0, 1)))
+
+    assert(ExtractIntervalFilters.extract(ApplyComparisonOp(NEQ(TInt32()), I32(0), k1), ref1, k1) == Unknown)
+    assert(ExtractIntervalFilters.extract(ApplyComparisonOp(EQWithNA(TInt32()), I32(0), k1), ref1, k1) == Unknown)
+    assert(ExtractIntervalFilters.extract(ApplyComparisonOp(NEQWithNA(TInt32()), I32(0), k1), ref1, k1) == Unknown)
+    assert(ExtractIntervalFilters.extract(ApplyComparisonOp(Compare(TInt32()), I32(0), k1), ref1, k1) == Unknown)
+  }
+
+  @Test def testLiteralContains() {
+    for (lit <- Array(
+      Literal(TSet(TInt32()), Set(1, 10)),
+      Literal(TArray(TInt32()), FastIndexedSeq(1, 10)),
+      Literal(TDict(TInt32(), TString()), Map(1 -> "foo", 10 -> "bar")))) {
+      val ir = invoke("contains", lit, k1)
+
+      assert(ExtractIntervalFilters.extract(ir, ref1, k1) == LiteralContains(ir))
+      val (s, i) = ExtractIntervalFilters.processPredicates(LiteralContains(ir), TInt32())
+      assert(s == Set(ir))
+      assert(i.toSeq == FastSeq(Interval(IntervalEndpoint(1, -1), IntervalEndpoint(1, 1)),
+        Interval(IntervalEndpoint(10, -1), IntervalEndpoint(10, 1))))
+    }
+  }
+
+  @Test def testIntervalContains() {
+    val interval = Interval(IntervalEndpoint(1, 1), IntervalEndpoint(5, 1))
+    val ir = invoke("contains", Literal(TInterval(TInt32()), interval), k1)
+    assert(ExtractIntervalFilters.extract(ir, ref1, k1) == IntervalContains(ir))
+    val (s, i) = ExtractIntervalFilters.processPredicates(IntervalContains(ir), TInt32())
+    assert(s == Set(ir))
+    assert(i.toSeq == FastSeq(interval))
+  }
+
+  @Test def testLocusContigComparison() {
+    hc // force initialization
+    val ref = Ref("foo", TStruct("x" -> TLocus(ReferenceGenome.GRCh38)))
+    val k = GetField(ref, "x")
+
+    val ir1 = ApplyComparisonOp(EQ(TString()), Str("chr2"), invoke("contig", k))
+    val ir2 = ApplyComparisonOp(EQ(TString()), invoke("contig", k), Str("chr2"))
+
+    assert(ExtractIntervalFilters.extract(ir1, ref, k) == LocusContigComparison(ir1))
+    assert(ExtractIntervalFilters.extract(ir2, ref, k) == LocusContigComparison(ir2))
+
+    val (s, i) = ExtractIntervalFilters.processPredicates(LocusContigComparison(ir1), k.typ)
+    assert(s == Set(ir1))
+    assert(i.toSeq == FastSeq(Interval(IntervalEndpoint(Locus("chr2", 1), -1),
+      IntervalEndpoint(Locus("chr2", ReferenceGenome.GRCh38.contigLength("chr2")), -1))))
+  }
+
+  @Test def testLocusPositionComparison() {
+    hc // force initialization
+    val ref = Ref("foo", TStruct("x" -> TLocus(ReferenceGenome.GRCh38)))
+    val k = GetField(ref, "x")
+    val pos = invoke("position", k)
+
+    def check(node: ApplyComparisonOp, expectedInterval: (String, Int) => Interval) {
+      assert(ExtractIntervalFilters.extract(node, ref, k) == LocusPositionComparison(node))
+      val (s, i) = ExtractIntervalFilters.processPredicates(LocusPositionComparison(node), k.typ)
+      assert(s == Set(node))
+      assert(i.toSeq == ReferenceGenome.GRCh38.contigs
+        .map { c => expectedInterval(c, ReferenceGenome.GRCh38.contigLength(c)) }
+        .filter(_ != null)
+        .toFastSeq)
+    }
+
+    check(ApplyComparisonOp(GT(TInt32()), pos, I32(100)),
+      (c: String, len: Int) => if (len < 100)
+        null
+      else
+        Interval(IntervalEndpoint(Locus(c, 100), 1), IntervalEndpoint(Locus(c, len), -1)))
+    check(ApplyComparisonOp(GT(TInt32()), pos, I32(-1000)),
+      (c: String, len: Int) => Interval(IntervalEndpoint(Locus(c, 1), -1), IntervalEndpoint(Locus(c, len), -1)))
+    check(ApplyComparisonOp(GT(TInt32()), I32(100), pos),
+      (c: String, _: Int) => Interval(IntervalEndpoint(Locus(c, 1), -1), IntervalEndpoint(Locus(c, 100), -1)))
+
+    check(ApplyComparisonOp(GTEQ(TInt32()), pos, I32(100)),
+      (c: String, len: Int) => if (len < 100)
+        null
+      else
+        Interval(IntervalEndpoint(Locus(c, 100), -1), IntervalEndpoint(Locus(c, len), -1)))
+    check(ApplyComparisonOp(GTEQ(TInt32()), pos, I32(-1000)),
+      (c: String, len: Int) => Interval(IntervalEndpoint(Locus(c, 1), -1), IntervalEndpoint(Locus(c, len), -1)))
+    check(ApplyComparisonOp(GTEQ(TInt32()), I32(100), pos),
+      (c: String, _: Int) => Interval(IntervalEndpoint(Locus(c, 1), -1), IntervalEndpoint(Locus(c, 100), 1)))
+
+    check(ApplyComparisonOp(LT(TInt32()), pos, I32(100)),
+      (c: String, _: Int) => Interval(IntervalEndpoint(Locus(c, 1), -1), IntervalEndpoint(Locus(c, 100), -1)))
+    check(ApplyComparisonOp(LT(TInt32()), pos, I32(-1000)),
+      (c: String, len: Int) => null)
+    check(ApplyComparisonOp(LT(TInt32()), I32(100), pos),
+      (c: String, len: Int) => if (len < 100)
+        null
+      else
+        Interval(IntervalEndpoint(Locus(c, 100), 1), IntervalEndpoint(Locus(c, len), -1)))
+
+    check(ApplyComparisonOp(LTEQ(TInt32()), pos, I32(100)),
+      (c: String, _: Int) => Interval(IntervalEndpoint(Locus(c, 1), -1), IntervalEndpoint(Locus(c, 100), 1)))
+    check(ApplyComparisonOp(LTEQ(TInt32()), pos, I32(-1000)),
+      (c: String, len: Int) => null)
+    check(ApplyComparisonOp(LTEQ(TInt32()), I32(100), pos),
+      (c: String, len: Int) => if (len < 100)
+        null
+      else
+        Interval(IntervalEndpoint(Locus(c, 100), -1), IntervalEndpoint(Locus(c, len), -1)))
+
+    check(ApplyComparisonOp(EQ(TInt32()), pos, I32(100)),
+      (c: String, len: Int) => if (len < 100)
+        null
+      else
+        Interval(IntervalEndpoint(Locus(c, 100), -1), IntervalEndpoint(Locus(c, 100), 1)))
+    check(ApplyComparisonOp(EQ(TInt32()), I32(-1000), pos),
+      (c: String, len: Int) => null)
+    check(ApplyComparisonOp(EQ(TInt32()), I32(100), pos),
+      (c: String, len: Int) => if (len < 100)
+        null
+      else
+        Interval(IntervalEndpoint(Locus(c, 100), -1), IntervalEndpoint(Locus(c, 100), 1)))
+
+    assert(ExtractIntervalFilters.extract(ApplyComparisonOp(NEQ(TInt32()), I32(0), pos), ref, k) == Unknown)
+    assert(ExtractIntervalFilters.extract(ApplyComparisonOp(EQWithNA(TInt32()), I32(0), pos), ref, k) == Unknown)
+    assert(ExtractIntervalFilters.extract(ApplyComparisonOp(NEQWithNA(TInt32()), I32(0), pos), ref, k) == Unknown)
+    assert(ExtractIntervalFilters.extract(ApplyComparisonOp(Compare(TInt32()), I32(0), pos), ref, k) == Unknown)
+  }
+
+  @Test def testLocusContigContains() {
+    hc // force initialization
+    val ref = Ref("foo", TStruct("x" -> TLocus(ReferenceGenome.GRCh38)))
+    val k = GetField(ref, "x")
+    val contig = invoke("contig", k)
+
+    for (lit <- Array(
+      Literal(TSet(TString()), Set("chr1", "chr10")),
+      Literal(TArray(TString()), FastIndexedSeq("chr1", "chr10")),
+      Literal(TDict(TString(), TString()), Map("chr1" -> "foo", "chr10" -> "bar")))) {
+
+      val ir = invoke("contains", lit, contig)
+
+      assert(ExtractIntervalFilters.extract(ir, ref, k) == LocusContigContains(ir))
+      val (s, i) = ExtractIntervalFilters.processPredicates(LocusContigContains(ir), k.typ)
+      assert(s == Set(ir))
+      assert(i.toSeq == FastSeq(
+        Interval(
+          IntervalEndpoint(Locus("chr1", 1), -1),
+          IntervalEndpoint(Locus("chr1", ReferenceGenome.GRCh38.contigLength("chr1")), -1)),
+        Interval(
+          IntervalEndpoint(Locus("chr10", 1), -1),
+          IntervalEndpoint(Locus("chr10", ReferenceGenome.GRCh38.contigLength("chr10")), -1))))
+    }
+  }
+
+  @Test def testDisjunction() {
+    val ir1 = ApplyComparisonOp(GT(TInt32()), k1, I32(0))
+    val ir2 = ApplyComparisonOp(GT(TInt32()), k1, I32(10))
+
+    assert(ExtractIntervalFilters.extract(invoke("||", ir1, ir2), ref1, k1) == Disjunction(KeyComparison(ir1), KeyComparison(ir2)))
+
+    val (s, i) = ExtractIntervalFilters.processPredicates(Disjunction(KeyComparison(ir1), KeyComparison(ir2)), TInt32())
+    assert(s == Set(ir1, ir2))
+    assert(i.toSeq == FastSeq(Interval(IntervalEndpoint(0, 1), IntervalEndpoint(Int.MaxValue, 1))))
+
+    assert(ExtractIntervalFilters.extract(invoke("||", ir1, Ref("foo", TBoolean())), ref1, k1) == Unknown)
+  }
+
+  @Test def testConjunction() {
+    val ir1 = ApplyComparisonOp(GT(TInt32()), k1, I32(0))
+    val ir2 = ApplyComparisonOp(GT(TInt32()), k1, I32(10))
+
+    assert(ExtractIntervalFilters.extract(invoke("&&", ir1, ir2), ref1, k1) == Conjunction(KeyComparison(ir1), KeyComparison(ir2)))
+
+    val (s, i) = ExtractIntervalFilters.processPredicates(Conjunction(KeyComparison(ir1), KeyComparison(ir2)), TInt32())
+    assert(s == Set(ir1, ir2))
+    assert(i.toSeq == FastSeq(Interval(IntervalEndpoint(10, 1), IntervalEndpoint(Int.MaxValue, 1))))
+
+    assert(ExtractIntervalFilters.extract(invoke("&&", ir1, Ref("foo", TBoolean())), ref1, k1) == Conjunction(KeyComparison(ir1), Unknown))
+  }
+
+  @Test def testIntegration() {
+    hc // force initialization
+    val tab1 = TableRange(10, 5)
+
+    def k = GetField(Ref("row", tab1.typ.rowType), "idx")
+
+    val tf = TableFilter(tab1,
+      Coalesce(FastSeq(invoke("&&",
+        ApplyComparisonOp(GT(TInt32()), k, I32(3)),
+        ApplyComparisonOp(LTEQ(TInt32()), k, I32(9))
+      ), False())))
+
+    assert(ExtractIntervalFilters(tf).asInstanceOf[TableFilter].child.isInstanceOf[TableToTableApply])
+    assertEvalsTo(TableCount(tf), 6L)(ExecStrategy.interpretOnly)
+  }
+}


### PR DESCRIPTION
This PR will not be merged as-is, but split along the 3 commits contained within: 
 - Add `Coalesce` IR node
 - Expose pruning on FilterIntervals relational functions. These should be promoted to full IR nodes, especially after this PR.
 - Add `ExtractIntervalFilters` optimizer pass.

I also have yet to add tests for the last commit.

What does this PR do?

```python
In [2]: mt = hl.read_matrix_table('data/1kg.rep.mt')

In [3]: mt.filter_rows(mt.locus.contig == '16').count()
Hail: INFO: interval filter loaded 5 of 128 partitions
Out[3]: (384, 284)

In [4]: mt.filter_rows(mt.locus.contig == '16').count_rows()
Hail: INFO: interval filter loaded 5 of 128 partitions
Out[4]: 384

In [5]: mt.filter_rows((mt.locus.contig == '16') | (mt.locus.contig == '19')).count()
Hail: INFO: interval filter loaded 10 of 128 partitions
Out[5]: (730, 284)

In [6]: mt.filter_rows(hl.literal({'16', '19'}).contains(mt.locus.contig)).count_rows()
Hail: INFO: interval filter loaded 10 of 128 partitions
Out[6]: 730

In [7]: mt.filter_rows((mt.locus.contig == '16') & (mt.locus.position > 10_000_000)).count_rows()
Hail: INFO: interval filter loaded 2 of 128 partitions
Out[7]: 82

In [8]: mt.filter_rows((mt.locus.contig == '16') & (mt.locus.position > 10_000_000) & (mt.locus.position < 12_000_000)).count_rows()
Hail: INFO: interval filter loaded 5 of 128 partitions
Out[8]: 384

In [9]: mt.filter_rows(mt.locus == hl.parse_locus('1:3761547')).count()
Hail: INFO: interval filter loaded 1 of 128 partitions
Out[9]: (1, 284)

In [10]: mt.filter_rows(hl.parse_locus_interval('16:20000000-30000000').contains(mt.locus)).count()
Hail: INFO: interval filter loaded 1 of 128 partitions
Out[10]: (35, 284)
```