### PR TITLE
NDArray Map

### DIFF
--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -3196,7 +3196,7 @@ class Tests(unittest.TestCase):
 
     @skip_unless_spark_backend()
     @run_with_cxx_compile()
-    def test_ndarray_map(self):
+    def test_ndarray_map_cxx(self):
         a = hl._ndarray([[2, 3, 4], [5, 6, 7]])
         b = hl.map(lambda x: -x, a)
         c = hl.map(lambda x: True, a)
@@ -3205,6 +3205,17 @@ class Tests(unittest.TestCase):
             (b, [[-2, -3, -4], [-5, -6, -7]]),
             (c, [[True, True, True],
                  [True, True, True]]))
+
+    @skip_unless_spark_backend()
+    def test_ndarray_map_jvm(self):
+        a = hl._ndarray([[2, 3, 4], [5, 6, 7]])
+        b = hl.map(lambda x: -x, a)
+        c = hl.map(lambda x: True, a)
+
+        assert(np.array_equal(hl.eval(b), [[-2, -3, -4],
+                                           [-5, -6, -7]]))
+        assert(np.array_equal(hl.eval(c), [[True, True, True],
+                                           [True, True, True]]))
 
     @skip_unless_spark_backend()
     @run_with_cxx_compile()

--- a/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -143,7 +143,7 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: PType, va
   )
 
   def start(): Code[Unit] = {
-    assert(!ftype.isInstanceOf[PArray])
+    assert(!ftype.isInstanceOf[PArray]) //Need to use other start with length.
     ftype match {
       case _: PBaseStruct => start(true)
       case _: PBinary =>

--- a/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -143,7 +143,7 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: PType, va
   )
 
   def start(): Code[Unit] = {
-    assert(!ftype.isInstanceOf[PArray]) //Need to use other start with length.
+    assert(!ftype.isInstanceOf[PArray]) // Need to use other start with length.
     ftype match {
       case _: PBaseStruct => start(true)
       case _: PBinary =>

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -18,6 +18,13 @@ object Code {
     }
   }
 
+  def apply[S1](c1: Code[S1]): Code[S1] =
+    new Code[S1] {
+      def emit(il: Growable[AbstractInsnNode]): Unit = {
+        c1.emit(il)
+      }
+    }
+
   def apply[S1, S2](c1: Code[S1], c2: Code[S2]): Code[S2] =
     new Code[S2] {
       def emit(il: Growable[AbstractInsnNode]): Unit = {

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -18,13 +18,6 @@ object Code {
     }
   }
 
-  def apply[S1](c1: Code[S1]): Code[S1] =
-    new Code[S1] {
-      def emit(il: Growable[AbstractInsnNode]): Unit = {
-        c1.emit(il)
-      }
-    }
-
   def apply[S1, S2](c1: Code[S1], c2: Code[S2]): Code[S2] =
     new Code[S2] {
       def emit(il: Growable[AbstractInsnNode]): Unit = {

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1344,7 +1344,7 @@ private class Emit(
               Code.foreach(0 until nDims) { index =>
                 shapePType.isFieldMissing(shapet.value[Long], index).mux[Unit](
                   Code._fatal(s"shape missing at index $index"),
-                  Code(Code._println("Shaped"), shapeSrvb.addLong(getShapeAtIdx(index)), shapeSrvb.advance())
+                  Code(shapeSrvb.addLong(getShapeAtIdx(index)), shapeSrvb.advance())
                 )
               },
               ndAddress := xP.construct(0, 0, shapeSrvb.end(), xP.makeDefaultStrides(getShapeAtIdx, mb), requiredData, mb)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1351,9 +1351,7 @@ private class Emit(
                   })
               }),
               srvb.advance(),
-              {
-                srvb.addIRIntermediate(repr.fieldType("strides").asInstanceOf[PBaseStruct])(xP.makeDefaultStrides(getShapeAtIdx, mb))
-              },
+              srvb.addIRIntermediate(repr.fieldType("strides").asInstanceOf[PBaseStruct])(xP.makeDefaultStrides(getShapeAtIdx, mb)),
               srvb.advance(),
               srvb.addIRIntermediate(repr.fieldType("data").asInstanceOf[PArray])(
                 repr.fieldType("data").asInstanceOf[PArray].checkedConvertFrom(mb, region, datat.value[Long], dataContainer, "NDArray cannot have missing data"))
@@ -1926,9 +1924,7 @@ private class Emit(
 
         val childEmitter = deforest(child)
         val setup = Code(childEmitter.setup)
-
-//        val shape = childP.representation.field("shape").typ.asInstanceOf[PStruct].loadField(region, childEmitter.shape,)
-
+        
         new NDArrayEmitter(mb, childEmitter.nDims, childEmitter.outputShape,
           childP.representation.field("shape").typ.asInstanceOf[PTuple],
           body.pType, setup) {

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1346,7 +1346,7 @@ private class Emit(
                   Code(shapeSrvb.addLong(getShapeAtIdx(index)), shapeSrvb.advance())
                 )
               },
-              ndAddress := xP.construct(0, 0, shapeSrvb.end(), xP.makeDefaultStrides(getShapeAtIdx, mb), requiredData, mb)
+              ndAddress := xP.construct(0, 0, shapeSrvb.end(), xP.makeDefaultStrides(shapePType, shapet.value[Long], mb), requiredData, mb)
             )
           )
         )
@@ -1949,15 +1949,13 @@ abstract class NDArrayEmitter(
    val mb: MethodBuilder,
    val nDims: Int,
    val outputShape: Code[Long],
-   val outputShapePType: PBaseStruct,
+   val outputShapePType: PTuple,
    val outputElementPType: PType,
    val setup: Code[_]) {
 
   def outputElement(idxVars: Seq[ClassFieldRef[Long]]): Code[_]
 
   def emit(targetType: PNDArray): EmitTriplet = {
-    def getShapeAtIdx(index: Int) = Region.loadLong(outputShapePType.loadField(outputShape, index))
-
     val dataSrvb = new StagedRegionValueBuilder(mb, targetType.representation.fieldType("data").asInstanceOf[PArray])
 
     val dataAddress: Code[Long] = {
@@ -1972,7 +1970,7 @@ abstract class NDArrayEmitter(
 
     val ndSetup = Code(
       setup,
-      ndAddress := targetType.construct(0, 0, outputShape, targetType.makeDefaultStrides(getShapeAtIdx, mb), dataAddress, mb)
+      ndAddress := targetType.construct(0, 0, outputShape, targetType.makeDefaultStrides(outputShapePType, outputShape, mb), dataAddress, mb)
     )
     EmitTriplet(ndSetup, false, ndAddress)
   }
@@ -1996,7 +1994,6 @@ abstract class NDArrayEmitter(
       )
     }
   }
-
 }
 
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1334,6 +1334,8 @@ private class Emit(
           rowMajort.setup)
 
         val value = coerce[Long](Code(
+          Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
+            "println", "MAKING ND ARRAY"),
           srvb.start(),
           srvb.addInt(0),
           srvb.advance(),
@@ -1381,6 +1383,8 @@ private class Emit(
               srvb.advance(),
               srvb.addIRIntermediate(repr.fieldType("data").asInstanceOf[PArray])(
                 repr.fieldType("data").asInstanceOf[PArray].checkedConvertFrom(mb, region, datat.value[Long], dataContainer, "NDArray cannot have missing data")),
+              Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
+                "println", "FINISHED MAKING ND ARRAY"),
               srvb.end()
             )
           )
