### PR TITLE
Support empty ndarray

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3911,7 +3911,7 @@ def _ndarray(collection, row_major=None):
         row_major = True
 
     shape_expr = to_expr(tuple([hl.int64(i) for i in shape]), ir.ttuple(*[tint64 for _ in shape]))
-    data_expr = hl.array(data)
+    data_expr = hl.array(data) if data else hl.empty_array("float64")
     ndir = ir.MakeNDArray(data_expr._ir, shape_expr._ir, hl.bool(row_major)._ir)
 
     return construct_expr(ndir, tndarray(data_expr.dtype.element_type, builtins.len(shape)))

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3867,13 +3867,16 @@ def _ndarray(collection, row_major=None):
     def list_shape(x):
         if isinstance(x, list):
             dim_len = builtins.len(x)
-            first, rest = x[0], x[1:]
-            inner_shape = list_shape(first)
-            for e in rest:
-                other_inner_shape = list_shape(e)
-                if inner_shape != other_inner_shape:
-                    raise ValueError(f'inner dimensions do not match: {inner_shape}, {other_inner_shape}')
-            return [dim_len] + inner_shape
+            if dim_len != 0:
+                first, rest = x[0], x[1:]
+                inner_shape = list_shape(first)
+                for e in rest:
+                    other_inner_shape = list_shape(e)
+                    if inner_shape != other_inner_shape:
+                        raise ValueError(f'inner dimensions do not match: {inner_shape}, {other_inner_shape}')
+                return [dim_len] + inner_shape
+            else:
+                return [dim_len]
         else:
             return []
 

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -3148,6 +3148,8 @@ class Tests(unittest.TestCase):
         assert(evaled.tolist() == np_equiv.tolist())
         assert(evaled.strides == np_equiv.strides)
 
+        assert hl.eval(hl._ndarray([[], []])).strides == (8, 8)
+        assert np.array_equal(hl.eval(hl._ndarray([])), np.array([]))
 
 
     @skip_unless_spark_backend()


### PR DESCRIPTION
This PR adds support for ndarrays where one of the shape fields is 0. `list_shape` was previously written to ask for first element of each list, which did not work when lists were empty. Also had to fix the way strides were calculated, as the expression: 

`hl._ndarray([[], []])` should have stride (8, 8), and the previous code would have returned (8, 0), due to the shape being 0 on the last dimension. 