### PR TITLE
wait for deployment before testing service

### DIFF
--- a/ci2/ci/build.py
+++ b/ci2/ci/build.py
@@ -618,6 +618,7 @@ set -e
                     assert w['for'] == 'alive', w['for']
                     port = w.get('port', 80)
                     script += f'''
+kubectl -n {self.namespace} wait --timeout=300s deployment --for=condition=available {name}
 python3 wait-for.py 300 {self.namespace} Service -p {port} {name}
 '''
                 else:

--- a/ci2/ci/build.py
+++ b/ci2/ci/build.py
@@ -618,8 +618,8 @@ set -e
                     assert w['for'] == 'alive', w['for']
                     port = w.get('port', 80)
                     script += f'''
-kubectl -n {self.namespace} wait --timeout=300s deployment --for=condition=available {name}
-python3 wait-for.py 300 {self.namespace} Service -p {port} {name}
+kubectl -n {self.namespace} wait --timeout=240s deployment --for=condition=available {name}
+python3 wait-for.py 60 {self.namespace} Service -p {port} {name}
 '''
                 else:
                     assert w['kind'] == 'Pod', w['kind']


### PR DESCRIPTION
I think tests of services are failing during deployment because wait-for Service (which probes /healthcheck) hits the old service, then the service goes down during (re)deployment.

Here is an example test failure: first few tests pass then the rest fail due to connection timeout: https://ci2.hail.is/jobs/1413/log.

This doesn't quite make sense, because batch and apiserver both have readiness checks, so the rollout should be have now downtime (although some of the tests could hit the old service which could fail if there were differences).

I think this is a good chance but I'm not totally confident.  Interested in your thoughts.  Also, I can't seem the find the different between `wait deployment` and `rollout status`.
