### PR TITLE
move load/store methods onto Region object

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -1,5 +1,7 @@
 package is.hail.annotations
 
+import is.hail.asm4s
+import is.hail.asm4s.{Code, coerce}
 import is.hail.expr.types.physical._
 import is.hail.utils._
 import is.hail.nativecode._
@@ -9,6 +11,116 @@ object Region {
 
   def scoped[T](f: Region => T): T =
     using(Region())(f)
+
+  def loadInt(addr: Long): Int = Memory.loadInt(addr)
+  def loadLong(addr: Long): Long = Memory.loadLong(addr)
+  def loadFloat(addr: Long): Float = Memory.loadFloat(addr)
+  def loadDouble(addr: Long): Double = Memory.loadDouble(addr)
+  def loadAddress(addr: Long): Long = Memory.loadLong(addr)
+  def loadByte(addr: Long): Byte = Memory.loadByte(addr)
+
+  def storeInt(addr: Long, v: Int): Unit = Memory.storeInt(addr, v)
+  def storeLong(addr: Long, v: Long): Unit = Memory.storeLong(addr, v)
+  def storeFloat(addr: Long, v: Float): Unit = Memory.storeFloat(addr, v)
+  def storeDouble(addr: Long, v: Double): Unit = Memory.storeDouble(addr, v)
+  def storeAddress(addr: Long, v: Long): Unit = Memory.storeAddress(addr, v)
+  def storeByte(addr: Long, v: Byte): Unit = Memory.storeByte(addr, v)
+
+  def loadBoolean(addr: Long): Boolean = if (Memory.loadByte(addr) == 0) false else true
+  def storeBoolean(addr: Long, v: Boolean): Unit = Memory.storeByte(addr, if (v) 1 else 0)
+
+  def loadBytes(addr: Long, n: Int): Array[Byte] = {
+    val a = new Array[Byte](n)
+    Memory.copyToArray(a, 0, addr, n)
+    a
+  }
+
+  def loadBytes(addr: Long, dst: Array[Byte], dstOff: Long, n: Long): Unit =
+    Memory.copyToArray(dst, dstOff, addr, n)
+
+  def storeBytes(addr: Long, src: Array[Byte]): Unit =
+    Memory.copyFromArray(addr, src, 0, src.length)
+
+  def storeBytes(addr: Long, src: Array[Byte], srcOff: Long, n: Long): Unit =
+    Memory.copyFromArray(addr, src, srcOff, n)
+
+  def copyFrom(srcOff: Long, dstOff: Long, n: Long): Unit =
+    Memory.memcpy(dstOff, srcOff, n)
+
+  def loadBit(byteOff: Long, bitOff: Long): Boolean = {
+    val b = byteOff + (bitOff >> 3)
+    (loadByte(b) & (1 << (bitOff & 7))) != 0
+  }
+
+  def setBit(byteOff: Long, bitOff: Long) {
+    val b = byteOff + (bitOff >> 3)
+    storeByte(b,
+      (loadByte(b) | (1 << (bitOff & 7))).toByte)
+  }
+
+  def clearBit(byteOff: Long, bitOff: Long) {
+    val b = byteOff + (bitOff >> 3)
+    storeByte(b,
+      (loadByte(b) & ~(1 << (bitOff & 7))).toByte)
+  }
+
+  def storeBit(byteOff: Long, bitOff: Long, b: Boolean) {
+    if (b)
+      setBit(byteOff, bitOff)
+    else
+      clearBit(byteOff, bitOff)
+  }
+
+
+  def loadInt(addr: Code[Long]): Code[Int] = Code.invokeScalaObject[Long, Int](Region.getClass, "loadInt", addr)
+  def loadLong(addr: Code[Long]): Code[Long] = Code.invokeScalaObject[Long, Long](Region.getClass, "loadLong", addr)
+  def loadFloat(addr: Code[Long]): Code[Float] = Code.invokeScalaObject[Long, Float](Region.getClass, "loadFloat", addr)
+  def loadDouble(addr: Code[Long]): Code[Double] = Code.invokeScalaObject[Long, Double](Region.getClass, "loadDouble", addr)
+  def loadAddress(addr: Code[Long]): Code[Long] = Code.invokeScalaObject[Long, Long](Region.getClass, "loadAddress", addr)
+  def loadByte(addr: Code[Long]): Code[Byte] = Code.invokeScalaObject[Long, Byte](Region.getClass, "loadByte", addr)
+
+  def storeInt(addr: Code[Long], v: Code[Int]): Code[Unit] = Code.invokeScalaObject[Long, Int, Unit](Region.getClass, "storeInt", addr, v)
+  def storeLong(addr: Code[Long], v: Code[Long]): Code[Unit] = Code.invokeScalaObject[Long, Long, Unit](Region.getClass, "storeLong", addr, v)
+  def storeFloat(addr: Code[Long], v: Code[Float]): Code[Unit] = Code.invokeScalaObject[Long, Float, Unit](Region.getClass, "storeFloat", addr, v)
+  def storeDouble(addr: Code[Long], v: Code[Double]): Code[Unit] = Code.invokeScalaObject[Long, Double, Unit](Region.getClass, "storeDouble", addr, v)
+  def storeAddress(addr: Code[Long], v: Code[Long]): Code[Unit] = Code.invokeScalaObject[Long, Long, Unit](Region.getClass, "storeAddress", addr, v)
+  def storeByte(addr: Code[Long], v: Code[Byte]): Code[Unit] = Code.invokeScalaObject[Long, Byte, Unit](Region.getClass, "storeByte", addr, v)
+
+  def loadBoolean(addr: Code[Long]): Code[Boolean] = Code.invokeScalaObject[Long, Boolean](Region.getClass, "loadBoolean", addr)
+  def storeBoolean(addr: Code[Long], v: Code[Boolean]): Code[Unit] = Code.invokeScalaObject[Long, Boolean, Unit](Region.getClass, "storeBoolean", addr, v)
+  def loadBytes(addr: Code[Long], n: Code[Int]): Code[Array[Byte]] = Code.invokeScalaObject[Long, Int, Array[Byte]](Region.getClass, "loadBytes", addr, n)
+  def loadBytes(addr: Code[Long], dst: Code[Array[Byte]], dstOff: Code[Long], n: Code[Long]): Unit =
+    Code.invokeScalaObject[Long, Array[Byte], Long, Long, Unit](Region.getClass, "loadBytes", addr, dst, dstOff, n)
+  def storeBytes(addr: Code[Long], src: Code[Array[Byte]]): Code[Unit] = Code.invokeScalaObject[Long, Array[Byte], Unit](Region.getClass, "storeBytes", addr, src)
+  def storeBytes(addr: Code[Long], src: Code[Array[Byte]], srcOff: Code[Long], n: Code[Long]): Code[Unit] =
+    Code.invokeScalaObject[Long, Array[Byte], Long, Long, Unit](Region.getClass, "storeBytes", addr, src, srcOff, n)
+
+  def copyFrom(srcOff: Code[Long], dstOff: Code[Long], n: Code[Long]): Code[Unit] =
+    Code.invokeScalaObject[Long, Long, Long, Unit](Region.getClass, "copyFrom", srcOff, dstOff, n)
+  def loadBit(byteOff: Code[Long], bitOff: Code[Long]): Code[Boolean] =
+    Code.invokeScalaObject[Long, Long, Boolean](Region.getClass, "loadBit", byteOff, bitOff)
+  def setBit(byteOff: Code[Long], bitOff: Code[Long]): Code[Unit] =
+    Code.invokeScalaObject[Long, Long, Unit](Region.getClass, "setBit", byteOff, bitOff)
+  def clearBit(byteOff: Code[Long], bitOff: Code[Long]): Code[Unit] =
+    Code.invokeScalaObject[Long, Long, Unit](Region.getClass, "clearBit", byteOff, bitOff)
+  def storeBit(byteOff: Code[Long], bitOff: Code[Long], b: Code[Boolean]): Code[Unit] =
+    Code.invokeScalaObject[Long, Long, Boolean, Unit](Region.getClass, "storeBit", byteOff, bitOff, b)
+
+  def loadPrimitive(typ: PType): Code[Long] => Code[_] = typ.fundamentalType match {
+    case _: PBoolean => loadBoolean
+    case _: PInt32 => loadInt
+    case _: PInt64 => loadLong
+    case _: PFloat32 => loadFloat
+    case _: PFloat64 => loadDouble
+  }
+
+  def storePrimitive(typ: PType, dest: Code[Long]): Code[_] => Code[Unit] = typ.fundamentalType match {
+    case _: PBoolean => v => storeBoolean(dest, coerce[Boolean](v))
+    case _: PInt32 => v => storeInt(dest, coerce[Int](v))
+    case _: PInt64 => v => storeLong(dest, coerce[Long](v))
+    case _: PFloat32 => v => storeFloat(dest, coerce[Float](v))
+    case _: PFloat64 => v => storeDouble(dest, coerce[Double](v))
+  }
 }
 
 // Off-heap implementation of Region differs from the previous
