### PR TITLE
Fix makefile

### DIFF
--- a/hail/.gitignore
+++ b/hail/.gitignore
@@ -20,3 +20,4 @@ src/test/resources/parallelBgenExport.bgen/part-00000.idx*
 src/test/resources/random-*.bgen.idx*
 src/test/resources/random.bgen.idx*
 src/test/resources/skip_invalid_loci.bgen.idx*
+env/

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -1,6 +1,7 @@
 .PHONY: shadowJar jars clean
 
 include env_var.mk
+.DEFAULT_GOAL := shadowJar
 MAKEFLAGS += --no-builtin-rules
 SUFFIXES:
 

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -207,7 +207,7 @@ deploy: tag
 install-deps:
 	$(PIP) install -U -r python/requirements.txt -r python/dev-requirements.txt
 
-clean:
+clean: clean-env
 	./gradlew clean
 	rm -rf build/deploy
 	rm -rf python/hail/hail-all-spark.jar

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -29,8 +29,8 @@ JAR_TEST_SOURCES != git ls-files src/test
 PY_FILES != git ls-files python
 
 INIT_SCRIPTS := python/hailtop/hailctl/deploy.yaml
-BUILD_INFO := src/main/resources/build-info.properties python/hail/hail_version python/hail/hail_pip_version \
-	python/hailtop/hailctl/hail_version
+PYTHON_VERSION_INFO := python/hail/hail_version python/hail/hail_pip_version python/hailtop/hailctl/hail_version
+SCALA_BUILD_INFO := src/main/resources/build-info.properties
 
 SHADOW_JAR := build/libs/hail-all-spark.jar
 SHADOW_TEST_JAR := build/libs/hail-all-spark-test.jar
@@ -38,14 +38,14 @@ WHEEL := build/deploy/dist/hail-$(HAIL_PIP_VERSION)-py3-none-any.whl
 
 shadowJar: $(SHADOW_JAR)
 
-$(SHADOW_JAR): $(JAR_SOURCES) env/SHORT_REVISION
+$(SHADOW_JAR): $(JAR_SOURCES) env/SHORT_REVISION $(SCALA_BUILD_INFO)
 ifdef HAIL_COMPILE_NATIVES
 	./gradlew releaseJar
 else
 	./gradlew shadowJar
 endif
 
-$(SHADOW_TEST_JAR): $(JAR_SOURCES) $(JAR_TEST_SOURCES) env/SHORT_REVISION
+$(SHADOW_TEST_JAR): $(JAR_SOURCES) $(JAR_TEST_SOURCES) env/SHORT_REVISION  $(SCALA_BUILD_INFO)
 	./gradlew shadowTestJar
 
 define properties
@@ -71,7 +71,7 @@ python/hail/hail_pip_version: Makefile
 python/hailtop/hailctl/hail_version: python/hail/hail_version
 	cp -f $< $@
 
-jars: $(BUILD_INFO)
+jars:
 	./gradlew shadowJar shadowTestJar
 
 python/README.md: ../README.md
@@ -81,12 +81,12 @@ python/hail/hail-all-spark.jar: $(SHADOW_JAR)
 	cp -f $< $@
 
 .PHONY: install-editable
-install-editable: $(BUILD_INFO) $(INIT_SCRIPTS)
+install-editable: $(PYTHON_VERSION_INFO) $(INIT_SCRIPTS)
 install-editable: python/README.md python/hail/hail-all-spark.jar
 	cd python && $(PIP) install -e .
 
 .PHONY: pytest
-pytest: $(BUILD_INFO) $(SHADOW_JAR) init-scripts
+pytest: $(PYTHON_VERSION_INFO) $(SHADOW_JAR) init-scripts
 pytest: python/README.md python/hail/hail-all-spark.jar
 	cd python && $(HAIL_PYTHON3) setup.py pytest \
     --addopts '-v -n $(PARALLELISM) --dist=loadscope --noconftest --color=no -r a --html=build/reports/pytest.html --self-contained-html $(PYTEST_ARGS)'
@@ -94,7 +94,7 @@ pytest: python/README.md python/hail/hail-all-spark.jar
 .PHONY: wheel
 wheel: $(WHEEL)
 
-$(WHEEL): $(BUILD_INFO) $(SHADOW_JAR) $(INIT_SCRIPTS) $(PY_FILES)
+$(WHEEL): $(PYTHON_VERSION_INFO) $(SHADOW_JAR) $(INIT_SCRIPTS) $(PY_FILES)
 	rm -rf build/deploy
 	mkdir -p build/deploy
 	mkdir -p build/deploy/src

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -1,5 +1,9 @@
 .PHONY: shadowJar jars clean
 
+include env_var.mk
+MAKEFLAGS += --no-builtin-rules
+SUFFIXES:
+
 REVISION := $(shell git rev-parse HEAD)
 SHORT_REVISION := $(shell git rev-parse --short=12 HEAD)
 DATE := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -8,6 +12,12 @@ URL := $(shell git config --get remote.origin.url)
 SPARK_VERSION := 2.4.0
 HAIL_PIP_VERSION := 0.2.19
 PARALLELISM := 2
+
+$(eval $(call ENV_VAR,REVISION))
+$(eval $(call ENV_VAR,SHORT_REVISION))
+# date is not important and changes often
+$(eval $(call ENV_VAR,BRANCH))
+$(eval $(call ENV_VAR,URL))
 
 HAIL_PYTHON3 ?= python3
 PIP ?= $(HAIL_PYTHON3) -m pip
