### PR TITLE
[www/docs] support HTMLEntities in id

### DIFF
--- a/hail/python/hail/docs/_static/goto.js
+++ b/hail/python/hail/docs/_static/goto.js
@@ -1,6 +1,6 @@
 //https://caniuse.com/#feat=history
 if ((window.history && window.history.pushState)) {
-    var startingHash = window.location.hash ? window.location.hash.replace('#', '') : null;
+    var startingHash = window.location.hash ? decodeURIComponent(window.location.hash.replace('#', '')) : null;
 
     // necessary to prevent browser from overriding our initial scroll
     // browser scroll is otherwise undefeatable
@@ -34,7 +34,7 @@ if ((window.history && window.history.pushState)) {
                     return;
                 }
 
-                var hash = hrefParts[1];
+                var hash = decodeURIComponent(hrefParts[1]);
                 var elem = document.getElementById(hash);
 
                 if (!elem) {


### PR DESCRIPTION
Enables id="Let's-Do-a-GWAS!" which previously wouldn't scroll to element because of the apostrophe, which is a reserved character, and which JS receives as an encoded HTMLEntity.

As an aside, it would be nice to not have reserved characters in IDs. 