### PR TITLE
[combiner] Add canonical allele specific GATK annotation parsing

### DIFF
--- a/hail/python/hail/experimental/vcf_combiner.py
+++ b/hail/python/hail/experimental/vcf_combiner.py
@@ -45,8 +45,8 @@ def parse_as_ranksum(string, has_non_ref):
 _as_function_map = {
     'AS_QUALapprox': parse_as_ints,
     'AS_RAW_MQ': parse_as_doubles,
-    'AS_RAW_MQRankSum': parse_as_ranksum,  # FIXME |NaN| issue
-    'AS_RAW_ReadPosRankSum': parse_as_ranksum,  # FIXME |NaN| issue
+    'AS_RAW_MQRankSum': parse_as_ranksum,
+    'AS_RAW_ReadPosRankSum': parse_as_ranksum,
     'AS_SB_TABLE': parse_as_sb_table,
     'AS_VarDP': parse_as_ints,
 }

--- a/hail/python/hail/experimental/vcf_combiner.py
+++ b/hail/python/hail/experimental/vcf_combiner.py
@@ -3,13 +3,55 @@
 import hail as hl
 from hail import MatrixTable, Table
 from hail.expr import StructExpression
-from hail.expr.expressions import expr_call, expr_array, expr_int32
+from hail.expr.expressions import expr_bool, expr_call, expr_array, expr_int32, expr_str
 from hail.genetics.reference_genome import reference_genome_type
 from hail.ir import Apply, TableMapRows, TopLevelReference
 from hail.typecheck import oneof, sequenceof, typecheck
 
 _transform_rows_function_map = {}
 _merge_function_map = {}
+
+@typecheck(string=expr_str, has_non_ref=expr_bool)
+def parse_as_ints(string, has_non_ref):
+    ints = string.split(r'\|')
+    ints = hl.cond(has_non_ref, ints[:-1], ints)
+    return ints.map(lambda i: hl.cond(hl.len(i) == 0 | i == '.', hl.null(hl.tint32), hl.int32(i)))
+
+@typecheck(string=expr_str, has_non_ref=expr_bool)
+def parse_as_doubles(string, has_non_ref):
+    ints = string.split(r'\|')
+    ints = hl.cond(has_non_ref, ints[:-1], ints)
+    return ints.map(lambda i: hl.cond(hl.len(i) == 0 | i == '.', hl.null(hl.tfloat64), hl.float64(i)))
+
+@typecheck(string=expr_str, has_non_ref=expr_bool)
+def parse_as_sb_table(string, has_non_ref):
+    ints = string.split(r'\|')
+    ints = hl.cond(has_non_ref, ints[:-1], ints)
+    return ints.map(lambda xs: xs.split(",").map(hl.int32))
+
+@typecheck(string=expr_str, has_non_ref=expr_bool)
+def parse_as_ranksum(string, has_non_ref):
+    # FIXME handle AS_RAW_RankSum=|NaN|NaN;
+    typ = hl.ttuple(hl.tfloat64, hl.tint32)
+    items = string.split(r'\|')
+    items = hl.cond(has_non_ref, items[:-1], items)
+    return items.map(lambda s: hl.cond(
+        hl.len(s) == 0 | s == '.',
+        hl.null(typ),
+        hl.rbind(s.split(','), lambda ss: hl.tuple([hl.float64(ss[0]), hl.int32(ss[1])]))))
+
+_as_function_map = {
+    'AS_QUALapprox': parse_as_ints,
+    'AS_RAW_MQ': parse_as_doubles,
+    'AS_RAW_MQRankSum': parse_as_ranksum,  # FIXME |NaN| issue
+    'AS_RAW_ReadPosRankSum': parse_as_ranksum,  # FIXME |NaN| issue
+    'AS_SB_TABLE': parse_as_sb_table,
+    'AS_VarDP': parse_as_ints,
+}
+
+def parse_as_fields(info, has_non_ref):
+    return hl.struct(**{f: info[f] if f not in _as_function_map
+                        else _as_function_map[f](info[f], has_non_ref) for f in info})
 
 def localize(mt):
     if isinstance(mt, MatrixTable):
