### PR TITLE
Transpose bug

### DIFF
--- a/hail/src/main/scala/is/hail/linalg/GridPartitioner.scala
+++ b/hail/src/main/scala/is/hail/linalg/GridPartitioner.scala
@@ -111,7 +111,7 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks
   
   def transpose: (GridPartitioner, Int => Int) = {
     val gpT = GridPartitioner(blockSize, nCols, nRows)
-    def transposeBI(bi: Int): Int = coordinatesBlock(gpT.blockBlockCol(bi), gpT.blockBlockRow(bi))
+    def transposeBI(bi: Int): Int = gpT.coordinatesBlock(this.blockBlockCol(bi), this.blockBlockRow(bi))
     maybeBlocks match {
       case Some(bis) =>
         val (biTranspose, piTranspose) = bis.map(transposeBI).zipWithIndex.sortBy(_._1).unzip

--- a/hail/src/main/scala/is/hail/linalg/GridPartitioner.scala
+++ b/hail/src/main/scala/is/hail/linalg/GridPartitioner.scala
@@ -108,17 +108,23 @@ case class GridPartitioner(blockSize: Int, nRows: Long, nCols: Long, maybeBlocks
   override def getPartition(key: Any): Int = key match {
     case (i: Int, j: Int) => coordinatesPart(i, j)
   }
-  
+
+  /**
+    *
+    * @return A transposed GridPartitioner and a function that maps partitions in the new partitioner to partitions
+    *         in the old partitioner. 
+    */
   def transpose: (GridPartitioner, Int => Int) = {
     val gpT = GridPartitioner(blockSize, nCols, nRows)
     def transposeBI(bi: Int): Int = gpT.coordinatesBlock(this.blockBlockCol(bi), this.blockBlockRow(bi))
+    def inverseTransposeBI(bi: Int) = this.coordinatesBlock(gpT.blockBlockCol(bi), gpT.blockBlockRow(bi))
     maybeBlocks match {
       case Some(bis) =>
         val (biTranspose, piTranspose) = bis.map(transposeBI).zipWithIndex.sortBy(_._1).unzip
         val inverseTransposePI = piTranspose.zipWithIndex.sortBy(_._1).map(_._2)
         
         (GridPartitioner(blockSize, nCols, nRows, Some(biTranspose)), inverseTransposePI)
-      case None => (gpT, transposeBI)
+      case None => (gpT, inverseTransposeBI)
     }
   }
 

--- a/hail/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
+++ b/hail/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
@@ -797,6 +797,14 @@ class BlockMatrixSuite extends HailSuite {
   }
 
   @Test
+  def testSparseTransposeMaybeBlocks(): Unit = {
+    val lm = new BDM[Double](9, 12, (0 to 107).map(_.toDouble).toArray)
+    val bm = toBM(lm, blockSize = 3)
+    val sparse = bm.filterBand(0, 0, true)
+    assert(sparse.transpose().gp.maybeBlocks.get.toIndexedSeq == IndexedSeq(0, 5, 10))
+  }
+
+  @Test
   def testFilterBlocks() {
     val lm = toLM(4, 4, Array(
       1, 2, 3, 4,

--- a/hail/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
+++ b/hail/src/test/scala/is/hail/linalg/BlockMatrixSuite.scala
@@ -805,6 +805,18 @@ class BlockMatrixSuite extends HailSuite {
   }
 
   @Test
+  def filterRowsRectangleSum(): Unit = {
+    val nRows = 10
+    val nCols = 50
+    val bm = BlockMatrix.fill(hc, nRows, nCols, 2, 1)
+    val banded = bm.filterBand(0, 0, false)
+    val rowFilt = banded.filterRows((0L until nRows.toLong by 2L).toArray)
+    val summed = rowFilt.rowSum().toBreezeMatrix().toArray
+    val expected = Array.tabulate(nRows)(x => if (x % 2 == 0) 2.0 else 0) ++ Array.tabulate(nCols - nRows)(x => 0.0)
+    assert(summed sameElements expected)
+  }
+
+  @Test
   def testFilterBlocks() {
     val lm = toLM(4, 4, Array(
       1, 2, 3, 4,


### PR DESCRIPTION
`BlockMatrix.transpose` was not implemented correctly, failed on sparse, rectangular matrices. 

Specifically, the `transposeBI` function in the old implementation was a function from new block indices to old block indices. However, in mapping over maybeBlocks, it was used as though it was a function from old block indices to new block indices. To fix this, I now have `transposeBI` and `inverseTransposeBI`