### PR TITLE
dev deploy dont wait for batch

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -68,6 +68,10 @@ class BuildConfiguration:
         config = yaml.safe_load(config_str)
         name_step = {}
         self.steps = []
+        
+        if profile:
+            log.info(f"Constructing build configuration with following profile: {profile}")
+        
         for step_config in config['steps']:
             step_params = StepParameters(code, scope, step_config, name_step)
 

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -282,7 +282,7 @@ async def dev_test_branch(request):
 
     batch_id = await unwatched_branch.deploy(batch_client, profile)
 
-    if batch_id:
+    if batch_id is not None:
         return web.Response(status=200, text=str(batch_id))
     else:
         return web.Response(status=503)

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -283,7 +283,7 @@ async def dev_test_branch(request):
     batch_id = await unwatched_branch.deploy(batch_client, profile)
 
     if batch_id:
-        return web.Response(status=200)
+        return web.Response(status=200, text=str(batch_id))
     else:
         return web.Response(status=503)
 

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -280,9 +280,12 @@ async def dev_test_branch(request):
 
     batch_client = app['batch_client']
 
-    await unwatched_branch.deploy(batch_client, profile)
+    batch_id = await unwatched_branch.deploy(batch_client, profile)
 
-    return web.Response(status=200)
+    if batch_id:
+        return web.Response(status=200)
+    else:
+        return web.Response(status=503)
 
 @routes.post('/api/v1alpha/batch_callback')
 async def batch_callback(request):

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -821,7 +821,7 @@ mkdir -p {shq(repo_dir)}
             config.build(deploy_batch, self, scope='dev')
             deploy_batch = await deploy_batch.submit()
             self.deploy_batch = deploy_batch
-            await deploy_batch.wait()
+            return await deploy_batch.id()
         finally:
             if deploy_batch and not self.deploy_batch:
                 log.info(f'cancelling partial deploy batch {deploy_batch.id}')

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -806,6 +806,7 @@ class UnwatchedBranch(Code):
 mkdir -p {shq(repo_dir)}
 (cd {shq(repo_dir)}; {self.checkout_script()})
 ''')
+            log.info(f'User {self.user} requested these steps for dev deploy: {profile_steps}')
             with open(f'{repo_dir}/build.yaml', 'r') as f:
                 config = BuildConfiguration(self, f.read(), scope='dev', profile=profile_steps)
 
@@ -821,7 +822,7 @@ mkdir -p {shq(repo_dir)}
             config.build(deploy_batch, self, scope='dev')
             deploy_batch = await deploy_batch.submit()
             self.deploy_batch = deploy_batch
-            return await deploy_batch.id()
+            return deploy_batch.id
         finally:
             if deploy_batch and not self.deploy_batch:
                 log.info(f'cancelling partial deploy batch {deploy_batch.id}')

--- a/hail/python/hailtop/hailctl/dev/deploy/cli.py
+++ b/hail/python/hailtop/hailctl/dev/deploy/cli.py
@@ -46,4 +46,8 @@ async def submit(args):
             'namespace': args.namespace
         }
         async with session.post('https://ci.hail.is/api/v1alpha/dev_test_branch/', json=data) as resp:
-            print(await resp.text())
+            if (resp.status == 200):
+                text = await resp.text()
+                print(f"Created batch {text}")
+            else:
+                print(f"Error: Returned status code {resp.status}")

--- a/hail/python/hailtop/hailctl/dev/deploy/cli.py
+++ b/hail/python/hailtop/hailctl/dev/deploy/cli.py
@@ -45,6 +45,7 @@ async def submit(args):
             'profile': profiles[args.profile],
             'namespace': args.namespace
         }
+        print(f"Submitting: {data}")
         async with session.post('https://ci.hail.is/api/v1alpha/dev_test_branch/', json=data) as resp:
             if (resp.status == 200):
                 text = await resp.text()


### PR DESCRIPTION
Currently, dev deploy always eventually returns a timeout in the terminal because it tries to wait for the entire batch deploy / tests to run before returning. Now it will just create the batch and return the batch number instead of waiting. 