### PR TITLE
Reordered the decorators so timings actually work

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -698,7 +698,7 @@ async def get_healthcheck(request):  # pylint: disable=W0613
     return jsonify({})
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}')
-@prom_async_time(REQUEST_TIME_POST_CREATE_BATCH)
+@prom_async_time(REQUEST_TIME_GET_JOB)
 @rest_authenticated_users_only
 async def get_job(request, userdata):
     batch_id = int(request.match_info['batch_id'])

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -697,9 +697,9 @@ def create_job(jobs_builder, batch_id, userdata, parameters):  # pylint: disable
 async def get_healthcheck(request):  # pylint: disable=W0613
     return jsonify({})
 
-@prom_async_time(REQUEST_TIME_GET_JOB)
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}')
 @rest_authenticated_users_only
+@prom_async_time(REQUEST_TIME_GET_JOB)
 async def get_job(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     job_id = int(request.match_info['job_id'])
@@ -733,9 +733,9 @@ async def _get_pod_status(batch_id, job_id, user):
     abort(404)
 
 
-@prom_async_time(REQUEST_TIME_GET_JOB_LOG)
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/log')
 @rest_authenticated_users_only
+@prom_async_time(REQUEST_TIME_GET_JOB_LOG)
 async def get_job_log(request, userdata):  # pylint: disable=R1710
     batch_id = int(request.match_info['batch_id'])
     job_id = int(request.match_info['job_id'])
@@ -744,9 +744,9 @@ async def get_job_log(request, userdata):  # pylint: disable=R1710
     return jsonify(job_log)
 
 
-@prom_async_time(REQUEST_TIME_GET_POD_STATUS)
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/pod_status')
 @rest_authenticated_users_only
+@prom_async_time(REQUEST_TIME_GET_POD_STATUS)
 async def get_pod_status(request, userdata):  # pylint: disable=R1710
     batch_id = int(request.match_info['batch_id'])
     job_id = int(request.match_info['job_id'])
@@ -924,18 +924,18 @@ async def _get_batches_list(params, user):
     return [await batch.to_dict(include_jobs=False) for batch in batches]
 
 
-@prom_async_time(REQUEST_TIME_GET_BATCHES)
 @routes.get('/api/v1alpha/batches')
 @rest_authenticated_users_only
+@prom_async_time(REQUEST_TIME_GET_BATCHES)
 async def get_batches_list(request, userdata):
     params = request.query
     user = userdata['username']
     return jsonify(await _get_batches_list(params, user))
 
 
-@prom_async_time(REQUEST_TIME_POST_CREATE_JOBS)
 @routes.post('/api/v1alpha/batches/{batch_id}/jobs/create')
 @rest_authenticated_users_only
+@prom_async_time(REQUEST_TIME_POST_CREATE_JOBS)
 async def create_jobs(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
@@ -972,9 +972,9 @@ async def create_jobs(request, userdata):
 
     return jsonify({})
 
-@prom_async_time(REQUEST_TIME_POST_CREATE_BATCH)
 @routes.post('/api/v1alpha/batches/create')
 @rest_authenticated_users_only
+@prom_async_time(REQUEST_TIME_POST_CREATE_BATCH)
 async def create_batch(request, userdata):
     parameters = await request.json()
 
@@ -1003,26 +1003,26 @@ async def _cancel_batch(batch_id, user):
         abort(404)
     await batch.cancel()
 
-@prom_async_time(REQUEST_TIME_POST_GET_BATCH)
 @routes.get('/api/v1alpha/batches/{batch_id}')
 @rest_authenticated_users_only
+@prom_async_time(REQUEST_TIME_POST_GET_BATCH)
 async def get_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
     return jsonify(await _get_batch(batch_id, user))
 
-@prom_async_time(REQUEST_TIME_PATCH_CANCEL_BATCH)
 @routes.patch('/api/v1alpha/batches/{batch_id}/cancel')
 @rest_authenticated_users_only
+@prom_async_time(REQUEST_TIME_PATCH_CANCEL_BATCH)
 async def cancel_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
     await _cancel_batch(batch_id, user)
     return jsonify({})
 
-@prom_async_time(REQUEST_TIME_PATCH_CLOSE_BATCH)
 @routes.patch('/api/v1alpha/batches/{batch_id}/close')
 @rest_authenticated_users_only
+@prom_async_time(REQUEST_TIME_PATCH_CLOSE_BATCH)
 async def close_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
@@ -1032,9 +1032,9 @@ async def close_batch(request, userdata):
     await batch.close()
     return jsonify({})
 
-@prom_async_time(REQUEST_TIME_DELETE_BATCH)
 @routes.delete('/api/v1alpha/batches/{batch_id}')
 @rest_authenticated_users_only
+@prom_async_time(REQUEST_TIME_DELETE_BATCH)
 async def delete_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
@@ -1045,10 +1045,10 @@ async def delete_batch(request, userdata):
     await batch.mark_deleted()
     return jsonify({})
 
-@prom_async_time(REQUEST_TIME_GET_BATCH_UI)
 @routes.get('/batches/{batch_id}')
 @aiohttp_jinja2.template('batch.html')
 @web_authenticated_users_only
+@prom_async_time(REQUEST_TIME_GET_BATCH_UI)
 async def ui_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
@@ -1056,11 +1056,11 @@ async def ui_batch(request, userdata):
     return {'batch': batch}
 
 
-@prom_async_time(REQUEST_TIME_POST_CANCEL_BATCH_UI)
 @routes.post('/batches/{batch_id}/cancel')
 @aiohttp_jinja2.template('batches.html')
 @check_csrf_token
 @web_authenticated_users_only
+@prom_async_time(REQUEST_TIME_POST_CANCEL_BATCH_UI)
 async def ui_cancel_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
@@ -1069,9 +1069,9 @@ async def ui_cancel_batch(request, userdata):
     raise web.HTTPFound(location=location)
 
 
-@prom_async_time(REQUEST_TIME_GET_BATCHES_UI)
 @routes.get('/batches', name='batches')
 @web_authenticated_users_only
+@prom_async_time(REQUEST_TIME_GET_BATCHES_UI)
 async def ui_batches(request, userdata):
     params = request.query
     user = userdata['username']
@@ -1085,10 +1085,10 @@ async def ui_batches(request, userdata):
     response.set_cookie('_csrf', token, secure=True, httponly=True)
     return response
 
-@prom_async_time(REQUEST_TIME_GET_LOGS_UI)
 @routes.get('/batches/{batch_id}/jobs/{job_id}/log')
 @aiohttp_jinja2.template('job_log.html')
 @web_authenticated_users_only
+@prom_async_time(REQUEST_TIME_GET_LOGS_UI)
 async def ui_get_job_log(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     job_id = int(request.match_info['job_id'])
@@ -1097,10 +1097,10 @@ async def ui_get_job_log(request, userdata):
     return {'batch_id': batch_id, 'job_id': job_id, 'job_log': job_log}
 
 
-@prom_async_time(REQUEST_TIME_GET_POD_STATUS_UI)
 @routes.get('/batches/{batch_id}/jobs/{job_id}/pod_status')
 @aiohttp_jinja2.template('pod_status.html')
 @web_authenticated_users_only
+@prom_async_time(REQUEST_TIME_GET_POD_STATUS_UI)
 async def ui_get_pod_status(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     job_id = int(request.match_info['job_id'])

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -698,8 +698,8 @@ async def get_healthcheck(request):  # pylint: disable=W0613
     return jsonify({})
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}')
+@prom_async_time(REQUEST_TIME_POST_CREATE_BATCH)
 @rest_authenticated_users_only
-@prom_async_time(REQUEST_TIME_GET_JOB)
 async def get_job(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     job_id = int(request.match_info['job_id'])
@@ -734,8 +734,8 @@ async def _get_pod_status(batch_id, job_id, user):
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/log')
-@rest_authenticated_users_only
 @prom_async_time(REQUEST_TIME_GET_JOB_LOG)
+@rest_authenticated_users_only
 async def get_job_log(request, userdata):  # pylint: disable=R1710
     batch_id = int(request.match_info['batch_id'])
     job_id = int(request.match_info['job_id'])
@@ -745,8 +745,8 @@ async def get_job_log(request, userdata):  # pylint: disable=R1710
 
 
 @routes.get('/api/v1alpha/batches/{batch_id}/jobs/{job_id}/pod_status')
-@rest_authenticated_users_only
 @prom_async_time(REQUEST_TIME_GET_POD_STATUS)
+@rest_authenticated_users_only
 async def get_pod_status(request, userdata):  # pylint: disable=R1710
     batch_id = int(request.match_info['batch_id'])
     job_id = int(request.match_info['job_id'])
@@ -925,8 +925,8 @@ async def _get_batches_list(params, user):
 
 
 @routes.get('/api/v1alpha/batches')
-@rest_authenticated_users_only
 @prom_async_time(REQUEST_TIME_GET_BATCHES)
+@rest_authenticated_users_only
 async def get_batches_list(request, userdata):
     params = request.query
     user = userdata['username']
@@ -934,8 +934,8 @@ async def get_batches_list(request, userdata):
 
 
 @routes.post('/api/v1alpha/batches/{batch_id}/jobs/create')
-@rest_authenticated_users_only
 @prom_async_time(REQUEST_TIME_POST_CREATE_JOBS)
+@rest_authenticated_users_only
 async def create_jobs(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
@@ -973,8 +973,8 @@ async def create_jobs(request, userdata):
     return jsonify({})
 
 @routes.post('/api/v1alpha/batches/create')
-@rest_authenticated_users_only
 @prom_async_time(REQUEST_TIME_POST_CREATE_BATCH)
+@rest_authenticated_users_only
 async def create_batch(request, userdata):
     parameters = await request.json()
 
@@ -1004,16 +1004,16 @@ async def _cancel_batch(batch_id, user):
     await batch.cancel()
 
 @routes.get('/api/v1alpha/batches/{batch_id}')
-@rest_authenticated_users_only
 @prom_async_time(REQUEST_TIME_POST_GET_BATCH)
+@rest_authenticated_users_only
 async def get_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
     return jsonify(await _get_batch(batch_id, user))
 
 @routes.patch('/api/v1alpha/batches/{batch_id}/cancel')
-@rest_authenticated_users_only
 @prom_async_time(REQUEST_TIME_PATCH_CANCEL_BATCH)
+@rest_authenticated_users_only
 async def cancel_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
@@ -1021,8 +1021,8 @@ async def cancel_batch(request, userdata):
     return jsonify({})
 
 @routes.patch('/api/v1alpha/batches/{batch_id}/close')
-@rest_authenticated_users_only
 @prom_async_time(REQUEST_TIME_PATCH_CLOSE_BATCH)
+@rest_authenticated_users_only
 async def close_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
@@ -1033,8 +1033,8 @@ async def close_batch(request, userdata):
     return jsonify({})
 
 @routes.delete('/api/v1alpha/batches/{batch_id}')
-@rest_authenticated_users_only
 @prom_async_time(REQUEST_TIME_DELETE_BATCH)
+@rest_authenticated_users_only
 async def delete_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
@@ -1046,9 +1046,9 @@ async def delete_batch(request, userdata):
     return jsonify({})
 
 @routes.get('/batches/{batch_id}')
+@prom_async_time(REQUEST_TIME_GET_BATCH_UI)
 @aiohttp_jinja2.template('batch.html')
 @web_authenticated_users_only
-@prom_async_time(REQUEST_TIME_GET_BATCH_UI)
 async def ui_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
@@ -1057,10 +1057,10 @@ async def ui_batch(request, userdata):
 
 
 @routes.post('/batches/{batch_id}/cancel')
+@prom_async_time(REQUEST_TIME_POST_CANCEL_BATCH_UI)
 @aiohttp_jinja2.template('batches.html')
 @check_csrf_token
 @web_authenticated_users_only
-@prom_async_time(REQUEST_TIME_POST_CANCEL_BATCH_UI)
 async def ui_cancel_batch(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     user = userdata['username']
@@ -1070,8 +1070,8 @@ async def ui_cancel_batch(request, userdata):
 
 
 @routes.get('/batches', name='batches')
-@web_authenticated_users_only
 @prom_async_time(REQUEST_TIME_GET_BATCHES_UI)
+@web_authenticated_users_only
 async def ui_batches(request, userdata):
     params = request.query
     user = userdata['username']
@@ -1086,9 +1086,9 @@ async def ui_batches(request, userdata):
     return response
 
 @routes.get('/batches/{batch_id}/jobs/{job_id}/log')
+@prom_async_time(REQUEST_TIME_GET_LOGS_UI)
 @aiohttp_jinja2.template('job_log.html')
 @web_authenticated_users_only
-@prom_async_time(REQUEST_TIME_GET_LOGS_UI)
 async def ui_get_job_log(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     job_id = int(request.match_info['job_id'])
@@ -1098,9 +1098,9 @@ async def ui_get_job_log(request, userdata):
 
 
 @routes.get('/batches/{batch_id}/jobs/{job_id}/pod_status')
+@prom_async_time(REQUEST_TIME_GET_POD_STATUS_UI)
 @aiohttp_jinja2.template('pod_status.html')
 @web_authenticated_users_only
-@prom_async_time(REQUEST_TIME_GET_POD_STATUS_UI)
 async def ui_get_pod_status(request, userdata):
     batch_id = int(request.match_info['batch_id'])
     job_id = int(request.match_info['job_id'])

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     app: batch
     hail.is/sha: "{{ code.sha }}"
- spec:
+spec:
   selector:
     matchLabels:
       app: batch

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -10,8 +10,7 @@ metadata:
   labels:
     app: batch
     hail.is/sha: "{{ code.sha }}"
-    grafanak8sapp: "true"
-spec:
+ spec:
   selector:
     matchLabels:
       app: batch
@@ -21,6 +20,7 @@ spec:
       labels:
         app: batch
         hail.is/sha: "{{ code.sha }}"
+        grafanak8sapp: "true"
     spec:
       serviceAccountName: batch
 {% if deploy %}


### PR DESCRIPTION
Did a local test of prometheus_async on a tiny aiohttp server, turns out the order of the decorators does matter. The timing decorator has to be on the bottom to actually time anything successfully. Does the order of any of the other decorators matter? 