### PR TITLE
Use pip, not pip3, to install hail

### DIFF
--- a/hail/python/hail/docs/getting_started.rst
+++ b/hail/python/hail/docs/getting_started.rst
@@ -57,7 +57,7 @@ Create a `conda enviroment
 
     conda create -n hail python\>=3.6
     conda activate hail
-    pip3 install hail
+    pip install hail
 
 To try Hail out, open iPython or a Jupyter notebook and run:
 


### PR DESCRIPTION
When the conda env is created with `python>=3.6` there will not be a `pip3` alias created; as long as the env is activated, `pip` will work correctly.