### PR TITLE
[notebook] fixes for playbook

### DIFF
--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -80,8 +80,7 @@ def web_authenticated_workshop_guest_only(redirect=True):
             if not userdata:
                 if redirect:
                     return web.HTTPFound(deploy_config.external_url('workshop', '/login'))
-                else:
-                    return web.HTTPUnauthorized()
+                raise web.HTTPUnauthorized()
             return await fun(request, userdata, *args, **kwargs)
         return wrapped
     return wrap

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -55,10 +55,7 @@ async def workshop_userdata_from_web_request(request):
             workshops = await cursor.fetchall()
 
             if len(workshops) != 1:
-                set_message(
-                    session,
-                    'You are not logged into an active workshop.  Please log in to join the workshop.',
-                    'error')
+                del session['workshop_session']
                 return None
             workshop = workshops[0]
 

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -652,7 +652,7 @@ async def workshop_post_login(request):
 SELECT * FROM workshops
 WHERE name = %s AND password = %s AND active = 1;
 ''',
-                name, password)
+                (name, password))
             workshops = await cursor.fetchall()
 
             if len(workshops) != 1:

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -528,7 +528,7 @@ async def create_workshop(request, userdata):  # pylint: disable=unused-argument
                 else:
                     token = None
                 await cursor.execute('''
-INSERT INTO workshops (name, image, password, active, token) VALUES (%s, %s, %s, %s, %s);
+INSERT INTO workshops (name, image, cpu, memory, password, active, token) VALUES (%s, %s, %s, %s, %s, %s, %s);
 ''',
                                      (name,
                                       post['image'],
@@ -569,7 +569,7 @@ async def update_workshop(request, userdata):  # pylint: disable=unused-argument
             else:
                 token = None
             n = await cursor.execute('''
