### PR TITLE
[batch] Change client interface

### DIFF
--- a/batch/batch/aioclient.py
+++ b/batch/batch/aioclient.py
@@ -33,15 +33,27 @@ class Job:
         if attributes is None:
             attributes = {}
 
-        self.batch = batch
-        self.batch_id = self.batch.id
+        self._batch = batch
         self.job_id = job_id
-        self.id = (self.batch_id, self.job_id)
         self.attributes = attributes
         self.parent_ids = parent_ids
         self._status = _status
 
+    @property
+    def batch_id(self):
+        if self._batch.id is None:
+            raise ValueError("cannot get the batch_id of an unsubmitted")
+        return self._batch.id
+
+    @property
+    def id(self):
+        if self._batch.id is None:
+            raise ValueError("cannot get the id of an unsubmitted job")
+        return self.batch_id, self.job_id
+
     async def is_complete(self):
+        if self._batch.id is None:
+            raise ValueError("cannot determine if an unsubmitted job is complete")
         if self._status:
             state = self._status['state']
             if state in ('Complete', 'Cancelled'):
@@ -51,10 +63,14 @@ class Job:
         return state in ('Complete', 'Cancelled')
 
     async def status(self):
-        self._status = await self.batch._client._get(f'/batches/{self.batch_id}/jobs/{self.job_id}')
+        if self._batch.id is None:
+            raise ValueError("cannot get the status of an unsubmitted job")
+        self._status = await self._batch._client._get(f'/batches/{self.batch_id}/jobs/{self.job_id}')
         return self._status
 
     async def wait(self):
+        if self._batch.id is None:
+            raise ValueError("cannot wait on an unsubmitted job")
         i = 0
         while True:
             if await self.is_complete():
@@ -66,7 +82,9 @@ class Job:
                 i = i + 1
 
     async def log(self):
-        return await self.batch._client._get(f'/batches/{self.batch_id}/jobs/{self.job_id}/log')
+        if self._batch.id is None:
+            raise ValueError("cannot get the log of a unsubmitted job")
+        return await self._batch._client._get(f'/batches/{self.batch_id}/jobs/{self.job_id}/log')
 
 
 class Batch:
@@ -74,17 +92,60 @@ class Batch:
         self._client = client
         self.id = id
         self.attributes = attributes
-        self._job_idx = 0
 
-    async def create_job(self, image, command=None, args=None, env=None, ports=None,
-                         resources=None, tolerations=None, volumes=None, security_context=None,
-                         service_account_name=None, attributes=None, callback=None, parents=None,
-                         input_files=None, output_files=None, always_run=False, pvc_size=None):
+    async def cancel(self):
+        await self._client._patch(f'/batches/{self.id}/cancel')
+
+    async def status(self):
+        return await self._client._get(f'/batches/{self.id}')
+
+    async def wait(self):
+        i = 0
+        while True:
+            status = await self.status()
+            if status['complete']:
+                return status
+            j = random.randrange(math.floor(1.1 ** i))
+            time.sleep(0.100 * j)
+            # max 4.45s
+            if i < 64:
+                i = i + 1
+
+    async def delete(self):
+        await self._client._delete(f'/batches/{self.id}')
+
+
+class BatchBuilder:
+    def __init__(self, client, attributes, callback):
+        doc = {}
+        if attributes:
+            doc['attributes'] = attributes
+        if callback:
+            doc['callback'] = callback
+
+        self._client = client
+        self._batch = Batch(client, None, attributes)
+        self._doc = doc
+        self._job_idx = 0
+        self._job_docs = []
+        self._submitted = False
+
+    def create_job(self, image, command=None, args=None, env=None, ports=None,
+                   resources=None, tolerations=None, volumes=None, security_context=None,
+                   service_account_name=None, attributes=None, callback=None, parents=None,
+                   input_files=None, output_files=None, always_run=False, pvc_size=None):
+        if self._submitted:
+            raise ValueError("cannot create a job on an already submitted batch")
+
         self._job_idx += 1
 
         if parents is None:
             parents = []
         parent_ids = [parent.job_id for parent in parents]
