### PR TITLE
[hail] use val for IndexedRVDSpec partitioner

### DIFF
--- a/hail/python/hailtop/hailctl/dev/benchmark/cli.py
+++ b/hail/python/hailtop/hailctl/dev/benchmark/cli.py
@@ -35,6 +35,8 @@ def main(args):
         elif module == 'compare':
             from .compare import cli
             cli.main(args)
+        elif module == '-h' or module == '--help' or module == 'help':
+            print_help()
         else:
             sys.stderr.write(f"ERROR: no such module: {module!r}")
             print_help()

--- a/hail/python/hailtop/hailctl/dev/benchmark/run/cli.py
+++ b/hail/python/hailtop/hailctl/dev/benchmark/run/cli.py
@@ -82,7 +82,7 @@ def main(args_):
     if args.tests:
         run_list(args.tests, config)
     if args.pattern:
-        run_pattern(args, config)
+        run_pattern(args.pattern, config)
     if not args.pattern and not args.tests:
         run_all(config)
 

--- a/hail/python/hailtop/hailctl/dev/benchmark/run/table_benchmarks.py
+++ b/hail/python/hailtop/hailctl/dev/benchmark/run/table_benchmarks.py
@@ -141,6 +141,12 @@ def write_range_table_p10():
         ht.write(path.join(tmpdir, 'tmp.ht'))
 
 @benchmark
+def read_with_index_p50k():
+    intervals = [hl.Interval(start=i, end=i + 200) for i in range(0, 10_000_000, 200)]
+    ht = hl.read_table(resource('table_10M_par_10.ht'), _intervals=intervals)
+    ht._force_count()
+
+@benchmark
 def union_p100_p100():
     ht1 = hl.read_table(resource('table_10M_par_100.ht'))
     ht2 = hl.read_table(resource('table_10M_par_100.ht'))

--- a/hail/python/hailtop/hailctl/dev/cli.py
+++ b/hail/python/hailtop/hailctl/dev/cli.py
@@ -27,6 +27,8 @@ def main(args):
         if module == 'benchmark':
             from .benchmark import cli
             cli.main(args)
+        elif module == '-h' or module == '--help' or module == 'help':
+            print_help()
         else:
             sys.stderr.write(f"ERROR: no such module: {module!r}")
             print_help()

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -280,7 +280,7 @@ case class IndexedRVDSpec(
 
   override def encodedType: PStruct = rvdType.rowType
 
-  def partitioner: RVDPartitioner = {
+  val partitioner: RVDPartitioner = {
     val rangeBoundsType = TArray(TInterval(rvdType.kType.virtualType))
     new RVDPartitioner(rvdType.kType.virtualType,
       JSONAnnotationImpex.importAnnotation(jRangeBounds, rangeBoundsType, padNulls = false).asInstanceOf[IndexedSeq[Interval]])


### PR DESCRIPTION
When using indexed reads, we were creating a new partitioner for every
partiton in tmpPartitioner. It was not good.