@@ -98,68 +210,37 @@ final class Region private (empty: Boolean) extends NativeBase() {
     nativeClearParentReference(i)
   }
   
-  final def loadInt(addr: Long): Int = Memory.loadInt(addr)
-  final def loadLong(addr: Long): Long = Memory.loadLong(addr)
-  final def loadFloat(addr: Long): Float = Memory.loadFloat(addr)
-  final def loadDouble(addr: Long): Double = Memory.loadDouble(addr)
-  final def loadAddress(addr: Long): Long = Memory.loadLong(addr)
-  final def loadByte(addr: Long): Byte = Memory.loadByte(addr)
+  final def loadInt(addr: Long): Int = Region.loadInt(addr)
+  final def loadLong(addr: Long): Long = Region.loadLong(addr)
+  final def loadFloat(addr: Long): Float = Region.loadFloat(addr)
+  final def loadDouble(addr: Long): Double = Region.loadDouble(addr)
+  final def loadAddress(addr: Long): Long = Region.loadLong(addr)
+  final def loadByte(addr: Long): Byte = Region.loadByte(addr)
   
-  final def storeInt(addr: Long, v: Int) = Memory.storeInt(addr, v)
-  final def storeLong(addr: Long, v: Long) = Memory.storeLong(addr, v)
-  final def storeFloat(addr: Long, v: Float) = Memory.storeFloat(addr, v)
-  final def storeDouble(addr: Long, v: Double) = Memory.storeDouble(addr, v)
-  final def storeAddress(addr: Long, v: Long) = Memory.storeAddress(addr, v)
-  final def storeByte(addr: Long, v: Byte) = Memory.storeByte(addr, v)
+  final def storeInt(addr: Long, v: Int): Unit = Region.storeInt(addr, v)
+  final def storeLong(addr: Long, v: Long): Unit = Region.storeLong(addr, v)
+  final def storeFloat(addr: Long, v: Float): Unit = Region.storeFloat(addr, v)
+  final def storeDouble(addr: Long, v: Double): Unit = Region.storeDouble(addr, v)
+  final def storeAddress(addr: Long, v: Long): Unit = Region.storeAddress(addr, v)
+  final def storeByte(addr: Long, v: Byte): Unit = Region.storeByte(addr, v)
   
