### PR TITLE
Numpy literals

### DIFF
--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -220,8 +220,6 @@ def _to_expr(e, dtype):
             key_array = to_expr(keys, tarray(dtype.key_type))
             value_array = to_expr(values, tarray(dtype.value_type))
             return hl.dict(hl.zip(key_array, value_array))
-    elif isinstance(dtype, tndarray):
-        return e
     else:
         raise NotImplementedError(dtype)
 

--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -220,6 +220,8 @@ def _to_expr(e, dtype):
             key_array = to_expr(keys, tarray(dtype.key_type))
             value_array = to_expr(values, tarray(dtype.value_type))
             return hl.dict(hl.zip(key_array, value_array))
+    elif isinstance(dtype, tndarray):
+        return e
     else:
         raise NotImplementedError(dtype)
 

--- a/hail/python/hail/expr/expressions/base_expression.py
+++ b/hail/python/hail/expr/expressions/base_expression.py
@@ -1,7 +1,10 @@
 from typing import *
 
+import numpy as np
+
 from hail.expr import expressions
 from hail.expr.types import *
+from hail.expr.types import from_numpy
 from hail.ir import *
 from hail.typecheck import linked_list
 from hail.utils.java import *
@@ -82,6 +85,9 @@ def impute_type(x):
             raise ExpressionException("Hail does not support heterogeneous dicts: "
                                       "found dict with values of types {} ".format(list(vts)))
         return tdict(unified_key_type, unified_value_type)
+    elif isinstance(x, np.ndarray):
+        element_type = from_numpy(x.dtype)
+        return tndarray(element_type, x.ndim)
     elif x is None:
         raise ExpressionException("Hail cannot impute the type of 'None'")
     elif isinstance(x, (hl.expr.builders.CaseBuilder, hl.expr.builders.SwitchBuilder)):

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -6,7 +6,7 @@ from typing import *
 import hail as hl
 from hail.expr.expressions import *
 from hail.expr.expressions.expression_typecheck import *
-from hail.expr.types import *
+from hail.expr.types import from_numpy
 from hail.genetics.reference_genome import reference_genome_type, ReferenceGenome
 from hail.ir import *
 from hail.typecheck import *
@@ -3891,15 +3891,7 @@ def _ndarray(collection, row_major=None):
         return result
 
     if isinstance(collection, np.ndarray):
-        if row_major is None:
-            row_major = not collection.flags.f_contiguous
-            flattened = collection.flatten('A')
-        else:
-            flattened = collection.flatten('C' if row_major else 'F')
-
-        elem_type = np_type_to_hl_type(collection.dtype)
-        data = [to_expr(i.item(), elem_type) for i in flattened]
-        shape = collection.shape
+        return literal(collection)
     elif isinstance(collection, list):
         shape = list_shape(collection)
         data = deep_flatten(collection)

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3891,7 +3891,14 @@ def _ndarray(collection, row_major=None):
         return result
 
     if isinstance(collection, np.ndarray):
-        return literal(collection)
+        if row_major is None:
+            row_major = not collection.flags.f_contiguous
+            flattened = collection.flatten('A')
+        else:
+            flattened = collection.flatten('C' if row_major else 'F')
+
+        data = flattened.tolist()
+        shape = collection.shape
     elif isinstance(collection, list):
         shape = list_shape(collection)
         data = deep_flatten(collection)

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -1665,6 +1665,8 @@ def from_numpy(np_dtype):
         return tfloat32
     elif np_dtype == np.float64:
         return tfloat64
+    elif np_dtype == np.bool:
+        return tbool
     else:
         raise ValueError(f"numpy type {np_dtype} could not be converted to a hail type.")
 

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -1665,6 +1665,8 @@ def from_numpy(np_dtype):
         return tfloat32
     elif np_dtype == np.float64:
         return tfloat64
+    else:
+        raise ValueError(f"numpy type {np_dtype} could not be converted to a hail type.")
 
 
 class tvariable(HailType):

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -609,11 +609,12 @@ class tndarray(HailType):
 
     def _traverse(self, obj, f):
         if f(self, obj):
-            for elt in obj:
-                self.element_type._traverse(elt, f)
+            for elt in np.nditer(obj):
+                self.element_type._traverse(elt.item(), f)
 
     def _typecheck_one_level(self, annotation):