@@ -28,19 +38,20 @@ WHEEL := build/deploy/dist/hail-$(HAIL_PIP_VERSION)-py3-none-any.whl
 
 shadowJar: $(SHADOW_JAR)
 
+$(SHADOW_JAR): $(JAR_SOURCES) env/SHORT_REVISION
 ifdef HAIL_COMPILE_NATIVES
-$(SHADOW_JAR): $(JAR_SOURCES)
 	./gradlew releaseJar
 else
-$(SHADOW_JAR): $(JAR_SOURCES)
 	./gradlew shadowJar
 endif
-$(SHADOW_TEST_JAR): $(JAR_SOURCES) $(JAR_TEST_SOURCES)
+
+$(SHADOW_TEST_JAR): $(JAR_SOURCES) $(JAR_TEST_SOURCES) env/SHORT_REVISION
 	./gradlew shadowTestJar
 
 define properties
 endef
 
+src/main/resources/build-info.properties: env/REVISION env/SHORT_REVISION env/BRANCH env/URL
 src/main/resources/build-info.properties: Makefile
 	echo '[Build Metadata]' > $@
 	echo 'user=$(USER)' >> $@
@@ -51,7 +62,7 @@ src/main/resources/build-info.properties: Makefile
 	echo 'sparkVersion=$(SPARK_VERSION)' >> $@
 	echo 'hailPipVersion=$(HAIL_PIP_VERSION)' >> $@
 
-python/hail/hail_version: Makefile
+python/hail/hail_version: Makefile env/SHORT_REVISION
 	echo $(HAIL_PIP_VERSION)-$(SHORT_REVISION) > $@
 
 python/hail/hail_pip_version: Makefile
@@ -112,6 +123,10 @@ HAILCTL_BUCKET_BASE ?= gs://hail-common/hailctl/dataproc
 cloud_base := $(HAILCTL_BUCKET_BASE)/$(DEV_CLARIFIER)$(CLOUD_SUB_FOLDER)
 wheel_cloud_path := $(cloud_base)/hail-$(HAIL_PIP_VERSION)-py3-none-any.whl
 resources := $(wildcard python/hailtop/hailctl/dataproc/resources/*)
+$(eval $(call ENV_VAR,cloud_base))
+$(eval $(call ENV_VAR,wheel_cloud_path))
+
+python/hailtop/hailctl/deploy.yaml: env/cloud_base env/wheel_cloud_path
 python/hailtop/hailctl/deploy.yaml: $(resources) python/requirements.txt
 	rm -f $@
 	echo "dataproc:" >> $@

--- a/hail/env_var.mk
+++ b/hail/env_var.mk
@@ -1,0 +1,28 @@
+# $(1) is an environment variable name
+#
+# Example:
+#
+#    VERSION ?= 30
+#    $(eval $(call ENV_VAR,VERSION))
+#
+#    build: env/VERSION
+#    build:
+#      ...
+#
+# If VERSION is set on the command line: `VERSION=31 make` and make was
+# previously called with VERSION set to a different value, then `build` will be
+# marked out-of-date.
+
+define ENV_VAR
+ifneq ($$($(1)),$$(shell cat env/$(1)))
+$$(info $(1) is set to "$$($(1))" which is different from old value "$$(shell cat env/$(1))")
+.PHONY: env/$(1)
+env/$(1):
+	mkdir -p env
+	printf "$$($(1))" > $$@
+endif
+endef
+
+.PHONY: clean-env
+clean-env:
+	rm -rf env

--- a/hail/env_var.mk
+++ b/hail/env_var.mk
@@ -14,10 +14,10 @@
 # marked out-of-date.
 
 define ENV_VAR
-ifneq ($$($(1)),$$(shell cat env/$(1)))
-$$(info $(1) is set to "$$($(1))" which is different from old value "$$(shell cat env/$(1))")
+ifneq ($$($(1)),$$(shell cat env/$(1) 2>/dev/null))
 .PHONY: env/$(1)
 env/$(1):
+	$$(info $(1) is set to "$$($(1))" which is different from old value "$$(shell cat env/$(1) 2>/dev/null)")
 	mkdir -p env
 	printf "$$($(1))" > $$@
 endif

--- a/hail/env_var.mk
+++ b/hail/env_var.mk
@@ -18,7 +18,7 @@ ifneq ($$($(1)),$$(shell cat env/$(1) 2>/dev/null))
 .PHONY: env/$(1)
 env/$(1):
 	$$(info $(1) is set to "$$($(1))" which is different from old value "$$(shell cat env/$(1) 2>/dev/null)")
-	mkdir -p env
+	@mkdir -p env
 	printf "$$($(1))" > $$@
 endif
 endef


### PR DESCRIPTION
Suppose you have two branches with the same base commit. Neither branch has Scala changes. Consider `make shadowJar` when switching between these branches: it thinks there's nothing to do because the Scala code hasn't changed.

This of course doesn't work because the python version *is* changing (note: make install-editable refreshes the version files) and Hail refuses to use an out of date jar.

This adds a tiny make macro that lets make targets depend on variables that depend on the latent environment, like git SHAs. To create a target for such a variable add this line: `$(eval $(call ENV_VAR,VARIABLE_NAME))`. Any rule that depends on the value of `VARIABLE_NAME` should depend on the target `env/VARIABLE_NAME`.

I also split `BUILD_INFO` into the scala parts and the python parts and moved the scala dependency down to the shadow jar rule, where it belongs. This bug was hidden because build.gradle still regenerates the build info every time shadowJar is called.

cc: @tpoterba 