### PR TITLE
Use Backend.broadcast instead of SparkContext.broadcast in most places

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -139,10 +139,10 @@ abstract class MatrixHybridReader extends TableReader with MatrixReader {
           .map(_.index)
           .toArray
         val arr = values.map(r => Row.fromSeq(colValueIndices.map(r.get))).toFastIndexedSeq
-        BroadcastRow(Row(arr), requestedType.globalType, HailContext.get.sc)
+        BroadcastRow(Row(arr), requestedType.globalType, HailContext.backend)
       case None =>
         assert(requestedType.globalType == TStruct())
-        BroadcastRow(Row.empty, requestedType.globalType, HailContext.get.sc)
+        BroadcastRow(Row.empty, requestedType.globalType, HailContext.backend)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
@@ -194,7 +194,7 @@ case class MatrixValue(
         BroadcastIndexedSeq(
           IndexedSeq.range(0, colValues.safeValue.length),
           TArray(TInt32()),
-          colValues.sc))
+          colValues.backend))
     else {
       val sortedValsWithIdx = colValues.safeValue
         .zipWithIndex
@@ -206,7 +206,7 @@ case class MatrixValue(
         BroadcastIndexedSeq(
           sortedValsWithIdx.map(_._2),
           TArray(TInt32()),
-          colValues.sc))
+          colValues.backend))
     }
   }
 
@@ -225,7 +225,7 @@ case class MatrixValue(
     val partCounts: Array[Long] = rvd.countPerPartition()
     val partStarts = partCounts.scanLeft(0L)(_ + _)
     assert(partStarts.length == rvd.getNumPartitions + 1)
-    val partStartsBc = sparkContext.broadcast(partStarts)
+    val partStartsBc = HailContext.backend.broadcast(partStarts)
 
     val localRvRowPType = rvRowPType
     val localEntryArrayPType = entryArrayPType
@@ -282,7 +282,7 @@ case class MatrixValue(
     val newGlobals = BroadcastRow(
       Row.merge(globals.safeValue, Row(colValues.safeValue)),
       tt.globalType,
-      HailContext.get.sc)
+      HailContext.backend)
 
     TableValue(tt, newGlobals, rvd.cast(tt.rowType.physicalType))
   }

--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -185,8 +185,8 @@ case class TableValue(typ: TableType, globals: BroadcastRow, rvd: RVD) {
 
     MatrixValue(
       mType,
-      BroadcastRow(newGlobals, mType.globalType, HailContext.get.sc),
-      BroadcastIndexedSeq(colValues, TArray(mType.colType), HailContext.get.sc),
+      BroadcastRow(newGlobals, mType.globalType, HailContext.backend),
+      BroadcastIndexedSeq(colValues, TArray(mType.colType), HailContext.backend),
       newRVD
     )
   }

--- a/hail/src/main/scala/is/hail/io/LoadMatrix.scala
+++ b/hail/src/main/scala/is/hail/io/LoadMatrix.scala
@@ -298,7 +298,7 @@ object LoadMatrix {
 
     val rowFieldType: TStruct = verifyRowFields(rowFieldNames, rowFields)
 
-    val header1Bc = sc.broadcast(header1)
+    val header1Bc = hc.backend.broadcast(header1)
 
     if (!noHeader)
       LoadMatrix.warnDuplicates(colIDs.asInstanceOf[Array[String]])
@@ -395,8 +395,8 @@ object LoadMatrix {
       RVD.coerce(rvdType, rdd)
 
     MatrixLiteral(MatrixValue(matrixType,
-      BroadcastRow(Row(), matrixType.globalType, hc.sc),
-      BroadcastIndexedSeq(colIDs.map(x => Annotation(x)), TArray(matrixType.colType), hc.sc),
+      BroadcastRow(Row(), matrixType.globalType, hc.backend),
+      BroadcastIndexedSeq(colIDs.map(x => Annotation(x)), TArray(matrixType.colType), hc.backend),
       rvd))
   }
 }

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDD.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDD.scala
@@ -2,6 +2,7 @@ package is.hail.io.bgen
 
 import is.hail.annotations._
 import is.hail.asm4s.AsmFunction4
+import is.hail.backend.BroadcastValue
 import is.hail.expr.types._
 import is.hail.expr.types.physical.PStruct
 import is.hail.expr.types.virtual.{TStruct, Type}