+
+        invalid_parents = list(filter(lambda parent: parent._batch != self._batch, parents))
+        if len(invalid_parents) != 0:
+            raise ValueError("found parents from another batch")
 
         if env:
             env = [{'name': k, 'value': v} for (k, v) in env.items()]
@@ -138,7 +199,6 @@ class Batch:
             'spec': spec,
             'parent_ids': parent_ids,
             'always_run': always_run,
-            'batch_id': self.id,
             'job_id': self._job_idx
         }
         if attributes:
@@ -152,36 +212,30 @@ class Batch:
         if pvc_size:
             doc['pvc_size'] = pvc_size
 
-        j = await self._client._post('/jobs/create', json=doc)
+        self._job_docs.append(doc)
 
-        return Job(self,
-                   j['job_id'],
-                   attributes=j.get('attributes'),
-                   parent_ids=j.get('parent_ids', []))
+        j = Job(self._batch,
+                self._job_idx,
+                attributes=attributes,
+                parent_ids=parent_ids)
+        return j
 
-    async def close(self):
-        await self._client._patch(f'/batches/{self.id}/close')
+    async def submit(self):
+        if self._submitted:
+            raise ValueError("cannot submit an already submitted batch")
+        self._submitted = True
 
-    async def cancel(self):
-        await self._client._patch(f'/batches/{self.id}/cancel')
+        if len(self._job_docs) != 0:
+            self._doc['jobs'] = self._job_docs
 
-    async def status(self):
-        return await self._client._get(f'/batches/{self.id}')
+        b = await self._client._post('/batches/create', json=self._doc)
+        self._batch.id = b['id']
+        self._batch.attributes = b.get('attributes')
 
-    async def wait(self):
-        i = 0
-        while True:
-            status = await self.status()
-            if status['complete']:
-                return status
-            j = random.randrange(math.floor(1.1 ** i))
-            time.sleep(0.100 * j)
-            # max 4.45s
-            if i < 64:
-                i = i + 1
+        self._job_docs = []
+        self._job_idx = 0
 
-    async def delete(self):
-        await self._client._delete(f'/batches/{self.id}')
+        return self._batch
 
 
 class BatchClient:
@@ -250,16 +304,8 @@ class BatchClient:
                      b['id'],
                      attributes=b.get('attributes'))
 
-    async def create_batch(self, attributes=None, callback=None, ttl=None):
-        doc = {}
-        if attributes:
-            doc['attributes'] = attributes
-        if callback:
-            doc['callback'] = callback
-        if ttl:
-            doc['ttl'] = ttl
-        b = await self._post('/batches/create', json=doc)
-        return Batch(self, b['id'], b.get('attributes'))
+    def create_batch(self, attributes=None, callback=None):
+        return BatchBuilder(self, attributes, callback)
 
     async def close(self):
         await self._session.close()

--- a/batch/batch/client.py
+++ b/batch/batch/client.py
@@ -19,8 +19,8 @@ class Job:
         return j
 
     def __init__(self, batch, job_id, attributes=None, parent_ids=None, _status=None):
-        self._async_job = aioclient.Job(batch, job_id, attributes=attributes,
-                                        parent_ids=parent_ids, _status=_status)
+        j = aioclient.SubmittedJob(batch, job_id, attributes, parent_ids, _status)
+        self._async_job = aioclient.Job(j)
 
     @property
     def _status(self):
@@ -99,10 +99,6 @@ class BatchBuilder:
 
     def __init__(self, client, attributes, callback):
         self._async_builder = aioclient.BatchBuilder(client, attributes, callback)
