### PR TITLE
[hail] Only generate etype methods once per etype/ptype combination

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -445,10 +445,7 @@ class EmitFunctionBuilder[F >: Null](
   def getOrDefineMethod(prefix: String, key: Any, argsInfo: Array[TypeInfo[_]], returnInfo: TypeInfo[_])
     (f: EmitMethodBuilder => Unit): EmitMethodBuilder = {
     methodMemo.get(key) match {
-      case Some(mb) =>
-        assert(mb.parameterTypeInfo.sameElements(argsInfo))
-        assert(mb.returnTypeInfo == returnInfo)
-        mb
+      case Some(mb) => mb
       case None =>
         val mb = newMethod(prefix, argsInfo, returnInfo)
         f(mb)

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EArray.scala
@@ -143,7 +143,7 @@ final case class EArray(elementType: EType, override val required: Boolean = fal
     }
   }
 
-  def asIdent = s"array_of_${elementType.asIdent}"
+  def _asIdent = s"array_of_${elementType.asIdent}"
   def _toPretty = s"Array[$elementType]"
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean = false) {

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EBaseStruct.scala
@@ -208,7 +208,7 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
       Code._empty)
   }
 
-  def asIdent: String = {
+  def _asIdent: String = {
     val sb = new StringBuilder
     sb.append("struct_of_")
     types.foreachBetween { ty =>

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EBinary.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EBinary.scala
@@ -54,7 +54,7 @@ class EBinary(override val required: Boolean) extends EType {
     case t: TString => PString(required)
   }
 
-  def asIdent = "binary"
+  def _asIdent = "binary"
   def _toPretty = "Binary"
 }
 

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EBoolean.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EBoolean.scala
@@ -32,7 +32,7 @@ class EBoolean(override val required: Boolean) extends EType {
 
   def _decodedPType(requestedType: Type): PType = PBoolean(required)
 
-  def asIdent = "bool"
+  def _asIdent = "bool"
   def _toPretty = "Boolean"
 }
 

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EFloat32.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EFloat32.scala
@@ -32,7 +32,7 @@ class EFloat32(override val required: Boolean) extends EType {
 
   def _decodedPType(requestedType: Type): PType = PFloat32(required)
 
-  def asIdent = "float32"
+  def _asIdent = "float32"
   def _toPretty = "Float32"
 }
 

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EFloat64.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EFloat64.scala
@@ -32,7 +32,7 @@ class EFloat64(override val required: Boolean) extends EType {
 
   def _decodedPType(requestedType: Type): PType = PFloat64(required)
 
-  def asIdent = "float64"
+  def _asIdent = "float64"
   def _toPretty = "Float64"
 }
 

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EInt32.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EInt32.scala
@@ -35,7 +35,7 @@ class EInt32(override val required: Boolean) extends EType {
     case _ => PInt32(required)
   }
 
-  def asIdent = "int32"
+  def _asIdent = "int32"
   def _toPretty = "Int32"
 }
 

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EInt64.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EInt64.scala
@@ -32,7 +32,7 @@ class EInt64(override val required: Boolean) extends EType {
 
   def _decodedPType(requestedType: Type): PType = PInt64(required)
 
-  def asIdent = "int64"
+  def _asIdent = "int64"
   def _toPretty = "Int64"
 }
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PArray.scala
@@ -27,7 +27,7 @@ final case class PArray(elementType: PType, override val required: Boolean = fal
       this.copy(elementType = elementType.fundamentalType)
   }
 
-  def asIdent = s"array_of_${elementType.asIdent}"
+  def _asIdent = s"array_of_${elementType.asIdent}"
   def _toPretty = s"Array[$elementType]"
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean = false) {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -72,7 +72,7 @@ abstract class PBaseStruct extends PType {
   }
 
   def identBase: String
-  def asIdent: String = {
+  def _asIdent: String = {
     val sb = new StringBuilder
     sb.append(identBase)
     sb.append("_of_")

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBinary.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBinary.scala
@@ -18,7 +18,7 @@ case object PBinaryRequired extends PBinary(true)
 class PBinary(override val required: Boolean) extends PType {
   lazy val virtualType: TBinary = TBinary(required)
 
-  def asIdent = "binary"
+  def _asIdent = "binary"
   def _toPretty = "Binary"
 
   override def unsafeOrdering(): UnsafeOrdering = new UnsafeOrdering {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBoolean.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBoolean.scala
@@ -13,7 +13,7 @@ case object PBooleanRequired extends PBoolean(true)
 class PBoolean(override val required: Boolean) extends PType {
   lazy val virtualType: TBoolean = TBoolean(required)
 
-  def asIdent = "bool"
+  def _asIdent = "bool"
   def _toPretty = "Boolean"
 
   override def pyString(sb: StringBuilder): Unit = {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PCall.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PCall.scala
@@ -13,7 +13,7 @@ case object PCallRequired extends PCall(true)
 class PCall(override val required: Boolean) extends ComplexPType {
   lazy val virtualType: TCall = TCall(required)
 
-  def asIdent = "call"
+  def _asIdent = "call"
   def _toPretty = "Call"
 
   override def pyString(sb: StringBuilder): Unit = {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PDict.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PDict.scala
@@ -20,7 +20,7 @@ final case class PDict(keyType: PType, valueType: PType, override val required: 
 
   override val fundamentalType: PArray = PArray(elementType.fundamentalType, required)
 
-  def asIdent = s"dict_of_${keyType.asIdent}AND${valueType.asIdent}"
+  def _asIdent = s"dict_of_${keyType.asIdent}AND${valueType.asIdent}"
   def _toPretty = s"Dict[$keyType, $valueType]"
 
   override def pyString(sb: StringBuilder): Unit = {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PFloat32.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PFloat32.scala
@@ -16,7 +16,7 @@ case object PFloat32Required extends PFloat32(true)
 class PFloat32(override val required: Boolean) extends PType {
   lazy val virtualType: TFloat32 = TFloat32(required)
 
-  def asIdent = "float32"
+  def _asIdent = "float32"
   def _toPretty = "Float32"
 
   override def pyString(sb: StringBuilder): Unit = {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PFloat64.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PFloat64.scala
@@ -16,7 +16,7 @@ case object PFloat64Required extends PFloat64(true)
 class PFloat64(override val required: Boolean) extends PType {
   lazy val virtualType: TFloat64 = TFloat64(required)
 
-  def asIdent = "float64"
+  def _asIdent = "float64"
   override def _toPretty = "Float64"
 
   override def pyString(sb: StringBuilder): Unit = {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PInt32.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PInt32.scala
@@ -15,7 +15,7 @@ case object PInt32Required extends PInt32(true)
 
 class PInt32(override val required: Boolean) extends PIntegral {
   lazy val virtualType: TInt32 = TInt32(required)
-  def asIdent = "int32"
+  def _asIdent = "int32"
   def _toPretty = "Int32"
 
   override def pyString(sb: StringBuilder): Unit = {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PInt64.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PInt64.scala
@@ -16,7 +16,7 @@ case object PInt64Required extends PInt64(true)
 class PInt64(override val required: Boolean) extends PIntegral {
   lazy val virtualType: TInt64 = TInt64(required)
 
-  def asIdent = "int64"
+  def _asIdent = "int64"
   def _toPretty = "Int64"
 
   override def pyString(sb: StringBuilder): Unit = {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PInterval.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PInterval.scala
@@ -13,7 +13,7 @@ import scala.reflect.{ClassTag, classTag}
 case class PInterval(pointType: PType, override val required: Boolean = false) extends ComplexPType {
   lazy val virtualType: TInterval = TInterval(pointType.virtualType, required)
 
-  def asIdent = s"interval_of_${pointType.asIdent}"
+  def _asIdent = s"interval_of_${pointType.asIdent}"
   def _toPretty = s"""Interval[$pointType]"""
 
   override def pyString(sb: StringBuilder): Unit = {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PLocus.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PLocus.scala
@@ -29,7 +29,7 @@ case class PLocus(rgBc: BroadcastRG, override val required: Boolean = false) ext
 
   lazy val virtualType: TLocus = TLocus(rgBc, required)
 
-  def asIdent = "locus"
+  def _asIdent = "locus"
   def _toPretty = s"Locus($rg)"
 
   override def pyString(sb: StringBuilder): Unit = {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -11,7 +11,7 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
   lazy val virtualType: TNDArray = TNDArray(elementType.virtualType, Nat(nDims), required)
   assert(elementType.required, "elementType must be required")
 
-  def asIdent: String = s"ndarray_of_${elementType.asIdent}"
+  def _asIdent: String = s"ndarray_of_${elementType.asIdent}"
   override def _toPretty = s"NDArray[$elementType,$nDims]"
 
   override def codeOrdering(mb: EmitMethodBuilder, other: PType): CodeOrdering = throw new UnsupportedOperationException

--- a/hail/src/main/scala/is/hail/expr/types/physical/PSet.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PSet.scala
@@ -17,7 +17,7 @@ final case class PSet(elementType: PType, override val required: Boolean = false
 
   override val fundamentalType: PArray = PArray(elementType.fundamentalType, required)
 
-  def asIdent = s"set_of_${elementType.asIdent}"
+  def _asIdent = s"set_of_${elementType.asIdent}"
   def _toPretty = s"Set[$elementType]"
 
   override def pyString(sb: StringBuilder): Unit = {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PStream.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PStream.scala
@@ -37,7 +37,7 @@ final case class PStream(elementType: PType, override val required: Boolean = fa
       this.copy(elementType = elementType.fundamentalType)
   }
 
-  def asIdent = s"stream_of_${elementType.asIdent}"
+  def _asIdent = s"stream_of_${elementType.asIdent}"
   def _toPretty = s"Stream[$elementType]"
 
   override def _pretty(sb: StringBuilder, indent: Int, compact: Boolean = false) {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PString.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PString.scala
@@ -17,7 +17,7 @@ case object PStringRequired extends PString(true)
 class PString(override val required: Boolean) extends PType {
   lazy val virtualType: TString = TString(required)
 
-  def asIdent = "string"
+  def _asIdent = "string"
   def _toPretty = "String"
 
   override def pyString(sb: StringBuilder): Unit = {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
@@ -183,7 +183,9 @@ abstract class PType extends BaseType with Serializable with Requiredness {
       (signature, (a, toIns) => toIns)
   }
 
-  def asIdent: String
+  def asIdent: String = (if (required) "r_" else "o_") + _asIdent
+
+  def _asIdent: String
 
   final def pretty(sb: StringBuilder, indent: Int, compact: Boolean) {
     if (required)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PVoid.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PVoid.scala
@@ -8,7 +8,7 @@ case object PVoid extends PType {
 
   override val required = true
 
-  def asIdent = "void"
+  def _asIdent = "void"
   override def _toPretty = "Void"
 
   def codeOrdering(mb: EmitMethodBuilder, other: PType): CodeOrdering = null


### PR DESCRIPTION
No detectable difference in performance:

```
$ hail-bench compare /tmp/before.json /tmp/after2.json
                         Name      Ratio    Time 1    Time 2
                         ----      -----    ------    ------
matrix_table_decode_and_count     101.5%     4.216     4.278
----------------------
Geometric mean: 101.5%
Simple mean: 101.5%
Median:  101.5%
```