### PR TITLE
fix encode/decode of non-wrapped values, some other refactoring changes

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -148,6 +148,17 @@ object Region {
     case _: PFloat64 => loadDouble
     case _ => off => off
   }
+
+  def storeIRIntermediate(typ: PType): (Code[Long], Code[_]) => Code[Unit] = typ.fundamentalType match {
+    case _: PBoolean => (addr, v) => Region.storeBoolean(addr, coerce[Boolean](v))
+    case _: PInt32 => (addr, v) => Region.storeInt(addr, coerce[Int](v))
+    case _: PInt64 => (addr, v) => Region.storeLong(addr, coerce[Long](v))
+    case _: PFloat32 => (addr, v) => Region.storeFloat(addr, coerce[Float](v))
+    case _: PFloat64 => (addr, v) => Region.storeDouble(addr, coerce[Double](v))
+    case _: PArray => (addr, v) => Region.storeAddress(addr, coerce[Long](v))
+    case _: PBinary => (addr, v) => Region.storeAddress(addr, coerce[Long](v))
+    case t: PBaseStruct => (addr, v) => Region.copyFrom(coerce[Long](v), addr, t.byteSize)
+  }
 }
 
 // Off-heap implementation of Region differs from the previous

--- a/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -225,7 +225,7 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: PType, va
       boff := PBinary.allocate(region, n),
       region.storeInt(boff, n),
       ftype match {
-        case _: PBinary => _empty
+        case _: PBinary => startOffset := boff
         case _ =>
           region.storeAddress(currentOffset, boff)
       },

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -427,6 +427,21 @@ class CodeBoolean(val lhs: Code[Boolean]) extends AnyVal {
     }
   }
 
+  def orEmpty[T](cthen: Code[T]): Code[T] = {
+    val cond = lhs.toConditional
+    new Code[T] {
+      def emit(il: Growable[AbstractInsnNode]): Unit = {
+        val lafter = new LabelNode
+        val ltrue = new LabelNode
+        cond.emitConditional(il, ltrue, lafter)
+        il += ltrue
+        cthen.emit(il)
+        // fall through
+        il += lafter
+      }
+    }
+  }
+
   def &(rhs: Code[Boolean]): Code[Boolean] =
     Code(lhs, rhs, new InsnNode(IAND))
 

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -432,11 +432,14 @@ class EmitFunctionBuilder[F >: Null](
     m
   }
 
