### PR TITLE
[hailtop, batch2] improve retry

### DIFF
--- a/batch2/Dockerfile.test
+++ b/batch2/Dockerfile.test
@@ -10,4 +10,4 @@ RUN python3 -m pip install --no-cache-dir \
   pytest-instafail==0.4.1 \
   pytest-asyncio==0.10.0
 
-CMD ["python3", "-m", "pytest", "-s", "-v", "--instafail", "-k", "not test_scale", "/test/"]
+CMD ["python3", "-m", "pytest", "--log-cli-level=INFO", "-s", "-v", "--instafail", "-k", "not test_scale", "/test/"]

--- a/batch2/test/test_aioclient.py
+++ b/batch2/test/test_aioclient.py
@@ -1,8 +1,5 @@
-import logging
 import pytest
 from hailtop.batch_client.aioclient import BatchClient
-
-logging.basicConfig(level=logging.INFO)
 
 pytestmark = pytest.mark.asyncio
 

--- a/batch2/test/test_aioclient.py
+++ b/batch2/test/test_aioclient.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 from hailtop.batch_client.aioclient import BatchClient
 

--- a/batch2/test/test_aioclient.py
+++ b/batch2/test/test_aioclient.py
@@ -1,6 +1,8 @@
 import pytest
 from hailtop.batch_client.aioclient import BatchClient
 
+logging.basicConfig(level=logging.INFO)
+
 pytestmark = pytest.mark.asyncio
 
 

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -5,7 +5,6 @@ from hailtop.batch_client.client import BatchClient
 import json
 import os
 import base64
-import logging
 import pkg_resources
 import secrets
 import time
@@ -16,8 +15,6 @@ import requests
 from hailtop.config import get_deploy_config
 
 from .serverthread import ServerThread
-
-logging.basicConfig(level=logging.INFO)
 
 
 def poll_until(p, max_polls=None):

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -5,6 +5,7 @@ from hailtop.batch_client.client import BatchClient
 import json
 import os
 import base64
+import logging
 import pkg_resources
 import secrets
 import time
@@ -12,10 +13,11 @@ import unittest
 import aiohttp
 from flask import Flask, Response, request
 import requests
-
 from hailtop.config import get_deploy_config
 
 from .serverthread import ServerThread
+
+logging.basicConfig(level=logging.INFO)
 
 
 def poll_until(p, max_polls=None):

--- a/batch2/test/test_dag.py
+++ b/batch2/test/test_dag.py
@@ -1,8 +1,9 @@
 import os
 import time
+import logging
+import re
 import pytest
 import aiohttp
-import re
 from flask import Response
 from hailtop.batch_client.client import BatchClient, Job
 import hailtop.batch_client.aioclient as aioclient

--- a/batch2/test/test_dag.py
+++ b/batch2/test/test_dag.py
@@ -10,6 +10,8 @@ from hailtop.auth import get_userinfo
 
 from .serverthread import ServerThread
 
+logging.basicConfig(level=logging.INFO)
+
 
 @pytest.fixture
 def client():

--- a/batch2/test/test_dag.py
+++ b/batch2/test/test_dag.py
@@ -1,6 +1,5 @@
 import os
 import time
-import logging
 import re
 import pytest
 import aiohttp
@@ -10,8 +9,6 @@ import hailtop.batch_client.aioclient as aioclient
 from hailtop.auth import get_userinfo
 
 from .serverthread import ServerThread
-
-logging.basicConfig(level=logging.INFO)
 
 
 @pytest.fixture

--- a/batch2/test/test_scale.py
+++ b/batch2/test/test_scale.py
@@ -1,10 +1,7 @@
 import random
-import logging
 import pytest
 
 from hailtop.batch_client.client import BatchClient
-
-logging.basicConfig(level=logging.INFO)
 
 
 @pytest.fixture

