### PR TITLE
[batch] if current task name is None, ignore pod update

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1067,7 +1067,9 @@ async def batch_id(request, userdata):
 
 
 async def update_job_with_pod(job, pod):
-    if pod and (job.is_complete() or pod.metadata.labels['task'] != job._current_task.name):
+    if pod and (job.is_complete() or
+                job._current_task.name is None or
+                pod.metadata.labels['task'] != job._current_task.name):
         log.info(f'ignoring pod update for job {job.full_id} because it is at a different job task')
         return
 


### PR DESCRIPTION
When `_current_task` is `None`, that means we expect no pods to be running because we're finished with this job.