### PR TITLE
[hail] Add lazily computed `rowCountUpperBound` to MatrixIR/TableIR

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -46,6 +46,8 @@ abstract sealed class MatrixIR extends BaseIR {
 
   def partitionCounts: Option[IndexedSeq[Long]] = None
 
+  val rowCountUpperBound: Option[Long]
+
   def columnCount: Option[Int] = None
 
   override def copy(newChildren: IndexedSeq[BaseIR]): MatrixIR
@@ -93,6 +95,8 @@ object MatrixLiteral {
 
 case class MatrixLiteral(typ: MatrixType, tl: TableLiteral) extends MatrixIR {
   lazy val children: IndexedSeq[BaseIR] = Array.empty[BaseIR]
+
+  lazy val rowCountUpperBound: Option[Long] = None
 
   def copy(newChildren: IndexedSeq[BaseIR]): MatrixLiteral = {
     assert(newChildren.isEmpty)
@@ -301,6 +305,8 @@ case class MatrixRead(
       reader.partitionCounts
   }
 
+  lazy val rowCountUpperBound: Option[Long] = partitionCounts.map(_.sum)
+
   override def columnCount: Option[Int] = {
     if (dropCols)
       Some(0)
@@ -323,6 +329,8 @@ case class MatrixFilterCols(child: MatrixIR, pred: IR) extends MatrixIR {
   val typ: MatrixType = child.typ
 
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 }
 
 case class MatrixFilterRows(child: MatrixIR, pred: IR) extends MatrixIR {
@@ -337,6 +345,8 @@ case class MatrixFilterRows(child: MatrixIR, pred: IR) extends MatrixIR {
   def typ: MatrixType = child.typ
 
   override def columnCount: Option[Int] = child.columnCount
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 }
 
 case class MatrixChooseCols(child: MatrixIR, oldIndices: IndexedSeq[Int]) extends MatrixIR {
@@ -352,6 +362,8 @@ case class MatrixChooseCols(child: MatrixIR, oldIndices: IndexedSeq[Int]) extend
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
 
   override def columnCount: Option[Int] = Some(oldIndices.length)
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 }
 
 case class MatrixCollectColsByKey(child: MatrixIR) extends MatrixIR {
@@ -371,6 +383,8 @@ case class MatrixCollectColsByKey(child: MatrixIR) extends MatrixIR {
   }
 
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 }
 
 case class MatrixAggregateRowsByKey(child: MatrixIR, entryExpr: IR, rowExpr: IR) extends MatrixIR {
@@ -389,6 +403,8 @@ case class MatrixAggregateRowsByKey(child: MatrixIR, entryExpr: IR, rowExpr: IR)
   )
 
   override def columnCount: Option[Int] = child.columnCount
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 }
 
 case class MatrixAggregateColsByKey(child: MatrixIR, entryExpr: IR, colExpr: IR) extends MatrixIR {
@@ -406,6 +422,8 @@ case class MatrixAggregateColsByKey(child: MatrixIR, entryExpr: IR, colExpr: IR)
     colType = child.typ.colKeyStruct ++ coerce[TStruct](colExpr.typ))
 
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 }
 
 case class MatrixUnionCols(left: MatrixIR, right: MatrixIR) extends MatrixIR {
@@ -420,6 +438,13 @@ case class MatrixUnionCols(left: MatrixIR, right: MatrixIR) extends MatrixIR {
 
   override def columnCount: Option[Int] =
     left.columnCount.flatMap(leftCount => right.columnCount.map(rightCount => leftCount + rightCount))
+
+  lazy val rowCountUpperBound: Option[Long] = (left.rowCountUpperBound, right.rowCountUpperBound) match {
+    case (Some(l), Some(r)) => Some(l.min(r))
+    case (Some(l), None) => Some(l)
+    case (None, Some(r)) => Some(r)
+    case (None, None) => None
+  }
 }
 
 case class MatrixMapEntries(child: MatrixIR, newEntries: IR) extends MatrixIR {
@@ -436,6 +461,8 @@ case class MatrixMapEntries(child: MatrixIR, newEntries: IR) extends MatrixIR {
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
 
   override def columnCount: Option[Int] = child.columnCount
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 }
 
 case class MatrixKeyRowsBy(child: MatrixIR, keys: IndexedSeq[String], isSorted: Boolean = false) extends MatrixIR {
@@ -452,6 +479,8 @@ case class MatrixKeyRowsBy(child: MatrixIR, keys: IndexedSeq[String], isSorted: 
   }
 
   override def columnCount: Option[Int] = child.columnCount
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 }
 
 case class MatrixMapRows(child: MatrixIR, newRow: IR) extends MatrixIR {
@@ -470,6 +499,8 @@ case class MatrixMapRows(child: MatrixIR, newRow: IR) extends MatrixIR {
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
 
   override def columnCount: Option[Int] = child.columnCount
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 }
 
 case class MatrixMapCols(child: MatrixIR, newCol: IR, newKey: Option[IndexedSeq[String]]) extends MatrixIR {
@@ -489,6 +520,8 @@ case class MatrixMapCols(child: MatrixIR, newCol: IR, newKey: Option[IndexedSeq[
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
 
   override def columnCount: Option[Int] = child.columnCount
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 }
 
 case class MatrixMapGlobals(child: MatrixIR, newGlobals: IR) extends MatrixIR {
@@ -505,6 +538,8 @@ case class MatrixMapGlobals(child: MatrixIR, newGlobals: IR) extends MatrixIR {
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
 
   override def columnCount: Option[Int] = child.columnCount
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 }
 
 case class MatrixFilterEntries(child: MatrixIR, pred: IR) extends MatrixIR {
@@ -520,6 +555,8 @@ case class MatrixFilterEntries(child: MatrixIR, pred: IR) extends MatrixIR {
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
 
   override def columnCount: Option[Int] = child.columnCount
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 }
 
 case class MatrixAnnotateColsTable(
@@ -543,6 +580,8 @@ case class MatrixAnnotateColsTable(
       newChildren(1).asInstanceOf[TableIR],
       root)
   }
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 }
 
 case class MatrixAnnotateRowsTable(
@@ -560,6 +599,8 @@ case class MatrixAnnotateRowsTable(
   override def columnCount: Option[Int] = child.columnCount
 
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 
   private val annotationType =
     if (product)
@@ -580,6 +621,8 @@ case class MatrixExplodeRows(child: MatrixIR, path: IndexedSeq[String]) extends 
   assert(path.nonEmpty)
 
   lazy val children: IndexedSeq[BaseIR] = FastIndexedSeq(child)
+
+  lazy val rowCountUpperBound: Option[Long] = None
 
   def copy(newChildren: IndexedSeq[BaseIR]): MatrixExplodeRows = {
     val IndexedSeq(newChild) = newChildren
@@ -618,6 +661,8 @@ case class MatrixRepartition(child: MatrixIR, n: Int, strategy: Int) extends Mat
   }
 
   override def columnCount: Option[Int] = child.columnCount
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 }
 
 case class MatrixUnionRows(children: IndexedSeq[MatrixIR]) extends MatrixIR {
@@ -640,6 +685,14 @@ case class MatrixUnionRows(children: IndexedSeq[MatrixIR]) extends MatrixIR {
       require(c1.forall { i1 => c2.forall(i1 == _) })
       c1.orElse(c2)
     }
+
+  lazy val rowCountUpperBound: Option[Long] = {
+    val definedChildren = children.flatMap(_.rowCountUpperBound)
+    if (definedChildren.length == children.length)
+      Some(definedChildren.sum)
+    else
+      None
+  }
 }
 
 case class MatrixDistinctByRow(child: MatrixIR) extends MatrixIR {
@@ -654,6 +707,8 @@ case class MatrixDistinctByRow(child: MatrixIR) extends MatrixIR {
   }
 
   override def columnCount: Option[Int] = child.columnCount
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 }
 
 case class MatrixRowsHead(child: MatrixIR, n: Long) extends MatrixIR {
@@ -668,6 +723,11 @@ case class MatrixRowsHead(child: MatrixIR, n: Long) extends MatrixIR {
   }
 
   override def columnCount: Option[Int] = child.columnCount
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound match {
+    case Some(c) => Some(c.min(n))
+    case None => Some(n)
+  }
 }
 
 case class MatrixColsHead(child: MatrixIR, n: Int) extends MatrixIR {
@@ -684,6 +744,8 @@ case class MatrixColsHead(child: MatrixIR, n: Int) extends MatrixIR {
   override def columnCount: Option[Int] = child.columnCount.map(math.min(_, n))
 
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 }
 
 case class MatrixExplodeCols(child: MatrixIR, path: IndexedSeq[String]) extends MatrixIR {
@@ -698,6 +760,8 @@ case class MatrixExplodeCols(child: MatrixIR, path: IndexedSeq[String]) extends 
   override def columnCount: Option[Int] = None
 
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 
   private val (keysType, querier) = child.typ.colType.queryTyped(path.toList)
   private val keyType = keysType match {
@@ -738,6 +802,8 @@ case class CastTableToMatrix(
   }
 
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 }
 
 case class MatrixToMatrixApply(child: MatrixIR, function: MatrixToMatrixFunction) extends MatrixIR {
@@ -752,6 +818,8 @@ case class MatrixToMatrixApply(child: MatrixIR, function: MatrixToMatrixFunction
 
   override def partitionCounts: Option[IndexedSeq[Long]] =
     if (function.preservesPartitionCounts) child.partitionCounts else None
+
+  lazy val rowCountUpperBound: Option[Long] = if (function.preservesPartitionCounts) child.rowCountUpperBound else None
 }
 
 case class MatrixRename(child: MatrixIR,
@@ -773,6 +841,8 @@ case class MatrixRename(child: MatrixIR,
 
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
 
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
+
   override def columnCount: Option[Int] = child.columnCount
 
   def copy(newChildren: IndexedSeq[BaseIR]): MatrixRename = {
@@ -792,6 +862,8 @@ case class MatrixFilterIntervals(child: MatrixIR, intervals: IndexedSeq[Interval
   override lazy val typ: MatrixType = child.typ
 
   override def columnCount: Option[Int] = child.columnCount
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 }
 
 case class RelationalLetMatrixTable(name: String, value: IR, body: MatrixIR) extends MatrixIR {
@@ -803,4 +875,6 @@ case class RelationalLetMatrixTable(name: String, value: IR, body: MatrixIR) ext
     val IndexedSeq(newValue: IR, newBody: MatrixIR) = newChildren
     RelationalLetMatrixTable(name, newValue, newBody)
   }
+
+  lazy val rowCountUpperBound: Option[Long] = body.rowCountUpperBound
 }

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -45,6 +45,8 @@ abstract sealed class TableIR extends BaseIR {
 
   def partitionCounts: Option[IndexedSeq[Long]] = None
 
+  val rowCountUpperBound: Option[Long]
+
   protected[ir] def execute(ctx: ExecuteContext): TableValue =
     fatal("tried to execute unexecutable IR:\n" + Pretty(this))
 
@@ -95,6 +97,8 @@ object TableLiteral {
 
 case class TableLiteral(typ: TableType, rvd: RVD, enc: CodecSpec2, encodedGlobals: Array[Byte]) extends TableIR {
   val children: IndexedSeq[BaseIR] = Array.empty[BaseIR]
+
+  lazy val rowCountUpperBound: Option[Long] = None
 
   def copy(newChildren: IndexedSeq[BaseIR]): TableLiteral = {
     assert(newChildren.isEmpty)
@@ -277,6 +281,8 @@ case class TableRead(typ: TableType, dropRows: Boolean, tr: TableReader) extends
 
   override def partitionCounts: Option[IndexedSeq[Long]] = tr.partitionCounts
 
+  lazy val rowCountUpperBound: Option[Long] = partitionCounts.map(_.sum)
+
   val children: IndexedSeq[BaseIR] = Array.empty[BaseIR]
 
   def copy(newChildren: IndexedSeq[BaseIR]): TableRead = {
@@ -290,6 +296,8 @@ case class TableRead(typ: TableType, dropRows: Boolean, tr: TableReader) extends
 case class TableParallelize(rowsAndGlobal: IR, nPartitions: Option[Int] = None) extends TableIR {
   require(rowsAndGlobal.typ.isInstanceOf[TStruct])
   require(rowsAndGlobal.typ.asInstanceOf[TStruct].fieldNames.sameElements(Array("rows", "global")))
+
+  lazy val rowCountUpperBound: Option[Long] = None
 
   private val rowsType = rowsAndGlobal.typ.asInstanceOf[TStruct].fieldType("rows").asInstanceOf[TArray]
   private val globalsType = rowsAndGlobal.typ.asInstanceOf[TStruct].fieldType("global").asInstanceOf[TStruct]
@@ -341,6 +349,8 @@ case class TableKeyBy(child: TableIR, keys: IndexedSeq[String], isSorted: Boolea
   private val fields = child.typ.rowType.fieldNames.toSet
   assert(keys.forall(fields.contains), s"${ keys.filter(k => !fields.contains(k)).mkString(", ") }")
 
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
+
   val children: IndexedSeq[BaseIR] = Array(child)
 
   val typ: TableType = child.typ.copy(key = keys)
@@ -370,6 +380,8 @@ case class TableRange(n: Int, nPartitions: Int) extends TableIR {
   private val partCounts = partition(n, nPartitionsAdj)
 
   override val partitionCounts = Some(partCounts.map(_.toLong).toFastIndexedSeq)
+
+  lazy val rowCountUpperBound: Option[Long] = Some(n.toLong)
 
   val typ: TableType = TableType(
     TStruct("idx" -> TInt32()),
@@ -414,6 +426,8 @@ case class TableFilter(child: TableIR, pred: IR) extends TableIR {
 
   val typ: TableType = child.typ
 
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
+
   def copy(newChildren: IndexedSeq[BaseIR]): TableFilter = {
     assert(newChildren.length == 2)
     TableFilter(newChildren(0).asInstanceOf[TableIR], newChildren(1).asInstanceOf[IR])
@@ -452,6 +466,11 @@ case class TableHead(child: TableIR, n: Long) extends TableIR {
   override def partitionCounts: Option[IndexedSeq[Long]] =
     child.partitionCounts.map(getHeadPartitionCounts(_, n))
 
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound match {
+    case Some(c) => Some(c.min(n))
+    case None => Some(n)
+  }
+
   protected[ir] override def execute(ctx: ExecuteContext): TableValue = {
     val prev = child.execute(ctx)
     prev.copy(rvd = prev.rvd.head(n, child.partitionCounts))
@@ -466,6 +485,8 @@ object RepartitionStrategy {
 
 case class TableRepartition(child: TableIR, n: Int, strategy: Int) extends TableIR {
   def typ: TableType = child.typ
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 
   lazy val children: IndexedSeq[BaseIR] = FastIndexedSeq(child)
 
@@ -525,8 +546,7 @@ case class TableJoin(left: TableIR, right: TableIR, joinType: String, joinKey: I
 
   val children: IndexedSeq[BaseIR] = Array(left, right)
 
-
-
+  lazy val rowCountUpperBound: Option[Long] = None
 
   private val newRowType = {
     val leftRowType = left.typ.rowType
@@ -649,6 +669,8 @@ case class TableIntervalJoin(
 ) extends TableIR {
   lazy val children: IndexedSeq[BaseIR] = Array(left, right)
 
+  lazy val rowCountUpperBound: Option[Long] = left.rowCountUpperBound
+
   val rightType: Type = if (product) TArray(right.typ.valueType) else right.typ.valueType
   val typ: TableType = left.typ.copy(rowType = left.typ.rowType.appendKey(root, rightType))
 
@@ -731,6 +753,13 @@ case class TableZipUnchecked(left: TableIR, right: TableIR) extends TableIR {
   require((left.typ.rowType.fieldNames ++ right.typ.rowType.fieldNames).areDistinct())
   require(right.typ.key.isEmpty)
 
+  lazy val rowCountUpperBound: Option[Long] = (left.rowCountUpperBound, right.rowCountUpperBound) match {
+    case (Some(l), Some(r)) => Some(l.min(r))
+    case (Some(l), None) => Some(l)
+    case (None, Some(r)) => Some(r)
+    case (None, None) => None
+  }
+
   val typ: TableType = left.typ.copy(rowType = left.typ.rowType ++ right.typ.rowType)
 
   override def partitionCounts: Option[IndexedSeq[Long]] = left.partitionCounts
@@ -791,6 +820,8 @@ case class TableMultiWayZipJoin(children: IndexedSeq[TableIR], fieldName: String
 
   private val first = children.head
   private val rest = children.tail
+
+  lazy val rowCountUpperBound: Option[Long] = None
 
   require(rest.forall(e => e.typ.rowType == first.typ.rowType), "all rows must have the same type")
   require(rest.forall(e => e.typ.key == first.typ.key), "all keys must be the same")
@@ -885,6 +916,8 @@ case class TableLeftJoinRightDistinct(left: TableIR, right: TableIR, root: Strin
   require(right.typ.keyType isPrefixOf left.typ.keyType,
     s"\n  L: ${ left.typ }\n  R: ${ right.typ }")
 
+  lazy val rowCountUpperBound: Option[Long] = left.rowCountUpperBound
+
   lazy val children: IndexedSeq[BaseIR] = Array(left, right)
 
   private val newRowType = left.typ.rowType.structInsert(right.typ.valueType, List(root))._1
@@ -913,6 +946,8 @@ case class TableLeftJoinRightDistinct(left: TableIR, right: TableIR, root: Strin
 // Must leave key fields unchanged.
 case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
   val children: IndexedSeq[BaseIR] = Array(child, newRow)
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 
   val typ: TableType = child.typ.copy(rowType = newRow.typ.asInstanceOf[TStruct])
 
@@ -1067,6 +1102,8 @@ case class TableMapRows(child: TableIR, newRow: IR) extends TableIR {
 case class TableMapGlobals(child: TableIR, newGlobals: IR) extends TableIR {
   val children: IndexedSeq[BaseIR] = Array(child, newGlobals)
 
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
+
   val typ: TableType =
     child.typ.copy(globalType = newGlobals.typ.asInstanceOf[TStruct])
 
@@ -1102,6 +1139,8 @@ case class TableMapGlobals(child: TableIR, newGlobals: IR) extends TableIR {
 case class TableExplode(child: TableIR, path: IndexedSeq[String]) extends TableIR {
   assert(path.nonEmpty)
   assert(!child.typ.key.contains(path.head))
+
+  lazy val rowCountUpperBound: Option[Long] = None
 
   lazy val children: IndexedSeq[BaseIR] = Array(child)
 
@@ -1183,6 +1222,14 @@ case class TableUnion(children: IndexedSeq[TableIR]) extends TableIR {
   assert(children.tail.forall(_.typ.rowType == children(0).typ.rowType))
   assert(children.tail.forall(_.typ.key == children(0).typ.key))
 
+  lazy val rowCountUpperBound: Option[Long] = {
+    val definedChildren = children.flatMap(_.rowCountUpperBound)
+    if (definedChildren.length == children.length)
+      Some(definedChildren.sum)
+    else
+      None
+  }
+
   def copy(newChildren: IndexedSeq[BaseIR]): TableUnion = {
     TableUnion(newChildren.map(_.asInstanceOf[TableIR]))
   }
@@ -1203,6 +1250,8 @@ case class MatrixRowsTable(child: MatrixIR) extends TableIR {
 
   override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
 
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
+
   def copy(newChildren: IndexedSeq[BaseIR]): MatrixRowsTable = {
     assert(newChildren.length == 1)
     MatrixRowsTable(newChildren(0).asInstanceOf[MatrixIR])
@@ -1213,6 +1262,8 @@ case class MatrixRowsTable(child: MatrixIR) extends TableIR {
 
 case class MatrixColsTable(child: MatrixIR) extends TableIR {
   val children: IndexedSeq[BaseIR] = Array(child)
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 
   def copy(newChildren: IndexedSeq[BaseIR]): MatrixColsTable = {
     assert(newChildren.length == 1)
@@ -1225,6 +1276,8 @@ case class MatrixColsTable(child: MatrixIR) extends TableIR {
 case class MatrixEntriesTable(child: MatrixIR) extends TableIR {
   val children: IndexedSeq[BaseIR] = Array(child)
 
+  lazy val rowCountUpperBound: Option[Long] = None
+
   def copy(newChildren: IndexedSeq[BaseIR]): MatrixEntriesTable = {
     assert(newChildren.length == 1)
     MatrixEntriesTable(newChildren(0).asInstanceOf[MatrixIR])
@@ -1235,6 +1288,8 @@ case class MatrixEntriesTable(child: MatrixIR) extends TableIR {
 
 case class TableDistinct(child: TableIR) extends TableIR {
   lazy val children: IndexedSeq[BaseIR] = Array(child)
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 
   def copy(newChildren: IndexedSeq[BaseIR]): TableDistinct = {
     val IndexedSeq(newChild) = newChildren
@@ -1260,6 +1315,8 @@ case class TableKeyByAndAggregate(
   require(bufferSize > 0)
 
   lazy val children: IndexedSeq[BaseIR] = Array(child, expr, newKey)
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 
   def copy(newChildren: IndexedSeq[BaseIR]): TableKeyByAndAggregate = {
     val IndexedSeq(newChild: TableIR, newExpr: IR, newNewKey: IR) = newChildren
@@ -1398,6 +1455,8 @@ case class TableKeyByAndAggregate(
 // follows key_by non-empty key
 case class TableAggregateByKey(child: TableIR, expr: IR) extends TableIR {
   require(child.typ.key.nonEmpty)
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 
   lazy val children: IndexedSeq[BaseIR] = Array(child, expr)
 
@@ -1544,6 +1603,8 @@ case class TableOrderBy(child: TableIR, sortFields: IndexedSeq[SortField]) exten
   // TableOrderBy expects an unkeyed child, so that we can better optimize by
   // pushing these two steps around as needed
 
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
+
   val children: IndexedSeq[BaseIR] = FastIndexedSeq(child)
 
   def copy(newChildren: IndexedSeq[BaseIR]): TableOrderBy = {
@@ -1589,6 +1650,8 @@ case class CastMatrixToTable(
   colsFieldName: String
 ) extends TableIR {
 
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
+
   lazy val typ: TableType = child.typ.toTableType(entriesFieldName, colsFieldName)
 
   lazy val children: IndexedSeq[BaseIR] = FastIndexedSeq(child)
@@ -1604,6 +1667,8 @@ case class CastMatrixToTable(
 case class TableRename(child: TableIR, rowMap: Map[String, String], globalMap: Map[String, String]) extends TableIR {
   require(rowMap.keys.forall(child.typ.rowType.hasField))
   require(globalMap.keys.forall(child.typ.globalType.hasField))
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 
   def rowF(old: String): String = rowMap.getOrElse(old, old)
 
@@ -1634,6 +1699,8 @@ case class TableRename(child: TableIR, rowMap: Map[String, String], globalMap: M
 case class TableFilterIntervals(child: TableIR, intervals: IndexedSeq[Interval], keep: Boolean) extends TableIR {
   lazy val children: IndexedSeq[BaseIR] = Array(child)
 
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
+
   def copy(newChildren: IndexedSeq[BaseIR]): TableIR = {
     val IndexedSeq(newChild: TableIR) = newChildren
     TableFilterIntervals(newChild, intervals, keep)
@@ -1653,6 +1720,8 @@ case class TableFilterIntervals(child: TableIR, intervals: IndexedSeq[Interval],
 
 case class MatrixToTableApply(child: MatrixIR, function: MatrixToTableFunction) extends TableIR {
   lazy val children: IndexedSeq[BaseIR] = Array(child)
+
+  lazy val rowCountUpperBound: Option[Long] = if (function.preservesPartitionCounts) child.rowCountUpperBound else None
 
   def copy(newChildren: IndexedSeq[BaseIR]): TableIR = {
     val IndexedSeq(newChild: MatrixIR) = newChildren
@@ -1678,6 +1747,8 @@ case class TableToTableApply(child: TableIR, function: TableToTableFunction) ext
   override def partitionCounts: Option[IndexedSeq[Long]] =
     if (function.preservesPartitionCounts) child.partitionCounts else None
 
+  lazy val rowCountUpperBound: Option[Long] = if (function.preservesPartitionCounts) child.rowCountUpperBound else None
+
   protected[ir] override def execute(ctx: ExecuteContext): TableValue = {
     function.execute(ctx, child.execute(ctx))
   }
@@ -1689,6 +1760,8 @@ case class BlockMatrixToTableApply(
   function: BlockMatrixToTableFunction) extends TableIR {
 
   override lazy val children: IndexedSeq[BaseIR] = Array(bm, aux)
+
+  lazy val rowCountUpperBound: Option[Long] = None
 
   override def copy(newChildren: IndexedSeq[BaseIR]): TableIR =
     BlockMatrixToTableApply(
@@ -1708,6 +1781,8 @@ case class BlockMatrixToTableApply(
 case class BlockMatrixToTable(child: BlockMatrixIR) extends TableIR {
   lazy val children: IndexedSeq[BaseIR] = Array(child)
 
+  lazy val rowCountUpperBound: Option[Long] = None
+
   def copy(newChildren: IndexedSeq[BaseIR]): TableIR = {
     val IndexedSeq(newChild: BlockMatrixIR) = newChildren
     BlockMatrixToTable(newChild)
@@ -1725,6 +1800,8 @@ case class BlockMatrixToTable(child: BlockMatrixIR) extends TableIR {
 
 case class RelationalLetTable(name: String, value: IR, body: TableIR) extends TableIR {
   def typ: TableType = body.typ
+
+  lazy val rowCountUpperBound: Option[Long] = body.rowCountUpperBound
 
   def children: IndexedSeq[BaseIR] = Array(value, body)
 


### PR DESCRIPTION
I want to use this in optimization.