### PR TITLE
[hail] fix make docs-no-test

### DIFF
--- a/hail/Makefile
+++ b/hail/Makefile
@@ -318,7 +318,7 @@ upload-docs: docs
 test: pytest jvm-test doctest tutorial-test
 
 .PHONY: tutorial-test
-docs-no-test: $(PYTHON_VERSION_INFO)
+docs-no-test: install $(PYTHON_VERSION_INFO)
 	mkdir -p build
 	rm -rf build/www
 	cp -R www build/www


### PR DESCRIPTION
Apparently Hail needs to be installed even to build the docs without tests? I don't know why but I ran into this today. Seems wrong that we need it installed to build the docs, but 🤷‍♂ 