### PR TITLE
[notebook] Disable notebook link until ready

### DIFF
--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -179,7 +179,7 @@ def notebook_status_from_pod(pod):
         if pod.status and pod.status.conditions:
             for c in pod.status.conditions:
                 if c.type == 'Ready' and c.status == 'True':
-                    state = 'Running'
+                    state = 'Initializing'
     return {
         'pod_ip': pod_ip,
         'state': state
@@ -199,7 +199,7 @@ async def notebook_status_from_notebook(k8s, service, headers, cookies, notebook
 
     status = notebook_status_from_pod(pod)
 
-    if status['state'] == 'Running':
+    if status['state'] == 'Initializing':
         if notebook['state'] == 'Ready':
             status['state'] = 'Ready'
         else:

--- a/notebook/notebook/styles/pages/notebook.scss
+++ b/notebook/notebook/styles/pages/notebook.scss
@@ -24,11 +24,27 @@
     .nb-state-container {
         flex-direction: column;
         display: flex;
+	/* override link styling */
+	color: black;
+	&:active,
+	&:hover {
+            text-decoration: underline;
+
+	    .nb-link {
+		text-decoration: underline;
+	    }
+	}
+    }
+
+    .nb-link {
+	color: #07c;
+	text-decoration: none;
     }
 
     .nb-close {
         margin-left: $margin * 4;
         font-size: $icon-size;
+	font-weight: bold;
         /* clear button styling */
         border: none;
         background: none;

--- a/notebook/notebook/styles/pages/notebook.scss
+++ b/notebook/notebook/styles/pages/notebook.scss
@@ -13,6 +13,7 @@
 
     .ready-icon {
         font-size: $icon-size;
+	font-weight: bold;
         color: green;
         margin-right: $margin;
     }

--- a/notebook/notebook/styles/pages/notebook.scss
+++ b/notebook/notebook/styles/pages/notebook.scss
@@ -28,7 +28,7 @@
 	color: black;
 	&:active,
 	&:hover {
-            text-decoration: underline;
+            text-decoration: none;
 
 	    .nb-link {
 		text-decoration: underline;

--- a/notebook/notebook/styles/pages/notebook.scss
+++ b/notebook/notebook/styles/pages/notebook.scss
@@ -13,7 +13,7 @@
 
     .ready-icon {
         font-size: $icon-size;
-        color: $blue;
+        color: green;
         margin-right: $margin;
     }
 
@@ -24,11 +24,6 @@
     .nb-state-container {
         flex-direction: column;
         display: flex;
-        color: $black;
-        &:hover {
-            text-decoration: none;
-            color: $devil-gray;
-        }
     }
 
     .nb-close {

--- a/notebook/notebook/templates/notebook-state.html
+++ b/notebook/notebook/templates/notebook-state.html
@@ -4,17 +4,17 @@
     {% else %}
         <div class="spinner"></div>
     {% endif %}
-    <div id="nb-state-container">
-      {% if notebook['state'] != 'Ready' %}
+    <div class="nb-state-container">
+      {% if notebook['state'] == 'Ready' %}
 	<a target="_blank" href="{{ base_url }}/instance/{{ notebook['notebook_token'] }}/?token={{ notebook['jupyter_token'] }}">
 	  <b>Open Notebook<i class="material-icons text-icon">open_in_new</i></b>
 	</a>
       {% else %}
 	<b>Creating Notebook...</b>
       {% endif %}
-      <span class="small">Status: <b>{{ notebook['state'] }}</b></span>
-      <span class="small">Pod Name: {{ notebook['pod_name'] }}</span>
-      <span class="small">Created on: {{ notebook['creation_date'] }}</span>
+      <div class="small">Status: <b>{{ notebook['state'] }}</b></div>
+      <div class="small">Pod Name: {{ notebook['pod_name'] }}</div>
+      <div class="small">Created on: {{ notebook['creation_date'] }}</div>
     </div>
     <form action="{{ base_path }}/notebook/delete" method="POST">
         <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>

--- a/notebook/notebook/templates/notebook-state.html
+++ b/notebook/notebook/templates/notebook-state.html
@@ -4,18 +4,16 @@
     {% else %}
         <div class="spinner"></div>
     {% endif %}
-    <div class="nb-state-container">
+    <a class="nb-state-container" target="_blank" href="{{ base_url }}/instance/{{ notebook['notebook_token'] }}/?token={{ notebook['jupyter_token'] }}">
       {% if notebook['state'] == 'Ready' %}
-	<a target="_blank" href="{{ base_url }}/instance/{{ notebook['notebook_token'] }}/?token={{ notebook['jupyter_token'] }}">
-	  <b>Open Notebook<i class="material-icons text-icon">open_in_new</i></b>
-	</a>
+        <b class="nb-link">Open Notebook<i class="material-icons text-icon">open_in_new</i></b>
       {% else %}
 	<b>Creating Notebook...</b>
       {% endif %}
       <div class="small">Status: <b>{{ notebook['state'] }}</b></div>
       <div class="small">Pod Name: {{ notebook['pod_name'] }}</div>
       <div class="small">Created on: {{ notebook['creation_date'] }}</div>
-    </div>
+    </a>
     <form action="{{ base_path }}/notebook/delete" method="POST">
         <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>
         <button type="submit" class="material-icons nb-close">

--- a/notebook/notebook/templates/notebook-state.html
+++ b/notebook/notebook/templates/notebook-state.html
@@ -4,16 +4,18 @@
     {% else %}
         <div class="spinner"></div>
     {% endif %}
-    <a target="_blank" class="nb-state-container" href="{{ base_url }}/instance/{{ notebook['notebook_token'] }}/?token={{ notebook['jupyter_token'] }}">
-        <b>a_notebook</b>
-        <span class="small">
-        Status: <b>{{ notebook['state'] }}</b>
-        </span>
-        <span class="small">
-        Pod Name: <b>{{ notebook['pod_name'] }}</b>
-        </span>
-        <span class="small">Created on: {{ notebook['creation_date'] }}</span>
-    </a>
+    <div id="nb-state-container">
+      {% if notebook['state'] != 'Ready' %}
+	<a target="_blank" href="{{ base_url }}/instance/{{ notebook['notebook_token'] }}/?token={{ notebook['jupyter_token'] }}">
+	  <b>Open Notebook<i class="material-icons text-icon">open_in_new</i></b>
+	</a>
+      {% else %}
+	<b>Creating Notebook...</b>
+      {% endif %}
+      <span class="small">Status: <b>{{ notebook['state'] }}</b></span>
+      <span class="small">Pod Name: {{ notebook['pod_name'] }}</span>
+      <span class="small">Created on: {{ notebook['creation_date'] }}</span>
+    </div>
     <form action="{{ base_path }}/notebook/delete" method="POST">
         <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>
         <button type="submit" class="material-icons nb-close">


### PR DESCRIPTION
Summary of changes:
 - change notebook states to Scheduling, Initializing, Ready (Running was too suggestion of being ready)
 - remove "a_notebook" notebook name, replace with "Creating Notebook..." or "Open Notebook[open_in_new]" link
 - change nb-state-container styling, blue/underline link on top, but the whole container still acts as a link
 - made material icons bold.  I'm not sure if I like this, it is bordering on cartoonish.
 - make checkmark green to match other success/ok coloring using green (e.g. messages)
 - un-bold pod name, which is really only interested for us (maybe we should remove?)

It is deployed in my namespace if you want to play with it.