### PR TITLE
Fix set compare

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/Annotation.scala
+++ b/hail/src/main/scala/is/hail/annotations/Annotation.scala
@@ -4,6 +4,8 @@ import is.hail.expr.types.virtual._
 import is.hail.utils._
 import org.apache.spark.sql.Row
 
+import scala.collection.immutable.{TreeMap, TreeSet}
+
 object Annotation {
 
   final val COL_HEAD = "sa"
@@ -50,11 +52,13 @@ object Annotation {
         Array.tabulate(arr.length)(i => Annotation.copy(t.elementType, arr(i))).toFastIndexedSeq
 
       case t: TSet =>
-        a.asInstanceOf[Set[Annotation]].map(Annotation.copy(t.elementType, _))
+        val s = a.asInstanceOf[TreeSet[Any]]
+        TreeSet(s.iterator.map(a => Annotation.copy(t.elementType, a)).toFastIndexedSeq: _*)(s.ordering)
 
       case t: TDict =>
-        a.asInstanceOf[Map[Annotation, Annotation]]
-          .map { case (k, v) => (Annotation.copy(t.keyType, k), Annotation.copy(t.valueType, v)) }
+        val m = a.asInstanceOf[TreeMap[Any, Any]]
+        TreeMap(
+          m.iterator.map { case (k, v) => (Annotation.copy(t.keyType, k), Annotation.copy(t.valueType, v)) }.toFastIndexedSeq: _*)(m.ordering)
 
       case t: TInterval =>
         val i = a.asInstanceOf[Interval]

--- a/hail/src/main/scala/is/hail/annotations/ExtendedOrdering.scala
+++ b/hail/src/main/scala/is/hail/annotations/ExtendedOrdering.scala
@@ -435,10 +435,12 @@ abstract class IntervalEndpointOrdering extends ExtendedOrdering {
   def lteqWithOverlap(allowedOverlap: Int)(x: IntervalEndpoint, y: IntervalEndpoint): Boolean
 
   override def compareNonnull(x: Any, y: Any): Int = {
+    println((x, y))
     val xp = if (x.isInstanceOf[IntervalEndpoint]) x.asInstanceOf[IntervalEndpoint].point else x
     val xs = if (x.isInstanceOf[IntervalEndpoint]) x.asInstanceOf[IntervalEndpoint].sign else 0
     val yp = if (y.isInstanceOf[IntervalEndpoint]) y.asInstanceOf[IntervalEndpoint].point else y
     val ys = if (y.isInstanceOf[IntervalEndpoint]) y.asInstanceOf[IntervalEndpoint].sign else 0
+    println((xp, xs, yp, ys))
     compareIntervalEndpoints(xp, xs, yp, ys)
   }
 }

--- a/hail/src/main/scala/is/hail/annotations/ExtendedOrdering.scala
+++ b/hail/src/main/scala/is/hail/annotations/ExtendedOrdering.scala
@@ -400,6 +400,10 @@ abstract class ExtendedOrdering extends Serializable {
     override def equiv(x: T, y: T): Boolean = outer.equiv(x, y)
   }
 
+  def toTotalOrdering: Ordering[T] = new Ordering[T] {
+    def compare(x: T, y: T): Int = outer.compare(x, y)
+  }
+
   lazy val intervalEndpointOrdering: IntervalEndpointOrdering =
     new IntervalEndpointOrdering {
       override def compareIntervalEndpoints(xp: Any, xs: Int, yp: Any, ys: Int): Int = {

--- a/hail/src/main/scala/is/hail/annotations/aggregators/RegionValueCollectAsSetAggregator.scala
+++ b/hail/src/main/scala/is/hail/annotations/aggregators/RegionValueCollectAsSetAggregator.scala
@@ -1,9 +1,7 @@
 package is.hail.annotations.aggregators
 
 import is.hail.annotations.{Region, RegionValueBuilder, SafeRow}
-import is.hail.expr.types.virtual.{TSet, Type}
-
-import scala.collection.mutable
+import is.hail.expr.types.virtual._
 
 class RegionValueCollectAsSetBooleanAggregator extends RegionValueAggregator {
   private var hasTrue = false
@@ -57,14 +55,14 @@ class RegionValueCollectAsSetBooleanAggregator extends RegionValueAggregator {
 }
 
 class RegionValueCollectAsSetIntAggregator extends RegionValueAggregator {
-  private var values = mutable.Set[Int]()
+  private var values = TSet(TInt32()).literal()
   private var hasMissing = false
 
   def seqOp(region: Region, x: Int, missing: Boolean) {
     if (missing)
       hasMissing = true
     else
-      values.add(x)
+      values += x
   }
 
   def combOp(agg2: RegionValueAggregator) {
@@ -75,8 +73,8 @@ class RegionValueCollectAsSetIntAggregator extends RegionValueAggregator {
 
   def result(rvb: RegionValueBuilder) {
     rvb.startArray(if (hasMissing) values.size + 1 else values.size)
-    values.toArray.sorted.foreach { i =>
-      rvb.addInt(i)
+    values.foreach { i =>
+      rvb.addInt(i.asInstanceOf[Int])
     }
     if (hasMissing)
       rvb.setMissing()
@@ -87,25 +85,25 @@ class RegionValueCollectAsSetIntAggregator extends RegionValueAggregator {
 
   override def copy(): RegionValueCollectAsSetIntAggregator = {
     val rva = new RegionValueCollectAsSetIntAggregator()
-    rva.values = values.clone()
+    rva.values = values
     rva
   }
 
   def clear() {
-    values.clear()
+    values = TSet(TInt32()).literal()
     hasMissing = false
   }
 }
 
 class RegionValueCollectAsSetLongAggregator extends RegionValueAggregator {
-  private var values = mutable.Set[Long]()
+  private var values = TSet(TInt64()).literal()
   private var hasMissing = false
 
   def seqOp(region: Region, x: Long, missing: Boolean) {
     if (missing)
       hasMissing = true
     else
-      values.add(x)
+      values += x
   }
 
   def combOp(agg2: RegionValueAggregator) {
@@ -116,8 +114,8 @@ class RegionValueCollectAsSetLongAggregator extends RegionValueAggregator {
 
   def result(rvb: RegionValueBuilder) {
     rvb.startArray(if (hasMissing) values.size + 1 else values.size)
-    values.toArray.sorted.foreach { i =>
-      rvb.addLong(i)
+    values.foreach { i =>
+      rvb.addLong(i.asInstanceOf[Long])
     }
     if (hasMissing)
       rvb.setMissing()
@@ -128,25 +126,25 @@ class RegionValueCollectAsSetLongAggregator extends RegionValueAggregator {
 
   override def copy(): RegionValueCollectAsSetLongAggregator = {
     val rva = new RegionValueCollectAsSetLongAggregator()
-    rva.values = values.clone()
+    rva.values = values
     rva
   }
 
   def clear() {
-    values.clear()
+    values = TSet(TInt64()).literal()
     hasMissing = false
   }
 }
 
 class RegionValueCollectAsSetFloatAggregator extends RegionValueAggregator {
-  private var values = mutable.Set[Float]()
+  private var values = TSet(TFloat64()).literal()
   private var hasMissing = false
 
   def seqOp(region: Region, x: Float, missing: Boolean) {
     if (missing)
       hasMissing = true
     else
-      values.add(x)
+      values += x
   }
 
   def combOp(agg2: RegionValueAggregator) {
@@ -157,8 +155,8 @@ class RegionValueCollectAsSetFloatAggregator extends RegionValueAggregator {
 
   def result(rvb: RegionValueBuilder) {
     rvb.startArray(if (hasMissing) values.size + 1 else values.size)
-    values.toArray.sorted.foreach { i =>
-      rvb.addFloat(i)
+    values.foreach { i =>
+      rvb.addFloat(i.asInstanceOf[Float])
     }
     if (hasMissing)
       rvb.setMissing()
@@ -169,25 +167,25 @@ class RegionValueCollectAsSetFloatAggregator extends RegionValueAggregator {
 
   override def copy(): RegionValueCollectAsSetFloatAggregator = {
     val rva = new RegionValueCollectAsSetFloatAggregator()
-    rva.values = values.clone()
+    rva.values = values
     rva
   }
 
   def clear() {
-    values.clear()
+    values = TSet(TFloat32()).literal()
     hasMissing = false
   }
 }
 
 class RegionValueCollectAsSetDoubleAggregator extends RegionValueAggregator {
-  private var values = mutable.Set[Double]()
+  private var values = TSet(TFloat64()).literal()
   private var hasMissing = false
 
   def seqOp(region: Region, x: Double, missing: Boolean) {
     if (missing)
       hasMissing = true
     else
-      values.add(x)
+      values += x
   }
 
   def combOp(agg2: RegionValueAggregator) {
@@ -198,8 +196,8 @@ class RegionValueCollectAsSetDoubleAggregator extends RegionValueAggregator {
 
   def result(rvb: RegionValueBuilder) {
     rvb.startArray(if (hasMissing) values.size + 1 else values.size)
-    values.toArray.sorted.foreach { i =>
-      rvb.addDouble(i)
+    values.foreach { i =>
+      rvb.addDouble(i.asInstanceOf[Double])
     }
     if (hasMissing)
       rvb.setMissing()
@@ -210,24 +208,24 @@ class RegionValueCollectAsSetDoubleAggregator extends RegionValueAggregator {
 
   override def copy(): RegionValueCollectAsSetDoubleAggregator = {
     val rva = new RegionValueCollectAsSetDoubleAggregator()
-    rva.values = values.clone()
+    rva.values = values
     rva
   }
 
   def clear() {
-    values.clear()
+    values = TSet(TFloat64()).literal()
     hasMissing = false
   }
 }
 
 class RegionValueCollectAsSetAnnotationAggregator(val typ: Type) extends RegionValueAggregator {
-  private var values = mutable.Set[Any]()
+  private var values = TSet(typ).literal()
 
   def seqOp(region: Region, offset: Long, missing: Boolean) {
     if (missing)
-      values.add(null)
+      values += null
     else
-      values.add(SafeRow.read(typ.physicalType, region, offset))
+      values += SafeRow.read(typ.physicalType, region, offset)
   }
 
   def combOp(agg2: RegionValueAggregator) {
@@ -236,19 +234,18 @@ class RegionValueCollectAsSetAnnotationAggregator(val typ: Type) extends RegionV
   }
 
   def result(rvb: RegionValueBuilder) {
-    rvb.addAnnotation(TSet(typ), values.toSet)
+    rvb.addAnnotation(TSet(typ), values)
   }
 
   def newInstance(): RegionValueCollectAsSetAnnotationAggregator = new RegionValueCollectAsSetAnnotationAggregator(typ)
 
   override def copy(): RegionValueCollectAsSetAnnotationAggregator = {
     val rva = new RegionValueCollectAsSetAnnotationAggregator(typ)
-    rva.values = values.clone()
+    rva.values = values
     rva
   }
 
   def clear() {
-    values.clear()
+    values = TSet(typ).literal()
   }
 }
-

--- a/hail/src/main/scala/is/hail/check/Prop.scala
+++ b/hail/src/main/scala/is/hail/check/Prop.scala
@@ -9,8 +9,8 @@ abstract class Prop {
   def apply(p: Parameters, name: Option[String] = None): Unit
 
   def check() {
-    val size = System.getProperty("check.size", "1000").toInt
-    val count = System.getProperty("check.count", "10").toInt
+    val size = System.getProperty("check.size", "10").toInt
+    val count = System.getProperty("check.count", "1000").toInt
 
     println(s"check: size = $size, count = $count")
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -481,7 +481,7 @@ private class Emit(
           case ArraySort(a, l, r, comp) => (a, Subst(comp, BindingEnv(Env[IR](l -> In(0, eltType), r -> In(1, eltType)))), Code._empty[Unit])
           case ToSet(a) =>
             val discardNext = mb.fb.newMethod(Array[TypeInfo[_]](typeInfo[Region], sorter.ti, typeInfo[Boolean], sorter.ti, typeInfo[Boolean]), typeInfo[Boolean])
-            val EmitTriplet(s, m, v) = new Emit(discardNext, 1).emit(ApplyComparisonOp(EQWithNA(eltType), In(0, eltType), In(1, eltType)), Env.empty, er)
+            val EmitTriplet(s, m, v) = new Emit(discardNext, 1).emit(ApplyComparisonOp(Compare(eltType), In(0, eltType), In(1, eltType)).ceq(0), Env.empty, er)
             discardNext.emit(Code(s, m || coerce[Boolean](v)))
             (a, ApplyComparisonOp(Compare(eltType), In(0, eltType), In(1, eltType)) < 0, sorter.distinctFromSorted(discardNext.invoke(_, _, _, _, _)))
           case ToDict(a) =>
@@ -489,7 +489,7 @@ private class Emit(
             val k0 = GetField(In(0, dType.elementType), "key")
             val k1 = GetField(In(1, dType.elementType), "key")
             val discardNext = mb.fb.newMethod(Array[TypeInfo[_]](typeInfo[Region], sorter.ti, typeInfo[Boolean], sorter.ti, typeInfo[Boolean]), typeInfo[Boolean])
-            val EmitTriplet(s, m, v) = new Emit(discardNext, 1).emit(ApplyComparisonOp(EQWithNA(dType.keyType), k0, k1), Env.empty, er)
+            val EmitTriplet(s, m, v) = new Emit(discardNext, 1).emit(ApplyComparisonOp(Compare(dType.keyType), k0, k1).ceq(0), Env.empty, er)
             discardNext.emit(Code(s, m || coerce[Boolean](v)))
             (a, ApplyComparisonOp(Compare(dType.keyType), k0, k1) < 0, Code(sorter.pruneMissing, sorter.distinctFromSorted(discardNext.invoke(_, _, _, _, _))))
         }

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TDict.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TDict.scala
@@ -6,6 +6,7 @@ import is.hail.expr.types.physical.PDict
 import is.hail.utils._
 import org.json4s.jackson.JsonMethods
 
+import scala.collection.SortedMap
 import scala.collection.immutable.TreeMap
 import scala.reflect.{ClassTag, classTag}
 
@@ -54,14 +55,14 @@ final case class TDict(keyType: Type, valueType: Type, override val required: Bo
   }
 
   def _typeCheck(a: Any): Boolean = a == null || (a.isInstanceOf[Map[_, _]] &&
-    a.asInstanceOf[TreeMap[_, _]].forall { case (k, v) => keyType.typeCheck(k) && valueType.typeCheck(v) })
+    a.asInstanceOf[SortedMap[_, _]].forall { case (k, v) => keyType.typeCheck(k) && valueType.typeCheck(v) })
 
   override def str(a: Annotation): String = JsonMethods.compact(toJSON(a))
 
-  def literal(elems: (Any, Any)*): TreeMap[Any, Any] =
+  def literal(elems: (Any, Any)*): SortedMap[Any, Any] =
     TreeMap(elems: _*)(keyType.ordering.toTotalOrdering)
 
-  def toLiteral(elems: IndexedSeq[(Any, Any)]): TreeMap[Any, Any] = literal(elems: _*)
+  def toLiteral(elems: IndexedSeq[(Any, Any)]): SortedMap[Any, Any] = literal(elems: _*)
 
   override def genNonmissingValue: Gen[Annotation] =
     Gen.treeMapOf[Any, Any](Gen.zip(keyType.genValue, valueType.genValue))(keyType.ordering.toTotalOrdering)

--- a/hail/src/main/scala/is/hail/methods/Aggregators.scala
+++ b/hail/src/main/scala/is/hail/methods/Aggregators.scala
@@ -11,6 +11,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.util.StatCounter
 
 import scala.collection.JavaConverters._
+import scala.collection.immutable.TreeSet
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.language.implicitConversions
@@ -169,11 +170,11 @@ class HistAggregator(indices: Array[Double])
   def copy() = new HistAggregator(indices)
 }
 
-class CollectSetAggregator(t: Type) extends TypedAggregator[Set[Any]] {
+class CollectSetAggregator(t: Type) extends TypedAggregator[TreeSet[Any]] {
 
-  var _state = new mutable.HashSet[Any]
+  var _state = new TreeSet[Any]()(t.ordering.toTotalOrdering)
 
-  def result = _state.toSet
+  def result: TreeSet[Any] = _state
 
   def seqOp(x: Any) {
     _state += Annotation.copy(t, x)

--- a/hail/src/main/scala/is/hail/methods/Aggregators.scala
+++ b/hail/src/main/scala/is/hail/methods/Aggregators.scala
@@ -139,7 +139,7 @@ class CounterAggregator(t: Type) extends TypedAggregator[Map[Annotation, Long]] 
   def _seqOp(k: Any, w: Long) {
     m.get(k) match {
       case Some(v) =>
-        m += k -> v + w
+        m += k -> (v + w)
       case None =>
         m += k -> w
     }

--- a/hail/src/main/scala/is/hail/utils/Interval.scala
+++ b/hail/src/main/scala/is/hail/utils/Interval.scala
@@ -153,7 +153,7 @@ class Interval(val left: IntervalEndpoint, val right: IntervalEndpoint) extends 
   def coarsen(newKeyLen: Int): Interval =
     Interval(left.coarsenLeft(newKeyLen), right.coarsenRight(newKeyLen))
 
-  override def toString: String = (if (includesStart) "[" else "(") + start + "-" + end + (if (includesEnd) "]" else ")")
+  override def toString: String = left.sign + "/" + (if (includesStart) "[" else "(") + start + "-" + end + (if (includesEnd) "]" else ")") + "/" + right.sign
 
   override def equals(other: Any): Boolean = other match {
     case that: Interval => left == that.left && right == that.right
@@ -216,9 +216,10 @@ object Interval {
     override def compareNonnull(x: Any, y: Any): Int = {
       val xi = x.asInstanceOf[Interval]
       val yi = y.asInstanceOf[Interval]
-
+      println(("c", xi, yi))
       if (startPrimary) {
         val c = pord.intervalEndpointOrdering.compare(xi.left, yi.left)
+        println(c)
         if (c != 0) c else pord.intervalEndpointOrdering.compare(xi.right, yi.right)
       } else {
         val c = pord.intervalEndpointOrdering.compare(xi.right, yi.right)

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -747,6 +747,32 @@ package object utils extends Logging
            |  Created at ${ dateFormat.format(new Date()) }""".stripMargin)
     }
   }
+
+  def distinctOrd[T](a: IndexedSeq[T])(ord: Ordering[T])(implicit tct: ClassTag[T]): IndexedSeq[T] = {
+    val b = new ArrayBuilder[T]()
+    var i = 0
+    while (i < a.length) {
+      if (i == 0 || !ord.equiv(a(i - 1), a(i)))
+        b += a(i)
+      i += 1
+    }
+    b.result()
+  }
+
+  def mapOrdering[T, U](f: (U) => T, ord: Ordering[T]): Ordering[U] = new Ordering[U] {
+    def compare(x: U, y: U): Int = ord.compare(f(x), f(y))
+
+    override def lt(x: U, y: U): Boolean = ord.lt(f(x), f(y))
+
+    override def lteq(x: U, y: U): Boolean = ord.lteq(f(x), f(y))
+
+    override def equiv(x: U, y: U): Boolean = ord.equiv(f(x), f(y))
+
+    override def gt(x: U, y: U): Boolean = ord.gt(f(x), f(y))
+
+    override def gteq(x: U, y: U): Boolean = ord.gteq(f(x), f(y))
+
+  }
 }
 
 // FIXME: probably resolved in 3.6 https://github.com/json4s/json4s/commit/fc96a92e1aa3e9e3f97e2e91f94907fdfff6010d

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -404,7 +404,7 @@ object TestUtils {
     TypeCheck(x, BindingEnv(env.mapValues(_._2), agg = agg.map(_._2.toEnv)))
 
     val t = x.typ
-    assert(t.typeCheck(expected), t)
+    assert(t.typeCheck(expected), s"(t=$t, expected=$expected)")
 
     ExecStrategy.values.intersect(execStrats).foreach { strat =>
       try {

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -416,7 +416,7 @@ object TestUtils {
             eval(x, env, args, agg)
           case ExecStrategy.CxxCompile => nativeExecute(x, env, args, agg)
         }
-        assert(t.typeCheck(res))
+        assert(t.typeCheck(res), s"(res=$res, strategy=$strat")
         assert(t.valuesSimilar(res, expected), s"(res=$res, expect=$expected, strategy=$strat)")
       } catch {
         case e: Exception =>

--- a/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
@@ -166,32 +166,34 @@ class AggregatorsSuite extends SparkSuite {
   }
 
   @Test def collectAsSetBoolean() {
-    runAggregator(CollectAsSet(), TBoolean(), FastIndexedSeq(true, false, null, true, false), Set(true, false, null))
-    runAggregator(CollectAsSet(), TBoolean(), FastIndexedSeq(true, null, true), Set(true, null))
+    runAggregator(CollectAsSet(), TBoolean(), FastIndexedSeq(true, false, null, true, false), TSet(TBoolean()).literal(true, false, null))
+    runAggregator(CollectAsSet(), TBoolean(), FastIndexedSeq(true, null, true), TSet(TBoolean()).literal(true, null))
   }
 
   @Test def collectAsSetNumeric() {
-    runAggregator(CollectAsSet(), TInt32(), FastIndexedSeq(10, null, 5, 5, null), Set(10, null, 5))
-    runAggregator(CollectAsSet(), TInt64(), FastIndexedSeq(10L, null, 5L, 5L, null), Set(10L, null, 5L))
-    runAggregator(CollectAsSet(), TFloat32(), FastIndexedSeq(10f, null, 5f, 5f, null), Set(10f, null, 5f))
-    runAggregator(CollectAsSet(), TFloat64(), FastIndexedSeq(10d, null, 5d, 5d, null), Set(10d, null, 5d))
+    runAggregator(CollectAsSet(), TInt32(), FastIndexedSeq(10, null, 5, 5, null), TSet(TInt32()).literal(10, null, 5))
+    runAggregator(CollectAsSet(), TInt64(), FastIndexedSeq(10L, null, 5L, 5L, null), TSet(TInt64()).literal(10L, null, 5L))
+    runAggregator(CollectAsSet(), TFloat32(), FastIndexedSeq(10f, null, 5f, 5f, null), TSet(TFloat32()).literal(10f, null, 5f))
+    runAggregator(CollectAsSet(), TFloat64(), FastIndexedSeq(10d, null, 5d, 5d, null), TSet(TFloat64()).literal(10d, null, 5d))
   }
 
   @Test def collectAsSetString() {
-    runAggregator(CollectAsSet(), TString(), FastIndexedSeq("hello", null, "foo", null, "foo"), Set("hello", null, "foo"))
+    runAggregator(CollectAsSet(), TString(), FastIndexedSeq("hello", null, "foo", null, "foo"), TSet(TString()).literal("hello", null, "foo"))
   }
 
   @Test def collectAsSetArray() {
     val inputCollection = FastIndexedSeq(FastIndexedSeq(1, 2, 3), null, FastIndexedSeq(), null, FastIndexedSeq(1, 2, 3))
-    val expected = Set(FastIndexedSeq(1, 2, 3), null, FastIndexedSeq())
-    runAggregator(CollectAsSet(), TArray(TInt32()), inputCollection, expected)
+    val t = TArray(TInt32())
+    val expected = TSet(t).literal(FastIndexedSeq(1, 2, 3), null, FastIndexedSeq())
+    runAggregator(CollectAsSet(), t, inputCollection, expected)
   }
 
   @Test def collectAsSetStruct(): Unit = {
+    val t = TStruct("a" -> TInt32(), "b" -> TBoolean())
     runAggregator(CollectAsSet(),
-      TStruct("a" -> TInt32(), "b" -> TBoolean()),
+      t,
       FastIndexedSeq(Row(5, true), Row(3, false), null, Row(0, false), null, Row(5, true)),
-      Set(Row(5, true), Row(3, false), null, Row(0, false)))
+      TSet(t).literal(Row(5, true), Row(3, false), null, Row(0, false)))
   }
 
   @Test def callStats() {

--- a/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
@@ -115,7 +115,7 @@ class AggregatorsSuite extends SparkSuite {
     runAggregator(Counter(),
       TArray(TInt32()),
       FastIndexedSeq(FastIndexedSeq(), FastIndexedSeq(1, 2, 3), null, FastIndexedSeq(), FastIndexedSeq(1), null),
-      Map(FastIndexedSeq() -> 2L, FastIndexedSeq(1, 2, 3) -> 1L, FastIndexedSeq(1) -> 1L, (null, 2L)))
+      TDict(TArray(TInt32()), TInt32()).literal(FastIndexedSeq() -> 2L, FastIndexedSeq(1, 2, 3) -> 1L, FastIndexedSeq(1) -> 1L, (null, 2L)))
   }
 
   @Test def counterBoolean() {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -688,14 +688,14 @@ class IRSuite extends SparkSuite {
     assertEvalsTo(ToSet(NA(TArray(TInt32()))), null)
 
     val a = MakeArray(FastIndexedSeq(I32(-7), I32(2), NA(TInt32()), I32(2)), TArray(TInt32()))
-    assertEvalsTo(ToSet(a), Set(-7, 2, null))
+    assertEvalsTo(ToSet(a), TSet(TInt32()).literal(-7, 2, null))
   }
 
   @Test def testToArrayFromSet() {
     val t = TSet(TInt32())
     assertEvalsTo(ToArray(NA(t)), null)
     assertEvalsTo(ToArray(In(0, t)),
-      FastIndexedSeq((Set(-7, 2, null), t)),
+      FastIndexedSeq((TSet(TInt32()).literal(-7, 2, null), t)),
       FastIndexedSeq(-7, 2, null))
   }
 
@@ -1417,7 +1417,7 @@ class IRSuite extends SparkSuite {
 
     val collection1 = groupby(tuple("foo", 0), tuple("bar", 4), tuple("foo", -1), tuple("bar", 0), tuple("foo", 10), tuple("", 0))
 
-    assertEvalsTo(collection1, TDict(TInt32(), TArray(TInt32())).literal("" -> FastIndexedSeq(0), "bar" -> FastIndexedSeq(4, 0), "foo" -> FastIndexedSeq(0, -1, 10)))
+    assertEvalsTo(collection1, TDict(TString(), TArray(TInt32())).literal("" -> FastIndexedSeq(0), "bar" -> FastIndexedSeq(4, 0), "foo" -> FastIndexedSeq(0, -1, 10)))
   }
 
   @DataProvider(name = "compareDifferentTypes")

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -155,7 +155,7 @@ class OrderingSuite extends SparkSuite {
     val p = Prop.forAll(compareGen) { case (telt: TTuple, a: IndexedSeq[Row]@unchecked) =>
       val tdict = TDict(telt.types(0), telt.types(1))
       val array: IndexedSeq[Row] = a ++ a
-      val expectedKeys = array.filter(_ != null).map { case Row(k, v) => k }
+      val expectedKeys = TSet(telt.types(0)).toLiteral(array.filter(_ != null).map { case Row(k, v) => k }).toFastIndexedSeq
       assertEvalsTo(
         ArrayMap(ToArray(ToDict(In(0, TArray(telt)))),
         "x", GetField(Ref("x", -tdict.elementType), "key")),

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -155,7 +155,7 @@ class OrderingSuite extends SparkSuite {
     val p = Prop.forAll(compareGen) { case (telt: TTuple, a: IndexedSeq[Row]@unchecked) =>
       val tdict = TDict(telt.types(0), telt.types(1))
       val array: IndexedSeq[Row] = a ++ a
-      val expectedKeys = TSet(telt.types(0)).toLiteral(array.filter(_ != null).map { case Row(k, v) => k })
+      val expectedKeys = array.filter(_ != null).map { case Row(k, v) => k }
       assertEvalsTo(
         ArrayMap(ToArray(ToDict(In(0, TArray(telt)))),
         "x", GetField(Ref("x", -tdict.elementType), "key")),

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -12,6 +12,8 @@ import is.hail.utils._
 import org.apache.spark.sql.Row
 import org.testng.annotations.{DataProvider, Test}
 
+import scala.collection.immutable.TreeSet
+
 class OrderingSuite extends SparkSuite {
 
   implicit val execStrats = ExecStrategy.values
@@ -138,7 +140,7 @@ class OrderingSuite extends SparkSuite {
       val array = a ++ a
       assertEvalsTo(ToArray(ToSet(In(0, TArray(t)))),
         FastIndexedSeq(array -> TArray(t)),
-        expected = array.sorted(t.ordering.toOrdering).distinct)
+        TSet(t).toLiteral(array).toFastIndexedSeq)
       true
     }
     p.check()
@@ -211,7 +213,7 @@ class OrderingSuite extends SparkSuite {
         dict.getOrElse(testKey1, null))
 
       if (dict.nonEmpty) {
-        val testKey2 = dict.keys.toSeq.head
+        val testKey2 = dict.keys.head
         val expected2 = dict(testKey2)
         assertEvalsTo(invoke("get", In(0, tdict), In(1, -tdict.keyType)),
           FastIndexedSeq(dict -> tdict,

--- a/hail/src/test/scala/is/hail/expr/ir/SetFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/SetFunctionsSuite.scala
@@ -15,17 +15,19 @@ class SetFunctionsSuite extends TestNGSuite {
 
   implicit val execStrats = ExecStrategy.javaOnly
 
+  val t = TSet(TInt32())
+
   @Test def toSet() {
-    assertEvalsTo(IRSet(3, 7), Set(3, 7))
-    assertEvalsTo(IRSet(3, null, 7), Set(null, 3, 7))
+    assertEvalsTo(IRSet(3, 7), t.literal(3, 7))
+    assertEvalsTo(IRSet(3, null, 7), t.literal(null, 3, 7))
     assertEvalsTo(nas, null)
     assertEvalsTo(ToSet(naa), null)
-    assertEvalsTo(invoke("toSet", IRArray(3, 7)), Set(3, 7))
-    assertEvalsTo(invoke("toSet", IRArray(3, null, 7)), Set(null, 3, 7))
+    assertEvalsTo(invoke("toSet", IRArray(3, 7)), t.literal(3, 7))
+    assertEvalsTo(invoke("toSet", IRArray(3, null, 7)), t.literal(null, 3, 7))
     assertEvalsTo(invoke("toSet", naa), null)
   }
 
-  @Test def isEmpty() {
+  @Test def testIsEmpty() {
     assertEvalsTo(invoke("isEmpty", IRSet(3, 7)), false)
     assertEvalsTo(invoke("isEmpty", IRSet(3, null, 7)), false)
     assertEvalsTo(invoke("isEmpty", IRSet()), true)
@@ -49,19 +51,19 @@ class SetFunctionsSuite extends TestNGSuite {
 
   @Test def remove() {
     val s = IRSet(3, null, 7)
-    assertEvalsTo(invoke("remove", s, I32(3)), Set(null, 7))
-    assertEvalsTo(invoke("remove", s, I32(4)), Set(null, 3, 7))
-    assertEvalsTo(invoke("remove", s, NA(TInt32())), Set(3, 7))
-    assertEvalsTo(invoke("remove", IRSet(3, 7), NA(TInt32())), Set(3, 7))
+    assertEvalsTo(invoke("remove", s, I32(3)), t.literal(null, 7))
+    assertEvalsTo(invoke("remove", s, I32(4)), t.literal(null, 3, 7))
+    assertEvalsTo(invoke("remove", s, NA(TInt32())), t.literal(3, 7))
+    assertEvalsTo(invoke("remove", IRSet(3, 7), NA(TInt32())), t.literal(3, 7))
   }
 
   @Test def add() {
     val s = IRSet(3, null, 7)
-    assertEvalsTo(invoke("add", s, I32(3)), Set(null, 3, 7))
-    assertEvalsTo(invoke("add", s, I32(4)), Set(null, 3, 4, 7))
-    assertEvalsTo(invoke("add", s, I32(4)), Set(null, 3, 4, 7))
-    assertEvalsTo(invoke("add", s, NA(TInt32())), Set(null, 3, 7))
-    assertEvalsTo(invoke("add", IRSet(3, 7), NA(TInt32())), Set(null, 3, 7))
+    assertEvalsTo(invoke("add", s, I32(3)), t.literal(null, 3, 7))
+    assertEvalsTo(invoke("add", s, I32(4)), t.literal(null, 3, 4, 7))
+    assertEvalsTo(invoke("add", s, I32(4)), t.literal(null, 3, 4, 7))
+    assertEvalsTo(invoke("add", s, NA(TInt32())), t.literal(null, 3, 7))
+    assertEvalsTo(invoke("add", IRSet(3, 7), NA(TInt32())), t.literal(null, 3, 7))
   }
 
   @Test def isSubset() {
@@ -73,18 +75,18 @@ class SetFunctionsSuite extends TestNGSuite {
   }
 
   @Test def union() {
-    assertEvalsTo(invoke("union", IRSet(3, null, 7), IRSet(3, 8)), Set(null, 3, 7, 8))
-    assertEvalsTo(invoke("union", IRSet(3, 7), IRSet(3, 8, null)), Set(null, 3, 7, 8))
+    assertEvalsTo(invoke("union", IRSet(3, null, 7), IRSet(3, 8)), t.literal(null, 3, 7, 8))
+    assertEvalsTo(invoke("union", IRSet(3, 7), IRSet(3, 8, null)), t.literal(null, 3, 7, 8))
   }
 
   @Test def intersection() {
-    assertEvalsTo(invoke("intersection", IRSet(3, null, 7), IRSet(3, 8)), Set(3))
-    assertEvalsTo(invoke("intersection", IRSet(3, null, 7), IRSet(3, 8, null)), Set(null, 3))
+    assertEvalsTo(invoke("intersection", IRSet(3, null, 7), IRSet(3, 8)), t.literal(3))
+    assertEvalsTo(invoke("intersection", IRSet(3, null, 7), IRSet(3, 8, null)), t.literal(null, 3))
   }
 
   @Test def difference() {
-    assertEvalsTo(invoke("difference", IRSet(3, null, 7), IRSet(3, 8)), Set(null, 7))
-    assertEvalsTo(invoke("difference", IRSet(3, null, 7), IRSet(3, 8, null)), Set(7))
+    assertEvalsTo(invoke("difference", IRSet(3, null, 7), IRSet(3, 8)), t.literal(null, 7))
+    assertEvalsTo(invoke("difference", IRSet(3, null, 7), IRSet(3, 8, null)), t.literal(7))
   }
 
   @Test def sum() {

--- a/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/SimplifySuite.scala
@@ -77,13 +77,13 @@ class SimplifySuite extends SparkSuite {
 
 
     assertEvalsTo(invoke("contains", ToArray(In(0, TSet(TString()))), Str("a")),
-      FastIndexedSeq(Set("a") -> TSet(TString())),
+      FastIndexedSeq(TSet(TString()).literal("a") -> TSet(TString())),
       true)
   }
 
   @Test def testTableCountExplodeSetRewrite() {
     var ir: TableIR = TableRange(1, 1)
-    ir = TableMapRows(ir, InsertFields(Ref("row", ir.typ.rowType), Seq("foo" -> Literal(TSet(TInt32()), Set(1)))))
+    ir = TableMapRows(ir, InsertFields(Ref("row", ir.typ.rowType), Seq("foo" -> Literal(TSet(TInt32()), TSet(TInt32()).literal(1)))))
     ir = TableExplode(ir, FastIndexedSeq("foo"))
     assertEvalsTo(TableCount(ir), 1L)
   }

--- a/hail/src/test/scala/is/hail/expr/ir/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TestUtils.scala
@@ -6,11 +6,11 @@ import is.hail.utils.{FastIndexedSeq, FastSeq}
 import is.hail.variant.Call
 
 object TestUtils {
-  def toIRInt(i: Integer): IR =
+  def toIRInt(i: Any): IR =
     if (i == null)
       NA(TInt32())
     else
-      I32(i)
+      I32(i.asInstanceOf[Int])
 
   def toIRDouble(d: java.lang.Double): IR =
     if (d == null)
@@ -18,19 +18,19 @@ object TestUtils {
     else
       F64(d)
 
-  def toIRPair(p: (Integer, Integer)): IR =
+  def toIRPair(p: (Any, Any)): IR =
     if (p == null)
       NA(TTuple(TInt32(), TInt32()))
     else
       MakeTuple(Seq(toIRInt(p._1), toIRInt(p._2)))
 
-  def toIRArray(a: Seq[Integer]): IR =
+  def toIRArray(a: Seq[Any]): IR =
     if (a == null)
       NA(TArray(TInt32()))
     else
       MakeArray(a.map(toIRInt), TArray(TInt32()))
 
-  def IRArray(a: Integer*): IR = toIRArray(a)
+  def IRArray(a: Any*): IR = toIRArray(a)
 
   def toIRStringArray(a: Seq[String]): IR =
     if (a == null)
@@ -50,27 +50,27 @@ object TestUtils {
 
   def IRDoubleArray(a: java.lang.Double*): IR = toIRDoubleArray(a)
 
-  def toIRPairArray(a: Seq[(Integer, Integer)]): IR =
+  def toIRPairArray(a: Seq[(Any, Any)]): IR =
     if (a == null)
       NA(TArray(TTuple(TInt32(), TInt32())))
     else
       MakeArray(a.map(toIRPair), TArray(TTuple(TInt32(), TInt32())))
 
-  def toIRDict(a: Seq[(Integer, Integer)]): IR =
+  def toIRDict(a: Seq[(Any, Any)]): IR =
     if (a == null)
       NA(TDict(TInt32(), TInt32()))
     else
       ToDict(MakeArray(a.map(toIRPair), TArray(TTuple(TInt32(), TInt32()))))
 
-  def IRDict(a: (Integer, Integer)*): IR = toIRDict(a)
+  def IRDict(a: (Any, Any)*): IR = toIRDict(a)
 
-  def toIRSet(a: Seq[Integer]): IR =
+  def toIRSet(a: Seq[Any]): IR =
     if (a == null)
       NA(TSet(TInt32()))
   else
       ToSet(toIRArray(a))
 
-  def IRSet(a: Integer*): IR = toIRSet(a)
+  def IRSet(a: Any*): IR = toIRSet(a)
 
   def IRCall(c: Call): IR = Cast(I32(c), TCall())
 


### PR DESCRIPTION
Set and Dict used an inconsistent definition in the JVM backend, and what's more, it is different from the Scala code.  This fixes that, and in particular, it is technically a breaking change.

There are two orderings on types, the default coming from <, <=, etc. and a total ordering coming from `compare`.  The default can compare "strangely", e.g. for Doubles every comparison with nan returns false.  This code changes Set and Dict to use the total ordering on types for comparison of elements and keys.  The representation of Set and Dict in Java are now SortedSet and SortedMap, which are implemented as TreeSet and TreeMap, which is always parameterized to take the total ordering.

Note, I left the tests disabled because there's another comparison bug related to intervals I'm sorting out with @patrick-schultz.