### PR TITLE
[batch] fix assertion error in mark_job_task_complete

### DIFF
--- a/batch/batch/server/server.py
+++ b/batch/batch/server/server.py
@@ -281,7 +281,6 @@ class Job:
         return None
 
     async def _mark_job_task_complete(self, task_name, log, exit_code, new_state):
-        assert self._pod_name is not None
         self.exit_codes[self._task_idx] = exit_code
 
         self._task_idx += 1
@@ -299,6 +298,10 @@ class Job:
                                          pod_name=None,
                                          duration=self.duration,
                                          state=new_state)
+
+        if self._pod_name is None:
+            return
+
         err = await app['k8s'].delete_pod(self._pod_name)
         if err is not None:
             traceback.print_tb(err.__traceback__)


### PR DESCRIPTION
Addresses this error:
```
ERROR   | 2019-06-17 09:41:59,615       | web_protocol.py       | log_exception:355 | Error handling request
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_protocol.py", line 418, in start
    resp = await task
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_app.py", line 458, in _handle
    resp = await handler(request)
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_urldispatcher.py", line 157, in handler_wrapper
    result = await result
  File "/usr/local/lib/python3.6/dist-packages/batch/server/server.py", line 849, in create_batch
    await create_job(batch.id, userdata, job_params)
  File "/usr/local/lib/python3.6/dist-packages/batch/server/server.py", line 628, in create_job
    pvc_size=pvc_size)
  File "/usr/local/lib/python3.6/dist-packages/batch/server/server.py", line 398, in create_job
    await job._create_pod()
  File "/usr/local/lib/python3.6/dist-packages/batch/server/server.py", line 190, in _create_pod
    self._pvc_name = await self._create_pvc()
  File "/usr/local/lib/python3.6/dist-packages/batch/server/server.py", line 165, in _create_pvc
    await self.mark_complete(None, failed=True, failure_reason=str(err))
  File "/usr/local/lib/python3.6/dist-packages/batch/server/server.py", line 526, in mark_complete
    await self._mark_job_task_complete(task_name, pod_log, exit_code)
  File "/usr/local/lib/python3.6/dist-packages/batch/server/server.py", line 288, in _mark_job_task_complete
    assert self._pod_name is not None
AssertionError
```