### PR TITLE
deps should be empty if there aren't any

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -119,7 +119,7 @@ class Step(abc.ABC):
         if 'dependsOn' in json:
             self.deps = [params.name_step[d] for d in json['dependsOn']]
         else:
-            self.deps = None
+            self.deps = []
         self.scopes = json.get('scopes')
 
         self.token = generate_token()


### PR DESCRIPTION
None is an unfortunate default for a list of dependencies. 