### PR TITLE
[hail] Refactor ExtractIntervalFilters

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
@@ -14,7 +14,7 @@ object ExtractIntervalFilters {
     val firstKeyType: Type = rowKeyType.types.head
     val iOrd: IntervalEndpointOrdering = rowKeyType.ordering.intervalEndpointOrdering
 
-    def isFirstKey(ir: IR): Boolean = ir == GetField(rowRef, rowType.fieldNames.head)
+    def isFirstKey(ir: IR): Boolean = ir == GetField(rowRef, rowKeyType.fieldNames.head)
   }
 
   def wrapInRow(intervals: Array[Interval]): Array[Interval] = {

--- a/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
@@ -11,7 +11,7 @@ object ExtractIntervalFilters {
   case class ExtractionState(rowRef: Ref, keyFields: IndexedSeq[String]) {
     val rowType: TStruct = rowRef.typ.asInstanceOf[TStruct]
     val rowKeyType: TStruct = rowType.select(keyFields)._1
-    val firstKeyType: Type = rowType.types.head
+    val firstKeyType: Type = rowKeyType.types.head
     val iOrd: IntervalEndpointOrdering = rowKeyType.ordering.intervalEndpointOrdering
 
     def isFirstKey(ir: IR): Boolean = ir == GetField(rowRef, rowType.fieldNames.head)

--- a/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
@@ -1,11 +1,32 @@
 package is.hail.expr.ir
 
+import is.hail.annotations.IntervalEndpointOrdering
 import is.hail.expr.types.virtual._
 import is.hail.utils.{FastSeq, Interval, IntervalEndpoint, _}
 import is.hail.variant.{Locus, ReferenceGenome}
 import org.apache.spark.sql.Row
 
 object ExtractIntervalFilters {
+
+  case class ExtractionState(rowRef: Ref, keyFields: IndexedSeq[String]) {
+    val rowType: TStruct = rowRef.typ.asInstanceOf[TStruct]
+    val rowKeyType: TStruct = rowType.select(keyFields)._1
+    val firstKeyType: Type = rowType.types.head
+    val iOrd: IntervalEndpointOrdering = rowKeyType.ordering.intervalEndpointOrdering
+
+    def isFirstKey(ir: IR): Boolean = ir == GetField(rowRef, rowType.fieldNames.head)
+
+    def isKeyStructPrefix(ir: IR): Boolean = ir match {
+      case MakeStruct(fields) => fields
+        .iterator
+        .map(_._2)
+        .zipWithIndex
+        .forall { case (fd, idx) => idx < rowType.size && fd == GetField(rowRef, rowType.fieldNames(idx)) }
+      case SelectFields(`rowRef`, fields) => keyFields.startsWith(fields)
+      case _ => false
+    }
+  }
+
   def wrapInRow(intervals: Array[Interval]): Array[Interval] = {
     intervals.map { interval =>
       Interval(IntervalEndpoint(Row(interval.left.point), interval.left.sign),
@@ -40,8 +61,8 @@ object ExtractIntervalFilters {
     case Literal(_, v) => v
   }
 
-  def endpoint(value: Any, inclusivity: Int): IntervalEndpoint = {
-    IntervalEndpoint(value, inclusivity)
+  def endpoint(value: Any, inclusivity: Int, wrapped: Boolean = true): IntervalEndpoint = {
+    IntervalEndpoint(if (wrapped) Row(value) else value, inclusivity)
   }
 
   def getIntervalFromContig(c: String, rg: ReferenceGenome): Interval = {
@@ -87,21 +108,21 @@ object ExtractIntervalFilters {
     }
   }
 
-  def extractAndRewrite(cond1: IR, ref: Ref, k: IR): Option[(IR, Array[Interval])] = {
+  def extractAndRewrite(cond1: IR, es: ExtractionState): Option[(IR, Array[Interval])] = {
     cond1 match {
       case ApplySpecial("||", Seq(l, r)) =>
-        extractAndRewrite(l, ref, k)
-          .liftedZip(extractAndRewrite(r, ref, k))
+        extractAndRewrite(l, es)
+          .liftedZip(extractAndRewrite(r, es))
           .map { case ((_, i1), (_, i2)) =>
-            (True(), Interval.union(i1 ++ i2, k.typ.ordering.intervalEndpointOrdering))
+            (True(), Interval.union(i1 ++ i2, es.iOrd))
           }
       case ApplySpecial("&&", Seq(l, r)) =>
-        val ll = extractAndRewrite(l, ref, k)
-        val rr = extractAndRewrite(r, ref, k)
+        val ll = extractAndRewrite(l, es)
+        val rr = extractAndRewrite(r, es)
         (ll, rr) match {
           case (Some((ir1, i1)), Some((ir2, i2))) =>
             log.info(s"intersecting list of ${ i1.length } intervals with list of ${ i2.length } intervals")
-            val intersection = Interval.intersection(i1, i2, k.typ.ordering.intervalEndpointOrdering)
+            val intersection = Interval.intersection(i1, i2, es.iOrd)
             log.info(s"intersect generated ${ intersection.length } intersected intervals")
             Some((invoke("&&", ir1, ir2), intersection))
           case (Some((ir1, i1)), None) =>
@@ -113,32 +134,32 @@ object ExtractIntervalFilters {
         }
       case ArrayFold(Literal(t, lit), False(), acc, value, body) =>
         body match {
-          case ApplySpecial("||", Seq(Ref(`acc`, _), ApplySpecial("contains", Seq(Ref(`value`, _), `k`)))) =>
+          case ApplySpecial("||", Seq(Ref(`acc`, _), ApplySpecial("contains", Seq(Ref(`value`, _), k)))) if es.isFirstKey(k) =>
             assert(t.asInstanceOf[TContainer].elementType.isInstanceOf[TInterval])
             Some((True(),
               Interval.union(lit.asInstanceOf[Iterable[_]]
                 .filter(_ != null)
                 .map(_.asInstanceOf[Interval])
                 .toArray,
-                k.typ.ordering.intervalEndpointOrdering)))
+                es.iOrd)))
           case _ => None
         }
-      case Coalesce(Seq(x, False())) => extractAndRewrite(x, ref, k)
+      case Coalesce(Seq(x, False())) => extractAndRewrite(x, es)
         .map { case (ir, intervals) => (Coalesce(FastSeq(ir, False())), intervals) }
-      case ApplyIR("contains", Seq(lit: Literal, `k`)) =>
+      case ApplyIR("contains", Seq(lit: Literal, k)) if es.isFirstKey(k) =>
         val intervals = (lit.value: @unchecked) match {
           case x: IndexedSeq[_] => x.map(elt => Interval(endpoint(elt, -1), endpoint(elt, 1))).toArray
           case x: Set[_] => x.map(elt => Interval(endpoint(elt, -1), endpoint(elt, 1))).toArray
           case x: Map[_, _] => x.keys.map(elt => Interval(endpoint(elt, -1), endpoint(elt, 1))).toArray
         }
         Some((True(), intervals))
-      case ApplySpecial("contains", Seq(lit: Literal, `k`)) =>
+      case ApplySpecial("contains", Seq(lit: Literal, k)) if es.isFirstKey(k) =>
         val intervals = (lit.value: @unchecked) match {
           case null => Array[Interval]()
-          case i: Interval => Array(i)
+          case i: Interval => wrapInRow(Array(i))
         }
         Some((True(), intervals))
-      case ApplyIR("contains", Seq(lit: Literal, Apply("contig", Seq(`k`)))) =>
+      case ApplyIR("contains", Seq(lit: Literal, Apply("contig", Seq(k)))) if es.isFirstKey(k) =>
         val rg = k.typ.asInstanceOf[TLocus].rg.asInstanceOf[ReferenceGenome]
 
         val intervals = (lit.value: @unchecked) match {
@@ -148,40 +169,47 @@ object ExtractIntervalFilters {
         }
         Some((True(), intervals))
       case ApplyComparisonOp(op, l, r) if opIsSupported(op) =>
-        if (IsConstant(l) && r == k || l == k && IsConstant(r)) {
-          // simple key comparison
-          // TODO: need to look for casts, since patterns like [ `k` > 1.5 ] will not match if `k` is an integer
-          val (v, isFlipped) = if (IsConstant(l)) (l, false) else (r, true)
-          Some((True(), Array(openInterval(constValue(v), v.typ, op, isFlipped))))
-        } else if ((IsConstant(l) && r == Apply("contig", FastSeq(k)) || l == Apply("contig", FastSeq(k)) && IsConstant(r)) && op.isInstanceOf[EQ]) {
-          // locus contig comparison
-          val v = if (IsConstant(l)) l else r
-          val intervals = (constValue(v): @unchecked) match {
-            case s: String => Array(getIntervalFromContig(s, k.typ.asInstanceOf[TLocus].rg.asInstanceOf[ReferenceGenome]))
-          }
-          Some((True(), intervals))
-        } else if (IsConstant(l) && r == Apply("position", FastSeq(k)) || l == Apply("position", FastSeq(k)) && IsConstant(r)) {
-          // locus position comparison
-          val (v, isFlipped) = if (IsConstant(l)) (l, false) else (r, true)
-          val pos = constValue(v).asInstanceOf[Int]
-          val rg = k.typ.asInstanceOf[TLocus].rg.asInstanceOf[ReferenceGenome]
-          val ord = TInt32().ordering
-          val intervals = rg.contigs.indices
-            .flatMap { i =>
-              openInterval(pos, TInt32(), op, isFlipped).intersect(ord,
-                Interval(endpoint(1, -1), endpoint(rg.contigLength(i), -1)))
-                .map { interval =>
-                  Interval(endpoint(Locus(rg.contigs(i), interval.left.point.asInstanceOf[Int]), interval.left.sign),
-                    endpoint(Locus(rg.contigs(i), interval.right.point.asInstanceOf[Int]), interval.right.sign))
-                }
-            }.toArray
+        val comparisonData = if (IsConstant(l))
+          Some((l, r, false))
+        else if (IsConstant(r))
+          Some((r, l, true))
+        else
+          None
+        comparisonData.flatMap { case (const, k, flipped) =>
+          k match {
+            case x if es.isFirstKey(x) =>
+              // simple key comparison
+              Some((True(), Array(openInterval(constValue(const), const.typ, op, flipped))))
+            case Apply("contig", Seq(x)) if es.isFirstKey(x) =>
+              // locus contig comparison
+              val intervals = (constValue(const): @unchecked) match {
+                case s: String => Array(getIntervalFromContig(s, es.firstKeyType.asInstanceOf[TLocus].rg.asInstanceOf[ReferenceGenome]))
+              }
+              Some((True(), intervals))
+            case Apply("position", Seq(x)) if es.isFirstKey(x) =>
+              // locus position comparison
+              val pos = constValue(const).asInstanceOf[Int]
+              val rg = es.firstKeyType.asInstanceOf[TLocus].rg.asInstanceOf[ReferenceGenome]
+              val ord = TTuple(TInt32()).ordering
+              val intervals = rg.contigs.indices
+                .flatMap { i =>
+                  openInterval(pos, TInt32(), op, flipped).intersect(ord,
+                    Interval(endpoint(1, -1), endpoint(rg.contigLength(i), -1)))
+                    .map { interval =>
+                      Interval(
+                        endpoint(Locus(rg.contigs(i), interval.left.point.asInstanceOf[Row].getAs[Int](0)), interval.left.sign),
+                        endpoint(Locus(rg.contigs(i), interval.right.point.asInstanceOf[Row].getAs[Int](0)), interval.right.sign))
+                    }
+                }.toArray
 
-          Some((True(), intervals))
-        } else None
-      case Let(name, value, body) if name != ref.name =>
+              Some((True(), intervals))
+            case _ => None
+          }
+        }
+      case Let(name, value, body) if name != es.rowRef.name =>
         // TODO: thread key identity through values, since this will break when CSE arrives
         // TODO: thread predicates in `value` through `body` as a ref
-        extractAndRewrite(body, ref, k)
+        extractAndRewrite(body, es)
           .map { case (ir, intervals) => (Let(name, value, ir), intervals) }
       case _ => None
     }
@@ -191,7 +219,7 @@ object ExtractIntervalFilters {
     if (key.isEmpty)
       None
     else
-      extractAndRewrite(cond, ref, GetField(ref, key.head))
+      extractAndRewrite(cond, ExtractionState(ref, key))
   }
 
   def apply(ir0: BaseIR): BaseIR = {
@@ -204,7 +232,7 @@ object ExtractIntervalFilters {
               s"Intervals: ${ intervals.mkString(", ") }\n  " +
               s"Predicate: ${ Pretty(pred) }")
             TableFilter(
-              TableFilterIntervals(child, wrapInRow(intervals), keep = true),
+              TableFilterIntervals(child, intervals, keep = true),
               newCond)
           }
       case MatrixFilterRows(child, pred) =>
@@ -214,7 +242,7 @@ object ExtractIntervalFilters {
               s"Intervals: ${ intervals.mkString(", ") }\n  " +
               s"Predicate: ${ Pretty(pred) }")
             MatrixFilterRows(
-              MatrixFilterIntervals(child, wrapInRow(intervals), keep = true),
+              MatrixFilterIntervals(child, intervals, keep = true),
               newCond)
           }
 

--- a/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractIntervalFilters.scala
@@ -15,16 +15,6 @@ object ExtractIntervalFilters {
     val iOrd: IntervalEndpointOrdering = rowKeyType.ordering.intervalEndpointOrdering
 
     def isFirstKey(ir: IR): Boolean = ir == GetField(rowRef, rowType.fieldNames.head)
-
-    def isKeyStructPrefix(ir: IR): Boolean = ir match {
-      case MakeStruct(fields) => fields
-        .iterator
-        .map(_._2)
-        .zipWithIndex
-        .forall { case (fd, idx) => idx < rowType.size && fd == GetField(rowRef, rowType.fieldNames(idx)) }
-      case SelectFields(`rowRef`, fields) => keyFields.startsWith(fields)
-      case _ => false
-    }
   }
 
   def wrapInRow(intervals: Array[Interval]): Array[Interval] = {

--- a/hail/src/test/scala/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
@@ -10,7 +10,7 @@ import org.testng.annotations.Test
 
 class ExtractIntervalFiltersSuite extends SparkSuite {
 
-  lazy val ref1 = Ref("foo", TStruct("x" -> TInt32()))
+  lazy val ref1 = Ref("foo", TStruct("w" -> TInt32(), "x" -> TInt32()))
   lazy val k1 = GetField(ref1, "x")
   val ref1Key = FastIndexedSeq("x")
 

--- a/hail/src/test/scala/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
@@ -5,49 +5,53 @@ import is.hail.expr.types.virtual._
 import is.hail.utils.{FastIndexedSeq, FastSeq, Interval, IntervalEndpoint}
 import is.hail.variant.{Locus, ReferenceGenome}
 import is.hail.{ExecStrategy, SparkSuite}
+import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
 class ExtractIntervalFiltersSuite extends SparkSuite {
 
   lazy val ref1 = Ref("foo", TStruct("x" -> TInt32()))
   lazy val k1 = GetField(ref1, "x")
+  val ref1Key = FastIndexedSeq("x")
+
+  def wrappedIntervalEndpoint(x: Any, sign: Int) = IntervalEndpoint(Row(x), sign)
 
   @Test def testKeyComparison() {
     def check(node: ApplyComparisonOp, expectedInterval: Interval) {
-      val (rw, intervals) = ExtractIntervalFilters.extractAndRewrite(node, ref1, k1).get
+      val (rw, intervals) = ExtractIntervalFilters.extractPartitionFilters(node, ref1, ref1Key).get
       assert(rw == True())
       assert(intervals.toSeq == FastSeq(expectedInterval))
     }
 
     check(ApplyComparisonOp(GT(TInt32()), k1, I32(0)),
-      Interval(IntervalEndpoint(0, 1), IntervalEndpoint(Int.MaxValue, 1)))
+      Interval(wrappedIntervalEndpoint(0, 1), wrappedIntervalEndpoint(Int.MaxValue, 1)))
     check(ApplyComparisonOp(GT(TInt32()), I32(0), k1),
-      Interval(IntervalEndpoint(Int.MinValue, -1), IntervalEndpoint(0, -1)))
+      Interval(wrappedIntervalEndpoint(Int.MinValue, -1), wrappedIntervalEndpoint(0, -1)))
 
     check(ApplyComparisonOp(GTEQ(TInt32()), k1, I32(0)),
-      Interval(IntervalEndpoint(0, -1), IntervalEndpoint(Int.MaxValue, 1)))
+      Interval(wrappedIntervalEndpoint(0, -1), wrappedIntervalEndpoint(Int.MaxValue, 1)))
     check(ApplyComparisonOp(GTEQ(TInt32()), I32(0), k1),
-      Interval(IntervalEndpoint(Int.MinValue, -1), IntervalEndpoint(0, 1)))
+      Interval(wrappedIntervalEndpoint(Int.MinValue, -1), wrappedIntervalEndpoint(0, 1)))
 
     check(ApplyComparisonOp(LT(TInt32()), k1, I32(0)),
-      Interval(IntervalEndpoint(Int.MinValue, -1), IntervalEndpoint(0, -1)))
+      Interval(wrappedIntervalEndpoint(Int.MinValue, -1), wrappedIntervalEndpoint(0, -1)))
     check(ApplyComparisonOp(LT(TInt32()), I32(0), k1),
-      Interval(IntervalEndpoint(0, 1), IntervalEndpoint(Int.MaxValue, 1)))
+      Interval(wrappedIntervalEndpoint(0, 1), wrappedIntervalEndpoint(Int.MaxValue, 1)))
 
     check(ApplyComparisonOp(LTEQ(TInt32()), k1, I32(0)),
-      Interval(IntervalEndpoint(Int.MinValue, -1), IntervalEndpoint(0, 1)))
+      Interval(wrappedIntervalEndpoint(Int.MinValue, -1), wrappedIntervalEndpoint(0, 1)))
     check(ApplyComparisonOp(LTEQ(TInt32()), I32(0), k1),
-      Interval(IntervalEndpoint(0, -1), IntervalEndpoint(Int.MaxValue, 1)))
+      Interval(wrappedIntervalEndpoint(0, -1), wrappedIntervalEndpoint(Int.MaxValue, 1)))
 
     check(ApplyComparisonOp(EQ(TInt32()), k1, I32(0)),
-      Interval(IntervalEndpoint(0, -1), IntervalEndpoint(0, 1)))
+      Interval(wrappedIntervalEndpoint(0, -1), wrappedIntervalEndpoint(0, 1)))
     check(ApplyComparisonOp(EQ(TInt32()), I32(0), k1),
-      Interval(IntervalEndpoint(0, -1), IntervalEndpoint(0, 1)))
+      Interval(wrappedIntervalEndpoint(0, -1), wrappedIntervalEndpoint(0, 1)))
 
-    assert(ExtractIntervalFilters.extractAndRewrite(ApplyComparisonOp(NEQ(TInt32()), I32(0), k1), ref1, k1).isEmpty)
-    assert(ExtractIntervalFilters.extractAndRewrite(ApplyComparisonOp(EQWithNA(TInt32()), I32(0), k1), ref1, k1).isEmpty)
-    assert(ExtractIntervalFilters.extractAndRewrite(ApplyComparisonOp(NEQWithNA(TInt32()), I32(0), k1), ref1, k1).isEmpty)
-    assert(ExtractIntervalFilters.extractAndRewrite(ApplyComparisonOp(Compare(TInt32()), I32(0), k1), ref1, k1).isEmpty)
+    assert(ExtractIntervalFilters.extractPartitionFilters(ApplyComparisonOp(NEQ(TInt32()), I32(0), k1), ref1, ref1Key).isEmpty)
+    assert(ExtractIntervalFilters.extractPartitionFilters(ApplyComparisonOp(EQWithNA(TInt32()), I32(0), k1), ref1, ref1Key).isEmpty)
+    assert(ExtractIntervalFilters.extractPartitionFilters(ApplyComparisonOp(NEQWithNA(TInt32()), I32(0), k1), ref1, ref1Key).isEmpty)
+    assert(ExtractIntervalFilters.extractPartitionFilters(ApplyComparisonOp(Compare(TInt32()), I32(0), k1), ref1, ref1Key).isEmpty)
   }
 
   @Test def testLiteralContains() {
@@ -57,17 +61,17 @@ class ExtractIntervalFiltersSuite extends SparkSuite {
       Literal(TDict(TInt32(), TString()), Map(1 -> "foo", 10 -> "bar")))) {
       val ir = invoke("contains", lit, k1)
 
-      val (rw, i) = ExtractIntervalFilters.extractAndRewrite(ir, ref1, k1).get
+      val (rw, i) = ExtractIntervalFilters.extractPartitionFilters(ir, ref1, ref1Key).get
       assert(rw == True())
-      assert(i.toSeq == FastSeq(Interval(IntervalEndpoint(1, -1), IntervalEndpoint(1, 1)),
-        Interval(IntervalEndpoint(10, -1), IntervalEndpoint(10, 1))))
+      assert(i.toSeq == FastSeq(Interval(wrappedIntervalEndpoint(1, -1), wrappedIntervalEndpoint(1, 1)),
+        Interval(wrappedIntervalEndpoint(10, -1), wrappedIntervalEndpoint(10, 1))))
     }
   }
 
   @Test def testIntervalContains() {
     val interval = Interval(IntervalEndpoint(1, 1), IntervalEndpoint(5, 1))
     val ir = invoke("contains", Literal(TInterval(TInt32()), interval), k1)
-    val (rw, i) = ExtractIntervalFilters.extractAndRewrite(ir, ref1, k1).get
+    val (rw, i) = ExtractIntervalFilters.extractPartitionFilters(ir, ref1, ref1Key).get
     assert(rw == True())
     assert(i.toSeq == FastSeq(interval))
   }
