### PR TITLE
[dev] Add `wheel` to setup dependencies

### DIFF
--- a/hail/python/setup.py
+++ b/hail/python/setup.py
@@ -39,6 +39,6 @@ setup(
     entry_points={
         'console_scripts': ['hailctl = hailtop.hailctl.__main__:main']
     },
-    setup_requires=["pytest-runner"],
+    setup_requires=["pytest-runner", "wheel"],
     tests_require=["pytest"]
 )


### PR DESCRIPTION
This is required to run `setup bdist_wheel`, and is not in the standard
library.