### PR TITLE
[hail] Fix copy_log test to not pollute working directory

### DIFF
--- a/hail/python/test/hail/utils/test_utils.py
+++ b/hail/python/test/hail/utils/test_utils.py
@@ -60,7 +60,7 @@ class Tests(unittest.TestCase):
         self.assertFalse(hl.hadoop_exists(resource('doesnt.exist')))
 
     def test_hadoop_copy_log(self):
-        r = resource('copy_log_test.txt')
+        r = new_local_temp_file('log')
         hl.copy_log(r)
         stats = hl.hadoop_stat(r)
         self.assertTrue(stats['size_bytes'] > 0)


### PR DESCRIPTION
the `resource` directory is `src/test/resources`, not meant for output.