### PR TITLE
yoink regions out of CodeOrdering method signatures

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/CodeOrdering.scala
+++ b/hail/src/main/scala/is/hail/annotations/CodeOrdering.scala
@@ -19,7 +19,7 @@ object CodeOrdering {
   val gteq: Op = 5
   val neq: Op = 6
 
-  type F[R] = (Code[Region], (Code[Boolean], Code[_]), Code[Region], (Code[Boolean], Code[_])) => Code[R]
+  type F[R] = ((Code[Boolean], Code[_]), (Code[Boolean], Code[_])) => Code[R]
 
   def rowOrdering(t1: PBaseStruct, t2: PBaseStruct, mb: EmitMethodBuilder): CodeOrdering = new CodeOrdering {
     type T = Long
@@ -30,69 +30,69 @@ object CodeOrdering {
     val v1s: Array[LocalRef[_]] = t1.types.map(tf => mb.newLocal(ir.typeToTypeInfo(tf)))
     val v2s: Array[LocalRef[_]] = t2.types.map(tf => mb.newLocal(ir.typeToTypeInfo(tf)))
 
-    def setup(i: Int)(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Unit] = {
+    def setup(i: Int)(x: Code[Long], y: Code[Long]): Code[Unit] = {
       val tf1 = t1.types(i)
       val tf2 = t2.types(i)
       Code(
-        m1 := t1.isFieldMissing(rx, x, i),
-        m2 := t2.isFieldMissing(ry, y, i),
-        v1s(i).storeAny(m1.mux(ir.defaultValue(tf1), rx.loadIRIntermediate(tf1)(t1.fieldOffset(x, i)))),
-        v2s(i).storeAny(m2.mux(ir.defaultValue(tf2), ry.loadIRIntermediate(tf2)(t2.fieldOffset(y, i)))))
+        m1 := t1.isFieldMissing(x, i),
+        m2 := t2.isFieldMissing(y, i),
+        v1s(i).storeAny(m1.mux(ir.defaultValue(tf1), Region.loadIRIntermediate(tf1)(t1.fieldOffset(x, i)))),
+        v2s(i).storeAny(m2.mux(ir.defaultValue(tf2), Region.loadIRIntermediate(tf2)(t2.fieldOffset(y, i)))))
     }
 
-    override def compareNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Int] = {
+    override def compareNonnull(x: Code[Long], y: Code[Long]): Code[Int] = {
       val cmp = mb.newLocal[Int]
 
       val c = Array.tabulate(t1.size) { i =>
         val mbcmp = mb.getCodeOrdering[Int](t1.types(i), t2.types(i), CodeOrdering.compare)
-        Code(setup(i)(rx, x, ry, y),
-          mbcmp(rx, (m1, v1s(i)), ry, (m2, v2s(i))))
+        Code(setup(i)(x, y),
+          mbcmp((m1, v1s(i)), (m2, v2s(i))))
       }.foldRight[Code[Int]](cmp.load()) { (ci, cont) => cmp.ceq(0).mux(Code(cmp := ci, cont), cmp) }
 
       Code(cmp := 0, c)
     }
 
-    override def ltNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Boolean] = {
+    override def ltNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = {
       Array.tabulate(t1.size) { i =>
         val mblt = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.lt)
         val mbequiv = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.equiv)
-        (Code(setup(i)(rx, x, ry, y), mblt(rx, (m1, v1s(i)), ry, (m2, v2s(i)))),
-          mbequiv(rx, (m1, v1s(i)), ry, (m2, v2s(i))))
+        (Code(setup(i)(x, y), mblt((m1, v1s(i)), (m2, v2s(i)))),
+          mbequiv((m1, v1s(i)), (m2, v2s(i))))
       }.foldRight[Code[Boolean]](false) { case ((clt, ceq), cont) => clt || (ceq && cont) }
     }
 
-    override def lteqNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Boolean] = {
+    override def lteqNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = {
       Array.tabulate(t1.size) { i =>
         val mblteq = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.lteq)
         val mbequiv = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.equiv)
-        (Code(setup(i)(rx, x, ry, y), mblteq(rx, (m1, v1s(i)), ry, (m2, v2s(i)))),
-          mbequiv(rx, (m1, v1s(i)), ry, (m2, v2s(i))))
+        (Code(setup(i)(x, y), mblteq((m1, v1s(i)), (m2, v2s(i)))),
+          mbequiv((m1, v1s(i)), (m2, v2s(i))))
       }.foldRight[Code[Boolean]](true) { case ((clteq, ceq), cont) => clteq && (!ceq || cont) }
     }
 
-    override def gtNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Boolean] = {
+    override def gtNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = {
       Array.tabulate(t1.size) { i =>
         val mbgt = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.gt)
         val mbequiv = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.equiv)
-        (Code(setup(i)(rx, x, ry, y), mbgt(rx, (m1, v1s(i)), ry, (m2, v2s(i)))),
-          mbequiv(rx, (m1, v1s(i)), ry, (m2, v2s(i))))
+        (Code(setup(i)(x, y), mbgt((m1, v1s(i)), (m2, v2s(i)))),
+          mbequiv((m1, v1s(i)), (m2, v2s(i))))
       }.foldRight[Code[Boolean]](false) { case ((cgt, ceq), cont) => cgt || (ceq && cont) }
     }
 
-    override def gteqNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Boolean] = {
+    override def gteqNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = {
       Array.tabulate(t1.size) { i =>
         val mbgteq = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.gteq)
         val mbequiv = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.equiv)
-        (Code(setup(i)(rx, x, ry, y), mbgteq(rx, (m1, v1s(i)), ry, (m2, v2s(i)))),
-          mbequiv(rx, (m1, v1s(i)), ry, (m2, v2s(i))))
+        (Code(setup(i)(x, y), mbgteq((m1, v1s(i)), (m2, v2s(i)))),
+          mbequiv((m1, v1s(i)), (m2, v2s(i))))
       }.foldRight[Code[Boolean]](true) { case ((cgteq, ceq), cont) => cgteq && (!ceq || cont) }
     }
 
-    override def equivNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Boolean] = {
+    override def equivNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = {
       Array.tabulate(t1.size) { i =>
         val mbequiv = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.equiv)
-        Code(setup(i)(rx, x, ry, y),
-          mbequiv(rx, (m1, v1s(i)), ry, (m2, v2s(i))))
+        Code(setup(i)(x, y),
+          mbequiv((m1, v1s(i)), (m2, v2s(i))))
       }.foldRight[Code[Boolean]](const(true))(_ && _)
     }
   }
