### PR TITLE
[batch] remove endpoints for deleting and cancelling jobs

### DIFF
--- a/batch/batch/aioclient.py
+++ b/batch/batch/aioclient.py
@@ -48,19 +48,6 @@ class Job:
             if i < 64:
                 i = i + 1
 
-    async def cancel(self):
-        await self.client._patch('/jobs/{}/cancel'.format(self.id))
-
-    async def delete(self):
-        await self.client._delete('/jobs/{}/delete'.format(self.id))
-
-        # this object should not be referenced again
-        del self.client
-        del self.id
-        del self.attributes
-        del self.parent_ids
-        del self._status
-
     async def log(self):
         return await self.client._get('/jobs/{}/log'.format(self.id))
 
@@ -215,16 +202,6 @@ class BatchClient:
 
     async def _refresh_k8s_state(self):
         await self._post('/refresh_k8s_state')
-
-    async def list_jobs(self, complete=None, success=None, attributes=None):
-        params = filter_params(complete, success, attributes)
-        jobs = await self._get('/jobs', params=params)
-        return [Job(self,
-                    j['id'],
-                    attributes=j.get('attributes'),
-                    parent_ids=j.get('parent_ids', []),
-                    _status=j)
-                for j in jobs]
 
     async def list_batches(self, complete=None, success=None, attributes=None):
         params = filter_params(complete, success, attributes)

--- a/batch/batch/api.py
+++ b/batch/batch/api.py
@@ -74,21 +74,11 @@ class API():
         params = filter_params(complete, success, attributes)
         return self.get(f'{url}/batches', params=params)
 
-    def list_jobs(self, url, complete, success, attributes):
-        params = filter_params(complete, success, attributes)
-        return self.get(f'{url}/jobs', params=params)
-
     def get_job(self, url, job_id):
         return self.get(f'{url}/jobs/{job_id}')
 
     def get_job_log(self, url, job_id):
         return self.get(f'{url}/jobs/{job_id}/log')
-
-    def delete_job(self, url, job_id):
-        return self.delete(f'{url}/jobs/{job_id}', json_response=False)
-
-    def cancel_job(self, url, job_id):
-        return self.patch(f'{url}/jobs/{job_id}/cancel', json_response=False)
 
     def create_batch(self, url, attributes, callback, ttl):
         doc = {}

--- a/batch/batch/client.py
+++ b/batch/batch/client.py
@@ -44,19 +44,6 @@ class Job:
         poll_until(update_and_is_complete)
         return self._status
 
-    def cancel(self):
-        self.client._cancel_job(self.id)
-
-    def delete(self):
-        self.client._delete_job(self.id)
-
-        # this object should not be referenced again
-        del self.client
-        del self.id
-        del self.attributes
-        del self.parent_ids
-        del self._status
-
     def log(self):
         return self.client._get_job_log(self.id)
 
@@ -219,15 +206,6 @@ class BatchClient:
 
     def _close_batch(self, batch_id):
         return self.api.close_batch(self.url, batch_id)
-
-    def list_jobs(self, complete=None, success=None, attributes=None):
-        jobs = self.api.list_jobs(self.url, complete=complete, success=success, attributes=attributes)
-        return [Job(self,
-                    j['id'],
-                    attributes=j.get('attributes'),
-                    parent_ids=j.get('parent_ids', []),
-                    _status=j)
-                for j in jobs]
 
     def list_batches(self, complete=None, success=None, attributes=None):
         batches = self.api.list_batches(self.url, complete=complete, success=success, attributes=attributes)

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -54,20 +54,6 @@ def test_missing_parent_is_400(client):
     assert False
 
 
