### PR TITLE
[hail] Better fix for make pytest

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -97,25 +97,25 @@ python/hail/hail-all-spark.jar: $(SHADOW_JAR)
 pytest: $(PYTHON_VERSION_INFO) $(SHADOW_JAR) $(INIT_SCRIPTS)
 pytest: python/README.md python/hail/hail-all-spark.jar
 	cd python && $(HAIL_PYTHON3) setup.py pytest \
-     --addopts '-v \
+     --addopts "-v \
      --color=no \
      --instafail \
      -r A \
      --self-contained-html \
-     --html=build/reports/pytest.html \
+     --html=../build/reports/pytest.html \
      --noconftest \
-     $(PYTEST_ARGS)'
+     $(PYTEST_ARGS)"
 
 .PHONY: doctest
 doctest: $(PYTHON_VERSION_INFO) $(SHADOW_JAR) $(INIT_SCRIPTS)
 doctest: python/README.md python/hail/hail-all-spark.jar
 	cd python && $(HAIL_PYTHON3) setup.py pytest \
-	  --addopts '-v \
+	  --addopts "-v \
     --color=no \
     --instafail \
     -r A \
     --self-contained-html \
-    --html=build/reports/pytest-doctest.html \
+    --html=../build/reports/pytest-doctest.html \
     --doctest-modules \
     --doctest-glob='*.rst' \
     --ignore=setup.py \
@@ -127,7 +127,7 @@ doctest: python/README.md python/hail/hail-all-spark.jar
     --ignore=hail/docs/doctest_write_data.py \
     --ignore=hail/docs/getting_started_developing.rst \
     --ignore=hail/docs/getting_started.rst \
-    $(PYTEST_ARGS)'
+    $(PYTEST_ARGS)"
 
 .PHONY: wheel
 wheel: $(WHEEL)


### PR DESCRIPTION
Single quotes and escaped newlines interact strangely. I don't pretend
to ungerstand it. This is fixed by changing to double quotes. I also
changed the paths of the pytest html as we are invoking the pytest
command from the 'python' directory.

I think this is the better solution to the issue previously solved by #6956 