### PR TITLE
[batch2] fix running read_logs and read_status

### DIFF
--- a/batch2/batch/driver/driver.py
+++ b/batch2/batch/driver/driver.py
@@ -264,7 +264,7 @@ class Pod:
 
         inst = self.instance
         url = f'http://{inst.ip_address}:5000/api/v1alpha/pods/{self.name}/logs'
-        resp = self._request('GET', url)
+        resp = await self._request('GET', url)
         return await resp.json()
 
     async def read_pod_status(self):
@@ -275,7 +275,7 @@ class Pod:
 
         inst = self.instance
         url = f'http://{inst.ip_address}:5000/api/v1alpha/pods/{self.name}/status'
-        resp = self._request('GET', url)
+        resp = await self._request('GET', url)
         return await resp.json()
 
     def status(self):

--- a/batch2/batch/driver/main.py
+++ b/batch2/batch/driver/main.py
@@ -78,6 +78,30 @@ async def delete_batch(request):
     return web.Response()
 
 
+@routes.get('/api/v1alpha/batches/{user}/{batch_id}/jobs/{job_id}/log')
+async def read_logs(request):
+    user = request.match_info['user']
+    batch_id = int(request.match_info['batch_id'])
+    job_id = int(request.match_info['job_id'])
+    job = await Job.from_db(request.app, batch_id, job_id, user)
+    if not job:
+        raise web.HTTPNotFound()
+    job_logs = await job._read_logs()
+    return web.json_response(job_logs)
+
+
+@routes.get('/api/v1alpha/batches/{user}/{batch_id}/jobs/{job_id}/pod_status')
+async def read_status(request):
+    user = request.match_info['user']
+    batch_id = int(request.match_info['batch_id'])
+    job_id = int(request.match_info['job_id'])
+    job = await Job.from_db(request.app, batch_id, job_id, user)
+    if not job:
+        raise web.HTTPNotFound()
+    job_logs = await job._read_pod_status()
+    return web.json_response(job_logs)
+
+
 async def update_job_with_pod(app, job, pod_status):  # pylint: disable=R0911
     if pod_status:
         pod_name = pod_status["name"]

--- a/batch2/deployment.yaml
+++ b/batch2/deployment.yaml
@@ -43,7 +43,10 @@ spec:
            value: "{{ default_ns.name }}"
 {% if deploy %}
          - name: HAIL_INSTANCE_ID
-           value: cd50b95a89914efb897965a5e982a29d
+           value: cd50b95a89914efb897965a5e982a29
+{% else %}
+         - name: HAIL_INSTANCE_ID
+           value: {{ token }}
 {% endif %}
 {% if not deploy %}
          - name: WORKER_TYPE
@@ -160,6 +163,9 @@ spec:
 {% if deploy %}
          - name: HAIL_INSTANCE_ID
            value: cd50b95a89914efb897965a5e982a29d
+{% else %}
+         - name: HAIL_INSTANCE_ID
+           value: {{ token }}
 {% endif %}
         ports:
          - containerPort: 5000

--- a/batch2/deployment.yaml
+++ b/batch2/deployment.yaml
@@ -41,13 +41,8 @@ spec:
            value: "{{ batch2_worker_image.image }}"
          - name: BATCH_NAMESPACE
            value: "{{ default_ns.name }}"
-{% if deploy %}
-         - name: HAIL_INSTANCE_ID
-           value: cd50b95a89914efb897965a5e982a29
-{% else %}
          - name: HAIL_INSTANCE_ID
            value: {{ token }}
-{% endif %}
 {% if not deploy %}
          - name: WORKER_TYPE
            value: "standard"
@@ -160,13 +155,8 @@ spec:
            value: "{{ global.domain }}"
          - name: HAIL_DEPLOY_CONFIG_FILE
            value: /deploy-config/deploy-config.json
-{% if deploy %}
-         - name: HAIL_INSTANCE_ID
-           value: cd50b95a89914efb897965a5e982a29d
-{% else %}
          - name: HAIL_INSTANCE_ID
            value: {{ token }}
-{% endif %}
         ports:
          - containerPort: 5000
         resources:

--- a/batch2/test/test_batch.py
+++ b/batch2/test/test_batch.py
@@ -158,6 +158,19 @@ class Test(unittest.TestCase):
         status = j.wait()
         self.assertEqual(status['exit_code']['main'], 1)
 
+    def test_running_job_log_and_status(self):
+        b = self.client.create_batch()
+        j = b.create_job('ubuntu:18.04', ['sleep', '300'])
+        b = b.submit()
+
+        while True:
+            if j.status()['state'] == 'Running' or j.is_complete():
+                break
+
+        j.log()
+        j.pod_status()
+        b.cancel()
+
     def test_deleted_job_log(self):
         b = self.client.create_batch()
         j = b.create_job('ubuntu:18.04', ['echo', 'test'])


