### PR TITLE
[hail] Relax ArrayAgg/ArrayAggScan restriction about nested aggs

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/ForwardLets.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ForwardLets.scala
@@ -51,9 +51,7 @@ object ForwardLets {
           (IsConstant(value) && !value.isInstanceOf[Str]) ||
           refs.isEmpty ||
           (refs.size == 1 &&
-            nestingDepth.lookup(refs.head) == nestingDepth.lookup(base) &&
-            !ContainsScan(value) &&
-            !ContainsAgg(value))
+            nestingDepth.lookup(refs.head) == nestingDepth.lookup(base))
       }
 
       def mapRewrite(): IR = ir.copy(ir.children

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -457,7 +457,6 @@ object Interpret {
         ()
 
       case ArrayAgg(a, name, body) =>
-        assert(aggArgs.isEmpty)
         val aggElementType = TStruct(name -> a.typ.asInstanceOf[TArray].elementType)
         val aValue = interpret(a, env, args, aggArgs)
           .asInstanceOf[IndexedSeq[Any]]

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -243,10 +243,8 @@ object TypeCheck {
         assert(body.typ == TVoid)
       case x@ArrayAgg(a, name, query) =>
         assert(a.typ.isInstanceOf[TStreamable])
-        assert(env.agg.isEmpty)
       case x@ArrayAggScan(a, name, query) =>
         assert(a.typ.isInstanceOf[TStreamable])
-        assert(env.scan.isEmpty)
       case x@AggFilter(cond, aggIR, _) =>
         assert(cond.typ isOfType TBoolean())
         assert(x.typ == aggIR.typ)

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -22,6 +22,7 @@ object ExecStrategy extends Enumeration {
 
   val javaOnly:Set[ExecStrategy] = Set(Interpret, InterpretUnoptimized, JvmCompile)
   val interpretOnly: Set[ExecStrategy] = Set(Interpret, InterpretUnoptimized)
+  val interpretNoOpt: Set[ExecStrategy] = Set(InterpretUnoptimized)
   val nonLowering: Set[ExecStrategy] = Set(Interpret, InterpretUnoptimized, JvmCompile)
   val backendOnly: Set[ExecStrategy] = Set(LoweredJVMCompile)
 }

--- a/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/AggregatorsSuite.scala
@@ -213,7 +213,7 @@ class AggregatorsSuite extends HailSuite {
         AggArrayPerElement(GetField(Ref("row", tp.typ.rowType), "foo"), "elt", "_",
           ApplyAggOp(FastSeq(), None, FastSeq(Ref("elt", eltType)), aggSig), None, isScan = false)),
       (aggregable, TStruct("a" -> TArray(eltType))),
-      expected)(ExecStrategy.interpretOnly)
+      expected)(ExecStrategy.interpretNoOpt)
   }
 
   @Test


### PR DESCRIPTION
Permit `ArrayAgg(a, ...)` where `a` contains nested aggregations.

This will lead to better IR through more let forwarding, and is required
by #7141.