### PR TITLE
[batch] resolve ui pages with namespace

### DIFF
--- a/batch/batch/__main__.py
+++ b/batch/batch/__main__.py
@@ -1,4 +1,4 @@
 from aiohttp import web
-from .batch import main_app
+from .batch import app
 
-web.run_app(main_app, host='0.0.0.0', port=5000)
+web.run_app(app, host='0.0.0.0', port=5000)

--- a/batch/batch/__main__.py
+++ b/batch/batch/__main__.py
@@ -1,4 +1,4 @@
 from aiohttp import web
-from .batch import app
+from .batch import main_app
 
-web.run_app(app, host='0.0.0.0', port=5000)
+web.run_app(main_app, host='0.0.0.0', port=5000)

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1389,11 +1389,10 @@ app.add_routes(web_routes)
 if HAIL_NAMESPACE != 'default':
     main_app = web.Application()
     main_app.add_subapp(f'/{HAIL_NAMESPACE}/', app)
-else:
-    main_app = app
+    app = main_app
 
-main_app.add_routes(rest_routes)
-main_app.router.add_get("/metrics", server_stats)
+app.add_routes(rest_routes)
+app.router.add_get("/metrics", server_stats)
 
-main_app.on_startup.append(on_startup)
-main_app.on_cleanup.append(on_cleanup)
+app.on_startup.append(on_startup)
+app.on_cleanup.append(on_cleanup)

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -36,12 +36,6 @@ from .throttler import PodThrottler
 
 from . import schemas
 
-
-async def scale_queue_consumers(queue, f, n=1):
-    for _ in range(n):
-        asyncio.ensure_future(f(queue))
-
-
 gear.configure_logging()
 log = logging.getLogger('batch')
 
@@ -1389,6 +1383,8 @@ async def on_cleanup(app):
     blocking_pool = app['blocking_pool']
     blocking_pool.shutdown()
 
+app.on_startup.append(on_startup)
+app.on_cleanup.append(on_cleanup)
 
 if HAIL_NAMESPACE != 'default':
     main_app = web.Application()
@@ -1396,5 +1392,5 @@ if HAIL_NAMESPACE != 'default':
 else:
     main_app = app
 
-main_app.on_startup.append(on_startup)
-main_app.on_cleanup.append(on_cleanup)
+# main_app.on_startup.append(on_startup)
+# main_app.on_cleanup.append(on_cleanup)

--- a/batch/batch/batch_configuration.py
+++ b/batch/batch/batch_configuration.py
@@ -3,6 +3,7 @@ import uuid
 
 KUBERNETES_TIMEOUT_IN_SECONDS = float(os.environ.get('KUBERNETES_TIMEOUT_IN_SECONDS', 5.0))
 REFRESH_INTERVAL_IN_SECONDS = int(os.environ.get('REFRESH_INTERVAL_IN_SECONDS', 5 * 60))
+HAIL_NAMESPACE = os.environ.get('HAIL_NAMESPACE', 'default')
 HAIL_POD_NAMESPACE = os.environ.get('HAIL_POD_NAMESPACE', 'batch-pods')
 POD_VOLUME_SIZE = os.environ.get('POD_VOLUME_SIZE', '10Mi')
 INSTANCE_ID = os.environ.get('HAIL_INSTANCE_ID', uuid.uuid4().hex)

--- a/batch/batch/sidecar.py
+++ b/batch/batch/sidecar.py
@@ -178,7 +178,7 @@ async def refresh_k8s_pods():
             log.info(f'could not refresh pods due to {err}, will try again later')
             return
 
-        name = pod.metadata['name']
+        name = pod.metadata.name
         log.info(f'refreshing from pod {name}')
         await pod_changed(pod)
         await asyncio.sleep(REFRESH_INTERVAL_IN_SECONDS)

--- a/batch/batch/templates/batch.html
+++ b/batch/batch/templates/batch.html
@@ -38,8 +38,8 @@
           <td>{{ job['state'] }}</td>
           <td>{{ job['exit_code'] }}</td>
           <td>{{ job['duration'] }}</td>
-          <td><a href="/batches/{{ job['batch_id'] }}/jobs/{{ job['job_id'] }}/log">log</a></td>
-          <td><a href="/batches/{{ job['batch_id'] }}/jobs/{{ job['job_id'] }}/pod_status">pod_status</a></td>
+          <td><a href="{{ url('job_log', batch_id=job['batch_id'], job_id=job['job_id']) }}">log</a></td>
+          <td><a href="{{ url('job_pod_status', batch_id=job['batch_id'], job_id=job['job_id']) }}">pod_status</a></td>
         </tr>
         {% endfor %}
       </tbody>

--- a/batch/batch/templates/batches.html
+++ b/batch/batch/templates/batches.html
@@ -20,7 +20,7 @@
       <tbody>
         {% for batch in batch_list %}
         <tr>
-          <td><a href="/batches/{{ batch['id'] }}">{{ batch['id'] }}</a></td>
+          <td><a href="{{ url('batch_index', batch_id=batch['id']) }}">{{ batch['id'] }}</a></td>
           <td>
             {% if 'attributes' in batch and 'name' in batch['attributes'] and batch['attributes']['name'] is not none %}
             {{ batch['attributes']['name'] }}
@@ -29,7 +29,7 @@
           <td>{{ batch['state'] }}</td>
           <td>
             {% if not batch['complete'] %}
-            <form action="/batches/{{ batch['id'] }}/cancel" method="post">
+            <form action="{{ url('batch_cancel', batch_id=batch['id']) }}" method="post">
               <input type="hidden" name="_csrf" value="{{ token }}"/>
               <input type="submit" value="Cancel">
             </form>

--- a/batch/deployment.yaml
+++ b/batch/deployment.yaml
@@ -34,6 +34,8 @@ spec:
             memory: "1G"
             cpu: "1"
         env:
+         - name: HAIL_NAMESPACE
+           value: "{{ default_ns.name }}"
          - name: HAIL_POD_NAMESPACE
            value: "{{ batch_pods_ns.name }}"
          - name: HAIL_JWT_SECRET_KEY_FILE


### PR DESCRIPTION
If batch is not being run from the default namespace, the url should have the namespace prepended to it. Example `http://localhost:8080/jigold/batches/1/jobs/1`

The jinja template also needs to have the namespace prepended if not default. aiohttp_jinja2 provides this functionality with the built-in `url` function.

Two documentation links:
https://docs.aiohttp.org/en/stable/web_advanced.html#nested-applications
https://aiohttp-jinja2.readthedocs.io/en/stable/#default-globals