### PR TITLE
[hail] Improve performance of IR copying

### DIFF
--- a/hail/src/main/scala/is/hail/expr/ir/AggOp.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/AggOp.scala
@@ -12,7 +12,9 @@ case class AggSignature(
   op: AggOp,
   constructorArgs: Seq[Type],
   initOpArgs: Option[Seq[Type]],
-  seqOpArgs: Seq[Type])
+  seqOpArgs: Seq[Type]) {
+  lazy val returnType: Type = AggOp.getType(this)
+}
 
 case class AggSignature2(
   op: AggOp,

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -124,7 +124,7 @@ object Copy {
         ArrayFilter(newChildren(0).asInstanceOf[IR], name, newChildren(1).asInstanceOf[IR])
       case ArrayFlatMap(_, name, _) =>
         assert(newChildren.length == 2)
-        ArrayFlatMap(newChildren(0).asInstanceOf[IR], name, newChildren(0).asInstanceOf[IR])
+        ArrayFlatMap(newChildren(0).asInstanceOf[IR], name, newChildren(1).asInstanceOf[IR])
       case ArrayFold(_, _, accumName, valueName, _) =>
         assert(newChildren.length == 3)
         ArrayFold(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], accumName, valueName, newChildren(1).asInstanceOf[IR])

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -13,123 +13,121 @@ object Copy {
       case Literal(typ, value) => Literal(typ, value)
       case Void() => Void()
       case Cast(_, typ) =>
-        val IndexedSeq(v: IR) = newChildren
-        Cast(v, typ)
+        assert(newChildren.length == 1)
+        Cast(newChildren(0).asInstanceOf[IR], typ)
       case CastRename(_, typ) =>
-        val IndexedSeq(v: IR) = newChildren
-        CastRename(v, typ)
+        assert(newChildren.length == 1)
+        CastRename(newChildren(0).asInstanceOf[IR], typ)
       case NA(t) => NA(t)
       case IsNA(value) =>
-        val IndexedSeq(value: IR) = newChildren
-        IsNA(value)
+        assert(newChildren.length == 1)
+        IsNA(newChildren(0).asInstanceOf[IR])
       case Coalesce(_) =>
         Coalesce(newChildren.map(_.asInstanceOf[IR]))
       case If(_, _, _) =>
-        val IndexedSeq(cond: IR, cnsq: IR, altr: IR) = newChildren
-        If(cond, cnsq, altr)
+        assert(newChildren.length == 3)
+        If(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], newChildren(2).asInstanceOf[IR])
       case Let(name, _, _) =>
-        val IndexedSeq(value: IR, body: IR) = newChildren
-        Let(name, value, body)
+        assert(newChildren.length == 2)
+        Let(name, newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])
       case AggLet(name, _, _, isScan) =>
-        val IndexedSeq(value: IR, body: IR) = newChildren
-        AggLet(name, value, body, isScan)
+        assert(newChildren.length == 2)
+        AggLet(name, newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], isScan)
       case Ref(name, t) => Ref(name, t)
       case RelationalRef(name, t) => RelationalRef(name, t)
       case RelationalLet(name, _, _) =>
-        val IndexedSeq(value: IR, body: IR) = newChildren
-        RelationalLet(name, value, body)
+        assert(newChildren.length == 2)
+        RelationalLet(name, newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])
       case ApplyBinaryPrimOp(op, _, _) =>
-        val IndexedSeq(l: IR, r: IR) = newChildren
-        ApplyBinaryPrimOp(op, l, r)
+        assert(newChildren.length == 2)
+        ApplyBinaryPrimOp(op, newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])
       case ApplyUnaryPrimOp(op, _) =>
-        val IndexedSeq(x: IR) = newChildren
-        ApplyUnaryPrimOp(op, x)
+        assert(newChildren.length == 1)
+        ApplyUnaryPrimOp(op, newChildren(0).asInstanceOf[IR])
       case ApplyComparisonOp(op, _, _) =>
-        val IndexedSeq(l: IR, r: IR) = newChildren
-        ApplyComparisonOp(op, l, r)
+        assert(newChildren.length == 2)
+        ApplyComparisonOp(op, newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])
       case MakeArray(args, typ) =>
         assert(args.length == newChildren.length)
         MakeArray(newChildren.map(_.asInstanceOf[IR]), typ)
