### PR TITLE
[bugfix] check key ordering when isSorted = true

### DIFF
--- a/hail/python/benchmark/matrix_table_benchmarks.py
+++ b/hail/python/benchmark/matrix_table_benchmarks.py
@@ -20,6 +20,12 @@ def matrix_table_entries_table():
     mt = hl.read_matrix_table(resource('profile.mt'))
     mt.entries()._force_count()
 
+
+@benchmark
+def matrix_table_entries_table_no_key():
+    mt = hl.read_matrix_table(resource('profile.mt')).key_rows_by().key_cols_by()
+    mt.entries()._force_count()
+
 @benchmark
 def matrix_table_rows_force_count():
     ht = hl.read_matrix_table(resource('profile.mt')).rows().key_by()

--- a/hail/src/main/scala/is/hail/expr/ir/IRBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IRBuilder.scala
@@ -230,6 +230,18 @@ object IRBuilder {
 
     def dropFields(fields: Symbol*): IRProxy = dropFieldList(fields.map(_.name))
 
+    def insertStruct(other: IRProxy): IRProxy = (env: E) => {
+      val right = other(env)
+      val sym = genUID()
+      Let(
+        sym,
+        right,
+        InsertFields(
+          ir(env),
+          right.typ.asInstanceOf[TStruct].fieldNames.map(f => f -> GetField(Ref(sym, right.typ), f)),
+          None))
+    }
+
     def len: IRProxy = (env: E) => ArrayLen(ir(env))
 
     def isNA: IRProxy = (env: E) => IsNA(ir(env))

--- a/hail/src/main/scala/is/hail/expr/ir/IRBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IRBuilder.scala
@@ -216,8 +216,10 @@ object IRBuilder {
 
     def castRename(t: Type): IRProxy = (env: E) => CastRename(ir(env), t)
 
-    def insertFields(fields: (Symbol, IRProxy)*): IRProxy = (env: E) =>
-      InsertFields(ir(env), fields.map { case (s, fir) => (s.name, fir(env)) })
+    def insertFields(fields: (Symbol, IRProxy)*): IRProxy = insertFieldsList(fields)
+
+    def insertFieldsList(fields: Seq[(Symbol, IRProxy)], ordering: Option[IndexedSeq[String]] = None): IRProxy = (env: E) =>
+      InsertFields(ir(env), fields.map { case (s, fir) => (s.name, fir(env))}, ordering)
 
     def selectFields(fields: String*): IRProxy = (env: E) =>
       SelectFields(ir(env), fields)
@@ -230,7 +232,7 @@ object IRBuilder {
 
     def dropFields(fields: Symbol*): IRProxy = dropFieldList(fields.map(_.name))
 
-    def insertStruct(other: IRProxy): IRProxy = (env: E) => {
+    def insertStruct(other: IRProxy, ordering: Option[IndexedSeq[String]] = None): IRProxy = (env: E) => {
       val right = other(env)
       val sym = genUID()
       Let(
@@ -239,7 +241,7 @@ object IRBuilder {
         InsertFields(
           ir(env),
           right.typ.asInstanceOf[TStruct].fieldNames.map(f => f -> GetField(Ref(sym, right.typ), f)),
-          None))
+          ordering))
     }
 
     def len: IRProxy = (env: E) => ArrayLen(ir(env))


### PR DESCRIPTION
This was causing out-of-order keys to exist and be used in #6223. This doesn't fix that issue specifically, but it will now throw the correct error (and prevent incorrect tables/matrix tables from being written out).