### PR TITLE
[www/docs] don't modify url on load

### DIFF
--- a/hail/python/hail/docs/_static/goto.js
+++ b/hail/python/hail/docs/_static/goto.js
@@ -1,8 +1,5 @@
 //https://caniuse.com/#feat=history
 if ((window.history && window.history.pushState && window.scrollTo)) {
-    // necessary for chrome
-    window.history.scrollRestoration = "manual";
-
     $(document).ready(function () {
         MathJax.Hub.Register.StartupHook("End", function () {
             var navHeight = $('nav').height();

--- a/hail/python/hail/docs/_static/goto.js
+++ b/hail/python/hail/docs/_static/goto.js
@@ -1,29 +1,23 @@
 //https://caniuse.com/#feat=history
-if ((window.history && window.history.pushState)) {
-    var startingHash = window.location.hash ? decodeURIComponent(window.location.hash.replace('#', '')) : null;
-
-    // necessary to prevent browser from overriding our initial scroll
-    // browser scroll is otherwise undefeatable
-    history.pushState("", document.title, window.location.pathname);
+if ((window.history && window.history.pushState && window.scrollTo)) {
     // necessary for chrome
     window.history.scrollRestoration = "manual";
 
     $(document).ready(function () {
         MathJax.Hub.Register.StartupHook("End", function () {
             var navHeight = $('nav').height();
+            var hash = window.location.hash ? decodeURIComponent(window.location.hash.replace('#', '')) : null;
 
-            if (startingHash) {
-                var elem = document.getElementById(startingHash);
+            if (hash) {
+                var elem = document.getElementById(hash);
 
                 if (!elem) {
                     return;
                 }
 
-                // setTimeout is necessary for safari, but not firefox or chrome
                 setTimeout(() => {
                     window.scrollTo(0, parseInt($(elem).offset().top, 10) - navHeight);
-                    history.pushState({}, null, `#${startingHash}`);
-                }, 0)
+                }, 1)
             }
 
             $(document).on('click', 'a', function (e) {
@@ -49,5 +43,5 @@ if ((window.history && window.history.pushState)) {
         });
     });
 } else {
-    console.warn("Histroy API unsupported. Please consider updating your browser");
+    console.warn("Histroy API or scrollTo unsupported. Please consider updating your browser");
 }


### PR DESCRIPTION
The actual necessary fix is `history.pushState("", document.title, loc.pathname + loc.search);` instead of `history.pushState("", document.title, loc.pathname);`

Given the nervousness around JS and its use in docs (many imperative scripts interacting), I've decided to take a simpler approach that guarantees that Firefox will have behavior inconsistent with Chrome/Safari. In practice it isn't so bad (initially scrolls too far instead of starting at top of page). There may also be a chance that the browser's built-in scroll will act after the JS command, but there simply isn't a better way (besides setting a longer timeout), or the version that alters the url.
