### PR TITLE
NDArrays Support Slicing

### DIFF
--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3520,9 +3520,9 @@ class NDArrayExpression(Expression):
             slices = []
             for i, s in enumerate(item):
                 if isinstance(s, slice):
-                    start = hl.cond(s.start >= 0, s.start, self.shape[i] + s.start) if s.start is not None else to_expr(0, tint64)
-                    stop = hl.cond(s.stop >= 0, s.stop, self.shape[i] + s.stop) if s.stop is not None else self.shape[i]
                     step = s.step if s.step is not None else to_expr(1, tint64)
+                    start = hl.cond(s.start >= 0, s.start, self.shape[i] + s.start) if s.start is not None else hl.cond(step >= 0, to_expr(0, tint64), self.shape[i] - 1)
+                    stop = hl.cond(s.stop >= 0, s.stop, self.shape[i] + s.stop) if s.stop is not None else hl.cond(step >= 0, self.shape[i], to_expr(-1, tint64))
                     slices.append(hl.tuple((start, stop, step)))
                 else:
                     slices.append(s)

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3520,7 +3520,7 @@ class NDArrayExpression(Expression):
             slices = []
             for i, s in enumerate(item):
                 if isinstance(s, slice):
-                    step = s.step if s.step is not None else to_expr(1, tint64)
+                    step = hl.case().when(s.step != 0, s.step).or_error("Slice step cannot be zero") if s.step is not None else to_expr(1, tint64)
                     start = hl.cond(s.start >= 0, s.start, self.shape[i] + s.start) if s.start is not None else hl.cond(step >= 0, to_expr(0, tint64), self.shape[i] - 1)
                     stop = hl.cond(s.stop >= 0, s.stop, self.shape[i] + s.stop) if s.stop is not None else hl.cond(step >= 0, self.shape[i], to_expr(-1, tint64))
                     slices.append(hl.tuple((start, stop, step)))

--- a/hail/python/hail/expr/expressions/typed_expressions.py
+++ b/hail/python/hail/expr/expressions/typed_expressions.py
@@ -3520,8 +3520,8 @@ class NDArrayExpression(Expression):
             slices = []
             for i, s in enumerate(item):
                 if isinstance(s, slice):
-                    start = s.start if s.start is not None else to_expr(0, tint64)
-                    stop = s.stop if s.stop is not None else self.shape[i]
+                    start = hl.cond(s.start >= 0, s.start, self.shape[i] + s.start) if s.start is not None else to_expr(0, tint64)
+                    stop = hl.cond(s.stop >= 0, s.stop, self.shape[i] + s.stop) if s.stop is not None else self.shape[i]
                     step = s.step if s.step is not None else to_expr(1, tint64)
                     slices.append(hl.tuple((start, stop, step)))
                 else:

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -86,6 +86,7 @@ def test_ndarray_slice():
         (flat[::-22], np_flat[::-22]),
         (flat[15:5], np_flat[15:5]),
         (flat[3:12:-1], np_flat[3:12:-1]),
+        (flat[12:3:1], np_flat[12:3:1]),
         (mat[::-1, :], np_mat[::-1, :])
     )
 

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -64,20 +64,19 @@ def test_ndarray_ref():
 def test_ndarray_slice():
     np_arr = np.arange(24).reshape((2, 3, 4))
     arr = hl._ndarray(np_arr)
