### PR TITLE
[batch] Miscellaneous performance improvements

### DIFF
--- a/batch/batch/database.py
+++ b/batch/batch/database.py
@@ -85,7 +85,7 @@ class Table:  # pylint: disable=R0903
                     sql = f"UPDATE `{self.name}` SET {set_template} WHERE {where_template}"
                     await cursor.execute(sql, (*set_values, *where_values))
 
-    async def get_record(self, where_items, select_fields=None):
+    async def get_records(self, where_items, select_fields=None):
         assert select_fields is None or len(select_fields) != 0
         async with self._db.pool.acquire() as conn:
             async with conn.cursor() as cursor:

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -883,7 +883,7 @@ async def get_batches_list(request, userdata):
     params = request.query
     user = userdata['ksa_name']
 
-    batches = [Batch.from_record(record) for record in await db.batch.get_records({'user': user})]
+    batches = [Batch.from_record(record) for record in await db.batch.get_all_records({'user': user})]
     for name, value in params.items():
         if name == 'complete':
             if value not in ('0', '1'):

--- a/batch/test/test_database.py
+++ b/batch/test/test_database.py
@@ -53,7 +53,7 @@ class Test(unittest.TestCase):
             run_synchronous(t.update_record({'id': 3, 'name': '3'},
                                             {'name': 'hello'}))
 
-            updated_record = run_synchronous(t.get_record({'id': 3}))
+            updated_record = run_synchronous(t.get_records({'id': 3}))
             assert len(updated_record) == 1
             assert updated_record[0]['name'] == 'hello'
         finally:
@@ -62,7 +62,7 @@ class Test(unittest.TestCase):
     def test_get_records(self):
         t = self.temp_table()
         try:
-            records = run_synchronous(t.get_record({'id': [1, 2]}))
+            records = run_synchronous(t.get_records({'id': [1, 2]}))
             assert len(records) == 2
             assert records == [{'id': 1, 'less_than_two': True, 'name': '1'},
                                {'id': 2, 'less_than_two': False, 'name': '2'}]
@@ -72,7 +72,7 @@ class Test(unittest.TestCase):
     def test_select_records(self):
         t = self.temp_table()
         try:
-            records = run_synchronous(t.get_record({'id': 1}, ['less_than_two']))
+            records = run_synchronous(t.get_records({'id': 1}, ['less_than_two']))
             assert len(records) == 1
             assert records == [{'less_than_two': True}]
         finally:
@@ -82,7 +82,7 @@ class Test(unittest.TestCase):
         t = self.temp_table()
         try:
             run_synchronous(t.delete_record({'id': 1}))
-            records = run_synchronous(t.get_record({'id': 1}))
+            records = run_synchronous(t.get_records({'id': 1}))
             assert len(records) == 0
         finally:
             self.db.drop_table_sync(t.name)
@@ -103,7 +103,7 @@ class Test(unittest.TestCase):
         t = self.db.create_temporary_table_sync("temp", schema, keys)
 
         try:
-            records = run_synchronous(t.get_record({'`less_than_two`': True}))
+            records = run_synchronous(t.get_records({'`less_than_two`': True}))
             assert len(records) == 0
             run_synchronous(t.new_record(**{'id': 5, '`less_than_two`': False, 'name': "foo"}))
             assert run_synchronous(t.has_record({'`less_than_two`': False}))
@@ -116,9 +116,9 @@ class Test(unittest.TestCase):
         t = self.temp_table()
         try:
             run_synchronous(t.update_record({'id': 1}, {'name': None}))
-            records = run_synchronous(t.get_record({'name': 'NOT NULL'}))
+            records = run_synchronous(t.get_records({'name': 'NOT NULL'}))
             assert len(records) == 4
-            records = run_synchronous(t.get_record({'name': None}))
+            records = run_synchronous(t.get_records({'name': None}))
             assert len(records) == 1
         finally:
             self.db.drop_table_sync(t.name)

--- a/ci2/ci/ci.py
+++ b/ci2/ci/ci.py
@@ -16,7 +16,6 @@ import batch
 from .log import log
 from .constants import BUCKET
 from .github import Repo, FQBranch, WatchedBranch
-from .utils import update_batch_status
 
 with open(os.environ.get('HAIL_CI2_OAUTH_TOKEN', 'oauth-token/oauth-token'), 'r') as f:
     oauth_token = f.read().strip()
@@ -94,8 +93,6 @@ async def get_batches(request):
     batch_client = request.app['batch_client']
     batches = await batch_client.list_batches()
     statuses = [await b.status() for b in batches]
-    for status in statuses:
-        update_batch_status(status)
     return {
         'batches': statuses
     }

--- a/ci2/ci/github.py
+++ b/ci2/ci/github.py
@@ -7,7 +7,7 @@ import gidgethub
 from .log import log
 from .constants import GITHUB_CLONE_URL
 from .environment import SELF_HOSTNAME
-from .utils import CalledProcessError, check_shell, check_shell_output, update_batch_status
+from .utils import CalledProcessError, check_shell, check_shell_output
 from .build import BuildConfiguration, Code
 
 repos_lock = asyncio.Lock()
@@ -293,7 +293,6 @@ mkdir -p {shq(repo_dir)}
         if self.batch:
             seen_batch_ids.add(self.batch.id)
             status = await self.batch.status()
-            update_batch_status(status)
             if status['complete']:
                 if status['state'] == 'success':
                     self.build_state = 'success'
@@ -476,7 +475,6 @@ class WatchedBranch(Code):
 
             if self.deploy_batch:
                 status = await self.deploy_batch.status()
-                update_batch_status(status)
                 if status['complete']:
                     if status['state'] == 'success':
                         self.deploy_state = 'success'

--- a/ci2/ci/utils.py
+++ b/ci2/ci/utils.py
@@ -40,23 +40,3 @@ def generate_token(size=12):
 
 def flatten(xxs):
     return [x for xs in xxs for x in xs]
-
-
-# FIXME move to batch
-def update_batch_status(status):
-    jobs = status['jobs']
-
-    if any(job['state'] == 'Complete' and job['exit_code'] > 0 for job in jobs):
-        state = 'failure'
-    elif any(job['state'] == 'Cancelled' for job in jobs):
-        state = 'cancelled'
-    elif all(job['state'] == 'Complete' and job['exit_code'] == 0 for job in jobs):
-        state = 'success'
-    else:
-        state = 'running'
-
-    if state:
-        status['state'] = state
-
-    complete = all(job['state'] in ('Cancelled', 'Complete') for job in jobs)
-    status['complete'] = complete


### PR DESCRIPTION
- renamed `get_record` to `get_records` to be clear that this returns all matching records
- Added `state` and `complete` to the Batch class in server. These are computed when the Batch is queried from the database.
- Batch `to_dict` returns `state` and `complete` in the result. It also has an option on whether to include `jobs` in the output.
- Batch `list_batches` in `server.py` no longer outputs the `jobs` per Batch
- Changed `ci2` to use the new Batch status with the state and complete included.