### PR TITLE
implement CollectDistributedArray in ir.Emit

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -78,7 +78,7 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: PType, va
   def start(init: Boolean): Code[Unit] = {
     val t = ftype.asInstanceOf[PBaseStruct]
     var c = if (pOffset == null)
-      startOffset.store(region.allocate(t.alignment, t.byteSize))
+        startOffset.store(region.allocate(t.alignment, t.byteSize))
     else
       startOffset.store(pOffset)
     assert(staticIdx == 0)

--- a/hail/src/main/scala/is/hail/backend/spark/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/LowerTableIR.scala
@@ -92,9 +92,6 @@ object LowerTableIR {
     case node if node.children.exists( _.isInstanceOf[MatrixIR] ) =>
       throw new SparkBackendUnsupportedOperation(s"MatrixIR nodes must be lowered to TableIR nodes separately: \n${ Pretty(node) }")
 
-    case _: In =>
-      throw new SparkBackendUnsupportedOperation(s"`In` value IR node cannot be lowered in Spark backend.")
-
     case node =>
       Copy(node, ir.children.map { case c: IR => lower(c) })
   }

--- a/hail/src/main/scala/is/hail/backend/spark/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/LowerTableIR.scala
@@ -4,7 +4,6 @@ import is.hail.annotations._
 import is.hail.expr.ir._
 import is.hail.expr.types._
 import is.hail.expr.types.virtual._
-import is.hail.io.CodecSpec
 import is.hail.rvd.{RVDPartitioner, RVDType}
 import is.hail.utils._
 import org.apache.spark.rdd.RDD
@@ -37,6 +36,38 @@ case class SparkStage(
 }
 
 object LowerTableIR {
+
+  def apply(ir0: IR, timer: ExecutionTimer, optimize: Boolean = true): IR = {
+    var ir = ir0
+
+    ir = ir.unwrap
+    if (optimize) {
+      val context = "first pass"
+      ir = timer.time(
+        Optimize(ir, noisy = true, canGenerateLiterals = true, Some(s"${ timer.context }: $context")),
+        context)
+    }
+
+    ir = timer.time(LiftNonCompilable(ir).asInstanceOf[IR], "lifting non-compilable")
+    ir = timer.time(LowerMatrixIR(ir), "lowering MatrixIR")
+
+    if (optimize) {
+      val context = "after MatrixIR lowering"
+      ir = timer.time(
+        Optimize(ir, noisy = true, canGenerateLiterals = true, Some(s"${ timer.context }: $context")),
+        context)
+    }
+
+    ir = LowerTableIR.lower(ir)
+
+    if (optimize) {
+      val context = "after TableIR lowering"
+      ir = timer.time(
+        Optimize(ir, noisy = true, canGenerateLiterals = true, Some(s"${ timer.context }: $context")),
+        context)
+    }
+    ir
+  }
 
   def lower(ir: IR): IR = ir match {
 

--- a/hail/src/main/scala/is/hail/backend/spark/SparkBackendUtils.scala
+++ b/hail/src/main/scala/is/hail/backend/spark/SparkBackendUtils.scala
@@ -1,0 +1,33 @@
+package is.hail.backend.spark
+
+import is.hail.HailContext
+import is.hail.annotations.Region
+import is.hail.asm4s._
+
+class SparkBackendUtils(mods: Array[(String, Int => AsmFunction3[Region, Array[Byte], Array[Byte], Array[Byte]])]) {
+
+  type F = AsmFunction3[Region, Array[Byte], Array[Byte], Array[Byte]]
+
+  private[this] val loadedModules: Map[String, Int => F] = mods.toMap
+
+  def getModule(id: String): Int => F = loadedModules(id)
+
+  def collectDArray(modID: String, contexts: Array[Array[Byte]], globals: Array[Byte]): Array[Array[Byte]] = {
+    val sc = HailContext.get.sc
+    val rdd = sc.parallelize[Array[Byte]](contexts, numSlices = contexts.length)
+    val f = getModule(modID)
+
+    val globalsBC = sc.broadcast(globals)
+
+    rdd.mapPartitionsWithIndex { case (i, ctxIt) =>
+      val ctx = ctxIt.next()
+      assert(!ctxIt.hasNext)
+      val gs = globalsBC.value
+
+      Region.scoped { region =>
+        val res = f(i)(region, ctx, gs)
+        Iterator.single(res)
+      }
+    }.collect()
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1187,8 +1187,8 @@ private class Emit(
           val bEnc = spec.buildEmitEncoderMethod(bTypeTuple, bTypeTuple, bodyFB)
 
           val env = Env[(TypeInfo[_], Code[Boolean], Code[_])](
-            cname -> (typeToTypeInfo(ctxType), bodyMB.getArg[Boolean](3).load(), bodyMB.getArg(2)(typeToTypeInfo(ctxType)).load()),
-            gname -> (typeToTypeInfo(gType), bodyMB.getArg[Boolean](5).load(), bodyMB.getArg(4)(typeToTypeInfo(gType)).load()))
+            (cname, (typeToTypeInfo(ctxType), bodyMB.getArg[Boolean](3).load(), bodyMB.getArg(2)(typeToTypeInfo(ctxType)).load())),
+            (gname, (typeToTypeInfo(gType), bodyMB.getArg[Boolean](5).load(), bodyMB.getArg(4)(typeToTypeInfo(gType)).load())))
 
           val t = new Emit(bodyMB, 1).emit(MakeTuple(FastSeq(body)), env, EmitRegion.default(bodyMB))
           bodyMB.emit(Code(t.setup, t.m.mux(Code._fatal("return cannot be missing"), t.v)))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1,11 +1,14 @@
 package is.hail.expr.ir
 
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+
 import is.hail.annotations._
 import is.hail.annotations.aggregators._
 import is.hail.asm4s._
 import is.hail.expr.ir.functions.{MathFunctions, StringFunctions}
 import is.hail.expr.types.physical._
 import is.hail.expr.types.virtual._
+import is.hail.io.{CodecSpec, InputBuffer, OutputBuffer}
 import is.hail.utils._
 
 import scala.collection.mutable
@@ -1163,6 +1166,132 @@ private class Emit(
             res.isNull))
 
         EmitTriplet(setup, m, res.invoke[Double]("doubleValue"))
+      case x@CollectDistributedArray(contexts, globals, cname, gname, body) =>
+        val ctxType = coerce[TArray](contexts.typ).elementType.physicalType
+        val gType = globals.typ.physicalType
+        val bType = body.typ.physicalType
+
+        val ctxTypeTuple = PTuple(FastIndexedSeq(ctxType))
+        val gTypeTuple = PTuple(FastIndexedSeq(gType))
+        val bTypeTuple = PTuple(FastIndexedSeq(bType))
+
+        val spec = CodecSpec.defaultUncompressed
+        val parentFB = mb.fb
+
+        val functionID: String = {
+          val bodyFB = EmitFunctionBuilder[Region, Array[Byte], Array[Byte], Array[Byte]]
+          val bodyMB = bodyFB.newMethod(Array[TypeInfo[_]](typeInfo[Region], typeToTypeInfo(ctxType), typeInfo[Boolean], typeToTypeInfo(gType), typeInfo[Boolean]), typeInfo[Long])
+
+          val cDec = spec.buildEmitDecoderMethod(ctxTypeTuple, ctxTypeTuple, bodyFB)
+          val gDec = spec.buildEmitDecoderMethod(gTypeTuple, gTypeTuple, bodyFB)
+          val bEnc = spec.buildEmitEncoderMethod(bTypeTuple, bTypeTuple, bodyFB)
+
+          val env = Env[(TypeInfo[_], Code[Boolean], Code[_])](
+            cname -> (typeToTypeInfo(ctxType), bodyMB.getArg[Boolean](3).load(), bodyMB.getArg(2)(typeToTypeInfo(ctxType)).load()),
+            gname -> (typeToTypeInfo(gType), bodyMB.getArg[Boolean](5).load(), bodyMB.getArg(4)(typeToTypeInfo(gType)).load()))
+
+          val t = new Emit(bodyMB, 1).emit(MakeTuple(FastSeq(body)), env, EmitRegion.default(bodyMB))
+          bodyMB.emit(Code(t.setup, t.m.mux(Code._fatal("return cannot be missing"), t.v)))
+
+          val cIB = spec.child.buildCodeInputBuffer(Code.newInstance[ByteArrayInputStream, Array[Byte]](bodyFB.getArg[Array[Byte]](2)))
+          val gIB = spec.child.buildCodeInputBuffer(Code.newInstance[ByteArrayInputStream, Array[Byte]](bodyFB.getArg[Array[Byte]](3)))
+
+          val ctxOff = bodyFB.newLocal[Long]
+          val gOff = bodyFB.newLocal[Long]
+          val bOff = bodyFB.newLocal[Long]
+          val bOS = bodyFB.newLocal[ByteArrayOutputStream]
+          val bOB = bodyFB.newLocal[OutputBuffer]
+
+          bodyFB.emit(Code(
+            ctxOff := cDec.invoke[Long](bodyFB.getArg[Region](1), cIB),
+            gOff := gDec.invoke[Long](bodyFB.getArg[Region](1), gIB),
+            bOff := bodyMB.invoke[Long](bodyFB.getArg[Region](1),
+              region.loadIRIntermediate(ctxType.virtualType)(ctxTypeTuple.fieldOffset(ctxOff, 0)),
+              ctxTypeTuple.isFieldMissing(region, ctxOff, 0),
+              region.loadIRIntermediate(gType.virtualType)(gTypeTuple.fieldOffset(gOff, 0)),
+              gTypeTuple.isFieldMissing(region, gOff, 0)),
+            bOS := Code.newInstance[ByteArrayOutputStream](),
+            bOB := spec.child.buildCodeOutputBuffer(bOS),
+            bEnc.invoke[Unit](bodyFB.getArg[Region](1), bOff, bOB),
+            bOB.invoke[Unit]("flush"),
+            bOB.invoke[Unit]("close"),
+            bOS.invoke[Array[Byte]]("toByteArray")))
+
+          val fID = genUID()
+          parentFB.addModule(fID, bodyFB.resultWithIndex())
+          fID
+        }
+
+        val spark = parentFB.sparkBackend()
+        val contextAE = emitArrayIterator(contexts)
+        val globalsT = emit(globals)
+
+        val cEnc = spec.buildEmitEncoderMethod(ctxTypeTuple, ctxTypeTuple, parentFB)
+        val gEnc = spec.buildEmitEncoderMethod(gTypeTuple, gTypeTuple, parentFB)
+        val bDec = spec.buildEmitDecoderMethod(bTypeTuple, bTypeTuple, parentFB)
+
+        val baos = mb.newField[ByteArrayOutputStream]
+        val buf = mb.newField[OutputBuffer]
+        val ctxab = mb.newField[ByteArrayArrayBuilder]
+        val encRes = mb.newField[Array[Array[Byte]]]
+
+        val contextT = {
+          val sctxb = new StagedRegionValueBuilder(mb, ctxTypeTuple)
+          contextAE.arrayEmitter { (m: Code[Boolean], v: Code[_]) =>
+            Code(
+              baos.invoke[Unit]("reset"),
+              sctxb.start(),
+              m.mux(
+                sctxb.setMissing(),
+                sctxb.addIRIntermediate(ctxType)(v)),
+              cEnc.invoke[Unit](region, sctxb.offset, buf),
+              buf.invoke[Unit]("flush"),
+              ctxab.invoke[Array[Byte], Unit]("add", baos.invoke[Array[Byte]]("toByteArray")))
+          }
+        }
+
+        val addGlobals = {
+          val sgb = new StagedRegionValueBuilder(mb, gTypeTuple)
+          Code(
+            globalsT.setup,
+            sgb.start(),
+            globalsT.m.mux(
+              sgb.setMissing(),
+              sgb.addIRIntermediate(gType)(globalsT.v)),
+            gEnc.invoke[Unit](region, sgb.offset, buf),
+            buf.invoke[Unit]("flush"))
+        }
+
+        val decodeResult = {
+          val sab = new StagedRegionValueBuilder(mb, x.pType)
+          val bais = Code.newInstance[ByteArrayInputStream, Array[Byte]](encRes(sab.arrayIdx))
+          val eltTupled = mb.newField[Long]
+          Code(
+            sab.start(encRes.length()),
+            Code.whileLoop(sab.arrayIdx < encRes.length(),
+              eltTupled := bDec.invoke[Long](region, spec.child.buildCodeInputBuffer(bais)),
+              bTypeTuple.isFieldMissing(region, eltTupled, 0).mux(
+                sab.setMissing(),
+                sab.addIRIntermediate(bType)(region.loadIRIntermediate(bType)(bTypeTuple.fieldOffset(eltTupled, 0)))),
+              sab.advance()),
+            sab.end())
+        }
+
+        EmitTriplet(
+          contextT.setup,
+          contextT.m.getOrElse(false),
+          Code(
+            baos := Code.newInstance[ByteArrayOutputStream](),
+            buf := spec.child.buildCodeOutputBuffer(baos),
+            ctxab := Code.newInstance[ByteArrayArrayBuilder, Int](16),
+            contextT.addElements,
+            baos.invoke[Unit]("reset"),
+            addGlobals,
+            encRes := spark.invoke[String, Array[Array[Byte]], Array[Byte], Array[Array[Byte]]](
+              "collectDArray", functionID,
+              ctxab.invoke[Array[Array[Byte]]]("result"),
+              baos.invoke[Array[Byte]]("toByteArray")),
+            decodeResult))
     }
   }
 
@@ -1185,7 +1314,6 @@ private class Emit(
       }: _*)
     })
   }
