### PR TITLE
[bugfix][c++] fix strides for length-1 dimensions

### DIFF
--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2685,6 +2685,8 @@ class Tests(unittest.TestCase):
         self.assert_evals_to(h_cube[1, 1, 0], 6)
         self.assert_evals_to(h_np_cube[0, 0, 1], 1)
         self.assert_evals_to(h_np_cube[1, 1, 0], 6)
+        self.assert_evals_to(hl._ndarray([[[[1]]]])[0, 0, 0, 0], 1)
+        self.assert_evals_to(hl._ndarray([[[1, 2]], [[3, 4]]])[1, 0, 0], 3)
 
         self.assertRaises(ValueError, hl._ndarray, [[4], [1, 2, 3], 5])
 

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2932,6 +2932,11 @@ class Tests(unittest.TestCase):
         self.ndarray_eq(m @ rect_prism, np_m @ np_rect_prism)
         self.ndarray_eq(m @ rect_prism.T, np_m @ np_rect_prism.T)
 
+        np_broadcasted_mat = np.array([[[1, 2],
+                                        [3, 4]]])
+        self.ndarray_eq(hl._ndarray(np_broadcasted_mat) @ rect_prism,
+                        np_broadcasted_mat @ np_rect_prism)
+
         self.assertRaises(ValueError, lambda: m @ 5)
         self.assertRaises(ValueError, lambda: m @ hl._ndarray(5))
         self.assertRaises(ValueError, lambda: cube @ hl._ndarray(5))

