### PR TITLE
Add viewport tag to improve home page layout on mobile devices

### DIFF
--- a/hail/www/Makefile
+++ b/hail/www/Makefile
@@ -4,7 +4,7 @@ GENERATED_HTML = 404.html index.html
 
 all: $(GENERATED_HTML)
 
-$(GENERATED_HTML): %.html: %.md %.xslt
+$(GENERATED_HTML): %.html: %.md %.xslt template.xslt
 	pandoc -s $< \
 	  -f markdown \
 	  -t html \

--- a/hail/www/template.xslt
+++ b/hail/www/template.xslt
@@ -15,6 +15,7 @@
         <html lang="en">
             <head>
                 <meta charset="utf-8"/>
+                <meta name="viewport" content="width=device-width, initial-scale=1"/>
                 <title><xsl:call-template name="page-title"/></title>
                 <link rel='shortcut icon' href='hail_logo_sq.ico' type='image/x-icon'/>
                 <xsl:call-template name="meta-description"/>


### PR DESCRIPTION
Currently, on mobile browsers, the home page of [hail.is](https://hail.is/) is shrunk down to the point where it's difficult to read without zooming in. This adds a [viewport tag](https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag) to improve that layout.

## Before:

![before](https://user-images.githubusercontent.com/1156625/59926804-12a60f00-9409-11e9-80c5-52fe4c8ddd66.png)

## After:

![after](https://user-images.githubusercontent.com/1156625/59926813-16d22c80-9409-11e9-958c-8553ef583be8.png)