-    np_mat = np.array([[1, 2, 3, 4],
-                       [5, 6, 7, 8]])
+    np_mat = np.arange(8).reshape((2, 4))
     mat = hl._ndarray(np_mat)
 
     assert_ndarrays_eq(
         (arr[:, :, :], np_arr[:, :, :]),
         (arr[:, :, 1], np_arr[:, :, 1]),
         (arr[0:1, 1:3, 0:2], np_arr[0:1, 1:3, 0:2]),
-        # (arr[:, :, 1:4:2], np_arr[:, :, 1:4:2]),
-        # (arr[:, 2, 1:4:2], np_arr[:, 2, 1:4:2]),
-        # (arr[0, 2, 1:4:2], np_arr[0, 2, 1:4:2]),
-        # (arr[0, :, 1:4:2] + arr[:, :1, 1:4:2], np_arr[0, :, 1:4:2] + np_arr[:, :1, 1:4:2]),
-        # (arr[0:, :, 1:4:2] + arr[:, :1, 1:4:2], np_arr[0:, :, 1:4:2] + np_arr[:, :1, 1:4:2]),
-        # (mat[0, 1:4:2] + mat[:, 1:4:2], np_mat[0, 1:4:2] + np_mat[:, 1:4:2])
+        (arr[:, :, 1:4:2], np_arr[:, :, 1:4:2]),
+        (arr[:, 2, 1:4:2], np_arr[:, 2, 1:4:2]),
+        (arr[0, 2, 1:4:2], np_arr[0, 2, 1:4:2]),
+        (arr[0, :, 1:4:2] + arr[:, :1, 1:4:2], np_arr[0, :, 1:4:2] + np_arr[:, :1, 1:4:2]),
+        (arr[0:, :, 1:4:2] + arr[:, :1, 1:4:2], np_arr[0:, :, 1:4:2] + np_arr[:, :1, 1:4:2]),
+        (mat[0, 1:4:2] + mat[:, 1:4:2], np_mat[0, 1:4:2] + np_mat[:, 1:4:2])
     )
 
 @skip_unless_spark_backend()

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -62,22 +62,26 @@ def test_ndarray_ref():
 
 @skip_unless_spark_backend()
 def test_ndarray_slice():
-    np_arr = np.arange(24).reshape((2, 3, 4))
-    arr = hl._ndarray(np_arr)
+    np_rect_prism = np.arange(24).reshape((2, 3, 4))
+    rect_prism = hl._ndarray(np_rect_prism)
     np_mat = np.arange(8).reshape((2, 4))
     mat = hl._ndarray(np_mat)
+    np_flat = np.arange(20)
+    flat = hl._ndarray(np_flat)
 
     assert_ndarrays_eq(
-        (arr[:, :, :], np_arr[:, :, :]),
-        (arr[:, :, 1], np_arr[:, :, 1]),
-        (arr[0:1, 1:3, 0:2], np_arr[0:1, 1:3, 0:2]),
-        (arr[:, :, 1:4:2], np_arr[:, :, 1:4:2]),
-        (arr[:, 2, 1:4:2], np_arr[:, 2, 1:4:2]),
-        (arr[0, 2, 1:4:2], np_arr[0, 2, 1:4:2]),
-        (arr[0, :, 1:4:2] + arr[:, :1, 1:4:2], np_arr[0, :, 1:4:2] + np_arr[:, :1, 1:4:2]),
-        (arr[0:, :, 1:4:2] + arr[:, :1, 1:4:2], np_arr[0:, :, 1:4:2] + np_arr[:, :1, 1:4:2]),
+        (rect_prism[:, :, :], np_rect_prism[:, :, :]),
+        (rect_prism[:, :, 1], np_rect_prism[:, :, 1]),
+        (rect_prism[0:1, 1:3, 0:2], np_rect_prism[0:1, 1:3, 0:2]),
+        (rect_prism[:, :, 1:4:2], np_rect_prism[:, :, 1:4:2]),
+        (rect_prism[:, 2, 1:4:2], np_rect_prism[:, 2, 1:4:2]),
+        (rect_prism[0, 2, 1:4:2], np_rect_prism[0, 2, 1:4:2]),
+        (rect_prism[0, :, 1:4:2] + rect_prism[:, :1, 1:4:2], np_rect_prism[0, :, 1:4:2] + np_rect_prism[:, :1, 1:4:2]),
+        (rect_prism[0:, :, 1:4:2] + rect_prism[:, :1, 1:4:2], np_rect_prism[0:, :, 1:4:2] + np_rect_prism[:, :1, 1:4:2]),
         (mat[0, 1:4:2] + mat[:, 1:4:2], np_mat[0, 1:4:2] + np_mat[:, 1:4:2]),
-        (arr[0, 0, -3:-1], np_arr[0, 0, -3:-1])
+        (rect_prism[0, 0, -3:-1], np_rect_prism[0, 0, -3:-1]),
+        (flat[15:5:-1], np_flat[15:5:-1]),
+        (flat[::-1], np_flat[::-1]),
     )
 
 @skip_unless_spark_backend()

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -93,6 +93,8 @@ def test_ndarray_slice():
         (flat[-4:-1:2], np_flat[-4:-1:2])
     )
 