@@ -2005,26 +2009,42 @@ abstract class NDArrayEmitter(
       Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
         "println", "Set up emitter!"),
       //Ugh, need to create a new NDArray
+      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
+        "println", "About to start SRVB!"),
       srvb.start(),
+      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
+        "println", "Started SRVB!"),
       srvb.addInt(0),
-      srvb.advance(),
-      srvb.addInt(0),
+      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
+        "println", "Added first int!"),
       srvb.advance(),
       Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
-        "println", "Added first two ints"),
+        "println", "Advanced!"),
+      srvb.addInt(0),
+      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
+        "println", "Added second int!"),
+      srvb.advance(),
+      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
+        "println", "Advanced!"),
       srvb.addIRIntermediate(outputShapePType)(outputShape), //shape
       Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
-        "println", "Added shape"),
+        "println", "Added shape!"),
       srvb.advance(),
+      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
+        "println", "Advanced!"),
       srvb.addBaseStruct(targetType.representation.fieldType("strides").asInstanceOf[PBaseStruct], {srvb =>
         coerce[Unit](targetType.makeDefaultStrides(getShapeAtIdx, srvb, mb))
       }),
       Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
         "println", "Added stride"),
       srvb.advance(),
+      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
+        "println", "Advanced!"),
       srvb.addArray(targetType.representation.fieldType("data").asInstanceOf[PArray], {srvb =>
         coerce[Unit](emitLoops(srvb))
       }),
