### PR TITLE
filebeat should run on preemptibles

### DIFF
--- a/monitoring/monitoring.yaml
+++ b/monitoring/monitoring.yaml
@@ -709,6 +709,11 @@ spec:
         hostPath:
           path: /var/lib/filebeat-data
           type: DirectoryOrCreate
+      tolerations:
+        - key: "preemptible"
+          operator: "Equal"
+          value: "true"
+          effect: "NoSchedule"
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
As discussed at team meeting today, filebeat needs a toleration to run on preemptibles. 