### PR TITLE
[hail] matrix table tail

### DIFF
--- a/hail/python/hail/ir/matrix_ir.py
+++ b/hail/python/hail/ir/matrix_ir.py
@@ -401,6 +401,38 @@ class MatrixColsHead(MatrixIR):
         self._type = self.child.typ
 
 
+class MatrixRowsTail(MatrixIR):
+    def __init__(self, child, n):
+        super().__init__(child)
+        self.child = child
+        self.n = n
+
+    def head_str(self):
+        return self.n
+
+    def _eq(self, other):
+        return self.n == other.n
+
+    def _compute_type(self):
+        self._type = self.child.typ
+
+
+class MatrixColsTail(MatrixIR):
+    def __init__(self, child, n):
+        super().__init__(child)
+        self.child = child
+        self.n = n
+
+    def head_str(self):
+        return self.n
+
+    def _eq(self, other):
+        return self.n == other.n
+
+    def _compute_type(self):
+        self._type = self.child.typ
+
+
 class MatrixExplodeCols(MatrixIR):
     def __init__(self, child, path):
         super().__init__(child)

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -3688,6 +3688,67 @@ class MatrixTable(ExprContainer):
             mt = MatrixTable(MatrixColsHead(mt._mir, n_cols))
         return mt
 
+    @typecheck_method(n=nullable(int), n_cols=nullable(int))
+    def tail(self, n: Optional[int], n_cols: Optional[int] = None) -> 'MatrixTable':
+        """Subset matrix to last `n` rows.
+
+        Examples
+        --------
+        >>> mt_range = hl.utils.range_matrix_table(100, 100)
+
+        Passing only one argument will take the last `n` rows:
+
+        >>> mt_range.tail(10).count()
+        (10, 100)
+
+        Passing two arguments refers to rows and columns, respectively:
+
+        >>> mt_range.tail(10, 20).count()
+        (10, 20)
+
+        Either argument may be ``None`` to indicate no filter.
+
+        Last 10 rows, all columns:
+
+        >>> mt_range.tail(10, None).count()
+        (10, 100)
+
+        All rows, last 10 columns:
+
+        >>> mt_range.tail(None, 10).count()
+        (100, 10)
+
+        Notes
+        -----
+        For backwards compatibility, the `n` parameter is not named `n_rows`,
+        but the parameter refers to the number of rows to keep.
+
+        The number of partitions in the new matrix is equal to the number of
+        partitions containing the last `n` rows.
+
+        Parameters
+        ----------
+        n : :obj:`int`
+            Number of rows to include (all rows included if ``None``).
+        n_cols : :obj:`int`, optional
+            Number of cols to include (all cols included if ``None``).
+
+        Returns
+        -------
+        :class:`.MatrixTable`
+            Matrix including the last `n` rows and last `n_cols` cols.
+        """
+        mt = self
+        if n is not None:
+            if n < 0:
+                raise ValueError(f"MatrixTable.tail: expect 'n' to be non-negative or None, found '{n}'")
+            mt = MatrixTable(MatrixRowsTail(mt._mir, n))
+        if n_cols is not None:
+            if n_cols < 0:
+                raise ValueError(f"MatrixTable.tail: expect 'n_cols' to be non-negative or None, found '{n_cols}'")
+            mt = MatrixTable(MatrixColsTail(mt._mir, n_cols))
+        return mt
+
     @typecheck_method(parts=sequenceof(int), keep=bool)
     def _filter_partitions(self, parts, keep=True) -> 'MatrixTable':
         return MatrixTable(MatrixToMatrixApply(self._mir, {'name': 'MatrixFilterPartitions', 'parts': parts, 'keep': keep}))

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -140,6 +140,16 @@ class Tests(unittest.TestCase):
         assert tail(30, None) == expected(30, 29)
         assert tail(30, 10) == expected(30, 10)
 
+    def test_tail_scan(self):
+        mt = hl.utils.range_matrix_table(30, 40)
+        mt = mt.annotate_rows(i = hl.scan.count())
+        mt = mt.annotate_cols(j = hl.scan.count())
+        mt = mt.tail(10, 11)
+        ht = mt.entries()
+        assert ht.aggregate(agg.collect_as_set(hl.tuple([ht.i, ht.j]))) == set(
+            (i, j) for i in range(20, 30) for j in range(29, 40)
+        )
+
     def test_filter(self):
         mt = self.get_mt()
         mt = mt.annotate_globals(foo=5)

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -99,6 +99,47 @@ class Tests(unittest.TestCase):
         assert mt1.head(1, None).count() == (1, 10)
         assert mt1.head(None, 1).count() == (10, 1)
 
