### PR TITLE
[batch] skip ERROR events

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1297,6 +1297,9 @@ async def kube_event_loop():
                 object = event['object']
                 name = object.metadata.name
                 log.info(f'received event {type} {name}')
+                if type == 'ERROR':
+                    log.info(f'kubernetes sent an ERROR event: {event}')
+                    continue
                 await pod_changed(object)
         except Exception as exc:  # pylint: disable=W0703
             log.exception(f'k8s event stream failed due to: {exc}')


### PR DESCRIPTION
I do not know what these are, but they generally have broken schemas
which break assumptions elsewhere in the code. Just skip them.