### PR TITLE
[hail] remove confusing try-catch

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -145,7 +145,7 @@ object IRParser {
     try {
       Serialization.read[T](str)
     } catch {
-      case e: MappingException => 
+      case e: MappingException =>
         if (e.cause != null)
           throw e.cause
         else
@@ -882,11 +882,7 @@ object IRParser {
       case "MatrixMultiWrite" =>
         val writerStr = string_literal(it)
         implicit val formats = MatrixNativeMultiWriter.formats
-        val writer = try{
-          Serialization.read[MatrixNativeMultiWriter](writerStr)
-        } catch {
-          case e: MappingException => throw e.cause
-        }
+        val writer = deserialize[MatrixNativeMultiWriter](writerStr)
         val children = matrix_ir_children(env)(it)
         MatrixMultiWrite(children, writer)
       case "BlockMatrixWrite" =>
@@ -1144,11 +1140,7 @@ object IRParser {
         val dropRows = boolean_literal(it)
         val readerStr = string_literal(it)
         implicit val formats: Formats = MatrixReader.formats + new MatrixBGENReaderSerializer(env)
-        val reader = try {
-          Serialization.read[MatrixReader](readerStr)
-        } catch {
-          case e: MappingException => throw e.cause
-        }
+        val reader = deserialize[MatrixReader](readerStr)
         MatrixRead(requestedType.getOrElse(reader.fullMatrixType), dropCols, dropRows, reader)
       case "MatrixAnnotateRowsTable" =>
         val root = string_literal(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -142,11 +142,7 @@ object IRParser {
   def error(t: Token, msg: String): Nothing = ParserUtils.error(t.pos, msg)
 
   def deserialize[T](str: String)(implicit formats: Formats, mf: Manifest[T]): T = {
-    try {
-      Serialization.read[T](str)
-    } catch {
-      case e: MappingException => throw e.cause
-    }
+    Serialization.read[T](str)
   }
 
   def consumeToken(it: TokenIterator): Token = {

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -142,8 +142,17 @@ object IRParser {
   def error(t: Token, msg: String): Nothing = ParserUtils.error(t.pos, msg)
 
   def deserialize[T](str: String)(implicit formats: Formats, mf: Manifest[T]): T = {
-    Serialization.read[T](str)
-  }
+    try {
+	      Serialization.read[T](str)
+	    } catch {
+	      case e: MappingException => 
+          if (e.cause != null) {
+            throw e.cause
+          } else {
+            throw e
+          }
+	    }
+	  }
 
   def consumeToken(it: TokenIterator): Token = {
     if (!it.hasNext)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -145,12 +145,13 @@ object IRParser {
     try {
       Serialization.read[T](str)
     } catch {
-	    case e: MappingException => 
+      case e: MappingException => 
         if (e.cause != null)
           throw e.cause
         else
           throw e
-	  }
+    }
+  }
 
   def consumeToken(it: TokenIterator): Token = {
     if (!it.hasNext)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -143,15 +143,13 @@ object IRParser {
 
   def deserialize[T](str: String)(implicit formats: Formats, mf: Manifest[T]): T = {
     try {
-	      Serialization.read[T](str)
-	    } catch {
-	      case e: MappingException => 
-          if (e.cause != null) {
-            throw e.cause
-          } else {
-            throw e
-          }
-	    }
+      Serialization.read[T](str)
+    } catch {
+	    case e: MappingException => 
+        if (e.cause != null)
+          throw e.cause
+        else
+          throw e
 	  }
 
   def consumeToken(it: TokenIterator): Token = {


### PR DESCRIPTION
This catch was masking a `org.json4s.package$MappingException: Parsed JSON values do not match with class constructor` as a `NullPointerException` on line 148. Exceptions always include their cause in the stack trace, I see no compelling reason to maintain this try-catch.