### PR TITLE
[batch,ci] minor fixes to callbacks

### DIFF
--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -554,7 +554,8 @@ class Job:
 
         if self.batch_id:
             batch = await Batch.from_db(self.batch_id, self.user)
-            await batch.mark_job_complete(self)
+            if batch is not None:
+                await batch.mark_job_complete(self)
 
     def to_dict(self):
         result = {

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -242,7 +242,7 @@ async def batch_callback_handler(request):
                     await wb.notify_batch_changed()
 
 
-@routes.post('/batch_callack')
+@routes.post('/batch_callback')
 async def batch_callback(request):
     await asyncio.shield(batch_callback_handler(request))
     return web.Response(status=200)


### PR DESCRIPTION
I decided that if a batch has been deleted, then there should not be callbacks from each job finishing after the deletion (ex: always_run jobs).