### PR TITLE
[image-fetcher] remove notebook/worker-image prefetch

### DIFF
--- a/image-fetcher/fetch-image.sh
+++ b/image-fetcher/fetch-image.sh
@@ -8,7 +8,7 @@ gcloud auth configure-docker
 
 while true
 do
-    for image in gcr.io/$PROJECT/base:latest $(curl -sSL http://notebook/worker-image) $(curl -sSL http://notebook2/worker-image) google/cloud-sdk:237.0.0-alpine
+    for image in gcr.io/$PROJECT/base:latest $(curl -sSL http://notebook2/worker-image) google/cloud-sdk:237.0.0-alpine
     do
     	docker pull $image
     done


### PR DESCRIPTION
To avoid this:

```sh
+ sleep 360
+ true
+ curl -sSL http://notebook/worker-image
curl: (7) Failed to connect to notebook port 80: Connection refused
```

Since notebook is not currently running