### PR TITLE
[bugfix] Remove region.close in IndexReader

### DIFF
--- a/hail/python/hailtop/hailctl/dev/benchmark/run/table_benchmarks.py
+++ b/hail/python/hailtop/hailctl/dev/benchmark/run/table_benchmarks.py
@@ -147,7 +147,7 @@ def write_range_table_p10():
         ht = hl.utils.range_table(10_000_000, 10)
         ht.write(path.join(tmpdir, 'tmp.ht'))
 
-# @benchmark segfaulting
+@benchmark
 def read_with_index_p1000():
     rows = 10_000_000
     bins = 1_000

--- a/hail/src/main/scala/is/hail/io/index/IndexReader.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexReader.scala
@@ -268,7 +268,6 @@ class IndexReader(fs: FS,
     iterator(0, lowerBound(key))
 
   def close() {
-    region.close()
     leafDecoder.close()
     internalDecoder.close()
     log.info(s"Index reader cache queries: ${ cacheHits + cacheMisses }")


### PR DESCRIPTION
Was causing segfaults in the read_with_index_p1000 benchmark.

closes #6793 