### PR TITLE
Cache blockmatrix type

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -95,14 +95,12 @@ abstract class BlockMatrixReader {
 }
 
 case class BlockMatrixNativeReader(path: String) extends BlockMatrixReader {
-  lazy val _fullType = {
+  lazy val fullType = {
     val metadata = BlockMatrix.readMetadata(HailContext.get, path)
     val (tensorShape, isRowVector) = BlockMatrixIR.matrixShapeToTensorShape(metadata.nRows, metadata.nCols)
 
     BlockMatrixType(TFloat64(), tensorShape, isRowVector, metadata.blockSize)
   }
-
-  override def fullType: BlockMatrixType = _fullType
 
   override def apply(hc: HailContext): BlockMatrix = BlockMatrix.read(hc, path)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -67,7 +67,7 @@ abstract sealed class BlockMatrixIR extends BaseIR {
 }
 
 case class BlockMatrixRead(reader: BlockMatrixReader) extends BlockMatrixIR {
-  override def typ: BlockMatrixType = reader.fullType
+  override lazy val typ: BlockMatrixType = reader.fullType
 
   lazy val children: IndexedSeq[BaseIR] = Array.empty[BlockMatrixIR]
 
@@ -95,7 +95,7 @@ abstract class BlockMatrixReader {
 }
 
 case class BlockMatrixNativeReader(path: String) extends BlockMatrixReader {
-  lazy val fullType = {
+  override lazy val fullType = {
     val metadata = BlockMatrix.readMetadata(HailContext.get, path)
     val (tensorShape, isRowVector) = BlockMatrixIR.matrixShapeToTensorShape(metadata.nRows, metadata.nCols)
 
@@ -109,7 +109,7 @@ case class BlockMatrixBinaryReader(path: String, shape: IndexedSeq[Long], blockS
   val IndexedSeq(nRows, nCols) = shape
   BlockMatrixIR.checkFitsIntoArray(nRows, nCols)
 
-  override def fullType: BlockMatrixType = {
+  override lazy val fullType: BlockMatrixType = {
     val (tensorShape, isRowVector) = BlockMatrixIR.matrixShapeToTensorShape(nRows, nCols)
 
     BlockMatrixType(TFloat64(), tensorShape, isRowVector, blockSize)
@@ -122,7 +122,7 @@ case class BlockMatrixBinaryReader(path: String, shape: IndexedSeq[Long], blockS
 }
 
 class BlockMatrixLiteral(value: BlockMatrix) extends BlockMatrixIR {
-  override def typ: BlockMatrixType = {
+  override lazy val typ: BlockMatrixType = {
     val (shape, isRowVector) = BlockMatrixIR.matrixShapeToTensorShape(value.nRows, value.nCols)
     BlockMatrixType(TFloat64(), shape, isRowVector, value.blockSize)
   }
@@ -140,7 +140,7 @@ class BlockMatrixLiteral(value: BlockMatrix) extends BlockMatrixIR {
 case class BlockMatrixMap(child: BlockMatrixIR, f: IR) extends BlockMatrixIR {
   assert(f.isInstanceOf[ApplyUnaryPrimOp] || f.isInstanceOf[Apply])
 
-  override def typ: BlockMatrixType = child.typ
+  override lazy val typ: BlockMatrixType = child.typ
 
   lazy val children: IndexedSeq[BaseIR] = Array(child)
 

--- a/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BlockMatrixIR.scala
@@ -95,12 +95,14 @@ abstract class BlockMatrixReader {
 }
 
 case class BlockMatrixNativeReader(path: String) extends BlockMatrixReader {
-  override def fullType: BlockMatrixType = {
+  lazy val _fullType = {
     val metadata = BlockMatrix.readMetadata(HailContext.get, path)
     val (tensorShape, isRowVector) = BlockMatrixIR.matrixShapeToTensorShape(metadata.nRows, metadata.nCols)
 
     BlockMatrixType(TFloat64(), tensorShape, isRowVector, metadata.blockSize)
   }
+
+  override def fullType: BlockMatrixType = _fullType
 
   override def apply(hc: HailContext): BlockMatrix = BlockMatrix.read(hc, path)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -142,7 +142,7 @@ case class TableNativeReader(
 
   def partitionCounts: Option[IndexedSeq[Long]] = if (intervals.isEmpty) Some(spec.partitionCounts) else None
 
-  def fullType: TableType = spec.table_type
+  override lazy val fullType: TableType = spec.table_type
 
   private val filterIntervals = options.map(_.filterIntervals).getOrElse(false)
   private def intervals = options.map(_.intervals)
@@ -204,7 +204,7 @@ case class TableNativeZippedReader(
 
   def partitionCounts: Option[IndexedSeq[Long]] = if (intervals.isEmpty) Some(specLeft.partitionCounts) else None
 
-  def fullType: TableType = specLeft.table_type.copy(rowType = specLeft.table_type.rowType ++ specRight.table_type.rowType)
+  override lazy val fullType: TableType = specLeft.table_type.copy(rowType = specLeft.table_type.rowType ++ specRight.table_type.rowType)
 
   def apply(tr: TableRead, ctx: ExecuteContext): TableValue = {
     val hc = HailContext.get
@@ -262,7 +262,7 @@ case class TableFromBlockMatrixNativeReader(path: String, nPartitions: Option[In
     Some(partitionRanges.map(r => r.end - r.start))
   }
 
-  override def fullType: TableType = {
+  override lazy val fullType: TableType = {
     val rowType = TStruct("row_idx" -> TInt64(), "entries" -> TArray(TFloat64()))
     TableType(rowType, Array("row_idx"), TStruct())
   }


### PR DESCRIPTION
This PR makes the BlockMatrixNativeReader's type a lazy val so that it doesn't keep going to disk. 

4800x speedup on my filtering and exporting 300 block matrices example. 