### PR TITLE
[hail] implement to_numpy for ndarrays going through disk

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3115,50 +3115,6 @@ class NDArrayExpression(Expression):
         assert isinstance(self._type, tndarray)
         return ndarray_map
 
-    @typecheck_method(uri=str)
-    def save(self, uri):
-        """Write out the NDArray to the given path as in .npy format. If the URI does not
-        end with ".npy" the file extension will be appended. This method reflects the numpy
-        `save` method. NDArrays saved with this method can be loaded into numpy using numpy
-        `load`.
-
-        Examples
-        --------
-        >>> import numpy as np
-        >>> nd.save('file://local/file') # doctest: +SKIP
-        >>> np.load('/local/file.npy') # doctest: +SKIP
-        array([[1, 2],
-               [3, 4]], dtype=int32)
-
-        Parameters
-        ----------
-        uri : :obj: `str`
-        """
-        if not uri.endswith('.npy'):
-            uri += '.npy'
-
-        Env.backend().execute(NDArrayWrite(self._ir, hl.str(uri)._ir))
-
-    def to_numpy(self):
-        """Execute and convert this NDArray to a `NumPy ndarray.
-
-        Examples
-        --------
-        >>> a = nd.to_numpy() # doctest: +SKIP
-
-        Notes
-        -----
-        The resulting ndarray will have the same shape as the block matrix.
-
-        Returns
-        -------
-        :class:`numpy.ndarray`
-        """
-        # FIXME Use filesystem abstraction instead when that is ready
-        temp_file = tempfile.NamedTemporaryFile(suffix='.npy').name
-        self.save(temp_file)
-        return np.load(temp_file)
-
     def _broadcast_to_same_ndim(self, other):
         if isinstance(other, NDArrayExpression):
             if self.ndim < other.ndim:
@@ -3312,6 +3268,46 @@ class NDArrayNumericExpression(NDArrayExpression):
 
     def __rfloordiv__(self, other):
         return self._bin_op_numeric_reverse('//', other)
+
+    @typecheck_method(uri=str)
+    def save(self, uri):
+        """Write out the NDArray to the given path as in .npy format. If the URI does not
+        end with ".npy" the file extension will be appended. This method reflects the numpy
+        `save` method. NDArrays saved with this method can be loaded into numpy using numpy
+        `load`.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> nd.save('file://local/file') # doctest: +SKIP
+        >>> np.load('/local/file.npy') # doctest: +SKIP
+        array([[1, 2],
+               [3, 4]], dtype=int32)
+
+        Parameters
+        ----------
+        uri : :obj: `str`
+        """
+        if not uri.endswith('.npy'):
+            uri += '.npy'
+
+        Env.backend().execute(NDArrayWrite(self._ir, hl.str(uri)._ir))
+
+    def to_numpy(self):
+        """Execute and convert this NDArray to a `NumPy` ndarray.
+
+        Examples
+        --------
+        >>> a = nd.to_numpy() # doctest: +SKIP
+
+        Returns
+        -------
+        :class:`numpy.ndarray`
+        """
+        # FIXME Use filesystem abstraction instead when that is ready
+        temp_file = tempfile.NamedTemporaryFile(suffix='.npy').name
+        self.save(temp_file)
+        return np.load(temp_file)
 
 
 scalars = {tbool: BooleanExpression,


### PR DESCRIPTION
Quality of life improvement, wrapper around saving an ndarray and loading through numpy. Most changes are in the tests which previously could only extract elements from ndarrays to assert the transformation worked.