### PR TITLE
NDArray Segfault

### DIFF
--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -425,3 +425,6 @@ def test_ndarray_matmul():
 
     with pytest.raises(ValueError):
         cube @ hl._ndarray(5)
+
+def test_ndarray_big():
+    assert hl.eval(hl._ndarray(hl.range(100_000))).size == 100_000

--- a/hail/src/main/scala/is/hail/annotations/Annotation.scala
+++ b/hail/src/main/scala/is/hail/annotations/Annotation.scala
@@ -62,7 +62,7 @@ object Annotation {
 
       case t: TNDArray => copy(t.representation, a)
 
-      case _: TInt32 | _: TInt64 | _: TFloat32 | _: TFloat64 | _: TBoolean | _: TString | _: TCall | _: TLocus => a
+      case _: TInt32 | _: TInt64 | _: TFloat32 | _: TFloat64 | _: TBoolean | _: TString | _: TCall | _: TLocus | _: TBinary => a
     }
   }
 
@@ -86,7 +86,9 @@ object Annotation {
         val i = a.asInstanceOf[Interval]
         Annotation.isSafe(t.pointType, i.start) && Annotation.isSafe(t.pointType, i.end)
 
-      case _ => true
+      case t: TNDArray => isSafe(t.representation, a)
+
+      case _: TInt32 | _: TInt64 | _: TFloat32 | _: TFloat64 | _: TBoolean | _: TString | _: TCall | _: TLocus | _: TBinary => true
     })
   }
 }

--- a/hail/src/main/scala/is/hail/annotations/Annotation.scala
+++ b/hail/src/main/scala/is/hail/annotations/Annotation.scala
@@ -60,7 +60,9 @@ object Annotation {
         val i = a.asInstanceOf[Interval]
         i.copy(start = Annotation.copy(t.pointType, i.start), end = Annotation.copy(t.pointType, i.end))
 
-      case _ => a
+      case t: TNDArray => copy(t.representation, a)
+
+      case _: TInt32 | _: TInt64 | _: TFloat32 | _: TFloat64 | _: TBoolean | _: TString | _: TCall | _: TLocus => a
     }
   }
 


### PR DESCRIPTION
We needed a case in Annotation copy for `TNDArray`. I also don't want someone to have this issue again, so I replaced the wildcard catch a list of all the types. 