### PR TITLE
Block Matrix filter rows/cols edge issues

### DIFF
--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -834,6 +834,7 @@ class BlockMatrix(val blocks: RDD[((Int, Int), BDM[Double])],
       s"Int.MaxValue. Currently nCols: $nCols")
     require(nRows * nCols <= Int.MaxValue, "The length of the values array must be " +
       s"less than or equal to Int.MaxValue. Currently nRows * nCols: ${ nRows * nCols }")
+    utils.log.info(s"toBreezeMatrix partition indices ${this.blocks.partitions.toIndexedSeq.map(_.index)}\n Is one of the indices -1? ${this.blocks.partitions.contains(-1)}")
     val nRowsInt = nRows.toInt
     val nColsInt = nCols.toInt
     val localBlocks = blocks.collect()

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -1566,7 +1566,7 @@ private class BlockMatrixFilterColsRDD(bm: BlockMatrix, keep: Array[Long])
           k = j + ei - si
 
           try {
-            newBlock(::, j until k) := block(::, si until ei)
+            newBlock(::, j until k) := block(0 until newBlock.rows, si until ei)
           } catch {
             case x: IllegalArgumentException =>
               val breezeMessage = x.getMessage()

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -1357,6 +1357,9 @@ private class BlockMatrixFilterRDD(bm: BlockMatrix, keepRows: Array[Long], keepC
 
   private val originalMaybeBlocksSet = originalGP.maybeBlocks.map(_.toSet)
 
+  // This thing considers every block in the whole new matrix, and looks up that block's
+  // parents (by block coord) in the old matrix. It then filters out any parents known to be unrealized blocks.
+  // If a block has no parents, we remove that block entirely from the mapping.
   private val blockParentMap = (0 until tempDenseGP.numPartitions).map {blockId =>
     val (newBlockRow, newBlockCol) = tempDenseGP.blockCoordinates(blockId)
 
@@ -1373,8 +1376,11 @@ private class BlockMatrixFilterRDD(bm: BlockMatrix, keepRows: Array[Long], keepC
     (blockId, filteredParents)
   }.filter{case (_, parents) => !parents.isEmpty}.toMap
 
+  // The blocks that are realized are those in the block parent map.
   private val blockIndices = blockParentMap.keys.toArray.sorted
+  // The blocks the new GP should mark as reaalized are the ones in the maybe blocks map.
   private val newGPMaybeBlocks: Option[Array[Int]] = if (blockIndices.length == tempDenseGP.maxNBlocks) None else Some(blockIndices)
+  // the new gp is the same as the tempDense one except it has maybeblocks set.
   private val newGP = tempDenseGP.copy(maybeBlocks = newGPMaybeBlocks)
 
   log.info(s"Finished constructing block matrix filter RDD. Total time ${(System.nanoTime() - t0).toDouble / 1000000000}")
@@ -1387,12 +1393,24 @@ private class BlockMatrixFilterRDD(bm: BlockMatrix, keepRows: Array[Long], keepC
         allBlockColRanges(newGP.blockBlockCol(blockIndex)))
     }
 
+  // Problem: Can this thing return -1? blockToPartition can return -1.
   override def getDependencies: Seq[Dependency[_]] = Array[Dependency[_]](
     new NarrowDependency(bm.blocks) {
       def getParents(partitionId: Int): Seq[Int] = {
+        // This always returns an actual block number.
         val blockForPartition = newGP.partitionToBlock(partitionId)
+        // This would throw an error if the partition wasn't found
         val blockParents = blockParentMap(blockForPartition)
+        // Interesting bit. For each parent, look up its partition in original thing.
         val partitionParents = blockParents.map(blockId => originalGP.blockToPartition(blockId)).toSet.toArray.sorted
+        if (partitionParents.contains(-1)) {
+          log.error(s"PARTITION PARENTS CONTAINED -1! Parents of partition $partitionId were: ${partitionParents.toIndexedSeq}")
+          log.error(s"DIAGNOSTIC INFO:")
+          log.error(s"originalGP.maybeBlocks = ${originalGP.maybeBlocks.map(_.toIndexedSeq)}")
+          log.error(s"newGP.maybeBlocks = ${newGP.maybeBlocks.map(_.toIndexedSeq)}")
+          log.error(s"blockParentMap = ${blockParentMap.mapValues(_.toIndexedSeq)}")
+          throw new HailException("Partiton parent was -1 for BlockMatrixFilterRDD. See log")
+        }
         partitionParents
       }
     })
@@ -1506,6 +1524,14 @@ private class BlockMatrixFilterColsRDD(bm: BlockMatrix, keep: Array[Long])
           val blockForPartition = newGP.partitionToBlock(partitionId)
           val blockParents = blockParentMap(blockForPartition)
           val partitionParents = blockParents.map(blockId => originalGP.blockToPartition(blockId)).toSet.toArray.sorted
+          if (partitionParents.contains(-1)) {
+            log.error(s"PARTITION PARENTS CONTAINED -1! Parents of partition $partitionId were: ${partitionParents.toIndexedSeq}")
+            log.error(s"DIAGNOSTIC INFO:")
+            log.error(s"originalGP.maybeBlocks = ${originalGP.maybeBlocks.map(_.toIndexedSeq)}")
+            log.error(s"newGP.maybeBlocks = ${newGP.maybeBlocks.map(_.toIndexedSeq)}")
+            log.error(s"blockParentMap = ${blockParentMap.mapValues(_.toIndexedSeq)}")
+            throw new HailException("Partiton parent was -1 for BlockMatrixFilterColsRDD. See log")
+          }
           partitionParents
       }
     })

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -1537,8 +1537,9 @@ private class BlockMatrixFilterColsRDD(bm: BlockMatrix, keep: Array[Long])
     })
 
   def compute(split: Partition, context: TaskContext): Iterator[((Int, Int), BDM[Double])] = {
-    val (blockRow, newBlockCol) = newGP.blockCoordinates(newGP.partitionToBlock(split.index))
-    val (blockNRows, newBlockNCols) = newGP.blockDims(split.index)
+    val blockIndex = newGP.partitionToBlock(split.index)
+    val (blockRow, newBlockCol) = newGP.blockCoordinates(blockIndex)
+    val (blockNRows, newBlockNCols) = newGP.blockDims(blockIndex)
     val parentZeroBlock = BDM.zeros[Double](originalGP.blockSize, originalGP.blockSize)
     val newBlock = BDM.zeros[Double](blockNRows, newBlockNCols)
     var j = 0

--- a/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
+++ b/hail/src/main/scala/is/hail/linalg/BlockMatrix.scala
@@ -1582,6 +1582,11 @@ private class BlockMatrixFilterColsRDD(bm: BlockMatrix, keep: Array[Long])
                    |zeroBlockUsed = $zeroBlockUsed
                    |blockCol = $blockCol
                    |blockRow = $blockRow
+                   |newBlockCol = $newBlockCol
+                   |blockNRows = $blockNRows
+                   |newBlockNCols = $newBlockNCols
+                   |split.index = ${split.index}
+                   |parentBI = ${parentBI}
                    |startIndices.length = ${startIndices.length}
                    |startIndices = ${startIndices.toIndexedSeq}
                    |endIndices = ${endIndices.toIndexedSeq}

--- a/hail/src/main/scala/is/hail/linalg/GridPartitioner.scala
+++ b/hail/src/main/scala/is/hail/linalg/GridPartitioner.scala
@@ -36,11 +36,11 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks
       bis.length < maxNBlocks))) // a block-sparse matrix cannot have all blocks present
     throw new IllegalArgumentException(s"requirement failed: Sparse blocks sequence was ${maybeBlocks.toIndexedSeq}")
 
