### PR TITLE
[batchs] add custom job schema in batch client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,6 @@ check:
 	make -C auth check
 	make -C scorecard check
 	make -C batch check
+	make -C batch2 check
 	make -C ci check
+	make -C hail/python check

--- a/batch/Dockerfile.test
+++ b/batch/Dockerfile.test
@@ -7,4 +7,4 @@ RUN python3 -m pip install --no-cache-dir /hailtop \
 
 COPY batch/test/ /test/
 
-CMD ["python3", "-m", "pytest", "-v", "--instafail", "/test/"]
+CMD ["python3", "-m", "pytest", "--log-cli-level=INFO", "-s", "-v", "--instafail", "/test/"]

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -128,7 +128,7 @@ def copy(files):
             mkdirs = ""
         return f'{mkdirs} gsutil -m cp -R {shq(src)} {shq(dst)}'
 
-    copies = ' && '.join([copy_command(src, dst) for (src, dst) in files])
+    copies = ' && '.join([copy_command(f['from'], f['to']) for f in files])
     return f'set -ex; {resiliently_authenticate("/gsa-key/privateKeyData")} && {copies}'
 
 

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -1008,7 +1008,7 @@ async def create_jobs(request, userdata):
     try:
         batch_client.validate.validate_jobs(jobs)
     except batch_client.validate.ValidationError as e:
-        abort(400, f'bad request: {e.reason}')
+        abort(400, e.reason)
 
     jobs_builder = JobsBuilder(db)
     try:

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -706,40 +706,17 @@ class Job:
         return result
 
 
-def create_job(jobs_builder, batch_id, userdata, parameters):  # pylint: disable=R0912
-    pod_spec = v1.api_client._ApiClient__deserialize(
-        parameters['spec'], kube.client.V1PodSpec)
-
-    job_id = parameters.get('job_id')
-    parent_ids = parameters.get('parent_ids', [])
-    input_files = parameters.get('input_files')
-    output_files = parameters.get('output_files')
-    pvc_size = parameters.get('pvc_size')
+def create_job(jobs_builder, batch_id, userdata, job_spec):  # pylint: disable=R0912
+    job_id = job_spec['job_id']
+    parent_ids = job_spec.get('parent_ids', [])
+    input_files = job_spec.get('input_files')
+    output_files = job_spec.get('output_files')
+    pvc_size = job_spec.get('pvc_size')
     if pvc_size is None and (input_files or output_files):
         pvc_size = POD_VOLUME_SIZE
-    always_run = parameters.get('always_run', False)
+    always_run = job_spec.get('always_run', False)
 
-    if len(pod_spec.containers) != 1:
-        abort(400, f'only one container allowed in pod_spec {pod_spec}')
-
-    if pod_spec.containers[0].name != 'main':
-        abort(400, f'container name must be "main" was {pod_spec.containers[0].name}')
-
-    if not pod_spec.containers[0].resources:
-        pod_spec.containers[0].resources = kube.client.V1ResourceRequirements()
-    if not pod_spec.containers[0].resources.requests:
-        pod_spec.containers[0].resources.requests = {}
-    if 'cpu' not in pod_spec.containers[0].resources.requests:
-        pod_spec.containers[0].resources.requests['cpu'] = '100m'
-    if 'memory' not in pod_spec.containers[0].resources.requests:
-        pod_spec.containers[0].resources.requests['memory'] = '500M'
-
-    if not pod_spec.tolerations:
-        pod_spec.tolerations = []
-    pod_spec.tolerations.append(kube.client.V1Toleration(key='preemptible', value='true'))
-
-    # pod_spec.automount_service_account_token = False
-    pod_spec.service_account = "batch-output-pod"
+    pod_spec = batch_client.validate.job_spec_to_k8s_pod_spec(job_spec)
 
     state = 'Running' if len(parent_ids) == 0 else 'Pending'
 
@@ -748,8 +725,8 @@ def create_job(jobs_builder, batch_id, userdata, parameters):  # pylint: disable
         batch_id=batch_id,
         job_id=job_id,
         pod_spec=pod_spec,
-        attributes=parameters.get('attributes'),
-        callback=parameters.get('callback'),
+        attributes=job_spec.get('attributes'),
+        callback=job_spec.get('callback'),
         parent_ids=parent_ids,
         input_files=input_files,
         output_files=output_files,
@@ -1036,8 +1013,7 @@ async def create_jobs(request, userdata):
     jobs_builder = JobsBuilder(db)
     try:
         for job in jobs:
-            k8s_pod_spec = batch_client.validate.job_spec_to_k8s_pod_spec(job)
-            create_job(jobs_builder, batch.id, userdata, k8s_pod_spec)
+            create_job(jobs_builder, batch.id, userdata, job)
 
         success = await jobs_builder.commit()
         if not success:

--- a/batch/batch/schemas.py
+++ b/batch/batch/schemas.py
@@ -5,34 +5,6 @@ pod_spec = {
     'schema': {}
 }
 
