### PR TITLE
hailctl dataproc connect needs dry-run

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/connect.py
+++ b/hail/python/hailtop/hailctl/dataproc/connect.py
@@ -15,11 +15,10 @@ def init_parser(parser):
                         help='Local port to use for SSH tunnel to master node (default: %(default)s).')
     parser.add_argument('--zone', '-z', default='us-central1-b', type=str,
                         help='Compute zone for Dataproc cluster (default: %(default)s).')
+    parser.add_argument('--dry-run', action='store_true', help="Print gcloud dataproc command, but don't run it.")
 
 
 def main(args, pass_through_args):  # pylint: disable=unused-argument
-    print("Connecting to cluster '{}'...".format(args.name))
-
     # shortcut mapping
     shortcut = {
         'ui': 'spark-ui',
@@ -38,44 +37,52 @@ def main(args, pass_through_args):  # pylint: disable=unused-argument
     }
     connect_port_and_path = dataproc_port_and_path[service]
 
-    # open SSH tunnel to master node
-    sp.check_call(
-        ['gcloud',
-         'compute',
-         'ssh',
-         '{}-m'.format(args.name),
-         '--zone={}'.format(args.zone),
-         '--ssh-flag=-D {}'.format(args.port),
-         '--ssh-flag=-N',
-         '--ssh-flag=-f',
-         '--ssh-flag=-n'],
-        stderr=sp.STDOUT
-    )
+    cmd = ['gcloud',
+           'compute',
+           'ssh',
+           '{}-m'.format(args.name),
+           '--zone={}'.format(args.zone),
+           '--ssh-flag=-D {}'.format(args.port),
+           '--ssh-flag=-N',
+           '--ssh-flag=-f',
+           '--ssh-flag=-n']
 
-    import platform
-    system = platform.system()
+    print('gcloud command:')
+    print(' '.join(cmd[:4]) + ' \\\n    ' + ' \\\n    '.join(cmd[4:]))
 
-    chrome = os.environ.get('HAILCTL_CHROME')
-    if system == 'Darwin':
-        chrome = chrome or r'/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
-    elif system == 'Linux':
-        for c in ['chromium', 'chromium-browser']:
-            chrome = chrome or shutil.which(c)
-        if chrome is None:
-            raise EnvironmentError("cannot find 'chromium' or 'chromium-browser' on path")
-    elif system == 'Windows':
-        chrome = chrome or r'/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe'
+    if not args.dry_run:
+        print("Connecting to cluster '{}'...".format(args.name))
 
-    if not chrome:
-        raise ValueError(f"unsupported system: {system}, set environment variable HAILCTL_CHROME to a chrome executable")
+        # open SSH tunnel to master node
+        sp.check_call(
+            cmd,
+            stderr=sp.STDOUT
+        )
 
-    # open Chrome with SOCKS proxy configuration
-    with open(os.devnull, 'w') as f:
-        sp.Popen([
-            chrome,
-            'http://localhost:{}'.format(connect_port_and_path),
-            '--proxy-server=socks5://localhost:{}'.format(args.port),
-            '--host-resolver-rules=MAP * 0.0.0.0 , EXCLUDE localhost',
-            '--proxy-bypass-list=<-loopback>',  # https://chromium.googlesource.com/chromium/src/+/da790f920bbc169a6805a4fb83b4c2ab09532d91
-            '--user-data-dir={}'.format(tempfile.gettempdir())
-        ], stdout=f, stderr=f)
+        import platform
+        system = platform.system()
+
+        chrome = os.environ.get('HAILCTL_CHROME')
+        if system == 'Darwin':
+            chrome = chrome or r'/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+        elif system == 'Linux':
+            for c in ['chromium', 'chromium-browser']:
+                chrome = chrome or shutil.which(c)
+            if chrome is None:
+                raise EnvironmentError("cannot find 'chromium' or 'chromium-browser' on path")
+        elif system == 'Windows':
+            chrome = chrome or r'/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe'
+
+        if not chrome:
+            raise ValueError(f"unsupported system: {system}, set environment variable HAILCTL_CHROME to a chrome executable")
+
+        # open Chrome with SOCKS proxy configuration
+        with open(os.devnull, 'w') as f:
+            sp.Popen([
+                chrome,
+                'http://localhost:{}'.format(connect_port_and_path),
+                '--proxy-server=socks5://localhost:{}'.format(args.port),
+                '--host-resolver-rules=MAP * 0.0.0.0 , EXCLUDE localhost',
+                '--proxy-bypass-list=<-loopback>',  # https://chromium.googlesource.com/chromium/src/+/da790f920bbc169a6805a4fb83b4c2ab09532d91
+                '--user-data-dir={}'.format(tempfile.gettempdir())
+            ], stdout=f, stderr=f)

--- a/hail/python/hailtop/hailctl/dataproc/connect.py
+++ b/hail/python/hailtop/hailctl/dataproc/connect.py
@@ -48,7 +48,7 @@ def main(args, pass_through_args):  # pylint: disable=unused-argument
            '--ssh-flag=-n']
 
     print('gcloud command:')
-    print(' '.join(cmd[:4]) + ' \\\n    ' + ' \\\n    '.join(cmd[4:]))
+    print(' '.join(cmd[:4]) + ' \\\n    ' + ' \\\n    '.join([f"'{x}'" for x in cmd[4:]]))
 
     if not args.dry_run:
         print("Connecting to cluster '{}'...".format(args.name))


### PR DESCRIPTION
Turns out we didn't support `--dry-run` on `dataproc connect`. I'm not totally satisfied with this, as the command that gets printed out isn't runnable, because it will lack quotes around the `--ssh-flag=-D 1000` part. I tried adding the quotes into the command, thinking it would work but just be redundant, but I couldn't get it to work. I suppose I could have the printing logic go through the list and replace that bit with a quoted version. Let me know what you think. 