### PR TITLE
[hail][etc.] Update aiohttp version to avoid bug

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,6 +1,6 @@
 aiodocker==0.14.0
 aiodns==2.0.0
-aiohttp==3.5.4
+aiohttp==3.6.0
 aiohttp-jinja2==1.1.1
 aiohttp-session==2.7.0
 aiomysql==0.0.20

--- a/hail/python/requirements.txt
+++ b/hail/python/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp>=3.5,<3.6
+aiohttp>=3.6,<3.7
 aiohttp_session>=2.7,<2.8
 bokeh>1.1,<1.3
 decorator<5


### PR DESCRIPTION
Currently, the notebook scale tests are broken by this.

Aiohttp [has a bug in 3.5](https://github.com/aio-libs/aiohttp/issues/3700) that incorrectly handles cookies in 302 redirects. The master commit was cherry-picked into 3.6.0.