### PR TITLE
refactor backend stuff in preparation for scheduler's backend

### DIFF
--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -1,8 +1,12 @@
 package is.hail.backend
 
+import is.hail.annotations.{Region, SafeRow}
 import is.hail.backend.spark.SparkBackend
+import is.hail.{HailContext, cxx}
 import is.hail.expr.JSONAnnotationImpex
-import is.hail.expr.ir.IR
+import is.hail.expr.ir.{Compilable, Compile, CompileAndEvaluate, IR, MakeTuple, Pretty}
+import is.hail.expr.types.physical.PTuple
+import is.hail.expr.types.virtual.TVoid
 import is.hail.utils._
 import org.json4s.DefaultFormats
 import org.json4s.jackson.{JsonMethods, Serialization}
@@ -16,7 +20,44 @@ abstract class Backend {
 
   def parallelizeAndComputeWithIndex[T: ClassTag, U : ClassTag](collection: Array[T])(f: (T, Int) => U): Array[U]
 
-  def execute(ir: IR, optimize: Boolean): (Any, Timings)
+  def lower(ir: IR, timer: Option[ExecutionTimer], optimize: Boolean = true): IR =
+      LowerTableIR(ir, timer, optimize)
+
+  def jvmLowerAndExecute(ir0: IR, optimize: Boolean): (Any, Timings) = {
+    val timer = new ExecutionTimer("Backend.execute")
+    val ir = lower(ir0, Some(timer), optimize)
+
+    if (!Compilable(ir))
+      throw new LowererUnsupportedOperation(s"lowered to uncompilable IR: ${Pretty(ir)}")
+
+    val res = Region.scoped { region =>
+      ir.typ match {
+        case TVoid =>
+          val (_, f) = timer.time(Compile[Unit](ir), "JVM compile")
+          timer.time(f(0)(region), "Runtime")
+        case _ =>
+          val (pt: PTuple, f) = timer.time(Compile[Long](MakeTuple(FastSeq(ir))), "JVM compile")
+          timer.time(SafeRow(pt, region, f(0)(region)).get(0), "Runtime")
+      }
+    }
+
+    (res, timer.timings)
+  }
+
+  def cxxLowerAndExecute(ir0: IR, optimize: Boolean): (Any, Timings) =
+    throw new cxx.CXXUnsupportedOperation("can't execute C++ on non-Spark backend!")
+
+  def execute(ir: IR, optimize: Boolean): (Any, Timings) = {
+    try {
+      if (HailContext.get.flags.get("cpp") == null)
+        jvmLowerAndExecute(ir, optimize)
+      else
+        cxxLowerAndExecute(ir, optimize)
+    } catch {
+      case (_: cxx.CXXUnsupportedOperation | _: LowererUnsupportedOperation) =>
+        CompileAndEvaluate(ir, optimize = optimize)
+    }
+  }
 
   def executeJSON(ir: IR): String = {
     val t = ir.typ

--- a/hail/src/main/scala/is/hail/backend/BackendUtils.scala
+++ b/hail/src/main/scala/is/hail/backend/BackendUtils.scala
@@ -1,10 +1,10 @@
-package is.hail.backend.spark
+package is.hail.backend
 
 import is.hail.HailContext
 import is.hail.annotations.Region
 import is.hail.asm4s._
 
-class SparkBackendUtils(mods: Array[(String, Int => AsmFunction3[Region, Array[Byte], Array[Byte], Array[Byte]])]) {
+class BackendUtils(mods: Array[(String, Int => AsmFunction3[Region, Array[Byte], Array[Byte], Array[Byte]])]) {
 
   type F = AsmFunction3[Region, Array[Byte], Array[Byte], Array[Byte]]
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1244,7 +1244,7 @@ private class Emit(
           fID
         }
 
-        val spark = parentFB.sparkBackend()
+        val spark = parentFB.backend()
         val contextAE = emitArrayIterator(contexts)
         val globalsT = emit(globals)
 

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -147,7 +147,7 @@ object TestUtils {
 
     if (env.m.isEmpty && args.isEmpty) {
       try {
-        val (res, _) = HailContext.backend.asSpark().cxxExecute(x, optimize = false)
+        val (res, _) = HailContext.backend.asSpark().cxxLowerAndExecute(x, optimize = false)
         res
       } catch {
         case e: CXXUnsupportedOperation =>


### PR DESCRIPTION
This PR should not change any of the backend functionality; it just renames some things that shouldn't be spark-specific and moves some generally-applicable code into the Backend class.