### PR TITLE
fix agg take

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
@@ -30,6 +30,14 @@ class StagedArrayBuilder(eltType: PType, mb: EmitMethodBuilder, er: EmitRegion, 
     )
   }
 
+
+  def copyFrom(src: Code[Long]): Code[Unit] = {
+    Code(
+      size := Region.loadInt(currentSizeOffset(src)),
+      capacity := Region.loadInt(capacityOffset(src)),
+      data := StagedRegionValueBuilder.deepCopy(er, eltArray, Region.loadAddress(dataOffset(src))))
+  }
+
   def storeFields(dest: Code[Long]): Code[Unit] = {
     Code(
       Region.storeInt(currentSizeOffset(dest), size),

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
@@ -113,9 +113,7 @@ case class TakeRVAS(eltType: PType, resultType: PArray, mb: EmitMethodBuilder) e
   def copyFrom(src: Code[Long]): Code[Unit] = {
     Code(
       maxSize := region.loadInt(maxSizeOffset(src)),
-      builder.loadFields(builderStateOffset(src)),
-      builder.size.cne(0)
-        .orEmpty(Code._fatal("tried to copy from a non-empty aggregator"))
+      builder.copyFrom(builderStateOffset(src))
     )
   }
 }


### PR DESCRIPTION
`builder.loadFields` just loads the offset of the data array, but it needs to do a deep copy otherwise all of the array aggragators will start off writing to (and overwriting) the same arraybuilder.