-  final def loadBoolean(addr: Long): Boolean = if (Memory.loadByte(addr) == 0) false else true
-  final def storeBoolean(addr: Long, v: Boolean) = Memory.storeByte(addr, if (v) 1 else 0)
+  final def loadBoolean(addr: Long): Boolean = Region.loadBoolean(addr)
+  final def storeBoolean(addr: Long, v: Boolean): Unit = Region.storeBoolean(addr, v)
 
-  final def loadBytes(addr: Long, n: Int): Array[Byte] = {
-    val a = new Array[Byte](n)
-    Memory.copyToArray(a, 0, addr, n)
-    a
-  }
+  final def loadBytes(addr: Long, n: Int): Array[Byte] = Region.loadBytes(addr, n)
+  final def loadBytes(addr: Long, dst: Array[Byte], dstOff: Long, n: Long): Unit =
+    Region.loadBytes(addr, dst, dstOff, n)
 
-  final def loadBytes(addr: Long, dst: Array[Byte], dstOff: Long, n: Long): Unit = {
-    Memory.copyToArray(dst, dstOff, addr, n)
-  }
+  final def storeBytes(addr: Long, src: Array[Byte]): Unit = Region.storeBytes(addr, src)
+  final def storeBytes(addr: Long, src: Array[Byte], srcOff: Long, n: Long): Unit =
+    Region.storeBytes(addr, src, srcOff, n)
+  final def copyFrom(src: Region, srcOff: Long, dstOff: Long, n: Long) =
+    Region.copyFrom(srcOff, dstOff, n)
 
