### PR TITLE
Pipeline fix verbose

### DIFF
--- a/pipeline/pipeline/backend.py
+++ b/pipeline/pipeline/backend.py
@@ -255,7 +255,7 @@ class BatchBackend(Backend):
                 jobs_to_command[j] = write_cmd
                 n_jobs_submitted += 1
                 if verbose:
-                    print(f"Submitted Job {j.id} with command: {write_cmd}")
+                    print(write_cmd)
 
         for task in pipeline._tasks:
             inputs = [x for r in task._inputs for x in copy_input(r)]
@@ -305,7 +305,7 @@ class BatchBackend(Backend):
             task_to_job_mapping[task] = j
             jobs_to_command[j] = cmd
             if verbose:
-                print(f"Submitted Job {j.id} with command: {cmd}")
+                print(cmd)
 
         if dry_run:
             print("\n\n".join(commands))

--- a/pipeline/pipeline/backend.py
+++ b/pipeline/pipeline/backend.py
@@ -254,8 +254,6 @@ class BatchBackend(Backend):
                                      attributes={'name': 'write_external_inputs'})
                 jobs_to_command[j] = write_cmd
                 n_jobs_submitted += 1
-                if verbose:
-                    print(write_cmd)
 
         for task in pipeline._tasks:
             inputs = [x for r in task._inputs for x in copy_input(r)]
@@ -304,8 +302,6 @@ class BatchBackend(Backend):
 
             task_to_job_mapping[task] = j
             jobs_to_command[j] = cmd
-            if verbose:
-                print(cmd)
 
         if dry_run:
             print("\n\n".join(commands))
@@ -325,6 +321,12 @@ class BatchBackend(Backend):
             n_jobs_submitted += 1
 
         batch = batch.submit()
+
+        if verbose:
+            print(f'Submitted batch {batch.id} with {n_jobs_submitted} jobs:')
+            for job, cmd in jobs_to_command.items():
+                print(f'{job.id}: {cmd}')
+
         status = batch.wait()
 
         if status['state'] == 'success':

--- a/pipeline/test/test_pipeline.py
+++ b/pipeline/test/test_pipeline.py
@@ -408,3 +408,11 @@ class BatchTests(unittest.TestCase):
         t.command(f'echo hello > {t.ofile}')
         p.write_output(t.ofile, f'{gcs_output_dir}/test_single_task_output.txt')
         p.run(dry_run=True)
+
+    def test_verbose(self):
+        p = self.pipeline()
+        input = p.read_input(f'{gcs_input_dir}/hello.txt')
+        t = p.new_task()
+        t.command(f'cat {input}')
+        p.write_output(input, f'{gcs_output_dir}/hello.txt')
+        p.run(verbose=True)


### PR DESCRIPTION
Let me know if you need the context. I don't think it's necessary and will break my interface. I didn't want the job id to be available until the whole batch is submitted and the batch id is available.