### PR TITLE
[fix] Fix IOB exception when broadcasting BlockMatrix vectors

### DIFF
--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -1173,10 +1173,17 @@ class BlockMatrix(object):
         -------
         :class:`.BlockMatrix`
         """
-        return BlockMatrix(BlockMatrixBroadcast(self._bmir,
-                                                [1, 0],
-                                                [self.n_cols, self.n_rows],
-                                                self.block_size))
+        if self.n_rows == 1 and self.n_cols == 1:
+            return self
+
+        if self.n_rows == 1:
+            index_expr = [0]
+        elif self.n_cols == 1:
+            index_expr = [1]
+        else:
+            index_expr = [1, 0]
+
+        return BlockMatrix(BlockMatrixBroadcast(self._bmir, index_expr, [self.n_cols, self.n_rows], self.block_size))
 
     def densify(self):
         """Restore all dropped blocks as explicit blocks of zeros.

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -394,6 +394,8 @@ class Tests(unittest.TestCase):
     def test_matrix_ops(self):
         nm = np.matrix([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         m = BlockMatrix.from_numpy(nm, block_size=2)
+        nsquare = np.matrix([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+        square = BlockMatrix.from_numpy(nsquare, block_size=2)
 
         nrow = np.matrix([[7.0, 8.0, 9.0]])
         row = BlockMatrix.from_numpy(nrow, block_size=2)
@@ -427,6 +429,7 @@ class Tests(unittest.TestCase):
         self._assert_eq(m.sum(axis=0) + row.T, np.array([[12.0, 14.0, 16.0],
                                                          [13.0, 15.0, 17.0],
                                                          [14.0, 16.0, 18.0]]))
+        self._assert_eq(square.sum(axis=0).T + square.sum(axis=1), np.array([[18.0], [30.0], [42.0]]))
 
     def test_fill(self):
         nd = np.ones((3, 5))

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -424,6 +424,9 @@ class Tests(unittest.TestCase):
         self._assert_eq(m.sum(axis=0).T + row, np.array([[12.0, 13.0, 14.0],
                                                          [14.0, 15.0, 16.0],
                                                          [16.0, 17.0, 18.0]]))
+        self._assert_eq(m.sum(axis=0) + row.T, np.array([[12.0, 14.0, 16.0],
+                                                         [13.0, 15.0, 17.0],
+                                                         [14.0, 16.0, 18.0]]))
 
     def test_fill(self):
         nd = np.ones((3, 5))

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -369,14 +369,14 @@ case class BlockMatrixBroadcast(
   private def broadcastRowVector(hc: HailContext, vec: Array[Double], nRows: Int, nCols: Int): BlockMatrix = {
     val data = ArrayBuffer[Double]()
     data.sizeHint(nRows * nCols)
-    (0 to nRows).foreach(_ => data ++= vec)
+    (0 until nRows).foreach(_ => data ++= vec)
     BlockMatrixIR.toBlockMatrix(hc, nRows, nCols, data.toArray, blockSize)
   }
 
   private def broadcastColVector(hc: HailContext, vec: Array[Double], nRows: Int, nCols: Int): BlockMatrix = {
     val data = ArrayBuffer[Double]()
     data.sizeHint(nRows * nCols)
-    (0 to nRows).foreach(row => (0 to nCols).foreach(_ => data += vec(row)))
+    (0 until nRows).foreach(row => (0 until nCols).foreach(_ => data += vec(row)))
     BlockMatrixIR.toBlockMatrix(hc, nRows, nCols, data.toArray, blockSize)
   }
 }


### PR DESCRIPTION
Two small, related bug fixes here:
- Vectors were not being transposed correctly, the index expression is different than that of a matrix.
- In the edge cases where vector broadcasts/transposes had to be realized, there was an IOB exception because `to` is evil and I should've used `until`. I knew this would happen one day...