### PR TITLE
[hail] fix docs, fix bug, add empty file parsing to import_matrix_table

### DIFF
--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -1400,8 +1400,8 @@ class ImportMatrixTableTests(unittest.TestCase):
             "invalid header",
             hl.import_matrix_table,
             resource("sampleheader*.txt"),
-            row_fields={'f0': hl.tstr},
-            row_key=['f0'])
+            row_fields={'col000000': hl.tstr},
+            row_key=['col000000'])
 
     def test_too_few_entries(self):
         def boom():

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -1400,8 +1400,8 @@ class ImportMatrixTableTests(unittest.TestCase):
             "invalid header",
             hl.import_matrix_table,
             resource("sampleheader*.txt"),
-            row_fields={'col000000': hl.tstr},
-            row_key=['col000000'])
+            row_fields={'f0': hl.tstr},
+            row_key=['f0'])
 
     def test_too_few_entries(self):
         def boom():

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -1530,6 +1530,16 @@ class ImportMatrixTableTests(unittest.TestCase):
         actual = mt.alt.collect()
         assert actual == ['T', 'TGG', 'A', None]
 
+    def test_empty_import_matrix_table(self):
+        path = new_temp_file(suffix='tsv.bgz')
+        mt = hl.utils.range_matrix_table(0, 0)
+        mt = mt.annotate_entries(x=1)
+        mt.x.export(path)
+        assert hl.import_matrix_table(path)._force_count_rows() == 0
+
+        mt.x.export(path, header=False)
+        assert hl.import_matrix_table(path, no_header=True)._force_count_rows() == 0
+
 
 class ImportTableTests(unittest.TestCase):
     def test_import_table_force_bgz(self):

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -1375,14 +1375,14 @@ class ImportMatrixTableTests(unittest.TestCase):
 
         row_fields = {'f0': hl.tstr, 'f1': hl.tstr, 'f2': hl.tfloat32}
         hl.import_matrix_table(doctest_resource('matrix2.tsv'),
-                               row_fields=row_fields, row_key=[]).count()
+                               row_fields=row_fields, row_key=[])._force_count()
         hl.import_matrix_table(doctest_resource('matrix3.tsv'),
                                row_fields=row_fields,
-                               no_header=True).count()
+                               no_header=True)._force_count()
         hl.import_matrix_table(doctest_resource('matrix3.tsv'),
                                row_fields=row_fields,
                                no_header=True,
-                               row_key=[]).count()
+                               row_key=[])._force_count()
 
     @skip_unless_spark_backend()
     def test_import_matrix_table_no_cols(self):

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -1375,14 +1375,14 @@ class ImportMatrixTableTests(unittest.TestCase):
 
         row_fields = {'f0': hl.tstr, 'f1': hl.tstr, 'f2': hl.tfloat32}
         hl.import_matrix_table(doctest_resource('matrix2.tsv'),
-                               row_fields=row_fields, row_key=[])._force_count()
+                               row_fields=row_fields, row_key=[])._force_count_rows()
         hl.import_matrix_table(doctest_resource('matrix3.tsv'),
                                row_fields=row_fields,
-                               no_header=True)._force_count()
+                               no_header=True)._force_count_rows()
         hl.import_matrix_table(doctest_resource('matrix3.tsv'),
                                row_fields=row_fields,
                                no_header=True,
-                               row_key=[])._force_count()
+                               row_key=[])._force_count_rows()
 
     @skip_unless_spark_backend()
     def test_import_matrix_table_no_cols(self):
@@ -1477,6 +1477,8 @@ class ImportMatrixTableTests(unittest.TestCase):
                        mt[f])
             for f in mt.row})
         mt = mt.key_rows_by(*row_key)
+        mt.show()
+        actual.show()
         assert mt._same(actual)
 
     def test_key_by_after_empty_key_import(self):

--- a/hail/python/test/hail/methods/test_impex.py
+++ b/hail/python/test/hail/methods/test_impex.py
@@ -1477,8 +1477,6 @@ class ImportMatrixTableTests(unittest.TestCase):
                        mt[f])
             for f in mt.row})
         mt = mt.key_rows_by(*row_key)
