### PR TITLE
[hail] new aggregator path for TableKeyByAndAggregate

### DIFF
--- a/benchmark/python/benchmark_hail/run/table_benchmarks.py
+++ b/benchmark/python/benchmark_hail/run/table_benchmarks.py
@@ -333,3 +333,9 @@ def join_p100_p10():
 def group_by_collect_per_row():
     ht = hl.read_matrix_table(resource('gnomad_dp_simulation.mt')).localize_entries('e', 'c')
     ht.group_by(*ht.key).aggregate(value=hl.agg.collect(ht.row_value))._force_count()
+    
+
+@benchmark
+def group_by_take_rekey():
+    ht = hl.read_matrix_table(resource('gnomad_dp_simulation.mt')).localize_entries('e', 'c')
+    ht.group_by(k=hl.int(ht.row_idx / 50)).aggregate(value=hl.agg.take(ht.row_value, 1))._force_count()

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1508,7 +1508,6 @@ case class TableKeyByAndAggregate(
           val f = makeSeq(i, partRegion)
           (rv: RegionValue, rvAggs: Array[RegionValueAggregator]) => {
             f(rv.region, rvAggs, globals, false, rv.offset, false)
-            rvAggs
           }
         }
         new BufferedAggregatorIterator[RegionValue, Array[RegionValueAggregator], Array[RegionValueAggregator], Row](

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -6,7 +6,7 @@ import is.hail.HailContext
 import is.hail.annotations._
 import is.hail.annotations.aggregators.RegionValueAggregator
 import is.hail.expr.types._
-import is.hail.expr.types.physical.{PArray, PBaseStruct, PInt32, PStruct, PType}
+import is.hail.expr.types.physical._
 import is.hail.expr.types.virtual._
 import is.hail.expr.JSONAnnotationImpex
 import is.hail.expr.ir
@@ -23,7 +23,7 @@ import is.hail.io._
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.storage.StorageLevel
 import org.json4s.{CustomSerializer, Formats, JObject, ShortTypeHints}
-import org.json4s.JsonAST.{JArray, JField, JInt, JNothing, JNull, JString}
+import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods
 
@@ -1336,6 +1336,123 @@ case class TableKeyByAndAggregate(
   protected[ir] override def execute(ctx: ExecuteContext): TableValue = {
     val prev = child.execute(ctx)
 
+    val localKeyType = keyType
+    val (localKeyPType: PStruct, makeKeyF) = ir.Compile[Long, Long, Long](
+      "row", prev.rvd.rowPType,
+      "global", prev.globals.t,
+      newKey
+    )
+
+    val globalsBc = prev.globals.broadcast
+    val localBufferSize = bufferSize
+
+    if (HailContext.getFlag("newaggs") != null) {
+      try {
+        val spec = BufferSpec.defaultUncompressed
+        val res = genUID()
+        val extracted = agg.Extract(expr, res)
+
+        val (_, makeInit) = ir.CompileWithAggregators2[Long, Unit](
+          extracted.aggs,
+          "global", prev.globals.t,
+          extracted.init)
+
+        val (_, makeSeq) = ir.CompileWithAggregators2[Long, Long, Unit](
+          extracted.aggs,
+          "global", prev.globals.t,
+          "row", prev.rvd.rowPType,
+          extracted.seqPerElt)
+
+        val (rTyp: PStruct, makeAnnotate) = ir.CompileWithAggregators2[Long, Long](
+          extracted.aggs,
+          "global", prev.globals.t,
+          Let(res, extracted.results, extracted.postAggIR))
+        assert(rTyp.virtualType == typ.valueType, s"$rTyp, ${ typ.valueType }")
+
+        val serialize = extracted.serialize(spec)
+        val deserialize = extracted.deserialize(spec)
+        val combOp = extracted.combOpF(spec)
+
+        val initF = makeInit(0, ctx.r)
+        val globalsOffset = prev.globals.value.offset
+        val initAggs = Region.scoped { aggRegion =>
+          initF.newAggState(aggRegion)
+          initF(ctx.r, globalsOffset, false)
+          serialize(aggRegion, initF.getAggOffset())
+        }
+
+        val newRowType = localKeyPType ++ rTyp
+
+        val localBufferSize = bufferSize
+        val rdd = prev.rvd
+          .boundary
+          .mapPartitionsWithIndex { (i, ctx, it) =>
+            val partRegion = ctx.freshRegion
+            val aggRegion = ctx.freshRegion
+            val globals = globalsBc.value.readRegionValue(partRegion)
+            val makeKey = {
+              val f = makeKeyF(i, partRegion)
+              rv: RegionValue => {
+                val keyOff = f(rv.region, rv.offset, false, globals, false)
+                SafeRow.read(localKeyPType, rv.region, keyOff).asInstanceOf[Row]
+              }
+            }
+
+            val seqOp = {
+              val f = makeSeq(i, partRegion)
+              (rv: RegionValue, aggOff: Long) => {
+                f.setAggState(aggRegion, aggOff)
+                f(rv.region, globals, false, rv.offset, false)
+                f.getAggOffset()
+              }
+            }
+            new BufferedAggregatorIterator[RegionValue, Long, Array[Byte], Row](
+              it,
+              () => deserialize(aggRegion, initAggs),
+              makeKey,
+              seqOp,
+              serialize(aggRegion, _),
+              localBufferSize)
+          }.aggregateByKey(initAggs, nPartitions.getOrElse(prev.rvd.getNumPartitions))(combOp, combOp)
+
+        val crdd = ContextRDD.weaken(rdd).cmapPartitionsWithIndex(
+          { (i, ctx, it) =>
+            val region = ctx.region
+
+            val rvb = new RegionValueBuilder()
+            val partRegion = ctx.freshRegion
+            val globals = globalsBc.value.readRegionValue(partRegion)
+            val annotate = makeAnnotate(i, partRegion)
+
+            val rv = RegionValue(region)
+            it.map { case (key, aggs) =>
+              rvb.set(region)
+              rvb.start(newRowType)
+              rvb.startStruct()
+              var i = 0
+              while (i < localKeyType.size) {
+                rvb.addAnnotation(localKeyType.types(i), key.get(i))
+                i += 1
+              }
+
+              val aggOff = deserialize(rv.region, aggs)
+              annotate.setAggState(rv.region, aggOff)
+              rvb.addAllFields(rTyp, region, annotate(region, globals, false))
+              rvb.endStruct()
+              rv.setOffset(rvb.end())
+              rv
+            }
+          })
+
+        return prev.copy(
+          typ = typ,
+          rvd = RVD.coerce(RVDType(newRowType, keyType.fieldNames), crdd))
+      } catch {
+        case e: agg.UnsupportedExtraction =>
+          log.info(s"couldn't lower TableAggregate: $e")
+      }
+    }
+
     val (rvAggs, makeInit, makeSeq, aggResultType, postAggIR) = ir.CompileWithAggregators[Long, Long, Long](
       "global", prev.globals.t,
       "global", prev.globals.t,
@@ -1348,27 +1465,14 @@ case class TableKeyByAndAggregate(
       "AGGR", aggResultType,
       "global", prev.globals.t,
       postAggIR)
+    assert(rTyp.virtualType == typ.valueType, s"$rTyp, ${ typ.valueType }")
 
     val init = makeInit(0, ctx.r)
     val globalsOffset = prev.globals.value.offset
     init(ctx.r, rvAggs, globalsOffset, false)
 
     val nAggs = rvAggs.length
-
-    assert(rTyp.virtualType == typ.valueType, s"$rTyp, ${ typ.valueType }")
-
-    val globalsType = prev.typ.globalType
-    val globalsBc = prev.globals.broadcast
-
-    val localKeyType = keyType
-    val (localKeyPType: PStruct, makeKeyF) = ir.Compile[Long, Long, Long](
-      "row", prev.rvd.rowPType,
-      "global", prev.globals.t,
-      newKey
-    )
     val newRowType = localKeyPType ++ rTyp
-
-    val localBufferSize = bufferSize
     val combOp = { (aggs1: Array[RegionValueAggregator], aggs2: Array[RegionValueAggregator]) =>
       var i = 0
       while (i < aggs2.length) {
@@ -1395,13 +1499,15 @@ case class TableKeyByAndAggregate(
           val f = makeSeq(i, partRegion)
           (rv: RegionValue, rvAggs: Array[RegionValueAggregator]) => {
             f(rv.region, rvAggs, globals, false, rv.offset, false)
+            rvAggs
           }
         }
-        new BufferedAggregatorIterator[RegionValue, Array[RegionValueAggregator], Row](
+        new BufferedAggregatorIterator[RegionValue, Array[RegionValueAggregator], Array[RegionValueAggregator], Row](
           it,
           () => rvAggs.map(_.copy()),
           makeKey,
           sequence,
+          aggs => aggs,
           localBufferSize)
       }.aggregateByKey(rvAggs, nPartitions.getOrElse(prev.rvd.getNumPartitions))(combOp, combOp)
 

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1458,7 +1458,7 @@ case class TableKeyByAndAggregate(
           rvd = RVD.coerce(RVDType(newRowType, keyType.fieldNames), crdd))
       } catch {
         case e: agg.UnsupportedExtraction =>
-          log.info(s"couldn't lower TableAggregate: $e")
+          log.info(s"couldn't lower TableKeyByAndAggregate: $e")
       }
     }
 

--- a/hail/src/test/scala/is/hail/utils/BufferedAggregatorIteratorSuite.scala
+++ b/hail/src/test/scala/is/hail/utils/BufferedAggregatorIteratorSuite.scala
@@ -28,11 +28,12 @@ class BufferedAggregatorIteratorSuite extends TestNGSuite {
     ) { case (arr, bufferSize) =>
       val simple = arr.groupBy(_._1).map { case (k, a) => k -> a.map(_._2.toLong).sum }
       val buffAgg = {
-        new BufferedAggregatorIterator[(Int, Int), SumAgg, Int](
+        new BufferedAggregatorIterator[(Int, Int), SumAgg, SumAgg, Int](
           arr.iterator,
           () => new SumAgg(),
           { case (k, v) => k },
           { case (t, agg) => agg.add(t._2) },
+          a => a,
           bufferSize)
           .toArray
           .groupBy(_._1)


### PR DESCRIPTION
This pretty closely mimics the existing execution pattern.

I made a change to allow BufferedArrayIterator to store its internal buffer values in non-serializable form---I wanted to store the intermediate aggregator states as region values for as long as possible, and only serialize them when we have to return something for the iterator we're passing to Spark's aggregateByKey function.

I'm also allocating one aggRegion per key---that way, when we send an aggregator state into the Spark aggregation, we can clean up the region that we were using for aggregation. I'm managing this region manually, though--not sure how else to do it.