### PR TITLE
[hail] Method-wrap aggregator functionality

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/asm4s/FunctionBuilder.scala
@@ -316,7 +316,7 @@ class FunctionBuilder[F >: Null](val parameterTypeInfo: Array[MaybeGenericTypeIn
         val count = method.instructions.size
         log.info(s"${ cn.name }.${ method.name } instruction count: $count")
         if (count > 8000)
-          log.info(s"${ cn.name }.${ method.name } instruction count > 8000")
+          log.warn(s"big method: ${ cn.name }.${ method.name }: $count")
       }
 
       cn.accept(cw)
@@ -329,7 +329,13 @@ class FunctionBuilder[F >: Null](val parameterTypeInfo: Array[MaybeGenericTypeIn
         val cwNoFrames = new ClassWriter(ClassWriter.COMPUTE_MAXS)
         val sw2 = new StringWriter()
         cn.accept(cwNoFrames)
-        CheckClassAdapter.verify(new ClassReader(cwNoFrames.toByteArray), false, new PrintWriter(sw2))
+        try {
+          CheckClassAdapter.verify(new ClassReader(cwNoFrames.toByteArray), false, new PrintWriter(sw2))
+        } catch {
+          case e: Exception =>
+            log.error("Verify Output 1 for " + name + ":")
+            throw e
+        }
 
         if (sw2.toString().length() != 0) {
           System.err.println("Verify Output 2 for " + name + ":")
@@ -337,7 +343,7 @@ class FunctionBuilder[F >: Null](val parameterTypeInfo: Array[MaybeGenericTypeIn
           throw new IllegalStateException("Bytecode failed verification 1", e)
         } else {
           if (sw1.toString().length() != 0) {
-            System.err.println("Verifiy Output 1 for " + name + ":")
+            System.err.println("Verify Output 1 for " + name + ":")
             System.err.println(sw1)
           }
           throw e

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -258,7 +258,7 @@ class EmitFunctionBuilder[F >: Null](
     _aggRegion = newField[Region]("agg_top_region")
     _aggOff = newField[Long]("agg_off")
     val states = agg.StateTuple(aggSigs.map(a => agg.Extract.getAgg(a).createState(this)).toArray)
-    _aggState = agg.TupleAggregatorState(states, _aggRegion, _aggOff)
+    _aggState = new agg.TupleAggregatorState(this, states, _aggRegion, _aggOff)
     _aggSerialized = newField[Array[Array[Byte]]]("agg_serialized")
 
     val newF = new EmitMethodBuilder(this, "newAggState", Array(typeInfo[Region]), typeInfo[Unit])
@@ -279,14 +279,14 @@ class EmitFunctionBuilder[F >: Null](
       Code(_aggRegion := newF.getArg[Region](1),
         _aggState.topRegion.setNumParents(aggSigs.length),
         _aggOff := _aggRegion.load().allocate(states.storageType.alignment, states.storageType.byteSize),
-        states.createStates,
+        states.createStates(this),
         _aggState.newState))
 
     setF.emit(
       Code(
         _aggRegion := setF.getArg[Region](1),
         _aggState.topRegion.setNumParents(aggSigs.length),
-        states.createStates,
+        states.createStates(this),
         _aggOff := setF.getArg[Long](2),
         _aggState.load))
 
@@ -439,6 +439,14 @@ class EmitFunctionBuilder[F >: Null](
       )
     }
     m
+  }
+
+  def wrapVoids(x: Seq[Code[Unit]], prefix: String, size: Int = 32): Code[Unit] = {
+    coerce[Unit](Code(x.grouped(size).zipWithIndex.map { case (codes, i) =>
+      val mb = newMethod(prefix + s"_group$i", Array[TypeInfo[_]](), UnitInfo)
+      mb.emit(Code(codes: _*))
+      mb.invoke()
+    }.toArray: _*))
   }
 
   def getOrDefineMethod(prefix: String, key: Any, argsInfo: Array[TypeInfo[_]], returnInfo: TypeInfo[_])

--- a/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/AggregatorState.scala
@@ -165,14 +165,14 @@ case class StateTuple(states: Array[AggregatorState]) {
 
   def apply(i: Int): AggregatorState = states(i)
 
-  def toCode(f: (Int, AggregatorState) => Code[Unit]): Code[Unit] =
-    coerce[Unit](Code(Array.tabulate(nStates)(i => f(i, states(i))): _*))
+  def toCode(fb: EmitFunctionBuilder[_], prefix: String, f: (Int, AggregatorState) => Code[Unit]): Code[Unit] =
+    fb.wrapVoids(Array.tabulate(nStates)((i: Int) => f(i, states(i))), prefix)
 
-  def createStates: Code[Unit] =
-    toCode((i, s) => s.createState)
+  def createStates(fb: EmitFunctionBuilder[_]): Code[Unit] =
+    toCode(fb, "create_states", (i, s) => s.createState)
 }
 
-case class TupleAggregatorState(states: StateTuple, topRegion: Code[Region], off: Code[Long], rOff: Code[Int] = 0) {
+class TupleAggregatorState(val fb: EmitFunctionBuilder[_], val states: StateTuple, val topRegion: Code[Region], val off: Code[Long], val rOff: Code[Int] = 0) {
   val storageType: PTuple = states.storageType
   private def getRegion(i: Int): Code[Region] => Code[Unit] = { r: Code[Region] =>
     r.setFromParentReference(topRegion, rOff + i, states(i).regionSize) }
@@ -185,9 +185,9 @@ case class TupleAggregatorState(states: StateTuple, topRegion: Code[Region], off
     coerce[Unit](Code(Array.tabulate(states.nStates)(i => f(i, states(i))): _*))
 
   def newState(i: Int): Code[Unit] = states(i).newState(getStateOffset(i))
-  def newState: Code[Unit] = states.toCode((i, s) => s.newState(getStateOffset(i)))
-  def load: Code[Unit] = states.toCode((i, s) => s.load(getRegion(i), getStateOffset(i)))
-  def store: Code[Unit] = states.toCode((i, s) => s.store(setRegion(i), getStateOffset(i)))
+  def newState: Code[Unit] = states.toCode(fb, "new_state", (i, s) => s.newState(getStateOffset(i)))
+  def load: Code[Unit] = states.toCode(fb, "load", (i, s) => s.load(getRegion(i), getStateOffset(i)))
+  def store: Code[Unit] = states.toCode(fb, "store", (i, s) => s.store(setRegion(i), getStateOffset(i)))
   def copyFrom(statesOffset: Code[Long]): Code[Unit] =
-    states.toCode((i, s) => s.copyFrom(storageType.loadField(statesOffset, i)))
+    states.toCode(fb, "copy_from", (i, s) => s.copyFrom(storageType.loadField(statesOffset, i)))
 }


### PR DESCRIPTION
Permits the big aggregate benchmarks to run...slowly:

```
2019-10-05 10:58:08,110: INFO: [1/2] Running table_big_aggregate_compilation...
2019-10-05 10:58:24,685: INFO:     burn in: 16.57s
2019-10-05 10:58:28,664: INFO:     run 1: 3.98s
2019-10-05 10:58:32,558: INFO:     run 2: 3.89s
2019-10-05 10:58:36,332: INFO:     run 3: 3.77s
2019-10-05 10:58:36,335: INFO: [2/2] Running table_big_aggregate_compile_and_execute...
2019-10-05 10:58:42,972: INFO:     burn in: 6.64s
2019-10-05 10:58:48,677: INFO:     run 1: 5.71s
2019-10-05 10:58:54,358: INFO:     run 2: 5.68s
2019-10-05 10:59:00,091: INFO:     run 3: 5.73s
```