@@ -112,94 +112,94 @@ object CodeOrdering {
     val eq: LocalRef[Boolean] = mb.newLocal[Boolean]
 
     def loop(cmp: Code[Unit], loopCond: Code[Boolean])
-      (rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Unit] = {
+      (x: Code[Long], y: Code[Long]): Code[Unit] = {
       Code(
         i := 0,
-        len1 := t1.loadLength(rx, x),
-        len2 := t2.loadLength(ry, y),
+        len1 := t1.loadLength(x),
+        len2 := t2.loadLength(y),
         lim := (len1 < len2).mux(len1, len2),
         Code.whileLoop(loopCond && i < lim,
-          m1 := t1.isElementMissing(rx, x, i),
-          v1.storeAny(rx.loadIRIntermediate(t1.elementType)(t1.elementOffset(x, len1, i))),
-          m2 := t2.isElementMissing(ry, y, i),
-          v2.storeAny(ry.loadIRIntermediate(t2.elementType)(t2.elementOffset(y, len2, i))),
+          m1 := t1.isElementMissing(x, i),
+          v1.storeAny(Region.loadIRIntermediate(t1.elementType)(t1.elementOffset(x, len1, i))),
+          m2 := t2.isElementMissing(y, i),
+          v2.storeAny(Region.loadIRIntermediate(t2.elementType)(t2.elementOffset(y, len2, i))),
           cmp, i += 1))
     }
 
-    override def compareNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Int] = {
+    override def compareNonnull(x: Code[Long], y: Code[Long]): Code[Int] = {
       val mbcmp = mb.getCodeOrdering[Int](t1.elementType, t2.elementType, CodeOrdering.compare)
       val cmp = mb.newLocal[Int]
 
       Code(cmp := 0,
-        loop(cmp := mbcmp(rx, (m1, v1), ry, (m2, v2)), cmp.ceq(0))(rx, x, ry, y),
+        loop(cmp := mbcmp((m1, v1), (m2, v2)), cmp.ceq(0))(x, y),
         cmp.ceq(0).mux(
-          lord.compareNonnull(rx, coerce[lord.T](len1.load()), ry, coerce[lord.T](len2.load())),
+          lord.compareNonnull(coerce[lord.T](len1.load()), coerce[lord.T](len2.load())),
           cmp))
     }
 
-    override def ltNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Boolean] = {
+    override def ltNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = {
       val mblt = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.lt)
       val mbequiv = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.equiv)
       val lt = mb.newLocal[Boolean]
       val lcmp = Code(
-        lt := mblt(rx, (m1, v1), ry, (m2, v2)),
-        eq := mbequiv(rx, (m1, v1), ry, (m2, v2)))
+        lt := mblt((m1, v1), (m2, v2)),
+        eq := mbequiv((m1, v1), (m2, v2)))
 
       Code(lt := false, eq := true,
-        loop(lcmp, !lt && eq)(rx, x, ry, y),
-        lt || eq && lord.ltNonnull(rx, coerce[lord.T](len1.load()), ry, coerce[lord.T](len2.load())))
+        loop(lcmp, !lt && eq)(x, y),
+        lt || eq && lord.ltNonnull(coerce[lord.T](len1.load()), coerce[lord.T](len2.load())))
     }
 
-    override def lteqNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Boolean] = {
+    override def lteqNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = {
       val mblteq = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.lteq)
       val mbequiv = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.equiv)
 
       val lteq = mb.newLocal[Boolean]
       val lcmp = Code(
-        lteq := mblteq(rx, (m1, v1), ry, (m2, v2)),
-        eq := mbequiv(rx, (m1, v1), ry, (m2, v2)))
+        lteq := mblteq((m1, v1), (m2, v2)),
+        eq := mbequiv((m1, v1), (m2, v2)))
 
       Code(lteq := true, eq := true,
-        loop(lcmp, eq)(rx, x, ry, y),
-        lteq && (!eq || lord.lteqNonnull(rx, coerce[lord.T](len1.load()), ry, coerce[lord.T](len2.load()))))
+        loop(lcmp, eq)(x, y),
+        lteq && (!eq || lord.lteqNonnull(coerce[lord.T](len1.load()), coerce[lord.T](len2.load()))))
     }
 
-    override def gtNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Boolean] = {
+    override def gtNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = {
       val mbgt = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.gt)
       val mbequiv = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.equiv)
       val gt = mb.newLocal[Boolean]
       val lcmp = Code(
-        gt := mbgt(rx, (m1, v1), ry, (m2, v2)),
-        eq := !gt && mbequiv(rx, (m1, v1), ry, (m2, v2)))
+        gt := mbgt((m1, v1), (m2, v2)),
+        eq := !gt && mbequiv((m1, v1), (m2, v2)))
 
       Code(gt := false,
         eq := true,
-        loop(lcmp, eq)(rx, x, ry, y),
+        loop(lcmp, eq)(x, y),
         gt || (eq &&
-            lord.gtNonnull(rx, coerce[lord.T](len1.load()), ry, coerce[lord.T](len2.load()))))
+            lord.gtNonnull(coerce[lord.T](len1.load()), coerce[lord.T](len2.load()))))
     }
 
-    override def gteqNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Boolean] = {
+    override def gteqNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = {
       val mbgteq = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.gteq)
       val mbequiv = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.equiv)
 
       val gteq = mb.newLocal[Boolean]
       val lcmp = Code(
-        gteq := mbgteq(rx, (m1, v1), ry, (m2, v2)),
-        eq := mbequiv(rx, (m1, v1), ry, (m2, v2)))
+        gteq := mbgteq((m1, v1), (m2, v2)),
+        eq := mbequiv((m1, v1), (m2, v2)))
 
       Code(gteq := true,
         eq := true,
-        loop(lcmp, eq)(rx, x, ry, y),
-        gteq && (!eq || lord.gteqNonnull(rx, coerce[lord.T](len1.load()), ry, coerce[lord.T](len2.load()))))
+        loop(lcmp, eq)(x, y),
+        gteq && (!eq || lord.gteqNonnull(coerce[lord.T](len1.load()),  coerce[lord.T](len2.load()))))
     }
 
-    override def equivNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Boolean] = {
+    override def equivNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = {
       val mbequiv = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.equiv)
-      val lcmp = eq := mbequiv(rx, (m1, v1), ry, (m2, v2))
+      val lcmp = eq := mbequiv((m1, v1), (m2, v2))
       Code(eq := true,
-        loop(lcmp, eq)(rx, x, ry, y),
-        eq && lord.equivNonnull(rx, coerce[lord.T](len1.load()), ry, coerce[lord.T](len2.load())))
+        loop(lcmp, eq)(x, y),
+        eq && lord.equivNonnull(coerce[lord.T](len1.load()), coerce[lord.T](len2.load())))
     }
   }
 
