### PR TITLE
[batch2] use shutdown-script to copy worker log files

### DIFF
--- a/batch2/Dockerfile.worker
+++ b/batch2/Dockerfile.worker
@@ -5,11 +5,6 @@ RUN apt-get update && \
     curl && \
   rm -rf /var/lib/apt/lists/*
 
-# source: https://cloud.google.com/storage/docs/gsutil_install#linux
-RUN /bin/sh -c 'curl https://sdk.cloud.google.com | bash' && \
-    mv /root/google-cloud-sdk /
-ENV PATH $PATH:/google-cloud-sdk/bin
-
 COPY docker/requirements.txt .
 RUN python3 -m pip install --no-cache-dir -U -r requirements.txt
 

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -129,7 +129,7 @@ class InstancePool:
             'metadata': {
                 'items': [{
                     'key': 'startup-script',
-                    'value': f'''
+                    'value': '''
 #!/bin/bash
 set -ex
 
@@ -172,7 +172,7 @@ retry docker run \
            -c "sh /run-worker.sh"
 '''
                 }, {
-                   'key': 'shutdown-script',
+                    'key': 'shutdown-script',
                     'value': '''
 set -ex
 

--- a/batch2/batch/driver/instance_pool.py
+++ b/batch2/batch/driver/instance_pool.py
@@ -136,12 +136,12 @@ set -ex
 export BATCH_WORKER_IMAGE=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/batch_worker_image")
 export HOME=/root
 
-function retry {{
+function retry {
     local n=1
     local max=5
     local delay=15
     while true; do
-        "$@" > worker.log 2>&1 && break || {{
+        "$@" > worker.log 2>&1 && break || {
             if [[ $n -lt $max ]]; then
                 ((n++))
                 echo "Command failed. Attempt $n/$max:"
@@ -157,9 +157,9 @@ function retry {{
                 export ZONE=$(curl http://metadata.google.internal/computeMetadata/v1/instance/zone -H 'Metadata-Flavor: Google')
                 gcloud -q compute instances delete $NAME --zone=$ZONE
              fi
-        }}
+        }
     done
-}}
+}
 
 retry docker run \
            -v /var/run/docker.sock:/var/run/docker.sock \

--- a/batch2/batch/worker.py
+++ b/batch2/batch/worker.py
@@ -638,6 +638,6 @@ log.info(f'closed')
 
 compute_client = googleapiclient.discovery.build('compute', 'v1',
                                                  cache_discovery=False)
-compute_client.instances().delete(project=project, zone=zone, instance=instance).execute()
+compute_client.instances().delete(project=project, zone=zone, instance=instance).execute() # pylint: disable=no-member
 
 sys.exit(0)

--- a/batch2/create-batch-tables.sql
+++ b/batch2/create-batch-tables.sql
@@ -1,9 +1,9 @@
 CREATE TABLE IF NOT EXISTS `batch` (
   `id` BIGINT NOT NULL AUTO_INCREMENT,
-  `userdata` VARCHAR(65535) NOT NULL,
+  `userdata` TEXT NOT NULL,
   `user` VARCHAR(100) NOT NULL,
-  `attributes` VARCHAR(65535),
-  `callback` VARCHAR(65535),
+  `attributes` TEXT,
+  `callback` TEXT,
   `deleted` BOOLEAN NOT NULL default false,
   `cancelled` BOOLEAN NOT NULL default false,
   `closed` BOOLEAN NOT NULL default false,
@@ -24,8 +24,8 @@ CREATE TABLE IF NOT EXISTS `jobs` (
   `state` VARCHAR(40) NOT NULL,
   `time_created` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   `directory` VARCHAR(1024),
-  `spec` VARCHAR(65535),
-  `status` VARCHAR(65535),
+  `spec` TEXT,
+  `status` TEXT,
   PRIMARY KEY (`batch_id`, `job_id`),
   FOREIGN KEY (`batch_id`) REFERENCES batch(id) ON DELETE CASCADE
 ) ENGINE = InnoDB;
@@ -43,7 +43,7 @@ CREATE INDEX jobs_parents_parent_id ON `jobs-parents` (batch_id, parent_id);
 CREATE TABLE IF NOT EXISTS `batch-attributes` (
   `batch_id` BIGINT NOT NULL,
   `key` VARCHAR(100) NOT NULL,
-  `value` VARCHAR(65535),
+  `value` TEXT,
   PRIMARY KEY (`batch_id`, `key`),
   FOREIGN KEY (`batch_id`) REFERENCES batch(id) ON DELETE CASCADE  
 ) ENGINE = InnoDB;
@@ -59,12 +59,12 @@ CREATE TABLE IF NOT EXISTS `instances` (
 CREATE TABLE IF NOT EXISTS `pods` (
   `name` VARCHAR(100) NOT NULL,
   `batch_id` BIGINT NOT NULL,
-  `job_spec` VARCHAR(65535) NOT NULL,
-  `userdata` VARCHAR(65535) NOT NULL,
+  `job_spec` TEXT NOT NULL,
+  `userdata` TEXT NOT NULL,
   `output_directory` VARCHAR(100) NOT NULL,
   `cores_mcpu` INT NOT NULL,
   `instance` VARCHAR(100),
-  `status` VARCHAR(65535),
+  `status` TEXT,
   `time_created` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`name`),
   FOREIGN KEY (`instance`) REFERENCES instances (`token`) ON DELETE SET NULL

--- a/batch2/run-worker.sh
+++ b/batch2/run-worker.sh
@@ -5,13 +5,9 @@ export CORES=$(nproc)
 export NAMESPACE=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/namespace")
 export BATCH_WORKER_IMAGE=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/batch_worker_image")
 export INST_TOKEN=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/inst_token")
-export WORKER_LOGS_DIRECTORY=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/worker_logs_directory")
 export INTERNAL_IP=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip")
+export INST_NAME=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/name")
+export ZONE=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/zone")
+export PROJECT=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/project")
 
-python3 -u -m "batch.worker" > worker.log 2>&1
-
-gsutil -m cp worker.log $WORKER_LOGS_DIRECTORY/$INST_TOKEN/
-
-export NAME=$(curl http://metadata.google.internal/computeMetadata/v1/instance/name -H 'Metadata-Flavor: Google')
-export ZONE=$(curl http://metadata.google.internal/computeMetadata/v1/instance/zone -H 'Metadata-Flavor: Google')
-gcloud -q compute instances delete $NAME --zone=$ZONE
+python3 -u -m "batch.worker" > /batch2/worker.log 2>&1


### PR DESCRIPTION
- Also changed VARCHAR fields back to TEXT where it was VARCHAR(65535).
- Added names to containers for ease in identifying when debugging
- Got rid of the google sdk dependency in the docker worker image (saves 400MB)