-
-    @property
-    def _batch(self):
-        return Batch.from_async_batch(self._async_builder._batch)
 
     def create_job(self, image, command=None, args=None, env=None, ports=None,
                    resources=None, tolerations=None, volumes=None, security_context=None,

--- a/batch/batch/client.py
+++ b/batch/batch/client.py
@@ -77,22 +77,6 @@ class Batch:
     def attributes(self):
         return self._async_batch.attributes
 
-    def create_job(self, image, command=None, args=None, env=None, ports=None,
-                   resources=None, tolerations=None, volumes=None, security_context=None,
-                   service_account_name=None, attributes=None, callback=None, parents=None,
-                   input_files=None, output_files=None, always_run=False, pvc_size=None):
-        coroutine = self._async_batch.create_job(
-            image, command=command, args=args, env=env, ports=ports,
-            resources=resources, tolerations=tolerations, volumes=volumes,
-            security_context=security_context, service_account_name=service_account_name,
-            attributes=attributes, callback=callback, parents=parents,
-            input_files=input_files, output_files=output_files, always_run=always_run,
-            pvc_size=pvc_size)
-        return Job.from_async_job(async_to_blocking(coroutine))
-
-    def close(self):
-        async_to_blocking(self._async_batch.close())
-
     def cancel(self):
         async_to_blocking(self._async_batch.cancel())
 
@@ -104,6 +88,42 @@ class Batch:
 
     def delete(self):
         async_to_blocking(self._async_batch.delete())
+
+
+class BatchBuilder:
+    @classmethod
+    def from_async_builder(cls, builder):
+        b = object.__new__(cls)
+        b._async_builder = builder
+        return b
+
+    def __init__(self, client, attributes, callback):
+        self._async_builder = aioclient.BatchBuilder(client, attributes, callback)
+
+    @property
+    def _batch(self):
+        return Batch.from_async_batch(self._async_builder._batch)
+
+    def create_job(self, image, command=None, args=None, env=None, ports=None,
+                   resources=None, tolerations=None, volumes=None, security_context=None,
+                   service_account_name=None, attributes=None, callback=None, parents=None,
+                   input_files=None, output_files=None, always_run=False, pvc_size=None):
+        if parents:
+            parents = [parent._async_job for parent in parents]
+
+        async_job = self._async_builder.create_job(
+            image, command=command, args=args, env=env, ports=ports,
+            resources=resources, tolerations=tolerations, volumes=volumes,
+            security_context=security_context, service_account_name=service_account_name,
+            attributes=attributes, callback=callback, parents=parents,
+            input_files=input_files, output_files=output_files, always_run=always_run,
+            pvc_size=pvc_size)
+
+        return Job.from_async_job(async_job)
+
+    def submit(self):
+        async_batch = async_to_blocking(self._async_builder.submit())
+        return Batch.from_async_batch(async_batch)
 
 
 class BatchClient:
@@ -131,10 +151,9 @@ class BatchClient:
         b = async_to_blocking(self._async_client.get_batch(id))
         return Batch.from_async_batch(b)
 
-    def create_batch(self, attributes=None, callback=None, ttl=None):
-        b = async_to_blocking(
-            self._async_client.create_batch(attributes=attributes, callback=callback, ttl=ttl))
-        return Batch.from_async_batch(b)
+    def create_batch(self, attributes=None, callback=None):
+        builder = self._async_client.create_batch(attributes=attributes, callback=callback)
+        return BatchBuilder.from_async_builder(builder)
 
     def close(self):
         async_to_blocking(self._async_client.close())

--- a/batch/batch/schemas.py
+++ b/batch/batch/schemas.py
@@ -4,3 +4,37 @@ pod_spec = {
     'allow_unknown': True,
     'schema': {}
 }
+
+job_schema = {
+    'type': 'dict',
+    'required': True,
+    'allow_unknown': True,
+    'schema': {
+        'job_id': {'type': 'integer', 'nullable': False},
+        'spec': pod_spec,
+        'parent_ids': {'type': 'list', 'schema': {'type': 'integer'}},
+        'input_files': {
+            'type': 'list',
+            'schema': {'type': 'list', 'items': 2 * ({'type': 'string'},)}},
+        'output_files': {
+            'type': 'list',
+            'schema': {'type': 'list', 'items': 2 * ({'type': 'string'},)}},
+        'always_run': {'type': 'boolean'},
+        'attributes': {
+            'type': 'dict',
+            'keyschema': {'type': 'string'},
+            'valueschema': {'type': 'string'}
+        },
+        'callback': {'type': 'string'}
+    }
+}
+
+batch_schema = {
+    'attributes': {
+        'type': 'dict',
+        'keyschema': {'type': 'string'},
+        'valueschema': {'type': 'string'}
+    },
+    'callback': {'type': 'string'},
+    'jobs': {'type': 'list', 'schema': job_schema}
+}

--- a/batch/create-batch-tables.sql
+++ b/batch/create-batch-tables.sql
@@ -4,8 +4,6 @@ CREATE TABLE IF NOT EXISTS `batch` (
   `user` VARCHAR(100) NOT NULL,
   `attributes` TEXT(65535),
   `callback` TEXT(65535),
-  `ttl` INT,
-  `is_open` BOOLEAN NOT NULL,
   `deleted` BOOLEAN NOT NULL default false,
   `n_jobs` INT NOT NULL default 0,
   `n_completed` INT NOT NULL default 0,

--- a/batch/test/test_aioclient.py
+++ b/batch/test/test_aioclient.py
@@ -18,9 +18,9 @@ class Test(unittest.TestCase):
 
     def test_job(self):
         async def f():
-            b = await self.client.create_batch()
-            j = await b.create_job('alpine', ['echo', 'test'])
-            b.close()
+            b = self.client.create_batch()
+            j = b.create_job('alpine', ['echo', 'test'])
+            await b.submit()
             status = await j.wait()
             self.assertTrue('attributes' not in status)
             self.assertEqual(status['state'], 'Complete')

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -28,9 +28,9 @@ class Test(unittest.TestCase):
         self.client.close()
 
     def test_job(self):
-        b = self.client.create_batch()
-        j = b.create_job('alpine', ['echo', 'test'])
-        b.close()
+        builder = self.client.create_batch()
+        j = builder.create_job('alpine', ['echo', 'test'])
+        builder.submit()
         status = j.wait()
         self.assertTrue('attributes' not in status)
         self.assertEqual(status['state'], 'Complete')
@@ -40,45 +40,47 @@ class Test(unittest.TestCase):
 
         self.assertTrue(j.is_complete())
 
-    def test_create_fails_for_closed_batch(self):
-        b = self.client.create_batch()
-        b.close()
-        try:
-            b.create_job('alpine', ['echo', 'test'])
-        except aiohttp.ClientResponseError as err:
-            assert err.status == 400
-            assert re.search('.*invalid request: batch_id [0-9]+ is closed', err.message)
-            return
-        assert False
-
-    def test_batch_ttl(self):
-        b = self.client.create_batch(ttl=1)
-        t = 1
-        while b.status()['is_open']:
-            if t > 64:
-                assert False, "took more than 128 seconds to close a batch with ttl 1"
-            time.sleep(t)
-            t = t * 2
-
     def test_attributes(self):
         a = {
             'name': 'test_attributes',
             'foo': 'bar'
         }
-        b = self.client.create_batch()
-        j = b.create_job('alpine', ['true'], attributes=a)
+        builder = self.client.create_batch()
+        j = builder.create_job('alpine', ['true'], attributes=a)
+        builder.submit()
         status = j.status()
         assert(status['attributes'] == a)
+
+    def test_unsubmitted_state(self):
+        builder = self.client.create_batch()
+        j = builder.create_job('alpine', ['echo', 'test'])
+
+        with self.assertRaises(ValueError):
+            j.batch_id
+        with self.assertRaises(ValueError):
+            j.id
+        with self.assertRaises(ValueError):
+            j.status()
+        with self.assertRaises(ValueError):
+            j.is_complete()
+        with self.assertRaises(ValueError):
+            j.log()
+        with self.assertRaises(ValueError):
+            j.wait()
+
+        builder.submit()
+        with self.assertRaises(ValueError):
+            builder.create_job('alpine', ['echo', 'test'])
 
     def test_list_batches(self):
         tag = secrets.token_urlsafe(64)
         b1 = self.client.create_batch(attributes={'tag': tag, 'name': 'b1'})
         b1.create_job('alpine', ['sleep', '30'])
-        b1.close()
+        b1 = b1.submit()
 
         b2 = self.client.create_batch(attributes={'tag': tag, 'name': 'b2'})
         b2.create_job('alpine', ['echo', 'test'])
-        b2.close()
+        b2 = b2.submit()
 
         def assert_batch_ids(expected, complete=None, success=None, attributes=None):
             batches = self.client.list_batches(complete=complete, success=success, attributes=attributes)
@@ -110,14 +112,14 @@ class Test(unittest.TestCase):
     def test_fail(self):
         b = self.client.create_batch()
         j = b.create_job('alpine', ['false'])
-        b.close()
+        b.submit()
         status = j.wait()
         self.assertEqual(status['exit_code']['main'], 1)
 
     def test_deleted_job_log(self):
         b = self.client.create_batch()
         j = b.create_job('alpine', ['echo', 'test'])
-        b.close()
+        b = b.submit()
         j.wait()
         b.delete()
 
@@ -132,7 +134,7 @@ class Test(unittest.TestCase):
     def test_delete_batch(self):
         b = self.client.create_batch()
         j = b.create_job('alpine', ['sleep', '30'])
-        b.close()
+        b = b.submit()
         b.delete()
 
         # verify doesn't exist
@@ -147,7 +149,7 @@ class Test(unittest.TestCase):
     def test_cancel_batch(self):
         b = self.client.create_batch()
         j = b.create_job('alpine', ['sleep', '30'])
-        b.close()
+        b = b.submit()
 
         status = j.status()
         self.assertTrue(status['state'], 'Ready')
@@ -179,7 +181,7 @@ class Test(unittest.TestCase):
     def test_get_job(self):
         b = self.client.create_batch()
         j = b.create_job('alpine', ['true'])
-        b.close()
+        b.submit()
 
         j2 = self.client.get_job(*j.id)
         status2 = j2.status()
@@ -190,7 +192,7 @@ class Test(unittest.TestCase):
         j1 = b.create_job('alpine', ['false'])
         j2 = b.create_job('alpine', ['sleep', '1'])
         j3 = b.create_job('alpine', ['sleep', '30'])
-        b.close()
+        b = b.submit()
 
         j1.wait()
         j2.wait()
@@ -210,7 +212,7 @@ class Test(unittest.TestCase):
     def test_batch_status(self):
         b1 = self.client.create_batch()
         b1.create_job('alpine', ['true'])
-        b1.close()
+        b1 = b1.submit()
         b1.wait()
         b1s = b1.status()
         assert b1s['complete'] and b1s['state'] == 'success', b1s
@@ -218,20 +220,20 @@ class Test(unittest.TestCase):
         b2 = self.client.create_batch()
         b2.create_job('alpine', ['false'])
         b2.create_job('alpine', ['true'])
-        b2.close()
+        b2 = b2.submit()
         b2.wait()
         b2s = b2.status()
         assert b2s['complete'] and b2s['state'] == 'failure', b2s
 
         b3 = self.client.create_batch()
         b3.create_job('alpine', ['sleep', '30'])
-        b3.close()
+        b3 = b3.submit()
         b3s = b3.status()
         assert not b3s['complete'] and b3s['state'] == 'running', b3s
 
         b4 = self.client.create_batch()
         b4.create_job('alpine', ['sleep', '30'])
-        b4.close()
+        b4 = b4.submit()
         b4.cancel()
         b4.wait()
         b4s = b4.status()
@@ -256,7 +258,7 @@ class Test(unittest.TestCase):
                 ['echo', 'test'],
                 attributes={'foo': 'bar'},
                 callback=server.url_for('/test'))
-            b.close()
+            b = b.submit()
             j.wait()
 
             batch.poll_until(lambda: 'status' in d)
@@ -270,7 +272,7 @@ class Test(unittest.TestCase):
     def test_log_after_failing_job(self):
         b = self.client.create_batch()
         j = b.create_job('alpine', ['/bin/sh', '-c', 'echo test; exit 127'])
-        b.close()
+        b.submit()
         status = j.wait()
         self.assertTrue('attributes' not in status)
         self.assertEqual(status['state'], 'Complete')
@@ -282,14 +284,12 @@ class Test(unittest.TestCase):
 
     def test_authorized_users_only(self):
         endpoints = [
-            (requests.post, '/jobs/create'),
             (requests.get, '/batches/0/jobs/0'),
             (requests.get, '/batches/0/jobs/0/log'),
             (requests.get, '/batches'),
             (requests.post, '/batches/create'),
             (requests.get, '/batches/0'),
             (requests.delete, '/batches/0'),
-            (requests.patch, '/batches/0/close'),
             (requests.get, '/ui/batches'),
             (requests.get, '/ui/batches/0'),
             (requests.get, '/ui/batches/0/jobs/0/log')]
@@ -311,7 +311,7 @@ class Test(unittest.TestCase):
         try:
             b = bc.create_batch()
             j = b.create_job('alpine', ['false'])
-            b.close()
+            b.submit()
             assert False, j
         except aiohttp.ClientResponseError as e:
             if e.status == 401:
@@ -332,7 +332,7 @@ class Test(unittest.TestCase):
     def test_ui_batch_and_job_log(self):
         b = self.client.create_batch()
         j = b.create_job('alpine', ['true'])
-        b.close()
+        b = b.submit()
         status = j.wait()
 
         with open(os.environ['HAIL_TOKEN_FILE']) as f:

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -49,7 +49,7 @@ def test_simple(client):
 def test_missing_parent_is_400(client):
     try:
         batch = client.create_batch()
-        fake_job = aioclient.Job(aioclient.UnsubmittedJob(batch, 10000))
+        fake_job = aioclient.Job.unsubmitted_job(batch._async_builder, 10000)
         fake_job = Job.from_async_job(fake_job)
         batch.create_job('alpine:3.8', command=['echo', 'head'], parents=[fake_job])
         batch.submit()

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -39,7 +39,7 @@ def test_simple(client):
     batch = client.create_batch()
     head = batch.create_job('alpine:3.8', command=['echo', 'head'])
     tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parents=[head])
