### PR TITLE
Fix aggregator source propagation for transformations of hl.agg.count

### DIFF
--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -111,7 +111,7 @@ class AggFunc(object):
             aggregations = aggregations.push(Aggregation(array_agg_expr, aggregated))
         return construct_expr(AggExplode(array_agg_expr._ir, var, aggregated._ir, self._as_scan),
                               aggregated.dtype,
-                              aggregated._indices,
+                              Indices(indices.source, aggregated._indices.axes),
                               aggregations)
 
     @typecheck_method(condition=expr_bool,
@@ -126,14 +126,14 @@ class AggFunc(object):
 
         _check_agg_bindings(condition, self._agg_bindings)
         _check_agg_bindings(aggregation, self._agg_bindings)
-        unify_all(condition, aggregation)
+        indices, _ = unify_all(condition, aggregation)
 
         aggregations = hl.utils.LinkedList(Aggregation)
         if not self._as_scan:
             aggregations = aggregations.push(Aggregation(condition, aggregation))
         return construct_expr(AggFilter(condition._ir, aggregation._ir, self._as_scan),
                               aggregation.dtype,
-                              aggregation._indices,
+                              Indices(indices.source, aggregation._indices.axes),
                               aggregations)
 
     def group_by(self, group, aggregation):
@@ -146,7 +146,7 @@ class AggFunc(object):
 
         _check_agg_bindings(group, self._agg_bindings)
         _check_agg_bindings(aggregation, self._agg_bindings)
-        unify_all(group, aggregation)
+        indices, _ = unify_all(group, aggregation)
 
         aggregations = hl.utils.LinkedList(Aggregation)
         if not self._as_scan:
@@ -154,7 +154,7 @@ class AggFunc(object):
 
         return construct_expr(AggGroupBy(group._ir, aggregation._ir, self._as_scan),
                               tdict(group.dtype, aggregation.dtype),
-                              aggregation._indices,
+                              Indices(indices.source, aggregation._indices.axes),
                               aggregations)
 
     def array_agg(self, array, f):
@@ -181,7 +181,7 @@ class AggFunc(object):
             aggregations = aggregations.push(Aggregation(array, aggregated))
         return construct_expr(AggArrayPerElement(array._ir, var, 'unused', aggregated._ir, self._as_scan),
                               tarray(aggregated.dtype),
-                              aggregated._indices,
+                              Indices(indices.source, aggregated._indices.axes),
                               aggregations)
 
 _agg_func = AggFunc()

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -350,7 +350,15 @@ class Tests(unittest.TestCase):
                  (hl.agg.filter(t.idx > 7,
                              hl.agg.group_by(t.idx % 3,
                                           hl.array(hl.agg.collect_as_set(t.idx + 1)).append(0))),
-                  {0: [10, 0], 2: [9, 0]})
+                  {0: [10, 0], 2: [9, 0]}),
+                 (hl.agg.filter(t.idx > 7, hl.agg.count()), 2),
+                 (hl.agg.filter(t.idx > 7,
+                                hl.agg.explode(lambda elt: hl.agg.count(),
+                                               [t.idx, t.idx + 1])), 3),
+                 (hl.agg.filter(t.idx > 7,
+                                hl.agg.group_by(t.idx % 3,
+                                                hl.agg.count())),
+                  {0: 1, 2: 1}),
                  ]
         for aggregation, expected in tests:
             self.assertEqual(t.aggregate(aggregation), expected)
@@ -395,10 +403,16 @@ class Tests(unittest.TestCase):
         r = ht.aggregate(hl.agg.explode(lambda x: hl.agg.array_agg(lambda elt: hl.agg.sum(elt), x), ht.a))
         assert r == [285, 570]
 
+        r = ht.aggregate(hl.agg.explode(lambda x: hl.agg.array_agg(lambda elt: hl.agg.count(), x), ht.a))
+        assert r == [45, 45]
+
         ht = hl.utils.range_table(10)
         ht = ht.annotate(a=[hl.range(0, ht.idx), hl.range(ht.idx, 2 * ht.idx)])
         r = ht.aggregate(hl.agg.array_agg(lambda x: hl.agg.explode(lambda elt: hl.agg.sum(elt), x), ht.a))
         assert r == [120, 405]
+
+        r = ht.aggregate(hl.agg.array_agg(lambda x: hl.agg.explode(lambda elt: hl.agg.count(), x), ht.a))
+        assert r == [45, 45]
 
     def test_agg_array_filter(self):
         ht = hl.utils.range_table(10)
@@ -409,6 +423,12 @@ class Tests(unittest.TestCase):
         r2 = ht.aggregate(hl.agg.array_agg(lambda x: hl.agg.filter(x == 5, hl.agg.sum(x)), ht.a))
         assert r2 == [5]
 
