### PR TITLE
[hail] add HTTPClient which abstracts over Apache HTTP client

### DIFF
--- a/hail/src/main/scala/is/hail/utils/HTTPClient.scala
+++ b/hail/src/main/scala/is/hail/utils/HTTPClient.scala
@@ -1,0 +1,65 @@
+package is.hail.utils
+
+import java.net.URL
+import java.io.OutputStream
+import java.io.InputStream
+import java.net.HttpURLConnection
+import is.hail.utils._
+import java.nio.charset.StandardCharsets
+import org.apache.commons.io.output.ByteArrayOutputStream
+
+
+object HTTPClient {
+  def post[T](
+    url: String,
+    contentLength: Int,
+    writeBody: OutputStream => Unit,
+    readResponse: InputStream => T = (_: InputStream) => (),
+    chunkSize: Int = 0
+  ): T = {
+    val conn = new URL(url).openConnection().asInstanceOf[HttpURLConnection]
+    conn.setRequestMethod("POST")
+    if (chunkSize > 0)
+      conn.setChunkedStreamingMode(chunkSize)
+    conn.setDoOutput(true);
+    conn.setRequestProperty("Content-Length", Integer.toString(contentLength))
+    using(conn.getOutputStream())(writeBody)
+    assert(200 <= conn.getResponseCode() && conn.getResponseCode() < 300,
+      s"POST ${url} ${conn.getResponseCode()} ${using(conn.getErrorStream())(fullyReadInputStreamAsString)}")
+    val result = using(conn.getInputStream())(readResponse)
+    conn.disconnect()
+    result
+  }
+
+  def get[T](
+    url: String,
+    readResponse: InputStream => T
+  ): T = {
+    val conn = new URL(url).openConnection().asInstanceOf[HttpURLConnection]
+    conn.setRequestMethod("GET")
+    assert(200 <= conn.getResponseCode() && conn.getResponseCode() < 300,
+      s"GET ${url} ${conn.getResponseCode()} ${using(conn.getErrorStream())(fullyReadInputStreamAsString)}")
+    val result = using(conn.getInputStream())(readResponse)
+    conn.disconnect()
+    result
+  }
+
+  def delete(
+    url: String,
+    readResponse: InputStream => Unit = (_: InputStream) => ()
+  ): Unit = {
+    val conn = new URL(url).openConnection().asInstanceOf[HttpURLConnection]
+    conn.setRequestMethod("DELETE")
+    assert(200 <= conn.getResponseCode() && conn.getResponseCode() < 300,
+      s"DELETE ${url} ${conn.getResponseCode()} ${using(conn.getErrorStream())(fullyReadInputStreamAsString)}")
+    val result = using(conn.getInputStream())(readResponse)
+    conn.disconnect()
+    result
+  }
+
+  private[this] def fullyReadInputStreamAsString(is: InputStream): String =
+    using(new ByteArrayOutputStream()) { baos =>
+      drainInputStreamToOutputStream(is, baos)
+      new String(baos.toByteArray(), StandardCharsets.UTF_8)
+    }
+}

--- a/hail/src/main/scala/is/hail/utils/package.scala
+++ b/hail/src/main/scala/is/hail/utils/package.scala
@@ -792,6 +792,17 @@ package object utils extends Logging
     f(arg1, arg2, arg3, arg4, arg5, arg6)
   }
 
+  def drainInputStreamToOutputStream(
+    is: InputStream,
+    os: OutputStream
+  ): Unit = {
+    val buffer = new Array[Byte](1024)
+    var length = is.read(buffer)
+    while (length != -1) {
+      os.write(buffer, 0, length);
+      length = is.read(buffer)
+    }
+  }
 }
 
 // FIXME: probably resolved in 3.6 https://github.com/json4s/json4s/commit/fc96a92e1aa3e9e3f97e2e91f94907fdfff6010d


### PR DESCRIPTION
Take a wild guess what this is for.

The Java HTTP libraries are oddly complicated. This makes each verb I need in the shuffler a static method.