### PR TITLE
[hail] Reorganize `import_bgen` staged code; use lookup table to parse

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -420,3 +420,18 @@ class Function4Builder[A1 : TypeInfo, A2 : TypeInfo, A3 : TypeInfo, A4 : TypeInf
 
   def arg4 = getArg[A4](4)
 }
+
+class Function5Builder[A1 : TypeInfo, A2 : TypeInfo, A3 : TypeInfo, A4 : TypeInfo, A5 : TypeInfo, R : TypeInfo](name: String)
+  extends FunctionBuilder[AsmFunction5[A1, A2, A3, A4, A5, R]](Array(GenericTypeInfo[A1], GenericTypeInfo[A2], GenericTypeInfo[A3], GenericTypeInfo[A4], GenericTypeInfo[A5]), GenericTypeInfo[R], namePrefix = name) {
+
+  def arg1 = getArg[A1](1)
+
+  def arg2 = getArg[A2](2)
+
+  def arg3 = getArg[A3](3)
+
+  def arg4 = getArg[A4](4)
+
+  def arg5 = getArg[A5](5)
+}
+

--- a/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/BgenRDDPartitions.scala
@@ -2,9 +2,11 @@ package is.hail.io.bgen
 
 import is.hail.HailContext
 import is.hail.annotations.{Region, _}
-import is.hail.asm4s._
+import is.hail.asm4s.{coerce, _}
+import is.hail.expr.ir.{EmitFunctionBuilder, EmitMethodBuilder, EmitRegion}
+import is.hail.expr.ir.functions.StringFunctions
 import is.hail.expr.types._
-import is.hail.expr.types.physical.{PArray, PStruct}
+import is.hail.expr.types.physical.{PArray, PStruct, PType}
 import is.hail.expr.types.virtual.{TArray, TInterval, Type}
 import is.hail.io.index.IndexReader
 import is.hail.io.{ByteArrayReader, HadoopFSDataBinaryReader}