-def test_already_deleted_parent_is_400(client):
-    try:
-        batch = client.create_batch()
-        head = batch.create_job('alpine:3.8', command=['echo', 'head'])
-        head_id = head.id
-        head.delete()
-        batch.create_job('alpine:3.8', command=['echo', 'tail'], parent_ids=[head_id])
-    except requests.exceptions.HTTPError as err:
-        assert err.response.status_code == 400
-        assert re.search('.*invalid parent_id: no job with id.*', err.response.text)
-        return
-    assert False
-
-
 def test_dag(client):
     batch = client.create_batch()
     head = batch.create_job('alpine:3.8', command=['echo', 'head'])
@@ -91,7 +77,9 @@ def test_cancel_tail(client):
         'alpine:3.8',
         command=['/bin/sh', '-c', 'while true; do sleep 86000; done'],
         parent_ids=[left.id, right.id])
-    tail.cancel()
+    left.wait()
+    right.wait()
+    batch.cancel()
     status = batch.wait()
     assert batch_status_job_counter(status, 'Complete') == 3
     for node in [head, left, right]:
@@ -99,26 +87,6 @@ def test_cancel_tail(client):
         assert status['state'] == 'Complete'
         assert status['exit_code'] == 0
     assert tail.status()['state'] == 'Cancelled'
-
-
-def test_cancel_left_before_tail(client):
-    batch = client.create_batch()
-    head = batch.create_job('alpine:3.8', command=['echo', 'head'])
-    left = batch.create_job(
-        'alpine:3.8',
-        command=['/bin/sh', '-c', 'while true; do sleep 86000; done'],
-        parent_ids=[head.id])
-    left.cancel()
-    right = batch.create_job('alpine:3.8', command=['echo', 'right'], parent_ids=[head.id])
-    tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parent_ids=[left.id, right.id])
-    status = batch.wait()
-    assert batch_status_job_counter(status, 'Complete') == 2
-    for node in [head, right]:
-        status = node.status()
-        assert status['state'] == 'Complete'
-        assert status['exit_code'] == 0
-    for node in [left, tail]:
-        assert node.status()['state'] == 'Cancelled'
 
 
 def test_cancel_left_after_tail(client):
@@ -130,7 +98,9 @@ def test_cancel_left_after_tail(client):
         parent_ids=[head.id])
     right = batch.create_job('alpine:3.8', command=['echo', 'right'], parent_ids=[head.id])
     tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parent_ids=[left.id, right.id])
-    left.cancel()
+    head.wait()
+    right.wait()
+    batch.cancel()
     status = batch.wait()
     assert batch_status_job_counter(status, 'Complete') == 2
     for node in [head, right]:
@@ -141,24 +111,6 @@ def test_cancel_left_after_tail(client):
         assert node.status()['state'] == 'Cancelled'
 
 
-def test_delete(client):
-    batch = client.create_batch()
-    head = batch.create_job('alpine:3.8', command=['echo', 'head'])
-    left = batch.create_job('alpine:3.8', command=['echo', 'left'], parent_ids=[head.id])
-    right = batch.create_job('alpine:3.8', command=['echo', 'right'], parent_ids=[head.id])
-    tail = batch.create_job(
-        'alpine:3.8',
-        command=['/bin/sh', '-c', 'while true; do sleep 86000; done'],
-        parent_ids=[left.id, right.id])
-    tail.delete()
-    status = batch.wait()
-    assert batch_status_job_counter(status, 'Complete') >= 3
-    for node in [head, left, right]:
-        status = node.status()
-        assert status['state'] == 'Complete'
-        assert status['exit_code'] == 0
-
-
 def test_one_of_two_parent_ids_cancelled(client):
     batch = client.create_batch()
     left = batch.create_job(
@@ -166,7 +118,8 @@ def test_one_of_two_parent_ids_cancelled(client):
         command=['/bin/sh', '-c', 'while true; do sleep 86000; done'])
     right = batch.create_job('alpine:3.8', command=['echo', 'right'])
     tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parent_ids=[left.id, right.id])
-    left.cancel()
+    right.wait()
+    batch.cancel()
     status = batch.wait()
     assert batch_status_job_counter(status, 'Complete') == 1
     assert batch_status_job_counter(status, 'Cancelled') == 2
