### PR TITLE
[docker] use standard gsa key location for Hadoop gs connector

### DIFF
--- a/docker/core-site.xml
+++ b/docker/core-site.xml
@@ -10,7 +10,7 @@
   
   <property>
     <name>google.cloud.auth.service.account.json.keyfile</name>
-    <value>/hail-vdc-sa-key/hail-vdc-sa-key.json</value>
+    <value>/gsa-key/privateKeyData</value>
   </property>
   
 </configuration>


### PR DESCRIPTION
The hail-vdc-sa-key was (temporarily) used by apiserver, which is no longer being deployed.  When it comes back, it should either have its own service account (mounted in the standard location) or, if @akotlar user isolation stuff is ready, not use the Hadoop connector.

FYI @konradjk when this goes I'll push a new version to Docker Hub.
