### PR TITLE
lift TableAggregate to new aggregator path

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -63,6 +63,18 @@ trait FunctionWithAggRegion {
   def setSerializedAgg(i: Int, b: Array[Byte]): Unit
 
   def getSerializedAgg(i: Int): Array[Byte]
+
+  def initialize(aggRegion: Region, serialized: Array[Byte]): Unit = {
+    newAggState(aggRegion)
+    setSerializedAgg(0, serialized)
+  }
+
+  def initialize(aggRegion: Region, serialized: Array[Array[Byte]]): Unit = {
+    newAggState(aggRegion)
+    Array.range(0, serialized.length).foreach { i =>
+      setSerializedAgg(i, serialized(i))
+    }
+  }
 }
 
 trait FunctionWithLiterals {

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -63,18 +63,6 @@ trait FunctionWithAggRegion {
   def setSerializedAgg(i: Int, b: Array[Byte]): Unit
 
   def getSerializedAgg(i: Int): Array[Byte]
-
-  def initialize(aggRegion: Region, serialized: Array[Byte]): Unit = {
-    newAggState(aggRegion)
-    setSerializedAgg(0, serialized)
-  }
-
-  def initialize(aggRegion: Region, serialized: Array[Array[Byte]]): Unit = {
-    newAggState(aggRegion)
-    Array.range(0, serialized.length).foreach { i =>
-      setSerializedAgg(i, serialized(i))
-    }
-  }
 }
 
 trait FunctionWithLiterals {

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -848,7 +848,8 @@ object Interpret {
               Region.scoped { r =>
                 val resF = f(0, r)
                 Region.smallScoped { aggRegion =>
-                  resF.initialize(aggRegion, aggResults)
+                  resF.newAggState(aggRegion)
+                  resF.setSerializedAgg(0, aggResults)
                   SafeRow(rTyp, r, resF(r, globalsOffset, false))
                 }
               }

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -790,7 +790,7 @@ object Interpret {
             val wrapped = if (extracted.aggs.isEmpty) {
               val (rt: PTuple, f) = Compile[Long, Long](
                 "global", value.globals.t,
-                MakeTuple(FastSeq(extracted.postAggIR)))
+                MakeTuple.ordered(FastSeq(extracted.postAggIR)))
 
               Region.scoped { region =>
                 SafeRow(rt, region, f(0, region)(region, globalsOffset, false))

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -4,7 +4,6 @@ import is.hail.{HailContext, stats}
 import is.hail.annotations.aggregators.RegionValueAggregator
 import is.hail.annotations._
 import is.hail.asm4s.AsmFunction3
-import is.hail.expr.ir.agg
 import is.hail.expr.{JSONAnnotationImpex, TypedAggregator}
 import is.hail.expr.types._
 import is.hail.expr.types.physical.{PTuple, PType}

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -803,8 +803,6 @@ object Interpret {
                 "global", value.globals.t,
                 extracted.init)
 
-              println(Pretty(query))
-              println(Pretty(extracted.seqPerElt))
               val (_, partitionOpSeq) = CompileWithAggregators2[Long, Long, Unit](
                 extracted.aggs,
                 "global", value.globals.t,

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -816,7 +816,7 @@ object Interpret {
               val (rTyp: PTuple, f) = CompileWithAggregators2[Long, Long](
                 extracted.aggs,
                 "global", value.globals.t,
-                Let(res, extracted.results, MakeTuple(FastSeq(extracted.postAggIR))))
+                Let(res, extracted.results, MakeTuple.ordered(FastSeq(extracted.postAggIR))))
               assert(rTyp.types(0).virtualType == query.typ)
 
               val aggResults = value.rvd.combine[Array[Byte]](

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -803,12 +803,15 @@ object Interpret {
                 "global", value.globals.t,
                 extracted.init)
 
+              println(Pretty(query))
+              println(Pretty(extracted.seqPerElt))
               val (_, partitionOpSeq) = CompileWithAggregators2[Long, Long, Unit](
                 extracted.aggs,
                 "global", value.globals.t,
                 "row", value.rvd.rowPType,
                 extracted.seqPerElt)
 
+              val read = extracted.deserialize(spec)
               val write = extracted.serialize(spec)
               val combOpF = extracted.combOpF(spec)
 
@@ -848,8 +851,7 @@ object Interpret {
               Region.scoped { r =>
                 val resF = f(0, r)
                 Region.smallScoped { aggRegion =>
-                  resF.newAggState(aggRegion)
-                  resF.setSerializedAgg(0, aggResults)
+                  resF.setAggState(aggRegion, read(aggRegion, aggResults))
                   SafeRow(rTyp, r, resF(r, globalsOffset, false))
                 }
               }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -240,7 +240,7 @@ object Extract {
     val rt = TTuple(aggs.map(Extract.getType): _*)
     ref._typ = rt
 
-    Aggs(postAgg, Begin(initOps), Begin(seq.result()), aggs)
+    Aggs(postAgg, Begin(initOps), addLets(Begin(seq.result()), let.result()), aggs)
   }
 
   private def extract(ir: IR, ab: ArrayBuilder[InitOp2], seqBuilder: ArrayBuilder[IR], letBuilder: ArrayBuilder[AggLet], result: IR): IR = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -151,7 +151,8 @@ case class Aggs(postAggIR: IR, init: IR, seqPerElt: IR, aggs: Array[AggSignature
 
     { (aggRegion: Region, bytes: Array[Byte]) =>
       val f2 = f(0, aggRegion);
-      f2.initialize(aggRegion, bytes)
+      f2.newAggState(aggRegion)
+      f2.setSerializedAgg(0, bytes)
       f2(aggRegion)
       f2.getAggOffset()
     }
@@ -181,7 +182,9 @@ case class Aggs(postAggIR: IR, init: IR, seqPerElt: IR, aggs: Array[AggSignature
     { (c1: Array[Byte], c2: Array[Byte]) =>
       Region.smallScoped { aggRegion =>
         val comb = f(0, aggRegion)
-        comb.initialize(aggRegion, Array(c1, c2))
+        comb.newAggState(aggRegion)
+        comb.setSerializedAgg(0, c1)
+        comb.setSerializedAgg(1, c2)
         comb(aggRegion)
         comb.getSerializedAgg(0)
       }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -189,8 +189,6 @@ case class Aggs(postAggIR: IR, init: IR, seqPerElt: IR, aggs: Array[AggSignature
         comb.getSerializedAgg(0)
       }
     }
-
-
   }
 
   def results: IR = ResultOp2(0, aggs)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -36,7 +36,6 @@ object TableMapIRNew {
         null
 
     val spec = CodecSpec.defaultUncompressed
-    val aggSlots = extracted.aggs ++ extracted.aggs
 
     // Order of operations:
     // 1. init op on all aggs and serialize to byte array.
@@ -49,30 +48,18 @@ object TableMapIRNew {
       "global", gType,
       Begin(FastIndexedSeq(extracted.init, extracted.serializeSet(0, 0, spec))))
 
-    val (_, deserializeFirstF) = ir.CompileWithAggregators2[Unit](
-      aggSlots,
-      extracted.deserializeSet(0, 0, spec))
-
-    val (_, serializeFirstF) = ir.CompileWithAggregators2[Unit](
-      aggSlots,
-      extracted.serializeSet(0, 0, spec))
-
     val (_, eltSeqF) = ir.CompileWithAggregators2[Long, Long, Unit](
-      aggSlots,
+      extracted.aggs,
       "global", gType,
       "row", typ.rowType.physicalType,
       extracted.eltOp())
 
-    val (_, combOpF) = ir.CompileWithAggregators2[Unit](
-      aggSlots,
-      Begin(
-        extracted.deserializeSet(0, 0, spec) +:
-        extracted.deserializeSet(1, 1, spec) +:
-          Array.tabulate(nAggs)(i => CombOp2(i, nAggs + i, extracted.aggs(i))) :+
-          extracted.serializeSet(0, 0, spec)))
+    val read = extracted.deserialize(spec)
+    val write = extracted.serialize(spec)
+    val combOpF = extracted.combOpF(spec)
 
     val (rTyp, f) = ir.CompileWithAggregators2[Long, Long, Long](
-      aggSlots,
+      extracted.aggs,
       "global", gType,
       "row", typ.rowType.physicalType,
       Let(scanRef, extracted.results, extracted.postAggIR))
@@ -94,40 +81,20 @@ object TableMapIRNew {
       val globals = if (scanSeqNeedsGlobals) globalsBc.value.readRegionValue(globalRegion) else 0
 
       Region.smallScoped { aggRegion =>
-        val init = deserializeFirstF(i, globalRegion)
         val seq = eltSeqF(i, globalRegion)
-        val write = serializeFirstF(i, globalRegion)
-        init.newAggState(aggRegion)
-        init.setSerializedAgg(0, initAgg)
-        init(globalRegion)
-        seq.setAggState(aggRegion, init.getAggOffset())
+
+        seq.setAggState(aggRegion, read(aggRegion, initAgg))
         it.foreach { rv =>
           seq(rv.region, globals, false, rv.offset, false)
           ctx.region.clear()
         }
-        write.setAggState(aggRegion, seq.getAggOffset())
-        write(globalRegion)
-        Iterator.single(write.getSerializedAgg(0))
-
+        Iterator.single(write(aggRegion, seq.getAggOffset()))
       }
     }, HailContext.get.flags.get("max_leader_scans").toInt)
 
 
     // 3. load in partition aggregations, comb op as necessary, write back out.
-    val partAggs = Region.scoped { fRegion =>
-      val combOp = combOpF(0, fRegion)
-      var i = 0
-      scanPartitionAggs.scanLeft(initAgg) { case (prev, current) =>
-        i += 1
-        Region.scoped { agg2 =>
-          combOp.newAggState(agg2)
-          combOp.setSerializedAgg(0, prev)
-          combOp.setSerializedAgg(1, current)
-          combOp(fRegion)
-          combOp.getSerializedAgg(0)
-        }
-      }
-    }
+    val partAggs = scanPartitionAggs.scanLeft(initAgg)(combOpF)
 
     // 4. load in partStarts, calculate newRow based on those results.
     val itF = { (i: Int, ctx: RVDContext, partitionAggs: Array[Byte], it: Iterator[RegionValue]) =>
@@ -138,13 +105,9 @@ object TableMapIRNew {
         0
 
       val aggRegion = ctx.freshRegion
-      val read = deserializeFirstF(i, globalRegion)
       val newRow = f(i, globalRegion)
       val seq = eltSeqF(i, globalRegion)
-      read.newAggState(aggRegion)
-      read.setSerializedAgg(0, partitionAggs)
-      read(globalRegion)
-      var aggOff = read.getAggOffset()
+      var aggOff = read(aggRegion, partitionAggs)
 
       it.map { rv =>
         newRow.setAggState(aggRegion, aggOff)
@@ -181,6 +144,51 @@ case class Aggs(postAggIR: IR, init: IR, seqPerElt: IR, aggs: Array[AggSignature
     WriteAggs(i * nAggs, path, spec, aggs)
 
   def eltOp(optimize: Boolean = true): IR = if (optimize) Optimize(seqPerElt) else seqPerElt
+
+  def deserialize(spec: CodecSpec): ((Region, Array[Byte]) => Long) = {
+    val (_, f) = ir.CompileWithAggregators2[Unit](
+      aggs, ir.DeserializeAggs(0, 0, spec, aggs))
+
+    { (aggRegion: Region, bytes: Array[Byte]) =>
+      val f2 = f(0, aggRegion);
+      f2.initialize(aggRegion, bytes)
+      f2(aggRegion)
+      f2.getAggOffset()
+    }
+  }
+
+  def serialize(spec: CodecSpec): (Region, Long) => Array[Byte] = {
+    val (_, f) = ir.CompileWithAggregators2[Unit](
+      aggs, ir.SerializeAggs(0, 0, spec, aggs))
+
+    { (aggRegion: Region, off: Long) =>
+      val f2 = f(0, aggRegion);
+      f2.setAggState(aggRegion, off)
+      f2(aggRegion)
+      f2.getSerializedAgg(0)
+    }
+  }
+
+  def combOpF(spec: CodecSpec): (Array[Byte], Array[Byte]) => Array[Byte] = {
+    val (_, f) = ir.CompileWithAggregators2[Unit](
+      aggs ++ aggs,
+      Begin(
+        deserializeSet(0, 0, spec) +:
+          deserializeSet(1, 1, spec) +:
+          Array.tabulate(nAggs)(i => CombOp2(i, nAggs + i, aggs(i))) :+
+          serializeSet(0, 0, spec)))
+
+    { (c1: Array[Byte], c2: Array[Byte]) =>
+      Region.smallScoped { aggRegion =>
+        val comb = f(0, aggRegion)
+        comb.initialize(aggRegion, Array(c1, c2))
+        comb(aggRegion)
+        comb.getSerializedAgg(0)
+      }
+    }
+
+
+  }
 
   def results: IR = ResultOp2(0, aggs)
 }

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -559,7 +559,16 @@ class RVD(
     RVD(typ, newPartitioner, crdd.subsetPartitions(keep))
   }
 
-  // Aggregating
+  // used in Interpret by TableAggregate2
+  def combine[U: ClassTag](
+    zeroValue: U,
+    itF: (Int, RVDContext, Iterator[RegionValue]) => U,
+    combOp: (U, U) => U): U = {
+    val reduced = crdd.cmapPartitionsWithIndex[U] { (i, ctx, it) => Iterator.single(itF(i, ctx, it)) }
+    val ac = new AssociativeCombiner(zeroValue, combOp)
+    sparkContext.runJob(reduced.run, (it: Iterator[U]) => singletonElement(it), ac.combine _)
+    ac.result()
+  }
 
   // used in Interpret by TableAggregate, MatrixAggregate
   def aggregateWithPartitionOp[PC, U: ClassTag](

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -559,6 +559,7 @@ class RVD(
     RVD(typ, newPartitioner, crdd.subsetPartitions(keep))
   }
 
+  // Aggregating
   // used in Interpret by TableAggregate2
   def combine[U: ClassTag](
     zeroValue: U,


### PR DESCRIPTION
Renamed agg->aggArgs in Interpret to avoid name collision.