### PR TITLE
add execute permission to user

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -826,7 +826,7 @@ CREATE USER '{self.admin_username}'@'%' IDENTIFIED BY '$ADMIN_PASSWORD';
 GRANT ALL ON \\`{self._name}\\`.* TO '{self.admin_username}'@'%';
 
 CREATE USER '{self.user_username}'@'%' IDENTIFIED BY '$USER_PASSWORD';
-GRANT SELECT, INSERT, UPDATE, DELETE ON \\`{self._name}\\`.* TO '{self.user_username}'@'%';
+GRANT SELECT, INSERT, UPDATE, DELETE, EXECUTE ON \\`{self._name}\\`.* TO '{self.user_username}'@'%';
 EOF
 
 echo create database, admin and user...


### PR DESCRIPTION
This is necessary for the user account to execute (call) stored procedures.

We'll have to update batch2/deployed users by hand.