### PR TITLE
[ci] fix github state

### DIFF
--- a/ci2/ci/github.py
+++ b/ci2/ci/github.py
@@ -258,7 +258,7 @@ class PR(Code):
             if state == 'APPROVED':
                 review_state = 'approved'
             else:
-                assert state in ('DISMISSED', 'COMMENTED'), state
+                assert state in ('DISMISSED', 'COMMENTED', 'PENDING'), state
 
         if review_state != self.review_state:
             self.review_state = review_state


### PR DESCRIPTION
Fixes this assertion error in ci2 logs:
```
ERROR   | 2019-05-21 20:22:56,019       | ci.py         | update_loop:239 | hail-is/hail:master update failed due to exception: Traceback (most recent call last):
  File "/ci/ci.py", line 235, in update_loop
    await wb.update(app)
  File "/ci/github.py", line 465, in update
    await self._update(app)
  File "/ci/github.py", line 481, in _update
    await self._update_github(gh)
  File "/ci/github.py", line 543, in _update_github
    await pr._update_github_review_state(gh)
  File "/ci/github.py", line 261, in _update_github_review_state
    assert state in ('DISMISSED', 'COMMENTED'), state
AssertionError: PENDING
PENDING
```