### PR TITLE
UI tweaking

### DIFF
--- a/batch/batch/templates/batch.html
+++ b/batch/batch/templates/batch.html
@@ -16,7 +16,7 @@
     <table class="data-table" id="batch">
       <thead>
         <tr>
-          <th>ID</th>
+          <th class="numeric-cell">ID</th>
           <th>Name</th>
           <th>State</th>
           <th>Exit Code</th>
@@ -28,7 +28,7 @@
       <tbody>
         {% for job in batch['jobs'] %}
         <tr>
-          <td>{{ job['job_id'] }}</td>
+          <td class="numeric-cell">{{ job['job_id'] }}</td>
           <td>
             {% if 'attributes' in job and 'name' in job['attributes'] and job['attributes']['name'] is not none %}
             {{ job['attributes']['name'] }}

--- a/batch/batch/templates/batch.html
+++ b/batch/batch/templates/batch.html
@@ -16,7 +16,7 @@
     <table class="data-table" id="batch">
       <thead>
         <tr>
-          <th class="numeric-cell">ID</th>
+          <th>ID</th>
           <th>Name</th>
           <th>State</th>
           <th>Exit Code</th>

--- a/batch/batch/templates/batch.html
+++ b/batch/batch/templates/batch.html
@@ -13,7 +13,7 @@
   <h2>Jobs</h2>
   <div class="searchbar-table">
     <input size=30 type="text" id="searchBar" onkeyup="searchTable('batch', 'searchBar')" placeholder="Search terms...">
-    <table style="min-width:480px;" id="batch">
+    <table class="data-table" id="batch">
       <thead>
         <tr>
           <th>ID</th>

--- a/batch/batch/templates/batches.html
+++ b/batch/batch/templates/batches.html
@@ -10,7 +10,7 @@
     <table class="data-table" id="batches">
       <thead>
         <tr>
-          <th>ID</th>
+          <th class="numeric-cell">ID</th>
           <th>Name</th>
           <th>State</th>
         </tr>
@@ -18,7 +18,7 @@
       <tbody>
         {% for batch in batch_list %}
         <tr>
-          <td><a href="{{ base_path }}/batches/{{ batch['id'] }}">{{ batch['id'] }}</a></td>
+          <td class="numeric-cell"><a href="{{ base_path }}/batches/{{ batch['id'] }}">{{ batch['id'] }}</a></td>
           <td>
             {% if 'attributes' in batch and 'name' in batch['attributes'] and batch['attributes']['name'] is not none %}
             {{ batch['attributes']['name'] }}

--- a/batch/batch/templates/batches.html
+++ b/batch/batch/templates/batches.html
@@ -10,7 +10,7 @@
     <table class="data-table" id="batches">
       <thead>
         <tr>
-          <th class="numeric-cell">ID</th>
+          <th>ID</th>
           <th>Name</th>
           <th>State</th>
         </tr>

--- a/batch/batch/templates/batches.html
+++ b/batch/batch/templates/batches.html
@@ -7,7 +7,7 @@
   <h1>Batches</h1>
   <div class="searchbar-table">
     <input size=30 type="text" id="searchBar" onkeyup="searchTable('batches', 'searchBar')" placeholder="Search terms...">
-    <table style="min-width:480px;" id="batches">
+    <table class="data-table" id="batches">
       <thead>
         <tr>
           <th>ID</th>

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -125,7 +125,8 @@ async def get_pr(request, userdata):  # pylint: disable=unused-argument
                 if 'link' in attrs:
                     attrs['link'] = attrs['link'].split(',')
             config['batch'] = status
-            config['artifacts'] = f'{BUCKET}/build/{pr.batch.attributes["token"]}'
+            # [4:] strips off gs:/
+            config['artifacts'] = f'{BUCKET}/build/{pr.batch.attributes["token"]}'[4:]
         else:
             config['exception'] = '\n'.join(
                 traceback.format_exception(None, pr.batch.exception, pr.batch.exception.__traceback__))

--- a/ci/ci/templates/batch.html
+++ b/ci/ci/templates/batch.html
@@ -11,22 +11,22 @@
     <table class="data-table">
       <thead>
         <tr>
-          <th align="right">id</th>
-          <th align="left">name</th>
-          <th align="left">state</th>
-          <th align="right">exit_code</th>
-          <th align="right">duration</th>
-          <th align="left">log</th>
-          <th align="left">pod status</th>
+          <th class="numeric-cell">id</th>
+          <th>name</th>
+          <th>state</th>
+          <th>exit_code</th>
+          <th>duration</th>
+          <th>log</th>
+          <th>pod status</th>
         </tr>
       </thead>
       <tbody>
         {% for job in batch['jobs'] %}
         <tr>
-          <td align="right">{{ job['job_id'] }}</td>
-          <td align="left">{{ job['attributes']['name'] }}</td>
-          <td align="left">{{ job['state'] }}</td>
-          <td align="right">
+          <td class="numeric-cell">{{ job['job_id'] }}</td>
+          <td>{{ job['attributes']['name'] }}</td>
+          <td>{{ job['state'] }}</td>
+          <td>
             {% if 'exit_code' in job and job['exit_code'] is not none %}
             {% if job['exit_code'] == 0 %}
             <span style="color: #55aa33;">
@@ -39,15 +39,15 @@
               </span>
               {% endif %}
           </td>
-          <td align="right">
+          <td>
             {% if 'duration' in job and job['duration'] %}
             {{ job['duration'] }}
             {% endif %}
           </td>
-          <td align="left">
+          <td>
             <a href="/batches/{{ job['batch_id'] }}/jobs/{{ job['job_id'] }}/log">log</a>
           </td>
-          <td align="left">
+          <td>
             <a href="/batches/{{ job['batch_id'] }}/jobs/{{ job['job_id'] }}/pod_status">pod_status</a>
           </td>
         </tr>

--- a/ci/ci/templates/batch.html
+++ b/ci/ci/templates/batch.html
@@ -3,10 +3,12 @@
 {% block content %}
     <h1>Batch {{ batch['id'] }}</h1>
     {% if 'attributes' in batch %}
-    {% for name, value in batch['attributes'].items() %}
-    <div>{{ name }}: {{ value }}</div>
-    {% endfor %}
-    {% endif %}
+    <div class="attributes">
+      {% for name, value in batch['attributes'].items() %}
+      <div>{{ name }}: {{ value }}</div>
+      {% endfor %}
+      {% endif %}
+    </div>
     <h2>Jobs</h2>
     <table class="data-table">
       <thead>

