### PR TITLE
Add ukbb rg browser

### DIFF
--- a/letsencrypt/domains.txt
+++ b/letsencrypt/domains.txt
@@ -2,9 +2,9 @@
 ci.@domain@
 notebook.@domain@
 notebook2.@domain@
-app.@domain@
 scorecard.@domain@
-upload.@domain@
 www.@domain@
 batch.@domain@
 internal.@domain@
+auth.@domain@
+ukbb-rg.@domain@

--- a/router/Makefile
+++ b/router/Makefile
@@ -21,5 +21,6 @@ deploy: push
 	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"router_image":{"image":"$(ROUTER_IMAGE)"},"default_ns":{"name":"default","domain":"hail.is"}}' deployment.yaml deployment.yaml.out
 	kubectl -n default apply -f deployment.yaml.out
 
+.PHONY: clean
 clean:
 	rm -rf deployment.yaml

--- a/router/Makefile
+++ b/router/Makefile
@@ -1,31 +1,25 @@
-.PHONY: build clean
-
-ifeq ($(IN_HAIL_CI),1)
-.PHONY: push deploy
-
 PROJECT = $(shell gcloud config get-value project)
 ROUTER_LATEST = gcr.io/$(PROJECT)/router:latest
 ROUTER_IMAGE = gcr.io/$(PROJECT)/router:$(shell docker images -q --no-trunc router | sed -e 's,[^:]*:,,')
 DOMAIN ?= hail.is
 
+.PHONY: build
 build:
 	docker pull ubuntu:18.04
 	-docker pull $(ROUTER_LATEST)
 	docker build -t router --cache-from router,$(ROUTER_LATEST),ubuntu:18.04 .
 
+.PHONY: push
 push: build
 	docker tag router $(ROUTER_LATEST)
 	docker push $(ROUTER_LATEST)
 	docker tag router $(ROUTER_IMAGE)
 	docker push $(ROUTER_IMAGE)
 
+.PHONY: deploy
 deploy: push
 	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"router_image":{"image":"$(ROUTER_IMAGE)"},"default_ns":{"name":"default","domain":"hail.is"}}' deployment.yaml deployment.yaml.out
 	kubectl -n default apply -f deployment.yaml.out
-else
-build:
-	docker build -t router .
-endif
 
 clean:
 	rm -rf deployment.yaml

--- a/router/get-deployed-sha.sh
+++ b/router/get-deployed-sha.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -ex
-
-kubectl -n default get --selector=app=router deployments -o "jsonpath={.items[*].metadata.labels.hail\.is/sha}"

--- a/router/router.nginx.conf.in
+++ b/router/router.nginx.conf.in
@@ -60,22 +60,6 @@ server {
 }
 
 server {
-    server_name upload.@domain@;
-
-    location / {
-        proxy_pass http://upload/;
-    }
-
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Host $host;
-    proxy_set_header X-Forwarded-Proto https;
-
-    listen 80;
-    listen [::]:80;
-}
-
-server {
     server_name notebook.@domain@;
 
     # needed to correctly handle error_page with internal handles
@@ -205,6 +189,32 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_read_timeout 86400;
+    }
+
+    listen 80;
+    listen [::]:80;
+}
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    server_name ukbb-rg.@domain@;
+
+    location /rg_browser {
+        proxy_pass http://ukbb-rg-browser.ukbb-rg;
+
+	proxy_http_version 1.1;
+	proxy_set_header Upgrade $http_upgrade;
+	proxy_set_header Connection $connection_upgrade;
+	proxy_read_timeout 20d;
+	proxy_buffering off;
+    }
+
+    location / {
+        proxy_pass http://ukbb-rg-static.ukbb-rg;
     }
 
     listen 80;

