### PR TITLE
[hail] only convert row keys into Java objects in PCA

### DIFF
--- a/hail/src/main/scala/is/hail/methods/PCA.scala
+++ b/hail/src/main/scala/is/hail/methods/PCA.scala
@@ -47,9 +47,10 @@ case class PCA(entryField: String, k: Int, computeLoadings: Boolean) extends Mat
 
     def collectRowKeys(): Array[Annotation] = {
       val rowKeyIdx = mv.typ.rowKeyFieldIdx
+      val rowKeyTypes = mv.typ.rowKeyStruct.types
 
-      mv.rvd.toRows.map[Any] { r =>
-        Row.fromSeq(rowKeyIdx.map(r.get))
+      mv.rvd.toUnsafeRows.map[Any] { r =>
+        Row.fromSeq(rowKeyIdx.map(i => Annotation.copy(rowKeyTypes(i), r(i))))
       }
         .collect()
     }

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -75,6 +75,11 @@ class RVD(
     map(rv => SafeRow(localRowType.physicalType, rv.region, rv.offset))
   }
 
+  def toUnsafeRows: RDD[UnsafeRow] = {
+    val localRowPType = rowPType
+    map(rv => new UnsafeRow(localRowPType, rv.region, rv.offset))
+  }
+
   def stabilize(codec: CodecSpec = RVD.memoryCodec): RDD[Array[Byte]] = {
     val enc = codec.buildEncoder(rowPType)
     crdd.mapPartitions(_.map(_.toBytes(enc))).clearingRun


### PR DESCRIPTION
fixes #6236

instead of calling `SafeRow` to manifest the entire row and then pick out the keys, create `UnsafeRow`s and then copy only the keys.

added `RVD.toUnsafeRows`