### PR TITLE
[batch2] Use AsyncGenerators when getting jobs from database

### DIFF
--- a/batch2/batch/driver/main.py
+++ b/batch2/batch/driver/main.py
@@ -123,7 +123,8 @@ async def pod_changed(app, pod_status):
 async def refresh_pods(app):
     log.info(f'refreshing pods')
 
-    pod_jobs = [Job.from_record(app, record) for record in await app['db'].jobs.get_records_where({'state': 'Running'})]
+    pod_jobs = [Job.from_record(app, record)
+                async for record in app['db'].jobs.get_records_where({'state': 'Running'})]
 
     pod_statuses = app['driver'].list_pods()
     log.info(f'batch had {len(pod_statuses)} pods')


### PR DESCRIPTION
@cseed I'm pretty sure this is the right thing to do. Before 3.6, you'd have to define a class with `__aiter__` and `__anext__`. Now, you can also use an AsyncGenerator (example below)

```
async def my_generator():
    for i in range(10):
        await asyncio.sleep(5)
        yield i

async def main():
    async for i in my_generator():
         print(i)
```

I'd like to switch the rest of the database commands to using an iterator with fetchmany, but I don't want to conflict with you if you are making lots of changes to that file. Can you let me know if I can go ahead and make the changes to the rest of the functions such as `get_children`, `get_parents` etc.