-
 
   private def makeDependentSortingFunction[T: TypeInfo](
     ir: IR, env: Emit.E): DependentEmitFunction[AsmFunction2[T, T, Boolean]] = {

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -5,6 +5,7 @@ import java.io.PrintWriter
 import is.hail.annotations.{CodeOrdering, Region}
 import is.hail.asm4s
 import is.hail.asm4s._
+import is.hail.backend.spark.SparkBackendUtils
 import is.hail.expr.Parser
 import is.hail.expr.ir.functions.IRRandomness
 import is.hail.expr.types.physical.PType
@@ -50,6 +51,10 @@ trait FunctionWithHadoopConfiguration {
 
 trait FunctionWithSeededRandomness {
   def setPartitionIndex(idx: Int): Unit
+}
+
+trait FunctionWithSparkBackend {
+  def setSparkBackend(spark: SparkBackendUtils): Unit
 }
 
 class EmitMethodBuilder(
@@ -146,6 +151,25 @@ class EmitFunctionBuilder[F >: Null](
 
   private[this] var _hconf: SerializableHadoopConfiguration = _
   private[this] var _hfield: ClassFieldRef[SerializableHadoopConfiguration] = _
+
+  private[this] var _mods: ArrayBuilder[(String, Int => AsmFunction3[Region, Array[Byte], Array[Byte], Array[Byte]])] = new ArrayBuilder()
+  private[this] var _sparkField: ClassFieldRef[SparkBackendUtils] = _
+
+  def sparkBackend(): Code[SparkBackendUtils] = {
+    if (_sparkField == null) {
+      cn.interfaces.asInstanceOf[java.util.List[String]].add(typeInfo[FunctionWithSparkBackend].iname)
+      val sparkField = newField[SparkBackendUtils]
+      val mb = new EmitMethodBuilder(this, "setSparkBackend", Array(typeInfo[SparkBackendUtils]), typeInfo[Unit])
+      methods.append(mb)
+      mb.emit(sparkField := mb.getArg[SparkBackendUtils](1))
+      _sparkField = sparkField
+    }
+    _sparkField
+  }
+
+  def addModule(name: String, mod: Int => AsmFunction3[Region, Array[Byte], Array[Byte], Array[Byte]]): Unit = {
+    _mods += name -> mod
+  }
 
   def addHadoopConfiguration(hConf: SerializableHadoopConfiguration): Unit = {
     assert(hConf != null)
@@ -338,6 +362,9 @@ class EmitFunctionBuilder[F >: Null](
     val n = name.replace("/",".")
     val localHConf = _hconf
 
+    val useSpark = _sparkField != null
+    val spark = if (useSpark) new SparkBackendUtils(_mods.result()) else null
+
     assert(TaskContext.get() == null,
       "FunctionBuilder emission should happen on master, but happened on worker")
 
@@ -357,6 +384,8 @@ class EmitFunctionBuilder[F >: Null](
           val f = theClass.newInstance().asInstanceOf[F]
           if (localHConf != null)
             f.asInstanceOf[FunctionWithHadoopConfiguration].addHadoopConfiguration(localHConf)
+          if (useSpark)
+            f.asInstanceOf[FunctionWithSparkBackend].setSparkBackend(spark)
           f.asInstanceOf[FunctionWithSeededRandomness].setPartitionIndex(idx)
           f
         } catch {

--- a/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
@@ -182,6 +182,10 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
         MatrixAggregate(normalizeMatrix(child),
           normalizeIR(query, BindingEnv(child.typ.globalEnv, agg = Some(child.typ.entryEnv))
             .mapValuesWithKey({ case (k, _) => k })))
+      case CollectDistributedArray(ctxs, globals, cname, gname, body) =>
+        val newC = gen()
+        val newG = gen()
+        CollectDistributedArray(normalize(ctxs), normalize(globals), newC, newG, normalize(body, BindingEnv.empty.bindEval(cname -> newC, gname -> newG)))
       case _ =>
         Copy(ir, ir.children.map {
           case child: IR => normalize(child)

--- a/hail/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/SpecializedArrayBuilders.scala
@@ -407,3 +407,45 @@ class BooleanArrayBuilder(initialCapacity: Int) extends MissingArrayBuilder(init
     }
   }
 }
+
+class ByteArrayArrayBuilder(initialCapacity: Int) {
+
+  var size_ : Int = 0
+  private var b: Array[Array[Byte]] = new Array[Array[Byte]](initialCapacity)
+
+  def size: Int = size_
+
+  def setSize(n: Int) {
+    require(n >= 0 && n <= size)
+    size_ = n
+  }
+
+  def apply(i: Int): Array[Byte] = {
+    require(i >= 0 && i < size)
+    b(i)
+  }
+
+  def ensureCapacity(n: Int): Unit = {
+    if (b.length < n) {
+      val newCapacity = (b.length * 2).max(n)
+      val newb = new Array[Array[Byte]](newCapacity)
+      Array.copy(b, 0, newb, 0, size_)
+      b = newb
+    }
+  }
+
+  def add(x: Array[Byte]): Unit = {
+    ensureCapacity(size_ + 1)
+    b(size_) = x
+    size_ += 1
+  }
+
+  def update(i: Int, x: Array[Byte]): Unit = {
+    require(i >= 0 && i < size)
+    b(i) = x
+  }
+
+  def clear() {  size_ = 0 }
+
+  def result(): Array[Array[Byte]] = b.slice(0, size_)
+}

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -5,7 +5,8 @@ import java.util
 
 import is.hail.annotations._
 import is.hail.asm4s._
-import is.hail.expr.ir.{EmitUtils, EstimableEmitter, MethodBuilderLike}
+import is.hail.expr.ir
+import is.hail.expr.ir.{EmitFunctionBuilder, EmitUtils, EstimableEmitter, MethodBuilderLike}
 import is.hail.expr.types.MatrixType
 import is.hail.expr.types.physical._
 import is.hail.io.compress.LZ4Utils
@@ -27,6 +28,10 @@ trait BufferSpec extends Serializable {
 
   def buildOutputBuffer(out: OutputStream): OutputBuffer
 
+  def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBuffer]
+
+  def buildCodeOutputBuffer(in: Code[OutputStream]): Code[OutputBuffer]
+
   def nativeOutputBufferType: String
 
   def nativeInputBufferType: String
@@ -36,6 +41,12 @@ final case class LEB128BufferSpec(child: BufferSpec) extends BufferSpec {
   def buildInputBuffer(in: InputStream): InputBuffer = new LEB128InputBuffer(child.buildInputBuffer(in))
 
   def buildOutputBuffer(out: OutputStream): OutputBuffer = new LEB128OutputBuffer(child.buildOutputBuffer(out))
+
+  def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBuffer] =
+    Code.newInstance[LEB128InputBuffer, InputBuffer](child.buildCodeInputBuffer(in))
+
+  def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBuffer] =
+    Code.newInstance[LEB128OutputBuffer, OutputBuffer](child.buildCodeOutputBuffer(out))
 
   def nativeOutputBufferType: String = s"LEB128OutputBuffer<${ child.nativeOutputBufferType }>"
 
@@ -47,6 +58,12 @@ final case class BlockingBufferSpec(blockSize: Int, child: BlockBufferSpec) exte
 
   def buildOutputBuffer(out: OutputStream): OutputBuffer = new BlockingOutputBuffer(blockSize, child.buildOutputBuffer(out))
 
+  def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBuffer] =
+    Code.newInstance[BlockingInputBuffer, Int, InputBlockBuffer](blockSize, child.buildCodeInputBuffer(in))
+
+  def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBuffer] =
+    Code.newInstance[BlockingOutputBuffer, Int, OutputBlockBuffer](blockSize, child.buildCodeOutputBuffer(out))
+
   def nativeOutputBufferType: String = s"BlockingOutputBuffer<$blockSize, ${ child.nativeOutputBufferType }>"
 
   def nativeInputBufferType: String = s"BlockingInputBuffer<$blockSize, ${ child.nativeInputBufferType }>"
@@ -57,6 +74,10 @@ trait BlockBufferSpec extends Serializable {
 
   def buildOutputBuffer(out: OutputStream): OutputBlockBuffer
 
+  def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBlockBuffer]
+
+  def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBlockBuffer]
+
   def nativeOutputBufferType: String
 
   def nativeInputBufferType: String
@@ -66,6 +87,12 @@ final case class LZ4BlockBufferSpec(blockSize: Int, child: BlockBufferSpec) exte
   def buildInputBuffer(in: InputStream): InputBlockBuffer = new LZ4InputBlockBuffer(blockSize, child.buildInputBuffer(in))
 
   def buildOutputBuffer(out: OutputStream): OutputBlockBuffer = new LZ4OutputBlockBuffer(blockSize, child.buildOutputBuffer(out))
+
+  def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBlockBuffer] =
+    Code.newInstance[LZ4InputBlockBuffer, Int, InputBlockBuffer](blockSize, child.buildCodeInputBuffer(in))
+
+  def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBlockBuffer] =
+    Code.newInstance[LZ4OutputBlockBuffer, Int, OutputBlockBuffer](blockSize, child.buildCodeOutputBuffer(out))
 
   def nativeOutputBufferType: String = s"LZ4OutputBlockBuffer<${ 4 + LZ4Utils.maxCompressedLength(blockSize) }, ${ child.nativeOutputBufferType }>"
 
@@ -81,6 +108,12 @@ final class StreamBlockBufferSpec extends BlockBufferSpec {
 
   def buildOutputBuffer(out: OutputStream): OutputBlockBuffer = new StreamBlockOutputBuffer(out)
 
+  def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBlockBuffer] =
+    Code.newInstance[StreamBlockInputBuffer, InputStream](in)
+
+  def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBlockBuffer] =
+    Code.newInstance[StreamBlockOutputBuffer, OutputStream](out)
+
   def nativeOutputBufferType: String = s"StreamOutputBlockBuffer"
 
   def nativeInputBufferType: String = s"StreamInputBlockBuffer"
