### PR TITLE
[hail] fix setNumParents bug in GroupedAggregator

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -92,7 +92,7 @@ class DictState(val fb: EmitFunctionBuilder[_], val keyType: PType, val nested: 
   def initElement(eltOff: Code[Long], km: Code[Boolean], kv: Code[_]): Code[Unit] = {
     Code(
       size := size + 1,
-      region.setNumParents(size * (nStates + 1)),
+      region.setNumParents((size + 1) * nStates),
       keyed.initValue(_elt, km, kv, size * nStates),
       container.newStates)
   }


### PR DESCRIPTION
i'm only partially sure this is correct but i believe it is. `+1` to `nStates` didn't really make sense, and this causes my collect agg to work