### PR TITLE
[batch2] fix manifest path

### DIFF
--- a/batch2/MANIFEST.in
+++ b/batch2/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include batch/templates *
+recursive-include batch/front_end/templates *


### PR DESCRIPTION
The jinja2 templates got moved from batch2/templates to batch2/front_end/templates but the manifest file to copy the template files wasn't updated.