@@ -92,6 +125,12 @@ final class StreamBufferSpec extends BufferSpec {
   override def buildInputBuffer(in: InputStream): InputBuffer = new StreamInputBuffer(in)
 
   override def buildOutputBuffer(out: OutputStream): OutputBuffer = new StreamOutputBuffer(out)
+
+  def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBuffer] =
+    Code.newInstance[StreamInputBuffer, InputStream](in)
+
+  def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBuffer] =
+    Code.newInstance[StreamOutputBuffer, OutputStream](out)
 
   override def nativeInputBufferType: String = s"StreamInputBuffer"
 
@@ -212,6 +251,12 @@ final case class PackCodecSpec(child: BufferSpec) extends CodecSpec {
       (in: InputStream) => new CompiledPackDecoder(child.buildInputBuffer(in), f)
     }
   }
+
+  def buildEmitDecoderMethod(t: PType, requestedType: PType, fb: EmitFunctionBuilder[_]): ir.EmitMethodBuilder =
+    EmitPackDecoder.buildMethod(t, requestedType, fb)
+
+  def buildEmitEncoderMethod(t: PType, requestedType: PType, fb: EmitFunctionBuilder[_]): ir.EmitMethodBuilder =
+    EmitPackEncoder.buildMethod(t, requestedType, fb)
 
   def buildNativeDecoderClass(t: PType, requestedType: PType, tub: cxx.TranslationUnitBuilder): cxx.Class = cxx.PackDecoder(t, requestedType, child, tub)
 
