### PR TITLE
Fix SRVB.deepCopy(er, typ, src, dest)

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -57,7 +57,7 @@ object StagedRegionValueBuilder {
     typ.fundamentalType match {
       case t if t.isPrimitive => region.copyFrom(region, src, dest, t.byteSize)
       case t@(_: PBinary | _: PArray) =>
-        region.storeAddress(deepCopy(er, t, src), dest)
+        region.storeAddress(dest, deepCopy(er, t, src))
       case t: PBaseStruct =>
         Code(region.copyFrom(region, src, dest, t.byteSize),
           fixupStruct(er, t, dest))

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -114,6 +114,13 @@ class Aggregators2Suite extends HailSuite {
     assertAggEquals(aggSig, FastIndexedSeq(), seqOpArgs, expected = 10L, args = FastIndexedSeq(("rows", (arrayType, rows))))
   }
 
+  @Test def testPrevNonnullStr() {
+    val aggSig = AggSignature2(PrevNonnull(), FastSeq(), FastSeq(TString()), None)
+    val seqOpArgs = Array.tabulate(rows.length)(i => FastIndexedSeq[IR](GetField(ArrayRef(Ref("rows", arrayType), i), "a")))
+
+    assertAggEquals(aggSig, FastIndexedSeq(), seqOpArgs, expected = rows.last.get(0), args = FastIndexedSeq(("rows", (arrayType, rows))))
+  }
+
   @Test def testPrevNonnull() {
     val aggSig = AggSignature2(PrevNonnull(), FastSeq(), FastSeq(t), None)
     val seqOpArgs = Array.tabulate(rows.length)(i => FastIndexedSeq[IR](ArrayRef(Ref("rows", TArray(t)), i)))


### PR DESCRIPTION
argument order to `storeAddress` was reversed, which could cause a segfault