-  override def newMethod(argsInfo: Array[TypeInfo[_]], returnInfo: TypeInfo[_]): EmitMethodBuilder = {
-    val mb = new EmitMethodBuilder(this, s"method${ methods.size }", argsInfo, returnInfo)
+  def newMethod(prefix: String, argsInfo: Array[TypeInfo[_]], returnInfo: TypeInfo[_]): EmitMethodBuilder = {
+    val mb = new EmitMethodBuilder(this, s"${prefix}_${ methods.size }", argsInfo, returnInfo)
     methods.append(mb)
     mb
   }
+
+  override def newMethod(argsInfo: Array[TypeInfo[_]], returnInfo: TypeInfo[_]): EmitMethodBuilder =
+    newMethod("method", argsInfo, returnInfo)
 
   override def newMethod[R: TypeInfo]: EmitMethodBuilder =
     newMethod(Array[TypeInfo[_]](), typeInfo[R])

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -125,6 +125,16 @@ abstract class PBaseStruct extends PType {
     region.allocate(alignment, byteSize)
   }
 
+  def setAllMissing(off: Code[Long]): Code[Unit] = {
+    var c: Code[Unit] = Code._empty
+    var i = 0
+    while (i < nMissingBytes) {
+      c = Code(c, Region.storeByte(off + i.toLong, const(0xFF.toByte)))
+      i += 1
+    }
+    c
+  }
+
   def clearMissingBits(region: Region, off: Long) {
     var i = 0
     while (i < nMissingBytes) {
@@ -133,15 +143,18 @@ abstract class PBaseStruct extends PType {
     }
   }
 
-  def clearMissingBits(region: Code[Region], off: Code[Long]): Code[Unit] = {
+  def clearMissingBits(off: Code[Long]): Code[Unit] = {
     var c: Code[Unit] = Code._empty
     var i = 0
     while (i < nMissingBytes) {
-      c = Code(c, region.storeByte(off + i.toLong, const(0)))
+      c = Code(c, Region.storeByte(off + i.toLong, const(0)))
       i += 1
     }
     c
   }
+
+  def clearMissingBits(region: Code[Region], off: Code[Long]): Code[Unit] =
+    clearMissingBits(off)
 
   def isFieldDefined(rv: RegionValue, fieldIdx: Int): Boolean =
     isFieldDefined(rv.region, rv.offset, fieldIdx)

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -1692,8 +1692,7 @@ object EmitPackEncoder { self =>
     Code(writeLen, writeMissingBytes, writeElems)
   }
 
-  def writeBinary(mb: MethodBuilder, region: Code[Region], off: Code[Long], out: Code[OutputBuffer]): Code[Unit] = {
-    val boff = region.loadAddress(off)
+  def writeBinary(mb: MethodBuilder, region: Code[Region], boff: Code[Long], out: Code[OutputBuffer]): Code[Unit] = {
     val length = region.loadInt(boff)
     Code(out.writeInt(length),
       out.writeBytes(region, boff + const(4), length))
@@ -1703,13 +1702,13 @@ object EmitPackEncoder { self =>
     t.fundamentalType match {
       case t: PStruct => emitStruct(t, requestedType.fundamentalType.asInstanceOf[PStruct], mb, region, off, out)
       case t: PTuple => emitTuple(t, requestedType.fundamentalType.asInstanceOf[PTuple], mb, region, off, out)
-      case t: PArray => emitArray(t, requestedType.fundamentalType.asInstanceOf[PArray], mb, region, region.loadAddress(off), out)
-      case _: PBoolean => out.writeBoolean(region.loadBoolean(off))
-      case _: PInt32 => out.writeInt(region.loadInt(off))
-      case _: PInt64 => out.writeLong(region.loadLong(off))
-      case _: PFloat32 => out.writeFloat(region.loadFloat(off))
-      case _: PFloat64 => out.writeDouble(region.loadDouble(off))
-      case _: PBinary => writeBinary(mb, region, off, out)
+      case t: PArray => emitArray(t, requestedType.fundamentalType.asInstanceOf[PArray], mb, region, Region.loadAddress(off), out)
+      case _: PBoolean => out.writeBoolean(Region.loadBoolean(off))
+      case _: PInt32 => out.writeInt(Region.loadInt(off))
+      case _: PInt64 => out.writeLong(Region.loadLong(off))
+      case _: PFloat32 => out.writeFloat(Region.loadFloat(off))
+      case _: PFloat64 => out.writeDouble(Region.loadDouble(off))
+      case _: PBinary => writeBinary(mb, region, Region.loadAddress(off), out)
     }
   }
 
@@ -1718,12 +1717,14 @@ object EmitPackEncoder { self =>
     val region: Code[Region] = mb.getArg[Region](1)
     val v: Code[_] = mb.getArg(2)(ir.typeToTypeInfo(rt))
     val out: Code[OutputBuffer] = mb.getArg[OutputBuffer](3)
-    val encode: Code[Unit] = t match {
+    val encode: Code[Unit] = t.fundamentalType match {
       case _: PBoolean => out.writeBoolean(coerce[Boolean](v))
       case _: PInt32 => out.writeInt(coerce[Int](v))
       case _: PInt64 => out.writeLong(coerce[Long](v))
       case _: PFloat32 => out.writeFloat(coerce[Float](v))
       case _: PFloat64 => out.writeDouble(coerce[Double](v))
+      case t: PArray => emitArray(t, rt.fundamentalType.asInstanceOf[PArray], mb, region, coerce[Long](v), out)
+      case _: PBinary => writeBinary(mb, region, coerce[Long](v), out)
       case _ => emit(t, rt, mb, region, coerce[Long](v), out)
     }
     mb.emit(encode)

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -1363,10 +1363,9 @@ object EmitPackDecoder {
     }
   }
 
-  def buildMethod(t: PType, rt: PType, fb: EmitFunctionBuilder[_]): ir.EmitMethodBuilder = {
-    val mb = fb.newMethod(Array[TypeInfo[_]](typeInfo[Region], typeInfo[InputBuffer]), ir.typeToTypeInfo(rt))
+  def decode(t: PType, rt: PType, mb: MethodBuilder): Code[_] = {
     val in = mb.getArg[InputBuffer](2)
-    val decode: Code[_] = t match {
+    t match {
       case _: PBoolean => in.load().readBoolean()
       case _: PInt32 => in.load().readInt()
       case _: PInt64 => in.load().readLong()
@@ -1381,26 +1380,27 @@ object EmitPackDecoder {
         }
         Code(emit, srvb.end())
     }
-    mb.emit(decode)
+  }
+
+  def buildMethod(t: PType, rt: PType, fb: EmitFunctionBuilder[_]): ir.EmitMethodBuilder = {
+    val mb = fb.newMethod(Array[TypeInfo[_]](typeInfo[Region], typeInfo[InputBuffer]), ir.typeToTypeInfo(rt))
+    mb.emit(decode(t, rt, mb))
     mb
   }
 
   def apply(t: PType, requestedType: PType): () => AsmFunction2[Region, InputBuffer, Long] = {
     val fb = new Function2Builder[Region, InputBuffer, Long]
     val mb = fb.apply_method
-    val in = mb.getArg[InputBuffer](2).load()
-    val srvb = new StagedRegionValueBuilder(mb, requestedType)
 
-    var c = t.fundamentalType match {
-      case t: PBaseStruct =>
-        emitBaseStruct(t, requestedType.fundamentalType.asInstanceOf[PBaseStruct], mb, in, srvb)
-      case t: PArray =>
-        emitArray(t, requestedType.fundamentalType.asInstanceOf[PArray], mb, in, srvb)
+    if (t.isPrimitive) {
+      val srvb = new StagedRegionValueBuilder(mb, requestedType)
+      mb.emit(Code(
+        srvb.start(),
+        srvb.addIRIntermediate(requestedType)(decode(t, requestedType, mb)),
+        srvb.end()))
+    } else {
+      mb.emit(decode(t, requestedType, mb))
     }
-
-    mb.emit(Code(
-      c,
-      Code._return(srvb.end())))
 
     fb.result()
   }
@@ -1712,12 +1712,10 @@ object EmitPackEncoder { self =>
     }
   }
 
-  def buildMethod(t: PType, rt: PType, fb: EmitFunctionBuilder[_]): ir.EmitMethodBuilder = {
-    val mb = fb.newMethod(Array[TypeInfo[_]](typeInfo[Region], ir.typeToTypeInfo(rt), typeInfo[OutputBuffer]), typeInfo[Unit])
+  def encode(t: PType, rt: PType, v: Code[_], mb: MethodBuilder): Code[Unit] = {
     val region: Code[Region] = mb.getArg[Region](1)
-    val v: Code[_] = mb.getArg(2)(ir.typeToTypeInfo(rt))
     val out: Code[OutputBuffer] = mb.getArg[OutputBuffer](3)
-    val encode: Code[Unit] = t.fundamentalType match {
+    t.fundamentalType match {
       case _: PBoolean => out.writeBoolean(coerce[Boolean](v))
       case _: PInt32 => out.writeInt(coerce[Int](v))
       case _: PInt64 => out.writeLong(coerce[Long](v))
@@ -1727,18 +1725,19 @@ object EmitPackEncoder { self =>
       case _: PBinary => writeBinary(mb, region, coerce[Long](v), out)
       case _ => emit(t, rt, mb, region, coerce[Long](v), out)
     }
-    mb.emit(encode)
+  }
+
+  def buildMethod(t: PType, rt: PType, fb: EmitFunctionBuilder[_]): ir.EmitMethodBuilder = {
+    val mb = fb.newMethod(Array[TypeInfo[_]](typeInfo[Region], ir.typeToTypeInfo(rt), typeInfo[OutputBuffer]), typeInfo[Unit])
+    mb.emit(encode(t, rt, mb.getArg(2)(ir.typeToTypeInfo(rt)), mb))
     mb
   }
 
   def apply(t: PType, requestedType: PType): () => AsmFunction3[Region, Long, OutputBuffer, Unit] = {
     val fb = new Function3Builder[Region, Long, OutputBuffer, Unit]
     val mb = fb.apply_method
-    val region = mb.getArg[Region](1).load()
     val offset = mb.getArg[Long](2).load()
-    val out = mb.getArg[OutputBuffer](3).load()
-
-    mb.emit(emit(t, requestedType, mb, region, offset, out))
+    mb.emit(encode(t, requestedType, Region.getIRIntermediate(t)(offset), mb))
     fb.result()
   }
 }

--- a/hail/testng-cpp-codegen.xml
+++ b/hail/testng-cpp-codegen.xml
@@ -3,7 +3,11 @@
       <classes>
            <class name="is.hail.nativecode.NativeCodeSuite"/>
            <method name="is.hail.annotations.AnnotationsSuite.testReadWrite"/>
-           <class name="is.hail.annotations.UnsafeSuite"/>
+           <class name="is.hail.annotations.UnsafeSuite">
+               <methods>
+                   <exclude name="testCodecForNonWrappedTypes" />
+               </methods>
+           </class>
            <method name="is.hail.expr.ir.TableIRSuite.testShuffleAndJoinDoesntMemoryLeak"/>
            <class name="is.hail.io.IndexSuite"/>
       </classes>


### PR DESCRIPTION
The Encoder/Decoder methods weren't handling non-struct values correctly (this is mostly fine from an Encoder/Decoder perspective, since they don't handle non-struct/array values). I fixed this in #6727 because I wanted to encode arbitrary values, and changed EmitPackDecoder/EmitPackEncoder to handle arbitrary values so that I could test this.

I also pulled out some more peripheral changes from that PR, mostly defining some (currently unused, untested) methods like `Code.orEmpty` and a version of `newMethod` that lets you give the method a real name for ease of debugging, as well as some more changes to move more load/store methods off of region instances and onto the Region object.