### PR TITLE
[batches] fix slow tests by adding a cancel

### DIFF
--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -252,6 +252,7 @@ class Test(unittest.TestCase):
         b3 = b3.submit()
         b3s = b3.status()
         assert not b3s['complete'] and b3s['state'] == 'running', b3s
+        b3.cancel()
 
         b4 = self.client.create_batch()
         b4.create_job('alpine', ['sleep', '30'])

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -272,6 +272,7 @@ class Test(unittest.TestCase):
         b3 = b3.submit()
         b3s = b3.status()
         assert not b3s['complete'] and b3s['state'] == 'running', b3s
+        b3.cancel()
 
         b4 = self.client.create_batch()
         b4.create_job('ubuntu:18.04', ['sleep', '30'])


### PR DESCRIPTION
This job was adding an extra 30 seconds that was unnecessary.