### PR TITLE
[hail] [bugfix] Fix correctness bug in Table.order_by optimization

### DIFF
--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -858,6 +858,22 @@ class Tests(unittest.TestCase):
         self.assertEqual(rt.order_by('x').idx.take(10), expected)
         self.assertEqual(rt.order_by('x').idx.collect(), expected)
 
+    def test_order_by_expr(self):
+        ht = hl.utils.range_table(10, 3)
+        ht = ht.annotate(xs = hl.range(0, 1).map(lambda x: hl.int(hl.rand_unif(0, 100))))
+
+        asc = ht.order_by(ht.xs[0])
+        desc = ht.order_by(hl.desc(ht.xs[0]))
+
+        res = ht.xs[0].collect()
+
+        res_asc = sorted(res)
+        res_desc = sorted(res, reverse=True)
+
+        assert asc.xs[0].collect() == res_asc
+        assert desc.xs[0].collect() == res_desc
+        assert [s['xs'][0] for s in desc.take(5)] == res_desc[:5]
+
     def test_null_joins(self):
         tr = hl.utils.range_table(7, 1)
         table1 = tr.key_by(new_key=hl.cond((tr.idx == 3) | (tr.idx == 5),

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -530,6 +530,7 @@ object Simplify {
 
     case TableHead(TableOrderBy(child, sortFields), n)
       if !TableOrderBy.isAlreadyOrdered(sortFields, child.typ.key) // FIXME: https://github.com/hail-is/hail/issues/6234
+        && sortFields.forall(_.sortOrder == Ascending)
         && n < 256 && canRepartition =>
       // n < 256 is arbitrary for memory concerns
       val row = Ref("row", child.typ.rowType)


### PR DESCRIPTION
`hl.desc` sorts could be instead sorted ascending in some cases.