### PR TITLE
Fixed Getting Started

### DIFF
--- a/hail/python/hail/docs/getting_started.rst
+++ b/hail/python/hail/docs/getting_started.rst
@@ -36,7 +36,7 @@ Create a `conda enviroment
 
 .. code-block:: sh
 
-    conda create --name hail python>=3.6
+    conda create -n hail python==3.6
     conda activate hail
     pip install hail
 


### PR DESCRIPTION
The greater than or equal to sign wouldn't allow Conda to create the Hail environment. 