### PR TITLE
[c++] increment offset instead of computing it from the ndarray index

### DIFF
--- a/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
+++ b/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
@@ -144,10 +144,9 @@ abstract class NDArrayLoopEmitter(
 
   private def emitLoops(builder: StagedContainerBuilder): Code = {
     val idxVars = Seq.tabulate(nDims) { i => fb.variable(s"dim${i}_", "int") }
-    val offset = fb.variable("offset", "int", "0")
 
     val body = Code(builder.add(outputElement(idxVars)), builder.advance())
-    val loops = idxVars.zipWithIndex.foldRight(body) { case ((dimVar, dimIdx), innerLoops) =>
+    idxVars.zipWithIndex.foldRight(body) { case ((dimVar, dimIdx), innerLoops) =>
       s"""
          |${ dimVar.define }
          |for ($dimVar = 0; $dimVar < $shape[$dimIdx]; ++$dimVar) {
@@ -155,7 +154,5 @@ abstract class NDArrayLoopEmitter(
          |}
          |""".stripMargin
     }
-
-    Code(offset.define, loops)
   }
 }

--- a/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
+++ b/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
@@ -123,7 +123,7 @@ abstract class NDArrayLoopEmitter(
   def emit(elemType: PType): Code = {
     val container = PArray(elemType)
 
-    val builder = fb.variable("builder", StagedContainerBuilder.builderType(container))
+    val builder = new StagedContainerBuilder(fb, resultRegion.region, container)
     val data = fb.variable("data", "const char *")
     // Always stores the result as row-major
     val strides = fb.variable("strides", "std::vector<long>", s"make_strides(true, $shape)")
@@ -131,26 +131,23 @@ abstract class NDArrayLoopEmitter(
     s"""
       |({
       | ${ setup }
-      | ${ data.define }
       | ${ strides.define }
       |
-      | ${ builder.defineWith(s"{ (int) n_elements($shape), $resultRegion }") }
-      | $builder.clear_missing_bits();
+      | ${ builder.start(s"(int) n_elements($shape)") }
+      | ${ emitLoops(builder) }
       |
-      | ${ emitLoops(builder, strides) }
-      |
-      | $data = ${container.cxxImpl}::elements_address($builder.offset());
+      | ${ data.defineWith(s"${ container.cxxImpl }::elements_address(${ builder.end() })") }
       | make_ndarray(0, 0, ${elemType.byteSize}, $shape, $strides, $data);
       |})
     """.stripMargin
   }
 
-  private def emitLoops(builder: Variable, strides: Variable): Code = {
+  private def emitLoops(builder: StagedContainerBuilder): Code = {
     val idxVars = Seq.tabulate(nDims) { i => fb.variable(s"dim${i}_", "int") }
-    val outIndex = NDArrayLoopEmitter.linearizeIndices(idxVars, strides.toString)
+    val offset = fb.variable("offset", "int", "0")
 
-    val body = s"$builder.set_element($outIndex, ${ outputElement(idxVars) });"
-    idxVars.zipWithIndex.foldRight(body){ case ((dimVar, dimIdx), innerLoops) =>
+    val body = Code(builder.add(outputElement(idxVars)), builder.advance())
+    val loops = idxVars.zipWithIndex.foldRight(body) { case ((dimVar, dimIdx), innerLoops) =>
       s"""
          |${ dimVar.define }
          |for ($dimVar = 0; $dimVar < $shape[$dimIdx]; ++$dimVar) {
@@ -158,5 +155,7 @@ abstract class NDArrayLoopEmitter(
          |}
          |""".stripMargin
     }
+
+    Code(offset.define, loops)
   }
 }


### PR DESCRIPTION
- I don't know why I was recomputing the whole output index instead of just moving forward one. The loops will always just iterate down the new data buffer. Also means I can use the normal array builder abstraction instead.