### PR TITLE
[hail] [jvm] implement switch for JVM codegen

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -170,12 +170,12 @@ object Code {
     }
   }
 
-  def switch(target: Code[Int], dflt: Code[Unit], cases: Seq[Code[Unit]]): Code[Unit] = {
+  def switch[T: TypeInfo](target: Code[Int], dflt: Code[T], cases: Seq[Code[T]]): Code[T] = {
     import is.hail.asm4s.joinpoint._
-    JoinPoint.CallCC[Unit] { (jb, ret) =>
-      def thenReturn(c: Code[Unit]): JoinPoint[Unit] = {
+    JoinPoint.CallCC[Code[T]] { (jb, ret) =>
+      def thenReturn(c: Code[T]): JoinPoint[Unit] = {
         val j = jb.joinPoint()
-        j.define { _ => Code(c, ret(())) }
+        j.define { _ => ret(c) }
         j
       }
       JoinPoint.switch(target,

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -170,7 +170,7 @@ object Code {
     }
   }
 
-  def switch(target: Code[Int], dflt: Code[Unit], cases: Seq[(Int, Code[Unit])]): Code[Unit] = {
+  def switch(target: Code[Int], dflt: Code[Unit], cases: Seq[Code[Unit]]): Code[Unit] = {
     import is.hail.asm4s.joinpoint._
     JoinPoint.CallCC[Unit] { (jb, ret) =>
       def thenReturn(c: Code[Unit]): JoinPoint[Unit] = {
@@ -180,9 +180,7 @@ object Code {
       }
       JoinPoint.switch(target,
         thenReturn(dflt),
-        cases.map { case (key, body) =>
-          key -> thenReturn(body)
-        })
+        cases.map(thenReturn))
     }
   }
 

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -170,7 +170,7 @@ object Code {
     }
   }
 
-  def switch(value: Code[Int], dflt: Code[Unit], cases: (Int, Code[Unit])*): Code[Unit] = {
+  def switch(target: Code[Int], dflt: Code[Unit], cases: Seq[(Int, Code[Unit])]): Code[Unit] = {
     import is.hail.asm4s.joinpoint._
     JoinPoint.CallCC[Unit] { (jb, ret) =>
       def thenReturn(c: Code[Unit]): JoinPoint[Unit] = {
@@ -178,7 +178,7 @@ object Code {
         j.define { _ => Code(c, ret(())) }
         j
       }
-      JoinPoint.switch(value,
+      JoinPoint.switch(target,
         thenReturn(dflt),
         cases.map { case (key, body) =>
           key -> thenReturn(body)

--- a/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
@@ -217,7 +217,7 @@ class ASM4SSuite extends TestNGSuite {
       Code(
         Code.switch(fb.getArg[Int](1),
           v := 999,
-          (1 to 50).map { i => i -> (v := const(i * i)) }: _*),
+          (1 to 50).map { i => i -> (v := const(i * i)) }),
         _return(v))
     }
     val f = fb.result()()

--- a/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
@@ -212,14 +212,10 @@ class ASM4SSuite extends TestNGSuite {
 
   @Test def switchLookup(): Unit = {
     val fb = functionBuilder[Int, Int]
-    fb.emit {
-      val v = fb.newLocal[Int]
-      Code(
-        Code.switch(fb.getArg[Int](1),
-          v := 999,
-          (0 until 50).map { i => v := const(i * i) }),
-        _return(v))
-    }
+    fb.emit(
+      Code.switch[Int](fb.getArg[Int](1),
+        999,
+        (0 until 50).map { i => const(i * i) }))
     val f = fb.result()()
     for (i <- -20 to 100) {
       if (i >= 0 && i < 50)
@@ -234,7 +230,7 @@ class ASM4SSuite extends TestNGSuite {
     fb.emit({
       val v = fb.newLocal[Int]
       Code(v := 5,
-        Code.switch(1, v := 6, Seq()),
+        Code.switch[Unit](1, v := 6, Seq()),
         _return(v))
     })
     val f = fb.result()()

--- a/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
@@ -210,6 +210,25 @@ class ASM4SSuite extends TestNGSuite {
     }
   }
 
+  @Test def switchLookup(): Unit = {
+    val fb = functionBuilder[Int, Int]
+    fb.emit {
+      val v = fb.newLocal[Int]
+      Code(
+        Code.switch(fb.getArg[Int](1),
+          v := 999,
+          (1 to 50).map { i => i -> (v := const(i * i)) }: _*),
+        _return(v))
+    }
+    val f = fb.result()()
+    Prop.forAll(Gen.choose(0, 100)) { i =>
+      if (i >= 1 && i <= 50)
+        (i * i) == f(i)
+      else
+        999 == f(i)
+    }
+  }
+
   @Test def nanAlwaysComparesFalse(): Unit = {
     Prop.forAll { (x: Double) =>
       {

--- a/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
+++ b/hail/src/test/scala/is/hail/asm4s/ASM4SSuite.scala
@@ -217,16 +217,28 @@ class ASM4SSuite extends TestNGSuite {
       Code(
         Code.switch(fb.getArg[Int](1),
           v := 999,
-          (1 to 50).map { i => i -> (v := const(i * i)) }),
+          (0 until 50).map { i => v := const(i * i) }),
         _return(v))
     }
     val f = fb.result()()
-    Prop.forAll(Gen.choose(0, 100)) { i =>
-      if (i >= 1 && i <= 50)
-        (i * i) == f(i)
+    for (i <- -20 to 100) {
+      if (i >= 0 && i < 50)
+        assert((i * i) == f(i), i)
       else
-        999 == f(i)
+        assert(999 == f(i), i)
     }
+  }
+
+  @Test def emptySwitch(): Unit = {
+    val fb = functionBuilder[Int]
+    fb.emit({
+      val v = fb.newLocal[Int]
+      Code(v := 5,
+        Code.switch(1, v := 6, Seq()),
+        _return(v))
+    })
+    val f = fb.result()()
+    assert(f() == 6)
   }
 
   @Test def nanAlwaysComparesFalse(): Unit = {


### PR DESCRIPTION
`switch` can either be used with `Code[T]`s or `JoinPoint[Unit]`s. The former resemble's Java's `switch` by executing the code in the matched case. The latter in some cases generates less bytecode; it simply jumps to the join point for the matched case.

```scala
Code.switch[T](target: Code[Int], dflt: Code[T], cases: Seq[Code[T]]): Code[T]
JoinPoint.switch(target: Code[Int], dflt: JoinPoint[Unit], cases: Seq[JoinPoint[Unit]]): Code[Ctrl]
```