### PR TITLE
[hail] add delimiter argument to import_matrix_table

### DIFF
--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -1656,17 +1656,16 @@ def import_matrix_table(paths,
     :class:`.MatrixTable`
         MatrixTable constructed from imported data
     """
-    if sep is None:
-        if delimiter is None:
-            delimiter = '\t'
-    else:
-        if delimiter is None:
-            delimiter = sep
-        else:
+    if sep is not None:
+        if delimiter is not None:
             raise ValueError(
                 f'expecting either sep or delimiter but received both: '
                 f'{sep}, {delimiter}')
+        delimiter = sep
     del sep
+
+    if delimiter is None:
+        delimiter = '\t'
     if len(delimiter) != 1:
         raise FatalError('delimiter or sep must be a single character')
 

--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -1494,7 +1494,7 @@ def import_table(paths,
            min_partitions=nullable(int),
            no_header=bool,
            force_bgz=bool,
-           sep=str,
+           sep=nullable(str),
            delimiter=nullable(str))
 def import_matrix_table(paths,
                         row_fields={},
@@ -1504,7 +1504,7 @@ def import_matrix_table(paths,
                         min_partitions=None,
                         no_header=False,
                         force_bgz=False,
-                        sep='\t',
+                        sep=None,
                         delimiter=None) -> MatrixTable:
     """Import tab-delimited file(s) as a :class:`.MatrixTable`.
 
@@ -1656,6 +1656,19 @@ def import_matrix_table(paths,
     :class:`.MatrixTable`
         MatrixTable constructed from imported data
     """
+    if sep is None:
+        if delimiter is None:
+            delimiter = '\t'
+    else:
+        if delimiter is None:
+            delimiter = sep
+        else:
+            raise ValueError(
+                f'expecting either sep or delimiter but received both: '
+                f'{sep}, {delimiter}')
+    del sep
+    if len(delimiter) != 1:
+        raise FatalError('delimiter or sep must be a single character')
 
     add_row_id = False
     if isinstance(row_key, list) and len(row_key) == 0:
@@ -1675,8 +1688,6 @@ def import_matrix_table(paths,
     if entry_type not in {tint32, tint64, tfloat32, tfloat64, tstr}:
         raise FatalError("""import_matrix_table expects entry types to be one of:
         'int32', 'int64', 'float32', 'float64', 'str': found '{}'""".format(entry_type))
-    if len(sep) != 1:
-        raise FatalError('sep must be a single character')
 
     reader = TextMatrixReader(paths,
                               min_partitions,
@@ -1684,7 +1695,7 @@ def import_matrix_table(paths,
                               entry_type,
                               missing,
                               not no_header,
-                              sep,
+                              delimiter,
                               force_bgz,
                               add_row_id)
 

--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -1494,7 +1494,8 @@ def import_table(paths,
            min_partitions=nullable(int),
            no_header=bool,
            force_bgz=bool,
-           sep=str)
+           sep=str,
+           delimiter=str)
 def import_matrix_table(paths,
                         row_fields={},
                         row_key=[],
@@ -1503,7 +1504,8 @@ def import_matrix_table(paths,
                         min_partitions=None,
                         no_header=False,
                         force_bgz=False,
-                        sep='\t') -> MatrixTable:
+                        sep='\t',
+                        delimiter=None) -> MatrixTable:
     """Import tab-delimited file(s) as a :class:`.MatrixTable`.
 
     Examples
@@ -1643,6 +1645,11 @@ def import_matrix_table(paths,
     force_bgz : :obj:`bool`
         If ``True``, load **.gz** files as blocked gzip files, assuming
         that they were actually compressed using the BGZ codec.
+    sep : :obj:`str`
+        This parameter is a deprecated name for `delimiter`, please use that
+        instead.
+    delimiter : :obj:`str`
+        A single character string which separates values in the file.
 
     Returns
     -------

--- a/hail/python/hail/methods/impex.py
+++ b/hail/python/hail/methods/impex.py
@@ -1495,7 +1495,7 @@ def import_table(paths,
            no_header=bool,
            force_bgz=bool,
            sep=str,
-           delimiter=str)
+           delimiter=nullable(str))
 def import_matrix_table(paths,
                         row_fields={},
                         row_key=[],


### PR DESCRIPTION
Also note that `sep` is a deprecated name.