### PR TITLE
staged GroupBy aggregator

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -22,7 +22,11 @@ class GroupedBTreeKey(kt: PType, fb: EmitFunctionBuilder[_], region: Code[Region
 
   def initValue(dest: Code[Long], km: Code[Boolean], kv: Code[_], rIdx: Code[Int]): Code[Unit] = {
     val koff = storageType.fieldOffset(dest, 0)
-    var storeK = Region.storeIRIntermediate(kt)(koff, kv)
+    var storeK =
+      if (kt.isPrimitive)
+        Region.storeIRIntermediate(kt)(koff, kv)
+      else
+        StagedRegionValueBuilder.deepCopy(fb, region, kt, coerce[Long](kv), koff)
     if (!kt.required)
       storeK = km.mux(storageType.setFieldMissing(dest, 0), Code(storageType.setFieldPresent(dest, 0), storeK))
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -1,0 +1,248 @@
+package is.hail.expr.ir.agg
+
+import is.hail.annotations.{CodeOrdering, Region, RegionUtils, StagedRegionValueBuilder}
+import is.hail.asm4s._
+import is.hail.expr.ir.{EmitMethodBuilder, EmitRegion, EmitTriplet, defaultValue, typeToTypeInfo}
+import is.hail.expr.types.physical._
+import is.hail.io._
+import is.hail.utils._
+
+class GroupedBTreeKey(kt: PType, er: EmitRegion, container: StateContainer) extends BTreeKey {
+  private val keyInline = kt.isPrimitive
+  val storageType: PStruct = PStruct(required = true,
+    "kt" -> (if (keyInline) kt else PInt64(kt.required)),
+    "regionIdx" -> PInt32(true),
+    "container" -> PInt64(true))
+
+  val compType: PType = kt
+  private val kcomp = er.mb.getCodeOrdering[Int](kt, kt, CodeOrdering.compare)
+
+  def isKeyMissing(off: Code[Long]): Code[Boolean] =
+    storageType.isFieldMissing(off, 0)
+  def loadKey(off: Code[Long]): Code[_] =
+    if (keyInline)
+      Region.loadIRIntermediate(kt)(storageType.fieldOffset(off, 0))
+    else
+      Region.loadAddress(storageType.fieldOffset(off, 0))
+
+  def initValue(dest: Code[Long], km: Code[Boolean], kv: Code[_], rIdx: Code[Int]): Code[Unit] = {
+    val koff = storageType.fieldOffset(dest, 0)
+    var storeK = {
+      if (keyInline)
+        Region.storeIRIntermediate(kt)(koff, kv)
+      else
+        Region.storeAddress(koff, StagedRegionValueBuilder.deepCopy(er, kt, coerce[Long](kv)))
+    }
+    if (!kt.required)
+      storeK = km.mux(storageType.setFieldMissing(dest, 0), Code(storageType.setFieldPresent(dest, 0), storeK))
+
+    Code(
+      storeK,
+      storeRegionIdx(dest, rIdx),
+      Region.storeAddress(containerOffset(dest), er.region.allocate(container.typ.alignment, container.typ.byteSize)))
+  }
+
+  def regionIdx(off: Code[Long]): Code[Int] =
+    Region.loadInt(storageType.fieldOffset(off, 1))
+
+  def storeRegionIdx(off: Code[Long], idx: Code[Int]): Code[Unit] =
+    Region.storeInt(storageType.fieldOffset(off, 1), idx)
+
+  def containerOffset(off: Code[Long]): Code[Long] =
+    storageType.fieldOffset(off, 2)
+
+  def containerAddress(off: Code[Long]): Code[Long] =
+    Region.loadAddress(containerOffset(off))
+
+  def isEmpty(off: Code[Long]): Code[Boolean] =
+    Region.loadAddress(storageType.fieldOffset(off, 2)).ceq(0L)
+  def initializeEmpty(off: Code[Long]): Code[Unit] =
+    Region.storeAddress(storageType.fieldOffset(off, 2), 0L)
+
+  def copy(src: Code[Long], dest: Code[Long]): Code[Unit] =
+    Region.copyFrom(src, dest, storageType.byteSize)
+
+  def deepCopy(er: EmitRegion, dest: Code[Long], src: Code[Long]): Code[Unit] = {
+    var c = StagedRegionValueBuilder.deepCopy(er, storageType, src, dest)
+    if (!keyInline)
+      c = Code(c, Region.storeAddress(storageType.fieldOffset(dest, 0),
+        StagedRegionValueBuilder.deepCopy(er, kt,
+          Region.loadAddress(storageType.fieldOffset(src, 0)))))
+    Code(c,
+      container.toCode((i, s) => s.copyFrom(container.getStateOffset(containerAddress(src), i))),
+      container.store(regionIdx(dest), containerAddress(dest)))
+  }
+
+  def compKeys(k1: (Code[Boolean], Code[_]), k2: (Code[Boolean], Code[_])): Code[Int] =
+    kcomp(k1, k2)
+
+  def loadCompKey(off: Code[Long]): (Code[Boolean], Code[_]) =
+    isKeyMissing(off) -> isKeyMissing(off).mux(defaultValue(kt), loadKey(off))
+
+}
+
+case class DictState(mb: EmitMethodBuilder, keyType: PType, nested: Array[AggregatorState]) extends PointerBasedRVAState {
+  val nStates: Int = nested.length
+  val container: StateContainer = new StateContainer(nested, region)
+  val valueType: PStruct = PStruct("regionIdx" -> PInt32(true), "states" -> container.typ)
+  val root: ClassFieldRef[Long] = mb.newField[Long]
+  val size: ClassFieldRef[Int] = mb.newField[Int]
+  val keyed = new GroupedBTreeKey(keyType, EmitRegion(mb, region), container)
+  val tree = new AppendOnlyBTree(mb.fb, keyed, region, root)
+
+  val typ: PStruct = PStruct(
+    required = true,
+    "inits" -> container.typ,
+    "size" -> PInt32(true),
+    "tree" -> PInt64(true))
+
+  private val initStatesOffset: Code[Long] = typ.fieldOffset(off, 0)
+  private def initStateOffset(idx: Int): Code[Long] = container.getStateOffset(initStatesOffset, idx)
+
+  private val _elt = mb.newField[Long]
+  def loadContainer(km: Code[Boolean], kv: Code[_]): Code[Unit] = {
+    val initValue = Code(
+      size := size + 1,
+      region.setNumParents(size * (nStates + 1)),
+      keyed.initValue(_elt, km, kv, size * nStates),
+      container.newStates,
+      container.toCode((i, s) => s.copyFrom(initStateOffset(i))))
+
+    Code(
+      _elt := tree.getOrElseInitialize(km, km.mux(defaultValue(keyType), kv)),
+      keyed.isEmpty(_elt).mux(initValue,
+        container.load(keyed.regionIdx(_elt), keyed.containerAddress(_elt))))
+  }
+
+  def withContainer(km: Code[Boolean], kv: Code[_], seqOps: Code[Unit]): Code[Unit] =
+    Code(loadContainer(km, kv), seqOps, container.store(keyed.regionIdx(_elt), keyed.containerAddress(_elt)))
+
+  override def createState: Code[Unit] = Code(
+    super.createState,
+    container.toCode((_, s) => s.createState))
+
+  override def load(regionLoader: Code[Region] => Code[Unit], src: Code[Long]): Code[Unit] = {
+    Code(super.load(regionLoader, src),
+      off.ceq(0L).mux(Code._empty,
+        Code(
+          size := Region.loadInt(typ.loadField(off, 1)),
+          root := Region.loadAddress(typ.loadField(off, 2)))))
+  }
+
+  override def store(regionStorer: Code[Region] => Code[Unit], dest: Code[Long]): Code[Unit] = {
+    Code(
+      Region.storeInt(typ.fieldOffset(off, 1), size),
+      Region.storeAddress(typ.fieldOffset(off, 2), root),
+      super.store(regionStorer, dest))
+  }
+
+  def init(initOps: Code[Unit]): Code[Unit] = Code(
+    region.setNumParents(nStates),
+    off := region.allocate(typ.alignment, typ.byteSize),
+    container.newStates,
+    initOps,
+    container.store(0, initStatesOffset),
+    size := 0,
+    tree.init)
+
+  def combine(other: DictState, comb: Code[Unit]): Code[Unit] =
+    other.foreach { (km, kv) => withContainer(km, kv, comb) }
+
+  // loads container; does not update.
+  def foreach(f: (Code[Boolean], Code[_]) => Code[Unit]): Code[Unit] =
+    tree.foreach { kvOff =>
+      Code(
+        container.load(
+          keyed.regionIdx(kvOff),
+          keyed.containerAddress(kvOff)),
+        f(keyed.isKeyMissing(kvOff), keyed.loadKey(kvOff)))
+    }
+
+  def copyFromAddress(src: Code[Long]): Code[Unit] =
+    Code(
+      init(container.toCode((i, s) => s.copyFrom(container.getStateOffset(typ.loadField(src, 0), i)))),
+      size := Region.loadInt(typ.loadField(src, 1)),
+      tree.deepCopy(Region.loadAddress(typ.loadField(src, 2))))
+
+  def serialize(codec: CodecSpec): Code[OutputBuffer] => Code[Unit] = {
+    val serializers = nested.map(_.serialize(codec))
+    val kEnc = EmitPackEncoder.buildMethod(keyType, keyType, mb.fb)
+
+    { ob: Code[OutputBuffer] =>
+      Code(
+        container.load(0, initStatesOffset),
+        container.toCode((i, _) => serializers(i)(ob)),
+        ob.writeInt(size),
+        foreach { (km, kv) =>
+          Code(
+            ob.writeBoolean(km),
+            (!km).orEmpty(kEnc.invoke(region, kv, ob)),
+            container.toCode((i, _) => serializers(i)(ob)))
+        })
+    }
+  }
+
+  def deserialize(codec: CodecSpec): Code[InputBuffer] => Code[Unit] = {
+    val deserializers = nested.map(_.deserialize(codec))
+    val kDec = EmitPackDecoder.buildMethod(keyType, keyType, mb.fb);
+
+    val readSize = mb.newField[Int]
+    val km = mb.newField[Boolean]
+    val kv = mb.newField()(typeToTypeInfo(keyType))
+
+    { ib: Code[InputBuffer] =>
+      Code(
+        init(container.toCode((i, _) => deserializers(i)(ib))),
+        readSize := ib.readInt(),
+        Code.whileLoop(size < readSize,
+          km := ib.readBoolean(),
+          (!km).orEmpty(kv := kDec.invoke(region, ib)),
+          withContainer(km, kv, container.toCode((i, _) => deserializers(i)(ib)))))
+    }
+  }
+}
+
+class GroupedAggregator(kt: PType, nestedAggs: Array[StagedAggregator]) extends StagedAggregator {
+  type State = DictState
+
+  val resultEltType: PTuple = PTuple(nestedAggs.map(_.resultType): _*)
+  val resultType: PDict = PDict(kt, resultEltType)
+
+  def createState(mb: EmitMethodBuilder): State = DictState(mb, kt, nestedAggs.map(_.createState(mb)))
+
+  def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+    val Array(inits) = init
+    state.init(inits.setup)
+  }
+
+  def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
+    val Array(key, seqs) = seq
+    Code(key.setup, state.withContainer(key.m, key.v, seqs.setup))
+  }
+
+  def combOp(state: State, other: State, dummy: Boolean): Code[Unit] = {
+    state.combine(other, state.container.toCode((i, s) => nestedAggs(i).combOp(s, other.nested(i))))
+  }
+
+  def result(state: State, srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit] =
+    srvb.addArray(resultType.fundamentalType.asPArray, sab =>
+      Code(
+        sab.start(state.size),
+        state.foreach { (km, kv) =>
+          Code(
+            sab.addBaseStruct(resultType.elementType, ssb =>
+              Code(
+                ssb.start(),
+                km.mux(
+                  ssb.setMissing(),
+                  ssb.addWithDeepCopy(kt, kv)),
+                ssb.advance(),
+                ssb.addBaseStruct(resultEltType, { svb =>
+                  Code(svb.start(),
+                    state.container.toCode { (i, s) =>
+                      Code(nestedAggs(i).result(s, svb), svb.advance())
+                    })
+                }))),
+            sab.advance())
+        }))
+}

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
@@ -7,9 +7,6 @@ import is.hail.expr.types.physical._
 import is.hail.io.{CodecSpec, InputBuffer, OutputBuffer}
 import is.hail.utils._
 
-object TakeRVAS {
-}
-
 class TakeRVAS(val eltType: PType, val resultType: PArray, val fb: EmitFunctionBuilder[_]) extends AggregatorState {
   private val r: ClassFieldRef[Region] = fb.newField[Region]
   val region: Code[Region] = r.load()

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -162,6 +162,11 @@ abstract class PBaseStruct extends PType {
   def isFieldDefined(region: Region, offset: Long, fieldIdx: Int): Boolean =
     fieldRequired(fieldIdx) || !region.loadBit(offset, missingIdx(fieldIdx))
 
+  def isFieldDefined(offset: Long, fieldIdx: Int): Boolean =
+    fieldRequired(fieldIdx) || !Region.loadBit(offset, missingIdx(fieldIdx))
+
+  def isFieldMissing(off: Long, fieldIdx: Int): Boolean = !isFieldDefined(off, fieldIdx)
+
   def isFieldMissing(offset: Code[Long], fieldIdx: Int): Code[Boolean] =
     if (fieldRequired(fieldIdx))
       false

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -1365,7 +1365,7 @@ object EmitPackDecoder {
 
   def decode(t: PType, rt: PType, mb: MethodBuilder): Code[_] = {
     val in = mb.getArg[InputBuffer](2)
-    t match {
+    t.fundamentalType match {
       case _: PBoolean => in.load().readBoolean()
       case _: PInt32 => in.load().readInt()
       case _: PInt64 => in.load().readLong()

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -1694,7 +1694,8 @@ object EmitPackEncoder { self =>
 
   def writeBinary(mb: MethodBuilder, region: Code[Region], boff: Code[Long], out: Code[OutputBuffer]): Code[Unit] = {
     val length = region.loadInt(boff)
-    Code(out.writeInt(length),
+    Code(
+      out.writeInt(length),
       out.writeBytes(region, boff + const(4), length))
   }
 

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichCodeOutputBuffer.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichCodeOutputBuffer.scala
@@ -41,4 +41,6 @@ class RichCodeOutputBuffer(out: Code[OutputBuffer]) {
     case _: PFloat32 => v => writeFloat(coerce[Float](v))
     case _: PFloat64 => v => writeDouble(coerce[Double](v))
   }
+
+  def flush(): Code[Unit] = out.invoke[Unit]("flush")
 }

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -10,13 +10,6 @@ import is.hail.utils._
 import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
-class KVPairBuilder() {
-  val ab: ArrayBuilder[(Boolean, Long, Boolean, Long)] = new ArrayBuilder()
-  def add(km: Boolean, kv: Long, vm: Boolean, vv: Long): Unit =
-    ab += ((km, kv, vm, vv))
-  def result(): Array[(Boolean, Long, Boolean, Long)] = ab.result()
-}
-
 class Aggregators2Suite extends HailSuite {
 
   def assertAggEquals(

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -10,6 +10,13 @@ import is.hail.utils._
 import org.apache.spark.sql.Row
 import org.testng.annotations.Test
 
+class KVPairBuilder() {
+  val ab: ArrayBuilder[(Boolean, Long, Boolean, Long)] = new ArrayBuilder()
+  def add(km: Boolean, kv: Long, vm: Boolean, vv: Long): Unit =
+    ab += ((km, kv, vm, vv))
+  def result(): Array[(Boolean, Long, Boolean, Long)] = ab.result()
+}
+
 class Aggregators2Suite extends HailSuite {
 
   def assertAggEquals(
@@ -40,28 +47,41 @@ class Aggregators2Suite extends HailSuite {
     assert(rt.types(0) == rt.types(1))
 
     val resultType = rt.types(0)
-    assert(resultType.virtualType.typeCheck(expected))
+    assert(resultType.virtualType.typeCheck(expected), s"expected type $resultType")
 
     Region.scoped { region =>
       val argOff = ScalaToRegionValue(region, argT, argVs)
       val serializedParts = seqOps.grouped(math.ceil(seqOps.length / nPartitions.toDouble).toInt).map { seqs =>
-        val partitionOp = Begin(
-          initOp +: seqs :+ SerializeAggs(0, 0, spec, Array(aggSig)))
+        val serialize = SerializeAggs(0, 0, spec, Array(aggSig))
 
-        val (_, f) = CompileWithAggregators2[Long, Unit](
-          Array(aggSig),
-          argRef.name, argRef.pType,
-          args.map(_._1).foldLeft[IR](partitionOp) { case (op, name) =>
-            Let(name, GetField(argRef, name), op)
-          })
-
-        val initAndSeq = f(0, region)
-        Region.smallScoped { aggRegion =>
-          initAndSeq.newAggState(aggRegion)
-          initAndSeq(region, argOff, false)
-          initAndSeq.getSerializedAgg(0)
+        def withArgs(foo: IR) = {
+          CompileWithAggregators2[Long, Unit](
+            Array(aggSig),
+            argRef.name, argRef.pType,
+            args.map(_._1).foldLeft[IR](foo) { case (op, name) =>
+              Let(name, GetField(argRef, name), op)
+            })._2(0, region)
         }
-      }
+
+        val (_, writeF) = CompileWithAggregators2[Unit](
+          Array(aggSig),
+          serialize)
+
+        val init = withArgs(initOp)
+        val seq = withArgs(Begin(seqs))
+        val write = writeF(0, region)
+        Region.smallScoped { aggRegion =>
+          init.newAggState(aggRegion)
+          init(region, argOff, false)
+          val ioff = init.getAggOffset()
+          seq.setAggState(aggRegion, ioff)
+          seq(region, argOff, false)
+          val soff = seq.getAggOffset()
+          write.setAggState(aggRegion, soff)
+          write(region)
+          write.getSerializedAgg(0)
+        }
+      }.toArray
 
       Region.smallScoped { aggRegion =>
         val combOp = combAndDuplicate(0, region)
@@ -323,5 +343,101 @@ class Aggregators2Suite extends HailSuite {
 
     val expected = Array.tabulate(value(0).length)(i => Row(Array.tabulate(3)(j => value(j)(i)).toFastIndexedSeq)).toFastIndexedSeq
     assertAggEquals(lcAggSig, init, seq, expected, FastIndexedSeq(("stream", (stream.typ, value))), 2)
+
+  @Test def testGroup() {
+    val pnn = AggSignature2(PrevNonnull(), FastSeq(), FastSeq(t), None)
+    val count = AggSignature2(Count(), FastSeq(), FastSeq(), None)
+    val sum = AggSignature2(Sum(), FastSeq(), FastSeq(TInt64()), None)
+
+    val kt = TString()
+    val grouped = AggSignature2(Group(), FastSeq(TVoid), FastSeq(kt, TVoid), Some(FastSeq(pnn, count, sum)))
+
+    val initOpArgs = FastIndexedSeq(Begin(FastIndexedSeq(
+      InitOp2(0, FastIndexedSeq(), pnn),
+      InitOp2(1, FastIndexedSeq(), count),
+      InitOp2(2, FastIndexedSeq(), sum))))
+
+    val rows = FastIndexedSeq(Row("abcd", 5L), null, Row(null, -2L), Row("abcd", 7L), null, Row("foo", null))
+    val rref = Ref("rows", TArray(t))
+
+    val seqOpArgs = Array.tabulate(rows.length)(i =>
+      FastIndexedSeq[IR](GetField(ArrayRef(rref, i), "a"),
+        Begin(FastIndexedSeq(
+          SeqOp2(0, FastIndexedSeq(ArrayRef(rref, i)), pnn),
+          SeqOp2(1, FastIndexedSeq(), count),
+          SeqOp2(2, FastIndexedSeq(GetField(ArrayRef(rref, i), "b")), sum)))))
+
+    val expected = Map(
+      "abcd" -> Row(Row("abcd", 7L), 2L, 12L),
+      "foo" -> Row(Row("foo", null), 1L, 0L),
+      (null, Row(Row(null, -2L), 3L, -2L)))
+
+    assertAggEquals(grouped, initOpArgs, seqOpArgs, expected = expected, args = FastIndexedSeq(("rows", (arrayType, rows))))
+  }
+
+  @Test def testNestedGroup() {
+    val pnn = AggSignature2(PrevNonnull(), FastSeq(), FastSeq(t), None)
+    val count = AggSignature2(Count(), FastSeq(), FastSeq(), None)
+    val sum = AggSignature2(Sum(), FastSeq(), FastSeq(TInt64()), None)
+
+    val kt = TString()
+    val grouped1 = AggSignature2(Group(), FastSeq(TVoid), FastSeq(kt, TVoid), Some(FastSeq(pnn, count, sum)))
+    val grouped2 = AggSignature2(Group(), FastSeq(TVoid), FastSeq(kt, TVoid), Some(FastSeq(grouped1)))
+
+    val initOpArgs = FastIndexedSeq(
+      InitOp2(0, FastIndexedSeq(
+        Begin(FastIndexedSeq(
+          InitOp2(0, FastIndexedSeq(), pnn),
+          InitOp2(1, FastIndexedSeq(), count),
+          InitOp2(2, FastIndexedSeq(), sum)))
+      ), grouped1))
+
+    val rows = FastIndexedSeq(Row("abcd", 5L), null, Row(null, -2L), Row("abcd", 7L), null, Row("foo", null))
+    val rref = Ref("rows", TArray(t))
+
+    val seqOpArgs = Array.tabulate(rows.length)(i =>
+      FastIndexedSeq[IR](GetField(ArrayRef(rref, i), "a"),
+        SeqOp2(0, FastIndexedSeq[IR](GetField(ArrayRef(rref, i), "a"),
+          Begin(FastIndexedSeq(
+            SeqOp2(0, FastIndexedSeq(ArrayRef(rref, i)), pnn),
+            SeqOp2(1, FastIndexedSeq(), count),
+            SeqOp2(2, FastIndexedSeq(GetField(ArrayRef(rref, i), "b")), sum)))
+        ), grouped1)))
+
+    val expected = Map(
+      "abcd" -> Row(Map("abcd" -> Row(Row("abcd", 7L), 2L, 12L))),
+      "foo" -> Row(Map("foo" -> Row(Row("foo", null), 1L, 0L))),
+      (null, Row(Map((null, Row(Row(null, -2L), 3L, -2L))))))
+
+    assertAggEquals(grouped2, initOpArgs, seqOpArgs, expected = expected, args = FastIndexedSeq(("rows", (arrayType, rows))))
+  }
+
+  @Test def testNestedGroupPrimitiveKey() {
+    val rows = Array.tabulate(10)(Row(_)).toFastIndexedSeq
+    val rtyp = TArray(TStruct("idx" -> TInt32()))
+    val rref = Ref("rows", rtyp)
+
+    val count = AggSignature2(Count(), FastSeq(), FastSeq(), None)
+    val grouped1 = AggSignature2(Group(), FastSeq(TVoid), FastSeq(TInt32(), TVoid), Some(FastSeq(count)))
+    val grouped2 = AggSignature2(Group(), FastSeq(TVoid), FastSeq(TInt32(), TVoid), Some(FastSeq(grouped1)))
+
+    val initOpArgs = FastIndexedSeq(InitOp2(0, FastIndexedSeq(InitOp2(0, FastIndexedSeq(), count)), grouped1))
+
+    val seqOpArgs = Array.tabulate(rows.length)(i =>
+      FastIndexedSeq[IR](invoke("%", GetField(ArrayRef(rref, i), "idx"), 5),
+        SeqOp2(0,
+          FastIndexedSeq(
+            invoke("%", GetField(ArrayRef(rref, i), "idx"), 2),
+            SeqOp2(0, FastIndexedSeq(), count)),
+          grouped1)))
+
+
+    val expected = Map(0 -> Row(Map(0 -> Row(1L), 1 -> Row(1L))),
+      1 -> Row(Map(0 -> Row(1L), 1 -> Row(1L))),
+      2 -> Row(Map(0 -> Row(1L), 1 -> Row(1L))),
+      3 -> Row(Map(0 -> Row(1L), 1 -> Row(1L))),
+      4 -> Row(Map(0 -> Row(1L), 1 -> Row(1L))))
+
+    assertAggEquals(grouped2, initOpArgs, seqOpArgs, expected = expected, args = FastIndexedSeq(("rows", (rtyp, rows))))
   }
 }


### PR DESCRIPTION
The way I ended up structuring this:

There's an AppendOnlyBTree type, which has keys of a certain type (BTreeKey). The BTree relies on this key type to know how to manage memory and what type to use for the comparison key. The BTree knows how to do three things:
- initialize an empty tree with one node
- get the address of a key corresponding to a certain comparison key, inserting and initializing an empty key if no matching key is found
- traverse the keys of the btree and do something with them
- deepCopy itself using the deepCopy defined by the BTreeKey.

The BTreeKey must know:
- the storage type within the BTree
- how to initialize itself, and whether or not it's empty
- the type of the comparison key
- a comparison function between two BTreeKeys 
- and one between a BTreeKey and a comparison key of the correct type
- a way to construct the comparison key from its value
- a way to copy and deepCopy itself.

All of these things work within a single region, because they're append-only structures, so copies shouldn't leave garbage in the region.

The GroupedAggregator uses a BTreeKey that:
- stores the group key, and uses that as the comparison key
- stores the child region idx that the nested aggregators use
- stores the offset that the region states are stored at.