### PR TITLE
[hail][bugfix] account for return type when caching methods in Emit

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -204,7 +204,7 @@ private class Emit(
 
   val resultRegion: EmitRegion = EmitRegion.default(mb)
   val region: Code[Region] = mb.getArg[Region](1)
-  val methods: mutable.Map[String, Seq[(Seq[PType], EmitMethodBuilder)]] = mutable.Map().withDefaultValue(FastSeq())
+  val methods: mutable.Map[String, Seq[(Seq[PType], PType, EmitMethodBuilder)]] = mutable.Map().withDefaultValue(FastSeq())
 
   import Emit.{E, F}
 
@@ -1254,12 +1254,15 @@ private class Emit(
 
         val argPTypes = args.map(_.pType)
         val meth =
-          methods(fn).filter { case (argt, _) => argt.zip(argPTypes).forall { case (t1, t2) => t1 == t2 } } match {
-            case Seq(f) =>
-              f._2
+          methods(fn).filter { case (argt, rtExpected, _) =>
+            argt.zip(argPTypes).forall { case (t1, t2) => t1 == t2 } &&
+              rtExpected == ir.pType
+          } match {
+            case Seq((_, _, funcMB)) =>
+              funcMB
             case Seq() =>
               val methodbuilder = impl.getAsMethod(mb.fb, rt, argPTypes: _*)
-              methods.update(fn, methods(fn) :+ (argPTypes -> methodbuilder))
+              methods.update(fn, methods(fn) :+ ((argPTypes, ir.pType, methodbuilder)))
               methodbuilder
           }
         val codeArgs = args.map(emit(_))

--- a/hail/src/test/scala/is/hail/expr/ir/LocusFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/LocusFunctionsSuite.scala
@@ -71,4 +71,14 @@ class LocusFunctionsSuite extends HailSuite {
     val globalPosition = 2824183054L
     assertEvalsTo(invoke("globalPosToLocus", tlocus, I64(globalPosition)), grch38.globalPosToLocus(globalPosition))
   }
+
+  @Test def testMultipleReferenceGenomes() {
+    implicit val execStrats = Set(ExecStrategy.JvmCompile)
+
+    val ir = MakeTuple.ordered(FastSeq(
+      invoke("Locus", TLocus(ReferenceGenome.GRCh37), Str("1"), I32(1)),
+      invoke("Locus", TLocus(ReferenceGenome.GRCh38), Str("chr1"), I32(1))))
+
+    assertEvalsTo(ir, Row(Locus("1", 1, ReferenceGenome.GRCh37), Locus("chr1", 1, ReferenceGenome.GRCh38)))
+  }
 }


### PR DESCRIPTION
Fixes #7063.

I forgot to change the cached methods in Emit to account for return type when I changed it to allow a single function to specify multiple return types.