### PR TITLE
Changed Grafana Deployment to StatefulSet in monitoring.yaml

### DIFF
--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -17,7 +17,7 @@ push: build
 
 # FIXME use stateful set or prometheus, grafana
 deploy: push
-	kubectl -n monitoring delete deployments prometheus grafana
+	kubectl -n monitoring delete deployments prometheus
 	sleep 5
 	kubectl apply -f monitoring.yaml
 	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"monitoring_router_image":{"image":"$(MONITORING_ROUTER_IMAGE)"}}' router.yaml router.yaml.out

--- a/monitoring/monitoring.yaml
+++ b/monitoring/monitoring.yaml
@@ -359,20 +359,8 @@ spec:
   selector:
     app: prometheus
 ---
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: grafana-storage
-  namespace: monitoring
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 10Gi
----
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: grafana
   namespace: monitoring
@@ -382,6 +370,7 @@ spec:
   selector:
     matchLabels:
       app: grafana
+  serviceName: "grafana"
   replicas: 1
   template:
     metadata:
@@ -409,10 +398,16 @@ spec:
              cpu: "1"
          ports:
           - containerPort: 3000
-      volumes:
-       - name: grafana-storage
-         persistentVolumeClaim:
-           claimName: grafana-storage
+  volumeClaimTemplates:
+  - metadata:
+      name: grafana-storage
+      namespace: monitoring
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This is the most recently deployed version of monitoring.yaml. I'm not sure the best way to test it solves the problem that deployments faced.

One thing to note is that StatefulSets don't guarantee that all of their constituent pods get deleted when the StatefulSet is deleted. To be sure the pods all get deleted, we'd have to either manually delete them or scale the StatefulSet size down to 0 before deleting it. 