-        mt.show()
-        actual.show()
         assert mt._same(actual)
 
     def test_key_by_after_empty_key_import(self):

--- a/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
+++ b/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
@@ -31,7 +31,7 @@ object TextMatrixReader {
   private case class HeaderInfo (
     headerValues: Array[String],
     rowFieldNames: Array[String],
-    columnIdentifiers: Array[String]
+    columnIdentifiers: Array[_] // String or Int
   ) {
     val nCols = columnIdentifiers.length
   }

--- a/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
+++ b/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
@@ -63,7 +63,7 @@ object TextMatrixReader {
         HeaderInfo(
           headerValues,
           headerValues.slice(0, nRowFields),
-          headerValues.slice(nRowFields))
+          headerValues.drop(nRowFields))
       case (true, Seq(header, dataLine)) =>
         val headerValues = header.split(sep)
         val nHeaderValues = headerValues.length
@@ -77,7 +77,7 @@ object TextMatrixReader {
           HeaderInfo(
             headerValues,
             rowFieldNames = headerValues.slice(0, nRowFields),
-            columnIdentifiers = headerValues.slice(nRowFields))
+            columnIdentifiers = headerValues.drop(nRowFields))
         } else {
           fatal(
             s"""In file $file, expected the header line to match either:
@@ -98,7 +98,7 @@ object TextMatrixReader {
         HeaderInfo(
           Array(),
           Array.tabulate(nRowFields)(i => s"f$i"),
-          Array.range(0, nSeparatedValues))
+          Array.range(0, nSeparatedValues - nRowFields))
     }
   }
 

--- a/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
+++ b/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
@@ -103,7 +103,7 @@ object TextMatrixReader {
         case Some(t) => (name, t)
         case None =>
           val rowFieldsAsPython = fieldTypes
-            .map { case (fieldName, typ) => s"${fieldName}: ${typ.toString}" }
+            .map { case (fieldName, typ) => s"'${fieldName}': ${typ.toString}" }
             .mkString("{", ",\n       ", "}")
           fatal(
           s"""In file $fileName, found a row field, $name, that is not in `row_fields':

--- a/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
+++ b/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
@@ -49,7 +49,7 @@ object TextMatrixReader {
                      |found instead only $nSeparatedValues fields:
                      |    ${header.truncate}""".stripMargin)
         }
-        (separatedValues, nSeparatedValues)
+        (separatedValues, nSeparatedValues - nRowFields)
       case (false, Array()) =>
         warn(s"File $file is empty and has no header, so we assume no columns.")
         (Array(), 0)

--- a/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
+++ b/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
@@ -57,7 +57,7 @@ object TextMatrixReader {
             s"""File ${file} contains one line and you told me it had a header,
                |so I expected to see at least the ${nRowFields} row field names
                |on the header line, but instead I only saw ${headerValues.length}
-               |lines. The header was:
+               |separated values. The header was:
                |    ${header}""".stripMargin)
         }
         HeaderInfo(

--- a/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
+++ b/hail/src/main/scala/is/hail/io/TextMatrixReader.scala
@@ -56,7 +56,7 @@ object TextMatrixReader {
       case (false, Seq()) =>
         warn(s"File $file is empty and has no header, so we assume no columns.")
         (Array(), 0)
-      case (false, Seq(firstLine)) =>
+      case (false, firstLine +: _) =>
         val nSeparatedValues = firstLine.split(sep).length
         (Array(), nSeparatedValues - nRowFields)
     }


### PR DESCRIPTION
This will fail until #7376 lands and allows the test to create an empty matrix table.

- document `sep`
- add two tests for importing empty matrix tables, one with a header and one without
- include the offending lines in error messages when files have different numbers of columns
- consistently use `String.split(separator, 0)` instead of using two different approaches which yield inconsistent results.
- simplify `parseHeader` and generalize to empty files
- improve error message when a row field found in the file does not match one of the row fields specified by `row_fields` (a dictionary from row field name to type).

NB: A no-header empty file implies no columns in the MT. We print a warning to this effect when we discover an empty file.

Resolves #7242