### PR TITLE
Monitoring

### DIFF
--- a/apiserver/apiserver/apiserver.py
+++ b/apiserver/apiserver/apiserver.py
@@ -10,7 +10,7 @@ import jwt
 import hail as hl
 from hail.utils import FatalError
 from hail.utils.java import Env, info, scala_object
-import hailjwt as hj
+from hailjwt as authenticated_users_only
 
 uvloop.install()
 
@@ -19,26 +19,6 @@ hl.init(master=master, min_block_size=0)
 
 app = web.Application()
 routes = web.RouteTableDef()
-
-
-with open(os.environ.get('HAIL_JWT_SECRET_KEY_FILE') or '/jwt-secret-key/secret-key', 'rb') as f:
-    jwtclient = hj.JWTClient(f.read())
-
-
-def authenticated_users_only(fun):
-    @ft.wraps(fun)
-    def wrapped(request, *args, **kwargs):
-        encoded_token = request.cookies.get('user')
-        if encoded_token is not None:
-            try:
-                userdata = jwtclient.decode(encoded_token)
-                if 'userdata' in fun.__code__.co_varnames:
-                    return fun(request, *args, userdata=userdata, **kwargs)
-                return fun(request, *args, **kwargs)
-            except jwt.exceptions.DecodeError:
-                pass
-        raise web.HTTPUnauthorized(headers={'WWW-Authenticate': 'Bearer'})
-    return wrapped
 
 
 def status_response(status):
@@ -71,7 +51,7 @@ def blocking_execute(code):
 
 @routes.post('/execute')
 @authenticated_users_only
-async def execute(request):
+async def execute(request, userdata):
     code = await request.json()
     info(f'execute: {code}')
     try:
@@ -91,7 +71,7 @@ def blocking_value_type(code):
 
 @routes.post('/type/value')
 @authenticated_users_only
-async def value_type(request):
+async def value_type(request, userdata):
     code = await request.json()
     info(f'value type: {code}')
     try:
@@ -116,7 +96,7 @@ def blocking_table_type(code):
 
 @routes.post('/type/table')
 @authenticated_users_only
-async def table_type(request):
+async def table_type(request, userdata):
     code = await request.json()
     info(f'table type: {code}')
     try:
@@ -144,7 +124,7 @@ def blocking_matrix_type(code):
 
 @routes.post('/type/matrix')
 @authenticated_users_only
-async def matrix_type(request):
+async def matrix_type(request, userdata):
     code = await request.json()
     info(f'matrix type: {code}')
     try:
@@ -170,7 +150,7 @@ def blocking_blockmatrix_type(code):
 
 @routes.post('/type/blockmatrix')
 @authenticated_users_only
-async def blockmatrix_type(request):
+async def blockmatrix_type(request, userdata):
     code = await request.json()
     info(f'blockmatrix type: {code}')
     try:
@@ -185,7 +165,7 @@ async def blockmatrix_type(request):
 
 @routes.post('/references/create')
 @authenticated_users_only
-async def create_reference(request):
+async def create_reference(request, userdata):
     try:
         config = await request.json()
         hl.ReferenceGenome._from_config(config)
@@ -198,7 +178,7 @@ async def create_reference(request):
 
 @routes.post('/references/create/fasta')
 @authenticated_users_only
