### PR TITLE
[ukbb-rg] lower resource requirements

### DIFF
--- a/ukbb-rg/deployment.yaml
+++ b/ukbb-rg/deployment.yaml
@@ -27,8 +27,8 @@ spec:
          imagePullPolicy: Always
          resources:
            requests:
-             memory: "3.75G"
-             cpu: "1"
+             memory: "1G"
+             cpu: "0.5"
          ports:
           - containerPort: 80
             protocol: TCP


### PR DESCRIPTION
@cseed shiny-server is using 0 CPU and slightly under 1 GB of RAM. The requests should be set lower. It can always burst above it when there's a traffic spike.