### PR TITLE
Verify field uniqueness when renaming fields of tstruct

### DIFF
--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -1004,7 +1004,20 @@ class tstruct(HailType, Mapping):
         return t
 
     def _rename(self, map):
-        return tstruct(**{map.get(f, f): t for f, t in self.items()})
+        seen = {}
+        new_field_types = {}
+
+        for f0, t in self.items():
+            f = map.get(f0, f0)
+            if f in seen:
+                raise ValueError(
+                    "Cannot rename two fields to the same name: attempted to rename {} and {} both to {}".format(
+                        repr(seen[f]), repr(f0), repr(f)))
+            else:
+                seen[f] = f0
+                new_field_types[f] = t
+
+        return tstruct(**new_field_types)
 
     def unify(self, t):
         if not (isinstance(t, tstruct) and len(self) == len(t)):

--- a/hail/python/test/hail/expr/test_types.py
+++ b/hail/python/test/hail/expr/test_types.py
@@ -90,3 +90,9 @@ class Tests(unittest.TestCase):
         ht = hl.utils.range_table(10)
         ht = ht.annotate(nested=hl.dict({"tup": hl.tuple([ht.idx])}))
         ht.to_spark()  # should not throw exception
+
+    def test_rename_not_unique(self):
+        with self.assertRaisesRegex(ValueError, "attempted to rename 'b' and 'c' both to 'x'"):
+            hl.tstruct(a=hl.tbool, b=hl.tint32, c=hl.tint32)._rename({'b': 'x', 'c': 'x'})
+        with self.assertRaisesRegex(ValueError, "attempted to rename 'a' and 'b' both to 'a'"):
+            hl.tstruct(a=hl.tbool, b=hl.tint32)._rename({'b': 'a'})


### PR DESCRIPTION
I could also add checks to `_insert_field`, but currently it looks like the ability to overwrite an existing field is intended.

`tunion` already makes it impossible to overlap field names

fixes #6409 