### PR TITLE
[hail] remove load/store/append from Region methods

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -295,42 +295,14 @@ final class Region protected[annotations](var blockSize: Region.Size, var pool: 
 
   def loadByte(addr: Long): Byte = Region.loadByte(addr)
 
-  def storeInt(addr: Long, v: Int): Unit = Region.storeInt(addr, v)
-
-  def storeLong(addr: Long, v: Long): Unit = Region.storeLong(addr, v)
-
-  def storeFloat(addr: Long, v: Float): Unit = Region.storeFloat(addr, v)
-
-  def storeDouble(addr: Long, v: Double): Unit = Region.storeDouble(addr, v)
-
-  def storeAddress(addr: Long, v: Long): Unit = Region.storeAddress(addr, v)
-
-  def storeByte(addr: Long, v: Byte): Unit = Region.storeByte(addr, v)
-
   def loadBoolean(addr: Long): Boolean = Region.loadBoolean(addr)
-
-  def storeBoolean(addr: Long, v: Boolean): Unit = Region.storeBoolean(addr, v)
 
   def loadBytes(addr: Long, n: Int): Array[Byte] = Region.loadBytes(addr, n)
 
   def loadBytes(addr: Long, dst: Array[Byte], dstOff: Long, n: Long): Unit =
     Region.loadBytes(addr, dst, dstOff, n)
 
-  def storeBytes(addr: Long, src: Array[Byte]): Unit = Region.storeBytes(addr, src)
-
-  def storeBytes(addr: Long, src: Array[Byte], srcOff: Long, n: Long): Unit =
-    Region.storeBytes(addr, src, srcOff, n)
-
-  def copyFrom(src: Region, srcOff: Long, dstOff: Long, n: Long) =
-    Region.copyFrom(srcOff, dstOff, n)
-
   def loadBit(byteOff: Long, bitOff: Long): Boolean = Region.loadBit(byteOff, bitOff)
-
-  def setBit(byteOff: Long, bitOff: Long): Unit = Region.setBit(byteOff, bitOff)
-
-  def clearBit(byteOff: Long, bitOff: Long): Unit = Region.clearBit(byteOff, bitOff)
-
-  def storeBit(byteOff: Long, bitOff: Long, b: Boolean): Unit = Region.storeBit(byteOff, bitOff, b)
 
   def visit(t: PType, off: Long, v: ValueVisitor) {
     t match {

--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -283,15 +283,6 @@ final class Region protected[annotations](var blockSize: Region.Size, var pool: 
     memory.releaseReferenceAtIndex(idx)
   }
 
-  def appendBinary(v: Array[Byte]): Long = {
-    val len: Int = v.length
-    val grain = if (PBinary.contentAlignment < 4) 4 else PBinary.contentAlignment
-    val addr = allocate(grain, grain + len) + (grain - 4)
-    Region.storeInt(addr, len)
-    Region.storeBytes(addr + 4, v)
-    addr
-  }
-
   def loadInt(addr: Long): Int = Region.loadInt(addr)
 
   def loadLong(addr: Long): Long = Region.loadLong(addr)
@@ -340,40 +331,6 @@ final class Region protected[annotations](var blockSize: Region.Size, var pool: 
   def clearBit(byteOff: Long, bitOff: Long): Unit = Region.clearBit(byteOff, bitOff)
 
   def storeBit(byteOff: Long, bitOff: Long, b: Boolean): Unit = Region.storeBit(byteOff, bitOff, b)
-
-  // Use of appendXXX methods is deprecated now that Region uses absolute
-  // addresses and non-contiguous memory allocation.  You can't assume any
-  // relationships between the addresses returned by appendXXX methods -
-  // and to make it even more confusing, there may be long sequences of
-  // ascending addresses (within a buffer) followed by an arbitrary jump
-  // to an address in a different buffer.
-
-  def appendInt(v: Int): Long = {
-    val a = allocate(4, 4)
-    Memory.storeInt(a, v)
-    a
-  }
-
-  def appendLong(v: Long): Long = {
-    val a = allocate(8, 8)
-    Memory.storeLong(a, v)
-    a
-  }
-
-  def appendDouble(v: Double): Long = {
-    val a = allocate(8, 8)
-    Memory.storeDouble(a, v)
-    a
-  }
-
-  def appendByte(v: Byte): Long = {
-    val a = allocate(1)
-    Memory.storeByte(a, v)
-    a
-  }
-
-  def appendString(v: String): Long =
-    appendBinary(v.getBytes)
 
   def visit(t: PType, off: Long, v: ValueVisitor) {
     t match {

--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -283,41 +283,20 @@ final class Region protected[annotations](var blockSize: Region.Size, var pool: 
     memory.releaseReferenceAtIndex(idx)
   }
 
-  def loadInt(addr: Long): Int = Region.loadInt(addr)
-
-  def loadLong(addr: Long): Long = Region.loadLong(addr)
-
-  def loadFloat(addr: Long): Float = Region.loadFloat(addr)
-
-  def loadDouble(addr: Long): Double = Region.loadDouble(addr)
-
-  def loadAddress(addr: Long): Long = Region.loadLong(addr)
-
-  def loadByte(addr: Long): Byte = Region.loadByte(addr)
-
-  def loadBoolean(addr: Long): Boolean = Region.loadBoolean(addr)
-
-  def loadBytes(addr: Long, n: Int): Array[Byte] = Region.loadBytes(addr, n)
-
-  def loadBytes(addr: Long, dst: Array[Byte], dstOff: Long, n: Long): Unit =
-    Region.loadBytes(addr, dst, dstOff, n)
-
-  def loadBit(byteOff: Long, bitOff: Long): Boolean = Region.loadBit(byteOff, bitOff)
-
   def visit(t: PType, off: Long, v: ValueVisitor) {
     t match {
-      case _: PBoolean => v.visitBoolean(loadBoolean(off))
-      case _: PInt32 => v.visitInt32(loadInt(off))
-      case _: PInt64 => v.visitInt64(loadLong(off))
-      case _: PFloat32 => v.visitFloat32(loadFloat(off))
-      case _: PFloat64 => v.visitFloat64(loadDouble(off))
+      case _: PBoolean => v.visitBoolean(Region.loadBoolean(off))
+      case _: PInt32 => v.visitInt32(Region.loadInt(off))
+      case _: PInt64 => v.visitInt64(Region.loadLong(off))
+      case _: PFloat32 => v.visitFloat32(Region.loadFloat(off))
+      case _: PFloat64 => v.visitFloat64(Region.loadDouble(off))
       case _: PString =>
         val boff = off
         v.visitString(PString.loadString(this, boff))
       case _: PBinary =>
         val boff = off
         val length = PBinary.loadLength(this, boff)
-        val b = loadBytes(PBinary.bytesOffset(boff), length)
+        val b = Region.loadBytes(PBinary.bytesOffset(boff), length)
         v.visitBinary(b)
       case t: PContainer =>
         val aoff = off

--- a/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
@@ -275,7 +275,8 @@ class RegionValueBuilder(var region: Region) {
   def addBinary(bytes: Array[Byte]) {
     assert(currentType().isInstanceOf[PBinary])
 
-    val boff = region.appendBinary(bytes)
+    val boff = PBinary.allocate(region, bytes.length)
+    PBinary.store(boff, bytes)
 
     if (typestk.nonEmpty) {
       val off = currentOffset()

--- a/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -61,7 +61,7 @@ object StagedRegionValueBuilder {
     typ.fundamentalType match {
       case t if t.isPrimitive => Region.storePrimitive(t, dest)(value)
       case t@(_: PBinary | _: PArray) =>
-        region.storeAddress(dest, deepCopyFromOffset(fb, region, t, coerce[Long](value)))
+        Region.storeAddress(dest, deepCopyFromOffset(fb, region, t, coerce[Long](value)))
       case t: PBaseStruct =>
         Code(Region.copyFrom(coerce[Long](value), dest, t.byteSize),
           fixupStruct(fb, region, t, dest))
@@ -171,7 +171,7 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: PType, va
     val t = ftype.asInstanceOf[PArray]
     var c = startOffset.store(region.allocate(t.contentsAlignment, t.contentsByteSize(length)))
     if (pOffset != null) {
-      c = Code(c, region.storeAddress(pOffset, startOffset))
+      c = Code(c, Region.storeAddress(pOffset, startOffset))
     }
     if (init)
       c = Code(c, t.stagedInitialize(startOffset, length))
@@ -217,38 +217,38 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: PType, va
 
   def addBoolean(v: Code[Boolean]): Code[Unit] = {
     checkType(TBoolean())
-    region.storeByte(currentOffset, v.toI.toB)
+    Region.storeByte(currentOffset, v.toI.toB)
   }
 
   def addInt(v: Code[Int]): Code[Unit] = {
     checkType(TInt32())
-    region.storeInt(currentOffset, v)
+    Region.storeInt(currentOffset, v)
   }
 
   def addLong(v: Code[Long]): Code[Unit] = {
     checkType(TInt64())
-    region.storeLong(currentOffset, v)
+    Region.storeLong(currentOffset, v)
   }
 
   def addFloat(v: Code[Float]): Code[Unit] = {
     checkType(TFloat32())
-    region.storeFloat(currentOffset, v)
+    Region.storeFloat(currentOffset, v)
   }
 
   def addDouble(v: Code[Double]): Code[Unit] = {
     checkType(TFloat64())
-    region.storeDouble(currentOffset, v)
+    Region.storeDouble(currentOffset, v)
   }
 
   def allocateBinary(n: Code[Int]): Code[Long] = {
     val boff = mb.newField[Long]
     Code(
       boff := PBinary.allocate(region, n),
-      region.storeInt(boff, n),
+      Region.storeInt(boff, n),
       ftype match {
         case _: PBinary => startOffset := boff
         case _ =>
-          region.storeAddress(currentOffset, boff)
+          Region.storeAddress(currentOffset, boff)
       },
       boff)
   }
@@ -263,7 +263,7 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: PType, va
   }
 
 
-  def addAddress(v: Code[Long]): Code[Unit] = region.storeAddress(currentOffset, v)
+  def addAddress(v: Code[Long]): Code[Unit] = Region.storeAddress(currentOffset, v)
 
   def addString(str: Code[String]): Code[Unit] = addBinary(str.invoke[Array[Byte]]("getBytes"))
 

--- a/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -254,16 +254,14 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: PType, va
   }
 
   def addBinary(bytes: Code[Array[Byte]]): Code[Unit] = {
+    val b = mb.newField[Array[Byte]]
     val boff = mb.newField[Long]
     Code(
-      boff := region.appendBinary(bytes),
-      ftype match {
-        case _: PBinary =>
-          startOffset := boff
-        case _ =>
-          region.storeAddress(currentOffset, boff)
-      })
+      b := bytes,
+      boff := PBinary.allocate(region, b.length()),
+      PBinary.store(boff, b))
   }
+
 
   def addAddress(v: Code[Long]): Code[Unit] = region.storeAddress(currentOffset, v)
 

--- a/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/StagedRegionValueBuilder.scala
@@ -259,6 +259,11 @@ class StagedRegionValueBuilder private(val mb: MethodBuilder, val typ: PType, va
     Code(
       b := bytes,
       boff := PBinary.allocate(region, b.length()),
+      ftype match {
+        case _: PBinary => startOffset := boff
+        case _ =>
+          Region.storeAddress(currentOffset, boff)
+      },
       PBinary.store(boff, b))
   }
 

--- a/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
+++ b/hail/src/main/scala/is/hail/annotations/UnsafeRow.scala
@@ -41,7 +41,7 @@ class UnsafeIndexedSeq(
 object UnsafeRow {
   def readBinary(region: Region, boff: Long, t: PBinary): Array[Byte] = {
     val binLength = PBinary.loadLength(region, boff)
-    region.loadBytes(PBinary.bytesOffset(boff), binLength)
+    Region.loadBytes(PBinary.bytesOffset(boff), binLength)
   }
 
   def readArray(t: PContainer, region: Region, aoff: Long): IndexedSeq[Any] =
@@ -57,7 +57,7 @@ object UnsafeRow {
     val ft = t.representation.asInstanceOf[PStruct]
     Locus(
       readString(region, ft.loadField(region, offset, 0), ft.types(0).asInstanceOf[PString]),
-      region.loadInt(ft.loadField(region, offset, 1)))
+      Region.loadInt(ft.loadField(region, offset, 1)))
   }
 
   def readAnyRef(t: PType, region: Region, offset: Long): AnyRef = read(t, region, offset).asInstanceOf[AnyRef]
@@ -65,11 +65,11 @@ object UnsafeRow {
   def read(t: PType, region: Region, offset: Long): Any = {
     t match {
       case _: PBoolean =>
-        region.loadBoolean(offset)
-      case _: PInt32 | _: PCall => region.loadInt(offset)
-      case _: PInt64 => region.loadLong(offset)
-      case _: PFloat32 => region.loadFloat(offset)
-      case _: PFloat64 => region.loadDouble(offset)
+        Region.loadBoolean(offset)
+      case _: PInt32 | _: PCall => Region.loadInt(offset)
+      case _: PInt64 => Region.loadLong(offset)
+      case _: PFloat32 => Region.loadFloat(offset)
+      case _: PFloat64 => Region.loadDouble(offset)
       case t: PArray =>
         readArray(t, region, offset)
       case t: PSet =>
@@ -136,32 +136,32 @@ class UnsafeRow(var t: PBaseStruct,
 
   override def getInt(i: Int): Int = {
     assertDefined(i)
-    region.loadInt(t.loadField(region, offset, i))
+    Region.loadInt(t.loadField(region, offset, i))
   }
 
   override def getLong(i: Int): Long = {
     assertDefined(i)
-    region.loadLong(t.loadField(region, offset, i))
+    Region.loadLong(t.loadField(region, offset, i))
   }
 
   override def getFloat(i: Int): Float = {
     assertDefined(i)
-    region.loadFloat(t.loadField(region, offset, i))
+    Region.loadFloat(t.loadField(region, offset, i))
   }
 
   override def getDouble(i: Int): Double = {
     assertDefined(i)
-    region.loadDouble(t.loadField(region, offset, i))
+    Region.loadDouble(t.loadField(region, offset, i))
   }
 
   override def getBoolean(i: Int): Boolean = {
     assertDefined(i)
-    region.loadBoolean(t.loadField(region, offset, i))
+    Region.loadBoolean(t.loadField(region, offset, i))
   }
 
   override def getByte(i: Int): Byte = {
     assertDefined(i)
-    region.loadByte(t.loadField(region, offset, i))
+    Region.loadByte(t.loadField(region, offset, i))
   }
 
   override def isNullAt(i: Int): Boolean = {

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -506,7 +506,7 @@ private class Emit(
                     .concat(irString))))))
 
         EmitTriplet(setup, xmv, Code(
-          region.loadIRIntermediate(typ)(pArray.elementOffset(xa, len, xi))))
+          Region.loadIRIntermediate(x.pType)(pArray.elementOffset(xa, len, xi))))
       case ArrayLen(a) =>
         val codeA = emit(a)
         strict(PContainer.loadLength(coerce[Long](codeA.v)), codeA)
@@ -614,10 +614,10 @@ private class Emit(
         val i = mb.newLocal[Int]
 
         def loadKey(n: Code[Int]): Code[_] =
-          region.loadIRIntermediate(ktyp)(etyp.fieldOffset(coerce[Long](eab(n)), 0))
+          Region.loadIRIntermediate(ktyp)(etyp.fieldOffset(coerce[Long](eab(n)), 0))
 
         def loadValue(n: Code[Int]): Code[_] =
-          region.loadIRIntermediate(vtyp)(etyp.fieldOffset(coerce[Long](eab(n)), 1))
+          Region.loadIRIntermediate(vtyp)(etyp.fieldOffset(coerce[Long](eab(n)), 1))
 
         val srvb = new StagedRegionValueBuilder(mb, ir.pType)
 
@@ -1170,7 +1170,7 @@ private class Emit(
               val i = oldt.fieldIdx(name)
               val t = oldt.types(i)
               val fieldMissing = oldt.isFieldMissing(region, oldv, i)
-              val fieldValue = region.loadIRIntermediate(t)(oldt.fieldOffset(oldv, i))
+              val fieldValue = Region.loadIRIntermediate(t)(oldt.fieldOffset(oldv, i))
               Code(
                 fieldMissing.mux(
                   srvb.setMissing(),
@@ -1227,7 +1227,7 @@ private class Emit(
                         Code(
                           oldtype.isFieldMissing(region, xo, oldField.index).mux(
                             srvb.setMissing(),
-                            srvb.addIRIntermediate(f.typ)(region.loadIRIntermediate(oldField.typ)(oldtype.fieldOffset(xo, oldField.index)))),
+                            srvb.addIRIntermediate(f.typ)(Region.loadIRIntermediate(oldField.typ)(oldtype.fieldOffset(xo, oldField.index)))),
                           srvb.advance())
                     }
                 }
@@ -1256,7 +1256,7 @@ private class Emit(
           xo := coerce[Long](xmo.mux(defaultValue(t), codeO.v)))
         EmitTriplet(setup,
           xmo || !t.isFieldDefined(region, xo, fieldIdx),
-          region.loadIRIntermediate(t.types(fieldIdx))(t.fieldOffset(xo, fieldIdx)))
+          Region.loadIRIntermediate(t.types(fieldIdx))(t.fieldOffset(xo, fieldIdx)))
 
       case x@MakeTuple(fields) =>
         val srvb = new StagedRegionValueBuilder(mb, x.pType)
@@ -1280,7 +1280,7 @@ private class Emit(
           xo := coerce[Long](xmo.mux(defaultValue(t), codeO.v)))
         EmitTriplet(setup,
           xmo || !t.isFieldDefined(region, xo, idx),
-          region.loadIRIntermediate(t.types(idx))(t.fieldOffset(xo, idx)))
+          Region.loadIRIntermediate(t.types(idx))(t.fieldOffset(xo, idx)))
 
       case In(i, typ) =>
         EmitTriplet(Code._empty,
@@ -1394,7 +1394,7 @@ private class Emit(
         val ndAddress = mb.newField[Long]
 
 
-        def getShapeAtIdx(index: Int) = region.loadLong(shapePType.loadField(shapet.value[Long], index))
+        def getShapeAtIdx(index: Int) = Region.loadLong(shapePType.loadField(shapet.value[Long], index))
 
         val setup = Code(
           shapet.setup,
@@ -1473,9 +1473,9 @@ private class Emit(
             ctxOff := cDec(bodyFB.getArg[Region](1), cCodec.buildCodeInputBuffer(ctxIS)),
             gOff := gDec(bodyFB.getArg[Region](1), gCodec.buildCodeInputBuffer(gIS)),
             bOff := bodyMB.invoke[Long](bodyFB.getArg[Region](1),
-              region.loadIRIntermediate(ctxType.virtualType)(ctxTypeTuple.fieldOffset(ctxOff, 0)),
+              Region.loadIRIntermediate(ctxType)(ctxTypeTuple.fieldOffset(ctxOff, 0)),
               ctxTypeTuple.isFieldMissing(region, ctxOff, 0),
-              region.loadIRIntermediate(gType.virtualType)(gTypeTuple.fieldOffset(gOff, 0)),
+              Region.loadIRIntermediate(gType)(gTypeTuple.fieldOffset(gOff, 0)),
               gTypeTuple.isFieldMissing(region, gOff, 0)),
             bOS := Code.newInstance[ByteArrayOutputStream](),
             bOB := bCodec.buildCodeOutputBuffer(bOS),
@@ -1541,7 +1541,7 @@ private class Emit(
               eltTupled := bDec(region, bCodec.buildCodeInputBuffer(bais)),
               bTypeTuple.isFieldMissing(region, eltTupled, 0).mux(
                 sab.setMissing(),
-                sab.addIRIntermediate(bType)(region.loadIRIntermediate(bType)(bTypeTuple.fieldOffset(eltTupled, 0)))),
+                sab.addIRIntermediate(bType)(Region.loadIRIntermediate(bType)(bTypeTuple.fieldOffset(eltTupled, 0)))),
               sab.advance()),
             sab.end())
         }
@@ -1942,7 +1942,7 @@ private class Emit(
             i := 0,
             Code.whileLoop(i < len,
               continuation(t.isElementMissing(region, aoff, i),
-                region.loadIRIntermediate(t.elementType)(t.elementOffsetInRegion(region, aoff, i))),
+                Region.loadIRIntermediate(t.elementType)(t.elementOffsetInRegion(region, aoff, i))),
               i := i + 1)))
         })
     }
@@ -2003,7 +2003,7 @@ private class Emit(
           xP.representation.fieldType("shape").asInstanceOf[PTuple], xP.elementType, setup) {
           override def outputElement(idxVars: Seq[ClassFieldRef[Long]]): Code[_] = {
             val elementLocation = xP.getElementPosition(idxVars, ndt.value[Long], er.region, mb)
-            region.loadIRIntermediate(outputElementPType)(elementLocation)
+            Region.loadIRIntermediate(outputElementPType)(elementLocation)
           }
         }
     }

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -202,7 +202,7 @@ class EmitFunctionBuilder[F >: Null](
     val mb2 = new EmitMethodBuilder(this, "addLiterals", Array(typeInfo[Array[Byte]], typeInfo[Region]), typeInfo[Unit])
     val off = mb2.newLocal[Long]
     val storeFields = literals.zipWithIndex.map { case (((_, _), f), i) =>
-      f.storeAny(mb2.getArg[Region](2).load().loadIRIntermediate(litType.types(i))(litType.fieldOffset(off, i)))
+      f.storeAny(Region.loadIRIntermediate(litType.types(i))(litType.fieldOffset(off, i)))
     }
 
     mb2.emit(Code(

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
@@ -266,7 +266,7 @@ case class MatrixValue(
             val entryOffset = localEntryArrayPType.loadElement(region, entryArrayOffset, j)
             if (localEntryPType.isFieldDefined(region, entryOffset, fieldIdx)) {
               val fieldOffset = localEntryPType.loadField(region, entryOffset, fieldIdx)
-              data(j) = region.loadDouble(fieldOffset)
+              data(j) = Region.loadDouble(fieldOffset)
             } else
               fatal(s"Cannot create RowMatrix: missing value at row $i and col $j")
           } else

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -143,7 +143,7 @@ case class StateContainer(states: Array[AggregatorState], topRegion: Code[Region
   def getStateOffset(off: Code[Long], i: Int): Code[Long] = typ.loadField(topRegion, off, i)
 
   def setAllMissing(off: Code[Long]): Code[Unit] = toCode((i, _) =>
-    topRegion.storeAddress(typ.fieldOffset(off, i), 0L))
+    Region.storeAddress(typ.fieldOffset(off, i), 0L))
 
   def toCode(f: (Int, AggregatorState) => Code[Unit]): Code[Unit] =
     coerce[Unit](Code(Array.tabulate(nStates)(i => f(i, states(i))): _*))

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
@@ -44,7 +44,7 @@ class ArrayElementState(val fb: EmitFunctionBuilder[_], val nested: Array[Aggreg
     Code(
       region.setNumParents((lenRef + 1) * nStates),
       aoff := region.allocate(arrayType.contentsAlignment, arrayType.contentsByteSize(lenRef)),
-      region.storeAddress(typ.fieldOffset(off, 1), aoff),
+      Region.storeAddress(typ.fieldOffset(off, 1), aoff),
       arrayType.stagedInitialize(aoff, lenRef),
       typ.setFieldPresent(region, off, 1))
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
@@ -24,7 +24,7 @@ class TakeRVAS(val eltType: PType, val resultType: PArray, val fb: EmitFunctionB
   override def load(regionLoader: Code[Region] => Code[Unit], src: Code[Long]): Code[Unit] =
     Code(
       regionLoader(r),
-      maxSize := region.loadInt(maxSizeOffset(src)),
+      maxSize := Region.loadInt(maxSizeOffset(src)),
       builder.loadFields(builderStateOffset(src)))
 
   override def store(regionStorer: Code[Region] => Code[Unit], dest: Code[Long]): Code[Unit] =
@@ -103,7 +103,7 @@ class TakeRVAS(val eltType: PType, val resultType: PArray, val fb: EmitFunctionB
 
   def copyFrom(src: Code[Long]): Code[Unit] = {
     Code(
-      maxSize := region.loadInt(maxSizeOffset(src)),
+      maxSize := Region.loadInt(maxSizeOffset(src)),
       builder.copyFrom(builderStateOffset(src))
     )
   }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir.functions
 
+import is.hail.annotations.Region
 import is.hail.asm4s._
 import is.hail.expr.ir._
 import is.hail.expr.types.coerce
@@ -354,10 +355,10 @@ object ArrayFunctions extends RegistryFunctions {
               Code(
                 (t1.isElementDefined(region, a1, i) && t2.isElementDefined(region, a2, i)).mux(
                   Code(
-                    x := region.loadDouble(t1.loadElement(region, a1, i)),
+                    x := Region.loadDouble(t1.loadElement(region, a1, i)),
                     xSum := xSum + x,
                     xSqSum := xSqSum + x * x,
-                    y := region.loadDouble(t2.loadElement(region, a2, i)),
+                    y := Region.loadDouble(t2.loadElement(region, a2, i)),
                     ySum := ySum + y,
                     ySqSum := ySqSum + y * y,
                     xySum := xySum + x * y,

--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -204,7 +204,8 @@ abstract class RegistryFunctions {
       Code(
         bytes := coerce[String](c).invoke[Array[Byte]]("getBytes"),
         v := PBinary.allocate(r.region, bytes.length()),
-        PBinary.store(v, bytes))
+        PBinary.store(v, bytes),
+        v)
     case _: TCall => coerce[Int]
     case TArray(_: TInt32, _) => c =>
       val srvb = new StagedRegionValueBuilder(r, t)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/Functions.scala
@@ -199,7 +199,12 @@ abstract class RegistryFunctions {
     case _: TFloat32 => identity[Code[_]]
     case _: TFloat64 => identity[Code[_]]
     case _: TString => c =>
-      r.region.appendString(coerce[String](c))
+      val bytes = r.mb.newLocal[Array[Byte]]
+      val v = r.mb.newLocal[Long]
+      Code(
+        bytes := coerce[String](c).invoke[Array[Byte]]("getBytes"),
+        v := PBinary.allocate(r.region, bytes.length()),
+        PBinary.store(v, bytes))
     case _: TCall => coerce[Int]
     case TArray(_: TInt32, _) => c =>
       val srvb = new StagedRegionValueBuilder(r, t)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/GenotypeFunctions.scala
@@ -27,7 +27,7 @@ object GenotypeFunctions extends RegistryFunctions {
           tPL.isElementDefined(region, pl, i).mux(
             Code._empty,
             Code._fatal("PL cannot have missing elements.")),
-          pli := region.loadInt(tPL.loadElement(region, pl, len, i)),
+          pli := Region.loadInt(tPL.loadElement(region, pl, len, i)),
           (pli < m).mux(
             Code(m2 := m, m := pli),
             (pli < m2).mux(
@@ -48,8 +48,8 @@ object GenotypeFunctions extends RegistryFunctions {
         gp := gpOff,
         len.cne(3).mux(
           Code._fatal(const("length of gp array must be 3, got ").concat(len.toS)),
-          region.loadDouble(pArray.elementOffset(gp, 3, 1)) +
-            region.loadDouble(pArray.elementOffset(gp, 3, 2)) * 2.0))
+          Region.loadDouble(pArray.elementOffset(gp, 3, 1)) +
+            Region.loadDouble(pArray.elementOffset(gp, 3, 2)) * 2.0))
     }
 
     // FIXME: remove when SkatSuite is moved to Python
@@ -64,9 +64,9 @@ object GenotypeFunctions extends RegistryFunctions {
         len.cne(3).mux(
           Code._fatal(const("length of pl array must be 3, got ").concat(len.toS)),
           Code.invokeScalaObject[Int, Int, Int, Double](Genotype.getClass, "plToDosage",
-            region.loadInt(pArray.elementOffset(pl, 3, 0)),
-            region.loadInt(pArray.elementOffset(pl, 3, 1)),
-            region.loadInt(pArray.elementOffset(pl, 3, 2)))))
+            Region.loadInt(pArray.elementOffset(pl, 3, 0)),
+            Region.loadInt(pArray.elementOffset(pl, 3, 1)),
+            Region.loadInt(pArray.elementOffset(pl, 3, 2)))))
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
@@ -53,7 +53,7 @@ object IntervalFunctions extends RegistryFunctions {
         EmitTriplet(
           Code(interval.setup, iv.storeAny(defaultValue(intervalT))),
           interval.m || !Code(iv := interval.value[Long], intervalT.startDefined(iv)),
-          region.loadIRIntermediate(intervalT.pointType)(intervalT.startOffset(iv))
+          Region.loadIRIntermediate(intervalT.pointType)(intervalT.startOffset(iv))
         )
     }
 
@@ -64,7 +64,7 @@ object IntervalFunctions extends RegistryFunctions {
         EmitTriplet(
           Code(interval.setup, iv.storeAny(defaultValue(intervalT))),
           interval.m || !Code(iv := interval.value[Long], intervalT.endDefined(iv)),
-          region.loadIRIntermediate(tv("T").t)(intervalT.endOffset(iv))
+          Region.loadIRIntermediate(intervalT.pointType)(intervalT.endOffset(iv))
         )
     }
 
@@ -138,9 +138,9 @@ class IRInterval(r: EmitRegion, typ: PInterval, value: Code[Long]) {
   def storeToLocal: Code[Unit] = ref := value
 
   def start: (Code[Boolean], Code[_]) =
-    (!typ.startDefined(ref), region.getIRIntermediate(typ.pointType)(typ.startOffset(ref)))
+    (!typ.startDefined(ref), Region.getIRIntermediate(typ.pointType)(typ.startOffset(ref)))
   def end: (Code[Boolean], Code[_]) =
-    (!typ.endDefined(ref), region.getIRIntermediate(typ.pointType)(typ.endOffset(ref)))
+    (!typ.endDefined(ref), Region.getIRIntermediate(typ.pointType)(typ.endOffset(ref)))
   def includeStart: Code[Boolean] = typ.includeStart(ref)
   def includeEnd: Code[Boolean] = typ.includeEnd(ref)
 

--- a/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/LocusFunctions.scala
@@ -221,14 +221,14 @@ object LocusFunctions extends RegistryFunctions {
         val lastCoord = r.mb.newLocal[Double]("coord")
 
         val getCoord = { i: Code[Int] =>
-          asm4s.coerce[Double](region.loadIRIntermediate(coordT.elementType)(coordT.elementOffset(coordsPerContig, len, i)))
+          asm4s.coerce[Double](Region.loadIRIntermediate(coordT.elementType)(coordT.elementOffset(coordsPerContig, len, i)))
         }
 
         def forAllContigs(c: Code[Unit]): Code[Unit] = {
           Code(iContig := 0,
             Code.whileLoop(iContig < ncontigs,
               coordsPerContig := asm4s.coerce[Long](
-                region.loadIRIntermediate(coordT)(
+                Region.loadIRIntermediate(coordT)(
                   groupedT.elementOffset(coords, ncontigs, iContig))),
               c,
               iContig += 1))

--- a/hail/src/main/scala/is/hail/expr/ir/functions/RandomSeededFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/RandomSeededFunctions.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir.functions
 
-import is.hail.annotations.StagedRegionValueBuilder
+import is.hail.annotations.{Region, StagedRegionValueBuilder}
 import is.hail.asm4s.Code
 import is.hail.expr.types._
 import is.hail.expr.types.physical.{PArray, PFloat64}
@@ -114,7 +114,7 @@ object RandomSeededFunctions extends RegistryFunctions {
         length := aT.loadLength(r.region, aoff),
         array := Code.newArray[Double](length),
         Code.whileLoop(i < length,
-          array.load().update(i, r.region.loadDouble(aT.elementOffset(aoff, length, i))),
+          array.load().update(i, Region.loadDouble(aT.elementOffset(aoff, length, i))),
           i += 1),
         r.mb.newRNG(seed).invoke[Array[Double], Int]("rcat", array))
     }

--- a/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/StringFunctions.scala
@@ -175,8 +175,8 @@ object StringFunctions extends RegistryFunctions {
         Code(n := 0,
           i := 0,
           Code.whileLoop(i < len,
-            region.loadByte(PBinary.bytesOffset(v1) + i.toL)
-              .cne(region.loadByte(PBinary.bytesOffset(v2) + i.toL)).mux(
+            Region.loadByte(PBinary.bytesOffset(v1) + i.toL)
+              .cne(Region.loadByte(PBinary.bytesOffset(v2) + i.toL)).mux(
               n += 1,
               Code._empty[Unit]),
             i += 1),

--- a/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -194,7 +194,7 @@ object UtilFunctions extends RegistryFunctions {
 
     registerCode("format", TString(), tv("T", "tuple"), TString(), null) {
       case (r, rt, (fmtT: PString, format: Code[Long]), (argsT: PTuple, args: Code[Long])) =>
-        r.region.appendString(Code.invokeScalaObject[String, Row, String](thisClass, "format",
+        unwrapReturn(r, rt)(Code.invokeScalaObject[String, Row, String](thisClass, "format",
           asm4s.coerce[String](wrapArg(r, fmtT)(format)),
           Code.checkcast[Row](asm4s.coerce[java.lang.Object](wrapArg(r, argsT)(args)))))
     }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBinary.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBinary.scala
@@ -109,4 +109,11 @@ object PBinary {
     region.allocate(const(contentAlignment), contentByteSize(length))
   }
 
+  def store(addr: Long, bytes: Array[Byte]): Unit = {
+    Region.storeInt(addr, bytes.length)
+    Region.storeBytes(bytesOffset(addr), bytes)
+  }
+
+  def store(addr: Code[Long], bytes: Code[Array[Byte]]): Code[Unit] =
+    Code.invokeScalaObject[Long, Array[Byte], Unit](PBinary.getClass, "store", addr, bytes)
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBoolean.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBoolean.scala
@@ -21,7 +21,7 @@ class PBoolean(override val required: Boolean) extends PType {
 
   override def unsafeOrdering(): UnsafeOrdering = new UnsafeOrdering {
     def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
-      java.lang.Boolean.compare(r1.loadBoolean(o1), r2.loadBoolean(o2))
+      java.lang.Boolean.compare(Region.loadBoolean(o1), Region.loadBoolean(o2))
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
@@ -73,7 +73,7 @@ abstract class PContainer extends PIterable {
     !isElementDefined(region, aoff, i)
 
   def isElementDefined(region: Region, aoff: Long, i: Int): Boolean =
-    elementType.required || !region.loadBit(aoff + 4, i)
+    elementType.required || !Region.loadBit(aoff + 4, i)
 
   def isElementMissing(aoff: Code[Long], i: Code[Int]): Code[Boolean] =
     !isElementDefined(aoff, i)
@@ -127,7 +127,7 @@ abstract class PContainer extends PIterable {
   def loadElement(region: Region, aoff: Long, length: Int, i: Int): Long = {
     val off = elementOffset(aoff, length, i)
     elementType.fundamentalType match {
-      case _: PArray | _: PBinary => region.loadAddress(off)
+      case _: PArray | _: PBinary => Region.loadAddress(off)
       case _ => off
     }
   }
@@ -141,7 +141,7 @@ abstract class PContainer extends PIterable {
   }
 
   def loadElement(region: Region, aoff: Long, i: Int): Long =
-    loadElement(region, aoff, region.loadInt(aoff), i)
+    loadElement(region, aoff, Region.loadInt(aoff), i)
 
   def loadElement(aoff: Code[Long], i: Code[Int]): Code[Long] = {
     val off = elementOffset(aoff, Region.loadInt(aoff), i)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PContainer.scala
@@ -92,7 +92,7 @@ abstract class PContainer extends PIterable {
 
   def setElementMissing(region: Region, aoff: Long, i: Int) {
     assert(!elementType.required)
-    region.setBit(aoff + 4, i)
+    Region.setBit(aoff + 4, i)
   }
 
   def setElementMissing(aoff: Code[Long], i: Code[Int]): Code[Unit] =
@@ -103,7 +103,7 @@ abstract class PContainer extends PIterable {
 
   def setElementPresent(region: Region, aoff: Long, i: Int) {
     assert(!elementType.required)
-    region.clearBit(aoff + 4, i)
+    Region.clearBit(aoff + 4, i)
   }
 
   def setElementPresent(aoff: Code[Long], i: Code[Int]): Code[Unit] =
@@ -179,7 +179,7 @@ abstract class PContainer extends PIterable {
   }
 
   def initialize(region: Region, aoff: Long, length: Int, setMissing: Boolean = false) {
-    region.storeInt(aoff, length)
+    Region.storeInt(aoff, length)
     if (setMissing)
       setAllMissingBits(region, aoff, length)
     else

--- a/hail/src/main/scala/is/hail/expr/types/physical/PFloat32.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PFloat32.scala
@@ -24,7 +24,7 @@ class PFloat32(override val required: Boolean) extends PType {
 
   override def unsafeOrdering(): UnsafeOrdering = new UnsafeOrdering {
     def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
-      java.lang.Float.compare(r1.loadFloat(o1), r2.loadFloat(o2))
+      java.lang.Float.compare(Region.loadFloat(o1), Region.loadFloat(o2))
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PFloat64.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PFloat64.scala
@@ -24,7 +24,7 @@ class PFloat64(override val required: Boolean) extends PType {
 
   override def unsafeOrdering(): UnsafeOrdering = new UnsafeOrdering {
     def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
-      java.lang.Double.compare(r1.loadDouble(o1), r2.loadDouble(o2))
+      java.lang.Double.compare(Region.loadDouble(o1), Region.loadDouble(o2))
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PInt32.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PInt32.scala
@@ -23,7 +23,7 @@ class PInt32(override val required: Boolean) extends PIntegral {
 
   override def unsafeOrdering(): UnsafeOrdering = new UnsafeOrdering {
     def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
-      Integer.compare(r1.loadInt(o1), r2.loadInt(o2))
+      Integer.compare(Region.loadInt(o1), Region.loadInt(o2))
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PInt64.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PInt64.scala
@@ -24,7 +24,7 @@ class PInt64(override val required: Boolean) extends PIntegral {
 
   override def unsafeOrdering(): UnsafeOrdering = new UnsafeOrdering {
     def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
-      java.lang.Long.compare(r1.loadLong(o1), r2.loadLong(o2))
+      java.lang.Long.compare(Region.loadLong(o1), Region.loadLong(o2))
     }
   }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PInterval.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PInterval.scala
@@ -114,9 +114,9 @@ case class PInterval(pointType: PType, override val required: Boolean = false) e
 
   def endDefined(region: Region, off: Long): Boolean = representation.isFieldDefined(region, off, 1)
 
-  def includesStart(region: Region, off: Long): Boolean = region.loadBoolean(representation.loadField(region, off, 2))
+  def includesStart(region: Region, off: Long): Boolean = Region.loadBoolean(representation.loadField(region, off, 2))
 
-  def includesEnd(region: Region, off: Long): Boolean = region.loadBoolean(representation.loadField(region, off, 3))
+  def includesEnd(region: Region, off: Long): Boolean = Region.loadBoolean(representation.loadField(region, off, 3))
 
   def startDefined(off: Code[Long]): Code[Boolean] = representation.isFieldDefined(off, 0)
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PLocus.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PLocus.scala
@@ -57,7 +57,7 @@ case class PLocus(rgBc: BroadcastRG, override val required: Boolean = false) ext
 
         val posOff1 = repr.loadField(r1, o1, 1)
         val posOff2 = repr.loadField(r2, o2, 1)
-        java.lang.Integer.compare(r1.loadInt(posOff1), r2.loadInt(posOff2))
+        java.lang.Integer.compare(Region.loadInt(posOff1), Region.loadInt(posOff2))
       }
     }
   }
@@ -94,5 +94,5 @@ case class PLocus(rgBc: BroadcastRG, override val required: Boolean = false) ext
 
   def contig(region: Code[Region], off: Code[Long]): Code[Long] = representation.loadField(region, off, 0)
   
-  def position(region: Code[Region], off: Code[Long]): Code[Int] = region.loadInt(representation.loadField(region, off, 1))
+  def position(region: Code[Region], off: Code[Long]): Code[Int] = Region.loadInt(representation.loadField(region, off, 1))
 }

--- a/hail/src/main/scala/is/hail/io/InputBuffers.scala
+++ b/hail/src/main/scala/is/hail/io/InputBuffers.scala
@@ -86,7 +86,7 @@ final class StreamInputBuffer(in: InputStream) extends InputBuffer {
   }
 
   def readBytes(toRegion: Region, toOff: Long, n: Int): Unit = {
-    toRegion.storeBytes(toOff, Array.tabulate(n)(_ => readByte()))
+    Region.storeBytes(toOff, Array.tabulate(n)(_ => readByte()))
   }
 
   def skipByte(): Unit = in.skip(1)
@@ -280,7 +280,7 @@ final class BlockingInputBuffer(blockSize: Int, in: InputBlockBuffer) extends In
         readBlock()
       val p = math.min(end - off, n)
       assert(p > 0)
-      toRegion.storeBytes(toOff, buf, off, p)
+      Region.storeBytes(toOff, buf, off, p)
       toOff += p
       n -= p
       off += p

--- a/hail/src/main/scala/is/hail/io/OutputBuffers.scala
+++ b/hail/src/main/scala/is/hail/io/OutputBuffers.scala
@@ -73,7 +73,7 @@ final class StreamOutputBuffer(out: OutputStream) extends OutputBuffer {
     out.write(buf, 0, 8)
   }
 
-  def writeBytes(region: Region, off: Long, n: Int): Unit = out.write(region.loadBytes(off, n))
+  def writeBytes(region: Region, off: Long, n: Int): Unit = out.write(Region.loadBytes(off, n))
 
   def writeDoubles(from: Array[Double], fromOff: Int, n: Int) {
     var i = 0
@@ -214,14 +214,14 @@ final class BlockingOutputBuffer(blockSize: Int, out: OutputBlockBuffer) extends
 
     while (off + n > buf.length) {
       val p = buf.length - off
-      fromRegion.loadBytes(fromOff, buf, off, p)
+      Region.loadBytes(fromOff, buf, off, p)
       off += p
       fromOff += p
       n -= p
       assert(off == buf.length)
       writeBlock()
     }
-    fromRegion.loadBytes(fromOff, buf, off, n)
+    Region.loadBytes(fromOff, buf, off, n)
     off += n
   }
 

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -188,7 +188,7 @@ object EmitPackDecoder {
       length := in.readInt(),
       srvb.start(length, init = false),
       aoff := srvb.offset,
-      srvb.region.storeInt(aoff, length),
+      Region.storeInt(aoff, length),
       if (t.elementType.required)
         Code._empty
       else

--- a/hail/src/main/scala/is/hail/io/RowStore.scala
+++ b/hail/src/main/scala/is/hail/io/RowStore.scala
@@ -141,7 +141,7 @@ object EmitPackDecoder {
                 if (f.typ.required)
                   readElement
                 else {
-                  region.loadBit(moff, const(t.missingIdx(f.index))).mux(
+                  Region.loadBit(moff, t.missingIdx(f.index).toLong).mux(
                     srvb.setMissing(),
                     readElement)
                 },
@@ -157,7 +157,7 @@ object EmitPackDecoder {
               if (f.typ.required)
                 skipField
               else {
-                region.loadBit(moff, const(t.missingIdx(f.index))).mux(
+                Region.loadBit(moff, t.missingIdx(f.index).toLong).mux(
                   Code._empty,
                   skipField)
               }
@@ -219,7 +219,7 @@ object EmitPackDecoder {
           if (f.typ.required)
             skipField
           else
-            region.loadBit(moff, const(t.missingIdx(f.index))).mux(
+            Region.loadBit(moff, t.missingIdx(f.index).toLong).mux(
               Code._empty,
               skipField)
         }
@@ -259,7 +259,7 @@ object EmitPackDecoder {
         in.readBytes(region, moff, nMissing),
         i := 0,
         Code.whileLoop(i < length,
-          region.loadBit(moff, i.toL).mux(
+          Region.loadBit(moff, i.toL).mux(
             Code._empty,
             skip(t.elementType, mb, in, region)),
           i := i + const(1)))
@@ -461,7 +461,7 @@ object EmitPackEncoder {
     out: Code[OutputBuffer],
     prefixLength: Code[Int]
   ): Code[Unit] = {
-    val actualLength = region.loadInt(aoff)
+    val actualLength = Region.loadInt(aoff)
 
     val writeLen = out.writeInt(prefixLength)
     val writeMissingBytes =
@@ -494,7 +494,7 @@ object EmitPackEncoder {
     emitArray(t, requestedType, mb, region, aoff, out, t.loadLength(region, aoff))
 
   def writeBinary(mb: MethodBuilder, region: Code[Region], boff: Code[Long], out: Code[OutputBuffer]): Code[Unit] = {
-    val length = region.loadInt(boff)
+    val length = Region.loadInt(boff)
     Code(
       out.writeInt(length),
       out.writeBytes(region, boff + const(4), length))

--- a/hail/src/main/scala/is/hail/io/plink/ExportPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/ExportPlink.scala
@@ -148,7 +148,7 @@ class BimAnnotationView(rowType: PStruct) extends View {
   }
 
   def cmPosition(): Double =
-    region.loadDouble(cmPosOffset)
+    Region.loadDouble(cmPosOffset)
 
   def varid(): String = {
     if (cachedVarid == null)

--- a/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala
+++ b/hail/src/main/scala/is/hail/io/vcf/ExportVCF.scala
@@ -23,22 +23,22 @@ object ExportVCF {
   def strVCF(sb: StringBuilder, elementType: PType, m: Region, offset: Long) {
     elementType match {
       case PInt32(_) =>
-        val x = m.loadInt(offset)
+        val x = Region.loadInt(offset)
         sb.append(x)
       case PInt64(_) =>
-        val x = m.loadLong(offset)
+        val x = Region.loadLong(offset)
         if (x > Int.MaxValue || x < Int.MinValue)
           fatal(s"Cannot convert Long to Int if value is greater than Int.MaxValue (2^31 - 1) " +
             s"or less than Int.MinValue (-2^31). Found $x.")
         sb.append(x)
       case PFloat32(_) =>
-        val x = m.loadFloat(offset)
+        val x = Region.loadFloat(offset)
         if (x.isNaN)
           sb += '.'
         else
           sb.append(x.formatted("%.5e"))
       case PFloat64(_) =>
-        val x = m.loadDouble(offset)
+        val x = Region.loadDouble(offset)
         if (x.isNaN)
           sb += '.'
         else
@@ -46,7 +46,7 @@ object ExportVCF {
       case PString(_) =>
         sb.append(PString.loadString(m, offset))
       case PCall(_) =>
-        val c = m.loadInt(offset)
+        val c = Region.loadInt(offset)
         Call.vcfString(c, sb)
       case _ =>
         fatal(s"VCF does not support type $elementType")
@@ -85,7 +85,7 @@ object ExportVCF {
           true
         }
       case PBoolean(_) =>
-        if (m.loadBoolean(offset)) {
+        if (Region.loadBoolean(offset)) {
           if (wroteLast)
             sb += ';'
           sb.append(f.name)
@@ -418,7 +418,7 @@ object ExportVCF {
 
         if (qualExists && fullRowType.isFieldDefined(rv, qualIdx)) {
           val qualOffset = fullRowType.loadField(rv, qualIdx)
-          sb.append(m.loadDouble(qualOffset).formatted("%.2f"))
+          sb.append(Region.loadDouble(qualOffset).formatted("%.2f"))
         } else
           sb += '.'
 

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -1862,7 +1862,7 @@ class WriteBlocksRDD(path: String,
                 val entryOffset = entryArrayType.loadElement(region, entryArrayOffset, colIdx)
                 if (entryType.isFieldDefined(region, entryOffset, fieldIdx)) {
                   val fieldOffset = entryType.loadField(region, entryOffset, fieldIdx)
-                  data(j) = region.loadDouble(fieldOffset)
+                  data(j) = Region.loadDouble(fieldOffset)
                 } else {
                   val rowIdx = blockRow * blockSize + i
                   fatal(s"Cannot create BlockMatrix: missing value at row $rowIdx and col $colIdx")

--- a/hail/src/main/scala/is/hail/methods/IBD.scala
+++ b/hail/src/main/scala/is/hail/methods/IBD.scala
@@ -29,10 +29,10 @@ object IBDInfo {
     fromRegionValue(rv.region, rv.offset)
 
   def fromRegionValue(region: Region, offset: Long): IBDInfo = {
-    val Z0 = region.loadDouble(pType.loadField(region, offset, 0))
-    val Z1 = region.loadDouble(pType.loadField(region, offset, 1))
-    val Z2 = region.loadDouble(pType.loadField(region, offset, 2))
-    val PI_HAT = region.loadDouble(pType.loadField(region, offset, 3))
+    val Z0 = Region.loadDouble(pType.loadField(region, offset, 0))
+    val Z1 = Region.loadDouble(pType.loadField(region, offset, 1))
+    val Z2 = Region.loadDouble(pType.loadField(region, offset, 2))
+    val PI_HAT = Region.loadDouble(pType.loadField(region, offset, 3))
     IBDInfo(Z0, Z1, Z2, PI_HAT)
   }
 }
@@ -62,9 +62,9 @@ object ExtendedIBDInfo {
 
   def fromRegionValue(region: Region, offset: Long): ExtendedIBDInfo = {
     val ibd = IBDInfo.fromRegionValue(region, pType.loadField(region, offset, 0))
-    val ibs0 = region.loadLong(pType.loadField(region, offset, 1))
-    val ibs1 = region.loadLong(pType.loadField(region, offset, 2))
-    val ibs2 = region.loadLong(pType.loadField(region, offset, 3))
+    val ibs0 = Region.loadLong(pType.loadField(region, offset, 1))
+    val ibs1 = Region.loadLong(pType.loadField(region, offset, 2))
+    val ibs2 = Region.loadLong(pType.loadField(region, offset, 3))
     ExtendedIBDInfo(ibd, ibs0, ibs1, ibs2)
   }
 }
@@ -316,9 +316,9 @@ object IBD {
       val i = PString.loadString(region, ibdPType.loadField(rv, 0))
       val j = PString.loadString(region, ibdPType.loadField(rv, 1))
       val ibd = IBDInfo.fromRegionValue(region, ibdPType.loadField(rv, 2))
-      val ibs0 = region.loadLong(ibdPType.loadField(rv, 3))
-      val ibs1 = region.loadLong(ibdPType.loadField(rv, 4))
-      val ibs2 = region.loadLong(ibdPType.loadField(rv, 5))
+      val ibs0 = Region.loadLong(ibdPType.loadField(rv, 3))
+      val ibs1 = Region.loadLong(ibdPType.loadField(rv, 4))
+      val ibs2 = Region.loadLong(ibdPType.loadField(rv, 5))
       val eibd = ExtendedIBDInfo(ibd, ibs0, ibs1, ibs2)
       ((i, j), eibd)
     }
@@ -336,7 +336,7 @@ object IBD {
 
     (rv: RegionValue) => {
       val isDefined = rvRowPType.isFieldDefined(rv, idx)
-      val maf = rv.region.loadDouble(rvRowPType.loadField(rv, idx))
+      val maf = Region.loadDouble(rvRowPType.loadField(rv, idx))
       if (!isDefined) {
         val row = new UnsafeRow(rvRowPType, rv).deleteField(entriesIdx)
         fatal(s"The minor allele frequency expression evaluated to NA at ${ rowKeysF(row) }.")

--- a/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
+++ b/hail/src/main/scala/is/hail/methods/LocalLDPrune.scala
@@ -56,16 +56,16 @@ class BitPackedVectorView(rvRowType: PStruct) {
     if (idx < 0 || idx >= bpvLength)
       throw new ArrayIndexOutOfBoundsException(idx)
     val packOffset = bpvElementOffset + idx * BitPackedVectorView.bpvElementSize
-    m.loadLong(packOffset)
+    Region.loadLong(packOffset)
   }
 
   def getNPacks: Int = bpvLength
 
-  def getNSamples: Int = m.loadInt(nSamplesOffset)
+  def getNSamples: Int = Region.loadInt(nSamplesOffset)
 
-  def getMean: Double = m.loadDouble(meanOffset)
+  def getMean: Double = Region.loadDouble(meanOffset)
 
-  def getCenteredLengthRec: Double = m.loadDouble(centeredLengthRecOffset)
+  def getCenteredLengthRec: Double = Region.loadDouble(centeredLengthRecOffset)
 }
 
 object LocalLDPrune {

--- a/hail/src/main/scala/is/hail/methods/Skat.scala
+++ b/hail/src/main/scala/is/hail/methods/Skat.scala
@@ -4,7 +4,7 @@ import is.hail.utils._
 import is.hail.expr.types._
 import is.hail.nativecode.NativeCode
 import is.hail.stats.{LogisticRegressionModel, RegressionUtils, eigSymD}
-import is.hail.annotations.{Annotation, BroadcastRow, UnsafeRow}
+import is.hail.annotations.{Annotation, BroadcastRow, Region, UnsafeRow}
 import breeze.linalg.{DenseMatrix => BDM, DenseVector => BDV, _}
 import breeze.numerics._
 import org.apache.spark.rdd.RDD
@@ -350,7 +350,7 @@ case class Skat(
       val weightIsDefined = fullRowType.isFieldDefined(rv, weightIndex)
 
       if (keyIsDefined && weightIsDefined) {
-        val weight = rv.region.loadDouble(fullRowType.loadField(rv, weightIndex))
+        val weight = Region.loadDouble(fullRowType.loadField(rv, weightIndex))
         if (weight < 0)
           fatal(s"Row weights must be non-negative, got $weight")
         val key = Annotation.copy(keyType.virtualType, UnsafeRow.read(keyType, rv.region, fullRowType.loadField(rv, keyIndex)))

--- a/hail/src/main/scala/is/hail/stats/LinearRegressionCombiner.scala
+++ b/hail/src/main/scala/is/hail/stats/LinearRegressionCombiner.scala
@@ -61,7 +61,7 @@ class LinearRegressionCombiner(k: Int, k0: Int, t: PType) extends Serializable {
       if (xType.isElementMissing(region, xOffset, i))
         return
 
-      x(i) = region.loadDouble(xType.loadElement(region, xOffset, i))
+      x(i) = Region.loadDouble(xType.loadElement(region, xOffset, i))
       i += 1
     }
 

--- a/hail/src/main/scala/is/hail/stats/RegressionUtils.scala
+++ b/hail/src/main/scala/is/hail/stats/RegressionUtils.scala
@@ -1,7 +1,7 @@
 package is.hail.stats
 
 import breeze.linalg._
-import is.hail.annotations.RegionValue
+import is.hail.annotations.{Region, RegionValue}
 import is.hail.expr.ir.MatrixValue
 import is.hail.expr.types.physical.{PArray, PStruct}
 import is.hail.expr.types.virtual.TFloat64
@@ -34,7 +34,7 @@ object RegressionUtils {
         val entryOffset = entryArrayType.loadElement(region, entryArrayOffset, k)
         if (entryType.isFieldDefined(region, entryOffset, fieldIdx)) {
           val fieldOffset = entryType.loadField(region, entryOffset, fieldIdx)
-          val e = region.loadDouble(fieldOffset)
+          val e = Region.loadDouble(fieldOffset)
           sum += e
           data(offset + j) = e
         } else

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichCodeInputBuffer.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichCodeInputBuffer.scala
@@ -42,7 +42,7 @@ class RichCodeInputBuffer(in: Code[InputBuffer]) {
     else if (n < 5)
       Code(
         Code((0 until n).map(i =>
-          toRegion.storeByte(toOff + const(i), in.readByte())): _*),
+          Region.storeByte(toOff + const(i), in.readByte())): _*),
         // for type
         Code._empty)
     else

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichCodeRegion.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichCodeRegion.scala
@@ -118,50 +118,6 @@ class RichCodeRegion(val region: Code[Region]) extends AnyVal {
     region.invoke[Long, Long, Boolean, Unit]("setBit", byteOff, bitOff, b)
   }
 
-  def appendInt(i: Code[Int]): Code[Long] = {
-    region.invoke[Int, Long]("appendInt", i)
-  }
-
-  def appendLong(l: Code[Long]): Code[Long] = {
-    region.invoke[Long, Long]("appendLong", l)
-  }
-
-  def appendFloat(f: Code[Float]): Code[Long] = {
-    region.invoke[Float, Long]("appendFloat", f)
-  }
-
-  def appendDouble(d: Code[Double]): Code[Long] = {
-    region.invoke[Double, Long]("appendDouble", d)
-  }
-
-  def appendByte(b: Code[Byte]): Code[Long] = {
-    region.invoke[Byte, Long]("appendByte", b)
-  }
-
-  def appendBinary(bytes: Code[Array[Byte]]): Code[Long] = {
-    region.invoke[Array[Byte], Long]("appendBinary", bytes)
-  }
-
-  def appendBinarySlice(
-    fromRegion: Code[Region],
-    fromOff: Code[Long],
-    start: Code[Int],
-    n: Code[Int]
-  ): Code[Long] =
-    region.invoke[Region, Long, Int, Int, Long]("appendBinarySlice", fromRegion, fromOff, start, n)
-
-  def appendString(string: Code[String]): Code[Long] = {
-    region.invoke[String, Long]("appendString", string)
-  }
-
-  def appendStringSlice(
-    fromRegion: Code[Region],
-    fromOff: Code[Long],
-    start: Code[Int],
-    n: Code[Int]
-  ): Code[Long] =
-    region.invoke[Region, Long, Int, Int, Long]("appendStringSlice", fromRegion, fromOff, start, n)
-
   def clear(): Code[Unit] = { region.invoke[Unit]("clear") }
 
   def reference(other: Code[Region]): Code[Unit] =

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichCodeRegion.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichCodeRegion.scala
@@ -2,72 +2,10 @@ package is.hail.utils.richUtils
 
 import is.hail.annotations.Region
 import is.hail.asm4s.Code
-import is.hail.expr.types.physical.PType
-import is.hail.expr.types.virtual._
 
 class RichCodeRegion(val region: Code[Region]) extends AnyVal {
   def allocate(alignment: Code[Long], n: Code[Long]): Code[Long] = {
     region.invoke[Long, Long, Long]("allocate", alignment, n)
-  }
-
-  def loadBoolean(off: Code[Long]): Code[Boolean] = {
-    region.invoke[Long, Boolean]("loadBoolean", off)
-  }
-
-  def loadByte(off: Code[Long]): Code[Byte] = {
-    region.invoke[Long, Byte]("loadByte", off)
-  }
-
-  def loadInt(off: Code[Long]): Code[Int] = {
-    region.invoke[Long, Int]("loadInt", off)
-  }
-
-  def loadLong(off: Code[Long]): Code[Long] = {
-    region.invoke[Long, Long]("loadLong", off)
-  }
-
-  def loadFloat(off: Code[Long]): Code[Float] = {
-    region.invoke[Long, Float]("loadFloat", off)
-  }
-
-  def loadDouble(off: Code[Long]): Code[Double] = {
-    region.invoke[Long, Double]("loadDouble", off)
-  }
-
-  def loadAddress(off: Code[Long]): Code[Long] = {
-    region.invoke[Long, Long]("loadAddress", off)
-  }
-
-  def loadBit(byteOff: Code[Long], bitOff: Code[Long]): Code[Boolean] = {
-    region.invoke[Long, Long, Boolean]("loadBit", byteOff, bitOff)
-  }
-
-  def loadBytes(off: Code[Long], n: Code[Int]): Code[Array[Byte]] = {
-    region.invoke[Long, Int, Array[Byte]]("loadBytes", off, n)
-  }
-
-  def loadIRIntermediate(typ: PType): Code[Long] => Code[_] = loadIRIntermediate(typ.virtualType)
-
-  def loadIRIntermediate(typ: Type): Code[Long] => Code[_] = typ.fundamentalType match {
-    case _: TBoolean => loadBoolean
-    case _: TInt32 => loadInt
-    case _: TInt64 => loadLong
-    case _: TFloat32 => loadFloat
-    case _: TFloat64 => loadDouble
-    case _: TArray => loadAddress
-    case _: TBinary => loadAddress
-    case _: TBaseStruct => off => off
-  }
-
-  def getIRIntermediate(typ: PType): Code[Long] => Code[_] = getIRIntermediate(typ.virtualType)
-
-  def getIRIntermediate(typ: Type): Code[Long] => Code[_] = typ.fundamentalType match {
-    case _: TBoolean => loadBoolean
-    case _: TInt32 => loadInt
-    case _: TInt64 => loadLong
-    case _: TFloat32 => loadFloat
-    case _: TFloat64 => loadDouble
-    case _ => off => off
   }
 
   def clear(): Code[Unit] = { region.invoke[Unit]("clear") }

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichCodeRegion.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichCodeRegion.scala
@@ -6,38 +6,6 @@ import is.hail.expr.types.physical.PType
 import is.hail.expr.types.virtual._
 
 class RichCodeRegion(val region: Code[Region]) extends AnyVal {
-  def storeBoolean(off: Code[Long], v: Code[Boolean]): Code[Unit] = {
-    region.invoke[Long, Boolean, Unit]("storeBoolean", off, v)
-  }
-
-  def storeInt(off: Code[Long], v: Code[Int]): Code[Unit] = {
-    region.invoke[Long,Int,Unit]("storeInt", off, v)
-  }
-
-  def storeLong(off: Code[Long], v: Code[Long]): Code[Unit] = {
-    region.invoke[Long,Long,Unit]("storeLong", off, v)
-  }
-
-  def storeFloat(off: Code[Long], v: Code[Float]): Code[Unit] = {
-    region.invoke[Long,Float,Unit]("storeFloat", off, v)
-  }
-
-  def storeDouble(off: Code[Long], v: Code[Double]): Code[Unit] = {
-    region.invoke[Long,Double,Unit]("storeDouble", off, v)
-  }
-
-  def storeAddress(off: Code[Long], a: Code[Long]): Code[Unit] = {
-    region.invoke[Long,Long,Unit]("storeAddress", off, a)
-  }
-
-  def storeByte(off: Code[Long], b: Code[Byte]): Code[Unit] = {
-    region.invoke[Long, Byte, Unit]("storeByte", off, b)
-  }
-
-  def storeBytes(off: Code[Long], bytes: Code[Array[Byte]]): Code[Unit] = {
-    region.invoke[Long, Array[Byte], Unit]("storeBytes", off, bytes)
-  }
-
   def allocate(alignment: Code[Long], n: Code[Long]): Code[Long] = {
     region.invoke[Long, Long, Long]("allocate", alignment, n)
   }
@@ -100,22 +68,6 @@ class RichCodeRegion(val region: Code[Region]) extends AnyVal {
     case _: TFloat32 => loadFloat
     case _: TFloat64 => loadDouble
     case _ => off => off
-  }
-
-  def setBit(byteOff: Code[Long], bitOff: Code[Long]): Code[Unit] = {
-    region.invoke[Long, Long, Unit]("setBit", byteOff, bitOff)
-  }
-
-  def setBit(byteOff: Code[Long], bitOff: Long): Code[Unit] = {
-    region.invoke[Long, Long, Unit]("setBit", byteOff, bitOff)
-  }
-
-  def clearBit(byteOff: Code[Long], bitOff: Code[Long]): Code[Unit] = {
-    region.invoke[Long, Long, Unit]("clearBit", byteOff, bitOff)
-  }
-
-  def storeBit(byteOff: Code[Long], bitOff: Code[Long], b: Code[Boolean]): Code[Unit] = {
-    region.invoke[Long, Long, Boolean, Unit]("setBit", byteOff, bitOff, b)
   }
 
   def clear(): Code[Unit] = { region.invoke[Unit]("clear") }

--- a/hail/src/main/scala/is/hail/variant/HardCallView.scala
+++ b/hail/src/main/scala/is/hail/variant/HardCallView.scala
@@ -50,7 +50,7 @@ final class ArrayGenotypeView(rvType: PStruct) {
 
   def getGT: Call = {
     val callOffset = tg.loadField(m, gOffset, gtIndex)
-    m.loadInt(callOffset)
+    Region.loadInt(callOffset)
   }
 
   def getGP(idx: Int): Double = {
@@ -60,7 +60,7 @@ final class ArrayGenotypeView(rvType: PStruct) {
       throw new ArrayIndexOutOfBoundsException(idx)
     assert(gpType.isElementDefined(m, gpOffset, idx))
     val elementOffset = gpType.elementOffset(gpOffset, length, idx)
-    m.loadDouble(elementOffset)
+    Region.loadDouble(elementOffset)
   }
 
   def getGPLength(): Int = {
@@ -120,7 +120,7 @@ final class HardCallView(rvType: PStruct, callField: String) {
   def getGT: Call = {
     assert(gtExists && gIsDefined)
     val callOffset = tg.loadField(m, gOffset, gtIndex)
-    m.loadInt(callOffset)
+    Region.loadInt(callOffset)
   }
 
   def getLength: Int = gsLength

--- a/hail/src/main/scala/is/hail/variant/RegionValueVariant.scala
+++ b/hail/src/main/scala/is/hail/variant/RegionValueVariant.scala
@@ -40,7 +40,7 @@ class RegionValueVariant(rowType: PStruct) extends View {
   }
 
   def position(): Int = {
-    region.loadInt(tl.loadField(region, locusOffset, 1))
+    Region.loadInt(tl.loadField(region, locusOffset, 1))
   }
 
   def alleles(): Array[String] = {

--- a/hail/src/test/scala/is/hail/annotations/RegionSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/RegionSuite.scala
@@ -5,34 +5,6 @@ import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.Test
 
 class RegionSuite extends TestNGSuite {
-  @Test def testRegionAppending() {
-    val buff = Region()
-
-    val addrA = buff.allocate(8, 8)
-    Region.storeLong(addrA, 124L)
-
-    val addrB = buff.allocate(1, 1)
-    Region.storeByte(addrB, 2.toByte)
-
-    val addrC = buff.allocate(1, 1)
-    Region.storeByte(addrC, 1.toByte)
-
-    val addrD = buff.allocate(1, 1)
-    Region.storeByte(addrD, 1.toByte)
-
-    val addrE = buff.allocate(4, 4)
-    Region.storeInt(addrE, 1234567)
-
-    val addrF = buff.allocate(4, 4)
-    Region.storeDouble(addrF, 1.1)
-
-    assert(Region.loadLong(addrA) == 124L)
-    assert(Region.loadByte(addrB) == 2)
-    assert(Region.loadByte(addrC) == 1)
-    assert(Region.loadByte(addrD) == 4)
-    assert(Region.loadInt(addrE) == 1234567)
-    assert(Region.loadDouble(addrF) == 1.1)
-  }
 
   @Test def testRegionSizes() {
     Region.smallScoped { region =>

--- a/hail/src/test/scala/is/hail/annotations/RegionSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/RegionSuite.scala
@@ -8,12 +8,23 @@ class RegionSuite extends TestNGSuite {
   @Test def testRegionAppending() {
     val buff = Region()
 
-    val addrA = buff.appendLong(124L)
-    val addrB = buff.appendByte(2)
-    val addrC = buff.appendByte(1)
-    val addrD = buff.appendByte(4)
-    val addrE = buff.appendInt(1234567)
-    val addrF = buff.appendDouble(1.1)
+    val addrA = buff.allocate(8, 8)
+    Region.storeLong(addrA, 124L)
+
+    val addrB = buff.allocate(1, 1)
+    Region.storeByte(addrB, 2.toByte)
+
+    val addrC = buff.allocate(1, 1)
+    Region.storeByte(addrC, 1.toByte)
+
+    val addrD = buff.allocate(1, 1)
+    Region.storeByte(addrD, 1.toByte)
+
+    val addrE = buff.allocate(4, 4)
+    Region.storeInt(addrE, 1234567)
+
+    val addrF = buff.allocate(4, 4)
+    Region.storeDouble(addrF, 1.1)
 
     assert(buff.loadLong(addrA) == 124L)
     assert(buff.loadByte(addrB) == 2)

--- a/hail/src/test/scala/is/hail/annotations/RegionSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/RegionSuite.scala
@@ -26,12 +26,12 @@ class RegionSuite extends TestNGSuite {
     val addrF = buff.allocate(4, 4)
     Region.storeDouble(addrF, 1.1)
 
-    assert(buff.loadLong(addrA) == 124L)
-    assert(buff.loadByte(addrB) == 2)
-    assert(buff.loadByte(addrC) == 1)
-    assert(buff.loadByte(addrD) == 4)
-    assert(buff.loadInt(addrE) == 1234567)
-    assert(buff.loadDouble(addrF) == 1.1)
+    assert(Region.loadLong(addrA) == 124L)
+    assert(Region.loadByte(addrB) == 2)
+    assert(Region.loadByte(addrC) == 1)
+    assert(Region.loadByte(addrD) == 4)
+    assert(Region.loadInt(addrE) == 1234567)
+    assert(Region.loadDouble(addrF) == 1.1)
   }
 
   @Test def testRegionSizes() {

--- a/hail/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
@@ -41,7 +41,11 @@ class StagedRegionValueSuite extends HailSuite {
 
     val region2 = Region()
     val rv2 = RegionValue(region2)
-    rv2.setOffset(region2.appendString(input))
+    val bytes = input.getBytes()
+    val boff = PBinary.allocate(region2, bytes.length)
+    Region.storeInt(boff, bytes.length)
+    Region.storeBytes(PBinary.bytesOffset(boff), bytes)
+    rv2.setOffset(boff)
 
     if (showRVInfo) {
       printRegion(region2, "string")
@@ -79,7 +83,8 @@ class StagedRegionValueSuite extends HailSuite {
 
     val region2 = Region()
     val rv2 = RegionValue(region2)
-    rv2.setOffset(region2.appendInt(input))
+    rv2.setOffset(region2.allocate(4, 4))
+    Region.storeInt(rv2.offset, input)
 
     if (showRVInfo) {
       printRegion(region2, "int")

--- a/hail/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
@@ -486,7 +486,7 @@ class StagedRegionValueSuite extends HailSuite {
 
           //clear old stuff
           val len = srcRegion.allocate(0) - src
-          srcRegion.storeBytes(src, Array.fill(len.toInt)(0.toByte))
+          Region.storeBytes(src, Array.fill(len.toInt)(0.toByte))
           newOff
         }
         SafeRow(t, region, copyOff)

--- a/hail/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/StagedRegionValueSuite.scala
@@ -92,7 +92,7 @@ class StagedRegionValueSuite extends HailSuite {
     }
 
     assert(rv.pretty(rt) == rv2.pretty(rt))
-    assert(rv.region.loadInt(rv.offset) == rv2.region.loadInt(rv2.offset))
+    assert(Region.loadInt(rv.offset) == Region.loadInt(rv2.offset))
   }
 
   @Test
@@ -131,8 +131,8 @@ class StagedRegionValueSuite extends HailSuite {
 
     assert(rt.loadLength(rv.region, rv.offset) == 1)
     assert(rv.pretty(rt) == rv2.pretty(rt))
-    assert(rv.region.loadInt(rt.loadElement(rv.region, rv.offset, 0)) ==
-      rv2.region.loadInt(rt.loadElement(rv2.region, rv2.offset, 0)))
+    assert(Region.loadInt(rt.loadElement(rv.region, rv.offset, 0)) ==
+      Region.loadInt(rt.loadElement(rv2.region, rv2.offset, 0)))
   }
 
   @Test
@@ -173,8 +173,8 @@ class StagedRegionValueSuite extends HailSuite {
     assert(rv.pretty(rt) == rv2.pretty(rt))
     assert(PString.loadString(rv.region, rt.loadField(rv.region, rv.offset, 0)) ==
       PString.loadString(rv2.region, rt.loadField(rv2.region, rv2.offset, 0)))
-    assert(rv.region.loadInt(rt.loadField(rv.region, rv.offset, 1)) ==
-      rv2.region.loadInt(rt.loadField(rv2.region, rv2.offset, 1)))
+    assert(Region.loadInt(rt.loadField(rv.region, rv.offset, 1)) ==
+      Region.loadInt(rt.loadField(rv2.region, rv2.offset, 1)))
   }
 
   @Test
@@ -313,10 +313,10 @@ class StagedRegionValueSuite extends HailSuite {
     rv2.setOffset(rvb2.end())
 
     assert(rv.pretty(rt) == rv2.pretty(rt))
-    assert(rv.region.loadInt(rt.loadField(rv.region, rv.offset, 0)) ==
-      rv2.region.loadInt(rt.loadField(rv2.region, rv2.offset, 0)))
-    assert(rv.region.loadDouble(rt.loadField(rv.region, rv.offset, 2)) ==
-      rv2.region.loadDouble(rt.loadField(rv2.region, rv2.offset, 2)))
+    assert(Region.loadInt(rt.loadField(rv.region, rv.offset, 0)) ==
+      Region.loadInt(rt.loadField(rv2.region, rv2.offset, 0)))
+    assert(Region.loadDouble(rt.loadField(rv.region, rv.offset, 2)) ==
+      Region.loadDouble(rt.loadField(rv2.region, rv2.offset, 2)))
   }
 
   @Test
@@ -453,9 +453,9 @@ class StagedRegionValueSuite extends HailSuite {
     val f = fb.result()()
     def run(i: Int, b: Boolean, d: Double): (Int, Boolean, Double) = {
       val off = f(region, i, b, d)
-      (region.loadInt(t.loadField(region, off, 0)),
-        region.loadBoolean(t.loadField(region, off, 1)),
-        region.loadDouble(t.loadField(region, off, 2)))
+      (Region.loadInt(t.loadField(region, off, 0)),
+        Region.loadBoolean(t.loadField(region, off, 1)),
+        Region.loadDouble(t.loadField(region, off, 2)))
     }
 
     assert(run(3, true, 42.0) == ((3, true, 42.0)))

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -239,7 +239,7 @@ class OrderingSuite extends HailSuite {
         val cetuple = fb.getArg[Long](3)
 
         val bs = new BinarySearch(fb.apply_method, pset, keyOnly = false)
-        fb.emit(bs.getClosestIndex(cset, false, cregion.loadIRIntermediate(t)(pTuple.fieldOffset(cetuple, 0))))
+        fb.emit(bs.getClosestIndex(cset, false, Region.loadIRIntermediate(pt)(pTuple.fieldOffset(cetuple, 0))))
 
         val asArray = SafeIndexedSeq(pArray, region, soff)
 
@@ -280,7 +280,7 @@ class OrderingSuite extends HailSuite {
 
         val bs = new BinarySearch(fb.apply_method, pDict, keyOnly = true)
         val m = ptuple.isFieldMissing(cregion, cktuple, 0)
-        val v = cregion.loadIRIntermediate(pDict.keyType)(ptuple.fieldOffset(cktuple, 0))
+        val v = Region.loadIRIntermediate(pDict.keyType)(ptuple.fieldOffset(cktuple, 0))
         fb.emit(bs.getClosestIndex(cdict, m, v))
 
         val asArray = SafeIndexedSeq(PArray(pDict.elementType), region, soff)

--- a/hail/src/test/scala/is/hail/expr/ir/TakeByAggregatorSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TakeByAggregatorSuite.scala
@@ -17,6 +17,7 @@ class TakeByAggregatorSuite extends HailSuite {
         val argR = fb.getArg[Region](1).load()
         val i = fb.newField[Long]
         val off = fb.newField[Long]
+        val bytes = fb.newField[Array[Byte]]
         val rt = tba.resultType
 
         fb.emit(Code(
@@ -26,10 +27,11 @@ class TakeByAggregatorSuite extends HailSuite {
           i := 0L,
           Code.whileLoop(i < n.toLong,
             argR.invoke[Unit]("clear"),
-            off := argR.appendBinary(const("str").concat(i.toS).invoke[Array[Byte]]("getBytes")),
+            bytes := const("str").concat(i.toS).invoke[Array[Byte]]("getBytes"),
+            off := PBinary.allocate(argR, bytes.length()),
+            PBinary.store(off, bytes),
             tba.seqOp(false, off, false, -i),
-            i := i + 1L
-          ),
+            i := i + 1L),
           tba.result(argR, rt)
         ))
 

--- a/hail/src/test/scala/is/hail/methods/LocalLDPruneSuite.scala
+++ b/hail/src/test/scala/is/hail/methods/LocalLDPruneSuite.scala
@@ -323,34 +323,6 @@ class LocalLDPruneSuite extends HailSuite {
     Spec.check()
   }
 
-  @Test def bitPackedVectorCorrectWhenOffsetNotZero() {
-    Region.scoped { r =>
-      val rvb = new RegionValueBuilder(r)
-      val t = BitPackedVectorView.rvRowPType(
-        +PLocus(ReferenceGenome.GRCh37),
-        +PArray(+PString()))
-      val bpv = new BitPackedVectorView(t)
-      r.appendInt(0xbeef)
-      rvb.start(t)
-      rvb.startStruct()
-      rvb.startStruct()
-      rvb.addString("X")
-      rvb.addInt(42)
-      rvb.endStruct()
-      rvb.startArray(0)
-      rvb.endArray()
-      rvb.startArray(0)
-      rvb.endArray()
-      rvb.addInt(0)
-      rvb.addDouble(0.0)
-      rvb.addDouble(0.0)
-      rvb.endStruct()
-      bpv.setRegion(r, rvb.end())
-      assert(bpv.getContig == "X")
-      assert(bpv.getStart == 42)
-    }
-  }
-
   @Test def testIsLocallyUncorrelated() {
     val locallyPrunedVariantsTable = LocalLDPrune(vds, r2Threshold = 0.2, windowSize = 1000000, maxQueueSize = maxQueueSize)
     assert(isLocallyUncorrelated(vds, locallyPrunedVariantsTable, 0.2, 1000000))

--- a/hail/src/test/scala/is/hail/nativecode/package.scala
+++ b/hail/src/test/scala/is/hail/nativecode/package.scala
@@ -16,14 +16,14 @@ final class PackEncoder(rowType: PType, out: OutputBuffer) extends Encoder {
   def writeByte(b: Byte): Unit = out.writeByte(b)
 
   def writeBinary(region: Region, offset: Long) {
-    val boff = region.loadAddress(offset)
-    val length = region.loadInt(boff)
+    val boff = Region.loadAddress(offset)
+    val length = Region.loadInt(boff)
     out.writeInt(length)
     out.writeBytes(region, boff + 4, length)
   }
 
   def writeArray(t: PArray, region: Region, aoff: Long) {
-    val length = region.loadInt(aoff)
+    val length = Region.loadInt(aoff)
 
     out.writeInt(length)
     if (!t.elementType.required) {
@@ -38,7 +38,7 @@ final class PackEncoder(rowType: PType, out: OutputBuffer) extends Encoder {
       while (i < length) {
         if (t.isElementDefined(region, aoff, i)) {
           val off = elemsOff + i * elemSize
-          out.writeInt(region.loadInt(off))
+          out.writeInt(Region.loadInt(off))
         }
         i += 1
       }
@@ -49,11 +49,11 @@ final class PackEncoder(rowType: PType, out: OutputBuffer) extends Encoder {
           val off = elemsOff + i * elemSize
           t.elementType match {
             case t2: PBaseStruct => writeBaseStruct(t2, region, off)
-            case t2: PArray => writeArray(t2, region, region.loadAddress(off))
-            case _: PBoolean => out.writeBoolean(region.loadByte(off) != 0)
-            case _: PInt64 => out.writeLong(region.loadLong(off))
-            case _: PFloat32 => out.writeFloat(region.loadFloat(off))
-            case _: PFloat64 => out.writeDouble(region.loadDouble(off))
+            case t2: PArray => writeArray(t2, region, Region.loadAddress(off))
+            case _: PBoolean => out.writeBoolean(Region.loadByte(off) != 0)
+            case _: PInt64 => out.writeLong(Region.loadLong(off))
+            case _: PFloat32 => out.writeFloat(Region.loadFloat(off))
+            case _: PFloat64 => out.writeDouble(Region.loadDouble(off))
             case _: PBinary => writeBinary(region, off)
           }
         }
@@ -73,12 +73,12 @@ final class PackEncoder(rowType: PType, out: OutputBuffer) extends Encoder {
         val off = offset + t.byteOffsets(i)
         t.types(i) match {
           case t2: PBaseStruct => writeBaseStruct(t2, region, off)
-          case t2: PArray => writeArray(t2, region, region.loadAddress(off))
-          case _: PBoolean => out.writeBoolean(region.loadByte(off) != 0)
-          case _: PInt32 => out.writeInt(region.loadInt(off))
-          case _: PInt64 => out.writeLong(region.loadLong(off))
-          case _: PFloat32 => out.writeFloat(region.loadFloat(off))
-          case _: PFloat64 => out.writeDouble(region.loadDouble(off))
+          case t2: PArray => writeArray(t2, region, Region.loadAddress(off))
+          case _: PBoolean => out.writeBoolean(Region.loadByte(off) != 0)
+          case _: PInt32 => out.writeInt(Region.loadInt(off))
+          case _: PInt64 => out.writeLong(Region.loadLong(off))
+          case _: PFloat32 => out.writeFloat(Region.loadFloat(off))
+          case _: PFloat64 => out.writeDouble(Region.loadDouble(off))
           case _: PBinary => writeBinary(region, off)
         }
       }


### PR DESCRIPTION
This consisted almost entirely of `region` -> `Region`. I had to rewrite some things to replace `appendBinary` and `appendString`, but there shouldn't be any other substantive changes in here.