### PR TITLE
[hailjwt,batch,ci] Use headers instead of cookies in api calls

### DIFF
--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -17,7 +17,8 @@ import kubernetes as kube
 import requests
 import uvloop
 
-from hailjwt import authenticated_users_only, new_csrf_token, check_csrf_token
+from hailjwt import rest_authenticated_users_only, web_authenticated_users_only
+from hailjwt import new_csrf_token, check_csrf_token
 
 from .blocking_to_async import blocking_to_async
 from .log_store import LogStore
@@ -640,7 +641,7 @@ async def get_healthcheck(request):  # pylint: disable=W0613
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}')
-@authenticated_users_only
+@rest_authenticated_users_only
 async def get_job(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     job_id = int(request.match_info['job_id'])
@@ -664,7 +665,7 @@ async def _get_job_log(batch_id, job_id, user):
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/log')
-@authenticated_users_only
+@rest_authenticated_users_only
 async def get_job_log(request, userdata):  # pylint: disable=R1710
     batch_id = int(request.match_info['batch_id'])
     job_id = int(request.match_info['job_id'])
@@ -831,7 +832,7 @@ async def _get_batches_list(params, user):
 
 
 @routes.get('/api/v1alpha/batches')
-@authenticated_users_only
+@rest_authenticated_users_only
 async def get_batches_list(request, userdata):
     params = request.query
     user = userdata['username']
@@ -839,7 +840,7 @@ async def get_batches_list(request, userdata):
 
 
 @routes.post('/api/v1alpha/batches/create')
-@authenticated_users_only
+@rest_authenticated_users_only
 async def create_batch(request, userdata):
     parameters = await request.json()
 
@@ -898,7 +899,7 @@ async def _cancel_batch(batch_id, user):
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}')
-@authenticated_users_only
+@rest_authenticated_users_only
 async def get_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
@@ -906,7 +907,7 @@ async def get_batch(request, userdata):
 
 
 @routes.patch('/api/v1alpha/batches/{batch_id}/cancel')
-@authenticated_users_only
+@rest_authenticated_users_only
 async def cancel_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
@@ -915,7 +916,7 @@ async def cancel_batch(request, userdata):
 
 
 @routes.delete('/api/v1alpha/batches/{batch_id}')
-@authenticated_users_only
+@rest_authenticated_users_only
 async def delete_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
@@ -929,7 +930,7 @@ async def delete_batch(request, userdata):
 
 @routes.get('/batches/{batch_id}')
 @aiohttp_jinja2.template('batch.html')
-@authenticated_users_only
+@web_authenticated_users_only
 async def ui_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
@@ -940,7 +941,7 @@ async def ui_batch(request, userdata):
 @routes.post('/batches/{batch_id}/cancel')
 @aiohttp_jinja2.template('batches.html')
 @check_csrf_token
-@authenticated_users_only
+@web_authenticated_users_only
 async def ui_cancel_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
@@ -950,7 +951,7 @@ async def ui_cancel_batch(request, userdata):
 
 
 @routes.get('/batches', name='batches')
-@authenticated_users_only
+@web_authenticated_users_only
 async def ui_batches(request, userdata):
     params = request.query
     user = userdata['username']
@@ -967,7 +968,7 @@ async def ui_batches(request, userdata):
 
 @routes.get('/batches/{batch_id}/jobs/{job_id}/log')
 @aiohttp_jinja2.template('job_log.html')