-async def create_reference_from_fasta(request):
+async def create_reference_from_fasta(request, userdata):
     try:
         data = await request.json()
         hl.ReferenceGenome.from_fasta_file(
@@ -225,7 +205,7 @@ def blocking_get_reference(data):
 
 @routes.get('/references/get')
 @authenticated_users_only
-async def get_reference(request):
+async def get_reference(request, userdata):
     try:
         data = await request.json()
         result = await run(blocking_get_reference, data)
@@ -243,7 +223,7 @@ def blocking_reference_add_sequence(data):
 
 @routes.post('/references/sequence/set')
 @authenticated_users_only
-async def reference_add_sequence(request):
+async def reference_add_sequence(request, userdata):
     try:
         data = await request.json()
         await run(blocking_reference_add_sequence, data)
@@ -259,7 +239,7 @@ def blocking_reference_remove_sequence(data):
 
 @routes.delete('/references/sequence/delete')
 @authenticated_users_only
-async def reference_remove_sequence(request):
+async def reference_remove_sequence(request, userdata):
     try:
         data = await request.json()
         await run(blocking_reference_remove_sequence, data)
@@ -279,7 +259,7 @@ def blocking_reference_add_liftover(data):
 
 @routes.post('/references/liftover/add')
 @authenticated_users_only
-async def reference_add_liftover(request):
+async def reference_add_liftover(request, userdata):
     try:
         data = await request.json()
         await run(blocking_reference_add_liftover, data)
@@ -296,7 +276,7 @@ def blocking_reference_remove_liftover(data):
 
 @routes.delete('/references/liftover/remove')
 @authenticated_users_only
-async def reference_remove_liftover(request):
+async def reference_remove_liftover(request, userdata):
     try:
         data = await request.json()
         await run(blocking_reference_remove_liftover, data)
@@ -311,7 +291,7 @@ def blocking_parse_vcf_metadata(data):
 
 @routes.post('/parse-vcf-metadata')
 @authenticated_users_only
-async def parse_vcf_metadata(request):
+async def parse_vcf_metadata(request, userdata):
     try:
         data = await request.json()
         result = await run(blocking_parse_vcf_metadata, data)

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -13,7 +13,7 @@ import aiohttp_jinja2
 from gidgethub import aiohttp as gh_aiohttp, routing as gh_routing, sansio as gh_sansio
 
 import batch
-from hailjwt import authenticated_users_only
+from hailjwt import authenticated_developers_only
 
 from .log import log
 from .constants import BUCKET
@@ -35,7 +35,7 @@ routes = web.RouteTableDef()
 
 
 @routes.get('/')
-@authenticated_users_only
+@authenticated_developers_only
 @aiohttp_jinja2.template('index.html')
 async def index(request):  # pylint: disable=unused-argument
     wb_configs = []
@@ -74,7 +74,7 @@ async def index(request):  # pylint: disable=unused-argument
 
 
 @routes.get('/watched_branches/{watched_branch_index}/pr/{pr_number}')
-@authenticated_users_only
+@authenticated_developers_only
 @aiohttp_jinja2.template('pr.html')
 async def get_pr(request):
     watched_branch_index = int(request.match_info['watched_branch_index'])
@@ -119,7 +119,7 @@ async def get_pr(request):
 
 
 @routes.get('/batches')
-@authenticated_users_only
+@authenticated_developers_only
 @aiohttp_jinja2.template('batches.html')
 async def get_batches(request):
     batch_client = request.app['batch_client']
@@ -131,7 +131,7 @@ async def get_batches(request):
 
 
 @routes.get('/batches/{batch_id}')
-@authenticated_users_only
+@authenticated_developers_only
 @aiohttp_jinja2.template('batch.html')
 async def get_batch(request):
     batch_id = int(request.match_info['batch_id'])
@@ -148,7 +148,7 @@ async def get_batch(request):
 
 
 @routes.get('/batches/{batch_id}/jobs/{job_id}/log')
-@authenticated_users_only
+@authenticated_developers_only
 @aiohttp_jinja2.template('job_log.html')
 async def get_job_log(request):
     batch_id = int(request.match_info['batch_id'])

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,9 +1,6 @@
-.PHONY: build clean
+.PHONY: push deploy build clean
 
 build: build-stmp
-
-ifeq ($(IN_HAIL_CI),1)
-.PHONY: push deploy
 
 PROJECT := $(shell gcloud config get-value project)
 BASE_LATEST = gcr.io/$(PROJECT)/base:latest
@@ -22,11 +19,6 @@ push: build
 	docker push $(BASE_IMAGE)
 
 deploy: push
-else
-build-stmp: Dockerfile.base core-site.xml requirements.txt
-	docker build -t base -f Dockerfile.base .
-	touch build-stmp
-endif
 
 clean:
 	rm -f build-stmp

--- a/gateway/.gitignore
+++ b/gateway/.gitignore
@@ -1,0 +1,2 @@
+/deployment.yaml.out
+/service.yaml.out

--- a/gateway/gateway.nginx.conf
+++ b/gateway/gateway.nginx.conf
@@ -23,15 +23,17 @@ server {
 }
 
 server {
-    server_name *.internal.hail.is;
+    server_name internal.hail.is;
 
     location = /auth {
         internal;
-        proxy_pass http://router-resolver/;
-        proxy_set_header Host $host;
+        resolver kube-dns.kube-system.svc.cluster.local;
+        proxy_pass http://router-resolver.default.svc.cluster.local/auth/$namespace;
     }
 
-    location / {
+    location ~ ^/([^/]+) {
+        set $namespace $1;
+
         auth_request /auth;
         auth_request_set $router_ip $upstream_http_x_router_ip;
 
@@ -57,7 +59,7 @@ server {
 }
 
 server {
-    server_name .hail.is;
+    server_name hail.is;
 
     location / {
         proxy_pass http://router/;

--- a/hailjwt/hailjwt/__init__.py
+++ b/hailjwt/hailjwt/__init__.py
@@ -1,7 +1,8 @@
-from .hailjwt import JWTClient, get_domain, authenticated_users_only
+from .hailjwt import JWTClient, get_domain, authenticated_users_only, authenticated_developers_only
 
 __all__ = [
     'JWTClient',
     'get_domain',
-    'authenticated_users_only'
+    'authenticated_users_only',
+    'authenticated_developers_only'
 ]

--- a/monitoring/.gitignore
+++ b/monitoring/.gitignore
@@ -1,0 +1,1 @@
+/router.yaml.out

--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:18.04
+
+RUN apt-get update -y && \
+    apt-get install -y nginx && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN rm -f /etc/nginx/sites-enabled/default
+ADD router.nginx.conf /etc/nginx/conf.d
+
+RUN ln -sf /dev/stdout /var/log/nginx/access.log
+RUN ln -sf /dev/stderr /var/log/nginx/error.log
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -1,0 +1,24 @@
+.PHONY: build push deploy
+
+PROJECT = $(shell gcloud config get-value project)
+MONITORING_ROUTER_LATEST = gcr.io/$(PROJECT)/monitoring-router:latest
+MONITORING_ROUTER_IMAGE = gcr.io/$(PROJECT)/monitoring-router:$(shell docker images -q --no-trunc monitoring-router | sed -e 's,[^:]*:,,')
+
+build:
+	docker pull ubuntu:18.04
+	-docker pull $(MONITORING_ROUTER_LATEST)
+	docker build -t monitoring-router --cache-from monitoring-router,$(MONITORING_ROUTER_LATEST),ubuntu:18.04 .
+
+push: build
+	docker tag monitoring-router $(MONITORING_ROUTER_LATEST)
+	docker push $(MONITORING_ROUTER_LATEST)
+	docker tag monitoring-router $(MONITORING_ROUTER_IMAGE)
+	docker push $(MONITORING_ROUTER_IMAGE)
+
+# FIXME use stateful set or prometheus, grafana
+deploy: push
+	kubectl -n monitoring delete deployments prometheus grafana
+	sleep 5
+	kubectl apply -f monitoring.yaml
+	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"monitoring_router_image":{"image":"$(MONITORING_ROUTER_IMAGE)"}}' router.yaml router.yaml.out
+	kubectl apply -f router.yaml.out

--- a/monitoring/grafana-cluster.json
+++ b/monitoring/grafana-cluster.json
@@ -1,0 +1,605 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 7,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(kube_node_info)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Node Count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 7,
+        "x": 7,
+        "y": 0
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(rate(http_request_duration_microseconds{quantile=\"0.99\"}[5m]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "mean",
+          "refId": "A"
+        },
+        {
+          "expr": "max(rate(http_request_duration_microseconds{quantile=\"0.99\"}[5m]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "max",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Request Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 7,
+        "x": 14,
+        "y": 0
+      },
+      "id": 10,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(node_network_receive_bytes_total[5m]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "received",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(node_network_transmit_bytes_total[5m]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "sent",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Network",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 7,
+        "x": 0,
+        "y": 5
+      },
+      "id": 12,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(kube_pod_info)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Pods",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 7,
+        "x": 7,
+        "y": 5
+      },
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(kube_pod_container_resource_requests_cpu_cores)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "requested",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(kube_node_status_allocatable_cpu_cores)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "available",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(node_load1)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "1m load average",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Cores",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 7,
+        "x": 14,
+        "y": 5
+      },
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(kube_pod_container_resource_requests_memory_bytes)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "requested",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(kube_node_status_allocatable_memory_bytes)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "available",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Memory",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Cluster",
+  "uid": "fTL6coMWz",
+  "version": 13
+}

--- a/monitoring/monitoring.yaml
+++ b/monitoring/monitoring.yaml
@@ -1,0 +1,427 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: node-exporter
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: node-exporter
+  template:
+    metadata:
+      name: node-exporter
+      labels:
+        daemon: node-exporter
+        app: node-exporter
+        grafanak8sapp: "true"
+    spec:
+      volumes:
+       - name: proc
+         hostPath:
+           path: /proc
+       - name: sys
+         hostPath:
+           path: /sys
+      tolerations:
+       - key: preemptible
+         value: "true"
+      containers:
+       - name: node-exporter
+         image: quay.io/prometheus/node-exporter:v0.18.0
+         args:
+          - --path.procfs=/proc_host
+          - --path.sysfs=/host_sys
+         ports:
+          - name: node-exporter
+            hostPort: 9100
+            containerPort: 9100
+         volumeMounts:
+          - name: sys
+            readOnly: true
+            mountPath: /host_sys
+          - name: proc
+            readOnly: true
+            mountPath: /proc_host
+         imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      hostNetwork: true
+      hostPID: true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics
+  namespace: monitoring
+rules:
+ - apiGroups: [""]
+   resources:
+   - configmaps
+   - secrets
+   - nodes
+   - pods
+   - services
+   - resourcequotas
+   - replicationcontrollers
+   - limitranges
+   - persistentvolumeclaims
+   - persistentvolumes
+   - namespaces
+   - endpoints
+   verbs: ["list", "watch"]
+ - apiGroups: ["extensions"]
+   resources:
+   - daemonsets
+   - deployments
+   - replicasets
+   - ingresses
+   verbs: ["list", "watch"]
+ - apiGroups: ["apps"]
+   resources:
+   - daemonsets
+   - deployments
+   - replicasets
+   - statefulsets
+   verbs: ["list", "watch"]
+ - apiGroups: ["batch"]
+   resources:
+   - cronjobs
+   - jobs
+   verbs: ["list", "watch"]
+ - apiGroups: ["autoscaling"]
+   resources:
+   - horizontalpodautoscalers
+   verbs: ["list", "watch"]
+ - apiGroups: ["policy"]
+   resources:
+   - poddisruptionbudgets
+   verbs: ["list", "watch"]
+ - apiGroups: ["certificates.k8s.io"]
+   resources:
+   - certificatesigningrequests
+   verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+ - kind: ServiceAccount
+   name: kube-state-metrics
+   namespace: monitoring
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: monitoring
+  labels:
+    app: kube-state-metrics
+    grafanak8sapp: "true"
+spec:
+  selector:
+    matchLabels:
+      app: kube-state-metrics
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: kube-state-metrics
+        grafanak8sapp: "true" 
+    spec:
+      serviceAccountName: kube-state-metrics
+      containers:
+      - name: kube-state-metrics
+        image: quay.io/coreos/kube-state-metrics:v1.6.0
+        ports:
+        - name: http-metrics
+          containerPort: 8080
+        - name: telemetry
+          containerPort: 8081
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: monitoring
+  labels:
+    app: kube-state-metrics
+  annotations:
+    prometheus.io/scrape: 'true'
+spec:
+  ports:
+   - name: http-metrics
+     port: 8080
+     targetPort: http-metrics
+     protocol: TCP
+   - name: telemetry
+     port: 8081
+     targetPort: telemetry
+     protocol: TCP
+  selector:
+    app: kube-state-metrics
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: prometheus
+  namespace: monitoring
+rules:
+ - apiGroups: [""]
+   resources:
+    - nodes
+    - nodes/proxy
+    - services
+    - endpoints
+    - pods
+   verbs: ["get", "list", "watch"]
+ - apiGroups:
+    - extensions
+   resources:
+    - ingresses
+   verbs: ["get", "list", "watch"]
+ - nonResourceURLs: ["/metrics"]
+   verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+ - kind: ServiceAccount
+   name: prometheus
+   namespace: monitoring
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etc-prometheus
+  namespace: monitoring
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+    scrape_configs:
+     - job_name: 'kubernetes-kubelet'
+       scheme: https
+       tls_config:
+         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+         insecure_skip_verify: true
+       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+       kubernetes_sd_configs:
+        - role: node
+       relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_node_label_(.+)
+        - target_label: __address__
+          replacement: kubernetes.default.svc.cluster.local:443
+        - source_labels: [__meta_kubernetes_node_name]
+          regex: (.+)
+          target_label: __metrics_path__
+          replacement: /api/v1/nodes/${1}/proxy/metrics
+     - job_name: 'kubernetes-cadvisor'
+       scheme: https
+       tls_config:
+         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+         insecure_skip_verify: true
+       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+       kubernetes_sd_configs:
+        - role: node
+       relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_node_label_(.+)
+        - target_label: __address__
+          replacement: kubernetes.default.svc.cluster.local:443
+        - source_labels: [__meta_kubernetes_node_name]
+          regex: (.+)
+          target_label: __metrics_path__
+          replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+     - job_name: 'kubernetes-kube-state'
+       kubernetes_sd_configs:
+        - role: pod
+       relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
+        - source_labels: [__meta_kubernetes_namespace]
+          action: replace
+          target_label: kubernetes_namespace
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: kubernetes_pod_name
+        - source_labels: [__meta_kubernetes_pod_label_grafanak8sapp]
+          regex: .*true.*
+          action: keep
+        - source_labels: ['__meta_kubernetes_pod_label_daemon', '__meta_kubernetes_pod_node_name']
+          regex: 'node-exporter;(.*)'
+          action: replace
+          target_label: nodename
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-storage
+  namespace: monitoring
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    name: prometheus
+  name: prometheus
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: prometheus
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      securityContext:
+        fsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: prometheus
+      containers:
+       - name: prometheus
+         image: prom/prometheus:v2.10.0
+         imagePullPolicy: Always
+         command:
+          - "/bin/prometheus"
+          - "--config.file=/etc/prometheus/prometheus.yml"
+          - "--storage.tsdb.path=/prometheus"
+          - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+          - "--web.console.templates=/usr/share/prometheus/consoles"
+          - "--web.external-url=https://internal.hail.is/monitoring/prometheus"
+         ports:
+          - containerPort: 9090
+            protocol: TCP
+         volumeMounts:
+          - mountPath: "/etc/prometheus"
+            name: etc-prometheus
+          - mountPath: "/prometheus"
+            name: prometheus-storage
+      volumes:
+       - name: etc-prometheus
+         configMap:
+           name: etc-prometheus
+       - name: prometheus-storage
+         persistentVolumeClaim:
+           claimName: prometheus-storage
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  ports:
+   - port: 80
+     targetPort: 9090
+  selector:
+    app: prometheus
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-storage
+  namespace: monitoring
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: monitoring
+  labels:
+    app: grafana
+spec:
+  selector:
+    matchLabels:
+      app: grafana
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      securityContext:
+        fsGroup: 472
+        runAsNonRoot: true
+        runAsUser: 472
+      containers:
+       - name: grafana
+         image: grafana/grafana:6.2.1
+         env:
+          - name: GF_SERVER_DOMAIN
+            value: internal.hail.is
+          - name: GF_SERVER_ROOT_URL
+            value: "%(protocol)s://%(domain)s/monitoring/grafana/"
+         volumeMounts:
+          - mountPath: /var/lib/grafana
+            name: grafana-storage
+         resources:
+           requests:
+             memory: "1G"
+             cpu: "1"
+         ports:
+          - containerPort: 3000
+      volumes:
+       - name: grafana-storage
+         persistentVolumeClaim:
+           claimName: grafana-storage
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  ports:
+   - port: 80
+     targetPort: 3000
+  selector:
+    app: grafana

--- a/monitoring/router.nginx.conf
+++ b/monitoring/router.nginx.conf
@@ -1,0 +1,14 @@
+server {
+    server_name _;
+
+    location /monitoring/grafana/ {
+        proxy_pass http://grafana/;
+    }
+
+    location /monitoring/prometheus/ {
+        proxy_pass http://prometheus;
+    }
+
+    listen 80 default_server;
+    listen [::]:80 default_server;
+}

--- a/monitoring/router.yaml
+++ b/monitoring/router.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: router
+  namespace: monitoring
+  labels:
+    app: router
+    hail.is/sha: "{{ code.sha }}"
+spec:
+  selector:
+    matchLabels:
+      app: router
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: router
+        hail.is/sha: "{{ code.sha }}"
+    spec:
+      containers:
+       - name: router
+         image: "{{ monitoring_router_image.image }}"
+         ports:
+          - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: router
+  namespace: monitoring
+  labels:
+    app: router
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: router

--- a/router-resolver/Dockerfile
+++ b/router-resolver/Dockerfile
@@ -1,6 +1,11 @@
 FROM {{ base_image.image }}
 
-COPY router-resolver /router-resolver
+COPY hailjwt/setup.py /hailjwt/
+COPY hailjwt/hailjwt /hailjwt/hailjwt/
+RUN pip3 install --no-cache-dir /hailjwt && \
+  rm -rf /hailjwt
+
+COPY router-resolver/router-resolver /router-resolver
 
 EXPOSE 5000
 

--- a/router-resolver/Makefile
+++ b/router-resolver/Makefile
@@ -8,7 +8,7 @@ build:
 	make -C ../docker build
 	-docker pull $(ROUTER_RESOLVER_LATEST)
 	python3 ../ci/jinja2_render.py '{"base_image":{"image":"base"}}' Dockerfile Dockerfile.out
-	docker build -f Dockerfile.out -t router-resolver --cache-from router-resolver,$(ROUTER_RESOLVER_LATEST),base .
+	docker build -f Dockerfile.out -t router-resolver --cache-from router-resolver,$(ROUTER_RESOLVER_LATEST),base ..
 
 push: build
 	docker tag router-resolver $(ROUTER_RESOLVER_LATEST)

--- a/router-resolver/deployment.yaml
+++ b/router-resolver/deployment.yaml
@@ -68,8 +68,17 @@ spec:
            limits:
              memory: "1G"
              cpu: "1"
+         volumeMounts:
+          - name: jwt-secret-key
+            mountPath: /jwt-secret-key
+            readOnly: true
          ports:
           - containerPort: 5000
+      volumes:
+       - name: jwt-secret-key
+         secret:
+           optional: false
+           secretName: jwt-secret-key
 ---
 apiVersion: v1
 kind: Service

--- a/router/.gitignore
+++ b/router/.gitignore
@@ -1,0 +1,1 @@
+/deployment.yaml.out


### PR DESCRIPTION
Changes:
 - added monitoring setup (Prometheus, Grafana) to monitoring namespace
 - I'm considering monitoring part of "infrastructure", no automated tests, gateway and router-resolver changes already deployed
 - authenticated_users_only always passes userdata as second argument
 - added authenticated_developers_only decorator to hailjwt, no userdata
 - gateway forwards to internal namespaces: internal.hail.is/namespace proxies to router.namespace, so in general you'll go to internal.hail.is/namespace/service/the/real/url
 - proxy only if namespace has router service and authorized developer
 - add router to monitoring namespace that proxies for prometheus and grafana
 - restrict ci to authorized developers

monitoring/grafana-cluster.json is an export of an initial Grafana monitoring dashboard that I constructed through the UI.

If you're logged in as a developer, you can see Grafana at internal.hail.is/monitoring/grafana.  The admin password is in the usual place.
