### PR TITLE
[hail] fix search on docs

### DIFF
--- a/hail/python/dev-requirements.txt
+++ b/hail/python/dev-requirements.txt
@@ -1,7 +1,7 @@
 pytest==4.5
 pytest-html==1.20.0
 pytest-xdist==1.28
-sphinx==2.0
+sphinx==2.0.1
 nbsphinx==0.4
 sphinx_rtd_theme==0.4.2
 jupyter==1.0.0


### PR DESCRIPTION
Search in Sphinx 2.0.0. is known to be broken with third party themes, such as RTD. https://github.com/sphinx-doc/sphinx/issues/6244 . Sphinx 2.0.1 resolves this https://github.com/sphinx-doc/sphinx/pull/6257 .