### PR TITLE
[notebook] restyle dropdowns

### DIFF
--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -146,19 +146,19 @@ a {
        15px - 20px / 2 = 5px
        plus 2px to make triangle slightly smaller */
     top: 7px;
-    /* left: (header-dropdown-item width) / 2 */
+    /* left: (header-dropdown-item width) / 2 + padding - width / 2 */
     background-color: white;
     border: 1px solid black;
 }
 
 .notebook-caret:after {
-    /* measured */
-    left: 37px;
+    /* 74 (measured) / 2 + 9 - 20 / 2 = 38px */
+    left: 36px;
 }
 
 .monitoring-caret:after {
-    /* measured */
-    left: 41px;
+    /* 82 (measured) / 2 + 9 - 20 / 2 = 42px */
+    left: 40px;
 }
 
 .header-dropdown-menu {

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -125,6 +125,7 @@ a {
 
 .header-dropdown-menu-caret {
     position: absolute;
+    /* big enough to contain ::after */
     width: 100px;
     /* Chrome doesn't seem to handle exact overlap.  Depending on the zoom
        level, there is a thin border or overhang artifacts.  The extra
@@ -145,11 +146,19 @@ a {
        15px - 20px / 2 = 5px
        plus 2px to make triangle slightly smaller */
     top: 7px;
-    /* (header-dropdown-link text width) / 2 + (header-dropdown-link padding)
-       35px = ~52px / 2 + 9px */
-    left: 35px;
+    /* left: (header-dropdown-item width) / 2 */
     background-color: white;
     border: 1px solid black;
+}
+
+.notebook-caret:after {
+    /* measured */
+    left: 37px;
+}
+
+.monitoring-caret:after {
+    /* measured */
+    left: 41px;
 }
 
 .header-dropdown-menu {

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -120,7 +120,9 @@ a {
 .header-dropdown-menu-caret {
     position: absolute;
     width: 100px;
-    height: 15px;
+    /* Extra 0.1 is needed to fully cover the border.  Don't know why it
+       is needed. */
+    height: 15.1px;
     overflow: hidden;
     top: -15px;
 }
@@ -147,6 +149,8 @@ a {
     border-radius: 3px;
     background-color: white;
     border: 1px solid black;
+    /* 12px: height of triangle + 5px spacing */
+    transform: translate(0px, 12px);
 }
 
 .header-dropdown-menu-link {

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -103,9 +103,11 @@ a {
 }
 
 .header-dropdown-menu-caret {
+    position: absolute;
     width: 100px;
     height: 15px;
     overflow: hidden;
+    top: -15px;
 }
 
 .header-dropdown-menu-caret:after {
@@ -115,7 +117,7 @@ a {
     height: 20px;
     background: #999;
     transform: rotate(45deg);
-    top: -10px;
+    top: 5px;
     left: 25px;
     background-color: white;
     border: 1px solid black;
@@ -124,9 +126,6 @@ a {
 .header-dropdown-menu {
     position: absolute;
     display: none;
-}
-
-.header-dropdown-menu-items {
     border-radius: 3px;
     background-color: white;
     border: 1px solid black;

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -120,8 +120,10 @@ a {
 .header-dropdown-menu-caret {
     position: absolute;
     width: 100px;
-    /* Extra 0.1 is needed to fully cover the border.  Don't know why it
-       is needed. */
+    /* Chrome doesn't seem to handle exact overlap.  Depending on the zoom
+       level, there is a thin border or overhang artifacts.  The extra
+       0.1 appears to fully covers the border.  Firefox looks correct
+       at 15px and this creates a slight overhang at high zoom.  */
     height: 15.1px;
     overflow: hidden;
     top: -15px;
@@ -152,7 +154,7 @@ a {
     border: 1px solid black;
     /* height of triangle + 5px spacing
        12px = 7px + 5px */
-    transform: translate(0px, 12px);
+    top-margin: 12px;
 }
 
 .header-dropdown-menu-link {

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -91,6 +91,21 @@ a {
     padding: 15px 15px;
 }
 
+.header-dropdown-item-margin {
+    margin: 6px;
+}
+
+.header-dropdown-link {
+    padding: 9px 9px;
+    color: $black;
+    white-space: nowrap;
+    &:active,
+    &:hover {
+        text-decoration: none;
+        color: $devil-gray;
+    }
+}
+
 .header-dropdown {
     display: block;
 
@@ -115,10 +130,13 @@ a {
     position: absolute;
     width: 20px;
     height: 20px;
-    background: #999;
     transform: rotate(45deg);
-    top: 5px;
-    left: 25px;
+    /* width / 2 - (header-dropdown top) 
+       plus 2px to make triangle slightly smaller */
+    top: 7px;
+    /* (header-dropdown-link text width) / 2 + (header-dropdown-link padding)
+       ~52px / 2 + 9px = 35px */
+    left: 35px;
     background-color: white;
     border: 1px solid black;
 }

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -95,6 +95,12 @@ a {
     margin: 6px;
 }
 
+.disabled-header-dropdown-item {
+    padding: 9px 9px;
+    color: $devil-gray;
+    white-space: nowrap;
+}
+
 .header-dropdown-link {
     padding: 9px 9px;
     color: $black;

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -96,49 +96,39 @@ a {
 
     &:active,
     &:hover {
-	.header-dropdown-link {
-	    border-color: black;
-	}
-	
 	.header-dropdown-menu {
 	    display: block;
 	}
     }
 }
 
-.header-dropdown-link-margin {
-    margin: 6px 6px 7px 6px;
+.header-dropdown-menu-caret {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    top: -100px;
+    overflow: hidden;
 }
 
-.header-dropdown-link {
-    position: relative;
-    display: inline-block;
-    padding: 8px;
-    color: $black;
-    white-space: nowrap;
+.header-dropdown-menu-caret:after {
+    content: "";
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    background: #999;
+    transform: rotate(45deg);
+    top: 90px;
+    left: 25px;
     background-color: white;
-    border-radius: 3px 3px 0 0;
-    border-style: solid;
-    border-color: white;
-    border-width: 1px 1px 0 1px;
-    z-index: 999; /* above header-dropdown-menu */
-    &:active,
-    &:hover {
-        text-decoration: none;
-        color: $devil-gray;
-    }
+    border: 1px solid black;
 }
 
 .header-dropdown-menu {
-    border-radius: 0 3px 3px 3px;
+    border-radius: 3px;
     position: absolute;
     display: none;
     background-color: white;
     border: 1px solid black;
-    /* -1.1px came from experimentation, I don't know why the extra 0.1px
-       is needed. */
-    transform: translate(0px, -1.1px);
-    z-index: 1;  /* below header-dropdown-link */
 }
 
 .header-dropdown-menu-link {

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -133,11 +133,12 @@ a {
     width: 20px;
     height: 20px;
     transform: rotate(45deg);
-    /* width / 2 - (header-dropdown top) 
+    /* abs(header-dropdown top) - width / 2
+       15px - 20px / 2 = 5px
        plus 2px to make triangle slightly smaller */
     top: 7px;
     /* (header-dropdown-link text width) / 2 + (header-dropdown-link padding)
-       ~52px / 2 + 9px = 35px */
+       35px = ~52px / 2 + 9px */
     left: 35px;
     background-color: white;
     border: 1px solid black;
@@ -149,7 +150,8 @@ a {
     border-radius: 3px;
     background-color: white;
     border: 1px solid black;
-    /* 12px: height of triangle + 5px spacing */
+    /* height of triangle + 5px spacing
+       12px = 7px + 5px */
     transform: translate(0px, 12px);
 }
 

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -154,7 +154,7 @@ a {
     border: 1px solid black;
     /* height of triangle + 5px spacing
        12px = 7px + 5px */
-    top-margin: 12px;
+    margin-top: 12px;
 }
 
 .header-dropdown-menu-link {

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -104,27 +104,30 @@ a {
 
 .header-dropdown-menu-caret {
     width: 100px;
-    height: 100px;
-    top: -100px;
+    height: 15px;
     overflow: hidden;
 }
 
 .header-dropdown-menu-caret:after {
     content: "";
+    position: absolute;
     width: 20px;
     height: 20px;
     background: #999;
     transform: rotate(45deg);
-    top: 90px;
+    top: -10px;
     left: 25px;
     background-color: white;
     border: 1px solid black;
 }
 
 .header-dropdown-menu {
-    border-radius: 3px;
     position: absolute;
     display: none;
+}
+
+.header-dropdown-menu-items {
+    border-radius: 3px;
     background-color: white;
     border: 1px solid black;
 }

--- a/web_common/web_common/styles/main.scss
+++ b/web_common/web_common/styles/main.scss
@@ -103,7 +103,6 @@ a {
 }
 
 .header-dropdown-menu-caret {
-    position: absolute;
     width: 100px;
     height: 100px;
     top: -100px;
@@ -112,7 +111,6 @@ a {
 
 .header-dropdown-menu-caret:after {
     content: "";
-    position: absolute;
     width: 20px;
     height: 20px;
     background: #999;

--- a/web_common/web_common/templates/header.html
+++ b/web_common/web_common/templates/header.html
@@ -8,7 +8,7 @@
       <div class="header-dropdown-item-margin">
 	<a href="{{ notebook_base_url }}/notebook" class="header-dropdown-link">Notebook</a>
 	<div class="header-dropdown-menu">
-	  <div class="header-dropdown-menu-caret"></div>
+	  <div class="notebook-caret header-dropdown-menu-caret"></div>
 	  <a class="header-dropdown-menu-link" href="{{ notebook_base_url }}/workshop-admin">Workshop Admin</a>
 	  <a class="header-dropdown-menu-link" href="{{ workshop_base_url }}">Workshop</a>
 	</div>
@@ -37,7 +37,7 @@
       <div class="header-dropdown-item-margin">
 	<div class="disabled-header-dropdown-item">Monitoring</div>
 	<div class="header-dropdown-menu">
-	  <div class="header-dropdown-menu-caret"></div>
+	  <div class="monitoring-caret header-dropdown-menu-caret"></div>
 	  <a target="_blank" class="header-dropdown-menu-link" href="https://internal.hail.is/monitoring/grafana/">
 	    Grafana<i class="material-icons text-icon">open_in_new</i>
 	  </a>

--- a/web_common/web_common/templates/header.html
+++ b/web_common/web_common/templates/header.html
@@ -8,10 +8,8 @@
       <div class="header-link">Notebook</div>
       <div class="header-dropdown-menu">
 	<div class="header-dropdown-menu-caret"></div>
-	<div class="header-dropdown-menu-items">
-	  <a class="header-dropdown-menu-link" href="{{ notebook_base_url }}/workshop-admin">Workshop Admin</a>
-	  <a class="header-dropdown-menu-link" href="{{ workshop_base_url }}">Workshop</a>
-	</div>
+	<a class="header-dropdown-menu-link" href="{{ notebook_base_url }}/workshop-admin">Workshop Admin</a>
+	<a class="header-dropdown-menu-link" href="{{ workshop_base_url }}">Workshop</a>
       </div>
     </div>
   {% else %}

--- a/web_common/web_common/templates/header.html
+++ b/web_common/web_common/templates/header.html
@@ -4,15 +4,12 @@
   </a>
 
   {% if userdata['developer'] == 1 %}
-    <div class="header-dropdown-link-margin">
-      <div class="header-dropdown">
-	<a class="header-dropdown-link" href="{{ notebook_base_url }}/notebook">
-	  Notebook
-	</a>
-	<div class="header-dropdown-menu">
-	  <a class="header-dropdown-menu-link" href="{{ notebook_base_url }}/workshop-admin">Workshop Admin</a>
-	  <a class="header-dropdown-menu-link" href="{{ workshop_base_url }}">Workshop</a>
-	</div>
+    <div class="header-dropdown">
+      <div class="header-link">Notebook</div>
+      <div class="header-dropdown-menu-caret"></div>
+      <div class="header-dropdown-menu">
+	<a class="header-dropdown-menu-link" href="{{ notebook_base_url }}/workshop-admin">Workshop Admin</a>
+	<a class="header-dropdown-menu-link" href="{{ workshop_base_url }}">Workshop</a>
       </div>
     </div>
   {% else %}

--- a/web_common/web_common/templates/header.html
+++ b/web_common/web_common/templates/header.html
@@ -6,10 +6,12 @@
   {% if userdata['developer'] == 1 %}
     <div class="header-dropdown">
       <div class="header-link">Notebook</div>
-      <div class="header-dropdown-menu-caret"></div>
       <div class="header-dropdown-menu">
-	<a class="header-dropdown-menu-link" href="{{ notebook_base_url }}/workshop-admin">Workshop Admin</a>
-	<a class="header-dropdown-menu-link" href="{{ workshop_base_url }}">Workshop</a>
+	<div class="header-dropdown-menu-caret"></div>
+	<div class="header-dropdown-menu-items">
+	  <a class="header-dropdown-menu-link" href="{{ notebook_base_url }}/workshop-admin">Workshop Admin</a>
+	  <a class="header-dropdown-menu-link" href="{{ workshop_base_url }}">Workshop</a>
+	</div>
       </div>
     </div>
   {% else %}

--- a/web_common/web_common/templates/header.html
+++ b/web_common/web_common/templates/header.html
@@ -5,11 +5,13 @@
 
   {% if userdata['developer'] == 1 %}
     <div class="header-dropdown">
-      <div class="header-link">Notebook</div>
-      <div class="header-dropdown-menu">
-	<div class="header-dropdown-menu-caret"></div>
-	<a class="header-dropdown-menu-link" href="{{ notebook_base_url }}/workshop-admin">Workshop Admin</a>
-	<a class="header-dropdown-menu-link" href="{{ workshop_base_url }}">Workshop</a>
+      <div class="header-dropdown-item-margin">
+	<a href="{{ notebook_base_url }}/notebook" class="header-dropdown-link">Notebook</a>
+	<div class="header-dropdown-menu">
+	  <div class="header-dropdown-menu-caret"></div>
+	  <a class="header-dropdown-menu-link" href="{{ notebook_base_url }}/workshop-admin">Workshop Admin</a>
+	  <a class="header-dropdown-menu-link" href="{{ workshop_base_url }}">Workshop</a>
+	</div>
       </div>
     </div>
   {% else %}

--- a/web_common/web_common/templates/header.html
+++ b/web_common/web_common/templates/header.html
@@ -35,7 +35,7 @@
 
     <div class="header-dropdown">
       <div class="header-dropdown-item-margin">
-	<div class="disabled-header-dropdown-item">Monitoring</div>
+	<span class="disabled-header-dropdown-item">Monitoring</span>
 	<div class="header-dropdown-menu">
 	  <div class="monitoring-caret header-dropdown-menu-caret"></div>
 	  <a target="_blank" class="header-dropdown-menu-link" href="https://internal.hail.is/monitoring/grafana/">

--- a/web_common/web_common/templates/header.html
+++ b/web_common/web_common/templates/header.html
@@ -33,17 +33,23 @@
       Scorecard
     </a>
 
-    <a target="_blank" class="header-link" href="https://internal.hail.is/monitoring/grafana/">
-      Grafana<i class="material-icons text-icon">open_in_new</i>
-    </a>
-
-    <a target="_blank" class="header-link" href="https://internal.hail.is/monitoring/prometheus/">
-      Prometheus<i class="material-icons text-icon">open_in_new</i>
-    </a>
-
-    <a target="_blank" class="header-link" href="https://internal.hail.is/monitoring/kibana/">
-      Kibana<i class="material-icons text-icon">open_in_new</i>
-    </a>
+    <div class="header-dropdown">
+      <div class="header-dropdown-item-margin">
+	<div class="disabled-header-dropdown-item">Monitoring</div>
+	<div class="header-dropdown-menu">
+	  <div class="header-dropdown-menu-caret"></div>
+	  <a target="_blank" class="header-dropdown-menu-link" href="https://internal.hail.is/monitoring/grafana/">
+	    Grafana<i class="material-icons text-icon">open_in_new</i>
+	  </a>
+	  <a target="_blank" class="header-dropdown-menu-link" href="https://internal.hail.is/monitoring/prometheus/">
+	    Prometheus<i class="material-icons text-icon">open_in_new</i>
+	  </a>
+	  <a target="_blank" class="header-dropdown-menu-link" href="https://internal.hail.is/monitoring/kibana/">
+	    Kibana<i class="material-icons text-icon">open_in_new</i>
+	  </a>
+	</div>
+      </div>
+    </div>
   {% endif %}
 
   <div id="header-flex"></div>


### PR DESCRIPTION
Another attempt at dropdown menus.  I like this better, too, for the reasons you described.

Changes:
 - change dropdowns to "caret" style, with a triangle on the top of the dropdown that points to the header item it dropped down from
 - move monitoring links into their own dropdown

To issues I'm not totally happy with:
 - Monitoring can't be clicked on, so it is grayed out, but styling matches hover styling for active header items
 - To center the triangle under the header item, I had to measure the width of the header items in the browser first.  It would be nice to do this from within CSS, but I don't know how to do that: the caret and the header item are in different parts of the DOM, and I don't know how to communicate the width of the header item to the left property of the caret.

It is deployed in my namespace if you want to take a look.
