### PR TITLE
[blog] add ghost blogging infrastructure to blog.hail.is

### DIFF
--- a/blog/deployment.yaml
+++ b/blog/deployment.yaml
@@ -20,7 +20,7 @@ spec:
 {% endif %}
       containers:
       - name: blog
-        image: ghost:2.37-alpine
+        image: ghost:3.0-alpine
         imagePullPolicy: Always
         env:
           - name: NODE_ENV

--- a/blog/deployment.yaml
+++ b/blog/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: blog
+  labels:
+    app: blog
+spec:
+  serviceName: blog
+  replicas: 1
+  selector:
+    matchLabels:
+      app: blog
+  template:
+    metadata:
+      labels:
+        app: blog
+    spec:
+{% if deploy %}
+      priorityClassName: production
+{% endif %}
+      containers:
+      - name: blog
+        image: ghost:3.0-alpine
+        imagePullPolicy: Always
+        env:
+          - name: NODE_ENV
+            value: production
+          - name: url
+{% if deploy %}
+            value: http://blog.hail.is
+{% endif %}
+{% if not deploy %}
+            value: http://internal.hail.is/{{ default_ns.name }}/blog
+{% endif %}
+        ports:
+        - containerPort: 2368
+        volumeMounts:
+          - mountPath: /var/lib/ghost/content
+            name: blog-content
+  volumeClaimTemplates:
+    - metadata:
+        name: blog-content
+        namespace: {{ default_ns.name }}
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi

--- a/blog/deployment.yaml
+++ b/blog/deployment.yaml
@@ -26,9 +26,9 @@ spec:
             value: production
           - name: url
 {% if deploy %}
-            value: http://blog.hail.is
+            value: https://blog.hail.is
 {% else %}
-            value: http://internal.hail.is/{{ default_ns.name }}/blog
+            value: https://internal.hail.is/{{ default_ns.name }}/blog
 {% endif %}
         ports:
         - containerPort: 2368
@@ -40,6 +40,9 @@ spec:
             path: /{{ default_ns.name }}/blog/
 {% endif %}
             port: 2368
+            httpHeaders:
+            - name: X-Forwarded-Proto
+              value: https
           initialDelaySeconds: 5
           periodSeconds: 10
         readinessProbe:
@@ -50,6 +53,9 @@ spec:
             path: /{{ default_ns.name }}/blog/
 {% endif %}
             port: 2368
+            httpHeaders:
+            - name: X-Forwarded-Proto
+              value: https
           initialDelaySeconds: 5
           periodSeconds: 5
         volumeMounts:

--- a/blog/deployment.yaml
+++ b/blog/deployment.yaml
@@ -33,6 +33,27 @@ spec:
 {% endif %}
         ports:
         - containerPort: 2368
+        livenessProbe:
+          httpGet:
+{% if deploy %}
+            value: /
+{% else %}
+            value: /{{ default_ns.name }}/blog/
+{% endif %}
+            path: /
+            port: 2368
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+{% if deploy %}
+            value: /
+{% else %}
+            value: /{{ default_ns.name }}/blog/
+{% endif %}
+            port: 2368
+          initialDelaySeconds: 5
+          periodSeconds: 5
         volumeMounts:
           - mountPath: /var/lib/ghost/content
             name: blog-content

--- a/blog/deployment.yaml
+++ b/blog/deployment.yaml
@@ -39,14 +39,12 @@ spec:
             port: 2368
           initialDelaySeconds: 5
           periodSeconds: 30
-          timeoutSeconds: 3
         readinessProbe:
           httpGet:
             path: /
             port: 2368
           initialDelaySeconds: 5
-          periodSeconds: 30
-          timeoutSeconds: 3
+          periodSeconds: 5
         volumeMounts:
           - mountPath: /var/lib/ghost/content
             name: blog-content

--- a/blog/deployment.yaml
+++ b/blog/deployment.yaml
@@ -35,16 +35,18 @@ spec:
         - containerPort: 2368
         livenessProbe:
           httpGet:
-            path: /healthcheck
+            path: /
             port: 2368
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
+          timeoutSeconds: 3
         readinessProbe:
           httpGet:
