### PR TITLE
Fix typo installation docs

### DIFF
--- a/hail/python/hail/docs/getting_started.rst
+++ b/hail/python/hail/docs/getting_started.rst
@@ -55,7 +55,7 @@ Create a `conda enviroment
 
 .. code-block:: sh
 
-    conda create -n hail python=3.6
+    conda create -n hail python\>=3.6
     conda activate hail
     pip3 install hail
 

--- a/hail/python/hail/docs/getting_started.rst
+++ b/hail/python/hail/docs/getting_started.rst
@@ -55,7 +55,7 @@ Create a `conda enviroment
 
 .. code-block:: sh
 
-    conda create -n hail python==3.6
+    conda create -n hail python=3.6
     conda activate hail
     pip3 install hail
 


### PR DESCRIPTION
I believe `conda create -n hail python==3.6` should only use `=`.