### PR TITLE
[hail] Code Ordering Sort Fields

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/CodeOrdering.scala
+++ b/hail/src/main/scala/is/hail/annotations/CodeOrdering.scala
@@ -6,22 +6,30 @@ import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.expr.types._
 import is.hail.asm4s.coerce
 import is.hail.expr.types.physical._
+import is.hail.table.{ Ascending, Descending, SortOrder }
 import is.hail.utils._
 
 object CodeOrdering {
 
-  type Op = Int
-  val compare: Op = 0
-  val equiv: Op = 1
-  val lt: Op = 2
-  val lteq: Op = 3
-  val gt: Op = 4
-  val gteq: Op = 5
-  val neq: Op = 6
+  sealed trait Op { type ReturnType }
+  final case object compare extends Op { type ReturnType = Int }
+  sealed trait BooleanOp extends Op { type ReturnType = Boolean }
+  final case object equiv extends BooleanOp
+  final case object lt extends BooleanOp
+  final case object lteq extends BooleanOp
+  final case object gt extends BooleanOp
+  final case object gteq extends BooleanOp
+  final case object neq extends BooleanOp
 
   type F[R] = ((Code[Boolean], Code[_]), (Code[Boolean], Code[_])) => Code[R]
 
-  def rowOrdering(t1: PBaseStruct, t2: PBaseStruct, mb: EmitMethodBuilder): CodeOrdering = new CodeOrdering {
+  def rowOrdering(
+    t1: PBaseStruct,
+    t2: PBaseStruct,
+    mb: EmitMethodBuilder,
+    sortOrders: Array[SortOrder] = null
+  ): CodeOrdering = new CodeOrdering {
+    require(sortOrders == null || sortOrders.size == t1.size)
     type T = Long
 
     val m1: LocalRef[Boolean] = mb.newLocal[Boolean]
@@ -40,11 +48,18 @@ object CodeOrdering {
         v2s(i).storeAny(m2.mux(ir.defaultValue(tf2), Region.loadIRIntermediate(tf2)(t2.fieldOffset(y, i)))))
     }
 
+    private[this] def fieldOrdering(i: Int, op: CodeOrdering.Op): CodeOrdering.F[op.ReturnType] =
+      mb.getCodeOrdering(
+        t1.types(i),
+        t2.types(i),
+        if (sortOrders == null) Ascending else sortOrders(i),
+        op)
+
     override def compareNonnull(x: Code[Long], y: Code[Long]): Code[Int] = {
       val cmp = mb.newLocal[Int]
 
       val c = Array.tabulate(t1.size) { i =>
-        val mbcmp = mb.getCodeOrdering[Int](t1.types(i), t2.types(i), CodeOrdering.compare)
+        val mbcmp = fieldOrdering(i, CodeOrdering.compare)
         Code(setup(i)(x, y),
           mbcmp((m1, v1s(i)), (m2, v2s(i))))
       }.foldRight[Code[Int]](cmp.load()) { (ci, cont) => cmp.ceq(0).mux(Code(cmp := ci, cont), cmp) }
@@ -52,45 +67,51 @@ object CodeOrdering {
       Code(cmp := 0, c)
     }
 
-    override def ltNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = {
+    private[this] def dictionaryOrderingFromFields(
+      op: CodeOrdering.BooleanOp,
+      zero: Code[Boolean],
+      combine: (Code[Boolean], Code[Boolean], Code[Boolean]) => Code[Boolean]
+    )(x: Code[Long],
+      y: Code[Long]
+    ): Code[Boolean] =
       Array.tabulate(t1.size) { i =>
-        val mblt = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.lt)
-        val mbequiv = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.equiv)
+        val mblt = fieldOrdering(i, op)
+        val mbequiv = fieldOrdering(i, CodeOrdering.equiv)
         (Code(setup(i)(x, y), mblt((m1, v1s(i)), (m2, v2s(i)))),
           mbequiv((m1, v1s(i)), (m2, v2s(i))))
-      }.foldRight[Code[Boolean]](false) { case ((clt, ceq), cont) => clt || (ceq && cont) }
-    }
+      }.foldRight(zero) { case ((cop, ceq), cont) => combine(cop, ceq, cont) }
 
-    override def lteqNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = {
-      Array.tabulate(t1.size) { i =>
-        val mblteq = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.lteq)
-        val mbequiv = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.equiv)
-        (Code(setup(i)(x, y), mblteq((m1, v1s(i)), (m2, v2s(i)))),
-          mbequiv((m1, v1s(i)), (m2, v2s(i))))
-      }.foldRight[Code[Boolean]](true) { case ((clteq, ceq), cont) => clteq && (!ceq || cont) }
-    }
+    val _ltNonnull = dictionaryOrderingFromFields(
+      CodeOrdering.lt,
+      false,
+      { (isLessThan, isEqual, subsequentLt) =>
+        isLessThan || (isEqual && subsequentLt) }) _
+    override def ltNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = _ltNonnull(x, y)
 
-    override def gtNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = {
-      Array.tabulate(t1.size) { i =>
-        val mbgt = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.gt)
-        val mbequiv = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.equiv)
-        (Code(setup(i)(x, y), mbgt((m1, v1s(i)), (m2, v2s(i)))),
-          mbequiv((m1, v1s(i)), (m2, v2s(i))))
-      }.foldRight[Code[Boolean]](false) { case ((cgt, ceq), cont) => cgt || (ceq && cont) }
-    }
+    val _lteqNonnull = dictionaryOrderingFromFields(
+      CodeOrdering.lteq,
+      true,
+      { (isLessThanEq, isEqual, subsequentLtEq) =>
+        isLessThanEq || (!isEqual || subsequentLtEq) }) _
+    override def lteqNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = _lteqNonnull(x, y)
 