-  final def storeBytes(addr: Long, src: Array[Byte]) {
-    Memory.copyFromArray(addr, src, 0, src.length)
-  }
-
-  final def storeBytes(addr: Long, src: Array[Byte], srcOff: Long, n: Long) {
-    Memory.copyFromArray(addr, src, srcOff, n)
-  }
-
-  final def copyFrom(src: Region, srcOff: Long, dstOff: Long, n: Long) {
-    Memory.memcpy(dstOff, srcOff, n)
-  }
-
-  final def loadBit(byteOff: Long, bitOff: Long): Boolean = {
-    val b = byteOff + (bitOff >> 3)
-    (loadByte(b) & (1 << (bitOff & 7))) != 0
-  }
-
-  final def setBit(byteOff: Long, bitOff: Long) {
-    val b = byteOff + (bitOff >> 3)
-    storeByte(b,
-      (loadByte(b) | (1 << (bitOff & 7))).toByte)
-  }
-
-  final def clearBit(byteOff: Long, bitOff: Long) {
-    val b = byteOff + (bitOff >> 3)
-    storeByte(b,
-      (loadByte(b) & ~(1 << (bitOff & 7))).toByte)
-  }
-
-  final def storeBit(byteOff: Long, bitOff: Long, b: Boolean) {
-    if (b)
-      setBit(byteOff, bitOff)
-    else
-      clearBit(byteOff, bitOff)
-  }
+  final def loadBit(byteOff: Long, bitOff: Long): Boolean = Region.loadBit(byteOff, bitOff)
+  final def setBit(byteOff: Long, bitOff: Long): Unit = Region.setBit(byteOff, bitOff)
+  final def clearBit(byteOff: Long, bitOff: Long): Unit = Region.clearBit(byteOff, bitOff)
+  final def storeBit(byteOff: Long, bitOff: Long, b: Boolean): Unit = Region.storeBit(byteOff, bitOff, b)
 
   final def appendBinary(v: Array[Byte]): Long = {
     val len: Int = v.length
@@ -167,20 +248,6 @@ final class Region private (empty: Boolean) extends NativeBase() {
     val addr = allocate(grain, grain+len) + (grain-4)
     storeInt(addr, len)
     storeBytes(addr+4, v)
-    addr
-  }
-  
-  final def appendBinarySlice(
-    fromRegion: Region,
-    fromOff: Long,
-    start: Int,
-    len: Int
-  ): Long = {
-    assert(len >= 0)
-    val grain = if (PBinary.contentAlignment < 4) 4 else PBinary.contentAlignment
-    val addr = allocate(grain, grain+len) + (grain-4)
-    storeInt(addr, len)
-    copyFrom(fromRegion, PBinary.bytesOffset(fromOff) + start, addr+4, len)
     addr
   }
 
@@ -191,19 +258,6 @@ final class Region private (empty: Boolean) extends NativeBase() {
   // ascending addresses (within a buffer) followed by an arbitrary jump
   // to an address in a different buffer.
   
-  final def appendArrayInt(v: Array[Int]): Long = {
-    val len: Int = v.length
-    val addr = allocate(4, 4*(1+len))
-    storeInt(addr, len)
-    val data = addr+4
-    var idx = 0
-    while (idx < len) {
-      storeInt(data + 4 * idx, v(idx))
-      idx += 1
-    }
-    addr
-  }
-  
   final def appendInt(v: Int): Long = {
     val a = allocate(4, 4)
     Memory.storeInt(a, v)
@@ -212,11 +266,6 @@ final class Region private (empty: Boolean) extends NativeBase() {
   final def appendLong(v: Long): Long = {
     val a = allocate(8, 8)
     Memory.storeLong(a, v)
-    a
-  }
-  final def appendFloat(v: Float): Long = {
-    val a = allocate(4, 4)
-    Memory.storeFloat(a, v)
     a
   }
   final def appendDouble(v: Double): Long = {
@@ -231,9 +280,6 @@ final class Region private (empty: Boolean) extends NativeBase() {
   }
   final def appendString(v: String): Long =
     appendBinary(v.getBytes)
-  
-  final def appendStringSlice(fromRegion: Region, fromOff: Long, start: Int, n: Int): Long =
-    appendBinarySlice(fromRegion, fromOff, start, n)
 
   def visit(t: PType, off: Long, v: ValueVisitor) {
     t match {
@@ -327,5 +373,29 @@ class RegionPool private() extends NativeBase() {
   @native def numFreeRegions(): Int
   @native def numFreeBlocks(): Int
 
+  def logStats(context: String): Unit = {
+    val pool = RegionPool.get
+    val nFree = pool.numFreeRegions()
+    val nRegions = pool.numRegions()
+    val nBlocks = pool.numFreeBlocks()
 
+    info(
+      s"""Region count for $context
+         |    regions: $nRegions
+         |     blocks: $nBlocks
+         |       free: $nFree
+         |       used: ${ nRegions - nFree }""".stripMargin)
+  }
+}
+
+object RegionUtils {
+  def printBytes(off: Long, n: Int, header: String): String = {
+    Region.loadBytes(off, n).zipWithIndex
+      .grouped(16)
+      .map(bs => bs.map { case (b, _) => "%02x".format(b) }.mkString("  %016x: ".format(off + bs(0)._2), " ", ""))
+      .mkString(if (header != null) s"$header\n" else "\n", "\n", "")
+  }
+
+  def printBytes(off: Code[Long], n: Int, header: String): Code[String] =
+    Code.invokeScalaObject[Long, Int, String, String](RegionUtils.getClass, "printBytes", off, n, asm4s.const(header))
 }


### PR DESCRIPTION
I've left all the instances of `region.loadX` untouched (and left the methods on the region object, but this should let us avoid piping through region objects when we just need to read something.

(Broken out from #6580)