+      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
+        "println", "Added data"),
       srvb.end()
     )
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1379,6 +1379,10 @@ private class Emit(
 //                )
               }),
               srvb.advance(),
+              Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
+                "println", "About to write data, srvb is at:"),
+              Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[Long, Unit](
+                "println", srvb.currentOffset),
               srvb.addIRIntermediate(repr.fieldType("data").asInstanceOf[PArray])(
                 repr.fieldType("data").asInstanceOf[PArray].checkedConvertFrom(mb, region, datat.value[Long], dataContainer, "NDArray cannot have missing data")),
               Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1386,6 +1386,10 @@ private class Emit(
               srvb.addIRIntermediate(repr.fieldType("data").asInstanceOf[PArray])(
                 repr.fieldType("data").asInstanceOf[PArray].checkedConvertFrom(mb, region, datat.value[Long], dataContainer, "NDArray cannot have missing data")),
               Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
+                "println", "Trying to print address to data:"),
+              Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[Long, Unit](
+                "println", region.loadAddress(srvb.currentOffset)),
+              Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
                 "println", "FINISHED MAKING ND ARRAY. It's at:"),
               Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[Long, Unit](
                 "println", srvb.end())

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1924,18 +1924,15 @@ private class Emit(
 
         val childEmitter = deforest(child)
         val setup = Code(childEmitter.setup)
-        
+
         new NDArrayEmitter(mb, childEmitter.nDims, childEmitter.outputShape,
           childP.representation.field("shape").typ.asInstanceOf[PTuple],
           body.pType, setup) {
           override def outputElement(idxVars: Seq[ClassFieldRef[Long]]): Code[_] = {
             Code(
-              Code._println("Reached output element in NDArrayMap"),
               elemRef := childEmitter.outputElement(idxVars),
               bodyt.setup,
-              Code._println("Set up body"),
               bodyt.m.orEmpty(Code._fatal("NDArray map body cannot be missing")),
-              Code._println("Body wasn't empty"),
               bodyt.v
             )
           }
@@ -1995,7 +1992,6 @@ abstract class NDArrayEmitter(
     val storeElement = mb.newLocal(typeToTypeInfo(outputElementPType.virtualType)).asInstanceOf[LocalRef[Double]]
     val body =
       Code(
-        Code._println("Evaluating innermost loop body"),
         storeElement := outputElement(idxVars).asInstanceOf[Code[Double]],
         srvb.addIRIntermediate(outputElementPType)(storeElement),
         srvb.advance()
@@ -2004,10 +2000,6 @@ abstract class NDArrayEmitter(
       Code(
         dimVar := 0L,
         Code.whileLoop(dimVar < Region.loadLong(outputShapePType.loadField(outputShape, dimIdx)),
-          Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
-            "println", "The value of dimVar is:"),
-          Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[Long, Unit](
-            "println", dimVar),
           innerLoops,
           dimVar := dimVar + 1L
         )

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1958,13 +1958,12 @@ abstract class NDArrayEmitter(
   def emit(targetType: PNDArray): EmitTriplet = {
     val dataSrvb = new StagedRegionValueBuilder(mb, targetType.representation.fieldType("data").asInstanceOf[PArray])
 
-    val dataAddress: Code[Long] = {
+    val dataAddress: Code[Long] =
       Code(
         dataSrvb.start(targetType.numElements(outputShape, mb).toI),
         emitLoops(dataSrvb),
         dataSrvb.end()
       )
-    }
 
     val ndAddress = mb.newField[Long]
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1967,7 +1967,7 @@ private class Emit(
 
         new NDArrayEmitter(mb, childEmitter.nDims, childEmitter.outputShape,
           childP.representation.field("shape").typ.asInstanceOf[PTuple],
-          childP.elementType, setup) {
+          body.pType, setup) {
           override def outputElement(idxVars: Seq[ClassFieldRef[Long]]): Code[_] = {
             Code(
               Code._println("Reached output element in NDArrayMap"),
@@ -2045,17 +2045,11 @@ abstract class NDArrayEmitter(
       Code(
         Code._println("Evaluating innermost loop body"),
         storeElement := outputElement(idxVars).asInstanceOf[Code[Double]],
-        Code._println("Output element"),
-        Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[Double, Unit](
-          "println", storeElement),
         srvb.addIRIntermediate(outputElementPType)(storeElement),
-        Code._println("Executed add with deep copy"),
         srvb.advance()
       )
     idxVars.zipWithIndex.foldRight(body) { case((dimVar, dimIdx), innerLoops) =>
       Code(
-        Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
-          "println", "Reached emit loops"),
         dimVar := 0L,
         Code.whileLoop(dimVar < Region.loadLong(outputShapePType.loadField(outputShape, dimIdx)),
           Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1357,9 +1357,10 @@ private class Emit(
         val shape = t.loadField(region, ndt.value[Long], "shape")
 
         EmitTriplet(ndt.setup, false, shape)
-      case x@NDArrayMap(nd, valueName, body) =>
+      case x: NDArrayMap =>
         val emitter = emitDeforestedNDArray(resultRegion, x, env)
         emitter.emit(x.pType.asInstanceOf[PNDArray])
+
       case x@CollectDistributedArray(contexts, globals, cname, gname, body) =>
         val ctxType = coerce[PArray](contexts.pType).elementType
         val gType = globals.pType

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1389,6 +1389,10 @@ private class Emit(
         val shape = t.loadField(region, ndt.value[Long], "shape")
 
         EmitTriplet(ndt.setup, false, shape)
+      case x@NDArrayMap(nd, valueName, body) =>
+        val emitter = emitDeforestedNDArray(resultRegion, x, env)
+
+        ???
       case x@CollectDistributedArray(contexts, globals, cname, gname, body) =>
         val ctxType = coerce[PArray](contexts.pType).elementType
         val gType = globals.pType
@@ -1927,4 +1931,26 @@ private class Emit(
   private def normalArgumentPosition(idx: Int): Int = {
     1 + nSpecialArguments + idx * 2
   }
+
+  def emitDeforestedNDArray(region: EmitRegion, map: NDArrayMap, env: Emit.E): NDArrayEmitter = {
+    ???
+  }
 }
+abstract class NDArrayEmitter(
+ val mb: MethodBuilder,
+ val nDims: Int,
+ val setup: Code[_]) {
+
+
+
+  def emit(elemType: PType): Code[_] = {
+    setup
+  }
+
+  private def emitLoops(): Code[_] = {
+    val idxVars
+  }
+
+}
+
+

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1379,16 +1379,8 @@ private class Emit(
 //                )
               }),
               srvb.advance(),
-              Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
-                "println", "About to write data, srvb is at:"),
-              Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[Long, Unit](
-                "println", srvb.currentOffset),
               srvb.addIRIntermediate(repr.fieldType("data").asInstanceOf[PArray])(
                 repr.fieldType("data").asInstanceOf[PArray].checkedConvertFrom(mb, region, datat.value[Long], dataContainer, "NDArray cannot have missing data")),
-              Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
-                "println", "Trying to print address to data:"),
-              Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[Long, Unit](
-                "println", region.loadAddress(srvb.currentOffset)),
               Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
                 "println", "FINISHED MAKING ND ARRAY. It's at:"),
               Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[Long, Unit](
@@ -2003,9 +1995,6 @@ abstract class NDArrayEmitter(
    val outputElementPType: PType,
    val setup: Code[_]) {
 
-  // Need to make a SRVB to fill with array elements
-  // Then call emit on MakeNDArray of
-
   def outputElement(idxVars: Seq[ClassFieldRef[Long]]): Code[_]
 
   def emit(targetType: PNDArray): Code[_] = {
@@ -2014,8 +2003,6 @@ abstract class NDArrayEmitter(
 
     Code(
       setup,
-      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
-        "println", "Set up emitter!"),
       srvb.start(),
       srvb.addInt(0),
       srvb.advance(),
@@ -2032,8 +2019,7 @@ abstract class NDArrayEmitter(
           srvb.start(targetType.numElements(outputShape, mb).toI),
           coerce[Unit](emitLoops(srvb)))
       }),
-      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
-        "println", "Added data"),
+
       srvb.end()
     )
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1948,7 +1948,9 @@ abstract class NDArrayEmitter(
   }
 
   private def emitLoops(): Code[_] = {
-    val idxVars
+    val idxVars = Seq.tabulate(nDims) {i => mb.newField[Int]}
+
+    ???
   }
 
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1328,12 +1328,10 @@ private class Emit(
 
         def getShapeAtIdx(index: Int) = region.loadLong(shapePType.loadField(shapet.value[Long], index))
 
-        val setup = Code(
+        val setup = coerce[Unit](Code(
           shapet.setup,
           datat.setup,
-          rowMajort.setup)
-
-        val value = coerce[Long](Code(
+          rowMajort.setup,
           Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
             "println", "MAKING ND ARRAY"),
           srvb.start(),
@@ -1384,12 +1382,13 @@ private class Emit(
               srvb.addIRIntermediate(repr.fieldType("data").asInstanceOf[PArray])(
                 repr.fieldType("data").asInstanceOf[PArray].checkedConvertFrom(mb, region, datat.value[Long], dataContainer, "NDArray cannot have missing data")),
               Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
-                "println", "FINISHED MAKING ND ARRAY"),
-              srvb.end()
+                "println", "FINISHED MAKING ND ARRAY. It's at:"),
+              Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[Long, Unit](
+                "println", srvb.end())
             )
           )
         ))
-        EmitTriplet(setup, false, value)
+        EmitTriplet(setup, false, srvb.end())
       case x@NDArrayShape(ndIR) =>
         val ndt = emit(ndIR)
         val t = x.pType.asInstanceOf[PNDArray].representation
@@ -2008,38 +2007,19 @@ abstract class NDArrayEmitter(
       setup,
       Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
         "println", "Set up emitter!"),
-      //Ugh, need to create a new NDArray
-      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
-        "println", "About to start SRVB!"),
       srvb.start(),
-      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
-        "println", "Started SRVB!"),
       srvb.addInt(0),
-      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
-        "println", "Added first int!"),
       srvb.advance(),
-      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
-        "println", "Advanced!"),
       srvb.addInt(0),
-      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
-        "println", "Added second int!"),
       srvb.advance(),
-      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
-        "println", "Advanced!"),
-      srvb.addIRIntermediate(outputShapePType)(outputShape), //shape
-      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
-        "println", "Added shape!"),
+      srvb.addIRIntermediate(outputShapePType)(outputShape),
       srvb.advance(),
-      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
-        "println", "Advanced!"),
       srvb.addBaseStruct(targetType.representation.fieldType("strides").asInstanceOf[PBaseStruct], {srvb =>
         coerce[Unit](targetType.makeDefaultStrides(getShapeAtIdx, srvb, mb))
       }),
       Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
         "println", "Added stride"),
       srvb.advance(),
-      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
-        "println", "Advanced!"),
       srvb.addArray(targetType.representation.fieldType("data").asInstanceOf[PArray], {srvb =>
         coerce[Unit](emitLoops(srvb))
       }),

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -39,14 +39,7 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
       0L
     }
     else {
-      val totalElements = mb.newField[Long]
-      Code(
-        totalElements := 1L,
-        Code.foreach(0 until nDims) { index =>
-          totalElements := totalElements * getShapeAtIdx(index)
-        },
-        totalElements
-      )
+      Array.range(0, nDims).foldLeft(coerce[Long](Code(1L))) { (prod, idx) => prod * getShapeAtIdx(idx) }
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -78,10 +78,8 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
       indices.zipWithIndex.foldLeft(Code._empty[Unit]){case (codeSoFar: Code[_], (requestedIndex: ClassFieldRef[Long], strideIndex: Int)) =>
         Code(
           codeSoFar,
-          bytesAway := bytesAway + requestedIndex * getStrideAtIdx(strideIndex)
-        )
+          bytesAway := bytesAway + requestedIndex * getStrideAtIdx(strideIndex))
       },
