### PR TITLE
[pipeline] add tags

### DIFF
--- a/pipeline/pipeline/backend.py
+++ b/pipeline/pipeline/backend.py
@@ -115,7 +115,7 @@ class LocalBackend(Backend):
         for task in pipeline._tasks:
             os.makedirs(tmpdir + task._uid + '/', exist_ok=True)
 
-            script.append(f"# {task._uid} {task._name if task._name else ''}")
+            script.append(f"# {task._uid} {task.name if task.name else ''}")
 
             script += [x for r in task._inputs for x in copy_input(task, r)]
 
@@ -284,9 +284,9 @@ class BatchBackend(Backend):
             parents = [task_to_job_mapping[t] for t in task._dependencies]
 
             attributes = {'task_uid': task._uid}
-            if task._name:
-                attributes['name'] = task._name
-            attributes.update(task.tags)
+            if task.name:
+                attributes['name'] = task.name
+            attributes.update(task.attributes)
 
             resources = {'requests': {}}
             if task._cpu:

--- a/pipeline/pipeline/backend.py
+++ b/pipeline/pipeline/backend.py
@@ -204,8 +204,8 @@ class BatchBackend(Backend):
         default_image = 'ubuntu'
 
         attributes = pipeline.attributes
-        if pipeline._name is not None:
-            attributes['name'] = pipeline._name
+        if pipeline.name is not None:
+            attributes['name'] = pipeline.name
 
         batch = self._batch_client.create_batch(attributes=attributes)
 

--- a/pipeline/pipeline/backend.py
+++ b/pipeline/pipeline/backend.py
@@ -203,11 +203,12 @@ class BatchBackend(Backend):
 
         default_image = 'ubuntu'
 
-        attributes = {}
+        attributes = pipeline.attributes
         if pipeline._name is not None:
             attributes['name'] = pipeline._name
 
         batch = self._batch_client.create_batch(attributes=attributes)
+
         n_jobs_submitted = 0
         used_remote_tmpdir = False
 
@@ -285,6 +286,7 @@ class BatchBackend(Backend):
             attributes = {'task_uid': task._uid}
             if task._name:
                 attributes['name'] = task._name
+            attributes.update(task.tags)
 
             resources = {'requests': {}}
             if task._cpu:

--- a/pipeline/pipeline/pipeline.py
+++ b/pipeline/pipeline/pipeline.py
@@ -37,6 +37,9 @@ class Pipeline:
         Name of the pipeline.
     backend: :func:`.Backend`, optional
         Backend used to execute the jobs. Default is :class:`.LocalBackend`
+    tags: :obj:`dict` of :obj:`str` to :obj:`str`, optional
+        Key-value pairs of additional tags. 'name' is not a valid keyword.
+        Use the name argument instead.
     default_image: :obj:`str`, optional
         Docker image to use by default if not specified by a task.
     default_memory: :obj:`str`, optional
@@ -62,15 +65,23 @@ class Pipeline:
         cls._counter += 1
         return uid
 
-    def __init__(self, name=None, backend=None, default_image=None, default_memory=None,
-                 default_cpu=None, default_storage=None):
+    def __init__(self, name=None, backend=None, tags=None,
+                 default_image=None, default_memory=None, default_cpu=None,
+                 default_storage=None):
         self._tasks = []
         self._resource_map = {}
         self._allocated_files = set()
         self._input_resources = set()
         self._uid = Pipeline._get_uid()
 
-        self._name = name
+        self.name = name
+
+        if tags is None:
+            tags = {}
+        if 'name' in tags:
+            raise ValueError("'name' is not a valid tag. Use the name argument instead.")
+        self.tags = tags
+
         self._default_image = default_image
         self._default_memory = default_memory
         self._default_cpu = default_cpu

--- a/pipeline/pipeline/task.py
+++ b/pipeline/pipeline/task.py
@@ -59,9 +59,16 @@ class Task:
         cls._counter += 1
         return uid
 
-    def __init__(self, pipeline, name=None):
+    def __init__(self, pipeline, name=None, tags=None):
         self._pipeline = pipeline
         self._name = name
+
+        if tags is None:
+            tags = {}
+        if 'name' in tags:
+            raise ValueError("'name' is not a valid tag. Use the name argument instead.")
+        self.tags = tags
+
         self._cpu = None
         self._memory = None
         self._storage = None

--- a/pipeline/pipeline/task.py
+++ b/pipeline/pipeline/task.py
@@ -59,16 +59,10 @@ class Task:
         cls._counter += 1
         return uid
 
-    def __init__(self, pipeline, name=None, tags=None):
+    def __init__(self, pipeline, name=None, attributes=None):
         self._pipeline = pipeline
-        self._name = name
-
-        if tags is None:
-            tags = {}
-        if 'name' in tags:
-            raise ValueError("'name' is not a valid tag. Use the name argument instead.")
-        self.tags = tags
-
+        self.name = name
+        self.attributes = attributes
         self._cpu = None
         self._memory = None
         self._storage = None
@@ -329,31 +323,6 @@ class Task:
         self._storage = storage
         return self
 
