### PR TITLE
[batch2] fewer globals

### DIFF
--- a/batch2/batch/__main__.py
+++ b/batch2/batch/__main__.py
@@ -1,12 +1,11 @@
-from aiohttp import web
-
-from hailtop.config import get_deploy_config
 from gear import configure_logging
-
-from .batch import app
-
+# configure logging before importing anything else
 configure_logging()
 
-deploy_config = get_deploy_config()
 
-web.run_app(deploy_config.prefix_application(app, 'batch2'), host='0.0.0.0', port=5000)
+def main():
+    from .batch import run
+    run()
+
+
+main()


### PR DESCRIPTION
Stacked on: https://github.com/hail-is/hail/pull/7208

Make app, db and v1 not global variables in batch.py.   I'm doing this because I want to break Batch, Job into separate files and use them in both the scheduler and the front end.  To do that, they need to be parameterized by the app (or the services that are carried on the app).