--- a/ukbb-rg/Dockerfile.browser
+++ b/ukbb-rg/Dockerfile.browser
@@ -1,0 +1,25 @@
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+  apt-get -y install \
+    tzdata \
+    r-base \
+    wget \
+    gdebi-core && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN R -e "install.packages(c('shiny', 'rmarkdown', 'data.table', 'formattable', 'dplyr', 'DT', 'shinyWidgets', 'shinyjs'), repos='http://cran.rstudio.com/', Ncpus=4)"
+
+RUN wget -nv -O shiny-server-1.5.9.923-amd64.deb https://download3.rstudio.org/ubuntu-14.04/x86_64/shiny-server-1.5.9.923-amd64.deb && \
+ gdebi -n shiny-server-1.5.9.923-amd64.deb && \
+ rm -f shiny-server-1.5.9.923-amd64.deb && \
+ rm -r /srv/shiny-server/index.html /srv/shiny-server/sample-apps
+
+COPY shiny-server.conf /etc/shiny-server/shiny-server.conf
+COPY app/app.R /srv/shiny-server/rg_browser/
+COPY app/www/rainbowvis.js /srv/shiny-server/static/
+
+EXPOSE 3838
+
+CMD ["shiny-server"]

--- a/ukbb-rg/Dockerfile.static
+++ b/ukbb-rg/Dockerfile.static
@@ -1,0 +1,13 @@
+FROM ubuntu:18.04
+
+RUN apt-get update -y && \
+    apt-get install -y nginx && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN rm -f /etc/nginx/sites-enabled/default
+ADD static.nginx.conf /etc/nginx/conf.d
+
+RUN ln -sf /dev/stdout /var/log/nginx/access.log
+RUN ln -sf /dev/stderr /var/log/nginx/error.log
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/ukbb-rg/Makefile
+++ b/ukbb-rg/Makefile
@@ -1,0 +1,30 @@
+PROJECT := $(shell gcloud config get-value project)
+
+UKBB_RG_STATIC_LATEST = gcr.io/$(PROJECT)/ukbb-rg-static:latest
+UKBB_RG_STATIC_IMAGE = gcr.io/$(PROJECT)/ukbb-rg-static:$(shell docker images -q --no-trunc ukbb-rg-static | sed -e 's,[^:]*:,,')
+
+UKBB_RG_BROWSER_LATEST = gcr.io/$(PROJECT)/ukbb-rg-browser:latest
+UKBB_RG_BROWSER_IMAGE = gcr.io/$(PROJECT)/ukbb-rg-browser:$(shell docker images -q --no-trunc ukbb-rg-browser | sed -e 's,[^:]*:,,')
+
+.PHONY: build
+build:
+	docker pull ubuntu:18.04
+	-docker pull $(UKBB_RG_STATIC_LATEST)
+	docker build -t ukbb-rg-static -f Dockerfile.static --cache-from ukbb-rg-static,$(UKBB_RG_STATIC_LATEST),ubuntu:18.04 .
+	-docker pull $(UKBB_RG_BROWSER_LATEST)
+	docker build -t ukbb-rg-browser -f Dockerfile.browser --cache-from ukbb-rg-browser,$(UKBB_RG_BROWSER_LATEST),ubuntu:18.04 .
+
+.PHONY: push
+push: build
+	docker tag ukbb-rg-static $(UKBB_RG_STATIC_LATEST)
+	docker push $(UKBB_RG_STATIC_LATEST)
+	docker tag ukbb-rg-static $(UKBB_RG_STATIC_IMAGE)
+	docker push $(UKBB_RG_STATIC_IMAGE)
+	docker tag ukbb-rg-browser $(UKBB_RG_BROWSER_LATEST)
+	docker push $(UKBB_RG_BROWSER_LATEST)
+	docker tag ukbb-rg-browser $(UKBB_RG_BROWSER_IMAGE)
+	docker push $(UKBB_RG_BROWSER_IMAGE)
+
+.PHONY: deploy
+deploy: push
+	kubectl apply -f deployment.yaml

--- a/ukbb-rg/deployment.yaml
+++ b/ukbb-rg/deployment.yaml
@@ -25,6 +25,10 @@ spec:
        - name: ukbb-rg-static
          image: gcr.io/hail-vdc/ukbb-rg-static
          imagePullPolicy: Always
+         resources:
+           requests:
+             memory: "3.75G"
+             cpu: "1"
          ports:
           - containerPort: 80
             protocol: TCP