-UPDATE workshops SET name = %s, image = %s, password = %s, active = %s, token = %s WHERE id = %s;
+UPDATE workshops SET name = %s, image = %s, cpu = %s, memory = %s, password = %s, active = %s, token = %s WHERE id = %s;
 ''',
                                      (name,
                                       post['image'],

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -434,7 +434,7 @@ async def _get_auth(request, userdata):
                 'pod_ip': f'{pod_ip}:{POD_PORT}'
             })
 
-    return web.HTTPUnauthorized()
+    return web.HTTPForbidden()
 
 
 @routes.get('/notebook')

--- a/notebook/notebook/notebook.py
+++ b/notebook/notebook/notebook.py
@@ -204,6 +204,9 @@ def notebook_status_from_pod(pod):
 
 
 async def k8s_notebook_status_from_notebook(k8s, notebook):
+    if not notebook:
+        return None
+
     try:
         pod = await k8s.read_namespaced_pod(
             name=notebook['pod_name'],

--- a/notebook/notebook/templates/notebook-form.html
+++ b/notebook/notebook/templates/notebook-form.html
@@ -1,4 +1,4 @@
 <form action="{{ base_path }}/notebook" method="post">
   <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>  
-  <button class="nb-create">Create Notebook</button>
+  <button class="nb-create">Launch Jupyter</button>
 </form>

--- a/notebook/notebook/templates/notebook-state.html
+++ b/notebook/notebook/templates/notebook-state.html
@@ -6,9 +6,9 @@
     {% endif %}
     <a class="nb-state-container" target="_blank" href="{{ base_url }}/instance/{{ notebook['notebook_token'] }}/?token={{ notebook['jupyter_token'] }}">
       {% if notebook['state'] == 'Ready' %}
-        <b class="nb-link">Open Notebook<i class="material-icons text-icon">open_in_new</i></b>
+        <b class="nb-link">Open Jupyter<i class="material-icons text-icon">open_in_new</i></b>
       {% else %}
-	<b>Creating Notebook...</b>
+	<b>Launching Jupyter</b>
       {% endif %}
       <div class="small">Status: <b>{{ notebook['state'] }}</b></div>
       <div class="small">Pod Name: {{ notebook['pod_name'] }}</div>

--- a/notebook/notebook/templates/workshop-admin.html
+++ b/notebook/notebook/templates/workshop-admin.html
@@ -8,8 +8,8 @@
         <tr>
           <th>Name</th>
           <th>Image</th>
-          <th>Memory</th>
           <th>CPU</th>
+          <th>Memory</th>
           <th>Password</th>
           <th>Active</th>
           <th></th>

--- a/notebook/notebook/templates/workshop-admin.html
+++ b/notebook/notebook/templates/workshop-admin.html
@@ -48,10 +48,10 @@
           <tr>
             <td>
               <input name="name" />
+	    </td>
             <td><input name="image" /></td>
             <td><input name="cpu" /></td>
             <td><input name="memory" /></td>
-            <td><input name="image" /></td>
             <td>
               <input name="password" />
             </td>

--- a/notebook/notebook/templates/workshop/index.html
+++ b/notebook/notebook/templates/workshop/index.html
@@ -11,11 +11,11 @@
     {% endif %}
 
     <p>Navigate to the <a href="{{ base_path }}/notebook">Notebook</a>
-      tab to create a notebook with workshop materials installed, or
-      return to an existing notebook.</p>
+      tab to launch Jupyter with workshop materials installed, or
+      return to an existing Jupyter instance.</p>
 
     <p><span style="color:red;">Warning:</span> Notebooks are
-      ephemeral.  If you close a notebook or log out, any work in the
+      ephemeral.  If you close Jupyter or log out, any work in the
       notebook will be lost.  To download a notebook, use the File >
       Download as menu in Jupyter.</p>
 

--- a/notebook/test-playbook.txt
+++ b/notebook/test-playbook.txt
@@ -68,7 +68,7 @@ i.  Launch Jupyter
  - log into an active workshop
  - deactivate the workshop in another tab
  - launch Jupyter
- - you should be redirected to workshop/login with an error message
+ - you should be redirected to workshop/login
 
 ii.  Connect to Jupyter
 
@@ -76,4 +76,4 @@ ii.  Connect to Jupyter
  - launch Jupyter
  - deactivate the workshop in another tab
  - connect to Jupyer
- - you should be redirected to workshop/login with an error message
+ - you should be redirected to workshop/login

--- a/router/router.nginx.conf.in
+++ b/router/router.nginx.conf.in
@@ -164,7 +164,7 @@ server {
     }
 
     location @error {
-    	return 302 $updated_scheme://$updated_host@notebook_base_path@/error;
+    	return 302 $updated_scheme://$updated_host@workshop_base_path@/error;
     }
 
     location / {

--- a/router/router.nginx.conf.in
+++ b/router/router.nginx.conf.in
@@ -106,11 +106,10 @@ server {
         proxy_connect_timeout 5s;
 
         proxy_intercept_errors on;
-        # 502: no service, 504: pod not responding
-        error_page 502 504 = @pod_dead;
+        error_page 401 403 502 504 = @error;
     }
 
-    location @pod_dead {
+    location @error {
     	return 302 $updated_scheme://$updated_host@notebook_base_path@/error;
     }
 
@@ -161,11 +160,10 @@ server {
         proxy_connect_timeout 5s;
 
         proxy_intercept_errors on;
-        # 502: no service, 504: pod not responding
-        error_page 502 504 = @pod_dead;
+        error_page 401 403 502 504 = @error;
     }
 
-    location @pod_dead {
+    location @error {
     	return 302 $updated_scheme://$updated_host@notebook_base_path@/error;
     }
 

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -242,6 +242,12 @@ a {
 .dangerous {
     color: red;
     border-color: red;
+    &:active,
+    &:hover {
+        text-decoration: none;
+        color: #f66;
+        border-color: #f66;
+    }
 }
 
 .attributes {

--- a/web_common/web_common/web_common.py
+++ b/web_common/web_common/web_common.py
@@ -82,5 +82,5 @@ async def render_template(service, request, userdata, file, page_context):
     context['csrf_token'] = csrf_token
 
     response = aiohttp_jinja2.render_template(file, request, context)
-    response.set_cookie('_csrf', csrf_token, secure=True, httponly=True)
+    response.set_cookie('_csrf', csrf_token, domain=os.environ['HAIL_DOMAIN'], secure=True, httponly=True)
     return response


### PR DESCRIPTION
Mostly small, straightforward stuff.  /auth must only return 2xx, 401 or 403, or nginx returns 500.  Redirect auth failures connecting to instance to /error, too.  Changed "Create/Open Notebook" to "Launch/Open Jupyter" and associated language throughout.

I'll run through the whole test playbook again after these go in.

Note to self, some improvements to consider:
 - Validate image, memory, cpu values in workshop-admin.  Right now, if you enter invalid values, you get a 500 on launch Jupyter with invalid pod spec.
 - Could change notebook.hail.is/notebook URL to notebook.hail.is/jupyter now.
 - A background loop to kill any notebook workers associated to inactive workshops.  Then if you just inactivate the workshop at the end, everything gets cleaned up.
