### PR TITLE
MakeNDArray Missingess Semantics

### DIFF
--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -30,6 +30,7 @@ def test_ndarray_ref():
     np_scalar = np.array(scalar)
     h_scalar = hl._ndarray(scalar)
     h_np_scalar = hl._ndarray(np_scalar)
+
     assert_evals_to(h_scalar[()], 5.0)
     assert_evals_to(h_np_scalar[()], 5.0)
 
@@ -39,13 +40,17 @@ def test_ndarray_ref():
              [6, 7]]]
     h_cube = hl._ndarray(cube)
     h_np_cube = hl._ndarray(np.array(cube))
+    missing = hl._ndarray(hl.null(hl.tarray(hl.tint32)))
+
     assert_all_eval_to(
         (h_cube[0, 0, 1], 1),
         (h_cube[1, 1, 0], 6),
         (h_np_cube[0, 0, 1], 1),
         (h_np_cube[1, 1, 0], 6),
         (hl._ndarray([[[[1]]]])[0, 0, 0, 0], 1),
-        (hl._ndarray([[[1, 2]], [[3, 4]]])[1, 0, 0], 3))
+        (hl._ndarray([[[1, 2]], [[3, 4]]])[1, 0, 0], 3),
+        (missing[1], None)
+    )
 
     with pytest.raises(FatalError) as exc:
         hl.eval(hl._ndarray([1, 2, 3])[4])

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -102,6 +102,8 @@ def test_ndarray_eval():
     assert "inner dimensions do not match" in str(exc.value)
 
 
+
+
 @skip_unless_spark_backend()
 def test_ndarray_shape():
     np_e = np.array(3)

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -49,7 +49,9 @@ def test_ndarray_ref():
         (h_np_cube[1, 1, 0], 6),
         (hl._ndarray([[[[1]]]])[0, 0, 0, 0], 1),
         (hl._ndarray([[[1, 2]], [[3, 4]]])[1, 0, 0], 3),
-        (missing[1], None)
+        (missing[1], None),
+        (hl._ndarray([1, 2, 3])[hl.null(hl.tint32)], None),
+        (h_cube[0, 0, hl.null(hl.tint32)], None)
     )
 
     with pytest.raises(FatalError) as exc:

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -97,11 +97,12 @@ def test_ndarray_eval():
     assert np.array_equal(hl.eval(hl._ndarray(hl.range(6))), np.arange(6))
     assert np.array_equal(hl.eval(hl._ndarray(hl.int64(4))), np.array(4))
 
+    # Testing missing data
+    assert hl.eval(hl._ndarray(hl.null(hl.tarray(hl.tint32)))) is None
+
     with pytest.raises(ValueError) as exc:
         hl._ndarray([[4], [1, 2, 3], 5])
     assert "inner dimensions do not match" in str(exc.value)
-
-
 
 
 @skip_unless_spark_backend()

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -118,6 +118,7 @@ def test_ndarray_shape():
     col = hl._ndarray(np_col)
     m = hl._ndarray(np_m)
     nd = hl._ndarray(np_nd)
+    missing = hl._ndarray(hl.null(hl.tarray(hl.tint32)))
 
     assert_all_eval_to(
         (e.shape, np_e.shape),
@@ -127,7 +128,9 @@ def test_ndarray_shape():
         (nd.shape, np_nd.shape),
         ((row + nd).shape, (np_row + np_nd).shape),
         ((row + col).shape, (np_row + np_col).shape),
-        (m.transpose().shape, np_m.transpose().shape))
+        (m.transpose().shape, np_m.transpose().shape),
+        (missing.shape, None)
+    )
 
 @skip_unless_spark_backend()
 @run_with_cxx_compile()

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1500,20 +1500,19 @@ private class Emit(
         val setup = Code(
           shapet.setup,
           datat.setup,
-          rowMajort.setup,
-          shapet.m.mux(
-            Code._fatal("Missing shape"),
-            shapeAddress := shapet.value[Long]
-          ),
+          rowMajort.setup
+        )
+        val result = Code(
+          shapeAddress := shapet.value[Long],
           Code.foreach(0 until nDims) {index =>
             shapeTuple.isMissing(index).mux[Unit](
               Code._fatal(s"shape missing at index $index"),
               shapeVariables(index) := shapeTuple(index)
             )
-          }
+          },
+          xP.construct(0, 0, shapeBuilder, xP.makeDefaultStridesBuilder(shapeVariables.map(_.load()), mb), requiredData, mb)
         )
-        val result = xP.construct(0, 0, shapeBuilder, xP.makeDefaultStridesBuilder(shapeVariables.map(_.load()), mb), requiredData, mb)
-        EmitTriplet(setup, false, result)
+        EmitTriplet(setup, shapet.m, result)
       case NDArrayShape(ndIR) =>
         val ndt = emit(ndIR)
         val ndP = ndIR.pType.asInstanceOf[PNDArray]

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1517,7 +1517,7 @@ private class Emit(
         val ndt = emit(ndIR)
         val ndP = ndIR.pType.asInstanceOf[PNDArray]
 
-        EmitTriplet(ndt.setup, false, ndP.shape.load(region, ndt.value[Long]))
+        EmitTriplet(ndt.setup, ndt.m, ndP.shape.load(region, ndt.value[Long]))
       case NDArrayRef(nd, idxs) =>
         val ndt = emit(nd)
         val idxst = idxs.map(emit(_))

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -1512,7 +1512,7 @@ private class Emit(
           },
           xP.construct(0, 0, shapeBuilder, xP.makeDefaultStridesBuilder(shapeVariables.map(_.load()), mb), requiredData, mb)
         )
-        EmitTriplet(setup, shapet.m, result)
+        EmitTriplet(setup, datat.m || shapet.m, result)
       case NDArrayShape(ndIR) =>
         val ndt = emit(ndIR)
         val ndP = ndIR.pType.asInstanceOf[PNDArray]


### PR DESCRIPTION
Resolves #6957 

Basically none of the NDArray stuff currently supports missingess, so this is the beginning of adding that support. The IR nodes that rely on the `NDArrayEmitter` are more complicated, but here's two easy ones to start. This fixes MakeNDArray and NDArrayShape's handling of missingness, with a test for each. It also adds some test for NDArrayRef with missingess, which was already handled but not tested. 