### PR TITLE
Fixed spark ui commands

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/connect.py
+++ b/hail/python/hailtop/hailctl/dataproc/connect.py
@@ -21,9 +21,7 @@ def main(args, pass_through_args):
     # shortcut mapping
     shortcut = {
         'ui': 'spark-ui',
-        'ui1': 'spark-ui1',
-        'ui2': 'spark-ui2',
-        'hist': 'history',
+        'hist': 'spark-history',
         'nb': 'notebook'
     }
 
@@ -32,14 +30,12 @@ def main(args, pass_through_args):
         service = shortcut[service]
 
     # Dataproc port mapping
-    dataproc_ports = {
-        'spark-ui': 4040,
-        'spark-ui1': 4041,
-        'spark-ui2': 4042,
-        'spark-history': 18080,
-        'notebook': 8123
+    dataproc_port_and_path = {
+        'spark-ui': '18080/?showIncomplete=true',
+        'spark-history': '18080',
+        'notebook': '8123'
     }
-    connect_port = dataproc_ports[service]
+    connect_port_and_path = dataproc_port_and_path[service]
 
     # open SSH tunnel to master node
     sp.check_call(
@@ -76,7 +72,7 @@ def main(args, pass_through_args):
     with open(os.devnull, 'w') as f:
         sp.Popen([
             chrome,
-            'http://localhost:{}'.format(connect_port),
+            'http://localhost:{}'.format(connect_port_and_path),
             '--proxy-server=socks5://localhost:{}'.format(args.port),
             '--host-resolver-rules=MAP * 0.0.0.0 , EXCLUDE localhost',
             '--proxy-bypass-list=<-loopback>', # https://chromium.googlesource.com/chromium/src/+/da790f920bbc169a6805a4fb83b4c2ab09532d91


### PR DESCRIPTION
Unfortunately, Google changed the way to connect to Spark UI, and now makes you either go through the YARN UI or use the Spark history page. This PR changes our Spark UI commands in `hailctl dataproc connect` to use the spark history page instead, since that works. The regular `spark-ui` command will show you running jobs, the `spark-history` command will show you finished jobs. I don't know what ui1 and ui2 were, but they're no longer usable so I removed them. 