### PR TITLE
Update docs for building Hail

### DIFF
--- a/hail/python/hail/docs/getting_started_developing.rst
+++ b/hail/python/hail/docs/getting_started_developing.rst
@@ -24,11 +24,11 @@ variable tells GNU Make to build the native libraries from source.
 
 Build and install a wheel file from source with local-mode ``pyspark``::
 
-    make install-wheel HAIL_COMPILE_NATIVES=1
+    make install HAIL_COMPILE_NATIVES=1
 
 As above, but explicitly specifying the Spark version::
 
-    make install-wheel HAIL_COMPILE_NATIVES=1 SPARK_VERSION=2.4.1
+    make install HAIL_COMPILE_NATIVES=1 SPARK_VERSION=2.4.1
 
 Building the Docs and Website
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The `install-wheel` Make target was renamed to `install` in hail-is/hail@346fb67aa5f943c42981025823876272ee222183 but the documentation for building Hail still refers to the old name.