### PR TITLE
Responded to deprecations of abcs in toplevel collections module

### DIFF
--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -1,7 +1,7 @@
 import abc
 import json
 import math
-from collections import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 import hail as hl
 from hail import genetics

--- a/hail/python/hail/utils/linkedlist.py
+++ b/hail/python/hail/utils/linkedlist.py
@@ -1,4 +1,4 @@
-from collections import Iterable, Iterator
+from collections.abc import Iterable, Iterator
 
 class ListIterator(Iterator):
     def __init__(self, node):

--- a/hail/python/hail/utils/struct.py
+++ b/hail/python/hail/utils/struct.py
@@ -1,6 +1,9 @@
-from hail.typecheck import *
-from collections import Mapping, OrderedDict
+from collections import OrderedDict
+from collections.abc import Mapping
+
 from hail.utils.misc import get_nice_attr_error, get_nice_field_error
+from hail.typecheck import *
+
 
 
 class Struct(Mapping):

--- a/hail/python/hail/utils/struct.py
+++ b/hail/python/hail/utils/struct.py
@@ -5,7 +5,6 @@ from hail.utils.misc import get_nice_attr_error, get_nice_field_error
 from hail.typecheck import *
 
 
-
 class Struct(Mapping):
     """
     Nested annotation structure.


### PR DESCRIPTION
We were getting warnings of the form:

`DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working`

because Python has moved abstract collections like `Iterable` from `collections` to `collections.abc`. We still get some warnings from packages we depend on, but I've addressed all instances of this I saw warnings for in our hail python code. 