### PR TITLE
Fix Streamify

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Streamify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Streamify.scala
@@ -4,71 +4,51 @@ import is.hail.expr.types.virtual._
 
 object Streamify {
 
+  /* Notes on the invariants of these functions:
+   * - 'streamify' converts an IR with a TIterable type into an IR with type TStream.
+   * - 'unstreamify' converts an IR with type TStream into an IR with some non-TStream
+   *      TIterable type (such as TArray).
+   * - 'apply' preserves an IR's type.
+   */
+
   private[this] def streamify(streamableNode: IR): IR = streamableNode match {
-    case _: MakeStream | _: StreamRange | _: ReadPartition => Copy(streamableNode, Children(streamableNode).map { case c: IR => apply(c) } )
-    case ArrayRange(start, stop, step) => StreamRange(apply(start), apply(stop), apply(step))
+    case ArrayRange(start, stop, step) => StreamRange(start, stop, step)
     case MakeArray(args, t) => MakeStream(args.map(apply), TStream(t.elementType, t.required))
-    case ArrayMap(a, n, b) =>
-      if (a.typ.isInstanceOf[TStream]) streamableNode
-      else ArrayMap(streamify(a), n, apply(b))
-    case ArrayFilter(a, n, b) =>
-      if (a.typ.isInstanceOf[TStream]) streamableNode
-      else ArrayFilter(streamify(a), n, apply(b))
-    case ArrayFlatMap(a, n, b) =>
-      if (a.typ.isInstanceOf[TStream] && b.typ.isInstanceOf[TStream]) streamableNode
-      else ArrayFlatMap(streamify(a), n, streamify(b))
-    case ArrayScan(a, zero, zn, an, body) =>
-      if (a.typ.isInstanceOf[TStream]) streamableNode
-      else ArrayScan(streamify(a), apply(zero), zn, an, apply(body))
-    case ToArray(a) =>
-      a.typ match {
-        case _: TStream => a
-        case _: TArray => streamify(a)
-        case _ => ToStream(apply(streamableNode))
-      }
-    case ToStream(a) =>
-      a.typ match {
-        case _: TStream => a
-        case _ => ToStream(apply(a))
-      }
-    case ArrayLeftJoinDistinct(l, r, ln, rn, keyf, joinf) =>
-      ArrayLeftJoinDistinct(streamify(l), streamify(r), ln, rn, apply(keyf), apply(joinf))
-    case Let(n, v, b) =>
-      Let(n, apply(v), streamify(b))
+    case ArrayMap(a, x, b) => ArrayMap(streamify(a), x, apply(b))
+    case ArrayFilter(a, x, b) => ArrayFilter(streamify(a), x, apply(b))
+    case ArrayFlatMap(a, x, b) => ArrayFlatMap(streamify(a), x, streamify(b))
+    case ArrayScan(a, z, zn, vn, b) => ArrayScan(streamify(a), apply(z), zn, vn, apply(b))
+    case ArraySort(a, l, r, c) => ToStream(ArraySort(streamify(a), l, r, apply(c)))
+    case ArrayLeftJoinDistinct(l, r, ln, rn, k, j) =>
+      ToStream( // TODO: remove this 'ToStream' when we implement streaming joins
+        ArrayLeftJoinDistinct(streamify(l), streamify(r), ln, rn, apply(k), apply(j)))
+    case ToArray(s) => streamify(s)
+    case ToDict(s) => ToStream(ToDict(streamify(s)))
+    case ToSet(s) => ToStream(ToSet(streamify(s)))
+    case Let(n, v, b) => Let(n, apply(v), streamify(b))
     case _ =>
-      ToStream(Copy(streamableNode, Children(streamableNode).map { case c: IR => apply(c) } ))
+      if (streamableNode.typ.isInstanceOf[TStream])
+        MapIR(apply)(streamableNode)
+      else
+        ToStream(MapIR(apply)(streamableNode))
   }
 
-  private[this] def unstreamify(streamableNode: IR): IR = streamableNode match {
-    case ToArray(a) =>
-      a.typ match {
-        case _: TArray => ToArray(streamify(a))
-        case _ => streamableNode
-      }
-    case ToStream(a) =>
-      a.typ match {
-        case _: TStream => ToArray(a)
-        case _ => a
-      }
-    case If(cond, cnsq, altr) =>
-      If(cond, unstreamify(cnsq), unstreamify(altr))
-    case Let(n, v, b) =>
-      Let(n, v, unstreamify(b))
-    case _ =>
-      streamify(streamableNode) match {
-        case ToStream(a) if !a.typ.isInstanceOf[TStream] => a
-        case s => ToArray(s)
-      }
+  private[this] def unstreamify(streamNode: IR): IR = {
+    assert(streamNode.typ.isInstanceOf[TStream])
+    streamNode match {
+      case ToStream(c) => c
+      case Let(n, v, b) => Let(n, v, unstreamify(b))
+      case s => ToArray(s)
+    }
   }
 
   def apply(node: IR): IR = node match {
-    case ArraySort(a, l, r, comp) => ArraySort(streamify(a), l, r, comp)
-    case ToSet(a) => ToSet(streamify(a))
-    case ToDict(a) => ToDict(streamify(a))
     case ArrayFold(a, zero, zn, an, body) => ArrayFold(streamify(a), zero, zn, an, body)
     case ArrayFor(a, n, b) => ArrayFor(streamify(a), n, b)
-    case x: ApplyIR => apply(x.explicitNode)
-    case _ if node.typ.isInstanceOf[TStreamable] => unstreamify(node)
-    case _ => Copy(node, Children(node).map { case c: IR => apply(c) })
+    case _ =>
+      if (node.typ.isInstanceOf[TIterable])
+        unstreamify(streamify(node))
+      else
+        MapIR(apply)(node)
   }
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
@@ -247,6 +247,7 @@ abstract class PType extends BaseType with Serializable {
           t.asInstanceOf[PTuple].size == t2.size &&
           t.asInstanceOf[PTuple].types.zip(t2.types).forall { case (typ1, typ2) => typ1.isOfType(typ2) }
       case t2: PArray => t.isInstanceOf[PArray] && t.asInstanceOf[PArray].elementType.isOfType(t2.elementType)
+      case t2: PStream => t.isInstanceOf[PStream] && t.asInstanceOf[PStream].elementType.isOfType(t2.elementType)
       case t2: PSet => t.isInstanceOf[PSet] && t.asInstanceOf[PSet].elementType.isOfType(t2.elementType)
       case t2: PDict => t.isInstanceOf[PDict] && t.asInstanceOf[PDict].keyType.isOfType(t2.keyType) && t.asInstanceOf[PDict].valueType.isOfType(t2.valueType)
     }

--- a/hail/src/main/scala/is/hail/expr/types/virtual/Type.scala
+++ b/hail/src/main/scala/is/hail/expr/types/virtual/Type.scala
@@ -275,6 +275,7 @@ abstract class Type extends BaseType with Serializable {
           t.asInstanceOf[TTuple].size == t2.size &&
           t.asInstanceOf[TTuple].types.zip(t2.types).forall { case (typ1, typ2) => typ1.isOfType(typ2) }
       case t2: TArray => t.isInstanceOf[TArray] && t.asInstanceOf[TArray].elementType.isOfType(t2.elementType)
+      case t2: TStream => t.isInstanceOf[TStream] && t.asInstanceOf[TStream].elementType.isOfType(t2.elementType)
       case t2: TSet => t.isInstanceOf[TSet] && t.asInstanceOf[TSet].elementType.isOfType(t2.elementType)
       case t2: TDict => t.isInstanceOf[TDict] && t.asInstanceOf[TDict].keyType.isOfType(t2.keyType) && t.asInstanceOf[TDict].valueType.isOfType(t2.valueType)
       case t2: TNDArray =>

--- a/hail/src/test/scala/is/hail/expr/ir/ArrayDeforestationSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ArrayDeforestationSuite.scala
@@ -64,4 +64,17 @@ class ArrayDeforestationSuite extends HailSuite {
     assertEvalsTo(arrayFoldWithStruct(5, -5, -6), Row(Row(4, 0), Row(5, 0)))
   }
 
+  @Test def testStreamifyNestedSort() {
+    val t = TInt32()
+    val x = Ref("x", t)
+    assertEvalsTo(
+      ArrayMap(
+        ArraySort(
+          MakeArray(
+            Seq(I32(1), I32(2), I32(3)),
+            TArray(t))),
+        "x",
+        x * 5),
+      IndexedSeq(5, 10, 15))
+  }
 }


### PR DESCRIPTION
this IR caused an error in the C++ emitter because `Streamify` "skipped over" the `ArraySort` and didn't streamify it properly (since ArraySort expects a stream as input, not an array)
```scala
      ArrayMap(
        ArraySort(
          MakeArray(
            Seq(I32(1), I32(2), I32(3)),
            TArray(TInt32()))),
        "x",
        Ref("x", TInt32()) * 5)
```

this PR fixes this by hopefully making Streamify more straightforward