+    def test_tail(self):
+        # no empty partitions
+        mt1 = hl.utils.range_matrix_table(10, 10)
+
+        # empty partitions at front
+        mt2 = hl.utils.range_matrix_table(20, 10, 20)
+        mt2 = mt2.filter_rows(mt2.row_idx > 9)
+        mts = [mt1, mt2]
+
+        for mt in mts:
+            tmp_file = new_temp_file(suffix='mt')
+
+            mt.write(tmp_file)
+            mt_readback = hl.read_matrix_table(tmp_file)
+            for mt_ in [mt, mt_readback]:
+                assert mt_.tail(1).count_rows() == 1
+                assert mt_.tail(1)._force_count_rows() == 1
+                assert mt_.tail(100).count_rows() == 10
+                assert mt_.tail(100)._force_count_rows() == 10
+
+    def test_tail_cols(self):
+        mt1 = hl.utils.range_matrix_table(10, 10)
+        assert mt1.tail(1, 2).count() == (1, 2)
+        assert mt1.tail(1, None).count() == (1, 10)
+        assert mt1.tail(None, 1).count() == (10, 1)
+
+    def test_tail_entries(self):
+        mt = hl.utils.range_matrix_table(100, 30)
+        mt = mt.filter_cols(mt.col_idx != 29)
+
+        def tail(*args):
+            ht = mt.tail(*args).entries()
+            return ht.aggregate(hl.agg.collect_as_set(hl.tuple([ht.row_idx, ht.col_idx])))
+
+        def expected(n, m):
+            return set((i, j) for i in range(100 - n, 100) for j in range(29 - m, 29))
+
+        assert tail(None, 10) == expected(100, 10)
+        assert tail(30, None) == expected(30, 29)
+        assert tail(30, 10) == expected(30, 10)
+
     def test_filter(self):
         mt = self.get_mt()
         mt = mt.annotate_globals(foo=5)

--- a/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/LowerMatrixIR.scala
@@ -369,10 +369,15 @@ object LowerMatrixIR {
       case MatrixDistinctByRow(child) => TableDistinct(lower(child, ab))
 
       case MatrixRowsHead(child, n) => TableHead(lower(child, ab), n)
+      case MatrixRowsTail(child, n) => TableTail(lower(child, ab), n)
 
       case MatrixColsHead(child, n) => lower(child, ab)
         .mapGlobals('global.insertFields(colsField -> 'global (colsField).invoke("[:*]", TArray(child.typ.colType), n)))
         .mapRows('row.insertFields(entriesField -> 'row (entriesField).invoke("[:*]", TArray(child.typ.entryType), n)))
+
+      case MatrixColsTail(child, n) => lower(child, ab)
+        .mapGlobals('global.insertFields(colsField -> 'global (colsField).invoke("[*:]", TArray(child.typ.colType), - n)))
+        .mapRows('row.insertFields(entriesField -> 'row (entriesField).invoke("[*:]", TArray(child.typ.entryType), - n)))
 
       case MatrixExplodeCols(child, path) =>
         val loweredChild = lower(child, ab)

--- a/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/MatrixIR.scala
@@ -748,6 +748,43 @@ case class MatrixColsHead(child: MatrixIR, n: Int) extends MatrixIR {
   lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
 }
 
