### PR TITLE
[cloudtools] get rid of conda bootstrap

### DIFF
--- a/cloudtools/cloudtools/init_notebook.py
+++ b/cloudtools/cloudtools/init_notebook.py
@@ -87,15 +87,16 @@ if role == 'Master':
     else:
         pip_pkgs.extend(user_pkgs.split('|'))
 
-    safe_call('/opt/conda/bin/conda', 'update', 'setuptools')
+    safe_call('/opt/conda/default/bin/conda', 'update', 'setuptools')
 
     print('conda packages are {}'.format(conda_pkgs))
-    command = ['/opt/conda/bin/conda', 'install']
+    command = ['/opt/conda/default/bin/conda', 'install']
+
     command.extend(conda_pkgs)
     safe_call(*command)
 
     print('pip packages are {}'.format(pip_pkgs))
-    command = ['/opt/conda/bin/pip', 'install']
+    command = ['/opt/conda/default/bin/pip', 'install']
     command.extend(pip_pkgs)
     safe_call(*command)
 
@@ -115,8 +116,8 @@ if role == 'Master':
         'PYTHONPATH':
          '/usr/lib/spark/python/:{}:/home/hail/hail.zip'.format(py4j),
         'SPARK_HOME': '/usr/lib/spark/',
-        'PYSPARK_PYTHON': '/opt/conda/bin/python',
-        'PYSPARK_DRIVER_PYTHON': '/opt/conda/bin/python'
+        'PYSPARK_PYTHON': '/opt/conda/default/bin/python',
+        'PYSPARK_DRIVER_PYTHON': '/opt/conda/default/bin/python'
     }
 
     print('setting environment')
@@ -143,7 +144,7 @@ if role == 'Master':
     # create Jupyter kernel spec file
     kernel = {
         'argv': [
-            '/opt/conda/bin/python',
+            '/opt/conda/default/bin/python',
             '-m',
             'ipykernel',
             '-f',
@@ -189,7 +190,7 @@ if role == 'Master':
             'User=root',
             'Group=root',
             'WorkingDirectory=/home/hail/',
-            'ExecStart=/opt/conda/bin/python /opt/conda/bin/jupyter notebook --allow-root',
+            'ExecStart=/opt/conda/default/bin/python /opt/conda/default/bin/jupyter notebook --allow-root',
             'Restart=always',
             'RestartSec=1',
             '[Install]',

--- a/cloudtools/cloudtools/start.py
+++ b/cloudtools/cloudtools/start.py
@@ -137,8 +137,7 @@ def main(args):
 
     # default initialization script to start up cluster with
     conf.extend_flag('initialization-actions',
-                     ['gs://dataproc-initialization-actions/conda/bootstrap-conda.sh',
-                      init_script])
+                     [init_script])
     # add VEP init script
     if args.vep:
         if args.version == '0.1':


### PR DESCRIPTION
These changes should be integrated into the next cloud tools package deployment. Not sure whether the changes should be here or the old cloud tools repo.