-        raise NotImplementedError
+        if annotation is not None and not isinstance(annotation, np.ndarray):
+            raise TypeError("type 'ndarray' expected Python 'numpy.ndarray', but found type '%s'" % type(annotation))
 
     def __str__(self):
         return "ndarray<{}, {}>".format(self.element_type, self.ndim)
@@ -636,7 +637,15 @@ class tndarray(HailType):
         return np.ndarray(shape=x['shape'], buffer=np.array(x['data'], dtype=np_type), strides=x['strides'], dtype=np_type)
 
     def _convert_to_json(self, x):
-        raise NotImplementedError
+        data = x.reshape(x.size).tolist()
+        json_dict = {
+            "shape": x.shape,
+            "strides": x.strides,
+            "flags": 0,
+            "data": data,
+            "offset": 0
+        }
+        return json_dict
 
     def clear(self):
         self._element_type.clear()

--- a/hail/python/hail/expr/types.py
+++ b/hail/python/hail/expr/types.py
@@ -1647,6 +1647,16 @@ def types_match(left, right) -> bool:
     return (len(left) == len(right)
             and all(map(lambda lr: lr[0].dtype == lr[1].dtype, zip(left, right))))
 
+def from_numpy(np_dtype):
+    if np_dtype == np.int32:
+        return tint32
+    elif np_dtype == np.int64:
+        return tint64
+    elif np_dtype == np.float32:
+        return tfloat32
+    elif np_dtype == np.float64:
+        return tfloat64
+
 
 class tvariable(HailType):
     _cond_map = {

--- a/hail/python/hail/utils/misc.py
+++ b/hail/python/hail/utils/misc.py
@@ -463,21 +463,6 @@ def timestamp_path(base, suffix=''):
                     datetime.datetime.now().strftime("%Y%m%d-%H%M"),
                     suffix])
 
-
-def np_type_to_hl_type(t):
-    if t == np.int64:
-        return hail.tint64
-    elif t == np.int32:
-        return hail.tint32
-    elif t == np.float64:
-        return hail.tfloat64
-    elif t == np.float32:
-        return hail.tfloat32
-    elif t == np.bool:
-        return hail.tbool
-    else:
-        raise TypeError(f'Unsupported numpy type: {t}')
-
 def upper_hex(n, num_digits=None):
     if num_digits is None:
         return "{0:X}".format(n)

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -88,7 +88,11 @@ def test_ndarray_eval():
     assert hl.eval(hl._ndarray([[], []])).strides == (8, 8)
     assert np.array_equal(hl.eval(hl._ndarray([])), np.array([]))
 
-    assert np.array_equal(hl.eval(hl.literal(np.zeros((10, 10)))), np.zeros((10, 10)))
+    zero_array = np.zeros((10, 10), dtype=np.int64)
+    evaled_zero_array = hl.eval(hl.literal(zero_array))
+
+    assert np.array_equal(evaled_zero_array, zero_array)
+    assert zero_array.dtype == evaled_zero_array.dtype
 
 
 @skip_unless_spark_backend()

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -88,6 +88,9 @@ def test_ndarray_eval():
     assert hl.eval(hl._ndarray([[], []])).strides == (8, 8)
     assert np.array_equal(hl.eval(hl._ndarray([])), np.array([]))
 
+    assert np.array_equal(hl.eval(hl.literal(np.zeros((10, 10)))), np.zeros((10, 10)))
+
+
 @skip_unless_spark_backend()
 def test_ndarray_shape():
     np_e = np.array(3)
@@ -132,7 +135,7 @@ def test_ndarray_reshape():
         (cube_t_to_rect, np_cube_t_to_rect))
 
 @skip_unless_spark_backend()
-def test_ndarray_map_jvm():
+def test_ndarray_map():
     a = hl._ndarray([[2, 3, 4], [5, 6, 7]])
     b = hl.map(lambda x: -x, a)
     c = hl.map(lambda x: True, a)

--- a/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValueBuilder.scala
@@ -582,6 +582,8 @@ class RegionValueBuilder(var region: Region) {
           addBoolean(i.includesStart)
           addBoolean(i.includesEnd)
           endStruct()
+        case t: TNDArray =>
+          addAnnotation(t.representation, a)
       }
 
   }

--- a/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
+++ b/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
@@ -236,12 +236,8 @@ object JSONAnnotationImpex {
         }
       case (_, TLocus(_, _)) =>
         jv.extract[Locus]
