### PR TITLE
[ci2] always link to the pr build page

### DIFF
--- a/ci2/ci/templates/index.html
+++ b/ci2/ci/templates/index.html
@@ -68,15 +68,15 @@
             {{ pr.title }}
           </td>
           <td align="left">
+            <a href="/watched_branches/{{ wb.index }}/pr/{{ pr.number }}">
             {% if pr.build_state is not none %}
-            <a href="/watched_branches/{{ wb.index }}/pr/{{ pr.number }}">
               {{ pr.build_state }}
-            </a>
             {% elif pr.batch_id is not none %}
-            <a href="/watched_branches/{{ wb.index }}/pr/{{ pr.number }}">
               building
-            </a>
+            {% else %}
+              pending
             {% endif %}
+            </a>
           </td>
           <td align="left">
             {% if pr.review_state %}


### PR DESCRIPTION
Even if there is no currently running build, there may be useful history.