### PR TITLE
[batch2] clean up K8s client

### DIFF
--- a/batch2/batch/driver/k8s.py
+++ b/batch2/batch/driver/k8s.py
@@ -1,112 +1,24 @@
-import logging
-
-import kubernetes as kube
+import kubernetes_asyncio as kube
 import prometheus_client as pc
 
-from hailtop.utils import blocking_to_async
-
-log = logging.getLogger('batch.k8s')
-
-
-class EmptyContextManager:
-    def __enter__(self):
-        return None
-
-    def __exit__(self, type, value, callback):
-        return None
-
-
-class NoSummary:
-    EMPTY_CONTEXT_MANAGER = EmptyContextManager()
-
-    def time(self):  # pylint: disable=R0201
-        return NoSummary.EMPTY_CONTEXT_MANAGER
+READ_SECRET_TIME = pc.Summary('batch2_read_secret',
+                              'Batch2 k8s read secret latency in seconds')
 
 
 class K8s:
-    def __init__(self, blocking_pool, timeout, namespace, k8s_api):
-        self.blocking_pool = blocking_pool
+    def __init__(self, timeout, namespace, k8s_client):
         self.timeout = timeout
         self.namespace = namespace
-        self._delete_pod = self._wrap_k8s_delete(k8s_api.delete_namespaced_pod)
-        self._delete_pvc = self._wrap_k8s_delete(k8s_api.delete_namespaced_persistent_volume_claim)
-        self._create_pod = self._wrap_k8s(k8s_api.create_namespaced_pod,
-                                          pc.Summary('batch_create_pod_seconds',
-                                                     'Batch k8s create pod latency in seconds'))
-        self._create_pvc = self._wrap_k8s(k8s_api.create_namespaced_persistent_volume_claim,
-                                          pc.Summary('batch_create_pvc_seconds',
-                                                     'Batch k8s create pvc latency in seconds'))
-        self._read_pod_log = self._wrap_k8s(k8s_api.read_namespaced_pod_log)
-        self._read_pod_status = self._wrap_k8s(k8s_api.read_namespaced_pod_status)
-        self._list_pods = self._wrap_k8s(k8s_api.list_namespaced_pod)
-        self._list_pvcs = self._wrap_k8s(k8s_api.list_namespaced_persistent_volume_claim)
-        self._get_pod = self._wrap_k8s(k8s_api.read_namespaced_pod)
-        self._get_pvc = self._wrap_k8s(k8s_api.read_namespaced_persistent_volume_claim)
-        self._read_secret = self._wrap_k8s(k8s_api.read_namespaced_secret,
-                                           pc.Summary('batch_read_secret',
-                                                      'Batch k8s read secret latency in seconds'))
-
-    async def delete_pod(self, name):
-        assert name is not None
-        return await self._delete_pod(name=name)
-
-    async def delete_pvc(self, name):
-        assert name is not None
-        return await self._delete_pvc(name=name)
-
-    async def create_pod(self, *args, **kwargs):
-        return await self._create_pod(*args, **kwargs)
-
-    async def create_pvc(self, *args, **kwargs):
-        return await self._create_pvc(*args, **kwargs)
-
-    async def read_pod_log(self, *args, **kwargs):
-        return await self._read_pod_log(*args, **kwargs)
-
-    async def read_pod_status(self, *args, **kwargs):
-        return await self._read_pod_status(*args, **kwargs)
-
-    async def list_pods(self, *args, **kwargs):
-        return await self._list_pods(*args, **kwargs)
-
-    async def list_pvcs(self, *args, **kwargs):
-        return await self._list_pvcs(*args, **kwargs)
-
-    async def get_pod(self, *args, **kwargs):
-        return await self._get_pod(*args, **kwargs)
-
-    async def get_pvc(self, *args, **kwargs):
-        return await self._get_pvc(*args, **kwargs)
+        self.k8s_client = k8s_client
 
     async def read_secret(self, *args, **kwargs):
-        return await self._read_secret(*args, **kwargs)
-
-    def _wrap_k8s(self, fun, pc_summary=NoSummary()):
-        async def wrapped(*args, **kwargs):
+        if '_request_timeout' not in kwargs:
+            kwargs['_request_timeout'] = self.timeout
+        if 'namespace' not in kwargs:
+            kwargs['namespace'] = self.namespace
+        with READ_SECRET_TIME.time():
             try:
-                if '_request_timeout' not in kwargs:
-                    kwargs['_request_timeout'] = self.timeout
-                if 'namespace' not in kwargs:
-                    kwargs['namespace'] = self.namespace
-                with pc_summary.time():
-                    return (await blocking_to_async(self.blocking_pool,
-                                                    fun,
-                                                    *args,
-                                                    **kwargs),
-                            None)
+                return (await self.k8s_client.read_namespaced_secret(*args, **kwargs),
+                        None)
             except kube.client.rest.ApiException as err:
                 return (None, err)
