### PR TITLE
hailctl dataproc modify --update-hail-version

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/modify.py
+++ b/hail/python/hailtop/hailctl/dataproc/modify.py
@@ -67,13 +67,11 @@ def main(args, pass_through_args):
             raise RuntimeError(f"package has no 'deploy.yaml' file")
         updated_wheel = yaml.safe_load(
             pkg_resources.resource_stream('hailtop.hailctl', "deploy.yaml"))['dataproc']['wheel']
-        args.wheel = updated_wheel
+        wheel = updated_wheel
     else:
         wheel = args.wheel
 
-
     if wheel is not None:
-        wheel = args.wheel
         wheelfile = os.path.basename(wheel)
         cmds = []
         if wheel.startswith("gs://"):

--- a/hail/python/hailtop/hailctl/dataproc/modify.py
+++ b/hail/python/hailtop/hailctl/dataproc/modify.py
@@ -61,14 +61,18 @@ def main(args, pass_through_args):
             print("Updating cluster '{}'...".format(args.name))
             check_call(cmd)
 
+    wheel = None
     if args.update_hail_version:
         if not pkg_resources.resource_exists('hailtop.hailctl', "deploy.yaml"):
             raise RuntimeError(f"package has no 'deploy.yaml' file")
         updated_wheel = yaml.safe_load(
             pkg_resources.resource_stream('hailtop.hailctl', "deploy.yaml"))['dataproc']['wheel']
         args.wheel = updated_wheel
+    else:
+        wheel = args.wheel
 
-    if args.wheel is not None:
+
+    if wheel is not None:
         wheel = args.wheel
         wheelfile = os.path.basename(wheel)
         cmds = []


### PR DESCRIPTION
Running the command `hailctl dataproc modify --update-hail-version` will update the version of hail running on the cluster to the version you're currently running locally.

So if user has a cluster already and we tell them to update hail, they can just do:
```
pip install hail -U
hailctl dataproc modify my-cluster --update-hail-version
```

This arguably satisfies the intent of #6674, Dan can decide if we need more than this. 