### PR TITLE
allow Literals to be emitted in generated JVM code

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -144,6 +144,17 @@ trait DependentFunction[F >: Null <: AnyRef] extends FunctionBuilder[F] {
     cfr
   }
 
+  def addField[T](value: Code[_], dummy: Boolean)(implicit ti: TypeInfo[T]): ClassFieldRef[T] = {
+    val cfr = newField[T]
+    val add: (Growable[AbstractInsnNode]) => Unit = { (il: Growable[AbstractInsnNode]) =>
+      il += new TypeInsnNode(CHECKCAST, name)
+      value.emit(il)
+      il += new FieldInsnNode(PUTFIELD, name, cfr.name, typeInfo[T].name)
+    }
+    definedFields += add
+    cfr
+  }
+
   def newInstance()(implicit fct: ClassTag[F]): Code[F] = {
     val instance: Code[F] =
       new Code[F] {

--- a/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
@@ -15,7 +15,7 @@ object Compilable {
       case _: TableToValueApply => false
       case _: MatrixToValueApply => false
       case _: BlockMatrixToValueApply => false
-      case _: Literal => false
+//      case _: Literal => false
       case _: CollectDistributedArray => false
       case _: ReadPartition => false
 

--- a/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
@@ -15,7 +15,6 @@ object Compilable {
       case _: TableToValueApply => false
       case _: MatrixToValueApply => false
       case _: BlockMatrixToValueApply => false
-//      case _: Literal => false
       case _: CollectDistributedArray => false
       case _: ReadPartition => false
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -279,7 +279,12 @@ private class Emit(
       case F64(x) =>
         present(const(x))
       case Str(x) =>
-        present(region.appendString(const(x)))
+        present(mb.fb.addLiteral(x, TString()))
+      case Literal(t, v) =>
+        if (v == null)
+          emit(NA(t))
+        else
+          present(mb.fb.addLiteral(v, t))
       case True() =>
         present(const(true))
       case False() =>

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -49,7 +49,9 @@ object EmitRegion {
   def default(mb: EmitMethodBuilder): EmitRegion = EmitRegion(mb, mb.getArg[Region](1))
 }
 
-case class EmitRegion(mb: EmitMethodBuilder, region: Code[Region])
+case class EmitRegion(mb: EmitMethodBuilder, region: Code[Region]) {
+  def baseRegion: Code[Region] = mb.getArg[Region](1)
+}
 
 case class EmitTriplet(setup: Code[Unit], m: Code[Boolean], v: Code[_]) {
   def value[T]: Code[T] = coerce[T](v)
@@ -279,12 +281,12 @@ private class Emit(
       case F64(x) =>
         present(const(x))
       case Str(x) =>
-        present(mb.fb.addLiteral(x, TString()))
+        present(mb.fb.addLiteral(x, TString(), er.baseRegion))
       case Literal(t, v) =>
         if (v == null)
           emit(NA(t))
         else
-          present(mb.fb.addLiteral(v, t))
+          present(mb.fb.addLiteral(v, t, er.baseRegion))
       case True() =>
         present(const(true))
       case False() =>

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1400,6 +1400,12 @@ class IRSuite extends SparkSuite {
     assertEvalsTo(Str("hello"+poopEmoji), "hello"+poopEmoji)
   }
 
+  @Test def testSameLiteralsWithDifferentTypes() {
+    assertEvalsTo(ApplyComparisonOp(EQ(TArray(TInt32())),
+      ArrayMap(Literal(TArray(TFloat64()), FastIndexedSeq(1.0, 2.0)), "elt", Cast(Ref("elt", TFloat64()), TInt32())),
+      Literal(TArray(TInt32()), FastIndexedSeq(1, 2))), true)
+  }
+
   @Test def testTableCount() {
     implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized, ExecStrategy.CxxCompile)
     assertEvalsTo(TableCount(TableRange(0, 4)), 0L)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1382,7 +1382,7 @@ class IRSuite extends SparkSuite {
   }
 
   @Test def testLiteral() {
-    implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized, ExecStrategy.CxxCompile)
+    implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized, ExecStrategy.CxxCompile, ExecStrategy.JvmCompile)
     val poopEmoji = new String(Array[Char](0xD83D, 0xDCA9))
     val types = Array(
       TTuple(TInt32(), TString(), TArray(TInt32())),

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -93,7 +93,6 @@ class TableIRSuite extends SparkSuite {
   }
 
   @Test def testTableMapWithLiterals() {
-    implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized, ExecStrategy.CxxCompile)
     val t = TableRange(10, 2)
     val node = TableMapRows(t,
       InsertFields(Ref("row", t.typ.rowType),


### PR DESCRIPTION
Basically, serializes all necessary literals onto the emitted function to be decoded and used on worker nodes.