### PR TITLE
[notebook] mitigate CVE-2019-11245

### DIFF
--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -89,6 +89,8 @@ def start_pod(jupyter_token, image):
         _request_timeout=KUBERNETES_TIMEOUT_IN_SECONDS
     )
     pod_spec = kube.client.V1PodSpec(
+        security_context=kube.client.V1SecurityContext(
+            run_as_user=1000),
         containers=[
             kube.client.V1Container(
                 command=[
@@ -310,4 +312,3 @@ if __name__ == '__main__':
     from geventwebsocket.handler import WebSocketHandler
     server = pywsgi.WSGIServer(('', 5000), app, handler_class=WebSocketHandler, log=log)
     server.serve_forever()
-


### PR DESCRIPTION
CVE-2019-11245 is a vulnerability in k8s that causes some (all?)
containers without a runAsUser configuration to run
as user id 0, i.e. root. Jupyter refuses to start as root.
This change enables Jupyter to start successfully.