### PR TITLE
[hail] Fix a bunch of warnings generated by the tests.

### DIFF
--- a/hail/python/hail/experimental/ldscsim.py
+++ b/hail/python/hail/experimental/ldscsim.py
@@ -299,7 +299,7 @@ def multitrait_ss(mt, h2, pi, rg=0, seed=None):
 @typecheck(h2=list,
            rg=list)
 def create_cov_matrix(h2, rg):
-    """Creates covariance matrix for simulating correlated SNP effects.
+    r"""Creates covariance matrix for simulating correlated SNP effects.
     
     Given a list of heritabilities and a list of genetic correlations, :func:`.create_cov_matrix`
     constructs the covariance matrix necessary to draw from a multivariate normal

--- a/hail/python/hail/genetics/reference_genome.py
+++ b/hail/python/hail/genetics/reference_genome.py
@@ -344,7 +344,7 @@ class ReferenceGenome(object):
             the fasta_file's extension with `fai`.
         """
         if index_file is None:
-            index_file = re.sub('\.[^.]*$', '.fai', fasta_file)
+            index_file = re.sub(r'\.[^.]*$', '.fai', fasta_file)
         Env.backend().add_sequence(self.name, fasta_file, index_file)
         self._has_sequence = True
 

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -730,10 +730,10 @@ class Tests(unittest.TestCase):
         table = hl.utils.range_table(32)
         table = table.annotate(d=hl.cond(table.idx == 11, -0.0, table.idx / 3))
         r = table.aggregate(hl.agg.hist(table.d, 0, 10, 5))
-        self.assertEquals(r.bin_edges, [0, 2, 4, 6, 8, 10])
-        self.assertEquals(r.bin_freq, [6, 5, 6, 6, 7])
-        self.assertEquals(r.n_smaller, 1)
-        self.assertEquals(r.n_larger, 1)
+        self.assertEqual(r.bin_edges, [0, 2, 4, 6, 8, 10])
+        self.assertEqual(r.bin_freq, [6, 5, 6, 6, 7])
+        self.assertEqual(r.n_smaller, 1)
+        self.assertEqual(r.n_larger, 1)
 
     # Tested against R code
     # y = c(0.22848042, 0.09159706, -0.43881935, -0.99106171, 2.12823289)

--- a/hail/python/test/hail/expr/test_types.py
+++ b/hail/python/test/hail/expr/test_types.py
@@ -56,7 +56,7 @@ class Tests(unittest.TestCase):
 
         for i in range(len(ts)):
             for j in range(len(ts2)):
-                if (i == j):
+                if i == j:
                     self.assertEqual(ts[i], ts2[j])
                 else:
                     self.assertNotEqual(ts[i], ts2[j])
@@ -86,4 +86,4 @@ class Tests(unittest.TestCase):
     def test_nested_type_to_spark(self):
         ht = hl.utils.range_table(10)
         ht = ht.annotate(nested=hl.dict({"tup": hl.tuple([ht.idx])}))
-        ht.to_spark() # should not throw exception
+        ht.to_spark()  # should not throw exception

--- a/hail/python/test/hail/linalg/test_linalg.py
+++ b/hail/python/test/hail/linalg/test_linalg.py
@@ -15,9 +15,9 @@ class Tests(unittest.TestCase):
     @staticmethod
     def _np_matrix(a):
         if isinstance(a, BlockMatrix):
-            return np.matrix(a.to_numpy())
+            return np.array(a.to_numpy())
         else:
-            return np.matrix(a)
+            return np.array(a)
 
     def _assert_eq(self, a, b):
         self.assertTrue(np.array_equal(self._np_matrix(a), self._np_matrix(b)))
@@ -195,10 +195,10 @@ class Tests(unittest.TestCase):
         assert mt._same(mt_round_trip)
 
     def test_elementwise_ops(self):
-        nx = np.matrix([[2.0]])
-        nc = np.matrix([[1.0], [2.0]])
-        nr = np.matrix([[1.0, 2.0, 3.0]])
-        nm = np.matrix([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        nx = np.array([[2.0]])
+        nc = np.array([[1.0], [2.0]])
+        nr = np.array([[1.0, 2.0, 3.0]])
+        nm = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
 
         e = 2.0
         x = BlockMatrix.from_numpy(nx, block_size=8)
@@ -228,11 +228,11 @@ class Tests(unittest.TestCase):
         self._assert_eq(r + r, 2 * r)
         self._assert_eq(m + m, 2 * m)
 
-        self._assert_eq(x + c, np.matrix([[3.0], [4.0]]))
-        self._assert_eq(x + r, np.matrix([[3.0, 4.0, 5.0]]))
-        self._assert_eq(x + m, np.matrix([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]))
-        self._assert_eq(c + m, np.matrix([[2.0, 3.0, 4.0], [6.0, 7.0, 8.0]]))
-        self._assert_eq(r + m, np.matrix([[2.0, 4.0, 6.0], [5.0, 7.0, 9.0]]))
+        self._assert_eq(x + c, np.array([[3.0], [4.0]]))
+        self._assert_eq(x + r, np.array([[3.0, 4.0, 5.0]]))
+        self._assert_eq(x + m, np.array([[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]))
+        self._assert_eq(c + m, np.array([[2.0, 3.0, 4.0], [6.0, 7.0, 8.0]]))
+        self._assert_eq(r + m, np.array([[2.0, 4.0, 6.0], [5.0, 7.0, 9.0]]))
         self._assert_eq(x + c, c + x)
         self._assert_eq(x + r, r + x)
         self._assert_eq(x + m, m + x)
@@ -270,11 +270,11 @@ class Tests(unittest.TestCase):
         self._assert_eq(r - r, np.zeros((1, 3)))
         self._assert_eq(m - m, np.zeros((2, 3)))
 
-        self._assert_eq(x - c, np.matrix([[1.0], [0.0]]))
-        self._assert_eq(x - r, np.matrix([[1.0, 0.0, -1.0]]))
-        self._assert_eq(x - m, np.matrix([[1.0, 0.0, -1.0], [-2.0, -3.0, -4.0]]))
-        self._assert_eq(c - m, np.matrix([[0.0, -1.0, -2.0], [-2.0, -3.0, -4.0]]))
-        self._assert_eq(r - m, np.matrix([[0.0, 0.0, 0.0], [-3.0, -3.0, -3.0]]))
+        self._assert_eq(x - c, np.array([[1.0], [0.0]]))
+        self._assert_eq(x - r, np.array([[1.0, 0.0, -1.0]]))
+        self._assert_eq(x - m, np.array([[1.0, 0.0, -1.0], [-2.0, -3.0, -4.0]]))
+        self._assert_eq(c - m, np.array([[0.0, -1.0, -2.0], [-2.0, -3.0, -4.0]]))
+        self._assert_eq(r - m, np.array([[0.0, 0.0, 0.0], [-3.0, -3.0, -3.0]]))
         self._assert_eq(x - c, -(c - x))
         self._assert_eq(x - r, -(r - x))
         self._assert_eq(x - m, -(m - x))
@@ -312,11 +312,11 @@ class Tests(unittest.TestCase):
         self._assert_eq(r * r, r ** 2)
         self._assert_eq(m * m, m ** 2)
 
-        self._assert_eq(x * c, np.matrix([[2.0], [4.0]]))
-        self._assert_eq(x * r, np.matrix([[2.0, 4.0, 6.0]]))
-        self._assert_eq(x * m, np.matrix([[2.0, 4.0, 6.0], [8.0, 10.0, 12.0]]))
-        self._assert_eq(c * m, np.matrix([[1.0, 2.0, 3.0], [8.0, 10.0, 12.0]]))
-        self._assert_eq(r * m, np.matrix([[1.0, 4.0, 9.0], [4.0, 10.0, 18.0]]))
+        self._assert_eq(x * c, np.array([[2.0], [4.0]]))
+        self._assert_eq(x * r, np.array([[2.0, 4.0, 6.0]]))
+        self._assert_eq(x * m, np.array([[2.0, 4.0, 6.0], [8.0, 10.0, 12.0]]))
+        self._assert_eq(c * m, np.array([[1.0, 2.0, 3.0], [8.0, 10.0, 12.0]]))
+        self._assert_eq(r * m, np.array([[1.0, 4.0, 9.0], [4.0, 10.0, 18.0]]))
         self._assert_eq(x * c, c * x)
         self._assert_eq(x * r, r * x)
         self._assert_eq(x * m, m * x)
@@ -354,11 +354,11 @@ class Tests(unittest.TestCase):
         self._assert_close(r / r, np.ones((1, 3)))
         self._assert_close(m / m, np.ones((2, 3)))
 
-        self._assert_close(x / c, np.matrix([[2 / 1.0], [2 / 2.0]]))
-        self._assert_close(x / r, np.matrix([[2 / 1.0, 2 / 2.0, 2 / 3.0]]))
-        self._assert_close(x / m, np.matrix([[2 / 1.0, 2 / 2.0, 2 / 3.0], [2 / 4.0, 2 / 5.0, 2 / 6.0]]))
-        self._assert_close(c / m, np.matrix([[1 / 1.0, 1 / 2.0, 1 / 3.0], [2 / 4.0, 2 / 5.0, 2 / 6.0]]))
-        self._assert_close(r / m, np.matrix([[1 / 1.0, 2 / 2.0, 3 / 3.0], [1 / 4.0, 2 / 5.0, 3 / 6.0]]))
+        self._assert_close(x / c, np.array([[2 / 1.0], [2 / 2.0]]))
+        self._assert_close(x / r, np.array([[2 / 1.0, 2 / 2.0, 2 / 3.0]]))
+        self._assert_close(x / m, np.array([[2 / 1.0, 2 / 2.0, 2 / 3.0], [2 / 4.0, 2 / 5.0, 2 / 6.0]]))
+        self._assert_close(c / m, np.array([[1 / 1.0, 1 / 2.0, 1 / 3.0], [2 / 4.0, 2 / 5.0, 2 / 6.0]]))
+        self._assert_close(r / m, np.array([[1 / 1.0, 2 / 2.0, 3 / 3.0], [1 / 4.0, 2 / 5.0, 3 / 6.0]]))
         self._assert_close(x / c, 1 / (c / x))
         self._assert_close(x / r, 1 / (r / x))
         self._assert_close(x / m, 1 / (m / x))
@@ -392,12 +392,12 @@ class Tests(unittest.TestCase):
         self._assert_close((m - 4).abs(), np.abs(nm - 4))
 
     def test_matrix_ops(self):
-        nm = np.matrix([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        nm = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         m = BlockMatrix.from_numpy(nm, block_size=2)
-        nsquare = np.matrix([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+        nsquare = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
         square = BlockMatrix.from_numpy(nsquare, block_size=2)
 
-        nrow = np.matrix([[7.0, 8.0, 9.0]])
+        nrow = np.array([[7.0, 8.0, 9.0]])
         row = BlockMatrix.from_numpy(nrow, block_size=2)
 
         self._assert_eq(m.T, nm.T)
@@ -417,12 +417,12 @@ class Tests(unittest.TestCase):
         self.assertRaises(ValueError, lambda: m @ m)
         self.assertRaises(ValueError, lambda: m @ nm)
 
-        self._assert_eq(m.diagonal(), np.array([1.0, 5.0]))
-        self._assert_eq(m.T.diagonal(), np.array([1.0, 5.0]))
-        self._assert_eq((m @ m.T).diagonal(), np.array([14.0, 77.0]))
+        self._assert_eq(m.diagonal(), np.array([[1.0, 5.0]]))
+        self._assert_eq(m.T.diagonal(), np.array([[1.0, 5.0]]))
+        self._assert_eq((m @ m.T).diagonal(), np.array([[14.0, 77.0]]))
 
         self._assert_eq(m.sum(axis=0).T, np.array([[5.0], [7.0], [9.0]]))
-        self._assert_eq(m.sum(axis=1).T, np.array([6.0, 15.0]))
+        self._assert_eq(m.sum(axis=1).T, np.array([[6.0, 15.0]]))
         self._assert_eq(m.sum(axis=0).T + row, np.array([[12.0, 13.0, 14.0],
                                                          [14.0, 15.0, 16.0],
                                                          [16.0, 17.0, 18.0]]))

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -331,15 +331,15 @@ class Tests(unittest.TestCase):
         ds.annotate_entries(**exprs)
         ds.select_entries(**exprs)
 
-        ds1.explode_cols('\%!^!@#&#&$%#$%')
-        ds1.explode_cols(ds1['\%!^!@#&#&$%#$%'])
+        ds1.explode_cols(r'\%!^!@#&#&$%#$%')
+        ds1.explode_cols(ds1[r'\%!^!@#&#&$%#$%'])
         ds1.group_cols_by(ds1.a).aggregate(**{'*``81': agg.count()})
 
-        ds1.drop('\%!^!@#&#&$%#$%')
-        ds1.drop(ds1['\%!^!@#&#&$%#$%'])
+        ds1.drop(r'\%!^!@#&#&$%#$%')
+        ds1.drop(ds1[r'\%!^!@#&#&$%#$%'])
 
-        ds2.explode_rows('\%!^!@#&#&$%#$%')
-        ds2.explode_rows(ds2['\%!^!@#&#&$%#$%'])
+        ds2.explode_rows(r'\%!^!@#&#&$%#$%')
+        ds2.explode_rows(ds2[r'\%!^!@#&#&$%#$%'])
         ds2.group_rows_by(ds2.a).aggregate(**{'*``81': agg.count()})
 
     def test_semi_anti_join_rows(self):

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -50,11 +50,11 @@ class VCFTests(unittest.TestCase):
         mt = hl.import_vcf(resource('malformed.vcf'), filter='rs685723')
         mt._force_count_rows()
 
-        mt = hl.import_vcf(resource('sample.vcf'), filter='\trs\d+\t')
+        mt = hl.import_vcf(resource('sample.vcf'), filter=r'\trs\d+\t')
         assert mt.aggregate_rows(hl.agg.all(hl.is_missing(mt.rsid)))
 
     def test_find_replace(self):
-        mt = hl.import_vcf(resource('sample.vcf'), find_replace=('\trs\d+\t', '\t.\t'))
+        mt = hl.import_vcf(resource('sample.vcf'), find_replace=(r'\trs\d+\t', '\t.\t'))
         mt.rows().show()
         assert mt.aggregate_rows(hl.agg.all(hl.is_missing(mt.rsid)))
 

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -541,11 +541,11 @@ class Tests(unittest.TestCase):
         df.select(**exprs)
         df = df.transmute(**exprs)
 
-        df.explode('\%!^!@#&#&$%#$%')
-        df.explode(df['\%!^!@#&#&$%#$%'])
+        df.explode(r'\%!^!@#&#&$%#$%')
+        df.explode(df[r'\%!^!@#&#&$%#$%'])
 
-        df.drop('\%!^!@#&#&$%#$%')
-        df.drop(df['\%!^!@#&#&$%#$%'])
+        df.drop(r'\%!^!@#&#&$%#$%')
+        df.drop(df[r'\%!^!@#&#&$%#$%'])
         df.group_by(**{'*``81': df.a}).aggregate(c=agg.count())
 
     def test_sample(self):


### PR DESCRIPTION
Most are deprecation warnings related to np.matrix, some are
about invalid escape characters and resolved by using r- (raw-)
strings.