### PR TITLE
[batch] fix cancelled

### DIFF
--- a/batch/batch/database.py
+++ b/batch/batch/database.py
@@ -72,8 +72,7 @@ class Table:  # pylint: disable=R0903
                 values_template = ", ".join(["%s" for _ in items.values()])
                 sql = f"INSERT INTO `{self.name}` ({names}) VALUES ({values_template})"
                 await cursor.execute(sql, tuple(items.values()))
-                id = cursor.lastrowid  # This returns 0 unless an autoincrement field is in the table
-        return id
+                return cursor.lastrowid  # This returns 0 unless an autoincrement field is in the table
 
     async def update_record(self, where_items, set_items):
         async with self._db.pool.acquire() as conn:
@@ -93,8 +92,7 @@ class Table:  # pylint: disable=R0903
                 select_fields = ",".join(select_fields) if select_fields is not None else "*"
                 sql = f"SELECT {select_fields} FROM `{self.name}` WHERE {where_template}"
                 await cursor.execute(sql, tuple(where_values))
-                result = await cursor.fetchall()
-        return result
+                return await cursor.fetchall()
 
     async def get_all_records(self):
         async with self._db.pool.acquire() as conn:
@@ -109,7 +107,7 @@ class Table:  # pylint: disable=R0903
                 sql = f"SELECT COUNT(1) FROM `{self.name}` WHERE {where_template}"
                 await cursor.execute(sql, where_values)
                 result = await cursor.fetchone()
-        return result['COUNT(1)'] >= 1
+                return result['COUNT(1)'] >= 1
 
     async def delete_record(self, where_items):
         async with self._db.pool.acquire() as conn:

--- a/batch/batch/server/database.py
+++ b/batch/batch/server/database.py
@@ -119,9 +119,12 @@ class JobsTable(Table):
     async def get_records_where(self, condition):
         async with self._db.pool.acquire() as conn:
             async with conn.cursor() as cursor:
+                batch_name = self._db.batch.name
                 where_template, where_values = make_where_statement(condition)
                 fields = ', '.join(self._select_fields())
-                sql = f"SELECT {fields} FROM `{self.name}` WHERE {where_template}"
+                sql = f"""SELECT {fields} FROM `{self.name}`
+                          INNER JOIN `{batch_name}` ON `{self.name}`.batch_id = `{batch_name}`.id 
+                          WHERE {where_template}"""
                 await cursor.execute(sql, tuple(where_values))
                 return await cursor.fetchall()
 

--- a/batch/batch/server/database.py
+++ b/batch/batch/server/database.py
@@ -42,7 +42,7 @@ class JobsTable(Table):
         super().__init__(db, 'jobs')
 
     async def update_record(self, batch_id, job_id, **items):
-        assert 'cancelled' not in items
+        assert not set(items).intersection(JobsTable.batch_view_fields)
         await super().update_record({'batch_id': batch_id, 'job_id': job_id}, items)
 
     async def get_all_records(self):

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -378,8 +378,7 @@ class Job:
             tasks=json.dumps([jt.to_dict() for jt in tasks]),
             task_idx=task_idx,
             always_run=always_run,
-            duration=duration,
-            cancelled=cancelled)
+            duration=duration)
 
         job = Job(batch_id=batch_id, job_id=job_id, attributes=attributes, callback=callback,
                   userdata=userdata, user=user, always_run=always_run, pvc_name=pvc_name,

--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -379,8 +379,6 @@ class Job:
             task_idx=task_idx,
             always_run=always_run,
             duration=duration,
-            userdata=json.dumps(userdata),
-            user=user,
             cancelled=cancelled)
 
         job = Job(batch_id=batch_id, job_id=job_id, attributes=attributes, callback=callback,

--- a/batch/create-batch-tables.sql
+++ b/batch/create-batch-tables.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS `batch` (
   `attributes` TEXT(65535),
   `callback` TEXT(65535),
   `deleted` BOOLEAN NOT NULL default false,
+  `cancelled` BOOLEAN NOT NULL default false,
   `n_jobs` INT NOT NULL default 0,
   `n_completed` INT NOT NULL default 0,
   `n_succeeded` INT NOT NULL default 0,

--- a/batch/create-batch-tables.sql
+++ b/batch/create-batch-tables.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS `batch` (
   `id` BIGINT NOT NULL AUTO_INCREMENT,
   `userdata` TEXT(65535) NOT NULL,
-  `user` VARCHAR(100) NOT NULL,
+  `user` VARCHAR(100) NOT NULL,  
   `attributes` TEXT(65535),
   `callback` TEXT(65535),
   `deleted` BOOLEAN NOT NULL default false,
@@ -31,8 +31,6 @@ CREATE TABLE IF NOT EXISTS `jobs` (
   `always_run` BOOLEAN NOT NULL,
   `time_created` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   `duration` BIGINT,
-  `userdata` TEXT(65535) NOT NULL,
-  `user` VARCHAR(100) NOT NULL,
   `attributes` TEXT(65535),
   `tasks` TEXT(65535) NOT NULL,
   `input_log_uri` VARCHAR(1024),
@@ -41,7 +39,6 @@ CREATE TABLE IF NOT EXISTS `jobs` (
   PRIMARY KEY (`batch_id`, `job_id`),
   FOREIGN KEY (`batch_id`) REFERENCES batch(id) ON DELETE CASCADE
 ) ENGINE = InnoDB;
-CREATE INDEX jobs_user ON jobs (user);
 
 CREATE TABLE IF NOT EXISTS `jobs-parents` (
   `batch_id` BIGINT NOT NULL,

--- a/batch/create-batch-tables.sql
+++ b/batch/create-batch-tables.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS `batch` (
   `id` BIGINT NOT NULL AUTO_INCREMENT,
   `userdata` TEXT(65535) NOT NULL,
-  `user` VARCHAR(100) NOT NULL,  
+  `user` VARCHAR(100) NOT NULL,
   `attributes` TEXT(65535),
   `callback` TEXT(65535),
   `deleted` BOOLEAN NOT NULL default false,


### PR DESCRIPTION
I implemented `cancelled` as a join from the batch table rather than storing redundant information for each job.

@akotlar The issue was that all jobs were getting set to cancelled at the same time (and thus notifying children), so always run jobs were all getting run at once neglecting the hierarchy of job dependencies. This is the purpose of having the `cancelled` flag as separate from the `Cancelled` state and is checked in `create_if_ready`.

@cseed Can you look and see if this solves the cancel problem we discussed earlier? The faulty PR was this one: https://github.com/hail-is/hail/pull/6128/files