### PR TITLE
[hail] Fix ForwardLets inlining ArrayAggs

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/Exists.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Exists.scala
@@ -61,6 +61,7 @@ object ContainsAgg {
   def apply(root: IR): Boolean = IsAggResult(root) || (root match {
     case _: TableAggregate => false
     case _: MatrixAggregate => false
+    case _: ArrayAgg => true // this should be permitted, but causes problems elsewhere in the IR
     case _ => root.children.exists {
       case child: IR => ContainsAgg(child)
       case _ => false
@@ -91,6 +92,7 @@ object ContainsScan {
   def apply(root: IR): Boolean = IsScanResult(root) || (root match {
     case _: TableAggregate => false
     case _: MatrixAggregate => false
+    case _: ArrayAggScan => true // this should be permitted, but causes problems elsewhere in the IR
     case _ => root.children.exists {
       case child: IR => ContainsScan(child)
       case _ => false

--- a/hail/src/test/scala/is/hail/expr/ir/ForwardLetsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/ForwardLetsSuite.scala
@@ -144,4 +144,21 @@ class ForwardLetsSuite extends HailSuite {
     TypeCheck(ir, BindingEnv(env))
     TypeCheck(ForwardLets(ir).asInstanceOf[IR], BindingEnv(env))
   }
+
+  @Test def testLetsDoNotForwardInsideArrayAggWithNoOps(): Unit = {
+    val x = Let(
+      "x",
+      ArrayAgg(
+        In(0, TArray(TInt32())),
+        "foo",
+        Ref(
+          "y", TInt32())),
+      ArrayAgg(In(1, TArray(TInt32())),
+        "bar",
+        Ref("y", TInt32()) + Ref("x", TInt32()
+        )))
+
+    TypeCheck(x, BindingEnv(Env("y" -> TInt32())))
+    TypeCheck(ForwardLets(x).asInstanceOf[IR], BindingEnv(Env("y" -> TInt32())))
+  }
 }


### PR DESCRIPTION
Fixed inlining of ArrayAgg nodes without aggs in the body. Also added
simplify rule to rewrite these nodes to just the body.