### PR TITLE
[hailctl] generate a friendly error message if not authenticated

### DIFF
--- a/batch/test/test_aioclient.py
+++ b/batch/test/test_aioclient.py
@@ -11,10 +11,7 @@ def async_to_blocking(coro):
 
 class Test(unittest.TestCase):
     def setUp(self):
-        session = aiohttp.ClientSession(
-            raise_for_status=True,
-            timeout=aiohttp.ClientTimeout(total=60))
-        self.client = async_to_blocking(BatchClient(session))
+        self.client = async_to_blocking(BatchClient())
 
     def tearDown(self):
         loop = asyncio.get_event_loop()

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -33,10 +33,7 @@ def poll_until(p, max_polls=None):
 
 class Test(unittest.TestCase):
     def setUp(self):
-        session = aiohttp.ClientSession(
-            raise_for_status=True,
-            timeout=aiohttp.ClientTimeout(total=60))
-        self.client = BatchClient(session)
+        self.client = BatchClient()
 
     def tearDown(self):
         self.client.close()
@@ -336,10 +333,7 @@ class Test(unittest.TestCase):
 
     def test_bad_token(self):
         token = base64.urlsafe_b64encode(secrets.token_bytes(32)).decode('ascii')
-        session = aiohttp.ClientSession(
-            raise_for_status=True,
-            timeout=aiohttp.ClientTimeout(total=60))
-        bc = BatchClient(session, _token=token)
+        bc = BatchClient(_token=token)
         try:
             b = bc.create_batch()
             j = b.create_job('alpine', ['false'])

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -13,10 +13,7 @@ from .serverthread import ServerThread
 
 @pytest.fixture
 def client():
-    session = aiohttp.ClientSession(
-        raise_for_status=True,
-        timeout=aiohttp.ClientTimeout(total=60))
-    client = BatchClient(session)
+    client = BatchClient()
     yield client
     client.close()
 

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -329,7 +329,7 @@ async def on_startup(app):
         raise_for_status=True,
         timeout=aiohttp.ClientTimeout(total=60))
     app['client_session'] = session
-    app['github_client'] = gh_aiohttp.GitHubAPI(app['client_session'], 'ci', oauth_token=oauth_token)
+    app['github_client'] = gh_aiohttp.GitHubAPI(session, 'ci', oauth_token=oauth_token)
     app['batch_client'] = await BatchClient(session=session)
 
     with open('/ci-user-secret/sql-config.json', 'r') as f:

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -325,11 +325,12 @@ aiohttp_jinja2.setup(app, loader=jinja2.FileSystemLoader('ci/templates'))
 
 
 async def on_startup(app):
