### PR TITLE
[hail] Add simplify rule to invert order_by and collect

### DIFF
--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1821,8 +1821,12 @@ class Table(ExprContainer):
         :obj:`list` of :class:`.Struct`
             List of rows.
         """
-        ir = GetField(TableCollect(self._tir), 'rows')
-        e = construct_expr(ir, hl.tarray(self.row.dtype))
+        if len(self.key) > 0:
+            t = self.order_by(*self.key)
+        else:
+            t = self
+        ir = GetField(TableCollect(t._tir), 'rows')
+        e = construct_expr(ir, hl.tarray(t.row.dtype))
         if _localize:
             return Env.backend().execute(e._ir)
         else:

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -143,6 +143,10 @@ class Tests(unittest.TestCase):
         mt = mt.annotate_cols(x = hl.agg.count())
         assert mt.x.collect() == [0, 0, 0]
 
+    def test_col_collect(self):
+        mt = hl.utils.range_matrix_table(3, 3)
+        mt.cols().collect()
+
     def test_aggregate_ir(self):
         ds = (hl.utils.range_matrix_table(5, 5)
               .annotate_globals(g1=5)

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -96,7 +96,7 @@ class ValueIRTests(unittest.TestCase):
             ir.Literal(hl.tarray(hl.tint32), [1, 2, None]),
             ir.TableCount(table),
             ir.TableGetGlobals(table),
-            ir.TableCollect(table),
+            ir.TableCollect(ir.TableKeyBy(table, [], False)),
             ir.TableToValueApply(table, {'name': 'ForceCountTable'}),
             ir.MatrixToValueApply(matrix_read, {'name': 'ForceCountMatrixTable'}),
             ir.TableAggregate(table, ir.MakeStruct([('foo', ir.ApplyAggOp('Collect', [], None, [ir.I32(0)]))])),

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -1201,7 +1201,6 @@ object PruneDeadFields {
         memoizeTableIR(child, TableType(
           key = child.typ.key,
           rowType = unify(child.typ.rowType,
-            selectKey(child.typ.rowType, child.typ.key),
             rStruct.fieldOption("rows").map(_.typ.asInstanceOf[TStreamable].elementType.asInstanceOf[TStruct]).getOrElse(TStruct())),
           globalType = rStruct.fieldOption("global").map(_.typ.asInstanceOf[TStruct]).getOrElse(TStruct())),
           memo)
@@ -1215,7 +1214,6 @@ object PruneDeadFields {
         BindingEnv.empty
       case TableAggregate(child, query) =>
         val queryDep = memoizeAndGetDep(query, query.typ, child.typ, memo)
-        // FIXME look at aggregator commutativity to prune keys
         val dep = TableType(
           key = child.typ.key,
           rowType = unify(child.typ.rowType, queryDep.rowType, selectKey(child.typ.rowType, child.typ.key)),

--- a/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Simplify.scala
@@ -217,6 +217,8 @@ object Simplify {
     case ArrayMap(ArrayMap(a, n1, b1), n2, b2) =>
       ArrayMap(a, n1, Let(n2, b1, b2))
 
+    case ArrayFilter(ArraySort(a, left, right, compare), name, cond) => ArraySort(ArrayFilter(a, name, cond), left, right, compare)
+
     case NDArrayShape(MakeNDArray(_, shape, _)) => shape
 
     case NDArrayShape(NDArrayMap(nd, _, _)) => NDArrayShape(nd)
@@ -413,7 +415,37 @@ object Simplify {
       }
 
     case TableCollect(TableParallelize(x, _)) => x
+    case x@TableCollect(TableOrderBy(child, sortFields)) if sortFields.forall(_.sortOrder == Ascending) =>
+      val uid = genUID()
+      val uid2 = genUID()
+      val left = genUID()
+      val right = genUID()
+      val uid3 = genUID()
+      val sortType = child.typ.rowType.select(sortFields.map(_.field))._1
+
+      val kvElement = MakeStruct(FastSeq(
+        ("key", SelectFields(Ref(uid2, child.typ.rowType), sortFields.map(_.field))),
+        ("value", Ref(uid2, child.typ.rowType))))
+      val sorted = ArraySort(
+        ArrayMap(
+          GetField(Ref(uid, x.typ), "rows"),
+          uid2,
+          kvElement
+        ),
+        left,
+        right,
+        ApplyComparisonOp(LT(sortType),
+          GetField(Ref(left, kvElement.typ), "key"),
+          GetField(Ref(right, kvElement.typ), "key")))
+      Let(uid,
+        TableCollect(TableKeyBy(child, FastIndexedSeq())),
+        MakeStruct(FastSeq(
+          ("rows", ArrayMap(sorted,
+            uid3,
+            GetField(Ref(uid3, sorted.typ.asInstanceOf[TArray].elementType), "value"))),
+          ("global", GetField(Ref(uid, x.typ), "global")))))
     case ArrayLen(GetField(TableCollect(child), "rows")) => TableCount(child)
+    case GetField(TableCollect(child), "global") => TableGetGlobals(child)
 
     case TableAggregate(child, query) if child.typ.key.nonEmpty && !ContainsNonCommutativeAgg(query) =>
       TableAggregate(TableKeyBy(child, FastIndexedSeq(), false), query)

--- a/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TypeCheck.scala
@@ -336,7 +336,8 @@ object TypeCheck {
       case TableMultiWrite(_, _) =>
       case TableCount(_) =>
       case TableGetGlobals(_) =>
-      case TableCollect(_) =>
+      case TableCollect(child) =>
+        assert(child.typ.key.isEmpty)
       case TableToValueApply(_, _) =>
       case MatrixToValueApply(_, _) =>
       case BlockMatrixToValueApply(_, _) =>

--- a/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/PruneSuite.scala
@@ -1056,7 +1056,7 @@ class PruneSuite extends HailSuite {
   }
 
   @Test def testTableCollectRebuild() {
-    val tc = TableCollect(tab)
+    val tc = TableCollect(TableKeyBy(tab, FastIndexedSeq()))
     checkRebuild(tc, TStruct("global" -> TStruct("g1" -> TInt32())),
       (_: BaseIR, r: BaseIR) => {
         r.asInstanceOf[MakeStruct].fields.head._2.isInstanceOf[TableGetGlobals]

--- a/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/TableIRSuite.scala
@@ -28,6 +28,8 @@ class TableIRSuite extends HailSuite {
 
   def rangeKT: TableIR = Table.range(hc, 20, Some(4)).unkey().tir
 
+  def collect(tir: TableIR): TableCollect = TableCollect(TableKeyBy(tir, FastIndexedSeq()))
+
   implicit val execStrats: Set[ExecStrategy] = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized, ExecStrategy.LoweredJVMCompile)
 
   @Test def testRangeCount() {
@@ -40,7 +42,7 @@ class TableIRSuite extends HailSuite {
   }
 
   @Test def testRangeRead() {
-    implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized, ExecStrategy.LoweredJVMCompile)
+    implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized)
     val original = TableMapGlobals(TableRange(10, 3), MakeStruct(FastIndexedSeq("foo" -> I32(57))))
 
     val path = tmpDir.createTempFile()
@@ -52,15 +54,16 @@ class TableIRSuite extends HailSuite {
     val expectedRows = Array.tabulate(10)(i => Row(i)).toFastIndexedSeq
     val expectedGlobals = Row(57)
 
-    assertEvalsTo(TableCollect(read), Row(expectedRows, expectedGlobals))
-    assertEvalsTo(TableCollect(droppedRows), Row(FastIndexedSeq(), expectedGlobals))
+    assertEvalsTo(collect(read), Row(expectedRows, expectedGlobals))
+    assertEvalsTo(collect(droppedRows), Row(FastIndexedSeq(), expectedGlobals))
   }
 
   @Test def testRangeCollect() {
+    implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized)
     val t = TableRange(10, 2)
     val row = Ref("row", t.typ.rowType)
-    val node = TableCollect(TableMapRows(t, InsertFields(row, FastIndexedSeq("x" -> GetField(row, "idx")))))
-    assertEvalsTo(TableCollect(t), Row(Array.tabulate(10)(Row(_)).toFastIndexedSeq, Row()))
+    val node = collect(TableMapRows(t, InsertFields(row, FastIndexedSeq("x" -> GetField(row, "idx")))))
+    assertEvalsTo(collect(t), Row(Array.tabulate(10)(Row(_)).toFastIndexedSeq, Row()))
     assertEvalsTo(node, Row(Array.tabulate(10)(i => Row(i, i)).toFastIndexedSeq, Row()))
   }
 
@@ -69,20 +72,22 @@ class TableIRSuite extends HailSuite {
     val t = TableRange(10, 2)
     val row = Ref("row", t.typ.rowType)
     val sum = AggSignature(Sum(), FastSeq(), None, FastSeq(TInt64()))
-    val node = TableCollect(TableMapRows(t, InsertFields(row, FastIndexedSeq("sum" -> ApplyScanOp(FastSeq(), None, FastSeq(Cast(GetField(row, "idx"), TInt64())), sum)))))
+    val node = collect(TableMapRows(t, InsertFields(row, FastIndexedSeq("sum" -> ApplyScanOp(FastSeq(), None, FastSeq(Cast(GetField(row, "idx"), TInt64())), sum)))))
     assertEvalsTo(node, Row(Array.tabulate(10)(i => Row(i, Array.range(0, i).sum.toLong)).toFastIndexedSeq, Row()))
   }
 
   @Test def testGetGlobals() {
+    implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized)
     val t = TableRange(10, 2)
-    val newGlobals = InsertFields(Ref("global", t.typ.globalType), FastSeq("x" -> TableCollect(t)))
+    val newGlobals = InsertFields(Ref("global", t.typ.globalType), FastSeq("x" -> collect(t)))
     val node = TableGetGlobals(TableMapGlobals(t, newGlobals))
     assertEvalsTo(node, Row(Row(Array.tabulate(10)(i => Row(i)).toFastIndexedSeq, Row())))
   }
 
   @Test def testCollectGlobals() {
+    implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized)
     val t = TableRange(10, 2)
-    val newGlobals = InsertFields(Ref("global", t.typ.globalType), FastSeq("x" -> TableCollect(t)))
+    val newGlobals = InsertFields(Ref("global", t.typ.globalType), FastSeq("x" -> collect(t)))
     val node = TableMapRows(
       TableMapGlobals(t, newGlobals),
       InsertFields(Ref("row", t.typ.rowType), FastSeq("x" -> GetField(Ref("global", newGlobals.typ), "x"))))
@@ -90,38 +95,41 @@ class TableIRSuite extends HailSuite {
     val collectedT = Row(Array.tabulate(10)(i => Row(i)).toFastIndexedSeq, Row())
     val expected = Array.tabulate(10)(i => Row(i, collectedT)).toFastIndexedSeq
 
-    assertEvalsTo(TableCollect(node), Row(expected, Row(collectedT)))
+    assertEvalsTo(collect(node), Row(expected, Row(collectedT)))
   }
 
   @Test def testRangeExplode() {
+    implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized)
     val t = TableRange(10, 2)
     val row = Ref("row", t.typ.rowType)
 
     val t2 = TableMapRows(t, InsertFields(row, FastIndexedSeq("x" -> ArrayRange(0, GetField(row, "idx"), 1))))
     val node = TableExplode(t2, FastIndexedSeq("x"))
     val expected = Array.range(0, 10).flatMap(i => Array.range(0, i).map(Row(i, _))).toFastIndexedSeq
-    assertEvalsTo(TableCollect(node), Row(expected, Row()))
+    assertEvalsTo(collect(node), Row(expected, Row()))
 
     val t3 = TableMapRows(t, InsertFields(row,
       FastIndexedSeq("x" ->
         MakeStruct(FastSeq("y" -> ArrayRange(0, GetField(row, "idx"), 1))))))
     val node2 = TableExplode(t3, FastIndexedSeq("x", "y"))
     val expected2 = Array.range(0, 10).flatMap(i => Array.range(0, i).map(j => Row(i, Row(j)))).toFastIndexedSeq
-    assertEvalsTo(TableCollect(node2), Row(expected2, Row()))
+    assertEvalsTo(collect(node2), Row(expected2, Row()))
   }
 
   @Test def testFilter() {
+    implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized)
     val t = TableRange(10, 2)
     val node = TableFilter(
-      TableMapGlobals(t, MakeStruct(FastSeq("x" -> GetField(ArrayRef(GetField(TableCollect(t), "rows"), 4), "idx")))),
+      TableMapGlobals(t, MakeStruct(FastSeq("x" -> GetField(ArrayRef(GetField(collect(t), "rows"), 4), "idx")))),
        ApplyComparisonOp(EQ(TInt32()), GetField(Ref("row", t.typ.rowType), "idx"), GetField(Ref("global", TStruct("x" -> TInt32())), "x")))
 
     val expected = Array.tabulate(10)(Row(_)).filter(_.get(0) == 4).toFastIndexedSeq
 
-    assertEvalsTo(TableCollect(node), Row(expected, Row(4)))
+    assertEvalsTo(collect(node), Row(expected, Row(4)))
   }
 
   @Test def testTableMapWithLiterals() {
+    implicit val execStrats = Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized)
     val t = TableRange(10, 2)
     val node = TableMapRows(t,
       InsertFields(Ref("row", t.typ.rowType),
@@ -130,7 +138,7 @@ class TableIRSuite extends HailSuite {
           "b" -> Literal(TTuple(TInt32(), TString()), Row(1, "hello")))))
 
     val expected = Array.tabulate(10)(Row(_, "foo", Row(1, "hello"))).toFastIndexedSeq
-    assertEvalsTo(TableCollect(node), Row(expected, Row()))
+    assertEvalsTo(collect(node), Row(expected, Row()))
   }
 
   @Test def testScanCountBehavesLikeIndex() {
@@ -342,7 +350,7 @@ class TableIRSuite extends HailSuite {
         .repartition(if (!rightProject.contains(1)) rightPart else rightPart.coarsen(1)))
 
     val (_, joinProjectF) = joinedType.filter(f => !leftProject.contains(f.index) && !rightProject.contains(f.index - 2))
-    val joined = TableCollect(
+    val joined = collect(
       TableJoin(
         partitionedLeft.tir,
         TableRename(
@@ -379,7 +387,7 @@ class TableIRSuite extends HailSuite {
     val value = Row(FastIndexedSeq(Row(0, "row1"), Row(1, "row2")), Row("glob"))
 
     assertEvalsTo(
-      TableCollect(
+      collect(
         TableParallelize(
           Literal(
             t,


### PR DESCRIPTION
Also require that TableCollect has an unkeyed table. order_by in
Python to enforce key ordering.