### PR TITLE
fix routing from internal.hail.is

### DIFF
--- a/gateway/Makefile
+++ b/gateway/Makefile
@@ -20,7 +20,7 @@ push: build
 
 deploy: push
 	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"global":{"internal_ip":"$(INTERNAL_IP)"}}' internal-service.yaml internal-service.yaml.out
-        kubectl -n default apply -f internal-service.yaml.out
+	kubectl -n default apply -f internal-service.yaml.out
 	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"global":{"ip":"$(IP)"}}' external-service.yaml external-service.yaml.out
 	kubectl -n default apply -f external-service.yaml.out
 	python3 ../ci/jinja2_render.py '{"code":{"sha":"$(shell git rev-parse --short=12 HEAD)"},"deploy":true,"gateway_image":{"image":"$(GATEWAY_IMAGE)"}}' deployment.yaml deployment.yaml.out

--- a/gateway/deployment.yaml
+++ b/gateway/deployment.yaml
@@ -16,7 +16,6 @@ spec:
         app: gateway
         hail.is/sha: "{{ code.sha }}"
     spec:
-      serviceAccountName: gateway
       priorityClassName: infrastructure
       affinity:
         podAntiAffinity:

--- a/gateway/gateway.nginx.conf
+++ b/gateway/gateway.nginx.conf
@@ -32,15 +32,16 @@ server {
         proxy_pass http://router-resolver.default.svc.cluster.local/auth/$namespace;
     }
 
-    location ~ ^/([^/]+) {
+    location ~ ^/([^/]+)/([^/]+) {
         set $namespace $1;
+        set $service $2;
 
         auth_request /auth;
         auth_request_set $router_ip $upstream_http_x_router_ip;
 
         proxy_pass http://$router_ip$request_uri;
 
-        proxy_set_header Host $host;
+        proxy_set_header Host $service.internal;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/monitoring/router.nginx.conf
+++ b/monitoring/router.nginx.conf
@@ -3,10 +3,12 @@ server {
 
     location /monitoring/grafana/ {
         proxy_pass http://grafana/;
+        proxy_set_header Host internal.hail.is;
     }
 
     location /monitoring/prometheus/ {
         proxy_pass http://prometheus;
+        proxy_set_header Host internal.hail.is;
     }
 
     location /monitoring/kibana/ {

--- a/router/router.nginx.conf.in
+++ b/router/router.nginx.conf.in
@@ -6,7 +6,7 @@ map $http_x_forwarded_proto $updated_scheme {
 }
 
 server {
-    server_name @domain@ www.@domain@;
+    server_name @domain@ www.* site.*;
 
     location = /healthcheck {
       return 204;
@@ -21,7 +21,7 @@ server {
 }
 
 server {
-    server_name scorecard.@domain@;
+    server_name scorecard.*;
 
     location / {
         proxy_pass http://scorecard/;
@@ -32,7 +32,7 @@ server {
 }
 
 server {
-    server_name ci.@domain@;
+    server_name ci.*;
 
     location ~ /(test-ci-[a-z0-9]+)/(.*) {
         resolver kube-dns.kube-system.svc.cluster.local;
@@ -48,7 +48,7 @@ server {
 }
 
 server {
-    server_name batch.@domain@;
+    server_name batch.*;
     client_max_body_size 10000m;
 
     location / {
@@ -60,7 +60,7 @@ server {
 }
 
 server {
-    server_name batch2.@domain@;
+    server_name batch2.*;
     client_max_body_size 10000m;
 
     location / {
@@ -72,7 +72,7 @@ server {
 }
 
 server {
-    server_name notebook.@domain@;
+    server_name notebook.*;
 
     # needed to correctly handle error_page with internal handles
     recursive_error_pages on;
@@ -138,7 +138,7 @@ server {
 }
 
 server {
-    server_name notebook2.@domain@;
+    server_name notebook2.*;
 
     # needed to correctly handle error_page with internal handles
     recursive_error_pages on;
@@ -213,7 +213,7 @@ map $http_upgrade $connection_upgrade {
 }
 
 server {
-    server_name ukbb-rg.@domain@;
+    server_name ukbb-rg.*;
 
     location /rg_browser {
         proxy_pass http://ukbb-rg-browser.ukbb-rg;


### PR DESCRIPTION
OK, this should fix routing from internal.hail.is.  The gateway routes internal.hail.is/ns/svc to router.ns with Host: svc.internal so the ns router can dispatch to the right server block off the Host.  We could dispatch off the URL, but that would mean the default and private namespaces dispatch different, doubling the complexity of the router NGINX configuration.  Change the host back for grafana and prometheus which generate a redirect otherwise.

The monitoring and gateway changes are deployed and everything seems to be working.
