### PR TITLE
[batches] remove job callbacks, batch callback with batch info

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -2,7 +2,6 @@ import asyncio
 import concurrent
 import logging
 import os
-import threading
 import traceback
 import json
 import uuid
@@ -13,7 +12,6 @@ from aiohttp import web
 import aiohttp_session
 import cerberus
 import kubernetes as kube
-import requests
 import uvloop
 import prometheus_client as pc
 from prometheus_async.aio import time as prom_async_time
@@ -391,7 +389,7 @@ class Job:
             durations = json.loads(record['durations'])
 
             return Job(batch_id=record['batch_id'], job_id=record['job_id'], attributes=attributes,
-                       callback=record['callback'], userdata=userdata, user=record['user'],
+                       userdata=userdata, user=record['user'],
                        always_run=record['always_run'], exit_codes=exit_codes, durations=durations,
                        state=record['state'], pvc_size=record['pvc_size'], cancelled=record['cancelled'],
                        directory=record['directory'], token=record['token'], pod_spec=pod_spec,
@@ -424,7 +422,7 @@ class Job:
         return jobs
 
     @staticmethod
-    def create_job(jobs_builder, pod_spec, batch_id, job_id, attributes, callback,
+    def create_job(jobs_builder, pod_spec, batch_id, job_id, attributes,
                    parent_ids, input_files, output_files, userdata, always_run,
                    pvc_size, state):
         cancelled = False
@@ -441,7 +439,7 @@ class Job:
             job_id=job_id,
             state=state,
             pvc_size=pvc_size,
-            callback=callback,
+            callback=None,  # legacy
             attributes=json.dumps(attributes),
             always_run=always_run,
             token=token,
@@ -458,7 +456,7 @@ class Job:
                 job_id=job_id,
                 parent_id=parent)
 
-        job = Job(batch_id=batch_id, job_id=job_id, attributes=attributes, callback=callback,
+        job = Job(batch_id=batch_id, job_id=job_id, attributes=attributes,
                   userdata=userdata, user=user, always_run=always_run,
                   exit_codes=exit_codes, durations=durations, state=state, pvc_size=pvc_size,
                   cancelled=cancelled, directory=directory, token=token,
@@ -466,7 +464,7 @@ class Job:
 
         return job
 
-    def __init__(self, batch_id, job_id, attributes, callback, userdata, user, always_run,
+    def __init__(self, batch_id, job_id, attributes, userdata, user, always_run,
                  exit_codes, durations, state, pvc_size, cancelled, directory,
                  token, pod_spec, input_files, output_files):
         self.batch_id = batch_id
@@ -474,7 +472,6 @@ class Job:
         self.id = (batch_id, job_id)
 
         self.attributes = attributes
-        self.callback = callback
         self.always_run = always_run
         self.userdata = userdata
         self.user = user
@@ -673,21 +670,10 @@ class Job:
         await self.set_state(new_state, durations, exit_codes)
         await self._delete_k8s_resources()
         self.log_info(f'complete with state {self._state}, exit_codes {self.exit_codes}')
-        if self.callback:
-            def handler(job, callback, json):
-                try:
-                    requests.post(callback, json=json, timeout=120)
-                except requests.exceptions.RequestException as exc:
-                    job.log_warning(
-                        f'callback failed due to an error, I will not retry. '
-                        f'Error: {exc}')
-
-            threading.Thread(target=handler, args=(self, self.callback, self.to_dict())).start()
-
         if self.batch_id:
             batch = await Batch.from_db(self.batch_id, self.user)
             if batch is not None:
-                await batch.mark_job_complete(self)
+                await batch.mark_job_complete()
 
     def to_dict(self):
         result = {
@@ -726,7 +712,6 @@ def create_job(jobs_builder, batch_id, userdata, job_spec):  # pylint: disable=R
         job_id=job_id,
         pod_spec=pod_spec,
         attributes=job_spec.get('attributes'),
-        callback=job_spec.get('callback'),
         parent_ids=parent_ids,
         input_files=input_files,
         output_files=output_files,
@@ -922,20 +907,12 @@ class Batch:
         await db.batch.delete_record(self.id)
         log.info(f'batch {self.id} deleted')
 
-    async def mark_job_complete(self, job):
-        if self.callback:
-            def handler(id, job_id, callback, json):
-                try:
-                    requests.post(callback, json=json, timeout=120)
-                except requests.exceptions.RequestException as exc:
-                    log.warning(
-                        f'callback for batch {id}, job {job_id} failed due to an error, I will not retry. '
-                        f'Error: {exc}')
-
-            threading.Thread(
-                target=handler,
-                args=(self.id, job.id, self.callback, job.to_dict())
-            ).start()
+    async def mark_job_complete(self):
+        if self.complete and self.callback:
+            try:
+                await app['client_session'].post(self.callback, json=self.to_dict(include_jobs=False))
+            except Exception:  # pylint: disable=broad-except
+                log.exception(f'callback for batch {self.id}, will not retry.')
 
     def is_complete(self):
         return self.complete

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -910,7 +910,7 @@ class Batch:
     async def mark_job_complete(self):
         if self.complete and self.callback:
             try:
-                await app['client_session'].post(self.callback, json=self.to_dict(include_jobs=False))
+                await app['client_session'].post(self.callback, json=await self.to_dict(include_jobs=False))
             except Exception:  # pylint: disable=broad-except
                 log.exception(f'callback for batch {self.id}, will not retry.')
 

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -909,10 +909,12 @@ class Batch:
 
     async def mark_job_complete(self):
         if self.complete and self.callback:
+            log.info(f'making callback for batch {self.id}: {self.callback}')
             try:
                 await app['client_session'].post(self.callback, json=await self.to_dict(include_jobs=False))
+                log.info(f'callback for batch {self.id} successful')
             except Exception:  # pylint: disable=broad-except
-                log.exception(f'callback for batch {self.id}, will not retry.')
+                log.exception(f'callback for batch {self.id} failed, will not retry.')
 
     def is_complete(self):
         return self.complete

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -10,7 +10,6 @@ import secrets
 import time
 import unittest
 import aiohttp
-from flask import Flask, Response, request
 import requests
 
 from hailtop.config import get_deploy_config

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -113,48 +113,43 @@ def test_cancel_left_after_tail(client):
 def test_callback(client):
     from flask import Flask, request
     app = Flask('test-client')
-    output = []
+    callback_body = None
 
     @app.route('/test', methods=['POST'])
     def test():
-        body = request.get_json()
-        print(f'body {body}')
-        output.append(body)
+        callback_body = request.get_json()
         return Response(status=200)
 
     try:
-        print('starting...')
         server = ServerThread(app)
         server.start()
-        batch = client.create_batch(callback=server.url_for('/test'))
-        head = batch.create_job('alpine:3.8', command=['echo', 'head'])
-        left = batch.create_job('alpine:3.8', command=['echo', 'left'], parents=[head])
-        right = batch.create_job('alpine:3.8', command=['echo', 'right'], parents=[head])
-        tail = batch.create_job('alpine:3.8', command=['echo', 'tail'], parents=[left, right])
-        batch = batch.submit()
-        print(f'ids {head.job_id} {left.job_id} {right.job_id} {tail.job_id}')
-        batch_status = batch.wait()
+        b = client.create_batch(
+            callback=server.url_for('/test'),
+            attributes={'foo': 'bar'})
+        b.create_job('alpine:3.8', command=['echo', 'head'])
+        b.create_job('alpine:3.8', command=['echo', 'tail'], parents=[head])
+        b = b.submit()
+        b.wait()
 
         i = 0
-        while len(output) != 4:
+        while not callback_body:
             time.sleep(0.100 * (3/2) ** i)
             i += 1
             if i > 14:
                 break
 
-        assert len(output) == 4, output
-        assert all([job_result['state'] == 'Success' and job_result['exit_code']['main'] == 0
-                    for job_result in output]), (output, batch_status)
-        assert output[0]['job_id'] == head.job_id, (output, batch_status)
-        middle_ids = (output[1]['job_id'], output[2]['job_id'])
-        assert middle_ids in ((left.job_id, right.job_id), (right.job_id, left.job_id)), (output, batch_status)
-        assert output[3]['job_id'] == tail.job_id, (output, batch_status)
+        self.assertDictEqual(
+            received_callback, {
+                'id': batch.id,
+                'state': 'success',
+                'complete': True,
+                'closed': True,
+                'attributes': {'foo': 'bar'},
+            })
     finally:
         if server:
-            print('shutting down...')
             server.shutdown()
             server.join()
-            print('shut down, joined')
 
 
 def test_no_parents_allowed_in_other_batches(client):

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -139,7 +139,7 @@ def test_callback(client):
                 break
 
         assert (received_callback == {
-            'id': batch.id,
+            'id': b.id,
             'state': 'success',
             'complete': True,
             'closed': True,

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -138,14 +138,13 @@ def test_callback(client):
             if i > 14:
                 break
 
-        self.assertDictEqual(
-            received_callback, {
-                'id': batch.id,
-                'state': 'success',
-                'complete': True,
-                'closed': True,
-                'attributes': {'foo': 'bar'},
-            })
+        assert (received_callback == {
+            'id': batch.id,
+            'state': 'success',
+            'complete': True,
+            'closed': True,
+            'attributes': {'foo': 'bar'},
+        }), received_callback
     finally:
         if server:
             server.shutdown()

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -113,11 +113,11 @@ def test_cancel_left_after_tail(client):
 def test_callback(client):
     from flask import Flask, request
     app = Flask('test-client')
-    callback_body = None
+    callback_body = []
 
     @app.route('/test', methods=['POST'])
     def test():
-        callback_body = request.get_json()
+        callback_body.append(request.get_json())
         return Response(status=200)
 
     try:
@@ -137,6 +137,7 @@ def test_callback(client):
             i += 1
             if i > 14:
                 break
+        callback_body = callback_body[0]
 
         assert (callback_body == {
             'id': b.id,
@@ -176,7 +177,6 @@ def test_input_dependency(client):
     batch.submit()
     tail.wait()
     assert head.status()['exit_code']['main'] == 0, head._status
-    print(head.log())
     assert tail.log()['main'] == 'head1\nhead2\n', tail.status()
 
 

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -126,8 +126,8 @@ def test_callback(client):
         b = client.create_batch(
             callback=server.url_for('/test'),
             attributes={'foo': 'bar'})
-        b.create_job('alpine:3.8', command=['echo', 'head'])
-        b.create_job('alpine:3.8', command=['echo', 'tail'], parents=[head])
+        head = b.create_job('alpine:3.8', command=['echo', 'head'])
+        tail = b.create_job('alpine:3.8', command=['echo', 'tail'], parents=[head])
         b = b.submit()
         b.wait()
 

--- a/batch/test/test_dag.py
+++ b/batch/test/test_dag.py
@@ -138,13 +138,13 @@ def test_callback(client):
             if i > 14:
                 break
 
-        assert (received_callback == {
+        assert (callback_body == {
             'id': b.id,
             'state': 'success',
             'complete': True,
             'closed': True,
             'attributes': {'foo': 'bar'},
-        }), received_callback
+        }), callback_body
     finally:
         if server:
             server.shutdown()

--- a/batch2/batch/batch.py
+++ b/batch2/batch/batch.py
@@ -551,12 +551,14 @@ class Batch:
 
     async def mark_job_complete(self):
         if self.complete and self.callback:
+            log.info(f'making callback for batch {self.id}: {self.callback}')
             try:
                 async with aiohttp.ClientSession(
                         raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
                     await session.post(self.callback, json=await self.to_dict(include_jobs=False))
+                    log.info(f'callback for batch {self.id} successful')
             except Exception:  # pylint: disable=broad-except
-                log.exception(f'callback for batch {self.id}, will not retry.')
+                log.exception(f'callback for batch {self.id} failed, will not retry.')
 
     def is_complete(self):
         return self.complete

--- a/batch2/batch/batch.py
+++ b/batch2/batch/batch.py
@@ -554,7 +554,7 @@ class Batch:
             try:
                 async with aiohttp.ClientSession(
                         raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
-                    await session.post(self.callback, json=self.to_dict(include_jobs=False))
+                    await session.post(self.callback, json=await self.to_dict(include_jobs=False))
             except Exception:  # pylint: disable=broad-except
                 log.exception(f'callback for batch {self.id}, will not retry.')
 

--- a/batch2/batch/batch.py
+++ b/batch2/batch/batch.py
@@ -1,11 +1,10 @@
 import json
 import logging
 import os
-import threading
 import traceback
 from shlex import quote as shq
 import asyncio
-import requests
+import aiohttp
 import kubernetes as kube
 from hailtop import batch_client
 
@@ -252,10 +251,6 @@ class Job:
         return self._spec.get('attributes')
 
     @property
-    def callback(self):
-        return self._spec.get('callback')
-
-    @property
     def input_files(self):
         return self._spec.get('input_files')
 
@@ -403,21 +398,10 @@ class Job:
 
         log.info('job {} complete with state {}, exit_codes {}'.format(self.id, self._state, self.exit_codes))
 
-        if self.callback:
-            def handler(id, callback, json):
-                try:
-                    requests.post(callback, json=json, timeout=120)
-                except requests.exceptions.RequestException as exc:
-                    log.warning(
-                        f'callback for job {id} failed due to an error, I will not retry. '
-                        f'Error: {exc}')
-
-            threading.Thread(target=handler, args=(self.id, self.callback, self.to_dict())).start()
-
         if self.batch_id:
             batch = await Batch.from_db(self.app, self.batch_id, self.user)
             if batch is not None:
-                await batch.mark_job_complete(self)
+                await batch.mark_job_complete()
 
     def to_dict(self):
         result = {
@@ -565,20 +549,14 @@ class Batch:
         await self.app['db'].batch.delete_record(self.id)
         log.info(f'batch {self.id} deleted')
 
-    async def mark_job_complete(self, job):
-        if self.callback:
-            def handler(id, job_id, callback, json):
-                try:
-                    requests.post(callback, json=json, timeout=120)
-                except requests.exceptions.RequestException as exc:
-                    log.warning(
-                        f'callback for batch {id}, job {job_id} failed due to an error, I will not retry. '
-                        f'Error: {exc}')
-
-            threading.Thread(
-                target=handler,
-                args=(self.id, job.id, self.callback, job.to_dict())
-            ).start()
+    async def mark_job_complete(self):
+        if self.complete and self.callback:
+            try:
+                async with aiohttp.ClientSession(
+                        raise_for_status=True, timeout=aiohttp.ClientTimeout(total=60)) as session:
+                    await session.post(self.callback, json=self.to_dict(include_jobs=False))
+            except Exception:  # pylint: disable=broad-except
+                log.exception(f'callback for batch {self.id}, will not retry.')
 
     def is_complete(self):
         return self.complete

--- a/batch2/deployment.yaml
+++ b/batch2/deployment.yaml
@@ -57,6 +57,12 @@ spec:
          - name: MAX_INSTANCES
            value: "2"
 {% endif %}
+{% if not deploy %}
+         - name: HAIL_BATCH_JOB_DEFAULT_CPU
+           value: "0.1"
+         - name: HAIL_BATCH_JOB_DEFAULT_MEMORY
+           value: "375M"
+{% endif %}
         ports:
          - containerPort: 5000
         volumeMounts:
@@ -150,12 +156,6 @@ spec:
 {% if deploy %}
          - name: HAIL_INSTANCE_ID
            value: cd50b95a89914efb897965a5e982a29d
-{% endif %}
-{% if not deploy %}
-         - name: HAIL_BATCH_JOB_DEFAULT_CPU
-           value: "0.1"
-         - name: HAIL_BATCH_JOB_DEFAULT_MEMORY
-           value: "375M"
 {% endif %}
         ports:
          - containerPort: 5000

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -282,37 +282,6 @@ class Test(unittest.TestCase):
         b4s = b4.status()
         assert b4s['complete'] and b4s['state'] == 'cancelled', b4s
 
-    def test_callback(self):
-        app = Flask('test-client')
-
-        d = {}
-
-        @app.route('/test', methods=['POST'])
-        def test():
-            body = request.get_json()
-            d['status'] = body
-            return Response(status=200)
-
-        server = ServerThread(app)
-        try:
-            server.start()
-            b = self.client.create_batch()
-            j = b.create_job(
-                'ubuntu:18.04',
-                ['echo', 'test'],
-                attributes={'foo': 'bar'},
-                callback=server.url_for('/test'))
-            b = b.submit()
-            j.wait()
-
-            poll_until(lambda: 'status' in d)
-            status = d['status']
-            self.assertEqual(status['state'], 'Success')
-            self.assertEqual(status['attributes'], {'foo': 'bar'})
-        finally:
-            server.shutdown()
-            server.join()
-
     def test_log_after_failing_job(self):
         b = self.client.create_batch()
         j = b.create_job('ubuntu:18.04', ['/bin/sh', '-c', 'echo test; exit 127'])

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -10,7 +10,6 @@ import secrets
 import time
 import unittest
 import aiohttp
-from flask import Flask, Response, request
 import requests
 from hailtop.config import get_deploy_config
 from hailtop.auth import service_auth_headers

--- a/batch2/test/test_dag.py
+++ b/batch2/test/test_dag.py
@@ -113,11 +113,12 @@ def test_cancel_left_after_tail(client):
 def test_callback(client):
     from flask import Flask, request
     app = Flask('test-client')
-    callback_body = None
+    callback_body = []
 
     @app.route('/test', methods=['POST'])
     def test():
-        callback_body = request.get_json()
+        body = request.get_json()
+        callback_body.append(body)
         return Response(status=200)
 
     try:
@@ -137,6 +138,7 @@ def test_callback(client):
             i += 1
             if i > 14:
                 break
+        callback_body = callback_body[0]
 
         assert (callback_body == {
             'id': b.id,
@@ -176,7 +178,6 @@ def test_input_dependency(client):
     batch.submit()
     tail.wait()
     assert head.status()['exit_code']['main'] == 0, head._status
-    print(head.log())
     assert tail.log()['main'] == 'head1\nhead2\n', tail.status()
 
 

--- a/batch2/test/test_dag.py
+++ b/batch2/test/test_dag.py
@@ -139,7 +139,7 @@ def test_callback(client):
                 break
 
         assert (received_callback == {
-            'id': batch.id,
+            'id': b.id,
             'state': 'success',
             'complete': True,
             'closed': True,

--- a/batch2/test/test_dag.py
+++ b/batch2/test/test_dag.py
@@ -113,48 +113,43 @@ def test_cancel_left_after_tail(client):
 def test_callback(client):
     from flask import Flask, request
     app = Flask('test-client')
-    output = []
+    callback_body = None
 
     @app.route('/test', methods=['POST'])
     def test():
-        body = request.get_json()
-        print(f'body {body}')
-        output.append(body)
+        callback_body = request.get_json()
         return Response(status=200)
 
     try:
-        print('starting...')
         server = ServerThread(app)
         server.start()
-        batch = client.create_batch(callback=server.url_for('/test'))
-        head = batch.create_job('ubuntu:18.04', command=['echo', 'head'])
-        left = batch.create_job('ubuntu:18.04', command=['echo', 'left'], parents=[head])
-        right = batch.create_job('ubuntu:18.04', command=['echo', 'right'], parents=[head])
-        tail = batch.create_job('ubuntu:18.04', command=['echo', 'tail'], parents=[left, right])
-        batch = batch.submit()
-        print(f'ids {head.job_id} {left.job_id} {right.job_id} {tail.job_id}')
-        batch_status = batch.wait()
+        b = client.create_batch(
+            callback=server.url_for('/test'),
+            attributes={'foo': 'bar'})
+        head = b.create_job('alpine:3.8', command=['echo', 'head'])
+        tail = b.create_job('alpine:3.8', command=['echo', 'tail'], parents=[head])
+        b = b.submit()
+        b.wait()
 
         i = 0
-        while len(output) != 4:
+        while not callback_body:
             time.sleep(0.100 * (3/2) ** i)
             i += 1
             if i > 14:
                 break
 
-        assert len(output) == 4, output
-        assert all([job_result['state'] == 'Success' and job_result['exit_code']['main'] == 0
-                    for job_result in output]), (output, batch_status)
-        assert output[0]['job_id'] == head.job_id, (output, batch_status)
-        middle_ids = (output[1]['job_id'], output[2]['job_id'])
-        assert middle_ids in ((left.job_id, right.job_id), (right.job_id, left.job_id)), (output, batch_status)
-        assert output[3]['job_id'] == tail.job_id, (output, batch_status)
+        self.assertDictEqual(
+            received_callback, {
+                'id': batch.id,
+                'state': 'success',
+                'complete': True,
+                'closed': True,
+                'attributes': {'foo': 'bar'},
+            })
     finally:
         if server:
-            print('shutting down...')
             server.shutdown()
             server.join()
-            print('shut down, joined')
 
 
 def test_no_parents_allowed_in_other_batches(client):

--- a/batch2/test/test_dag.py
+++ b/batch2/test/test_dag.py
@@ -138,14 +138,13 @@ def test_callback(client):
             if i > 14:
                 break
 
-        self.assertDictEqual(
-            received_callback, {
-                'id': batch.id,
-                'state': 'success',
-                'complete': True,
-                'closed': True,
-                'attributes': {'foo': 'bar'},
-            })
+        assert (received_callback == {
+            'id': batch.id,
+            'state': 'success',
+            'complete': True,
+            'closed': True,
+            'attributes': {'foo': 'bar'},
+        }), received_callback
     finally:
         if server:
             server.shutdown()

--- a/batch2/test/test_dag.py
+++ b/batch2/test/test_dag.py
@@ -138,13 +138,13 @@ def test_callback(client):
             if i > 14:
                 break
 
-        assert (received_callback == {
+        assert (callback_body == {
             'id': b.id,
             'state': 'success',
             'complete': True,
             'closed': True,
             'attributes': {'foo': 'bar'},
-        }), received_callback
+        }), callback_body
     finally:
         if server:
             server.shutdown()

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -270,7 +270,7 @@ class BatchBuilder:
 
     def create_job(self, image, command, env=None, mount_docker_socket=False,
                    resources=None, secrets=None,
-                   service_account_name=None, attributes=None, callback=None, parents=None,
+                   service_account_name=None, attributes=None, parents=None,
                    input_files=None, output_files=None, always_run=False, pvc_size=None):
         if self._submitted:
             raise ValueError("cannot create a job in an already submitted batch")
@@ -325,8 +325,6 @@ class BatchBuilder:
 
         if attributes:
             job_spec['attributes'] = attributes
-        if callback:
-            job_spec['callback'] = callback
         if input_files:
             job_spec['input_files'] = [{"from": src, "to": dst} for (src, dst) in input_files]
         if output_files:

--- a/hail/python/hailtop/batch_client/client.py
+++ b/hail/python/hailtop/batch_client/client.py
@@ -117,7 +117,7 @@ class BatchBuilder:
 
     def create_job(self, image, command, env=None, mount_docker_socket=False,
                    resources=None, secrets=None,
-                   service_account_name=None, attributes=None, callback=None, parents=None,
+                   service_account_name=None, attributes=None, parents=None,
                    input_files=None, output_files=None, always_run=False, pvc_size=None):
         if parents:
             parents = [parent._async_job for parent in parents]
@@ -126,7 +126,7 @@ class BatchBuilder:
             image, command, env=env, mount_docker_socket=mount_docker_socket,
             resources=resources, secrets=secrets,
             service_account_name=service_account_name,
-            attributes=attributes, callback=callback, parents=parents,
+            attributes=attributes, parents=parents,
             input_files=input_files, output_files=output_files, always_run=always_run,
             pvc_size=pvc_size)
 

--- a/hail/python/hailtop/pipeline/pipeline.py
+++ b/hail/python/hailtop/pipeline/pipeline.py
@@ -150,13 +150,13 @@ class Pipeline:
     def _new_task_resource_file(self, source, value=None):
         trf = TaskResourceFile(value if value else self._tmp_file())
         trf._add_source(source)
-        self._resource_map[trf._uid] = trf
+        self._resource_map[trf._uid] = trf  # pylint: disable=no-member
         return trf
 
     def _new_input_resource_file(self, input_path, value=None):
         irf = InputResourceFile(value if value else self._tmp_file())
         irf._add_input_path(input_path)
-        self._resource_map[irf._uid] = irf
+        self._resource_map[irf._uid] = irf  # pylint: disable=no-member
         self._input_resources.add(irf)
         return irf
 
@@ -170,7 +170,7 @@ class Pipeline:
                 raise PipelineException(f"value for name '{name}' is not a string. Found '{type(code)}' instead.")
             r = self._new_task_resource_file(source=source, value=eval(f'f"""{code}"""'))  # pylint: disable=W0123
             d[name] = r
-            new_resource_map[r._uid] = r
+            new_resource_map[r._uid] = r  # pylint: disable=no-member
 
         self._resource_map.update(new_resource_map)
         rg = ResourceGroup(source, root, **d)

--- a/hail/python/hailtop/pipeline/resource.py
+++ b/hail/python/hailtop/pipeline/resource.py
@@ -17,7 +17,7 @@ class Resource:
         pass
 
     def _declare(self, directory):
-        return f"{self._uid}={shq(self._get_path(directory))}"
+        return f"{self._uid}={shq(self._get_path(directory))}"  # pylint: disable=no-member
 
 
 class ResourceFile(Resource, str):
@@ -107,10 +107,10 @@ class ResourceFile(Resource, str):
         return self
 
     def __str__(self):
-        return self._uid
+        return self._uid  # pylint: disable=no-member
 
     def __repr__(self):
-        return self._uid
+        return self._uid  # pylint: disable=no-member
 
 
 class InputResourceFile(ResourceFile):


### PR DESCRIPTION
Changes:
 - Remove the per-job callback.  Nobody is relying on this.
 - The batch callback should send batch metadata, not job metadata.  This is already what the CI is expecting (I think the only callback user).
 - Switch to aiohttp for the callback, not threading/requests.

@tpoterba this will speed up merges in the CI by a few minutes.  Now the callback is ignored and its the periodic poll loop that notices the finished tests.