-      case (JObject(list), TNDArray(_, _, _)) =>
-        val m = list.toMap
-        (m.get("flags"), m.get("offset"), m.get("shape"), m.get("strides"), m.get("data")) match {
-          case (Some(flagsJV), Some(offsetJV), Some(shapeJV), Some(stridesJV), Some(dataJV)) =>
-            
-        }
+      case (JObject(_), t@TNDArray(_, _, _)) =>
+        imp(jv, t.representation, parent)
       case (_, TInterval(pointType, _)) =>
         jv match {
           case JObject(list) =>

--- a/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
+++ b/hail/src/main/scala/is/hail/expr/AnnotationImpex.scala
@@ -236,6 +236,12 @@ object JSONAnnotationImpex {
         }
       case (_, TLocus(_, _)) =>
         jv.extract[Locus]
+      case (JObject(list), TNDArray(_, _, _)) =>
+        val m = list.toMap
+        (m.get("flags"), m.get("offset"), m.get("shape"), m.get("strides"), m.get("data")) match {
+          case (Some(flagsJV), Some(offsetJV), Some(shapeJV), Some(stridesJV), Some(dataJV)) =>
+            
+        }
       case (_, TInterval(pointType, _)) =>
         jv match {
           case JObject(list) =>

--- a/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
@@ -1,5 +1,5 @@
 package is.hail.expr.ir
-
+import is.hail.utils._
 import is.hail.utils.HailException
 
 object FoldConstants {
@@ -37,6 +37,7 @@ object FoldConstants {
           } &&
           (canGenerateLiterals || CanEmit(ir.typ)) =>
           try {
+            log.info(s"Safe to interpret: $ir")
             Some(
               Literal.coerce(ir.typ, Interpret(ctx, ir, optimize = false)))
           } catch {

--- a/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/FoldConstants.scala
@@ -37,7 +37,6 @@ object FoldConstants {
           } &&
           (canGenerateLiterals || CanEmit(ir.typ)) =>
           try {
-            log.info(s"Safe to interpret: $ir")
             Some(
               Literal.coerce(ir.typ, Interpret(ctx, ir, optimize = false)))
           } catch {

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -86,6 +86,8 @@ object Interpret {
     ir = EvaluateRelationalLets(ir).asInstanceOf[IR]
     ir = LiftNonCompilable(ir).asInstanceOf[IR]
 
+
+    log.info(s"Thing I am actually interpreting: $ir")
     val result = apply(ctx, ir, valueEnv, args, aggArgs, None, Memo.empty[AsmFunction3[Region, Long, Boolean, Long]]).asInstanceOf[T]
 
     result

--- a/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpret.scala
@@ -87,7 +87,6 @@ object Interpret {
     ir = LiftNonCompilable(ir).asInstanceOf[IR]
 
 
-    log.info(s"Thing I am actually interpreting: $ir")
     val result = apply(ctx, ir, valueEnv, args, aggArgs, None, Memo.empty[AsmFunction3[Region, Long, Boolean, Long]]).asInstanceOf[T]
 
     result

--- a/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Interpretable.scala
@@ -1,8 +1,11 @@
 package is.hail.expr.ir
 
+import is.hail.expr.types.virtual.TNDArray
+
 object Interpretable {
   def apply(ir: IR): Boolean = {
-    ir match {
+    !ir.typ.isInstanceOf[TNDArray] &&
+      (ir match {
       case
         _: InitOp2 |
         _: SeqOp2 |
@@ -22,6 +25,6 @@ object Interpretable {
         _: NDArrayMatMul |
         _: NDArrayWrite => false
       case _ => true
-    }
+    })
   }
 }

--- a/hail/src/main/scala/is/hail/expr/types/encoded/EBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/encoded/EBaseStruct.scala
@@ -86,6 +86,9 @@ final case class EBaseStruct(fields: IndexedSeq[EField], override val required: 
         PTupleField(idx, pt)
       }
       PTuple(pFields, required)
+    case t: TNDArray =>
+      val elementType = _decodedPType(t.representation).asInstanceOf[PStruct].fieldType("data").asInstanceOf[PArray].elementType
+      PNDArray(elementType, t.nDims, required)
   }
 
   def _buildEncoder(pt: PType, mb: EmitMethodBuilder, v: Code[_], out: Code[OutputBuffer]): Code[Unit] = {


### PR DESCRIPTION
This PR adds the ability to use `hl.literal` on numpy arrays. It also changes the behavior of `hl._ndarray` when called on a numpy ndarray so it just goes through literal to avoid creating an IR node for each element of tensor. 