### PR TITLE
Expose a range bounds calculator

### DIFF
--- a/hail/python/hail/ir/ir.py
+++ b/hail/python/hail/ir/ir.py
@@ -1826,6 +1826,8 @@ class TableToValueApply(IR):
         name = self.config['name']
         if name == 'ForceCountTable':
             self._type = tint64
+        elif name == 'TableCalculateNewPartitions':
+            self._type = tarray(tinterval(self.child.typ.key_type))
         else:
             assert name == 'NPartitionsTable', name
             self._type = tint32

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -4020,5 +4020,14 @@ class MatrixTable(ExprContainer):
              'entryField': entry_field,
              'blockSize': block_size}))
 
+    def _calculate_new_partitions(self, n_partitions):
+        """returns a set of range bounds that can be passed to write"""
+        mt = self.rows()
+        mt = mt.select()
+        return Env.backend().execute(TableToValueApply(
+            mt._tir,
+            {'name': 'TableCalculateNewPartitions',
+             'nPartitions': n_partitions}))
+
 
 matrix_table_type.set(MatrixTable)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
@@ -116,6 +116,7 @@ object RelationalFunctions {
     classOf[WindowByLocus],
     classOf[TableFilterPartitions],
     classOf[MatrixFilterPartitions],
+    classOf[TableCalculateNewPartitions],
     classOf[ForceCountTable],
     classOf[ForceCountMatrixTable],
     classOf[NPartitionsTable],

--- a/hail/src/main/scala/is/hail/expr/ir/functions/TableCalculateNewPartitions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/TableCalculateNewPartitions.scala
@@ -1,0 +1,26 @@
+package is.hail.expr.ir.functions
+
+import is.hail.expr.ir.{ExecuteContext, TableValue}
+import is.hail.expr.types.virtual._
+import is.hail.expr.types.TableType
+import is.hail.rvd.RVD
+import is.hail.utils._
+
+case class TableCalculateNewPartitions(
+  nPartitions: Int
+) extends TableToValueFunction {
+  def typ(childType: TableType): Type = TArray(TInterval(childType.keyType))
+
+  def execute(ctx: ExecuteContext, tv: TableValue): Any = {
+    val rvd = tv.rvd
+    if (rvd.typ.key.isEmpty)
+      FastIndexedSeq()
+    else {
+      val ki = RVD.getKeyInfo(rvd.typ, rvd.typ.key.length, RVD.getKeys(rvd.typ, rvd.crdd))
+      if (ki.isEmpty)
+        FastIndexedSeq()
+      else
+        RVD.calculateKeyRanges(rvd.typ, ki, nPartitions, rvd.typ.key.length).rangeBounds.toIndexedSeq
+    }
+  }
+}


### PR DESCRIPTION
Uses a similar method to RVD.coalesce to calculate the new bounds.
Requires a quick scan of the data but no shuffles.