-    def name(self, name):
-        """
-        Set the task's name.
-
-        Examples
-        --------
-
-        Set the task's name to `qc`:
-
-        >>> t1 = p.new_task()
-        >>> (t1.name('qc')
-        ...    .command(f'echo "hello"'))
-
-        Parameters
-        ----------
-        name: :obj:`str`
-
-        Returns
-        -------
-        :class:`.Task`
-            Same task object with name set.
-        """
-        self._name = name
-        return self
-
     def memory(self, memory):
         """
         Set the task's memory requirements.
@@ -435,7 +404,8 @@ class Task:
 
     def _pretty(self):
         s = f"Task '{self._uid}'" \
-            f"\tName:\t'{self._name}'" \
+            f"\tName:\t'{self.name}'" \
+            f"\tAttributes:\t'{self.attributes}'" \
             f"\tImage:\t'{self._image}'" \
             f"\tCPU:\t'{self._cpu}'" \
             f"\tMemory:\t'{self._memory}'" \

--- a/pipeline/test/test_pipeline.py
+++ b/pipeline/test/test_pipeline.py
@@ -298,7 +298,8 @@ class BatchTests(unittest.TestCase):
 
     def pipeline(self):
         return Pipeline(backend=self.backend,
-                        default_image='google/cloud-sdk:237.0.0-alpine')
+                        default_image='google/cloud-sdk:237.0.0-alpine',
+                        tags={'foo': 'a', 'bar': 'b'})
 
     def test_single_task_no_io(self):
         p = self.pipeline()
@@ -323,7 +324,7 @@ class BatchTests(unittest.TestCase):
 
     def test_single_task_output(self):
         p = self.pipeline()
-        t = p.new_task()
+        t = p.new_task(tags={'a': 'bar', 'b': 'foo'})
         t.command(f'echo hello > {t.ofile}')
         p.run()
 

--- a/pipeline/test/test_pipeline.py
+++ b/pipeline/test/test_pipeline.py
@@ -324,7 +324,7 @@ class BatchTests(unittest.TestCase):
 
     def test_single_task_output(self):
         p = self.pipeline()
-        t = p.new_task().attributes({'a': 'bar', 'b': 'foo'})
+        t = p.new_task(attributes={'a': 'bar', 'b': 'foo'})
         t.command(f'echo hello > {t.ofile}')
         p.run()
 

--- a/pipeline/test/test_pipeline.py
+++ b/pipeline/test/test_pipeline.py
@@ -238,7 +238,7 @@ class LocalTests(unittest.TestCase):
 
             merger = p.new_task()
             merger.command('cat {files} > {ofile}'.format(files=' '.join([t.ofile for t in sorted(p.select_tasks('foo'),
-                                                                                                  key=lambda x: x._name,
+                                                                                                  key=lambda x: x.name,
                                                                                                   reverse=True)]),
                                                           ofile=merger.ofile))
 
@@ -299,7 +299,7 @@ class BatchTests(unittest.TestCase):
     def pipeline(self):
         return Pipeline(backend=self.backend,
                         default_image='google/cloud-sdk:237.0.0-alpine',
-                        tags={'foo': 'a', 'bar': 'b'})
+                        attributes={'foo': 'a', 'bar': 'b'})
 
     def test_single_task_no_io(self):
         p = self.pipeline()
@@ -324,7 +324,7 @@ class BatchTests(unittest.TestCase):
 
     def test_single_task_output(self):
         p = self.pipeline()
-        t = p.new_task(tags={'a': 'bar', 'b': 'foo'})
+        t = p.new_task().attributes({'a': 'bar', 'b': 'foo'})
         t.command(f'echo hello > {t.ofile}')
         p.run()
 
@@ -389,7 +389,7 @@ class BatchTests(unittest.TestCase):
 
         merger = p.new_task()
         merger.command('cat {files} > {ofile}'.format(files=' '.join([t.ofile for t in sorted(p.select_tasks('foo'),
-                                                                                              key=lambda x: x._name,
+                                                                                              key=lambda x: x.name,
                                                                                               reverse=True)]),
                                                       ofile=merger.ofile))
 

--- a/pipeline/test/test_pipeline.py
+++ b/pipeline/test/test_pipeline.py
@@ -225,7 +225,7 @@ class LocalTests(unittest.TestCase):
     def test_select_tasks(self):
         p = self.pipeline()
         for i in range(3):
-            t = p.new_task().name(f'foo{i}')
+            t = p.new_task(name=f'foo{i}')
         self.assertTrue(len(p.select_tasks('foo')) == 3)
 
     def test_scatter_gather(self):
@@ -233,7 +233,7 @@ class LocalTests(unittest.TestCase):
             p = self.pipeline()
 
             for i in range(3):
-                t = p.new_task().name(f'foo{i}')
+                t = p.new_task(name=f'foo{i}')
                 t.command(f'echo "{i}" > {t.ofile}')
 
             merger = p.new_task()
@@ -384,7 +384,7 @@ class BatchTests(unittest.TestCase):
         p = self.pipeline()
 
         for i in range(3):
-            t = p.new_task().name(f'foo{i}')
+            t = p.new_task(name=f'foo{i}')
             t.command(f'echo "{i}" > {t.ofile}')
 
         merger = p.new_task()


### PR DESCRIPTION
These will be helpful when we support searching based on attributes in the Batch UI. Maybe calling it attributes would be better than tags to be consistent with k8s and batch? Also, when making this PR, I don't love the redundancy of the name argument on init and the name method for Tasks. I propose getting rid of the name method. Thoughts? 

Stacked on #6277 