@@ -202,43 +155,6 @@ def test_one_of_two_parent_ids_already_done(client):
         status = node.status()
         assert status['state'] == 'Complete'
         assert status['exit_code'] == 0
-
-
-def test_one_of_two_parent_ids_already_cancelled(client):
-    batch = client.create_batch()
-    left = batch.create_job(
-        'alpine:3.8',
-        command=['/bin/sh', '-c', 'while true; do sleep 86000; done'])
-    left.cancel()
-    right = batch.create_job('alpine:3.8', command=['echo', 'right'])
-    tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parent_ids=[left.id, right.id])
-    status = batch.wait()
-    assert batch_status_job_counter(status, 'Complete') == 1
-    assert batch_status_job_counter(status, 'Cancelled') == 2
-    right_status = right.status()
-    assert right_status['state'] == 'Complete'
-    assert right_status['exit_code'] == 0
-    for node in [left, tail]:
-        assert node.status()['state'] == 'Cancelled'
-
-
-def test_parent_deleted(client):
-    batch = client.create_batch()
-    head = batch.create_job('alpine:3.8', command=['echo', 'head'])
-    left = batch.create_job(
-        'alpine:3.8',
-        command=['/bin/sh', '-c', 'while true; do sleep 86000; done'],
-        parent_ids=[head.id])
-    right = batch.create_job('alpine:3.8', command=['echo', 'right'], parent_ids=[head.id])
-    tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parent_ids=[left.id, right.id])
-    left.delete()
-    status = batch.wait()
-    assert batch_status_job_counter(status, 'Complete') == 2
-    for node in [head, right]:
-        status = node.status()
-        assert status['state'] == 'Complete'
-        assert status['exit_code'] == 0
-    assert tail.status()['state'] == 'Cancelled'
 
 
 def test_callback(client):
@@ -341,7 +257,7 @@ def test_input_dependency_directory(client, test_user):
     assert tail.log()['main'] == 'head1\nhead2\n'
 
 
-def test_always_run_delete(client):
+def test_always_run_cancel(client):
     batch = client.create_batch()
     head = batch.create_job('alpine:3.8', command=['echo', 'head'])
     left = batch.create_job(
@@ -353,7 +269,7 @@ def test_always_run_delete(client):
                             command=['echo', 'tail'],
                             parent_ids=[left.id, right.id],
                             always_run=True)
-    left.delete()
+    batch.cancel()
     status = batch.wait()
     assert batch_status_job_counter(status, 'Complete') == 3
     for node in [head, right, tail]:

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -111,25 +111,6 @@ def test_cancel_left_after_tail(client):
         assert node.status()['state'] == 'Cancelled'
 
 
-def test_one_of_two_parent_ids_cancelled(client):
-    batch = client.create_batch()
-    left = batch.create_job(
-        'alpine:3.8',
-        command=['/bin/sh', '-c', 'while true; do sleep 86000; done'])
-    right = batch.create_job('alpine:3.8', command=['echo', 'right'])
-    tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parent_ids=[left.id, right.id])
-    right.wait()
-    batch.cancel()
-    status = batch.wait()
-    assert batch_status_job_counter(status, 'Complete') == 1
-    assert batch_status_job_counter(status, 'Cancelled') == 2
-    right_status = right.status()
-    assert right_status['state'] == 'Complete'
-    assert right_status['exit_code'] == 0
-    for node in [left, tail]:
-        assert node.status()['state'] == 'Cancelled'
-
-
 def test_parent_already_done(client):
     batch = client.create_batch()
     head = batch.create_job('alpine:3.8', command=['echo', 'head'])


### PR DESCRIPTION
It doesn't make sense to be able to delete or cancel an individual job since they must be part of a batch now. I also deleted `list_jobs` since a job must be a part of a batch. I left in `job.wait()` because I felt the tests in `test_dag` were important and shouldn't be deleted and the wait functionality is needed for there not to be race conditions. 