-    batch.close()
+    batch = batch.submit()
     status = batch.wait()
     assert batch_status_job_counter(status, 'Complete') == 2
     assert batch_status_exit_codes(status) == [{'main': 0}, {'main': 0}]
@@ -48,9 +48,9 @@ def test_simple(client):
 def test_missing_parent_is_400(client):
     try:
         batch = client.create_batch()
-        fake_job = Job(batch, 100000)
+        fake_job = Job(batch._batch._async_batch, 100000)
         batch.create_job('alpine:3.8', command=['echo', 'head'], parents=[fake_job])
-        batch.close()
+        batch.submit()
     except aiohttp.ClientResponseError as err:
         assert err.status == 400
         assert re.search('.*invalid parent_id: no job with id.*', err.message)
@@ -64,7 +64,7 @@ def test_dag(client):
     left = batch.create_job('alpine:3.8', command=['echo', 'left'], parents=[head])
     right = batch.create_job('alpine:3.8', command=['echo', 'right'], parents=[head])
     tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parents=[left, right])
-    batch.close()
+    batch = batch.submit()
     status = batch.wait()
     assert batch_status_job_counter(status, 'Complete') == 4
     for node in [head, left, right, tail]:
@@ -82,7 +82,7 @@ def test_cancel_tail(client):
         'alpine:3.8',
         command=['/bin/sh', '-c', 'while true; do sleep 86000; done'],
         parents=[left, right])
