### PR TITLE
(scala) don't assume region as first argument to generated function

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -2,6 +2,7 @@ package is.hail.annotations
 
 import is.hail.asm4s.Code._
 import is.hail.asm4s.{Code, FunctionBuilder, _}
+import is.hail.expr.ir
 import is.hail.expr.types.physical._
 import is.hail.utils._
 
@@ -19,6 +20,10 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: PType, va
 
   def this(mb: MethodBuilder, rowType: PType) = {
     this(mb, rowType, mb.getArg[Region](1), null)
+  }
+
+  def this (er: ir.EmitRegion, rowType: PType) = {
+    this(er.mb, rowType, er.region, null)
   }
 
   private val ftype = typ.fundamentalType

--- a/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ArraySorter.scala
@@ -5,9 +5,10 @@ import is.hail.expr.types._
 import is.hail.asm4s._
 import is.hail.expr.types.physical.{PArray, PType}
 
-class ArraySorter(mb: EmitMethodBuilder, array: StagedArrayBuilder) {
+class ArraySorter(r: EmitRegion, array: StagedArrayBuilder) {
   val typ: PType = array.elt
   val ti: TypeInfo[_] = typeToTypeInfo(typ)
+  val mb: EmitMethodBuilder = r.mb
 
   def sort(sorter: DependentEmitFunction[_]): Code[Unit] = {
     val localF = ti match {
@@ -21,7 +22,7 @@ class ArraySorter(mb: EmitMethodBuilder, array: StagedArrayBuilder) {
   }
 
   def toRegion(): Code[Long] = {
-    val srvb = new StagedRegionValueBuilder(mb, PArray(typ))
+    val srvb = new StagedRegionValueBuilder(r, PArray(typ))
     Code(
       srvb.start(array.size),
       Code.whileLoop(srvb.arrayIdx < array.size,
@@ -58,7 +59,7 @@ class ArraySorter(mb: EmitMethodBuilder, array: StagedArrayBuilder) {
       i := 0,
       n := 0,
       Code.whileLoop(i < array.size,
-        Code.whileLoop(i < array.size && discardNext(mb.getArg[Region](1), array(n), array.isMissing(n), array(i), array.isMissing(i)),
+        Code.whileLoop(i < array.size && discardNext(r.region, array(n), array.isMissing(n), array(i), array.isMissing(i)),
           i += 1),
         n += 1,
         (i < array.size && i.cne(n)).mux(

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -646,18 +646,18 @@ private class Emit(
         val marray = processAElts.m.getOrElse(const(false))
 
         EmitTriplet(Code(
+          codeZ.setup,
+          xmaccum := codeZ.m,
+          xvaccum := xmaccum.mux(defaultValue(typ), codeZ.v),
           processAElts.setup,
           marray.mux(
             Code(
               xmaccum := true,
               xvaccum := defaultValue(typ)),
             Code(
-              codeZ.setup,
-              xmaccum := codeZ.m,
-              xvaccum := xmaccum.mux(defaultValue(typ), codeZ.v),
               aBase.calcLength,
-              processAElts.addElements))
-        ), xmaccum, xvaccum)
+              processAElts.addElements))),
+          xmaccum, xvaccum)
 
       case ArrayFor(a, valueName, body) =>
         val tarray = coerce[TStreamable](a.typ)
@@ -983,7 +983,7 @@ private class Emit(
                       def estimatedSize: Int = vir.size * opSize
 
                       def emit(mbLike: EmitMethodBuilderLike): Code[Unit] =
-                        addFields(mbLike.mb, vir.pType, mbLike.emit.emit(vir, env, er))
+                        addFields(mbLike.mb, vir.pType, mbLike.emit.emit(vir, env, EmitRegion.default(mbLike.mb)))
                     }
                   case None =>
                     val oldField = oldtype.field(f.name)
@@ -994,8 +994,7 @@ private class Emit(
                         Code(
                           oldtype.isFieldMissing(region, xo, oldField.index).mux(
                             srvb.setMissing(),
-                            srvb.addIRIntermediate(f.typ)(region.loadIRIntermediate(oldField.typ)(oldtype.fieldOffset(xo, oldField.index)))
-                          ),
+                            srvb.addIRIntermediate(f.typ)(region.loadIRIntermediate(oldField.typ)(oldtype.fieldOffset(xo, oldField.index)))),
                           srvb.advance())
                     }
                 }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -42,9 +42,15 @@ object Emit {
     env: E,
     nSpecialArguments: Int): EmitTriplet = {
     TypeCheck(ir)
-    new Emit(fb.apply_method, nSpecialArguments).emit(ir, env)
+    new Emit(fb.apply_method, nSpecialArguments).emit(ir, env, EmitRegion.default(fb.apply_method))
   }
 }
+
+object EmitRegion {
+  def default(mb: EmitMethodBuilder): EmitRegion = EmitRegion(mb, mb.getArg[Region](1))
+}
+
+case class EmitRegion(mb: EmitMethodBuilder, region: Code[Region])
 
 case class EmitTriplet(setup: Code[Unit], m: Code[Boolean], v: Code[_]) {
   def value[T]: Code[T] = coerce[T](v)
@@ -170,6 +176,7 @@ private class Emit(
   val mb: EmitMethodBuilder,
   val nSpecialArguments: Int) {
 
+  val resultRegion: EmitRegion = EmitRegion.default(mb)
   val region: Code[Region] = mb.getArg[Region](1)
   val methods: mutable.Map[String, Seq[(Seq[Type], EmitMethodBuilder)]] = mutable.Map().withDefaultValue(FastSeq())
 
@@ -194,7 +201,7 @@ private class Emit(
         def estimatedSize: Int = ir.size * opSize
 
         def emit(mbLike: EmitMethodBuilderLike): Code[Unit] =
-          useValues(mbLike.mb, ir.pType, mbLike.emit.emit(ir, env, rvas))
+          useValues(mbLike.mb, ir.pType, mbLike.emit.emit(ir, env, rvas, EmitRegion.default(mbLike.emit.mb)))
       }
     }
 
@@ -240,23 +247,23 @@ private class Emit(
     * {@code tAggIn.elementType}.  {@code tAggIn.symTab} is not used by Emit.
     *
     **/
-  private def emit(ir: IR, env: E): EmitTriplet = {
+  private def emit(ir: IR, env: E, region: EmitRegion): EmitTriplet = {
     emit(ir, env,
       // FIXME hasAggreagtors
       if (nSpecialArguments == 2)
         Some(mb.fb.getArg[Array[RegionValueAggregator]](2))
       else
-        None)
+        None, region)
   }
 
-  private def emit(ir: IR, env: E, rvas: Emit.RVAS): EmitTriplet = {
+  private def emit(ir: IR, env: E, rvas: Emit.RVAS, er: EmitRegion): EmitTriplet = {
 
-    def emit(ir: IR, env: E = env, rvas: Emit.RVAS = rvas): EmitTriplet =
-      this.emit(ir, env, rvas)
+    def emit(ir: IR, env: E = env, rvas: Emit.RVAS = rvas, er: EmitRegion = er): EmitTriplet =
+      this.emit(ir, env, rvas, er)
 
-    def emitArrayIterator(ir: IR, env: E = env, rvas: Emit.RVAS = rvas) = this.emitArrayIterator(ir, env, rvas)
+    def emitArrayIterator(ir: IR, env: E = env, rvas: Emit.RVAS = rvas) = this.emitArrayIterator(ir, env, rvas, er)
 
-    val region = mb.getArg[Region](1).load()
+    val region = er.region
 
     lazy val aggregator = {
       assert(nSpecialArguments >= 2)
@@ -438,13 +445,13 @@ private class Emit(
         val atyp = coerce[PIterable](x.pType)
         val eltType = -atyp.elementType.virtualType
         val vab = new StagedArrayBuilder(atyp.elementType, mb, 16)
-        val sorter = new ArraySorter(mb, vab)
+        val sorter = new ArraySorter(er, vab)
 
         val (array, compare, distinct) = (x: @unchecked) match {
           case ArraySort(a, l, r, comp) => (a, Subst(comp, BindingEnv(Env[IR](l -> In(0, eltType), r -> In(1, eltType)))), Code._empty[Unit])
           case ToSet(a) =>
             val discardNext = mb.fb.newMethod(Array[TypeInfo[_]](typeInfo[Region], sorter.ti, typeInfo[Boolean], sorter.ti, typeInfo[Boolean]), typeInfo[Boolean])
-            val EmitTriplet(s, m, v) = new Emit(discardNext, 1).emit(ApplyComparisonOp(EQWithNA(eltType), In(0, eltType), In(1, eltType)), Env.empty)
+            val EmitTriplet(s, m, v) = new Emit(discardNext, 1).emit(ApplyComparisonOp(EQWithNA(eltType), In(0, eltType), In(1, eltType)), Env.empty, er)
             discardNext.emit(Code(s, m || coerce[Boolean](v)))
             (a, ApplyComparisonOp(Compare(eltType), In(0, eltType), In(1, eltType)) < 0, sorter.distinctFromSorted(discardNext.invoke(_, _, _, _, _)))
           case ToDict(a) =>
@@ -452,7 +459,7 @@ private class Emit(
             val k0 = GetField(In(0, dType.elementType), "key")
             val k1 = GetField(In(1, dType.elementType), "key")
             val discardNext = mb.fb.newMethod(Array[TypeInfo[_]](typeInfo[Region], sorter.ti, typeInfo[Boolean], sorter.ti, typeInfo[Boolean]), typeInfo[Boolean])
-            val EmitTriplet(s, m, v) = new Emit(discardNext, 1).emit(ApplyComparisonOp(EQWithNA(dType.keyType), k0, k1), Env.empty)
+            val EmitTriplet(s, m, v) = new Emit(discardNext, 1).emit(ApplyComparisonOp(EQWithNA(dType.keyType), k0, k1), Env.empty, er)
             discardNext.emit(Code(s, m || coerce[Boolean](v)))
             (a, ApplyComparisonOp(Compare(dType.keyType), k0, k1) < 0, Code(sorter.pruneMissing, sorter.distinctFromSorted(discardNext.invoke(_, _, _, _, _))))
         }
@@ -515,7 +522,7 @@ private class Emit(
         val aout = emitArrayIterator(collection)
 
         val eab = new StagedArrayBuilder(etyp, mb, 16)
-        val sorter = new ArraySorter(mb, eab)
+        val sorter = new ArraySorter(er, eab)
 
         val (k1, k2) = etyp match {
           case t: PStruct => GetField(In(0, t.virtualType), "key") -> GetField(In(1, t.virtualType), "key")
@@ -976,7 +983,7 @@ private class Emit(
                       def estimatedSize: Int = vir.size * opSize
 
                       def emit(mbLike: EmitMethodBuilderLike): Code[Unit] =
-                        addFields(mbLike.mb, vir.pType, mbLike.emit.emit(vir, env))
+                        addFields(mbLike.mb, vir.pType, mbLike.emit.emit(vir, env, er))
                     }
                   case None =>
                     val oldField = oldtype.field(f.name)
@@ -1054,7 +1061,7 @@ private class Emit(
             Code._throw(Code.newInstance[HailException, String](
               cm.m.mux[String](
                 "<exception message missing>",
-                coerce[String](StringFunctions.wrapArg(mb, m.typ)(cm.v)))))))
+                coerce[String](StringFunctions.wrapArg(er, m.typ)(cm.v)))))))
       case ir@ApplyIR(fn, args) =>
         val mfield = mb.newField[Boolean]
         val vfield = mb.newField()(typeToTypeInfo(ir.typ))
@@ -1097,12 +1104,12 @@ private class Emit(
         assert(unified)
         impl.setSeed(seed)
         val codeArgs = args.map(emit(_))
-        impl.apply(mb, codeArgs: _*)
+        impl.apply(er, codeArgs: _*)
       case x@ApplySpecial(_, args) =>
         x.implementation.argTypes.foreach(_.clear())
         val unified = x.implementation.unify(args.map(_.typ))
         assert(unified)
-        x.implementation.apply(mb, args.map(emit(_)): _*)
+        x.implementation.apply(er, args.map(emit(_)): _*)
       case x@Uniroot(argname, fn, min, max) =>
         val missingError = s"result of function missing in call to uniroot; must be defined along entire interval"
         val asmfunction = getAsDependentFunction[Double, Double](fn, Env[IR](argname -> In(0, TFloat64())), env, missingError)
@@ -1159,7 +1166,7 @@ private class Emit(
     val newEnv = getEnv(env, f)
 
     val sort = f.newMethod[Region, T, Boolean, T, Boolean, Boolean]
-    val EmitTriplet(setup, m, v) = new Emit(sort, 1).emit(newIR, newEnv)
+    val EmitTriplet(setup, m, v) = new Emit(sort, 1).emit(newIR, newEnv, EmitRegion.default(sort))
 
     sort.emit(Code(setup, m.mux(Code._fatal("Result of sorting function cannot be missing."), v)))
     f.apply_method.emit(Code(sort.invoke(fregion, f.getArg[T](1), false, f.getArg[T](2), false)))
@@ -1175,7 +1182,7 @@ private class Emit(
     val newEnv = getEnv(env, f)
 
     val foo = new Emit(f.apply_method, 1)
-    val EmitTriplet(setup, m, v) = foo.emit(newIR, newEnv)
+    val EmitTriplet(setup, m, v) = foo.emit(newIR, newEnv, EmitRegion.default(f.apply_method))
 
     val call = Code(
       setup,
@@ -1184,11 +1191,11 @@ private class Emit(
     f
   }
 
-  private def emitArrayIterator(ir: IR, env: E, rvas: Emit.RVAS): ArrayIteratorTriplet = {
+  private def emitArrayIterator(ir: IR, env: E, rvas: Emit.RVAS, er: EmitRegion): ArrayIteratorTriplet = {
 
-    def emit(ir: IR, env: E = env) = this.emit(ir, env, rvas)
+    def emit(ir: IR, env: E = env) = this.emit(ir, env, rvas, er)
 
-    def emitArrayIterator(ir: IR, env: E = env) = this.emitArrayIterator(ir, env, rvas)
+    def emitArrayIterator(ir: IR, env: E = env) = this.emitArrayIterator(ir, env, rvas, er)
 
     ir match {
       case x@ArrayRange(startir, stopir, stepir) =>
@@ -1392,10 +1399,10 @@ private class Emit(
           r -> (typeToTypeInfo(relt), rm.load() || rtyp.isElementMissing(region, rv, ri), rtyp.loadElement(region, rv, ri)))
 
         val compKeyF = mb.fb.newMethod(typeInfo[Region], typeInfo[Int])
-        val et = new Emit(compKeyF, 1).emit(compKey, fenv)
+        val et = new Emit(compKeyF, 1).emit(compKey, fenv, er)
         compKeyF.emit(Code(et.setup, et.m.mux(Code._fatal("ArrayLeftJoinDistinct: comp can't be missing"), et.value[Int])))
         val joinF = mb.fb.newMethod(typeInfo[Region], typeToTypeInfo(relt), typeInfo[Boolean], typeToTypeInfo(join.typ))
-        val jet = new Emit(joinF, 1).emit(Subst(join, BindingEnv(Env[IR](r -> In(0, relt)))), fenv)
+        val jet = new Emit(joinF, 1).emit(Subst(join, BindingEnv(Env[IR](r -> In(0, relt)))), fenv, er)
         joinF.emit(Code(jet.setup, jet.m.mux(Code._fatal("ArrayLeftJoinDistinct: joined can't be missing"), jet.v)))
 
         val ae = { cont: Emit.F =>
@@ -1437,14 +1444,14 @@ private class Emit(
           context = Some("ArrayAggScan/StagedExtractAggregators/perElt"))
 
         val rvas = mb.newField[Array[RegionValueAggregator]]("rvas")
-        val aggInit = this.emit(init, env, Some(rvas))
+        val aggInit = this.emit(init, env, Some(rvas), er)
 
         val elt = coerce[TStreamable](a.typ).elementType
         val elementTypeInfoA = coerce[Any](typeToTypeInfo(elt))
         val xmv = mb.newField[Boolean]()
         val xvv = mb.newField(name)(elementTypeInfoA)
         val bodyEnv = env.bind(name -> (elementTypeInfoA, xmv.load(), xvv.load()))
-        val accumulate = this.emit(perElt, bodyEnv, Some(rvas))
+        val accumulate = this.emit(perElt, bodyEnv, Some(rvas), er)
 
         val aggr = mb.newField[Long]("AGGR")
         val rvb = mb.newField[RegionValueBuilder]("rvb")

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -320,22 +320,22 @@ object ArrayFunctions extends RegistryFunctions {
     }
 
     registerCodeWithMissingness("corr", TArray(TFloat64()), TArray(TFloat64()), TFloat64()) {
-      case (mb, EmitTriplet(setup1, m1, v1), EmitTriplet(setup2, m2, v2)) =>
+      case (r, EmitTriplet(setup1, m1, v1), EmitTriplet(setup2, m2, v2)) =>
         val t1 = PArray(PFloat64())
         val t2 = PArray(PFloat64())
-        val region = getRegion(mb)
+        val region = r.region
 
-        val xSum = mb.newLocal[Double]
-        val ySum = mb.newLocal[Double]
-        val xSqSum = mb.newLocal[Double]
-        val ySqSum = mb.newLocal[Double]
-        val xySum = mb.newLocal[Double]
-        val n = mb.newLocal[Int]
-        val i = mb.newLocal[Int]
-        val l1 = mb.newLocal[Int]
-        val l2 = mb.newLocal[Int]
-        val x = mb.newLocal[Double]
-        val y = mb.newLocal[Double]
+        val xSum = r.mb.newLocal[Double]
+        val ySum = r.mb.newLocal[Double]
+        val xSqSum = r.mb.newLocal[Double]
+        val ySqSum = r.mb.newLocal[Double]
+        val xySum = r.mb.newLocal[Double]
+        val n = r.mb.newLocal[Int]
+        val i = r.mb.newLocal[Int]
+        val l1 = r.mb.newLocal[Int]
+        val l2 = r.mb.newLocal[Int]
+        val x = r.mb.newLocal[Double]
+        val y = r.mb.newLocal[Double]
 
         val a1 = v1.asInstanceOf[Code[Long]]
         val a2 = v2.asInstanceOf[Code[Long]]

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -2,7 +2,6 @@ package is.hail.expr.ir.functions
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.expr.types._
 import is.hail.expr.types.physical.PArray
 import is.hail.expr.types.virtual.{TArray, TFloat64, TInt32}
@@ -12,14 +11,14 @@ import is.hail.variant.Genotype
 object GenotypeFunctions extends RegistryFunctions {
 
   def registerAll() {
-    registerCode("gqFromPL", TArray(tv("N", "int32")), TInt32()) { (mb, pl: Code[Long]) =>
-      val region = getRegion(mb)
+    registerCode("gqFromPL", TArray(tv("N", "int32")), TInt32()) { (r, pl: Code[Long]) =>
+      val region = r.region
       val tPL = PArray(tv("N").t.physicalType)
-      val m = mb.newLocal[Int]("m")
-      val m2 = mb.newLocal[Int]("m2")
-      val len = mb.newLocal[Int]("len")
-      val pli = mb.newLocal[Int]("pli")
-      val i = mb.newLocal[Int]("i")
+      val m = r.mb.newLocal[Int]("m")
+      val m2 = r.mb.newLocal[Int]("m2")
+      val len = r.mb.newLocal[Int]("len")
+      val pli = r.mb.newLocal[Int]("pli")
+      val i = r.mb.newLocal[Int]("i")
       Code(
         m := 99,
         m2 := 99,
@@ -41,11 +40,10 @@ object GenotypeFunctions extends RegistryFunctions {
       )
     }
 
-    registerCode("dosage", TArray(tv("N", "float64")), TFloat64()) { (mb, gpOff: Code[Long]) =>
-      def getRegion(mb: EmitMethodBuilder): Code[Region] = mb.getArg[Region](1)
+    registerCode("dosage", TArray(tv("N", "float64")), TFloat64()) { (r, gpOff: Code[Long]) =>
       val pArray = TArray(tv("N").t).physicalType
-      val gp = mb.newLocal[Long]
-      val region = getRegion(mb)
+      val gp = r.mb.newLocal[Long]
+      val region = r.region
       val len = pArray.loadLength(region, gp)
 
       Code(
@@ -58,11 +56,10 @@ object GenotypeFunctions extends RegistryFunctions {
 
     // FIXME: remove when SkatSuite is moved to Python
     // the pl_dosage function in Python is implemented in Python
-    registerCode("plDosage", TArray(tv("N", "int32")), TFloat64()) { (mb, plOff: Code[Long]) =>
-      def getRegion(mb: EmitMethodBuilder): Code[Region] = mb.getArg[Region](1)
+    registerCode("plDosage", TArray(tv("N", "int32")), TFloat64()) { (r, plOff: Code[Long]) =>
       val pArray = TArray(tv("N").t).physicalType
-      val pl = mb.newLocal[Long]
-      val region = getRegion(mb)
+      val pl = r.mb.newLocal[Long]
+      val region = r.region
       val len = pArray.loadLength(region, pl)
 
       Code(

--- a/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -14,36 +14,34 @@ import is.hail.utils._
 
 object LocusFunctions extends RegistryFunctions {
 
-  def getLocus(mb: EmitMethodBuilder, locus: Code[Long], typeString: String): Code[Locus] = {
+  def getLocus(r: EmitRegion, locus: Code[Long], typeString: String): Code[Locus] = {
     val tlocus = types.coerce[TLocus](tv(typeString).t)
-    Code.checkcast[Locus](wrapArg(mb, tlocus)(locus).asInstanceOf[Code[AnyRef]])
+    Code.checkcast[Locus](wrapArg(r, tlocus)(locus).asInstanceOf[Code[AnyRef]])
   }
 
   def registerLocusCode(methodName: String): Unit = {
     registerCode(methodName, tv("T", "locus"), TBoolean()) {
-      case (mb: EmitMethodBuilder, locus: Code[Long]) =>
-        val locusObject = getLocus(mb, locus, "T")
+      case (r: EmitRegion, locus: Code[Long]) =>
+        val locusObject = getLocus(r, locus, "T")
         val tlocus = types.coerce[TLocus](tv("T").t)
         val rg = tlocus.rg.asInstanceOf[ReferenceGenome]
 
-        val codeRG = mb.getReferenceGenome(rg)
-        unwrapReturn(mb, TBoolean())(locusObject.invoke[RGBase, Boolean](methodName, codeRG))
+        val codeRG = r.mb.getReferenceGenome(rg)
+        unwrapReturn(r, TBoolean())(locusObject.invoke[RGBase, Boolean](methodName, codeRG))
     }
   }
 
   def registerAll() {
     registerCode("contig", tv("T", "locus"), TString()) {
-      case (mb, locus: Code[Long]) =>
-        val region = getRegion(mb)
+      case (r, locus: Code[Long]) =>
         val tlocus = types.coerce[TLocus](tv("T").t).physicalType
-        tlocus.contig(region, locus)
+        tlocus.contig(r.region, locus)
     }
 
     registerCode("position", tv("T", "locus"), TInt32()) {
-      case (mb, locus: Code[Long]) =>
-        val region = getRegion(mb)
+      case (r, locus: Code[Long]) =>
         val tlocus = types.coerce[TLocus](tv("T").t).physicalType
-        tlocus.position(region, locus)
+        tlocus.position(r.region, locus)
     }
 
     registerLocusCode("isAutosomalOrPseudoAutosomal")
@@ -54,16 +52,16 @@ object LocusFunctions extends RegistryFunctions {
     registerLocusCode("inXNonPar")
     registerLocusCode("inYPar")
 
-    registerCode("min_rep", tv("T", "locus"), TArray(TString()), TStruct("locus" -> tv("T"), "alleles" -> TArray(TString()))) { (mb, lOff, aOff) =>
-      val returnTuple = mb.newLocal[(Locus, IndexedSeq[String])]
-      val locus = getLocus(mb, lOff, "T")
-      val alleles = Code.checkcast[IndexedSeq[String]](wrapArg(mb, TArray(TString()))(aOff).asInstanceOf[Code[AnyRef]])
+    registerCode("min_rep", tv("T", "locus"), TArray(TString()), TStruct("locus" -> tv("T"), "alleles" -> TArray(TString()))) { (r, lOff, aOff) =>
+      val returnTuple = r.mb.newLocal[(Locus, IndexedSeq[String])]
+      val locus = getLocus(r, lOff, "T")
+      val alleles = Code.checkcast[IndexedSeq[String]](wrapArg(r, TArray(TString()))(aOff).asInstanceOf[Code[AnyRef]])
       val tuple = Code.invokeScalaObject[Locus, IndexedSeq[String], (Locus, IndexedSeq[String])](VariantMethods.getClass, "minRep", locus, alleles)
 
       val newLocus = Code.checkcast[Locus](returnTuple.load().get[java.lang.Object]("_1"))
       val newAlleles = Code.checkcast[IndexedSeq[String]](returnTuple.load().get[java.lang.Object]("_2"))
 
-      val srvb = new StagedRegionValueBuilder(mb, PTuple(FastIndexedSeq(tv("T").t.physicalType, PArray(PString()))))
+      val srvb = new StagedRegionValueBuilder(r, PTuple(FastIndexedSeq(tv("T").t.physicalType, PArray(PString()))))
       Code(
         returnTuple := tuple,
         srvb.start(),
@@ -86,23 +84,23 @@ object LocusFunctions extends RegistryFunctions {
     }
 
     registerCode("locus_windows_per_contig", TArray(TArray(TFloat64())), TFloat64(), TTuple(TArray(TInt32()), TArray(TInt32()))) {
-      (mb: EmitMethodBuilder, coords: Code[Long], radius: Code[Double]) =>
-        val region: Code[Region] = getRegion(mb)
+      (r: EmitRegion, coords: Code[Long], radius: Code[Double]) =>
+        val region: Code[Region] = r.region
 
         val groupedt = PArray(PArray(PFloat64()))
         val coordt = types.coerce[PArray](groupedt.elementType)
         val rt = PTuple(FastIndexedSeq(PArray(PInt64()), PArray(PInt64())))
 
-        val ncontigs = mb.newLocal[Int]("ncontigs")
-        val totalLen = mb.newLocal[Int]("l")
-        val iContig = mb.newLocal[Int]
+        val ncontigs = r.mb.newLocal[Int]("ncontigs")
+        val totalLen = r.mb.newLocal[Int]("l")
+        val iContig = r.mb.newLocal[Int]
 
-        val len = mb.newLocal[Int]("l")
-        val i = mb.newLocal[Int]("i")
-        val idx = mb.newLocal[Int]("i")
-        val coordsPerContig = mb.newLocal[Long]("coords")
-        val offset = mb.newLocal[Int]("offset")
-        val lastCoord = mb.newLocal[Double]("coord")
+        val len = r.mb.newLocal[Int]("l")
+        val i = r.mb.newLocal[Int]("i")
+        val idx = r.mb.newLocal[Int]("i")
+        val coordsPerContig = r.mb.newLocal[Long]("coords")
+        val offset = r.mb.newLocal[Int]("offset")
+        val lastCoord = r.mb.newLocal[Double]("coord")
 
         val getCoord = { i: Code[Int] =>
           asm4s.coerce[Double](region.loadIRIntermediate(PFloat64())(coordt.elementOffset(coordsPerContig, len, i)))
@@ -146,7 +144,7 @@ object LocusFunctions extends RegistryFunctions {
                 offset := offset + len)))
         }
 
-        val srvb = new StagedRegionValueBuilder(mb, rt)
+        val srvb = new StagedRegionValueBuilder(r, rt)
         Code(
           ncontigs := groupedt.loadLength(region, coords),
           totalLen := 0,

--- a/hail/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/MathFunctions.scala
@@ -180,9 +180,9 @@ object MathFunctions extends RegistryFunctions {
 
     registerWrappedScalaFunction("entropy", TString(), TFloat64())(thisClass, "irentropy")
 
-    registerCode("fisher_exact_test", TInt32(), TInt32(), TInt32(), TInt32(), fetStruct){ case (mb, a, b, c, d) =>
-      val res = mb.newLocal[Array[Double]]
-      val srvb = new StagedRegionValueBuilder(mb, fetStruct.physicalType)
+    registerCode("fisher_exact_test", TInt32(), TInt32(), TInt32(), TInt32(), fetStruct){ case (r, a, b, c, d) =>
+      val res = r.mb.newLocal[Array[Double]]
+      val srvb = new StagedRegionValueBuilder(r, fetStruct.physicalType)
       Code(
         res := Code.invokeScalaObject[Int, Int, Int, Int, Array[Double]](statsPackageClass, "fisherExactTest", a, b, c, d),
         srvb.start(),
@@ -198,9 +198,9 @@ object MathFunctions extends RegistryFunctions {
       )
     }
     
-    registerCode("chi_squared_test", TInt32(), TInt32(), TInt32(), TInt32(), chisqStruct){ case (mb, a, b, c, d) =>
-      val res = mb.newLocal[Array[Double]]
-      val srvb = new StagedRegionValueBuilder(mb, chisqStruct.physicalType)
+    registerCode("chi_squared_test", TInt32(), TInt32(), TInt32(), TInt32(), chisqStruct){ case (r, a, b, c, d) =>
+      val res = r.mb.newLocal[Array[Double]]
+      val srvb = new StagedRegionValueBuilder(r, chisqStruct.physicalType)
       Code(
         res := Code.invokeScalaObject[Int, Int, Int, Int, Array[Double]](statsPackageClass, "chiSquaredTest", a, b, c, d),
         srvb.start(),
@@ -212,9 +212,9 @@ object MathFunctions extends RegistryFunctions {
       )
     }
 
-    registerCode("contingency_table_test", TInt32(), TInt32(), TInt32(), TInt32(), TInt32(), chisqStruct){ case (mb, a, b, c, d, min_cell_count) =>
-      val res = mb.newLocal[Array[Double]]
-      val srvb = new StagedRegionValueBuilder(mb, chisqStruct.physicalType)
+    registerCode("contingency_table_test", TInt32(), TInt32(), TInt32(), TInt32(), TInt32(), chisqStruct){ case (r, a, b, c, d, min_cell_count) =>
+      val res = r.mb.newLocal[Array[Double]]
+      val srvb = new StagedRegionValueBuilder(r, chisqStruct.physicalType)
       Code(
         res := Code.invokeScalaObject[Int, Int, Int, Int, Int, Array[Double]](statsPackageClass, "contingencyTableTest", a, b, c, d, min_cell_count),
         srvb.start(),
@@ -226,9 +226,9 @@ object MathFunctions extends RegistryFunctions {
       )
     }
 
-    registerCode("hardy_weinberg_test", TInt32(), TInt32(), TInt32(), hweStruct){ case (mb, nHomRef, nHet, nHomVar) =>
-      val res = mb.newLocal[Array[Double]]
-      val srvb = new StagedRegionValueBuilder(mb, hweStruct.physicalType)
+    registerCode("hardy_weinberg_test", TInt32(), TInt32(), TInt32(), hweStruct){ case (r, nHomRef, nHet, nHomVar) =>
+      val res = r.mb.newLocal[Array[Double]]
+      val srvb = new StagedRegionValueBuilder(r, hweStruct.physicalType)
       Code(
         res := Code.invokeScalaObject[Int, Int, Int, Array[Double]](statsPackageClass, "hardyWeinbergTest", nHomRef, nHet, nHomVar),
         srvb.start(),

--- a/hail/src/main/scala/is/hail/expr/ir/functions/RandomSeededFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/RandomSeededFunctions.scala
@@ -51,44 +51,44 @@ class IRRandomness(seed: Long) {
 object RandomSeededFunctions extends RegistryFunctions {
 
   def registerAll() {
-    registerSeeded("rand_unif", TFloat64(), TFloat64(), TFloat64()) { case (mb, seed, min, max) =>
-      mb.newRNG(seed).invoke[Double, Double, Double]("runif", min, max)
+    registerSeeded("rand_unif", TFloat64(), TFloat64(), TFloat64()) { case (r, seed, min, max) =>
+      r.mb.newRNG(seed).invoke[Double, Double, Double]("runif", min, max)
     }
 
-    registerSeeded("rand_norm", TFloat64(), TFloat64(), TFloat64()) { case (mb, seed, mean, sd) =>
-      mb.newRNG(seed).invoke[Double, Double, Double]("rnorm", mean, sd)
+    registerSeeded("rand_norm", TFloat64(), TFloat64(), TFloat64()) { case (r, seed, mean, sd) =>
+      r.mb.newRNG(seed).invoke[Double, Double, Double]("rnorm", mean, sd)
     }
 
-    registerSeeded("rand_bool", TFloat64(), TBoolean()) { case (mb, seed, p) =>
-      mb.newRNG(seed).invoke[Double, Boolean]("rcoin", p)
+    registerSeeded("rand_bool", TFloat64(), TBoolean()) { case (r, seed, p) =>
+      r.mb.newRNG(seed).invoke[Double, Boolean]("rcoin", p)
     }
 
-    registerSeeded("rand_pois", TFloat64(), TFloat64()) { case (mb, seed, lambda) =>
-      mb.newRNG(seed).invoke[Double, Double]("rpois", lambda)
+    registerSeeded("rand_pois", TFloat64(), TFloat64()) { case (r, seed, lambda) =>
+      r.mb.newRNG(seed).invoke[Double, Double]("rpois", lambda)
     }
 
-    registerSeeded("rand_pois", TInt32(), TFloat64(), TArray(TFloat64())) { case (mb, seed, n, lambda) =>
-      val length = mb.newLocal[Int]
-      val srvb = new StagedRegionValueBuilder(mb, PArray(PFloat64()))
+    registerSeeded("rand_pois", TInt32(), TFloat64(), TArray(TFloat64())) { case (r, seed, n, lambda) =>
+      val length = r.mb.newLocal[Int]
+      val srvb = new StagedRegionValueBuilder(r, PArray(PFloat64()))
       Code(
         length := n,
         srvb.start(n),
         Code.whileLoop(srvb.arrayIdx < length,
-          srvb.addDouble(mb.newRNG(seed).invoke[Double, Double]("rpois", lambda)),
+          srvb.addDouble(r.mb.newRNG(seed).invoke[Double, Double]("rpois", lambda)),
           srvb.advance()
         ),
         srvb.offset)
     }
 
-    registerSeeded("rand_beta", TFloat64(), TFloat64(), TFloat64()) { case (mb, seed, a, b) =>
-      mb.newRNG(seed).invoke[Double, Double, Double]("rbeta", a, b)
+    registerSeeded("rand_beta", TFloat64(), TFloat64(), TFloat64()) { case (r, seed, a, b) =>
+      r.mb.newRNG(seed).invoke[Double, Double, Double]("rbeta", a, b)
     }
 
-    registerSeeded("rand_beta", TFloat64(), TFloat64(), TFloat64(), TFloat64(), TFloat64()) { case (mb, seed, a, b, min, max) =>
-      val rng = mb.newRNG(seed)
-      val value = mb.newLocal[Double]
-      val lmin = mb.newLocal[Double]
-      val lmax = mb.newLocal[Double]
+    registerSeeded("rand_beta", TFloat64(), TFloat64(), TFloat64(), TFloat64(), TFloat64()) { case (r, seed, a, b, min, max) =>
+      val rng = r.mb.newRNG(seed)
+      val value = r.mb.newLocal[Double]
+      val lmin = r.mb.newLocal[Double]
+      val lmax = r.mb.newLocal[Double]
       Code(
         lmin := min,
         lmax := max,
@@ -98,25 +98,25 @@ object RandomSeededFunctions extends RegistryFunctions {
         value)
     }
 
-    registerSeeded("rand_gamma", TFloat64(), TFloat64(), TFloat64()) { case (mb, seed, a, scale) =>
-      mb.newRNG(seed).invoke[Double, Double, Double]("rgamma", a, scale)
+    registerSeeded("rand_gamma", TFloat64(), TFloat64(), TFloat64()) { case (r, seed, a, scale) =>
+      r.mb.newRNG(seed).invoke[Double, Double, Double]("rgamma", a, scale)
     }
 
-    registerSeeded("rand_cat", TArray(TFloat64()), TInt32()) { case (mb, seed, a) =>
+    registerSeeded("rand_cat", TArray(TFloat64()), TInt32()) { case (r, seed, a) =>
       val pArray = PArray(PFloat64())
-      val array = mb.newLocal[Array[Double]]
-      val aoff = mb.newLocal[Long]
-      val length = mb.newLocal[Int]
-      val i = mb.newLocal[Int]
+      val array = r.mb.newLocal[Array[Double]]
+      val aoff = r.mb.newLocal[Long]
+      val length = r.mb.newLocal[Int]
+      val i = r.mb.newLocal[Int]
       Code(
         aoff := a,
         i := 0,
-        length := pArray.loadLength(getRegion(mb), aoff),
+        length := pArray.loadLength(r.region, aoff),
         array := Code.newArray[Double](length),
         Code.whileLoop(i < length,
-          array.load().update(i, getRegion(mb).loadDouble(pArray.elementOffset(aoff, length, i))),
+          array.load().update(i, r.region.loadDouble(pArray.elementOffset(aoff, length, i))),
           i += 1),
-        mb.newRNG(seed).invoke[Array[Double], Int]("rcat", array))
+        r.mb.newRNG(seed).invoke[Array[Double], Int]("rcat", array))
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -156,7 +156,7 @@ object StringFunctions extends RegistryFunctions {
       EmitTriplet(setup, missing, value)
     }
 
-    registerCodeWithMissingness("hamming", TString(), TString(), TInt32()) { case (r: EmitMethodBuilder, e1: EmitTriplet, e2: EmitTriplet) =>
+    registerCodeWithMissingness("hamming", TString(), TString(), TInt32()) { case (r: EmitRegion, e1: EmitTriplet, e2: EmitTriplet) =>
       val len = r.mb.newLocal[Int]
       val i = r.mb.newLocal[Int]
       val n = r.mb.newLocal[Int]

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -34,7 +34,7 @@ object IRSuite {
 
   object TestFunctions extends RegistryFunctions {
 
-    def registerSeededWithMissingness(mname: String, aTypes: Array[Type], rType: Type)(impl: (EmitMethodBuilder, Long, Array[EmitTriplet]) => EmitTriplet) {
+    def registerSeededWithMissingness(mname: String, aTypes: Array[Type], rType: Type)(impl: (EmitRegion, Long, Array[EmitTriplet]) => EmitTriplet) {
       IRFunctionRegistry.addIRFunction(new SeededIRFunction {
         val isDeterministic: Boolean = false
 
@@ -44,13 +44,13 @@ object IRSuite {
 
         override val returnType: Type = rType
 
-        def applySeeded(seed: Long, mb: EmitMethodBuilder, args: EmitTriplet*): EmitTriplet =
-          impl(mb, seed, args.toArray)
+        def applySeeded(seed: Long, r: EmitRegion, args: EmitTriplet*): EmitTriplet =
+          impl(r, seed, args.toArray)
       })
     }
 
-    def registerSeededWithMissingness(mname: String, mt1: Type, rType: Type)(impl: (EmitMethodBuilder, Long, EmitTriplet) => EmitTriplet): Unit =
-      registerSeededWithMissingness(mname, Array(mt1), rType) { case (mb, seed, Array(a1)) => impl(mb, seed, a1) }
+    def registerSeededWithMissingness(mname: String, mt1: Type, rType: Type)(impl: (EmitRegion, Long, EmitTriplet) => EmitTriplet): Unit =
+      registerSeededWithMissingness(mname, Array(mt1), rType) { case (r, seed, Array(a1)) => impl(r, seed, a1) }
 
     def registerAll() {
       registerSeededWithMissingness("incr_s", TBoolean(), TBoolean()) { (mb, _, l) =>

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -16,7 +16,7 @@ import is.hail.linalg.BlockMatrix
 import is.hail.methods._
 import is.hail.rvd.RVD
 import is.hail.table.{Ascending, Descending, SortField, Table}
-import is.hail.utils._
+import is.hail.utils.{FastIndexedSeq, _}
 import is.hail.variant.{Call, Call2, MatrixTable}
 import org.apache.spark.sql.Row
 import org.json4s.jackson.Serialization
@@ -1982,5 +1982,13 @@ class IRSuite extends SparkSuite {
       case x: TableToValueFunction => assert(RelationalFunctions.lookupTableToValue(Serialization.write(x)) == x)
       case x: BlockMatrixToValueFunction => assert(RelationalFunctions.lookupBlockMatrixToValue(Serialization.write(x)) == x)
     }
+  }
+
+  @Test def testFoldWithSetup() {
+    val v = In(0, TInt32())
+    val cond1 = If(v.ceq(I32(3)),
+      MakeArray(FastIndexedSeq(I32(1), I32(2), I32(3)), TArray(TInt32())),
+      MakeArray(FastIndexedSeq(I32(4), I32(5), I32(6)), TArray(TInt32())))
+    assertEvalsTo(ArrayFold(cond1, True(), "accum", "i", Ref("i", TInt32()).ceq(v)), FastIndexedSeq(0 -> TInt32()), false)
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
@@ -36,16 +36,16 @@ object TestRandomFunctions extends RegistryFunctions {
   }
 
   def registerAll() {
-    registerSeeded("counter_seeded", TInt32()) { case (mb, seed) =>
-      getTestRNG(mb, seed).invoke[Int]("counter")
+    registerSeeded("counter_seeded", TInt32()) { case (r, seed) =>
+      getTestRNG(r.mb, seed).invoke[Int]("counter")
     }
 
-    registerSeeded("seed_seeded", TInt64()) { case (mb, seed) =>
-      getTestRNG(mb, seed).invoke[Long]("seed")
+    registerSeeded("seed_seeded", TInt64()) { case (r, seed) =>
+      getTestRNG(r.mb, seed).invoke[Long]("seed")
     }
 
-    registerSeeded("pi_seeded", TInt32()) { case (mb, seed) =>
-      getTestRNG(mb, seed).invoke[Int]("partitionIndex")
+    registerSeeded("pi_seeded", TInt32()) { case (r, seed) =>
+      getTestRNG(r.mb, seed).invoke[Int]("partitionIndex")
     }
   }
 }


### PR DESCRIPTION
In this PR, I replaced the usage of EmitMethodBuilder with a shim class called EmitRegion basically wherever we expect to need to pull the region from the methodbuilder. EmitRegion currently just holds the methodbuilder and the region to use if we need to store values.

I have not yet changed any region behavior, so this PR should not affect the generated code.