### PR TITLE
[hail] fix aggregation checking in aggregator transformations

### DIFF
--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -102,7 +102,7 @@ class AggFunc(object):
         _check_agg_bindings(aggregated, self._agg_bindings)
         self._agg_bindings.remove(var)
 
-        if len(aggregated._ir.search(lambda n: isinstance(n, BaseApplyAggOp))) == 0:
+        if not self._as_scan and not aggregated._aggregations:
             raise ExpressionException("'{}.explode' must take mapping that contains aggregation expression.".format(self.correct_prefix()))
 
         indices, _ = unify_all(array_agg_expr, aggregated)
@@ -120,7 +120,7 @@ class AggFunc(object):
         if condition._aggregations:
             raise ExpressionException(f"'hl.{self.correct_prefix()}.filter' does not "
                                       f"support an already-aggregated expression as the argument to 'condition'")
-        if not aggregation._aggregations:
+        if not self._as_scan and not aggregation._aggregations:
             raise ExpressionException(f"'hl.{self.correct_prefix()}.filter' "
                                       f"must have aggregation in argument to 'aggregation'")
 
@@ -140,7 +140,7 @@ class AggFunc(object):
         if group._aggregations:
             raise ExpressionException(f"'hl.{self.correct_prefix()}.group_by' "
                                       f"does not support an already-aggregated expression as the argument to 'group'")
-        if not aggregation._aggregations:
+        if not self._as_scan and not aggregation._aggregations:
             raise ExpressionException(f"'hl.{self.correct_prefix()}.group_by' "
                                       f"must have aggregation in argument to 'aggregation'")
 
@@ -171,7 +171,7 @@ class AggFunc(object):
         _check_agg_bindings(aggregated, self._agg_bindings)
         self._agg_bindings.remove(var)
 
-        if len(aggregated._ir.search(lambda n: isinstance(n, BaseApplyAggOp))) == 0:
+        if not self._as_scan and not aggregated._aggregations:
             raise ExpressionException(f"'hl.{self.correct_prefix()}.array_agg' "
                                       f"must take mapping that contains aggregation expression.")
 

--- a/hail/python/hail/expr/aggregators/aggregators.py
+++ b/hail/python/hail/expr/aggregators/aggregators.py
@@ -88,7 +88,7 @@ class AggFunc(object):
     @typecheck_method(f=func_spec(1, expr_any),
                       array_agg_expr=expr_oneof(expr_array(), expr_set()))
     def explode(self, f, array_agg_expr):
-        if len(array_agg_expr._ir.search(lambda n: isinstance(n, BaseApplyAggOp))) != 0:
+        if array_agg_expr._aggregations:
             raise ExpressionException("'{}.explode' does not support an already-aggregated expression as the argument to 'collection'".format(self.correct_prefix()))
         _check_agg_bindings(array_agg_expr, self._agg_bindings)
 
@@ -117,10 +117,10 @@ class AggFunc(object):
     @typecheck_method(condition=expr_bool,
                       aggregation=agg_expr(expr_any))
     def filter(self, condition, aggregation):
-        if len(condition._ir.search(lambda n: isinstance(n, BaseApplyAggOp))) != 0:
+        if condition._aggregations:
             raise ExpressionException(f"'hl.{self.correct_prefix()}.filter' does not "
                                       f"support an already-aggregated expression as the argument to 'condition'")
-        if len(aggregation._ir.search(lambda n: isinstance(n, BaseApplyAggOp))) == 0:
+        if not aggregation._aggregations:
             raise ExpressionException(f"'hl.{self.correct_prefix()}.filter' "
                                       f"must have aggregation in argument to 'aggregation'")
 
@@ -137,10 +137,10 @@ class AggFunc(object):
                               aggregations)
 
     def group_by(self, group, aggregation):
-        if len(group._ir.search(lambda n: isinstance(n, BaseApplyAggOp))) != 0:
+        if group._aggregations:
             raise ExpressionException(f"'hl.{self.correct_prefix()}.group_by' "
                                       f"does not support an already-aggregated expression as the argument to 'group'")
-        if len(aggregation._ir.search(lambda n: isinstance(n, BaseApplyAggOp))) == 0:
+        if not aggregation._aggregations:
             raise ExpressionException(f"'hl.{self.correct_prefix()}.group_by' "
                                       f"must have aggregation in argument to 'aggregation'")
 
@@ -158,7 +158,7 @@ class AggFunc(object):
                               aggregations)
 
     def array_agg(self, array, f):
-        if len(array._ir.search(lambda n: isinstance(n, BaseApplyAggOp))) != 0:
+        if array._aggregations:
             raise ExpressionException(f"'hl.{self.correct_prefix()}.array_agg' "
                                       f"does not support an already-aggregated expression as the argument to 'array'")
         _check_agg_bindings(array, self._agg_bindings)

--- a/hail/python/hail/ir/base_ir.py
+++ b/hail/python/hail/ir/base_ir.py
@@ -182,7 +182,7 @@ class IR(BaseIR):
 
     @property
     def bound_variables(self):
-        return {v for child in self.children for v in child.bound_variables}
+        return {v for child in self.children if isinstance(child, IR) for v in child.bound_variables}
 
     @property
     def typ(self):

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -326,6 +326,25 @@ class Tests(unittest.TestCase):
         self.assertTrue(r.assert1)
         self.assertTrue(r.assert2)
 
+    def test_agg_nesting(self):
+        t = hl.utils.range_table(10)
+        aggregated_count = t.aggregate(hl.agg.count(), _localize=False) #10
+
+        filter_count = t.aggregate(hl.agg.filter(aggregated_count == 10, hl.agg.count()))
+        self.assertEqual(filter_count, 10)
+
+        exploded_count = t.aggregate(hl.agg.explode(lambda x: hl.agg.count(), hl.range(hl.int32(aggregated_count))))
+        self.assertEqual(exploded_count, 100)
+
+        grouped_count = t.aggregate(hl.agg.group_by(aggregated_count, hl.agg.count()))
+        self.assertEqual(grouped_count, {10: 10})
+
+        array_agg_count = t.aggregate(hl.agg.array_agg(lambda x: hl.agg.count(), hl.range(hl.int32(aggregated_count))))
+        self.assertEqual(array_agg_count, [10 for i in range(10)])
+
+
+
+
     def test_approx_cdf(self):
         table = hl.utils.range_table(100)
         table = table.annotate(i=table.idx)


### PR DESCRIPTION
we were looking at the IR to check whether an expression was an aggregation, but 1. we already track that and 2. we were ignoring that TableAggregates existed.