-    app['client_session'] = aiohttp.ClientSession(
+    session = aiohttp.ClientSession(
         raise_for_status=True,
         timeout=aiohttp.ClientTimeout(total=60))
+    app['client_session'] = session
     app['github_client'] = gh_aiohttp.GitHubAPI(app['client_session'], 'ci', oauth_token=oauth_token)
-    app['batch_client'] = await BatchClient(app['client_session'])
+    app['batch_client'] = await BatchClient(session=session)
 
     with open('/ci-user-secret/sql-config.json', 'r') as f:
         config = json.loads(f.read().strip())

--- a/hail/python/hail/backend/backend.py
+++ b/hail/python/hail/backend/backend.py
@@ -1,6 +1,7 @@
 import abc
 import os
-
+import requests
+import pyspark
 from hail.utils.java import *
 from hail.expr.types import dtype
 from hail.expr.table_type import *
@@ -9,10 +10,6 @@ from hail.expr.blockmatrix_type import *
 from hail.ir.renderer import Renderer
 from hail.table import Table
 from hail.matrixtable import MatrixTable
-
-import requests
-
-import pyspark
 
 
 class Backend(abc.ABC):
@@ -206,11 +203,14 @@ class LocalBackend(Backend):
 
 
 class ServiceBackend(Backend):
-    def __init__(self):
+    def __init__(self, deploy_config=None):
         from hailtop.config import get_deploy_config
-        deploy_config = get_deploy_config()
+        from hailtop.auth import service_auth_headers
+
+        if not deploy_config:
+            deploy_config = get_deploy_config()
         self.url = deploy_config.base_url('apiserver')
-        self.headers = deploy_config.auth_headers('apiserver')
+        self.headers = service_auth_headers(deploy_config, 'apiserver')
         self._fs = None
 
     @property

--- a/hail/python/hailtop/auth/__init__.py
+++ b/hail/python/hailtop/auth/__init__.py
@@ -1,10 +1,11 @@
 from .tokens import get_tokens
-from .auth import async_get_userinfo, get_userinfo, auth_headers
-
+from .auth import async_get_userinfo, get_userinfo, \
+    namespace_auth_headers, service_auth_headers
 
 __all__ = [
     'get_tokens',
     'async_get_userinfo',
     'get_userinfo',
-    'auth_headers'
+    'namespace_auth_headers',
+    'service_auth_headers'
 ]

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -5,8 +5,9 @@ from hailtop.utils import async_to_blocking
 from .tokens import get_tokens
 
 
-async def async_get_userinfo():
-    deploy_config = get_deploy_config()
+async def async_get_userinfo(deploy_config=None):
+    if not deploy_config:
+        deploy_config = get_deploy_config()
     headers = service_auth_headers(deploy_config, 'auth')
     async with aiohttp.ClientSession(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
@@ -15,8 +16,8 @@ async def async_get_userinfo():
             return await resp.json()
 
 
-def get_userinfo():
-    return async_to_blocking(async_get_userinfo())
+def get_userinfo(deploy_config=None):
+    return async_to_blocking(async_get_userinfo(deploy_config))
 
 
 def namespace_auth_headers(deploy_config, ns, authorize_target=True):

--- a/hail/python/hailtop/auth/tokens.py
+++ b/hail/python/hailtop/auth/tokens.py
@@ -1,5 +1,6 @@
 import collections.abc
 import os
+import sys
 import json
 import logging
 from hailtop.config import get_deploy_config
@@ -30,6 +31,22 @@ class Tokens(collections.abc.MutableMapping):
 
     def __getitem__(self, key):
         return self._tokens[key]
+
+    def namespace_token_or_error(self, ns):
+        if ns in self._tokens:
+            return self._tokens[ns]
+
+        deploy_config = get_deploy_config()
+        auth_ns = deploy_config.service_ns('auth')
+        ns_arg = '' if ns == auth_ns else f'-n {ns}'
+        sys.stderr.write(f'''\
+You are not authenticated.  Please log in with:
+
+  $ hailctl auth login {ns_arg}
+
+to obtain new credentials.
+''')
+        sys.exit(1)
 
     def __delitem__(self, key):
         del self._tokens[key]

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -430,8 +430,10 @@ class BatchBuilder:
 
 @asyncinit
 class BatchClient:
-    async def __init__(self, session=None, headers=None, _token=None):
-        deploy_config = get_deploy_config()
+    async def __init__(self, deploy_config=None, session=None, headers=None, _token=None):
+        if not deploy_config:
+            deploy_config = get_deploy_config()
+
         self.url = deploy_config.base_url('batch')
 
         if session is None:
@@ -439,7 +441,7 @@ class BatchClient:
                                             timeout=aiohttp.ClientTimeout(total=60))
         self._session = session
 
-        userinfo = await async_get_userinfo()
+        userinfo = await async_get_userinfo(deploy_config)
         self.bucket = userinfo['bucket_name']
 
         h = {}

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -5,7 +5,7 @@ import aiohttp
 from asyncinit import asyncinit
 
 from hailtop.config import get_deploy_config
-from hailtop.auth import async_get_userinfo, auth_headers
+from hailtop.auth import async_get_userinfo, service_auth_headers
 
 from .globals import complete_states
 
@@ -448,7 +448,7 @@ class BatchClient:
         if _token:
             h['Authorization'] = f'Bearer {_token}'
         else:
-            h.update(auth_headers('batch'))
+            h.update(service_auth_headers(deploy_config, 'batch'))
         self._headers = h
 
     async def _get(self, path, params=None):

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -135,11 +135,8 @@ class BatchBuilder:
 
 
 class BatchClient:
-    def __init__(self, session=None, headers=None, _token=None):
-        if session is None:
-            session = aiohttp.ClientSession(raise_for_status=True,
-                                            timeout=aiohttp.ClientTimeout(total=60))
-        self._async_client = async_to_blocking(aioclient.BatchClient(session, headers=headers, _token=_token))
+    def __init__(self, deploy_config=None, session=None, headers=None, _token=None):
+        self._async_client = async_to_blocking(aioclient.BatchClient(deploy_config, session, headers=headers, _token=_token))
 
     @property
     def bucket(self):

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -1,5 +1,4 @@
 import asyncio
-import aiohttp
 
 from . import aioclient
 

--- a/hail/python/hailtop/hailctl/auth/auth_list.py
+++ b/hail/python/hailtop/hailctl/auth/auth_list.py
@@ -1,7 +1,8 @@
 from hailtop.config import get_deploy_config
 from hailtop.auth import get_tokens
 
-def init_parser(parser):
+
+def init_parser(parser):  # pylint: disable=unused-argument
     pass
 
 
@@ -9,7 +10,7 @@ def main(args, pass_through_args):  # pylint: disable=unused-argument
     deploy_config = get_deploy_config()
     auth_ns = deploy_config.service_ns('auth')
     tokens = get_tokens()
-    for ns, token in tokens.items():
+    for ns in tokens:
         if ns == auth_ns:
             s = '*'
         else:

--- a/hail/python/hailtop/hailctl/auth/auth_list.py
+++ b/hail/python/hailtop/hailctl/auth/auth_list.py
@@ -1,0 +1,17 @@
+from hailtop.config import get_deploy_config
+from hailtop.auth import get_tokens
+
+def init_parser(parser):
+    pass
+
+
+def main(args, pass_through_args):  # pylint: disable=unused-argument
+    deploy_config = get_deploy_config()
+    auth_ns = deploy_config.service_ns('auth')
+    tokens = get_tokens()
+    for ns, token in tokens.items():
+        if ns == auth_ns:
+            s = '*'
+        else:
+            s = ' '
+        print(f'{s}{ns}')

--- a/hail/python/hailtop/hailctl/auth/cli.py
+++ b/hail/python/hailtop/hailctl/auth/cli.py
@@ -3,6 +3,7 @@ import argparse
 
 from . import login
 from . import logout
+from . import auth_list
 
 
 def parser():
@@ -18,13 +19,20 @@ def parser():
     logout_parser = subparsers.add_parser(
         'logout',
         help='Revoke Hail credentials.',
-        description='Obtain Hail credentials.')
+        description='Revoke Hail credentials.')
+    list_parser = subparsers.add_parser(
+        'list',
+        help='List Hail credentials.',
+        description='List Hail credentials.')
 
     login_parser.set_defaults(module='login')
     login.init_parser(login_parser)
 
     logout_parser.set_defaults(module='logout')
     logout.init_parser(logout_parser)
