### PR TITLE
[www/docs] simplify section rule, enable scrollto functions

### DIFF
--- a/hail/python/hail/docs/_static/rtd_modifications.css
+++ b/hail/python/hail/docs/_static/rtd_modifications.css
@@ -1,9 +1,7 @@
 /* color on hail.is: #444 */
 /* border-color on hail.is: #ddd */
 /* background-color on hail.is: #fff */
-.section>.section,
-.section:first-of-type,
-.section+.section {
+.section {
   margin-top: -51px;
 }
 
@@ -13,6 +11,23 @@
   display: block;
 }
 
+.rst-content dl:not(.docutils) dt,
+.rst-content dl:not(.docutils) dt:first-child {
+  position: relative;
+  border-top: 51px solid transparent;
+  margin-top: -48px;
+  background-clip: padding-box;
+}
+
+.rst-content dl:not(.docutils) dt:before {
+  display: block;
+  content: "";
+  position: absolute;
+  top: -3px;
+  left: 0;
+  right: 0;
+  border-top: 3px solid #6ab0de;
+}
 
 .wy-nav-content {
   max-width: 1140px !important;


### PR DESCRIPTION
This should fully address the scroll-to artifact on docs, which had the item that was scrolled to (specified by a #id after the url) was hidden by the navbar.


### Background
Browsers interpret a hash after a url as being an element selector (id) to move the top of the page to. The browser will set the top of the browser to the top of the element, which is determined by its height, padding, and box-sizing rule (which determines whether padding and borders are taken into account when calculating the element's height and width). *The margin on the element is not taken into account*

This is incompatible with fixed navbars, because now the the top of the element should also take into account the height of the nabber.

### Solution
2 solutions, one for the case where the element has a transparent background, and one for the case that it doesn't.

In the transparent case (`.section`), we add padding to the element that is larger than the default by the height of the navbar, and a negative margin that is the negative height of the navbar. For `.section`, which doesn't have any padding, we simply use the height of the navbar.

In the colored-background case (`dt`, the function blocks, which have 6px of padding, a blue background, and darker blue top-border) we need to use a different solution, because that padding will be the color of the background, making the element appear much taller than expected.

The solution is to use a tall transparent border instead, along with the setting `background-clip: padding-box`. To handle the border we use a pseudo element that is absolutely positioned.
  - background-clip is widely supported: https://caniuse.com/#search=background-clip

### Before
<img width="697" alt="Screenshot 2019-10-12 14 34 42" src="https://user-images.githubusercontent.com/5543229/66706171-960fa700-ecfd-11e9-9fa0-17a05da486a2.png">

<img width="701" alt="Screenshot 2019-10-12 14 34 53" src="https://user-images.githubusercontent.com/5543229/66706173-9740d400-ecfd-11e9-9fa5-5fd4bb23fc54.png">


### After

<img width="700" alt="Screenshot 2019-10-12 14 35 03" src="https://user-images.githubusercontent.com/5543229/66706179-a293ff80-ecfd-11e9-98f7-dfcfc1d9afc0.png">

<img width="697" alt="Screenshot 2019-10-12 14 35 14" src="https://user-images.githubusercontent.com/5543229/66706183-a45dc300-ecfd-11e9-9686-50dd71f3176b.png">


cc @cseed 