### PR TITLE
[notebook] variety of fixes

### DIFF
--- a/notebook/images/isia/Dockerfile
+++ b/notebook/images/isia/Dockerfile
@@ -1,5 +1,1 @@
-FROM gcr.io/daly-lab/isia@sha256:f127ddee322dabc1bc3eb639d518d7c9360e50f0a6f0ce8f438a29a8d1eccf8c
-
-RUN useradd -ms /bin/bash jupyter
-USER jupyter
-WORKDIR /home/jupyter
+FROM gcr.io/hail-vdc/isia:e35f8e171a799262b092a4e656c324ce3cd009be9dc89319d8bee4402ea3f850

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -46,7 +46,7 @@ def read_string(f):
         return f.read().strip()
 
 
-app.secret_key = read_string('/notebook-secrets/secret-key')
+SECRET_KEY = read_string('/notebook-secrets/secret-key').encode('utf-8')
 PASSWORD = read_string('/notebook-secrets/password')
 ADMIN_PASSWORD = read_string('/notebook-secrets/admin-password')
 INSTANCE_ID = uuid.uuid4().hex
@@ -133,12 +133,13 @@ async def root(request):
         log.info(f'no svc_name found in session {session.keys()}')
         return {'form_action_url': str(request.app.router['new'].url_for()),
                 'images': list(WORKER_IMAGES),
-                'default': 'gew2019'}
+                'default': 'isia'}
     svc_name = session['svc_name']
     jupyter_token = session['jupyter_token']
     # str(request.app.router['root'].url_for()) +
-    url = request.url.with_path(f'instance/{svc_name}/?token={jupyter_token}')
-    log.info('redirecting to ' + url)
+    url = request.url.with_path(f'instance/{svc_name}/')
+    url = url.with_query(token=jupyter_token)
+    log.info('redirecting to ' + str(url))
     raise aiohttp.web.HTTPFound(url)
 
 
@@ -183,7 +184,9 @@ async def auth(request):
     session = await aiohttp_session.get_session(request)
     requested_svc_name = request.match_info['requested_svc_name']
     approved_svc_name = session.get('svc_name')
-    if approved_svc_name and approved_svc_name == requested_svc_name:
+    if approved_svc_name is None:
+        return aiohttp.web.HTTPBadGateway()  # router treats 502 as pod_dead
+    if approved_svc_name == requested_svc_name:
         return aiohttp.web.Response()
     raise aiohttp.web.HTTPForbidden()
 
@@ -341,9 +344,9 @@ if __name__ == '__main__':
     app.on_startup.append(setup_k8s)
     app['client_session'] = aiohttp.ClientSession()
     app.on_cleanup.append(cleanup)
-    fernet_key = fernet.Fernet.generate_key()
-    secret_key = base64.urlsafe_b64decode(fernet_key)
     aiohttp_session.setup(
         app,
-        aiohttp_session.cookie_storage.EncryptedCookieStorage(secret_key))
+        aiohttp_session.cookie_storage.EncryptedCookieStorage(
+            SECRET_KEY,
+            cookie_name="NOTEBOOK_AIOHTTP_SESSION"))
     aiohttp.web.run_app(app, host='0.0.0.0', port=5000)


### PR DESCRIPTION
A few things.

- `app.secret_key` was never used, it was an old hold over from the flask style of doing HTTP session cookies. When I translated notebook, I accidentally made it generate a new secret key every time it started up. This PR fixes it to use the secret key in the notebook secret.
- set the default image to isia
- fix the URL redirect when you go to `notebook.hail.is` with a preexisting session. I screwed this up when I switched to aiohttp. You're not supposed to put query parameters in yourself, you're supposed to use `with_query`. What I did URL encoded the `?` so it wasn't treated as a query parameter it was treated as a file with a literal `?` in the name.
- the router (see router/router.nginx.conf.in) treats 502 and 504 as if the pod was dead which redirects to the login page and deletes the pod and service if they exist, if the user does not have a valid service name in their cookie, something went wrong with the cookie and we should kill everything and start fresh, returning 502 has this effect.
- set isia image to latest one (I build this locally, it depends on some very large files, notebook1 is going away soon otherwise we'd have to have a better solution to this).
