### PR TITLE
[batch] sometimes pod metadata name is None

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1028,8 +1028,8 @@ class DeblockedIterator:
 
 
 async def pod_changed(pod):
-    if pod is None:
-        log.info('ignoring pod=None')
+    if pod.metadata.name is None:
+        log.info(f'ignoring pod.metadata.name is None: {pod.to_dict()}')
         return
 
     job = Job.from_record(await db.jobs.get_record_by_pod(pod.metadata.name))
@@ -1068,8 +1068,8 @@ async def refresh_k8s_pods():
 
     seen_pods = set()
     for pod in pods.items:
-        if pod is None:
-            log.info('ignoring pod=None')
+        if pod.metadata.name is None:
+            log.info(f'ignoring pod.metadata.name is None: {pod.to_dict()}')
             continue
 
         pod_name = pod.metadata.name


### PR DESCRIPTION
The previous checks for `pod is None` were intended to catch this case. We're not sure why this happens. By including the pod in the message we hope to understand the cause of nameless pods.