--- a/batch2/test/test_scale.py
+++ b/batch2/test/test_scale.py
@@ -3,6 +3,8 @@ import random
 
 from hailtop.batch_client.client import BatchClient
 
+logging.basicConfig(level=logging.INFO)
+
 
 @pytest.fixture
 def client():

--- a/batch2/test/test_scale.py
+++ b/batch2/test/test_scale.py
@@ -1,5 +1,6 @@
-import pytest
 import random
+import logging
+import pytest
 
 from hailtop.batch_client.client import BatchClient
 

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -9,10 +9,11 @@ async def async_get_userinfo(deploy_config=None):
     if not deploy_config:
         deploy_config = get_deploy_config()
     headers = service_auth_headers(deploy_config, 'auth')
+    userinfo_url = deploy_config.url('auth', '/api/v1alpha/userinfo')
     async with aiohttp.ClientSession(
-            raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
-        async with session.get(
-                deploy_config.url('auth', '/api/v1alpha/userinfo'), headers=headers) as resp:
+            raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
+        async with request_retry_transient_errors(
+                session.get, userinfo_url, headers=headers) as resp:
             return await resp.json()
 
 

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -12,9 +12,9 @@ async def async_get_userinfo(deploy_config=None):
     userinfo_url = deploy_config.url('auth', '/api/v1alpha/userinfo')
     async with aiohttp.ClientSession(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
-        async with request_retry_transient_errors(
-                session.get, userinfo_url, headers=headers) as resp:
-            return await resp.json()
+        resp = await request_retry_transient_errors(
+            session.get, userinfo_url, headers=headers)
+        return await resp.json()
 
 
 def get_userinfo(deploy_config=None):

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -1,6 +1,6 @@
 import aiohttp
 from hailtop.config import get_deploy_config
-from hailtop.utils import async_to_blocking
+from hailtop.utils import async_to_blocking, request_retry_transient_errors
 
 from .tokens import get_tokens
 

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -1,4 +1,5 @@
-from .utils import unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool
+from .utils import unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool, \
+    request_retry_transient_errors
 from .process import CalledProcessError, check_shell, check_shell_output
 
 __all__ = [
@@ -8,5 +9,6 @@ __all__ = [
     'AsyncWorkerPool',
     'CalledProcessError',
     'check_shell',
-    'check_shell_output'
+    'check_shell_output',
+    'request_retry_transient_errors'
 ]

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -58,7 +58,7 @@ async def request_retry_transient_errors(f, *args, **kwargs):
         try:
             return await f(*args, **kwargs)
         # observed exceptions:
-        # aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host <host> ssl:None [Connect call failed (<ip>, 80)]
+        # aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host <host> ssl:None [Connect call failed ('<ip>', 80)]
         except aiohttp.ClientResponseError as e:
             # 408 request timeout, 503 service unavailable, 504 gateway timeout
             if e.status == 408 or e.status == 503 or e.status == 504:

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -57,6 +57,8 @@ async def request_retry_transient_errors(f, *args, **kwargs):
     while True:
         try:
             return await f(*args, **kwargs)
+        # observed exceptions:
+        # aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host <host> ssl:None [Connect call failed (<ip>, 80)]
         except aiohttp.ClientResponseError as e:
             # 408 request timeout, 503 service unavailable, 504 gateway timeout
             if e.status == 408 or e.status == 503 or e.status == 504:

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -1,5 +1,8 @@
-import asyncio
+import errno
+import random
 import logging
+import asyncio
+import aiohttp
 
 log = logging.getLogger('hailtop.utils')
 


### PR DESCRIPTION
retry in get_userinfo
retry on ClientOSError (client connection error) on timeout
log errno to diagnose future failures

Some of the current errors are ClientOSErrors (ClientConnectionErrors, actually) with strerror "Connect call failed" but that doesn't correspond to a standard errno message returned by perror/os.strerror as far as I can tell.  So I'm retrying on timeout (good) and logging the errno so we can diagnose future transient failures.