-            path: /healthcheck
+            path: /
             port: 2368
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
+          timeoutSeconds: 3
         volumeMounts:
           - mountPath: /var/lib/ghost/content
             name: blog-content

--- a/blog/deployment.yaml
+++ b/blog/deployment.yaml
@@ -36,20 +36,19 @@ spec:
         livenessProbe:
           httpGet:
 {% if deploy %}
-            value: /
-{% else %}
-            value: /{{ default_ns.name }}/blog/
-{% endif %}
             path: /
+{% else %}
+            path: /{{ default_ns.name }}/blog/
+{% endif %}
             port: 2368
           initialDelaySeconds: 5
           periodSeconds: 10
         readinessProbe:
           httpGet:
 {% if deploy %}
-            value: /
+            path: /
 {% else %}
-            value: /{{ default_ns.name }}/blog/
+            path: /{{ default_ns.name }}/blog/
 {% endif %}
             port: 2368
           initialDelaySeconds: 5

--- a/blog/deployment.yaml
+++ b/blog/deployment.yaml
@@ -28,15 +28,30 @@ spec:
           - name: url
 {% if deploy %}
             value: http://blog.hail.is
-{% endif %}
-{% if not deploy %}
+{% else %}
             value: http://internal.hail.is/{{ default_ns.name }}/blog
 {% endif %}
         ports:
         - containerPort: 2368
+        livenessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 2368
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 2368
+          initialDelaySeconds: 5
+          periodSeconds: 5
         volumeMounts:
           - mountPath: /var/lib/ghost/content
             name: blog-content
+        resources:
+          requests:
+            memory: "1G"
+            cpu: "300m"
   volumeClaimTemplates:
     - metadata:
         name: blog-content
@@ -47,3 +62,4 @@ spec:
         resources:
           requests:
             storage: 10Gi
+            

--- a/blog/deployment.yaml
+++ b/blog/deployment.yaml
@@ -21,7 +21,6 @@ spec:
       containers:
       - name: blog
         image: ghost:3.0-alpine
-        imagePullPolicy: Always
         env:
           - name: NODE_ENV
             value: production

--- a/blog/deployment.yaml
+++ b/blog/deployment.yaml
@@ -20,7 +20,7 @@ spec:
 {% endif %}
       containers:
       - name: blog
-        image: ghost:3.0-alpine
+        image: ghost:2.37-alpine
         imagePullPolicy: Always
         env:
           - name: NODE_ENV
@@ -33,6 +33,18 @@ spec:
 {% endif %}
         ports:
         - containerPort: 2368
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 2368
+          initialDelaySeconds: 5
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 2368
+          initialDelaySeconds: 5
+          periodSeconds: 5
         volumeMounts:
           - mountPath: /var/lib/ghost/content
             name: blog-content

--- a/blog/deployment.yaml
+++ b/blog/deployment.yaml
@@ -33,18 +33,6 @@ spec:
 {% endif %}
         ports:
         - containerPort: 2368
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 2368
-          initialDelaySeconds: 5
-          periodSeconds: 30
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 2368
-          initialDelaySeconds: 5
-          periodSeconds: 5
         volumeMounts:
           - mountPath: /var/lib/ghost/content
             name: blog-content

--- a/build.yaml
+++ b/build.yaml
@@ -1080,6 +1080,7 @@ steps:
       name: blog
       for: alive
       resource_type: statefulset
+      endpoint: /
    dependsOn:
     - default_ns
     - deploy_router

--- a/build.yaml
+++ b/build.yaml
@@ -1081,6 +1081,9 @@ steps:
       for: alive
       resource_type: statefulset
       endpoint: /
+      headers:
+      - name: X-Forwarded-Proto
+        value: https
    dependsOn:
     - default_ns
     - deploy_router

--- a/build.yaml
+++ b/build.yaml
@@ -1075,9 +1075,10 @@ steps:
    namespace:
      valueFrom: default_ns.name
    config: blog/deployment.yaml
-   scopes:
-    - deploy
-    - dev
+   wait:
+    - kind: Service
+      name: blog
+      for: alive
    dependsOn:
     - default_ns
     - deploy_router

--- a/build.yaml
+++ b/build.yaml
@@ -1079,6 +1079,7 @@ steps:
     - kind: Service
       name: blog
       for: alive
