### PR TITLE
[gear, hailtop] improve retry 2

### DIFF
--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -5,7 +5,7 @@ import aiohttp
 from aiohttp import web
 import aiohttp_session
 from hailtop.config import get_deploy_config
-from hailtop.utils import request_raise_transient_errors
+from hailtop.utils import request_retry_transient_errors
 
 log = logging.getLogger('gear.auth')
 

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -17,7 +17,7 @@ async def _userdata_from_session_id(session_id):
     try:
         async with aiohttp.ClientSession(
                 raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
-            resp = request_retry_transient_errors(
+            resp = await request_retry_transient_errors(
                 session, 'GET', deploy_config.url('auth', '/api/v1alpha/userinfo'),
                 headers=headers)
             assert resp.status == 200

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -17,13 +17,11 @@ async def _userdata_from_session_id(session_id):
     try:
         async with aiohttp.ClientSession(
                 raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
-            resp = request_raise_transient_errors(
+            resp = request_retry_transient_errors(
                 session, 'GET', deploy_config.url('auth', '/api/v1alpha/userinfo'),
                 headers=headers)
             assert resp.status == 200
             return await resp.json()
-    except web.HTTPServiceUnavailable:
-        raise
     except aiohttp.ClientResponseError as e:
         if e.status == 401:
             return None

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -5,6 +5,7 @@ import aiohttp
 from aiohttp import web
 import aiohttp_session
 from hailtop.config import get_deploy_config
+from hailtop.utils import request_raise_transient_errors
 
 log = logging.getLogger('gear.auth')
 

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -16,7 +16,7 @@ async def _userdata_from_session_id(session_id):
     try:
         async with aiohttp.ClientSession(
                 raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
-            resp = request_raise_transient_error(
+            resp = request_raise_transient_errors(
                 session, 'GET', deploy_config.url('auth', '/api/v1alpha/userinfo'),
                 headers=headers)
             assert resp.status == 200

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -21,6 +21,8 @@ async def _userdata_from_session_id(session_id):
                 headers=headers)
             assert resp.status == 200
             return await resp.json()
+    except web.HTTPServiceUnavailable:
+        raise
     except aiohttp.ClientResponseError as e:
         if e.status == 401:
             return None

--- a/hail/python/hailtop/auth/auth.py
+++ b/hail/python/hailtop/auth/auth.py
@@ -13,7 +13,7 @@ async def async_get_userinfo(deploy_config=None):
     async with aiohttp.ClientSession(
             raise_for_status=True, timeout=aiohttp.ClientTimeout(total=5)) as session:
         resp = await request_retry_transient_errors(
-            session.get, userinfo_url, headers=headers)
+            session, 'GET', userinfo_url, headers=headers)
         return await resp.json()
 
 

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -447,22 +447,22 @@ class BatchClient:
 
     async def _get(self, path, params=None):
         return await request_retry_transient_errors(
-            self._session.get,
+            self._session, 'GET',
             self.url + path, params=params, headers=self._headers)
 
     async def _post(self, path, json=None):
         return await request_retry_transient_errors(
-            self._session.post,
+            self._session, 'POST',
             self.url + path, json=json, headers=self._headers)
 
     async def _patch(self, path):
         return await request_retry_transient_errors(
-            self._session.patch,
+            self._session, 'PATCH',
             self.url + path, headers=self._headers)
 
     async def _delete(self, path):
         return await request_retry_transient_errors(
-            self._session.delete,
+            self._session, 'DELETE',
             self.url + path, headers=self._headers)
 
     async def list_batches(self, complete=None, success=None, attributes=None):

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -1,5 +1,5 @@
 from .utils import unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool, \
-    request_retry_transient_errors
+    request_retry_transient_errors, request_raise_transient_errors
 from .process import CalledProcessError, check_shell, check_shell_output
 
 __all__ = [

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -10,5 +10,6 @@ __all__ = [
     'CalledProcessError',
     'check_shell',
     'check_shell_output',
-    'request_retry_transient_errors'
+    'request_retry_transient_errors',
+    'request_raise_transient_errors'
 ]

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -94,5 +94,4 @@ async def request_raise_transient_errors(session, method, url, **kwargs):
         if is_transient_error(e):
             log.exception('request failed with transient exception: {method} {url}')
             raise web.HTTPServiceUnavailable()
-        else:
-            raise
+        raise

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -70,7 +70,7 @@ def is_transient_error(e):
     return False
 
 
-async def request_retry_transient_errors(session, method, url, *, **kwargs):
+async def request_retry_transient_errors(session, method, url, **kwargs):
     delay = 0.1
     while True:
         try:
@@ -86,7 +86,7 @@ async def request_retry_transient_errors(session, method, url, *, **kwargs):
         await asyncio.sleep(t)
 
 
-async def request_raise_transient_errors(session, method, url, *, **kwargs):
+async def request_raise_transient_errors(session, method, url, **kwargs):
     try:
         return await session.request(method, url, **kwargs)
     except Exception as e:  # pylint: disable=broad-except

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -3,6 +3,7 @@ import random
 import logging
 import asyncio
 import aiohttp
+from aiohttp import web
 
 log = logging.getLogger('hailtop.utils')
 
@@ -74,7 +75,7 @@ async def request_retry_transient_errors(session, method, url, **kwargs):
     delay = 0.1
     while True:
         try:
-            return await f(*args, **kwargs)
+            return await session.request(method, url, **kwargs)
         except Exception as e:  # pylint: disable=broad-except
             if is_transient_error(e):
                 pass

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -70,7 +70,7 @@ def is_transient_error(e):
     return False
 
 
-async def request_retry_transient_errors(f, *args, **kwargs):
+async def request_retry_transient_errors(session, method, url, *, **kwargs):
     delay = 0.1
     while True:
         try:
@@ -86,7 +86,7 @@ async def request_retry_transient_errors(f, *args, **kwargs):
         await asyncio.sleep(t)
 
 
-async def request_raise_transient_error(session, method, url, *, **kwargs):
+async def request_raise_transient_errors(session, method, url, *, **kwargs):
     try:
         return await session.request(method, url, **kwargs)
     except Exception as e:  # pylint: disable=broad-except


### PR DESCRIPTION
So I'm of two minds here, and I don't quite know which to choose.  Imagine we make an internal (service to service) request.  It fails with a transient error like a timeout.  What do we do?

Option 1.  Retry.

Option 2.  Return a transient error 503 service unavailable to our client, and let them to decide what to do.

I've implemented both options here: request_{retry, raise}_transient_errors.  Which should I use in, for example, the auth decorators which hit the auth/userinfo endpoint?

I've chosen option 1 after bouncing back and forth a few times.  I feel like retrying will give a better experience in the common case (a real transient error) and both will recover eventually in the case of a real outage.

It appears that browsers don't retry 503 even with Retry-After header set.  I'd want it to retry immediately or after a very short delay (1s).  In the end, this is what convinced me we should retry.

Currently CI uses option 1 when calling batch because it is hardcoded into the batch client.

The signature of these functions match aiohttp.ClientSession.request.

@danking I'm compelled by your concern that we have a potentially infinite loop of failures nobody will be notified about.  I will follow up with another PR to add some logging to the request_retry function.

Finally, I'm not quite sure why we're getting so many transient errors.  I suspect some of it is gaps in k8s service handoffs, but I'm not sure.