### PR TITLE
[batch] address latent bug

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -560,9 +560,9 @@ class Job:
         if failed:
             if failure_reason is not None:
                 container_logs['setup'] = failure_reason
-                uri, err = await app['log_store'].write_gs_file(self.directory,
-                                                                LogStore.log_file_name,
-                                                                json.dumps(container_logs))
+                err = await app['log_store'].write_gs_file(self.directory,
+                                                           LogStore.log_file_name,
+                                                           json.dumps(container_logs))
                 if err is not None:
                     traceback.print_tb(err.__traceback__)
                     log.info(f'job {self.id} will have a missing log due to {err}')


### PR DESCRIPTION
We apparently did not exercise this code path much before I fixed batch to treat ImagePullBackOff as failure.

Really confusing error message because `write_gs_file` returns `None` which is not iterable so you get a type error on line 565. The real issue is that you're trying to deconstruct a pair as `uri, err` and you received `None`.