### PR TITLE
[c++] Deforest reshape

### DIFF
--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2827,15 +2827,15 @@ class Tests(unittest.TestCase):
         self.ndarray_eq(a.reshape((2, 3)), np_a.reshape((2, 3)))
         self.ndarray_eq(a.reshape((3, 2)), np_a.reshape((3, 2)))
 
-        np_nums = np.array([0, 1, 2, 3, 4, 5, 6, 7])
-        nums = hl._ndarray(np_nums, row_major=False)
+        np_nums = np.array([0, 1, 2, 3, 4, 5, 6, 7]).reshape((2, 2, 2))
+        nums = hl._ndarray(np_nums)
 
-        cube_to_rect = nums.reshape((2, 2, 2)).reshape((2, 4))
-        np_cube_to_rect = np_nums.reshape((2, 2, 2)).reshape((2, 4))
+        cube_to_rect = nums.reshape((2, 4))
+        np_cube_to_rect = np_nums.reshape((2, 4))
         self.ndarray_eq(cube_to_rect, np_cube_to_rect)
 
-        cube_t_to_rect = nums.reshape((2, 2, 2)).transpose((1, 0, 2)).reshape((2, 4))
-        np_cube_t_to_rect = np_nums.reshape((2, 2, 2)).transpose((1, 0, 2)).reshape((2, 4))
+        cube_t_to_rect = nums.transpose((1, 0, 2)).reshape((2, 4))
+        np_cube_t_to_rect = np_nums.transpose((1, 0, 2)).reshape((2, 4))
         self.ndarray_eq(cube_t_to_rect, np_cube_t_to_rect)
 
     @skip_unless_spark_backend()

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2821,20 +2821,22 @@ class Tests(unittest.TestCase):
     @skip_unless_spark_backend()
     @run_with_cxx_compile()
     def test_ndarray_reshape(self):
-        a = hl._ndarray([1, 2, 3, 4, 5, 6])
-        fat = a.reshape((2, 3))
-        skinny = a.reshape((3, 2))
+        np_a = np.array([1, 2, 3, 4, 5, 6])
+        a = hl._ndarray(np_a)
 
-        a_three = a[2]
-        fat_three = fat[0, 2]
-        skinny_three = skinny[1, 0]
-        self.assertTrue(hl.eval(a_three) == hl.eval(fat_three) == hl.eval(skinny_three) == 3)
+        self.ndarray_eq(a.reshape((2, 3)), np_a.reshape((2, 3)))
+        self.ndarray_eq(a.reshape((3, 2)), np_a.reshape((3, 2)))
 
-        nums = hl._ndarray([0, 1, 2, 3, 4, 5, 6, 7])
-        cube = nums.reshape((2, 2, 2))
-        rect = cube.reshape((2, 4))
-        cube_t_to_rect = cube.transpose((1, 0, 2)).reshape((2, 4))
-        self.assertTrue(hl.eval(cube[0, 1, 1]) == hl.eval(rect[0, 3]) == hl.eval(cube_t_to_rect[1, 1]) == 3)
+        np_nums = np.array([0, 1, 2, 3, 4, 5, 6, 7])
+        nums = hl._ndarray(np_nums, row_major=False)
+
+        cube_to_rect = nums.reshape((2, 2, 2)).reshape((2, 4))
+        np_cube_to_rect = np_nums.reshape((2, 2, 2)).reshape((2, 4))
+        self.ndarray_eq(cube_to_rect, np_cube_to_rect)
+
+        cube_t_to_rect = nums.reshape((2, 2, 2)).transpose((1, 0, 2)).reshape((2, 4))
+        np_cube_t_to_rect = np_nums.reshape((2, 2, 2)).transpose((1, 0, 2)).reshape((2, 4))
+        self.ndarray_eq(cube_t_to_rect, np_cube_t_to_rect)
 
     @skip_unless_spark_backend()
     @run_with_cxx_compile()

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2827,15 +2827,15 @@ class Tests(unittest.TestCase):
         self.ndarray_eq(a.reshape((2, 3)), np_a.reshape((2, 3)))
         self.ndarray_eq(a.reshape((3, 2)), np_a.reshape((3, 2)))
 
-        np_nums = np.array([0, 1, 2, 3, 4, 5, 6, 7]).reshape((2, 2, 2))
-        nums = hl._ndarray(np_nums)
+        np_cube = np.array([0, 1, 2, 3, 4, 5, 6, 7], order='F').reshape((2, 2, 2))
+        cube = hl._ndarray([0, 1, 2, 3, 4, 5, 6, 7], row_major=False).reshape((2, 2, 2))
 
-        cube_to_rect = nums.reshape((2, 4))
-        np_cube_to_rect = np_nums.reshape((2, 4))
+        cube_to_rect = cube.reshape((2, 4))
+        np_cube_to_rect = np_cube.reshape((2, 4))
         self.ndarray_eq(cube_to_rect, np_cube_to_rect)
 
-        cube_t_to_rect = nums.transpose((1, 0, 2)).reshape((2, 4))
-        np_cube_t_to_rect = np_nums.transpose((1, 0, 2)).reshape((2, 4))
+        cube_t_to_rect = cube.transpose((1, 0, 2)).reshape((2, 4))
+        np_cube_t_to_rect = np_cube.transpose((1, 0, 2)).reshape((2, 4))
         self.ndarray_eq(cube_t_to_rect, np_cube_t_to_rect)
 
     @skip_unless_spark_backend()

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2824,19 +2824,18 @@ class Tests(unittest.TestCase):
         np_a = np.array([1, 2, 3, 4, 5, 6])
         a = hl._ndarray(np_a)
 
