### PR TITLE
[hailctl] only load deploy metadata when needed

### DIFF
--- a/hail/python/hailtop/hailctl/__init__.py
+++ b/hail/python/hailtop/hailctl/__init__.py
@@ -7,12 +7,6 @@ def version() -> str:
     return pkg_resources.resource_string(__name__, 'hail_version').decode().strip()
 
 
-if not pkg_resources.resource_exists(__name__, "deploy.yaml"):
-    raise RuntimeError(f"package has no 'deploy.yaml' file")
-_deploy_metadata = yaml.safe_load(
-    pkg_resources.resource_stream(__name__, "deploy.yaml"))
-
 __all__ = [
-    'version',
-    '_deploy_metadata'
+    'version'
 ]

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -103,7 +103,10 @@ def main(args, pass_through_args):
     conf = ClusterConfig()
     conf.extend_flag('image-version', IMAGE_VERSION)
 
-    deploy_metadata = hailctl._deploy_metadata['dataproc']
+    if not pkg_resources.resource_exists(__name__, "deploy.yaml"):
+        raise RuntimeError(f"package has no 'deploy.yaml' file")
+    deploy_metadata = yaml.safe_load(
+        pkg_resources.resource_stream(__name__, "deploy.yaml"))
 
     conf.extend_flag('properties', DEFAULT_PROPERTIES)
     if args.properties:


### PR DESCRIPTION
in hailctl dataproc start
allows other hailctl commands to be used without being installed

This way you can set PYHTONPATH=$HAIL_HOME/hail/python and use the development version instead of the installed version (except for `hailctl dataproc start`)