+        r3 = ht.aggregate(hl.agg.filter(ht.idx == 5, hl.agg.array_agg(lambda x: hl.agg.count(), ht.a)))
+        assert r3 == [1]
+
+        r4 = ht.aggregate(hl.agg.array_agg(lambda x: hl.agg.filter(x == 5, hl.agg.count()), ht.a))
+        assert r4 == [1]
+
     def test_agg_array_group_by(self):
         ht = hl.utils.range_table(10)
         ht = ht.annotate(a=[ht.idx, ht.idx + 1])
@@ -417,10 +437,18 @@ class Tests(unittest.TestCase):
         assert r == {0: [20, 25], 1: [25, 30]}
 
         r2 = ht.aggregate(
-            hl.agg.array_agg(lambda x: hl.agg.group_by(x % 2, hl.agg.sum(x)), ht.a)
-        )
+            hl.agg.array_agg(lambda x: hl.agg.group_by(x % 2, hl.agg.sum(x)), ht.a))
 
         assert r2 == [{0: 20, 1: 25}, {0: 30, 1: 25}]
+
+        r3 = ht.aggregate(
+            hl.agg.group_by(ht.idx % 2, hl.agg.array_agg(lambda x: hl.agg.count(), ht.a)))
+        assert r3 == {0: [5, 5], 1: [5, 5]}
+
+        r4 = ht.aggregate(
+            hl.agg.array_agg(lambda x: hl.agg.group_by(x % 2, hl.agg.count()), ht.a))
+
+        assert r4 == [{0: 5, 1: 5}, {0: 5, 1: 5}]
 
     def test_agg_array_nested(self):
         ht = hl.utils.range_table(10)
@@ -476,7 +504,24 @@ class Tests(unittest.TestCase):
                                            hl.cond(t.idx > 7,
                                                    [t.idx, t.idx + 1],
                                                    hl.empty_array(hl.tint32))),
-                  {0: [10, 10, 0], 1: [11, 0], 2:[9, 0]})
+                  {0: [10, 10, 0], 1: [11, 0], 2:[9, 0]}),
+                 (hl.agg.explode(lambda elt: hl.agg.count(),
+                                 hl.cond(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32))),
+                  4),
+                 (hl.agg.explode(lambda elt: hl.agg.explode(lambda elt2: hl.agg.count(),
+                                                            [elt, elt + 1]),
+                                 hl.cond(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32))),
+                  8),
+                 (hl.agg.explode(lambda elt: hl.agg.filter(elt > 8,
+                                                           hl.agg.count()),
+                                 hl.cond(t.idx > 7, [t.idx, t.idx + 1], hl.empty_array(hl.tint32))),
+                  3),
+                 (hl.agg.explode(lambda elt: hl.agg.group_by(elt % 3,
+                                                             hl.agg.count()),
+                                 hl.cond(t.idx > 7,
+                                         [t.idx, t.idx + 1],
+                                         hl.empty_array(hl.tint32))),
+                  {0: 2, 1: 1, 2: 1})
                  ]
         for aggregation, expected in tests:
             self.assertEqual(t.aggregate(aggregation), expected)
@@ -496,6 +541,19 @@ class Tests(unittest.TestCase):
                                                    [t.idx, t.idx + 1],
                                                    hl.empty_array(hl.tint32)))),
                   {0: [10, 11, 0], 1: [0], 2:[9, 10, 0]}),
+                 (hl.agg.group_by(t.idx % 2, hl.agg.count()), {0: 5, 1: 5}),
+                 (hl.agg.group_by(t.idx % 3,
+                                  hl.agg.filter(t.idx > 7, hl.agg.count())),
+                  {0: 1, 1: 0, 2: 1}),
+                 (hl.agg.group_by(t.idx % 3,
+                                  hl.agg.explode(lambda elt: hl.agg.count(),
+                                                 hl.cond(t.idx > 7,
+                                                         [t.idx, t.idx + 1],
+                                                         hl.empty_array(hl.tint32)))),
+                  {0: 2, 1: 0, 2: 2}),
+                 (hl.agg.group_by(t.idx % 5,
+                                  hl.agg.group_by(t.idx % 2, hl.agg.count())),
+                  {i: {0: 1, 1: 1} for i in range(5)}),
                  ]
         for aggregation, expected in tests:
             self.assertEqual(t.aggregate(aggregation), expected)

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -354,7 +354,7 @@ class Tests(unittest.TestCase):
                  (hl.agg.filter(t.idx > 7, hl.agg.count()), 2),
                  (hl.agg.filter(t.idx > 7,
                                 hl.agg.explode(lambda elt: hl.agg.count(),
-                                               [t.idx, t.idx + 1])), 3),
+                                               [t.idx, t.idx + 1])), 4),
                  (hl.agg.filter(t.idx > 7,
                                 hl.agg.group_by(t.idx % 3,
                                                 hl.agg.count())),


### PR DESCRIPTION
The sources for agg transformations weren't being recorded correctly for transformations of hl.agg.count(). This wasn't a problem for e.g. a single-level hl.agg.group_by(key, hl.agg.count()), but was throwing errors when that was nested within other transformations.