### PR TITLE
[batch] various improvements re: benchmark

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1300,7 +1300,7 @@ async def update_job_with_pod(job, pod):  # pylint: disable=R0911,R0915
                         err = await job._terminate_cleanup_pod(pod)
                         if err:
                             log.info(f'could not connect to cleanup pod, we will '
-                                     f'try again in next refresh loop {job} {pod} {err}')
+                                     f'try again in next refresh loop {job.id} {pod} {err}')
                             return
                         return
 
@@ -1451,7 +1451,8 @@ async def on_startup(app):
 
     app['log_store'] = LogStore(pool, INSTANCE_ID, userinfo['bucket_name'])
     app['pod_throttler'] = PodThrottler(QUEUE_SIZE, MAX_PODS, parallelism=16)
-    app['client_session'] = aiohttp.ClientSession()
+    app['client_session'] = aiohttp.ClientSession(
+        timeout=aiohttp.ClientTimeout(10))
 
     asyncio.ensure_future(polling_event_loop())
     asyncio.ensure_future(kube_event_loop())

--- a/batch/batch/batch_configuration.py
+++ b/batch/batch/batch_configuration.py
@@ -2,7 +2,7 @@ import os
 import uuid
 
 KUBERNETES_TIMEOUT_IN_SECONDS = float(os.environ.get('KUBERNETES_TIMEOUT_IN_SECONDS', 5.0))
-REFRESH_INTERVAL_IN_SECONDS = int(os.environ.get('REFRESH_INTERVAL_IN_SECONDS', 5 * 60))
+REFRESH_INTERVAL_IN_SECONDS = int(os.environ.get('REFRESH_INTERVAL_IN_SECONDS', 2 * 60))
 HAIL_POD_NAMESPACE = os.environ.get('HAIL_POD_NAMESPACE', 'batch-pods')
 POD_VOLUME_SIZE = os.environ.get('POD_VOLUME_SIZE', '10Mi')
 INSTANCE_ID = os.environ.get('HAIL_INSTANCE_ID', uuid.uuid4().hex)


### PR DESCRIPTION
1. log should include job id not job
2. `client_session` is only used for k8s-internal requests to worker pods, so
   use a very aggressive timeout of 10s
3. reduce refresh delay to two minutes