### PR TITLE
[c++] NDArray Reshape

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3145,6 +3145,18 @@ class NDArrayExpression(Expression):
 
         return construct_expr(ir.NDArrayRef(self._ir, [idx._ir for idx in item]), self._type.element_type)
 
+    @typecheck_method(shape=oneof(expr_int64, tupleof(expr_int64)))
+    def reshape(self, shape):
+        shape = wrap_to_list(shape)
+        if len(shape) == 0:
+            if self.ndim == 0:
+                return self
+            else:
+                raise FatalError(f'Cannot reshape an NDArray of {self.ndim} dimensions to 0 dimensions.')
+
+        return type(self)(NDArrayReshape(self._ir, [dim._ir for dim in shape]),
+                          tndarray(self._type.element_type, len(shape)))
+
     @typecheck_method(f=func_spec(1, expr_any))
     def map(self, f):
         """Transform each element of an NDArray.

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3147,6 +3147,18 @@ class NDArrayExpression(Expression):
 
     @typecheck_method(shape=oneof(expr_int64, tupleof(expr_int64)))
     def reshape(self, shape):
+        """Reshape this ndarray to a new shape.
+
+        Examples
+        --------
+
+        >>> v = hl._ndarray([1, 2, 3, 4]) # doctest: +SKIP
+        >>> m = v.reshape((2, 2)) # doctest: +SKIP
+
+        Returns
+        -------
+        :class:`.NDArrayExpression`.
+        """
         shape = wrap_to_list(shape)
         if len(shape) == 0:
             if self.ndim == 0:

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3171,8 +3171,10 @@ class NDArrayExpression(Expression):
             else:
                 raise FatalError(f'Cannot reshape an NDArray of {self.ndim} dimensions to 0 dimensions.')
 
-        return type(self)(NDArrayReshape(self._ir, [dim._ir for dim in shape]),
-                          tndarray(self._type.element_type, len(shape)))
+        return construct_expr(NDArrayReshape(self._ir, [dim._ir for dim in shape]),
+                              tndarray(self._type.element_type, len(shape)),
+                              self._indices,
+                              self._aggregations)
 
     @typecheck_method(f=func_spec(1, expr_any))
     def map(self, f):

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3149,6 +3149,11 @@ class NDArrayExpression(Expression):
     def reshape(self, shape):
         """Reshape this ndarray to a new shape.
 
+        Parameters
+        ----------
+        shape : :class:`.Expression` of type :py:data:`.tint64` or
+                :obj: `tuple` of :class:`.Expression` of type :py:data:`.tint64`
+
         Examples
         --------
 

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -495,6 +495,22 @@ class MakeNDArray(IR):
         self._type = tndarray(self.data.typ.element_type, self.ndim)
 
 
+class NDArrayReshape(IR):
+    @typecheck_method(nd=IR, shape=sequenceof(IR))
+    def __init__(self, nd, shape):
+        super().__init__(nd, *shape)
+        self.nd = nd
+        self.shape = shape
+
+    def copy(self, *args):
+        return NDArrayReshape(args[0], args[1:])
+
+    def _compute_type(self, env, agg_env):
+        self.nd._compute_type(env, agg_env)
+        [dim_length._compute_type(env, agg_env) for dim_length in self.shape]
+        self._type = tndarray(self.nd.typ.element_type, len(self.shape))
+
+
 class NDArrayMap(IR):
     @typecheck_method(nd=IR, name=str, body=IR)
     def __init__(self, nd, name, body):

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2658,6 +2658,18 @@ class Tests(unittest.TestCase):
 
     @skip_unless_spark_backend()
     @run_with_cxx_compile()
+    def test_ndarray_reshape(self):
+        a = hl._ndarray([1, 2, 3, 4, 5, 6])
+        fat = a.reshape((2, 3))
+        skinny = a.reshape((3, 2))
+
+        a_three = a[2]
+        fat_three = fat[0, 2]
+        skinny_three = skinny[1, 0]
+        self.assertTrue(hl.eval(a_three) == hl.eval(fat_three) == hl.eval(skinny_three))
+
+    @skip_unless_spark_backend()
+    @run_with_cxx_compile()
     def test_ndarray_map(self):
         a = hl._ndarray([[2, 3, 4], [5, 6, 7]])
         b = hl.map(lambda x: -x, a)

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2666,7 +2666,13 @@ class Tests(unittest.TestCase):
         a_three = a[2]
         fat_three = fat[0, 2]
         skinny_three = skinny[1, 0]
