### PR TITLE
[pipeline] minor fixes

### DIFF
--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -7,7 +7,7 @@ from asyncinit import asyncinit
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import async_get_userinfo, service_auth_headers
-from hailtop.utils import AsyncGather, request_retry_transient_errors
+from hailtop.utils import AsyncThrottledGather, request_retry_transient_errors
 
 from .globals import complete_states
 
@@ -266,7 +266,6 @@ class BatchBuilder:
         self._submitted = False
         self.attributes = attributes
         self.callback = callback
-        self.pool = AsyncGather(2)
 
     def create_job(self, image, command, env=None, mount_docker_socket=False,
                    resources=None, secrets=None,
@@ -358,20 +357,21 @@ class BatchBuilder:
         batch = Batch(self._client, b['id'], b.get('attributes'))
 
         specs = []
+        runner = AsyncThrottledGather(2)
         n = 0
         for job_spec in self._job_specs:
             n += 1
             specs.append(job_spec)
             if n == job_array_size:
-                await self.pool.call(self._submit_job, batch.id, specs)
+                await runner.call(self._submit_job, batch.id, specs)
                 n = 0
                 specs = []
 
         if specs:
-            await self.pool.call(self._submit_job, batch.id, specs)
+            await runner.call(self._submit_job, batch.id, specs)
 
         if len(self._job_specs) > 0:
-            await self.pool.wait()
+            await runner.wait()
 
         await self._client._patch(f'/api/v1alpha/batches/{batch.id}/close')
         log.info(f'closed batch {b["id"]}')

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -7,7 +7,7 @@ from asyncinit import asyncinit
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import async_get_userinfo, service_auth_headers
-from hailtop.utils import AsyncThrottledGather, request_retry_transient_errors
+from hailtop.utils import throttled_gather, request_retry_transient_errors
 
 from .globals import complete_states
 
@@ -357,21 +357,20 @@ class BatchBuilder:
         batch = Batch(self._client, b['id'], b.get('attributes'))
 
         specs = []
-        runner = AsyncThrottledGather(2)
+        coros = []
         n = 0
         for job_spec in self._job_specs:
             n += 1
             specs.append(job_spec)
             if n == job_array_size:
-                await runner.call(self._submit_job, batch.id, specs)
+                coros.append(self._submit_job(batch.id, specs))
                 n = 0
                 specs = []
 
         if specs:
-            await runner.call(self._submit_job, batch.id, specs)
+            coros.append(self._submit_job(batch.id, specs))
 
-        if len(self._job_specs) > 0:
-            await runner.wait()
+        await throttled_gather(*coros, parallelism=10)
 
         await self._client._patch(f'/api/v1alpha/batches/{batch.id}/close')
         log.info(f'closed batch {b["id"]}')

--- a/hail/python/hailtop/batch_client/aioclient.py
+++ b/hail/python/hailtop/batch_client/aioclient.py
@@ -7,7 +7,7 @@ from asyncinit import asyncinit
 
 from hailtop.config import get_deploy_config
 from hailtop.auth import async_get_userinfo, service_auth_headers
-from hailtop.utils import AsyncWorkerPool, request_retry_transient_errors
+from hailtop.utils import AsyncGather, request_retry_transient_errors
 
 from .globals import complete_states
 
@@ -266,7 +266,7 @@ class BatchBuilder:
         self._submitted = False
         self.attributes = attributes
         self.callback = callback
-        self.pool = AsyncWorkerPool(2)
+        self.pool = AsyncGather(2)
 
     def create_job(self, image, command, env=None, mount_docker_socket=False,
                    resources=None, secrets=None,
@@ -370,7 +370,8 @@ class BatchBuilder:
         if specs:
             await self.pool.call(self._submit_job, batch.id, specs)
 
-        await self.pool.wait()
+        if len(self._job_specs) > 0:
+            await self.pool.wait()
 
         await self._client._patch(f'/api/v1alpha/batches/{batch.id}/close')
         log.info(f'closed batch {b["id"]}')

--- a/hail/python/hailtop/pipeline/backend.py
+++ b/hail/python/hailtop/pipeline/backend.py
@@ -337,7 +337,6 @@ class BatchBackend(Backend):
 
         if status['state'] == 'success':
             print('Pipeline completed successfully!')
-            self._batch_client.close()
             return
 
         failed_jobs = [((j['batch_id'], j['job_id']), j['exit_code']) for j in status['jobs'] if 'exit_code' in j and any([ec != 0 for _, ec in j['exit_code'].items()])]
@@ -353,7 +352,5 @@ class BatchBackend(Backend):
                 f"  Task name:\t{name}\n"
                 f"  Command:\t{jobs_to_command[jid]}\n"
                 f"  Log:\t{log}\n")
-
-        self._batch_client.close()
 
         raise PipelineException(fail_msg)

--- a/hail/python/hailtop/pipeline/task.py
+++ b/hail/python/hailtop/pipeline/task.py
@@ -347,7 +347,7 @@ class Task:
         :class:`.Task`
             Same task object with memory requirements set.
         """
-        self._memory = memory
+        self._memory = str(memory)
         return self
 
     def cpu(self, cores):
@@ -373,7 +373,7 @@ class Task:
             Same task object with CPU requirements set.
         """
 
-        self._cpu = cores
+        self._cpu = str(cores)
         return self
 
     def image(self, image):

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -1,16 +1,16 @@
 from .utils import unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool, \
-    AsyncThrottledGather, request_retry_transient_errors, request_raise_transient_errors
+    request_retry_transient_errors, request_raise_transient_errors, throttled_gather
 from .process import CalledProcessError, check_shell, check_shell_output
 
 __all__ = [
     'unzip',
     'async_to_blocking',
     'blocking_to_async',
-    'AsyncThrottledGather',
     'AsyncWorkerPool',
     'CalledProcessError',
     'check_shell',
     'check_shell_output',
     'request_retry_transient_errors',
-    'request_raise_transient_errors'
+    'request_raise_transient_errors',
+    'throttled_gather'
 ]

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -1,12 +1,12 @@
 from .utils import unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool, \
-    AsyncGather, request_retry_transient_errors, request_raise_transient_errors
+    AsyncThrottledGather, request_retry_transient_errors, request_raise_transient_errors
 from .process import CalledProcessError, check_shell, check_shell_output
 
 __all__ = [
     'unzip',
     'async_to_blocking',
     'blocking_to_async',
-    'AsyncGather',
+    'AsyncThrottledGather',
     'AsyncWorkerPool',
     'CalledProcessError',
     'check_shell',

--- a/hail/python/hailtop/utils/__init__.py
+++ b/hail/python/hailtop/utils/__init__.py
@@ -1,11 +1,12 @@
 from .utils import unzip, async_to_blocking, blocking_to_async, AsyncWorkerPool, \
-    request_retry_transient_errors, request_raise_transient_errors
+    AsyncGather, request_retry_transient_errors, request_raise_transient_errors
 from .process import CalledProcessError, check_shell, check_shell_output
 
 __all__ = [
     'unzip',
     'async_to_blocking',
     'blocking_to_async',
+    'AsyncGather',
     'AsyncWorkerPool',
     'CalledProcessError',
     'check_shell',

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -38,7 +38,7 @@ class AsyncThrottledGather:
                 await f(*args, **kwargs)
             except asyncio.CancelledError:  # pylint: disable=try-except-raise
                 raise
-            except Exception:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except,try-except-raise
                 raise
             finally:
                 assert self._count > 0

--- a/hail/python/hailtop/utils/utils.py
+++ b/hail/python/hailtop/utils/utils.py
@@ -26,7 +26,7 @@ async def blocking_to_async(thread_pool, fun, *args, **kwargs):
         thread_pool, lambda: fun(*args, **kwargs))
 
 
-class AsyncGather:
+class AsyncThrottledGather:
     def __init__(self, parallelism):
         self._sem = asyncio.Semaphore(parallelism)
         self._count = 0


### PR DESCRIPTION
- made sure the batch client is closed after a pipeline finishes
- fixed cpu and memory to take ints and floats
- Split AsyncWorkerPool into AsyncWorkerPool and AsyncThrottledGather
- Raise errors in AsyncThrottledGather (errors ignored in AsyncWorkerPool)