### PR TITLE
[notebook2]: update get query to match user_data schema 

### DIFF
--- a/notebook2/notebook/notebook.py
+++ b/notebook2/notebook/notebook.py
@@ -343,7 +343,7 @@ def root():
 @app.route('/notebook', methods=['GET'])
 @requires_auth()
 def notebook_page():
-    notebooks = get_live_user_notebooks(user_id = user_id_transform(g.user['auth0_id']))
+    notebooks = get_live_user_notebooks(user_id = user_id_transform(g.user['user_id']))
 
     # https://github.com/hail-is/hail/issues/5487
     assert len(notebooks) <= 1
@@ -375,7 +375,7 @@ def notebook_delete():
 def notebook_post():
     jupyter_token = uuid.uuid4().hex
     name = request.form.get('name', 'a_notebook')
-    safe_id = user_id_transform(g.user['auth0_id'])
+    safe_id = user_id_transform(g.user['user_id'])
 
     pod = start_pod(jupyter_token, WORKER_IMAGE, name, safe_id, g.user)
     session['notebook'] = notebooks_for_ui([pod])[0]
@@ -524,9 +524,7 @@ def auth0_callback():
         return redirect(external_url_for(f"error?err=Unauthorized"))
 
     g.user = {
-        'auth0_id': userinfo['sub'],
         'name': userinfo['name'],
-        'email': email,
         'picture': userinfo['picture'],
         **user_table.get(userinfo['sub'])
     }

--- a/notebook2/notebook/table.py
+++ b/notebook2/notebook/table.py
@@ -47,8 +47,7 @@ class Table:
         with self.acquire_connection() as cursor:
             cursor.execute(
                 """
-                SELECT id, gsa_email, ksa_name, bucket_name,
-                gsa_key_secret_name, user_jwt_secret_name
+                SELECT *
                 FROM user_data
                 WHERE user_id=%s
                 """, (user_id,))


### PR DESCRIPTION
Also stops referring to auth0_id ; users the mysql name (user_id) in the user dict and corresponding jwt cookie 

Needed to undreak notebook following user jwt rollover.