### PR TITLE
Speed up ndarray tests

### DIFF
--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2758,11 +2758,9 @@ class Tests(unittest.TestCase):
         exprs, expecteds = zip(*exprs_and_expecteds)
 
         from hail.ir import NDArrayWrite, Begin
-        from hail.utils.java import Env
-
         tmp_files = [tempfile.NamedTemporaryFile(suffix='.npy').name for _ in exprs]
         write_irs = [NDArrayWrite(expr._ir, hl.str(f_name)._ir) for (expr, f_name) in zip(exprs, tmp_files)]
-        Env.backend().execute(Begin(write_irs))
+        hl.utils.java.Env.backend().execute(Begin(write_irs))
 
         for (tmp_file, expected) in zip(tmp_files, expecteds):
             self.assertTrue(asserter(np.load(tmp_file), expected))

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2427,6 +2427,10 @@ class Tests(unittest.TestCase):
     def assert_evals_to(self, e, v):
         self.assertEqual(hl.eval(e), v)
 
+    def batch_assert_evals_to(self, *expr_and_expected):
+        exprs, expecteds = zip(*expr_and_expected)
+        self.assert_evals_to(hl.eval(hl.tuple(exprs)), expecteds)
+
     def test_set_functions(self):
         s = hl.set([1, 3, 7])
         t = hl.set([3, 8])
@@ -2739,21 +2743,35 @@ class Tests(unittest.TestCase):
                  [6, 7]]]
         h_cube = hl._ndarray(cube)
         h_np_cube = hl._ndarray(np.array(cube))
-        self.assert_evals_to(h_cube[0, 0, 1], 1)
-        self.assert_evals_to(h_cube[1, 1, 0], 6)
-        self.assert_evals_to(h_np_cube[0, 0, 1], 1)
-        self.assert_evals_to(h_np_cube[1, 1, 0], 6)
-        self.assert_evals_to(hl._ndarray([[[[1]]]])[0, 0, 0, 0], 1)
-        self.assert_evals_to(hl._ndarray([[[1, 2]], [[3, 4]]])[1, 0, 0], 3)
-        self.assert_evals_to(h_np_cube[0, :, :][:, 0][1], 2)
+        self.batch_assert_evals_to(
+            (h_cube[0, 0, 1], 1),
+            (h_cube[1, 1, 0], 6),
+            (h_np_cube[0, 0, 1], 1),
+            (h_np_cube[1, 1, 0], 6),
+            (hl._ndarray([[[[1]]]])[0, 0, 0, 0], 1),
+            (hl._ndarray([[[1, 2]], [[3, 4]]])[1, 0, 0], 3),
+            (h_np_cube[0, :, :][:, 0][1], 2))
 
         self.assertRaises(ValueError, hl._ndarray, [[4], [1, 2, 3], 5])
 
-    def ndarray_eq(self, expr, expected):
-        self.assertTrue(np.array_equal(expr.to_numpy(), expected))
+    def verify_ndarray_eq(self, asserter, exprs_and_expecteds):
+        exprs, expecteds = zip(*exprs_and_expecteds)
 
-    def ndarray_almost_eq(self, expr, expected):
-        self.assertTrue(np.allclose(expr.to_numpy(), expected))
+        from hail.ir import NDArrayWrite, Begin
+        from hail.utils.java import Env
+
+        tmp_files = [tempfile.NamedTemporaryFile(suffix='.npy').name for _ in exprs]
+        write_irs = [NDArrayWrite(expr._ir, hl.str(f_name)._ir) for (expr, f_name) in zip(exprs, tmp_files)]
+        Env.backend().execute(Begin(write_irs))
+
+        for (tmp_file, expected) in zip(tmp_files, expecteds):
+            self.assertTrue(asserter(np.load(tmp_file), expected))
+
+    def ndarrays_eq(self, *expr_and_expected):
+        self.verify_ndarray_eq(np.array_equal, expr_and_expected)
+
+    def ndarrays_almost_eq(self, *expr_and_expected):
+        self.verify_ndarray_eq(np.allclose, expr_and_expected)
 
     @skip_unless_spark_backend()
     @run_with_cxx_compile()
@@ -2769,14 +2787,15 @@ class Tests(unittest.TestCase):
                            [5, 6, 7, 8]])
         mat = hl._ndarray(np_mat)
 
