### PR TITLE
[hail][performance] Fix literals lazy decoding

### DIFF
--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -474,7 +474,7 @@ object HailContext {
   def readSplitRowsPartition(
     mkRowsDec: (InputStream) => Decoder,
     mkEntriesDec: (InputStream) => Decoder,
-    mkInserter: (Int) => (is.hail.asm4s.AsmFunction5[is.hail.annotations.Region,Long,Boolean,Long,Boolean,Long])
+    mkInserter: (Int, Region) => (is.hail.asm4s.AsmFunction5[is.hail.annotations.Region,Long,Boolean,Long,Boolean,Long])
   )(ctx: RVDContext,
     isRows: InputStream,
     isEntries: InputStream,
@@ -495,7 +495,7 @@ object HailContext {
     private val rowsIdxField = rowsOffsetField.map { f => idxr.get.annotationType.asInstanceOf[TStruct].fieldIdx(f) }
     private val entriesIdxField = entriesOffsetField.map { f => idxr.get.annotationType.asInstanceOf[TStruct].fieldIdx(f) }
 
-    private val inserter = mkInserter(partIdx)
+    private val inserter = mkInserter(partIdx, ctx.freshRegion)
     private val rows = try {
       if (idx.map(_.hasNext).getOrElse(true)) {
         val dec = mkRowsDec(trackedRowsIn)

--- a/hail/src/main/scala/is/hail/backend/Backend.scala
+++ b/hail/src/main/scala/is/hail/backend/Backend.scala
@@ -36,10 +36,10 @@ abstract class Backend {
       ir.typ match {
         case TVoid =>
           val (_, f) = timer.time(Compile[Unit](ir), "JVM compile")
-          timer.time(f(0)(region), "Runtime")
+          timer.time(f(0, region)(region), "Runtime")
         case _ =>
           val (pt: PTuple, f) = timer.time(Compile[Long](MakeTuple(FastSeq(ir))), "JVM compile")
-          timer.time(SafeRow(pt, region, f(0)(region)).get(0), "Runtime")
+          timer.time(SafeRow(pt, region, f(0, region)(region)).get(0), "Runtime")
       }
     }
 
@@ -107,7 +107,7 @@ abstract class Backend {
 
     Region.scoped { region =>
       val (pt: PTuple, f) = Compile[Long](MakeTuple(FastSeq(ir)))
-      (pt.parsableString(), codec.encode(pt, region, f(0)(region)))
+      (pt.parsableString(), codec.encode(pt, region, f(0, region)(region)))
     }
   }
 

--- a/hail/src/main/scala/is/hail/backend/BackendUtils.scala
+++ b/hail/src/main/scala/is/hail/backend/BackendUtils.scala
@@ -4,13 +4,13 @@ import is.hail.HailContext
 import is.hail.annotations.Region
 import is.hail.asm4s._
 
-class BackendUtils(mods: Array[(String, Int => AsmFunction3[Region, Array[Byte], Array[Byte], Array[Byte]])]) {
+class BackendUtils(mods: Array[(String, (Int, Region) => AsmFunction3[Region, Array[Byte], Array[Byte], Array[Byte]])]) {
 
   type F = AsmFunction3[Region, Array[Byte], Array[Byte], Array[Byte]]
 
-  private[this] val loadedModules: Map[String, Int => F] = mods.toMap
+  private[this] val loadedModules: Map[String, (Int, Region) => F] = mods.toMap
 
-  def getModule(id: String): Int => F = loadedModules(id)
+  def getModule(id: String): (Int, Region) => F = loadedModules(id)
 
   def collectDArray(modID: String, contexts: Array[Array[Byte]], globals: Array[Byte]): Array[Array[Byte]] = {
     if (contexts.isEmpty)
@@ -23,7 +23,7 @@ class BackendUtils(mods: Array[(String, Int => AsmFunction3[Region, Array[Byte],
     backend.parallelizeAndComputeWithIndex(contexts) { (ctx, i) =>
       val gs = globalsBC.value
       Region.scoped { region =>
-        val res = f(i)(region, ctx, gs)
+        val res = f(i, region)(region, ctx, gs)
         res
       }
     }

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -11,7 +11,7 @@ import scala.reflect.{ClassTag, classTag}
 
 case class CodeCacheKey(aggSigs: IndexedSeq[AggSignature], args: Seq[(String, PType)], nSpecialArgs: Int, body: IR)
 
-case class CodeCacheValue(typ: PType, f: Int => Any)
+case class CodeCacheValue(typ: PType, f: (Int, Region) => Any)
 
 object Compile {
   private[this] val codeCache: Cache[CodeCacheKey, CodeCacheValue] = new Cache(50)
@@ -22,14 +22,14 @@ object Compile {
     body: IR,
     nSpecialArgs: Int,
     optimize: Boolean
-  ): (PType, Int => F) = {
+  ): (PType, (Int, Region) => F) = {
     val normalizeNames = new NormalizeNames(_.toString)
     val normalizedBody = normalizeNames(body,
       Env(args.map { case (n, _, _) => n -> n }: _*))
     val k = CodeCacheKey(FastIndexedSeq[AggSignature](), args.map { case (n, pt, _) => (n, pt) }, nSpecialArgs, normalizedBody)
     codeCache.get(k) match {
       case Some(v) => 
-        return (v.typ, v.f.asInstanceOf[Int => F])
+        return (v.typ, v.f.asInstanceOf[(Int, Region) => F])
       case None =>
     }
 
@@ -59,7 +59,7 @@ object Compile {
     body: IR,
     nSpecialArgs: Int,
     optimize: Boolean
-  ): (PType, Int => F) = {
+  ): (PType, (Int, Region) => F) = {
     assert(args.forall { case (_, t, ct) => TypeToIRIntermediateClassTag(t.virtualType) == ct })
 
     val ab = new ArrayBuilder[MaybeGenericTypeInfo[_]]()
@@ -76,7 +76,7 @@ object Compile {
     Compile[F, R](args, argTypeInfo, body, nSpecialArgs, optimize)
   }
 
-  def apply[R: TypeInfo : ClassTag](body: IR): (PType, Int => AsmFunction1[Region, R]) = {
+  def apply[R: TypeInfo : ClassTag](body: IR): (PType, (Int, Region) => AsmFunction1[Region, R]) = {
     apply[AsmFunction1[Region, R], R](FastSeq[(String, PType, ClassTag[_])](), body, 1, optimize = true)
   }
 
@@ -84,7 +84,7 @@ object Compile {
     name0: String,
     typ0: PType,
     body: IR,
-    optimize: Boolean): (PType, Int => AsmFunction3[Region, T0, Boolean, R]) = {
+    optimize: Boolean): (PType, (Int, Region) => AsmFunction3[Region, T0, Boolean, R]) = {
 
     apply[AsmFunction3[Region, T0, Boolean, R], R](FastSeq((name0, typ0, classTag[T0])), body, 1, optimize)
   }
@@ -92,7 +92,7 @@ object Compile {
   def apply[T0: ClassTag, R: TypeInfo : ClassTag](
     name0: String,
     typ0: PType,
-    body: IR): (PType, Int => AsmFunction3[Region, T0, Boolean, R]) = {
+    body: IR): (PType, (Int, Region) => AsmFunction3[Region, T0, Boolean, R]) = {
 
     apply[AsmFunction3[Region, T0, Boolean, R], R](FastSeq((name0, typ0, classTag[T0])), body, 1, optimize = true)
   }
@@ -102,7 +102,7 @@ object Compile {
     typ0: PType,
     name1: String,
     typ1: PType,
-    body: IR): (PType, Int => AsmFunction5[Region, T0, Boolean, T1, Boolean, R]) = {
+    body: IR): (PType, (Int, Region) => AsmFunction5[Region, T0, Boolean, T1, Boolean, R]) = {
 
     apply[AsmFunction5[Region, T0, Boolean, T1, Boolean, R], R](FastSeq((name0, typ0, classTag[T0]), (name1, typ1, classTag[T1])), body, 1, optimize = true)
   }
@@ -119,7 +119,7 @@ object Compile {
     name2: String,
     typ2: PType,
     body: IR
-  ): (PType, Int => AsmFunction7[Region, T0, Boolean, T1, Boolean, T2, Boolean, R]) = {
+  ): (PType, (Int, Region) => AsmFunction7[Region, T0, Boolean, T1, Boolean, T2, Boolean, R]) = {
     apply[AsmFunction7[Region, T0, Boolean, T1, Boolean, T2, Boolean, R], R](FastSeq(
       (name0, typ0, classTag[T0]),
       (name1, typ1, classTag[T1]),
@@ -139,7 +139,7 @@ object Compile {
     name2: String, typ2: PType,
     name3: String, typ3: PType,
     body: IR
-  ): (PType, Int => AsmFunction9[Region, T0, Boolean, T1, Boolean, T2, Boolean, T3, Boolean, R]) = {
+  ): (PType, (Int, Region) => AsmFunction9[Region, T0, Boolean, T1, Boolean, T2, Boolean, T3, Boolean, R]) = {
     apply[AsmFunction9[Region, T0, Boolean, T1, Boolean, T2, Boolean, T3, Boolean, R], R](FastSeq(
       (name0, typ0, classTag[T0]),
       (name1, typ1, classTag[T1]),
@@ -164,7 +164,7 @@ object Compile {
     name4: String, typ4: PType,
     name5: String, typ5: PType,
     body: IR
-  ): (PType, Int => AsmFunction13[Region, T0, Boolean, T1, Boolean, T2, Boolean, T3, Boolean, T4, Boolean, T5, Boolean, R]) = {
+  ): (PType, (Int, Region) => AsmFunction13[Region, T0, Boolean, T1, Boolean, T2, Boolean, T3, Boolean, T4, Boolean, T5, Boolean, R]) = {
 
     apply[AsmFunction13[Region, T0, Boolean, T1, Boolean, T2, Boolean, T3, Boolean, T4, Boolean, T5, Boolean, R], R](FastSeq(
       (name0, typ0, classTag[T0]),
@@ -188,14 +188,14 @@ object CompileWithAggregators2 {
     body: IR,
     nSpecialArgs: Int,
     optimize: Boolean
-  ): (PType, Int => (F with FunctionWithAggRegion)) = {
+  ): (PType, (Int, Region) => (F with FunctionWithAggRegion)) = {
     val normalizeNames = new NormalizeNames(_.toString)
     val normalizedBody = normalizeNames(body,
       Env(args.map { case (n, _, _) => n -> n }: _*))
     val k = CodeCacheKey(aggSigs.toFastIndexedSeq, args.map { case (n, pt, _) => (n, pt) }, nSpecialArgs, normalizedBody)
     codeCache.get(k) match {
       case Some(v) =>
-        return (v.typ, v.f.asInstanceOf[Int => (F with FunctionWithAggRegion)])
+        return (v.typ, v.f.asInstanceOf[(Int, Region) => (F with FunctionWithAggRegion)])
       case None =>
     }
 
@@ -217,7 +217,7 @@ object CompileWithAggregators2 {
 
     val f = fb.resultWithIndex()
     codeCache += k -> CodeCacheValue(ir.pType, f)
-    (ir.pType, f.asInstanceOf[Int => (F with FunctionWithAggRegion)])
+    (ir.pType, f.asInstanceOf[(Int, Region) => (F with FunctionWithAggRegion)])
   }
 
   def apply[F >: Null : TypeInfo, R: TypeInfo : ClassTag](
@@ -226,7 +226,7 @@ object CompileWithAggregators2 {
     body: IR,
     nSpecialArgs: Int,
     optimize: Boolean
-  ): (PType, Int => (F with FunctionWithAggRegion)) = {
+  ): (PType, (Int, Region) => (F with FunctionWithAggRegion)) = {
     assert(args.forall { case (_, t, ct) => TypeToIRIntermediateClassTag(t.virtualType) == ct })
 
     val ab = new ArrayBuilder[MaybeGenericTypeInfo[_]]()
@@ -246,7 +246,7 @@ object CompileWithAggregators2 {
   def apply[T0: ClassTag, R: TypeInfo : ClassTag](
     aggSigs: Array[AggSignature],
     name0: String, typ0: PType,
-    body: IR): (PType, Int => AsmFunction3[Region, T0, Boolean, R] with FunctionWithAggRegion) = {
+    body: IR): (PType, (Int, Region) => AsmFunction3[Region, T0, Boolean, R] with FunctionWithAggRegion) = {
 
     apply[AsmFunction3[Region, T0, Boolean, R], R](aggSigs, FastSeq((name0, typ0, classTag[T0])), body, 1, optimize = true)
   }
@@ -255,14 +255,14 @@ object CompileWithAggregators2 {
     aggSigs: Array[AggSignature],
     name0: String, typ0: PType,
     name1: String, typ1: PType,
-    body: IR): (PType, Int => (AsmFunction5[Region, T0, Boolean, T1, Boolean, R] with FunctionWithAggRegion)) = {
+    body: IR): (PType, (Int, Region) => (AsmFunction5[Region, T0, Boolean, T1, Boolean, R] with FunctionWithAggRegion)) = {
 
     apply[AsmFunction5[Region, T0, Boolean, T1, Boolean, R], R](aggSigs, FastSeq((name0, typ0, classTag[T0]), (name1, typ1, classTag[T1])), body, 1, optimize = true)
   }
 }
 
 object CompileWithAggregators {
-  type Compiler[F] = (IR) => (PType, Int => F)
+  type Compiler[F] = (IR) => (PType, (Int, Region) => F)
   type IRAggFun1[T0] =
     AsmFunction4[Region, Array[RegionValueAggregator], T0, Boolean, Unit]
   type IRAggFun2[T0, T1] =
@@ -326,7 +326,7 @@ object CompileWithAggregators {
     body: IR, aggResultName: String,
     transformInitOp: (Int, IR) => IR,
     transformSeqOp: (Int, IR) => IR
-  ): (Array[RegionValueAggregator], Int => F0, Int => F1, PType, IR) = {
+  ): (Array[RegionValueAggregator], (Int, Region) => F0, (Int, Region) => F1, PType, IR) = {
     val (rvAggs, (initOpIR, compileInitOp),
       (seqOpIR, compileSeqOp),
       aggResultType, postAggIR
@@ -354,8 +354,8 @@ object CompileWithAggregators {
     transformInitOp: (Int, IR) => IR,
     transformSeqOp: (Int, IR) => IR
   ): (Array[RegionValueAggregator],
-    Int => IRAggFun1[T0],
-    Int => IRAggFun2[S0, S1],
+    (Int, Region) => IRAggFun1[T0],
+    (Int, Region) => IRAggFun2[S0, S1],
     PType,
     IR) = {
     val args = FastSeq((name0, typ0, classTag[T0]))
@@ -382,8 +382,8 @@ object CompileWithAggregators {
     transformInitOp: (Int, IR) => IR,
     transformSeqOp: (Int, IR) => IR
   ): (Array[RegionValueAggregator],
-    Int => IRAggFun2[T0, T1],
-    Int => IRAggFun3[S0, S1, S2],
+    (Int, Region) => IRAggFun2[T0, T1],
+    (Int, Region) => IRAggFun3[S0, S1, S2],
     PType,
     IR) = {
     val args = FastSeq(
@@ -411,8 +411,8 @@ object CompileWithAggregators {
     transformInitOp: (Int, IR) => IR,
     transformSeqOp: (Int, IR) => IR
   ): (Array[RegionValueAggregator],
-    Int => IRAggFun1[T0],
-    Int => IRAggFun3[S0, S1, S2],
+    (Int, Region) => IRAggFun1[T0],
+    (Int, Region) => IRAggFun3[S0, S1, S2],
     PType,
     IR) = {
     val args = FastSeq((name0, typ0, classTag[T0]))
@@ -442,8 +442,8 @@ object CompileWithAggregators {
     transformInitOp: (Int, IR) => IR,
     transformSeqOp: (Int, IR) => IR
   ): (Array[RegionValueAggregator],
-    Int => IRAggFun2[T0, T1],
-    Int => IRAggFun4[S0, S1, S2, S3],
+    (Int, Region) => IRAggFun2[T0, T1],
+    (Int, Region) => IRAggFun4[S0, S1, S2, S3],
     PType,
     IR) = {
     val args = FastSeq(

--- a/hail/src/main/scala/is/hail/expr/ir/CompileAndEvaluate.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/CompileAndEvaluate.scala
@@ -97,7 +97,7 @@ object CompileAndEvaluate {
         rvb.addAnnotation(envType, envValue)
         val envOffset = rvb.end()
 
-        val resultOff = f(0)(region,
+        val resultOff = f(0, region)(region,
           ncOffset, ncValue == null,
           argsInOffset, argsInValue == null,
           envOffset, envValue == null)

--- a/hail/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExtractAggregators.scala
@@ -64,7 +64,7 @@ object ExtractAggregators {
   private def unstagedNewAggregator(ir: ApplyAggOp): RegionValueAggregator = {
     val fb = EmitFunctionBuilder[Region, RegionValueAggregator]
     fb.emit(newAggregator(fb, ir))
-    Region.scoped(fb.resultWithIndex()(0)(_))
+    Region.scoped(r => fb.resultWithIndex()(0, r)(r))
   }
 
   def apply(ir: IR, resultName: String = "AGGR"): ExtractedAggregators = {

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -807,8 +807,9 @@ object Interpret {
           }
 
           value.rvd.aggregateWithPartitionOp(rvAggs, (i, ctx) => {
-            val globalsOffset = globalsBc.value.readRegionValue(ctx.freshRegion)
-            val seqOpsFunction = seqOps(i, ctx.r)
+            val partRegion =  ctx.freshRegion
+            val globalsOffset = globalsBc.value.readRegionValue(partRegion)
+            val seqOpsFunction = seqOps(i, partRegion)
             (globalsOffset, seqOpsFunction)
           })({ case ((globalsOffset, seqOpsFunction), comb, rv) =>
             seqOpsFunction(rv.region, comb, globalsOffset, false, rv.offset, false)

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -718,16 +718,16 @@ object Interpret {
         }
       case ir: AbstractApplyNode[_] =>
         val argTuple = PType.canonical(TTuple(ir.args.map(_.typ): _*)).asInstanceOf[PTuple]
-        val f = functionMemo.getOrElseUpdate(ir, {
-          val wrappedArgs: IndexedSeq[BaseIR] = ir.args.zipWithIndex.map { case (x, i) =>
-            GetTupleElement(Ref("in", argTuple.virtualType), i)
-          }.toFastIndexedSeq
-          val wrappedIR = Copy(ir, wrappedArgs)
-
-          val (_, makeFunction) = Compile[Long, Long]("in", argTuple, MakeTuple(List(wrappedIR)), optimize = false)
-          makeFunction(0)
-        })
         Region.scoped { region =>
+          val f = functionMemo.getOrElseUpdate(ir, {
+            val wrappedArgs: IndexedSeq[BaseIR] = ir.args.zipWithIndex.map { case (x, i) =>
+              GetTupleElement(Ref("in", argTuple.virtualType), i)
+            }.toFastIndexedSeq
+            val wrappedIR = Copy(ir, wrappedArgs)
+
+            val (_, makeFunction) = Compile[Long, Long]("in", argTuple, MakeTuple(List(wrappedIR)), optimize = false)
+            makeFunction(0, region)
+          })
           val rvb = new RegionValueBuilder()
           rvb.set(region)
           rvb.start(argTuple)
@@ -799,7 +799,7 @@ object Interpret {
           val rvb: RegionValueBuilder = new RegionValueBuilder()
           rvb.set(ctx.r)
 
-          initOps(0)(ctx.r, rvAggs, globalsOffset, false)
+          initOps(0, ctx.r)(ctx.r, rvAggs, globalsOffset, false)
 
           val combOp = { (rvAggs1: Array[RegionValueAggregator], rvAggs2: Array[RegionValueAggregator]) =>
             rvAggs1.zip(rvAggs2).foreach { case (rvAgg1, rvAgg2) => rvAgg1.combOp(rvAgg2) }
@@ -808,7 +808,7 @@ object Interpret {
 
           value.rvd.aggregateWithPartitionOp(rvAggs, (i, ctx) => {
             val globalsOffset = globalsBc.value.readRegionValue(ctx.freshRegion)
-            val seqOpsFunction = seqOps(i)
+            val seqOpsFunction = seqOps(i, ctx.r)
             (globalsOffset, seqOpsFunction)
           })({ case ((globalsOffset, seqOpsFunction), comb, rv) =>
             seqOpsFunction(rv.region, comb, globalsOffset, false, rv.offset, false)
@@ -825,7 +825,7 @@ object Interpret {
         rvb.endTuple()
         val aggResultsOffset = rvb.end()
 
-        val resultOffset = f(0)(ctx.r, globalsOffset, false, aggResultsOffset, false)
+        val resultOffset = f(0, ctx.r)(ctx.r, globalsOffset, false, aggResultsOffset, false)
 
         SafeRow(coerce[PTuple](t), ctx.r, resultOffset).get(0)
       case x: ReadPartition =>

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -956,9 +956,10 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
       scanInitOps(0, ctx.r)(ctx.r, scanAggs, tv.globals.value.offset, false)
 
       val scannedAggs = SpillingCollectIterator(tv.rvd.mapPartitionsWithIndex { (i, ctx, it) =>
-        val globals = if (scanSeqNeedsGlobals) globalsBc.value.readRegionValue(ctx.freshRegion) else 0L
+        val partRegion = ctx.freshRegion
+        val globals = if (scanSeqNeedsGlobals) globalsBc.value.readRegionValue(partRegion) else 0L
 
-        val scanSeqOpF = scanSeqOps(i, ctx.r)
+        val scanSeqOpF = scanSeqOps(i, partRegion)
         it.foreach { rv =>
           scanSeqOpF(rv.region, scanAggs, globals, false, rv.offset, false)
           ctx.region.clear()

--- a/hail/src/main/scala/is/hail/utils/Graph.scala
+++ b/hail/src/main/scala/is/hail/utils/Graph.scala
@@ -79,7 +79,7 @@ object Graph {
           rvb.endTuple()
           val rOffset = rvb.end()
 
-          val resultOffset = f(0)(region, lOffset, false, rOffset, false)
+          val resultOffset = f(0, region)(region, lOffset, false, rOffset, false)
           SafeRow(t.asInstanceOf[PBaseStruct], region, resultOffset).get(0).asInstanceOf[Long]
         }
       }

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -284,8 +284,8 @@ object TestUtils {
           // aggregate
           i = 0
           rvAggs.foreach(_.clear())
-          initOps(0)(region, rvAggs, argsOff, false)
-          var seqOpF = seqOps(0)
+          initOps(0, region)(region, rvAggs, argsOff, false)
+          var seqOpF = seqOps(0, region)
           while (i < (aggElements.length / 2)) {
             // FIXME use second region for elements
             rvb.start(aggType.physicalType)
@@ -299,8 +299,8 @@ object TestUtils {
 
           val rvAggs2 = rvAggs.map(_.newInstance())
           rvAggs2.foreach(_.clear())
-          initOps(0)(region, rvAggs2, argsOff, false)
-          seqOpF = seqOps(1)
+          initOps(0, region)(region, rvAggs2, argsOff, false)
+          seqOpF = seqOps(1, region)
           while (i < aggElements.length) {
             // FIXME use second region for elements
             rvb.start(aggType.physicalType)
@@ -325,7 +325,7 @@ object TestUtils {
           rvb.endTuple()
           val aggResultsOff = rvb.end()
 
-          val resultOff = f(0)(region, aggResultsOff, false, argsOff, false)
+          val resultOff = f(0, region)(region, aggResultsOff, false, argsOff, false)
           SafeRow(resultType.asInstanceOf[TBaseStruct].physicalType, region, resultOff).get(0)
         }
 
@@ -347,7 +347,7 @@ object TestUtils {
           rvb.endTuple()
           val argsOff = rvb.end()
 
-          val resultOff = f(0)(region, argsOff, false)
+          val resultOff = f(0, region)(region, argsOff, false)
           SafeRow(resultType.asInstanceOf[TBaseStruct].physicalType, region, resultOff).get(0)
         }
     }

--- a/hail/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
@@ -474,7 +474,7 @@ class StagedRegionValueSuite extends HailSuite {
               EmitRegion.default(fb.apply_method),
               t.physicalType,
               fb.getArg[Long](2).load()))
-          val copyF = fb.resultWithIndex()(0)
+          val copyF = fb.resultWithIndex()(0, region)
           val newOff = copyF(region, src)
 
 

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -140,7 +140,7 @@ class Aggregators2Suite extends HailSuite {
 
     Region.scoped { region =>
       val offset = ScalaToRegionValue(region, arrayType.virtualType, firstCol)
-      val res = aggf(0)(region, offset)
+      val res = aggf(0, region)(region, offset)
       assert(SafeRow(resType, region, res) == expected(0))
     }
   }
@@ -166,7 +166,7 @@ class Aggregators2Suite extends HailSuite {
 
     Region.scoped { region =>
       val offset = ScalaToRegionValue(region, streamType.virtualType, value)
-      val res = aggf(0)(region, offset)
+      val res = aggf(0, region)(region, offset)
       assert(SafeRow(resType, region, res) == Row(expected))
     }
   }
@@ -229,7 +229,7 @@ class Aggregators2Suite extends HailSuite {
 
     Region.scoped { region =>
       val offset = ScalaToRegionValue(region, TArray(streamType.virtualType), partitioned)
-      val res = aggf(0)(region, offset)
+      val res = aggf(0, region)(region, offset)
       assert(SafeRow(resType, region, res) == Row(expected))
     }
   }

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -27,7 +27,7 @@ class OrderingSuite extends HailSuite {
     inner + 1
   }
 
-  def getStagedOrderingFunction[T: TypeInfo](t: Type, comp: String): AsmFunction3[Region, Long, Long, T] = {
+  def getStagedOrderingFunction[T: TypeInfo](t: Type, comp: String, r: Region): AsmFunction3[Region, Long, Long, T] = {
     val fb = EmitFunctionBuilder[Region, Long, Long, T]
     val stagedOrdering = t.physicalType.codeOrdering(fb.apply_method)
     val cregion: Code[Region] = fb.getArg[Region](1)
@@ -41,7 +41,7 @@ class OrderingSuite extends HailSuite {
       case "gt" => fb.emit(stagedOrdering.gt(cregion, (const(false), cv1), cregion, (const(false), cv2)))
       case "gteq" => fb.emit(stagedOrdering.gteq(cregion, (const(false), cv1), cregion, (const(false), cv2)))
     }
-    fb.resultWithIndex()(0)
+    fb.resultWithIndex()(0, r)
   }
 
   def addTupledArgsToRegion(region: Region, args: (Type, Annotation)*): Array[Long] = {
@@ -74,34 +74,34 @@ class OrderingSuite extends HailSuite {
         val v2 = rvb.end()
 
         val compare = java.lang.Integer.signum(t.ordering.compare(a1, a2))
-        val fcompare = getStagedOrderingFunction[Int](t, "compare")
+        val fcompare = getStagedOrderingFunction[Int](t, "compare", region)
         val result = java.lang.Integer.signum(fcompare(region, v1, v2))
 
         assert(result == compare, s"compare expected: $compare vs $result")
 
 
         val equiv = t.ordering.equiv(a1, a2)
-        val fequiv = getStagedOrderingFunction[Boolean](t, "equiv")
+        val fequiv = getStagedOrderingFunction[Boolean](t, "equiv", region)
 
         assert(fequiv(region, v1, v2) == equiv, s"equiv expected: $equiv")
 
         val lt = t.ordering.lt(a1, a2)
-        val flt = getStagedOrderingFunction[Boolean](t, "lt")
+        val flt = getStagedOrderingFunction[Boolean](t, "lt", region)
 
         assert(flt(region, v1, v2) == lt, s"lt expected: $lt")
 
         val lteq = t.ordering.lteq(a1, a2)
-        val flteq = getStagedOrderingFunction[Boolean](t, "lteq")
+        val flteq = getStagedOrderingFunction[Boolean](t, "lteq", region)
 
         assert(flteq(region, v1, v2) == lteq, s"lteq expected: $lteq")
 
         val gt = t.ordering.gt(a1, a2)
-        val fgt = getStagedOrderingFunction[Boolean](t, "gt")
+        val fgt = getStagedOrderingFunction[Boolean](t, "gt", region)
 
         assert(fgt(region, v1, v2) == gt, s"gt expected: $gt")
 
         val gteq = t.ordering.gteq(a1, a2)
-        val fgteq = getStagedOrderingFunction[Boolean](t, "gteq")
+        val fgteq = getStagedOrderingFunction[Boolean](t, "gteq", region)
 
         assert(fgteq(region, v1, v2) == gteq, s"gteq expected: $gteq")
       }
@@ -250,7 +250,7 @@ class OrderingSuite extends HailSuite {
 
         val asArray = SafeIndexedSeq(TArray(t).physicalType, region, soff)
 
-        val f = fb.resultWithIndex()(0)
+        val f = fb.resultWithIndex()(0, region)
         val closestI = f(region, soff, eoff)
         val maybeEqual = asArray(closestI)
 
@@ -292,7 +292,7 @@ class OrderingSuite extends HailSuite {
 
         val asArray = SafeIndexedSeq(PArray(pDict.elementType), region, soff)
 
-        val f = fb.resultWithIndex()(0)
+        val f = fb.resultWithIndex()(0, region)
         val closestI = f(region, soff, eoff)
 
         if (closestI == asArray.length) {

--- a/hail/src/test/scala/is/hail/variant/ReferenceGenomeSuite.scala
+++ b/hail/src/test/scala/is/hail/variant/ReferenceGenomeSuite.scala
@@ -2,6 +2,7 @@ package is.hail.variant
 
 import java.io.FileNotFoundException
 
+import is.hail.annotations.Region
 import is.hail.asm4s.FunctionBuilder
 import is.hail.check.Prop._
 import is.hail.check.Properties
@@ -166,8 +167,10 @@ class ReferenceGenomeSuite extends HailSuite {
     val rgfield = fb.newLazyField(grch38.codeSetup(fb))
     fb.emit(rgfield.invoke[String, Boolean]("isValidContig", fb.getArg[String](1)))
 
-    val f = fb.resultWithIndex()(0)
-    assert(f("X") == grch38.isValidContig("X"))
+    Region.scoped { r =>
+      val f = fb.resultWithIndex()(0, r)
+      assert(f("X") == grch38.isValidContig("X"))
+    }
   }
 
   @Test def testSerializeWithFastaOnFB() {
@@ -183,8 +186,10 @@ class ReferenceGenomeSuite extends HailSuite {
     val rgfield = fb.newLazyField(rg.codeSetup(fb))
     fb.emit(rgfield.invoke[String, Int, Int, Int, String]("getSequence", fb.getArg[String](1), fb.getArg[Int](2), fb.getArg[Int](3), fb.getArg[Int](4)))
 
-    val f = fb.resultWithIndex()(0)
-    assert(f("a", 25, 0, 5) == rg.getSequence("a", 25, 0, 5))
+    Region.scoped { r =>
+      val f = fb.resultWithIndex()(0, r)
+      assert(f("a", 25, 0, 5) == rg.getSequence("a", 25, 0, 5))
+    }
   }
 
   @Test def testSerializeWithLiftoverOnFB() {
@@ -197,8 +202,10 @@ class ReferenceGenomeSuite extends HailSuite {
     val rgfield = fb.newLazyField(grch37.codeSetup(fb))
     fb.emit(rgfield.invoke[String, Locus, Double, (Locus, Boolean)]("liftoverLocus", fb.getArg[String](1), fb.getArg[Locus](2), fb.getArg[Double](3)))
 
-    val f = fb.resultWithIndex()(0)
-    assert(f("GRCh38", Locus("20", 60001), 0.95) == grch37.liftoverLocus("GRCh38", Locus("20", 60001), 0.95))
-    grch37.removeLiftover("GRCh38")
+    Region.scoped { r =>
+      val f = fb.resultWithIndex()(0, r)
+      assert(f("GRCh38", Locus("20", 60001), 0.95) == grch37.liftoverLocus("GRCh38", Locus("20", 60001), 0.95))
+      grch37.removeLiftover("GRCh38")
+    }
   }
 }


### PR DESCRIPTION
Cloud providers don't want you to know this one weird trick to save
thousands on your compute bill

This PR:
```
Running matrix_table_array_arithmetic...
    run 1: 18.28
    run 2: 15.26
    run 3: 14.76
```

Master:
```
Running matrix_table_array_arithmetic...
    (I waited 30 minutes and the first partition still hadn't finished...)
```

Lower bound: 900x faster