+
+    list_parser.set_defaults(module='list')
+    auth_list.init_parser(list_parser)
 
     return main_parser
 
@@ -36,6 +44,7 @@ def main(args):
     jmp = {
         'login': login,
         'logout': logout,
+        'list': auth_list,
     }
 
     args, pass_through_args = parser().parse_known_args(args=args)

--- a/hail/python/hailtop/hailctl/auth/login.py
+++ b/hail/python/hailtop/hailctl/auth/login.py
@@ -6,11 +6,12 @@ import aiohttp
 from aiohttp import web
 
 from hailtop.config import get_deploy_config
-from hailtop.auth import get_tokens, auth_headers
+from hailtop.auth import get_tokens, namespace_auth_headers
 
 
-def init_parser(parser):  # pylint: disable=unused-argument
-    pass
+def init_parser(parser):
+    parser.add_argument("--namespace", "-n", type=str,
+                        help="Specify namespace for auth server.  (default: from deploy configuration)")
 
 
 routes = web.RouteTableDef()
@@ -42,9 +43,7 @@ async def start_server():
     return (runner, port)
 
 
-async def auth_flow(session):
-    deploy_config = get_deploy_config()
-
+async def auth_flow(deploy_config, auth_ns, session):
     runner, port = await start_server()
 
     async with session.get(deploy_config.url('auth', '/api/v1alpha/login'),
@@ -76,7 +75,6 @@ Opening in your browser.
     token = resp['token']
     username = resp['username']
 
-    auth_ns = deploy_config.service_ns('auth')
     tokens = get_tokens()
     tokens[auth_ns] = token
     dot_hail_dir = os.path.expanduser('~/.hail')
@@ -84,16 +82,26 @@ Opening in your browser.
         os.mkdir(dot_hail_dir, mode=0o700)
     tokens.write()
 
-    print(f'Logged in as {username}.')
+    if auth_ns == 'default':
+        print(f'Logged in as {username}.')
+    else:
+        print(f'Logged into namespace {auth_ns} as {username}.')
 
 
-async def async_main():
-    headers = auth_headers('auth', authorize_target=False)
+async def async_main(args):
+    deploy_config = get_deploy_config()
+    if args.namespace:
+        auth_ns = args.namespace
+        deploy_config = deploy_config.with_service('auth', auth_ns)
+    else:
+        auth_ns = deploy_config.service_ns('auth')
+    print('auth_ns', auth_ns)
+    headers = namespace_auth_headers(deploy_config, auth_ns, authorize_target=False)
     async with aiohttp.ClientSession(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60), headers=headers) as session:
