### PR TITLE
[hail] improve performance of import_plink

### DIFF
--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -1278,7 +1278,6 @@ object RVD {
     crdd: ContextRDD[RVDContext, RegionValue],
     keys: ContextRDD[RVDContext, RegionValue]
   ): RVD = {
-    val keys = getKeys(typ, crdd)
     makeCoercer(typ, partitionKey, keys).coerce(typ, crdd)
   }
 


### PR DESCRIPTION
Previously, we ignored the fast keys which required
reading all the data of the RVD to get the keys.
There does not appear to be any users of this method
other than `import_plink`.