### PR TITLE
Fix MatrixEntriesTable lowering

### DIFF
--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -653,6 +653,12 @@ class Tests(unittest.TestCase):
         assert mt.key_rows_by().key_cols_by().entries().collect() == original_order
         assert mt.key_rows_by().entries().collect() == sorted(original_order, key=lambda x: x.col_idx)
 
+    def test_entries_table_with_out_of_order_row_key_fields(self):
+        mt = hl.utils.range_matrix_table(10, 10, 1)
+        mt = mt.select_rows(key2=0, key1=mt.row_idx)
+        mt = mt.key_rows_by(mt.key1, mt.key2)
+        mt.entries()._force_count()
+
     def test_filter_cols_required_entries(self):
         mt1 = hl.utils.range_matrix_table(10, 10, n_partitions=4)
         mt1 = mt1.filter_cols(mt1.col_idx < 3)

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -542,8 +542,9 @@ object LowerMatrixIR {
                   }))))
 
             .explode(toExplode)
-            .mapRows('row.dropFields(toExplode).insertStruct('row (toExplode),
-              ordering = Some(x.typ.rowType.fieldNames.toFastIndexedSeq)))
+            .mapRows(makeStruct(x.typ.rowType.fieldNames.map { f =>
+              val fd = Symbol(f)
+              (fd, if (child.typ.rowKey.contains(f)) 'row (fd) else 'row (toExplode) (fd)) }: _*))
             .mapGlobals('global.dropFields(colsField, oldColIdx))
             .keyBy(child.typ.rowKey ++ child.typ.colKey, isSorted = true)
         } else {


### PR DESCRIPTION
The `MatrixEntriesTable` lowering rule was broken. It fails when the input `MatrixTable` has multiple key fields, which appear out of order in the row struct.

`MatrixEntriesTable` has to do an `TableAggregateByKey`, which makes a table with row type `Struct{keyFields..., aggResult}`. In particular, it rearranges the key fields to the key order. Then the later
```scala
mapRows('row.dropFields(toExplode).insertStruct('row (toExplode),
  ordering = Some(x.typ.rowType.fieldNames.toFastIndexedSeq)))
```
fails, because it tries to put the key fields back in their original order.

I've fixed this by changing the above line to a `mapRows(makeStruct(...))`, but I don't see any good reason for the restriction that `InsertFields` must preserve the relative ordering of old fields.

Another fix, which I prefer, is to change the typecheck rule for `InsertFields` to
```scala
case x@InsertFields(old, fields, fieldOrder) =>
  fieldOrder.foreach { fds =>
    val fieldsMap = scala.collection.mutable.Map(
      old.typ.asInstanceOf[TStruct].fields.map(f => f.name -> -f.typ): _*)
    fieldsMap ++= fields.map { case (name, ir) => name -> ir.typ }

    assert(fds.forall { f =>
      fieldsMap.get(f).forall(_ == -x.typ.fieldType(f))
    })
    assert(fds.length == x.typ.size)
```
As far as I can tell, code generation for `InsertFields` is safe for this relaxed typechecking.

@tpoterba Can you weigh in on the `InsertFields` semantics?