### PR TITLE
[batch] handle missing labels

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -387,6 +387,10 @@ class Job:
 
     @staticmethod
     async def from_k8s_labels(pod):
+        if pod.metadata.labels is None:
+            return None
+        if not set(['batch_id', 'job_id', 'user']).issubset(set(pod.metadata.labels)):
+            return None
         batch_id = pod.metadata.labels['batch_id']
         job_id = pod.metadata.labels['job_id']
         user = pod.metadata.labels['user']


### PR DESCRIPTION
I don't really understand how this happens, but it happens. The callees of this method already handle the case that the database has no job, so adding another `return None` is fine. It will result in this pod getting deleted, which seems reasonable since it is missing necessary labels.