### PR TITLE
Adding the missing divider to the generated yaml for namespace creation

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -501,6 +501,7 @@ metadata:
   name: {self._name}
   labels:
     for: test
+---
 '''
         config = config + f'''\
 kind: Role


### PR DESCRIPTION
I accidentally deleted this dividing line when I reorganized the namespace creation step. 