-
       bytesAway + dataP.elementOffset(data, dataP.loadLength(data), 0)
     ))
   }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -39,7 +39,7 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
       0L
     }
     else {
-      Array.range(0, nDims).foldLeft(Code(1L)) { (prod, idx) => prod * getShapeAtIdx(idx) }
+      Array.range(0, nDims).foldLeft(const(1L)) { (prod, idx) => prod * getShapeAtIdx(idx) }
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -50,8 +50,9 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
     }
   }
 
-  def makeDefaultStrides(getShapeAtIdx: (Int) => Code[Long], srvb: StagedRegionValueBuilder, mb: MethodBuilder): Code[Long] = {
+  def makeDefaultStrides(getShapeAtIdx: (Int) => Code[Long], mb: MethodBuilder): Code[Long] = {
     val stridesPType = this.representation.fieldType("strides").asInstanceOf[PTuple]
+    val srvb = new StagedRegionValueBuilder(mb, stridesPType)
     val tupleStartAddress = mb.newField[Long]
     (Code (
       srvb.start(),
@@ -70,7 +71,8 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
               Region.storeLong(fieldOffset, runningProduct),
               runningProduct := runningProduct * getShapeAtIdx(idx)
             )
-          }
+          },
+          srvb.end()
         )
       }
     )).asInstanceOf[Code[Long]]

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -39,7 +39,7 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
       0L
     }
     else {
-      Array.range(0, nDims).foldLeft(coerce[Long](Code(1L))) { (prod, idx) => prod * getShapeAtIdx(idx) }
+      Array.range(0, nDims).foldLeft(Code(1L)) { (prod, idx) => prod * getShapeAtIdx(idx) }
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -112,11 +112,11 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
       srvb.advance(),
       srvb.addInt(offset),
       srvb.advance(),
-      srvb.addIRIntermediate(this.representation.fieldType("shape").asInstanceOf[PTuple])(shape),
+      srvb.addIRIntermediate(this.representation.fieldType("shape"))(shape),
       srvb.advance(),
-      srvb.addIRIntermediate(this.representation.fieldType("strides").asInstanceOf[PBaseStruct])(this.makeDefaultStrides(shapeP, shape, mb)),
+      srvb.addIRIntermediate(this.representation.fieldType("strides"))(this.makeDefaultStrides(shapeP, shape, mb)),
       srvb.advance(),
-      srvb.addIRIntermediate(this.representation.fieldType("data").asInstanceOf[PArray])(data),
+      srvb.addIRIntermediate(this.representation.fieldType("data"))(data),
       srvb.end()
     ))
   }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -54,7 +54,7 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
     val stridesPType = this.representation.fieldType("strides").asInstanceOf[PTuple]
     val srvb = new StagedRegionValueBuilder(mb, stridesPType)
     val tupleStartAddress = mb.newField[Long]
