### PR TITLE
clean up uses of Emit in tests

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -22,10 +22,6 @@ object Emit {
     emit(ir, fb, Env.empty, nSpecialArguments)
   }
 
-  def apply(ir: IR, fb: EmitFunctionBuilder[_]) {
-    apply(ir, fb, 1)
-  }
-
   def apply(ir: IR, fb: EmitFunctionBuilder[_], nSpecialArguments: Int) {
     val triplet = emit(ir, fb, Env.empty, nSpecialArguments)
     typeToTypeInfo(ir.typ) match {


### PR DESCRIPTION
Just cleaning up some old tests to use assertEvalsTo instead of manually constructing the functions.