### PR TITLE
[hail] thread execute context through RVD

### DIFF
--- a/hail/src/main/scala/is/hail/HailContext.scala
+++ b/hail/src/main/scala/is/hail/HailContext.scala
@@ -9,7 +9,7 @@ import is.hail.backend.distributed.DistributedBackend
 import is.hail.backend.spark.SparkBackend
 import is.hail.expr.ir
 import is.hail.expr.ir.functions.IRFunctionRegistry
-import is.hail.expr.ir.{BaseIR, TextTableReader}
+import is.hail.expr.ir.{BaseIR, TextTableReader, ExecuteContext}
 import is.hail.expr.types.physical.PStruct
 import is.hail.expr.types.virtual._
 import is.hail.io.bgen.IndexBgen
@@ -671,7 +671,9 @@ class HailContext private(
     rg: Option[String] = None,
     contigRecoding: Map[String, String] = Map.empty[String, String],
     skipInvalidLoci: Boolean = false) {
-    IndexBgen(this, files.toArray, indexFileMap, rg, contigRecoding, skipInvalidLoci)
+    ExecuteContext.scoped { ctx =>
+      IndexBgen(this, files.toArray, indexFileMap, rg, contigRecoding, skipInvalidLoci, ctx)
+    }
     info(s"Number of BGEN files indexed: ${ files.length }")
   }
 

--- a/hail/src/main/scala/is/hail/compatibility/LegacyRVDSpecs.scala
+++ b/hail/src/main/scala/is/hail/compatibility/LegacyRVDSpecs.scala
@@ -2,6 +2,7 @@ package is.hail.compatibility
 
 import is.hail.HailContext
 import is.hail.expr.JSONAnnotationImpex
+import is.hail.expr.ir.ExecuteContext
 import is.hail.expr.types.encoded._
 import is.hail.expr.types.virtual._
 import is.hail.io._
