### PR TITLE
[bug-fix] Fix incorrect assert when transposing row vector

### DIFF
--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -419,6 +419,12 @@ class Tests(unittest.TestCase):
         self._assert_eq(m.T.diagonal(), np.array([1.0, 5.0]))
         self._assert_eq((m @ m.T).diagonal(), np.array([14.0, 77.0]))
 
+        self._assert_eq(m.sum(axis=0).T, np.array([[5.0], [7.0], [9.0]]))
+        self._assert_eq(m.sum(axis=1).T, np.array([6.0, 15.0]))
+        self._assert_eq(m.sum(axis=0).T + row, np.array([[12.0, 13.0, 14.0],
+                                                         [14.0, 15.0, 16.0],
+                                                         [16.0, 17.0, 18.0]]))
+
     def test_fill(self):
         nd = np.ones((3, 5))
         bm = BlockMatrix.fill(3, 5, 1.0)


### PR DESCRIPTION
Because `BlockMatrix` is strictly 2-D but the IR backing it represents 0, 1 and 2-D arrays, we have to track whether 1-D vectors are really row or column vectors, and convert back and forth to their "matrix shape". This caused a mismatch of the 2-D vs 1-D type when transposing a row vector to a column vector and trying to do col vector + row vector. We assert that dimensions that aren't being broadcasted to a larger length retain their original length. This uncovered a related bug in the conversion between 1-D vector length and 2-D matrix dimensions.