### PR TITLE
[hail] default to pip3 in Makefile

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -12,6 +12,7 @@ SPARK_VERSION=2.4.0
 HAIL_PIP_VERSION=0.2.14
 
 HAIL_PYTHON3?=python3
+HAIL_PIP3?=pip3
 
 shadowJar:
 	./gradlew shadowJar
@@ -102,8 +103,8 @@ upload-deferred-artifacts: wheel
 
 .PHONY: install-wheel
 install-wheel: wheel
-	pip uninstall -y hail
-	pip install $(wheel_path)
+	$(HAIL_PIP3) uninstall -y hail
+	$(HAIL_PIP3) install $(wheel_path)
 
 .PHONY: install-hailctl-wheel
 install-hailctl-wheel: install-wheel upload-deferred-artifacts
@@ -120,7 +121,7 @@ test-dataproc: install-hailctl-wheel
 init-scripts: python/hailctl/deploy.yaml
 
 DEPLOYED_VERSION=$(shell \
-  pip --no-cache-dir search hail \
+  $(HAIL_PIP3) --no-cache-dir search hail \
    | grep '^hail ' \
    | sed 's/hail (//' \
    | sed 's/).*//')


### PR DESCRIPTION
This broke my install, which does not use Conda. I have no `pip`, just `pip3`.

cc: @chrisvittal you represent the other major environment, does this break you?