### PR TITLE
NDArray from Hail Array

### DIFF
--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3890,15 +3890,15 @@ def _ndarray(collection, row_major=None):
         if isinstance(collection, ArrayNumericExpression):
             data_expr = collection
             shape_expr = to_expr(tuple([hl.int64(hl.len(collection))]), ir.ttuple(tint64))
+            ndim = 1
 
         elif isinstance(collection, NumericExpression):
             data_expr = array([collection])
             shape_expr = hl.tuple([])
+            ndim = 0
         else:
             raise ValueError(f"{collection} cannot be converted into an ndarray")
 
-        ndir = ir.MakeNDArray(data_expr._ir, shape_expr._ir, hl.bool(True)._ir)
-        return construct_expr(ndir, tndarray(data_expr.dtype.element_type, 1))
     else:
         if isinstance(collection, np.ndarray):
             return hl.literal(collection)
@@ -3911,9 +3911,10 @@ def _ndarray(collection, row_major=None):
 
         shape_expr = to_expr(tuple([hl.int64(i) for i in shape]), ir.ttuple(*[tint64 for _ in shape]))
         data_expr = hl.array(data) if data else hl.empty_array("float64")
-        ndir = ir.MakeNDArray(data_expr._ir, shape_expr._ir, hl.bool(True)._ir)
+        ndim = builtins.len(shape)
 
-        return construct_expr(ndir, tndarray(data_expr.dtype.element_type, builtins.len(shape)))
+    ndir = ir.MakeNDArray(data_expr._ir, shape_expr._ir, hl.bool(True)._ir)
+    return construct_expr(ndir, tndarray(data_expr.dtype.element_type, ndim))
 
 
 @typecheck(key_type=hail_type, value_type=hail_type)

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3848,7 +3848,7 @@ def empty_array(t: Union[HailType, str]) -> ArrayExpression:
 
 
 def _ndarray(collection, row_major=None):
-    """Construct a Hail ndarray from either a `NumPy` ndarray or python value/nested lists.
+    """Construct a Hail ndarray from either a flat Hail array, a `NumPy` ndarray or python value/nested lists.
 
     Parameters
     ----------
@@ -3886,20 +3886,30 @@ def _ndarray(collection, row_major=None):
 
         return result
 
-    if isinstance(collection, np.ndarray):
-        return hl.literal(collection)
-    elif isinstance(collection, list):
-        shape = list_shape(collection)
-        data = deep_flatten(collection)
+    if isinstance(collection, Expression):
+        if isinstance(collection, ArrayNumericExpression):
+            data_expr = collection
+            shape_expr = to_expr(tuple([hl.int64(hl.len(collection))]), ir.ttuple(tint64))
+            ndir = ir.MakeNDArray(data_expr._ir, shape_expr._ir, hl.bool(True)._ir)
+
+            return construct_expr(ndir, tndarray(data_expr.dtype.element_type, 1))
+        else:
+            raise ValueError(f"{collection} cannot be converted into an ndarray")
     else:
-        shape = []
-        data = [collection]
+        if isinstance(collection, np.ndarray):
+            return hl.literal(collection)
+        elif isinstance(collection, list):
+            shape = list_shape(collection)
+            data = deep_flatten(collection)
+        else:
+            shape = []
+            data = [collection]
 
-    shape_expr = to_expr(tuple([hl.int64(i) for i in shape]), ir.ttuple(*[tint64 for _ in shape]))
-    data_expr = hl.array(data) if data else hl.empty_array("float64")
-    ndir = ir.MakeNDArray(data_expr._ir, shape_expr._ir, hl.bool(True)._ir)
+        shape_expr = to_expr(tuple([hl.int64(i) for i in shape]), ir.ttuple(*[tint64 for _ in shape]))
+        data_expr = hl.array(data) if data else hl.empty_array("float64")
+        ndir = ir.MakeNDArray(data_expr._ir, shape_expr._ir, hl.bool(True)._ir)
 
-    return construct_expr(ndir, tndarray(data_expr.dtype.element_type, builtins.len(shape)))
+        return construct_expr(ndir, tndarray(data_expr.dtype.element_type, builtins.len(shape)))
 
 
 @typecheck(key_type=hail_type, value_type=hail_type)

--- a/hail/python/hail/expr/functions.py
+++ b/hail/python/hail/expr/functions.py
@@ -3890,11 +3890,15 @@ def _ndarray(collection, row_major=None):
         if isinstance(collection, ArrayNumericExpression):
             data_expr = collection
             shape_expr = to_expr(tuple([hl.int64(hl.len(collection))]), ir.ttuple(tint64))
-            ndir = ir.MakeNDArray(data_expr._ir, shape_expr._ir, hl.bool(True)._ir)
 
-            return construct_expr(ndir, tndarray(data_expr.dtype.element_type, 1))
+        elif isinstance(collection, NumericExpression):
+            data_expr = array([collection])
+            shape_expr = hl.tuple([])
         else:
             raise ValueError(f"{collection} cannot be converted into an ndarray")
+
+        ndir = ir.MakeNDArray(data_expr._ir, shape_expr._ir, hl.bool(True)._ir)
+        return construct_expr(ndir, tndarray(data_expr.dtype.element_type, 1))
     else:
         if isinstance(collection, np.ndarray):
             return hl.literal(collection)

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -93,7 +93,9 @@ def test_ndarray_eval():
     assert np.array_equal(evaled_zero_array, zero_array)
     assert zero_array.dtype == evaled_zero_array.dtype
 
+    # Testing from hail arrays
     assert np.array_equal(hl.eval(hl._ndarray(hl.range(6))), np.arange(6))
+    assert np.array_equal(hl.eval(hl._ndarray(hl.int64(4))), np.array(4))
 
     with pytest.raises(ValueError) as exc:
         hl._ndarray([[4], [1, 2, 3], 5])

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -93,6 +93,8 @@ def test_ndarray_eval():
     assert np.array_equal(evaled_zero_array, zero_array)
     assert zero_array.dtype == evaled_zero_array.dtype
 
+    assert np.array_equal(hl.eval(hl._ndarray(hl.range(6))), np.arange(6))
+
     with pytest.raises(ValueError) as exc:
         hl._ndarray([[4], [1, 2, 3], 5])
     assert "inner dimensions do not match" in str(exc.value)


### PR DESCRIPTION
This PR introduces the ability to create an `NDArrayNumericExpression` from an `ArrayNumericExpression` or a `NumericExpression`. Along with #7304, this will allow hail users to make ndarrays from scratch by doing things like 

`hl._ndarray(hl.range(6)).reshape((3, 2))`