### PR TITLE
[hail][pipeline][batch] add pytest-instafail to base-image and pervasively use it

### DIFF
--- a/batch/Dockerfile.test
+++ b/batch/Dockerfile.test
@@ -6,6 +6,5 @@ RUN python3 -m pip install --no-cache-dir /hailtop \
   && rm -rf /hailtop
 
 COPY batch/test/ /test/
-RUN python3 -m pip install --no-cache-dir pytest-instafail==0.4.1
 
 CMD ["python3", "-m", "pytest", "-v", "--instafail", "/test/"]

--- a/build.yaml
+++ b/build.yaml
@@ -360,7 +360,7 @@ steps:
      export HAIL_DOCTEST_DATA_DIR=./data
      export PYSPARK_SUBMIT_ARGS="--conf spark.driver.extraClassPath=./hail.jar --conf spark.executor.extraClassPath=./hail.jar pyspark-shell"
      export PYTHONPATH=${PYTHONPATH:+${PYTHONPATH}:}./hail.zip
-     python3 -m pytest test --durations=50
+     python3 -m pytest --instafail test --durations=50
    inputs:
      - from: /hail.jar
        to: /io/hail.jar
@@ -382,7 +382,7 @@ steps:
    script: |
      set -ex
      cd /hail/python/hail
-     python3 -m pytest \
+     python3 -m pytest --instafail \
        --doctest-modules \
        --doctest-glob='*.rst' \
        --ignore=docs/conf.py \

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -26,6 +26,7 @@ PyGithub==1.43.7
 pylint==2.3.1
 PyMySQL==0.9.3
 pytest==4.6.3
+pytest-instafail==0.4.1
 python-json-logger==0.1.11
 requests==2.22.0
 tabulate==0.8.3

--- a/pipeline/Dockerfile.test
+++ b/pipeline/Dockerfile.test
@@ -7,4 +7,4 @@ RUN python3 -m pip install --no-cache-dir /hailtop \
 
 COPY pipeline/test /test/
 
-CMD ["python3", "-m", "pytest", "-v", "-s", "/test/"]
+CMD ["python3", "-m", "pytest", "--instafail", "-v", "-s", "/test/"]


### PR DESCRIPTION
> pytest-instafail is a plugin for py.test that shows failures and errors instantly instead of waiting until the end of test session.

https://github.com/pytest-dev/pytest-instafail/

