### PR TITLE
implement SerializeAggs/DeserializeAggs

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -130,6 +130,8 @@ object Children {
     case _: CombOp2 => none
     case WriteAggs(_, path, _, _) => Array(path)
     case ReadAggs(_, path, _, _) => Array(path)
+    case SerializeAggs(_, _, _, _) => none
+    case DeserializeAggs(_, _, _, _) => none
     case Begin(xs) =>
       xs
     case ApplyAggOp(constructorArgs, initOpArgs, seqOpArgs, aggSig) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -189,6 +189,8 @@ object Copy {
       case ReadAggs(startIdx, _, spec, aggSigs) =>
         assert(newChildren.length == 1)
         ReadAggs(startIdx, newChildren.head.asInstanceOf[IR], spec, aggSigs)
+      case x: SerializeAggs => x
+      case x: DeserializeAggs => x
       case Begin(_) =>
         Begin(newChildren.map(_.asInstanceOf[IR]))
       case x@ApplyAggOp(_, initOpArgs, _, aggSig) =>

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -57,6 +57,12 @@ trait FunctionWithAggRegion {
   def setAggState(region: Region, offset: Long): Unit
 
   def newAggState(region: Region): Unit
+
+  def setNumSerialized(i: Int): Unit
+
+  def setSerializedAgg(i: Int, b: Array[Byte]): Unit
+
+  def getSerializedAgg(i: Int): Array[Byte]
 }
 
 trait FunctionWithLiterals {
@@ -231,6 +237,8 @@ class EmitFunctionBuilder[F >: Null](
   private[this] var _aggRegion: ClassFieldRef[Region] = _
   private[this] var _aggOff: ClassFieldRef[Long] = _
   private[this] var _aggState: agg.StateContainer = _
+  private[this] var _nSerialized: Int = 0
+  private[this] var _aggSerialized: ClassFieldRef[Array[Array[Byte]]] = _
 
   def addAggStates(aggSigs: Array[AggSignature]): (agg.StateContainer, Code[Long]) = {
     if (_aggSigs != null) {
@@ -242,17 +250,24 @@ class EmitFunctionBuilder[F >: Null](
     _aggRegion = newField[Region]
     _aggOff = newField[Long]
     _aggState = agg.StateContainer(aggSigs.map(a => agg.Extract.getAgg(a).createState(apply_method)).toArray, _aggRegion)
+    _aggSerialized = newField[Array[Array[Byte]]]
 
     val newF = new EmitMethodBuilder(this, "newAggState", Array(typeInfo[Region]), typeInfo[Unit])
     val setF = new EmitMethodBuilder(this, "setAggState", Array(typeInfo[Region], typeInfo[Long]), typeInfo[Unit])
     val getF = new EmitMethodBuilder(this, "getAggOffset", Array(), typeInfo[Long])
+    val setNSer = new EmitMethodBuilder(this, "setNumSerialized", Array(typeInfo[Int]), typeInfo[Unit])
+    val setSer = new EmitMethodBuilder(this, "setSerializedAgg", Array(typeInfo[Int], typeInfo[Array[Byte]]), typeInfo[Unit])
+    val getSer = new EmitMethodBuilder(this, "getSerializedAgg", Array(typeInfo[Int]), typeInfo[Array[Byte]])
 
     methods += newF
     methods += setF
     methods += getF
+    methods += setNSer
+    methods += setSer
+    methods += getSer
 
     newF.emit(
-      Code(_aggRegion := setF.getArg[Region](1),
+      Code(_aggRegion := newF.getArg[Region](1),
         _aggState.topRegion.setNumParents(aggSigs.length),
         _aggOff := _aggRegion.load().allocate(_aggState.typ.alignment, _aggState.typ.byteSize),
         _aggState.loadRegions(0)))
@@ -265,7 +280,26 @@ class EmitFunctionBuilder[F >: Null](
         _aggState.loadStateOffsets(_aggOff)))
 
     getF.emit(Code(_aggState.storeRegions(0), _aggState.storeStateOffsets(_aggOff), _aggOff))
+
+    setNSer.emit(_aggSerialized := Code.newArray[Array[Byte]](setNSer.getArg[Int](1)))
+
+    setSer.emit(_aggSerialized.load().update(setSer.getArg[Int](1), setSer.getArg[Array[Byte]](2)))
+
+    getSer.emit(_aggSerialized.load()(getSer.getArg[Int](1)))
+
     _aggState -> _aggOff
+  }
+
+  def getSerializedAgg(i: Int): Code[Array[Byte]] = {
+    if (_nSerialized <= i)
+      _nSerialized = i + 1
+    _aggSerialized.load()(i)
+  }
+
+  def setSerializedAgg(i: Int, b: Code[Array[Byte]]): Code[Unit] = {
+    if (_nSerialized <= i)
+      _nSerialized = i + 1
+    _aggSerialized.load().update(i, b)
   }
 
   def backend(): Code[BackendUtils] = {
@@ -482,6 +516,8 @@ class EmitFunctionBuilder[F >: Null](
     val n = name.replace("/",".")
     val localFS = _hfs
 
+    val nSerializedAggs = _nSerialized
+
     val useBackend = _backendField != null
     val backend = if (useBackend) new BackendUtils(_mods.result()) else null
 
@@ -508,6 +544,8 @@ class EmitFunctionBuilder[F >: Null](
             f.asInstanceOf[FunctionWithBackend].setBackend(backend)
           if (hasLiterals)
             f.asInstanceOf[FunctionWithLiterals].addLiterals(literalsBc.value, region)
+          if (nSerializedAggs != 0)
+            f.asInstanceOf[FunctionWithAggRegion].setNumSerialized(nSerializedAggs)
           f.asInstanceOf[FunctionWithSeededRandomness].setPartitionIndex(idx)
           f
         } catch {

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -310,11 +310,8 @@ final case class ResultOp2(startIdx: Int, aggSigs: IndexedSeq[AggSignature]) ext
 
 final case class WriteAggs(startIdx: Int, path: IR, spec: CodecSpec, aggSigs: IndexedSeq[AggSignature]) extends IR
 final case class ReadAggs(startIdx: Int, path: IR, spec: CodecSpec, aggSigs: IndexedSeq[AggSignature]) extends IR
-
-//final case class WriteAggs(path: IR, spec: CodecSpec) extends IR
-//final case class ReadAggs(path: IR, spec: CodecSpec, aggSigs: Array[AggSignature]) extends IR
-//
-//final case class CombAggs(paths: IndexedSeq[IR], spec: CodecSpec, aggSigs: Array[AggSignature]) extends IR
+final case class SerializeAggs(startIdx: Int, serializedIdx: Int, spec: CodecSpec, aggSigs: IndexedSeq[AggSignature]) extends IR
+final case class DeserializeAggs(startIdx: Int, serializedIdx: Int, spec: CodecSpec, aggSigs: IndexedSeq[AggSignature]) extends IR
 
 final case class Begin(xs: IndexedSeq[IR]) extends IR
 final case class MakeStruct(fields: Seq[(String, IR)]) extends IR

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -43,6 +43,8 @@ object InferType {
         TTuple(aggSigs.map(agg.Extract.getType): _*)
       case _: ReadAggs => TVoid
       case _: WriteAggs => TVoid
+      case _: SerializeAggs => TVoid
+      case _: DeserializeAggs => TVoid
       case _: Begin => TVoid
       case Die(_, t) => t
       case If(cond, cnsq, altr) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
@@ -10,6 +10,8 @@ object Interpretable {
         _: ResultOp2 |
         _: ReadAggs |
         _: WriteAggs |
+        _: SerializeAggs |
+        _: DeserializeAggs |
         _: MakeNDArray |
         _: NDArrayShape |
         _: NDArrayReshape |

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -841,6 +841,20 @@ object IRParser {
         val aggSigs = agg_signatures(it)
         val path = ir_value_expr(env)(it)
         WriteAggs(i, path, spec, aggSigs)
+      case "SerializeAggs" =>
+        val i = int32_literal(it)
+        val i2 = int32_literal(it)
+        implicit val formats: Formats = AbstractRVDSpec.formats
+        val spec = JsonMethods.parse(string_literal(it)).extract[CodecSpec]
+        val aggSigs = agg_signatures(it)
+        SerializeAggs(i, i2, spec, aggSigs)
+      case "DeserializeAggs" =>
+        val i = int32_literal(it)
+        val i2 = int32_literal(it)
+        implicit val formats: Formats = AbstractRVDSpec.formats
+        val spec = JsonMethods.parse(string_literal(it)).extract[CodecSpec]
+        val aggSigs = agg_signatures(it)
+        DeserializeAggs(i, i2, spec, aggSigs)
       case "InitOp" =>
         val aggSig = agg_signature(it)
         val i = ir_value_expr(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -185,6 +185,24 @@ object Pretty {
           prettyAggSeq(aggSigs, depth + 2)
           sb += '\n'
           pretty(path, depth + 2)
+        case SerializeAggs(i, i2, spec, aggSigs) =>
+          sb += ' '
+          sb.append(i)
+          sb += ' '
+          sb.append(i2)
+          sb += ' '
+          sb.append(prettyStringLiteral(spec.toString))
+          sb += '\n'
+          prettyAggSeq(aggSigs, depth + 2)
+        case DeserializeAggs(i, i2, spec, aggSigs) =>
+          sb += ' '
+          sb.append(i)
+          sb += ' '
+          sb.append(i2)
+          sb += ' '
+          sb.append(prettyStringLiteral(spec.toString))
+          sb += '\n'
+          prettyAggSeq(aggSigs, depth + 2)
         case InsertFields(old, fields, fieldOrder) =>
           sb += '\n'
           pretty(old, depth + 2)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -270,6 +270,8 @@ object TypeCheck {
         assert(path.typ isOfType TString())
       case x@WriteAggs(_, path, _, _) =>
         assert(path.typ isOfType TString())
+      case _: SerializeAggs =>
+      case _: DeserializeAggs =>
       case x@Begin(xs) =>
         xs.foreach { x =>
           assert(x.typ == TVoid)

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1602,6 +1602,8 @@ class IRSuite extends HailSuite {
       ResultOp2(0, FastSeq(collectSig)),
       ReadAggs(0, Str("foo"), CodecSpec.default, FastSeq(collectSig)),
       WriteAggs(0, Str("foo"), CodecSpec.default, FastSeq(collectSig)),
+      SerializeAggs(0, 0, CodecSpec.default, FastSeq(collectSig)),
+      DeserializeAggs(0, 0, CodecSpec.default, FastSeq(collectSig)),
       Begin(FastIndexedSeq(Void())),
       MakeStruct(FastIndexedSeq("x" -> i)),
       SelectFields(s, FastIndexedSeq("x", "z")),


### PR DESCRIPTION
Works pretty much like Read/Write, except serializes to/from a fixed number of byte array slots on the function object. Not *super* happy with this design, but I'm using it in the new TableMapRows implementation to avoid reading/writing all the aggregations to a file.

(Broken out from #6580)