### PR TITLE
[hail] add custom method names to FunctionBuilder

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -270,11 +270,14 @@ class FunctionBuilder[F >: Null](val parameterTypeInfo: Array[MaybeGenericTypeIn
 
   def emit(insn: AbstractInsnNode) = apply_method.emit(insn)
 
-  def newMethod(argsInfo: Array[TypeInfo[_]], returnInfo: TypeInfo[_]): MethodBuilder = {
-    val mb = new MethodBuilder(this, s"method${ methods.size }", argsInfo, returnInfo)
+  def newMethod(prefix: String, argsInfo: Array[TypeInfo[_]], returnInfo: TypeInfo[_]): MethodBuilder = {
+    val mb = new MethodBuilder(this, s"${ prefix }_${ methods.size }", argsInfo, returnInfo)
     methods.append(mb)
     mb
   }
+
+  def newMethod(argsInfo: Array[TypeInfo[_]], returnInfo: TypeInfo[_]): MethodBuilder =
+    newMethod("method", argsInfo, returnInfo)
 
   def newMethod[R: TypeInfo]: MethodBuilder =
     newMethod(Array[TypeInfo[_]](), typeInfo[R])

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -433,7 +433,7 @@ class EmitFunctionBuilder[F >: Null](
     m
   }
 
-  def newMethod(prefix: String, argsInfo: Array[TypeInfo[_]], returnInfo: TypeInfo[_]): EmitMethodBuilder = {
+  override def newMethod(prefix: String, argsInfo: Array[TypeInfo[_]], returnInfo: TypeInfo[_]): EmitMethodBuilder = {
     val mb = new EmitMethodBuilder(this, s"${prefix}_${ methods.size }", argsInfo, returnInfo)
     methods.append(mb)
     mb


### PR DESCRIPTION
Previously only `EmitFunctionBuilder` had the ability to set a custom function name.
I'm not sure of the difference between the classes but the discrepancy seems arbitrary.