### PR TITLE
don't check if agg states are loaded

### DIFF
--- a/hail/python/hailtop/hailctl/dev/benchmark/run/matrix_table_benchmarks.py
+++ b/hail/python/hailtop/hailctl/dev/benchmark/run/matrix_table_benchmarks.py
@@ -105,6 +105,7 @@ def matrix_table_many_aggs_row_wise():
 
 @benchmark
 def matrix_table_many_aggs_col_wise():
+    # hl._set_flags(newaggs=None)
     mt = hl.read_matrix_table(resource('profile.mt'))
     mt = mt.annotate_cols(**many_aggs(mt))
     mt.cols()._force_count()

--- a/hail/python/hailtop/hailctl/dev/benchmark/run/matrix_table_benchmarks.py
+++ b/hail/python/hailtop/hailctl/dev/benchmark/run/matrix_table_benchmarks.py
@@ -105,7 +105,6 @@ def matrix_table_many_aggs_row_wise():
 
 @benchmark
 def matrix_table_many_aggs_col_wise():
-    # hl._set_flags(newaggs=None)
     mt = hl.read_matrix_table(resource('profile.mt'))
     mt = mt.annotate_cols(**many_aggs(mt))
     mt.cols()._force_count()

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -998,9 +998,7 @@ private class Emit(
         val rvAgg = agg.Extract.getAgg(aggSig)
 
         val argVars = args.map(a => emit(a, container = container.flatMap(_.nested(i)))).toArray
-        void(
-          sc.loadOneIfMissing(aggOff, i),
-          rvAgg.seqOp(sc(i), argVars))
+        void(rvAgg.seqOp(sc(i), argVars))
 
       case CombOp2(i1, i2, aggSig) =>
         val AggContainer(aggs, sc, aggOff) = container.get
@@ -1008,10 +1006,7 @@ private class Emit(
         assert(agg.Extract.compatible(aggs(i2), aggSig), s"${ aggs(i2) } vs $aggSig")
         val rvAgg = agg.Extract.getAgg(aggSig)
 
-        void(
-          sc.loadOneIfMissing(aggOff, i1),
-          sc.loadOneIfMissing(aggOff, i2),
-          rvAgg.combOp(sc(i1), sc(i2)))
+        void(rvAgg.combOp(sc(i1), sc(i2)))
 
       case x@ResultOp2(start, aggSigs) =>
         val AggContainer(aggs, sc, aggOff) = container.get
@@ -1021,7 +1016,6 @@ private class Emit(
           assert(aggSigs(j) == aggs(idx))
           val rvAgg = agg.Extract.getAgg(aggSigs(j))
           Code(
-            sc.loadOneIfMissing(aggOff, idx),
             rvAgg.result(sc(idx), srvb),
             srvb.advance())
         }: _*))
@@ -1041,11 +1035,7 @@ private class Emit(
           PString.getClass, "loadString", region, p.value[Long])
 
         val serialize = Array.range(start, start + aggSigs.length)
