### PR TITLE
[hailctl] Move default location for hail config directory

### DIFF
--- a/hail/python/hailtop/auth/tokens.py
+++ b/hail/python/hailtop/auth/tokens.py
@@ -3,7 +3,7 @@ import os
 import sys
 import json
 import logging
-from hailtop.config import get_deploy_config
+from hailtop.config import HAIL_CONFIG_DIR, get_deploy_config
 
 log = logging.getLogger('gear')
 
@@ -14,7 +14,7 @@ class Tokens(collections.abc.MutableMapping):
         deploy_config = get_deploy_config()
         location = deploy_config.location()
         if location == 'external':
-            return os.path.expanduser('~/.hail/tokens.json')
+            return os.path.join(HAIL_CONFIG_DIR, 'tokens.json')
         return '/user-tokens/tokens.json'
 
     def __init__(self):

--- a/hail/python/hailtop/config/__init__.py
+++ b/hail/python/hailtop/config/__init__.py
@@ -1,5 +1,6 @@
-from .deploy_config import get_deploy_config
+from .deploy_config import HAIL_CONFIG_DIR, get_deploy_config
 
 __all__ = [
+    'HAIL_CONFIG_DIR',
     'get_deploy_config'
 ]

--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -9,9 +9,11 @@ log = logging.getLogger('gear')
 def get_conf_dir():
     xdg_conf_home = os.environ.get('XDG_CONFIG_HOME', os.path.expanduser('~/.config'))
     hail_conf = os.path.join(xdg_conf_home, 'hail')
+    dot_hail = os.path.expanduser('~/.hail')
+    if os.path.exists(os.path.join(dot_hail, 'tokens.json')):
+        return dot_hail
     if os.path.isdir(hail_conf):
         return hail_conf
-    dot_hail = os.path.expanduser('~/.hail')
     if not os.path.exists(dot_hail):
         return hail_conf
     return dot_hail

--- a/hail/python/hailtop/config/deploy_config.py
+++ b/hail/python/hailtop/config/deploy_config.py
@@ -6,6 +6,20 @@ from aiohttp import web
 log = logging.getLogger('gear')
 
 
+def get_conf_dir():
+    xdg_conf_home = os.environ.get('XDG_CONFIG_HOME', os.path.expanduser('~/.config'))
+    hail_conf = os.path.join(xdg_conf_home, 'hail')
+    if os.path.isdir(hail_conf):
+        return hail_conf
+    dot_hail = os.path.expanduser('~/.hail')
+    if not os.path.exists(dot_hail):
+        return hail_conf
+    return dot_hail
+
+
+HAIL_CONFIG_DIR = get_conf_dir()
+
+
 class DeployConfig:
     @staticmethod
     def from_config(config):
@@ -15,7 +29,7 @@ class DeployConfig:
     def from_config_file(config_file=None):
         if not config_file:
             config_file = os.environ.get(
-                'HAIL_DEPLOY_CONFIG_FILE', os.path.expanduser('~/.hail/deploy-config.json'))
+                'HAIL_DEPLOY_CONFIG_FILE', os.path.join(HAIL_CONFIG_DIR, 'deploy-config.json'))
         if os.path.isfile(config_file):
             with open(config_file, 'r') as f:
                 config = json.loads(f.read())

--- a/hail/python/hailtop/hailctl/auth/login.py
+++ b/hail/python/hailtop/hailctl/auth/login.py
@@ -5,7 +5,7 @@ import webbrowser
 import aiohttp
 from aiohttp import web
 
-from hailtop.config import get_deploy_config
+from hailtop.config import HAIL_CONFIG_DIR, get_deploy_config
 from hailtop.auth import get_tokens, namespace_auth_headers
 
 
@@ -77,9 +77,8 @@ Opening in your browser.
 
     tokens = get_tokens()
     tokens[auth_ns] = token
-    dot_hail_dir = os.path.expanduser('~/.hail')
-    if not os.path.exists(dot_hail_dir):
-        os.mkdir(dot_hail_dir, mode=0o700)
+    if not os.path.exists(HAIL_CONFIG_DIR):
+        os.mkdirs(HAIL_CONFIG_DIR, mode=0o700, exist_ok=True)
     tokens.write()
 
     if auth_ns == 'default':

--- a/hail/python/hailtop/hailctl/dev/config/cli.py
+++ b/hail/python/hailtop/hailctl/dev/config/cli.py
@@ -1,6 +1,6 @@
 import os
 import json
-from hailtop.config import get_deploy_config
+from hailtop.config import HAIL_CONFIG_DIR, get_deploy_config
 
 
 def init_parser(parser):
@@ -35,6 +35,6 @@ def main(args):
     }
 
     config_file = os.environ.get(
-        'HAIL_DEPLOY_CONFIG_FILE', os.path.expanduser('~/.hail/deploy-config.json'))
+        'HAIL_DEPLOY_CONFIG_FILE', os.path.join(HAIL_CONFIG_DIR, 'deploy-config.json'))
     with open(config_file, 'w') as f:
         f.write(json.dumps(config))


### PR DESCRIPTION
Now we try, in order:
```
    $XDG_CONFIG_HOME/hail
    ~/.config/hail
    ~/.hail
```

The [XDG Base Directory Specification] is a freedesktop spec inteded to
define where applications should look for files they need to run.

[XDG Base Directory Specification]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

If ~/.hail already exists on your system, this should not break you as
long as $XDG_CONFIG_HOME/hail or ~/.config/hail also do not exist.

I have enough 💩 in my home directory for applications I don't control,
I'd like to try to keep it clean when it comes to applications I do
control.