### PR TITLE
[batch] Cancel Fast

### DIFF
--- a/batch/Dockerfile.test
+++ b/batch/Dockerfile.test
@@ -7,4 +7,4 @@ RUN python3 -m pip install --no-cache-dir /hailtop \
 
 COPY batch/test/ /test/
 
-CMD ["python3", "-m", "pytest", "-v", "-s", "/test/"]
+CMD ["python3", "-m", "pytest", "-vvv", "--maxfail=1", "-s", "/test/"]

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1024,7 +1024,7 @@ inner join (    select jobs.job_id
               group by jobs.job_id
                 having count({jobs_parents}.state = 'Success') = count(*)
                     or (jobs.always_run = TRUE and
-                        count(`{jobs_parents}`.state in ('Success', 'Error', 'Failed', 'CancelledDone')) = count(*))
+                        count({jobs_parents}.state in ('Success', 'Error', 'Failed', 'CancelledDone')) = count(*))
            ) as jobs2 on jobs2.job_id = jobs.job_id and jobs2.batch_id = jobs.batch_id
        set state = (case jobs.state when 'Pending' then 'Ready' else 'CancelledDone')
 ''', (batch_id,))

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1002,14 +1002,14 @@ async def _cancel_batch(batch_id, user):
         async with conn.cursor() as cursor:
             await cursor.execute('''
     update jobs
-inner join batch on jobs.batch_id == batch.batch_id
+inner join batch on jobs.batch_id = batch.batch_id
        set jobs.state = 'Cancelled'
      where jobs.batch_id = %s
        and jobs.user = %s
        and batch.deleted = FALSE
        and batch.cancelled = FALSE
        and jobs.state not in ('Cancelled', 'Error', 'Failed', 'Success', 'Pending')
-       and jobs.always_run == FALSE
+       and jobs.always_run = FALSE
 ''', (batch_id, user))
             await cursor.execute('''
     update jobs

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1036,8 +1036,9 @@ update batch
  where batch.id = %s
 ''', (batch_id,))
             await cursor.execute('''
-    select jobs.*
+    select jobs.*, batch.*
       from jobs
+inner join batch on jobs.batch_id = batch.id
      where jobs.state in ('Ready', 'Cancelled', 'CancelledDone')
        and jobs.batch_id = %s
 ''', (batch_id,))

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -524,6 +524,12 @@ class Job:
                 log.info(f'parents deleted, cancelled, or failed: cancelling {self.full_id}')
                 await self.set_state('Cancelled')
 
+    @staticmethod
+    async def cancel_many(*ids):
+        for id in ids:
+            await self.set_state('Cancelled')  # must call before deleting resources to prevent race conditions
+            await self._delete_k8s_resources()
+
     async def cancel(self):
         self._cancelled = True
 

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1018,7 +1018,7 @@ call propagate_cancelled(%s)
 ''', (batch_id,))
             await cursor.execute('''
 update batch
-   set cancelled = TRUE, closed = TRUE
+   set cancelled = true, closed = true
  where batch.id = %s
 ''', (batch_id,))
             await cursor.execute('''

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1013,7 +1013,7 @@ async def _cancel_batch(batch_id, user):
        and jobs.state not in ('Cancelled', 'Error', 'Failed', 'Success', 'Pending')
        and jobs.always_run = FALSE
 ''', (batch_id,))
