### PR TITLE
[hail] Extend AggArrayPerElement to support a "knownLength" argument.

### DIFF
--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1063,7 +1063,7 @@ class AggArrayPerElement(IR):
         return AggArrayPerElement(array, self.element_name, self.index_name, agg_ir, self.is_scan)
 
     def head_str(self):
-        return f'{escape_id(self.element_name)} {escape_id(self.index_name)} {self.is_scan}'
+        return f'{escape_id(self.element_name)} {escape_id(self.index_name)} {self.is_scan} False'
 
     def _eq(self, other):
         return self.element_name == other.element_name and self.index_name == other.index_name and  self.is_scan == other.is_scan

--- a/hail/src/main/scala/is/hail/annotations/aggregators/ArrayElementsAggregator.scala
+++ b/hail/src/main/scala/is/hail/annotations/aggregators/ArrayElementsAggregator.scala
@@ -12,15 +12,20 @@ final case class ArrayElementsAggregator(rvAggs: Array[RegionValueAggregator]) e
     ArrayElementsAggregator(rvAggs)
   }
 
+  def broadcast(n: Int): Unit = {
+    assert(a == null)
+    a = new Array[Array[RegionValueAggregator]](n)
+    var i = 0
+    while (i < n) {
+      a(i) = rvAggs.map(_.copy())
+      i += 1
+    }
+  }
+
   def checkSizeOrBroadcast(n: Int): Unit = {
-    if (a == null) {
-      a = new Array[Array[RegionValueAggregator]](n)
-      var i = 0
-      while (i < n) {
-        a(i) = rvAggs.map(_.copy())
-        i += 1
-      }
-    } else {
+    if (a == null)
+      broadcast(n)
+    else {
       if (n != a.length)
         fatal(s"cannot apply array aggregation: size mismatch: $n, ${ a.length }")
     }

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -22,7 +22,7 @@ object Bindings {
     case ArrayAggScan(a, name, _) => if (i == 1) FastIndexedSeq(name -> a.typ.asInstanceOf[TStreamable].elementType) else empty
     case ArrayLeftJoinDistinct(ll, rr, l, r, _, _) => if (i == 2 || i == 3) Array(l -> -coerce[TStreamable](ll.typ).elementType, r -> -coerce[TStreamable](rr.typ).elementType) else empty
     case ArraySort(a, left, right, _) => if (i == 1) Array(left -> -coerce[TStreamable](a.typ).elementType, right -> -coerce[TStreamable](a.typ).elementType) else empty
-    case AggArrayPerElement(a, _, indexName, _, _) => if (i == 1) FastIndexedSeq(indexName -> TInt32()) else empty
+    case AggArrayPerElement(a, _, indexName, _, _, _) => if (i == 1) FastIndexedSeq(indexName -> TInt32()) else empty
     case NDArrayMap(nd, name, _) => if (i == 1) Array(name -> -coerce[TNDArray](nd.typ).elementType) else empty
     case NDArrayMap2(l, r, lName, rName, _) => if (i == 2) Array(lName -> -coerce[TNDArray](l.typ).elementType, rName -> -coerce[TNDArray](r.typ).elementType) else empty
     case CollectDistributedArray(contexts, globals, cname, gname, _) => if (i == 2) Array(cname -> -coerce[TArray](contexts.typ).elementType, gname -> globals.typ) else empty
@@ -64,7 +64,7 @@ object AggBindings {
     x match {
       case AggLet(name, value, _, false) => if (i == 1) wrapped(FastIndexedSeq(name -> value.typ)) else base
       case AggExplode(a, name, _, false) => if (i == 1) wrapped(FastIndexedSeq(name -> a.typ.asInstanceOf[TIterable].elementType)) else base
-      case AggArrayPerElement(a, elementName, _, _, false) => if (i == 1) wrapped(FastIndexedSeq(elementName -> a.typ.asInstanceOf[TIterable].elementType)) else base
+      case AggArrayPerElement(a, elementName, _, _, _, false) => if (i == 1) wrapped(FastIndexedSeq(elementName -> a.typ.asInstanceOf[TIterable].elementType)) else base
       case ArrayAgg(a, name, _) => if (i == 1) Some(FastIndexedSeq(name -> a.typ.asInstanceOf[TIterable].elementType)) else base
       case TableAggregate(child, _) => if (i == 1) wrapped(child.typ.rowEnv.m) else throw new UnsupportedOperationException
       case MatrixAggregate(child, _) => if (i == 1) Some(child.typ.entryEnv.m) else throw new UnsupportedOperationException
@@ -106,7 +106,7 @@ object ScanBindings {
     x match {
       case AggLet(name, value, _, true) => if (i == 1) wrapped(FastIndexedSeq(name -> value.typ)) else base
       case AggExplode(a, name, _, true) => if (i == 1) wrapped(FastIndexedSeq(name -> a.typ.asInstanceOf[TIterable].elementType)) else base
-      case AggArrayPerElement(a, elementName, _, _, true) => if (i == 1) wrapped(FastIndexedSeq(elementName -> a.typ.asInstanceOf[TIterable].elementType)) else base
+      case AggArrayPerElement(a, elementName, _, _, _, true) => if (i == 1) wrapped(FastIndexedSeq(elementName -> a.typ.asInstanceOf[TIterable].elementType)) else base
       case ArrayAggScan(a, name, _) => if (i == 1) Some(FastIndexedSeq(name -> a.typ.asInstanceOf[TIterable].elementType)) else base
       case _ => base
     }

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -111,7 +111,7 @@ object Children {
       Array(array, aggBody)
     case AggGroupBy(key, aggIR, _) =>
       Array(key, aggIR)
-    case AggArrayPerElement(a, _, _, aggBody, _) => Array(a, aggBody)
+    case AggArrayPerElement(a, _, _, aggBody, knownLength, _) => Array(a, aggBody) ++ knownLength.toArray[IR]
     case MakeStruct(fields) =>
       fields.map(_._2).toFastIndexedSeq
     case SelectFields(old, fields) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -151,9 +151,12 @@ object Copy {
       case AggGroupBy(_, _, isScan) =>
         val IndexedSeq(key: IR, aggIR: IR) = newChildren
         AggGroupBy(key, aggIR, isScan)
-      case AggArrayPerElement(a, elementName, indexName, aggBody, isScan) =>
-        val IndexedSeq(newA: IR, newAggBody: IR) = newChildren
-        AggArrayPerElement(newA, elementName, indexName, newAggBody, isScan)
+      case AggArrayPerElement(_, elementName, indexName, _, _, isScan) =>
+        val (newA, newAggBody, newKnownLength) = newChildren match {
+          case IndexedSeq(newA: IR, newAggBody: IR) => (newA, newAggBody, None)
+          case IndexedSeq(newA: IR, newAggBody: IR, newKnownLength: IR) => (newA, newAggBody, Some(newKnownLength))
+        }
+        AggArrayPerElement(newA, elementName, indexName, newAggBody, newKnownLength, isScan)
       case MakeStruct(fields) =>
         assert(fields.length == newChildren.length)
         MakeStruct(fields.zip(newChildren).map { case ((n, _), a) => (n, a.asInstanceOf[IR]) })

--- a/hail/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -183,12 +183,13 @@ object ExtractAggregators {
         val rt = TArray(TTuple(nestedAggs.map(_.rt): _*))
         newRef._typ = -rt.elementType
 
-        val (knownLengthSig, knownLengthIRSeq) = knownLength.map(l => (FastSeq(TInt32()), FastSeq(l)))
-          .getOrElse((FastSeq(), FastSeq()))
-        val aggSigCheck = AggSignature(AggElementsLengthCheck(), FastSeq(),
-          Some(FastSeq(TVoid) ++ knownLengthSig),
+        val (knownLengthSig, knownLengthIRSeq) = knownLength
+          .map(l => (FastIndexedSeq[Type](TInt32()), FastIndexedSeq[IR](l)))
+          .getOrElse((FastIndexedSeq[Type](), FastIndexedSeq[IR]()))
+        val aggSigCheck = AggSignature(AggElementsLengthCheck(), FastSeq[Type](),
+          Some(FastSeq[Type](TVoid) ++ knownLengthSig),
           FastSeq(TInt32()))
-        val aggSig = AggSignature(AggElements(), FastSeq(), None, FastSeq(TInt32(), TVoid))
+        val aggSig = AggSignature(AggElements(), FastSeq[Type](), None, FastSeq(TInt32(), TVoid))
 
         val aUID = genUID()
         val iUID = genUID()
@@ -197,7 +198,7 @@ object ExtractAggregators {
         val i = ab.length
         ab += IRAgg[RVAgg](i, agg, rt)
         ab2 += AggOps(
-          Some(InitOp(i, FastIndexedSeq(Begin(initOp.flatten.toFastIndexedSeq)) ++ knownLengthIRSeq, aggSigCheck)),
+          Some(InitOp(i, FastIndexedSeq[IR](Begin(initOp.flatten.toFastIndexedSeq)) ++ knownLengthIRSeq, aggSigCheck)),
           Let(
             aUID,
             a,

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -257,7 +257,7 @@ final case class AggExplode(array: IR, name: String, aggBody: IR, isScan: Boolea
 
 final case class AggGroupBy(key: IR, aggIR: IR, isScan: Boolean) extends IR
 
-final case class AggArrayPerElement(a: IR, elementName: String, indexName: String, aggBody: IR, isScan: Boolean) extends IR
+final case class AggArrayPerElement(a: IR, elementName: String, indexName: String, aggBody: IR, knownLength: Option[IR], isScan: Boolean) extends IR
 
 final case class ApplyAggOp(constructorArgs: IndexedSeq[IR], initOpArgs: Option[IndexedSeq[IR]], seqOpArgs: IndexedSeq[IR], aggSig: AggSignature) extends IR {
   assert(!(seqOpArgs ++ constructorArgs ++ initOpArgs.getOrElse(FastIndexedSeq.empty[IR])).exists(ContainsScan(_)))

--- a/hail/src/main/scala/is/hail/expr/ir/IRBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IRBuilder.scala
@@ -261,7 +261,7 @@ object IRBuilder {
       ArrayAgg(array, f.s.name, f.body(env.bind(f.s.name -> eltType)))
     }
 
-    def aggElements(elementsSym: Symbol, indexSym: Symbol)(aggBody: IRProxy): IRProxy = (env: E) => {
+    def aggElements(elementsSym: Symbol, indexSym: Symbol, knownLength: Option[IRProxy])(aggBody: IRProxy): IRProxy = (env: E) => {
       val array = ir(env)
       val eltType = array.typ.asInstanceOf[TArray].elementType
       AggArrayPerElement(
@@ -269,6 +269,7 @@ object IRBuilder {
         elementsSym.name,
         indexSym.name,
         aggBody.apply(env.bind(elementsSym.name -> eltType, indexSym.name -> TInt32())),
+        knownLength.map(_ (env)),
         isScan = false)
     }
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -133,7 +133,7 @@ object InferType {
         aggBody.typ
       case AggGroupBy(key, aggIR, _) =>
         TDict(key.typ, aggIR.typ)
-      case AggArrayPerElement(a, _, _, aggBody, _) => TArray(aggBody.typ)
+      case AggArrayPerElement(a, _, _, aggBody, _, _) => TArray(aggBody.typ)
       case ApplyAggOp(_, _, _, aggSig) =>
         AggOp.getType(aggSig)
       case ApplyScanOp(_, _, _, aggSig) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -515,7 +515,7 @@ object Interpret {
           interpret(aggIR, agg=Some((row, aggElementType)))
         }
 
-      case x@AggArrayPerElement(a, elementName, indexName, aggBody, isScan) => ???
+      case x@AggArrayPerElement(a, elementName, indexName, aggBody, knownLength, isScan) => ???
       case x@ApplyAggOp(constructorArgs, initOpArgs, seqOpArgs, aggSig) =>
         assert(AggOp.getType(aggSig) == x.typ)
 

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -328,7 +328,7 @@ object LowerMatrixIR {
       lower(child)
         .aggregateByKey(
           reSub.insertFields(entriesField -> irRange(0, 'global (colsField).len)
-            .aggElements('__element_idx, '__result_idx)(
+            .aggElements('__element_idx, '__result_idx, Some('global(colsField).len))(
               let(sa = 'global (colsField)('__result_idx)) {
                 aggLet(sa = 'global (colsField)('__element_idx),
                   g = 'row (entriesField)('__element_idx)) {

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -316,12 +316,14 @@ case class MatrixRangeReader(nRows: Int, nCols: Int, nPartitions: Option[Int]) e
   override def lower(mr: MatrixRead): TableIR = {
     val uid1 = Symbol(genUID())
 
-    TableRange(nRows, nPartitions.getOrElse(HailContext.get.sc.defaultParallelism))
+    val nRowsAdj = if (mr.dropRows) 0 else nRows
+    val nColsAdj = if (mr.dropCols) 0 else nCols
+    TableRange(nRowsAdj, nPartitions.getOrElse(HailContext.get.sc.defaultParallelism))
       .rename(Map("idx" -> "row_idx"))
       .mapGlobals(makeStruct(LowerMatrixIR.colsField ->
-        irRange(0, nCols).map('i ~> makeStruct('col_idx -> 'i))))
+        irRange(0, nColsAdj).map('i ~> makeStruct('col_idx -> 'i))))
       .mapRows('row.insertFields(LowerMatrixIR.entriesField ->
-        irRange(0, nCols).map('i ~> makeStruct())))
+        irRange(0, nColsAdj).map('i ~> makeStruct())))
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/NormalizeNames.scala
@@ -153,14 +153,14 @@ class NormalizeNames(normFunction: Int => String, allowFreeVariables: Boolean = 
         else
           env.promoteAgg
         AggGroupBy(normalize(key, keyEnv), normalize(aggIR), isScan)
-      case AggArrayPerElement(a, elementName, indexName, aggBody, isScan) =>
+      case AggArrayPerElement(a, elementName, indexName, aggBody, knownLength, isScan) =>
         val newElementName = gen()
         val newIndexName = gen()
         val (aEnv, bodyEnv) = if (isScan)
           env.promoteScan -> env.bindScan(elementName, newElementName)
         else
           env.promoteAgg -> env.bindAgg(elementName, newElementName)
-        AggArrayPerElement(normalize(a, aEnv), newElementName, newIndexName, normalize(aggBody, bodyEnv.bindEval(indexName, newIndexName)), isScan)
+        AggArrayPerElement(normalize(a, aEnv), newElementName, newIndexName, normalize(aggBody, bodyEnv.bindEval(indexName, newIndexName)), knownLength.map(normalize(_, env)), isScan)
       case ApplyAggOp(ctorArgs, initOpArgs, seqOpArgs, aggSig) =>
         ApplyAggOp(ctorArgs.map(a => normalize(a)),
           initOpArgs.map(_.map(a => normalize(a))),

--- a/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Optimize.scala
@@ -16,9 +16,9 @@ object Optimize {
     while (iter < maxIter && ir != last) {
       last = ir
       ir = FoldConstants(ir, canGenerateLiterals = canGenerateLiterals)
+      ir = ExtractIntervalFilters(ir)
       ir = Simplify(ir)
       ir = ForwardLets(ir)
-      ir = ExtractIntervalFilters(ir)
       ir = ForwardRelationalLets(ir)
       ir = PruneDeadFields(ir)
 

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -770,11 +770,13 @@ object IRParser {
         val elementName = identifier(it)
         val indexName = identifier(it)
         val isScan = boolean_literal(it)
+        val hasKnownLength = boolean_literal(it)
         val a = ir_value_expr(env)(it)
         val aggBody = ir_value_expr(env
           + (elementName -> coerce[TStreamable](a.typ).elementType)
           + (indexName -> TInt32()))(it)
-        AggArrayPerElement(a, elementName, indexName, aggBody, isScan)
+        val knownLength = if (hasKnownLength) Some(ir_value_expr(env)(it)) else None
+        AggArrayPerElement(a, elementName, indexName, aggBody, knownLength, isScan)
       case "ApplyAggOp" =>
         val aggOp = agg_op(it)
         val ctorArgs = ir_value_exprs(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -188,8 +188,8 @@ object Pretty {
             case AggExplode(_, name, _, isScan) => prettyIdentifier(name) + " " + prettyBooleanLiteral(isScan)
             case AggFilter(_, _, isScan) => prettyBooleanLiteral(isScan)
             case AggGroupBy(_, _, isScan) => prettyBooleanLiteral(isScan)
-            case AggArrayPerElement(_, elementName, indexName, _, isScan) =>
-              prettyIdentifier(elementName) + " " + prettyIdentifier(indexName) + " " + prettyBooleanLiteral(isScan)
+            case AggArrayPerElement(_, elementName, indexName, _, knownLength, isScan) =>
+              prettyIdentifier(elementName) + " " + prettyIdentifier(indexName) + " " + prettyBooleanLiteral(isScan) + " " + prettyBooleanLiteral(knownLength.isDefined)
             case NDArrayMap(_, name, _) => prettyIdentifier(name)
             case NDArrayMap2(_, _, lName, rName, _) => prettyIdentifier(lName) + " " + prettyIdentifier(rName)
             case NDArrayReindex(_, indexExpr) => prettyInts(indexExpr)

--- a/hail/src/main/scala/is/hail/expr/ir/Scope.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Scope.scala
@@ -6,7 +6,7 @@ object UsesAggEnv {
     case AggGroupBy(_, _, false) => i == 0
     case AggFilter(_, _, false) => i == 0
     case AggExplode(_, _, _, false) => i == 0
-    case AggArrayPerElement(_, _, _, _, false) => i == 0
+    case AggArrayPerElement(_, _, _, _, _, false) => i == 0
     case ApplyAggOp(ctor, initOp, _, _) => i >= ctor.length + initOp.map(_.length).getOrElse(0)
     case _ => false
   }
@@ -18,7 +18,7 @@ object UsesScanEnv {
     case AggGroupBy(_, _, true) => i == 0
     case AggFilter(_, _, true) => i == 0
     case AggExplode(_, _, _, true) => i == 0
-    case AggArrayPerElement(_, _, _, _, true) => i == 0
+    case AggArrayPerElement(_, _, _, _, _, true) => i == 0
     case ApplyScanOp(ctor, initOp, _, _) => i >= ctor.length + initOp.map(_.length).getOrElse(0)
     case _ => false
   }

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -243,8 +243,9 @@ object TypeCheck {
         assert(x.typ == aggBody.typ)
       case x@AggGroupBy(key, aggIR, _) =>
         assert(x.typ == TDict(key.typ, aggIR.typ))
-      case x@AggArrayPerElement(a, _, _, aggBody, _) =>
+      case x@AggArrayPerElement(a, _, _, aggBody, knownLength, _) =>
         assert(x.typ == TArray(aggBody.typ))
+        assert(knownLength.forall(_.typ == TInt32()))
       case x@InitOp(i, args, aggSig) =>
         assert(Some(args.map(_.typ)) == aggSig.initOpArgs)
         assert(i.typ.isInstanceOf[TInt32])

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -684,6 +684,7 @@ class PruneSuite extends SparkSuite {
       "bar",
       ApplyAggOp(FastIndexedSeq(), None, FastIndexedSeq(select),
         AggSignature(Collect(), FastIndexedSeq(), None, FastIndexedSeq(select.typ))),
+      None,
       false),
       TArray(TArray(TStruct("a" -> TInt32()))),
       Array(TArray(TStruct("a" -> TInt32())),


### PR DESCRIPTION
This is required to implement lowering for MatrixMapCols (coming after
a dependent PR goes in). We lower the per-column aggregations to an
`AggArrayPerElement`, but if there are no rows, the result would be
missing.

This PR will allow us to feed in the known number of columns as the
base case.