### PR TITLE
[hail][performance] Deduplicate inlined IRs in `annotate(**thing)`

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -1499,10 +1499,11 @@ class StructExpression(Mapping[str, Expression], Expression):
 
         new_type = hl.tstruct(**{f: get_type(f) for f in field_order})
         indices, aggregations = unify_all(self, *insertions_dict.values())
-        return construct_expr(InsertFields(self._ir, [(field, expr._ir) for field, expr in insertions_dict.items()], field_order),
-                              new_type,
-                              indices,
-                              aggregations)
+        return construct_expr(InsertFields.construct_with_deduplication(
+            self._ir, [(field, expr._ir) for field, expr in insertions_dict.items()], field_order),
+            new_type,
+            indices,
+            aggregations)
 
     @typecheck_method(named_exprs=expr_any)
     def annotate(self, **named_exprs):
@@ -1538,8 +1539,9 @@ class StructExpression(Mapping[str, Expression], Expression):
         result_type = tstruct(**new_types)
         indices, aggregations = unify_all(self, *[x for (f, x) in named_exprs.items()])
 
-        return construct_expr(InsertFields(self._ir, list(map(lambda x: (x[0], x[1]._ir), named_exprs.items())), None),
-                              result_type, indices, aggregations)
+        return construct_expr(InsertFields.construct_with_deduplication(
+            self._ir, list(map(lambda x: (x[0], x[1]._ir), named_exprs.items())), None),
+            result_type, indices, aggregations)
 
     @typecheck_method(fields=str, named_exprs=expr_any)
     def select(self, *fields, **named_exprs):

--- a/hail/python/hail/ir/base_ir.py
+++ b/hail/python/hail/ir/base_ir.py
@@ -68,6 +68,9 @@ class BaseIR(Renderable):
         """
         return True
 
+    def __hash__(self):
+        return 31 + hash(str(self))
+
 
 class IR(BaseIR):
     def __init__(self, *children):

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -13,8 +13,6 @@ from .matrix_writer import MatrixWriter, MatrixNativeMultiWriter
 from .renderer import Renderer, Renderable, RenderableStr, ParensRenderer
 from .table_writer import TableWriter
 
-import hashlib
-
 def _env_bind(env, k, v):
     env = env.copy()
     env[k] = v
@@ -1178,18 +1176,10 @@ class BaseApplyAggOp(IR):
                other.seq_op_args == self.seq_op_args
 
     def __hash__(self):
-        h = hash(self.agg_op)
-        h *= 37
-        for x in self.constructor_args:
-            h += 31 * hash(x)
-        h *= 37
-        if self.init_op_args:
-            for x in self.constructor_args:
-                h += 31 * hash(x)
-        h *= 37
-        for x in self.seq_op_args:
-            h += 31 * hash(x)
-        return h
+        return hash(tuple([self.agg_op,
+                           tuple(self.constructor_args),
+                           tuple(self.init_op_args),
+                           tuple(self.seq_op_args)]))
 
     def _compute_type(self, env, agg_env):
         for a in self.constructor_args:
@@ -1256,6 +1246,9 @@ class MakeStruct(IR):
     def __eq__(self, other):
         return isinstance(other, MakeStruct) \
                and other.fields == self.fields
+
+    def __hash__(self):
+        return hash(tuple(self.fields))
 
     def _compute_type(self, env, agg_env):
         for f, x in self.fields:

--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1178,7 +1178,7 @@ class BaseApplyAggOp(IR):
     def __hash__(self):
         return hash(tuple([self.agg_op,
                            tuple(self.constructor_args),
-                           tuple(self.init_op_args),
+                           tuple(self.init_op_args) if self.init_op_args is not None else hash(None),
                            tuple(self.seq_op_args)]))
 
     def _compute_type(self, env, agg_env):

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -3024,16 +3024,20 @@ class MatrixTable(ExprContainer):
         mir = base._mir
 
         if row_exprs:
-            row_struct = InsertFields(base.row._ir, [(n, e._ir) for (n, e) in row_exprs.items()], None)
+            row_struct = InsertFields.construct_with_deduplication(
+                base.row._ir, [(n, e._ir) for (n, e) in row_exprs.items()], None)
             mir = MatrixMapRows(mir, row_struct)
         if col_exprs:
-            col_struct = InsertFields(base.col._ir, [(n, e._ir) for (n, e) in col_exprs.items()], None)
+            col_struct = InsertFields.construct_with_deduplication(
+                base.col._ir, [(n, e._ir) for (n, e) in col_exprs.items()], None)
             mir = MatrixMapCols(mir, col_struct, None)
         if entry_exprs:
-            entry_struct = InsertFields(base.entry._ir, [(n, e._ir) for (n, e) in entry_exprs.items()], None)
+            entry_struct = InsertFields.construct_with_deduplication(
+                base.entry._ir, [(n, e._ir) for (n, e) in entry_exprs.items()], None)
             mir = MatrixMapEntries(mir, entry_struct)
         if global_exprs:
-            globals_struct = InsertFields(base.globals._ir, [(n, e._ir) for (n, e) in global_exprs.items()], None)
+            globals_struct = InsertFields.construct_with_deduplication(
+                base.globals._ir, [(n, e._ir) for (n, e) in global_exprs.items()], None)
             mir = MatrixMapGlobals(mir, globals_struct)
 
         return cleanup(MatrixTable(mir))

--- a/hail/python/hailtop/hailctl/dev/benchmark/matrix_table_benchmarks.py
+++ b/hail/python/hailtop/hailctl/dev/benchmark/matrix_table_benchmarks.py
@@ -98,6 +98,11 @@ def matrix_table_aggregate_entries():
     mt = hl.read_matrix_table(resource('profile.mt'))
     mt.aggregate_entries(hl.agg.stats(mt.GQ))
 
+@benchmark
+def matrix_table_call_stats_star_star():
+    mt = hl.read_matrix_table(resource('profile.mt'))
+    mt.annotate_rows(**hl.agg.call_stats(mt.GT, mt.alleles))._force_count_rows()
+
 # @benchmark never finishes
 def gnomad_coverage_stats():
     mt = hl.read_matrix_table(resource('gnomad_dp_simulation.mt'))
@@ -145,3 +150,12 @@ def gnomad_coverage_stats_optimized():
                           **{f'above_{x}': hl.sum(mt.count_array[x:]) for x in [1, 5, 10, 15, 20, 25, 30, 50, 100]}
                           )
     mt.rows()._force_count()
+
+@benchmark
+def per_row_stats_star_star():
+    mt = hl.read_matrix_table(resource('gnomad_dp_simulation.mt'))
+    mt.annotate_rows(**hl.agg.stats(mt.x))._force_count_rows()
+
+@benchmark
+def read_decode_gnomad_coverage():
+    hl.read_matrix_table(resource('gnomad_dp_simulation.mt'))._force_count_rows()


### PR DESCRIPTION
Benchmark:
```python
@benchmark
def per_row_stats_star_star():
    mt = hl.read_matrix_table(resource('gnomad_dp_simulation.mt'))
    mt.annotate_rows(**hl.agg.stats(mt.x))._force_count_rows()
```

This branch:
```
running per_row_stats_star_star...
    run 1 took 14.53s
    run 2 took 16.56s
    run 3 took 15.05s
    Mean, Median: 15.38s, 15.05s
```

Master:
```
running per_row_stats_star_star...
    run 1 took 31.47s
    run 2 took 37.34s
    run 3 took 26.67s
    Mean, Median: 31.83s, 31.47s
```