+    assert hl.eval(hl._ndarray(hl.range(20))[4:hl.null(hl.tint32)]) is None
+
 @skip_unless_spark_backend()
 def test_ndarray_eval():
     data_list = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -93,7 +93,11 @@ def test_ndarray_slice():
         (flat[-4:-1:2], np_flat[-4:-1:2])
     )
 
-    assert hl.eval(hl._ndarray(hl.range(20))[4:hl.null(hl.tint32)]) is None
+    assert hl.eval(flat[4:hl.null(hl.tint32)]) is None
+
+    with pytest.raises(FatalError) as exc:
+        hl.eval(flat[::0])
+    assert "Slice step cannot be zero" in str(exc)
 
 @skip_unless_spark_backend()
 def test_ndarray_eval():

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -82,7 +82,9 @@ def test_ndarray_slice():
         (rect_prism[0, 0, -3:-1], np_rect_prism[0, 0, -3:-1]),
         (flat[15:5:-1], np_flat[15:5:-1]),
         (flat[::-1], np_flat[::-1]),
-        (flat[::22], np_flat[::22])
+        (flat[::22], np_flat[::22]),
+        (flat[15:5], np_flat[15:5]),
+        (flat[3:12:-1], np_flat[3:12:-1])
     )
 
 @skip_unless_spark_backend()

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -82,6 +82,7 @@ def test_ndarray_slice():
         (rect_prism[0, 0, -3:-1], np_rect_prism[0, 0, -3:-1]),
         (flat[15:5:-1], np_flat[15:5:-1]),
         (flat[::-1], np_flat[::-1]),
+        (flat[::22], np_flat[::22])
     )
 
 @skip_unless_spark_backend()

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -61,14 +61,8 @@ def test_ndarray_ref():
     assert "Index out of bounds" in str(exc)
 
 @skip_unless_spark_backend()
-@run_with_cxx_compile()
 def test_ndarray_slice():
-    np_arr = np.array([[[0, 1, 2, 3],
-                        [4, 5, 6, 7],
-                        [8, 9, 10, 11]],
-                       [[12, 13, 14, 15],
-                        [16, 17, 18, 19],
-                        [20, 21, 22, 23]]])
+    np_arr = np.arange(24).reshape((2, 3, 4))
     arr = hl._ndarray(np_arr)
     np_mat = np.array([[1, 2, 3, 4],
                        [5, 6, 7, 8]])
@@ -77,12 +71,14 @@ def test_ndarray_slice():
     assert_ndarrays_eq(
         (arr[:, :, :], np_arr[:, :, :]),
         (arr[:, :, 1], np_arr[:, :, 1]),
-        (arr[:, :, 1:4:2], np_arr[:, :, 1:4:2]),
-        (arr[:, 2, 1:4:2], np_arr[:, 2, 1:4:2]),
-        (arr[0, 2, 1:4:2], np_arr[0, 2, 1:4:2]),
-        (arr[0, :, 1:4:2] + arr[:, :1, 1:4:2], np_arr[0, :, 1:4:2] + np_arr[:, :1, 1:4:2]),
-        (arr[0:, :, 1:4:2] + arr[:, :1, 1:4:2], np_arr[0:, :, 1:4:2] + np_arr[:, :1, 1:4:2]),
-        (mat[0, 1:4:2] + mat[:, 1:4:2], np_mat[0, 1:4:2] + np_mat[:, 1:4:2]))
+        (arr[0:1, 1:3, 0:2], np_arr[0:1, 1:3, 0:2]),
+        # (arr[:, :, 1:4:2], np_arr[:, :, 1:4:2]),
+        # (arr[:, 2, 1:4:2], np_arr[:, 2, 1:4:2]),
+        # (arr[0, 2, 1:4:2], np_arr[0, 2, 1:4:2]),
+        # (arr[0, :, 1:4:2] + arr[:, :1, 1:4:2], np_arr[0, :, 1:4:2] + np_arr[:, :1, 1:4:2]),
+        # (arr[0:, :, 1:4:2] + arr[:, :1, 1:4:2], np_arr[0:, :, 1:4:2] + np_arr[:, :1, 1:4:2]),
+        # (mat[0, 1:4:2] + mat[:, 1:4:2], np_mat[0, 1:4:2] + np_mat[:, 1:4:2])
+    )
 
 @skip_unless_spark_backend()
 def test_ndarray_eval():

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -93,7 +93,7 @@ def test_ndarray_slice():
         (flat[-4:-1:2], np_flat[-4:-1:2])
     )
 
