### PR TITLE
[hail] fix docs in variant_qc

### DIFF
--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -46,7 +46,8 @@ def sample_qc(mt, name='sample_qc') -> MatrixTable:
     :py:data:`.tcall`, then an error is raised. The following fields are always
     computed from `GT`:
 
-    - `call_rate` (``float64``) -- Fraction of calls not missing or filtered. Equivalent to `n_called` divided by :meth:`.count_rows`.
+    - `call_rate` (``float64``) -- Fraction of calls not missing or filtered.
+      Equivalent to `n_called` divided by :meth:`.count_rows`.
     - `n_called` (``int64``) -- Number of non-missing calls.
     - `n_not_called` (``int64``) -- Number of missing calls.
     - `n_filtered` (``int64``) -- Number of filtered entries.
@@ -206,7 +207,7 @@ def variant_qc(mt, name='variant_qc') -> MatrixTable:
     - `homozygote_count` (``array<int32>``) -- Number of homozygotes per
       allele. One element per allele, including the reference.
     - `call_rate` (``float64``) -- Fraction of calls neither missing nor filtered.
-       Equivalent to `n_called` / :meth:`.count_cols`.
+      Equivalent to `n_called` / :meth:`.count_cols`.
     - `n_called` (``int64``) -- Number of samples with a defined `GT`.
     - `n_not_called` (``int64``) -- Number of samples with a missing `GT`.
     - `n_filtered` (``int64``) -- Number of filtered entries.

--- a/hail/python/hail/methods/qc.py
+++ b/hail/python/hail/methods/qc.py
@@ -46,8 +46,7 @@ def sample_qc(mt, name='sample_qc') -> MatrixTable:
     :py:data:`.tcall`, then an error is raised. The following fields are always
     computed from `GT`:
 
-    - `call_rate` (``float64``) -- Fraction of calls not missing or filtered.
-       Equivalent to `n_called` divided by :meth:`.count_rows`.
+    - `call_rate` (``float64``) -- Fraction of calls not missing or filtered. Equivalent to `n_called` divided by :meth:`.count_rows`.
     - `n_called` (``int64``) -- Number of non-missing calls.
     - `n_not_called` (``int64``) -- Number of missing calls.
     - `n_filtered` (``int64``) -- Number of filtered entries.


### PR DESCRIPTION
I don't think RST handles newlines in lists well.
<img width="488" alt="Screen Shot 2019-10-06 at 8 51 10 PM" src="https://user-images.githubusercontent.com/106194/66278864-0d1aea80-e87b-11e9-809c-005fa0762a3b.png">
