### PR TITLE
add keepRatio param to cdf aggregator

### DIFF
--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -219,6 +219,9 @@ def approx_cdf(expr, k=100):
     with the value `values(i)` occupying indices `ranks(i)` (inclusive) to
     `ranks(i+1)` (exclusive).
 
+    The returned struct also contains an array `_compaction_counts`, which is
+    used internally to support downstream error estimation.
+
     Warning
     -------
     This is an approximate and nondeterministic method.
@@ -235,7 +238,7 @@ def approx_cdf(expr, k=100):
     :class:`.StructExpression`
         Struct containing `values` and `ranks` arrays.
     """
-    return _agg_func('ApproxCDF', [expr], tstruct(values=tarray(expr.dtype), ranks=tarray(tint64)), constructor_args=[k])
+    return _agg_func('ApproxCDF', [expr], tstruct(values=tarray(expr.dtype), ranks=tarray(tint64), _compaction_counts=tarray(tint32)), constructor_args=[k])
 
 
 @typecheck(expr=expr_numeric, qs=expr_oneof(expr_numeric, expr_array(expr_numeric)), k=int)

--- a/hail/python/hail/ir/register_aggregators.py
+++ b/hail/python/hail/ir/register_aggregators.py
@@ -4,13 +4,14 @@ def register_aggregators():
     from hail.expr.types import dtype
 
     register_aggregator('ApproxCDF', (dtype('int32'),), None, (dtype('int32'),),
-                        dtype('struct{values:array<int32>,ranks:array<int64>}'))
+                        dtype('struct{values:array<int32>,ranks:array<int64>,_compaction_counts:array<int32>}'))
     register_aggregator('ApproxCDF', (dtype('int32'),), None, (dtype('int64'),),
-                        dtype('struct{values:array<int64>,ranks:array<int64>}'))
+                        dtype('struct{values:array<int64>,ranks:array<int64>,_compaction_counts:array<int32>}'))
     register_aggregator('ApproxCDF', (dtype('int32'),), None, (dtype('float32'),),
-                        dtype('struct{values:array<float32>,ranks:array<int64>}'))
+                        dtype('struct{values:array<float32>,ranks:array<int64>,_compaction_counts:array<int32>}'))
     register_aggregator('ApproxCDF', (dtype('int32'),), None, (dtype('float64'),),
-                        dtype('struct{values:array<float64>,ranks:array<int64>}'))
+                        dtype('struct{values:array<float64>,ranks:array<int64>,_compaction_counts:array<int32>}'))
+
     register_aggregator('Fraction', (), None, (dtype('bool'),), dtype('float64'))
 
     stats_aggregator_type = dtype('struct{mean:float64,stdev:float64,min:float64,max:float64,n:int64,sum:float64}')

--- a/hail/src/test/scala/is/hail/annotations/ApproxCDFAggregatorSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/ApproxCDFAggregatorSuite.scala
@@ -16,7 +16,7 @@ class ApproxCDFAggregatorSuite extends TestNGSuite {
   @Test
   def testCompactLevelZero() {
     val rand = new java.util.Random(1) // first Boolean is `true`
-    val levels: Array[Int] = Array(0,3,7,10)
+    val levels: Array[Int] = Array(0,4,7,10)
     val items: Array[Int] = Array(7,2,6,4, 1,3,8, 0,5,9)
     val compactionCounts: Array[Int] = Array(0, 0, 0)
     val combiner = new ApproxCDFCombiner(levels, items, compactionCounts, 3, Double.NaN, rand)

--- a/hail/src/test/scala/is/hail/annotations/ApproxCDFAggregatorSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/ApproxCDFAggregatorSuite.scala
@@ -14,22 +14,24 @@ class ApproxCDFAggregatorSuite extends TestNGSuite {
   }
 
   @Test
-  def testCompactLevel() {
+  def testCompactLevelZero() {
     val rand = new java.util.Random(1) // first Boolean is `true`
     val levels: Array[Int] = Array(0,3,7,10)
-    val items: Array[Int] = Array(7,2,4, 1,3,6,8, 0,5,9)
-    val combiner = new ApproxCDFCombiner(levels, items, 3, rand)
-    combiner.compactLevel(0, shiftLowerLevels = true, keep = 0)
-    assert(items.view(1,10) sameElements Array(2, 1,3,6,7,8, 0,5,9))
+    val items: Array[Int] = Array(7,2,6,4, 1,3,8, 0,5,9)
+    val compactionCounts: Array[Int] = Array(0, 0, 0)
+    val combiner = new ApproxCDFCombiner(levels, items, compactionCounts, 3, Double.NaN, rand)
+    combiner.compactLevel(0)
+    assert(items.view(1,10) sameElements Array(2,7, 1,3,6,8, 0,5,9))
   }
 
   @Test
-  def testCompactLevelAndShift() {
+  def testCompactLevel() {
     val rand = new java.util.Random(1) // first Boolean is `true`
     val levels: Array[Int] = Array(0,3,6,9)
     val items: Array[Int] = Array(7,2,4, 1,3,8, 0,5,9)
-    val combiner = new ApproxCDFCombiner(levels, items, 3, rand)
-    combiner.compactLevel(1, shiftLowerLevels = true)
+    val compactionCounts: Array[Int] = Array(0, 0, 0)
+    val combiner = new ApproxCDFCombiner(levels, items, compactionCounts, 3, Double.NaN, rand)
+    combiner.compactLevel(1)
     assert(items.view(1,9) sameElements Array(7,2,4, 1, 0,5,8,9))
   }
 
@@ -38,8 +40,9 @@ class ApproxCDFAggregatorSuite extends TestNGSuite {
     val rand = new java.util.Random(1) // first Boolean is `true`
     val levels: Array[Int] = Array(0,3,7,10)
     val items: Array[Int] = Array(7,2,4, 1,3,6,8, 0,5,9)
-    val combiner = new ApproxCDFCombiner(levels, items, 3, rand)
-    combiner.compactLevel(1, shiftLowerLevels = true, keep = 1)
+    val compactionCounts: Array[Int] = Array(0, 0, 0)
+    val combiner = new ApproxCDFCombiner(levels, items, compactionCounts, 3, .01, rand)
+    combiner.compactLevel(1)
     assert(items.view(1,10) sameElements Array(7,2,4, 1,8, 0,5,6,9))
   }
 }


### PR DESCRIPTION
Add a `keepRatio` parameter to the ApproxCDF aggregator. When compacting any level, always keep a fixed fraction of the smallest and largest values at that level.

Also keep counts of the number of times each level is compacted, for use in downstream error estimates.