-      case MakeStream(args, typ) => 
+      case MakeStream(args, typ) =>
         assert(args.length == newChildren.length)
         MakeStream(newChildren.map(_.asInstanceOf[IR]), typ)
       case ArrayRef(_, _) =>
-        val IndexedSeq(a: IR, i: IR) = newChildren
-        ArrayRef(a, i)
+        assert(newChildren.length == 2)
+        ArrayRef(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])
       case ArrayLen(_) =>
-        val IndexedSeq(a: IR) = newChildren
-        ArrayLen(a)
+        assert(newChildren.length == 1)
+        ArrayLen(newChildren(0).asInstanceOf[IR])
       case ArrayRange(_, _, _) =>
-        val IndexedSeq(start: IR, stop: IR, step: IR) = newChildren
-        ArrayRange(start, stop, step)
+        assert(newChildren.length == 3)
+        ArrayRange(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], newChildren(2).asInstanceOf[IR])
       case StreamRange(_, _, _) =>
-        val IndexedSeq(start: IR, stop: IR, step: IR) = newChildren
-        StreamRange(start, stop, step)
+        assert(newChildren.length == 3)
+        StreamRange(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], newChildren(2).asInstanceOf[IR])
       case MakeNDArray(_, _, _) =>
-        val IndexedSeq(data: IR, shape: IR, rowMajor: IR) = newChildren
-        MakeNDArray(data, shape, rowMajor)
+        MakeNDArray(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], newChildren(2).asInstanceOf[IR])
       case NDArrayShape(_) =>
         NDArrayShape(newChildren(0).asInstanceOf[IR])
       case NDArrayReshape(_, _) =>
-        val IndexedSeq(nd: IR, shape: IR) = newChildren
-        NDArrayReshape(nd, shape)
+        assert(newChildren.length ==  2)
+        NDArrayReshape(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])
       case NDArrayRef(_, _) =>
-        val (nd: IR) +: (idxs: IndexedSeq[_]) = newChildren
-        NDArrayRef(nd, idxs.asInstanceOf[IndexedSeq[IR]])
+        NDArrayRef(newChildren(0).asInstanceOf[IR], newChildren.tail.map(_.asInstanceOf[IR]))
       case NDArraySlice(_, _) =>
-        val IndexedSeq(nd: IR, slices: IR) = newChildren
-        NDArraySlice(nd, slices)
+        assert(newChildren.length ==  2)
+        NDArraySlice(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])
       case NDArrayMap(_, name, _) =>
-        val IndexedSeq(nd: IR, body: IR) = newChildren
-        NDArrayMap(nd, name, body)
+        assert(newChildren.length ==  2)
+        NDArrayMap(newChildren(0).asInstanceOf[IR], name, newChildren(1).asInstanceOf[IR])
       case NDArrayMap2(_, _, lName, rName, _) =>
-        val IndexedSeq(l: IR, r: IR, body: IR) = newChildren
-        NDArrayMap2(l, r, lName, rName, body)
+        assert(newChildren.length ==  3)
+        NDArrayMap2(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], lName, rName, newChildren(2).asInstanceOf[IR])
       case NDArrayReindex(_, indexExpr) =>
-        val IndexedSeq(nd: IR) = newChildren
-        NDArrayReindex(nd, indexExpr)
+        assert(newChildren.length == 1)
+        NDArrayReindex(newChildren(0).asInstanceOf[IR], indexExpr)
       case NDArrayAgg(_, axes) =>
-        val IndexedSeq(nd: IR) = newChildren
-        NDArrayAgg(nd, axes)
+        assert(newChildren.length == 1)
+        NDArrayAgg(newChildren(0).asInstanceOf[IR], axes)
       case NDArrayMatMul(_, _) =>
-        val IndexedSeq(l: IR, r: IR) = newChildren
-        NDArrayMatMul(l, r)
+        assert(newChildren.length == 2)
+        NDArrayMatMul(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])
       case NDArrayWrite(_, _) =>