-        await auth_flow(session)
+        await auth_flow(deploy_config, auth_ns, session)
 
 
 def main(args, pass_through_args):  # pylint: disable=unused-argument
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(async_main())
+    loop.run_until_complete(async_main(args))

--- a/hail/python/hailtop/hailctl/auth/login.py
+++ b/hail/python/hailtop/hailctl/auth/login.py
@@ -95,7 +95,6 @@ async def async_main(args):
         deploy_config = deploy_config.with_service('auth', auth_ns)
     else:
         auth_ns = deploy_config.service_ns('auth')
-    print('auth_ns', auth_ns)
     headers = namespace_auth_headers(deploy_config, auth_ns, authorize_target=False)
     async with aiohttp.ClientSession(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60), headers=headers) as session:

--- a/hail/python/hailtop/hailctl/auth/logout.py
+++ b/hail/python/hailtop/hailctl/auth/logout.py
@@ -2,7 +2,7 @@ import asyncio
 import aiohttp
 
 from hailtop.config import get_deploy_config
-from hailtop.auth import get_tokens, auth_headers
+from hailtop.auth import get_tokens, service_auth_headers
 
 
 def init_parser(parser):  # pylint: disable=unused-argument
@@ -18,7 +18,7 @@ async def async_main():
         print('Not logged in.')
         return
 
-    headers = auth_headers('auth')
+    headers = service_auth_headers(deploy_config, 'auth')
     async with aiohttp.ClientSession(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60), headers=headers) as session:
         async with session.post(deploy_config.url('auth', '/api/v1alpha/logout')):

--- a/hail/python/hailtop/hailctl/batch/cli.py
+++ b/hail/python/hailtop/hailctl/batch/cli.py
@@ -91,10 +91,7 @@ def main(args):
 
     args, pass_through_args = parser().parse_known_args(args=args)
 
