### PR TITLE
[notebook] scale tester

### DIFF
--- a/notebook/scale_test.py
+++ b/notebook/scale_test.py
@@ -4,9 +4,9 @@ import aiohttp
 import timeit
 import traceback
 import numpy as np
+import argparse
 
-
-async def run(i, times):
+async def run(i, times, class_key, image):
     try:
         async with aiohttp.ClientSession() as session:
             start = timeit.default_timer()
@@ -15,8 +15,8 @@ async def run(i, times):
                 assert resp.status == 200, await resp.text()
                 await resp.text()
             data = aiohttp.FormData()
-            data.add_field(name='password', value='hail2019')
-            data.add_field(name='image', value='hands-on-with-hail')
+            data.add_field(name='password', value=class_key)
+            data.add_field(name='image', value=image)
             print(f'{i}: new')
             async with session.post('https://notebook.hail.is/new', data=data) as resp:
                 assert resp.status == 200, await resp.text()
@@ -47,12 +47,17 @@ async def run(i, times):
         print(f'{i}: failed due to {e} {repr(traceback.format_exc())}')
 
 if __name__ == '__main__':
-    assert len(sys.argv) == 2
-    n = int(sys.argv[1])
+    parser = argparse.ArgumentParser(
+        description='Scale test notebook.hail.is.')
+    parser.add_argument('n', type=int, help='number of notebooks to start')
+    parser.add_argument('class_key', type=str, help='class key')
+    parser.add_argument('image', type=str, help='image name')
+    args = parser.parse_args()
     times = []
 
     async def f():
-        await asyncio.gather(*(run(i, times) for i in range(n)))
+        await asyncio.gather(*(run(i, times, args.class_key, args.image)
+                               for i in range(args.n)))
     asyncio.run(f())
-    print(f'successes: {len(times)}, mean time: {sum(times) / n}')
+    print(f'successes: {len(times)}, mean time: {sum(times) / args.n}')
     print(f'histogram:\n{np.histogram(times, density=True)}')


### PR DESCRIPTION
You can run this as `python3 scale_test.py 120` to simulate 120 clients simultaneously creating notebooks. You have to delete the notebooks yourself using the admin account or manually killing them in k8s.

This isn't actually used anywhere (notebook isn't deployed by CI), but I want it in our repository. At some point we should productionize notebook.