### PR TITLE
add missing stats methods

### DIFF
--- a/hail/python/hail/docs/methods/index.rst
+++ b/hail/python/hail/docs/methods/index.rst
@@ -39,6 +39,10 @@ Methods
 .. autosummary::
 
     linear_mixed_model
+    linear_mixed_regression_rows
+    linear_regression_rows
+    logistic_regression_rows
+    poisson_regression_rows
     pca
     row_correlation
 


### PR DESCRIPTION
Only 3 of the 7 methods appear here: https://hail.is/docs/0.2/methods/index.html

Though they all appear here: https://hail.is/docs/0.2/methods/stats.html