-            await cursor.execute('''
+            await cursor.execute(f'''
     update jobs
 inner join (    select jobs.id
                   from jobs

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1013,9 +1013,26 @@ async def _cancel_batch(batch_id, user):
        and jobs.state not in ('Cancelled', 'CancelledDone', 'Error', 'Failed', 'Success')
        and jobs.always_run = FALSE
 ''', (batch_id,))
-            await cursor.execute(f'''
-call propagate_cancelled(%s)
+            while True:
+                await cursor.execute(f'''
+    update jobs
+inner join (    select jobs.job_id, jobs.batch_id
+                  from jobs
+            inner join `jobs-parents` on `jobs-parents`.batch_id = jobs.batch_id
+                                     and `jobs-parents`.job_id = jobs.job_id
+            inner join jobs as parents on `jobs-parents`.batch_id = parents.batch_id
+                                      and `jobs-parents`.parent_id = parents.job_id
+                 where jobs.state = 'Cancelled'
+                   and jobs.batch_id = batch_id
+              group by jobs.batch_id, jobs.job_id, jobs.always_run
+                having count(parents.state = 'Success') = count(*)
+                    or (jobs.always_run = true and
+                        count(parents.state in ('Success', 'Error', 'Failed', 'CancelledDone')) = count(*))
+           ) as jobs2 on jobs2.job_id = jobs.job_id and jobs2.batch_id = jobs.batch_id
+       set state = (case jobs.always_run when true then 'Ready' else 'CancelledDone' end);
 ''', (batch_id,))
+                if cursor.rowcount == 0:
+                    break
             await cursor.execute('''
 update batch
    set cancelled = true, closed = true

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1001,7 +1001,7 @@ async def _cancel_batch(batch_id, user):
     batch = await Batch.from_db(batch_id, user)
     if not batch:
         abort(404)
-    if batch._cancelled or batch.deleted:
+    if batch.cancelled or batch.deleted:
         return
     async with db.pool.acquire() as conn:
         async with conn.cursor() as cursor:

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1033,6 +1033,7 @@ inner join `jobs-parents` on `jobs-parents`.batch_id = jobs.batch_id
        and batch.cancelled = FALSE
 ;
     update batch set cancelled = TRUE, closed = TRUE
+;
 ''', (batch_id, user, batch_id, user, batch_id, user))
             actionable_jobs = await cursor.fetchall()
             cancelled = [Job.from_record(job) for job in actionable_jobs if job['state'] == 'Cancelled']

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1019,12 +1019,14 @@ inner join (    select jobs.job_id
                   from jobs
             inner join {jobs_parents} on {jobs_parents}.batch_id = jobs.batch_id
                                      and {jobs_parents}.job_id = jobs.job_id
+            inner join jobs as parents on {jobs_parents}.batch_id = parents.batch_id
+                                      and {jobs_parents}.parent_id = parents.job_id
                  where jobs.state in ('Pending', 'Cancelled')
                    and jobs.batch_id = %s
               group by jobs.job_id
-                having count({jobs_parents}.state = 'Success') = count(*)
+                having count(parents.state = 'Success') = count(*)
                     or (jobs.always_run = TRUE and
-                        count({jobs_parents}.state in ('Success', 'Error', 'Failed', 'CancelledDone')) = count(*))
+                        count(parents.state in ('Success', 'Error', 'Failed', 'CancelledDone')) = count(*))
            ) as jobs2 on jobs2.job_id = jobs.job_id and jobs2.batch_id = jobs.batch_id
        set state = (case jobs.state when 'Pending' then 'Ready' else 'CancelledDone' end)
 ''', (batch_id,))

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1012,7 +1012,7 @@ async def _cancel_batch(batch_id, user):
      where jobs.batch_id = %s
        and jobs.state not in ('Cancelled', 'Error', 'Failed', 'Success', 'Pending')
        and jobs.always_run = FALSE
-''', (batch_id, user))
+''', (batch_id,))
             await cursor.execute('''
     update jobs
 inner join (    select jobs.id
@@ -1027,19 +1027,18 @@ inner join (    select jobs.id
                         count(`jobs.parents`.state in ('Success', 'Error', 'Failed', 'Cancelled')) = count(*))
            ) as jobs2 on jobs2.job_id = jobs.job_id and jobs2.batch_id = jobs.batch_id
        set state = 'Ready'
-''', (batch_id, user))
+''', (batch_id,))
             await cursor.execute('''
 update batch
    set cancelled = TRUE, closed = TRUE
  where batch.id = %s
-   and batch.user = %s
-''', (batch_id, user))
+''', (batch_id,))
             await cursor.execute('''
     select jobs.*
       from jobs
      where (jobs.state = 'Ready' or jobs.state = 'Cancelled')
        and jobs.batch_id = %s
-''', (batch_id, user))
+''', (batch_id,))
             actionable_jobs = await cursor.fetchall()
     for record in actionable_jobs:
         job = Job.from_record(record)

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1000,7 +1000,7 @@ async def _get_batch(batch_id, user):
 async def _cancel_batch(batch_id, user):
     async with db.pool.acquire() as conn:
         async with conn.cursor() as cursor:
