### PR TITLE
set namespace on admin account

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -517,6 +517,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: admin
+  namespace: {self._name}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
I messed this up, forgot the namespace on the admin account, so they were all going into the current namespace (bach-pods).  Oops.