### PR TITLE
[WIP] Stream join

### DIFF
--- a/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
+++ b/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
@@ -94,8 +94,9 @@ abstract class ArrayEmitter(val setup: Code, val m: Code, val setupLen: Code, va
   // f: (missing, value) => result
   def consume(f: (Code, Code) => Code): Code
 
-  // k: (element => result, end-of-stream) => result
-  def produce(k: (Code => Code, Code) => Code): Code = ""
+  // TODO: should be (missing, element) => result
+  // (init, (element) => result, end-of-stream) => result
+  def produce(): (Code, (Code => Code, Code) => Code) = ("", (_, _) => "")
 }
 
 object NDArrayEmitter {

--- a/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
+++ b/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
@@ -1,6 +1,7 @@
 package is.hail.cxx
 
 import is.hail.expr.types.physical._
+import org.apache.zookeeper.KeeperException.UnimplementedException
 
 object EmitTriplet {
   def apply(pType: PType, setup: Code, m: Code, v: Code, region: EmitRegion): EmitTriplet =
@@ -96,7 +97,7 @@ abstract class ArrayEmitter(val setup: Code, val m: Code, val setupLen: Code, va
 
   // TODO: should be (missing, element) => result
   // (init, (element) => result, end-of-stream) => result
-  def produce(): (Code, (Code => Code, Code) => Code) = ("", (_, _) => "")
+  def produce(): (Code, (Code => Code, Code) => Code) = throw new UnimplementedException
 }
 
 object NDArrayEmitter {

--- a/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
+++ b/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
@@ -91,7 +91,11 @@ object SparkFunctionContext {
 case class SparkFunctionContext(sparkEnv: Code, fs: Code, region: EmitRegion)
 
 abstract class ArrayEmitter(val setup: Code, val m: Code, val setupLen: Code, val length: Option[Code], val arrayRegion: EmitRegion) {
-  def emit(f: (Code, Code) => Code): Code
+  // f: (missing, value) => result
+  def consume(f: (Code, Code) => Code): Code
+
+  // k: (element => result, end-of-stream) => result
+  def produce(k: (Code => Code, Code) => Code): Code = ""
 }
 
 object NDArrayEmitter {

--- a/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
+++ b/hail/src/main/scala/is/hail/cxx/EmitTriplet.scala
@@ -95,10 +95,10 @@ abstract class ArrayEmitter(val setup: Code, val m: Code, val setupLen: Code, va
   // f: (missing, value) => result
   def consume(f: (Code, Code) => Code): Code
 
-  // TODO: should be (missing, element) => result
-  // (init, (element) => result, end-of-stream) => result
-  def produce(): (Code, (Code => Code, Code) => Code) = throw new UnimplementedException
+  def produce(): Producer = throw new UnimplementedException
 }
+
+case class Producer(init: Code => Code, step: Code => Code, x: Variable)
 
 object NDArrayEmitter {
   def broadcastFlags(fb: FunctionBuilder, nDims: Int, shape: Code): Seq[Variable] = {

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -17,7 +17,7 @@ object Bindings {
     case ArrayFor(a, name, _) => if (i == 1) Array(name -> -coerce[TStreamable](a.typ).elementType) else empty
     case ArrayFlatMap(a, name, _) => if (i == 1) Array(name -> -coerce[TStreamable](a.typ).elementType) else empty
     case ArrayFilter(a, name, _) => if (i == 1) Array(name -> -coerce[TStreamable](a.typ).elementType) else empty
-    case ArrayJoin(l, r, lName, rName, _, _, _, _) => if (i == 2 || i == 3 || i == 4 || i == 5) Array(lName -> -coerce[TStreamable](l.typ).elementType, rName -> -coerce[TStreamable](r.typ).elementType) else empty
+    case ArrayJoin(l, r, lName, rName, _, _, _, _) => if (!(i == 0 || i == 1)) Array(lName -> -coerce[TStreamable](l.typ).elementType, rName -> -coerce[TStreamable](r.typ).elementType) else empty
     case ArrayFold(a, zero, accumName, valueName, _) => if (i == 2) Array(accumName -> zero.typ, valueName -> -coerce[TStreamable](a.typ).elementType) else empty
     case ArrayScan(a, zero, accumName, valueName, _) => if (i == 2) Array(accumName -> zero.typ, valueName -> -coerce[TStreamable](a.typ).elementType) else empty
     case ArrayAggScan(a, name, _) => if (i == 1) FastIndexedSeq(name -> a.typ.asInstanceOf[TStreamable].elementType) else empty

--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -17,6 +17,7 @@ object Bindings {
     case ArrayFor(a, name, _) => if (i == 1) Array(name -> -coerce[TStreamable](a.typ).elementType) else empty
     case ArrayFlatMap(a, name, _) => if (i == 1) Array(name -> -coerce[TStreamable](a.typ).elementType) else empty
     case ArrayFilter(a, name, _) => if (i == 1) Array(name -> -coerce[TStreamable](a.typ).elementType) else empty
+    case ArrayJoin(l, r, lName, rName, _, _, _, _) => if (i == 2 || i == 3 || i == 4 || i == 5) Array(lName -> -coerce[TStreamable](l.typ).elementType, rName -> -coerce[TStreamable](r.typ).elementType) else empty
     case ArrayFold(a, zero, accumName, valueName, _) => if (i == 2) Array(accumName -> zero.typ, valueName -> -coerce[TStreamable](a.typ).elementType) else empty
     case ArrayScan(a, zero, accumName, valueName, _) => if (i == 2) Array(accumName -> zero.typ, valueName -> -coerce[TStreamable](a.typ).elementType) else empty
     case ArrayAggScan(a, name, _) => if (i == 1) FastIndexedSeq(name -> a.typ.asInstanceOf[TStreamable].elementType) else empty

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -79,8 +79,8 @@ object Children {
       Array(a, cond)
     case ArrayFlatMap(a, name, body) =>
       Array(a, body)
-    case ArrayJoin(l, r, _, _, stepLeftF, stepRightF, produceValueF, joinF) =>
-      Array(l, r, stepLeftF, stepRightF, produceValueF, joinF)
+    case ArrayJoin(l, r, _, _, _, _, compF, joinFs) =>
+      Array(l, r, compF) ++ joinFs
     case ArrayFold(a, zero, accumName, valueName, body) =>
       Array(a, zero, body)
     case ArrayScan(a, zero, accumName, valueName, body) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -79,6 +79,8 @@ object Children {
       Array(a, cond)
     case ArrayFlatMap(a, name, body) =>
       Array(a, body)
+    case ArrayJoin(l, r, _, _, stepLeftF, stepRightF, produceValueF, joinF) =>
+      Array(l, r, stepLeftF, stepRightF, produceValueF, joinF)
     case ArrayFold(a, zero, accumName, valueName, body) =>
       Array(a, zero, body)
     case ArrayScan(a, zero, accumName, valueName, body) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -129,7 +129,7 @@ object Copy {
         ArrayFlatMap(a, name, body)
       case ArrayJoin(_, _, lName, rName, _, _, _, _) =>
         val IndexedSeq(l: IR, r: IR, stepLeftF: IR, stepRightF: IR, produceValueF: IR, joinF: IR) = newChildren
-        ArrayJoin(l, r, lName, rName, stepLeftF, stepRightF, produceValueF, joinF)
+        ArrayJoin(l, r, lName, rName, produceValueF, joinF, stepLeftF, stepRightF)
       case ArrayFold(_, _, accumName, valueName, _) =>
         val IndexedSeq(a: IR, zero: IR, body: IR) = newChildren
         ArrayFold(a, zero, accumName, valueName, body)

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -127,6 +127,9 @@ object Copy {
       case ArrayFlatMap(_, name, _) =>
         val IndexedSeq(a: IR, body: IR) = newChildren
         ArrayFlatMap(a, name, body)
+      case ArrayJoin(_, _, lName, rName, _, _, _, _) =>
+        val IndexedSeq(l: IR, r: IR, stepLeftF: IR, stepRightF: IR, produceValueF: IR, joinF: IR) = newChildren
+        ArrayJoin(l, r, lName, rName, stepLeftF, stepRightF, produceValueF, joinF)
       case ArrayFold(_, _, accumName, valueName, _) =>
         val IndexedSeq(a: IR, zero: IR, body: IR) = newChildren
         ArrayFold(a, zero, accumName, valueName, body)

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -127,9 +127,9 @@ object Copy {
       case ArrayFlatMap(_, name, _) =>
         val IndexedSeq(a: IR, body: IR) = newChildren
         ArrayFlatMap(a, name, body)
-      case ArrayJoin(_, _, lName, rName, _, _, _, _) =>
-        val IndexedSeq(l: IR, r: IR, stepLeftF: IR, stepRightF: IR, produceValueF: IR, joinF: IR) = newChildren
-        ArrayJoin(l, r, lName, rName, produceValueF, joinF, stepLeftF, stepRightF)
+      case ArrayJoin(_, _, lName, rName, lOnlyName, rOnlyName, _, _) =>
+        val l +: r +: compF +: joinFs = newChildren.map(_.asInstanceOf[IR])
+        ArrayJoin(l, r, lName, rName, lOnlyName, rOnlyName, compF, joinFs)
       case ArrayFold(_, _, accumName, valueName, _) =>
         val IndexedSeq(a: IR, zero: IR, body: IR) = newChildren
         ArrayFold(a, zero, accumName, valueName, body)

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -218,8 +218,8 @@ final case class ArrayFlatMap(a: IR, name: String, body: IR) extends IR {
 final case class ArrayJoin(
   left: IR, right: IR,
   lName: String, rName: String,
-  produceValueF: IR, joinF: IR,
-  stepLeftF: IR, stepRightF: IR) extends IR {
+  lOnlyName: Option[String], rOnlyName: Option[String],
+  compF: IR, joinFs: IndexedSeq[IR]) extends IR {
 
   override def typ: TStreamable = coerce[TStreamable](super.typ)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -215,7 +215,12 @@ final case class ArrayFlatMap(a: IR, name: String, body: IR) extends IR {
   override def typ: TStreamable = coerce[TStreamable](super.typ)
 }
 
-final case class ArrayJoin(left: IR, right: IR, lName: String, rName: String, stepLeftF: IR, stepRightF: IR, produceValueF: IR, joinF: IR) extends IR {
+final case class ArrayJoin(
+  left: IR, right: IR,
+  lName: String, rName: String,
+  produceValueF: IR, joinF: IR,
+  stepLeftF: IR, stepRightF: IR) extends IR {
+
   override def typ: TStreamable = coerce[TStreamable](super.typ)
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -214,6 +214,11 @@ final case class ArrayFilter(a: IR, name: String, cond: IR) extends IR {
 final case class ArrayFlatMap(a: IR, name: String, body: IR) extends IR {
   override def typ: TStreamable = coerce[TStreamable](super.typ)
 }
+
+final case class ArrayJoin(left: IR, right: IR, lName: String, rName: String, stepLeftF: IR, stepRightF: IR, produceValueF: IR, joinF: IR) extends IR {
+  override def typ: TStreamable = coerce[TStreamable](super.typ)
+}
+
 final case class ArrayFold(a: IR, zero: IR, accumName: String, valueName: String, body: IR) extends IR
 
 final case class ArrayScan(a: IR, zero: IR, accumName: String, valueName: String, body: IR) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -93,6 +93,8 @@ object InferType {
         a.typ
       case ArrayFlatMap(a, name, body) =>
         coerce[TStreamable](a.typ).copyStreamable(coerce[TIterable](body.typ).elementType)
+      case ArrayJoin(l, r, _, _, _, _, _, joinF) =>
+        coerce[TStreamable](l.typ).copyStreamable(joinF.typ)
       case ArrayFold(a, zero, accumName, valueName, body) =>
         assert(body.typ == zero.typ)
         zero.typ

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -93,8 +93,8 @@ object InferType {
         a.typ
       case ArrayFlatMap(a, name, body) =>
         coerce[TStreamable](a.typ).copyStreamable(coerce[TIterable](body.typ).elementType)
-      case ArrayJoin(l, r, _, _, _, _, _, joinF) =>
-        coerce[TStreamable](l.typ).copyStreamable(joinF.typ)
+      case ArrayJoin(l, r, _, _, _, _, _ , joinFs) =>
+        coerce[TStreamable](l.typ).copyStreamable(joinFs(0).typ)
       case ArrayFold(a, zero, accumName, valueName, body) =>
         assert(body.typ == zero.typ)
         zero.typ

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -179,6 +179,7 @@ object Pretty {
             case ArrayMap(_, name, _) => prettyIdentifier(name)
             case ArrayFilter(_, name, _) => prettyIdentifier(name)
             case ArrayFlatMap(_, name, _) => prettyIdentifier(name)
+            case ArrayJoin(_, _, lName, rName, _, _, _, _) => prettyIdentifier(lName) + " " + prettyIdentifier(rName)
             case ArrayFold(_, _, accumName, valueName, _) => prettyIdentifier(accumName) + " " + prettyIdentifier(valueName)
             case ArrayScan(_, _, accumName, valueName, _) => prettyIdentifier(accumName) + " " + prettyIdentifier(valueName)
             case ArrayLeftJoinDistinct(_, _, l, r, _, _) => prettyIdentifier(l) + " " + prettyIdentifier(r)

--- a/hail/src/main/scala/is/hail/expr/ir/Streamify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Streamify.scala
@@ -19,7 +19,7 @@ object Streamify {
       else ArrayFlatMap(streamify(a), n, streamify(b))
     case ArrayJoin(l, r, lName, rName, stepL, stepR, produce, join) =>
       if (l.typ.isInstanceOf[TStream] && r.typ.isInstanceOf[TStream]) streamableNode
-      else ArrayJoin(streamify(l), streamify(r), lName, rName, stepL, stepR, produce, join)
+      else ArrayJoin(streamify(l), streamify(r), lName, rName, produce, join, stepL, stepR)
     case ArrayScan(a, zero, zn, an, body) =>
       if (a.typ.isInstanceOf[TStream]) streamableNode
       else ArrayScan(streamify(a), apply(zero), zn, an, apply(body))

--- a/hail/src/main/scala/is/hail/expr/ir/Streamify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Streamify.scala
@@ -17,9 +17,9 @@ object Streamify {
     case ArrayFlatMap(a, n, b) =>
       if (a.typ.isInstanceOf[TStream] && b.typ.isInstanceOf[TStream]) streamableNode
       else ArrayFlatMap(streamify(a), n, streamify(b))
-    case ArrayJoin(l, r, lName, rName, stepL, stepR, produce, join) =>
+    case ArrayJoin(l, r, lName, rName, lOnlyName, rOnlyName, comp, joinFs) =>
       if (l.typ.isInstanceOf[TStream] && r.typ.isInstanceOf[TStream]) streamableNode
-      else ArrayJoin(streamify(l), streamify(r), lName, rName, produce, join, stepL, stepR)
+      else ArrayJoin(streamify(l), streamify(r), lName, rName, lOnlyName, rOnlyName, comp, joinFs)
     case ArrayScan(a, zero, zn, an, body) =>
       if (a.typ.isInstanceOf[TStream]) streamableNode
       else ArrayScan(streamify(a), apply(zero), zn, an, apply(body))

--- a/hail/src/main/scala/is/hail/expr/ir/Streamify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Streamify.scala
@@ -17,6 +17,9 @@ object Streamify {
     case ArrayFlatMap(a, n, b) =>
       if (a.typ.isInstanceOf[TStream] && b.typ.isInstanceOf[TStream]) streamableNode
       else ArrayFlatMap(streamify(a), n, streamify(b))
+    case ArrayJoin(l, r, lName, rName, stepL, stepR, produce, join) =>
+      if (l.typ.isInstanceOf[TStream] && r.typ.isInstanceOf[TStream]) streamableNode
+      else ArrayJoin(streamify(l), streamify(r), lName, rName, stepL, stepR, produce, join)
     case ArrayScan(a, zero, zn, an, body) =>
       if (a.typ.isInstanceOf[TStream]) streamableNode
       else ArrayScan(streamify(a), apply(zero), zn, an, apply(body))

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -221,6 +221,13 @@ object TypeCheck {
       case x@ArrayFlatMap(a, name, body) =>
         assert(a.typ.isInstanceOf[TStreamable])
         assert(body.typ.isInstanceOf[TArray])
+      case x@ArrayJoin(l, r, _, _, stepLeftF, stepRightF, produceValueF, joinF) =>
+        assert(l.typ.isInstanceOf[TStreamable])
+        assert(r.typ.isInstanceOf[TStreamable])
+        assert(stepLeftF.typ.isOfType(TBoolean()))
+        assert(stepRightF.typ.isOfType(TBoolean()))
+        assert(produceValueF.typ.isOfType(TBoolean()))
+        assert(joinF.typ == x.typ.elementType)
       case x@ArrayFold(a, zero, accumName, valueName, body) =>
         assert(a.typ.isInstanceOf[TStreamable])
         assert(body.typ == zero.typ)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -61,6 +61,7 @@ object TypeCheck {
       .iterator
       .zipWithIndex
       .foreach {
+        case null => null
         case (child: IR, i) => check(child, ChildBindings(ir, i, env))
         case (tir: TableIR, _) => check(tir)
         case (mir: MatrixIR, _) => check(mir)
@@ -221,13 +222,16 @@ object TypeCheck {
       case x@ArrayFlatMap(a, name, body) =>
         assert(a.typ.isInstanceOf[TStreamable])
         assert(body.typ.isInstanceOf[TArray])
-      case x@ArrayJoin(l, r, _, _, stepLeftF, stepRightF, produceValueF, joinF) =>
+      case x@ArrayJoin(l, r, _, _, lOnlyName, rOnlyName, compF, joinFs) =>
         assert(l.typ.isInstanceOf[TStreamable])
         assert(r.typ.isInstanceOf[TStreamable])
-        assert(stepLeftF.typ.isOfType(TBoolean()))
-        assert(stepRightF.typ.isOfType(TBoolean()))
-        assert(produceValueF.typ.isOfType(TBoolean()))
-        assert(joinF.typ == x.typ.elementType)
+        assert(compF.typ.isOfType(TInt32()))
+        (lOnlyName, rOnlyName) match {
+          case (None, None) => assert(joinFs.length == 1)
+          case (Some(_), None) | (None, Some(_)) => assert(joinFs.length == 2)
+          case (Some(_), Some(_)) => assert(joinFs.length == 3)
+        }
+        assert(joinFs.forall(_.typ == x.typ.elementType))
       case x@ArrayFold(a, zero, accumName, valueName, body) =>
         assert(a.typ.isInstanceOf[TStreamable])
         assert(body.typ == zero.typ)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -61,7 +61,6 @@ object TypeCheck {
       .iterator
       .zipWithIndex
       .foreach {
-        case null => null
         case (child: IR, i) => check(child, ChildBindings(ir, i, env))
         case (tir: TableIR, _) => check(tir)
         case (mir: MatrixIR, _) => check(mir)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -936,11 +936,7 @@ class IRSuite extends HailSuite {
       val lKey = GetField(l, key)
       val rKey = GetField(r, key)
 
-      ArrayJoin(left, right, "l", "r",
-        ApplyComparisonOp(LT(TInt32(), TInt32()), lKey, rKey),
-        ApplyComparisonOp(LT(TInt32(), TInt32()), rKey, lKey),
-        ApplyComparisonOp(EQ(TInt32(), TInt32()), lKey, rKey),
-        InsertFields(l, Seq("val2" -> GetField(r, "val"))))
+      ArrayJoin(left, right, "l", "r", ApplyComparisonOp(EQ(TInt32(), TInt32()), lKey, rKey), InsertFields(l, Seq("val2" -> GetField(r, "val"))), ApplyComparisonOp(LTEQ(TInt32(), TInt32()), lKey, rKey), ApplyComparisonOp(LT(TInt32(), TInt32()), rKey, lKey))
     }
 
     def fold(array: IR, zero: IR, f: (IR, IR) => IR): IR =


### PR DESCRIPTION
Start of an IR node for joining two streams.

## Logic
Works off the "producer" pattern, where a stream is an object that you can
1. Initialize, so the head of the stream is ready to be consumed.
2. Step, so updates the current head to the next element in the stream

A join then takes two streams and its Step steps the left stream, the right stream, or both streams until a "valid" state is reached. E.g. In an outer join every step is a new valid state while an inner join must loop until the match condition is met. The node must also take some combining binary functions so as not to produce runtime tuples. Optional "left" and "right" functions determine at compilation time whether an unmatched pair of values should still produce a value (e.g. in a left join you always act, just either on just the left head or both).

## State of the code base
- Added `produce` abstract method to `ArrayEmitter`. Tests will fail until that is implemented on all the array nodes.
- Inserted a small hack to the `ir.ToArray` emit case that uses the producer route
- Added a test case for `ArrayJoin` (this one passes! :))
- Have not yet incorporated missingness into producer logic and have not implemented `consume` for ArrayJoin`.
- `Binds` needs to be updated to add the appropriate bindings for the children. Right now it just adds them all.