-        val IndexedSeq(nd: IR, path: IR) = newChildren
-        NDArrayWrite(nd, path)
+        assert(newChildren.length == 2)
+        NDArrayWrite(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR])
       case ArraySort(_, l, r, _) =>
-        val IndexedSeq(a: IR, comp: IR) = newChildren
-        ArraySort(a, l, r, comp)
+        assert(newChildren.length == 2)
+        ArraySort(newChildren(0).asInstanceOf[IR], l, r, newChildren(1).asInstanceOf[IR])
       case ToSet(_) =>
-        val IndexedSeq(a: IR) = newChildren
-        ToSet(a)
+        assert(newChildren.length == 1)
+        ToSet(newChildren(0).asInstanceOf[IR])
       case ToDict(_) =>
-        val IndexedSeq(a: IR) = newChildren
-        ToDict(a)
+        assert(newChildren.length == 1)
+        ToDict(newChildren(0).asInstanceOf[IR])
       case ToArray(_) =>
-        val IndexedSeq(a: IR) = newChildren
-        ToArray(a)
+        assert(newChildren.length == 1)
+        ToArray(newChildren(0).asInstanceOf[IR])
       case ToStream(_) =>
-        val IndexedSeq(a: IR) = newChildren
-        ToStream(a)
+        assert(newChildren.length == 1)
+        ToStream(newChildren(0).asInstanceOf[IR])
       case LowerBoundOnOrderedCollection(_, _, asKey) =>
-        val IndexedSeq(orderedCollection: IR, elem: IR) = newChildren
-        LowerBoundOnOrderedCollection(orderedCollection, elem, asKey)
+        assert(newChildren.length == 2)
+        LowerBoundOnOrderedCollection(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], asKey)
       case GroupByKey(_) =>
-        val IndexedSeq(collection: IR) = newChildren
-        GroupByKey(collection)
+        assert(newChildren.length == 1)
+        GroupByKey(newChildren(0).asInstanceOf[IR])
       case ArrayMap(_, name, _) =>
-        val IndexedSeq(a: IR, body: IR) = newChildren
-        ArrayMap(a, name, body)
+        assert(newChildren.length == 2)
+        ArrayMap(newChildren(0).asInstanceOf[IR], name, newChildren(1).asInstanceOf[IR])
       case ArrayFilter(_, name, _) =>
-        val IndexedSeq(a: IR, cond: IR) = newChildren
-        ArrayFilter(a, name, cond)
+        assert(newChildren.length == 2)
+        ArrayFilter(newChildren(0).asInstanceOf[IR], name, newChildren(1).asInstanceOf[IR])
       case ArrayFlatMap(_, name, _) =>
-        val IndexedSeq(a: IR, body: IR) = newChildren
-        ArrayFlatMap(a, name, body)
+        assert(newChildren.length == 2)
+        ArrayFlatMap(newChildren(0).asInstanceOf[IR], name, newChildren(0).asInstanceOf[IR])
       case ArrayFold(_, _, accumName, valueName, _) =>
-        val IndexedSeq(a: IR, zero: IR, body: IR) = newChildren
-        ArrayFold(a, zero, accumName, valueName, body)
+        assert(newChildren.length == 3)
+        ArrayFold(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], accumName, valueName, newChildren(1).asInstanceOf[IR])
       case ArrayFold2(_, accum, valueName, seq, _) =>
         val ncIR = newChildren.map(_.asInstanceOf[IR])
         assert(newChildren.length == 2 + accum.length + seq.length)
@@ -138,47 +136,49 @@ object Copy {
           valueName,
           seq.indices.map(i => ncIR(i + 1 + accum.length)), ncIR.last)
       case ArrayScan(_, _, accumName, valueName, _) =>
-        val IndexedSeq(a: IR, zero: IR, body: IR) = newChildren
-        ArrayScan(a, zero, accumName, valueName, body)
+        assert(newChildren.length == 3)
+        ArrayScan(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], accumName, valueName, newChildren(2).asInstanceOf[IR])
       case ArrayLeftJoinDistinct(_, _, l, r, _, _) =>
