### PR TITLE
[hail] JoinPoints for JVM backend

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/joinpoint/JoinPoint.scala
+++ b/hail/src/main/scala/is/hail/asm4s/joinpoint/JoinPoint.scala
@@ -29,9 +29,7 @@ object JoinPoint {
       }
     }
 
-  def mux[A: ParameterPack, X](cond: Code[Boolean],
-    j1: JoinPoint[Unit, X], j2: JoinPoint[Unit, X]
-  ): Code[X] =
+  def mux[X](cond: Code[Boolean], j1: JoinPoint[Unit, X], j2: JoinPoint[Unit, X]): Code[X] =
     mux((), cond, j1, j2)
 }
 

--- a/hail/src/main/scala/is/hail/asm4s/joinpoint/JoinPoint.scala
+++ b/hail/src/main/scala/is/hail/asm4s/joinpoint/JoinPoint.scala
@@ -15,11 +15,14 @@ object JoinPoint {
   // equivalent but produces better bytecode than 'cond.mux(j1(arg), j2(arg))'
   def mux[A](arg: A, cond: Code[Boolean], j1: JoinPoint[A], j2: JoinPoint[A])(
     implicit ap: ParameterPack[A]
-  ) = new Code[Ctrl] {
-    def emit(il: Growable[AbstractInsnNode]): Unit = {
-      ap.push(arg).emit(il)
-      cond.toConditional.emitConditional(il, j1.label, j2.label)
-    }
+  ) = {
+    assert(j1.stackIndicator eq j2.stackIndicator)
+    ensureStackIndicator(j1.stackIndicator)(new Code[Ctrl] {
+      def emit(il: Growable[AbstractInsnNode]): Unit = {
+        ap.push(arg).emit(il)
+        cond.toConditional.emitConditional(il, j1.label, j2.label)
+      }
+    })
   }
 
   def mux(cond: Code[Boolean], j1: JoinPoint[Unit], j2: JoinPoint[Unit]): Code[Ctrl] =
@@ -29,26 +32,73 @@ object JoinPoint {
     f: (JoinPointBuilder, JoinPoint[A]) => Code[Ctrl]
   ) {
     private[joinpoint] def code: Code[Nothing] = {
-      // NOTE: unsafe if you have nested CallCC's
-      val jb = new JoinPointBuilder
-      val ret = JoinPoint[A](new LabelNode)
+      val si = new Object()
+      val jb = new JoinPointBuilder(si)
+      val ret = JoinPoint[A](new LabelNode, si)
       val body = f(jb, ret)
-      Code(body, jb.define, ret.placeLabel)
+      withStackIndicator(si) {
+        Code(body, jb.define, ret.placeLabel)
+      }
+    }
+  }
+
+  /**
+    * So-called "stack-indicators" are placed on the following `mutable.Stack` during the extent of
+    * a CallCC being emitted. Whenever a join-point is called, it checks that the stack-indicator at
+    * the top of this stack is the same one associated with the CallCC from which the join-point
+    * originated. This ensures that you cannot escape a CallCC by returning from an outer CallCC,
+    * e.g.:
+    *
+    *   CallCC[Code[Int]] { (jb1, ret1) =>
+    *     ret1(const(1) + CallCC[Code[Int]] { (jb2, ret2) =>
+    *       ret1(const(2))
+    *     })
+    *   }
+    *
+    * The above code typechecks in Scala, but at runtime would corrupt the JVM stack, leaving a "1"
+    * behind without consuming it. This stack-indicator machinery catches this before bytecode
+    * verification.
+    */
+
+  class EmitLongJumpError extends AssertionError("cannot jump out of nested CallCC")
+
+  private val stack: mutable.Stack[Object] = new mutable.Stack
+
+  private def withStackIndicator[T](si: Object)(c: Code[T]) = new Code[T] {
+    def emit(il: Growable[AbstractInsnNode]): Unit = {
+      stack.push(si)
+      try
+        c.emit(il)
+      finally
+        assert(stack.pop() eq si)
+    }
+  }
+
+  private[joinpoint] def ensureStackIndicator[T](si: Object)(c: Code[T]) = new Code[T] {
+    def emit(il: Growable[AbstractInsnNode]): Unit = {
+      if (stack.top ne si) throw new EmitLongJumpError
+      c.emit(il)
     }
   }
 }
 
 case class JoinPoint[A] private[joinpoint](
-  label: LabelNode
+  label: LabelNode,
+  stackIndicator: Object
 )(implicit p: ParameterPack[A]) extends (A => Code[Ctrl]) {
-  def apply(args: A) = Code(p.push(args), gotoLabel)
+  def apply(args: A) =
+    JoinPoint.ensureStackIndicator(stackIndicator) {
+      Code(p.push(args), gotoLabel)
+    }
+
   private[joinpoint] def placeLabel = Code(label)
   private[joinpoint] def gotoLabel = Code[Ctrl](new JumpInsnNode(Opcodes.GOTO, label))
 }
 
