### PR TITLE
[hail] do not require a hail context if there are no literals

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/EmitFunctionBuilder.scala
@@ -554,9 +554,13 @@ class EmitFunctionBuilder[F >: Null](
     val childClasses = children.result().map(f => (f.name.replace("/","."), f.classAsBytes(print)))
 
     val hasLiterals: Boolean = literalsMap.nonEmpty
-    val literals: Array[Byte] = if (hasLiterals) encodeLiterals() else Array()
 
-    val literalsBc = HailContext.get.backend.broadcast(literals)
+    val literalsBc = if (hasLiterals) {
+      HailContext.get.backend.broadcast(encodeLiterals())
+    } else {
+      // if there are no literals, there might not be a HailContext
+      null
+    }
 
     val bytes = classAsBytes(print)
     val n = name.replace("/",".")


### PR DESCRIPTION
I use the compiler in the shuffler to check if an interval contains a key. I didn't see any way to do this without running the compiler on this IR:
```
        ApplySpecial(
          "contains",
          Seq(
            Ref("interval", intervalType.virtualType),
            Ref("key", wireKeyType.virtualType)),
          TBoolean(true))
```
And I don't want to start Spark (to create a HailContext) in the shuffler.