-        val IndexedSeq(left: IR, right: IR, compare: IR, join: IR) = newChildren
-        ArrayLeftJoinDistinct(left, right, l, r, compare, join)
+        assert(newChildren.length == 4)
+        ArrayLeftJoinDistinct(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], l, r, newChildren(2).asInstanceOf[IR], newChildren(3).asInstanceOf[IR])
       case ArrayFor(_, valueName, _) =>
-        val IndexedSeq(a: IR, body: IR) = newChildren
-        ArrayFor(a, valueName, body)
+        assert(newChildren.length == 2)
+        ArrayFor(newChildren(0).asInstanceOf[IR], valueName, newChildren(1).asInstanceOf[IR])
       case ArrayAgg(_, name, _) =>
-        val IndexedSeq(a: IR, query: IR) = newChildren
-        ArrayAgg(a, name, query)
+        assert(newChildren.length == 2)
+        ArrayAgg(newChildren(0).asInstanceOf[IR], name, newChildren(1).asInstanceOf[IR])
       case ArrayAggScan(_, name, _) =>
-        val IndexedSeq(a: IR, query: IR) = newChildren
-        ArrayAggScan(a, name, query)
+        assert(newChildren.length == 2)
+        ArrayAggScan(newChildren(0).asInstanceOf[IR], name, newChildren(1).asInstanceOf[IR])
       case AggFilter(_, _, isScan) =>
-        val IndexedSeq(cond: IR, aggIR: IR) = newChildren
-        AggFilter(cond, aggIR, isScan)
+        assert(newChildren.length == 2)
+        AggFilter(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], isScan)
       case AggExplode(_, name, _, isScan) =>
-        val IndexedSeq(array: IR, aggBody: IR) = newChildren
-        AggExplode(array, name, aggBody, isScan)
+        assert(newChildren.length == 2)
+        AggExplode(newChildren(0).asInstanceOf[IR], name, newChildren(1).asInstanceOf[IR], isScan)
       case AggGroupBy(_, _, isScan) =>
-        val IndexedSeq(key: IR, aggIR: IR) = newChildren
-        AggGroupBy(key, aggIR, isScan)
+        assert(newChildren.length == 2)
+        AggGroupBy(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], isScan)
       case AggArrayPerElement(_, elementName, indexName, _, _, isScan) =>
