### PR TITLE
Requested step names -> Requested Steps

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -271,11 +271,14 @@ class Test(unittest.TestCase):
 
         @app.route('/test', methods=['POST'])
         def test():
-            d['status'] = request.get_json()
+            body = request.get_json()
+            print(f'body {body}')
+            d['status'] = body
             return Response(status=200)
 
         server = ServerThread(app)
         try:
+            print('1starting...')
             server.start()
             b = self.client.create_batch()
             j = b.create_job(
@@ -284,6 +287,7 @@ class Test(unittest.TestCase):
                 attributes={'foo': 'bar'},
                 callback=server.url_for('/test'))
             b = b.submit()
+            print(f'1ids {j.job_id}')
             j.wait()
 
             poll_until(lambda: 'status' in d)
@@ -291,8 +295,10 @@ class Test(unittest.TestCase):
             self.assertEqual(status['state'], 'Success')
             self.assertEqual(status['attributes'], {'foo': 'bar'})
         finally:
+            print(f'1shutting down...')
             server.shutdown()
             server.join()
+            print(f'1shut down, joined')
 
     def test_log_after_failing_job(self):
         b = self.client.create_batch()

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -141,8 +141,8 @@ def test_callback(client):
         left = batch.create_job('alpine:3.8', command=['echo', 'left'], parents=[head])
         right = batch.create_job('alpine:3.8', command=['echo', 'right'], parents=[head])
         tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parents=[left, right])
-        print(f'ids {head.job_id} {left.job_id} {right.job_id} {tail.job_id}')
         batch = batch.submit()
+        print(f'ids {head.job_id} {left.job_id} {right.job_id} {tail.job_id}')
         batch_status = batch.wait()
 
         i = 0

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -127,10 +127,13 @@ def test_callback(client):
 
     @app.route('/test', methods=['POST'])
     def test():
-        output.append(request.get_json())
+        body = request.get_json()
+        print(f'body {body}')
+        output.append(body)
         return Response(status=200)
 
     try:
+        print('starting...')
         server = ServerThread(app)
         server.start()
         batch = client.create_batch(callback=server.url_for('/test'))
@@ -138,6 +141,7 @@ def test_callback(client):
         left = batch.create_job('alpine:3.8', command=['echo', 'left'], parents=[head])
         right = batch.create_job('alpine:3.8', command=['echo', 'right'], parents=[head])
         tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parents=[left, right])
+        print(f'ids {head.job_id} {left.job_id} {right.job_id} {tail.job_id}')
         batch = batch.submit()
         batch_status = batch.wait()
 
@@ -157,8 +161,10 @@ def test_callback(client):
         assert output[3]['job_id'] == tail.job_id, (output, batch_status)
     finally:
         if server:
+            print('shutting down...')
             server.shutdown()
             server.join()
+            print('shut down, joined')
 
 
 def test_no_parents_allowed_in_other_batches(client):

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -67,13 +67,13 @@ class StepParameters:
 
 
 class BuildConfiguration:
-    def __init__(self, code, config_str, scope, requested_steps=None):
+    def __init__(self, code, config_str, scope, requested_step_names=None):
         config = yaml.safe_load(config_str)
         name_step = {}
         self.steps = []
 
-        if requested_steps:
-            log.info(f"Constructing build configuration with steps: {requested_steps}")
+        if requested_step_names:
+            log.info(f"Constructing build configuration with steps: {requested_step_names}")
 
         for step_config in config['steps']:
             step_params = StepParameters(code, scope, step_config, name_step)
@@ -81,6 +81,7 @@ class BuildConfiguration:
             self.steps.append(step)
             name_step[step.name] = step
 
+        requested_steps = [name_step[s] for s in requested_step_names]
         # transitively close requested_steps over dependenies
         if requested_steps:
             visited = set()
@@ -93,7 +94,7 @@ class BuildConfiguration:
 
             for s in requested_steps:
                 request(s)
-            self.steps = [s for s in self.steps if s in visited]
+            self.steps = [s for s in self.steps if s.name in visited]
 
     def build(self, batch, code, scope):
         assert scope in ('deploy', 'test', 'dev')

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -81,9 +81,8 @@ class BuildConfiguration:
             self.steps.append(step)
             name_step[step.name] = step
 
-        requested_steps = [name_step[s] for s in requested_step_names]
-        # transitively close requested_steps over dependenies
-        if requested_steps:
+        # transitively close requested_step_names over dependenies
+        if requested_step_names:
             visited = set()
 
             def request(step):
@@ -92,9 +91,9 @@ class BuildConfiguration:
                     for s2 in step.deps:
                         request(s2)
 
-            for s in requested_steps:
-                request(s)
-            self.steps = [s for s in self.steps if s.name in visited]
+            for step_name in requested_step_names:
+                request(name_step[step_name])
+            self.steps = [s for s in self.steps if s in visited]
 
     def build(self, batch, code, scope):
         assert scope in ('deploy', 'test', 'dev')

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -815,7 +815,7 @@ mkdir -p {shq(repo_dir)}
 ''')
             log.info(f'User {self.user} requested these steps for dev deploy: {steps}')
             with open(f'{repo_dir}/build.yaml', 'r') as f:
-                config = BuildConfiguration(self, f.read(), scope='dev', requested_steps=steps)
+                config = BuildConfiguration(self, f.read(), scope='dev', requested_step_names=steps)
 
             log.info(f'creating dev deploy batch for {self.branch.short_str()} and user {self.user}')
 


### PR DESCRIPTION
Dev deploy is currently broken, this should hopefully fix. Issue is that we were treating the name of a step like it was a step object. I am calling the argument `requested_step_names` now to help keep track of the distinction. 

@jigold @cseed