### PR TITLE
preserve valid keys in TableKeyBy pruning

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -391,10 +391,10 @@ object PruneDeadFields {
       case TableKeyBy(child, key, isSorted) =>
         val reqKey = requestedType.key
         val childReqKey = if (isSorted)
-          child.typ.key.take(reqKey.length)
+          child.typ.key
         else {
-          val nSame = key.zip(child.typ.key).takeWhile { case (l, r) => l == r }.length
-          key.take(nSame)
+          val nPreserved = reqKey.zip(child.typ.key).takeWhile { case (l, r) => l == r }.length
+          child.typ.key.take(nPreserved)
         }
 
         memoizeTableIR(child, TableType(

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -394,7 +394,7 @@ object PruneDeadFields {
         val childReqKey = if (isSorted)
           child.typ.key
         else if (isPrefix)
-          reqKey
+          if  (reqKey.length <= child.typ.key.length) reqKey else child.typ.key
         else FastIndexedSeq()
 
         memoizeTableIR(child, TableType(

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -390,12 +390,12 @@ object PruneDeadFields {
         memoizeTableIR(child, unify(child.typ, requestedType, irDep), memo)
       case TableKeyBy(child, key, isSorted) =>
         val reqKey = requestedType.key
+        val isPrefix = reqKey.zip(child.typ.key).forall { case (l, r) => l == r }
         val childReqKey = if (isSorted)
           child.typ.key
-        else {
-          val nPreserved = reqKey.zip(child.typ.key).takeWhile { case (l, r) => l == r }.length
-          child.typ.key.take(nPreserved)
-        }
+        else if (isPrefix)
+          reqKey
+        else FastIndexedSeq()
 
         memoizeTableIR(child, TableType(
           key = childReqKey,

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -388,7 +388,7 @@ object PruneDeadFields {
       case TableFilter(child, pred) =>
         val irDep = memoizeAndGetDep(pred, pred.typ, child.typ, memo)
         memoizeTableIR(child, unify(child.typ, requestedType, irDep), memo)
-      case TableKeyBy(child, key, isSorted) =>
+      case TableKeyBy(child, _, isSorted) =>
         val reqKey = requestedType.key
         val isPrefix = reqKey.zip(child.typ.key).forall { case (l, r) => l == r }
         val childReqKey = if (isSorted)


### PR DESCRIPTION
If we're using a TableKeyBy to go from e.g. `[locus, alleles]` to `[locus]`, the requested type of the child node shouldn't have an empty key---we should preserve the necessary keys since they already exist.

Would love a glance from @patrick-schultz and @tpoterba to double-check that this is correct.