### PR TITLE
[hail] Extend TableKeyByAndAggregate => TableAggregateByKey rewrite

### DIFF
--- a/hail/python/hailtop/hailctl/dev/benchmark/run/table_benchmarks.py
+++ b/hail/python/hailtop/hailctl/dev/benchmark/run/table_benchmarks.py
@@ -1,4 +1,3 @@
-
 from os import path
 from tempfile import TemporaryDirectory
 import hail as hl
@@ -299,6 +298,7 @@ def join_p100_p10():
     ht1 = hl.read_table(resource('table_10M_par_100.ht'))
     ht2 = hl.read_table(resource('table_10M_par_10.ht'))
     ht1.join(ht2)._force_count()
+
 
 @benchmark
 def group_by_collect_per_row():

--- a/hail/python/hailtop/hailctl/dev/benchmark/run/table_benchmarks.py
+++ b/hail/python/hailtop/hailctl/dev/benchmark/run/table_benchmarks.py
@@ -299,3 +299,8 @@ def join_p100_p10():
     ht1 = hl.read_table(resource('table_10M_par_100.ht'))
     ht2 = hl.read_table(resource('table_10M_par_10.ht'))
     ht1.join(ht2)._force_count()
+
+@benchmark
+def group_by_collect_per_row():
+    ht = hl.read_matrix_table(resource('gnomad_dp_simulation.mt')).localize_entries('e', 'c')
+    ht.group_by(*ht.key).aggregate(value=hl.agg.collect(ht.row_value))._force_count()

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -564,7 +564,8 @@ object Simplify {
       TableDistinct(TableKeyBy(TableMapRows(TableKeyBy(child, FastIndexedSeq()), k), k.typ.asInstanceOf[TStruct].fieldNames))
 
     case TableKeyByAndAggregate(child, expr, newKey, _, _)
-      if newKey == MakeStruct(child.typ.key.map(k => k -> GetField(Ref("row", child.typ.rowType), k)))
+      if (newKey == MakeStruct(child.typ.key.map(k => k -> GetField(Ref("row", child.typ.rowType), k))) ||
+        newKey == SelectFields(Ref("row", child.typ.rowType), child.typ.key))
         && child.typ.key.nonEmpty && canRepartition =>
       TableAggregateByKey(child, expr)
 


### PR DESCRIPTION
At some point we started optimizing the MakeStruct to a SelectFields,
which is great, but not if it breaks important optimizations like the
avoid-a-shuffle rewrite rule!