### PR TITLE
Do not start hail spark monitor outside of jupyter

### DIFF
--- a/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
+++ b/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
@@ -85,8 +85,6 @@ if role == 'Master':
         'SPARK_HOME': '/usr/lib/spark/',
         'PYSPARK_PYTHON': '/opt/conda/default/bin/python',
         'PYSPARK_DRIVER_PYTHON': '/opt/conda/default/bin/python',
-        'HAIL_SPARK_MONITOR': '1',
-        'SPARK_MONITOR_UI': 'http://localhost:8088/proxy/%APP_ID%',
     }
 
     print('setting environment')
@@ -124,7 +122,11 @@ if role == 'Master':
         ],
         'display_name': 'Hail',
         'language': 'python',
-        'env': env_to_set
+        'env': {
+            **env_to_set,
+            'HAIL_SPARK_MONITOR': '1',
+            'SPARK_MONITOR_UI': 'http://localhost:8088/proxy/%APP_ID%',
+        }
     }
 
     # write kernel spec file to default Jupyter kernel directory


### PR DESCRIPTION
This causes issues when starting interactive sessions on clusters.

Before, I get lots of output like this:
SPARKMONITOR_LISTENER: Started SparkListener for Jupyter Notebook
SPARKMONITOR_LISTENER: Port obtained from environment: ERRORNOTFOUND

SPARKMONITOR_LISTENER: Exception creating socket:java.lang.NumberFormatException: For input string: "ERRORNOTFOUND"

SPARKMONITOR_LISTENER: Application Started: application_1569946119076_0001 ...Start Time: 1569946336092

SPARKMONITOR_LISTENER: Exception sending socket message:java.lang.NullPointerException

After:
<nothing>

I also tested to make sure the monitor still worked in a notebook.