--- a/ci/ci/templates/batch.html
+++ b/ci/ci/templates/batch.html
@@ -8,7 +8,7 @@
     {% endfor %}
     {% endif %}
     <h2>Jobs</h2>
-    <table>
+    <table class="data-table">
       <thead>
         <tr>
           <th align="right">id</th>

--- a/ci/ci/templates/batch.html
+++ b/ci/ci/templates/batch.html
@@ -4,7 +4,7 @@
     <h1>Batch {{ batch['id'] }}</h1>
     {% if 'attributes' in batch %}
     {% for name, value in batch['attributes'].items() %}
-    <p>{{ name }}: {{ value }}</p>
+    <div>{{ name }}: {{ value }}</div>
     {% endfor %}
     {% endif %}
     <h2>Jobs</h2>

--- a/ci/ci/templates/batch.html
+++ b/ci/ci/templates/batch.html
@@ -11,7 +11,7 @@
     <table class="data-table">
       <thead>
         <tr>
-          <th class="numeric-cell">id</th>
+          <th>id</th>
           <th>name</th>
           <th>state</th>
           <th>exit_code</th>

--- a/ci/ci/templates/batches.html
+++ b/ci/ci/templates/batches.html
@@ -3,7 +3,7 @@
 {% block content %}
     <h1>Batches</h1>
     {% if batches %}
-    <table>
+    <table class="data-table">
       <thead>
         <tr>
           <th align="right">id</th>

--- a/ci/ci/templates/batches.html
+++ b/ci/ci/templates/batches.html
@@ -6,7 +6,7 @@
     <table class="data-table">
       <thead>
         <tr>
-          <th class="numeric-cell">id</th>
+          <th>id</th>
           <th>type</th>
           <th>state</th>
         </tr>

--- a/ci/ci/templates/batches.html
+++ b/ci/ci/templates/batches.html
@@ -6,17 +6,18 @@
     <table class="data-table">
       <thead>
         <tr>
-          <th align="right">id</th>
-          <th align="left">type</th>
-          <th align="left">state</th>
+          <th class="numeric-cell">id</th>
+          <th>type</th>
+          <th>state</th>
         </tr>
       </thead>
       <tbody>
 	{% for batch in batches %}
         <tr>
-          <td align="right">
-            <a href="/batches/{{ batch['id'] }}">{{ batch['id'] }}</a></td>
-          <td align="left">
+          <td class="numeric-cell">
+            <a href="/batches/{{ batch['id'] }}">{{ batch['id'] }}</a>
+          </td>
+          <td>
             {% if 'attributes' in batch %}
             {% if 'deploy' in batch['attributes'] %}
             deploy
@@ -27,7 +28,7 @@
             {% endif %}
             {% endif %}
           </td>
-          <td align="left">
+          <td>
             {% if 'state' in batch and batch['state'] %}
             {{ batch['state'] }}
             {% endif %}

--- a/ci/ci/templates/index.html
+++ b/ci/ci/templates/index.html
@@ -30,7 +30,7 @@
     {% if wb.prs|length > 0 %}
     <div class="searchbar-table">
       <input size=30 type="text" id="searchBar" onkeyup="searchTable()" placeholder="Search terms...">
-      <table id="statuses">
+      <table class="data-table">
         <thead>
           <tr>
             <th align="left">Number</th>

--- a/ci/ci/templates/index.html
+++ b/ci/ci/templates/index.html
@@ -7,23 +7,24 @@
     <h1>CI</h1>
     {% for wb in watched_branches %}
     <h2>{{ wb.branch }}</h2>
-    <p>SHA:
-      {% if wb.sha is not none %}
-      {{ wb.sha }}
-      {% else %}
-      unknown
-      {% endif %}
-    </p>
-    <p>Deploy State:
-      {% if wb.deploy_state is not none %}
-      {{ wb.deploy_state }}
-      {% endif %}
-    </p>
-    <p>Deploy Batch:
+    <div>
+      <div>SHA:
+	{% if wb.sha is not none %}
+	{{ wb.sha }}
+	{% else %}
+	unknown
+	{% endif %}
+      </div>
+      <div>Deploy State:
+	{% if wb.deploy_state is not none %}
+	{{ wb.deploy_state }}
+	{% endif %}
+      </div>
+    <div>Deploy Batch:
       {% if wb.deploy_batch_id is not none %}
       <a href="/batches/{{ wb.deploy_batch_id }}">{{ wb.deploy_batch_id }}</a>
       {% endif %}
-    </p>
+    </div>
 
     <h2>PRs</h2>
     {% if wb.prs is not none %}

--- a/ci/ci/templates/index.html
+++ b/ci/ci/templates/index.html
@@ -31,7 +31,7 @@
     {% if wb.prs is not none %}
     {% if wb.prs|length > 0 %}
     <div class="searchbar-table">
-      <input size=30 type="text" id="searchBar" onkeyup="searchTable('prs', 'searchBar')" placeholder="Search terms...">
+      <input type="text" id="searchBar" onkeyup="searchTable('prs', 'searchBar')" placeholder="Search terms...">
       <table id="prs" class="data-table">
         <thead>
           <tr>

--- a/ci/ci/templates/index.html
+++ b/ci/ci/templates/index.html
@@ -6,8 +6,8 @@
 {% block content %}
     <h1>CI</h1>
     {% for wb in watched_branches %}
-    <h2>{{ wb.branch }}</h2>
-    <div>
+    <h2 class="stacked-header">{{ wb.branch }}</h2>
+    <div class="attributes">
       <div>SHA:
 	{% if wb.sha is not none %}
 	{{ wb.sha }}
@@ -20,10 +20,11 @@
 	{{ wb.deploy_state }}
 	{% endif %}
       </div>
-    <div>Deploy Batch:
-      {% if wb.deploy_batch_id is not none %}
-      <a href="/batches/{{ wb.deploy_batch_id }}">{{ wb.deploy_batch_id }}</a>
-      {% endif %}
+      <div>Deploy Batch:
+	{% if wb.deploy_batch_id is not none %}
+	<a href="/batches/{{ wb.deploy_batch_id }}">{{ wb.deploy_batch_id }}</a>
+	{% endif %}
+      </div>
     </div>
 
     <h2>PRs</h2>
