### PR TITLE
[hail] print out JVM bytecode in tests if HailContext feature flag is set

### DIFF
--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -908,7 +908,8 @@ class HailFeatureFlags {
     mutable.Map[String, String](
       "lower" -> null,
       "newaggs" -> "1",
-      "max_leader_scans" -> "1000"
+      "max_leader_scans" -> "1000",
+      "jvm_bytecode_dump" -> null
     )
 
   val available: java.util.ArrayList[String] =

--- a/hail/src/main/scala/is/hail/expr/ir/Compile.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Compile.scala
@@ -82,7 +82,7 @@ object Compile {
 
   def apply[R: TypeInfo : ClassTag](
     body: IR,
-    print: Option[PrintWriter] = None
+    print: Option[PrintWriter]
   ): (PType, (Int, Region) => AsmFunction1[Region, R]) = {
     apply[AsmFunction1[Region, R], R](print, FastSeq[(String, PType, ClassTag[_])](), body, 1, optimize = true)
   }
@@ -91,17 +91,33 @@ object Compile {
     name0: String,
     typ0: PType,
     body: IR,
-    optimize: Boolean): (PType, (Int, Region) => AsmFunction3[Region, T0, Boolean, R]) = {
-
-    apply[AsmFunction3[Region, T0, Boolean, R], R](None, FastSeq((name0, typ0, classTag[T0])), body, 1, optimize)
+    optimize: Boolean,
+    print: Option[PrintWriter]
+  ): (PType, (Int, Region) => AsmFunction3[Region, T0, Boolean, R]) = {
+    apply[AsmFunction3[Region, T0, Boolean, R], R](print, FastSeq((name0, typ0, classTag[T0])), body, 1, optimize)
   }
 
   def apply[T0: ClassTag, R: TypeInfo : ClassTag](
     name0: String,
     typ0: PType,
-    body: IR): (PType, (Int, Region) => AsmFunction3[Region, T0, Boolean, R]) = {
+    body: IR,
+    optimize: Boolean): (PType, (Int, Region) => AsmFunction3[Region, T0, Boolean, R]) =
+    apply(name0, typ0, body, optimize, None)
 
-    apply[AsmFunction3[Region, T0, Boolean, R], R](None, FastSeq((name0, typ0, classTag[T0])), body, 1, optimize = true)
+  def apply[T0: ClassTag, R: TypeInfo : ClassTag](
+    name0: String,
+    typ0: PType,
+    body: IR): (PType, (Int, Region) => AsmFunction3[Region, T0, Boolean, R]) =
+    apply(name0, typ0, body, true)
+
+  def apply[T0: ClassTag, T1: ClassTag, R: TypeInfo : ClassTag](
+    name0: String,
+    typ0: PType,
+    name1: String,
+    typ1: PType,
+    body: IR,
+    print: Option[PrintWriter]): (PType, (Int, Region) => AsmFunction5[Region, T0, Boolean, T1, Boolean, R]) = {
+    apply[AsmFunction5[Region, T0, Boolean, T1, Boolean, R], R](print, FastSeq((name0, typ0, classTag[T0]), (name1, typ1, classTag[T1])), body, 1, optimize = true)
   }
 
   def apply[T0: ClassTag, T1: ClassTag, R: TypeInfo : ClassTag](
@@ -109,10 +125,8 @@ object Compile {
     typ0: PType,
     name1: String,
     typ1: PType,
-    body: IR): (PType, (Int, Region) => AsmFunction5[Region, T0, Boolean, T1, Boolean, R]) = {
-
-    apply[AsmFunction5[Region, T0, Boolean, T1, Boolean, R], R](None, FastSeq((name0, typ0, classTag[T0]), (name1, typ1, classTag[T1])), body, 1, optimize = true)
-  }
+    body: IR): (PType, (Int, Region) => AsmFunction5[Region, T0, Boolean, T1, Boolean, R]) =
+    apply(name0, typ0, name1, typ1, body, None)
 
   def apply[
   T0: TypeInfo : ClassTag,

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -157,7 +157,12 @@ object TestUtils {
 
   def eval(x: IR): Any = eval(x, Env.empty, FastIndexedSeq(), None)
 
-  def eval(x: IR, env: Env[(Any, Type)], args: IndexedSeq[(Any, Type)], agg: Option[(IndexedSeq[Row], TStruct)]): Any = {
+  def eval(x: IR,
+    env: Env[(Any, Type)],
+    args: IndexedSeq[(Any, Type)],
+    agg: Option[(IndexedSeq[Row], TStruct)],
+    bytecodePrinter: Option[PrintWriter] = None
+  ): Any = {
     val inputTypesB = new ArrayBuilder[Type]()
     val inputsB = new ArrayBuilder[Any]()
 
@@ -207,7 +212,8 @@ object TestUtils {
         val (resultType2, f) = Compile[Long, Long, Long](
           "AGGR", aggResultType,
           argsVar, argsPType,
-          postAggIR)
+          postAggIR,
+          print = bytecodePrinter)
         assert(resultType2.virtualType == resultType)
 
         Region.scoped { region =>
@@ -275,7 +281,9 @@ object TestUtils {
       case None =>
         val (resultType2, f) = Compile[Long, Long](
           argsVar, argsPType,
-          MakeTuple.ordered(FastSeq(rewrite(Subst(x, BindingEnv(substEnv))))))
+          MakeTuple.ordered(FastSeq(rewrite(Subst(x, BindingEnv(substEnv))))),
+          optimize = true,
+          print = bytecodePrinter)
         assert(resultType2.virtualType == resultType)
 
         Region.scoped { region =>

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -1,5 +1,7 @@
 package is.hail
 
+import java.io.PrintWriter
+
 import breeze.linalg.{DenseMatrix, Matrix, Vector}
 import is.hail.ExecStrategy.ExecStrategy
 import is.hail.annotations.{Annotation, Region, RegionValueBuilder, SafeRow}
@@ -143,10 +145,14 @@ object TestUtils {
   }
 
 
-  def loweredExecute(x: IR, env: Env[(Any, Type)], args: IndexedSeq[(Any, Type)], agg: Option[(IndexedSeq[Row], TStruct)]): Any = {
+  def loweredExecute(x: IR, env: Env[(Any, Type)],
+    args: IndexedSeq[(Any, Type)],
+    agg: Option[(IndexedSeq[Row], TStruct)],
+    bytecodePrinter: Option[PrintWriter] = None
+  ): Any = {
     if (agg.isDefined || !env.isEmpty || !args.isEmpty)
       throw new LowererUnsupportedOperation("can't test with aggs or user defined args/env")
-    HailContext.backend.jvmLowerAndExecute(x, optimize = false)._1
+    HailContext.backend.jvmLowerAndExecute(x, optimize = false, print = bytecodePrinter)._1
   }
 
   def eval(x: IR): Any = eval(x, Env.empty, FastIndexedSeq(), None)


### PR DESCRIPTION
Most of the functionality was already available in EmitFunctionBuilder, but Compile() didn't make it available. This PR creates a `PrintWriter` during assertEvalsTo if you set the `jvm_bytecode_dump` flag to a file path you want the bytecode to be written to.

Example:
```scala
    HailContext.setFlag("jvm_bytecode_dump", "arr_filter_bytecode.java")
    assertEvalsTo(ArrayFilter(a, "x",
      ApplyComparisonOp(LT(TInt32()), Ref("x", TInt32()), I32(6))), FastIndexedSeq(3))
    HailContext.setFlag("jvm_bytecode_dump", null)
```