-  val blockToPartitonMap = maybeBlocks.map(_.zipWithIndex.toMap.withDefaultValue(-1))
+  val blockToPartitionMap = maybeBlocks.map(_.zipWithIndex.toMap.withDefaultValue(-1))
 
   val lastBlockRowNRows: Int = indexBlockOffset(nRows - 1) + 1
   val lastBlockColNCols: Int = indexBlockOffset(nCols - 1) + 1
-  
+
   def blockRowNRows(i: Int): Int = if (i < nBlockRows - 1) blockSize else lastBlockRowNRows
   def blockColNCols(j: Int): Int = if (j < nBlockCols - 1) blockSize else lastBlockColNCols
 
@@ -48,7 +48,7 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks
   def blockBlockCol(bi: Int): Int = bi / nBlockRows
 
   def blockDims(bi: Int): (Int, Int) = (blockRowNRows(blockBlockRow(bi)), blockColNCols(blockBlockCol(bi)))
-  
+
   def blockCoordinates(bi: Int): (Int, Int) = (blockBlockRow(bi), blockBlockCol(bi))
 
   def coordinatesBlock(i: Int, j: Int): Int = {
@@ -56,7 +56,7 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks
     require(0 <= j && j < nBlockCols, s"Block column $j out of range [0, $nBlockCols).")
     i + j * nBlockRows
   }
