### PR TITLE
Prometheus Stateful Set and Storage Bump

### DIFF
--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -15,10 +15,7 @@ push: build
 	docker tag monitoring-router $(MONITORING_ROUTER_IMAGE)
 	docker push $(MONITORING_ROUTER_IMAGE)
 
-# FIXME use stateful set or prometheus, grafana
 deploy: push
-	kubectl -n monitoring delete deployments prometheus
-	sleep 5
 	kubectl apply -f monitoring.yaml
-	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"monitoring_router_image":{"image":"$(MONITORING_ROUTER_IMAGE)"}}' router.yaml router.yaml.out
+	python3 ../builder/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"monitoring_router_image":{"image":"$(MONITORING_ROUTER_IMAGE)"}}' router.yaml router.yaml.out
 	kubectl apply -f router.yaml.out

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -17,5 +17,5 @@ push: build
 
 deploy: push
 	kubectl apply -f monitoring.yaml
-	python3 ../builder/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"monitoring_router_image":{"image":"$(MONITORING_ROUTER_IMAGE)"}}' router.yaml router.yaml.out
+	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"monitoring_router_image":{"image":"$(MONITORING_ROUTER_IMAGE)"}}' router.yaml router.yaml.out
 	kubectl apply -f router.yaml.out

--- a/monitoring/monitoring.yaml
+++ b/monitoring/monitoring.yaml
@@ -286,26 +286,15 @@ data:
           action: replace
           target_label: nodename
 ---
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: prometheus-storage
-  namespace: monitoring
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 10Gi
----
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   labels:
     name: prometheus
   name: prometheus
   namespace: monitoring
 spec:
+  serviceName: "prometheus"
   selector:
     matchLabels:
       app: prometheus
@@ -343,9 +332,16 @@ spec:
        - name: etc-prometheus
          configMap:
            name: etc-prometheus
-       - name: prometheus-storage
-         persistentVolumeClaim:
-           claimName: prometheus-storage
+  volumeClaimTemplates:
+    - metadata:
+        name: prometheus-storage
+        namespace: monitoring
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 50Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Prometheus is now a StatefulSet, removing the need to delete a deployment and sleep in the monitoring Makefile. The storage has also been bumped up to 50Gi to prevent running out of storage in the future. 