### PR TITLE
Cleanup Before Removing Sink

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -155,6 +155,12 @@ class Step(abc.ABC):
             return CreateDatabaseStep.from_json(params)
         raise ValueError(f'unknown build step kind: {kind}')
 
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.name == other.name
+
+    def __hash__(self):
+        return hash(self.name)
+
     @abc.abstractmethod
     def build(self, batch, code, scope):
         pass

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -69,10 +69,10 @@ class BuildConfiguration:
         config = yaml.safe_load(config_str)
         name_step = {}
         self.steps = []
-        
+
         if profile:
             log.info(f"Constructing build configuration with following profile: {profile}")
-        
+
         for step_config in config['steps']:
             step_params = StepParameters(code, scope, step_config, name_step)
 


### PR DESCRIPTION
Small amount of preliminary work #6673. I made a PR trying to address this issue already, but ended up reverting it because it broke CI and we don't test that well. To minimize frustration, I'm making some initial changes here first. 

Namely:

- Steps have an equality and hash method based solely on their name (I'm going to want to build a hash map of steps when coming up with dependencies for the cleanup jobs. 
- Cleanup now takes a list of parents, instead of just the sink job (useful for when there are more parents than just the sink job). 