@@ -45,7 +46,7 @@
           <tr>
             <td>
               <a href="https://github.com/{{ wb.repo }}/pull/{{ pr.number }}">
-                {{ pr.title }} <span class="gh-number">{{ pr.number }}</a>
+                {{ pr.title }} <span class="gh-number">#{{ pr.number }}</a>
               </a>
             </td>
             <td>

--- a/ci/ci/templates/index.html
+++ b/ci/ci/templates/index.html
@@ -29,29 +29,25 @@
     {% if wb.prs is not none %}
     {% if wb.prs|length > 0 %}
     <div class="searchbar-table">
-      <input size=30 type="text" id="searchBar" onkeyup="searchTable()" placeholder="Search terms...">
-      <table class="data-table">
+      <input size=30 type="text" id="searchBar" onkeyup="searchTable('prs', 'searchBar')" placeholder="Search terms...">
+      <table id="prs" class="data-table">
         <thead>
           <tr>
-            <th align="left">Number</th>
-            <th align="left">Title</th>
-            <th align="left">Build State</th>
-            <th align="left">Review State</th>
-            <th align="left">Author</th>
+            <th>PR</th>
+            <th>Build State</th>
+            <th>Review State</th>
+            <th>Author</th>
           </tr>
         </thead>
         <tbody>
           {% for pr in wb.prs %}
           <tr>
-            <td align="left">
+            <td>
               <a href="https://github.com/{{ wb.repo }}/pull/{{ pr.number }}">
-                {{ pr.number }}
+                {{ pr.title }} <span class="gh-number">{{ pr.number }}</a>
               </a>
             </td>
-            <td align="left">
-              {{ pr.title }}
-            </td>
-            <td align="left">
+            <td>
               {% if pr.build_state is not none %}
                 <a href="/watched_branches/{{ wb.index }}/pr/{{ pr.number }}">{{ pr.build_state }}</a>
               {% else %}
@@ -61,12 +57,12 @@
                 *
               {% endif %}
             </td>
-            <td align="left">
+            <td>
               {% if pr.review_state %}
               {{ pr.review_state }}
               {% endif %}
             </td>
-            <td align="left">
+            <td>
               {{ pr.author }}
             </td>
           </tr>

--- a/ci/ci/templates/job_log.html
+++ b/ci/ci/templates/job_log.html
@@ -3,7 +3,7 @@
 {% block content %}
     <h1>Job {{ job_id }} Log</h1>
     {% if 'setup' in job_log %}
-    <h2>Setup</h2>
+    <h2 class="stacked-header">Setup</h2>
     <pre>{{ job_log['setup'] }}</pre>
     {% endif %}
 

--- a/ci/ci/templates/pr.html
+++ b/ci/ci/templates/pr.html
@@ -5,7 +5,7 @@
     {% if batch is defined %}
     <h2>Batch {{ batch['id'] }} Jobs</h2>
     <p>artifacts: {{ artifacts }}</p>
-    <table>
+    <table class="data-table">
       <thead>
         <tr>
           <th align="right">id</th>
@@ -70,7 +70,7 @@
 
     <h2>Build History</h2>
     {% if history %}
-    <table>
+    <table class="data-table">
       <thead>
         <tr>
           <th align="right">id</th>

--- a/ci/ci/templates/pr.html
+++ b/ci/ci/templates/pr.html
@@ -4,7 +4,7 @@
     <h1>PR {{ number }}</h1>
     {% if batch is defined %}
     <h2>Batch {{ batch['id'] }} Jobs</h2>
-    <p>artifacts: {{ artifacts }}</p>
+    <div>artifacts: {{ artifacts }}</div>
     <table class="data-table">
       <thead>
         <tr>

--- a/ci/ci/templates/pr.html
+++ b/ci/ci/templates/pr.html
@@ -4,27 +4,29 @@
     <h1>PR {{ number }}</h1>
     {% if batch is defined %}
     <h2>Batch {{ batch['id'] }} Jobs</h2>
-    <div>artifacts: {{ artifacts }}</div>
+    <div class="attributes">
+      <div>artifacts: {{ artifacts }}</div>
+    </div>
     <table class="data-table">
       <thead>
         <tr>
-          <th align="right">id</th>
-          <th align="left">name</th>
-          <th align="left">state</th>
-          <th align="right">exit_code</th>
-          <th align="right">duration</th>
-          <th align="left">log</th>
-          <th align="left">pod status</th>
-          <th align="left">links</th>
+          <th>id</th>
+          <th>name</th>
+          <th>state</th>
+          <th>exit_code</th>
+          <th>duration</th>
+          <th>log</th>
+          <th>pod status</th>
+          <th>links</th>
         </tr>
       </thead>
       <tbody>
         {% for job in batch['jobs'] %}
         <tr>
-          <td align="right">{{ job['job_id'] }}</td>
-          <td align="left">{{ job['attributes']['name'] }}</td>
-          <td align="left">{{ job['state'] }}</td>
-          <td align="right">
+          <td>{{ job['job_id'] }}</td>
+          <td>{{ job['attributes']['name'] }}</td>
+          <td>{{ job['state'] }}</td>
+          <td>
             {% if 'exit_code' in job and job['exit_code'] is not none %}
             {% if job['exit_code'] == 0 %}
             <span style="color: #55aa33;">
@@ -37,15 +39,15 @@
               </span>
               {% endif %}
           </td>
-          <td align="right">
+          <td>
             {% if 'duration' in job and job['duration'] %}
             {{ job['duration'] }}
             {% endif %}
           </td>
-          <td align="left">
+          <td>
             <a href="/batches/{{ job['batch_id'] }}/jobs/{{ job['job_id'] }}/log">log</a>
           </td>
-          <td align="left">
+          <td>
             <a href="/batches/{{ job['batch_id'] }}/jobs/{{ job['job_id'] }}/pod_status">pod_status</a>
           </td>
           <td>
@@ -73,17 +75,17 @@
     <table class="data-table">
       <thead>
         <tr>
-          <th align="right">id</th>
-          <th align="left">state</th>
+          <th>id</th>
+          <th>state</th>
         </tr>
       </thead>
       <tbody>
         {% for batch in history %}
         <tr>
-          <td align="right">
+          <td>
             <a href="/batches/{{ batch['id'] }}">{{ batch['id'] }}</a>
           </td>
