### PR TITLE
remove Read/Write Aggs

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Children.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Children.scala
@@ -128,8 +128,6 @@ object Children {
     case SeqOp2(_, args, _) => args
     case _: ResultOp2 => none
     case _: CombOp2 => none
-    case WriteAggs(_, path, _, _) => Array(path)
-    case ReadAggs(_, path, _, _) => Array(path)
     case SerializeAggs(_, _, _, _) => none
     case DeserializeAggs(_, _, _, _) => none
     case Begin(xs) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -183,12 +183,6 @@ object Copy {
       case x@(_: ResultOp2 | _: CombOp2) =>
         assert(newChildren.isEmpty)
         x
-      case WriteAggs(startIdx, _, spec, aggSigs) =>
-        assert(newChildren.length == 1)
-        WriteAggs(startIdx, newChildren.head.asInstanceOf[IR], spec, aggSigs)
-      case ReadAggs(startIdx, _, spec, aggSigs) =>
-        assert(newChildren.length == 1)
-        ReadAggs(startIdx, newChildren.head.asInstanceOf[IR], spec, aggSigs)
       case x: SerializeAggs => x
       case x: DeserializeAggs => x
       case Begin(_) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1026,50 +1026,6 @@ private class Emit(
           sc.store(0, aggOff),
           srvb.offset))
 
-      case WriteAggs(start, path, spec, aggSigs) =>
-        val AggContainer(aggs, sc, aggOff) = container.get
-        val ob = mb.newField[OutputBuffer]
-
-        val p = emit(path)
-        val pathString = Code.invokeScalaObject[Region, Long, String](
-          PString.getClass, "loadString", region, p.value[Long])
-
-        val serialize = Array.range(start, start + aggSigs.length)
-          .map { idx => sc(idx).serialize(spec)(ob) }
-
-        void(
-          p.setup, p.m.mux(Code._fatal("agg path can't be missing"), Code._empty),
-          ob := spec.buildCodeOutputBuffer(mb.fb.getUnsafeWriter(pathString)),
-          coerce[Unit](Code(serialize: _*)),
-          ob.invoke[Unit]("flush"),
-          ob.invoke[Unit]("close"),
-          sc.store(0, aggOff))
-
-      case ReadAggs(start, path, spec, aggSigs) =>
-        val AggContainer(aggs, sc, aggOff) = container.get
-        val ib = mb.newField[InputBuffer]
-
-        val p = emit(path)
-        val pathString = Code.invokeScalaObject[Region, Long, String](
-          PString.getClass, "loadString", region, p.value[Long])
-
-        val deserializers = sc.states
-          .slice(start, start + aggSigs.length)
-          .map(_.deserialize(spec))
-
-        val init = coerce[Unit](Code(Array.range(start, start + aggSigs.length)
-          .map(i => sc(i).newState): _*))
-
-        val unserialize = Array.tabulate(aggSigs.length) { j =>
-          deserializers(j)(ib)
-        }
-
-        void(
-          init,
-          p.setup, p.m.mux(Code._fatal("agg path can't be missing"), Code._empty),
-          ib := spec.buildCodeInputBuffer(mb.fb.getUnsafeReader(pathString, true)),
-          coerce[Unit](Code(unserialize: _*)))
-
       case SerializeAggs(start, sIdx, spec, aggSigs) =>
         val AggContainer(aggs, sc, aggOff) = container.get
         val ob = mb.newField[OutputBuffer]

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -315,8 +315,6 @@ final case class SeqOp2(i: Int, args: IndexedSeq[IR], aggSig: AggSignature2) ext
 final case class CombOp2(i1: Int, i2: Int, aggSig: AggSignature2) extends IR
 final case class ResultOp2(startIdx: Int, aggSigs: IndexedSeq[AggSignature2]) extends IR
 
-final case class WriteAggs(startIdx: Int, path: IR, spec: CodecSpec, aggSigs: IndexedSeq[AggSignature2]) extends IR
-final case class ReadAggs(startIdx: Int, path: IR, spec: CodecSpec, aggSigs: IndexedSeq[AggSignature2]) extends IR
 final case class SerializeAggs(startIdx: Int, serializedIdx: Int, spec: CodecSpec, aggSigs: IndexedSeq[AggSignature2]) extends IR
 final case class DeserializeAggs(startIdx: Int, serializedIdx: Int, spec: CodecSpec, aggSigs: IndexedSeq[AggSignature2]) extends IR
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -41,8 +41,6 @@ object InferType {
       case _: CombOp2 => TVoid
       case ResultOp2(_, aggSigs) =>
         TTuple(aggSigs.map(agg.Extract.getType): _*)
-      case _: ReadAggs => TVoid
-      case _: WriteAggs => TVoid
       case _: SerializeAggs => TVoid
       case _: DeserializeAggs => TVoid
       case _: Begin => TVoid

--- a/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
@@ -8,8 +8,6 @@ object Interpretable {
         _: SeqOp2 |
         _: CombOp2 |
         _: ResultOp2 |
-        _: ReadAggs |
-        _: WriteAggs |
         _: SerializeAggs |
         _: DeserializeAggs |
         _: MakeNDArray |

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -849,20 +849,6 @@ object IRParser {
         val i = int32_literal(it)
         val aggSigs = agg_signatures(it)
         ResultOp2(i, aggSigs)
-      case "ReadAggs" =>
-        val i = int32_literal(it)
-        implicit val formats: Formats = AbstractRVDSpec.formats
-        val spec = JsonMethods.parse(string_literal(it)).extract[CodecSpec]
-        val aggSigs = agg_signatures(it)
-        val path = ir_value_expr(env)(it)
-        ReadAggs(i, path, spec, aggSigs)
-      case "WriteAggs" =>
-        val i = int32_literal(it)
-        implicit val formats: Formats = AbstractRVDSpec.formats
-        val spec = JsonMethods.parse(string_literal(it)).extract[CodecSpec]
-        val aggSigs = agg_signatures(it)
-        val path = ir_value_expr(env)(it)
-        WriteAggs(i, path, spec, aggSigs)
       case "SerializeAggs" =>
         val i = int32_literal(it)
         val i2 = int32_literal(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -181,24 +181,6 @@ object Pretty {
           sb.append(i)
           sb += '\n'
           prettyAggSeq(aggSigs, depth + 2)
-        case ReadAggs(i, path, spec, aggSigs) =>
-          sb += ' '
-          sb.append(i)
-          sb += ' '
-          sb.append(prettyStringLiteral(spec.toString))
-          sb += '\n'
-          prettyAggSeq(aggSigs, depth + 2)
-          sb += '\n'
-          pretty(path, depth + 2)
-        case WriteAggs(i, path, spec, aggSigs) =>
-          sb += ' '
-          sb.append(i)
-          sb += ' '
-          sb.append(prettyStringLiteral(spec.toString))
-          sb += '\n'
-          prettyAggSeq(aggSigs, depth + 2)
-          sb += '\n'
-          pretty(path, depth + 2)
         case SerializeAggs(i, i2, spec, aggSigs) =>
           sb += ' '
           sb.append(i)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -266,10 +266,6 @@ object TypeCheck {
         assert(args.map(_.typ) == aggSig.seqOpArgs)
       case _: CombOp2 =>
       case _: ResultOp2 =>
-      case x@ReadAggs(_, path, _, _) =>
-        assert(path.typ isOfType TString())
-      case x@WriteAggs(_, path, _, _) =>
-        assert(path.typ isOfType TString())
       case _: SerializeAggs =>
       case _: DeserializeAggs =>
       case x@Begin(xs) =>

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -137,12 +137,6 @@ case class Aggs(postAggIR: IR, init: IR, seqPerElt: IR, aggs: Array[AggSignature
   def serializeSet(i: Int, i2: Int, spec: CodecSpec): IR =
     SerializeAggs(i * nAggs, i2, spec, aggs)
 
-  def readSet(i: Int, path: IR, spec: CodecSpec): IR =
-    ReadAggs(i * nAggs, path, spec, aggs)
-
-  def writeSet(i: Int, path: IR, spec: CodecSpec): IR =
-    WriteAggs(i * nAggs, path, spec, aggs)
-
   def eltOp(optimize: Boolean = true): IR = if (optimize) Optimize(seqPerElt) else seqPerElt
 
   def deserialize(spec: CodecSpec): ((Region, Array[Byte]) => Long) = {

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -1827,8 +1827,6 @@ class IRSuite extends HailSuite {
       SeqOp2(0, FastIndexedSeq(i), collectSig2),
       CombOp2(0, 1, collectSig2),
       ResultOp2(0, FastSeq(collectSig2)),
-      ReadAggs(0, Str("foo"), CodecSpec.default, FastSeq(collectSig2)),
-      WriteAggs(0, Str("foo"), CodecSpec.default, FastSeq(collectSig2)),
       SerializeAggs(0, 0, CodecSpec.default, FastSeq(collectSig2)),
       DeserializeAggs(0, 0, CodecSpec.default, FastSeq(collectSig2)),
       Begin(FastIndexedSeq(Void())),


### PR DESCRIPTION
This is currently just dead code, although it could conceivably be useful in the future; I want to remove this for now as it's pretty simple to add back in at a later date (follows the pattern of Serialize/Deserialize Aggs pretty much exactly) and makes for less code to keep refactoring as we optimize the aggregator stuff.