### PR TITLE
[benchmark] Add benchmark for range_matrix_table write

### DIFF
--- a/hail/python/hailtop/hailctl/dev/benchmark/matrix_table_benchmarks.py
+++ b/hail/python/hailtop/hailctl/dev/benchmark/matrix_table_benchmarks.py
@@ -1,6 +1,8 @@
-from .utils import benchmark, resource
-import tempfile
+from os import path
+from tempfile import TemporaryDirectory
+
 import hail as hl
+from .utils import benchmark, resource
 
 
 @benchmark
@@ -33,6 +35,12 @@ def matrix_table_rows_force_count():
     ht = hl.read_matrix_table(resource('profile.mt')).rows().key_by()
     ht._force_count()
 
+@benchmark
+def write_range_matrix_table_p100():
+    with TemporaryDirectory() as tmpdir:
+        mt = hl.utils.range_matrix_table(n_rows=1_000_000, n_cols=10, n_partitions=100)
+        mt = mt.annotate_entries(x = mt.col_idx + mt.row_idx)
+        mt.write(path.join(tmpdir, 'tmp.mt'))
 
 @benchmark
 def matrix_table_rows_is_transition():


### PR DESCRIPTION
Pretty horrible performance.

Most of the time is spent in the IR evaluation to annotate entries:

```
  (Let __iruid_65
      (InsertFields
        (Ref row)
        None
        (`the entries! [877f12a8827e18f61222c6c8c5fb04a8]`
          (ArrayMap __iruid_66
            (ArrayRange
              (I32 0)
              (I32 10)
              (I32 1))
            (Literal Struct{} <literal value>))))
      (InsertFields
        (Ref __iruid_65)
        None
        (`the entries! [877f12a8827e18f61222c6c8c5fb04a8]`
          (ArrayMap __iruid_67
            (ArrayRange
              (I32 0)
              (ArrayLen
                (GetField __cols
                  (Ref global)))
              (I32 1))
            (InsertFields
              (ArrayRef
                (GetField `the entries! [877f12a8827e18f61222c6c8c5fb04a8]`
                  (Ref __iruid_65))
                (Ref __iruid_67))
              None
              (x
                (ApplyBinaryPrimOp Add
                  (GetField col_idx
                    (ArrayRef
                      (GetField __cols
                        (Ref global))
                      (Ref __iruid_67)))
                  (GetField row_idx
                    (Ref __iruid_65)))))))))))
```