-    batch.close()
+    batch = batch.submit()
     left.wait()
     right.wait()
     batch.cancel()
@@ -104,7 +104,7 @@ def test_cancel_left_after_tail(client):
         parents=[head])
     right = batch.create_job('alpine:3.8', command=['echo', 'right'], parents=[head])
     tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parents=[left, right])
-    batch.close()
+    batch = batch.submit()
     head.wait()
     right.wait()
     batch.cancel()
@@ -116,35 +116,6 @@ def test_cancel_left_after_tail(client):
         assert status['exit_code']['main'] == 0
     for node in [left, tail]:
         assert node.status()['state'] == 'Cancelled'
-
-
-def test_parent_already_done(client):
-    batch = client.create_batch()
-    head = batch.create_job('alpine:3.8', command=['echo', 'head'])
-    head.wait()
-    tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parents=[head])
-    batch.close()
-    status = batch.wait()
-    assert batch_status_job_counter(status, 'Complete') == 2
-    for node in [head, tail]:
-        status = node.status()
-        assert status['state'] == 'Complete'
-        assert status['exit_code']['main'] == 0
-
-
-def test_one_of_two_parents_already_done(client):
-    batch = client.create_batch()
-    left = batch.create_job('alpine:3.8', command=['echo', 'left'])
-    left.wait()
-    right = batch.create_job('alpine:3.8', command=['echo', 'right'])
-    tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parents=[left, right])
-    batch.close()
-    status = batch.wait()
-    assert batch_status_job_counter(status, 'Complete') == 3
-    for node in [left, right, tail]:
-        status = node.status()
-        assert status['state'] == 'Complete'
-        assert status['exit_code']['main'] == 0
 
 
 def test_callback(client):