-    #assert hl.eval(hl._ndarray(hl.range(20))[4:hl.null(hl.tint32)]) is None
+    assert hl.eval(hl._ndarray(hl.range(20))[4:hl.null(hl.tint32)]) is None
 
 @skip_unless_spark_backend()
 def test_ndarray_eval():

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -93,7 +93,10 @@ def test_ndarray_slice():
         (flat[-4:-1:2], np_flat[-4:-1:2])
     )
 
+    assert hl.eval(flat[hl.null(hl.tint32):4:1]) is None
     assert hl.eval(flat[4:hl.null(hl.tint32)]) is None
+    assert hl.eval(flat[4:10:hl.null(hl.tint32)]) is None
+    assert hl.eval(rect_prism[:, :, 0:hl.null(hl.tint32):1]) is None
 
     with pytest.raises(FatalError) as exc:
         hl.eval(flat[::0])

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -93,7 +93,7 @@ def test_ndarray_slice():
         (flat[-4:-1:2], np_flat[-4:-1:2])
     )
 
-    assert hl.eval(hl._ndarray(hl.range(20))[4:hl.null(hl.tint32)]) is None
+    #assert hl.eval(hl._ndarray(hl.range(20))[4:hl.null(hl.tint32)]) is None
 
 @skip_unless_spark_backend()
 def test_ndarray_eval():

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -97,6 +97,7 @@ def test_ndarray_slice():
     assert hl.eval(flat[4:hl.null(hl.tint32)]) is None
     assert hl.eval(flat[4:10:hl.null(hl.tint32)]) is None
     assert hl.eval(rect_prism[:, :, 0:hl.null(hl.tint32):1]) is None
+    assert hl.eval(rect_prism[hl.null(hl.tint32), :, :]) is None
 
     with pytest.raises(FatalError) as exc:
         hl.eval(flat[::0])

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -83,8 +83,10 @@ def test_ndarray_slice():
         (flat[15:5:-1], np_flat[15:5:-1]),
         (flat[::-1], np_flat[::-1]),
         (flat[::22], np_flat[::22]),
+        (flat[::-22], np_flat[::-22]),
         (flat[15:5], np_flat[15:5]),
-        (flat[3:12:-1], np_flat[3:12:-1])
+        (flat[3:12:-1], np_flat[3:12:-1]),
+        (mat[::-1, :], np_mat[::-1, :])
     )
 
 @skip_unless_spark_backend()

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -87,7 +87,10 @@ def test_ndarray_slice():
         (flat[15:5], np_flat[15:5]),
         (flat[3:12:-1], np_flat[3:12:-1]),
         (flat[12:3:1], np_flat[12:3:1]),
-        (mat[::-1, :], np_mat[::-1, :])
+        (mat[::-1, :], np_mat[::-1, :]),
+        (flat[4:1:-2], np_flat[4:1:-2]),
+        (flat[0:0:1], np_flat[0:0:1]),
+        (flat[-4:-1:2], np_flat[-4:-1:2])
     )
 
 @skip_unless_spark_backend()

