### PR TITLE
Add empty_dict function to documentation

### DIFF
--- a/hail/python/hail/docs/functions/collections.rst
+++ b/hail/python/hail/docs/functions/collections.rst
@@ -9,6 +9,7 @@ Collection functions
 .. autosummary::
 
     dict
+    empty_dict
     array
     empty_array
     set

--- a/hail/python/hail/docs/functions/constructors.rst
+++ b/hail/python/hail/docs/functions/constructors.rst
@@ -27,6 +27,7 @@ Constructor functions
     set
     empty_set
     dict
+    empty_dict
 
 
 .. autofunction:: bool
@@ -45,3 +46,4 @@ Constructor functions
 .. autofunction:: set
 .. autofunction:: empty_set
 .. autofunction:: dict
+.. autofunction:: empty_dict

--- a/hail/python/hail/docs/functions/index.rst
+++ b/hail/python/hail/docs/functions/index.rst
@@ -63,6 +63,7 @@ These functions are exposed at the top level of the module, e.g. ``hl.case``.
     set
     empty_set
     dict
+    empty_dict
 
 .. rubric:: Collection functions
 


### PR DESCRIPTION
Unlike `empty_array` and `empty_set`, `empty_dict` does not currently appear in the documentation.