### PR TITLE
Bring Streamify back to JVM

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Binds.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Binds.scala
@@ -32,7 +32,7 @@ object Bindings {
     case AggArrayPerElement(a, _, indexName, _, _, _) => if (i == 1) FastIndexedSeq(indexName -> TInt32()) else empty
     case NDArrayMap(nd, name, _) => if (i == 1) Array(name -> -coerce[TNDArray](nd.typ).elementType) else empty
     case NDArrayMap2(l, r, lName, rName, _) => if (i == 2) Array(lName -> -coerce[TNDArray](l.typ).elementType, rName -> -coerce[TNDArray](r.typ).elementType) else empty
-    case CollectDistributedArray(contexts, globals, cname, gname, _) => if (i == 2) Array(cname -> -coerce[TArray](contexts.typ).elementType, gname -> globals.typ) else empty
+    case CollectDistributedArray(contexts, globals, cname, gname, _) => if (i == 2) Array(cname -> -coerce[TStreamable](contexts.typ).elementType, gname -> globals.typ) else empty
     case Uniroot(argname, _, _, _) => if (i == 0) Array(argname -> TFloat64()) else empty
     case TableAggregate(child, _) => if (i == 1) child.typ.globalEnv.m else empty
     case MatrixAggregate(child, _) => if (i == 1) child.typ.globalEnv.m else empty

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -38,6 +38,7 @@ object Compile {
     var ir = body
     if (optimize)
       ir = Optimize(ir, noisy = true, canGenerateLiterals = false, context = Some("Compile"))
+    ir = Streamify(ir)
     TypeCheck(ir, BindingEnv(Env.fromSeq[Type](args.map { case (name, t, _) => name -> t.virtualType })))
 
     val env = args
@@ -204,6 +205,7 @@ object CompileWithAggregators2 {
     var ir = body
     if (optimize)
       ir = Optimize(ir, noisy = true, canGenerateLiterals = false, context = Some("Compile"))
+    ir = Streamify(ir)
     TypeCheck(ir, BindingEnv(Env.fromSeq[Type](args.map { case (name, t, _) => name -> t.virtualType })))
 
     val env = args

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -109,11 +109,10 @@ object InferType {
         coerce[TStreamable](a.typ).copyStreamable(zero.typ)
       case ArrayAgg(_, _, query) =>
         query.typ
-      case ArrayAggScan(_, _, query) =>
-        TArray(query.typ)
+      case ArrayAggScan(a, _, query) =>
+        coerce[TStreamable](a.typ).copyStreamable(query.typ)
       case ArrayLeftJoinDistinct(left, right, l, r, compare, join) =>
         coerce[TStreamable](left.typ).copyStreamable(join.typ)
-        TArray(join.typ)
       case NDArrayShape(nd) =>
         TTuple(nd.typ.required, List.tabulate(nd.typ.asInstanceOf[TNDArray].nDims)(_ => TInt64()):_*)
       case NDArrayReshape(nd, shape) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Streamify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Streamify.scala
@@ -1,9 +1,17 @@
 package is.hail.expr.ir
 
 import is.hail.expr.types.virtual._
+import scala.annotation.tailrec
 
 object Streamify {
-  def apply(ir0: IR): IR = MapIR(apply)(ir0) match {
+
+  @tailrec
+  private def expandFunctions(ir: IR): IR = ir match {
+    case air: ApplyIR => expandFunctions(air.explicitNode)
+    case _ => ir
+  }
+
+  def apply(ir0: IR): IR = MapIR(apply)(expandFunctions(ir0)) match {
     case ArrayRange(i, j, k) =>
       ToArray(StreamRange(i, j, k))
     case MakeArray(xs, t) =>
@@ -33,7 +41,6 @@ object Streamify {
     case ToArray(a) => ToArray(toStream(a))
     case ToDict(a) => ToDict(toStream(a))
     case ToSet(a) => ToSet(toStream(a))
-    case app: ApplyIR => apply(app.explicitNode)
     case ir => ir
   }
 

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -220,7 +220,7 @@ object TypeCheck {
         assert(cond.typ.isOfType(TBoolean()))
       case x@ArrayFlatMap(a, name, body) =>
         assert(a.typ.isInstanceOf[TStreamable])
-        assert(body.typ.isInstanceOf[TArray])
+        assert(body.typ.isInstanceOf[TStreamable])
       case x@ArrayFold(a, zero, accumName, valueName, body) =>
         assert(a.typ.isInstanceOf[TStreamable])
         assert(body.typ == zero.typ)
@@ -343,7 +343,7 @@ object TypeCheck {
       case BlockMatrixWrite(_, _) =>
       case BlockMatrixMultiWrite(_, _) =>
       case CollectDistributedArray(ctxs, globals, cname, gname, body) =>
-        assert(ctxs.typ.isInstanceOf[TArray])
+        assert(ctxs.typ.isInstanceOf[TStreamable])
       case x@ReadPartition(path, _, rowType) =>
         assert(path.typ == TString())
         assert(x.typ == TStream(rowType))

--- a/hail/src/test/scala/is/hail/expr/ir/StreamifySuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StreamifySuite.scala
@@ -1,0 +1,37 @@
+package is.hail.expr.ir
+
+import is.hail.expr.types.virtual._
+
+import org.scalatest.testng.TestNGSuite
+import org.testng.annotations.Test
+
+class StreamifySuite extends TestNGSuite {
+
+  val Seq(x, y, z) = Seq("x", "y", "z").map(Ref(_, TInt32()))
+  val a = Ref("a", TArray(TInt32()))
+
+  def tests: Seq[(IR, IR)] = Seq(
+    ArrayRange(0, 40, 2) ->
+      ToArray(StreamRange(0, 40, 2)),
+    ArrayMap(ArrayRange(0, 40, 2), "x", x + 1) ->
+      ToArray(ArrayMap(StreamRange(0, 40, 2), "x", x + 1)),
+    ArrayMap(ArrayMap(ArrayRange(0, 40, 2), "x", x + 1), "y", y * 2) ->
+      ToArray(ArrayMap(ArrayMap(StreamRange(0, 40, 2), "x", x + 1), "y", y * 2)),
+    ArrayFlatMap(ArrayRange(0, 40, 2), "x", ArrayMap(a, "y", x + y)) ->
+      ToArray(ArrayFlatMap(StreamRange(0, 40, 2), "x", ArrayMap(ToStream(a), "y", x + y))),
+    ArrayScan(a, 0, "a", "x", ArrayFold(ArrayRange(0, x, 1), 1, "z", "y", z * y)) ->
+      ToArray(ArrayScan(ToStream(a), 0, "a", "x", ArrayFold(StreamRange(0, x, 1), 1, "z", "y", z * y))),
+    ArrayMap(ArraySort(Let("x", 3, ArrayRange(0, x, 1)), "l", "r", true), "y", y) ->
+      ToArray(ArrayMap(ToStream(ArraySort(Let("x", 3, StreamRange(0, x, 1)), "l", "r", true)), "y", y)),
+    ArrayFilter(ToArray(ToSet(a)), "y", y < 2) ->
+      ToArray(ArrayFilter(ToStream(ToSet(ToStream(a))), "y", y < 2)),
+    ArrayMap(If(true, ArrayRange(0, 5, 1), ArrayRange(0, 10, 1)), "x", x - 1) ->
+      ToArray(ArrayMap(
+        ToStream(If(true, ToArray(StreamRange(0, 5, 1)), ToArray(StreamRange(0, 10, 1)))),
+        "x", x - 1))
+  )
+
+  @Test def testStreamify() =
+    for ((ir0, ir1) <- tests)
+      assert(Streamify(ir0) == ir1)
+}


### PR DESCRIPTION
This PR brings the `Streamify` pass back to the JVM emitter. Streamify is useful because it make explicit *in the structure of the IR*, which nodes are stream producers and which nodes are stream consumer.

In particular, the following nodes **produce** streams:
```
ReadPartition
MakeStream
StreamRange
ToStream

ArrayMap
ArrayFilter
ArrayFlatMap
ArrayScan
ArrayAggScan
ArrayLeftJoinDistinct

Let /* sometimes */
```
And the following nodes **consume** streams (`#` indicates which arguments are streams):
```
ToArray(#)
ToDict(#)
ToSet(#)
GroupByKey(#)  
ArraySort(#, -, -, -)
ArrayFold(#, -, -, -, -)
ArrayFold2(#, -, -, -, -)
ArrayFor(#, -, -)
ArrayAgg(#, -, -)
CollectDistributedArray(#, -, -, -, -)

ArrayMap(#, -, -)
ArrayFilter(#, -, -)
ArrayFlatMap(#, -, #)
ArrayScan(#, -, -, -, -)
ArrayAggScan(#, -, -)
ArrayLeftJoinDistinct(#, #, -, -, -, -)

Let(-, -, #) /* sometimes */
```

Thus, `Emit` may make better assumptions about the IR it is walking over. `emitArrayIterator` only deals with stream producers, and all stream consumers must call `emitArrayIterator` on their stream arguments.

Additionally:
  - `Streamify` was fixed to materialize less arrays than it used to (there were also bugs that caused errors on certain IR; see tests)
  - The producer `ToStream` may assume that its argument is a container.
  - The IR nodes `ArrayRange` and `MakeArray` do not make their way to `Emit`.
  - I'm not sure what the purpose of `{T,P}Streamable` is, I think all of its functionality is already covered by `{T,P}Iterable`.