### PR TITLE
Use JSON formatting in logs

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -24,6 +24,7 @@ PyGithub==1.43.7
 pylint==2.3.1
 PyMySQL==0.9.3
 pytest==4.6.3
+python-json-logger
 requests==2.22.0
 urllib3==1.24.3
 uvloop==0.12.2

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -24,7 +24,7 @@ PyGithub==1.43.7
 pylint==2.3.1
 PyMySQL==0.9.3
 pytest==4.6.3
-python-json-logger
+python-json-logger==0.1.11
 requests==2.22.0
 urllib3==1.24.3
 uvloop==0.12.2

--- a/hail/python/hailtop/gear/logging.py
+++ b/hail/python/hailtop/gear/logging.py
@@ -1,10 +1,13 @@
 import logging
+from pythonjsonlogger import jsonlogger
+
+class CustomJsonFormatter(jsonlogger.JsonFormatter):
+    def add_fields(self, log_record, record, message_dict):
+        super(CustomJsonFormatter, self).add_fields(log_record, record, message_dict)
+        log_record['funcNameAndLine'] = "{}:{}".format(record.funcName, record.lineno)
 
 def configure_logging():
-    fmt = logging.Formatter(
-        # NB: no space after levename because WARNING is so long
-        '%(levelname)s\t| %(asctime)s \t| %(filename)s \t| %(funcName)s:%(lineno)d | '
-        '%(message)s')
+    fmt = CustomJsonFormatter('(levelname) (asctime) (filename) (funcNameAndLine) (message)')
 
     stream_handler = logging.StreamHandler()
     stream_handler.setLevel(logging.INFO)

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -10,6 +10,6 @@ pandas>0.22,<0.24
 parsimonious<0.9
 PyJWT
 pyspark>=2.4,<2.4.2
-python-json-logger
+python-json-logger==0.1.11
 requests>=2.21.0,<2.21.1
 scipy>1.2,<1.4

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -10,5 +10,6 @@ pandas>0.22,<0.24
 parsimonious<0.9
 PyJWT
 pyspark>=2.4,<2.4.2
+python-json-logger
 requests>=2.21.0,<2.21.1
 scipy>1.2,<1.4


### PR DESCRIPTION
I just pulled in a library specifically for json log formatting that handles escaping nicely + makes it easy to add anything else we might want to do. I've obviously not run batch locally but I've tested this code locally by running 

```from hailtop.gear import configure_logging
import logging
configure_logging()
logging.info('"Foo"')
```

We are definitely going to want more than this eventually, but this should at least let us start to break up our logs in Kibana. And it's hard to test more complicated things without some way to run my own batch. 