-        val (newA, newAggBody, newKnownLength) = newChildren match {
-          case IndexedSeq(newA: IR, newAggBody: IR) => (newA, newAggBody, None)
-          case IndexedSeq(newA: IR, newAggBody: IR, newKnownLength: IR) => (newA, newAggBody, Some(newKnownLength))
+        val newKnownLength = if (newChildren.length == 3)
+          Some(newChildren(2).asInstanceOf[IR])
+        else {
+          assert(newChildren.length == 2)
+          None
         }
-        AggArrayPerElement(newA, elementName, indexName, newAggBody, newKnownLength, isScan)
+        AggArrayPerElement(newChildren(0).asInstanceOf[IR], elementName, indexName, newChildren(1).asInstanceOf[IR], newKnownLength, isScan)
       case MakeStruct(fields) =>
         assert(fields.length == newChildren.length)
         MakeStruct(fields.zip(newChildren).map { case ((n, _), a) => (n, a.asInstanceOf[IR]) })
       case SelectFields(_, fields) =>
-        val IndexedSeq(old: IR) = newChildren
-        SelectFields(old, fields)
+        assert(newChildren.length == 1)
+        SelectFields(newChildren(0).asInstanceOf[IR], fields)
       case InsertFields(_, fields, fieldOrder) =>
         assert(newChildren.length == fields.length + 1)
         InsertFields(newChildren.head.asInstanceOf[IR], fields.zip(newChildren.tail).map { case ((n, _), a) => (n, a.asInstanceOf[IR]) }, fieldOrder)
       case GetField(_, name) =>
-        val IndexedSeq(o: IR) = newChildren
-        GetField(o, name)
+        assert(newChildren.length == 1)
+        GetField(newChildren(0).asInstanceOf[IR], name)
       case InitOp(_, _, aggSig) =>
         InitOp(newChildren.head.asInstanceOf[IR], newChildren.tail.map(_.asInstanceOf[IR]), aggSig)
       case SeqOp(_, _, aggSig) =>
@@ -212,12 +212,12 @@ object Copy {
         assert(fields.length == newChildren.length)
         MakeTuple(fields.zip(newChildren).map { case ((i, _), newValue) => (i, newValue.asInstanceOf[IR]) })
       case GetTupleElement(_, idx) =>
-        val IndexedSeq(o: IR) = newChildren
-        GetTupleElement(o, idx)
+        assert(newChildren.length == 1)
+        GetTupleElement(newChildren(0).asInstanceOf[IR], idx)
       case In(i, t) => In(i, t)
       case Die(_, typ) =>
-        val IndexedSeq(s: IR) = newChildren
-        Die(s, typ)
+        assert(newChildren.length == 1)
+        Die(newChildren(0).asInstanceOf[IR], typ)
       case x@ApplyIR(fn, args) =>
         val r = ApplyIR(fn, newChildren.map(_.asInstanceOf[IR]))
         r.conversion = x.conversion
@@ -230,55 +230,55 @@ object Copy {
       case ApplySpecial(fn, args, t) =>
         ApplySpecial(fn, newChildren.map(_.asInstanceOf[IR]), t)
       case Uniroot(argname, _, _, _) =>
-        val IndexedSeq(fn: IR, min: IR, max: IR) = newChildren
-        Uniroot(argname, fn, min, max)
+        assert(newChildren.length == 3)
+        Uniroot(argname, newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], newChildren(2).asInstanceOf[IR])
       // from MatrixIR
       case MatrixWrite(_, writer) =>
-        val IndexedSeq(child: MatrixIR) = newChildren
-        MatrixWrite(child, writer)
+        assert(newChildren.length == 1)
+        MatrixWrite(newChildren(0).asInstanceOf[MatrixIR], writer)
       case MatrixMultiWrite(_, writer) =>
         MatrixMultiWrite(newChildren.map(_.asInstanceOf[MatrixIR]), writer)
       // from TableIR
       case TableCount(_) =>
-        val IndexedSeq(child: TableIR) = newChildren
-        TableCount(child)
+        assert(newChildren.length == 1)
+        TableCount(newChildren(0).asInstanceOf[TableIR])
       case TableGetGlobals(_) =>
-        val IndexedSeq(child: TableIR) = newChildren
-        TableGetGlobals(child)
+        assert(newChildren.length == 1)
+        TableGetGlobals(newChildren(0).asInstanceOf[TableIR])
       case TableCollect(_) =>
-        val IndexedSeq(child: TableIR) = newChildren
-        TableCollect(child)
+        assert(newChildren.length == 1)
+        TableCollect(newChildren(0).asInstanceOf[TableIR])
       case TableAggregate(_, _) =>
-        val IndexedSeq(child: TableIR, query: IR) = newChildren
-        TableAggregate(child, query)
+        assert(newChildren.length == 2)
+        TableAggregate(newChildren(0).asInstanceOf[TableIR], newChildren(1).asInstanceOf[IR])
       case MatrixAggregate(_, _) =>
-        val IndexedSeq(child: MatrixIR, query: IR) = newChildren
-        MatrixAggregate(child, query)
+        assert(newChildren.length == 2)
+        MatrixAggregate(newChildren(0).asInstanceOf[MatrixIR], newChildren(1).asInstanceOf[IR])
       case TableWrite(_, writer) =>
-        val IndexedSeq(child: TableIR) = newChildren
-        TableWrite(child, writer)
+        assert(newChildren.length == 1)
+        TableWrite(newChildren(0).asInstanceOf[TableIR], writer)
       case TableMultiWrite(_, writer) =>
         TableMultiWrite(newChildren.map(_.asInstanceOf[TableIR]), writer)
       case TableToValueApply(_, function) =>
-        val IndexedSeq(newChild: TableIR) = newChildren
-        TableToValueApply(newChild, function)
+        assert(newChildren.length == 1)
+        TableToValueApply(newChildren(0).asInstanceOf[TableIR], function)
       case MatrixToValueApply(_, function) =>
-        val IndexedSeq(newChild: MatrixIR) = newChildren
-        MatrixToValueApply(newChild, function)
+        assert(newChildren.length == 1)
+        MatrixToValueApply(newChildren(0).asInstanceOf[MatrixIR], function)
       case BlockMatrixToValueApply(_, function) =>
-        val IndexedSeq(newChild: BlockMatrixIR) = newChildren
-        BlockMatrixToValueApply(newChild, function)
+        assert(newChildren.length == 1)
+        BlockMatrixToValueApply(newChildren(0).asInstanceOf[BlockMatrixIR], function)
       case BlockMatrixWrite(_, writer) =>
-        val IndexedSeq(newChild: BlockMatrixIR) = newChildren
-        BlockMatrixWrite(newChild, writer)
+        assert(newChildren.length == 1)
+        BlockMatrixWrite(newChildren(0).asInstanceOf[BlockMatrixIR], writer)
       case BlockMatrixMultiWrite(_, writer) =>
         BlockMatrixMultiWrite(newChildren.map(_.asInstanceOf[BlockMatrixIR]), writer)
       case CollectDistributedArray(_, _, cname, gname, _) =>
-        val IndexedSeq(ctxs: IR, globals: IR, newBody: IR) = newChildren
-        CollectDistributedArray(ctxs, globals, cname, gname, newBody)
+        assert(newChildren.length == 3)
+        CollectDistributedArray(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], cname, gname, newChildren(2).asInstanceOf[IR])
       case ReadPartition(path, spec, rowType) =>
-        val IndexedSeq(newPath: IR) = newChildren
-        ReadPartition(newPath, spec, rowType)
+        assert(newChildren.length == 1)
+        ReadPartition(newChildren(0).asInstanceOf[IR], spec, rowType)
     }
   }
 }

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -66,8 +66,10 @@ object Copy {
         assert(newChildren.length == 3)
         StreamRange(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], newChildren(2).asInstanceOf[IR])
       case MakeNDArray(_, _, _) =>