-          .map { idx =>
-            Code(
-              sc.loadOneIfMissing(aggOff, idx),
-              sc(idx).serialize(spec)(ob))
-          }
+          .map { idx => sc(idx).serialize(spec)(ob) }
 
         void(
           p.setup, p.m.mux(Code._fatal("agg path can't be missing"), Code._empty),
@@ -1086,11 +1076,7 @@ private class Emit(
         val baos = mb.newField[ByteArrayOutputStream]
 
         val serialize = Array.range(start, start + aggSigs.length)
-          .map { idx =>
-            Code(
-              sc.loadOneIfMissing(aggOff, idx),
-              sc(idx).serialize(spec)(ob))
-          }
+          .map { idx => sc(idx).serialize(spec)(ob) }
 
         void(
           baos := Code.newInstance[ByteArrayOutputStream](),

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -15,7 +15,7 @@ trait AggregatorState {
 
   def regionSize: Int = Region.TINY
 
-  def isLoaded: Code[Boolean]
+//  def isLoaded: Code[Boolean]
 
   def createState: Code[Unit]
   def newState: Code[Unit]
@@ -39,7 +39,7 @@ trait PointerBasedRVAState extends AggregatorState {
 
   override val regionSize: Int = Region.TINIER
 
-  def isLoaded: Code[Boolean] = region.isValid
+//  def isLoaded: Code[Boolean] = region.isValid
 
   def newState: Code[Unit] = region.getNewRegion(regionSize)
 
@@ -88,14 +88,10 @@ case class PrimitiveRVAState(types: Array[PType], mb: EmitMethodBuilder) extends
   def foreachField(f: (Int, ValueField) => Code[Unit]): Code[Unit] =
     coerce[Unit](Code(Array.tabulate(nFields)(i => f(i, fields(i))) :_*))
 
-  val _loaded: ClassFieldRef[Boolean] = mb.newField[Boolean]
-
-  def isLoaded: Code[Boolean] = _loaded
-
   def newState: Code[Unit] = Code._empty
   def createState: Code[Unit] = Code._empty
 
-  private[this] def loadVarsFromRegion(src: Code[Long]): Code[Unit] = Code(
+  private[this] def loadVarsFromRegion(src: Code[Long]): Code[Unit] =
     foreachField {
       case (i, (None, v, t)) =>
         v.storeAny(Region.loadPrimitive(t)(storageType.fieldOffset(src, i)))
@@ -103,14 +99,12 @@ case class PrimitiveRVAState(types: Array[PType], mb: EmitMethodBuilder) extends
         m := storageType.isFieldMissing(src, i),
         m.mux(Code._empty,
           v.storeAny(Region.loadPrimitive(t)(storageType.fieldOffset(src, i)))))
-    },
-    _loaded := true)
+    }
 
   def load(regionLoader: Code[Region] => Code[Unit], src: Code[Long]): Code[Unit] =
     loadVarsFromRegion(src)
 
   def store(regionStorer: Code[Region] => Code[Unit], dest: Code[Long]): Code[Unit] =
-    Code(
       foreachField {
         case (i, (None, v, t)) =>
           Region.storePrimitive(t, storageType.fieldOffset(dest, i))(v)
@@ -118,31 +112,29 @@ case class PrimitiveRVAState(types: Array[PType], mb: EmitMethodBuilder) extends
           m.mux(storageType.setFieldMissing(dest, i),
             Code(storageType.setFieldPresent(dest, i),
               Region.storePrimitive(t, storageType.fieldOffset(dest, i))(v)))
-      },
-      _loaded := false)
+      }
 
   def copyFrom(src: Code[Long]): Code[Unit] = loadVarsFromRegion(src)
 
   def serialize(codec: CodecSpec): Code[OutputBuffer] => Code[Unit] = {
-    ob: Code[OutputBuffer] => Code(
+    ob: Code[OutputBuffer] =>
       foreachField {
         case (_, (None, v, t)) => ob.writePrimitive(t)(v)
         case (_, (Some(m), v, t)) => Code(
           ob.writeBoolean(m),
           m.mux(Code._empty, ob.writePrimitive(t)(v)))
-      }, _loaded := false)
+      }
   }
 
   def deserialize(codec: CodecSpec): Code[InputBuffer] => Code[Unit] = {
-    ib: Code[InputBuffer] => Code(
+    ib: Code[InputBuffer] =>
       foreachField {
         case (_, (None, v, t)) =>
           v.storeAny(ib.readPrimitive(t))
         case (_, (Some(m), v, t)) => Code(
           m := ib.readBoolean(),
           m.mux(Code._empty, v.storeAny(ib.readPrimitive(t))))
-      },
-      _loaded := true)
+      }
   }
 }
 
@@ -160,10 +152,6 @@ case class StateContainer(states: Array[AggregatorState], topRegion: Code[Region
 
   def toCode(f: (Int, AggregatorState) => Code[Unit]): Code[Unit] =
     coerce[Unit](Code(Array.tabulate(nStates)(i => f(i, states(i))): _*))
-
-  def loadOneIfMissing(stateOffset: Code[Long], idx: Int): Code[Unit] =
-    states(idx).isLoaded.mux(Code._empty,
-      states(idx).load(getRegion(0, idx), getStateOffset(stateOffset, idx)))
 
   def createStates: Code[Unit] =
     toCode((i, s) => s.createState)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -15,8 +15,6 @@ trait AggregatorState {
 
   def regionSize: Int = Region.TINY
 
-//  def isLoaded: Code[Boolean]
-
   def createState: Code[Unit]
   def newState: Code[Unit]
 
@@ -38,8 +36,6 @@ trait PointerBasedRVAState extends AggregatorState {
   val er: EmitRegion = EmitRegion(mb, region)
 
   override val regionSize: Int = Region.TINIER
-
-//  def isLoaded: Code[Boolean] = region.isValid
 
   def newState: Code[Unit] = region.getNewRegion(regionSize)
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CountAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CountAggregator.scala
@@ -16,7 +16,7 @@ object CountAggregator extends StagedAggregator {
   def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
     assert(init.length == 0)
     val (_, v, _) = state.fields(0)
-    Code(v.storeAny(0L), state._loaded := true)
+    v.storeAny(0L)
   }
 
   def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/SumAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/SumAggregator.scala
@@ -26,7 +26,7 @@ class SumAggregator(typ: PType) extends StagedAggregator {
   def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
     assert(init.length == 0)
     val (_, v, _) = state.fields(0)
-    Code(v.storeAny(zero), state._loaded := true)
+    v.storeAny(zero)
   }
 
   def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {


### PR DESCRIPTION
This isn't needed any more, since setAggState() and newAggState() do the right thing when called.

At least on my laptop, this brings the one test down to 
```
Name	Mean	Median	StDev
matrix_table_many_aggs_col_wise	24.275	24.372	0.818
```
vs with the flag disabled, which is 
```
Name	Mean	Median	StDev
matrix_table_many_aggs_col_wise	30.147	29.706	1.868
```
(oops)