### PR TITLE
[hail] various cleanups to the GroupBy aggregator

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -93,7 +93,7 @@ class DictState(val fb: EmitFunctionBuilder[_], val keyType: PType, val nested: 
   val initContainer: TupleAggregatorState = new TupleAggregatorState(fb, nested, region, initStatesOffset)
 
   val keyed = new GroupedBTreeKey(keyType, fb, region, _elt, nested)
-  val tree = new AppendOnlyBTree(fb, keyed, region, root)
+  val tree = new AppendOnlyBTree(fb, keyed, region, root, maxElements = 6)
 
   def initElement(eltOff: Code[Long], km: Code[Boolean], kv: Code[_]): Code[Unit] = {
     Code(


### PR DESCRIPTION
- each node in the BTree holds 6 elements
- the agg containers are stored inline in each tree element instead of by reference
- unrolled the recursive calls to `get` into a while loop (I'm not actually super sure why this helps, but it seems to have sped up the benchmark.)

Current master vs this PR:
```
                   Name      Ratio    Time 1    Time 2
                   ----      -----    ------    ------
table_aggregate_counter      86.6%     9.107     7.887
```