@@ -64,6 +68,10 @@ spec:
        - name: ukbb-rg-browser
          image: gcr.io/hail-vdc/ukbb-rg-browser
          imagePullPolicy: Always
+         resources:
+           requests:
+             memory: "3.75G"
+             cpu: "1"
          ports:
           - containerPort: 3838
             protocol: TCP

--- a/ukbb-rg/deployment.yaml
+++ b/ukbb-rg/deployment.yaml
@@ -1,0 +1,112 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ukbb-rg
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ukbb-rg-static
+  namespace: ukbb-rg
+  labels:
+    name: ukbb-rg-static
+spec:
+  serviceName: "ukbb-rg-static"
+  selector:
+    matchLabels:
+      app: ukbb-rg-static
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ukbb-rg-static
+    spec:
+      containers:
+       - name: ukbb-rg-static
+         image: gcr.io/hail-vdc/ukbb-rg-static
+         imagePullPolicy: Always
+         ports:
+          - containerPort: 80
+            protocol: TCP
+         volumeMounts:
+          - mountPath: "/ukbb-rg-static"
+            name: ukbb-rg-static-storage
+  volumeClaimTemplates:
+    - metadata:
+        name: ukbb-rg-static-storage
+        namespace: ukbb-rg-static
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ukbb-rg-browser
+  namespace: ukbb-rg
+  labels:
+    name: ukbb-rg-browser
+spec:
+  serviceName: "ukbb-rg-browser"
+  selector:
+    matchLabels:
+      app: ukbb-rg-browser
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ukbb-rg-browser
+    spec:
+      containers:
+       - name: ukbb-rg-browser
+         image: gcr.io/hail-vdc/ukbb-rg-browser
+         imagePullPolicy: Always
+         ports:
+          - containerPort: 3838
+            protocol: TCP
+         volumeMounts:
+          - mountPath: "/ukbb-rg-browser"
+            name: ukbb-rg-browser-storage
+  volumeClaimTemplates:
+    - metadata:
+        name: ukbb-rg-browser-storage
+        namespace: ukbb-rg-browser
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ukbb-rg-static
+  namespace: ukbb-rg
+  labels:
+    app: ukbb-rg-static
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: ukbb-rg-static
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ukbb-rg-browser
+  namespace: ukbb-rg
+  labels:
+    app: ukbb-rg-browser
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 3838
+  selector:
+    app: ukbb-rg-browser

--- a/ukbb-rg/shiny-server.conf
+++ b/ukbb-rg/shiny-server.conf
@@ -1,0 +1,27 @@
+# Instruct Shiny Server to run applications as the user "shiny"
+run_as shiny;
+
+# Define a server that listens on port 3838
+server {
+  listen 3838;
+
+  location /rg_browser/static {
+    site_dir /srv/shiny-server/static;
+    log_dir /var/log/shiny-server;
+  }
+  
+  # Define a location at the base URL
+  location /rg_browser {
+
+    # Host the directory of Shiny Apps stored in this directory
+    site_dir /srv/shiny-server/rg_browser;
+
+    # Log all Shiny output to files in this directory
+    log_dir /var/log/shiny-server;
+
+    # When a user visits the base URL rather than a particular application,
+    # an index of the applications available in this directory will be shown.
+    directory_index on;
+  }
+
+}

--- a/ukbb-rg/static.nginx.conf
+++ b/ukbb-rg/static.nginx.conf
@@ -1,0 +1,13 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name ukbb-rg;
+
+    location = /health {
+        return 200;
+    }
+
+    location / {
+        root /ukbb-rg-static;
+    }
+}


### PR DESCRIPTION
Hand deployed (currently running).  Only visible change is to router, add proxy rules from ukbb-hail.is to the ukbb-rg servers.  The web site has two parts: static HTML served by nginx and a interactive, data-driven Shiny site run by R/shiny/shiny server.  Servers run as stateful sets.  Static HTML and 
data for Shiny were hand-populated.

Currently giving them each one core.  Given how much state is involved here, it's not clear how to autoscale this like we do with the other services.
