### PR TITLE
[hail] Memory-efficient scan

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -906,7 +906,9 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
             newAgg.combOp(agg2)
             newAgg
           }
-        }
+        }.toArray
+
+      assert(scanAggsPerPartition.length - 1 == tv.rvd.getNumPartitions, s"${scanAggsPerPartition.length} ${tv.rvd.getNumPartitions}")
 
       tv.copy(
         typ = typ,

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -884,7 +884,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
       }
 
       val scanAggsPerPartition =
-        tv.rvd.collectPerPartition { (i, ctx, it) =>
+        SpillingCollectIterator(tv.rvd.mapPartitionsWithIndex { (i, ctx, it) =>
           val globals =
             if (scanSeqNeedsGlobals) {
               val rvb = new RegionValueBuilder(ctx.freshRegion)
@@ -899,8 +899,8 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
             scanSeqOpF(rv.region, scanAggs, globals, false, rv.offset, false)
             ctx.region.clear()
           }
-          scanAggs
-        }.scanLeft(scanAggs) { (a1, a2) =>
+          Iterator.single(scanAggs)
+        }).scanLeft(scanAggs) { (a1, a2) =>
           (a1, a2).zipped.map { (agg1, agg2) =>
             val newAgg = agg1.copy()
             newAgg.combOp(agg2)

--- a/hail/src/main/scala/is/hail/utils/SpillingCollectIterator.scala
+++ b/hail/src/main/scala/is/hail/utils/SpillingCollectIterator.scala
@@ -40,7 +40,7 @@ class SpillingCollectIterator[T: ClassTag] private (rdd: RDD[T], sizeLimit: Int)
     if (buf.length == sizeLimit) {
       val file = hc.getTemporaryFile()
       hConf.writeFile(file) { os =>
-	      using(new ObjectOutputStream(os)) { oos =>
+        using(new ObjectOutputStream(os)) { oos =>
           var j = 0
           while (j < buf.length) {
             oos.writeObject(buf(j))
@@ -48,7 +48,7 @@ class SpillingCollectIterator[T: ClassTag] private (rdd: RDD[T], sizeLimit: Int)
           }
         }
       }
-	    files += file
+      files += file
       buf.clear()
     }
   }
@@ -66,18 +66,18 @@ class SpillingCollectIterator[T: ClassTag] private (rdd: RDD[T], sizeLimit: Int)
       if (i < files.length) {
         buf.clear()
         hConf.readFile(files(i)) { is =>
-	        using(new ObjectInputStream(is)) { ois =>
-	          var j = 0
-	          while (j < sizeLimit) {
-	            buf += ois.readObject().asInstanceOf[T]
-	            j += 1
-	          }
-	        }
-	      }
+          using(new ObjectInputStream(is)) { ois =>
+            var j = 0
+            while (j < sizeLimit) {
+              buf += ois.readObject().asInstanceOf[T]
+              j += 1
+            }
+          }
+        }
         i += 1
         it = buf.iterator
         return it.hasNext
-	    }
+      }
       i += 1
       it = null
       return false

--- a/hail/src/main/scala/is/hail/utils/SpillingCollectIterator.scala
+++ b/hail/src/main/scala/is/hail/utils/SpillingCollectIterator.scala
@@ -1,0 +1,82 @@
+package is.hail.utils
+
+import is.hail.HailContext
+import java.io.{ ObjectInputStream, ObjectOutputStream }
+import org.apache.spark.rdd.RDD
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
+
+object SpillingCollectIterator {
+  def apply[T: ClassTag](rdd: RDD[T], sizeLimit: Int = 1000): SpillingCollectIterator[T] = {
+    val x = new SpillingCollectIterator(rdd, sizeLimit)
+    x.runJob()
+    x
+  }
+}
+
+class SpillingCollectIterator[T: ClassTag] private (rdd: RDD[T], sizeLimit: Int) extends Iterator[T] {
+  private[this] val hc = HailContext.get
+  private[this] val hConf = hc.hadoopConf
+  private[this] val sc = hc.sc
+  private[this] val files: ArrayBuilder[String] = new ArrayBuilder[String]()
+  private[this] val buf: ArrayBuffer[T] = new ArrayBuffer()
+  private[this] var i: Int = -1
+  private[this] var it: Iterator[T] = null
+  private[this] var readyToIterate: Boolean = false
+
+  private def runJob(): Unit = {
+    sc.runJob(rdd, (tctx, it: Iterator[T]) => it.toArray, 0 until rdd.partitions.length,
+      (partition, a: Array[T]) => append(a))
+    readyToIterate = true
+  }
+
+  private[this] def append(a: Array[T]): Unit = synchronized {
+    buf ++= a
+    if (buf.length == sizeLimit) {
+      val file = hc.getTemporaryFile()
+      hConf.writeFile(file) { os =>
+	      using(new ObjectOutputStream(os)) { oos =>
+          var j = 0
+          while (j < buf.length) {
+            oos.writeObject(buf(j))
+            j += 1
+          }
+        }
+      }
+	    files += file
+      buf.clear()
+    }
+  }
+
+  def hasNext: Boolean = {
+    assert(readyToIterate)
+    if (it == null || !it.hasNext) {
+      if (i == -1) {
+        it = buf.iterator
+        i += 1
+      } else if (i < files.length) {
+        buf.clear()
+        hConf.readFile(files(i)) { is =>
+	        using(new ObjectInputStream(is)) { ois =>
+	          var j = 0
+	          while (j < sizeLimit) {
+	            buf += ois.readObject().asInstanceOf[T]
+	            j += 1
+	          }
+	        }
+	      }
+        it = buf.iterator
+        i += 1
+	    } else {
+        it = null
+      }
+    }
+    it != null && it.hasNext
+  }
+
+  def next: T = {
+    assert(readyToIterate)
+    it.next
+  }
+}
+


### PR DESCRIPTION
This adds `SpillingCollectIterator` which avoids holding more than 1000 aggregation results in memory at one time. We could do something that [listens for GC events](https://stackoverflow.com/questions/30041332/a-useful-metric-for-determining-when-the-jvm-is-about-to-get-into-memory-gc-trou) and spills data if there's high memory pressure. That seems a bit error prone and hard.

How should I pipe the size limit down to TableMapRows? The only workable solution I can think of is a HailContext setting. Maybe I should bite the bullet and respond to memory pressure? Either way this should get Laurent cooking with gas.


Spilling ten local files and then reading them in is probably in the noise of timings. 🎉

Master 0.2.14-4da055db5a7b
```ipython
In [1]: %%time  
   ...:  
   ...: import hail as hl 
   ...: ht = hl.utils.range_table(10000, n_partitions=10000) 
   ...: ht = ht.annotate(rank = hl.scan.count())._force_count()                                                                                                                                             
CPU times: user 1.45 s, sys: 333 ms, total: 1.78 s
Wall time: 24.6 s
In [3]: %%time  
   ...:  
   ...: import hail as hl 
   ...: ht = hl.utils.range_table(1000000, n_partitions=1000) 
   ...: ht = ht.annotate(rank = hl.scan.count())._force_count()                                                                                                                                             
CPU times: user 6.23 ms, sys: 1.96 ms, total: 8.19 ms
Wall time: 1.33 s
```
This branch:
```ipython
In [2]: %%time  
   ...:  
   ...: import hail as hl 
   ...: ht = hl.utils.range_table(10000, n_partitions=10000) 
   ...: ht = ht.annotate(rank = hl.scan.count())._force_count()                                                                                                                                                                                                                 
CPU times: user 1.41 s, sys: 313 ms, total: 1.72 s
Wall time: 25.2 s

In [3]: %%time 
   ...:  
   ...: import hail as hl 
   ...: ht = hl.utils.range_table(1000000, n_partitions=1000) 
   ...: ht = ht.annotate(rank = hl.scan.count())._force_count() 
   ...:  
   ...:                                                                                                                                                                                                                                                                         
CPU times: user 4.72 ms, sys: 1.82 ms, total: 6.53 ms
Wall time: 1.41 s
```

---

Minor implementation note: I did the rigamarole with `runJob` because I wasn't sure that using `synchronized` in a constructor was kosher and I'm also generally weary of Scala's constructor syntax.