### PR TITLE
[ci] filter out None

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -167,7 +167,10 @@ async def get_batch(request):
     status = await b.status()
     for j in status['jobs']:
         if 'duration' in j and j['duration'] is not None:
-            j['duration'] = humanize.naturaldelta(datetime.timedelta(seconds=sum(j['duration'])))
+            j['duration'] = humanize.naturaldelta(
+                datetime.timedelta(
+                    seconds=sum(
+                        x for x in j['duration'] if x is not None)))
         j['exit_code'] = Job.exit_code(j)
     return {
         'batch': status


### PR DESCRIPTION
This fixes an issue where we cannot retrieve old batches for a PR.

Addresses this error:
```
{"levelname": "ERROR", "asctime": "2019-08-01 15:59:17,119", "filename": "web_protocol.py", "funcNameAndLine": "log_exception:355", "message": "Error handling request", "exc_info": "Traceback (most recent call last):\n  File \"/usr/local/lib/python3.6/dist-packages/aiohttp/web_protocol.py\", line 418, in start\n    resp = await task\n  File \"/usr/local/lib/python3.6/dist-packages/aiohttp/web_app.py\", line 458, in _handle\n    resp = await handler(request)\n  File \"/usr/local/lib/python3.6/dist-packages/aiohttp/web_urldispatcher.py\", line 157, in handler_wrapper\n    result = await result\n  File \"/usr/local/lib/python3.6/dist-packages/aiohttp_jinja2/__init__.py\", line 91, in wrapped\n    context = await coro(*args)\n  File \"/ci/ci.py\", line 170, in get_batch\n    j['duration'] = humanize.naturaldelta(datetime.timedelta(seconds=sum(j['duration'])))\nTypeError: unsupported operand type(s) for +: 'int' and 'NoneType'"}
{"levelname": "INFO", "asctime": "2019-08-01 15:59:17,119", "filename": "web_log.py", "funcNameAndLine": "log:233", "message": "10.32.0.177 [01/Aug/2019:15:59:17 +0000] \"GET /batches/584 HTTP/1.0\" 500 315 \"-\" \"Mozilla/5.0 (Macintosh;
```