@@ -80,15 +84,15 @@ class ExtractIntervalFiltersSuite extends SparkSuite {
     val ir1 = ApplyComparisonOp(EQ(TString()), Str("chr2"), invoke("contig", k))
     val ir2 = ApplyComparisonOp(EQ(TString()), invoke("contig", k), Str("chr2"))
 
-    val (rw1, i1) = ExtractIntervalFilters.extractAndRewrite(ir1, ref, k).get
+    val (rw1, i1) = ExtractIntervalFilters.extractPartitionFilters(ir1, ref, ref1Key).get
     assert(rw1 == True())
-    assert(i1.toSeq == FastSeq(Interval(IntervalEndpoint(Locus("chr2", 1), -1),
-      IntervalEndpoint(Locus("chr2", ReferenceGenome.GRCh38.contigLength("chr2")), -1))))
+    assert(i1.toSeq == FastSeq(Interval(wrappedIntervalEndpoint(Locus("chr2", 1), -1),
+      wrappedIntervalEndpoint(Locus("chr2", ReferenceGenome.GRCh38.contigLength("chr2")), -1))))
 
-    val (rw2, i2) = ExtractIntervalFilters.extractAndRewrite(ir2, ref, k).get
+    val (rw2, i2) = ExtractIntervalFilters.extractPartitionFilters(ir2, ref, ref1Key).get
     assert(rw2 == True())
-    assert(i2.toSeq == FastSeq(Interval(IntervalEndpoint(Locus("chr2", 1), -1),
-      IntervalEndpoint(Locus("chr2", ReferenceGenome.GRCh38.contigLength("chr2")), -1))))
+    assert(i2.toSeq == FastSeq(Interval(wrappedIntervalEndpoint(Locus("chr2", 1), -1),
+      wrappedIntervalEndpoint(Locus("chr2", ReferenceGenome.GRCh38.contigLength("chr2")), -1))))
   }
 
   @Test def testLocusPositionComparison() {
@@ -98,7 +102,7 @@ class ExtractIntervalFiltersSuite extends SparkSuite {
     val pos = invoke("position", k)
 
     def check(node: ApplyComparisonOp, expectedInterval: (String, Int) => Interval) {
-      val (rw, intervals) = ExtractIntervalFilters.extractAndRewrite(node, ref, k).get
+      val (rw, intervals) = ExtractIntervalFilters.extractPartitionFilters(node, ref, ref1Key).get
       assert(rw == True())
       assert(intervals.toSeq == ReferenceGenome.GRCh38.contigs
         .map { c => expectedInterval(c, ReferenceGenome.GRCh38.contigLength(c)) }
@@ -110,59 +114,59 @@ class ExtractIntervalFiltersSuite extends SparkSuite {
       (c: String, len: Int) => if (len < 100)
         null
       else
-        Interval(IntervalEndpoint(Locus(c, 100), 1), IntervalEndpoint(Locus(c, len), -1)))
+        Interval(wrappedIntervalEndpoint(Locus(c, 100), 1), wrappedIntervalEndpoint(Locus(c, len), -1)))
     check(ApplyComparisonOp(GT(TInt32()), pos, I32(-1000)),
-      (c: String, len: Int) => Interval(IntervalEndpoint(Locus(c, 1), -1), IntervalEndpoint(Locus(c, len), -1)))
+      (c: String, len: Int) => Interval(wrappedIntervalEndpoint(Locus(c, 1), -1), wrappedIntervalEndpoint(Locus(c, len), -1)))
     check(ApplyComparisonOp(GT(TInt32()), I32(100), pos),
-      (c: String, _: Int) => Interval(IntervalEndpoint(Locus(c, 1), -1), IntervalEndpoint(Locus(c, 100), -1)))
+      (c: String, _: Int) => Interval(wrappedIntervalEndpoint(Locus(c, 1), -1), wrappedIntervalEndpoint(Locus(c, 100), -1)))
 
     check(ApplyComparisonOp(GTEQ(TInt32()), pos, I32(100)),
       (c: String, len: Int) => if (len < 100)
         null
       else
-        Interval(IntervalEndpoint(Locus(c, 100), -1), IntervalEndpoint(Locus(c, len), -1)))
+        Interval(wrappedIntervalEndpoint(Locus(c, 100), -1), wrappedIntervalEndpoint(Locus(c, len), -1)))
     check(ApplyComparisonOp(GTEQ(TInt32()), pos, I32(-1000)),
-      (c: String, len: Int) => Interval(IntervalEndpoint(Locus(c, 1), -1), IntervalEndpoint(Locus(c, len), -1)))
+      (c: String, len: Int) => Interval(wrappedIntervalEndpoint(Locus(c, 1), -1), wrappedIntervalEndpoint(Locus(c, len), -1)))
     check(ApplyComparisonOp(GTEQ(TInt32()), I32(100), pos),
-      (c: String, _: Int) => Interval(IntervalEndpoint(Locus(c, 1), -1), IntervalEndpoint(Locus(c, 100), 1)))
+      (c: String, _: Int) => Interval(wrappedIntervalEndpoint(Locus(c, 1), -1), wrappedIntervalEndpoint(Locus(c, 100), 1)))
 
     check(ApplyComparisonOp(LT(TInt32()), pos, I32(100)),
-      (c: String, _: Int) => Interval(IntervalEndpoint(Locus(c, 1), -1), IntervalEndpoint(Locus(c, 100), -1)))
+      (c: String, _: Int) => Interval(wrappedIntervalEndpoint(Locus(c, 1), -1), wrappedIntervalEndpoint(Locus(c, 100), -1)))
     check(ApplyComparisonOp(LT(TInt32()), pos, I32(-1000)),
       (c: String, len: Int) => null)
     check(ApplyComparisonOp(LT(TInt32()), I32(100), pos),
       (c: String, len: Int) => if (len < 100)
         null
       else
-        Interval(IntervalEndpoint(Locus(c, 100), 1), IntervalEndpoint(Locus(c, len), -1)))
+        Interval(wrappedIntervalEndpoint(Locus(c, 100), 1), wrappedIntervalEndpoint(Locus(c, len), -1)))
 
     check(ApplyComparisonOp(LTEQ(TInt32()), pos, I32(100)),
-      (c: String, _: Int) => Interval(IntervalEndpoint(Locus(c, 1), -1), IntervalEndpoint(Locus(c, 100), 1)))
+      (c: String, _: Int) => Interval(wrappedIntervalEndpoint(Locus(c, 1), -1), wrappedIntervalEndpoint(Locus(c, 100), 1)))
     check(ApplyComparisonOp(LTEQ(TInt32()), pos, I32(-1000)),
       (c: String, len: Int) => null)
     check(ApplyComparisonOp(LTEQ(TInt32()), I32(100), pos),
       (c: String, len: Int) => if (len < 100)
         null
       else
-        Interval(IntervalEndpoint(Locus(c, 100), -1), IntervalEndpoint(Locus(c, len), -1)))
+        Interval(wrappedIntervalEndpoint(Locus(c, 100), -1), wrappedIntervalEndpoint(Locus(c, len), -1)))
 
     check(ApplyComparisonOp(EQ(TInt32()), pos, I32(100)),
       (c: String, len: Int) => if (len < 100)
         null
       else
-        Interval(IntervalEndpoint(Locus(c, 100), -1), IntervalEndpoint(Locus(c, 100), 1)))
+        Interval(wrappedIntervalEndpoint(Locus(c, 100), -1), wrappedIntervalEndpoint(Locus(c, 100), 1)))
     check(ApplyComparisonOp(EQ(TInt32()), I32(-1000), pos),
       (c: String, len: Int) => null)
     check(ApplyComparisonOp(EQ(TInt32()), I32(100), pos),
       (c: String, len: Int) => if (len < 100)
         null
       else
-        Interval(IntervalEndpoint(Locus(c, 100), -1), IntervalEndpoint(Locus(c, 100), 1)))
+        Interval(wrappedIntervalEndpoint(Locus(c, 100), -1), wrappedIntervalEndpoint(Locus(c, 100), 1)))
 
