### PR TITLE
[hail] if an MT is string-column-keyed, use said strings in show

### DIFF
--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2571,10 +2571,18 @@ class MatrixTable(ExprContainer):
 
         t = self.localize_entries('entries', 'cols')
         t = t.key_by()
+        col_key_type = self.col_key.dtype
+        if len(col_key_type) == 1 and col_key_type[0] == hl.tstr:
+            col_key_field_name = list(col_key_type)[0]
+            cols = t.cols.collect()
+            entries = {cols[0][i][col_key_field_name]: t.entries[i]
+                       for i in range(0, displayed_n_cols)}
+        else:
+            entries = {str(i): t.entries[i] for i in range(0, displayed_n_cols)}
         t = t.select(
             **{f: t[f] for f in self.row_key},
             **{f: t[f] for f in self.row_value if include_row_fields},
-            **{str(i): t.entries[i] for i in range(0, displayed_n_cols)})
+            **entries)
         if handler is None:
             try:
                 from IPython.display import display


### PR DESCRIPTION
Previously the below would display `0.GT | 1.GT` (simply the index in the entries array).

```
In [2]: import hail as hl  
   ...: mt = hl.balding_nichols_model(3, 100, 100) 
   ...: mt = mt.key_cols_by(sample_id = 'sample-' + hl.str(mt.sample_idx)) 
   ...: mt.show(n_rows=10, n_cols=10)                                                                                                                                                                               
2019-06-19 16:20:33 Hail: INFO: balding_nichols_model: generating genotypes for 3 populations, 100 samples, and 100 variants...
+---------------+------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+
| locus         | alleles    | sample-0.GT | sample-1.GT | sample-2.GT | sample-3.GT | sample-4.GT | sample-5.GT | sample-6.GT | sample-7.GT | sample-8.GT | sample-9.GT |
+---------------+------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+
| locus<GRCh37> | array<str> | call        | call        | call        | call        | call        | call        | call        | call        | call        | call        |
+---------------+------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+
| 1:1           | ["A","C"]  | 0/0         | 0/0         | 0/1         | 1/1         | 0/1         | 0/0         | 0/1         | 0/1         | 0/1         | 0/1         |
| 1:2           | ["A","C"]  | 1/1         | 0/1         | 0/0         | 0/1         | 1/1         | 1/1         | 0/1         | 1/1         | 0/0         | 1/1         |
| 1:3           | ["A","C"]  | 1/1         | 0/1         | 0/0         | 1/1         | 0/0         | 1/1         | 1/1         | 0/1         | 0/0         | 1/1         |
| 1:4           | ["A","C"]  | 0/0         | 0/1         | 0/0         | 1/1         | 0/1         | 0/0         | 0/1         | 0/0         | 0/0         | 0/1         |
| 1:5           | ["A","C"]  | 0/1         | 0/0         | 0/0         | 0/0         | 0/1         | 0/0         | 0/1         | 0/1         | 0/0         | 1/1         |
| 1:6           | ["A","C"]  | 0/0         | 1/1         | 1/1         | 0/1         | 0/1         | 1/1         | 0/1         | 0/1         | 1/1         | 1/1         |
| 1:7           | ["A","C"]  | 0/0         | 0/1         | 1/1         | 0/1         | 0/1         | 0/1         | 0/0         | 0/1         | 0/0         | 0/1         |
| 1:8           | ["A","C"]  | 0/1         | 0/1         | 1/1         | 1/1         | 0/1         | 0/1         | 1/1         | 1/1         | 0/1         | 0/1         |
| 1:9           | ["A","C"]  | 0/0         | 0/1         | 1/1         | 1/1         | 1/1         | 0/1         | 1/1         | 1/1         | 1/1         | 1/1         |
| 1:10          | ["A","C"]  | 0/1         | 0/1         | 0/1         | 0/0         | 0/1         | 0/0         | 0/1         | 0/1         | 0/0         | 0/1         |
+---------------+------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+
showing top 10 rows
showing the first 10 of 100 columns

In [3]:  
```