### PR TITLE
[batch] convert V1Pod to dict before sending to json encoder

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -337,17 +337,6 @@ class Job:
     async def _read_pod_statuses(self):
         if self._state in ('Pending', 'Cancelled'):
             return None
-
-        async def _read_pod_status_from_gcs():
-            pod_status, err = await app['log_store'].read_gs_file(self.directory,
-                                                                  LogStore.pod_status_file_name)
-            if err is not None:
-                traceback.print_tb(err.__traceback__)
-                log.info(f'ignoring: could not read pod status for {self.id} '
-                         f'due to {err}')
-                return None
-            return json.loads(pod_status)
-
         if self._state == 'Running':
             pod_status, err = await app['k8s'].read_pod_status(self._pod_name, pretty=True)
             if err is not None:
@@ -357,7 +346,14 @@ class Job:
             pod_status = pod_status.to_dict()
             return pod_status
         assert self._state in ('Error', 'Failed', 'Success')
-        return await _read_pod_status_from_gcs()
+        pod_status, err = await app['log_store'].read_gs_file(self.directory,
+                                                              LogStore.pod_status_file_name)
+        if err is not None:
+            traceback.print_tb(err.__traceback__)
+            log.info(f'ignoring: could not read pod status for {self.id} '
+                     f'due to {err}')
+            return None
+        return json.loads(pod_status)
 
     async def _delete_gs_files(self):
         errs = await app['log_store'].delete_gs_files(self.directory)

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -354,6 +354,7 @@ class Job:
                 traceback.print_tb(err.__traceback__)
                 log.info(f'ignoring: could not get pod status for {self.id} '
                          f'due to {err}')
+            pod_status = pod_status.to_dict()
             return pod_status
         assert self._state in ('Error', 'Failed', 'Success')
         return await _read_pod_status_from_gcs()


### PR DESCRIPTION
When we retrieve a live pod status, we recieve a V1Pod object from the k8s
API. The `json` library does not know how to convert that to a JSON object.
This change makes the return type of `Job._read_pod_statuses()` uniformly
`dict`.