### PR TITLE
[bugfix] read partion aggs in loop during scan

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -103,7 +103,7 @@ object TableMapIRNew {
         if (i < scanAggCount) {
           partitionIndices(i) = os.getPos
           os.writeInt(x.length)
-          os.write(x)
+          os.write(x, 0, x.length)
           os.hflush()
         }
       }
@@ -122,8 +122,10 @@ object TableMapIRNew {
         is.seek(filePosition)
         val aggSize = is.readInt()
         val partAggs = new Array[Byte](aggSize)
-        val nread = is.read(partAggs)
-        assert(nread == aggSize)
+        val nread = is.read(partAggs, 0, aggSize)
+        if (nread != aggSize) {
+          fatal(s"aggs read wrong number of bytes: $nread vs $aggSize")
+        }
         partAggs
       }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -122,7 +122,12 @@ object TableMapIRNew {
         is.seek(filePosition)
         val aggSize = is.readInt()
         val partAggs = new Array[Byte](aggSize)
-        val nread = is.read(partAggs, 0, aggSize)
+        var nread = is.read(partAggs, 0, aggSize)
+        var r = nread
+        while (r > 0 && nread < aggSize) {
+          r = is.read(partAggs, nread, aggSize - nread)
+          if (r > 0) nread += r
+        }
         if (nread != aggSize) {
           fatal(s"aggs read wrong number of bytes: $nread vs $aggSize")
         }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -104,6 +104,7 @@ object TableMapIRNew {
           partitionIndices(i) = os.getPos
           os.writeInt(x.length)
           os.write(x)
+          os.hflush()
         }
       }
     }


### PR DESCRIPTION
@chrisvittal I don't know if this fixes Laurent's issue, since I haven't been able to reproduce it, but it seems like this is the desired behavior anyways.