### PR TITLE
Add better sparse split multi error message

### DIFF
--- a/hail/python/hail/experimental/sparse_split_multi.py
+++ b/hail/python/hail/experimental/sparse_split_multi.py
@@ -102,7 +102,15 @@ def sparse_split_multi(sparse_mt):
                                   alleles=[mr.alleles[0], mr.alleles[1]],
                                   a_index=i,
                                   was_split=True))
-                        .or_error("Found non-left-aligned variant in sparse_split_multi")),
+                        .or_error(
+                            "Found non-left-aligned variant in sparse_split_multi\n"
+                            + "old locus: " + hl.str(ds.locus) + "\n"
+                            + "old ref  : " + ds.alleles[0] + "\n"
+                            + "old alt  : " + ds.alleles[i] + "\n"
+                            + "mr locus : " + hl.str(mr.locus) + "\n"
+                            + "mr ref   : " + mr.alleles[0] + "\n"
+                            + "mr alt   : " + mr.alleles[1]
+                            )),
                        hl.min_rep(ds.locus, [ds.alleles[0], ds.alleles[i]]))
 
     explode_structs = hl.cond(hl.len(ds.alleles) < 3,


### PR DESCRIPTION
Try to give the user information about the failure.

A follow up to this is to give a mode to ignore the error, and filter the variant.