-    session = aiohttp.ClientSession(
-        raise_for_status=True,
-        timeout=aiohttp.ClientTimeout(total=60))
-    client = BatchClient(session)
+    client = BatchClient()
 
     try:
         jmp[args.module].main(args, pass_through_args, client)

--- a/hail/python/hailtop/hailctl/batch/cli.py
+++ b/hail/python/hailtop/hailctl/batch/cli.py
@@ -1,6 +1,5 @@
 import sys
 import argparse
-import aiohttp
 
 from hailtop.batch_client.client import BatchClient
 from . import list_batches

--- a/hail/python/hailtop/hailctl/dev/config/cli.py
+++ b/hail/python/hailtop/hailctl/dev/config/cli.py
@@ -1,21 +1,30 @@
 import os
 import json
-
+from hailtop.config import get_deploy_config
 
 def init_parser(parser):
+    parser.add_argument("namespace", type=str, nargs='?',
+                        help="Default namespace.  Show the current configuration if not specified.")
     parser.add_argument("--location", "-l", type=str, default='external',
                         choices=['external', 'gce', 'k8s'],
                         help="Location.  (default: external)")
-    parser.add_argument("--namespace", "-n", type=str,
-                        help="Default namespace.", required=True)
     parser.add_argument("--override", "-o", type=str, default='',
                         help="List of comma-separated service=namespace overrides.  (default: none)")
 
 
 def main(args):
+    if not args.namespace:
+        deploy_config = get_deploy_config()
+        print(f'  location: {deploy_config.location()}')
+        print(f'  default: {deploy_config._default_ns}')
+        if deploy_config._service_namespace:
+            print('  overrides:')
+            for service, ns in deploy_config._service_namespace.items():
+                print(f'    {service}: {ns}')
+        return
+
     override = args.override.split(',')
     override = [o.split('=') for o in override if o]
-    print(override)
     service_namespace = {o[0]: o[1] for o in override}
 
     config = {

--- a/hail/python/hailtop/hailctl/dev/config/cli.py
+++ b/hail/python/hailtop/hailctl/dev/config/cli.py
@@ -2,6 +2,7 @@ import os
 import json
 from hailtop.config import get_deploy_config
 
+
 def init_parser(parser):
     parser.add_argument("namespace", type=str, nargs='?',
                         help="Default namespace.  Show the current configuration if not specified.")

--- a/hail/python/hailtop/hailctl/dev/deploy/cli.py
+++ b/hail/python/hailtop/hailctl/dev/deploy/cli.py
@@ -3,7 +3,7 @@ import webbrowser
 import aiohttp
 
 from hailtop.config import get_deploy_config
-from hailtop.auth import auth_headers
+from hailtop.auth import service_auth_headers
 
 
 def init_parser(parser):
@@ -17,11 +17,14 @@ def init_parser(parser):
 
 
 class CIClient:
-    def __init__(self):
+    def __init__(self, deploy_config=None):
+        if not deploy_config:
+            deploy_config = get_deploy_config()
+        self._deploy_config = deploy_config
         self._session = None
 
     async def __aenter__(self):
-        headers = auth_headers('ci')
+        headers = service_auth_headers(self._deploy_config, 'ci')
         self._session = aiohttp.ClientSession(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60), headers=headers)
         return self
@@ -35,24 +38,23 @@ class CIClient:
             self._session = None
 
     async def dev_deploy_branch(self, branch, steps):
-        deploy_config = get_deploy_config()
         data = {
             'branch': branch,
             'steps': steps
         }
         async with self._session.post(
-                deploy_config.url('ci', '/api/v1alpha/dev_deploy_branch'), json=data) as resp:
+                self._deploy_config.url('ci', '/api/v1alpha/dev_deploy_branch'), json=data) as resp:
             resp_data = await resp.json()
             return resp_data['batch_id']
 
 
 async def submit(args):
