### PR TITLE
[bugfix] create a new instance of F every time we want a new function result

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -354,20 +354,20 @@ class FunctionBuilder[F >: Null](val parameterTypeInfo: Array[MaybeGenericTypeIn
 
     new (() => F) with java.io.Serializable {
       @transient
-      @volatile private var f: F = null
+      @volatile private var theClass: Class[_] = null
 
       def apply(): F = {
         try {
-          if (f == null) {
+          if (theClass == null) {
             this.synchronized {
-              if (f == null) {
+              if (theClass == null) {
                 childClasses.foreach { case (fn, b) => loadClass(fn, b) }
-                f = loadClass(n, bytes).newInstance().asInstanceOf[F]
+                theClass = loadClass(n, bytes)
               }
             }
           }
 
-          f
+          theClass.newInstance().asInstanceOf[F]
         } catch {
           //  only triggers on classloader
           case e@(_: Exception | _: LinkageError) => {


### PR DESCRIPTION
@tpoterba this is the FunctionBuilder fix I was talking about. If two threads are both using the resulting function at the same time, having them use the same function object will result in overwriting fields and nonsensical behavior.

The only place this was really broken should be in the Encoder/Decoder---all the IR codegen calls EmitFunctionBuilder.resultWithIndex(), which does the correct thing. I fixed the base FunctionBuilder.result() to do the same thing as EmitFunctionBuilder.resultWithIndex().