-          <td align="left">
+          <td>
             {% if 'state' in batch and batch['state'] %}
             {{ batch['state'] }}
             {% endif %}

--- a/ci/ci/templates/pr.html
+++ b/ci/ci/templates/pr.html
@@ -3,10 +3,16 @@
 {% block content %}
     <h1>PR {{ number }}</h1>
     {% if batch is defined %}
-    <h2>Batch {{ batch['id'] }} Jobs</h2>
     <div class="attributes">
-      <div>artifacts: {{ artifacts }}</div>
+      <div>batch: <a href="{{ base_path }}/batches/{{ batch['id'] }}">{{ batch['id'] }}</a></div>
+      <div>artifacts:
+	<a  target="_blank" href="https://console.cloud.google.com/storage/browser{{ artifacts }}">gs:/{{ artifacts }}</a><i class="material-icons text-icon">open_in_new</i>
+      </div>
+      {% for name, value in batch['attributes'].items() %}
+      <div>{{ name }}: {{ value }}</div>
+      {% endfor %}
     </div>
+    <h2>Jobs</h2>
     <table class="data-table">
       <thead>
         <tr>
@@ -23,7 +29,7 @@
       <tbody>
         {% for job in batch['jobs'] %}
         <tr>
-          <td>{{ job['job_id'] }}</td>
+          <td class="numeric-cell">{{ job['job_id'] }}</td>
           <td>{{ job['attributes']['name'] }}</td>
           <td>{{ job['state'] }}</td>
           <td>
@@ -82,7 +88,7 @@
       <tbody>
         {% for batch in history %}
         <tr>
-          <td>
+          <td class="numeric-cell">
             <a href="/batches/{{ batch['id'] }}">{{ batch['id'] }}</a>
           </td>
           <td>

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,5 +1,5 @@
-.PHONY:
-build: build-stmp
+.PHONY: build
+build: base-stmp service-base
 
 PROJECT := $(shell gcloud config get-value project)
 