-        self.assertTrue(hl.eval(a_three) == hl.eval(fat_three) == hl.eval(skinny_three))
+        self.assertTrue(hl.eval(a_three) == hl.eval(fat_three) == hl.eval(skinny_three) == 3)
+
+        nums = hl._ndarray([0, 1, 2, 3, 4, 5, 6, 7])
+        cube = nums.reshape((2, 2, 2))
+        rect = cube.reshape((2, 4))
+        cube_t_to_rect = cube.transpose((1, 0, 2)).reshape((2, 4))
+        self.assertTrue(hl.eval(cube[0, 1, 1]) == hl.eval(rect[0, 3]) == hl.eval(cube_t_to_rect[1, 1]) == 3)
 
     @skip_unless_spark_backend()
     @run_with_cxx_compile()

--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -918,10 +918,7 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
            """.stripMargin
         }
 
-        val totalExpectedElements = shapeVars.foldRight("1") { (dimLen, elementsSoFar) =>
-          s"($dimLen * $elementsSoFar)"
-        }
-
+        val totalExpectedElements = shapeVars.foldRight("1") { (dimLen, nElements) => s"($dimLen * $nElements)" }
         val strides = fb.variable("strides", "std::vector<long>", s"make_strides(true, $shape)")
         present(
           s"""

--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -901,6 +901,45 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
         val emitter = emitDeforestedNDArray(resultRegion, x, env)
         present(emitter.emit(x.pType.asInstanceOf[PNDArray].elementType))
 
+      case ir.NDArrayReshape(child, shapeIRs) =>
+        // Force copy of new array that is row major
+        val childRowMajor = emitDeforestedNDArray(resultRegion, child, env)
+        val nd = fb.variable("nd", "NDArray", childRowMajor.emit(child.pType.asInstanceOf[PNDArray].elementType))
+
+        val shapet = shapeIRs.map(emit(_))
+        val shapeVars = shapet.zipWithIndex.map { case (lent, dim) => fb.variable(s"dim_${dim}_len", "long", lent.v) }
+        val shape = fb.variable("shape", "std::vector<long>")
+        val buildShape = shapet.zip(shapeVars).map { case (lent, lenVar) =>
+          s"""
+             | if (${ lent.m }) {
+             |  ${ fb.nativeError("Cannot reshape with missing dimension length") }
+             | }
+             | $shape.push_back($lenVar);
+           """.stripMargin
+        }
+
+        val totalExpectedElements = shapeVars.foldRight("1") { (dimLen, elementsSoFar) =>
+          s"($dimLen * $elementsSoFar)"
+        }
+
+        val strides = fb.variable("strides", "std::vector<long>", s"make_strides(true, $shape)")
+        present(
+          s"""
+             |({
+             | ${ nd.define }
+             | ${ Code.sequence(shapeVars.map(_.define)) }
+             | ${ shape.define }
+             | ${ Code.sequence(buildShape) }
+             | ${ strides.define }
+             |
+             | if ($totalExpectedElements != n_elements($nd.shape)) {
+             |  ${ fb.nativeError("Initial shape and new shape have differing number of elements") }
+             | }
+             |
+             | make_ndarray(0, 0, $nd.elem_size, $shape, $strides, $nd.data);
+             |})
+           """.stripMargin)
+
       case ir.NDArrayReindex(child, indexExpr) =>
         val ndt = emit(child)
         val nd = fb.variable("nd", "NDArray", ndt.v)