@@ -1076,8 +1121,7 @@ object EmitPackDecoder {
     assert(j == requestedType.size)
 
     Code(initCode,
-      EmitUtils.wrapToMethod(fieldEmitters, new MethodBuilderSelfLike(mb)),
-      Code._empty)
+      EmitUtils.wrapToMethod(fieldEmitters, new MethodBuilderSelfLike(mb)))
   }
 
   def emitArray(
@@ -1218,6 +1262,28 @@ object EmitPackDecoder {
       case _: PFloat64 => srvb.addDouble(in.readDouble())
       case t2: PBinary => emitBinary(t2, mb, in, srvb)
     }
+  }
+
+  def buildMethod(t: PType, rt: PType, fb: EmitFunctionBuilder[_]): ir.EmitMethodBuilder = {
+    val mb = fb.newMethod(Array[TypeInfo[_]](typeInfo[Region], typeInfo[InputBuffer]), ir.typeToTypeInfo(rt))
+    val in: Code[InputBuffer] = mb.getArg[InputBuffer](2)
+    val decode: Code[_] = t match {
+      case _: PBoolean => in.readBoolean()
+      case _: PInt32 => in.readInt()
+      case _: PInt64 => in.readLong()
+      case _: PFloat32 => in.readFloat()
+      case _: PFloat64 => in.readDouble()
+      case _ =>
+        val srvb = new StagedRegionValueBuilder(mb, rt)
+        val emit = t.fundamentalType match {
+          case t2: PBinary => emitBinary(t2, mb, in, srvb)
+          case t2: PBaseStruct => emitBaseStruct(t2, rt.fundamentalType.asInstanceOf[PBaseStruct], mb, in, srvb)
+          case t2: PArray => emitArray(t2, rt.fundamentalType.asInstanceOf[PArray], mb, in, srvb)
+        }
+        Code(emit, srvb.end())
+    }
+    mb.emit(decode)
+    mb
   }
 
   def apply(t: PType, requestedType: PType): () => AsmFunction2[Region, InputBuffer, Long] = {
@@ -1542,6 +1608,23 @@ object EmitPackEncoder { self =>
       case _: PFloat64 => out.writeDouble(region.loadDouble(off))
       case _: PBinary => writeBinary(mb, region, off, out)
     }
+  }
+
+  def buildMethod(t: PType, rt: PType, fb: EmitFunctionBuilder[_]): ir.EmitMethodBuilder = {
+    val mb = fb.newMethod(Array[TypeInfo[_]](typeInfo[Region], ir.typeToTypeInfo(rt), typeInfo[OutputBuffer]), typeInfo[Unit])
+    val region: Code[Region] = mb.getArg[Region](1)
+    val v: Code[_] = mb.getArg(2)(ir.typeToTypeInfo(rt))
+    val out: Code[OutputBuffer] = mb.getArg[OutputBuffer](3)
+    val encode: Code[Unit] = t match {
+      case _: PBoolean => out.writeBoolean(coerce[Boolean](v))
+      case _: PInt32 => out.writeInt(coerce[Int](v))
+      case _: PInt64 => out.writeLong(coerce[Long](v))
+      case _: PFloat32 => out.writeFloat(coerce[Float](v))
+      case _: PFloat64 => out.writeDouble(coerce[Double](v))
+      case _ => emit(t, rt, mb, region, coerce[Long](v), out)
+    }
+    mb.emit(encode)
+    mb
   }
 
   def apply(t: PType, requestedType: PType): () => AsmFunction3[Region, Long, OutputBuffer, Unit] = {

--- a/hail/src/main/scala/is/hail/utils/ExecutionTimer.scala
+++ b/hail/src/main/scala/is/hail/utils/ExecutionTimer.scala
@@ -12,7 +12,7 @@ class Timings(val value: mutable.Map[String, Map[String, Any]]) extends AnyVal {
   }
 }
 
