### PR TITLE
[ci] support authorized shas for external PRs

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -423,6 +423,27 @@ steps:
     - default_ns
     - scorecard_image
     - deploy_router
+ - kind: createDatabase
+   name: ci_database
+   databaseName: ci
+   namespace:
+     valueFrom: default_ns.name
+   dependsOn:
+    - default_ns
+ - kind: deploy
+   name: create_ci_tables
+   namespace:
+     valueFrom: default_ns.name
+   config: ci/create-ci-tables-pod.yaml
+   wait:
+    - kind: Pod
+      name: create-ci-tables
+      for: completed
+      timeout: 120
+   dependsOn:
+     - default_ns
+     - base_image
+     - ci_database
  - kind: deploy
    name: deploy_ci
    namespace:
@@ -437,6 +458,8 @@ steps:
     - ci_image
     - ci_utils_image
     - create_accounts
+    - ci_database
+    - create_ci_tables
  - kind: createDatabase
    name: batch_database
    databaseName: batch

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -39,6 +39,8 @@ routes = web.RouteTableDef()
 @authenticated_developers_only
 @aiohttp_jinja2.template('index.html')
 async def index(request):  # pylint: disable=unused-argument
+    app = request.app
+    pool = app['pool']
     wb_configs = []
     for i, wb in enumerate(watched_branches):
         if wb.prs:
@@ -49,7 +51,7 @@ async def index(request):  # pylint: disable=unused-argument
                     'title': pr.title,
                     # FIXME generate links to the merge log
                     'batch_id': pr.batch.id if pr.batch and hasattr(pr.batch, 'id') else None,
-                    'build_state': pr.build_state if pr.authorized() else 'unauthorized',
+                    'build_state': pr.build_state if pr.authorized(pool) else 'unauthorized',
                     'review_state': pr.review_state,
                     'author': pr.author
                 }

--- a/ci/ci/constants.py
+++ b/ci/ci/constants.py
@@ -4,8 +4,6 @@ import hailjwt as hj
 GITHUB_CLONE_URL = 'https://github.com/'
 
 with open(os.environ['HAIL_TOKEN_FILE']) as f:
-    global BUCKET
-
     userdata = hj.JWTClient.unsafe_decode(f.read())
     BUCKET = f'gs://{userdata["bucket_name"]}'
 

--- a/ci/ci/templates/index.html
+++ b/ci/ci/templates/index.html
@@ -97,5 +97,12 @@
     Unknown.
     {% endif %}
     {% endfor %}
+
+    <h2>Authorize SHA</h2>
+    <form action="/authorize_source_sha" method="post">
+      <label for="sha">SHA:</label>
+      <input type="text" name="sha">
+      <button type="submit">Authorize</button>
+    </form>
   </body>
 </html>

--- a/ci/create-ci-tables-pod.yaml
+++ b/ci/create-ci-tables-pod.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: create-ci-tables
+spec:
+  containers:
+  - name: create-ci-tables
+    image: "{{ base_image.image }}"
+    env:
+     - name: CREATE_TABLES_SQL
+       value: |
+         CREATE TABLE IF NOT EXISTS authorized_shas (
+           sha VARCHAR(100) NOT NULL
+         ) ENGINE = InnoDB;
+         CREATE INDEX authorized_shas_sha ON authorized_shas (sha);
+    command:
+     - /bin/bash
+     - -c
+     - |
+       set -ex
+       # index creation isn't idempotent, don't create if a table exists
+       T=$(echo "SHOW TABLES LIKE 'authorized_shas';" | mysql --defaults-extra-file=/secrets/ci-admin/sql-config.cnf -s)
+       if [ "$T" != "authorized_shas" ]; then
+         echo "$CREATE_TABLES_SQL" | mysql --defaults-extra-file=/secrets/ci-admin/sql-config.cnf
+       fi
+    volumeMounts:
+      - mountPath: /secrets/ci-admin
+        readOnly: true
+        name: ci-admin-secret
+  volumes:
+    - name: ci-admin-secret
+      secret:
+        secretName: "{{ ci_database.admin_secret_name }}"
+  restartPolicy: Never

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -55,15 +55,18 @@ spec:
           ports:
             - containerPort: 5000
           volumeMounts:
-            - mountPath: /secrets/oauth-token
-              readOnly: true
-              name: hail-ci-0-1-github-oauth-token
-            - mountPath: /ci-jwt
-              readOnly: true
-              name: ci-jwt
-            - name: jwt-secret-key
-              mountPath: /jwt-secret-key
-              readOnly: true
+           - name: ci-user-secret
+             mountPath: /ci-user-secret
+             readOnly: true
+           - mountPath: /secrets/oauth-token
+             readOnly: true
+             name: hail-ci-0-1-github-oauth-token
+           - mountPath: /ci-jwt
+             readOnly: true
+             name: ci-jwt
+           - name: jwt-secret-key
+             mountPath: /jwt-secret-key
+             readOnly: true
           livenessProbe:
             httpGet:
               path: /healthcheck
@@ -77,16 +80,20 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
       volumes:
-        - name: hail-ci-0-1-github-oauth-token
-          secret:
-            secretName: hail-ci-0-1-github-oauth-token
-        - name: ci-jwt
-          secret:
-            secretName: ci-jwt
-        - name: jwt-secret-key
-          secret:
-            optional: false
-            secretName: jwt-secret-key
+       - name: ci-user-secret
+         secret:
+           optional: false
+           secretName: "{{ ci_database.user_secret_name }}"
+       - name: hail-ci-0-1-github-oauth-token
+         secret:
+           secretName: hail-ci-0-1-github-oauth-token
+       - name: ci-jwt
+         secret:
+           secretName: ci-jwt
+       - name: jwt-secret-key
+         secret:
+           optional: false
+           secretName: jwt-secret-key
 ---
 apiVersion: v1
 kind: Service

--- a/ci/deployment.yaml
+++ b/ci/deployment.yaml
@@ -55,17 +55,17 @@ spec:
           ports:
             - containerPort: 5000
           volumeMounts:
-           - name: ci-user-secret
-             mountPath: /ci-user-secret
+           - mountPath: /ci-user-secret
+             name: ci-user-secret
              readOnly: true
            - mountPath: /secrets/oauth-token
-             readOnly: true
              name: hail-ci-0-1-github-oauth-token
-           - mountPath: /ci-jwt
              readOnly: true
+           - mountPath: /ci-jwt
              name: ci-jwt
-           - name: jwt-secret-key
-             mountPath: /jwt-secret-key
+             readOnly: true
+           - mountPath: /jwt-secret-key
+             name: jwt-secret-key
              readOnly: true
           livenessProbe:
             httpGet:


### PR DESCRIPTION
 - add ci database with 1 table: authorized_shas
 - only start build if authorized author or source_sha is authorized
 - form on main page to add authorized sha,
 - unauthorized PRs are created, but not tested, and shown as unauthorized in UI