@@ -165,7 +136,7 @@ def test_callback(client):
         left = batch.create_job('alpine:3.8', command=['echo', 'left'], parents=[head])
         right = batch.create_job('alpine:3.8', command=['echo', 'right'], parents=[head])
         tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parents=[left, right])
-        batch.close()
+        batch = batch.submit()
         batch.wait()
         i = 0
         while len(output) != 4:
@@ -192,9 +163,8 @@ def test_no_parents_allowed_in_other_batches(client):
     head = b1.create_job('alpine:3.8', command=['echo', 'head'])
     try:
         b2.create_job('alpine:3.8', command=['echo', 'tail'], parents=[head])
-    except aiohttp.ClientResponseError as err:
-        assert err.status == 400
-        assert re.search('.*invalid parent_id: no job with id .*', err.message)
+    except ValueError as err:
+        assert re.search('found parents from another batch', str(err))
         return
     assert False
 
@@ -209,7 +179,7 @@ def test_input_dependency(client):
                             command=['/bin/sh', '-c', 'cat /io/data1 ; cat /io/data2'],
                             input_files=[(f'gs://{user["bucket_name"]}/data*', '/io/')],
                             parents=[head])
-    batch.close()
+    batch.submit()
     tail.wait()
     assert head.status()['exit_code']['main'] == 0, head._status
     assert tail.log()['main'] == 'head1\nhead2\n'