-class DefinableJoinPoint[A: ParameterPack](
-  args: ParameterStore[A]
-) extends JoinPoint[A](new LabelNode) {
+class DefinableJoinPoint[A: ParameterPack] private[joinpoint](
+  args: ParameterStore[A],
+  _stackIndicator: Object
+) extends JoinPoint[A](new LabelNode, _stackIndicator) {
 
   def define(f: A => Code[Ctrl]): Unit =
     body = Some(Code(args.store, f(args.load)))
@@ -56,7 +106,9 @@ class DefinableJoinPoint[A: ParameterPack](
   private[joinpoint] var body: Option[Code[Ctrl]] = None
 }
 
-class JoinPointBuilder private[joinpoint] {
+class JoinPointBuilder private[joinpoint](
+  stackIndicator: Object
+) {
   private[joinpoint] val joinPoints: mutable.ArrayBuffer[DefinableJoinPoint[_]] =
     new mutable.ArrayBuffer()
 
@@ -69,7 +121,7 @@ class JoinPointBuilder private[joinpoint] {
     }
 
   private def joinPoint[A: ParameterPack](s: ParameterStore[A]): DefinableJoinPoint[A] = {
-    val j = new DefinableJoinPoint[A](s)
+    val j = new DefinableJoinPoint[A](s, stackIndicator)
     joinPoints += j
     j
   }

--- a/hail/src/main/scala/is/hail/asm4s/joinpoint/JoinPoint.scala
+++ b/hail/src/main/scala/is/hail/asm4s/joinpoint/JoinPoint.scala
@@ -55,7 +55,7 @@ class DefinableJoinPoint[A: ParameterPack, X](
   store: ParameterStore[A]
 ) extends JoinPoint[A, X](new LabelNode) {
   def define(f: A => Code[X]): Unit =
-    jb.definitions += this -> Code(store.pop, f(store.load))
+    jb.definitions += this -> Code(store.store, f(store.load))
 }
 
 class JoinPointBuilder[X] private[joinpoint](val mb: MethodBuilder) {
@@ -68,5 +68,5 @@ class JoinPointBuilder[X] private[joinpoint](val mb: MethodBuilder) {
     }
 
   def joinPoint[A](implicit p: ParameterPack[A]): DefinableJoinPoint[A, X] =
-    new DefinableJoinPoint[A, X](this, p.store(mb))
+    new DefinableJoinPoint[A, X](this, p.newLocals(mb))
 }

--- a/hail/src/main/scala/is/hail/asm4s/joinpoint/JoinPoint.scala
+++ b/hail/src/main/scala/is/hail/asm4s/joinpoint/JoinPoint.scala
@@ -17,6 +17,22 @@ object JoinPoint {
       Code(body, jb.define, ret.placeLabel)
     }
   }
+
+  // equivalent but produces better bytecode than 'cond.mux(j1(arg), j2(arg))'
+  def mux[A, X](arg: A, cond: Code[Boolean], j1: JoinPoint[A, X], j2: JoinPoint[A, X])(
+    implicit ap: ParameterPack[A]
+  ): Code[X] =
+    new Code[Nothing] {
+      def emit(il: Growable[AbstractInsnNode]): Unit = {
+        ap.push(arg).emit(il)
+        cond.toConditional.emitConditional(il, j1.label, j2.label)
+      }
+    }
+
+  def mux[A: ParameterPack, X](cond: Code[Boolean],
+    j1: JoinPoint[Unit, X], j2: JoinPoint[Unit, X]
+  ): Code[X] =
+    mux((), cond, j1, j2)
 }
 
 

--- a/hail/src/main/scala/is/hail/asm4s/joinpoint/JoinPoint.scala
+++ b/hail/src/main/scala/is/hail/asm4s/joinpoint/JoinPoint.scala
@@ -1,0 +1,59 @@
+package is.hail.asm4s.joinpoint
+
+import is.hail.asm4s._
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.{LabelNode, AbstractInsnNode, JumpInsnNode}
+import scala.collection.mutable
+import scala.collection.generic.Growable
+
+object JoinPoint {
+  abstract class CallCC[R](mb: MethodBuilder)(implicit p: ParameterPack[R]) {
+    // polymorphic over 'X', to try to enforce continuations get called in tail position
+    def apply[X](jb: JoinPointBuilder[X], ret: R => Code[X]): Code[X]
+
+    def emit: (Code[Unit], R) = {
+      val jb = new JoinPointBuilder[Nothing](mb)
+      val ret = JoinPoint[R, Nothing](new LabelNode)
+      val store = p.store(mb)
+      val body = apply(jb, ret)
+      (Code(body, jb.define, ret.placeLabel, store.pop), store.load)
+    }
+  }
+}
+
+case class JoinPoint[A, X] private[joinpoint](label: LabelNode)(implicit p: ParameterPack[A])
+    extends (A => Code[X]) {
+  def apply(args: A): Code[X] = new Code[Nothing] {
+    val push = p.push(args)
+    def emit(il: Growable[AbstractInsnNode]): Unit = {
+      push.emit(il)
+      il += new JumpInsnNode(Opcodes.GOTO, label)
+    }
+  }
+
+  private[joinpoint] def placeLabel: Code[X] = new Code[Nothing] {
+    def emit(il: Growable[AbstractInsnNode]): Unit =
+      il += label
+  }
+}
+
+class DefinableJoinPoint[A: ParameterPack, X](
+  jb: JoinPointBuilder[X],
+  store: ParameterStore[A]
+) extends JoinPoint[A, X](new LabelNode) {
+  def define(f: A => Code[X]): Unit =
+    jb.definitions += this -> Code(store.pop, f(store.load))
+}
+
+class JoinPointBuilder[X] private[joinpoint](val mb: MethodBuilder) {
+  private[joinpoint] val definitions: mutable.ArrayBuffer[(JoinPoint[_, X], Code[X])] =
+    new mutable.ArrayBuffer()
+
+  private[joinpoint] def define: Code[Unit] =
+    Code.foreach(definitions) { case (j, body) =>
+      Code(j.placeLabel, body)
+    }
+
+  def joinPoint[A](implicit p: ParameterPack[A]): DefinableJoinPoint[A, X] =
+    new DefinableJoinPoint[A, X](this, p.store(mb))
+}

--- a/hail/src/main/scala/is/hail/asm4s/joinpoint/ParameterPack.scala
+++ b/hail/src/main/scala/is/hail/asm4s/joinpoint/ParameterPack.scala
@@ -1,0 +1,53 @@
+package is.hail.asm4s.joinpoint
+
+import is.hail.asm4s._
+
+object ParameterPack {
+  implicit val unit: ParameterPack[Unit] = new ParameterPack[Unit] {
+    def push(u: Unit) = Code._empty
+    def store(mb: MethodBuilder) = ParameterStore[Unit](Code._empty, ())
+  }
+
+  implicit def code[T](implicit tti: TypeInfo[T]): ParameterPack[Code[T]] =
+    new ParameterPack[Code[T]] {
+      def push(v: Code[T]): Code[Unit] = coerce[Unit](v)
+      def store(mb: MethodBuilder): ParameterStore[Code[T]] = {
+        val x = mb.newLocal(tti)
+        ParameterStore(x.storeInsn, x.load)
+      }
+    }
+
+  implicit def tuple2[A, B](implicit ap: ParameterPack[A], bp: ParameterPack[B]): ParameterPack[(A, B)] =
+    new ParameterPack[(A, B)] {
+      def push(v: (A, B)) = Code(ap.push(v._1), bp.push(v._2))
+      def store(mb: MethodBuilder) = {
+        val as = ap.store(mb)
+        val bs = bp.store(mb)
+        ParameterStore(Code(bs.pop, as.pop), (as.load, bs.load))
+      }
+    }
+
+  implicit def tuple3[A, B, C](
+    implicit ap: ParameterPack[A],
+    bp: ParameterPack[B],
+    cp: ParameterPack[C]
+  ): ParameterPack[(A, B, C)] = new ParameterPack[(A, B, C)] {
+    def push(v: (A, B, C)) = Code(ap.push(v._1), bp.push(v._2), cp.push(v._3))
+    def store(mb: MethodBuilder) = {
+      val as = ap.store(mb)
+      val bs = bp.store(mb)
+      val cs = cp.store(mb)
+      ParameterStore(Code(cs.pop, bs.pop, as.pop), (as.load, bs.load, cs.load))
+    }
+  }
+}
+
+trait ParameterPack[A] {
+  def push(a: A): Code[Unit]
+  def store(mb: MethodBuilder): ParameterStore[A]
+}
+
+case class ParameterStore[A](
+  pop: Code[Unit],
+  load: A
+)

--- a/hail/src/main/scala/is/hail/asm4s/joinpoint/ParameterPack.scala
+++ b/hail/src/main/scala/is/hail/asm4s/joinpoint/ParameterPack.scala
@@ -4,8 +4,8 @@ import is.hail.asm4s._
 
 object ParameterPack {
   implicit val unit: ParameterPack[Unit] = new ParameterPack[Unit] {
-    def push(u: Unit) = Code._empty
-    def newLocals(mb: MethodBuilder) = ParameterStore.unit
+    def push(u: Unit): Code[Unit] = Code._empty
+    def newLocals(mb: MethodBuilder): ParameterStore[Unit] = ParameterStore.unit
   }
 
   implicit def code[T](implicit tti: TypeInfo[T]): ParameterPack[Code[T]] =
@@ -17,10 +17,12 @@ object ParameterPack {
       }
     }
 
-  implicit def tuple2[A, B](implicit ap: ParameterPack[A], bp: ParameterPack[B]): ParameterPack[(A, B)] =
-    new ParameterPack[(A, B)] {
-      def push(v: (A, B)) = Code(ap.push(v._1), bp.push(v._2))
-      def newLocals(mb: MethodBuilder) = {
+  implicit def tuple2[A, B](
+    implicit ap: ParameterPack[A],
+    bp: ParameterPack[B]
+  ): ParameterPack[(A, B)] = new ParameterPack[(A, B)] {
+      def push(v: (A, B)): Code[Unit] = Code(ap.push(v._1), bp.push(v._2))
+      def newLocals(mb: MethodBuilder): ParameterStore[(A, B)] = {
         val as = ap.newLocals(mb)
         val bs = bp.newLocals(mb)
         ParameterStore(Code(bs.store, as.store), (as.load, bs.load))
@@ -32,8 +34,8 @@ object ParameterPack {
     bp: ParameterPack[B],
     cp: ParameterPack[C]
   ): ParameterPack[(A, B, C)] = new ParameterPack[(A, B, C)] {
-    def push(v: (A, B, C)) = Code(ap.push(v._1), bp.push(v._2), cp.push(v._3))
-    def newLocals(mb: MethodBuilder) = {
+    def push(v: (A, B, C)): Code[Unit] = Code(ap.push(v._1), bp.push(v._2), cp.push(v._3))
+    def newLocals(mb: MethodBuilder): ParameterStore[(A, B, C)] = {
       val as = ap.newLocals(mb)
       val bs = bp.newLocals(mb)
       val cs = cp.newLocals(mb)
@@ -43,7 +45,7 @@ object ParameterPack {
 }
 
 object ParameterStore {
-  def unit = ParameterStore[Unit](Code._empty, ())
+  def unit: ParameterStore[Unit] = ParameterStore(Code._empty, ())
 }
 
 trait ParameterPack[A] {

--- a/hail/src/main/scala/is/hail/asm4s/joinpoint/ParameterPack.scala
+++ b/hail/src/main/scala/is/hail/asm4s/joinpoint/ParameterPack.scala
@@ -5,13 +5,13 @@ import is.hail.asm4s._
 object ParameterPack {
   implicit val unit: ParameterPack[Unit] = new ParameterPack[Unit] {
     def push(u: Unit) = Code._empty
-    def store(mb: MethodBuilder) = ParameterStore[Unit](Code._empty, ())
+    def newLocals(mb: MethodBuilder) = ParameterStore[Unit](Code._empty, ())
   }
 
   implicit def code[T](implicit tti: TypeInfo[T]): ParameterPack[Code[T]] =
     new ParameterPack[Code[T]] {
       def push(v: Code[T]): Code[Unit] = coerce[Unit](v)
-      def store(mb: MethodBuilder): ParameterStore[Code[T]] = {
+      def newLocals(mb: MethodBuilder): ParameterStore[Code[T]] = {
         val x = mb.newLocal(tti)
         ParameterStore(x.storeInsn, x.load)
       }
@@ -20,10 +20,10 @@ object ParameterPack {
   implicit def tuple2[A, B](implicit ap: ParameterPack[A], bp: ParameterPack[B]): ParameterPack[(A, B)] =
     new ParameterPack[(A, B)] {
       def push(v: (A, B)) = Code(ap.push(v._1), bp.push(v._2))
-      def store(mb: MethodBuilder) = {
-        val as = ap.store(mb)
-        val bs = bp.store(mb)
-        ParameterStore(Code(bs.pop, as.pop), (as.load, bs.load))
+      def newLocals(mb: MethodBuilder) = {
+        val as = ap.newLocals(mb)
+        val bs = bp.newLocals(mb)
+        ParameterStore(Code(bs.store, as.store), (as.load, bs.load))
       }
     }
 
@@ -33,21 +33,21 @@ object ParameterPack {
     cp: ParameterPack[C]
   ): ParameterPack[(A, B, C)] = new ParameterPack[(A, B, C)] {
     def push(v: (A, B, C)) = Code(ap.push(v._1), bp.push(v._2), cp.push(v._3))
-    def store(mb: MethodBuilder) = {
-      val as = ap.store(mb)
-      val bs = bp.store(mb)
-      val cs = cp.store(mb)
-      ParameterStore(Code(cs.pop, bs.pop, as.pop), (as.load, bs.load, cs.load))
+    def newLocals(mb: MethodBuilder) = {
+      val as = ap.newLocals(mb)
+      val bs = bp.newLocals(mb)
+      val cs = cp.newLocals(mb)
+      ParameterStore(Code(cs.store, bs.store, as.store), (as.load, bs.load, cs.load))
     }
   }
 }
 
 trait ParameterPack[A] {
   def push(a: A): Code[Unit]
-  def store(mb: MethodBuilder): ParameterStore[A]
+  def newLocals(mb: MethodBuilder): ParameterStore[A]
 }
 
 case class ParameterStore[A](
-  pop: Code[Unit],
+  store: Code[Unit],
   load: A
 )

--- a/hail/src/main/scala/is/hail/asm4s/joinpoint/ParameterPack.scala
+++ b/hail/src/main/scala/is/hail/asm4s/joinpoint/ParameterPack.scala
@@ -5,7 +5,7 @@ import is.hail.asm4s._
 object ParameterPack {
   implicit val unit: ParameterPack[Unit] = new ParameterPack[Unit] {
     def push(u: Unit) = Code._empty
-    def newLocals(mb: MethodBuilder) = ParameterStore[Unit](Code._empty, ())
+    def newLocals(mb: MethodBuilder) = ParameterStore.unit
   }
 
   implicit def code[T](implicit tti: TypeInfo[T]): ParameterPack[Code[T]] =
@@ -40,6 +40,10 @@ object ParameterPack {
       ParameterStore(Code(cs.store, bs.store, as.store), (as.load, bs.load, cs.load))
     }
   }
+}
+
+object ParameterStore {
+  def unit = ParameterStore[Unit](Code._empty, ())
 }
 
 trait ParameterPack[A] {

--- a/hail/src/main/scala/is/hail/asm4s/joinpoint/package.scala
+++ b/hail/src/main/scala/is/hail/asm4s/joinpoint/package.scala
@@ -1,0 +1,10 @@
+package is.hail.asm4s
+
+import scala.language.implicitConversions
+
+package object joinpoint {
+
+  implicit def callCC[T: TypeInfo](f: JoinPoint.CallCC[Code[T]]): Code[T] = f.emit
+
+  implicit def callCC(f: JoinPoint.CallCC[Unit]): Code[Unit] = f.emit
+}

--- a/hail/src/main/scala/is/hail/asm4s/joinpoint/package.scala
+++ b/hail/src/main/scala/is/hail/asm4s/joinpoint/package.scala
@@ -4,7 +4,7 @@ import scala.language.implicitConversions
 
 package object joinpoint {
 
-  implicit def callCC[T: TypeInfo](f: JoinPoint.CallCC[Code[T]]): Code[T] = f.emit
+  implicit def callCC[T: TypeInfo](ccc: JoinPoint.CallCC[Code[T]]): Code[T] = ccc.code
 
-  implicit def callCC(f: JoinPoint.CallCC[Unit]): Code[Unit] = f.emit
+  implicit def callCC(ccc: JoinPoint.CallCC[Unit]): Code[Unit] = ccc.code
 }

--- a/hail/src/test/scala/is/hail/asm4s/JoinPointSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/JoinPointSuite.scala
@@ -177,4 +177,18 @@ class JoinPointSuite extends TestNGSuite {
       }
     }
   }
+
+  @Test def testDuplicateCallCC() {
+    val f = compile1[Int, Int] { (mb, arg) =>
+      val num: Code[Int] =
+        JoinPoint.CallCC[Code[Int]] { (jb, ret) =>
+          val j = jb.joinPoint()
+          j.define { _ => ret(arg) }
+          j(())
+        }
+      (num + num)
+    }
+    for (i <- 1 to 50)
+      assert(f(i) == i * 2)
+  }
 }

--- a/hail/src/test/scala/is/hail/asm4s/JoinPointSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/JoinPointSuite.scala
@@ -1,0 +1,39 @@
+package is.hail.asm4s
+
+import is.hail.asm4s.joinpoint._
+
+import org.scalatest.testng.TestNGSuite
+import org.testng.annotations.Test
+
+class JoinPointSuite extends TestNGSuite {
+
+  def fac(mb: MethodBuilder, n: Code[Int]): Code[Int] = {
+    val (setup, result) = new JoinPoint.CallCC[Code[Int]](mb) {
+      def apply[X](jb: JoinPointBuilder[X], ret: Code[Int] => Code[X]) = {
+        val loop = jb.joinPoint[(Code[Int], Code[Int])]
+        loop.define { case (i, a) =>
+          (i <= n).mux(
+            loop((i + 1, a * i)),
+            ret(a))
+        }
+        loop((1, 1))
+      }
+    }.emit
+    Code(setup, result)
+  }
+
+  def fac(n: Int): Int =
+    (1 to n).fold(1)(_ * _)
+
+  @Test def testFac() {
+    val f = {
+      val fb = FunctionBuilder.functionBuilder[Int, Int]
+      val mb = fb.apply_method
+      mb.emit(fac(mb, mb.getArg[Int](1).load))
+      fb.result()()
+    }
+    for (i <- 0 to 12)
+      assert(f(i) == fac(i), s"fac($i)")
+  }
+
+}

--- a/hail/src/test/scala/is/hail/asm4s/JoinPointSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/JoinPointSuite.scala
@@ -189,4 +189,16 @@ class JoinPointSuite extends TestNGSuite {
     for (i <- 1 to 50)
       assert(sumS(i) == sum(i), s"compute: 0 + ... + min($i, 10)")
   }
+
+  @Test def testBadCallCCEscape() {
+    intercept[JoinPoint.EmitLongJumpError] {
+      compile1[Int, Int] { (mb, n) =>
+        JoinPoint.CallCC[Code[Int]] { (jb1, ret1) =>
+          ret1(const(1) + JoinPoint.CallCC[Code[Int]] { (jb2, ret2) =>
+            ret1(const(2))
+          })
+        }
+      }
+    }
+  }
 }

--- a/hail/src/test/scala/is/hail/asm4s/JoinPointSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/JoinPointSuite.scala
@@ -72,15 +72,6 @@ class JoinPointSuite extends TestNGSuite {
     isEven(n)
   }
 
-  def whileLoop(cond: Code[Boolean], code: Code[Unit]*): Code[Unit] =
-    JoinPoint.CallCC[Unit] { (jb, ret) =>
-      val guard = jb.joinPoint()
-      val body = jb.joinPoint()
-      guard.define { _ => JoinPoint.mux(cond, body, ret) }
-      body.define { _ => Code(Code(code: _*), guard(())) }
-      guard(())
-    }
-
   @Test def testSimpleEarlyReturn() {
     val f = compile1[Int, Boolean] { (mb, n) =>
       JoinPoint.CallCC[Code[Boolean]] { (jb, ret) =>
@@ -170,21 +161,6 @@ class JoinPointSuite extends TestNGSuite {
           },
           ret)
       }
-    }
-    for (i <- 1 to 50)
-      assert(sumS(i) == sum(i), s"compute: 0 + ... + min($i, 10)")
-  }
-
-  @Test def testWhileLoop() {
-    def sum(n: Int): Int = (0 until n.min(10)).sum
-    val sumS = compile1[Int, Int] { (mb, n) =>
-      val acc = mb.newField[Int]
-      val i = mb.newField[Int]
-      Code(acc := 0, i := 0,
-        whileLoop((i < n && i < 10),
-          acc := acc + i,
-          i := i + 1),
-        acc)
     }
     for (i <- 1 to 50)
       assert(sumS(i) == sum(i), s"compute: 0 + ... + min($i, 10)")

--- a/hail/src/test/scala/is/hail/asm4s/JoinPointSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/JoinPointSuite.scala
@@ -7,9 +7,9 @@ import org.testng.annotations.Test
 
 class JoinPointSuite extends TestNGSuite {
 
-  def fac(mb: MethodBuilder, n: Code[Int]): Code[Int] = {
-    val (setup, result) = new JoinPoint.CallCC[Code[Int]](mb) {
-      def apply[X](jb: JoinPointBuilder[X], ret: Code[Int] => Code[X]) = {
+  def fac(mb: MethodBuilder, n: Code[Int]): Code[Int] =
+    new JoinPoint.CallCC[Code[Int]](mb) {
+      def apply[X](jb: JoinPointBuilder[X], ret: JoinPoint[Code[Int], X]) = {
         val loop = jb.joinPoint[(Code[Int], Code[Int])]
         loop.define { case (i, a) =>
           (i <= n).mux(
@@ -18,9 +18,7 @@ class JoinPointSuite extends TestNGSuite {
         }
         loop((1, 1))
       }
-    }.emit
-    Code(setup, result)
-  }
+    }
 
   def fac(n: Int): Int =
     (1 to n).fold(1)(_ * _)


### PR DESCRIPTION
## `JoinPoint` interface for nontrivial, type-safe control flow in the JVM backend

This PR implements a "join-point" abstraction for the JVM backend. Join-points are a primitive
control flow construct that allow sophisticated forms of branching to be implemented in a type safe
way, without having to directly manipulate labels and jumps at the JVM bytecode level. Importantly,
they will enable the kinds of branching needed by stream-deforestation techniques that
@patrick-schultz and I have been discussing, for which while loops and if's were not sufficient.

We've also discussed plans for implementing join points as a feature in the IR.

### Notable examples:

* Implementation of `whileLoop` (emits bytecode identical to current version):
```scala
def whileLoop(cond: Code[Boolean], body: Code[Unit]): Code[Unit] =
  JoinPoint.CallCC[Unit] { (jb, break) =>
    val continue = jb.joinPoint()
    val loopBody = jb.joinPoint()
    continue.define { _ => JoinPoint.mux(cond, loopBody, break) }
    loopBody.define { _ => Code(body, continue(())) }
    continue(())
  }
```

* Mutual recursion:
```scala
def parity(
  n: Code[Int],
  even: Code[Ctrl],
  odd: Code[Ctrl]
): Code[Ctrl] = {
  val isEven = jb.joinPoint[Code[Int]](mb)
  val isOdd = jb.joinPoint[Code[Int]](mb)
  isEven.define { i => (i ceq 0).mux(even, isOdd(i - 1)) }
  isOdd.define { i => (i ceq 0).mux(odd, isEven(i - 1)) }
  isEven(n)
}
```

### Classes of interest (tl;dr)

- `JoinPoint` - Non-returning function. Used to implement control flow in a type-safe, functional way.
- `ParameterPack` - Trait used for tuple deforesting. Allows join-points to be provided multiple
  arguments.
- `JoinPointBuilder` - Used to define new join points.
- `CallCC` - Entry-point for expressions with complex control flow. Provides a `JoinPointBuilder`
  and a `JoinPoint` to return a value from the expression.

### `JoinPoint`

A `JoinPoint[A]` acts like a non-returning function with an argument of type `A`.  The type of an
applied join point is `Code[Ctrl]`, which indicates that this code does some sort of control flow
(like a jump, or a loop), instead of returning a value. Under the hood, `JoinPoint`s are implemented
with a label and a `GOTO` instruction.

```scala
def example1(j: JoinPoint[Code[Int]]): Code[Ctrl] = Code(
  j(3),
  "this line is never reached".println,
  j(4))
```

### `ParameterPack`

The trait `ParameterPack[A]` says that the type `A` is comprised of a list of `Code[T]`s, such that the structure of that list is statically known. While this is generally useful for representing deforested tuples, it is specifically useful here because it allows `JoinPoint`s to take multiple arguments as a tuple of the individual arguments. This "tuple" will be represented at runtime by pushing or popping multiple values from the JVM argument stack.

```scala
// case class JoinPoint[A: ParameterPack] ( .... )
def example2(j: JoinPoint[(Code[Int], Code[Boolean], Code[Int])]): Code[Ctrl] =
  j((8, true, 9))
  /* LDC 8
   * LDC 1
   * LDC 9
   * GOTO j */
```

### `JoinPointBuilder`

The only way to create new join-points is via a `JoinPointBuilder` object, using the `joinPoint[A]` method (where `A` is the desired argument type). Then the body of the join-point can be provided by calling `define`.

```scala
val mb: MethodBuilder
// method builder required to create locals to store join point arguments
def example3(jb: JoinPointBuilder, exit: JoinPoint[Code[Int]]): JoinPoint[Code[Int]] = {
  val j = jb.joinPoint[Code[Int]](mb)
  j.define { n => exit(n + 1) }
  j
}
```

### `CallCC`

The only way to obtain a `JoinPointBuilder` is through a `CallCC`. `CallCC` also provides access to
the "current continuation" -- a join-point which takes an argument that will become the final result
of the entire `CallCC` expression. In fact, the only way to return a value from a `CallCC` is by
eventually calling this join-point.

```scala
val example4: Code[Boolean] =
  JoinPoint.CallCC { (jb: JoinPointBuilder, ret: JoinPoint[Code[Boolean]]) =>
    const(false).mux(
      ret(false),
      ret(true))
  }
// running 'example4' gives 'true'
```
