### PR TITLE
[batch,ci,pipeline] change client - parent_ids -> parents

### DIFF
--- a/batch/batch/aioclient.py
+++ b/batch/batch/aioclient.py
@@ -78,13 +78,13 @@ class Batch:
 
     async def create_job(self, image, command=None, args=None, env=None, ports=None,
                          resources=None, tolerations=None, volumes=None, security_context=None,
-                         service_account_name=None, attributes=None, callback=None, parent_ids=None,
+                         service_account_name=None, attributes=None, callback=None, parents=None,
                          input_files=None, output_files=None, always_run=False, pvc_size=None):
         self._job_idx += 1
 
-        if parent_ids is None:
-            parent_ids = []
-        parent_ids = [pid[1] for pid in parent_ids]
+        if parents is None:
+            parents = []
+        parent_ids = [parent.job_id for parent in parents]
 
         if env:
             env = [{'name': k, 'value': v} for (k, v) in env.items()]

--- a/batch/batch/client.py
+++ b/batch/batch/client.py
@@ -79,13 +79,13 @@ class Batch:
 
     def create_job(self, image, command=None, args=None, env=None, ports=None,
                    resources=None, tolerations=None, volumes=None, security_context=None,
-                   service_account_name=None, attributes=None, callback=None, parent_ids=None,
+                   service_account_name=None, attributes=None, callback=None, parents=None,
                    input_files=None, output_files=None, always_run=False, pvc_size=None):
         coroutine = self._async_batch.create_job(
             image, command=command, args=args, env=env, ports=ports,
             resources=resources, tolerations=tolerations, volumes=volumes,
             security_context=security_context, service_account_name=service_account_name,
-            attributes=attributes, callback=callback, parent_ids=parent_ids,
+            attributes=attributes, callback=callback, parents=parents,
             input_files=input_files, output_files=output_files, always_run=always_run,
             pvc_size=pvc_size)
         return Job.from_async_job(async_to_blocking(coroutine))

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -38,7 +38,7 @@ def batch_status_exit_codes(batch_status):
 def test_simple(client):
     batch = client.create_batch()
     head = batch.create_job('alpine:3.8', command=['echo', 'head'])
-    tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parent_ids=[head.id])
+    tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parents=[head])
     batch.close()
     status = batch.wait()
     assert batch_status_job_counter(status, 'Complete') == 2
@@ -48,7 +48,8 @@ def test_simple(client):
 def test_missing_parent_is_400(client):
     try:
         batch = client.create_batch()
-        batch.create_job('alpine:3.8', command=['echo', 'head'], parent_ids=[(batch.id, 100000)])
+        fake_job = Job(batch, 100000)
+        batch.create_job('alpine:3.8', command=['echo', 'head'], parents=[fake_job])
         batch.close()
     except aiohttp.ClientResponseError as err:
         assert err.status == 400
@@ -60,9 +61,9 @@ def test_missing_parent_is_400(client):
 def test_dag(client):
     batch = client.create_batch()
     head = batch.create_job('alpine:3.8', command=['echo', 'head'])
-    left = batch.create_job('alpine:3.8', command=['echo', 'left'], parent_ids=[head.id])
-    right = batch.create_job('alpine:3.8', command=['echo', 'right'], parent_ids=[head.id])
-    tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parent_ids=[left.id, right.id])
+    left = batch.create_job('alpine:3.8', command=['echo', 'left'], parents=[head])
+    right = batch.create_job('alpine:3.8', command=['echo', 'right'], parents=[head])
+    tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parents=[left, right])
     batch.close()
     status = batch.wait()
     assert batch_status_job_counter(status, 'Complete') == 4
@@ -75,12 +76,12 @@ def test_dag(client):
 def test_cancel_tail(client):
     batch = client.create_batch()
     head = batch.create_job('alpine:3.8', command=['echo', 'head'])
-    left = batch.create_job('alpine:3.8', command=['echo', 'left'], parent_ids=[head.id])
-    right = batch.create_job('alpine:3.8', command=['echo', 'right'], parent_ids=[head.id])
+    left = batch.create_job('alpine:3.8', command=['echo', 'left'], parents=[head])
+    right = batch.create_job('alpine:3.8', command=['echo', 'right'], parents=[head])
     tail = batch.create_job(
         'alpine:3.8',
         command=['/bin/sh', '-c', 'while true; do sleep 86000; done'],
-        parent_ids=[left.id, right.id])
+        parents=[left, right])
     batch.close()
     left.wait()
     right.wait()
@@ -100,9 +101,9 @@ def test_cancel_left_after_tail(client):
     left = batch.create_job(
         'alpine:3.8',
         command=['/bin/sh', '-c', 'while true; do sleep 86000; done'],
-        parent_ids=[head.id])
-    right = batch.create_job('alpine:3.8', command=['echo', 'right'], parent_ids=[head.id])
-    tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parent_ids=[left.id, right.id])
+        parents=[head])
+    right = batch.create_job('alpine:3.8', command=['echo', 'right'], parents=[head])
+    tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parents=[left, right])
     batch.close()
     head.wait()
     right.wait()