-    assert(ExtractIntervalFilters.extractAndRewrite(ApplyComparisonOp(NEQ(TInt32()), I32(0), pos), ref, k).isEmpty)
-    assert(ExtractIntervalFilters.extractAndRewrite(ApplyComparisonOp(EQWithNA(TInt32()), I32(0), pos), ref, k).isEmpty)
-    assert(ExtractIntervalFilters.extractAndRewrite(ApplyComparisonOp(NEQWithNA(TInt32()), I32(0), pos), ref, k).isEmpty)
-    assert(ExtractIntervalFilters.extractAndRewrite(ApplyComparisonOp(Compare(TInt32()), I32(0), pos), ref, k).isEmpty)
+    assert(ExtractIntervalFilters.extractPartitionFilters(ApplyComparisonOp(NEQ(TInt32()), I32(0), pos), ref, ref1Key).isEmpty)
+    assert(ExtractIntervalFilters.extractPartitionFilters(ApplyComparisonOp(EQWithNA(TInt32()), I32(0), pos), ref, ref1Key).isEmpty)
+    assert(ExtractIntervalFilters.extractPartitionFilters(ApplyComparisonOp(NEQWithNA(TInt32()), I32(0), pos), ref, ref1Key).isEmpty)
+    assert(ExtractIntervalFilters.extractPartitionFilters(ApplyComparisonOp(Compare(TInt32()), I32(0), pos), ref, ref1Key).isEmpty)
   }
 
   @Test def testLocusContigContains() {
@@ -178,24 +182,24 @@ class ExtractIntervalFiltersSuite extends SparkSuite {
 
       val ir = invoke("contains", lit, contig)
 
-      val (rw, intervals) = ExtractIntervalFilters.extractAndRewrite(ir, ref, k).get
+      val (rw, intervals) = ExtractIntervalFilters.extractPartitionFilters(ir, ref, ref1Key).get
       assert(rw == True())
       assert(intervals.toSeq == FastSeq(
         Interval(
-          IntervalEndpoint(Locus("chr1", 1), -1),
-          IntervalEndpoint(Locus("chr1", ReferenceGenome.GRCh38.contigLength("chr1")), -1)),
+          wrappedIntervalEndpoint(Locus("chr1", 1), -1),
+          wrappedIntervalEndpoint(Locus("chr1", ReferenceGenome.GRCh38.contigLength("chr1")), -1)),
         Interval(
-          IntervalEndpoint(Locus("chr10", 1), -1),
-          IntervalEndpoint(Locus("chr10", ReferenceGenome.GRCh38.contigLength("chr10")), -1))))
+          wrappedIntervalEndpoint(Locus("chr10", 1), -1),
+          wrappedIntervalEndpoint(Locus("chr10", ReferenceGenome.GRCh38.contigLength("chr10")), -1))))
     }
   }
 
   @Test def testIntervalListFold() {
     val inIntervals = FastIndexedSeq(
-      Interval(IntervalEndpoint(0, -1), IntervalEndpoint(10, -1)),
+      Interval(wrappedIntervalEndpoint(0, -1), wrappedIntervalEndpoint(10, -1)),
       null,
-      Interval(IntervalEndpoint(20, -1), IntervalEndpoint(25, -1)),
-      Interval(IntervalEndpoint(-10, -1), IntervalEndpoint(5, -1))
+      Interval(wrappedIntervalEndpoint(20, -1), wrappedIntervalEndpoint(25, -1)),
+      Interval(wrappedIntervalEndpoint(-10, -1), wrappedIntervalEndpoint(5, -1))
     )
 
     val ir = ArrayFold(
@@ -205,22 +209,22 @@ class ExtractIntervalFiltersSuite extends SparkSuite {
       "elt",
       invoke("||", Ref("acc", TBoolean()), invoke("contains", Ref("elt", TInterval(TInt32())), k1))
     )
-    val (rw, intervals) = ExtractIntervalFilters.extractAndRewrite(ir, ref1, k1).get
+    val (rw, intervals) = ExtractIntervalFilters.extractPartitionFilters(ir, ref1, ref1Key).get
     assert(rw == True())
     assert(intervals.toSeq == FastSeq(
-      Interval(IntervalEndpoint(-10, -1), IntervalEndpoint(10, -1)),
-      Interval(IntervalEndpoint(20, -1), IntervalEndpoint(25, -1))))
+      Interval(wrappedIntervalEndpoint(-10, -1), wrappedIntervalEndpoint(10, -1)),
+      Interval(wrappedIntervalEndpoint(20, -1), wrappedIntervalEndpoint(25, -1))))
   }
 
   @Test def testDisjunction() {
     val ir1 = ApplyComparisonOp(GT(TInt32()), k1, I32(0))
     val ir2 = ApplyComparisonOp(GT(TInt32()), k1, I32(10))
 
-    val (rw, intervals) = ExtractIntervalFilters.extractAndRewrite(invoke("||", ir1, ir2), ref1, k1).get
+    val (rw, intervals) = ExtractIntervalFilters.extractPartitionFilters(invoke("||", ir1, ir2), ref1, ref1Key).get
     assert(rw == True())
-    assert(intervals.toSeq == FastSeq(Interval(IntervalEndpoint(0, 1), IntervalEndpoint(Int.MaxValue, 1))))
+    assert(intervals.toSeq == FastSeq(Interval(wrappedIntervalEndpoint(0, 1), wrappedIntervalEndpoint(Int.MaxValue, 1))))
 
-    assert(ExtractIntervalFilters.extractAndRewrite(invoke("||", ir1, Ref("foo", TBoolean())), ref1, k1).isEmpty)
+    assert(ExtractIntervalFilters.extractPartitionFilters(invoke("||", ir1, Ref("foo", TBoolean())), ref1, ref1Key).isEmpty)
   }
 
   @Test def testConjunction() {
@@ -228,15 +232,15 @@ class ExtractIntervalFiltersSuite extends SparkSuite {
     val ir2 = ApplyComparisonOp(GT(TInt32()), k1, I32(10))
     val ir3 = In(0, TBoolean())
 
-    val (rw1, intervals1) = ExtractIntervalFilters.extractAndRewrite(invoke("&&", ir1, ir2), ref1, k1).get
+    val (rw1, intervals1) = ExtractIntervalFilters.extractPartitionFilters(invoke("&&", ir1, ir2), ref1, ref1Key).get
     assert(rw1 == invoke("&&", True(), True()))
-    assert(intervals1.toSeq == FastSeq(Interval(IntervalEndpoint(10, 1), IntervalEndpoint(Int.MaxValue, 1))))
+    assert(intervals1.toSeq == FastSeq(Interval(wrappedIntervalEndpoint(10, 1), wrappedIntervalEndpoint(Int.MaxValue, 1))))
 
-    val (rw2, intervals2) = ExtractIntervalFilters.extractAndRewrite(invoke("&&", ir3, ir2), ref1, k1).get
+    val (rw2, intervals2) = ExtractIntervalFilters.extractPartitionFilters(invoke("&&", ir3, ir2), ref1, ref1Key).get
     assert(rw2 == invoke("&&", ir3, True()))
-    assert(intervals2.toSeq == FastSeq(Interval(IntervalEndpoint(10, 1), IntervalEndpoint(Int.MaxValue, 1))))
+    assert(intervals2.toSeq == FastSeq(Interval(wrappedIntervalEndpoint(10, 1), wrappedIntervalEndpoint(Int.MaxValue, 1))))
 
-    assert(ExtractIntervalFilters.extractAndRewrite(invoke("&&", ir3, ir3), ref1, k1).isEmpty)
+    assert(ExtractIntervalFilters.extractPartitionFilters(invoke("&&", ir3, ir3), ref1, ref1Key).isEmpty)
   }
 
   @Test def testIntegration() {

--- a/hail/src/test/scala/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
@@ -73,7 +73,7 @@ class ExtractIntervalFiltersSuite extends SparkSuite {
     val ir = invoke("contains", Literal(TInterval(TInt32()), interval), k1)
     val (rw, i) = ExtractIntervalFilters.extractPartitionFilters(ir, ref1, ref1Key).get
     assert(rw == True())
-    assert(i.toSeq == FastSeq(interval))
+    assert(i.toSeq == FastSeq(Interval(wrappedIntervalEndpoint(1, 1), wrappedIntervalEndpoint(5, 1))))
   }
 
   @Test def testLocusContigComparison() {


### PR DESCRIPTION
This change is necessary to make it easy to support multiple kinds
of key patterns. In particular, I want to extract comparisons with
the key struct (or a prefix of the key struct).