### PR TITLE
[hail][annotationdb] refactor annotation db

### DIFF
--- a/hail/.gitignore
+++ b/hail/.gitignore
@@ -7,6 +7,7 @@ python/hail/hail_pip_version
 python/hail/hail_version
 python/hail/docs/_build/*
 python/hail/hail-all-spark.jar
+python/hail/docs/_static/hail_version.js
 python/hailtop/hailctl/hail_version
 python/hailtop/hailctl/deploy.yaml
 src/main/c/.cxx.vsn

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -31,7 +31,10 @@ JAR_TEST_SOURCES := $(shell git ls-files src/test)
 PY_FILES := $(shell git ls-files python)
 
 INIT_SCRIPTS := python/hailtop/hailctl/deploy.yaml
-PYTHON_VERSION_INFO := python/hail/hail_version python/hail/hail_pip_version python/hailtop/hailctl/hail_version
+PYTHON_VERSION_INFO := python/hail/hail_version
+PYTHON_VERSION_INFO += python/hail/hail_pip_version
+PYTHON_VERSION_INFO += python/hailtop/hailctl/hail_version
+PYTHON_VERSION_INFO += python/hail/docs/_static/hail_version.js
 SCALA_BUILD_INFO := src/main/resources/build-info.properties
 
 SHADOW_JAR := build/libs/hail-all-spark.jar
@@ -84,6 +87,10 @@ python/hail/hail_version: env/SHORT_REVISION env/HAIL_PIP_VERSION
 
 python/hail/hail_pip_version: env/HAIL_PIP_VERSION
 	echo $(HAIL_PIP_VERSION) > $@
+
+python/hail/docs/_static/hail_version.js: python/hail/hail_version python/hail/hail_pip_version
+	printf 'hail_version="$(shell cat python/hail/hail_version)";' > $@
+	printf 'hail_pip_version="$(shell cat python/hail/hail_pip_version)"' >> $@
 
 python/hailtop/hailctl/hail_version: python/hail/hail_version
 	cp -f $< $@

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -219,9 +219,9 @@ DEPLOYED_VERSION = $(shell \
 .PHONY: check-pypi
 check-pypi:
 	if [ -z "$$DEPLOY_PROD" ]; then \
-	  echo "DEPLOY_PROD must be set to deploy to PyPI"; exit 1; fi
+	  echo "ERROR: DEPLOY_PROD must be set to deploy to PyPI"; exit 1; fi
 	if [ "$(DEPLOYED_VERSION)" == "$(HAIL_PIP_VERSION)" ]; then \
-	  echo "version $(HAIL_PIP_VERSION) already deployed"; exit 1; fi
+	  echo "ERROR: version $(HAIL_PIP_VERSION) already deployed"; exit 1; fi
 
 HAIL_TWINE_CREDS_FOLDER ?= /secrets/
 
@@ -234,11 +234,18 @@ pypi-deploy: check-pypi test-dataproc set-docs-sha
 TAG_EXISTS = $(shell git ls-remote --exit-code --tags origin $(HAIL_PIP_VERSION) || echo "does not exist")
 .PHONY: check-tag
 check-tag:
-	if [ -z "$(TAG_EXISTS)" ]; then echo "tag $(HAIL_PIP_VERSION) already exists"; exit 1; fi
+	if [ -z "$(TAG_EXISTS)" ]; then echo "ERROR: tag $(HAIL_PIP_VERSION) already exists"; exit 1; fi
+
+annotation_db_json_url := gs://hail-common/annotationdb/$(HAIL_PIP_VERSION)/annotationdb.json
+.PHONY: deploy-annotation-db
+deploy-annotation-db:
+	! gsutil ls $(annotation_db_json_url) && \
+    gsutil cp python/hail/experimental/annotation_db.json $(annotation_db_json_url) || \
+    echo "ERROR: annotation db $(HAIL_PIP_VERSION) already exists, refusing to overwrite" && exit 1
 
 GITHUB_RELEASE_URL = https://github.com/hail-is/hail/releases/new
 .PHONY: tag
-tag: check-tag pypi-deploy
+tag: check-tag pypi-deploy deploy-annotation-db
 	git tag $(HAIL_PIP_VERSION) -m "Hail version $(HAIL_PIP_VERSION)"
 	git push https://github.com/hail-is/hail.git $(HAIL_PIP_VERSION)
 	@echo Please make a release: $(GITHUB_RELEASE_URL)

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -243,12 +243,6 @@ TAG_EXISTS = $(shell git ls-remote --exit-code --tags origin $(HAIL_PIP_VERSION)
 check-tag:
 	if [ -z "$(TAG_EXISTS)" ]; then echo "ERROR: tag $(HAIL_PIP_VERSION) already exists"; exit 1; fi
 
-annotation_db_json_url := gs://hail-common/annotationdb/$(HAIL_PIP_VERSION)/annotation_db.json
-.PHONY: deploy-annotation-db
-deploy-annotation-db:
-	gsutil cp python/hail/experimental/annotation_db.json $(annotation_db_json_url)
-	gsutil -m retention temp set $(annotation_db_json_url)
-
 GITHUB_RELEASE_URL = https://github.com/hail-is/hail/releases/new
 .PHONY: tag
 tag: check-tag pypi-deploy deploy-annotation-db

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -243,6 +243,12 @@ TAG_EXISTS = $(shell git ls-remote --exit-code --tags origin $(HAIL_PIP_VERSION)
 check-tag:
 	if [ -z "$(TAG_EXISTS)" ]; then echo "ERROR: tag $(HAIL_PIP_VERSION) already exists"; exit 1; fi
 
+annotation_db_json_url := gs://hail-common/annotationdb/$(HAIL_PIP_VERSION)/annotation_db.json
+.PHONY: deploy-annotation-db
+deploy-annotation-db:
+	gsutil cp python/hail/experimental/annotation_db.json $(annotation_db_json_url)
+	gsutil -m retention temp set $(annotation_db_json_url)
+
 GITHUB_RELEASE_URL = https://github.com/hail-is/hail/releases/new
 .PHONY: tag
 tag: check-tag pypi-deploy deploy-annotation-db

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -246,9 +246,8 @@ check-tag:
 annotation_db_json_url := gs://hail-common/annotationdb/$(HAIL_PIP_VERSION)/annotation_db.json
 .PHONY: deploy-annotation-db
 deploy-annotation-db:
-	(! gsutil ls $(annotation_db_json_url) >/dev/null 2>/dev/null && \
-    gsutil cp python/hail/experimental/annotation_db.json $(annotation_db_json_url)) || \
-    (echo "ERROR: annotation db $(HAIL_PIP_VERSION) already exists, refusing to overwrite" && exit 1)
+	gsutil cp python/hail/experimental/annotation_db.json $(annotation_db_json_url)
+	gsutil -m retention temp set $(annotation_db_json_url)
 
 GITHUB_RELEASE_URL = https://github.com/hail-is/hail/releases/new
 .PHONY: tag

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -236,12 +236,12 @@ TAG_EXISTS = $(shell git ls-remote --exit-code --tags origin $(HAIL_PIP_VERSION)
 check-tag:
 	if [ -z "$(TAG_EXISTS)" ]; then echo "ERROR: tag $(HAIL_PIP_VERSION) already exists"; exit 1; fi
 
-annotation_db_json_url := gs://hail-common/annotationdb/$(HAIL_PIP_VERSION)/annotationdb.json
+annotation_db_json_url := gs://hail-common/annotationdb/$(HAIL_PIP_VERSION)/annotation_db.json
 .PHONY: deploy-annotation-db
 deploy-annotation-db:
-	! gsutil ls $(annotation_db_json_url) && \
-    gsutil cp python/hail/experimental/annotation_db.json $(annotation_db_json_url) || \
-    echo "ERROR: annotation db $(HAIL_PIP_VERSION) already exists, refusing to overwrite" && exit 1
+	(! gsutil ls $(annotation_db_json_url) >/dev/null 2>/dev/null && \
+    gsutil cp python/hail/experimental/annotation_db.json $(annotation_db_json_url)) || \
+    (echo "ERROR: annotation db $(HAIL_PIP_VERSION) already exists, refusing to overwrite" && exit 1)
 
 GITHUB_RELEASE_URL = https://github.com/hail-is/hail/releases/new
 .PHONY: tag

--- a/hail/Makefile
+++ b/hail/Makefile
@@ -243,25 +243,25 @@ TAG_EXISTS = $(shell git ls-remote --exit-code --tags origin $(HAIL_PIP_VERSION)
 check-tag:
 	if [ -z "$(TAG_EXISTS)" ]; then echo "ERROR: tag $(HAIL_PIP_VERSION) already exists"; exit 1; fi
 
-annotation_db_json_url := gs://hail-common/annotationdb/$(HAIL_PIP_VERSION)/annotation_db.json
-.PHONY: deploy-annotation-db
-deploy-annotation-db:
-	gsutil cp python/hail/experimental/annotation_db.json $(annotation_db_json_url)
-	gsutil -m retention temp set $(annotation_db_json_url)
-
 GITHUB_RELEASE_URL = https://github.com/hail-is/hail/releases/new
 .PHONY: tag
-tag: check-tag pypi-deploy deploy-annotation-db
+tag: check-tag pypi-deploy
 	git tag $(HAIL_PIP_VERSION) -m "Hail version $(HAIL_PIP_VERSION)"
 	git push https://github.com/hail-is/hail.git $(HAIL_PIP_VERSION)
 	@echo Please make a release: $(GITHUB_RELEASE_URL)
 	if [ `uname` == "Darwin" ]; then open $(GITHUB_RELEASE_URL); fi
 
+annotation_db_json_url := gs://hail-common/annotationdb/$(HAIL_PIP_VERSION)-$(SHORT_REVISION)/annotation_db.json
+.PHONY: deploy-annotation-db
+deploy-annotation-db:
+	gsutil cp python/hail/experimental/annotation_db.json $(annotation_db_json_url)
+	gsutil -m retention temp set $(annotation_db_json_url)
+
 docs_location := gs://hail-common/builds/0.2/docs/hail-0.2-docs-$(REVISION).tar.gz
 local_sha_location := build/deploy/latest-hash-spark-$(SPARK_VERSION).txt
 cloud_sha_location := gs://hail-common/builds/0.2/latest-hash/cloudtools-5-spark-2.4.0.txt
 .PHONY: set-docs-sha
-set-docs-sha:
+set-docs-sha: deploy-annotation-db
 	mkdir -p $(dir $(local_sha_location))
 	gsutil ls $(docs_location)  # make sure file exists
 	echo "$(REVISION)" > $(local_sha_location)

--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -98,6 +98,7 @@ ir.register_functions()
 ir.register_aggregators()
 
 __version__ = None  # set in hail.init()
+__pip_version__ = None  # set in hail.init()
 
 import warnings
 

--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -25,7 +25,6 @@ For help, visit either:
 To report a bug, please open an issue: https://github.com/hail-is/hail/issues
 """
 
-
 from .context import init, stop, spark_context, default_reference, \
     get_reference, set_global_seed, _set_flags, _get_flags, \
     current_backend, debug_info, citation, cite_hail, cite_hail_bibtex

--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -1,11 +1,11 @@
 import pkg_resources
 import sys
 
-__pip_version__ = pkg_resources.resource_string(__name__, 'hail_pip_version').decode().strip()
-
 if sys.version_info < (3, 6):
     raise EnvironmentError('Hail requires Python 3.6, found {}.{}'.format(
         sys.version_info.major, sys.version_info.minor))
+
+__pip_version__ = pkg_resources.resource_string(__name__, 'hail_pip_version').decode().strip()
 del pkg_resources
 del sys
 

--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -1,8 +1,12 @@
+import pkg_resources
 import sys
+
+__pip_version__ = pkg_resources.resource_string(__name__, 'hail_pip_version').decode().strip()
 
 if sys.version_info < (3, 6):
     raise EnvironmentError('Hail requires Python 3.6, found {}.{}'.format(
         sys.version_info.major, sys.version_info.minor))
+del pkg_resources
 del sys
 
 __doc__ = r"""
@@ -20,6 +24,7 @@ For help, visit either:
  
 To report a bug, please open an issue: https://github.com/hail-is/hail/issues
 """
+
 
 from .context import init, stop, spark_context, default_reference, \
     get_reference, set_global_seed, _set_flags, _get_flags, \
@@ -98,7 +103,6 @@ ir.register_functions()
 ir.register_aggregators()
 
 __version__ = None  # set in hail.init()
-__pip_version__ = None  # set in hail.init()
 
 import warnings
 

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -96,7 +96,6 @@ class HailContext(object):
 
         version = read_version()
         hail.__version__ = version
-        hail.__pip_version__ = read_pip_version()
 
         if log is None:
             log = hail.utils.timestamp_path(os.path.join(os.getcwd(), 'hail'),
@@ -392,17 +391,9 @@ def set_global_seed(seed):
     Env.set_seed(seed)
 
 
-def _read_string_from_resource(fname):
-    # https://stackoverflow.com/questions/6028000/how-to-read-a-static-file-from-inside-a-python-package
-    return pkg_resources.resource_string(__name__, fname).decode().strip()
-
-
 def read_version() -> str:
-    return _read_string_from_resource('hail_version')
-
-
-def read_pip_version() -> str:
-    return _read_string_from_resource('hail_pip_version')
+    # https://stackoverflow.com/questions/6028000/how-to-read-a-static-file-from-inside-a-python-package
+    return pkg_resources.resource_string(__name__, 'hail_version').decode().strip()
 
 
 def _set_flags(**flags):

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -94,8 +94,9 @@ class HailContext(object):
         tmp_dir = get_env_or_default(tmp_dir, 'TMPDIR', '/tmp')
         optimizer_iterations = get_env_or_default(optimizer_iterations, 'HAIL_OPTIMIZER_ITERATIONS', 3)
 
-        version = read_version_info()
+        version = read_version()
         hail.__version__ = version
+        hail.__pip_version__ = read_pip_version()
 
         if log is None:
             log = hail.utils.timestamp_path(os.path.join(os.getcwd(), 'hail'),
@@ -281,7 +282,7 @@ def init(sc=None, app_name='Hail', master=None, local='local[*]',
 
 
 def _hail_cite_url():
-    version = read_version_info()
+    version = read_version()
     [tag, sha_prefix] = version.split("-")
     if pkg_resources.resource_exists(__name__, "hail-all-spark.jar"):
         # pip installed
@@ -391,9 +392,17 @@ def set_global_seed(seed):
     Env.set_seed(seed)
 
 
-def read_version_info() -> str:
+def _read_string_from_resource(fname):
     # https://stackoverflow.com/questions/6028000/how-to-read-a-static-file-from-inside-a-python-package
-    return pkg_resources.resource_string(__name__, 'hail_version').decode().strip()
+    return pkg_resources.resource_string(__name__, fname).decode().strip()
+
+
+def read_version() -> str:
+    return _read_string_from_resource('hail_version')
+
+
+def read_pip_version() -> str:
+    return _read_string_from_resource('hail_pip_version')
 
 
 def _set_flags(**flags):

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -94,7 +94,7 @@ class HailContext(object):
         tmp_dir = get_env_or_default(tmp_dir, 'TMPDIR', '/tmp')
         optimizer_iterations = get_env_or_default(optimizer_iterations, 'HAIL_OPTIMIZER_ITERATIONS', 3)
 
-        version = read_version()
+        version = read_version_info()
         hail.__version__ = version
 
         if log is None:
@@ -281,7 +281,7 @@ def init(sc=None, app_name='Hail', master=None, local='local[*]',
 
 
 def _hail_cite_url():
-    version = read_version()
+    version = read_version_info()
     [tag, sha_prefix] = version.split("-")
     if pkg_resources.resource_exists(__name__, "hail-all-spark.jar"):
         # pip installed
@@ -391,7 +391,7 @@ def set_global_seed(seed):
     Env.set_seed(seed)
 
 
-def read_version() -> str:
+def read_version_info() -> str:
     # https://stackoverflow.com/questions/6028000/how-to-read-a-static-file-from-inside-a-python-package
     return pkg_resources.resource_string(__name__, 'hail_version').decode().strip()
 

--- a/hail/python/hail/docs/_static/annotationdb/annotationdb.js
+++ b/hail/python/hail/docs/_static/annotationdb/annotationdb.js
@@ -4,7 +4,7 @@ $("#checkAll").click(function(){
 
 $.ajax({type: 'GET',
         url: ('https://www.googleapis.com/storage/v1/b/hail-common/o/annotationdb%2f' +
-              hail_pip_version +
+              hail_version +
               '%2fannotation_db.json?alt=media'),
         dataType: 'json',
         success: function (data) {

--- a/hail/python/hail/docs/_static/annotationdb/annotationdb.js
+++ b/hail/python/hail/docs/_static/annotationdb/annotationdb.js
@@ -2,58 +2,50 @@ $("#checkAll").click(function(){
     $('input:checkbox').not(this).prop('checked', this.checked);
 });
 
-$.ajax({
-        type: 'GET',
-        url: 'https://www.googleapis.com/storage/v1/b/hail-common/o/annotationdb%2f1%2fannotation_db.json?alt=media',
+$.ajax({type: 'GET',
+        url: ('https://www.googleapis.com/storage/v1/b/hail-common/o/annotationdb%2f' +
+              hail_pip_version +
+              '%2fannotation_db.json?alt=media'),
         dataType: 'json',
         success: function (data) {
-             console.log(data);
-             var tr = data.report
-             var dict = {};
-             var mySet = new Set();
-             for (var i = 0; i < data.length; i++) {
-                 if(data[i].name in dict){
-                    dict[data[i].name].push(data[i].reference_genome);
-                 }else{
-                     dict[data[i].name] = [data[i].reference_genome]
-                 }  
-            }
-            for (var i = 0; i < data.length; i++) {
-                    if(!mySet.has(data[i].name)){
-                        mySet.add(data[i].name);
-                        tr = $('<tr/>');
-                        tr.append("<td><input type='checkbox' class='checkboxadd' value='"+data[i].name+"' onClick='updateTextArea()'/>&nbsp;</td>")
-                        tr.append("<td>" + data[i].name + "</td>");
-                        tr.append("<td>" + data[i].description + "\n<a href='"+ data[i].url + "'>" +data[i].url+ "</a></td>");
-                        tr.append("<td>" + (data[i].version == null ? "" : data[i].version) + 
-                                  "\n" + (dict[data[i].name][0] == null ? "" : "("+ dict[data[i].name]+ ")") + "</td>");
-                        $('.table1').append(tr);
-                     }
-                }
+          for (name in data) {
+            dataset = data[name]
+            versions_string = dataset.versions.map(function (i) {
+              return i["version"]
+            }).reduce(function (i, j) {
+              return i + "; " + j
+            })
+            tr = $('<tr/>');
+            tr.append("<td><input type='checkbox' class='checkboxadd' value='"+name+"' onClick='updateTextArea()'/>&nbsp;</td>")
+            tr.append("<td>" + name + "</td>");
+            tr.append("<td>" + dataset.description + "\n<a href='"+ dataset.url + "'>link</a></td>");
+            tr.append("<td>" + versions_string + "</td>");
+            $('.table1').append(tr);
+          }
         }
-    });
+       });
 
 
 function filterTable() {
-    var input, filter, found, table, tr, td, i, j;
-    input = document.getElementById("searchInput");
-    filter = input.value.toUpperCase();
-    table = document.getElementById("table1");
-    tr = table.getElementsByTagName("tr");
-    for (i = 0; i < tr.length; i++) {
-        td = tr[i].getElementsByTagName("td");
-        for (j = 0; j < td.length; j++) {
-            if (td[j].innerHTML.toUpperCase().indexOf(filter) > -1) {
-                found = true;
-            }
-        }
-        if (found) {
-            tr[i].style.display = "";
-            found = false;
-        } else if (!tr[i].id.match('^tableHeader'))  {
-            tr[i].style.display = "none";
-        }
+  let input = document.getElementById("searchInput")
+  let filter = input.value.toUpperCase()
+  let table = document.getElementById("table1")
+  let tr = table.getElementsByTagName("tr")
+  var found = false
+  for (var i = 0; i < tr.length; i++) {
+    let td = tr[i].getElementsByTagName("td")
+    for (var j = 0; j < td.length; j++) {
+      if (td[j].innerHTML.toUpperCase().indexOf(filter) > -1) {
+        found = true
+      }
     }
+    if (found) {
+      tr[i].style.display = ""
+      found = false
+    } else if (!tr[i].id.match('^tableHeader'))  {
+      tr[i].style.display = "none"
+    }
+  }
 }
 
 function copy() {
@@ -64,15 +56,9 @@ function copy() {
 
 
 function updateTextArea() {
-    var text = "db = hl.experimental.DB()\nmt = db.annotate_rows_db(mt,";
-    var isFirst = true;
+    var text = "db = hl.experimental.DB()\nmt = db.annotate_rows_db(mt";
     $('input[type=checkbox]:checked').filter(".checkboxadd").each( function() {
-        if(!isFirst){
-            text += ",";
-        } else {
-            isFirst = false;
-        } 
-        text += '"' + $(this).val() + '"';
+        text += ', "' + $(this).val() + '"';
         $('#result').val(text + ')');
     });
      $('input[type="checkbox"]:not(:checked)').filter(".checkboxadd").each( function(){
@@ -82,4 +68,4 @@ function updateTextArea() {
 
 $('input[type=checkbox]').change(function () {
     updateTextArea();
-}); 
+});

--- a/hail/python/hail/docs/_templates/layout.html
+++ b/hail/python/hail/docs/_templates/layout.html
@@ -12,7 +12,7 @@
 
 {% if pagename == "annotation_database_ui" %}
 {%- set css_files = css_files + [ '_static/annotationdb/annotationdb.css'] %}
-{%- set script_files = script_files + ['_static/annotationdb/clipboard.min.js', '_static/annotationdb/annotationdb.js'] %}
+{%- set script_files = script_files + ['_static/annotationdb/clipboard.min.js','_static/hail_version.js','_static/annotationdb/annotationdb.js'] %}
 {% endif %}
 
 <!DOCTYPE html>

--- a/hail/python/hail/docs/annotation_database_ui.rst
+++ b/hail/python/hail/docs/annotation_database_ui.rst
@@ -5,7 +5,7 @@
 Annotation Database
 ===================
 
-This database contains a curated collection of variant annotations in an accessible and Hail-friendly format, for use in Hail analysis pipelines. 
+This database contains a curated collection of variant annotations in an accessible and Hail-friendly format, for use in Hail analysis pipelines.
 
 To incorporate these annotations in your own Hail analysis pipeline, select which annotations you would like to query from the table below and then copy-and-paste the Hail generated code into your own analysis script.
 
@@ -15,18 +15,18 @@ Database Query
 --------------
 
 Select annotations by clicking on the checkboxes in the table, and the appropriate Hail command will be generated
-in the panel below. 
+in the panel below.
 
 In addition, a search bar is provided if looking for a specific annotation within our curated collection.
 
 Use the "Copy to clipboard" button to copy the generated Hail code, and paste the command into your
 own Hail script.
 
-.. raw:: html   
+.. raw:: html
     <div class="jumbotron" sytle="margin-bottom:0px; color:white;">
     <h2 class="text-center" style="font-size:40px; font-weight:400;"> Hail </h2>
-    </div>  
-      
+    </div>
+
     <div class="d-flex flex-column" style="height:1150px;" id='annotation-db'>
     <div class="flex-1" >
     <div class="panel panel-default flex-fill">
@@ -52,7 +52,7 @@ own Hail script.
     <div class="form-group">
     <label for="exampleFormControlTextarea1">Hail Generated Code</label>
     <textarea readonly class="form-control" id="result" rows="3">db = hl.experimental.DB()
-    mt = db.annotate_rows_db(mt, </textarea>
+    mt = db.annotate_rows_db(mt)</textarea>
     </div>
     </div>
     </div>

--- a/hail/python/hail/experimental/annotation_db.json
+++ b/hail/python/hail/experimental/annotation_db.json
@@ -1,0 +1,121 @@
+{"DANN":
+ {"description": "DANN: a deep learning approach for annotating the pathogenicity of genetic variants.",
+  "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4341060/",
+  "key_properties": ["unique"],
+  "versions": [
+    {"url":"gs://hail-common/datasets/1/DANN.GRCh37.ht",
+     "version": null},
+    {"url":"gs://hail-common/datasets/1/DANN.GRCh38.ht",
+     "version": null}]},
+ "CADD":
+ {"description": "CADD: an algorithm designed to annotate both coding and non-coding variants.",
+  "url": "http://europepmc.org/abstract/med/11384848",
+  "key_properties": ["unique"],
+  "versions": [
+    {"url":"gs://hail-common/datasets/1/CADD.v1.4.GRCh37.ht",
+     "version": "1.4"},
+    {"url":"gs://hail-common/datasets/1/CADD.v1.4.GRCh38.ht",
+     "version": "1.4"}]},
+ "Ensembl_homo_sapiens_reference_genome":
+ {"description": "Ensembl: a genome browser for vertebrate genomes that supports research in comparative genomics, evolution, sequence variation and transcriptional regulation.",
+  "url": "https://useast.ensembl.org/index.html",
+  "key_properties": ["unique"],
+  "versions": [
+    {"url":"gs://hail-common/datasets/1/Ensembl_homo_sapiens_reference_genome.release_95.GRCh37.ht",
+     "version": "release_95"},
+    {"url":"gs://hail-common/datasets/1/Ensembl_homo_sapiens_reference_genome.release_95.GRCh38.ht",
+     "version": "release_95"}]},
+ "Ensembl_homo_sapiens_low_complexity_regions":
+ {"description": "Ensembl: a genome browser for vertebrate genomes that supports research in comparative genomics, evolution, sequence variation and transcriptional regulation.",
+  "url": "https://useast.ensembl.org/index.html",
+  "key_properties": ["unique"],
+  "versions": [
+    {"url":"gs://hail-common/datasets/1/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh37.ht",
+     "version": "release_95"},
+    {"url":"gs://hail-common/datasets/1/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh38.ht",
+     "version": "release_95"}]},
+ "gencode":
+ {"description": "GENCODE: aims to identify all gene features in the human genome using a combination of computational analysis, manual annotation, and experimental validation.",
+  "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3431492/",
+  "key_properties": [],
+  "versions": [
+    {"url":"gs://hail-common/datasets/1/gencode.v19.annotation.GRCh37.ht",
+     "version": "v19"},
+    {"url":"gs://hail-common/datasets/1/gencode.v31.annotation.GRCh38.ht",
+     "version": "v31"}]},
+ "gnomad_lof_metrics":
+ {"description": "gnomAD: a resource with the goal of aggregating and harmonizing both exome and genome sequencing data from a wide variety of large-scale sequencing projects.",
+  "url": "https://gnomad.broadinstitute.org/",
+  "key_properties": ["gene"],
+  "versions": [
+    {"url":"gs://hail-common/datasets/1/gnomad_v2.1.1_lof_metrics_by_gene.ht",
+     "version": "2.1.1"}]},
+ "gnomad_exome_sites":
+ {"description": "gnomAD: a resource with the goal of aggregating and harmonizing both exome and genome sequencing data from a wide variety of large-scale sequencing projects.",
+  "url": "https://gnomad.broadinstitute.org/",
+  "key_properties": ["unique"],
+  "versions": [
+    {"url":"gs://gnomad-public/release/2.1.1/ht/exomes/gnomad.exomes.r2.1.1.sites.ht",
+     "version": "2.1.1"},
+    {"url":"gs://gnomad-public/release/2.1.1/liftover_grch38/ht/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.ht",
+     "version": "2.1.1"}]},
+ "gnomad_genome_sites":
+ {"description": "gnomAD: a resource with the goal of aggregating and harmonizing both exome and genome sequencing data from a wide variety of large-scale sequencing projects.",
+  "url": "https://gnomad.broadinstitute.org/",
+  "key_properties": ["unique"],
+  "versions": [
+    {"url":"gs://gnomad-public/release/2.1.1/ht/genomes/gnomad.genomes.r2.1.1.sites.ht",
+     "version": "2.1.1"},
+    {"url":"gs://gnomad-public/release/2.1.1/liftover_grch38/ht/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.ht",
+     "version": "2.1.1"}]},
+ "clinvar_gene_summary":
+ {"description": "Clinvar: aggregates information about genomic variation and its relationship to human health.",
+  "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+  "key_properties": ["gene", "unique"],
+  "versions": [
+    {"url":"gs://hail-common/datasets/1/gene_specific_summary_2019-07.txt.gz.ht",
+     "version": "2019-07"}]},
+ "clinvar_variant_summary":
+ {"description": "Clinvar: aggregates information about genomic variation and its relationship to human health.",
+  "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+  "key_properties": [],
+  "versions": [
+    {"url":"gs://hail-common/datasets/1/variant_summary_2019-07.GRCh37.txt.gz.ht",
+     "version": "2019-07"},
+    {"url":"gs://hail-common/datasets/1/variant_summary_2019-07.GRCh38.txt.gz.ht",
+     "version": "2019-07"}]},
+ "dbNSFP_variants":
+ {"description": "dbNSFP: a database developed for functional prediction and annotation of all nsSNVs in the human genome.",
+  "url": "https://sites.google.com/site/jpopgen/dbNSFP",
+  "key_properties": ["FIXME: unique?"],
+  "versions": [
+    {"url":"gs://hail-common/datasets/1/dbnsfp4.0a.GRCh37.ht",
+     "version": "4.0"},
+    {"url":"gs://hail-common/datasets/1/dbnsfp4.0a.GRCh38.ht",
+     "version": "4.0"}]},
+ "dbNSFP_genes":
+ {"description": "dbNSFP: a database developed for functional prediction and annotation of all nsSNVs in the human genome.",
+  "url": "https://sites.google.com/site/jpopgen/dbNSFP",
+  "key_properties": ["gene", "unique"],
+  "versions": [
+    {"url":"gs://hail-common/datasets/1/dbnsfp/dbNSFP4.0_gene.complete.bgz.ht",
+     "version": "4.0"}]},
+ "gerp_scores":
+ {"description": "GERP: identifies constrained elements in multiple alignments by quantifying substitution deficits.",
+  "url": "http://mendel.stanford.edu/SidowLab/downloads/gerp/",
+  "key_properties": [],
+  "versions": [
+    {"url": "gs://hail-common/datasets/1/GERP_scores.GERP++.GRCh37.ht",
+     "version": null},
+    {"url":"gs://hail-common/datasets/1/GERP_scores.GERP++.GRCh38.ht",
+     "version": null}]},
+ "gerp_elements":
+ {"description": "GERP: identifies constrained elements in multiple alignments by quantifying substitution deficits.",
+  "url": "http://mendel.stanford.edu/SidowLab/downloads/gerp/",
+  "key_properties": ["FIXME: unique?"],
+  "versions": [
+    {"url":"gs://hail-common/datasets/1/GERP_elements.GERP++.GRCh37.ht",
+     "version": null},
+    {"url":"gs://hail-common/datasets/1/GERP_elements.GERP++.GRCh38.ht",
+     "version": null}]}
+}

--- a/hail/python/hail/experimental/annotation_db.json
+++ b/hail/python/hail/experimental/annotation_db.json
@@ -4,45 +4,45 @@
   "key_properties": ["unique"],
   "versions": [
     {"url":"gs://hail-common/datasets/1/DANN.GRCh37.ht",
-     "version": null},
+     "version": "GRCh37"},
     {"url":"gs://hail-common/datasets/1/DANN.GRCh38.ht",
-     "version": null}]},
+     "version": "GRCh38"}]},
  "CADD":
  {"description": "CADD: an algorithm designed to annotate both coding and non-coding variants.",
   "url": "http://europepmc.org/abstract/med/11384848",
   "key_properties": ["unique"],
   "versions": [
     {"url":"gs://hail-common/datasets/1/CADD.v1.4.GRCh37.ht",
-     "version": "1.4"},
+     "version": "1.4-GRCh37"},
     {"url":"gs://hail-common/datasets/1/CADD.v1.4.GRCh38.ht",
-     "version": "1.4"}]},
+     "version": "1.4-GRCh38"}]},
  "Ensembl_homo_sapiens_reference_genome":
  {"description": "Ensembl: a genome browser for vertebrate genomes that supports research in comparative genomics, evolution, sequence variation and transcriptional regulation.",
   "url": "https://useast.ensembl.org/index.html",
   "key_properties": ["unique"],
   "versions": [
     {"url":"gs://hail-common/datasets/1/Ensembl_homo_sapiens_reference_genome.release_95.GRCh37.ht",
-     "version": "release_95"},
+     "version": "95-GRCh37"},
     {"url":"gs://hail-common/datasets/1/Ensembl_homo_sapiens_reference_genome.release_95.GRCh38.ht",
-     "version": "release_95"}]},
+     "version": "95-GRCh38"}]},
  "Ensembl_homo_sapiens_low_complexity_regions":
  {"description": "Ensembl: a genome browser for vertebrate genomes that supports research in comparative genomics, evolution, sequence variation and transcriptional regulation.",
   "url": "https://useast.ensembl.org/index.html",
   "key_properties": ["unique"],
   "versions": [
     {"url":"gs://hail-common/datasets/1/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh37.ht",
-     "version": "release_95"},
+     "version": "95-GRCh37"},
     {"url":"gs://hail-common/datasets/1/Ensembl_homo_sapiens_low_complexity_regions.release_95.GRCh38.ht",
-     "version": "release_95"}]},
+     "version": "95-GRCh38"}]},
  "gencode":
  {"description": "GENCODE: aims to identify all gene features in the human genome using a combination of computational analysis, manual annotation, and experimental validation.",
   "url": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3431492/",
   "key_properties": [],
   "versions": [
     {"url":"gs://hail-common/datasets/1/gencode.v19.annotation.GRCh37.ht",
-     "version": "v19"},
+     "version": "GRCh37"},
     {"url":"gs://hail-common/datasets/1/gencode.v31.annotation.GRCh38.ht",
-     "version": "v31"}]},
+     "version": "GRCh38"}]},
  "gnomad_lof_metrics":
  {"description": "gnomAD: a resource with the goal of aggregating and harmonizing both exome and genome sequencing data from a wide variety of large-scale sequencing projects.",
   "url": "https://gnomad.broadinstitute.org/",
@@ -56,18 +56,18 @@
   "key_properties": ["unique"],
   "versions": [
     {"url":"gs://gnomad-public/release/2.1.1/ht/exomes/gnomad.exomes.r2.1.1.sites.ht",
-     "version": "2.1.1"},
+     "version": "2.1.1-GRCh37"},
     {"url":"gs://gnomad-public/release/2.1.1/liftover_grch38/ht/exomes/gnomad.exomes.r2.1.1.sites.liftover_grch38.ht",
-     "version": "2.1.1"}]},
+     "version": "2.1.1-GRCh38"}]},
  "gnomad_genome_sites":
  {"description": "gnomAD: a resource with the goal of aggregating and harmonizing both exome and genome sequencing data from a wide variety of large-scale sequencing projects.",
   "url": "https://gnomad.broadinstitute.org/",
   "key_properties": ["unique"],
   "versions": [
     {"url":"gs://gnomad-public/release/2.1.1/ht/genomes/gnomad.genomes.r2.1.1.sites.ht",
-     "version": "2.1.1"},
+     "version": "2.1.1-GRCh37"},
     {"url":"gs://gnomad-public/release/2.1.1/liftover_grch38/ht/genomes/gnomad.genomes.r2.1.1.sites.liftover_grch38.ht",
-     "version": "2.1.1"}]},
+     "version": "2.1.1-GRCh38"}]},
  "clinvar_gene_summary":
  {"description": "Clinvar: aggregates information about genomic variation and its relationship to human health.",
   "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
@@ -81,18 +81,18 @@
   "key_properties": [],
   "versions": [
     {"url":"gs://hail-common/datasets/1/variant_summary_2019-07.GRCh37.txt.gz.ht",
-     "version": "2019-07"},
+     "version": "2019-07-GRCh37"},
     {"url":"gs://hail-common/datasets/1/variant_summary_2019-07.GRCh38.txt.gz.ht",
-     "version": "2019-07"}]},
+     "version": "2019-07-GRCh38"}]},
  "dbNSFP_variants":
  {"description": "dbNSFP: a database developed for functional prediction and annotation of all nsSNVs in the human genome.",
   "url": "https://sites.google.com/site/jpopgen/dbNSFP",
   "key_properties": [],
   "versions": [
     {"url":"gs://hail-common/datasets/1/dbnsfp4.0a.GRCh37.ht",
-     "version": "4.0"},
+     "version": "4.0-GRCh37"},
     {"url":"gs://hail-common/datasets/1/dbnsfp4.0a.GRCh38.ht",
-     "version": "4.0"}]},
+     "version": "4.0-GRCh38"}]},
  "dbNSFP_genes":
  {"description": "dbNSFP: a database developed for functional prediction and annotation of all nsSNVs in the human genome.",
   "url": "https://sites.google.com/site/jpopgen/dbNSFP",
@@ -106,16 +106,16 @@
   "key_properties": ["unique"],
   "versions": [
     {"url": "gs://hail-common/datasets/1/GERP_scores.GERP++.GRCh37.ht",
-     "version": null},
+     "version": "GRCh37"},
     {"url":"gs://hail-common/datasets/1/GERP_scores.GERP++.GRCh38.ht",
-     "version": null}]},
+     "version": "GRCh38"}]},
  "gerp_elements":
  {"description": "GERP: identifies constrained elements in multiple alignments by quantifying substitution deficits.",
   "url": "http://mendel.stanford.edu/SidowLab/downloads/gerp/",
   "key_properties": [],
   "versions": [
     {"url":"gs://hail-common/datasets/1/GERP_elements.GERP++.GRCh37.ht",
-     "version": null},
+     "version": "GRCh37"},
     {"url":"gs://hail-common/datasets/1/GERP_elements.GERP++.GRCh38.ht",
-     "version": null}]}
+     "version": "GRCh38"}]}
 }

--- a/hail/python/hail/experimental/annotation_db.json
+++ b/hail/python/hail/experimental/annotation_db.json
@@ -87,7 +87,7 @@
  "dbNSFP_variants":
  {"description": "dbNSFP: a database developed for functional prediction and annotation of all nsSNVs in the human genome.",
   "url": "https://sites.google.com/site/jpopgen/dbNSFP",
-  "key_properties": ["FIXME: unique?"],
+  "key_properties": [],
   "versions": [
     {"url":"gs://hail-common/datasets/1/dbnsfp4.0a.GRCh37.ht",
      "version": "4.0"},
@@ -103,7 +103,7 @@
  "gerp_scores":
  {"description": "GERP: identifies constrained elements in multiple alignments by quantifying substitution deficits.",
   "url": "http://mendel.stanford.edu/SidowLab/downloads/gerp/",
-  "key_properties": [],
+  "key_properties": ["unique"],
   "versions": [
     {"url": "gs://hail-common/datasets/1/GERP_scores.GERP++.GRCh37.ht",
      "version": null},
@@ -112,7 +112,7 @@
  "gerp_elements":
  {"description": "GERP: identifies constrained elements in multiple alignments by quantifying substitution deficits.",
   "url": "http://mendel.stanford.edu/SidowLab/downloads/gerp/",
-  "key_properties": ["FIXME: unique?"],
+  "key_properties": [],
   "versions": [
     {"url":"gs://hail-common/datasets/1/GERP_elements.GERP++.GRCh37.ht",
      "version": null},

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -147,7 +147,7 @@ class GroupedNoLens:
 
 
 class DB:
-    _valid_key_properties = {'gene', 'unique', 'FIXME: unique?'}
+    _valid_key_properties = {'gene', 'unique'}
 
     def __init__(self,
                  db_url='https://www.googleapis.com/storage/v1/b/hail-common/o/annotationdb%2f' +
@@ -185,7 +185,7 @@ class DB:
         return gene_field, rel.annotate(**{gene_field: gencode.gene_name})
 
     @typecheck_method(rel=oneof(table_type, matrix_table_type), names=str)
-    def annotate(self, rel, *names):
+    def annotate_rows_db(self, rel, *names):
         """Add annotations from datasets specified by name.
 
         List datasets with at :meth:`.available_databases`. An interactive query
@@ -196,12 +196,12 @@ class DB:
         Annotate a matrix table with the `gnomad_lof_metrics`:
 
         >>> db = hl.experimental.DB()
-        >>> mt = db.annotate(mt, 'gnomad_lof_metrics') # doctest: +SKIP
+        >>> mt = db.annotate_rows_db(mt, 'gnomad_lof_metrics') # doctest: +SKIP
 
         Annotate a table with `clinvar_gene_summary`, `CADD`, and `DANN`:
 
         >>> db = hl.experimental.DB()
-        >>> mt = db.annotate(mt, 'clinvar_gene_summary', 'CADD', 'DANN') # doctest: +SKIP
+        >>> mt = db.annotate_rows_db(mt, 'clinvar_gene_summary', 'CADD', 'DANN') # doctest: +SKIP
 
         Notes
         -----

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -118,9 +118,9 @@ class DB:
     @staticmethod
     def _row_lens(rel):
         if isinstance(rel, hl.MatrixTable):
-            return lens.MatrixRowTableLens(rel)
+            return lens.MatrixRows(rel)
         elif isinstance(rel, hl.Table):
-            return lens.NoLens(rel)
+            return lens.TableRows(rel)
         else:
             raise ValueError(
                 'annotation database can only annotate Hail MatrixTable or Table')

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -119,16 +119,19 @@ class NoLens:
         return NoLens(self.t.drop(*args, **kwargs))
 
     def select(self, *args, **kwargs):
-        return RowLens(self.t.select(*args, **kwargs))
+        return NoLens(self.t.select(*args, **kwargs))
 
     def explode(self, *args, **kwargs):
-        return RowLens(self.t.explode(*args, **kwargs))
+        return NoLens(self.t.explode(*args, **kwargs))
 
     def group_by(self, *args, **kwargs):
         return GroupedNoLens(self.t.group_by(*args, **kwargs))
 
     def __getitem__(self, *args, **kwargs):
         return self.t.__getitem__(*args, **kwargs)
+
+    def index(self, *args, **kwargs):
+        return self.t.index(*args, **kwargs)
 
     def unlens(self):
         return self.t
@@ -144,7 +147,7 @@ class GroupedNoLens:
 
 
 class DB:
-    _valid_key_properties = {'gene', 'unique'}
+    _valid_key_properties = {'gene', 'unique', 'FIXME: unique?'}
 
     def __init__(self, db_url='http://localhost:8000/annodb.json'):
         response = requests.get(db_url)
@@ -175,16 +178,15 @@ class DB:
 
     def _annotate_gene_name(self, rel):
         gene_field = Env.get_uid()
-        gencode = DB.__by_name['gencode'].index_compatible_version(rel.key)
+        gencode = self.__by_name['gencode'].index_compatible_version(rel.key)
         return gene_field, rel.annotate(**{gene_field: gencode.gene_name})
 
     @typecheck_method(rel=oneof(table_type, matrix_table_type), names=str)
     def annotate(self, rel, *names):
         """Add annotations from datasets specified by name.
 
-        The list of available datasets is at :meth:`.DB.available_databases`. An
-        interactive query builder is available in the Hail Annotation Database
-        documentation.
+        List datasets with at :meth:`.available_databases`. An interactive query
+        builder is available in the Hail Annotation Database documentation.
 
         Examples
         --------

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -1,64 +1,253 @@
 import requests
 import hail as hl
 
+from ..utils.java import Env
+from ..typecheck import typecheck_method, oneof
+from ..table import table_type
+from ..matrixtable import matrix_table_type
+
+
+class DatasetVersion:
+    @staticmethod
+    def from_json(doc):
+        assert 'url' in doc, doc
+        assert 'version' in doc, doc
+        return DatasetVersion(doc['url'],
+                              doc['version'])
+
+    def __init__(self, url, version):
+        self.url = url
+        self.version = version
+
+    def maybe_index(self, indexer_key_expr, all_matches):
+        return hl.read_table(self.url)._maybe_flexindex_table_by_expr(
+            indexer_key_expr, all_matches=all_matches)
+
+
+class Dataset:
+    @staticmethod
+    def from_name_and_json(name, doc):
+        assert 'description' in doc, doc
+        assert 'url' in doc, doc
+        assert 'key_properties' in doc, doc
+        assert 'versions' in doc, doc
+        versions = [DatasetVersion.from_json(x)
+                    for x in doc['versions']]
+        return Dataset(name,
+                       doc['description'],
+                       doc['url'],
+                       set(doc['key_properties']),
+                       versions)
+
+    def __init__(self, name, description, url, key_properties, versions):
+        assert set(key_properties).issubset(DB._valid_key_properties)
+        self.name = name
+        self.description = description
+        self.url = url
+        self.key_properties = key_properties
+        self.versions = versions
+
+    def is_gene_keyed(self):
+        return 'gene' in self.key_properties
+
+    def index_compatible_version(self, key_expr):
+        all_matches = 'unique' not in self.key_properties
+        compatible_indexed_values = [
+            index
+            for index in (version.maybe_index(key_expr, all_matches)
+                          for version in self.versions)
+            if index is not None]
+        if len(compatible_indexed_values) == 0:
+            raise ValueError(
+                f'Could not find compatible version of {self.name} for user '
+                f'dataset with key {key_expr.dtype}.')
+        assert len(compatible_indexed_values) == 1, \
+            f'{key_expr.dtype}, {self.name}, {compatible_indexed_values}'
+        return compatible_indexed_values[0]
+
+
+class RowLens:
+    def __init__(self, mt):
+        assert isinstance(mt, hl.MatrixTable)
+        self.mt = mt
+        self.key = mt.row_key
+
+    def annotate(self, *args, **kwargs):
+        return RowLens(self.mt.annotate_rows(*args, **kwargs))
+
+    def drop(self, *args, **kwargs):
+        return RowLens(self.mt.drop(*args, **kwargs))
+
+    def select(self, *args, **kwargs):
+        return RowLens(self.mt.select_rows(*args, **kwargs))
+
+    def explode(self, *args, **kwargs):
+        return RowLens(self.mt.explode_rows(*args, **kwargs))
+
+    def group_by(self, *args, **kwargs):
+        return GroupedRowLens(self.mt.group_rows_by(*args, **kwargs))
+
+    def __getitem__(self, *args, **kwargs):
+        return self.mt.__getitem__(*args, **kwargs)
+
+    def index(self, *args, **kwargs):
+        return self.mt.rows().index(*args, **kwargs)
+
+    def unlens(self):
+        return self.mt
+
+
+class GroupedRowLens:
+    def __init__(self, mt):
+        assert isinstance(mt, hl.GroupedMatrixTable)
+        self.mt = mt
+
+    def aggregate(self, *args, **kwargs):
+        return RowLens(self.mt.aggregate_rows(*args, **kwargs).result())
+
+
+class NoLens:
+    def __init__(self, t):
+        assert isinstance(t, hl.Table)
+        self.t = t
+        self.key = t.key
+
+    def annotate(self, *args, **kwargs):
+        return NoLens(self.t.annotate(*args, **kwargs))
+
+    def drop(self, *args, **kwargs):
+        return NoLens(self.t.drop(*args, **kwargs))
+
+    def select(self, *args, **kwargs):
+        return RowLens(self.t.select(*args, **kwargs))
+
+    def explode(self, *args, **kwargs):
+        return RowLens(self.t.explode(*args, **kwargs))
+
+    def group_by(self, *args, **kwargs):
+        return GroupedNoLens(self.t.group_by(*args, **kwargs))
+
+    def __getitem__(self, *args, **kwargs):
+        return self.t.__getitem__(*args, **kwargs)
+
+    def unlens(self):
+        return self.t
+
+
+class GroupedNoLens:
+    def __init__(self, t):
+        assert isinstance(t, hl.GroupedTable)
+        self.t = t
+
+    def aggregate(self, *args, **kwargs):
+        return NoLens(self.t.aggregate(*args, **kwargs))
+
 
 class DB:
-    _annotation_dataset_urls = None
-    _geneDict_dataset_urls = None
+    _valid_key_properties = {'gene', 'unique'}
+
+    def __init__(self, db_url='http://localhost:8000/annodb.json'):
+        response = requests.get(db_url)
+        doc = response.json()
+        assert isinstance(doc, dict)
+        self.__by_name = {k: Dataset.from_name_and_json(k, v)
+                          for k, v in doc.items()}
+
+    def available_databases(self):
+        return self._by_name().keys()
 
     @staticmethod
-    def annotation_dataset_urls():
-        if DB._annotation_dataset_urls is None:
-            assert DB._geneDict_dataset_urls is None
-            response = requests.get(
-                'https://www.googleapis.com/storage/v1/b/'
-                'hail-common/o/annotationdb%2f1%2fannotation_db.json?alt=media')
-            datasets = response.json()
+    def _row_lens(rel):
+        if isinstance(rel, hl.MatrixTable):
+            return RowLens(rel)
+        elif isinstance(rel, hl.Table):
+            return NoLens(rel)
+        else:
+            raise ValueError(
+                'annotation database can only annotate Hail MatrixTable or Table')
 
-            DB._annotation_dataset_urls = {
-                (dataset["name"], dataset.get("reference_genome")): dataset["path"]
-                for dataset in datasets}
-            DB._geneDict_dataset_urls = {
-                dataset["name"]: dataset["gene_key"]
-                for dataset in datasets}
+    def dataset_by_name(self, name):
+        if name not in self.__by_name:
+            raise ValueError(
+                f'{name} not found in annotation database, you may list all '
+                f'known dataset names with available_databases()')
+        return self.__by_name[name]
 
-        return DB._annotation_dataset_urls, DB._geneDict_dataset_urls
+    def _annotate_gene_name(self, rel):
+        gene_field = Env.get_uid()
+        gencode = DB.__by_name['gencode'].index_compatible_version(rel.key)
+        return gene_field, rel.annotate(**{gene_field: gencode.gene_name})
 
-    def annotate_rows_db(self, mt, *names):
-        """
+    @typecheck_method(rel=oneof(table_type, matrix_table_type), names=str)
+    def annotate(self, rel, *names):
+        """Add annotations from datasets specified by name.
+
+        The list of available datasets is at :meth:`.DB.available_databases`. An
+        interactive query builder is available in the Hail Annotation Database
+        documentation.
+
         Examples
         --------
-        Annotates rows based on keyword implementation of annotation name.
-        The user can type in multiple annotation names when attaching to their datasets.
+        Annotate a matrix table with the `gnomad_lof_metrics`:
+
         >>> db = hl.experimental.DB()
-        >>> mt = db.annotate_rows_db(mt, 'gnomad_lof_metrics')
+        >>> mt = db.annotate(mt, 'gnomad_lof_metrics') # doctest: +SKIP
+
+        Annotate a table with `clinvar_gene_summary`, `CADD`, and `DANN`:
+
+        >>> db = hl.experimental.DB()
+        >>> mt = db.annotate(mt, 'clinvar_gene_summary', 'CADD', 'DANN') # doctest: +SKIP
+
+        Notes
+        -----
+
+        If a dataset is gene-keyed, the annotation will be a dictionary mapping
+        from gene name to the annotation value. There will be one entry for each
+        gene overlapping the given locus.
+
+        If a dataset does not have unique rows for each key (consider the
+        `gencode` genes, which may overlap; and `clinvar_variant_summary`, which
+        contains many overlapping multiple nucleotide variants), then the result
+        will be an array of annotation values, one for each row.
 
         Parameters
         ----------
-        names: Keyword argument of the annotation.
-        Can include multiple annotations at one time.
+        rel : :class:`.MatrixTable` or :class:`.Table`
+            The relational object to which to add annotations.
+        names : varargs of :obj:`str`
+            The names of the datasets with which to annotate `rel`.
 
         Returns
         -------
-        :class:`.MatrixTable`
+        :class:`.MatrixTable` or :class:`.Table
+            The original dataset with new annotations added.
         """
-        d, geneDict = DB.annotation_dataset_urls()
-        reference_genome = mt.row_key.locus.dtype.reference_genome.name
-        for name in names:
-            gene_key = geneDict[(name)]
-            if gene_key is True:
-                gene_url = d[('gencode', reference_genome)]
-                t = hl.read_table(gene_url)
-                mt = mt.annotate_rows(gene_name=t[mt.locus].gene_name)
-                url = d[(name, None)]
-                t2 = hl.read_table(url)
-                mt = mt.annotate_rows(**{name: t2[mt.gene_name]})
-                mt = mt.drop('gene_name')
+        rel = self._row_lens(rel)
+        if len(set(names)) != len(names):
+            raise ValueError(
+                f'cannot annotate same dataset twice, please remove duplicates from: {names}')
+        datasets = [self.dataset_by_name(name) for name in names]
+        if any(dataset.is_gene_keyed() for dataset in datasets):
+            gene_field, rel = self._annotate_gene_name(rel)
+        else:
+            gene_field = None
+        for dataset in datasets:
+            if dataset.is_gene_keyed():
+                genes = rel.select(gene_field).explode(gene_field)
+                genes = genes.annotate(**{
+                    dataset.name: dataset.index_compatible_version(genes[gene_field])})
+                genes = genes.group_by(*genes.key)\
+                             .aggregate(**{
+                                 dataset.name: hl.dict(
+                                     hl.agg.filter(hl.is_defined(genes[dataset.name]),
+                                                   hl.agg.collect((genes[gene_field],
+                                                                   genes[dataset.name]))))})
+                rel = rel.annotate(**{dataset.name: genes.index(rel.key)[dataset.name]})
             else:
-                url = d[(name, reference_genome)]
-                t = hl.read_table(url)
-                if len(t.key) > 1:
-                    mt = mt.annotate_rows(**{name: t[mt.row_key]})
-                else:
-                    mt = mt.annotate_rows(**{name: t[mt.locus]})
-        return mt
+                indexed_value = dataset.index_compatible_version(rel.key)
+                if isinstance(indexed_value.dtype, hl.tstruct) and len(indexed_value.dtype) == 0:
+                    indexed_value = hl.is_defined(indexed_value)
+                rel = rel.annotate(**{dataset.name: indexed_value})
+        if gene_field:
+            rel = rel.drop(gene_field)
+        return rel.unlens()

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -215,7 +215,8 @@ class DB:
         """Add annotations from datasets specified by name.
 
         List datasets with at :meth:`.available_databases`. An interactive query
-        builder is available in the Hail Annotation Database documentation.
+        builder is available in the
+        `Hail Annotation Database documentation </docs/0.2/annotation_database_ui.html>`_.
 
         Examples
         --------

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -1,60 +1,64 @@
-from ..matrixtable import MatrixTable
 import requests
-import json
 import hail as hl
 
+
 class DB:
-    
     _annotation_dataset_urls = None
-    
+    _geneDict_dataset_urls = None
+
     @staticmethod
     def annotation_dataset_urls():
         if DB._annotation_dataset_urls is None:
-            r = requests.get("https://www.googleapis.com/storage/v1/b/hail-common/o/annotationdb%2f1%2fannotation_db.json?alt=media")
-            j = r.json()
-            
-            DB._annotation_dataset_urls = {(x["name"], x.get("reference_genome")): x["path"] for x in j}
-            DB._geneDict_dataset_urls = { x["name"]: (x["gene_key"]) for x in j}
-        
+            assert DB._geneDict_dataset_urls is None
+            response = requests.get(
+                'https://www.googleapis.com/storage/v1/b/'
+                'hail-common/o/annotationdb%2f1%2fannotation_db.json?alt=media')
+            datasets = response.json()
+
+            DB._annotation_dataset_urls = {
+                (dataset["name"], dataset.get("reference_genome")): dataset["path"]
+                for dataset in datasets}
+            DB._geneDict_dataset_urls = {
+                dataset["name"]: dataset["gene_key"]
+                for dataset in datasets}
+
         return DB._annotation_dataset_urls, DB._geneDict_dataset_urls
-    
-    def annotate_rows_db(self,mt,*names):
+
+    def annotate_rows_db(self, mt, *names):
         """
-            Examples
-            --------
-            Annotates rows based on keyword implementation of annotation name.
-            The user can type in multiple annotation names when attaching to their datasets.
-            
-            >>> db = hl.experimental.DB()
-            >>> mt = db.annotate_rows_db(mt, 'gnomad_lof_metrics')
-            ...
-            
-            Parameters
-            ----------
-            names: Keyword argument of the annotation.
-            Can include multiple annotations at one time.
-            
-            Returns
-            -------
-            :class:`.MatrixTable`
-            """
+        Examples
+        --------
+        Annotates rows based on keyword implementation of annotation name.
+        The user can type in multiple annotation names when attaching to their datasets.
+        >>> db = hl.experimental.DB()
+        >>> mt = db.annotate_rows_db(mt, 'gnomad_lof_metrics')
+
+        Parameters
+        ----------
+        names: Keyword argument of the annotation.
+        Can include multiple annotations at one time.
+
+        Returns
+        -------
+        :class:`.MatrixTable`
+        """
         d, geneDict = DB.annotation_dataset_urls()
         reference_genome = mt.row_key.locus.dtype.reference_genome.name
         for name in names:
             gene_key = geneDict[(name)]
             if gene_key is True:
                 gene_url = d[('gencode', reference_genome)]
-                t  = hl.read_table(gene_url)
+                t = hl.read_table(gene_url)
                 mt = mt.annotate_rows(gene_name=t[mt.locus].gene_name)
                 url = d[(name, None)]
                 t2 = hl.read_table(url)
-                mt = mt.annotate_rows(**{name:t2[mt.gene_name]})
+                mt = mt.annotate_rows(**{name: t2[mt.gene_name]})
                 mt = mt.drop('gene_name')
             else:
-                url = d[(name,reference_genome)]
+                url = d[(name, reference_genome)]
                 t = hl.read_table(url)
                 if len(t.key) > 1:
-                    mt = mt.annotate_rows(**{name:t[mt.row_key]})
+                    mt = mt.annotate_rows(**{name: t[mt.row_key]})
                 else:
-                    mt = mt.annotate_rows(**{name:t[mt.locus]})
+                    mt = mt.annotate_rows(**{name: t[mt.locus]})
         return mt

--- a/hail/python/hail/experimental/db.py
+++ b/hail/python/hail/experimental/db.py
@@ -149,7 +149,10 @@ class GroupedNoLens:
 class DB:
     _valid_key_properties = {'gene', 'unique', 'FIXME: unique?'}
 
-    def __init__(self, db_url='http://localhost:8000/annodb.json'):
+    def __init__(self,
+                 db_url='https://www.googleapis.com/storage/v1/b/hail-common/o/annotationdb%2f' +
+                 str(hl.__pip_version__) +
+                 '%2fannotation_db.json?alt=media'):
         response = requests.get(db_url)
         doc = response.json()
         assert isinstance(doc, dict)

--- a/hail/python/hail/experimental/lens.py
+++ b/hail/python/hail/experimental/lens.py
@@ -1,0 +1,122 @@
+import abc
+import hail as hl
+
+
+class TableLike(abc.ABC):
+    @abc.abstractmethod
+    def annotate(self, *args, **kwargs):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def drop(self, *args, **kwargs):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def select(self, *args, **kwargs):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def explode(self, *args, **kwargs):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def group_by(self, *args, **kwargs):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def __getitem__(self, *args, **kwargs):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def index(self, *args, **kwargs):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def unlens(self):
+        raise NotImplementedError
+
+
+class GroupedTableLike(abc.ABC):
+    @abc.abstractmethod
+    def aggregate(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class MatrixRows(TableLike):
+    def __init__(self, mt):
+        assert isinstance(mt, hl.MatrixTable)
+        self.mt = mt
+        self.key = mt.row_key
+
+    def annotate(self, *args, **kwargs):
+        return MatrixRows(self.mt.annotate_rows(*args, **kwargs))
+
+    def drop(self, *args, **kwargs):
+        return MatrixRows(self.mt.drop(*args, **kwargs))
+
+    def select(self, *args, **kwargs):
+        return MatrixRows(self.mt.select_rows(*args, **kwargs))
+
+    def explode(self, *args, **kwargs):
+        return MatrixRows(self.mt.explode_rows(*args, **kwargs))
+
+    def group_by(self, *args, **kwargs):
+        return GroupedMatrixRows(self.mt.group_rows_by(*args, **kwargs))
+
+    def __getitem__(self, *args, **kwargs):
+        return self.mt.__getitem__(*args, **kwargs)
+
+    def index(self, *args, **kwargs):
+        return self.mt.rows().index(*args, **kwargs)
+
+    def unlens(self):
+        return self.mt
+
+
+class GroupedMatrixRows(GroupedTableLike):
+    def __init__(self, mt):
+        assert isinstance(mt, hl.GroupedMatrixTable)
+        self.mt = mt
+
+    def aggregate(self, *args, **kwargs):
+        return MatrixRows(self.mt.aggregate_rows(*args, **kwargs).result())
+
+
+class TableRows(TableLike):
+    def __init__(self, t):
+        assert isinstance(t, hl.Table)
+        self.t = t
+        self.key = t.key
+
+    def annotate(self, *args, **kwargs):
+        return TableRows(self.t.annotate(*args, **kwargs))
+
+    def drop(self, *args, **kwargs):
+        return TableRows(self.t.drop(*args, **kwargs))
+
+    def select(self, *args, **kwargs):
+        return TableRows(self.t.select(*args, **kwargs))
+
+    def explode(self, *args, **kwargs):
+        return TableRows(self.t.explode(*args, **kwargs))
+
+    def group_by(self, *args, **kwargs):
+        return GroupedTableRows(self.t.group_by(*args, **kwargs))
+
+    def __getitem__(self, *args, **kwargs):
+        return self.t.__getitem__(*args, **kwargs)
+
+    def index(self, *args, **kwargs):
+        return self.t.index(*args, **kwargs)
+
+    def unlens(self):
+        return self.t
+
+
+class GroupedTableRows(GroupedTableLike):
+    def __init__(self, t):
+        assert isinstance(t, hl.GroupedTable)
+        self.t = t
+
+    def aggregate(self, *args, **kwargs):
+        return TableRows(self.t.aggregate(*args, **kwargs))

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -1478,9 +1478,8 @@ class StructExpression(Mapping[str, Expression], Expression):
             assert item.start is None or isinstance(item.start, int)
             assert item.stop is None or isinstance(item.stop, int)
             assert item.step is None or isinstance(item.step, int)
-            return hl.struct(**{
-                f: self[f]
-                for f in self.dtype.fields[item.start:item.stop:item.step]})
+            return hl.select(
+                *self.dtype.fields[item.start:item.stop:item.step])
 
     def __iter__(self):
         return iter(self._fields)
@@ -1671,9 +1670,10 @@ class TupleExpression(Expression, Sequence):
             assert item.start is None or isinstance(item.start, int)
             assert item.stop is None or isinstance(item.stop, int)
             assert item.step is None or isinstance(item.step, int)
-            return hl.tuple([
-                self[i]
-                for i in range(len(self))[item.start:item.stop:item.step]])
+            return hl.or_missing(hl.is_defined(self),
+                                 hl.tuple([
+                                     self[i]
+                                     for i in range(len(self))[item.start:item.stop:item.step]]))
         if not 0 <= item < len(self):
             raise IndexError("Out of bounds index. Tuple length is {}.".format(len(self)))
         return construct_expr(ir.GetTupleElement(self._ir, item), self.dtype.types[item], self._indices)

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -1478,7 +1478,7 @@ class StructExpression(Mapping[str, Expression], Expression):
             assert item.start is None or isinstance(item.start, int)
             assert item.stop is None or isinstance(item.stop, int)
             assert item.step is None or isinstance(item.step, int)
-            return hl.select(
+            return self.select(
                 *self.dtype.fields[item.start:item.stop:item.step])
 
     def __iter__(self):

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -951,6 +951,16 @@ class tstruct(HailType, Mapping):
         super(tstruct, self).__init__()
 
     @property
+    def types(self):
+        """Struct field types.
+
+        Returns
+        -------
+        :obj:`tuple` of :class:`.HailType`
+        """
+        return tuple(self._field_types.values())
+
+    @property
     def fields(self):
         """Struct field names.
 

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -1198,7 +1198,7 @@ class tunion(HailType, Mapping):
         return HailTypeContext.union(*self.values())
 
 
-class ttuple(HailType):
+class ttuple(HailType, Mapping):
     """Hail type for tuples.
 
     In Python, these are represented as :obj:`tuple`.
@@ -1241,6 +1241,13 @@ class ttuple(HailType):
             if len(annotation) != len(self.types):
                 raise TypeError("%s expected tuple of size '%i', but found '%s'" %
                                 (self, len(self.types), annotation))
+
+    @typecheck_method(item=int)
+    def __getitem__(self, item):
+        return self._types[item]
+
+    def __iter__(self):
+        return iter(range(len(self._types)))
 
     def __len__(self):
         return len(self._types)

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -1198,7 +1198,7 @@ class tunion(HailType, Mapping):
         return HailTypeContext.union(*self.values())
 
 
-class ttuple(HailType, Mapping):
+class ttuple(HailType, Sequence):
     """Hail type for tuples.
 
     In Python, these are represented as :obj:`tuple`.
@@ -1247,7 +1247,8 @@ class ttuple(HailType, Mapping):
         return self._types[item]
 
     def __iter__(self):
-        return iter(range(len(self._types)))
+        for i in range(len(self)):
+            yield self[i]
 
     def __len__(self):
         return len(self._types)

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1568,7 +1568,7 @@ class Table(ExprContainer):
 
 
     @typecheck_method(indexer=expr_any, all_matches=bool)
-    def _maybe_flexindex_table_by_expr(self, indexer, all_matches):
+    def _maybe_flexindex_table_by_expr(self, indexer, all_matches=False):
         truncated_indexer = Table._maybe_truncate_for_flexindex(
             indexer, self.key.dtype)
         if truncated_indexer is not None:

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1546,7 +1546,7 @@ class Table(ExprContainer):
             indexer = hl.tuple([indexer])
 
         matching_prefix = 0
-        for x, y in zip(indexer.dtype.values(), indexee_dtype.values()):
+        for x, y in zip(indexer.dtype.types(), indexee_dtype.types()):
             if x != y:
                 break
             matching_prefix += 1

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1546,7 +1546,7 @@ class Table(ExprContainer):
             indexer = hl.tuple([indexer])
 
         matching_prefix = 0
-        for x, y in zip(indexer.dtype.types(), indexee_dtype.types()):
+        for x, y in zip(indexer.dtype.types, indexee_dtype.types):
             if x != y:
                 break
             matching_prefix += 1

--- a/hail/python/setup.py
+++ b/hail/python/setup.py
@@ -27,7 +27,10 @@ setup(
         'hail': 'hail',
         'hailtop': 'hailtop'},
     package_data={
-        'hail': ['hail-all-spark.jar', 'hail_pip_version', 'hail_version'],
+        'hail': ['hail-all-spark.jar',
+                 'hail_pip_version',
+                 'hail_version',
+                 'experimental/annotation_db.json'],
         'hailtop.hailctl': ['hail_version', 'deploy.yaml']},
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/hail/python/test/hail/experimental/test_annotation_db.py
+++ b/hail/python/test/hail/experimental/test_annotation_db.py
@@ -34,7 +34,7 @@ class AnnotationDBTests(unittest.TestCase):
     tearDownClass = tearDownAnnotationDBTests
 
     def test_uniqueness(self):
-        db = hl.experimental.DB(json=AnnotationDBTests.db_json)
+        db = hl.experimental.DB(config=AnnotationDBTests.db_json)
         t = hl.utils.range_table(10)
         t = t.annotate(locus=hl.locus('1', t.idx + 1))
         t = db.annotate_rows_db(t, 'unique_dataset', 'nonunique_dataset')

--- a/hail/python/test/hail/experimental/test_annotation_db.py
+++ b/hail/python/test/hail/experimental/test_annotation_db.py
@@ -1,0 +1,42 @@
+import unittest
+import tempfile
+
+import hail as hl
+from ..helpers import startTestHailContext, stopTestHailContext
+
+
+class AnnotationDBTests(unittest.TestCase):
+    @classmethod
+    def setupAnnotationDBTests(cls):
+        startTestHailContext()
+        t = hl.utils.range_table(10)
+        t = t.annotate(locus=hl.locus('1', t.idx + 1))
+        t = t.annotate(annotation=hl.str(t.idx))
+        d = tempfile.TemporaryDirectory()
+        fname = d.name + '/f.mt'
+        t.write(fname)
+        cls.temp_dir = d
+        cls.db_json = {
+            'unique_dataset': {'description': 'now with unique rows!',
+                               'url': 'http://example.com',
+                               'key_properties': ['unique'],
+                               'versions': [{'url': fname, 'version': 'v1-GRCh37'}]},
+            'nonunique_dataset': {'description': 'non-unique rows :(',
+                                  'url': 'http://example.net',
+                                  'key_properties': [],
+                                  'versions': [{'url': fname, 'version': 'v1-GRCh37'}]}}
+
+    def tearDownAnnotationDBTests():
+        stopTestHailContext()
+        AnnotationDBTests.temp_dir.cleanup()
+
+    setUpClass = setupAnnotationDBTests
+    tearDownClass = tearDownAnnotationDBTests
+
+    def test_uniqueness(self):
+        db = hl.experimental.DB(json=AnnotationDBTests.db_json)
+        t = hl.utils.range_table(10)
+        t = t.annotate(locus=hl.locus('1', t.idx + 1))
+        t = db.annotate_rows_db(t, 'unique_dataset', 'nonunique_dataset')
+        t.unique_dataset.dtype == hl.tstruct(annotation=hl.tstr)
+        t.nonunique_dataset.dtype == hl.tstruct(annotation=hl.tarray(hl.tstr))

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -3543,3 +3543,13 @@ class Tests(unittest.TestCase):
         t = hl.utils.range_table(3)
         t = t.key_by(-t.idx)
         assert t.idx.collect() == [2, 1, 0]
+
+    def test_struct_slice(self):
+        assert hl.eval(hl.struct(x=3, y=4, z=5, a=10)[1:]) == hl.Struct(y=4, z=5, a=10)
+        assert hl.eval(hl.struct(x=3, y=4, z=5, a=10)[0:4:2]) == hl.Struct(x=3, z=5)
+        assert hl.eval(hl.struct(x=3, y=4, z=5, a=10)[-2:]) == hl.Struct(z=5, a=10)
+
+    def test_tuple_slice(self):
+        assert hl.eval(hl.tuple((3, 4, 5, 10))[1:]) == (4, 5, 10)
+        assert hl.eval(hl.tuple((3, 4, 5, 10))[0:4:2]) == (3, 5)
+        assert hl.eval(hl.tuple((3, 4, 5, 10))[-2:]) == (5, 10)

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -1186,3 +1186,81 @@ def test_segfault():
     joined = t.key_by('foo').join(t2.key_by('foo'))
     joined = joined.filter(hl.is_missing(joined.idx))
     assert joined.collect() == []
+
+
+def test_maybe_flexindex_table_by_expr_direct_match():
+    t1 = hl.utils.range_table(1)
+    t2 = hl.utils.range_table(1)
+    match_key = t1._maybe_flexindex_table_by_expr(t2.key)
+    t2.annotate(foo=match_key)._force_count()
+    match_idx = t1._maybe_flexindex_table_by_expr(t2.idx)
+    t2.annotate(foo=match_idx)._force_count()
+
+    mt1 = hl.utils.range_matrix_table(1, 1)
+    match_row_key = t1._maybe_flexindex_table_by_expr(mt1.row_key)
+    mt1.annotate_rows(match=match_row_key)._force_count_rows()
+    match_row_idx = t1._maybe_flexindex_table_by_expr(mt1.row_idx)
+    mt1.annotate_rows(match=match_row_idx)._force_count_rows()
+
+    assert t1._maybe_flexindex_table_by_expr(t2.idx * 3.0) is None
+    assert t1._maybe_flexindex_table_by_expr(hl.str(t2.key)) is None
+    assert t1._maybe_flexindex_table_by_expr(hl.str(mt1.row_key)) is None
+
+
+def test_maybe_flexindex_table_by_expr_prefix_match():
+    t1 = hl.utils.range_table(1)
+    t2 = hl.utils.range_table(1)
+    t2 = t2.key_by(idx=t2.idx, idx2=t2.idx)
+    match_key = t1._maybe_flexindex_table_by_expr(t2.key)
+    t2.annotate(foo=match_key)._force_count()
+    match_expr = t1._maybe_flexindex_table_by_expr((t2.idx, t2.idx2))
+    t2.annotate(foo=match_expr)._force_count()
+
+    mt1 = hl.utils.range_matrix_table(1, 1)
+    mt1 = mt1.key_rows_by(row_idx=mt1.row_idx, str_row_idx=hl.str(mt1.row_idx))
+    match_row_key = t1._maybe_flexindex_table_by_expr(mt1.row_key)
+    mt1.annotate_rows(match=match_row_key)._force_count_rows()
+    match_row_expr = t1._maybe_flexindex_table_by_expr((mt1.row_idx, hl.str(mt1.row_idx)))
+    mt1.annotate_rows(match=match_row_expr)._force_count_rows()
+
+    assert t1._maybe_flexindex_table_by_expr((hl.str(mt1.row_idx), mt1.row_idx)) is None
+
+
+def test_maybe_flexindex_table_by_expr_direct_interval_match():
+    t1 = hl.utils.range_table(1)
+    t1 = t1.key_by(interval=hl.interval(t1.idx, t1.idx+1))
+    t2 = hl.utils.range_table(1)
+    match_key = t1._maybe_flexindex_table_by_expr(t2.key)
+    t2.annotate(foo=match_key)._force_count()
+    match_expr = t1._maybe_flexindex_table_by_expr(t2.idx)
+    t2.annotate(foo=match_expr)._force_count()
+
+    mt1 = hl.utils.range_matrix_table(1, 1)
+    match_row_key = t1._maybe_flexindex_table_by_expr(mt1.row_key)
+    mt1.annotate_rows(match=match_row_key)._force_count_rows()
+    match_row_idx = t1._maybe_flexindex_table_by_expr(mt1.row_idx)
+    mt1.annotate_rows(match=match_row_idx)._force_count_rows()
+
+    assert t1._maybe_flexindex_table_by_expr(t2.idx * 3.0) is None
+    assert t1._maybe_flexindex_table_by_expr(hl.str(t2.key)) is None
+    assert t1._maybe_flexindex_table_by_expr(hl.str(mt1.row_key)) is None
+
+
+def test_maybe_flexindex_table_by_expr_prefix_interval_match():
+    t1 = hl.utils.range_table(1)
+    t1 = t1.key_by(interval=hl.interval(t1.idx, t1.idx+1))
+    t2 = hl.utils.range_table(1)
+    t2 = t2.key_by(idx=t2.idx, idx2=t2.idx)
+    match_key = t1._maybe_flexindex_table_by_expr(t2.key)
+    t2.annotate(foo=match_key)._force_count()
+    match_expr = t1._maybe_flexindex_table_by_expr((t2.idx, t2.idx2))
+    t2.annotate(foo=match_expr)._force_count()
+
+    mt1 = hl.utils.range_matrix_table(1, 1)
+    mt1 = mt1.key_rows_by(row_idx=mt1.row_idx, str_row_idx=hl.str(mt1.row_idx))
+    match_row_key = t1._maybe_flexindex_table_by_expr(mt1.row_key)
+    mt1.annotate_rows(match=match_row_key)._force_count_rows()
+    match_row_expr = t1._maybe_flexindex_table_by_expr((mt1.row_idx, hl.str(mt1.row_idx)))
+    mt1.annotate_rows(match=match_row_expr)._force_count_rows()
+
+    assert t1._maybe_flexindex_table_by_expr((hl.str(mt1.row_idx), mt1.row_idx)) is None


### PR DESCRIPTION
This change simplifies aspects of the annotation db's implementation as well as adding new features such as annotating a Table or using a custom JSON configuration file.

The Annotation DB will remain experimental until we iron out the JSON configuration file's structure and we're confident in the deploy process.


- Allow custom URL or JSON for configuration (enabling testing and local development).
- Support Tables.
- Restructure the annotation db JSON to reduce duplication. It now maps from dataset name to dataset metadata and dataset versions.
- Simplify JS logic based on new JSON structure.
- Check-in and implement versioned deployment of the annotation db configuration JSON.
- Add a JS file to the website that defines `hail_version` and `hail_pip_version`.
- Add `key_properties` which currently supports two properties `gene` and `unique`. Gene keyed datasets require using the `gencode` dataset to crosswalk from locus to gene before joining.
- Rudimentary test of key properties functionality.

Foundational Changes Outside Annotation DB:
- Define `__pip_version__` in `hail`.
- Teach `StructExpression` and `TupleExpression` how to slice by integers, facilitating the construction of structs of a prefix of fields.
- Make `ttuple` a mapping from integers to the tuple elements.
- Implement `Table._maybe_flexindex_table_by_expr` which, given a indexer expression, finds a prefix of the expression that can index the indexee, if such an expression exists.

Unrelated changes:
- Clarify Makefile error echos with `ERROR:`


---

## flexindex

The primary use case for this is a dataset which is `locus, allele` keyed and needs to index into a `locus` keyed or `interval<locus>` keyed dataset. Hail's normal join logic will return a key mismatch error:

```python
import hail as hl
t = hl.utils.range_table(10)
t2 = t.key_by(x=t.idx, y=t.idx)
t.index(t2.key)
```
```
Traceback (most recent call last):
  File "<ipython-input-6-3ddc90774dfe>", line 1, in <module>
    t.index(t2.key)
  File "/usr/local/lib/python3.7/site-packages/hail/table.py", line 1536, in index
    raise ExpressionException(f"Key type mismatch: cannot index table with given expressions:\n"
ExpressionException: Key type mismatch: cannot index table with given expressions:
  Table key:         int32
  Index Expressions: int32, int32
```

This new, private, method facilitates the annotation db which users expect to automatically find a compatible prefix of the key to use as an indexer.

---

Dice came up @chrisvittal, but I'm curious to hear @tpoterba 's feedback as well.