-    (Code (
+    Code (
       srvb.start(),
       tupleStartAddress := srvb.offset,
       // Fill with 0s, then backfill with actual data
@@ -75,7 +75,7 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
           srvb.end()
         )
       }
-    )).asInstanceOf[Code[Long]]
+    )
   }
 
   def getElementPosition(indices: Seq[ClassFieldRef[Long]], nd: Code[Long], region: Code[Region], mb: MethodBuilder): Code[Long] = {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -68,6 +68,18 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
     coerce[Long](Code(
       Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
         "println", "Reached getElementPosition"),
+      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
+        "println", "nd is at:"),
+      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[Long, Unit](
+        "println", nd),
+      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
+        "println", "Data is at:"),
+      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[Long, Unit](
+        "println", data),
+      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
+        "println", "Data length is:"),
+      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[Int, Unit](
+        "println", dataLength),
       bytesAway := 0L,
       indices.zipWithIndex.foldLeft(Code._empty[Unit]){case (codeSoFar: Code[_], (elementIndex: ClassFieldRef[Long], strideIndex: Int)) =>
         Code(
@@ -80,10 +92,6 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
 
       Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
         "println", "Computed bytesAway"),
-      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
-        "println", "Data is at:"),
-      Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[Long, Unit](
-        "println", data),
       Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[String, Unit](
         "println", "BytesAway is:"),
       Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[Long, Unit](

--- a/hail/src/main/scala/is/hail/expr/types/physical/PStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PStruct.scala
@@ -264,7 +264,7 @@ final case class PStruct(fields: IndexedSeq[PField], override val required: Bool
 
   def loadField(region: Code[Region], offset: Code[Long], fieldName: String): Code[Long] = {
     val f = field(fieldName)
-    loadField(region, fieldOffset(offset, f.index), f.index)
+    loadField(region, offset, f.index)
   }
 
   def insertFields(fieldsToInsert: TraversableOnce[(String, PType)]): PStruct = {


### PR DESCRIPTION
This PR:

- Introduces mapping over NDArrays in JVM emitter. 
- Introduces the `NDArrayEmitter` class, mimicking the cxx analogue. This class is used as the basis of our `NDArray` deforesting efforts (see `emitLoops`)
- Fixes a bug in `PStruct`'s load field function. 
- Introduces useful helper functions on `PNDArray`: `numElements` and `makeDefaultStrides`

Ready for review