### PR TITLE
[hail] dedicated IR node for PCRelate

### DIFF
--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -596,6 +596,19 @@ class BlockMatrixToTableApply(TableIR):
     def _eq(self, other):
         return self.config == other.config
 
+    def _compute_type(self):
+        name = self.config['name']
+        assert name == 'PCRelate', name
+        self._type = hl.ttable(
+            hl.tstruct(),
+            hl.tstruct(i=hl.tint32, j=hl.tint32,
+                       kin=hl.tfloat64,
+                       ibd0=hl.tfloat64,
+                       ibd1=hl.tfloat64,
+                       ibd2=hl.tfloat64),
+            ['i', 'j'])
+
+
 class BlockMatrixToTable(TableIR):
     def __init__(self, child):
         super().__init__(child)

--- a/hail/python/hail/ir/table_ir.py
+++ b/hail/python/hail/ir/table_ir.py
@@ -583,6 +583,19 @@ class MatrixToTableApply(TableIR):
                 list(child_typ.row_key))
 
 
+class BlockMatrixToTableApply(TableIR):
+    def __init__(self, bm, aux, config):
+        super().__init__(bm, aux)
+        self.bm = bm
+        self.aux = aux
+        self.config = config
+
+    def head_str(self):
+        return dump_json(self.config)
+
+    def _eq(self, other):
+        return self.config == other.config
+
 class BlockMatrixToTable(TableIR):
     def __init__(self, child):
         super().__init__(child)

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -146,6 +146,10 @@ class TableIRTests(unittest.TestCase):
             ir.MatrixNativeReader(resource('backward_compatability/1.0.0/matrix_table/0.hmt'), None, False),
             False, False)
 
+        block_matrix_read = ir.BlockMatrixRead(ir.BlockMatrixNativeReader('fake_file_path'))
+
+        aa = hl.literal([[0.00],[0.01],[0.02]])._ir
+
         range = ir.TableRange(10, 4)
         table_irs = [
             ir.TableKeyBy(table_read, ['m', 'd'], False),
@@ -190,6 +194,7 @@ class TableIRTests(unittest.TestCase):
             ir.TableMultiWayZipJoin([table_read, table_read], '__data', '__globals'),
             ir.MatrixToTableApply(matrix_read, {'name': 'LinearRegressionRowsSingle', 'yFields': ['col_m'], 'xField': 'entry_m', 'covFields': [], 'rowBlockSize': 10, 'passThrough': []}),
             ir.TableToTableApply(table_read, {'name': 'TableFilterPartitions', 'parts': [0], 'keep': True}),
+            ir.BlockMatrixToTableApply(block_matrix_read, aa, {'name': 'PCRelate', 'maf': 0.01, 'blockSize': 4096}),
             ir.TableFilterIntervals(table_read, [hl.utils.Interval(hl.utils.Struct(row_idx=0), hl.utils.Struct(row_idx=10))], hl.tstruct(row_idx=hl.tint32), keep=False),
         ]
 

