### PR TITLE
Fix error message when indexing into (Matrix)Tables without keys

### DIFF
--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2760,7 +2760,7 @@ class MatrixTable(ExprContainer):
             key_type, exprs = err.args
             raise ExpressionException(
                 f"Key type mismatch: cannot index matrix table with given expressions:\n"
-                f"  MatrixTable row key: {', '.join(str(t) for t in key_type.values())}\n"
+                f"  MatrixTable row key: {', '.join(str(t) for t in key_type.values()) or '<<<empty key>>>'}\n"
                 f"  Index expressions:   {', '.join(str(e.dtype) for e in exprs)}")
 
     def index_cols(self, *exprs, all_matches=False) -> 'Expression':
@@ -2800,7 +2800,7 @@ class MatrixTable(ExprContainer):
             key_type, exprs = err.args
             raise ExpressionException(
                 f"Key type mismatch: cannot index matrix table with given expressions:\n"
-                f"  MatrixTable col key: {', '.join(str(t) for t in key_type.values())}\n"
+                f"  MatrixTable col key: {', '.join(str(t) for t in key_type.values()) or '<<<empty key>>>'}\n"
                 f"  Index expressions:   {', '.join(str(e.dtype) for e in exprs)}")
 
     def index_entries(self, row_exprs, col_exprs):

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1553,6 +1553,7 @@ class Table(ExprContainer):
             raise ExpressionException('Cannot index with a scalar expression')
 
         is_interval = (len(exprs) == 1
+                       and len(self.key) > 0
                        and isinstance(self.key[0].dtype, hl.tinterval)
                        and exprs[0].dtype == self.key[0].dtype.point_type)
 

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1532,8 +1532,9 @@ class Table(ExprContainer):
             return self._index(*exprs, all_matches=all_matches)
         except TableIndexKeyError as err:
             key_type, exprs = err.args
+
             raise ExpressionException(f"Key type mismatch: cannot index table with given expressions:\n"
-                                      f"  Table key:         {', '.join(str(t) for t in key_type.values())}\n"
+                                      f"  Table key:         {', '.join(str(t) for t in key_type.values()) or '<<<empty key>>>'}\n"
                                       f"  Index Expressions: {', '.join(str(e.dtype) for e in exprs)}")
 
     def _index(self, *exprs, all_matches=False) -> 'Expression':

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -387,6 +387,13 @@ class Tests(unittest.TestCase):
         self.assertEqual(mt.index_cols(mt.col_key).take(1), mt.index_cols(mt.s).take(1))
         self.assertEqual(mt[mt.row_key, mt.col_key].take(1), mt[(mt.locus, mt.alleles), mt.s].take(1))
 
+    def test_index_keyless(self):
+        mt = hl.utils.range_matrix_table(3, 3)
+        with self.assertRaisesRegex(hl.expr.ExpressionException, "MatrixTable row key: *<<<empty key>>>"):
+            mt.key_rows_by().index_rows(mt.row_idx)
+        with self.assertRaisesRegex(hl.expr.ExpressionException, "MatrixTable col key: *<<<empty key>>>"):
+            mt.key_cols_by().index_cols(mt.col_idx)
+
     def test_table_join(self):
         ds = self.get_vds()
         # test different row schemas

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -518,6 +518,11 @@ class Tests(unittest.TestCase):
         j = t1.annotate(f=t2[t1.a].x)
         self.assertEqual(j.count(), t1.count())
 
+    def test_index_keyless_table(self):
+        t = hl.utils.range_table(10).key_by()
+        with self.assertRaisesRegex(hl.expr.ExpressionException, "Table key: *<<<empty key>>>"):
+            t[t.idx]
+
     def test_aggregation_with_no_aggregators(self):
         ht = hl.utils.range_table(3)
         self.assertEqual(ht.group_by(ht.idx).aggregate().count(), 3)


### PR DESCRIPTION
also changes the error message to display `<<<empty key>>>` as the list of keys

fixes #6663 
