### PR TITLE
[hail] Add experimental udf decorator, use to register big functions

### DIFF
--- a/hail/python/hail/experimental/__init__.py
+++ b/hail/python/hail/experimental/__init__.py
@@ -11,7 +11,7 @@ from .write_multiple import write_matrix_tables, block_matrices_tofiles, export_
 from .export_entries_by_col import export_entries_by_col
 from .densify import densify
 from .sparse_split_multi import sparse_split_multi
-from .function import define_function, udf
+from .function import define_function
 from .ldscsim import simulate_phenotypes
 from .full_outer_join_mt import full_outer_join_mt
 from .tidyr import gather, separate, spread
@@ -37,7 +37,6 @@ __all__ = ['ld_score',
            'densify',
            'sparse_split_multi',
            'define_function',
-           'udf',
            'simulate_phenotypes',
            'full_outer_join_mt',
            'gather',

--- a/hail/python/hail/experimental/__init__.py
+++ b/hail/python/hail/experimental/__init__.py
@@ -11,7 +11,7 @@ from .write_multiple import write_matrix_tables, block_matrices_tofiles, export_
 from .export_entries_by_col import export_entries_by_col
 from .densify import densify
 from .sparse_split_multi import sparse_split_multi
-from .function import define_function
+from .function import define_function, udf
 from .ldscsim import simulate_phenotypes
 from .full_outer_join_mt import full_outer_join_mt
 from .tidyr import gather, separate, spread
@@ -37,6 +37,7 @@ __all__ = ['ld_score',
            'densify',
            'sparse_split_multi',
            'define_function',
+           'udf',
            'simulate_phenotypes',
            'full_outer_join_mt',
            'gather',

--- a/hail/python/hail/experimental/function.py
+++ b/hail/python/hail/experimental/function.py
@@ -3,9 +3,6 @@ from hail.ir import Apply, Ref, Renderer, register_session_function
 from hail.expr.types import HailType
 from hail.expr.expressions import construct_expr, anytype, expr_any, unify_all
 from hail.typecheck import typecheck, nullable
-import hail
-
-from decorator import decorator
 
 class Function(object):
     def __init__(self, f, param_types, ret_type, name):
@@ -16,24 +13,6 @@ class Function(object):
 
     def __call__(self, *args):
         return self._f(*args)
-
-
-@typecheck(param_types=hail.expr.types.hail_type)
-def udf(*param_types):
-
-    uid = Env.get_uid()
-
-    @decorator
-    def wrapper(__original_func, *args, **kwargs):
-        registry = hail.ir.ir._udf_registry
-        if uid in registry:
-            f = registry[uid]
-        else:
-            f = define_function(__original_func, *param_types, _name=uid)
-            registry[uid] = f
-        return f(*args, **kwargs)
-
-    return wrapper
 
 
 @typecheck(f=anytype, param_types=HailType, _name=nullable(str))

--- a/hail/python/hail/experimental/function.py
+++ b/hail/python/hail/experimental/function.py
@@ -16,7 +16,7 @@ class Function(object):
 
 
 @typecheck(f=anytype, param_types=hail_type, _name=nullable(str))
-def define_function(f, *param_types, _name):
+def define_function(f, *param_types, _name=None):
     mname = _name if _name is not None else Env.get_uid()
     param_names = [Env.get_uid() for _ in param_types]
     body = f(*(construct_expr(Ref(pn), pt) for pn, pt in zip(param_names, param_types)))

--- a/hail/python/hail/experimental/function.py
+++ b/hail/python/hail/experimental/function.py
@@ -1,6 +1,6 @@
 from hail.utils.java import Env
 from hail.ir import Apply, Ref, Renderer, register_session_function
-from hail.expr.types import HailType
+from hail.expr.types import hail_type
 from hail.expr.expressions import construct_expr, anytype, expr_any, unify_all
 from hail.typecheck import typecheck, nullable
 
@@ -15,7 +15,7 @@ class Function(object):
         return self._f(*args)
 
 
-@typecheck(f=anytype, param_types=HailType, _name=nullable(str))
+@typecheck(f=anytype, param_types=hail_type, _name=nullable(str))
 def define_function(f, *param_types, _name):
     mname = _name if _name is not None else Env.get_uid()
     param_names = [Env.get_uid() for _ in param_types]

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -2285,6 +2285,7 @@ _allele_ints = {v: k for k, v in _allele_enum.items()}
 
 
 @typecheck(ref=expr_str, alt=expr_str)
+@hl.experimental.udf(hl.tstr, hl.tstr)
 def _num_allele_type(ref, alt) -> Int32Expression:
     return hl.bind(lambda r, a:
                    hl.cond(r.matches(_base_regex),
@@ -2411,6 +2412,7 @@ def is_transversion(ref, alt) -> BooleanExpression:
 
 
 @typecheck(ref=expr_str, alt=expr_str)
+@hl.experimental.udf(hl.tstr, hl.tstr)
 def _is_snp_transition(ref, alt) -> BooleanExpression:
     indices = hl.range(0, ref.length())
     return hl.any(lambda i: ((ref[i] != alt[i]) & (((ref[i] == 'A') & (alt[i] == 'G')) |

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -2285,7 +2285,7 @@ _allele_ints = {v: k for k, v in _allele_enum.items()}
 
 
 @typecheck(ref=expr_str, alt=expr_str)
-@hl.experimental.udf(hl.tstr, hl.tstr)
+@udf(tstr, tstr)
 def _num_allele_type(ref, alt) -> Int32Expression:
     return hl.bind(lambda r, a:
                    hl.cond(r.matches(_base_regex),
@@ -2412,7 +2412,7 @@ def is_transversion(ref, alt) -> BooleanExpression:
 
 
 @typecheck(ref=expr_str, alt=expr_str)
-@hl.experimental.udf(hl.tstr, hl.tstr)
+@udf(tstr, tstr)
 def _is_snp_transition(ref, alt) -> BooleanExpression:
     indices = hl.range(0, ref.length())
     return hl.any(lambda i: ((ref[i] != alt[i]) & (((ref[i] == 'A') & (alt[i] == 'G')) |

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1412,13 +1412,18 @@ class Die(IR):
 _function_registry = defaultdict(list)
 _seeded_function_registry = defaultdict(list)
 _session_functions = set()
+_udf_registry = dict()
 
 def clear_session_functions():
-    global _session_functions
+    global _session_functions, _udf_registry
     for name, param_types, ret_type in _session_functions:
         remove_function(name, param_types, ret_type)
 
+    for f in _udf_registry.values():
+        remove_function(f._name, f._param_types, f._ret_type)
+
     _session_functions = set()
+    _udf_registry = dict()
 
 def remove_function(name, param_types, ret_type):
     f = (param_types, ret_type)


### PR DESCRIPTION
The SNP manipulation functions are huge and get inlined a million
times in sample_qc. This will help keep IR size down.