+    deploy_config = get_deploy_config()
     steps = args.steps.split(',')
     steps = [s.strip() for s in steps]
     steps = [s for s in steps if s]
-    async with CIClient() as ci_client:
+    async with CIClient(deploy_config) as ci_client:
         batch_id = await ci_client.dev_deploy_branch(args.branch, steps)
-        deploy_config = get_deploy_config()
         url = deploy_config.url('ci', f'/batches/{batch_id}')
         print(f'Created deploy batch, see {url}')
         if args.open:

--- a/hail/python/hailtop/pipeline/backend.py
+++ b/hail/python/hailtop/pipeline/backend.py
@@ -3,7 +3,6 @@ import os
 import subprocess as sp
 import uuid
 from shlex import quote as shq
-import aiohttp
 from hailtop.batch_client.client import BatchClient, Job
 
 from .resource import InputResourceFile, TaskResourceFile

--- a/hail/python/hailtop/pipeline/backend.py
+++ b/hail/python/hailtop/pipeline/backend.py
@@ -188,10 +188,7 @@ class BatchBackend(Backend):
     """
 
     def __init__(self):
-        session = aiohttp.ClientSession(
-            raise_for_status=True,
-            timeout=aiohttp.ClientTimeout(total=60))
-        self._batch_client = BatchClient(session)
+        self._batch_client = BatchClient()
 
     def close(self):
         self._batch_client.close()

--- a/hail/python/test/hailtop/gear/test_deploy_config.py
+++ b/hail/python/test/hailtop/gear/test_deploy_config.py
@@ -3,7 +3,7 @@ from hailtop.config.deploy_config import DeployConfig
 
 class Test(unittest.TestCase):
     def test_deploy_external_default(self):
-        deploy_config = DeployConfig.from_config('external', 'default', {'foo': 'bar'})
+        deploy_config = DeployConfig('external', 'default', {'foo': 'bar'})
 
         self.assertEqual(deploy_config.location(), 'external')
         self.assertEqual(deploy_config.service_ns('quam'), 'default')

--- a/hail/python/test/hailtop/gear/test_deploy_config.py
+++ b/hail/python/test/hailtop/gear/test_deploy_config.py
@@ -3,11 +3,7 @@ from hailtop.config.deploy_config import DeployConfig
 
 class Test(unittest.TestCase):
     def test_deploy_external_default(self):
-        deploy_config = DeployConfig(_config={
-            'location': 'external',
-            'default_namespace': 'default',
-            'service_namespace': {'foo': 'bar'}
-        })
+        deploy_config = DeployConfig.from_config('external', 'default', {'foo': 'bar'})
 
         self.assertEqual(deploy_config.location(), 'external')
         self.assertEqual(deploy_config.service_ns('quam'), 'default')
@@ -27,11 +23,7 @@ class Test(unittest.TestCase):
         self.assertEqual(deploy_config.external_url('foo', '/moo'), 'https://internal.hail.is/bar/foo/moo')
 
     def test_deploy_k8s_default(self):
-        deploy_config = DeployConfig(_config={
-            'location': 'k8s',
-            'default_namespace': 'default',
-            'service_namespace': {'foo': 'bar'}
-        })
+        deploy_config = DeployConfig('k8s', 'default', {'foo': 'bar'})
 
         self.assertEqual(deploy_config.location(), 'k8s')
         self.assertEqual(deploy_config.service_ns('quam'), 'default')


### PR DESCRIPTION
Stacked on: https://github.com/hail-is/hail/pull/7031

Changes:
 - primary change was to add `Tokens.namespace_token_or_error` which prints a friendly error of the user doesn't have the necessary authentication
 - added `hailctl auth list`, and made `hailctl dev config` with no options print out the current configuration
 - implemented @danking's suggestion: change some natural entrypoints (BatchClient, get_userinfo, etc.) to take optional `deploy_config` argument and load the default config if not given
