### PR TITLE
[ci, batch2, hailtop] move shared async subprocess code to hailtop.utils

### DIFF
--- a/batch2/batch/utils.py
+++ b/batch2/batch/utils.py
@@ -44,31 +44,3 @@ def parse_image_tag(image_string):
     if match:
         return match.group(3)
     return None
-
-
-class CalledProcessError(Exception):
-    def __init__(self, command, returncode):
-        super().__init__()
-        self.command = command
-        self.returncode = returncode
-
-    def __str__(self):
-        return f'Command {self.command} returned non-zero exit status {self.returncode}.'
-
-
-async def check_shell(script):
-    proc = await asyncio.create_subprocess_exec('/bin/bash', '-c', script)
-    await proc.wait()
-    if proc.returncode != 0:
-        raise CalledProcessError(script, proc.returncode)
-
-
-async def check_shell_output(script):
-    proc = await asyncio.create_subprocess_exec(
-        '/bin/bash', '-c', script,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE)
-    outerr = await proc.communicate()
-    if proc.returncode != 0:
-        raise CalledProcessError(script, proc.returncode)
-    return outerr

--- a/batch2/batch/utils.py
+++ b/batch2/batch/utils.py
@@ -1,5 +1,4 @@
 import re
-import asyncio
 from aiohttp import web
 import secrets
 import logging

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -6,9 +6,9 @@ import asyncio
 import concurrent.futures
 import aiohttp
 import gidgethub
+from hailtop.utils import check_shell, check_shell_output
 from .constants import GITHUB_CLONE_URL, AUTHORIZED_USERS
 from .environment import SELF_HOSTNAME
-from .utils import check_shell, check_shell_output
 from .build import BuildConfiguration, Code
 
 repos_lock = asyncio.Lock()

--- a/ci/ci/utils.py
+++ b/ci/ci/utils.py
@@ -1,34 +1,5 @@
 import string
 import secrets
-import asyncio
-
-
-class CalledProcessError(Exception):
-    def __init__(self, command, returncode):
-        super().__init__()
-        self.command = command
-        self.returncode = returncode
-
-    def __str__(self):
-        return f'Command {self.command} returned non-zero exit status {self.returncode}.'
-
-
-async def check_shell(script):
-    proc = await asyncio.create_subprocess_exec('/bin/bash', '-c', script)
-    await proc.wait()
-    if proc.returncode != 0:
-        raise CalledProcessError(script, proc.returncode)
-
-
-async def check_shell_output(script):
-    proc = await asyncio.create_subprocess_exec(
-        '/bin/bash', '-c', script,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE)
-    outerr = await proc.communicate()
-    if proc.returncode != 0:
-        raise CalledProcessError(script, proc.returncode)
-    return outerr
 
 
 def generate_token(size=12):

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -1,4 +1,5 @@
 from .utils import unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool
+from .process import CalledProcessError, check_shell, check_shell_output
 
 __all__ = [
     'unzip',

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -5,5 +5,8 @@ __all__ = [
     'unzip',
     'async_to_blocking',
     'blocking_to_async',
-    'AsyncWorkerPool'
+    'AsyncWorkerPool',
+    'CalledProcessError',
+    'check_shell',
+    'check_shell_output'
 ]

--- a/hail/python/hailtop/utils/process.py
+++ b/hail/python/hailtop/utils/process.py
@@ -1,0 +1,29 @@
+import asyncio
+
+
+class CalledProcessError(Exception):
+    def __init__(self, command, returncode):
+        super().__init__()
+        self.command = command
+        self.returncode = returncode
+
+    def __str__(self):
+        return f'Command {self.command} returned non-zero exit status {self.returncode}.'
+
+
+async def check_shell(script):
+    proc = await asyncio.create_subprocess_exec('/bin/bash', '-c', script)
+    await proc.wait()
+    if proc.returncode != 0:
+        raise CalledProcessError(script, proc.returncode)
+
+
+async def check_shell_output(script):
+    proc = await asyncio.create_subprocess_exec(
+        '/bin/bash', '-c', script,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE)
+    outerr = await proc.communicate()
+    if proc.returncode != 0:
+        raise CalledProcessError(script, proc.returncode)
+    return outerr


### PR DESCRIPTION
I thought I was eliminating some duplicated code, but it turned out it wasn't used in batch2 anymore.  Anyway, it probably belongs in the common utils.