### PR TITLE
[hail] pin aiohttp, add aiohttp_session

### DIFF
--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -1,4 +1,5 @@
-aiohttp
+aiohttp>=3.5,<3.6
+aiohttp_session>=2.7,<2.8
 bokeh>1.1,<1.3
 decorator<5
 gcsfs==0.2.1


### PR DESCRIPTION
In noticed this was missing when I tried to run the benchmarks, which use pipeline.