### PR TITLE
[auth] teach token to error on missing token file

### DIFF
--- a/hail/python/hailtop/gear/auth/__init__.py
+++ b/hail/python/hailtop/gear/auth/__init__.py
@@ -1,4 +1,4 @@
-from .tokens import get_tokens
+from .tokens import get_tokens, Tokens
 from .auth import async_get_userinfo, get_userinfo, \
     rest_authenticated_users_only, rest_authenticated_developers_only, \
     web_authenticated_users_only, web_authenticated_developers_only, \
@@ -8,6 +8,7 @@ from .utils import insert_user, create_session
 
 
 __all__ = [
+    'Tokens',
     'get_tokens',
     'async_get_userinfo',
     'get_userinfo',

--- a/hail/python/hailtop/gear/auth/exceptions.py
+++ b/hail/python/hailtop/gear/auth/exceptions.py
@@ -1,0 +1,6 @@
+class NoTokenFileFound(Exception):
+    def __init__(self, tokens_file):
+        self.tokens_file = tokens_file
+        self.message = (f'Cannot authenticate because no tokens file was found '
+                        f'at {tokens_file}. Execute `hailctl auth login` to '
+                        f'obtain tokens.')

--- a/hail/python/hailtop/gear/auth/exceptions.py
+++ b/hail/python/hailtop/gear/auth/exceptions.py
@@ -1,6 +1,7 @@
-class NoTokenFileFound(Exception):
+class NoTokenFileFoundError(Exception):
     def __init__(self, tokens_file):
         self.tokens_file = tokens_file
         self.message = (f'Cannot authenticate because no tokens file was found '
                         f'at {tokens_file}. Execute `hailctl auth login` to '
                         f'obtain tokens.')
+        super().__init__(self.message)

--- a/hail/python/hailtop/gear/auth/tokens.py
+++ b/hail/python/hailtop/gear/auth/tokens.py
@@ -4,6 +4,7 @@ import json
 import logging
 
 from ..deploy_config import get_deploy_config
+from .exceptions import NoTokenFileFound
 
 log = logging.getLogger('gear')
 
@@ -23,8 +24,7 @@ class Tokens(collections.abc.MutableMapping):
             with open(tokens_file, 'r') as f:
                 self._tokens = json.loads(f.read())
         else:
-            log.info(f'tokens file not found: {tokens_file}')
-            self._tokens = {}
+            raise NoTokenFileFound(tokens_file)
 
     def __setitem__(self, key, value):
         self._tokens[key] = value

--- a/hail/python/hailtop/gear/auth/tokens.py
+++ b/hail/python/hailtop/gear/auth/tokens.py
@@ -4,7 +4,7 @@ import json
 import logging
 
 from ..deploy_config import get_deploy_config
-from .exceptions import NoTokenFileFound
+from .exceptions import NoTokenFileFoundError
 
 log = logging.getLogger('gear')
 
@@ -24,7 +24,7 @@ class Tokens(collections.abc.MutableMapping):
             with open(tokens_file, 'r') as f:
                 self._tokens = json.loads(f.read())
         else:
-            raise NoTokenFileFound(tokens_file)
+            raise NoTokenFileFoundError(tokens_file)
 
     def __setitem__(self, key, value):
         self._tokens[key] = value

--- a/hail/python/hailtop/gear/auth/tokens.py
+++ b/hail/python/hailtop/gear/auth/tokens.py
@@ -18,13 +18,17 @@ class Tokens(collections.abc.MutableMapping):
             return os.path.expanduser('~/.hail/tokens.json')
         return '/user-tokens/tokens.json'
 
-    def __init__(self):
-        tokens_file = self.get_tokens_file()
+    @staticmethod
+    def from_file():
+        tokens_file = Tokens.get_tokens_file()
         if os.path.isfile(tokens_file):
             with open(tokens_file, 'r') as f:
-                self._tokens = json.loads(f.read())
+                return Tokens(json.loads(f.read()))
         else:
             raise NoTokenFileFoundError(tokens_file)
+
+    def __init__(self, tokens):
+        self._tokens = tokens
 
     def __setitem__(self, key, value):
         self._tokens[key] = value
@@ -54,5 +58,5 @@ def get_tokens():
     global tokens
 
     if not tokens:
-        tokens = Tokens()
+        tokens = Tokens.from_file()
     return tokens

--- a/hail/python/hailtop/hailctl/auth/login.py
+++ b/hail/python/hailtop/hailctl/auth/login.py
@@ -6,7 +6,7 @@ import aiohttp
 from aiohttp import web
 
 from hailtop.gear import get_deploy_config
-from hailtop.gear.auth import get_tokens, auth_headers
+from hailtop.gear.auth import Tokens, auth_headers
 
 
 def init_parser(parser):  # pylint: disable=unused-argument
@@ -76,21 +76,18 @@ Opening in your browser.
     token = resp['token']
     username = resp['username']
 
-    auth_ns = deploy_config.service_ns('auth')
-    tokens = get_tokens()
-    tokens[auth_ns] = token
     dot_hail_dir = os.path.expanduser('~/.hail')
     if not os.path.exists(dot_hail_dir):
         os.mkdir(dot_hail_dir, mode=0o700)
-    tokens.write()
+    auth_ns = deploy_config.service_ns('auth')
+    Tokens({auth_ns: token}).write()
 
     print(f'Logged in as {username}.')
 
 
 async def async_main():
-    headers = auth_headers('auth', authorize_target=False)
     async with aiohttp.ClientSession(
-            raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60), headers=headers) as session:
+            raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
         await auth_flow(session)
 
 


### PR DESCRIPTION
I think this improves on the experience of receiving a KeyError
when the default namespace has no tokens defined. Now the user
will recieve a NoTokenFileFound exception that indicates the
user should log in with `hailctl auth login`.