@@ -69,7 +111,11 @@ def transform_one(mt, info_to_keep=[]) -> Table:
                             SB=e.SB,
                             gvcf_info=hl.case()
                                 .when(hl.is_missing(row.info.END),
-                                      hl.struct(**(row.info.select(*info_to_keep))))
+                                      hl.struct(**(
+                                          parse_as_fields(
+                                              row.info.select(*info_to_keep),
+                                              has_non_ref)
+                                      )))
                                 .or_missing()
                         ))),
             ),

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -381,6 +381,42 @@ class VCFTests(unittest.TestCase):
         self.assertEqual(len(parts), comb.n_partitions())
         comb._force_count_rows()
 
+    def test_combiner_parse_as_annotations(self):
+        import hail.experimental.vcf_combiner as c
+        infos = hl.array([
+            hl.struct(
+                AS_QUALapprox="|1171|",
+                AS_SB_TABLE="0,0|30,27|0,0",
+                AS_VarDP="0|57|0",
+                AS_RAW_MQ="0.00|15100.00|0.00",
+                AS_RAW_MQRankSum="|0.0,1|NaN",
+                AS_RAW_ReadPosRankSum="|0.7,1|NaN"),
+            hl.struct(
+                AS_QUALapprox="|1171|",
+                AS_SB_TABLE="0,0|30,27|0,0",
+                AS_VarDP="0|57|0",
+                AS_RAW_MQ="0.00|15100.00|0.00",
+                AS_RAW_MQRankSum="|NaN|NaN",
+                AS_RAW_ReadPosRankSum="|NaN|NaN")])
+
+        output = hl.eval(infos.map(lambda info: c.parse_as_fields(info, False)))
+        expected = [
+            hl.Struct(
+                AS_QUALapprox=[None, 1171, None],
+                AS_SB_TABLE=[[0, 0], [30, 27], [0, 0]],
+                AS_VarDP=[0, 57, 0],
+                AS_RAW_MQ=[0.00, 15100.00, 0.00],
+                AS_RAW_MQRankSum=[None, (0.0, 1), None],
+                AS_RAW_ReadPosRankSum=[None, (0.7, 1), None]),
+            hl.Struct(
+                AS_QUALapprox=[None, 1171, None],
+                AS_SB_TABLE=[[0, 0], [30, 27], [0, 0]],
+                AS_VarDP=[0, 57, 0],
+                AS_RAW_MQ=[0.00, 15100.00, 0.00],
+                AS_RAW_MQRankSum=[None, None, None],
+                AS_RAW_ReadPosRankSum=[None, None, None])]
+        assert output == expected
+
     def test_flag_at_eol(self):
         vcf_path = resource('flag_at_end.vcf')
         mt = hl.import_vcf(vcf_path)


### PR DESCRIPTION
The GVCF AS Fields were described to me as follows:
  - `AS_QUALapprox`: string, pipe-delimited R-length int list
  - `AS_SB_TABLE`: string, pipe-delimited R-length list of
    comma-delimited length 2 lists of ints
  - `AS_VarDP`: string, pipe-delimited R-length list of ints
  - `AS_RAW_MQ`: string, pipe-delimited R-length list of doubles (sum
    of squared MQs for each read)
  - `AS_RAW_MQRankSum`: string, pipe-delimited R-length list of
  histograms where histogram is a comma-delimited set of double bin
  values followed by int counts-- may have empty entries or dots; e.g.
  `AS_RAW_MQRankSum=||1.0,1||-2.1,1|`
  - `AS_RAW_ReadPosRankSum`: string, pipe-delimited R-length list of
  histograms where histogram is a comma-delimited set of double bin
  values followed by int counts-- may have empty entries or dots