### PR TITLE
[hail] Don't write files during C++ backend compilation

### DIFF
--- a/hail/src/main/c/NativePtr.cpp
+++ b/hail/src/main/c/NativePtr.cpp
@@ -92,6 +92,7 @@ void catch_signals() {
   signal(SIGFPE,  on_signal);
   signal(SIGILL,  on_signal);
   //signal(SIGSEGV, on_signal);
+  signal(SIGPIPE, SIG_IGN);
 }
 
 class NativePtrInfo {


### PR DESCRIPTION
This change removes previous infrastructure for building generated C++
code. The previous infrastructure would write two files, a cpp file and
a makefile, then run make to build the shared object.

This change gets rid of all that in favor of a pipe-fork-exec model,
using the ability of clang++/g++ to read from stdin via `-x <LANG>` and
`-` arguments. Some notes:

* We still invoke the shell to find JAVA_HOME if it is not defined. We
  do this in a similar way to what we do in the makefiles.
* Because of the odd signatures of the `exec` family of functions, we
  use a `const_cast` to discard the appropriate qualifiers. This is safe
  because we only do it after forking, and only to exec, and never use
  that data after the call to `execvp`.
* We ignore `SIGPIPE`, as it is raised when the process tries to write
  to a pipe where the other end is closed. Not doing this could crash
  hail, and means that the child process died before we wrote all of the
  c++ source to the pipe, other error handling will catch what actually
  went wrong, rather than being unable to write to the pipe.