### PR TITLE
fix approx_quantiles on all-missing data

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -44,10 +44,13 @@ def _quantile_from_cdf(cdf, q):
         n = cdf.ranks[cdf.ranks.length() - 1]
         pos = hl.int64(q*n) + 1
         idx = (hl.switch(q)
-                .when(0.0, 0)
-                .when(1.0, cdf.values.length() - 1)
-                .default(_lower_bound(cdf.ranks, pos) - 1))
-        return cdf.values[idx]
+                 .when(0.0, 0)
+                 .when(1.0, cdf.values.length() - 1)
+                 .default(_lower_bound(cdf.ranks, pos) - 1))
+        res = hl.cond(n == 0,
+                      hl.null(cdf.values.dtype.element_type),
+                      cdf.values[idx])
+        return res
     return hl.rbind(cdf, compute)
 
 

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -316,6 +316,10 @@ class Tests(unittest.TestCase):
         table.aggregate(hl.agg.approx_cdf(hl.float32(table.i)))
         table.aggregate(hl.agg.approx_cdf(hl.float64(table.i)))
 
+    def test_approx_cdf_all_missing(self):
+        table = hl.utils.range_table(10).annotate(foo=hl.null(tint))
+        table.aggregate(hl.agg.approx_quantiles(table.foo, qs=[0.5]))
+
     def test_approx_cdf_col_aggregate(self):
         mt = hl.utils.range_matrix_table(10, 10)
         mt = mt.annotate_entries(foo=mt.row_idx + mt.col_idx)


### PR DESCRIPTION
If all data is missing, `approx_cdf` computes an empty `values` array. We just need to check that case, and return `NA` quantiles.