### PR TITLE
[gear] teach gear to not always depend on aiomysql

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -8,7 +8,8 @@ import google.auth.transport.requests
 import google.oauth2.id_token
 import google_auth_oauthlib.flow
 
-from hailtop.gear import get_deploy_config, setup_aiohttp_session, create_database_pool
+from hailtop.gear import get_deploy_config, setup_aiohttp_session
+from hailtop.gear.database import create_database_pool
 from hailtop.gear.auth import rest_authenticated_users_only, \
     web_maybe_authenticated_user, create_session
 

--- a/auth/create-accounts-pod.yaml
+++ b/auth/create-accounts-pod.yaml
@@ -21,7 +21,8 @@ spec:
        import sys
        import json
        import asyncio
-       from hailtop.gear import create_database_pool, get_deploy_config
+       from hailtop.gear import get_deploy_config
+       from hailtop.gear.database import create_database_pool
        from hailtop.gear.auth import get_tokens, insert_user, create_session
        async def main():
            dbpool = await create_database_pool()

--- a/hail/python/hailtop/gear/__init__.py
+++ b/hail/python/hailtop/gear/__init__.py
@@ -1,13 +1,11 @@
 from .logging import configure_logging
 from .data_manipulation import unzip
 from .deploy_config import get_deploy_config
-from .database import create_database_pool
 from .session import setup_aiohttp_session
 
 __all__ = [
     'configure_logging',
     'unzip',
     'get_deploy_config',
-    'create_database_pool',
     'setup_aiohttp_session'
 ]


### PR DESCRIPTION
Without this change, you cannot import hailtop on any non-
developer machine (i.e. a machine with the dev-requirements).