### PR TITLE
autoscale site

### DIFF
--- a/site/deployment.yaml
+++ b/site/deployment.yaml
@@ -58,7 +58,6 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: site
-  namespace: default
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/site/deployment.yaml
+++ b/site/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: site-deployment
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app: site
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:
@@ -19,9 +19,26 @@ spec:
 {% if deploy %}
       priorityClassName: production
 {% endif %}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                    - site
+              topologyKey: "kubernetes.io/hostname"
       containers:
       - name: site
         image: "{{ site_image.image }}"
+        resources:
+          requests:
+            memory: "250M"
+            cpu: "100m"
+          limits:
+            memory: "1G"
+            cpu: "1"
         ports:
         - containerPort: 80
         livenessProbe:
@@ -36,3 +53,21 @@ spec:
             port: 80
           initialDelaySeconds: 5
           periodSeconds: 5
+---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: site
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: site
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: 80


### PR DESCRIPTION
This sets up auto-scaling for site.  Request 100m, min 2, max 10 for now (unlikely we'll exceed that any time soon), anti-affinity to get instances on different nodes.  With the replication, we could probably schedule them on preemptibles.