### PR TITLE
[hail] compare bytes before strings in locus ordering

### DIFF
--- a/hail/src/main/scala/is/hail/expr/types/physical/PLocus.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PLocus.scala
@@ -1,7 +1,7 @@
 package is.hail.expr.types.physical
 
 import is.hail.annotations._
-import is.hail.asm4s.Code
+import is.hail.asm4s.{Code, coerce}
 import is.hail.backend.BroadcastValue
 import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.expr.types.virtual.TLocus
@@ -43,22 +43,22 @@ case class PLocus(rgBc: BroadcastRG, override val required: Boolean = false) ext
     val repr = representation.fundamentalType
 
     val localRGBc = rgBc
+    val binaryOrd = repr.fieldType("contig").asInstanceOf[PBinary].unsafeOrdering()
 
     new UnsafeOrdering {
       def compare(r1: Region, o1: Long, r2: Region, o2: Long): Int = {
         val cOff1 = repr.loadField(r1, o1, 0)
         val cOff2 = repr.loadField(r2, o2, 0)
 
-        val contig1 = PString.loadString(r1, cOff1)
-        val contig2 = PString.loadString(r2, cOff2)
-
-        val c = localRGBc.value.compare(contig1, contig2)
-        if (c != 0)
-          return c
-
-        val posOff1 = repr.loadField(r1, o1, 1)
-        val posOff2 = repr.loadField(r2, o2, 1)
-        java.lang.Integer.compare(Region.loadInt(posOff1), Region.loadInt(posOff2))
+        if (binaryOrd.compare(r1, cOff1, r2, cOff2) == 0) {
+          val posOff1 = repr.loadField(r1, o1, 1)
+          val posOff2 = repr.loadField(r2, o2, 1)
+          java.lang.Integer.compare(Region.loadInt(posOff1), Region.loadInt(posOff2))
+        } else {
+          val contig1 = PString.loadString(r1, cOff1)
+          val contig2 = PString.loadString(r2, cOff2)
+          localRGBc.value.compare(contig1, contig2)
+        }
       }
     }
   }
@@ -67,12 +67,12 @@ case class PLocus(rgBc: BroadcastRG, override val required: Boolean = false) ext
     assert(other isOfType this)
     new CodeOrdering {
       type T = Long
+      val contigBin = representation.fundamentalType.fieldType("contig").asInstanceOf[PBinary]
+      val bincmp = contigBin.codeOrdering(mb)
 
       override def compareNonnull(x: Code[Long], y: Code[Long]): Code[Int] = {
-        val cmp = mb.newLocal[Int]
-
-        val c1 = representation.loadField(x, 0)
-        val c2 = representation.loadField(y, 0)
+        val c1 = mb.newLocal[Long]("c1")
+        val c2 = mb.newLocal[Long]("c2")
 
         val s1 = PString.loadString(c1)
         val s2 = PString.loadString(c2)
@@ -80,13 +80,15 @@ case class PLocus(rgBc: BroadcastRG, override val required: Boolean = false) ext
         val p1 = Region.loadInt(representation.fieldOffset(x, 1))
         val p2 = Region.loadInt(representation.fieldOffset(y, 1))
 
+        val cmp = bincmp.compareNonnull(coerce[bincmp.T](c1), coerce[bincmp.T](c2))
         val codeRG = mb.getReferenceGenome(rg.asInstanceOf[ReferenceGenome])
 
         Code(
-          cmp := codeRG.invoke[String, String, Int]("compare", s1, s2),
+          c1 := representation.loadField(x, 0),
+          c2 := representation.loadField(y, 0),
           cmp.ceq(0).mux(
             Code.invokeStatic[java.lang.Integer, Int, Int, Int]("compare", p1, p2),
-            cmp))
+            codeRG.invoke[String, String, Int]("compare", s1, s2)))
       }
     }
   }


### PR DESCRIPTION
New algorithm:
    Check the bytes of the contig string
    If equal, compare the positions
    Otherwise, use the contig ordering