@@ -169,13 +171,17 @@ object BgenRDDPartitions extends Logging {
 object CompileDecoder {
   def apply(
     settings: BgenSettings
-  ): () => AsmFunction4[Region, BgenPartition, HadoopFSDataBinaryReader, BgenSettings, Long] = {
-    val fb = new Function4Builder[Region, BgenPartition, HadoopFSDataBinaryReader, BgenSettings, Long]("bgen_decoder")
+  ): (Int, Region) => AsmFunction4[Region, BgenPartition, HadoopFSDataBinaryReader, BgenSettings, Long] = {
+    val fb = EmitFunctionBuilder[Region, BgenPartition, HadoopFSDataBinaryReader, BgenSettings, Long]
     val mb = fb.apply_method
+    val region = mb.getArg[Region](1).load()
     val cp = mb.getArg[BgenPartition](2).load()
     val cbfis = mb.getArg[HadoopFSDataBinaryReader](3).load()
     val csettings = mb.getArg[BgenSettings](4).load()
-    val srvb = new StagedRegionValueBuilder(mb, settings.rowPType)
+
+    val regionField = mb.newField[Region]("region")
+    val srvb = new StagedRegionValueBuilder(mb, settings.rowPType, regionField)
+
     val offset = mb.newLocal[Long]("offset")
     val fileIdx = mb.newLocal[Int]("fileIdx")
     val varid = mb.newLocal[String]("varid")
@@ -200,9 +206,9 @@ object CompileDecoder {
     val phase = mb.newLocal[Int]("phase")
     val nBitsPerProb = mb.newLocal[Int]("nBitsPerProb")
     val nExpectedBytesProbs = mb.newLocal[Int]("nExpectedBytesProbs")
-    val c0 = mb.newLocal[Int]("c0")
-    val c1 = mb.newLocal[Int]("c1")
-    val c2 = mb.newLocal[Int]("c2")
+    val c0 = mb.newField[Int]("c0")
+    val c1 = mb.newField[Int]("c1")
+    val c2 = mb.newField[Int]("c2")
     val off = mb.newLocal[Int]("off")
     val d0 = mb.newLocal[Int]("d0")
     val d1 = mb.newLocal[Int]("d1")
@@ -254,6 +260,7 @@ object CompileDecoder {
           Code._empty // if locus is valid continue
         }
       ),
+      regionField := region,
       srvb.start(),
       if (settings.hasField("locus"))
         Code(
@@ -307,6 +314,152 @@ object CompileDecoder {
           val includeGT = t.hasField("GT")
           val includeGP = t.hasField("GP")
           val includeDosage = t.hasField("dosage")
+
+          val alreadyMemoized = mb.newField[Boolean]("alreadyMemoized")
+          val memoizedEntryData = mb.newField[Long]("memoizedEntryData")
+
+          val memoTyp = PArray(entryType.setRequired(true), required = true)
+          val memoizeAllValues: Code[Unit] = {
+            val memoMB = mb.fb.newMethod("memoizeEntries", Array[TypeInfo[_]](), UnitInfo)
+
+            val d0 = memoMB.newLocal[Int]("memoize_entries_d0")
+            val d1 = memoMB.newLocal[Int]("memoize_entries_d1")
+            val d2 = memoMB.newLocal[Int]("memoize_entries_d2")
+
+            val srvb = new StagedRegionValueBuilder(memoMB, memoTyp, fb.partitionRegion)
+
+            memoMB.emit(Code(
+              alreadyMemoized.mux(
+                Code._empty,
+                Code(
+                  srvb.start(1 << 16),
+                  d0 := 0,
+                  Code.whileLoop(d0 < 256,
+                    d1 := 0,
+                    Code.whileLoop(d1 < 256,
+                      d2 := const(255) - d0 - d1,
+                      srvb.addBaseStruct(entryType, { srvb =>
+                        val addGT: Code[Unit] = if (includeGT) {
+
+                          val addGtMB = mb.fb.newMethod("bgen_add_gt",
+                            Array[TypeInfo[_]](IntInfo, IntInfo, IntInfo),
+                            UnitInfo)
+                          val d0arg = addGtMB.getArg[Int](1)
+                          val d1arg = addGtMB.getArg[Int](2)
+                          val d2arg = addGtMB.getArg[Int](3)
+
+                          addGtMB.emit(
+                            Code(
+                              (d0arg > d1arg).mux(
+                                (d0arg > d2arg).mux(
+                                  srvb.addInt(c0),
+                                  (d2arg > d0arg).mux(
+                                    srvb.addInt(c2),
+                                    // d0 == d2
+                                    srvb.setMissing())),
+                                // d0 <= d1
+                                (d2arg > d1arg).mux(
+                                  srvb.addInt(c2),
+                                  // d2 <= d1
+                                  (d1arg.ceq(d0arg) || d1arg.ceq(d2arg)).mux(
+                                    srvb.setMissing(),
+                                    srvb.addInt(c1)))),
+                              if (includeGP || includeDosage) srvb.advance() else Code._empty))
+                          addGtMB.invoke(d0, d1, d2)
+                        } else Code._empty
+
+                        val addGP: Code[Unit] = if (includeGP) {
+                          val addGpMB = mb.fb.newMethod("bgen_add_gp",
+                            Array[TypeInfo[_]](IntInfo, IntInfo, IntInfo),
+                            UnitInfo)
+
+                          val d0arg = addGpMB.getArg[Int](1)
+                          val d1arg = addGpMB.getArg[Int](2)
+                          val d2arg = addGpMB.getArg[Int](3)
+
+                          val divisor = addGpMB.newLocal[Double]("divisor")
+
+                          addGpMB.emit(Code(
+                            srvb.addArray(entryType.field("GP").typ.asInstanceOf[PArray], { srvb =>
+                              Code(
+                                divisor := 255.0,
+                                srvb.start(3),
+                                srvb.addDouble(d0arg.toD / divisor),
+                                srvb.advance(),
+                                srvb.addDouble(d1arg.toD / divisor),
+                                srvb.advance(),
+                                srvb.addDouble(d2arg.toD / divisor))
+                            }),
+                            if (includeDosage) srvb.advance() else Code._empty))
+                          addGpMB.invoke(d0, d1, d2)
+                        } else Code._empty
+
+                        val addDosage: Code[Unit] = if (includeDosage) {
+                          val addDosageMB = mb.fb.newMethod("bgen_add_dosage",
+                            Array[TypeInfo[_]](IntInfo, IntInfo),
+                            UnitInfo)
+
+                          val d1arg = addDosageMB.getArg[Int](1)
+                          val d2arg = addDosageMB.getArg[Int](2)
+
+                          addDosageMB.emit(srvb.addDouble((d1arg + (d2arg << 1)).toD / 255.0))
+                          addDosageMB.invoke(d1, d2)
+                        } else Code._empty
+
+                        Code(srvb.start(), addGT, addGP, addDosage)
+                      }),
+                      srvb.advance(),
+                      d1 := d1 + 1
+                    ),
+                    d0 := d0 + 1
+                ),
+                memoizedEntryData := srvb.end(),
+                alreadyMemoized := true
+              )
+            )))
+            memoMB.invoke()
+          }
+
+          val lookupEntry: (Code[Int], Code[Int]) => Code[Long] = {
+            val lookupMB = mb.fb.newMethod("bgen_look_up_add_entry", Array[TypeInfo[_]](IntInfo, IntInfo), LongInfo)
+
+            val d0 = lookupMB.getArg[Int](1)
+            val d1 = lookupMB.getArg[Int](2)
+            lookupMB.emit(Code(
+              Code._empty,
+              memoTyp.elementOffset(memoizedEntryData, settings.nSamples, (d0 << 8) | d1)
+            ))
+            lookupMB.invoke(_, _)
+          }
+
+          val addEntries: Code[Array[Byte]] => Code[Unit] = {
+            val addEntriesMB = mb.fb.newMethod("bgen_add_entries", Array[TypeInfo[_]](typeInfo[Array[Byte]]), UnitInfo)
+            val data = addEntriesMB.getArg[Array[Byte]](1)
+            val i = addEntriesMB.newLocal[Int]("i")
+            val off = addEntriesMB.newLocal[Int]("off")
+            val d0 = addEntriesMB.newLocal[Int]("d0")
+            val d1 = addEntriesMB.newLocal[Int]("d1")
+            addEntriesMB.emit(Code(
+              srvb.addArray(entriesArrayType,
+                { srvb =>
+                  Code(
+                    srvb.start(settings.nSamples),
+                    i := 0,
+                    Code.whileLoop(i < settings.nSamples,
+                      (data(i + 8) & 0x80).cne(0).mux(
+                        srvb.setMissing(),
+                        Code(
+                          off := const(settings.nSamples + 10) + i * 2,
+                          d0 := data(off) & 0xff,
+                          d1 := data(off + 1) & 0xff,
+                          srvb.addIRIntermediate(entryType)(lookupEntry(d0, d1))
+                        )),
+                      srvb.advance(),
+                      i := i + 1))
+                })
+            ))
+            addEntriesMB.invoke(_)
+          }
 
           Code(
             cp.invoke[Boolean]("compressed").mux(
@@ -395,67 +548,13 @@ object CompileDecoder {
             c0 := Call2.fromUnphasedDiploidGtIndex(0),
             c1 := Call2.fromUnphasedDiploidGtIndex(1),
             c2 := Call2.fromUnphasedDiploidGtIndex(2),
-            srvb.addArray(entriesArrayType,
-              { srvb =>
-                Code(
-                  srvb.start(settings.nSamples),
-                  i := 0,
-                  Code.whileLoop(i < settings.nSamples,
-                    (data(i + 8) & 0x80).cne(0).mux(
-                      srvb.setMissing(),
-                      srvb.addBaseStruct(entryType, { srvb =>
-                        Code(
-                          srvb.start(),
-                          off := const(settings.nSamples + 10) + i * 2,
-                          d0 := data(off) & 0xff,
-                          d1 := data(off + 1) & 0xff,
-                          d2 := const(255) - d0 - d1,
-                          if (includeGT) {
-                            Code(
-                              (d0 > d1).mux(
-                                (d0 > d2).mux(
-                                  srvb.addInt(c0),
-                                  (d2 > d0).mux(
-                                    srvb.addInt(c2),
-                                    // d0 == d2
-                                    srvb.setMissing())),
-                                // d0 <= d1
-                                (d2 > d1).mux(
-                                  srvb.addInt(c2),
-                                  // d2 <= d1
-                                  (d1.ceq(d0) || d1.ceq(d2)).mux(
-                                    srvb.setMissing(),
-                                    srvb.addInt(c1)))),
-                              srvb.advance())
-                          } else Code._empty,
-                          if (includeGP) {
-                            Code(
-                              srvb.addArray(entryType.field("GP").typ.asInstanceOf[PArray], { srvb =>
-                                Code(
-                                  srvb.start(3),
-                                  srvb.addDouble(d0.toD / 255.0),
-                                  srvb.advance(),
-                                  srvb.addDouble(d1.toD / 255.0),
-                                  srvb.advance(),
-                                  srvb.addDouble(d2.toD / 255.0),
-                                  srvb.advance())
-                              }),
-                              srvb.advance())
-                          } else Code._empty,
-                          if (includeDosage) {
-                            val dosage = (d1 + (d2 << 1)).toD / 255.0
-                            Code(
-                              srvb.addDouble(dosage),
-                              srvb.advance())
-                          } else Code._empty)
-                      })),
-                    srvb.advance(),
-                    i := i + 1))
-              }))
+            memoizeAllValues,
+            addEntries(data)
+            )
       },
       srvb.end())
 
     mb.emit(c)
-    fb.result()
+    fb.resultWithIndex()
   }
 }


### PR DESCRIPTION
This doesn't actually hugely improve performance:

Master:
```
2019-09-12 16:25:06,282: INFO: [1/1] Running import_bgen_force_count_all...
2019-09-12 16:26:26,427: INFO:     burn in: 80.14s
2019-09-12 16:27:46,816: INFO:     run 1: 80.39s
2019-09-12 16:29:10,637: INFO:     run 2: 83.82s
2019-09-12 16:30:33,742: INFO:     run 3: 83.11s
2019-09-12 16:31:53,968: INFO:     run 4: 80.22s
2019-09-12 16:33:18,855: INFO:     run 5: 84.89s
```

PR:
```
2019-09-12 16:46:20,424: INFO: [1/1] Running import_bgen_force_count_all...
2019-09-12 16:47:39,550: INFO:     burn in: 79.12s
2019-09-12 16:48:57,259: INFO:     run 1: 77.71s
2019-09-12 16:50:15,457: INFO:     run 2: 78.20s
2019-09-12 16:51:32,472: INFO:     run 3: 77.01s
2019-09-12 16:52:49,160: INFO:     run 4: 76.68s
2019-09-12 16:54:05,504: INFO:     run 5: 76.34s
```

However, it does make the generated much easier to profile, and
would make much more of difference if we support BGEN 1.3 with ZSTD.