### PR TITLE
[hail] Fix converting numpy ndarrays to hail ndarrays

### DIFF
--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -221,7 +221,7 @@ def _to_expr(e, dtype):
     elif isinstance(dtype, tndarray):
         row_major = not e.flags.f_contiguous
         data = hl.array([to_expr(i.item(), dtype.element_type) for i in e.flatten('A')])
-        shape = hl.tuple(list(e.shape))
+        shape = to_expr(tuple([hl.int64(i) for i in e.shape]), ttuple(*[tint64 for _ in e.shape]))
         return expressions.construct_expr(MakeNDArray(data._ir, shape._ir, hl.bool(row_major)._ir), dtype)
     else:
         raise NotImplementedError(dtype)

--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -6,8 +6,10 @@ from hail.ir import *
 from hail.typecheck import linked_list
 from hail.utils.java import *
 from hail.utils.linkedlist import LinkedList
+from hail.utils.misc import np_type_to_hl_type
 from .indices import *
 
+import numpy as np
 
 class ExpressionException(Exception):
     def __init__(self, msg=''):
@@ -82,6 +84,8 @@ def impute_type(x):
             raise ExpressionException("Hail does not support heterogeneous dicts: "
                                       "found dict with values of types {} ".format(list(vts)))
         return tdict(unified_key_type, unified_value_type)
+    elif isinstance(x, np.ndarray):
+        return tndarray(np_type_to_hl_type(x.dtype), len(x.shape))
     elif x is None:
         raise ExpressionException("Hail cannot impute the type of 'None'")
     elif isinstance(x, (hl.expr.builders.CaseBuilder, hl.expr.builders.SwitchBuilder)):
@@ -214,6 +218,11 @@ def _to_expr(e, dtype):
             key_array = to_expr(keys, tarray(dtype.key_type))
             value_array = to_expr(values, tarray(dtype.value_type))
             return hl.dict(hl.zip(key_array, value_array))
+    elif isinstance(dtype, tndarray):
+        row_major = not e.flags.f_contiguous
+        data = hl.array([to_expr(i.item(), dtype.element_type) for i in e.flatten('A')])
+        shape = hl.tuple(list(e.shape))
+        return expressions.construct_expr(MakeNDArray(data._ir, shape._ir, hl.bool(row_major)._ir), dtype)
     else:
         raise NotImplementedError(dtype)
 

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -11,7 +11,7 @@ from hail.genetics.reference_genome import reference_genome_type, ReferenceGenom
 from hail.ir import *
 from hail.typecheck import *
 from hail.utils.java import Env
-from hail.utils.misc import plural, np_type_to_hl_type
+from hail.utils.misc import plural
 
 import numpy as np
 
@@ -3739,13 +3739,12 @@ def _ndarray(collection, row_major=True):
         return result
 
     if isinstance(collection, np.ndarray):
-        shape = list(collection.shape)
-        data_expr = to_expr(deep_flatten(collection.tolist()), tarray(np_type_to_hl_type(collection.dtype)))
-    else:
-        shape = list_shape(collection)
-        data_expr = hl.array(deep_flatten(collection))
+        return to_expr(collection)
 
+    shape = list_shape(collection)
     shape_expr = to_expr(tuple([hl.int64(i) for i in shape]), ir.ttuple(*[tint64 for _ in shape]))
+
+    data_expr = hl.array(deep_flatten(collection))
 
     ndir = ir.MakeNDArray(data_expr._ir, shape_expr._ir, hl.bool(row_major)._ir)
     return construct_expr(ndir, tndarray(data_expr.dtype.element_type, builtins.len(shape)))

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -11,7 +11,7 @@ from hail.genetics.reference_genome import reference_genome_type, ReferenceGenom
 from hail.ir import *
 from hail.typecheck import *
 from hail.utils.java import Env
-from hail.utils.misc import plural
+from hail.utils.misc import plural, np_type_to_hl_type
 
 import numpy as np
 
@@ -3738,23 +3738,9 @@ def _ndarray(collection, row_major=True):
 
         return result
 
-    def np_to_hl_type(t):
-        if t == np.int64:
-            return tint64
-        elif t == np.int32:
-            return tint32
-        elif t == np.float64:
-            return tfloat64
-        elif t == np.float32:
-            return tfloat32
-        elif t == np.bool:
-            return tbool
-        else:
-            raise TypeError(f'Unsupported numpy type: {t}')
-
     if isinstance(collection, np.ndarray):
         shape = list(collection.shape)