@@ -210,97 +210,97 @@ object CodeOrdering {
     val p1: LocalRef[_] = mb.newLocal(ir.typeToTypeInfo(t1.pointType))
     val p2: LocalRef[_] = mb.newLocal(ir.typeToTypeInfo(t2.pointType))
 
-    def loadStart(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Unit] = {
+    def loadStart(x: Code[T], y: Code[T]): Code[Unit] = {
       Code(
-        mp1 := !t1.startDefined(rx, x),
-        mp2 := !t2.startDefined(ry, y),
-        p1.storeAny(mp1.mux(ir.defaultValue(t1.pointType), rx.loadIRIntermediate(t1.pointType)(t1.startOffset(x)))),
-        p2.storeAny(mp2.mux(ir.defaultValue(t2.pointType), ry.loadIRIntermediate(t2.pointType)(t2.startOffset(y)))))
+        mp1 := !t1.startDefined(x),
+        mp2 := !t2.startDefined(y),
+        p1.storeAny(mp1.mux(ir.defaultValue(t1.pointType), Region.loadIRIntermediate(t1.pointType)(t1.startOffset(x)))),
+        p2.storeAny(mp2.mux(ir.defaultValue(t2.pointType), Region.loadIRIntermediate(t2.pointType)(t2.startOffset(y)))))
     }
 
-    def loadEnd(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Unit] = {
+    def loadEnd(x: Code[T], y: Code[T]): Code[Unit] = {
       Code(
-        mp1 := !t1.endDefined(rx, x),
-        mp2 := !t2.endDefined(ry, y),
-        p1.storeAny(mp1.mux(ir.defaultValue(t1.pointType), rx.loadIRIntermediate(t1.pointType)(t1.endOffset(x)))),
-        p2.storeAny(mp2.mux(ir.defaultValue(t2.pointType), ry.loadIRIntermediate(t2.pointType)(t2.endOffset(y)))))
+        mp1 := !t1.endDefined(x),
+        mp2 := !t2.endDefined(y),
+        p1.storeAny(mp1.mux(ir.defaultValue(t1.pointType), Region.loadIRIntermediate(t1.pointType)(t1.endOffset(x)))),
+        p2.storeAny(mp2.mux(ir.defaultValue(t2.pointType), Region.loadIRIntermediate(t2.pointType)(t2.endOffset(y)))))
     }
 
-    override def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Int] = {
+    override def compareNonnull(x: Code[T], y: Code[T]): Code[Int] = {
       val mbcmp = mb.getCodeOrdering[Int](t1.pointType, t2.pointType, CodeOrdering.compare)
 
       val cmp = mb.newLocal[Int]
-      Code(loadStart(rx, x, ry, y),
-        cmp := mbcmp(rx, (mp1, p1), ry, (mp2, p2)),
+      Code(loadStart(x, y),
+        cmp := mbcmp((mp1, p1), (mp2, p2)),
         cmp.ceq(0).mux(
-          Code(mp1 := t1.includeStart(rx, x),
-            mp1.cne(t2.includeStart(ry, y)).mux(
+          Code(mp1 := t1.includeStart(x),
+            mp1.cne(t2.includeStart(y)).mux(
               mp1.mux(-1, 1),
               Code(
-                loadEnd(rx, x, ry, y),
-                cmp := mbcmp(rx, (mp1, p1), ry, (mp2, p2)),
+                loadEnd(x, y),
+                cmp := mbcmp((mp1, p1), (mp2, p2)),
                 cmp.ceq(0).mux(
-                  Code(mp1 := t1.includeEnd(rx, x),
-                    mp1.cne(t2.includeEnd(ry, y)).mux(mp1.mux(1, -1), 0)),
+                  Code(mp1 := t1.includeEnd(x),
+                    mp1.cne(t2.includeEnd(y)).mux(mp1.mux(1, -1), 0)),
                   cmp)))),
           cmp))
     }
 
-    override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] = {
+    override def equivNonnull(x: Code[T], y: Code[T]): Code[Boolean] = {
       val mbeq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.equiv)
 
-      Code(loadStart(rx, x, ry, y), mbeq(rx, (mp1, p1), ry, (mp2, p2))) &&
-        t1.includeStart(rx, x).ceq(t2.includeStart(ry, y)) &&
-        Code(loadEnd(rx, x, ry, y), mbeq(rx, (mp1, p1), ry, (mp2, p2))) &&
-        t1.includeEnd(rx, x).ceq(t2.includeEnd(ry, y))
+      Code(loadStart(x, y), mbeq((mp1, p1), (mp2, p2))) &&
+        t1.includeStart(x).ceq(t2.includeStart(y)) &&
+        Code(loadEnd(x, y), mbeq((mp1, p1), (mp2, p2))) &&
+        t1.includeEnd(x).ceq(t2.includeEnd(y))
     }
 
-    override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] = {
+    override def ltNonnull(x: Code[T], y: Code[T]): Code[Boolean] = {
       val mblt = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.lt)
       val mbeq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.equiv)
 
-      Code(loadStart(rx, x, ry, y), mblt(rx, (mp1, p1), ry, (mp2, p2))) || (
-        mbeq(rx, (mp1, p1), ry, (mp2, p2)) && (
-          Code(mp1 := t1.includeStart(rx, x), mp2 := t2.includeStart(ry, y), mp1 && !mp2) || (mp1.ceq(mp2) && (
-            Code(loadEnd(rx, x, ry, y), mblt(rx, (mp1, p1), ry, (mp2, p2))) || (
-              mbeq(rx, (mp1, p1), ry, (mp2, p2)) &&
-                !t1.includeEnd(rx, x) && t2.includeEnd(ry, y))))))
+      Code(loadStart(x, y), mblt((mp1, p1), (mp2, p2))) || (
+        mbeq((mp1, p1), (mp2, p2)) && (
+          Code(mp1 := t1.includeStart(x), mp2 := t2.includeStart(y), mp1 && !mp2) || (mp1.ceq(mp2) && (
+            Code(loadEnd(x, y), mblt((mp1, p1), (mp2, p2))) || (
+              mbeq((mp1, p1), (mp2, p2)) &&
+                !t1.includeEnd(x) && t2.includeEnd(y))))))
     }
 
-    override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] = {
+    override def lteqNonnull(x: Code[T], y: Code[T]): Code[Boolean] = {
       val mblteq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.lteq)
       val mbeq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.equiv)
 
-      Code(loadStart(rx, x, ry, y), mblteq(rx, (mp1, p1), ry, (mp2, p2))) && (
-        !mbeq(rx, (mp1, p1), ry, (mp2, p2)) || ( // if not equal, then lt
-          Code(mp1 := t1.includeStart(rx, x), mp2 := t2.includeStart(ry, y), mp1 && !mp2) || (mp1.ceq(mp2) && (
-            Code(loadEnd(rx, x, ry, y), mblteq(rx, (mp1, p1), ry, (mp2, p2))) && (
-              !mbeq(rx, (mp1, p1), ry, (mp2, p2)) ||
-                !t1.includeEnd(rx, x) || t2.includeEnd(ry, y))))))
+      Code(loadStart(x, y), mblteq((mp1, p1), (mp2, p2))) && (
+        !mbeq((mp1, p1), (mp2, p2)) || ( // if not equal, then lt
+          Code(mp1 := t1.includeStart(x), mp2 := t2.includeStart(y), mp1 && !mp2) || (mp1.ceq(mp2) && (
+            Code(loadEnd(x, y), mblteq((mp1, p1), (mp2, p2))) && (
+              !mbeq((mp1, p1), (mp2, p2)) ||
+                !t1.includeEnd(x) || t2.includeEnd(y))))))
     }
 
-    override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] = {
+    override def gtNonnull(x: Code[T], y: Code[T]): Code[Boolean] = {
       val mbgt = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.gt)
       val mbeq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.equiv)
 