--- a/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compilable.scala
@@ -15,6 +15,7 @@ object Compilable {
       case _: TableToValueApply => false
       case _: MatrixToValueApply => false
       case _: BlockMatrixToValueApply => false
+      case _: BlockMatrixToTableApply => false
       case _: RelationalRef => false
       case _: RelationalLet => false
       case _ => true

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1145,6 +1145,11 @@ object IRParser {
         val config = string_literal(it)
         val child = table_ir(env)(it)
         TableToTableApply(child, RelationalFunctions.lookupTableToTable(config))
+      case "BlockMatrixToTableApply" =>
+        val config = string_literal(it)
+        val bm = blockmatrix_ir(env)(it)
+        val aux = ir_value_expr(env)(it)
+        BlockMatrixToTableApply(bm, aux, RelationalFunctions.lookupBlockMatrixToTable(config))
       case "BlockMatrixToTable" =>
         val child = blockmatrix_ir(env)(it)
         BlockMatrixToTable(child)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -358,6 +358,7 @@ object Pretty {
             case TableToTableApply(_, function) => prettyStringLiteral(Serialization.write(function)(RelationalFunctions.formats))
             case TableToValueApply(_, function) => prettyStringLiteral(Serialization.write(function)(RelationalFunctions.formats))
             case MatrixToValueApply(_, function) => prettyStringLiteral(Serialization.write(function)(RelationalFunctions.formats))
+            case BlockMatrixToTableApply(_, _, function) => prettyStringLiteral(Serialization.write(function)(RelationalFunctions.formats))
             case TableRename(_, rowMap, globalMap) =>
               val rowKV = rowMap.toArray
               val globalKV = globalMap.toArray

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -501,6 +501,9 @@ object PruneDeadFields {
             PruneDeadFields.selectKey(child.typ.rowType, child.typ.key))), memo)
       case TableToTableApply(child, f) => memoizeTableIR(child, child.typ, memo)
       case MatrixToTableApply(child, _) => memoizeMatrixIR(child, child.typ, memo)
+      case BlockMatrixToTableApply(bm, aux, _) =>
+        memoizeBlockMatrixIR(bm, bm.typ, memo)
+        memoizeValueIR(aux, aux.typ, memo)
       case BlockMatrixToTable(child) => memoizeBlockMatrixIR(child, child.typ, memo)
       case RelationalLetTable(name, value, body) =>
         memoizeTableIR(body, requestedType, memo)
@@ -1313,6 +1316,10 @@ object PruneDeadFields {
         val value2 = rebuildIR(value, BindingEnv.empty, memo)
         memo.relationalRefs += name -> value2.typ
         RelationalLetTable(name, value2, rebuild(body, memo))
+      case BlockMatrixToTableApply(bmir, aux, function) =>
+        val bmir2 = rebuild(bmir, memo)
+        val aux2 = rebuildIR(aux, BindingEnv.empty, memo)
+        BlockMatrixToTableApply(bmir2, aux2, function)
       case _ => tir.copy(tir.children.map {
         // IR should be a match error - all nodes with child value IRs should have a rule
         case childT: TableIR => rebuild(childT, memo)

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1704,8 +1704,11 @@ case class BlockMatrixToTableApply(
 
   override lazy val typ: TableType = function.typ(bm.typ, aux.typ)
 
-  protected[ir] override def execute(ctx: ExecuteContext): TableValue =
-    function.execute(ctx, bm.execute(ctx), Interpret[Any](ctx, aux))
+  protected[ir] override def execute(ctx: ExecuteContext): TableValue = {
+    val b = bm.execute(ctx)
+    val (a, _) = CompileAndEvaluate[Any](ctx, aux, optimize = false)
+    function.execute(ctx, b, a)
+  }
 }
 
 case class BlockMatrixToTable(child: BlockMatrixIR) extends TableIR {

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -10,7 +10,7 @@ import is.hail.expr.types.physical.{PArray, PBaseStruct, PInt32, PStruct, PType}
 import is.hail.expr.types.virtual._
 import is.hail.expr.JSONAnnotationImpex
 import is.hail.expr.ir
-import is.hail.expr.ir.functions.{MatrixToTableFunction, TableToTableFunction}
+import is.hail.expr.ir.functions.{BlockMatrixToTableFunction, MatrixToTableFunction, TableToTableFunction}
 import is.hail.linalg.{BlockMatrix, BlockMatrixMetadata, BlockMatrixReadRowBlockedRDD}
 import is.hail.rvd._
 import is.hail.sparkextras.ContextRDD
@@ -1687,6 +1687,25 @@ case class TableToTableApply(child: TableIR, function: TableToTableFunction) ext
   protected[ir] override def execute(ctx: ExecuteContext): TableValue = {
     function.execute(ctx, child.execute(ctx))
   }
+}
+
+case class BlockMatrixToTableApply(
+  bm: BlockMatrixIR,
+  aux: IR,
+  function: BlockMatrixToTableFunction) extends TableIR {
+
+  override lazy val children: IndexedSeq[BaseIR] = Array(bm, aux)
+
+  override def copy(newChildren: IndexedSeq[BaseIR]): TableIR =
+    BlockMatrixToTableApply(
+      newChildren(0).asInstanceOf[BlockMatrixIR],
+      newChildren(1).asInstanceOf[IR],
+      function)
+
+  override lazy val typ: TableType = function.typ(bm.typ, aux.typ)
+
+  protected[ir] override def execute(ctx: ExecuteContext): TableValue =
+    function.execute(ctx, bm.execute(ctx), Interpret[Any](ctx, aux))
 }
 
 case class BlockMatrixToTable(child: BlockMatrixIR) extends TableIR {

--- a/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
@@ -33,6 +33,12 @@ abstract class MatrixToTableFunction {
   def lower(): Option[TableToTableFunction] = None
 }
 
+abstract class BlockMatrixToTableFunction {
+  def typ(bmType: BlockMatrixType, auxType: Type): TableType
+
+  def execute(ctx: ExecuteContext, bm: BlockMatrix, aux: Any): TableValue
+}
+
 case class WrappedMatrixToTableFunction(
   function: MatrixToTableFunction,
   colsFieldName: String,
@@ -146,6 +152,8 @@ object RelationalFunctions {
   def lookupMatrixToTable(config: String): MatrixToTableFunction = extractTo[MatrixToTableFunction](config)
 
   def lookupTableToTable(config: String): TableToTableFunction = extractTo[TableToTableFunction](config)
+
+  def lookupBlockMatrixToTable(config: String): BlockMatrixToTableFunction = extractTo[BlockMatrixToTableFunction](config)
 
   def lookupTableToValue(config: String): TableToValueFunction = extractTo[TableToValueFunction](config)
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/RelationalFunctions.scala
@@ -140,7 +140,8 @@ object RelationalFunctions {
     classOf[GetElement],
     classOf[WrappedMatrixToTableFunction],
     classOf[WrappedMatrixToMatrixFunction],
-    classOf[WrappedMatrixToValueFunction]
+    classOf[WrappedMatrixToValueFunction],
+    classOf[PCRelate]
   ))
 
   def extractTo[T: Manifest](config: String): T = {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2362,6 +2362,7 @@ class IRSuite extends HailSuite {
     Array(Skat("a", "b", "c", "d", Array("e", "f"), false, 1, 0.1, 100)),
     Array(LocalLDPrune("x", 0.95, 123, 456)),
     Array(PCA("x", 1, false)),
+    Array(PCRelate(0.00, 4096, Some(0.1), PCRelate.PhiK2K0K1)),
     Array(WindowByLocus(1)),
     Array(MatrixFilterPartitions(Array(1, 2, 3), keep = true)),
     Array(ForceCountTable()),
@@ -2388,6 +2389,7 @@ class IRSuite extends HailSuite {
       case x: MatrixToValueFunction => assert(RelationalFunctions.lookupMatrixToValue(Serialization.write(x)) == x)
       case x: TableToTableFunction => assert(RelationalFunctions.lookupTableToTable(Serialization.write(x)) == x)
       case x: TableToValueFunction => assert(RelationalFunctions.lookupTableToValue(Serialization.write(x)) == x)
+      case x: BlockMatrixToTableFunction => assert(RelationalFunctions.lookupBlockMatrixToTable(Serialization.write(x)) == x)
       case x: BlockMatrixToValueFunction => assert(RelationalFunctions.lookupBlockMatrixToValue(Serialization.write(x)) == x)
     }
   }

--- a/hail/src/test/scala/is/hail/methods/PCRelateSuite.scala
+++ b/hail/src/test/scala/is/hail/methods/PCRelateSuite.scala
@@ -5,11 +5,15 @@ import is.hail.{HailSuite, TestUtils}
 import is.hail.linalg.BlockMatrix
 import is.hail.utils._
 import is.hail.TestUtils._
-import is.hail.variant.MatrixTable
+import is.hail.expr.ir.{BlockMatrixLiteral, BlockMatrixToTableApply, Literal}
+import is.hail.annotations.Annotation
+import is.hail.expr.types.virtual.{TArray, TFloat64}
+import is.hail.table.Table
+import is.hail.variant.{Call, HardCallView, MatrixTable}
+import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.mllib.linalg.distributed.{IndexedRow, IndexedRowMatrix}
 import org.testng.annotations.Test
 import scala.language.postfixOps
-
-import scala.sys.process._
 
 class PCRelateSuite extends HailSuite {
   private val blockSize: Int = BlockMatrix.defaultBlockSize
@@ -20,23 +24,82 @@ class PCRelateSuite extends HailSuite {
   private def toBoxedD(a: Any): java.lang.Double =
     a.asInstanceOf[java.lang.Double]
 
+  type Quad[T] = (T, T, T, T)
+  type Double4 = Quad[Double]
+  type JavaDouble4 = Quad[java.lang.Double]
+
   private def quadMap[T,U](f: T => U): (T, T, T, T) => (U, U, U, U) =
     { case (x, y, z, w) => (f(x), f(y), f(z), f(w)) }
 
-  def runPcRelateHail(
-    vds: MatrixTable,
-    pcs: BDM[Double],
-    maf: Double,
-    minKinship: Double = PCRelate.defaultMinKinship,
-    statistics: PCRelate.StatisticSubset = PCRelate.defaultStatisticSubset): Map[(String, String), (java.lang.Double, java.lang.Double, java.lang.Double, java.lang.Double)] =
-    PCRelate(hc, vds, pcs, maf, blockSize, minKinship, statistics)
+  private def vdsToMeanImputedMatrix(vds: MatrixTable): BlockMatrix = {
+    val nSamples = vds.numCols
+    val localRowPType = vds.rvRowPType
+    val partStarts = vds.partitionStarts()
+    val partStartsBc = vds.hc.backend.broadcast(partStarts)
+    val rdd = vds.rvd.mapPartitionsWithIndex { (partIdx, it) =>
+      val view = HardCallView(localRowPType)
+      val missingIndices = new ArrayBuilder[Int]()
+
+      var rowIdx = partStartsBc.value(partIdx)
+      it.map { rv =>
+        view.setRegion(rv)
+
+        missingIndices.clear()
+        var sum = 0
+        var nNonMissing = 0
+        val a = new Array[Double](nSamples)
+        var i = 0
+        while (i < nSamples) {
+          view.setGenotype(i)
+          if (view.hasGT) {
+            val gt = Call.unphasedDiploidGtIndex(view.getGT)
+            sum += gt
+            a(i) = gt
+            nNonMissing += 1
+          } else
+            missingIndices += i
+          i += 1
+        }
+
+        val mean = sum.toDouble / nNonMissing
+
+        i = 0
+        while (i < missingIndices.length) {
+          a(missingIndices(i)) = mean
+          i += 1
+        }
+
+        rowIdx += 1
+        IndexedRow(rowIdx - 1, Vectors.dense(a))
+      }
+    }
+
+    val irr = new IndexedRowMatrix(rdd.cache(), partStarts.last, nSamples)
+    BlockMatrix.fromIRM(irr, blockSize).cache()
+  }
+
+  def runPcRelateHail(vds: MatrixTable, pcs: BDM[Double], maf: Double): Map[(String, String), JavaDouble4] = {
+    val gIR = new BlockMatrixLiteral(vdsToMeanImputedMatrix(vds))
+    val pcsIR = Literal(TArray(TArray(TFloat64())),
+      IndexedSeq.tabulate(pcs.rows) { row =>
+        IndexedSeq.tabulate(pcs.cols)(pcs(row, _)) })
+
+    val sampleIds = vds.stringSampleIds.toArray[Annotation]
+    val tir = BlockMatrixToTableApply(gIR, pcsIR, new PCRelate(maf, blockSize))
+
+    new Table(hc, tir)
       .collect()
-      .map(r => ((r(0), r(1)), (r(2), r(3), r(4), r(5))))
+      .map { r =>
+        val i = r(0).asInstanceOf[Int]
+        val j = r(1).asInstanceOf[Int]
+        ((sampleIds(i), sampleIds(j)), (r(2), r(3), r(4), r(5)))
+      }
       .toMap
       .mapValues(quadMap(toBoxedD).tupled)
-      .asInstanceOf[Map[(String, String), (java.lang.Double, java.lang.Double, java.lang.Double, java.lang.Double)]]
+      .asInstanceOf[Map[(String, String), JavaDouble4]]
+  }
 
-  def compareDoubleQuadruplet(cmp: (Double, Double) => Boolean)(x: (Double, Double, Double, Double), y: (Double, Double, Double, Double)): Boolean =
+  private def compareDoubleQuadruplet(cmp: (Double, Double) => Boolean)(x: Double4, y: Double4): Boolean =
     cmp(x._1, y._1) && cmp(x._2, y._2) && cmp(x._3, y._3) && cmp(x._4, y._4)
 
   @Test


### PR DESCRIPTION
- clean up PCRelate
  - [x] use IR node
  - [x] clean up unneeded/test-only functions
  - [x] delete pyApply
- BlockMatrixToTableFunction
  - [x] class
  - [x] .execute
  - [x] type info
- BlockMatrixToTableApply
  - [x] class
  - [x] .children
  - [x] .copy
  - [x] InferType
  - [x] PruneDeadField -- *not sure if correct, needs to be looked at*
  - [x] Interpretable, Compilable
  - [x] Parser
  - [x] Pretty
  - [x] IRSuite
  - [x] Interpret
  - [x] Lower(?)