### PR TITLE
[hail] introduce (empty) type parsing context in Scala

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -925,12 +925,12 @@ object IRParser {
       case "ApplySeeded" =>
         val function = identifier(it)
         val seed = int64_literal(it)
-        val rt = type_expr(it)
+        val rt = type_expr(env.typEnv)(it)
         val args = ir_value_children(env)(it)
         ApplySeeded(function, args, seed, rt)
       case "ApplyIR" | "ApplySpecial" | "Apply" =>
         val function = identifier(it)
-        val rt = type_expr(it)
+        val rt = type_expr(env.typEnv)(it)
         val args = ir_value_children(env)(it)
         invoke(function, rt, args: _*)
       case "Uniroot" =>


### PR DESCRIPTION
Threads an environment through the type parser to handle reference genomes. Currently we're just using the default, which looks at the global ReferenceGenome.references; this needs to be threaded through the type serialization logic before we can get rid of that.