### PR TITLE
[batch] fix throttler bugs

### DIFF
--- a/batch/batch/throttler.py
+++ b/batch/batch/throttler.py
@@ -19,14 +19,14 @@ class PodThrottler:
 
         async def manager(workers):
             while True:
-                failed, pending = await asyncio.wait(workers, return_when=asyncio.FIRST_COMPLETED)
+                failed, pending = await asyncio.wait(workers, return_when=asyncio.FIRST_EXCEPTION)
                 for fut in failed:
                     err = fut.exception()
                     assert err is not None
                     err_msg = '\n'.join(
                         traceback.format_exception(type(err), err, err.__traceback__))
                     log.error(f'restarting failed worker: {err} {err_msg}')
-                    pending.append(asyncio.ensure_future(self._create_pod()))
+                    pending.add(asyncio.ensure_future(self._create_pod()))
                 workers = pending
 
         asyncio.ensure_future(manager(workers))


### PR DESCRIPTION
I thought first completed would also fire on first exception,
but it appears not. These futures should only finish by raising
an exception anyway, so `FIRST_EXCEPTION` is fine.

I failed to realize `pending` was a `set` and thus adding an element
is called `add` not `append`.