### PR TITLE
have srvb.addWithDeepCopy take value instead of offset

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -267,8 +267,16 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: PType, va
     case ft => throw new UnsupportedOperationException("Unknown fundamental type: " + ft)
   }
 
-  def addWithDeepCopy(t: PType, src: Code[Long]): Code[Unit] = {
-    StagedRegionValueBuilder.deepCopy(EmitRegion(mb.asInstanceOf[EmitMethodBuilder], region), t, src, currentOffset)
+  def addWithDeepCopy(t: PType, v: Code[_]): Code[Unit] = t.fundamentalType match {
+    case _: PBoolean => addBoolean(v.asInstanceOf[Code[Boolean]])
+    case _: PInt32 => addInt(v.asInstanceOf[Code[Int]])
+    case _: PInt64 => addLong(v.asInstanceOf[Code[Long]])
+    case _: PFloat32 => addFloat(v.asInstanceOf[Code[Float]])
+    case _: PFloat64 => addDouble(v.asInstanceOf[Code[Double]])
+    case _ =>
+      StagedRegionValueBuilder.deepCopy(
+        EmitRegion(mb.asInstanceOf[EmitMethodBuilder], region),
+        t, coerce[Long](v), currentOffset)
   }
 
   def advance(): Code[Unit] = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
@@ -60,6 +60,6 @@ class PrevNonNullAggregator(typ: PType) extends StagedAggregator {
   def result(state: State, srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit] = {
     stateType.isFieldMissing(state.region, state.off, 0).mux(
       srvb.setMissing(),
-      srvb.addWithDeepCopy(resultType, Region.loadIRIntermediate(resultType)(stateType.fieldOffset(state.off, 0)))
+      srvb.addWithDeepCopy(resultType, Region.loadIRIntermediate(resultType)(stateType.fieldOffset(state.off, 0))))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir.agg
 
-import is.hail.annotations.StagedRegionValueBuilder
+import is.hail.annotations.{Region, StagedRegionValueBuilder}
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitFunctionBuilder, EmitTriplet}
 import is.hail.expr.types.physical._
@@ -60,6 +60,6 @@ class PrevNonNullAggregator(typ: PType) extends StagedAggregator {
   def result(state: State, srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit] = {
     stateType.isFieldMissing(state.region, state.off, 0).mux(
       srvb.setMissing(),
-      srvb.addWithDeepCopy(resultType, stateType.loadField(state.region, state.off, 0)))
+      srvb.addWithDeepCopy(resultType, Region.loadIRIntermediate(resultType)(stateType.fieldOffset(state.off, 0)))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/StagedArrayBuilder.scala
@@ -106,8 +106,8 @@ class StagedArrayBuilder(eltType: PType, fb: EmitFunctionBuilder[_], region: Cod
     )
   }
 
-  def loadElementOffset(idx: Code[Int]): (Code[Boolean], Code[Long]) = {
-    (eltArray.isElementMissing(data, idx), eltArray.loadElement(region, data, capacity, idx))
+  def elementOffset(idx: Code[Int]): (Code[Boolean], Code[Long]) = {
+    (eltArray.isElementMissing(data, idx), eltArray.elementOffset(data, capacity, idx))
   }
 
   def loadElement(idx: Code[Int]): (Code[Boolean], Code[_]) = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
@@ -92,13 +92,13 @@ class TakeRVAS(val eltType: PType, val resultType: PArray, val fb: EmitFunctionB
 
   def result(srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit] = {
     srvb.addArray(resultType, { rvb =>
-      val (eltIMissing, eltOffset) = builder.loadElementOffset(rvb.arrayIdx)
+      val (eltIMissing, eltOffset) = builder.elementOffset(rvb.arrayIdx)
       Code(
         rvb.start(builder.size),
         Code.whileLoop(rvb.arrayIdx < builder.size,
           eltIMissing.mux(
             rvb.setMissing(),
-            rvb.addWithDeepCopy(eltType, eltOffset)
+            rvb.addWithDeepCopy(eltType, Region.loadIRIntermediate(eltType)(eltOffset))
           ),
           rvb.advance()))
       })


### PR DESCRIPTION
the way it worked previously seemed kind of counterintuitive because we were using the offset instead of the actual value, like the actual rvb stuff does.