--- a/hail/python/test/hail/expr/test_ndarrays.py
+++ b/hail/python/test/hail/expr/test_ndarrays.py
@@ -76,7 +76,8 @@ def test_ndarray_slice():
         (arr[0, 2, 1:4:2], np_arr[0, 2, 1:4:2]),
         (arr[0, :, 1:4:2] + arr[:, :1, 1:4:2], np_arr[0, :, 1:4:2] + np_arr[:, :1, 1:4:2]),
         (arr[0:, :, 1:4:2] + arr[:, :1, 1:4:2], np_arr[0:, :, 1:4:2] + np_arr[:, :1, 1:4:2]),
-        (mat[0, 1:4:2] + mat[:, 1:4:2], np_mat[0, 1:4:2] + np_mat[:, 1:4:2])
+        (mat[0, 1:4:2] + mat[:, 1:4:2], np_mat[0, 1:4:2] + np_mat[:, 1:4:2]),
+        (arr[0, 0, -3:-1], np_arr[0, 0, -3:-1])
     )
 
 @skip_unless_spark_backend()

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2448,17 +2448,12 @@ private class Emit(
 
         var missingSliceElements = const(false)
 
-        coerce[PTuple](slicesIR.pType).types.zipWithIndex.foreach { case (sliceOrIndex, dim) =>
-          sliceOrIndex match {
-            case p: PTuple => {
-              val oneSlice = new CodePTuple(p, region, slicesTuple(dim))
-              missingSliceElements = missingSliceElements || oneSlice.isMissing(0) || oneSlice.isMissing(1) || oneSlice.isMissing(2)
-              codeSlices += ((oneSlice[Long](0), oneSlice[Long](1), oneSlice[Long](2)))
-            }
-            case _: PInt64 => {
-              codeRefMap += dim -> slicesTuple(dim)
-            }
-          }
+        coerce[PTuple](slicesIR.pType).types.zipWithIndex.foreach {
+          case (p: PTuple, dim) =>
+            val oneSlice = new CodePTuple(p, region, slicesTuple(dim))
+            missingSliceElements = missingSliceElements || oneSlice.isMissing(0) || oneSlice.isMissing(1) || oneSlice.isMissing(2)
+            codeSlices += ((oneSlice[Long](0), oneSlice[Long](1), oneSlice[Long](2)))
+          case (_: PInt64, dim) => codeRefMap += dim -> slicesTuple(dim)
         }
 
         val outputShape = codeSlices.toArray.map { case (start, stop, step) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2453,7 +2453,10 @@ private class Emit(
             val oneSlice = new CodePTuple(p, region, slices(dim))
             missingSliceElements ||= oneSlice.isMissing(0) || oneSlice.isMissing(1) || oneSlice.isMissing(2)
             codeSlices += ((oneSlice[Long](0), oneSlice[Long](1), oneSlice[Long](2)))
-          case (_: PInt64, dim) => codeRefMap += dim -> slices(dim)
+          case (_: PInt64, dim) => {
+            missingSliceElements ||= slices.isMissing(dim)
+            codeRefMap(dim) = slices(dim)
+          }
         }
 
         val outputShape = codeSlices.map { case (start, stop, step) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2444,13 +2444,13 @@ private class Emit(
         val slicesTuple = new CodePTuple(coerce[PTuple](slicesIR.pType), region, slicesValueAddress)
 
         val codeSlices = ArrayBuffer[(Code[Long], Code[Long], Code[Long])]()
-        val codeRefMap = mutable.Map[Int, (Code[Long])]()
+        val codeRefMap = mutable.Map[Int, Code[Long]]()
 
         coerce[PTuple](slicesIR.pType).types.zipWithIndex.foreach { case (sliceOrIndex, dim) =>
           sliceOrIndex match {
             case p: PTuple => {
-              val tup = new CodePTuple(p, region, slicesTuple(dim))
-              codeSlices += ((tup[Long](0), tup[Long](1), tup[Long](2)))
+              val oneSlice = new CodePTuple(p, region, slicesTuple(dim))
+              codeSlices += ((oneSlice[Long](0), oneSlice[Long](1), oneSlice[Long](2)))
             }
             case _: PInt64 => {
               codeRefMap += dim -> slicesTuple(dim)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2461,7 +2461,7 @@ private class Emit(
 
         val outputShape = sliceVars.toArray.map{ case (start, stop, step) =>
           (step >= 0L).mux(
-            (const(1L) + ((stop - start) - const(1L)) / step),
+            const(1L) + ((stop - start) - const(1L)) / step,
             (((stop - start) + const(1L)) / step) + const(1L))
         }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2460,9 +2460,11 @@ private class Emit(
         }
 
         val outputShape = sliceVars.toArray.map{ case (start, stop, step) =>
-          (step >= 0L).mux(
+          (step >= 0L && start <= stop).mux(
             const(1L) + ((stop - start) - const(1L)) / step,
-            (((stop - start) + const(1L)) / step) + const(1L))
+            (step < 0L && stop <= start).mux((((stop - start) + const(1L)) / step) + const(1L),
+              0L)
+          )
         }
 
         val setup = Code(

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2469,14 +2469,18 @@ private class Emit(
           )
         }
 
-        val setup = Code(
+        val setupMissing = Code(
           slicest.setup,
-          childEmitter.setup,
+          childEmitter.setupMissing
+        )
+
+        val setupShape = Code(
+          childEmitter.setupShape,
           slicesValueAddress := slicest.value[Long],
           missingSlices := false
         )
 
-        new NDArrayEmitter(mb, x.pType.nDims, outputShape, x.pType.shape.pType, x.pType.elementType, setup) {
+        new NDArrayEmitter(mb, x.pType.nDims, outputShape, x.pType.shape.pType, x.pType.elementType, setupShape, setupMissing, false) {
           override def outputElement(idxVars: Array[Code[Long]]): Code[_] = {
             val oldIdxVarsIter = idxVars.iterator
             val sliceIdxVarsIter = codeSlices.iterator

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2441,19 +2441,19 @@ private class Emit(
 
         val slicest = emit(slicesIR, env, resultRegion, None)
         val slicesValueAddress = mb.newField[Long]
-        val slicesTuple = new CodePTuple(coerce[PTuple](slicesIR.pType), region, slicesValueAddress)
+        val slices = new CodePTuple(coerce[PTuple](slicesIR.pType), region, slicesValueAddress)
 
         val codeSlices = ArrayBuffer[(Code[Long], Code[Long], Code[Long])]()
         val codeRefMap = mutable.Map[Int, Code[Long]]()
 
         var missingSliceElements = const(false)
 
-        slicesTuple.pType.types.zipWithIndex.foreach {
+        slices.pType.types.zipWithIndex.foreach {
           case (p: PTuple, dim) =>
-            val oneSlice = new CodePTuple(p, region, slicesTuple(dim))
+            val oneSlice = new CodePTuple(p, region, slices(dim))
             missingSliceElements ||= oneSlice.isMissing(0) || oneSlice.isMissing(1) || oneSlice.isMissing(2)
             codeSlices += ((oneSlice[Long](0), oneSlice[Long](1), oneSlice[Long](2)))
-          case (_: PInt64, dim) => codeRefMap += dim -> slicesTuple(dim)
+          case (_: PInt64, dim) => codeRefMap += dim -> slices(dim)
         }
 
         val outputShape = codeSlices.map { case (start, stop, step) =>

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2459,7 +2459,7 @@ private class Emit(
 
         val outputShape = codeSlices.map { case (start, stop, step) =>
           (step >= 0L && start <= stop).mux(
-            const(1L) + ((stop - start) - const(1L)) / step,
+            const(1L) + ((stop - start) - 1L) / step,
             (step < 0L && start >= stop).mux(
               (((stop - start) + 1L) / step) + 1L,
               0L)

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2460,7 +2460,7 @@ private class Emit(
         }
 
         // TODO Consider step size
-        val outputShape = sliceVars.toArray.map{case (start, stop, step) => stop - start}
+        val outputShape = sliceVars.toArray.map{case (start, stop, step) => (const(1L) + ((stop - start) - const(1L)) / step)}
 
         val setup = Code(
           slicest.setup,
@@ -2479,7 +2479,7 @@ private class Emit(
               } else {
                 val (start, _, step) = sliceIdxVarsIter.next()
                 val oldIdxVar = oldIdxVarsIter.next()
-                start + oldIdxVar
+                start + oldIdxVar * step
               }
             }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2470,7 +2470,20 @@ private class Emit(
 
         new NDArrayEmitter(mb, x.pType.nDims, outputShape, x.pType.shape.pType, x.pType.elementType, setup) {
           override def outputElement(idxVars: Array[Code[Long]]): Code[_] = {
-            const(4)
+            val oldIdxVarsIter = idxVars.iterator
+            val sliceIdxVarsIter = sliceVars.iterator
+
+            val sliceIdxVars = Array.tabulate(childEmitter.nDims) { dim =>
+              if (refVars.contains(dim)) {
+                refVars(dim)
+              } else {
+                val (start, _, step) = sliceIdxVarsIter.next()
+                val oldIdxVar = oldIdxVarsIter.next()
+                start + oldIdxVar
+              }
+            }
+
+            childEmitter.outputElement(sliceIdxVars)
           }
         }
 

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2458,10 +2458,11 @@ private class Emit(
           }
         }
 
-        val outputShape = codeSlices.toArray.map{ case (start, stop, step) =>
+        val outputShape = codeSlices.toArray.map { case (start, stop, step) =>
           (step >= 0L && start <= stop).mux(
             const(1L) + ((stop - start) - const(1L)) / step,
-            (step < 0L && stop <= start).mux((((stop - start) + const(1L)) / step) + const(1L),
+            (step < 0L && stop <= start).mux(
+              (((stop - start) + const(1L)) / step) + const(1L),
               0L)
           )
         }

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2446,6 +2446,8 @@ private class Emit(
         val codeSlices = ArrayBuffer[(Code[Long], Code[Long], Code[Long])]()
         val codeRefMap = mutable.Map[Int, Code[Long]]()
 
+        val missingSlices = mb.newField[Boolean]
+
         coerce[PTuple](slicesIR.pType).types.zipWithIndex.foreach { case (sliceOrIndex, dim) =>
           sliceOrIndex match {
             case p: PTuple => {
@@ -2470,7 +2472,8 @@ private class Emit(
         val setup = Code(
           slicest.setup,
           childEmitter.setup,
-          slicesValueAddress := slicest.value[Long]
+          slicesValueAddress := slicest.value[Long],
+          missingSlices := false
         )
 
         new NDArrayEmitter(mb, x.pType.nDims, outputShape, x.pType.shape.pType, x.pType.elementType, setup) {

--- a/hail/src/main/scala/is/hail/expr/ir/Emit.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/Emit.scala
@@ -2440,7 +2440,6 @@ private class Emit(
         val childEmitter = deforest(child)
 
 
-
         val slicest = emit(slicesIR, env, resultRegion, None)
         val slicesTuple = new CodePTuple(coerce[PTuple](slicesIR.pType), region, coerce[Long](slicest.v))
 
@@ -2469,10 +2468,9 @@ private class Emit(
         )
 
 
-        new NDArrayEmitter(mb, x.pType.nDims, outputShape, ???, ???, setup) {
+        new NDArrayEmitter(mb, x.pType.nDims, outputShape, x.pType.shape.pType, x.pType.elementType, setup) {
           override def outputElement(idxVars: Array[Code[Long]]): Code[_] = {
-
-            ???
+            const(4)
           }
         }
 

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -134,7 +134,7 @@ object InferType {
       case NDArraySlice(nd, slices) =>
         val childTyp = coerce[TNDArray](nd.typ)
         val slicesTyp = coerce[TTuple](slices.typ)
-        val tuplesOnly = slicesTyp.types.collect{ case x: TTuple => x}
+        val tuplesOnly = slicesTyp.types.collect { case x: TTuple => x}
         val remainingDims = Nat(tuplesOnly.length)
         TNDArray(childTyp.elementType, remainingDims)
       case NDArrayMatMul(l, r) =>

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -133,7 +133,9 @@ object InferType {
         coerce[TNDArray](nd.typ).elementType.setRequired(nd.typ.required && idxs.forall(_.typ.required))
       case NDArraySlice(nd, slices) =>
         val childTyp = coerce[TNDArray](nd.typ)
-        val remainingDims = coerce[TTuple](slices.typ).types.filter(_.isInstanceOf[TTuple])
+        val slicesTyp = coerce[TTuple](slices.typ)
+        assert(childTyp.nDims == slicesTyp.size)
+        val remainingDims = slicesTyp.types.filter(_.isInstanceOf[TTuple])
         TNDArray(childTyp.elementType, Nat(remainingDims.length))
       case NDArrayMatMul(l, r) =>
         val lTyp = coerce[TNDArray](l.typ)

--- a/hail/src/main/scala/is/hail/expr/ir/InferType.scala
+++ b/hail/src/main/scala/is/hail/expr/ir/InferType.scala
@@ -134,9 +134,9 @@ object InferType {
       case NDArraySlice(nd, slices) =>
         val childTyp = coerce[TNDArray](nd.typ)
         val slicesTyp = coerce[TTuple](slices.typ)
-        assert(childTyp.nDims == slicesTyp.size)
-        val remainingDims = slicesTyp.types.filter(_.isInstanceOf[TTuple])
-        TNDArray(childTyp.elementType, Nat(remainingDims.length))
+        val tuplesOnly = slicesTyp.types.collect{ case x: TTuple => x}
+        val remainingDims = Nat(tuplesOnly.length)
+        TNDArray(childTyp.elementType, remainingDims)
       case NDArrayMatMul(l, r) =>
         val lTyp = coerce[TNDArray](l.typ)
         val rTyp = coerce[TNDArray](r.typ)

--- a/hail/src/main/scala/is/hail/expr/types/physical/PTuple.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PTuple.scala
@@ -91,4 +91,9 @@ class CodePTuple(
   def withTypes = withTypesAndIndices.map(x => (x._1, x._2))
 
   def missingnessPattern = (0 until pType.nFields).map(isMissing(_))
+
+  def values[T, U, V] = {
+    assert(pType.nFields == 3)
+    (apply[T](0), apply[U](1), apply[V](2))
+  }
 }

--- a/hail/src/main/scala/is/hail/expr/types/physical/PTuple.scala
+++ b/hail/src/main/scala/is/hail/expr/types/physical/PTuple.scala
@@ -85,4 +85,10 @@ class CodePTuple(
   def isMissing(i: Int): Code[Boolean] = {
     pType.isFieldMissing(offset, i)
   }
+
+  def withTypesAndIndices = (0 until pType.nFields).map(i => (pType.types(i), apply(i), i))
+
+  def withTypes = withTypesAndIndices.map(x => (x._1, x._2))
+
+  def missingnessPattern = (0 until pType.nFields).map(isMissing(_))
 }


### PR DESCRIPTION
This adds slicing support to NDArrays. I've implemented most of what numpy offers here under "Basic Indexing": https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html

Edge cases to note, assuming I have a 3 dimensional ndarray `arr`:

- `arr[:, ::, ::1]` returns the whole array (: is shorthand for "give me the full extent of this particular dimension", 2 colons does the same thing since it's like making a slice with all default values, and 2 colons followed by a 1 is specifying a slice with step size 1, which is the default step size. ). 
- `arr[2:3, 4:8:1, 5:10]` passing in 1 as a step argument has no effect, as 1 is assumed to be the default step. 
- `arr[:, :, -5:-2]` means that in the last dimension we should start selecting at the 5th to last element and stop at the second to last element
- `arr[:, :, 3]` will return a 2 dimensional ndarray, since by passing in a particular value for one of the dimensions I've "deleted" a dimension.
- `arr[:, :, ::-1]` will reverse the elements of last dimension.

I **don't** support:
- Passing in an ellipsis
- Something like `np.newaxis`

^ We can definitely support both of those things, but I haven't done it yet / doesn't seem super high priority