### PR TITLE
[hail] [streams] new streaming interface for some basic streams

### DIFF
--- a/hail/src/main/scala/is/hail/asm4s/joinpoint/ParameterPack.scala
+++ b/hail/src/main/scala/is/hail/asm4s/joinpoint/ParameterPack.scala
@@ -42,6 +42,11 @@ object ParameterPack {
       ParameterStore(Code(cs.store, bs.store, as.store), (as.load, bs.load, cs.load))
     }
   }
+
+  def localMemoize[A, X](mb: MethodBuilder, a0: A)(k: A => Code[X])(implicit ap: ParameterPack[A]): Code[X] ={
+    val a = ap.newLocals(mb)
+    Code(ap.push(a0), a.store, k(a.load))
+  }
 }
 
 object ParameterStore {
@@ -56,4 +61,10 @@ trait ParameterPack[A] {
 case class ParameterStore[A](
   store: Code[Unit],
   load: A
-)
+) {
+  def :=(v: A)(implicit p: ParameterPack[A]): Code[Unit] =
+    Code(p.push(v), store)
+
+  def :=(cc: JoinPoint.CallCC[A]): Code[Unit] =
+    Code(cc.code, store)
+}

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -1,0 +1,222 @@
+package is.hail.expr.ir
+
+import is.hail.utils._
+import is.hail.asm4s._
+import is.hail.asm4s.joinpoint._
+import is.hail.expr.types.physical._
+import is.hail.annotations.{Region, StagedRegionValueBuilder}
+
+import scala.language.existentials
+
+object EmitStream {
+  sealed trait Init[+S]
+  object Missing extends Init[Nothing]
+  object Empty extends Init[Nothing]
+  case class Start[S](s0: S) extends Init[S]
+
+  sealed trait Step[+A, +S]
+  object EOS extends Step[Nothing, Nothing]
+  case class Yield[A, S](elt: A, s: S) extends Step[A, S]
+
+  def stepIf[A, S, X](k: Step[A, S] => Code[X], c: Code[Boolean], a: A, s: S): Code[X] =
+    c.mux(k(Yield(a, s)), k(EOS))
+
+  trait Parameterized[-P, +A] { self =>
+    type S
+    val stateP: ParameterPack[S]
+    def dummyState: S
+
+    def length(s0: S): Option[Code[Int]]
+
+    def init(
+      mb: MethodBuilder,
+      jb: JoinPointBuilder,
+      param: P
+    )(k: Init[S] => Code[Ctrl]): Code[Ctrl]
+
+    def step(
+      mb: MethodBuilder,
+      jb: JoinPointBuilder,
+      state: S
+    )(k: Step[A, S] => Code[Ctrl]): Code[Ctrl]
+  }
+
+  val missing: Parameterized[Any, Nothing] = new Parameterized[Any, Nothing] {
+    type S = Unit
+    val stateP: ParameterPack[S] = implicitly
+    def dummyState: S = ()
+    def length(s0: S): Option[Code[Int]] = Some(0)
+    def init(mb: MethodBuilder, jb: JoinPointBuilder, param: Any)(k: Init[S] => Code[Ctrl]): Code[Ctrl] =
+      k(Missing)
+    def step(mb: MethodBuilder, jb: JoinPointBuilder, s: S)(k: Step[Nothing, S] => Code[Ctrl]): Code[Ctrl] =
+      k(EOS)
+  }
+
+  def range[P](
+    // initialize(param, k) = ...k(None) or k(Some((len, start)))...
+    initialize: (P, Option[(Code[Int], Code[Int])] => Code[Ctrl]) => Code[Ctrl],
+    incr: Code[Int] => Code[Int]
+  ): Parameterized[P, Code[Int]] = new Parameterized[P, Code[Int]] {
+    type S = (Code[Int], Code[Int])
+    val stateP: ParameterPack[S] = implicitly
+    def dummyState: S = (0, 0)
+    def length(s0: S): Option[Code[Int]] = Some(s0._1)
+
+    def init(mb: MethodBuilder, jb: JoinPointBuilder, param: P)(k: Init[S] => Code[Ctrl]): Code[Ctrl] =
+      initialize(param, {
+        case None => k(Missing)
+        case Some(s0) => k(Start(s0))
+      })
+
+    def step(mb: MethodBuilder, jb: JoinPointBuilder, state: S)(k: Step[Code[Int], S] => Code[Ctrl]): Code[Ctrl] = {
+      val (pos, idx) = state
+      stepIf(k, pos > 0, idx, (pos - 1, incr(idx)))
+    }
+  }
+
+  private[ir] def apply(
+    emitter: Emit,
+    streamIR0: IR,
+    env0: Emit.E,
+    rvas: Emit.RVAS,
+    er: EmitRegion,
+    container: Option[AggContainer]
+  ): EmitStream = {
+    val fb = emitter.mb.fb
+
+    def emitIR(ir: IR, env: Emit.E): EmitTriplet =
+      emitter.emit(ir, env, rvas, er, container)
+
+    def emitStream(streamIR: IR, env: Emit.E): Parameterized[Any, EmitTriplet] =
+      emitPStream[Any](streamIR, env, _ => Code._empty)
+
+    def emitPStream[E](streamIR: IR, env: Emit.E, setupEnv: E => Code[Unit]): Parameterized[E, EmitTriplet] =
+      streamIR match {
+
+        case NA(_) =>
+          missing
+
+        case StreamRange(startIR, stopIR, stepIR) =>
+          val step = fb.newField[Int]("sr_step")
+          val start = fb.newField[Int]("sr_start")
+          val stop = fb.newField[Int]("sr_stop")
+          val llen = fb.newField[Long]("sr_llen")
+          range[E](
+            (e, k) => {
+              val startt = emitIR(startIR, env)
+              val stopt = emitIR(stopIR, env)
+              val stept = emitIR(stepIR, env)
+              Code(setupEnv(e), startt.setup, stopt.setup, stept.setup,
+                (startt.m || stopt.m || stept.m).mux(
+                  k(None),
+                  Code(
+                    start := startt.value,
+                    stop := stopt.value,
+                    step := stept.value,
+                    (step ceq 0).orEmpty(Code._fatal("Array range cannot have step size 0.")),
+                    llen := (step < 0).mux(
+                      (start <= stop).mux(0L, (start.toL - stop.toL - 1L) / (-step).toL + 1L),
+                      (start >= stop).mux(0L, (stop.toL - start.toL - 1L) / step.toL + 1L)),
+                    (llen > const(Int.MaxValue.toLong)).mux(
+                      Code._fatal("Array range cannot have more than MAXINT elements."),
+                      k(Some((llen.toI, start)))))))
+            },
+            i => i + step
+          )
+            .map { i => EmitTriplet(Code._empty, false, i) }
+
+        case ToStream(containerIR) =>
+          val pType = containerIR.pType.asInstanceOf[PContainer]
+          val eltPType = pType.elementType
+          val region = er.region
+          val aoff = fb.newField[Long]("a_off")
+          val len = pType.loadLength(region, aoff)
+          range[E](
+            (e, k) => {
+              val arrt = emitIR(containerIR, env)
+              Code(setupEnv(e),
+                arrt.setup,
+                arrt.m.mux(k(None), Code(aoff := arrt.value, k(Some((len, 0))))))
+            },
+            i => i + 1
+          )
+            .map { i =>
+              EmitTriplet(Code._empty,
+                pType.isElementMissing(region, aoff, i),
+                Region.loadIRIntermediate(eltPType)(pType.elementOffsetInRegion(region, aoff, i)))
+            }
+
+        case Let(name, valueIR, childIR) =>
+          val valueType = valueIR.pType
+          val valueTI = coerce[Any](typeToTypeInfo(valueType))
+          val vm = fb.newField[Boolean](name + "_missing")
+          val vv = fb.newField(name)(valueTI)
+          val valuet = emitIR(valueIR, env)
+          val bodyEnv = env.bind(name -> ((valueTI, vm, vv)))
+          def setupBodyEnv(e: E): Code[Unit] =
+            Code(setupEnv(e),
+              valuet.setup,
+              vm := valuet.m,
+              vv := vm.mux(defaultValue(valueType), valuet.v))
+          emitPStream[E](childIR, bodyEnv, setupBodyEnv)
+
+        case _ =>
+          fatal(s"not a streamable IR: ${Pretty(streamIR)}")
+      }
+
+    EmitStream(
+      emitStream(streamIR0, env0),
+      streamIR0.pType.asInstanceOf[PStreamable].elementType)
+  }
+
+  def apply(fb: EmitFunctionBuilder[_], ir: IR): EmitStream =
+    apply(new Emit(fb.apply_method, 1), ir, Env.empty,
+      None, EmitRegion.default(fb.apply_method), None)
+}
+
+case class EmitStream(
+  stream: EmitStream.Parameterized[Any, EmitTriplet],
+  elementType: PType
+) {
+  import EmitStream._
+  private implicit val sP = stream.stateP
+
+  def toArrayIterator(mb: MethodBuilder): ArrayIteratorTriplet = {
+    val state = sP.newLocals(mb)
+
+    ArrayIteratorTriplet(
+      Code._empty,
+      stream.length(state.load),
+      (cont: (Code[Boolean], Code[_]) => Code[Unit]) => {
+        // status == 2 iff the inner stream is missing
+        // status == 1 iff the inner stream is actually empty (so the state is invalid)
+        // status == 0 otherwise
+        val status = mb.newField[Int]("stream_status")
+
+        val setup =
+          state := JoinPoint.CallCC[stream.S] { (jb, ret) =>
+            stream.init(mb, jb, ()) {
+              case Missing => Code(status := 2, ret(stream.dummyState))
+              case Empty => Code(status := 1, ret(stream.dummyState))
+              case Start(s0) => Code(status := 0, ret(s0))
+            }
+          }
+
+        val addElements =
+          JoinPoint.CallCC[Unit] { (jb, ret) =>
+            val loop = jb.joinPoint()
+            loop.define { _ => stream.step(mb, jb, state.load) {
+              case EOS => ret(())
+              case Yield(elt, s1) => Code(
+                elt.setup,
+                cont(elt.m, elt.value),
+                state := s1,
+                loop(()))
+            } }
+            JoinPoint.mux((status ceq 0), loop, ret)
+          }
+
+        EmitArrayTriplet(setup, Some(status ceq 2), addElements)
+      })
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitStream.scala
@@ -129,7 +129,7 @@ object EmitStream {
     type S = Code[Int]
     val stateP: ParameterPack[S] = implicitly
     def emptyState: S = elements.length
-    def length(s0: S): Option[Code[Int]] = Some(elements.length)
+    def length(s0: S): Option[Code[Int]] = Some(const(elements.length) - s0)
 
     def init(mb: MethodBuilder, jb: JoinPointBuilder, param: P)(k: Init[S] => Code[Ctrl]): Code[Ctrl] =
       Code(initialize(param), k(Start(0)))

--- a/hail/src/main/scala/is/hail/expr/ir/Streamify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Streamify.scala
@@ -5,6 +5,7 @@ import is.hail.expr.types.virtual._
 object Streamify {
   def apply(ir: IR): IR = ir match {
     case NA(t) => NA(t)
+    case MakeArray(xs, t) => MakeStream(xs, TStream(t.elementType, t.required))
     case ArrayRange(x, y, z) => StreamRange(x, y, z)
     case ArrayMap(a, n, b) => ArrayMap(apply(a), n, b)
     case ArrayFilter(a, n, b) => ArrayFilter(apply(a), n, b)

--- a/hail/src/main/scala/is/hail/expr/ir/Streamify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Streamify.scala
@@ -6,6 +6,8 @@ object Streamify {
   def apply(ir: IR): IR = ir match {
     case NA(t) => NA(t)
     case ArrayRange(x, y, z) => StreamRange(x, y, z)
+    case ArrayMap(a, n, b) => ArrayMap(apply(a), n, b)
+    case ArrayFilter(a, n, b) => ArrayFilter(apply(a), n, b)
     case Let(n, v, b) => Let(n, v, apply(b))
     case ir => ToStream(ir)
   }

--- a/hail/src/main/scala/is/hail/expr/ir/Streamify.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Streamify.scala
@@ -3,73 +3,10 @@ package is.hail.expr.ir
 import is.hail.expr.types.virtual._
 
 object Streamify {
-
-  private[this] def streamify(streamableNode: IR): IR = streamableNode match {
-    case _: MakeStream | _: StreamRange | _: ReadPartition => Copy(streamableNode, Children(streamableNode).map { case c: IR => apply(c) } )
-    case ArrayRange(start, stop, step) => StreamRange(apply(start), apply(stop), apply(step))
-    case MakeArray(args, t) => MakeStream(args.map(apply), TStream(t.elementType, t.required))
-    case ArrayMap(a, n, b) =>
-      if (a.typ.isInstanceOf[TStream]) streamableNode
-      else ArrayMap(streamify(a), n, apply(b))
-    case ArrayFilter(a, n, b) =>
-      if (a.typ.isInstanceOf[TStream]) streamableNode
-      else ArrayFilter(streamify(a), n, apply(b))
-    case ArrayFlatMap(a, n, b) =>
-      if (a.typ.isInstanceOf[TStream] && b.typ.isInstanceOf[TStream]) streamableNode
-      else ArrayFlatMap(streamify(a), n, streamify(b))
-    case ArrayScan(a, zero, zn, an, body) =>
-      if (a.typ.isInstanceOf[TStream]) streamableNode
-      else ArrayScan(streamify(a), apply(zero), zn, an, apply(body))
-    case ToArray(a) =>
-      a.typ match {
-        case _: TStream => a
-        case _: TArray => streamify(a)
-        case _ => ToStream(apply(streamableNode))
-      }
-    case ToStream(a) =>
-      a.typ match {
-        case _: TStream => a
-        case _ => ToStream(apply(a))
-      }
-    case ArrayLeftJoinDistinct(l, r, ln, rn, keyf, joinf) =>
-      ArrayLeftJoinDistinct(streamify(l), streamify(r), ln, rn, apply(keyf), apply(joinf))
-    case Let(n, v, b) =>
-      Let(n, apply(v), streamify(b))
-    case _ =>
-      ToStream(Copy(streamableNode, Children(streamableNode).map { case c: IR => apply(c) } ))
-  }
-
-  private[this] def unstreamify(streamableNode: IR): IR = streamableNode match {
-    case ToArray(a) =>
-      a.typ match {
-        case _: TArray => ToArray(streamify(a))
-        case _ => streamableNode
-      }
-    case ToStream(a) =>
-      a.typ match {
-        case _: TStream => ToArray(a)
-        case _ => a
-      }
-    case If(cond, cnsq, altr) =>
-      If(cond, unstreamify(cnsq), unstreamify(altr))
-    case Let(n, v, b) =>
-      Let(n, v, unstreamify(b))
-    case _ =>
-      streamify(streamableNode) match {
-        case ToStream(a) if !a.typ.isInstanceOf[TStream] => a
-        case s => ToArray(s)
-      }
-  }
-
-  def apply(node: IR): IR = node match {
-    case ArraySort(a, l, r, comp) => ArraySort(streamify(a), l, r, comp)
-    case ToSet(a) => ToSet(streamify(a))
-    case ToDict(a) => ToDict(streamify(a))
-    case ArrayFold(a, zero, zn, an, body) => ArrayFold(streamify(a), zero, zn, an, body)
-    case ArrayFold2(a, acc, vn, seq, res) => ArrayFold2(streamify(a), acc, vn, seq, res)
-    case ArrayFor(a, n, b) => ArrayFor(streamify(a), n, b)
-    case x: ApplyIR => apply(x.explicitNode)
-    case _ if node.typ.isInstanceOf[TStreamable] => unstreamify(node)
-    case _ => Copy(node, Children(node).map { case c: IR => apply(c) })
+  def apply(ir: IR): IR = ir match {
+    case NA(t) => NA(t)
+    case ArrayRange(x, y, z) => StreamRange(x, y, z)
+    case Let(n, v, b) => Let(n, v, apply(b))
+    case ir => ToStream(ir)
   }
 }

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -1,0 +1,114 @@
+package is.hail.expr.ir
+
+import is.hail.annotations.{Region, SafeRow, ScalaToRegionValue}
+import is.hail.asm4s._
+import is.hail.asm4s.joinpoint._
+import is.hail.expr.types.physical._
+import is.hail.expr.types.virtual._
+import is.hail.utils._
+import is.hail.variant.Call2
+
+import org.apache.spark.sql.Row
+import org.scalatest.testng.TestNGSuite
+import org.testng.annotations.Test
+
+class EmitStreamSuite extends TestNGSuite {
+
+  private def compileStream(streamIR: IR, inputPType: PType): Any => IndexedSeq[Any] = {
+    val fb = EmitFunctionBuilder[Region, Long, Boolean, Long]("eval_stream")
+    val stream = EmitStream(fb, streamIR)
+    val eltPType = stream.elementType
+    fb.emit {
+      val ait = stream.toArrayIterator(fb.apply_method)
+      val arrayt = ait.toEmitTriplet(fb.apply_method, PArray(eltPType))
+      Code(arrayt.setup, arrayt.m.mux(0L, arrayt.v))
+    }
+    val f = fb.resultWithIndex()
+    ({ arg: Any => Region.scoped { r =>
+      val off =
+        if(arg == null)
+          f(0, r)(r, 0L, true)
+        else
+          f(0, r)(r, ScalaToRegionValue(r, inputPType, arg), false)
+      if(off == 0L)
+        null
+      else
+        SafeRow.read(PArray(eltPType), r, off).asInstanceOf[IndexedSeq[Any]]
+    } })
+  }
+
+  private def evalStream(streamIR: IR): IndexedSeq[Any] =
+    compileStream(streamIR, PStruct.empty())(null)
+
+  private def evalStreamLen(streamIR: IR): Option[Int] = {
+    val fb = EmitFunctionBuilder[Region, Int]("eval_stream_len")
+    val stream = EmitStream(fb, streamIR)
+    fb.emit {
+      JoinPoint.CallCC[Code[Int]] { (jb, ret) =>
+        val str = stream.stream
+        val mb = fb.apply_method
+        str.init(mb, jb, ()) {
+          case EmitStream.Missing | EmitStream.Empty => ret(0)
+          case EmitStream.Start(s0) =>
+            str.length(s0) match {
+              case Some(len) => ret(len)
+              case None => ret(-1)
+            }
+        }
+      }
+    }
+    val f = fb.resultWithIndex()
+    Region.scoped { r =>
+      val len = f(0, r)(r)
+      if(len < 0) None else Some(len)
+    }
+  }
+
+  @Test def testEmitNA() {
+    assert(evalStream(NA(TStream(TInt32()))) == null)
+  }
+
+  @Test def testEmitRange() {
+    val tripleType = PStruct(false, "start" -> PInt32(), "stop" -> PInt32(), "step" -> PInt32())
+    val triple = In(0, tripleType.virtualType)
+    val range = compileStream(
+      StreamRange(GetField(triple, "start"), GetField(triple, "stop"), GetField(triple, "step")),
+      tripleType)
+    for {
+      start <- -2 to 2
+      stop <- -2 to 8
+      step <- 1 to 3
+    } {
+      assert(range(Row(start, stop, step)) == Array.range(start, stop, step).toFastIndexedSeq,
+        s"($start, $stop, $step)")
+    }
+    assert(range(Row(null, 10, 1)) == null)
+    assert(range(Row(0, null, 1)) == null)
+    assert(range(Row(0, 10, null)) == null)
+    assert(range(null) == null)
+  }
+
+  @Test def testEmitToStream() {
+    val tests: Array[(IR, IndexedSeq[Any])] = Array(
+      ToStream(MakeArray(Seq[IR](), TArray(TInt32()))) -> IndexedSeq(),
+      ToStream(MakeArray(Seq[IR](1, 2, 3, 4), TArray(TInt32()))) -> IndexedSeq(1, 2, 3, 4),
+      ToStream(NA(TArray(TInt32()))) -> null
+    )
+    for ((ir, v) <- tests) {
+      val expectedLen = Some(if(v == null) 0 else v.length)
+      assert(evalStream(ir) == v, Pretty(ir))
+      assert(evalStreamLen(ir) == expectedLen, Pretty(ir))
+    }
+  }
+
+  @Test def testEmitLet() {
+    val Seq(start, end, i) = Seq("start", "end", "i").map(Ref(_, TInt32()))
+    val ir =
+      Let("end", 10,
+        Let("start", 3,
+          StreamRange(start, end, 1))
+      )
+    assert(evalStream(ir) == (3 until 10).toIndexedSeq, Pretty(ir))
+    assert(evalStreamLen(ir) == Some(10 - 3), Pretty(ir))
+  }
+}

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -68,6 +68,23 @@ class EmitStreamSuite extends TestNGSuite {
     assert(evalStream(NA(TStream(TInt32()))) == null)
   }
 
+  @Test def testEmitMake() {
+    val x = Ref("x", TInt32())
+    val typ = TStream(TInt32())
+    val tests: Array[(IR, IndexedSeq[Any])] = Array(
+      MakeStream(Seq[IR](1, 2, NA(TInt32()), 3), typ) -> IndexedSeq(1, 2, null, 3),
+      MakeStream(Seq[IR](), typ) -> IndexedSeq(),
+      MakeStream(Seq[IR](MakeTuple.ordered(Seq(4, 5))), TStream(TTuple(TInt32(), TInt32()))) ->
+        IndexedSeq(Row(4, 5)),
+      MakeStream(Seq[IR](Str("hi"), Str("world")), TStream(TString())) ->
+        IndexedSeq("hi", "world")
+    )
+    for ((ir, v) <- tests) {
+      assert(evalStream(ir) == v, Pretty(ir))
+      assert(evalStreamLen(ir) == Some(v.length), Pretty(ir))
+    }
+  }
+
   @Test def testEmitRange() {
     val tripleType = PStruct(false, "start" -> PInt32(), "stop" -> PInt32(), "step" -> PInt32())
     val triple = In(0, tripleType.virtualType)

--- a/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/EmitStreamSuite.scala
@@ -48,7 +48,7 @@ class EmitStreamSuite extends TestNGSuite {
         val str = stream.stream
         val mb = fb.apply_method
         str.init(mb, jb, ()) {
-          case EmitStream.Missing | EmitStream.Empty => ret(0)
+          case EmitStream.Missing => ret(0)
           case EmitStream.Start(s0) =>
             str.length(s0) match {
               case Some(len) => ret(len)


### PR DESCRIPTION
- [x] ~~Stacked on #7207 (needed for `MakeArray`)~~

Implements a new interface `EmitStream` for staged "pull" based streams. This design differs significantly from the current `ArrayIteratorTriplet` design; such "push" based streams are incapable of deforested operations that operate on multiple sub-streams, notably joins or zips.

A (pull) stream has an internal state, which can be used to generate new elements by a `step` operation. This state is initialized by passing an initial parameter to an `init` operation, which will determine the initial state. You can think of a stream as allowing elements to be computed "on-demand", as opposed to the old design where the entire stream is consumed at once.

This PR just contains the most simple streams (`ArrayRange`, `MakeArray`, `ArrayMap`, `ArrayFilter`). I'd like to get comments on it before merging my other stream implementations. So far I have all of the other streams implemented, except for `ReadPartition` and `If` (it turns out that `If` is tricky).

**Interface**

`init` can return in two possible ways:
- `Missing` - the stream is actually entirely missing; this usually happens if one of the parameters to a stream is missing (e.g. `ArrayRange(0, NA, 1) = NA`)
- `State(s0)` - the stream has started; its initial state is `s0`.

`step` can return in three possible ways as well:
- `EOS` - we've reached the End Of Stream, there are no more elements left.
- `Skip(s1)` - this iteration didn't produce an element, you must try stepping again with state `s1` (see "design notes").
- `Yield(elt, s1)` - the stream computed an element `elt`; the following stream state will be `s1`.

**Design Notes**

- The `Skip` return is very useful for simplifying the implementation of `ArrayFilter`. There is basically no nice way to implement filter otherwise without introducing some significant code duplication.
- ~~The stream "parameter", as well as the `Empty` return, are not very useful for the basic streams in this PR. However, they simplify the implementation of `ArrayFlatMap` (aka "composing" two parameterized streams).~~ NOTE (to Patrick): I decided to abandon the "empty" return idea in favor of just providing "default states" that always yield empty streams.

**Implementation Notes**

- The implementation makes great use of Scala's type system. Most of the streams are implemented first in a very type aware manner, where it is easy to reason about the types of data flowing in and out, before being instantiated with EmitTriplets and Envs which don't hold very much type information. For instance, we have the following helper for `map`:
    ```scala
    Parameterized[P, A].map(f: A => B): Parameterized[P, B]
    ```
  The emitter instantiates P = `Any`, A = `EmitTriplet`, B = `EmitTriplet` :/

- Complex streams will have non trivial control flow and jumps. Therefore `init` and `step` both take `JoinPointBuilder`s and return `Code[Ctrl]`, to indicate that they may create join points and do jumps.

- I've utilized a cute continuation passing style trick in multiple functions. Instead of `init` "returning" `Missing`/`Start(s0)` (which is impossible, since these are compile time data structures; they won't exist during JVM runtime), init takes a continuation `k: Init[S] => Code[Ctrl]`, which it must call with one of these values. To use `init`, you can simply provide a pattern matching lambda, which closely resembles the syntax you would normally use to pattern match on a returned value, e.g. (from `contMap`):
    ```scala
    self.init(mb, jb, param) {
      case Missing => k(Missing)
      case Start(s) => Code(setup, k(Start(s)))
    }
    ```
    This technique actually cleans up the implementation significantly, especially moving forward to more complicated streams.