### PR TITLE
[hail] simplify region value fromBytes code

### DIFF
--- a/hail/src/main/scala/is/hail/annotations/RegionValue.scala
+++ b/hail/src/main/scala/is/hail/annotations/RegionValue.scala
@@ -3,7 +3,7 @@ package is.hail.annotations
 import java.io._
 
 import is.hail.expr.types.physical.PType
-import is.hail.utils.RestartableByteArrayInputStream
+import is.hail.utils.{using, RestartableByteArrayInputStream}
 import is.hail.io._
 import sun.reflect.generics.reflectiveObjects.NotImplementedException
 
@@ -17,17 +17,17 @@ object RegionValue {
   def fromBytes(
     makeDec: InputStream => Decoder,
     r: Region,
-    carrierRv: RegionValue
-  )(byteses: Iterator[Array[Byte]]
+    byteses: Iterator[Array[Byte]]
   ): Iterator[RegionValue] = {
+    val rv = RegionValue(r)
     val bad = new ByteArrayDecoder(makeDec)
     byteses.map { bytes =>
-      carrierRv.setOffset(bad.regionValueFromBytes(r, bytes))
-      carrierRv
+      rv.setOffset(bad.regionValueFromBytes(r, bytes))
+      rv
     }
   }
 
-  def fromBytes(
+  def pointerFromBytes(
     makeDec: InputStream => Decoder,
     r: Region,
     byteses: Iterator[Array[Byte]]

--- a/hail/src/main/scala/is/hail/io/CodecSpec.scala
+++ b/hail/src/main/scala/is/hail/io/CodecSpec.scala
@@ -48,8 +48,7 @@ trait AbstractTypedCodecSpec extends Spec {
   def decodeRDD(requestedType: Type, bytes: RDD[Array[Byte]]): (PType, ContextRDD[RVDContext, RegionValue]) = {
     val (pt, dec) = buildDecoder(requestedType)
     (pt, ContextRDD.weaken[RVDContext](bytes).cmapPartitions { (ctx, it) =>
-      val rv = RegionValue(ctx.region)
-      RegionValue.fromBytes(dec, ctx.region, rv)(it)
+      RegionValue.fromBytes(dec, ctx.region, it)
     })
   }
 

--- a/hail/src/main/scala/is/hail/rvd/RVD.scala
+++ b/hail/src/main/scala/is/hail/rvd/RVD.scala
@@ -668,7 +668,7 @@ class RVD(
     val encodedData = collectAsBytes(enc)
     val (pType: PStruct, dec) = enc.buildDecoder(rowType)
     Region.scoped { region =>
-      RegionValue.fromBytes(dec, region, RegionValue(region))(encodedData.iterator)
+      RegionValue.fromBytes(dec, region, encodedData.iterator)
         .map { rv =>
           val row = SafeRow(pType, rv)
           region.clear()
@@ -1172,8 +1172,7 @@ class RVD(
   ): (PStruct, ContextRDD[RVDContext, RegionValue]) = {
     val (rowPType: PStruct, dec) = enc.buildDecoder(rowType)
     (rowPType, ContextRDD.weaken[RVDContext](stable).cmapPartitions { (ctx, it) =>
-      val rv = RegionValue(ctx.region)
-      RegionValue.fromBytes(dec, ctx.region, rv)(it)
+      RegionValue.fromBytes(dec, ctx.region, it)
     })
   }
 


### PR DESCRIPTION
Cosmetic. Seemed simpler overall to not take an RV to mutate. No one used this in a smart way anyway.