-      Code(loadStart(rx, x, ry, y), mbgt(rx, (mp1, p1), ry, (mp2, p2))) || (
-        mbeq(rx, (mp1, p1), ry, (mp2, p2)) && (
-          Code(mp1 := t1.includeStart(rx, x), mp2 := t2.includeStart(ry, y), !mp1 && mp2) || (mp1.ceq(mp2) && (
-            Code(loadEnd(rx, x, ry, y), mbgt(rx, (mp1, p1), ry, (mp2, p2))) || (
-              mbeq(rx, (mp1, p1), ry, (mp2, p2)) &&
-                t1.includeEnd(rx, x) && !t2.includeEnd(ry, y))))))
+      Code(loadStart(x, y), mbgt((mp1, p1), (mp2, p2))) || (
+        mbeq((mp1, p1), (mp2, p2)) && (
+          Code(mp1 := t1.includeStart(x), mp2 := t2.includeStart(y), !mp1 && mp2) || (mp1.ceq(mp2) && (
+            Code(loadEnd(x, y), mbgt((mp1, p1), (mp2, p2))) || (
+              mbeq((mp1, p1), (mp2, p2)) &&
+                t1.includeEnd(x) && !t2.includeEnd(y))))))
     }
 
-    override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] = {
+    override def gteqNonnull(x: Code[T], y: Code[T]): Code[Boolean] = {
       val mbgteq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.gteq)
       val mbeq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.equiv)
 
-      Code(loadStart(rx, x, ry, y), mbgteq(rx, (mp1, p1), ry, (mp2, p2))) && (
-        !mbeq(rx, (mp1, p1), ry, (mp2, p2)) || ( // if not equal, then lt
-          Code(mp1 := t1.includeStart(rx, x), mp2 := t2.includeStart(ry, y), !mp1 && mp2) || (mp1.ceq(mp2) && (
-            Code(loadEnd(rx, x, ry, y), mbgteq(rx, (mp1, p1), ry, (mp2, p2))) && (
-              !mbeq(rx, (mp1, p1), ry, (mp2, p2)) ||
-                t1.includeEnd(rx, x) || !t2.includeEnd(ry, y))))))
+      Code(loadStart(x, y), mbgteq((mp1, p1), (mp2, p2))) && (
+        !mbeq((mp1, p1), (mp2, p2)) || ( // if not equal, then lt
+          Code(mp1 := t1.includeStart(x), mp2 := t2.includeStart(y), !mp1 && mp2) || (mp1.ceq(mp2) && (
+            Code(loadEnd(x, y), mbgteq((mp1, p1), (mp2, p2))) && (
+              !mbeq((mp1, p1), (mp2, p2)) ||
+                t1.includeEnd(x) || !t2.includeEnd(y))))))
     }
   }
 
@@ -313,73 +313,67 @@ object CodeOrdering {
 }
 
 abstract class CodeOrdering {
-
   outer =>
 
   type T
   type P = (Code[Boolean], Code[T])
 
-  def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Int]
+  def compareNonnull(x: Code[T], y: Code[T]): Code[Int]
 
-  def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-    compareNonnull(rx, x, ry, y) < 0
+  def ltNonnull(x: Code[T], y: Code[T]): Code[Boolean] = compareNonnull(x, y) < 0
 
-  def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-    compareNonnull(rx, x, ry, y) <= 0
+  def lteqNonnull(x: Code[T], y: Code[T]): Code[Boolean] = compareNonnull(x, y) <= 0
 
-  def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-    compareNonnull(rx, x, ry, y) > 0
+  def gtNonnull(x: Code[T], y: Code[T]): Code[Boolean] = compareNonnull(x, y) > 0
 
-  def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-    compareNonnull(rx, x, ry, y) >= 0
+  def gteqNonnull(x: Code[T], y: Code[T]): Code[Boolean] = compareNonnull(x, y) >= 0
 
-  def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-    compareNonnull(rx, x, ry, y).ceq(0)
+  def equivNonnull(x: Code[T], y: Code[T]): Code[Boolean] = compareNonnull(x, y).ceq(0)
 