+case class MatrixRowsTail(child: MatrixIR, n: Long) extends MatrixIR {
+  require(n >= 0)
+  val typ: MatrixType = child.typ
+
+  lazy val children: IndexedSeq[BaseIR] = Array(child)
+
+  override def copy(newChildren: IndexedSeq[BaseIR]): MatrixRowsTail = {
+    val IndexedSeq(newChild: MatrixIR) = newChildren
+    MatrixRowsTail(newChild, n)
+  }
+
+  override def columnCount: Option[Int] = child.columnCount
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound match {
+    case Some(c) => Some(c.min(n))
+    case None => Some(n)
+  }
+}
+
+case class MatrixColsTail(child: MatrixIR, n: Int) extends MatrixIR {
+  require(n >= 0)
+  val typ: MatrixType = child.typ
+
+  lazy val children: IndexedSeq[BaseIR] = Array(child)
+
+  override def copy(newChildren: IndexedSeq[BaseIR]): MatrixColsTail = {
+    val IndexedSeq(newChild: MatrixIR) = newChildren
+    MatrixColsTail(newChild, n)
+  }
+
+  override def columnCount: Option[Int] = child.columnCount.map(math.min(_, n))
+
+  override def partitionCounts: Option[IndexedSeq[Long]] = child.partitionCounts
+
+  lazy val rowCountUpperBound: Option[Long] = child.rowCountUpperBound
+}
+
 case class MatrixExplodeCols(child: MatrixIR, path: IndexedSeq[String]) extends MatrixIR {
 
   lazy val children: IndexedSeq[BaseIR] = FastIndexedSeq(child)

--- a/hail/src/main/scala/is/hail/expr/ir/Parser.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Parser.scala
@@ -1320,6 +1320,14 @@ object IRParser {
         val n = int32_literal(it)
         val child = matrix_ir(env)(it)
         MatrixColsHead(child, n)
+      case "MatrixRowsTail" =>
+        val n = int64_literal(it)
+        val child = matrix_ir(env)(it)
+        MatrixRowsTail(child, n)
+      case "MatrixColsTail" =>
+        val n = int32_literal(it)
+        val child = matrix_ir(env)(it)
+        MatrixColsTail(child, n)
       case "CastTableToMatrix" =>
         val entriesField = identifier(it)
         val colsField = identifier(it)

--- a/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Pretty.scala
@@ -310,6 +310,8 @@ object Pretty {
               blockSize.toString + " "
             case MatrixRowsHead(_, n) => n.toString
             case MatrixColsHead(_, n) => n.toString
+            case MatrixRowsTail(_, n) => n.toString
+            case MatrixColsTail(_, n) => n.toString
             case MatrixAnnotateRowsTable(_, _, uid, product) =>
               prettyStringLiteral(uid) + " " + prettyBooleanLiteral(product)
             case MatrixAnnotateColsTable(_, _, uid) =>

--- a/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/PruneDeadFields.scala
@@ -707,6 +707,13 @@ object PruneDeadFields {
         )
         memoizeMatrixIR(child, dep, memo)
       case MatrixColsHead(child, n) => memoizeMatrixIR(child, requestedType, memo)
+      case MatrixRowsTail(child, n) =>
+        val dep = requestedType.copy(
+          rowKey = child.typ.rowKey,
+          rowType = unify(child.typ.rowType, requestedType.rowType, selectKey(child.typ.rowType, child.typ.rowKey))
+        )
+        memoizeMatrixIR(child, dep, memo)
+      case MatrixColsTail(child, n) => memoizeMatrixIR(child, requestedType, memo)
       case CastTableToMatrix(child, entriesFieldName, colsFieldName, _) =>
         val m = Map(MatrixType.entriesIdentifier -> entriesFieldName)
         val childDep = child.typ.copy(

--- a/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
+++ b/hail/src/test/scala/is/hail/expr/ir/IRSuite.scala
@@ -2566,6 +2566,8 @@ class IRSuite extends HailSuite {
         MatrixDistinctByRow(range1),
         MatrixRowsHead(range1, 3),
         MatrixColsHead(range1, 3),
+        MatrixRowsTail(range1, 3),
+        MatrixColsTail(range1, 3),
         MatrixExplodeCols(read, FastIndexedSeq("col_mset")),
         CastTableToMatrix(
           CastMatrixToTable(read, " # entries", " # cols"),


### PR DESCRIPTION
~~stacked on #7386~~

* implements `.tail` method on `MatrixTable`

```python
    def tail(self, n: Optional[int], n_cols: Optional[int] = None) -> 'MatrixTable':
        """Subset matrix to last `n` rows.

        ....

        Parameters
        ----------
        n : :obj:`int`
            Number of rows to include (all rows included if ``None``).
        n_cols : :obj:`int`, optional
            Number of cols to include (all cols included if ``None``).
        Returns
        -------
        :class:`.MatrixTable`
            Matrix including the last `n` rows and last `n_cols` cols.
        """
```

question: should the interface have the same backwards compatibility naming issue as `.head`, to preserve consistency? or should the keyword arguments be `n_cols` and `n_rows`?