### PR TITLE
some cleanup to staged aggregators

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -985,7 +985,7 @@ private class Emit(
         assert(agg.Extract.compatible(aggs(i), aggSig))
         val rvAgg = agg.Extract.getAgg(aggSig)
 
-        val argVars = args.map(a => agg.RVAVariable(emit(a, container = container.flatMap(_.nested(i))), a.pType)).toArray
+        val argVars = args.map(a => emit(a, container = container.flatMap(_.nested(i)))).toArray
         void(
           sc(i).newState,
           rvAgg.initOp(sc(i), argVars))
@@ -995,7 +995,7 @@ private class Emit(
         assert(agg.Extract.compatible(aggs(i), aggSig), s"${ aggs(i) } vs $aggSig")
         val rvAgg = agg.Extract.getAgg(aggSig)
 
-        val argVars = args.map(a => agg.RVAVariable(emit(a, container = container.flatMap(_.nested(i))), a.pType)).toArray
+        val argVars = args.map(a => emit(a, container = container.flatMap(_.nested(i)))).toArray
         void(
           sc.loadOneIfMissing(aggOff, i),
           rvAgg.seqOp(sc(i), argVars))

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
@@ -159,7 +159,7 @@ class ArrayElementLengthCheckAggregator(nestedAggs: Array[StagedAggregator], kno
 
     var check = state.checkLength(len.value[Int])
     if (!knownLength)
-      check = (state.lenRef < 0).mux(state.initLength(len.v[Int]), check)
+      check = (state.lenRef < 0).mux(state.initLength(len.value[Int]), check)
     Code(len.setup, len.m.mux(Code._empty, check))
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CountAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CountAggregator.scala
@@ -2,26 +2,24 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.{Region, StagedRegionValueBuilder}
 import is.hail.asm4s._
-import is.hail.expr.ir.EmitMethodBuilder
+import is.hail.expr.ir.{EmitMethodBuilder, EmitTriplet}
 import is.hail.expr.types.physical._
 import is.hail.utils._
 
-object CountAggregator extends StagedRegionValueAggregator {
+object CountAggregator extends StagedAggregator {
   type State = PrimitiveRVAState
 
-  val initOpTypes: Array[PType] = Array()
-  val seqOpTypes: Array[PType] = Array()
   val resultType: PType = PInt64()
 
   def createState(mb: EmitMethodBuilder): State = PrimitiveRVAState(Array(PInt64(true)), mb)
 
-  def initOp(state: State, init: Array[RVAVariable], dummy: Boolean): Code[Unit] = {
+  def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
     assert(init.length == 0)
     val (_, v, _) = state.fields(0)
     Code(v.storeAny(0L), state._loaded := true)
   }
 
-  def seqOp(state: State, seq: Array[RVAVariable], dummy: Boolean): Code[Unit] = {
+  def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
     assert(seq.length == 0)
     val (_, v, _) = state.fields(0)
     v.storeAny(coerce[Long](v) + 1L)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -221,20 +221,20 @@ object Extract {
   def getType(aggSig: AggSignature2): Type = getPType(aggSig).virtualType
 
   def apply(ir: IR, resultName: String): Aggs = {
-    val ab = new ArrayBuilder[(AggSignature2, IndexedSeq[IR])]()
+    val ab = new ArrayBuilder[InitOp2]()
     val seq = new ArrayBuilder[IR]()
     val let = new ArrayBuilder[AggLet]()
     val ref = Ref(resultName, null)
     val postAgg = extract(ir, ab, seq, let, ref)
-    val (aggs, initArgs) = ab.result().unzip
+    val initOps = ab.result()
+    val aggs = initOps.map(_.aggSig)
     val rt = TTuple(aggs.map(Extract.getType): _*)
     ref._typ = rt
 
-    val initOps = Array.tabulate(initArgs.length)(i => InitOp2(i, initArgs(i), aggs(i)))
     Aggs(postAgg, Begin(initOps), Begin(seq.result()), aggs)
   }
 
-  private def extract(ir: IR, ab: ArrayBuilder[(AggSignature2, IndexedSeq[IR])], seqBuilder: ArrayBuilder[IR], letBuilder: ArrayBuilder[AggLet], result: IR): IR = {
+  private def extract(ir: IR, ab: ArrayBuilder[InitOp2], seqBuilder: ArrayBuilder[IR], letBuilder: ArrayBuilder[AggLet], result: IR): IR = {
     def extract(node: IR): IR = this.extract(node, ab, seqBuilder, letBuilder, result)
 
     ir match {
@@ -251,7 +251,7 @@ object Extract {
           x.aggSig.constructorArgs ++ x.aggSig.initOpArgs.getOrElse(FastSeq.empty),
           x.aggSig.seqOpArgs,
           None)
-        ab += newSig -> (x.constructorArgs ++ x.initOpArgs.getOrElse[IndexedSeq[IR]](FastIndexedSeq()))
+        ab += InitOp2(i, x.constructorArgs ++ x.initOpArgs.getOrElse[IndexedSeq[IR]](FastIndexedSeq()), newSig)
         seqBuilder += SeqOp2(i, x.seqOpArgs, newSig)
         GetTupleElement(result, i)
       case AggFilter(cond, aggIR, _) =>
@@ -276,7 +276,7 @@ object Extract {
         throw new UnsupportedExtraction("group by")
 
       case AggArrayPerElement(a, elementName, indexName, aggBody, knownLength, _) =>
-        val newAggs = new ArrayBuilder[(AggSignature2, IndexedSeq[IR])]()
+        val newAggs = new ArrayBuilder[InitOp2]()
         val newSeq = new ArrayBuilder[IR]()
         val newLet = new ArrayBuilder[AggLet]()
         val newRef = Ref(genUID(), null)
@@ -286,18 +286,22 @@ object Extract {
         letBuilder ++= independent
 
         val i = ab.length
-        val (aggs, inits) = newAggs.result().unzip
+        val initOps = newAggs.result()
+        val aggs = initOps.map(_.aggSig)
+
         val rt = TArray(TTuple(aggs.map(Extract.getType): _*))
         newRef._typ = -rt.elementType
-        val initArgs = knownLength.map(FastIndexedSeq(_)).getOrElse[IndexedSeq[IR]](FastIndexedSeq()) ++ inits.flatten.toFastIndexedSeq
 
-        val aggSigCheck = AggSignature2(AggElementsLengthCheck(), initArgs.map(_.typ), FastSeq(TInt32()), Some(aggs))
+        val aggSigCheck = AggSignature2(
+          AggElementsLengthCheck(),
+          knownLength.map(l => FastSeq(l.typ)).getOrElse(FastSeq()) :+ TVoid,
+          FastSeq(TInt32()), Some(aggs))
         val aggSig = AggSignature2(AggElements(), FastSeq[Type](), FastSeq(TInt32(), TVoid), Some(aggs))
 
         val aRef = Ref(genUID(), a.typ)
         val iRef = Ref(genUID(), TInt32())
 
-        ab += aggSigCheck -> initArgs
+        ab += InitOp2(i, knownLength.map(FastSeq(_)).getOrElse(FastSeq[IR]()) :+ Begin(initOps), aggSigCheck)
         seqBuilder +=
           Let(
             aRef.name, a,

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -201,7 +201,7 @@ object Extract {
     case _ => sig1 == sig2
   }
 
-  def getAgg(aggSig: AggSignature2): StagedRegionValueAggregator = aggSig match {
+  def getAgg(aggSig: AggSignature2): StagedAggregator = aggSig match {
     case AggSignature2(Sum(), _, Seq(t), _) =>
       new SumAggregator(t.physicalType)
     case AggSignature2(Count(), _, _, _) =>

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -207,7 +207,7 @@ object Extract {
     case AggSignature2(Count(), _, _, _) =>
       CountAggregator
     case AggSignature2(AggElementsLengthCheck(), initOpArgs, _, Some(nestedAggs)) =>
-      val knownLength = nestedAggs.flatMap(_.initOpArgs).length == initOpArgs.length - 1
+      val knownLength = initOpArgs.length == 2
       new ArrayElementLengthCheckAggregator(nestedAggs.map(getAgg).toArray, knownLength)
     case AggSignature2(AggElements(), _, _, Some(nestedAggs)) =>
       new ArrayElementwiseOpAggregator(nestedAggs.map(getAgg).toArray)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
@@ -33,7 +33,7 @@ class PrevNonNullAggregator(typ: PType) extends StagedAggregator {
       case _: PFloat64 => state.region.storeDouble(stateType.fieldOffset(state.off, 0), elt.value[Double])
       case _ =>
         val v = state.mb.newField[Long]
-        Code(v := elt.v[Long],
+        Code(v := elt.value[Long],
           StagedRegionValueBuilder.deepCopy(state.er, typ, v, stateType.fieldOffset(state.off, 0)))
     }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
@@ -2,15 +2,12 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.{Region, StagedRegionValueBuilder}
 import is.hail.asm4s._
-import is.hail.expr.ir.EmitMethodBuilder
+import is.hail.expr.ir.{EmitMethodBuilder, EmitTriplet}
 import is.hail.expr.types.physical._
 import is.hail.utils._
 
-class PrevNonNullAggregator(typ: PType) extends StagedRegionValueAggregator {
+class PrevNonNullAggregator(typ: PType) extends StagedAggregator {
   type State = TypedRVAState
-
-  val initOpTypes: Array[PType] = Array()
-  val seqOpTypes: Array[PType] = Array(typ)
 
   val stateType: PTuple = PTuple(FastIndexedSeq(typ.setRequired(false)))
   val resultType: PType = typ
@@ -18,27 +15,26 @@ class PrevNonNullAggregator(typ: PType) extends StagedRegionValueAggregator {
   def createState(mb: EmitMethodBuilder): State =
     TypedRVAState(stateType, mb)
 
-  def initOp(state: State, init: Array[RVAVariable], dummy: Boolean): Code[Unit] = {
+  def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
     assert(init.length == 0)
     Code(
       state.off := state.region.allocate(stateType.alignment, stateType.byteSize),
       stateType.setFieldMissing(state.region, state.off, 0))
   }
 
-  def seqOp(state: State, seq: Array[RVAVariable], dummy: Boolean): Code[Unit] = {
-    val Array(elt: RVAVariable) = seq
-    assert(elt.t == typ)
+  def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+    val Array(elt: EmitTriplet) = seq
 
     val copyValue = typ match {
-      case _: PBoolean => state.region.storeByte(stateType.fieldOffset(state.off, 0), elt.v[Boolean].toI.toB)
-      case _: PInt32 => state.region.storeInt(stateType.fieldOffset(state.off, 0), elt.v[Int])
-      case _: PInt64 => state.region.storeLong(stateType.fieldOffset(state.off, 0), elt.v[Long])
-      case _: PFloat32 => state.region.storeFloat(stateType.fieldOffset(state.off, 0), elt.v[Float])
-      case _: PFloat64 => state.region.storeDouble(stateType.fieldOffset(state.off, 0), elt.v[Double])
+      case _: PBoolean => state.region.storeByte(stateType.fieldOffset(state.off, 0), elt.value[Boolean].toI.toB)
+      case _: PInt32 => state.region.storeInt(stateType.fieldOffset(state.off, 0), elt.value[Int])
+      case _: PInt64 => state.region.storeLong(stateType.fieldOffset(state.off, 0), elt.value[Long])
+      case _: PFloat32 => state.region.storeFloat(stateType.fieldOffset(state.off, 0), elt.value[Float])
+      case _: PFloat64 => state.region.storeDouble(stateType.fieldOffset(state.off, 0), elt.value[Double])
       case _ =>
         val v = state.mb.newField[Long]
         Code(v := elt.v[Long],
-          StagedRegionValueBuilder.deepCopy(state.er, elt.t, v, stateType.fieldOffset(state.off, 0)))
+          StagedRegionValueBuilder.deepCopy(state.er, typ, v, stateType.fieldOffset(state.off, 0)))
     }
 
     Code(

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedAggregator.scala
@@ -5,33 +5,23 @@ import is.hail.asm4s._
 import is.hail.expr.ir.{EmitMethodBuilder, EmitTriplet}
 import is.hail.expr.types.physical.PType
 
-case class RVAVariable(triplet: EmitTriplet, t: PType) {
-  def setup: Code[Unit] = triplet.setup
-  def m: Code[Boolean] = triplet.m
-  def v[T]: Code[T] = triplet.value[T]
-}
-
-abstract class StagedRegionValueAggregator {
+abstract class StagedAggregator {
   type State <: AggregatorState
-  def eltArgIdx: Int = 0
-
-  def initOpTypes: Array[PType]
-  def seqOpTypes: Array[PType]
 
   def resultType: PType
 
   def createState(mb: EmitMethodBuilder): State
 
-  def initOp(state: State, init: Array[RVAVariable], dummy: Boolean): Code[Unit]
+  def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit]
 
-  def seqOp(state: State, seq: Array[RVAVariable], dummy: Boolean): Code[Unit]
+  def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit]
 
   def combOp(state: State, other: State, dummy: Boolean): Code[Unit]
 
   def result(state: State, srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit]
 
-  def initOp(state: AggregatorState, init: Array[RVAVariable]): Code[Unit] = initOp(state.asInstanceOf[State], init, dummy = true)
-  def seqOp(state: AggregatorState, seq: Array[RVAVariable]): Code[Unit] = seqOp(state.asInstanceOf[State], seq, dummy = true)
+  def initOp(state: AggregatorState, init: Array[EmitTriplet]): Code[Unit] = initOp(state.asInstanceOf[State], init, dummy = true)
+  def seqOp(state: AggregatorState, seq: Array[EmitTriplet]): Code[Unit] = seqOp(state.asInstanceOf[State], seq, dummy = true)
   def combOp(state: AggregatorState, other: AggregatorState): Code[Unit] = combOp(state.asInstanceOf[State], other.asInstanceOf[State], dummy = true)
   def result(state: AggregatorState, srvb: StagedRegionValueBuilder): Code[Unit] = result(state.asInstanceOf[State], srvb, dummy = true)
 }

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -28,7 +28,7 @@ class Aggregators2Suite extends HailSuite {
   val sumAgg = agg.Extract.getAgg(sumAggSig)
 
   val aggSigs = FastIndexedSeq(pnnAggSig, countAggSig, sumAggSig)
-  val aggs: Array[StagedRegionValueAggregator] = Array(pnnAgg, countAgg, sumAgg)
+  val aggs: Array[StagedAggregator] = Array(pnnAgg, countAgg, sumAgg)
 
 
   val lcAggSig = AggSignature2(AggElementsLengthCheck(), FastSeq[Type](), FastSeq[Type](TInt32()), Some(aggSigs))

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -113,7 +113,7 @@ class Aggregators2Suite extends HailSuite {
 
   @Test def testArrayElementsAgg() {
     val aggSigs = FastIndexedSeq(pnnAggSig, countAggSig, sumAggSig)
-    val lcAggSig = AggSignature2(AggElementsLengthCheck(), FastSeq[Type](), FastSeq[Type](TInt32()), Some(aggSigs))
+    val lcAggSig = AggSignature2(AggElementsLengthCheck(), FastSeq[Type](TVoid), FastSeq[Type](TInt32()), Some(aggSigs))
     val eltAggSig = AggSignature2(AggElements(), FastSeq[Type](), FastSeq[Type](TInt32(), TVoid), Some(aggSigs))
 
 

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -1,263 +1,155 @@
 package is.hail.expr.ir
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
-
 import is.hail.HailSuite
 import is.hail.annotations._
 import is.hail.asm4s._
-import is.hail.expr.ir.agg._
 import is.hail.expr.types.physical._
 import is.hail.expr.types.virtual._
-import is.hail.io.{CodecSpec, InputBuffer, OutputBuffer}
-import is.hail.methods.ForceCountTable
+import is.hail.io.CodecSpec
 import is.hail.utils._
 import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
 class Aggregators2Suite extends HailSuite {
 
-  val rowType = PStruct("a" -> PString(), "b" -> PInt64())
-  val arrayType = PArray(rowType)
-  val streamType = PArray(arrayType)
+  def assertAggEquals(
+    aggSig: AggSignature2,
+    initArgs: IndexedSeq[IR],
+    seqArgs: IndexedSeq[IndexedSeq[IR]],
+    expected: Any,
+    args: IndexedSeq[(String, (Type, Any))] = FastIndexedSeq(),
+    nPartitions: Int = 2): Unit = {
+    assert(seqArgs.length >= 2 * nPartitions, s"Test aggregators with a larger stream!")
 
-  val pnnAggSig = AggSignature2(PrevNonnull(), FastSeq[Type](), FastSeq[Type](rowType.virtualType), None)
-  val pnnAgg = agg.Extract.getAgg(pnnAggSig)
-  val countAggSig = AggSignature2(Count(), FastSeq[Type](), FastSeq[Type](), None)
-  val countAgg = agg.Extract.getAgg(countAggSig)
-  val sumAggSig = AggSignature2(Sum(), FastSeq[Type](), FastSeq[Type](TInt64()), None)
-  val sumAgg = agg.Extract.getAgg(sumAggSig)
-
-  val aggSigs = FastIndexedSeq(pnnAggSig, countAggSig, sumAggSig)
-  val aggs: Array[StagedAggregator] = Array(pnnAgg, countAgg, sumAgg)
-
-
-  val lcAggSig = AggSignature2(AggElementsLengthCheck(), FastSeq[Type](TVoid), FastSeq[Type](TInt32()), Some(aggSigs))
-  val lcAgg: ArrayElementLengthCheckAggregator = agg.Extract.getAgg(lcAggSig).asInstanceOf[ArrayElementLengthCheckAggregator]
-  val eltAggSig = AggSignature2(AggElements(), FastSeq[Type](), FastSeq[Type](TInt32(), TVoid), Some(aggSigs))
-  val eltAgg: ArrayElementwiseOpAggregator = agg.Extract.getAgg(eltAggSig).asInstanceOf[ArrayElementwiseOpAggregator]
-
-  val resType = PTuple(FastSeq(lcAgg.resultType))
-
-  val value = FastIndexedSeq(
-    FastIndexedSeq(Row("a", 0L), Row("b", 0L), Row("c", 0L), Row("f", 0L)),
-    FastIndexedSeq(Row("a", 1L), null, Row("c", 1L), null),
-    FastIndexedSeq(Row("a", 2L), Row("b", 2L), null, Row("f", 2L)),
-    FastIndexedSeq(Row("a", 3L), Row("b", 3L), Row("c", 3L), Row("f", 3L)),
-    FastIndexedSeq(Row("a", 4L), Row("b", 4L), Row("c", 4L), null),
-    FastIndexedSeq(null, null, null, Row("f", 5L)))
-
-  val expected =
-    FastIndexedSeq(
-      Row(Row("a", 4), 6L, 10L),
-      Row(Row("b", 4), 6L, 9L),
-      Row(Row("c", 4), 6L, 8L),
-      Row(Row("f", 5), 6L, 10L))
-
-  def rowVar(a: Code[Long], i: Code[Int]): EmitTriplet =
-    EmitTriplet(Code._empty,
-      arrayType.isElementMissing(a, i),
-      arrayType.loadElement(a, i))
-
-  def bVar(a: Code[Long], i: Code[Int]): EmitTriplet = {
-    val row = rowVar(a, i)
-    EmitTriplet(row.setup,
-      row.m || rowType.isFieldMissing(row.value[Long], 1),
-      Region.loadLong(rowType.loadField(row.value[Long], 1)))
-  }
-
-  def seqOne(s: Array[AggregatorState], a: Code[Long], i: Code[Int]): Code[Unit] = {
-    Code(
-      pnnAgg.seqOp(s(0), Array(rowVar(a, i))),
-      countAgg.seqOp(s(1), Array()),
-      sumAgg.seqOp(s(2), Array(bVar(a, i))))
-  }
-
-  def initAndSeq(s: ArrayElementState, off: Code[Long]): Code[Unit] = {
-    val streamLen = s.mb.newField[Int]
-    val streamIdx = s.mb.newField[Int]
-
-    val aidx = s.mb.newField[Int]
-    val alen = s.mb.newField[Int]
-
-    val a = s.mb.newField[Long]
-    val r = s.region
-
-    val lenVar = EmitTriplet(Code._empty, false, alen)
-    val idxVar = EmitTriplet(Code._empty, false, aidx)
-
-    val eltSeqOp = EmitTriplet(seqOne(s.nested, a, aidx), false, Code._empty)
-
-    Code(
-      lcAgg.initOp(s, Array(EmitTriplet(Code(
-        pnnAgg.initOp(s.nested(0), Array()),
-        countAgg.initOp(s.nested(1), Array()),
-        sumAgg.initOp(s.nested(2), Array())
-      ), false, Code._empty))),
-      streamIdx := 0,
-      streamLen := streamType.loadLength(r, off),
-      Code.whileLoop(streamIdx < streamLen,
-        a := streamType.loadElement(r, off, streamIdx),
-        alen := arrayType.loadLength(r, a),
-        aidx := 0,
-        lcAgg.seqOp(s, Array(lenVar)),
-        Code.whileLoop(aidx < alen,
-          eltAgg.seqOp(s, Array(idxVar, eltSeqOp)),
-          aidx := aidx + 1),
-        streamIdx := streamIdx + 1))
-  }
-
-  @Test def testInitSeqResult() {
-    val firstCol = value.map(_(0))
-
-    val fb = EmitFunctionBuilder[Region, Long, Long]
-    val r = fb.apply_method.getArg[Region](1)
-    val off = fb.apply_method.getArg[Long](2)
-
-    val resType = PTuple(aggs.map(_.resultType))
-    val states: Array[AggregatorState] = aggs.map(_.createState(fb.apply_method))
-    val srvb = new StagedRegionValueBuilder(EmitRegion.default(fb.apply_method), resType)
-
-    val aidx = fb.newField[Int]
-    val alen = fb.newField[Int]
-
-    fb.emit(
-      Code(
-        r.load().setNumParents(aggs.length),
-        Code(Array.tabulate(aggs.length) { i =>
-          Code(
-            states(i).createState,
-            states(i).newState,
-            aggs(i).initOp(states(i), Array()))
-        }: _*),
-        aidx := 0,
-        alen := arrayType.loadLength(r, off),
-        Code.whileLoop(aidx < alen,
-          seqOne(states, off, aidx),
-          aidx := aidx + 1),
-        srvb.start(),
-        Code(aggs.zip(states).map{ case (agg, s) => Code(agg.result(s, srvb), srvb.advance()) }: _*),
-        srvb.offset))
-
-    val aggf = fb.resultWithIndex()
-
-    Region.scoped { region =>
-      val offset = ScalaToRegionValue(region, arrayType.virtualType, firstCol)
-      val res = aggf(0, region)(region, offset)
-      assert(SafeRow(resType, region, res) == expected(0))
-    }
-  }
-
-  @Test def testInitSeqResultArray() {
-    val fb = EmitFunctionBuilder[Region, Long, Long]
-    val r = fb.apply_method.getArg[Region](1)
-    val off = fb.apply_method.getArg[Long](2)
-
-    val s = lcAgg.createState(fb.apply_method)
-    val srvb = new StagedRegionValueBuilder(EmitRegion.default(fb.apply_method), resType)
-
-    fb.emit(
-      Code(
-        r.load().setNumParents(1),
-        s.createState,
-        s.newState,
-        initAndSeq(s, off),
-        srvb.start(),
-        lcAgg.result(s, srvb),
-        srvb.offset))
-
-    val aggf = fb.resultWithIndex()
-
-    Region.scoped { region =>
-      val offset = ScalaToRegionValue(region, streamType.virtualType, value)
-      val res = aggf(0, region)(region, offset)
-      assert(SafeRow(resType, region, res) == Row(expected))
-    }
-  }
-
-  @Test def serializeDeserializeAndCombOp() {
-    val partitioned = value.grouped(3).toFastIndexedSeq
-
-    val fb = EmitFunctionBuilder[Region, Long, Long]
-    val r = fb.apply_method.getArg[Region](1)
-    val off = fb.apply_method.getArg[Long](2)
-
-    val s = lcAgg.createState(fb.apply_method)
-    val s2 = lcAgg.createState(fb.apply_method)
-    val srvb = new StagedRegionValueBuilder(EmitRegion.default(fb.apply_method), resType)
-
-    val partitionIdx = fb.newField[Int]
-    val nPart = fb.newField[Int]
-    val soff = fb.newField[Long]
+    val argT = TStruct(args.map { case (n, (typ, _)) => n -> typ }: _*)
+    val argVs = Row.fromSeq(args.map { case (_, (_, v)) => v })
+    val argRef = Ref(genUID(), argT)
     val spec = CodecSpec.defaultUncompressed
 
-    val serialized = fb.newField[Array[Array[Byte]]]
-    val baos = fb.newField[ByteArrayOutputStream]
-    val bais = fb.newField[ByteArrayInputStream]
-    val ob = fb.newField[OutputBuffer]
-    val ib = fb.newField[InputBuffer]
+    val (_, combAndDuplicate) = CompileWithAggregators2[Unit](
+      Array.fill(nPartitions)(aggSig),
+      Begin(
+        Array.tabulate(nPartitions)(i => DeserializeAggs(i, i, spec, Array(aggSig))) ++
+          Array.range(1, nPartitions).map(i => CombOp2(0, i, aggSig)) :+
+          SerializeAggs(0, 0, spec, Array(aggSig)) :+
+          DeserializeAggs(1, 0, spec, Array(aggSig))))
 
-    fb.emit(
-      Code(
-        r.load().setNumParents(2),
-        s.createState,
-        s2.createState,
-        s.newState,
-        nPart := PArray(streamType).loadLength(r, off),
-        partitionIdx := 0,
-        serialized := Code.newArray[Array[Byte]](nPart),
-        Code.whileLoop(partitionIdx < nPart,
-          baos := Code.newInstance[ByteArrayOutputStream](),
-          ob := spec.buildCodeOutputBuffer(baos),
-          s.newState,
-          soff := PArray(streamType).loadElement(s.region, off, partitionIdx),
-          initAndSeq(s, soff),
-          s.serialize(spec)(ob),
-          ob.invoke[Unit]("flush"),
-          serialized.load().update(partitionIdx, baos.invoke[Array[Byte]]("toByteArray")),
-          partitionIdx := partitionIdx + 1),
-        bais := Code.newInstance[ByteArrayInputStream, Array[Byte]](serialized.load()(0)),
-        ib := spec.buildCodeInputBuffer(bais),
-        s.newState,
-        s.deserialize(spec)(ib),
-        partitionIdx := 1,
-        Code.whileLoop(partitionIdx < nPart,
-          bais := Code.newInstance[ByteArrayInputStream, Array[Byte]](serialized.load()(partitionIdx)),
-          ib := spec.buildCodeInputBuffer(bais),
-          s2.newState,
-          s2.deserialize(spec)(ib),
-          lcAgg.combOp(s, s2),
-          partitionIdx := partitionIdx + 1),
-        srvb.start(),
-        lcAgg.result(s, srvb),
-        srvb.offset))
+    val (rt: PTuple, resF) = CompileWithAggregators2[Long](
+      Array.fill(nPartitions)(aggSig),
+      ResultOp2(0, Array(aggSig, aggSig)))
+    assert(rt.types(0) == rt.types(1))
 
-    val aggf = fb.resultWithIndex()
+    val resultType = rt.types(0)
+    assert(resultType.virtualType.typeCheck(expected))
 
     Region.scoped { region =>
-      val offset = ScalaToRegionValue(region, TArray(streamType.virtualType), partitioned)
-      val res = aggf(0, region)(region, offset)
-      assert(SafeRow(resType, region, res) == Row(expected))
+      val argOff = ScalaToRegionValue(region, argT, argVs)
+      val serializedParts = seqArgs.grouped(math.ceil(seqArgs.length / nPartitions.toDouble).toInt).map { seqs =>
+        val partitionOp = Begin(
+          InitOp2(0, initArgs, aggSig) +:
+            seqs.map { s => SeqOp2(0, s, aggSig) } :+
+            SerializeAggs(0, 0, spec, Array(aggSig)))
+
+        val (_, f) = CompileWithAggregators2[Long, Unit](
+          Array(aggSig),
+          argRef.name, argRef.pType,
+          args.map(_._1).foldLeft[IR](partitionOp) { case (op, name) =>
+              Let(name, GetField(argRef, name), op)
+          })
+
+        val initAndSeq = f(0, region)
+        Region.smallScoped { aggRegion =>
+          initAndSeq.newAggState(aggRegion)
+          initAndSeq(region, argOff, false)
+          initAndSeq.getSerializedAgg(0)
+        }
+      }
+
+      Region.smallScoped { aggRegion =>
+        val combOp = combAndDuplicate(0, region)
+        combOp.newAggState(aggRegion)
+        serializedParts.zipWithIndex.foreach { case (s, i) =>
+          combOp.setSerializedAgg(i, s)
+        }
+        combOp(region)
+
+        val res = resF(0, region)
+        res.setAggState(aggRegion, combOp.getAggOffset())
+        val double = SafeRow(rt, region, res(region))
+        assert(double.get(0) == double.get(1)) // state does not change through serialization
+        assert(double.get(0) == expected)
+      }
     }
   }
 
-  @Test def testEmit() {
-    val array = Ref("array", arrayType.virtualType)
+  val t = TStruct("a" -> TString(), "b" -> TInt64())
+  val rows = FastIndexedSeq(Row("abcd", 5L), null, Row(null, -2L), Row("abcd", 7L), null, Row("foo", null))
+  val arrayType = TArray(t)
+
+  val pnnAggSig = AggSignature2(PrevNonnull(), FastSeq[Type](), FastSeq[Type](t), None)
+  val countAggSig = AggSignature2(Count(), FastSeq[Type](), FastSeq[Type](), None)
+  val sumAggSig = AggSignature2(Sum(), FastSeq[Type](), FastSeq[Type](TInt64()), None)
+
+  @Test def TestCount() {
+    val aggSig = AggSignature2(Count(), FastSeq(), FastSeq(), None)
+    val seqOpArgs = Array.fill(rows.length)(FastIndexedSeq[IR]())
+
+    assertAggEquals(aggSig, FastIndexedSeq(), seqOpArgs, expected = rows.length.toLong, args = FastIndexedSeq(("rows", (arrayType, rows))))
+  }
+
+  @Test def testSum() {
+    val aggSig = AggSignature2(Sum(), FastSeq(), FastSeq(TInt64()), None)
+    val seqOpArgs = Array.tabulate(rows.length)(i => FastIndexedSeq[IR](GetField(ArrayRef(Ref("rows", arrayType), i), "b")))
+
+    assertAggEquals(aggSig, FastIndexedSeq(), seqOpArgs, expected = 10L, args = FastIndexedSeq(("rows", (arrayType, rows))))
+  }
+
+  @Test def testPrevNonnull() {
+    val aggSig = AggSignature2(PrevNonnull(), FastSeq(), FastSeq(t), None)
+    val seqOpArgs = Array.tabulate(rows.length)(i => FastIndexedSeq[IR](ArrayRef(Ref("rows", TArray(t)), i)))
+
+    assertAggEquals(aggSig, FastIndexedSeq(), seqOpArgs, expected = rows.last, args = FastIndexedSeq(("rows", (arrayType, rows))))
+  }
+
+  @Test def testArrayElementsAgg() {
+    val aggSigs = FastIndexedSeq(pnnAggSig, countAggSig, sumAggSig)
+    val lcAggSig = AggSignature2(AggElementsLengthCheck(), FastSeq[Type](), FastSeq[Type](TInt32()), Some(aggSigs))
+    val eltAggSig = AggSignature2(AggElements(), FastSeq[Type](), FastSeq[Type](TInt32(), TVoid), Some(aggSigs))
+
+
+    val value = FastIndexedSeq(
+      FastIndexedSeq(Row("a", 0L), Row("b", 0L), Row("c", 0L), Row("f", 0L)),
+      FastIndexedSeq(Row("a", 1L), null, Row("c", 1L), null),
+      FastIndexedSeq(Row("a", 2L), Row("b", 2L), null, Row("f", 2L)),
+      FastIndexedSeq(Row("a", 3L), Row("b", 3L), Row("c", 3L), Row("f", 3L)),
+      FastIndexedSeq(Row("a", 4L), Row("b", 4L), Row("c", 4L), null),
+      FastIndexedSeq(null, null, null, Row("f", 5L)))
+
+    val expected =
+      FastIndexedSeq(
+        Row(Row("a", 4), 6L, 10L),
+        Row(Row("b", 4), 6L, 9L),
+        Row(Row("c", 4), 6L, 8L),
+        Row(Row("f", 5), 6L, 10L))
+
+    val array = Ref("array", arrayType)
+    val stream = Ref("stream", TArray(arrayType))
     val idx = Ref("idx", TInt32())
-    val elt = Ref("elt", rowType.virtualType)
+    val elt = Ref("elt", t)
 
     val spec = CodecSpec.defaultUncompressed
     val partitioned = value.grouped(3).toFastIndexedSeq
 
     val (_, initAndSeqF) = CompileWithAggregators2[Long, Unit](
       Array(lcAggSig),
-      "stream", streamType,
+      "stream", stream.pType,
       Begin(FastIndexedSeq(
         InitOp2(0, FastIndexedSeq(Begin(FastIndexedSeq[IR](
           InitOp2(0, FastIndexedSeq(), pnnAggSig),
           InitOp2(1, FastIndexedSeq(), countAggSig),
           InitOp2(2, FastIndexedSeq(), sumAggSig)
         ))), lcAggSig),
-        ArrayFor(Ref("stream", streamType.virtualType),
+        ArrayFor(stream,
           array.name,
           Begin(FastIndexedSeq(
             SeqOp2(0, FastIndexedSeq(ArrayLen(array)), lcAggSig),
@@ -275,14 +167,14 @@ class Aggregators2Suite extends HailSuite {
                   eltAggSig)))))),
         SerializeAggs(0, 0, spec, FastIndexedSeq(lcAggSig)))))
 
-    val (_, resultF) = CompileWithAggregators2[Long](
+    val (rt: PTuple, resultF) = CompileWithAggregators2[Long](
       Array(lcAggSig, lcAggSig), ResultOp2(0, FastIndexedSeq(lcAggSig)))
 
     val aggs = Region.scoped { region =>
       val f = initAndSeqF(0, region)
 
       partitioned.map { case lit =>
-        val voff = ScalaToRegionValue(region, streamType.virtualType, lit)
+        val voff = ScalaToRegionValue(region, stream.typ, lit)
 
         Region.scoped { aggRegion =>
           f.newAggState(aggRegion)
@@ -315,7 +207,7 @@ class Aggregators2Suite extends HailSuite {
         resF.setAggState(aggRegion, comb.getAggOffset())
         val res = resF(region)
 
-        assert(SafeRow(resType, region, res) == Row(expected))
+        assert(SafeRow(rt, region, res).get(0) == expected)
       }
     }
   }

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -53,16 +53,16 @@ class Aggregators2Suite extends HailSuite {
       Row(Row("c", 4), 6L, 8L),
       Row(Row("f", 5), 6L, 10L))
 
-  def rowVar(a: Code[Long], i: Code[Int]): RVAVariable =
-    RVAVariable(EmitTriplet(Code._empty,
+  def rowVar(a: Code[Long], i: Code[Int]): EmitTriplet =
+    EmitTriplet(Code._empty,
       arrayType.isElementMissing(a, i),
-      arrayType.loadElement(a, i)), rowType)
+      arrayType.loadElement(a, i))
 
-  def bVar(a: Code[Long], i: Code[Int]): RVAVariable = {
-    val RVAVariable(row, _) = rowVar(a, i)
-    RVAVariable(EmitTriplet(row.setup,
+  def bVar(a: Code[Long], i: Code[Int]): EmitTriplet = {
+    val row = rowVar(a, i)
+    EmitTriplet(row.setup,
       row.m || rowType.isFieldMissing(row.value[Long], 1),
-      Region.loadLong(rowType.loadField(row.value[Long], 1))), PInt64())
+      Region.loadLong(rowType.loadField(row.value[Long], 1)))
   }
 
   def seqOne(s: Array[AggregatorState], a: Code[Long], i: Code[Int]): Code[Unit] = {
@@ -82,10 +82,10 @@ class Aggregators2Suite extends HailSuite {
     val a = s.mb.newField[Long]
     val r = s.region
 
-    val lenVar = RVAVariable(EmitTriplet(Code._empty, false, alen), PInt32())
-    val idxVar = RVAVariable(EmitTriplet(Code._empty, false, aidx), PInt32())
+    val lenVar = EmitTriplet(Code._empty, false, alen)
+    val idxVar = EmitTriplet(Code._empty, false, aidx)
 
-    val eltSeqOp = RVAVariable(EmitTriplet(seqOne(s.nested, a, aidx), false, Code._empty), PVoid)
+    val eltSeqOp = EmitTriplet(seqOne(s.nested, a, aidx), false, Code._empty)
 
     Code(
       lcAgg.initOp(s, Array()),


### PR DESCRIPTION
- rewrite ArrayElements.initOp to take nested initOps as arguments directly
- pass in EmitTriplet instead of RVAVariable; get rid of RVAVariable
- StagedRegionValueAggregator -> StagedAggregator, since doesn't always use RVs
- refactor tests to be more extensible for new aggregators