### PR TITLE
allow all batch jobs to be scheduled on preemptibles

### DIFF
--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -125,7 +125,10 @@ class JobTask:  # pylint: disable=R0903
                 command=['/bin/sh', '-c', sh_expression])
             spec = kube.client.V1PodSpec(
                 containers=[container],
-                restart_policy='Never')
+                restart_policy='Never',
+                tolerations=[
+                    kube.client.V1Toleration(key='preemptible', value='true')
+                ])
             return JobTask.from_spec(task_name, spec)
         return None
 
@@ -619,6 +622,10 @@ async def create_job(request, userdata):  # pylint: disable=R0912
         pod_spec.containers[0].resources.requests['cpu'] = '100m'
     if 'memory' not in pod_spec.containers[0].resources.requests:
         pod_spec.containers[0].resources.requests['memory'] = '500M'
+
+    if not pod_spec.tolerations:
+        pod_spec.tolerations = []
+    pod_spec.tolerations.extend(kube.client.V1Toleration(key='preemptible', value='true'))
 
     job = await Job.create_job(
         pod_spec=pod_spec,

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -625,7 +625,7 @@ async def create_job(request, userdata):  # pylint: disable=R0912
 
     if not pod_spec.tolerations:
         pod_spec.tolerations = []
-    pod_spec.tolerations.extend(kube.client.V1Toleration(key='preemptible', value='true'))
+    pod_spec.tolerations.append(kube.client.V1Toleration(key='preemptible', value='true'))
 
     job = await Job.create_job(
         pod_spec=pod_spec,


### PR DESCRIPTION
I think this is a good change, but we should keep in eye out, it is going to increase preemptions and restarts, and will almost certainly expose issues.  Poor man's chaos.

I will add an option to the batch interface to disable this for longer-running jobs.
