### PR TITLE
require the jwt-secret-key to be binary

### DIFF
--- a/apiserver/apiserver/apiserver.py
+++ b/apiserver/apiserver/apiserver.py
@@ -21,7 +21,7 @@ app = web.Application()
 routes = web.RouteTableDef()
 
 
-with open(os.environ.get('HAIL_JWT_SECRET_KEY_FILE') or '/jwt-secret-key/secret-key') as f:
+with open(os.environ.get('HAIL_JWT_SECRET_KEY_FILE') or '/jwt-secret-key/secret-key', 'rb') as f:
     jwtclient = hj.JWTClient(f.read())
 
 

--- a/apiserver/create_key.py
+++ b/apiserver/create_key.py
@@ -2,7 +2,7 @@ import hailjwt as hj
 import json
 import sys
 
-with open(sys.argv[1]) as f:
+with open(sys.argv[1], 'rb') as f:
     c = hj.JWTClient(f.read())
 
-sys.stdout.buffer.write(c.encode(json.loads(sys.stdin.read())))
+sys.stdout.write(c.encode(json.loads(sys.stdin.read())))

--- a/batch/batch/server/database.py
+++ b/batch/batch/server/database.py
@@ -36,7 +36,7 @@ class JobsTable(Table):
             async with conn.cursor() as cursor:
                 batch_name = self._db.batch.name
                 where_template, where_values = make_where_statement({'id': ids, 'user': user})