@@ -9,14 +9,17 @@ BASE_IMAGE = gcr.io/$(PROJECT)/base:$(shell docker images -q --no-trunc base:lat
 SERVICE_BASE_LATEST = gcr.io/$(PROJECT)/service-base:latest
 SERVICE_BASE_IMAGE = gcr.io/$(PROJECT)/service-base:$(shell docker images -q --no-trunc service-base:latest | sed -e 's,[^:]*:,,')
 
-build-stmp: Dockerfile.base core-site.xml requirements.txt
+base-stmp: Dockerfile.base core-site.xml requirements.txt ../pylintrc ../setup.cfg
 	-docker pull ubuntu:18.04
 	-docker pull $(BASE_LATEST)
 	docker build -t base -f Dockerfile.base --cache-from base,$(BASE_LATEST),ubuntu:18.04 ..
+	touch base-stmp
+
+.PHONY: service-base
+service-base:
 	-docker pull $(SERVICE_BASE_LATEST)
 	python3 ../ci/jinja2_render.py '{"base_image":{"image":"base"}}' Dockerfile.service-base Dockerfile.service-base.out
 	docker build -t service-base -f Dockerfile.service-base.out --cache-from service-base,$(SERVICE_BASE_LATEST),base ..
-	touch build-stmp
 
 .PHONY: push
 push: build

--- a/notebook2/notebook/notebook.py
+++ b/notebook2/notebook/notebook.py
@@ -137,7 +137,7 @@ def container_status_for_ui(container_statuses):
     state = container_statuses[0].state
 
     if state.running:
-        return {"running": {"started_at": state.running.started_at.strftime("%Y-%m-%-d %H:%M:%S")}
+        return {"running": {"started_at": state.running.started_at.strftime("%Y-%m-%-d %H:%M:%S")}}
 
     if state.waiting:
         return {"waiting": {"reason": state.waiting.reason}}

--- a/notebook2/notebook/notebook.py
+++ b/notebook2/notebook/notebook.py
@@ -137,7 +137,7 @@ def container_status_for_ui(container_statuses):
     state = container_statuses[0].state
 
     if state.running:
-        return {"running": {"started_at": str(state.running.started_at)}}
+        return {"running": {"started_at": state.running.started_at.strftime("%Y-%m-%-d %H:%M:%S")}
 
     if state.waiting:
         return {"waiting": {"reason": state.waiting.reason}}
@@ -145,8 +145,8 @@ def container_status_for_ui(container_statuses):
     if state.terminated:
         return {"terminated": {
             "exit_code": state.terminated.exit_code,
-            "finished_at": str(state.terminated.finished_at),
-            "started_at": str(state.terminated.started_at),
+            "finished_at": state.terminated.finished_at.strftime("%Y-%m-%-d %H:%M:%S"),
+            "started_at": state.terminated.started_at.strftime("%Y-%m-%-d %H:%M:%S"),
             "reason": state.terminated.reason
         }}
 
@@ -177,7 +177,7 @@ def pod_to_ui_dict(pod):
         'pod_status': pod.status.phase,
         'pod_uuid': pod.metadata.labels['uuid'],
         'pod_ip': pod.status.pod_ip,
-        'creation_date': str(pod.metadata.creation_timestamp),
+        'creation_date': pod.metadata.creation_timestamp.strftime("%Y-%m-%-d %H:%M:%S"),
         'jupyter_token': pod.metadata.labels['jupyter-token'],
         'container_status': container_status_for_ui(pod.status.container_statuses),
         'condition': pod_condition_for_ui(pod.status.conditions)

--- a/notebook2/notebook/styles/pages/notebook.scss
+++ b/notebook2/notebook/styles/pages/notebook.scss
@@ -5,6 +5,7 @@
     flex-direction: column;
 
     .nb {
+        color: $black;
         display: flex;
         align-items: center;
         justify-content: space-around;

--- a/notebook2/notebook/styles/pages/notebook.scss
+++ b/notebook2/notebook/styles/pages/notebook.scss
@@ -5,7 +5,6 @@
     flex-direction: column;
 
     .nb {
-        color: $black;
         display: flex;
         align-items: center;
         justify-content: space-around;
@@ -25,6 +24,7 @@
     .nb-state-container {
         flex-direction: column;
         display: flex;
+        color: $black;
     }
 
     .nb-close {

--- a/notebook2/notebook/styles/pages/notebook.scss
+++ b/notebook2/notebook/styles/pages/notebook.scss
@@ -1,5 +1,4 @@
-@import "variables/margins.scss";
-@import "variables/colors.scss";
+@import "variables.scss";
 
 #notebook {
     display: flex;

--- a/notebook2/notebook/styles/pages/notebook.scss
+++ b/notebook2/notebook/styles/pages/notebook.scss
@@ -25,6 +25,10 @@
         flex-direction: column;
         display: flex;
         color: $black;
+        &:hover {
+            text-decoration: none;
+            color: $devil-gray;
+        }
     }
 
     .nb-close {

--- a/notebook2/notebook/styles/pages/user.scss
+++ b/notebook2/notebook/styles/pages/user.scss
@@ -1,1 +1,0 @@
-@import "variables/margins.scss";

--- a/notebook2/notebook/templates/notebook.html
+++ b/notebook2/notebook/templates/notebook.html
@@ -1,7 +1,6 @@
 {% extends "layout.html" %}
 {% block title %}Notebook{% endblock %}
 {% block head %}
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="stylesheet" type="text/css" href="{{ base_path }}/static/css/pages/notebook.css">
 {% endblock %}
 {% block content %}

--- a/notebook2/notebook/templates/user.html
+++ b/notebook2/notebook/templates/user.html
@@ -1,8 +1,5 @@
 {% extends "layout.html" %}
 {% block title %}User{% endblock %}
-{% block head %}
-  <link rel="stylesheet" type="text/css" href="{{ base_path }}/static/css/pages/user.css">
-{% endblock %}
 {% block content %}
   <div id="profile" class="vcentered">
     <h1>{{ userdata['username'] }}</h1>

--- a/notebook2/notebook/templates/user.html
+++ b/notebook2/notebook/templates/user.html
@@ -7,7 +7,7 @@
     <p>
       <b>Bucket: </b>
       <a href="https://console.cloud.google.com/storage/browser/{{ userdata['bucket_name'] }}" target='_blank'>
-        {{ userdata['bucket_name'] }}
+        {{ userdata['bucket_name'] }}<i class="material-icons text-icon">open_in_new</i>
       </a>
     </p>
     <p><b>Service Account: </b>{{ userdata['gsa_email'] }}</p>

--- a/scorecard/scorecard/templates/index.html
+++ b/scorecard/scorecard/templates/index.html
@@ -67,20 +67,20 @@
         </table>
     {% endif %}
 
-      <table>
-	<thead>
-          <th align="left">component</th>
-          <th align="left">reviewers</th>
-	</thead>
-	<tbody>
-          {% for component, user in component_user.items() %}
-	  <tr>
-            <td align="left">{{ component }}</td>
-            <td align="left"><a href="{{ base_path }}/users/{{ user }}">{{ user }}</a></td>
-	  </tr>
-	  {% endfor %}
-	</tbody>
-      </table>
-    
-      <p><small>last updated {{ updated }}</small></p>
+    <table class="data-table">
+      <thead>
+        <th align="left">component</th>
+        <th align="left">reviewers</th>
+      </thead>
+      <tbody>
+        {% for component, user in component_user.items() %}
+        <tr>
+          <td align="left">{{ component }}</td>
+          <td align="left"><a href="{{ base_path }}/users/{{ user }}">{{ user }}</a></td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+    <p><small>last updated {{ updated }}</small></p>
 {% endblock %}

--- a/scorecard/scorecard/templates/index.html
+++ b/scorecard/scorecard/templates/index.html
@@ -3,7 +3,7 @@
 {% block content %}
         <h1>Scorecard!</h1>
 
-        <table>
+        <table class="data-table">
             <thead>
             <tr>
                 <th align="left">user</th>

--- a/scorecard/scorecard/templates/index.html
+++ b/scorecard/scorecard/templates/index.html
@@ -18,17 +18,17 @@
                 <td><a href="{{ base_path }}/users/{{ user }}">{{ user }}</a></td>
                 <td>
                     {% for pr in d['NEEDS_REVIEW'] %}
-                    <a href="{{ pr.html_url }}">{{ pr.id }}</a>
+                    <a href="{{ pr.html_url }}">#{{ pr.id }}</a>
                     {% endfor %}
                 </td>
                 <td>
                     {% for pr in d['CHANGES_REQUESTED'] %}
-                    <a href="{{ pr.html_url }}">{{ pr.id }}</a>
+                    <a href="{{ pr.html_url }}">#{{ pr.id }}</a>
                     {% endfor %}
                 </td>
                 <td>
                     {% for issue in d['ISSUES'] %}
-                    <a href="{{ issue.html_url }}">{{ issue.id }}</a>
+                    <a href="{{ issue.html_url }}">#{{ issue.id }}</a>
                     {% endfor %}
                 </td>
             </tr>

--- a/scorecard/scorecard/templates/index.html
+++ b/scorecard/scorecard/templates/index.html
@@ -6,27 +6,27 @@
         <table class="data-table">
             <thead>
             <tr>
-                <th align="left">user</th>
-                <th align="left">needs review</th>
-                <th align="left">changes requested</th>
-                <th align="left">issues</th>
+                <th>user</th>
+                <th>needs review</th>
+                <th>changes requested</th>
+                <th>issues</th>
             </tr>
             </thead>
             <tbody>
             {% for user, d in user_data.items() %}
             <tr>
-                <td align="left"><a href="{{ base_path }}/users/{{ user }}">{{ user }}</a></td>
-                <td align="left">
+                <td><a href="{{ base_path }}/users/{{ user }}">{{ user }}</a></td>
+                <td>
                     {% for pr in d['NEEDS_REVIEW'] %}
                     <a href="{{ pr.html_url }}">{{ pr.id }}</a>
                     {% endfor %}
                 </td>
-                <td align="left">
+                <td>
                     {% for pr in d['CHANGES_REQUESTED'] %}
                     <a href="{{ pr.html_url }}">{{ pr.id }}</a>
                     {% endfor %}
                 </td>
-                <td align="left">
+                <td>
                     {% for issue in d['ISSUES'] %}
                     <a href="{{ issue.html_url }}">{{ issue.id }}</a>
                     {% endfor %}
@@ -48,17 +48,17 @@
         <table>
             <thead>
                 <tr>
-                    <th align="left">assignee</th>
-                    <th align="left">time outstanding</th>
-                    <th align="left">issue</th>
+                    <th>assignee</th>
+                    <th>time outstanding</th>
+                    <th>issue</th>
                 </tr>
             </thead>
             <tbody>
             {% for issue in urgent_issues %}
                 <tr>
-                    <td align="left"><a href="{{ base_path }}/users/{{ issue['USER'] }}">{{ issue['USER'] }}</a></td>
-                    <td align="left">{{ issue['AGE'] }}</td>
-                    <td align="left">
+                    <td><a href="{{ base_path }}/users/{{ issue['USER'] }}">{{ issue['USER'] }}</a></td>
+                    <td>{{ issue['AGE'] }}</td>
+                    <td>
                         <a href="{{ issue['ISSUE'].html_url }}">{{ issue['ISSUE'].title }}</a>
                     </td>
                 </tr>
@@ -69,14 +69,14 @@
 
     <table class="data-table">
       <thead>
-        <th align="left">component</th>
-        <th align="left">reviewers</th>
+        <th>component</th>
+        <th>reviewer</th>
       </thead>
       <tbody>
         {% for component, user in component_user.items() %}
         <tr>
-          <td align="left">{{ component }}</td>
-          <td align="left"><a href="{{ base_path }}/users/{{ user }}">{{ user }}</a></td>
+          <td>{{ component }}</td>
+          <td><a href="{{ base_path }}/users/{{ user }}">{{ user }}</a></td>
         </tr>
         {% endfor %}
       </tbody>

--- a/scorecard/scorecard/templates/index.html
+++ b/scorecard/scorecard/templates/index.html
@@ -38,7 +38,7 @@
 
         <p>Unassigned:
             {% for pr in unassigned %}
-            <a href="{{ pr.html_url }}">{{ pr.id }}</a>
+            <a href="{{ pr.html_url }}">#{{ pr.id }}</a>
             {% endfor %}
         </p>
 

--- a/scorecard/scorecard/templates/user.html
+++ b/scorecard/scorecard/templates/user.html
@@ -27,7 +27,7 @@
 
         <h2>Needs Review</h2>
         {% if user_data['NEEDS_REVIEW'] %}
-        <table>
+        <table class="data-table">
             <tbody>
             {% for pr in user_data['NEEDS_REVIEW'] %}
             <tr>
@@ -44,7 +44,7 @@
 
         <h2>Changes Requested</h2>
         {% if user_data['CHANGES_REQUESTED'] %}
-        <table>
+        <table class="data-table">
             <tbody>
             {% for pr in user_data['CHANGES_REQUESTED'] %}
             <tr>

--- a/scorecard/scorecard/templates/user.html
+++ b/scorecard/scorecard/templates/user.html
@@ -31,7 +31,7 @@
             <tbody>
             {% for pr in user_data['NEEDS_REVIEW'] %}
             <tr>
-                <td><a href="{{ pr.html_url }}">{{ pr.id }}</a></td>
+                <td class="numeric-cell"><a href="{{ pr.html_url }}">{{ pr.id }}</a></td>
                 <td><a href="https://github.com/{{ pr.user }}">{{ pr.user }}</a></td>
                 <td>{{ pr.title }}</td>
             </tr>
@@ -48,7 +48,7 @@
             <tbody>
             {% for pr in user_data['CHANGES_REQUESTED'] %}
             <tr>
-                <td><a href="{{ pr.html_url }}">{{ pr.id }}</a></td>
+                <td class="numeric-cell"><a href="{{ pr.html_url }}">{{ pr.id }}</a></td>
                 <td>{{ pr.title }}</td>
             </tr>
             {% endfor %}
@@ -60,11 +60,11 @@
 
         <h2>Failing tests</h2>
         {% if user_data['FAILING'] %}
-        <table>
+        <table class="data-table">
             <tbody>
             {% for pr in user_data['FAILING'] %}
             <tr>
-                <td><a href="{{ pr.html_url }}">{{ pr.id }}</a></td>
+                <td class="numeric-cell"><a href="{{ pr.html_url }}">{{ pr.id }}</a></td>
                 <td>{{ pr.title }}</td>
             </tr>
             {% endfor %}
@@ -77,7 +77,7 @@
 
         <h2>Issues</h2>
         {% if user_data['ISSUES'] %}
-        <table>
+        <table class="data-table">
             <tbody>
             {% for issue in user_data['ISSUES'] %}
             <tr>

--- a/scorecard/scorecard/templates/user.html
+++ b/scorecard/scorecard/templates/user.html
@@ -31,9 +31,8 @@
             <tbody>
             {% for pr in user_data['NEEDS_REVIEW'] %}
             <tr>
-                <td class="numeric-cell"><a href="{{ pr.html_url }}">{{ pr.id }}</a></td>
-                <td><a href="https://github.com/{{ pr.user }}">{{ pr.user }}</a></td>
-                <td>{{ pr.title }}</td>
+              <td><a href="https://github.com/{{ pr.user }}">{{ pr.user }}</a></td>
+              <td><a href="{{ pr.html_url }}">{{ pr.title }} <span class="gh-number">#{{ pr.id }}</a></a></td>
             </tr>
             {% endfor %}
             </tbody>
@@ -48,8 +47,7 @@
             <tbody>
             {% for pr in user_data['CHANGES_REQUESTED'] %}
             <tr>
-                <td class="numeric-cell"><a href="{{ pr.html_url }}">{{ pr.id }}</a></td>
-                <td>{{ pr.title }}</td>
+              <td><a href="{{ pr.html_url }}">{{ pr.title }} <span class="gh-number">#{{ pr.id }}</span></a></td>
             </tr>
             {% endfor %}
             </tbody>
@@ -64,8 +62,7 @@
             <tbody>
             {% for pr in user_data['FAILING'] %}
             <tr>
-                <td class="numeric-cell"><a href="{{ pr.html_url }}">{{ pr.id }}</a></td>
-                <td>{{ pr.title }}</td>
+              <td><a href="{{ pr.html_url }}">{{ pr.title }} <span class="gh-number">#{{ pr.id }}</span></a></td>
             </tr>
             {% endfor %}
             </tbody>
@@ -81,8 +78,7 @@
             <tbody>
             {% for issue in user_data['ISSUES'] %}
             <tr>
-                <td><a href="{{ issue.html_url }}">{{ issue.id }}</a></td>
-                <td>{{ issue.title }}</td>
+              <td><a href="{{ issue.html_url }}">{{ issue.title }} <span class="gh-number">{{ issue.id }}</span></a></td>
             </tr>
             {% endfor %}
             </tbody>

--- a/scorecard/scorecard/templates/user.html
+++ b/scorecard/scorecard/templates/user.html
@@ -78,7 +78,7 @@
             <tbody>
             {% for issue in user_data['ISSUES'] %}
             <tr>
-              <td><a href="{{ issue.html_url }}">{{ issue.title }} <span class="gh-number">{{ issue.id }}</span></a></td>
+              <td><a href="{{ issue.html_url }}">{{ issue.title }} <span class="gh-number">#{{ issue.id }}</span></a></td>
             </tr>
             {% endfor %}
             </tbody>

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -40,6 +40,7 @@ a {
 
 .header-link {
     padding: 15px 15px;
+    color: $black;
 }
 
 .button-header-link {
@@ -50,6 +51,7 @@ a {
     color: $black;
     &:active,
     &:hover {
+        text-decoration: none;
         color: $devil-gray;
     }
     padding: 15px 15px;
@@ -74,6 +76,13 @@ a {
     flex-direction: column;
     align-items: flex-start;
     margin: 0 8px 8px 8px;
+}
+
+.text-icon {
+    /* baseline of material icons is messed up, see:
+       https://github.com/google/material-design-icons/issues/206 */
+    vertical-align: middle;
+    font-size: 0.8rem;
 }
 
 .data-table {

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -27,6 +27,12 @@ button {
     border: 1px solid $black;
     border-radius: 3px;
     margin: 0;
+    cursor: pointer;
+    &:active,
+    &:hover {
+	outline: 0;
+        color: $devil-gray;
+    }
 }
 
 a {
@@ -58,10 +64,6 @@ a {
     cursor: pointer;
     color: $black;
     white-space: nowrap;
-    &:active,
-    &:hover {
-        color: $devil-gray;
-    }
     padding: 15px 15px;
 }
 
@@ -113,10 +115,18 @@ a {
     text-align: right;
 }
 
+.searchbar {
+    width: 40%;
+}
+
 .searchbar-table {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
+}
+
+.gh-number {
+    color: #6a737d;
 }
 
 /* viewport centered */

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -30,17 +30,20 @@ button {
 }
 
 a {
-    color: #3d7e9a;
+    color: #07c;
     text-decoration: none;
     &:active,
     &:hover {
         text-decoration: underline;
+        /* color: #3af */
+        
     }
 }
 
 .header-link {
     padding: 15px 15px;
     color: $black;
+    white-space: nowrap;
     &:active,
     &:hover {
         text-decoration: none;
@@ -54,6 +57,7 @@ a {
     font-size: 1rem;
     cursor: pointer;
     color: $black;
+    white-space: nowrap;
     &:active,
     &:hover {
         color: $devil-gray;
@@ -103,6 +107,10 @@ a {
     tbody tr:hover {
         background-color: #ddd;
     }
+}
+
+.numeric-cell {
+    text-align: right;
 }
 
 .searchbar-table {

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -21,7 +21,7 @@ body {
 }
 
 h1, h2, h3, h4, h5, h6 {
-    margin: 0.5rem;
+    margin: 0.5rem 0;
 }
 
 .stacked-header {

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -1,5 +1,4 @@
-@import "variables/colors.scss";
-@import "variables/margins.scss";
+@import "variables.scss";
 
 html {
     box-sizing: border-box;
@@ -30,15 +29,12 @@ button {
     margin: 0;
 }
 
-tr:nth-child(even) { background-color: #f2f2f2; }
-
 a {
-    color: $black;
-    /* remove underline */
+    color: #3d7e9a;
     text-decoration: none;
     &:active,
     &:hover {
-        color: $devil-gray;
+        text-decoration: underline;
     }
 }
 
@@ -78,6 +74,22 @@ a {
     flex-direction: column;
     align-items: flex-start;
     margin: 0 8px 8px 8px;
+}
+
+.data-table {
+    min-width: 480px;
+    table-spacing: 3px;
+    td {
+        white-space: nowrap;
+    }
+    tr {
+        &:nth-child(even) {
+            background-color: #f2f2f2;
+        }
+        &:hover {
+            background-color: #ddd;
+        }
+    }
 }
 
 .searchbar-table {

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -41,7 +41,11 @@ a {
 .header-link {
     padding: 15px 15px;
     color: $black;
-    white-space: nowrap;
+    &:active,
+    &:hover {
+        text-decoration: none;
+        color: $devil-gray;
+    }
 }
 
 .button-header-link {
@@ -52,7 +56,6 @@ a {
     color: $black;
     &:active,
     &:hover {
-        text-decoration: none;
         color: $devil-gray;
     }
     padding: 15px 15px;

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -21,7 +21,11 @@ body {
 }
 
 h1, h2, h3, h4, h5, h6 {
-    margin: 0;
+    margin: 0.5rem;
+}
+
+.stacked-header {
+    margin: 0 0 0.5rem 0;
 }
 
 button {
@@ -39,6 +43,7 @@ button {
     &:hover {
 	outline: 0;
         color: $devil-gray;
+	border-color: $devil-gray;
     }
 }
 
@@ -139,6 +144,10 @@ a {
 
 .gh-number {
     color: #6a737d;
+}
+
+.attributes {
+    margin-left: 1rem;
 }
 
 /* viewport centered */

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -87,17 +87,17 @@ a {
 
 .data-table {
     min-width: 480px;
-    table-spacing: 3px;
-    td {
+    border-spacing: 3px;
+    th {
         white-space: nowrap;
     }
     tr {
         &:nth-child(even) {
             background-color: #f2f2f2;
         }
-        &:hover {
-            background-color: #ddd;
-        }
+    }
+    tbody tr:hover {
+        background-color: #ddd;
     }
 }
 

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -41,6 +41,7 @@ a {
 .header-link {
     padding: 15px 15px;
     color: $black;
+    white-space: nowrap;
 }
 
 .button-header-link {

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -100,7 +100,7 @@ a {
 
 .data-table {
     min-width: 480px;
-    border-spacing: 3px;
+    border-spacing: 2px;
     thead {
 	color: $white;
 	background-color: #888;

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -28,6 +28,9 @@ button {
     border-radius: 3px;
     margin: 0;
     cursor: pointer;
+    &:focus {
+	outline: 0;
+    }
     &:active,
     &:hover {
 	outline: 0;
@@ -98,6 +101,10 @@ a {
 .data-table {
     min-width: 480px;
     border-spacing: 3px;
+    thead {
+	color: $white;
+	background-color: #888;
+    }
     th {
         white-space: nowrap;
     }

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -20,6 +20,10 @@ body {
     margin: 0;
 }
 
+h1, h2, h3, h4, h5, h6 {
+    margin: 0;
+}
+
 button {
     font-family: inherit;
     font-size: 1rem;

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -107,6 +107,7 @@ a {
     }
     th {
         white-space: nowrap;
+	padding: 3px 10px;
     }
     tr {
         &:nth-child(even) {

--- a/web_common/web_common/styles/variables.scss
+++ b/web_common/web_common/styles/variables.scss
@@ -1,0 +1,10 @@
+$black: #000;
+$white: #fff;
+$light-gray: #a1a1a1;
+$devil-gray: #666;
+$dark-gray: #333;
+$blue: #428bca;
+$red: #800020;
+
+$margin: 1rem;
+$icon-size: 2rem;

--- a/web_common/web_common/styles/variables/colors.scss
+++ b/web_common/web_common/styles/variables/colors.scss
@@ -1,7 +1,0 @@
-$black: #000;
-$white: #fff;
-$light-gray: #a1a1a1;
-$devil-gray: #666;
-$dark-gray: #333;
-$blue: #428bca;
-$red: #800020;

--- a/web_common/web_common/styles/variables/margins.scss
+++ b/web_common/web_common/styles/variables/margins.scss
@@ -1,2 +1,0 @@
-$margin: 1rem;
-$icon-size: 2rem;

--- a/web_common/web_common/templates/header.html
+++ b/web_common/web_common/templates/header.html
@@ -20,15 +20,15 @@
       Scorecard
     </a>
 
-    <a class="header-link" href="https://internal.hail.is/monitoring/grafana">
+    <a class="header-link" href="https://internal.hail.is/monitoring/grafana/">
       Grafana<i class="material-icons text-icon">open_in_new</i>
     </a>
 
-    <a class="header-link" href="https://internal.hail.is/monitoring/prometheus">
+    <a class="header-link" href="https://internal.hail.is/monitoring/prometheus/">
       Prometheus<i class="material-icons text-icon">open_in_new</i>
     </a>
 
-    <a class="header-link" href="https://internal.hail.is/monitoring/kibana">
+    <a class="header-link" href="https://internal.hail.is/monitoring/kibana/">
       Kibana<i class="material-icons text-icon">open_in_new</i>
     </a>
   {% endif %}

--- a/web_common/web_common/templates/header.html
+++ b/web_common/web_common/templates/header.html
@@ -20,15 +20,15 @@
       Scorecard
     </a>
 
-    <a class="header-link" href="https://internal.hail.is/monitoring/grafana/">
+    <a target="_blank" class="header-link" href="https://internal.hail.is/monitoring/grafana/">
       Grafana<i class="material-icons text-icon">open_in_new</i>
     </a>
 
-    <a class="header-link" href="https://internal.hail.is/monitoring/prometheus/">
+    <a target="_blank" class="header-link" href="https://internal.hail.is/monitoring/prometheus/">
       Prometheus<i class="material-icons text-icon">open_in_new</i>
     </a>
 
-    <a class="header-link" href="https://internal.hail.is/monitoring/kibana/">
+    <a target="_blank" class="header-link" href="https://internal.hail.is/monitoring/kibana/">
       Kibana<i class="material-icons text-icon">open_in_new</i>
     </a>
   {% endif %}

--- a/web_common/web_common/templates/header.html
+++ b/web_common/web_common/templates/header.html
@@ -21,15 +21,15 @@
     </a>
 
     <a class="header-link" href="https://internal.hail.is/monitoring/grafana">
-      Grafana<i class="material-icons">open_in_new</i>
+      Grafana<i class="material-icons text-icon">open_in_new</i>
     </a>
 
     <a class="header-link" href="https://internal.hail.is/monitoring/prometheus">
-      Prometheus<i class="material-icons">open_in_new</i>
+      Prometheus<i class="material-icons text-icon">open_in_new</i>
     </a>
 
     <a class="header-link" href="https://internal.hail.is/monitoring/kibana">
-      Kibana<i class="material-icons">open_in_new</i>
+      Kibana<i class="material-icons text-icon">open_in_new</i>
     </a>
   {% endif %}
 

--- a/web_common/web_common/templates/header.html
+++ b/web_common/web_common/templates/header.html
@@ -19,6 +19,18 @@
     <a class="header-link" href="{{ scorecard_base_url }}">
       Scorecard
     </a>
+
+    <a class="header-link" href="https://internal.hail.is/monitoring/grafana">
+      Grafana<i class="material-icons">open_in_new</i>
+    </a>
+
+    <a class="header-link" href="https://internal.hail.is/monitoring/prometheus">
+      Prometheus<i class="material-icons">open_in_new</i>
+    </a>
+
+    <a class="header-link" href="https://internal.hail.is/monitoring/kibana">
+      Kibana<i class="material-icons">open_in_new</i>
+    </a>
   {% endif %}
 
   <div id="header-flex"></div>

--- a/web_common/web_common/templates/layout.html
+++ b/web_common/web_common/templates/layout.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1"></meta>
     <link rel="shortcut icon" href="{{ base_path }}/common_static/hail_logo_sq.ico" type="image/x-icon" />
     <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="{{ base_path }}/common_static/css/main.css" />
     {% block head %}{% endblock %}
   </head>


### PR DESCRIPTION
Pushing pixels around.  Summary of changes:
 - make links blue, with underline :hover, :active
 - added data-table class for striped, hover-highlighting tables, dark background headers, use all over
 - put open_in_new on links that open new tabs
 - made the search bars a bit wider (40%)
 - make Github links all be <title> #<number>, where number is a lighter gray
 - format attributes of repos and batches in CI tighter
 - added batch labels on PR page
 - made artifacts link clickable (long overdue)

@tpoterba I think this will fix most of your complaints from earlier today.

I deployed just CI by hand to verify it works, looks good.

I'm going to leave off styling for a bit after this and work on workshops in notebook2 and support many jobs in batch (paging, search, etc.)