### PR TITLE
Improve error message for incorrect type for dict.get default argument

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -1299,9 +1299,9 @@ class DictExpression(Expression):
 
         if default is not None:
             if not self._vc.can_coerce(default.dtype):
-                raise TypeError("'get' expects parameter 'default' to have the "
-                                "same type as the dictionary value type, found '{}' and '{}'"
-                                .format(self.dtype, default.dtype))
+                raise TypeError("'get' expects parameter 'default' to have the same type "
+                                "as the dictionary value type, expected '{}' and found '{}'"
+                                .format(self.dtype.value_type, default.dtype))
             return self._method("get", self.dtype.value_type, key, self._vc.coerce(default))
         else:
             return self._method("get", self.dtype.value_type, key)


### PR DESCRIPTION
Currently, if the type of the `default` argument to `dict.get` does not match the dictionary's value type, the error message contains the dictionary's type and the `default` argument's type. However, the `default` argument's type should be compared to the dictionary's **value** type.

This can be particularly confusing when dealing with nested dictionaries. For example:
```python
d = hl.dict({"foo": {"foo": 1}})
d.get("somekey", hl.dict({"bar": {"bar": 2}}))
```
results in:
```
TypeError: 'get' expects parameter 'default' to have the same type as the dictionary 
value type, found 'dict<str, dict<str, int32>>' and 'dict<str, dict<str, int32>>'
```

This change puts the value type instead of the dictionary type in the error message and slightly rewords the message to be clearer about which type is which.