### PR TITLE
use rollout status when waiting for deployments

### DIFF
--- a/ci2/ci/build.py
+++ b/ci2/ci/build.py
@@ -608,7 +608,8 @@ echo {shq(rendered_config)} | kubectl -n {self.namespace} apply -f -
                     # FIXME what if the cluster isn't big enough?
                     script += f'''
 set +e
-kubectl -n {self.namespace} wait --timeout=1h deployment --for=condition=available {name}
+kubectl -n {self.namespace} rollout status --timeout=1h deployment {name} && \
+  kubectl -n {self.namespace} wait --timeout=1h --for=condition=available deployment {name}
 EC=$?
 kubectl -n {self.namespace} logs -l app={name}
 set -e
@@ -620,7 +621,8 @@ set -e
                     timeout = w.get('timeout', 60)
                     script += f'''
 set +e
-kubectl -n {self.namespace} wait --timeout=1h deployment --for=condition=available {name} && \
+kubectl -n {self.namespace} rollout status --timeout=1h deployment {name} && \
+  kubectl -n {self.namespace} wait --timeout=1h --for=condition=available deployment {name} && \
   python3 wait-for.py {timeout} {self.namespace} Service -p {port} {name}
 EC=$?
 kubectl -n {self.namespace} logs -l app={name}


### PR DESCRIPTION
I'm seeing deploy failures where the tests start failing part way through because batch becomes unavailable, for example: https://ci2.hail.is/jobs/2886/log

However, this can't be the whole story, because batch has a readiness check and it isn't clear why it should go unavailable.  Either way, this seems safer because it makes sure you pick up the intended version.
