### PR TITLE
[hail] (PTypes) Remove more usages of `physicalType`

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -54,7 +54,7 @@ object UnsafeRow {
     new String(readBinary(region, boff, t.fundamentalType))
 
   def readLocus(region: Region, offset: Long, t: PLocus): Locus = {
-    val ft = t.fundamentalType.asInstanceOf[PStruct]
+    val ft = t.representation.asInstanceOf[PStruct]
     Locus(
       readString(region, ft.loadField(region, offset, 0), ft.types(0).asInstanceOf[PString]),
       region.loadInt(ft.loadField(region, offset, 1)))

--- a/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -39,7 +39,7 @@ class UnsafeIndexedSeq(
 }
 
 object UnsafeRow {
-  def readBinary(region: Region, boff: Long): Array[Byte] = {
+  def readBinary(region: Region, boff: Long, t: PBinary): Array[Byte] = {
     val binLength = PBinary.loadLength(region, boff)
     region.loadBytes(PBinary.bytesOffset(boff), binLength)
   }
@@ -50,13 +50,13 @@ object UnsafeRow {
   def readBaseStruct(t: PBaseStruct, region: Region, offset: Long): UnsafeRow =
     new UnsafeRow(t, region, offset)
 
-  def readString(region: Region, boff: Long): String =
-    new String(readBinary(region, boff))
+  def readString(region: Region, boff: Long, t: PString): String =
+    new String(readBinary(region, boff, t.fundamentalType))
 
-  def readLocus(region: Region, offset: Long, rg: RGBase): Locus = {
-    val ft = rg.locusType.physicalType.fundamentalType.asInstanceOf[PStruct]
+  def readLocus(region: Region, offset: Long, t: PLocus): Locus = {
+    val ft = t.fundamentalType.asInstanceOf[PStruct]
     Locus(
-      readString(region, ft.loadField(region, offset, 0)),
+      readString(region, ft.loadField(region, offset, 0), ft.types(1).asInstanceOf[PString]),
       region.loadInt(ft.loadField(region, offset, 1)))
   }
 
@@ -72,13 +72,13 @@ object UnsafeRow {
         readArray(t, region, offset)
       case t: PSet =>
         readArray(t, region, offset).toSet
-      case _: PString => readString(region, offset)
-      case _: PBinary => readBinary(region, offset)
+      case t: PString => readString(region, offset, t)
+      case t: PBinary => readBinary(region, offset, t)
       case td: PDict =>
         val a = readArray(td, region, offset)
         a.asInstanceOf[IndexedSeq[Row]].map(r => (r.get(0), r.get(1))).toMap
       case t: PBaseStruct => readBaseStruct(t, region, offset)
-      case x: PLocus => readLocus(region, offset, x.rg)
+      case x: PLocus => readLocus(region, offset, x)
       case x: PInterval =>
         val start: Annotation =
           if (x.startDefined(region, offset))

--- a/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -56,7 +56,7 @@ object UnsafeRow {
   def readLocus(region: Region, offset: Long, t: PLocus): Locus = {
     val ft = t.fundamentalType.asInstanceOf[PStruct]
     Locus(
-      readString(region, ft.loadField(region, offset, 0), ft.types(1).asInstanceOf[PString]),
+      readString(region, ft.loadField(region, offset, 0), ft.types(0).asInstanceOf[PString]),
       region.loadInt(ft.loadField(region, offset, 1)))
   }
 

--- a/hail/src/main/scala/is/hail/backend/LowerTableIR.scala
+++ b/hail/src/main/scala/is/hail/backend/LowerTableIR.scala
@@ -3,6 +3,7 @@ package is.hail.backend
 import is.hail.HailContext
 import is.hail.expr.ir._
 import is.hail.expr.types._
+import is.hail.expr.types.physical.{PStruct, PType}
 import is.hail.expr.types.virtual._
 import is.hail.rvd.{AbstractRVDSpec, RVDPartitioner, RVDType}
 import is.hail.utils._
@@ -145,7 +146,7 @@ object LowerTableIR {
       val partCounts = partition(n, nPartitionsAdj)
       val partStarts = partCounts.scanLeft(0)(_ + _)
 
-      val rvdType = RVDType(tir.typ.rowType.physicalType, Array("idx"))
+      val rvdType = RVDType(PType.canonical(tir.typ.rowType).asInstanceOf[PStruct], Array("idx"))
 
       val contextType = TStruct(
         "start" -> TInt32(),

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -443,8 +443,8 @@ private class Emit(
               (rm, rm.mux(defaultValue(r.typ), codeR.v)))))
         }
 
-      case MakeArray(args, typ) =>
-        val pType = typ.physicalType
+      case x@MakeArray(args, typ) =>
+        val pType = x.pType.asInstanceOf[PArray]
         val srvb = new StagedRegionValueBuilder(mb, pType)
         val addElement = srvb.addIRIntermediate(pType.elementType)
         val addElts = { (newMB: EmitMethodBuilder, t: PType, v: EmitTriplet) =>
@@ -901,7 +901,7 @@ private class Emit(
                   case t =>
                     Code.invokeScalaObject[PType, Region, Long, AnyRef](
                       SafeRow.getClass, "read",
-                      mb.getPType(t.physicalType), region, key.value[Long])
+                      mb.getPType(args.head.pType), region, key.value[Long])
                 }))
             val groupRVAs = mb.newField[Array[RegionValueAggregator]]("groupRVAs")
 

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
@@ -227,7 +227,7 @@ case class MatrixValue(
     // only used in exportPlink
     assert(typ.colKey.isEmpty)
     val hc = HailContext.get
-    val colPType = typ.colType.physicalType
+    val colPType = PType.canonical(typ.colType).asInstanceOf[PStruct]
 
     RVD.coerce(
       typ.colsTableType.canonicalRVDType,

--- a/hail/src/main/scala/is/hail/expr/types/physical/PString.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PString.scala
@@ -27,7 +27,7 @@ class PString(override val required: Boolean) extends PType {
 
   override def byteSize: Long = 8
 
-  override def fundamentalType: PType = PBinary(required)
+  override def fundamentalType: PBinary = PBinary(required)
 
   def codeOrdering(mb: EmitMethodBuilder, other: PType): CodeOrdering = {
     assert(this isOfType other)

--- a/hail/src/main/scala/is/hail/methods/VEP.scala
+++ b/hail/src/main/scala/is/hail/methods/VEP.scala
@@ -9,6 +9,7 @@ import is.hail.expr._
 import is.hail.expr.ir.{ExecuteContext, TableValue}
 import is.hail.expr.ir.functions.TableToTableFunction
 import is.hail.expr.types._
+import is.hail.expr.types.physical.{PStruct, PType}
 import is.hail.expr.types.virtual._
 import is.hail.methods.VEP._
 import is.hail.rvd.{RVD, RVDContext, RVDType}
@@ -131,7 +132,7 @@ case class VEP(config: String, csq: Boolean, blockSize: Int) extends TableToTabl
 
     val localBlockSize = blockSize
 
-    val localRowType = tv.typ.rowType.physicalType
+    val localRowType = tv.rvd.rowPType
     val rowKeyOrd = tv.typ.keyType.ordering
 
     val prev = tv.rvd
@@ -215,7 +216,7 @@ case class VEP(config: String, csq: Boolean, blockSize: Int) extends TableToTabl
 
     val vepType: Type = if (csq) TArray(TString()) else vepSignature
 
-    val vepRVDType = prev.typ.copy(rowType = (prev.rowType ++ TStruct("vep" -> vepType)).physicalType)
+    val vepRVDType = prev.typ.copy(rowType = PType.canonical(prev.rowType ++ TStruct("vep" -> vepType)).asInstanceOf[PStruct])
 
     val vepRowType = vepRVDType.rowType
 

--- a/hail/src/main/scala/is/hail/methods/WindowByLocus.scala
+++ b/hail/src/main/scala/is/hail/methods/WindowByLocus.scala
@@ -84,8 +84,9 @@ case class WindowByLocus(basePairs: Int) extends MatrixToMatrixFunction {
         deque.push(locus -> RegionValue(cpRegion, rvb.end()))
       }
 
+      val pLocus = localRVRowType.field("locus").typ.asInstanceOf[PLocus]
       def getLocus(row: RegionValue): Locus =
-        UnsafeRow.readLocus(row.region, localRVRowType.loadField(row, locusIndex), rg)
+        UnsafeRow.readLocus(row.region, localRVRowType.loadField(row, locusIndex), pLocus)
 
       val unsafeRow = new UnsafeRow(localRVRowType)
       val keyView = new KeyedRow(unsafeRow, localKeyFieldIdx)
@@ -95,7 +96,7 @@ case class WindowByLocus(basePairs: Int) extends MatrixToMatrixFunction {
       }
 
       bit.map { rv =>
-        val locus = UnsafeRow.readLocus(rv.region, localRVRowType.loadField(rv, locusIndex), rg)
+        val locus = UnsafeRow.readLocus(rv.region, localRVRowType.loadField(rv, locusIndex), pLocus)
 
         def discard(x: (Locus, RegionValue)): Boolean = x != null && (x._1.position < locus.position - basePairs
           || x._1.contig != locus.contig)

--- a/hail/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/hail/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -229,7 +229,7 @@ object MatrixTable {
       TStruct.empty())
 
     val rvRowType = matrixType.canonicalTableType.canonicalRVDType.rowType
-    val oldRowType = kt.signature.physicalType
+    val oldRowType = kt.rvd.rowPType
 
     val rvd = kt.rvd.mapPartitions(matrixType.canonicalTableType.canonicalRVDType) { it =>
       val rvb = new RegionValueBuilder()


### PR DESCRIPTION
Usages of `physicalType` remain in four places:

 - in/around aggregators
 - tests
 - a few stray TableIR nodes
 - at the boundary of encoding/decoding