### PR TITLE
Add override options to import_vcfs

### DIFF
--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -1952,7 +1952,9 @@ def import_vcf(path,
            array_elements_required=bool,
            skip_invalid_loci=bool,
            filter=nullable(str),
-           find_replace=nullable(sized_tupleof(str, str)))
+           find_replace=nullable(sized_tupleof(str, str)),
+           _external_sample_ids=nullable(sequenceof(sequenceof(str))),
+           _external_header=nullable(str))
 def import_vcfs(path,
                 partitions,
                 force=False,
@@ -1964,7 +1966,9 @@ def import_vcfs(path,
                 array_elements_required=True,
                 skip_invalid_loci=False,
                 filter=None,
-                find_replace=None) -> List[MatrixTable]:
+                find_replace=None,
+                _external_sample_ids=None,
+                _external_header=None) -> List[MatrixTable]:
     """Experimental. Import multiple vcfs as :class:`.MatrixTable`s
 
     The arguments to this function are almost identical to :func:`.import_vcf`,
@@ -2021,7 +2025,9 @@ def import_vcfs(path,
         partitions,
         filter,
         find_replace[0] if find_replace is not None else None,
-        find_replace[1] if find_replace is not None else None)
+        find_replace[1] if find_replace is not None else None,
+        _external_sample_ids,
+        _external_header)
     tmp = json.loads(vector_ref_s)
     jir_vref = JIRVectorReference(tmp['vector_ir_id'],
                                   tmp['length'],

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -1568,7 +1568,9 @@ object ImportVCFs {
     partitionsJSON: String,
     filter: String,
     find: String,
-    replace: String
+    replace: String,
+    externalSampleIds: java.util.List[java.util.List[String]],
+    externalHeader: String
   ): String = {
     val reader = new VCFsReader(
       files.asScala.toArray,
@@ -1581,7 +1583,9 @@ object ImportVCFs {
       gzAsBGZ,
       forceGZ,
       TextInputFilterAndReplace(Option(find), Option(filter), Option(replace)),
-      partitionsJSON)
+      partitionsJSON,
+      Option(externalSampleIds).map(_.map(_.asScala.toArray).toArray),
+      Option(externalHeader))
 
     val irArray = reader.read()
     val id = HailContext.get.addIrVector(irArray)
@@ -1605,7 +1609,11 @@ class VCFsReader(
   gzAsBGZ: Boolean,
   forceGZ: Boolean,
   filterAndReplace: TextInputFilterAndReplace,
-  partitionsJSON: String) {
+  partitionsJSON: String,
+  externalSampleIds: Option[Array[Array[String]]],
+  externalHeader: Option[String]) {
+
+  require(!(externalSampleIds.isEmpty ^ externalHeader.isEmpty))
 
   private val hc = HailContext.get
   private val sc = hc.sc
@@ -1619,7 +1627,7 @@ class VCFsReader(
   private val rowKeyType = TStruct("locus" -> locusType)
 
   private val file1 = files.head
-  private val headerLines1 = getHeaderLines(hConf, file1, filterAndReplace)
+  private val headerLines1 = getHeaderLines(hConf, externalHeader.getOrElse(file1), filterAndReplace)
   private val headerLines1Bc = sc.broadcast(headerLines1)
   private val entryFloatType = LoadVCF.getEntryFloatType(entryFloatTypeName)
   private val header1 = parseHeader(callFields, entryFloatType, headerLines1, arrayElementsRequired = arrayElementsRequired)
@@ -1662,7 +1670,7 @@ class VCFsReader(
     PartitionedVCFPartition(i, start.contig, start.position, end.position): Partition
   }
 
-  private val fileInfo = {
+  private val fileInfo: Array[Array[String]] = externalSampleIds.getOrElse {
     val localHConfBc = hConfBc
     val localFile1 = file1
     val localEntryFloatType = entryFloatType


### PR DESCRIPTION
This overrides each vcf's header with a user provided one, and
overrides the vcfs' samples' names with a user provided list of lists.

This is wildly unsafe. I don't like this code. However it seems that it
is the best way to proceed with data production for gnomAD v3.

cc @cseed 