-        self.ndarray_eq(arr[:, :, :], np_arr[:, :, :])
-        self.ndarray_eq(arr[:, :, 1], np_arr[:, :, 1])
-        self.ndarray_eq(arr[:, :, 1:4:2], np_arr[:, :, 1:4:2])
-        self.ndarray_eq(arr[:, 2, 1:4:2], np_arr[:, 2, 1:4:2])
-        self.ndarray_eq(arr[0, 2, 1:4:2], np_arr[0, 2, 1:4:2])
-        self.ndarray_eq(arr[0, :, 1:4:2] + arr[:, :1, 1:4:2], np_arr[0, :, 1:4:2] + np_arr[:, :1, 1:4:2])
-        self.ndarray_eq(arr[0:, :, 1:4:2] + arr[:, :1, 1:4:2], np_arr[0:, :, 1:4:2] + np_arr[:, :1, 1:4:2])
-        self.ndarray_eq(mat[0, 1:4:2] + mat[:, 1:4:2], np_mat[0, 1:4:2] + np_mat[:, 1:4:2])
+        self.ndarrays_eq(
+            (arr[:, :, :], np_arr[:, :, :]),
+            (arr[:, :, 1], np_arr[:, :, 1]),
+            (arr[:, :, 1:4:2], np_arr[:, :, 1:4:2]),
+            (arr[:, 2, 1:4:2], np_arr[:, 2, 1:4:2]),
+            (arr[0, 2, 1:4:2], np_arr[0, 2, 1:4:2]),
+            (arr[0, :, 1:4:2] + arr[:, :1, 1:4:2], np_arr[0, :, 1:4:2] + np_arr[:, :1, 1:4:2]),
+            (arr[0:, :, 1:4:2] + arr[:, :1, 1:4:2], np_arr[0:, :, 1:4:2] + np_arr[:, :1, 1:4:2]),
+            (mat[0, 1:4:2] + mat[:, 1:4:2], np_mat[0, 1:4:2] + np_mat[:, 1:4:2]))
 
     @skip_unless_spark_backend()
     @run_with_cxx_compile()
@@ -2792,12 +2811,14 @@ class Tests(unittest.TestCase):
         col = hl._ndarray(np_col)
         m = hl._ndarray(np_m)
         nd = hl._ndarray(np_nd)
-        self.assert_evals_to(e.shape, np_e.shape)
-        self.assert_evals_to(row.shape, np_row.shape)
-        self.assert_evals_to(m.shape, np_m.shape)
-        self.assert_evals_to(nd.shape, np_nd.shape)
-        self.assert_evals_to((row + nd).shape, (np_row + np_nd).shape)
-        self.assert_evals_to((row + col).shape, (np_row + np_col).shape)
+
+        self.batch_assert_evals_to(
+            (e.shape, np_e.shape),
+            (row.shape, np_row.shape),
+            (m.shape, np_m.shape),
+            (nd.shape, np_nd.shape),
+            ((row + nd).shape, (np_row + np_nd).shape),
+            ((row + col).shape, (np_row + np_col).shape))
 
     @skip_unless_spark_backend()
     @run_with_cxx_compile()
@@ -2824,9 +2845,10 @@ class Tests(unittest.TestCase):
         b = hl.map(lambda x: -x, a)
         c = hl.map(lambda x: True, a)
 
-        self.ndarray_eq(b, [[-2, -3, -4], [-5, -6, -7]])
-        self.ndarray_eq(c, [[True, True, True],
-                            [True, True, True]])
+        self.ndarrays_eq(
+            (b, [[-2, -3, -4], [-5, -6, -7]]),
+            (c, [[True, True, True],
+                 [True, True, True]]))
 
     @skip_unless_spark_backend()
     @run_with_cxx_compile()
@@ -2853,77 +2875,79 @@ class Tests(unittest.TestCase):
         ncube1 = hl._ndarray(cube1)
         ncube2 = hl._ndarray(cube2)
 
