### PR TITLE
[ci] wait for at least four minutes

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -468,7 +468,7 @@ steps:
     - kind: Pod
       name: create-ci-tables
       for: completed
-      timeout: 120
+      timeout: 240
    dependsOn:
      - default_ns
      - base_image
@@ -511,7 +511,7 @@ steps:
     - kind: Pod
       name: create-batch-tables
       for: completed
-      timeout: 120
+      timeout: 240
    dependsOn:
      - default_ns
      - create_batch_tables_image
@@ -525,7 +525,7 @@ steps:
     - kind: Pod
       name: create-batch-tables
       for: completed
-      timeout: 120
+      timeout: 240
    dependsOn:
      - default_ns
      - create_batch_tables_image


### PR DESCRIPTION
Spinning up a VM takes around two minutes. Downloading fresh container images
takes additional time, maybe a whole minute.

The cost of timing out is high: an otherwise passing PR test run may fail
demanding a bump and delaying merging of said PR by fifteen to twenty minutes.

The cost of waiting two more minutes is that a resource deadlock may last
two extra minutes. We address deadlocks by scaling up and limiting concurrent
PR tests to four.