-job_schema = {
-    'type': 'dict',
-    'required': True,
-    'allow_unknown': True,
-    'schema': {
-        'job_id': {'type': 'integer', 'nullable': False},
-        'spec': pod_spec,
-        'parent_ids': {'type': 'list', 'schema': {'type': 'integer'}},
-        'input_files': {
-            'type': 'list',
-            'schema': {'type': 'list', 'items': 2 * ({'type': 'string'},)}},
-        'output_files': {
-            'type': 'list',
-            'schema': {'type': 'list', 'items': 2 * ({'type': 'string'},)}},
-        'always_run': {'type': 'boolean'},
-        'attributes': {
-            'type': 'dict',
-            'keyschema': {'type': 'string'},
-            'valueschema': {'type': 'string'}
-        },
-        'callback': {'type': 'string'}
-    }
-}
-
-job_array_schema = {
-    'jobs': {'type': 'list', 'schema': job_schema}
-}
-
 batch_schema = {
     'attributes': {
         'type': 'dict',

--- a/batch/batch/schemas.py
+++ b/batch/batch/schemas.py
@@ -1,10 +1,3 @@
-pod_spec = {
-    'type': 'dict',
-    'required': True,
-    'allow_unknown': True,
-    'schema': {}
-}
-
 batch_schema = {
     'attributes': {
         'type': 'dict',

--- a/batch2/batch/batch.py
+++ b/batch2/batch/batch.py
@@ -29,7 +29,7 @@ def copy(files):
             mkdirs = ""
         return f'{mkdirs} gsutil -m cp -R {shq(src)} {shq(dst)}'
 
-    copies = ' && '.join([copy_command(src, dst) for (src, dst) in files])
+    copies = ' && '.join([copy_command(f['from'], f['to']) for f in files])
     return f'{authenticate} && {copies}'
 
 

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -63,33 +63,17 @@ routes = web.RouteTableDef()
 deploy_config = get_deploy_config()
 
 
-def create_job(app, jobs_builder, batch_id, userdata, parameters):  # pylint: disable=R0912
-    pod_spec = app['k8s_client'].api_client._ApiClient__deserialize(
-        parameters['spec'], kube.client.V1PodSpec)
-
-    job_id = parameters.get('job_id')
-    parent_ids = parameters.get('parent_ids', [])
-    input_files = parameters.get('input_files')
-    output_files = parameters.get('output_files')
-    pvc_size = parameters.get('pvc_size')
+def create_job(app, jobs_builder, batch_id, userdata, job_spec):  # pylint: disable=R0912
+    job_id = job_spec['job_id']
+    parent_ids = job_spec.get('parent_ids', [])
+    input_files = job_spec.get('input_files')
+    output_files = job_spec.get('output_files')
+    pvc_size = job_spec.get('pvc_size')
     if pvc_size is None and (input_files or output_files):
         pvc_size = POD_VOLUME_SIZE
-    always_run = parameters.get('always_run', False)
+    always_run = job_spec.get('always_run', False)
 
-    if len(pod_spec.containers) != 1:
-        raise web.HTTPBadRequest(reason=f'only one container allowed in pod_spec {pod_spec}')
-
-    if pod_spec.containers[0].name != 'main':
-        raise web.HTTPBadRequest(reason=f'container name must be "main" was {pod_spec.containers[0].name}')
-
-    if not pod_spec.containers[0].resources:
-        pod_spec.containers[0].resources = kube.client.V1ResourceRequirements()
-    if not pod_spec.containers[0].resources.requests:
-        pod_spec.containers[0].resources.requests = {}
-    if 'cpu' not in pod_spec.containers[0].resources.requests:
-        pod_spec.containers[0].resources.requests['cpu'] = '100m'
-    if 'memory' not in pod_spec.containers[0].resources.requests:
-        pod_spec.containers[0].resources.requests['memory'] = '500M'
+    pod_spec = batch_client.validate.job_spec_to_k8s_pod_spec(job_spec)
 
     state = 'Running' if len(parent_ids) == 0 else 'Pending'
 
@@ -99,8 +83,8 @@ def create_job(app, jobs_builder, batch_id, userdata, parameters):  # pylint: di
         batch_id=batch_id,
         job_id=job_id,
         pod_spec=pod_spec,
-        attributes=parameters.get('attributes'),
-        callback=parameters.get('callback'),
+        attributes=job_spec.get('attributes'),
+        callback=job_spec.get('callback'),
         parent_ids=parent_ids,
         input_files=input_files,
         output_files=output_files,
@@ -242,8 +226,7 @@ async def create_jobs(request, userdata):
     jobs_builder = JobsBuilder(app['db'])
     try:
         for job in jobs:
-            k8s_pod_spec = batch_client.validate.job_spec_to_k8s_pod_spec(job)
-            create_job(app, jobs_builder, batch.id, userdata, k8s_pod_spec)
+            create_job(app, jobs_builder, batch.id, userdata, job)
 
         success = await jobs_builder.commit()
         if not success:

--- a/batch2/batch/front_end/front_end.py
+++ b/batch2/batch/front_end/front_end.py
@@ -219,7 +219,7 @@ async def create_jobs(request, userdata):
     try:
         batch_client.validate.validate_jobs(jobs)
     except batch_client.validate.ValidationError as e:
-        raise web.HTTPBadRequest(reason=f'bad request: {e.reason}')
+        raise web.HTTPBadRequest(reason=e.reason)
     log.info(f"took {round(time.time() - start3, 3)} seconds to validate spec")
 
     start4 = time.time()

--- a/batch2/batch/front_end/schemas.py
+++ b/batch2/batch/front_end/schemas.py
@@ -5,34 +5,6 @@ pod_spec = {
     'schema': {}
 }
 
-job_schema = {
-    'type': 'dict',
-    'required': True,
-    'allow_unknown': True,
-    'schema': {
-        'job_id': {'type': 'integer', 'nullable': False},
-        'spec': pod_spec,
-        'parent_ids': {'type': 'list', 'schema': {'type': 'integer'}},
-        'input_files': {
-            'type': 'list',
-            'schema': {'type': 'list', 'items': 2 * ({'type': 'string'},)}},
-        'output_files': {
-            'type': 'list',
-            'schema': {'type': 'list', 'items': 2 * ({'type': 'string'},)}},
-        'always_run': {'type': 'boolean'},
-        'attributes': {
-            'type': 'dict',
-            'keyschema': {'type': 'string'},
-            'valueschema': {'type': 'string'}
-        },
-        'callback': {'type': 'string'}
-    }
-}
-
-job_array_schema = {
-    'jobs': {'type': 'list', 'schema': job_schema}
-}
-
 batch_schema = {
     'attributes': {
         'type': 'dict',

--- a/batch2/batch/front_end/schemas.py
+++ b/batch2/batch/front_end/schemas.py
@@ -1,10 +1,3 @@
-pod_spec = {
-    'type': 'dict',
-    'required': True,
-    'allow_unknown': True,
-    'schema': {}
-}
-
 batch_schema = {
     'attributes': {
         'type': 'dict',

--- a/hail/python/Makefile
+++ b/hail/python/Makefile
@@ -1,0 +1,7 @@
+PYTHONPATH := $${PYTHONPATH:+$${PYTHONPATH}:}
+PYTHON := PYTHONPATH=$(PYTHONPATH) python3
+
+.PHONY: check
+check:
+	$(PYTHON) -m flake8 --config ../../setup.cfg hailtop
+	$(PYTHON) -m pylint --rcfile ../../pylintrc hailtop --score=n

--- a/hail/python/hailtop/batch_client/__init__.py
+++ b/hail/python/hailtop/batch_client/__init__.py
@@ -1,6 +1,7 @@
-from . import client, aioclient
+from . import client, aioclient, validate
 
 __all__ = [
     'client',
-    'aioclient'
+    'aioclient',
+    'validate'
 ]

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -312,8 +312,7 @@ class BatchBuilder:
         }
 
         if env:
-            env = [{'name': k, 'value': v} for (k, v) in env.items()]
-            job_spec['env'] = env
+            job_spec['env'] = [{'name': k, 'value': v} for (k, v) in env.items()]
         if resources:
             job_spec['resources'] = resources
         if secrets:
@@ -326,9 +325,9 @@ class BatchBuilder:
         if callback:
             job_spec['callback'] = callback
         if input_files:
-            job_spec['input_files'] = input_files
+            job_spec['input_files'] = [{"from": src, "to": dst} for (src, dest) in input_files]
         if output_files:
-            job_spec['output_files'] = output_files
+            job_spec['output_files'] = [{"from": src, "to": dst} for (src, dest) in output_files]
         if pvc_size:
             job_spec['pvc_size'] = pvc_size
 

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -330,9 +330,9 @@ class BatchBuilder:
         if output_files:
             job_spec['output_files'] = output_files
         if pvc_size:
-            sjob_spec['pvc_size'] = pvc_size
+            job_spec['pvc_size'] = pvc_size
 
-        self._job_docs.append(doc)
+        self._job_docs.append(job_spec)
 
         j = Job.unsubmitted_job(self, self._job_idx, attributes, parent_ids)
         self._jobs.append(j)

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -303,9 +303,12 @@ class BatchBuilder:
             raise ValueError("\n".join(error_msg))
 
         job_spec = {
+            'always_run': always_run,
             'command': command,
             'image': image,
-            'mount_docker_socket': mount_docker_socket
+            'job_id': self._job_idx,
+            'mount_docker_socket': mount_docker_socket,
+            'parent_ids': parent_ids
         }
 
         if env:
@@ -318,22 +321,16 @@ class BatchBuilder:
         if service_account_name:
             job_spec['service_account_name'] = service_account_name
 
-        doc = {
-            'job_spec': job_spec,
-            'parent_ids': parent_ids,
-            'always_run': always_run,
-            'job_id': self._job_idx
-        }
         if attributes:
-            doc['attributes'] = attributes
+            job_spec['attributes'] = attributes
         if callback:
-            doc['callback'] = callback
+            job_spec['callback'] = callback
         if input_files:
-            doc['input_files'] = input_files
+            job_spec['input_files'] = input_files
         if output_files:
-            doc['output_files'] = output_files
+            job_spec['output_files'] = output_files
         if pvc_size:
-            doc['pvc_size'] = pvc_size
+            sjob_spec['pvc_size'] = pvc_size
 
         self._job_docs.append(doc)
 

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -325,9 +325,9 @@ class BatchBuilder:
         if callback:
             job_spec['callback'] = callback
         if input_files:
-            job_spec['input_files'] = [{"from": src, "to": dst} for (src, dest) in input_files]
+            job_spec['input_files'] = [{"from": src, "to": dst} for (src, dst) in input_files]
         if output_files:
-            job_spec['output_files'] = [{"from": src, "to": dst} for (src, dest) in output_files]
+            job_spec['output_files'] = [{"from": src, "to": dst} for (src, dst) in output_files]
         if pvc_size:
             job_spec['pvc_size'] = pvc_size
 

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -115,16 +115,16 @@ class BatchBuilder:
     def callback(self):
         return self._async_builder.callback
 
-    def create_job(self, image, command=None, args=None, env=None,
-                   resources=None, volumes=None,
+    def create_job(self, image, command, env=None, mount_docker_socket=False,
+                   resources=None, secrets=None,
                    service_account_name=None, attributes=None, callback=None, parents=None,
                    input_files=None, output_files=None, always_run=False, pvc_size=None):
         if parents:
             parents = [parent._async_job for parent in parents]
 
         async_job = self._async_builder.create_job(
-            image, command=command, args=args, env=env,
-            resources=resources, volumes=volumes,
+            image, command, env=env, mount_docker_socket=mount_docker_socket,
+            resources=resources, secrets=secrets,
             service_account_name=service_account_name,
             attributes=attributes, callback=callback, parents=parents,
             input_files=input_files, output_files=output_files, always_run=always_run,

--- a/hail/python/hailtop/batch_client/validate.py
+++ b/hail/python/hailtop/batch_client/validate.py
@@ -44,7 +44,7 @@ FILE_KEYS = {'from', 'to'}
 K8S_NAME_REGEXPAT = r'[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\.[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)*'
 K8S_NAME_REGEX = re.compile(K8S_NAME_REGEXPAT)
 
-MEMORY_REGEXPAT = r'[+]?(?:[0-9]*[.])?[0-9]+[KMGTP]?'
+MEMORY_REGEXPAT = r'[+]?(?:[0-9]*[.])?[0-9]+(?:[KMGTP][i]?)?'
 MEMORY_REGEX = re.compile(MEMORY_REGEXPAT)
 
 CPU_REGEXPAT = r'[+]?(?:[0-9]*[.])?[0-9]+[m]?'

--- a/hail/python/hailtop/batch_client/validate.py
+++ b/hail/python/hailtop/batch_client/validate.py
@@ -226,7 +226,7 @@ def validate_job(i, job):
             cpu = resources['cpu']
             if not isinstance(cpu, str):
                 raise ValidationError(f'jobs[{i}].resources.cpu is not str')
-            if not CPU_REGEX.fullmatch(memory):
+            if not CPU_REGEX.fullmatch(cpu):
                 raise ValidationError(f'jobs[{i}].resources.cpu must match regex: {CPU_REGEXPAT}')
 
     if 'secrets' in job:

--- a/hail/python/hailtop/batch_client/validate.py
+++ b/hail/python/hailtop/batch_client/validate.py
@@ -34,10 +34,10 @@ RESOURCES_KEYS = {'memory', 'cpu'}
 K8S_NAME_REGEXPAT = r'[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\.[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)*'
 K8S_NAME_REGEX = re.compile(K8S_NAME_REGEXPAT)
 
-MEMORY_REGEXPAT = r'+?(?:[0-9]*[.])?[0-9]+[KMGTP]?'
+MEMORY_REGEXPAT = r'[+]?(?:[0-9]*[.])?[0-9]+[KMGTP]?'
 MEMORY_REGEX = re.compile(MEMORY_REGEXPAT)
 
-CPU_REGEXPAT = r'+?(?:[0-9]*[.])?[0-9]+[u]?'
+CPU_REGEXPAT = r'[+]?(?:[0-9]*[.])?[0-9]+[u]?'
 CPU_REGEX = re.compile(CPU_REGEXPAT)
 
 

--- a/hail/python/hailtop/batch_client/validate.py
+++ b/hail/python/hailtop/batch_client/validate.py
@@ -1,0 +1,242 @@
+import re
+
+# rough schema (without requiredness, value validation):
+# jobs_schema = [{
+#   'command': [str]
+#   'env': [{
+#     'name': str,
+#     'value': str
+#   }],
+#   'image': str,
+#   'mount_docker_socket': bool,
+#   'resoures': {
+#     'memory': str,
+#     'cpu': str
+#   },
+#   secrets: [{
+#     'namespace': str,
+#     'name': str,
+#     'mount_path': str
+#   }],
+#   service_account_name: str
+# }]
+
+JOB_KEYS = {
+    'command', 'env', 'image', 'mount_docker_socket', 'resources', 'secrets', 'service_account_name'
+}
+
+ENV_VAR_KEYS = {'name', 'value'}
+
+SECRET_KEYS = {'namespace', 'name', 'mount_path'}
+
+RESOURCES_KEYS = {'memory', 'cpu'}
+
+K8S_NAME_REGEXPAT = r'[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\.[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)*'
+K8S_NAME_REGEX = re.compile(K8S_NAME_REGEXPAT)
+
+MEMORY_REGEXPAT = r'+?(?:[0-9]*[.])?[0-9]+[KMGTP]?'
+MEMORY_REGEX = re.compile(MEMORY_REGEXPAT)
+
+CPU_REGEXPAT = r'+?(?:[0-9]*[.])?[0-9]+[u]?'
+CPU_REGEX = re.compile(CPU_REGEXPAT)
+
+
+class ValidationError(Exception):
+    def __init__(self, reason):
+        super().__init__()
+        self.reason = reason
+
+
+def validate_jobs(jobs):
+    if not isinstance(jobs, list):
+        raise ValidationError('jobs is not list')
+    for i, job in enumerate(jobs):
+        validate_job(i, job)
+
+
+def validate_job(i, job):
+    if not isinstance(job, dict):
+        raise ValidationError(f'jobs[{i}] not dict')
+
+    for k in job:
+        if k not in JOB_SPEC_KEYS:
+            raise ValidationError(f'unknown key in jobs[{i}]: {k}')
+
+    if 'command' not in job:
+        raise ValidationError(f'no required key command in jobs[{i}]')
+    command = job['command']
+    if not isinstance(command, list):
+        raise ValidationError(f'jobs[{i}].command not list')
+    for j, a in enumerate(command):
+        if not isinstance(a, str):
+            raise ValidationError(f'jobs[{i}].command[{j}] is not str')
+
+    if 'env' in job:
+        env = job['env']
+        if not isinstance(env, list):
+            raise ValidationError(f'jobs[{i}].env is not list')
+        for j, e in enumerate(env):
+            if not isinstance(e, dict):
+                raise ValidationError(f'jobs[{i}].env[{j}] is not dict')
+            for k in e:
+                if k not in ENV_VAR_KEYS:
+                    raise ValidationError(f'unknown key in jobs[{i}].env[{j}]: {k}')
+            if 'name' not in e:
+                raise ValidationError(f'no required key name in jobs[{i}].env[{j}]')
+            name = e['name']
+            if not isinstance(name, str):
+                raise ValidationError(f'jobs[{i}].env[{j}].name is not str')
+            if 'value' not in e:
+                raise ValidationError(f'no required key value in jobs[{i}].env[{j}]')
+            if not isinstance(value, str):
+                raise ValidationError(f'jobs[{i}].env[{j}].value is not str')
+
+    if 'image' not in job:
+        raise ValidationError(f'no required key image in jobs[{i}]')
+    image = job['image']
+    if not isinstance(image, str):
+        raise ValidationError(f'jobs[{i}].image not str')
+    # FIXME validate image
+    # https://github.com/docker/distribution/blob/master/reference/regexp.go#L68
+
+    if 'mount_docker_socket' not in job:
+        raise ValidationError(f'no required key mount_docker_socket in jobs[{i}]')
+    mount_docker_socket = job['mount_docker_socket']
+    if not isinstance(mount_docker_socket, bool):
+        raise ValidationError(f'jobs[{i}].mount_docker_socket not bool')
+
+    if 'resources' in job:
+        resources = job['resources']
+        if not isinstance(resources, dict):
+            raise ValidationError(f'jobs[{i}].resources is not dict')
+        for k in resources:
+            if k not in RESOURCES_KEYS:
+                raise ValidationError(f'unknown key in jobs[{i}].resources: {k}')
+
+        if 'memory' not in secret:
+            raise ValidationError(f'no required key memory in jobs[{i}].resources')
+        memory = secret['memory']
+        if not isinstance(memory, str):
+            raise ValidationError(f'jobs[{i}].resources.memory is not str')
+        if not MEMORY_REGEX.fullmatch(memory):
+            raise ValidationError(f'jobs[{i}].resources.memory must match regex: {MEMORY_REGEXPAT}')
+
+        if 'cpu' not in secret:
+            raise ValidationError(f'no required key cpu in jobs[{i}].resources')
+        cpu = secret['cpu']
+        if not isinstance(cpu, str):
+            raise ValidationError(f'jobs[{i}].resources.cpu is not str')
+        if not CPU_REGEX.fullmatch(memory):
+            raise ValidationError(f'jobs[{i}].resources.cpu must match regex: {CPU_REGEXPAT}')
+
+    if 'secrets' in job:
+        secrets = job['secrets']
+        if not isinstance(secrets, list):
+            raise ValidationError(f'jobs[{i}].secrets is not list')
+        for j, secret in enumerate(secrets):
+            if not isinstance(secret, dict):
+                raise ValidationError(f'jobs[{i}].secrets[{j}] is not dict')
+            for k in secret:
+                if k not in SECRET_KEYS:
+                    raise ValidationError(f'unknown key in jobs[{i}].secrets[{j}]: {k}')
+
+                if 'namespace' not in secret:
+                    raise ValidationError(f'no required key namespace in jobs[{i}].secrets[{j}]')
+                namespace = secret['namespace']
+                if not isinstance(namespace, str):
+                    raise ValidationError(f'jobs[{i}].secrets[{j}].namespace is not str')
+                if len(namespace) > 253:
+                    raies ValidationError(f'length of jobs[{i}].secrets[{j}].namespace must be <= 253')
+                if not K8S_NAME_REGEX.fullmatch(namespace):
+                    raise ValidationError(f'jobs[{i}].secrets[{j}].namespace must match regex: {K8S_NAME_REGEXPAT}')
+
+                if 'name' not in secret:
+                    raise ValidationError(f'no required key name in jobs[{i}].secrets[{j}]')
+                name = secret['name']
+                if not isinstance(name, str):
+                    raise ValidationError(f'jobs[{i}].secrets[{j}].name is not str')
+                if len(name) > 253:
+                    raise ValidationError(f'length of jobs[{i}].secrets[{j}].name must be <= 253')
+                if not K8S_NAME_REGEX.fullmatch(name):
+                    raise ValidationError(f'jobs[{i}].secrets[{j}].name must match regex: {K8S_NAME_REGEXPAT}')
+
+                if 'mount_path' not in secret:
+                    raise ValidationError(f'no required key mount_path in jobs[{i}].secrets[{j}]')
+                if not isinstance(name, str):
+                    raise ValidationError(f'jobs[{i}].secrets[{j}].mount_path is not str')
+
+    if 'service_account_name' not in job:
+        raise ValidationError(f'no required key service_account_name in jobs[{i}]')
+    service_account_name = job['service_account_name']
+    if not isinstance(service_account_name, str):
+        raise ValidationError(f'jobs[{i}].service_account_name not str')
+    if len(service_account_name) > 253:
+        raise ValidationError(f'length of jobs[{i}].service_account_name must be <= 253')
+    if not K8S_NAME_REGEX.fullmatch(service_account_name):
+        raise ValidationError(f'jobs[{i}].service_account_name must match regex: {K8S_NAME_REGEXPAT}')
+
+
+def job_spec_to_k8s_pod_spec(job_spec):
+    volumes = []
+    volume_mounts = []
+
+    if job_spec.get('mount_docker_socket', False):
+        volumes.append({
+            'name': 'docker-sock-volume',
+            'hostPath': {
+                'path': '/var/run/docker.sock',
+                'type': 'File'
+            }
+        })
+        volume_mounts.append({
+            'mountPath': '/var/run/docker.sock',
+            'name': 'docker-sock-volume'
+        })
+
+    if secrets in job_spec:
+        secrets = job_spec['secrets']
+        for secret in secrets:
+            volumes.append({
+                'name': secret['name'],
+                'secret': {
+                    'secretName': secret['name']
+                }
+            })
+            volume_mounts.append({
+                'mountPath': secret['mount_path'],
+                'name': secret['name'],
+                'readOnly': True
+            })
+
+    container = {
+        'image': job_spec['image'],
+        'name': 'main',
+        'command': job_spec['command'],
+        'volumes': volumes
+    }
+    if 'env' in job_spec:
+        container['env'] = job_spec['env']
+    if 'resources' in job_spec:
+        requests = {}
+        limits = {}
+        job_resources = job_spec['resources']
+        if 'memory' in job_resources:
+            memory = job_resources['memory']
+            requests['memory'] = memory
+            limits['memory'] = memory
+        if 'cpu' in job_resources:
+            cpu = job_resources['cpu']
+            requests['cpu'] = cpu
+            limits['cpu'] = cpu
+        container['resources'] = {
+            'requests': requests,
+            'limits': limits
+        }
+    pod_spec = {
+        'containers': [container],
+        'restartPolicy': 'Never'
+        'volumeMounts': volume_mounts
+    }
+    if 'service_account_name' in job_spec:
+        pod_spec['serviceAccountName'] = job_spec['service_account_name']
+    return pod_spec

--- a/hail/python/hailtop/batch_client/validate.py
+++ b/hail/python/hailtop/batch_client/validate.py
@@ -232,15 +232,14 @@ def validate_job(i, job):
                 if not isinstance(name, str):
                     raise ValidationError(f'jobs[{i}].secrets[{j}].mount_path is not str')
 
-    if 'service_account_name' not in job:
-        raise ValidationError(f'no required key service_account_name in jobs[{i}]')
-    service_account_name = job['service_account_name']
-    if not isinstance(service_account_name, str):
-        raise ValidationError(f'jobs[{i}].service_account_name not str')
-    if len(service_account_name) > 253:
-        raise ValidationError(f'length of jobs[{i}].service_account_name must be <= 253')
-    if not K8S_NAME_REGEX.fullmatch(service_account_name):
-        raise ValidationError(f'jobs[{i}].service_account_name must match regex: {K8S_NAME_REGEXPAT}')
+    if 'service_account_name' in job:
+        service_account_name = job['service_account_name']
+        if not isinstance(service_account_name, str):
+            raise ValidationError(f'jobs[{i}].service_account_name not str')
+        if len(service_account_name) > 253:
+            raise ValidationError(f'length of jobs[{i}].service_account_name must be <= 253')
+        if not K8S_NAME_REGEX.fullmatch(service_account_name):
+            raise ValidationError(f'jobs[{i}].service_account_name must match regex: {K8S_NAME_REGEXPAT}')
 
 
 def job_spec_to_k8s_pod_spec(job_spec):

--- a/hail/python/hailtop/batch_client/validate.py
+++ b/hail/python/hailtop/batch_client/validate.py
@@ -30,7 +30,7 @@ import re
 # }]
 
 JOB_KEYS = {
-    'always_run', 'attributes', 'callback', 'command', 'env', 'image', 'job_id', 'mount_docker_socket', 'parent_ids', 'resources', 'secrets', 'service_account_name'
+    'always_run', 'attributes', 'callback', 'command', 'env', 'image', 'input_files', 'job_id', 'mount_docker_socket', 'output_files', 'parent_ids', 'resources', 'secrets', 'service_account_name'
 }
 
 ENV_VAR_KEYS = {'name', 'value'}
@@ -45,7 +45,7 @@ K8S_NAME_REGEX = re.compile(K8S_NAME_REGEXPAT)
 MEMORY_REGEXPAT = r'[+]?(?:[0-9]*[.])?[0-9]+[KMGTP]?'
 MEMORY_REGEX = re.compile(MEMORY_REGEXPAT)
 
-CPU_REGEXPAT = r'[+]?(?:[0-9]*[.])?[0-9]+[u]?'
+CPU_REGEXPAT = r'[+]?(?:[0-9]*[.])?[0-9]+[m]?'
 CPU_REGEX = re.compile(CPU_REGEXPAT)
 
 

--- a/hail/python/hailtop/batch_client/validate.py
+++ b/hail/python/hailtop/batch_client/validate.py
@@ -30,7 +30,7 @@ import re
 # }]
 
 JOB_KEYS = {
-    'always_run', 'attributes', 'callback', 'command', 'env', 'image', 'input_files', 'job_id', 'mount_docker_socket', 'output_files', 'parent_ids', 'resources', 'secrets', 'service_account_name'
+    'always_run', 'attributes', 'callback', 'command', 'env', 'image', 'input_files', 'job_id', 'mount_docker_socket', 'output_files', 'parent_ids', 'pvc_size', 'resources', 'secrets', 'service_account_name'
 }
 
 ENV_VAR_KEYS = {'name', 'value'}

--- a/hail/python/hailtop/batch_client/validate.py
+++ b/hail/python/hailtop/batch_client/validate.py
@@ -138,7 +138,7 @@ def validate_job(i, job):
 
     if 'job_id' not in job:
         raise ValidationError(f'no required key job_id in jobs[{i}]')
-    job_id = jobs['job_id']
+    job_id = job['job_id']
     if not isinstance(job_id, int):
         raise ValidationError(f'jobs[{i}].job_id is not int')
 
@@ -158,7 +158,7 @@ def validate_job(i, job):
 
     if 'parent_ids' not in job:
         raise ValidationError(f'no required key parent_ids in jobs[{i}]')
-    parent_ids = jobs['parent_ids']
+    parent_ids = job['parent_ids']
     if not isinstance(parent_ids, list):
         raise ValidationError(f'jobs[{i}].job_id is not list')
     for j, id in enumerate(parent_ids):

--- a/hail/python/hailtop/batch_client/validate.py
+++ b/hail/python/hailtop/batch_client/validate.py
@@ -215,21 +215,19 @@ def validate_job(i, job):
             if k not in RESOURCES_KEYS:
                 raise ValidationError(f'unknown key in jobs[{i}].resources: {k}')
 
-        if 'memory' not in resources:
-            raise ValidationError(f'no required key memory in jobs[{i}].resources')
-        memory = resources['memory']
-        if not isinstance(memory, str):
-            raise ValidationError(f'jobs[{i}].resources.memory is not str')
-        if not MEMORY_REGEX.fullmatch(memory):
-            raise ValidationError(f'jobs[{i}].resources.memory must match regex: {MEMORY_REGEXPAT}')
+        if 'memory' in resources:
+            memory = resources['memory']
+            if not isinstance(memory, str):
+                raise ValidationError(f'jobs[{i}].resources.memory is not str')
+            if not MEMORY_REGEX.fullmatch(memory):
+                raise ValidationError(f'jobs[{i}].resources.memory must match regex: {MEMORY_REGEXPAT}')
 
-        if 'cpu' not in resources:
-            raise ValidationError(f'no required key cpu in jobs[{i}].resources')
-        cpu = resources['cpu']
-        if not isinstance(cpu, str):
-            raise ValidationError(f'jobs[{i}].resources.cpu is not str')
-        if not CPU_REGEX.fullmatch(memory):
-            raise ValidationError(f'jobs[{i}].resources.cpu must match regex: {CPU_REGEXPAT}')
+        if 'cpu' in resources:
+            cpu = resources['cpu']
+            if not isinstance(cpu, str):
+                raise ValidationError(f'jobs[{i}].resources.cpu is not str')
+            if not CPU_REGEX.fullmatch(memory):
+                raise ValidationError(f'jobs[{i}].resources.cpu must match regex: {CPU_REGEXPAT}')
 
     if 'secrets' in job:
         secrets = job['secrets']

--- a/hail/python/hailtop/batch_client/validate.py
+++ b/hail/python/hailtop/batch_client/validate.py
@@ -134,6 +134,7 @@ def validate_job(i, job):
         input_files = job['input_files']
         if not isinstance(input_files, list):
             raise ValidationError(f'jobs[{i}].input_files not list')
+
         for j, f in enumerate(input_files):
             if not isinstance(f, dict):
                 raise ValidationError(f'jobs[{i}].input_files[{j}] not dict')
@@ -169,8 +170,9 @@ def validate_job(i, job):
         output_files = job['output_files']
         if not isinstance(output_files, list):
             raise ValidationError(f'jobs[{i}].output_files not list')
+
         for j, f in enumerate(output_files):
-            if not isinstance(f, str):
+            if not isinstance(f, dict):
                 raise ValidationError(f'jobs[{i}].output_files[{j}] not dict')
 
             for k in f:

--- a/hail/python/hailtop/batch_client/validate.py
+++ b/hail/python/hailtop/batch_client/validate.py
@@ -128,7 +128,7 @@ def validate_job(i, job):
     # FIXME validate image
     # https://github.com/docker/distribution/blob/master/reference/regexp.go#L68
 
-    if 'input_files' not in job:
+    if 'input_files' in job:
         input_files = job['input_files']
         if not isinstance(input_files, list):
             raise ValidationError(f'jobs[{i}].input_files not list')
@@ -148,7 +148,7 @@ def validate_job(i, job):
     if not isinstance(mount_docker_socket, bool):
         raise ValidationError(f'jobs[{i}].mount_docker_socket not bool')
 
-    if 'output_files' not in job:
+    if 'output_files' in job:
         output_files = job['output_files']
         if not isinstance(output_files, list):
             raise ValidationError(f'jobs[{i}].output_files not list')

--- a/hail/python/hailtop/pipeline/backend.py
+++ b/hail/python/hailtop/pipeline/backend.py
@@ -285,11 +285,11 @@ class BatchBackend(Backend):
                 attributes['name'] = task.name
             attributes.update(task.attributes)
 
-            resources = {'requests': {}}
+            resources = {}
             if task._cpu:
-                resources['requests']['cpu'] = task._cpu
+                resources['cpu'] = task._cpu
             if task._memory:
-                resources['requests']['memory'] = task._memory
+                resources['memory'] = task._memory
 
             j = batch.create_job(image=task._image if task._image else default_image,
                                  command=['/bin/bash', '-c', cmd],

--- a/pipeline/Dockerfile.test
+++ b/pipeline/Dockerfile.test
@@ -8,4 +8,4 @@ RUN python3 -m pip install --no-cache-dir /hailtop \
 COPY pipeline/test /test/
 RUN python3 -m pip install --no-cache-dir pytest-instafail
 
-CMD ["python3", "-m", "pytest", "--instafail", "-v", "-s", "/test/"]
+CMD ["python3", "-m", "pytest", "--log-cli-level=INFO", "--instafail", "-v", "-s", "/test/"]

--- a/pipeline/Dockerfile.test
+++ b/pipeline/Dockerfile.test
@@ -8,4 +8,4 @@ RUN python3 -m pip install --no-cache-dir /hailtop \
 COPY pipeline/test /test/
 RUN python3 -m pip install --no-cache-dir pytest-instafail
 
-CMD ["python3", "-m", "pytest", "--log-cli-level=INFO", "--instafail", "-v", "-s", "/test/"]
+CMD ["python3", "-m", "pytest", "--log-cli-level=INFO", "-s", "-v", "--instafail", "/test/"]


### PR DESCRIPTION
Changes:
 - create a custom job spec schema for what a job means to us
 - hand-rolled validator
 - use in bath_client, /jobs/create endpoints in batch, batch2
 - slightly changed create_job interface around volumes, docker socket and secrets, update usage
 - wrote route to convert this to a k8s pod spec, use when actually creating jobs

The secret has a namespace, but it is ignored by the servers.  Eventually, batch should be able to pull secrets from wherever, but needs to enforce permissions on who can use what secrets.  This was a long-standing issue that I think now has a clearer path.

We can get rid of the mount docker socket option by making the worker support a build (rather than run) task.

The validator should really go in the server code, but it needs to be shared between batch and batch2 for now.

Plan is to push this through batch2 to remove the dependence on the k8s pod serialization.  When that's done, the job to pod spec routine can go into batch (and go away when CI uses batch2).  Will be interested to benchmark my validator vs. the previous cerberus + k8s validation/serialization.  
