### PR TITLE
[ci] fix batch_callback_handler

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -264,6 +264,7 @@ async def github_callback(request):
 
 
 async def batch_callback_handler(request):
+    app = request.app
     params = await request.json()
     log.info(f'batch callback {params}')
     attrs = params.get('attributes')
@@ -273,7 +274,7 @@ async def batch_callback_handler(request):
             for wb in watched_branches:
                 if wb.branch.short_str() == target_branch:
                     log.info(f'watched_branch {wb.branch.short_str()} notify batch changed')
-                    await wb.notify_batch_changed()
+                    await wb.notify_batch_changed(app)
 
 
 @routes.post('/api/v1alpha/dev_deploy_branch')


### PR DESCRIPTION
Fixes this error message in logs:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_protocol.py", line 418, in start
    resp = await task
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_app.py", line 458, in _handle
    resp = await handler(request)
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_middlewares.py", line 119, in impl
    return await handler(request)
  File "/usr/local/lib/python3.6/dist-packages/aiohttp_session/__init__.py", line 152, in factory
    response = await handler(request)
  File "/usr/local/lib/python3.6/dist-packages/ci/ci.py", line 302, in batch_callback
    await asyncio.shield(batch_callback_handler(request))
  File "/usr/local/lib/python3.6/dist-packages/ci/ci.py", line 276, in batch_callback_handler
    await wb.notify_batch_changed()
TypeError: notify_batch_changed() missing 1 required positional argument: 'app'
```