-    override def gteqNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = {
-      Array.tabulate(t1.size) { i =>
-        val mbgteq = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.gteq)
-        val mbequiv = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.equiv)
-        (Code(setup(i)(x, y), mbgteq((m1, v1s(i)), (m2, v2s(i)))),
-          mbequiv((m1, v1s(i)), (m2, v2s(i))))
-      }.foldRight[Code[Boolean]](true) { case ((cgteq, ceq), cont) => cgteq && (!ceq || cont) }
-    }
+    val _gtNonnull = dictionaryOrderingFromFields(
+      CodeOrdering.gt,
+      false,
+      { (isGreaterThan, isEqual, subsequentGt) =>
+        isGreaterThan || (isEqual && subsequentGt) }) _
+    override def gtNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = _gtNonnull(x, y)
+
+    val _gteqNonnull = dictionaryOrderingFromFields(
+      CodeOrdering.gteq,
+      false,
+      { (isGreaterThanEq, isEqual, subsequentGteq) =>
+        isGreaterThanEq && (!isEqual || subsequentGteq) }) _
+    override def gteqNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = _gteqNonnull(x, y)
 
     override def equivNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = {
       Array.tabulate(t1.size) { i =>
-        val mbequiv = mb.getCodeOrdering[Boolean](t1.types(i), t2.types(i), CodeOrdering.equiv)
+        val mbequiv = fieldOrdering(i, CodeOrdering.equiv)
         Code(setup(i)(x, y),
           mbequiv((m1, v1s(i)), (m2, v2s(i))))
       }.foldRight[Code[Boolean]](const(true))(_ && _)
@@ -127,7 +148,7 @@ object CodeOrdering {
     }
 
     override def compareNonnull(x: Code[Long], y: Code[Long]): Code[Int] = {
-      val mbcmp = mb.getCodeOrdering[Int](t1.elementType, t2.elementType, CodeOrdering.compare)
+      val mbcmp = mb.getCodeOrdering(t1.elementType, t2.elementType, CodeOrdering.compare)
       val cmp = mb.newLocal[Int]
 
       Code(cmp := 0,
@@ -138,8 +159,8 @@ object CodeOrdering {
     }
 
     override def ltNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = {
-      val mblt = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.lt)
-      val mbequiv = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.equiv)
+      val mblt = mb.getCodeOrdering(t1.elementType, t2.elementType, CodeOrdering.lt)
+      val mbequiv = mb.getCodeOrdering(t1.elementType, t2.elementType, CodeOrdering.equiv)
       val lt = mb.newLocal[Boolean]
       val lcmp = Code(
         lt := mblt((m1, v1), (m2, v2)),
@@ -151,8 +172,8 @@ object CodeOrdering {
     }
 
     override def lteqNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = {
-      val mblteq = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.lteq)
-      val mbequiv = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.equiv)
+      val mblteq = mb.getCodeOrdering(t1.elementType, t2.elementType, CodeOrdering.lteq)
+      val mbequiv = mb.getCodeOrdering(t1.elementType, t2.elementType, CodeOrdering.equiv)
 
       val lteq = mb.newLocal[Boolean]
       val lcmp = Code(
@@ -165,8 +186,8 @@ object CodeOrdering {
     }
 
     override def gtNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = {
-      val mbgt = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.gt)
-      val mbequiv = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.equiv)
+      val mbgt = mb.getCodeOrdering(t1.elementType, t2.elementType, CodeOrdering.gt)
+      val mbequiv = mb.getCodeOrdering(t1.elementType, t2.elementType, CodeOrdering.equiv)
       val gt = mb.newLocal[Boolean]
       val lcmp = Code(
         gt := mbgt((m1, v1), (m2, v2)),
@@ -180,8 +201,8 @@ object CodeOrdering {
     }
 
     override def gteqNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = {
-      val mbgteq = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.gteq)
-      val mbequiv = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.equiv)
+      val mbgteq = mb.getCodeOrdering(t1.elementType, t2.elementType, CodeOrdering.gteq)
+      val mbequiv = mb.getCodeOrdering(t1.elementType, t2.elementType, CodeOrdering.equiv)
 
       val gteq = mb.newLocal[Boolean]
       val lcmp = Code(
@@ -195,7 +216,7 @@ object CodeOrdering {
     }
 
     override def equivNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = {
-      val mbequiv = mb.getCodeOrdering[Boolean](t1.elementType, t2.elementType, CodeOrdering.equiv)
+      val mbequiv = mb.getCodeOrdering(t1.elementType, t2.elementType, CodeOrdering.equiv)
       val lcmp = eq := mbequiv((m1, v1), (m2, v2))
       Code(eq := true,
         loop(lcmp, eq)(x, y),
@@ -227,7 +248,7 @@ object CodeOrdering {
     }
 
     override def compareNonnull(x: Code[T], y: Code[T]): Code[Int] = {
-      val mbcmp = mb.getCodeOrdering[Int](t1.pointType, t2.pointType, CodeOrdering.compare)
+      val mbcmp = mb.getCodeOrdering(t1.pointType, t2.pointType, CodeOrdering.compare)
 
       val cmp = mb.newLocal[Int]
       Code(loadStart(x, y),
@@ -247,7 +268,7 @@ object CodeOrdering {
     }
 
     override def equivNonnull(x: Code[T], y: Code[T]): Code[Boolean] = {
-      val mbeq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.equiv)
+      val mbeq = mb.getCodeOrdering(t1.pointType, t2.pointType, CodeOrdering.equiv)
 
       Code(loadStart(x, y), mbeq((mp1, p1), (mp2, p2))) &&
         t1.includeStart(x).ceq(t2.includeStart(y)) &&
@@ -256,8 +277,8 @@ object CodeOrdering {
     }
 
     override def ltNonnull(x: Code[T], y: Code[T]): Code[Boolean] = {
-      val mblt = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.lt)
-      val mbeq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.equiv)
+      val mblt = mb.getCodeOrdering(t1.pointType, t2.pointType, CodeOrdering.lt)
+      val mbeq = mb.getCodeOrdering(t1.pointType, t2.pointType, CodeOrdering.equiv)
 
       Code(loadStart(x, y), mblt((mp1, p1), (mp2, p2))) || (
         mbeq((mp1, p1), (mp2, p2)) && (
@@ -268,8 +289,8 @@ object CodeOrdering {
     }
 
     override def lteqNonnull(x: Code[T], y: Code[T]): Code[Boolean] = {
-      val mblteq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.lteq)
-      val mbeq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.equiv)
+      val mblteq = mb.getCodeOrdering(t1.pointType, t2.pointType, CodeOrdering.lteq)
+      val mbeq = mb.getCodeOrdering(t1.pointType, t2.pointType, CodeOrdering.equiv)
 
       Code(loadStart(x, y), mblteq((mp1, p1), (mp2, p2))) && (
         !mbeq((mp1, p1), (mp2, p2)) || ( // if not equal, then lt
@@ -280,8 +301,8 @@ object CodeOrdering {
     }
 
     override def gtNonnull(x: Code[T], y: Code[T]): Code[Boolean] = {
-      val mbgt = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.gt)
-      val mbeq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.equiv)
+      val mbgt = mb.getCodeOrdering(t1.pointType, t2.pointType, CodeOrdering.gt)
+      val mbeq = mb.getCodeOrdering(t1.pointType, t2.pointType, CodeOrdering.equiv)
 
       Code(loadStart(x, y), mbgt((mp1, p1), (mp2, p2))) || (
         mbeq((mp1, p1), (mp2, p2)) && (
@@ -292,8 +313,8 @@ object CodeOrdering {
     }
 
     override def gteqNonnull(x: Code[T], y: Code[T]): Code[Boolean] = {
-      val mbgteq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.gteq)
-      val mbeq = mb.getCodeOrdering[Boolean](t1.pointType, t2.pointType, CodeOrdering.equiv)
+      val mbgteq = mb.getCodeOrdering(t1.pointType, t2.pointType, CodeOrdering.gteq)
+      val mbeq = mb.getCodeOrdering(t1.pointType, t2.pointType, CodeOrdering.equiv)
 
       Code(loadStart(x, y), mbgteq((mp1, p1), (mp2, p2))) && (
         !mbeq((mp1, p1), (mp2, p2)) || ( // if not equal, then lt

--- a/hail/src/main/scala/is/hail/annotations/CodeOrdering.scala
+++ b/hail/src/main/scala/is/hail/annotations/CodeOrdering.scala
@@ -75,9 +75,9 @@ object CodeOrdering {
       y: Code[Long]
     ): Code[Boolean] =
       Array.tabulate(t1.size) { i =>
-        val mblt = fieldOrdering(i, op)
+        val mbop = fieldOrdering(i, op)
         val mbequiv = fieldOrdering(i, CodeOrdering.equiv)
-        (Code(setup(i)(x, y), mblt((m1, v1s(i)), (m2, v2s(i)))),
+        (Code(setup(i)(x, y), mbop((m1, v1s(i)), (m2, v2s(i)))),
           mbequiv((m1, v1s(i)), (m2, v2s(i))))
       }.foldRight(zero) { case ((cop, ceq), cont) => combine(cop, ceq, cont) }
 
@@ -92,7 +92,7 @@ object CodeOrdering {
       CodeOrdering.lteq,
       true,
       { (isLessThanEq, isEqual, subsequentLtEq) =>
-        isLessThanEq || (!isEqual || subsequentLtEq) }) _
+        isLessThanEq && (!isEqual || subsequentLtEq) }) _
     override def lteqNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = _lteqNonnull(x, y)
 
     val _gtNonnull = dictionaryOrderingFromFields(
@@ -104,7 +104,7 @@ object CodeOrdering {
 
     val _gteqNonnull = dictionaryOrderingFromFields(
       CodeOrdering.gteq,
-      false,
+      true,
       { (isGreaterThanEq, isEqual, subsequentGteq) =>
         isGreaterThanEq && (!isEqual || subsequentGteq) }) _
     override def gteqNonnull(x: Code[Long], y: Code[Long]): Code[Boolean] = _gteqNonnull(x, y)

--- a/hail/src/main/scala/is/hail/annotations/CodeOrdering.scala
+++ b/hail/src/main/scala/is/hail/annotations/CodeOrdering.scala
@@ -350,15 +350,15 @@ abstract class CodeOrdering {
 
   def compareNonnull(x: Code[T], y: Code[T]): Code[Int]
 
-  def ltNonnull(x: Code[T], y: Code[T]): Code[Boolean] = compareNonnull(x, y) < 0
+  def ltNonnull(x: Code[T], y: Code[T]): Code[Boolean]
 
-  def lteqNonnull(x: Code[T], y: Code[T]): Code[Boolean] = compareNonnull(x, y) <= 0
+  def lteqNonnull(x: Code[T], y: Code[T]): Code[Boolean]
 
-  def gtNonnull(x: Code[T], y: Code[T]): Code[Boolean] = compareNonnull(x, y) > 0
+  def gtNonnull(x: Code[T], y: Code[T]): Code[Boolean]
 
-  def gteqNonnull(x: Code[T], y: Code[T]): Code[Boolean] = compareNonnull(x, y) >= 0
+  def gteqNonnull(x: Code[T], y: Code[T]): Code[Boolean]
 
-  def equivNonnull(x: Code[T], y: Code[T]): Code[Boolean] = compareNonnull(x, y).ceq(0)
+  def equivNonnull(x: Code[T], y: Code[T]): Code[Boolean]
 
   private[this] def liftMissing[U](
     op: (Code[T], Code[T]) => Code[U],
@@ -393,4 +393,16 @@ abstract class CodeOrdering {
     override def gteqNonnull(x: Code[T], y: Code[T]) = CodeOrdering.this.gteqNonnull(y, x)
     override def equivNonnull(x: Code[T], y: Code[T]) = CodeOrdering.this.equivNonnull(y, x)
   }
+}
+
+abstract class CodeOrderingCompareConsistentWithOthers extends CodeOrdering {
+  def ltNonnull(x: Code[T], y: Code[T]): Code[Boolean] = compareNonnull(x, y) < 0
+
+  def lteqNonnull(x: Code[T], y: Code[T]): Code[Boolean] = compareNonnull(x, y) <= 0
+
+  def gtNonnull(x: Code[T], y: Code[T]): Code[Boolean] = compareNonnull(x, y) > 0
+
+  def gteqNonnull(x: Code[T], y: Code[T]): Code[Boolean] = compareNonnull(x, y) >= 0
+
+  def equivNonnull(x: Code[T], y: Code[T]): Code[Boolean] = compareNonnull(x, y).ceq(0)
 }

--- a/hail/src/main/scala/is/hail/annotations/CodeOrdering.scala
+++ b/hail/src/main/scala/is/hail/annotations/CodeOrdering.scala
@@ -397,4 +397,14 @@ abstract class CodeOrdering {
 
     (xm || ym).mux(xm && ym, equivNonnull(xv, yv))
   }
+
+  // reverses the sense of the non-null comparison only
+  def reverse: CodeOrdering = new CodeOrdering () {
+    override def reverse: CodeOrdering = CodeOrdering.this
+    override type T = CodeOrdering.this.T
+    override type P = CodeOrdering.this.P
+
+    def compareNonnull(x: Code[T], y: Code[T]): Code[Int] =
+      CodeOrdering.this.compareNonnull(y, x)
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/BinarySearch.scala
@@ -25,18 +25,18 @@ class BinarySearch(mb: EmitMethodBuilder, typ: PContainer, keyOnly: Boolean) {
       case ((mk1: Code[Boolean], k1: Code[_]), (m2: Code[Boolean], v2: Code[Long] @unchecked)) =>
         val mk2 = Code(mk2l := m2 || ttype.isFieldMissing(v2, 0), mk2l)
         val k2 = mk2l.mux(defaultValue(kt), Region.loadIRIntermediate(kt)(ttype.fieldOffset(v2, 0)))
-        findMB.getCodeOrdering[Int](kt, CodeOrdering.compare)((mk1, k1), (mk2, k2))
+        findMB.getCodeOrdering(kt, CodeOrdering.compare)((mk1, k1), (mk2, k2))
     }
     val ceq: CodeOrdering.F[Boolean] = {
       case ((mk1: Code[Boolean], k1: Code[_]), (m2: Code[Boolean], v2: Code[Long] @unchecked)) =>
         val mk2 = Code(mk2l1 := m2 || ttype.isFieldMissing(v2, 0), mk2l1)
         val k2 = mk2l1.mux(defaultValue(kt), Region.loadIRIntermediate(kt)(ttype.fieldOffset(v2, 0)))
-        mb.getCodeOrdering[Boolean](kt, CodeOrdering.equiv)((mk1, k1), (mk2, k2))
+        mb.getCodeOrdering(kt, CodeOrdering.equiv)((mk1, k1), (mk2, k2))
     }
     (comp, ceq, findMB, kt)
   } else
-    (mb.getCodeOrdering[Int](elt, CodeOrdering.compare),
-      mb.getCodeOrdering[Boolean](elt, CodeOrdering.equiv),
+    (mb.getCodeOrdering(elt, CodeOrdering.compare),
+      mb.getCodeOrdering(elt, CodeOrdering.equiv),
       mb.fb.newMethod(Array[TypeInfo[_]](typeInfo[Long], typeInfo[Boolean], typeToTypeInfo(elt)), typeInfo[Int]), elt)
 
   private[this] val array = findElt.getArg[Long](1)

--- a/hail/src/main/scala/is/hail/expr/ir/ComparisonOp.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ComparisonOp.scala
@@ -52,11 +52,12 @@ object ComparisonOp {
 sealed trait ComparisonOp[ReturnType] {
   def t1: Type
   def t2: Type
-  def op: CodeOrdering.Op
+  // FIXME: WTF
+  val op: CodeOrdering.Op
   val strict: Boolean = true
-  def codeOrdering(mb: EmitMethodBuilder, t1p: PType, t2p: PType): CodeOrdering.F[ReturnType] = {
+  def codeOrdering(mb: EmitMethodBuilder, t1p: PType, t2p: PType): CodeOrdering.F[op.ReturnType] = {
     ComparisonOp.checkCompatible(t1p.virtualType, t2p.virtualType)
-    mb.getCodeOrdering[ReturnType](t1p, t2p, op)
+    mb.getCodeOrdering(t1p, t2p, op)
   }
 }
 

--- a/hail/src/main/scala/is/hail/expr/ir/ComparisonOp.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/ComparisonOp.scala
@@ -52,7 +52,6 @@ object ComparisonOp {
 sealed trait ComparisonOp[ReturnType] {
   def t1: Type
   def t2: Type
-  // FIXME: WTF
   val op: CodeOrdering.Op
   val strict: Boolean = true
   def codeOrdering(mb: EmitMethodBuilder, t1p: PType, t2p: PType): CodeOrdering.F[op.ReturnType] = {

--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -1,5 +1,7 @@
 package is.hail.expr.ir
 
+import is.hail.backend.BroadcastValue
+import is.hail.table.{ Ascending, SortOrder }
 import java.io._
 
 import is.hail.HailContext
@@ -98,17 +100,34 @@ class EmitMethodBuilder(
 
   def getPType(t: PType): Code[PType] = fb.getPType(t)
 
-  def getCodeOrdering[T](t: PType, op: CodeOrdering.Op): CodeOrdering.F[T] =
-    getCodeOrdering[T](t, op, ignoreMissingness = false)
+  def getCodeOrdering(t: PType, op: CodeOrdering.Op): CodeOrdering.F[op.ReturnType] =
+    getCodeOrdering(t, t, sortOrder = Ascending, op, ignoreMissingness = false)
 
-  def getCodeOrdering[T](t: PType, op: CodeOrdering.Op, ignoreMissingness: Boolean): CodeOrdering.F[T] =
-    fb.getCodeOrdering[T](t, op, ignoreMissingness)
+  def getCodeOrdering(t: PType, op: CodeOrdering.Op, ignoreMissingness: Boolean): CodeOrdering.F[op.ReturnType] =
+    getCodeOrdering(t, t, sortOrder = Ascending, op, ignoreMissingness)
 
-  def getCodeOrdering[T](t1: PType, t2: PType, op: CodeOrdering.Op): CodeOrdering.F[T] =
-    fb.getCodeOrdering[T](t1, t2, op, ignoreMissingness = false)
+  def getCodeOrdering(t1: PType, t2: PType, op: CodeOrdering.Op): CodeOrdering.F[op.ReturnType] =
+    getCodeOrdering(t1, t2, sortOrder = Ascending, op, ignoreMissingness = false)
 
-  def getCodeOrdering[T](t1: PType, t2: PType, op: CodeOrdering.Op, ignoreMissingness: Boolean): CodeOrdering.F[T] =
-    fb.getCodeOrdering[T](t1, t2, op, ignoreMissingness)
+  def getCodeOrdering(t1: PType, t2: PType, op: CodeOrdering.Op, ignoreMissingness: Boolean): CodeOrdering.F[op.ReturnType] =
+    getCodeOrdering(t1, t2, sortOrder = Ascending, op, ignoreMissingness)
+
+  def getCodeOrdering(
+    t1: PType,
+    t2: PType,
+    sortOrder: SortOrder,
+    op: CodeOrdering.Op
+  ): CodeOrdering.F[op.ReturnType] =
+    getCodeOrdering(t1, t2, sortOrder, op, ignoreMissingness = false)
+
+  def getCodeOrdering(
+    t1: PType,
+    t2: PType,
+    sortOrder: SortOrder,
+    op: CodeOrdering.Op,
+    ignoreMissingness: Boolean
+  ): CodeOrdering.F[op.ReturnType] =
+    fb.getCodeOrdering(t1, t2, sortOrder, op, ignoreMissingness)
 
   def newRNG(seed: Long): Code[IRRandomness] = fb.newRNG(seed)
 }
@@ -169,8 +188,9 @@ class EmitFunctionBuilder[F >: Null](
 
   private[this] val pTypeMap: mutable.Map[PType, Code[PType]] = mutable.Map[PType, Code[PType]]()
 
-  private[this] val compareMap: mutable.Map[(PType, PType, CodeOrdering.Op, Boolean), CodeOrdering.F[_]] =
-    mutable.Map[(PType, PType, CodeOrdering.Op, Boolean), CodeOrdering.F[_]]()
+  private[this] type CompareMapKey = (PType, PType, CodeOrdering.Op, SortOrder, Boolean)
+  private[this] val compareMap: mutable.Map[CompareMapKey, CodeOrdering.F[_]] =
+    mutable.Map[CompareMapKey, CodeOrdering.F[_]]()
 
   private[this] val methodMemo: mutable.Map[Any, EmitMethodBuilder] = mutable.HashMap.empty
 
@@ -368,14 +388,40 @@ class EmitFunctionBuilder[F >: Null](
       newLazyField[Type](setup))
   }
 
-  def getCodeOrdering[T](t1: PType, t2: PType, op: CodeOrdering.Op, ignoreMissingness: Boolean): CodeOrdering.F[T] = {
-    val f = compareMap.getOrElseUpdate((t1, t2, op, ignoreMissingness), {
+  def getCodeOrdering(t: PType, op: CodeOrdering.Op): CodeOrdering.F[op.ReturnType] =
+    getCodeOrdering(t, t, sortOrder = Ascending, op, ignoreMissingness = false)
+
+  def getCodeOrdering(t: PType, op: CodeOrdering.Op, ignoreMissingness: Boolean): CodeOrdering.F[op.ReturnType] =
+    getCodeOrdering(t, t, sortOrder = Ascending, op, ignoreMissingness)
+
+  def getCodeOrdering(t1: PType, t2: PType, op: CodeOrdering.Op): CodeOrdering.F[op.ReturnType] =
+    getCodeOrdering(t1, t2, sortOrder = Ascending, op, ignoreMissingness = false)
+
+  def getCodeOrdering(t1: PType, t2: PType, op: CodeOrdering.Op, ignoreMissingness: Boolean): CodeOrdering.F[op.ReturnType] =
+    getCodeOrdering(t1, t2, sortOrder = Ascending, op, ignoreMissingness)
+
+  def getCodeOrdering(
+    t1: PType,
+    t2: PType,
+    sortOrder: SortOrder,
+    op: CodeOrdering.Op
+  ): CodeOrdering.F[op.ReturnType] =
+    getCodeOrdering(t1, t2, sortOrder, op, ignoreMissingness = false)
+
+  def getCodeOrdering(
+    t1: PType,
+    t2: PType,
+    sortOrder: SortOrder,
+    op: CodeOrdering.Op,
+    ignoreMissingness: Boolean
+  ): CodeOrdering.F[op.ReturnType] = {
+    val f = compareMap.getOrElseUpdate((t1, t2, op, sortOrder, ignoreMissingness), {
       val ti = typeToTypeInfo(t1)
       val rt = if (op == CodeOrdering.compare) typeInfo[Int] else typeInfo[Boolean]
 
       val newMB = if (ignoreMissingness) {
         val newMB = newMethod(Array[TypeInfo[_]](ti, ti), rt)
-        val ord = t1.codeOrdering(newMB, t2)
+        val ord = t1.codeOrdering(newMB, t2, sortOrder)
         val v1 = newMB.getArg(1)(ti)
         val v2 = newMB.getArg(3)(ti)
         val c: Code[_] = op match {
@@ -391,7 +437,7 @@ class EmitFunctionBuilder[F >: Null](
         newMB
       } else {
         val newMB = newMethod(Array[TypeInfo[_]](typeInfo[Boolean], ti, typeInfo[Boolean], ti), rt)
-        val ord = t1.codeOrdering(newMB, t2)
+        val ord = t1.codeOrdering(newMB, t2, sortOrder)
         val m1 = newMB.getArg[Boolean](1)
         val v1 = newMB.getArg(2)(ti)
         val m2 = newMB.getArg[Boolean](3)
@@ -416,11 +462,16 @@ class EmitFunctionBuilder[F >: Null](
       }
       f
     })
-    (v1: (Code[Boolean], Code[_]), v2: (Code[Boolean], Code[_])) => coerce[T](f(v1, v2))
+    (v1: (Code[Boolean], Code[_]), v2: (Code[Boolean], Code[_])) => coerce[op.ReturnType](f(v1, v2))
   }
 
-  def getCodeOrdering[T](t: PType, op: CodeOrdering.Op, ignoreMissingness: Boolean): CodeOrdering.F[T] =
-    getCodeOrdering[T](t, t, op, ignoreMissingness)
+  def getCodeOrdering(
+    t: PType,
+    op: CodeOrdering.Op,
+    sortOrder: SortOrder,
+    ignoreMissingness: Boolean
+  ): CodeOrdering.F[op.ReturnType] =
+    getCodeOrdering(t, t, sortOrder, op, ignoreMissingness)
 
   override val apply_method: EmitMethodBuilder = {
     val m = new EmitMethodBuilder(this, "apply", parameterTypeInfo.map(_.base), returnTypeInfo.base)

--- a/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/CollectAsSetAggregator.scala
@@ -12,7 +12,7 @@ class TypedKey(typ: PType, fb: EmitFunctionBuilder[_], region: Code[Region]) ext
   val inline: Boolean = typ.isPrimitive
   val storageType: PTuple = PTuple(if (inline) typ else PInt64(typ.required), PTuple())
   val compType: PType = typ
-  private val kcomp = fb.getCodeOrdering[Int](typ, CodeOrdering.compare, ignoreMissingness = false)
+  private val kcomp = fb.getCodeOrdering(typ, CodeOrdering.compare, ignoreMissingness = false)
 
   def isKeyMissing(src: Code[Long]): Code[Boolean] = storageType.isFieldMissing(src, 0)
   def loadKey(src: Code[Long]): Code[_] = Region.loadIRIntermediate(if (inline) typ else PInt64(typ.required))(storageType.fieldOffset(src, 0))

--- a/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/DownsampleAggregator.scala
@@ -16,7 +16,7 @@ class DownsampleBTreeKey(binType: PBaseStruct, pointType: PBaseStruct, fb: EmitF
     "empty" -> PBooleanRequired)
 
   val compType: PType = binType
-  private val kcomp = fb.getCodeOrdering[Int](binType, CodeOrdering.compare, ignoreMissingness = false)
+  private val kcomp = fb.getCodeOrdering(binType, CodeOrdering.compare, ignoreMissingness = false)
 
   def isEmpty(off: Code[Long]): Code[Boolean] = coerce[Boolean](Region.loadIRIntermediate(PBooleanRequired)(storageType.fieldOffset(off, "empty")))
 

--- a/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/agg/GroupedAggregator.scala
@@ -15,7 +15,7 @@ class GroupedBTreeKey(kt: PType, fb: EmitFunctionBuilder[_], region: Code[Region
     "container" -> PInt64(true))
 
   val compType: PType = kt
-  private val kcomp = fb.getCodeOrdering[Int](kt, CodeOrdering.compare, ignoreMissingness = false)
+  private val kcomp = fb.getCodeOrdering(kt, CodeOrdering.compare, ignoreMissingness = false)
 
   val regionIdx: Code[Int] = Region.loadInt(storageType.fieldOffset(offset, 1))
   val container = new TupleAggregatorState(fb, states, region, containerAddress(offset), regionIdx)

--- a/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/functions/IntervalFunctions.scala
@@ -143,8 +143,8 @@ class IRInterval(r: EmitRegion, typ: PInterval, value: Code[Long]) {
   val ref: LocalRef[Long] = r.mb.newLocal[Long]
   val region: Code[Region] = r.region
 
-  def ordering[T](op: CodeOrdering.Op): ((Code[Boolean], Code[_]), (Code[Boolean], Code[_])) => Code[T] =
-    r.mb.getCodeOrdering[T](typ.pointType, op)(_, _)
+  def ordering(op: CodeOrdering.Op): ((Code[Boolean], Code[_]), (Code[Boolean], Code[_])) => Code[op.ReturnType] =
+    r.mb.getCodeOrdering(typ.pointType, op)(_, _)
 
   def storeToLocal: Code[Unit] = ref := value
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -2,6 +2,7 @@ package is.hail.expr.types.physical
 
 import is.hail.annotations._
 import is.hail.asm4s.{Code, _}
+import is.hail.table.SortOrder
 import is.hail.utils._
 
 object PBaseStruct {
@@ -84,6 +85,11 @@ abstract class PBaseStruct extends PType {
     sb.append("END")
     sb.result()
   }
+
+  def codeOrdering(mb: EmitMethodBuilder, so: Array[SortOrder]): CodeOrdering =
+    codeOrdering(mb, this, so)
+
+  def codeOrdering(mb: EmitMethodBuilder, other: PType, so: Array[SortOrder]): CodeOrdering
 
   def isIsomorphicTo(other: PBaseStruct): Boolean =
     size == other.size && isCompatibleWith(other)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBaseStruct.scala
@@ -2,6 +2,7 @@ package is.hail.expr.types.physical
 
 import is.hail.annotations._
 import is.hail.asm4s.{Code, _}
+import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.table.SortOrder
 import is.hail.utils._
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBinary.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBinary.scala
@@ -46,7 +46,7 @@ class PBinary(override val required: Boolean) extends PType {
 
   def codeOrdering(mb: EmitMethodBuilder, other: PType): CodeOrdering = {
     assert(other isOfType this)
-    new CodeOrdering {
+    new CodeOrderingCompareConsistentWithOthers {
       type T = Long
 
       def compareNonnull(x: Code[T], y: Code[T]): Code[Int] = {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PBoolean.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PBoolean.scala
@@ -28,7 +28,7 @@ class PBoolean(override val required: Boolean) extends PType {
 
   def codeOrdering(mb: EmitMethodBuilder, other: PType): CodeOrdering = {
     assert(other isOfType this)
-    new CodeOrdering {
+    new CodeOrderingCompareConsistentWithOthers {
       type T = Boolean
 
       def compareNonnull(x: Code[T], y: Code[T]): Code[Int] =

--- a/hail/src/main/scala/is/hail/expr/types/physical/PInt32.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PInt32.scala
@@ -30,7 +30,7 @@ class PInt32(override val required: Boolean) extends PIntegral {
 
   def codeOrdering(mb: EmitMethodBuilder, other: PType): CodeOrdering = {
     assert(other isOfType this)
-    new CodeOrdering {
+    new CodeOrderingCompareConsistentWithOthers {
       type T = Int
 
       def compareNonnull(x: Code[T], y: Code[T]): Code[Int] =

--- a/hail/src/main/scala/is/hail/expr/types/physical/PInt64.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PInt64.scala
@@ -31,7 +31,7 @@ class PInt64(override val required: Boolean) extends PIntegral {
 
   def codeOrdering(mb: EmitMethodBuilder, other: PType): CodeOrdering = {
     assert(other isOfType this)
-    new CodeOrdering {
+    new CodeOrderingCompareConsistentWithOthers {
       type T = Long
 
       def compareNonnull(x: Code[T], y: Code[T]): Code[Int] =

--- a/hail/src/main/scala/is/hail/expr/types/physical/PLocus.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PLocus.scala
@@ -65,7 +65,7 @@ case class PLocus(rgBc: BroadcastRG, override val required: Boolean = false) ext
 
   def codeOrdering(mb: EmitMethodBuilder, other: PType): CodeOrdering = {
     assert(other isOfType this)
-    new CodeOrdering {
+    new CodeOrderingCompareConsistentWithOthers {
       type T = Long
       val contigBin = representation.fundamentalType.fieldType("contig").asInstanceOf[PBinary]
       val bincmp = contigBin.codeOrdering(mb)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PStruct.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PStruct.scala
@@ -5,6 +5,7 @@ import is.hail.asm4s.Code
 import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.expr.types.BaseStruct
 import is.hail.expr.types.virtual.{Field, TStruct, Type}
+import is.hail.table.SortOrder
 import is.hail.utils._
 import org.apache.spark.sql.Row
 
@@ -63,9 +64,13 @@ final case class PStruct(fields: IndexedSeq[PField], override val required: Bool
   override val byteSize: Long = PBaseStruct.getByteSizeAndOffsets(types, nMissingBytes, byteOffsets)
   override val alignment: Long = PBaseStruct.alignment(types)
 
-  def codeOrdering(mb: EmitMethodBuilder, other: PType): CodeOrdering = {
+  override def codeOrdering(mb: EmitMethodBuilder, other: PType): CodeOrdering =
+    codeOrdering(mb, other, null)
+
+  override def codeOrdering(mb: EmitMethodBuilder, other: PType, so: Array[SortOrder]): CodeOrdering = {
     assert(other isOfType this)
-    CodeOrdering.rowOrdering(this, other.asInstanceOf[PStruct], mb)
+    assert(so == null || so.size == types.size)
+    CodeOrdering.rowOrdering(this, other.asInstanceOf[PStruct], mb, so)
   }
 
   def unsafeStructInsert(typeToInsert: PType, path: List[String]): (PStruct, UnsafeInserter) = {

--- a/hail/src/main/scala/is/hail/expr/types/physical/PTuple.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PTuple.scala
@@ -5,6 +5,7 @@ import is.hail.asm4s.Code
 import is.hail.expr.ir.EmitMethodBuilder
 import is.hail.expr.types.BaseStruct
 import is.hail.expr.types.virtual.{TTuple, TupleField}
+import is.hail.table.SortOrder
 import is.hail.utils._
 
 case class PTupleField(index: Int, typ: PType)
@@ -25,9 +26,13 @@ final case class PTuple(_types: IndexedSeq[PTupleField], override val required: 
 
   lazy val fieldIndex: Map[Int, Int] = _types.zipWithIndex.map { case (tf, idx) => tf.index -> idx }.toMap
 
-  def codeOrdering(mb: EmitMethodBuilder, other: PType): CodeOrdering = {
+  override def codeOrdering(mb: EmitMethodBuilder, other: PType): CodeOrdering =
+    codeOrdering(mb, other, null)
+
+  override def codeOrdering(mb: EmitMethodBuilder, other: PType, so: Array[SortOrder]): CodeOrdering = {
     assert(other isOfType this)
-    CodeOrdering.rowOrdering(this, other.asInstanceOf[PTuple], mb)
+    assert(so == null || so.size == types.size)
+    CodeOrdering.rowOrdering(this, other.asInstanceOf[PTuple], mb, so)
   }
 
   override def truncate(newSize: Int): PTuple =

--- a/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PType.scala
@@ -6,6 +6,7 @@ import is.hail.expr.ir.{EmitMethodBuilder, IRParser}
 import is.hail.expr.types.virtual._
 import is.hail.expr.types.{BaseType, Requiredness}
 import is.hail.expr.types.encoded.EType
+import is.hail.table.{ Ascending, Descending, SortOrder }
 import is.hail.utils._
 import is.hail.variant.ReferenceGenome
 import org.json4s.CustomSerializer
@@ -197,7 +198,17 @@ abstract class PType extends BaseType with Serializable with Requiredness {
     sb.append(_toPretty)
   }
 
-  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering = codeOrdering(mb, this)
+  def codeOrdering(mb: EmitMethodBuilder): CodeOrdering =
+    codeOrdering(mb, this)
+
+  def codeOrdering(mb: EmitMethodBuilder, so: SortOrder): CodeOrdering =
+    codeOrdering(mb, this, so)
+
+  def codeOrdering(mb: EmitMethodBuilder, other: PType, so: SortOrder): CodeOrdering =
+    so match {
+      case Ascending => codeOrdering(mb, other)
+      case Descending => codeOrdering(mb, other).reverse
+    }
 
   def codeOrdering(mb: EmitMethodBuilder, other: PType): CodeOrdering
 

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -8,6 +8,7 @@ import is.hail.asm4s._
 import is.hail.TestUtils._
 import is.hail.expr.types.physical._
 import is.hail.expr.types.virtual._
+import is.hail.table.{ Ascending, Descending, SortOrder }
 import is.hail.utils._
 import org.apache.spark.sql.Row
 import org.testng.annotations.{DataProvider, Test}
@@ -27,19 +28,17 @@ class OrderingSuite extends HailSuite {
     inner + 1
   }
 
-  def getStagedOrderingFunction[T: TypeInfo](t: PType, comp: String, r: Region): AsmFunction3[Region, Long, Long, T] = {
-    val fb = EmitFunctionBuilder[Region, Long, Long, T]("ord")
-    val stagedOrdering = t.codeOrdering(fb.apply_method)
-    val cv1 = coerce[stagedOrdering.T](Region.getIRIntermediate(t)(fb.getArg[Long](2)))
-    val cv2 = coerce[stagedOrdering.T](Region.getIRIntermediate(t)(fb.getArg[Long](3)))
-    comp match {
-      case "compare" => fb.emit(stagedOrdering.compare((const(false), cv1), (const(false), cv2)))
-      case "equiv" => fb.emit(stagedOrdering.equiv((const(false), cv1), (const(false), cv2)))
-      case "lt" => fb.emit(stagedOrdering.lt((const(false), cv1), (const(false), cv2)))
-      case "lteq" => fb.emit(stagedOrdering.lteq((const(false), cv1), (const(false), cv2)))
-      case "gt" => fb.emit(stagedOrdering.gt((const(false), cv1), (const(false), cv2)))
-      case "gteq" => fb.emit(stagedOrdering.gteq((const(false), cv1), (const(false), cv2)))
-    }
+  def getStagedOrderingFunction(
+    t: PType,
+    op: CodeOrdering.Op,
+    r: Region,
+    sortOrder: SortOrder = Ascending
+  ): AsmFunction3[Region, Long, Long, op.ReturnType] = {
+    implicit val x = op.rtti
+    val fb = EmitFunctionBuilder[Region, Long, Long, op.ReturnType]("lifted")
+    val cv1 = Region.getIRIntermediate(t)(fb.getArg[Long](2))
+    val cv2 = Region.getIRIntermediate(t)(fb.getArg[Long](3))
+    fb.emit(fb.apply_method.getCodeOrdering(t, op)((const(false), cv1), (const(false), cv2)))
     fb.resultWithIndex()(0, r)
   }
 
@@ -63,34 +62,93 @@ class OrderingSuite extends HailSuite {
         val v2 = rvb.end()
 
         val compare = java.lang.Integer.signum(t.ordering.compare(a1, a2))
-        val fcompare = getStagedOrderingFunction[Int](pType, "compare", region)
+        val fcompare = getStagedOrderingFunction(pType, CodeOrdering.compare, region)
         val result = java.lang.Integer.signum(fcompare(region, v1, v2))
 
         assert(result == compare, s"compare expected: $compare vs $result")
 
 
         val equiv = t.ordering.equiv(a1, a2)
-        val fequiv = getStagedOrderingFunction[Boolean](pType, "equiv", region)
+        val fequiv = getStagedOrderingFunction(pType, CodeOrdering.equiv, region)
 
         assert(fequiv(region, v1, v2) == equiv, s"equiv expected: $equiv")
 
         val lt = t.ordering.lt(a1, a2)
-        val flt = getStagedOrderingFunction[Boolean](pType, "lt", region)
+        val flt = getStagedOrderingFunction(pType, CodeOrdering.lt, region)
 
         assert(flt(region, v1, v2) == lt, s"lt expected: $lt")
 
         val lteq = t.ordering.lteq(a1, a2)
-        val flteq = getStagedOrderingFunction[Boolean](pType, "lteq", region)
+        val flteq = getStagedOrderingFunction(pType, CodeOrdering.lteq, region)
 
         assert(flteq(region, v1, v2) == lteq, s"lteq expected: $lteq")
 
         val gt = t.ordering.gt(a1, a2)
-        val fgt = getStagedOrderingFunction[Boolean](pType, "gt", region)
+        val fgt = getStagedOrderingFunction(pType, CodeOrdering.gt, region)
 
         assert(fgt(region, v1, v2) == gt, s"gt expected: $gt")
 
         val gteq = t.ordering.gteq(a1, a2)
-        val fgteq = getStagedOrderingFunction[Boolean](pType, "gteq", region)
+        val fgteq = getStagedOrderingFunction(pType, CodeOrdering.gteq, region)
+
+        assert(fgteq(region, v1, v2) == gteq, s"gteq expected: $gteq")
+      }
+
+      true
+    }
+    p.check()
+  }
+
+  @Test def testReverseIsSwappedArgumentsOfExtendedOrdering() {
+    val compareGen = for {
+      t <- Type.genArb
+      a1 <- t.genNonmissingValue
+      a2 <- t.genNonmissingValue
+    } yield (t, a1, a2)
+    val p = Prop.forAll(compareGen) { case (t, a1, a2) =>
+      Region.scoped { region =>
+        val pType = PType.canonical(t)
+        val rvb = new RegionValueBuilder(region)
+
+        rvb.start(pType)
+        rvb.addAnnotation(t, a1)
+        val v1 = rvb.end()
+
+        rvb.start(pType)
+        rvb.addAnnotation(t, a2)
+        val v2 = rvb.end()
+
+        val reversedExtendedOrdering = t.ordering.reverse
+
+        val compare = java.lang.Integer.signum(reversedExtendedOrdering.compare(a2, a1))
+        val fcompare = getStagedOrderingFunction(pType, CodeOrdering.compare, region, Descending)
+        val result = java.lang.Integer.signum(fcompare(region, v1, v2))
+
+        assert(result == compare, s"compare expected: $compare vs $result")
+
+
+        val equiv = reversedExtendedOrdering.equiv(a2, a1)
+        val fequiv = getStagedOrderingFunction(pType, CodeOrdering.equiv, region, Descending)
+
+        assert(fequiv(region, v1, v2) == equiv, s"equiv expected: $equiv")
+
+        val lt = reversedExtendedOrdering.lt(a2, a1)
+        val flt = getStagedOrderingFunction(pType, CodeOrdering.lt, region, Descending)
+
+        assert(flt(region, v1, v2) == lt, s"lt expected: $lt")
+
+        val lteq = reversedExtendedOrdering.lteq(a2, a1)
+        val flteq = getStagedOrderingFunction(pType, CodeOrdering.lteq, region, Descending)
+
+        assert(flteq(region, v1, v2) == lteq, s"lteq expected: $lteq")
+
+        val gt = reversedExtendedOrdering.gt(a2, a1)
+        val fgt = getStagedOrderingFunction(pType, CodeOrdering.gt, region, Descending)
+
+        assert(fgt(region, v1, v2) == gt, s"gt expected: $gt")
+
+        val gteq = reversedExtendedOrdering.gteq(a2, a1)
+        val fgteq = getStagedOrderingFunction(pType, CodeOrdering.gteq, region, Descending)
 
         assert(fgteq(region, v1, v2) == gteq, s"gteq expected: $gteq")
       }

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -446,7 +446,6 @@ class OrderingSuite extends HailSuite {
 
     val args = FastIndexedSeq(r -> t, r2 -> t)
 
-    println(s"${r} ${r2}")
     assertEvalSame(ApplyComparisonOp(EQ(t, t), In(0, t), In(1, t)), args)
     assertEvalSame(ApplyComparisonOp(EQWithNA(t, t), In(0, t), In(1, t)), args)
     assertEvalSame(ApplyComparisonOp(NEQ(t, t), In(0, t), In(1, t)), args)

--- a/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/OrderingSuite.scala
@@ -388,6 +388,7 @@ class OrderingSuite extends HailSuite {
 
     val args = FastIndexedSeq(r -> t, r2 -> t)
 
+    println(s"${r} ${r2}")
     assertEvalSame(ApplyComparisonOp(EQ(t, t), In(0, t), In(1, t)), args)
     assertEvalSame(ApplyComparisonOp(EQWithNA(t, t), In(0, t), In(1, t)), args)
     assertEvalSame(ApplyComparisonOp(NEQ(t, t), In(0, t), In(1, t)), args)

--- a/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/StagedBTreeSuite.scala
@@ -14,7 +14,7 @@ import org.testng.annotations.Test
 
 import scala.collection.mutable
 class TestBTreeKey(mb: EmitMethodBuilder) extends BTreeKey {
-  private val comp = mb.getCodeOrdering[Int](PInt64(), CodeOrdering.compare)
+  private val comp = mb.getCodeOrdering(PInt64(), CodeOrdering.compare)
   def storageType: PTuple = PTuple(required = true, PInt64(), PTuple())
   def compType: PType = PInt64()
   def isEmpty(off: Code[Long]): Code[Boolean] =


### PR DESCRIPTION
`order_by` supports sort fields. Eventually `order_by` will use the shuffler. To support this `CodeOrdering` needs to support sort fields.

I didn't actually add any tests. The Shuffler will eventually land and use this to do non-standard orderings.

There's a lot of noise due to threading SortField's everywhere, but the implementation of `CodeOrdering.reverse` and `PType.codeOrdering` are actually quite simple.

I also cleaned the code that I touched by abstracting over lt, lteq, gt, gteq.