-            jobs_parents = '`' + db.jobs_parents.name '`'
+            jobs_parents = '`' + db.jobs_parents.name + '`'
             await cursor.execute(f'''
     update jobs
 inner join batch on jobs.batch_id = batch.batch_id

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1003,7 +1003,7 @@ async def _cancel_batch(batch_id, user):
             jobs_parents = '`' + db.jobs_parents.name + '`'
             await cursor.execute(f'''
     update jobs
-inner join batch on jobs.batch_id = batch.batch_id
+inner join batch on jobs.batch_id = batch.id
        set jobs.state = 'Cancelled'
      where jobs.batch_id = %s
        and batch.user = %s
@@ -1031,14 +1031,15 @@ inner join (    select jobs.id
        set state = 'Ready'
 ''', (batch_id, user))
             await cursor.execute('''
-update batch set cancelled = TRUE, closed = TRUE
- where batch.batch_id = %s
+update batch
+   set cancelled = TRUE, closed = TRUE
+ where batch.id = %s
    and batch.user = %s
 ''', (batch_id, user))
             await cursor.execute('''
     select jobs.*
       from jobs
-inner join batch on jobs.batch_id = batch.batch_id
+inner join batch on jobs.batch_id = batch.id
      where (jobs.state = 'Ready' or jobs.state = 'Cancelled')
        and jobs.batch_id = %s
        and batch.user = %s

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1018,12 +1018,12 @@ async def _cancel_batch(batch_id, user):
     update jobs
 inner join (    select jobs.job_id, jobs.batch_id
                   from jobs
-            inner join `jobs-parents` on `jobs-parents`.batch_id = jobs.batch_id
-                                     and `jobs-parents`.job_id = jobs.job_id
-            inner join jobs as parents on `jobs-parents`.batch_id = parents.batch_id
-                                      and `jobs-parents`.parent_id = parents.job_id
+            inner join {jobs_parents} on {jobs_parents}.batch_id = jobs.batch_id
+                                     and {jobs_parents}.job_id = jobs.job_id
+            inner join jobs as parents on {jobs_parents}.batch_id = parents.batch_id
+                                      and {jobs_parents}.parent_id = parents.job_id
                  where jobs.state = 'Cancelled'
-                   and jobs.batch_id = batch_id
+                   and jobs.batch_id = %s
               group by jobs.batch_id, jobs.job_id, jobs.always_run
                 having count(parents.state = 'Success') = count(*)
                     or (jobs.always_run = true and

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1026,7 +1026,7 @@ inner join (    select jobs.job_id
                     or (jobs.always_run = TRUE and
                         count({jobs_parents}.state in ('Success', 'Error', 'Failed', 'CancelledDone')) = count(*))
            ) as jobs2 on jobs2.job_id = jobs.job_id and jobs2.batch_id = jobs.batch_id
-       set state = (case jobs.state when 'Pending' then 'Ready' else 'CancelledDone')
+       set state = (case jobs.state when 'Pending' then 'Ready' else 'CancelledDone' end case)
 ''', (batch_id,))
             await cursor.execute('''
 update batch
@@ -1036,7 +1036,7 @@ update batch
             await cursor.execute('''
     select jobs.*
       from jobs
-     where (jobs.state = 'Ready' or jobs.state = 'Cancelled' or jobs.state = 'CancelledDone')
+     where jobs.state in ('Ready', 'Cancelled', 'CancelledDone')
        and jobs.batch_id = %s
 ''', (batch_id,))
             actionable_jobs = await cursor.fetchall()

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1015,7 +1015,7 @@ async def _cancel_batch(batch_id, user):
 ''', (batch_id,))
             await cursor.execute(f'''
     update jobs
-inner join (    select jobs.job_id
+inner join (    select jobs.job_id, jobs.batch_id
                   from jobs
             inner join {jobs_parents} on {jobs_parents}.batch_id = jobs.batch_id
                                      and {jobs_parents}.job_id = jobs.job_id
@@ -1023,7 +1023,7 @@ inner join (    select jobs.job_id
                                       and {jobs_parents}.parent_id = parents.job_id
                  where jobs.state in ('Pending', 'Cancelled')
                    and jobs.batch_id = %s
-              group by jobs.job_id
+              group by jobs.batch_id, jobs.job_id, jobs.always_run
                 having count(parents.state = 'Success') = count(*)
                     or (jobs.always_run = TRUE and
                         count(parents.state in ('Success', 'Error', 'Failed', 'CancelledDone')) = count(*))

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1024,7 +1024,7 @@ inner join (    select jobs.job_id
               group by jobs.job_id
                 having count({jobs_parents}.state = 'Success') = count(*)
                     or (jobs.always_run = TRUE and
-                        count(`jobs.parents`.state in ('Success', 'Error', 'Failed', 'Cancelled')) = count(*))
+                        count(`{jobs_parents}`.state in ('Success', 'Error', 'Failed', 'Cancelled')) = count(*))
            ) as jobs2 on jobs2.job_id = jobs.job_id and jobs2.batch_id = jobs.batch_id
        set state = 'Ready'
 ''', (batch_id,))

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1015,7 +1015,7 @@ async def _cancel_batch(batch_id, user):
 ''', (batch_id,))
             await cursor.execute(f'''
     update jobs
-inner join (    select jobs.id
+inner join (    select jobs.job_id
                   from jobs
             inner join {jobs_parents} on {jobs_parents}.batch_id = jobs.batch_id
                                      and {jobs_parents}.job_id = jobs.job_id

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1026,7 +1026,7 @@ inner join (    select jobs.job_id
                     or (jobs.always_run = TRUE and
                         count({jobs_parents}.state in ('Success', 'Error', 'Failed', 'CancelledDone')) = count(*))
            ) as jobs2 on jobs2.job_id = jobs.job_id and jobs2.batch_id = jobs.batch_id
-       set state = (case jobs.state when 'Pending' then 'Ready' else 'CancelledDone' end case)
+       set state = (case jobs.state when 'Pending' then 'Ready' else 'CancelledDone' end)
 ''', (batch_id,))
             await cursor.execute('''
 update batch

--- a/batch/batch/globals.py
+++ b/batch/batch/globals.py
@@ -1,2 +1,2 @@
 
-complete_states = ('Cancelled', 'Error', 'Failed', 'Success')
+complete_states = ('Cancelled', 'CancelledDone', 'Error', 'Failed', 'Success')

--- a/batch/create-batch-tables.sql
+++ b/batch/create-batch-tables.sql
@@ -89,7 +89,6 @@ $$
 
 CREATE PROCEDURE propagate_cancelled (IN batch_id INT)
 BEGIN
-$$
 
 declare first int default true;
 

--- a/batch/create-batch-tables.sql
+++ b/batch/create-batch-tables.sql
@@ -90,7 +90,6 @@ $$
 CREATE PROCEDURE propagate_cancelled (IN batch_id INT)
 BEGIN
 $$
-delimiter $$
 
 declare first int default true;
 

--- a/batch/create-batch-tables.sql
+++ b/batch/create-batch-tables.sql
@@ -86,36 +86,3 @@ CREATE TRIGGER trigger_jobs_update AFTER UPDATE ON jobs
         END IF;
     END;
 $$
-
-CREATE PROCEDURE propagate_cancelled (IN batch_id INT)
-BEGIN
-
-declare first int default true;
-
-while first or row_count() > 0 do
-    set first = FALSE;
-    update jobs
-inner join (    select jobs.job_id, jobs.batch_id
-                  from jobs
-            inner join `jobs-parents` on `jobs-parents`.batch_id = jobs.batch_id
-                                     and `jobs-parents`.job_id = jobs.job_id
-            inner join jobs as parents on `jobs-parents`.batch_id = parents.batch_id
-                                      and `jobs-parents`.parent_id = parents.job_id
-                 where jobs.state = 'Cancelled'
-                   and jobs.batch_id = batch_id
-              group by jobs.batch_id, jobs.job_id, jobs.always_run
-                having count(parents.state = 'Success') = count(*)
-                    or (jobs.always_run = true and
-                        count(parents.state in ('Success', 'Error', 'Failed', 'CancelledDone')) = count(*))
-           ) as jobs2 on jobs2.job_id = jobs.job_id and jobs2.batch_id = jobs.batch_id
-       set state = (case jobs.always_run when true then 'Ready' else 'CancelledDone' end);
-end while;
-
-END;
-
-$$
-
-DELIMITER ;
-
-GRANT EXECUTE ON PROCEDURE propagate_cancelled TO ''@'%';
-flush privileges;

--- a/batch/create-batch-tables.sql
+++ b/batch/create-batch-tables.sql
@@ -89,10 +89,12 @@ $$
 
 CREATE PROCEDURE propagate_cancelled (IN batch_id INT)
 BEGIN
+$$
+delimiter $$
 
-declare first int default TRUE;
+declare first int default true;
 
-while first or ROW_COUNT() > 0 do
+while first or row_count() > 0 do
     set first = FALSE;
     update jobs
 inner join (    select jobs.job_id, jobs.batch_id
@@ -105,10 +107,10 @@ inner join (    select jobs.job_id, jobs.batch_id
                    and jobs.batch_id = batch_id
               group by jobs.batch_id, jobs.job_id, jobs.always_run
                 having count(parents.state = 'Success') = count(*)
-                    or (jobs.always_run = TRUE and
+                    or (jobs.always_run = true and
                         count(parents.state in ('Success', 'Error', 'Failed', 'CancelledDone')) = count(*))
            ) as jobs2 on jobs2.job_id = jobs.job_id and jobs2.batch_id = jobs.batch_id
-       set state = (case jobs.always_run when TRUE then 'Ready' else 'CancelledDone' end);
+       set state = (case jobs.always_run when true then 'Ready' else 'CancelledDone' end);
 end while;
 
 END;
@@ -116,3 +118,6 @@ END;
 $$
 
 DELIMITER ;
+
+GRANT EXECUTE ON PROCEDURE propagate_cancelled TO ''@'%';
+flush privileges;

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -116,7 +116,7 @@ def test_cancel_left_after_tail(client):
         assert status['state'] == 'Success'
         assert status['exit_code']['main'] == 0
     for node in [left, tail]:
-        assert node.status()['state'] == 'Cancelled'
+        assert node.status()['state'] == 'CancelledDone'
 
 
 def test_callback(client):

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -93,7 +93,7 @@ def test_cancel_tail(client):
         status = node.status()
         assert status['state'] == 'Success'
         assert status['exit_code']['main'] == 0
-    assert tail.status()['state'] == 'Cancelled'
+    assert tail.status()['state'] == 'CancelledDone'
 
 
 def test_cancel_left_after_tail(client):

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -782,6 +782,7 @@ CREATE DATABASE \\`{self._name}\\`;
 
 CREATE USER '{self.admin_username}'@'%' IDENTIFIED BY '$ADMIN_PASSWORD';
 GRANT ALL ON \\`{self._name}\\`.* TO '{self.admin_username}'@'%';
+GRANT GRANT OPTION \\`{self._name}\\`.* TO '{self.admin_username}'@'%';
 
 CREATE USER '{self.user_username}'@'%' IDENTIFIED BY '$USER_PASSWORD';
 GRANT SELECT, INSERT, UPDATE, DELETE ON \\`{self._name}\\`.* TO '{self.user_username}'@'%';

--- a/hail/python/hailtop/batch_client/globals.py
+++ b/hail/python/hailtop/batch_client/globals.py
@@ -1,2 +1,2 @@
 
-complete_states = ('Cancelled', 'Error', 'Failed', 'Success')
+complete_states = ('Cancelled', 'CancelledDone', 'Error', 'Failed', 'Success')


### PR DESCRIPTION
I think this is the direction we need to head with Batch. Mapping DB things to objects and then using recursive functions over the graph is not going to scale.

This uses one database call to:
- set the state of every non-always-run, incomplete job in the given batch to `Cancelled`
- move the state from `Running` to `Pending` for every
  - job whose parents all succeeded, and every
  - always-run job whose parents all completed
- get a list of every `Ready` or `Cancelled` job
- update the batch to cancelled and closed

Then uses a loop to delete k8s resources and create pods, as appropriate for the given job.

I think we can go further! We should make our k8s requests in parallel (I don't see anyway to delete a *list* of jobs in k8s [only to delete a whole namespace]) and we should avoid retrieving every column from the database. We only need a few things to `create_pod` or `delete_k8s_resources`.

cc: @johnc1231 