-class ExecutionTimer(context: String) {
+class ExecutionTimer(val context: String) {
   val timings: Timings = new Timings(mutable.Map.empty)
 
   def time[T](block: => T, stage: String): T = {

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -25,10 +25,9 @@ class TableIRSuite extends SparkSuite {
 
   def rangeKT: TableIR = Table.range(hc, 20, Some(4)).unkey().tir
 
-  implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized, ExecStrategy.CxxCompile)
+  implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized, ExecStrategy.CxxCompile, ExecStrategy.LoweredJVMCompile)
 
   @Test def testRangeCount() {
-    implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized, ExecStrategy.CxxCompile, ExecStrategy.LoweredJVMCompile)
     val node1 = TableCount(TableRange(10, 2))
     val node2 = TableCount(TableRange(15, 5))
     val node = ApplyBinaryPrimOp(Add(), node1, node2)
@@ -94,6 +93,7 @@ class TableIRSuite extends SparkSuite {
   }
 
   @Test def testTableMapWithLiterals() {
+    implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized, ExecStrategy.CxxCompile)
     val t = TableRange(10, 2)
     val node = TableMapRows(t,
       InsertFields(Ref("row", t.typ.rowType),

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -28,6 +28,7 @@ class TableIRSuite extends SparkSuite {
   implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized, ExecStrategy.CxxCompile)
 
   @Test def testRangeCount() {
+    implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized, ExecStrategy.CxxCompile, ExecStrategy.LoweredJVMCompile)
     val node1 = TableCount(TableRange(10, 2))
     val node2 = TableCount(TableRange(15, 5))
     val node = ApplyBinaryPrimOp(Add(), node1, node2)


### PR DESCRIPTION
there's also a small amount of refactoring that was necessary to send TableIRSuite.testRangeCount through the lowered, jvm-emitted path to test the CollectDistributedArray implementation.

cc @cseed 