-                sql = f"""SELECT * FROM `{self.name}` WHERE {where_template} AND EXISTS 
+                sql = f"""SELECT * FROM `{self.name}` WHERE {where_template} AND EXISTS
                 (SELECT id from `{batch_name}` WHERE `{batch_name}`.id = batch_id AND `{batch_name}`.deleted = FALSE)"""
                 await cursor.execute(sql, tuple(where_values))
                 result = await cursor.fetchall()
@@ -92,7 +92,8 @@ class JobsTable(Table):
             return records[0][uri_field]
         return None
 
-    def exit_code_field(self, task_name):
+    @staticmethod
+    def exit_code_field(task_name):
         return JobsTable.exit_code_mapping[task_name]
 
     async def get_parents(self, job_id):

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -509,6 +509,7 @@ class Job:
                 log.exception(f'could not get logs for {pod.metadata.name} due to {exc}')
                 if exc.status == 400:
                     await self.mark_unscheduled()
+                    return
                 raise
 
         await self._mark_job_task_complete(task_name, pod_log, exit_code)

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -10,7 +10,6 @@ from shlex import quote as shq
 
 from aiohttp import web
 import cerberus
-import jwt
 import kubernetes as kube
 import requests
 import uvloop
@@ -507,13 +506,10 @@ class Job:
                     HAIL_POD_NAMESPACE,
                     _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS)
             except kube.client.rest.ApiException as exc:
-                pod_log = f'could not get logs for {pod.metadata.name} due to {exc}'
                 log.exception(f'could not get logs for {pod.metadata.name} due to {exc}')
                 if exc.status == 400:
                     await self.mark_unscheduled()
-                    return
-                else:
-                    raise
+                raise
 
         await self._mark_job_task_complete(task_name, pod_log, exit_code)
 

--- a/batch/create_key.py
+++ b/batch/create_key.py
@@ -2,7 +2,7 @@ import hailjwt as hj
 import json
 import sys
 
-with open(sys.argv[1]) as f:
+with open(sys.argv[1], 'rb') as f:
     c = hj.JWTClient(f.read())
 
-sys.stdout.buffer.write(c.encode(json.loads(sys.stdin.read())))
+sys.stdout.write(c.encode(json.loads(sys.stdin.read())))

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -62,7 +62,7 @@ spec:
          secret:
            optional: false
            secretName: "{{ batch_database.user_secret_name }}"
-      - name: jwt-secret-key
+       - name: jwt-secret-key
          secret:
            optional: false
            secretName: jwt-secret-key

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -62,26 +62,18 @@ spec:
          secret:
            optional: false
            secretName: "{{ batch_database.user_secret_name }}"
-       - name: jwt-secret-key
+      - name: jwt-secret-key
          secret:
            optional: false
            secretName: jwt-secret-key
        - name: gsa-key
          secret:
            optional: false
-{% if deploy %}
-           secretName: gsa-key-n6hf9
-{% else %}
-           secretName: test-gsa-key
-{% endif %}
+           secretName: batch-gsa-key
        - name: batch-jwt
          secret:
            optional: false
-{% if deploy %}
-           secretName: user-jwt-fh7kp
-{% else %}
            secretName: batch-jwt
-{% endif %}
 ---
 apiVersion: v1
 kind: Service

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -295,7 +295,7 @@ class Test(unittest.TestCase):
             'jwt-test-user.json')
         with open(fname) as f:
             userdata = json.loads(f.read())
-        token = hj.JWTClient(hj.JWTClient.generate_key()).encode(userdata).decode('ascii')
+        token = hj.JWTClient(hj.JWTClient.generate_key()).encode(userdata)
         bc = batch.client.BatchClient(url=os.environ.get('BATCH_URL'), token=token)
         try:
             b = bc.create_batch()

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -21,7 +21,7 @@ def client():
 
 def test_user():
     fname = os.environ.get("HAIL_TOKEN_FILE")
-    with open(fname) as f:
+    with open(fname, 'rb') as f:
         return hj.JWTClient.unsafe_decode(f.read())
 
 

--- a/build.yaml
+++ b/build.yaml
@@ -41,18 +41,43 @@ steps:
      valueFrom: base_image.image
    script: |
      set -ex
+     # secret-key
      python3 -c "
      import secrets, jwt
      secret_key = secrets.token_urlsafe(64)
-     with open('secret-key', 'w') as f:
+     with open('secret-key', 'wb') as f:
        f.write(secret_key)
-     payload = {'ksa_name':'unused','gsa_email':'hail-test@hail-vdc.iam.gserviceaccount.com','bucket_name':'hail-test-1c9nm','gsa_key_secret_name':'test-gsa-key'}
+     "
+     kubectl -n {{ default_ns.name }} create secret generic jwt-secret-key --from-file=./secret-key
+     # batch
+     kubectl -n {{ default_ns.name }} get -o json --export secret test-gsa-key | jq '.metadata.name = "batch-gsa-key"' | kubectl -n {{ default_ns.name }} apply -f -
+     python3 -c "
+     with open('secret-key', 'rb') as f:
+       secret_key = f.read()
+     payload = {'id':1,'username':'batch','gsa_email':'hail-test@hail-vdc.iam.gserviceaccount.com','bucket_name':'hail-test-1c9nm','gsa_key_secret_name':'batch-gsa-key','jwt_secret_name':'batch-jwt'}
      with open('jwt', 'w') as f:
        f.write(jwt.encode(payload, secret_key).decode('utf-8'))
      "
-     kubectl -n {{ default_ns.name }} create secret generic jwt-secret-key --from-file=./secret-key
      kubectl -n {{ default_ns.name }} create secret generic batch-jwt --from-file=./jwt
+     # ci2
+     kubectl -n {{ default_ns.name }} get -o json --export secret test-gsa-key | jq '.metadata.name = "ci2-gsa-key"' | kubectl -n {{ default_ns.name }} apply -f -
+     python3 -c "
+     with open('secret-key', 'rb') as f:
+       secret_key = f.read()
+     payload = {'id':2,'username':'ci2','gsa_email':'hail-test@hail-vdc.iam.gserviceaccount.com','bucket_name':'hail-test-1c9nm','gsa_key_secret_name':'ci2-gsa-key','jwt_secret_name':'ci2-jwt'}
+     with open('jwt', 'w') as f:
+       f.write(jwt.encode(payload, secret_key).decode('utf-8'))
+     "
      kubectl -n {{ default_ns.name }} create secret generic ci2-jwt --from-file=./jwt
+     # test
+     # test-gsa-key exists
+     python3 -c "
+     with open('secret-key', 'rb') as f:
+       secret_key = f.read()
+     payload = {'id':3,'username':'test','gsa_email':'hail-test@hail-vdc.iam.gserviceaccount.com','bucket_name':'hail-test-1c9nm','gsa_key_secret_name':'test-gsa-key','jwt_secret_name':'test-jwt'}
+     with open('jwt', 'w') as f:
+       f.write(jwt.encode(payload, secret_key).decode('utf-8'))
+     "
      kubectl -n {{ batch_pods_ns.name }} create secret generic test-jwt --from-file=./jwt
    serviceAccount: ci2-agent
    scopes:

--- a/build.yaml
+++ b/build.yaml
@@ -54,7 +54,7 @@ steps:
      python3 -c "
      with open('secret-key', 'rb') as f:
        secret_key = f.read()
-     payload = {'id':1,'username':'batch','gsa_email':'hail-test@hail-vdc.iam.gserviceaccount.com','bucket_name':'hail-test-1c9nm','gsa_key_secret_name':'batch-gsa-key','jwt_secret_name':'batch-jwt'}
+     payload = {'id':1,'service_account':True,'username':'batch','gsa_email':'hail-test@hail-vdc.iam.gserviceaccount.com','bucket_name':'hail-test-1c9nm','gsa_key_secret_name':'batch-gsa-key','jwt_secret_name':'batch-jwt'}
      with open('jwt', 'w') as f:
        f.write(jwt.encode(payload, secret_key).decode('utf-8'))
      "
@@ -64,7 +64,7 @@ steps:
      python3 -c "
      with open('secret-key', 'rb') as f:
        secret_key = f.read()
-     payload = {'id':2,'username':'ci2','gsa_email':'hail-test@hail-vdc.iam.gserviceaccount.com','bucket_name':'hail-test-1c9nm','gsa_key_secret_name':'ci2-gsa-key','jwt_secret_name':'ci2-jwt'}
+     payload = {'id':2,'service_account':True,'username':'ci2','gsa_email':'hail-test@hail-vdc.iam.gserviceaccount.com','bucket_name':'hail-test-1c9nm','gsa_key_secret_name':'ci2-gsa-key','jwt_secret_name':'ci2-jwt'}
      with open('jwt', 'w') as f:
        f.write(jwt.encode(payload, secret_key).decode('utf-8'))
      "
@@ -74,7 +74,7 @@ steps:
      python3 -c "
      with open('secret-key', 'rb') as f:
        secret_key = f.read()
-     payload = {'id':3,'username':'test','gsa_email':'hail-test@hail-vdc.iam.gserviceaccount.com','bucket_name':'hail-test-1c9nm','gsa_key_secret_name':'test-gsa-key','jwt_secret_name':'test-jwt'}
+     payload = {'id':3,'service_account':True,'username':'test','gsa_email':'hail-test@hail-vdc.iam.gserviceaccount.com','bucket_name':'hail-test-1c9nm','gsa_key_secret_name':'test-gsa-key','jwt_secret_name':'test-jwt'}
      with open('jwt', 'w') as f:
        f.write(jwt.encode(payload, secret_key).decode('utf-8'))
      "

--- a/build.yaml
+++ b/build.yaml
@@ -59,16 +59,16 @@ steps:
        f.write(jwt.encode(payload, secret_key).decode('utf-8'))
      "
      kubectl -n {{ default_ns.name }} create secret generic batch-jwt --from-file=./jwt
-     # ci2
-     kubectl -n {{ default_ns.name }} get -o json --export secret test-gsa-key | jq '.metadata.name = "ci2-gsa-key"' | kubectl -n {{ default_ns.name }} apply -f -
+     # ci
+     kubectl -n {{ default_ns.name }} get -o json --export secret test-gsa-key | jq '.metadata.name = "ci-gsa-key"' | kubectl -n {{ default_ns.name }} apply -f -
      python3 -c "
      with open('secret-key', 'rb') as f:
        secret_key = f.read()
-     payload = {'id':2,'service_account':True,'username':'ci2','gsa_email':'hail-test@hail-vdc.iam.gserviceaccount.com','bucket_name':'hail-test-1c9nm','gsa_key_secret_name':'ci2-gsa-key','jwt_secret_name':'ci2-jwt'}
+     payload = {'id':2,'service_account':True,'username':'ci','gsa_email':'hail-test@hail-vdc.iam.gserviceaccount.com','bucket_name':'hail-test-1c9nm','gsa_key_secret_name':'ci-gsa-key','jwt_secret_name':'ci-jwt'}
      with open('jwt', 'w') as f:
        f.write(jwt.encode(payload, secret_key).decode('utf-8'))
      "
-     kubectl -n {{ default_ns.name }} create secret generic ci2-jwt --from-file=./jwt
+     kubectl -n {{ default_ns.name }} create secret generic ci-jwt --from-file=./jwt
      # test
      # test-gsa-key exists
      python3 -c "

--- a/ci2/Dockerfile.ci-utils
+++ b/ci2/Dockerfile.ci-utils
@@ -1,10 +1,7 @@
 FROM {{ base_image.image }}
 
 RUN apt-get update && \
-  apt-get -y install \
-    tar \
-    jq \
-    docker.io && \
+  apt-get -y install docker.io && \
   rm -rf /var/lib/apt/lists/*
 
 COPY jinja2_render.py .

--- a/ci2/deployment.yaml
+++ b/ci2/deployment.yaml
@@ -47,7 +47,7 @@ spec:
             - name: HAIL_DOMAIN
               value: "{{ global.domain }}"
             - name: HAIL_TOKEN_FILE
-              value: '/ci2-jwt/jwt'
+              value: '/ci-jwt/jwt'
             - name: HAIL_SELF_HOSTNAME
               value: ci2
             - name: HAIL_JWT_SECRET_KEY_FILE
@@ -58,9 +58,9 @@ spec:
             - mountPath: /secrets/oauth-token
               readOnly: true
               name: hail-ci-0-1-github-oauth-token
-            - mountPath: /ci2-jwt
+            - mountPath: /ci-jwt
               readOnly: true
-              name: ci2-jwt
+              name: ci-jwt
             - name: jwt-secret-key
               mountPath: /jwt-secret-key
               readOnly: true
@@ -80,9 +80,9 @@ spec:
         - name: hail-ci-0-1-github-oauth-token
           secret:
             secretName: hail-ci-0-1-github-oauth-token
-        - name: ci2-jwt
+        - name: ci-jwt
           secret:
-            secretName: ci2-jwt
+            secretName: ci-jwt
         - name: jwt-secret-key
           secret:
             optional: false

--- a/ci2/deployment.yaml
+++ b/ci2/deployment.yaml
@@ -82,11 +82,7 @@ spec:
             secretName: hail-ci-0-1-github-oauth-token
         - name: ci2-jwt
           secret:
-{% if deploy %}
-            secretName: user-jwt-fzp4f
-{% else %}
             secretName: ci2-jwt
-{% endif %}
         - name: jwt-secret-key
           secret:
             optional: false

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -6,12 +6,13 @@ RUN apt-get update && \
   apt-get -y install \
     git \
     htop \
-    unzip bzip2 zip \
+    unzip bzip2 zip tar \
     wget curl \
     rsync \
     emacs25-nox \
     mysql-client \
     xsltproc pandoc \
+    jq \
     openjdk-8-jdk-headless \
     python \
     python3 python3-pip && \

--- a/hailjwt/Makefile
+++ b/hailjwt/Makefile
@@ -1,3 +1,20 @@
+PYTHON := python3
+
+PY_FILES := $(shell find hailjwt -iname \*.py -not -exec git check-ignore -q {} \; -print)
+
+flake8-stmp: $(PY_FILES)
+	python3 -m flake8 hailjwt
+	touch $@
+
+pylint-stmp: $(PY_FILES)
+	$(PYTHON) -m pylint --rcfile ../pylintrc hailjwt --score=n
+	touch $@
+
+check: flake8-stmp pylint-stmp
+
 .PHONY: test
 test:
 	python3 -m pytest ${PYTEST_ARGS:- -v --failed-first} test
+
+clean:
+	rm -f flake8-stmp pylint-stmp

--- a/hailjwt/hailjwt/hailjwt.py
+++ b/hailjwt/hailjwt/hailjwt.py
@@ -5,6 +5,7 @@ import jwt
 
 log = logging.getLogger('hailjwt')
 
+
 class JWTClient:
     __ALGORITHM = 'HS256'
 
@@ -16,13 +17,13 @@ class JWTClient:
     @staticmethod
     def unsafe_decode(token):
         return jwt.decode(token, verify=False)
-    
+
     @staticmethod
     def _verify_key_preqrequisites(secret_key):
-        if len(key_bytes) < 32:
+        if len(secret_key) < 32:
             raise ValueError(
-                f'found secret key with {len(key_bytes)} bytes, but secret key '
-                f'must have at least 32 bytes (i.e. 256 bits)')
+                f'found secret key with {len(secret_key)} bytes, but secret '
+                f'key must have at least 32 bytes (i.e. 256 bits)')
 
     def __init__(self, secret_key):
         assert isinstance(secret_key, bytes)
@@ -34,13 +35,15 @@ class JWTClient:
             token, self.secret_key, algorithms=[JWTClient.__ALGORITHM])
 
     def encode(self, payload):
-        return jwt.encode(
-            payload, self.secret_key, algorithm=JWTClient.__ALGORITHM).decode('ascii')
+        return (jwt.encode(
+            payload, self.secret_key, algorithm=JWTClient.__ALGORITHM)
+                .decode('ascii'))
 
 
 def get_domain(host):
     parts = host.split('.')
     return f"{parts[-2]}.{parts[-1]}"
+
 
 jwtclient = None
 
@@ -49,7 +52,8 @@ def authenticated_users_only(fun):
     global jwtclient
 
     if not jwtclient:
-        with open(os.environ.get('HAIL_JWT_SECRET_KEY_FILE', '/jwt-secret/secret-key'), 'rb') as f:
+        with open(os.environ.get('HAIL_JWT_SECRET_KEY_FILE',
+                                 '/jwt-secret/secret-key'), 'rb') as f:
             jwtclient = JWTClient(f.read())
 
     def wrapped(request, *args, **kwargs):

--- a/hailjwt/hailjwt/hailjwt.py
+++ b/hailjwt/hailjwt/hailjwt.py
@@ -19,17 +19,13 @@ class JWTClient:
     
     @staticmethod
     def _verify_key_preqrequisites(secret_key):
-        if isinstance(secret_key, str):
-            key_bytes = secret_key.encode('utf-8')
-        else:
-            assert isinstance(secret_key, bytes), type(secret_key)
-            key_bytes = secret_key
         if len(key_bytes) < 32:
             raise ValueError(
                 f'found secret key with {len(key_bytes)} bytes, but secret key '
                 f'must have at least 32 bytes (i.e. 256 bits)')
 
     def __init__(self, secret_key):
+        assert isinstance(secret_key, bytes)
         JWTClient._verify_key_preqrequisites(secret_key)
         self.secret_key = secret_key
 
@@ -39,7 +35,7 @@ class JWTClient:
 
     def encode(self, payload):
         return jwt.encode(
-            payload, self.secret_key, algorithm=JWTClient.__ALGORITHM)
+            payload, self.secret_key, algorithm=JWTClient.__ALGORITHM).decode('ascii')
 
 
 def get_domain(host):
@@ -53,7 +49,7 @@ def authenticated_users_only(fun):
     global jwtclient
 
     if not jwtclient:
-        with open(os.environ.get('HAIL_JWT_SECRET_KEY_FILE', '/jwt-secret/secret-key')) as f:
+        with open(os.environ.get('HAIL_JWT_SECRET_KEY_FILE', '/jwt-secret/secret-key'), 'rb') as f:
             jwtclient = JWTClient(f.read())
 
     def wrapped(request, *args, **kwargs):

--- a/notebook2/notebook/notebook.py
+++ b/notebook2/notebook/notebook.py
@@ -72,10 +72,8 @@ INSTANCE_ID = uuid.uuid4().hex
 
 POD_PORT = 8888
 
-SECRET_KEY = read_string('/jwt-secret-key/secret-key')
 USE_SECURE_COOKIE = os.environ.get("NOTEBOOK_DEBUG") != "1"
 app.config.update(
-    SECRET_KEY = SECRET_KEY,
     SESSION_COOKIE_SAMESITE = 'Lax',
     SESSION_COOKIE_HTTPONLY = True,
     SESSION_COOKIE_SECURE = USE_SECURE_COOKIE
@@ -109,7 +107,8 @@ k8s = kube.client.CoreV1Api()
 log.info(f'KUBERNETES_TIMEOUT_IN_SECONDS {KUBERNETES_TIMEOUT_IN_SECONDS}')
 log.info(f'INSTANCE_ID {INSTANCE_ID}')
 
-jwtclient = JWTClient(SECRET_KEY)
+with open('/jwt-secret-key/secret-key', 'rb') as f:
+    jwtclient = JWTClient(f.read())
 
 
 def jwt_decode(token):


### PR DESCRIPTION
We should hand merge this when we roll over the new keys.  The newly generated jwt secret should be generated by hailjwt.JWTClient.generate_key (type bytes) and written binary when creating the new jwt-secret-key secret.