### PR TITLE
[hail] prevent users from referencing "hail.nd"

### DIFF
--- a/hail/python/hail/__init__.py
+++ b/hail/python/hail/__init__.py
@@ -94,6 +94,9 @@ __all__ = [
 __all__.extend(genetics.__all__)
 __all__.extend(methods.__all__)
 
+# prevent users from referring to 'hl.nd'
+del nd
+
 # don't overwrite builtins in `from hail import *`
 import builtins
 


### PR DESCRIPTION
we can force users to refer to the `_`-prefixed version (`hail._nd`) by `del`eting the original module in `__init__.py`

python's module system is very strange