### PR TITLE
[hail] add releaseJar

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -12,6 +12,9 @@ HAIL_PIP_VERSION=0.2.14
 shadowJar:
 	./gradlew shadowJar
 
+releaseJar:
+	./gradlew releaseJar
+
 build-info: src/main/resources/build-info.properties python/hail/hail_version python/hail/hail_pip_version
 
 define properties

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -106,6 +106,13 @@ task nativeLibPrebuilt(type: Exec) {
     outputs.upToDateWhen { false }
 }
 
+task nativeLibResetPrebuilt(type: Exec) {
+    workingDir 'src/main/c'
+    args('reset-prebuilt')
+    executable 'make'
+    outputs.upToDateWhen { false }
+}
+
 sourceSets {
     main {
         resources {
@@ -175,7 +182,8 @@ task pipInstall(type: Exec, dependsOn: ['generateBuildInfo', 'shadowJar']) {
 }
 
 shadowJar.mustRunAfter nativeLibPrebuilt
-task releaseJar(type: Wrapper, dependsOn: ['nativeLibPrebuilt', 'shadowJar']) {
+nativeLibResetPrebuilt.mustRunAfter shadowJar
+task releaseJar(type: Wrapper, dependsOn: ['nativeLibPrebuilt', 'shadowJar', 'nativeLibResetPrebuilt']) {
 }
 
 compileScala {

--- a/hail/build.gradle
+++ b/hail/build.gradle
@@ -174,6 +174,10 @@ task pipInstall(type: Exec, dependsOn: ['generateBuildInfo', 'shadowJar']) {
     outputs.upToDateWhen { false }
 }
 
+shadowJar.mustRunAfter nativeLibPrebuilt
+task releaseJar(type: Wrapper, dependsOn: ['nativeLibPrebuilt', 'shadowJar']) {
+}
+
 compileScala {
     dependsOn generateBuildInfo
     scalaCompileOptions.additionalParameters = [

--- a/hail/gradle/wrapper/gradle-wrapper.properties
+++ b/hail/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Sep 04 22:53:23 EDT 2018
+#Mon May 20 14:03:36 EDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip

--- a/hail/python/hail/docs/getting_started.rst
+++ b/hail/python/hail/docs/getting_started.rst
@@ -66,7 +66,7 @@ On Mac OS X, you might try::
 
 To build the Hail JAR compatible with Spark 2.3.0, execute this::
 
-    ./gradlew -Dspark.version=2.3.0 shadowJar
+    ./gradlew -Dspark.version=2.3.0 releaseJar
 
 The Spark version in this command should match whichever version of Spark you
 would like to build against.
@@ -190,7 +190,7 @@ the same as above, except:
    builds a Hail JAR for Cloudera's
    2.4.0 version of Spark::
 
-    ./gradlew shadowJar -Dspark.version=2.4.0.cloudera -Dpy4j.version=0.10.7
+    ./gradlew releaseJar -Dspark.version=2.4.0.cloudera -Dpy4j.version=0.10.7
 
  - On a Cloudera cluster, ``SPARK_HOME`` should be set as:
    ``SPARK_HOME=/opt/cloudera/parcels/SPARK2/lib/spark2``,

--- a/hail/python/hail/docs/getting_started_developing.rst
+++ b/hail/python/hail/docs/getting_started_developing.rst
@@ -35,6 +35,13 @@ The Hail source code is hosted `on GitHub <https://github.com/hail-is/hail>`_::
     git clone https://github.com/hail-is/hail.git
     cd hail/hail
 
+By default, hail uses pre-compiled native libraries that are compatible with
+recent Mac OS X and Debian releases. If you're not using on of these OSes, you
+must rebuild the native libraries from source and move them into place before
+building a shadowJar::
+
+    ./gradlew nativeLibPrebuilt
+
 Build a Hail JAR compatible with Spark 2.4.0::
 
     ./gradlew -Dspark.version=2.4.0 shadowJar
@@ -42,6 +49,9 @@ Build a Hail JAR compatible with Spark 2.4.0::
 Should you wish to build a Hail JAR compatible with a different Spark version (2.2.0 here)::
 
     ./gradlew -Dspark.version=2.2.0 shadowJar
+
+The end user documentation encourages users to use the `releaseJar` target which
+ensures that `nativeLibPrebuilt` is run before `shadowJar`.
 
 
 Environment Variables and Conda Environments

--- a/hail/src/main/c/Makefile
+++ b/hail/src/main/c/Makefile
@@ -1,5 +1,5 @@
 MAKEFLAGS += --no-builtin-rules
-.PHONY: all clean debug prebuilt test
+.PHONY: all clean debug prebuilt test reset-prebuilt
 .SUFFIXES:
 .DEFAULT_GOAL := all
 
@@ -170,6 +170,10 @@ $(PREBUILT)/$(LIBHAIL): $(LIBHAIL)
 	cp -p -f $< $@
 
 prebuilt: $(PREBUILT)/$(LIBBOOT) $(PREBUILT)/$(LIBHAIL)
+
+reset-prebuilt:
+	git checkout HEAD -- $(PREBUILT)/$(LIBBOOT)
+	git checkout HEAD -- $(PREBUILT)/$(LIBHAIL)
 
 test: $(BUILD)/functional-tests $(BUILD)/unit-tests
 	./$(BUILD)/unit-tests -w NoAssertions -s -d yes -# --use-colour yes -r xml -o $(BUILD)/cxx-test.xml; \


### PR DESCRIPTION
Users who build from source are often confused by the native
library configuration. This adds a target that handles native
library configuration for the user. I also changed the docs to
encourage the use of this target. This means everyone building hail
from source will need to build the C libraries, but I think this
is for the best, since most people building from source need to
correctly handle native libraries anyway.

Resolves https://github.com/hail-is/hail/issues/6132