### PR TITLE
Support NDArray Reshape

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3499,11 +3499,6 @@ class NDArrayExpression(Expression):
         :class:`.NDArrayExpression`.
         """
         shape = wrap_to_list(shape)
-        # if len(shape) == 0:
-        #     if self.ndim == 0:
-        #         return self
-        #     else:
-        #         raise FatalError(f'Cannot reshape an NDArray of {self.ndim} dimensions to 0 dimensions.')
 
         return construct_expr(NDArrayReshape(self._ir, hl.tuple(shape)._ir),
                               tndarray(self._type.element_type, len(shape)),

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3499,11 +3499,11 @@ class NDArrayExpression(Expression):
         :class:`.NDArrayExpression`.
         """
         shape = wrap_to_list(shape)
-        if len(shape) == 0:
-            if self.ndim == 0:
-                return self
-            else:
-                raise FatalError(f'Cannot reshape an NDArray of {self.ndim} dimensions to 0 dimensions.')
+        # if len(shape) == 0:
+        #     if self.ndim == 0:
+        #         return self
+        #     else:
+        #         raise FatalError(f'Cannot reshape an NDArray of {self.ndim} dimensions to 0 dimensions.')
 
         return construct_expr(NDArrayReshape(self._ir, hl.tuple(shape)._ir),
                               tndarray(self._type.element_type, len(shape)),

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -133,6 +133,9 @@ def test_ndarray_reshape():
     np_single = np.array([8])
     single = hl._ndarray([8])
 
+    np_zero_dim = np.array(4)
+    zero_dim = hl._ndarray(4)
+
     np_a = np.array([1, 2, 3, 4, 5, 6])
     a = hl._ndarray(np_a)
 
@@ -148,6 +151,7 @@ def test_ndarray_reshape():
 
     assert_ndarrays_eq(
         (single.reshape(()), np_single.reshape(())),
+        (zero_dim.reshape(()), np_zero_dim.reshape(())),
         (a.reshape((6,)), np_a.reshape((6,))),
         (a.reshape((2, 3)), np_a.reshape((2, 3))),
         (a.reshape((3, 2)), np_a.reshape((3, 2))),

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -162,6 +162,10 @@ def test_ndarray_reshape():
     assert "requested shape is incompatible with number of elements" in str(exc)
 
     with pytest.raises(FatalError) as exc:
+        hl.eval(a.reshape((3,)))
+    assert "requested shape is incompatible with number of elements" in str(exc)
+
+    with pytest.raises(FatalError) as exc:
         hl.eval(hl.literal(np_cube).reshape((0, 2, 2)))
     assert "must contain only positive numbers or -1" in str(exc)
 

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -144,6 +144,8 @@ def test_ndarray_reshape():
         (a.reshape((6,)), np_a),
         (a.reshape((2, 3)), np_a.reshape((2, 3))),
         (a.reshape((3, 2)), np_a.reshape((3, 2))),
+        (a.reshape((3, -1)), np_a.reshape((3, -1))),
+        (a.reshape((-1, 2)), np_a.reshape((-1, 2))),
         (cube_to_rect, np_cube_to_rect),
         (cube_t_to_rect, np_cube_t_to_rect))
 

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -131,7 +131,7 @@ def test_ndarray_shape():
 @skip_unless_spark_backend()
 def test_ndarray_reshape():
     np_single = np.array([8])
-    #single = hl._ndarray([np_single])
+    single = hl._ndarray([8])
 
     np_a = np.array([1, 2, 3, 4, 5, 6])
     a = hl._ndarray(np_a)
@@ -144,7 +144,7 @@ def test_ndarray_reshape():
     np_cube_t_to_rect = np_cube.transpose((1, 0, 2)).reshape((2, 4))
 
     assert_ndarrays_eq(
-        #(single.reshape(()), np_single.reshape(())),
+        (single.reshape(()), np_single.reshape(())),
         (a.reshape((6,)), np_a),
         (a.reshape((2, 3)), np_a.reshape((2, 3))),
         (a.reshape((3, 2)), np_a.reshape((3, 2))),

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -141,11 +141,11 @@ def test_ndarray_reshape():
     np_cube_t_to_rect = np_cube.transpose((1, 0, 2)).reshape((2, 4))
 
     assert_ndarrays_eq(
-        (a.reshape((6,)), np_a))
-        # (a.reshape((2, 3)), np_a.reshape((2, 3))),
-        # (a.reshape((3, 2)), np_a.reshape((3, 2))),
-        # (cube_to_rect, np_cube_to_rect),
-        # (cube_t_to_rect, np_cube_t_to_rect))
+        (a.reshape((6,)), np_a),
+        (a.reshape((2, 3)), np_a.reshape((2, 3))),
+        (a.reshape((3, 2)), np_a.reshape((3, 2))),
+        (cube_to_rect, np_cube_to_rect),
+        (cube_t_to_rect, np_cube_t_to_rect))
 
     with pytest.raises(FatalError) as exc:
         hl.eval(hl.literal(np_cube).reshape((-1, -1)))

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -166,6 +166,10 @@ def test_ndarray_reshape():
     assert "requested shape is incompatible with number of elements" in str(exc)
 
     with pytest.raises(FatalError) as exc:
+        hl.eval(a.reshape(()))
+    assert "requested shape is incompatible with number of elements" in str(exc)
+
+    with pytest.raises(FatalError) as exc:
         hl.eval(hl.literal(np_cube).reshape((0, 2, 2)))
     assert "must contain only positive numbers or -1" in str(exc)
 

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -139,7 +139,7 @@ def test_ndarray_reshape():
     np_a = np.array([1, 2, 3, 4, 5, 6])
     a = hl._ndarray(np_a)
 
-    np_cube = np.array([0, 1, 2, 3, 4, 5, 6, 7], order='F').reshape((2, 2, 2))
+    np_cube = np.array([0, 1, 2, 3, 4, 5, 6, 7]).reshape((2, 2, 2))
     cube = hl._ndarray([0, 1, 2, 3, 4, 5, 6, 7]).reshape((2, 2, 2))
     cube_to_rect = cube.reshape((2, 4))
     np_cube_to_rect = np_cube.reshape((2, 4))
@@ -152,6 +152,7 @@ def test_ndarray_reshape():
     assert_ndarrays_eq(
         (single.reshape(()), np_single.reshape(())),
         (zero_dim.reshape(()), np_zero_dim.reshape(())),
+        (zero_dim.reshape((1,)), np_zero_dim.reshape((1,))),
         (a.reshape((6,)), np_a.reshape((6,))),
         (a.reshape((2, 3)), np_a.reshape((2, 3))),
         (a.reshape((3, 2)), np_a.reshape((3, 2))),

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -157,6 +157,13 @@ def test_ndarray_reshape():
         hl.eval(hl.literal(np_cube).reshape((20,)))
     assert "requested shape is incompatible with number of elements" in str(exc)
 
+    with pytest.raises(FatalError) as exc:
+        hl.eval(hl.literal(np_cube).reshape((0, 2, 2)))
+    assert "must contain only positive numbers or -1" in str(exc)
+
+    with pytest.raises(FatalError) as exc:
+        hl.eval(hl.literal(np_cube).reshape((2, 2, -2)))
+    assert "must contain only positive numbers or -1" in str(exc)
 
 
 @skip_unless_spark_backend()

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -130,6 +130,9 @@ def test_ndarray_shape():
 
 @skip_unless_spark_backend()
 def test_ndarray_reshape():
+    np_single = np.array([8])
+    single = hl._ndarray([np_single])
+
     np_a = np.array([1, 2, 3, 4, 5, 6])
     a = hl._ndarray(np_a)
 
@@ -141,6 +144,7 @@ def test_ndarray_reshape():
     np_cube_t_to_rect = np_cube.transpose((1, 0, 2)).reshape((2, 4))
 
     assert_ndarrays_eq(
+        (single.reshape(()), np_single.reshape(())),
         (a.reshape((6,)), np_a),
         (a.reshape((2, 3)), np_a.reshape((2, 3))),
         (a.reshape((3, 2)), np_a.reshape((3, 2))),

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -131,7 +131,7 @@ def test_ndarray_shape():
 @skip_unless_spark_backend()
 def test_ndarray_reshape():
     np_single = np.array([8])
-    single = hl._ndarray([np_single])
+    #single = hl._ndarray([np_single])
 
     np_a = np.array([1, 2, 3, 4, 5, 6])
     a = hl._ndarray(np_a)
@@ -144,7 +144,7 @@ def test_ndarray_reshape():
     np_cube_t_to_rect = np_cube.transpose((1, 0, 2)).reshape((2, 4))
 
     assert_ndarrays_eq(
-        (single.reshape(()), np_single.reshape(())),
+        #(single.reshape(()), np_single.reshape(())),
         (a.reshape((6,)), np_a),
         (a.reshape((2, 3)), np_a.reshape((2, 3))),
         (a.reshape((3, 2)), np_a.reshape((3, 2))),

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -143,15 +143,20 @@ def test_ndarray_reshape():
     cube_t_to_rect = cube.transpose((1, 0, 2)).reshape((2, 4))
     np_cube_t_to_rect = np_cube.transpose((1, 0, 2)).reshape((2, 4))
 
+    np_hypercube = np.arange(3 * 5 * 7 * 9).reshape((3, 5, 7, 9))
+    hypercube = hl._ndarray(np_hypercube)
+
     assert_ndarrays_eq(
         (single.reshape(()), np_single.reshape(())),
-        (a.reshape((6,)), np_a),
+        (a.reshape((6,)), np_a.reshape((6,))),
         (a.reshape((2, 3)), np_a.reshape((2, 3))),
         (a.reshape((3, 2)), np_a.reshape((3, 2))),
         (a.reshape((3, -1)), np_a.reshape((3, -1))),
         (a.reshape((-1, 2)), np_a.reshape((-1, 2))),
         (cube_to_rect, np_cube_to_rect),
-        (cube_t_to_rect, np_cube_t_to_rect))
+        (cube_t_to_rect, np_cube_t_to_rect),
+        (hypercube.reshape((5, 7, 9, 3)).reshape((7, 9, 3, 5)), np_hypercube.reshape((7, 9, 3, 5)))
+    )
 
     with pytest.raises(FatalError) as exc:
         hl.eval(hl.literal(np_cube).reshape((-1, -1)))

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -553,6 +553,8 @@ class CodeLong(val lhs: Code[Long]) extends AnyVal {
 
   def /(rhs: Code[Long]): Code[Long] = Code(lhs, rhs, new InsnNode(LDIV))
 
+  def %(rhs: Code[Long]): Code[Long] = Code(lhs, rhs, new InsnNode(LREM))
+
   def compare(rhs: Code[Long]): Code[Int] = Code(lhs, rhs, new InsnNode(LCMP))
 
   def <(rhs: Code[Long]): Code[Boolean] = compare(rhs) < 0

--- a/hail/src/main/scala/is/hail/asm4s/Code.scala
+++ b/hail/src/main/scala/is/hail/asm4s/Code.scala
@@ -500,6 +500,8 @@ class CodeInt(val lhs: Code[Int]) extends AnyVal {
 
   def /(rhs: Code[Int]): Code[Int] = Code(lhs, rhs, new InsnNode(IDIV))
 
+  def %(rhs: Code[Int]): Code[Int] = Code(lhs, rhs, new InsnNode(IREM))
+
   def >(rhs: Code[Int]): Code[Boolean] = lhs.compare(IF_ICMPGT, rhs)
 
   def >=(rhs: Code[Int]): Code[Boolean] = lhs.compare(IF_ICMPGE, rhs)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2271,7 +2271,28 @@ private class Emit(
           // Steps:
           // Keep a running product. Also keep a count of -1s. If there's more than one -1, break. If the running product doesn't
           // divide number of elements, break. If there's one -1, loop over elements and replace the -1 with total / product.
+          val countNegs = mb.newLocal[Int]
+          val runningProduct = mb.newLocal[Long]
+          val quotient = mb.newLocal[Long]
 
+          Code(
+            countNegs := 0,
+            runningProduct := 1L,
+
+            (countNegs > 1).mux(
+              Code._fatal("Can't infer shape, more than one -1"),
+              Code._empty
+            ),
+            ((const(numElements.toLong) % runningProduct) > 0L).mux(
+              Code._fatal("Can't reshape since requested shape is incompatible with number of elements"),
+              Code._empty
+            ),
+            quotient := const(numElements.toLong) / runningProduct,
+            (countNegs >= 1).mux(
+              ???,
+              Code._empty
+            )
+          )
           //
           ???
         }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2281,7 +2281,9 @@ private class Emit(
             // Compute negative 1 count and product
             Code.foreach(requestedShape){ requestedShapeElement =>
               (requestedShapeElement.toI <= 0).mux(
-                (requestedShapeElement ceq -1L).mux(countNegs := countNegs + 1, Code._fatal("Can't reshape, new shape must contain only positive numbers or -1")),
+                (requestedShapeElement ceq -1L).mux(
+                  countNegs := countNegs + 1,
+                  Code._fatal("Can't reshape, new shape must contain only positive numbers or -1")),
                 runningProduct := runningProduct * requestedShapeElement
               )
             },
@@ -2325,10 +2327,10 @@ private class Emit(
             val newPType = x.pType
             val storeElementIndex = mb.newField[Long]
 
-            val (newIdxVarsSetup, newIdxVars) = x.pType.elementIndexToIndices(storeElementIndex, childShapeCached.map(_.load()), region, mb)
+            val (newIdxVarsSetup, newIdxVars) = x.pType.unlinearizeIndex(storeElementIndex, childShapeCached.map(_.load()), region, mb)
 
             Code(
-              storeElementIndex := newPType.getElementIndex(idxVars, reshapedShapeArray, region, mb),
+              storeElementIndex := newPType.linearizeIndices(idxVars, reshapedShapeArray, region, mb),
               newIdxVarsSetup,
               childEmitter.outputElement(newIdxVars)
             )

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2278,10 +2278,9 @@ private class Emit(
             runningProduct := 1L,
 
             // Compute negative 1 count and product
-            // TODO Handle zero, more negatives
             Code.foreach(requestedShape){ requestedShapeElement =>
-              (requestedShapeElement.toI ceq -1).mux(
-                countNegs := countNegs + 1,
+              (requestedShapeElement.toI <= 0).mux(
+                (requestedShapeElement ceq -1L).mux(countNegs := countNegs + 1, Code._fatal("Can't reshape, new shape must contain only positive numbers or -1")),
                 runningProduct := runningProduct * requestedShapeElement
               )
             },

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2242,7 +2242,6 @@ private class Emit(
         val outputPType = x.pType
         val outputShapePType = outputPType.shape.pType
 
-
         val shapeSeq = indexExpr.map {childIndex =>
           if (childIndex < childPType.nDims) {
             childEmitter.outputShape(childIndex)
@@ -2287,14 +2286,8 @@ private class Emit(
               )
             },
 
-            (countNegs > 1).mux(
-              Code._fatal("Can't infer shape, more than one -1"),
-              Code._empty
-            ),
-            ((numElements.toL % runningProduct) > 0L).mux(
-              Code._fatal("Can't reshape since requested shape is incompatible with number of elements"),
-              Code._empty
-            ),
+            (countNegs > 1).orEmpty(Code._fatal("Can't infer shape, more than one -1")),
+            ((numElements.toL % runningProduct) > 0L).orEmpty(Code._fatal("Can't reshape since requested shape is incompatible with number of elements")),
             quotient := numElements.toL / runningProduct,
             // Loop over the elements, replace if it's a negative one. For now, let's not.
             Code(newShapeVars.zip(requestedShape).map{ case (variable, shapeElement) => variable := shapeElement})

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2242,7 +2242,7 @@ private class Emit(
         val outputPType = x.pType
         val outputShapePType = outputPType.shape.pType
 
-        
+
         val shapeSeq = indexExpr.map {childIndex =>
           if (childIndex < childPType.nDims) {
             childEmitter.outputShape(childIndex)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2278,7 +2278,6 @@ private class Emit(
             countNegs := 0,
             runningProduct := 1L,
 
-            // Compute negative 1 count and product
             Code.foreach(requestedShape){ requestedShapeElement =>
               (requestedShapeElement.toI <= 0).mux(
                 (requestedShapeElement ceq -1L).mux(
@@ -2293,7 +2292,6 @@ private class Emit(
               numElements.toL cne runningProduct
             ).orEmpty(Code._fatal("Can't reshape since requested shape is incompatible with number of elements")),
             quotient := numElements.toL / runningProduct,
-            // Loop over the elements, replace if it's a negative one.
             Code(newShapeVars.zip(requestedShape).map{ case (variable, shapeElement) => variable := (shapeElement ceq -1L).mux(quotient, shapeElement)})
           ))
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2337,7 +2337,7 @@ private class Emit(
             Code(
               storeElementIndex := x.pType.linearizeIndices(idxVars, reshapedShapeArray, region, mb),
               newIdxVarsSetup,
-              childEmitter.outputElement(newIdxVars) // Error comes from something inside this call.
+              childEmitter.outputElement(newIdxVars)
             )
           }
         }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2284,9 +2284,11 @@ private class Emit(
                 runningProduct := runningProduct * requestedShapeElement
               )
             },
-
             (countNegs > 1).orEmpty(Code._fatal("Can't infer shape, more than one -1")),
-            ((numElements.toL % runningProduct) > 0L).orEmpty(Code._fatal("Can't reshape since requested shape is incompatible with number of elements")),
+            (countNegs ceq 1).mux(
+              (numElements.toL % runningProduct) > 0L,
+              numElements.toL cne runningProduct
+            ).orEmpty(Code._fatal("Can't reshape since requested shape is incompatible with number of elements")),
             quotient := numElements.toL / runningProduct,
             // Loop over the elements, replace if it's a negative one.
             Code(newShapeVars.zip(requestedShape).map{ case (variable, shapeElement) => variable := (shapeElement ceq -1L).mux(quotient, shapeElement)})

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2323,13 +2323,12 @@ private class Emit(
 
         new NDArrayEmitter(mb, reshapedShapeArray.length, reshapedShapeArray, requestedShapePType.setRequired(true).asInstanceOf[PTuple], childEmitter.outputElementPType, setup) {
           override def outputElement(idxVars: Array[Code[Long]]): Code[_] = {
-            val newPType = x.pType
             val storeElementIndex = mb.newField[Long]
 
             val (newIdxVarsSetup, newIdxVars) = x.pType.unlinearizeIndex(storeElementIndex, childShapeCached, region, mb)
 
             Code(
-              storeElementIndex := newPType.linearizeIndices(idxVars, reshapedShapeArray, region, mb),
+              storeElementIndex := x.pType.linearizeIndices(idxVars, reshapedShapeArray, region, mb),
               newIdxVarsSetup,
               childEmitter.outputElement(newIdxVars)
             )

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2301,7 +2301,7 @@ private class Emit(
 
         val childEmitter = deforest(childND)
 
-        val requestedShapet = emit(shape, env, resultRegion, None) // Double check
+        val requestedShapet = emit(shape, env, resultRegion, None)
         val requestedShapeAddress = mb.newField[Long]
         val requestedShapePType = coerce[PTuple](shape.pType)
         val requestedShapeTuple = new CodePTuple(requestedShapePType, region, requestedShapeAddress)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2289,8 +2289,8 @@ private class Emit(
             (countNegs > 1).orEmpty(Code._fatal("Can't infer shape, more than one -1")),
             ((numElements.toL % runningProduct) > 0L).orEmpty(Code._fatal("Can't reshape since requested shape is incompatible with number of elements")),
             quotient := numElements.toL / runningProduct,
-            // Loop over the elements, replace if it's a negative one. For now, let's not.
-            Code(newShapeVars.zip(requestedShape).map{ case (variable, shapeElement) => variable := shapeElement})
+            // Loop over the elements, replace if it's a negative one.
+            Code(newShapeVars.zip(requestedShape).map{ case (variable, shapeElement) => variable := (shapeElement ceq -1L).mux(quotient, shapeElement)})
           ))
 
           (setup, newShapeVars.map(_.load()).toArray)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2335,31 +2335,20 @@ private class Emit(
           childEmitter.setup,
           shapet.setup,
           requestedShapeAddress := shapet.value[Long],
-          Code._println("shapeAddress bound"),
-          reshapeSetup,
-          Code._println("Reshape setup complete")
+          reshapeSetup
         )
 
         // I suspect that shape.pType not being required will cause problems, because everything causes problems these days.
         new NDArrayEmitter(mb, reshapedShapeArray.length, reshapedShapeArray, requestedShapePType.setRequired(true).asInstanceOf[PTuple], childEmitter.outputElementPType, setup){
           override def outputElement(idxVars: Array[Code[Long]]): Code[_] = {
             val newPType = x.pType
-            val temp = mb.newField[Long]
+            val storeElementIndex = mb.newField[Long]
 
-            val (newIdxVarsSetup, newIdxVars) = x.pType.elementIndexToIndices(temp, childEmitter.outputShape, region, mb)
+            val (newIdxVarsSetup, newIdxVars) = x.pType.elementIndexToIndices(storeElementIndex, childEmitter.outputShape, region, mb)
 
             Code(
-              temp := newPType.getElementIndex(idxVars, reshapedShapeArray, region, mb),
+              storeElementIndex := newPType.getElementIndex(idxVars, reshapedShapeArray, region, mb),
               newIdxVarsSetup,
-              Code._println("elementIndex:"),
-              Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[Long, Unit](
-                "println", temp),
-              Code._println("newIdxVars"),
-              Code.foreach(newIdxVars){v =>
-                Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[Long, Unit](
-                  "println", v)
-              },
-
               childEmitter.outputElement(newIdxVars)
             )
           }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2242,6 +2242,7 @@ private class Emit(
         val outputPType = x.pType
         val outputShapePType = outputPType.shape.pType
 
+        
         val shapeSeq = indexExpr.map {childIndex =>
           if (childIndex < childPType.nDims) {
             childEmitter.outputShape(childIndex)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2345,11 +2345,22 @@ private class Emit(
           override def outputElement(idxVars: Array[Code[Long]]): Code[_] = {
             val newPType = x.pType
             val temp = mb.newField[Long]
+
+            val (newIdxVarsSetup, newIdxVars) = x.pType.elementIndexToIndices(temp, childEmitter.outputShape, region, mb)
+
             Code(
               temp := newPType.getElementIndex(idxVars, reshapedShapeArray, region, mb),
+              newIdxVarsSetup,
+              Code._println("elementIndex:"),
               Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[Long, Unit](
                 "println", temp),
-              childEmitter.outputElement(idxVars)
+              Code._println("newIdxVars"),
+              Code.foreach(newIdxVars){v =>
+                Code.getStatic[java.lang.System, java.io.PrintStream]("out").invoke[Long, Unit](
+                  "println", v)
+              },
+
+              childEmitter.outputElement(newIdxVars)
             )
           }
         }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1596,6 +1596,7 @@ private class Emit(
         EmitTriplet(setup, childt.m, value)
       case x: NDArrayMap  =>  emitDeforestedNDArray(x)
       case x: NDArrayMap2 =>  emitDeforestedNDArray(x)
+      case x: NDArrayReshape => emitDeforestedNDArray(x)
 
       case x@CollectDistributedArray(contexts, globals, cname, gname, body) =>
         val ctxType = coerce[PArray](contexts.pType).elementType
@@ -2261,6 +2262,22 @@ private class Emit(
             }
             childEmitter.outputElement(concreteIdxsForChild)
           }
+        }
+
+      case NDArrayReshape(nd, shape) =>
+
+        // Need to take this shape, which may have a -1 in it, and turn it into a compatible shape if possible.
+        def compatibleShape(numElements: Int, requestedShape: Array[Code[Long]]): Array[Code[Long]] = {
+          // Steps:
+          // Keep a running product. Also keep a count of -1s. If there's more than one -1, break. If the running product doesn't
+          // divide number of elements, break. If there's one -1, loop over elements and replace the -1 with total / product.
+
+          //
+          ???
+        }
+
+        new NDArrayEmitter(mb, ???, ???, ???, ???, ???){
+          override def outputElement(idxVars: Array[Code[Long]]): Code[_] = ???
         }
 
       case _ =>

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2314,7 +2314,6 @@ private class Emit(
           reshapeSetup
         )
 
-        // I suspect that shape.pType not being required will cause problems, because everything causes problems these days.
         new NDArrayEmitter(mb, reshapedShapeArray.length, reshapedShapeArray, requestedShapePType.setRequired(true).asInstanceOf[PTuple], childEmitter.outputElementPType, setup){
           override def outputElement(idxVars: Array[Code[Long]]): Code[_] = {
             val newPType = x.pType

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2332,10 +2332,12 @@ private class Emit(
 
             val (newIdxVarsSetup, newIdxVars) = x.pType.unlinearizeIndex(storeElementIndex, childShapeCached, region, mb)
 
+            assert(newIdxVars.length == childEmitter.nDims)
+
             Code(
               storeElementIndex := x.pType.linearizeIndices(idxVars, reshapedShapeArray, region, mb),
               newIdxVarsSetup,
-              childEmitter.outputElement(newIdxVars)
+              childEmitter.outputElement(newIdxVars) // Error comes from something inside this call.
             )
           }
         }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2302,12 +2302,12 @@ private class Emit(
 
         val requestedShapet = emit(shape, env, resultRegion, None) // Double check
         val requestedShapeAddress = mb.newField[Long]
-        val requestedShapePType = shape.pType.asInstanceOf[PTuple]
+        val requestedShapePType = coerce[PTuple](shape.pType)
         val requestedShapeTuple = new CodePTuple(requestedShapePType, region, requestedShapeAddress)
         val requestedShapeArray = (0 until requestedShapePType.size).map(i => requestedShapeTuple[Long](i)).toArray
 
         val (childShapeCachingCode, childShapeCached) = childEmitter.outputShape.cacheEntries(mb, LongInfo)
-        
+
         val numElements = coerce[PNDArray](childND.pType).numElements(childShapeCached, mb)
 
         val (reshapeSetup, reshapedShapeArray) = compatibleShape(numElements.toI, requestedShapeArray)

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -267,9 +267,10 @@ final case class MakeNDArray(data: IR, shape: IR, rowMajor: IR) extends NDArrayI
 
 final case class NDArrayShape(nd: IR) extends IR
 
-final case class NDArrayReshape(nd: IR, shape: IR) extends NDArrayIR {
-  require(shape.typ.asInstanceOf[TTuple].size > 0)
-}
+final case class NDArrayReshape(nd: IR, shape: IR) extends NDArrayIR
+//{
+//  require(shape.typ.asInstanceOf[TTuple].size > 0)
+//}
 
 final case class NDArrayRef(nd: IR, idxs: IndexedSeq[IR]) extends IR
 final case class NDArraySlice(nd: IR, slices: IR) extends NDArrayIR

--- a/hail/src/main/scala/is/hail/expr/ir/IR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/IR.scala
@@ -268,9 +268,6 @@ final case class MakeNDArray(data: IR, shape: IR, rowMajor: IR) extends NDArrayI
 final case class NDArrayShape(nd: IR) extends IR
 
 final case class NDArrayReshape(nd: IR, shape: IR) extends NDArrayIR
-//{
-//  require(shape.typ.asInstanceOf[TTuple].size > 0)
-//}
 
 final case class NDArrayRef(nd: IR, idxs: IndexedSeq[IR]) extends IR
 final case class NDArraySlice(nd: IR, slices: IR) extends NDArrayIR

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -110,23 +110,23 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
     )
   }
 
-  def getElementIndex(indices: Array[Code[Long]], shapeArray: Array[Code[Long]], region: Code[Region], mb: MethodBuilder): Code[Long] = {
+  def linearizeIndices(indices: Array[Code[Long]], shapeArray: Array[Code[Long]], region: Code[Region], mb: MethodBuilder): Code[Long] = {
     val index = mb.newField[Long]
-    val elementsBeneathThisLevel = mb.newField[Long]
+    val elementsInProcessedDimensions = mb.newField[Long]
     Code(
       index := 0L,
-      elementsBeneathThisLevel := 1L,
+      elementsInProcessedDimensions := 1L,
       Code.foreach((shapeArray.length - 1) to 0 by - 1){ dimIndex =>
         Code(
-          index := index + indices(dimIndex) * elementsBeneathThisLevel,
-          elementsBeneathThisLevel := elementsBeneathThisLevel * shapeArray(dimIndex)
+          index := index + indices(dimIndex) * elementsInProcessedDimensions,
+          elementsInProcessedDimensions := elementsInProcessedDimensions * shapeArray(dimIndex)
         )
       },
       index
     )
   }
 
-  def elementIndexToIndices(index: Code[Long], shapeArray: Array[Code[Long]], region: Code[Region], mb: MethodBuilder): (Code[Unit], Array[Code[Long]]) = {
+  def unlinearizeIndex(index: Code[Long], shapeArray: Array[Code[Long]], region: Code[Region], mb: MethodBuilder): (Code[Unit], Array[Code[Long]]) = {
     val nDim = shapeArray.length
 
     if (nDim <= 1) {
@@ -134,20 +134,20 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
     }
     else {
       val newIndices = (0 until nDim).map(_ => mb.newField[Long]).toArray
-      val elementsAboveThisLevel = mb.newField[Long]
+      val elementsInProcessedDimensions = mb.newField[Long]
       val workRemaining = mb.newField[Long]
 
       val setupShape = Code(
-        elementsAboveThisLevel := 1L,
+        elementsInProcessedDimensions := 1L,
         workRemaining := index,
         Code.foreach(shapeArray){ shapeElement =>
-          elementsAboveThisLevel := elementsAboveThisLevel * shapeElement
+          elementsInProcessedDimensions := elementsInProcessedDimensions * shapeElement
         },
         Code.foreach(0 until nDim){ dimIndex =>
           Code(
-            elementsAboveThisLevel := elementsAboveThisLevel / shapeArray(dimIndex),
-            newIndices(dimIndex) := workRemaining / elementsAboveThisLevel,
-            workRemaining := workRemaining % elementsAboveThisLevel
+            elementsInProcessedDimensions := elementsInProcessedDimensions / shapeArray(dimIndex),
+            newIndices(dimIndex) := workRemaining / elementsInProcessedDimensions,
+            workRemaining := workRemaining % elementsInProcessedDimensions
           )
         }
       )

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -168,18 +168,21 @@ def getElementIndex(indices: Array[Code[Long]], shapeArray: Array[Code[Long]], r
     else {
       val newIndices = (0 until nDim).map(_ => mb.newField[Long]).toArray
       val elementsAboveThisLevel = mb.newField[Long]
+      val workRemaining = mb.newField[Long]
 
       val setupShape = Code(
         elementsAboveThisLevel := 1L,
-        // Compute product of all elements of shape but the first one.
-        Code.foreach(shapeArray.drop(1)){ shapeElement =>
+        workRemaining := index,
+        // Compute product of all elements of shape
+        Code.foreach(shapeArray){ shapeElement =>
           elementsAboveThisLevel := elementsAboveThisLevel * shapeElement
         },
         //Now walk backwards through shape generating the elements
         Code.foreach(0 until nDim){ dimIndex =>
           Code(
-            newIndices(dimIndex) := shapeArray(dimIndex) / elementsAboveThisLevel,
-            elementsAboveThisLevel := shapeArray(dimIndex) % elementsAboveThisLevel
+            elementsAboveThisLevel := elementsAboveThisLevel / shapeArray(dimIndex),
+            newIndices(dimIndex) := workRemaining / elementsAboveThisLevel,
+            workRemaining := workRemaining % elementsAboveThisLevel
           )
         }
       )

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -156,7 +156,7 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
 
   }
 
-    def construct(flags: Code[Int], offset: Code[Int], shapeBuilder: (StagedRegionValueBuilder => Code[Unit]),
+  def construct(flags: Code[Int], offset: Code[Int], shapeBuilder: (StagedRegionValueBuilder => Code[Unit]),
     stridesBuilder: (StagedRegionValueBuilder => Code[Unit]), data: Code[Long], mb: MethodBuilder): Code[Long] = {
     val srvb = new StagedRegionValueBuilder(mb, this.representation)
 

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -103,7 +103,7 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
     val outOfBounds = mb.newField[Boolean]
     Code(
       outOfBounds := false,
-      Code.foreach(0 until nDims){ dimIndex =>
+      Code.foreach(0 until nDims) { dimIndex =>
         outOfBounds := outOfBounds || (indices(dimIndex) >= shapeTuple(dimIndex))
       },
       outOfBounds
@@ -140,10 +140,10 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
       val createShape = Code(
         elementsInProcessedDimensions := 1L,
         workRemaining := index,
-        Code.foreach(shapeArray){ shapeElement =>
+        Code.foreach(shapeArray) { shapeElement =>
           elementsInProcessedDimensions := elementsInProcessedDimensions * shapeElement
         },
-        Code.foreach(0 until nDim){ dimIndex =>
+        Code.foreach(0 until nDim) { dimIndex =>
           Code(
             elementsInProcessedDimensions := elementsInProcessedDimensions / shapeArray(dimIndex),
             newIndices(dimIndex) := workRemaining / elementsInProcessedDimensions,

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -129,7 +129,10 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
   def unlinearizeIndex(index: Code[Long], shapeArray: Array[Code[Long]], region: Code[Region], mb: MethodBuilder): (Code[Unit], Array[Code[Long]]) = {
     val nDim = shapeArray.length
 
-    if (nDim <= 1) {
+    if (nDim == 0) {
+      (Code._empty, Array(index))
+    }
+    else if (nDim == 1) {
       (Code._empty, Array(index))
     } else {
       val newIndices = (0 until nDim).map(_ => mb.newField[Long]).toArray
@@ -137,7 +140,6 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
       val workRemaining = mb.newField[Long]
 
       val createShape = Code(
-        elementsInProcessedDimensions := 1L,
         workRemaining := index,
         elementsInProcessedDimensions := shapeArray.reduce(_ * _),
         Code.foreach(shapeArray.zip(newIndices)) { case (shapeElement, newIndex) =>

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -110,6 +110,27 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
     )
   }
 
+  def getElementIndex(indices: Array[Code[Long]], nd: Code[Long], region: Code[Region], mb: MethodBuilder): Code[Long] = {
+    // Probably inlining pretty badly here with nd load
+    val shapeTuple = new CodePTuple(shape.pType, region, shape.load(region, nd))
+    val index = mb.newField[Long]
+    Code(
+      index := 0L,
+      indices.zipWithIndex.foldLeft(Code._empty[Unit]){case (codeSoFar: Code[_], (requestedIndex: Code[Long], shapeIndex: Int)) =>
+        Code(
+          codeSoFar,
+          index := index + requestedIndex * shapeTuple(shapeIndex))
+      },
+      index
+    )
+  }
+
+  def elementIndexToIndices(index: Code[Long], nd: Code[Long], region: Code[Region], mb: MethodBuilder): Array[Code[Long]] = {
+    val shapeTuple = new CodePTuple(shape.pType, region, shape.load(region, nd))
+    
+    ???
+  }
+
   def construct(flags: Code[Int], offset: Code[Int], shapeBuilder: (StagedRegionValueBuilder => Code[Unit]),
     stridesBuilder: (StagedRegionValueBuilder => Code[Unit]), data: Code[Long], mb: MethodBuilder): Code[Long] = {
     val srvb = new StagedRegionValueBuilder(mb, this.representation)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -140,11 +140,9 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
       val setupShape = Code(
         elementsAboveThisLevel := 1L,
         workRemaining := index,
-        // Compute product of all elements of shape
         Code.foreach(shapeArray){ shapeElement =>
           elementsAboveThisLevel := elementsAboveThisLevel * shapeElement
         },
-        //Now walk backwards through shape generating the elements
         Code.foreach(0 until nDim){ dimIndex =>
           Code(
             elementsAboveThisLevel := elementsAboveThisLevel / shapeArray(dimIndex),

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -110,54 +110,21 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
     )
   }
 
-//  def getElementIndex(indices: Array[Code[Long]], nd: Code[Long], region: Code[Region], mb: MethodBuilder): Code[Long] = {
-    // Probably inlining pretty badly here with nd load
-//  def getElementIndex(indices: Array[Code[Long]], shapeArray: Array[Code[Long]], region: Code[Region], mb: MethodBuilder): Code[Long] = {
-//    val index = mb.newField[Long]
-//    Code(
-//      index := 0L,
-//      indices.zipWithIndex.foldLeft(Code._empty[Unit]){case (codeSoFar: Code[_], (requestedIndex: Code[Long], shapeIndex: Int)) =>
-//        Code(
-//          codeSoFar,
-//          index := index + requestedIndex * shapeArray(shapeIndex))
-//      },
-//      index
-//    )
-//  }
-def getElementIndex(indices: Array[Code[Long]], shapeArray: Array[Code[Long]], region: Code[Region], mb: MethodBuilder): Code[Long] = {
-  val index = mb.newField[Long]
-  val elementsBeneathThisLevel = mb.newField[Long]
-  Code(
-    index := 0L,
-    elementsBeneathThisLevel := 1L,
-    Code.foreach((shapeArray.length - 1) to 0 by - 1){ dimIndex =>
-      Code(
-        index := index + indices(dimIndex) * elementsBeneathThisLevel,
-        elementsBeneathThisLevel := elementsBeneathThisLevel * shapeArray(dimIndex)
-      )
-    },
-    index
-  )
-}
-
-//  def elementIndexToIndices(index: Code[Long], shapeArray: Array[Code[Long]], region: Code[Region], mb: MethodBuilder): (Code[Unit], Array[Code[Long]]) = {
-//    //val shapeTuple = new CodePTuple(shape.pType, region, shape.load(region, nd))
-//    val nDim = shapeArray.length
-//
-//    val newIndices = (0 until nDim).map(_ => mb.newField[Long]).toArray
-//
-//    val remainingWork = mb.newField[Long]
-//    val setupShape = Code(
-//      remainingWork := index,
-//      Code.foreach(0 until nDim){ dimIndex =>
-//        Code(
-//          newIndices(dimIndex) := remainingWork / shapeArray(dimIndex),
-//          remainingWork := remainingWork % shapeArray(dimIndex)
-//        )
-//      }
-//    )
-//    (setupShape, newIndices.map(_.load()))
-//  }
+  def getElementIndex(indices: Array[Code[Long]], shapeArray: Array[Code[Long]], region: Code[Region], mb: MethodBuilder): Code[Long] = {
+    val index = mb.newField[Long]
+    val elementsBeneathThisLevel = mb.newField[Long]
+    Code(
+      index := 0L,
+      elementsBeneathThisLevel := 1L,
+      Code.foreach((shapeArray.length - 1) to 0 by - 1){ dimIndex =>
+        Code(
+          index := index + indices(dimIndex) * elementsBeneathThisLevel,
+          elementsBeneathThisLevel := elementsBeneathThisLevel * shapeArray(dimIndex)
+        )
+      },
+      index
+    )
+  }
 
   def elementIndexToIndices(index: Code[Long], shapeArray: Array[Code[Long]], region: Code[Region], mb: MethodBuilder): (Code[Unit], Array[Code[Long]]) = {
     val nDim = shapeArray.length

--- a/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PNDArray.scala
@@ -137,7 +137,7 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
       val elementsInProcessedDimensions = mb.newField[Long]
       val workRemaining = mb.newField[Long]
 
-      val setupShape = Code(
+      val createShape = Code(
         elementsInProcessedDimensions := 1L,
         workRemaining := index,
         Code.foreach(shapeArray){ shapeElement =>
@@ -151,7 +151,7 @@ final case class PNDArray(elementType: PType, nDims: Int, override val required:
           )
         }
       )
-      (setupShape, newIndices.map(_.load()))
+      (createShape, newIndices.map(_.load()))
     }
 
   }

--- a/hail/src/main/scala/is/hail/utils/richUtils/Implicits.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/Implicits.scala
@@ -117,4 +117,6 @@ trait Implicits {
   implicit def toRichCodeInputBuffer(in: Code[InputBuffer]): RichCodeInputBuffer = new RichCodeInputBuffer(in)
 
   implicit def toRichCodeOutputBuffer(out: Code[OutputBuffer]): RichCodeOutputBuffer = new RichCodeOutputBuffer(out)
+
+  implicit def toRichCodeArray[T](arr: Array[Code[T]]): RichCodeArray[T] = new RichCodeArray[T](arr)
 }

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichCodeArray.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichCodeArray.scala
@@ -1,0 +1,17 @@
+package is.hail.utils.richUtils
+
+import is.hail.asm4s.{Code, MethodBuilder, TypeInfo}
+
+class RichCodeArray[T](arr: Array[Code[T]]) {
+  def cacheEntries(mb: MethodBuilder, ti: TypeInfo[T]): (Code[Unit], Array[Code[T]]) = {
+    val cacheVariables = arr.map(_ => mb.newField(ti))
+
+    val cachingCode = Code(
+      cacheVariables.zip(arr).map { case (cacheVariable, arrElement) =>
+        cacheVariable := arrElement
+      }:_*
+    ).asInstanceOf[Code[Unit]]
+
+    (cachingCode, cacheVariables.map(_.load()))
+  }
+}

--- a/hail/src/main/scala/is/hail/utils/richUtils/RichCodeArray.scala
+++ b/hail/src/main/scala/is/hail/utils/richUtils/RichCodeArray.scala
@@ -6,11 +6,9 @@ class RichCodeArray[T](arr: Array[Code[T]]) {
   def cacheEntries(mb: MethodBuilder, ti: TypeInfo[T]): (Code[Unit], Array[Code[T]]) = {
     val cacheVariables = arr.map(_ => mb.newField(ti))
 
-    val cachingCode = Code(
-      cacheVariables.zip(arr).map { case (cacheVariable, arrElement) =>
-        cacheVariable := arrElement
-      }:_*
-    ).asInstanceOf[Code[Unit]]
+    val cachingCode = Code.foreach(cacheVariables.zip(arr)) { case (cacheVariable, arrElement) =>
+      cacheVariable := arrElement
+    }
 
     (cachingCode, cacheVariables.map(_.load()))
   }


### PR DESCRIPTION
This PR adds the ability to call reshape on hail NDArrayExpressions. It should behave just like: https://docs.scipy.org/doc/numpy/reference/generated/numpy.reshape.html
except that it doesn't take an order argument since we are currently not exposing user control over in memory layout of their ndarrays. If you haven't used numpy much, the potentially surprising detail is that you're allowed to specify a `-1` as one of the dimension sizes in the new shape, which will result in numpy inferring the correct size for that dimension by dividing the total number of elements by the product of the dimension sizes you did specify. 