--- a/hail/src/main/resources/include/hail/NDArray.h
+++ b/hail/src/main/resources/include/hail/NDArray.h
@@ -54,20 +54,10 @@ std::vector<long> strides_row_major(std::vector<long> &shape) {
   std::vector<long> strides(shape.size());
 
   if (shape.size() > 0) {
-    int end = shape.size() - 1;
+    strides[shape.size() - 1] = 1;
 
-    int prev_concrete_dim = -1;
-    for (int i = shape.size() - 1; i >= 0; --i) {
-      if (shape[i] == 1) {
-        strides[i] = 0;
-      } else {
-        if (prev_concrete_dim >= 0) {
-          strides[i] = shape[prev_concrete_dim] * strides[prev_concrete_dim];
-        } else {
-          strides[i] = 1;
-        }
-        prev_concrete_dim = i;
-      }
+    for (int i = shape.size() - 2; i >= 0; --i) {
+      strides[i] = shape[i + 1] * strides[i + 1];
     }
   }
   return strides;
@@ -92,19 +82,10 @@ std::vector<long> strides_col_major(std::vector<long> &shape) {
   std::vector<long> strides(shape.size());
 
   if (shape.size() > 0) {
+    strides[0] = 1;
 
-    int prev_concrete_dim = -1;
-    for (int i = 0; i < shape.size(); ++i) {
-      if (shape[i] == 1) {
-        strides[i] = 0;
-      } else {
-        if (prev_concrete_dim >= 0) {
-          strides[i] = shape[prev_concrete_dim] * strides[prev_concrete_dim];
-        } else {
-          strides[i] = 1;
-        }
-        prev_concrete_dim = i;
-      }
+    for (int i = 1; i < shape.size(); ++i) {
+      strides[i] = shape[i - 1] * strides[i - 1];
     }
   }
   return strides;

--- a/hail/src/main/resources/include/hail/NDArray.h
+++ b/hail/src/main/resources/include/hail/NDArray.h
@@ -45,7 +45,6 @@ int n_elements(std::vector<long> &shape) {
   return total;
 }
 
-// Length-1 dimensions have stride 0 for free broadcasting
 std::vector<long> make_strides(int row_major, std::vector<long> &shape) {
   return (row_major == 1) ? strides_row_major(shape) : strides_col_major(shape);
 }

--- a/hail/src/main/scala/is/hail/cxx/Code.scala
+++ b/hail/src/main/scala/is/hail/cxx/Code.scala
@@ -4,4 +4,6 @@ object Code {
   def apply(args: Code*): Code = sequence(args)
 
   def sequence(codes: Seq[Code]): Code = codes.mkString("\n")
+
+  def defineVars(variables: Seq[Variable]): Code = sequence(variables.map(_.define))
 }

--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -1087,14 +1087,14 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
                 val stackDims :+ m = idxVars
 
                 val rStackVars =
-                  NDArrayEmitter.adjustBroadcastedDims(fb, rStackDimsBroadcastFlags, stackDims)
+                  NDArrayEmitter.zeroBroadcastedDims(fb, rStackDimsBroadcastFlags, stackDims)
                 rStackVars.foreach(broadcastingLoopVars += _)
                 (Seq(k), rStackVars :+ k :+ m)
               case (_, 1) =>
                 val stackDims :+ n = idxVars
 
                 val lStackVars =
-                  NDArrayEmitter.adjustBroadcastedDims(fb, lStackDimsBroadcastFlags, stackDims)
+                  NDArrayEmitter.zeroBroadcastedDims(fb, lStackDimsBroadcastFlags, stackDims)
                 lStackVars.foreach(broadcastingLoopVars += _)
 
                 (lStackVars :+ n :+ k, Seq(k))
@@ -1102,10 +1102,10 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
                 val stackDims :+ n :+ m = idxVars
 
                 val lStackVars =
-                  NDArrayEmitter.adjustBroadcastedDims(fb, lStackDimsBroadcastFlags, stackDims)
+                  NDArrayEmitter.zeroBroadcastedDims(fb, lStackDimsBroadcastFlags, stackDims)
                 lStackVars.foreach(broadcastingLoopVars += _)
                 val rStackVars =
-                  NDArrayEmitter.adjustBroadcastedDims(fb, rStackDimsBroadcastFlags, stackDims)
+                  NDArrayEmitter.zeroBroadcastedDims(fb, rStackDimsBroadcastFlags, stackDims)
                 rStackVars.foreach(broadcastingLoopVars += _)
 
                 (lStackVars :+ n :+ k, rStackVars :+ k :+ m)
@@ -1476,8 +1476,8 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
 
         new NDArrayEmitter(fb, resultRegion, lEmitter.nDims, shape, setup) {
           override def outputElement(idxVars: Seq[Variable]): Code = {
-            val lIdxVars = NDArrayEmitter.adjustBroadcastedDims(fb, lBroadcastFlags, idxVars)
-            val rIdxVars = NDArrayEmitter.adjustBroadcastedDims(fb, rBroadcastFlags, idxVars)
+            val lIdxVars = NDArrayEmitter.zeroBroadcastedDims(fb, lBroadcastFlags, idxVars)
+            val rIdxVars = NDArrayEmitter.zeroBroadcastedDims(fb, rBroadcastFlags, idxVars)
 
             s"""
                |({

--- a/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
+++ b/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
@@ -94,16 +94,16 @@ abstract class ArrayEmitter(val setup: Code, val m: Code, val setupLen: Code, va
   def emit(f: (Code, Code) => Code): Code
 }
 
-object NDArrayLoopEmitter {
+object NDArrayEmitter {
   def broadcastFlags(fb: FunctionBuilder, nDims: Int, shape: Code): Seq[Variable] = {
     IndexedSeq.tabulate(nDims) { dim =>
       fb.variable(s"is_not_broadcast_$dim", "int", s"$shape[$dim] > 1 ? 1 : 0")
     }
   }
 
-  def nullifyBroadcastedLoopVars(fb: FunctionBuilder, broadcastFlags: Seq[Variable], loopVars: Seq[Variable]): Seq[Variable] = {
-    broadcastFlags.zip(loopVars).map { case (flag, idxVar) =>
-      fb.variable("new_idx_var", "int", s"$flag * $idxVar")
+  def adjustBroadcastedDims(fb: FunctionBuilder, broadcastFlags: Seq[Variable], loopVars: Seq[Variable]): Seq[Variable] = {
+    broadcastFlags.zip(loopVars).map { case (flag, loopVar) =>
+      fb.variable("new_loop_var", "int", s"$flag * $loopVar")
     }
   }
 
@@ -119,7 +119,7 @@ object NDArrayLoopEmitter {
   }
 }
 
-abstract class NDArrayLoopEmitter(
+abstract class NDArrayEmitter(
   fb: FunctionBuilder,
   resultRegion: EmitRegion,
   val nDims: Int,

--- a/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
+++ b/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
@@ -96,12 +96,14 @@ abstract class ArrayEmitter(val setup: Code, val m: Code, val setupLen: Code, va
 
 object NDArrayEmitter {
   def broadcastFlags(fb: FunctionBuilder, nDims: Int, shape: Code): Seq[Variable] = {
+    val broadcasted = 0
+    val notBroadcasted = 1
     IndexedSeq.tabulate(nDims) { dim =>
-      fb.variable(s"is_not_broadcast_$dim", "int", s"$shape[$dim] > 1 ? 1 : 0")
+      fb.variable(s"not_broadcasted_$dim", "int", s"$shape[$dim] > 1 ? $notBroadcasted : $broadcasted")
     }
   }
 
-  def adjustBroadcastedDims(fb: FunctionBuilder, broadcastFlags: Seq[Variable], loopVars: Seq[Variable]): Seq[Variable] = {
+  def zeroBroadcastedDims(fb: FunctionBuilder, broadcastFlags: Seq[Variable], loopVars: Seq[Variable]): Seq[Variable] = {
     broadcastFlags.zip(loopVars).map { case (flag, loopVar) =>
       fb.variable("new_loop_var", "int", s"$flag * $loopVar")
     }


### PR DESCRIPTION
~~Stride for a dimension should be calculated based off the length * stride of the previous innermost dimension with length > 1. I was remembering to do that for the stride but just taking the length of the adjacent dimension.~~

~~Length-1 dimensions have stride 0 so broadcasting happens implicitly without the need for checks while indexing into the ndarray.~~

Broadcasting was previously handled implicitly by having 0 stride for dimensions of length 1. This doesn't actually work in all scenarios and conflates the concept of a multidimensional index with the underlying representation. Since we already compute the shapes of all intermediate NDArrays before doing any iteration, we can identify broadcasting "statically". Instead, loop variables associated with a braodcast are replaced with 0 when indexing into the backing array. This method is more robust and I've already seen works with slicing, which will follow this PR.