### PR TITLE
[benchmark] Fix imports

### DIFF
--- a/hail/python/hailtop/hailctl/dev/benchmark/run/__init__.py
+++ b/hail/python/hailtop/hailctl/dev/benchmark/run/__init__.py
@@ -1,8 +1,14 @@
 from .utils import run_all, run_pattern, run_list, initialize
+from . import matrix_table_benchmarks
+from . import table_benchmarks
+from . import methods_benchmarks
 
 __all__ = [
     'run_all',
     'run_pattern',
     'run_list',
     'initialize',
+    'matrix_table_benchmarks',
+    'table_benchmarks',
+    'methods_benchmarks'
 ]


### PR DESCRIPTION
#6915 broke benchmarks by removing these import lines, which had the
 side effect of adding benchmarks to a registry.