### PR TITLE
[batch] robust against job tasks running multiple times

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -228,7 +228,7 @@ class Job:
                             f'(touch {success_file} && exit 0)'
             init_container = kube.client.V1Container(
                 image='alpine:3.8',
-                name=self._current_task.name,
+                name=f'{self._current_task.name}-init',
                 command=['/bin/sh', '-c', sh_expression],
                 resources=kube.client.V1ResourceRequirements(
                     requests={'cpu': '500m'}))

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -224,7 +224,7 @@ class Job:
 
         if self._current_task.name == 'main':
             success_file = f'/io/__BATCH_{self._current_task.name.upper()}_SUCCESS__'
-            sh_expression = f'(test -e {success_file} && rm {success_file}; exit 1) || ' \
+            sh_expression = f'(test -e {success_file} && (rm {success_file}; exit 1)) || ' \
                             f'(touch {success_file} && exit 0)'
             init_container = kube.client.V1Container(
                 image='alpine:3.8',

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -104,8 +104,9 @@ class JobTask:  # pylint: disable=R0903
     def copy_task(task_name, files):
         if files is not None:
             authenticate = 'set -ex; gcloud -q auth activate-service-account --key-file=/gsa-key/privateKeyData'
-            touch_success = 'touch /io/__BATCH_{}_SUCCESS__'.format(task_name.upper())
-            check_success = 'test -e /io/__BATCH_{}_SUCCESS__ && exit 0'.format(task_name.upper())
+            success_file = '/io/__BATCH_{}_SUCCESS__'.format(task_name.upper())
+            touch_success = f'touch {success_file}'
+            check_success = f'test -e {success_file} && exit 0'
             clean = 'rm -rf /io/*' if task_name == 'input' else 'true'
 
             def copy_command(src, dst):

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -250,8 +250,6 @@ class Job:
                 init_container.volume_mounts = []
             init_container.volume_mounts.extend(volume_mounts)
 
-        log.info(f'pod_spec: {pod_spec.to_dict()}')
-
         pod_template = kube.client.V1Pod(
             metadata=kube.client.V1ObjectMeta(
                 name=self._pod_name,
@@ -1226,7 +1224,6 @@ async def update_job_with_pod(job, pod):
         log.info(f'job {job.full_id} mark unscheduled')
         await job.mark_unscheduled()
     elif pod and pod.status:
-        log.info(f'pod.status = {pod.status.to_str()}')
         if pod.status.container_statuses:
             assert len(pod.status.container_statuses) == 1
             container_status = pod.status.container_statuses[0]

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1257,18 +1257,6 @@ async def update_job_with_pod(job, pod):
                       and container_status.state.waiting.reason == 'PodInitializing'):
                     if pod.status.init_container_statuses:
                         await job.check_init_container(pod)
-                        assert len(pod.status.init_container_statuses) == 1
-                        init_container_status = pod.status.init_container_statuses[0]
-                        assert init_container_status.name == 'main-init'
-
-                        if init_container_status.state:
-                            if init_container_status.state.terminated:
-                                log.info(f'job {job.full_id} check init container')
-                                await job.check_init_container(pod)
-                            elif (init_container_status.state.waiting
-                                  and init_container_status.state.waiting.reason == 'ImagePullBackOff'):
-                                log.info(f'job {job.full_id} mark failed: ImagePullBackOff')
-                                await job.mark_complete(pod, failed=True, failure_reason=init_container_status.state.waiting.reason)
 
 
 class DeblockedIterator:

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -221,7 +221,7 @@ class Job:
             if self._current_task.name == 'main':
                 success_file = f'/io/__BATCH_{self._current_task.name.upper()}_SUCCESS__'
                 sh_expression = f'(test -e {success_file} && (rm {success_file}; exit 1)) || ' \
-                    f'(touch {success_file} && exit 1)'  # FIXME: revert to 0
+                    f'(touch {success_file} && exit 0)'
                 init_containers.append(kube.client.V1Container(
                     image='alpine:3.8',
                     name=f'{self._current_task.name}-init',

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -249,6 +249,8 @@ class Job:
             if init_container.volume_mounts is None:
                 init_container.volume_mounts = []
             init_container.volume_mounts.extend(volume_mounts)
+            
+        log.info(f'pod_spec: {pod_spec.to_dict()}')
 
         pod_template = kube.client.V1Pod(
             metadata=kube.client.V1ObjectMeta(
@@ -1214,6 +1216,7 @@ async def update_job_with_pod(job, pod):
         log.info(f'job {job.full_id} mark unscheduled')
         await job.mark_unscheduled()
     elif pod and pod.status:
+        log.info(f'pod.status = {pod.status.to_str()}')
         if pod.status.container_statuses:
             assert len(pod.status.container_statuses) == 1
             container_status = pod.status.container_statuses[0]

--- a/batch/batch/database.py
+++ b/batch/batch/database.py
@@ -350,6 +350,16 @@ class JobsTable(Table):
             return records[0][pod_status_field]
         return None
 
+    async def reset_job_state(self, batch_id, job_id, state, duration, task_idx,
+                        exit_codes, log_uris, pod_statuses):
+        await self.update_record(batch_id, job_id,
+                                 state=state,
+                                 duration=duration,
+                                 task_idx=task_idx,
+                                 **{fd: ec for fd, ec in zip(JobsTable.exit_code_mapping.keys(), exit_codes)},
+                                 **{fd: uri for fd, uri in zip(JobsTable.log_uri_mapping.keys(), log_uris)},
+                                 **{fd: pod_statuses for fd, ps in zip(JobsTable.pod_status_mapping.keys(), pod_statuses)})
+
     async def get_parents(self, batch_id, job_id):
         async with self._db.pool.acquire() as conn:
             async with conn.cursor() as cursor:

--- a/batch/batch/database.py
+++ b/batch/batch/database.py
@@ -350,9 +350,11 @@ class JobsTable(Table):
             return records[0][pod_status_field]
         return None
 
-    async def reset_job_state(self, batch_id, job_id, state, duration, task_idx,
-                        exit_codes, log_uris, pod_statuses):
+    async def reset_job_state(self, batch_id, job_id, compare_items,
+                              state, duration, exit_codes, log_uris,
+                              pod_statuses, task_idx):
         await self.update_record(batch_id, job_id,
+                                 compare_items=compare_items,
                                  state=state,
                                  duration=duration,
                                  task_idx=task_idx,


### PR DESCRIPTION
- If 'input' or 'output' task, check for existance of success file before continuing. If success file exists, just exit 0
- If 'main', use an init container to test whether a success file exists. If so, delete the file and restart the entire job (including "input").

See #6494 