### PR TITLE
[ci] improve formatting of build errors

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -131,7 +131,8 @@ async def get_pr(request):
             config['batch'] = status
             config['artifacts'] = f'{BUCKET}/build/{pr.batch.attributes["token"]}'
         else:
-            config['exception'] = traceback.format_exception(None, pr.batch.exception, pr.batch.exception.__traceback__)
+            config['exception'] = '\n'.join(
+                traceback.format_exception(None, pr.batch.exception, pr.batch.exception.__traceback__))
 
     batch_client = request.app['batch_client']
     batches = await batch_client.list_batches(


### PR DESCRIPTION
Before this change we got an array of strings rather than
several lines