-  def compare(rx: Code[Region], x: P, ry: Code[Region], y: P): Code[Int] = {
+  def compare(x: P, y: P): Code[Int] = {
     val (xm, xv) = x
     val (ym, yv) = y
     val compMissing = (xm && ym).mux(0, xm.mux(1, -1))
 
-    (xm || ym).mux(compMissing, compareNonnull(rx, xv, ry, yv))
+    (xm || ym).mux(compMissing, compareNonnull(xv, yv))
   }
 
-  def lt(rx: Code[Region], x: P, ry: Code[Region], y: P): Code[Boolean] = {
+  def lt(x: P, y: P): Code[Boolean] = {
     val (xm, xv) = x
     val (ym, yv) = y
     val compMissing = (xm && ym).mux(false, !xm)
 
-    (xm || ym).mux(compMissing, ltNonnull(rx, xv, ry, yv))
+    (xm || ym).mux(compMissing, ltNonnull(xv, yv))
   }
 
-  def lteq(rx: Code[Region], x: P, ry: Code[Region], y: P): Code[Boolean] = {
+  def lteq(x: P, y: P): Code[Boolean] = {
     val (xm, xv) = x
     val (ym, yv) = y
     val compMissing = (xm && ym).mux(true, !xm)
 
-    (xm || ym).mux(compMissing, lteqNonnull(rx, xv, ry, yv))
+    (xm || ym).mux(compMissing, lteqNonnull(xv, yv))
   }
 
-  def gt(rx: Code[Region], x: P, ry: Code[Region], y: P): Code[Boolean] = {
+  def gt(x: P, y: P): Code[Boolean] = {
     val (xm, xv) = x
     val (ym, yv) = y
     val compMissing = (xm && ym).mux(false, xm)
 
-    (xm || ym).mux(compMissing, gtNonnull(rx, xv, ry, yv))
+    (xm || ym).mux(compMissing, gtNonnull(xv, yv))
   }
 
-  def gteq(rx: Code[Region], x: P, ry: Code[Region], y: P): Code[Boolean] = {
+  def gteq(x: P, y: P): Code[Boolean] = {
     val (xm, xv) = x
     val (ym, yv) = y
     val compMissing = (xm && ym).mux(true, xm)
 
-    (xm || ym).mux(compMissing, gteqNonnull(rx, xv, ry, yv))
+    (xm || ym).mux(compMissing, gteqNonnull(xv, yv))
   }
 
-  def equiv(rx: Code[Region], x: P, ry: Code[Region], y: P): Code[Boolean] = {
+  def equiv(x: P, y: P): Code[Boolean] = {
     val (xm, xv) = x
     val (ym, yv) = y
 
-    (xm || ym).mux(xm && ym, equivNonnull(rx, xv, ry, yv))
+    (xm || ym).mux(xm && ym, equivNonnull(xv, yv))
   }
 }

--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -128,6 +128,26 @@ object Region {
     case _: PFloat32 => v => storeFloat(dest, coerce[Float](v))
     case _: PFloat64 => v => storeDouble(dest, coerce[Double](v))
   }
+
+  def loadIRIntermediate(typ: PType): Code[Long] => Code[_] = typ.fundamentalType match {
+    case _: PBoolean => loadBoolean
+    case _: PInt32 => loadInt
+    case _: PInt64 => loadLong
+    case _: PFloat32 => loadFloat
+    case _: PFloat64 => loadDouble
+    case _: PArray => loadAddress
+    case _: PBinary => loadAddress
+    case _: PBaseStruct => off => off
+  }
+
+  def getIRIntermediate(typ: PType): Code[Long] => Code[_] = typ.fundamentalType match {
+    case _: PBoolean => loadBoolean
+    case _: PInt32 => loadInt
+    case _: PInt64 => loadLong
+    case _: PFloat32 => loadFloat
+    case _: PFloat64 => loadDouble
+    case _ => off => off
+  }
 }
 
 // Off-heap implementation of Region differs from the previous

--- a/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
@@ -2,9 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.annotations.{CodeOrdering, Region}
 import is.hail.asm4s._
-import is.hail.expr.types._
-import is.hail.expr.types.physical.{PBaseStruct, PContainer, PType}
-import is.hail.utils._
+import is.hail.expr.types.physical._
 
 class BinarySearch(mb: EmitMethodBuilder, typ: PContainer, keyOnly: Boolean) {
 
@@ -15,51 +13,44 @@ class BinarySearch(mb: EmitMethodBuilder, typ: PContainer, keyOnly: Boolean) {
     val ttype = coerce[PBaseStruct](elt)
     require(ttype.size == 2)
     val kt = ttype.types(0)
-    val findMB = mb.fb.newMethod(Array[TypeInfo[_]](typeInfo[Region], typeInfo[Long], typeInfo[Boolean], typeToTypeInfo(kt)), typeInfo[Int])
+    val findMB = mb.fb.newMethod(Array[TypeInfo[_]](typeInfo[Long], typeInfo[Boolean], typeToTypeInfo(kt)), typeInfo[Int])
     val mk2l = findMB.newLocal[Boolean]
     val mk2l1 = mb.newLocal[Boolean]
 
     val comp: CodeOrdering.F[Int] = {
-      case (r1: Code[Region],
-      (mk1: Code[Boolean], k1: Code[_]),
-      r2: Code[Region],
-      (m2: Code[Boolean], v2: Code[Long] @unchecked)) =>
-        val mk2 = Code(mk2l := m2 || ttype.isFieldMissing(r2, v2, 0), mk2l)
-        val k2 = mk2l.mux(defaultValue(kt), r2.loadIRIntermediate(kt)(ttype.fieldOffset(v2, 0)))
-        findMB.getCodeOrdering[Int](kt, CodeOrdering.compare)(r1, (mk1, k1), r2, (mk2, k2))
+      case ((mk1: Code[Boolean], k1: Code[_]), (m2: Code[Boolean], v2: Code[Long] @unchecked)) =>
+        val mk2 = Code(mk2l := m2 || ttype.isFieldMissing(v2, 0), mk2l)
+        val k2 = mk2l.mux(defaultValue(kt), Region.loadIRIntermediate(kt)(ttype.fieldOffset(v2, 0)))
+        findMB.getCodeOrdering[Int](kt, CodeOrdering.compare)((mk1, k1), (mk2, k2))
     }
     val ceq: CodeOrdering.F[Boolean] = {
-      case (r1: Code[Region],
-      (mk1: Code[Boolean], k1: Code[_]),
-      r2: Code[Region],
-      (m2: Code[Boolean], v2: Code[Long] @unchecked)) =>
-        val mk2 = Code(mk2l1 := m2 || ttype.isFieldMissing(r2, v2, 0), mk2l1)
-        val k2 = mk2l1.mux(defaultValue(kt), r2.loadIRIntermediate(kt)(ttype.fieldOffset(v2, 0)))
-        mb.getCodeOrdering[Boolean](kt, CodeOrdering.equiv)(r1, (mk1, k1), r2, (mk2, k2))
+      case ((mk1: Code[Boolean], k1: Code[_]), (m2: Code[Boolean], v2: Code[Long] @unchecked)) =>
+        val mk2 = Code(mk2l1 := m2 || ttype.isFieldMissing(v2, 0), mk2l1)
+        val k2 = mk2l1.mux(defaultValue(kt), Region.loadIRIntermediate(kt)(ttype.fieldOffset(v2, 0)))
+        mb.getCodeOrdering[Boolean](kt, CodeOrdering.equiv)((mk1, k1), (mk2, k2))
     }
     (comp, ceq, findMB, kt)
   } else
     (mb.getCodeOrdering[Int](elt, CodeOrdering.compare),
       mb.getCodeOrdering[Boolean](elt, CodeOrdering.equiv),
-      mb.fb.newMethod(Array[TypeInfo[_]](typeInfo[Region], typeInfo[Long], typeInfo[Boolean], typeToTypeInfo(elt)), typeInfo[Int]), elt)
+      mb.fb.newMethod(Array[TypeInfo[_]](typeInfo[Long], typeInfo[Boolean], typeToTypeInfo(elt)), typeInfo[Int]), elt)
 
-  private[this] val region = findElt.getArg[Region](1).load()
-  private[this] val array = findElt.getArg[Long](2)
-  private[this] val m = findElt.getArg[Boolean](3)
-  private[this] val e = findElt.getArg(4)(typeToTypeInfo(t))
+  private[this] val array = findElt.getArg[Long](1)
+  private[this] val m = findElt.getArg[Boolean](2)
+  private[this] val e = findElt.getArg(3)(typeToTypeInfo(t))
   private[this] val len = findElt.newLocal[Int]
   private[this] val i = findElt.newLocal[Int]
   private[this] val low = findElt.newLocal[Int]
   private[this] val high = findElt.newLocal[Int]
 
   def cmp(i: Code[Int]): Code[Int] =
-    compare(region, (m, e),
-      region, (typ.isElementMissing(region, array, i),
-        region.loadIRIntermediate(elt)(typ.elementOffset(array, len, i))))
+    compare((m, e),
+      (typ.isElementMissing(array, i),
+        Region.loadIRIntermediate(elt)(typ.elementOffset(array, len, i))))
 
   // Returns smallest i, 0 <= i < n, for which a(i) >= key, or returns n if a(i) < key for all i
   findElt.emit(Code(
-    len := typ.loadLength(region, array),
+    len := typ.loadLength(array),
     low := 0,
     high := len,
     Code.whileLoop(low < high,
@@ -71,7 +62,6 @@ class BinarySearch(mb: EmitMethodBuilder, typ: PContainer, keyOnly: Boolean) {
 
   // check missingness of v before calling
   def getClosestIndex(array: Code[Long], m: Code[Boolean], v: Code[_]): Code[Int] = {
-    val region = mb.getArg[Region](1).load()
-    findElt.invoke(region, array, m, v)
+    findElt.invoke(array, m, v)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -429,7 +429,7 @@ private class Emit(
         val codeL = emit(l)
         val codeR = emit(r)
         if (op.strict) {
-          strict(f(region, (false, codeL.v), region, (false, codeR.v)),
+          strict(f((false, codeL.v), (false, codeR.v)),
             codeL, codeR)
         } else {
           val lm = mb.newLocal[Boolean]
@@ -439,8 +439,8 @@ private class Emit(
             codeR.setup,
             lm := codeL.m,
             rm := codeR.m,
-            f(region, (lm, lm.mux(defaultValue(l.typ), codeL.v)),
-              region, (rm, rm.mux(defaultValue(r.typ), codeR.v)))))
+            f((lm, lm.mux(defaultValue(l.typ), codeL.v)),
+              (rm, rm.mux(defaultValue(r.typ), codeR.v)))))
         }
 
       case MakeArray(args, typ) =>

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -365,53 +365,49 @@ class EmitFunctionBuilder[F >: Null](
       val rt = if (op == CodeOrdering.compare) typeInfo[Int] else typeInfo[Boolean]
 
       val newMB = if (ignoreMissingness) {
-        val newMB = newMethod(Array[TypeInfo[_]](typeInfo[Region], ti, typeInfo[Region], ti), rt)
+        val newMB = newMethod(Array[TypeInfo[_]](ti, ti), rt)
         val ord = t1.codeOrdering(newMB, t2)
-        val r1 = newMB.getArg[Region](1)
-        val r2 = newMB.getArg[Region](3)
-        val v1 = newMB.getArg(2)(ti)
-        val v2 = newMB.getArg(4)(ti)
+        val v1 = newMB.getArg(1)(ti)
+        val v2 = newMB.getArg(3)(ti)
         val c: Code[_] = op match {
-          case CodeOrdering.compare => ord.compareNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2))
-          case CodeOrdering.equiv => ord.equivNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2))
-          case CodeOrdering.lt => ord.ltNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2))
-          case CodeOrdering.lteq => ord.lteqNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2))
-          case CodeOrdering.gt => ord.gtNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2))
-          case CodeOrdering.gteq => ord.gteqNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2))
-          case CodeOrdering.neq => !ord.equivNonnull(r1, coerce[ord.T](v1), r2, coerce[ord.T](v2))
+          case CodeOrdering.compare => ord.compareNonnull(coerce[ord.T](v1), coerce[ord.T](v2))
+          case CodeOrdering.equiv => ord.equivNonnull(coerce[ord.T](v1), coerce[ord.T](v2))
+          case CodeOrdering.lt => ord.ltNonnull(coerce[ord.T](v1), coerce[ord.T](v2))
+          case CodeOrdering.lteq => ord.lteqNonnull(coerce[ord.T](v1), coerce[ord.T](v2))
+          case CodeOrdering.gt => ord.gtNonnull(coerce[ord.T](v1), coerce[ord.T](v2))
+          case CodeOrdering.gteq => ord.gteqNonnull(coerce[ord.T](v1), coerce[ord.T](v2))
+          case CodeOrdering.neq => !ord.equivNonnull(coerce[ord.T](v1), coerce[ord.T](v2))
         }
         newMB.emit(c)
         newMB
       } else {
-        val newMB = newMethod(Array[TypeInfo[_]](typeInfo[Region], typeInfo[Boolean], ti, typeInfo[Region], typeInfo[Boolean], ti), rt)
+        val newMB = newMethod(Array[TypeInfo[_]](typeInfo[Boolean], ti, typeInfo[Boolean], ti), rt)
         val ord = t1.codeOrdering(newMB, t2)
-        val r1 = newMB.getArg[Region](1)
-        val r2 = newMB.getArg[Region](4)
-        val m1 = newMB.getArg[Boolean](2)
-        val v1 = newMB.getArg(3)(ti)
-        val m2 = newMB.getArg[Boolean](5)
-        val v2 = newMB.getArg(6)(ti)
+        val m1 = newMB.getArg[Boolean](1)
+        val v1 = newMB.getArg(2)(ti)
+        val m2 = newMB.getArg[Boolean](3)
+        val v2 = newMB.getArg(4)(ti)
         val c: Code[_] = op match {
-          case CodeOrdering.compare => ord.compare(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)))
-          case CodeOrdering.equiv => ord.equiv(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)))
-          case CodeOrdering.lt => ord.lt(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)))
-          case CodeOrdering.lteq => ord.lteq(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)))
-          case CodeOrdering.gt => ord.gt(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)))
-          case CodeOrdering.gteq => ord.gteq(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)))
-          case CodeOrdering.neq => !ord.equiv(r1, (m1, coerce[ord.T](v1)), r2, (m2, coerce[ord.T](v2)))
+          case CodeOrdering.compare => ord.compare((m1, coerce[ord.T](v1)), (m2, coerce[ord.T](v2)))
+          case CodeOrdering.equiv => ord.equiv((m1, coerce[ord.T](v1)), (m2, coerce[ord.T](v2)))
+          case CodeOrdering.lt => ord.lt((m1, coerce[ord.T](v1)), (m2, coerce[ord.T](v2)))
+          case CodeOrdering.lteq => ord.lteq((m1, coerce[ord.T](v1)), (m2, coerce[ord.T](v2)))
+          case CodeOrdering.gt => ord.gt((m1, coerce[ord.T](v1)), (m2, coerce[ord.T](v2)))
+          case CodeOrdering.gteq => ord.gteq((m1, coerce[ord.T](v1)), (m2, coerce[ord.T](v2)))
+          case CodeOrdering.neq => !ord.equiv((m1, coerce[ord.T](v1)), (m2, coerce[ord.T](v2)))
         }
         newMB.emit(c)
         newMB
       }