@@ -37,7 +38,7 @@ case class BgenSettings(
   entries: EntriesSetting,
   dropCols: Boolean,
   rowFields: RowFields,
-  rgBc: Option[Broadcast[ReferenceGenome]],
+  rgBc: Option[BroadcastValue[ReferenceGenome]],
   indexAnnotationType: Type
 ) {
   val (includeGT, includeGP, includeDosage) = entries match {

--- a/hail/src/main/scala/is/hail/io/gen/LoadGen.scala
+++ b/hail/src/main/scala/is/hail/io/gen/LoadGen.scala
@@ -2,6 +2,7 @@ package is.hail.io.gen
 
 import is.hail.HailContext
 import is.hail.annotations._
+import is.hail.backend.BroadcastValue
 import is.hail.expr.ir.{LowerMatrixIR, MatrixHybridReader, MatrixRead, MatrixReader, MatrixValue, TableRead, TableValue}
 import is.hail.expr.types.MatrixType
 import is.hail.expr.types.virtual._
@@ -23,7 +24,7 @@ object LoadGen {
     genFile: String,
     sampleFile: String,
     sc: SparkContext,
-    rgBc: Option[Broadcast[ReferenceGenome]],
+    rgBc: Option[BroadcastValue[ReferenceGenome]],
     nPartitions: Option[Int] = None,
     tolerance: Double = 0.02,
     chromosome: Option[String] = None,

--- a/hail/src/main/scala/is/hail/io/plink/ExportPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/ExportPlink.scala
@@ -69,7 +69,7 @@ object ExportPlink {
     hConf.mkDir(tmpBedDir)
     hConf.mkDir(tmpBimDir)
 
-    val sHConfBc = sc.broadcast(new SerializableHadoopConfiguration(hConf))
+    val sHConfBc = HailContext.hadoopConfBc
 
     val nPartitions = mv.rvd.getNumPartitions
     val d = digitsNeeded(nPartitions)

--- a/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
@@ -199,7 +199,7 @@ case class MatrixPLINKReader(
     val rvd = if (tr.dropRows)
       RVD.empty(sc, requestedType.canonicalRVDType)
     else {
-      val variantsBc = sc.broadcast(variants)
+      val variantsBc = hc.backend.broadcast(variants)
       sc.hadoopConfiguration.setInt("nSamples", nSamples)
       sc.hadoopConfiguration.setBoolean("a2Reference", a2Reference)
 

--- a/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/LoadVCF.scala
@@ -3,6 +3,7 @@ package is.hail.io.vcf
 import htsjdk.variant.vcf._
 import is.hail.HailContext
 import is.hail.annotations._
+import is.hail.backend.BroadcastValue
 import is.hail.expr.JSONAnnotationImpex
 import is.hail.expr.ir.{IRParser, LowerMatrixIR, MatrixHybridReader, MatrixIR, MatrixLiteral, MatrixValue, PruneDeadFields, TableRead, TableValue}
 import is.hail.expr.types._
@@ -1202,7 +1203,7 @@ object LoadVCF {
   )(f: (C, VCFLine, RegionValueBuilder) => Unit
   )(lines: ContextRDD[RVDContext, WithContext[String]],
     t: Type,
-    rgBc: Option[Broadcast[ReferenceGenome]],
+    rgBc: Option[BroadcastValue[ReferenceGenome]],
     contigRecoding: Map[String, String],
     arrayElementsRequired: Boolean,
     skipInvalidLoci: Boolean

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -112,7 +112,7 @@ object BlockMatrix {
       val iOffset = i * blockSize
       val jOffset = j * blockSize
 
-      sc.broadcast(lm(iOffset until iOffset + blockNRows, jOffset until jOffset + blockNCols).copy)
+      HailContext.backend.broadcast(lm(iOffset until iOffset + blockNRows, jOffset until jOffset + blockNCols).copy)
     }
     
     BlockMatrix(sc, gp, (gp, pi) => (gp.blockCoordinates(pi), localBlocksBc(pi).value))
@@ -478,11 +478,11 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
   }
 
   def zeroRowIntervals(starts: Array[Long], stops: Array[Long]): BlockMatrix = {    
-    val sc = blocks.sparkContext
-    val startBlockIndexBc = sc.broadcast(starts.map(gp.indexBlockIndex))
-    val stopBlockIndexBc = sc.broadcast(stops.map(stop => (stop / blockSize).toInt))
-    val startBlockOffsetBc = sc.broadcast(starts.map(gp.indexBlockOffset))
-    val stopBlockOffsetsBc = sc.broadcast(stops.map(gp.indexBlockOffset))
+    val backend = HailContext.backend
+    val startBlockIndexBc = backend.broadcast(starts.map(gp.indexBlockIndex))
+    val stopBlockIndexBc = backend.broadcast(stops.map(stop => (stop / blockSize).toInt))
+    val startBlockOffsetBc = backend.broadcast(starts.map(gp.indexBlockOffset))
+    val stopBlockOffsetsBc = backend.broadcast(stops.map(gp.indexBlockOffset))
 
     val zeroedBlocks = blocks.mapPartitions( { it =>
       assert(it.hasNext)
@@ -1140,7 +1140,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     reqDense: Boolean = true): Array[Double] => M = {
     a => val v = BDV(a)
       require(v.length == nRows, s"vector length must equal nRows: ${ v.length }, $nRows")
-      val vBc = blocks.sparkContext.broadcast(v)
+      val vBc = HailContext.backend.broadcast(v)
       blockMapWithIndex( { case ((i, _), lm) =>
         val lv = gp.vectorOnBlockRow(vBc.value, i)
         op(lm, lv)
@@ -1152,7 +1152,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
     reqDense: Boolean = true): Array[Double] => M = {
     a => val v = BDV(a)
       require(v.length == nCols, s"vector length must equal nCols: ${ v.length }, $nCols")
-      val vBc = blocks.sparkContext.broadcast(v)
+      val vBc = HailContext.backend.broadcast(v)
       blockMapWithIndex( { case ((_, j), lm) =>
         val lv = gp.vectorOnBlockCol(vBc.value, j)
         op(lm, lv)

--- a/hail/src/main/scala/is/hail/methods/LinearRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/LinearRegression.scala
@@ -2,6 +2,7 @@ package is.hail.methods
 
 import breeze.linalg._
 import breeze.numerics.sqrt
+import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.expr.ir.functions.MatrixToTableFunction
 import is.hail.expr.ir.{MatrixValue, TableValue}
@@ -60,12 +61,12 @@ case class LinearRegressionRowsSingle(
 
     val Qty = Qt * y
 
-    val sc = mv.sparkContext
-    val completeColIdxBc = sc.broadcast(completeColIdx)
-    val yBc = sc.broadcast(y)
-    val QtBc = sc.broadcast(Qt)
-    val QtyBc = sc.broadcast(Qty)
-    val yypBc = sc.broadcast(y.t(*, ::).map(r => r dot r) - Qty.t(*, ::).map(r => r dot r))
+    val backend = HailContext.backend
+    val completeColIdxBc = backend.broadcast(completeColIdx)
+    val yBc = backend.broadcast(y)
+    val QtBc = backend.broadcast(Qt)
+    val QtyBc = backend.broadcast(Qty)
+    val yypBc = backend.broadcast(y.t(*, ::).map(r => r dot r) - Qty.t(*, ::).map(r => r dot r))
 
     val fullRowType = mv.rvd.rowPType
     val entryArrayType = MatrixType.getEntryArrayType(fullRowType)
@@ -220,8 +221,7 @@ case class LinearRegressionRowsChained(
       ChainedLinregInput(n, y, completeColIdx, Qt, Qty, yyp, d)
     }
 
-    val sc = mv.sparkContext
-    val bc = sc.broadcast(bcData)
+    val bc = HailContext.backend.broadcast(bcData)
     val nGroups = bcData.length
 
     val fullRowType = mv.rvd.rowPType

--- a/hail/src/main/scala/is/hail/methods/MatrixExportEntriesByCol.scala
+++ b/hail/src/main/scala/is/hail/methods/MatrixExportEntriesByCol.scala
@@ -46,7 +46,7 @@ case class MatrixExportEntriesByCol(parallelism: Int, path: String, bgzip: Boole
 
       val extension = if (bgzip) ".tsv.bgz" else ".tsv"
 
-      val colValuesJSON = mv.sparkContext.broadcast(
+      val colValuesJSON = HailContext.backend.broadcast(
         (startIdx until endIdx)
           .map(allColValuesJSON)
           .toArray)

--- a/hail/src/main/scala/is/hail/methods/Nirvana.scala
+++ b/hail/src/main/scala/is/hail/methods/Nirvana.scala
@@ -476,7 +476,7 @@ object Nirvana {
 
       TableValue(
         TableType(nirvanaRowType.virtualType, FastIndexedSeq("locus", "alleles"), TStruct()),
-        BroadcastRow(Row(), TStruct(), tv.globals.sc),
+        BroadcastRow(Row(), TStruct(), tv.globals.backend),
         nirvanaRVD
       )
   }

--- a/hail/src/main/scala/is/hail/methods/PCA.scala
+++ b/hail/src/main/scala/is/hail/methods/PCA.scala
@@ -55,7 +55,7 @@ case class PCA(entryField: String, k: Int, computeLoadings: Boolean) extends Mat
     }
 
     val rowType = TStruct(mv.typ.rowKey.zip(mv.typ.rowKeyStruct.types): _*) ++ TStruct("loadings" -> TArray(TFloat64()))
-    val rowKeysBc = sc.broadcast(collectRowKeys())
+    val rowKeysBc = HailContext.backend.broadcast(collectRowKeys())
     val localRowKeySignature = mv.typ.rowKeyStruct.types
 
     val crdd: ContextRDD[RVDContext, RegionValue] = if (computeLoadings) {
@@ -117,6 +117,6 @@ case class PCA(entryField: String, k: Int, computeLoadings: Boolean) extends Mat
     val newGlobal = f2(g1, globalScores)
     
     TableValue(TableType(rowType, mv.typ.rowKey, newGlobalType.asInstanceOf[TStruct]),
-      BroadcastRow(newGlobal.asInstanceOf[Row], newGlobalType.asInstanceOf[TStruct], sc), rvd)
+      BroadcastRow(newGlobal.asInstanceOf[Row], newGlobalType.asInstanceOf[TStruct], hc.backend), rvd)
   }
 }

--- a/hail/src/main/scala/is/hail/methods/PCRelate.scala
+++ b/hail/src/main/scala/is/hail/methods/PCRelate.scala
@@ -181,7 +181,7 @@ object PCRelate {
     val nSamples = vds.numCols
     val localRowPType = vds.value.rvRowPType
     val partStarts = vds.partitionStarts()
-    val partStartsBc = vds.sparkContext.broadcast(partStarts)
+    val partStartsBc = vds.hc.backend.broadcast(partStarts)
     val rdd = vds.rvd.mapPartitionsWithIndex { (partIdx, it) =>
       val view = HardCallView(localRowPType)
       val missingIndices = new ArrayBuilder[Int]()

--- a/hail/src/main/scala/is/hail/methods/PoissonRegression.scala
+++ b/hail/src/main/scala/is/hail/methods/PoissonRegression.scala
@@ -1,6 +1,7 @@
 package is.hail.methods
 
 import breeze.linalg._
+import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.expr.ir.functions.MatrixToTableFunction
 import is.hail.expr.ir.{MatrixValue, TableValue}
@@ -57,13 +58,13 @@ case class PoissonRegression(
         else
           "Newton iteration failed to converge"))
 
-    val sc = mv.sparkContext
-    val completeColIdxBc = sc.broadcast(completeColIdx)
+    val backend = HailContext.backend
+    val completeColIdxBc = backend.broadcast(completeColIdx)
 
-    val yBc = sc.broadcast(y)
-    val XBc = sc.broadcast(new DenseMatrix[Double](n, k + 1, cov.toArray ++ Array.ofDim[Double](n)))
-    val nullFitBc = sc.broadcast(nullFit)
-    val poisRegTestBc = sc.broadcast(poisRegTest)
+    val yBc = backend.broadcast(y)
+    val XBc = backend.broadcast(new DenseMatrix[Double](n, k + 1, cov.toArray ++ Array.ofDim[Double](n)))
+    val nullFitBc = backend.broadcast(nullFit)
+    val poisRegTestBc = backend.broadcast(poisRegTest)
 
     val fullRowType = mv.rvRowPType
     val entryArrayType = mv.entryArrayPType

--- a/hail/src/main/scala/is/hail/methods/VEP.scala
+++ b/hail/src/main/scala/is/hail/methods/VEP.scala
@@ -247,7 +247,7 @@ case class VEP(config: String, csq: Boolean, blockSize: Int) extends TableToTabl
 
     TableValue(
       TableType(vepRowType.virtualType, FastIndexedSeq("locus", "alleles"), globalType),
-      BroadcastRow(globalValue, globalType, HailContext.get.sc),
+      BroadcastRow(globalValue, globalType, HailContext.backend),
       vepRVD)
   }
 }

--- a/hail/src/main/scala/is/hail/methods/WindowByLocus.scala
+++ b/hail/src/main/scala/is/hail/methods/WindowByLocus.scala
@@ -1,5 +1,6 @@
 package is.hail.methods
 
+import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.expr.ir.MatrixValue
 import is.hail.expr.ir.functions.MatrixToMatrixFunction
@@ -45,7 +46,7 @@ case class WindowByLocus(basePairs: Int) extends MatrixToMatrixFunction {
     val entryType = entryArrayType.elementType.asInstanceOf[PStruct]
     val rg = localRVRowType.types(locusIndex).asInstanceOf[PLocus].rg
 
-    val rangeBoundsBc = mv.sparkContext.broadcast(oldBounds)
+    val rangeBoundsBc = HailContext.backend.broadcast(oldBounds)
 
     val nCols = mv.nCols
 

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -427,7 +427,7 @@ class RVD(
     val (newRowPType, ins) = rowPType.unsafeStructInsert(PInt64(), List(name))
     val newRowType = newRowPType
 
-    val a = sparkContext.broadcast(partitionCounts.map(_.toArray).getOrElse(countPerPartition()).scanLeft(0L)(_ + _))
+    val a = HailContext.backend.broadcast(partitionCounts.map(_.toArray).getOrElse(countPerPartition()).scanLeft(0L)(_ + _))
 
     val newCRDD = crdd.cmapPartitionsWithIndex({ (i, ctx, it) =>
       val rv2 = RegionValue()

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -143,7 +143,7 @@ object Table {
     new Table(hc, TableLiteral(
       TableValue(
         TableType(signature, FastIndexedSeq(), globalSignature),
-        BroadcastRow(globals.asInstanceOf[Row], globalSignature, hc.sc),
+        BroadcastRow(globals.asInstanceOf[Row], globalSignature, hc.backend),
         RVD.unkeyed(signature.physicalType, crdd2)))
     ).keyBy(key, isSorted)
   }
@@ -181,7 +181,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
         TableLiteral(
           TableValue(
             TableType(signature, key, globalSignature),
-            BroadcastRow(globals, globalSignature, hc.sc),
+            BroadcastRow(globals, globalSignature, hc.backend),
             RVD.coerce(RVDType(signature.physicalType, key), crdd)))
   )
 

--- a/hail/src/main/scala/is/hail/utils/TextTableReader.scala
+++ b/hail/src/main/scala/is/hail/utils/TextTableReader.scala
@@ -409,6 +409,6 @@ case class TextTableReader(options: TextTableReaderOptions) extends TableReader 
       }
     }
 
-    TableValue(tr.typ, BroadcastRow(Row.empty, tr.typ.globalType, hc.sc), RVD.unkeyed(rowTyp.physicalType, crdd))
+    TableValue(tr.typ, BroadcastRow(Row.empty, tr.typ.globalType, hc.backend), RVD.unkeyed(rowTyp.physicalType, crdd))
   }
 }

--- a/hail/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/hail/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -159,8 +159,8 @@ object MatrixTable {
     val localNCols = colValues.length
 
     val ds = new MatrixTable(hc, matrixType,
-      BroadcastRow(globals.asInstanceOf[Row], matrixType.globalType, hc.sc),
-      BroadcastIndexedSeq(colValues, TArray(matrixType.colType), hc.sc),
+      BroadcastRow(globals.asInstanceOf[Row], matrixType.globalType, hc.backend),
+      BroadcastIndexedSeq(colValues, TArray(matrixType.colType), hc.backend),
       RVD.coerce(matrixType.canonicalRVDType,
         ContextRDD.weaken[RVDContext](rdd).cmapPartitions { (ctx, it) =>
           val region = ctx.region
@@ -230,7 +230,7 @@ object MatrixTable {
     }
 
     val colValues =
-      BroadcastIndexedSeq(Array.empty[Annotation], TArray(matrixType.colType), kt.hc.sc)
+      BroadcastIndexedSeq(Array.empty[Annotation], TArray(matrixType.colType), kt.hc.backend)
 
     new MatrixTable(kt.hc, matrixType, kt.globals, colValues, rvd)
   }

--- a/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
+++ b/hail/src/main/scala/is/hail/variant/ReferenceGenome.scala
@@ -5,6 +5,7 @@ import java.io.InputStream
 import htsjdk.samtools.reference.FastaSequenceIndex
 import is.hail.HailContext
 import is.hail.asm4s.Code
+import is.hail.backend.BroadcastValue
 import is.hail.check.Gen
 import is.hail.expr.types._
 import is.hail.expr.{JSONExtractContig, JSONExtractIntervalLocus, JSONExtractReferenceGenome, Parser}
@@ -76,7 +77,7 @@ abstract class RGBase extends Serializable {
 class BroadcastRGBase(rgParam: RGBase) extends Serializable {
   @transient private[this] val rg: RGBase = rgParam
 
-  private[this] val rgBc: Broadcast[ReferenceGenome] = {
+  private[this] val rgBc: BroadcastValue[ReferenceGenome] = {
     if (TaskContext.get != null)
       null
     else
@@ -470,7 +471,7 @@ case class ReferenceGenome(name: String, contigs: Array[String], lengths: Map[St
     lo.queryInterval(interval, minMatch)
   }
 
-  @transient lazy val broadcast: Broadcast[ReferenceGenome] = HailContext.get.sc.broadcast(this)
+  @transient lazy val broadcast: BroadcastValue[ReferenceGenome] = HailContext.backend.broadcast(this)
 
   override def hashCode: Int = {
     import org.apache.commons.lang.builder.HashCodeBuilder

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2052,8 +2052,8 @@ class IRSuite extends SparkSuite {
 
     val t1 = TableType(TStruct("a" -> TInt32()), FastIndexedSeq("a"), TStruct("g1" -> TInt32(), "g2" -> TFloat64()))
     val t2 = TableType(TStruct("a" -> TInt32()), FastIndexedSeq("a"), TStruct("g3" -> TInt32(), "g4" -> TFloat64()))
-    val tab1 = TableLiteral(TableValue(t1, BroadcastRow(Row(1, 1.1), t1.globalType, sc), RVD.empty(sc, t1.canonicalRVDType)))
-    val tab2 = TableLiteral(TableValue(t2, BroadcastRow(Row(2, 2.2), t2.globalType, sc), RVD.empty(sc, t2.canonicalRVDType)))
+    val tab1 = TableLiteral(TableValue(t1, BroadcastRow(Row(1, 1.1), t1.globalType, hc.backend), RVD.empty(sc, t1.canonicalRVDType)))
+    val tab2 = TableLiteral(TableValue(t2, BroadcastRow(Row(2, 2.2), t2.globalType, hc.backend), RVD.empty(sc, t2.canonicalRVDType)))
 
     assertEvalsTo(TableGetGlobals(TableJoin(tab1, tab2, "left")), Row(1, 1.1, 2, 2.2))
     assertEvalsTo(TableGetGlobals(TableMapGlobals(tab1, InsertFields(Ref("global", t1.globalType), Seq("g1" -> I32(3))))), Row(3, 1.1))

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -108,8 +108,8 @@ class PruneSuite extends SparkSuite {
     TStruct("e1" -> TFloat64(), "e2" -> TFloat64()))
   val mat = MatrixLiteral(MatrixValue(
     mType,
-    BroadcastRow(Row(1, 1.0), mType.globalType, sc),
-    BroadcastIndexedSeq(FastIndexedSeq(Row("1", 2, FastIndexedSeq(Row(3)))), TArray(mType.colType), sc),
+    BroadcastRow(Row(1, 1.0), mType.globalType, hc.backend),
+    BroadcastIndexedSeq(FastIndexedSeq(Row("1", 2, FastIndexedSeq(Row(3)))), TArray(mType.colType), hc.backend),
     RVD.empty(sc, mType.canonicalRVDType)))
 
   val mr = MatrixRead(mat.typ, false, false, new MatrixReader {

--- a/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -31,7 +31,7 @@ class PartitioningSuite extends SparkSuite {
   @Test def testShuffleOnEmptyRDD() {
     val typ = TableType(TStruct("tidx" -> TInt32()), FastIndexedSeq("tidx"), TStruct.empty())
     val t = TableLiteral(TableValue(
-      typ, BroadcastRow(Row.empty, TStruct.empty(), sc), RVD.empty(sc, typ.canonicalRVDType)))
+      typ, BroadcastRow(Row.empty, TStruct.empty(), hc.backend), RVD.empty(sc, typ.canonicalRVDType)))
     val rangeReader = ir.MatrixRangeReader(100, 10, Some(10))
     Interpret(
       MatrixAnnotateRowsTable(


### PR DESCRIPTION
Leaves RVDPartitioner.broadcast and HailContext.hadoopConfBc untouched.

Backend.broadcast is just a thin wrapper around SparkContext.broadcast for the SparkBackend case.