### PR DESCRIPTION
@tpoterba tried to run some jobs on the batch2 instance in the default namespace. He ran into two errors when trying to get log files (one while the job was running and the other when it terminated):

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_protocol.py", line 418, in start
    resp = await task
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_app.py", line 458, in _handle
    resp = await handler(request)
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_middlewares.py", line 119, in impl
    return await handler(request)
  File "/usr/local/lib/python3.6/dist-packages/aiohttp_session/__init__.py", line 152, in factory
    response = await handler(request)
  File "/usr/local/lib/python3.6/dist-packages/prometheus_async/aio/_decorators.py", line 42, in time_decorator
    rv = await wrapped(*args, **kw)
  File "/usr/local/lib/python3.6/dist-packages/gear/auth.py", line 86, in wrapped
    return await fun(request, userdata, *args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/batch/front_end/front_end.py", line 383, in ui_get_job_log
    'job_log': await _get_job_log(request.app, batch_id, job_id, user)
  File "/usr/local/lib/python3.6/dist-packages/batch/front_end/front_end.py", line 112, in _get_job_log
    job_log = await job._read_logs()
  File "/usr/local/lib/python3.6/dist-packages/batch/batch.py", line 49, in _read_logs
    return await self.app['driver'].read_pod_logs(self._pod_name)
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_app.py", line 160, in __getitem__
    return self._state[key]
KeyError: 'driver'
```

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/google/cloud/storage/blob.py", line 636, in download_to_file
    self._do_download(transport, file_obj, download_url, headers, start, end)
  File "/usr/local/lib/python3.6/dist-packages/google/cloud/storage/blob.py", line 574, in _do_download
    download.consume(transport)
  File "/usr/local/lib/python3.6/dist-packages/google/resumable_media/requests/download.py", line 171, in consume
    self._process_response(result)
  File "/usr/local/lib/python3.6/dist-packages/google/resumable_media/_download.py", line 171, in _process_response
    response, _ACCEPTABLE_STATUS_CODES, self._get_status_code
  File "/usr/local/lib/python3.6/dist-packages/google/resumable_media/_helpers.py", line 96, in require_status_code
    *status_codes
google.resumable_media.common.InvalidResponse: ('Request failed with status code', 403, 'Expected one of', <HTTPStatus.OK: 200>, <HTTPStatus.PARTIAL_CONTENT: 206>)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_protocol.py", line 418, in start
    resp = await task
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_app.py", line 458, in _handle
    resp = await handler(request)
  File "/usr/local/lib/python3.6/dist-packages/aiohttp/web_middlewares.py", line 119, in impl
    return await handler(request)
  File "/usr/local/lib/python3.6/dist-packages/aiohttp_session/__init__.py", line 152, in factory
    response = await handler(request)
  File "/usr/local/lib/python3.6/dist-packages/prometheus_async/aio/_decorators.py", line 42, in time_decorator
    rv = await wrapped(*args, **kw)
  File "/usr/local/lib/python3.6/dist-packages/gear/auth.py", line 86, in wrapped
    return await fun(request, userdata, *args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/batch/front_end/front_end.py", line 383, in ui_get_job_log
    'job_log': await _get_job_log(request.app, batch_id, job_id, user)
  File "/usr/local/lib/python3.6/dist-packages/batch/front_end/front_end.py", line 112, in _get_job_log
    job_log = await job._read_logs()
  File "/usr/local/lib/python3.6/dist-packages/batch/batch.py", line 57, in _read_logs
    return {k: v for k, v in await future_logs}
  File "/usr/local/lib/python3.6/dist-packages/batch/batch.py", line 52, in _read_log_from_gcs
    pod_log = await self.app['log_store'].read_gs_file(LogStore.container_log_path(self.directory, task_name))
  File "/usr/local/lib/python3.6/dist-packages/batch/log_store.py", line 40, in read_gs_file
    return await self.gcs.read_gs_file(uri)
  File "/usr/local/lib/python3.6/dist-packages/batch/google_storage.py", line 27, in read_gs_file
    return await self._wrapped_read_gs_file(self, uri)
  File "/usr/local/lib/python3.6/dist-packages/batch/google_storage.py", line 37, in wrapped
    **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/hailtop/utils/utils.py", line 33, in blocking_to_async
    thread_pool, lambda: fun(*args, **kwargs))
  File "/usr/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.6/dist-packages/hailtop/utils/utils.py", line 33, in <lambda>
    thread_pool, lambda: fun(*args, **kwargs))
  File "/usr/local/lib/python3.6/dist-packages/batch/google_storage.py", line 53, in _read_gs_file
    content = f.download_as_string()
  File "/usr/local/lib/python3.6/dist-packages/google/cloud/storage/blob.py", line 697, in download_as_string
    self.download_to_file(string_buffer, client=client, start=start, end=end)
  File "/usr/local/lib/python3.6/dist-packages/google/cloud/storage/blob.py", line 638, in download_to_file
    _raise_from_invalid_response(exc)
  File "/usr/local/lib/python3.6/dist-packages/google/cloud/storage/blob.py", line 2034, in _raise_from_invalid_response
    raise exceptions.from_http_status(response.status_code, message, response=response)
google.api_core.exceptions.Forbidden: 403 GET https://www.googleapis.com/download/storage/v1/b/hail-batch2-nru9x/o/cd50b95a89914efb897965a5e982a29d%2F1%2F1%2Fsetup%2Fjob.log?alt=media: ('Request failed with status code', 403, 'Expected one of', <HTTPStatus.OK: 200>, <HTTPStatus.PARTIAL_CONTENT: 206>)
```

- The first error is caused by the driver object is only available on the batch2-driver instance. Now the front end sends a request to the driver to get the logs if the job is running. I purposefully left the driver and front end calling the same function in case the job terminates before the driver handles the request from the front end

- Unified the Instance_ID between the front_end and the driver. I thought this was causing the second bug where gcs was unauthorized, but Tim was running in the default namespace, so they had the same instance id.

- I checked and we're loading the same gsa-key in both the front end and driver.