### PR TITLE
[hail] Simplify buffer spec parsing code

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixValue.scala
@@ -185,20 +185,14 @@ case class MatrixValue(
   def write(path: String,
     overwrite: Boolean,
     stageLocally: Boolean,
-    codecSpecJSONStr: String,
+    codecSpecJSON: String,
     partitions: String,
     partitionsTypeStr: String) = {
     assert(typ.isCanonical)
     val hc = HailContext.get
     val fs = hc.sFS
 
-    val bufferSpec =
-      if (codecSpecJSONStr != null) {
-        implicit val formats = AbstractRVDSpec.formats
-        val codecSpecJSON = parse(codecSpecJSONStr)
-        codecSpecJSON.extract[BufferSpec]
-      } else
-        BufferSpec.default
+    val bufferSpec = BufferSpec.parseOrDefault(codecSpecJSON)
 
     if (overwrite)
       fs.delete(path, recursive = true)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -874,15 +874,13 @@ object IRParser {
       case "SerializeAggs" =>
         val i = int32_literal(it)
         val i2 = int32_literal(it)
-        implicit val formats: Formats = AbstractRVDSpec.formats
-        val spec = JsonMethods.parse(string_literal(it)).extract[BufferSpec]
+        val spec = BufferSpec.parse(string_literal(it))
         val aggSigs = agg_signatures(env.typEnv)(it)
         SerializeAggs(i, i2, spec, aggSigs)
       case "DeserializeAggs" =>
         val i = int32_literal(it)
         val i2 = int32_literal(it)
-        implicit val formats: Formats = AbstractRVDSpec.formats
-        val spec = JsonMethods.parse(string_literal(it)).extract[BufferSpec]
+        val spec = BufferSpec.parse(string_literal(it))
         val aggSigs = agg_signatures(env.typEnv)(it)
         DeserializeAggs(i, i2, spec, aggSigs)
       case "InitOp" =>
@@ -1021,7 +1019,7 @@ object IRParser {
         val name = identifier(it)
         env.irMap(name).asInstanceOf[IR]
       case "ReadPartition" =>
-        implicit val formats: Formats = AbstractRVDSpec.formats
+        import AbstractRVDSpec.formats
         val spec = JsonMethods.parse(string_literal(it)).extract[AbstractTypedCodecSpec]
         val rowType = coerce[TStruct](type_expr(env.typEnv)(it))
         val path = ir_value_expr(env)(it)

--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -65,16 +65,12 @@ case class TableValue(typ: TableType, globals: BroadcastRow, rvd: RVD) {
     filterWithPartitionOp((_, _) => ())((_, rv1, rv2) => p(rv1, rv2))
   }
 
-  def write(path: String, overwrite: Boolean, stageLocally: Boolean, codecSpecJSONStr: String) {
+  def write(path: String, overwrite: Boolean, stageLocally: Boolean, codecSpecJSON: String) {
     assert(typ.isCanonical)
     val hc = HailContext.get
     val fs = hc.sFS
 
-    val bufferSpec: BufferSpec = if (codecSpecJSONStr != null) {
-      implicit val formats = AbstractRVDSpec.formats
-      val codecSpecJSON = JsonMethods.parse(codecSpecJSONStr)
-      codecSpecJSON.extract[BufferSpec]
-    } else BufferSpec.default
+    val bufferSpec = BufferSpec.parse(codecSpecJSON)
 
     if (overwrite)
       fs.delete(path, recursive = true)

--- a/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/TableValue.scala
@@ -70,7 +70,7 @@ case class TableValue(typ: TableType, globals: BroadcastRow, rvd: RVD) {
     val hc = HailContext.get
     val fs = hc.sFS
 
-    val bufferSpec = BufferSpec.parse(codecSpecJSON)
+    val bufferSpec = BufferSpec.parseOrDefault(codecSpecJSON)
 
     if (overwrite)
       fs.delete(path, recursive = true)

--- a/hail/src/main/scala/is/hail/io/BufferSpecs.scala
+++ b/hail/src/main/scala/is/hail/io/BufferSpecs.scala
@@ -33,6 +33,9 @@ object BufferSpec {
     Array(blockSpec, LEB128BufferSpec(blockSpec))
   }
 
+  val wireSpec: BufferSpec = default
+  val memorySpec: BufferSpec = default
+
   def parse(s: String): BufferSpec = {
     import AbstractRVDSpec.formats
     JsonMethods.parse(s).extract[BufferSpec]

--- a/hail/src/main/scala/is/hail/io/BufferSpecs.scala
+++ b/hail/src/main/scala/is/hail/io/BufferSpecs.scala
@@ -49,8 +49,6 @@ object BufferSpec {
   val shortTypeHints = ShortTypeHints(List(
       classOf[BlockBufferSpec],
       classOf[LZ4BlockBufferSpec],
-      classOf[LZ4HCBlockBufferSpec],
-      classOf[LZ4FastBlockBufferSpec],
       classOf[StreamBlockBufferSpec],
       classOf[BufferSpec],
       classOf[LEB128BufferSpec],

--- a/hail/src/main/scala/is/hail/io/BufferSpecs.scala
+++ b/hail/src/main/scala/is/hail/io/BufferSpecs.scala
@@ -4,7 +4,7 @@ import is.hail.rvd.AbstractRVDSpec
 import java.io._
 
 import is.hail.asm4s._
-import is.hail.io.compress.LZ4
+import is.hail.io.compress.LZ4Utils
 import org.json4s.{ DefaultFormats, Formats, ShortTypeHints }
 
 import org.json4s.jackson.JsonMethods

--- a/hail/src/main/scala/is/hail/io/BufferSpecs.scala
+++ b/hail/src/main/scala/is/hail/io/BufferSpecs.scala
@@ -1,9 +1,11 @@
 package is.hail.io
 
+import is.hail.rvd.AbstractRVDSpec
 import java.io._
 
 import is.hail.asm4s._
-import is.hail.io.compress.LZ4Utils
+import is.hail.io.compress.LZ4
+import org.json4s.{ DefaultFormats, Formats, ShortTypeHints }
 
 import org.json4s.jackson.JsonMethods
 import org.json4s.{Extraction, JValue}
@@ -31,8 +33,27 @@ object BufferSpec {
     Array(blockSpec, LEB128BufferSpec(blockSpec))
   }
 
-  val wireSpec: BufferSpec = default
-  val memorySpec: BufferSpec = default
+  def parse(s: String): BufferSpec = {
+    import AbstractRVDSpec.formats
+    JsonMethods.parse(s).extract[BufferSpec]
+  }
+
+  def parseOrDefault(
+    s: String,
+    default: BufferSpec = BufferSpec.default
+  ): BufferSpec = if (s == null) default else parse(s)
+
+  val shortTypeHints = ShortTypeHints(List(
+      classOf[BlockBufferSpec],
+      classOf[LZ4BlockBufferSpec],
+      classOf[LZ4HCBlockBufferSpec],
+      classOf[LZ4FastBlockBufferSpec],
+      classOf[StreamBlockBufferSpec],
+      classOf[BufferSpec],
+      classOf[LEB128BufferSpec],
+      classOf[BlockingBufferSpec],
+      classOf[StreamBufferSpec]
+    ))
 }
 
 trait BufferSpec extends Spec {

--- a/hail/src/main/scala/is/hail/io/Spec.scala
+++ b/hail/src/main/scala/is/hail/io/Spec.scala
@@ -6,7 +6,7 @@ import org.json4s.jackson.JsonMethods
 
 trait Spec extends Serializable {
   override def toString: String = {
-    implicit val formats = AbstractRVDSpec.formats
+    import AbstractRVDSpec.formats
     val jv = Extraction.decompose(this)
     JsonMethods.compact(JsonMethods.render(jv))
   }

--- a/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
+++ b/hail/src/main/scala/is/hail/io/index/IndexWriter.scala
@@ -220,7 +220,7 @@ class IndexWriter(
         "index",
         rootOffset,
         attributes)
-      implicit val formats: Formats = AbstractRVDSpec.formats
+      import AbstractRVDSpec.formats
       Serialization.write(metadata, out)
     }
   }

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -25,17 +25,11 @@ object AbstractRVDSpec {
       classOf[compatibility.IndexedRVDSpec],
       classOf[compatibility.IndexSpec],
       classOf[compatibility.UnpartitionedRVDSpec],
-      classOf[BlockBufferSpec],
-      classOf[LZ4BlockBufferSpec],
-      classOf[StreamBlockBufferSpec],
-      classOf[BufferSpec],
-      classOf[LEB128BufferSpec],
-      classOf[BlockingBufferSpec],
-      classOf[StreamBufferSpec],
       classOf[AbstractTypedCodecSpec],
-      classOf[TypedCodecSpec]))
+      classOf[TypedCodecSpec])
+    ) + BufferSpec.shortTypeHints
     override val typeHintFieldName = "name"
-  } +
+  }  +
     new TStructSerializer +
     new TypeSerializer +
     new PTypeSerializer +

--- a/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/src/main/scala/is/hail/rvd/AbstractRVDSpec.scala
@@ -183,7 +183,7 @@ abstract class AbstractRVDSpec {
 
   def write(fs: FS, path: String) {
     fs.writeTextFile(path + "/metadata.json.gz") { out =>
-      implicit val formats = AbstractRVDSpec.formats
+      import AbstractRVDSpec.formats
       Serialization.write(this, out)
     }
   }


### PR DESCRIPTION
Cosmetic. I was working on buffer specs and noticed this duplicative code. Also we should never do `implicit val = x....z` if `z` is marked `implicit`. It is equivalent to `import x....z`.