-        # with lists/numerics
-        self.ndarray_eq(na + b, np.array(a + b))
-        self.ndarray_eq(b + na, np.array(a + b))
-        self.ndarray_eq(nx + y, x + y)
-        self.ndarray_eq(ncube1 + cube2, cube1 + cube2)
+        self.ndarrays_eq(
+            # with lists/numerics
+            (na + b, np.array(a + b)),
+            (b + na, np.array(a + b)),
+            (nx + y, x + y),
+            (ncube1 + cube2, cube1 + cube2),
 
-        # Addition
-        self.ndarray_eq(na + na, np.array(a + a))
-        self.ndarray_eq(nx + ny, x + y)
-        self.ndarray_eq(ncube1 + ncube2, cube1 + cube2)
-        # Broadcasting
-        self.ndarray_eq(ncube1 + na, cube1 + a)
-        self.ndarray_eq(na + ncube1, a + cube1)
-        self.ndarray_eq(ncube1 + ny, cube1 + y)
-        self.ndarray_eq(ny + ncube1, y + cube1)
-        self.ndarray_eq(nrow_vec + ncube1, row_vec + cube1)
-        self.ndarray_eq(ncube1 + nrow_vec, cube1 + row_vec)
+            # Addition
+            (na + na, np.array(a + a)),
+            (nx + ny, x + y),
+            (ncube1 + ncube2, cube1 + cube2),
+            # Broadcasting
+            (ncube1 + na, cube1 + a),
+            (na + ncube1, a + cube1),
+            (ncube1 + ny, cube1 + y),
+            (ny + ncube1, y + cube1),
+            (nrow_vec + ncube1, row_vec + cube1),
+            (ncube1 + nrow_vec, cube1 + row_vec),
 
-        # Subtraction
-        self.ndarray_eq(na - na, np.array(a - a))
-        self.ndarray_eq(nx - nx, x - x)
-        self.ndarray_eq(ncube1 - ncube2, cube1 - cube2)
-        # Broadcasting
-        self.ndarray_eq(ncube1 - na, cube1 - a)
-        self.ndarray_eq(na - ncube1, a - cube1)
-        self.ndarray_eq(ncube1 - ny, cube1 - y)
-        self.ndarray_eq(ny - ncube1, y - cube1)
-        self.ndarray_eq(ncube1 - nrow_vec, cube1 - row_vec)
-        self.ndarray_eq(nrow_vec - ncube1, row_vec - cube1)
+            # Subtraction
+            (na - na, np.array(a - a)),
+            (nx - nx, x - x),
+            (ncube1 - ncube2, cube1 - cube2),
+            # Broadcasting
+            (ncube1 - na, cube1 - a),
+            (na - ncube1, a - cube1),
+            (ncube1 - ny, cube1 - y),
+            (ny - ncube1, y - cube1),
+            (ncube1 - nrow_vec, cube1 - row_vec),
+            (nrow_vec - ncube1, row_vec - cube1),
 
-        # Multiplication
-        self.ndarray_eq(na * na, np.array(a * a))
-        self.ndarray_eq(nx * nx, x * x)
-        self.ndarray_eq(nx * na, x * a)
-        self.ndarray_eq(na * nx, a * x)
-        self.ndarray_eq(ncube1 * ncube2, cube1 * cube2)
-        # Broadcasting
-        self.ndarray_eq(ncube1 * na, cube1 * a)
-        self.ndarray_eq(na * ncube1, a * cube1)
-        self.ndarray_eq(ncube1 * ny, cube1 * y)
-        self.ndarray_eq(ny * ncube1, y * cube1)
-        self.ndarray_eq(ncube1 * nrow_vec, cube1 * row_vec)
-        self.ndarray_eq(nrow_vec * ncube1, row_vec * cube1)
+            # Multiplication
+            (na * na, np.array(a * a)),
+            (nx * nx, x * x),
+            (nx * na, x * a),
+            (na * nx, a * x),
+            (ncube1 * ncube2, cube1 * cube2),
+            # Broadcasting
+            (ncube1 * na, cube1 * a),
+            (na * ncube1, a * cube1),
+            (ncube1 * ny, cube1 * y),
+            (ny * ncube1, y * cube1),
+            (ncube1 * nrow_vec, cube1 * row_vec),
+            (nrow_vec * ncube1, row_vec * cube1),
+
+            # Floor div
+            (na // na, np.array(a // a)),
+            (nx // nx, x // x),
+            (nx // na, x // a),
+            (na // nx, a // x),
+            (ncube1 // ncube2, cube1 // cube2),
+            # Broadcasting
+            (ncube1 // na, cube1 // a),
+            (na // ncube1, a // cube1),
+            (ncube1 // ny, cube1 // y),
+            (ny // ncube1, y // cube1),
+            (ncube1 // nrow_vec, cube1 // row_vec),
+            (nrow_vec // ncube1, row_vec // cube1))
 
         # Division
-        self.ndarray_almost_eq(na / na, np.array(a / a))
-        self.ndarray_almost_eq(nx / nx, x / x)
-        self.ndarray_almost_eq(nx / na, x / a)
-        self.ndarray_almost_eq(na / nx, a / x)
-        self.ndarray_almost_eq(ncube1 / ncube2, cube1 / cube2)
-        # Broadcasting
-        self.ndarray_almost_eq(ncube1 / na, cube1 / a)
-        self.ndarray_almost_eq(na / ncube1, a / cube1)
-        self.ndarray_almost_eq(ncube1 / ny, cube1 / y)
-        self.ndarray_almost_eq(ny / ncube1, y / cube1)
-        self.ndarray_almost_eq(ncube1 / nrow_vec, cube1 / row_vec)
-        self.ndarray_almost_eq(nrow_vec / ncube1, row_vec / cube1)
-
-        # Floor div
-        self.ndarray_eq(na // na, np.array(a // a))
-        self.ndarray_eq(nx // nx, x // x)
-        self.ndarray_eq(nx // na, x // a)
-        self.ndarray_eq(na // nx, a // x)
-        self.ndarray_eq(ncube1 // ncube2, cube1 // cube2)
-        # Broadcasting
-        self.ndarray_eq(ncube1 // na, cube1 // a)
-        self.ndarray_eq(na // ncube1, a // cube1)
-        self.ndarray_eq(ncube1 // ny, cube1 // y)
-        self.ndarray_eq(ny // ncube1, y // cube1)
-        self.ndarray_eq(ncube1 // nrow_vec, cube1 // row_vec)
-        self.ndarray_eq(nrow_vec // ncube1, row_vec // cube1)
+        self.ndarrays_almost_eq(
+            (na / na, np.array(a / a)),
+            (nx / nx, x / x),
+            (nx / na, x / a),
+            (na / nx, a / x),
+            (ncube1 / ncube2, cube1 / cube2),
+            # Broadcastisng
+            (ncube1 / na, cube1 / a),
+            (na / ncube1, a / cube1),
+            (ncube1 / ny, cube1 / y),
+            (ny / ncube1, y / cube1),
+            (ncube1 / nrow_vec, cube1 / row_vec),
+            (nrow_vec / ncube1, row_vec / cube1))
 
     @skip_unless_spark_backend()
     @run_with_cxx_compile()
@@ -2954,9 +2978,10 @@ class Tests(unittest.TestCase):
         np_m = np.array([[1, 2], [3, 4]])
         m = hl._ndarray(np_m)
 
-        self.ndarray_eq(m.sum(axis=0), np_m.sum(axis=0))
-        self.ndarray_eq(m.sum(axis=1), np_m.sum(axis=1))
-        self.ndarray_eq(m.sum(), np_m.sum())
+        self.ndarrays_eq(
+            (m.sum(axis=0), np_m.sum(axis=0)),
+            (m.sum(axis=1), np_m.sum(axis=1)),
+            (m.sum(), np_m.sum()))
 
     @skip_unless_spark_backend()
     @run_with_cxx_compile()
@@ -2971,11 +2996,12 @@ class Tests(unittest.TestCase):
         m = hl._ndarray(np_m)
         cube = hl._ndarray(np_cube)
 
-        self.ndarray_eq(v.T, np_v.T)
-        self.ndarray_eq(v.T, np_v)
-        self.ndarray_eq(m.T, np_m.T)
-        self.ndarray_eq(cube.transpose((0, 2, 1)), np_cube.transpose((0, 2, 1)))
-        self.ndarray_eq(cube.T, np_cube.T)
+        self.ndarrays_eq(
+            (v.T, np_v.T),
+            (v.T, np_v),
+            (m.T, np_m.T),
+            (cube.transpose((0, 2, 1)), np_cube.transpose((0, 2, 1))),
+            (cube.T, np_cube.T))
 
         self.assertRaises(ValueError, lambda: v.transpose((1,)))
         self.assertRaises(ValueError, lambda: cube.transpose((1, 1)))
@@ -2999,25 +3025,25 @@ class Tests(unittest.TestCase):
         m = hl._ndarray(np_m)
         cube = hl._ndarray(np_cube)
         rect_prism = hl._ndarray(np_rect_prism)
-
-        self.assertEqual(hl.eval(v @ v), np_v @ np_v)
-        self.ndarray_eq(m @ m, np_m @ np_m)
-        self.ndarray_eq(m @ m.T, np_m @ np_m.T)
-        self.ndarray_eq(v @ m, np_v @ np_m)
-        self.ndarray_eq(m @ v, np_m @ np_v)
-        self.ndarray_eq(cube @ cube, np_cube @ np_cube)
-        self.ndarray_eq(cube @ v, np_cube @ np_v)
-        self.ndarray_eq(v @ cube, np_v @ np_cube)
-        self.ndarray_eq(cube @ m, np_cube @ np_m)
-        self.ndarray_eq(m @ cube, np_m @ np_cube)
-        self.ndarray_eq(rect_prism @ m, np_rect_prism @ np_m)
-        self.ndarray_eq(m @ rect_prism, np_m @ np_rect_prism)
-        self.ndarray_eq(m @ rect_prism.T, np_m @ np_rect_prism.T)
-
         np_broadcasted_mat = np.array([[[1, 2],
                                         [3, 4]]])
-        self.ndarray_eq(hl._ndarray(np_broadcasted_mat) @ rect_prism,
-                        np_broadcasted_mat @ np_rect_prism)
+
+        self.assertEqual(hl.eval(v @ v), np_v @ np_v)
+
+        self.ndarrays_eq(
+            (m @ m, np_m @ np_m),
+            (m @ m.T, np_m @ np_m.T),
+            (v @ m, np_v @ np_m),
+            (m @ v, np_m @ np_v),
+            (cube @ cube, np_cube @ np_cube),
+            (cube @ v, np_cube @ np_v),
+            (v @ cube, np_v @ np_cube),
+            (cube @ m, np_cube @ np_m),
+            (m @ cube, np_m @ np_cube),
+            (rect_prism @ m, np_rect_prism @ np_m),
+            (m @ rect_prism, np_m @ np_rect_prism),
+            (m @ rect_prism.T, np_m @ np_rect_prism.T),
+            (hl._ndarray(np_broadcasted_mat) @ rect_prism, np_broadcasted_mat @ np_rect_prism))
 
         self.assertRaises(ValueError, lambda: m @ 5)
         self.assertRaises(ValueError, lambda: m @ hl._ndarray(5))

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -2754,22 +2754,22 @@ class Tests(unittest.TestCase):
 
         self.assertRaises(ValueError, hl._ndarray, [[4], [1, 2, 3], 5])
 
-    def verify_ndarray_eq(self, asserter, exprs_and_expecteds):
+    def assert_ndarrays(self, asserter, exprs_and_expecteds):
         exprs, expecteds = zip(*exprs_and_expecteds)
 
         from hail.ir import NDArrayWrite, Begin
         tmp_files = [tempfile.NamedTemporaryFile(suffix='.npy').name for _ in exprs]
-        write_irs = [NDArrayWrite(expr._ir, hl.str(f_name)._ir) for (expr, f_name) in zip(exprs, tmp_files)]
+        write_irs = [NDArrayWrite(expr._ir, hl.str(tmp_file)._ir) for (expr, tmp_file) in zip(exprs, tmp_files)]
         hl.utils.java.Env.backend().execute(Begin(write_irs))
 
         for (tmp_file, expected) in zip(tmp_files, expecteds):
             self.assertTrue(asserter(np.load(tmp_file), expected))
 
     def ndarrays_eq(self, *expr_and_expected):
-        self.verify_ndarray_eq(np.array_equal, expr_and_expected)
+        self.assert_ndarrays(np.array_equal, expr_and_expected)
 
     def ndarrays_almost_eq(self, *expr_and_expected):
-        self.verify_ndarray_eq(np.allclose, expr_and_expected)
+        self.assert_ndarrays(np.allclose, expr_and_expected)
 
     @skip_unless_spark_backend()
     @run_with_cxx_compile()


### PR DESCRIPTION
Batch eval for tests by putting expressions in a tuple and using `Begin` for write statements. This helps dramatically by avoiding the c++ compilation time on every assert.