+        assert(newChildren.length == 3)
         MakeNDArray(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], newChildren(2).asInstanceOf[IR])
       case NDArrayShape(_) =>
+        assert(newChildren.length == 1)
         NDArrayShape(newChildren(0).asInstanceOf[IR])
       case NDArrayReshape(_, _) =>
         assert(newChildren.length ==  2)

--- a/hail/src/main/scala/is/hail/expr/ir/Copy.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Copy.scala
@@ -127,7 +127,7 @@ object Copy {
         ArrayFlatMap(newChildren(0).asInstanceOf[IR], name, newChildren(1).asInstanceOf[IR])
       case ArrayFold(_, _, accumName, valueName, _) =>
         assert(newChildren.length == 3)
-        ArrayFold(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], accumName, valueName, newChildren(1).asInstanceOf[IR])
+        ArrayFold(newChildren(0).asInstanceOf[IR], newChildren(1).asInstanceOf[IR], accumName, valueName, newChildren(2).asInstanceOf[IR])
       case ArrayFold2(_, accum, valueName, seq, _) =>
         val ncIR = newChildren.map(_.asInstanceOf[IR])
         assert(newChildren.length == 2 + accum.length + seq.length)

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -148,9 +148,9 @@ object InferType {
         TDict(key.typ, aggIR.typ)
       case AggArrayPerElement(a, _, _, aggBody, _, _) => TArray(aggBody.typ)
       case ApplyAggOp(_, _, _, aggSig) =>
-        AggOp.getType(aggSig)
+        aggSig.returnType
       case ApplyScanOp(_, _, _, aggSig) =>
-        AggOp.getType(aggSig)
+        aggSig.returnType
       case MakeStruct(fields) =>
         TStruct(fields.map { case (name, a) =>
           (name, a.typ)


### PR DESCRIPTION
 * don't use inefficient unapply
 * Cache the returnType of AggSignatures so they persist through copies

```
                           Name      Ratio    Time 1    Time 2
                           ----      -----    ------    ------
table_big_aggregate_compilation      85.6%     4.113     3.519
----------------------
Geometric mean: 85.6%
Simple mean: 85.6%
Median:  85.6%
```