### PR TITLE
[hail] Go back to interruptible iterators in RepartitionedOrderedRDD2

### DIFF
--- a/benchmark/python/benchmark_hail/run/table_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/table_benchmarks.py
@@ -35,6 +35,18 @@ def table_range_force_count():
 
 
 @benchmark
+def table_range_join_1b_1k():
+    ht1 = hl.utils.range_table(1_000_000_000)
+    ht2 = hl.utils.range_table(1_000)
+    ht1.join(ht2, 'inner').count()
+
+@benchmark
+def table_range_join_1b_1b():
+    ht1 = hl.utils.range_table(1_000_000_000)
+    ht2 = hl.utils.range_table(1_000_000_000)
+    ht1.join(ht2, 'inner').count()
+
+@benchmark
 def table_python_construction():
     n = 100
     ht = hl.utils.range_table(100)

--- a/hail/src/main/scala/is/hail/sparkextras/RepartitionedOrderedRDD2.scala
+++ b/hail/src/main/scala/is/hail/sparkextras/RepartitionedOrderedRDD2.scala
@@ -60,7 +60,7 @@ class RepartitionedOrderedRDD2 private (prev: RVD, newRangeBounds: IndexedSeq[In
         }.dropWhile { rv =>
           ur.set(rv)
           pord.lt(key, range.left)
-        }.filter { rv =>
+        }.takeWhile { rv =>
           ur.set(rv)
           pord.lteq(key, range.right)
         }


### PR DESCRIPTION
the 1b_1k benchmark goes from 100s to 0.12s