@@ -121,7 +122,7 @@ def test_parent_already_done(client):
     batch = client.create_batch()
     head = batch.create_job('alpine:3.8', command=['echo', 'head'])
     head.wait()
-    tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parent_ids=[head.id])
+    tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parents=[head])
     batch.close()
     status = batch.wait()
     assert batch_status_job_counter(status, 'Complete') == 2
@@ -131,12 +132,12 @@ def test_parent_already_done(client):
         assert status['exit_code']['main'] == 0
 
 
-def test_one_of_two_parent_ids_already_done(client):
+def test_one_of_two_parents_already_done(client):
     batch = client.create_batch()
     left = batch.create_job('alpine:3.8', command=['echo', 'left'])
     left.wait()
     right = batch.create_job('alpine:3.8', command=['echo', 'right'])
-    tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parent_ids=[left.id, right.id])
+    tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parents=[left, right])
     batch.close()
     status = batch.wait()
     assert batch_status_job_counter(status, 'Complete') == 3
@@ -161,9 +162,9 @@ def test_callback(client):
         server.start()
         batch = client.create_batch(callback=server.url_for('/test'))
         head = batch.create_job('alpine:3.8', command=['echo', 'head'])
-        left = batch.create_job('alpine:3.8', command=['echo', 'left'], parent_ids=[head.id])
-        right = batch.create_job('alpine:3.8', command=['echo', 'right'], parent_ids=[head.id])
-        tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parent_ids=[left.id, right.id])
+        left = batch.create_job('alpine:3.8', command=['echo', 'left'], parents=[head])
+        right = batch.create_job('alpine:3.8', command=['echo', 'right'], parents=[head])
+        tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parents=[left, right])
         batch.close()
         batch.wait()
         i = 0
@@ -185,12 +186,12 @@ def test_callback(client):
             server.join()
 
 
-def test_no_parent_ids_allowed_in_other_batches(client):
+def test_no_parents_allowed_in_other_batches(client):
     b1 = client.create_batch()
     b2 = client.create_batch()
     head = b1.create_job('alpine:3.8', command=['echo', 'head'])
     try:
-        b2.create_job('alpine:3.8', command=['echo', 'tail'], parent_ids=[head.id])
+        b2.create_job('alpine:3.8', command=['echo', 'tail'], parents=[head])
     except aiohttp.ClientResponseError as err:
         assert err.status == 400
         assert re.search('.*invalid parent_id: no job with id .*', err.message)
@@ -207,7 +208,7 @@ def test_input_dependency(client):
     tail = batch.create_job('alpine:3.8',
                             command=['/bin/sh', '-c', 'cat /io/data1 ; cat /io/data2'],
                             input_files=[(f'gs://{user["bucket_name"]}/data*', '/io/')],
-                            parent_ids=[head.id])
+                            parents=[head])
     batch.close()
     tail.wait()
     assert head.status()['exit_code']['main'] == 0, head._status
@@ -223,7 +224,7 @@ def test_input_dependency_directory(client):
     tail = batch.create_job('alpine:3.8',
                             command=['/bin/sh', '-c', 'cat /io/test/data1 ; cat /io/test/data2'],
                             input_files=[(f'gs://{user["bucket_name"]}/test', '/io/')],
-                            parent_ids=[head.id])
+                            parents=[head])
     batch.close()
     tail.wait()
     assert head.status()['exit_code']['main'] == 0, head._status
@@ -236,11 +237,11 @@ def test_always_run_cancel(client):
     left = batch.create_job(
         'alpine:3.8',
         command=['/bin/sh', '-c', 'while true; do sleep 86000; done'],
-        parent_ids=[head.id])
-    right = batch.create_job('alpine:3.8', command=['echo', 'right'], parent_ids=[head.id])
+        parents=[head])
+    right = batch.create_job('alpine:3.8', command=['echo', 'right'], parents=[head])
     tail = batch.create_job('alpine:3.8',
                             command=['echo', 'tail'],
-                            parent_ids=[left.id, right.id],
+                            parents=[left, right],
                             always_run=True)
     batch.close()
     right.wait()
@@ -258,7 +259,7 @@ def test_always_run_error(client):
     head = batch.create_job('alpine:3.8', command=['/bin/sh', '-c', 'exit 1'])
     tail = batch.create_job('alpine:3.8',
                             command=['echo', 'tail'],
-                            parent_ids=[head.id],
+                            parents=[head],
                             always_run=True)
     batch.close()
     status = batch.wait()


### PR DESCRIPTION
I think this interface is clearer and it will be a necessary change when atomic batch creation causes the batch_id to be None until the entire batch is submitted.