### PR TITLE
[hail] fix BlockInputBuffer seek assertion

### DIFF
--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -694,7 +694,11 @@ final class BlockingOutputBuffer(blockSize: Int, out: OutputBlockBuffer) extends
   private val buf: Array[Byte] = new Array[Byte](blockSize)
   private var off: Int = 0
 
-  def indexOffset(): Long = (out.getPos() << 16) | off
+  def indexOffset(): Long = {
+    if (off == blockSize)
+      writeBlock()
+    (out.getPos() << 16) | off
+  }
 
   private def writeBlock() {
     out.writeBlock(buf, off)

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -994,7 +994,7 @@ final class BlockingInputBuffer(blockSize: Int, in: InputBlockBuffer) extends In
     off = end
     readBlock()
     off = (offset & 0xFFFF).asInstanceOf[Int]
-    assert(off < end)
+    assert(off <= end)
   }
 
   def readByte(): Byte = {


### PR DESCRIPTION
It is currently possible to write a blocked index where the virtual file
offset is exactly ((REAL_FILE_OFFSET << 16) | BLOCK_SIZE). This is a bug
and leads to assertion errors when trying to seek to the appropriate row
because `off == end` for that index.