@@ -225,7 +195,7 @@ def test_input_dependency_directory(client):
                             command=['/bin/sh', '-c', 'cat /io/test/data1 ; cat /io/test/data2'],
                             input_files=[(f'gs://{user["bucket_name"]}/test', '/io/')],
                             parents=[head])
-    batch.close()
+    batch.submit()
     tail.wait()
     assert head.status()['exit_code']['main'] == 0, head._status
     assert tail.log()['main'] == 'head1\nhead2\n', tail.log()
@@ -243,7 +213,7 @@ def test_always_run_cancel(client):
                             command=['echo', 'tail'],
                             parents=[left, right],
                             always_run=True)
-    batch.close()
+    batch = batch.submit()
     right.wait()
     batch.cancel()
     status = batch.wait()
@@ -261,7 +231,7 @@ def test_always_run_error(client):
                             command=['echo', 'tail'],
                             parents=[head],
                             always_run=True)
-    batch.close()
+    batch = batch.submit()
     status = batch.wait()
     assert batch_status_job_counter(status, 'Complete') == 2
 

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -8,6 +8,7 @@ from flask import Response
 import hailjwt as hj
 
 from batch.client import BatchClient, Job
+import batch.aioclient as aioclient
 from .serverthread import ServerThread
 
 
@@ -48,7 +49,8 @@ def test_simple(client):
 def test_missing_parent_is_400(client):
     try:
         batch = client.create_batch()