-  
+
   def intersect(that: GridPartitioner): GridPartitioner = {
     copy(maybeBlocks = (maybeBlocks, that.maybeBlocks) match {
       case (Some(bis), Some(bis2)) => Some(bis.filter(bis2.toSet))
@@ -65,7 +65,7 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks
       case (None, None) => None
     })
   }
-  
+
   def union(that: GridPartitioner): GridPartitioner = {
     copy(maybeBlocks = (maybeBlocks, that.maybeBlocks) match {
       case (Some(bis), Some(bis2)) =>
@@ -86,7 +86,7 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks
       assert(maxNBlocks < Int.MaxValue)
       maxNBlocks.toInt
   }
-  
+
   def partitionToBlock(pi: Int): Int = maybeBlocks match {
     case Some(bis) =>
       assert(pi >= 0 && pi < bis.length)
@@ -95,8 +95,8 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks
       assert(pi >= 0 && pi < numPartitions)
       pi
   }
-  
-  def blockToPartition(blockId: Int): Int = blockToPartitonMap match {
+
+  def blockToPartition(blockId: Int): Int = blockToPartitionMap match {
     case Some(bpMap) => bpMap(blockId)
     case None =>  blockId
   }

--- a/hail/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
+++ b/hail/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
@@ -782,6 +782,21 @@ class BlockMatrixSuite extends HailSuite {
     bm1.blocks.collect() sameElements bm2.blocks.collect()
 
   @Test
+  def testSparseFilterEdges(): Unit = {
+    val lm = new BDM[Double](12, 12, (0 to 143).map(_.toDouble).toArray)
+    val bm = toBM(lm, blockSize = 5)
+
+    val onlyEight = bm.filterBlocks(Array(8)) // Bottom right corner block
+    val onlyEightRowEleven = onlyEight.filterRows(Array(11)).toBreezeMatrix()
+    val onlyEightColEleven = onlyEight.filterCols(Array(11)).toBreezeMatrix()
+    val onlyEightCornerFour = onlyEight.filter(Array(10, 11), Array(10, 11)).toBreezeMatrix()
+
+    assert(onlyEightRowEleven.toArray sameElements Array(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 131, 143).map(_.toDouble))
+    assert(onlyEightColEleven.toArray sameElements Array(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 142, 143).map(_.toDouble))
+    assert(onlyEightCornerFour == new BDM[Double](2, 2, Array(130.0, 131.0, 142.0, 143.0)))
+  }
+
+  @Test
   def testFilterBlocks() {
     val lm = toLM(4, 4, Array(
       1, 2, 3, 4,


### PR DESCRIPTION
`BlockMatrix.filterCols` and `BlockMatrix.filterRows` has a bug where the smaller blocks located on the edge of the matrix are not always correctly handled when they're of a smaller size than the rest of the blocks. The source of this problem was the fact that `BlockMatrix.scala` line 1515 below, which was calling `blockDims(split.index)`. This was a problem because `split.index` is a partition index, not a block index. The fix was to convert it to a block index and then call `blockDims`. The rest of this PR is some white space fixes, a spelling error, and an additional test case for BlockMatrix filtering that would fail in current master because of this bug. 