-@authenticated_users_only
+@web_authenticated_users_only
 async def ui_get_job_log(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     job_id = int(request.match_info['job_id'])
@@ -977,7 +978,7 @@ async def ui_get_job_log(request, userdata):
 
 
 @routes.get('/')
-@authenticated_users_only
+@web_authenticated_users_only
 async def batch_id(request, userdata):
     location = request.app.router['batches'].url_for()
     raise web.HTTPFound(location=location)

--- a/batch_client/batch_client/aioclient.py
+++ b/batch_client/batch_client/aioclient.py
@@ -376,7 +376,11 @@ class BatchClient:
         userdata = hj.JWTClient.unsafe_decode(token)
         assert "bucket_name" in userdata
         self.bucket = userdata["bucket_name"]
-        self._cookies = {'user': token}
+        self._cookies = None
+
+        if headers is None:
+            headers = {}
+        headers['Authorization'] = f'Bearer {token}'
         self._headers = headers
 
     async def _get(self, path, params=None):

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -14,7 +14,7 @@ import aiohttp_jinja2
 from gidgethub import aiohttp as gh_aiohttp, routing as gh_routing, sansio as gh_sansio
 
 from batch_client.aioclient import BatchClient, Job
-from hailjwt import authenticated_developers_only
+from hailjwt import web_authenticated_developers_only
 from hailjwt import new_csrf_token, check_csrf_token
 
 from .log import log
@@ -39,7 +39,7 @@ start_time = datetime.datetime.now()
 
 
 @routes.get('/')
-@authenticated_developers_only
+@web_authenticated_developers_only
 async def index(request):  # pylint: disable=unused-argument
     app = request.app
     dbpool = app['dbpool']
@@ -97,7 +97,7 @@ async def index(request):  # pylint: disable=unused-argument
 
 
 @routes.get('/watched_branches/{watched_branch_index}/pr/{pr_number}')
-@authenticated_developers_only
+@web_authenticated_developers_only
 @aiohttp_jinja2.template('pr.html')
 async def get_pr(request):
     watched_branch_index = int(request.match_info['watched_branch_index'])
@@ -142,7 +142,7 @@ async def get_pr(request):
 
 
 @routes.get('/batches')
-@authenticated_developers_only
+@web_authenticated_developers_only
 @aiohttp_jinja2.template('batches.html')
 async def get_batches(request):
     batch_client = request.app['batch_client']
@@ -154,7 +154,7 @@ async def get_batches(request):
 
 
 @routes.get('/batches/{batch_id}')
-@authenticated_developers_only
+@web_authenticated_developers_only
 @aiohttp_jinja2.template('batch.html')
 async def get_batch(request):
     batch_id = int(request.match_info['batch_id'])
@@ -171,7 +171,7 @@ async def get_batch(request):
 
 
 @routes.get('/batches/{batch_id}/jobs/{job_id}/log')
-@authenticated_developers_only
+@web_authenticated_developers_only
 @aiohttp_jinja2.template('job_log.html')
 async def get_job_log(request):
     batch_id = int(request.match_info['batch_id'])
@@ -187,7 +187,7 @@ async def get_job_log(request):
 
 @routes.post('/authorize_source_sha')
 @check_csrf_token
-@authenticated_developers_only
+@web_authenticated_developers_only
 async def post_authorized_source_sha(request):
     app = request.app
     dbpool = app['dbpool']

--- a/hailjwt/hailjwt/__init__.py
+++ b/hailjwt/hailjwt/__init__.py
@@ -1,11 +1,16 @@
-from .hailjwt import JWTClient, get_domain, authenticated_users_only, authenticated_developers_only
+from .hailjwt import JWTClient, get_domain
+from .hailjwt import rest_authenticated_users_only, rest_authenticated_developers_only
+from .hailjwt import web_authenticated_users_only, web_authenticated_developers_only
 from .csrf import new_csrf_token, check_csrf_token
+
 
 __all__ = [
     'JWTClient',
     'get_domain',
-    'authenticated_users_only',
-    'authenticated_developers_only',
+    'rest_authenticated_users_only',
+    'rest_authenticated_developers_only',
+    'web_authenticated_users_only',
+    'web_authenticated_developers_only',
     'new_csrf_token',
     'check_csrf_token'
 ]


### PR DESCRIPTION
@cseed Can you take a look at the last commit and see if this is what you envisioned by securing the api calls with headers instead of cookies?

Stacked on #6288 