### PR TITLE
[docs] fixes scrollto section

### DIFF
--- a/hail/python/hail/docs/_static/rtd_modifications.css
+++ b/hail/python/hail/docs/_static/rtd_modifications.css
@@ -1,6 +1,18 @@
 /* color on hail.is: #444 */
 /* border-color on hail.is: #ddd */
 /* background-color on hail.is: #fff */
+.section>.section,
+.section:first-of-type {
+  margin-top: -51px;
+}
+
+.section:before {
+  height: 51px;
+  content: "";
+  display: block;
+}
+
+
 .wy-nav-content {
   max-width: 1140px !important;
   background-color: #fff;
@@ -9,6 +21,7 @@
 .wy-nav-content-wrap {
   background-color: #fff;
 }
+
 .wy-grid-for-nav {
   top: 51px;
 }
@@ -91,6 +104,7 @@ hr {
 }
 
 @media screen and (max-width: 768px) {
+
   /* Nav is absolutely broken on mobile and we already have breadcrumbs */
   .wy-nav-top {
     display: none;

--- a/hail/python/hail/docs/_static/rtd_modifications.css
+++ b/hail/python/hail/docs/_static/rtd_modifications.css
@@ -2,7 +2,8 @@
 /* border-color on hail.is: #ddd */
 /* background-color on hail.is: #fff */
 .section>.section,
-.section:first-of-type {
+.section:first-of-type,
+.section+.section {
   margin-top: -51px;
 }
 


### PR DESCRIPTION
There may be a more elegant way of doing this. I would like to remake doc styles at some point, post ASHG. (fyi @cseed). I think needed for workshop. Docs should work.

Before:
<img width="967" alt="Screenshot 2019-10-09 18 30 23" src="https://user-images.githubusercontent.com/5543229/66525321-1b5b4780-eac3-11e9-833f-664f1d479b56.png">


After:
<img width="963" alt="Screenshot 2019-10-09 18 30 17" src="https://user-images.githubusercontent.com/5543229/66525339-2ca45400-eac3-11e9-9458-d97c4ffbea7a.png">