-      val f = { (rx: Code[Region], x: (Code[Boolean], Code[_]), ry: Code[Region], y: (Code[Boolean], Code[_])) =>
+      val f = { (x: (Code[Boolean], Code[_]), y: (Code[Boolean], Code[_])) =>
         if (ignoreMissingness)
-          newMB.invoke(rx, x._2, ry, y._2)
+          newMB.invoke(x._2, y._2)
         else
-          newMB.invoke(rx, x._1, x._2, ry, y._1, y._2)
+          newMB.invoke(x._1, x._2, y._1, y._2)
       }
       f
     })
-    (r1: Code[Region], v1: (Code[Boolean], Code[_]), r2: Code[Region], v2: (Code[Boolean], Code[_])) => coerce[T](f(r1, v1, r2, v2))
+    (v1: (Code[Boolean], Code[_]), v2: (Code[Boolean], Code[_])) => coerce[T](f(v1, v2))
   }
 
   def getCodeOrdering[T](t: PType, op: CodeOrdering.Op, ignoreMissingness: Boolean): CodeOrdering.F[T] =

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -158,8 +158,11 @@ abstract class PBaseStruct extends PType {
   def isFieldMissing(region: Code[Region], offset: Code[Long], fieldIdx: Int): Code[Boolean] =
     isFieldMissing(offset, fieldIdx)
 
+  def isFieldDefined(offset: Code[Long], fieldIdx: Int): Code[Boolean] =
+    !isFieldMissing(offset, fieldIdx)
+
   def isFieldDefined(region: Code[Region], offset: Code[Long], fieldIdx: Int): Code[Boolean] =
-    !isFieldMissing(region, offset, fieldIdx)
+    isFieldDefined(offset, fieldIdx)
 
   def setFieldMissing(region: Region, offset: Long, fieldIdx: Int) {
     assert(!fieldRequired(fieldIdx))

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBoolean.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBoolean.scala
@@ -30,7 +30,7 @@ class PBoolean(override val required: Boolean) extends PType {
     new CodeOrdering {
       type T = Boolean
 
-      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Int] =
+      def compareNonnull(x: Code[T], y: Code[T]): Code[Int] =
         Code.invokeStatic[java.lang.Boolean, Boolean, Boolean, Int]("compare", x, y)
     }
   }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PFloat32.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PFloat32.scala
@@ -33,23 +33,18 @@ class PFloat32(override val required: Boolean) extends PType {
     new CodeOrdering {
       type T = Float
 
-      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Int] =
+      def compareNonnull(x: Code[T], y: Code[T]): Code[Int] =
         Code.invokeStatic[java.lang.Float, Float, Float, Int]("compare", x, y)
 
-      override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x < y
+      override def ltNonnull(x: Code[T], y: Code[T]): Code[Boolean] = x < y
 
-      override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x <= y
+      override def lteqNonnull(x: Code[T], y: Code[T]): Code[Boolean] = x <= y
 
-      override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x > y
+      override def gtNonnull(x: Code[T], y: Code[T]): Code[Boolean] = x > y
 
-      override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x >= y
+      override def gteqNonnull(x: Code[T], y: Code[T]): Code[Boolean] = x >= y
 
-      override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x.ceq(y)
+      override def equivNonnull(x: Code[T], y: Code[T]): Code[Boolean] = x.ceq(y)
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PFloat64.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PFloat64.scala
@@ -33,23 +33,18 @@ class PFloat64(override val required: Boolean) extends PType {
     new CodeOrdering {
       type T = Double
 
-      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Int] =
+      def compareNonnull(x: Code[T], y: Code[T]): Code[Int] =
         Code.invokeStatic[java.lang.Double, Double, Double, Int]("compare", x, y)
 
-      override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x < y
+      override def ltNonnull(x: Code[T], y: Code[T]): Code[Boolean] = x < y
 
-      override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x <= y
+      override def lteqNonnull(x: Code[T], y: Code[T]): Code[Boolean] = x <= y
 
-      override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x > y
+      override def gtNonnull(x: Code[T], y: Code[T]): Code[Boolean] = x > y
 
-      override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x >= y
+      override def gteqNonnull(x: Code[T], y: Code[T]): Code[Boolean] = x >= y
 
-      override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x.ceq(y)
+      override def equivNonnull(x: Code[T], y: Code[T]): Code[Boolean] = x.ceq(y)
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PInt32.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PInt32.scala
@@ -32,23 +32,18 @@ class PInt32(override val required: Boolean) extends PIntegral {
     new CodeOrdering {
       type T = Int
 
-      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Int] =
+      def compareNonnull(x: Code[T], y: Code[T]): Code[Int] =
         Code.invokeStatic[java.lang.Integer, Int, Int, Int]("compare", x, y)
 
-      override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x < y
+      override def ltNonnull(x: Code[T], y: Code[T]): Code[Boolean] = x < y
 
-      override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x <= y
+      override def lteqNonnull(x: Code[T], y: Code[T]): Code[Boolean] = x <= y
 
-      override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x > y
+      override def gtNonnull(x: Code[T], y: Code[T]): Code[Boolean] = x > y
 
-      override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x >= y
+      override def gteqNonnull(x: Code[T], y: Code[T]): Code[Boolean] = x >= y
 
-      override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x.ceq(y)
+      override def equivNonnull(x: Code[T], y: Code[T]): Code[Boolean] = x.ceq(y)
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PInt64.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PInt64.scala
@@ -33,23 +33,18 @@ class PInt64(override val required: Boolean) extends PIntegral {
     new CodeOrdering {
       type T = Long
 
-      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Int] =
+      def compareNonnull(x: Code[T], y: Code[T]): Code[Int] =
         Code.invokeStatic[java.lang.Long, Long, Long, Int]("compare", x, y)
 
-      override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x < y
+      override def ltNonnull(x: Code[T], y: Code[T]): Code[Boolean] = x < y
 
-      override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x <= y
+      override def lteqNonnull(x: Code[T], y: Code[T]): Code[Boolean] = x <= y
 
-      override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x > y
+      override def gtNonnull(x: Code[T], y: Code[T]): Code[Boolean] = x > y
 
-      override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x >= y
+      override def gteqNonnull(x: Code[T], y: Code[T]): Code[Boolean] = x >= y
 
-      override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x.ceq(y)
+      override def equivNonnull(x: Code[T], y: Code[T]): Code[Boolean] = x.ceq(y)
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PInterval.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PInterval.scala
@@ -118,13 +118,13 @@ case class PInterval(pointType: PType, override val required: Boolean = false) e
 
   def includesEnd(region: Region, off: Long): Boolean = region.loadBoolean(representation.loadField(region, off, 3))
 
-  def startDefined(region: Code[Region], off: Code[Long]): Code[Boolean] = representation.isFieldDefined(region, off, 0)
+  def startDefined(off: Code[Long]): Code[Boolean] = representation.isFieldDefined(off, 0)
 
-  def endDefined(region: Code[Region], off: Code[Long]): Code[Boolean] = representation.isFieldDefined(region, off, 1)
+  def endDefined(off: Code[Long]): Code[Boolean] = representation.isFieldDefined(off, 1)
 
-  def includeStart(region: Code[Region], off: Code[Long]): Code[Boolean] =
-    region.loadBoolean(representation.loadField(region, off, 2))
+  def includeStart(off: Code[Long]): Code[Boolean] =
+    Region.loadBoolean(representation.loadField(off, 2))
 
-  def includeEnd(region: Code[Region], off: Code[Long]): Code[Boolean] =
-    region.loadBoolean(representation.loadField(region, off, 3))
+  def includeEnd(off: Code[Long]): Code[Boolean] =
+    Region.loadBoolean(representation.loadField(off, 3))
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PLocus.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PLocus.scala
@@ -69,17 +69,17 @@ case class PLocus(rgBc: BroadcastRGBase, override val required: Boolean = false)
     new CodeOrdering {
       type T = Long
 
-      override def compareNonnull(rx: Code[Region], x: Code[Long], ry: Code[Region], y: Code[Long]): Code[Int] = {
+      override def compareNonnull(x: Code[Long], y: Code[Long]): Code[Int] = {
         val cmp = mb.newLocal[Int]
 
-        val c1 = representation.loadField(rx, x, 0)
-        val c2 = representation.loadField(ry, y, 0)
+        val c1 = representation.loadField(x, 0)
+        val c2 = representation.loadField(y, 0)
 
-        val s1 = Code.invokeScalaObject[Region, Long, String](PString.getClass, "loadString", rx, c1)
-        val s2 = Code.invokeScalaObject[Region, Long, String](PString.getClass, "loadString", ry, c2)
+        val s1 = PString.loadString(c1)
+        val s2 = PString.loadString(c2)
 
-        val p1 = rx.loadInt(representation.fieldOffset(x, 1))
-        val p2 = ry.loadInt(representation.fieldOffset(y, 1))
+        val p1 = Region.loadInt(representation.fieldOffset(x, 1))
+        val p2 = Region.loadInt(representation.fieldOffset(y, 1))
 
         val codeRG = mb.getReferenceGenome(rg.asInstanceOf[ReferenceGenome])
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PString.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PString.scala
@@ -45,11 +45,14 @@ object PString {
     new String(region.loadBytes(PBinary.bytesOffset(boff), length))
   }
 
-  def loadString(region: Code[Region], boff: Code[Long]): Code[String] = {
-    val length = PBinary.loadLength(region, boff)
+  def loadString(boff: Code[Long]): Code[String] = {
+    val length = PBinary.loadLength(boff)
     Code.newInstance[String, Array[Byte]](
-      region.loadBytes(PBinary.bytesOffset(boff), length))
+      Region.loadBytes(PBinary.bytesOffset(boff), length))
   }
+
+  def loadString(region: Code[Region], boff: Code[Long]): Code[String] =
+    loadString(boff)
 
   def loadLength(region: Region, boff: Long): Int =
     PBinary.loadLength(region, boff)

--- a/hail/src/main/scala/is/hail/expr/types/virtual/TInt32.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/TInt32.scala
@@ -29,31 +29,6 @@ class TInt32(override val required: Boolean) extends TIntegral {
 
   val ordering: ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Int]])
-
-  def codeOrdering(mb: EmitMethodBuilder, other: Type): CodeOrdering = {
-    assert(other isOfType this)
-    new CodeOrdering {
-      type T = Int
-
-      def compareNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Int] =
-        Code.invokeStatic[java.lang.Integer, Int, Int, Int]("compare", x, y)
-
-      override def ltNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x < y
-
-      override def lteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x <= y
-
-      override def gtNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x > y
-
-      override def gteqNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x >= y
-
-      override def equivNonnull(rx: Code[Region], x: Code[T], ry: Code[Region], y: Code[T]): Code[Boolean] =
-        x.ceq(y)
-    }
-  }
 }
 
 object TInt32 {

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -27,19 +27,18 @@ class OrderingSuite extends HailSuite {
     inner + 1
   }
 
-  def getStagedOrderingFunction[T: TypeInfo](t: Type, comp: String, r: Region): AsmFunction3[Region, Long, Long, T] = {
+  def getStagedOrderingFunction[T: TypeInfo](t: PType, comp: String, r: Region): AsmFunction3[Region, Long, Long, T] = {
     val fb = EmitFunctionBuilder[Region, Long, Long, T]
-    val stagedOrdering = t.physicalType.codeOrdering(fb.apply_method)
-    val cregion: Code[Region] = fb.getArg[Region](1)
-    val cv1 = coerce[stagedOrdering.T](cregion.getIRIntermediate(t)(fb.getArg[Long](2)))
-    val cv2 = coerce[stagedOrdering.T](cregion.getIRIntermediate(t)(fb.getArg[Long](3)))
+    val stagedOrdering = t.codeOrdering(fb.apply_method)
+    val cv1 = coerce[stagedOrdering.T](Region.getIRIntermediate(t)(fb.getArg[Long](2)))
+    val cv2 = coerce[stagedOrdering.T](Region.getIRIntermediate(t)(fb.getArg[Long](3)))
     comp match {
-      case "compare" => fb.emit(stagedOrdering.compare(cregion, (const(false), cv1), cregion, (const(false), cv2)))
-      case "equiv" => fb.emit(stagedOrdering.equiv(cregion, (const(false), cv1), cregion, (const(false), cv2)))
-      case "lt" => fb.emit(stagedOrdering.lt(cregion, (const(false), cv1), cregion, (const(false), cv2)))
-      case "lteq" => fb.emit(stagedOrdering.lteq(cregion, (const(false), cv1), cregion, (const(false), cv2)))
-      case "gt" => fb.emit(stagedOrdering.gt(cregion, (const(false), cv1), cregion, (const(false), cv2)))
-      case "gteq" => fb.emit(stagedOrdering.gteq(cregion, (const(false), cv1), cregion, (const(false), cv2)))
+      case "compare" => fb.emit(stagedOrdering.compare((const(false), cv1), (const(false), cv2)))
+      case "equiv" => fb.emit(stagedOrdering.equiv((const(false), cv1), (const(false), cv2)))
+      case "lt" => fb.emit(stagedOrdering.lt((const(false), cv1), (const(false), cv2)))
+      case "lteq" => fb.emit(stagedOrdering.lteq((const(false), cv1), (const(false), cv2)))
+      case "gt" => fb.emit(stagedOrdering.gt((const(false), cv1), (const(false), cv2)))
+      case "gteq" => fb.emit(stagedOrdering.gteq((const(false), cv1), (const(false), cv2)))
     }
     fb.resultWithIndex()(0, r)
   }
@@ -63,9 +62,10 @@ class OrderingSuite extends HailSuite {
     } yield (t, a1, a2)
     val p = Prop.forAll(compareGen) { case (t, a1, a2) =>
       Region.scoped { region =>
+        val pType = PType.canonical(t)
         val rvb = new RegionValueBuilder(region)
 
-        rvb.start(t.physicalType)
+        rvb.start(pType)
         rvb.addAnnotation(t, a1)
         val v1 = rvb.end()
 
@@ -74,34 +74,34 @@ class OrderingSuite extends HailSuite {
         val v2 = rvb.end()
 
         val compare = java.lang.Integer.signum(t.ordering.compare(a1, a2))
-        val fcompare = getStagedOrderingFunction[Int](t, "compare", region)
+        val fcompare = getStagedOrderingFunction[Int](pType, "compare", region)
         val result = java.lang.Integer.signum(fcompare(region, v1, v2))
 
         assert(result == compare, s"compare expected: $compare vs $result")
 
 
         val equiv = t.ordering.equiv(a1, a2)
-        val fequiv = getStagedOrderingFunction[Boolean](t, "equiv", region)
+        val fequiv = getStagedOrderingFunction[Boolean](pType, "equiv", region)
 
         assert(fequiv(region, v1, v2) == equiv, s"equiv expected: $equiv")
 
         val lt = t.ordering.lt(a1, a2)
-        val flt = getStagedOrderingFunction[Boolean](t, "lt", region)
+        val flt = getStagedOrderingFunction[Boolean](pType, "lt", region)
 
         assert(flt(region, v1, v2) == lt, s"lt expected: $lt")
 
         val lteq = t.ordering.lteq(a1, a2)
-        val flteq = getStagedOrderingFunction[Boolean](t, "lteq", region)
+        val flteq = getStagedOrderingFunction[Boolean](pType, "lteq", region)
 
         assert(flteq(region, v1, v2) == lteq, s"lteq expected: $lteq")
 
         val gt = t.ordering.gt(a1, a2)
-        val fgt = getStagedOrderingFunction[Boolean](t, "gt", region)
+        val fgt = getStagedOrderingFunction[Boolean](pType, "gt", region)
 
         assert(fgt(region, v1, v2) == gt, s"gt expected: $gt")
 
         val gteq = t.ordering.gteq(a1, a2)
-        val fgteq = getStagedOrderingFunction[Boolean](t, "gteq", region)
+        val fgteq = getStagedOrderingFunction[Boolean](pType, "gteq", region)
 
         assert(fgteq(region, v1, v2) == gteq, s"gteq expected: $gteq")
       }


### PR DESCRIPTION
Slowly getting rid of the regions being threading through non-allocating functions, part i + 1.

This changes the method signature of CodeOrdering method signatures from f(region1, v1, region2, v2) to f(v1, v2). Some other function signatures (e.g. PInterval.loadStart) were also updated as necessary. No functionality has been changed.