### PR TITLE
[batch] use composite upload when copying out dependencies

### DIFF
--- a/batch/Dockerfile
+++ b/batch/Dockerfile
@@ -5,6 +5,11 @@ COPY batch/batch /batch/batch/
 RUN pip3 install --no-cache-dir /batch && \
   rm -rf /batch
 
+# https://cloud.google.com/storage/docs/gsutil/addlhelp/CRC32CandInstallingcrcmod
+RUN apt-get install gcc python-dev python-setuptools && \
+    pip uninstall crcmod && \
+    pip install --no-cache-dir -U crcmod
+
 EXPOSE 5000
 
 CMD ["python3", "-m", "batch"]

--- a/batch/Dockerfile
+++ b/batch/Dockerfile
@@ -6,7 +6,7 @@ RUN pip3 install --no-cache-dir /batch && \
   rm -rf /batch
 
 # https://cloud.google.com/storage/docs/gsutil/addlhelp/CRC32CandInstallingcrcmod
-RUN apt-get install gcc python-dev python-setuptools && \
+RUN apt-get install gcc python-setuptools && \
     pip uninstall crcmod && \
     pip install --no-cache-dir -U crcmod
 

--- a/batch/Dockerfile
+++ b/batch/Dockerfile
@@ -6,9 +6,10 @@ RUN pip3 install --no-cache-dir /batch && \
   rm -rf /batch
 
 # https://cloud.google.com/storage/docs/gsutil/addlhelp/CRC32CandInstallingcrcmod
-RUN apt-get install gcc python-setuptools && \
-    pip uninstall crcmod && \
-    pip install --no-cache-dir -U crcmod
+RUN apt-get update && \
+    apt-get install -y python-pip && \
+    rm -rf /var/lib/apt/lists/* && \
+    python -m pip install --no-cache-dir -U crcmod
 
 EXPOSE 5000
 

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -124,7 +124,7 @@ def copy(files):
             mkdirs = f'mkdir -p {shq(os.path.dirname(dst))};'
         else:
             mkdirs = ""
-        return f'{mkdirs} gsutil -m cp -R {shq(src)} {shq(dst)}'
+        return f'{mkdirs} gsutil -m -o GSUtil:parallel_composite_upload_threshold=150M cp -R {shq(src)} {shq(dst)}'
 
     copies = ' && '.join([copy_command(f['from'], f['to']) for f in files])
     return f'set -ex; {resiliently_authenticate("/gsa-key/privateKeyData")} && {copies}'

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -264,7 +264,7 @@ def copy(files):
             mkdirs = f'mkdir -p {shq(os.path.dirname(dst))};'
         else:
             mkdirs = ""
-        return (f'{mkdirs} gsutil -m cp -R {shq(src)} {shq(dst)}')
+        return f'{mkdirs} gsutil -m cp -R {shq(src)} {shq(dst)}'
 
     copies = ' && '.join([copy_command(f['from'], f['to']) for f in files])
     return f'{authenticate} && {copies}'

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -264,7 +264,7 @@ def copy(files):
             mkdirs = f'mkdir -p {shq(os.path.dirname(dst))};'
         else:
             mkdirs = ""
-        return f'{mkdirs} gsutil -m cp -R {shq(src)} {shq(dst)}'
+        return (f'{mkdirs} gsutil -m cp -R {shq(src)} {shq(dst)}')
 
     copies = ' && '.join([copy_command(f['from'], f['to']) for f in files])
     return f'{authenticate} && {copies}'


### PR DESCRIPTION
This is why copying is so slow:

```
==> NOTE: You are uploading one or more large file(s), which would run
significantly faster if you enable parallel composite uploads. This
feature can be enabled by editing the
"parallel_composite_upload_threshold" value in your .boto
configuration file. However, note that if you do this large files will
be uploaded as `composite objects
<https://cloud.google.com/storage/docs/composite-objects>`_,which
means that any user who downloads such objects will need to have a
compiled crcmod installed (see "gsutil help crcmod"). This is because
without a compiled crcmod, computing checksums on composite objects is
so slow that gsutil disables downloads of composite objects.

/ [1/1 files][  4.1 GiB/  4.1 GiB] 100% Done  45.8 MiB/s ETA 00:00:00
Operation completed over 1 objects/4.1 GiB.
```

We can also set this with -o GSUtil:parallel_composite_upload_threshold on the command line. https://cloud.google.com/storage/docs/gsutil/commands/cp

We currently use `-m` which is parallel per-file:

    If you have a large number of files to transfer you might want to use the
    gsutil -m option, to perform a parallel (multi-threaded/multi-processing)
    copy:

        gsutil -m cp -r dir gs://my-bucket