### PR TITLE
[hail] cleaning up the new aggregator interface a little bit

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/Region.scala
+++ b/hail/src/main/scala/is/hail/annotations/Region.scala
@@ -357,6 +357,9 @@ final class Region protected[annotations](var blockSize: Region.Size, var pool: 
 }
 
 object RegionUtils {
+  def printAddr(off: Long, name: String): String = s"$name: ${"%016x".format(off)}"
+  def printAddr(off: Code[Long], name: String): Code[String] = Code.invokeScalaObject[Long, String, String](RegionUtils.getClass, "printAddr", off, name)
+
   def printBytes(off: Long, n: Int, header: String): String = {
     Region.loadBytes(off, n).zipWithIndex
       .grouped(16)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -69,9 +69,9 @@ case class AggContainer(aggs: Array[AggSignature2], container: agg.TupleAggregat
         case Group() =>
           val state = container.states(i).asInstanceOf[agg.DictState]
           if (init)
-            AggContainer(n.toArray, state.keyed.container, state.keyed.container.off)
-          else
             AggContainer(n.toArray, state.initContainer, state.initContainer.off)
+          else
+            AggContainer(n.toArray, state.keyed.container, state.keyed.container.off)
       }
     }
   }
@@ -1065,7 +1065,7 @@ private class Emit(
 
         val argVars = args.map(a => emit(a, container = container.flatMap(_.nested(i, init = true)))).toArray
         void(
-          sc.states(i).newState,
+          sc.newState(i),
           rvAgg.initOp(sc.states(i), argVars))
 
       case SeqOp2(i, args, aggSig) =>
@@ -1131,7 +1131,7 @@ private class Emit(
           .map(sc => sc.deserialize(CodecSpec.defaultUncompressedBuffer))
 
         val init = coerce[Unit](Code(Array.range(start, start + aggSigs.length)
-          .map(i => sc.states(i).newState): _*))
+          .map(i => sc.newState(i)): _*))
 
         val unserialize = Array.tabulate(aggSigs.length) { j =>
           deserializers(j)(ib)

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -241,17 +241,17 @@ class EmitFunctionBuilder[F >: Null](
   private[this] var _nSerialized: Int = 0
   private[this] var _aggSerialized: ClassFieldRef[Array[Array[Byte]]] = _
 
-  def addAggStates(aggSigs: Array[AggSignature2]): (agg.TupleAggregatorState, Code[Long]) = {
+  def addAggStates(aggSigs: Array[AggSignature2]): agg.TupleAggregatorState = {
     if (_aggSigs != null) {
       assert(aggSigs sameElements _aggSigs)
-      return _aggState -> _aggOff
+      return _aggState
     }
     cn.interfaces.asInstanceOf[java.util.List[String]].add(typeInfo[FunctionWithAggRegion].iname)
     _aggSigs = aggSigs
     _aggRegion = newField[Region]("agg_top_region")
     _aggOff = newField[Long]("agg_off")
     val states = agg.StateTuple(aggSigs.map(a => agg.Extract.getAgg(a).createState(this)).toArray)
-    _aggState = agg.TupleAggregatorState(states, _aggRegion, _aggOff, 0)
+    _aggState = agg.TupleAggregatorState(states, _aggRegion, _aggOff)
     _aggSerialized = newField[Array[Array[Byte]]]("agg_serialized")
 
     val newF = new EmitMethodBuilder(this, "newAggState", Array(typeInfo[Region]), typeInfo[Unit])
@@ -291,7 +291,7 @@ class EmitFunctionBuilder[F >: Null](
 
     getSer.emit(_aggSerialized.load()(getSer.getArg[Int](1)))
 
-    _aggState -> _aggOff
+    _aggState
   }
 
   def getSerializedAgg(i: Int): Code[Array[Byte]] = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -72,7 +72,7 @@ class TypedRegionBackedAggState(val typ: PType, val fb: EmitFunctionBuilder[_]) 
       Region.copyFrom(off, dest, storageType.byteSize))),
       super.store(regionStorer, dest))
 
-  def storeMissing(): Code[Unit] = Code(Code._println(RegionUtils.printAddr(off, "off")), storageType.setFieldMissing(off, 0))
+  def storeMissing(): Code[Unit] = storageType.setFieldMissing(off, 0)
   def storeNonmissing(v: Code[_]): Code[Unit] = Code(
     region.getNewRegion(regionSize),
     storageType.setFieldPresent(off, 0),

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -138,9 +138,9 @@ case class StateContainer(states: Array[AggregatorState], topRegion: Code[Region
   val typ: PTuple = PTuple(true, states.map { s => s.storageType }: _*)
 
   def apply(i: Int): AggregatorState = states(i)
-  def getRegion(rOffset: Code[Int], i: Int): Code[Region] => Code[Unit] = { r: Code[Region] =>
+  private def getRegion(rOffset: Code[Int], i: Int): Code[Region] => Code[Unit] = { r: Code[Region] =>
     r.setFromParentReference(topRegion, rOffset + i, states(i).regionSize) }
-  def getStateOffset(off: Code[Long], i: Int): Code[Long] = typ.loadField(topRegion, off, i)
+  private def getStateOffset(off: Code[Long], i: Int): Code[Long] = typ.loadField(topRegion, off, i)
 
   def setAllMissing(off: Code[Long]): Code[Unit] = toCode((i, _) =>
     Region.storeAddress(typ.fieldOffset(off, i), 0L))
@@ -159,4 +159,7 @@ case class StateContainer(states: Array[AggregatorState], topRegion: Code[Region
 
   def store(rOffset: Code[Int], statesOffset: Code[Long]): Code[Unit] =
     toCode((i, s) => s.store(r => topRegion.setParentReference(r, rOffset + i), getStateOffset(statesOffset, i)))
+
+  def copyFrom(statesOffset: Code[Long]): Code[Unit] =
+    toCode((i, s) => s.copyFrom(getStateOffset(statesOffset, i)))
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir.agg
 
-import is.hail.annotations.{Region, StagedRegionValueBuilder}
+import is.hail.annotations.{Region, RegionUtils, StagedRegionValueBuilder}
 import is.hail.asm4s._
 import is.hail.expr.ir._
 import is.hail.expr.types.physical._
@@ -16,7 +16,7 @@ trait AggregatorState {
   def regionSize: Int = Region.TINY
 
   def createState: Code[Unit]
-  def newState: Code[Unit]
+  def newState(off: Code[Long]): Code[Unit]
 
   def load(regionLoader: Code[Region] => Code[Unit], src: Code[Long]): Code[Unit]
   def store(regionStorer: Code[Region] => Code[Unit], dest: Code[Long]): Code[Unit]
@@ -28,43 +28,70 @@ trait AggregatorState {
   def deserialize(codec: BufferSpec): Code[InputBuffer] => Code[Unit]
 }
 
-trait PointerBasedRVAState extends AggregatorState {
-  private val r: ClassFieldRef[Region] = fb.newField[Region]
-  val off: ClassFieldRef[Long] = fb.newField[Long]
-  val storageType: PType = PInt64(true)
+trait RegionBackedAggState extends AggregatorState {
+  protected val r: ClassFieldRef[Region] = fb.newField[Region]
   val region: Code[Region] = r.load()
 
-  override val regionSize: Int = Region.TINIER
-
-  def newState: Code[Unit] = region.getNewRegion(regionSize)
+  def newState(off: Code[Long]): Code[Unit] = region.getNewRegion(regionSize)
 
   def createState: Code[Unit] = region.isNull.mux(r := Region.stagedCreate(regionSize), Code._empty)
 
-  def load(regionLoader: Code[Region] => Code[Unit], src: Code[Long]): Code[Unit] =
-    Code(regionLoader(r), off := Region.loadAddress(src))
+  def load(regionLoader: Code[Region] => Code[Unit], src: Code[Long]): Code[Unit] = regionLoader(r)
 
   def store(regionStorer: Code[Region] => Code[Unit], dest: Code[Long]): Code[Unit] =
-    region.isValid.mux(Code(regionStorer(region), region.invalidate(), Region.storeAddress(dest, off)), Code._empty)
+    region.isValid.orEmpty(Code(regionStorer(region), region.invalidate()))
+}
+
+trait PointerBasedRVAState extends RegionBackedAggState {
+  val off: ClassFieldRef[Long] = fb.newField[Long]
+  val storageType: PType = PInt64(true)
+
+  override val regionSize: Int = Region.TINIER
+
+  override def load(regionLoader: Code[Region] => Code[Unit], src: Code[Long]): Code[Unit] =
+    Code(super.load(regionLoader, src), off := Region.loadAddress(src))
+
+  override def store(regionStorer: Code[Region] => Code[Unit], dest: Code[Long]): Code[Unit] =
+    Code(region.isValid.orEmpty(Region.storeAddress(dest, off)), super.store(regionStorer, dest))
 
   def copyFrom(src: Code[Long]): Code[Unit] = copyFromAddress(Region.loadAddress(src))
 
   def copyFromAddress(src: Code[Long]): Code[Unit]
 }
 
-class TypedRVAState(val valueType: PType, val fb: EmitFunctionBuilder[_]) extends PointerBasedRVAState {
-  override def load(regionLoader: Code[Region] => Code[Unit], src: Code[Long]): Code[Unit] =
-    super.load(r => r.invalidate(), src)
+class TypedRegionBackedAggState(val typ: PType, val fb: EmitFunctionBuilder[_]) extends RegionBackedAggState {
+  override val regionSize: Int = Region.TINIER
+  val storageType: PTuple = PTuple(required = true, typ)
+  val off: ClassFieldRef[Long] = fb.newField[Long]
 
-  def copyFromAddress(src: Code[Long]): Code[Unit] = off := StagedRegionValueBuilder.deepCopyFromOffset(fb, region, valueType, src)
+  override def newState(src: Code[Long]): Code[Unit] = Code(off := src, super.newState(off))
+  override def load(regionLoader: Code[Region] => Code[Unit], src: Code[Long]): Code[Unit] =
+    Code(super.load(r => r.invalidate(), src), off := src)
+  override def store(regionStorer: Code[Region] => Code[Unit], dest: Code[Long]): Code[Unit] =
+    Code(region.isValid.orEmpty(dest.cne(off).orEmpty(
+      Region.copyFrom(off, dest, storageType.byteSize))),
+      super.store(regionStorer, dest))
+
+  def storeMissing(): Code[Unit] = Code(Code._println(RegionUtils.printAddr(off, "off")), storageType.setFieldMissing(off, 0))
+  def storeNonmissing(v: Code[_]): Code[Unit] = Code(
+    region.getNewRegion(regionSize),
+    storageType.setFieldPresent(off, 0),
+    StagedRegionValueBuilder.deepCopy(fb, region, typ, v, storageType.fieldOffset(off, 0)))
+
+  def get(): EmitTriplet = EmitTriplet(Code._empty, storageType.isFieldMissing(off, 0), Region.loadIRIntermediate(typ)(storageType.fieldOffset(off, 0)))
+
+  def copyFrom(src: Code[Long]): Code[Unit] =
+    Code(newState(off), StagedRegionValueBuilder.deepCopy(fb, region, storageType, src, off))
 
   def serialize(codec: BufferSpec): Code[OutputBuffer] => Code[Unit] = {
-    val enc = PackCodecSpec2(valueType, codec).buildEmitEncoderF[Long](valueType, fb)
+    val enc = PackCodecSpec2(storageType, codec).buildEmitEncoderF[Long](storageType, fb)
     ob: Code[OutputBuffer] => enc(region, off, ob)
   }
 
   def deserialize(codec: BufferSpec): Code[InputBuffer] => Code[Unit] = {
-    val (t, dec) = PackCodecSpec2(valueType, codec).buildEmitDecoderF[Long](valueType.virtualType, fb)
-    ib: Code[InputBuffer] => off := dec(region, ib)
+    val (t, dec) = PackCodecSpec2(storageType, codec).buildEmitDecoderF[Long](storageType.virtualType, fb)
+    val off2: ClassFieldRef[Long] = fb.newField[Long]
+    ib: Code[InputBuffer] => Code(off2 := dec(region, ib), Region.copyFrom(off2, off, storageType.byteSize))
   }
 }
 
@@ -83,7 +110,7 @@ class PrimitiveRVAState(val types: Array[PType], val fb: EmitFunctionBuilder[_])
   def foreachField(f: (Int, ValueField) => Code[Unit]): Code[Unit] =
     coerce[Unit](Code(Array.tabulate(nFields)(i => f(i, fields(i))) :_*))
 
-  def newState: Code[Unit] = Code._empty
+  def newState(off: Code[Long]): Code[Unit] = Code._empty
   def createState: Code[Unit] = Code._empty
 
   private[this] def loadVarsFromRegion(src: Code[Long]): Code[Unit] =
@@ -149,7 +176,7 @@ case class StateTuple(states: Array[AggregatorState]) {
     toCode((i, s) => s.createState)
 
   def newStates(stateOffset: Code[Long]): Code[Unit] =
-    toCode((_, s) => s.newState)
+    toCode((i, s) => s.newState(getStateOffset(stateOffset, i)))
 
   def load(region: Code[Region], rOffset: Code[Int], stateOffset: Code[Long]): Code[Unit] =
     toCode((i, s) => s.load(getRegion(region, rOffset, i), getStateOffset(stateOffset, i)))
@@ -167,9 +194,8 @@ case class TupleAggregatorState(states: StateTuple, topRegion: Code[Region], off
     r.setFromParentReference(topRegion, rOff + i, states(i).regionSize) }
   private def getStateOffset(i: Int): Code[Long] = storageType.loadField(off, i)
 
+  def newState(i: Int): Code[Unit] = states(i).newState(getStateOffset(i))
   def newState: Code[Unit] = states.newStates(off)
-
   def load: Code[Unit] = states.toCode((i, s) => s.load(getRegion(i), getStateOffset(i)))
-
   def store: Code[Unit] = states.store(topRegion, rOff, off)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -190,5 +190,5 @@ case class TupleAggregatorState(states: StateTuple, topRegion: Code[Region], off
   def load: Code[Unit] = states.toCode((i, s) => s.load(getRegion(i), getStateOffset(i)))
   def store: Code[Unit] = states.toCode((i, s) => s.store(setRegion(i), getStateOffset(i)))
   def copyFrom(statesOffset: Code[Long]): Code[Unit] =
-    states.toCode((i, s) => s.copyFrom(getStateOffset(i)))
+    states.toCode((i, s) => s.copyFrom(storageType.loadField(statesOffset, i)))
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -133,17 +133,14 @@ class PrimitiveRVAState(val types: Array[PType], val fb: EmitFunctionBuilder[_])
   }
 }
 
-case class StateContainer(states: Array[AggregatorState], topRegion: Code[Region]) {
+case class States(states: Array[AggregatorState]) {
   val nStates: Int = states.length
   val typ: PTuple = PTuple(true, states.map { s => s.storageType }: _*)
 
   def apply(i: Int): AggregatorState = states(i)
-  private def getRegion(rOffset: Code[Int], i: Int): Code[Region] => Code[Unit] = { r: Code[Region] =>
-    r.setFromParentReference(topRegion, rOffset + i, states(i).regionSize) }
-  private def getStateOffset(off: Code[Long], i: Int): Code[Long] = typ.loadField(topRegion, off, i)
-
-  def setAllMissing(off: Code[Long]): Code[Unit] = toCode((i, _) =>
-    Region.storeAddress(typ.fieldOffset(off, i), 0L))
+  private def getRegion(region: Code[Region], rOffset: Code[Int], i: Int): Code[Region] => Code[Unit] = { r: Code[Region] =>
+    r.setFromParentReference(region, rOffset + i, states(i).regionSize) }
+  private def getStateOffset(off: Code[Long], i: Int): Code[Long] = typ.loadField(off, i)
 
   def toCode(f: (Int, AggregatorState) => Code[Unit]): Code[Unit] =
     coerce[Unit](Code(Array.tabulate(nStates)(i => f(i, states(i))): _*))
@@ -154,12 +151,31 @@ case class StateContainer(states: Array[AggregatorState], topRegion: Code[Region
   def newStates: Code[Unit] =
     toCode((_, s) => s.newState)
 
-  def load(rOffset: Code[Int], stateOffset: Code[Long]): Code[Unit] =
-    toCode((i, s) => s.load(getRegion(rOffset, i), getStateOffset(stateOffset, i)))
+  def load(region: Code[Region], rOffset: Code[Int], stateOffset: Code[Long]): Code[Unit] =
+    toCode((i, s) => s.load(getRegion(region, rOffset, i), getStateOffset(stateOffset, i)))
 
-  def store(rOffset: Code[Int], statesOffset: Code[Long]): Code[Unit] =
-    toCode((i, s) => s.store(r => topRegion.setParentReference(r, rOffset + i), getStateOffset(statesOffset, i)))
+  def store(region: Code[Region], rOffset: Code[Int], statesOffset: Code[Long]): Code[Unit] =
+    toCode((i, s) => s.store(r => region.setParentReference(r, rOffset + i), getStateOffset(statesOffset, i)))
 
   def copyFrom(statesOffset: Code[Long]): Code[Unit] =
     toCode((i, s) => s.copyFrom(getStateOffset(statesOffset, i)))
+}
+
+case class StateContainer(states: States, topRegion: Code[Region], var off: Code[Long], var rOff: Code[Int] = 0) {
+  def nStates: Int = states.nStates
+  def typ: PTuple = states.typ
+
+  def withOffsets(newOff: Code[Long], rOff: Code[Int]): StateContainer = this.copy(off = newOff, rOff = rOff)
+
+  def apply(i: Int): AggregatorState = states(i)
+
+  def toCode(f: (Int, AggregatorState) => Code[Unit]): Code[Unit] = states.toCode(f)
+
+  def newStates: Code[Unit] = states.newStates
+
+  def load: Code[Unit] = states.load(topRegion, rOff, off)
+
+  def store: Code[Unit] = states.store(topRegion, rOff, off)
+
+  def copyFrom(srcOffset: Code[Long]): Code[Unit] = states.copyFrom(srcOffset)
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
@@ -59,7 +59,7 @@ class ArrayElementState(val fb: EmitFunctionBuilder[_], val nested: StateTuple) 
     seq(initArray, container.newState, seqOp)
 
   def initLength(len: Code[Int]): Code[Unit] = {
-    Code(lenRef := len, seq(nested.copyFrom(initContainer.off)))
+    Code(lenRef := len, seq(container.copyFrom(initContainer.off)))
   }
 
   def checkLength(len: Code[Int]): Code[Unit] = {
@@ -119,13 +119,13 @@ class ArrayElementState(val fb: EmitFunctionBuilder[_], val nested: StateTuple) 
 
     Code(
       srcOff := src,
-      init(nested.copyFrom(initOffset), initLen = false),
+      init(initContainer.copyFrom(initOffset), initLen = false),
       typ.isFieldMissing(srcOff, 1).mux(
         Code(typ.setFieldMissing(off, 1),
           lenRef := -1),
         Code(
           lenRef := arrayType.loadLength(typ.loadField(srcOff, 1)),
-          seq(nested.copyFrom(eltOffset)))))
+          seq(container.copyFrom(eltOffset)))))
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/ArrayElementLengthCheckAggregator.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir.agg
 
-import is.hail.annotations.{Region, StagedRegionValueBuilder}
+import is.hail.annotations.{Region, RegionUtils, StagedRegionValueBuilder}
 import is.hail.asm4s._
 import is.hail.expr.ir._
 import is.hail.expr.types.physical._
@@ -71,7 +71,7 @@ class ArrayElementState(val fb: EmitFunctionBuilder[_], val nested: StateTuple) 
       Code(
         region.setNumParents(nStates),
         off := region.allocate(typ.alignment, typ.byteSize),
-        container.newState,
+        initContainer.newState,
         initOp,
         initContainer.store,
         if (initLen) typ.setFieldMissing(off, 1) else Code._empty)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAggregator.scala
@@ -12,7 +12,6 @@ class CollectAggregator(val elemType: PType) extends StagedAggregator {
   val resultType = PArray(elemType, required = true)
 
   class State(val fb: EmitFunctionBuilder[_]) extends AggregatorState {
-
     val r = fb.newField[Region]
     val region = r.load
     val bll = new StagedBlockLinkedList(elemType, fb)
@@ -25,7 +24,7 @@ class CollectAggregator(val elemType: PType) extends StagedAggregator {
         r := Region.stagedCreate(regionSize),
         region.invalidate()))
 
-    def newState: Code[Unit] =
+    def newState(off: Code[Long]): Code[Unit] =
       region.getNewRegion(regionSize)
 
     def load(regionLoader: Code[Region] => Code[Unit], src: Code[Long]): Code[Unit] =

--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -17,7 +17,7 @@ class GroupedBTreeKey(kt: PType, fb: EmitFunctionBuilder[_], region: Code[Region
   private val kcomp = fb.getCodeOrdering[Int](kt, CodeOrdering.compare, ignoreMissingness = false)
 
   val regionIdx: Code[Int] = Region.loadInt(storageType.fieldOffset(offset, 1))
-  val container = new TupleAggregatorState(states, region, containerAddress(offset), regionIdx)
+  val container = TupleAggregatorState(states, region, containerAddress(offset), regionIdx)
 
   def isKeyMissing(off: Code[Long]): Code[Boolean] =
     storageType.isFieldMissing(off, 0)
@@ -88,7 +88,7 @@ class DictState(val fb: EmitFunctionBuilder[_], val keyType: PType, val nested: 
 
   private val _elt = fb.newField[Long]
   private val initStatesOffset: Code[Long] = typ.loadField(off, 0)
-  val initContainer: TupleAggregatorState = new TupleAggregatorState(nested, region, initStatesOffset, 0)
+  val initContainer: TupleAggregatorState = TupleAggregatorState(nested, region, initStatesOffset)
 
   val keyed = new GroupedBTreeKey(keyType, fb, region, _elt, nested)
   val tree = new AppendOnlyBTree(fb, keyed, region, root)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -87,12 +87,11 @@ class DictState(val fb: EmitFunctionBuilder[_], val keyType: PType, val nested: 
     "tree" -> PInt64(true))
 
   private val _elt = fb.newField[Long]
-  val initContainer: TupleAggregatorState = new TupleAggregatorState(nested, region, typ.fieldOffset(off, 0), 0)
+  private val initStatesOffset: Code[Long] = typ.loadField(off, 0)
+  val initContainer: TupleAggregatorState = new TupleAggregatorState(nested, region, initStatesOffset, 0)
 
   val keyed = new GroupedBTreeKey(keyType, fb, region, _elt, nested)
   val tree = new AppendOnlyBTree(fb, keyed, region, root)
-
-  private val initStatesOffset: Code[Long] = typ.fieldOffset(off, 0)
 
   def initElement(eltOff: Code[Long], km: Code[Boolean], kv: Code[_]): Code[Unit] = {
     Code(

--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -42,7 +42,7 @@ class GroupedBTreeKey(kt: PType, fb: EmitFunctionBuilder[_], region: Code[Region
 
   def loadStates: Code[Unit] = container.load
   def storeStates: Code[Unit] = container.store
-  def copyStatesFrom(srcOff: Code[Long]): Code[Unit] = states.copyFrom(srcOff)
+  def copyStatesFrom(srcOff: Code[Long]): Code[Unit] = container.copyFrom(srcOff)
 
   def storeRegionIdx(off: Code[Long], idx: Code[Int]): Code[Unit] =
     Region.storeInt(storageType.fieldOffset(off, 1), idx)
@@ -63,7 +63,7 @@ class GroupedBTreeKey(kt: PType, fb: EmitFunctionBuilder[_], region: Code[Region
 
   def deepCopy(er: EmitRegion, dest: Code[Long], src: Code[Long]): Code[Unit] =
     Code(StagedRegionValueBuilder.deepCopy(er, storageType, src, dest),
-      states.copyFrom(containerAddress(src)),
+      container.copyFrom(containerAddress(src)),
       container.store)
 
   def compKeys(k1: (Code[Boolean], Code[_]), k2: (Code[Boolean], Code[_])): Code[Int] =
@@ -150,7 +150,7 @@ class DictState(val fb: EmitFunctionBuilder[_], val keyType: PType, val nested: 
 
   def copyFromAddress(src: Code[Long]): Code[Unit] =
     Code(
-      init(nested.copyFrom(typ.loadField(src, 0))),
+      init(initContainer.copyFrom(typ.loadField(src, 0))),
       size := Region.loadInt(typ.loadField(src, 1)),
       tree.deepCopy(Region.loadAddress(typ.loadField(src, 2))))
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
@@ -34,7 +34,7 @@ class PrevNonNullAggregator(typ: PType) extends StagedAggregator {
     Code(
       t.setup,
       t.m.mux(Code._empty,
-        Code(v := t.value, Code._println(RegionUtils.printBytes(coerce[Long](v), 16, "")), state.storeNonmissing(v))))
+        Code(v := t.value, state.storeNonmissing(v))))
   }
 
   def result(state: State, srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit] = {

--- a/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/PrevNonNullAggregator.scala
@@ -1,59 +1,48 @@
 package is.hail.expr.ir.agg
 
-import is.hail.annotations.{Region, StagedRegionValueBuilder}
+import is.hail.annotations.{Region, RegionUtils, StagedRegionValueBuilder}
 import is.hail.asm4s._
 import is.hail.expr.ir.{EmitFunctionBuilder, EmitTriplet, typeToTypeInfo}
 import is.hail.expr.types.physical._
 import is.hail.utils._
 
 class PrevNonNullAggregator(typ: PType) extends StagedAggregator {
-  type State = TypedRVAState
-
-  val stateType: PTuple = PTuple(typ.setRequired(false))
+  type State = TypedRegionBackedAggState
   val resultType: PType = typ
 
   def createState(fb: EmitFunctionBuilder[_]): State =
-    new TypedRVAState(stateType, fb)
+    new TypedRegionBackedAggState(typ.setRequired(false), fb)
 
   def initOp(state: State, init: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
     assert(init.length == 0)
-    Code(
-      state.off := state.region.allocate(stateType.alignment, stateType.byteSize),
-      stateType.setFieldMissing(state.region, state.off, 0))
+    state.storeMissing()
   }
 
   def seqOp(state: State, seq: Array[EmitTriplet], dummy: Boolean): Code[Unit] = {
     val Array(elt: EmitTriplet) = seq
-
     val v = state.fb.newField(typeToTypeInfo(typ))
-    val copyValue =
-      Code(
-        v := elt.value,
-        StagedRegionValueBuilder.deepCopy(state.fb, state.region, typ, v, stateType.fieldOffset(state.off, 0)))
-
     Code(
       elt.setup,
-      elt.m.mux(
-        Code._empty,
-        Code(
-          state.newState,
-          state.off := state.region.allocate(stateType.alignment, stateType.byteSize),
-          stateType.clearMissingBits(state.region, state.off),
-          copyValue))
+      elt.m.mux(Code._empty,
+        Code(v := elt.value, state.storeNonmissing(v)))
     )
   }
 
   def combOp(state: State, other: State, dummy: Boolean): Code[Unit] = {
-    stateType.isFieldMissing(other.off, 0).mux(
-      Code._empty,
-      Code(
-        state.newState,
-        state.off := StagedRegionValueBuilder.deepCopyFromOffset(state.fb, state.region, stateType, other.off)))
+    val t = other.get()
+    val v = state.fb.newField(typeToTypeInfo(typ))
+    Code(
+      t.setup,
+      t.m.mux(Code._empty,
+        Code(v := t.value, Code._println(RegionUtils.printBytes(coerce[Long](v), 16, "")), state.storeNonmissing(v))))
   }
 
   def result(state: State, srvb: StagedRegionValueBuilder, dummy: Boolean): Code[Unit] = {
-    stateType.isFieldMissing(state.region, state.off, 0).mux(
-      srvb.setMissing(),
-      srvb.addWithDeepCopy(resultType, Region.loadIRIntermediate(resultType)(stateType.fieldOffset(state.off, 0))))
+    val t = state.get()
+    Code(
+      t.setup,
+      t.m.mux(
+        srvb.setMissing(),
+        srvb.addWithDeepCopy(resultType, t.v)))
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeAggregator.scala
@@ -17,7 +17,7 @@ class TakeRVAS(val eltType: PType, val resultType: PArray, val fb: EmitFunctionB
   private val maxSizeOffset: Code[Long] => Code[Long] = storageType.loadField(_, 0)
   private val builderStateOffset: Code[Long] => Code[Long] = storageType.loadField(_, 1)
 
-  def newState: Code[Unit] = region.getNewRegion(regionSize)
+  def newState(off: Code[Long]): Code[Unit] = region.getNewRegion(regionSize)
 
   def createState: Code[Unit] = region.isNull.mux(r := Region.stagedCreate(regionSize), Code._empty)
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/TakeByAggregator.scala
@@ -84,7 +84,7 @@ class TakeByRVAS(val valueType: PType, val keyType: PType, val resultType: PArra
     asm4s.coerce[Unit](Code(allCode: _*))
   }
 
-  def newState: Code[Unit] = region.getNewRegion(regionSize)
+  def newState(off: Code[Long]): Code[Unit] = region.getNewRegion(regionSize)
 
   def createState: Code[Unit] = region.isNull.mux(Code(r := Region.stagedCreate(regionSize), region.invalidate()), Code._empty)
 

--- a/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/Aggregators2Suite.scala
@@ -81,8 +81,6 @@ class Aggregators2Suite extends HailSuite {
         }
       }
 
-      println("tested expected init")
-
       val serializedParts = seqOps.grouped(math.ceil(seqOps.length / nPartitions.toDouble).toInt).map { seqs =>
         val init = initF(0, region)
         val seq = withArgs(Begin(seqs))(0, region)
@@ -91,22 +89,14 @@ class Aggregators2Suite extends HailSuite {
           init.newAggState(aggRegion)
           init(region, argOff, false)
           val ioff = init.getAggOffset()
-          println("tested init")
           seq.setAggState(aggRegion, ioff)
           seq(region, argOff, false)
           val soff = seq.getAggOffset()
-          println("tested seq")
           write.setAggState(aggRegion, soff)
           write(region)
-          println("tested write")
           write.getSerializedAgg(0)
         }
       }.toArray
-      println("collected serialized aggs")
-
-      serializedParts.foreach { s =>
-        println(s.map("%02x".format(_)).mkString(" "))
-      }
 
       Region.smallScoped { aggRegion =>
         val combOp = combAndDuplicate(0, region)
@@ -115,7 +105,6 @@ class Aggregators2Suite extends HailSuite {
           combOp.setSerializedAgg(i, s)
         }
         combOp(region)
-        println("tested comb op")
         val res = resF(0, region)
         res.setAggState(aggRegion, combOp.getAggOffset())
         val double = SafeRow(rt, region, res(region))

--- a/hail/src/test/scala/is/hail/expr/ir/TakeByAggregatorSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TakeByAggregatorSuite.scala
@@ -22,7 +22,7 @@ class TakeByAggregatorSuite extends HailSuite {
 
         fb.emit(Code(
           tba.createState,
-          tba.newState,
+          tba.newState(0L),
           tba.initialize(size),
           i := 0L,
           Code.whileLoop(i < n.toLong,
@@ -55,7 +55,7 @@ class TakeByAggregatorSuite extends HailSuite {
 
       fb.emit(Code(
         tba.createState,
-        tba.newState,
+        tba.newState(0L),
         tba.initialize(7),
         tba.seqOp(true, 0, true, 0),
         tba.seqOp(true, 0, true, 0),
@@ -93,7 +93,7 @@ class TakeByAggregatorSuite extends HailSuite {
 
         fb.emit(Code(
           tba.createState,
-          tba.newState,
+          tba.newState(0L),
           tba.initialize(nToTake),
           ab.initialize(),
           i := 0,


### PR DESCRIPTION
The main goal here was to flatten out the aggregator states in the tuple of aggregator states, so that we could e.g. inline the value of a prevnonnull aggregator instead of storing a pointer to the state. The big change that I made was in creating a `TupleAggregatorState` that knows its own offset so that when we initialize a state, we can initialize the value offset directly from the value of the container. (The previous StateContainer got renamed `StateTuple` and was slimmed down accordingly.) I think I eventually want `TupleAggregatorState` to implement the `AggregatorState` interface; I haven't pushed it there yet because I haven't needed to, but I think it would fit a lot better.