### PR TITLE
First step towards relative error approx cdf

### DIFF
--- a/hail/src/test/scala/is/hail/annotations/ApproxCDFAggregatorSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/ApproxCDFAggregatorSuite.scala
@@ -16,20 +16,30 @@ class ApproxCDFAggregatorSuite extends TestNGSuite {
   @Test
   def testCompactLevel() {
     val rand = new java.util.Random(1) // first Boolean is `true`
-    val levels: Array[Int] = Array(0,3,6,9)
-    val items: Array[Int] = Array(7,2,4,1,3,8,0,5,9)
-    val combiner = new ApproxCDFCombiner(levels, items, 3, 0, 9, rand)
-    combiner.compactLevel(0)
-    assert(items.view(1,9) sameElements Array(7,1,3,4,8,0,5,9))
+    val levels: Array[Int] = Array(0,3,7,10)
+    val items: Array[Int] = Array(7,2,4, 1,3,6,8, 0,5,9)
+    val combiner = new ApproxCDFCombiner(levels, items, 3, rand)
+    combiner.compactLevel(0, shiftLowerLevels = true, keep = 0)
+    assert(items.view(1,10) sameElements Array(2, 1,3,6,7,8, 0,5,9))
   }
 
   @Test
   def testCompactLevelAndShift() {
     val rand = new java.util.Random(1) // first Boolean is `true`
     val levels: Array[Int] = Array(0,3,6,9)
-    val items: Array[Int] = Array(7,2,4,1,3,8,0,5,9)
-    val combiner = new ApproxCDFCombiner(levels, items, 3, 0, 9, rand)
+    val items: Array[Int] = Array(7,2,4, 1,3,8, 0,5,9)
+    val combiner = new ApproxCDFCombiner(levels, items, 3, rand)
     combiner.compactLevel(1, shiftLowerLevels = true)
-    assert(items.view(1,9) sameElements Array(7,2,4,1,0,5,8,9))
+    assert(items.view(1,9) sameElements Array(7,2,4, 1, 0,5,8,9))
+  }
+
+  @Test
+  def testCompactLevelKeep() {
+    val rand = new java.util.Random(1) // first Boolean is `true`
+    val levels: Array[Int] = Array(0,3,7,10)
+    val items: Array[Int] = Array(7,2,4, 1,3,6,8, 0,5,9)
+    val combiner = new ApproxCDFCombiner(levels, items, 3, rand)
+    combiner.compactLevel(1, shiftLowerLevels = true, keep = 1)
+    assert(items.view(1,10) sameElements Array(7,2,4, 1,8, 0,5,6,9))
   }
 }


### PR DESCRIPTION
Add `keep` parameter to `compactLevel`, which will keep the `keep` smallest and largest values in `level`, only compacting the middle.

Get rid of the messy special handling of the min and max values of the stream. Instead, always have `keep = 1` when compacting the bottom level, which guarantees the min and max will never get compacted away.