### PR TITLE
WIP: Add Table/MatrixTable Indicies

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
@@ -58,6 +58,7 @@ case class MatrixValue(
     val colsSpec = TableSpec(
       FileFormat.version.rep,
       is.hail.HAIL_PRETTY_VERSION,
+      None,  // cols are not indexed
       "../references",
       typ.colsTableType,
       Map("globals" -> RVDComponentSpec("../globals/rows"),
@@ -76,6 +77,7 @@ case class MatrixValue(
     val globalsSpec = TableSpec(
       FileFormat.version.rep,
       is.hail.HAIL_PRETTY_VERSION,
+      None,  // globals are not indexed
       "../references",
       TableType(typ.globalType, FastIndexedSeq(), TStruct.empty()),
       Map("globals" -> RVDComponentSpec("globals"),
@@ -99,6 +101,7 @@ case class MatrixValue(
     val rowsSpec = TableSpec(
       FileFormat.version.rep,
       is.hail.HAIL_PRETTY_VERSION,
+      None, // FIXME rows should be indexed
       "../references",
       typ.rowsTableType,
       Map("globals" -> RVDComponentSpec("../globals/rows"),
@@ -111,6 +114,7 @@ case class MatrixValue(
     val entriesSpec = TableSpec(
       FileFormat.version.rep,
       is.hail.HAIL_PRETTY_VERSION,
+      None, // FIXME entries should be indexed
       "../references",
       TableType(typ.entriesRVType, FastIndexedSeq(), typ.globalType),
       Map("globals" -> RVDComponentSpec("../globals/rows"),
@@ -132,6 +136,7 @@ case class MatrixValue(
     val spec = MatrixTableSpec(
       FileFormat.version.rep,
       is.hail.HAIL_PRETTY_VERSION,
+      None,
       "references",
       typ,
       Map("globals" -> RVDComponentSpec("globals/rows"),

--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -92,7 +92,7 @@ case class TableValue(typ: TableType, globals: BroadcastRow, rvd: RVD) {
     hadoopConf.mkDir(globalsPath)
     AbstractRVDSpec.writeSingle(hadoopConf, globalsPath, typ.globalType.physicalType, codecSpec, Array(globals.value))
 
-    val partitionCounts = rvd.write(path + "/rows", stageLocally, codecSpec)
+    val partitionCounts = rvd.write(path + "/rows", path + "/index", stageLocally, codecSpec)
 
     val referencesPath = path + "/references"
     hadoopConf.mkDir(referencesPath)

--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -102,6 +102,7 @@ case class TableValue(typ: TableType, globals: BroadcastRow, rvd: RVD) {
     val spec = TableSpec(
       FileFormat.version.rep,
       is.hail.HAIL_PRETTY_VERSION,
+      Some("index"),
       "references",
       typ,
       Map("globals" -> RVDComponentSpec("globals"),

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -46,7 +46,6 @@ final case class LEB128BufferSpec(child: BufferSpec) extends BufferSpec {
 }
 
 final case class BlockingBufferSpec(blockSize: Int, child: BlockBufferSpec) extends BufferSpec {
-  require((blockSize & (blockSize - 1)) == 0)
   require(blockSize <= (1 << 16))
 
   def buildInputBuffer(in: InputStream): InputBuffer = new BlockingInputBuffer(blockSize, child.buildInputBuffer(in))
@@ -69,7 +68,6 @@ trait BlockBufferSpec extends Serializable {
 }
 
 final case class LZ4BlockBufferSpec(blockSize: Int, child: BlockBufferSpec) extends BlockBufferSpec {
-  require((blockSize & (blockSize - 1)) == 0)
   require(blockSize <= (1 << 16))
 
   def buildInputBuffer(in: InputStream): InputBlockBuffer = new LZ4InputBlockBuffer(blockSize, child.buildInputBuffer(in))

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -1775,7 +1775,7 @@ object RichContextRDDRegionValue {
       if (iw != null) {
         val off = en.indexOffset()
         val key = SafeRow.selectFields(rowType, rv)(indexKeyFieldIndices)
-        iw += (key, off, null)
+        iw += (key, off, Row())
       }
       en.writeByte(1)
       en.writeRegionValue(rv.region, rv.offset)
@@ -1921,14 +1921,16 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RVDContext, RegionValue]) e
 
   def writeRows(
     path: String,
+    idxPath: String,
     t: RVDType,
     stageLocally: Boolean,
     codecSpec: CodecSpec
   ): (Array[String], Array[Long]) = {
     crdd.writePartitions(
       path,
+      idxPath,
       stageLocally,
-      IndexWriter.builder(t.kType.virtualType, +TStruct(), codecSpec),
+      IndexWriter.builder(t.kType.virtualType, +TStruct()),
       RichContextRDDRegionValue.writeRowsPartition(
         codecSpec.buildEncoder(t.rowType),
         t.kFieldIdx,

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -253,7 +253,7 @@ final class StreamBlockOutputBuffer(out: OutputStream) extends OutputBlockBuffer
   }
 
   // FIXME this fails
-  def getPos(): Long = out.asInstanceOf[FSDataOutputStream].getPos()
+  def getPos(): Long = out.asInstanceOf[ByteTrackingOutputStream].bytesWritten
 }
 
 final class StreamBlockInputBuffer(in: InputStream) extends InputBlockBuffer {
@@ -500,7 +500,7 @@ final class StreamOutputBuffer(out: OutputStream) extends OutputBuffer {
 
   override def close(): Unit = out.close()
 
-  def indexOffset(): Long = out.asInstanceOf[FSDataOutputStream].getPos()
+  def indexOffset(): Long = ??? // out.asInstanceOf[FSDataOutputStream].getPos() // FIXME generic way of getting bytes written
 
   override def writeByte(b: Byte): Unit = out.write(Array(b))
 
@@ -1929,7 +1929,10 @@ class RichContextRDDRegionValue(val crdd: ContextRDD[RVDContext, RegionValue]) e
       path,
       stageLocally,
       IndexWriter.builder(t.kType.virtualType, +TStruct(), codecSpec),
-      RichContextRDDRegionValue.writeRowsPartition(codecSpec.buildEncoder(t.rowType)))
+      RichContextRDDRegionValue.writeRowsPartition(
+        codecSpec.buildEncoder(t.rowType),
+        t.kFieldIdx,
+        t.rowType))
   }
 
   def writeRowsSplit(

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -38,11 +38,11 @@ object IndexWriter {
   def builder(
     keyType: Type,
     annotationType: Type,
-    codecSpec: CodecSpec,
     branchingFactor: Int = 4096,
     attributes: Map[String, Any] = Map.empty[String, Any]
   ): (Configuration, String) => IndexWriter = {
-    val makeLeafEncoder = codecSpec.buildEncoder(LeafNodeBuilder.typ(keyType, annotationType).physicalType);
+    val codecSpec = CodecSpec.default
+    val makeLeafEncoder = codecSpec.buildEncoder(LeafNodeBuilder.typ(keyType, annotationType).physicalType)
     val makeInternalEncoder = codecSpec.buildEncoder(InternalNodeBuilder.typ(keyType, annotationType).physicalType);
     { (conf, path) =>
       new IndexWriter(

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -34,6 +34,17 @@ case class IndexNodeInfo(
 
 object IndexWriter {
   val version: SemanticVersion = SemanticVersion(1, 0, 0)
+
+  def builder(
+    keyType: Type,
+    annotationType: Type,
+    makeLeafEncoder: (OutputStream) => Encoder,
+    makeInternalEncoder: (OutputStream) => Encoder,
+    branchingFactor: Int = 4096,
+    attributes: Map[String, Any] = Map.empty[String, Any]
+  ): (Configuration, String) => IndexWriter = { (conf, path) =>
+    new IndexWriter(conf, path, keyType, annotationType, makeLeafEncoder, makeInternalEncoder, branchingFactor, attributes)
+  }
 }
 
 class IndexWriter(
@@ -150,7 +161,7 @@ class IndexWriter(
       val metadata = IndexMetadata(
         IndexWriter.version.rep,
         branchingFactor,
-        height, 
+        height,
         keyType.parsableString(),
         annotationType.parsableString(),
         elementIdx,

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -38,14 +38,26 @@ object IndexWriter {
   def builder(
     keyType: Type,
     annotationType: Type,
-    makeLeafEncoder: (OutputStream) => Encoder,
-    makeInternalEncoder: (OutputStream) => Encoder,
+    codecSpec: CodecSpec,
     branchingFactor: Int = 4096,
     attributes: Map[String, Any] = Map.empty[String, Any]
-  ): (Configuration, String) => IndexWriter = { (conf, path) =>
-    new IndexWriter(conf, path, keyType, annotationType, makeLeafEncoder, makeInternalEncoder, branchingFactor, attributes)
+  ): (Configuration, String) => IndexWriter = {
+    val makeLeafEncoder = codecSpec.buildEncoder(LeafNodeBuilder.typ(keyType, annotationType).physicalType);
+    val makeInternalEncoder = codecSpec.buildEncoder(InternalNodeBuilder.typ(keyType, annotationType).physicalType);
+    { (conf, path) =>
+      new IndexWriter(
+        conf,
+        path,
+        keyType,
+        annotationType,
+        makeLeafEncoder,
+        makeInternalEncoder,
+        branchingFactor,
+        attributes)
+    }
   }
 }
+
 
 class IndexWriter(
   hConf: Configuration,

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -80,7 +80,7 @@ object AbstractRVDSpec {
               rvb.start(rowType)
               rvb.addAnnotation(rowType.virtualType, a)
               RegionValue(region, rvb.end())
-            }, os)
+            }, os, null)
         }
       }
 

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -667,8 +667,8 @@ class RVD(
 
   def storageLevel: StorageLevel = StorageLevel.NONE
 
-  def write(path: String, stageLocally: Boolean, codecSpec: CodecSpec): Array[Long] = {
-    val (partFiles, partitionCounts) = crdd.writeRows(path, typ, stageLocally, codecSpec)
+  def write(path: String, idxPath: String, stageLocally: Boolean, codecSpec: CodecSpec): Array[Long] = {
+    val (partFiles, partitionCounts) = crdd.writeRows(path, idxPath, typ, stageLocally, codecSpec)
     rvdSpec(codecSpec, partFiles).write(sparkContext.hadoopConfiguration, path)
     partitionCounts
   }

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -668,7 +668,7 @@ class RVD(
   def storageLevel: StorageLevel = StorageLevel.NONE
 
   def write(path: String, stageLocally: Boolean, codecSpec: CodecSpec): Array[Long] = {
-    val (partFiles, partitionCounts) = crdd.writeRows(path, rowPType, stageLocally, codecSpec)
+    val (partFiles, partitionCounts) = crdd.writeRows(path, typ, stageLocally, codecSpec)
     rvdSpec(codecSpec, partFiles).write(sparkContext.hadoopConfiguration, path)
     partitionCounts
   }

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -40,6 +40,7 @@ abstract class AbstractTableSpec extends RelationalSpec {
 case class TableSpec(
   file_version: Int,
   hail_version: String,
+  index_path: Option[String],
   references_rel_path: String,
   table_type: TableType,
   components: Map[String, ComponentSpec]) extends AbstractTableSpec

--- a/hail/src/main/scala/is/hail/utils/ByteTrackingInputStream.scala
+++ b/hail/src/main/scala/is/hail/utils/ByteTrackingInputStream.scala
@@ -1,6 +1,7 @@
 package is.hail.utils
 
 import java.io.InputStream
+import org.apache.hadoop.fs.Seekable
 
 class ByteTrackingInputStream(base: InputStream) extends InputStream {
   var bytesRead = 0L
@@ -29,4 +30,6 @@ class ByteTrackingInputStream(base: InputStream) extends InputStream {
   }
 
   override def close(): Unit = base.close()
+
+  def seek(offset: Long) = base.asInstanceOf[Seekable].seek(offset)
 }

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
@@ -3,10 +3,11 @@ package is.hail.utils.richUtils
 import java.io._
 
 import is.hail.HailContext
+import is.hail.io.index.IndexWriter
 import is.hail.rvd.RVDContext
-import org.apache.spark.TaskContext
 import is.hail.utils._
 import is.hail.sparkextras._
+import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
 
 import scala.reflect.ClassTag

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichContextRDD.scala
@@ -53,10 +53,11 @@ class RichContextRDD[T: ClassTag](crdd: ContextRDD[RVDContext, T]) {
       val os = hConf.unsafeWriter(filename)
       val iw = mkIdxWriter(hConf, filename + ".idx")
       val count = write(ctx, it, os, iw)
+      if (iw != null)
+        iw.close()
       if (stageLocally) {
         hConf.copy(filename, finalFilename)
         if (iw != null) {
-          iw.close()
           hConf.copy(filename + ".idx/index", finalFilename + ".idx/index")
           hConf.copy(filename + ".idx/metadata.json.gz", finalFilename + ".idx/metadata.json.gz")
         }

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -168,6 +168,7 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
   ): (Array[String], Array[Long]) =
     ContextRDD.weaken[RVDContext](r).writePartitions(
       path,
+      null,
       stageLocally,
       (_, _) => null,
       (_, it, os, _) => write(it, os))

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichRDD.scala
@@ -116,7 +116,7 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
 
       def compute(split: Partition, context: TaskContext): Iterator[T] =
         r.compute(split.asInstanceOf[SubsetRDDPartition].parentPartition, context)
-      
+
       @transient override val partitioner: Option[Partitioner] = newPartitioner
     }
   }
@@ -126,11 +126,11 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
     newNPartitions: Int,
     newPIPartition: Int => Iterator[T],
     newPartitioner: Option[Partitioner] = None)(implicit ct: ClassTag[T]): RDD[T] = {
-    
+
     require(oldToNewPI.length == r.partitions.length)
     require(oldToNewPI.forall(pi => pi >= 0 && pi < newNPartitions))
     require(oldToNewPI.areDistinct())
-    
+
     val parentPartitions = r.partitions
     val newToOldPI = oldToNewPI.zipWithIndex.toMap
 
@@ -169,5 +169,6 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
     ContextRDD.weaken[RVDContext](r).writePartitions(
       path,
       stageLocally,
-      (_, it, os) => write(it, os))
+      (_, _) => null,
+      (_, it, os, _) => write(it, os))
 }

--- a/hail/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/hail/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -67,6 +67,8 @@ abstract class RelationalSpec {
 
   def hail_version: String
 
+  def index_path: Option[String]
+
   def components: Map[String, ComponentSpec]
 
   def getComponent[T <: ComponentSpec](name: String): T = components(name).asInstanceOf[T]
@@ -128,6 +130,7 @@ abstract class AbstractMatrixTableSpec extends RelationalSpec {
 case class MatrixTableSpec(
   file_version: Int,
   hail_version: String,
+  index_path: Option[String],
   references_rel_path: String,
   matrix_type: MatrixType,
   components: Map[String, ComponentSpec]) extends AbstractMatrixTableSpec {


### PR DESCRIPTION
This is an initial revision intended for feedback, there is much left to do
### TODOs
- [ ] Implement Read from index, notably for two operations, filter and repartition.
- [ ] Write matrix table indices
    - There needs to be some work done on figuring out how to index both the rows and entries, especially when reading the entries as a table. Indices support an arbitrary `Annotation` payload that could be used.

One thought I had for handling this is changing Indices rather than requiring a `offset: Long` and an `Annotation` changing them so that they only take some `Annotation`. Then the `TableSpec` or `MatrixTableSpec` would have a list of indices that would describe what needs to be pulled out of the `Annotation` in order to get the key's offset.

cc @cseed