### PR TITLE
[batch] fix cancelled, created jobs

### DIFF
--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -330,7 +330,7 @@ class Job:
                        callback=record['callback'], userdata=userdata, user=record['user'],
                        always_run=record['always_run'], pvc_name=record['pvc_name'], pod_name=record['pod_name'],
                        exit_codes=exit_codes, duration=record['duration'], tasks=tasks,
-                       task_idx=record['task_idx'], state=record['state'], cancelled=record['cancelled'])
+                       task_idx=record['task_idx'], state=record['state'])
         return None
 
     @staticmethod
@@ -354,7 +354,6 @@ class Job:
         duration = 0
         task_idx = 0
         state = 'Created'
-        cancelled = False
         user = userdata['username']
 
         tasks = [JobTask.copy_task('input', input_files),
@@ -373,7 +372,6 @@ class Job:
                                       tasks=json.dumps([jt.to_dict() for jt in tasks]),
                                       task_idx=task_idx,
                                       always_run=always_run,
-                                      cancelled=cancelled,
                                       duration=duration,
                                       userdata=json.dumps(userdata),
                                       user=user)
@@ -381,7 +379,7 @@ class Job:
         job = Job(id=id, batch_id=batch_id, attributes=attributes, callback=callback,
                   userdata=userdata, user=user, always_run=always_run, pvc_name=pvc_name,
                   pod_name=pod_name, exit_codes=exit_codes, duration=duration, tasks=tasks,
-                  task_idx=task_idx, state=state, cancelled=cancelled)
+                  task_idx=task_idx, state=state)
 
         for parent in parent_ids:
             await db.jobs_parents.new_record(job_id=id,
@@ -398,7 +396,7 @@ class Job:
         return job
 
     def __init__(self, id, batch_id, attributes, callback, userdata, user, always_run,
-                 pvc_name, pod_name, exit_codes, duration, tasks, task_idx, state, cancelled):
+                 pvc_name, pod_name, exit_codes, duration, tasks, task_idx, state):
         self.id = id
         self.batch_id = batch_id
         self.attributes = attributes
@@ -415,7 +413,6 @@ class Job:
         self._task_idx = task_idx
         self._current_task = tasks[task_idx] if task_idx < len(tasks) else None
         self._state = state
-        self._cancelled = cancelled
 
     async def refresh_parents_and_maybe_create(self):
         for record in await db.jobs.get_parents(self.id):
@@ -449,8 +446,7 @@ class Job:
         incomplete_parent_ids = await db.jobs.get_incomplete_parents(self.id)
         if self._state == 'Created' and not incomplete_parent_ids:
             parents = [Job.from_record(record) for record in await db.jobs.get_parents(self.id)]
-            if (self.always_run or
-                    (all(p.is_successful() for p in parents) and not self._cancelled)):
+            if self.always_run or all(p.is_successful() for p in parents):
                 log.info(f'all parents complete for {self.id},'
                          f' creating pod')
                 await self.set_state('Ready')
@@ -464,8 +460,7 @@ class Job:
         if self.is_complete():
             return
         if self._state == 'Created':
-            self._cancelled = True
-            await db.jobs.update_record(self.id, cancelled=True)
+            await self.set_state('Cancelled')
         else:
             assert self._state == 'Ready', self._state
             await self.set_state('Cancelled')  # must call before deleting resources to prevent race conditions

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -460,7 +460,8 @@ class Job:
         if self.is_complete():
             return
         if self._state == 'Created':
-            await self.set_state('Cancelled')
+            if not self.always_run:
+                await self.set_state('Cancelled')
         else:
             assert self._state == 'Ready', self._state
             await self.set_state('Cancelled')  # must call before deleting resources to prevent race conditions

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -464,8 +464,9 @@ class Job:
                 await self.set_state('Cancelled')
         else:
             assert self._state == 'Ready', self._state
-            await self.set_state('Cancelled')  # must call before deleting resources to prevent race conditions
-            await self._delete_k8s_resources()
+            if not self.always_run:
+                await self.set_state('Cancelled')  # must call before deleting resources to prevent race conditions
+                await self._delete_k8s_resources()
 
     def is_complete(self):
         return self._state in ('Complete', 'Cancelled')

--- a/batch/create-batch-tables.sql
+++ b/batch/create-batch-tables.sql
@@ -29,7 +29,6 @@ CREATE TABLE IF NOT EXISTS `jobs` (
   `callback` TEXT(65535),
   `task_idx` INT NOT NULL,
   `always_run` BOOLEAN NOT NULL,
-  `cancelled` BOOLEAN NOT NULL,
   `time_created` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   `duration` BIGINT,
   `userdata` TEXT(65535) NOT NULL,


### PR DESCRIPTION
@cseed This fixes a bug in cancel where a job that was created but not ready was never actually cancelled. I discovered it with my PR that creates the entire batch in one atomic call. I don't think this change requires us to reset the database (just deleted a field), but if so I should probably combine this with another database change.

Can you confirm that changing (state=Created, cancelled=True) -> Cancelled doesn't change the meaning of the 'Cancelled' state how you intended?