### PR TITLE
[hail] Support passing ndarray reshape a hail tuple

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3533,7 +3533,7 @@ class NDArrayExpression(Expression):
 
         return construct_expr(ir.NDArrayRef(self._ir, [idx._ir for idx in item]), self._type.element_type)
 
-    @typecheck_method(shape=oneof(expr_int64, tupleof(expr_int64)))
+    @typecheck_method(shape=oneof(expr_int64, tupleof(expr_int64), expr_tuple()))
     def reshape(self, shape):
         """Reshape this ndarray to a new shape.
 
@@ -3552,9 +3552,13 @@ class NDArrayExpression(Expression):
         -------
         :class:`.NDArrayExpression`.
         """
-        shape = wrap_to_list(shape)
+        if isinstance(shape, TupleExpression):
+            shape_ir = hl.tuple([hl.int64(i) for i in shape])._ir
+        else:
+            wrapped_shape = wrap_to_list(shape)
+            shape_ir = hl.tuple(wrapped_shape)._ir
 
-        return construct_expr(NDArrayReshape(self._ir, hl.tuple(shape)._ir),
+        return construct_expr(NDArrayReshape(self._ir, shape_ir),
                               tndarray(self._type.element_type, len(shape)),
                               self._indices,
                               self._aggregations)

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -173,7 +173,8 @@ def test_ndarray_reshape():
         (a.reshape((-1, 2)), np_a.reshape((-1, 2))),
         (cube_to_rect, np_cube_to_rect),
         (cube_t_to_rect, np_cube_t_to_rect),
-        (hypercube.reshape((5, 7, 9, 3)).reshape((7, 9, 3, 5)), np_hypercube.reshape((7, 9, 3, 5)))
+        (hypercube.reshape((5, 7, 9, 3)).reshape((7, 9, 3, 5)), np_hypercube.reshape((7, 9, 3, 5))),
+        (hypercube.reshape(hl.tuple([5, 7, 9, 3])), np_hypercube.reshape((5, 7, 9, 3)))
     )
 
     with pytest.raises(FatalError) as exc:


### PR DESCRIPTION
Currently, `reshape` only takes a python tuple. This will allow it to take a hail tuple as well. 