-        fake_job = Job(batch._batch._async_batch, 100000)
+        fake_job = aioclient.Job(aioclient.UnsubmittedJob(batch, 10000))
+        fake_job = Job.from_async_job(fake_job)
         batch.create_job('alpine:3.8', command=['echo', 'head'], parents=[fake_job])
         batch.submit()
     except aiohttp.ClientResponseError as err:

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -667,7 +667,6 @@ mkdir -p {shq(repo_dir)}
                     'sha': self.sha
                 },
                 callback=f'http://{SELF_HOSTNAME}/batch_callback')
-            # FIXME make build atomic
             config.build(deploy_batch, self, deploy=True)
             deploy_batch = await deploy_batch.submit()
             self.deploy_batch = deploy_batch

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -287,7 +287,7 @@ mkdir -p {shq(repo_dir)}
                 config = BuildConfiguration(self, f.read(), deploy=False)
 
             log.info(f'creating test batch for {self.number}')
-            batch = await batch_client.create_batch(
+            batch = batch_client.create_batch(
                 attributes={
                     'token': secrets.token_hex(16),
                     'test': '1',
@@ -297,8 +297,8 @@ mkdir -p {shq(repo_dir)}
                     'target_sha': self.target_branch.sha
                 },
                 callback=f'http://{SELF_HOSTNAME}/batch_callback')
-            await config.build(batch, self, deploy=False)
-            await batch.close()
+            config.build(batch, self, deploy=False)
+            batch = await batch.submit()
             self.batch = batch
         except concurrent.futures.CancelledError:
             raise
@@ -659,7 +659,7 @@ mkdir -p {shq(repo_dir)}
                 config = BuildConfiguration(self, f.read(), deploy=True)
 
             log.info(f'creating deploy batch for {self.branch.short_str()}')
-            deploy_batch = await batch_client.create_batch(
+            deploy_batch = batch_client.create_batch(
                 attributes={
                     'token': secrets.token_hex(16),
                     'deploy': '1',
@@ -668,8 +668,8 @@ mkdir -p {shq(repo_dir)}
                 },
                 callback=f'http://{SELF_HOSTNAME}/batch_callback')
             # FIXME make build atomic
-            await config.build(deploy_batch, self, deploy=True)
-            await deploy_batch.close()
+            config.build(deploy_batch, self, deploy=True)
+            deploy_batch = await deploy_batch.submit()
             self.deploy_batch = deploy_batch
         except concurrent.futures.CancelledError:
             raise

--- a/pipeline/pipeline/backend.py
+++ b/pipeline/pipeline/backend.py
@@ -295,7 +295,7 @@ class BatchBackend(Backend):
             jobs_to_command[j] = cmd
             n_jobs_submitted += 1
 
-        batch.close()
+        batch = batch.submit()
         status = batch.wait()
 
         failed_jobs = [(j['job_id'], j['exit_code']) for j in status['jobs'] if 'exit_code' in j and any([ec != 0 for _, ec in j['exit_code'].items()])]


### PR DESCRIPTION
- Removed `close`, `is_open`, and `ttl` on batches
- Changed `create_job` and `create_batch` to be synchronous (bunch of ci code changed as a result)
- Added `submit` to batches that actually submits to request to the server
- Server still inserts records not in one transaction (future PR)
- Added some tests of operations not allowed when the batch is being created

I'm not entirely happy with the client code. I'm open to suggestions!