### PR TITLE
[hail] pipeline scan combOps

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -102,13 +102,13 @@ object TableMapIRNew {
     HailContext.get.sFS.writeFileNoCompression(scanAggsPerPartitionFile) { os =>
       HailContext.get.sc.runJob(
         runscan,
-        (it: Iterator[Array[Byte]]) => it.next,
+        (_, it: Iterator[Array[Byte]]) => it.next,
         (i: Int, row: Array[Byte]) => synchronized {
           assert(aggs(i+1) == null)
           aggs(i+1) = row
           while (nextIdx < aggs.length - 1 && aggs(nextIdx) != null && aggs(nextIdx+1) != null) {
             if (nextIdx < scanAggCount) {
-              partitionIndices(i) = os.getPos
+              partitionIndices(nextIdx) = os.getPos
               os.writeInt(aggs(nextIdx).length)
               os.write(aggs(nextIdx), 0, aggs(nextIdx).length)
               os.hflush()


### PR DESCRIPTION
Try to run scan combOps while running the job. There's a very real
possiblity that jobs will finish in the worst possible order and we will
blow memory. But it's a start. Also this won't have the SpillingCollectIterator
overhead, so hopefully this should be faster in many cases.