@@ -82,7 +83,14 @@ trait ShimRVDSpec extends AbstractRVDSpec {
 
   override def partitioner: RVDPartitioner = shim.partitioner
 
-  override def read(hc: HailContext, path: String, requestedType: TStruct, newPartitioner: Option[RVDPartitioner], filterIntervals: Boolean): RVD = shim.read(hc, path, requestedType, newPartitioner, filterIntervals)
+  override def read(
+    hc: HailContext,
+    path: String,
+    requestedType: TStruct,
+    ctx: ExecuteContext,
+    newPartitioner: Option[RVDPartitioner],
+    filterIntervals: Boolean
+  ): RVD = shim.read(hc, path, requestedType, ctx, newPartitioner, filterIntervals)
 
   override def typedCodecSpec: AbstractTypedCodecSpec = shim.typedCodecSpec
 

--- a/hail/src/main/scala/is/hail/expr/ir/ExecuteContext.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ExecuteContext.scala
@@ -1,13 +1,24 @@
 package is.hail.expr.ir
 
+import is.hail.utils._
 import is.hail.annotations.Region
+import scala.collection.mutable.ArrayBuffer
 
 object ExecuteContext {
   def scoped[T](f: ExecuteContext => T): T = {
     Region.scoped { r =>
-      f(ExecuteContext(r))
+      using(ExecuteContext(r))(f)
     }
   }
 }
 
-case class ExecuteContext(r: Region)
+case class ExecuteContext(r: Region) extends AutoCloseable {
+  private[this] val onExits = new ArrayBuffer[() => Unit]()
+  def addOnExit(onExit: () => Unit): Unit = {
+    onExits += onExit
+  }
+
+  def close(): Unit = {
+    onExits.foreach(_())
+  }
+}

--- a/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableIR.scala
@@ -1458,7 +1458,7 @@ case class TableKeyByAndAggregate(
 
         return prev.copy(
           typ = typ,
-          rvd = RVD.coerce(RVDType(newRowType, keyType.fieldNames), crdd))
+          rvd = RVD.coerce(RVDType(newRowType, keyType.fieldNames), crdd, ctx))
       } catch {
         case e: agg.UnsupportedExtraction =>
           log.info(s"couldn't lower TableKeyByAndAggregate: $e")
@@ -1629,7 +1629,7 @@ case class TableAggregateByKey(child: TableIR, expr: IR) extends TableIR {
         val newRVDType = prevRVD.typ.copy(rowType = rowType)
 
         val newRVD = prevRVD
-          .repartition(prevRVD.partitioner.strictify)
+          .repartition(prevRVD.partitioner.strictify, ctx)
           .boundary
           .mapPartitionsWithIndex(newRVDType, { (i, ctx, it) =>
             val partRegion = ctx.freshRegion

--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -22,14 +22,14 @@ object TableValue {
     val tt = TableType(rowType.virtualType, key, TStruct.empty())
     TableValue(tt,
       BroadcastRow.empty(ctx),
-      RVD.coerce(RVDType(rowType, key), rdd))
+      RVD.coerce(RVDType(rowType, key), rdd, ctx))
   }
 
   def apply(ctx: ExecuteContext, rowType: TStruct, key: IndexedSeq[String], rdd: ContextRDD[RVDContext, RegionValue]): TableValue = {
     val tt = TableType(rowType, key, TStruct.empty())
     TableValue(tt,
         BroadcastRow.empty(ctx),
-        RVD.coerce(tt.canonicalRVDType, rdd))
+        RVD.coerce(tt.canonicalRVDType, rdd, ctx))
   }
 
   def apply(ctx: ExecuteContext, rowType:  TStruct, key: IndexedSeq[String], rdd: RDD[Row]): TableValue = {
@@ -37,7 +37,10 @@ object TableValue {
     val tt = TableType(rowType, key, TStruct.empty())
     TableValue(tt,
       BroadcastRow.empty(ctx),
-      RVD.coerce(RVDType(canonicalRowType, key), ContextRDD.weaken[RVDContext](rdd).toRegionValues(canonicalRowType)))
+      RVD.coerce(
+        RVDType(canonicalRowType, key),
+        ContextRDD.weaken[RVDContext](rdd).toRegionValues(canonicalRowType),
+        ctx))
   }
 }
 

--- a/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
@@ -41,7 +41,9 @@ object IndexBgen {
     indexFileMap: Map[String, String] = null,
     rg: Option[String] = None,
     contigRecoding: Map[String, String] = null,
-    skipInvalidLoci: Boolean = false) {
+    skipInvalidLoci: Boolean = false,
+    ctx: ExecuteContext
+  ) {
     val fs = hc.sFS
     val bcFS = hc.bcFS
 
@@ -115,7 +117,7 @@ object IndexBgen {
     val intEnc = intCodec.buildEncoder(intPType)
 
     RVD.unkeyed(rowType, crvd)
-      .repartition(partitioner, shuffle = true)
+      .repartition(partitioner, ctx, shuffle = true)
       .toRows
       .foreachPartition { it =>
         val partIdx = TaskContext.get.partitionId()

--- a/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
+++ b/hail/src/main/scala/is/hail/io/bgen/IndexBgen.scala
@@ -1,6 +1,7 @@
 package is.hail.io.bgen
 
 import is.hail.HailContext
+import is.hail.expr.ir.ExecuteContext
 import is.hail.expr.types.TableType
 import is.hail.expr.types.physical.PStruct
 import is.hail.expr.types.virtual._

--- a/hail/src/main/scala/is/hail/io/gen/LoadGen.scala
+++ b/hail/src/main/scala/is/hail/io/gen/LoadGen.scala
@@ -192,7 +192,8 @@ case class MatrixGENReader(
     val gpType = requestedEntryType.fieldOption("GP").map(_.typ)
 
     val localRVDType = tr.typ.canonicalRVDType
-    val rvd = RVD.coerce(localRVDType,
+    val rvd = RVD.coerce(
+      localRVDType,
       ContextRDD.weaken[RVDContext](rdd).cmapPartitions { (ctx, it) =>
         val region = ctx.region
         val rvb = new RegionValueBuilder(region)
@@ -225,7 +226,8 @@ case class MatrixGENReader(
           rv.setOffset(rvb.end())
           rv
         }
-      })
+      },
+      ctx)
 
     val globalValue = makeGlobalValue(ctx, requestedType, samples.map(Row(_)))
 

--- a/hail/src/main/scala/is/hail/io/plink/ExportPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/ExportPlink.scala
@@ -1,5 +1,6 @@
 package is.hail.io.plink
 
+import is.hail.expr.ir.ExecuteContext
 import java.io.{OutputStream, OutputStreamWriter}
 
 import is.hail.HailContext
@@ -116,7 +117,9 @@ object ExportPlink {
     fs.writeTextFile(tmpBimDir + "/_SUCCESS")(out => ())
     fs.copyMerge(tmpBimDir, path + ".bim", nPartitions, header = false, partFilesOpt = Some(partFiles))
 
-    mv.colsTableValue.export(path + ".fam", header = false)
+    ExecuteContext.scoped { ctx =>
+      mv.colsTableValue(ctx).export(path + ".fam", header = false)
+    }
 
     info(s"wrote $nRecordsWritten variants and $nSamples samples to '$path'")
   }

--- a/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
+++ b/hail/src/main/scala/is/hail/io/plink/LoadPlink.scala
@@ -282,7 +282,7 @@ case class MatrixPLINKReader(
         }
       }
 
-      RVD.coerce(requestedType.canonicalRVDType, rdd2, fastKeys)
+      RVD.coerce(requestedType.canonicalRVDType, rdd2, fastKeys, ctx)
     }
 
     if (skipInvalidLoci && referenceGenome.isDefined) {

--- a/hail/src/main/scala/is/hail/methods/PCA.scala
+++ b/hail/src/main/scala/is/hail/methods/PCA.scala
@@ -90,7 +90,7 @@ case class PCA(entryField: String, k: Int, computeLoadings: Boolean) extends Mat
       }
     } else
       ContextRDD.empty(sc)
-    val rvd = RVD.coerce(RVDType(rowType, mv.typ.rowKey), crdd)
+    val rvd = RVD.coerce(RVDType(rowType, mv.typ.rowKey), crdd, ctx)
 
     val (t1, f1) = mv.typ.globalType.insert(TArray(TFloat64()), "eigenvalues")
     val (globalScoreType, f3) = mv.typ.colKeyStruct.insert(TArray(TFloat64()), "scores")

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -2,6 +2,7 @@ package is.hail.rvd
 
 import is.hail.annotations._
 import is.hail.expr.JSONAnnotationImpex
+import is.hail.expr.ir.ExecuteContext
 import is.hail.expr.types.encoded.ETypeSerializer
 import is.hail.expr.types.physical.{PInt64Optional, PInt64Required, PStruct, PType, PTypeSerializer}
 import is.hail.expr.types.virtual.{TStructSerializer, _}
@@ -118,7 +119,8 @@ object AbstractRVDSpec {
     requestedTypeLeft: TStruct,
     requestedTypeRight: TStruct,
     newPartitioner: Option[RVDPartitioner],
-    filterIntervals: Boolean
+    filterIntervals: Boolean,
+    ctx: ExecuteContext
   ): RVD = {
     require(specRight.key.isEmpty)
     require(requestedType == requestedTypeLeft ++ requestedTypeRight)
@@ -143,7 +145,7 @@ object AbstractRVDSpec {
     assert(t.virtualType == requestedType)
     val tmprvd = RVD(RVDType(t, requestedKey), tmpPartitioner.coarsen(requestedKey.length), crdd)
     newPartitioner match {
-      case Some(part) if !filterIntervals => tmprvd.repartition(part.coarsen(requestedKey.length))
+      case Some(part) if !filterIntervals => tmprvd.repartition(part.coarsen(requestedKey.length), ctx)
       case _ => tmprvd
     }
   }
@@ -172,6 +174,7 @@ abstract class AbstractRVDSpec {
     hc: HailContext,
     path: String,
     requestedType: TStruct,
+    ctx: ExecuteContext,
     newPartitioner: Option[RVDPartitioner] = None,
     filterIntervals: Boolean = false
   ): RVD = newPartitioner match {
@@ -328,6 +331,7 @@ case class IndexedRVDSpec2(_key: IndexedSeq[String],
     hc: HailContext,
     path: String,
     requestedType: TStruct,
+    ctx: ExecuteContext,
     newPartitioner: Option[RVDPartitioner] = None,
     filterIntervals: Boolean = false
   ): RVD = {
@@ -346,10 +350,10 @@ case class IndexedRVDSpec2(_key: IndexedSeq[String],
         if (filterIntervals)
           tmprvd
         else
-          tmprvd.repartition(np.coarsen(requestedKey.length))
+          tmprvd.repartition(np.coarsen(requestedKey.length), ctx)
       case None =>
         // indexed reads are costly; don't use an indexed read when possible
-        super.read(hc, path, requestedType, None, filterIntervals)
+        super.read(hc, path, requestedType, ctx, None, filterIntervals)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -13,6 +13,7 @@ import is.hail.io.index.IndexWriter
 import is.hail.io.{BufferSpec, AbstractTypedCodecSpec, TypedCodecSpec, RichContextRDDRegionValue}
 import is.hail.sparkextras._
 import is.hail.utils._
+import is.hail.expr.ir.ExecuteContext
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.TaskContext
 import org.apache.spark.rdd.{RDD, ShuffledRDD}
@@ -109,7 +110,11 @@ class RVD(
   }
 
   // Return an OrderedRVD whose key equals or at least starts with 'newKey'.
-  def enforceKey(newKey: IndexedSeq[String], isSorted: Boolean = false): RVD = {
+  def enforceKey(
+    newKey: IndexedSeq[String],
+    executeContext: ExecuteContext,
+    isSorted: Boolean = false
+  ): RVD = {
     require(newKey.forall(rowType.hasField))
     val nPreservedFields = typ.key.zip(newKey).takeWhile { case (l, r) => l == r }.length
     require(!isSorted || nPreservedFields > 0 || newKey.isEmpty)
@@ -117,19 +122,31 @@ class RVD(
     if (nPreservedFields == newKey.length)
       this
     else if (isSorted)
-      truncateKey(newKey.take(nPreservedFields)).extendKeyPreservesPartitioning(newKey).checkKeyOrdering()
+      truncateKey(newKey.take(nPreservedFields)
+      ).extendKeyPreservesPartitioning(newKey, executeContext
+      ).checkKeyOrdering()
     else
-      changeKey(newKey)
+      changeKey(newKey, executeContext)
   }
 
   // Key and partitioner manipulation
-  def changeKey(newKey: IndexedSeq[String]): RVD =
-    changeKey(newKey, newKey.length)
+  def changeKey(
+    newKey: IndexedSeq[String],
+    executeContext: ExecuteContext
+  ): RVD =
+    changeKey(newKey, newKey.length, executeContext)
 
-  def changeKey(newKey: IndexedSeq[String], partitionKey: Int): RVD =
-    RVD.coerce(typ.copy(key = newKey), partitionKey, this.crdd)
+  def changeKey(
+    newKey: IndexedSeq[String],
+    partitionKey: Int,
+    executeContext: ExecuteContext
+  ): RVD =
+    RVD.coerce(typ.copy(key = newKey), partitionKey, this.crdd, executeContext)
 
-  def extendKeyPreservesPartitioning(newKey: IndexedSeq[String]): RVD = {
+  def extendKeyPreservesPartitioning(
+    newKey: IndexedSeq[String],
+    executeContext: ExecuteContext
+  ): RVD = {
     require(newKey startsWith typ.key)
     require(newKey.forall(typ.rowType.fieldNames.contains))
     val rvdType = typ.copy(key = newKey)
@@ -137,7 +154,7 @@ class RVD(
       copy(typ = rvdType, partitioner = partitioner.copy(kType = rvdType.kType.virtualType))
     else {
       val adjustedPartitioner = partitioner.strictify
-      repartition(adjustedPartitioner)
+      repartition(adjustedPartitioner, executeContext)
         .copy(typ = rvdType, partitioner = adjustedPartitioner.copy(kType = rvdType.kType.virtualType))
     }
   }
@@ -215,6 +232,7 @@ class RVD(
   // WARNING: will drop any data with keys falling outside 'partitioner'.
   def repartition(
     newPartitioner: RVDPartitioner,
+    executeContext: ExecuteContext,
     shuffle: Boolean = false,
     filter: Boolean = true
   ): RVD = {
@@ -258,7 +276,10 @@ class RVD(
     }
   }
 
-  def naiveCoalesce(maxPartitions: Int): RVD = {
+  def naiveCoalesce(
+    maxPartitions: Int,
+    executeContext: ExecuteContext
+  ): RVD = {
     val n = partitioner.numPartitions
     if (maxPartitions >= n)
       return this
@@ -267,10 +288,14 @@ class RVD(
     val newNParts = partition(n, newN)
     assert(newNParts.forall(_ > 0))
     val newPartitioner = partitioner.coalesceRangeBounds(newNParts.scanLeft(-1)(_ + _).tail)
-    repartition(newPartitioner)
+    repartition(newPartitioner, executeContext)
   }
 
-  def coalesce(maxPartitions: Int, shuffle: Boolean): RVD = {
+  def coalesce(
+    maxPartitions: Int,
+    executeContext: ExecuteContext,
+    shuffle: Boolean
+  ): RVD = {
     require(maxPartitions > 0, "cannot coalesce to nPartitions <= 0")
     val n = crdd.partitions.length
     if (!shuffle && maxPartitions >= n)
@@ -322,14 +347,14 @@ class RVD(
       warn(s"coalesced to ${ newPartitioner.numPartitions} " +
         s"${ plural(newPartitioner.numPartitions, "partition") }, less than requested $maxPartitions")
 
-    repartition(newPartitioner, shuffle)
+    repartition(newPartitioner, executeContext, shuffle)
   }
 
   // Key-wise operations
 
-  def distinctByKey(): RVD = {
+  def distinctByKey(executeContext: ExecuteContext): RVD = {
     val localType = typ
-    repartition(partitioner.strictify)
+    repartition(partitioner.strictify, executeContext)
       .mapPartitions(typ, (ctx, it) =>
         OrderedRVIterator(localType, it, ctx)
           .staircase
@@ -930,18 +955,20 @@ class RVD(
     right: RVD,
     joinType: String,
     joiner: (RVDContext, Iterator[JoinedRegionValue]) => Iterator[RegionValue],
-    joinedType: RVDType
+    joinedType: RVDType,
+    ctx: ExecuteContext
   ): RVD =
-    orderedJoin(right, typ.key.length, joinType, joiner, joinedType)
+    orderedJoin(right, typ.key.length, joinType, joiner, joinedType, ctx)
 
   def orderedJoin(
     right: RVD,
     joinKey: Int,
     joinType: String,
     joiner: (RVDContext, Iterator[JoinedRegionValue]) => Iterator[RegionValue],
-    joinedType: RVDType
+    joinedType: RVDType,
+    ctx: ExecuteContext
   ): RVD =
-    keyBy(joinKey).orderedJoin(right.keyBy(joinKey), joinType, joiner, joinedType)
+    keyBy(joinKey).orderedJoin(right.keyBy(joinKey), joinType, joiner, joinedType, ctx)
 
   def orderedJoinDistinct(
     right: RVD,
@@ -972,24 +999,36 @@ class RVD(
   ): RVD =
     keyBy(1).orderedLeftIntervalJoinDistinct(right.keyBy(1), joiner)
 
-  def orderedZipJoin(right: RVD): (RVDPartitioner, ContextRDD[RVDContext, JoinedRegionValue]) =
-    orderedZipJoin(right, typ.key.length)
+  def orderedZipJoin(
+    right: RVD,
+    ctx: ExecuteContext
+  ): (RVDPartitioner, ContextRDD[RVDContext, JoinedRegionValue]) =
+    orderedZipJoin(right, typ.key.length, ctx)
 
-  def orderedZipJoin(right: RVD, joinKey: Int): (RVDPartitioner, ContextRDD[RVDContext, JoinedRegionValue]) =
-    keyBy(joinKey).orderedZipJoin(right.keyBy(joinKey))
+  def orderedZipJoin(
+    right: RVD,
+    joinKey: Int,
+    ctx: ExecuteContext
+  ): (RVDPartitioner, ContextRDD[RVDContext, JoinedRegionValue]) =
+    keyBy(joinKey).orderedZipJoin(right.keyBy(joinKey), ctx)
 
   def orderedZipJoin(
     right: RVD,
     joinKey: Int,
     joiner: (RVDContext, Iterator[JoinedRegionValue]) => Iterator[RegionValue],
-    joinedType: RVDType
+    joinedType: RVDType,
+    ctx: ExecuteContext
   ): RVD = {
-    val (joinedPartitioner, jcrdd) = orderedZipJoin(right, joinKey)
+    val (joinedPartitioner, jcrdd) = orderedZipJoin(right, joinKey, ctx)
     RVD(joinedType, joinedPartitioner, jcrdd.cmapPartitions(joiner))
   }
 
-  def orderedMerge(right: RVD, joinKey: Int): RVD =
-    keyBy(joinKey).orderedMerge(right.keyBy(joinKey))
+  def orderedMerge(
+    right: RVD,
+    joinKey: Int,
+    ctx: ExecuteContext
+  ): RVD =
+    keyBy(joinKey).orderedMerge(right.keyBy(joinKey), ctx)
 
   def partitionSortedUnion(rdd2: RVD): RVD = {
     assert(typ == rdd2.typ)
@@ -1245,44 +1284,50 @@ object RVD {
 
   def coerce(
     typ: RVDType,
-    crdd: ContextRDD[RVDContext, RegionValue]
-  ): RVD = coerce(typ, typ.key.length, crdd)
+    crdd: ContextRDD[RVDContext, RegionValue],
+    executeContext: ExecuteContext
+  ): RVD = coerce(typ, typ.key.length, crdd, executeContext)
 
   def coerce(
     typ: RVDType,
     crdd: ContextRDD[RVDContext, RegionValue],
-    fastKeys: ContextRDD[RVDContext, RegionValue]
-  ): RVD = coerce(typ, typ.key.length, crdd, fastKeys)
+    fastKeys: ContextRDD[RVDContext, RegionValue],
+    executeContext: ExecuteContext
+  ): RVD = coerce(typ, typ.key.length, crdd, fastKeys, executeContext)
 
   def coerce(
     typ: RVDType,
     partitionKey: Int,
-    crdd: ContextRDD[RVDContext, RegionValue]
+    crdd: ContextRDD[RVDContext, RegionValue],
+    executeContext: ExecuteContext
   ): RVD = {
     val keys = getKeys(typ, crdd)
-    makeCoercer(typ, partitionKey, keys).coerce(typ, crdd)
+    makeCoercer(typ, partitionKey, keys, executeContext).coerce(typ, crdd)
   }
 
   def coerce(
     typ: RVDType,
     partitionKey: Int,
     crdd: ContextRDD[RVDContext, RegionValue],
-    keys: ContextRDD[RVDContext, RegionValue]
+    keys: ContextRDD[RVDContext, RegionValue],
+    executeContext: ExecuteContext
   ): RVD = {
-    makeCoercer(typ, partitionKey, keys).coerce(typ, crdd)
+    makeCoercer(typ, partitionKey, keys, executeContext).coerce(typ, crdd)
   }
 
   def makeCoercer(
     fullType: RVDType,
     // keys: RDD[RegionValue[fullType.kType]]
-    keys: ContextRDD[RVDContext, RegionValue]
-  ): RVDCoercer = makeCoercer(fullType, fullType.key.length, keys)
+    keys: ContextRDD[RVDContext, RegionValue],
+    executeContext: ExecuteContext
+  ): RVDCoercer = makeCoercer(fullType, fullType.key.length, keys, executeContext)
 
   def makeCoercer(
     fullType: RVDType,
     partitionKey: Int,
     // keys: RDD[RegionValue[fullType.kType]]
-    keys: ContextRDD[RVDContext, RegionValue]
+    keys: ContextRDD[RVDContext, RegionValue],
+    executeContext: ExecuteContext
   ): RVDCoercer = {
     type CRDD = ContextRDD[RVDContext, RegionValue]
     val sc = keys.sparkContext
@@ -1340,7 +1385,7 @@ object RVD {
 
         def _coerce(typ: RVDType, crdd: CRDD): RVD = {
           RVD(typ, unfixedPartitioner, orderPartitions(crdd))
-            .repartition(newPartitioner, shuffle = false)
+            .repartition(newPartitioner, executeContext, shuffle = false)
         }
       }
 
@@ -1366,7 +1411,7 @@ object RVD {
             typ.copy(key = typ.key.take(partitionKey)),
             unfixedPartitioner,
             orderPartitions(crdd)
-          ).repartition(newPartitioner, shuffle = false)
+          ).repartition(newPartitioner, executeContext, shuffle = false)
             .localSort(typ.key)
         }
       }
@@ -1382,7 +1427,7 @@ object RVD {
 
         def _coerce(typ: RVDType, crdd: CRDD): RVD = {
           RVD.unkeyed(typ.rowType, crdd)
-            .repartition(newPartitioner, shuffle = true, filter = false)
+            .repartition(newPartitioner, executeContext, shuffle = true, filter = false)
         }
       }
     }
@@ -1416,7 +1461,11 @@ object RVD {
       return new RVD(typ, partitioner, crdd).checkKeyOrdering()
   }
 
-  def union(rvds: Seq[RVD], joinKey: Int): RVD = rvds match {
+  def union(
+    rvds: Seq[RVD],
+    joinKey: Int,
+    ctx: ExecuteContext
+  ): RVD = rvds match {
     case Seq(x) => x
     case first +: _ =>
       assert(rvds.forall(_.rowPType == first.rowPType))
@@ -1424,11 +1473,14 @@ object RVD {
         val sc = first.sparkContext
         RVD.unkeyed(first.rowPType, ContextRDD.union(sc, rvds.map(_.crdd)))
       } else
-        rvds.toArray.treeReduce(_.orderedMerge(_, joinKey))
+        rvds.toArray.treeReduce(_.orderedMerge(_, joinKey, ctx))
   }
 
-  def union(rvds: Seq[RVD]): RVD =
-    union(rvds, rvds.head.typ.key.length)
+  def union(
+    rvds: Seq[RVD],
+    ctx: ExecuteContext
+  ): RVD =
+    union(rvds, rvds.head.typ.key.length, ctx)
 
   def writeRowsSplitFiles(
     rvds: IndexedSeq[RVD],

--- a/hail/src/main/scala/is/hail/table/Table.scala
+++ b/hail/src/main/scala/is/hail/table/Table.scala
@@ -215,7 +215,7 @@ class Table(val hc: HailContext, val tir: TableIR) {
           TableValue(
             TableType(signature, key, globalSignature),
             BroadcastRow(ctx, globals, globalSignature),
-            RVD.coerce(RVDType(PType.canonical(signature).asInstanceOf[PStruct], key), crdd)), ctx)}
+            RVD.coerce(RVDType(PType.canonical(signature).asInstanceOf[PStruct], key), crdd, ctx)), ctx)}
   )
 
   def typ: TableType = tir.typ

--- a/hail/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/hail/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -219,7 +219,8 @@ object MatrixTable {
 
             rv
           }
-        }))
+        },
+        ctx))
     ds
   }
 

--- a/hail/src/main/scala/is/hail/variant/MatrixTable.scala
+++ b/hail/src/main/scala/is/hail/variant/MatrixTable.scala
@@ -115,12 +115,13 @@ case class RVDComponentSpec(rel_path: String) extends ComponentSpec {
     hc: HailContext,
     path: String,
     requestedType: TStruct,
+    ctx: ExecuteContext,
     newPartitioner: Option[RVDPartitioner] = None,
     filterIntervals: Boolean = false
   ): RVD = {
     val rvdPath = path + "/" + rel_path
     rvdSpec(hc.sFS, path)
-      .read(hc, rvdPath, requestedType, newPartitioner, filterIntervals)
+      .read(hc, rvdPath, requestedType, ctx, newPartitioner, filterIntervals)
   }
 
   def readLocalSingleRow(hc: HailContext, path: String, requestedType: TStruct, r: Region): (PStruct, Long) = {
@@ -172,11 +173,14 @@ object MatrixTable {
   def read(hc: HailContext, path: String, dropCols: Boolean = false, dropRows: Boolean = false): MatrixTable =
     new MatrixTable(hc, MatrixIR.read(hc, path, dropCols, dropRows, None))
 
-  def fromLegacy[T](hc: HailContext,
+  def fromLegacy[T](
+    hc: HailContext,
     matrixType: MatrixType,
     globals: Annotation,
     colValues: IndexedSeq[Annotation],
-    rdd: RDD[(Annotation, Iterable[T])]): MatrixTable = {
+    rdd: RDD[(Annotation, Iterable[T])],
+    ctx: ExecuteContext
+  ): MatrixTable = {
 
     val localGType = matrixType.entryType
     val tt = matrixType.canonicalTableType
@@ -188,7 +192,8 @@ object MatrixTable {
     val ds = new MatrixTable(hc, matrixType,
       globals.asInstanceOf[Row],
       colValues.asInstanceOf[IndexedSeq[Row]],
-      RVD.coerce(localRVDType,
+      RVD.coerce(
+        localRVDType,
         ContextRDD.weaken[RVDContext](rdd).cmapPartitions { (ctx, it) =>
           val region = ctx.region
           val rvb = new RegionValueBuilder(region)
@@ -224,8 +229,8 @@ object MatrixTable {
     } else
       new MatrixTable(hc, MatrixIR.range(hc, nRows, nCols, nPartitions))
 
-  def gen(hc: HailContext, gen: VSMSubgen): Gen[MatrixTable] =
-    gen.gen(hc)
+  def gen(hc: HailContext, gen: VSMSubgen, ctx: ExecuteContext): Gen[MatrixTable] =
+    gen.gen(hc, ctx)
 
   def fromRowsTable(kt: Table): MatrixTable = {
     val matrixType = MatrixType(
@@ -277,7 +282,7 @@ case class VSMSubgen(
   vGen: (Type) => Gen[Annotation],
   tGen: (TStruct, Annotation) => Gen[Annotation]) {
 
-  def gen(hc: HailContext): Gen[MatrixTable] =
+  def gen(hc: HailContext, ctx: ExecuteContext): Gen[MatrixTable] =
     for {
       size <- Gen.size
       (l, w) <- Gen.squareOfAreaAtMostSize.resize((size / 3 / 10) * 8)
@@ -316,13 +321,15 @@ case class VSMSubgen(
             (finalVASig, vaIns, Array("v"), Array("v"))
         }
 
-      MatrixTable.fromLegacy(hc,
+      MatrixTable.fromLegacy(
+        hc,
         MatrixType(globalSig, Array("s"), finalSASig, rowKey, finalVASig, tSig),
         global,
         sampleIds.zip(saValues).map { case (id, sa) => sIns(sa, id) },
         hc.sc.parallelize(rows.map { case (v, (va, gs)) =>
           (vaIns(va, v), gs)
-        }, nPartitions))
+        }, nPartitions),
+        ctx)
         .distinctByRow()
     }
 }
@@ -474,7 +481,12 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
 
   def sparkContext: SparkContext = hc.sc
 
-  def same(that: MatrixTable, tolerance: Double = utils.defaultTolerance, absolute: Boolean = false): Boolean = {
+  def same(
+    that: MatrixTable,
+    ctx: ExecuteContext,
+    tolerance: Double = utils.defaultTolerance,
+    absolute: Boolean = false
+  ): Boolean = {
     var metadataSame = true
     if (rowType.deepOptional() != that.rowType.deepOptional()) {
       metadataSame = false
@@ -538,7 +550,7 @@ class MatrixTable(val hc: HailContext, val ast: MatrixIR) {
     val localRKF = rowKeysF
     val localColKeys = colKeys
 
-    val (_, jcrdd) = this.rvd.orderedZipJoin(that.rvd)
+    val (_, jcrdd) = this.rvd.orderedZipJoin(that.rvd, ctx)
 
     metadataSame &&
       jcrdd.mapPartitions { it =>

--- a/hail/src/test/scala/is/hail/TestUtils.scala
+++ b/hail/src/test/scala/is/hail/TestUtils.scala
@@ -490,14 +490,19 @@ object TestUtils {
       },
       nPartitions)
 
-    MatrixTable.fromLegacy(hc, MatrixType(
-      globalType = TStruct.empty(),
-      colKey = Array("s"),
-      colType = TStruct("s" -> TString()),
-      rowKey = Array("locus", "alleles"),
-      rowType = TStruct("locus" -> TLocus(ReferenceGenome.GRCh37),
-        "alleles" -> TArray(TString())),
-      entryType = Genotype.htsGenotypeType),
-      Annotation.empty, sampleIds.map(Annotation(_)), rdd)
+    ExecuteContext.scoped { ctx =>
+      MatrixTable.fromLegacy(hc, MatrixType(
+        globalType = TStruct.empty(),
+        colKey = Array("s"),
+        colType = TStruct("s" -> TString()),
+        rowKey = Array("locus", "alleles"),
+        rowType = TStruct("locus" -> TLocus(ReferenceGenome.GRCh37),
+          "alleles" -> TArray(TString())),
+        entryType = Genotype.htsGenotypeType),
+        Annotation.empty,
+        sampleIds.map(Annotation(_)),
+        rdd,
+        ctx)
+    }
   }
 }

--- a/hail/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
+++ b/hail/src/test/scala/is/hail/annotations/AnnotationsSuite.scala
@@ -1,5 +1,6 @@
 package is.hail.annotations
 
+import is.hail.expr.ir.ExecuteContext
 import is.hail.expr.types.virtual._
 import is.hail.testUtils._
 import is.hail.utils._
@@ -70,12 +71,16 @@ class AnnotationsSuite extends HailSuite {
   @Test def testReadWrite() {
     val vds1 = TestUtils.importVCF(hc, "src/test/resources/sample.vcf")
     val vds2 = TestUtils.importVCF(hc, "src/test/resources/sample.vcf")
-    assert(vds1.same(vds2))
+    ExecuteContext.scoped { ctx =>
+      assert(vds1.same(vds2, ctx))
+    }
 
     val f = tmpDir.createTempFile("sample", extension = ".vds")
     vds1.write(f)
     val vds3 = hc.readVDS(f)
-    assert(vds3.same(vds1))
+    ExecuteContext.scoped { ctx =>
+      assert(vds3.same(vds1, ctx))
+    }
   }
 
   @Test def testExtendedOrdering() {

--- a/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/MatrixIRSuite.scala
@@ -264,7 +264,9 @@ class MatrixIRSuite extends HailSuite {
     val path = tmpDir.createLocalTempFile(extension = "mt")
     Interpret[Unit](ctx, MatrixWrite(range.ast, MatrixNativeWriter(path)))
     val read = MatrixTable.read(hc, path)
-    assert(read.same(range))
+    ExecuteContext.scoped { ctx =>
+      assert(read.same(range, ctx))
+    }
   }
 
   @Test def testMatrixVCFWrite() {
@@ -280,13 +282,17 @@ class MatrixIRSuite extends HailSuite {
     Interpret[Unit](ctx, MatrixMultiWrite(ranges.map(_.ast), MatrixNativeMultiWriter(path)))
     val read0 = MatrixTable.read(hc, path + "0.mt")
     val read1 = MatrixTable.read(hc, path + "1.mt")
-    assert(ranges(0).same(read0))
-    assert(ranges(1).same(read1))
+    ExecuteContext.scoped { ctx =>
+      assert(ranges(0).same(read0, ctx))
+      assert(ranges(1).same(read1, ctx))
+    }
 
     val pathRef = tmpDir.createLocalTempFile(extension = "mt")
     Interpret[Unit](ctx, MatrixWrite(ranges(1).ast, MatrixNativeWriter(path)))
     val readRef = MatrixTable.read(hc, path)
-    assert(readRef.same(read1))
+    ExecuteContext.scoped { ctx =>
+      assert(readRef.same(read1, ctx))
+    }
   }
 
   @Test def testMatrixMultiWriteDifferentTypesFails() {

--- a/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/RandomFunctionsSuite.scala
@@ -93,11 +93,13 @@ class RandomFunctionsSuite extends HailSuite {
       Interval(Row(10), Row(14), false, true))
     val newPartitioner = mapped.partitioner.copy(rangeBounds=newRangeBounds)
 
-    val repartitioned = mapped.repartition(newPartitioner)
-    val cachedAndRepartitioned = mapped.cache().repartition(newPartitioner)
+    ExecuteContext.scoped { ctx =>
+      val repartitioned = mapped.repartition(newPartitioner, ctx)
+      val cachedAndRepartitioned = mapped.cache().repartition(newPartitioner, ctx)
 
-    assert(mapped.toRows.collect() sameElements repartitioned.toRows.collect())
-    assert(mapped.toRows.collect() sameElements cachedAndRepartitioned.toRows.collect())
+      assert(mapped.toRows.collect() sameElements repartitioned.toRows.collect())
+      assert(mapped.toRows.collect() sameElements cachedAndRepartitioned.toRows.collect())
+    }
   }
 
   @Test def testInterpretIncrementsCorrectly() {

--- a/hail/src/test/scala/is/hail/io/ImportVCFSuite.scala
+++ b/hail/src/test/scala/is/hail/io/ImportVCFSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.io
 
 import is.hail.check.Prop._
+import is.hail.expr.ir.ExecuteContext
 import is.hail.io.vcf.ExportVCF
 import is.hail.variant._
 import is.hail.{HailSuite, TestUtils}
@@ -8,21 +9,23 @@ import org.testng.annotations.Test
 
 class ImportVCFSuite extends HailSuite {
   @Test def randomExportImportIsIdentity() {
-    forAll(MatrixTable.gen(hc, VSMSubgen.random)) { vds =>
+    ExecuteContext.scoped { ctx =>
+      forAll(MatrixTable.gen(hc, VSMSubgen.random, ctx)) { vds =>
 
-      val truth = {
-        val f = tmpDir.createTempFile(extension="vcf")
-        ExportVCF(vds, f)
-        TestUtils.importVCF(hc, f, rg = Some(vds.referenceGenome))
-      }
+        val truth = {
+          val f = tmpDir.createTempFile(extension="vcf")
+          ExportVCF(vds, f)
+          TestUtils.importVCF(hc, f, rg = Some(vds.referenceGenome))
+        }
 
-      val actual = {
-        val f = tmpDir.createTempFile(extension="vcf")
-        ExportVCF(truth, f)
-        TestUtils.importVCF(hc, f, rg = Some(vds.referenceGenome))
-      }
+        val actual = {
+          val f = tmpDir.createTempFile(extension="vcf")
+          ExportVCF(truth, f)
+          TestUtils.importVCF(hc, f, rg = Some(vds.referenceGenome))
+        }
 
-      truth.same(actual)
-    }.check()
+        truth.same(actual, ctx)
+      }.check()
+    }
   }
 }

--- a/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
+++ b/hail/src/test/scala/is/hail/variant/vsm/PartitioningSuite.scala
@@ -3,7 +3,7 @@ package is.hail.variant.vsm
 import is.hail.HailSuite
 import is.hail.annotations.BroadcastRow
 import is.hail.expr.ir
-import is.hail.expr.ir.{Interpret, MatrixAnnotateRowsTable, TableLiteral, TableValue}
+import is.hail.expr.ir.{ ExecuteContext, Interpret, MatrixAnnotateRowsTable, TableLiteral, TableValue }
 import is.hail.expr.types._
 import is.hail.expr.types.virtual.{TInt32, TStruct}
 import is.hail.rvd.RVD
@@ -58,9 +58,11 @@ class PartitioningSuite extends HailSuite {
     val nonEmptyRVD = mt.rvd
     val emptyRVD = RVD.empty(hc.sc, rvdType)
 
-    emptyRVD.orderedJoin(nonEmptyRVD, "left", (_, it) => it.map(_._1), rvdType).count()
-    emptyRVD.orderedJoin(nonEmptyRVD, "inner", (_, it) => it.map(_._1), rvdType).count()
-    nonEmptyRVD.orderedJoin(emptyRVD, "left", (_, it) => it.map(_._1), rvdType).count()
-    nonEmptyRVD.orderedJoin(emptyRVD, "inner", (_, it) => it.map(_._1), rvdType).count()
+    ExecuteContext.scoped { ctx =>
+      emptyRVD.orderedJoin(nonEmptyRVD, "left", (_, it) => it.map(_._1), rvdType, ctx).count()
+      emptyRVD.orderedJoin(nonEmptyRVD, "inner", (_, it) => it.map(_._1), rvdType, ctx).count()
+      nonEmptyRVD.orderedJoin(emptyRVD, "left", (_, it) => it.map(_._1), rvdType, ctx).count()
+      nonEmptyRVD.orderedJoin(emptyRVD, "inner", (_, it) => it.map(_._1), rvdType, ctx).count()
+    }
   }
 }


### PR DESCRIPTION
This PR just clutters the RVD code with `ExecuteContext`. A later PR will leverage this to manage shuffle lifetimes.

I also added `addOnExit` to `ExecuteContext` which I'll use to make HTTP requests to the shuffle service to delete shuffle data.