-        wrapped.__name__ = fun.__name__
-        return wrapped
-
-    def _wrap_k8s_delete(self, fun, pc_summary=NoSummary()):
-        k8s_fun = self._wrap_k8s(fun, pc_summary)
-
-        async def wrapped(*args, **kwargs):
-            _, err = await k8s_fun(*args, **kwargs)
-            if err is None or err.status == 404:
-                log.debug(f'ignore already deleted {fun.__name__}(*{args}, **{kwargs})')
-                return None
-            return err
-        wrapped.__name__ = fun.__name__
-        return wrapped

--- a/batch2/batch/driver/k8s.py
+++ b/batch2/batch/driver/k8s.py
@@ -1,12 +1,14 @@
-import kubernetes_asyncio as kube
+import kubernetes as kube
 import prometheus_client as pc
+from hailtop.utils import blocking_to_async
 
 READ_SECRET_TIME = pc.Summary('batch2_read_secret',
                               'Batch2 k8s read secret latency in seconds')
 
 
 class K8s:
-    def __init__(self, timeout, namespace, k8s_client):
+    def __init__(self, thread_pool, timeout, namespace, k8s_client):
+        self.thread_pool = thread_pool
         self.timeout = timeout
         self.namespace = namespace
         self.k8s_client = k8s_client
@@ -18,7 +20,9 @@ class K8s:
             kwargs['namespace'] = self.namespace
         with READ_SECRET_TIME.time():
             try:
-                return (await self.k8s_client.read_namespaced_secret(*args, **kwargs),
-                        None)
+                v = await blocking_to_async(
+                    self.thread_pool,
+                    self.k8s_client.read_namespaced_secret, *args, **kwargs)
+                return (v, None)
             except kube.client.rest.ApiException as err:
                 return (None, err)

--- a/batch2/batch/driver/main.py
+++ b/batch2/batch/driver/main.py
@@ -4,7 +4,7 @@ import logging
 import traceback
 
 from aiohttp import web
-import kubernetes_asyncio as kube
+import kubernetes as kube
 
 import prometheus_client as pc
 from prometheus_async.aio.web import server_stats
@@ -217,7 +217,7 @@ async def on_startup(app):
     k8s_client = kube.client.CoreV1Api()
     app['k8s_client'] = k8s_client
 
-    k8s = K8s(KUBERNETES_TIMEOUT_IN_SECONDS, BATCH_NAMESPACE, k8s_client)
+    k8s = K8s(pool, KUBERNETES_TIMEOUT_IN_SECONDS, BATCH_NAMESPACE, k8s_client)
 
     userinfo = await async_get_userinfo()
     log.info(f'running as {userinfo["username"]}')

--- a/batch2/batch/driver/main.py
+++ b/batch2/batch/driver/main.py
@@ -1,11 +1,10 @@
 import asyncio
 import concurrent
 import logging
-import os
 import traceback
 
 from aiohttp import web
-import kubernetes as kube
+import kubernetes_asyncio as kube
 
 import prometheus_client as pc
 from prometheus_async.aio.web import server_stats
@@ -214,14 +213,11 @@ async def on_startup(app):
     pool = concurrent.futures.ThreadPoolExecutor()
     app['blocking_pool'] = pool
 
-    if 'BATCH_USE_KUBE_CONFIG' in os.environ:
-        kube.config.load_kube_config()
-    else:
-        kube.config.load_incluster_config()
-    v1 = kube.client.CoreV1Api()
-    app['k8s_client'] = v1
+    kube.config.load_incluster_config()
+    k8s_client = kube.client.CoreV1Api()
+    app['k8s_client'] = k8s_client
 
-    k8s = K8s(pool, KUBERNETES_TIMEOUT_IN_SECONDS, BATCH_NAMESPACE, v1)
+    k8s = K8s(KUBERNETES_TIMEOUT_IN_SECONDS, BATCH_NAMESPACE, k8s_client)
 
     userinfo = await async_get_userinfo()
     log.info(f'running as {userinfo["username"]}')

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -64,7 +64,7 @@ def is_transient_error(e):
         if e.status == 408 or e.status == 503 or e.status == 504:
             return True
     elif isinstance(e, aiohttp.ClientOSError):
-        if e.errno == errno.ETIMEDOUT:
+        if e.errno == errno.ETIMEDOUT or e.errno == errno.ECONNREFUSED:
             return True
     elif isinstance(e, aiohttp.ServerTimeoutError):
         return True


### PR DESCRIPTION
 - clean up unused code
 - switch to async kubernetes client (I think now the only legacy use of the non-async library is in batch1)
 - remove BATCH_USE_KUBE_CONFIG check since this can't run outside the cluster (for a long time now)

I really want async Google libraries so we can get read of the thread pool.
