### PR TITLE
[hail] implement type context to hold reference genomes

### DIFF
--- a/hail/python/hail/genetics/reference_genome.py
+++ b/hail/python/hail/genetics/reference_genome.py
@@ -121,7 +121,6 @@ class ReferenceGenome(object):
         self._sequence_files = None
         self._liftovers = dict()
 
-
     def __str__(self):
         return self._config['name']
 

--- a/hail/python/test/hail/expr/test_types.py
+++ b/hail/python/test/hail/expr/test_types.py
@@ -96,3 +96,47 @@ class Tests(unittest.TestCase):
             hl.tstruct(a=hl.tbool, b=hl.tint32, c=hl.tint32)._rename({'b': 'x', 'c': 'x'})
         with self.assertRaisesRegex(ValueError, "attempted to rename 'a' and 'b' both to 'a'"):
             hl.tstruct(a=hl.tbool, b=hl.tint32)._rename({'b': 'a'})
+
+    def test_get_context(self):
+        tl1 = tlocus('GRCh37')
+        tl2 = tlocus('GRCh38')
+
+        types_and_rgs = [
+            ([
+                tint32,
+                tint64,
+                tfloat32,
+                tfloat64,
+                tstr,
+                tbool,
+                tcall,
+                tinterval(tset(tint32)),
+                tdict(tstr, tarray(tint32)),
+                tndarray(tstr, 1),
+                tstruct(),
+                tstruct(x=tint32, y=tint64, z=tarray(tset(tstr))),
+                tunion(),
+                tunion(a=tint32, b=tstr),
+                ttuple(tstr, tint32),
+                ttuple()], set()),
+            ([
+                tl1,
+                tinterval(tl1),
+                tdict(tstr, tl1),
+                tndarray(tl1, 2),
+                tinterval(tl1),
+                tset(tinterval(tl1)),
+                tstruct(a=tint32, b=tint32, c=tarray(tl1)),
+                tunion(a=tint32, b=tl1),
+                ttuple(tarray(tint32), tl1, tstr, tint32, tbool),
+            ], {"GRCh37"}),
+            ([
+                tdict(tl1, tl2),
+                ttuple(tarray(tl2), tl1, tstr, tint32, tbool),
+            ], {"GRCh37", "GRCh38"})
+        ]
+
+        for types, rgs in types_and_rgs:
+            for t in types:
+                print(f"type: {t} refs: {t.get_context().references} expected: {rgs}")
+                self.assertEqual(t.get_context().references, rgs)


### PR DESCRIPTION
So we can pull out the necessary reference genomes (in python) to execute a given IR, or to parse a given type, and pass them in to the Scala execution context which will not have access to the reference genomes.