### PR TITLE
[batch] display pod statuses as JSON not python dict

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -795,7 +795,7 @@ async def _get_pod_status(batch_id, job_id, user):
 
     pod_statuses = await job._read_pod_statuses()
     if pod_statuses:
-        return pod_statuses
+        return JSON_ENCODER.encode(pod_statuses)
     abort(404)
 
 

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -91,7 +91,7 @@ class Test(unittest.TestCase):
     def test_list_batches(self):
         tag = secrets.token_urlsafe(64)
         b1 = self.client.create_batch(attributes={'tag': tag, 'name': 'b1'})
-        b1.create_job('alpine', ['sleep', '30'])
+        b1.create_job('alpine', ['sleep', '3600'])
         b1 = b1.submit()
 
         b2 = self.client.create_batch(attributes={'tag': tag, 'name': 'b2'})


### PR DESCRIPTION
Without this change, it is very annoying to copy and manipulate the result.