-        self.ndarray_eq(a.reshape((2, 3)), np_a.reshape((2, 3)))
-        self.ndarray_eq(a.reshape((3, 2)), np_a.reshape((3, 2)))
-
         np_cube = np.array([0, 1, 2, 3, 4, 5, 6, 7], order='F').reshape((2, 2, 2))
         cube = hl._ndarray([0, 1, 2, 3, 4, 5, 6, 7], row_major=False).reshape((2, 2, 2))
-
         cube_to_rect = cube.reshape((2, 4))
         np_cube_to_rect = np_cube.reshape((2, 4))
-        self.ndarray_eq(cube_to_rect, np_cube_to_rect)
-
         cube_t_to_rect = cube.transpose((1, 0, 2)).reshape((2, 4))
         np_cube_t_to_rect = np_cube.transpose((1, 0, 2)).reshape((2, 4))
-        self.ndarray_eq(cube_t_to_rect, np_cube_t_to_rect)
+
+        self.ndarrays_eq(
+            (a.reshape((2, 3)), np_a.reshape((2, 3))),
+            (a.reshape((3, 2)), np_a.reshape((3, 2))),
+            (cube_to_rect, np_cube_to_rect),
+            (cube_t_to_rect, np_cube_t_to_rect))
 
     @skip_unless_spark_backend()
     @run_with_cxx_compile()

--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -1602,15 +1602,15 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
 
         new NDArrayEmitter(fb, resultRegion, nDims, shape, setup) {
           override def outputElement(idxVars: Seq[Variable]): Code = {
-            val globalIndex = fb.variable("global_index", "int", idxVars.zip(reshapedNInnerElems).foldRight("0") {
-              case ((idx, nInnerElements), prod) => s"$prod + $idx * $nInnerElements"
+            val globalIndex = fb.variable("global_index", "long", idxVars.zip(reshapedNInnerElems).foldRight("0") {
+              case ((idx, nInnerElements), res) => s"$res + $idx * $nInnerElements"
             })
 
             val mappedIdxs = childNInnerElems.map { nInnerElementsForDim =>
-              val newIdx = fb.variable("new_idx", "int", s"$globalIndex / $nInnerElementsForDim")
+              val newIdx = fb.variable("new_idx", "long")
               val definition =
                 s"""
-                   | ${ newIdx.define }
+                   | ${ newIdx.defineWith(s"$globalIndex / $nInnerElementsForDim") }
                    | $globalIndex = $globalIndex % $nInnerElementsForDim;
                  """.stripMargin
 

--- a/hail/src/main/scala/is/hail/cxx/Emit.scala
+++ b/hail/src/main/scala/is/hail/cxx/Emit.scala
@@ -921,11 +921,7 @@ class Emitter(fb: FunctionBuilder, nSpecialArgs: Int, ctx: SparkFunctionContext)
              |})
            """.stripMargin)
 
-<<<<<<< HEAD
-      case _: ir.NDArrayMap | _: ir.NDArrayMap2 | _: ir.NDArraySlice | _: ir.NDArrayAgg =>
-=======
-      case _: ir.NDArrayMap | _: ir.NDArrayMap2 | _: ir.NDArraySlice | _: ir.NDArrayReshape =>
->>>>>>> deforest reshape
+      case _: ir.NDArrayMap | _: ir.NDArrayMap2 | _: ir.NDArraySlice | _: ir.NDArrayAgg | _: ir.NDArrayReshape =>
         val emitter = emitDeforestedNDArray(resultRegion, x, env)
         present(emitter.emit(x.pType.asInstanceOf[PNDArray].elementType))
 

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -976,10 +976,10 @@ class IRSuite extends HailSuite {
     val v = NDArrayReshape(matrixRowMajor, MakeTuple(Seq(I64(4))))
     val mat2 = NDArrayReshape(v, MakeTuple(Seq(I64(2), I64(2))))
 
-    assertEvalsTo(makeNDArrayRef(v, IndexedSeq(2)), 3.0)
-    assertEvalsTo(makeNDArrayRef(mat2, IndexedSeq(1, 0)), 3.0)
-    assertEvalsTo(makeNDArrayRef(v, IndexedSeq(0)), 1.0)
-    assertEvalsTo(makeNDArrayRef(mat2, IndexedSeq(0, 0)), 1.0)
+    assertEvalsTo(makeNDArrayRef(v, FastIndexedSeq(2)), 3.0)
+    assertEvalsTo(makeNDArrayRef(mat2, FastIndexedSeq(1, 0)), 3.0)
+    assertEvalsTo(makeNDArrayRef(v, FastIndexedSeq(0)), 1.0)
+    assertEvalsTo(makeNDArrayRef(mat2, FastIndexedSeq(0, 0)), 1.0)
   }
 
   @Test def testNDArrayMap() {


### PR DESCRIPTION
Instead of realizing an intermediate NDArray and switching up the shape/strides, now just map the new indices into the NDArray after a reshape to the corresponding indices prior to the reshape. Do this by converting to/from the single scalar index of an element in the NDArray (NOTE: this indexes elements in the NDArray by the row major (C) convention, but _does not_ necessarily correlate, nor is it related, to the actual memory layout)