@@ -1009,7 +1048,7 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
              |({
              | ${ nd.define }
              | ${ Code.sequence(idxVars.map(_.define)) }
-             | ${ NDArrayLoopEmitter.loadElement(nd, index, x.pType) }
+             | ${ NDArrayLoopEmitter.loadElement(nd, index, x.pType) };
              |})
            """.stripMargin)
 

--- a/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
+++ b/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
@@ -102,7 +102,7 @@ object NDArrayLoopEmitter {
   }
 
   def loadElement(nd: Variable, index: Code, elemType: PType): Code = {
-    s"load_element<${ typeToCXXType(elemType) }>(load_index($nd, $index));"
+    s"load_element<${ typeToCXXType(elemType) }>(load_index($nd, $index))"
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -51,6 +51,8 @@ object Children {
       Array(start, stop, step)
     case MakeNDArray(_, data, shape, rowMajor) =>
       Array(data, shape, rowMajor)
+    case NDArrayReshape(nd, shape) =>
+      nd +: shape
     case ArraySort(a, _, _, compare) =>
       Array(a, compare)
     case ToSet(a) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -64,6 +64,9 @@ object Copy {
       case MakeNDArray(nDim, _, _, _) =>
         val IndexedSeq(data: IR, shape: IR, rowMajor: IR) = newChildren
         MakeNDArray(nDim, data, shape, rowMajor)
+      case NDArrayReshape(_, _) =>
+        val nd +: shape = newChildren
+        NDArrayReshape(nd.asInstanceOf[IR], shape.map(ir => ir.asInstanceOf[IR]))
       case NDArrayRef(_, _) =>
         val (nd: IR) +: (idxs: IndexedSeq[_]) = newChildren
         NDArrayRef(nd, idxs.asInstanceOf[IndexedSeq[IR]])

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -219,6 +219,9 @@ final case class ArrayAggScan(a: IR, name: String, query: IR) extends IR
 final case class ArrayLeftJoinDistinct(left: IR, right: IR, l: String, r: String, keyF: IR, joinF: IR) extends IR
 
 final case class MakeNDArray(nDim: Int, data: IR, shape: IR, rowMajor: IR) extends IR
+final case class NDArrayReshape(nd: IR, shape: IndexedSeq[IR]) extends IR {
+  require(shape.nonEmpty)
+}
 
 final case class NDArrayRef(nd: IR, idxs: IndexedSeq[IR]) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -103,6 +103,8 @@ object InferType {
       case ArrayLeftJoinDistinct(left, right, l, r, compare, join) =>
         coerce[TStreamable](left.typ).copyStreamable(join.typ)
         TArray(join.typ)
+      case NDArrayReshape(nd, shape) =>
+        TNDArray(coerce[TNDArray](nd.typ).elementType, Nat(shape.length), nd.typ.required)
       case NDArrayMap(nd, _, body) =>
         TNDArray(body.typ, coerce[TNDArray](nd.typ).nDimsBase, nd.typ.required)
       case NDArrayMap2(l, _, _, _, body) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
@@ -4,6 +4,7 @@ object Interpretable {
   def apply(ir: IR): Boolean = {
     ir match {
       case _: MakeNDArray |
+           _: NDArrayReshape |
            _: NDArrayRef |
            _: NDArrayMap |
            _: NDArrayMap2 |

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -631,6 +631,10 @@ object IRParser {
         val shape = ir_value_expr(env)(it)
         val rowMajor = ir_value_expr(env)(it)
         MakeNDArray(nDim, data, shape, rowMajor)
+      case "NDArrayReshape" =>
+        val nd = ir_value_expr(env)(it)
+        val shape = ir_value_children(env)(it)
+        NDArrayReshape(nd, shape)
       case "NDArrayMap" =>
         val name = identifier(it)
         val nd = ir_value_expr(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -143,6 +143,9 @@ object TypeCheck {
         assert(data.typ.isInstanceOf[TStreamable])
         assert(shape.typ.isOfType(TArray(TInt64())))
         assert(rowMajor.typ.isOfType(TBoolean()))
+      case x@NDArrayReshape(nd, shape) =>
+        assert(nd.typ.isInstanceOf[TNDArray])
+        assert(shape.forall(_.typ.isOfType(TInt64())))
       case x@NDArrayRef(nd, idxs) =>
         assert(nd.typ.isInstanceOf[TNDArray])
         assert(nd.typ.asInstanceOf[TNDArray].nDims == idxs.length)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1506,6 +1506,7 @@ class IRSuite extends SparkSuite {
       MakeArray(FastSeq(i, NA(TInt32()), I32(-3)), TArray(TInt32())),
       MakeStream(FastSeq(i, NA(TInt32()), I32(-3)), TStream(TInt32())),
       nd,
+      NDArrayReshape(nd, IndexedSeq(4)),
       NDArrayRef(nd, FastSeq(I64(1), I64(2))),
       NDArrayMap(nd, "v", ApplyUnaryPrimOp(Negate(), v)),
       NDArrayMap2(nd, nd, "l", "r", ApplyBinaryPrimOp(Add(), l, r)),

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -968,6 +968,17 @@ class IRSuite extends SparkSuite {
     assertEvalsTo(centerColMajor, 13.0)
   }
 
+  @Test def testNDArrayReshape() {
+    implicit val execStrats = Set(ExecStrategy.CxxCompile)
+    val v = NDArrayReshape(matrixRowMajor, IndexedSeq(I64(4)))
+    val mat2 = NDArrayReshape(v, IndexedSeq(I64(2), I64(2)))
+
+    assertEvalsTo(makeNDArrayRef(v, IndexedSeq(2)), 3.0)
+    assertEvalsTo(makeNDArrayRef(mat2, IndexedSeq(1, 0)), 3.0)
+    assertEvalsTo(makeNDArrayRef(v, IndexedSeq(0)), 1.0)
+    assertEvalsTo(makeNDArrayRef(mat2, IndexedSeq(0, 0)), 1.0)
+  }
+
   @Test def testNDArrayMap() {
     implicit val execStrats = Set(ExecStrategy.CxxCompile)
 


### PR DESCRIPTION
Ideally, a reshape would just be a different view onto the same underlying data. This is not always possible given the way the data is ordered (e.g. after a transpose)  in which case it might have to copy the data and start fresh. This implementation is naive in that it always copies the data. Additional checks for compatibility of strides, etc. can be added to prevent copying and just make a new view with new shape/strides.