+      resource_type: statefulset
    dependsOn:
     - default_ns
     - deploy_router

--- a/build.yaml
+++ b/build.yaml
@@ -1082,7 +1082,7 @@ steps:
       resource_type: statefulset
       endpoint: /
       headers:
-      - name: X-Forwarded-Proto
+      - key: X-Forwarded-Proto
         value: https
    dependsOn:
     - default_ns

--- a/build.yaml
+++ b/build.yaml
@@ -1070,3 +1070,15 @@ steps:
     - base_image
     - make_docs
     - build_hail
+ - kind: deploy
+   name: deploy_blog
+   namespace:
+     valueFrom: default_ns.name
+   config: blog/deployment.yaml
+   scopes:
+    - deploy
+    - dev
+   dependsOn:
+    - default_ns
+    - deploy_router
+

--- a/build.yaml
+++ b/build.yaml
@@ -1082,8 +1082,7 @@ steps:
       resource_type: statefulset
       endpoint: /
       headers:
-      - key: X-Forwarded-Proto
-        value: https
+        X-Forwarded-Proto: https
    dependsOn:
     - default_ns
     - deploy_router

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -680,6 +680,7 @@ set -e
 '''
                 elif w['kind'] == 'Service':
                     assert w['for'] == 'alive', w['for']
+					resource_type = w.get("resource_type", "deployment")
                     port = w.get('port', 80)
                     resource_type = w.get('resource_type', 'deployment').lower()
                     endpoint = w.get('endpoint', '/healthcheck')

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -680,7 +680,6 @@ set -e
 '''
                 elif w['kind'] == 'Service':
                     assert w['for'] == 'alive', w['for']
-					resource_type = w.get("resource_type", "deployment")
                     port = w.get('port', 80)
                     resource_type = w.get('resource_type', 'deployment').lower()
                     endpoint = w.get('endpoint', '/healthcheck')

--- a/gateway/gateway.nginx.conf
+++ b/gateway/gateway.nginx.conf
@@ -62,6 +62,7 @@ server {
 
 server {
     server_name hail.is;
+    client_max_body_size 8M;
 
     location / {
         proxy_pass http://router/;

--- a/router/deployment.yaml
+++ b/router/deployment.yaml
@@ -129,6 +129,20 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: blog
+  labels:
+    app: blog
+spec:
+  ports:
+   - port: 80
+     protocol: TCP
+     targetPort: 2368
+  selector:
+    app: blog
+---
+apiVersion: v1
+kind: Service
+metadata:
   name: workshop
   labels:
     app: workshop

--- a/router/router.nginx.conf.in
+++ b/router/router.nginx.conf.in
@@ -232,3 +232,19 @@ server {
     listen 80;
     listen [::]:80;
 }
+
+server {
+    server_name blog.*;
+
+    location / {
+        proxy_pass http://blog/;
+
+        proxy_set_header Host $updated_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    listen 80;
+    listen [::]:80;
+	client_max_body_size 8M;
+}
+

--- a/router/router.nginx.conf.in
+++ b/router/router.nginx.conf.in
@@ -241,7 +241,7 @@ server {
 
         proxy_set_header Host $updated_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Proto $updated_scheme;
     }
 
     listen 80;

--- a/router/router.nginx.conf.in
+++ b/router/router.nginx.conf.in
@@ -241,6 +241,7 @@ server {
 
         proxy_set_header Host $updated_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $updated_host;
         proxy_set_header X-Forwarded-Proto $updated_scheme;
     }
 

--- a/router/router.nginx.conf.in
+++ b/router/router.nginx.conf.in
@@ -239,10 +239,9 @@ server {
     location / {
         proxy_pass http://blog/;
 
-        proxy_set_header Host $updated_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $updated_host;
-        proxy_set_header X-Forwarded-Proto $updated_scheme;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     }
 
     listen 80;

--- a/router/router.nginx.conf.in
+++ b/router/router.nginx.conf.in
@@ -241,6 +241,7 @@ server {
 
         proxy_set_header Host $updated_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
     }
 
     listen 80;


### PR DESCRIPTION
this deploys a standard ghost installation to the default namespace and routes to it from blog.hail.is; can be customized once deployed.

This won't pass tests until #7413 is in.