### PR TITLE
[hail] Add TableAggregate simplify rules

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Exists.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Exists.scala
@@ -70,14 +70,14 @@ object ContainsAgg {
 
 object AggIsCommutative {
   def apply(op: AggOp): Boolean = op match {
-    case Take() | Collect() | PrevNonnull() | TakeBy() => true
-    case _ => false
+    case Take() | Collect() | PrevNonnull() | TakeBy() => false
+    case _ => true
   }
 }
 
 object ContainsNonCommutativeAgg {
   def apply(root: IR): Boolean = root match {
-    case ApplyAggOp(_, _, _, sig) => AggIsCommutative(sig.op)
+    case ApplyAggOp(_, _, _, sig) => !AggIsCommutative(sig.op)
     case _: TableAggregate => false
     case _: MatrixAggregate => false
     case _ => root.children.exists {

--- a/hail/src/main/scala/is/hail/expr/ir/Exists.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Exists.scala
@@ -68,6 +68,25 @@ object ContainsAgg {
   })
 }
 
+object AggIsCommutative {
+  def apply(op: AggOp): Boolean = op match {
+    case Take() | Collect() | PrevNonnull() | TakeBy() => true
+    case _ => false
+  }
+}
+
+object ContainsNonCommutativeAgg {
+  def apply(root: IR): Boolean = root match {
+    case ApplyAggOp(_, _, _, sig) => AggIsCommutative(sig.op)
+    case _: TableAggregate => false
+    case _: MatrixAggregate => false
+    case _ => root.children.exists {
+      case child: IR => ContainsNonCommutativeAgg(child)
+      case _ => false
+    }
+  }
+}
+
 object ContainsScan {
   def apply(root: IR): Boolean = IsScanResult(root) || (root match {
     case _: TableAggregate => false

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -415,10 +415,30 @@ object Simplify {
     case TableCollect(TableParallelize(x, _)) => x
     case ArrayLen(GetField(TableCollect(child), "rows")) => TableCount(child)
 
+    case TableAggregate(child, query) if child.typ.key.nonEmpty && !ContainsNonCommutativeAgg(query) =>
+      TableAggregate(TableKeyBy(child, FastIndexedSeq(), false), query)
+    case TableAggregate(TableOrderBy(child, _), query) if !ContainsNonCommutativeAgg(query) =>
+      if (child.typ.key.isEmpty)
+        TableAggregate(child, query)
+      else
+        TableAggregate(TableKeyBy(child, FastIndexedSeq(), false), query)
     case TableAggregate(TableMapRows(child, newRow), query) if !ContainsScan(newRow) =>
       val uid = genUID()
       TableAggregate(child,
         AggLet(uid, newRow, Subst(query, BindingEnv(agg = Some(Env("row" -> Ref(uid, newRow.typ))))), isScan = false))
+    case TableAggregate(TableParallelize(rowsAndGlobal, _), query) =>
+      rowsAndGlobal match {
+        // match because we currently don't optimize MakeStruct through Let, and this is a common pattern
+        case MakeStruct(Seq((_, rows), (_, global))) =>
+          Let("global", global, ArrayAgg(rows, "row", query))
+        case other =>
+          val uid = genUID()
+          Let(uid,
+            rowsAndGlobal,
+            Let("global",
+              GetField(Ref(uid, rowsAndGlobal.typ), "global"),
+              ArrayAgg(GetField(Ref(uid, rowsAndGlobal.typ), "rows"), "row", query)))
+      }
 
     case ApplyIR("annotate", Seq(s, MakeStruct(fields))) =>
       InsertFields(s, fields)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/Extract.scala
@@ -162,10 +162,7 @@ case class Aggs(postAggIR: IR, init: IR, seqPerElt: IR, aggs: Array[AggSignature
   val nAggs: Int = aggs.length
 
   def isCommutative: Boolean = {
-    def aggCommutes(agg: AggSignature2): Boolean = agg.nested.forall(_.forall(aggCommutes)) && (agg.op match {
-      case Take() | Collect() | PrevNonnull() | TakeBy() => false
-      case _ => true
-    })
+    def aggCommutes(agg: AggSignature2): Boolean = agg.nested.forall(_.forall(aggCommutes)) && AggIsCommutative(agg.op)
     aggs.forall(aggCommutes)
   }
 


### PR DESCRIPTION
Better IR for:

```
ht = mt.cols()
ht.aggregate(...)
```

Instead of a `TableAgg(TableKeyBy(TableParallelize(x)))`, we get an `ArrayAgg(x)`.