### PR TITLE
[batch] separate eviction from missing pod, check queue before rescheduling

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1252,9 +1252,14 @@ async def update_job_with_pod(job, pod):
                               failure_reason="\n".join(image_pull_back_off_reasons))
             return
 
-    if not pod or (pod.status and pod.status.reason == 'Evicted'):
+    if not pod:
+        log.info(f'job {job.id} no pod found, rescheduling')
+        await job.mark_unscheduled()
+        return
+
+    if pod.status and pod.status.reason == 'Evicted':
         POD_EVICTIONS.inc()
-        log.info(f'job {job.id} mark unscheduled -- pod is missing or was evicted')
+        log.info(f'job {job.id} mark unscheduled -- pod was evicted')
         await job.mark_unscheduled()
         return
 

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1257,7 +1257,7 @@ async def update_job_with_pod(job, pod):
         await job.mark_unscheduled()
         return
 
-    if pod.status and pod.status.reason == 'Evicted':
+    if pod and pod.status and pod.status.reason == 'Evicted':
         POD_EVICTIONS.inc()
         log.info(f'job {job.id} mark unscheduled -- pod was evicted')
         await job.mark_unscheduled()

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1252,7 +1252,7 @@ async def update_job_with_pod(job, pod):
                               failure_reason="\n".join(image_pull_back_off_reasons))
             return
 
-    if not pod:
+    if not pod and not app['pod_throttler'].is_queued(job):
         log.info(f'job {job.id} no pod found, rescheduling')
         await job.mark_unscheduled()
         return

--- a/batch/batch/throttler.py
+++ b/batch/batch/throttler.py
@@ -33,6 +33,9 @@ class PodThrottler:
             self.created_pods.add(pod_name)
             self.queue.task_done()
 
+    def is_queued(self, job):
+        return job._pod_name in self.pending_pods
+
     def create_pod(self, job):
         # this method does not wait for the pod to be created before returning
         pod_name = job._pod_name


### PR DESCRIPTION
The separation makes that metric more accurate. Moreover, I check the queue before rescheduling. This saves a database call, a kubernetes call, and set churn (we remove then add back the job).