-        data_expr = to_expr(deep_flatten(collection.tolist()), tarray(np_to_hl_type(collection.dtype)))
+        data_expr = to_expr(deep_flatten(collection.tolist()), tarray(np_type_to_hl_type(collection.dtype)))
     else:
         shape = list_shape(collection)
         data_expr = hl.array(deep_flatten(collection))

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3753,11 +3753,14 @@ def _ndarray(collection, row_major=None):
 
     if isinstance(collection, np.ndarray):
         if row_major is None:
-            return to_expr(collection)
+            row_major = not collection.flags.f_contiguous
+            flattened = collection.flatten('A')
         else:
-            elem_type = np_type_to_hl_type(collection.dtype)
-            data = [to_expr(i.item(), elem_type) for i in collection.flatten('C' if row_major else 'F')]
-            shape = collection.shape
+            flattened = collection.flatten('C' if row_major else 'F')
+
+        elem_type = np_type_to_hl_type(collection.dtype)
+        data = [to_expr(i.item(), elem_type) for i in flattened]
+        shape = collection.shape
     elif isinstance(collection, list):
         shape = list_shape(collection)
         data = deep_flatten(collection)

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -1450,7 +1450,9 @@ def is_container(t) -> bool:
 def is_compound(t) -> bool:
     return (is_container(t)
             or isinstance(t, tstruct)
-            or isinstance(t, ttuple))
+            or isinstance(t, ttuple)
+            or isinstance(t, tndarray))
+
 
 def types_match(left, right) -> bool:
     return (len(left) == len(right)

--- a/hail/python/hail/utils/misc.py
+++ b/hail/python/hail/utils/misc.py
@@ -10,6 +10,8 @@ import hail
 from hail.typecheck import enumeration, typecheck, nullable
 from hail.utils.java import Env, joption, error
 
+import numpy as np
+
 
 @typecheck(n_rows=int, n_cols=int, n_partitions=nullable(int))
 def range_matrix_table(n_rows, n_cols, n_partitions=None) -> 'hail.MatrixTable':
@@ -454,3 +456,18 @@ def timestamp_path(base, suffix=''):
                     '-',
                     datetime.datetime.now().strftime("%Y%m%d-%H%M"),
                     suffix])
+
+
+def np_type_to_hl_type(t):
+    if t == np.int64:
+        return hail.tint64
+    elif t == np.int32:
+        return hail.tint32
+    elif t == np.float64:
+        return hail.tfloat64
+    elif t == np.float32:
+        return hail.tfloat32
+    elif t == np.bool:
+        return hail.tbool
+    else:
+        raise TypeError(f'Unsupported numpy type: {t}')

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2943,10 +2943,13 @@ class Tests(unittest.TestCase):
             np.array([True, False, True, True])
         ]
 
-        for arr in arrs:
+        for expected in arrs:
             with tempfile.NamedTemporaryFile(suffix='.npy') as f:
-                hl._ndarray(arr).save(f.name)
-                self.assertTrue(np.array_equal(arr, np.load(f.name)))
+                hl._ndarray(expected).save(f.name)
+                actual = np.load(f.name)
+
+                self.assertTrue(expected.dtype == actual.dtype, f'expected: {expected.dtype}, actual: {actual.dtype}')
+                self.assertTrue(np.array_equal(expected, actual))
 
     @skip_unless_spark_backend()
     @run_with_cxx_compile()


### PR DESCRIPTION
Couples changes:
- Explicitly convert numpy types to hail types and don't only accept numpy floats. Apparently `np.array_equal` is very relaxed and will coerce between ints and booleans so the test that should have caught this now checks the types too.
- There was a subtle bug when extracting the numpy ndarray values into python. The values were always being extracted in row-major order, regardless of their previous layout in numpy. Changed it so now `row_major` can be `None`, in which case for numpy ndarrays it will use the existing ordering and will default to row major if just entering a python list.

Note: row and column major (or in numpy terms, C contiguous and F contiguous) aren't the only options. It can be strided in a bunch of different permutations, but in these cases we read it out of numpy as row major.