### PR TITLE
[hail] Add `permit_shuffle` option to `split_multi`

### DIFF
--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -2018,7 +2018,7 @@ def split_multi(ds, keep_star=False, left_aligned=False, *, permit_shuffle=False
                         .or_error("Found non-left-aligned variant in split_multi"))
             return hl.bind(error_on_moved,
                            hl.min_rep(old_row.locus, [old_row.alleles[0], old_row.alleles[i]]))
-        return split_rows(hl.sorted(kept_alleles.map(make_struct)), False)
+        return split_rows(hl.sorted(kept_alleles.map(make_struct)), permit_shuffle)
     else:
         def make_struct(i, cond):
             def struct_or_empty(v):
@@ -2031,8 +2031,8 @@ def split_multi(ds, keep_star=False, left_aligned=False, *, permit_shuffle=False
         def make_array(cond):
             return hl.sorted(kept_alleles.flatmap(lambda i: make_struct(i, cond)))
 
-        left = split_rows(make_array(lambda locus: locus == ds['locus']), False)
-        moved = split_rows(make_array(lambda locus: locus != ds['locus']), not permit_shuffle)
+        left = split_rows(make_array(lambda locus: locus == ds['locus']), permit_shuffle)
+        moved = split_rows(make_array(lambda locus: locus != ds['locus']), True)
     return left.union(moved) if is_table else left.union_rows(moved, _check_cols=False)
 
 

--- a/hail/python/hail/methods/statgen.py
+++ b/hail/python/hail/methods/statgen.py
@@ -2195,7 +2195,7 @@ def split_multi_hts(ds, keep_star=False, left_aligned=False, vep_root='vep', *, 
 
     """
 
-    split = split_multi(ds, keep_star=keep_star, left_aligned=left_aligned)
+    split = split_multi(ds, keep_star=keep_star, left_aligned=left_aligned, permit_shuffle=permit_shuffle)
 
     row_fields = set(ds.row)
     update_rows_expression = {}

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -1285,8 +1285,15 @@ class Tests(unittest.TestCase):
         ht = ht.explode(ht.keys)
         ht = ht.key_by(**ht.keys).drop('keys')
         alleles = hl.split_multi(ht, permit_shuffle=True).alleles.collect()
-
         assert alleles == [['A', 'C'], ['A', 'G'], ['A', 'T']]
+
+        ht = ht.annotate_globals(cols = [hl.struct(s='sample1'), hl.struct(s='sample2')])
+        ht = ht.annotate(entries=[hl.struct(GT=hl.call(0, 1)), hl.struct(GT=hl.call(1, 1))])
+        mt = ht._unlocalize_entries('entries', 'cols', ['s'])
+        mt = hl.split_multi_hts(mt, permit_shuffle=True)
+        mt._force_count_rows()
+        assert mt.alleles.collect() == [['A', 'C'], ['A', 'G'], ['A', 'T']]
+
 
     def test_issue_4527(self):
         mt = hl.utils.range_matrix_table(1, 1)

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -1280,8 +1280,8 @@ class Tests(unittest.TestCase):
 
     def test_split_multi_shuffle(self):
         ht = hl.utils.range_table(1)
-        ht = ht.annotate(keys=[hl.struct(locus=hl.locus('1', 1180), alleles=['A', 'T']),
-                               hl.struct(locus=hl.locus('1', 1180), alleles=['A', 'C', 'G'])])
+        ht = ht.annotate(keys=[hl.struct(locus=hl.locus('1', 1180), alleles=['A', 'C', 'T']),
+                               hl.struct(locus=hl.locus('1', 1180), alleles=['A', 'G'])])
         ht = ht.explode(ht.keys)
         ht = ht.key_by(**ht.keys).drop('keys')
         alleles = hl.split_multi(ht, permit_shuffle=True).alleles.collect()

--- a/hail/python/test/hail/methods/test_statgen.py
+++ b/hail/python/test/hail/methods/test_statgen.py
@@ -1278,6 +1278,16 @@ class Tests(unittest.TestCase):
         ds1 = ds1.drop('was_split', 'a_index')
         self.assertTrue(ds1._same(ds2))
 
+    def test_split_multi_shuffle(self):
+        ht = hl.utils.range_table(1)
+        ht = ht.annotate(keys=[hl.struct(locus=hl.locus('1', 1180), alleles=['A', 'T']),
+                               hl.struct(locus=hl.locus('1', 1180), alleles=['A', 'C', 'G'])])
+        ht = ht.explode(ht.keys)
+        ht = ht.key_by(**ht.keys).drop('keys')
+        alleles = hl.split_multi(ht, permit_shuffle=True).alleles.collect()
+
+        assert alleles == [['A', 'C'], ['A', 'G'], ['A', 'T']]
+
     def test_issue_4527(self):
         mt = hl.utils.range_matrix_table(1, 1)
         mt = mt.key_rows_by(locus=hl.locus(hl.str(mt.row_idx+1), mt.row_idx+1), alleles=['A', 'T'])


### PR DESCRIPTION
Makes it possible to proceed past the duplicate-multiallelic-loci error.