### PR TITLE
[hail] memory-efficient scan

### DIFF
--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -621,7 +621,8 @@ class HailFeatureFlags {
   private[this] val flags: mutable.Map[String, String] =
     mutable.Map[String, String](
       "cpp" -> null,
-      "lower" -> null
+      "lower" -> null,
+      "max_leader_scans" -> "1000"
     )
 
   val available: java.util.ArrayList[String] =

--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -271,7 +271,7 @@ object HailContext {
 
     if (!quiet)
       ProgressBarBuilder.build(sparkContext)
-     
+
     val hc = new HailContext(SparkBackend(sparkContext), logFile, tmpDir, branchingFactor, optimizerIterations)
     sparkContext.uiWebUrl.foreach(ui => info(s"SparkUI: $ui"))
 
@@ -397,7 +397,7 @@ class HailContext private(
   val sparkSession = SparkSession.builder().config(sc.getConf).getOrCreate()
   val sFS: FS = new HadoopFS(new SerializableHadoopConfiguration(sc.hadoopConfiguration))
   val bcFS: Broadcast[FS] = sc.broadcast(sFS)
-  
+
   val tmpDir = TempDir.createTempDir(tmpDirPath, sFS)
   info(s"Hail temporary directory: $tmpDir")
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -894,7 +894,7 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
             ctx.region.clear()
           }
           Iterator.single(scanAggs)
-        }).scanLeft(scanAggs) { (a1, a2) =>
+        }, HailContext.get.flags.get("max_leader_scans").toInt).scanLeft(scanAggs) { (a1, a2) =>
           (a1, a2).zipped.map { (agg1, agg2) =>
             val newAgg = agg1.copy()
             newAgg.combOp(agg2)

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -900,7 +900,9 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
             newAgg.combOp(agg2)
             newAgg
           }
-        }
+        }.toArray
+
+      assert(scanAggsPerPartition.length - 1 == tv.rvd.getNumPartitions, s"${scanAggsPerPartition.length} ${tv.rvd.getNumPartitions}")
 
       tv.copy(
         typ = typ,

--- a/hail/src/main/scala/is/hail/io/fs/FS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/FS.scala
@@ -6,7 +6,7 @@ import java.util
 import is.hail.utils.{TextInputFilterAndReplace, WithContext}
 import net.jpountz.lz4.LZ4Compressor
 import com.esotericsoftware.kryo.io.{Input, Output}
-import org.apache.hadoop.fs.FSDataInputStream
+import org.apache.hadoop.fs.{ FSDataInputStream, FSDataOutputStream }
 
 trait FileSystem {
   def open: FSDataInputStream
@@ -108,6 +108,10 @@ trait FS extends Serializable{
   def readFile[T](filename: String)(f: (InputStream) => T): T
 
   def writeFile[T](filename: String)(f: (OutputStream) => T): T
+
+  def readFileNoCompression[T](filename: String)(f: (FSDataInputStream) => T): T
+
+  def writeFileNoCompression[T](filename: String)(f: (FSDataOutputStream) => T): T
 
   def readLines[T](filename: String, filtAndReplace: TextInputFilterAndReplace = TextInputFilterAndReplace())(reader: Iterator[WithContext[String]] => T): T
 

--- a/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
@@ -10,7 +10,7 @@ import is.hail.io.compress.BGzipCodec
 import is.hail.utils.{Context, TextInputFilterAndReplace, WithContext, readableBytes}
 import net.jpountz.lz4.{LZ4BlockOutputStream, LZ4Compressor}
 import org.apache.hadoop
-import org.apache.hadoop.fs.{ FSDataInputStream, FSDataOutputStream, FileStatus }
+import org.apache.hadoop.fs.{ FSDataInputStream, FSDataOutputStream }
 import org.apache.hadoop.io.IOUtils._
 import org.apache.hadoop.io.compress.CompressionCodecFactory
 

--- a/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
+++ b/hail/src/main/scala/is/hail/io/fs/HadoopFS.scala
@@ -10,8 +10,8 @@ import is.hail.io.compress.BGzipCodec
 import is.hail.utils.{Context, TextInputFilterAndReplace, WithContext, readableBytes}
 import net.jpountz.lz4.{LZ4BlockOutputStream, LZ4Compressor}
 import org.apache.hadoop
-import org.apache.hadoop.fs.FSDataInputStream
-import org.apache.hadoop.io.IOUtils.copyBytes
+import org.apache.hadoop.fs.{ FSDataInputStream, FSDataOutputStream, FileStatus }
+import org.apache.hadoop.io.IOUtils._
 import org.apache.hadoop.io.compress.CompressionCodecFactory
 
 import scala.io.Source
@@ -90,11 +90,16 @@ class HadoopFS(val conf: SerializableHadoopConfiguration) extends FS {
     val os = fs.create(hPath)
     val codecFactory = new CompressionCodecFactory(conf.value)
     val codec = codecFactory.getCodec(hPath)
-
     if (codec != null)
       codec.createOutputStream(os)
     else
       os
+  }
+
+  private def createNoCompresion(filename: String): FSDataOutputStream = {
+    val fs = _fileSystem(filename)
+    val hPath = new hadoop.fs.Path(filename)
+    return fs.create(hPath)
   }
 
   def open(filename: String, checkCodec: Boolean = true): InputStream = {
@@ -119,6 +124,20 @@ class HadoopFS(val conf: SerializableHadoopConfiguration) extends FS {
         is
     } else
       is
+  }
+
+  private def openNoCompression(filename: String): FSDataInputStream = {
+    val fs = _fileSystem(filename)
+    val hPath = new hadoop.fs.Path(filename)
+    try {
+      fs.open(hPath)
+    } catch {
+      case e: FileNotFoundException =>
+        if (isDir(filename))
+          throw new FileNotFoundException(s"'$filename' is a directory (or native Table/MatrixTable)")
+        else
+          throw e
+    }
   }
 
   def getProperty(name: String): String = {
@@ -383,6 +402,12 @@ class HadoopFS(val conf: SerializableHadoopConfiguration) extends FS {
 
   def writeFile[T](filename: String)(f: (OutputStream) => T): T =
     using(create(filename))(f)
+
+  def readFileNoCompression[T](filename: String)(f: (FSDataInputStream) => T): T =
+    using(openNoCompression(filename))(f)
+
+  def writeFileNoCompression[T](filename: String)(f: (FSDataOutputStream) => T): T =
+    using(createNoCompresion(filename))(f)
 
   def readLines[T](filename: String, filtAndReplace: TextInputFilterAndReplace = TextInputFilterAndReplace())(reader: Iterator[WithContext[String]] => T): T = {
     readFile[T](filename) {

--- a/hail/src/main/scala/is/hail/utils/SpillingCollectIterator.scala
+++ b/hail/src/main/scala/is/hail/utils/SpillingCollectIterator.scala
@@ -40,7 +40,7 @@ class SpillingCollectIterator[T: ClassTag] private (rdd: RDD[T], sizeLimit: Int)
     if (buf.length == sizeLimit) {
       val file = hc.getTemporaryFile()
       hConf.writeFile(file) { os =>
-	      using(new ObjectOutputStream(os)) { oos =>
+        using(new ObjectOutputStream(os)) { oos =>
           var j = 0
           while (j < buf.length) {
             oos.writeObject(buf(j))
@@ -48,7 +48,7 @@ class SpillingCollectIterator[T: ClassTag] private (rdd: RDD[T], sizeLimit: Int)
           }
         }
       }
-	    files += file
+      files += file
       buf.clear()
     }
   }
@@ -66,18 +66,18 @@ class SpillingCollectIterator[T: ClassTag] private (rdd: RDD[T], sizeLimit: Int)
       if (i < files.length) {
         buf.clear()
         hConf.readFile(files(i)) { is =>
-	        using(new ObjectInputStream(is)) { ois =>
-	          var j = 0
-	          while (j < sizeLimit) {
-	            buf += ois.readObject().asInstanceOf[T]
-	            j += 1
-	          }
-	        }
-	      }
+          using(new ObjectInputStream(is)) { ois =>
+            var j = 0
+            while (j < sizeLimit) {
+              buf += ois.readObject().asInstanceOf[T]
+              j += 1
+            }
+          }
+        }
         i += 1
         it = buf.iterator
         return it.hasNext
-	    }
+      }
       i += 1
       it = null
       return false

--- a/hail/src/main/scala/is/hail/utils/SpillingCollectIterator.scala
+++ b/hail/src/main/scala/is/hail/utils/SpillingCollectIterator.scala
@@ -1,0 +1,82 @@
+package is.hail.utils
+
+import is.hail.HailContext
+import java.io.{ ObjectInputStream, ObjectOutputStream }
+import org.apache.spark.rdd.RDD
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
+
+object SpillingCollectIterator {
+  def apply[T: ClassTag](rdd: RDD[T], sizeLimit: Int = 1000): SpillingCollectIterator[T] = {
+    val x = new SpillingCollectIterator(rdd, sizeLimit)
+    x.runJob()
+    x
+  }
+}
+
+class SpillingCollectIterator[T: ClassTag] private (rdd: RDD[T], sizeLimit: Int) extends Iterator[T] {
+  private[this] val hc = HailContext.get
+  private[this] val hConf = hc.hadoopConf
+  private[this] val sc = hc.sc
+  private[this] val files: ArrayBuilder[String] = new ArrayBuilder[String]()
+  private[this] val buf: ArrayBuffer[T] = new ArrayBuffer()
+  private[this] var i: Int = -1
+  private[this] var it: Iterator[T] = null
+  private[this] var readyToIterate: Boolean = false
+
+  private def runJob(): Unit = {
+    sc.runJob(rdd, (tctx, it: Iterator[T]) => it.toArray, 0 until rdd.partitions.length,
+      (partition, a: Array[T]) => append(a))
+    readyToIterate = true
+  }
+
+  private[this] def append(a: Array[T]): Unit = synchronized {
+    buf ++= a
+    if (buf.length == sizeLimit) {
+      val file = hc.getTemporaryFile()
+      hConf.writeFile(file) { os =>
+	      using(new ObjectOutputStream(os)) { oos =>
+          var j = 0
+          while (j < buf.length) {
+            oos.writeObject(buf(j))
+            j += 1
+          }
+        }
+      }
+	    files += file
+      buf.clear()
+    }
+  }
+
+  def hasNext: Boolean = {
+    assert(readyToIterate)
+    if (it == null || !it.hasNext) {
+      if (i == -1) {
+        it = buf.iterator
+        i += 1
+      } else if (i < files.length) {
+        buf.clear()
+        hConf.readFile(files(i)) { is =>
+	        using(new ObjectInputStream(is)) { ois =>
+	          var j = 0
+	          while (j < sizeLimit) {
+	            buf += ois.readObject().asInstanceOf[T]
+	            j += 1
+	          }
+	        }
+	      }
+        it = buf.iterator
+        i += 1
+	    } else {
+        it = null
+      }
+    }
+    it != null && it.hasNext
+  }
+
+  def next: T = {
+    assert(readyToIterate)
+    it.next
+  }
+}
+

--- a/hail/src/main/scala/is/hail/utils/SpillingCollectIterator.scala
+++ b/hail/src/main/scala/is/hail/utils/SpillingCollectIterator.scala
@@ -2,12 +2,7 @@ package is.hail.utils
 
 import is.hail.HailContext
 import java.io.{ ObjectInputStream, ObjectOutputStream }
-import java.util.TreeMap
-import java.util.function.BiConsumer
-import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
-import scala.collection.mutable
-import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 import scala.reflect.classTag
 

--- a/hail/src/main/scala/is/hail/utils/SpillingCollectIterator.scala
+++ b/hail/src/main/scala/is/hail/utils/SpillingCollectIterator.scala
@@ -7,7 +7,7 @@ import scala.reflect.ClassTag
 import scala.reflect.classTag
 
 object SpillingCollectIterator {
-  def apply[T: ClassTag](rdd: RDD[T], sizeLimit: Int = 1000): SpillingCollectIterator[T] = {
+  def apply[T: ClassTag](rdd: RDD[T], sizeLimit: Int): SpillingCollectIterator[T] = {
     val x = new SpillingCollectIterator(rdd, sizeLimit)
     val ctc = classTag[T]
     HailContext.get.sc.runJob(


### PR DESCRIPTION
This adds `SpillingCollectIterator` which avoids holding more than 1000 aggregation results in memory at one time. We could do something that listens for GC events and spills data if there's high memory pressure. That seems a bit error prone and hard.

How should I pipe the size limit down to TableMapRows? I decided to make it a HailContext `flag` which means its not very user-visible, but Laurent can set it for now. In C++ we can design a system that is aware of its memory usage and adjusts memory allocated to scans accordingly.

Spilling ten local files and then reading them in is probably in the noise of timings. 🎉

---

### Implementation Notes

I had to add two new file operations to the `RichHadoopConfiguration` because I need seekable file input streams. I don't like the names. I'm not sure what to do here. Hadoop really screws us with the seek-ability on compressed streams.

The implementation is rather simple, it just maintains an array of the per-partition results. The index of the array corresponds to the partition index. The sparsity of that array is controlled by how often we spill. For an operation with a huge number of partitions that are often spilled (e.g. large number of partitions, each with a lot of data), we may want to use a `Map` instead of an `Array`.

The use of `ObjectOutputStream` without a try-catch-finally block is non-standard. I was having trouble seeking to individual classes when I used one ObjectOutputStream to output each partition's array. There were these "bad header" messages. This seems to work. I don't close the OOS because I'm going to re-use the underlying output stream on the next partition.

We use O(n_spills) files.

---

### Timings

Master 0.2.14-4da055db5a7b
```
In [1]: %%time  
   ...:  
   ...: import hail as hl 
   ...: ht = hl.utils.range_table(10000, n_partitions=10000) 
   ...: ht = ht.annotate(rank = hl.scan.count())._force_count()                                                                                                                                             
CPU times: user 1.45 s, sys: 333 ms, total: 1.78 s
Wall time: 24.6 s
In [3]: %%time  
   ...:  
   ...: import hail as hl 
   ...: ht = hl.utils.range_table(1000000, n_partitions=1000) 
   ...: ht = ht.annotate(rank = hl.scan.count())._force_count()                                                                                                                                             
CPU times: user 6.23 ms, sys: 1.96 ms, total: 8.19 ms
Wall time: 1.33 s
```
This branch
```
In [1]: %%time  
   ...:  
   ...: import hail as hl 
   ...: ht = hl.utils.range_table(10000, n_partitions=10000) 
   ...: ht = ht.annotate(rank = hl.scan.count())._force_count()                                                                                                                                                                                                                 
CPU times: user 1.4 s, sys: 362 ms, total: 1.76 s
Wall time: 25.6 s

In [2]: %%time  
   ...:  
   ...: import hail as hl 
   ...: ht = hl.utils.range_table(1000000, n_partitions=1000) 
   ...: ht = ht.annotate(rank = hl.scan.count())._force_count()                                                                                                                                                                                                                 
CPU times: user 4.14 ms, sys: 1.26 ms, total: 5.4 ms
Wall time: 1.47 s
```